### PR TITLE
control-plane: API docs: cluster must have a name

### DIFF
--- a/components/konvoy-control-plane/API.md
+++ b/components/konvoy-control-plane/API.md
@@ -87,6 +87,7 @@ spec:
         resource: |
           '@type': type.googleapis.com/envoy.api.v2.Cluster
           connectTimeout: 5s
+          name: localhost:8080
           loadAssignment:
             clusterName: localhost:8080
             endpoints:


### PR DESCRIPTION
While trying to run sample CRD with `minikube` I discovered a problem with validation error on Envoy side. The cluster name is missing in the example.