### PR TITLE
control-plane: Services Source API

### DIFF
--- a/components/konvoy-control-plane/pkg/discovery_source.go
+++ b/components/konvoy-control-plane/pkg/discovery_source.go
@@ -1,0 +1,21 @@
+package pkg
+
+type Service struct {
+	Name string
+	Endpoints []Workload
+}
+
+type Workload struct {
+	Labels []string
+	Address string
+	Port uint32
+}
+
+type State struct {
+	Zone string
+	Services []Service
+}
+
+type ServicesSource interface {
+	StateChanges() <-chan State
+}


### PR DESCRIPTION
API for fetching services from the Discovery Service system.

The idea is to have a source that returns channel. We want to react on changes from discovery system.
We could have simple
```
type ServicesSource interface {
	State() State
}
```
and set somewhere a timer to ask periodically a Discovery System for whole state, but some Discovery Services can provide more reactive approach like Zookeeper Watches or Consul Blocking Queries that are more efficient, that's why it's better to have a channel.

When a given Discovery Service has no such functionality to watch changes, we can just run timer with fetching in the implementation.

Service and Workload objects are the entities we talked about in
https://github.com/Kong/konvoy-docs/commit/fb29e72a02490f799200ef9232ee58ddb12f8a35

I looked into [Consul API](https://www.consul.io/api/catalog.html) and [Eureka API](https://github.com/Netflix/eureka/wiki/Eureka-REST-operations) (with Zookeper every organisation builds custom solution, it's only KV).

`State#Zone` is Datacenter in Consul and Dataceter Info in Eureka. On K8S I [think](https://kubernetes.io/docs/setup/best-practices/multiple-zones/) there is a label for this.

`Workload#Labels` are tags (+maybe matadata) in Consul and metadata in Kubernetes. There is no such concept in Eureka.

Zone info can be later used for [zone aware load balancing](https://www.envoyproxy.io/docs/envoy/v1.6.0/intro/arch_overview/load_balancing#zone-aware-routing) in Envoy.

This probably may be merged only after we create proper Konvoy entities.