### PR TITLE
control-plane: add a mapping between Core types and K8s CRDs

### DIFF
--- a/components/konvoy-control-plane/pkg/plugins/resources/k8s/native/api/v1alpha1/proxytemplate_types_helpers.go
+++ b/components/konvoy-control-plane/pkg/plugins/resources/k8s/native/api/v1alpha1/proxytemplate_types_helpers.go
@@ -1,7 +1,9 @@
 package v1alpha1
 
 import (
+	proto "github.com/Kong/konvoy/components/konvoy-control-plane/api/mesh/v1alpha1"
 	"github.com/Kong/konvoy/components/konvoy-control-plane/pkg/plugins/resources/k8s/native/pkg/model"
+	"github.com/Kong/konvoy/components/konvoy-control-plane/pkg/plugins/resources/k8s/native/pkg/registry"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -27,4 +29,9 @@ func (l *ProxyTemplateList) GetItems() []model.KubernetesObject {
 		result[i] = &l.Items[i]
 	}
 	return result
+}
+
+func init() {
+	registry.RegisterObjectType(&proto.ProxyTemplate{}, &ProxyTemplate{})
+	registry.RegisterListType(&proto.ProxyTemplate{}, &ProxyTemplateList{})
 }

--- a/components/konvoy-control-plane/pkg/plugins/resources/k8s/native/go.mod
+++ b/components/konvoy-control-plane/pkg/plugins/resources/k8s/native/go.mod
@@ -5,9 +5,11 @@ go 1.12
 require (
 	github.com/Kong/konvoy/components/konvoy-control-plane/api v0.0.0-00010101000000-000000000000
 	github.com/go-logr/logr v0.1.0
+	github.com/gogo/protobuf v1.2.1
 	github.com/googleapis/gnostic v0.3.0 // indirect
 	github.com/onsi/ginkgo v1.8.0
 	github.com/onsi/gomega v1.5.0
+	github.com/pkg/errors v0.8.1
 	golang.org/x/net v0.0.0-20190620200207-3b0461eec859
 	k8s.io/api v0.0.0-20190409021203-6e4e0e4f393b
 	k8s.io/apimachinery v0.0.0-20190404173353-6a84e37a896d

--- a/components/konvoy-control-plane/pkg/plugins/resources/k8s/native/go.sum
+++ b/components/konvoy-control-plane/pkg/plugins/resources/k8s/native/go.sum
@@ -70,6 +70,7 @@ github.com/onsi/gomega v1.5.0 h1:izbySO9zDPmjJ8rDjLvkA2zJHIo+HkYXHnf7eN7SSyo=
 github.com/onsi/gomega v1.5.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
 github.com/pborman/uuid v0.0.0-20170612153648-e790cca94e6c h1:MUyE44mTvnI5A0xrxIxaMqoWFzPfQvtE2IWUollMDMs=
 github.com/pborman/uuid v0.0.0-20170612153648-e790cca94e6c/go.mod h1:VyrYX9gd7irzKovcSS6BIIEwPRkP2Wm2m9ufcdFSJ34=
+github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_golang v0.9.0 h1:tXuTFVHC03mW0D+Ua1Q2d1EAVqLTuggX50V0VLICCzY=

--- a/components/konvoy-control-plane/pkg/plugins/resources/k8s/native/pkg/registry/global.go
+++ b/components/konvoy-control-plane/pkg/plugins/resources/k8s/native/pkg/registry/global.go
@@ -1,0 +1,23 @@
+package registry
+
+import (
+	"github.com/Kong/konvoy/components/konvoy-control-plane/pkg/plugins/resources/k8s/native/pkg/model"
+)
+
+var global = NewTypeRegistry()
+
+func Global() TypeRegistry {
+	return global
+}
+
+func RegisterObjectType(typ ResourceType, obj model.KubernetesObject) {
+	if err := global.RegisterObjectType(typ, obj); err != nil {
+		panic(err)
+	}
+}
+
+func RegisterListType(typ ResourceType, obj model.KubernetesList) {
+	if err := global.RegisterListType(typ, obj); err != nil {
+		panic(err)
+	}
+}

--- a/components/konvoy-control-plane/pkg/plugins/resources/k8s/native/pkg/registry/interfaces.go
+++ b/components/konvoy-control-plane/pkg/plugins/resources/k8s/native/pkg/registry/interfaces.go
@@ -1,0 +1,16 @@
+package registry
+
+import (
+	"github.com/Kong/konvoy/components/konvoy-control-plane/pkg/plugins/resources/k8s/native/pkg/model"
+	"github.com/gogo/protobuf/proto"
+)
+
+type ResourceType = proto.Message
+
+type TypeRegistry interface {
+	RegisterObjectType(ResourceType, model.KubernetesObject) error
+	RegisterListType(ResourceType, model.KubernetesList) error
+
+	NewObject(ResourceType) (model.KubernetesObject, error)
+	NewList(ResourceType) (model.KubernetesList, error)
+}

--- a/components/konvoy-control-plane/pkg/plugins/resources/k8s/native/pkg/registry/registry.go
+++ b/components/konvoy-control-plane/pkg/plugins/resources/k8s/native/pkg/registry/registry.go
@@ -1,0 +1,55 @@
+package registry
+
+import (
+	"github.com/Kong/konvoy/components/konvoy-control-plane/pkg/plugins/resources/k8s/native/pkg/model"
+	"github.com/gogo/protobuf/proto"
+	"github.com/pkg/errors"
+)
+
+func NewTypeRegistry() TypeRegistry {
+	return &typeRegistry{
+		objectTypes:     make(map[string]model.KubernetesObject),
+		objectListTypes: make(map[string]model.KubernetesList),
+	}
+}
+
+var _ TypeRegistry = &typeRegistry{}
+
+type typeRegistry struct {
+	objectTypes     map[string]model.KubernetesObject
+	objectListTypes map[string]model.KubernetesList
+}
+
+func (r *typeRegistry) RegisterObjectType(typ ResourceType, obj model.KubernetesObject) error {
+	name := proto.MessageName(typ)
+	if previous, ok := r.objectTypes[name]; ok {
+		return errors.Errorf("duplicate registration of KubernetesObject type under name %q: previous=%#v new=%#v", name, previous, obj)
+	}
+	r.objectTypes[name] = obj
+	return nil
+}
+
+func (r *typeRegistry) RegisterListType(typ ResourceType, obj model.KubernetesList) error {
+	name := proto.MessageName(typ)
+	if previous, ok := r.objectListTypes[name]; ok {
+		return errors.Errorf("duplicate registration of KubernetesList type under name %q: previous=%#v new=%#v", name, previous, obj)
+	}
+	r.objectListTypes[name] = obj
+	return nil
+}
+
+func (r *typeRegistry) NewObject(typ ResourceType) (model.KubernetesObject, error) {
+	name := proto.MessageName(typ)
+	if obj, ok := r.objectTypes[name]; ok {
+		return obj.DeepCopyObject().(model.KubernetesObject), nil
+	}
+	return nil, errors.Errorf("unknown message type: %q", name)
+}
+
+func (r *typeRegistry) NewList(typ ResourceType) (model.KubernetesList, error) {
+	name := proto.MessageName(typ)
+	if obj, ok := r.objectListTypes[name]; ok {
+		return obj.DeepCopyObject().(model.KubernetesList), nil
+	}
+	return nil, errors.Errorf("unknown message type: %q", name)
+}

--- a/components/konvoy-control-plane/pkg/plugins/resources/k8s/store.go
+++ b/components/konvoy-control-plane/pkg/plugins/resources/k8s/store.go
@@ -7,8 +7,7 @@ import (
 	core_model "github.com/Kong/konvoy/components/konvoy-control-plane/pkg/core/resources/model"
 	"github.com/Kong/konvoy/components/konvoy-control-plane/pkg/core/resources/store"
 	k8s_model "github.com/Kong/konvoy/components/konvoy-control-plane/pkg/plugins/resources/k8s/native/pkg/model"
-	sample_k8s "github.com/Kong/konvoy/components/konvoy-control-plane/pkg/plugins/resources/k8s/native/test/api/sample/v1alpha1"
-	sample_core "github.com/Kong/konvoy/components/konvoy-control-plane/pkg/test/resources/apis/sample"
+	k8s_registry "github.com/Kong/konvoy/components/konvoy-control-plane/pkg/plugins/resources/k8s/native/pkg/registry"
 	util_proto "github.com/Kong/konvoy/components/konvoy-control-plane/pkg/util/proto"
 	"github.com/pkg/errors"
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
@@ -126,24 +125,15 @@ type KubeFactory interface {
 var _ KubeFactory = &SimpleKubeFactory{}
 
 type SimpleKubeFactory struct {
+	KubeTypes k8s_registry.TypeRegistry
 }
 
 func (f *SimpleKubeFactory) NewObject(r core_model.Resource) (k8s_model.KubernetesObject, error) {
-	switch r.GetType() {
-	case sample_core.TrafficRouteType:
-		return &sample_k8s.TrafficRoute{}, nil
-	default:
-		return nil, fmt.Errorf("unknown type: %q", r.GetType())
-	}
+	return f.KubeTypes.NewObject(r.GetSpec())
 }
 
 func (f *SimpleKubeFactory) NewList(rl core_model.ResourceList) (k8s_model.KubernetesList, error) {
-	switch rl.GetItemType() {
-	case sample_core.TrafficRouteType:
-		return &sample_k8s.TrafficRouteList{}, nil
-	default:
-		return nil, fmt.Errorf("unknown type: %q", rl.GetItemType())
-	}
+	return f.KubeTypes.NewList(rl.NewItem().GetSpec())
 }
 
 type Converter interface {

--- a/components/konvoy-control-plane/pkg/plugins/resources/k8s/store_test.go
+++ b/components/konvoy-control-plane/pkg/plugins/resources/k8s/store_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/Kong/konvoy/components/konvoy-control-plane/pkg/core/resources/store"
 	"github.com/Kong/konvoy/components/konvoy-control-plane/pkg/plugins/resources/k8s"
+	k8s_registry "github.com/Kong/konvoy/components/konvoy-control-plane/pkg/plugins/resources/k8s/native/pkg/registry"
 	sample_k8s "github.com/Kong/konvoy/components/konvoy-control-plane/pkg/plugins/resources/k8s/native/test/api/sample/v1alpha1"
 	sample_proto "github.com/Kong/konvoy/components/konvoy-control-plane/pkg/test/apis/sample/v1alpha1"
 	sample_core "github.com/Kong/konvoy/components/konvoy-control-plane/pkg/test/resources/apis/sample"
@@ -69,10 +70,16 @@ var _ = Describe("KubernetesStore", func() {
 	}
 
 	BeforeEach(func() {
+		kubeTypes := k8s_registry.NewTypeRegistry()
+		Expect(kubeTypes.RegisterObjectType(&sample_proto.TrafficRoute{}, &sample_k8s.TrafficRoute{})).To(Succeed())
+		Expect(kubeTypes.RegisterListType(&sample_proto.TrafficRoute{}, &sample_k8s.TrafficRouteList{})).To(Succeed())
+
 		ks = &k8s.KubernetesStore{
 			Client: k8sClient,
 			Converter: &k8s.SimpleConverter{
-				KubeFactory: &k8s.SimpleKubeFactory{},
+				KubeFactory: &k8s.SimpleKubeFactory{
+					KubeTypes: kubeTypes,
+				},
 			},
 		}
 		s = store.NewStrictResourceStore(ks)


### PR DESCRIPTION
Changes:
* add `TypeRegistry` abstraction to hold a mapping between Protobuf types and K8s CRDs
* add "global" `TypeRegistry`
* update `ProxyTemplate` CRD to register itself with "global" `TypeRegistry`
* update k8s-based `ResourceStore` to utilize `TypeRegistry`
