### PR TITLE
Feature: Add Discovery Source API

### DIFF
--- a/components/konvoy-control-plane/pkg/core/alias.go
+++ b/components/konvoy-control-plane/pkg/core/alias.go
@@ -1,10 +1,13 @@
 package core
 
 import (
+	kube_types "k8s.io/apimachinery/pkg/types"
 	kube_ctrl "sigs.k8s.io/controller-runtime"
 	kube_log "sigs.k8s.io/controller-runtime/pkg/log"
 	kube_log_zap "sigs.k8s.io/controller-runtime/pkg/log/zap"
 )
+
+type NamespacedName = kube_types.NamespacedName
 
 var (
 	Log       = kube_ctrl.Log

--- a/components/konvoy-control-plane/pkg/core/discovery/interfaces.go
+++ b/components/konvoy-control-plane/pkg/core/discovery/interfaces.go
@@ -1,0 +1,42 @@
+package discovery
+
+import (
+	discovery_proto "github.com/Kong/konvoy/components/konvoy-control-plane/api/discovery/v1alpha1"
+	"github.com/Kong/konvoy/components/konvoy-control-plane/pkg/core"
+)
+
+// DiscoverySource is a source of discovery information, i.e. Services and Workloads.
+type DiscoverySource interface {
+	AddConsumer(DiscoveryConsumer)
+}
+
+// ServiceInfo combines original proto object with auxiliary information.
+type ServiceInfo struct {
+	Service *discovery_proto.Service
+}
+
+// WorkloadInfo combines original proto object with auxiliary information.
+type WorkloadInfo struct {
+	Workload *discovery_proto.Workload
+	Desc     *WorkloadDescription
+}
+
+// WorkloadDescription represents auxiliary information about a Workload.
+type WorkloadDescription struct {
+	Version   string
+	Endpoints []WorkloadEndpoint
+}
+
+type WorkloadEndpoint struct {
+	Address string
+	Port    uint32
+}
+
+// DiscoveryConsumer is a consumer of discovery information, i.e. Services and Workloads.
+type DiscoveryConsumer interface {
+	OnServiceUpdate(*ServiceInfo) error
+	OnServiceDelete(core.NamespacedName) error
+
+	OnWorkloadUpdate(*WorkloadInfo) error
+	OnWorkloadDelete(core.NamespacedName) error
+}

--- a/components/konvoy-control-plane/pkg/core/discovery/sink.go
+++ b/components/konvoy-control-plane/pkg/core/discovery/sink.go
@@ -1,0 +1,42 @@
+package discovery
+
+import (
+	"github.com/Kong/konvoy/components/konvoy-control-plane/pkg/core"
+)
+
+var _ DiscoverySource = &DiscoverySink{}
+var _ DiscoveryConsumer = &DiscoverySink{}
+
+// DiscoverySink is both a source and a consumer of discovery information.
+type DiscoverySink struct {
+	Consumer DiscoveryConsumer
+}
+
+func (s *DiscoverySink) AddConsumer(c DiscoveryConsumer) {
+	s.Consumer = c
+}
+
+func (s *DiscoverySink) OnServiceUpdate(svc *ServiceInfo) error {
+	if s.Consumer != nil {
+		return s.Consumer.OnServiceUpdate(svc)
+	}
+	return nil
+}
+func (s *DiscoverySink) OnServiceDelete(name core.NamespacedName) error {
+	if s.Consumer != nil {
+		return s.Consumer.OnServiceDelete(name)
+	}
+	return nil
+}
+func (s *DiscoverySink) OnWorkloadUpdate(wrk *WorkloadInfo) error {
+	if s.Consumer != nil {
+		return s.Consumer.OnWorkloadUpdate(wrk)
+	}
+	return nil
+}
+func (s *DiscoverySink) OnWorkloadDelete(name core.NamespacedName) error {
+	if s.Consumer != nil {
+		return s.Consumer.OnWorkloadDelete(name)
+	}
+	return nil
+}


### PR DESCRIPTION
Changes:
* define API for receiving Discovery information

Notice that this API is different from https://github.com/Kong/konvoy/pull/27.

It's designed around individual `Service` and `Workload` objects to leverage k8s watches.

Effectively, it is similar to Envoy Delta API.