### PR TITLE
control-plane: add Plugin API

### DIFF
--- a/components/konvoy-control-plane/pkg/core/plugins/global.go
+++ b/components/konvoy-control-plane/pkg/core/plugins/global.go
@@ -1,0 +1,20 @@
+package plugins
+
+import (
+	"os"
+
+	"github.com/Kong/konvoy/components/konvoy-control-plane/pkg/core"
+)
+
+var global = NewRegistry()
+
+func Plugins() Registry {
+	return global
+}
+
+func Register(name PluginName, plugin Plugin) {
+	if err := global.Register(name, plugin); err != nil {
+		core.Log.Error(err, "failed to register a plugin", "name", name, "plugin", plugin)
+		os.Exit(1)
+	}
+}

--- a/components/konvoy-control-plane/pkg/core/plugins/interfaces.go
+++ b/components/konvoy-control-plane/pkg/core/plugins/interfaces.go
@@ -1,0 +1,36 @@
+package plugins
+
+import (
+	core_discovery "github.com/Kong/konvoy/components/konvoy-control-plane/pkg/core/discovery"
+	core_store "github.com/Kong/konvoy/components/konvoy-control-plane/pkg/core/resources/store"
+)
+
+type Plugin interface{}
+
+type PluginConfig interface{}
+
+// TODO(yskopets): TBD
+type PluginContext interface{}
+
+// TODO(yskopets): TBD
+type MutablePluginContext struct{}
+
+// BootstrapPlugin is responsible for environment-specific initialization at start up,
+// e.g. Kubernetes-specific part of configuration.
+// Unlike other plugins, can mutate plugin context directly.
+type BootstrapPlugin interface {
+	Plugin
+	Bootstrap(*MutablePluginContext, PluginConfig) error
+}
+
+// ResourceStorePlugin is responsible for instantiating a particular ResourceStore.
+type ResourceStorePlugin interface {
+	Plugin
+	NewResourceStore(PluginContext, PluginConfig) (core_store.ResourceStore, error)
+}
+
+// DiscoveryPlugin is responsible for instantiating a particular DiscoverySource.
+type DiscoveryPlugin interface {
+	Plugin
+	NewDiscoverySource(PluginContext, PluginConfig) (core_discovery.DiscoverySource, error)
+}

--- a/components/konvoy-control-plane/pkg/core/plugins/registry.go
+++ b/components/konvoy-control-plane/pkg/core/plugins/registry.go
@@ -1,0 +1,105 @@
+package plugins
+
+import (
+	"github.com/pkg/errors"
+)
+
+type pluginType string
+
+const (
+	bootstrapPlugin     pluginType = "bootstrap"
+	resourceStorePlugin pluginType = "resource-store"
+	discoveryPlugin     pluginType = "discovery"
+)
+
+type PluginName string
+
+const (
+	Kubernetes PluginName = "k8s"
+)
+
+type Registry interface {
+	Bootstrap(PluginName) (BootstrapPlugin, error)
+	ResourceStore(name PluginName) (ResourceStorePlugin, error)
+	Discovery(name PluginName) (DiscoveryPlugin, error)
+}
+
+type RegistryMutator interface {
+	Register(PluginName, Plugin) error
+}
+
+type MutableRegistry interface {
+	Registry
+	RegistryMutator
+}
+
+func NewRegistry() MutableRegistry {
+	return &registry{
+		bootstrap:     make(map[PluginName]BootstrapPlugin),
+		resourceStore: make(map[PluginName]ResourceStorePlugin),
+		discovery:     make(map[PluginName]DiscoveryPlugin),
+	}
+}
+
+var _ MutableRegistry = &registry{}
+
+type registry struct {
+	bootstrap     map[PluginName]BootstrapPlugin
+	resourceStore map[PluginName]ResourceStorePlugin
+	discovery     map[PluginName]DiscoveryPlugin
+}
+
+func (r *registry) Bootstrap(name PluginName) (BootstrapPlugin, error) {
+	if p, ok := r.bootstrap[name]; ok {
+		return p, nil
+	} else {
+		return nil, noSuchPluginError(bootstrapPlugin, name)
+	}
+}
+
+func (r *registry) ResourceStore(name PluginName) (ResourceStorePlugin, error) {
+	if p, ok := r.resourceStore[name]; ok {
+		return p, nil
+	} else {
+		return nil, noSuchPluginError(resourceStorePlugin, name)
+	}
+}
+
+func (r *registry) Discovery(name PluginName) (DiscoveryPlugin, error) {
+	if p, ok := r.discovery[name]; ok {
+		return p, nil
+	} else {
+		return nil, noSuchPluginError(discoveryPlugin, name)
+	}
+}
+
+func (r *registry) Register(name PluginName, plugin Plugin) error {
+	if bp, ok := plugin.(BootstrapPlugin); ok {
+		if old, exists := r.bootstrap[name]; exists {
+			return pluginAlreadyRegisteredError(bootstrapPlugin, name, old, bp)
+		}
+		r.bootstrap[name] = bp
+	}
+	if rsp, ok := plugin.(ResourceStorePlugin); ok {
+		if old, exists := r.resourceStore[name]; exists {
+			return pluginAlreadyRegisteredError(resourceStorePlugin, name, old, rsp)
+		}
+		r.resourceStore[name] = rsp
+	}
+	if dp, ok := plugin.(DiscoveryPlugin); ok {
+		if old, exists := r.discovery[name]; exists {
+			return pluginAlreadyRegisteredError(discoveryPlugin, name, old, dp)
+		}
+		r.discovery[name] = dp
+	}
+	return nil
+}
+
+func noSuchPluginError(typ pluginType, name PluginName) error {
+	return errors.Errorf("there is no plugin registered with type=%q and name=%s", typ, name)
+}
+
+func pluginAlreadyRegisteredError(typ pluginType, name PluginName, old, new Plugin) error {
+	return errors.Errorf("plugin with type=%q and name=%s has already been registered: old=%#v new=%#v",
+		typ, name, old, new)
+}


### PR DESCRIPTION
Changes:
* define API for plugins, e.g. `Postgres ResourceStore`, `k8s Service Discovery`, etc

This is an intermediate step towards support for non-k8s environments 