### PR TITLE
control-plane: api on mesh itself

### DIFF
--- a/components/konvoy-control-plane/pkg/api-server/mesh/mesh_definition.go
+++ b/components/konvoy-control-plane/pkg/api-server/mesh/mesh_definition.go
@@ -1,0 +1,18 @@
+package mesh
+
+import (
+	api_server "github.com/Kong/konvoy/components/konvoy-control-plane/pkg/api-server"
+	"github.com/Kong/konvoy/components/konvoy-control-plane/pkg/core/resources/apis/mesh"
+	"github.com/Kong/konvoy/components/konvoy-control-plane/pkg/core/resources/model"
+)
+
+var MeshWsDefinition = api_server.ResourceWsDefinition{
+	Name: "Mesh",
+	Path: "meshes",
+	ResourceFactory: func() model.Resource {
+		return &mesh.MeshResource{}
+	},
+	ResourceListFactory: func() model.ResourceList {
+		return &mesh.MeshResourceList{}
+	},
+}

--- a/components/konvoy-control-plane/pkg/api-server/mesh_ws_test.go
+++ b/components/konvoy-control-plane/pkg/api-server/mesh_ws_test.go
@@ -1,0 +1,232 @@
+package api_server_test
+
+import (
+	"context"
+	"fmt"
+	"github.com/Kong/konvoy/components/konvoy-control-plane/api/mesh/v1alpha1"
+	"github.com/Kong/konvoy/components/konvoy-control-plane/pkg/api-server"
+	"github.com/Kong/konvoy/components/konvoy-control-plane/pkg/core/resources/apis/mesh"
+	"github.com/Kong/konvoy/components/konvoy-control-plane/pkg/core/resources/model/rest"
+	"github.com/Kong/konvoy/components/konvoy-control-plane/pkg/core/resources/store"
+	"github.com/Kong/konvoy/components/konvoy-control-plane/pkg/plugins/resources/memory"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"io/ioutil"
+)
+
+var _ = Describe("Resource WS", func() {
+	var apiServer *api_server.ApiServer
+	var resourceStore store.ResourceStore
+	var client resourceApiClient
+
+	const namespace = "default"
+
+	BeforeEach(func() {
+		resourceStore = memory.NewStore()
+		apiServer = createTestApiServer(resourceStore, api_server.ApiServerConfig{})
+		client = resourceApiClient{
+			apiServer.Address(),
+			"/meshes",
+		}
+		apiServer.Start()
+		waitForServer(&client)
+	})
+
+	AfterEach(func() {
+		err := apiServer.Stop()
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	Describe("On GET", func() {
+		It("should return an existing resource", func() {
+			// given
+			putMeshIntoStore(resourceStore, "mesh-1")
+
+			// when
+			response := client.get("mesh-1")
+
+			// then
+			Expect(response.StatusCode).To(Equal(200))
+			body, err := ioutil.ReadAll(response.Body)
+			Expect(err).ToNot(HaveOccurred())
+			json := `
+			{
+				"type": "Mesh",
+				"name": "mesh-1",
+				"mesh": "mesh-1"
+			}`
+			Expect(body).To(MatchJSON(json))
+		})
+
+		It("should return 404 for non existing resource", func() {
+			// when
+			response := client.get("non-existing-resource")
+
+			// then
+			Expect(response.StatusCode).To(Equal(404))
+		})
+
+		It("should list resources", func() {
+			// given
+			putMeshIntoStore(resourceStore, "mesh-1")
+			putMeshIntoStore(resourceStore, "mesh-2")
+
+			// when
+			response := client.list()
+
+			// then
+			Expect(response.StatusCode).To(Equal(200))
+			json1 := `
+			{
+				"type": "Mesh",
+				"name": "mesh-1",
+				"mesh": "mesh-1"
+			}`
+			json2 := `
+			{
+				"type": "Mesh",
+				"name": "mesh-2",
+				"mesh": "mesh-2"
+			}`
+			body, err := ioutil.ReadAll(response.Body)
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(string(body)).To(Or(
+				MatchJSON(fmt.Sprintf(`{"items": [%s,%s]}`, json1, json2)),
+				MatchJSON(fmt.Sprintf(`{"items": [%s,%s]}`, json2, json1)),
+			))
+		})
+	})
+
+	Describe("On PUT", func() {
+		It("should create a resource when one does not exist", func() {
+			// given
+			res := rest.Resource{
+				Meta: rest.ResourceMeta{
+					Name: "new-mesh",
+					Mesh: "new-mesh",
+					Type: string(mesh.MeshType),
+				},
+				Spec: &v1alpha1.Mesh{},
+			}
+
+			// when
+			response := client.put(res)
+
+			// then
+			Expect(response.StatusCode).To(Equal(201))
+		})
+
+		It("should update a resource when one already exist", func() {
+			// given
+			name := "mesh-1"
+			putMeshIntoStore(resourceStore, name)
+
+			// when
+			res := rest.Resource{
+				Meta: rest.ResourceMeta{
+					Name: "mesh-1",
+					Mesh: "mesh-1",
+					Type: string(mesh.MeshType),
+				},
+				Spec: &v1alpha1.Mesh{
+					Tracing: &v1alpha1.Tracing{
+						Type: &v1alpha1.Tracing_Zipkin_{},
+					},
+				},
+			}
+			response := client.put(res)
+			Expect(response.StatusCode).To(Equal(200))
+
+			// then
+			resource := mesh.MeshResource{}
+			err := resourceStore.Get(context.Background(), &resource, store.GetByKey(namespace, name, name))
+			Expect(err).ToNot(HaveOccurred())
+			Expect(resource.Spec.Tracing.Type).To(Equal(&v1alpha1.Tracing_Zipkin_{}))
+		})
+
+		It("should return 400 on the type in url that is different from request", func() {
+			// given
+			json := `
+			{
+				"type": "Mesh",
+				"name": "tr-1",
+				"mesh": "default"
+			}
+			`
+
+			// when
+			response := client.putJson("tr-1", []byte(json))
+
+			// then
+			Expect(response.StatusCode).To(Equal(400))
+		})
+
+		It("should return 400 on the name that is different from request", func() {
+			// given
+			json := `
+			{
+				"type": "Mesh",
+				"name": "different-name",
+				"mesh": "different-name"
+			}
+			`
+
+			// when
+			response := client.putJson("mesh-1", []byte(json))
+
+			// then
+			Expect(response.StatusCode).To(Equal(400))
+		})
+
+		It("should return 400 on the mesh that is different from request", func() {
+			// given
+			json := `
+			{
+				"type": "Mesh",
+				"name": "mesh-1",
+				"mesh": "different-mesh"
+			}
+			`
+
+			// when
+			response := client.putJson("mesh-1", []byte(json))
+
+			// then
+			Expect(response.StatusCode).To(Equal(400))
+		})
+	})
+
+	Describe("On DELETE", func() {
+		It("should delete existing resource", func() {
+			// given
+			name := "mesh-1"
+			putMeshIntoStore(resourceStore, name)
+
+			// when
+			response := client.delete(name)
+
+			// then
+			Expect(response.StatusCode).To(Equal(200))
+
+			// and
+			resource := mesh.MeshResource{}
+			err := resourceStore.Get(context.Background(), &resource, store.GetByKey(namespace, name, name))
+			Expect(err).To(Equal(store.ErrorResourceNotFound(resource.GetType(), namespace, name, name)))
+		})
+
+		It("should delete non-existing resource", func() {
+			// when
+			response := client.delete("non-existing-resource")
+
+			// then
+			Expect(response.StatusCode).To(Equal(200))
+		})
+	})
+})
+
+func putMeshIntoStore(resourceStore store.ResourceStore, name string) {
+	resource := mesh.MeshResource{}
+	err := resourceStore.Create(context.Background(), &resource, store.CreateByKey("default", name, name))
+	Expect(err).NotTo(HaveOccurred())
+}

--- a/components/konvoy-control-plane/pkg/api-server/read_only_resource_ws_test.go
+++ b/components/konvoy-control-plane/pkg/api-server/read_only_resource_ws_test.go
@@ -2,9 +2,11 @@ package api_server_test
 
 import (
 	"github.com/Kong/konvoy/components/konvoy-control-plane/pkg/api-server"
+	"github.com/Kong/konvoy/components/konvoy-control-plane/pkg/core/resources/model/rest"
 	"github.com/Kong/konvoy/components/konvoy-control-plane/pkg/core/resources/store"
 	"github.com/Kong/konvoy/components/konvoy-control-plane/pkg/plugins/resources/memory"
 	sample_proto "github.com/Kong/konvoy/components/konvoy-control-plane/pkg/test/apis/sample/v1alpha1"
+	"github.com/Kong/konvoy/components/konvoy-control-plane/pkg/test/resources/apis/sample"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -22,7 +24,7 @@ var _ = Describe("Read only Resource WS", func() {
 		apiServer = createTestApiServer(resourceStore, api_server.ApiServerConfig{ReadOnly: true})
 		client = resourceApiClient{
 			address: apiServer.Address(),
-			mesh:    mesh,
+			path:    "/meshes/" + mesh + "/traffic-routes",
 		}
 		apiServer.Start()
 		waitForServer(&client)
@@ -56,12 +58,19 @@ var _ = Describe("Read only Resource WS", func() {
 	Describe("On PUT", func() {
 		It("should return 405", func() {
 			// given
-			route := sample_proto.TrafficRoute{
-				Path: "/sample-path",
+			res := rest.Resource{
+				Meta: rest.ResourceMeta{
+					Name: "new-resource",
+					Mesh: mesh,
+					Type: string(sample.TrafficRouteType),
+				},
+				Spec: &sample_proto.TrafficRoute{
+					Path: "/sample-path",
+				},
 			}
 
 			// when
-			response := client.put("new-resource", &route)
+			response := client.put(res)
 
 			// then
 			Expect(response.StatusCode).To(Equal(405))


### PR DESCRIPTION
This PR adds support for
GET /meshes
GET /meshes/:name
PUT /meshes/:name
DELETE /meshes/:name

The test is basically a copy paste of the traffic resource test as I could not find proper abstraction for it.