### PR TITLE
ci: Makefiles should support GOPATH value with multiple dirs

### DIFF
--- a/components/konvoy-control-plane/Makefile
+++ b/components/konvoy-control-plane/Makefile
@@ -69,8 +69,9 @@ CI_TOOLS_IMAGE ?= circleci/golang:1.12
 
 CI_TOOLS_DIR ?= $(HOME)/bin
 PATH := $(CI_TOOLS_DIR):$(PATH)
-GO_BIN_DIR := $(shell go env GOPATH | awk -F: '{print $$1}')/bin
-export PATH := $(CI_TOOLS_DIR):$(GO_BIN_DIR):$(PATH)
+GOPATH_DIR := $(shell go env GOPATH | awk -F: '{print $$1}')
+GOPATH_BIN_DIR := $(GOPATH_DIR)/bin
+export PATH := $(CI_TOOLS_DIR):$(GOPATH_BIN_DIR):$(PATH)
 
 PROTOC_PATH := $(CI_TOOLS_DIR)/protoc
 KUBEBUILDER_DIR := $(CI_TOOLS_DIR)/kubebuilder.d
@@ -88,7 +89,7 @@ protoc_search_go_packages := \
 	github.com/gogo/protobuf@$(GOGO_PROTOBUF_VERSION)/protobuf \
 	github.com/envoyproxy/protoc-gen-validate@$(PROTOC_PGV_VERSION) \
 
-protoc_search_go_paths := $(foreach go_package,$(protoc_search_go_packages),--proto_path=$(shell go env GOPATH)/pkg/mod/$(go_package))
+protoc_search_go_paths := $(foreach go_package,$(protoc_search_go_packages),--proto_path=$(GOPATH_DIR)/pkg/mod/$(go_package))
 
 # Protobuf-specifc configuration
 PROTOC_GO := protoc \
@@ -153,7 +154,7 @@ dev/install/ginkgo: ## Bootstrap: Install Ginkgo (BDD testing framework)
 	# see https://github.com/onsi/ginkgo#set-me-up
 	echo "Installing Ginkgo ..."
 	go get -u github.com/onsi/ginkgo/ginkgo  # installs the ginkgo CLI
-	echo "Ginkgo has been installed at $(shell go env GOPATH)/bin/ginkgo"
+	echo "Ginkgo has been installed at $(GOPATH_BIN_DIR)/ginkgo"
 	echo "Installing Gomega ..."
 	go get -u github.com/onsi/gomega/...     # fetches the matcher library
 	echo "Gomega has been installed"

--- a/components/konvoy-control-plane/api/Makefile
+++ b/components/konvoy-control-plane/api/Makefile
@@ -3,8 +3,9 @@
 		protoc protoc/discovery/v1alpha1 protoc/mesh/v1alpha1
 
 TOOLS_DIR ?= $(HOME)/bin
-GO_BIN_DIR := $(shell go env GOPATH | awk -F: '{print $$1}')/bin
-export PATH := $(TOOLS_DIR):$(GO_BIN_DIR):$(PATH)
+GOPATH_DIR := $(shell go env GOPATH | awk -F: '{print $$1}')
+GOPATH_BIN_DIR := $(GOPATH_DIR)/bin
+export PATH := $(TOOLS_DIR):$(GOPATH_BIN_DIR):$(PATH)
 
 PROTOC_PATH := $(TOOLS_DIR)/protoc
 
@@ -17,7 +18,7 @@ protoc_search_go_packages := \
 	github.com/gogo/protobuf@$(GOGO_PROTOBUF_VERSION)/protobuf \
 	github.com/envoyproxy/protoc-gen-validate@$(PROTOC_PGV_VERSION) \
 
-protoc_search_go_paths := $(foreach go_package,$(protoc_search_go_packages),--proto_path=$(shell go env GOPATH)/pkg/mod/$(go_package))
+protoc_search_go_paths := $(foreach go_package,$(protoc_search_go_packages),--proto_path=$(GOPATH_DIR)/pkg/mod/$(go_package))
 
 gogo_import_mapping_entries := \
 	google/protobuf/any.proto=github.com/gogo/protobuf/types \

--- a/components/konvoy-control-plane/pkg/plugins/resources/k8s/native/Makefile
+++ b/components/konvoy-control-plane/pkg/plugins/resources/k8s/native/Makefile
@@ -10,7 +10,9 @@ IMG ?= konvoy/konvoy-controller-manager:latest
 #CRD_OUTPUT := output:crd:artifacts:config=config/crd/bases
 
 CI_TOOLS_DIR ?= $(HOME)/bin
-PATH := $(CI_TOOLS_DIR):$(PATH)
+GOPATH_DIR := $(shell go env GOPATH | awk -F: '{print $$1}')
+GOPATH_BIN_DIR := $(GOPATH_DIR)/bin
+export PATH := $(CI_TOOLS_DIR):$(GOPATH_BIN_DIR):$(PATH)
 
 KUBE_APISERVER_PATH := $(CI_TOOLS_DIR)/kube-apiserver
 ETCD_PATH := $(CI_TOOLS_DIR)/etcd
@@ -83,7 +85,7 @@ docker-push:
 controller-gen:
 ifeq (, $(shell which controller-gen))
 	go get sigs.k8s.io/controller-tools/cmd/controller-gen@v0.2.0-beta.2
-CONTROLLER_GEN=$(shell go env GOPATH)/bin/controller-gen
+CONTROLLER_GEN=$(GOPATH_BIN_DIR)/controller-gen
 else
 CONTROLLER_GEN=$(shell which controller-gen)
 endif


### PR DESCRIPTION
Changes:
* handle a case where `GOPATH` value is set to multiple dirs separated by `:`