### PR TITLE
konvoyctl: use `kubectl proxy` to connect to Konvoy API Server

### DIFF
--- a/components/konvoy-control-plane/app/konvoyctl/pkg/k8s/client.go
+++ b/components/konvoy-control-plane/app/konvoyctl/pkg/k8s/client.go
@@ -6,6 +6,7 @@ import (
 	kube_core "k8s.io/api/core/v1"
 	kube_apierrors "k8s.io/apimachinery/pkg/api/errors"
 	kube_scheme "k8s.io/client-go/kubernetes/scheme"
+	kube_rest "k8s.io/client-go/rest"
 	kube_client "sigs.k8s.io/controller-runtime/pkg/client"
 
 	mesh_v1alpha1 "github.com/Kong/konvoy/components/konvoy-control-plane/pkg/plugins/resources/k8s/native/api/v1alpha1"
@@ -15,14 +16,10 @@ type Client interface {
 	HasNamespace(name string) (bool, error)
 }
 
-func newClient(cfg *kubeConfig) (Client, error) {
-	kubeConfig, err := cfg.clientConfig.ClientConfig()
-	if err != nil {
-		return nil, err
-	}
+func NewClient(cfg *kube_rest.Config) (Client, error) {
 	scheme := kube_scheme.Scheme
 	mesh_v1alpha1.AddToScheme(scheme)
-	kubeClient, err := kube_client.New(kubeConfig, kube_client.Options{Scheme: scheme})
+	kubeClient, err := kube_client.New(cfg, kube_client.Options{Scheme: scheme})
 	if err != nil {
 		return nil, err
 	}

--- a/components/konvoy-control-plane/app/konvoyctl/pkg/k8s/k8s_suite_test.go
+++ b/components/konvoy-control-plane/app/konvoyctl/pkg/k8s/k8s_suite_test.go
@@ -1,0 +1,13 @@
+package k8s_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestK8s(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "K8s Suite")
+}

--- a/components/konvoy-control-plane/app/konvoyctl/pkg/k8s/kubectl_proxy.go
+++ b/components/konvoy-control-plane/app/konvoyctl/pkg/k8s/kubectl_proxy.go
@@ -1,0 +1,88 @@
+/*
+Copyright 2014 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package k8s
+
+import (
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	utilnet "k8s.io/apimachinery/pkg/util/net"
+	"k8s.io/apimachinery/pkg/util/proxy"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/transport"
+)
+
+// NewKubeProxyHandler creates a proxy server which is similar to `kubectl proxy`
+// but, unlike it, is not exposed outside of the process.
+func NewKubeProxyHandler(cfg *rest.Config) (http.Handler, error) {
+	host := cfg.Host
+	if !strings.HasSuffix(host, "/") {
+		host = host + "/"
+	}
+	target, err := url.Parse(host)
+	if err != nil {
+		return nil, err
+	}
+	transport, err := rest.TransportFor(cfg)
+	if err != nil {
+		return nil, err
+	}
+	upgradeTransport, err := makeUpgradeTransport(cfg)
+	if err != nil {
+		return nil, err
+	}
+	responder := &responder{}
+	proxy := proxy.NewUpgradeAwareHandler(target, transport, false, false, responder)
+	proxy.UpgradeTransport = upgradeTransport
+	proxy.UseRequestLocation = true
+
+	return proxy, nil
+}
+
+// makeUpgradeTransport creates a transport that explicitly bypasses HTTP2 support
+// for proxy connections that must upgrade.
+func makeUpgradeTransport(config *rest.Config) (proxy.UpgradeRequestRoundTripper, error) {
+	transportConfig, err := config.TransportConfig()
+	if err != nil {
+		return nil, err
+	}
+	tlsConfig, err := transport.TLSConfigFor(transportConfig)
+	if err != nil {
+		return nil, err
+	}
+	rt := utilnet.SetOldTransportDefaults(&http.Transport{
+		TLSClientConfig: tlsConfig,
+		DialContext: (&net.Dialer{
+			Timeout: 30 * time.Second,
+		}).DialContext,
+	})
+
+	upgrader, err := transport.HTTPWrappersForConfig(transportConfig, proxy.MirrorRequest)
+	if err != nil {
+		return nil, err
+	}
+	return proxy.NewUpgradeRequestRoundTripper(rt, upgrader), nil
+}
+
+type responder struct{}
+
+func (r *responder) Error(w http.ResponseWriter, req *http.Request, err error) {
+	http.Error(w, err.Error(), http.StatusInternalServerError)
+}

--- a/components/konvoy-control-plane/app/konvoyctl/pkg/k8s/proxy.go
+++ b/components/konvoy-control-plane/app/konvoyctl/pkg/k8s/proxy.go
@@ -1,0 +1,97 @@
+package k8s
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"net/http"
+	"runtime/debug"
+	"strings"
+
+	kube_util_net "k8s.io/apimachinery/pkg/util/net"
+	kube_rest "k8s.io/client-go/rest"
+
+	"net/http/httptest"
+)
+
+func NewServiceProxyTransport(kubeApiServer http.RoundTripper, namespace, name string) http.RoundTripper {
+	return &resourceProxyTransport{
+		resource:      "services",
+		namespace:     namespace,
+		name:          name,
+		kubeApiServer: kubeApiServer,
+	}
+}
+
+var _ http.RoundTripper = &resourceProxyTransport{}
+
+type resourceProxyTransport struct {
+	resource      string
+	namespace     string
+	name          string
+	kubeApiServer http.RoundTripper
+}
+
+func (t *resourceProxyTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	req = kube_util_net.CloneRequest(req)
+
+	if strings.HasPrefix(req.URL.Path, "/") {
+		if 1 < len(req.URL.Path) {
+			req.URL.Path = req.URL.Path[1:]
+		} else {
+			req.URL.Path = ""
+		}
+	}
+
+	req.URL.Path = fmt.Sprintf("/api/v1/namespaces/%s/%s/%s/proxy/%s", t.namespace, t.resource, t.name, req.URL.Path)
+
+	return t.kubeApiServer.RoundTrip(req)
+}
+
+func NewKubeApiProxyTransport(cfg *kube_rest.Config) (http.RoundTripper, error) {
+	proxy, err := NewKubeProxyHandler(cfg)
+	if err != nil {
+		return nil, err
+	}
+	return NewInprocessKubeProxyTransport(proxy), nil
+}
+
+func NewInprocessKubeProxyTransport(handler http.Handler) http.RoundTripper {
+	return &inprocessKubeProxyTransport{handler: handler}
+}
+
+var _ http.RoundTripper = &inprocessKubeProxyTransport{}
+
+type inprocessKubeProxyTransport struct {
+	handler http.Handler
+}
+
+func (t *inprocessKubeProxyTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	var buf bytes.Buffer
+	if err := req.Write(&buf); err != nil {
+		return nil, err
+	}
+	req, err := http.ReadRequest(bufio.NewReader(&buf))
+	if err != nil {
+		return nil, err
+	}
+
+	type result struct {
+		resp *http.Response
+		err  error
+	}
+	ch := make(chan result)
+	go func() {
+		defer close(ch)
+		defer func() {
+			if p := recover(); p != nil {
+				ch <- result{resp: nil, err: fmt.Errorf("kube proxy paniced: %v\n%s", p, debug.Stack())}
+			}
+		}()
+		w := httptest.NewRecorder()
+		t.handler.ServeHTTP(w, req)
+		ch <- result{resp: w.Result(), err: nil}
+	}()
+	res := <-ch
+	return res.resp, res.err
+}

--- a/components/konvoy-control-plane/app/konvoyctl/pkg/k8s/proxy_test.go
+++ b/components/konvoy-control-plane/app/konvoyctl/pkg/k8s/proxy_test.go
@@ -1,0 +1,151 @@
+package k8s_test
+
+import (
+	"bytes"
+	"io/ioutil"
+	"net/http"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+
+	kube_rest "k8s.io/client-go/rest"
+
+	"github.com/Kong/konvoy/components/konvoy-control-plane/app/konvoyctl/pkg/k8s"
+)
+
+var _ = Describe("Proxy", func() {
+	Describe("NewServiceProxyTransport(..)", func() {
+
+		type testCase struct {
+			originalPath string
+			expectedPath string
+		}
+
+		DescribeTable("should rewrite request URI",
+			func(given testCase) {
+				// given
+				req, _ := http.NewRequest("GET", given.originalPath, nil)
+				expected := &http.Response{}
+
+				// setup
+				rt := RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
+					Expect(req.URL.Path).To(Equal(given.expectedPath))
+					return expected, nil
+				})
+
+				// when
+				spt := k8s.NewServiceProxyTransport(rt, "konvoy-system", "konvoy-control-plane:http-apis-server")
+				// and
+				resp, err := spt.RoundTrip(req)
+				// then
+				Expect(err).ToNot(HaveOccurred())
+				// and
+				Expect(resp).To(BeIdenticalTo(expected))
+			},
+			Entry("", testCase{
+				originalPath: "",
+				expectedPath: "/api/v1/namespaces/konvoy-system/services/konvoy-control-plane:http-apis-server/proxy/",
+			}),
+			Entry("/", testCase{
+				originalPath: "/",
+				expectedPath: "/api/v1/namespaces/konvoy-system/services/konvoy-control-plane:http-apis-server/proxy/",
+			}),
+			Entry("meshes", testCase{
+				originalPath: "meshes",
+				expectedPath: "/api/v1/namespaces/konvoy-system/services/konvoy-control-plane:http-apis-server/proxy/meshes",
+			}),
+			Entry("/meshes/default/dataplanes", testCase{
+				originalPath: "/meshes/default/dataplanes",
+				expectedPath: "/api/v1/namespaces/konvoy-system/services/konvoy-control-plane:http-apis-server/proxy/meshes/default/dataplanes",
+			}),
+		)
+	})
+
+	Describe("NewInprocessKubeProxyTransport(..)", func() {
+		It("should process requests in-process using a given handler", func() {
+			// given
+			req, _ := http.NewRequest("GET", "/api/v1/namespaces/konvoy-system/services/konvoy-control-plane:http-apis-server/proxy/meshes", nil)
+
+			// setup
+			handler := http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+				w.WriteHeader(http.StatusOK)
+				w.Write([]byte("hi there!"))
+			})
+
+			// when
+			kpt := k8s.NewInprocessKubeProxyTransport(handler)
+			// and
+			resp, err := kpt.RoundTrip(req)
+			// then
+			Expect(err).ToNot(HaveOccurred())
+			// and
+			Expect(resp.StatusCode).To(Equal(http.StatusOK))
+
+			// when
+			data, err := ioutil.ReadAll(resp.Body)
+			// then
+			Expect(err).ToNot(HaveOccurred())
+			// and
+			Expect(string(data)).To(Equal("hi there!"))
+		})
+
+		It("should catch a panic and translate it into an error", func() {
+			// given
+			req, _ := http.NewRequest("GET", "/api/v1/namespaces/konvoy-system/services/konvoy-control-plane:http-apis-server/proxy/meshes", nil)
+
+			// setup
+			handler := http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+				panic("something bad has happened")
+			})
+
+			// when
+			kpt := k8s.NewInprocessKubeProxyTransport(handler)
+			// and
+			resp, err := kpt.RoundTrip(req)
+			// then
+			Expect(err.Error()).To(MatchRegexp("kube proxy paniced: something bad has happened\n.+"))
+			// and
+			Expect(resp).To(BeNil())
+		})
+	})
+
+	Describe("NewKubeApiProxyTransport(..)", func() {
+		It("should work", func() {
+			// given
+			req, _ := http.NewRequest("GET", "/api/v1/namespaces/konvoy-system/services/konvoy-control-plane:http-apis-server/proxy/meshes", nil)
+			expected := &http.Response{
+				StatusCode: http.StatusCreated,
+				Body:       ioutil.NopCloser(&bytes.Buffer{}),
+			}
+
+			// setup
+			rt := RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
+				Expect(req.Header.Get("Authorization")).To(Equal("Bearer abcdef"))
+				return expected, nil
+			})
+
+			// when
+			apt, err := k8s.NewKubeApiProxyTransport(&kube_rest.Config{
+				Host:        "1.2.3.4",
+				BearerToken: "abcdef",
+				Transport:   rt,
+			})
+			// then
+			Expect(err).ToNot(HaveOccurred())
+
+			// when
+			resp, err := apt.RoundTrip(req)
+			// then
+			Expect(err).ToNot(HaveOccurred())
+			// and
+			Expect(resp.StatusCode).To(Equal(expected.StatusCode))
+		})
+	})
+})
+
+type RoundTripperFunc func(*http.Request) (*http.Response, error)
+
+func (f RoundTripperFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}

--- a/components/konvoy-control-plane/app/konvoyctl/pkg/resources/store.go
+++ b/components/konvoy-control-plane/app/konvoyctl/pkg/resources/store.go
@@ -1,12 +1,14 @@
 package resources
 
 import (
+	"net/http"
+
 	konvoyctl_k8s "github.com/Kong/konvoy/components/konvoy-control-plane/app/konvoyctl/pkg/k8s"
+	konvoy_rest "github.com/Kong/konvoy/components/konvoy-control-plane/pkg/api-server/definitions"
 	config_proto "github.com/Kong/konvoy/components/konvoy-control-plane/pkg/config/app/konvoyctl/v1alpha1"
 	core_store "github.com/Kong/konvoy/components/konvoy-control-plane/pkg/core/resources/store"
-	k8s_resources "github.com/Kong/konvoy/components/konvoy-control-plane/pkg/plugins/resources/k8s"
+	remote_resources "github.com/Kong/konvoy/components/konvoy-control-plane/pkg/plugins/resources/remote"
 	"github.com/pkg/errors"
-	kube_client "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 func NewResourceStore(controlPlane *config_proto.ControlPlane) (core_store.ResourceStore, error) {
@@ -17,11 +19,12 @@ func NewResourceStore(controlPlane *config_proto.ControlPlane) (core_store.Resou
 			return nil, errors.Wrapf(err, "Failed to load `kubectl` config: kubeconfig=%q context=%q namespace=%q",
 				coordinates.Kubernetes.Kubeconfig, coordinates.Kubernetes.Context, coordinates.Kubernetes.Namespace)
 		}
-		kubeClient, err := kubeConfig.NewClient()
+		// create a Transport that proxies requests to the Control Plane through kube-apiserver
+		t, err := kubeConfig.NewServiceProxyTransport(coordinates.Kubernetes.Namespace, "konvoy-control-plane:http-api-server")
 		if err != nil {
-			return nil, errors.Wrapf(err, "Failed to create Kubernetes client")
+			return nil, errors.Wrapf(err, "Failed to create Kubernetes proxy transport")
 		}
-		return k8s_resources.NewStore(kubeClient.(kube_client.Client))
+		return remote_resources.NewStore(http.Client{Transport: t}, konvoy_rest.AllApis()), nil
 	default:
 		return nil, errors.Errorf("Control Plane has coordinates that are not supported yet: %s", controlPlane.Coordinates.Type)
 	}

--- a/components/konvoy-control-plane/examples/minikube/konvoy-demo.yaml
+++ b/components/konvoy-control-plane/examples/minikube/konvoy-demo.yaml
@@ -14,6 +14,8 @@ spec:
     name: grpc-xds
   - port: 5679
     name: http-xds
+  - port: 5681
+    name: http-api-server
   selector:
     app: konvoy-control-plane
 ---
@@ -50,11 +52,14 @@ spec:
           value: "5678"
         - name: KONVOY_XDS_SERVER_HTTP_PORT
           value: "5679"
+        - name: KONVOY_API_SERVER_PORT
+          value: "5681"
         args:
         - run
         ports:
         - containerPort: 5678
         - containerPort: 5679
+        - containerPort: 5681
         livenessProbe:
           httpGet:
             path: /healthy

--- a/components/konvoy-control-plane/go.mod
+++ b/components/konvoy-control-plane/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/golang/protobuf v1.3.2
 	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/lib/pq v1.1.1
+	github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f // indirect
 	github.com/onsi/ginkgo v1.8.0
 	github.com/onsi/gomega v1.5.0
 	github.com/pborman/uuid v0.0.0-20170612153648-e790cca94e6c

--- a/components/konvoy-control-plane/go.sum
+++ b/components/konvoy-control-plane/go.sum
@@ -122,6 +122,8 @@ github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742 h1:Esafd1046DLD
 github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/modern-go/reflect2 v1.0.1 h1:9f412s+6RmYXLWZSEzVVgPGK7C2PphHj5RJrvfx9AWI=
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
+github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f h1:y5//uYreIhSUg3J1GEMiLbxo1LJaP8RfCpH6pymGZus=
+github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f/go.mod h1:ZdcZmHo+o7JKHSa8/e818NopupXU1YMK5fe1lsApnBw=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.8.0 h1:VkHVNpR4iVnU8XQR6DBm8BqYjN7CRzw+xKUbVVbbW9w=
 github.com/onsi/ginkgo v1.8.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=

--- a/components/konvoy-control-plane/pkg/api-server/definitions/api.go
+++ b/components/konvoy-control-plane/pkg/api-server/definitions/api.go
@@ -6,7 +6,7 @@ import (
 )
 
 func AllApis() core_rest.Api {
-	return Apis(MeshWsDefinition)
+	return Apis(MeshWsDefinition, DataplaneWsDefinition)
 }
 
 func Apis(wss ...ResourceWsDefinition) core_rest.Api {


### PR DESCRIPTION
Changes:
* use `kubectl proxy` to connect to `Konvoy API Server`
  * notice that that we don't actually run `kubectl proxy` but rather embed it in-process in order to avoid exposing Kubernetes apis on `localhost:XXXX`
* use "remote" `ResourceStore` abstraction to make requests to `Konvoy API Server`
* add `--mesh` flag to `konvoyctl`
* `konvoyctl get dataplanes` can now only list dataplanes per single mesh