### PR TITLE
konvoyctl: add `--mesh` option

### DIFF
--- a/components/konvoy-control-plane/app/konvoyctl/cmd/get_dataplanes.go
+++ b/components/konvoy-control-plane/app/konvoyctl/cmd/get_dataplanes.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Kong/konvoy/components/konvoy-control-plane/app/konvoyctl/pkg/output/table"
 	mesh_core "github.com/Kong/konvoy/components/konvoy-control-plane/pkg/core/resources/apis/mesh"
 	rest_types "github.com/Kong/konvoy/components/konvoy-control-plane/pkg/core/resources/model/rest"
+	core_store "github.com/Kong/konvoy/components/konvoy-control-plane/pkg/core/resources/store"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
@@ -31,7 +32,7 @@ func newGetDataplanesCmd(pctx *getContext) *cobra.Command {
 			}
 
 			dataplaneStatuses := &mesh_core.DataplaneStatusResourceList{}
-			if err := rs.List(context.Background(), dataplaneStatuses); err != nil {
+			if err := rs.List(context.Background(), dataplaneStatuses, core_store.ListByMesh(pctx.CurrentMesh())); err != nil {
 				return errors.Wrapf(err, "Failed to list Dataplanes")
 			}
 

--- a/components/konvoy-control-plane/app/konvoyctl/cmd/get_dataplanes_test.go
+++ b/components/konvoy-control-plane/app/konvoyctl/cmd/get_dataplanes_test.go
@@ -39,7 +39,7 @@ var _ = Describe("konvoy get dataplanes", func() {
 		sampleDataplaneStatuses = []*mesh_core.DataplaneStatusResource{
 			{
 				Meta: &test_model.ResourceMeta{
-					Mesh:      "pilot",
+					Mesh:      "default",
 					Namespace: "trial",
 					Name:      "experiment",
 				},
@@ -93,6 +93,21 @@ var _ = Describe("konvoy get dataplanes", func() {
 					},
 				},
 			},
+			{
+				Meta: &test_model.ResourceMeta{
+					Mesh:      "pilot",
+					Namespace: "default",
+					Name:      "simple",
+				},
+				Spec: mesh_proto.DataplaneStatus{
+					Subscriptions: []*mesh_proto.DiscoverySubscription{
+						{
+							Id:                     "1",
+							ControlPlaneInstanceId: "node-001",
+						},
+					},
+				},
+			},
 		}
 	})
 
@@ -133,8 +148,9 @@ MESH   NAMESPACE   NAME   SUBSCRIPTIONS   LAST CONNECTED AGO   TOTAL UPDATES   T
 			// and
 			Expect(strings.TrimSpace(buf.String())).To(Equal(strings.TrimSpace(`
 MESH      NAMESPACE   NAME         SUBSCRIPTIONS   LAST CONNECTED AGO   TOTAL UPDATES   TOTAL ERRORS
-pilot     trial       experiment   2               2h3m4s               30              3
+default   trial       experiment   2               2h3m4s               30              3
 default   demo        example      3               never                0               0
+pilot     default     simple       1               never                0               0
 `)))
 		})
 	})

--- a/components/konvoy-control-plane/app/konvoyctl/cmd/root.go
+++ b/components/konvoy-control-plane/app/konvoyctl/cmd/root.go
@@ -18,6 +18,7 @@ var (
 
 type rootArgs struct {
 	configFile string
+	mesh       string
 	debug      bool
 }
 
@@ -46,6 +47,7 @@ func newRootCmd(root *rootContext) *cobra.Command {
 	}
 	// root flags
 	cmd.PersistentFlags().StringVar(&root.args.configFile, "config-file", "", "path to the configuration file to use")
+	cmd.PersistentFlags().StringVar(&root.args.mesh, "mesh", "", "mesh to use")
 	cmd.PersistentFlags().BoolVar(&root.args.debug, "debug", true, "enable debug-level logging")
 	// sub-commands
 	cmd.AddCommand(newConfigCmd(root))

--- a/components/konvoy-control-plane/app/konvoyctl/cmd/root_context.go
+++ b/components/konvoy-control-plane/app/konvoyctl/cmd/root_context.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/Kong/konvoy/components/konvoy-control-plane/app/konvoyctl/pkg/config"
 	config_proto "github.com/Kong/konvoy/components/konvoy-control-plane/pkg/config/app/konvoyctl/v1alpha1"
+	core_model "github.com/Kong/konvoy/components/konvoy-control-plane/pkg/core/resources/model"
 	core_store "github.com/Kong/konvoy/components/konvoy-control-plane/pkg/core/resources/store"
 	"github.com/pkg/errors"
 )
@@ -42,6 +43,13 @@ func (rc *rootContext) CurrentControlPlane() (*config_proto.ControlPlane, error)
 		return nil, errors.Errorf("Current context refers to a Control Plane that doesn't exist: %q", currentContext.ControlPlane)
 	}
 	return controlPlane, nil
+}
+
+func (rc *rootContext) CurrentMesh() string {
+	if rc.args.mesh != "" {
+		return rc.args.mesh
+	}
+	return core_model.DefaultMesh
 }
 
 func (rc *rootContext) Now() time.Time {

--- a/components/konvoy-control-plane/app/konvoyctl/cmd/testdata/get-dataplanes.golden.json
+++ b/components/konvoy-control-plane/app/konvoyctl/cmd/testdata/get-dataplanes.golden.json
@@ -1,7 +1,7 @@
 {
   "items": [
     {
-      "mesh": "pilot",
+      "mesh": "default",
       "name": "experiment",
       "subscriptions": [
         {

--- a/components/konvoy-control-plane/app/konvoyctl/cmd/testdata/get-dataplanes.golden.txt
+++ b/components/konvoy-control-plane/app/konvoyctl/cmd/testdata/get-dataplanes.golden.txt
@@ -1,3 +1,3 @@
 MESH      NAMESPACE   NAME         SUBSCRIPTIONS   LAST CONNECTED AGO   TOTAL UPDATES   TOTAL ERRORS
-pilot     trial       experiment   2               2h3m4s               30              3
+default   trial       experiment   2               2h3m4s               30              3
 default   demo        example      3               never                0               0

--- a/components/konvoy-control-plane/app/konvoyctl/cmd/testdata/get-dataplanes.golden.yaml
+++ b/components/konvoy-control-plane/app/konvoyctl/cmd/testdata/get-dataplanes.golden.yaml
@@ -1,5 +1,5 @@
 items:
-- mesh: pilot
+- mesh: default
   name: experiment
   subscriptions:
   - connectTime: "2018-07-17T16:05:36.995Z"

--- a/components/konvoy-control-plane/docs/cmd/konvoyctl/HELP.md
+++ b/components/konvoy-control-plane/docs/cmd/konvoyctl/HELP.md
@@ -15,6 +15,7 @@ Flags:
       --config-file string   path to the configuration file to use
       --debug                enable debug-level logging (default true)
   -h, --help                 help for konvoyctl
+      --mesh string          mesh to use
 
 Use "konvoyctl [command] --help" for more information about a command.
 ```
@@ -37,6 +38,7 @@ Flags:
 Global Flags:
       --config-file string   path to the configuration file to use
       --debug                enable debug-level logging (default true)
+      --mesh string          mesh to use
 
 Use "konvoyctl config [command] --help" for more information about a command.
 ```
@@ -55,6 +57,7 @@ Flags:
 Global Flags:
       --config-file string   path to the configuration file to use
       --debug                enable debug-level logging (default true)
+      --mesh string          mesh to use
 ```
 
 ### konvoyctl config control-planes
@@ -75,6 +78,7 @@ Flags:
 Global Flags:
       --config-file string   path to the configuration file to use
       --debug                enable debug-level logging (default true)
+      --mesh string          mesh to use
 
 Use "konvoyctl config control-planes [command] --help" for more information about a command.
 ```
@@ -93,6 +97,7 @@ Flags:
 Global Flags:
       --config-file string   path to the configuration file to use
       --debug                enable debug-level logging (default true)
+      --mesh string          mesh to use
 ```
 
 #### konvoyctl config control-planes add
@@ -113,6 +118,7 @@ Flags:
 Global Flags:
       --config-file string   path to the configuration file to use
       --debug                enable debug-level logging (default true)
+      --mesh string          mesh to use
 
 Use "konvoyctl config control-planes add [command] --help" for more information about a command.
 ```
@@ -131,6 +137,7 @@ Flags:
 Global Flags:
       --config-file string   path to the configuration file to use
       --debug                enable debug-level logging (default true)
+      --mesh string          mesh to use
       --name string          reference name for a Control Plane
 ```
 
@@ -152,6 +159,7 @@ Flags:
 Global Flags:
       --config-file string   path to the configuration file to use
       --debug                enable debug-level logging (default true)
+      --mesh string          mesh to use
 
 Use "konvoyctl get [command] --help" for more information about a command.
 ```
@@ -170,6 +178,7 @@ Flags:
 Global Flags:
       --config-file string   path to the configuration file to use
       --debug                enable debug-level logging (default true)
+      --mesh string          mesh to use
   -o, --output string        Output format: one of table|yaml|json (default "table")
 ```
 


### PR DESCRIPTION
changes:
* add `--mesh` option to `konvoyctl`
* limit output of `konvoyctl get dataplanes` to a single mesh