### PR TITLE
konvoyctl: change output of `konvoyctl get dataplanes`

### DIFF
--- a/components/konvoy-control-plane/api/internal/util/proto/types.go
+++ b/components/konvoy-control-plane/api/internal/util/proto/types.go
@@ -2,6 +2,7 @@ package proto
 
 import (
 	"time"
+
 	"github.com/gogo/protobuf/types"
 )
 

--- a/components/konvoy-control-plane/api/mesh/v1alpha1/dataplane_status_helpers.go
+++ b/components/konvoy-control-plane/api/mesh/v1alpha1/dataplane_status_helpers.go
@@ -7,6 +7,15 @@ import (
 	"github.com/gogo/protobuf/types"
 )
 
+func (ds *DataplaneStatus) IsOnline() bool {
+	for _, s := range ds.Subscriptions {
+		if s.ConnectTime != nil && s.DisconnectTime == nil {
+			return true
+		}
+	}
+	return false
+}
+
 func (ds *DataplaneStatus) GetSubscription(id string) (int, *DiscoverySubscription) {
 	for i, s := range ds.Subscriptions {
 		if s.Id == id {

--- a/components/konvoy-control-plane/app/konvoyctl/cmd/get_dataplanes_test.go
+++ b/components/konvoy-control-plane/app/konvoyctl/cmd/get_dataplanes_test.go
@@ -132,7 +132,7 @@ var _ = Describe("konvoy get dataplanes", func() {
 			Expect(err).ToNot(HaveOccurred())
 			// and
 			Expect(strings.TrimSpace(buf.String())).To(Equal(strings.TrimSpace(`
-MESH   NAMESPACE   NAME   SUBSCRIPTIONS   LAST CONNECTED AGO   TOTAL UPDATES   TOTAL ERRORS
+MESH   NAME   STATUS   LAST CONNECTED AGO   LAST UPDATED AGO   TOTAL UPDATES   TOTAL ERRORS
 `)))
 		})
 
@@ -147,10 +147,10 @@ MESH   NAMESPACE   NAME   SUBSCRIPTIONS   LAST CONNECTED AGO   TOTAL UPDATES   T
 			Expect(err).ToNot(HaveOccurred())
 			// and
 			Expect(strings.TrimSpace(buf.String())).To(Equal(strings.TrimSpace(`
-MESH      NAMESPACE   NAME         SUBSCRIPTIONS   LAST CONNECTED AGO   TOTAL UPDATES   TOTAL ERRORS
-default   trial       experiment   2               2h3m4s               30              3
-default   demo        example      3               never                0               0
-pilot     default     simple       1               never                0               0
+MESH      NAME         STATUS    LAST CONNECTED AGO   LAST UPDATED AGO   TOTAL UPDATES   TOTAL ERRORS
+default   experiment   Online    2h3m4s               never              30              3
+default   example      Offline   never                never              0               0
+pilot     simple       Offline   never                never              0               0
 `)))
 		})
 	})

--- a/components/konvoy-control-plane/app/konvoyctl/cmd/testdata/get-dataplanes.golden.txt
+++ b/components/konvoy-control-plane/app/konvoyctl/cmd/testdata/get-dataplanes.golden.txt
@@ -1,3 +1,3 @@
-MESH      NAMESPACE   NAME         SUBSCRIPTIONS   LAST CONNECTED AGO   TOTAL UPDATES   TOTAL ERRORS
-default   trial       experiment   2               2h3m4s               30              3
-default   demo        example      3               never                0               0
+MESH      NAME         STATUS    LAST CONNECTED AGO   LAST UPDATED AGO   TOTAL UPDATES   TOTAL ERRORS
+default   experiment   Online    2h3m4s               never              30              3
+default   example      Offline   never                never              0               0

--- a/components/konvoy-control-plane/pkg/util/proto/types.go
+++ b/components/konvoy-control-plane/pkg/util/proto/types.go
@@ -1,8 +1,9 @@
 package proto
 
 import (
-	"github.com/gogo/protobuf/types"
 	"time"
+
+	"github.com/gogo/protobuf/types"
 )
 
 func MustTimestampProto(t time.Time) *types.Timestamp {
@@ -11,4 +12,15 @@ func MustTimestampProto(t time.Time) *types.Timestamp {
 		panic(err.Error())
 	}
 	return ts
+}
+
+func MustTimestampFromProto(ts *types.Timestamp) *time.Time {
+	if ts == nil {
+		return nil
+	}
+	t, err := types.TimestampFromProto(ts)
+	if err != nil {
+		panic(err.Error())
+	}
+	return &t
 }


### PR DESCRIPTION
changes:
* per @subnetmarco request, the output of `konvoyctl get dataplanes` should look like

```
GET /dataplanes

[{
	"mesh": "default",
	"id": "web-1adj23",
	"status": "online",
	"version": 0.2,
	"last_connected_ago": 418731,
	"last_updated_ago": 123123,
	"total_updates": 30,
	"total_errors": 3
}]
```