### PR TITLE
control-plane: change information encoded into Dataplane inbound interface

### DIFF
--- a/components/konvoy-control-plane/api/mesh/v1alpha1/dataplane.pb.go
+++ b/components/konvoy-control-plane/api/mesh/v1alpha1/dataplane.pb.go
@@ -144,11 +144,9 @@ func (m *Dataplane_Networking) GetTransparentProxying() *Dataplane_Networking_Tr
 type Dataplane_Networking_Inbound struct {
 	// Interface describes networking rules for incoming traffic.
 	// The value is a string formatted as
-	// <WORKLOAD_IP_ADDRESS>:<SERVICE_PORT>:<WORKLOAD_PORT>, which means
-	// that dataplane must listen on <WORKLOAD_IP_ADDRESS>:<WORKLOAD_PORT>
-	// and must dispatch to 127.0.0.1:<WORKLOAD_PORT>;
-	// client applications should connect to
-	// <SERVICE_DNS_NAME>:<SERVICE_PORT>.
+	// <DATAPLANE_IP>:<DATAPLANE_PORT>:<WORKLOAD_PORT>, which means
+	// that dataplane must listen on <DATAPLANE_IP>:<DATAPLANE_PORT>
+	// and must dispatch to 127.0.0.1:<WORKLOAD_PORT>.
 	Interface string `protobuf:"bytes,1,opt,name=interface,proto3" json:"interface,omitempty"`
 	// Tags associated with an application this dataplane is deployed next to,
 	// e.g. service=web, version=1.0.

--- a/components/konvoy-control-plane/api/mesh/v1alpha1/dataplane.proto
+++ b/components/konvoy-control-plane/api/mesh/v1alpha1/dataplane.proto
@@ -20,11 +20,9 @@ message Dataplane {
 
       // Interface describes networking rules for incoming traffic.
       // The value is a string formatted as
-      // <WORKLOAD_IP_ADDRESS>:<SERVICE_PORT>:<WORKLOAD_PORT>, which means
-      // that dataplane must listen on <WORKLOAD_IP_ADDRESS>:<WORKLOAD_PORT>
-      // and must dispatch to 127.0.0.1:<WORKLOAD_PORT>;
-      // client applications should connect to
-      // <SERVICE_DNS_NAME>:<SERVICE_PORT>.
+      // <DATAPLANE_IP>:<DATAPLANE_PORT>:<WORKLOAD_PORT>, which means
+      // that dataplane must listen on <DATAPLANE_IP>:<DATAPLANE_PORT>
+      // and must dispatch to 127.0.0.1:<WORKLOAD_PORT>.
       string interface = 1 [ (validate.rules).string.min_len = 2 ];
 
       // Tags associated with an application this dataplane is deployed next to,

--- a/components/konvoy-control-plane/api/mesh/v1alpha1/dataplane_helpers.go
+++ b/components/konvoy-control-plane/api/mesh/v1alpha1/dataplane_helpers.go
@@ -14,20 +14,20 @@ const (
 )
 
 type InboundInterface struct {
-	WorkloadAddress string
-	WorkloadPort    uint32
-	ServicePort     uint32
+	DataplaneIP   string
+	DataplanePort uint32
+	WorkloadPort  uint32
 }
 
 func (i InboundInterface) String() string {
 	return strings.Join([]string{
-		i.WorkloadAddress,
-		strconv.FormatUint(uint64(i.ServicePort), 10),
+		i.DataplaneIP,
+		strconv.FormatUint(uint64(i.DataplanePort), 10),
 		strconv.FormatUint(uint64(i.WorkloadPort), 10),
 	}, ":")
 }
 
-const inboundInterfacePattern = `^(?P<workload_ip>(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)):(?P<service_port>[0-9]{1,5}):(?P<workload_port>[0-9]{1,5})$`
+const inboundInterfacePattern = `^(?P<dataplane_ip>(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)):(?P<dataplane_port>[0-9]{1,5}):(?P<workload_port>[0-9]{1,5})$`
 
 var inboundInterfaceRegexp = regexp.MustCompile(inboundInterfacePattern)
 
@@ -36,22 +36,22 @@ func ParseInboundInterface(text string) (InboundInterface, error) {
 	if groups == nil {
 		return InboundInterface{}, errors.Errorf("invalid format: expected %s, got %q", inboundInterfacePattern, text)
 	}
-	workloadAddress, err := ParseIP(groups[1])
+	dataplaneIP, err := ParseIP(groups[1])
 	if err != nil {
-		return InboundInterface{}, errors.Wrapf(err, "invalid <WORKLOAD_IP> in %q", text)
+		return InboundInterface{}, errors.Wrapf(err, "invalid <DATAPLANE_IP> in %q", text)
 	}
-	servicePort, err := ParsePort(groups[2])
+	dataplanePort, err := ParsePort(groups[2])
 	if err != nil {
-		return InboundInterface{}, errors.Wrapf(err, "invalid <SERVICE_PORT> in %q", text)
+		return InboundInterface{}, errors.Wrapf(err, "invalid <DATAPLANE_PORT> in %q", text)
 	}
 	workloadPort, err := ParsePort(groups[3])
 	if err != nil {
 		return InboundInterface{}, errors.Wrapf(err, "invalid <WORKLOAD_PORT> in %q", text)
 	}
 	return InboundInterface{
-		WorkloadAddress: workloadAddress,
-		WorkloadPort:    workloadPort,
-		ServicePort:     servicePort,
+		DataplaneIP:   dataplaneIP,
+		DataplanePort: dataplanePort,
+		WorkloadPort:  workloadPort,
 	}, nil
 }
 

--- a/components/konvoy-control-plane/api/mesh/v1alpha1/dataplane_helpers_test.go
+++ b/components/konvoy-control-plane/api/mesh/v1alpha1/dataplane_helpers_test.go
@@ -23,9 +23,9 @@ var _ = Describe("InboundInterface", func() {
 			},
 			Entry("all fields set", testCase{
 				iface: InboundInterface{
-					WorkloadAddress: "1.2.3.4",
-					WorkloadPort:    8080,
-					ServicePort:     80,
+					DataplaneIP:   "1.2.3.4",
+					DataplanePort: 80,
+					WorkloadPort:  8080,
 				},
 				expected: "1.2.3.4:80:8080",
 			}),
@@ -53,9 +53,9 @@ var _ = Describe("ParseInboundInterface(..)", func() {
 			Entry("all fields set", testCase{
 				input: "1.2.3.4:80:8080",
 				expected: InboundInterface{
-					WorkloadAddress: "1.2.3.4",
-					WorkloadPort:    8080,
-					ServicePort:     80,
+					DataplaneIP:   "1.2.3.4",
+					DataplanePort: 80,
+					WorkloadPort:  8080,
 				},
 			}),
 		)
@@ -90,7 +90,7 @@ var _ = Describe("ParseInboundInterface(..)", func() {
 			}),
 			Entry("service port is out of range", testCase{
 				input:       "1.2.3.4:0:8080",
-				expectedErr: Equal(`invalid <SERVICE_PORT> in "1.2.3.4:0:8080": port number must be in the range [1, 65535] but got 0`),
+				expectedErr: Equal(`invalid <DATAPLANE_PORT> in "1.2.3.4:0:8080": port number must be in the range [1, 65535] but got 0`),
 			}),
 			Entry("application port is missing", testCase{
 				input:       "1.2.3.4:80:",
@@ -139,8 +139,8 @@ var _ = Describe("Dataplane_Networking", func() {
 						},
 					},
 					expected: []InboundInterface{
-						{WorkloadAddress: "192.168.0.1", ServicePort: 80, WorkloadPort: 8080},
-						{WorkloadAddress: "192.168.0.1", ServicePort: 443, WorkloadPort: 8443},
+						{DataplaneIP: "192.168.0.1", DataplanePort: 80, WorkloadPort: 8080},
+						{DataplaneIP: "192.168.0.1", DataplanePort: 443, WorkloadPort: 8443},
 					},
 				}),
 			)
@@ -149,7 +149,7 @@ var _ = Describe("Dataplane_Networking", func() {
 		Context("invalid input values", func() {
 			type testCase struct {
 				input       *Dataplane_Networking
-				expectedErr string
+				expectedErr gomega_types.GomegaMatcher
 			}
 
 			DescribeTable("should fail on invalid input values",
@@ -159,7 +159,7 @@ var _ = Describe("Dataplane_Networking", func() {
 					// then
 					Expect(ifaces).To(BeNil())
 					// and
-					Expect(err).To(MatchError(given.expectedErr))
+					Expect(err.Error()).To(given.expectedErr)
 				},
 				Entry("dataplane IP address is missing", testCase{
 					input: &Dataplane_Networking{
@@ -168,7 +168,7 @@ var _ = Describe("Dataplane_Networking", func() {
 							{Interface: ":443:8443"},
 						},
 					},
-					expectedErr: `invalid format: expected ^(?P<workload_ip>(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)):(?P<service_port>[0-9]{1,5}):(?P<workload_port>[0-9]{1,5})$, got ":443:8443"`,
+					expectedErr: MatchRegexp(`invalid format: expected .*, got ":443:8443"`),
 				}),
 			)
 		})

--- a/components/konvoy-control-plane/pkg/plugins/discovery/k8s/controllers/pod_controller_test.go
+++ b/components/konvoy-control-plane/pkg/plugins/discovery/k8s/controllers/pod_controller_test.go
@@ -243,14 +243,14 @@ var _ = Describe("PodReconciler", func() {
         spec:
           networking:
             inbound:
-            - interface: 192.168.0.1:80:8080
+            - interface: 192.168.0.1:8080:8080
               tags:
                 getkonvoy.io/mesh: pilot
-                service: example.demo.svc
-            - interface: 192.168.0.1:6061:6060
+                service: example.demo.svc:80
+            - interface: 192.168.0.1:6060:6060
               tags:
                 getkonvoy.io/mesh: pilot
-                service: example.demo.svc
+                service: example.demo.svc:6061
 `))
 	})
 
@@ -309,14 +309,14 @@ var _ = Describe("PodReconciler", func() {
         spec:
           networking:
             inbound:
-            - interface: 192.168.0.1:80:8080
+            - interface: 192.168.0.1:8080:8080
               tags:
                 getkonvoy.io/mesh: pilot
-                service: example.demo.svc
-            - interface: 192.168.0.1:6061:6060
+                service: example.demo.svc:80
+            - interface: 192.168.0.1:6060:6060
               tags:
                 getkonvoy.io/mesh: pilot
-                service: example.demo.svc
+                service: example.demo.svc:6061
 `))
 	})
 })

--- a/components/konvoy-control-plane/pkg/xds/generator/proxy_template.go
+++ b/components/konvoy-control-plane/pkg/xds/generator/proxy_template.go
@@ -124,12 +124,12 @@ func (_ InboundProxyGenerator) Generate(proxy *model.Proxy) ([]*Resource, error)
 			names[localClusterName] = true
 		}
 
-		inboundListenerName := fmt.Sprintf("inbound:%s:%d", endpoint.WorkloadAddress, endpoint.WorkloadPort)
+		inboundListenerName := fmt.Sprintf("inbound:%s:%d", endpoint.DataplaneIP, endpoint.DataplanePort)
 		if used := names[inboundListenerName]; !used {
 			resources = append(resources, &Resource{
 				Name:     inboundListenerName,
 				Version:  proxy.Dataplane.Meta.GetVersion(),
-				Resource: envoy.CreateInboundListener(inboundListenerName, endpoint.WorkloadAddress, endpoint.WorkloadPort, localClusterName, virtual),
+				Resource: envoy.CreateInboundListener(inboundListenerName, endpoint.DataplaneIP, endpoint.DataplanePort, localClusterName, virtual),
 			})
 			names[inboundListenerName] = true
 		}

--- a/components/konvoy-control-plane/pkg/xds/generator/proxy_template_test.go
+++ b/components/konvoy-control-plane/pkg/xds/generator/proxy_template_test.go
@@ -104,13 +104,13 @@ var _ = Describe("Generator", func() {
             name: localhost:8080
             type: STATIC
           version: v1
-        - name: inbound:192.168.0.1:8080
+        - name: inbound:192.168.0.1:80
           resource:
             '@type': type.googleapis.com/envoy.api.v2.Listener
             address:
               socketAddress:
                 address: 192.168.0.1
-                portValue: 8080
+                portValue: 80
             filterChains:
             - filters:
               - name: envoy.tcp_proxy
@@ -118,7 +118,7 @@ var _ = Describe("Generator", func() {
                   '@type': type.googleapis.com/envoy.config.filter.network.tcp_proxy.v2.TcpProxy
                   cluster: localhost:8080
                   statPrefix: localhost:8080
-            name: inbound:192.168.0.1:8080
+            name: inbound:192.168.0.1:80
           version: v1
 `,
 			}),
@@ -159,13 +159,13 @@ var _ = Describe("Generator", func() {
             name: localhost:8080
             type: STATIC
           version: v1
-        - name: inbound:192.168.0.1:8080
+        - name: inbound:192.168.0.1:80
           resource:
             '@type': type.googleapis.com/envoy.api.v2.Listener
             address:
               socketAddress:
                 address: 192.168.0.1
-                portValue: 8080
+                portValue: 80
             deprecatedV1:
               bindToPort: false
             filterChains:
@@ -175,7 +175,7 @@ var _ = Describe("Generator", func() {
                   '@type': type.googleapis.com/envoy.config.filter.network.tcp_proxy.v2.TcpProxy
                   cluster: localhost:8080
                   statPrefix: localhost:8080
-            name: inbound:192.168.0.1:8080
+            name: inbound:192.168.0.1:80
           version: v1
 `,
 			}),
@@ -214,13 +214,13 @@ var _ = Describe("Generator", func() {
               name: localhost:8080
               type: STATIC
             version: v1
-          - name: inbound:192.168.0.1:8080
+          - name: inbound:192.168.0.1:80
             resource:
               '@type': type.googleapis.com/envoy.api.v2.Listener
               address:
                 socketAddress:
                   address: 192.168.0.1
-                  portValue: 8080
+                  portValue: 80
               filterChains:
               - filters:
                 - name: envoy.tcp_proxy
@@ -228,7 +228,7 @@ var _ = Describe("Generator", func() {
                     '@type': type.googleapis.com/envoy.config.filter.network.tcp_proxy.v2.TcpProxy
                     cluster: localhost:8080
                     statPrefix: localhost:8080
-              name: inbound:192.168.0.1:8080
+              name: inbound:192.168.0.1:80
             version: v1
           - name: localhost:8443
             resource:
@@ -246,13 +246,13 @@ var _ = Describe("Generator", func() {
               name: localhost:8443
               type: STATIC
             version: v1
-          - name: inbound:192.168.0.1:8443
+          - name: inbound:192.168.0.1:443
             resource:
               '@type': type.googleapis.com/envoy.api.v2.Listener
               address:
                 socketAddress:
                   address: 192.168.0.1
-                  portValue: 8443
+                  portValue: 443
               filterChains:
               - filters:
                 - name: envoy.tcp_proxy
@@ -260,7 +260,7 @@ var _ = Describe("Generator", func() {
                     '@type': type.googleapis.com/envoy.config.filter.network.tcp_proxy.v2.TcpProxy
                     cluster: localhost:8443
                     statPrefix: localhost:8443
-              name: inbound:192.168.0.1:8443
+              name: inbound:192.168.0.1:443
             version: v1
 `,
 			}),
@@ -302,13 +302,13 @@ var _ = Describe("Generator", func() {
               name: localhost:8080
               type: STATIC
             version: v1
-          - name: inbound:192.168.0.1:8080
+          - name: inbound:192.168.0.1:80
             resource:
               '@type': type.googleapis.com/envoy.api.v2.Listener
               address:
                 socketAddress:
                   address: 192.168.0.1
-                  portValue: 8080
+                  portValue: 80
               deprecatedV1:
                 bindToPort: false
               filterChains:
@@ -318,7 +318,7 @@ var _ = Describe("Generator", func() {
                     '@type': type.googleapis.com/envoy.config.filter.network.tcp_proxy.v2.TcpProxy
                     cluster: localhost:8080
                     statPrefix: localhost:8080
-              name: inbound:192.168.0.1:8080
+              name: inbound:192.168.0.1:80
             version: v1
           - name: localhost:8443
             resource:
@@ -336,13 +336,13 @@ var _ = Describe("Generator", func() {
               name: localhost:8443
               type: STATIC
             version: v1
-          - name: inbound:192.168.0.1:8443
+          - name: inbound:192.168.0.1:443
             resource:
               '@type': type.googleapis.com/envoy.api.v2.Listener
               address:
                 socketAddress:
                   address: 192.168.0.1
-                  portValue: 8443
+                  portValue: 443
               deprecatedV1:
                 bindToPort: false
               filterChains:
@@ -352,7 +352,7 @@ var _ = Describe("Generator", func() {
                     '@type': type.googleapis.com/envoy.config.filter.network.tcp_proxy.v2.TcpProxy
                     cluster: localhost:8443
                     statPrefix: localhost:8443
-              name: inbound:192.168.0.1:8443
+              name: inbound:192.168.0.1:443
             version: v1
 `,
 			}),
@@ -393,13 +393,13 @@ var _ = Describe("Generator", func() {
             name: localhost:8080
             type: STATIC
           version: v1
-        - name: inbound:192.168.0.1:8080
+        - name: inbound:192.168.0.1:80
           resource:
             '@type': type.googleapis.com/envoy.api.v2.Listener
             address:
               socketAddress:
                 address: 192.168.0.1
-                portValue: 8080
+                portValue: 80
             filterChains:
             - filters:
               - name: envoy.tcp_proxy
@@ -407,15 +407,15 @@ var _ = Describe("Generator", func() {
                   '@type': type.googleapis.com/envoy.config.filter.network.tcp_proxy.v2.TcpProxy
                   cluster: localhost:8080
                   statPrefix: localhost:8080
-            name: inbound:192.168.0.1:8080
+            name: inbound:192.168.0.1:80
           version: v1
-        - name: inbound:192.168.0.2:8080
+        - name: inbound:192.168.0.2:80
           resource:
             '@type': type.googleapis.com/envoy.api.v2.Listener
             address:
               socketAddress:
                 address: 192.168.0.2
-                portValue: 8080
+                portValue: 80
             filterChains:
             - filters:
               - name: envoy.tcp_proxy
@@ -423,7 +423,7 @@ var _ = Describe("Generator", func() {
                   '@type': type.googleapis.com/envoy.config.filter.network.tcp_proxy.v2.TcpProxy
                   cluster: localhost:8080
                   statPrefix: localhost:8080
-            name: inbound:192.168.0.2:8080
+            name: inbound:192.168.0.2:80
           version: v1
         - name: localhost:8443
           resource:
@@ -441,13 +441,13 @@ var _ = Describe("Generator", func() {
             name: localhost:8443
             type: STATIC
           version: v1
-        - name: inbound:192.168.0.1:8443
+        - name: inbound:192.168.0.1:443
           resource:
             '@type': type.googleapis.com/envoy.api.v2.Listener
             address:
               socketAddress:
                 address: 192.168.0.1
-                portValue: 8443
+                portValue: 443
             filterChains:
             - filters:
               - name: envoy.tcp_proxy
@@ -455,15 +455,15 @@ var _ = Describe("Generator", func() {
                   '@type': type.googleapis.com/envoy.config.filter.network.tcp_proxy.v2.TcpProxy
                   cluster: localhost:8443
                   statPrefix: localhost:8443
-            name: inbound:192.168.0.1:8443
+            name: inbound:192.168.0.1:443
           version: v1
-        - name: inbound:192.168.0.2:8443
+        - name: inbound:192.168.0.2:443
           resource:
             '@type': type.googleapis.com/envoy.api.v2.Listener
             address:
               socketAddress:
                 address: 192.168.0.2
-                portValue: 8443
+                portValue: 443
             filterChains:
             - filters:
               - name: envoy.tcp_proxy
@@ -471,7 +471,7 @@ var _ = Describe("Generator", func() {
                   '@type': type.googleapis.com/envoy.config.filter.network.tcp_proxy.v2.TcpProxy
                   cluster: localhost:8443
                   statPrefix: localhost:8443
-            name: inbound:192.168.0.2:8443
+            name: inbound:192.168.0.2:443
           version: v1
 `,
 			}),
@@ -515,13 +515,13 @@ var _ = Describe("Generator", func() {
             name: localhost:8080
             type: STATIC
           version: v1
-        - name: inbound:192.168.0.1:8080
+        - name: inbound:192.168.0.1:80
           resource:
             '@type': type.googleapis.com/envoy.api.v2.Listener
             address:
               socketAddress:
                 address: 192.168.0.1
-                portValue: 8080
+                portValue: 80
             deprecatedV1:
               bindToPort: false
             filterChains:
@@ -531,15 +531,15 @@ var _ = Describe("Generator", func() {
                   '@type': type.googleapis.com/envoy.config.filter.network.tcp_proxy.v2.TcpProxy
                   cluster: localhost:8080
                   statPrefix: localhost:8080
-            name: inbound:192.168.0.1:8080
+            name: inbound:192.168.0.1:80
           version: v1
-        - name: inbound:192.168.0.2:8080
+        - name: inbound:192.168.0.2:80
           resource:
             '@type': type.googleapis.com/envoy.api.v2.Listener
             address:
               socketAddress:
                 address: 192.168.0.2
-                portValue: 8080
+                portValue: 80
             deprecatedV1:
               bindToPort: false
             filterChains:
@@ -549,7 +549,7 @@ var _ = Describe("Generator", func() {
                   '@type': type.googleapis.com/envoy.config.filter.network.tcp_proxy.v2.TcpProxy
                   cluster: localhost:8080
                   statPrefix: localhost:8080
-            name: inbound:192.168.0.2:8080
+            name: inbound:192.168.0.2:80
           version: v1
         - name: localhost:8443
           resource:
@@ -567,13 +567,13 @@ var _ = Describe("Generator", func() {
             name: localhost:8443
             type: STATIC
           version: v1
-        - name: inbound:192.168.0.1:8443
+        - name: inbound:192.168.0.1:443
           resource:
             '@type': type.googleapis.com/envoy.api.v2.Listener
             address:
               socketAddress:
                 address: 192.168.0.1
-                portValue: 8443
+                portValue: 443
             deprecatedV1:
               bindToPort: false
             filterChains:
@@ -583,15 +583,15 @@ var _ = Describe("Generator", func() {
                   '@type': type.googleapis.com/envoy.config.filter.network.tcp_proxy.v2.TcpProxy
                   cluster: localhost:8443
                   statPrefix: localhost:8443
-            name: inbound:192.168.0.1:8443
+            name: inbound:192.168.0.1:443
           version: v1
-        - name: inbound:192.168.0.2:8443
+        - name: inbound:192.168.0.2:443
           resource:
             '@type': type.googleapis.com/envoy.api.v2.Listener
             address:
               socketAddress:
                 address: 192.168.0.2
-                portValue: 8443
+                portValue: 443
             deprecatedV1:
               bindToPort: false
             filterChains:
@@ -601,7 +601,7 @@ var _ = Describe("Generator", func() {
                   '@type': type.googleapis.com/envoy.config.filter.network.tcp_proxy.v2.TcpProxy
                   cluster: localhost:8443
                   statPrefix: localhost:8443
-            name: inbound:192.168.0.2:8443
+            name: inbound:192.168.0.2:443
           version: v1
 `,
 			}),
@@ -759,13 +759,13 @@ var _ = Describe("Generator", func() {
             name: localhost:8080
             type: STATIC
           version: v1
-        - name: inbound:192.168.0.1:8080
+        - name: inbound:192.168.0.1:80
           resource:
             '@type': type.googleapis.com/envoy.api.v2.Listener
             address:
               socketAddress:
                 address: 192.168.0.1
-                portValue: 8080
+                portValue: 80
             filterChains:
             - filters:
               - name: envoy.tcp_proxy
@@ -773,7 +773,7 @@ var _ = Describe("Generator", func() {
                   '@type': type.googleapis.com/envoy.config.filter.network.tcp_proxy.v2.TcpProxy
                   cluster: localhost:8080
                   statPrefix: localhost:8080
-            name: inbound:192.168.0.1:8080
+            name: inbound:192.168.0.1:80
           version: v1
 `,
 			}),
@@ -842,13 +842,13 @@ var _ = Describe("Generator", func() {
             name: localhost:8080
             type: STATIC
           version: v1
-        - name: inbound:192.168.0.1:8080
+        - name: inbound:192.168.0.1:80
           resource:
             '@type': type.googleapis.com/envoy.api.v2.Listener
             address:
               socketAddress:
                 address: 192.168.0.1
-                portValue: 8080
+                portValue: 80
             deprecatedV1:
               bindToPort: false
             filterChains:
@@ -858,7 +858,7 @@ var _ = Describe("Generator", func() {
                   '@type': type.googleapis.com/envoy.config.filter.network.tcp_proxy.v2.TcpProxy
                   cluster: localhost:8080
                   statPrefix: localhost:8080
-            name: inbound:192.168.0.1:8080
+            name: inbound:192.168.0.1:80
           version: v1
 `,
 			}),
@@ -1479,13 +1479,13 @@ var _ = Describe("Generator", func() {
               name: localhost:8080
               type: STATIC
             version: v1
-          - name: inbound:192.168.0.1:8080
+          - name: inbound:192.168.0.1:80
             resource:
               '@type': type.googleapis.com/envoy.api.v2.Listener
               address:
                 socketAddress:
                   address: 192.168.0.1
-                  portValue: 8080
+                  portValue: 80
               deprecatedV1:
                 bindToPort: false
               filterChains:
@@ -1495,7 +1495,7 @@ var _ = Describe("Generator", func() {
                     '@type': type.googleapis.com/envoy.config.filter.network.tcp_proxy.v2.TcpProxy
                     cluster: localhost:8080
                     statPrefix: localhost:8080
-              name: inbound:192.168.0.1:8080
+              name: inbound:192.168.0.1:80
             version: v1
           - name: raw-name
             resource:

--- a/components/konvoy-control-plane/pkg/xds/server/snapshot_generator_test.go
+++ b/components/konvoy-control-plane/pkg/xds/server/snapshot_generator_test.go
@@ -136,13 +136,13 @@ var _ = Describe("Reconcile", func() {
             name: localhost:8080
             type: STATIC
           version: "3"
-        - name: inbound:192.168.0.1:8080
+        - name: inbound:192.168.0.1:80
           resource:
             '@type': type.googleapis.com/envoy.api.v2.Listener
             address:
               socketAddress:
                 address: 192.168.0.1
-                portValue: 8080
+                portValue: 80
             filterChains:
             - filters:
               - name: envoy.tcp_proxy
@@ -150,7 +150,7 @@ var _ = Describe("Reconcile", func() {
                   '@type': type.googleapis.com/envoy.config.filter.network.tcp_proxy.v2.TcpProxy
                   cluster: localhost:8080
                   statPrefix: localhost:8080
-            name: inbound:192.168.0.1:8080
+            name: inbound:192.168.0.1:80
           version: "3"
 `,
 			}),
@@ -216,13 +216,13 @@ var _ = Describe("Reconcile", func() {
             name: catch_all
             useOriginalDst: true
           version: "3"
-        - name: inbound:192.168.0.1:8080
+        - name: inbound:192.168.0.1:80
           resource:
             '@type': type.googleapis.com/envoy.api.v2.Listener
             address:
               socketAddress:
                 address: 192.168.0.1
-                portValue: 8080
+                portValue: 80
             deprecatedV1:
               bindToPort: false
             filterChains:
@@ -232,7 +232,7 @@ var _ = Describe("Reconcile", func() {
                   '@type': type.googleapis.com/envoy.config.filter.network.tcp_proxy.v2.TcpProxy
                   cluster: localhost:8080
                   statPrefix: localhost:8080
-            name: inbound:192.168.0.1:8080
+            name: inbound:192.168.0.1:80
           version: "3"
 `,
 			}),
@@ -287,29 +287,13 @@ var _ = Describe("Reconcile", func() {
             name: localhost:8443
             type: STATIC
           version: "4"
-        - name: inbound:192.168.0.1:8080
+        - name: inbound:192.168.0.1:443
           resource:
             '@type': type.googleapis.com/envoy.api.v2.Listener
             address:
               socketAddress:
                 address: 192.168.0.1
-                portValue: 8080
-            filterChains:
-            - filters:
-              - name: envoy.tcp_proxy
-                typedConfig:
-                  '@type': type.googleapis.com/envoy.config.filter.network.tcp_proxy.v2.TcpProxy
-                  cluster: localhost:8080
-                  statPrefix: localhost:8080
-            name: inbound:192.168.0.1:8080
-          version: "4"
-        - name: inbound:192.168.0.1:8443
-          resource:
-            '@type': type.googleapis.com/envoy.api.v2.Listener
-            address:
-              socketAddress:
-                address: 192.168.0.1
-                portValue: 8443
+                portValue: 443
             filterChains:
             - filters:
               - name: envoy.tcp_proxy
@@ -317,7 +301,23 @@ var _ = Describe("Reconcile", func() {
                   '@type': type.googleapis.com/envoy.config.filter.network.tcp_proxy.v2.TcpProxy
                   cluster: localhost:8443
                   statPrefix: localhost:8443
-            name: inbound:192.168.0.1:8443
+            name: inbound:192.168.0.1:443
+          version: "4"
+        - name: inbound:192.168.0.1:80
+          resource:
+            '@type': type.googleapis.com/envoy.api.v2.Listener
+            address:
+              socketAddress:
+                address: 192.168.0.1
+                portValue: 80
+            filterChains:
+            - filters:
+              - name: envoy.tcp_proxy
+                typedConfig:
+                  '@type': type.googleapis.com/envoy.config.filter.network.tcp_proxy.v2.TcpProxy
+                  cluster: localhost:8080
+                  statPrefix: localhost:8080
+            name: inbound:192.168.0.1:80
           version: "4"
 `,
 			}),
@@ -400,31 +400,13 @@ var _ = Describe("Reconcile", func() {
             name: catch_all
             useOriginalDst: true
           version: "4"
-        - name: inbound:192.168.0.1:8080
+        - name: inbound:192.168.0.1:443
           resource:
             '@type': type.googleapis.com/envoy.api.v2.Listener
             address:
               socketAddress:
                 address: 192.168.0.1
-                portValue: 8080
-            deprecatedV1:
-              bindToPort: false
-            filterChains:
-            - filters:
-              - name: envoy.tcp_proxy
-                typedConfig:
-                  '@type': type.googleapis.com/envoy.config.filter.network.tcp_proxy.v2.TcpProxy
-                  cluster: localhost:8080
-                  statPrefix: localhost:8080
-            name: inbound:192.168.0.1:8080
-          version: "4"
-        - name: inbound:192.168.0.1:8443
-          resource:
-            '@type': type.googleapis.com/envoy.api.v2.Listener
-            address:
-              socketAddress:
-                address: 192.168.0.1
-                portValue: 8443
+                portValue: 443
             deprecatedV1:
               bindToPort: false
             filterChains:
@@ -434,7 +416,25 @@ var _ = Describe("Reconcile", func() {
                   '@type': type.googleapis.com/envoy.config.filter.network.tcp_proxy.v2.TcpProxy
                   cluster: localhost:8443
                   statPrefix: localhost:8443
-            name: inbound:192.168.0.1:8443
+            name: inbound:192.168.0.1:443
+          version: "4"
+        - name: inbound:192.168.0.1:80
+          resource:
+            '@type': type.googleapis.com/envoy.api.v2.Listener
+            address:
+              socketAddress:
+                address: 192.168.0.1
+                portValue: 80
+            deprecatedV1:
+              bindToPort: false
+            filterChains:
+            - filters:
+              - name: envoy.tcp_proxy
+                typedConfig:
+                  '@type': type.googleapis.com/envoy.config.filter.network.tcp_proxy.v2.TcpProxy
+                  cluster: localhost:8080
+                  statPrefix: localhost:8080
+            name: inbound:192.168.0.1:80
           version: "4"
 `,
 			}),
@@ -491,29 +491,13 @@ var _ = Describe("Reconcile", func() {
             name: localhost:8443
             type: STATIC
           version: "5"
-        - name: inbound:192.168.0.1:8080
+        - name: inbound:192.168.0.1:443
           resource:
             '@type': type.googleapis.com/envoy.api.v2.Listener
             address:
               socketAddress:
                 address: 192.168.0.1
-                portValue: 8080
-            filterChains:
-            - filters:
-              - name: envoy.tcp_proxy
-                typedConfig:
-                  '@type': type.googleapis.com/envoy.config.filter.network.tcp_proxy.v2.TcpProxy
-                  cluster: localhost:8080
-                  statPrefix: localhost:8080
-            name: inbound:192.168.0.1:8080
-          version: "5"
-        - name: inbound:192.168.0.1:8443
-          resource:
-            '@type': type.googleapis.com/envoy.api.v2.Listener
-            address:
-              socketAddress:
-                address: 192.168.0.1
-                portValue: 8443
+                portValue: 443
             filterChains:
             - filters:
               - name: envoy.tcp_proxy
@@ -521,15 +505,15 @@ var _ = Describe("Reconcile", func() {
                   '@type': type.googleapis.com/envoy.config.filter.network.tcp_proxy.v2.TcpProxy
                   cluster: localhost:8443
                   statPrefix: localhost:8443
-            name: inbound:192.168.0.1:8443
+            name: inbound:192.168.0.1:443
           version: "5"
-        - name: inbound:192.168.0.2:8080
+        - name: inbound:192.168.0.1:80
           resource:
             '@type': type.googleapis.com/envoy.api.v2.Listener
             address:
               socketAddress:
-                address: 192.168.0.2
-                portValue: 8080
+                address: 192.168.0.1
+                portValue: 80
             filterChains:
             - filters:
               - name: envoy.tcp_proxy
@@ -537,15 +521,15 @@ var _ = Describe("Reconcile", func() {
                   '@type': type.googleapis.com/envoy.config.filter.network.tcp_proxy.v2.TcpProxy
                   cluster: localhost:8080
                   statPrefix: localhost:8080
-            name: inbound:192.168.0.2:8080
+            name: inbound:192.168.0.1:80
           version: "5"
-        - name: inbound:192.168.0.2:8443
+        - name: inbound:192.168.0.2:443
           resource:
             '@type': type.googleapis.com/envoy.api.v2.Listener
             address:
               socketAddress:
                 address: 192.168.0.2
-                portValue: 8443
+                portValue: 443
             filterChains:
             - filters:
               - name: envoy.tcp_proxy
@@ -553,7 +537,23 @@ var _ = Describe("Reconcile", func() {
                   '@type': type.googleapis.com/envoy.config.filter.network.tcp_proxy.v2.TcpProxy
                   cluster: localhost:8443
                   statPrefix: localhost:8443
-            name: inbound:192.168.0.2:8443
+            name: inbound:192.168.0.2:443
+          version: "5"
+        - name: inbound:192.168.0.2:80
+          resource:
+            '@type': type.googleapis.com/envoy.api.v2.Listener
+            address:
+              socketAddress:
+                address: 192.168.0.2
+                portValue: 80
+            filterChains:
+            - filters:
+              - name: envoy.tcp_proxy
+                typedConfig:
+                  '@type': type.googleapis.com/envoy.config.filter.network.tcp_proxy.v2.TcpProxy
+                  cluster: localhost:8080
+                  statPrefix: localhost:8080
+            name: inbound:192.168.0.2:80
           version: "5"
 `,
 			}),
@@ -638,31 +638,13 @@ var _ = Describe("Reconcile", func() {
             name: catch_all
             useOriginalDst: true
           version: "5"
-        - name: inbound:192.168.0.1:8080
+        - name: inbound:192.168.0.1:443
           resource:
             '@type': type.googleapis.com/envoy.api.v2.Listener
             address:
               socketAddress:
                 address: 192.168.0.1
-                portValue: 8080
-            deprecatedV1:
-              bindToPort: false
-            filterChains:
-            - filters:
-              - name: envoy.tcp_proxy
-                typedConfig:
-                  '@type': type.googleapis.com/envoy.config.filter.network.tcp_proxy.v2.TcpProxy
-                  cluster: localhost:8080
-                  statPrefix: localhost:8080
-            name: inbound:192.168.0.1:8080
-          version: "5"
-        - name: inbound:192.168.0.1:8443
-          resource:
-            '@type': type.googleapis.com/envoy.api.v2.Listener
-            address:
-              socketAddress:
-                address: 192.168.0.1
-                portValue: 8443
+                portValue: 443
             deprecatedV1:
               bindToPort: false
             filterChains:
@@ -672,15 +654,15 @@ var _ = Describe("Reconcile", func() {
                   '@type': type.googleapis.com/envoy.config.filter.network.tcp_proxy.v2.TcpProxy
                   cluster: localhost:8443
                   statPrefix: localhost:8443
-            name: inbound:192.168.0.1:8443
+            name: inbound:192.168.0.1:443
           version: "5"
-        - name: inbound:192.168.0.2:8080
+        - name: inbound:192.168.0.1:80
           resource:
             '@type': type.googleapis.com/envoy.api.v2.Listener
             address:
               socketAddress:
-                address: 192.168.0.2
-                portValue: 8080
+                address: 192.168.0.1
+                portValue: 80
             deprecatedV1:
               bindToPort: false
             filterChains:
@@ -690,15 +672,15 @@ var _ = Describe("Reconcile", func() {
                   '@type': type.googleapis.com/envoy.config.filter.network.tcp_proxy.v2.TcpProxy
                   cluster: localhost:8080
                   statPrefix: localhost:8080
-            name: inbound:192.168.0.2:8080
+            name: inbound:192.168.0.1:80
           version: "5"
-        - name: inbound:192.168.0.2:8443
+        - name: inbound:192.168.0.2:443
           resource:
             '@type': type.googleapis.com/envoy.api.v2.Listener
             address:
               socketAddress:
                 address: 192.168.0.2
-                portValue: 8443
+                portValue: 443
             deprecatedV1:
               bindToPort: false
             filterChains:
@@ -708,7 +690,25 @@ var _ = Describe("Reconcile", func() {
                   '@type': type.googleapis.com/envoy.config.filter.network.tcp_proxy.v2.TcpProxy
                   cluster: localhost:8443
                   statPrefix: localhost:8443
-            name: inbound:192.168.0.2:8443
+            name: inbound:192.168.0.2:443
+          version: "5"
+        - name: inbound:192.168.0.2:80
+          resource:
+            '@type': type.googleapis.com/envoy.api.v2.Listener
+            address:
+              socketAddress:
+                address: 192.168.0.2
+                portValue: 80
+            deprecatedV1:
+              bindToPort: false
+            filterChains:
+            - filters:
+              - name: envoy.tcp_proxy
+                typedConfig:
+                  '@type': type.googleapis.com/envoy.config.filter.network.tcp_proxy.v2.TcpProxy
+                  cluster: localhost:8080
+                  statPrefix: localhost:8080
+            name: inbound:192.168.0.2:80
           version: "5"
 `,
 			}),


### PR DESCRIPTION
changes:
* in the original implementation, value of `Dataplane` Inbound interface, i.e. `192.168.0.1:80:8080`, was interpreted as `<DATAPLANE_IP>:<SERVICE_PORT>:<WORKLOAD_PORT>`, which works fine on `k8s`
* however, in oder to support `universal` environment, it should be possible to define unequal `WORKLOAD_PORT` and `DATAPLANE_PORT`
* that is why
  * the new interpretation is `<DATAPLANE_IP>:<DATAPLANE_PORT>:<WORKLOAD_PORT>`
  * information about `SERVICE_PORT` is now encoded into `service` tag, i.e. `example.demo.svc:80`
 