### PR TITLE
Validate mesh existence

### DIFF
--- a/components/konvoy-control-plane/pkg/api-server/dataplane_overview_ws.go
+++ b/components/konvoy-control-plane/pkg/api-server/dataplane_overview_ws.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	mesh_proto "github.com/Kong/konvoy/components/konvoy-control-plane/api/mesh/v1alpha1"
 	"github.com/Kong/konvoy/components/konvoy-control-plane/pkg/core"
+	core_resources "github.com/Kong/konvoy/components/konvoy-control-plane/pkg/core/resources"
 	"github.com/Kong/konvoy/components/konvoy-control-plane/pkg/core/resources/apis/mesh"
 	"github.com/Kong/konvoy/components/konvoy-control-plane/pkg/core/resources/model/rest"
 	"github.com/Kong/konvoy/components/konvoy-control-plane/pkg/core/resources/store"
@@ -12,7 +13,7 @@ import (
 )
 
 type overviewWs struct {
-	resourceStore store.ResourceStore
+	resources core_resources.Resources
 }
 
 func (r *overviewWs) AddToWs(ws *restful.WebService) {
@@ -53,12 +54,12 @@ func (r *overviewWs) inspectDataplane(request *restful.Request, response *restfu
 
 func (r *overviewWs) fetchOverview(ctx context.Context, name string, meshName string) (*mesh.DataplaneOverviewResource, error) {
 	dataplane := mesh.DataplaneResource{}
-	if err := r.resourceStore.Get(ctx, &dataplane, store.GetByKey(namespace, name, meshName)); err != nil {
+	if err := r.resources.Get(ctx, &dataplane, store.GetByKey(namespace, name, meshName)); err != nil {
 		return nil, err
 	}
 
 	insight := mesh.DataplaneInsightResource{}
-	err := r.resourceStore.Get(ctx, &insight, store.GetByKey(namespace, name, meshName))
+	err := r.resources.Get(ctx, &insight, store.GetByKey(namespace, name, meshName))
 	if err != nil && !store.IsResourceNotFound(err) { // It's fine to have dataplane without insight
 		return nil, err
 	}
@@ -93,12 +94,12 @@ func (r *overviewWs) inspectDataplanes(request *restful.Request, response *restf
 
 func (r *overviewWs) fetchOverviews(ctx context.Context, meshName string) (mesh.DataplaneOverviewResourceList, error) {
 	dataplanes := mesh.DataplaneResourceList{}
-	if err := r.resourceStore.List(ctx, &dataplanes, store.ListByMesh(meshName)); err != nil {
+	if err := r.resources.List(ctx, &dataplanes, store.ListByMesh(meshName)); err != nil {
 		return mesh.DataplaneOverviewResourceList{}, err
 	}
 
 	insights := mesh.DataplaneInsightResourceList{}
-	if err := r.resourceStore.List(ctx, &insights, store.ListByMesh(meshName)); err != nil {
+	if err := r.resources.List(ctx, &insights, store.ListByMesh(meshName)); err != nil {
 		return mesh.DataplaneOverviewResourceList{}, err
 	}
 

--- a/components/konvoy-control-plane/pkg/api-server/dataplane_overview_ws_test.go
+++ b/components/konvoy-control-plane/pkg/api-server/dataplane_overview_ws_test.go
@@ -44,6 +44,15 @@ var _ = Describe("Dataplane Overview WS", func() {
 	})
 
 	BeforeEach(func() {
+		// create default mesh
+		meshRes := mesh_core.MeshResource{
+			Spec: v1alpha1.Mesh{},
+		}
+		err := resourceStore.Create(context.Background(), &meshRes, store.CreateByKey("default", "mesh1", "mesh1"))
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	BeforeEach(func() {
 		// given
 		dpResource := mesh_core.DataplaneResource{
 			Spec: v1alpha1.Dataplane{

--- a/components/konvoy-control-plane/pkg/api-server/resource_api_client_test.go
+++ b/components/konvoy-control-plane/pkg/api-server/resource_api_client_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/Kong/konvoy/components/konvoy-control-plane/pkg/api-server"
 	"github.com/Kong/konvoy/components/konvoy-control-plane/pkg/api-server/definitions"
 	config "github.com/Kong/konvoy/components/konvoy-control-plane/pkg/config/api-server"
+	core_resources "github.com/Kong/konvoy/components/konvoy-control-plane/pkg/core/resources"
 	"github.com/Kong/konvoy/components/konvoy-control-plane/pkg/core/resources/store"
 	sample_proto "github.com/Kong/konvoy/components/konvoy-control-plane/pkg/test/apis/sample/v1alpha1"
 	sample_model "github.com/Kong/konvoy/components/konvoy-control-plane/pkg/test/resources/apis/sample"
@@ -100,7 +101,8 @@ func createTestApiServer(store store.ResourceStore, config config.ApiServerConfi
 		TrafficRouteWsDefinition,
 		definitions.MeshWsDefinition,
 	}
-	return api_server.NewApiServer(store, defs, config)
+	resources := core_resources.Resources{Store: store}
+	return api_server.NewApiServer(resources, defs, config)
 }
 
 func getFreePort() (int, error) {

--- a/components/konvoy-control-plane/pkg/api-server/resource_ws.go
+++ b/components/konvoy-control-plane/pkg/api-server/resource_ws.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"github.com/Kong/konvoy/components/konvoy-control-plane/pkg/api-server/definitions"
 	"github.com/Kong/konvoy/components/konvoy-control-plane/pkg/core"
+	core_resources "github.com/Kong/konvoy/components/konvoy-control-plane/pkg/core/resources"
 	"github.com/Kong/konvoy/components/konvoy-control-plane/pkg/core/resources/apis/mesh"
 	"github.com/Kong/konvoy/components/konvoy-control-plane/pkg/core/resources/model"
 	"github.com/Kong/konvoy/components/konvoy-control-plane/pkg/core/resources/model/rest"
@@ -16,7 +17,7 @@ import (
 const namespace = "default"
 
 type resourceWs struct {
-	resourceStore   store.ResourceStore
+	resources       core_resources.Resources
 	readOnly        bool
 	nameFromRequest func(*restful.Request) string
 	meshFromRequest func(*restful.Request) string
@@ -74,7 +75,7 @@ func (r *resourceWs) findResource(request *restful.Request, response *restful.Re
 	meshName := r.meshFromRequest(request)
 
 	resource := r.ResourceFactory()
-	err := r.resourceStore.Get(request.Request.Context(), resource, store.GetByKey(namespace, name, meshName))
+	err := r.resources.Get(request.Request.Context(), resource, store.GetByKey(namespace, name, meshName))
 	if err != nil {
 		if err.Error() == store.ErrorResourceNotFound(resource.GetType(), namespace, name, meshName).Error() {
 			writeError(response, 404, "")
@@ -94,7 +95,7 @@ func (r *resourceWs) listResources(request *restful.Request, response *restful.R
 	meshName := r.meshFromRequest(request)
 
 	list := r.ResourceListFactory()
-	if err := r.resourceStore.List(request.Request.Context(), list, store.ListByMesh(meshName)); err != nil {
+	if err := r.resources.List(request.Request.Context(), list, store.ListByMesh(meshName)); err != nil {
 		core.Log.Error(err, "Could not retrieve resources")
 		writeError(response, 500, "Could not list a resource")
 	} else {
@@ -124,15 +125,15 @@ func (r *resourceWs) createOrUpdateResource(request *restful.Request, response *
 		writeError(response, 400, err.Error())
 	} else {
 		resource := r.ResourceFactory()
-		if err := r.resourceStore.Get(request.Request.Context(), resource, store.GetByKey(namespace, name, meshName)); err != nil {
-			if err.Error() == store.ErrorResourceNotFound(resource.GetType(), namespace, name, meshName).Error() {
+		if err := r.resources.Get(request.Request.Context(), resource, store.GetByKey(namespace, name, meshName)); err != nil {
+			if store.IsResourceNotFound(err) {
 				r.createResource(request.Request.Context(), name, meshName, resourceRes.Spec, response)
 			} else {
 				core.Log.Error(err, "Could get a resource from the store", "namespace", namespace, "name", name, "type", string(resource.GetType()))
 				writeError(response, 500, "Could not create a resource")
 			}
 		} else {
-			r.updateResource(request.Request.Context(), resource, resourceRes.Spec, response)
+			r.updateResource(request.Request.Context(), resource, resourceRes, response)
 		}
 	}
 }
@@ -155,19 +156,27 @@ func (r *resourceWs) validateResourceRequest(request *restful.Request, resource 
 func (r *resourceWs) createResource(ctx context.Context, name string, meshName string, spec model.ResourceSpec, response *restful.Response) {
 	res := r.ResourceFactory()
 	_ = res.SetSpec(spec)
-	if err := r.resourceStore.Create(ctx, res, store.CreateByKey(namespace, name, meshName)); err != nil {
-		core.Log.Error(err, "Could not create a resource")
-		writeError(response, 500, "Could not create a resource")
+	if err := r.resources.Create(ctx, res, store.CreateByKey(namespace, name, meshName)); err != nil {
+		if core_resources.IsMeshNotFound(err) {
+			writeError(response, 400, fmt.Sprintf("Mesh of name %v is not found", meshName))
+		} else {
+			core.Log.Error(err, "Could not create a resource")
+			writeError(response, 500, "Could not create a resource")
+		}
 	} else {
 		response.WriteHeader(201)
 	}
 }
 
-func (r *resourceWs) updateResource(ctx context.Context, res model.Resource, spec model.ResourceSpec, response *restful.Response) {
-	_ = res.SetSpec(spec)
-	if err := r.resourceStore.Update(ctx, res); err != nil {
-		core.Log.Error(err, "Could not update a resource")
-		writeError(response, 500, "Could not update a resource")
+func (r *resourceWs) updateResource(ctx context.Context, res model.Resource, restRes rest.Resource, response *restful.Response) {
+	_ = res.SetSpec(restRes.Spec)
+	if err := r.resources.Update(ctx, res, store.UpdateMesh(restRes.Meta.Mesh)); err != nil {
+		if core_resources.IsMeshNotFound(err) {
+			writeError(response, 400, fmt.Sprintf("Mesh of name %v is not found", restRes.Meta.Mesh))
+		} else {
+			core.Log.Error(err, "Could not update a resource")
+			writeError(response, 500, "Could not update a resource")
+		}
 	} else {
 		response.WriteHeader(200)
 	}
@@ -178,7 +187,7 @@ func (r *resourceWs) deleteResource(request *restful.Request, response *restful.
 	meshName := r.meshFromRequest(request)
 
 	resource := r.ResourceFactory()
-	err := r.resourceStore.Delete(request.Request.Context(), resource, store.DeleteByKey(namespace, name, meshName))
+	err := r.resources.Delete(request.Request.Context(), resource, store.DeleteByKey(namespace, name, meshName))
 	if err != nil {
 		writeError(response, 500, "Could not delete a resource")
 		core.Log.Error(err, "Could not delete a resource", "namespace", namespace, "name", name, "type", string(resource.GetType()))

--- a/components/konvoy-control-plane/pkg/api-server/resource_ws_test.go
+++ b/components/konvoy-control-plane/pkg/api-server/resource_ws_test.go
@@ -3,8 +3,10 @@ package api_server_test
 import (
 	"context"
 	"fmt"
+	mesh_proto "github.com/Kong/konvoy/components/konvoy-control-plane/api/mesh/v1alpha1"
 	"github.com/Kong/konvoy/components/konvoy-control-plane/pkg/api-server"
 	config "github.com/Kong/konvoy/components/konvoy-control-plane/pkg/config/api-server"
+	mesh_res "github.com/Kong/konvoy/components/konvoy-control-plane/pkg/core/resources/apis/mesh"
 	"github.com/Kong/konvoy/components/konvoy-control-plane/pkg/core/resources/model/rest"
 	"github.com/Kong/konvoy/components/konvoy-control-plane/pkg/core/resources/store"
 	"github.com/Kong/konvoy/components/konvoy-control-plane/pkg/plugins/resources/memory"
@@ -42,6 +44,15 @@ var _ = Describe("Resource WS", func() {
 
 	AfterEach(func() {
 		close(stop)
+	})
+
+	BeforeEach(func() {
+		// create default mesh
+		meshRes := mesh_res.MeshResource{
+			Spec: mesh_proto.Mesh{},
+		}
+		err := resourceStore.Create(context.Background(), &meshRes, store.CreateByKey(namespace, mesh, mesh))
+		Expect(err).ToNot(HaveOccurred())
 	})
 
 	Describe("On GET", func() {

--- a/components/konvoy-control-plane/pkg/api-server/server.go
+++ b/components/konvoy-control-plane/pkg/api-server/server.go
@@ -3,12 +3,12 @@ package api_server
 import (
 	"context"
 	"fmt"
+	core_resources "github.com/Kong/konvoy/components/konvoy-control-plane/pkg/core/resources"
 	"net/http"
 
 	"github.com/Kong/konvoy/components/konvoy-control-plane/pkg/api-server/definitions"
 	config "github.com/Kong/konvoy/components/konvoy-control-plane/pkg/config/api-server"
 	"github.com/Kong/konvoy/components/konvoy-control-plane/pkg/core"
-	"github.com/Kong/konvoy/components/konvoy-control-plane/pkg/core/resources/store"
 	"github.com/Kong/konvoy/components/konvoy-control-plane/pkg/core/runtime"
 	"github.com/emicklei/go-restful"
 	restfulspec "github.com/emicklei/go-restful-openapi"
@@ -26,7 +26,7 @@ func (a *ApiServer) Address() string {
 	return a.server.Addr
 }
 
-func NewApiServer(resourceStore store.ResourceStore, defs []definitions.ResourceWsDefinition, config config.ApiServerConfig) *ApiServer {
+func NewApiServer(resources core_resources.Resources, defs []definitions.ResourceWsDefinition, config config.ApiServerConfig) *ApiServer {
 	container := restful.NewContainer()
 	srv := &http.Server{
 		Addr:    fmt.Sprintf(":%d", config.Port),
@@ -39,7 +39,7 @@ func NewApiServer(resourceStore store.ResourceStore, defs []definitions.Resource
 		Consumes(restful.MIME_JSON).
 		Produces(restful.MIME_JSON)
 
-	addToWs(ws, defs, resourceStore, config)
+	addToWs(ws, defs, resources, config)
 	container.Add(ws)
 	configureOpenApi(config, container, ws)
 
@@ -48,15 +48,15 @@ func NewApiServer(resourceStore store.ResourceStore, defs []definitions.Resource
 	}
 }
 
-func addToWs(ws *restful.WebService, defs []definitions.ResourceWsDefinition, resourceStore store.ResourceStore, config config.ApiServerConfig) {
+func addToWs(ws *restful.WebService, defs []definitions.ResourceWsDefinition, resources core_resources.Resources, config config.ApiServerConfig) {
 	overviewWs := overviewWs{
-		resourceStore: resourceStore,
+		resources: resources,
 	}
 	overviewWs.AddToWs(ws)
 
 	for _, definition := range defs {
 		resourceWs := resourceWs{
-			resourceStore:        resourceStore,
+			resources:            resources,
 			readOnly:             config.ReadOnly,
 			ResourceWsDefinition: definition,
 		}
@@ -99,6 +99,6 @@ func (a *ApiServer) Start(stop <-chan struct{}) error {
 }
 
 func SetupServer(rt runtime.Runtime) error {
-	apiServer := NewApiServer(rt.ResourceStore(), definitions.All, *rt.Config().ApiServer)
+	apiServer := NewApiServer(rt.Resources(), definitions.All, *rt.Config().ApiServer)
 	return rt.Add(apiServer)
 }

--- a/components/konvoy-control-plane/pkg/core/resources/resources.go
+++ b/components/konvoy-control-plane/pkg/core/resources/resources.go
@@ -1,0 +1,70 @@
+package resources
+
+import (
+	"context"
+	"github.com/Kong/konvoy/components/konvoy-control-plane/pkg/core/resources/apis/mesh"
+	"github.com/Kong/konvoy/components/konvoy-control-plane/pkg/core/resources/model"
+	"github.com/Kong/konvoy/components/konvoy-control-plane/pkg/core/resources/store"
+	"github.com/pkg/errors"
+	"strings"
+)
+
+type Resources struct {
+	Store store.ResourceStore
+}
+
+func (f *Resources) Get(ctx context.Context, resource model.Resource, fs ...store.GetOptionsFunc) error {
+	return f.Store.Get(ctx, resource, fs...)
+}
+
+func (f *Resources) List(ctx context.Context, list model.ResourceList, fs ...store.ListOptionsFunc) error {
+	return f.Store.List(ctx, list, fs...)
+}
+
+func (f *Resources) Create(ctx context.Context, resource model.Resource, fs ...store.CreateOptionsFunc) error {
+	opts := store.NewCreateOptions(fs...)
+	if resource.GetType() != mesh.MeshType {
+		if err := f.ensureMeshExists(ctx, opts.Mesh, opts.Namespace); err != nil {
+			return err
+		}
+	}
+	return f.Store.Create(ctx, resource, fs...)
+}
+
+func (f *Resources) Delete(ctx context.Context, resource model.Resource, fs ...store.DeleteOptionsFunc) error {
+	return f.Store.Delete(ctx, resource, fs...)
+}
+
+func (f *Resources) Update(ctx context.Context, resource model.Resource, fs ...store.UpdateOptionsFunc) error {
+	if resource.GetType() != mesh.MeshType {
+		opts := store.NewUpdateOptions(fs...)
+		var meshName string
+		if opts.Mesh != "" {
+			meshName = opts.Mesh
+		} else {
+			meshName = resource.GetMeta().GetMesh()
+		}
+		if err := f.ensureMeshExists(ctx, meshName, resource.GetMeta().GetNamespace()); err != nil {
+			return err
+		}
+	}
+	return f.Store.Update(ctx, resource, fs...)
+}
+
+func (f *Resources) ensureMeshExists(ctx context.Context, meshName string, namespace string) error {
+	if err := f.Store.Get(ctx, &mesh.MeshResource{}, store.GetByKey(namespace, meshName, meshName)); err != nil { // todo namespace
+		if store.IsResourceNotFound(err) {
+			return MeshNotFound(meshName)
+		}
+		return err
+	}
+	return nil
+}
+
+func MeshNotFound(meshName string) error {
+	return errors.Errorf("mesh of name %v is not found", meshName)
+}
+
+func IsMeshNotFound(err error) bool {
+	return err != nil && strings.HasPrefix(err.Error(), "mesh of name") && strings.HasSuffix(err.Error(), "is not found")
+}

--- a/components/konvoy-control-plane/pkg/core/resources/resources_suite_test.go
+++ b/components/konvoy-control-plane/pkg/core/resources/resources_suite_test.go
@@ -1,0 +1,13 @@
+package resources_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestResources(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Resources")
+}

--- a/components/konvoy-control-plane/pkg/core/resources/resources_test.go
+++ b/components/konvoy-control-plane/pkg/core/resources/resources_test.go
@@ -1,0 +1,97 @@
+package resources_test
+
+import (
+	"context"
+	mesh_proto "github.com/Kong/konvoy/components/konvoy-control-plane/api/mesh/v1alpha1"
+	"github.com/Kong/konvoy/components/konvoy-control-plane/pkg/core/resources"
+	"github.com/Kong/konvoy/components/konvoy-control-plane/pkg/core/resources/apis/mesh"
+	"github.com/Kong/konvoy/components/konvoy-control-plane/pkg/core/resources/store"
+	"github.com/Kong/konvoy/components/konvoy-control-plane/pkg/plugins/resources/memory"
+	"github.com/Kong/konvoy/components/konvoy-control-plane/pkg/test/apis/sample/v1alpha1"
+	"github.com/Kong/konvoy/components/konvoy-control-plane/pkg/test/resources/apis/sample"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Resources", func() {
+
+	var resStore store.ResourceStore
+	var res resources.Resources
+
+	BeforeEach(func() {
+		resStore = memory.NewStore()
+		res = resources.Resources{Store: resStore}
+	})
+
+	createSampleMesh := func() error {
+		meshRes := mesh.MeshResource{
+			Spec: mesh_proto.Mesh{},
+		}
+		return res.Create(context.Background(), &meshRes, store.CreateByKey("default", "mesh-1", "mesh-1"))
+	}
+
+	createSampleResource := func() (*sample.TrafficRouteResource, error) {
+		trRes := sample.TrafficRouteResource{
+			Spec: v1alpha1.TrafficRoute{
+				Path: "/some",
+			},
+		}
+		err := res.Create(context.Background(), &trRes, store.CreateByKey("default", "tr-1", "mesh-1"))
+		return &trRes, err
+	}
+
+	Describe("Create()", func() {
+		It("should let create when mesh exists", func() {
+			// given
+			err := createSampleMesh()
+			Expect(err).ToNot(HaveOccurred())
+
+			// when
+			_, err = createSampleResource()
+
+			// then
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("should not let to create a resource when mesh not exists", func() {
+			// given no mesh for resource
+
+			// when
+			_, err := createSampleResource()
+
+			// then
+			Expect(err.Error()).To(Equal("mesh of name mesh-1 is not found"))
+		})
+	})
+
+	Describe("Update()", func() {
+		It("should let update when mesh exists", func() {
+			// given resource in mesh
+			err := createSampleMesh()
+			Expect(err).ToNot(HaveOccurred())
+			trRes, err := createSampleResource()
+			Expect(err).ToNot(HaveOccurred())
+
+			// when resource is updated within the mesh
+			trRes.Spec.Path = "/updated"
+			err = res.Update(context.Background(), trRes)
+
+			// then
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("should not let to update a resource when mesh not exists", func() {
+			// given resource in mesh
+			err := createSampleMesh()
+			Expect(err).ToNot(HaveOccurred())
+			trRes, err := createSampleResource()
+			Expect(err).ToNot(HaveOccurred())
+
+			// when resource is updated with non existing mesh
+			err = res.Update(context.Background(), trRes, store.UpdateMesh("non-existing"))
+
+			// then
+			Expect(err.Error()).To(Equal("mesh of name non-existing is not found"))
+		})
+	})
+})

--- a/components/konvoy-control-plane/pkg/core/resources/store/options.go
+++ b/components/konvoy-control-plane/pkg/core/resources/store/options.go
@@ -32,7 +32,15 @@ func CreateByKey(ns, name, mesh string) CreateOptionsFunc {
 	}
 }
 
+// todo(jakubdyszkiewicz) implement in other stores than in-memory
 type UpdateOptions struct {
+	Mesh string
+}
+
+func UpdateMesh(mesh string) UpdateOptionsFunc {
+	return func(opts *UpdateOptions) {
+		opts.Mesh = mesh
+	}
 }
 
 type UpdateOptionsFunc func(*UpdateOptions)
@@ -94,14 +102,6 @@ func GetByKey(ns, name, mesh string) GetOptionsFunc {
 		opts.Namespace = ns
 		opts.Name = name
 		opts.Mesh = mesh
-	}
-}
-
-// todo(jakubdyszkiewicz) delete eventually once k8s store tests are not ignored
-func GetByName(ns, name string) GetOptionsFunc {
-	return func(opts *GetOptions) {
-		opts.Namespace = ns
-		opts.Name = name
 	}
 }
 

--- a/components/konvoy-control-plane/pkg/core/runtime/runtime.go
+++ b/components/konvoy-control-plane/pkg/core/runtime/runtime.go
@@ -3,6 +3,7 @@ package runtime
 import (
 	"github.com/Kong/konvoy/components/konvoy-control-plane/pkg/config/app/konvoy-cp"
 	core_discovery "github.com/Kong/konvoy/components/konvoy-control-plane/pkg/core/discovery"
+	core_resources "github.com/Kong/konvoy/components/konvoy-control-plane/pkg/core/resources"
 	core_store "github.com/Kong/konvoy/components/konvoy-control-plane/pkg/core/resources/store"
 	core_xds "github.com/Kong/konvoy/components/konvoy-control-plane/pkg/core/xds"
 )
@@ -23,6 +24,7 @@ type RuntimeContext interface {
 	ResourceStore() core_store.ResourceStore
 	DiscoverySources() []core_discovery.DiscoverySource
 	XDS() core_xds.XdsContext
+	Resources() core_resources.Resources
 }
 
 var _ Runtime = &runtime{}
@@ -63,4 +65,7 @@ func (rc *runtimeContext) DiscoverySources() []core_discovery.DiscoverySource {
 }
 func (rc *runtimeContext) XDS() core_xds.XdsContext {
 	return rc.xds
+}
+func (rc *runtimeContext) Resources() core_resources.Resources {
+	return core_resources.Resources{Store: rc.ResourceStore()}
 }

--- a/components/konvoy-control-plane/pkg/plugins/resources/memory/store.go
+++ b/components/konvoy-control-plane/pkg/plugins/resources/memory/store.go
@@ -106,7 +106,7 @@ func (c *memoryStore) Update(_ context.Context, r model.Resource, fs ...store.Up
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	_ = store.NewUpdateOptions(fs...)
+	opts := store.NewUpdateOptions(fs...)
 
 	meta, ok := (r.GetMeta()).(memoryMeta)
 	if !ok {
@@ -120,6 +120,9 @@ func (c *memoryStore) Update(_ context.Context, r model.Resource, fs ...store.Up
 		return store.ErrorResourceConflict(r.GetType(), r.GetMeta().GetNamespace(), r.GetMeta().GetName(), r.GetMeta().GetMesh())
 	}
 	meta.Version = meta.Version.Next()
+	if opts.Mesh != "" {
+		meta.Mesh = opts.Mesh
+	}
 
 	record, err := c.marshalRecord(
 		string(r.GetType()),


### PR DESCRIPTION
Introducing intermediate layer between resource store which is persistence layer and api server layer/business layer. I expect this to be used instead of resource store in business logic, so we can add later other stuff like for example logging/auditing, security etc.

In the future we can probably move something around here connecting dataplane inspection. 

For now I just added mesh validation when saving resources.

Name for now is just `Resources`. I like the simplicity, but it has a con that it clashes with resource package name, so in every import the package has to be aliased to `core_resources`.
Other options I could think of is `ResourcesFacade`, but it's probably too Java-ish.

Feel free to recommend your name!