### PR TITLE
control-plane: create bootstrap mesh as a runtime component

### DIFF
--- a/components/konvoy-control-plane/pkg/core/bootstrap/bootstrap.go
+++ b/components/konvoy-control-plane/pkg/core/bootstrap/bootstrap.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"github.com/Kong/konvoy/components/konvoy-control-plane/pkg/config/app/konvoy-cp"
 	"github.com/Kong/konvoy/components/konvoy-control-plane/pkg/config/core/resources/store"
+	"github.com/Kong/konvoy/components/konvoy-control-plane/pkg/core"
 	core_plugins "github.com/Kong/konvoy/components/konvoy-control-plane/pkg/core/plugins"
 	"github.com/Kong/konvoy/components/konvoy-control-plane/pkg/core/resources/apis/mesh"
 	core_model "github.com/Kong/konvoy/components/konvoy-control-plane/pkg/core/resources/model"
@@ -40,6 +41,7 @@ func createDefaultMesh(runtime core_runtime.Runtime) error {
 
 	if err := resManager.Get(context.Background(), &defaultMesh, getOpts); err != nil {
 		if core_store.IsResourceNotFound(err) {
+			core.Log.Info("Creating default mesh from the settings", "mesh", cfg.Defaults.Mesh)
 			defaultMesh.Spec = cfg.Defaults.Mesh
 			createOpts := core_store.CreateByKey(core_model.DefaultNamespace,
 				core_model.DefaultMesh, core_model.DefaultMesh)
@@ -50,14 +52,6 @@ func createDefaultMesh(runtime core_runtime.Runtime) error {
 		} else {
 			return err
 		}
-	}
-
-	return nil
-}
-
-func onStartup(runtime core_runtime.Runtime) error {
-	if err := createDefaultMesh(runtime); err != nil {
-		return err
 	}
 
 	return nil
@@ -74,6 +68,16 @@ func Bootstrap(cfg konvoy_cp.Config) (core_runtime.Runtime, error) {
 	}
 
 	return runtime, nil
+}
+
+func onStartup(runtime core_runtime.Runtime) error {
+	return runtime.Add(core_runtime.ComponentFunc(func(stop <-chan struct{}) error {
+		if err := createDefaultMesh(runtime); err != nil {
+			return err
+		}
+		<-stop // it has to block, otherwise the k8s component manager stops all other components
+		return nil
+	}))
 }
 
 func initializeBootstrap(cfg konvoy_cp.Config, builder *core_runtime.Builder) error {

--- a/components/konvoy-control-plane/pkg/core/bootstrap/bootstrap_suite_test.go
+++ b/components/konvoy-control-plane/pkg/core/bootstrap/bootstrap_suite_test.go
@@ -1,4 +1,4 @@
-package bootstrap_test
+package bootstrap
 
 import (
 	"testing"

--- a/components/konvoy-control-plane/pkg/core/bootstrap/bootstrap_test.go
+++ b/components/konvoy-control-plane/pkg/core/bootstrap/bootstrap_test.go
@@ -1,9 +1,8 @@
-package bootstrap_test
+package bootstrap
 
 import (
 	"context"
 	konvoy_cp "github.com/Kong/konvoy/components/konvoy-control-plane/pkg/config/app/konvoy-cp"
-	"github.com/Kong/konvoy/components/konvoy-control-plane/pkg/core/bootstrap"
 	"github.com/Kong/konvoy/components/konvoy-control-plane/pkg/core/resources/apis/mesh"
 	core_model "github.com/Kong/konvoy/components/konvoy-control-plane/pkg/core/resources/model"
 	core_store "github.com/Kong/konvoy/components/konvoy-control-plane/pkg/core/resources/store"
@@ -17,13 +16,25 @@ var _ = Describe("Bootstrap", func() {
 		// given
 		cfg := konvoy_cp.DefaultConfig()
 
-		rt, err := bootstrap.Bootstrap(cfg)
+		// when control plane is started
+		rt, err := Bootstrap(cfg)
+		ch := make(chan struct{})
+		go func() {
+			defer GinkgoRecover()
+			err := rt.Start(ch)
+			Expect(err).ToNot(HaveOccurred())
+		}()
 		Expect(err).ToNot(HaveOccurred())
 
-		// when
+		// then wait until resource is created
 		resManager := rt.ResourceManager()
-		getOpts := core_store.GetByKey(core_model.DefaultNamespace,
-			core_model.DefaultMesh, core_model.DefaultMesh)
+		Eventually(func() error {
+			getOpts := core_store.GetByKey(core_model.DefaultNamespace, core_model.DefaultMesh, core_model.DefaultMesh)
+			return resManager.Get(context.Background(), &mesh.MeshResource{}, getOpts)
+		}).Should(Succeed())
+
+		// when
+		getOpts := core_store.GetByKey(core_model.DefaultNamespace, core_model.DefaultMesh, core_model.DefaultMesh)
 		defaultMesh := mesh.MeshResource{}
 		err = resManager.Get(context.Background(), &defaultMesh, getOpts)
 		Expect(err).ToNot(HaveOccurred())
@@ -33,6 +44,27 @@ var _ = Describe("Bootstrap", func() {
 		Expect(meshMeta.GetName()).To(Equal("default"))
 		Expect(meshMeta.GetMesh()).To(Equal("default"))
 		Expect(meshMeta.GetNamespace()).To(Equal("default"))
+	})
+
+	It("should skip creating mesh if one already exist", func() {
+		// given
+		cfg := konvoy_cp.DefaultConfig()
+		runtime, err := buildRuntime(cfg)
+		Expect(err).ToNot(HaveOccurred())
+
+		// when
+		Expect(createDefaultMesh(runtime)).To(Succeed())
+
+		// then mesh exists
+		getOpts := core_store.GetByKey(core_model.DefaultNamespace, core_model.DefaultMesh, core_model.DefaultMesh)
+		err = runtime.ResourceManager().Get(context.Background(), &mesh.MeshResource{}, getOpts)
+		Expect(err).ToNot(HaveOccurred())
+
+		// when createDefaultMesh is called once mesh already exist
+		err = createDefaultMesh(runtime)
+
+		// then
+		Expect(err).ToNot(HaveOccurred())
 	})
 
 })

--- a/components/konvoy-control-plane/pkg/core/runtime/component.go
+++ b/components/konvoy-control-plane/pkg/core/runtime/component.go
@@ -7,6 +7,14 @@ import (
 // Component of the Control Plane, i.e. gRPC Server, HTTP server, reconciliation loop.
 type Component = manager.Runnable
 
+var _ Component = ComponentFunc(nil)
+
+type ComponentFunc func(<-chan struct{}) error
+
+func (f ComponentFunc) Start(stop <-chan struct{}) error {
+	return f(stop)
+}
+
 type ComponentManager interface {
 
 	// Add registers a component, i.e. gRPC Server, HTTP server, reconciliation loop.

--- a/components/konvoy-control-plane/pkg/plugins/resources/k8s/plugin.go
+++ b/components/konvoy-control-plane/pkg/plugins/resources/k8s/plugin.go
@@ -24,6 +24,8 @@ func (p *plugin) NewResourceStore(pc core_plugins.PluginContext, _ core_plugins.
 	if !ok {
 		return nil, errors.Errorf("Component Manager has a wrong type: expected=%q got=%q", reflect.TypeOf(kube_ctrl.Manager(nil)), reflect.TypeOf(pc.ComponentManager()))
 	}
-	mesh_k8s.AddToScheme(mgr.GetScheme())
+	if err := mesh_k8s.AddToScheme(mgr.GetScheme()); err != nil {
+		return nil, errors.Wrap(err, "could not add to scheme")
+	}
 	return NewStore(mgr.GetClient())
 }


### PR DESCRIPTION
There was a problem with creating bootstrap mesh in K8S. The `Get()` on ResourceManager always returned null so the control plane always tried to create a mesh. The problem was that cache in K8S was not initialized. Cache is initialized before a logic Component is run, that's why the creating mesh is moved to Component.