### PR TITLE
control-plane: refactor the way k8s Client is made available to different components

### DIFF
--- a/components/konvoy-control-plane/pkg/core/runtime/runtime.go
+++ b/components/konvoy-control-plane/pkg/core/runtime/runtime.go
@@ -1,7 +1,9 @@
 package runtime
 
 import (
-	"github.com/Kong/konvoy/components/konvoy-control-plane/pkg/config/app/konvoy-cp"
+	"context"
+
+	konvoy_cp "github.com/Kong/konvoy/components/konvoy-control-plane/pkg/config/app/konvoy-cp"
 	core_discovery "github.com/Kong/konvoy/components/konvoy-control-plane/pkg/core/discovery"
 	"github.com/Kong/konvoy/components/konvoy-control-plane/pkg/core/resources/manager"
 	core_store "github.com/Kong/konvoy/components/konvoy-control-plane/pkg/core/resources/store"
@@ -24,6 +26,7 @@ type RuntimeContext interface {
 	DiscoverySources() []core_discovery.DiscoverySource
 	XDS() core_xds.XdsContext
 	ResourceManager() manager.ResourceManager
+	Extensions() context.Context
 }
 
 var _ Runtime = &runtime{}
@@ -51,6 +54,7 @@ type runtimeContext struct {
 	rs  core_store.ResourceStore
 	dss []core_discovery.DiscoverySource
 	xds core_xds.XdsContext
+	ext context.Context
 }
 
 func (rc *runtimeContext) Config() konvoy_cp.Config {
@@ -64,4 +68,7 @@ func (rc *runtimeContext) XDS() core_xds.XdsContext {
 }
 func (rc *runtimeContext) ResourceManager() manager.ResourceManager {
 	return manager.NewResourceManager(rc.rs)
+}
+func (rc *runtimeContext) Extensions() context.Context {
+	return rc.ext
 }

--- a/components/konvoy-control-plane/pkg/plugins/bootstrap/k8s/plugin.go
+++ b/components/konvoy-control-plane/pkg/plugins/bootstrap/k8s/plugin.go
@@ -3,6 +3,7 @@ package k8s
 import (
 	core_plugins "github.com/Kong/konvoy/components/konvoy-control-plane/pkg/core/plugins"
 	core_runtime "github.com/Kong/konvoy/components/konvoy-control-plane/pkg/core/runtime"
+	k8s_runtime "github.com/Kong/konvoy/components/konvoy-control-plane/pkg/runtime/k8s"
 
 	kube_runtime "k8s.io/apimachinery/pkg/runtime"
 	kube_ctrl "sigs.k8s.io/controller-runtime"
@@ -26,5 +27,6 @@ func (p *plugin) Bootstrap(b *core_runtime.Builder, _ core_plugins.PluginConfig)
 		return err
 	}
 	b.WithComponentManager(mgr)
+	b.WithExtensions(k8s_runtime.NewManagerContext(b.Extensions(), mgr))
 	return nil
 }

--- a/components/konvoy-control-plane/pkg/plugins/discovery/k8s/plugin.go
+++ b/components/konvoy-control-plane/pkg/plugins/discovery/k8s/plugin.go
@@ -2,12 +2,10 @@ package k8s
 
 import (
 	"github.com/pkg/errors"
-	"reflect"
 
 	core_discovery "github.com/Kong/konvoy/components/konvoy-control-plane/pkg/core/discovery"
 	core_plugins "github.com/Kong/konvoy/components/konvoy-control-plane/pkg/core/plugins"
-
-	kube_ctrl "sigs.k8s.io/controller-runtime"
+	k8s_runtime "github.com/Kong/konvoy/components/konvoy-control-plane/pkg/runtime/k8s"
 )
 
 var _ core_plugins.DiscoveryPlugin = &plugin{}
@@ -19,9 +17,9 @@ func init() {
 }
 
 func (p *plugin) NewDiscoverySource(pc core_plugins.PluginContext, _ core_plugins.PluginConfig) (core_discovery.DiscoverySource, error) {
-	mgr, ok := pc.ComponentManager().(kube_ctrl.Manager)
+	mgr, ok := k8s_runtime.FromManagerContext(pc.Extensions())
 	if !ok {
-		return nil, errors.Errorf("Component Manager has a wrong type: expected=%q got=%q", reflect.TypeOf(kube_ctrl.Manager(nil)), reflect.TypeOf(pc.ComponentManager()))
+		return nil, errors.Errorf("k8s controller runtime Manager hasn't been configured")
 	}
 	return NewDiscoverySource(mgr)
 }

--- a/components/konvoy-control-plane/pkg/plugins/resources/k8s/plugin.go
+++ b/components/konvoy-control-plane/pkg/plugins/resources/k8s/plugin.go
@@ -2,13 +2,11 @@ package k8s
 
 import (
 	"github.com/pkg/errors"
-	"reflect"
 
 	core_plugins "github.com/Kong/konvoy/components/konvoy-control-plane/pkg/core/plugins"
 	core_store "github.com/Kong/konvoy/components/konvoy-control-plane/pkg/core/resources/store"
 	mesh_k8s "github.com/Kong/konvoy/components/konvoy-control-plane/pkg/plugins/resources/k8s/native/api/v1alpha1"
-
-	kube_ctrl "sigs.k8s.io/controller-runtime"
+	k8s_runtime "github.com/Kong/konvoy/components/konvoy-control-plane/pkg/runtime/k8s"
 )
 
 var _ core_plugins.ResourceStorePlugin = &plugin{}
@@ -20,9 +18,9 @@ func init() {
 }
 
 func (p *plugin) NewResourceStore(pc core_plugins.PluginContext, _ core_plugins.PluginConfig) (core_store.ResourceStore, error) {
-	mgr, ok := pc.ComponentManager().(kube_ctrl.Manager)
+	mgr, ok := k8s_runtime.FromManagerContext(pc.Extensions())
 	if !ok {
-		return nil, errors.Errorf("Component Manager has a wrong type: expected=%q got=%q", reflect.TypeOf(kube_ctrl.Manager(nil)), reflect.TypeOf(pc.ComponentManager()))
+		return nil, errors.Errorf("k8s controller runtime Manager hasn't been configured")
 	}
 	if err := mesh_k8s.AddToScheme(mgr.GetScheme()); err != nil {
 		return nil, errors.Wrap(err, "could not add to scheme")

--- a/components/konvoy-control-plane/pkg/runtime/k8s/context.go
+++ b/components/konvoy-control-plane/pkg/runtime/k8s/context.go
@@ -1,0 +1,18 @@
+package k8s
+
+import (
+	"context"
+
+	kube_ctrl "sigs.k8s.io/controller-runtime"
+)
+
+type managerKey struct{}
+
+func NewManagerContext(ctx context.Context, manager kube_ctrl.Manager) context.Context {
+	return context.WithValue(ctx, managerKey{}, manager)
+}
+
+func FromManagerContext(ctx context.Context) (manager kube_ctrl.Manager, ok bool) {
+	manager, ok = ctx.Value(managerKey{}).(kube_ctrl.Manager)
+	return
+}


### PR DESCRIPTION
changes:
* use idiomatic Golang way (`context.Context`) to share k8s Client between different components