### PR TITLE
control-plane: sds: add stub implementations

### DIFF
--- a/components/konvoy-control-plane/pkg/sds/auth/credential.go
+++ b/components/konvoy-control-plane/pkg/sds/auth/credential.go
@@ -1,0 +1,27 @@
+package auth
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+
+	"google.golang.org/grpc/metadata"
+)
+
+const (
+	authorization = "authorization"
+)
+
+func ExtractCredential(ctx context.Context) (Credential, error) {
+	metadata, ok := metadata.FromIncomingContext(ctx)
+	if !ok {
+		return "", errors.Errorf("SDS request has no metadata")
+	}
+	if values, ok := metadata[authorization]; ok {
+		if len(values) != 1 {
+			return "", errors.Errorf("SDS request must have exactly 1 %q header, got %d", authorization, len(values))
+		}
+		return Credential(values[0]), nil
+	}
+	return "", nil
+}

--- a/components/konvoy-control-plane/pkg/sds/auth/interfaces.go
+++ b/components/konvoy-control-plane/pkg/sds/auth/interfaces.go
@@ -1,0 +1,18 @@
+package auth
+
+import (
+	"context"
+
+	core_xds "github.com/Kong/konvoy/components/konvoy-control-plane/pkg/core/xds"
+)
+
+type Credential string
+
+type Identity struct {
+	Mesh    string
+	Service string
+}
+
+type Authenticator interface {
+	Authenticate(ctx context.Context, proxyId core_xds.ProxyId, credential Credential) (Identity, error)
+}

--- a/components/konvoy-control-plane/pkg/sds/auth/k8s/authenticator.go
+++ b/components/konvoy-control-plane/pkg/sds/auth/k8s/authenticator.go
@@ -1,0 +1,20 @@
+package stub
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+
+	core_xds "github.com/Kong/konvoy/components/konvoy-control-plane/pkg/core/xds"
+	sds_auth "github.com/Kong/konvoy/components/konvoy-control-plane/pkg/sds/auth"
+)
+
+func New() sds_auth.Authenticator {
+	return kubeAuthenticator{}
+}
+
+type kubeAuthenticator struct{}
+
+func (_ kubeAuthenticator) Authenticate(ctx context.Context, proxyId core_xds.ProxyId, credential sds_auth.Credential) (sds_auth.Identity, error) {
+	return sds_auth.Identity{}, errors.New("not implemented")
+}

--- a/components/konvoy-control-plane/pkg/sds/auth/universal/authenticator.go
+++ b/components/konvoy-control-plane/pkg/sds/auth/universal/authenticator.go
@@ -1,0 +1,21 @@
+package universal
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+
+	core_xds "github.com/Kong/konvoy/components/konvoy-control-plane/pkg/core/xds"
+	sds_auth "github.com/Kong/konvoy/components/konvoy-control-plane/pkg/sds/auth"
+)
+
+func New() sds_auth.Authenticator {
+	return universalAuthenticator{}
+}
+
+type universalAuthenticator struct {
+}
+
+func (_ universalAuthenticator) Authenticate(ctx context.Context, proxyId core_xds.ProxyId, credential sds_auth.Credential) (sds_auth.Identity, error) {
+	return sds_auth.Identity{}, errors.New("not implemented")
+}

--- a/components/konvoy-control-plane/pkg/sds/provider/ca/provider.go
+++ b/components/konvoy-control-plane/pkg/sds/provider/ca/provider.go
@@ -1,0 +1,46 @@
+package ca
+
+import (
+	"context"
+
+	sds_auth "github.com/Kong/konvoy/components/konvoy-control-plane/pkg/sds/auth"
+	sds_provider "github.com/Kong/konvoy/components/konvoy-control-plane/pkg/sds/provider"
+)
+
+func New() sds_provider.SecretProvider {
+	return &meshCaProvider{}
+}
+
+type meshCaProvider struct {
+}
+
+func (s *meshCaProvider) RequiresIdentity() bool {
+	return false
+}
+
+func (s *meshCaProvider) Get(ctx context.Context, name string, requestor sds_auth.Identity) (sds_provider.Secret, error) {
+	return &MeshCaSecret{
+		PemCerts: [][]byte{[]byte(`
+-----BEGIN CERTIFICATE-----
+MIIC/TCCAeWgAwIBAgIRAKgVvRCrr87LMCVhIoU2k2gwDQYJKoZIhvcNAQELBQAw
+EjEQMA4GA1UEChMHQWNtZSBDbzAeFw0xOTA4MzAxMzQ4NDlaFw0yOTA4MzAwMTQ4
+NDlaMBIxEDAOBgNVBAoTB0FjbWUgQ28wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAw
+ggEKAoIBAQDTzb7dLh/7o/5eNatxF4RGRaXKJw85OjwmJKNESJ/4+ykFHOTh2Cg3
+BK5E9BXTWlEWMXlDTeMT3sqsJLyKCcQ38G64ue/gxvmqu2fMIXL/kABkta1gOXJF
+/QNCf/bjln7gxeTQzwfHHFuMCxq7qq0pdXkvp/gxXDKpJiwCYwOpZ5eT0lWbfUk6
+s/pOFniUSlLNg8gi3nNNUSZDVTN9HpivXWVO3IAWkupxYV/8rwwyzb5Z4jheFDVj
+G+It6BmItQK7snmoB4f1S8ELUT62nBu/pyyc6Y5AIN2wbzccdhhBBbTUHkZb7RoV
+l2fbgnoKFLNNXvYxKAeqq65EhnYXR1fXAgMBAAGjTjBMMA4GA1UdDwEB/wQEAwIC
+pDATBgNVHSUEDDAKBggrBgEFBQcDATAPBgNVHRMBAf8EBTADAQH/MBQGA1UdEQQN
+MAuCCWxvY2FsaG9zdDANBgkqhkiG9w0BAQsFAAOCAQEAXpxcNfSfEUIwOgfPtDYV
+ZzzLxx9m27m9cYyjaXWDFdXVDO/MTPjr/bf/7QVhf3ofoF9l/ojwkl+MwmhkV0Jx
+W2kfIyVQpsRh2KvYVv74Zn610zbvMLSTyEHuG2UWO0UeZfOsHmTEJsuJH54GEYJh
+DYHKHl31pG9OF1CwAZNyhmOz3nFrzRJr695rR0ZKwYvAfaTA/VUEymmPX3RiHf6W
+i18K5lY9hrNfNgI4gMVyNaWbAtJASzNdH1TIlvHv+P5pXqE2okfVFG/Gaw7tBfCJ
+EpmbGZ7aOrJIX9zqzgYKMg0ALF0jzKwAcxkyyQpcvGQbN1qMMbNYwrJPdQ6eK6AQ
+5w==
+-----END CERTIFICATE-----
+`),
+		},
+	}, nil
+}

--- a/components/konvoy-control-plane/pkg/sds/provider/ca/types.go
+++ b/components/konvoy-control-plane/pkg/sds/provider/ca/types.go
@@ -1,0 +1,31 @@
+package ca
+
+import (
+	"bytes"
+
+	envoy_auth "github.com/envoyproxy/go-control-plane/envoy/api/v2/auth"
+	envoy_core "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
+
+	sds_provider "github.com/Kong/konvoy/components/konvoy-control-plane/pkg/sds/provider"
+)
+
+type MeshCaSecret struct {
+	PemCerts [][]byte
+}
+
+var _ sds_provider.Secret = &MeshCaSecret{}
+
+func (s *MeshCaSecret) ToResource(name string) *envoy_auth.Secret {
+	return &envoy_auth.Secret{
+		Name: name,
+		Type: &envoy_auth.Secret_ValidationContext{
+			ValidationContext: &envoy_auth.CertificateValidationContext{
+				TrustedCa: &envoy_core.DataSource{
+					Specifier: &envoy_core.DataSource_InlineBytes{
+						InlineBytes: []byte(bytes.Join(s.PemCerts, []byte("\n"))),
+					},
+				},
+			},
+		},
+	}
+}

--- a/components/konvoy-control-plane/pkg/sds/provider/identity/provider.go
+++ b/components/konvoy-control-plane/pkg/sds/provider/identity/provider.go
@@ -1,0 +1,75 @@
+package identity
+
+import (
+	"context"
+
+	sds_auth "github.com/Kong/konvoy/components/konvoy-control-plane/pkg/sds/auth"
+	sds_provider "github.com/Kong/konvoy/components/konvoy-control-plane/pkg/sds/provider"
+)
+
+func New() sds_provider.SecretProvider {
+	return &identityCertProvider{}
+}
+
+type identityCertProvider struct {
+}
+
+func (s *identityCertProvider) RequiresIdentity() bool {
+	return true
+}
+
+func (s *identityCertProvider) Get(ctx context.Context, name string, requestor sds_auth.Identity) (sds_provider.Secret, error) {
+	return &IdentityCertSecret{
+		PemCerts: [][]byte{[]byte(`
+-----BEGIN CERTIFICATE-----
+MIIC/TCCAeWgAwIBAgIRAKgVvRCrr87LMCVhIoU2k2gwDQYJKoZIhvcNAQELBQAw
+EjEQMA4GA1UEChMHQWNtZSBDbzAeFw0xOTA4MzAxMzQ4NDlaFw0yOTA4MzAwMTQ4
+NDlaMBIxEDAOBgNVBAoTB0FjbWUgQ28wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAw
+ggEKAoIBAQDTzb7dLh/7o/5eNatxF4RGRaXKJw85OjwmJKNESJ/4+ykFHOTh2Cg3
+BK5E9BXTWlEWMXlDTeMT3sqsJLyKCcQ38G64ue/gxvmqu2fMIXL/kABkta1gOXJF
+/QNCf/bjln7gxeTQzwfHHFuMCxq7qq0pdXkvp/gxXDKpJiwCYwOpZ5eT0lWbfUk6
+s/pOFniUSlLNg8gi3nNNUSZDVTN9HpivXWVO3IAWkupxYV/8rwwyzb5Z4jheFDVj
+G+It6BmItQK7snmoB4f1S8ELUT62nBu/pyyc6Y5AIN2wbzccdhhBBbTUHkZb7RoV
+l2fbgnoKFLNNXvYxKAeqq65EhnYXR1fXAgMBAAGjTjBMMA4GA1UdDwEB/wQEAwIC
+pDATBgNVHSUEDDAKBggrBgEFBQcDATAPBgNVHRMBAf8EBTADAQH/MBQGA1UdEQQN
+MAuCCWxvY2FsaG9zdDANBgkqhkiG9w0BAQsFAAOCAQEAXpxcNfSfEUIwOgfPtDYV
+ZzzLxx9m27m9cYyjaXWDFdXVDO/MTPjr/bf/7QVhf3ofoF9l/ojwkl+MwmhkV0Jx
+W2kfIyVQpsRh2KvYVv74Zn610zbvMLSTyEHuG2UWO0UeZfOsHmTEJsuJH54GEYJh
+DYHKHl31pG9OF1CwAZNyhmOz3nFrzRJr695rR0ZKwYvAfaTA/VUEymmPX3RiHf6W
+i18K5lY9hrNfNgI4gMVyNaWbAtJASzNdH1TIlvHv+P5pXqE2okfVFG/Gaw7tBfCJ
+EpmbGZ7aOrJIX9zqzgYKMg0ALF0jzKwAcxkyyQpcvGQbN1qMMbNYwrJPdQ6eK6AQ
+5w==
+-----END CERTIFICATE-----
+`),
+		},
+		PemKey: []byte(`
+-----BEGIN RSA PRIVATE KEY-----
+MIIEpAIBAAKCAQEA082+3S4f+6P+XjWrcReERkWlyicPOTo8JiSjREif+PspBRzk
+4dgoNwSuRPQV01pRFjF5Q03jE97KrCS8ignEN/BuuLnv4Mb5qrtnzCFy/5AAZLWt
+YDlyRf0DQn/245Z+4MXk0M8HxxxbjAsau6qtKXV5L6f4MVwyqSYsAmMDqWeXk9JV
+m31JOrP6ThZ4lEpSzYPIIt5zTVEmQ1UzfR6Yr11lTtyAFpLqcWFf/K8MMs2+WeI4
+XhQ1YxviLegZiLUCu7J5qAeH9UvBC1E+tpwbv6csnOmOQCDdsG83HHYYQQW01B5G
+W+0aFZdn24J6ChSzTV72MSgHqquuRIZ2F0dX1wIDAQABAoIBAAH2MuFbjwJGp5F5
+z8exXxFDjeCMchCmoG3+AuEcBxdIRD3+4YPR+7Vevrp2xEj72ippdOURsJu7gYcM
+pA5nPsEB4hSl7DnZvfA94h065hTF4asNH7j3bz6EtGYGR2QePbiZPKBOepT2h0aJ
+x8qbLxVmOCQf2yWh4/o7F0dCYYNNJP4RQrFSPHH27egmHGh7ts02HUf9tL5p5XGL
+SUIAqat0vWZsawIxuPhZCLPid8Z7V1Qc0YZNb3y7MbvH5NoJFntgONazTah8Qcgp
+yilFYNeg/FB+l5L447Ln18BhNWZ/BwTiwu67FD8DpvXTQUEovYT4sEE8vnuVakZT
+w5D0KoECgYEA//c1ovpJ7HqySxJSJNIAdZIibTV5Hdhk6uGD+t9Hn00JFpxoug6P
+Wbg76oJi9FSAv/I1UApjz+PQIgjAX0KjeeDiquIwqfuBsPsHpvoJ0YPoYYBLhBTv
+Y8gynvhFKmjPxaWudgxeZq8IAC0JTmN2HToy63oY4fniSKBzX2sAYhcCgYEA09UE
++GTrw5JMz0DSAoh1LxUJbJihVWgAHUCdAhbqF0cqMYcWzqE4otQi6DoesCPW/Brb
+B+gpGscgiVQgSopqugDkzfZHvm8SEZLJqrCI9rl/ji2G0JK/Ull1QL79JaO71RHZ
+v6eyjxdQk1eAunK/Mj4aO6tAMBiUURWCDYN7EEECgYEAj+l+154fV/z4J2sqkhcc
+OP4rqvkompYiz0hx+uf0jeUzGepgm1M6V7hUv5oFZtfn94OHY/QjgCvWxnvjJOwD
+m6/L4UYBFGEa3tWUzNXCFXEzgzYtvxpCKfjSNTzjLl/1iWuItkhn/xWjyu2HUPJs
+4yvomypvuQXUqv7DPz+a3IsCgYAslsNUEdI6uXnnikpqdBTOk0wHit0y4BBeF/K0
+tOQTgExWXowjdHY6eBLc9RbulqyzJmgCcxDr7QxhO88MQbSTcIq4++VAJZsVDePb
+RQufe45o/BZLowgYqnHu7gTVPnDUOcyu9fq0+gBg82NKW8r5JW9aLgL13MajhrZ4
+Z7uowQKBgQC++fEHyMUYDrTV+BdrVIgBSJTzz6decstMggrpDN8FEkjQdwFy00H+
+dRdy6yz9/TedG26tXZKxvZAX8YwjW/6hngvhljuhYUArqlbuF0/voKyQiEyKXbeb
+O3MYg+8MQDedqzs8MFRAvXrJy+C3zwMz8g6cMcWCzkzV0uOhzCm6mQ==
+-----END RSA PRIVATE KEY-----
+`),
+	}, nil
+}

--- a/components/konvoy-control-plane/pkg/sds/provider/identity/types.go
+++ b/components/konvoy-control-plane/pkg/sds/provider/identity/types.go
@@ -1,0 +1,37 @@
+package identity
+
+import (
+	"bytes"
+
+	envoy_auth "github.com/envoyproxy/go-control-plane/envoy/api/v2/auth"
+	envoy_core "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
+
+	sds_provider "github.com/Kong/konvoy/components/konvoy-control-plane/pkg/sds/provider"
+)
+
+type IdentityCertSecret struct {
+	PemCerts [][]byte
+	PemKey   []byte
+}
+
+var _ sds_provider.Secret = &IdentityCertSecret{}
+
+func (s *IdentityCertSecret) ToResource(name string) *envoy_auth.Secret {
+	return &envoy_auth.Secret{
+		Name: name,
+		Type: &envoy_auth.Secret_TlsCertificate{
+			TlsCertificate: &envoy_auth.TlsCertificate{
+				CertificateChain: &envoy_core.DataSource{
+					Specifier: &envoy_core.DataSource_InlineBytes{
+						InlineBytes: []byte(bytes.Join(s.PemCerts, []byte("\n"))),
+					},
+				},
+				PrivateKey: &envoy_core.DataSource{
+					Specifier: &envoy_core.DataSource_InlineBytes{
+						InlineBytes: []byte(s.PemKey),
+					},
+				},
+			},
+		},
+	}
+}

--- a/components/konvoy-control-plane/pkg/sds/provider/interfaces.go
+++ b/components/konvoy-control-plane/pkg/sds/provider/interfaces.go
@@ -1,0 +1,18 @@
+package provider
+
+import (
+	"context"
+
+	envoy_auth "github.com/envoyproxy/go-control-plane/envoy/api/v2/auth"
+
+	sds_auth "github.com/Kong/konvoy/components/konvoy-control-plane/pkg/sds/auth"
+)
+
+type Secret interface {
+	ToResource(name string) *envoy_auth.Secret
+}
+
+type SecretProvider interface {
+	RequiresIdentity() bool
+	Get(ctx context.Context, name string, requestor sds_auth.Identity) (Secret, error)
+}

--- a/components/konvoy-control-plane/pkg/sds/server/components.go
+++ b/components/konvoy-control-plane/pkg/sds/server/components.go
@@ -6,20 +6,104 @@ import (
 	"github.com/pkg/errors"
 
 	envoy "github.com/envoyproxy/go-control-plane/envoy/api/v2"
-	envoy_cache "github.com/envoyproxy/go-control-plane/pkg/cache"
+	envoy_auth "github.com/envoyproxy/go-control-plane/envoy/api/v2/auth"
+
+	konvoy_cp "github.com/Kong/konvoy/components/konvoy-control-plane/pkg/config/app/konvoy-cp"
+	core_mesh "github.com/Kong/konvoy/components/konvoy-control-plane/pkg/core/resources/apis/mesh"
+	core_manager "github.com/Kong/konvoy/components/konvoy-control-plane/pkg/core/resources/manager"
+	core_store "github.com/Kong/konvoy/components/konvoy-control-plane/pkg/core/resources/store"
+	core_runtime "github.com/Kong/konvoy/components/konvoy-control-plane/pkg/core/runtime"
+	core_xds "github.com/Kong/konvoy/components/konvoy-control-plane/pkg/core/xds"
+	sds_auth "github.com/Kong/konvoy/components/konvoy-control-plane/pkg/sds/auth"
+	k8s_sds_auth "github.com/Kong/konvoy/components/konvoy-control-plane/pkg/sds/auth/k8s"
+	universal_sds_auth "github.com/Kong/konvoy/components/konvoy-control-plane/pkg/sds/auth/universal"
+	sds_provider "github.com/Kong/konvoy/components/konvoy-control-plane/pkg/sds/provider"
+	ca_sds_provider "github.com/Kong/konvoy/components/konvoy-control-plane/pkg/sds/provider/ca"
+	identity_sds_provider "github.com/Kong/konvoy/components/konvoy-control-plane/pkg/sds/provider/identity"
 )
 
-func DefaultSecretDiscoveryHandler() SecretDiscoveryHandler {
-	return SecretDiscoveryHandlerFunc(func(ctx context.Context, req envoy.DiscoveryRequest) (envoy_cache.Response, error) {
-		block := make(chan struct{})
-		// block indefinitely
-		<-block
-		return envoy_cache.Response{}, errors.New("not implemented")
-	})
+const (
+	MeshCaResource       = "mesh_ca"
+	IdentityCertResource = "identity_cert"
+)
+
+func DefaultAuthenticator(rt core_runtime.Runtime) (sds_auth.Authenticator, error) {
+	switch env := rt.Config().Environment; env {
+	case konvoy_cp.KubernetesEnvironment:
+		return k8s_sds_auth.New(), nil
+	case konvoy_cp.UniversalEnvironment:
+		return universal_sds_auth.New(), nil
+	default:
+		return nil, errors.Errorf("unable to choose SDS authenticator for environment type %q", env)
+	}
 }
 
-type SecretDiscoveryHandlerFunc func(ctx context.Context, req envoy.DiscoveryRequest) (envoy_cache.Response, error)
+func DefaultDataplaneResolver(resourceManager core_manager.ResourceManager) func(core_xds.ProxyId) (*core_mesh.DataplaneResource, error) {
+	return func(proxyId core_xds.ProxyId) (*core_mesh.DataplaneResource, error) {
+		ctx := context.Background()
+		dataplane := &core_mesh.DataplaneResource{}
+		if err := resourceManager.Get(ctx, dataplane, core_store.GetBy(proxyId.ToResourceKey())); err != nil {
+			return nil, err
+		}
+		return dataplane, nil
+	}
+}
 
-func (f SecretDiscoveryHandlerFunc) Handle(ctx context.Context, req envoy.DiscoveryRequest) (envoy_cache.Response, error) {
+func DefaultMeshCaProvider() sds_provider.SecretProvider {
+	return ca_sds_provider.New()
+}
+
+func DefaultIdentityCertProvider() sds_provider.SecretProvider {
+	return identity_sds_provider.New()
+}
+
+func GetSecretProvider(resource string) (sds_provider.SecretProvider, error) {
+	switch resource {
+	case MeshCaResource:
+		return DefaultMeshCaProvider(), nil
+	case IdentityCertResource:
+		return DefaultIdentityCertProvider(), nil
+	default:
+		return nil, errors.Errorf("SDS request for %q resource is not supported", resource)
+	}
+}
+
+func DefaultSecretDiscoveryHandler(rt core_runtime.Runtime) (SecretDiscoveryHandler, error) {
+	authenticator, err := DefaultAuthenticator(rt)
+	if err != nil {
+		return nil, err
+	}
+	return SecretDiscoveryHandlerFunc(func(ctx context.Context, req envoy.DiscoveryRequest) (*envoy_auth.Secret, error) {
+		resource := req.ResourceNames[0]
+		provider, err := GetSecretProvider(resource)
+		if err != nil {
+			return nil, err
+		}
+		proxyId, err := core_xds.ParseProxyId(req.Node)
+		if err != nil {
+			return nil, errors.Wrap(err, "SDS request must have a valid Proxy Id")
+		}
+		requestor := sds_auth.Identity{Mesh: proxyId.Mesh}
+		if provider.RequiresIdentity() {
+			credential, err := sds_auth.ExtractCredential(ctx)
+			if err != nil {
+				return nil, err
+			}
+			requestor, err = authenticator.Authenticate(ctx, *proxyId, credential)
+			if err != nil {
+				return nil, err
+			}
+		}
+		secret, err := provider.Get(ctx, resource, requestor)
+		if err != nil {
+			return nil, err
+		}
+		return secret.ToResource(resource), nil
+	}), nil
+}
+
+type SecretDiscoveryHandlerFunc func(ctx context.Context, req envoy.DiscoveryRequest) (*envoy_auth.Secret, error)
+
+func (f SecretDiscoveryHandlerFunc) Handle(ctx context.Context, req envoy.DiscoveryRequest) (*envoy_auth.Secret, error) {
 	return f(ctx, req)
 }

--- a/components/konvoy-control-plane/pkg/sds/server/sds_test.go
+++ b/components/konvoy-control-plane/pkg/sds/server/sds_test.go
@@ -8,7 +8,6 @@ import (
 
 	envoy "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	envoy_auth "github.com/envoyproxy/go-control-plane/envoy/api/v2/auth"
-	envoy_cache "github.com/envoyproxy/go-control-plane/pkg/cache"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -50,14 +49,8 @@ var _ = Describe("Sds", func() {
 
 	It("should support valid SDS requests", func(done Done) {
 		// given
-		handler := SecretDiscoveryHandlerFunc(func(ctx context.Context, req envoy.DiscoveryRequest) (envoy_cache.Response, error) {
-			return envoy_cache.Response{
-				Request: req,
-				Version: "v0",
-				Resources: []envoy_cache.Resource{
-					&envoy_auth.Secret{},
-				},
-			}, nil
+		handler := SecretDiscoveryHandlerFunc(func(ctx context.Context, req envoy.DiscoveryRequest) (*envoy_auth.Secret, error) {
+			return &envoy_auth.Secret{}, nil
 		})
 		sds := NewServer(handler, nil, test_logr.NewTestLogger(GinkgoT()))
 

--- a/components/konvoy-control-plane/pkg/sds/server/server.go
+++ b/components/konvoy-control-plane/pkg/sds/server/server.go
@@ -11,9 +11,13 @@ var (
 )
 
 func SetupServer(rt core_runtime.Runtime) error {
+	handler, err := DefaultSecretDiscoveryHandler(rt)
+	if err != nil {
+		return err
+	}
 	callbacks := util_xds.CallbacksChain{
 		util_xds.LoggingCallbacks{Log: sdsServerLog},
 	}
-	srv := NewServer(DefaultSecretDiscoveryHandler(), callbacks, sdsServerLog)
+	srv := NewServer(handler, callbacks, sdsServerLog)
 	return core_runtime.Add(rt, &grpcServer{srv, *rt.Config().SdsServer})
 }


### PR DESCRIPTION
changes:
* add stab implementations that return `mesh_ca` certificate (to validate remote side) and `indentity_cert` certificate (to authenticate itself to the remote side)
