### PR TITLE
control-plane: sds: add universal authenticator and k8s authenticator

### DIFF
--- a/components/konvoy-control-plane/pkg/sds/auth/common/identity.go
+++ b/components/konvoy-control-plane/pkg/sds/auth/common/identity.go
@@ -1,0 +1,26 @@
+package common
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+
+	mesh_proto "github.com/Kong/konvoy/components/konvoy-control-plane/api/mesh/v1alpha1"
+	core_mesh "github.com/Kong/konvoy/components/konvoy-control-plane/pkg/core/resources/apis/mesh"
+	core_xds "github.com/Kong/konvoy/components/konvoy-control-plane/pkg/core/xds"
+	sds_auth "github.com/Kong/konvoy/components/konvoy-control-plane/pkg/sds/auth"
+)
+
+type DataplaneResolver func(context.Context, core_xds.ProxyId) (*core_mesh.DataplaneResource, error)
+
+func GetDataplaneIdentity(dataplane *core_mesh.DataplaneResource) (sds_auth.Identity, error) {
+	services := dataplane.Spec.Tags().Values(mesh_proto.ServiceTag)
+	if len(services) == 0 {
+		return sds_auth.Identity{}, errors.Errorf("Dataplane has no services associated with it")
+	}
+	service := services[0]
+	return sds_auth.Identity{
+		Mesh:    dataplane.Meta.GetMesh(),
+		Service: service,
+	}, nil
+}

--- a/components/konvoy-control-plane/pkg/sds/auth/k8s/authenticator.go
+++ b/components/konvoy-control-plane/pkg/sds/auth/k8s/authenticator.go
@@ -2,19 +2,66 @@ package stub
 
 import (
 	"context"
+	"strings"
 
 	"github.com/pkg/errors"
 
 	core_xds "github.com/Kong/konvoy/components/konvoy-control-plane/pkg/core/xds"
 	sds_auth "github.com/Kong/konvoy/components/konvoy-control-plane/pkg/sds/auth"
+	common_auth "github.com/Kong/konvoy/components/konvoy-control-plane/pkg/sds/auth/common"
+
+	kube_auth "k8s.io/api/authentication/v1"
+	kube_client "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func New() sds_auth.Authenticator {
-	return kubeAuthenticator{}
+func New(client kube_client.Client, dataplaneResolver common_auth.DataplaneResolver) sds_auth.Authenticator {
+	return &kubeAuthenticator{
+		client:            client,
+		dataplaneResolver: dataplaneResolver,
+	}
 }
 
-type kubeAuthenticator struct{}
+type kubeAuthenticator struct {
+	client            kube_client.Client
+	dataplaneResolver common_auth.DataplaneResolver
+}
 
-func (_ kubeAuthenticator) Authenticate(ctx context.Context, proxyId core_xds.ProxyId, credential sds_auth.Credential) (sds_auth.Identity, error) {
-	return sds_auth.Identity{}, errors.New("not implemented")
+func (k *kubeAuthenticator) Authenticate(ctx context.Context, proxyId core_xds.ProxyId, credential sds_auth.Credential) (sds_auth.Identity, error) {
+	if err := k.reviewToken(ctx, proxyId, credential); err != nil {
+		return sds_auth.Identity{}, err
+	}
+	// at this point we know that proxyId belongs to the same namespace as token.
+	// since legacy k8s tokens are not bound to a specific Pod,
+	// we have to rely on information included into proxyId.
+	dataplane, err := k.dataplaneResolver(ctx, proxyId)
+	if err != nil {
+		return sds_auth.Identity{}, errors.Wrapf(err, "unable to find Dataplane for proxy %q", proxyId)
+	}
+	return common_auth.GetDataplaneIdentity(dataplane)
+}
+
+func (k *kubeAuthenticator) reviewToken(ctx context.Context, proxyId core_xds.ProxyId, credential sds_auth.Credential) error {
+	tokenReview := &kube_auth.TokenReview{
+		Spec: kube_auth.TokenReviewSpec{
+			Token: string(credential),
+		},
+	}
+	if err := k.client.Create(ctx, tokenReview); err != nil {
+		return errors.Wrap(err, "authentication failed: call to TokenReview API failed")
+	}
+	if !tokenReview.Status.Authenticated {
+		return errors.Errorf("authentication failed: token doesn't belong to a valid user")
+	}
+	userInfo := strings.Split(tokenReview.Status.User.Username, ":")
+	if len(userInfo) != 4 {
+		return errors.Errorf("authentication failed: username inside TokenReview response has unexpected format: %q", tokenReview.Status.User.Username)
+	}
+	if !(userInfo[0] == "system" && userInfo[1] == "serviceaccount") {
+		return errors.Errorf("authentication failed: token must belong to a k8s system account, got %q", tokenReview.Status.User.Username)
+	}
+	namespace := userInfo[2]
+	if namespace != proxyId.Namespace {
+		return errors.Errorf("authentication failed: token belongs to a namespace (%q) different from proxyId (%q)", namespace, proxyId.Namespace)
+	}
+	return nil
 }

--- a/components/konvoy-control-plane/pkg/sds/auth/universal/authenticator.go
+++ b/components/konvoy-control-plane/pkg/sds/auth/universal/authenticator.go
@@ -7,15 +7,23 @@ import (
 
 	core_xds "github.com/Kong/konvoy/components/konvoy-control-plane/pkg/core/xds"
 	sds_auth "github.com/Kong/konvoy/components/konvoy-control-plane/pkg/sds/auth"
+	common_auth "github.com/Kong/konvoy/components/konvoy-control-plane/pkg/sds/auth/common"
 )
 
-func New() sds_auth.Authenticator {
-	return universalAuthenticator{}
+func New(dataplaneResolver common_auth.DataplaneResolver) sds_auth.Authenticator {
+	return &universalAuthenticator{
+		dataplaneResolver: dataplaneResolver,
+	}
 }
 
 type universalAuthenticator struct {
+	dataplaneResolver common_auth.DataplaneResolver
 }
 
-func (_ universalAuthenticator) Authenticate(ctx context.Context, proxyId core_xds.ProxyId, credential sds_auth.Credential) (sds_auth.Identity, error) {
-	return sds_auth.Identity{}, errors.New("not implemented")
+func (u *universalAuthenticator) Authenticate(ctx context.Context, proxyId core_xds.ProxyId, credential sds_auth.Credential) (sds_auth.Identity, error) {
+	dataplane, err := u.dataplaneResolver(ctx, proxyId)
+	if err != nil {
+		return sds_auth.Identity{}, errors.Wrapf(err, "unable to find Dataplane for proxy %q", proxyId)
+	}
+	return common_auth.GetDataplaneIdentity(dataplane)
 }


### PR DESCRIPTION
changes:
* add Authenticator for `universal` mode - only check that `Dataplane` exists
* add Authenticator for `k8s` mode - authenticate against k8s API + check that `Dataplane` exists
