### PR TITLE
cmd: add `version` command to all binaries

### DIFF
--- a/components/konvoy-control-plane/Makefile
+++ b/components/konvoy-control-plane/Makefile
@@ -24,6 +24,23 @@
 
 PKG_LIST := ./... ./api/... ./pkg/plugins/resources/k8s/native/...
 
+BUILD_INFO_GIT_TAG ?= $(shell git describe --tags 2>/dev/null || echo unknown)
+BUILD_INFO_GIT_COMMIT ?= $(shell git rev-parse HEAD 2>/dev/null || echo unknown)
+BUILD_INFO_BUILD_DATE ?= $(shell date -u +"%Y-%m-%dT%H:%M:%SZ" || echo unknown)
+BUILD_INFO_VERSION ?= $(shell prefix=$$(echo $(BUILD_INFO_GIT_TAG) | cut -c 1); if [ "$${prefix}" = "v" ]; then echo $(BUILD_INFO_GIT_TAG) | cut -c 2- ; else echo $(BUILD_INFO_GIT_TAG) ; fi)
+
+build_info_fields := \
+	version=$(BUILD_INFO_VERSION) \
+	gitTag=$(BUILD_INFO_GIT_TAG) \
+	gitCommit=$(BUILD_INFO_GIT_COMMIT) \
+	buildDate=$(BUILD_INFO_BUILD_DATE)
+build_info_ld_flags := $(foreach entry,$(build_info_fields), -X github.com/Kong/konvoy/components/konvoy-control-plane/pkg/version.$(entry))
+
+LD_FLAGS := -ldflags="-s -w $(build_info_ld_flags)"
+GO_BUILD := CGO_ENABLED=0 go build -v $(LD_FLAGS)
+GO_RUN := CGO_ENABLED=0 go run $(LD_FLAGS)
+GO_TEST := go test $(LD_FLAGS)
+
 BUILD_DIR ?= build
 BUILD_ARTIFACTS_DIR ?= $(BUILD_DIR)/artifacts
 
@@ -317,27 +334,27 @@ check: generate fmt vet docs ## Dev: Run code checks (go fmt, go vet, ...)
 
 test: ## Dev: Run tests
 	mkdir -p "$(shell dirname "$(COVERAGE_PROFILE)")"
-	go test $(GO_TEST_OPTS) -race -covermode=atomic -coverpkg=./... -coverprofile="$(COVERAGE_PROFILE)" $(PKG_LIST)
+	$(GO_TEST) $(GO_TEST_OPTS) -race -covermode=atomic -coverpkg=./... -coverprofile="$(COVERAGE_PROFILE)" $(PKG_LIST)
 	go tool cover -html="$(COVERAGE_PROFILE)" -o "$(COVERAGE_REPORT_HTML)"
 
 integration: ## Dev: Run integration tests
 	mkdir -p "$(shell dirname "$(COVERAGE_INTEGRATION_PROFILE)")"
-	tools/test/run-integration-tests.sh "go test -race -covermode=atomic -tags=integration -count=1 -coverpkg=./... -coverprofile=$(COVERAGE_INTEGRATION_PROFILE) $(PKG_LIST)"
+	tools/test/run-integration-tests.sh '$(GO_TEST) -race -covermode=atomic -tags=integration -count=1 -coverpkg=./... -coverprofile=$(COVERAGE_INTEGRATION_PROFILE) $(PKG_LIST)'
 	go tool cover -html="$(COVERAGE_INTEGRATION_PROFILE)" -o "$(COVERAGE_INTEGRATION_REPORT_HTML)"
 
 build: build/konvoy-cp build/kuma-dp build/kumactl build/konvoy-injector ## Dev: Build all binaries
 
 build/konvoy-cp: ## Dev: Build `Control Plane` binary
-	CGO_ENABLED=0 go build -ldflags="-s -w" -v -o ${BUILD_ARTIFACTS_DIR}/konvoy-control-plane/konvoy-control-plane ./app/konvoy-cp
+	$(GO_BUILD) -o ${BUILD_ARTIFACTS_DIR}/konvoy-control-plane/konvoy-control-plane ./app/konvoy-cp
 
 build/kuma-dp: ## Dev: Build `kuma-dp` binary
-	CGO_ENABLED=0 go build -ldflags="-s -w" -v -o ${BUILD_ARTIFACTS_DIR}/kuma-dp/kuma-dp ./app/kuma-dp
+	$(GO_BUILD) -o ${BUILD_ARTIFACTS_DIR}/kuma-dp/kuma-dp ./app/kuma-dp
 
 build/kumactl: ## Dev: Build `kumactl` binary
-	CGO_ENABLED=0 go build -ldflags="-s -w" -v -o $(BUILD_KUMACTL_DIR)/kumactl ./app/kumactl
+	$(GO_BUILD) -o $(BUILD_KUMACTL_DIR)/kumactl ./app/kumactl
 
 build/konvoy-injector: ## Dev: Build `konvoy-injector` binary
-	CGO_ENABLED=0 go build -ldflags="-s -w" -v -o ${BUILD_ARTIFACTS_DIR}/konvoy-injector/konvoy-injector ./app/konvoy-injector
+	$(GO_BUILD) -o ${BUILD_ARTIFACTS_DIR}/konvoy-injector/konvoy-injector ./app/konvoy-injector
 
 run/k8s: fmt vet ## Dev: Run Control Plane locally in Kubernetes mode
 	KUBECONFIG=$(KIND_KUBECONFIG) make crd/upgrade -C pkg/plugins/resources/k8s/native
@@ -347,7 +364,7 @@ run/k8s: fmt vet ## Dev: Run Control Plane locally in Kubernetes mode
     KONVOY_HTTP_PORT=$(CP_HTTP_PORT) \
     KONVOY_ENVIRONMENT=kubernetes \
     KONVOY_STORE_TYPE=kubernetes \
-	go run ./app/konvoy-cp/main.go run
+	$(GO_RUN) ./app/konvoy-cp/main.go run
 
 run/universal/memory: fmt vet ## Dev: Run Control Plane locally in universal mode with in-memory store
 	KONVOY_SDS_SERVER_GRPC_PORT=$(SDS_GRPC_PORT) \
@@ -355,7 +372,7 @@ run/universal/memory: fmt vet ## Dev: Run Control Plane locally in universal mod
 	KONVOY_HTTP_PORT=$(CP_HTTP_PORT) \
 	KONVOY_ENVIRONMENT=universal \
 	KONVOY_STORE_TYPE=memory \
-	go run ./app/konvoy-cp/main.go run
+	$(GO_RUN) ./app/konvoy-cp/main.go run
 
 start/postgres: ## Boostrap: start Postgres for Control Plane with initial schema
 	docker-compose -f tools/postgres/docker-compose.yaml up $(DOCKER_COMPOSE_OPTIONS) -d
@@ -372,7 +389,7 @@ run/universal/postgres: fmt vet ## Dev: Run Control Plane locally in universal m
 	KONVOY_STORE_POSTGRES_USER=konvoy \
 	KONVOY_STORE_POSTGRES_PASSWORD=konvoy \
 	KONVOY_STORE_POSTGRES_DB_NAME=konvoy \
-	go run ./app/konvoy-cp/main.go run
+	$(GO_RUN) ./app/konvoy-cp/main.go run
 
 curl/listeners: EXAMPLE_ENVOY_ID=$(KIND_EXAMPLE_ENVOY_ID)
 curl/listeners: ## Dev: Make Discovery request to LDS
@@ -513,7 +530,7 @@ generate/test/cert/konvoy-injector:  ## Dev: Generate TLS cert for Konvoy Inject
 run/konvoy-injector: ## Dev: Run Konvoy Injector locally
 	KUBECONFIG=$(KIND_KUBECONFIG) \
 	KONVOY_INJECTOR_WEBHOOK_SERVER_CERT_DIR=$(shell pwd)/app/konvoy-injector/cmd/testdata \
-	go run ./app/konvoy-injector/main.go run
+	$(GO_RUN) ./app/konvoy-injector/main.go run
 
 test/konvoy-injector: PKG_LIST=./app/konvoy-injector/... ./pkg/config/app/konvoy-injector/...
 test/konvoy-injector: test ## Dev: Run Konvoy Injector tests only
@@ -522,7 +539,7 @@ run/kuma-dp: ## Dev: Run `kuma-dp` locally
 	KUMA_CONTROL_PLANE_BOOTSTRAP_SERVER_URL=http://localhost:5682 \
 	KUMA_DATAPLANE_ID=$(EXAMPLE_ENVOY_ID) \
 	KUMA_DATAPLANE_ADMIN_PORT=$(ENVOY_ADMIN_PORT) \
-	go run ./app/kuma-dp/main.go run
+	$(GO_RUN) ./app/kuma-dp/main.go run
 
 test/kuma-dp: PKG_LIST=./app/kuma-dp/... ./pkg/config/app/kuma-dp/...
 test/kuma-dp: test ## Dev: Run `kuma-dp` tests only

--- a/components/konvoy-control-plane/app/konvoy-cp/cmd/root.go
+++ b/components/konvoy-control-plane/app/konvoy-cp/cmd/root.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/Kong/konvoy/components/konvoy-control-plane/pkg/cmd/version"
 	"github.com/Kong/konvoy/components/konvoy-control-plane/pkg/core"
 )
 
@@ -30,6 +31,7 @@ func newRootCmd() *cobra.Command {
 	cmd.PersistentFlags().BoolVar(&args.debug, "debug", true, "enable debug-level logging")
 	// sub-commands
 	cmd.AddCommand(newRunCmd())
+	cmd.AddCommand(version.NewVersionCmd())
 	return cmd
 }
 

--- a/components/konvoy-control-plane/app/konvoy-injector/cmd/root.go
+++ b/components/konvoy-control-plane/app/konvoy-injector/cmd/root.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/Kong/konvoy/components/konvoy-control-plane/pkg/cmd/version"
 	"github.com/Kong/konvoy/components/konvoy-control-plane/pkg/core"
 )
 
@@ -30,6 +31,7 @@ func newRootCmd() *cobra.Command {
 	cmd.PersistentFlags().BoolVar(&args.debug, "debug", true, "enable debug-level logging")
 	// sub-commands
 	cmd.AddCommand(newRunCmd())
+	cmd.AddCommand(version.NewVersionCmd())
 	return cmd
 }
 

--- a/components/konvoy-control-plane/app/kuma-dp/cmd/root.go
+++ b/components/konvoy-control-plane/app/kuma-dp/cmd/root.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/Kong/konvoy/components/konvoy-control-plane/pkg/cmd/version"
 	"github.com/Kong/konvoy/components/konvoy-control-plane/pkg/core"
 )
 
@@ -30,6 +31,7 @@ func newRootCmd() *cobra.Command {
 	cmd.PersistentFlags().BoolVar(&args.debug, "debug", true, "enable debug-level logging")
 	// sub-commands
 	cmd.AddCommand(newRunCmd())
+	cmd.AddCommand(version.NewVersionCmd())
 	return cmd
 }
 

--- a/components/konvoy-control-plane/app/kumactl/cmd/root.go
+++ b/components/konvoy-control-plane/app/kumactl/cmd/root.go
@@ -7,6 +7,7 @@ import (
 	"github.com/Kong/konvoy/components/konvoy-control-plane/app/kumactl/cmd/inspect"
 	"github.com/Kong/konvoy/components/konvoy-control-plane/app/kumactl/cmd/install"
 	kumactl_cmd "github.com/Kong/konvoy/components/konvoy-control-plane/app/kumactl/pkg/cmd"
+	"github.com/Kong/konvoy/components/konvoy-control-plane/pkg/cmd/version"
 	"github.com/spf13/cobra"
 	"os"
 
@@ -39,6 +40,7 @@ func NewRootCmd(root *kumactl_cmd.RootContext) *cobra.Command {
 	cmd.AddCommand(get.NewGetCmd(root))
 	cmd.AddCommand(inspect.NewInspectCmd(root))
 	cmd.AddCommand(apply.NewApplyCmd(root))
+	cmd.AddCommand(version.NewVersionCmd())
 	return cmd
 }
 

--- a/components/konvoy-control-plane/docs/cmd/kumactl/HELP.md
+++ b/components/konvoy-control-plane/docs/cmd/kumactl/HELP.md
@@ -13,6 +13,7 @@ Available Commands:
   help        Help about any command
   inspect     Inspect Kuma resources
   install     Install Kuma on Kubernetes
+  version     Print version
 
 Flags:
       --config-file string   path to the configuration file to use

--- a/components/konvoy-control-plane/pkg/api-server/index_ws.go
+++ b/components/konvoy-control-plane/pkg/api-server/index_ws.go
@@ -1,13 +1,17 @@
 package api_server
 
-import "github.com/emicklei/go-restful"
+import (
+	"github.com/emicklei/go-restful"
+
+	konvoy_version "github.com/Kong/konvoy/components/konvoy-control-plane/pkg/version"
+)
 
 func indexWs() *restful.WebService {
 	ws := new(restful.WebService)
 	ws.Route(ws.GET("/").To(func(req *restful.Request, resp *restful.Response) {
 		info := map[string]string{
 			"tagline": "Kuma",
-			"version": "0.1.0",
+			"version": konvoy_version.Build.Version,
 		}
 		if err := resp.WriteAsJson(info); err != nil {
 			log.Error(err, "Could not write the index response")

--- a/components/konvoy-control-plane/pkg/api-server/index_ws_test.go
+++ b/components/konvoy-control-plane/pkg/api-server/index_ws_test.go
@@ -7,10 +7,29 @@ import (
 	. "github.com/onsi/gomega"
 	"io/ioutil"
 	"net/http"
+
+	konvoy_version "github.com/Kong/konvoy/components/konvoy-control-plane/pkg/version"
 )
 
 var _ = Describe("Index WS", func() {
+
+	var backupBuildInfo konvoy_version.BuildInfo
+	BeforeEach(func() {
+		backupBuildInfo = konvoy_version.Build
+	})
+	AfterEach(func() {
+		konvoy_version.Build = backupBuildInfo
+	})
+
 	It("should return the version of Kuma Control Plane", func(done Done) {
+		// given
+		konvoy_version.Build = konvoy_version.BuildInfo{
+			Version:   "1.2.3",
+			GitTag:    "v1.2.3",
+			GitCommit: "91ce236824a9d875601679aa80c63783fb0e8725",
+			BuildDate: "2019-08-07T11:26:06Z",
+		}
+
 		// setup
 		resourceStore := memory.NewStore()
 		apiServer := createTestApiServer(resourceStore, *api_server.DefaultApiServerConfig())
@@ -39,7 +58,7 @@ var _ = Describe("Index WS", func() {
 		expected := `
 		{
 			"tagline": "Kuma",
-			"version": "0.1.0"
+			"version": "1.2.3"
 		}
 `
 		Expect(body).To(MatchJSON(expected))

--- a/components/konvoy-control-plane/pkg/cmd/version/version.go
+++ b/components/konvoy-control-plane/pkg/cmd/version/version.go
@@ -1,0 +1,37 @@
+package version
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	konvoy_version "github.com/Kong/konvoy/components/konvoy-control-plane/pkg/version"
+)
+
+func NewVersionCmd() *cobra.Command {
+	args := struct {
+		detailed bool
+	}{}
+	cmd := &cobra.Command{
+		Use:   "version",
+		Short: "Print version",
+		Long:  `Print version.`,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			buildInfo := konvoy_version.Build
+
+			if args.detailed {
+				cmd.Println(fmt.Sprintf("Version:    %s", buildInfo.Version))
+				cmd.Println(fmt.Sprintf("Git Tag:    %s", buildInfo.GitTag))
+				cmd.Println(fmt.Sprintf("Git Commit: %s", buildInfo.GitCommit))
+				cmd.Println(fmt.Sprintf("Build Date: %s", buildInfo.BuildDate))
+			} else {
+				cmd.Println(buildInfo.Version)
+			}
+
+			return nil
+		},
+	}
+	// flags
+	cmd.PersistentFlags().BoolVarP(&args.detailed, "detailed", "a", false, "Print detailed version")
+	return cmd
+}

--- a/components/konvoy-control-plane/pkg/cmd/version/version_suite_test.go
+++ b/components/konvoy-control-plane/pkg/cmd/version/version_suite_test.go
@@ -1,0 +1,13 @@
+package version_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestVersion(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Version Suite")
+}

--- a/components/konvoy-control-plane/pkg/cmd/version/version_test.go
+++ b/components/konvoy-control-plane/pkg/cmd/version/version_test.go
@@ -1,0 +1,90 @@
+package version_test
+
+import (
+	"bytes"
+	"strings"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+
+	. "github.com/Kong/konvoy/components/konvoy-control-plane/pkg/cmd/version"
+
+	"github.com/spf13/cobra"
+
+	konvoy_version "github.com/Kong/konvoy/components/konvoy-control-plane/pkg/version"
+)
+
+var _ = Describe("version", func() {
+
+	var backupBuildInfo konvoy_version.BuildInfo
+	BeforeEach(func() {
+		backupBuildInfo = konvoy_version.Build
+	})
+	AfterEach(func() {
+		konvoy_version.Build = backupBuildInfo
+	})
+
+	var rootCmd *cobra.Command
+	var buf *bytes.Buffer
+
+	BeforeEach(func() {
+		rootCmd = &cobra.Command{
+			Use: "app",
+		}
+		rootCmd.AddCommand(NewVersionCmd())
+
+		buf = &bytes.Buffer{}
+		rootCmd.SetOut(buf)
+	})
+
+	type testCase struct {
+		buildInfo konvoy_version.BuildInfo
+		args      []string
+		expected  string
+	}
+
+	DescribeTable("should format output properly",
+		func(given testCase) {
+			// setup
+			konvoy_version.Build = konvoy_version.BuildInfo{
+				Version:   "1.2.3",
+				GitTag:    "v1.2.3",
+				GitCommit: "91ce236824a9d875601679aa80c63783fb0e8725",
+				BuildDate: "2019-08-07T11:26:06Z",
+			}
+
+			// given
+			rootCmd.SetArgs(given.args)
+
+			// when
+			err := rootCmd.Execute()
+			// then
+			Expect(err).ToNot(HaveOccurred())
+			// and
+			Expect(strings.TrimSpace(buf.String())).To(Equal(strings.TrimSpace(given.expected)))
+		},
+		Entry("app version", testCase{
+			args:     []string{"version"},
+			expected: `1.2.3`,
+		}),
+		Entry("app version --detailed", testCase{
+			args: []string{"version", "--detailed"},
+			expected: `
+Version:    1.2.3
+Git Tag:    v1.2.3
+Git Commit: 91ce236824a9d875601679aa80c63783fb0e8725
+Build Date: 2019-08-07T11:26:06Z
+`,
+		}),
+		Entry("app version -a", testCase{
+			args: []string{"version", "-a"},
+			expected: `
+Version:    1.2.3
+Git Tag:    v1.2.3
+Git Commit: 91ce236824a9d875601679aa80c63783fb0e8725
+Build Date: 2019-08-07T11:26:06Z
+`,
+		}),
+	)
+})

--- a/components/konvoy-control-plane/pkg/version/version.go
+++ b/components/konvoy-control-plane/pkg/version/version.go
@@ -1,0 +1,28 @@
+package version
+
+var (
+	version   = "unknown"
+	gitTag    = "unknown"
+	gitCommit = "unknown"
+	buildDate = "unknown"
+)
+
+type BuildInfo struct {
+	Version   string
+	GitTag    string
+	GitCommit string
+	BuildDate string
+}
+
+var (
+	Build BuildInfo
+)
+
+func init() {
+	Build = BuildInfo{
+		Version:   version,
+		GitTag:    gitTag,
+		GitCommit: gitCommit,
+		BuildDate: buildDate,
+	}
+}


### PR DESCRIPTION
changes:
* add `pkg/version/BuildInfo` type to represent a version
* add `version` sub-command to all cli tools
* update Makefile to set `pkg/version/BuildInfo` as part of `go` builds  