### PR TITLE
kuma-dp: use separate parameters for `mesh` name and `dataplane` name

### DIFF
--- a/components/konvoy-control-plane/Makefile
+++ b/components/konvoy-control-plane/Makefile
@@ -62,8 +62,9 @@ SDS_GRPC_PORT ?= 5677
 LOCAL_IP ?= $(shell ifconfig en0 | grep 'inet ' | awk '{print $$2}')
 
 ENVOY_BINARY ?= envoy
-EXAMPLE_ENVOY_ID ?= default.example
-EXAMPLE_ENVOY_CLUSTER ?= demo
+EXAMPLE_DATAPLANE_MESH ?= default
+EXAMPLE_DATAPLANE_NAME ?= example
+EXAMPLE_ENVOY_ID ?= $(EXAMPLE_DATAPLANE_MESH).$(EXAMPLE_DATAPLANE_NAME)
 EXAMPLE_ENVOY_IP ?= $(LOCAL_IP)
 EXAMPLE_ENVOY_PORT ?= 8080
 ENVOY_ADMIN_PORT ?= 9901
@@ -72,8 +73,11 @@ EXAMPLE_NAMESPACE ?= konvoy-demo
 
 KIND_KUBECONFIG = $(shell kind get kubeconfig-path --name=konvoy)
 
-define KIND_EXAMPLE_ENVOY_ID
-$(shell KUBECONFIG=$(KIND_KUBECONFIG) kubectl -n $(EXAMPLE_NAMESPACE) exec $$(kubectl -n $(EXAMPLE_NAMESPACE) get pods -l app=demo-app -o=jsonpath='{.items[0].metadata.name}') -c konvoy-sidecar printenv KUMA_DATAPLANE_ID)
+define KIND_EXAMPLE_DATAPLANE_MESH
+$(shell KUBECONFIG=$(KIND_KUBECONFIG) kubectl -n $(EXAMPLE_NAMESPACE) exec $$(kubectl -n $(EXAMPLE_NAMESPACE) get pods -l app=demo-app -o=jsonpath='{.items[0].metadata.name}') -c konvoy-sidecar printenv KUMA_DATAPLANE_MESH)
+endef
+define KIND_EXAMPLE_DATAPLANE_NAME
+$(shell KUBECONFIG=$(KIND_KUBECONFIG) kubectl -n $(EXAMPLE_NAMESPACE) exec $$(kubectl -n $(EXAMPLE_NAMESPACE) get pods -l app=demo-app -o=jsonpath='{.items[0].metadata.name}') -c konvoy-sidecar printenv KUMA_DATAPLANE_NAME)
 endef
 
 SIMPLE_DISCOVERY_REQUEST ?= '{"node": {"id": "$(EXAMPLE_ENVOY_ID)", "metadata": {"IPS": "$(EXAMPLE_ENVOY_IP)", "PORTS": "$(EXAMPLE_ENVOY_PORT)"}}}'
@@ -391,22 +395,24 @@ run/universal/postgres: fmt vet ## Dev: Run Control Plane locally in universal m
 	KONVOY_STORE_POSTGRES_DB_NAME=konvoy \
 	$(GO_RUN) ./app/konvoy-cp/main.go run --log-level=debug
 
-curl/listeners: EXAMPLE_ENVOY_ID=$(KIND_EXAMPLE_ENVOY_ID)
+curl/listeners: EXAMPLE_ENVOY_ID=$(KIND_EXAMPLE_DATAPLANE_MESH).$(KIND_EXAMPLE_DATAPLANE_NAME)
 curl/listeners: ## Dev: Make Discovery request to LDS
 	curl -s $(CP_BIND_HOST):$(CP_HTTP_PORT)/v2/discovery:listeners --data-binary $(SIMPLE_DISCOVERY_REQUEST)
 
-curl/clusters: EXAMPLE_ENVOY_ID=$(KIND_EXAMPLE_ENVOY_ID)
+curl/clusters: EXAMPLE_ENVOY_ID=$(KIND_EXAMPLE_DATAPLANE_MESH).$(KIND_EXAMPLE_DATAPLANE_NAME)
 curl/clusters: ## Dev: Make Discovery request to CDS
 	curl -s $(CP_BIND_HOST):$(CP_HTTP_PORT)/v2/discovery:clusters --data-binary $(SIMPLE_DISCOVERY_REQUEST)
 
-run/example/envoy/k8s: EXAMPLE_ENVOY_ID=$(KIND_EXAMPLE_ENVOY_ID)
+run/example/envoy/k8s: EXAMPLE_DATAPLANE_MESH=$(KIND_EXAMPLE_DATAPLANE_MESH)
+run/example/envoy/k8s: EXAMPLE_DATAPLANE_NAME=$(KIND_EXAMPLE_DATAPLANE_NAME)
 run/example/envoy/k8s: run/example/envoy
 
 run/example/envoy/universal: run/example/envoy
 
 run/example/envoy: build/kuma-dp ## Dev: Run Envoy configured against local Control Plane
 	KUMA_CONTROL_PLANE_BOOTSTRAP_SERVER_URL=http://localhost:5682 \
-	KUMA_DATAPLANE_ID=$(EXAMPLE_ENVOY_ID) \
+	KUMA_DATAPLANE_MESH=$(EXAMPLE_DATAPLANE_MESH) \
+	KUMA_DATAPLANE_NAME=$(EXAMPLE_DATAPLANE_NAME) \
 	KUMA_DATAPLANE_ADMIN_PORT=$(ENVOY_ADMIN_PORT) \
 	${BUILD_ARTIFACTS_DIR}/kuma-dp/kuma-dp run --log-level=debug
 
@@ -537,7 +543,8 @@ test/konvoy-injector: test ## Dev: Run Konvoy Injector tests only
 
 run/kuma-dp: ## Dev: Run `kuma-dp` locally
 	KUMA_CONTROL_PLANE_BOOTSTRAP_SERVER_URL=http://localhost:5682 \
-	KUMA_DATAPLANE_ID=$(EXAMPLE_ENVOY_ID) \
+	KUMA_DATAPLANE_MESH=$(EXAMPLE_DATAPLANE_MESH) \
+	KUMA_DATAPLANE_NAME=$(EXAMPLE_DATAPLANE_NAME) \
 	KUMA_DATAPLANE_ADMIN_PORT=$(ENVOY_ADMIN_PORT) \
 	$(GO_RUN) ./app/kuma-dp/main.go run --log-level=debug
 

--- a/components/konvoy-control-plane/app/konvoy-injector/pkg/injector/injector.go
+++ b/components/konvoy-control-plane/app/konvoy-injector/pkg/injector/injector.go
@@ -91,14 +91,14 @@ func (i *KonvoyInjector) NewSidecarContainer(pod *kube_core.Pod) kube_core.Conta
 				Value: i.cfg.ControlPlane.BootstrapServer.URL,
 			},
 			{
-				Name:  "KUMA_MESH", // need to refer to this variable while evaluating KUMA_DATAPLANE_ID
+				Name:  "KUMA_DATAPLANE_MESH",
 				Value: mesh,
 			},
 			{
-				Name: "KUMA_DATAPLANE_ID",
+				Name: "KUMA_DATAPLANE_NAME",
 				// notice that Pod name might not be available at this time (in case of Deployment, ReplicaSet, etc)
 				// that is why we have to use a runtime reference to POD_NAME instead
-				Value: "$(KUMA_MESH).$(POD_NAME).$(POD_NAMESPACE)", // variable references get expanded by Kubernetes
+				Value: "$(POD_NAME).$(POD_NAMESPACE)", // variable references get expanded by Kubernetes
 			},
 		},
 		SecurityContext: &kube_core.SecurityContext{

--- a/components/konvoy-control-plane/app/konvoy-injector/pkg/injector/testdata/inject.01.golden.yaml
+++ b/components/konvoy-control-plane/app/konvoy-injector/pkg/injector/testdata/inject.01.golden.yaml
@@ -40,10 +40,10 @@ spec:
           fieldPath: status.podIP
     - name: KUMA_CONTROL_PLANE_BOOTSTRAP_SERVER_URL
       value: http://konvoy-control-plane.konvoy-system:5682
-    - name: KUMA_MESH
+    - name: KUMA_DATAPLANE_MESH
       value: default
-    - name: KUMA_DATAPLANE_ID
-      value: $(KUMA_MESH).$(POD_NAME).$(POD_NAMESPACE)
+    - name: KUMA_DATAPLANE_NAME
+      value: $(POD_NAME).$(POD_NAMESPACE)
     image: konvoy/konvoy-sidecar:latest
     imagePullPolicy: IfNotPresent
     livenessProbe:

--- a/components/konvoy-control-plane/app/konvoy-injector/pkg/injector/testdata/inject.02.golden.yaml
+++ b/components/konvoy-control-plane/app/konvoy-injector/pkg/injector/testdata/inject.02.golden.yaml
@@ -41,10 +41,10 @@ spec:
           fieldPath: status.podIP
     - name: KUMA_CONTROL_PLANE_BOOTSTRAP_SERVER_URL
       value: http://konvoy-control-plane.konvoy-system:5682
-    - name: KUMA_MESH
+    - name: KUMA_DATAPLANE_MESH
       value: default
-    - name: KUMA_DATAPLANE_ID
-      value: $(KUMA_MESH).$(POD_NAME).$(POD_NAMESPACE)
+    - name: KUMA_DATAPLANE_NAME
+      value: $(POD_NAME).$(POD_NAMESPACE)
     image: konvoy/konvoy-sidecar:latest
     imagePullPolicy: IfNotPresent
     livenessProbe:

--- a/components/konvoy-control-plane/app/konvoy-injector/pkg/injector/testdata/inject.03.golden.yaml
+++ b/components/konvoy-control-plane/app/konvoy-injector/pkg/injector/testdata/inject.03.golden.yaml
@@ -100,10 +100,10 @@ spec:
           fieldPath: status.podIP
     - name: KUMA_CONTROL_PLANE_BOOTSTRAP_SERVER_URL
       value: http://konvoy-control-plane.konvoy-system:5682
-    - name: KUMA_MESH
+    - name: KUMA_DATAPLANE_MESH
       value: default
-    - name: KUMA_DATAPLANE_ID
-      value: $(KUMA_MESH).$(POD_NAME).$(POD_NAMESPACE)
+    - name: KUMA_DATAPLANE_NAME
+      value: $(POD_NAME).$(POD_NAMESPACE)
     image: konvoy/konvoy-sidecar:latest
     imagePullPolicy: IfNotPresent
     livenessProbe:

--- a/components/konvoy-control-plane/app/konvoy-injector/pkg/injector/testdata/inject.04.golden.yaml
+++ b/components/konvoy-control-plane/app/konvoy-injector/pkg/injector/testdata/inject.04.golden.yaml
@@ -40,10 +40,10 @@ spec:
           fieldPath: status.podIP
     - name: KUMA_CONTROL_PLANE_BOOTSTRAP_SERVER_URL
       value: http://konvoy-control-plane.konvoy-system:5682
-    - name: KUMA_MESH
+    - name: KUMA_DATAPLANE_MESH
       value: pilot
-    - name: KUMA_DATAPLANE_ID
-      value: $(KUMA_MESH).$(POD_NAME).$(POD_NAMESPACE)
+    - name: KUMA_DATAPLANE_NAME
+      value: $(POD_NAME).$(POD_NAMESPACE)
     image: konvoy/konvoy-sidecar:latest
     imagePullPolicy: IfNotPresent
     livenessProbe:

--- a/components/konvoy-control-plane/app/kuma-dp/cmd/run_test.go
+++ b/components/konvoy-control-plane/app/kuma-dp/cmd/run_test.go
@@ -4,17 +4,18 @@ package cmd
 
 import (
 	"bytes"
-	"github.com/Kong/konvoy/components/konvoy-control-plane/app/kuma-dp/pkg/dataplane/envoy"
-	"github.com/Kong/konvoy/components/konvoy-control-plane/pkg/config/app/kuma-dp"
-	util_proto "github.com/Kong/konvoy/components/konvoy-control-plane/pkg/util/proto"
-	envoy_bootstrap "github.com/envoyproxy/go-control-plane/envoy/config/bootstrap/v2"
-	"github.com/gogo/protobuf/proto"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
 	"syscall"
+
+	"github.com/Kong/konvoy/components/konvoy-control-plane/app/kuma-dp/pkg/dataplane/envoy"
+	kumadp "github.com/Kong/konvoy/components/konvoy-control-plane/pkg/config/app/kuma-dp"
+	util_proto "github.com/Kong/konvoy/components/konvoy-control-plane/pkg/util/proto"
+	envoy_bootstrap "github.com/envoyproxy/go-control-plane/envoy/config/bootstrap/v2"
+	"github.com/gogo/protobuf/proto"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -90,7 +91,7 @@ var _ = Describe("run", func() {
 		// and
 		env := map[string]string{
 			"KUMA_CONTROL_PLANE_BOOTSTRAP_SERVER_URL": "http://localhost:1234",
-			"KUMA_DATAPLANE_ID":                       "example",
+			"KUMA_DATAPLANE_NAME":                     "example",
 			"KUMA_DATAPLANE_ADMIN_PORT":               "2345",
 			"KUMA_DATAPLANE_RUNTIME_BINARY_PATH":      filepath.Join("testdata", "envoy-mock.sleep.sh"),
 			"KUMA_DATAPLANE_RUNTIME_CONFIG_DIR":       configDir,

--- a/components/konvoy-control-plane/app/kuma-dp/pkg/dataplane/envoy/remote_bootstrap.go
+++ b/components/konvoy-control-plane/app/kuma-dp/pkg/dataplane/envoy/remote_bootstrap.go
@@ -3,14 +3,15 @@ package envoy
 import (
 	"bytes"
 	"encoding/json"
+	"io/ioutil"
+	"net/http"
+
 	kuma_dp "github.com/Kong/konvoy/components/konvoy-control-plane/pkg/config/app/kuma-dp"
 	util_proto "github.com/Kong/konvoy/components/konvoy-control-plane/pkg/util/proto"
 	xds_bootstrap "github.com/Kong/konvoy/components/konvoy-control-plane/pkg/xds/bootstrap"
 	envoy_bootstrap "github.com/envoyproxy/go-control-plane/envoy/config/bootstrap/v2"
 	"github.com/gogo/protobuf/proto"
 	"github.com/pkg/errors"
-	"io/ioutil"
-	"net/http"
 )
 
 type remoteBootstrap struct {
@@ -25,7 +26,8 @@ func NewRemoteBootstrapGenerator(client *http.Client) BootstrapConfigFactoryFunc
 func (b *remoteBootstrap) Generate(cfg kuma_dp.Config) (proto.Message, error) {
 	url := cfg.ControlPlane.BootstrapServer.URL + "/bootstrap"
 	request := xds_bootstrap.BootstrapRequest{
-		NodeId: cfg.Dataplane.Id,
+		Mesh: cfg.Dataplane.Mesh,
+		Name: cfg.Dataplane.Name,
 		// if not set in config, the 0 will be sent which will result in providing default admin port
 		// that is set in the control plane bootstrap params
 		AdminPort: cfg.Dataplane.AdminPort,

--- a/components/konvoy-control-plane/app/kuma-dp/pkg/dataplane/envoy/remote_bootstrap_test.go
+++ b/components/konvoy-control-plane/app/kuma-dp/pkg/dataplane/envoy/remote_bootstrap_test.go
@@ -2,15 +2,16 @@ package envoy
 
 import (
 	"fmt"
-	kuma_dp "github.com/Kong/konvoy/components/konvoy-control-plane/pkg/config/app/kuma-dp"
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
 	"strconv"
 	"strings"
+
+	kuma_dp "github.com/Kong/konvoy/components/konvoy-control-plane/pkg/config/app/kuma-dp"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
 )
 
 var _ = Describe("Remote Bootstrap", func() {
@@ -25,7 +26,8 @@ var _ = Describe("Remote Bootstrap", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(body).To(MatchJSON(`
 			{
-				"nodeId": "demo.sample",
+				"mesh": "demo",
+				"name": "sample",
 				"adminPort": 4321
 			}
 			`))
@@ -42,7 +44,8 @@ var _ = Describe("Remote Bootstrap", func() {
 		generator := NewRemoteBootstrapGenerator(http.DefaultClient)
 
 		cfg := kuma_dp.DefaultConfig()
-		cfg.Dataplane.Id = "demo.sample"
+		cfg.Dataplane.Mesh = "demo"
+		cfg.Dataplane.Name = "sample"
 		cfg.Dataplane.AdminPort = 4321
 		cfg.ControlPlane.BootstrapServer.URL = fmt.Sprintf("http://localhost:%d", port)
 

--- a/components/konvoy-control-plane/pkg/config/app/kuma-dp/config.go
+++ b/components/konvoy-control-plane/pkg/config/app/kuma-dp/config.go
@@ -1,8 +1,9 @@
 package kumadp
 
 import (
-	"github.com/Kong/konvoy/components/konvoy-control-plane/pkg/config"
 	"net/url"
+
+	"github.com/Kong/konvoy/components/konvoy-control-plane/pkg/config"
 
 	"github.com/pkg/errors"
 	"go.uber.org/multierr"
@@ -16,7 +17,8 @@ func DefaultConfig() Config {
 			},
 		},
 		Dataplane: Dataplane{
-			Id:        "", // Envoy Id must must be set explicitly
+			Mesh:      "default",
+			Name:      "", // Dataplane name must be set explicitly
 			AdminPort: 9901,
 		},
 		DataplaneRuntime: DataplaneRuntime{
@@ -49,8 +51,10 @@ type BootstrapServer struct {
 
 // Dataplane defines bootstrap configuration of the dataplane (Envoy).
 type Dataplane struct {
-	// Envoy node Id.
-	Id string `yaml:"id,omitempty" envconfig:"kuma_dataplane_id"`
+	// Mesh name.
+	Mesh string `yaml:"mesh,omitempty" envconfig:"kuma_dataplane_mesh"`
+	// Dataplane name.
+	Name string `yaml:"name,omitempty" envconfig:"kuma_dataplane_name"`
 	// Envoy Admin port.
 	AdminPort uint32 `yaml:"adminPort,omitempty" envconfig:"kuma_dataplane_admin_port"`
 }
@@ -90,8 +94,11 @@ func (c *ControlPlane) Validate() (errs error) {
 var _ config.Config = &Dataplane{}
 
 func (d *Dataplane) Validate() (errs error) {
-	if d.Id == "" {
-		errs = multierr.Append(errs, errors.Errorf(".Id must be non-empty"))
+	if d.Mesh == "" {
+		errs = multierr.Append(errs, errors.Errorf(".Mesh must be non-empty"))
+	}
+	if d.Name == "" {
+		errs = multierr.Append(errs, errors.Errorf(".Name must be non-empty"))
 	}
 	if 65535 < d.AdminPort {
 		errs = multierr.Append(errs, errors.Errorf(".AdminPort must be in the range [0, 65535]"))

--- a/components/konvoy-control-plane/pkg/config/app/kuma-dp/config_test.go
+++ b/components/konvoy-control-plane/pkg/config/app/kuma-dp/config_test.go
@@ -49,7 +49,8 @@ var _ = Describe("Config", func() {
 			// setup
 			env := map[string]string{
 				"KUMA_CONTROL_PLANE_BOOTSTRAP_SERVER_URL": "https://kuma-control-plane.internal:5682",
-				"KUMA_DATAPLANE_ID":                       "example",
+				"KUMA_DATAPLANE_MESH":                     "pilot",
+				"KUMA_DATAPLANE_NAME":                     "example",
 				"KUMA_DATAPLANE_ADMIN_PORT":               "2345",
 				"KUMA_DATAPLANE_RUNTIME_BINARY_PATH":      "envoy.sh",
 				"KUMA_DATAPLANE_RUNTIME_CONFIG_DIR":       "/var/run/envoy",
@@ -69,7 +70,8 @@ var _ = Describe("Config", func() {
 
 			// and
 			Expect(cfg.ControlPlane.BootstrapServer.URL).To(Equal("https://kuma-control-plane.internal:5682"))
-			Expect(cfg.Dataplane.Id).To(Equal("example"))
+			Expect(cfg.Dataplane.Mesh).To(Equal("pilot"))
+			Expect(cfg.Dataplane.Name).To(Equal("example"))
 			Expect(cfg.Dataplane.AdminPort).To(Equal(uint32(2345)))
 			Expect(cfg.DataplaneRuntime.BinaryPath).To(Equal("envoy.sh"))
 			Expect(cfg.DataplaneRuntime.ConfigDir).To(Equal("/var/run/envoy"))
@@ -101,6 +103,6 @@ var _ = Describe("Config", func() {
 		err := config.Load(filepath.Join("testdata", "invalid-config.input.yaml"), &cfg)
 
 		// then
-		Expect(err).To(MatchError(`Invalid configuration: .ControlPlane is not valid: .BootstrapServer is not valid: .URL must be a valid absolute URI; .Dataplane is not valid: .Id must be non-empty; .AdminPort must be in the range [0, 65535]; .DataplaneRuntime is not valid: .BinaryPath must be non-empty; .ConfigDir must be non-empty`))
+		Expect(err).To(MatchError(`Invalid configuration: .ControlPlane is not valid: .BootstrapServer is not valid: .URL must be a valid absolute URI; .Dataplane is not valid: .Mesh must be non-empty; .Name must be non-empty; .AdminPort must be in the range [0, 65535]; .DataplaneRuntime is not valid: .BinaryPath must be non-empty; .ConfigDir must be non-empty`))
 	})
 })

--- a/components/konvoy-control-plane/pkg/config/app/kuma-dp/testdata/default-config.golden.yaml
+++ b/components/konvoy-control-plane/pkg/config/app/kuma-dp/testdata/default-config.golden.yaml
@@ -1,4 +1,5 @@
 dataplane:
+  mesh: default
   adminPort: 9901
 dataplaneRuntime:
   binaryPath: envoy

--- a/components/konvoy-control-plane/pkg/config/app/kuma-dp/testdata/invalid-config.input.yaml
+++ b/components/konvoy-control-plane/pkg/config/app/kuma-dp/testdata/invalid-config.input.yaml
@@ -2,7 +2,8 @@ controlPlane:
   bootstrapServer:
     url: invalid-url
 dataplane:
-  id:
+  mesh:
+  name:
   adminPort: 82345
 dataplaneRuntime:
   binaryPath:

--- a/components/konvoy-control-plane/pkg/config/app/kuma-dp/testdata/valid-config.input.yaml
+++ b/components/konvoy-control-plane/pkg/config/app/kuma-dp/testdata/valid-config.input.yaml
@@ -2,7 +2,8 @@ controlPlane:
   bootstrapServer:
     url: https://kuma-control-plane.internal:5682
 dataplane:
-  id: example
+  mesh: pilot
+  name: example
   adminPort: 2345
 dataplaneRuntime:
   binaryPath: envoy.sh

--- a/components/konvoy-control-plane/pkg/core/xds/types.go
+++ b/components/konvoy-control-plane/pkg/core/xds/types.go
@@ -27,6 +27,11 @@ type Proxy struct {
 	Dataplane *mesh_core.DataplaneResource
 }
 
+func BuildProxyId(mesh, name string, more ...string) (*ProxyId, error) {
+	id := strings.Join(append([]string{mesh, name}, more...), ".")
+	return ParseProxyIdFromString(id)
+}
+
 func ParseProxyId(node *envoy_core.Node) (*ProxyId, error) {
 	if node == nil {
 		return nil, errors.Errorf("Envoy node must not be nil")

--- a/components/konvoy-control-plane/pkg/xds/bootstrap/server_test.go
+++ b/components/konvoy-control-plane/pkg/xds/bootstrap/server_test.go
@@ -100,12 +100,16 @@ var _ = Describe("Bootstrap Server", func() {
 
 			Expect(received).To(MatchYAML(expected))
 		},
-		Entry("minimal data provided", testCase{
-			body:               `{ "nodeId": "default.dp-1.default" }`,
+		Entry("minimal data provided (universal)", testCase{
+			body:               `{ "mesh": "default", "name": "dp-1" }`,
+			expectedConfigFile: "bootstrap.golden.yaml",
+		}),
+		Entry("minimal data provided (k8s)", testCase{
+			body:               `{ "mesh": "default", "name": "dp-1.default" }`,
 			expectedConfigFile: "bootstrap.golden.yaml",
 		}),
 		Entry("overridden admin port", testCase{
-			body:               `{ "nodeId": "default.dp-1.default", "adminPort": 1234 }`,
+			body:               `{ "mesh": "default", "name": "dp-1.default", "adminPort": 1234 }`,
 			expectedConfigFile: "bootstrap.overridden.golden.yaml",
 		}),
 	)
@@ -114,7 +118,8 @@ var _ = Describe("Bootstrap Server", func() {
 		// when
 		json := `
 		{
-			"nodeId": "default.dp-1.default"
+			"mesh": "default",
+			"name": "dp-1.default"
 		}
 		`
 


### PR DESCRIPTION
changes:
* to improve UX, `kuma-dp` now accepts 2 separate parameters - `KUMA_DATAPLANE_MESH` and `KUMA_DATAPLANE_NAME` - instead of a former `KUMA_DATAPLANE_ID`