### PR TITLE
sds: fix issues with auto-generated TLS cert for SDS server

### DIFF
--- a/components/konvoy-control-plane/app/kumactl/cmd/install/install_control_plane_test.go
+++ b/components/konvoy-control-plane/app/kumactl/cmd/install/install_control_plane_test.go
@@ -18,7 +18,7 @@ import (
 
 var _ = Describe("kumactl install control-plane", func() {
 
-	var backupNewSelfSignedCert func(string) (tls.KeyPair, error)
+	var backupNewSelfSignedCert func(string, ...string) (tls.KeyPair, error)
 
 	BeforeEach(func() {
 		backupNewSelfSignedCert = install.NewSelfSignedCert
@@ -28,7 +28,7 @@ var _ = Describe("kumactl install control-plane", func() {
 	})
 
 	BeforeEach(func() {
-		install.NewSelfSignedCert = func(string) (tls.KeyPair, error) {
+		install.NewSelfSignedCert = func(string, ...string) (tls.KeyPair, error) {
 			return tls.KeyPair{
 				CertPEM: []byte("CERT"),
 				KeyPEM:  []byte("KEY"),


### PR DESCRIPTION
changes:
* apparently, Envoy's SDS client (Google gRPC) does require DNS SAN in a X509 cert of an SDS server
* auto-generate SDS cert for Postgres-based deployment as well
* use RSA keys for SDS certs (for consistency with in-mesh certs and similar troubleshooting)
