### PR TITLE
control-plane: mesh is not required in Mesh

### DIFF
--- a/components/konvoy-control-plane/app/kumactl/cmd/apply/apply.go
+++ b/components/konvoy-control-plane/app/kumactl/cmd/apply/apply.go
@@ -3,6 +3,7 @@ package apply
 import (
 	"context"
 	kumactl_cmd "github.com/Kong/konvoy/components/konvoy-control-plane/app/kumactl/pkg/cmd"
+	"github.com/Kong/konvoy/components/konvoy-control-plane/pkg/core/resources/apis/mesh"
 	"github.com/Kong/konvoy/components/konvoy-control-plane/pkg/core/resources/model"
 	"github.com/Kong/konvoy/components/konvoy-control-plane/pkg/core/resources/model/rest"
 	"github.com/Kong/konvoy/components/konvoy-control-plane/pkg/core/resources/registry"
@@ -102,7 +103,7 @@ func parseResource(bytes []byte) (model.Resource, error) {
 	if resMeta.Name == "" {
 		return nil, errors.New("Name field cannot be empty")
 	}
-	if resMeta.Mesh == "" {
+	if resMeta.Mesh == "" && resMeta.Type != string(mesh.MeshType) {
 		return nil, errors.New("Mesh field cannot be empty")
 	}
 	resource, err := registry.Global().NewObject(model.ResourceType(resMeta.Type))

--- a/components/konvoy-control-plane/app/kumactl/cmd/apply/apply_test.go
+++ b/components/konvoy-control-plane/app/kumactl/cmd/apply/apply_test.go
@@ -170,36 +170,13 @@ var _ = Describe("kumactl apply", func() {
 
 		// when
 		resource := mesh.MeshResource{}
-		err = store.Get(context.Background(), &resource, core_store.GetByKey("default", "sample", "sample"))
+		// with production code, the mesh is not required for remote store. API Server then infer mesh from the name
+		err = store.Get(context.Background(), &resource, core_store.GetByKey("default", "sample", ""))
 		Expect(err).ToNot(HaveOccurred())
 
 		// then
 		Expect(resource.Meta.GetName()).To(Equal("sample"))
-		Expect(resource.Meta.GetMesh()).To(Equal("sample"))
-		Expect(resource.Meta.GetNamespace()).To(Equal("default"))
-	})
-
-	It("should fill in template (single variable)", func() {
-		// given
-		rootCmd.SetArgs([]string{
-			"--config-file", filepath.Join("..", "testdata", "sample-kumactl.config.yaml"),
-			"apply", "-f", filepath.Join("testdata", "apply-mesh-template-repeated-placeholder.yaml"),
-			"-v", "name=meshinit"},
-		)
-
-		// when
-		err := rootCmd.Execute()
-		// then
-		Expect(err).ToNot(HaveOccurred())
-
-		// when
-		resource := mesh.MeshResource{}
-		err = store.Get(context.Background(), &resource, core_store.GetByKey("default", "meshinit", "meshinit"))
-		Expect(err).ToNot(HaveOccurred())
-
-		// then
-		Expect(resource.Meta.GetName()).To(Equal("meshinit"))
-		Expect(resource.Meta.GetMesh()).To(Equal("meshinit"))
+		Expect(resource.Meta.GetMesh()).To(Equal(""))
 		Expect(resource.Meta.GetNamespace()).To(Equal("default"))
 	})
 
@@ -208,7 +185,7 @@ var _ = Describe("kumactl apply", func() {
 		rootCmd.SetArgs([]string{
 			"--config-file", filepath.Join("..", "testdata", "sample-kumactl.config.yaml"),
 			"apply", "-f", filepath.Join("testdata", "apply-mesh-template.yaml"),
-			"-v", "name=meshinit", "-v", "mesh=meshinit", "-v", "type=Mesh"},
+			"-v", "name=meshinit", "-v", "type=Mesh"},
 		)
 
 		// when
@@ -218,12 +195,13 @@ var _ = Describe("kumactl apply", func() {
 
 		// when
 		resource := mesh.MeshResource{}
-		err = store.Get(context.Background(), &resource, core_store.GetByKey("default", "meshinit", "meshinit"))
+		// with production code, the mesh is not required for remote store. API Server then infer mesh from the name
+		err = store.Get(context.Background(), &resource, core_store.GetByKey("default", "meshinit", ""))
 		Expect(err).ToNot(HaveOccurred())
 
 		// then
 		Expect(resource.Meta.GetName()).To(Equal("meshinit"))
-		Expect(resource.Meta.GetMesh()).To(Equal("meshinit"))
+		Expect(resource.Meta.GetMesh()).To(Equal(""))
 		Expect(resource.Meta.GetNamespace()).To(Equal("default"))
 	})
 

--- a/components/konvoy-control-plane/app/kumactl/cmd/apply/testdata/apply-mesh-template-repeated-placeholder.yaml
+++ b/components/konvoy-control-plane/app/kumactl/cmd/apply/testdata/apply-mesh-template-repeated-placeholder.yaml
@@ -1,6 +1,0 @@
-name: {{name}}
-mesh: {{name}}
-type: Mesh
-mtls:
-  ca:
-    embedded:

--- a/components/konvoy-control-plane/app/kumactl/cmd/apply/testdata/apply-mesh-template.yaml
+++ b/components/konvoy-control-plane/app/kumactl/cmd/apply/testdata/apply-mesh-template.yaml
@@ -1,5 +1,4 @@
 name: {{name}}
-mesh: {{mesh}}
 type: {{type}}
 mtls:
   ca:

--- a/components/konvoy-control-plane/app/kumactl/cmd/apply/testdata/apply-mesh.yaml
+++ b/components/konvoy-control-plane/app/kumactl/cmd/apply/testdata/apply-mesh.yaml
@@ -1,5 +1,4 @@
 name: sample
-mesh: sample
 type: Mesh
 mtls:
   ca:

--- a/components/konvoy-control-plane/app/kumactl/cmd/get/testdata/get-meshes.golden.json
+++ b/components/konvoy-control-plane/app/kumactl/cmd/get/testdata/get-meshes.golden.json
@@ -1,7 +1,6 @@
 {
   "items": [
     {
-      "mesh": "mesh1",
       "mtls": {
         "ca": {
           "builtin": {}
@@ -11,7 +10,6 @@
       "type": "Mesh"
     },
     {
-      "mesh": "mesh2",
       "mtls": {
         "ca": {
           "builtin": {}

--- a/components/konvoy-control-plane/app/kumactl/cmd/get/testdata/get-meshes.golden.yaml
+++ b/components/konvoy-control-plane/app/kumactl/cmd/get/testdata/get-meshes.golden.yaml
@@ -1,12 +1,10 @@
 items:
-  - mesh: mesh1
-    mtls:
+  - mtls:
       ca:
         builtin: {}
     name: mesh1
     type: Mesh
-  - mesh: mesh2
-    mtls:
+  - mtls:
       ca:
         builtin: {}
     name: mesh2

--- a/components/konvoy-control-plane/dev/examples/universal/meshes/mesh.yaml
+++ b/components/konvoy-control-plane/dev/examples/universal/meshes/mesh.yaml
@@ -1,3 +1,2 @@
 type: Mesh
 name: mesh-1
-mesh: mesh-1

--- a/components/konvoy-control-plane/dev/examples/universal/meshes/pilot.yaml
+++ b/components/konvoy-control-plane/dev/examples/universal/meshes/pilot.yaml
@@ -1,3 +1,2 @@
 type: Mesh
-mesh: pilot
 name: pilot

--- a/components/konvoy-control-plane/pkg/api-server/mesh_ws_test.go
+++ b/components/konvoy-control-plane/pkg/api-server/mesh_ws_test.go
@@ -58,8 +58,7 @@ var _ = Describe("Resource WS", func() {
 			json := `
 			{
 				"type": "Mesh",
-				"name": "mesh-1",
-				"mesh": "mesh-1"
+				"name": "mesh-1"
 			}`
 			Expect(body).To(MatchJSON(json))
 		})
@@ -85,14 +84,12 @@ var _ = Describe("Resource WS", func() {
 			json1 := `
 			{
 				"type": "Mesh",
-				"name": "mesh-1",
-				"mesh": "mesh-1"
+				"name": "mesh-1"
 			}`
 			json2 := `
 			{
 				"type": "Mesh",
-				"name": "mesh-2",
-				"mesh": "mesh-2"
+				"name": "mesh-2"
 			}`
 			body, err := ioutil.ReadAll(response.Body)
 			Expect(err).ToNot(HaveOccurred())
@@ -110,7 +107,6 @@ var _ = Describe("Resource WS", func() {
 			res := rest.Resource{
 				Meta: rest.ResourceMeta{
 					Name: "new-mesh",
-					Mesh: "new-mesh",
 					Type: string(mesh.MeshType),
 				},
 				Spec: &v1alpha1.Mesh{},
@@ -132,7 +128,6 @@ var _ = Describe("Resource WS", func() {
 			res := rest.Resource{
 				Meta: rest.ResourceMeta{
 					Name: "mesh-1",
-					Mesh: "mesh-1",
 					Type: string(mesh.MeshType),
 				},
 				Spec: &v1alpha1.Mesh{
@@ -155,9 +150,8 @@ var _ = Describe("Resource WS", func() {
 			// given
 			json := `
 			{
-				"type": "Mesh",
+				"type": "Mesh-1",
 				"name": "tr-1",
-				"mesh": "default"
 			}
 			`
 
@@ -174,7 +168,6 @@ var _ = Describe("Resource WS", func() {
 			{
 				"type": "Mesh",
 				"name": "different-name",
-				"mesh": "different-name"
 			}
 			`
 
@@ -190,8 +183,7 @@ var _ = Describe("Resource WS", func() {
 			json := `
 			{
 				"type": "Mesh",
-				"name": "mesh-1",
-				"mesh": "different-mesh"
+				"name": "different-mesh",
 			}
 			`
 

--- a/components/konvoy-control-plane/pkg/api-server/resource_ws.go
+++ b/components/konvoy-control-plane/pkg/api-server/resource_ws.go
@@ -119,6 +119,7 @@ func (r *resourceWs) createOrUpdateResource(request *restful.Request, response *
 	if err != nil {
 		core.Log.Error(err, "Could not read an entity")
 		writeError(response, 400, "Could not process the resource")
+		return
 	}
 
 	if err := r.validateResourceRequest(request, &resourceRes); err != nil {
@@ -147,7 +148,7 @@ func (r *resourceWs) validateResourceRequest(request *restful.Request, resource 
 	if string(r.ResourceFactory().GetType()) != resource.Meta.Type {
 		return errors.New("Type from the URL has to be the same as in body")
 	}
-	if meshName != resource.Meta.Mesh {
+	if meshName != resource.Meta.Mesh && r.ResourceFactory().GetType() != mesh.MeshType {
 		return errors.New("Mesh from the URL has to be the same as in body")
 	}
 	return nil

--- a/components/konvoy-control-plane/pkg/core/resources/model/rest/converter.go
+++ b/components/konvoy-control-plane/pkg/core/resources/model/rest/converter.go
@@ -1,6 +1,7 @@
 package rest
 
 import (
+	"github.com/Kong/konvoy/components/konvoy-control-plane/pkg/core/resources/apis/mesh"
 	"github.com/Kong/konvoy/components/konvoy-control-plane/pkg/core/resources/model"
 )
 
@@ -9,9 +10,13 @@ var From = &from{}
 type from struct{}
 
 func (c *from) Resource(r model.Resource) *Resource {
+	var meshName string
+	if r.GetType() != mesh.MeshType {
+		meshName = r.GetMeta().GetMesh()
+	}
 	return &Resource{
 		Meta: ResourceMeta{
-			Mesh: r.GetMeta().GetMesh(),
+			Mesh: meshName,
 			Type: string(r.GetType()),
 			Name: r.GetMeta().GetName(),
 		},

--- a/components/konvoy-control-plane/pkg/core/resources/model/rest/resource.go
+++ b/components/konvoy-control-plane/pkg/core/resources/model/rest/resource.go
@@ -13,7 +13,7 @@ import (
 type ResourceMeta struct {
 	Type string `json:"type"`
 	Name string `json:"name"`
-	Mesh string `json:"mesh"`
+	Mesh string `json:"mesh,omitempty"`
 }
 
 type Resource struct {

--- a/components/konvoy-control-plane/tools/postgres/docker-compose.yaml
+++ b/components/konvoy-control-plane/tools/postgres/docker-compose.yaml
@@ -4,9 +4,9 @@ services:
     image: postgres
     restart: always
     environment:
-      POSTGRES_USER: ${KUMA_STORE_POSTGRES_USER:-konvoy}
-      POSTGRES_PASSWORD: ${KUMA_STORE_POSTGRES_PASSWORD:-konvoy}
-      POSTGRES_DB: ${KUMA_STORE_POSTGRES_DB_NAME:-konvoy}
+      POSTGRES_USER: ${KUMA_STORE_POSTGRES_USER:-kuma}
+      POSTGRES_PASSWORD: ${KUMA_STORE_POSTGRES_PASSWORD:-kuma}
+      POSTGRES_DB: ${KUMA_STORE_POSTGRES_DB_NAME:-kuma}
     ports:
       - ${KUMA_STORE_POSTGRES_PORT:-15432}:5432
     volumes:


### PR DESCRIPTION
`mesh` in `Mesh` is not required by API Server nor by kumactl apply.
`mesh` is also not visible in GET, but it is still stored in our storage.
