### PR TITLE
docs: cli --help completion for kumactl

### DIFF
--- a/app/kumactl/cmd/apply/apply.go
+++ b/app/kumactl/cmd/apply/apply.go
@@ -2,6 +2,11 @@ package apply
 
 import (
 	"context"
+	"io/ioutil"
+	"net/http"
+	"strings"
+	"time"
+
 	kumactl_cmd "github.com/Kong/kuma/app/kumactl/pkg/cmd"
 	"github.com/Kong/kuma/pkg/core/resources/apis/mesh"
 	"github.com/Kong/kuma/pkg/core/resources/model"
@@ -13,10 +18,6 @@ import (
 	"github.com/hoisie/mustache"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
-	"io/ioutil"
-	"net/http"
-	"strings"
-	"time"
 )
 
 const (
@@ -38,6 +39,12 @@ func NewApplyCmd(pctx *kumactl_cmd.RootContext) *cobra.Command {
 		Use:   "apply",
 		Short: "Create or modify Kuma resources",
 		Long:  `Create or modify Kuma resources.`,
+		Example: `# Basic
+		kumactl apply my-dataplane.yml
+
+		# Apply a remote configuration
+		kumactl apply https://github.com/Kong/kuma/blob/master/dev/examples/universal/dataplanes/example.yaml
+		`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var b []byte
 			var err error

--- a/app/kumactl/cmd/apply/apply.go
+++ b/app/kumactl/cmd/apply/apply.go
@@ -39,11 +39,11 @@ func NewApplyCmd(pctx *kumactl_cmd.RootContext) *cobra.Command {
 		Use:   "apply",
 		Short: "Create or modify Kuma resources",
 		Long:  `Create or modify Kuma resources.`,
-		Example: `# Basic
-		kumactl apply my-dataplane.yml
+		Example: `1. Basic
+$: kumactl apply my-dataplane.yml
 
-		# Apply a remote configuration
-		kumactl apply https://github.com/Kong/kuma/blob/master/dev/examples/universal/dataplanes/example.yaml
+2. Apply a remote configuration
+$: kumactl apply https://github.com/Kong/kuma/blob/master/dev/examples/universal/dataplanes/example.yaml
 		`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var b []byte

--- a/app/kumactl/cmd/config/config_control_planes_add.go
+++ b/app/kumactl/cmd/config/config_control_planes_add.go
@@ -21,6 +21,11 @@ func newConfigControlPlanesAddCmd(pctx *kumactl_cmd.RootContext) *cobra.Command 
 		Use:   "add",
 		Short: "Add a Control Plane",
 		Long:  `Add a Control Plane.`,
+		Example: `
+		Add a new control plane
+$: kumactl config control-planes add --name my-new --address my-new-cp.my-domain.com --dataplane-token-client-cert 'path/to/cert.pem' --dataplane-token-client-key 'path/to/key.pem'
+added Control Plane "my-new"
+switch active Control Plane to "my-new"`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			cp := &config_proto.ControlPlane{
 				Name: args.name,

--- a/app/kumactl/cmd/config/config_control_planes_list.go
+++ b/app/kumactl/cmd/config/config_control_planes_list.go
@@ -14,9 +14,9 @@ func newConfigControlPlanesListCmd(pctx *kumactl_cmd.RootContext) *cobra.Command
 		Short: "List Control Planes",
 		Long:  `List Control Planes.`,
 		Example: `To retrieve all Control Planes from anyone Context:
-		$:kumactl config control-planes list
+$:kumactl config control-planes list
 		
-		This command displays if the Control Plane is active, its url and its name.`,
+This command displays if the Control Plane is active, its url and its name.`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			context, _ := pctx.CurrentContext()
 

--- a/app/kumactl/cmd/config/config_control_planes_list.go
+++ b/app/kumactl/cmd/config/config_control_planes_list.go
@@ -13,6 +13,10 @@ func newConfigControlPlanesListCmd(pctx *kumactl_cmd.RootContext) *cobra.Command
 		Use:   "list",
 		Short: "List Control Planes",
 		Long:  `List Control Planes.`,
+		Example: `To retrieve all Control Planes from anyone Context:
+		$:kumactl config control-planes list
+		
+		This command displays if the Control Plane is active, its url and its name.`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			context, _ := pctx.CurrentContext()
 

--- a/app/kumactl/cmd/config/config_control_planes_remove.go
+++ b/app/kumactl/cmd/config/config_control_planes_remove.go
@@ -15,6 +15,10 @@ func newConfigControlPlanesRemoveCmd(pctx *kumactl_cmd.RootContext) *cobra.Comma
 		Use:   "remove",
 		Short: "Remove a Control Plane",
 		Long:  `Remove a Control Plane.`,
+		Example: `To remove a Control Plane named "my-cp":
+$: kumactl config control-planes remove --name my-cp
+> removed Control Plane "my-cp"
+In case if this one is the current Control Plane, you will need to switch manually to a new one.`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			cfg := pctx.Config()
 			if !cfg.RemoveControlPlane(args.name) {

--- a/app/kumactl/cmd/config/config_control_planes_switch.go
+++ b/app/kumactl/cmd/config/config_control_planes_switch.go
@@ -15,6 +15,20 @@ func newConfigControlPlanesSwitchCmd(pctx *kumactl_cmd.RootContext) *cobra.Comma
 		Use:   "switch",
 		Short: "Switch active Control Plane",
 		Long:  `Switch active Control Plane.`,
+		Example: `If you have in your deployment configuration several contexts, for example:
+contexts:
+    - name: ctx1
+        control_plane: cp1
+        defaults:
+           mesh: pilot
+    - name: ctx2
+        control_plane: cp2
+        defaults:
+        mesh: default
+
+:$ kumactl config control-planes switch ctx2
+switched active Control Plate to "ctx2"
+`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			cfg := pctx.Config()
 			if !cfg.SwitchContext(args.name) {

--- a/app/kumactl/cmd/config/config_view.go
+++ b/app/kumactl/cmd/config/config_view.go
@@ -13,7 +13,7 @@ func newConfigViewCmd(pctx *kumactl_cmd.RootContext) *cobra.Command {
 		Short: "Show kumactl config",
 		Long:  `Show kumactl config.`,
 		Example: `:$ kumactl config view
-control_planes:
+> control_planes:
     - name: my-first-cp
         coordinates:
             api_server:

--- a/app/kumactl/cmd/config/config_view.go
+++ b/app/kumactl/cmd/config/config_view.go
@@ -12,6 +12,29 @@ func newConfigViewCmd(pctx *kumactl_cmd.RootContext) *cobra.Command {
 		Use:   "view",
 		Short: "Show kumactl config",
 		Long:  `Show kumactl config.`,
+		Example: `:$ kumactl config view
+control_planes:
+    - name: my-first-cp
+        coordinates:
+            api_server:
+            url: https://cp1.internal:5681
+    - name: my-second-cp
+        coordinates:
+            api_server:
+            url: https://cp1.internal:5681
+		
+contexts:
+    - name: stage1
+        control_plane: my-first-cp
+        defaults:
+            mesh: pilot
+    - name: stage2
+        control_plane: test2
+        defaults:
+            mesh: default
+
+current_context: stage1
+		`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			cfg := pctx.Config()
 			contents, err := util_proto.ToYAML(cfg)

--- a/app/kumactl/cmd/delete/delete.go
+++ b/app/kumactl/cmd/delete/delete.go
@@ -17,7 +17,13 @@ func NewDeleteCmd(pctx *kumactl_cmd.RootContext) *cobra.Command {
 		Use:   "delete TYPE NAME",
 		Short: "Delete Kuma resources",
 		Long:  `Delete Kuma resources.`,
-		Args:  cobra.ExactArgs(2),
+		Example: `1. Delete a Mesh:
+:$ kumactl delete mesh my-mesh 
+deleted mesh "my-mesh"
+
+Those resource types can be used: mesh, dataplane, proxytemplate, traffic-log, traffic-permission and traffic-route.
+		`,
+		Args: cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			rs, err := pctx.CurrentResourceStore()
 			if err != nil {

--- a/app/kumactl/cmd/generate/generate_dataplane_token.go
+++ b/app/kumactl/cmd/generate/generate_dataplane_token.go
@@ -20,6 +20,8 @@ func NewGenerateDataplaneTokenCmd(pctx *kumactl_cmd.RootContext) *cobra.Command 
 		Use:   "dataplane-token",
 		Short: "Generate Dataplane Token",
 		Long:  `Generate Dataplane Token that is used to prove Dataplane identity.`,
+		Example: `Generate the token for a dataplane of a mesh:
+		kumactl generate dataplane-token --dataplane=my-dataplane --mesh=my-mesh`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			client, err := pctx.CurrentDataplaneTokenClient()
 			if err != nil {

--- a/app/kumactl/cmd/get/get_dataplanes.go
+++ b/app/kumactl/cmd/get/get_dataplanes.go
@@ -20,9 +20,10 @@ func newGetDataplanesCmd(pctx *getContext) *cobra.Command {
 		Short: "Show Dataplanes",
 		Long:  `Show Dataplanes.`,
 		Example: `1. Get all dataplane's name:
-		kumactl get dataplanes -ojson | jq '.items[].name'
-		2. Get all dataplanes with inbounds configuration having specific tag:
-		kumactl get dataplane -ojson | jq '.items[] | select(.networking.inbound[].tags.my-tag == "value") | .name'`,
+$: kumactl get dataplanes -ojson | jq '.items[].name'
+
+2. Get all dataplanes with inbounds configuration having specific tag:
+$: kumactl get dataplane -ojson | jq '.items[] | select(.networking.inbound[].tags.my-tag == "value") | .name'`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			rs, err := pctx.CurrentResourceStore()
 			if err != nil {

--- a/app/kumactl/cmd/get/get_dataplanes.go
+++ b/app/kumactl/cmd/get/get_dataplanes.go
@@ -19,6 +19,10 @@ func newGetDataplanesCmd(pctx *getContext) *cobra.Command {
 		Use:   "dataplanes",
 		Short: "Show Dataplanes",
 		Long:  `Show Dataplanes.`,
+		Example: `1. Get all dataplane's name:
+		kumactl get dataplanes -ojson | jq '.items[].name'
+		2. Get all dataplanes with inbounds configuration having specific tag:
+		kumactl get dataplane -ojson | jq '.items[] | select(.networking.inbound[].tags.my-tag == "value") | .name'`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			rs, err := pctx.CurrentResourceStore()
 			if err != nil {

--- a/app/kumactl/cmd/get/get_meshes.go
+++ b/app/kumactl/cmd/get/get_meshes.go
@@ -19,6 +19,13 @@ func newGetMeshesCmd(pctx *getContext) *cobra.Command {
 		Use:   "meshes",
 		Short: "Show Meshes",
 		Long:  `Show Meshes.`,
+		Example: `# Get all service meshes
+		kumactl get meshes
+
+		# Get service meshes using mtls
+		kumactl get meshes -ojson | jq '.items[] | select(.mtls.enabled == true) | .name
+
+		`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			rs, err := pctx.CurrentResourceStore()
 			if err != nil {

--- a/app/kumactl/cmd/get/get_meshes.go
+++ b/app/kumactl/cmd/get/get_meshes.go
@@ -19,12 +19,11 @@ func newGetMeshesCmd(pctx *getContext) *cobra.Command {
 		Use:   "meshes",
 		Short: "Show Meshes",
 		Long:  `Show Meshes.`,
-		Example: `# Get all service meshes
-		kumactl get meshes
+		Example: `1. Get all service meshes
+$: kumactl get meshes
 
-		# Get service meshes using mtls
-		kumactl get meshes -ojson | jq '.items[] | select(.mtls.enabled == true) | .name
-
+2. Get service meshes using mtls
+$: kumactl get meshes -ojson | jq '.items[] | select(.mtls.enabled == true) | .name
 		`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			rs, err := pctx.CurrentResourceStore()

--- a/app/kumactl/cmd/get/get_proxytemplates.go
+++ b/app/kumactl/cmd/get/get_proxytemplates.go
@@ -18,6 +18,12 @@ func newGetProxyTemplatesCmd(pctx *getContext) *cobra.Command {
 		Use:   "proxytemplates",
 		Short: "Show ProxyTemplates",
 		Long:  `Show ProxyTemplates.`,
+		Example: `# Get all proxy template
+		kumactl get proxytemplates
+		
+		# Get all proxy templae of specific Mesh
+		kumactl get proxytemplate -ojson | jq '.items[] | select(.mesh == "my-service-mesh" | .name)'
+		`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			rs, err := pctx.CurrentResourceStore()
 			if err != nil {

--- a/app/kumactl/cmd/get/get_traffic_logs.go
+++ b/app/kumactl/cmd/get/get_traffic_logs.go
@@ -15,10 +15,11 @@ import (
 
 func newGetTrafficLogsCmd(pctx *getContext) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     "traffic-logs",
-		Short:   "Show TrafficLogs",
-		Long:    `Show TrafficLog entities.`,
-		Example: `kumactl get traffic-logs -ojson | jq '.items[] | select(.name == "my-log-entity")'`,
+		Use:   "traffic-logs",
+		Short: "Show TrafficLogs",
+		Long:  `Show TrafficLog entities.`,
+		Example: `To retrieve name of my entities:
+$: kumactl get traffic-logs -ojson | jq '.items[] | select(.name == "my-log-entity")'`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			rs, err := pctx.CurrentResourceStore()
 			if err != nil {

--- a/app/kumactl/cmd/get/get_traffic_logs.go
+++ b/app/kumactl/cmd/get/get_traffic_logs.go
@@ -15,9 +15,10 @@ import (
 
 func newGetTrafficLogsCmd(pctx *getContext) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "traffic-logs",
-		Short: "Show TrafficLogs",
-		Long:  `Show TrafficLog entities.`,
+		Use:     "traffic-logs",
+		Short:   "Show TrafficLogs",
+		Long:    `Show TrafficLog entities.`,
+		Example: `kumactl get traffic-logs -ojson | jq '.items[] | select(.name == "my-log-entity")'`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			rs, err := pctx.CurrentResourceStore()
 			if err != nil {

--- a/app/kumactl/cmd/get/get_traffic_routes.go
+++ b/app/kumactl/cmd/get/get_traffic_routes.go
@@ -19,11 +19,11 @@ func newGetTrafficRoutesCmd(pctx *getContext) *cobra.Command {
 		Short: "Show TrafficRoutes",
 		Long:  `Show TrafficRoutes.`,
 		Example: `
-		# Get all traffic routes name
-		kumactl get traffic-routes -ojson | jq '.items[].name'
+1.  Get all traffic routes name:
+$: kumactl get traffic-routes -ojson | jq '.items[].name'
 		
-		# Get traffic routes for a specific service Mesh
-		kumactl get traffic-routes -ojson | jq '.items[] | select(.mesh == "my-service-mesh")'
+2.Get traffic routes for a specific service Mesh
+$: kumactl get traffic-routes -ojson | jq '.items[] | select(.mesh == "my-service-mesh")'
 		`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			rs, err := pctx.CurrentResourceStore()

--- a/app/kumactl/cmd/get/get_traffic_routes.go
+++ b/app/kumactl/cmd/get/get_traffic_routes.go
@@ -18,6 +18,13 @@ func newGetTrafficRoutesCmd(pctx *getContext) *cobra.Command {
 		Use:   "traffic-routes",
 		Short: "Show TrafficRoutes",
 		Long:  `Show TrafficRoutes.`,
+		Example: `
+		# Get all traffic routes name
+		kumactl get traffic-routes -ojson | jq '.items[].name'
+		
+		# Get traffic routes for a specific service Mesh
+		kumactl get traffic-routes -ojson | jq '.items[] | select(.mesh == "my-service-mesh")'
+		`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			rs, err := pctx.CurrentResourceStore()
 			if err != nil {

--- a/app/kumactl/cmd/get/get_trafficpermissions.go
+++ b/app/kumactl/cmd/get/get_trafficpermissions.go
@@ -15,9 +15,10 @@ import (
 
 func newGetTrafficPermissionsCmd(pctx *getContext) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "traffic-permissions",
-		Short: "Show TrafficPermissions",
-		Long:  `Show TrafficPermission entities.`,
+		Use:     "traffic-permissions",
+		Short:   "Show TrafficPermissions",
+		Long:    `Show TrafficPermission entities.`,
+		Example: `kumactl get traffic-permissions -o json | jq '[.items[] |  .name ]'`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			rs, err := pctx.CurrentResourceStore()
 			if err != nil {

--- a/app/kumactl/cmd/inspect/inspect_dataplanes.go
+++ b/app/kumactl/cmd/inspect/inspect_dataplanes.go
@@ -29,9 +29,10 @@ func newInspectDataplanesCmd(pctx *inspectContext) *cobra.Command {
 		inspectContext: pctx,
 	}
 	cmd := &cobra.Command{
-		Use:   "dataplanes",
-		Short: "Inspect Dataplanes",
-		Long:  `Inspect Dataplanes.`,
+		Use:     "dataplanes",
+		Short:   "Inspect Dataplanes",
+		Long:    `Inspect Dataplanes.`,
+		Example: `kumactl inspect dataplanes -o json | jq '.items[0].dataplaneInsight.subscriptions[0].status.total.responsesSent`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			client, err := pctx.CurrentDataplaneOverviewClient()
 			if err != nil {

--- a/app/kumactl/cmd/install/install_control_plane.go
+++ b/app/kumactl/cmd/install/install_control_plane.go
@@ -62,10 +62,14 @@ func newInstallControlPlaneCmd(pctx *kumactl_cmd.RootContext) *cobra.Command {
 		SdsTlsKey:               "",
 	}
 	cmd := &cobra.Command{
-		Use:     "control-plane",
-		Short:   "Install Kuma Control Plane on Kubernetes",
-		Long:    `Install Kuma Control Plane on Kubernetes.`,
-		Example: `1. kumactl install control-plane | kubectl apply -f -`,
+		Use:   "control-plane",
+		Short: "Install Kuma Control Plane on Kubernetes",
+		Long:  `Install Kuma Control Plane on Kubernetes.`,
+		Example: `# Install Kuma on Kubernetes
+		kumactl install control-plane | kubectl apply -f -
+	  
+		# Generate installation script for a target platform. At the moment, always generate Kubernetes YAML
+		kumactl install control-plane`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			if args.AdmissionServerTlsCert == "" && args.AdmissionServerTlsKey == "" {
 				fqdn := fmt.Sprintf("%s.%s.svc", args.ControlPlaneServiceName, args.Namespace)

--- a/app/kumactl/cmd/install/install_control_plane.go
+++ b/app/kumactl/cmd/install/install_control_plane.go
@@ -62,9 +62,10 @@ func newInstallControlPlaneCmd(pctx *kumactl_cmd.RootContext) *cobra.Command {
 		SdsTlsKey:               "",
 	}
 	cmd := &cobra.Command{
-		Use:   "control-plane",
-		Short: "Install Kuma Control Plane on Kubernetes",
-		Long:  `Install Kuma Control Plane on Kubernetes.`,
+		Use:     "control-plane",
+		Short:   "Install Kuma Control Plane on Kubernetes",
+		Long:    `Install Kuma Control Plane on Kubernetes.`,
+		Example: `1. kumactl install control-plane | kubectl apply -f -`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			if args.AdmissionServerTlsCert == "" && args.AdmissionServerTlsKey == "" {
 				fqdn := fmt.Sprintf("%s.%s.svc", args.ControlPlaneServiceName, args.Namespace)

--- a/app/kumactl/cmd/install/install_control_plane.go
+++ b/app/kumactl/cmd/install/install_control_plane.go
@@ -65,11 +65,11 @@ func newInstallControlPlaneCmd(pctx *kumactl_cmd.RootContext) *cobra.Command {
 		Use:   "control-plane",
 		Short: "Install Kuma Control Plane on Kubernetes",
 		Long:  `Install Kuma Control Plane on Kubernetes.`,
-		Example: `# Install Kuma on Kubernetes
-		kumactl install control-plane | kubectl apply -f -
+		Example: `1. Install Kuma on Kubernetes
+$: kumactl install control-plane | kubectl apply -f -
 	  
-		# Generate installation script for a target platform. At the moment, always generate Kubernetes YAML
-		kumactl install control-plane`,
+2. Generate installation script for a target platform. At the moment, always generate Kubernetes YAML
+$: kumactl install control-plane`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			if args.AdmissionServerTlsCert == "" && args.AdmissionServerTlsKey == "" {
 				fqdn := fmt.Sprintf("%s.%s.svc", args.ControlPlaneServiceName, args.Namespace)

--- a/docs/cmd/kumactl/HELP.md
+++ b/docs/cmd/kumactl/HELP.md
@@ -34,6 +34,14 @@ Create or modify Kuma resources.
 Usage:
   kumactl apply [flags]
 
+Examples:
+# Basic
+		kumactl apply my-dataplane.yml
+
+		# Apply a remote configuration
+		kumactl apply https://github.com/Kong/kuma/blob/master/dev/examples/universal/dataplanes/example.yaml
+		
+
 Flags:
   -f, --file string          Path to file to apply
   -h, --help                 help for apply
@@ -385,6 +393,9 @@ Show TrafficLog entities.
 
 Usage:
   kumactl get traffic-logs [flags]
+
+Examples:
+kumactl get traffic-logs -ojson | jq '.items[] | select(.name == "my-log-entity")'
 
 Flags:
   -h, --help   help for traffic-logs

--- a/docs/cmd/kumactl/HELP.md
+++ b/docs/cmd/kumactl/HELP.md
@@ -340,6 +340,15 @@ Show Meshes.
 Usage:
   kumactl get meshes [flags]
 
+Examples:
+# Get all service meshes
+		kumactl get meshes
+
+		# Get service meshes using mtls
+		kumactl get meshes -ojson | jq '.items[] | select(.mtls.enabled == true) | .name
+
+		
+
 Flags:
   -h, --help   help for meshes
 
@@ -375,6 +384,14 @@ Show ProxyTemplates.
 
 Usage:
   kumactl get proxytemplates [flags]
+
+Examples:
+# Get all proxy template
+		kumactl get proxytemplates
+		
+		# Get all proxy templae of specific Mesh
+		kumactl get proxytemplate -ojson | jq '.items[] | select(.mesh == "my-service-mesh" | .name)'
+		
 
 Flags:
   -h, --help   help for proxytemplates
@@ -435,6 +452,15 @@ Show TrafficRoutes.
 
 Usage:
   kumactl get traffic-routes [flags]
+
+Examples:
+
+		# Get all traffic routes name
+		kumactl get traffic-routes -ojson | jq '.items[].name'
+		
+		# Get traffic routes for a specific service Mesh
+		kumactl get traffic-routes -ojson | jq '.items[] | select(.mesh == "my-service-mesh")'
+		
 
 Flags:
   -h, --help   help for traffic-routes

--- a/docs/cmd/kumactl/HELP.md
+++ b/docs/cmd/kumactl/HELP.md
@@ -168,6 +168,13 @@ Add a Control Plane.
 Usage:
   kumactl config control-planes add [flags]
 
+Examples:
+
+		Add a new control plane
+$: kumactl config control-planes add --name my-new --address my-new-cp.my-domain.com --dataplane-token-client-cert 'path/to/cert.pem' --dataplane-token-client-key 'path/to/key.pem'
+added Control Plane "my-new"
+switch active Control Plane to "my-new"
+
 Flags:
       --address string                       URL of the Control Plane API Server (required)
       --dataplane-token-client-cert string   Path to certificate of a client that is authorized to use Dataplane Token Server
@@ -277,7 +284,7 @@ Flags:
       --admission-server-tls-key string     TLS key for the admission web hooks implemented by the Kuma Control Plane
       --control-plane-image string          image of the Kuma Control Plane component (default "kong-docker-kuma-docker.bintray.io/kuma-cp")
       --control-plane-service-name string   Service name of the Kuma Control Plane (default "kuma-control-plane")
-      --control-plane-version string        version shared by all components of the Kuma Control Plane (default "latest")
+      --control-plane-version string        version shared by all components of the Kuma Control Plane (default "0.2.2-136-g000e670")
       --dataplane-image string              image of the Kuma Dataplane component (default "kong-docker-kuma-docker.bintray.io/kuma-dp")
       --dataplane-init-image string         init image of the Kuma Dataplane component (default "docker.io/istio/proxy_init")
       --dataplane-init-version string       version of the init image of the Kuma Dataplane component (default "1.1.2")

--- a/docs/cmd/kumactl/HELP.md
+++ b/docs/cmd/kumactl/HELP.md
@@ -151,6 +151,12 @@ List Control Planes.
 Usage:
   kumactl config control-planes list [flags]
 
+Examples:
+To retrieve all Control Planes from anyone Context:
+		$:kumactl config control-planes list
+		
+		This command displays if the Control Plane is active, its url and its name.
+
 Flags:
   -h, --help   help for list
 

--- a/docs/cmd/kumactl/HELP.md
+++ b/docs/cmd/kumactl/HELP.md
@@ -216,6 +216,13 @@ Install Kuma Control Plane on Kubernetes.
 Usage:
   kumactl install control-plane [flags]
 
+Examples:
+# Install Kuma on Kubernetes
+		kumactl install control-plane | kubectl apply -f -
+	  
+		# Generate installation script for a target platform. At the moment, always generate Kubernetes YAML
+		kumactl install control-plane
+
 Flags:
       --admission-server-tls-cert string    TLS certificate for the admission web hooks implemented by the Kuma Control Plane
       --admission-server-tls-key string     TLS key for the admission web hooks implemented by the Kuma Control Plane
@@ -397,6 +404,9 @@ Show TrafficPermission entities.
 Usage:
   kumactl get traffic-permissions [flags]
 
+Examples:
+kumactl get traffic-permissions -o json | jq '[.items[] |  .name ]'
+
 Flags:
   -h, --help   help for traffic-permissions
 
@@ -472,6 +482,9 @@ Inspect Dataplanes.
 
 Usage:
   kumactl inspect dataplanes [flags]
+
+Examples:
+kumactl inspect dataplanes -o json | jq '.items[0].dataplaneInsight.subscriptions[0].status.total.responsesSent
 
 Flags:
   -h, --help                 help for dataplanes

--- a/docs/cmd/kumactl/HELP.md
+++ b/docs/cmd/kumactl/HELP.md
@@ -367,6 +367,12 @@ Show Dataplanes.
 Usage:
   kumactl get dataplanes [flags]
 
+Examples:
+1. Get all dataplane's name:
+		kumactl get dataplanes -ojson | jq '.items[].name'
+		2. Get all dataplanes with inbounds configuration having specific tag:
+		kumactl get dataplane -ojson | jq '.items[] | select(.networking.inbound[].tags.my-tag == "value") | .name'
+
 Flags:
   -h, --help   help for dataplanes
 

--- a/docs/cmd/kumactl/HELP.md
+++ b/docs/cmd/kumactl/HELP.md
@@ -35,11 +35,11 @@ Usage:
   kumactl apply [flags]
 
 Examples:
-# Basic
-		kumactl apply my-dataplane.yml
+1. Basic
+$: kumactl apply my-dataplane.yml
 
-		# Apply a remote configuration
-		kumactl apply https://github.com/Kong/kuma/blob/master/dev/examples/universal/dataplanes/example.yaml
+2. Apply a remote configuration
+$: kumactl apply https://github.com/Kong/kuma/blob/master/dev/examples/universal/dataplanes/example.yaml
 		
 
 Flags:
@@ -86,7 +86,7 @@ Usage:
 
 Examples:
 :$ kumactl config view
-control_planes:
+> control_planes:
     - name: my-first-cp
         coordinates:
             api_server:
@@ -153,9 +153,9 @@ Usage:
 
 Examples:
 To retrieve all Control Planes from anyone Context:
-		$:kumactl config control-planes list
+$:kumactl config control-planes list
 		
-		This command displays if the Control Plane is active, its url and its name.
+This command displays if the Control Plane is active, its url and its name.
 
 Flags:
   -h, --help   help for list
@@ -285,11 +285,11 @@ Usage:
   kumactl install control-plane [flags]
 
 Examples:
-# Install Kuma on Kubernetes
-		kumactl install control-plane | kubectl apply -f -
+1. Install Kuma on Kubernetes
+$: kumactl install control-plane | kubectl apply -f -
 	  
-		# Generate installation script for a target platform. At the moment, always generate Kubernetes YAML
-		kumactl install control-plane
+2. Generate installation script for a target platform. At the moment, always generate Kubernetes YAML
+$: kumactl install control-plane
 
 Flags:
       --admission-server-tls-cert string    TLS certificate for the admission web hooks implemented by the Kuma Control Plane
@@ -401,12 +401,11 @@ Usage:
   kumactl get meshes [flags]
 
 Examples:
-# Get all service meshes
-		kumactl get meshes
+1. Get all service meshes
+$: kumactl get meshes
 
-		# Get service meshes using mtls
-		kumactl get meshes -ojson | jq '.items[] | select(.mtls.enabled == true) | .name
-
+2. Get service meshes using mtls
+$: kumactl get meshes -ojson | jq '.items[] | select(.mtls.enabled == true) | .name
 		
 
 Flags:
@@ -429,9 +428,10 @@ Usage:
 
 Examples:
 1. Get all dataplane's name:
-		kumactl get dataplanes -ojson | jq '.items[].name'
-		2. Get all dataplanes with inbounds configuration having specific tag:
-		kumactl get dataplane -ojson | jq '.items[] | select(.networking.inbound[].tags.my-tag == "value") | .name'
+$: kumactl get dataplanes -ojson | jq '.items[].name'
+
+2. Get all dataplanes with inbounds configuration having specific tag:
+$: kumactl get dataplane -ojson | jq '.items[] | select(.networking.inbound[].tags.my-tag == "value") | .name'
 
 Flags:
   -h, --help   help for dataplanes
@@ -478,7 +478,8 @@ Usage:
   kumactl get traffic-logs [flags]
 
 Examples:
-kumactl get traffic-logs -ojson | jq '.items[] | select(.name == "my-log-entity")'
+To retrieve name of my entities:
+$: kumactl get traffic-logs -ojson | jq '.items[] | select(.name == "my-log-entity")'
 
 Flags:
   -h, --help   help for traffic-logs
@@ -521,11 +522,11 @@ Usage:
 
 Examples:
 
-		# Get all traffic routes name
-		kumactl get traffic-routes -ojson | jq '.items[].name'
+1.  Get all traffic routes name:
+$: kumactl get traffic-routes -ojson | jq '.items[].name'
 		
-		# Get traffic routes for a specific service Mesh
-		kumactl get traffic-routes -ojson | jq '.items[] | select(.mesh == "my-service-mesh")'
+2.Get traffic routes for a specific service Mesh
+$: kumactl get traffic-routes -ojson | jq '.items[] | select(.mesh == "my-service-mesh")'
 		
 
 Flags:

--- a/docs/cmd/kumactl/HELP.md
+++ b/docs/cmd/kumactl/HELP.md
@@ -197,6 +197,12 @@ Remove a Control Plane.
 Usage:
   kumactl config control-planes remove [flags]
 
+Examples:
+To remove a Control Plane named "my-cp":
+$: kumactl config control-planes remove --name my-cp
+> removed Control Plane "my-cp"
+In case if this one is the current Control Plane, you will need to switch manually to a new one.
+
 Flags:
   -h, --help          help for remove
       --name string   reference name for the Control Plane (required)
@@ -284,7 +290,7 @@ Flags:
       --admission-server-tls-key string     TLS key for the admission web hooks implemented by the Kuma Control Plane
       --control-plane-image string          image of the Kuma Control Plane component (default "kong-docker-kuma-docker.bintray.io/kuma-cp")
       --control-plane-service-name string   Service name of the Kuma Control Plane (default "kuma-control-plane")
-      --control-plane-version string        version shared by all components of the Kuma Control Plane (default "0.2.2-136-g000e670")
+      --control-plane-version string        version shared by all components of the Kuma Control Plane (default "latest")
       --dataplane-image string              image of the Kuma Dataplane component (default "kong-docker-kuma-docker.bintray.io/kuma-dp")
       --dataplane-init-image string         init image of the Kuma Dataplane component (default "docker.io/istio/proxy_init")
       --dataplane-init-version string       version of the init image of the Kuma Dataplane component (default "1.1.2")

--- a/docs/cmd/kumactl/HELP.md
+++ b/docs/cmd/kumactl/HELP.md
@@ -84,6 +84,31 @@ Show kumactl config.
 Usage:
   kumactl config view [flags]
 
+Examples:
+:$ kumactl config view
+control_planes:
+    - name: my-first-cp
+        coordinates:
+            api_server:
+            url: https://cp1.internal:5681
+    - name: my-second-cp
+        coordinates:
+            api_server:
+            url: https://cp1.internal:5681
+		
+contexts:
+    - name: stage1
+        control_plane: my-first-cp
+        defaults:
+            mesh: pilot
+    - name: stage2
+        control_plane: test2
+        defaults:
+            mesh: default
+
+current_context: stage1
+		
+
 Flags:
   -h, --help   help for view
 
@@ -182,6 +207,22 @@ Switch active Control Plane.
 
 Usage:
   kumactl config control-planes switch [flags]
+
+Examples:
+If you have in your deployment configuration several contexts, for example:
+contexts:
+    - name: ctx1
+        control_plane: cp1
+        defaults:
+           mesh: pilot
+    - name: ctx2
+        control_plane: cp2
+        defaults:
+        mesh: default
+
+:$ kumactl config control-planes switch ctx2
+switched active Control Plate to "ctx2"
+
 
 Flags:
   -h, --help          help for switch
@@ -485,6 +526,14 @@ Delete Kuma resources.
 
 Usage:
   kumactl delete TYPE NAME [flags]
+
+Examples:
+1. Delete a Mesh:
+:$ kumactl delete mesh my-mesh 
+deleted mesh "my-mesh"
+
+Those resource types can be used: mesh, dataplane, proxytemplate, traffic-log, traffic-permission and traffic-route.
+		
 
 Flags:
   -h, --help   help for delete


### PR DESCRIPTION
### Summary

Add help documentation for remaining command without one.

### Full changelog
- [x] install control-plane
- [x] inspect dataplane
- [x] get traffic-permissions
- [x] get traffic-logs
- [x] get meshes
- [x] get proxy-templates
- [x] get trafficroutes
- [x] get dataplanes
- [x] generate dataplane-tokens
- [x] delete
- [x] config view
- [x] config control-planes switch
- [x] config control-planes add
- [x] config control-planes remove
- [ ] config control-planes list
- [x] apply



### Issues resolved

Fix #362 
