### PR TITLE
feat(*) add flag to skip default mesh creation, remove config option

### DIFF
--- a/pkg/api-server/config_ws_test.go
+++ b/pkg/api-server/config_ws_test.go
@@ -110,7 +110,7 @@ var _ = Describe("Config WS", func() {
             }
           },
           "defaults": {
-            "mesh": "type: Mesh\nname: default\n"
+            "skipMeshCreation": false
           },
           "dnsServer": {
             "domain": "mesh",

--- a/pkg/config/app/kuma-cp/config.go
+++ b/pkg/config/app/kuma-cp/config.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/kumahq/kuma/pkg/config/mode"
 
-	"github.com/kumahq/kuma/api/mesh/v1alpha1"
 	"github.com/kumahq/kuma/pkg/config"
 	admin_server "github.com/kumahq/kuma/pkg/config/admin-server"
 	api_server "github.com/kumahq/kuma/pkg/config/api-server"
@@ -20,8 +19,6 @@ import (
 	token_server "github.com/kumahq/kuma/pkg/config/token-server"
 	"github.com/kumahq/kuma/pkg/config/xds"
 	"github.com/kumahq/kuma/pkg/config/xds/bootstrap"
-	util_error "github.com/kumahq/kuma/pkg/util/error"
-	"github.com/kumahq/kuma/pkg/util/proto"
 )
 
 var _ config.Config = &Config{}
@@ -29,30 +26,14 @@ var _ config.Config = &Config{}
 var _ config.Config = &Defaults{}
 
 type Defaults struct {
-	// Default Mesh configuration in YAML that will be applied on first usage of Kuma CP
-	Mesh string `yaml:"mesh"`
+	SkipMeshCreation bool `yaml:"skipMeshCreation" envconfig:"kuma_defaults_skip_mesh_creation"`
 }
 
 func (d *Defaults) Sanitize() {
 }
 
-func (d *Defaults) MeshProto() v1alpha1.Mesh {
-	mesh, err := d.parseMesh()
-	util_error.MustNot(err)
-	return mesh
-}
-
-func (d *Defaults) parseMesh() (v1alpha1.Mesh, error) {
-	mesh := v1alpha1.Mesh{}
-	if err := proto.FromYAML([]byte(d.Mesh), &mesh); err != nil {
-		return mesh, errors.Wrap(err, "Mesh is not valid")
-	}
-	return mesh, nil
-}
-
 func (d *Defaults) Validate() error {
-	_, err := d.parseMesh()
-	return err
+	return nil
 }
 
 type Metrics struct {
@@ -160,9 +141,7 @@ func DefaultConfig() Config {
 		BootstrapServer:            bootstrap.DefaultBootstrapServerConfig(),
 		Runtime:                    runtime.DefaultRuntimeConfig(),
 		Defaults: &Defaults{
-			Mesh: `type: Mesh
-name: default
-`,
+			SkipMeshCreation: false,
 		},
 		Metrics: &Metrics{
 			Dataplane: &DataplaneMetrics{

--- a/pkg/config/app/kuma-cp/kuma-cp.defaults.yaml
+++ b/pkg/config/app/kuma-cp/kuma-cp.defaults.yaml
@@ -215,10 +215,7 @@ runtime:
 
 # Default Kuma entities configuration
 defaults:
-  # Default Mesh configuration in YAML that will be applied on first usage of Kuma CP
-  mesh: | # ENV: KUMA_DEFAULTS_MESH
-    type: Mesh
-    name: default
+  skipMeshCreation: false # ENV: KUMA_DEFAULTS_SKIP_MESH_CREATION
 
 # Metrics configuration
 metrics:

--- a/pkg/config/loader_test.go
+++ b/pkg/config/loader_test.go
@@ -135,6 +135,8 @@ var _ = Describe("Config loader", func() {
 			Expect(cfg.KDS.Server.TlsCertFile).To(Equal("/cert"))
 			Expect(cfg.KDS.Server.TlsKeyFile).To(Equal("/key"))
 			Expect(cfg.KDS.Client.RootCAFile).To(Equal("/rootCa"))
+
+			Expect(cfg.Defaults.SkipMeshCreation).To(BeTrue())
 		},
 		Entry("from config file", testCase{
 			envVars: map[string]string{},
@@ -231,6 +233,8 @@ kds:
     tlsKeyFile: /key
   client:
     rootCaFile: /rootCa
+defaults:
+  skipMeshCreation: true
 `,
 		}),
 		Entry("from env variables", testCase{
@@ -293,6 +297,7 @@ kds:
 				"KUMA_KDS_SERVER_TLS_CERT_FILE":                                 "/cert",
 				"KUMA_KDS_SERVER_TLS_KEY_FILE":                                  "/key",
 				"KUMA_KDS_CLIENT_ROOT_CA_FILE":                                  "/rootCa",
+				"KUMA_DEFAULTS_SKIP_MESH_CREATION":                              "true",
 			},
 			yamlFileConfig: "",
 		}),

--- a/pkg/core/bootstrap/bootstrap.go
+++ b/pkg/core/bootstrap/bootstrap.go
@@ -3,6 +3,8 @@ package bootstrap
 import (
 	"context"
 
+	"github.com/kumahq/kuma/api/mesh/v1alpha1"
+
 	"github.com/kumahq/kuma/pkg/config/mode"
 
 	config_manager "github.com/kumahq/kuma/pkg/core/config/manager"
@@ -136,10 +138,13 @@ func createDefaultSigningKey(runtime core_runtime.Runtime) error {
 func createDefaultMesh(runtime core_runtime.Runtime) error {
 	switch env := runtime.Config().Environment; env {
 	case config_core.KubernetesEnvironment:
-		// default Mesh on Kubernetes is managed by a Controller
+		// default Mesh on Kubernetes is managed by the Namespace Controller
 		return nil
 	case config_core.UniversalEnvironment:
-		return mesh_managers.CreateDefaultMesh(runtime.ResourceManager(), runtime.Config().Defaults.MeshProto())
+		if runtime.Config().Defaults.SkipMeshCreation {
+			return nil
+		}
+		return mesh_managers.CreateDefaultMesh(runtime.ResourceManager(), v1alpha1.Mesh{})
 	default:
 		return errors.Errorf("unknown environment type %s", env)
 	}

--- a/pkg/core/bootstrap/bootstrap_test.go
+++ b/pkg/core/bootstrap/bootstrap_test.go
@@ -3,6 +3,8 @@ package bootstrap
 import (
 	"context"
 
+	"github.com/kumahq/kuma/api/mesh/v1alpha1"
+
 	kuma_cp "github.com/kumahq/kuma/pkg/config/app/kuma-cp"
 	mesh_managers "github.com/kumahq/kuma/pkg/core/managers/apis/mesh"
 	"github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
@@ -58,7 +60,7 @@ var _ = Describe("Bootstrap", func() {
 		runtime, err := buildRuntime(cfg)
 		Expect(err).ToNot(HaveOccurred())
 
-		template := runtime.Config().Defaults.MeshProto()
+		template := v1alpha1.Mesh{}
 
 		// when
 		Expect(mesh_managers.CreateDefaultMesh(runtime.ResourceManager(), template)).To(Succeed())

--- a/pkg/plugins/runtime/k8s/controllers/namespace_controller.go
+++ b/pkg/plugins/runtime/k8s/controllers/namespace_controller.go
@@ -31,10 +31,11 @@ type NamespaceReconciler struct {
 	kube_client.Client
 	Log logr.Logger
 
-	SystemNamespace     string
-	CNIEnabled          bool
-	ResourceManager     core_manager.ResourceManager
-	DefaultMeshTemplate mesh_proto.Mesh
+	SystemNamespace         string
+	CNIEnabled              bool
+	SkipDefaultMeshCreation bool
+	ResourceManager         core_manager.ResourceManager
+	DefaultMeshTemplate     mesh_proto.Mesh
 }
 
 // Reconcile is in charge for two things:
@@ -57,7 +58,7 @@ func (r *NamespaceReconciler) Reconcile(req kube_ctrl.Request) (kube_ctrl.Result
 		return kube_ctrl.Result{}, err
 	}
 
-	if req.Name == r.SystemNamespace {
+	if req.Name == r.SystemNamespace && !r.SkipDefaultMeshCreation {
 		// Fetch default Mesh instance
 		mesh := &mesh_k8s.Mesh{}
 		name := kube_types.NamespacedName{Name: core_model.DefaultMesh}

--- a/pkg/plugins/runtime/k8s/controllers/namespace_controller_test.go
+++ b/pkg/plugins/runtime/k8s/controllers/namespace_controller_test.go
@@ -14,16 +14,25 @@ import (
 	kube_reconcile "sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"github.com/kumahq/kuma/pkg/core"
-	v1 "github.com/kumahq/kuma/pkg/plugins/runtime/k8s/apis/k8s.cni.cncf.io/v1"
+	core_mesh "github.com/kumahq/kuma/pkg/core/managers/apis/mesh"
+	mesh_core "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
+	"github.com/kumahq/kuma/pkg/core/resources/manager"
+	core_model "github.com/kumahq/kuma/pkg/core/resources/model"
+	"github.com/kumahq/kuma/pkg/plugins/resources/memory"
 	"github.com/kumahq/kuma/pkg/plugins/runtime/k8s/controllers"
+
+	v1 "github.com/kumahq/kuma/pkg/plugins/runtime/k8s/apis/k8s.cni.cncf.io/v1"
 )
 
 var _ = Describe("NamespaceReconciler", func() {
 
 	var kubeClient kube_client.Client
 	var reconciler kube_reconcile.Reconciler
+	var resManager manager.ResourceManager
 
 	BeforeEach(func() {
+		resStore := memory.NewStore()
+		resManager = manager.NewResourceManager(resStore)
 
 		kubeClient = kube_client_fake.NewFakeClientWithScheme(
 			k8sClientScheme,
@@ -49,89 +58,160 @@ var _ = Describe("NamespaceReconciler", func() {
 				},
 			},
 		)
-
-		reconciler = &controllers.NamespaceReconciler{
-			Client:          kubeClient,
-			SystemNamespace: "kuma-system",
-			CNIEnabled:      true,
-			Log:             core.Log.WithName("test"),
-		}
 	})
 
-	It("should create NetworkAttachmentDefinition", func() {
-		// given
-		req := kube_ctrl.Request{
-			NamespacedName: kube_types.NamespacedName{
-				Namespace: "non-system-ns-with-sidecar-injection",
-				Name:      "non-system-ns-with-sidecar-injection",
-			},
-		}
+	When("SkipDefaultMeshCreation is not set", func() {
+		BeforeEach(func() {
 
-		// when
-		result, err := reconciler.Reconcile(req)
-		// then
-		Expect(err).ToNot(HaveOccurred())
-		// and
-		Expect(result).To(BeZero())
+			reconciler = &controllers.NamespaceReconciler{
+				Client:          kubeClient,
+				SystemNamespace: "kuma-system",
+				CNIEnabled:      true,
+				Log:             core.Log.WithName("test"),
+				ResourceManager: resManager,
+			}
+		})
 
-		// when
-		nads := &v1.NetworkAttachmentDefinitionList{}
-		err = kubeClient.List(context.Background(), nads)
-		// then
-		Expect(err).ToNot(HaveOccurred())
-		// and
-		Expect(nads.Items).To(HaveLen(1))
-		Expect(nads.Items[0].Namespace).To(Equal("non-system-ns-with-sidecar-injection"))
-		Expect(nads.Items[0].Name).To(Equal("kuma-cni"))
+		It("should create NetworkAttachmentDefinition", func() {
+			// given
+			req := kube_ctrl.Request{
+				NamespacedName: kube_types.NamespacedName{
+					Namespace: "non-system-ns-with-sidecar-injection",
+					Name:      "non-system-ns-with-sidecar-injection",
+				},
+			}
+
+			// when
+			result, err := reconciler.Reconcile(req)
+			// then
+			Expect(err).ToNot(HaveOccurred())
+			// and
+			Expect(result).To(BeZero())
+
+			// when
+			nads := &v1.NetworkAttachmentDefinitionList{}
+			err = kubeClient.List(context.Background(), nads)
+			// then
+			Expect(err).ToNot(HaveOccurred())
+			// and
+			Expect(nads.Items).To(HaveLen(1))
+			Expect(nads.Items[0].Namespace).To(Equal("non-system-ns-with-sidecar-injection"))
+			Expect(nads.Items[0].Name).To(Equal("kuma-cni"))
+		})
+
+		It("should ignore system namespace", func() {
+			// given
+			req := kube_ctrl.Request{
+				NamespacedName: kube_types.NamespacedName{
+					Namespace: "kuma-system",
+					Name:      "kuma-system",
+				},
+			}
+
+			// when
+			result, err := reconciler.Reconcile(req)
+			// then
+			Expect(err).ToNot(HaveOccurred())
+			// and
+			Expect(result).To(BeZero())
+
+			// when
+			nads := &v1.NetworkAttachmentDefinitionList{}
+			err = kubeClient.List(context.Background(), nads)
+			// then
+			Expect(err).ToNot(HaveOccurred())
+			// and
+			Expect(nads.Items).To(HaveLen(0))
+		})
+
+		It("should create the default mesh for the system namespace", func() {
+			// given
+			req := kube_ctrl.Request{
+				NamespacedName: kube_types.NamespacedName{
+					Namespace: "kuma-system",
+					Name:      "kuma-system",
+				},
+			}
+
+			// when
+			result, err := reconciler.Reconcile(req)
+			// then
+			Expect(err).ToNot(HaveOccurred())
+			// and
+			Expect(result).To(BeZero())
+
+			// when
+			mesh := &mesh_core.MeshResource{}
+			exists, err := core_mesh.FetchDefaultMeshIfExists(resManager, mesh)
+			// then
+			Expect(err).ToNot(HaveOccurred())
+			// and
+			Expect(exists).To(BeTrue())
+			Expect(mesh.GetMeta().GetName()).To(Equal(core_model.DefaultMesh))
+		})
+
+		It("should ignore namespace namespaces without label", func() {
+			// given
+			req := kube_ctrl.Request{
+				NamespacedName: kube_types.NamespacedName{
+					Namespace: "non-system-ns-without-sidecar-injection",
+					Name:      "non-system-ns-without-sidecar-injection",
+				},
+			}
+
+			// when
+			result, err := reconciler.Reconcile(req)
+			// then
+			Expect(err).ToNot(HaveOccurred())
+			// and
+			Expect(result).To(BeZero())
+
+			// when
+			nads := &v1.NetworkAttachmentDefinitionList{}
+			err = kubeClient.List(context.Background(), nads)
+			// then
+			Expect(err).ToNot(HaveOccurred())
+			// and
+			Expect(nads.Items).To(HaveLen(0))
+		})
 	})
 
-	It("should ignore system namespace", func() {
-		// given
-		req := kube_ctrl.Request{
-			NamespacedName: kube_types.NamespacedName{
-				Namespace: "kube-system",
-				Name:      "kuma-system",
-			},
-		}
+	When("SkipDefaultMeshCreation is set", func() {
+		BeforeEach(func() {
 
-		// when
-		result, err := reconciler.Reconcile(req)
-		// then
-		Expect(err).ToNot(HaveOccurred())
-		// and
-		Expect(result).To(BeZero())
+			reconciler = &controllers.NamespaceReconciler{
+				Client:                  kubeClient,
+				SystemNamespace:         "kuma-system",
+				SkipDefaultMeshCreation: true,
+				CNIEnabled:              true,
+				Log:                     core.Log.WithName("test"),
+				ResourceManager:         resManager,
+			}
+		})
 
-		// when
-		nads := &v1.NetworkAttachmentDefinitionList{}
-		err = kubeClient.List(context.Background(), nads)
-		// then
-		Expect(err).ToNot(HaveOccurred())
-		// and
-		Expect(nads.Items).To(HaveLen(0))
-	})
+		It("should skip creating default mesh", func() {
+			// given
+			req := kube_ctrl.Request{
+				NamespacedName: kube_types.NamespacedName{
+					Namespace: "non-system-ns-with-sidecar-injection",
+					Name:      "non-system-ns-with-sidecar-injection",
+				},
+			}
 
-	It("should ignore namespace namespaces without label", func() {
-		// given
-		req := kube_ctrl.Request{
-			NamespacedName: kube_types.NamespacedName{
-				Namespace: "non-system-ns-without-sidecar-injection",
-				Name:      "non-system-ns-without-sidecar-injection",
-			},
-		}
+			// when
+			result, err := reconciler.Reconcile(req)
+			// then
+			Expect(err).ToNot(HaveOccurred())
+			// and
+			Expect(result).To(BeZero())
 
-		// when
-		result, err := reconciler.Reconcile(req)
-		// then
-		Expect(err).ToNot(HaveOccurred())
-		// and
-		Expect(result).To(BeZero())
-
-		// when
-		nads := &v1.NetworkAttachmentDefinitionList{}
-		err = kubeClient.List(context.Background(), nads)
-		// then
-		Expect(err).ToNot(HaveOccurred())
-		// and
-		Expect(nads.Items).To(HaveLen(0))
+			// when
+			mesh := &mesh_core.MeshResource{}
+			exists, err := core_mesh.FetchDefaultMeshIfExists(resManager, mesh)
+			// then
+			Expect(err).ToNot(HaveOccurred())
+			// and
+			Expect(exists).To(BeFalse())
+		})
 	})
 })

--- a/pkg/plugins/runtime/k8s/plugin.go
+++ b/pkg/plugins/runtime/k8s/plugin.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/kumahq/kuma/api/mesh/v1alpha1"
+
 	"github.com/kumahq/kuma/pkg/config/mode"
 
 	"github.com/kumahq/kuma/pkg/core/secrets/manager"
@@ -71,12 +73,13 @@ func addControllers(mgr kube_ctrl.Manager, rt core_runtime.Runtime) error {
 
 func addNamespaceReconciler(mgr kube_ctrl.Manager, rt core_runtime.Runtime) error {
 	reconciler := &k8s_controllers.NamespaceReconciler{
-		Client:              mgr.GetClient(),
-		Log:                 core.Log.WithName("controllers").WithName("Namespace"),
-		SystemNamespace:     rt.Config().Store.Kubernetes.SystemNamespace,
-		CNIEnabled:          rt.Config().Runtime.Kubernetes.Injector.CNIEnabled,
-		ResourceManager:     rt.ResourceManager(),
-		DefaultMeshTemplate: rt.Config().Defaults.MeshProto(),
+		Client:                  mgr.GetClient(),
+		Log:                     core.Log.WithName("controllers").WithName("Namespace"),
+		SystemNamespace:         rt.Config().Store.Kubernetes.SystemNamespace,
+		CNIEnabled:              rt.Config().Runtime.Kubernetes.Injector.CNIEnabled,
+		ResourceManager:         rt.ResourceManager(),
+		SkipDefaultMeshCreation: rt.Config().Defaults.SkipMeshCreation,
+		DefaultMeshTemplate:     v1alpha1.Mesh{},
 	}
 	return reconciler.SetupWithManager(mgr)
 }


### PR DESCRIPTION
### Summary

Adds the ability to skip default mesh creation, which will unblock using Helm to manage the default mesh (as noted in #887). Also removes the ability to customize the default mesh through configuration.

### Full changelog

* adds config option `defaults.skipDefaultMeshCreation`, which defaults to `false`
  * adds corresponding env variable `KUMA_DEFAULTS_SKIP_DEFAULT_MESH_CREATION`
* removes config option `defaults.mesh`
* adds corresponding flag in the `NamespaceReconciller` 
* adds helper method `FetchDefaultMeshIfExists` to faciliate easier testing 
* adds tests for default mesh creation and skipping in the `NamespaceReconciller` 

### Issues resolved

Fix #887

### Documentation

N/A