### PR TITLE
feat(kuma-cp) support for http2

### DIFF
--- a/pkg/core/resources/apis/mesh/dataplane_helpers.go
+++ b/pkg/core/resources/apis/mesh/dataplane_helpers.go
@@ -17,12 +17,15 @@ const (
 	ProtocolUnknown = "<unknown>"
 	ProtocolTCP     = "tcp"
 	ProtocolHTTP    = "http"
+	ProtocolHTTP2   = "http2"
 )
 
 func ParseProtocol(tag string) Protocol {
 	switch strings.ToLower(tag) {
 	case ProtocolHTTP:
 		return ProtocolHTTP
+	case ProtocolHTTP2:
+		return ProtocolHTTP2
 	case ProtocolTCP:
 		return ProtocolTCP
 	default:
@@ -44,6 +47,7 @@ func (l ProtocolList) Strings() []string {
 // SupportedProtocols is a list of supported protocols that will be communicated to a user.
 var SupportedProtocols = ProtocolList{
 	ProtocolHTTP,
+	ProtocolHTTP2,
 	ProtocolTCP,
 }
 

--- a/pkg/core/resources/apis/mesh/dataplane_helpers_test.go
+++ b/pkg/core/resources/apis/mesh/dataplane_helpers_test.go
@@ -462,7 +462,7 @@ var _ = Describe("ParseProtocol()", func() {
 		}),
 		Entry("http2", testCase{
 			tag:      "http2",
-			expected: ProtocolUnknown,
+			expected: ProtocolHTTP2,
 		}),
 		Entry("grpc", testCase{
 			tag:      "grpc",

--- a/pkg/core/resources/apis/mesh/dataplane_validator_test.go
+++ b/pkg/core/resources/apis/mesh/dataplane_validator_test.go
@@ -337,7 +337,7 @@ var _ = Describe("Dataplane", func() {
 			expected: `
                 violations:
                 - field: 'networking.inbound[0].tags["protocol"]'
-                  message: 'tag "protocol" has an invalid value "". Allowed values: http, tcp'
+                  message: 'tag "protocol" has an invalid value "". Allowed values: http, http2, tcp'
                 - field: 'networking.inbound[0].tags["protocol"]'
                   message: tag value cannot be empty`,
 		}),
@@ -359,7 +359,7 @@ var _ = Describe("Dataplane", func() {
 			expected: `
                 violations:
                 - field: 'networking.inbound[0].tags["protocol"]'
-                  message: 'tag "protocol" has an invalid value "not-yet-supported-protocol". Allowed values: http, tcp'`,
+                  message: 'tag "protocol" has an invalid value "not-yet-supported-protocol". Allowed values: http, http2, tcp'`,
 		}),
 		Entry("networking.gateway: empty service tag", testCase{
 			dataplane: `

--- a/pkg/plugins/runtime/k8s/webhooks/service_validator_test.go
+++ b/pkg/plugins/runtime/k8s/webhooks/service_validator_test.go
@@ -168,16 +168,15 @@ var _ = Describe("ServiceValidator", func() {
               details:
                 causes:
                 - field: metadata.annotations["8081.service.kuma.io/protocol"]
-                  message: 'value "" is not valid. Allowed values: http, tcp'
+                  message: 'value "" is not valid. Allowed values: http, http2, tcp'
                   reason: FieldValueInvalid
                 - field: metadata.annotations["8082.service.kuma.io/protocol"]
-                  message: 'value "not-yet-supported-protocol" is not valid. Allowed values: http,
-                    tcp'
+                  message: 'value "not-yet-supported-protocol" is not valid. Allowed values: http, http2, tcp'
                   reason: FieldValueInvalid
                 kind: Service
               message: 'metadata.annotations["8081.service.kuma.io/protocol"]: value "" is
-                not valid. Allowed values: http, tcp; metadata.annotations["8082.service.kuma.io/protocol"]:
-                value "not-yet-supported-protocol" is not valid. Allowed values: http, tcp'
+                not valid. Allowed values: http, http2, tcp; metadata.annotations["8082.service.kuma.io/protocol"]:
+                value "not-yet-supported-protocol" is not valid. Allowed values: http, http2, tcp'
               metadata: {}
               reason: Invalid
               status: Failure

--- a/pkg/xds/envoy/clusters/http2_configurer.go
+++ b/pkg/xds/envoy/clusters/http2_configurer.go
@@ -1,0 +1,20 @@
+package clusters
+
+import (
+	envoy_api "github.com/envoyproxy/go-control-plane/envoy/api/v2"
+	envoy_api_v2_core "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
+)
+
+func Http2() ClusterBuilderOpt {
+	return ClusterBuilderOptFunc(func(config *ClusterBuilderConfig) {
+		config.Add(&http2Configurer{})
+	})
+}
+
+type http2Configurer struct {
+}
+
+func (p *http2Configurer) Configure(c *envoy_api.Cluster) error {
+	c.Http2ProtocolOptions = &envoy_api_v2_core.Http2ProtocolOptions{}
+	return nil
+}

--- a/pkg/xds/envoy/clusters/http2_configurer_test.go
+++ b/pkg/xds/envoy/clusters/http2_configurer_test.go
@@ -1,0 +1,29 @@
+package clusters_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	util_proto "github.com/kumahq/kuma/pkg/util/proto"
+	"github.com/kumahq/kuma/pkg/xds/envoy/clusters"
+)
+
+var _ = Describe("Http2Configurer", func() {
+
+	It("should generate proper Envoy config", func() {
+		// given
+		expected := `http2ProtocolOptions: {}`
+
+		// when
+		cluster, err := clusters.NewClusterBuilder().
+			Configure(clusters.Http2()).
+			Build()
+
+		// then
+		Expect(err).ToNot(HaveOccurred())
+
+		actual, err := util_proto.ToYAML(cluster)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(actual).To(MatchYAML(expected))
+	})
+})

--- a/pkg/xds/generator/outbound_proxy_generator.go
+++ b/pkg/xds/generator/outbound_proxy_generator.go
@@ -135,6 +135,7 @@ func (o OutboundProxyGenerator) generateCDS(ctx xds_context.Context, proxy *mode
 			Configure(envoy_clusters.ClientSideMTLS(ctx, proxy.Metadata, serviceName, tags)).
 			Configure(envoy_clusters.OutlierDetection(circuitBreaker)).
 			Configure(envoy_clusters.HealthCheck(healthCheck)).
+			Configure(envoy_clusters.Http2()).
 			Build()
 		if err != nil {
 			return nil, err

--- a/pkg/xds/generator/protocol.go
+++ b/pkg/xds/generator/protocol.go
@@ -12,18 +12,20 @@ var (
 	// GRPC has a protocol stack [GRPC, HTTP2, TCP],
 	// TCP  has a protocol stack [TCP].
 	protocolStacks = map[mesh_core.Protocol]mesh_core.ProtocolList{
-		mesh_core.ProtocolHTTP: mesh_core.ProtocolList{mesh_core.ProtocolHTTP, mesh_core.ProtocolTCP},
-		mesh_core.ProtocolTCP:  mesh_core.ProtocolList{mesh_core.ProtocolTCP},
+		mesh_core.ProtocolHTTP2: {mesh_core.ProtocolHTTP2, mesh_core.ProtocolHTTP, mesh_core.ProtocolTCP},
+		mesh_core.ProtocolHTTP:  {mesh_core.ProtocolHTTP, mesh_core.ProtocolTCP},
+		mesh_core.ProtocolTCP:   {mesh_core.ProtocolTCP},
 	}
 )
 
 // getCommonProtocol returns a common protocol between given two.
 //
 // E.g.,
+// a common protocol between HTTP and HTTP2 is HTTP2,
 // a common protocol between HTTP and HTTP  is HTTP,
 // a common protocol between HTTP and TCP   is TCP,
 // a common protocol between GRPC and HTTP2 is HTTP2,
-// a common protocol between HTTP and HTTP2 is TCP.
+// a common protocol between HTTP and HTTP2 is HTTP.
 func getCommonProtocol(one, another mesh_core.Protocol) mesh_core.Protocol {
 	if one == another {
 		return one

--- a/pkg/xds/generator/protocol_private_test.go
+++ b/pkg/xds/generator/protocol_private_test.go
@@ -67,5 +67,20 @@ var _ = Describe("getCommonProtocol()", func() {
 			another:  mesh_core.ProtocolTCP,
 			expected: mesh_core.ProtocolTCP,
 		}),
+		Entry("`http2` and `http2`", testCase{
+			one:      mesh_core.ProtocolHTTP2,
+			another:  mesh_core.ProtocolHTTP2,
+			expected: mesh_core.ProtocolHTTP2,
+		}),
+		Entry("`http2` and `http`", testCase{
+			one:      mesh_core.ProtocolHTTP2,
+			another:  mesh_core.ProtocolHTTP,
+			expected: mesh_core.ProtocolHTTP,
+		}),
+		Entry("`http2` and `tcp`", testCase{
+			one:      mesh_core.ProtocolHTTP2,
+			another:  mesh_core.ProtocolTCP,
+			expected: mesh_core.ProtocolTCP,
+		}),
 	)
 })

--- a/pkg/xds/generator/testdata/outbound-proxy/03.envoy.golden.yaml
+++ b/pkg/xds/generator/testdata/outbound-proxy/03.envoy.golden.yaml
@@ -114,6 +114,7 @@ resources:
       edsClusterConfig:
         edsConfig:
           ads: {}
+      http2ProtocolOptions: {}
       name: api-http
       outlierDetection:
         enforcingConsecutive5xx: 100
@@ -129,6 +130,7 @@ resources:
       edsClusterConfig:
         edsConfig:
           ads: {}
+      http2ProtocolOptions: {}
       name: api-tcp
       type: EDS
   - name: backend
@@ -138,6 +140,7 @@ resources:
       edsClusterConfig:
         edsConfig:
           ads: {}
+      http2ProtocolOptions: {}
       name: backend
       type: EDS
   - name: db
@@ -147,6 +150,7 @@ resources:
       edsClusterConfig:
         edsConfig:
           ads: {}
+      http2ProtocolOptions: {}
       lbSubsetConfig:
         fallbackPolicy: ANY_ENDPOINT
         subsetSelectors:

--- a/pkg/xds/generator/testdata/outbound-proxy/04.envoy.golden.yaml
+++ b/pkg/xds/generator/testdata/outbound-proxy/04.envoy.golden.yaml
@@ -114,6 +114,7 @@ resources:
       edsClusterConfig:
         edsConfig:
           ads: {}
+      http2ProtocolOptions: {}
       name: api-http
       outlierDetection:
         enforcingConsecutive5xx: 100
@@ -165,6 +166,7 @@ resources:
       edsClusterConfig:
         edsConfig:
           ads: {}
+      http2ProtocolOptions: {}
       name: api-tcp
       transportSocket:
         name: envoy.transport_sockets.tls
@@ -210,6 +212,7 @@ resources:
       edsClusterConfig:
         edsConfig:
           ads: {}
+      http2ProtocolOptions: {}
       name: backend
       transportSocket:
         name: envoy.transport_sockets.tls
@@ -255,6 +258,7 @@ resources:
       edsClusterConfig:
         edsConfig:
           ads: {}
+      http2ProtocolOptions: {}
       lbSubsetConfig:
         fallbackPolicy: ANY_ENDPOINT
         subsetSelectors:

--- a/pkg/xds/generator/testdata/outbound-proxy/cluster-dots.envoy.golden.yaml
+++ b/pkg/xds/generator/testdata/outbound-proxy/cluster-dots.envoy.golden.yaml
@@ -25,6 +25,7 @@ resources:
       edsClusterConfig:
         edsConfig:
           ads: {}
+      http2ProtocolOptions: {}
       name: backend.kuma-system
       type: EDS
   - name: db
@@ -34,6 +35,7 @@ resources:
       edsClusterConfig:
         edsConfig:
           ads: {}
+      http2ProtocolOptions: {}
       lbSubsetConfig:
         fallbackPolicy: ANY_ENDPOINT
         subsetSelectors:

--- a/pkg/xds/generator/testdata/profile-source/1-envoy-config.golden.yaml
+++ b/pkg/xds/generator/testdata/profile-source/1-envoy-config.golden.yaml
@@ -36,6 +36,7 @@ resources:
       edsClusterConfig:
         edsConfig:
           ads: {}
+      http2ProtocolOptions: {}
       name: db
       transportSocket:
         name: envoy.transport_sockets.tls
@@ -87,6 +88,7 @@ resources:
           tcpHealthCheck: {}
           timeout: 4s
           unhealthyThreshold: 3
+      http2ProtocolOptions: {}
       name: elastic
       transportSocket:
         name: envoy.transport_sockets.tls

--- a/pkg/xds/generator/testdata/profile-source/2-envoy-config.golden.yaml
+++ b/pkg/xds/generator/testdata/profile-source/2-envoy-config.golden.yaml
@@ -36,6 +36,7 @@ resources:
       edsClusterConfig:
         edsConfig:
           ads: {}
+      http2ProtocolOptions: {}
       name: db
       transportSocket:
         name: envoy.transport_sockets.tls
@@ -87,6 +88,7 @@ resources:
           tcpHealthCheck: {}
           timeout: 4s
           unhealthyThreshold: 3
+      http2ProtocolOptions: {}
       name: elastic
       transportSocket:
         name: envoy.transport_sockets.tls

--- a/pkg/xds/generator/testdata/profile-source/3-envoy-config.golden.yaml
+++ b/pkg/xds/generator/testdata/profile-source/3-envoy-config.golden.yaml
@@ -36,6 +36,7 @@ resources:
       edsClusterConfig:
         edsConfig:
           ads: {}
+      http2ProtocolOptions: {}
       name: db
       transportSocket:
         name: envoy.transport_sockets.tls
@@ -87,6 +88,7 @@ resources:
           tcpHealthCheck: {}
           timeout: 4s
           unhealthyThreshold: 3
+      http2ProtocolOptions: {}
       name: elastic
       transportSocket:
         name: envoy.transport_sockets.tls

--- a/pkg/xds/generator/testdata/profile-source/4-envoy-config.golden.yaml
+++ b/pkg/xds/generator/testdata/profile-source/4-envoy-config.golden.yaml
@@ -36,6 +36,7 @@ resources:
       edsClusterConfig:
         edsConfig:
           ads: {}
+      http2ProtocolOptions: {}
       name: db
       transportSocket:
         name: envoy.transport_sockets.tls
@@ -87,6 +88,7 @@ resources:
           tcpHealthCheck: {}
           timeout: 4s
           unhealthyThreshold: 3
+      http2ProtocolOptions: {}
       name: elastic
       transportSocket:
         name: envoy.transport_sockets.tls


### PR DESCRIPTION
### Summary

Let's assume connection
```
web <--C1--> web's Envoy <--C2--> backend's Envoy <--C3--> backend
```

This PR sets HTTP/2 by default for connections between Envoys (C2 in the above example).

It also allows to set a `protocol: http2` tag for dataplane, so for example if such tag is set for `backend`, the C3 will also be on http2.

HTTP/2 support in Envoy can be enabled by setting `http2ProtocolOptions: {}` on a `cluster`.

SSL is recommended for HTTP/2, but it's not required. Connections between Envoy works on HTTP/2 without mTLS.

If `backend` is on HTTP/2 and there is no option to resign from TLS, TLS context can be configured with new ProxyTemplate modifications.

### Issues resolved

Fix #889

### Documentation

https://github.com/kumahq/kuma-website/pull/239
