### PR TITLE
feat(kuma-cp) e2e stabilization

### DIFF
--- a/test/e2e/kuma_deploy_multi_apps_test.go
+++ b/test/e2e/kuma_deploy_multi_apps_test.go
@@ -65,14 +65,16 @@ metadata:
 
 		clientPod := pods[0]
 
-		_, stderr, err := c1.ExecWithRetries(TestNamespace, clientPod.GetName(), "demo-client",
-			"curl", "-v", "-m", "3", "echo-server")
-		Expect(err).ToNot(HaveOccurred())
-		Expect(stderr).To(ContainSubstring("HTTP/1.1 200 OK"))
+		Eventually(func() (string, error) {
+			_, stderr, err := c1.ExecWithRetries(TestNamespace, clientPod.GetName(), "demo-client",
+				"curl", "-v", "-m", "3", "echo-server")
+			return stderr, err
+		}, "10s", "1s").Should(ContainSubstring("HTTP/1.1 200 OK"))
 
-		_, stderr, err = c1.ExecWithRetries(TestNamespace, clientPod.GetName(), "demo-client",
-			"curl", "-v", "-m", "3", "echo-server_kuma-test_svc_80.mesh")
-		Expect(err).ToNot(HaveOccurred())
-		Expect(stderr).To(ContainSubstring("HTTP/1.1 200 OK"))
+		Eventually(func() (string, error) {
+			_, stderr, err := c1.ExecWithRetries(TestNamespace, clientPod.GetName(), "demo-client",
+				"curl", "-v", "-m", "3", "echo-server_kuma-test_svc_80.mesh")
+			return stderr, err
+		}, "10s", "1s").Should(ContainSubstring("HTTP/1.1 200 OK"))
 	})
 })


### PR DESCRIPTION
Signed-off-by: Ilya Lobkov <ilya.lobkov@konghq.com>

### Summary

Policies might take some short period of time to be applied and propagated to Envoy. That's why all `curl` checks have to be done using `Eventually ` 

