### PR TITLE
fix(kuma-cp) remove + from minor version of Kubernetes so bitnami kubectl can be fetched

### DIFF
--- a/deployments/charts/kuma/templates/pre-delete-webhooks.yaml
+++ b/deployments/charts/kuma/templates/pre-delete-webhooks.yaml
@@ -2,6 +2,7 @@
 # But even that the policy of this webhook is Ignore, it fails because Kuma does not have permission to access Secrets anymore.
 # Therefore we first need to delete webhook so we can delete the rest of the deployment
 {{- $serviceAccountName := printf "%s-pre-delete-job" (include "kuma.name" .) }}
+{{- $kubeMinor := .Capabilities.KubeVersion.Minor | replace "+" "" }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -75,7 +76,7 @@ spec:
         - name: pre-delete-job
           {{- /* bitnami maintains an image for all k8s versions */}}
           {{- /* see: https://hub.docker.com/r/bitnami/kubectl */}}
-          image: {{ printf "%s/%s:%s.%s" "bitnami" "kubectl" .Capabilities.KubeVersion.Major .Capabilities.KubeVersion.Minor }}
+          image: {{ printf "%s/%s:%s.%s" "bitnami" "kubectl" .Capabilities.KubeVersion.Major $kubeMinor }}
           command:
             - 'kubectl'
             - 'delete'

--- a/deployments/charts/kuma/templates/pre-install-patch-namespace-job.yaml
+++ b/deployments/charts/kuma/templates/pre-install-patch-namespace-job.yaml
@@ -1,5 +1,6 @@
 {{- if .Values.patchSystemNamespace }}
   {{- $serviceAccountName := printf "%s-patch-ns-job" (include "kuma.name" .) }}
+  {{- $kubeMinor := .Capabilities.KubeVersion.Minor | replace "+" "" }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -76,7 +77,7 @@ spec:
         - name: pre-install-job
           {{- /* bitnami maintains an image for all k8s versions */}}
           {{- /* see: https://hub.docker.com/r/bitnami/kubectl */}}
-          image: {{ printf "%s/%s:%s.%s" "bitnami" "kubectl" .Capabilities.KubeVersion.Major .Capabilities.KubeVersion.Minor }}
+          image: {{ printf "%s/%s:%s.%s" "bitnami" "kubectl" .Capabilities.KubeVersion.Major $kubeMinor }}
           command:
             - 'kubectl'
             - 'patch'


### PR DESCRIPTION
The problem was that some K8S distros (especially in clouds) has `+` in minor version
```
❯❯❯ kubectl version
Client Version: version.Info{Major:"1", Minor:"14", GitVersion:"v1.14.1", GitCommit:"b7394102d6ef778017f2ca4046abbaa23b88c290", GitTreeState:"clean", BuildDate:"2019-04-08T17:11:31Z", GoVersion:"go1.12.1", Compiler:"gc", Platform:"darwin/amd64"}
Server Version: version.Info{Major:"1", Minor:"15+", GitVersion:"v1.15.12-gke.2", GitCommit:"fb7add51f767aae42655d39972210dc1c5dbd4b3", GitTreeState:"clean", BuildDate:"2020-06-01T22:20:10Z", GoVersion:"go1.12.17b4", Compiler:"gc", Platform:"linux/amd64"}
```

therefore `bitnami/kubectl` image in hooks could not be downloaded
```
Failed to apply default image tag "bitnami/kubectl:1.14+": couldn't parse image reference "bitnami/kubectl:1.14+": invalid reference format 
```

I tested it with GCP which contains `+`