### PR TITLE
feat(kuma-cp) change skipMeshDefault to false in HELM charts

### DIFF
--- a/deployments/charts/kuma/values.yaml
+++ b/deployments/charts/kuma/values.yaml
@@ -25,7 +25,7 @@ controlPlane:
     type: ClusterIP
 
   defaults:
-    skipMeshCreation: true
+    skipMeshCreation: false
 
   #  resources:
   #     requests:


### PR DESCRIPTION
Although I understand that it is very likely that someone who uses HELM to deploy Kuma will also use HELM to manage Kuma CRDs, I still think it's better to create a Mesh by default. A couple of days ago I was testing charts and I was confused why sidecar was not added. It turned out that it was lack of the mesh.

I think behavior should be consistent with kumactl install control-plane which creates a default Mesh.

CC: @austince you may need to change this manually after charts upgrade

