### PR TITLE
feat(kuma-cp) support HTTP/2 and gRPC on outbound

### DIFF
--- a/pkg/xds/generator/outbound_proxy_generator.go
+++ b/pkg/xds/generator/outbound_proxy_generator.go
@@ -94,8 +94,16 @@ func (_ OutboundProxyGenerator) generateLDS(proxy *model.Proxy, subsets []envoy_
 	filterChainBuilder := func() *envoy_listeners.FilterChainBuilder {
 		filterChainBuilder := envoy_listeners.NewFilterChainBuilder()
 		switch protocol {
+		case mesh_core.ProtocolGRPC:
+			filterChainBuilder.
+				Configure(envoy_listeners.HttpConnectionManager(serviceName)).
+				Configure(envoy_listeners.Tracing(proxy.TracingBackend)).
+				Configure(envoy_listeners.HttpAccessLog(meshName, envoy_listeners.TrafficDirectionOutbound, sourceService, serviceName, proxy.Logs[serviceName], proxy)).
+				Configure(envoy_listeners.HttpOutboundRoute(envoy_names.GetOutboundRouteName(serviceName))).
+				Configure(envoy_listeners.GrpcStats())
+		case mesh_core.ProtocolHTTP2:
+			fallthrough
 		case mesh_core.ProtocolHTTP:
-			// configuration for HTTP case
 			filterChainBuilder.
 				Configure(envoy_listeners.HttpConnectionManager(serviceName)).
 				Configure(envoy_listeners.Tracing(proxy.TracingBackend)).

--- a/pkg/xds/generator/outbound_proxy_generator_test.go
+++ b/pkg/xds/generator/outbound_proxy_generator_test.go
@@ -105,6 +105,28 @@ var _ = Describe("OutboundProxyGenerator", func() {
 					},
 					mesh_proto.OutboundInterface{
 						DataplaneIP:   "127.0.0.1",
+						DataplanePort: 40003,
+					}: &mesh_core.TrafficRouteResource{
+						Spec: mesh_proto.TrafficRoute{
+							Conf: []*mesh_proto.TrafficRoute_WeightedDestination{{
+								Weight:      100,
+								Destination: mesh_proto.MatchService("api-http2"),
+							}},
+						},
+					},
+					mesh_proto.OutboundInterface{
+						DataplaneIP:   "127.0.0.1",
+						DataplanePort: 40004,
+					}: &mesh_core.TrafficRouteResource{
+						Spec: mesh_proto.TrafficRoute{
+							Conf: []*mesh_proto.TrafficRoute_WeightedDestination{{
+								Weight:      100,
+								Destination: mesh_proto.MatchService("api-grpc"),
+							}},
+						},
+					},
+					mesh_proto.OutboundInterface{
+						DataplaneIP:   "127.0.0.1",
 						DataplanePort: 18080,
 					}: &mesh_core.TrafficRouteResource{
 						Spec: mesh_proto.TrafficRoute{
@@ -138,6 +160,12 @@ var _ = Describe("OutboundProxyGenerator", func() {
 					},
 					"api-tcp": model.TagSelectorSet{
 						{"kuma.io/service": "api-tcp"},
+					},
+					"api-http2": model.TagSelectorSet{
+						{"kuma.io/service": "api-http2"},
+					},
+					"api-grpc": model.TagSelectorSet{
+						{"kuma.io/service": "api-grpc"},
 					},
 					"backend": model.TagSelectorSet{
 						{"kuma.io/service": "backend"},
@@ -174,6 +202,22 @@ var _ = Describe("OutboundProxyGenerator", func() {
 							Target: "192.168.0.7",
 							Port:   8087,
 							Tags:   map[string]string{"kuma.io/service": "api-tcp", "region": "eu"},
+							Weight: 1,
+						},
+					},
+					"api-http2": []model.Endpoint{ // notice that all endpoints have tag `kuma.io/protocol: http2`
+						{
+							Target: "192.168.0.4",
+							Port:   8088,
+							Tags:   map[string]string{"kuma.io/service": "api-http2", "kuma.io/protocol": "http2"},
+							Weight: 1,
+						},
+					},
+					"api-grpc": []model.Endpoint{ // notice that all endpoints have tag `kuma.io/protocol: grpc`
+						{
+							Target: "192.168.0.4",
+							Port:   8089,
+							Tags:   map[string]string{"kuma.io/service": "api-grpc", "kuma.io/protocol": "grpc"},
 							Weight: 1,
 						},
 					},
@@ -279,6 +323,10 @@ var _ = Describe("OutboundProxyGenerator", func() {
                 service: api-http
               - port: 40002
                 service: api-tcp
+              - port: 40003
+                service: api-http2
+              - port: 40004
+                service: api-grpc
 `,
 			expected: "03.envoy.golden.yaml",
 		}),

--- a/pkg/xds/generator/testdata/outbound-proxy/03.envoy.golden.yaml
+++ b/pkg/xds/generator/testdata/outbound-proxy/03.envoy.golden.yaml
@@ -1,4 +1,22 @@
 resources:
+  - name: api-grpc
+    resource:
+      '@type': type.googleapis.com/envoy.api.v2.ClusterLoadAssignment
+      clusterName: api-grpc
+      endpoints:
+        - lbEndpoints:
+            - endpoint:
+                address:
+                  socketAddress:
+                    address: 192.168.0.4
+                    portValue: 8089
+              loadBalancingWeight: 1
+              metadata:
+                filterMetadata:
+                  envoy.lb:
+                    kuma.io/protocol: grpc
+                  envoy.transport_socket_match:
+                    kuma.io/protocol: grpc
   - name: api-http
     resource:
       '@type': type.googleapis.com/envoy.api.v2.ClusterLoadAssignment
@@ -33,6 +51,24 @@ resources:
                   envoy.transport_socket_match:
                     kuma.io/protocol: http
                     region: eu
+  - name: api-http2
+    resource:
+      '@type': type.googleapis.com/envoy.api.v2.ClusterLoadAssignment
+      clusterName: api-http2
+      endpoints:
+        - lbEndpoints:
+            - endpoint:
+                address:
+                  socketAddress:
+                    address: 192.168.0.4
+                    portValue: 8088
+              loadBalancingWeight: 1
+              metadata:
+                filterMetadata:
+                  envoy.lb:
+                    kuma.io/protocol: http2
+                  envoy.transport_socket_match:
+                    kuma.io/protocol: http2
   - name: api-tcp
     resource:
       '@type': type.googleapis.com/envoy.api.v2.ClusterLoadAssignment
@@ -107,6 +143,16 @@ resources:
                     role: master
                   envoy.transport_socket_match:
                     role: master
+  - name: api-grpc
+    resource:
+      '@type': type.googleapis.com/envoy.api.v2.Cluster
+      connectTimeout: 5s
+      edsClusterConfig:
+        edsConfig:
+          ads: {}
+      http2ProtocolOptions: {}
+      name: api-grpc
+      type: EDS
   - name: api-http
     resource:
       '@type': type.googleapis.com/envoy.api.v2.Cluster
@@ -122,6 +168,16 @@ resources:
         enforcingConsecutiveLocalOriginFailure: 0
         enforcingFailurePercentage: 0
         enforcingSuccessRate: 0
+      type: EDS
+  - name: api-http2
+    resource:
+      '@type': type.googleapis.com/envoy.api.v2.Cluster
+      connectTimeout: 5s
+      edsClusterConfig:
+        edsConfig:
+          ads: {}
+      http2ProtocolOptions: {}
+      name: api-http2
       type: EDS
   - name: api-tcp
     resource:
@@ -248,6 +304,53 @@ resources:
                 cluster: api-tcp
                 statPrefix: api-tcp
       name: outbound:127.0.0.1:40002
+      trafficDirection: OUTBOUND
+  - name: outbound:127.0.0.1:40003
+    resource:
+      '@type': type.googleapis.com/envoy.api.v2.Listener
+      address:
+        socketAddress:
+          address: 127.0.0.1
+          portValue: 40003
+      filterChains:
+        - filters:
+            - name: envoy.http_connection_manager
+              typedConfig:
+                '@type': type.googleapis.com/envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager
+                httpFilters:
+                  - name: envoy.router
+                rds:
+                  configSource:
+                    ads: {}
+                  routeConfigName: outbound:api-http2
+                statPrefix: api-http2
+      name: outbound:127.0.0.1:40003
+      trafficDirection: OUTBOUND
+  - name: outbound:127.0.0.1:40004
+    resource:
+      '@type': type.googleapis.com/envoy.api.v2.Listener
+      address:
+        socketAddress:
+          address: 127.0.0.1
+          portValue: 40004
+      filterChains:
+        - filters:
+            - name: envoy.http_connection_manager
+              typedConfig:
+                '@type': type.googleapis.com/envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager
+                httpFilters:
+                  - name: envoy.filters.http.grpc_stats
+                    typedConfig:
+                      '@type': type.googleapis.com/envoy.config.filter.http.grpc_stats.v2alpha.FilterConfig
+                      emitFilterState: true
+                      statsForAllMethods: true
+                  - name: envoy.router
+                rds:
+                  configSource:
+                    ads: {}
+                  routeConfigName: outbound:api-grpc
+                statPrefix: api-grpc
+      name: outbound:127.0.0.1:40004
       trafficDirection: OUTBOUND
   - name: outbound:127.0.0.1:54321
     resource:


### PR DESCRIPTION
Add support for HTTP/2 and gRPC on outbound proxy generator.

Fix #949