### PR TITLE
fix(*) zone insight failing test

### DIFF
--- a/mk/test.mk
+++ b/mk/test.mk
@@ -19,7 +19,10 @@ TEST_TARGETS ?= test/api test/k8s test/kuma
 
 .PHONY: test
 test: ${COVERAGE_PROFILE} ## Dev: Run tests for all modules
-	for test_target in $(TEST_TARGETS); do $(MAKE) $$test_target; done
+	for test_target in $(TEST_TARGETS);\
+	do \
+		$(MAKE) $$test_target || exit $$?; \
+	done
 	$(MAKE) coverage
 
 ${COVERAGE_PROFILE}:

--- a/pkg/plugins/resources/k8s/native/api/v1alpha1/zone_insight_types_test.go
+++ b/pkg/plugins/resources/k8s/native/api/v1alpha1/zone_insight_types_test.go
@@ -48,13 +48,11 @@ var _ = Describe("ZoneInsight", func() {
 		It("should create an object successfully", func() {
 
 			key = types.NamespacedName{
-				Name:      "foo",
-				Namespace: "default",
+				Name: "foo",
 			}
 			created = &ZoneInsight{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "foo",
-					Namespace: "default",
+					Name: "foo",
 				}}
 
 			By("creating an API obj")


### PR DESCRIPTION
### Summary

A side effect of the `test` make target unification, was that even if something in the listed test fails, only the last (and biggest) one was taken into account. We then overlooked a failing Zone Insights type test failure, which was easy to fix knowing that the resources are of Cluster scope and therefore does not have a namespace.
