### PR TITLE
feat(kuma-cp) pick service type and add custom annotations

### DIFF
--- a/deployments/charts/kuma/Chart.yaml
+++ b/deployments/charts/kuma/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: kuma
 description: A Helm chart for the Kuma Control Plane
 type: application
-version: 0.1.0
+version: 0.2.0
 appVersion: 0.7.0
 home: https://github.com/kumahq/kuma
 icon: https://kuma.io/images/brand/kuma-logo-new.svg

--- a/deployments/charts/kuma/README.md
+++ b/deployments/charts/kuma/README.md
@@ -22,6 +22,7 @@ The chart supports Helm v3+.
 | `controlPlane.service.annotations`                 | Additional annotations to put on the Kuma Control Plane service                   | {}                                   |
 | `controlPlane.globalRemoteSyncService.name`        | Service name of the Global-Remote Sync                                            | nil                                  |
 | `controlPlane.globalRemoteSyncService.type`        | Service type of the Global-Remote Sync                                            | LoadBalancer                         |
+| `controlPlane.globalRemoteSyncService.port`        | Port on which Global-Remote Sync is exposed                                       | 5685                                 |
 | `controlPlane.globalRemoteSyncService.annotations` | Additional annotations to put on the Global-Remote Sync service                   | {}                                   |
 | `controlPlane.defaults.skipMeshCreation`           | Whether or not to skip creating the default Mesh                                  | `true`                               |
 | `controlPlane.resources`                           | The K8s resources spec for Kuma CP                                                | nil, differs based on mode           |

--- a/deployments/charts/kuma/README.md
+++ b/deployments/charts/kuma/README.md
@@ -7,44 +7,48 @@ The chart supports Helm v3+.
 
 ## Values
 
-| Parameter                                   | Description                                                                       | Default                              |
-|---------------------------------------------|-----------------------------------------------------------------------------------|--------------------------------------|
-| `global.image.registry`                     | Default registry for all Kuma images                                              | `kong-docker-kuma-docker.bintray.io` |
-| `global.image.tag`                          | Default tag for all Kuma images                                                   | nil, defaults to Chart.AppVersion    |
-| `patchSystemNamespace`                      | Patch the release namespace with the Kuma system label                            | `true`                               |
-| `controlPlane.logLevel`                     | Kuma CP log level: one of off\|info\|debug                                        | `info`                               |
-| `controlPlane.mode`                         | Kuma CP modes: one of standalone\|remote\|global                                  | `standalone`                         |
-| `controlPlane.zone`                         | Kuma zone name                                                                    | nil                                  |
-| `controlPlane.kdsGlobalAddress`             | URL of Global Kuma CP                                                             |                                      |
-| `controlPlane.useNodePort`                  | Use NodePort instead of LoadBalancer                                              | `false`                              |
-| `controlPlane.injectorFailurePolicy`        | Failure policy of the mutating webhook implemented by the Kuma Injector component | `Ignore`                             |
-| `controlPlane.service.name`                 | Service name of the Kuma Control Plane                                            | nil                                  |
-| `controlPlane.service.type`                 | Service type of the Kuma Control Plane                                            | ClusterIP                            |
-| `controlPlane.defaults.skipMeshCreation`    | Whether or not to skip creating the default Mesh                                  | `true`                               |
-| `controlPlane.resources`                    | The K8s resources spec for Kuma CP                                                | nil, differs based on mode           |
-| `controlPlane.tls.{admission,sds,kds}.cert` | TLS certificate for the Admission, SDS, and KDS servers, respectively             | nil, generated and self-signed       |
-| `controlPlane.tls.{admission,sds,kds}.key`  | TLS key for the Admission, SDS, and KDS servers, respectively                     | nil, generated and self-signed       |
-| `controlPlane.image.pullPolicy`              | Kuma CP ImagePullPolicy                                                          | `IfNotPresent`                       |
-| `controlPlane.image.registry`               | Kuma CP image registry                                                            | nil, uses global                     |
-| `controlPlane.image.repository`             | Kuma CP image repository                                                          | `kuma-cp`                            |
-| `controlPlane.image.tag`                    | Kuma CP image tag                                                                 | nil, uses global                     |
-| `cni.enabled`                               | Install Kuma with CNI instead of proxy init container                             | `false`                              |
-| `cni.logLevel`                              | CNI log level: one of off\|info\|debug                                            | `info`                               |
-| `cni.image.registry`                        | CNI image registry                                                                | `docker.io`                          |
-| `cni.image.repository`                      | CNI image repository                                                              | `lobkovilya/install-cni`             |
-| `cni.image.tag`                             | The CNI image tag                                                                 | `0.0.1`                              |
-| `dataPlane.image.registry`                  | The Kuma DP image registry                                                        | nil, uses global                     |
-| `dataPlane.image.repository`                | The Kuma DP image repository                                                      | `kuma-cp`                            |
-| `dataPlane.image.tag`                       | The Kuma DP image tag                                                             | nil, uses global                     |
-| `dataPlane.initImage.registry`              | The Kuma DP init image registry                                                   | nil, uses global                     |
-| `dataPlane.initImage.repository`            | The Kuma DP init image repository                                                 | `kuma-init`                          |
-| `dataPlane.initImage.tag`                   | The Kuma DP init image tag                                                        | nil, uses global                     |
-| `ingress.enabled`                           | If true, it deploys Ingress for cross cluster communication                       | false                                |
-| `ingress.drainTime`                         | Time for which old listener will still be active as draining                      | 30s                                  |
-| `ingress.service.name`                      | Service name of the Ingress                                                       | nil                                  |
-| `ingress.service.type`                      | Service type of the Ingress                                                       | LoadBalancer                         |
-| `ingress.service.port`                      | Port on which Ingress is exposed                                                  | 10001                                |
-| `ingress.mesh`                              | Mesh to which Dataplane Ingress belongs to                                        | default                              |
+| Parameter                                          | Description                                                                       | Default                              |
+|---------------------------------------------       |-----------------------------------------------------------------------------------|--------------------------------------|
+| `global.image.registry`                            | Default registry for all Kuma images                                              | `kong-docker-kuma-docker.bintray.io` |
+| `global.image.tag`                                 | Default tag for all Kuma images                                                   | nil, defaults to Chart.AppVersion    |
+| `patchSystemNamespace`                             | Patch the release namespace with the Kuma system label                            | `true`                               |
+| `controlPlane.logLevel`                            | Kuma CP log level: one of off\|info\|debug                                        | `info`                               |
+| `controlPlane.mode`                                | Kuma CP modes: one of standalone\|remote\|global                                  | `standalone`                         |
+| `controlPlane.zone`                                | Kuma zone name                                                                    | nil                                  |
+| `controlPlane.kdsGlobalAddress`                    | URL of Global Kuma CP                                                             |                                      |
+| `controlPlane.injectorFailurePolicy`               | Failure policy of the mutating webhook implemented by the Kuma Injector component | `Ignore`                             |
+| `controlPlane.service.name`                        | Service name of the Kuma Control Plane                                            | nil                                  |
+| `controlPlane.service.type`                        | Service type of the Kuma Control Plane                                            | ClusterIP                            |
+| `controlPlane.service.annotations`                 | Additional annotations to put on the Kuma Control Plane service                   | {}                                   |
+| `controlPlane.globalRemoteSyncService.name`        | Service name of the Global-Remote Sync                                            | nil                                  |
+| `controlPlane.globalRemoteSyncService.type`        | Service type of the Global-Remote Sync                                            | LoadBalancer                         |
+| `controlPlane.globalRemoteSyncService.annotations` | Additional annotations to put on the Global-Remote Sync service                   | {}                                   |
+| `controlPlane.defaults.skipMeshCreation`           | Whether or not to skip creating the default Mesh                                  | `true`                               |
+| `controlPlane.resources`                           | The K8s resources spec for Kuma CP                                                | nil, differs based on mode           |
+| `controlPlane.tls.{admission,sds,kds}.cert`        | TLS certificate for the Admission, SDS, and KDS servers, respectively             | nil, generated and self-signed       |
+| `controlPlane.tls.{admission,sds,kds}.key`         | TLS key for the Admission, SDS, and KDS servers, respectively                     | nil, generated and self-signed       |
+| `controlPlane.image.pullPolicy`                    | Kuma CP ImagePullPolicy                                                           | `IfNotPresent`                       |
+| `controlPlane.image.registry`                      | Kuma CP image registry                                                            | nil, uses global                     |
+| `controlPlane.image.repository`                    | Kuma CP image repository                                                          | `kuma-cp`                            |
+| `controlPlane.image.tag`                           | Kuma CP image tag                                                                 | nil, uses global                     |
+| `cni.enabled`                                      | Install Kuma with CNI instead of proxy init container                             | `false`                              |
+| `cni.logLevel`                                     | CNI log level: one of off\|info\|debug                                            | `info`                               |
+| `cni.image.registry`                               | CNI image registry                                                                | `docker.io`                          |
+| `cni.image.repository`                             | CNI image repository                                                              | `lobkovilya/install-cni`             |
+| `cni.image.tag`                                    | The CNI image tag                                                                 | `0.0.1`                              |
+| `dataPlane.image.registry`                         | The Kuma DP image registry                                                        | nil, uses global                     |
+| `dataPlane.image.repository`                       | The Kuma DP image repository                                                      | `kuma-cp`                            |
+| `dataPlane.image.tag`                              | The Kuma DP image tag                                                             | nil, uses global                     |
+| `dataPlane.initImage.registry`                     | The Kuma DP init image registry                                                   | nil, uses global                     |
+| `dataPlane.initImage.repository`                   | The Kuma DP init image repository                                                 | `kuma-init`                          |
+| `dataPlane.initImage.tag`                          | The Kuma DP init image tag                                                        | nil, uses global                     |
+| `ingress.enabled`                                  | If true, it deploys Ingress for cross cluster communication                       | false                                |
+| `ingress.drainTime`                                | Time for which old listener will still be active as draining                      | 30s                                  |
+| `ingress.service.name`                             | Service name of the Ingress                                                       | nil                                  |
+| `ingress.service.type`                             | Service type of the Ingress                                                       | LoadBalancer                         |
+| `ingress.service.port`                             | Port on which Ingress is exposed                                                  | 10001                                |
+| `ingress.service.annotations`                      | Additional annotations to put on the Ingress service                              | {}                                   |
+| `ingress.mesh`                                     | Mesh to which Dataplane Ingress belongs to                                        | default                              |
 
 ## Custom Resource Definitions
 

--- a/deployments/charts/kuma/templates/_helpers.tpl
+++ b/deployments/charts/kuma/templates/_helpers.tpl
@@ -36,6 +36,11 @@ Create chart name and version as used by the chart label.
 {{ printf "%s" (default $defaultSvcName .Values.controlPlane.service.name) }}
 {{- end }}
 
+{{- define "kuma.controlPlane.globalRemoteSync.serviceName" -}}
+{{- $defaultSvcName := printf "%s-global-remote-sync" (include "kuma.name" .) -}}
+{{ printf "%s" (default $defaultSvcName .Values.controlPlane.globalRemoteSyncService.name) }}
+{{- end }}
+
 {{- define "kuma.ingress.serviceName" -}}
 {{- $defaultSvcName := printf "%s-ingress" (include "kuma.name" .) -}}
 {{ printf "%s" (default $defaultSvcName .Values.ingress.service.name) }}

--- a/deployments/charts/kuma/templates/cp-global-sync-service.yaml
+++ b/deployments/charts/kuma/templates/cp-global-sync-service.yaml
@@ -11,8 +11,8 @@ metadata:
 spec:
   type: {{ .Values.controlPlane.globalRemoteSyncService.type }}
   ports:
-    - port: 5685
-  {{- if eq .Values.controlPlane.service.type "NodePort" }}
+    - port: {{ .Values.controlPlane.globalRemoteSyncService.port }}
+  {{- if eq .Values.controlPlane.globalRemoteSyncService.type "NodePort" }}
       nodePort: 30685
   {{- end }}
       name: global-remote-sync

--- a/deployments/charts/kuma/templates/cp-global-sync-service.yaml
+++ b/deployments/charts/kuma/templates/cp-global-sync-service.yaml
@@ -2,17 +2,19 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "kuma.name" . }}-global-remote-sync
+  name: {{ include "kuma.controlPlane.globalRemoteSync.serviceName" . }}
   namespace: {{ .Release.Namespace }}
+  annotations:
+    {{- range $key, $value := .Values.controlPlane.globalRemoteSyncService.annotations }}
+      {{ $key }}: {{ $value | quote }}
+    {{- end }}
 spec:
-  {{- if .Values.controlPlane.useNodePort }}
-  type: NodePort
-  {{- else }}
-  type: LoadBalancer
-  {{- end }}
+  type: {{ .Values.controlPlane.globalRemoteSyncService.type }}
   ports:
     - port: 5685
+  {{- if eq .Values.controlPlane.service.type "NodePort" }}
       nodePort: 30685
+  {{- end }}
       name: global-remote-sync
   selector:
   {{ include "kuma.selectorLabels" . | nindent 4 }}

--- a/deployments/charts/kuma/templates/cp-service.yaml
+++ b/deployments/charts/kuma/templates/cp-service.yaml
@@ -5,6 +5,10 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
   {{- include "kuma.labels" . | nindent 4 }}
+  annotations:
+    {{- range $key, $value := .Values.controlPlane.service.annotations }}
+      {{ $key }}: {{ $value | quote }}
+    {{- end }}
 spec:
   type: {{ .Values.controlPlane.service.type }}
   ports:

--- a/deployments/charts/kuma/templates/ingress-service.yaml
+++ b/deployments/charts/kuma/templates/ingress-service.yaml
@@ -6,6 +6,10 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
   {{- include "kuma.labels" . | nindent 4 }}
+  annotations:
+    {{- range $key, $value := .Values.ingress.service.annotations }}
+      {{ $key }}: {{ $value | quote }}
+    {{- end }}
 spec:
   type: {{ .Values.ingress.service.type }}
   ports:

--- a/deployments/charts/kuma/values.yaml
+++ b/deployments/charts/kuma/values.yaml
@@ -27,6 +27,7 @@ controlPlane:
     # name: ""
     type: LoadBalancer
     annotations: {}
+    port: 5685
 
   defaults:
     skipMeshCreation: false

--- a/deployments/charts/kuma/values.yaml
+++ b/deployments/charts/kuma/values.yaml
@@ -16,13 +16,17 @@ controlPlane:
 
   kdsGlobalAddress: ""
 
-  useNodePort: false
-
   injectorFailurePolicy: Ignore
 
   service:
     # name: ""
     type: ClusterIP
+    annotations: {}
+
+  globalRemoteSyncService:
+    # name: ""
+    type: LoadBalancer
+    annotations: {}
 
   defaults:
     skipMeshCreation: false
@@ -68,10 +72,11 @@ dataPlane:
     repository: "kuma-init"
 
 ingress:
-  mesh: default
   enabled: false
+  mesh: default
   drainTime: 30s
   service:
     # name: ""
     type: LoadBalancer
+    annotations: {}
     port: 10001

--- a/test/framework/k8s_cluster.go
+++ b/test/framework/k8s_cluster.go
@@ -270,7 +270,7 @@ func (c *K8sCluster) deployKumaViaHelm(mode string, opts *deployOptions) error {
 
 	switch mode {
 	case core.Global:
-		values["controlPlane.useNodePort"] = "true"
+		values["controlPlane.globalRemoteSyncService.type"] = "NodePort"
 	case core.Remote:
 		values["controlPlane.zone"] = c.GetKumactlOptions().CPName
 		values["controlPlane.kdsGlobalAddress"] = opts.globalAddress


### PR DESCRIPTION
### Summary

Fix #960

Instead of useNodePort you can now specify type. Additionaly you can add your own annotations.