### PR TITLE
fix(kuma-cp) ignore services without selectors

### DIFF
--- a/pkg/plugins/discovery/k8s/controllers/pod_controller.go
+++ b/pkg/plugins/discovery/k8s/controllers/pod_controller.go
@@ -109,7 +109,7 @@ func (r *PodReconciler) findMatchingServices(pod *kube_core.Pod) ([]*kube_core.S
 	}
 
 	// only consider Services that match this Pod
-	matchingServices := util_k8s.FindServices(allServices, util_k8s.MatchServiceThatSelectsPod(pod))
+	matchingServices := util_k8s.FindServices(allServices, util_k8s.AnySelector(), util_k8s.MatchServiceThatSelectsPod(pod))
 
 	return matchingServices, nil
 }

--- a/pkg/plugins/discovery/k8s/controllers/pod_controller_test.go
+++ b/pkg/plugins/discovery/k8s/controllers/pod_controller_test.go
@@ -49,6 +49,9 @@ var _ = Describe("PodReconciler", func() {
 					Annotations: map[string]string{
 						"kuma.io/sidecar-injected": "true",
 					},
+					Labels: map[string]string{
+						"app": "sample",
+					},
 				},
 			},
 			&kube_core.Pod{
@@ -58,6 +61,9 @@ var _ = Describe("PodReconciler", func() {
 					Annotations: map[string]string{
 						"kuma.io/mesh":             "poc",
 						"kuma.io/sidecar-injected": "true",
+					},
+					Labels: map[string]string{
+						"app": "sample",
 					},
 				},
 				Spec: kube_core.PodSpec{
@@ -104,6 +110,9 @@ var _ = Describe("PodReconciler", func() {
 								StrVal: "metrics",
 							},
 						},
+					},
+					Selector: map[string]string{
+						"app": "sample",
 					},
 				},
 			})
@@ -254,10 +263,12 @@ var _ = Describe("PodReconciler", func() {
             inbound:
             - port: 8080
               tags:
+                app: sample
                 kuma.io/protocol: http
                 kuma.io/service: example_demo_svc_80
             - port: 6060
               tags:
+                app: sample
                 kuma.io/service: example_demo_svc_6061
                 kuma.io/protocol: tcp
 `))
@@ -324,10 +335,12 @@ var _ = Describe("PodReconciler", func() {
             inbound:
             - port: 8080
               tags:
+                app: sample
                 kuma.io/protocol: http
                 kuma.io/service: example_demo_svc_80
             - port: 6060
               tags:
+                app: sample
                 kuma.io/service: example_demo_svc_6061
                 kuma.io/protocol: tcp
 `))

--- a/pkg/plugins/discovery/k8s/util/util_test.go
+++ b/pkg/plugins/discovery/k8s/util/util_test.go
@@ -100,11 +100,18 @@ var _ = Describe("Util", func() {
 							},
 						},
 					},
+					{
+						ObjectMeta: kube_meta.ObjectMeta{
+							Name:      "kubernetes",
+							Namespace: "default",
+						},
+						Spec: kube_core.ServiceSpec{},
+					},
 				},
 			}
 
 			// when
-			matchingServices := FindServices(svcs, MatchServiceThatSelectsPod(pod))
+			matchingServices := FindServices(svcs, AnySelector(), MatchServiceThatSelectsPod(pod))
 			// then
 			Expect(matchingServices).To(HaveLen(1))
 			Expect(matchingServices).To(ConsistOf(&svcs.Items[0]))


### PR DESCRIPTION
Problem described in #977

The solution is to ignore all services without selector since this is an indication that it is a special service with endpoints managed by an external process.

Also added a comment on why we are picking Service port without matching containerPort since it was confusing to me.

Fix #977

### Documentation

- Nothing to change, it's an internal mechanism.