### PR TITLE
feat(deployments) specify nodeSelectors for CP and CNI pods

### DIFF
--- a/deployments/charts/kuma/Chart.yaml
+++ b/deployments/charts/kuma/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: kuma
 description: A Helm chart for the Kuma Control Plane
 type: application
-version: 0.2.1
+version: 0.3.0
 appVersion: 0.7.1
 home: https://github.com/kumahq/kuma
 icon: https://kuma.io/images/brand/kuma-logo-new.svg

--- a/deployments/charts/kuma/README.md
+++ b/deployments/charts/kuma/README.md
@@ -7,49 +7,51 @@ The chart supports Helm v3+.
 
 ## Values
 
-| Parameter                                          | Description                                                                       | Default                              |
-|---------------------------------------------       |-----------------------------------------------------------------------------------|--------------------------------------|
-| `global.image.registry`                            | Default registry for all Kuma images                                              | `kong-docker-kuma-docker.bintray.io` |
-| `global.image.tag`                                 | Default tag for all Kuma images                                                   | nil, defaults to Chart.AppVersion    |
-| `patchSystemNamespace`                             | Patch the release namespace with the Kuma system label                            | `true`                               |
-| `controlPlane.logLevel`                            | Kuma CP log level: one of off\|info\|debug                                        | `info`                               |
-| `controlPlane.mode`                                | Kuma CP modes: one of standalone\|remote\|global                                  | `standalone`                         |
-| `controlPlane.zone`                                | Kuma zone name                                                                    | nil                                  |
-| `controlPlane.kdsGlobalAddress`                    | URL of Global Kuma CP                                                             |                                      |
-| `controlPlane.injectorFailurePolicy`               | Failure policy of the mutating webhook implemented by the Kuma Injector component | `Ignore`                             |
-| `controlPlane.service.name`                        | Service name of the Kuma Control Plane                                            | nil                                  |
-| `controlPlane.service.type`                        | Service type of the Kuma Control Plane                                            | ClusterIP                            |
-| `controlPlane.service.annotations`                 | Additional annotations to put on the Kuma Control Plane service                   | {}                                   |
-| `controlPlane.globalRemoteSyncService.name`        | Service name of the Global-Remote Sync                                            | nil                                  |
-| `controlPlane.globalRemoteSyncService.type`        | Service type of the Global-Remote Sync                                            | LoadBalancer                         |
-| `controlPlane.globalRemoteSyncService.port`        | Port on which Global-Remote Sync is exposed                                       | 5685                                 |
-| `controlPlane.globalRemoteSyncService.annotations` | Additional annotations to put on the Global-Remote Sync service                   | {}                                   |
-| `controlPlane.defaults.skipMeshCreation`           | Whether or not to skip creating the default Mesh                                  | `true`                               |
-| `controlPlane.resources`                           | The K8s resources spec for Kuma CP                                                | nil, differs based on mode           |
-| `controlPlane.tls.{admission,sds,kds}.cert`        | TLS certificate for the Admission, SDS, and KDS servers, respectively             | nil, generated and self-signed       |
-| `controlPlane.tls.{admission,sds,kds}.key`         | TLS key for the Admission, SDS, and KDS servers, respectively                     | nil, generated and self-signed       |
-| `controlPlane.image.pullPolicy`                    | Kuma CP ImagePullPolicy                                                           | `IfNotPresent`                       |
-| `controlPlane.image.registry`                      | Kuma CP image registry                                                            | nil, uses global                     |
-| `controlPlane.image.repository`                    | Kuma CP image repository                                                          | `kuma-cp`                            |
-| `controlPlane.image.tag`                           | Kuma CP image tag                                                                 | nil, uses global                     |
-| `cni.enabled`                                      | Install Kuma with CNI instead of proxy init container                             | `false`                              |
-| `cni.logLevel`                                     | CNI log level: one of off\|info\|debug                                            | `info`                               |
-| `cni.image.registry`                               | CNI image registry                                                                | `docker.io`                          |
-| `cni.image.repository`                             | CNI image repository                                                              | `lobkovilya/install-cni`             |
-| `cni.image.tag`                                    | The CNI image tag                                                                 | `0.0.1`                              |
-| `dataPlane.image.registry`                         | The Kuma DP image registry                                                        | nil, uses global                     |
-| `dataPlane.image.repository`                       | The Kuma DP image repository                                                      | `kuma-cp`                            |
-| `dataPlane.image.tag`                              | The Kuma DP image tag                                                             | nil, uses global                     |
-| `dataPlane.initImage.registry`                     | The Kuma DP init image registry                                                   | nil, uses global                     |
-| `dataPlane.initImage.repository`                   | The Kuma DP init image repository                                                 | `kuma-init`                          |
-| `dataPlane.initImage.tag`                          | The Kuma DP init image tag                                                        | nil, uses global                     |
-| `ingress.enabled`                                  | If true, it deploys Ingress for cross cluster communication                       | false                                |
-| `ingress.drainTime`                                | Time for which old listener will still be active as draining                      | 30s                                  |
-| `ingress.service.name`                             | Service name of the Ingress                                                       | nil                                  |
-| `ingress.service.type`                             | Service type of the Ingress                                                       | LoadBalancer                         |
-| `ingress.service.port`                             | Port on which Ingress is exposed                                                  | 10001                                |
-| `ingress.service.annotations`                      | Additional annotations to put on the Ingress service                              | {}                                   |
-| `ingress.mesh`                                     | Mesh to which Dataplane Ingress belongs to                                        | default                              |
+| Parameter                                          | Description                                                                       | Default                                                  |
+|---------------------------------------------       |-----------------------------------------------------------------------------------|----------------------------------------------------------|
+| `global.image.registry`                            | Default registry for all Kuma images                                              | `kong-docker-kuma-docker.bintray.io`                     |
+| `global.image.tag`                                 | Default tag for all Kuma images                                                   | nil, defaults to Chart.AppVersion                        |
+| `patchSystemNamespace`                             | Patch the release namespace with the Kuma system label                            | `true`                                                   |
+| `controlPlane.logLevel`                            | Kuma CP log level: one of off\|info\|debug                                        | `info`                                                   |
+| `controlPlane.mode`                                | Kuma CP modes: one of standalone\|remote\|global                                  | `standalone`                                             |
+| `controlPlane.zone`                                | Kuma zone name                                                                    | nil                                                      |
+| `controlPlane.kdsGlobalAddress`                    | URL of Global Kuma CP                                                             |                                                          |
+| `controlPlane.nodeSelector`                        | Node Selector for the Kuma Control Plane pods                                     | `{ kubernetes.io/os: linux, kubernetes.io/arch: amd64 }` |
+| `controlPlane.injectorFailurePolicy`               | Failure policy of the mutating webhook implemented by the Kuma Injector component | `Ignore`                                                 |
+| `controlPlane.service.name`                        | Service name of the Kuma Control Plane                                            | nil                                                      |
+| `controlPlane.service.type`                        | Service type of the Kuma Control Plane                                            | ClusterIP                                                |
+| `controlPlane.service.annotations`                 | Additional annotations to put on the Kuma Control Plane service                   | {}                                                       |
+| `controlPlane.globalRemoteSyncService.name`        | Service name of the Global-Remote Sync                                            | nil                                                      |
+| `controlPlane.globalRemoteSyncService.type`        | Service type of the Global-Remote Sync                                            | LoadBalancer                                             |
+| `controlPlane.globalRemoteSyncService.port`        | Port on which Global-Remote Sync is exposed                                       | 5685                                                     |
+| `controlPlane.globalRemoteSyncService.annotations` | Additional annotations to put on the Global-Remote Sync service                   | {}                                                       |
+| `controlPlane.defaults.skipMeshCreation`           | Whether or not to skip creating the default Mesh                                  | `true`                                                   |
+| `controlPlane.resources`                           | The K8s resources spec for Kuma CP                                                | nil, differs based on mode                               |
+| `controlPlane.tls.{admission,sds,kds}.cert`        | TLS certificate for the Admission, SDS, and KDS servers, respectively             | nil, generated and self-signed                           |
+| `controlPlane.tls.{admission,sds,kds}.key`         | TLS key for the Admission, SDS, and KDS servers, respectively                     | nil, generated and self-signed                           |
+| `controlPlane.image.pullPolicy`                    | Kuma CP ImagePullPolicy                                                           | `IfNotPresent`                                           |
+| `controlPlane.image.registry`                      | Kuma CP image registry                                                            | nil, uses global                                         |
+| `controlPlane.image.repository`                    | Kuma CP image repository                                                          | `kuma-cp`                                                |
+| `controlPlane.image.tag`                           | Kuma CP image tag                                                                 | nil, uses global                                         |
+| `cni.enabled`                                      | Install Kuma with CNI instead of proxy init container                             | `false`                                                  |
+| `cni.logLevel`                                     | CNI log level: one of off\|info\|debug                                            | `info`                                                   |
+| `cni.nodeSelector`                                 | Node Selector for the CNI pods                                                    | `{ kubernetes.io/os: linux, kubernetes.io/arch: amd64 }` |
+| `cni.image.registry`                               | CNI image registry                                                                | `docker.io`                                              |
+| `cni.image.repository`                             | CNI image repository                                                              | `lobkovilya/install-cni`                                 |
+| `cni.image.tag`                                    | The CNI image tag                                                                 | `0.0.1`                                                  |
+| `dataPlane.image.registry`                         | The Kuma DP image registry                                                        | nil, uses global                                         |
+| `dataPlane.image.repository`                       | The Kuma DP image repository                                                      | `kuma-cp`                                                |
+| `dataPlane.image.tag`                              | The Kuma DP image tag                                                             | nil, uses global                                         |
+| `dataPlane.initImage.registry`                     | The Kuma DP init image registry                                                   | nil, uses global                                         |
+| `dataPlane.initImage.repository`                   | The Kuma DP init image repository                                                 | `kuma-init`                                              |
+| `dataPlane.initImage.tag`                          | The Kuma DP init image tag                                                        | nil, uses global                                         |
+| `ingress.enabled`                                  | If true, it deploys Ingress for cross cluster communication                       | false                                                    |
+| `ingress.drainTime`                                | Time for which old listener will still be active as draining                      | 30s                                                      |
+| `ingress.service.name`                             | Service name of the Ingress                                                       | nil                                                      |
+| `ingress.service.type`                             | Service type of the Ingress                                                       | LoadBalancer                                             |
+| `ingress.service.port`                             | Port on which Ingress is exposed                                                  | 10001                                                    |
+| `ingress.service.annotations`                      | Additional annotations to put on the Ingress service                              | {}                                                       |
+| `ingress.mesh`                                     | Mesh to which Dataplane Ingress belongs to                                        | default                                                  |
 
 ## Custom Resource Definitions
 

--- a/deployments/charts/kuma/templates/cni-daemonset.yaml
+++ b/deployments/charts/kuma/templates/cni-daemonset.yaml
@@ -26,8 +26,10 @@ spec:
         scheduler.alpha.kubernetes.io/critical-pod: ''
         checksum/config: {{ include (print $.Template.BasePath "/cni-configmap.yaml") . | sha256sum }}
     spec:
+      {{- with .Values.cni.nodeSelector }}
       nodeSelector:
-        beta.kubernetes.io/os: linux
+      {{ toYaml . | nindent 8 }}
+      {{- end }}
       hostNetwork: true
       tolerations:
         # Make sure kuma-cni-node gets scheduled on all nodes.

--- a/deployments/charts/kuma/templates/cp-deployment.yaml
+++ b/deployments/charts/kuma/templates/cp-deployment.yaml
@@ -25,6 +25,10 @@ spec:
         app: kuma-control-plane
     spec:
       serviceAccountName: {{ include "kuma.name" . }}-control-plane
+      {{- with .Values.controlPlane.nodeSelector }}
+      nodeSelector:
+        {{ toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: control-plane
           image: {{ include "kuma.formatImage" (dict "image" .Values.controlPlane.image "root" $) | quote }}

--- a/deployments/charts/kuma/values.yaml
+++ b/deployments/charts/kuma/values.yaml
@@ -16,6 +16,10 @@ controlPlane:
 
   kdsGlobalAddress: ""
 
+  nodeSelector:
+    kubernetes.io/os: linux
+    kubernetes.io/arch: amd64
+
   injectorFailurePolicy: Ignore
 
   service:
@@ -56,6 +60,10 @@ controlPlane:
 cni:
   enabled: false
   logLevel: info
+
+  nodeSelector:
+    kubernetes.io/os: linux
+    kubernetes.io/arch: amd64
 
   image:
     registry: "docker.io"


### PR DESCRIPTION
Signed-off-by: austin ce <austin.cawley@gmail.com>

### Summary

Adds `nodeSelector` fields to Kuma CP and CNI pod specs, and allows augmenting them via Helm values. Technically a breaking change, and moving the CNI pod selector out of the beta label.  

### Full changelog

* Add `controlPlane.nodeSelector` option with default `{ kubernetes.io/os: linux, kubernetes.io/arch: amd64 }` 
* Add `cni.nodeSelector` option with default `{ kubernetes.io/os: linux, kubernetes.io/arch: amd64 }` 

### Issues resolved

Fix #988

### Documentation

- [x] Link to the website **N/A**
