### PR TITLE
fix(kuma-cp) signing token in multizone

### DIFF
--- a/pkg/admin-server/server.go
+++ b/pkg/admin-server/server.go
@@ -189,16 +189,22 @@ func dataplaneTokenWs(rt runtime.Runtime) (*restful.WebService, error) {
 		return nil, nil
 	}
 
-	switch env := rt.Config().Environment; env {
-	case config_core.KubernetesEnvironment:
-		return nil, nil
-	case config_core.UniversalEnvironment:
+	start := true
+	switch rt.Config().Mode {
+	case config_core.Standalone, config_core.Remote:
+		// we still want to generate tokens on Universal even when Global CP is down, so we can scale up and down DPs
+		start = rt.Config().Environment == config_core.UniversalEnvironment
+	case config_core.Global:
+		// the flow may require to generate tokens for Universal's Remote on K8S Global
+		start = true
+	}
+
+	if start {
 		generator, err := builtin.NewDataplaneTokenIssuer(rt)
 		if err != nil {
 			return nil, err
 		}
 		return tokens_server.NewWebservice(generator), nil
-	default:
-		return nil, errors.Errorf("unknown environment type %s", env)
 	}
+	return nil, nil
 }

--- a/pkg/core/bootstrap/bootstrap.go
+++ b/pkg/core/bootstrap/bootstrap.go
@@ -131,15 +131,19 @@ func onStartup(runtime core_runtime.Runtime) error {
 }
 
 func createDefaultSigningKey(runtime core_runtime.Runtime) error {
-	switch env := runtime.Config().Environment; env {
-	case config_core.KubernetesEnvironment:
-		// we use service account token on K8S, so there is no need for dataplane token server
-		return nil
-	case config_core.UniversalEnvironment:
-		return builtin_issuer.CreateDefaultSigningKey(runtime.ResourceManager())
-	default:
-		return errors.Errorf("unknown environment type %s", env)
+	create := false
+	switch runtime.Config().Mode {
+	case config_core.Standalone:
+		create = runtime.Config().Environment == config_core.UniversalEnvironment // Signing Key should be created only on Universal since it is not used on K8S
+	case config_core.Global:
+		create = true // Signing Key with multi-zone should be created on Global even if the Environment is K8S, because we may connect Universal Remote
+	case config_core.Remote:
+		create = false // Signing Key should be synced from Global
 	}
+	if create {
+		return builtin_issuer.CreateDefaultSigningKey(runtime.ResourceManager())
+	}
+	return nil
 }
 
 func createDefaultMesh(runtime core_runtime.Runtime) error {

--- a/pkg/tokens/builtin/components.go
+++ b/pkg/tokens/builtin/components.go
@@ -7,6 +7,6 @@ import (
 
 func NewDataplaneTokenIssuer(rt runtime.Runtime) (issuer.DataplaneTokenIssuer, error) {
 	return issuer.NewDataplaneTokenIssuer(func() ([]byte, error) {
-		return issuer.GetSigningKey(rt.ResourceManager())
+		return issuer.GetSigningKey(rt.ReadOnlyResourceManager())
 	}), nil
 }

--- a/pkg/tokens/builtin/components.go
+++ b/pkg/tokens/builtin/components.go
@@ -6,9 +6,7 @@ import (
 )
 
 func NewDataplaneTokenIssuer(rt runtime.Runtime) (issuer.DataplaneTokenIssuer, error) {
-	key, err := issuer.GetSigningKey(rt.ResourceManager())
-	if err != nil {
-		return nil, err
-	}
-	return issuer.NewDataplaneTokenIssuer(key), nil
+	return issuer.NewDataplaneTokenIssuer(func() ([]byte, error) {
+		return issuer.GetSigningKey(rt.ResourceManager())
+	}), nil
 }

--- a/pkg/tokens/builtin/issuer/signing_key.go
+++ b/pkg/tokens/builtin/issuer/signing_key.go
@@ -66,7 +66,7 @@ func createSigningKey() (system.SecretResource, error) {
 	}
 	return res, nil
 }
-func GetSigningKey(manager manager.ResourceManager) ([]byte, error) {
+func GetSigningKey(manager manager.ReadOnlyResourceManager) ([]byte, error) {
 	resource := system.SecretResource{}
 	if err := manager.Get(context.Background(), &resource, store.GetBy(signingKeyResourceKey)); err != nil {
 		if store.IsResourceNotFound(err) {

--- a/test/e2e/kuma_deploy_hybrid_kube_global_test.go
+++ b/test/e2e/kuma_deploy_hybrid_kube_global_test.go
@@ -1,0 +1,98 @@
+package e2e
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/gruntwork-io/terratest/modules/k8s"
+	"github.com/gruntwork-io/terratest/modules/retry"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/pkg/errors"
+
+	"github.com/kumahq/kuma/pkg/config/core"
+	. "github.com/kumahq/kuma/test/framework"
+)
+
+var _ = Describe("Test Kubernetes/Universal deployment when Global is on K8S", func() {
+
+	var globalCluster, remoteCluster Cluster
+
+	BeforeEach(func() {
+		k8sClusters, err := NewK8sClusters(
+			[]string{Kuma1},
+			Verbose)
+		Expect(err).ToNot(HaveOccurred())
+
+		universalClusters, err := NewUniversalClusters(
+			[]string{Kuma3},
+			Verbose)
+		Expect(err).ToNot(HaveOccurred())
+
+		// Global
+		globalCluster = k8sClusters.GetCluster(Kuma1)
+		err = NewClusterSetup().
+			Install(Kuma(core.Global)).
+			Setup(globalCluster)
+		Expect(err).ToNot(HaveOccurred())
+		err = globalCluster.VerifyKuma()
+		Expect(err).ToNot(HaveOccurred())
+		globalCP := globalCluster.GetKuma()
+
+		echoServerToken, err := globalCP.GenerateDpToken("echo-server_kuma-test_svc_8080")
+		Expect(err).ToNot(HaveOccurred())
+		demoClientToken, err := globalCP.GenerateDpToken("demo-client")
+		Expect(err).ToNot(HaveOccurred())
+
+		// Remote
+		remoteCluster = universalClusters.GetCluster(Kuma3)
+		err = NewClusterSetup().
+			Install(Kuma(core.Remote, WithGlobalAddress(globalCP.GetKDSServerAddress()))).
+			Install(EchoServerUniversal(echoServerToken)).
+			Install(DemoClientUniversal(demoClientToken)).
+			Setup(remoteCluster)
+		Expect(err).ToNot(HaveOccurred())
+		err = remoteCluster.VerifyKuma()
+		Expect(err).ToNot(HaveOccurred())
+
+		// connect Remote with Global
+		err = k8s.KubectlApplyFromStringE(globalCluster.GetTesting(), globalCluster.GetKubectlOptions(),
+			fmt.Sprintf(ZoneTemplateK8s,
+				Kuma3,
+				remoteCluster.GetKuma().GetIngressAddress()))
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	AfterEach(func() {
+		err := globalCluster.DeleteKuma()
+		Expect(err).ToNot(HaveOccurred())
+		err = globalCluster.DismissCluster()
+		Expect(err).ToNot(HaveOccurred())
+
+		err = remoteCluster.DeleteKuma()
+		Expect(err).ToNot(HaveOccurred())
+		err = remoteCluster.DismissCluster()
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	It("communication in between apps in remote zone works", func() {
+		stdout, _, err := remoteCluster.ExecWithRetries("", "", "demo-client",
+			"curl", "-v", "-m", "3", "localhost:4001")
+		Expect(err).ToNot(HaveOccurred())
+		Expect(stdout).To(ContainSubstring("HTTP/1.1 200 OK"))
+
+		retry.DoWithRetry(remoteCluster.GetTesting(), "curl remote service",
+			DefaultRetries, DefaultTimeout,
+			func() (string, error) {
+				stdout, _, err = remoteCluster.ExecWithRetries("", "", "demo-client",
+					"curl", "-v", "-m", "3", "localhost:4001")
+				if err != nil {
+					return "should retry", err
+				}
+				if strings.Contains(stdout, "HTTP/1.1 200 OK") {
+					return "Accessing service successful", nil
+				}
+				return "should retry", errors.Errorf("should retry")
+			})
+	})
+})

--- a/test/e2e/kuma_deploy_hybrid_test.go
+++ b/test/e2e/kuma_deploy_hybrid_test.go
@@ -85,6 +85,11 @@ metadata:
 
 		globalCP := global.GetKuma()
 
+		echoServerToken, err := globalCP.GenerateDpToken("echo-server_kuma-test_svc_8080")
+		Expect(err).ToNot(HaveOccurred())
+		demoClientToken, err := globalCP.GenerateDpToken("demo-client")
+		Expect(err).ToNot(HaveOccurred())
+
 		// K8s Cluster 1
 		remote_1 = k8sClusters.GetCluster(Kuma1)
 
@@ -119,8 +124,8 @@ metadata:
 
 		err = NewClusterSetup().
 			Install(Kuma(core.Remote, WithGlobalAddress(globalCP.GetKDSServerAddress()))).
-			Install(EchoServerUniversal()).
-			Install(DemoClientUniversal()).
+			Install(EchoServerUniversal(echoServerToken)).
+			Install(DemoClientUniversal(demoClientToken)).
 			Setup(remote_3)
 		Expect(err).ToNot(HaveOccurred())
 		err = remote_3.VerifyKuma()
@@ -131,7 +136,7 @@ metadata:
 
 		err = NewClusterSetup().
 			Install(Kuma(core.Remote, WithGlobalAddress(globalCP.GetKDSServerAddress()))).
-			Install(DemoClientUniversal()).
+			Install(DemoClientUniversal(demoClientToken)).
 			Setup(remote_4)
 		Expect(err).ToNot(HaveOccurred())
 		err = remote_4.VerifyKuma()

--- a/test/e2e/kuma_deploy_universal_test.go
+++ b/test/e2e/kuma_deploy_universal_test.go
@@ -56,13 +56,18 @@ destinations:
 
 		globalCP := global.GetKuma()
 
+		echoServerToken, err := globalCP.GenerateDpToken("echo-server_kuma-test_svc_8080")
+		Expect(err).ToNot(HaveOccurred())
+		demoClientToken, err := globalCP.GenerateDpToken("demo-client")
+		Expect(err).ToNot(HaveOccurred())
+
 		// Cluster 1
 		remote_1 = clusters.GetCluster(Kuma2)
 
 		err = NewClusterSetup().
 			Install(Kuma(core.Remote, WithGlobalAddress(globalCP.GetKDSServerAddress()))).
-			Install(EchoServerUniversal()).
-			Install(DemoClientUniversal()).
+			Install(EchoServerUniversal(echoServerToken)).
+			Install(DemoClientUniversal(demoClientToken)).
 			Setup(remote_1)
 		Expect(err).ToNot(HaveOccurred())
 		err = remote_1.VerifyKuma()
@@ -73,7 +78,7 @@ destinations:
 
 		err = NewClusterSetup().
 			Install(Kuma(core.Remote, WithGlobalAddress(globalCP.GetKDSServerAddress()))).
-			Install(DemoClientUniversal()).
+			Install(DemoClientUniversal(demoClientToken)).
 			Setup(remote_2)
 		Expect(err).ToNot(HaveOccurred())
 		err = remote_2.VerifyKuma()

--- a/test/e2e/tracing_universal_test.go
+++ b/test/e2e/tracing_universal_test.go
@@ -46,12 +46,20 @@ selectors:
 
 		err := NewClusterSetup().
 			Install(Kuma(core.Standalone)).
-			Install(EchoServerUniversal()).
-			Install(DemoClientUniversal()).
 			Install(tracing.Install()).
 			Setup(cluster)
 		Expect(err).ToNot(HaveOccurred())
 		err = cluster.VerifyKuma()
+		Expect(err).ToNot(HaveOccurred())
+
+		echoServerToken, err := cluster.GetKuma().GenerateDpToken("echo-server_kuma-test_svc_8080")
+		Expect(err).ToNot(HaveOccurred())
+		demoClientToken, err := cluster.GetKuma().GenerateDpToken("demo-client")
+		Expect(err).ToNot(HaveOccurred())
+
+		err = EchoServerUniversal(echoServerToken)(cluster)
+		Expect(err).ToNot(HaveOccurred())
+		err = DemoClientUniversal(demoClientToken)(cluster)
 		Expect(err).ToNot(HaveOccurred())
 	})
 

--- a/test/framework/constants.go
+++ b/test/framework/constants.go
@@ -63,5 +63,6 @@ const (
 	helmChartPath = "../../deployments/charts/kuma"
 
 	kumaCPAPIPort        = 5681
+	kumaCPAdminPort      = 5679
 	kumaCPAPIPortFwdBase = 32000 + kumaCPAPIPort
 )

--- a/test/framework/interface.go
+++ b/test/framework/interface.go
@@ -97,7 +97,7 @@ type Cluster interface {
 	GetKubectlOptions(namespace ...string) *k8s.KubectlOptions
 	CreateNamespace(namespace string) error
 	DeleteNamespace(namespace string) error
-	DeployApp(namespace, appname string) error
+	DeployApp(namespace, appname, token string) error
 	DeleteApp(namespace, appname string) error
 	Exec(namespace, podName, containerName string, cmd ...string) (string, string, error)
 	ExecWithRetries(namespace, podName, containerName string, cmd ...string) (string, string, error)
@@ -112,4 +112,5 @@ type ControlPlane interface {
 	GetKDSServerAddress() string
 	GetIngressAddress() string
 	GetGlobaStatusAPI() string
+	GenerateDpToken(appname string) (string, error)
 }

--- a/test/framework/k8s_cluster.go
+++ b/test/framework/k8s_cluster.go
@@ -565,7 +565,7 @@ func (c *K8sCluster) DeleteNamespace(namespace string) error {
 	return nil
 }
 
-func (c *K8sCluster) DeployApp(namespace, appname string) error {
+func (c *K8sCluster) DeployApp(namespace, appname, token string) error {
 	retry.DoWithRetry(c.GetTesting(), "apply "+appname+" svc", DefaultRetries, DefaultTimeout,
 		func() (string, error) {
 			err := k8s.KubectlApplyE(c.GetTesting(),

--- a/test/framework/k8s_clusters.go
+++ b/test/framework/k8s_clusters.go
@@ -158,9 +158,9 @@ func (c *K8sClusters) GetKumactlOptions() *KumactlOptions {
 	return nil
 }
 
-func (cs *K8sClusters) DeployApp(namespace, appname string) error {
+func (cs *K8sClusters) DeployApp(namespace, appname, token string) error {
 	for name, c := range cs.clusters {
-		if err := c.DeployApp(namespace, appname); err != nil {
+		if err := c.DeployApp(namespace, appname, token); err != nil {
 			return errors.Wrapf(err, "Labeling Namespace %s on %s failed: %v", namespace, name, err)
 		}
 	}

--- a/test/framework/setup.go
+++ b/test/framework/setup.go
@@ -103,9 +103,9 @@ func EchoServerK8s() InstallFunc {
 	)
 }
 
-func EchoServerUniversal() InstallFunc {
+func EchoServerUniversal(token string) InstallFunc {
 	return func(cluster Cluster) error {
-		return cluster.DeployApp("", AppModeEchoServer)
+		return cluster.DeployApp("", AppModeEchoServer, token)
 	}
 }
 
@@ -167,9 +167,9 @@ func DemoClientK8s() InstallFunc {
 	)
 }
 
-func DemoClientUniversal() InstallFunc {
+func DemoClientUniversal(token string) InstallFunc {
 	return func(cluster Cluster) error {
-		return cluster.DeployApp("", AppModeDemoClient)
+		return cluster.DeployApp("", AppModeDemoClient, token)
 	}
 }
 

--- a/test/framework/universal_cluster.go
+++ b/test/framework/universal_cluster.go
@@ -93,7 +93,7 @@ func (c *UniversalCluster) DeployKuma(mode string, fs ...DeployOptionsFunc) erro
 	switch mode {
 	case core.Remote:
 		dpyaml := fmt.Sprintf(IngressDataplane, kdsPort)
-		err = c.CreateDP(app, "ingress", app.ip, dpyaml)
+		err = c.CreateDP(app, "ingress", app.ip, dpyaml, "XYZ") // todo token is static now, Ingress does not access SDS so the token does not matter for now
 		if err != nil {
 			return err
 		}
@@ -142,25 +142,13 @@ func (c *UniversalCluster) DeleteNamespace(namespace string) error {
 	return nil
 }
 
-func (c *UniversalCluster) CreateDP(app *UniversalApp, appname, ip, dpyaml string) error {
-	// generate the token on the CP node
-	sshApp := NewSshApp(c.verbose, c.apps[AppModeCP].ports["22"], []string{}, []string{"curl",
-		"-H", "\"Content-Type: application/json\"",
-		"--data", "'{\"name\": \"dp-" + appname + "\", \"mesh\": \"default\"}'",
-		"http://localhost:5679/tokens"})
-	if err := sshApp.Run(); err != nil {
-		return err
-	}
-
-	token := sshApp.Out()
-
+func (c *UniversalCluster) CreateDP(app *UniversalApp, appname, ip, dpyaml, token string) error {
 	cpAddress := "http://" + c.apps[AppModeCP].ip + ":5681"
 	app.CreateDP(token, cpAddress, appname, ip, dpyaml)
-
 	return app.dpApp.Start()
 }
 
-func (c *UniversalCluster) DeployApp(namespace, appname string) error {
+func (c *UniversalCluster) DeployApp(namespace, appname, token string) error {
 	var args []string
 	switch appname {
 	case AppModeEchoServer:
@@ -190,7 +178,7 @@ func (c *UniversalCluster) DeployApp(namespace, appname string) error {
 		dpyaml = fmt.Sprintf(DemoClientDataplane, "13000", "3000", "80", "8080")
 	}
 
-	err = c.CreateDP(app, appname, ip, dpyaml)
+	err = c.CreateDP(app, appname, ip, dpyaml, token)
 	if err != nil {
 		return err
 	}

--- a/test/framework/universal_clusters.go
+++ b/test/framework/universal_clusters.go
@@ -133,9 +133,9 @@ func (c *UniversalClusters) GetKumactlOptions() *KumactlOptions {
 	return nil
 }
 
-func (cs *UniversalClusters) DeployApp(namespace, appname string) error {
+func (cs *UniversalClusters) DeployApp(namespace, appname, token string) error {
 	for name, c := range cs.clusters {
-		if err := c.DeployApp(namespace, appname); err != nil {
+		if err := c.DeployApp(namespace, appname, token); err != nil {
 			return errors.Wrapf(err, "Labeling Namespace %s on %s failed: %v", namespace, name, err)
 		}
 	}

--- a/test/framework/universal_controlplane.go
+++ b/test/framework/universal_controlplane.go
@@ -1,7 +1,10 @@
 package framework
 
 import (
+	"fmt"
 	"strconv"
+
+	"github.com/pkg/errors"
 
 	"github.com/kumahq/kuma/pkg/config/core"
 
@@ -51,4 +54,19 @@ func (c *UniversalControlPlane) GetIngressAddress() string {
 
 func (c *UniversalControlPlane) GetGlobaStatusAPI() string {
 	panic("not implemented")
+}
+
+func (c *UniversalControlPlane) GenerateDpToken(service string) (string, error) {
+	sshApp := NewSshApp(c.verbose, c.cluster.apps[AppModeCP].ports["22"], []string{}, []string{"curl",
+		"--fail", "--show-error",
+		"-H", "\"Content-Type: application/json\"",
+		"--data", fmt.Sprintf(`'{"mesh": "default", "tags": {"kuma.io/service":["%s"]}}'`, service),
+		"http://localhost:5679/tokens"})
+	if err := sshApp.Run(); err != nil {
+		return "", err
+	}
+	if sshApp.Err() != "" {
+		return "", errors.New(sshApp.Err())
+	}
+	return sshApp.Out(), nil
 }


### PR DESCRIPTION
Dataplane Token is an identity that we give to Dataplanes and verify it on the CP on Universal deployments. On K8S we use service account tokens. Dataplane Token is a JWT token signed by Signing Token that is generated when CP starts.

With multizone setup when Global is on K8S and you connect Remote Universal, KDS syncs all the secrets from Global to Remote. Since Global is a centralized single source of truth for everything other than Dataplanes, if Secret is not available on Global, it will be removed from the Remote.  What happened is that we were generating token on Remote but not on Global so it was removed from Remote. This PR fixes this behavior.

This time we generate Signing Key with a multizone setup only on Global but in all environments. Even if Global is on K8S, we don't know when the user will connect Universal Remote and there will be a need to generate DP tokens. We don't generate token on the Remote anymore. From now, to deploy app on Remote Universal, you need to first connect to Global to sync Signing Key, otherwise you won't be able to verify Token that DP presents.

Additionally, you should be able to generate Tokens on both Global and Remote. The Global-Remote design assumes that you can spin up and down Dataplanes without Global. There might be a case that CI that deploys the app generates token beforehand therefore there should be a way to generate it also on the Remote.

I added a simple E2E test to check that if I have Global on K8S and Remote Universal I can deploy 2 apps.

### Documentation

- TODO with DP improvements.
