### PR TITLE
fix(*) drop k8s 1.13 support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -606,7 +606,7 @@ workflows:
         <<: *commit_workflow_filters
         name: minikube_v1_14
         requires:
-          - release
+          - images
         # custom parameters
         kubernetes_version: v1.14.10
         use_local_kuma_images: true

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -660,14 +660,6 @@ workflows:
           use_local_kuma_images: true
       - example_minikube:
           <<: *master_workflow_filters
-          name: minikube_v1_13
-          requires:
-            - images
-          # custom parameters
-          kubernetes_version: v1.13.12
-          use_local_kuma_images: true
-      - example_minikube:
-          <<: *master_workflow_filters
           name: minikube_v1_14
           requires:
             - images
@@ -746,15 +738,6 @@ workflows:
         requires:
         - release
         # custom parameters
-        # docker images for a release build must be downloaded from a public Docker registry
-        use_local_kuma_images: false
-    - example_minikube:
-        <<: *release_workflow_filters
-        name: minikube_v1_13
-        requires:
-        - release
-        # custom parameters
-        kubernetes_version: v1.13.12
         # docker images for a release build must be downloaded from a public Docker registry
         use_local_kuma_images: false
     - example_minikube:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -609,7 +609,7 @@ workflows:
         requires:
           - images
         # custom parameters
-        kubernetes_version: v1.18.6
+        kubernetes_version: v1.18.9
         use_local_kuma_images: true
     - integration:
         <<: *commit_workflow_filters
@@ -672,7 +672,7 @@ workflows:
           requires:
             - images
           # custom parameters
-          kubernetes_version: v1.15.11
+          kubernetes_version: v1.15.12
           use_local_kuma_images: true
       - example_minikube:
           <<: *master_workflow_filters
@@ -680,7 +680,7 @@ workflows:
           requires:
             - images
           # custom parameters
-          kubernetes_version: v1.16.13
+          kubernetes_version: v1.16.15
           use_local_kuma_images: true
       - example_minikube:
           <<: *master_workflow_filters
@@ -688,7 +688,7 @@ workflows:
           requires:
             - images
           # custom parameters
-          kubernetes_version: v1.17.9
+          kubernetes_version: v1.17.12
           use_local_kuma_images: true
       - example_minikube:
           <<: *master_workflow_filters
@@ -696,7 +696,7 @@ workflows:
           requires:
             - images
           # custom parameters
-          kubernetes_version: v1.18.6
+          kubernetes_version: v1.18.9
           use_local_kuma_images: true
       - integration:
           <<: *master_workflow_filters
@@ -755,7 +755,7 @@ workflows:
         requires:
         - release
         # custom parameters
-        kubernetes_version: v1.15.11
+        kubernetes_version: v1.15.12
         # docker images for a release build must be downloaded from a public Docker registry
         use_local_kuma_images: false
     - example_minikube:
@@ -764,7 +764,7 @@ workflows:
         requires:
         - release
         # custom parameters
-        kubernetes_version: v1.16.13
+        kubernetes_version: v1.16.15
         # docker images for a release build must be downloaded from a public Docker registry
         use_local_kuma_images: false
     - example_minikube:
@@ -773,7 +773,7 @@ workflows:
         requires:
         - release
         # custom parameters
-        kubernetes_version: v1.17.9
+        kubernetes_version: v1.17.12
         # docker images for a release build must be downloaded from a public Docker registry
         use_local_kuma_images: false
     - example_minikube:
@@ -782,6 +782,6 @@ workflows:
         requires:
           - release
         # custom parameters
-        kubernetes_version: v1.18.6
+        kubernetes_version: v1.18.9
         # docker images for a release build must be downloaded from a public Docker registry
         use_local_kuma_images: false

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -605,6 +605,14 @@ workflows:
         use_local_kuma_images: true
     - example_minikube:
         <<: *commit_workflow_filters
+        name: minikube_v1_14
+        requires:
+          - release
+        # custom parameters
+        kubernetes_version: v1.14.10
+        use_local_kuma_images: true
+    - example_minikube:
+        <<: *commit_workflow_filters
         name: minikube_v1_18
         requires:
           - images

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,8 +32,7 @@ reusable:
     commit_workflow_filters: &commit_workflow_filters
       filters:
         branches:
-          # don't run on gh-pages
-          ignore: /gh-pages/
+          ignore: master, gh-pages
 
 executors:
   golang:


### PR DESCRIPTION
### Summary

Disable testing against Kubernetes 1.13. 

#990 introduces NodeSelectors for CP and CNI pods in the Helm Charts. #989 makes the Helm Charts the default installation templating for `kumactl install control-plane`. 

Kubernetes 1.14 introduces `kubernetes.io/os` and `kubernetes.io/arch` and [deprecates](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.14.md#deprecations) `beta.kubernetes.io/os` and `beta.kubernetes.io/arch`. This effectively makes Kuma Helm Charts and now `kumactl install control-plane` unusable on Kubernetes versions prior to 1.14, as the deployment hangs trying to find nodes labelled with  `kubernetes.io/os` and `kubernetes.io/arch`, while such does not exist (as 1.13 uses the `beta` labels).

As the `beta` labels are not supported at all since 1.18, we'd better drop 1.13 support here.

While we are here, fix also:

 * Bump all Kubernetes versions used in the CI
 * Do not run kuma-commit for master, as it is an unneeded duplication
 * Test against the minimal supported K8s on kuma-commit, 


### Issues resolved

Master CI is failing

### Documentation

- [ ] will be reflected in the Changelog at release time
