### PR TITLE
Fixed set PATH environment variable for make build/kumactl in DEVELOPER.md

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -162,7 +162,7 @@ make run/universal/postgres
 1. Build a `kumactl`
 ```bash
 make build/kumactl
-export PATH=`pwd`/build/artifacts/kumactl:$PATH
+export PATH=`pwd`/build/artifacts-$(go env GOOS)-$(go env GOARCH)/kumactl:$PATH
 ```
 
 2. Configure a `kumactl` with running Control Plane


### PR DESCRIPTION
Corrected setting PATH environment variable for make build/kumactl in DEVELOPER.md
### Summary

In [developer doc](https://github.com/kumahq/kuma/blob/master/DEVELOPER.md),   step `export PATH=`pwd`/build/artifacts/kumactl:$PATH` does not match with the current value generated in make file for eg artifacts-linux-amd64 is generated instead of artifacts

### Full changelog
Present: export PATH=`pwd`/build/artifacts/kumactl:$PATH
This PR: export PATH=`pwd`/build/artifacts-$(go env GOOS)-$(go env GOARCH)/kumactl:$PATH

### Issues resolved
Documentation https://github.com/kumahq/kuma/blob/master/DEVELOPER.md

### Documentation
https://github.com/kumahq/kuma/blob/master/DEVELOPER.md
