### PR TITLE
Add more recognizable plane identifier in DiscoveryResponse

### DIFF
--- a/pkg/core/runtime/builder.go
+++ b/pkg/core/runtime/builder.go
@@ -2,6 +2,8 @@ package runtime
 
 import (
 	"context"
+	"fmt"
+	"os"
 
 	"github.com/pkg/errors"
 
@@ -61,12 +63,14 @@ type Builder struct {
 }
 
 func BuilderFor(cfg kuma_cp.Config) *Builder {
+	hostname, _ := os.Hostname()
+	suffix := core.NewUUID()[0:4]
 	return &Builder{
 		cfg: cfg,
 		ext: context.Background(),
 		cam: core_ca.Managers{},
 		runtimeInfo: &runtimeInfo{
-			instanceId: core.NewUUID(),
+			instanceId: fmt.Sprintf("%s-%s", hostname, suffix),
 		},
 	}
 }

--- a/pkg/kds/global/components.go
+++ b/pkg/kds/global/components.go
@@ -51,7 +51,7 @@ var (
 
 func Setup(rt runtime.Runtime) (err error) {
 	kdsServer, err := kds_server.New(kdsGlobalLog, rt, providedTypes,
-		"global", rt.Config().Multicluster.Global.KDS.RefreshInterval,
+		"global", rt.GetInstanceId(), rt.Config().Multicluster.Global.KDS.RefreshInterval,
 		ProvidedFilter, true)
 	if err != nil {
 		return err

--- a/pkg/kds/global/components.go
+++ b/pkg/kds/global/components.go
@@ -51,7 +51,7 @@ var (
 
 func Setup(rt runtime.Runtime) (err error) {
 	kdsServer, err := kds_server.New(kdsGlobalLog, rt, providedTypes,
-		"global", rt.GetInstanceId(), rt.Config().Multicluster.Global.KDS.RefreshInterval,
+		rt.GetInstanceId(), rt.Config().Multicluster.Global.KDS.RefreshInterval,
 		ProvidedFilter, true)
 	if err != nil {
 		return err

--- a/pkg/kds/global/components_test.go
+++ b/pkg/kds/global/components_test.go
@@ -41,7 +41,7 @@ var _ = Describe("Global Sync", func() {
 		for i := 0; i < 2; i++ {
 			wg.Add(1)
 			remoteStore := memory.NewStore()
-			serverStream := kds_setup.StartServer(remoteStore, wg, fmt.Sprintf("cluster-%d", i), kds.SupportedTypes, reconcile.Any)
+			serverStream := kds_setup.StartServer(remoteStore, wg, fmt.Sprintf("cluster-%d", i), fmt.Sprintf("localhost-%d", i), kds.SupportedTypes, reconcile.Any)
 			serverStreams = append(serverStreams, serverStream)
 			remoteStores = append(remoteStores, remoteStore)
 		}

--- a/pkg/kds/global/components_test.go
+++ b/pkg/kds/global/components_test.go
@@ -41,7 +41,7 @@ var _ = Describe("Global Sync", func() {
 		for i := 0; i < 2; i++ {
 			wg.Add(1)
 			remoteStore := memory.NewStore()
-			serverStream := kds_setup.StartServer(remoteStore, wg, fmt.Sprintf("cluster-%d", i), fmt.Sprintf("localhost-%d", i), kds.SupportedTypes, reconcile.Any)
+			serverStream := kds_setup.StartServer(remoteStore, wg, fmt.Sprintf("localhost-%d", i), kds.SupportedTypes, reconcile.Any)
 			serverStreams = append(serverStreams, serverStream)
 			remoteStores = append(remoteStores, remoteStore)
 		}

--- a/pkg/kds/remote/components.go
+++ b/pkg/kds/remote/components.go
@@ -44,7 +44,7 @@ var (
 func Setup(rt core_runtime.Runtime) error {
 	zone := rt.Config().Multicluster.Remote.Zone
 	kdsServer, err := kds_server.New(kdsRemoteLog, rt, providedTypes,
-		zone, rt.Config().Multicluster.Remote.KDS.RefreshInterval,
+		zone, rt.GetInstanceId(), rt.Config().Multicluster.Remote.KDS.RefreshInterval,
 		providedFilter(zone), false)
 	if err != nil {
 		return err

--- a/pkg/kds/remote/components.go
+++ b/pkg/kds/remote/components.go
@@ -44,7 +44,7 @@ var (
 func Setup(rt core_runtime.Runtime) error {
 	zone := rt.Config().Multicluster.Remote.Zone
 	kdsServer, err := kds_server.New(kdsRemoteLog, rt, providedTypes,
-		zone, rt.GetInstanceId(), rt.Config().Multicluster.Remote.KDS.RefreshInterval,
+		rt.GetInstanceId(), rt.Config().Multicluster.Remote.KDS.RefreshInterval,
 		providedFilter(zone), false)
 	if err != nil {
 		return err

--- a/pkg/kds/remote/components_test.go
+++ b/pkg/kds/remote/components_test.go
@@ -69,7 +69,7 @@ var _ = Describe("Remote Sync", func() {
 		globalStore = memory.NewStore()
 		wg := &sync.WaitGroup{}
 		wg.Add(1)
-		serverStream := setup.StartServer(globalStore, wg, "global", consumedTypes, global.ProvidedFilter)
+		serverStream := setup.StartServer(globalStore, wg, "global", "localhost-1234", consumedTypes, global.ProvidedFilter)
 
 		stop := make(chan struct{})
 		clientStream := serverStream.ClientStream(stop)

--- a/pkg/kds/remote/components_test.go
+++ b/pkg/kds/remote/components_test.go
@@ -69,7 +69,7 @@ var _ = Describe("Remote Sync", func() {
 		globalStore = memory.NewStore()
 		wg := &sync.WaitGroup{}
 		wg.Add(1)
-		serverStream := setup.StartServer(globalStore, wg, "global", "localhost-1234", consumedTypes, global.ProvidedFilter)
+		serverStream := setup.StartServer(globalStore, wg, "localhost-1234", consumedTypes, global.ProvidedFilter)
 
 		stop := make(chan struct{})
 		clientStream := serverStream.ClientStream(stop)

--- a/pkg/kds/server/components.go
+++ b/pkg/kds/server/components.go
@@ -20,7 +20,7 @@ import (
 	util_xds "github.com/kumahq/kuma/pkg/util/xds"
 )
 
-func New(log logr.Logger, rt core_runtime.Runtime, providedTypes []model.ResourceType, serverID string, refresh time.Duration, filter reconcile.ResourceFilter, insight bool) (Server, error) {
+func New(log logr.Logger, rt core_runtime.Runtime, providedTypes []model.ResourceType, serverID string, instanceID string, refresh time.Duration, filter reconcile.ResourceFilter, insight bool) (Server, error) {
 	hasher, cache := newKDSContext(log)
 	generator := reconcile.NewSnapshotGenerator(rt.ReadOnlyResourceManager(), providedTypes, filter)
 	versioner := util_xds.SnapshotAutoVersioner{UUID: core.NewUUID}
@@ -41,7 +41,7 @@ func New(log logr.Logger, rt core_runtime.Runtime, providedTypes []model.Resourc
 	if insight {
 		callbacks = append(callbacks, DefaultStatusTracker(rt, log))
 	}
-	return NewServer(cache, callbacks, log, serverID), nil
+	return NewServer(cache, callbacks, log, serverID, instanceID), nil
 }
 
 func DefaultStatusTracker(rt core_runtime.Runtime, log logr.Logger) StatusTracker {

--- a/pkg/kds/server/components.go
+++ b/pkg/kds/server/components.go
@@ -20,7 +20,7 @@ import (
 	util_xds "github.com/kumahq/kuma/pkg/util/xds"
 )
 
-func New(log logr.Logger, rt core_runtime.Runtime, providedTypes []model.ResourceType, serverID string, instanceID string, refresh time.Duration, filter reconcile.ResourceFilter, insight bool) (Server, error) {
+func New(log logr.Logger, rt core_runtime.Runtime, providedTypes []model.ResourceType, instanceID string, refresh time.Duration, filter reconcile.ResourceFilter, insight bool) (Server, error) {
 	hasher, cache := newKDSContext(log)
 	generator := reconcile.NewSnapshotGenerator(rt.ReadOnlyResourceManager(), providedTypes, filter)
 	versioner := util_xds.SnapshotAutoVersioner{UUID: core.NewUUID}
@@ -41,7 +41,7 @@ func New(log logr.Logger, rt core_runtime.Runtime, providedTypes []model.Resourc
 	if insight {
 		callbacks = append(callbacks, DefaultStatusTracker(rt, log))
 	}
-	return NewServer(cache, callbacks, log, serverID, instanceID), nil
+	return NewServer(cache, callbacks, log, instanceID), nil
 }
 
 func DefaultStatusTracker(rt core_runtime.Runtime, log logr.Logger) StatusTracker {

--- a/pkg/kds/server/server_test.go
+++ b/pkg/kds/server/server_test.go
@@ -46,7 +46,7 @@ var _ = Describe("KDS Server", func() {
 
 		wg := &sync.WaitGroup{}
 		wg.Add(1)
-		stream := kds_setup.StartServer(s, wg, "test-cluster", kds.SupportedTypes, reconcile.Any)
+		stream := kds_setup.StartServer(s, wg, "test-cluster", "localhost-1234", kds.SupportedTypes, reconcile.Any)
 
 		tc = &kds_verifier.TestContextImpl{
 			ResourceStore:      s,

--- a/pkg/kds/server/server_test.go
+++ b/pkg/kds/server/server_test.go
@@ -46,7 +46,7 @@ var _ = Describe("KDS Server", func() {
 
 		wg := &sync.WaitGroup{}
 		wg.Add(1)
-		stream := kds_setup.StartServer(s, wg, "test-cluster", "localhost-1234", kds.SupportedTypes, reconcile.Any)
+		stream := kds_setup.StartServer(s, wg, "localhost-1234", kds.SupportedTypes, reconcile.Any)
 
 		tc = &kds_verifier.TestContextImpl{
 			ResourceStore:      s,

--- a/pkg/test/kds/setup/server.go
+++ b/pkg/test/kds/setup/server.go
@@ -46,7 +46,7 @@ func (t *testRuntimeContext) Add(c ...component.Component) error {
 	return nil
 }
 
-func StartServer(store store.ResourceStore, wg *sync.WaitGroup, clusterID string, providedTypes []model.ResourceType, providedFilter reconcile.ResourceFilter) *test_grpc.MockServerStream {
+func StartServer(store store.ResourceStore, wg *sync.WaitGroup, clusterID string, instanceID string, providedTypes []model.ResourceType, providedFilter reconcile.ResourceFilter) *test_grpc.MockServerStream {
 	metrics, err := core_metrics.NewMetrics("Global")
 	Expect(err).ToNot(HaveOccurred())
 	rt := &testRuntimeContext{
@@ -54,7 +54,7 @@ func StartServer(store store.ResourceStore, wg *sync.WaitGroup, clusterID string
 		cfg:     kuma_cp.Config{},
 		metrics: metrics,
 	}
-	srv, err := kds_server.New(core.Log, rt, providedTypes, clusterID, 100*time.Millisecond, providedFilter, false)
+	srv, err := kds_server.New(core.Log, rt, providedTypes, clusterID, instanceID, 100*time.Millisecond, providedFilter, false)
 	Expect(err).ToNot(HaveOccurred())
 	stream := test_grpc.MakeMockStream()
 	go func() {

--- a/pkg/test/kds/setup/server.go
+++ b/pkg/test/kds/setup/server.go
@@ -46,7 +46,7 @@ func (t *testRuntimeContext) Add(c ...component.Component) error {
 	return nil
 }
 
-func StartServer(store store.ResourceStore, wg *sync.WaitGroup, clusterID string, instanceID string, providedTypes []model.ResourceType, providedFilter reconcile.ResourceFilter) *test_grpc.MockServerStream {
+func StartServer(store store.ResourceStore, wg *sync.WaitGroup, instanceID string, providedTypes []model.ResourceType, providedFilter reconcile.ResourceFilter) *test_grpc.MockServerStream {
 	metrics, err := core_metrics.NewMetrics("Global")
 	Expect(err).ToNot(HaveOccurred())
 	rt := &testRuntimeContext{
@@ -54,7 +54,7 @@ func StartServer(store store.ResourceStore, wg *sync.WaitGroup, clusterID string
 		cfg:     kuma_cp.Config{},
 		metrics: metrics,
 	}
-	srv, err := kds_server.New(core.Log, rt, providedTypes, clusterID, instanceID, 100*time.Millisecond, providedFilter, false)
+	srv, err := kds_server.New(core.Log, rt, providedTypes, instanceID, 100*time.Millisecond, providedFilter, false)
 	Expect(err).ToNot(HaveOccurred())
 	stream := test_grpc.MakeMockStream()
 	go func() {


### PR DESCRIPTION
### Summary

Replace random UUID with hostname and 4 random characters in `DiscoverResponse.ControlPlane.Identifier`.

### Issues resolved

Fix #1011 
