### PR TITLE
chore(*) adding austince as a maintainer

### DIFF
--- a/OWNERS.md
+++ b/OWNERS.md
@@ -8,7 +8,11 @@ Please see [GOVERNANCE.md](GOVERNANCE.md) for governance guidelines and responsi
 
 # Maintainers
 
-* Jakub Dyszkiewicz ([jakubdyszkiewicz](https://github.com/jakubdyszkiewicz)) (jakub.dyszkiewicz@konghq.com)
+In alphabetical order:
+
+* Austin Cawley-Edwards([austince](https://github.com/austince)) (austin.cawley@gmail.com)
 * Ilya Lobkov ([lobkovilya](https://github.com/lobkovilya)) (ilya.lobkov@konghq.com)
-* Nikolay Nikolaev ([nickolaev](https://github.com/nickolaev)) (nikolay.nikolaev@konghq.com)
+* Jakub Dyszkiewicz ([jakubdyszkiewicz](https://github.com/jakubdyszkiewicz)) (jakub.dyszkiewicz@konghq.com)
 * Marco Palladino ([subnetmarco](https://github.com/subnetmarco)) (marco@konghq.com)
+* Nikolay Nikolaev ([nickolaev](https://github.com/nickolaev)) (nikolay.nikolaev@konghq.com)
+


### PR DESCRIPTION
## Summary

Based on a discussion within the current maintainers, here is a proposal for Austin Cawley-Edwards (@austince) to officially join the project as a new maintainer.

He has demonstrated a strong commitment to the project by leading the efforts to adopt Helm as the main templating engine to deploy Kuma on Kubernetes. Here is a list of his most significant engagements so far:

 * feat(deployments) add Helm chart for kuma #916
 * feat(kumactl) merge install ingress into install control-plane #1038
 * feat(kumactl) upgrade CRDs to apiextensions.k8s.io/v1 #890

He also was pro-active in the Kuma community Slack channels and is doing a presentation on his experience in adopting Kuma within their organisation/project.

According to our [GOVERNANCE.md](https://github.com/kumahq/kuma/blob/master/GOVERNANCE.md) we need two other members of @kumahq/kuma-maintainers to approve this PR so we can merge it and make it official.


