### PR TITLE
feat(kuma-injector) health-check endpoint

### DIFF
--- a/pkg/plugins/runtime/k8s/webhooks/injector/injector.go
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/injector.go
@@ -223,7 +223,7 @@ func (i *KumaInjector) NewSidecarContainer(pod *kube_core.Pod, ns *kube_core.Nam
 					Command: []string{
 						"wget",
 						"-qO-",
-						fmt.Sprintf("http://127.0.0.1:%d", i.cfg.SidecarContainer.AdminPort),
+						fmt.Sprintf("http://127.0.0.1:%d/ready", i.cfg.SidecarContainer.AdminPort),
 					},
 				},
 			},
@@ -239,7 +239,7 @@ func (i *KumaInjector) NewSidecarContainer(pod *kube_core.Pod, ns *kube_core.Nam
 					Command: []string{
 						"wget",
 						"-qO-",
-						fmt.Sprintf("http://127.0.0.1:%d", i.cfg.SidecarContainer.AdminPort),
+						fmt.Sprintf("http://127.0.0.1:%d/ready", i.cfg.SidecarContainer.AdminPort),
 					},
 				},
 			},

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.01.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.01.golden.yaml
@@ -60,7 +60,7 @@ spec:
         command:
         - wget
         - -qO-
-        - http://127.0.0.1:9901
+        - http://127.0.0.1:9901/ready
       failureThreshold: 212
       initialDelaySeconds: 260
       periodSeconds: 25
@@ -72,7 +72,7 @@ spec:
         command:
         - wget
         - -qO-
-        - http://127.0.0.1:9901
+        - http://127.0.0.1:9901/ready
       failureThreshold: 112
       initialDelaySeconds: 11
       periodSeconds: 15

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.02.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.02.golden.yaml
@@ -61,7 +61,7 @@ spec:
         command:
         - wget
         - -qO-
-        - http://127.0.0.1:9901
+        - http://127.0.0.1:9901/ready
       failureThreshold: 212
       initialDelaySeconds: 260
       periodSeconds: 25
@@ -73,7 +73,7 @@ spec:
         command:
         - wget
         - -qO-
-        - http://127.0.0.1:9901
+        - http://127.0.0.1:9901/ready
       failureThreshold: 112
       initialDelaySeconds: 11
       periodSeconds: 15

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.03.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.03.golden.yaml
@@ -120,7 +120,7 @@ spec:
         command:
         - wget
         - -qO-
-        - http://127.0.0.1:9901
+        - http://127.0.0.1:9901/ready
       failureThreshold: 212
       initialDelaySeconds: 260
       periodSeconds: 25
@@ -132,7 +132,7 @@ spec:
         command:
         - wget
         - -qO-
-        - http://127.0.0.1:9901
+        - http://127.0.0.1:9901/ready
       failureThreshold: 112
       initialDelaySeconds: 11
       periodSeconds: 15

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.04.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.04.golden.yaml
@@ -60,7 +60,7 @@ spec:
         command:
         - wget
         - -qO-
-        - http://127.0.0.1:9901
+        - http://127.0.0.1:9901/ready
       failureThreshold: 212
       initialDelaySeconds: 260
       periodSeconds: 25
@@ -72,7 +72,7 @@ spec:
         command:
         - wget
         - -qO-
-        - http://127.0.0.1:9901
+        - http://127.0.0.1:9901/ready
       failureThreshold: 112
       initialDelaySeconds: 11
       periodSeconds: 15

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.05.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.05.golden.yaml
@@ -57,7 +57,7 @@ spec:
         command:
         - wget
         - -qO-
-        - http://127.0.0.1:9901
+        - http://127.0.0.1:9901/ready
       failureThreshold: 212
       initialDelaySeconds: 260
       periodSeconds: 25
@@ -69,7 +69,7 @@ spec:
         command:
         - wget
         - -qO-
-        - http://127.0.0.1:9901
+        - http://127.0.0.1:9901/ready
       failureThreshold: 112
       initialDelaySeconds: 11
       periodSeconds: 15

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.06.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.06.golden.yaml
@@ -61,7 +61,7 @@ spec:
         command:
         - wget
         - -qO-
-        - http://127.0.0.1:9901
+        - http://127.0.0.1:9901/ready
       failureThreshold: 212
       initialDelaySeconds: 260
       periodSeconds: 25
@@ -73,7 +73,7 @@ spec:
         command:
         - wget
         - -qO-
-        - http://127.0.0.1:9901
+        - http://127.0.0.1:9901/ready
       failureThreshold: 112
       initialDelaySeconds: 11
       periodSeconds: 15

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.07.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.07.golden.yaml
@@ -60,7 +60,7 @@ spec:
         command:
         - wget
         - -qO-
-        - http://127.0.0.1:9901
+        - http://127.0.0.1:9901/ready
       failureThreshold: 212
       initialDelaySeconds: 260
       periodSeconds: 25
@@ -72,7 +72,7 @@ spec:
         command:
         - wget
         - -qO-
-        - http://127.0.0.1:9901
+        - http://127.0.0.1:9901/ready
       failureThreshold: 112
       initialDelaySeconds: 11
       periodSeconds: 15

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.08.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.08.golden.yaml
@@ -63,7 +63,7 @@ spec:
         command:
         - wget
         - -qO-
-        - http://127.0.0.1:9901
+        - http://127.0.0.1:9901/ready
       failureThreshold: 212
       initialDelaySeconds: 260
       periodSeconds: 25
@@ -75,7 +75,7 @@ spec:
         command:
         - wget
         - -qO-
-        - http://127.0.0.1:9901
+        - http://127.0.0.1:9901/ready
       failureThreshold: 112
       initialDelaySeconds: 11
       periodSeconds: 15

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.09.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.09.golden.yaml
@@ -62,7 +62,7 @@ spec:
         command:
         - wget
         - -qO-
-        - http://127.0.0.1:9901
+        - http://127.0.0.1:9901/ready
       failureThreshold: 212
       initialDelaySeconds: 260
       periodSeconds: 25
@@ -74,7 +74,7 @@ spec:
         command:
         - wget
         - -qO-
-        - http://127.0.0.1:9901
+        - http://127.0.0.1:9901/ready
       failureThreshold: 112
       initialDelaySeconds: 11
       periodSeconds: 15

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.11.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.11.golden.yaml
@@ -61,7 +61,7 @@ spec:
         command:
         - wget
         - -qO-
-        - http://127.0.0.1:9901
+        - http://127.0.0.1:9901/ready
       failureThreshold: 212
       initialDelaySeconds: 260
       periodSeconds: 25
@@ -73,7 +73,7 @@ spec:
         command:
         - wget
         - -qO-
-        - http://127.0.0.1:9901
+        - http://127.0.0.1:9901/ready
       failureThreshold: 112
       initialDelaySeconds: 11
       periodSeconds: 15

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.12.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.12.golden.yaml
@@ -60,7 +60,7 @@ spec:
         command:
         - wget
         - -qO-
-        - http://127.0.0.1:9901
+        - http://127.0.0.1:9901/ready
       failureThreshold: 212
       initialDelaySeconds: 260
       periodSeconds: 25
@@ -72,7 +72,7 @@ spec:
         command:
         - wget
         - -qO-
-        - http://127.0.0.1:9901
+        - http://127.0.0.1:9901/ready
       failureThreshold: 112
       initialDelaySeconds: 11
       periodSeconds: 15

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.13.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.13.golden.yaml
@@ -60,7 +60,7 @@ spec:
         command:
         - wget
         - -qO-
-        - http://127.0.0.1:9901
+        - http://127.0.0.1:9901/ready
       failureThreshold: 212
       initialDelaySeconds: 260
       periodSeconds: 25
@@ -72,7 +72,7 @@ spec:
         command:
         - wget
         - -qO-
-        - http://127.0.0.1:9901
+        - http://127.0.0.1:9901/ready
       failureThreshold: 112
       initialDelaySeconds: 11
       periodSeconds: 15

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.14.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.14.golden.yaml
@@ -72,7 +72,7 @@ spec:
           command:
             - wget
             - -qO-
-            - http://127.0.0.1:9901
+            - http://127.0.0.1:9901/ready
         failureThreshold: 212
         initialDelaySeconds: 260
         periodSeconds: 25
@@ -84,7 +84,7 @@ spec:
           command:
             - wget
             - -qO-
-            - http://127.0.0.1:9901
+            - http://127.0.0.1:9901/ready
         failureThreshold: 112
         initialDelaySeconds: 11
         periodSeconds: 15

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.15.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.15.golden.yaml
@@ -72,7 +72,7 @@ spec:
           command:
             - wget
             - -qO-
-            - http://127.0.0.1:9901
+            - http://127.0.0.1:9901/ready
         failureThreshold: 212
         initialDelaySeconds: 260
         periodSeconds: 25
@@ -84,7 +84,7 @@ spec:
           command:
             - wget
             - -qO-
-            - http://127.0.0.1:9901
+            - http://127.0.0.1:9901/ready
         failureThreshold: 112
         initialDelaySeconds: 11
         periodSeconds: 15

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.16.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.16.golden.yaml
@@ -72,7 +72,7 @@ spec:
           command:
             - wget
             - -qO-
-            - http://127.0.0.1:9901
+            - http://127.0.0.1:9901/ready
         failureThreshold: 212
         initialDelaySeconds: 260
         periodSeconds: 25
@@ -84,7 +84,7 @@ spec:
           command:
             - wget
             - -qO-
-            - http://127.0.0.1:9901
+            - http://127.0.0.1:9901/ready
         failureThreshold: 112
         initialDelaySeconds: 11
         periodSeconds: 15

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.17.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.17.golden.yaml
@@ -62,7 +62,7 @@ spec:
         command:
         - wget
         - -qO-
-        - http://127.0.0.1:9901
+        - http://127.0.0.1:9901/ready
       failureThreshold: 212
       initialDelaySeconds: 260
       periodSeconds: 25
@@ -74,7 +74,7 @@ spec:
         command:
         - wget
         - -qO-
-        - http://127.0.0.1:9901
+        - http://127.0.0.1:9901/ready
       failureThreshold: 112
       initialDelaySeconds: 11
       periodSeconds: 15

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.18.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.18.golden.yaml
@@ -62,7 +62,7 @@ spec:
           command:
             - wget
             - -qO-
-            - http://127.0.0.1:9901
+            - http://127.0.0.1:9901/ready
         failureThreshold: 212
         initialDelaySeconds: 260
         periodSeconds: 25
@@ -74,7 +74,7 @@ spec:
           command:
             - wget
             - -qO-
-            - http://127.0.0.1:9901
+            - http://127.0.0.1:9901/ready
         failureThreshold: 112
         initialDelaySeconds: 11
         periodSeconds: 15

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.19.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.19.golden.yaml
@@ -62,7 +62,7 @@ spec:
         command:
         - wget
         - -qO-
-        - http://127.0.0.1:9901
+        - http://127.0.0.1:9901/ready
       failureThreshold: 212
       initialDelaySeconds: 260
       periodSeconds: 25
@@ -74,7 +74,7 @@ spec:
         command:
         - wget
         - -qO-
-        - http://127.0.0.1:9901
+        - http://127.0.0.1:9901/ready
       failureThreshold: 112
       initialDelaySeconds: 11
       periodSeconds: 15


### PR DESCRIPTION
### Summary

Use envoy's `/ready` endpoint for health-checks of `kuma-sidecar`.

### Full changelog

* Added `/ready` endpoint to kuma-injector's `LivenessProbe` and `ReadinessProbe` config. 

### Issues resolved

Fix #359 
