### PR TITLE
fix(*) make sure the GRPC services are registered before listener

### DIFF
--- a/app/kuma-dp/pkg/dataplane/accesslogs/server.go
+++ b/app/kuma-dp/pkg/dataplane/accesslogs/server.go
@@ -87,6 +87,7 @@ func (s *accessLogServer) StreamAccessLogs(stream envoy_accesslog.AccessLogServi
 
 func (s *accessLogServer) Start(stop <-chan struct{}) error {
 	envoy_accesslog.RegisterAccessLogServiceServer(s.server, s)
+
 	lis, err := net.Listen("unix", s.address)
 	if err != nil {
 		return err

--- a/pkg/kds/mux/server.go
+++ b/pkg/kds/mux/server.go
@@ -64,14 +64,14 @@ func (s *server) Start(stop <-chan struct{}) error {
 	}
 	grpcServer := grpc.NewServer(grpcOptions...)
 
+	// register services
+	mesh_proto.RegisterMultiplexServiceServer(grpcServer, s)
+	s.metrics.RegisterGRPC(grpcServer)
+
 	lis, err := net.Listen("tcp", fmt.Sprintf(":%d", s.config.GrpcPort))
 	if err != nil {
 		return err
 	}
-
-	// register services
-	mesh_proto.RegisterMultiplexServiceServer(grpcServer, s)
-	s.metrics.RegisterGRPC(grpcServer)
 
 	errChan := make(chan error)
 	go func() {

--- a/pkg/mads/server/grpc.go
+++ b/pkg/mads/server/grpc.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 	"net"
 
-	"google.golang.org/grpc"
-
 	observability_proto "github.com/kumahq/kuma/api/observability/v1alpha1"
+
+	"google.golang.org/grpc"
 
 	mads_config "github.com/kumahq/kuma/pkg/config/mads"
 	"github.com/kumahq/kuma/pkg/core"
@@ -38,14 +38,14 @@ func (s *grpcServer) Start(stop <-chan struct{}) error {
 	grpcOptions = append(grpcOptions, grpc.MaxConcurrentStreams(grpcMaxConcurrentStreams))
 	grpcServer := grpc.NewServer(grpcOptions...)
 
+	// register services
+	observability_proto.RegisterMonitoringAssignmentDiscoveryServiceServer(grpcServer, s.server)
+	s.metrics.RegisterGRPC(grpcServer)
+
 	lis, err := net.Listen("tcp", fmt.Sprintf(":%d", s.config.GrpcPort))
 	if err != nil {
 		return err
 	}
-
-	// register services
-	observability_proto.RegisterMonitoringAssignmentDiscoveryServiceServer(grpcServer, s.server)
-	s.metrics.RegisterGRPC(grpcServer)
 
 	errChan := make(chan error)
 	go func() {

--- a/pkg/xds/server/grpc.go
+++ b/pkg/xds/server/grpc.go
@@ -53,14 +53,14 @@ func (s *grpcServer) Start(stop <-chan struct{}) error {
 	}
 	grpcServer := grpc.NewServer(grpcOptions...)
 
+	// register services
+	envoy_discovery.RegisterAggregatedDiscoveryServiceServer(grpcServer, s.server)
+	s.metrics.RegisterGRPC(grpcServer)
+
 	lis, err := net.Listen("tcp", fmt.Sprintf(":%d", s.port))
 	if err != nil {
 		return err
 	}
-
-	// register services
-	envoy_discovery.RegisterAggregatedDiscoveryServiceServer(grpcServer, s.server)
-	s.metrics.RegisterGRPC(grpcServer)
 
 	errChan := make(chan error)
 	go func() {


### PR DESCRIPTION
### Summary

Makes sure the GRPC services are registered before the Listener is started.

### Issues resolved

Flaky SDS tests
https://app.circleci.com/pipelines/github/kumahq/kuma/4427/workflows/d996a2f4-a5b9-4dbf-8c4f-ab815afd0122/jobs/61040/parallel-runs/0/steps/0-107

