### PR TITLE
chore(build) use make param to start kube clusters for e2e tests

### DIFF
--- a/mk/check.mk
+++ b/mk/check.mk
@@ -7,7 +7,7 @@ fmt: fmt/go fmt/proto ## Dev: Run various format tools
 fmt/go: ## Dev: Run go fmt
 	go fmt $(GOFLAGS) ./...
 	@# apparently, it's not possible to simply use `go fmt ./pkg/plugins/resources/k8s/native/...`
-	make fmt -C pkg/plugins/resources/k8s/native
+	$(MAKE) fmt -C pkg/plugins/resources/k8s/native
 
 .PHONY: fmt/proto
 fmt/proto: ## Dev: Run clang-format on .proto files
@@ -17,7 +17,7 @@ fmt/proto: ## Dev: Run clang-format on .proto files
 vet: ## Dev: Run go vet
 	go vet $(GOFLAGS) ./...
 	@# for consistency with `fmt`
-	make vet -C pkg/plugins/resources/k8s/native
+	$(MAKE) vet -C pkg/plugins/resources/k8s/native
 
 .PHONY: tidy
 tidy:
@@ -47,5 +47,5 @@ imports: ## Dev: Runs goimports in order to organize imports
 
 .PHONY: check
 check: generate fmt vet docs helm-lint golangci-lint imports tidy ## Dev: Run code checks (go fmt, go vet, ...)
-	make generate manifests -C pkg/plugins/resources/k8s/native
+	$(MAKE) generate manifests -C pkg/plugins/resources/k8s/native
 	git diff --quiet || test $$(git diff --name-only | grep -v -e 'go.mod$$' -e 'go.sum$$' | wc -l) -eq 0 || ( echo "The following changes (result of code generators and code checks) have been detected:" && git --no-pager diff && false ) # fail if Git working tree is dirty

--- a/mk/e2e.new.mk
+++ b/mk/e2e.new.mk
@@ -10,20 +10,20 @@ define gen-k8sclusters
 test/e2e/kind/start/cluster/$1:
 	KIND_CLUSTER_NAME=$1 \
 	KIND_KUBECONFIG=$(KIND_KUBECONFIG_DIR)/kind-$1-config \
-		make kind/start
+		$(MAKE) kind/start
 	KIND_CLUSTER_NAME=$1 \
-		make kind/load/images
+		$(MAKE) kind/load/images
 	@kind load docker-image $(KUMA_UNIVERSAL_DOCKER_IMAGE) --name=$1
 
 .PHONY: test/e2e/kind/stop/cluster/$1
 test/e2e/kind/stop/cluster/$1:
 	KIND_CLUSTER_NAME=$1 \
 	KIND_KUBECONFIG=$(KIND_KUBECONFIG_DIR)/kind-$1-config \
-		make kind/stop
+		$(MAKE) kind/stop
 
 .PHONE: kind/load/images/$1
 kind/load/images/$1:
-	KIND_CLUSTER_NAME=$1 make kind/load/images
+	KIND_CLUSTER_NAME=$1 $(MAKE) kind/load/images
 endef
 
 $(foreach cluster, $(K8SCLUSTERS), $(eval $(call gen-k8sclusters,$(cluster))))
@@ -47,8 +47,8 @@ test/e2e/test:
 
 .PHONY: test/e2e
 test/e2e: build/kumactl images docker/build/universal test/e2e/kind/start
-	make test/e2e/test || \
+	$(MAKE) test/e2e/test || \
 	(ret=$$?; \
-	make test/e2e/kind/stop && \
+	$(MAKE) test/e2e/kind/stop && \
 	exit $$ret)
-	make test/e2e/kind/stop
+	$(MAKE) test/e2e/kind/stop

--- a/mk/kind.mk
+++ b/mk/kind.mk
@@ -117,7 +117,7 @@ kind/deploy/example-app:
 
 .PHONY: run/k8s
 run/k8s: fmt vet ## Dev: Run Control Plane locally in Kubernetes mode
-	@KUBECONFIG=$(KIND_KUBECONFIG) make crd/upgrade -C pkg/plugins/resources/k8s/native
+	@KUBECONFIG=$(KIND_KUBECONFIG) $(MAKE) crd/upgrade -C pkg/plugins/resources/k8s/native
 	KUBECONFIG=$(KIND_KUBECONFIG) \
 	KUMA_SDS_SERVER_GRPC_PORT=$(SDS_GRPC_PORT) \
 	KUMA_GRPC_PORT=$(CP_GRPC_PORT) \

--- a/mk/test.mk
+++ b/mk/test.mk
@@ -50,7 +50,7 @@ test/k8s: test/module
 
 .PHONY: test/module
 test/module:
-	GO_TEST='${GO_TEST}' GO_TEST_OPTS='${GO_TEST_OPTS}' COVERAGE_PROFILE='${COVERAGE_PROFILE}' make test -C ${MODULE}
+	GO_TEST='${GO_TEST}' GO_TEST_OPTS='${GO_TEST_OPTS}' COVERAGE_PROFILE='${COVERAGE_PROFILE}' $(MAKE) test -C ${MODULE}
 
 .PHONY: test/kuma-cp
 test/kuma-cp: PKG_LIST=./app/kuma-cp/... ./pkg/config/app/kuma-cp/...


### PR DESCRIPTION
### Summary

Use `$(MAKE)` instead of `make` so we can use `make -j test/e2e`, this way K8S clusters are run in parallel.