### PR TITLE
chore(*) add dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,20 @@
+version: 2
+updates:
+  - package-ecosystem: gomod
+    directory: /
+    schedule:
+      interval: weekly
+    labels:
+      - "dependencies"
+  - package-ecosystem: gomod
+    directory: /tools/releases/changelog
+    schedule:
+      interval: weekly
+    labels:
+      - "dependencies"
+  - package-ecosystem: docker
+    directory: /tools/releases/dockerfiles
+    schedule:
+      interval: weekly
+    labels:
+      - "dependencies"


### PR DESCRIPTION
### Summary

Adds a Dependabot config file for `go.{mod,sum}` and all the release Dockerfiles. Updates are done on a weekly basis, could also change to daily or monthly.

Follow up from: https://github.com/kumahq/kuma/pull/1060#issuecomment-706409263

See: https://docs.github.com/en/free-pro-team@latest/github/administering-a-repository/configuration-options-for-dependency-updates
