### PR TITLE
chore(kuma-cp) Ingress Dataplane on K8S can only be deployed in system namespace

### DIFF
--- a/pkg/plugins/runtime/k8s/controllers/pod_controller.go
+++ b/pkg/plugins/runtime/k8s/controllers/pod_controller.go
@@ -44,9 +44,10 @@ const (
 type PodReconciler struct {
 	kube_client.Client
 	kube_record.EventRecorder
-	Scheme       *kube_runtime.Scheme
-	Log          logr.Logger
-	PodConverter PodConverter
+	Scheme          *kube_runtime.Scheme
+	Log             logr.Logger
+	PodConverter    PodConverter
+	SystemNamespace string
 }
 
 func (r *PodReconciler) Reconcile(req kube_ctrl.Request) (kube_ctrl.Result, error) {
@@ -74,6 +75,9 @@ func (r *PodReconciler) Reconcile(req kube_ctrl.Request) (kube_ctrl.Result, erro
 		return kube_ctrl.Result{}, err
 	}
 	if exist && enabled {
+		if pod.Namespace != r.SystemNamespace {
+			return kube_ctrl.Result{}, errors.Errorf("Ingress can only be deployed in system namespace %q", r.SystemNamespace)
+		}
 		services, err := r.findMatchingServices(pod)
 		if err != nil {
 			return kube_ctrl.Result{}, err

--- a/pkg/plugins/runtime/k8s/plugin.go
+++ b/pkg/plugins/runtime/k8s/plugin.go
@@ -111,6 +111,7 @@ func addPodReconciler(mgr kube_ctrl.Manager, rt core_runtime.Runtime) error {
 			ServiceGetter: mgr.GetClient(),
 			Zone:          rt.Config().Multicluster.Remote.Zone,
 		},
+		SystemNamespace: rt.Config().Store.Kubernetes.SystemNamespace,
 	}
 	return reconciler.SetupWithManager(mgr)
 }


### PR DESCRIPTION
### Summary

Ingress should be only deployed in Kuma System namespace, otherwise anyone can deploy DP with `kuma.io/ingress: enabled` and act like an Ingress.

Users can still go and edit the Dataplane object adding ingress, but this is a broader problem. Users should not be able to touch Dataplane objects.

### Documentation

- [X] I'd say it's internal change.
