### PR TITLE
feat(kuma-cp) exclude pods that matches labels from injection

### DIFF
--- a/pkg/api-server/config_ws_test.go
+++ b/pkg/api-server/config_ws_test.go
@@ -202,7 +202,13 @@ var _ = Describe("Config WS", func() {
                   "excludeOutboundPorts": []
                 },
                 "virtualProbesEnabled": true,
-                "virtualProbesPort": 9000
+                "virtualProbesPort": 9000,
+                "exceptions": {
+                  "labels": {
+                    "openshift.io/build.name": "*",
+                    "openshift.io/deployer-pod-for.name": "*"
+                  }
+                }
               }
             },
             "universal": {

--- a/pkg/config/app/kuma-cp/kuma-cp.defaults.yaml
+++ b/pkg/config/app/kuma-cp/kuma-cp.defaults.yaml
@@ -164,6 +164,12 @@ runtime:
     injector:
       # if true runs kuma-cp in CNI compatible mode
       cniEnabled: false # ENV: KUMA_RUNTIME_KUBERNETES_INJECTOR_CNI_ENABLED
+      # list of exceptions for Kuma injection
+      exceptions:
+        # a map of labels for exception. If pod matches label with given value Kuma won't be injected. Specify '*' to match any value.
+        labels:
+          openshift.io/build.name: "*"
+          openshift.io/deployer-pod-for.name: "*"
       # VirtualProbesEnabled enables automatic converting HttpGet probes to virtual. Virtual probe
       #	serves on sub-path of insecure port 'virtualProbesPort',
       #	i.e :8080/health/readiness -> :9000/8080/health/readiness where 9000 is virtualProbesPort

--- a/pkg/config/plugins/runtime/k8s/config.go
+++ b/pkg/config/plugins/runtime/k8s/config.go
@@ -59,6 +59,13 @@ func DefaultKubernetesRuntimeConfig() *KubernetesRuntimeConfig {
 				ExcludeInboundPorts:  []uint32{},
 				ExcludeOutboundPorts: []uint32{},
 			},
+			Exceptions: Exceptions{
+				Labels: map[string]string{
+					// when using DeploymentConfig instead of Deployment, OpenShift will create an extra deployer Pod for which we don't want to inject Kuma
+					"openshift.io/build.name":            "*",
+					"openshift.io/deployer-pod-for.name": "*",
+				},
+			},
 		},
 	}
 }
@@ -99,6 +106,14 @@ type Injector struct {
 	VirtualProbesPort uint32 `yaml:"virtualProbesPort" envconfig:"kuma_runtime_kubernetes_virtual_probes_enabled"`
 	// Cnfiguration for a traffic that is intercepted by sidecar
 	SidecarTraffic SidecarTraffic `yaml:"sidecarTraffic"`
+	// Exceptions defines list of exceptions for Kuma injection
+	Exceptions Exceptions `yaml:"exceptions"`
+}
+
+// Exceptions defines list of exceptions for Kuma injection
+type Exceptions struct {
+	// Labels is a map of labels for exception. If pod matches label with given value Kuma won't be injected. Specify '*' to match any value.
+	Labels map[string]string `yaml:"labels" envconfig:"kuma_runtime_kubernetes_exceptions_labels"`
 }
 
 type SidecarTraffic struct {

--- a/pkg/config/plugins/runtime/k8s/testdata/default-config.golden.yaml
+++ b/pkg/config/plugins/runtime/k8s/testdata/default-config.golden.yaml
@@ -38,3 +38,7 @@ injector:
   sidecarTraffic:
     excludeInboundPorts: []
     excludeOutboundPorts: []
+  exceptions:
+    labels:
+      openshift.io/build.name: "*"
+      openshift.io/deployer-pod-for.name: "*"

--- a/pkg/plugins/runtime/k8s/webhooks/injector/injector_test.go
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/injector_test.go
@@ -420,5 +420,22 @@ var _ = Describe("Injector", func() {
                   kuma.io/sidecar-injection: enabled`,
 			cfgFile: "inject.config-ports.yaml",
 		}),
+		Entry("20. skip injection for label exception", testCase{
+			num: "20",
+			mesh: `
+              apiVersion: kuma.io/v1alpha1
+              kind: Mesh
+              metadata:
+                name: default
+              spec: {}`,
+			namespace: `
+              apiVersion: v1
+              kind: Namespace
+              metadata:
+                name: default
+                annotations:
+                  kuma.io/sidecar-injection: enabled`,
+			cfgFile: "inject.config.yaml",
+		}),
 	)
 })

--- a/pkg/plugins/runtime/k8s/webhooks/injector/probes.go
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/probes.go
@@ -10,7 +10,9 @@ import (
 )
 
 func (i *KumaInjector) overrideHTTPProbes(pod *kube_core.Pod) error {
+	log.WithValues("name", pod.Name, "namespace", pod.Namespace)
 	if ok, err := needVirtualProbes(pod, i.cfg); err != nil || !ok {
+		log.V(1).Info("skip adding virtual probes")
 		return err
 	}
 
@@ -21,11 +23,13 @@ func (i *KumaInjector) overrideHTTPProbes(pod *kube_core.Pod) error {
 
 	for _, c := range pod.Spec.Containers {
 		if c.LivenessProbe != nil && c.LivenessProbe.HTTPGet != nil {
+			log.V(1).Info("overriding liveness probe", "container", c.Name)
 			if err := overrideHTTPProbe(c.LivenessProbe, port); err != nil {
 				return err
 			}
 		}
 		if c.ReadinessProbe != nil && c.ReadinessProbe.HTTPGet != nil {
+			log.V(1).Info("overriding readiness probe", "container", c.Name)
 			if err := overrideHTTPProbe(c.ReadinessProbe, port); err != nil {
 				return err
 			}

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.20.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.20.golden.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  creationTimestamp: null
+  labels:
+    run: busybox
+    openshift.io/deployer-pod-for.name: "1234"
+  name: busybox
+spec:
+  containers:
+  - image: busybox
+    name: busybox
+    resources: {}
+    volumeMounts:
+    - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+      name: default-token-w7dxf
+      readOnly: true
+  volumes:
+  - name: default-token-w7dxf
+    secret:
+      secretName: default-token-w7dxf
+status: {}

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.20.input.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.20.input.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: busybox
+  labels:
+    run: busybox
+    openshift.io/deployer-pod-for.name: "1234"
+spec:
+  volumes:
+  - name: default-token-w7dxf
+    secret:
+      secretName: default-token-w7dxf
+  containers:
+  - name: busybox
+    image: busybox
+    resources: {}
+    volumeMounts:
+    - name: default-token-w7dxf
+      readOnly: true
+      mountPath: "/var/run/secrets/kubernetes.io/serviceaccount"

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.config.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.config.yaml
@@ -33,3 +33,6 @@ initContainer:
   image: kuma/kuma-init:latest
 virtualProbesEnabled: true
 virtualProbesPort: 9000
+exceptions:
+  labels:
+    "openshift.io/deployer-pod-for.name": "*"


### PR DESCRIPTION
### Summary

This PR introduces the capability to exclude individual pods from injection that match the given list of tags.

Use case:
On OpenShift when you use DeploymentConfig instead of Deployment, there is an additional Pod that does not match any Service, which is a requirement for Kuma. Now by default, we are excluding OpenShift Deployer Pods from Kuma injection.

Also, I added more logging to the injector

### Documentation

- [ ] Documented in config. We may need a separate site in docs for sidecar injection.
