### PR TITLE
chore(ci) skip master workflow for release commits

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,6 +27,8 @@ reusable:
       filters:
         branches:
           only: master
+        tags:
+          ignore: /.*/ # we don't want to run master worklow on commits with tag because use_local_kuma_images has to be false for all the jobs to pass
 
     # filters for the kuma-commit workflow
     commit_workflow_filters: &commit_workflow_filters


### PR DESCRIPTION
Master workflow should not run on tags because it always fails.