### PR TITLE
[DO NOT MERGE] feat(*) enable TPROXY

### DIFF
--- a/pkg/config/plugins/runtime/k8s/config.go
+++ b/pkg/config/plugins/runtime/k8s/config.go
@@ -23,8 +23,8 @@ func DefaultKubernetesRuntimeConfig() *KubernetesRuntimeConfig {
 				Image:                "kuma/kuma-dp:latest",
 				RedirectPortInbound:  15006,
 				RedirectPortOutbound: 15001,
-				UID:                  5678,
-				GID:                  5678,
+				UID:                  0,
+				GID:                  0,
 				AdminPort:            9901,
 				DrainTime:            30 * time.Second,
 

--- a/pkg/plugins/runtime/k8s/webhooks/injector/injector.go
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/injector.go
@@ -263,6 +263,11 @@ func (i *KumaInjector) NewSidecarContainer(pod *kube_core.Pod, ns *kube_core.Nam
 		SecurityContext: &kube_core.SecurityContext{
 			RunAsUser:  &i.cfg.SidecarContainer.UID,
 			RunAsGroup: &i.cfg.SidecarContainer.GID,
+			Capabilities: &kube_core.Capabilities{
+				Add: []kube_core.Capability{
+					kube_core.Capability("NET_ADMIN"),
+				},
+			},
 		},
 		LivenessProbe: &kube_core.Probe{
 			Handler: kube_core.Handler{
@@ -365,7 +370,7 @@ func (i *KumaInjector) NewInitContainer(pod *kube_core.Pod) (kube_core.Container
 			"-o",
 			excludeOutboundPorts,
 			"-m",
-			"REDIRECT",
+			"TPROXY",
 			"-i",
 			"*",
 			"-b",

--- a/tools/releases/dockerfiles/Dockerfile.kuma-dp
+++ b/tools/releases/dockerfiles/Dockerfile.kuma-dp
@@ -8,6 +8,9 @@ COPY $KUMA_ROOT/tools/releases/templates/LICENSE /kuma
 COPY $KUMA_ROOT/tools/releases/templates/NOTICE /kuma
 COPY $KUMA_ROOT/tools/releases/templates/README /kuma
 
-USER nobody:nobody
+RUN echo kuma-dp:x:31337: >> /etc/group
+RUN echo kuma-dp:x:31337:31337:kuma-dp:/nonexistent:/sbin/nologin >> /etc/passwd
+
+USER root:root
 
 ENTRYPOINT ["kuma-dp"]

--- a/tools/releases/dockerfiles/Dockerfile.kuma-init
+++ b/tools/releases/dockerfiles/Dockerfile.kuma-init
@@ -14,12 +14,12 @@ RUN cd /opt && wget https://storage.googleapis.com/golang/go${GOVERSION}.linux-a
 
 RUN GO111MODULE=on go get istio.io/istio/tools/istio-iptables@1.6.5
 
-FROM ubuntu:bionic
+FROM ubuntu:focal
 
 COPY --from=builder /root/.go/bin/istio-iptables ./kuma-iptables
 
 RUN apt-get update
-RUN apt-get -y install iptables
+RUN apt-get -y install iptables iproute2
 
 RUN mkdir /kuma
 COPY $KUMA_ROOT/tools/releases/templates/LICENSE /kuma


### PR DESCRIPTION
For reference only!!!

### Summary

Sharing an attempt to enable TPROXY. Notes:

In this mode the side-car needs more privileges in order to be able to set the proper socket options.

The changes to our infrastructure her are not sufficient, as the following log shows:

```
│ kuma-sidecar outbound:240.0.0.0:80: cannot bind '240.0.0.0:80': Address already in use                                                                         │
│ kuma-sidecar outbound:240.0.0.1:80: cannot bind '240.0.0.1:80': Address already in use                                                                         │
│ kuma-sidecar inbound:10.244.0.6:80: cannot bind '10.244.0.6:80': Address already in use
```
