### PR TITLE
chore(*) bump go 1.15.5

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,11 +3,11 @@ version: 2.1 # Adds support for executors, parameterized jobs, etc
 reusable:
 
   constants:
-  - &go_version "1.15.2"
+  - &go_version "1.15.5"
 
   docker_images:
-  - &golang_image "golang:1.15.2"
-  - &circleci_golang_image "circleci/golang:1.15.2"
+  - &golang_image "golang:1.15.5"
+  - &circleci_golang_image "circleci/golang:1.15.5"
 
   vm_images:
   - &ubuntu_vm_image "ubuntu-1604:202007-01"

--- a/mk/dev.mk
+++ b/mk/dev.mk
@@ -7,7 +7,7 @@ GINKGO_VERSION := v1.12.0
 CI_KUBEBUILDER_VERSION ?= 2.3.1
 CI_MINIKUBE_VERSION ?= v1.13.1
 CI_KUBECTL_VERSION ?= v1.18.9
-CI_TOOLS_IMAGE ?= circleci/golang:1.15.2
+CI_TOOLS_IMAGE ?= circleci/golang:1.15.5
 
 CI_TOOLS_DIR ?= $(HOME)/bin
 GOPATH_DIR := $(shell go env GOPATH | awk -F: '{print $$1}')

--- a/pkg/plugins/resources/k8s/native/Dockerfile
+++ b/pkg/plugins/resources/k8s/native/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.15.2 as builder
+FROM golang:1.15.5 as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/tools/releases/dockerfiles/Dockerfile.kuma-init
+++ b/tools/releases/dockerfiles/Dockerfile.kuma-init
@@ -1,6 +1,6 @@
 FROM ubuntu:bionic as builder
 
-ENV GOVERSION 1.15.2
+ENV GOVERSION 1.15.5
 ENV GOROOT /opt/go
 ENV GOPATH /root/.go
 


### PR DESCRIPTION
### Summary

Upgrading go 1.15.2 -> 1.15.5

[Changelog 1.15.3](https://github.com/golang/go/issues?q=milestone%3AGo1.15.3+label%3ACherryPickApproved)
[Changelog 1.15.4](https://github.com/golang/go/issues?q=milestone%3AGo1.15.4+label%3ACherryPickApproved)
[Changelog 1.15.5](https://github.com/golang/go/issues?q=milestone%3AGo1.15.5+label%3ACherryPickApproved)