### PR TITLE
chore(kuma-cp) drop default sufix on the default traffic permission

### DIFF
--- a/pkg/core/managers/apis/mesh/mesh_manager_test.go
+++ b/pkg/core/managers/apis/mesh/mesh_manager_test.go
@@ -99,7 +99,7 @@ var _ = Describe("Mesh Manager", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			// and default TrafficPermission for the mesh exists
-			err = resStore.Get(context.Background(), &core_mesh.TrafficPermissionResource{}, store.GetByKey("allow-all-mesh-1.default", meshName))
+			err = resStore.Get(context.Background(), &core_mesh.TrafficPermissionResource{}, store.GetByKey("allow-all-mesh-1", meshName))
 			Expect(err).ToNot(HaveOccurred())
 		})
 

--- a/pkg/defaults/mesh/traffic_permission.go
+++ b/pkg/defaults/mesh/traffic_permission.go
@@ -27,11 +27,9 @@ var defaultTrafficPermission = mesh_proto.TrafficPermission{
 	},
 }
 
-// Default traffic permission needs to be stored with default suffix so on K8S it will be stored in the default namespace
-// This will be dropped when TrafficPermission will be converted to Global Scope on K8S instead of Namespace Scope
 // TrafficPermission needs to contain mesh name inside it. Otherwise if the name is the same (ex. "allow-all") creating new mesh would fail because there is already resource of name "allow-all" which is unique key on K8S
 func defaultTrafficPermissionName(meshName string) string {
-	return fmt.Sprintf("allow-all-%s.default", meshName)
+	return fmt.Sprintf("allow-all-%s", meshName)
 }
 
 func createDefaultTrafficPermission(resManager manager.ResourceManager, meshName string) error {

--- a/test/e2e/kuma_deploy_hybrid_test.go
+++ b/test/e2e/kuma_deploy_hybrid_test.go
@@ -240,7 +240,7 @@ metadata:
 			return stdout, err
 		}, "10s", "1s").Should(ContainSubstring("HTTP/1.1 200 OK"))
 
-		err := global.GetKumactlOptions().KumactlDelete("traffic-permission", "allow-all-default.default") // remove builtin traffic permission
+		err := global.GetKumactlOptions().KumactlDelete("traffic-permission", "allow-all-default") // remove builtin traffic permission
 		Expect(err).ToNot(HaveOccurred())
 
 		err = YamlUniversal(trafficPermissionAllTo2Remote)(global)


### PR DESCRIPTION
### Summary

We changed the scope of Traffic Permissions on K8S to Cluster, so we can drop the prefix.

### Documentation

- [ ] None
