### PR TITLE
chore(ci) debug e2e test for quicker feedback loop

### DIFF
--- a/mk/e2e.new.mk
+++ b/mk/e2e.new.mk
@@ -45,6 +45,19 @@ test/e2e/test:
 	KUMACTLBIN=${BUILD_ARTIFACTS_DIR}/kumactl/kumactl \
 		$(GO_TEST) -v -timeout=45m ./test/e2e/...
 
+# test/e2e/debug is used for quicker feedback of E2E tests (ex. debugging flaky tests)
+# It runs tests with fail fast which means you don't have to wait for all tests to get information that something failed
+# Clusters are deleted only if all tests passes, otherwise clusters are live and running current test deployment
+# GINKGO_EDITOR_INTEGRATION is required to work with focused test. Normally they exit with non 0 code which prevents clusters to be cleaned up.
+# We run ginkgo instead of "go test" to fail fast (builtin "go test" fail fast does not seem to work with individual ginkgo tests)
+.PHONY: test/e2e/debug
+test/e2e/debug: build/kumactl images docker/build/universal test/e2e/kind/start
+	K8SCLUSTERS="$(K8SCLUSTERS)" \
+	KUMACTLBIN=${BUILD_ARTIFACTS_DIR}/kumactl/kumactl \
+	GINKGO_EDITOR_INTEGRATION=true \
+		ginkgo --failFast ./test/e2e/...
+	$(MAKE) test/e2e/kind/stop
+
 .PHONY: test/e2e
 test/e2e: build/kumactl images docker/build/universal test/e2e/kind/start
 	$(MAKE) test/e2e/test || \

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -3,6 +3,8 @@ package e2e_test
 import (
 	"testing"
 
+	ginkgo_config "github.com/onsi/ginkgo/config"
+
 	"github.com/kumahq/kuma/test/framework"
 
 	"github.com/go-logr/logr"
@@ -28,3 +30,7 @@ var _ = BeforeSuite(func() {
 	core.SetLogger = func(l logr.Logger) {}
 	logf.SetLogger(zap.LoggerTo(GinkgoWriter, true))
 })
+
+func ShouldSkipCleanup() bool {
+	return CurrentGinkgoTestDescription().Failed && ginkgo_config.GinkgoConfig.FailFast
+}

--- a/test/e2e/externalservices_kubernetes_test.go
+++ b/test/e2e/externalservices_kubernetes_test.go
@@ -148,6 +148,9 @@ metadata:
 	})
 
 	AfterEach(func() {
+		if ShouldSkipCleanup() {
+			return
+		}
 		err := cluster.DeleteKuma(deployOptsFuncs...)
 		Expect(err).ToNot(HaveOccurred())
 

--- a/test/e2e/externalservices_universal_test.go
+++ b/test/e2e/externalservices_universal_test.go
@@ -104,6 +104,9 @@ networking:
 	})
 
 	AfterEach(func() {
+		if ShouldSkipCleanup() {
+			return
+		}
 		err := cluster.DeleteKuma(deployOptsFuncs...)
 		Expect(err).ToNot(HaveOccurred())
 

--- a/test/e2e/kuma_deploy_global_remote_test.go
+++ b/test/e2e/kuma_deploy_global_remote_test.go
@@ -99,6 +99,10 @@ metadata:
 	})
 
 	AfterEach(func() {
+		if ShouldSkipCleanup() {
+			return
+		}
+
 		defer func() {
 			// restore the original namespace
 			KumaNamespace = originalKumaNamespace

--- a/test/e2e/kuma_deploy_hybrid_kube_global_test.go
+++ b/test/e2e/kuma_deploy_hybrid_kube_global_test.go
@@ -1,4 +1,4 @@
-package e2e
+package e2e_test
 
 import (
 	"strings"
@@ -65,6 +65,9 @@ var _ = Describe("Test Kubernetes/Universal deployment when Global is on K8S", f
 	})
 
 	AfterEach(func() {
+		if ShouldSkipCleanup() {
+			return
+		}
 		err := globalCluster.DeleteKuma(optsGlobal...)
 		Expect(err).ToNot(HaveOccurred())
 		err = globalCluster.DismissCluster()

--- a/test/e2e/kuma_deploy_hybrid_test.go
+++ b/test/e2e/kuma_deploy_hybrid_test.go
@@ -155,6 +155,9 @@ metadata:
 	})
 
 	AfterEach(func() {
+		if ShouldSkipCleanup() {
+			return
+		}
 		_ = k8s.KubectlDeleteFromStringE(remote_1.GetTesting(), remote_1.GetKubectlOptions(), namespaceWithSidecarInjection(TestNamespace))
 		err := remote_1.DeleteKuma(optsRemote1...)
 		Expect(err).ToNot(HaveOccurred())

--- a/test/e2e/kuma_deploy_universal_test.go
+++ b/test/e2e/kuma_deploy_universal_test.go
@@ -95,6 +95,9 @@ routing:
 	})
 
 	AfterEach(func() {
+		if ShouldSkipCleanup() {
+			return
+		}
 		err := remote_1.DeleteKuma(optsRemote1...)
 		Expect(err).ToNot(HaveOccurred())
 		err = remote_2.DeleteKuma(optsRemote2...)

--- a/test/e2e/kuma_helm_deploy_global_remote_test.go
+++ b/test/e2e/kuma_helm_deploy_global_remote_test.go
@@ -111,6 +111,9 @@ metadata:
 	})
 
 	AfterEach(func() {
+		if ShouldSkipCleanup() {
+			return
+		}
 		// tear down apps
 		Expect(c2.DeleteNamespace(TestNamespace)).To(Succeed())
 		// tear down Kuma

--- a/test/e2e/kuma_helm_deploy_multi_apps_test.go
+++ b/test/e2e/kuma_helm_deploy_multi_apps_test.go
@@ -66,6 +66,9 @@ metadata:
 	})
 
 	AfterEach(func() {
+		if ShouldSkipCleanup() {
+			return
+		}
 		// tear down apps
 		Expect(cluster.DeleteNamespace(TestNamespace)).To(Succeed())
 		// tear down Kuma

--- a/test/e2e/tracing_kubernetes_test.go
+++ b/test/e2e/tracing_kubernetes_test.go
@@ -80,6 +80,9 @@ spec:
 	})
 
 	AfterEach(func() {
+		if ShouldSkipCleanup() {
+			return
+		}
 		Expect(cluster.DeleteKuma(deployOptsFuncs...)).To(Succeed())
 		Expect(k8s.KubectlDeleteFromStringE(cluster.GetTesting(), cluster.GetKubectlOptions(), namespaceWithSidecarInjection(TestNamespace))).To(Succeed())
 		Expect(cluster.DismissCluster()).To(Succeed())

--- a/test/e2e/tracing_universal_test.go
+++ b/test/e2e/tracing_universal_test.go
@@ -66,6 +66,9 @@ selectors:
 	})
 
 	AfterEach(func() {
+		if ShouldSkipCleanup() {
+			return
+		}
 		Expect(cluster.DeleteKuma(deployOptsFuncs...)).To(Succeed())
 		Expect(cluster.DismissCluster()).To(Succeed())
 	})


### PR DESCRIPTION
### Summary

When I'm developing and want to check if my code passes E2E I want to receive feedback as quickly as possible (exit after first failed test)
Additionally, if something is wrong, I don't want clusters to be gone, but I want to inspect them and current test deployment.

### Documentation

- [X] Internal tests
