### PR TITLE
fix(kuma-cp) read-only endpoints for insights

### DIFF
--- a/pkg/api-server/definitions/all.go
+++ b/pkg/api-server/definitions/all.go
@@ -4,7 +4,6 @@ var All = []ResourceWsDefinition{
 	MeshWsDefinition,
 	MeshInsightWsDefinition,
 	DataplaneWsDefinition,
-	DataplaneInsightWsDefinition,
 	ExternalServiceWsDefinition,
 	HealthCheckWsDefinition,
 	ProxyTemplateWsDefinition,
@@ -15,6 +14,5 @@ var All = []ResourceWsDefinition{
 	FaultInjectionWsDefinition,
 	CircuitBreakerWsDefinition,
 	ZoneWsDefinition,
-	ZoneInsightWsDefinition,
 	SecretWsDefinition,
 }

--- a/pkg/api-server/definitions/mesh_insight.go
+++ b/pkg/api-server/definitions/mesh_insight.go
@@ -6,8 +6,9 @@ import (
 )
 
 var MeshInsightWsDefinition = ResourceWsDefinition{
-	Name: "Mesh Insight",
-	Path: "mesh-insights",
+	Name:     "Mesh Insight",
+	Path:     "mesh-insights",
+	ReadOnly: true,
 	ResourceFactory: func() model.Resource {
 		return &mesh.MeshInsightResource{}
 	},

--- a/pkg/api-server/resource_endpoints.go
+++ b/pkg/api-server/resource_endpoints.go
@@ -25,7 +25,8 @@ const (
 	k8sReadOnlyMessage = "On Kubernetes you cannot change the state of Kuma resources with 'kumactl apply' or via the HTTP API." +
 		" As a best practice, you should always be using 'kubectl apply' instead." +
 		" You can still use 'kumactl' or the HTTP API to make read-only operations. On Universal this limitation does not apply.\n"
-	globalReadOnlyMessage = "On global control plane you can not modify dataplane resources with 'kumactl apply' or via the HTTP API." +
+	universalReadOnlyMessage = "On Universal you cannot change the state of Insight resources, they are managed and updated only by Kuma Control Plane.\n"
+	globalReadOnlyMessage    = "On global control plane you can not modify dataplane resources with 'kumactl apply' or via the HTTP API." +
 		" You can still use 'kumactl' or the HTTP API to modify them on the remote control plane.\n"
 	remoteReadOnlyMessage = "On remote control plane you can only modify dataplane resources with 'kumactl apply' or via the HTTP API." +
 		" You can still use 'kumactl' or the HTTP API to modify the rest of the resource on the global control plane.\n"
@@ -33,6 +34,7 @@ const (
 
 type resourceEndpoints struct {
 	mode       config_core.CpMode
+	env        config_core.EnvironmentType
 	resManager manager.ResourceManager
 	definitions.ResourceWsDefinition
 	adminAuth authz.AdminAuth
@@ -233,6 +235,10 @@ func (r *resourceEndpoints) readOnlyMessage() string {
 		return globalReadOnlyMessage
 	case config_core.Remote:
 		return remoteReadOnlyMessage
+	}
+	switch r.env {
+	case config_core.UniversalEnvironment:
+		return universalReadOnlyMessage
 	default:
 		return k8sReadOnlyMessage
 	}

--- a/pkg/api-server/server.go
+++ b/pkg/api-server/server.go
@@ -159,6 +159,7 @@ func addResourcesEndpoints(ws *restful.WebService, defs []definitions.ResourceWs
 		}
 		endpoints := resourceEndpoints{
 			mode:                 cfg.Mode,
+			env:                  cfg.Environment,
 			resManager:           resManager,
 			ResourceWsDefinition: definition,
 			adminAuth: authz.AdminAuth{


### PR DESCRIPTION
Signed-off-by: Ilya Lobkov <ilya.lobkov@konghq.com>

### Summary

Some of the endpoints related to insights are not ReadOnly in practice.
