### PR TITLE
test(e2e) add env to deployment options

### DIFF
--- a/test/framework/interface.go
+++ b/test/framework/interface.go
@@ -24,6 +24,7 @@ type deployOptions struct {
 	helmReleaseName  string
 	helmOpts         map[string]string
 	ctlOpts          map[string]string
+	env              map[string]string
 	ingress          bool
 	cni              bool
 
@@ -60,6 +61,15 @@ func WithHelmOpt(name, value string) DeployOptionsFunc {
 			o.helmOpts = map[string]string{}
 		}
 		o.helmOpts[name] = value
+	}
+}
+
+func WithEnv(name, value string) DeployOptionsFunc {
+	return func(o *deployOptions) {
+		if o.env == nil {
+			o.env = map[string]string{}
+		}
+		o.env[name] = value
 	}
 }
 

--- a/test/framework/universal_cluster.go
+++ b/test/framework/universal_cluster.go
@@ -61,6 +61,9 @@ func (c *UniversalCluster) DeployKuma(mode string, fs ...DeployOptionsFunc) erro
 
 	cmd := []string{"kuma-cp", "run"}
 	env := []string{"KUMA_MODE=" + mode}
+	for k, v := range opts.env {
+		env = append(env, fmt.Sprintf("%s=%s", k, v))
+	}
 	if opts.globalAddress != "" {
 		env = append(env, "KUMA_MULTIZONE_REMOTE_GLOBAL_ADDRESS="+opts.globalAddress)
 	}


### PR DESCRIPTION
### Summary

In e2e, add Environment setting option used in kuma-cp universal deployment