### PR TITLE
fix(kuma-cp) create default mesh resources when default mesh is skipped

### DIFF
--- a/pkg/core/managers/apis/mesh/mesh_manager.go
+++ b/pkg/core/managers/apis/mesh/mesh_manager.go
@@ -80,7 +80,7 @@ func (m *meshManager) Create(ctx context.Context, resource core_model.Resource, 
 	if err := m.store.Create(ctx, mesh, append(fs, core_store.CreatedAt(time.Now()))...); err != nil {
 		return err
 	}
-	if err := defaults_mesh.CreateDefaultMeshResources(m.otherManagers, opts.Name); err != nil {
+	if err := defaults_mesh.EnsureDefaultMeshResources(m.otherManagers, opts.Name); err != nil {
 		return err
 	}
 	return nil

--- a/pkg/defaults/mesh/mesh.go
+++ b/pkg/defaults/mesh/mesh.go
@@ -33,7 +33,7 @@ func EnsureDefaultMeshResources(resManager manager.ResourceManager, meshName str
 		log.Info("default TrafficRoute already exist", "mesh", meshName, "name", defaultTrafficRouteKey(meshName).Name)
 	}
 
-	err, created = ensureSigningKey(resManager, meshName)
+	created, err = ensureSigningKey(resManager, meshName)
 	if err != nil {
 		return errors.Wrap(err, "could not create default Signing Key")
 	}

--- a/pkg/defaults/mesh/mesh.go
+++ b/pkg/defaults/mesh/mesh.go
@@ -5,23 +5,42 @@ import (
 
 	"github.com/kumahq/kuma/pkg/core"
 	"github.com/kumahq/kuma/pkg/core/resources/manager"
+	"github.com/kumahq/kuma/pkg/tokens/builtin/issuer"
 )
 
 var log = core.Log.WithName("defaults").WithName("mesh")
 
-func CreateDefaultMeshResources(resManager manager.ResourceManager, meshName string) error {
-	log.Info("creating default resources for mesh", "mesh", meshName)
-	if err := createDefaultTrafficPermission(resManager, meshName); err != nil {
-		return errors.Wrap(err, "could not create default traffic permission")
+func EnsureDefaultMeshResources(resManager manager.ResourceManager, meshName string) error {
+	log.Info("ensuring default resources for Mesh exist", "mesh", meshName)
+
+	err, created := ensureDefaultTrafficPermission(resManager, meshName)
+	if err != nil {
+		return errors.Wrap(err, "could not create default TrafficPermission")
 	}
-	if err := createDefaultTrafficRoute(resManager, meshName); err != nil {
-		return errors.Wrap(err, "could not create default traffic permission")
+	if created {
+		log.Info("default TrafficPermission created", "mesh", meshName, "name", defaultTrafficPermissionKey(meshName).Name)
+	} else {
+		log.Info("default TrafficPermission already exist", "mesh", meshName, "name", defaultTrafficPermissionKey(meshName).Name)
 	}
-	log.Info("default TrafficPermission created", "mesh", meshName, "name", defaultTrafficPermissionName(meshName))
-	log.Info("creating Signing Key for mesh", "mesh", meshName)
-	if err := createSigningKey(resManager, meshName); err != nil {
-		return errors.Wrap(err, "could not create default signing key")
+
+	err, created = ensureDefaultTrafficRoute(resManager, meshName)
+	if err != nil {
+		return errors.Wrap(err, "could not create default TrafficRoute")
 	}
-	log.Info("Signing Key created", "mesh", meshName)
+	if created {
+		log.Info("default TrafficRoute created", "mesh", meshName, "name", defaultTrafficRouteKey(meshName).Name)
+	} else {
+		log.Info("default TrafficRoute already exist", "mesh", meshName, "name", defaultTrafficRouteKey(meshName).Name)
+	}
+
+	err, created = ensureSigningKey(resManager, meshName)
+	if err != nil {
+		return errors.Wrap(err, "could not create default Signing Key")
+	}
+	if created {
+		log.Info("default Signing Key created", "mesh", meshName, "name", issuer.SigningKeyResourceKey(meshName).Name)
+	} else {
+		log.Info("default Signing Key already exist", "mesh", meshName, "name", issuer.SigningKeyResourceKey(meshName).Name)
+	}
 	return nil
 }

--- a/pkg/defaults/mesh/mesh_suite_test.go
+++ b/pkg/defaults/mesh/mesh_suite_test.go
@@ -1,0 +1,13 @@
+package mesh_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestMesh(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Defaults Mesh")
+}

--- a/pkg/defaults/mesh/mesh_test.go
+++ b/pkg/defaults/mesh/mesh_test.go
@@ -33,7 +33,7 @@ var _ = Describe("EnsureDefaultMeshResources", func() {
 		err := mesh.EnsureDefaultMeshResources(resManager, model.DefaultMesh)
 		Expect(err).ToNot(HaveOccurred())
 
-		// then
+		// then default TrafficPermission for the mesh exist
 		err = resManager.Get(context.Background(), &core_mesh.TrafficPermissionResource{}, core_store.GetByKey("allow-all-default", model.DefaultMesh))
 		Expect(err).ToNot(HaveOccurred())
 
@@ -55,6 +55,14 @@ var _ = Describe("EnsureDefaultMeshResources", func() {
 		err = mesh.EnsureDefaultMeshResources(resManager, model.DefaultMesh)
 
 		// then
+		Expect(err).ToNot(HaveOccurred())
+
+		// and all resources are in place
+		err = resManager.Get(context.Background(), &core_mesh.TrafficPermissionResource{}, core_store.GetByKey("allow-all-default", model.DefaultMesh))
+		Expect(err).ToNot(HaveOccurred())
+		err = resManager.Get(context.Background(), &core_mesh.TrafficRouteResource{}, core_store.GetByKey("route-all-default", model.DefaultMesh))
+		Expect(err).ToNot(HaveOccurred())
+		err = resManager.Get(context.Background(), &system.SecretResource{}, core_store.GetBy(issuer.SigningKeyResourceKey(model.DefaultMesh)))
 		Expect(err).ToNot(HaveOccurred())
 	})
 })

--- a/pkg/defaults/mesh/mesh_test.go
+++ b/pkg/defaults/mesh/mesh_test.go
@@ -1,0 +1,60 @@
+package mesh_test
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
+	"github.com/kumahq/kuma/pkg/core/resources/apis/system"
+	"github.com/kumahq/kuma/pkg/core/resources/manager"
+	"github.com/kumahq/kuma/pkg/core/resources/model"
+	core_store "github.com/kumahq/kuma/pkg/core/resources/store"
+	"github.com/kumahq/kuma/pkg/defaults/mesh"
+	"github.com/kumahq/kuma/pkg/plugins/resources/memory"
+	"github.com/kumahq/kuma/pkg/tokens/builtin/issuer"
+)
+
+var _ = Describe("EnsureDefaultMeshResources", func() {
+
+	var resManager manager.ResourceManager
+
+	BeforeEach(func() {
+		store := memory.NewStore()
+		resManager = manager.NewResourceManager(store)
+
+		err := resManager.Create(context.Background(), &core_mesh.MeshResource{}, core_store.CreateByKey(model.DefaultMesh, model.NoMesh))
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	It("should create default resources", func() {
+		// when
+		err := mesh.EnsureDefaultMeshResources(resManager, model.DefaultMesh)
+		Expect(err).ToNot(HaveOccurred())
+
+		// then
+		err = resManager.Get(context.Background(), &core_mesh.TrafficPermissionResource{}, core_store.GetByKey("allow-all-default", model.DefaultMesh))
+		Expect(err).ToNot(HaveOccurred())
+
+		// and default TrafficRoute for the mesh exists
+		err = resManager.Get(context.Background(), &core_mesh.TrafficRouteResource{}, core_store.GetByKey("route-all-default", model.DefaultMesh))
+		Expect(err).ToNot(HaveOccurred())
+
+		// and Signing Key for the mesh exists
+		err = resManager.Get(context.Background(), &system.SecretResource{}, core_store.GetBy(issuer.SigningKeyResourceKey(model.DefaultMesh)))
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	It("should ignore subsequent calls to EnsureDefaultMeshResources", func() {
+		// given already ensured default resources
+		err := mesh.EnsureDefaultMeshResources(resManager, model.DefaultMesh)
+		Expect(err).ToNot(HaveOccurred())
+
+		// when ensuring again
+		err = mesh.EnsureDefaultMeshResources(resManager, model.DefaultMesh)
+
+		// then
+		Expect(err).ToNot(HaveOccurred())
+	})
+})

--- a/pkg/defaults/mesh/signing_key.go
+++ b/pkg/defaults/mesh/signing_key.go
@@ -3,18 +3,28 @@ package mesh
 import (
 	"context"
 
+	"github.com/pkg/errors"
+
 	"github.com/kumahq/kuma/pkg/core/resources/manager"
 	core_store "github.com/kumahq/kuma/pkg/core/resources/store"
 	"github.com/kumahq/kuma/pkg/tokens/builtin/issuer"
 )
 
-func createSigningKey(resManager manager.ResourceManager, meshName string) error {
-	key, err := issuer.CreateSigningKey()
+func ensureSigningKey(resManager manager.ResourceManager, meshName string) (err error, created bool) {
+	signingKey, err := issuer.CreateSigningKey()
 	if err != nil {
-		return err
+		return errors.Wrap(err, "could not create a signing key"), false
 	}
-	if err := resManager.Create(context.Background(), &key, core_store.CreateBy(issuer.SigningKeyResourceKey(meshName))); err != nil {
-		return err
+	key := issuer.SigningKeyResourceKey(meshName)
+	err = resManager.Get(context.Background(), &signingKey, core_store.GetBy(key))
+	if err == nil {
+		return nil, false
 	}
-	return nil
+	if !core_store.IsResourceNotFound(err) {
+		return errors.Wrap(err, "could not retrieve a resource"), false
+	}
+	if err := resManager.Create(context.Background(), &signingKey, core_store.CreateBy(key)); err != nil {
+		return errors.Wrap(err, "could not create a resource"), false
+	}
+	return nil, true
 }

--- a/pkg/defaults/mesh/signing_key.go
+++ b/pkg/defaults/mesh/signing_key.go
@@ -10,21 +10,21 @@ import (
 	"github.com/kumahq/kuma/pkg/tokens/builtin/issuer"
 )
 
-func ensureSigningKey(resManager manager.ResourceManager, meshName string) (err error, created bool) {
+func ensureSigningKey(resManager manager.ResourceManager, meshName string) (created bool, err error) {
 	signingKey, err := issuer.CreateSigningKey()
 	if err != nil {
-		return errors.Wrap(err, "could not create a signing key"), false
+		return false, errors.Wrap(err, "could not create a signing key")
 	}
 	key := issuer.SigningKeyResourceKey(meshName)
 	err = resManager.Get(context.Background(), &signingKey, core_store.GetBy(key))
 	if err == nil {
-		return nil, false
+		return false, nil
 	}
 	if !core_store.IsResourceNotFound(err) {
-		return errors.Wrap(err, "could not retrieve a resource"), false
+		return false, errors.Wrap(err, "could not retrieve a resource")
 	}
 	if err := resManager.Create(context.Background(), &signingKey, core_store.CreateBy(key)); err != nil {
-		return errors.Wrap(err, "could not create a resource"), false
+		return false, errors.Wrap(err, "could not create a resource")
 	}
-	return nil, true
+	return true, nil
 }

--- a/pkg/defaults/mesh/traffic_permission.go
+++ b/pkg/defaults/mesh/traffic_permission.go
@@ -4,9 +4,12 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/pkg/errors"
+
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	"github.com/kumahq/kuma/pkg/core/resources/manager"
+	"github.com/kumahq/kuma/pkg/core/resources/model"
 	"github.com/kumahq/kuma/pkg/core/resources/store"
 )
 
@@ -28,13 +31,27 @@ var defaultTrafficPermission = mesh_proto.TrafficPermission{
 }
 
 // TrafficPermission needs to contain mesh name inside it. Otherwise if the name is the same (ex. "allow-all") creating new mesh would fail because there is already resource of name "allow-all" which is unique key on K8S
-func defaultTrafficPermissionName(meshName string) string {
-	return fmt.Sprintf("allow-all-%s", meshName)
+func defaultTrafficPermissionKey(meshName string) model.ResourceKey {
+	return model.ResourceKey{
+		Mesh: meshName,
+		Name: fmt.Sprintf("allow-all-%s", meshName),
+	}
 }
 
-func createDefaultTrafficPermission(resManager manager.ResourceManager, meshName string) error {
+func ensureDefaultTrafficPermission(resManager manager.ResourceManager, meshName string) (err error, created bool) {
+	key := defaultTrafficPermissionKey(meshName)
 	tp := &core_mesh.TrafficPermissionResource{
 		Spec: defaultTrafficPermission,
 	}
-	return resManager.Create(context.Background(), tp, store.CreateByKey(defaultTrafficPermissionName(meshName), meshName))
+	err = resManager.Get(context.Background(), tp, store.GetBy(key))
+	if err == nil {
+		return nil, false
+	}
+	if !store.IsResourceNotFound(err) {
+		return errors.Wrap(err, "could not retrieve a resource"), false
+	}
+	if err := resManager.Create(context.Background(), tp, store.CreateBy(key)); err != nil {
+		return errors.Wrap(err, "could not create a resource"), false
+	}
+	return nil, true
 }

--- a/pkg/defaults/mesh/traffic_route.go
+++ b/pkg/defaults/mesh/traffic_route.go
@@ -4,7 +4,10 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/pkg/errors"
+
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
+	"github.com/kumahq/kuma/pkg/core/resources/model"
 
 	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	"github.com/kumahq/kuma/pkg/core/resources/manager"
@@ -29,13 +32,27 @@ var (
 )
 
 // TrafficRoute needs to contain mesh name inside it. Otherwise if the name is the same (ex. "allow-all") creating new mesh would fail because there is already resource of name "allow-all" which is unique key on K8S
-func defaultTrafficRouteName(meshName string) string {
-	return fmt.Sprintf("route-all-%s", meshName)
+func defaultTrafficRouteKey(meshName string) model.ResourceKey {
+	return model.ResourceKey{
+		Mesh: meshName,
+		Name: fmt.Sprintf("route-all-%s", meshName),
+	}
 }
 
-func createDefaultTrafficRoute(resManager manager.ResourceManager, meshName string) error {
-	tp := &core_mesh.TrafficRouteResource{
+func ensureDefaultTrafficRoute(resManager manager.ResourceManager, meshName string) (err error, created bool) {
+	tr := &core_mesh.TrafficRouteResource{
 		Spec: defaultTrafficRoute,
 	}
-	return resManager.Create(context.Background(), tp, store.CreateByKey(defaultTrafficRouteName(meshName), meshName))
+	key := defaultTrafficRouteKey(meshName)
+	err = resManager.Get(context.Background(), tr, store.GetBy(key))
+	if err == nil {
+		return nil, false
+	}
+	if !store.IsResourceNotFound(err) {
+		return errors.Wrap(err, "could not retrieve a resource"), false
+	}
+	if err := resManager.Create(context.Background(), tr, store.CreateBy(key)); err != nil {
+		return errors.Wrap(err, "could not create a resource"), false
+	}
+	return nil, true
 }

--- a/test/e2e/kuma_helm_deploy_multi_apps_test.go
+++ b/test/e2e/kuma_helm_deploy_multi_apps_test.go
@@ -30,6 +30,13 @@ metadata:
 `, namespace)
 	}
 
+	defaultMesh := `
+apiVersion: kuma.io/v1alpha1
+kind: Mesh
+metadata:
+  name: default
+`
+
 	var cluster Cluster
 	var deployOptsFuncs []DeployOptionsFunc
 
@@ -48,12 +55,14 @@ metadata:
 		deployOptsFuncs = []DeployOptionsFunc{
 			WithInstallationMode(HelmInstallationMode),
 			WithHelmReleaseName(releaseName),
+			WithSkipDefaultMesh(true), // it's common case for HELM deployments that Mesh is also managed by HELM therefore it's not created by default
 			WithCNI(),
 		}
 
 		err = NewClusterSetup().
 			Install(Kuma(core.Standalone, deployOptsFuncs...)).
 			Install(KumaDNS()).
+			Install(YamlK8s(defaultMesh)).
 			Setup(cluster)
 		Expect(err).ToNot(HaveOccurred())
 

--- a/test/framework/interface.go
+++ b/test/framework/interface.go
@@ -21,6 +21,7 @@ type deployOptions struct {
 	// cp specific
 	globalAddress    string
 	installationMode InstallationMode
+	skipDefaultMesh  bool
 	helmReleaseName  string
 	helmOpts         map[string]string
 	ctlOpts          map[string]string
@@ -40,6 +41,12 @@ type DeployOptionsFunc func(*deployOptions)
 func WithGlobalAddress(address string) DeployOptionsFunc {
 	return func(o *deployOptions) {
 		o.globalAddress = address
+	}
+}
+
+func WithSkipDefaultMesh(skip bool) DeployOptionsFunc {
+	return func(o *deployOptions) {
+		o.skipDefaultMesh = skip
 	}
 }
 


### PR DESCRIPTION
### Summary

Default Mesh resources are created only when a Mesh is created. Default Mesh is created using ResourceManager which is in charge of executing `CreateDefaultMeshResources`. At the same time, there is a K8S Controller that picks up new meshes and executes this method. To not double this effort I skipped the default mesh from K8S Controller.

The problem was that if someone uses SkipDefaultMesh and creates it manually, resources were not created.

Fix:
* Change `CreateDefaultMeshResources` to `EnsureDefaultMeshResources` which can handle a case that resources were already created
* Remove the if in K8S Controller
* Change HELM E2E test to use SkipDefaultMesh since it's a common case with HELM deployment

### Documentation

- [X] No docs, internal fix.
