### PR TITLE
chore(kuma-cp) handle mesh delete more gracefully

### DIFF
--- a/pkg/core/resources/manager/manager.go
+++ b/pkg/core/resources/manager/manager.go
@@ -60,7 +60,7 @@ func (r *resourcesManager) Create(ctx context.Context, resource model.Resource, 
 	if resource.GetType() == core_mesh.MeshInsightType {
 		owner = &core_mesh.MeshResource{}
 		if err := r.Store.Get(ctx, owner, store.GetByKey(opts.Name, model.NoMesh)); err != nil {
-			return MeshNotFound(opts.Mesh)
+			return MeshNotFound(opts.Name)
 		}
 	}
 

--- a/pkg/insights/resyncer.go
+++ b/pkg/insights/resyncer.go
@@ -102,6 +102,10 @@ func (p *resyncer) Start(stop <-chan struct{}) error {
 			// because that's how we find online/offline Dataplane's status
 			continue
 		}
+		if resourceChanged.Type == core_mesh.MeshType || resourceChanged.Type == core_mesh.MeshInsightType {
+			// when don't count Mesh itself, we coun't Mesh resources, so there is no need to react on this event
+			continue
+		}
 		if !p.rateLimiter.Allow() {
 			continue
 		}

--- a/pkg/plugins/resources/memory/store.go
+++ b/pkg/plugins/resources/memory/store.go
@@ -222,7 +222,10 @@ func (c *memoryStore) delete(ctx context.Context, r model.Resource, fs ...store.
 		c.eventWriter.Send(events.ResourceChangedEvent{
 			Operation: events.Delete,
 			Type:      r.GetType(),
-			Key:       model.MetaToResourceKey(r.GetMeta()),
+			Key: model.ResourceKey{
+				Mesh: opts.Mesh,
+				Name: opts.Name,
+			},
 		})
 	}
 	return nil

--- a/pkg/plugins/runtime/k8s/controllers/mesh_controller.go
+++ b/pkg/plugins/runtime/k8s/controllers/mesh_controller.go
@@ -6,13 +6,13 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
 
+	"github.com/kumahq/kuma/pkg/core/resources/store"
 	k8s_common "github.com/kumahq/kuma/pkg/plugins/common/k8s"
 
 	core_ca "github.com/kumahq/kuma/pkg/core/ca"
 	core_managers "github.com/kumahq/kuma/pkg/core/managers/apis/mesh"
 	mesh_core "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	"github.com/kumahq/kuma/pkg/core/resources/manager"
-	"github.com/kumahq/kuma/pkg/core/resources/store"
 	mesh_k8s "github.com/kumahq/kuma/pkg/plugins/resources/k8s/native/api/v1alpha1"
 
 	kube_core "k8s.io/api/core/v1"
@@ -43,7 +43,12 @@ func (r *MeshReconciler) Reconcile(req kube_ctrl.Request) (kube_ctrl.Result, err
 	mesh := &mesh_k8s.Mesh{}
 	if err := r.Get(ctx, req.NamespacedName, mesh); err != nil {
 		if kube_apierrs.IsNotFound(err) {
+			// Force delete associated resources. It will return an error ErrorResourceNotFound because Mesh was already deleted but we still need to cleanup resources
+			// Remove this part after https://github.com/kumahq/kuma/issues/1137 is implemented.
 			err := r.ResourceManager.Delete(ctx, &mesh_core.MeshResource{}, store.DeleteByKey(req.Name, req.Name))
+			if err == nil || store.IsResourceNotFound(err) {
+				return kube_ctrl.Result{}, nil
+			}
 			return kube_ctrl.Result{}, err
 		}
 		log.Error(err, "unable to fetch Mesh")


### PR DESCRIPTION
### Summary

Two things
* Mesh resyncer was reacting on Mesh and MeshInsights events. That results in error messages when Mesh was deleted
* Mesh reconciller is executing MeshManager#Delete to delete secrets. Ideally, we should remove it completely and rely on ownership of secrets that we need to build (described #1137 ). Ignoring ErrorResourceNotFound should be enough for now.

### Documentation

- [X] Internal fixes
