### PR TITLE
fix(kuma-cp) handle missing TrafficRoute

### DIFF
--- a/pkg/xds/envoy/listeners/tcp_proxy_configurer.go
+++ b/pkg/xds/envoy/listeners/tcp_proxy_configurer.go
@@ -25,6 +25,9 @@ type TcpProxyConfigurer struct {
 }
 
 func (c *TcpProxyConfigurer) Configure(filterChain *envoy_listener.FilterChain) error {
+	if len(c.clusters) == 0 {
+		return nil
+	}
 	tcpProxy := c.tcpProxy()
 
 	pbst, err := proto.MarshalAnyDeterministic(tcpProxy)

--- a/pkg/xds/generator/outbound_proxy_generator_test.go
+++ b/pkg/xds/generator/outbound_proxy_generator_test.go
@@ -277,6 +277,10 @@ var _ = Describe("OutboundProxyGenerator", func() {
 							},
 						},
 					},
+					mesh_proto.OutboundInterface{
+						DataplaneIP:   "127.0.0.1",
+						DataplanePort: 4040,
+					}: nil,
 				},
 				OutboundSelectors: model.DestinationMap{
 					"api-http": model.TagSelectorSet{
@@ -456,6 +460,22 @@ var _ = Describe("OutboundProxyGenerator", func() {
                 redirectPortInbound: 15006
 `,
 			expected: "06.envoy.golden.yaml",
+		}),
+		Entry("07. no TrafficRoute", testCase{
+			ctx: mtlsCtx,
+			dataplane: `
+            networking:
+              address: 10.0.0.1
+              inbound:
+              - port: 8080
+                tags:
+                  kuma.io/service: web
+              outbound:
+              - port: 4040
+                tags:
+                  kuma.io/service: service-without-traffic-route
+`,
+			expected: "07.envoy.golden.yaml",
 		}),
 	)
 

--- a/pkg/xds/generator/testdata/outbound-proxy/07.envoy.golden.yaml
+++ b/pkg/xds/generator/testdata/outbound-proxy/07.envoy.golden.yaml
@@ -1,0 +1,12 @@
+resources:
+  - name: outbound:127.0.0.1:4040
+    resource:
+      '@type': type.googleapis.com/envoy.api.v2.Listener
+      address:
+        socketAddress:
+          address: 127.0.0.1
+          portValue: 4040
+      filterChains:
+        - {}
+      name: outbound:127.0.0.1:4040
+      trafficDirection: OUTBOUND


### PR DESCRIPTION
### Summary

Since 1.0 traffic is only routed when there is a TrafficRoute in the cluster. It is legal to remove it and see no traffic.
Before this PR, the Envoy config generation would fail, but what we want to do is to generate a config that does not route to the cluster.

My prediction is that 99% of cases when user will see this log is when they will delete TrafficRoute by accident therefore I'm putting a link in logs to the website where there will be a section with default TrafficRoute and an explanation that this will be required.

### Documentation

- [X] https://github.com/kumahq/kuma-website/pull/322
