### PR TITLE
feat(envoy-accesslog) Added grpc status command to accesslog

### DIFF
--- a/pkg/envoy/accesslog/commands.go
+++ b/pkg/envoy/accesslog/commands.go
@@ -27,6 +27,7 @@ const (
 	CMD_REQUEST_DURATION      = "REQUEST_DURATION"
 	CMD_RESPONSE_DURATION     = "RESPONSE_DURATION"
 	CMD_RESPONSE_TX_DURATION  = "RESPONSE_TX_DURATION"
+	CMD_GRPC_STATUS           = "GRPC_STATUS"
 
 	// Commands that are the same for HTTP and TCP log entries.
 
@@ -178,6 +179,8 @@ func (o CommandOperatorDescriptor) String() string {
 		return "%KUMA_MESH%"
 	case CMD_KUMA_TRAFFIC_DIRECTION:
 		return "%KUMA_TRAFFIC_DIRECTION%"
+	case CMD_GRPC_STATUS:
+		return "%CMD_GRPC_STATUS%"
 	default:
 		return fmt.Sprintf("%%%s%%", string(o))
 	}

--- a/pkg/envoy/accesslog/field_operator_test.go
+++ b/pkg/envoy/accesslog/field_operator_test.go
@@ -180,6 +180,32 @@ var _ = Describe("FieldOperator", func() {
 				},
 				expected: `21`, // time in millis
 			}),
+			Entry("GRPC_STATUS: OK", testCase{
+				field: "GRPC_STATUS",
+				entry: &accesslog_data.HTTPAccessLogEntry{
+					Response: &accesslog_data.HTTPResponseProperties{
+						ResponseTrailers: map[string]string{
+							"grpc-status": "0",
+						},
+					},
+				},
+				expected: "OK",
+			}),
+			Entry("GRPC_STATUS: no status", testCase{
+				field:    "GRPC_STATUS",
+				expected: "",
+			}),
+			Entry("GRPC_STATUS: InvalidCode", testCase{
+				field: "GRPC_STATUS",
+				entry: &accesslog_data.HTTPAccessLogEntry{
+					Response: &accesslog_data.HTTPResponseProperties{
+						ResponseTrailers: map[string]string{
+							"grpc-status": "",
+						},
+					},
+				},
+				expected: "InvalidCode",
+			}),
 		)
 	})
 


### PR DESCRIPTION
Signed-off-by: Tharun <rajendrantharun@live.com>

### Summary

Right now the way to get grpc status is by using the format string `%TRAILER%` and it returns grpc code as a number. This pr improves it by adding a command `GRPC_STATUS` which will return the respective string representation of the code.

### Full changelog

    Added `GRPC_STATUS` command
    Added tests

### Issues resolved

Fix #621
