### PR TITLE
chore(kuma-cp) change default flush intervals

### DIFF
--- a/pkg/api-server/config_ws_test.go
+++ b/pkg/api-server/config_ws_test.go
@@ -125,6 +125,7 @@ var _ = Describe("Config WS", func() {
               "kds": {
                 "grpcPort": 5685,
                 "refreshInterval": "1s",
+                "zoneInsightFlushInterval": "10s",
                 "tlsCertFile": "",
                 "tlsKeyFile": ""
               }
@@ -247,7 +248,7 @@ var _ = Describe("Config WS", func() {
           },
           "xdsServer": {
             "dataplaneConfigurationRefreshInterval": "1s",
-            "dataplaneStatusFlushInterval": "1s"
+            "dataplaneStatusFlushInterval": "10s"
           },
           "diagnostics": {
             "serverPort": 5680,

--- a/pkg/config/app/kuma-cp/kuma-cp.defaults.yaml
+++ b/pkg/config/app/kuma-cp/kuma-cp.defaults.yaml
@@ -90,7 +90,7 @@ xdsServer:
   # Interval for re-genarting configuration for Dataplanes connected to the Control Plane
   dataplaneConfigurationRefreshInterval: 1s # ENV: KUMA_XDS_SERVER_DATAPLANE_CONFIGURATION_REFRESH_INTERVAL
   # Interval for flushing status of Dataplanes connected to the Control Plane
-  dataplaneStatusFlushInterval: 1s # ENV: KUMA_XDS_SERVER_DATAPLANE_STATUS_FLUSH_INTERVAL
+  dataplaneStatusFlushInterval: 10s # ENV: KUMA_XDS_SERVER_DATAPLANE_STATUS_FLUSH_INTERVAL
 
 # API Server configuration
 apiServer:
@@ -298,6 +298,8 @@ multizone:
       grpcPort: 5685 # ENV: KUMA_MULTIZONE_GLOBAL_KDS_GRPC_PORT
       # Interval for refreshing state of the world
       refreshInterval: 1s # ENV: KUMA_MULTIZONE_GLOBAL_KDS_REFRESH_INTERVAL
+      # Interval for flushing Zone Insights (stats of multi-zone communication)
+      zoneInsightFlushInterval: 10s # ENV: KUMA_MULTIZONE_GLOBAL_KDS_ZONE_INSIGHT_FLUSH_INTERVAL
       # TlsCertFile defines a path to a file with PEM-encoded TLS cert.
       tlsCertFile: # ENV: KUMA_MULTIZONE_GLOBAL_KDS_TLS_CERT_FILE
       # TTlsKeyFile defines a path to a file with PEM-encoded TLS key.

--- a/pkg/config/loader_test.go
+++ b/pkg/config/loader_test.go
@@ -178,6 +178,7 @@ var _ = Describe("Config loader", func() {
 			Expect(cfg.Multizone.Global.PollTimeout).To(Equal(750 * time.Millisecond))
 			Expect(cfg.Multizone.Global.KDS.GrpcPort).To(Equal(uint32(1234)))
 			Expect(cfg.Multizone.Global.KDS.RefreshInterval).To(Equal(time.Second * 2))
+			Expect(cfg.Multizone.Global.KDS.ZoneInsightFlushInterval).To(Equal(time.Second * 5))
 			Expect(cfg.Multizone.Global.KDS.TlsCertFile).To(Equal("/cert"))
 			Expect(cfg.Multizone.Global.KDS.TlsKeyFile).To(Equal("/key"))
 			Expect(cfg.Multizone.Remote.GlobalAddress).To(Equal("grpc://1.1.1.1:5685"))
@@ -337,6 +338,7 @@ multizone:
     kds:
       grpcPort: 1234
       refreshInterval: 2s
+      zoneInsightFlushInterval: 5s
       tlsCertFile: /cert
       tlsKeyFile: /key
   remote:
@@ -469,6 +471,7 @@ sdsServer:
 				"KUMA_MULTIZONE_REMOTE_ZONE":                                                               "zone-1",
 				"KUMA_MULTIZONE_REMOTE_KDS_ROOT_CA_FILE":                                                   "/rootCa",
 				"KUMA_MULTIZONE_REMOTE_KDS_REFRESH_INTERVAL":                                               "9s",
+				"KUMA_MULTIZONE_GLOBAL_KDS_ZONE_INSIGHT_FLUSH_INTERVAL":                                    "5s",
 				"KUMA_DEFAULTS_SKIP_MESH_CREATION":                                                         "true",
 				"KUMA_DIAGNOSTICS_SERVER_PORT":                                                             "5003",
 				"KUMA_DIAGNOSTICS_DEBUG_ENDPOINTS":                                                         "true",

--- a/pkg/config/multizone/kds.go
+++ b/pkg/config/multizone/kds.go
@@ -14,6 +14,8 @@ type KdsServerConfig struct {
 	GrpcPort uint32 `yaml:"grpcPort" envconfig:"kuma_multizone_global_kds_grpc_port"`
 	// Interval for refreshing state of the world
 	RefreshInterval time.Duration `yaml:"refreshInterval" envconfig:"kuma_multizone_global_kds_refresh_interval"`
+	// Interval for flushing Zone Insights (stats of multi-zone communication)
+	ZoneInsightFlushInterval time.Duration `yaml:"zoneInsightFlushInterval" envconfig:"kuma_multizone_global_kds_zone_insight_flush_interval"`
 	// TlsCertFile defines a path to a file with PEM-encoded TLS cert.
 	TlsCertFile string `yaml:"tlsCertFile" envconfig:"kuma_multizone_global_kds_tls_cert_file"`
 	// TlsKeyFile defines a path to a file with PEM-encoded TLS key.
@@ -31,6 +33,9 @@ func (c *KdsServerConfig) Validate() (errs error) {
 	}
 	if c.RefreshInterval <= 0 {
 		return errors.New(".RefreshInterval must be positive")
+	}
+	if c.ZoneInsightFlushInterval <= 0 {
+		return errors.New(".ZoneInsightFlushInterval must be positive")
 	}
 	if c.TlsCertFile == "" && c.TlsKeyFile != "" {
 		return errors.New("TlsCertFile cannot be empty if TlsKeyFile has been set")

--- a/pkg/config/multizone/multicluster.go
+++ b/pkg/config/multizone/multicluster.go
@@ -33,8 +33,9 @@ func DefaultGlobalConfig() *GlobalConfig {
 	return &GlobalConfig{
 		PollTimeout: 500 * time.Millisecond,
 		KDS: &KdsServerConfig{
-			GrpcPort:        5685,
-			RefreshInterval: 1 * time.Second,
+			GrpcPort:                 5685,
+			RefreshInterval:          1 * time.Second,
+			ZoneInsightFlushInterval: 10 * time.Second,
 		},
 	}
 }

--- a/pkg/config/xds/config.go
+++ b/pkg/config/xds/config.go
@@ -34,6 +34,6 @@ func (x *XdsServerConfig) Validate() error {
 func DefaultXdsServerConfig() *XdsServerConfig {
 	return &XdsServerConfig{
 		DataplaneConfigurationRefreshInterval: 1 * time.Second,
-		DataplaneStatusFlushInterval:          1 * time.Second,
+		DataplaneStatusFlushInterval:          10 * time.Second,
 	}
 }

--- a/pkg/config/xds/testdata/default-config.golden.yaml
+++ b/pkg/config/xds/testdata/default-config.golden.yaml
@@ -1,2 +1,2 @@
 dataplaneConfigurationRefreshInterval: 1s
-dataplaneStatusFlushInterval: 1s
+dataplaneStatusFlushInterval: 10s

--- a/pkg/kds/server/components.go
+++ b/pkg/kds/server/components.go
@@ -49,7 +49,7 @@ func DefaultStatusTracker(rt core_runtime.Runtime, log logr.Logger) StatusTracke
 		return NewZoneInsightSink(
 			accessor,
 			func() *time.Ticker {
-				return time.NewTicker(1 * time.Second)
+				return time.NewTicker(rt.Config().Multizone.Global.KDS.ZoneInsightFlushInterval)
 			},
 			NewDataplaneInsightStore(rt.ResourceManager()),
 			l)


### PR DESCRIPTION
### Summary

Lower default flush intervals of Zone Insights and Dataplane Insights. We don't need to refresh the status that often, it's not critical for Kuma to function. Change it from 1s to 10s, to save an order of magnitude requests to the DB when there are many config changes.

Tradeoff - we will see DP online / offline and all stats changes with latency of 10s, not 1s.

I also parametrized Zone Insight since it was hardcoded.

### Documentation

- [X] No docs, internal changes.
