### PR TITLE
chore(kuma-cp) insights improvements

### DIFF
--- a/pkg/insights/components.go
+++ b/pkg/insights/components.go
@@ -1,6 +1,7 @@
 package insights
 
 import (
+	"github.com/go-kit/kit/ratelimit"
 	"golang.org/x/time/rate"
 
 	"github.com/kumahq/kuma/pkg/core/runtime"
@@ -13,7 +14,9 @@ func Setup(rt runtime.Runtime) error {
 		EventReaderFactory: rt.EventReaderFactory(),
 		MinResyncTimeout:   rt.Config().Metrics.Mesh.MinResyncTimeout,
 		MaxResyncTimeout:   rt.Config().Metrics.Mesh.MaxResyncTimeout,
-		RateLimiter:        rate.NewLimiter(rate.Every(rt.Config().Metrics.Mesh.MinResyncTimeout), 50),
+		NewRateLimiter: func() ratelimit.Allower {
+			return rate.NewLimiter(rate.Every(rt.Config().Metrics.Mesh.MinResyncTimeout), 50)
+		},
 	})
 	return rt.Add(component.NewResilientComponent(log, resyncer))
 }

--- a/pkg/xds/server/components.go
+++ b/pkg/xds/server/components.go
@@ -48,6 +48,7 @@ var (
 	meshResources = meshResourceTypes(map[core_model.ResourceType]bool{
 		core_mesh.DataplaneInsightType:  true,
 		core_mesh.DataplaneOverviewType: true,
+		core_mesh.ServiceInsightType:    true,
 		core_system.ConfigType:          true,
 	})
 )


### PR DESCRIPTION
### Full changelog

* When counting service insights, we were taking into account Ingress which can have no `kuma.io/service` tags which results in empty entry in Insights
* Rate limiter should be per mesh. Otherwise we can rate limit event from other mesh. This would be eventually counted back by full resync, but we can do better
* Mutex fo Mesh insight syncing should be between full resync and event so it has to be placed on `createOrUpdateMeshInsight` not `createOrUpdateMeshInsights`. Mutex technically could be also per Mesh, but I don't think it's necessary for now.
* ServiceInsights were taken into account of Hash Mesh which results in unnecessary Envoy config generation

### Documentation

- [X] No docs, internal changes
