### PR TITLE
feat(kuma-cp) expand service insight endpoints

### DIFF
--- a/pkg/api-server/dataplane_overview_endpoints.go
+++ b/pkg/api-server/dataplane_overview_endpoints.go
@@ -103,7 +103,7 @@ func (r *dataplaneOverviewEndpoints) inspectDataplanes(request *restful.Request,
 	// pagination is not supported yet so we need to override pagination total items after retaining dataplanes
 	overviews.GetPagination().SetTotal(uint32(len(overviews.Items)))
 	restList := rest.From.ResourceList(&overviews)
-	restList.Next = nextLink(request, &overviews)
+	restList.Next = nextLink(request, overviews.GetPagination().NextOffset)
 	if err := response.WriteAsJson(restList); err != nil {
 		rest_errors.HandleError(response, err, "Could not list dataplane overviews")
 	}

--- a/pkg/api-server/pagination.go
+++ b/pkg/api-server/pagination.go
@@ -7,8 +7,6 @@ import (
 	"github.com/kumahq/kuma/pkg/api-server/types"
 
 	"github.com/emicklei/go-restful"
-
-	"github.com/kumahq/kuma/pkg/core/resources/model"
 )
 
 const maxPageSize = 1000
@@ -38,13 +36,13 @@ func pagination(request *restful.Request) (page, error) {
 	}, nil
 }
 
-func nextLink(request *restful.Request, list model.ResourceList) *string {
-	if list.GetPagination().NextOffset == "" {
+func nextLink(request *restful.Request, nextOffset string) *string {
+	if nextOffset == "" {
 		return nil
 	}
 
 	query := request.Request.URL.Query()
-	query.Set("offset", list.GetPagination().NextOffset)
+	query.Set("offset", nextOffset)
 
 	nextURL := &url.URL{}
 	if request.Request.TLS == nil {

--- a/pkg/api-server/resource_endpoints.go
+++ b/pkg/api-server/resource_endpoints.go
@@ -93,7 +93,7 @@ func (r *resourceEndpoints) listResources(request *restful.Request, response *re
 		rest_errors.HandleError(response, err, "Could not retrieve resources")
 	} else {
 		restList := rest.From.ResourceList(list)
-		restList.Next = nextLink(request, list)
+		restList.Next = nextLink(request, list.GetPagination().NextOffset)
 		if err := response.WriteAsJson(restList); err != nil {
 			rest_errors.HandleError(response, err, "Could not list resources")
 		}

--- a/pkg/api-server/service_insight_endpoints.go
+++ b/pkg/api-server/service_insight_endpoints.go
@@ -2,12 +2,15 @@ package api_server
 
 import (
 	"fmt"
+	"sort"
+	"strconv"
 
 	"github.com/emicklei/go-restful"
 
 	"github.com/kumahq/kuma/api/mesh/v1alpha1"
 	"github.com/kumahq/kuma/pkg/core"
 	"github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
+	"github.com/kumahq/kuma/pkg/core/resources/model/rest"
 	"github.com/kumahq/kuma/pkg/core/resources/store"
 	rest_errors "github.com/kumahq/kuma/pkg/core/rest/errors"
 	"github.com/kumahq/kuma/pkg/insights"
@@ -39,8 +42,100 @@ func (s *serviceInsightEndpoints) findResource(request *restful.Request, respons
 		if stat == nil {
 			stat = &v1alpha1.ServiceInsight_DataplaneStat{}
 		}
-		if err := response.WriteAsJson(stat); err != nil {
+		res := rest.From.Resource(serviceInsight)
+		res.Meta.Name = service
+		res.Spec = stat
+		if err := response.WriteAsJson(res); err != nil {
 			core.Log.Error(err, "Could not write the response")
 		}
 	}
+}
+
+func (s *serviceInsightEndpoints) addListEndpoint(ws *restful.WebService, pathPrefix string) {
+	ws.Route(ws.GET(pathPrefix).To(s.listResources).
+		Filter(s.auth()).
+		Doc(fmt.Sprintf("List of %s", s.Name)).
+		Param(ws.PathParameter("size", "size of page").DataType("int")).
+		Param(ws.PathParameter("offset", "offset of page to list").DataType("string")).
+		Returns(200, "OK", nil))
+}
+
+func (s *serviceInsightEndpoints) listResources(request *restful.Request, response *restful.Response) {
+	meshName := s.meshFromRequest(request)
+
+	serviceInsightList := &mesh.ServiceInsightResourceList{}
+	err := s.resManager.List(request.Request.Context(), serviceInsightList, store.ListByMesh(meshName))
+	if err != nil {
+		rest_errors.HandleError(response, err, "Could not retrieve resources")
+		return
+	}
+
+	restList := s.expandInsights(serviceInsightList)
+
+	sort.Sort(rest.ByMeta(restList.Items))
+	restList.Total = uint32(len(restList.Items))
+
+	if err := s.paginateResources(request, &restList); err != nil {
+		rest_errors.HandleError(response, err, "Could not paginate resources")
+		return
+	}
+
+	if err := response.WriteAsJson(restList); err != nil {
+		rest_errors.HandleError(response, err, "Could not list resources")
+	}
+}
+
+// ServiceInsight is a resource that tracks insights about a Services (kuma.io/service tag in Dataplane)
+// All of those statistics are put into a single ServiceInsight for a mesh for two reasons
+// 1) It simpler and more efficient to manage 1 object because 1 Service != 1 Dataplane
+// 2) Mesh+Name is a key on Universal, but not on Kubernetes, so if there are two services of the same name in different Meshes we would have problems with naming.
+// From the API perspective it's better to provide ServiceInsight per Service, not per Mesh.
+// For this reason, this method expand the one ServiceInsight resource for the mesh to resource per service
+func (s *serviceInsightEndpoints) expandInsights(serviceInsightList *mesh.ServiceInsightResourceList) rest.ResourceList {
+	restList := rest.ResourceList{}
+	for _, insight := range serviceInsightList.Items {
+		for serviceName, stat := range insight.Spec.Services {
+			res := rest.From.Resource(insight)
+			res.Meta.Name = serviceName
+			res.Spec = stat
+			restList.Items = append(restList.Items, res)
+		}
+	}
+	return restList
+}
+
+// paginateResources paginates resources manually, because we are expanding resources.
+func (s *serviceInsightEndpoints) paginateResources(request *restful.Request, restList *rest.ResourceList) error {
+	page, err := pagination(request)
+	if err != nil {
+		return err
+	}
+
+	offset := 0
+	if page.offset != "" {
+		o, err := strconv.Atoi(page.offset)
+		if err != nil {
+			return store.ErrorInvalidOffset
+		}
+		offset = o
+	}
+
+	total := int(restList.Total)
+	start := offset
+	if offset >= total {
+		start = total
+	}
+	end := start + page.size
+	if end >= total {
+		end = total
+	}
+	restList.Items = restList.Items[start:end]
+
+	nextOffset := ""
+	if offset+page.size < total {
+		nextOffset = strconv.Itoa(offset + page.size)
+	}
+
+	restList.Next = nextLink(request, nextOffset)
+	return nil
 }

--- a/pkg/api-server/zone_overview_endpoints.go
+++ b/pkg/api-server/zone_overview_endpoints.go
@@ -85,7 +85,7 @@ func (r *zoneOverviewEndpoints) inspectZones(request *restful.Request, response 
 	// pagination is not supported yet so we need to override pagination total items after retaining dataplanes
 	overviews.GetPagination().SetTotal(uint32(len(overviews.Items)))
 	restList := rest.From.ResourceList(&overviews)
-	restList.Next = nextLink(request, &overviews)
+	restList.Next = nextLink(request, overviews.GetPagination().NextOffset)
 	if err := response.WriteAsJson(restList); err != nil {
 		rest_errors.HandleError(response, err, "Could not list dataplane overviews")
 	}

--- a/pkg/core/resources/model/rest/resource.go
+++ b/pkg/core/resources/model/rest/resource.go
@@ -135,3 +135,16 @@ func (rec *ResourceListReceiver) UnmarshalJSON(data []byte) error {
 	rec.ResourceList.Next = list.Next
 	return nil
 }
+
+type ByMeta []*Resource
+
+func (a ByMeta) Len() int { return len(a) }
+
+func (a ByMeta) Less(i, j int) bool {
+	if a[i].Meta.Mesh == a[j].Meta.Mesh {
+		return a[i].Meta.Name < a[j].Meta.Name
+	}
+	return a[i].Meta.Mesh < a[j].Meta.Mesh
+}
+
+func (a ByMeta) Swap(i, j int) { a[i], a[j] = a[j], a[i] }


### PR DESCRIPTION
### Summary

Expand ServiceInsight API so it returns `ServiceInsight` for the individual service. This makes GUI implementation much easier.
Just like the comment in the code says, we keep all services in one ServiceInsight for the Mesh but on the GUI and from the API perspective it's better to have one per service, so I expand the resources in the API.

In the future, we might change the internal `ServiceInsight` representation to 1 per Service. This way API will stay the same.

### Documentation

- [x] https://github.com/kumahq/kuma-website/pull/331
