### PR TITLE
fix(*) FaultInjection will not valide source protocol

### DIFF
--- a/pkg/core/resources/apis/mesh/fault_injection_validator.go
+++ b/pkg/core/resources/apis/mesh/fault_injection_validator.go
@@ -39,9 +39,6 @@ func (f *FaultInjectionResource) validateSources() validators.ValidationError {
 		RequireAtLeastOneSelector: true,
 		ValidateSelectorOpts: ValidateSelectorOpts{
 			RequireAtLeastOneTag: true,
-			ExtraSelectorValidators: []SelectorValidatorFunc{
-				ProtocolValidator("http"),
-			},
 		},
 	})
 }

--- a/pkg/core/resources/apis/mesh/fault_injection_validator_test.go
+++ b/pkg/core/resources/apis/mesh/fault_injection_validator_test.go
@@ -231,8 +231,6 @@ var _ = Describe("FaultInjection", func() {
                     percentage: 100`,
 				expected: `
                violations:
-               - field: sources[0].match["kuma.io/protocol"]
-                 message: must be one of the [http]
                - field: destinations[0].match
                  message: protocol must be specified`}),
 			Entry("tag value: invalid character set", testCase{


### PR DESCRIPTION
### Summary

FaultInjection source protocol is irrelevant. Remove the excessive check that it is `http`.

### Issues resolved

Fix #1281

### Documentation

- [x] Link to the website [documentation PR](https://github.com/kumahq/kuma-website/pull/341)
