### PR TITLE
fix(kuma-dp) HttpGet readiness (and liveness) probe path gets a "/" prepended if not supplied

### DIFF
--- a/pkg/plugins/runtime/k8s/probes/probe.go
+++ b/pkg/plugins/runtime/k8s/probes/probe.go
@@ -51,11 +51,15 @@ func (p KumaProbe) ToVirtual(virtualPort uint32) (KumaProbe, error) {
 		return KumaProbe{}, errors.Errorf("cannot override Pod's probes. Port for probe cannot "+
 			"be set to %d. It is reserved for the dataplane that will serve pods without mTLS.", virtualPort)
 	}
+	probePath := p.Path()
+	if !strings.HasPrefix(p.Path(), "/") {
+		probePath = fmt.Sprintf("/%s", p.Path())
+	}
 	return KumaProbe{
 		Handler: kube_core.Handler{
 			HTTPGet: &kube_core.HTTPGetAction{
 				Port: intstr.FromInt(int(virtualPort)),
-				Path: fmt.Sprintf("/%d%s", p.Port(), p.Path()),
+				Path: fmt.Sprintf("/%d%s", p.Port(), probePath),
 			},
 		},
 	}, nil

--- a/pkg/plugins/runtime/k8s/probes/probe_test.go
+++ b/pkg/plugins/runtime/k8s/probes/probe_test.go
@@ -62,4 +62,22 @@ var _ = Describe("KumaProbe", func() {
 				"to 9000. It is reserved for the dataplane that will serve pods without mTLS."))
 		})
 	})
+
+	Context("Prepend /", func() {
+		It("should convert to path with prepended /", func() {
+			podProbeYaml := `
+                httpGet:
+                  path: c1/hc
+                  port: 8080
+`
+			probe := kube_core.Probe{}
+			err := yaml.Unmarshal([]byte(podProbeYaml), &probe)
+			Expect(err).ToNot(HaveOccurred())
+
+			virtual, err := probes.KumaProbe(probe).ToVirtual(9000)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(virtual.Path()).To(Equal("/8080/c1/hc"))
+			Expect(virtual.Port()).To(Equal(uint32(9000)))
+		})
+	})
 })


### PR DESCRIPTION
Signed-off-by: Lennart Querter <lennart.querter@durstexpress.eu>

### Summary

If liveness probe (or readiness) httpGet path does not begins with "/", we add it automatically.

### Issues resolved

Fix #1288 

