### PR TITLE
fix(kuma-cp) allow fault injection for http2 and grpc

### DIFF
--- a/pkg/core/resources/apis/mesh/fault_injection_validator.go
+++ b/pkg/core/resources/apis/mesh/fault_injection_validator.go
@@ -49,7 +49,7 @@ func (f *FaultInjectionResource) validateDestinations() validators.ValidationErr
 		ValidateSelectorOpts: ValidateSelectorOpts{
 			RequireAtLeastOneTag: true,
 			ExtraSelectorValidators: []SelectorValidatorFunc{
-				ProtocolValidator("http"),
+				ProtocolValidator(ProtocolHTTP, ProtocolHTTP2, ProtocolGRPC),
 			},
 		},
 	})

--- a/pkg/core/resources/apis/mesh/fault_injection_validator_test.go
+++ b/pkg/core/resources/apis/mesh/fault_injection_validator_test.go
@@ -48,6 +48,18 @@ var _ = Describe("FaultInjection", func() {
                   responseBandwidth:
                     percentage: 40
                     limit: 50kbps`),
+			Entry("http2", `
+                sources:
+                - match:
+                    service: frontend
+                destinations:
+                - match:
+                    service: backend
+                    kuma.io/protocol: http2
+                conf:
+                  delay:
+                    percentage: 50
+                    value: 10ms`),
 			Entry("match any", `
                 sources:
                 - match:
@@ -56,7 +68,7 @@ var _ = Describe("FaultInjection", func() {
                 destinations:
                 - match:
                     service: backend
-                    kuma.io/protocol: http
+                    kuma.io/protocol: grpc
                     region: "*"
                 conf:
                   delay:
@@ -215,12 +227,11 @@ var _ = Describe("FaultInjection", func() {
                  message: has to be in [0.0 - 100.0] range
                - field: conf.responseBandwidth.limit
                  message: has to be in kbps/mbps/gbps units`}),
-			Entry("kuma.io/protocol: wrong format", testCase{
+			Entry("kuma.io/protocol: not specified", testCase{
 				faultInjection: `
                 sources:
                 - match:
                     service: frontend
-                    kuma.io/protocol: tcp
                 destinations:
                 - match:
                     service: backend
@@ -233,6 +244,24 @@ var _ = Describe("FaultInjection", func() {
                violations:
                - field: destinations[0].match
                  message: protocol must be specified`}),
+			Entry("kuma.io/protocol: wrong protocol", testCase{
+				faultInjection: `
+                sources:
+                - match:
+                    service: frontend
+                destinations:
+                - match:
+                    service: backend
+                    region: eu
+                    kuma.io/protocol: tcp
+                conf:
+                  responseBandwidth:
+                    limit: 50mbps
+                    percentage: 100`,
+				expected: `
+               violations:
+               - field: destinations[0].match["kuma.io/protocol"]
+                 message: must be one of the [http, http2, grpc]`}),
 			Entry("tag value: invalid character set", testCase{
 				faultInjection: `
                 sources:


### PR DESCRIPTION
### Summary

We support FaultInjection in outbound proxy generator but validation of entity prevents to place it on such protocols.
This PR changes the validation on protocol from `http` to `http`, `http2` and `grpc`

### Documentation

- [X] No docs
