### PR TITLE
fix(kumactl) backoff durations validation

### DIFF
--- a/pkg/core/resources/apis/mesh/retry_validator.go
+++ b/pkg/core/resources/apis/mesh/retry_validator.go
@@ -107,7 +107,7 @@ func validateDuration_GreaterThan0(
 	path validators.PathBuilder,
 	duration *duration.Duration,
 ) (err validators.ValidationError) {
-	if duration.Nanos == 0 {
+	if duration.Seconds == 0 && duration.Nanos == 0 {
 		err.AddViolationAt(path, HasToBeGreaterThan0Violation)
 	}
 
@@ -121,7 +121,7 @@ func validateDuration_GreaterThan0OrNil(
 		return
 	}
 
-	if duration.Nanos == 0 {
+	if duration.Seconds == 0 && duration.Nanos == 0 {
 		err.AddViolationAt(path, WhenDefinedHasToBeGreaterThan0Violation)
 	}
 
@@ -141,11 +141,18 @@ func validateConfProtocolBackOff(
 			path.Field("baseInterval"),
 			HasToBeDefinedViolation,
 		)
-	} else if conf.BaseInterval.Nanos == 0 {
-		err.Add(validateDuration_GreaterThan0(
-			path.Field("baseInterval"),
-			conf.BaseInterval,
-		))
+	} else {
+		if conf.BaseInterval.Seconds == 0 && conf.BaseInterval.Nanos == 0 {
+			err.Add(validateDuration_GreaterThan0(
+				path.Field("baseInterval"),
+				conf.BaseInterval,
+			))
+		} else {
+			err.Add(validateDuration_GreaterThan0OrNil(
+				path.Field("maxInterval"),
+				conf.MaxInterval,
+			))
+		}
 	}
 
 	return


### PR DESCRIPTION
There were two bugs, one was happening when there was only seconds in
timeout durations provided (`1s`) as the validator was not checking if
seconds are provided and assuming that if nanoseconds field is empty, it
means the value is equal 0 and then rejecting valid values.

The second bug was that we were not validating `maxInterval` values of
the backOff properties
