### PR TITLE
feat(kuma-cp) v3 components

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -98,6 +98,7 @@ github.com/DATA-DOG/go-sqlmock v1.3.3/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q
 github.com/DATA-DOG/go-sqlmock v1.4.1 h1:ThlnYciV1iM/V0OSF/dtkqWb6xo5qITT1TJBG1MRDJM=
 github.com/DATA-DOG/go-sqlmock v1.4.1/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q5eFN3EC/SaM=
 github.com/DataDog/datadog-go v2.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
+github.com/DataDog/datadog-go v3.2.0+incompatible h1:qSG2N4FghB1He/r2mFrWKCaL7dXCilEuNEeAn20fdD4=
 github.com/DataDog/datadog-go v3.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
 github.com/GoogleCloudPlatform/cloudsql-proxy v0.0.0-20190405210948-c70a36b8193f/go.mod h1:aJ4qN3TfrelA6NZ6AXsXRfmEVaYin3EDbSPJrKS8OXo=
 github.com/GoogleCloudPlatform/k8s-cloud-provider v0.0.0-20190822182118-27a4ced34534/go.mod h1:iroGtC8B3tQiqtds1l+mgk/BBOrxbqjH+eUfFQYRc14=
@@ -105,8 +106,10 @@ github.com/InVisionApp/go-health v2.1.0+incompatible/go.mod h1:/+Gv1o8JUsrjC6pi6
 github.com/InVisionApp/go-logger v1.0.1/go.mod h1:+cGTDSn+P8105aZkeOfIhdd7vFO5X1afUHcjvanY0L8=
 github.com/Knetic/govaluate v3.0.1-0.20171022003610-9aa49832a739+incompatible/go.mod h1:r7JcOSlj0wfOMncg0iLm8Leh48TZaKVeNIfJntJ2wa0=
 github.com/MakeNowJust/heredoc v0.0.0-20170808103936-bb23615498cd/go.mod h1:64YHyfSL2R96J44Nlwm39UHepQbyR5q10x7iYa1ks2E=
+github.com/Masterminds/goutils v1.1.0 h1:zukEsf/1JZwCMgHiK3GZftabmxiCw4apj3a28RPBiVg=
 github.com/Masterminds/goutils v1.1.0/go.mod h1:8cTjp+g8YejhMuvIA5y2vz3BpJxksy863GQaJW2MFNU=
 github.com/Masterminds/semver v1.4.2/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=
+github.com/Masterminds/semver v1.5.0 h1:H65muMkzWKEuNDnfl9d70GUjFniHKHRbFPGBuZ3QEww=
 github.com/Masterminds/semver v1.5.0/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=
 github.com/Masterminds/semver/v3 v3.1.0 h1:Y2lUDsFKVRSYGojLJ1yLxSXdMmMYTYls0rCvoqmMUQk=
 github.com/Masterminds/semver/v3 v3.1.0/go.mod h1:VPu/7SZ7ePZ3QOrcuXROw5FAcLl4a0cBrbBpGY/8hQs=
@@ -156,6 +159,7 @@ github.com/apache/thrift v0.13.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=
+github.com/armon/go-metrics v0.3.2 h1:EyUnxyP2yaGpLgMiuyyz8sHnByqeTJUfGs72pdH0i4A=
 github.com/armon/go-metrics v0.3.2/go.mod h1:4O98XIr/9W0sxpJ8UaYkvjk10Iff7SnFrb4QAOwNTFc=
 github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
 github.com/aryann/difflib v0.0.0-20170710044230-e206f873d14a/go.mod h1:DAHtR1m6lCRdSC2Tm3DSWRPvIPr6xNKyeHdqDQSQT+A=
@@ -177,6 +181,7 @@ github.com/aws/aws-sdk-go-v2 v0.18.0/go.mod h1:JWVYvqSMppoMJC0x5wdwiImzgXTI9FuZw
 github.com/beorn7/perks v0.0.0-20160804104726-4c0e84591b9a/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
+github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
 github.com/bitly/go-hostpool v0.0.0-20171023180738-a3a6125de932/go.mod h1:NOuUCSz6Q9T7+igc/hlvDOUdtWKryOrtFyIVABv/p7k=
@@ -198,9 +203,12 @@ github.com/cenkalti/backoff v2.0.0+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QH
 github.com/cenkalti/backoff v2.2.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
 github.com/cenkalti/backoff/v3 v3.0.0/go.mod h1:cIeZDE3IrqwwJl6VUwCN6trj1oXrTS4rc0ij+ULvLYs=
 github.com/cenkalti/backoff/v4 v4.0.2/go.mod h1:eEew/i+1Q6OrCDZh3WiXYv3+nJwBASZ8Bog/87DQnVg=
+github.com/census-instrumentation/opencensus-proto v0.2.1 h1:glEXhBS5PSLLv4IXzLA5yPRVX4bilULVyxxbrfOtDAk=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
+github.com/cespare/xxhash v1.1.0 h1:a6HrQnmkObjyL+Gs60czilIUGqrzKutQD6XZog3p+ko=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/cespare/xxhash/v2 v2.1.0/go.mod h1:dgIUBU3pDso/gPgZ1osOZ0iQf77oPR28Tjxl5dIMyVM=
+github.com/cespare/xxhash/v2 v2.1.1 h1:6MnRN8NT7+YBpUIWxHtefFZOKTAPgGjpQSxqLNn0+qY=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/chai2010/gettext-go v0.0.0-20160711120539-c6fed771bfd5/go.mod h1:/iP1qXHoty45bqomnu2LM+VVyAEdWN+vtSHGlQgyxbw=
 github.com/cheggaaa/pb/v3 v3.0.4/go.mod h1:7rgWxLrAUcFMkvJuv09+DYi7mMUYi8nO9iOWcvGJPfw=
@@ -265,6 +273,7 @@ github.com/cznic/mathutil v0.0.0-20180504122225-ca4c9f2c1369/go.mod h1:e6NPNENfs
 github.com/d4l3k/messagediff v1.2.1/go.mod h1:Oozbb1TVXFac9FtSIxHBMnBCq2qeH/2KkEQxENCrlLo=
 github.com/davecgh/go-spew v0.0.0-20151105211317-5215b55f46b2/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/daviddengcn/go-colortext v0.0.0-20160507010035-511bcaf42ccd/go.mod h1:dv4zxwHi5C/8AeI+4gX4dCWOIvNi7I6JCSX0HvlKPgE=
 github.com/dchest/siphash v1.1.0/go.mod h1:q+IRvb2gOSrUnYoPqHiyHXS0FOBBOdl6tONBlVnOnt4=
@@ -274,6 +283,7 @@ github.com/denisenkom/go-mssqldb v0.0.0-20191001013358-cfbb681360f0/go.mod h1:xb
 github.com/denisenkom/go-mssqldb v0.0.0-20200620013148-b91950f658ec/go.mod h1:xbL0rPBG9cCiLr28tMa8zpbdarY27NDyej4t/EjAShU=
 github.com/denverdino/aliyungo v0.0.0-20190125010748-a747050bb1ba/go.mod h1:dV8lFg6daOBZbT6/BDGIz6Y3WFGn8juu6G+CQ6LHtl0=
 github.com/dgrijalva/jwt-go v0.0.0-20170104182250-a601269ab70c/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
+github.com/dgrijalva/jwt-go v3.2.0+incompatible h1:7qlOGliEKZXTDg6OTjfoBKDXWrumCAMpl/TFQ4/5kLM=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
 github.com/dhui/dktest v0.3.3 h1:DBuH/9GFaWbDRa42qsut/hbQu+srAQ0rPWnUoiGX7CA=
@@ -351,10 +361,12 @@ github.com/franela/goblin v0.0.0-20200105215937-c9ffbefa60db/go.mod h1:7dvUGVsVB
 github.com/franela/goreq v0.0.0-20171204163338-bcd34c9993f8/go.mod h1:ZhphrRTfi2rbfLwlschooIH4+wKKDR4Pdxhh+TRoA20=
 github.com/frankban/quicktest v1.4.1/go.mod h1:36zfPVQyHxymz4cH7wlDmVwDrJuljRB60qkgn7rorfQ=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
+github.com/fsnotify/fsnotify v1.4.9 h1:hsms1Qyu0jgnwNXIxa+/V/PDsU6CfLf6CNO8H7IWoS4=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
 github.com/fsouza/fake-gcs-server v1.17.0/go.mod h1:D1rTE4YCyHFNa99oyJJ5HyclvN/0uQR+pM/VdlL83bw=
 github.com/garyburd/redigo v0.0.0-20150301180006-535138d7bcd7/go.mod h1:NR3MbYisc3/PwhQ00EMzDiPmrwpPxAn5GI05/YaO1SY=
 github.com/ghodss/yaml v0.0.0-20150909031657-73d445a93680/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
+github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/gin-contrib/sse v0.1.0/go.mod h1:RHrZQHXnP2xjPF+u1gW/2HnVO7nvIa9PG3Gm+fLHvGI=
 github.com/gin-gonic/gin v1.6.3/go.mod h1:75u5sXoLsGZoRN5Sgbi1eraJ4GU3++wFwWzhwvtwp4M=
@@ -376,6 +388,7 @@ github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9
 github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V4qmtdjCk=
 github.com/go-logfmt/logfmt v0.5.0 h1:TrB8swr/68K7m9CcGut2g3UOihhbcbiMAYiuTXdEih4=
 github.com/go-logfmt/logfmt v0.5.0/go.mod h1:wCYkCAKZfumFQihp8CzCvQ3paCTfi41vtzG1KdI/P7A=
+github.com/go-logr/logr v0.1.0 h1:M1Tv3VzNlEHg6uyACnRdtrploV2P7wZqH8BoQMtz0cg=
 github.com/go-logr/logr v0.1.0/go.mod h1:ixOQHD9gLJUVQQ2ZOR7zLEifBX6tGkNJF4QyIY7sIas=
 github.com/go-logr/zapr v0.1.0/go.mod h1:tabnROwaDl0UNxkVeFRbY8bwB37GwRv0P8lg6aAiEnk=
 github.com/go-logr/zapr v0.1.1 h1:qXBXPDdNncunGs7XeEpsJt8wCjYBygluzfdLO0G5baE=
@@ -458,6 +471,7 @@ github.com/gogo/protobuf v1.2.1/go.mod h1:hp+jE20tsWTFYpLwKvXlhS1hjn+gTNwPg2I6zV
 github.com/gogo/protobuf v1.2.2-0.20190723190241-65acae22fc9d/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=
 github.com/gogo/protobuf v1.2.2-0.20190730201129-28a6bbf47e48/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=
 github.com/gogo/protobuf v1.3.0/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=
+github.com/gogo/protobuf v1.3.1 h1:DqDEcV5aeaTmdFBePNpYsp3FlcVH/2ISVVM9Qf8PSls=
 github.com/gogo/protobuf v1.3.1/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=
 github.com/golang-migrate/migrate/v4 v4.14.1 h1:qmRd/rNGjM1r3Ve5gHd5ZplytrD02UcItYNxJ3iUHHE=
 github.com/golang-migrate/migrate/v4 v4.14.1/go.mod h1:l7Ks0Au6fYHuUIxUhQ0rcVX1uLlJg54C/VvW7tvxSz0=
@@ -468,6 +482,7 @@ github.com/golang/groupcache v0.0.0-20190129154638-5b532d6fd5ef/go.mod h1:cIg4er
 github.com/golang/groupcache v0.0.0-20190702054246-869f871628b6/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20191027212112-611e8accdfc9/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20191227052852-215e87163ea7/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
+github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e h1:1r7pUrabqp18hOBcwBwiTsbnFeTZHV9eER/QT5JVZxY=
 github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/mock v1.1.1/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=
 github.com/golang/mock v1.2.0/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=
@@ -519,6 +534,7 @@ github.com/google/go-github v17.0.0+incompatible/go.mod h1:zLgOLi98H3fifZn+44m+u
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
 github.com/google/gofuzz v0.0.0-20161122191042-44d81051d367/go.mod h1:HP5RmnzzSNb993RKQDq4+1A4ia9nllfqcQFTQJedwGI=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
+github.com/google/gofuzz v1.1.0 h1:Hsa8mG0dQ46ij8Sl2AYJDUv1oA9/d6Vk+3LG99Oe02g=
 github.com/google/gofuzz v1.1.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXiIaQGbYVAs8BPL6v8lEs=
 github.com/google/martian/v3 v3.0.0/go.mod h1:y5Zk1BBys9G+gd6Jrk0W3cC1+ELVxBWuIGO+w/tUAp0=
@@ -540,6 +556,7 @@ github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5m
 github.com/googleapis/gnostic v0.0.0-20170729233727-0c5108395e2d/go.mod h1:sJBsCZ4ayReDTBIg8b9dl28c5xFWyhBTVRp3pOg5EKY=
 github.com/googleapis/gnostic v0.1.0/go.mod h1:sJBsCZ4ayReDTBIg8b9dl28c5xFWyhBTVRp3pOg5EKY=
 github.com/googleapis/gnostic v0.2.2/go.mod h1:sJBsCZ4ayReDTBIg8b9dl28c5xFWyhBTVRp3pOg5EKY=
+github.com/googleapis/gnostic v0.3.1 h1:WeAefnSUHlBb0iJKwxFDZdbfGwkd7xRNuV+IpXMJhYk=
 github.com/googleapis/gnostic v0.3.1/go.mod h1:on+2t9HRStVgn95RSsFWFz+6Q0Snyqv1awfrALZdbtU=
 github.com/gophercloud/gophercloud v0.1.0 h1:P/nh25+rzXouhytV2pUHBb65fnds26Ghl8/391+sT5o=
 github.com/gophercloud/gophercloud v0.1.0/go.mod h1:vxM41WHh5uqHVBMZHzuwNOHh8XEoIEcSTewFxm1c5g8=
@@ -576,6 +593,7 @@ github.com/hashicorp/consul v1.3.1/go.mod h1:mFrjN1mfidgJfYP1xrJCF+AfRhr6Eaqhb2+
 github.com/hashicorp/consul/api v1.3.0/go.mod h1:MmDNSzIMUjNpY/mQ398R4bk2FnqQLoPndWW5VkKPlCE=
 github.com/hashicorp/consul/sdk v0.3.0/go.mod h1:VKf9jXwCTEY1QZP2MOLRhb5i/I/ssyNV1vwHyQBF0x8=
 github.com/hashicorp/errwrap v0.0.0-20141028054710-7554cd9344ce/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
+github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/UYA=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/go-cleanhttp v0.5.0/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
 github.com/hashicorp/go-cleanhttp v0.5.1/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
@@ -583,6 +601,7 @@ github.com/hashicorp/go-hclog v0.0.0-20180709165350-ff2cf002a8dd/go.mod h1:9bjs9
 github.com/hashicorp/go-hclog v0.8.0/go.mod h1:5CU+agLiy3J7N7QjHK5d05KxGsuXiQLrjA0H7acj2lQ=
 github.com/hashicorp/go-hclog v0.14.0 h1:1X+ga+2ki9aUJJaliI2isvjNLI8rNCGHFkZ1FaVpvCA=
 github.com/hashicorp/go-hclog v0.14.0/go.mod h1:whpDNt7SSdeAju8AWKIWsul05p54N/39EeqMAyrmvFQ=
+github.com/hashicorp/go-immutable-radix v1.0.0 h1:AKDB1HM5PWEA7i4nhcpwOrO2byshxBjXVn/J/3+z5/0=
 github.com/hashicorp/go-immutable-radix v1.0.0/go.mod h1:0y9vanUI8NX6FsYoO3zeMjhV/C5i9g4Q3DwcSNZ4P60=
 github.com/hashicorp/go-msgpack v0.5.3/go.mod h1:ahLV/dePpqEmjfWmKiqvPkv/twdG7iPBM1vqhUKIvfM=
 github.com/hashicorp/go-msgpack v0.5.5/go.mod h1:ahLV/dePpqEmjfWmKiqvPkv/twdG7iPBM1vqhUKIvfM=
@@ -609,8 +628,10 @@ github.com/hashicorp/go.net v0.0.1/go.mod h1:hjKkEWcCURg++eb33jQU7oqQcI9XDCnUzHA
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.3/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
+github.com/hashicorp/golang-lru v0.5.4 h1:YDjusn29QI/Das2iO9M0BHnIbxPeyuCHsjMW+lJfyTc=
 github.com/hashicorp/golang-lru v0.5.4/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
+github.com/hashicorp/hcl v1.0.1-0.20190430135223-99e2f22d1c94 h1:LaH4JWe6Q7ICdxL5raxQjSRw7Pj8uTtAENrjejIYZIg=
 github.com/hashicorp/hcl v1.0.1-0.20190430135223-99e2f22d1c94/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/hashicorp/logutils v1.0.0/go.mod h1:QIAnNjmIWmVIIkWDTG1z5v++HQmx9WQRO+LraFDTW64=
 github.com/hashicorp/mdns v1.0.0/go.mod h1:tL+uN++7HEJ6SQLQ2/p+z2pH24WQKWjBPkE0mNTz8vQ=
@@ -624,6 +645,7 @@ github.com/hashicorp/vault/sdk v0.1.13/go.mod h1:B+hVj7TpuQY1Y/GPbCpffmgd+tSEwvh
 github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
 github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d h1:kJCB4vdITiW1eC1vq2e6IsrXKrZit1bv/TDYFGMp4BQ=
 github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
+github.com/hoisie/mustache v0.0.0-20160804235033-6375acf62c69 h1:umaj0TCQ9lWUUKy2DxAhEzPbwd0jnxiw1EI2z3FiILM=
 github.com/hoisie/mustache v0.0.0-20160804235033-6375acf62c69/go.mod h1:zdLK9ilQRSMjSeLKoZ4BqUfBT7jswTGF8zRlKEsiRXA=
 github.com/howeyc/fsnotify v0.9.0/go.mod h1:41HzSPxBGeFRQKEEwgh49TRw/nKBsYZ2cF1OzPjSJsA=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
@@ -697,6 +719,7 @@ github.com/justinas/alice v1.2.0/go.mod h1:fN5HRH/reO/zrUflLfTN43t3vXvKzvZIENsNE
 github.com/k0kubun/colorstring v0.0.0-20150214042306-9440f1994b88/go.mod h1:3w7q1U84EfirKl04SVQ/s7nPm1ZPhiXd34z40TNz36k=
 github.com/k0kubun/pp v2.3.0+incompatible/go.mod h1:GWse8YhT0p8pT4ir3ZgBbfZild3tgzSScAn6HmfYukg=
 github.com/kardianos/osext v0.0.0-20190222173326-2bc1f35cddc0/go.mod h1:1NbS8ALrpOvjt0rHPNLyCIeMtbizbir8U//inJ+zuB8=
+github.com/kelseyhightower/envconfig v1.4.0 h1:Im6hONhd3pLkfDFsbRgu68RDNkGF1r3dvMUtDTo2cv8=
 github.com/kelseyhightower/envconfig v1.4.0/go.mod h1:cccZRl6mQpaq41TPp5QxidR+Sa3axMbJDNb//FQX6Gg=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=
@@ -770,6 +793,7 @@ github.com/mattn/go-sqlite3 v1.9.0/go.mod h1:FPy6KqzDD04eiIsT53CuJW3U88zkxoIYsOq
 github.com/mattn/go-sqlite3 v1.10.0/go.mod h1:FPy6KqzDD04eiIsT53CuJW3U88zkxoIYsOqkbpncsNc=
 github.com/mattn/go-sqlite3 v1.12.0/go.mod h1:FPy6KqzDD04eiIsT53CuJW3U88zkxoIYsOqkbpncsNc=
 github.com/mattn/go-zglob v0.0.2-0.20190814121620-e3c945676326/go.mod h1:9fxibJccNxU2cnpIKLRRFA7zX7qhkJIQWBb449FYHOo=
+github.com/matttproud/golang_protobuf_extensions v1.0.1 h1:4hp9jkHxhMHkqkrB3Ix0jegS5sx/RkqARlsWZ6pIwiU=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/maxbrunsfeld/counterfeiter/v6 v6.2.2/go.mod h1:eD9eIE7cdwcMi9rYluz88Jz2VyhSmden33/aXg4oVIY=
 github.com/mholt/archiver v3.1.1+incompatible/go.mod h1:Dh2dOXnSdiLxRiPoVfIr/fI1TwETms9B8CTWfeh7ROU=
@@ -797,9 +821,11 @@ github.com/mitchellh/reflectwalk v1.0.0/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx
 github.com/mitchellh/reflectwalk v1.0.1 h1:FVzMWA5RllMAKIdUSC8mdWo3XtwoecrH79BY70sEEpE=
 github.com/mitchellh/reflectwalk v1.0.1/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
+github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/reflect2 v0.0.0-20180320133207-05fbef0ca5da/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
+github.com/modern-go/reflect2 v1.0.1 h1:9f412s+6RmYXLWZSEzVVgPGK7C2PphHj5RJrvfx9AWI=
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/morikuni/aec v1.0.0/go.mod h1:BbKIizmSmc5MMPqRYbxO4ZU0S0+P200+tUnFx7PXmsc=
 github.com/munnerz/goautoneg v0.0.0-20120707110453-a547fc61f48d/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
@@ -824,6 +850,7 @@ github.com/nwaples/rardecode v1.0.0/go.mod h1:5DzqNKiOdpKKBH87u8VlvAnPZMXcGRhxWk
 github.com/nxadm/tail v1.4.4 h1:DQuhQpB1tVlglWS2hLQ5OV6B5r8aGxSrPc5Qo6uTN78=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
 github.com/oklog/oklog v0.3.2/go.mod h1:FCV+B7mhrz4o+ueLpx+KqkyXRGMWOYEvfiXtdGtbWGs=
+github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
 github.com/olekukonko/tablewriter v0.0.0-20170122224234-a0225b3f23b5/go.mod h1:vsDQFd/mU46D+Z4whnwzcISnGGzXWMclvtLoiIKAKIo=
@@ -880,6 +907,7 @@ github.com/oracle/oci-go-sdk v7.1.0+incompatible/go.mod h1:VQb79nF8Z2cwLkLS35ukw
 github.com/pact-foundation/pact-go v1.0.4/go.mod h1:uExwJY4kCzNPcHRj+hCR/HBbOOIwwtUjcrb0b5/5kLM=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pascaldekloe/goe v0.1.0/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
+github.com/patrickmn/go-cache v2.1.0+incompatible h1:HRMgzkcYKYpi3C8ajMPV8OFXaaRUnok+kx1WdO15EQc=
 github.com/patrickmn/go-cache v2.1.0+incompatible/go.mod h1:3Qf8kWWT7OJRJbdiICTKqZju1ZixQ/KpMGzzAfe6+WQ=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
@@ -926,6 +954,7 @@ github.com/prometheus/client_model v0.0.0-20190115171406-56726106282f/go.mod h1:
 github.com/prometheus/client_model v0.0.0-20190129233127-fd36f4220a90/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 github.com/prometheus/client_model v0.1.0/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
+github.com/prometheus/client_model v0.2.0 h1:uq5h0d+GuxiXLJLNABMgp2qUWDPiLvgCzz2dUR+/W/M=
 github.com/prometheus/client_model v0.2.0/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 github.com/prometheus/common v0.0.0-20180110214958-89604d197083/go.mod h1:daVV7qP5qjZbuso7PdcryaAu0sAZbrN9i7WWcTMWvro=
 github.com/prometheus/common v0.0.0-20181113130724-41aa239b4cce/go.mod h1:daVV7qP5qjZbuso7PdcryaAu0sAZbrN9i7WWcTMWvro=
@@ -987,6 +1016,7 @@ github.com/sethvargo/go-retry v0.1.0/go.mod h1:JzIOdZqQDNpPkQDmcqgtteAcxFLtYpNF/
 github.com/shirou/gopsutil v2.18.12+incompatible/go.mod h1:5b4v6he4MtMOwMlS0TUMTu2PcXUg8+E1lC7eC3UO/RA=
 github.com/shirou/w32 v0.0.0-20160930032740-bb4de0191aa4/go.mod h1:qsXQc7+bwAM3Q1u/4XEfrquwF8Lw7D7y5cD8CuHnfIc=
 github.com/shopspring/decimal v0.0.0-20180709203117-cd690d0c9e24/go.mod h1:M+9NzErvs504Cn4c5DxATwIqPbtswREoFCre64PpcG4=
+github.com/shurcooL/httpfs v0.0.0-20190707220628-8d4bc4ba7749 h1:bUGsEnyNbVPw06Bs80sCeARAlK8lhwqGyi6UT8ymuGk=
 github.com/shurcooL/httpfs v0.0.0-20190707220628-8d4bc4ba7749/go.mod h1:ZY1cvUeJuFPAdZ/B6v7RHavJWZn2YPVFQ1OSXhCGOkg=
 github.com/shurcooL/sanitized_anchor_name v1.0.0 h1:PdmoCO6wvbs+7yrJyMORt4/BmY5IYyJwS/kOiWx8mHo=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
@@ -1020,6 +1050,7 @@ github.com/spf13/cast v1.3.1/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkU
 github.com/spf13/cobra v0.0.2-0.20171109065643-2da4a54c5cee/go.mod h1:1l0Ry5zgKvJasoi3XT1TypsSe7PqH0Sj9dhYf7v3XqQ=
 github.com/spf13/cobra v0.0.3/go.mod h1:1l0Ry5zgKvJasoi3XT1TypsSe7PqH0Sj9dhYf7v3XqQ=
 github.com/spf13/cobra v0.0.5/go.mod h1:3K3wKZymM7VvHMDS9+Akkh4K60UwM26emMESw8tLCHU=
+github.com/spf13/cobra v1.0.0 h1:6m/oheQuQ13N9ks4hubMG6BnvwOeaJrqSPLahSnczz8=
 github.com/spf13/cobra v1.0.0/go.mod h1:/6GTrnGXV9HjY+aR4k0oJ5tcvakLuG6EuKReYlHNrgE=
 github.com/spf13/jwalterweatherman v1.0.0/go.mod h1:cQK4TGJAtQXfYWX+Ddv3mKDzgVb68N+wFjFa4jdeBTo=
 github.com/spf13/jwalterweatherman v1.1.0 h1:ue6voC5bR5F8YxI5S67j9i582FU4Qvo2bmqnqMYADFk=
@@ -1028,11 +1059,13 @@ github.com/spf13/pflag v0.0.0-20170130214245-9ff6c6923cff/go.mod h1:DYY7MBk1bdzu
 github.com/spf13/pflag v1.0.1-0.20171106142849-4c012f6dcd95/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/spf13/pflag v1.0.1/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/spf13/pflag v1.0.3/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
+github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/spf13/viper v1.3.2/go.mod h1:ZiWeW+zYFKm7srdB9IoDzzZXaJaI5eL9QjNiN/DMA2s=
 github.com/spf13/viper v1.4.0/go.mod h1:PTJ7Z/lr49W6bUbkmS1V3by4uWynFiR9p7+dSq/yZzE=
 github.com/spf13/viper v1.6.3 h1:pDDu1OyEDTKzpJwdq4TiuLyMsUgRa/BT5cn5O62NoHs=
 github.com/spf13/viper v1.6.3/go.mod h1:jUMtyi0/lB5yZH/FjyGAoH7IMNrIhlBf6pXZmbMDvzw=
+github.com/spiffe/go-spiffe v0.0.0-20190820222348-6adcf1eecbcc h1:YeGvOZLHZxE8nrxPGDNH1LGv8zzkAIDfIRgy256rotk=
 github.com/spiffe/go-spiffe v0.0.0-20190820222348-6adcf1eecbcc/go.mod h1:HyNeJnVYkDyQgB2qcSPxVYkAA2F3lQu51bDxNpFcKxY=
 github.com/spiffe/go-spiffe/v2 v2.0.0-beta.4 h1:tF4to8mhz24XGez/Vn9YPdmKrhg50M+zLGt1cbGuZbI=
 github.com/spiffe/go-spiffe/v2 v2.0.0-beta.4/go.mod h1:TEfgrEcyFhuSuvqohJt6IxENUNeHfndWCCV1EX7UaVk=
@@ -1065,6 +1098,7 @@ github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=
 github.com/tv42/httpunix v0.0.0-20191220191345-2ba4b9c3382c/go.mod h1:hzIxponao9Kjc7aWznkXaL4U4TWaDSs8zcsY4Ka08nM=
+github.com/uber-go/tally v3.3.12+incompatible h1:Qa0XrHsKXclmhEpHmBHTTEZotwvQHAbm3lvtJ6RNn+0=
 github.com/uber-go/tally v3.3.12+incompatible/go.mod h1:YDTIBxdXyOU/sCWilKB4bgyufu1cEi0jdVnRdxvjnmU=
 github.com/uber/jaeger-client-go v0.0.0-20190228190846-ecf2d03a9e80/go.mod h1:WVhlPFC8FDjOFMMWRy2pZqQJSXxYSwNYOkTr/Z6d3Kk=
 github.com/uber/jaeger-lib v2.0.0+incompatible/go.mod h1:ComeNDZlWwrWnDv8aPp0Ba6+uUTzImX/AauajbLI56U=
@@ -1268,6 +1302,7 @@ golang.org/x/oauth2 v0.0.0-20181106182150-f42d05182288/go.mod h1:N/0e6XlmueqKjAG
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20191202225959-858c2ad4c8b6/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
+golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d h1:TzXSXBo42m9gQenoE3b9BGiEpg5IG2JkU5FkPIawgtw=
 golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
@@ -1446,6 +1481,7 @@ golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8T
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 h1:go1bK/D/BFZV2I8cIQd1NKEZ+0owSTG1fDTci4IqFcE=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+gomodules.xyz/jsonpatch/v2 v2.0.1 h1:xyiBuvkD2g5n7cYzx6u2sxQvsAy4QJsZFCzGVdzOXZ0=
 gomodules.xyz/jsonpatch/v2 v2.0.1/go.mod h1:IhYNNY4jnS53ZnfE4PAmpKtDpTCj1JFXc+3mwe7XcUU=
 gonum.org/v1/gonum v0.0.0-20190331200053-3d26580ed485/go.mod h1:2ltnJ7xHfj0zHS40VVPYEAAMTa3ZGguvHGBSJeRWqE0=
 gonum.org/v1/netlib v0.0.0-20190313105609-8cb42192e0e0/go.mod h1:wa6Ws7BG/ESfp6dHfk7C6KdzKA7wR7u/rKwOGE66zvw=
@@ -1578,6 +1614,7 @@ gopkg.in/gcfg.v1 v1.2.3/go.mod h1:yesOnuUOFQAhST5vPY4nbZsb/huCgGGXlipJsBn0b3o=
 gopkg.in/gemnasium/logrus-airbrake-hook.v2 v2.1.2/go.mod h1:Xk6kEKp8OKb+X14hQBKWaSkCsqBpgog8nAV2xsGOxlo=
 gopkg.in/gorp.v1 v1.7.2/go.mod h1:Wo3h+DBQZIxATwftsglhdD/62zRFPhGhTiu5jUJmCaw=
 gopkg.in/inconshreveable/log15.v2 v2.0.0-20180818164646-67afb5ed74ec/go.mod h1:aPpfJ7XW+gOuirDoZ8gHhLh3kZ1B08FtV2bbmy7Jv3s=
+gopkg.in/inf.v0 v0.9.1 h1:73M5CoZyi3ZLMOyDlQh031Cx6N9NDJ2Vvfl76EDAgDc=
 gopkg.in/inf.v0 v0.9.1/go.mod h1:cWUDdTG/fYaXco+Dcufb5Vnc6Gp2YChqWtbxRZE0mXw=
 gopkg.in/ini.v1 v1.51.0 h1:AQvPpx3LzTDM0AjnIRlVFwFFGC+npRopjZxLJj6gdno=
 gopkg.in/ini.v1 v1.51.0/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=
@@ -1682,11 +1719,13 @@ k8s.io/gengo v0.0.0-20200114144118-36b2048a9120/go.mod h1:ezvh/TsK7cY6rbqRK0oQQ8
 k8s.io/klog v0.0.0-20181102134211-b9b56d5dfc92/go.mod h1:Gq+BEi5rUBO/HRz0bTSXDUcqjScdoY3a9IHpCEIOOfk=
 k8s.io/klog v0.2.0/go.mod h1:Gq+BEi5rUBO/HRz0bTSXDUcqjScdoY3a9IHpCEIOOfk=
 k8s.io/klog v0.3.0/go.mod h1:Gq+BEi5rUBO/HRz0bTSXDUcqjScdoY3a9IHpCEIOOfk=
+k8s.io/klog v1.0.0 h1:Pt+yjF5aB1xDSVbau4VsWe+dQNzA0qv1LlXdC2dF6Q8=
 k8s.io/klog v1.0.0/go.mod h1:4Bi6QPql/J/LkTDqv7R/cd3hPo4k2DG6Ptcz060Ez5I=
 k8s.io/klog/v2 v2.0.0 h1:Foj74zO6RbjjP4hBEKjnYtjjAhGg4jNynUdYF6fJrok=
 k8s.io/klog/v2 v2.0.0/go.mod h1:PBfzABfn139FHAV07az/IF9Wp1bkk3vpT2XSJ76fSDE=
 k8s.io/kube-openapi v0.0.0-20191107075043-30be4d16710a/go.mod h1:1TqjTSzOxsLGIKfj0lK8EeCP7K1iUG65v09OM0/WG5E=
 k8s.io/kube-openapi v0.0.0-20200121204235-bf4fb3bd569c/go.mod h1:GRQhZsXIAJ1xR0C9bd8UpWHZ5plfAS9fzPjJuQ6JL3E=
+k8s.io/kube-openapi v0.0.0-20200410145947-61e04a5be9a6 h1:Oh3Mzx5pJ+yIumsAD0MOECPVeXsVot0UkiaCGVyfGQY=
 k8s.io/kube-openapi v0.0.0-20200410145947-61e04a5be9a6/go.mod h1:GRQhZsXIAJ1xR0C9bd8UpWHZ5plfAS9fzPjJuQ6JL3E=
 k8s.io/kubectl v0.18.0/go.mod h1:LOkWx9Z5DXMEg5KtOjHhRiC1fqJPLyCr3KtQgEolCkU=
 k8s.io/kubectl v0.18.3/go.mod h1:k/EpvXBDgEsHBzWr0A44l9+ArvYi3txBBnzXBjQasUQ=
@@ -1726,11 +1765,14 @@ sigs.k8s.io/controller-tools v0.3.0/go.mod h1:enhtKGfxZD1GFEoMgP8Fdbu+uKQ/cq1/WG
 sigs.k8s.io/kustomize v2.0.3+incompatible/go.mod h1:MkjgH3RdOWrievjo6c9T245dYlB5QeXV4WCbnt/PEpU=
 sigs.k8s.io/service-apis v0.0.0-20200708220836-10c7cb28ed93/go.mod h1:s/e4e7RMwEcieVQ33+YMaKbSeaQyatebjinhC/kIJ3U=
 sigs.k8s.io/structured-merge-diff v0.0.0-20190525122527-15d366b2352e/go.mod h1:wWxsB5ozmmv/SG7nM11ayaAW51xMvak/t1r0CSlcokI=
+sigs.k8s.io/structured-merge-diff v1.0.1-0.20191108220359-b1b620dd3f06 h1:zD2IemQ4LmOcAumeiyDWXKUI2SO0NYDe3H6QGvPOVgU=
 sigs.k8s.io/structured-merge-diff v1.0.1-0.20191108220359-b1b620dd3f06/go.mod h1:/ULNhyfzRopfcjskuui0cTITekDduZ7ycKN3oUT9R18=
 sigs.k8s.io/structured-merge-diff/v3 v3.0.0-20200116222232-67a7b8c61874/go.mod h1:PlARxl6Hbt/+BC80dRLi1qAmnMqwqDg62YvvVkZjemw=
+sigs.k8s.io/structured-merge-diff/v3 v3.0.0 h1:dOmIZBMfhcHS09XZkMyUgkq5trg3/jRyJYFZUiaOp8E=
 sigs.k8s.io/structured-merge-diff/v3 v3.0.0/go.mod h1:PlARxl6Hbt/+BC80dRLi1qAmnMqwqDg62YvvVkZjemw=
 sigs.k8s.io/testing_frameworks v0.1.2/go.mod h1:ToQrwSC3s8Xf/lADdZp3Mktcql9CG0UAmdJG9th5i0w=
 sigs.k8s.io/yaml v1.1.0/go.mod h1:UJmg0vDUVViEyp3mgSv9WPwZCDxu4rQW1olrI1uml+o=
+sigs.k8s.io/yaml v1.2.0 h1:kr/MCeFWJWTwyaHoR9c8EjH9OumOmoF9YGiZd7lFm/Q=
 sigs.k8s.io/yaml v1.2.0/go.mod h1:yfXDCHCao9+ENCvLSE62v9VSji2MKu5jeNfTrofGhJc=
 sourcegraph.com/sourcegraph/appdash v0.0.0-20190731080439-ebfcffb1b5c0/go.mod h1:hI742Nqp5OhwiqlzhgfbWU4mW4yO10fP+LoT9WOswdU=
 vbom.ml/util v0.0.0-20160121211510-db5cfe13f5cc/go.mod h1:so/NYdZXCz+E3ZpW0uAoCj6uzU2+8OWDFv/HxUSs7kI=

--- a/pkg/core/xds/v3/context.go
+++ b/pkg/core/xds/v3/context.go
@@ -1,0 +1,67 @@
+package v2
+
+import (
+	envoy_core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	envoy_cache "github.com/envoyproxy/go-control-plane/pkg/cache/v3"
+	envoy_log "github.com/envoyproxy/go-control-plane/pkg/log"
+	"github.com/go-logr/logr"
+
+	"github.com/kumahq/kuma/pkg/core"
+	"github.com/kumahq/kuma/pkg/core/xds"
+	util_xds "github.com/kumahq/kuma/pkg/util/xds"
+)
+
+type XdsContext interface {
+	Hasher() envoy_cache.NodeHash
+	Cache() envoy_cache.SnapshotCache
+}
+
+func NewXdsContext() XdsContext {
+	return newXdsContext("xds-server", true)
+}
+
+func newXdsContext(name string, ads bool) XdsContext {
+	log := core.Log.WithName(name)
+	hasher := hasher{log}
+	logger := util_xds.NewLogger(log)
+	cache := envoy_cache.NewSnapshotCache(ads, hasher, logger)
+	return &xdsContext{
+		NodeHash:      hasher,
+		Logger:        logger,
+		SnapshotCache: cache,
+	}
+}
+
+var _ XdsContext = &xdsContext{}
+
+type xdsContext struct {
+	envoy_cache.NodeHash
+	envoy_log.Logger
+	envoy_cache.SnapshotCache
+}
+
+func (c *xdsContext) Hasher() envoy_cache.NodeHash {
+	return c.NodeHash
+}
+
+func (c *xdsContext) Cache() envoy_cache.SnapshotCache {
+	return c.SnapshotCache
+}
+
+var _ envoy_cache.NodeHash = &hasher{}
+
+type hasher struct {
+	log logr.Logger
+}
+
+func (h hasher) ID(node *envoy_core.Node) string {
+	if node == nil {
+		return "unknown"
+	}
+	proxyId, err := xds.ParseProxyIdFromString(node.GetId())
+	if err != nil {
+		h.log.Error(err, "failed to parse Proxy ID", "node", node)
+		return "unknown"
+	}
+	return proxyId.String()
+}

--- a/pkg/core/xds/v3/context.go
+++ b/pkg/core/xds/v3/context.go
@@ -1,4 +1,4 @@
-package v2
+package v3
 
 import (
 	envoy_core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"

--- a/pkg/sds/server/components.go
+++ b/pkg/sds/server/components.go
@@ -1,11 +1,13 @@
 package server
 
 import (
+	"github.com/pkg/errors"
 	"google.golang.org/grpc"
 
 	core_runtime "github.com/kumahq/kuma/pkg/core/runtime"
 	sds_metrics "github.com/kumahq/kuma/pkg/sds/metrics"
 	v2 "github.com/kumahq/kuma/pkg/sds/server/v2"
+	v3 "github.com/kumahq/kuma/pkg/sds/server/v3"
 )
 
 func RegisterSDS(rt core_runtime.Runtime, server *grpc.Server) error {
@@ -15,7 +17,10 @@ func RegisterSDS(rt core_runtime.Runtime, server *grpc.Server) error {
 	}
 
 	if err := v2.RegisterSDS(rt, sdsMetrics, server); err != nil {
-		return err
+		return errors.Wrap(err, "could not register V2 SDS")
+	}
+	if err := v3.RegisterSDS(rt, sdsMetrics, server); err != nil {
+		return errors.Wrap(err, "could not register V3 SDS")
 	}
 	return nil
 }

--- a/pkg/sds/server/v3/reconciler.go
+++ b/pkg/sds/server/v3/reconciler.go
@@ -1,0 +1,178 @@
+package v3
+
+import (
+	"context"
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/kumahq/kuma/pkg/config/core/resources/store"
+	sds_metrics "github.com/kumahq/kuma/pkg/sds/metrics"
+	envoy_common "github.com/kumahq/kuma/pkg/xds/envoy"
+	envoy_secrets "github.com/kumahq/kuma/pkg/xds/envoy/secrets/v3"
+	"github.com/kumahq/kuma/pkg/xds/envoy/tls"
+
+	"github.com/pkg/errors"
+
+	envoy_auth "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
+	envoy_types "github.com/envoyproxy/go-control-plane/pkg/cache/types"
+	envoy_cache "github.com/envoyproxy/go-control-plane/pkg/cache/v3"
+	envoy_resource "github.com/envoyproxy/go-control-plane/pkg/resource/v3"
+
+	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
+	"github.com/kumahq/kuma/pkg/core"
+	"github.com/kumahq/kuma/pkg/core/ca/issuer"
+	mesh_core "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
+	mesh_helper "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
+	core_manager "github.com/kumahq/kuma/pkg/core/resources/manager"
+	core_model "github.com/kumahq/kuma/pkg/core/resources/model"
+	core_store "github.com/kumahq/kuma/pkg/core/resources/store"
+	core_xds "github.com/kumahq/kuma/pkg/core/xds"
+	sds_ca "github.com/kumahq/kuma/pkg/sds/ca"
+	sds_identity "github.com/kumahq/kuma/pkg/sds/identity"
+)
+
+// DataplaneReconciler keeps the state of the Cache for SDS consistent
+// When Dataplane connects to the Control Plane, the Watchdog (separate goroutine) is started which on the defined interval
+// execute DataplaneReconciler#Reconcile. It will then check if certs needs to be regenerated because Mesh CA was changed
+// This follows the same pattern as XDS.
+//
+// Snapshot are versioned with UnixNano;NameOfTheCA pattern
+type DataplaneReconciler struct {
+	resManager         core_manager.ResourceManager
+	readOnlyResManager core_manager.ReadOnlyResourceManager
+	meshCaProvider     sds_ca.Provider
+	identityProvider   sds_identity.Provider
+	cache              envoy_cache.SnapshotCache
+	upsertConfig       store.UpsertConfig
+	sdsMetrics         *sds_metrics.Metrics
+}
+
+func (d *DataplaneReconciler) Reconcile(dataplaneId core_model.ResourceKey) error {
+	proxyID := core_xds.FromResourceKey(dataplaneId).String()
+
+	dataplane := mesh_core.NewDataplaneResource()
+	if err := d.readOnlyResManager.Get(context.Background(), dataplane, core_store.GetBy(dataplaneId)); err != nil {
+		if core_store.IsResourceNotFound(err) {
+			sdsServerLog.V(1).Info("Dataplane not found. Clearing the Snapshot.", "dataplaneId", dataplaneId)
+			d.cache.ClearSnapshot(proxyID)
+			return nil
+		}
+		return err
+	}
+
+	mesh := mesh_core.NewMeshResource()
+	if err := d.readOnlyResManager.Get(context.Background(), mesh, core_store.GetByKey(dataplane.GetMeta().GetMesh(), core_model.NoMesh)); err != nil {
+		return errors.Wrap(err, "could not retrieve a mesh")
+	}
+
+	if !mesh.MTLSEnabled() {
+		sdsServerLog.V(1).Info("mTLS for Mesh disabled. Clearing the Snapshot.", "dataplaneId", dataplaneId)
+		d.cache.ClearSnapshot(proxyID)
+		return nil
+	}
+
+	generateSnapshot, reason, err := d.shouldGenerateSnapshot(proxyID, mesh)
+	if err != nil {
+		return err
+	}
+
+	if generateSnapshot {
+		sdsServerLog.Info("Generating the Snapshot.", "dataplaneId", dataplaneId, "reason", reason)
+		snapshot, err := d.generateSnapshot(dataplane, mesh)
+		if err != nil {
+			return err
+		}
+		d.sdsMetrics.CertGenerations(envoy_common.APIV3).Inc()
+		if err := d.updateInsights(dataplaneId, snapshot); err != nil {
+			// do not stop updating Envoy even if insights update fails
+			sdsServerLog.Error(err, "Could not update Dataplane Insights", "dataplaneId", dataplaneId)
+		}
+		if err := d.cache.SetSnapshot(proxyID, snapshot); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (d *DataplaneReconciler) shouldGenerateSnapshot(proxyID string, mesh *mesh_core.MeshResource) (bool, string, error) {
+	currentSnapshot, err := d.cache.GetSnapshot(proxyID)
+	if err != nil {
+		return true, "Snapshot does not exist", nil
+	}
+
+	parts := strings.Split(currentSnapshot.GetVersion(envoy_resource.SecretType), ";")
+	if len(parts) != 2 {
+		return false, "", errors.New(`invalid snapshot version format. Format should be "UnixNano-NameOfTheCA"`)
+	}
+	// generate snapshot if CA changed
+	caName := parts[1]
+	if caName != mesh.GetEnabledCertificateAuthorityBackend().Name {
+		return true, fmt.Sprintf("Enabled CA changed from %s to %s", caName, mesh.GetEnabledCertificateAuthorityBackend().Name), nil
+	}
+	// generate snapshot if cert expired
+	generationUnixNano, err := strconv.Atoi(parts[0])
+	if err != nil {
+		return false, "", errors.Wrap(err, `invalid snapshot version format. Format should be "UnixNano;NameOfTheCA"`)
+	}
+	expiration := issuer.DefaultWorkloadCertValidityPeriod
+	if mesh.GetEnabledCertificateAuthorityBackend().GetDpCert().GetRotation().GetExpiration() != "" {
+		expiration, err = mesh_helper.ParseDuration(mesh.GetEnabledCertificateAuthorityBackend().GetDpCert().GetRotation().GetExpiration())
+		if err != nil {
+			return false, "", nil
+		}
+	}
+	generationTime := time.Unix(0, int64(generationUnixNano))
+	expirationTime := generationTime.Add(expiration)
+	if core.Now().After(generationTime.Add(expiration / 5 * 4)) { // regenerate cert after 4/5 of its lifetime
+		reason := fmt.Sprintf("Certificate generated at %s will expire in %s", generationTime, expirationTime.Sub(core.Now()))
+		return true, reason, nil
+	}
+	return false, "", nil
+}
+
+func (d *DataplaneReconciler) generateSnapshot(dataplane *mesh_core.DataplaneResource, mesh *mesh_core.MeshResource) (envoy_cache.Snapshot, error) {
+	requestor := sds_identity.Identity{
+		Services: dataplane.Spec.TagSet().Values(mesh_proto.ServiceTag),
+		Mesh:     dataplane.GetMeta().GetMesh(),
+	}
+	identitySecret, err := d.identityProvider.Get(context.Background(), requestor)
+	if err != nil {
+		return envoy_cache.Snapshot{}, errors.Wrap(err, "could not get Dataplane cert pair")
+	}
+
+	caSecret, err := d.meshCaProvider.Get(context.Background(), dataplane.GetMeta().GetMesh())
+	if err != nil {
+		return envoy_cache.Snapshot{}, errors.Wrap(err, "could not get mesh CA cert")
+	}
+
+	version := fmt.Sprintf("%d;%s", core.Now().UTC().UnixNano(), mesh.GetEnabledCertificateAuthorityBackend().Name)
+	snap := envoy_cache.Snapshot{
+		Resources: [envoy_types.UnknownType]envoy_cache.Resources{},
+	}
+	snap.Resources[envoy_types.Secret] = envoy_cache.NewResources(version, []envoy_types.Resource{
+		envoy_secrets.CreateIdentitySecret(identitySecret),
+		envoy_secrets.CreateCaSecret(caSecret),
+	})
+	return snap, nil
+}
+
+func (d *DataplaneReconciler) updateInsights(dataplaneId core_model.ResourceKey, snapshot envoy_cache.Snapshot) error {
+	secret := snapshot.Resources[envoy_types.Secret].Items[tls.IdentityCertResource].(*envoy_auth.Secret)
+	certPEM := secret.GetTlsCertificate().CertificateChain.GetInlineBytes()
+	block, _ := pem.Decode(certPEM)
+	cert, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		return err
+	}
+
+	return core_manager.Upsert(d.resManager, dataplaneId, mesh_core.NewDataplaneInsightResource(), func(resource core_model.Resource) {
+		insight := resource.(*mesh_core.DataplaneInsightResource)
+		if err := insight.Spec.UpdateCert(core.Now(), cert.NotAfter); err != nil {
+			sdsServerLog.Error(err, "could not update the certificate", "dataplaneId", dataplaneId)
+		}
+	}, core_manager.WithConflictRetry(d.upsertConfig.ConflictRetryBaseBackoff, d.upsertConfig.ConflictRetryMaxTimes)) // retry because DataplaneInsight could be updated from other parts of the code
+}

--- a/pkg/sds/server/v3/server.go
+++ b/pkg/sds/server/v3/server.go
@@ -1,0 +1,110 @@
+package v3
+
+import (
+	"context"
+	"time"
+
+	envoy_core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	envoy_service_secret "github.com/envoyproxy/go-control-plane/envoy/service/secret/v3"
+	envoy_cache "github.com/envoyproxy/go-control-plane/pkg/cache/v3"
+	envoy_server "github.com/envoyproxy/go-control-plane/pkg/server/v3"
+	"github.com/go-logr/logr"
+	"google.golang.org/grpc"
+
+	"github.com/kumahq/kuma/pkg/core"
+	core_model "github.com/kumahq/kuma/pkg/core/resources/model"
+	core_runtime "github.com/kumahq/kuma/pkg/core/runtime"
+	core_xds "github.com/kumahq/kuma/pkg/core/xds"
+	sds_ca "github.com/kumahq/kuma/pkg/sds/ca"
+	sds_identity "github.com/kumahq/kuma/pkg/sds/identity"
+	sds_metrics "github.com/kumahq/kuma/pkg/sds/metrics"
+	util_watchdog "github.com/kumahq/kuma/pkg/util/watchdog"
+	util_xds "github.com/kumahq/kuma/pkg/util/xds"
+	util_xds_v3 "github.com/kumahq/kuma/pkg/util/xds/v3"
+	xds_auth "github.com/kumahq/kuma/pkg/xds/auth"
+	auth_components "github.com/kumahq/kuma/pkg/xds/auth/components"
+	envoy_common "github.com/kumahq/kuma/pkg/xds/envoy"
+	xds_callbacks "github.com/kumahq/kuma/pkg/xds/server/callbacks"
+)
+
+var (
+	sdsServerLog = core.Log.WithName("sds-server")
+)
+
+func RegisterSDS(rt core_runtime.Runtime, sdsMetrics *sds_metrics.Metrics, server *grpc.Server) error {
+	hasher := hasher{sdsServerLog}
+	logger := util_xds.NewLogger(sdsServerLog)
+	cache := envoy_cache.NewSnapshotCache(false, hasher, logger)
+
+	caProvider := sds_ca.NewProvider(rt.ResourceManager(), rt.CaManagers())
+	identityProvider := sds_identity.NewProvider(rt.ResourceManager(), rt.CaManagers())
+	authenticator, err := auth_components.DefaultAuthenticator(rt)
+	if err != nil {
+		return err
+	}
+	authCallbacks := xds_auth.NewCallbacks(rt.ResourceManager(), authenticator)
+
+	reconciler := DataplaneReconciler{
+		resManager:         rt.ResourceManager(),
+		readOnlyResManager: rt.ReadOnlyResourceManager(),
+		meshCaProvider:     caProvider,
+		identityProvider:   identityProvider,
+		cache:              cache,
+		upsertConfig:       rt.Config().Store.Upsert,
+		sdsMetrics:         sdsMetrics,
+	}
+
+	syncTracker, err := syncTracker(&reconciler, rt.Config().SdsServer.DataplaneConfigurationRefreshInterval, sdsMetrics)
+	if err != nil {
+		return err
+	}
+	callbacks := util_xds_v3.CallbacksChain{
+		util_xds_v3.AdaptCallbacks(sdsMetrics.Callbacks),
+		util_xds_v3.AdaptCallbacks(util_xds.LoggingCallbacks{Log: sdsServerLog}),
+		util_xds_v3.AdaptCallbacks(authCallbacks),
+		util_xds_v3.AdaptCallbacks(syncTracker),
+	}
+
+	srv := envoy_server.NewServer(context.Background(), cache, callbacks)
+
+	sdsServerLog.Info("registering Secret Discovery Service V3 in Dataplane Server")
+	envoy_service_secret.RegisterSecretDiscoveryServiceServer(server, srv)
+	return nil
+}
+
+func syncTracker(reconciler *DataplaneReconciler, refresh time.Duration, sdsMetrics *sds_metrics.Metrics) (util_xds.Callbacks, error) {
+	return xds_callbacks.NewDataplaneSyncTracker(func(dataplaneId core_model.ResourceKey, streamId int64) util_watchdog.Watchdog {
+		return &util_watchdog.SimpleWatchdog{
+			NewTicker: func() *time.Ticker {
+				return time.NewTicker(refresh)
+			},
+			OnTick: func() error {
+				start := core.Now()
+				defer func() {
+					sdsMetrics.SdsGeneration(envoy_common.APIV3).Observe(float64(core.Now().Sub(start).Milliseconds()))
+				}()
+				return reconciler.Reconcile(dataplaneId)
+			},
+			OnError: func(err error) {
+				sdsMetrics.SdsGenerationsErrors(envoy_common.APIV3).Inc()
+				sdsServerLog.Error(err, "OnTick() failed")
+			},
+		}
+	}), nil
+}
+
+type hasher struct {
+	log logr.Logger
+}
+
+func (h hasher) ID(node *envoy_core.Node) string {
+	if node == nil {
+		return "unknown"
+	}
+	proxyId, err := core_xds.ParseProxyIdFromString(node.GetId())
+	if err != nil {
+		h.log.Error(err, "failed to parse Proxy ID", "node", node)
+		return "unknown"
+	}
+	return proxyId.String()
+}

--- a/pkg/sds/server/v3/server_suite_test.go
+++ b/pkg/sds/server/v3/server_suite_test.go
@@ -1,0 +1,13 @@
+package v3_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestServer(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "SDS Server Suite")
+}

--- a/pkg/sds/server/v3/server_test.go
+++ b/pkg/sds/server/v3/server_test.go
@@ -1,0 +1,319 @@
+package v3_test
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"sync/atomic"
+	"time"
+
+	"github.com/kumahq/kuma/pkg/xds/envoy/tls"
+
+	envoy_api_core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	envoy_discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
+	envoy_service_secret "github.com/envoyproxy/go-control-plane/envoy/service/secret/v3"
+	envoy_resource "github.com/envoyproxy/go-control-plane/pkg/resource/v3"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/metadata"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
+	kuma_cp "github.com/kumahq/kuma/pkg/config/app/kuma-cp"
+	dp_server_cfg "github.com/kumahq/kuma/pkg/config/dp-server"
+	"github.com/kumahq/kuma/pkg/core"
+	mesh_core "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
+	core_manager "github.com/kumahq/kuma/pkg/core/resources/manager"
+	"github.com/kumahq/kuma/pkg/core/resources/model"
+	core_store "github.com/kumahq/kuma/pkg/core/resources/store"
+	dp_server "github.com/kumahq/kuma/pkg/dp-server"
+	core_metrics "github.com/kumahq/kuma/pkg/metrics"
+	"github.com/kumahq/kuma/pkg/test"
+	test_metrics "github.com/kumahq/kuma/pkg/test/metrics"
+	"github.com/kumahq/kuma/pkg/test/runtime"
+	tokens_builtin "github.com/kumahq/kuma/pkg/tokens/builtin"
+	tokens_issuer "github.com/kumahq/kuma/pkg/tokens/builtin/issuer"
+)
+
+var _ = Describe("SDS Server", func() {
+
+	var dpCredential tokens_issuer.Token
+	var stop chan struct{}
+	var client envoy_service_secret.SecretDiscoveryServiceClient
+	var conn *grpc.ClientConn
+	var metrics core_metrics.Metrics
+
+	var resManager core_manager.ResourceManager
+
+	var now atomic.Value // it has to be stored as atomic to avoid race condition
+
+	BeforeSuite(func() {
+		now.Store(time.Now())
+		core.Now = func() time.Time {
+			return now.Load().(time.Time)
+		}
+		// setup runtime with SDS
+		cfg := kuma_cp.DefaultConfig()
+		cfg.SdsServer.DataplaneConfigurationRefreshInterval = 100 * time.Millisecond
+		port, err := test.GetFreePort()
+		Expect(err).ToNot(HaveOccurred())
+		cfg.DpServer.Port = port
+		cfg.DpServer.TlsCertFile = filepath.Join("..", "..", "..", "..", "test", "certs", "server-cert.pem")
+		cfg.DpServer.TlsKeyFile = filepath.Join("..", "..", "..", "..", "test", "certs", "server-key.pem")
+		cfg.DpServer.Auth.Type = dp_server_cfg.DpServerAuthDpToken
+
+		builder, err := runtime.BuilderFor(cfg)
+		Expect(err).ToNot(HaveOccurred())
+		runtime, err := builder.Build()
+		Expect(err).ToNot(HaveOccurred())
+		metrics = runtime.Metrics()
+		resManager = runtime.ResourceManager()
+
+		// setup default mesh with active mTLS and 2 CA
+		meshRes := mesh_core.MeshResource{
+			Spec: &mesh_proto.Mesh{
+				Mtls: &mesh_proto.Mesh_Mtls{
+					EnabledBackend: "ca-1",
+					Backends: []*mesh_proto.CertificateAuthorityBackend{
+						{
+							Name: "ca-1",
+							Type: "builtin",
+							DpCert: &mesh_proto.CertificateAuthorityBackend_DpCert{
+								Rotation: &mesh_proto.CertificateAuthorityBackend_DpCert_Rotation{
+									Expiration: "1m",
+								},
+							},
+						},
+						{
+							Name: "ca-2",
+							Type: "builtin",
+							DpCert: &mesh_proto.CertificateAuthorityBackend_DpCert{
+								Rotation: &mesh_proto.CertificateAuthorityBackend_DpCert_Rotation{
+									Expiration: "1m",
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+		err = resManager.Create(context.Background(), &meshRes, core_store.CreateByKey(model.DefaultMesh, model.NoMesh))
+		Expect(err).ToNot(HaveOccurred())
+
+		// setup backend dataplane
+		dpRes := mesh_core.DataplaneResource{
+			Spec: &mesh_proto.Dataplane{
+				Networking: &mesh_proto.Dataplane_Networking{
+					Address: "192.168.0.1",
+					Inbound: []*mesh_proto.Dataplane_Networking_Inbound{
+						{
+							Port: 1234,
+							Tags: map[string]string{
+								"kuma.io/service": "backend",
+							},
+						},
+					},
+				},
+			},
+		}
+		err = resManager.Create(context.Background(), &dpRes, core_store.CreateByKey("backend-01", "default"))
+		Expect(err).ToNot(HaveOccurred())
+
+		// retrieve example DP token
+		tokenIssuer, err := tokens_builtin.NewDataplaneTokenIssuer(runtime.ReadOnlyResourceManager())
+		Expect(err).ToNot(HaveOccurred())
+		dpCredential, err = tokenIssuer.Generate(tokens_issuer.DataplaneIdentity{
+			Name: dpRes.GetMeta().GetName(),
+			Mesh: dpRes.GetMeta().GetMesh(),
+		})
+		Expect(err).ToNot(HaveOccurred())
+
+		// start the runtime
+		Expect(dp_server.SetupServer(runtime)).To(Succeed())
+		stop = make(chan struct{})
+		go func() {
+			defer GinkgoRecover()
+			err := runtime.Start(stop)
+			Expect(err).ToNot(HaveOccurred())
+		}()
+
+		// wait for SDS server
+		Eventually(func() error {
+			creds, err := credentials.NewClientTLSFromFile(filepath.Join("..", "..", "..", "..", "test", "certs", "server-cert.pem"), "")
+			if err != nil {
+				return err
+			}
+			c, err := grpc.Dial(fmt.Sprintf("localhost:%d", port), grpc.WithTransportCredentials(creds))
+			if err != nil {
+				return err
+			}
+			conn = c
+			client = envoy_service_secret.NewSecretDiscoveryServiceClient(conn)
+			_, err = client.StreamSecrets(context.Background()) // dial is not enough, we need to double check if we can start to stream secrets
+			return err
+		}).ShouldNot(HaveOccurred())
+	})
+
+	AfterSuite(func() {
+		if conn != nil {
+			Expect(conn.Close()).To(Succeed())
+		}
+		close(stop)
+	})
+
+	newRequestForSecrets := func() envoy_discovery.DiscoveryRequest {
+		return envoy_discovery.DiscoveryRequest{
+			Node: &envoy_api_core.Node{
+				Id: "default.backend-01",
+			},
+			ResourceNames: []string{tls.MeshCaResource, tls.IdentityCertResource},
+			TypeUrl:       envoy_resource.SecretType,
+		}
+	}
+
+	It("should return CA and Identity cert when DP is authorized", func(done Done) {
+		// given
+		ctx := metadata.AppendToOutgoingContext(context.Background(), "authorization", dpCredential)
+		stream, err := client.StreamSecrets(ctx)
+		defer func() {
+			if stream != nil {
+				Expect(stream.CloseSend()).To(Succeed())
+			}
+		}()
+		Expect(err).ToNot(HaveOccurred())
+		req := newRequestForSecrets()
+
+		// when
+		err = stream.Send(&req)
+		Expect(err).ToNot(HaveOccurred())
+		resp, err := stream.Recv()
+		Expect(err).ToNot(HaveOccurred())
+
+		// then
+		Expect(resp).ToNot(BeNil())
+		Expect(resp.Resources).To(HaveLen(2))
+
+		// and insight is generated
+		dpInsight := mesh_core.NewDataplaneInsightResource()
+		err = resManager.Get(context.Background(), dpInsight, core_store.GetByKey("backend-01", "default"))
+		Expect(err).ToNot(HaveOccurred())
+		Expect(dpInsight.Spec.MTLS.CertificateRegenerations).To(Equal(uint32(1)))
+		expirationSeconds := now.Load().(time.Time).Add(60 * time.Second).Unix()
+		Expect(dpInsight.Spec.MTLS.CertificateExpirationTime.Seconds).To(Equal(expirationSeconds))
+
+		// and metrics are published
+		Expect(test_metrics.FindMetric(metrics, "sds_cert_generation").GetCounter().GetValue()).To(Equal(1.0))
+		Expect(test_metrics.FindMetric(metrics, "sds_generation")).ToNot(BeNil())
+
+		close(done)
+	}, 10)
+
+	Context("should return new pair of + key", func() { // we cannot use DescribeTable because it does not support timeouts
+
+		var firstExchangeResponse *envoy_discovery.DiscoveryResponse
+		var stream envoy_service_secret.SecretDiscoveryService_StreamSecretsClient
+
+		BeforeEach(func(done Done) {
+			// given
+			ctx := metadata.AppendToOutgoingContext(context.Background(), "authorization", dpCredential)
+			s, err := client.StreamSecrets(ctx)
+			stream = s
+			Expect(err).ToNot(HaveOccurred())
+			req := newRequestForSecrets()
+
+			// when
+			err = stream.Send(&req)
+			Expect(err).ToNot(HaveOccurred())
+			resp, err := stream.Recv()
+			Expect(err).ToNot(HaveOccurred())
+
+			// then
+			Expect(resp).ToNot(BeNil())
+			Expect(resp.Resources).To(HaveLen(2))
+			firstExchangeResponse = resp
+			close(done)
+		}, 10)
+
+		AfterEach(func() {
+			Expect(stream.CloseSend()).To(Succeed())
+		})
+
+		It("should return pair when CA is changed", func(done Done) {
+			// when
+			meshRes := mesh_core.NewMeshResource()
+			Expect(resManager.Get(context.Background(), meshRes, core_store.GetByKey(model.DefaultMesh, model.NoMesh))).To(Succeed())
+			meshRes.Spec.Mtls.EnabledBackend = "" // we need to first disable mTLS
+			Expect(resManager.Update(context.Background(), meshRes)).To(Succeed())
+			meshRes.Spec.Mtls.EnabledBackend = "ca-2"
+			Expect(resManager.Update(context.Background(), meshRes)).To(Succeed())
+
+			// and when send a request with version previously fetched
+			req := newRequestForSecrets()
+			req.VersionInfo = firstExchangeResponse.VersionInfo
+			req.ResponseNonce = firstExchangeResponse.Nonce
+			err := stream.Send(&req)
+			Expect(err).ToNot(HaveOccurred())
+			resp, err := stream.Recv()
+			Expect(err).ToNot(HaveOccurred())
+
+			// then certs are different
+			Expect(resp).ToNot(BeNil())
+			Expect(firstExchangeResponse.Resources).ToNot(Equal(resp.Resources))
+
+			// and insight is updated
+			dpInsight := mesh_core.NewDataplaneInsightResource()
+			err = resManager.Get(context.Background(), dpInsight, core_store.GetByKey("backend-01", "default"))
+			Expect(err).ToNot(HaveOccurred())
+			Expect(dpInsight.Spec.MTLS.CertificateRegenerations).To(Equal(uint32(2)))
+			expirationSeconds := now.Load().(time.Time).Add(60 * time.Second).Unix()
+			Expect(dpInsight.Spec.MTLS.CertificateExpirationTime.Seconds).To(Equal(expirationSeconds))
+
+			close(done)
+		}, 10)
+
+		It("should return pair when cert expired", func(done Done) {
+			// when time is moved 1s after 4/5 of 60s cert expiration
+			shiftedTime := now.Load().(time.Time).Add(49 * time.Second)
+			now.Store(shiftedTime)
+
+			// and when send a request with version previously fetched
+			req := newRequestForSecrets()
+			req.VersionInfo = firstExchangeResponse.VersionInfo
+			req.ResponseNonce = firstExchangeResponse.Nonce
+			err := stream.Send(&req)
+			Expect(err).ToNot(HaveOccurred())
+			resp, err := stream.Recv()
+			Expect(err).ToNot(HaveOccurred())
+
+			// then certs are different
+			Expect(resp).ToNot(BeNil())
+			Expect(firstExchangeResponse.Resources).ToNot(Equal(resp.Resources))
+
+			close(done)
+		}, 10)
+	})
+
+	It("should not return certs when DP is not authorized", func(done Done) {
+		// given
+		stream, err := client.StreamSecrets(context.Background())
+		defer func() {
+			if stream != nil {
+				Expect(stream.CloseSend()).To(Succeed())
+			}
+		}()
+		Expect(err).ToNot(HaveOccurred())
+		req := newRequestForSecrets()
+
+		// when
+		err = stream.Send(&req)
+		Expect(err).ToNot(HaveOccurred())
+		_, err = stream.Recv()
+
+		// then
+		Expect(err).To(MatchError("rpc error: code = Unknown desc = authentication failed: could not parse token: token contains an invalid number of segments"))
+
+		close(done)
+	}, 10)
+})

--- a/pkg/util/cache/v3/cache.go
+++ b/pkg/util/cache/v3/cache.go
@@ -1,0 +1,38 @@
+package v3
+
+import (
+	"sort"
+
+	"github.com/golang/protobuf/ptypes"
+
+	v3 "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
+	ctl_cache "github.com/envoyproxy/go-control-plane/pkg/cache/v3"
+)
+
+func ToDeltaDiscoveryResponse(s ctl_cache.Snapshot) (*v3.DeltaDiscoveryResponse, error) {
+	resp := &v3.DeltaDiscoveryResponse{}
+	for _, rs := range s.Resources {
+		for _, name := range sortedResourceNames(rs) {
+			r := rs.Items[name]
+			pbany, err := ptypes.MarshalAny(r)
+			if err != nil {
+				return nil, err
+			}
+			resp.Resources = append(resp.Resources, &v3.Resource{
+				Version:  rs.Version,
+				Name:     name,
+				Resource: pbany,
+			})
+		}
+	}
+	return resp, nil
+}
+
+func sortedResourceNames(rs ctl_cache.Resources) []string {
+	names := make([]string, 0, len(rs.Items))
+	for name := range rs.Items {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}

--- a/pkg/util/xds/v3/callbacks.go
+++ b/pkg/util/xds/v3/callbacks.go
@@ -1,0 +1,70 @@
+package v3
+
+import (
+	"context"
+
+	envoy_sd "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
+	envoy_xds "github.com/envoyproxy/go-control-plane/pkg/server/v3"
+	_struct "github.com/golang/protobuf/ptypes/struct"
+
+	"github.com/kumahq/kuma/pkg/util/xds"
+)
+
+type adapterCallbacks struct {
+	callbacks xds.Callbacks
+}
+
+// AdaptCallbacks translate Kuma callbacks to real go-control-plane Callbacks
+func AdaptCallbacks(callbacks xds.Callbacks) envoy_xds.Callbacks {
+	return &adapterCallbacks{
+		callbacks: callbacks,
+	}
+}
+
+var _ envoy_xds.Callbacks = &adapterCallbacks{}
+
+func (a *adapterCallbacks) OnFetchRequest(ctx context.Context, request *envoy_sd.DiscoveryRequest) error {
+	panic("implement me")
+}
+
+func (a *adapterCallbacks) OnFetchResponse(request *envoy_sd.DiscoveryRequest, response *envoy_sd.DiscoveryResponse) {
+	panic("implement me")
+}
+
+func (a *adapterCallbacks) OnStreamOpen(ctx context.Context, streamID int64, typeURL string) error {
+	return a.callbacks.OnStreamOpen(ctx, streamID, typeURL)
+}
+
+func (a *adapterCallbacks) OnStreamClosed(streamID int64) {
+	a.callbacks.OnStreamClosed(streamID)
+}
+
+func (a *adapterCallbacks) OnStreamRequest(streamID int64, request *envoy_sd.DiscoveryRequest) error {
+	return a.callbacks.OnStreamRequest(streamID, &discoveryRequest{request})
+}
+
+func (a *adapterCallbacks) OnStreamResponse(streamID int64, request *envoy_sd.DiscoveryRequest, response *envoy_sd.DiscoveryResponse) {
+	a.callbacks.OnStreamResponse(streamID, &discoveryRequest{request}, &discoveryResponse{response})
+}
+
+type discoveryRequest struct {
+	*envoy_sd.DiscoveryRequest
+}
+
+func (d *discoveryRequest) Metadata() *_struct.Struct {
+	return d.GetNode().GetMetadata()
+}
+
+func (d *discoveryRequest) NodeId() string {
+	return d.GetNode().GetId()
+}
+
+func (d *discoveryRequest) HasErrors() bool {
+	return d.ErrorDetail != nil
+}
+
+var _ xds.DiscoveryRequest = &discoveryRequest{}
+
+type discoveryResponse struct {
+	*envoy_sd.DiscoveryResponse
+}

--- a/pkg/util/xds/v3/callbacks_chain.go
+++ b/pkg/util/xds/v3/callbacks_chain.go
@@ -1,0 +1,71 @@
+package v3
+
+import (
+	"context"
+
+	envoy_sd "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
+	envoy_xds "github.com/envoyproxy/go-control-plane/pkg/server/v3"
+)
+
+type CallbacksChain []envoy_xds.Callbacks
+
+var _ envoy_xds.Callbacks = CallbacksChain{}
+
+// OnStreamOpen is called once an xDS stream is open with a stream ID and the type URL (or "" for ADS).
+// Returning an error will end processing and close the stream. OnStreamClosed will still be called.
+func (chain CallbacksChain) OnStreamOpen(ctx context.Context, streamID int64, typ string) error {
+	for _, cb := range chain {
+		if err := cb.OnStreamOpen(ctx, streamID, typ); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// OnStreamClosed is called immediately prior to closing an xDS stream with a stream ID.
+func (chain CallbacksChain) OnStreamClosed(streamID int64) {
+	for i := len(chain) - 1; i >= 0; i-- {
+		cb := chain[i]
+		cb.OnStreamClosed(streamID)
+	}
+}
+
+// OnStreamRequest is called once a request is received on a stream.
+// Returning an error will end processing and close the stream. OnStreamClosed will still be called.
+func (chain CallbacksChain) OnStreamRequest(streamID int64, req *envoy_sd.DiscoveryRequest) error {
+	for _, cb := range chain {
+		if err := cb.OnStreamRequest(streamID, req); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// OnStreamResponse is called immediately prior to sending a response on a stream.
+func (chain CallbacksChain) OnStreamResponse(streamID int64, req *envoy_sd.DiscoveryRequest, resp *envoy_sd.DiscoveryResponse) {
+	for i := len(chain) - 1; i >= 0; i-- {
+		cb := chain[i]
+		cb.OnStreamResponse(streamID, req, resp)
+	}
+}
+
+// OnFetchRequest is called for each Fetch request. Returning an error will end processing of the
+// request and respond with an error.
+func (chain CallbacksChain) OnFetchRequest(ctx context.Context, req *envoy_sd.DiscoveryRequest) error {
+	for _, cb := range chain {
+		if err := cb.OnFetchRequest(ctx, req); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// OnFetchRequest is called for each Fetch request. Returning an error will end processing of the
+// request and respond with an error.
+// OnFetchResponse is called immediately prior to sending a response.
+func (chain CallbacksChain) OnFetchResponse(req *envoy_sd.DiscoveryRequest, resp *envoy_sd.DiscoveryResponse) {
+	for i := len(chain) - 1; i >= 0; i-- {
+		cb := chain[i]
+		cb.OnFetchResponse(req, resp)
+	}
+}

--- a/pkg/util/xds/v3/callbacks_chain_test.go
+++ b/pkg/util/xds/v3/callbacks_chain_test.go
@@ -1,0 +1,185 @@
+package v3_test
+
+import (
+	"context"
+	"fmt"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	util_xds_v3 "github.com/kumahq/kuma/pkg/util/xds/v3"
+
+	envoy_sd "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
+	envoy_xds "github.com/envoyproxy/go-control-plane/pkg/server/v3"
+)
+
+var _ = Describe("CallbacksChain", func() {
+
+	var first, second CallbacksFuncs
+
+	type methodCall struct {
+		obj    string
+		method string
+		args   []interface{}
+	}
+	var calls []methodCall
+
+	BeforeEach(func() {
+		calls = make([]methodCall, 0)
+		first = CallbacksFuncs{
+			OnStreamOpenFunc: func(ctx context.Context, streamID int64, typ string) error {
+				calls = append(calls, methodCall{"1st", "OnStreamOpen()", []interface{}{ctx, streamID, typ}})
+				return fmt.Errorf("1st: OnStreamOpen()")
+			},
+			OnStreamClosedFunc: func(streamID int64) {
+				calls = append(calls, methodCall{"1st", "OnStreamClosed()", []interface{}{streamID}})
+			},
+			OnStreamRequestFunc: func(streamID int64, req *envoy_sd.DiscoveryRequest) error {
+				calls = append(calls, methodCall{"1st", "OnStreamRequest()", []interface{}{streamID, req}})
+				return fmt.Errorf("1st: OnStreamRequest()")
+			},
+			OnStreamResponseFunc: func(streamID int64, req *envoy_sd.DiscoveryRequest, resp *envoy_sd.DiscoveryResponse) {
+				calls = append(calls, methodCall{"1st", "OnStreamResponse()", []interface{}{streamID, req, resp}})
+			},
+		}
+		second = CallbacksFuncs{
+			OnStreamOpenFunc: func(ctx context.Context, streamID int64, typ string) error {
+				calls = append(calls, methodCall{"2nd", "OnStreamOpen()", []interface{}{ctx, streamID, typ}})
+				return fmt.Errorf("2nd: OnStreamOpen()")
+			},
+			OnStreamClosedFunc: func(streamID int64) {
+				calls = append(calls, methodCall{"2nd", "OnStreamClosed()", []interface{}{streamID}})
+			},
+			OnStreamRequestFunc: func(streamID int64, req *envoy_sd.DiscoveryRequest) error {
+				calls = append(calls, methodCall{"2nd", "OnStreamRequest()", []interface{}{streamID, req}})
+				return fmt.Errorf("2nd: OnStreamRequest()")
+			},
+			OnStreamResponseFunc: func(streamID int64, req *envoy_sd.DiscoveryRequest, resp *envoy_sd.DiscoveryResponse) {
+				calls = append(calls, methodCall{"2nd", "OnStreamResponse()", []interface{}{streamID, req, resp}})
+			},
+		}
+	})
+
+	Describe("OnStreamOpen", func() {
+		It("should be called sequentially and return after first error", func() {
+			// given
+			ctx := context.Background()
+			streamID := int64(1)
+			typ := "xDS"
+			// setup
+			chain := util_xds_v3.CallbacksChain{first, second}
+
+			// when
+			err := chain.OnStreamOpen(ctx, streamID, typ)
+
+			// then
+			Expect(calls).To(Equal([]methodCall{
+				methodCall{"1st", "OnStreamOpen()", []interface{}{ctx, streamID, typ}},
+			}))
+			// and
+			Expect(err).To(MatchError("1st: OnStreamOpen()"))
+		})
+	})
+	Describe("OnStreamClose", func() {
+		It("should be called in reverse order", func() {
+			// given
+			streamID := int64(1)
+			// setup
+			chain := util_xds_v3.CallbacksChain{first, second}
+
+			// when
+			chain.OnStreamClosed(streamID)
+
+			// then
+			Expect(calls).To(Equal([]methodCall{
+				{"2nd", "OnStreamClosed()", []interface{}{streamID}},
+				{"1st", "OnStreamClosed()", []interface{}{streamID}},
+			}))
+		})
+	})
+	Describe("OnStreamRequest", func() {
+		It("should be called sequentially and return after first error", func() {
+			// given
+			streamID := int64(1)
+			req := &envoy_sd.DiscoveryRequest{}
+
+			// setup
+			chain := util_xds_v3.CallbacksChain{first, second}
+
+			// when
+			err := chain.OnStreamRequest(streamID, req)
+
+			// then
+			Expect(calls).To(Equal([]methodCall{
+				{"1st", "OnStreamRequest()", []interface{}{streamID, req}},
+			}))
+			// and
+			Expect(err).To(MatchError("1st: OnStreamRequest()"))
+		})
+	})
+	Describe("OnStreamResponse", func() {
+		It("should be called in reverse order", func() {
+			// given
+			chain := util_xds_v3.CallbacksChain{first, second}
+			streamID := int64(1)
+			req := &envoy_sd.DiscoveryRequest{}
+			resp := &envoy_sd.DiscoveryResponse{}
+
+			// when
+			chain.OnStreamResponse(streamID, req, resp)
+
+			// then
+			Expect(calls).To(Equal([]methodCall{
+				{"2nd", "OnStreamResponse()", []interface{}{streamID, req, resp}},
+				{"1st", "OnStreamResponse()", []interface{}{streamID, req, resp}},
+			}))
+		})
+	})
+})
+
+var _ envoy_xds.Callbacks = CallbacksFuncs{}
+
+type CallbacksFuncs struct {
+	OnStreamOpenFunc   func(context.Context, int64, string) error
+	OnStreamClosedFunc func(int64)
+
+	OnStreamRequestFunc  func(int64, *envoy_sd.DiscoveryRequest) error
+	OnStreamResponseFunc func(int64, *envoy_sd.DiscoveryRequest, *envoy_sd.DiscoveryResponse)
+
+	OnFetchRequestFunc  func(context.Context, *envoy_sd.DiscoveryRequest) error
+	OnFetchResponseFunc func(*envoy_sd.DiscoveryRequest, *envoy_sd.DiscoveryResponse)
+}
+
+func (f CallbacksFuncs) OnStreamOpen(ctx context.Context, streamID int64, typ string) error {
+	if f.OnStreamOpenFunc != nil {
+		return f.OnStreamOpenFunc(ctx, streamID, typ)
+	}
+	return nil
+}
+func (f CallbacksFuncs) OnStreamClosed(streamID int64) {
+	if f.OnStreamClosedFunc != nil {
+		f.OnStreamClosedFunc(streamID)
+	}
+}
+func (f CallbacksFuncs) OnStreamRequest(streamID int64, req *envoy_sd.DiscoveryRequest) error {
+	if f.OnStreamRequestFunc != nil {
+		return f.OnStreamRequestFunc(streamID, req)
+	}
+	return nil
+}
+func (f CallbacksFuncs) OnStreamResponse(streamID int64, req *envoy_sd.DiscoveryRequest, resp *envoy_sd.DiscoveryResponse) {
+	if f.OnStreamResponseFunc != nil {
+		f.OnStreamResponseFunc(streamID, req, resp)
+	}
+}
+func (f CallbacksFuncs) OnFetchRequest(ctx context.Context, req *envoy_sd.DiscoveryRequest) error {
+	if f.OnFetchRequestFunc != nil {
+		return f.OnFetchRequestFunc(ctx, req)
+	}
+	return nil
+}
+func (f CallbacksFuncs) OnFetchResponse(req *envoy_sd.DiscoveryRequest, resp *envoy_sd.DiscoveryResponse) {
+	if f.OnFetchResponseFunc != nil {
+		f.OnFetchResponseFunc(req, resp)
+	}
+}

--- a/pkg/util/xds/v3/control_plane_id_callbacks.go
+++ b/pkg/util/xds/v3/control_plane_id_callbacks.go
@@ -1,0 +1,29 @@
+package v3
+
+import (
+	envoy_core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	envoy_discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
+	envoy_xds "github.com/envoyproxy/go-control-plane/pkg/server/v3"
+)
+
+// controlPlaneIdCallbacks adds Control Plane ID to the DiscoveryResponse
+type controlPlaneIdCallbacks struct {
+	NoopCallbacks
+	id string
+}
+
+var _ envoy_xds.Callbacks = &controlPlaneIdCallbacks{}
+
+func NewControlPlaneIdCallbacks(id string) envoy_xds.Callbacks {
+	return &controlPlaneIdCallbacks{
+		id: id,
+	}
+}
+
+func (c *controlPlaneIdCallbacks) OnStreamResponse(streamID int64, request *envoy_discovery.DiscoveryRequest, response *envoy_discovery.DiscoveryResponse) {
+	if c.id != "" {
+		response.ControlPlane = &envoy_core.ControlPlane{
+			Identifier: c.id,
+		}
+	}
+}

--- a/pkg/util/xds/v3/noop_callbacks.go
+++ b/pkg/util/xds/v3/noop_callbacks.go
@@ -1,0 +1,34 @@
+package v3
+
+import (
+	"context"
+
+	envoy_sd "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
+	envoy_xds "github.com/envoyproxy/go-control-plane/pkg/server/v3"
+)
+
+type NoopCallbacks struct {
+}
+
+func (c *NoopCallbacks) OnFetchRequest(context.Context, *envoy_sd.DiscoveryRequest) error {
+	return nil
+}
+
+func (c *NoopCallbacks) OnFetchResponse(*envoy_sd.DiscoveryRequest, *envoy_sd.DiscoveryResponse) {
+}
+
+func (c *NoopCallbacks) OnStreamOpen(context.Context, int64, string) error {
+	return nil
+}
+
+func (c *NoopCallbacks) OnStreamClosed(int64) {
+}
+
+func (c *NoopCallbacks) OnStreamRequest(int64, *envoy_sd.DiscoveryRequest) error {
+	return nil
+}
+
+func (c *NoopCallbacks) OnStreamResponse(int64, *envoy_sd.DiscoveryRequest, *envoy_sd.DiscoveryResponse) {
+}
+
+var _ envoy_xds.Callbacks = &NoopCallbacks{}

--- a/pkg/util/xds/v3/xds_suite_test.go
+++ b/pkg/util/xds/v3/xds_suite_test.go
@@ -1,0 +1,13 @@
+package v3_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestXds(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Xds V3 Suite")
+}

--- a/pkg/xds/bootstrap/template_v3.go
+++ b/pkg/xds/bootstrap/template_v3.go
@@ -1,0 +1,102 @@
+package bootstrap
+
+const configTemplateV3 string = `
+node:
+  id: {{.Id}}
+  cluster: {{.Service}}
+  metadata:
+{{if .DataplaneTokenPath}}
+    dataplaneTokenPath: {{.DataplaneTokenPath}}
+{{end}}
+{{if .DataplaneResource}}
+    dataplane.resource: '{{.DataplaneResource}}'
+{{end}}
+{{if .AdminPort }}
+    dataplane.admin.port: "{{ .AdminPort }}"
+{{ end }}
+    version:
+      kumaDp:
+        version: "{{ .KumaDpVersion }}"
+        gitTag: "{{ .KumaDpGitTag }}"
+        gitCommit: "{{ .KumaDpGitCommit }}"
+        buildDate: "{{ .KumaDpBuildDate }}"
+      envoy:
+        version: "{{ .EnvoyVersion }}"
+        build: "{{ .EnvoyBuild }}"
+
+{{if .AdminPort }}
+admin:
+  access_log_path: {{ .AdminAccessLogPath }}
+  address:
+    socket_address:
+      protocol: TCP
+      address: {{ .AdminAddress }}
+      port_value: {{ .AdminPort }}
+{{ end }}
+
+stats_config:
+  stats_tags:
+  - tag_name: name
+    regex: '^grpc\.((.+)\.)'
+  - tag_name: status
+    regex: '^grpc.*streams_closed(_([0-9]+))'
+  - tag_name: kafka_name
+    regex: '^kafka(\.(\S*[0-9]))\.'
+  - tag_name: kafka_type
+    regex: '^kafka\..*\.(.*)'
+  - tag_name: worker
+    regex: '(worker_([0-9]+)\.)'
+  - tag_name: listener
+    regex: '((.+?)\.)rbac\.'
+
+dynamic_resources:
+  lds_config:
+    ads: {}
+    resourceApiVersion: V3 
+  cds_config:
+    ads: {}
+    resourceApiVersion: V3
+  ads_config:
+    api_type: GRPC
+    transport_api_version: V3
+    timeout: {{ .XdsConnectTimeout }}
+    grpc_services:
+    - googleGrpc:
+{{ if .DataplaneTokenPath }}
+        callCredentials:
+        - fromPlugin:
+            name: envoy.grpc_credentials.file_based_metadata
+            typedConfig:
+              '@type': type.googleapis.com/envoy.config.grpc_credential.v3.FileBasedMetadataConfig
+              secretData:
+                filename: {{ .DataplaneTokenPath }}
+        credentialsFactoryName: envoy.grpc_credentials.file_based_metadata
+{{ end }}
+{{ if .CertBytes}}
+        channelCredentials:
+          sslCredentials:
+            rootCerts:
+              inlineBytes: {{ .CertBytes }}
+{{ end }}
+        statPrefix: ads
+        targetUri: {{ .XdsHost }}:{{ .XdsPort }}
+static_resources:
+  clusters:
+  - name: access_log_sink
+    connect_timeout: {{ .XdsConnectTimeout }}
+    type: STATIC
+    lb_policy: ROUND_ROBIN
+    http2_protocol_options: {}
+    upstream_connection_options:
+      # configure a TCP keep-alive to detect and reconnect to the admin
+      # server in the event of a TCP socket half open connection
+      tcp_keepalive: {}
+    load_assignment:
+      cluster_name: access_log_sink
+      endpoints:
+      - lb_endpoints:
+        - endpoint:
+            address:
+              pipe:
+                path: {{ .AccessLogPipe }}
+`

--- a/pkg/xds/envoy/clusters/v3/client_side_mtls_configurer_test.go
+++ b/pkg/xds/envoy/clusters/v3/client_side_mtls_configurer_test.go
@@ -99,6 +99,8 @@ var _ = Describe("EdsClusterConfigurer", func() {
                                     inlineBytes: Q0VSVElGSUNBVEU=
                               statPrefix: sds_mesh_ca
                               targetUri: kuma-control-plane:5677
+                          transportApiVersion: V3
+                        resourceApiVersion: V3
                   tlsCertificateSdsSecretConfigs:
                   - name: identity_cert
                     sdsConfig:
@@ -112,6 +114,8 @@ var _ = Describe("EdsClusterConfigurer", func() {
                                   inlineBytes: Q0VSVElGSUNBVEU=
                             statPrefix: sds_identity_cert
                             targetUri: kuma-control-plane:5677
+                        transportApiVersion: V3
+                      resourceApiVersion: V3
             type: EDS`,
 		}),
 		Entry("cluster with many different tag sets", testCase{
@@ -185,6 +189,8 @@ var _ = Describe("EdsClusterConfigurer", func() {
                                       inlineBytes: Q0VSVElGSUNBVEU=
                                 statPrefix: sds_mesh_ca
                                 targetUri: kuma-control-plane:5677
+                            transportApiVersion: V3
+                          resourceApiVersion: V3
                     tlsCertificateSdsSecretConfigs:
                     - name: identity_cert
                       sdsConfig:
@@ -198,6 +204,8 @@ var _ = Describe("EdsClusterConfigurer", func() {
                                     inlineBytes: Q0VSVElGSUNBVEU=
                               statPrefix: sds_identity_cert
                               targetUri: kuma-control-plane:5677
+                          transportApiVersion: V3
+                        resourceApiVersion: V3
                   sni: backend{cluster=1,mesh=default}
             - match:
                 cluster: "2"
@@ -224,6 +232,8 @@ var _ = Describe("EdsClusterConfigurer", func() {
                                       inlineBytes: Q0VSVElGSUNBVEU=
                                 statPrefix: sds_mesh_ca
                                 targetUri: kuma-control-plane:5677
+                            transportApiVersion: V3
+                          resourceApiVersion: V3
                     tlsCertificateSdsSecretConfigs:
                     - name: identity_cert
                       sdsConfig:
@@ -237,6 +247,8 @@ var _ = Describe("EdsClusterConfigurer", func() {
                                     inlineBytes: Q0VSVElGSUNBVEU=
                               statPrefix: sds_identity_cert
                               targetUri: kuma-control-plane:5677
+                          transportApiVersion: V3
+                        resourceApiVersion: V3
                   sni: backend{cluster=2,mesh=default}
             type: EDS`,
 		}),
@@ -314,6 +326,8 @@ var _ = Describe("EdsClusterConfigurer", func() {
                               credentialsFactoryName: envoy.grpc_credentials.file_based_metadata
                               statPrefix: sds_mesh_ca
                               targetUri: kuma-control-plane:5677
+                          transportApiVersion: V3
+                        resourceApiVersion: V3
                   tlsCertificateSdsSecretConfigs:
                   - name: identity_cert
                     sdsConfig:
@@ -335,6 +349,8 @@ var _ = Describe("EdsClusterConfigurer", func() {
                             credentialsFactoryName: envoy.grpc_credentials.file_based_metadata
                             statPrefix: sds_identity_cert
                             targetUri: kuma-control-plane:5677
+                        transportApiVersion: V3
+                      resourceApiVersion: V3
                 sni: backend{mesh=default,version=v1}
             type: EDS`,
 		}),

--- a/pkg/xds/envoy/clusters/v3/http2_configurer.go
+++ b/pkg/xds/envoy/clusters/v3/http2_configurer.go
@@ -3,10 +3,6 @@ package clusters
 import (
 	envoy_cluster "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
 	envoy_core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
-	envoy_upstream_http "github.com/envoyproxy/go-control-plane/envoy/extensions/upstreams/http/v3"
-	"github.com/golang/protobuf/ptypes/any"
-
-	"github.com/kumahq/kuma/pkg/util/proto"
 )
 
 type Http2Configurer struct {
@@ -15,22 +11,26 @@ type Http2Configurer struct {
 var _ ClusterConfigurer = &Http2Configurer{}
 
 func (p *Http2Configurer) Configure(c *envoy_cluster.Cluster) error {
-	options := &envoy_upstream_http.HttpProtocolOptions{
-		UpstreamProtocolOptions: &envoy_upstream_http.HttpProtocolOptions_ExplicitHttpConfig_{
-			ExplicitHttpConfig: &envoy_upstream_http.HttpProtocolOptions_ExplicitHttpConfig{
-				ProtocolConfig: &envoy_upstream_http.HttpProtocolOptions_ExplicitHttpConfig_Http2ProtocolOptions{
-					Http2ProtocolOptions: &envoy_core.Http2ProtocolOptions{},
-				},
-			},
-		},
-	}
+	// nolint:staticcheck ignore this is deprecated in the newest Envoy proto in master below code does not work with previous envoy
+	c.Http2ProtocolOptions = &envoy_core.Http2ProtocolOptions{}
 
-	pbst, err := proto.MarshalAnyDeterministic(options)
-	if err != nil {
-		return err
-	}
-	c.TypedExtensionProtocolOptions = map[string]*any.Any{
-		"envoy.extensions.upstreams.http.v3.HttpProtocolOptions": pbst,
-	}
+	// todo(jakubdyszkiewicz) switch to above code with Envoy 1.17+
+	// options := &envoy_upstream_http.HttpProtocolOptions{
+	// 	UpstreamProtocolOptions: &envoy_upstream_http.HttpProtocolOptions_ExplicitHttpConfig_{
+	// 		ExplicitHttpConfig: &envoy_upstream_http.HttpProtocolOptions_ExplicitHttpConfig{
+	// 			ProtocolConfig: &envoy_upstream_http.HttpProtocolOptions_ExplicitHttpConfig_Http2ProtocolOptions{
+	// 				Http2ProtocolOptions: &envoy_core.Http2ProtocolOptions{},
+	// 			},
+	// 		},
+	// 	},
+	// }
+	//
+	// pbst, err := proto.MarshalAnyDeterministic(options)
+	// if err != nil {
+	// 	return err
+	// }
+	// c.TypedExtensionProtocolOptions = map[string]*any.Any{
+	// 	"envoy.extensions.upstreams.http.v3.HttpProtocolOptions": pbst,
+	// }
 	return nil
 }

--- a/pkg/xds/envoy/clusters/v3/http2_configurer_test.go
+++ b/pkg/xds/envoy/clusters/v3/http2_configurer_test.go
@@ -13,12 +13,7 @@ var _ = Describe("Http2Configurer", func() {
 
 	It("should generate proper Envoy config", func() {
 		// given
-		expected := `
-        typedExtensionProtocolOptions:
-          envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
-            '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
-            explicitHttpConfig:
-              http2ProtocolOptions: {}`
+		expected := `http2ProtocolOptions: {}`
 
 		// when
 		cluster, err := clusters.NewClusterBuilder(envoy.APIV3).

--- a/pkg/xds/envoy/listeners/v3/server_mtls_configurer_test.go
+++ b/pkg/xds/envoy/listeners/v3/server_mtls_configurer_test.go
@@ -114,6 +114,8 @@ var _ = Describe("ServerMtlsConfigurer", func() {
                                       inlineBytes: Q0VSVElGSUNBVEU=
                                 statPrefix: sds_mesh_ca
                                 targetUri: kuma-control-plane:5677
+                            transportApiVersion: V3
+                          resourceApiVersion: V3
                     tlsCertificateSdsSecretConfigs:
                     - name: identity_cert
                       sdsConfig:
@@ -127,6 +129,8 @@ var _ = Describe("ServerMtlsConfigurer", func() {
                                     inlineBytes: Q0VSVElGSUNBVEU=
                               statPrefix: sds_identity_cert
                               targetUri: kuma-control-plane:5677
+                          transportApiVersion: V3
+                        resourceApiVersion: V3
                   requireClientCertificate: true
             name: inbound:192.168.0.1:8080
             trafficDirection: INBOUND
@@ -209,6 +213,8 @@ var _ = Describe("ServerMtlsConfigurer", func() {
                                 credentialsFactoryName: envoy.grpc_credentials.file_based_metadata
                                 statPrefix: sds_mesh_ca
                                 targetUri: kuma-control-plane:5677
+                            transportApiVersion: V3
+                          resourceApiVersion: V3
                     tlsCertificateSdsSecretConfigs:
                     - name: identity_cert
                       sdsConfig:
@@ -230,6 +236,8 @@ var _ = Describe("ServerMtlsConfigurer", func() {
                               credentialsFactoryName: envoy.grpc_credentials.file_based_metadata
                               statPrefix: sds_identity_cert
                               targetUri: kuma-control-plane:5677
+                          transportApiVersion: V3
+                        resourceApiVersion: V3
                   requireClientCertificate: true
             name: inbound:192.168.0.1:8080
             trafficDirection: INBOUND

--- a/pkg/xds/envoy/secrets/v3/ca_secret.go
+++ b/pkg/xds/envoy/secrets/v3/ca_secret.go
@@ -1,4 +1,4 @@
-package v2
+package v3
 
 import (
 	"bytes"

--- a/pkg/xds/envoy/secrets/v3/ca_secret.go
+++ b/pkg/xds/envoy/secrets/v3/ca_secret.go
@@ -1,0 +1,26 @@
+package v2
+
+import (
+	"bytes"
+
+	envoy_core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	envoy_auth "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
+
+	core_xds "github.com/kumahq/kuma/pkg/core/xds"
+	"github.com/kumahq/kuma/pkg/xds/envoy/tls"
+)
+
+func CreateCaSecret(secret *core_xds.CaSecret) *envoy_auth.Secret {
+	return &envoy_auth.Secret{
+		Name: tls.MeshCaResource,
+		Type: &envoy_auth.Secret_ValidationContext{
+			ValidationContext: &envoy_auth.CertificateValidationContext{
+				TrustedCa: &envoy_core.DataSource{
+					Specifier: &envoy_core.DataSource_InlineBytes{
+						InlineBytes: bytes.Join(secret.PemCerts, []byte("\n")),
+					},
+				},
+			},
+		},
+	}
+}

--- a/pkg/xds/envoy/secrets/v3/identity_secret.go
+++ b/pkg/xds/envoy/secrets/v3/identity_secret.go
@@ -1,4 +1,4 @@
-package v2
+package v3
 
 import (
 	"bytes"

--- a/pkg/xds/envoy/secrets/v3/identity_secret.go
+++ b/pkg/xds/envoy/secrets/v3/identity_secret.go
@@ -1,0 +1,31 @@
+package v2
+
+import (
+	"bytes"
+
+	envoy_core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	envoy_auth "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
+
+	core_xds "github.com/kumahq/kuma/pkg/core/xds"
+	"github.com/kumahq/kuma/pkg/xds/envoy/tls"
+)
+
+func CreateIdentitySecret(secret *core_xds.IdentitySecret) *envoy_auth.Secret {
+	return &envoy_auth.Secret{
+		Name: tls.IdentityCertResource,
+		Type: &envoy_auth.Secret_TlsCertificate{
+			TlsCertificate: &envoy_auth.TlsCertificate{
+				CertificateChain: &envoy_core.DataSource{
+					Specifier: &envoy_core.DataSource_InlineBytes{
+						InlineBytes: bytes.Join(secret.PemCerts, []byte("\n")),
+					},
+				},
+				PrivateKey: &envoy_core.DataSource{
+					Specifier: &envoy_core.DataSource_InlineBytes{
+						InlineBytes: secret.PemKey,
+					},
+				},
+			},
+		},
+	}
+}

--- a/pkg/xds/envoy/tls/v3/tls.go
+++ b/pkg/xds/envoy/tls/v3/tls.go
@@ -138,9 +138,11 @@ func sdsSecretConfig(context xds_context.Context, name string, metadata *core_xd
 	return &envoy_tls.SdsSecretConfig{
 		Name: name,
 		SdsConfig: &envoy_core.ConfigSource{
+			ResourceApiVersion: envoy_core.ApiVersion_V3,
 			ConfigSourceSpecifier: &envoy_core.ConfigSource_ApiConfigSource{
 				ApiConfigSource: &envoy_core.ApiConfigSource{
-					ApiType: envoy_core.ApiConfigSource_GRPC,
+					ApiType:             envoy_core.ApiConfigSource_GRPC,
+					TransportApiVersion: envoy_core.ApiVersion_V3,
 					GrpcServices: []*envoy_core.GrpcService{
 						{
 							TargetSpecifier: &envoy_core.GrpcService_GoogleGrpc_{

--- a/pkg/xds/envoy/tls/v3/tls_test.go
+++ b/pkg/xds/envoy/tls/v3/tls_test.go
@@ -106,6 +106,8 @@ var _ = Describe("CreateDownstreamTlsContext()", func() {
                                     inlineBytes: Q0VSVElGSUNBVEU=
                               statPrefix: sds_mesh_ca
                               targetUri: kuma-control-plane:5677
+                          transportApiVersion: V3
+                        resourceApiVersion: V3
                   tlsCertificateSdsSecretConfigs:
                   - name: identity_cert
                     sdsConfig:
@@ -119,6 +121,8 @@ var _ = Describe("CreateDownstreamTlsContext()", func() {
                                   inlineBytes: Q0VSVElGSUNBVEU=
                             statPrefix: sds_identity_cert
                             targetUri: kuma-control-plane:5677
+                        transportApiVersion: V3
+                      resourceApiVersion: V3
                 requireClientCertificate: true
 `,
 			}),
@@ -143,6 +147,8 @@ var _ = Describe("CreateDownstreamTlsContext()", func() {
                                     inlineBytes: Q0VSVElGSUNBVEU=
                               statPrefix: sds_mesh_ca
                               targetUri: kuma-control-plane:5677
+                          transportApiVersion: V3
+                        resourceApiVersion: V3
                   tlsCertificateSdsSecretConfigs:
                   - name: identity_cert
                     sdsConfig:
@@ -156,6 +162,8 @@ var _ = Describe("CreateDownstreamTlsContext()", func() {
                                   inlineBytes: Q0VSVElGSUNBVEU=
                             statPrefix: sds_identity_cert
                             targetUri: kuma-control-plane:5677
+                        transportApiVersion: V3
+                      resourceApiVersion: V3
                 requireClientCertificate: true
 `,
 			}),
@@ -191,6 +199,8 @@ var _ = Describe("CreateDownstreamTlsContext()", func() {
                               credentialsFactoryName: envoy.grpc_credentials.file_based_metadata
                               statPrefix: sds_mesh_ca
                               targetUri: kuma-control-plane:5677
+                          transportApiVersion: V3
+                        resourceApiVersion: V3
                   tlsCertificateSdsSecretConfigs:
                   - name: identity_cert
                     sdsConfig:
@@ -212,6 +222,8 @@ var _ = Describe("CreateDownstreamTlsContext()", func() {
                             credentialsFactoryName: envoy.grpc_credentials.file_based_metadata
                             statPrefix: sds_identity_cert
                             targetUri: kuma-control-plane:5677
+                        transportApiVersion: V3
+                      resourceApiVersion: V3
                 requireClientCertificate: true
 `,
 			}),
@@ -312,6 +324,8 @@ var _ = Describe("CreateUpstreamTlsContext()", func() {
                                     inlineBytes: Q0VSVElGSUNBVEU=
                               statPrefix: sds_mesh_ca
                               targetUri: kuma-control-plane:5677
+                          transportApiVersion: V3
+                        resourceApiVersion: V3
                   tlsCertificateSdsSecretConfigs:
                   - name: identity_cert
                     sdsConfig:
@@ -325,6 +339,8 @@ var _ = Describe("CreateUpstreamTlsContext()", func() {
                                   inlineBytes: Q0VSVElGSUNBVEU=
                             statPrefix: sds_identity_cert
                             targetUri: kuma-control-plane:5677
+                        transportApiVersion: V3
+                      resourceApiVersion: V3
 `,
 			}),
 			Entry("dataplane without a token", testCase{
@@ -349,6 +365,8 @@ var _ = Describe("CreateUpstreamTlsContext()", func() {
                                     inlineBytes: Q0VSVElGSUNBVEU=
                               statPrefix: sds_mesh_ca
                               targetUri: kuma-control-plane:5677
+                          transportApiVersion: V3
+                        resourceApiVersion: V3
                   tlsCertificateSdsSecretConfigs:
                   - name: identity_cert
                     sdsConfig:
@@ -362,6 +380,8 @@ var _ = Describe("CreateUpstreamTlsContext()", func() {
                                   inlineBytes: Q0VSVElGSUNBVEU=
                             statPrefix: sds_identity_cert
                             targetUri: kuma-control-plane:5677
+                        transportApiVersion: V3
+                      resourceApiVersion: V3
 `,
 			}),
 			Entry("dataplane with a token", testCase{
@@ -396,6 +416,8 @@ var _ = Describe("CreateUpstreamTlsContext()", func() {
                               credentialsFactoryName: envoy.grpc_credentials.file_based_metadata
                               statPrefix: sds_mesh_ca
                               targetUri: kuma-control-plane:5677
+                          transportApiVersion: V3
+                        resourceApiVersion: V3
                   tlsCertificateSdsSecretConfigs:
                   - name: identity_cert
                     sdsConfig:
@@ -417,6 +439,8 @@ var _ = Describe("CreateUpstreamTlsContext()", func() {
                             credentialsFactoryName: envoy.grpc_credentials.file_based_metadata
                             statPrefix: sds_identity_cert
                             targetUri: kuma-control-plane:5677
+                        transportApiVersion: V3
+                      resourceApiVersion: V3
 `,
 			}),
 		)

--- a/pkg/xds/server/components.go
+++ b/pkg/xds/server/components.go
@@ -14,6 +14,7 @@ import (
 	xds_context "github.com/kumahq/kuma/pkg/xds/context"
 	xds_metrics "github.com/kumahq/kuma/pkg/xds/metrics"
 	v2 "github.com/kumahq/kuma/pkg/xds/server/v2"
+	v3 "github.com/kumahq/kuma/pkg/xds/server/v3"
 
 	core_runtime "github.com/kumahq/kuma/pkg/core/runtime"
 )
@@ -67,6 +68,9 @@ func RegisterXDS(rt core_runtime.Runtime, server *grpc.Server) error {
 
 	if err := v2.RegisterXDS(statsCallbacks, xdsMetrics, meshSnapshotCache, envoyCpCtx, rt, server); err != nil {
 		return errors.Wrap(err, "could not register V2 XDS")
+	}
+	if err := v3.RegisterXDS(statsCallbacks, xdsMetrics, meshSnapshotCache, envoyCpCtx, rt, server); err != nil {
+		return errors.Wrap(err, "could not register V3 XDS")
 	}
 	return nil
 }

--- a/pkg/xds/server/v3/components.go
+++ b/pkg/xds/server/v3/components.go
@@ -1,0 +1,107 @@
+package v3
+
+import (
+	"context"
+	"time"
+
+	envoy_service_discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
+	envoy_server "github.com/envoyproxy/go-control-plane/pkg/server/v3"
+	"google.golang.org/grpc"
+
+	"github.com/kumahq/kuma/pkg/core"
+	core_runtime "github.com/kumahq/kuma/pkg/core/runtime"
+	v3 "github.com/kumahq/kuma/pkg/core/xds/v3"
+	util_xds "github.com/kumahq/kuma/pkg/util/xds"
+	util_xds_v3 "github.com/kumahq/kuma/pkg/util/xds/v3"
+	"github.com/kumahq/kuma/pkg/xds/auth"
+	auth_components "github.com/kumahq/kuma/pkg/xds/auth/components"
+	"github.com/kumahq/kuma/pkg/xds/cache/mesh"
+	xds_context "github.com/kumahq/kuma/pkg/xds/context"
+	envoy_common "github.com/kumahq/kuma/pkg/xds/envoy"
+	xds_metrics "github.com/kumahq/kuma/pkg/xds/metrics"
+	xds_callbacks "github.com/kumahq/kuma/pkg/xds/server/callbacks"
+	xds_sync "github.com/kumahq/kuma/pkg/xds/sync"
+	xds_template "github.com/kumahq/kuma/pkg/xds/template"
+)
+
+var xdsServerLog = core.Log.WithName("xds-server")
+
+func RegisterXDS(
+	statsCallbacks util_xds.Callbacks,
+	xdsMetrics *xds_metrics.Metrics,
+	meshSnapshotCache *mesh.Cache,
+	envoyCpCtx *xds_context.ControlPlaneContext,
+	rt core_runtime.Runtime,
+	server *grpc.Server,
+) error {
+	xdsContext := v3.NewXdsContext()
+
+	authenticator, err := auth_components.DefaultAuthenticator(rt)
+	if err != nil {
+		return err
+	}
+	authCallbacks := auth.NewCallbacks(rt.ResourceManager(), authenticator)
+
+	metadataTracker := xds_callbacks.NewDataplaneMetadataTracker()
+	connectionInfoTracker := xds_callbacks.NewConnectionInfoTracker()
+	reconciler := DefaultReconciler(rt, xdsContext)
+	ingressReconciler := DefaultIngressReconciler(rt, xdsContext)
+	watchdogFactory, err := xds_sync.DefaultDataplaneWatchdogFactory(rt, metadataTracker, connectionInfoTracker, reconciler, ingressReconciler, xdsMetrics, meshSnapshotCache, envoyCpCtx, envoy_common.APIV3)
+	if err != nil {
+		return err
+	}
+
+	callbacks := util_xds_v3.CallbacksChain{
+		util_xds_v3.NewControlPlaneIdCallbacks(rt.GetInstanceId()),
+		util_xds_v3.AdaptCallbacks(statsCallbacks),
+		util_xds_v3.AdaptCallbacks(connectionInfoTracker),
+		util_xds_v3.AdaptCallbacks(authCallbacks),
+		util_xds_v3.AdaptCallbacks(xds_callbacks.NewDataplaneSyncTracker(watchdogFactory.New)),
+		util_xds_v3.AdaptCallbacks(metadataTracker),
+		util_xds_v3.AdaptCallbacks(xds_callbacks.NewDataplaneLifecycle(rt.ResourceManager())),
+		util_xds_v3.AdaptCallbacks(DefaultDataplaneStatusTracker(rt)),
+		newResourceWarmingForcer(xdsContext.Cache(), xdsContext.Hasher()),
+	}
+
+	srv := envoy_server.NewServer(context.Background(), xdsContext.Cache(), callbacks)
+
+	xdsServerLog.Info("registering Aggregated Discovery Service V3 in Dataplane Server")
+	envoy_service_discovery.RegisterAggregatedDiscoveryServiceServer(server, srv)
+	return nil
+}
+
+func DefaultReconciler(rt core_runtime.Runtime, xdsContext v3.XdsContext) xds_sync.SnapshotReconciler {
+	return &reconciler{
+		&templateSnapshotGenerator{
+			ProxyTemplateResolver: &xds_template.SimpleProxyTemplateResolver{
+				ReadOnlyResourceManager: rt.ReadOnlyResourceManager(),
+				DefaultProxyTemplate:    xds_template.DefaultProxyTemplate,
+			},
+		},
+		&simpleSnapshotCacher{xdsContext.Hasher(), xdsContext.Cache()},
+	}
+}
+
+func DefaultIngressReconciler(rt core_runtime.Runtime, xdsContext v3.XdsContext) xds_sync.SnapshotReconciler {
+	return &reconciler{
+		generator: &templateSnapshotGenerator{
+			ProxyTemplateResolver: &xds_template.StaticProxyTemplateResolver{
+				Template: xds_template.IngressProxyTemplate,
+			},
+		},
+		cacher: &simpleSnapshotCacher{xdsContext.Hasher(), xdsContext.Cache()},
+	}
+}
+
+func DefaultDataplaneStatusTracker(rt core_runtime.Runtime) xds_callbacks.DataplaneStatusTracker {
+	return xds_callbacks.NewDataplaneStatusTracker(rt, func(accessor xds_callbacks.SubscriptionStatusAccessor) xds_callbacks.DataplaneInsightSink {
+		return xds_callbacks.NewDataplaneInsightSink(
+			accessor,
+			func() *time.Ticker {
+				return time.NewTicker(rt.Config().XdsServer.DataplaneStatusFlushInterval)
+			},
+			rt.Config().XdsServer.DataplaneStatusFlushInterval/10,
+			xds_callbacks.NewDataplaneInsightStore(rt.ResourceManager()),
+		)
+	})
+}

--- a/pkg/xds/server/v3/reconcile.go
+++ b/pkg/xds/server/v3/reconcile.go
@@ -1,0 +1,144 @@
+package v3
+
+import (
+	"github.com/golang/protobuf/proto"
+
+	"github.com/kumahq/kuma/pkg/core"
+	model "github.com/kumahq/kuma/pkg/core/xds"
+	xds_context "github.com/kumahq/kuma/pkg/xds/context"
+	"github.com/kumahq/kuma/pkg/xds/generator"
+	xds_sync "github.com/kumahq/kuma/pkg/xds/sync"
+	xds_template "github.com/kumahq/kuma/pkg/xds/template"
+
+	envoy_core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	envoy_types "github.com/envoyproxy/go-control-plane/pkg/cache/types"
+	envoy_cache "github.com/envoyproxy/go-control-plane/pkg/cache/v3"
+	envoy_resource "github.com/envoyproxy/go-control-plane/pkg/resource/v3"
+)
+
+var (
+	reconcileLog = core.Log.WithName("xds-server").WithName("reconcile")
+)
+
+var _ xds_sync.SnapshotReconciler = &reconciler{}
+
+type reconciler struct {
+	generator snapshotGenerator
+	cacher    snapshotCacher
+}
+
+func (r *reconciler) Clear(proxyId *model.ProxyId) error {
+	// cache.Clear() operation does not push a new (empty) configuration to Envoy.
+	// That is why instead of calling cache.Clear() we set configuration to an empty Snapshot.
+	// This fake value will be removed from cache on Envoy disconnect.
+	return r.cacher.Cache(&envoy_core.Node{Id: proxyId.String()}, envoy_cache.Snapshot{})
+}
+
+func (r *reconciler) Reconcile(ctx xds_context.Context, proxy *model.Proxy) error {
+	node := &envoy_core.Node{Id: proxy.Id.String()}
+	snapshot, err := r.generator.GenerateSnapshot(ctx, proxy)
+	if err != nil {
+		reconcileLog.Error(err, "failed to generate a snapshot", "node", node, "proxy", proxy)
+		return err
+	}
+	if err := snapshot.Consistent(); err != nil {
+		reconcileLog.Error(err, "inconsistent snapshot", "snapshot", snapshot, "proxy", proxy)
+	}
+	// to avoid assigning a new version every time,
+	// compare with the previous snapshot and reuse its version whenever possible,
+	// fallback to UUID otherwise
+	previous, err := r.cacher.Get(node)
+	if err != nil {
+		previous = envoy_cache.Snapshot{}
+	}
+	snapshot = r.autoVersion(previous, snapshot)
+	if err := r.cacher.Cache(node, snapshot); err != nil {
+		reconcileLog.Error(err, "failed to store snapshot", "snapshot", snapshot, "proxy", proxy)
+	}
+	return nil
+}
+
+func (r *reconciler) autoVersion(old envoy_cache.Snapshot, new envoy_cache.Snapshot) envoy_cache.Snapshot {
+	new.Resources[envoy_types.Listener] = reuseVersion(old.Resources[envoy_types.Listener], new.Resources[envoy_types.Listener])
+	new.Resources[envoy_types.Route] = reuseVersion(old.Resources[envoy_types.Route], new.Resources[envoy_types.Route])
+	new.Resources[envoy_types.Cluster] = reuseVersion(old.Resources[envoy_types.Cluster], new.Resources[envoy_types.Cluster])
+	new.Resources[envoy_types.Endpoint] = reuseVersion(old.Resources[envoy_types.Endpoint], new.Resources[envoy_types.Endpoint])
+	new.Resources[envoy_types.Secret] = reuseVersion(old.Resources[envoy_types.Secret], new.Resources[envoy_types.Secret])
+	return new
+}
+
+func reuseVersion(old, new envoy_cache.Resources) envoy_cache.Resources {
+	new.Version = old.Version
+	if !equalSnapshots(old.Items, new.Items) {
+		new.Version = core.NewUUID()
+	}
+	return new
+}
+
+func equalSnapshots(old, new map[string]envoy_types.Resource) bool {
+	if len(new) != len(old) {
+		return false
+	}
+	for key, newValue := range new {
+		if oldValue, hasOldValue := old[key]; !hasOldValue || !proto.Equal(newValue, oldValue) {
+			return false
+		}
+	}
+	return true
+}
+
+type snapshotGenerator interface {
+	GenerateSnapshot(ctx xds_context.Context, proxy *model.Proxy) (envoy_cache.Snapshot, error)
+}
+
+type templateSnapshotGenerator struct {
+	ProxyTemplateResolver xds_template.ProxyTemplateResolver
+}
+
+func (s *templateSnapshotGenerator) GenerateSnapshot(ctx xds_context.Context, proxy *model.Proxy) (envoy_cache.Snapshot, error) {
+	template := s.ProxyTemplateResolver.GetTemplate(proxy)
+
+	gen := generator.ProxyTemplateGenerator{ProxyTemplate: template}
+
+	rs, err := gen.Generate(ctx, proxy)
+	if err != nil {
+		reconcileLog.Error(err, "failed to generate a snapshot", "proxy", proxy, "template", template)
+		return envoy_cache.Snapshot{}, err
+	}
+
+	version := "" // empty value is a sign to other components to generate the version automatically
+	out := envoy_cache.Snapshot{
+		Resources: [envoy_types.UnknownType]envoy_cache.Resources{
+			envoy_types.Endpoint: envoy_cache.NewResources(version, rs.ListOf(envoy_resource.EndpointType).Payloads()),
+			envoy_types.Cluster:  envoy_cache.NewResources(version, rs.ListOf(envoy_resource.ClusterType).Payloads()),
+			envoy_types.Route:    envoy_cache.NewResources(version, rs.ListOf(envoy_resource.RouteType).Payloads()),
+			envoy_types.Listener: envoy_cache.NewResources(version, rs.ListOf(envoy_resource.ListenerType).Payloads()),
+			envoy_types.Secret:   envoy_cache.NewResources(version, rs.ListOf(envoy_resource.SecretType).Payloads()),
+		},
+	}
+
+	return out, nil
+}
+
+type snapshotCacher interface {
+	Get(*envoy_core.Node) (envoy_cache.Snapshot, error)
+	Cache(*envoy_core.Node, envoy_cache.Snapshot) error
+	Clear(*envoy_core.Node)
+}
+
+type simpleSnapshotCacher struct {
+	hasher envoy_cache.NodeHash
+	store  envoy_cache.SnapshotCache
+}
+
+func (s *simpleSnapshotCacher) Get(node *envoy_core.Node) (envoy_cache.Snapshot, error) {
+	return s.store.GetSnapshot(s.hasher.ID(node))
+}
+
+func (s *simpleSnapshotCacher) Cache(node *envoy_core.Node, snapshot envoy_cache.Snapshot) error {
+	return s.store.SetSnapshot(s.hasher.ID(node), snapshot)
+}
+
+func (s *simpleSnapshotCacher) Clear(node *envoy_core.Node) {
+	s.store.ClearSnapshot(s.hasher.ID(node))
+}

--- a/pkg/xds/server/v3/reconcile_test.go
+++ b/pkg/xds/server/v3/reconcile_test.go
@@ -1,0 +1,176 @@
+package v3
+
+import (
+	"fmt"
+	"sync/atomic"
+
+	envoy "github.com/envoyproxy/go-control-plane/envoy/api/v2"
+	envoy_auth "github.com/envoyproxy/go-control-plane/envoy/api/v2/auth"
+	envoy_types "github.com/envoyproxy/go-control-plane/pkg/cache/types"
+	envoy_cache "github.com/envoyproxy/go-control-plane/pkg/cache/v3"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
+	"github.com/kumahq/kuma/pkg/core"
+	mesh_core "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
+	xds_model "github.com/kumahq/kuma/pkg/core/xds"
+	core_xds_v3 "github.com/kumahq/kuma/pkg/core/xds/v3"
+	test_model "github.com/kumahq/kuma/pkg/test/resources/model"
+	xds_context "github.com/kumahq/kuma/pkg/xds/context"
+)
+
+var _ = Describe("Reconcile", func() {
+	Describe("reconciler", func() {
+
+		var backupNewUUID func() string
+
+		BeforeEach(func() {
+			backupNewUUID = core.NewUUID
+		})
+		AfterEach(func() {
+			core.NewUUID = backupNewUUID
+		})
+
+		var serial uint64
+
+		BeforeEach(func() {
+			core.NewUUID = func() string {
+				uuid := atomic.AddUint64(&serial, 1)
+				return fmt.Sprintf("v%d", uuid)
+			}
+		})
+
+		var xdsContext core_xds_v3.XdsContext
+
+		BeforeEach(func() {
+			xdsContext = core_xds_v3.NewXdsContext()
+		})
+
+		snapshot := envoy_cache.Snapshot{
+			Resources: [envoy_types.UnknownType]envoy_cache.Resources{
+				envoy_types.Listener: {
+					Items: map[string]envoy_types.Resource{
+						"listener": &envoy.Listener{},
+					},
+				},
+				envoy_types.Route: {
+					Items: map[string]envoy_types.Resource{
+						"route": &envoy.RouteConfiguration{},
+					},
+				},
+				envoy_types.Cluster: {
+					Items: map[string]envoy_types.Resource{
+						"cluster": &envoy.Cluster{},
+					},
+				},
+				envoy_types.Endpoint: {
+					Items: map[string]envoy_types.Resource{
+						"endpoint": &envoy.ClusterLoadAssignment{},
+					},
+				},
+				envoy_types.Secret: {
+					Items: map[string]envoy_types.Resource{
+						"secret": &envoy_auth.Secret{},
+					},
+				},
+			},
+		}
+
+		It("should generate a Snaphot per Envoy Node", func() {
+			// given
+			snapshots := make(chan envoy_cache.Snapshot, 3)
+			snapshots <- snapshot               // initial Dataplane configuration
+			snapshots <- snapshot               // same Dataplane configuration
+			snapshots <- envoy_cache.Snapshot{} // new Dataplane configuration
+
+			// setup
+			r := &reconciler{
+				snapshotGeneratorFunc(func(ctx xds_context.Context, proxy *xds_model.Proxy) (envoy_cache.Snapshot, error) {
+					return <-snapshots, nil
+				}),
+				&simpleSnapshotCacher{xdsContext.Hasher(), xdsContext.Cache()},
+			}
+
+			// given
+			dataplane := &mesh_core.DataplaneResource{
+				Meta: &test_model.ResourceMeta{
+					Mesh:    "demo",
+					Name:    "example",
+					Version: "abcdefg",
+				},
+				Spec: &mesh_proto.Dataplane{},
+			}
+
+			By("simulating discovery event")
+			// when
+			proxy := &xds_model.Proxy{
+				Id: xds_model.ProxyId{
+					Mesh: "demo",
+					Name: "example",
+				},
+				Dataplane: dataplane,
+			}
+			err := r.Reconcile(xds_context.Context{}, proxy)
+			// then
+			Expect(err).ToNot(HaveOccurred())
+
+			By("verifying that snapshot versions were auto-generated")
+			// when
+			snapshot, err := xdsContext.Cache().GetSnapshot("demo.example")
+			// then
+			Expect(err).ToNot(HaveOccurred())
+			Expect(snapshot).ToNot(BeZero())
+			// and
+			Expect(snapshot.Resources[envoy_types.Listener].Version).To(Equal("v1"))
+			Expect(snapshot.Resources[envoy_types.Route].Version).To(Equal("v2"))
+			Expect(snapshot.Resources[envoy_types.Cluster].Version).To(Equal("v3"))
+			Expect(snapshot.Resources[envoy_types.Endpoint].Version).To(Equal("v4"))
+			Expect(snapshot.Resources[envoy_types.Secret].Version).To(Equal("v5"))
+
+			By("simulating discovery event (Dataplane watchdog triggers refresh)")
+			// when
+			err = r.Reconcile(xds_context.Context{}, proxy)
+			// then
+			Expect(err).ToNot(HaveOccurred())
+
+			By("verifying that snapshot versions remain the same")
+			// when
+			snapshot, err = xdsContext.Cache().GetSnapshot("demo.example")
+			// then
+			Expect(err).ToNot(HaveOccurred())
+			Expect(snapshot).ToNot(BeZero())
+			// and
+			Expect(snapshot.Resources[envoy_types.Listener].Version).To(Equal("v1"))
+			Expect(snapshot.Resources[envoy_types.Route].Version).To(Equal("v2"))
+			Expect(snapshot.Resources[envoy_types.Cluster].Version).To(Equal("v3"))
+			Expect(snapshot.Resources[envoy_types.Endpoint].Version).To(Equal("v4"))
+			Expect(snapshot.Resources[envoy_types.Secret].Version).To(Equal("v5"))
+
+			By("simulating discovery event (Dataplane gets changed)")
+			// when
+			err = r.Reconcile(xds_context.Context{}, proxy)
+			// then
+			Expect(err).ToNot(HaveOccurred())
+
+			By("verifying that snapshot versions are new")
+			// when
+			snapshot, err = xdsContext.Cache().GetSnapshot("demo.example")
+			// then
+			Expect(err).ToNot(HaveOccurred())
+			Expect(snapshot).ToNot(BeZero())
+			// and
+			Expect(snapshot.Resources[envoy_types.Listener].Version).To(Equal("v6"))
+			Expect(snapshot.Resources[envoy_types.Route].Version).To(Equal("v7"))
+			Expect(snapshot.Resources[envoy_types.Cluster].Version).To(Equal("v8"))
+			Expect(snapshot.Resources[envoy_types.Endpoint].Version).To(Equal("v9"))
+			Expect(snapshot.Resources[envoy_types.Secret].Version).To(Equal("v10"))
+		})
+	})
+})
+
+type snapshotGeneratorFunc func(ctx xds_context.Context, proxy *xds_model.Proxy) (envoy_cache.Snapshot, error)
+
+func (f snapshotGeneratorFunc) GenerateSnapshot(ctx xds_context.Context, proxy *xds_model.Proxy) (envoy_cache.Snapshot, error) {
+	return f(ctx, proxy)
+}

--- a/pkg/xds/server/v3/resource_warming_forcer.go
+++ b/pkg/xds/server/v3/resource_warming_forcer.go
@@ -1,0 +1,127 @@
+package v3
+
+import (
+	"sync"
+
+	envoy_sd "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
+	"github.com/envoyproxy/go-control-plane/pkg/cache/types"
+	envoy_cache "github.com/envoyproxy/go-control-plane/pkg/cache/v3"
+	envoy_resource "github.com/envoyproxy/go-control-plane/pkg/resource/v3"
+	envoy_xds "github.com/envoyproxy/go-control-plane/pkg/server/v3"
+	"github.com/pkg/errors"
+
+	"github.com/kumahq/kuma/pkg/core"
+	"github.com/kumahq/kuma/pkg/core/xds"
+	util_xds_v3 "github.com/kumahq/kuma/pkg/util/xds/v3"
+)
+
+var warmingForcerLog = xdsServerLog.WithName("warming-forcer")
+
+// The problem
+//   When you send Cluster of type EDS to Envoy, it updates the config, but Cluster is marked as warming and is not used until you send EDS request.
+//   https://www.envoyproxy.io/docs/envoy/latest/api-docs/xds_protocol#xds-protocol-resource-warming
+//   The main problem is when you update the Cluster itself (for example enable mTLS or change a cluster property via ProxyTemplate)
+//   If you don't send EDS request after that (no endpoint has changed) then the cluster is stuck in warming state indefinitely.
+//
+// The solution
+//   The easiest solution would be to just set a new version of endpoints also when cluster changes (in pkg/xds/server/SnapshotReconciler) . The problem is that go-control-plane does not support resource ordering
+//   * https://github.com/envoyproxy/go-control-plane/issues/59
+//   * https://github.com/envoyproxy/go-control-plane/issues/218
+//   * https://github.com/envoyproxy/go-control-plane/issues/235
+//   Therefore even if we were to set a new version of EDS + CDS on one snapshot, there is no guarantee that EDS will be delivered after CDS.
+//
+//   The alternative solution is this based on a callbacks.
+//   Nonce is a sequence indicator of a sent DiscoveryResponse on a stream. We use ADS therefore every single DiscoveryResponse regardless of a type is sent with incremented nonce.
+//   Typical sequence of CDS + EDS looks like this:
+//   1) Envoy sends DiscoveryRequest [type=CDS, version="", nonce=""] // ask for the clusters
+//   2) Kuma sends DiscoveryResponse [type=CDS, version="UUID-1", nonce="1"] // response with clusters
+//   3) Envoy sends DiscoveryRequest [type=EDS, version="", nonce=""] // ask for the endpoints
+//   4) Envoy sends DiscoveryRequest [type=CDS, version="UUID-1", nonce="1"] // confirmations that it received clusters (ACK)
+//   5) Kuma sends DiscoveryResponse [type=EDS, version="UUID-2", nonce="2"] // response with endpoints
+//   6) Envoy sends DiscoveryRequest [type=EDS, version="UUID-2", nonce="2"] // confirmations that it received endpoints (ACK)
+//
+//   Then if we send a Cluster update (continuing the flow above)
+//   7) Kuma sends DiscoveryResponse [type=CDS, version="UUID-2", nonce="3"] // response with cluster update
+//   8) Envoy sends DiscoveryRequest [type=CDS, version="UUID-2", nonce="3"] // ACK
+//   9) Envoy sends DiscoveryRequest [type=EDS, version="UUID-2", nonce="2"] // Envoy sends a request which looks like the second ACK for the previous endpoints
+//
+//   Updated Cluster is now in warming state until we send DiscoveryResponse with EDS.
+//   We could sent the same DiscoveryResponse again: DiscoveryRequest [type=EDS, version="UUID-2", nonce="2"], but there is no API in go-control-plane to do it.
+//   Instead we set a new version of the Endpoints to force a new EDS exchange:
+//   10) Kuma sends DiscoveryResponse [type=EDS, version="UUID-3", nonce="3"] // triggered because we set snapshot with a new version
+//   11) Envoy sends DiscoveryRequest [type=EDS, version="UUID-3", nonce="3"] // ACK
+//   After this exchange, cluster is now out of the warming state.
+//
+// The same problem is with Listeners and Routes (change of the Listener that uses RDS requires RDS DiscoveryResponse), but since we don't use RDS now, the implementation is for EDS only.
+// More reading of how Envoy is trying to solve it https://github.com/envoyproxy/envoy/issues/13009
+type resourceWarmingForcer struct {
+	util_xds_v3.NoopCallbacks
+	cache  envoy_cache.SnapshotCache
+	hasher envoy_cache.NodeHash
+
+	sync.Mutex
+	lastEndpointNonces map[xds.StreamID]string
+	nodeIDs            map[xds.StreamID]string
+}
+
+func newResourceWarmingForcer(cache envoy_cache.SnapshotCache, hasher envoy_cache.NodeHash) *resourceWarmingForcer {
+	return &resourceWarmingForcer{
+		cache:              cache,
+		hasher:             hasher,
+		lastEndpointNonces: map[xds.StreamID]string{},
+		nodeIDs:            map[xds.StreamID]string{},
+	}
+}
+
+func (r *resourceWarmingForcer) OnStreamClosed(streamID int64) {
+	r.Lock()
+	defer r.Unlock()
+	delete(r.lastEndpointNonces, streamID)
+	delete(r.nodeIDs, streamID)
+}
+
+func (r *resourceWarmingForcer) OnStreamRequest(streamID xds.StreamID, request *envoy_sd.DiscoveryRequest) error {
+	if request.TypeUrl != envoy_resource.EndpointType {
+		return nil // we force Cluster warming only on receiving the same EDS Discovery Request
+	}
+	if request.ResponseNonce == "" {
+		return nil // initial request, no need to force warming
+	}
+	if request.ErrorDetail != nil {
+		return nil // we only care about ACKs, otherwise we can get 2 Nonces with multiple NACKs
+	}
+
+	r.Lock()
+	lastEndpointNonce := r.lastEndpointNonces[streamID]
+	r.lastEndpointNonces[streamID] = request.ResponseNonce
+	nodeID := r.nodeIDs[streamID]
+	if nodeID == "" {
+		nodeID = r.hasher.ID(request.Node) // request.Node can be set only on first request therefore we need to save it
+		r.nodeIDs[streamID] = nodeID
+	}
+	r.Unlock()
+
+	if lastEndpointNonce == request.ResponseNonce {
+		warmingForcerLog.V(1).Info("received second Endpoint DiscoveryRequest with same Nonce. Forcing new version of Endpoints to warm the Cluster")
+		if err := r.forceNewEndpointsVersion(nodeID); err != nil {
+			warmingForcerLog.Error(err, "could not force cluster warming")
+		}
+	}
+	return nil
+}
+
+func (r *resourceWarmingForcer) forceNewEndpointsVersion(nodeID string) error {
+	snapshot, err := r.cache.GetSnapshot(nodeID)
+	if err != nil {
+		return nil // GetSnapshot returns an error if there is no snapshot. We don't need to force on a new snapshot
+	}
+	endpoints := snapshot.Resources[types.Endpoint]
+	endpoints.Version = core.NewUUID()
+	snapshot.Resources[types.Endpoint] = endpoints
+	if err := r.cache.SetSnapshot(nodeID, snapshot); err != nil {
+		return errors.Wrap(err, "could not set snapshot")
+	}
+	return nil
+}
+
+var _ envoy_xds.Callbacks = &resourceWarmingForcer{}

--- a/pkg/xds/server/v3/server_suite_test.go
+++ b/pkg/xds/server/v3/server_suite_test.go
@@ -1,0 +1,13 @@
+package v3_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestSync(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "XDS Server V2 Suite")
+}

--- a/pkg/xds/server/v3/snapshot_generator_test.go
+++ b/pkg/xds/server/v3/snapshot_generator_test.go
@@ -1,0 +1,134 @@
+package v3
+
+import (
+	"io/ioutil"
+	"path/filepath"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
+	mesh_core "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
+	"github.com/kumahq/kuma/pkg/core/resources/manager"
+	model "github.com/kumahq/kuma/pkg/core/xds"
+	"github.com/kumahq/kuma/pkg/plugins/resources/memory"
+	test_model "github.com/kumahq/kuma/pkg/test/resources/model"
+	util_cache_v3 "github.com/kumahq/kuma/pkg/util/cache/v3"
+	util_proto "github.com/kumahq/kuma/pkg/util/proto"
+	xds_context "github.com/kumahq/kuma/pkg/xds/context"
+	envoy_common "github.com/kumahq/kuma/pkg/xds/envoy"
+	"github.com/kumahq/kuma/pkg/xds/template"
+)
+
+var _ = Describe("Reconcile", func() {
+	Describe("templateSnapshotGenerator", func() {
+
+		gen := templateSnapshotGenerator{
+			ProxyTemplateResolver: &template.SimpleProxyTemplateResolver{
+				ReadOnlyResourceManager: manager.NewResourceManager(memory.NewStore()),
+				DefaultProxyTemplate:    template.DefaultProxyTemplate,
+			},
+		}
+
+		It("Generate Snapshot per Envoy Node", func() {
+			// given
+			ctx := xds_context.Context{
+				ConnectionInfo: xds_context.ConnectionInfo{
+					Authority: "kuma-system:5677",
+				},
+				ControlPlane: &xds_context.ControlPlaneContext{
+					SdsTlsCert: []byte("12345"),
+				},
+				Mesh: xds_context.MeshContext{
+					Resource: &mesh_core.MeshResource{
+						Meta: &test_model.ResourceMeta{
+							Name: "demo",
+						},
+						Spec: &mesh_proto.Mesh{
+							Mtls: &mesh_proto.Mesh_Mtls{
+								EnabledBackend: "builtin",
+								Backends: []*mesh_proto.CertificateAuthorityBackend{
+									{
+										Name: "builtin",
+										Type: "builtin",
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+
+			dataplane := mesh_proto.Dataplane{}
+			dpBytes, err := ioutil.ReadFile(filepath.Join("testdata", "dataplane.input.yaml"))
+			Expect(err).ToNot(HaveOccurred())
+			Expect(util_proto.FromYAML(dpBytes, &dataplane)).To(Succeed())
+
+			proxy := &model.Proxy{
+				Id:         model.ProxyId{Name: "demo.web1"},
+				APIVersion: envoy_common.APIV3,
+				Dataplane: &mesh_core.DataplaneResource{
+					Meta: &test_model.ResourceMeta{
+						Name:    "web1",
+						Mesh:    "demo",
+						Version: "1",
+					},
+					Spec: &dataplane,
+				},
+				Policies: model.MatchedPolicies{
+					TrafficPermissions: model.TrafficPermissionMap{
+						mesh_proto.InboundInterface{
+							DataplaneIP:   "192.168.0.1",
+							DataplanePort: 80,
+							WorkloadIP:    "127.0.0.1",
+							WorkloadPort:  8080,
+						}: &mesh_core.TrafficPermissionResource{
+							Meta: &test_model.ResourceMeta{
+								Name: "tp-1",
+								Mesh: "default",
+							},
+							Spec: &mesh_proto.TrafficPermission{
+								Sources: []*mesh_proto.Selector{
+									{
+										Match: map[string]string{
+											"kuma.io/service": "web1",
+											"version":         "1.0",
+										},
+									},
+								},
+								Destinations: []*mesh_proto.Selector{
+									{
+										Match: map[string]string{
+											"kuma.io/service": "backend1",
+											"env":             "dev",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				Metadata: &model.DataplaneMetadata{},
+			}
+
+			// when
+			s, err := gen.GenerateSnapshot(ctx, proxy)
+
+			// then
+			Expect(err).ToNot(HaveOccurred())
+
+			// when
+			resp, err := util_cache_v3.ToDeltaDiscoveryResponse(s)
+			// then
+			Expect(err).ToNot(HaveOccurred())
+			// when
+			actual, err := util_proto.ToYAML(resp)
+			// then
+			Expect(err).ToNot(HaveOccurred())
+
+			expected, err := ioutil.ReadFile(filepath.Join("testdata", "envoy-config.golden.yaml"))
+			Expect(err).ToNot(HaveOccurred())
+			Expect(actual).To(MatchYAML(expected))
+		})
+	})
+})

--- a/pkg/xds/server/v3/testdata/dataplane.input.yaml
+++ b/pkg/xds/server/v3/testdata/dataplane.input.yaml
@@ -1,0 +1,16 @@
+networking:
+  transparentProxying:
+    redirectPortOutbound: 15001
+    redirectPortInbound: 15006
+  address: 192.168.0.1
+  inbound:
+    - port: 80
+      servicePort: 8080
+    - port: 443
+      servicePort: 8443
+    - address: 192.168.0.2
+      port: 80
+      servicePort: 8080
+    - address: 192.168.0.2
+      port: 443
+      servicePort: 8443

--- a/pkg/xds/server/v3/testdata/envoy-config.golden.yaml
+++ b/pkg/xds/server/v3/testdata/envoy-config.golden.yaml
@@ -1,0 +1,345 @@
+resources:
+  - name: inbound:passthrough
+    resource:
+      '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
+      altStatName: inbound_passthrough
+      connectTimeout: 5s
+      lbPolicy: CLUSTER_PROVIDED
+      name: inbound:passthrough
+      type: ORIGINAL_DST
+      upstreamBindConfig:
+        sourceAddress:
+          address: 127.0.0.6
+          portValue: 0
+  - name: localhost:8080
+    resource:
+      '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
+      altStatName: localhost_8080
+      connectTimeout: 5s
+      loadAssignment:
+        clusterName: localhost:8080
+        endpoints:
+          - lbEndpoints:
+              - endpoint:
+                  address:
+                    socketAddress:
+                      address: 127.0.0.1
+                      portValue: 8080
+      name: localhost:8080
+      type: STATIC
+  - name: localhost:8443
+    resource:
+      '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
+      altStatName: localhost_8443
+      connectTimeout: 5s
+      loadAssignment:
+        clusterName: localhost:8443
+        endpoints:
+          - lbEndpoints:
+              - endpoint:
+                  address:
+                    socketAddress:
+                      address: 127.0.0.1
+                      portValue: 8443
+      name: localhost:8443
+      type: STATIC
+  - name: outbound:passthrough
+    resource:
+      '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
+      altStatName: outbound_passthrough
+      connectTimeout: 5s
+      lbPolicy: CLUSTER_PROVIDED
+      name: outbound:passthrough
+      type: ORIGINAL_DST
+  - name: inbound:192.168.0.1:443
+    resource:
+      '@type': type.googleapis.com/envoy.config.listener.v3.Listener
+      address:
+        socketAddress:
+          address: 192.168.0.1
+          portValue: 443
+      deprecatedV1:
+        bindToPort: false
+      filterChains:
+        - filters:
+            - name: envoy.filters.network.rbac
+              typedConfig:
+                '@type': type.googleapis.com/envoy.extensions.filters.network.rbac.v3.RBAC
+                rules: {}
+                statPrefix: inbound_192_168_0_1_443.
+            - name: envoy.filters.network.tcp_proxy
+              typedConfig:
+                '@type': type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
+                cluster: localhost:8443
+                statPrefix: localhost_8443
+          transportSocket:
+            name: envoy.transport_sockets.tls
+            typedConfig:
+              '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext
+              commonTlsContext:
+                combinedValidationContext:
+                  defaultValidationContext:
+                    matchSubjectAltNames:
+                      - prefix: spiffe://demo/
+                  validationContextSdsSecretConfig:
+                    name: mesh_ca
+                    sdsConfig:
+                      apiConfigSource:
+                        apiType: GRPC
+                        grpcServices:
+                          - googleGrpc:
+                              channelCredentials:
+                                sslCredentials:
+                                  rootCerts:
+                                    inlineBytes: MTIzNDU=
+                              statPrefix: sds_mesh_ca
+                              targetUri: kuma-system:5677
+                        transportApiVersion: V3
+                      resourceApiVersion: V3
+                tlsCertificateSdsSecretConfigs:
+                  - name: identity_cert
+                    sdsConfig:
+                      apiConfigSource:
+                        apiType: GRPC
+                        grpcServices:
+                          - googleGrpc:
+                              channelCredentials:
+                                sslCredentials:
+                                  rootCerts:
+                                    inlineBytes: MTIzNDU=
+                              statPrefix: sds_identity_cert
+                              targetUri: kuma-system:5677
+                        transportApiVersion: V3
+                      resourceApiVersion: V3
+              requireClientCertificate: true
+      name: inbound:192.168.0.1:443
+      trafficDirection: INBOUND
+  - name: inbound:192.168.0.1:80
+    resource:
+      '@type': type.googleapis.com/envoy.config.listener.v3.Listener
+      address:
+        socketAddress:
+          address: 192.168.0.1
+          portValue: 80
+      deprecatedV1:
+        bindToPort: false
+      filterChains:
+        - filters:
+            - name: envoy.filters.network.rbac
+              typedConfig:
+                '@type': type.googleapis.com/envoy.extensions.filters.network.rbac.v3.RBAC
+                rules:
+                  policies:
+                    tp-1:
+                      permissions:
+                        - any: true
+                      principals:
+                        - authenticated:
+                            principalName:
+                              exact: spiffe://default/web1
+                statPrefix: inbound_192_168_0_1_80.
+            - name: envoy.filters.network.tcp_proxy
+              typedConfig:
+                '@type': type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
+                cluster: localhost:8080
+                statPrefix: localhost_8080
+          transportSocket:
+            name: envoy.transport_sockets.tls
+            typedConfig:
+              '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext
+              commonTlsContext:
+                combinedValidationContext:
+                  defaultValidationContext:
+                    matchSubjectAltNames:
+                      - prefix: spiffe://demo/
+                  validationContextSdsSecretConfig:
+                    name: mesh_ca
+                    sdsConfig:
+                      apiConfigSource:
+                        apiType: GRPC
+                        grpcServices:
+                          - googleGrpc:
+                              channelCredentials:
+                                sslCredentials:
+                                  rootCerts:
+                                    inlineBytes: MTIzNDU=
+                              statPrefix: sds_mesh_ca
+                              targetUri: kuma-system:5677
+                        transportApiVersion: V3
+                      resourceApiVersion: V3
+                tlsCertificateSdsSecretConfigs:
+                  - name: identity_cert
+                    sdsConfig:
+                      apiConfigSource:
+                        apiType: GRPC
+                        grpcServices:
+                          - googleGrpc:
+                              channelCredentials:
+                                sslCredentials:
+                                  rootCerts:
+                                    inlineBytes: MTIzNDU=
+                              statPrefix: sds_identity_cert
+                              targetUri: kuma-system:5677
+                        transportApiVersion: V3
+                      resourceApiVersion: V3
+              requireClientCertificate: true
+      name: inbound:192.168.0.1:80
+      trafficDirection: INBOUND
+  - name: inbound:192.168.0.2:443
+    resource:
+      '@type': type.googleapis.com/envoy.config.listener.v3.Listener
+      address:
+        socketAddress:
+          address: 192.168.0.2
+          portValue: 443
+      deprecatedV1:
+        bindToPort: false
+      filterChains:
+        - filters:
+            - name: envoy.filters.network.rbac
+              typedConfig:
+                '@type': type.googleapis.com/envoy.extensions.filters.network.rbac.v3.RBAC
+                rules: {}
+                statPrefix: inbound_192_168_0_2_443.
+            - name: envoy.filters.network.tcp_proxy
+              typedConfig:
+                '@type': type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
+                cluster: localhost:8443
+                statPrefix: localhost_8443
+          transportSocket:
+            name: envoy.transport_sockets.tls
+            typedConfig:
+              '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext
+              commonTlsContext:
+                combinedValidationContext:
+                  defaultValidationContext:
+                    matchSubjectAltNames:
+                      - prefix: spiffe://demo/
+                  validationContextSdsSecretConfig:
+                    name: mesh_ca
+                    sdsConfig:
+                      apiConfigSource:
+                        apiType: GRPC
+                        grpcServices:
+                          - googleGrpc:
+                              channelCredentials:
+                                sslCredentials:
+                                  rootCerts:
+                                    inlineBytes: MTIzNDU=
+                              statPrefix: sds_mesh_ca
+                              targetUri: kuma-system:5677
+                        transportApiVersion: V3
+                      resourceApiVersion: V3
+                tlsCertificateSdsSecretConfigs:
+                  - name: identity_cert
+                    sdsConfig:
+                      apiConfigSource:
+                        apiType: GRPC
+                        grpcServices:
+                          - googleGrpc:
+                              channelCredentials:
+                                sslCredentials:
+                                  rootCerts:
+                                    inlineBytes: MTIzNDU=
+                              statPrefix: sds_identity_cert
+                              targetUri: kuma-system:5677
+                        transportApiVersion: V3
+                      resourceApiVersion: V3
+              requireClientCertificate: true
+      name: inbound:192.168.0.2:443
+      trafficDirection: INBOUND
+  - name: inbound:192.168.0.2:80
+    resource:
+      '@type': type.googleapis.com/envoy.config.listener.v3.Listener
+      address:
+        socketAddress:
+          address: 192.168.0.2
+          portValue: 80
+      deprecatedV1:
+        bindToPort: false
+      filterChains:
+        - filters:
+            - name: envoy.filters.network.rbac
+              typedConfig:
+                '@type': type.googleapis.com/envoy.extensions.filters.network.rbac.v3.RBAC
+                rules: {}
+                statPrefix: inbound_192_168_0_2_80.
+            - name: envoy.filters.network.tcp_proxy
+              typedConfig:
+                '@type': type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
+                cluster: localhost:8080
+                statPrefix: localhost_8080
+          transportSocket:
+            name: envoy.transport_sockets.tls
+            typedConfig:
+              '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext
+              commonTlsContext:
+                combinedValidationContext:
+                  defaultValidationContext:
+                    matchSubjectAltNames:
+                      - prefix: spiffe://demo/
+                  validationContextSdsSecretConfig:
+                    name: mesh_ca
+                    sdsConfig:
+                      apiConfigSource:
+                        apiType: GRPC
+                        grpcServices:
+                          - googleGrpc:
+                              channelCredentials:
+                                sslCredentials:
+                                  rootCerts:
+                                    inlineBytes: MTIzNDU=
+                              statPrefix: sds_mesh_ca
+                              targetUri: kuma-system:5677
+                        transportApiVersion: V3
+                      resourceApiVersion: V3
+                tlsCertificateSdsSecretConfigs:
+                  - name: identity_cert
+                    sdsConfig:
+                      apiConfigSource:
+                        apiType: GRPC
+                        grpcServices:
+                          - googleGrpc:
+                              channelCredentials:
+                                sslCredentials:
+                                  rootCerts:
+                                    inlineBytes: MTIzNDU=
+                              statPrefix: sds_identity_cert
+                              targetUri: kuma-system:5677
+                        transportApiVersion: V3
+                      resourceApiVersion: V3
+              requireClientCertificate: true
+      name: inbound:192.168.0.2:80
+      trafficDirection: INBOUND
+  - name: inbound:passthrough
+    resource:
+      '@type': type.googleapis.com/envoy.config.listener.v3.Listener
+      address:
+        socketAddress:
+          address: 0.0.0.0
+          portValue: 15006
+      filterChains:
+        - filters:
+            - name: envoy.filters.network.tcp_proxy
+              typedConfig:
+                '@type': type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
+                cluster: inbound:passthrough
+                statPrefix: inbound_passthrough
+      name: inbound:passthrough
+      trafficDirection: INBOUND
+  - name: outbound:passthrough
+    resource:
+      '@type': type.googleapis.com/envoy.config.listener.v3.Listener
+      address:
+        socketAddress:
+          address: 0.0.0.0
+          portValue: 15001
+      filterChains:
+        - filters:
+            - name: envoy.filters.network.tcp_proxy
+              typedConfig:
+                '@type': type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
+                cluster: outbound:passthrough
+                statPrefix: outbound_passthrough
+      name: outbound:passthrough
+      trafficDirection: OUTBOUND


### PR DESCRIPTION
The majority of this code is the same as V2 equivalent. Review in IDE to see the structure in a better way.

This lets us serve V2 and V3 at the same time including XDS and SDS.

Parts missing to have full V3 support:
* TCP Access logger
* Proxy Template
* Transparent Proxy
* E2E CI for V3