### PR TITLE
fix(*) traffic log scope

### DIFF
--- a/pkg/plugins/resources/k8s/native/api/v1alpha1/trafficlogging_types_helpers.go
+++ b/pkg/plugins/resources/k8s/native/api/v1alpha1/trafficlogging_types_helpers.go
@@ -33,7 +33,7 @@ func (tp *TrafficLog) SetSpec(spec map[string]interface{}) {
 }
 
 func (tp *TrafficLog) Scope() model.Scope {
-	return model.ScopeNamespace
+	return model.ScopeCluster
 }
 
 func (l *TrafficLogList) GetItems() []model.KubernetesObject {


### PR DESCRIPTION
### Summary

Apparently, we have missed updating the TrafficLog helper to reflect that the resources are now Cluster scoped.

### Issues resolved

Unable to query TrafficLog through API + non-functioning TrafficLog GUI.

### Documentation

- Not needed
