### PR TITLE
fix(kube-prometheus-sd) allow kuma-cp config to grpcs scheme

### DIFF
--- a/pkg/config/app/kuma-prometheus-sd/config.go
+++ b/pkg/config/app/kuma-prometheus-sd/config.go
@@ -94,8 +94,8 @@ func (c *MonitoringAssignmentClientConfig) Validate() (errs error) {
 		if !url.IsAbs() {
 			errs = multierr.Append(errs, errors.Errorf(".URL must be a valid absolute URI"))
 		}
-		if url.Scheme != "grpc" {
-			errs = multierr.Append(errs, errors.Errorf(".URL must start with grpc://"))
+		if url.Scheme != "grpc" && url.Scheme != "grpcs" {
+			errs = multierr.Append(errs, errors.Errorf(".URL must start with grpc:// or grpcs://"))
 		}
 	}
 	return

--- a/pkg/config/app/kuma-prometheus-sd/config_test.go
+++ b/pkg/config/app/kuma-prometheus-sd/config_test.go
@@ -98,6 +98,19 @@ var _ = Describe("Config", func() {
 		err := config.Load(filepath.Join("testdata", "invalid-config.input.yaml"), &cfg)
 
 		// then
-		Expect(err.Error()).To(Equal(`Invalid configuration: .MonitoringAssignment is not valid: .Client is not valid: .Name must be non-empty; .URL must be a valid absolute URI; .URL must start with grpc://; .Prometheus is not valid: .OutputFile must be non-empty`))
+		Expect(err.Error()).To(Equal(`Invalid configuration: .MonitoringAssignment is not valid: .Client is not valid: .Name must be non-empty; .URL must be a valid absolute URI; .URL must start with grpc:// or grpcs://; .Prometheus is not valid: .OutputFile must be non-empty`))
+	})
+
+	It("should allow grpcs", func() {
+		// given
+		cfg := kuma_promsd.Config{}
+
+		// when
+		err := config.Load(filepath.Join("testdata", "valid-grpcs-config.input.yaml"), &cfg)
+
+		// then
+		Expect(err).ToNot(HaveOccurred())
+		// and
+		Expect(cfg.MonitoringAssignment.Client.URL).To(Equal("grpcs://kuma-control-plane.internal:5682"))
 	})
 })

--- a/pkg/config/app/kuma-prometheus-sd/testdata/valid-grpcs-config.input.yaml
+++ b/pkg/config/app/kuma-prometheus-sd/testdata/valid-grpcs-config.input.yaml
@@ -1,0 +1,6 @@
+monitoringAssignment:
+  client:
+    name: custom
+    url: grpcs://kuma-control-plane.internal:5682
+prometheus:
+  outputFile: /path/to/file


### PR DESCRIPTION
### Summary

The configuration validation was only allowing `grpc` schemes
in practice `grpc` and `grpcs` should both be allowed.

### Full changelog

* improve validation to allow grpcs scheme in the kube-prometheus-sd config