### PR TITLE
fix(*) traffic logging to tcp backends

### DIFF
--- a/app/kuma-dp/cmd/run.go
+++ b/app/kuma-dp/cmd/run.go
@@ -122,7 +122,7 @@ func newRunCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			server := accesslogs.NewAccessLogServer()
+			server := accesslogs.NewAccessLogServer(cfg.Dataplane)
 
 			componentMgr := component.NewManager(leader_memory.NewNeverLeaderElector())
 			if err := componentMgr.Add(server, dataplane); err != nil {

--- a/app/kuma-dp/pkg/dataplane/accesslogs/server.go
+++ b/app/kuma-dp/pkg/dataplane/accesslogs/server.go
@@ -10,6 +10,7 @@ import (
 	"github.com/pkg/errors"
 	"google.golang.org/grpc"
 
+	kumadp "github.com/kumahq/kuma/pkg/config/app/kuma-dp"
 	"github.com/kumahq/kuma/pkg/core"
 	"github.com/kumahq/kuma/pkg/core/runtime/component"
 )
@@ -31,13 +32,11 @@ func (s *accessLogServer) NeedLeaderElection() bool {
 	return false
 }
 
-func NewAccessLogServer() *accessLogServer {
-	id := core.NewUUID()
-	var address = fmt.Sprintf("/tmp/%s.sock", id)
+func NewAccessLogServer(dataplane kumadp.Dataplane) *accessLogServer {
 	return &accessLogServer{
 		server:     grpc.NewServer(),
 		newHandler: defaultHandler,
-		address:    address,
+		address:    fmt.Sprintf("/tmp/kuma-access-logs-%s-%s.sock", dataplane.Name, dataplane.Mesh),
 	}
 }
 

--- a/app/kuma-dp/pkg/dataplane/accesslogs/server.go
+++ b/app/kuma-dp/pkg/dataplane/accesslogs/server.go
@@ -33,10 +33,11 @@ func (s *accessLogServer) NeedLeaderElection() bool {
 }
 
 func NewAccessLogServer(dataplane kumadp.Dataplane) *accessLogServer {
+	address := fmt.Sprintf("/tmp/%s-%s.sock", dataplane.Name, dataplane.Mesh)
 	return &accessLogServer{
 		server:     grpc.NewServer(),
 		newHandler: defaultHandler,
-		address:    fmt.Sprintf("/tmp/kuma-access-logs-%s-%s.sock", dataplane.Name, dataplane.Mesh),
+		address:    address,
 	}
 }
 

--- a/app/kuma-dp/pkg/dataplane/accesslogs/server.go
+++ b/app/kuma-dp/pkg/dataplane/accesslogs/server.go
@@ -6,6 +6,8 @@ import (
 	"net"
 	"sync/atomic"
 
+	"github.com/kumahq/kuma/pkg/xds/envoy"
+
 	envoy_accesslog "github.com/envoyproxy/go-control-plane/envoy/service/accesslog/v2"
 	"github.com/pkg/errors"
 	"google.golang.org/grpc"
@@ -33,7 +35,7 @@ func (s *accessLogServer) NeedLeaderElection() bool {
 }
 
 func NewAccessLogServer(dataplane kumadp.Dataplane) *accessLogServer {
-	address := fmt.Sprintf("/tmp/%s-%s.sock", dataplane.Name, dataplane.Mesh)
+	address := envoy.AccessLogSocketName(dataplane.Name, dataplane.Mesh)
 	return &accessLogServer{
 		server:     grpc.NewServer(),
 		newHandler: defaultHandler,

--- a/pkg/xds/bootstrap/generator.go
+++ b/pkg/xds/bootstrap/generator.go
@@ -183,7 +183,7 @@ func (b *bootstrapGenerator) generateFor(proxyId core_xds.ProxyId, dataplane *co
 		}
 		certBytes = base64.StdEncoding.EncodeToString(cert)
 	}
-	accessLogPipe := fmt.Sprintf("/tmp/kuma-access-logs-%s-%s.sock", request.Name, request.Mesh)
+	accessLogPipe := fmt.Sprintf("/tmp/%s-%s.sock", request.Name, request.Mesh)
 	params := configParameters{
 		Id:                 proxyId.String(),
 		Service:            service,

--- a/pkg/xds/bootstrap/generator.go
+++ b/pkg/xds/bootstrap/generator.go
@@ -12,6 +12,8 @@ import (
 	"strings"
 	"text/template"
 
+	"github.com/kumahq/kuma/pkg/xds/envoy"
+
 	"github.com/kumahq/kuma/pkg/core/resources/model"
 	"github.com/kumahq/kuma/pkg/core/resources/model/rest"
 	"github.com/kumahq/kuma/pkg/core/validators"
@@ -175,7 +177,7 @@ func (b *bootstrapGenerator) generateFor(proxyId core_xds.ProxyId, dataplane *co
 		return nil, err
 	}
 
-	var certBytes string = ""
+	var certBytes = ""
 	if b.xdsCertFile != "" {
 		cert, err := ioutil.ReadFile(b.xdsCertFile)
 		if err != nil {
@@ -183,7 +185,7 @@ func (b *bootstrapGenerator) generateFor(proxyId core_xds.ProxyId, dataplane *co
 		}
 		certBytes = base64.StdEncoding.EncodeToString(cert)
 	}
-	accessLogPipe := fmt.Sprintf("/tmp/%s-%s.sock", request.Name, request.Mesh)
+	accessLogSocket := envoy.AccessLogSocketName(request.Name, request.Mesh)
 	params := configParameters{
 		Id:                 proxyId.String(),
 		Service:            service,
@@ -193,7 +195,7 @@ func (b *bootstrapGenerator) generateFor(proxyId core_xds.ProxyId, dataplane *co
 		XdsHost:            b.xdsHost(request),
 		XdsPort:            b.config.XdsPort,
 		XdsConnectTimeout:  b.config.XdsConnectTimeout,
-		AccessLogPipe:      accessLogPipe,
+		AccessLogPipe:      accessLogSocket,
 		DataplaneTokenPath: request.DataplaneTokenPath,
 		DataplaneResource:  request.DataplaneResource,
 		CertBytes:          certBytes,

--- a/pkg/xds/bootstrap/testdata/bootstrap.k8s.golden.yaml
+++ b/pkg/xds/bootstrap/testdata/bootstrap.k8s.golden.yaml
@@ -46,7 +46,7 @@ staticResources:
               - endpoint:
                   address:
                     pipe:
-                      path: /tmp/dp-1.default-default.sock
+                      path: /tmp/kuma-al-dp-1.default-default.sock
       name: access_log_sink
       type: STATIC
       upstreamConnectionOptions:

--- a/pkg/xds/bootstrap/testdata/bootstrap.k8s.golden.yaml
+++ b/pkg/xds/bootstrap/testdata/bootstrap.k8s.golden.yaml
@@ -46,7 +46,7 @@ staticResources:
               - endpoint:
                   address:
                     pipe:
-                      path: /tmp/kuma-access-logs-dp-1.default-default.sock
+                      path: /tmp/dp-1.default-default.sock
       name: access_log_sink
       type: STATIC
       upstreamConnectionOptions:

--- a/pkg/xds/bootstrap/testdata/bootstrap.overridden.golden.yaml
+++ b/pkg/xds/bootstrap/testdata/bootstrap.overridden.golden.yaml
@@ -53,7 +53,7 @@ staticResources:
               - endpoint:
                   address:
                     pipe:
-                      path: /tmp/dp-1.default-default.sock
+                      path: /tmp/kuma-al-dp-1.default-default.sock
       name: access_log_sink
       type: STATIC
       upstreamConnectionOptions:

--- a/pkg/xds/bootstrap/testdata/bootstrap.overridden.golden.yaml
+++ b/pkg/xds/bootstrap/testdata/bootstrap.overridden.golden.yaml
@@ -53,7 +53,7 @@ staticResources:
               - endpoint:
                   address:
                     pipe:
-                      path: /tmp/kuma-access-logs-dp-1.default-default.sock
+                      path: /tmp/dp-1.default-default.sock
       name: access_log_sink
       type: STATIC
       upstreamConnectionOptions:

--- a/pkg/xds/bootstrap/testdata/bootstrap.universal.golden.yaml
+++ b/pkg/xds/bootstrap/testdata/bootstrap.universal.golden.yaml
@@ -46,7 +46,7 @@ staticResources:
               - endpoint:
                   address:
                     pipe:
-                      path: /tmp/kuma-access-logs-dp-1-default.sock
+                      path: /tmp/dp-1-default.sock
       name: access_log_sink
       type: STATIC
       upstreamConnectionOptions:

--- a/pkg/xds/bootstrap/testdata/bootstrap.universal.golden.yaml
+++ b/pkg/xds/bootstrap/testdata/bootstrap.universal.golden.yaml
@@ -46,7 +46,7 @@ staticResources:
               - endpoint:
                   address:
                     pipe:
-                      path: /tmp/dp-1-default.sock
+                      path: /tmp/kuma-al-dp-1-default.sock
       name: access_log_sink
       type: STATIC
       upstreamConnectionOptions:

--- a/pkg/xds/bootstrap/testdata/generator.custom-config-minimal-request.golden.yaml
+++ b/pkg/xds/bootstrap/testdata/generator.custom-config-minimal-request.golden.yaml
@@ -44,7 +44,7 @@ staticResources:
               - endpoint:
                   address:
                     pipe:
-                      path: /tmp/name.namespace-mesh.sock
+                      path: /tmp/kuma-al-name.namespace-mesh.sock
       name: access_log_sink
       type: STATIC
       upstreamConnectionOptions:

--- a/pkg/xds/bootstrap/testdata/generator.custom-config-minimal-request.golden.yaml
+++ b/pkg/xds/bootstrap/testdata/generator.custom-config-minimal-request.golden.yaml
@@ -44,7 +44,7 @@ staticResources:
               - endpoint:
                   address:
                     pipe:
-                      path: /tmp/kuma-access-logs-name.namespace-mesh.sock
+                      path: /tmp/name.namespace-mesh.sock
       name: access_log_sink
       type: STATIC
       upstreamConnectionOptions:

--- a/pkg/xds/bootstrap/testdata/generator.custom-config.golden.yaml
+++ b/pkg/xds/bootstrap/testdata/generator.custom-config.golden.yaml
@@ -54,7 +54,7 @@ staticResources:
               - endpoint:
                   address:
                     pipe:
-                      path: /tmp/kuma-access-logs-name.namespace-mesh.sock
+                      path: /tmp/name.namespace-mesh.sock
       name: access_log_sink
       type: STATIC
       upstreamConnectionOptions:

--- a/pkg/xds/bootstrap/testdata/generator.custom-config.golden.yaml
+++ b/pkg/xds/bootstrap/testdata/generator.custom-config.golden.yaml
@@ -54,7 +54,7 @@ staticResources:
               - endpoint:
                   address:
                     pipe:
-                      path: /tmp/name.namespace-mesh.sock
+                      path: /tmp/kuma-al-name.namespace-mesh.sock
       name: access_log_sink
       type: STATIC
       upstreamConnectionOptions:

--- a/pkg/xds/bootstrap/testdata/generator.default-config-minimal-request.golden.yaml
+++ b/pkg/xds/bootstrap/testdata/generator.default-config-minimal-request.golden.yaml
@@ -37,7 +37,7 @@ staticResources:
               - endpoint:
                   address:
                     pipe:
-                      path: /tmp/name.namespace-mesh.sock
+                      path: /tmp/kuma-al-name.namespace-mesh.sock
       name: access_log_sink
       type: STATIC
       upstreamConnectionOptions:

--- a/pkg/xds/bootstrap/testdata/generator.default-config-minimal-request.golden.yaml
+++ b/pkg/xds/bootstrap/testdata/generator.default-config-minimal-request.golden.yaml
@@ -37,7 +37,7 @@ staticResources:
               - endpoint:
                   address:
                     pipe:
-                      path: /tmp/kuma-access-logs-name.namespace-mesh.sock
+                      path: /tmp/name.namespace-mesh.sock
       name: access_log_sink
       type: STATIC
       upstreamConnectionOptions:

--- a/pkg/xds/bootstrap/testdata/generator.default-config.golden.yaml
+++ b/pkg/xds/bootstrap/testdata/generator.default-config.golden.yaml
@@ -53,7 +53,7 @@ staticResources:
               - endpoint:
                   address:
                     pipe:
-                      path: /tmp/name.namespace-mesh.sock
+                      path: /tmp/kuma-al-name.namespace-mesh.sock
       name: access_log_sink
       type: STATIC
       upstreamConnectionOptions:

--- a/pkg/xds/bootstrap/testdata/generator.default-config.golden.yaml
+++ b/pkg/xds/bootstrap/testdata/generator.default-config.golden.yaml
@@ -53,7 +53,7 @@ staticResources:
               - endpoint:
                   address:
                     pipe:
-                      path: /tmp/kuma-access-logs-name.namespace-mesh.sock
+                      path: /tmp/name.namespace-mesh.sock
       name: access_log_sink
       type: STATIC
       upstreamConnectionOptions:

--- a/pkg/xds/envoy/access_log.go
+++ b/pkg/xds/envoy/access_log.go
@@ -1,0 +1,15 @@
+package envoy
+
+import (
+	"fmt"
+)
+
+// AccessLogSocketName generates a socket path that will fit the Unix socket path limitation of 108 chars
+func AccessLogSocketName(name, mesh string) string {
+	socketName := fmt.Sprintf("/tmp/kuma-al-%s-%s", name, mesh)
+	trimLen := len(socketName)
+	if trimLen > 100 {
+		trimLen = 100
+	}
+	return socketName[:trimLen] + ".sock"
+}


### PR DESCRIPTION
### Summary

#894 actually broke TrafficLogs with TCP logger. It actually created a discrepancy in the naming of the UNIX socket between `kuma-dp` and the bootstrap generator in `kuma-cp`. In effect, Envoy was not able to find the GRPC logging service as provided by `kuma-dp` and the logs are never sent to the TCP logger.

Revert it and shorten the UNIX socket name by removing the not needed prefix `kuma-access-logs-`.

### Issues resolved

Fix #853 (again)

### Documentation

- Not needed
