### PR TITLE
feat(kuma-cp) transparent proxy v3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/asaskevich/govalidator v0.0.0-20200428143746-21a406dcc535
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/emicklei/go-restful v2.14.2+incompatible
-	github.com/envoyproxy/go-control-plane v0.9.8
+	github.com/envoyproxy/go-control-plane v0.9.9-0.20210107210257-6e771204fae6
 	github.com/envoyproxy/protoc-gen-validate v0.4.1
 	github.com/ghodss/yaml v1.0.0
 	github.com/go-errors/errors v1.0.2-0.20180813162953-d98b870cc4e0

--- a/go.sum
+++ b/go.sum
@@ -345,8 +345,9 @@ github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.m
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=
 github.com/envoyproxy/go-control-plane v0.9.7-0.20200730005029-803dd64f0468/go.mod h1:cwu0lG7PUMfa9snN8LXBig5ynNVH9qI8YYLbd1fK2po=
 github.com/envoyproxy/go-control-plane v0.9.7/go.mod h1:cwu0lG7PUMfa9snN8LXBig5ynNVH9qI8YYLbd1fK2po=
-github.com/envoyproxy/go-control-plane v0.9.8 h1:bbmjRkjmP0ZggMoahdNMmJFFnK7v5H+/j5niP5QH6bg=
 github.com/envoyproxy/go-control-plane v0.9.8/go.mod h1:cXg6YxExXjJnVBQHBLXeUAgxn2UodCpnH306RInaBQk=
+github.com/envoyproxy/go-control-plane v0.9.9-0.20210107210257-6e771204fae6 h1:DZNZDoFHT7Q2zxdwbHkt2HFexENxiXTNd44M9pertiw=
+github.com/envoyproxy/go-control-plane v0.9.9-0.20210107210257-6e771204fae6/go.mod h1:cXg6YxExXjJnVBQHBLXeUAgxn2UodCpnH306RInaBQk=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/envoyproxy/protoc-gen-validate v0.4.1 h1:7dLaJvASGRD7X49jSCSXXHwKPm0ZN9r9kJD+p+vS7dM=
 github.com/envoyproxy/protoc-gen-validate v0.4.1/go.mod h1:E+IEazqdaWv3FrnGtZIu3b9fPFMK8AzeTTrk9SfVwWs=

--- a/pkg/sds/server/v2/reconciler.go
+++ b/pkg/sds/server/v2/reconciler.go
@@ -161,7 +161,7 @@ func (d *DataplaneReconciler) generateSnapshot(dataplane *mesh_core.DataplaneRes
 }
 
 func (d *DataplaneReconciler) updateInsights(dataplaneId core_model.ResourceKey, snapshot envoy_cache.Snapshot) error {
-	secret := snapshot.Resources[envoy_types.Secret].Items[tls.IdentityCertResource].(*envoy_auth.Secret)
+	secret := snapshot.Resources[envoy_types.Secret].Items[tls.IdentityCertResource].Resource.(*envoy_auth.Secret)
 	certPEM := secret.GetTlsCertificate().CertificateChain.GetInlineBytes()
 	block, _ := pem.Decode(certPEM)
 	cert, err := x509.ParseCertificate(block.Bytes)

--- a/pkg/sds/server/v3/reconciler.go
+++ b/pkg/sds/server/v3/reconciler.go
@@ -161,7 +161,7 @@ func (d *DataplaneReconciler) generateSnapshot(dataplane *mesh_core.DataplaneRes
 }
 
 func (d *DataplaneReconciler) updateInsights(dataplaneId core_model.ResourceKey, snapshot envoy_cache.Snapshot) error {
-	secret := snapshot.Resources[envoy_types.Secret].Items[tls.IdentityCertResource].(*envoy_auth.Secret)
+	secret := snapshot.Resources[envoy_types.Secret].Items[tls.IdentityCertResource].Resource.(*envoy_auth.Secret)
 	certPEM := secret.GetTlsCertificate().CertificateChain.GetInlineBytes()
 	block, _ := pem.Decode(certPEM)
 	cert, err := x509.ParseCertificate(block.Bytes)

--- a/pkg/util/cache/v2/cache.go
+++ b/pkg/util/cache/v2/cache.go
@@ -14,7 +14,7 @@ func ToDeltaDiscoveryResponse(s ctl_cache.Snapshot) (*v2.DeltaDiscoveryResponse,
 	for _, rs := range s.Resources {
 		for _, name := range sortedResourceNames(rs) {
 			r := rs.Items[name]
-			pbany, err := ptypes.MarshalAny(r)
+			pbany, err := ptypes.MarshalAny(r.Resource)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/util/cache/v3/cache.go
+++ b/pkg/util/cache/v3/cache.go
@@ -14,7 +14,7 @@ func ToDeltaDiscoveryResponse(s ctl_cache.Snapshot) (*v3.DeltaDiscoveryResponse,
 	for _, rs := range s.Resources {
 		for _, name := range sortedResourceNames(rs) {
 			r := rs.Items[name]
-			pbany, err := ptypes.MarshalAny(r)
+			pbany, err := ptypes.MarshalAny(r.Resource)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/xds/envoy/listeners/v3/original_dst_forwarder_configurer.go
+++ b/pkg/xds/envoy/listeners/v3/original_dst_forwarder_configurer.go
@@ -2,6 +2,7 @@ package v3
 
 import (
 	envoy_listener "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
+	"github.com/golang/protobuf/ptypes/wrappers"
 )
 
 type OriginalDstForwarderConfigurer struct {
@@ -11,7 +12,7 @@ var _ ListenerConfigurer = &OriginalDstForwarderConfigurer{}
 
 func (c *OriginalDstForwarderConfigurer) Configure(l *envoy_listener.Listener) error {
 	// TODO(yskopets): What is the up-to-date alternative ?
-	// l.UseOriginalDst = &wrappers.BoolValue{Value: true}
+	l.UseOriginalDst = &wrappers.BoolValue{Value: true}
 
 	return nil
 }

--- a/pkg/xds/envoy/listeners/v3/transparent_proxying_configurer.go
+++ b/pkg/xds/envoy/listeners/v3/transparent_proxying_configurer.go
@@ -10,10 +10,6 @@ type TransparentProxyingConfigurer struct {
 }
 
 func (c *TransparentProxyingConfigurer) Configure(l *envoy_listener.Listener) error {
-	// TODO(yskopets): What is the up-to-date alternative ?
-	l.DeprecatedV1 = &envoy_listener.Listener_DeprecatedV1{
-		BindToPort: &wrappers.BoolValue{Value: false},
-	}
-
+	l.BindToPort = &wrappers.BoolValue{Value: false}
 	return nil
 }

--- a/pkg/xds/envoy/listeners/v3/transparent_proxying_configurer_test.go
+++ b/pkg/xds/envoy/listeners/v3/transparent_proxying_configurer_test.go
@@ -54,8 +54,7 @@ var _ = Describe("TransparentProxyingConfigurer", func() {
               socketAddress:
                 address: 192.168.0.1
                 portValue: 8080
-            deprecatedV1:
-              bindToPort: false
+            bindToPort: false
 `,
 		}),
 		Entry("basic listener without transparent proxying", testCase{

--- a/pkg/xds/server/v2/reconcile.go
+++ b/pkg/xds/server/v2/reconcile.go
@@ -75,12 +75,12 @@ func reuseVersion(old, new envoy_cache.Resources) envoy_cache.Resources {
 	return new
 }
 
-func equalSnapshots(old, new map[string]envoy_types.Resource) bool {
+func equalSnapshots(old, new map[string]envoy_types.ResourceWithTtl) bool {
 	if len(new) != len(old) {
 		return false
 	}
 	for key, newValue := range new {
-		if oldValue, hasOldValue := old[key]; !hasOldValue || !proto.Equal(newValue, oldValue) {
+		if oldValue, hasOldValue := old[key]; !hasOldValue || !proto.Equal(newValue.Resource, oldValue.Resource) {
 			return false
 		}
 	}

--- a/pkg/xds/server/v2/reconcile_test.go
+++ b/pkg/xds/server/v2/reconcile_test.go
@@ -51,28 +51,38 @@ var _ = Describe("Reconcile", func() {
 		snapshot := envoy_cache.Snapshot{
 			Resources: [envoy_types.UnknownType]envoy_cache.Resources{
 				envoy_types.Listener: {
-					Items: map[string]envoy_types.Resource{
-						"listener": &envoy.Listener{},
+					Items: map[string]envoy_types.ResourceWithTtl{
+						"listener": {
+							Resource: &envoy.Listener{},
+						},
 					},
 				},
 				envoy_types.Route: {
-					Items: map[string]envoy_types.Resource{
-						"route": &envoy.RouteConfiguration{},
+					Items: map[string]envoy_types.ResourceWithTtl{
+						"route": {
+							Resource: &envoy.RouteConfiguration{},
+						},
 					},
 				},
 				envoy_types.Cluster: {
-					Items: map[string]envoy_types.Resource{
-						"cluster": &envoy.Cluster{},
+					Items: map[string]envoy_types.ResourceWithTtl{
+						"cluster": {
+							Resource: &envoy.Cluster{},
+						},
 					},
 				},
 				envoy_types.Endpoint: {
-					Items: map[string]envoy_types.Resource{
-						"endpoint": &envoy.ClusterLoadAssignment{},
+					Items: map[string]envoy_types.ResourceWithTtl{
+						"endpoint": {
+							Resource: &envoy.ClusterLoadAssignment{},
+						},
 					},
 				},
 				envoy_types.Secret: {
-					Items: map[string]envoy_types.Resource{
-						"secret": &envoy_auth.Secret{},
+					Items: map[string]envoy_types.ResourceWithTtl{
+						"secret": {
+							Resource: &envoy_auth.Secret{},
+						},
 					},
 				},
 			},

--- a/pkg/xds/server/v3/reconcile.go
+++ b/pkg/xds/server/v3/reconcile.go
@@ -75,12 +75,12 @@ func reuseVersion(old, new envoy_cache.Resources) envoy_cache.Resources {
 	return new
 }
 
-func equalSnapshots(old, new map[string]envoy_types.Resource) bool {
+func equalSnapshots(old, new map[string]envoy_types.ResourceWithTtl) bool {
 	if len(new) != len(old) {
 		return false
 	}
 	for key, newValue := range new {
-		if oldValue, hasOldValue := old[key]; !hasOldValue || !proto.Equal(newValue, oldValue) {
+		if oldValue, hasOldValue := old[key]; !hasOldValue || !proto.Equal(newValue.Resource, oldValue.Resource) {
 			return false
 		}
 	}

--- a/pkg/xds/server/v3/reconcile_test.go
+++ b/pkg/xds/server/v3/reconcile_test.go
@@ -50,28 +50,38 @@ var _ = Describe("Reconcile", func() {
 		snapshot := envoy_cache.Snapshot{
 			Resources: [envoy_types.UnknownType]envoy_cache.Resources{
 				envoy_types.Listener: {
-					Items: map[string]envoy_types.Resource{
-						"listener": &envoy.Listener{},
+					Items: map[string]envoy_types.ResourceWithTtl{
+						"listener": {
+							Resource: &envoy.Listener{},
+						},
 					},
 				},
 				envoy_types.Route: {
-					Items: map[string]envoy_types.Resource{
-						"route": &envoy.RouteConfiguration{},
+					Items: map[string]envoy_types.ResourceWithTtl{
+						"route": {
+							Resource: &envoy.RouteConfiguration{},
+						},
 					},
 				},
 				envoy_types.Cluster: {
-					Items: map[string]envoy_types.Resource{
-						"cluster": &envoy.Cluster{},
+					Items: map[string]envoy_types.ResourceWithTtl{
+						"cluster": {
+							Resource: &envoy.Cluster{},
+						},
 					},
 				},
 				envoy_types.Endpoint: {
-					Items: map[string]envoy_types.Resource{
-						"endpoint": &envoy.ClusterLoadAssignment{},
+					Items: map[string]envoy_types.ResourceWithTtl{
+						"endpoint": {
+							Resource: &envoy.ClusterLoadAssignment{},
+						},
 					},
 				},
 				envoy_types.Secret: {
-					Items: map[string]envoy_types.Resource{
-						"secret": &envoy_auth.Secret{},
+					Items: map[string]envoy_types.ResourceWithTtl{
+						"secret": {
+							Resource: &envoy_auth.Secret{},
+						},
 					},
 				},
 			},

--- a/pkg/xds/server/v3/testdata/envoy-config.golden.yaml
+++ b/pkg/xds/server/v3/testdata/envoy-config.golden.yaml
@@ -58,8 +58,7 @@ resources:
         socketAddress:
           address: 192.168.0.1
           portValue: 443
-      deprecatedV1:
-        bindToPort: false
+      bindToPort: false
       filterChains:
         - filters:
             - name: envoy.filters.network.rbac
@@ -121,8 +120,7 @@ resources:
         socketAddress:
           address: 192.168.0.1
           portValue: 80
-      deprecatedV1:
-        bindToPort: false
+      bindToPort: false
       filterChains:
         - filters:
             - name: envoy.filters.network.rbac
@@ -192,8 +190,7 @@ resources:
         socketAddress:
           address: 192.168.0.2
           portValue: 443
-      deprecatedV1:
-        bindToPort: false
+      bindToPort: false
       filterChains:
         - filters:
             - name: envoy.filters.network.rbac
@@ -255,8 +252,7 @@ resources:
         socketAddress:
           address: 192.168.0.2
           portValue: 80
-      deprecatedV1:
-        bindToPort: false
+      bindToPort: false
       filterChains:
         - filters:
             - name: envoy.filters.network.rbac
@@ -327,6 +323,7 @@ resources:
                 statPrefix: inbound_passthrough
       name: inbound:passthrough
       trafficDirection: INBOUND
+      useOriginalDst: true
   - name: outbound:passthrough
     resource:
       '@type': type.googleapis.com/envoy.config.listener.v3.Listener
@@ -343,3 +340,4 @@ resources:
                 statPrefix: outbound_passthrough
       name: outbound:passthrough
       trafficDirection: OUTBOUND
+      useOriginalDst: true


### PR DESCRIPTION
### Summary

This PR uses restores support for transparent proxy in V3.

To do this we had to upgrade to Envoy 1.17 (done) and use new Envoy config that has bind_to_port undeprecated.
For those new proto I had to upgrade the go-control-plane to the newest version from master. They introduced changes in Snapshot so I had to update our modified Snapshot as an interface.

### Documentation

- [X] No docs
