### PR TITLE
chore(kuma-dp) upgrade Envoy version to 1.17.0

### DIFF
--- a/app/kuma-dp/pkg/dataplane/envoy/envoy.go
+++ b/app/kuma-dp/pkg/dataplane/envoy/envoy.go
@@ -147,7 +147,7 @@ func (e *Envoy) Start(stop <-chan struct{}) error {
 	command := exec.CommandContext(ctx, resolvedPath, args...)
 	command.Stdout = e.opts.Stdout
 	command.Stderr = e.opts.Stderr
-	runLog.Info("starting Envoy")
+	runLog.Info("starting Envoy", "args", args)
 	if err := command.Start(); err != nil {
 		runLog.Error(err, "the envoy executable was found at "+resolvedPath+" but an error occurred when executing it")
 		return err

--- a/pkg/xds/bootstrap/handler.go
+++ b/pkg/xds/bootstrap/handler.go
@@ -62,9 +62,9 @@ func (b *BootstrapHandler) Handle(resp http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	resp.WriteHeader(http.StatusOK)
 	resp.Header().Set("content-type", "text/x-yaml")
 	resp.Header().Set(types.BootstrapVersionHeader, string(version))
+	resp.WriteHeader(http.StatusOK)
 	_, err = resp.Write(bytes)
 	if err != nil {
 		logger.Error(err, "Error while writing the response")

--- a/test/dockerfiles/Dockerfile.universal
+++ b/test/dockerfiles/Dockerfile.universal
@@ -1,5 +1,5 @@
 # using Envoy's base to copy the Envoy binary
-FROM envoyproxy/envoy-alpine:v1.16.1 as envoy
+FROM envoyproxy/envoy-alpine:v1.17.0 as envoy
 
 FROM ubuntu:bionic as builder
 

--- a/tools/releases/distros.sh
+++ b/tools/releases/distros.sh
@@ -13,7 +13,7 @@ BINTRAY_ENDPOINT="https://api.bintray.com/"
 BINTRAY_SUBJECT="kong"
 [ -z "$BINTRAY_REPOSITORY" ] && BINTRAY_REPOSITORY="kuma"
 [ -z "$RELEASE_NAME" ] && RELEASE_NAME="kuma"
-ENVOY_VERSION=1.16.1
+ENVOY_VERSION=1.17.0
 [ -z "$KUMA_CONFIG_PATH" ] && KUMA_CONFIG_PATH=pkg/config/app/kuma-cp/kuma-cp.defaults.yaml
 
 function msg_green {

--- a/tools/releases/dockerfiles/Dockerfile.kuma-dp
+++ b/tools/releases/dockerfiles/Dockerfile.kuma-dp
@@ -1,5 +1,5 @@
 # using Envoy's base to inherit the Envoy binary
-FROM envoyproxy/envoy-alpine:v1.16.2
+FROM envoyproxy/envoy-alpine:v1.17.0
 
 ADD $KUMA_ROOT/build/artifacts-linux-amd64/kuma-dp/kuma-dp /usr/bin
 


### PR DESCRIPTION
### Summary

Upgrade to Envoy 1.17.

https://www.envoyproxy.io/docs/envoy/latest/version_history/v1.17.0

The most important changes
* V2 is only supported if you pass `--bootstrap-version` as CLI arg (therefore this PR is not against master for now)
* Some depreciations in V3 which will be fixed in the following PRs

This PR is meant to be merged only to master, not `release-1.0`.

Envoy binaries are uploaded to bintray.

### Documentation

- [X] No docs
