### PR TITLE
chore(ci) test V3 in E2E tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -700,6 +700,13 @@ workflows:
             - images
           # custom parameters
           target: test/e2e
+      - integration:
+          <<: *commit_workflow_filters
+          name: test/e2e V3
+          requires:
+            - images
+          # custom parameters
+          target: test/e2e API_VERSION=v3
 
   kuma-release:
     jobs:

--- a/mk/e2e.new.mk
+++ b/mk/e2e.new.mk
@@ -1,6 +1,7 @@
 K8SCLUSTERS = kuma-1 kuma-2
 K8SCLUSTERS_START_TARGETS = $(addprefix test/e2e/kind/start/cluster/, $(K8SCLUSTERS))
 K8SCLUSTERS_STOP_TARGETS  = $(addprefix test/e2e/kind/stop/cluster/, $(K8SCLUSTERS))
+API_VERSION ?= v2
 
 KUMA_UNIVERSAL_DOCKER_IMAGE ?= kuma-universal
 KUMA_UNIVERSAL_DOCKERFILE ?= test/dockerfiles/Dockerfile.universal
@@ -43,6 +44,7 @@ test/e2e/kind/stop: $(K8SCLUSTERS_STOP_TARGETS)
 test/e2e/test:
 	K8SCLUSTERS="$(K8SCLUSTERS)" \
 	KUMACTLBIN=${BUILD_ARTIFACTS_DIR}/kumactl/kumactl \
+	API_VERSION="$(API_VERSION)" \
 		$(GO_TEST) -v -timeout=45m ./test/e2e/...
 
 # test/e2e/debug is used for quicker feedback of E2E tests (ex. debugging flaky tests)
@@ -54,6 +56,7 @@ test/e2e/test:
 test/e2e/debug: build/kumactl images docker/build/universal test/e2e/kind/start
 	K8SCLUSTERS="$(K8SCLUSTERS)" \
 	KUMACTLBIN=${BUILD_ARTIFACTS_DIR}/kumactl/kumactl \
+	API_VERSION="$(API_VERSION)" \
 	GINKGO_EDITOR_INTEGRATION=true \
 		ginkgo --failFast $(GOFLAGS) $(LD_FLAGS) ./test/e2e/...
 	$(MAKE) test/e2e/kind/stop

--- a/test/framework/constants.go
+++ b/test/framework/constants.go
@@ -28,6 +28,7 @@ const (
 
 	envKUMACTLBIN  = "KUMACTLBIN"
 	envK8SCLUSTERS = "K8SCLUSTERS"
+	envAPIVersion  = "API_VERSION"
 
 	maxClusters = 3
 

--- a/test/framework/k8s_cluster.go
+++ b/test/framework/k8s_cluster.go
@@ -270,6 +270,11 @@ func (c *K8sCluster) yamlForKumaViaKubectl(mode string, opts *deployOptions) (st
 		argsMap["--cni-conf-name"] = "10-kindnet.conflist"
 	}
 
+	apiVersion := os.Getenv(envAPIVersion)
+	if apiVersion != "" {
+		argsMap["--env-var"] = "KUMA_BOOTSTRAP_SERVER_API_VERSION=" + apiVersion
+	}
+
 	for opt, value := range opts.ctlOpts {
 		argsMap[opt] = value
 	}
@@ -305,6 +310,11 @@ func (c *K8sCluster) deployKumaViaHelm(mode string, opts *deployOptions) error {
 	}
 	for opt, value := range opts.helmOpts {
 		values[opt] = value
+	}
+
+	apiVersion := os.Getenv(envAPIVersion)
+	if apiVersion != "" {
+		values["controlPlane.envVars.KUMA_BOOTSTRAP_SERVER_API_VERSION"] = apiVersion
 	}
 
 	if opts.cni {


### PR DESCRIPTION
### Summary

This PR introduces parallel E2E tests that runs on V3 Envoy configuration. We want to only execute those tests on master to reduce CI on every commit on the branch.
