### PR TITLE
feat(kuma-dp) rename tokenPath metadata field name

### DIFF
--- a/pkg/core/xds/metadata.go
+++ b/pkg/core/xds/metadata.go
@@ -16,7 +16,7 @@ var metadataLog = core.Log.WithName("xds-server").WithName("metadata-tracker")
 const (
 	// Supported Envoy node metadata fields.
 
-	fieldDataplaneTokenPath         = "dataplaneTokenPath"
+	fieldDataplaneTokenPath         = "dataplane.token.filename"
 	fieldDataplaneAdminPort         = "dataplane.admin.port"
 	fieldDataplaneDataplaneResource = "dataplane.resource"
 )
@@ -66,6 +66,9 @@ func DataplaneMetadataFromXdsMetadata(xdsMetadata *_struct.Struct) *DataplaneMet
 	metadata := DataplaneMetadata{}
 	if xdsMetadata == nil {
 		return &metadata
+	}
+	if field := xdsMetadata.Fields["dataplaneTokenPath"]; field != nil {
+		metadata.DataplaneTokenPath = field.GetStringValue()
 	}
 	if field := xdsMetadata.Fields[fieldDataplaneTokenPath]; field != nil {
 		metadata.DataplaneTokenPath = field.GetStringValue()

--- a/pkg/core/xds/metadata_test.go
+++ b/pkg/core/xds/metadata_test.go
@@ -29,7 +29,7 @@ var _ = DescribeTable("DataplaneMetadataFromXdsMetadata",
 	Entry("should parse metadata", testCase{
 		node: &pstruct.Struct{
 			Fields: map[string]*pstruct.Value{
-				"dataplaneTokenPath": &pstruct.Value{
+				"dataplane.token.filename": &pstruct.Value{
 					Kind: &pstruct.Value_StringValue{
 						StringValue: "/tmp/token",
 					},

--- a/pkg/xds/bootstrap/template_v2.go
+++ b/pkg/xds/bootstrap/template_v2.go
@@ -6,7 +6,7 @@ node:
   cluster: {{.Service}}
   metadata:
 {{if .DataplaneTokenPath}}
-    dataplaneTokenPath: {{.DataplaneTokenPath}}
+    dataplane.token.filename: {{.DataplaneTokenPath}}
 {{end}}
 {{if .DataplaneResource}}
     dataplane.resource: '{{.DataplaneResource}}'

--- a/pkg/xds/bootstrap/template_v3.go
+++ b/pkg/xds/bootstrap/template_v3.go
@@ -6,7 +6,7 @@ node:
   cluster: {{.Service}}
   metadata:
 {{if .DataplaneTokenPath}}
-    dataplaneTokenPath: {{.DataplaneTokenPath}}
+    dataplane.token.filename: {{.DataplaneTokenPath}}
 {{end}}
 {{if .DataplaneResource}}
     dataplane.resource: '{{.DataplaneResource}}'

--- a/pkg/xds/bootstrap/testdata/bootstrap.k8s.golden.yaml
+++ b/pkg/xds/bootstrap/testdata/bootstrap.k8s.golden.yaml
@@ -26,7 +26,7 @@ node:
   cluster: backend
   id: default.dp-1.default
   metadata:
-    dataplaneTokenPath: /tmp/token
+    dataplane.token.filename: /tmp/token
     version:
       kumaDp:
         version: 0.0.1

--- a/pkg/xds/bootstrap/testdata/bootstrap.overridden.golden.yaml
+++ b/pkg/xds/bootstrap/testdata/bootstrap.overridden.golden.yaml
@@ -33,7 +33,7 @@ node:
   id: default.dp-1.default
   metadata:
     dataplane.admin.port: "1234"
-    dataplaneTokenPath: /tmp/token
+    dataplane.token.filename: /tmp/token
     version:
       kumaDp:
         version: 0.0.1

--- a/pkg/xds/bootstrap/testdata/bootstrap.universal.golden.yaml
+++ b/pkg/xds/bootstrap/testdata/bootstrap.universal.golden.yaml
@@ -26,7 +26,7 @@ node:
   cluster: backend
   id: default.dp-1
   metadata:
-    dataplaneTokenPath: /tmp/token
+    dataplane.token.filename: /tmp/token
     version:
       kumaDp:
         version: 0.0.1

--- a/pkg/xds/bootstrap/testdata/generator.custom-config.golden.yaml
+++ b/pkg/xds/bootstrap/testdata/generator.custom-config.golden.yaml
@@ -34,7 +34,7 @@ node:
   metadata:
     dataplane.admin.port: "1234"
     dataplane.resource: ' { "type": "Dataplane", "mesh": "mesh", "name": "name.namespace", "creationTime": "1970-01-01T00:00:00Z", "modificationTime": "1970-01-01T00:00:00Z", "networking": { "address": "127.0.0.1", "inbound": [ { "port": 22022, "servicePort": 8443, "tags": { "kuma.io/protocol": "http2", "kuma.io/service": "backend" } }, ] } }'
-    dataplaneTokenPath: /tmp/token
+    dataplane.token.filename: /tmp/token
     version:
       kumaDp:
         version: 0.0.1

--- a/pkg/xds/bootstrap/testdata/generator.default-config.golden.yaml
+++ b/pkg/xds/bootstrap/testdata/generator.default-config.golden.yaml
@@ -35,7 +35,7 @@ node:
   id: mesh.name.namespace
   metadata:
     dataplane.admin.port: "1234"
-    dataplaneTokenPath: /tmp/token
+    dataplane.token.filename: /tmp/token
     version:
       envoy:
         build: hash/1.15.0/RELEASE

--- a/pkg/xds/server/callbacks/dataplane_metadata_tracker_test.go
+++ b/pkg/xds/server/callbacks/dataplane_metadata_tracker_test.go
@@ -22,7 +22,7 @@ var _ = Describe("Dataplane Metadata Tracker", func() {
 			Id: "default.example",
 			Metadata: &pstruct.Struct{
 				Fields: map[string]*pstruct.Value{
-					"dataplaneTokenPath": &pstruct.Value{
+					"dataplane.token.filename": &pstruct.Value{
 						Kind: &pstruct.Value_StringValue{
 							StringValue: "/tmp/token",
 						},

--- a/pkg/xds/server/callbacks/dataplane_status_tracker_test.go
+++ b/pkg/xds/server/callbacks/dataplane_status_tracker_test.go
@@ -219,7 +219,7 @@ var _ = Describe("DataplaneStatusTracker", func() {
 					Id: "default.example-001",
 					Metadata: &pstruct.Struct{
 						Fields: map[string]*pstruct.Value{
-							"dataplaneTokenPath": {
+							"dataplane.token.filename": {
 								Kind: &pstruct.Value_StringValue{
 									StringValue: "/tmp/token",
 								},


### PR DESCRIPTION
renamed `dataplaneTokenPath` to `dataplane.token.filename` in envoy metadata

Fix #512

Signed-off-by: Tharun <rajendrantharun@live.com>

- [ ] Link to the website [documentation PR](https://github.com/kumahq/kuma-website/pull/XXX)
