### PR TITLE
feat(kuma-dp) Expose the possibility to add ProxyTemplates publicly

### DIFF
--- a/pkg/xds/generator/proxy_template.go
+++ b/pkg/xds/generator/proxy_template.go
@@ -80,8 +80,12 @@ func NewDefaultProxyProfile() ResourceGenerator {
 }
 
 func init() {
-	predefinedProfiles[mesh_core.ProfileDefaultProxy] = NewDefaultProxyProfile()
-	predefinedProfiles[IngressProxy] = CompositeResourceGenerator{AdminProxyGenerator{}, IngressGenerator{}}
+	RegisterProfile(mesh_core.ProfileDefaultProxy, NewDefaultProxyProfile())
+	RegisterProfile(IngressProxy, CompositeResourceGenerator{AdminProxyGenerator{}, IngressGenerator{}})
+}
+
+func RegisterProfile(profileName string, generator ResourceGenerator) {
+	predefinedProfiles[profileName] = generator
 }
 
 type ProxyTemplateProfileSource struct {


### PR DESCRIPTION
Populating the `predefinedProfiles` map was not possible publicly.
This is limiting for anyone wanting to make custom profiles
