### PR TITLE
chore(*) generate both DNS compliant and non-compliant names

### DIFF
--- a/pkg/dns/components.go
+++ b/pkg/dns/components.go
@@ -19,6 +19,7 @@ func Setup(rt runtime.Runtime) error {
 		rt.Config().DNSServer.Port,
 		rt.DNSResolver(),
 		rt.Metrics(),
+		DnsNameToKumaCompliant,
 	)
 	if err != nil {
 		return err

--- a/pkg/dns/name_modifier.go
+++ b/pkg/dns/name_modifier.go
@@ -1,0 +1,26 @@
+package dns
+
+import "strings"
+
+func DnsNameToKumaCompliant(name string) (string, error) {
+	// the request might be of the form:
+	//  service-name.namespace.something-else.mesh.
+	// it will always end with a dot, as specified by https://tools.ietf.org/html/rfc1034#section-3.1
+	//  `Since a complete domain name ends with the root label, this leads to a printed form which ends in a dot.`
+	countDots := strings.Count(name, ".")
+	toReplace := countDots
+	switch countDots {
+	case 0:
+		return name, nil
+	case 1:
+		if name[len(name)-1] == '.' {
+			return name, nil
+		}
+	default:
+		if name[len(name)-1] == '.' {
+			toReplace--
+		}
+	}
+
+	return strings.Replace(name, ".", "_", toReplace-1), nil
+}

--- a/pkg/dns/name_modifier_test.go
+++ b/pkg/dns/name_modifier_test.go
@@ -1,0 +1,57 @@
+package dns_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+
+	"github.com/kumahq/kuma/pkg/dns"
+)
+
+var _ = Describe("DNS name modifier", func() {
+	type testCase struct {
+		input    string
+		expected string
+	}
+
+	DescribeTable("should modify names",
+		func(given testCase) {
+			// when
+			actual, err := dns.DnsNameToKumaCompliant(given.input)
+
+			// then
+			Expect(err).ToNot(HaveOccurred())
+			// and
+			Expect(actual).To(MatchYAML(given.expected))
+		},
+		Entry("empty", testCase{
+			input:    "",
+			expected: "",
+		}),
+		Entry("one last dot", testCase{
+			input:    "mesh.",
+			expected: "mesh.",
+		}),
+		Entry("one dot", testCase{
+			input:    ".mesh",
+			expected: ".mesh",
+		}),
+		Entry("two dots with last", testCase{
+			input:    "a.mesh.",
+			expected: "a.mesh.",
+		}),
+		Entry("two dots", testCase{
+			input:    "a.b.mesh",
+			expected: "a_b.mesh",
+		}),
+		Entry("three dots with last", testCase{
+			input:    "a.b.mesh.",
+			expected: "a_b.mesh.",
+		}),
+		Entry("three dots", testCase{
+			input:    "a.b.c.mesh",
+			expected: "a_b_c.mesh",
+		}),
+	)
+
+})

--- a/pkg/dns/server.go
+++ b/pkg/dns/server.go
@@ -21,15 +21,18 @@ type DNSServer interface {
 	NeedLeaderElection() bool
 }
 
+type NameModifier = func(qName string) (string, error)
+
 type SimpleDNSServer struct {
 	address  string
 	resolver resolver.DNSResolver
 
 	latencyMetric    prometheus.Summary
 	resolutionMetric *prometheus.CounterVec
+	nameModifier     NameModifier
 }
 
-func NewDNSServer(port uint32, resolver resolver.DNSResolver, metrics core_metrics.Metrics) (DNSServer, error) {
+func NewDNSServer(port uint32, resolver resolver.DNSResolver, metrics core_metrics.Metrics, modifier NameModifier) (DNSServer, error) {
 	handler := &SimpleDNSServer{
 		address:  fmt.Sprintf("0.0.0.0:%d", port),
 		resolver: resolver,
@@ -42,6 +45,7 @@ func NewDNSServer(port uint32, resolver resolver.DNSResolver, metrics core_metri
 			Name: "dns_server_resolution",
 			Help: "Counter for DNS Server resolutions",
 		}, []string{"result"}),
+		nameModifier: modifier,
 	}
 	if err := metrics.Register(handler.latencyMetric); err != nil {
 		return nil, err
@@ -57,8 +61,8 @@ func (h *SimpleDNSServer) parseQuery(m *dns.Msg) {
 	for _, q := range m.Question {
 		switch q.Qtype {
 		case dns.TypeA:
-			serverLog.V(1).Info("query for " + q.Name)
-			ip, err := h.resolver.ForwardLookupFQDN(q.Name)
+			serverLog.V(1).Info("received a query for " + q.Name)
+			ip, err := h.lookup(q.Name)
 			if err != nil {
 				serverLog.V(1).Info("unable to resolve", "Name", q.Name, "error", err.Error())
 				h.resolutionMetric.WithLabelValues("unresolved").Inc()
@@ -131,4 +135,25 @@ func (h *SimpleDNSServer) registerDNSHandler() {
 		}()
 		h.handleDNSRequest(writer, msg)
 	})
+}
+
+func (h *SimpleDNSServer) lookup(qName string) (string, error) {
+	ip, err := h.resolver.ForwardLookupFQDN(qName)
+	if err != nil {
+		if h.nameModifier == nil {
+			return "", err
+		}
+
+		modifiedName, err := h.nameModifier(qName)
+		if err != nil {
+			return "", err
+		}
+
+		ip, err = h.resolver.ForwardLookupFQDN(modifiedName)
+		if err != nil {
+			return "", err
+		}
+	}
+
+	return ip, nil
 }


### PR DESCRIPTION
### Summary

Add a resolve for `.mesh` names with `.` instead of `_`. The latter is not compliant with the canonical DNS RFCs and therefore not supported by Kubernetes and other dev frameworks to be referred to.

Example: `kuma-test_namespace_svc_80.mesh` will resolve to the same VIP as `kuma-test.namespace.svc.80.mesh`

### Documentation

- [x] Link to the website [documentation PR](https://github.com/kumahq/kuma/pull/1519)
 -[x] #1519 
