### PR TITLE
feat(deployments) Add affinity, pdb, and hpa support

### DIFF
--- a/deployments/charts/kuma/Chart.yaml
+++ b/deployments/charts/kuma/Chart.yaml
@@ -3,7 +3,7 @@ name: kuma
 description: A Helm chart for the Kuma Control Plane
 type: application
 version: 0.4.8
-appVersion: 1.0.7
+appVersion: 1.0.8
 home: https://github.com/kumahq/kuma
 maintainers:
   - name: austince

--- a/deployments/charts/kuma/README.md
+++ b/deployments/charts/kuma/README.md
@@ -75,9 +75,9 @@ A Helm chart for the Kuma Control Plane
 | ingress.autoscaling.maxReplicas | int | `5` | The max Ingress pods to scale to |
 | ingress.autoscaling.targetCPUUtilizationPercentage | int | `80` | For clusters that don't support autoscaling/v2beta, autoscaling/v1 is used |
 | ingress.autoscaling.metrics | list | `[{"resource":{"name":"cpu","target":{"averageUtilization":80,"type":"Utilization"}},"type":"Resource"}]` | For clusters that do support autoscaling/v2beta, use metrics |
-| ingress.autoscaling.podDisruptionBudget.enabled | bool | `false` | Weather to enable a Pod Disruption Budget for the ingress pods |
-| ingress.autoscaling.podDisruptionBudget.maxUnavailable | string | `"50%"` | The maximum percentage of unavailable ingress pods |
-| ingress.autoscaling.affinity | object | `{}` | For affinity configurations |
+| ingress.podDisruptionBudget.enabled | bool | `false` | Weather to enable a Pod Disruption Budget for the ingress pods |
+| ingress.podDisruptionBudget.maxUnavailable | string | `"50%"` | The maximum percentage of unavailable ingress pods |
+| ingress.podDisruptionBudget.affinity | object | `{}` | For affinity configurations |
 | kumactl.image.repository | string | `"kumactl"` | The kumactl image repository |
 
 ## Custom Resource Definitions

--- a/deployments/charts/kuma/README.md
+++ b/deployments/charts/kuma/README.md
@@ -25,6 +25,7 @@ A Helm chart for the Kuma Control Plane
 | controlPlane.autoscaling.targetCPUUtilizationPercentage | int | `80` | For clusters that don't support autoscaling/v2beta, autoscaling/v1 is used |
 | controlPlane.autoscaling.metrics | list | `[{"resource":{"name":"cpu","target":{"averageUtilization":80,"type":"Utilization"}},"type":"Resource"}]` | For clusters that do support autoscaling/v2beta, use metrics |
 | controlPlane.nodeSelector | object | `{"kubernetes.io/arch":"amd64","kubernetes.io/os":"linux"}` | Node selector for the Kuma Control Plane pods |
+| controlPlane.affinity | object | `{}` | For affinity configurations |
 | controlPlane.injectorFailurePolicy | string | `"Ignore"` | Failure policy of the mutating webhook implemented by the Kuma Injector component |
 | controlPlane.service.name | string | `nil` | Optionally override of the Kuma Control Plane Service's name |
 | controlPlane.service.type | string | `"ClusterIP"` | Service type of the Kuma Control Plane |
@@ -76,6 +77,7 @@ A Helm chart for the Kuma Control Plane
 | ingress.autoscaling.metrics | list | `[{"resource":{"name":"cpu","target":{"averageUtilization":80,"type":"Utilization"}},"type":"Resource"}]` | For clusters that do support autoscaling/v2beta, use metrics |
 | ingress.autoscaling.podDisruptionBudget.enabled | bool | `false` | Weather to enable a Pod Disruption Budget for the ingress pods |
 | ingress.autoscaling.podDisruptionBudget.maxUnavailable | string | `"50%"` | The maximum percentage of unavailable ingress pods |
+| ingress.autoscaling.affinity | object | `{}` | For affinity configurations |
 | kumactl.image.repository | string | `"kumactl"` | The kumactl image repository |
 
 ## Custom Resource Definitions

--- a/deployments/charts/kuma/README.md
+++ b/deployments/charts/kuma/README.md
@@ -47,6 +47,8 @@ A Helm chart for the Kuma Control Plane
 | controlPlane.envVars | object | `{}` | Additional environment variables that will be passed to the control plane |
 | controlPlane.webhooks.validator.additionalRules | string | `""` | Additional rules to apply on Kuma validator webhook. Useful when building custom policy on top of Kuma. |
 | controlPlane.webhooks.ownerReference.additionalRules | string | `""` | Additional rules to apply on Kuma owner reference webhook. Useful when building custom policy on top of Kuma. |
+| controlPlane.podDisruptionBudget.enabled | bool | `false` | Weather to enable a Pod Disruption Budget for the control plane pods |
+| controlPlane.podDisruptionBudget.maxUnavailable | string | `"50%"` | The maximum percentage of unavailable control plane pods |
 | cni.enabled | bool | `false` | Install Kuma with CNI instead of proxy init container |
 | cni.chained | bool | `false` | Install CNI in chained mode |
 | cni.netDir | string | `"/etc/cni/multus/net.d"` | Set the CNI install directory |
@@ -72,6 +74,8 @@ A Helm chart for the Kuma Control Plane
 | ingress.autoscaling.maxReplicas | int | `5` | The max Ingress pods to scale to |
 | ingress.autoscaling.targetCPUUtilizationPercentage | int | `80` | For clusters that don't support autoscaling/v2beta, autoscaling/v1 is used |
 | ingress.autoscaling.metrics | list | `[{"resource":{"name":"cpu","target":{"averageUtilization":80,"type":"Utilization"}},"type":"Resource"}]` | For clusters that do support autoscaling/v2beta, use metrics |
+| ingress.autoscaling.podDisruptionBudget.enabled | bool | `false` | Weather to enable a Pod Disruption Budget for the ingress pods |
+| ingress.autoscaling.podDisruptionBudget.maxUnavailable | string | `"50%"` | The maximum percentage of unavailable ingress pods |
 | kumactl.image.repository | string | `"kumactl"` | The kumactl image repository |
 
 ## Custom Resource Definitions

--- a/deployments/charts/kuma/README.md
+++ b/deployments/charts/kuma/README.md
@@ -2,7 +2,7 @@
 
 A Helm chart for the Kuma Control Plane
 
-![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![Version: 0.4.8](https://img.shields.io/badge/Version-0.4.8-informational?style=flat-square) ![AppVersion: 1.0.7](https://img.shields.io/badge/AppVersion-1.0.7-informational?style=flat-square)
+![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![Version: 0.4.8](https://img.shields.io/badge/Version-0.4.8-informational?style=flat-square) ![AppVersion: 1.0.8](https://img.shields.io/badge/AppVersion-1.0.8-informational?style=flat-square)
 
 **Homepage:** <https://github.com/kumahq/kuma>
 
@@ -67,6 +67,11 @@ A Helm chart for the Kuma Control Plane
 | ingress.service.type | string | `"LoadBalancer"` | Service type of the Ingress |
 | ingress.service.annotations | object | `{}` | Additional annotations to put on the Ingress service |
 | ingress.service.port | int | `10001` | Port on which Ingress is exposed |
+| ingress.autoscaling.enabled | bool | `false` | Whether to enable Horizontal Pod Autoscaling, which requires the [Metrics Server](https://github.com/kubernetes-sigs/metrics-server) in the cluster |
+| ingress.autoscaling.minReplicas | int | `2` | The minimum Ingress pods to allow |
+| ingress.autoscaling.maxReplicas | int | `5` | The max Ingress pods to scale to |
+| ingress.autoscaling.targetCPUUtilizationPercentage | int | `80` | For clusters that don't support autoscaling/v2beta, autoscaling/v1 is used |
+| ingress.autoscaling.metrics | list | `[{"resource":{"name":"cpu","target":{"averageUtilization":80,"type":"Utilization"}},"type":"Resource"}]` | For clusters that do support autoscaling/v2beta, use metrics |
 | kumactl.image.repository | string | `"kumactl"` | The kumactl image repository |
 
 ## Custom Resource Definitions

--- a/deployments/charts/kuma/templates/cp-deployment.yaml
+++ b/deployments/charts/kuma/templates/cp-deployment.yaml
@@ -147,3 +147,7 @@ spec:
         - name: {{ include "kuma.name" . }}-control-plane-config
           configMap:
             name: {{ include "kuma.name" . }}-control-plane-config
+      {{- if .Values.controlPlane.affinity }}
+      affinity:
+{{ toYaml .Values.controlPlane.affinity | indent 8 }}
+      {{- end }}

--- a/deployments/charts/kuma/templates/cp-pdb.yaml
+++ b/deployments/charts/kuma/templates/cp-pdb.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.controlPlane.podDisruptionBudget.enabled }}
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "kuma.name" . }}-control-plane
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "kuma.labels" . | nindent 4 }}
+spec:
+  {{- if .Values.controlPlane.podDisruptionBudget.minAvailable }}
+  minAvailable: {{ .Values.controlPlane.podDisruptionBudget.minAvailable }}
+  {{- end  }}
+  {{- if .Values.controlPlane.podDisruptionBudget.maxUnavailable }}
+  maxUnavailable: {{ .Values.controlPlane.podDisruptionBudget.maxUnavailable }}
+  {{- end  }}
+  selector:
+    matchLabels:
+      {{- include "kuma.selectorLabels" . | nindent 6 }}
+      app: kuma-control-plane
+{{- end }}

--- a/deployments/charts/kuma/templates/ingress-deployment.yaml
+++ b/deployments/charts/kuma/templates/ingress-deployment.yaml
@@ -96,4 +96,8 @@ spec:
         - name: {{ include "kuma.name" . }}-tls-cert
           secret:
             secretName: {{ include "kuma.name" . }}-tls-cert
+      {{- if .Values.ingress.affinity }}
+      affinity:
+{{ toYaml .Values.ingress.affinity | indent 8 }}
+      {{- end }}
 {{- end }}

--- a/deployments/charts/kuma/templates/ingress-hpa.yaml
+++ b/deployments/charts/kuma/templates/ingress-hpa.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.ingress.autoscaling.enabled }}
+{{- $supportsV2Beta2 := .Capabilities.APIVersions.Has "autoscaling/v2beta2" }}
+apiVersion: {{ $supportsV2Beta2 | ternary "autoscaling/v2beta2" "autoscaling/v1" }}
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "kuma.name" . }}-ingress
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "kuma.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "kuma.name" . }}-ingress
+  minReplicas: {{ .Values.ingress.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.ingress.autoscaling.maxReplicas }}
+  {{- if not $supportsV2Beta2 }}
+  targetCPUUtilizationPercentage: {{ .Values.ingress.autoscaling.targetCPUUtilizationPercentage }}
+  {{- else }}
+  metrics:
+  {{- toYaml .Values.ingress.autoscaling.metrics | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/deployments/charts/kuma/templates/ingress-pdb.yaml
+++ b/deployments/charts/kuma/templates/ingress-pdb.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.ingress.podDisruptionBudget.enabled }}
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "kuma.name" . }}-ingress
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "kuma.labels" . | nindent 4 }}
+spec:
+  {{- if .Values.ingress.podDisruptionBudget.minAvailable }}
+  minAvailable: {{ .Values.ingress.podDisruptionBudget.minAvailable }}
+  {{- end  }}
+  {{- if .Values.ingress.podDisruptionBudget.maxUnavailable }}
+  maxUnavailable: {{ .Values.ingress.podDisruptionBudget.maxUnavailable }}
+  {{- end  }}
+  selector:
+    matchLabels:
+      {{- include "kuma.selectorLabels" . | nindent 6 }}
+      app: kuma-ingress
+{{- end }}

--- a/deployments/charts/kuma/values.yaml
+++ b/deployments/charts/kuma/values.yaml
@@ -56,6 +56,9 @@ controlPlane:
     kubernetes.io/os: linux
     kubernetes.io/arch: amd64
 
+  # -- For affinity configurations
+  affinity: {}
+
   # -- Failure policy of the mutating webhook implemented by the Kuma Injector component
   injectorFailurePolicy: Ignore
 
@@ -218,6 +221,9 @@ ingress:
       enabled: false
       # -- The maximum percentage of unavailable ingress pods
       maxUnavailable: "50%"
+
+    # -- For affinity configurations
+    affinity: {}
 
 kumactl:
   image:

--- a/deployments/charts/kuma/values.yaml
+++ b/deployments/charts/kuma/values.yaml
@@ -185,6 +185,27 @@ ingress:
     # -- Port on which Ingress is exposed
     port: 10001
 
+  # Horizontal Pod Autoscaling configuration
+  autoscaling:
+    # -- Whether to enable Horizontal Pod Autoscaling, which requires the [Metrics Server](https://github.com/kubernetes-sigs/metrics-server) in the cluster
+    enabled: false
+
+    # -- The minimum Ingress pods to allow
+    minReplicas: 2
+    # -- The max Ingress pods to scale to
+    maxReplicas: 5
+
+    # -- For clusters that don't support autoscaling/v2beta, autoscaling/v1 is used
+    targetCPUUtilizationPercentage: 80
+    # -- For clusters that do support autoscaling/v2beta, use metrics
+    metrics:
+      - type: Resource
+        resource:
+          name: cpu
+          target:
+            type: Utilization
+            averageUtilization: 80
+
 kumactl:
   image:
     # -- The kumactl image repository

--- a/deployments/charts/kuma/values.yaml
+++ b/deployments/charts/kuma/values.yaml
@@ -215,12 +215,12 @@ ingress:
           target:
             type: Utilization
             averageUtilization: 80
-    # Pod Distruption Budget Configuration
-    podDisruptionBudget:
-      # -- Weather to enable a Pod Disruption Budget for the ingress pods
-      enabled: false
-      # -- The maximum percentage of unavailable ingress pods
-      maxUnavailable: "50%"
+  # Pod Distruption Budget Configuration
+  podDisruptionBudget:
+    # -- Weather to enable a Pod Disruption Budget for the ingress pods
+    enabled: false
+    # -- The maximum percentage of unavailable ingress pods
+    maxUnavailable: "50%"
 
     # -- For affinity configurations
     affinity: {}

--- a/deployments/charts/kuma/values.yaml
+++ b/deployments/charts/kuma/values.yaml
@@ -131,6 +131,13 @@ controlPlane:
       # -- Additional rules to apply on Kuma owner reference webhook. Useful when building custom policy on top of Kuma.
       additionalRules: ""
 
+  # Pod Distruption Budget Configuration
+  podDisruptionBudget:
+    # -- Weather to enable a Pod Disruption Budget for the control plane pods
+    enabled: false
+    # -- The maximum percentage of unavailable control plane pods
+    maxUnavailable: "50%"
+
 cni:
   # -- Install Kuma with CNI instead of proxy init container
   enabled: false
@@ -205,6 +212,12 @@ ingress:
           target:
             type: Utilization
             averageUtilization: 80
+    # Pod Distruption Budget Configuration
+    podDisruptionBudget:
+      # -- Weather to enable a Pod Disruption Budget for the ingress pods
+      enabled: false
+      # -- The maximum percentage of unavailable ingress pods
+      maxUnavailable: "50%"
 
 kumactl:
   image:


### PR DESCRIPTION
### Summary
Affinity, PodDisruptionBudget, and HorizontalPodAutoscaler are necessary requirements in our organization for highly available deployments.  A service mesh is a critical component and should have support for these.

### Full changelog

- Adding support for affinity for the control plane and ingress pods.
- Added support for PodDisruptionBudget for the control plane and ingress.
- Added support for HorizontalPodAutoscaler to the ingress.

