### PR TITLE
feat(kuma-cp) sidecar env vars override

### DIFF
--- a/pkg/api-server/config_ws_test.go
+++ b/pkg/api-server/config_ws_test.go
@@ -159,6 +159,7 @@ var _ = Describe("Config WS", func() {
                   "image": "kuma/kuma-init:latest"
                 },
                 "sidecarContainer": {
+                  "envVars": {},
                   "adminPort": 9901,
                   "drainTime": "30s",
                   "gid": 5678,

--- a/pkg/config/app/kuma-cp/kuma-cp.defaults.yaml
+++ b/pkg/config/app/kuma-cp/kuma-cp.defaults.yaml
@@ -231,6 +231,8 @@ runtime:
             cpu: 1000m # ENV: KUMA_INJECTOR_SIDECAR_CONTAINER_RESOURCES_LIMITS_CPU
             # Memory, in bytes. (500Gi = 500GiB = 500 * 1024 * 1024 * 1024)
             memory: 512Mi # ENV: KUMA_INJECTOR_SIDECAR_CONTAINER_RESOURCES_LIMITS_MEMORY
+        # Additional environment variables that can be placed on Kuma DP sidecar
+        envVars: # ENV: KUMA_RUNTIME_KUBERNETES_INJECTOR_SIDECAR_CONTAINER_ENV_VARS
       # InitContainer defines configuration of the Kuma init container
       initContainer:
         # Image name.

--- a/pkg/config/loader_test.go
+++ b/pkg/config/loader_test.go
@@ -149,6 +149,7 @@ var _ = Describe("Config loader", func() {
 			Expect(cfg.Runtime.Kubernetes.Injector.VirtualProbesPort).To(Equal(uint32(1111)))
 			Expect(cfg.Runtime.Kubernetes.Injector.CNIEnabled).To(BeTrue())
 			Expect(cfg.Runtime.Kubernetes.Injector.InitContainer.Image).To(Equal("test-image:test"))
+			Expect(cfg.Runtime.Kubernetes.Injector.SidecarContainer.EnvVars).To(Equal(map[string]string{"a": "b", "c": "d"}))
 			Expect(cfg.Runtime.Kubernetes.Injector.SidecarContainer.RedirectPortInbound).To(Equal(uint32(2020)))
 			Expect(cfg.Runtime.Kubernetes.Injector.SidecarContainer.RedirectPortOutbound).To(Equal(uint32(1010)))
 			Expect(cfg.Runtime.Kubernetes.Injector.SidecarContainer.UID).To(Equal(int64(100)))
@@ -336,6 +337,9 @@ runtime:
           periodSeconds: 18
           failureThreshold: 22
           timeoutSeconds: 24
+        envVars:
+          a: b
+          c: d
       sidecarTraffic:
         excludeInboundPorts:
         - 1234
@@ -469,6 +473,7 @@ sdsServer:
 				"KUMA_RUNTIME_KUBERNETES_INJECTOR_SIDECAR_CONTAINER_REDIRECT_PORT_INBOUND":                 "2020",
 				"KUMA_RUNTIME_KUBERNETES_INJECTOR_SIDECAR_CONTAINER_REDIRECT_PORT_OUTBOUND":                "1010",
 				"KUMA_RUNTIME_KUBERNETES_INJECTOR_CNI_ENABLED":                                             "true",
+				"KUMA_RUNTIME_KUBERNETES_INJECTOR_SIDECAR_CONTAINER_ENV_VARS":                              "a:b,c:d",
 				"KUMA_RUNTIME_KUBERNETES_INJECTOR_SIDECAR_CONTAINER_UID":                                   "100",
 				"KUMA_RUNTIME_KUBERNETES_INJECTOR_SIDECAR_CONTAINER_ADMIN_PORT":                            "1099",
 				"KUMA_RUNTIME_KUBERNETES_INJECTOR_SIDECAR_CONTAINER_DRAIN_TIME":                            "33s",

--- a/pkg/config/plugins/runtime/k8s/config.go
+++ b/pkg/config/plugins/runtime/k8s/config.go
@@ -157,6 +157,8 @@ type SidecarContainer struct {
 	LivenessProbe SidecarLivenessProbe `yaml:"livenessProbe,omitempty"`
 	// Compute resource requirements.
 	Resources SidecarResources `yaml:"resources,omitempty"`
+	// EnvVars are additional environment variables that can be placed on Kuma DP sidecar
+	EnvVars map[string]string `yaml:"envVars" envconfig:"kuma_runtime_kubernetes_injector_sidecar_container_env_vars"`
 }
 
 // SidecarReadinessProbe defines periodic probe of container service readiness.

--- a/pkg/config/plugins/runtime/k8s/testdata/default-config.golden.yaml
+++ b/pkg/config/plugins/runtime/k8s/testdata/default-config.golden.yaml
@@ -29,6 +29,7 @@ injector:
       limits:
         cpu: 1000m
         memory: 512Mi
+    envVars: {}
   initContainer:
     image: kuma/kuma-init:latest
   cniEnabled: false

--- a/pkg/plugins/runtime/k8s/metadata/annotations.go
+++ b/pkg/plugins/runtime/k8s/metadata/annotations.go
@@ -135,7 +135,7 @@ func (a Annotations) GetMap(key string) (map[string]string, error) {
 	for _, pair := range pairs {
 		kvSplit := strings.Split(pair, "=")
 		if len(kvSplit) != 2 {
-			return nil, errors.Errorf("invalid format. Map in %q has to be provided in the following format: key1=value2;key2=value2", key)
+			return nil, errors.Errorf("invalid format. Map in %q has to be provided in the following format: key1=value1;key2=value2", key)
 		}
 		result[kvSplit[0]] = kvSplit[1]
 	}

--- a/pkg/plugins/runtime/k8s/metadata/annotations.go
+++ b/pkg/plugins/runtime/k8s/metadata/annotations.go
@@ -2,6 +2,7 @@ package metadata
 
 import (
 	"strconv"
+	"strings"
 
 	"github.com/pkg/errors"
 )
@@ -43,6 +44,10 @@ const (
 
 	// KumaVirtualProbesPortAnnotation is an insecure port for listening virtual probes
 	KumaVirtualProbesPortAnnotation = "kuma.io/virtual-probes-port"
+
+	// KumaSidecarEnvVarsAnnotation is a ; separated list of env vars that will be applied on Kuma Sidecar
+	// Example value: TEST1=1;TEST2=2
+	KumaSidecarEnvVarsAnnotation = "kuma.io/sidecar-env-vars"
 
 	// KumaMetricsPrometheusPort allows to override `Mesh`-wide default port
 	KumaMetricsPrometheusPort = "prometheus.metrics.kuma.io/port"
@@ -116,4 +121,23 @@ func (a Annotations) GetBool(key string) (bool, bool, error) {
 		return false, false, err
 	}
 	return b, true, nil
+}
+
+// GetMap returns map from annotation. Example: "kuma.io/sidecar-env-vars: TEST1=1;TEST2=2"
+func (a Annotations) GetMap(key string) (map[string]string, error) {
+	value, ok := a[key]
+	if !ok {
+		return nil, nil
+	}
+	result := map[string]string{}
+
+	pairs := strings.Split(value, ";")
+	for _, pair := range pairs {
+		kvSplit := strings.Split(pair, "=")
+		if len(kvSplit) != 2 {
+			return nil, errors.Errorf("invalid format. Map in %q has to be provided in the following format: key1=value2;key2=value2", key)
+		}
+		result[kvSplit[0]] = kvSplit[1]
+	}
+	return result, nil
 }

--- a/pkg/plugins/runtime/k8s/metadata/annotations_test.go
+++ b/pkg/plugins/runtime/k8s/metadata/annotations_test.go
@@ -37,4 +37,33 @@ var _ = Describe("Kubernetes Annotations", func() {
 			Expect(exist).To(BeTrue())
 		})
 	})
+
+	Context("GetMap()", func() {
+		It("should parse value to map", func() {
+			// given
+			annotations := map[string]string{
+				"key1": "TEST1=1;TEST2=2",
+			}
+
+			// when
+			m, err := metadata.Annotations(annotations).GetMap("key1")
+
+			// then
+			Expect(err).ToNot(HaveOccurred())
+			Expect(m).To(Equal(map[string]string{"TEST1": "1", "TEST2": "2"}))
+		})
+
+		It("should return error if value has wrong format", func() {
+			// given
+			annotations := map[string]string{
+				"key1": "TESTTEST",
+			}
+
+			// when
+			_, err := metadata.Annotations(annotations).GetMap("key1")
+
+			// then
+			Expect(err).To(MatchError(`invalid format. Map in "key1" has to be provided in the following format: key1=value2;key2=value2`))
+		})
+	})
 })

--- a/pkg/plugins/runtime/k8s/metadata/annotations_test.go
+++ b/pkg/plugins/runtime/k8s/metadata/annotations_test.go
@@ -63,7 +63,7 @@ var _ = Describe("Kubernetes Annotations", func() {
 			_, err := metadata.Annotations(annotations).GetMap("key1")
 
 			// then
-			Expect(err).To(MatchError(`invalid format. Map in "key1" has to be provided in the following format: key1=value2;key2=value2`))
+			Expect(err).To(MatchError(`invalid format. Map in "key1" has to be provided in the following format: key1=value1;key2=value2`))
 		})
 	})
 })

--- a/pkg/plugins/runtime/k8s/webhooks/injector/injector_test.go
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/injector_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/kumahq/kuma/pkg/plugins/resources/k8s"
 	"github.com/kumahq/kuma/pkg/plugins/resources/k8s/native/api/v1alpha1"
 	inject "github.com/kumahq/kuma/pkg/plugins/runtime/k8s/webhooks/injector"
+	"github.com/kumahq/kuma/pkg/test/matchers"
 
 	kube_core "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
@@ -85,12 +86,7 @@ var _ = Describe("Injector", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			By("comparing actual against golden")
-			// when
-			expected, err := ioutil.ReadFile(goldenFile)
-			// then
-			Expect(err).ToNot(HaveOccurred())
-			// and
-			Expect(actual).To(MatchYAML(expected))
+			Expect(actual).To(matchers.MatchGoldenYAML(goldenFile))
 		},
 		Entry("01. Pod without init containers and annotations", testCase{
 			num: "01",
@@ -490,6 +486,22 @@ var _ = Describe("Injector", func() {
                 annotations:
                   kuma.io/sidecar-injection: enabled`,
 			cfgFile: "inject.config.yaml",
+		}),
+		Entry("24. sidecar env var config overrides", testCase{
+			num: "24",
+			mesh: `
+              apiVersion: kuma.io/v1alpha1
+              kind: Mesh
+              metadata:
+                name: default`,
+			namespace: `
+              apiVersion: v1
+              kind: Namespace
+              metadata:
+                name: default
+                annotations:
+                  kuma.io/sidecar-injection: enabled`,
+			cfgFile: "inject.env-vars.config.yaml",
 		}),
 	)
 })

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.01.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.01.golden.yaml
@@ -5,8 +5,8 @@ metadata:
     kuma.io/mesh: default
     kuma.io/sidecar-injected: "true"
     kuma.io/transparent-proxying: enabled
-    kuma.io/transparent-proxying-outbound-port: "15001"
     kuma.io/transparent-proxying-inbound-port: "15006"
+    kuma.io/transparent-proxying-outbound-port: "15001"
     kuma.io/virtual-probes: enabled
     kuma.io/virtual-probes-port: "9000"
   creationTimestamp: null
@@ -41,18 +41,6 @@ spec:
         fieldRef:
           apiVersion: v1
           fieldPath: status.podIP
-    - name: KUMA_CONTROL_PLANE_URL
-      value: http://kuma-control-plane.kuma-system:5681
-    - name: KUMA_DATAPLANE_MESH
-      value: default
-    - name: KUMA_DATAPLANE_NAME
-      value: $(POD_NAME).$(POD_NAMESPACE)
-    - name: KUMA_DATAPLANE_ADMIN_PORT
-      value: "9901"
-    - name: KUMA_DATAPLANE_DRAIN_TIME
-      value: 31s
-    - name: KUMA_DATAPLANE_RUNTIME_TOKEN_PATH
-      value: /var/run/secrets/kubernetes.io/serviceaccount/token
     - name: KUMA_CONTROL_PLANE_CA_CERT
       value: |
         -----BEGIN CERTIFICATE-----
@@ -74,23 +62,35 @@ spec:
         aOKow0ze+zHVFqTHbjnCqEV3hnsUyRUwsBln9+jDJXgwZM/tMlVJrZCh0Sle9Y5Z
         MOB0fCf6sTMNRTGg5Lpl6uIYM/5INpmHVMo3n7MBSnpEDAUS2bf/uo5gIiq6XCdp
         -----END CERTIFICATE-----
+    - name: KUMA_CONTROL_PLANE_URL
+      value: http://kuma-control-plane.kuma-system:5681
+    - name: KUMA_DATAPLANE_ADMIN_PORT
+      value: "9901"
+    - name: KUMA_DATAPLANE_DRAIN_TIME
+      value: 31s
+    - name: KUMA_DATAPLANE_MESH
+      value: default
+    - name: KUMA_DATAPLANE_NAME
+      value: $(POD_NAME).$(POD_NAMESPACE)
+    - name: KUMA_DATAPLANE_RUNTIME_TOKEN_PATH
+      value: /var/run/secrets/kubernetes.io/serviceaccount/token
     image: kuma/kuma-sidecar:latest
     imagePullPolicy: IfNotPresent
     livenessProbe:
+      failureThreshold: 212
       httpGet:
         path: /ready
         port: 9901
-      failureThreshold: 212
       initialDelaySeconds: 260
       periodSeconds: 25
       successThreshold: 1
       timeoutSeconds: 23
     name: kuma-sidecar
     readinessProbe:
+      failureThreshold: 112
       httpGet:
         path: /ready
         port: 9901
-      failureThreshold: 112
       initialDelaySeconds: 11
       periodSeconds: 15
       successThreshold: 11

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.02.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.02.golden.yaml
@@ -6,8 +6,8 @@ metadata:
     kuma.io/mesh: default
     kuma.io/sidecar-injected: "true"
     kuma.io/transparent-proxying: enabled
-    kuma.io/transparent-proxying-outbound-port: "15001"
     kuma.io/transparent-proxying-inbound-port: "15006"
+    kuma.io/transparent-proxying-outbound-port: "15001"
     kuma.io/virtual-probes: enabled
     kuma.io/virtual-probes-port: "9000"
   creationTimestamp: null
@@ -42,18 +42,6 @@ spec:
         fieldRef:
           apiVersion: v1
           fieldPath: status.podIP
-    - name: KUMA_CONTROL_PLANE_URL
-      value: http://kuma-control-plane.kuma-system:5681
-    - name: KUMA_DATAPLANE_MESH
-      value: default
-    - name: KUMA_DATAPLANE_NAME
-      value: $(POD_NAME).$(POD_NAMESPACE)
-    - name: KUMA_DATAPLANE_ADMIN_PORT
-      value: "9901"
-    - name: KUMA_DATAPLANE_DRAIN_TIME
-      value: 31s
-    - name: KUMA_DATAPLANE_RUNTIME_TOKEN_PATH
-      value: /var/run/secrets/kubernetes.io/serviceaccount/token
     - name: KUMA_CONTROL_PLANE_CA_CERT
       value: |
         -----BEGIN CERTIFICATE-----
@@ -75,23 +63,35 @@ spec:
         aOKow0ze+zHVFqTHbjnCqEV3hnsUyRUwsBln9+jDJXgwZM/tMlVJrZCh0Sle9Y5Z
         MOB0fCf6sTMNRTGg5Lpl6uIYM/5INpmHVMo3n7MBSnpEDAUS2bf/uo5gIiq6XCdp
         -----END CERTIFICATE-----
+    - name: KUMA_CONTROL_PLANE_URL
+      value: http://kuma-control-plane.kuma-system:5681
+    - name: KUMA_DATAPLANE_ADMIN_PORT
+      value: "9901"
+    - name: KUMA_DATAPLANE_DRAIN_TIME
+      value: 31s
+    - name: KUMA_DATAPLANE_MESH
+      value: default
+    - name: KUMA_DATAPLANE_NAME
+      value: $(POD_NAME).$(POD_NAMESPACE)
+    - name: KUMA_DATAPLANE_RUNTIME_TOKEN_PATH
+      value: /var/run/secrets/kubernetes.io/serviceaccount/token
     image: kuma/kuma-sidecar:latest
     imagePullPolicy: IfNotPresent
     livenessProbe:
+      failureThreshold: 212
       httpGet:
         path: /ready
         port: 9901
-      failureThreshold: 212
       initialDelaySeconds: 260
       periodSeconds: 25
       successThreshold: 1
       timeoutSeconds: 23
     name: kuma-sidecar
     readinessProbe:
+      failureThreshold: 112
       httpGet:
         path: /ready
         port: 9901
-      failureThreshold: 112
       initialDelaySeconds: 11
       periodSeconds: 15
       successThreshold: 11
@@ -107,9 +107,9 @@ spec:
       runAsGroup: 5678
       runAsUser: 5678
     volumeMounts:
-    - name: default-token-w7dxf
+    - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+      name: default-token-w7dxf
       readOnly: true
-      mountPath: "/var/run/secrets/kubernetes.io/serviceaccount"
   initContainers:
   - command:
     - sh

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.03.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.03.golden.yaml
@@ -5,8 +5,8 @@ metadata:
     kuma.io/mesh: default
     kuma.io/sidecar-injected: "true"
     kuma.io/transparent-proxying: enabled
-    kuma.io/transparent-proxying-outbound-port: "15001"
     kuma.io/transparent-proxying-inbound-port: "15006"
+    kuma.io/transparent-proxying-outbound-port: "15001"
     kuma.io/virtual-probes: enabled
     kuma.io/virtual-probes-port: "9000"
   creationTimestamp: null
@@ -101,18 +101,6 @@ spec:
         fieldRef:
           apiVersion: v1
           fieldPath: status.podIP
-    - name: KUMA_CONTROL_PLANE_URL
-      value: http://kuma-control-plane.kuma-system:5681
-    - name: KUMA_DATAPLANE_MESH
-      value: default
-    - name: KUMA_DATAPLANE_NAME
-      value: $(POD_NAME).$(POD_NAMESPACE)
-    - name: KUMA_DATAPLANE_ADMIN_PORT
-      value: "9901"
-    - name: KUMA_DATAPLANE_DRAIN_TIME
-      value: 31s
-    - name: KUMA_DATAPLANE_RUNTIME_TOKEN_PATH
-      value: /var/run/secrets/kubernetes.io/serviceaccount/token
     - name: KUMA_CONTROL_PLANE_CA_CERT
       value: |
         -----BEGIN CERTIFICATE-----
@@ -134,23 +122,35 @@ spec:
         aOKow0ze+zHVFqTHbjnCqEV3hnsUyRUwsBln9+jDJXgwZM/tMlVJrZCh0Sle9Y5Z
         MOB0fCf6sTMNRTGg5Lpl6uIYM/5INpmHVMo3n7MBSnpEDAUS2bf/uo5gIiq6XCdp
         -----END CERTIFICATE-----
+    - name: KUMA_CONTROL_PLANE_URL
+      value: http://kuma-control-plane.kuma-system:5681
+    - name: KUMA_DATAPLANE_ADMIN_PORT
+      value: "9901"
+    - name: KUMA_DATAPLANE_DRAIN_TIME
+      value: 31s
+    - name: KUMA_DATAPLANE_MESH
+      value: default
+    - name: KUMA_DATAPLANE_NAME
+      value: $(POD_NAME).$(POD_NAMESPACE)
+    - name: KUMA_DATAPLANE_RUNTIME_TOKEN_PATH
+      value: /var/run/secrets/kubernetes.io/serviceaccount/token
     image: kuma/kuma-sidecar:latest
     imagePullPolicy: IfNotPresent
     livenessProbe:
+      failureThreshold: 212
       httpGet:
         path: /ready
         port: 9901
-      failureThreshold: 212
       initialDelaySeconds: 260
       periodSeconds: 25
       successThreshold: 1
       timeoutSeconds: 23
     name: kuma-sidecar
     readinessProbe:
+      failureThreshold: 112
       httpGet:
         path: /ready
         port: 9901
-      failureThreshold: 112
       initialDelaySeconds: 11
       periodSeconds: 15
       successThreshold: 11
@@ -166,9 +166,9 @@ spec:
       runAsGroup: 5678
       runAsUser: 5678
     volumeMounts:
-    - name: coredns-token-9gmrh
+    - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+      name: coredns-token-9gmrh
       readOnly: true
-      mountPath: "/var/run/secrets/kubernetes.io/serviceaccount"
   dnsPolicy: Default
   enableServiceLinks: true
   initContainers:

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.04.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.04.golden.yaml
@@ -5,8 +5,8 @@ metadata:
     kuma.io/mesh: demo
     kuma.io/sidecar-injected: "true"
     kuma.io/transparent-proxying: enabled
-    kuma.io/transparent-proxying-outbound-port: "15001"
     kuma.io/transparent-proxying-inbound-port: "15006"
+    kuma.io/transparent-proxying-outbound-port: "15001"
     kuma.io/virtual-probes: enabled
     kuma.io/virtual-probes-port: "9000"
   creationTimestamp: null
@@ -41,18 +41,6 @@ spec:
         fieldRef:
           apiVersion: v1
           fieldPath: status.podIP
-    - name: KUMA_CONTROL_PLANE_URL
-      value: http://kuma-control-plane.kuma-system:5681
-    - name: KUMA_DATAPLANE_MESH
-      value: demo
-    - name: KUMA_DATAPLANE_NAME
-      value: $(POD_NAME).$(POD_NAMESPACE)
-    - name: KUMA_DATAPLANE_ADMIN_PORT
-      value: "9901"
-    - name: KUMA_DATAPLANE_DRAIN_TIME
-      value: 31s
-    - name: KUMA_DATAPLANE_RUNTIME_TOKEN_PATH
-      value: /var/run/secrets/kubernetes.io/serviceaccount/token
     - name: KUMA_CONTROL_PLANE_CA_CERT
       value: |
         -----BEGIN CERTIFICATE-----
@@ -74,23 +62,35 @@ spec:
         aOKow0ze+zHVFqTHbjnCqEV3hnsUyRUwsBln9+jDJXgwZM/tMlVJrZCh0Sle9Y5Z
         MOB0fCf6sTMNRTGg5Lpl6uIYM/5INpmHVMo3n7MBSnpEDAUS2bf/uo5gIiq6XCdp
         -----END CERTIFICATE-----
+    - name: KUMA_CONTROL_PLANE_URL
+      value: http://kuma-control-plane.kuma-system:5681
+    - name: KUMA_DATAPLANE_ADMIN_PORT
+      value: "9901"
+    - name: KUMA_DATAPLANE_DRAIN_TIME
+      value: 31s
+    - name: KUMA_DATAPLANE_MESH
+      value: demo
+    - name: KUMA_DATAPLANE_NAME
+      value: $(POD_NAME).$(POD_NAMESPACE)
+    - name: KUMA_DATAPLANE_RUNTIME_TOKEN_PATH
+      value: /var/run/secrets/kubernetes.io/serviceaccount/token
     image: kuma/kuma-sidecar:latest
     imagePullPolicy: IfNotPresent
     livenessProbe:
+      failureThreshold: 212
       httpGet:
         path: /ready
         port: 9901
-      failureThreshold: 212
       initialDelaySeconds: 260
       periodSeconds: 25
       successThreshold: 1
       timeoutSeconds: 23
     name: kuma-sidecar
     readinessProbe:
+      failureThreshold: 112
       httpGet:
         path: /ready
         port: 9901
-      failureThreshold: 112
       initialDelaySeconds: 11
       periodSeconds: 15
       successThreshold: 11
@@ -106,9 +106,9 @@ spec:
       runAsGroup: 5678
       runAsUser: 5678
     volumeMounts:
-    - name: default-token-w7dxf
+    - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+      name: default-token-w7dxf
       readOnly: true
-      mountPath: "/var/run/secrets/kubernetes.io/serviceaccount"
   initContainers:
   - args:
     - -p

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.05.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.05.golden.yaml
@@ -5,8 +5,8 @@ metadata:
     kuma.io/mesh: default
     kuma.io/sidecar-injected: "true"
     kuma.io/transparent-proxying: enabled
-    kuma.io/transparent-proxying-outbound-port: "15001"
     kuma.io/transparent-proxying-inbound-port: "15006"
+    kuma.io/transparent-proxying-outbound-port: "15001"
     kuma.io/virtual-probes: enabled
     kuma.io/virtual-probes-port: "9000"
   creationTimestamp: null
@@ -38,18 +38,6 @@ spec:
         fieldRef:
           apiVersion: v1
           fieldPath: status.podIP
-    - name: KUMA_CONTROL_PLANE_URL
-      value: http://kuma-control-plane.kuma-system:5681
-    - name: KUMA_DATAPLANE_MESH
-      value: default
-    - name: KUMA_DATAPLANE_NAME
-      value: $(POD_NAME).$(POD_NAMESPACE)
-    - name: KUMA_DATAPLANE_ADMIN_PORT
-      value: "9901"
-    - name: KUMA_DATAPLANE_DRAIN_TIME
-      value: 31s
-    - name: KUMA_DATAPLANE_RUNTIME_TOKEN_PATH
-      value: /var/run/secrets/kubernetes.io/serviceaccount/token
     - name: KUMA_CONTROL_PLANE_CA_CERT
       value: |
         -----BEGIN CERTIFICATE-----
@@ -71,23 +59,35 @@ spec:
         aOKow0ze+zHVFqTHbjnCqEV3hnsUyRUwsBln9+jDJXgwZM/tMlVJrZCh0Sle9Y5Z
         MOB0fCf6sTMNRTGg5Lpl6uIYM/5INpmHVMo3n7MBSnpEDAUS2bf/uo5gIiq6XCdp
         -----END CERTIFICATE-----
+    - name: KUMA_CONTROL_PLANE_URL
+      value: http://kuma-control-plane.kuma-system:5681
+    - name: KUMA_DATAPLANE_ADMIN_PORT
+      value: "9901"
+    - name: KUMA_DATAPLANE_DRAIN_TIME
+      value: 31s
+    - name: KUMA_DATAPLANE_MESH
+      value: default
+    - name: KUMA_DATAPLANE_NAME
+      value: $(POD_NAME).$(POD_NAMESPACE)
+    - name: KUMA_DATAPLANE_RUNTIME_TOKEN_PATH
+      value: /var/run/secrets/kubernetes.io/serviceaccount/token
     image: kuma/kuma-sidecar:latest
     imagePullPolicy: IfNotPresent
     livenessProbe:
+      failureThreshold: 212
       httpGet:
         path: /ready
         port: 9901
-      failureThreshold: 212
       initialDelaySeconds: 260
       periodSeconds: 25
       successThreshold: 1
       timeoutSeconds: 23
     name: kuma-sidecar
     readinessProbe:
+      failureThreshold: 112
       httpGet:
         path: /ready
         port: 9901
-      failureThreshold: 112
       initialDelaySeconds: 11
       periodSeconds: 15
       successThreshold: 11

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.06.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.06.golden.yaml
@@ -2,12 +2,12 @@ apiVersion: v1
 kind: Pod
 metadata:
   annotations:
+    kuma.io/gateway: enabled
     kuma.io/mesh: default
     kuma.io/sidecar-injected: "true"
     kuma.io/transparent-proxying: enabled
-    kuma.io/transparent-proxying-outbound-port: "15001"
     kuma.io/transparent-proxying-inbound-port: "15006"
-    kuma.io/gateway: enabled
+    kuma.io/transparent-proxying-outbound-port: "15001"
     kuma.io/virtual-probes: disabled
     kuma.io/virtual-probes-port: "9000"
   creationTimestamp: null
@@ -42,18 +42,6 @@ spec:
         fieldRef:
           apiVersion: v1
           fieldPath: status.podIP
-    - name: KUMA_CONTROL_PLANE_URL
-      value: http://kuma-control-plane.kuma-system:5681
-    - name: KUMA_DATAPLANE_MESH
-      value: default
-    - name: KUMA_DATAPLANE_NAME
-      value: $(POD_NAME).$(POD_NAMESPACE)
-    - name: KUMA_DATAPLANE_ADMIN_PORT
-      value: "9901"
-    - name: KUMA_DATAPLANE_DRAIN_TIME
-      value: 31s
-    - name: KUMA_DATAPLANE_RUNTIME_TOKEN_PATH
-      value: /var/run/secrets/kubernetes.io/serviceaccount/token
     - name: KUMA_CONTROL_PLANE_CA_CERT
       value: |
         -----BEGIN CERTIFICATE-----
@@ -75,23 +63,35 @@ spec:
         aOKow0ze+zHVFqTHbjnCqEV3hnsUyRUwsBln9+jDJXgwZM/tMlVJrZCh0Sle9Y5Z
         MOB0fCf6sTMNRTGg5Lpl6uIYM/5INpmHVMo3n7MBSnpEDAUS2bf/uo5gIiq6XCdp
         -----END CERTIFICATE-----
+    - name: KUMA_CONTROL_PLANE_URL
+      value: http://kuma-control-plane.kuma-system:5681
+    - name: KUMA_DATAPLANE_ADMIN_PORT
+      value: "9901"
+    - name: KUMA_DATAPLANE_DRAIN_TIME
+      value: 31s
+    - name: KUMA_DATAPLANE_MESH
+      value: default
+    - name: KUMA_DATAPLANE_NAME
+      value: $(POD_NAME).$(POD_NAMESPACE)
+    - name: KUMA_DATAPLANE_RUNTIME_TOKEN_PATH
+      value: /var/run/secrets/kubernetes.io/serviceaccount/token
     image: kuma/kuma-sidecar:latest
     imagePullPolicy: IfNotPresent
     livenessProbe:
+      failureThreshold: 212
       httpGet:
         path: /ready
         port: 9901
-      failureThreshold: 212
       initialDelaySeconds: 260
       periodSeconds: 25
       successThreshold: 1
       timeoutSeconds: 23
     name: kuma-sidecar
     readinessProbe:
+      failureThreshold: 112
       httpGet:
         path: /ready
         port: 9901
-      failureThreshold: 112
       initialDelaySeconds: 11
       periodSeconds: 15
       successThreshold: 11

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.07.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.07.golden.yaml
@@ -5,8 +5,8 @@ metadata:
     kuma.io/mesh: default
     kuma.io/sidecar-injected: "true"
     kuma.io/transparent-proxying: enabled
-    kuma.io/transparent-proxying-outbound-port: "15001"
     kuma.io/transparent-proxying-inbound-port: "15006"
+    kuma.io/transparent-proxying-outbound-port: "15001"
     kuma.io/virtual-probes: enabled
     kuma.io/virtual-probes-port: "9000"
   creationTimestamp: null
@@ -41,18 +41,6 @@ spec:
         fieldRef:
           apiVersion: v1
           fieldPath: status.podIP
-    - name: KUMA_CONTROL_PLANE_URL
-      value: http://kuma-control-plane.kuma-system:5681
-    - name: KUMA_DATAPLANE_MESH
-      value: default
-    - name: KUMA_DATAPLANE_NAME
-      value: $(POD_NAME).$(POD_NAMESPACE)
-    - name: KUMA_DATAPLANE_ADMIN_PORT
-      value: "9901"
-    - name: KUMA_DATAPLANE_DRAIN_TIME
-      value: 31s
-    - name: KUMA_DATAPLANE_RUNTIME_TOKEN_PATH
-      value: /var/run/secrets/kubernetes.io/serviceaccount/token
     - name: KUMA_CONTROL_PLANE_CA_CERT
       value: |
         -----BEGIN CERTIFICATE-----
@@ -74,23 +62,35 @@ spec:
         aOKow0ze+zHVFqTHbjnCqEV3hnsUyRUwsBln9+jDJXgwZM/tMlVJrZCh0Sle9Y5Z
         MOB0fCf6sTMNRTGg5Lpl6uIYM/5INpmHVMo3n7MBSnpEDAUS2bf/uo5gIiq6XCdp
         -----END CERTIFICATE-----
+    - name: KUMA_CONTROL_PLANE_URL
+      value: http://kuma-control-plane.kuma-system:5681
+    - name: KUMA_DATAPLANE_ADMIN_PORT
+      value: "9901"
+    - name: KUMA_DATAPLANE_DRAIN_TIME
+      value: 31s
+    - name: KUMA_DATAPLANE_MESH
+      value: default
+    - name: KUMA_DATAPLANE_NAME
+      value: $(POD_NAME).$(POD_NAMESPACE)
+    - name: KUMA_DATAPLANE_RUNTIME_TOKEN_PATH
+      value: /var/run/secrets/kubernetes.io/serviceaccount/token
     image: kuma/kuma-sidecar:latest
     imagePullPolicy: IfNotPresent
     livenessProbe:
+      failureThreshold: 212
       httpGet:
         path: /ready
         port: 9901
-      failureThreshold: 212
       initialDelaySeconds: 260
       periodSeconds: 25
       successThreshold: 1
       timeoutSeconds: 23
     name: kuma-sidecar
     readinessProbe:
+      failureThreshold: 112
       httpGet:
         path: /ready
         port: 9901
-      failureThreshold: 112
       initialDelaySeconds: 11
       periodSeconds: 15
       successThreshold: 11

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.08.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.08.golden.yaml
@@ -5,8 +5,8 @@ metadata:
     kuma.io/mesh: default
     kuma.io/sidecar-injected: "true"
     kuma.io/transparent-proxying: enabled
-    kuma.io/transparent-proxying-outbound-port: "15001"
     kuma.io/transparent-proxying-inbound-port: "15006"
+    kuma.io/transparent-proxying-outbound-port: "15001"
     kuma.io/virtual-probes: enabled
     kuma.io/virtual-probes-port: "9000"
     prometheus.io/path: /appmetrics
@@ -44,18 +44,6 @@ spec:
         fieldRef:
           apiVersion: v1
           fieldPath: status.podIP
-    - name: KUMA_CONTROL_PLANE_URL
-      value: http://kuma-control-plane.kuma-system:5681
-    - name: KUMA_DATAPLANE_MESH
-      value: default
-    - name: KUMA_DATAPLANE_NAME
-      value: $(POD_NAME).$(POD_NAMESPACE)
-    - name: KUMA_DATAPLANE_ADMIN_PORT
-      value: "9901"
-    - name: KUMA_DATAPLANE_DRAIN_TIME
-      value: 31s
-    - name: KUMA_DATAPLANE_RUNTIME_TOKEN_PATH
-      value: /var/run/secrets/kubernetes.io/serviceaccount/token
     - name: KUMA_CONTROL_PLANE_CA_CERT
       value: |
         -----BEGIN CERTIFICATE-----
@@ -77,23 +65,35 @@ spec:
         aOKow0ze+zHVFqTHbjnCqEV3hnsUyRUwsBln9+jDJXgwZM/tMlVJrZCh0Sle9Y5Z
         MOB0fCf6sTMNRTGg5Lpl6uIYM/5INpmHVMo3n7MBSnpEDAUS2bf/uo5gIiq6XCdp
         -----END CERTIFICATE-----
+    - name: KUMA_CONTROL_PLANE_URL
+      value: http://kuma-control-plane.kuma-system:5681
+    - name: KUMA_DATAPLANE_ADMIN_PORT
+      value: "9901"
+    - name: KUMA_DATAPLANE_DRAIN_TIME
+      value: 31s
+    - name: KUMA_DATAPLANE_MESH
+      value: default
+    - name: KUMA_DATAPLANE_NAME
+      value: $(POD_NAME).$(POD_NAMESPACE)
+    - name: KUMA_DATAPLANE_RUNTIME_TOKEN_PATH
+      value: /var/run/secrets/kubernetes.io/serviceaccount/token
     image: kuma/kuma-sidecar:latest
     imagePullPolicy: IfNotPresent
     livenessProbe:
+      failureThreshold: 212
       httpGet:
         path: /ready
         port: 9901
-      failureThreshold: 212
       initialDelaySeconds: 260
       periodSeconds: 25
       successThreshold: 1
       timeoutSeconds: 23
     name: kuma-sidecar
     readinessProbe:
+      failureThreshold: 112
       httpGet:
         path: /ready
         port: 9901
-      failureThreshold: 112
       initialDelaySeconds: 11
       periodSeconds: 15
       successThreshold: 11

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.09.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.09.golden.yaml
@@ -5,8 +5,8 @@ metadata:
     kuma.io/mesh: default
     kuma.io/sidecar-injected: "true"
     kuma.io/transparent-proxying: enabled
-    kuma.io/transparent-proxying-outbound-port: "15001"
     kuma.io/transparent-proxying-inbound-port: "15006"
+    kuma.io/transparent-proxying-outbound-port: "15001"
     kuma.io/virtual-probes: enabled
     kuma.io/virtual-probes-port: "9000"
     prometheus.metrics.kuma.io/path: /custom-metrics
@@ -43,18 +43,6 @@ spec:
         fieldRef:
           apiVersion: v1
           fieldPath: status.podIP
-    - name: KUMA_CONTROL_PLANE_URL
-      value: http://kuma-control-plane.kuma-system:5681
-    - name: KUMA_DATAPLANE_MESH
-      value: default
-    - name: KUMA_DATAPLANE_NAME
-      value: $(POD_NAME).$(POD_NAMESPACE)
-    - name: KUMA_DATAPLANE_ADMIN_PORT
-      value: "9901"
-    - name: KUMA_DATAPLANE_DRAIN_TIME
-      value: 31s
-    - name: KUMA_DATAPLANE_RUNTIME_TOKEN_PATH
-      value: /var/run/secrets/kubernetes.io/serviceaccount/token
     - name: KUMA_CONTROL_PLANE_CA_CERT
       value: |
         -----BEGIN CERTIFICATE-----
@@ -76,23 +64,35 @@ spec:
         aOKow0ze+zHVFqTHbjnCqEV3hnsUyRUwsBln9+jDJXgwZM/tMlVJrZCh0Sle9Y5Z
         MOB0fCf6sTMNRTGg5Lpl6uIYM/5INpmHVMo3n7MBSnpEDAUS2bf/uo5gIiq6XCdp
         -----END CERTIFICATE-----
+    - name: KUMA_CONTROL_PLANE_URL
+      value: http://kuma-control-plane.kuma-system:5681
+    - name: KUMA_DATAPLANE_ADMIN_PORT
+      value: "9901"
+    - name: KUMA_DATAPLANE_DRAIN_TIME
+      value: 31s
+    - name: KUMA_DATAPLANE_MESH
+      value: default
+    - name: KUMA_DATAPLANE_NAME
+      value: $(POD_NAME).$(POD_NAMESPACE)
+    - name: KUMA_DATAPLANE_RUNTIME_TOKEN_PATH
+      value: /var/run/secrets/kubernetes.io/serviceaccount/token
     image: kuma/kuma-sidecar:latest
     imagePullPolicy: IfNotPresent
     livenessProbe:
+      failureThreshold: 212
       httpGet:
         path: /ready
         port: 9901
-      failureThreshold: 212
       initialDelaySeconds: 260
       periodSeconds: 25
       successThreshold: 1
       timeoutSeconds: 23
     name: kuma-sidecar
     readinessProbe:
+      failureThreshold: 112
       httpGet:
         path: /ready
         port: 9901
-      failureThreshold: 112
       initialDelaySeconds: 11
       periodSeconds: 15
       successThreshold: 11

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.12.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.12.golden.yaml
@@ -41,18 +41,6 @@ spec:
         fieldRef:
           apiVersion: v1
           fieldPath: status.podIP
-    - name: KUMA_CONTROL_PLANE_URL
-      value: http://kuma-control-plane.kuma-system:5681
-    - name: KUMA_DATAPLANE_MESH
-      value: mesh-name-from-ns
-    - name: KUMA_DATAPLANE_NAME
-      value: $(POD_NAME).$(POD_NAMESPACE)
-    - name: KUMA_DATAPLANE_ADMIN_PORT
-      value: "9901"
-    - name: KUMA_DATAPLANE_DRAIN_TIME
-      value: 31s
-    - name: KUMA_DATAPLANE_RUNTIME_TOKEN_PATH
-      value: /var/run/secrets/kubernetes.io/serviceaccount/token
     - name: KUMA_CONTROL_PLANE_CA_CERT
       value: |
         -----BEGIN CERTIFICATE-----
@@ -74,23 +62,35 @@ spec:
         aOKow0ze+zHVFqTHbjnCqEV3hnsUyRUwsBln9+jDJXgwZM/tMlVJrZCh0Sle9Y5Z
         MOB0fCf6sTMNRTGg5Lpl6uIYM/5INpmHVMo3n7MBSnpEDAUS2bf/uo5gIiq6XCdp
         -----END CERTIFICATE-----
+    - name: KUMA_CONTROL_PLANE_URL
+      value: http://kuma-control-plane.kuma-system:5681
+    - name: KUMA_DATAPLANE_ADMIN_PORT
+      value: "9901"
+    - name: KUMA_DATAPLANE_DRAIN_TIME
+      value: 31s
+    - name: KUMA_DATAPLANE_MESH
+      value: mesh-name-from-ns
+    - name: KUMA_DATAPLANE_NAME
+      value: $(POD_NAME).$(POD_NAMESPACE)
+    - name: KUMA_DATAPLANE_RUNTIME_TOKEN_PATH
+      value: /var/run/secrets/kubernetes.io/serviceaccount/token
     image: kuma/kuma-sidecar:latest
     imagePullPolicy: IfNotPresent
     livenessProbe:
+      failureThreshold: 212
       httpGet:
         path: /ready
         port: 9901
-      failureThreshold: 212
       initialDelaySeconds: 260
       periodSeconds: 25
       successThreshold: 1
       timeoutSeconds: 23
     name: kuma-sidecar
     readinessProbe:
+      failureThreshold: 112
       httpGet:
         path: /ready
         port: 9901
-      failureThreshold: 112
       initialDelaySeconds: 11
       periodSeconds: 15
       successThreshold: 11

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.13.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.13.golden.yaml
@@ -41,18 +41,6 @@ spec:
         fieldRef:
           apiVersion: v1
           fieldPath: status.podIP
-    - name: KUMA_CONTROL_PLANE_URL
-      value: http://kuma-control-plane.kuma-system:5681
-    - name: KUMA_DATAPLANE_MESH
-      value: mesh-name-from-pod
-    - name: KUMA_DATAPLANE_NAME
-      value: $(POD_NAME).$(POD_NAMESPACE)
-    - name: KUMA_DATAPLANE_ADMIN_PORT
-      value: "9901"
-    - name: KUMA_DATAPLANE_DRAIN_TIME
-      value: 31s
-    - name: KUMA_DATAPLANE_RUNTIME_TOKEN_PATH
-      value: /var/run/secrets/kubernetes.io/serviceaccount/token
     - name: KUMA_CONTROL_PLANE_CA_CERT
       value: |
         -----BEGIN CERTIFICATE-----
@@ -74,23 +62,35 @@ spec:
         aOKow0ze+zHVFqTHbjnCqEV3hnsUyRUwsBln9+jDJXgwZM/tMlVJrZCh0Sle9Y5Z
         MOB0fCf6sTMNRTGg5Lpl6uIYM/5INpmHVMo3n7MBSnpEDAUS2bf/uo5gIiq6XCdp
         -----END CERTIFICATE-----
+    - name: KUMA_CONTROL_PLANE_URL
+      value: http://kuma-control-plane.kuma-system:5681
+    - name: KUMA_DATAPLANE_ADMIN_PORT
+      value: "9901"
+    - name: KUMA_DATAPLANE_DRAIN_TIME
+      value: 31s
+    - name: KUMA_DATAPLANE_MESH
+      value: mesh-name-from-pod
+    - name: KUMA_DATAPLANE_NAME
+      value: $(POD_NAME).$(POD_NAMESPACE)
+    - name: KUMA_DATAPLANE_RUNTIME_TOKEN_PATH
+      value: /var/run/secrets/kubernetes.io/serviceaccount/token
     image: kuma/kuma-sidecar:latest
     imagePullPolicy: IfNotPresent
     livenessProbe:
+      failureThreshold: 212
       httpGet:
         path: /ready
         port: 9901
-      failureThreshold: 212
       initialDelaySeconds: 260
       periodSeconds: 25
       successThreshold: 1
       timeoutSeconds: 23
     name: kuma-sidecar
     readinessProbe:
+      failureThreshold: 112
       httpGet:
         path: /ready
         port: 9901
-      failureThreshold: 112
       initialDelaySeconds: 11
       periodSeconds: 15
       successThreshold: 11

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.14.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.14.golden.yaml
@@ -15,150 +15,150 @@ metadata:
   name: busybox
 spec:
   containers:
-    - image: busybox
-      livenessProbe:
-        httpGet:
-          path: /8080/metrics
-          port: 9000
-        initialDelaySeconds: 3
-        periodSeconds: 3
-      name: busybox
-      readinessProbe:
-        httpGet:
-          path: /3001/metrics
-          port: 9000
-        initialDelaySeconds: 3
-        periodSeconds: 3
-      resources: {}
-      volumeMounts:
-        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
-          name: default-token-w7dxf
-          readOnly: true
-    - args:
-        - run
-        - --log-level=info
-      env:
-        - name: POD_NAME
-          valueFrom:
-            fieldRef:
-              apiVersion: v1
-              fieldPath: metadata.name
-        - name: POD_NAMESPACE
-          valueFrom:
-            fieldRef:
-              apiVersion: v1
-              fieldPath: metadata.namespace
-        - name: INSTANCE_IP
-          valueFrom:
-            fieldRef:
-              apiVersion: v1
-              fieldPath: status.podIP
-        - name: KUMA_CONTROL_PLANE_URL
-          value: http://kuma-control-plane.kuma-system:5681
-        - name: KUMA_DATAPLANE_MESH
-          value: default
-        - name: KUMA_DATAPLANE_NAME
-          value: $(POD_NAME).$(POD_NAMESPACE)
-        - name: KUMA_DATAPLANE_ADMIN_PORT
-          value: "9901"
-        - name: KUMA_DATAPLANE_DRAIN_TIME
-          value: 31s
-        - name: KUMA_DATAPLANE_RUNTIME_TOKEN_PATH
-          value: /var/run/secrets/kubernetes.io/serviceaccount/token
-        - name: KUMA_CONTROL_PLANE_CA_CERT
-          value: |
-            -----BEGIN CERTIFICATE-----
-            MIIDLDCCAhSgAwIBAgIQHdPhxOfXgWuNxoFlV/EwqTANBgkqhkiG9w0BAQsFADAP
-            MQ0wCwYDVQQDEwRrdW1hMB4XDTIwMDkxNjEyMjg0NFoXDTMwMDkxNDEyMjg0NFow
-            DzENMAsGA1UEAxMEa3VtYTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEB
-            AOZGbWhSlQSRxFNt5p/2WCKFyHZ3CuwNgyLEP7nS4ZXykxsFbYSuV3bIgF7bT/uq
-            a5Qire+C60guhFbpLcPh2Z6UfgId69GlQzHMVYcmLGjVQuyAt4FMMkTfVEl5I4Oa
-            +2it3BvihVkKhUz8y5RR5KbqJfGp4Z20Fh6fttoCFbeODmvBsYJFmUQS+ifoyMY/
-            P3R03Su7g5iIvnz7tmkydoNC8nGRDzdD5C8fJvrVI1UX6JRGyLKt45oQXt1mxK10
-            5KaN2zNV2WtHsaJp9bwrPH+JiZGeZyvuh5UwrLdHCmqK7sm9TodGztUZY0VzAc4q
-            kYViXY8gUjfNm+cQrPO1kN8CAwEAAaOBgzCBgDAOBgNVHQ8BAf8EBAMCAqQwHQYD
-            VR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMBMA8GA1UdEwEB/wQFMAMBAf8wHQYD
-            VR0OBBYEFGMDBPPiBFJ3mv2oA9CTqjemFTV2MB8GA1UdEQQYMBaCCWxvY2FsaG9z
-            dIIJbG9jYWxob3N0MA0GCSqGSIb3DQEBCwUAA4IBAQC/17QweOpGdb1MEBJ8XPG7
-            3sK/utoWLX1tjf8Su1Dga6CDT/eTWHZrWRf81KOVY07dle5SRIDK1QhfbGGtFP+T
-            vZkroousI9US2aCWlkeCZWGTnqvLmDoOujqagDoKRRuk4mQdtNNonxiL/wZtTFKi
-            +1iNjUVbLWiDXdBLxoRIVdLOzqb/MNxwElUyaTDAkopQyOWaTDkYPrGmaWjcsfPG
-            aOKow0ze+zHVFqTHbjnCqEV3hnsUyRUwsBln9+jDJXgwZM/tMlVJrZCh0Sle9Y5Z
-            MOB0fCf6sTMNRTGg5Lpl6uIYM/5INpmHVMo3n7MBSnpEDAUS2bf/uo5gIiq6XCdp
-            -----END CERTIFICATE-----
-      image: kuma/kuma-sidecar:latest
-      imagePullPolicy: IfNotPresent
-      livenessProbe:
-        httpGet:
-          path: /ready
-          port: 9901
-        failureThreshold: 212
-        initialDelaySeconds: 260
-        periodSeconds: 25
-        successThreshold: 1
-        timeoutSeconds: 23
-      name: kuma-sidecar
-      readinessProbe:
-        httpGet:
-          path: /ready
-          port: 9901
-        failureThreshold: 112
-        initialDelaySeconds: 11
-        periodSeconds: 15
-        successThreshold: 11
-        timeoutSeconds: 13
-      resources:
-        limits:
-          cpu: 1100m
-          memory: 1512Mi
-        requests:
-          cpu: 150m
-          memory: 164Mi
-      securityContext:
-        runAsGroup: 5678
-        runAsUser: 5678
-      volumeMounts:
-        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
-          name: default-token-w7dxf
-          readOnly: true
+  - image: busybox
+    livenessProbe:
+      httpGet:
+        path: /8080/metrics
+        port: 9000
+      initialDelaySeconds: 3
+      periodSeconds: 3
+    name: busybox
+    readinessProbe:
+      httpGet:
+        path: /3001/metrics
+        port: 9000
+      initialDelaySeconds: 3
+      periodSeconds: 3
+    resources: {}
+    volumeMounts:
+    - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+      name: default-token-w7dxf
+      readOnly: true
+  - args:
+    - run
+    - --log-level=info
+    env:
+    - name: POD_NAME
+      valueFrom:
+        fieldRef:
+          apiVersion: v1
+          fieldPath: metadata.name
+    - name: POD_NAMESPACE
+      valueFrom:
+        fieldRef:
+          apiVersion: v1
+          fieldPath: metadata.namespace
+    - name: INSTANCE_IP
+      valueFrom:
+        fieldRef:
+          apiVersion: v1
+          fieldPath: status.podIP
+    - name: KUMA_CONTROL_PLANE_CA_CERT
+      value: |
+        -----BEGIN CERTIFICATE-----
+        MIIDLDCCAhSgAwIBAgIQHdPhxOfXgWuNxoFlV/EwqTANBgkqhkiG9w0BAQsFADAP
+        MQ0wCwYDVQQDEwRrdW1hMB4XDTIwMDkxNjEyMjg0NFoXDTMwMDkxNDEyMjg0NFow
+        DzENMAsGA1UEAxMEa3VtYTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEB
+        AOZGbWhSlQSRxFNt5p/2WCKFyHZ3CuwNgyLEP7nS4ZXykxsFbYSuV3bIgF7bT/uq
+        a5Qire+C60guhFbpLcPh2Z6UfgId69GlQzHMVYcmLGjVQuyAt4FMMkTfVEl5I4Oa
+        +2it3BvihVkKhUz8y5RR5KbqJfGp4Z20Fh6fttoCFbeODmvBsYJFmUQS+ifoyMY/
+        P3R03Su7g5iIvnz7tmkydoNC8nGRDzdD5C8fJvrVI1UX6JRGyLKt45oQXt1mxK10
+        5KaN2zNV2WtHsaJp9bwrPH+JiZGeZyvuh5UwrLdHCmqK7sm9TodGztUZY0VzAc4q
+        kYViXY8gUjfNm+cQrPO1kN8CAwEAAaOBgzCBgDAOBgNVHQ8BAf8EBAMCAqQwHQYD
+        VR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMBMA8GA1UdEwEB/wQFMAMBAf8wHQYD
+        VR0OBBYEFGMDBPPiBFJ3mv2oA9CTqjemFTV2MB8GA1UdEQQYMBaCCWxvY2FsaG9z
+        dIIJbG9jYWxob3N0MA0GCSqGSIb3DQEBCwUAA4IBAQC/17QweOpGdb1MEBJ8XPG7
+        3sK/utoWLX1tjf8Su1Dga6CDT/eTWHZrWRf81KOVY07dle5SRIDK1QhfbGGtFP+T
+        vZkroousI9US2aCWlkeCZWGTnqvLmDoOujqagDoKRRuk4mQdtNNonxiL/wZtTFKi
+        +1iNjUVbLWiDXdBLxoRIVdLOzqb/MNxwElUyaTDAkopQyOWaTDkYPrGmaWjcsfPG
+        aOKow0ze+zHVFqTHbjnCqEV3hnsUyRUwsBln9+jDJXgwZM/tMlVJrZCh0Sle9Y5Z
+        MOB0fCf6sTMNRTGg5Lpl6uIYM/5INpmHVMo3n7MBSnpEDAUS2bf/uo5gIiq6XCdp
+        -----END CERTIFICATE-----
+    - name: KUMA_CONTROL_PLANE_URL
+      value: http://kuma-control-plane.kuma-system:5681
+    - name: KUMA_DATAPLANE_ADMIN_PORT
+      value: "9901"
+    - name: KUMA_DATAPLANE_DRAIN_TIME
+      value: 31s
+    - name: KUMA_DATAPLANE_MESH
+      value: default
+    - name: KUMA_DATAPLANE_NAME
+      value: $(POD_NAME).$(POD_NAMESPACE)
+    - name: KUMA_DATAPLANE_RUNTIME_TOKEN_PATH
+      value: /var/run/secrets/kubernetes.io/serviceaccount/token
+    image: kuma/kuma-sidecar:latest
+    imagePullPolicy: IfNotPresent
+    livenessProbe:
+      failureThreshold: 212
+      httpGet:
+        path: /ready
+        port: 9901
+      initialDelaySeconds: 260
+      periodSeconds: 25
+      successThreshold: 1
+      timeoutSeconds: 23
+    name: kuma-sidecar
+    readinessProbe:
+      failureThreshold: 112
+      httpGet:
+        path: /ready
+        port: 9901
+      initialDelaySeconds: 11
+      periodSeconds: 15
+      successThreshold: 11
+      timeoutSeconds: 13
+    resources:
+      limits:
+        cpu: 1100m
+        memory: 1512Mi
+      requests:
+        cpu: 150m
+        memory: 164Mi
+    securityContext:
+      runAsGroup: 5678
+      runAsUser: 5678
+    volumeMounts:
+    - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+      name: default-token-w7dxf
+      readOnly: true
   initContainers:
-    - args:
-        - -p
-        - "15001"
-        - -z
-        - "15006"
-        - -u
-        - "5678"
-        - -g
-        - "5678"
-        - -d
-        - ""
-        - -o
-        - ""
-        - -m
-        - REDIRECT
-        - -i
-        - '*'
-        - -b
-        - '*'
-      image: kuma/kuma-init:latest
-      imagePullPolicy: IfNotPresent
-      name: kuma-init
-      resources:
-        limits:
-          cpu: 100m
-          memory: 50M
-        requests:
-          cpu: 10m
-          memory: 10M
-      securityContext:
-        capabilities:
-          add:
-            - NET_ADMIN
-        runAsGroup: 0
-        runAsUser: 0
+  - args:
+    - -p
+    - "15001"
+    - -z
+    - "15006"
+    - -u
+    - "5678"
+    - -g
+    - "5678"
+    - -d
+    - ""
+    - -o
+    - ""
+    - -m
+    - REDIRECT
+    - -i
+    - '*'
+    - -b
+    - '*'
+    image: kuma/kuma-init:latest
+    imagePullPolicy: IfNotPresent
+    name: kuma-init
+    resources:
+      limits:
+        cpu: 100m
+        memory: 50M
+      requests:
+        cpu: 10m
+        memory: 10M
+    securityContext:
+      capabilities:
+        add:
+        - NET_ADMIN
+      runAsGroup: 0
+      runAsUser: 0
   volumes:
-    - name: default-token-w7dxf
-      secret:
-        secretName: default-token-w7dxf
+  - name: default-token-w7dxf
+    secret:
+      secretName: default-token-w7dxf
 status: {}

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.15.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.15.golden.yaml
@@ -15,150 +15,150 @@ metadata:
   name: busybox
 spec:
   containers:
-    - image: busybox
-      livenessProbe:
-        httpGet:
-          path: /8080/metrics
-          port: 19000
-        initialDelaySeconds: 3
-        periodSeconds: 3
-      name: busybox
-      readinessProbe:
-        httpGet:
-          path: /3001/metrics
-          port: 19000
-        initialDelaySeconds: 3
-        periodSeconds: 3
-      resources: {}
-      volumeMounts:
-        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
-          name: default-token-w7dxf
-          readOnly: true
-    - args:
-        - run
-        - --log-level=info
-      env:
-        - name: POD_NAME
-          valueFrom:
-            fieldRef:
-              apiVersion: v1
-              fieldPath: metadata.name
-        - name: POD_NAMESPACE
-          valueFrom:
-            fieldRef:
-              apiVersion: v1
-              fieldPath: metadata.namespace
-        - name: INSTANCE_IP
-          valueFrom:
-            fieldRef:
-              apiVersion: v1
-              fieldPath: status.podIP
-        - name: KUMA_CONTROL_PLANE_URL
-          value: http://kuma-control-plane.kuma-system:5681
-        - name: KUMA_DATAPLANE_MESH
-          value: default
-        - name: KUMA_DATAPLANE_NAME
-          value: $(POD_NAME).$(POD_NAMESPACE)
-        - name: KUMA_DATAPLANE_ADMIN_PORT
-          value: "9901"
-        - name: KUMA_DATAPLANE_DRAIN_TIME
-          value: 31s
-        - name: KUMA_DATAPLANE_RUNTIME_TOKEN_PATH
-          value: /var/run/secrets/kubernetes.io/serviceaccount/token
-        - name: KUMA_CONTROL_PLANE_CA_CERT
-          value: |
-            -----BEGIN CERTIFICATE-----
-            MIIDLDCCAhSgAwIBAgIQHdPhxOfXgWuNxoFlV/EwqTANBgkqhkiG9w0BAQsFADAP
-            MQ0wCwYDVQQDEwRrdW1hMB4XDTIwMDkxNjEyMjg0NFoXDTMwMDkxNDEyMjg0NFow
-            DzENMAsGA1UEAxMEa3VtYTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEB
-            AOZGbWhSlQSRxFNt5p/2WCKFyHZ3CuwNgyLEP7nS4ZXykxsFbYSuV3bIgF7bT/uq
-            a5Qire+C60guhFbpLcPh2Z6UfgId69GlQzHMVYcmLGjVQuyAt4FMMkTfVEl5I4Oa
-            +2it3BvihVkKhUz8y5RR5KbqJfGp4Z20Fh6fttoCFbeODmvBsYJFmUQS+ifoyMY/
-            P3R03Su7g5iIvnz7tmkydoNC8nGRDzdD5C8fJvrVI1UX6JRGyLKt45oQXt1mxK10
-            5KaN2zNV2WtHsaJp9bwrPH+JiZGeZyvuh5UwrLdHCmqK7sm9TodGztUZY0VzAc4q
-            kYViXY8gUjfNm+cQrPO1kN8CAwEAAaOBgzCBgDAOBgNVHQ8BAf8EBAMCAqQwHQYD
-            VR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMBMA8GA1UdEwEB/wQFMAMBAf8wHQYD
-            VR0OBBYEFGMDBPPiBFJ3mv2oA9CTqjemFTV2MB8GA1UdEQQYMBaCCWxvY2FsaG9z
-            dIIJbG9jYWxob3N0MA0GCSqGSIb3DQEBCwUAA4IBAQC/17QweOpGdb1MEBJ8XPG7
-            3sK/utoWLX1tjf8Su1Dga6CDT/eTWHZrWRf81KOVY07dle5SRIDK1QhfbGGtFP+T
-            vZkroousI9US2aCWlkeCZWGTnqvLmDoOujqagDoKRRuk4mQdtNNonxiL/wZtTFKi
-            +1iNjUVbLWiDXdBLxoRIVdLOzqb/MNxwElUyaTDAkopQyOWaTDkYPrGmaWjcsfPG
-            aOKow0ze+zHVFqTHbjnCqEV3hnsUyRUwsBln9+jDJXgwZM/tMlVJrZCh0Sle9Y5Z
-            MOB0fCf6sTMNRTGg5Lpl6uIYM/5INpmHVMo3n7MBSnpEDAUS2bf/uo5gIiq6XCdp
-            -----END CERTIFICATE-----
-      image: kuma/kuma-sidecar:latest
-      imagePullPolicy: IfNotPresent
-      livenessProbe:
-        httpGet:
-          path: /ready
-          port: 9901
-        failureThreshold: 212
-        initialDelaySeconds: 260
-        periodSeconds: 25
-        successThreshold: 1
-        timeoutSeconds: 23
-      name: kuma-sidecar
-      readinessProbe:
-        httpGet:
-          path: /ready
-          port: 9901
-        failureThreshold: 112
-        initialDelaySeconds: 11
-        periodSeconds: 15
-        successThreshold: 11
-        timeoutSeconds: 13
-      resources:
-        limits:
-          cpu: 1100m
-          memory: 1512Mi
-        requests:
-          cpu: 150m
-          memory: 164Mi
-      securityContext:
-        runAsGroup: 5678
-        runAsUser: 5678
-      volumeMounts:
-        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
-          name: default-token-w7dxf
-          readOnly: true
+  - image: busybox
+    livenessProbe:
+      httpGet:
+        path: /8080/metrics
+        port: 19000
+      initialDelaySeconds: 3
+      periodSeconds: 3
+    name: busybox
+    readinessProbe:
+      httpGet:
+        path: /3001/metrics
+        port: 19000
+      initialDelaySeconds: 3
+      periodSeconds: 3
+    resources: {}
+    volumeMounts:
+    - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+      name: default-token-w7dxf
+      readOnly: true
+  - args:
+    - run
+    - --log-level=info
+    env:
+    - name: POD_NAME
+      valueFrom:
+        fieldRef:
+          apiVersion: v1
+          fieldPath: metadata.name
+    - name: POD_NAMESPACE
+      valueFrom:
+        fieldRef:
+          apiVersion: v1
+          fieldPath: metadata.namespace
+    - name: INSTANCE_IP
+      valueFrom:
+        fieldRef:
+          apiVersion: v1
+          fieldPath: status.podIP
+    - name: KUMA_CONTROL_PLANE_CA_CERT
+      value: |
+        -----BEGIN CERTIFICATE-----
+        MIIDLDCCAhSgAwIBAgIQHdPhxOfXgWuNxoFlV/EwqTANBgkqhkiG9w0BAQsFADAP
+        MQ0wCwYDVQQDEwRrdW1hMB4XDTIwMDkxNjEyMjg0NFoXDTMwMDkxNDEyMjg0NFow
+        DzENMAsGA1UEAxMEa3VtYTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEB
+        AOZGbWhSlQSRxFNt5p/2WCKFyHZ3CuwNgyLEP7nS4ZXykxsFbYSuV3bIgF7bT/uq
+        a5Qire+C60guhFbpLcPh2Z6UfgId69GlQzHMVYcmLGjVQuyAt4FMMkTfVEl5I4Oa
+        +2it3BvihVkKhUz8y5RR5KbqJfGp4Z20Fh6fttoCFbeODmvBsYJFmUQS+ifoyMY/
+        P3R03Su7g5iIvnz7tmkydoNC8nGRDzdD5C8fJvrVI1UX6JRGyLKt45oQXt1mxK10
+        5KaN2zNV2WtHsaJp9bwrPH+JiZGeZyvuh5UwrLdHCmqK7sm9TodGztUZY0VzAc4q
+        kYViXY8gUjfNm+cQrPO1kN8CAwEAAaOBgzCBgDAOBgNVHQ8BAf8EBAMCAqQwHQYD
+        VR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMBMA8GA1UdEwEB/wQFMAMBAf8wHQYD
+        VR0OBBYEFGMDBPPiBFJ3mv2oA9CTqjemFTV2MB8GA1UdEQQYMBaCCWxvY2FsaG9z
+        dIIJbG9jYWxob3N0MA0GCSqGSIb3DQEBCwUAA4IBAQC/17QweOpGdb1MEBJ8XPG7
+        3sK/utoWLX1tjf8Su1Dga6CDT/eTWHZrWRf81KOVY07dle5SRIDK1QhfbGGtFP+T
+        vZkroousI9US2aCWlkeCZWGTnqvLmDoOujqagDoKRRuk4mQdtNNonxiL/wZtTFKi
+        +1iNjUVbLWiDXdBLxoRIVdLOzqb/MNxwElUyaTDAkopQyOWaTDkYPrGmaWjcsfPG
+        aOKow0ze+zHVFqTHbjnCqEV3hnsUyRUwsBln9+jDJXgwZM/tMlVJrZCh0Sle9Y5Z
+        MOB0fCf6sTMNRTGg5Lpl6uIYM/5INpmHVMo3n7MBSnpEDAUS2bf/uo5gIiq6XCdp
+        -----END CERTIFICATE-----
+    - name: KUMA_CONTROL_PLANE_URL
+      value: http://kuma-control-plane.kuma-system:5681
+    - name: KUMA_DATAPLANE_ADMIN_PORT
+      value: "9901"
+    - name: KUMA_DATAPLANE_DRAIN_TIME
+      value: 31s
+    - name: KUMA_DATAPLANE_MESH
+      value: default
+    - name: KUMA_DATAPLANE_NAME
+      value: $(POD_NAME).$(POD_NAMESPACE)
+    - name: KUMA_DATAPLANE_RUNTIME_TOKEN_PATH
+      value: /var/run/secrets/kubernetes.io/serviceaccount/token
+    image: kuma/kuma-sidecar:latest
+    imagePullPolicy: IfNotPresent
+    livenessProbe:
+      failureThreshold: 212
+      httpGet:
+        path: /ready
+        port: 9901
+      initialDelaySeconds: 260
+      periodSeconds: 25
+      successThreshold: 1
+      timeoutSeconds: 23
+    name: kuma-sidecar
+    readinessProbe:
+      failureThreshold: 112
+      httpGet:
+        path: /ready
+        port: 9901
+      initialDelaySeconds: 11
+      periodSeconds: 15
+      successThreshold: 11
+      timeoutSeconds: 13
+    resources:
+      limits:
+        cpu: 1100m
+        memory: 1512Mi
+      requests:
+        cpu: 150m
+        memory: 164Mi
+    securityContext:
+      runAsGroup: 5678
+      runAsUser: 5678
+    volumeMounts:
+    - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+      name: default-token-w7dxf
+      readOnly: true
   initContainers:
-    - args:
-        - -p
-        - "15001"
-        - -z
-        - "15006"
-        - -u
-        - "5678"
-        - -g
-        - "5678"
-        - -d
-        - ""
-        - -o
-        - ""
-        - -m
-        - REDIRECT
-        - -i
-        - '*'
-        - -b
-        - '*'
-      image: kuma/kuma-init:latest
-      imagePullPolicy: IfNotPresent
-      name: kuma-init
-      resources:
-        limits:
-          cpu: 100m
-          memory: 50M
-        requests:
-          cpu: 10m
-          memory: 10M
-      securityContext:
-        capabilities:
-          add:
-            - NET_ADMIN
-        runAsGroup: 0
-        runAsUser: 0
+  - args:
+    - -p
+    - "15001"
+    - -z
+    - "15006"
+    - -u
+    - "5678"
+    - -g
+    - "5678"
+    - -d
+    - ""
+    - -o
+    - ""
+    - -m
+    - REDIRECT
+    - -i
+    - '*'
+    - -b
+    - '*'
+    image: kuma/kuma-init:latest
+    imagePullPolicy: IfNotPresent
+    name: kuma-init
+    resources:
+      limits:
+        cpu: 100m
+        memory: 50M
+      requests:
+        cpu: 10m
+        memory: 10M
+    securityContext:
+      capabilities:
+        add:
+        - NET_ADMIN
+      runAsGroup: 0
+      runAsUser: 0
   volumes:
-    - name: default-token-w7dxf
-      secret:
-        secretName: default-token-w7dxf
+  - name: default-token-w7dxf
+    secret:
+      secretName: default-token-w7dxf
 status: {}

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.16.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.16.golden.yaml
@@ -15,150 +15,150 @@ metadata:
   name: busybox
 spec:
   containers:
-    - image: busybox
-      livenessProbe:
-        httpGet:
-          path: /metrics
-          port: 8080
-        initialDelaySeconds: 3
-        periodSeconds: 3
-      name: busybox
-      readinessProbe:
-        httpGet:
-          path: /metrics
-          port: 3001
-        initialDelaySeconds: 3
-        periodSeconds: 3
-      resources: {}
-      volumeMounts:
-        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
-          name: default-token-w7dxf
-          readOnly: true
-    - args:
-        - run
-        - --log-level=info
-      env:
-        - name: POD_NAME
-          valueFrom:
-            fieldRef:
-              apiVersion: v1
-              fieldPath: metadata.name
-        - name: POD_NAMESPACE
-          valueFrom:
-            fieldRef:
-              apiVersion: v1
-              fieldPath: metadata.namespace
-        - name: INSTANCE_IP
-          valueFrom:
-            fieldRef:
-              apiVersion: v1
-              fieldPath: status.podIP
-        - name: KUMA_CONTROL_PLANE_URL
-          value: http://kuma-control-plane.kuma-system:5681
-        - name: KUMA_DATAPLANE_MESH
-          value: default
-        - name: KUMA_DATAPLANE_NAME
-          value: $(POD_NAME).$(POD_NAMESPACE)
-        - name: KUMA_DATAPLANE_ADMIN_PORT
-          value: "9901"
-        - name: KUMA_DATAPLANE_DRAIN_TIME
-          value: 31s
-        - name: KUMA_DATAPLANE_RUNTIME_TOKEN_PATH
-          value: /var/run/secrets/kubernetes.io/serviceaccount/token
-        - name: KUMA_CONTROL_PLANE_CA_CERT
-          value: |
-            -----BEGIN CERTIFICATE-----
-            MIIDLDCCAhSgAwIBAgIQHdPhxOfXgWuNxoFlV/EwqTANBgkqhkiG9w0BAQsFADAP
-            MQ0wCwYDVQQDEwRrdW1hMB4XDTIwMDkxNjEyMjg0NFoXDTMwMDkxNDEyMjg0NFow
-            DzENMAsGA1UEAxMEa3VtYTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEB
-            AOZGbWhSlQSRxFNt5p/2WCKFyHZ3CuwNgyLEP7nS4ZXykxsFbYSuV3bIgF7bT/uq
-            a5Qire+C60guhFbpLcPh2Z6UfgId69GlQzHMVYcmLGjVQuyAt4FMMkTfVEl5I4Oa
-            +2it3BvihVkKhUz8y5RR5KbqJfGp4Z20Fh6fttoCFbeODmvBsYJFmUQS+ifoyMY/
-            P3R03Su7g5iIvnz7tmkydoNC8nGRDzdD5C8fJvrVI1UX6JRGyLKt45oQXt1mxK10
-            5KaN2zNV2WtHsaJp9bwrPH+JiZGeZyvuh5UwrLdHCmqK7sm9TodGztUZY0VzAc4q
-            kYViXY8gUjfNm+cQrPO1kN8CAwEAAaOBgzCBgDAOBgNVHQ8BAf8EBAMCAqQwHQYD
-            VR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMBMA8GA1UdEwEB/wQFMAMBAf8wHQYD
-            VR0OBBYEFGMDBPPiBFJ3mv2oA9CTqjemFTV2MB8GA1UdEQQYMBaCCWxvY2FsaG9z
-            dIIJbG9jYWxob3N0MA0GCSqGSIb3DQEBCwUAA4IBAQC/17QweOpGdb1MEBJ8XPG7
-            3sK/utoWLX1tjf8Su1Dga6CDT/eTWHZrWRf81KOVY07dle5SRIDK1QhfbGGtFP+T
-            vZkroousI9US2aCWlkeCZWGTnqvLmDoOujqagDoKRRuk4mQdtNNonxiL/wZtTFKi
-            +1iNjUVbLWiDXdBLxoRIVdLOzqb/MNxwElUyaTDAkopQyOWaTDkYPrGmaWjcsfPG
-            aOKow0ze+zHVFqTHbjnCqEV3hnsUyRUwsBln9+jDJXgwZM/tMlVJrZCh0Sle9Y5Z
-            MOB0fCf6sTMNRTGg5Lpl6uIYM/5INpmHVMo3n7MBSnpEDAUS2bf/uo5gIiq6XCdp
-            -----END CERTIFICATE-----
-      image: kuma/kuma-sidecar:latest
-      imagePullPolicy: IfNotPresent
-      livenessProbe:
-        httpGet:
-          path: /ready
-          port: 9901
-        failureThreshold: 212
-        initialDelaySeconds: 260
-        periodSeconds: 25
-        successThreshold: 1
-        timeoutSeconds: 23
-      name: kuma-sidecar
-      readinessProbe:
-        httpGet:
-          path: /ready
-          port: 9901
-        failureThreshold: 112
-        initialDelaySeconds: 11
-        periodSeconds: 15
-        successThreshold: 11
-        timeoutSeconds: 13
-      resources:
-        limits:
-          cpu: 1100m
-          memory: 1512Mi
-        requests:
-          cpu: 150m
-          memory: 164Mi
-      securityContext:
-        runAsGroup: 5678
-        runAsUser: 5678
-      volumeMounts:
-        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
-          name: default-token-w7dxf
-          readOnly: true
+  - image: busybox
+    livenessProbe:
+      httpGet:
+        path: /metrics
+        port: 8080
+      initialDelaySeconds: 3
+      periodSeconds: 3
+    name: busybox
+    readinessProbe:
+      httpGet:
+        path: /metrics
+        port: 3001
+      initialDelaySeconds: 3
+      periodSeconds: 3
+    resources: {}
+    volumeMounts:
+    - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+      name: default-token-w7dxf
+      readOnly: true
+  - args:
+    - run
+    - --log-level=info
+    env:
+    - name: POD_NAME
+      valueFrom:
+        fieldRef:
+          apiVersion: v1
+          fieldPath: metadata.name
+    - name: POD_NAMESPACE
+      valueFrom:
+        fieldRef:
+          apiVersion: v1
+          fieldPath: metadata.namespace
+    - name: INSTANCE_IP
+      valueFrom:
+        fieldRef:
+          apiVersion: v1
+          fieldPath: status.podIP
+    - name: KUMA_CONTROL_PLANE_CA_CERT
+      value: |
+        -----BEGIN CERTIFICATE-----
+        MIIDLDCCAhSgAwIBAgIQHdPhxOfXgWuNxoFlV/EwqTANBgkqhkiG9w0BAQsFADAP
+        MQ0wCwYDVQQDEwRrdW1hMB4XDTIwMDkxNjEyMjg0NFoXDTMwMDkxNDEyMjg0NFow
+        DzENMAsGA1UEAxMEa3VtYTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEB
+        AOZGbWhSlQSRxFNt5p/2WCKFyHZ3CuwNgyLEP7nS4ZXykxsFbYSuV3bIgF7bT/uq
+        a5Qire+C60guhFbpLcPh2Z6UfgId69GlQzHMVYcmLGjVQuyAt4FMMkTfVEl5I4Oa
+        +2it3BvihVkKhUz8y5RR5KbqJfGp4Z20Fh6fttoCFbeODmvBsYJFmUQS+ifoyMY/
+        P3R03Su7g5iIvnz7tmkydoNC8nGRDzdD5C8fJvrVI1UX6JRGyLKt45oQXt1mxK10
+        5KaN2zNV2WtHsaJp9bwrPH+JiZGeZyvuh5UwrLdHCmqK7sm9TodGztUZY0VzAc4q
+        kYViXY8gUjfNm+cQrPO1kN8CAwEAAaOBgzCBgDAOBgNVHQ8BAf8EBAMCAqQwHQYD
+        VR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMBMA8GA1UdEwEB/wQFMAMBAf8wHQYD
+        VR0OBBYEFGMDBPPiBFJ3mv2oA9CTqjemFTV2MB8GA1UdEQQYMBaCCWxvY2FsaG9z
+        dIIJbG9jYWxob3N0MA0GCSqGSIb3DQEBCwUAA4IBAQC/17QweOpGdb1MEBJ8XPG7
+        3sK/utoWLX1tjf8Su1Dga6CDT/eTWHZrWRf81KOVY07dle5SRIDK1QhfbGGtFP+T
+        vZkroousI9US2aCWlkeCZWGTnqvLmDoOujqagDoKRRuk4mQdtNNonxiL/wZtTFKi
+        +1iNjUVbLWiDXdBLxoRIVdLOzqb/MNxwElUyaTDAkopQyOWaTDkYPrGmaWjcsfPG
+        aOKow0ze+zHVFqTHbjnCqEV3hnsUyRUwsBln9+jDJXgwZM/tMlVJrZCh0Sle9Y5Z
+        MOB0fCf6sTMNRTGg5Lpl6uIYM/5INpmHVMo3n7MBSnpEDAUS2bf/uo5gIiq6XCdp
+        -----END CERTIFICATE-----
+    - name: KUMA_CONTROL_PLANE_URL
+      value: http://kuma-control-plane.kuma-system:5681
+    - name: KUMA_DATAPLANE_ADMIN_PORT
+      value: "9901"
+    - name: KUMA_DATAPLANE_DRAIN_TIME
+      value: 31s
+    - name: KUMA_DATAPLANE_MESH
+      value: default
+    - name: KUMA_DATAPLANE_NAME
+      value: $(POD_NAME).$(POD_NAMESPACE)
+    - name: KUMA_DATAPLANE_RUNTIME_TOKEN_PATH
+      value: /var/run/secrets/kubernetes.io/serviceaccount/token
+    image: kuma/kuma-sidecar:latest
+    imagePullPolicy: IfNotPresent
+    livenessProbe:
+      failureThreshold: 212
+      httpGet:
+        path: /ready
+        port: 9901
+      initialDelaySeconds: 260
+      periodSeconds: 25
+      successThreshold: 1
+      timeoutSeconds: 23
+    name: kuma-sidecar
+    readinessProbe:
+      failureThreshold: 112
+      httpGet:
+        path: /ready
+        port: 9901
+      initialDelaySeconds: 11
+      periodSeconds: 15
+      successThreshold: 11
+      timeoutSeconds: 13
+    resources:
+      limits:
+        cpu: 1100m
+        memory: 1512Mi
+      requests:
+        cpu: 150m
+        memory: 164Mi
+    securityContext:
+      runAsGroup: 5678
+      runAsUser: 5678
+    volumeMounts:
+    - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+      name: default-token-w7dxf
+      readOnly: true
   initContainers:
-    - args:
-        - -p
-        - "15001"
-        - -z
-        - "15006"
-        - -u
-        - "5678"
-        - -g
-        - "5678"
-        - -d
-        - ""
-        - -o
-        - ""
-        - -m
-        - REDIRECT
-        - -i
-        - '*'
-        - -b
-        - '*'
-      image: kuma/kuma-init:latest
-      imagePullPolicy: IfNotPresent
-      name: kuma-init
-      resources:
-        limits:
-          cpu: 100m
-          memory: 50M
-        requests:
-          cpu: 10m
-          memory: 10M
-      securityContext:
-        capabilities:
-          add:
-            - NET_ADMIN
-        runAsGroup: 0
-        runAsUser: 0
+  - args:
+    - -p
+    - "15001"
+    - -z
+    - "15006"
+    - -u
+    - "5678"
+    - -g
+    - "5678"
+    - -d
+    - ""
+    - -o
+    - ""
+    - -m
+    - REDIRECT
+    - -i
+    - '*'
+    - -b
+    - '*'
+    image: kuma/kuma-init:latest
+    imagePullPolicy: IfNotPresent
+    name: kuma-init
+    resources:
+      limits:
+        cpu: 100m
+        memory: 50M
+      requests:
+        cpu: 10m
+        memory: 10M
+    securityContext:
+      capabilities:
+        add:
+        - NET_ADMIN
+      runAsGroup: 0
+      runAsUser: 0
   volumes:
-    - name: default-token-w7dxf
-      secret:
-        secretName: default-token-w7dxf
+  - name: default-token-w7dxf
+    secret:
+      secretName: default-token-w7dxf
 status: {}

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.17.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.17.golden.yaml
@@ -5,11 +5,11 @@ metadata:
     kuma.io/mesh: default
     kuma.io/sidecar-injected: "true"
     kuma.io/transparent-proxying: enabled
-    kuma.io/transparent-proxying-outbound-port: "15001"
     kuma.io/transparent-proxying-inbound-port: "15006"
+    kuma.io/transparent-proxying-outbound-port: "15001"
     kuma.io/virtual-probes: enabled
     kuma.io/virtual-probes-port: "9000"
-    traffic.kuma.io/exclude-inbound-ports: "1234,1235"
+    traffic.kuma.io/exclude-inbound-ports: 1234,1235
     traffic.kuma.io/exclude-outbound-ports: "1236"
   creationTimestamp: null
   labels:
@@ -43,18 +43,6 @@ spec:
         fieldRef:
           apiVersion: v1
           fieldPath: status.podIP
-    - name: KUMA_CONTROL_PLANE_URL
-      value: http://kuma-control-plane.kuma-system:5681
-    - name: KUMA_DATAPLANE_MESH
-      value: default
-    - name: KUMA_DATAPLANE_NAME
-      value: $(POD_NAME).$(POD_NAMESPACE)
-    - name: KUMA_DATAPLANE_ADMIN_PORT
-      value: "9901"
-    - name: KUMA_DATAPLANE_DRAIN_TIME
-      value: 31s
-    - name: KUMA_DATAPLANE_RUNTIME_TOKEN_PATH
-      value: /var/run/secrets/kubernetes.io/serviceaccount/token
     - name: KUMA_CONTROL_PLANE_CA_CERT
       value: |
         -----BEGIN CERTIFICATE-----
@@ -76,23 +64,35 @@ spec:
         aOKow0ze+zHVFqTHbjnCqEV3hnsUyRUwsBln9+jDJXgwZM/tMlVJrZCh0Sle9Y5Z
         MOB0fCf6sTMNRTGg5Lpl6uIYM/5INpmHVMo3n7MBSnpEDAUS2bf/uo5gIiq6XCdp
         -----END CERTIFICATE-----
+    - name: KUMA_CONTROL_PLANE_URL
+      value: http://kuma-control-plane.kuma-system:5681
+    - name: KUMA_DATAPLANE_ADMIN_PORT
+      value: "9901"
+    - name: KUMA_DATAPLANE_DRAIN_TIME
+      value: 31s
+    - name: KUMA_DATAPLANE_MESH
+      value: default
+    - name: KUMA_DATAPLANE_NAME
+      value: $(POD_NAME).$(POD_NAMESPACE)
+    - name: KUMA_DATAPLANE_RUNTIME_TOKEN_PATH
+      value: /var/run/secrets/kubernetes.io/serviceaccount/token
     image: kuma/kuma-sidecar:latest
     imagePullPolicy: IfNotPresent
     livenessProbe:
+      failureThreshold: 212
       httpGet:
         path: /ready
         port: 9901
-      failureThreshold: 212
       initialDelaySeconds: 260
       periodSeconds: 25
       successThreshold: 1
       timeoutSeconds: 23
     name: kuma-sidecar
     readinessProbe:
+      failureThreshold: 112
       httpGet:
         path: /ready
         port: 9901
-      failureThreshold: 112
       initialDelaySeconds: 11
       periodSeconds: 15
       successThreshold: 11
@@ -108,9 +108,9 @@ spec:
       runAsGroup: 5678
       runAsUser: 5678
     volumeMounts:
-    - name: default-token-w7dxf
+    - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+      name: default-token-w7dxf
       readOnly: true
-      mountPath: "/var/run/secrets/kubernetes.io/serviceaccount"
   initContainers:
   - command:
     - sh
@@ -129,7 +129,7 @@ spec:
     - -g
     - "5678"
     - -d
-    - "1234,1235"
+    - 1234,1235
     - -o
     - "1236"
     - -m

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.18.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.18.golden.yaml
@@ -17,145 +17,145 @@ metadata:
   name: busybox
 spec:
   containers:
-    - image: busybox
-      name: busybox
-      resources: {}
-      volumeMounts:
-        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
-          name: default-token-w7dxf
-          readOnly: true
-    - args:
-        - run
-        - --log-level=info
-      env:
-        - name: POD_NAME
-          valueFrom:
-            fieldRef:
-              apiVersion: v1
-              fieldPath: metadata.name
-        - name: POD_NAMESPACE
-          valueFrom:
-            fieldRef:
-              apiVersion: v1
-              fieldPath: metadata.namespace
-        - name: INSTANCE_IP
-          valueFrom:
-            fieldRef:
-              apiVersion: v1
-              fieldPath: status.podIP
-        - name: KUMA_CONTROL_PLANE_URL
-          value: http://kuma-control-plane.kuma-system:5681
-        - name: KUMA_DATAPLANE_MESH
-          value: default
-        - name: KUMA_DATAPLANE_NAME
-          value: $(POD_NAME).$(POD_NAMESPACE)
-        - name: KUMA_DATAPLANE_ADMIN_PORT
-          value: "9901"
-        - name: KUMA_DATAPLANE_DRAIN_TIME
-          value: 31s
-        - name: KUMA_DATAPLANE_RUNTIME_TOKEN_PATH
-          value: /var/run/secrets/kubernetes.io/serviceaccount/token
-        - name: KUMA_CONTROL_PLANE_CA_CERT
-          value: |
-            -----BEGIN CERTIFICATE-----
-            MIIDLDCCAhSgAwIBAgIQHdPhxOfXgWuNxoFlV/EwqTANBgkqhkiG9w0BAQsFADAP
-            MQ0wCwYDVQQDEwRrdW1hMB4XDTIwMDkxNjEyMjg0NFoXDTMwMDkxNDEyMjg0NFow
-            DzENMAsGA1UEAxMEa3VtYTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEB
-            AOZGbWhSlQSRxFNt5p/2WCKFyHZ3CuwNgyLEP7nS4ZXykxsFbYSuV3bIgF7bT/uq
-            a5Qire+C60guhFbpLcPh2Z6UfgId69GlQzHMVYcmLGjVQuyAt4FMMkTfVEl5I4Oa
-            +2it3BvihVkKhUz8y5RR5KbqJfGp4Z20Fh6fttoCFbeODmvBsYJFmUQS+ifoyMY/
-            P3R03Su7g5iIvnz7tmkydoNC8nGRDzdD5C8fJvrVI1UX6JRGyLKt45oQXt1mxK10
-            5KaN2zNV2WtHsaJp9bwrPH+JiZGeZyvuh5UwrLdHCmqK7sm9TodGztUZY0VzAc4q
-            kYViXY8gUjfNm+cQrPO1kN8CAwEAAaOBgzCBgDAOBgNVHQ8BAf8EBAMCAqQwHQYD
-            VR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMBMA8GA1UdEwEB/wQFMAMBAf8wHQYD
-            VR0OBBYEFGMDBPPiBFJ3mv2oA9CTqjemFTV2MB8GA1UdEQQYMBaCCWxvY2FsaG9z
-            dIIJbG9jYWxob3N0MA0GCSqGSIb3DQEBCwUAA4IBAQC/17QweOpGdb1MEBJ8XPG7
-            3sK/utoWLX1tjf8Su1Dga6CDT/eTWHZrWRf81KOVY07dle5SRIDK1QhfbGGtFP+T
-            vZkroousI9US2aCWlkeCZWGTnqvLmDoOujqagDoKRRuk4mQdtNNonxiL/wZtTFKi
-            +1iNjUVbLWiDXdBLxoRIVdLOzqb/MNxwElUyaTDAkopQyOWaTDkYPrGmaWjcsfPG
-            aOKow0ze+zHVFqTHbjnCqEV3hnsUyRUwsBln9+jDJXgwZM/tMlVJrZCh0Sle9Y5Z
-            MOB0fCf6sTMNRTGg5Lpl6uIYM/5INpmHVMo3n7MBSnpEDAUS2bf/uo5gIiq6XCdp
-            -----END CERTIFICATE-----
-      image: kuma/kuma-sidecar:latest
-      imagePullPolicy: IfNotPresent
-      livenessProbe:
-        httpGet:
-          path: /ready
-          port: 9901
-        failureThreshold: 212
-        initialDelaySeconds: 260
-        periodSeconds: 25
-        successThreshold: 1
-        timeoutSeconds: 23
-      name: kuma-sidecar
-      readinessProbe:
-        httpGet:
-          path: /ready
-          port: 9901
-        failureThreshold: 112
-        initialDelaySeconds: 11
-        periodSeconds: 15
-        successThreshold: 11
-        timeoutSeconds: 13
-      resources:
-        limits:
-          cpu: 1100m
-          memory: 1512Mi
-        requests:
-          cpu: 150m
-          memory: 164Mi
-      securityContext:
-        runAsGroup: 5678
-        runAsUser: 5678
-      volumeMounts:
-        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
-          name: default-token-w7dxf
-          readOnly: true
+  - image: busybox
+    name: busybox
+    resources: {}
+    volumeMounts:
+    - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+      name: default-token-w7dxf
+      readOnly: true
+  - args:
+    - run
+    - --log-level=info
+    env:
+    - name: POD_NAME
+      valueFrom:
+        fieldRef:
+          apiVersion: v1
+          fieldPath: metadata.name
+    - name: POD_NAMESPACE
+      valueFrom:
+        fieldRef:
+          apiVersion: v1
+          fieldPath: metadata.namespace
+    - name: INSTANCE_IP
+      valueFrom:
+        fieldRef:
+          apiVersion: v1
+          fieldPath: status.podIP
+    - name: KUMA_CONTROL_PLANE_CA_CERT
+      value: |
+        -----BEGIN CERTIFICATE-----
+        MIIDLDCCAhSgAwIBAgIQHdPhxOfXgWuNxoFlV/EwqTANBgkqhkiG9w0BAQsFADAP
+        MQ0wCwYDVQQDEwRrdW1hMB4XDTIwMDkxNjEyMjg0NFoXDTMwMDkxNDEyMjg0NFow
+        DzENMAsGA1UEAxMEa3VtYTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEB
+        AOZGbWhSlQSRxFNt5p/2WCKFyHZ3CuwNgyLEP7nS4ZXykxsFbYSuV3bIgF7bT/uq
+        a5Qire+C60guhFbpLcPh2Z6UfgId69GlQzHMVYcmLGjVQuyAt4FMMkTfVEl5I4Oa
+        +2it3BvihVkKhUz8y5RR5KbqJfGp4Z20Fh6fttoCFbeODmvBsYJFmUQS+ifoyMY/
+        P3R03Su7g5iIvnz7tmkydoNC8nGRDzdD5C8fJvrVI1UX6JRGyLKt45oQXt1mxK10
+        5KaN2zNV2WtHsaJp9bwrPH+JiZGeZyvuh5UwrLdHCmqK7sm9TodGztUZY0VzAc4q
+        kYViXY8gUjfNm+cQrPO1kN8CAwEAAaOBgzCBgDAOBgNVHQ8BAf8EBAMCAqQwHQYD
+        VR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMBMA8GA1UdEwEB/wQFMAMBAf8wHQYD
+        VR0OBBYEFGMDBPPiBFJ3mv2oA9CTqjemFTV2MB8GA1UdEQQYMBaCCWxvY2FsaG9z
+        dIIJbG9jYWxob3N0MA0GCSqGSIb3DQEBCwUAA4IBAQC/17QweOpGdb1MEBJ8XPG7
+        3sK/utoWLX1tjf8Su1Dga6CDT/eTWHZrWRf81KOVY07dle5SRIDK1QhfbGGtFP+T
+        vZkroousI9US2aCWlkeCZWGTnqvLmDoOujqagDoKRRuk4mQdtNNonxiL/wZtTFKi
+        +1iNjUVbLWiDXdBLxoRIVdLOzqb/MNxwElUyaTDAkopQyOWaTDkYPrGmaWjcsfPG
+        aOKow0ze+zHVFqTHbjnCqEV3hnsUyRUwsBln9+jDJXgwZM/tMlVJrZCh0Sle9Y5Z
+        MOB0fCf6sTMNRTGg5Lpl6uIYM/5INpmHVMo3n7MBSnpEDAUS2bf/uo5gIiq6XCdp
+        -----END CERTIFICATE-----
+    - name: KUMA_CONTROL_PLANE_URL
+      value: http://kuma-control-plane.kuma-system:5681
+    - name: KUMA_DATAPLANE_ADMIN_PORT
+      value: "9901"
+    - name: KUMA_DATAPLANE_DRAIN_TIME
+      value: 31s
+    - name: KUMA_DATAPLANE_MESH
+      value: default
+    - name: KUMA_DATAPLANE_NAME
+      value: $(POD_NAME).$(POD_NAMESPACE)
+    - name: KUMA_DATAPLANE_RUNTIME_TOKEN_PATH
+      value: /var/run/secrets/kubernetes.io/serviceaccount/token
+    image: kuma/kuma-sidecar:latest
+    imagePullPolicy: IfNotPresent
+    livenessProbe:
+      failureThreshold: 212
+      httpGet:
+        path: /ready
+        port: 9901
+      initialDelaySeconds: 260
+      periodSeconds: 25
+      successThreshold: 1
+      timeoutSeconds: 23
+    name: kuma-sidecar
+    readinessProbe:
+      failureThreshold: 112
+      httpGet:
+        path: /ready
+        port: 9901
+      initialDelaySeconds: 11
+      periodSeconds: 15
+      successThreshold: 11
+      timeoutSeconds: 13
+    resources:
+      limits:
+        cpu: 1100m
+        memory: 1512Mi
+      requests:
+        cpu: 150m
+        memory: 164Mi
+    securityContext:
+      runAsGroup: 5678
+      runAsUser: 5678
+    volumeMounts:
+    - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+      name: default-token-w7dxf
+      readOnly: true
   initContainers:
-    - command:
-        - sh
-        - -c
-        - sleep 5
-      image: busybox
-      name: init
-      resources: {}
-    - args:
-        - -p
-        - "15001"
-        - -z
-        - "15006"
-        - -u
-        - "5678"
-        - -g
-        - "5678"
-        - -d
-        - "1234,5678"
-        - -o
-        - "4321,7654"
-        - -m
-        - REDIRECT
-        - -i
-        - '*'
-        - -b
-        - '*'
-      image: kuma/kuma-init:latest
-      imagePullPolicy: IfNotPresent
-      name: kuma-init
-      resources:
-        limits:
-          cpu: 100m
-          memory: 50M
-        requests:
-          cpu: 10m
-          memory: 10M
-      securityContext:
-        capabilities:
-          add:
-            - NET_ADMIN
-        runAsGroup: 0
-        runAsUser: 0
+  - command:
+    - sh
+    - -c
+    - sleep 5
+    image: busybox
+    name: init
+    resources: {}
+  - args:
+    - -p
+    - "15001"
+    - -z
+    - "15006"
+    - -u
+    - "5678"
+    - -g
+    - "5678"
+    - -d
+    - 1234,5678
+    - -o
+    - 4321,7654
+    - -m
+    - REDIRECT
+    - -i
+    - '*'
+    - -b
+    - '*'
+    image: kuma/kuma-init:latest
+    imagePullPolicy: IfNotPresent
+    name: kuma-init
+    resources:
+      limits:
+        cpu: 100m
+        memory: 50M
+      requests:
+        cpu: 10m
+        memory: 10M
+    securityContext:
+      capabilities:
+        add:
+        - NET_ADMIN
+      runAsGroup: 0
+      runAsUser: 0
   volumes:
-    - name: default-token-w7dxf
-      secret:
-        secretName: default-token-w7dxf
+  - name: default-token-w7dxf
+    secret:
+      secretName: default-token-w7dxf
 status: {}

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.19.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.19.golden.yaml
@@ -5,8 +5,8 @@ metadata:
     kuma.io/mesh: default
     kuma.io/sidecar-injected: "true"
     kuma.io/transparent-proxying: enabled
-    kuma.io/transparent-proxying-outbound-port: "15001"
     kuma.io/transparent-proxying-inbound-port: "15006"
+    kuma.io/transparent-proxying-outbound-port: "15001"
     kuma.io/virtual-probes: enabled
     kuma.io/virtual-probes-port: "9000"
     traffic.kuma.io/exclude-inbound-ports: ""
@@ -43,18 +43,6 @@ spec:
         fieldRef:
           apiVersion: v1
           fieldPath: status.podIP
-    - name: KUMA_CONTROL_PLANE_URL
-      value: http://kuma-control-plane.kuma-system:5681
-    - name: KUMA_DATAPLANE_MESH
-      value: default
-    - name: KUMA_DATAPLANE_NAME
-      value: $(POD_NAME).$(POD_NAMESPACE)
-    - name: KUMA_DATAPLANE_ADMIN_PORT
-      value: "9901"
-    - name: KUMA_DATAPLANE_DRAIN_TIME
-      value: 31s
-    - name: KUMA_DATAPLANE_RUNTIME_TOKEN_PATH
-      value: /var/run/secrets/kubernetes.io/serviceaccount/token
     - name: KUMA_CONTROL_PLANE_CA_CERT
       value: |
         -----BEGIN CERTIFICATE-----
@@ -76,23 +64,35 @@ spec:
         aOKow0ze+zHVFqTHbjnCqEV3hnsUyRUwsBln9+jDJXgwZM/tMlVJrZCh0Sle9Y5Z
         MOB0fCf6sTMNRTGg5Lpl6uIYM/5INpmHVMo3n7MBSnpEDAUS2bf/uo5gIiq6XCdp
         -----END CERTIFICATE-----
+    - name: KUMA_CONTROL_PLANE_URL
+      value: http://kuma-control-plane.kuma-system:5681
+    - name: KUMA_DATAPLANE_ADMIN_PORT
+      value: "9901"
+    - name: KUMA_DATAPLANE_DRAIN_TIME
+      value: 31s
+    - name: KUMA_DATAPLANE_MESH
+      value: default
+    - name: KUMA_DATAPLANE_NAME
+      value: $(POD_NAME).$(POD_NAMESPACE)
+    - name: KUMA_DATAPLANE_RUNTIME_TOKEN_PATH
+      value: /var/run/secrets/kubernetes.io/serviceaccount/token
     image: kuma/kuma-sidecar:latest
     imagePullPolicy: IfNotPresent
     livenessProbe:
+      failureThreshold: 212
       httpGet:
         path: /ready
         port: 9901
-      failureThreshold: 212
       initialDelaySeconds: 260
       periodSeconds: 25
       successThreshold: 1
       timeoutSeconds: 23
     name: kuma-sidecar
     readinessProbe:
+      failureThreshold: 112
       httpGet:
         path: /ready
         port: 9901
-      failureThreshold: 112
       initialDelaySeconds: 11
       periodSeconds: 15
       successThreshold: 11
@@ -108,9 +108,9 @@ spec:
       runAsGroup: 5678
       runAsUser: 5678
     volumeMounts:
-    - name: default-token-w7dxf
+    - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+      name: default-token-w7dxf
       readOnly: true
-      mountPath: "/var/run/secrets/kubernetes.io/serviceaccount"
   initContainers:
   - command:
     - sh

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.20.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.20.golden.yaml
@@ -3,8 +3,8 @@ kind: Pod
 metadata:
   creationTimestamp: null
   labels:
-    run: busybox
     openshift.io/deployer-pod-for.name: "1234"
+    run: busybox
   name: busybox
 spec:
   containers:

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.21.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.21.golden.yaml
@@ -15,150 +15,150 @@ metadata:
   name: busybox
 spec:
   containers:
-    - image: busybox
-      livenessProbe:
-        httpGet:
-          path: /metrics
-          port: 8080
-        initialDelaySeconds: 3
-        periodSeconds: 3
-      name: busybox
-      readinessProbe:
-        httpGet:
-          path: /metrics
-          port: 3001
-        initialDelaySeconds: 3
-        periodSeconds: 3
-      resources: {}
-      volumeMounts:
-        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
-          name: default-token-w7dxf
-          readOnly: true
-    - args:
-        - run
-        - --log-level=info
-      env:
-        - name: POD_NAME
-          valueFrom:
-            fieldRef:
-              apiVersion: v1
-              fieldPath: metadata.name
-        - name: POD_NAMESPACE
-          valueFrom:
-            fieldRef:
-              apiVersion: v1
-              fieldPath: metadata.namespace
-        - name: INSTANCE_IP
-          valueFrom:
-            fieldRef:
-              apiVersion: v1
-              fieldPath: status.podIP
-        - name: KUMA_CONTROL_PLANE_URL
-          value: http://kuma-control-plane.kuma-system:5681
-        - name: KUMA_DATAPLANE_MESH
-          value: default
-        - name: KUMA_DATAPLANE_NAME
-          value: $(POD_NAME).$(POD_NAMESPACE)
-        - name: KUMA_DATAPLANE_ADMIN_PORT
-          value: "9901"
-        - name: KUMA_DATAPLANE_DRAIN_TIME
-          value: 31s
-        - name: KUMA_DATAPLANE_RUNTIME_TOKEN_PATH
-          value: /var/run/secrets/kubernetes.io/serviceaccount/token
-        - name: KUMA_CONTROL_PLANE_CA_CERT
-          value: |
-            -----BEGIN CERTIFICATE-----
-            MIIDLDCCAhSgAwIBAgIQHdPhxOfXgWuNxoFlV/EwqTANBgkqhkiG9w0BAQsFADAP
-            MQ0wCwYDVQQDEwRrdW1hMB4XDTIwMDkxNjEyMjg0NFoXDTMwMDkxNDEyMjg0NFow
-            DzENMAsGA1UEAxMEa3VtYTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEB
-            AOZGbWhSlQSRxFNt5p/2WCKFyHZ3CuwNgyLEP7nS4ZXykxsFbYSuV3bIgF7bT/uq
-            a5Qire+C60guhFbpLcPh2Z6UfgId69GlQzHMVYcmLGjVQuyAt4FMMkTfVEl5I4Oa
-            +2it3BvihVkKhUz8y5RR5KbqJfGp4Z20Fh6fttoCFbeODmvBsYJFmUQS+ifoyMY/
-            P3R03Su7g5iIvnz7tmkydoNC8nGRDzdD5C8fJvrVI1UX6JRGyLKt45oQXt1mxK10
-            5KaN2zNV2WtHsaJp9bwrPH+JiZGeZyvuh5UwrLdHCmqK7sm9TodGztUZY0VzAc4q
-            kYViXY8gUjfNm+cQrPO1kN8CAwEAAaOBgzCBgDAOBgNVHQ8BAf8EBAMCAqQwHQYD
-            VR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMBMA8GA1UdEwEB/wQFMAMBAf8wHQYD
-            VR0OBBYEFGMDBPPiBFJ3mv2oA9CTqjemFTV2MB8GA1UdEQQYMBaCCWxvY2FsaG9z
-            dIIJbG9jYWxob3N0MA0GCSqGSIb3DQEBCwUAA4IBAQC/17QweOpGdb1MEBJ8XPG7
-            3sK/utoWLX1tjf8Su1Dga6CDT/eTWHZrWRf81KOVY07dle5SRIDK1QhfbGGtFP+T
-            vZkroousI9US2aCWlkeCZWGTnqvLmDoOujqagDoKRRuk4mQdtNNonxiL/wZtTFKi
-            +1iNjUVbLWiDXdBLxoRIVdLOzqb/MNxwElUyaTDAkopQyOWaTDkYPrGmaWjcsfPG
-            aOKow0ze+zHVFqTHbjnCqEV3hnsUyRUwsBln9+jDJXgwZM/tMlVJrZCh0Sle9Y5Z
-            MOB0fCf6sTMNRTGg5Lpl6uIYM/5INpmHVMo3n7MBSnpEDAUS2bf/uo5gIiq6XCdp
-            -----END CERTIFICATE-----
-      image: kuma/kuma-sidecar:latest
-      imagePullPolicy: IfNotPresent
-      livenessProbe:
-        httpGet:
-          path: /ready
-          port: 9901
-        failureThreshold: 212
-        initialDelaySeconds: 260
-        periodSeconds: 25
-        successThreshold: 1
-        timeoutSeconds: 23
-      name: kuma-sidecar
-      readinessProbe:
-        httpGet:
-          path: /ready
-          port: 9901
-        failureThreshold: 112
-        initialDelaySeconds: 11
-        periodSeconds: 15
-        successThreshold: 11
-        timeoutSeconds: 13
-      resources:
-        limits:
-          cpu: 1100m
-          memory: 1512Mi
-        requests:
-          cpu: 150m
-          memory: 164Mi
-      securityContext:
-        runAsGroup: 5678
-        runAsUser: 5678
-      volumeMounts:
-        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
-          name: default-token-w7dxf
-          readOnly: true
+  - image: busybox
+    livenessProbe:
+      httpGet:
+        path: /metrics
+        port: 8080
+      initialDelaySeconds: 3
+      periodSeconds: 3
+    name: busybox
+    readinessProbe:
+      httpGet:
+        path: /metrics
+        port: 3001
+      initialDelaySeconds: 3
+      periodSeconds: 3
+    resources: {}
+    volumeMounts:
+    - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+      name: default-token-w7dxf
+      readOnly: true
+  - args:
+    - run
+    - --log-level=info
+    env:
+    - name: POD_NAME
+      valueFrom:
+        fieldRef:
+          apiVersion: v1
+          fieldPath: metadata.name
+    - name: POD_NAMESPACE
+      valueFrom:
+        fieldRef:
+          apiVersion: v1
+          fieldPath: metadata.namespace
+    - name: INSTANCE_IP
+      valueFrom:
+        fieldRef:
+          apiVersion: v1
+          fieldPath: status.podIP
+    - name: KUMA_CONTROL_PLANE_CA_CERT
+      value: |
+        -----BEGIN CERTIFICATE-----
+        MIIDLDCCAhSgAwIBAgIQHdPhxOfXgWuNxoFlV/EwqTANBgkqhkiG9w0BAQsFADAP
+        MQ0wCwYDVQQDEwRrdW1hMB4XDTIwMDkxNjEyMjg0NFoXDTMwMDkxNDEyMjg0NFow
+        DzENMAsGA1UEAxMEa3VtYTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEB
+        AOZGbWhSlQSRxFNt5p/2WCKFyHZ3CuwNgyLEP7nS4ZXykxsFbYSuV3bIgF7bT/uq
+        a5Qire+C60guhFbpLcPh2Z6UfgId69GlQzHMVYcmLGjVQuyAt4FMMkTfVEl5I4Oa
+        +2it3BvihVkKhUz8y5RR5KbqJfGp4Z20Fh6fttoCFbeODmvBsYJFmUQS+ifoyMY/
+        P3R03Su7g5iIvnz7tmkydoNC8nGRDzdD5C8fJvrVI1UX6JRGyLKt45oQXt1mxK10
+        5KaN2zNV2WtHsaJp9bwrPH+JiZGeZyvuh5UwrLdHCmqK7sm9TodGztUZY0VzAc4q
+        kYViXY8gUjfNm+cQrPO1kN8CAwEAAaOBgzCBgDAOBgNVHQ8BAf8EBAMCAqQwHQYD
+        VR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMBMA8GA1UdEwEB/wQFMAMBAf8wHQYD
+        VR0OBBYEFGMDBPPiBFJ3mv2oA9CTqjemFTV2MB8GA1UdEQQYMBaCCWxvY2FsaG9z
+        dIIJbG9jYWxob3N0MA0GCSqGSIb3DQEBCwUAA4IBAQC/17QweOpGdb1MEBJ8XPG7
+        3sK/utoWLX1tjf8Su1Dga6CDT/eTWHZrWRf81KOVY07dle5SRIDK1QhfbGGtFP+T
+        vZkroousI9US2aCWlkeCZWGTnqvLmDoOujqagDoKRRuk4mQdtNNonxiL/wZtTFKi
+        +1iNjUVbLWiDXdBLxoRIVdLOzqb/MNxwElUyaTDAkopQyOWaTDkYPrGmaWjcsfPG
+        aOKow0ze+zHVFqTHbjnCqEV3hnsUyRUwsBln9+jDJXgwZM/tMlVJrZCh0Sle9Y5Z
+        MOB0fCf6sTMNRTGg5Lpl6uIYM/5INpmHVMo3n7MBSnpEDAUS2bf/uo5gIiq6XCdp
+        -----END CERTIFICATE-----
+    - name: KUMA_CONTROL_PLANE_URL
+      value: http://kuma-control-plane.kuma-system:5681
+    - name: KUMA_DATAPLANE_ADMIN_PORT
+      value: "9901"
+    - name: KUMA_DATAPLANE_DRAIN_TIME
+      value: 31s
+    - name: KUMA_DATAPLANE_MESH
+      value: default
+    - name: KUMA_DATAPLANE_NAME
+      value: $(POD_NAME).$(POD_NAMESPACE)
+    - name: KUMA_DATAPLANE_RUNTIME_TOKEN_PATH
+      value: /var/run/secrets/kubernetes.io/serviceaccount/token
+    image: kuma/kuma-sidecar:latest
+    imagePullPolicy: IfNotPresent
+    livenessProbe:
+      failureThreshold: 212
+      httpGet:
+        path: /ready
+        port: 9901
+      initialDelaySeconds: 260
+      periodSeconds: 25
+      successThreshold: 1
+      timeoutSeconds: 23
+    name: kuma-sidecar
+    readinessProbe:
+      failureThreshold: 112
+      httpGet:
+        path: /ready
+        port: 9901
+      initialDelaySeconds: 11
+      periodSeconds: 15
+      successThreshold: 11
+      timeoutSeconds: 13
+    resources:
+      limits:
+        cpu: 1100m
+        memory: 1512Mi
+      requests:
+        cpu: 150m
+        memory: 164Mi
+    securityContext:
+      runAsGroup: 5678
+      runAsUser: 5678
+    volumeMounts:
+    - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+      name: default-token-w7dxf
+      readOnly: true
   initContainers:
-    - args:
-        - -p
-        - "15001"
-        - -z
-        - "15006"
-        - -u
-        - "5678"
-        - -g
-        - "5678"
-        - -d
-        - ""
-        - -o
-        - ""
-        - -m
-        - REDIRECT
-        - -i
-        - '*'
-        - -b
-        - '*'
-      image: kuma/kuma-init:latest
-      imagePullPolicy: IfNotPresent
-      name: kuma-init
-      resources:
-        limits:
-          cpu: 100m
-          memory: 50M
-        requests:
-          cpu: 10m
-          memory: 10M
-      securityContext:
-        capabilities:
-          add:
-            - NET_ADMIN
-        runAsGroup: 0
-        runAsUser: 0
+  - args:
+    - -p
+    - "15001"
+    - -z
+    - "15006"
+    - -u
+    - "5678"
+    - -g
+    - "5678"
+    - -d
+    - ""
+    - -o
+    - ""
+    - -m
+    - REDIRECT
+    - -i
+    - '*'
+    - -b
+    - '*'
+    image: kuma/kuma-init:latest
+    imagePullPolicy: IfNotPresent
+    name: kuma-init
+    resources:
+      limits:
+        cpu: 100m
+        memory: 50M
+      requests:
+        cpu: 10m
+        memory: 10M
+    securityContext:
+      capabilities:
+        add:
+        - NET_ADMIN
+      runAsGroup: 0
+      runAsUser: 0
   volumes:
-    - name: default-token-w7dxf
-      secret:
-        secretName: default-token-w7dxf
+  - name: default-token-w7dxf
+    secret:
+      secretName: default-token-w7dxf
 status: {}

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.22.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.22.golden.yaml
@@ -15,150 +15,150 @@ metadata:
   name: busybox
 spec:
   containers:
-    - image: busybox
-      livenessProbe:
-        httpGet:
-          path: /8080/metrics
-          port: 9000
-        initialDelaySeconds: 3
-        periodSeconds: 3
-      name: busybox
-      readinessProbe:
-        httpGet:
-          path: /3001/metrics
-          port: 9000
-        initialDelaySeconds: 3
-        periodSeconds: 3
-      resources: {}
-      volumeMounts:
-        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
-          name: default-token-w7dxf
-          readOnly: true
-    - args:
-        - run
-        - --log-level=info
-      env:
-        - name: POD_NAME
-          valueFrom:
-            fieldRef:
-              apiVersion: v1
-              fieldPath: metadata.name
-        - name: POD_NAMESPACE
-          valueFrom:
-            fieldRef:
-              apiVersion: v1
-              fieldPath: metadata.namespace
-        - name: INSTANCE_IP
-          valueFrom:
-            fieldRef:
-              apiVersion: v1
-              fieldPath: status.podIP
-        - name: KUMA_CONTROL_PLANE_URL
-          value: http://kuma-control-plane.kuma-system:5681
-        - name: KUMA_DATAPLANE_MESH
-          value: default
-        - name: KUMA_DATAPLANE_NAME
-          value: $(POD_NAME).$(POD_NAMESPACE)
-        - name: KUMA_DATAPLANE_ADMIN_PORT
-          value: "9901"
-        - name: KUMA_DATAPLANE_DRAIN_TIME
-          value: 31s
-        - name: KUMA_DATAPLANE_RUNTIME_TOKEN_PATH
-          value: /var/run/secrets/kubernetes.io/serviceaccount/token
-        - name: KUMA_CONTROL_PLANE_CA_CERT
-          value: |
-            -----BEGIN CERTIFICATE-----
-            MIIDLDCCAhSgAwIBAgIQHdPhxOfXgWuNxoFlV/EwqTANBgkqhkiG9w0BAQsFADAP
-            MQ0wCwYDVQQDEwRrdW1hMB4XDTIwMDkxNjEyMjg0NFoXDTMwMDkxNDEyMjg0NFow
-            DzENMAsGA1UEAxMEa3VtYTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEB
-            AOZGbWhSlQSRxFNt5p/2WCKFyHZ3CuwNgyLEP7nS4ZXykxsFbYSuV3bIgF7bT/uq
-            a5Qire+C60guhFbpLcPh2Z6UfgId69GlQzHMVYcmLGjVQuyAt4FMMkTfVEl5I4Oa
-            +2it3BvihVkKhUz8y5RR5KbqJfGp4Z20Fh6fttoCFbeODmvBsYJFmUQS+ifoyMY/
-            P3R03Su7g5iIvnz7tmkydoNC8nGRDzdD5C8fJvrVI1UX6JRGyLKt45oQXt1mxK10
-            5KaN2zNV2WtHsaJp9bwrPH+JiZGeZyvuh5UwrLdHCmqK7sm9TodGztUZY0VzAc4q
-            kYViXY8gUjfNm+cQrPO1kN8CAwEAAaOBgzCBgDAOBgNVHQ8BAf8EBAMCAqQwHQYD
-            VR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMBMA8GA1UdEwEB/wQFMAMBAf8wHQYD
-            VR0OBBYEFGMDBPPiBFJ3mv2oA9CTqjemFTV2MB8GA1UdEQQYMBaCCWxvY2FsaG9z
-            dIIJbG9jYWxob3N0MA0GCSqGSIb3DQEBCwUAA4IBAQC/17QweOpGdb1MEBJ8XPG7
-            3sK/utoWLX1tjf8Su1Dga6CDT/eTWHZrWRf81KOVY07dle5SRIDK1QhfbGGtFP+T
-            vZkroousI9US2aCWlkeCZWGTnqvLmDoOujqagDoKRRuk4mQdtNNonxiL/wZtTFKi
-            +1iNjUVbLWiDXdBLxoRIVdLOzqb/MNxwElUyaTDAkopQyOWaTDkYPrGmaWjcsfPG
-            aOKow0ze+zHVFqTHbjnCqEV3hnsUyRUwsBln9+jDJXgwZM/tMlVJrZCh0Sle9Y5Z
-            MOB0fCf6sTMNRTGg5Lpl6uIYM/5INpmHVMo3n7MBSnpEDAUS2bf/uo5gIiq6XCdp
-            -----END CERTIFICATE-----
-      image: kuma/kuma-sidecar:latest
-      imagePullPolicy: IfNotPresent
-      livenessProbe:
-        httpGet:
-          path: /ready
-          port: 9901
-        failureThreshold: 212
-        initialDelaySeconds: 260
-        periodSeconds: 25
-        successThreshold: 1
-        timeoutSeconds: 23
-      name: kuma-sidecar
-      readinessProbe:
-        httpGet:
-          path: /ready
-          port: 9901
-        failureThreshold: 112
-        initialDelaySeconds: 11
-        periodSeconds: 15
-        successThreshold: 11
-        timeoutSeconds: 13
-      resources:
-        limits:
-          cpu: 1100m
-          memory: 1512Mi
-        requests:
-          cpu: 150m
-          memory: 164Mi
-      securityContext:
-        runAsGroup: 5678
-        runAsUser: 5678
-      volumeMounts:
-        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
-          name: default-token-w7dxf
-          readOnly: true
+  - image: busybox
+    livenessProbe:
+      httpGet:
+        path: /8080/metrics
+        port: 9000
+      initialDelaySeconds: 3
+      periodSeconds: 3
+    name: busybox
+    readinessProbe:
+      httpGet:
+        path: /3001/metrics
+        port: 9000
+      initialDelaySeconds: 3
+      periodSeconds: 3
+    resources: {}
+    volumeMounts:
+    - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+      name: default-token-w7dxf
+      readOnly: true
+  - args:
+    - run
+    - --log-level=info
+    env:
+    - name: POD_NAME
+      valueFrom:
+        fieldRef:
+          apiVersion: v1
+          fieldPath: metadata.name
+    - name: POD_NAMESPACE
+      valueFrom:
+        fieldRef:
+          apiVersion: v1
+          fieldPath: metadata.namespace
+    - name: INSTANCE_IP
+      valueFrom:
+        fieldRef:
+          apiVersion: v1
+          fieldPath: status.podIP
+    - name: KUMA_CONTROL_PLANE_CA_CERT
+      value: |
+        -----BEGIN CERTIFICATE-----
+        MIIDLDCCAhSgAwIBAgIQHdPhxOfXgWuNxoFlV/EwqTANBgkqhkiG9w0BAQsFADAP
+        MQ0wCwYDVQQDEwRrdW1hMB4XDTIwMDkxNjEyMjg0NFoXDTMwMDkxNDEyMjg0NFow
+        DzENMAsGA1UEAxMEa3VtYTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEB
+        AOZGbWhSlQSRxFNt5p/2WCKFyHZ3CuwNgyLEP7nS4ZXykxsFbYSuV3bIgF7bT/uq
+        a5Qire+C60guhFbpLcPh2Z6UfgId69GlQzHMVYcmLGjVQuyAt4FMMkTfVEl5I4Oa
+        +2it3BvihVkKhUz8y5RR5KbqJfGp4Z20Fh6fttoCFbeODmvBsYJFmUQS+ifoyMY/
+        P3R03Su7g5iIvnz7tmkydoNC8nGRDzdD5C8fJvrVI1UX6JRGyLKt45oQXt1mxK10
+        5KaN2zNV2WtHsaJp9bwrPH+JiZGeZyvuh5UwrLdHCmqK7sm9TodGztUZY0VzAc4q
+        kYViXY8gUjfNm+cQrPO1kN8CAwEAAaOBgzCBgDAOBgNVHQ8BAf8EBAMCAqQwHQYD
+        VR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMBMA8GA1UdEwEB/wQFMAMBAf8wHQYD
+        VR0OBBYEFGMDBPPiBFJ3mv2oA9CTqjemFTV2MB8GA1UdEQQYMBaCCWxvY2FsaG9z
+        dIIJbG9jYWxob3N0MA0GCSqGSIb3DQEBCwUAA4IBAQC/17QweOpGdb1MEBJ8XPG7
+        3sK/utoWLX1tjf8Su1Dga6CDT/eTWHZrWRf81KOVY07dle5SRIDK1QhfbGGtFP+T
+        vZkroousI9US2aCWlkeCZWGTnqvLmDoOujqagDoKRRuk4mQdtNNonxiL/wZtTFKi
+        +1iNjUVbLWiDXdBLxoRIVdLOzqb/MNxwElUyaTDAkopQyOWaTDkYPrGmaWjcsfPG
+        aOKow0ze+zHVFqTHbjnCqEV3hnsUyRUwsBln9+jDJXgwZM/tMlVJrZCh0Sle9Y5Z
+        MOB0fCf6sTMNRTGg5Lpl6uIYM/5INpmHVMo3n7MBSnpEDAUS2bf/uo5gIiq6XCdp
+        -----END CERTIFICATE-----
+    - name: KUMA_CONTROL_PLANE_URL
+      value: http://kuma-control-plane.kuma-system:5681
+    - name: KUMA_DATAPLANE_ADMIN_PORT
+      value: "9901"
+    - name: KUMA_DATAPLANE_DRAIN_TIME
+      value: 31s
+    - name: KUMA_DATAPLANE_MESH
+      value: default
+    - name: KUMA_DATAPLANE_NAME
+      value: $(POD_NAME).$(POD_NAMESPACE)
+    - name: KUMA_DATAPLANE_RUNTIME_TOKEN_PATH
+      value: /var/run/secrets/kubernetes.io/serviceaccount/token
+    image: kuma/kuma-sidecar:latest
+    imagePullPolicy: IfNotPresent
+    livenessProbe:
+      failureThreshold: 212
+      httpGet:
+        path: /ready
+        port: 9901
+      initialDelaySeconds: 260
+      periodSeconds: 25
+      successThreshold: 1
+      timeoutSeconds: 23
+    name: kuma-sidecar
+    readinessProbe:
+      failureThreshold: 112
+      httpGet:
+        path: /ready
+        port: 9901
+      initialDelaySeconds: 11
+      periodSeconds: 15
+      successThreshold: 11
+      timeoutSeconds: 13
+    resources:
+      limits:
+        cpu: 1100m
+        memory: 1512Mi
+      requests:
+        cpu: 150m
+        memory: 164Mi
+    securityContext:
+      runAsGroup: 5678
+      runAsUser: 5678
+    volumeMounts:
+    - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+      name: default-token-w7dxf
+      readOnly: true
   initContainers:
-    - args:
-        - -p
-        - "15001"
-        - -z
-        - "15006"
-        - -u
-        - "5678"
-        - -g
-        - "5678"
-        - -d
-        - ""
-        - -o
-        - ""
-        - -m
-        - REDIRECT
-        - -i
-        - '*'
-        - -b
-        - '*'
-      image: kuma/kuma-init:latest
-      imagePullPolicy: IfNotPresent
-      name: kuma-init
-      resources:
-        limits:
-          cpu: 100m
-          memory: 50M
-        requests:
-          cpu: 10m
-          memory: 10M
-      securityContext:
-        capabilities:
-          add:
-            - NET_ADMIN
-        runAsGroup: 0
-        runAsUser: 0
+  - args:
+    - -p
+    - "15001"
+    - -z
+    - "15006"
+    - -u
+    - "5678"
+    - -g
+    - "5678"
+    - -d
+    - ""
+    - -o
+    - ""
+    - -m
+    - REDIRECT
+    - -i
+    - '*'
+    - -b
+    - '*'
+    image: kuma/kuma-init:latest
+    imagePullPolicy: IfNotPresent
+    name: kuma-init
+    resources:
+      limits:
+        cpu: 100m
+        memory: 50M
+      requests:
+        cpu: 10m
+        memory: 10M
+    securityContext:
+      capabilities:
+        add:
+        - NET_ADMIN
+      runAsGroup: 0
+      runAsUser: 0
   volumes:
-    - name: default-token-w7dxf
-      secret:
-        secretName: default-token-w7dxf
+  - name: default-token-w7dxf
+    secret:
+      secretName: default-token-w7dxf
 status: {}

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.23.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.23.golden.yaml
@@ -15,155 +15,155 @@ metadata:
   name: busybox
 spec:
   containers:
-    - image: busybox
-      ports:
-        - name: readiness-port
-          containerPort: 3001
-        - name: liveness-port
-          containerPort: 8080
-      livenessProbe:
-        httpGet:
-          path: /8080/metrics
-          port: 9000
-        initialDelaySeconds: 3
-        periodSeconds: 3
-      name: busybox
-      readinessProbe:
-        httpGet:
-          path: /3001/metrics
-          port: 9000
-        initialDelaySeconds: 3
-        periodSeconds: 3
-      resources: {}
-      volumeMounts:
-        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
-          name: default-token-w7dxf
-          readOnly: true
-    - args:
-        - run
-        - --log-level=info
-      env:
-        - name: POD_NAME
-          valueFrom:
-            fieldRef:
-              apiVersion: v1
-              fieldPath: metadata.name
-        - name: POD_NAMESPACE
-          valueFrom:
-            fieldRef:
-              apiVersion: v1
-              fieldPath: metadata.namespace
-        - name: INSTANCE_IP
-          valueFrom:
-            fieldRef:
-              apiVersion: v1
-              fieldPath: status.podIP
-        - name: KUMA_CONTROL_PLANE_URL
-          value: http://kuma-control-plane.kuma-system:5681
-        - name: KUMA_DATAPLANE_MESH
-          value: default
-        - name: KUMA_DATAPLANE_NAME
-          value: $(POD_NAME).$(POD_NAMESPACE)
-        - name: KUMA_DATAPLANE_ADMIN_PORT
-          value: "9901"
-        - name: KUMA_DATAPLANE_DRAIN_TIME
-          value: 31s
-        - name: KUMA_DATAPLANE_RUNTIME_TOKEN_PATH
-          value: /var/run/secrets/kubernetes.io/serviceaccount/token
-        - name: KUMA_CONTROL_PLANE_CA_CERT
-          value: |
-            -----BEGIN CERTIFICATE-----
-            MIIDLDCCAhSgAwIBAgIQHdPhxOfXgWuNxoFlV/EwqTANBgkqhkiG9w0BAQsFADAP
-            MQ0wCwYDVQQDEwRrdW1hMB4XDTIwMDkxNjEyMjg0NFoXDTMwMDkxNDEyMjg0NFow
-            DzENMAsGA1UEAxMEa3VtYTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEB
-            AOZGbWhSlQSRxFNt5p/2WCKFyHZ3CuwNgyLEP7nS4ZXykxsFbYSuV3bIgF7bT/uq
-            a5Qire+C60guhFbpLcPh2Z6UfgId69GlQzHMVYcmLGjVQuyAt4FMMkTfVEl5I4Oa
-            +2it3BvihVkKhUz8y5RR5KbqJfGp4Z20Fh6fttoCFbeODmvBsYJFmUQS+ifoyMY/
-            P3R03Su7g5iIvnz7tmkydoNC8nGRDzdD5C8fJvrVI1UX6JRGyLKt45oQXt1mxK10
-            5KaN2zNV2WtHsaJp9bwrPH+JiZGeZyvuh5UwrLdHCmqK7sm9TodGztUZY0VzAc4q
-            kYViXY8gUjfNm+cQrPO1kN8CAwEAAaOBgzCBgDAOBgNVHQ8BAf8EBAMCAqQwHQYD
-            VR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMBMA8GA1UdEwEB/wQFMAMBAf8wHQYD
-            VR0OBBYEFGMDBPPiBFJ3mv2oA9CTqjemFTV2MB8GA1UdEQQYMBaCCWxvY2FsaG9z
-            dIIJbG9jYWxob3N0MA0GCSqGSIb3DQEBCwUAA4IBAQC/17QweOpGdb1MEBJ8XPG7
-            3sK/utoWLX1tjf8Su1Dga6CDT/eTWHZrWRf81KOVY07dle5SRIDK1QhfbGGtFP+T
-            vZkroousI9US2aCWlkeCZWGTnqvLmDoOujqagDoKRRuk4mQdtNNonxiL/wZtTFKi
-            +1iNjUVbLWiDXdBLxoRIVdLOzqb/MNxwElUyaTDAkopQyOWaTDkYPrGmaWjcsfPG
-            aOKow0ze+zHVFqTHbjnCqEV3hnsUyRUwsBln9+jDJXgwZM/tMlVJrZCh0Sle9Y5Z
-            MOB0fCf6sTMNRTGg5Lpl6uIYM/5INpmHVMo3n7MBSnpEDAUS2bf/uo5gIiq6XCdp
-            -----END CERTIFICATE-----
-      image: kuma/kuma-sidecar:latest
-      imagePullPolicy: IfNotPresent
-      livenessProbe:
-        httpGet:
-          path: /ready
-          port: 9901
-        failureThreshold: 212
-        initialDelaySeconds: 260
-        periodSeconds: 25
-        successThreshold: 1
-        timeoutSeconds: 23
-      name: kuma-sidecar
-      readinessProbe:
-        httpGet:
-          path: /ready
-          port: 9901
-        failureThreshold: 112
-        initialDelaySeconds: 11
-        periodSeconds: 15
-        successThreshold: 11
-        timeoutSeconds: 13
-      resources:
-        limits:
-          cpu: 1100m
-          memory: 1512Mi
-        requests:
-          cpu: 150m
-          memory: 164Mi
-      securityContext:
-        runAsGroup: 5678
-        runAsUser: 5678
-      volumeMounts:
-        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
-          name: default-token-w7dxf
-          readOnly: true
+  - image: busybox
+    livenessProbe:
+      httpGet:
+        path: /8080/metrics
+        port: 9000
+      initialDelaySeconds: 3
+      periodSeconds: 3
+    name: busybox
+    ports:
+    - containerPort: 3001
+      name: readiness-port
+    - containerPort: 8080
+      name: liveness-port
+    readinessProbe:
+      httpGet:
+        path: /3001/metrics
+        port: 9000
+      initialDelaySeconds: 3
+      periodSeconds: 3
+    resources: {}
+    volumeMounts:
+    - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+      name: default-token-w7dxf
+      readOnly: true
+  - args:
+    - run
+    - --log-level=info
+    env:
+    - name: POD_NAME
+      valueFrom:
+        fieldRef:
+          apiVersion: v1
+          fieldPath: metadata.name
+    - name: POD_NAMESPACE
+      valueFrom:
+        fieldRef:
+          apiVersion: v1
+          fieldPath: metadata.namespace
+    - name: INSTANCE_IP
+      valueFrom:
+        fieldRef:
+          apiVersion: v1
+          fieldPath: status.podIP
+    - name: KUMA_CONTROL_PLANE_CA_CERT
+      value: |
+        -----BEGIN CERTIFICATE-----
+        MIIDLDCCAhSgAwIBAgIQHdPhxOfXgWuNxoFlV/EwqTANBgkqhkiG9w0BAQsFADAP
+        MQ0wCwYDVQQDEwRrdW1hMB4XDTIwMDkxNjEyMjg0NFoXDTMwMDkxNDEyMjg0NFow
+        DzENMAsGA1UEAxMEa3VtYTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEB
+        AOZGbWhSlQSRxFNt5p/2WCKFyHZ3CuwNgyLEP7nS4ZXykxsFbYSuV3bIgF7bT/uq
+        a5Qire+C60guhFbpLcPh2Z6UfgId69GlQzHMVYcmLGjVQuyAt4FMMkTfVEl5I4Oa
+        +2it3BvihVkKhUz8y5RR5KbqJfGp4Z20Fh6fttoCFbeODmvBsYJFmUQS+ifoyMY/
+        P3R03Su7g5iIvnz7tmkydoNC8nGRDzdD5C8fJvrVI1UX6JRGyLKt45oQXt1mxK10
+        5KaN2zNV2WtHsaJp9bwrPH+JiZGeZyvuh5UwrLdHCmqK7sm9TodGztUZY0VzAc4q
+        kYViXY8gUjfNm+cQrPO1kN8CAwEAAaOBgzCBgDAOBgNVHQ8BAf8EBAMCAqQwHQYD
+        VR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMBMA8GA1UdEwEB/wQFMAMBAf8wHQYD
+        VR0OBBYEFGMDBPPiBFJ3mv2oA9CTqjemFTV2MB8GA1UdEQQYMBaCCWxvY2FsaG9z
+        dIIJbG9jYWxob3N0MA0GCSqGSIb3DQEBCwUAA4IBAQC/17QweOpGdb1MEBJ8XPG7
+        3sK/utoWLX1tjf8Su1Dga6CDT/eTWHZrWRf81KOVY07dle5SRIDK1QhfbGGtFP+T
+        vZkroousI9US2aCWlkeCZWGTnqvLmDoOujqagDoKRRuk4mQdtNNonxiL/wZtTFKi
+        +1iNjUVbLWiDXdBLxoRIVdLOzqb/MNxwElUyaTDAkopQyOWaTDkYPrGmaWjcsfPG
+        aOKow0ze+zHVFqTHbjnCqEV3hnsUyRUwsBln9+jDJXgwZM/tMlVJrZCh0Sle9Y5Z
+        MOB0fCf6sTMNRTGg5Lpl6uIYM/5INpmHVMo3n7MBSnpEDAUS2bf/uo5gIiq6XCdp
+        -----END CERTIFICATE-----
+    - name: KUMA_CONTROL_PLANE_URL
+      value: http://kuma-control-plane.kuma-system:5681
+    - name: KUMA_DATAPLANE_ADMIN_PORT
+      value: "9901"
+    - name: KUMA_DATAPLANE_DRAIN_TIME
+      value: 31s
+    - name: KUMA_DATAPLANE_MESH
+      value: default
+    - name: KUMA_DATAPLANE_NAME
+      value: $(POD_NAME).$(POD_NAMESPACE)
+    - name: KUMA_DATAPLANE_RUNTIME_TOKEN_PATH
+      value: /var/run/secrets/kubernetes.io/serviceaccount/token
+    image: kuma/kuma-sidecar:latest
+    imagePullPolicy: IfNotPresent
+    livenessProbe:
+      failureThreshold: 212
+      httpGet:
+        path: /ready
+        port: 9901
+      initialDelaySeconds: 260
+      periodSeconds: 25
+      successThreshold: 1
+      timeoutSeconds: 23
+    name: kuma-sidecar
+    readinessProbe:
+      failureThreshold: 112
+      httpGet:
+        path: /ready
+        port: 9901
+      initialDelaySeconds: 11
+      periodSeconds: 15
+      successThreshold: 11
+      timeoutSeconds: 13
+    resources:
+      limits:
+        cpu: 1100m
+        memory: 1512Mi
+      requests:
+        cpu: 150m
+        memory: 164Mi
+    securityContext:
+      runAsGroup: 5678
+      runAsUser: 5678
+    volumeMounts:
+    - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+      name: default-token-w7dxf
+      readOnly: true
   initContainers:
-    - args:
-        - -p
-        - "15001"
-        - -z
-        - "15006"
-        - -u
-        - "5678"
-        - -g
-        - "5678"
-        - -d
-        - ""
-        - -o
-        - ""
-        - -m
-        - REDIRECT
-        - -i
-        - '*'
-        - -b
-        - '*'
-      image: kuma/kuma-init:latest
-      imagePullPolicy: IfNotPresent
-      name: kuma-init
-      resources:
-        limits:
-          cpu: 100m
-          memory: 50M
-        requests:
-          cpu: 10m
-          memory: 10M
-      securityContext:
-        capabilities:
-          add:
-            - NET_ADMIN
-        runAsGroup: 0
-        runAsUser: 0
+  - args:
+    - -p
+    - "15001"
+    - -z
+    - "15006"
+    - -u
+    - "5678"
+    - -g
+    - "5678"
+    - -d
+    - ""
+    - -o
+    - ""
+    - -m
+    - REDIRECT
+    - -i
+    - '*'
+    - -b
+    - '*'
+    image: kuma/kuma-init:latest
+    imagePullPolicy: IfNotPresent
+    name: kuma-init
+    resources:
+      limits:
+        cpu: 100m
+        memory: 50M
+      requests:
+        cpu: 10m
+        memory: 10M
+    securityContext:
+      capabilities:
+        add:
+        - NET_ADMIN
+      runAsGroup: 0
+      runAsUser: 0
   volumes:
-    - name: default-token-w7dxf
-      secret:
-        secretName: default-token-w7dxf
+  - name: default-token-w7dxf
+    secret:
+      secretName: default-token-w7dxf
 status: {}

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.24.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.24.golden.yaml
@@ -2,9 +2,10 @@ apiVersion: v1
 kind: Pod
 metadata:
   annotations:
+    docs: Documentation
     kuma.io/mesh: default
+    kuma.io/sidecar-env-vars: KUMA_DATAPLANE_DRAIN_TIME=5s;NEW_ENV_VAR=123
     kuma.io/sidecar-injected: "true"
-    kuma.io/sidecar-injection: enabled
     kuma.io/transparent-proxying: enabled
     kuma.io/transparent-proxying-inbound-port: "15006"
     kuma.io/transparent-proxying-outbound-port: "15001"
@@ -68,13 +69,17 @@ spec:
     - name: KUMA_DATAPLANE_ADMIN_PORT
       value: "9901"
     - name: KUMA_DATAPLANE_DRAIN_TIME
-      value: 31s
+      value: 5s
     - name: KUMA_DATAPLANE_MESH
       value: default
     - name: KUMA_DATAPLANE_NAME
       value: $(POD_NAME).$(POD_NAMESPACE)
     - name: KUMA_DATAPLANE_RUNTIME_TOKEN_PATH
-      value: /var/run/secrets/kubernetes.io/serviceaccount/token
+      value: /some/other/path
+    - name: NEW_ENV_VAR
+      value: "123"
+    - name: TEST_ENV_VAR
+      value: test123
     image: kuma/kuma-sidecar:latest
     imagePullPolicy: IfNotPresent
     livenessProbe:
@@ -111,6 +116,13 @@ spec:
       name: default-token-w7dxf
       readOnly: true
   initContainers:
+  - command:
+    - sh
+    - -c
+    - sleep 5
+    image: busybox
+    name: init
+    resources: {}
   - args:
     - -p
     - "15001"

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.24.input.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.24.input.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: busybox
+  labels:
+    run: busybox
+  annotations:
+    docs: "Documentation"
+    kuma.io/sidecar-env-vars: "KUMA_DATAPLANE_DRAIN_TIME=5s;NEW_ENV_VAR=123" # drain time overrides the file, NEW_ENV_VAR is completely new var
+spec:
+  volumes:
+  - name: default-token-w7dxf
+    secret:
+      secretName: default-token-w7dxf
+  containers:
+  - name: busybox
+    image: busybox
+    resources: {}
+    volumeMounts:
+    - name: default-token-w7dxf
+      readOnly: true
+      mountPath: "/var/run/secrets/kubernetes.io/serviceaccount"
+  initContainers:
+    - name: init
+      image: busybox
+      command: ['sh', '-c', 'sleep 5']

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.env-vars.config.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.env-vars.config.yaml
@@ -1,0 +1,42 @@
+controlPlane:
+  apiServer:
+    url: http://kuma-control-plane.kuma-system:5681
+sidecarContainer:
+  image: kuma/kuma-sidecar:latest
+  redirectPortOutbound: 15001
+  redirectPortInbound: 15006
+  uid: 5678
+  gid: 5678
+  adminPort: 9901
+  drainTime: 31s
+
+  readinessProbe:
+    initialDelaySeconds: 11
+    timeoutSeconds:      13
+    periodSeconds:       15
+    successThreshold:    11
+    failureThreshold:    112
+  livenessProbe:
+    initialDelaySeconds: 260
+    timeoutSeconds:      23
+    periodSeconds:       25
+    failureThreshold:    212
+  resources:
+    requests:
+      cpu: 150m
+      memory: 164Mi
+    limits:
+      cpu: 1100m
+      memory: 1512Mi
+  envVars:
+    TEST_ENV_VAR: test123 # a completely new var
+    KUMA_DATAPLANE_RUNTIME_TOKEN_PATH: "/some/other/path" # a var that will be overriden by this config
+    KUMA_DATAPLANE_DRAIN_TIME: 1s # a var that should be overriden by this config, but will be overriden by annotation on pod
+initContainer:
+  enabled: true
+  image: kuma/kuma-init:latest
+virtualProbesEnabled: true
+virtualProbesPort: 9000
+exceptions:
+  labels:
+    "openshift.io/deployer-pod-for.name": "*"


### PR DESCRIPTION
This PR introduces a way to configure any setting in Kuma DP sidecar.

In case of Universal, a user is responsible for starting Kuma DP in their environment so they can customize cli args and env vars.

In case of Kubernetes, Kuma Injector is injecting sidecar so it's harder to customize setting of sidecar itself. With this PR there are two ways to do it

1. Global way that applies to all sidecars
There is a new setting called "KUMA_RUNTIME_KUBERNETES_INJECTOR_SIDECAR_CONTAINER_ENV_VARS" that you can provide list of ENV_VARS that will be applied on all sidecars

2. Override setting of one sidecar
There is a new annotation called `kuma.io/sidecar-env-vars` that can override setting for individual sidecar.

### Documentation

- [X] TODO
