### PR TITLE
feat(XDS): Add internal support for outbound UDP listeners

### DIFF
--- a/pkg/xds/envoy/listeners/configurers.go
+++ b/pkg/xds/envoy/listeners/configurers.go
@@ -163,14 +163,16 @@ func NetworkRBAC(statsName string, rbacEnabled bool, permission *mesh_core.Traff
 	})
 }
 
-func OutboundListener(listenerName string, address string, port uint32) ListenerBuilderOpt {
+func OutboundListener(listenerName string, address string, port uint32, protocol core_xds.SocketAddressProtocol) ListenerBuilderOpt {
 	return ListenerBuilderOptFunc(func(config *ListenerBuilderConfig) {
 		config.AddV2(&v2.OutboundListenerConfigurer{
+			Protocol:     protocol,
 			ListenerName: listenerName,
 			Address:      address,
 			Port:         port,
 		})
 		config.AddV3(&v3.OutboundListenerConfigurer{
+			Protocol:     protocol,
 			ListenerName: listenerName,
 			Address:      address,
 			Port:         port,

--- a/pkg/xds/envoy/listeners/v2/http_access_log_configurer_test.go
+++ b/pkg/xds/envoy/listeners/v2/http_access_log_configurer_test.go
@@ -18,13 +18,14 @@ import (
 var _ = Describe("HttpAccessLogConfigurer", func() {
 
 	type testCase struct {
-		listenerName    string
-		listenerAddress string
-		listenerPort    uint32
-		statsName       string
-		routeName       string
-		backend         *mesh_proto.LoggingBackend
-		expected        string
+		listenerName     string
+		listenerAddress  string
+		listenerPort     uint32
+		listenerProtocol core_xds.SocketAddressProtocol
+		statsName        string
+		routeName        string
+		backend          *mesh_proto.LoggingBackend
+		expected         string
 	}
 
 	DescribeTable("should generate proper Envoy config",
@@ -60,7 +61,7 @@ var _ = Describe("HttpAccessLogConfigurer", func() {
 
 			// when
 			listener, err := NewListenerBuilder(envoy.APIV2).
-				Configure(OutboundListener(given.listenerName, given.listenerAddress, given.listenerPort)).
+				Configure(OutboundListener(given.listenerName, given.listenerAddress, given.listenerPort, given.listenerProtocol)).
 				Configure(FilterChain(NewFilterChainBuilder(envoy.APIV2).
 					Configure(HttpConnectionManager(given.statsName)).
 					Configure(HttpAccessLog(mesh, envoy.TrafficDirectionOutbound, sourceService, destinationService, given.backend, proxy)))).

--- a/pkg/xds/envoy/listeners/v2/http_outbound_route_configurer_test.go
+++ b/pkg/xds/envoy/listeners/v2/http_outbound_route_configurer_test.go
@@ -5,6 +5,8 @@ import (
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
 
+	core_xds "github.com/kumahq/kuma/pkg/core/xds"
+
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	envoy_common "github.com/kumahq/kuma/pkg/xds/envoy"
 	. "github.com/kumahq/kuma/pkg/xds/envoy/listeners"
@@ -15,21 +17,22 @@ import (
 var _ = Describe("HttpOutboundRouteConfigurer", func() {
 
 	type testCase struct {
-		listenerName    string
-		listenerAddress string
-		listenerPort    uint32
-		statsName       string
-		service         string
-		subsets         []envoy_common.ClusterSubset
-		dpTags          mesh_proto.MultiValueTagSet
-		expected        string
+		listenerName     string
+		listenerAddress  string
+		listenerPort     uint32
+		listenerProtocol core_xds.SocketAddressProtocol
+		statsName        string
+		service          string
+		subsets          []envoy_common.ClusterSubset
+		dpTags           mesh_proto.MultiValueTagSet
+		expected         string
 	}
 
 	DescribeTable("should generate proper Envoy config",
 		func(given testCase) {
 			// when
 			listener, err := NewListenerBuilder(envoy_common.APIV2).
-				Configure(OutboundListener(given.listenerName, given.listenerAddress, given.listenerPort)).
+				Configure(OutboundListener(given.listenerName, given.listenerAddress, given.listenerPort, given.listenerProtocol)).
 				Configure(FilterChain(NewFilterChainBuilder(envoy_common.APIV2).
 					Configure(HttpConnectionManager(given.statsName)).
 					Configure(HttpOutboundRoute(given.service, given.subsets, given.dpTags)))).

--- a/pkg/xds/envoy/listeners/v2/inbound_listener_configurer_test.go
+++ b/pkg/xds/envoy/listeners/v2/inbound_listener_configurer_test.go
@@ -61,9 +61,9 @@ var _ = Describe("InboundListenerConfigurer", func() {
             trafficDirection: INBOUND
             address:
               socketAddress:
+                protocol: UDP
                 address: 192.168.0.1
                 portValue: 8080
-                protocol: UDP
 `,
 		}),
 	)

--- a/pkg/xds/envoy/listeners/v2/max_connect_attempts_configurer_test.go
+++ b/pkg/xds/envoy/listeners/v2/max_connect_attempts_configurer_test.go
@@ -5,6 +5,8 @@ import (
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
 
+	core_xds "github.com/kumahq/kuma/pkg/core/xds"
+
 	. "github.com/kumahq/kuma/pkg/xds/envoy/listeners"
 
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
@@ -18,6 +20,7 @@ var _ = Describe("MaxConnectAttemptsConfigurer", func() {
 		listenerName       string
 		listenerAddress    string
 		listenerPort       uint32
+		listenerProtocol   core_xds.SocketAddressProtocol
 		statsName          string
 		clusters           []envoy_common.ClusterSubset
 		maxConnectAttempts uint32
@@ -42,11 +45,7 @@ var _ = Describe("MaxConnectAttemptsConfigurer", func() {
 
 			// when
 			listener, err := NewListenerBuilder(envoy_common.APIV2).
-				Configure(OutboundListener(
-					given.listenerName,
-					given.listenerAddress,
-					given.listenerPort,
-				)).
+				Configure(OutboundListener(given.listenerName, given.listenerAddress, given.listenerPort, given.listenerProtocol)).
 				Configure(FilterChain(NewFilterChainBuilder(envoy_common.APIV2).
 					Configure(TcpProxy(given.statsName, given.clusters...)).
 					Configure(MaxConnectAttempts(retry)))).

--- a/pkg/xds/envoy/listeners/v2/network_access_log_configurer_test.go
+++ b/pkg/xds/envoy/listeners/v2/network_access_log_configurer_test.go
@@ -18,13 +18,14 @@ import (
 var _ = Describe("NetworkAccessLogConfigurer", func() {
 
 	type testCase struct {
-		listenerName    string
-		listenerAddress string
-		listenerPort    uint32
-		statsName       string
-		clusters        []envoy_common.ClusterSubset
-		backend         *mesh_proto.LoggingBackend
-		expected        string
+		listenerName     string
+		listenerAddress  string
+		listenerPort     uint32
+		listenerProtocol core_xds.SocketAddressProtocol
+		statsName        string
+		clusters         []envoy_common.ClusterSubset
+		backend          *mesh_proto.LoggingBackend
+		expected         string
 	}
 
 	DescribeTable("should generate proper Envoy config",
@@ -60,7 +61,7 @@ var _ = Describe("NetworkAccessLogConfigurer", func() {
 
 			// when
 			listener, err := NewListenerBuilder(envoy_common.APIV2).
-				Configure(OutboundListener(given.listenerName, given.listenerAddress, given.listenerPort)).
+				Configure(OutboundListener(given.listenerName, given.listenerAddress, given.listenerPort, given.listenerProtocol)).
 				Configure(FilterChain(NewFilterChainBuilder(envoy_common.APIV2).
 					Configure(TcpProxy(given.statsName, given.clusters...)).
 					Configure(NetworkAccessLog(meshName, envoy_common.TrafficDirectionUnspecified, sourceService, destinationService, given.backend, proxy)))).

--- a/pkg/xds/envoy/listeners/v2/original_dst_forwarder_configurer_test.go
+++ b/pkg/xds/envoy/listeners/v2/original_dst_forwarder_configurer_test.go
@@ -5,6 +5,8 @@ import (
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
 
+	core_xds "github.com/kumahq/kuma/pkg/core/xds"
+
 	. "github.com/kumahq/kuma/pkg/xds/envoy/listeners"
 
 	util_proto "github.com/kumahq/kuma/pkg/util/proto"
@@ -14,19 +16,20 @@ import (
 var _ = Describe("OriginalDstForwarderConfigurer", func() {
 
 	type testCase struct {
-		listenerName    string
-		listenerAddress string
-		listenerPort    uint32
-		statsName       string
-		clusters        []envoy_common.ClusterSubset
-		expected        string
+		listenerName     string
+		listenerAddress  string
+		listenerPort     uint32
+		statsName        string
+		listenerProtocol core_xds.SocketAddressProtocol
+		clusters         []envoy_common.ClusterSubset
+		expected         string
 	}
 
 	DescribeTable("should generate proper Envoy config",
 		func(given testCase) {
 			// when
 			listener, err := NewListenerBuilder(envoy_common.APIV2).
-				Configure(OutboundListener(given.listenerName, given.listenerAddress, given.listenerPort)).
+				Configure(OutboundListener(given.listenerName, given.listenerAddress, given.listenerPort, given.listenerProtocol)).
 				Configure(FilterChain(NewFilterChainBuilder(envoy_common.APIV2).
 					Configure(TcpProxy(given.statsName, given.clusters...)))).
 				Configure(OriginalDstForwarder()).

--- a/pkg/xds/envoy/listeners/v2/outbound_listener_configurer.go
+++ b/pkg/xds/envoy/listeners/v2/outbound_listener_configurer.go
@@ -3,12 +3,15 @@ package v2
 import (
 	envoy_api "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	envoy_core "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
+
+	core_xds "github.com/kumahq/kuma/pkg/core/xds"
 )
 
 type OutboundListenerConfigurer struct {
 	ListenerName string
 	Address      string
 	Port         uint32
+	Protocol     core_xds.SocketAddressProtocol
 }
 
 func (c *OutboundListenerConfigurer) Configure(l *envoy_api.Listener) error {
@@ -17,7 +20,7 @@ func (c *OutboundListenerConfigurer) Configure(l *envoy_api.Listener) error {
 	l.Address = &envoy_core.Address{
 		Address: &envoy_core.Address_SocketAddress{
 			SocketAddress: &envoy_core.SocketAddress{
-				Protocol: envoy_core.SocketAddress_TCP,
+				Protocol: envoy_core.SocketAddress_Protocol(c.Protocol),
 				Address:  c.Address,
 				PortSpecifier: &envoy_core.SocketAddress_PortValue{
 					PortValue: c.Port,

--- a/pkg/xds/envoy/listeners/v2/retry_configurer_test.go
+++ b/pkg/xds/envoy/listeners/v2/retry_configurer_test.go
@@ -7,6 +7,8 @@ import (
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
 
+	core_xds "github.com/kumahq/kuma/pkg/core/xds"
+
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	mesh_core "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	util_proto "github.com/kumahq/kuma/pkg/util/proto"
@@ -16,27 +18,24 @@ import (
 
 var _ = Describe("RetryConfigurer", func() {
 	type testCase struct {
-		listenerName    string
-		listenerAddress string
-		listenerPort    uint32
-		statsName       string
-		service         string
-		subsets         []envoy_common.ClusterSubset
-		dpTags          mesh_proto.MultiValueTagSet
-		protocol        mesh_core.Protocol
-		retry           *mesh_core.RetryResource
-		expected        string
+		listenerName     string
+		listenerAddress  string
+		listenerPort     uint32
+		listenerProtocol core_xds.SocketAddressProtocol
+		statsName        string
+		service          string
+		subsets          []envoy_common.ClusterSubset
+		dpTags           mesh_proto.MultiValueTagSet
+		protocol         mesh_core.Protocol
+		retry            *mesh_core.RetryResource
+		expected         string
 	}
 
 	DescribeTable("should generate proper Envoy config",
 		func(given testCase) {
 			// when
 			listener, err := NewListenerBuilder(envoy_common.APIV2).
-				Configure(OutboundListener(
-					given.listenerName,
-					given.listenerAddress,
-					given.listenerPort,
-				)).
+				Configure(OutboundListener(given.listenerName, given.listenerAddress, given.listenerPort, given.listenerProtocol)).
 				Configure(FilterChain(NewFilterChainBuilder(envoy_common.APIV2).
 					Configure(HttpConnectionManager(given.statsName)).
 					Configure(HttpOutboundRoute(

--- a/pkg/xds/envoy/listeners/v2/timeout_configurer.go
+++ b/pkg/xds/envoy/listeners/v2/timeout_configurer.go
@@ -37,6 +37,6 @@ func (c *TimeoutConfigurer) Configure(filterChain *envoy_listener.FilterChain) e
 			return nil
 		})
 	default:
-		return errors.Errorf("unsupported protocol %s", c.Protocol)
+		return errors.Errorf("unsupported listenerProtocol %s", c.Protocol)
 	}
 }

--- a/pkg/xds/envoy/listeners/v3/http_access_log_configurer_test.go
+++ b/pkg/xds/envoy/listeners/v3/http_access_log_configurer_test.go
@@ -18,13 +18,14 @@ import (
 var _ = Describe("HttpAccessLogConfigurer", func() {
 
 	type testCase struct {
-		listenerName    string
-		listenerAddress string
-		listenerPort    uint32
-		statsName       string
-		routeName       string
-		backend         *mesh_proto.LoggingBackend
-		expected        string
+		listenerName     string
+		listenerAddress  string
+		listenerPort     uint32
+		listenerProtocol core_xds.SocketAddressProtocol
+		statsName        string
+		routeName        string
+		backend          *mesh_proto.LoggingBackend
+		expected         string
 	}
 
 	DescribeTable("should generate proper Envoy config",
@@ -60,7 +61,7 @@ var _ = Describe("HttpAccessLogConfigurer", func() {
 
 			// when
 			listener, err := NewListenerBuilder(envoy.APIV3).
-				Configure(OutboundListener(given.listenerName, given.listenerAddress, given.listenerPort)).
+				Configure(OutboundListener(given.listenerName, given.listenerAddress, given.listenerPort, given.listenerProtocol)).
 				Configure(FilterChain(NewFilterChainBuilder(envoy.APIV3).
 					Configure(HttpConnectionManager(given.statsName)).
 					Configure(HttpAccessLog(mesh, envoy.TrafficDirectionOutbound, sourceService, destinationService, given.backend, proxy)))).

--- a/pkg/xds/envoy/listeners/v3/http_outbound_route_configurer_test.go
+++ b/pkg/xds/envoy/listeners/v3/http_outbound_route_configurer_test.go
@@ -5,6 +5,8 @@ import (
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
 
+	core_xds "github.com/kumahq/kuma/pkg/core/xds"
+
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	envoy_common "github.com/kumahq/kuma/pkg/xds/envoy"
 	. "github.com/kumahq/kuma/pkg/xds/envoy/listeners"
@@ -15,21 +17,22 @@ import (
 var _ = Describe("HttpOutboundRouteConfigurer", func() {
 
 	type testCase struct {
-		listenerName    string
-		listenerAddress string
-		listenerPort    uint32
-		statsName       string
-		service         string
-		subsets         []envoy_common.ClusterSubset
-		dpTags          mesh_proto.MultiValueTagSet
-		expected        string
+		listenerName     string
+		listenerAddress  string
+		listenerPort     uint32
+		listenerProtocol core_xds.SocketAddressProtocol
+		statsName        string
+		service          string
+		subsets          []envoy_common.ClusterSubset
+		dpTags           mesh_proto.MultiValueTagSet
+		expected         string
 	}
 
 	DescribeTable("should generate proper Envoy config",
 		func(given testCase) {
 			// when
 			listener, err := NewListenerBuilder(envoy_common.APIV3).
-				Configure(OutboundListener(given.listenerName, given.listenerAddress, given.listenerPort)).
+				Configure(OutboundListener(given.listenerName, given.listenerAddress, given.listenerPort, given.listenerProtocol)).
 				Configure(FilterChain(NewFilterChainBuilder(envoy_common.APIV3).
 					Configure(HttpConnectionManager(given.statsName)).
 					Configure(HttpOutboundRoute(given.service, given.subsets, given.dpTags)))).

--- a/pkg/xds/envoy/listeners/v3/max_connect_attempts_configurer_test.go
+++ b/pkg/xds/envoy/listeners/v3/max_connect_attempts_configurer_test.go
@@ -5,6 +5,8 @@ import (
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
 
+	core_xds "github.com/kumahq/kuma/pkg/core/xds"
+
 	. "github.com/kumahq/kuma/pkg/xds/envoy/listeners"
 
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
@@ -18,6 +20,7 @@ var _ = Describe("MaxConnectAttemptsConfigurer", func() {
 		listenerName       string
 		listenerAddress    string
 		listenerPort       uint32
+		listenerProtocol   core_xds.SocketAddressProtocol
 		statsName          string
 		clusters           []envoy_common.ClusterSubset
 		maxConnectAttempts uint32
@@ -42,11 +45,7 @@ var _ = Describe("MaxConnectAttemptsConfigurer", func() {
 
 			// when
 			listener, err := NewListenerBuilder(envoy_common.APIV3).
-				Configure(OutboundListener(
-					given.listenerName,
-					given.listenerAddress,
-					given.listenerPort,
-				)).
+				Configure(OutboundListener(given.listenerName, given.listenerAddress, given.listenerPort, given.listenerProtocol)).
 				Configure(FilterChain(NewFilterChainBuilder(envoy_common.APIV3).
 					Configure(TcpProxy(given.statsName, given.clusters...)).
 					Configure(MaxConnectAttempts(retry)))).

--- a/pkg/xds/envoy/listeners/v3/network_access_log_configurer_test.go
+++ b/pkg/xds/envoy/listeners/v3/network_access_log_configurer_test.go
@@ -18,13 +18,14 @@ import (
 var _ = Describe("NetworkAccessLogConfigurer", func() {
 
 	type testCase struct {
-		listenerName    string
-		listenerAddress string
-		listenerPort    uint32
-		statsName       string
-		clusters        []envoy_common.ClusterSubset
-		backend         *mesh_proto.LoggingBackend
-		expected        string
+		listenerName     string
+		listenerAddress  string
+		listenerPort     uint32
+		listenerProtocol core_xds.SocketAddressProtocol
+		statsName        string
+		clusters         []envoy_common.ClusterSubset
+		backend          *mesh_proto.LoggingBackend
+		expected         string
 	}
 
 	DescribeTable("should generate proper Envoy config",
@@ -60,7 +61,7 @@ var _ = Describe("NetworkAccessLogConfigurer", func() {
 
 			// when
 			listener, err := NewListenerBuilder(envoy_common.APIV3).
-				Configure(OutboundListener(given.listenerName, given.listenerAddress, given.listenerPort)).
+				Configure(OutboundListener(given.listenerName, given.listenerAddress, given.listenerPort, given.listenerProtocol)).
 				Configure(FilterChain(NewFilterChainBuilder(envoy_common.APIV3).
 					Configure(TcpProxy(given.statsName, given.clusters...)).
 					Configure(NetworkAccessLog(meshName, envoy_common.TrafficDirectionUnspecified, sourceService, destinationService, given.backend, proxy)))).

--- a/pkg/xds/envoy/listeners/v3/original_dst_forwarder_configurer_test.go
+++ b/pkg/xds/envoy/listeners/v3/original_dst_forwarder_configurer_test.go
@@ -5,6 +5,8 @@ import (
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
 
+	core_xds "github.com/kumahq/kuma/pkg/core/xds"
+
 	. "github.com/kumahq/kuma/pkg/xds/envoy/listeners"
 
 	util_proto "github.com/kumahq/kuma/pkg/util/proto"
@@ -14,19 +16,20 @@ import (
 var _ = Describe("OriginalDstForwarderConfigurer", func() {
 
 	type testCase struct {
-		listenerName    string
-		listenerAddress string
-		listenerPort    uint32
-		statsName       string
-		clusters        []envoy_common.ClusterSubset
-		expected        string
+		listenerName     string
+		listenerAddress  string
+		listenerPort     uint32
+		listenerProtocol core_xds.SocketAddressProtocol
+		statsName        string
+		clusters         []envoy_common.ClusterSubset
+		expected         string
 	}
 
 	DescribeTable("should generate proper Envoy config",
 		func(given testCase) {
 			// when
 			listener, err := NewListenerBuilder(envoy_common.APIV3).
-				Configure(OutboundListener(given.listenerName, given.listenerAddress, given.listenerPort)).
+				Configure(OutboundListener(given.listenerName, given.listenerAddress, given.listenerPort, given.listenerProtocol)).
 				Configure(FilterChain(NewFilterChainBuilder(envoy_common.APIV3).
 					Configure(TcpProxy(given.statsName, given.clusters...)))).
 				Configure(OriginalDstForwarder()).

--- a/pkg/xds/envoy/listeners/v3/outbound_listener_configurer.go
+++ b/pkg/xds/envoy/listeners/v3/outbound_listener_configurer.go
@@ -3,12 +3,15 @@ package v3
 import (
 	envoy_core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	envoy_api "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
+
+	core_xds "github.com/kumahq/kuma/pkg/core/xds"
 )
 
 type OutboundListenerConfigurer struct {
 	ListenerName string
 	Address      string
 	Port         uint32
+	Protocol     core_xds.SocketAddressProtocol
 }
 
 func (c *OutboundListenerConfigurer) Configure(l *envoy_api.Listener) error {
@@ -17,7 +20,7 @@ func (c *OutboundListenerConfigurer) Configure(l *envoy_api.Listener) error {
 	l.Address = &envoy_core.Address{
 		Address: &envoy_core.Address_SocketAddress{
 			SocketAddress: &envoy_core.SocketAddress{
-				Protocol: envoy_core.SocketAddress_TCP,
+				Protocol: envoy_core.SocketAddress_Protocol(c.Protocol),
 				Address:  c.Address,
 				PortSpecifier: &envoy_core.SocketAddress_PortValue{
 					PortValue: c.Port,

--- a/pkg/xds/envoy/listeners/v3/outbound_listener_configurer_test.go
+++ b/pkg/xds/envoy/listeners/v3/outbound_listener_configurer_test.go
@@ -5,6 +5,8 @@ import (
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
 
+	core_xds "github.com/kumahq/kuma/pkg/core/xds"
+
 	"github.com/kumahq/kuma/pkg/xds/envoy"
 	. "github.com/kumahq/kuma/pkg/xds/envoy/listeners"
 
@@ -14,17 +16,18 @@ import (
 var _ = Describe("OutboundListenerConfigurer", func() {
 
 	type testCase struct {
-		listenerName    string
-		listenerAddress string
-		listenerPort    uint32
-		expected        string
+		listenerName     string
+		listenerAddress  string
+		listenerPort     uint32
+		listenerProtocol core_xds.SocketAddressProtocol
+		expected         string
 	}
 
 	DescribeTable("should generate proper Envoy config",
 		func(given testCase) {
 			// when
 			listener, err := NewListenerBuilder(envoy.APIV3).
-				Configure(OutboundListener(given.listenerName, given.listenerAddress, given.listenerPort)).
+				Configure(OutboundListener(given.listenerName, given.listenerAddress, given.listenerPort, given.listenerProtocol)).
 				Build()
 			// then
 			Expect(err).ToNot(HaveOccurred())
@@ -44,6 +47,21 @@ var _ = Describe("OutboundListenerConfigurer", func() {
             trafficDirection: OUTBOUND
             address:
               socketAddress:
+                address: 192.168.0.1
+                portValue: 8080
+`,
+		}),
+		Entry("basic UDP listener", testCase{
+			listenerName:     "outbound:192.168.0.1:8080",
+			listenerAddress:  "192.168.0.1",
+			listenerPort:     8080,
+			listenerProtocol: core_xds.SocketAddressProtocolUDP,
+			expected: `
+            name: outbound:192.168.0.1:8080
+            trafficDirection: OUTBOUND
+            address:
+              socketAddress:
+                protocol: UDP
                 address: 192.168.0.1
                 portValue: 8080
 `,

--- a/pkg/xds/envoy/listeners/v3/retry_configurer_test.go
+++ b/pkg/xds/envoy/listeners/v3/retry_configurer_test.go
@@ -7,6 +7,8 @@ import (
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
 
+	core_xds "github.com/kumahq/kuma/pkg/core/xds"
+
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	mesh_core "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	util_proto "github.com/kumahq/kuma/pkg/util/proto"
@@ -16,27 +18,24 @@ import (
 
 var _ = Describe("RetryConfigurer", func() {
 	type testCase struct {
-		listenerName    string
-		listenerAddress string
-		listenerPort    uint32
-		statsName       string
-		service         string
-		subsets         []envoy_common.ClusterSubset
-		dpTags          mesh_proto.MultiValueTagSet
-		protocol        mesh_core.Protocol
-		retry           *mesh_core.RetryResource
-		expected        string
+		listenerName     string
+		listenerAddress  string
+		listenerPort     uint32
+		listenerProtocol core_xds.SocketAddressProtocol
+		statsName        string
+		service          string
+		subsets          []envoy_common.ClusterSubset
+		dpTags           mesh_proto.MultiValueTagSet
+		protocol         mesh_core.Protocol
+		retry            *mesh_core.RetryResource
+		expected         string
 	}
 
 	DescribeTable("should generate proper Envoy config",
 		func(given testCase) {
 			// when
 			listener, err := NewListenerBuilder(envoy_common.APIV3).
-				Configure(OutboundListener(
-					given.listenerName,
-					given.listenerAddress,
-					given.listenerPort,
-				)).
+				Configure(OutboundListener(given.listenerName, given.listenerAddress, given.listenerPort, given.listenerProtocol)).
 				Configure(FilterChain(NewFilterChainBuilder(envoy_common.APIV3).
 					Configure(HttpConnectionManager(given.statsName)).
 					Configure(HttpOutboundRoute(

--- a/pkg/xds/generator/direct_access_proxy_generator.go
+++ b/pkg/xds/generator/direct_access_proxy_generator.go
@@ -47,7 +47,7 @@ func (_ DirectAccessProxyGenerator) Generate(ctx xds_context.Context, proxy *cor
 	for _, endpoint := range endpoints {
 		name := fmt.Sprintf("direct_access_%s:%d", endpoint.Address, endpoint.Port)
 		listener, err := envoy_listeners.NewListenerBuilder(proxy.APIVersion).
-			Configure(envoy_listeners.OutboundListener(name, endpoint.Address, endpoint.Port)).
+			Configure(envoy_listeners.OutboundListener(name, endpoint.Address, endpoint.Port, core_xds.SocketAddressProtocolTCP)).
 			Configure(envoy_listeners.FilterChain(envoy_listeners.NewFilterChainBuilder(proxy.APIVersion).
 				Configure(envoy_listeners.TcpProxy(name, envoy_common.ClusterSubset{ClusterName: "direct_access"})).
 				Configure(envoy_listeners.NetworkAccessLog(meshName, envoy_common.TrafficDirectionOutbound, sourceService, name, proxy.Policies.Logs[mesh_core.PassThroughService], proxy)))).

--- a/pkg/xds/generator/outbound_proxy_generator.go
+++ b/pkg/xds/generator/outbound_proxy_generator.go
@@ -147,7 +147,7 @@ func (_ OutboundProxyGenerator) generateLDS(proxy *model.Proxy, subsets []envoy_
 		return filterChainBuilder
 	}()
 	listener, err := envoy_listeners.NewListenerBuilder(proxy.APIVersion).
-		Configure(envoy_listeners.OutboundListener(outboundListenerName, oface.DataplaneIP, oface.DataplanePort)).
+		Configure(envoy_listeners.OutboundListener(outboundListenerName, oface.DataplaneIP, oface.DataplanePort, model.SocketAddressProtocolTCP)).
 		Configure(envoy_listeners.FilterChain(filterChainBuilder)).
 		Configure(envoy_listeners.TransparentProxying(proxy.Dataplane.Spec.Networking.GetTransparentProxying())).
 		Build()

--- a/pkg/xds/generator/transparent_proxy_generator.go
+++ b/pkg/xds/generator/transparent_proxy_generator.go
@@ -44,7 +44,7 @@ func (_ TransparentProxyGenerator) Generate(ctx xds_context.Context, proxy *mode
 	}
 
 	outboundListener, err = envoy_listeners.NewListenerBuilder(proxy.APIVersion).
-		Configure(envoy_listeners.OutboundListener(outboundName, "0.0.0.0", redirectPortOutbound)).
+		Configure(envoy_listeners.OutboundListener(outboundName, "0.0.0.0", redirectPortOutbound, model.SocketAddressProtocolTCP)).
 		Configure(envoy_listeners.FilterChain(envoy_listeners.NewFilterChainBuilder(proxy.APIVersion).
 			Configure(envoy_listeners.TcpProxy(outboundName, envoy_common.ClusterSubset{ClusterName: outboundName})).
 			Configure(envoy_listeners.NetworkAccessLog(meshName, envoy_common.TrafficDirectionUnspecified, sourceService, "external", proxy.Policies.Logs[mesh_core.PassThroughService], proxy)))).


### PR DESCRIPTION
This enables generators to add outbound listeners.
This is not first class support for UDP and only enables generators
to create listeners using UDP

Signed-off-by: Charly Molter <charly@koyeb.com>