### PR TITLE
fix(kuma-cp) set cluster ID to followers

### DIFF
--- a/app/kuma-cp/cmd/run.go
+++ b/app/kuma-cp/cmd/run.go
@@ -92,10 +92,6 @@ func newRunCmdWithOpts(opts runCmdOpts) *cobra.Command {
 					runLog.Error(err, "unable to set up GC")
 					return err
 				}
-				if err := clusterid.Setup(rt); err != nil {
-					runLog.Error(err, "unable to set up clusterID")
-					return err
-				}
 				if err := xds.Setup(rt); err != nil {
 					runLog.Error(err, "unable to set up XDS")
 					return err
@@ -158,10 +154,6 @@ func newRunCmdWithOpts(opts runCmdOpts) *cobra.Command {
 					runLog.Error(err, "unable to set up KDS Global")
 					return err
 				}
-				if err := clusterid.Setup(rt); err != nil {
-					runLog.Error(err, "unable to set up clusterID")
-					return err
-				}
 				if err := insights.Setup(rt); err != nil {
 					runLog.Error(err, "unable to set up Insights resyncer")
 					return err
@@ -172,6 +164,10 @@ func newRunCmdWithOpts(opts runCmdOpts) *cobra.Command {
 				}
 			}
 
+			if err := clusterid.Setup(rt); err != nil {
+				runLog.Error(err, "unable to set up clusterID")
+				return err
+			}
 			if err := diagnostics.SetupServer(rt); err != nil {
 				runLog.Error(err, "unable to set up Diagnostics server")
 				return err

--- a/pkg/clusterid/cluster_id_test.go
+++ b/pkg/clusterid/cluster_id_test.go
@@ -1,0 +1,44 @@
+package clusterid_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/kumahq/kuma/pkg/clusterid"
+	kuma_cp "github.com/kumahq/kuma/pkg/config/app/kuma-cp"
+	"github.com/kumahq/kuma/pkg/test/runtime"
+)
+
+var _ = Describe("Cluster ID", func() {
+
+	var stop chan struct{}
+
+	AfterEach(func() {
+		if stop != nil {
+			close(stop)
+		}
+	})
+
+	It("should create and set cluster ID", func() {
+		// given runtime with cluster ID components
+		cfg := kuma_cp.DefaultConfig()
+		builder, err := runtime.BuilderFor(cfg)
+		Expect(err).ToNot(HaveOccurred())
+		runtime, err := builder.Build()
+		Expect(err).ToNot(HaveOccurred())
+
+		err = clusterid.Setup(runtime)
+		Expect(err).ToNot(HaveOccurred())
+
+		// when runtime is started
+		stop = make(chan struct{})
+		go func() {
+			defer GinkgoRecover()
+			err := runtime.Start(stop)
+			Expect(err).ToNot(HaveOccurred())
+		}()
+
+		// then cluster ID is created and set in Runtime object
+		Eventually(runtime.GetClusterId, "5s", "100ms").ShouldNot(BeEmpty())
+	})
+})

--- a/pkg/clusterid/clusterid_suite_test.go
+++ b/pkg/clusterid/clusterid_suite_test.go
@@ -1,0 +1,13 @@
+package clusterid_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestClusterID(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Cluster ID Suite")
+}

--- a/pkg/clusterid/creator.go
+++ b/pkg/clusterid/creator.go
@@ -8,6 +8,7 @@ import (
 	"github.com/kumahq/kuma/pkg/core"
 	config_manager "github.com/kumahq/kuma/pkg/core/config/manager"
 	config_model "github.com/kumahq/kuma/pkg/core/resources/apis/system"
+	core_model "github.com/kumahq/kuma/pkg/core/resources/model"
 	"github.com/kumahq/kuma/pkg/core/resources/store"
 )
 
@@ -25,14 +26,14 @@ func (c *clusterIDCreator) NeedLeaderElection() bool {
 
 func (c *clusterIDCreator) create() error {
 	resource := config_model.NewConfigResource()
-	err := c.configManager.Get(context.Background(), resource, store.GetByKey(config_manager.ClusterIdConfigKey, ""))
+	err := c.configManager.Get(context.Background(), resource, store.GetByKey(config_manager.ClusterIdConfigKey, core_model.NoMesh))
 	if err != nil {
 		if !store.IsResourceNotFound(err) {
 			return err
 		}
 		resource.Spec.Config = core.NewUUID()
 		log.Info("creating cluster ID", "clusterID", resource.Spec.Config)
-		if err := c.configManager.Create(context.Background(), resource, store.CreateByKey(config_manager.ClusterIdConfigKey, "")); err != nil {
+		if err := c.configManager.Create(context.Background(), resource, store.CreateByKey(config_manager.ClusterIdConfigKey, core_model.NoMesh)); err != nil {
 			return errors.Wrap(err, "could not create config")
 		}
 	}

--- a/pkg/clusterid/creator.go
+++ b/pkg/clusterid/creator.go
@@ -1,0 +1,41 @@
+package clusterid
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+
+	"github.com/kumahq/kuma/pkg/core"
+	config_manager "github.com/kumahq/kuma/pkg/core/config/manager"
+	config_model "github.com/kumahq/kuma/pkg/core/resources/apis/system"
+	"github.com/kumahq/kuma/pkg/core/resources/store"
+)
+
+type clusterIDCreator struct {
+	configManager config_manager.ConfigManager
+}
+
+func (c *clusterIDCreator) Start(_ <-chan struct{}) error {
+	return c.create()
+}
+
+func (c *clusterIDCreator) NeedLeaderElection() bool {
+	return true
+}
+
+func (c *clusterIDCreator) create() error {
+	resource := config_model.NewConfigResource()
+	err := c.configManager.Get(context.Background(), resource, store.GetByKey(config_manager.ClusterIdConfigKey, ""))
+	if err != nil {
+		if !store.IsResourceNotFound(err) {
+			return err
+		}
+		resource.Spec.Config = core.NewUUID()
+		log.Info("creating cluster ID", "clusterID", resource.Spec.Config)
+		if err := c.configManager.Create(context.Background(), resource, store.CreateByKey(config_manager.ClusterIdConfigKey, "")); err != nil {
+			return errors.Wrap(err, "could not create config")
+		}
+	}
+
+	return nil
+}

--- a/pkg/clusterid/reader.go
+++ b/pkg/clusterid/reader.go
@@ -1,0 +1,58 @@
+package clusterid
+
+import (
+	"context"
+	"time"
+
+	"github.com/kumahq/kuma/pkg/core"
+	config_manager "github.com/kumahq/kuma/pkg/core/config/manager"
+	config_model "github.com/kumahq/kuma/pkg/core/resources/apis/system"
+	"github.com/kumahq/kuma/pkg/core/resources/store"
+	core_runtime "github.com/kumahq/kuma/pkg/core/runtime"
+)
+
+var log = core.Log.WithName("clusterID")
+
+// clusterIDReader tries to read cluster ID and sets it in the runtime. Cluster ID does not change during CP lifecycle
+// therefore once cluster ID is read and set, the component exits.
+// In standalone setup, followers are waiting until leader creates a cluster ID
+// In Multi-zone setup, the global followers and all remotes waits until global leader creates a cluster ID
+type clusterIDReader struct {
+	rt core_runtime.Runtime
+}
+
+func (c *clusterIDReader) Start(stop <-chan struct{}) error {
+	ticker := time.NewTicker(1 * time.Second)
+	for {
+		select {
+		case <-ticker.C:
+			clusterID, err := c.read()
+			if err != nil {
+				log.Error(err, "could not read cluster ID") // just log, do not exit to retry operation
+			}
+			if clusterID != "" {
+				log.Info("setting cluster ID", "clusterID", clusterID)
+				c.rt.SetClusterId(clusterID)
+				return nil
+			}
+		case <-stop:
+			return nil
+		}
+	}
+}
+
+func (c *clusterIDReader) NeedLeaderElection() bool {
+	return false
+}
+
+func (c *clusterIDReader) read() (string, error) {
+	resource := config_model.NewConfigResource()
+	err := c.rt.ConfigManager().Get(context.Background(), resource, store.GetByKey(config_manager.ClusterIdConfigKey, ""))
+	if err != nil {
+		if store.IsResourceNotFound(err) {
+			return "", nil
+		}
+		return "", err
+	}
+	return resource.Spec.Config, nil
+}

--- a/pkg/clusterid/reader.go
+++ b/pkg/clusterid/reader.go
@@ -7,6 +7,7 @@ import (
 	"github.com/kumahq/kuma/pkg/core"
 	config_manager "github.com/kumahq/kuma/pkg/core/config/manager"
 	config_model "github.com/kumahq/kuma/pkg/core/resources/apis/system"
+	core_model "github.com/kumahq/kuma/pkg/core/resources/model"
 	"github.com/kumahq/kuma/pkg/core/resources/store"
 	core_runtime "github.com/kumahq/kuma/pkg/core/runtime"
 )
@@ -47,7 +48,7 @@ func (c *clusterIDReader) NeedLeaderElection() bool {
 
 func (c *clusterIDReader) read() (string, error) {
 	resource := config_model.NewConfigResource()
-	err := c.rt.ConfigManager().Get(context.Background(), resource, store.GetByKey(config_manager.ClusterIdConfigKey, ""))
+	err := c.rt.ConfigManager().Get(context.Background(), resource, store.GetByKey(config_manager.ClusterIdConfigKey, core_model.NoMesh))
 	if err != nil {
 		if store.IsResourceNotFound(err) {
 			return "", nil

--- a/pkg/core/runtime/reports/reports.go
+++ b/pkg/core/runtime/reports/reports.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 	"time"
 
+	config_core "github.com/kumahq/kuma/pkg/config/core"
 	"github.com/kumahq/kuma/pkg/core/resources/apis/system"
 
 	"github.com/pkg/errors"
@@ -110,14 +111,16 @@ func (b *reportsBuffer) updateEntitiesReport(rt core_runtime.Runtime) error {
 	}
 	b.mutable["meshes_total"] = strconv.Itoa(len(meshes.Items))
 
-	zones, err := fetchZones(rt)
-	if err != nil {
-		return err
+	switch rt.Config().Mode {
+	case config_core.Standalone:
+		b.mutable["zones_total"] = strconv.Itoa(1)
+	case config_core.Global:
+		zones, err := fetchZones(rt)
+		if err != nil {
+			return err
+		}
+		b.mutable["zones_total"] = strconv.Itoa(len(zones.Items))
 	}
-	if len(zones.Items) > 0 {
-		b.mutable["zones_total"] = strconv.Itoa(len(meshes.Items))
-	}
-
 	return nil
 }
 

--- a/pkg/kds/remote/components.go
+++ b/pkg/kds/remote/components.go
@@ -4,7 +4,6 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/kumahq/kuma/pkg/config/core/resources/store"
-	config_manager "github.com/kumahq/kuma/pkg/core/config/manager"
 	"github.com/kumahq/kuma/pkg/core/runtime/component"
 	"github.com/kumahq/kuma/pkg/kds/mux"
 	kds_server "github.com/kumahq/kuma/pkg/kds/server"
@@ -104,19 +103,6 @@ func Callbacks(rt core_runtime.Runtime, syncer sync_store.ResourceSyncer, k8sSto
 				return syncer.Sync(rs, sync_store.PrefilterBy(func(r model.Resource) bool {
 					return r.(*mesh.DataplaneResource).Spec.IsRemoteIngress(localZone)
 				}))
-			}
-			if rs.GetItemType() == system.ConfigType {
-				for _, resource := range rs.GetItems() {
-					if resource.GetMeta().GetName() == config_manager.ClusterIdConfigKey {
-						if trr, ok := resource.(*system.ConfigResource); ok {
-							clusterId := trr.Spec.Config
-							rt.SetClusterId(clusterId)
-							return nil
-						} else {
-							return model.ErrorInvalidItemType((*system.ConfigResource)(nil), resource)
-						}
-					}
-				}
 			}
 			return syncer.Sync(rs)
 		},


### PR DESCRIPTION
### Summary

This PR fixes two problems
* Report proper number of zones. We were reporting meshes as zones and only when zones > 0. We want to report zones as 1 on standalone and real number of zones on global
* Cluster ID was only set on leader on standalone and global. I refactored the code so we set the cluster ID in consistent way in all use cases.

### Documentation

- [X] No docs
