### PR TITLE
chore(kuma-cp) keep backward compatibility with Kuma DP 1.0.x

### DIFF
--- a/mk/e2e.new.mk
+++ b/mk/e2e.new.mk
@@ -1,7 +1,7 @@
 K8SCLUSTERS = kuma-1 kuma-2
 K8SCLUSTERS_START_TARGETS = $(addprefix test/e2e/kind/start/cluster/, $(K8SCLUSTERS))
 K8SCLUSTERS_STOP_TARGETS  = $(addprefix test/e2e/kind/stop/cluster/, $(K8SCLUSTERS))
-API_VERSION ?= v2
+API_VERSION ?= v3
 
 KUMA_UNIVERSAL_DOCKER_IMAGE ?= kuma-universal
 KUMA_UNIVERSAL_DOCKERFILE ?= test/dockerfiles/Dockerfile.universal

--- a/pkg/xds/envoy/clusters/v3/http2_configurer.go
+++ b/pkg/xds/envoy/clusters/v3/http2_configurer.go
@@ -11,7 +11,7 @@ type Http2Configurer struct {
 var _ ClusterConfigurer = &Http2Configurer{}
 
 func (p *Http2Configurer) Configure(c *envoy_cluster.Cluster) error {
-	// nolint:staticcheck keep deprecated options to be compatible with Envoy 1.16.x in Kuma 1.0.x
+	// nolint:staticcheck // keep deprecated options to be compatible with Envoy 1.16.x in Kuma 1.0.x
 	c.Http2ProtocolOptions = &envoy_core.Http2ProtocolOptions{}
 
 	// options := &envoy_upstream_http.HttpProtocolOptions{

--- a/pkg/xds/envoy/clusters/v3/http2_configurer.go
+++ b/pkg/xds/envoy/clusters/v3/http2_configurer.go
@@ -3,10 +3,6 @@ package clusters
 import (
 	envoy_cluster "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
 	envoy_core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
-	envoy_upstream_http "github.com/envoyproxy/go-control-plane/envoy/extensions/upstreams/http/v3"
-	"github.com/golang/protobuf/ptypes/any"
-
-	"github.com/kumahq/kuma/pkg/util/proto"
 )
 
 type Http2Configurer struct {
@@ -15,22 +11,25 @@ type Http2Configurer struct {
 var _ ClusterConfigurer = &Http2Configurer{}
 
 func (p *Http2Configurer) Configure(c *envoy_cluster.Cluster) error {
-	options := &envoy_upstream_http.HttpProtocolOptions{
-		UpstreamProtocolOptions: &envoy_upstream_http.HttpProtocolOptions_ExplicitHttpConfig_{
-			ExplicitHttpConfig: &envoy_upstream_http.HttpProtocolOptions_ExplicitHttpConfig{
-				ProtocolConfig: &envoy_upstream_http.HttpProtocolOptions_ExplicitHttpConfig_Http2ProtocolOptions{
-					Http2ProtocolOptions: &envoy_core.Http2ProtocolOptions{},
-				},
-			},
-		},
-	}
+	// nolint:staticcheck keep deprecated options to be compatible with Envoy 1.16.x in Kuma 1.0.x
+	c.Http2ProtocolOptions = &envoy_core.Http2ProtocolOptions{}
 
-	pbst, err := proto.MarshalAnyDeterministic(options)
-	if err != nil {
-		return err
-	}
-	c.TypedExtensionProtocolOptions = map[string]*any.Any{
-		"envoy.extensions.upstreams.http.v3.HttpProtocolOptions": pbst,
-	}
+	// options := &envoy_upstream_http.HttpProtocolOptions{
+	// 	UpstreamProtocolOptions: &envoy_upstream_http.HttpProtocolOptions_ExplicitHttpConfig_{
+	// 		ExplicitHttpConfig: &envoy_upstream_http.HttpProtocolOptions_ExplicitHttpConfig{
+	// 			ProtocolConfig: &envoy_upstream_http.HttpProtocolOptions_ExplicitHttpConfig_Http2ProtocolOptions{
+	// 				Http2ProtocolOptions: &envoy_core.Http2ProtocolOptions{},
+	// 			},
+	// 		},
+	// 	},
+	// }
+	//
+	// pbst, err := proto.MarshalAnyDeterministic(options)
+	// if err != nil {
+	// 	return err
+	// }
+	// c.TypedExtensionProtocolOptions = map[string]*any.Any{
+	// 	"envoy.extensions.upstreams.http.v3.HttpProtocolOptions": pbst,
+	// }
 	return nil
 }

--- a/pkg/xds/envoy/clusters/v3/http2_configurer_test.go
+++ b/pkg/xds/envoy/clusters/v3/http2_configurer_test.go
@@ -13,11 +13,7 @@ var _ = Describe("Http2Configurer", func() {
 
 	It("should generate proper Envoy config", func() {
 		// given
-		expected := `typedExtensionProtocolOptions:
-        envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
-          '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
-          explicitHttpConfig:
-            http2ProtocolOptions: {}`
+		expected := `http2ProtocolOptions: {}`
 
 		// when
 		cluster, err := clusters.NewClusterBuilder(envoy.APIV3).

--- a/pkg/xds/envoy/clusters/v3/timeout_configurer.go
+++ b/pkg/xds/envoy/clusters/v3/timeout_configurer.go
@@ -24,7 +24,7 @@ func (t *TimeoutConfigurer) Configure(cluster *envoy_cluster.Cluster) error {
 	cluster.ConnectTimeout = ptypes.DurationProto(t.Conf.GetConnectTimeoutOrDefault(defaultConnectTimeout))
 	switch t.Protocol {
 	case mesh_core.ProtocolHTTP, mesh_core.ProtocolHTTP2:
-		// nolint:staticcheck keep deprecated options to be compatible with Envoy 1.16.x in Kuma 1.0.x
+		// nolint:staticcheck // keep deprecated options to be compatible with Envoy 1.16.x in Kuma 1.0.x
 		cluster.CommonHttpProtocolOptions = &envoy_core.HttpProtocolOptions{
 			IdleTimeout: ptypes.DurationProto(t.Conf.GetHttp().GetIdleTimeout().AsDuration()),
 		}
@@ -43,7 +43,7 @@ func (t *TimeoutConfigurer) Configure(cluster *envoy_cluster.Cluster) error {
 		// }
 	case mesh_core.ProtocolGRPC:
 		if maxStreamDuration := t.Conf.GetGrpc().GetMaxStreamDuration().AsDuration(); maxStreamDuration != 0 {
-			// nolint:staticcheck keep deprecated options to be compatible with Envoy 1.16.x in Kuma 1.0.x
+			// nolint:staticcheck // keep deprecated options to be compatible with Envoy 1.16.x in Kuma 1.0.x
 			cluster.CommonHttpProtocolOptions = &envoy_core.HttpProtocolOptions{
 				MaxStreamDuration: ptypes.DurationProto(maxStreamDuration),
 			}

--- a/pkg/xds/envoy/clusters/v3/timeout_configurer.go
+++ b/pkg/xds/envoy/clusters/v3/timeout_configurer.go
@@ -5,13 +5,10 @@ import (
 
 	envoy_cluster "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
 	envoy_core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
-	envoy_upstream_http "github.com/envoyproxy/go-control-plane/envoy/extensions/upstreams/http/v3"
 	"github.com/golang/protobuf/ptypes"
-	"github.com/golang/protobuf/ptypes/any"
 
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	mesh_core "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
-	"github.com/kumahq/kuma/pkg/util/proto"
 )
 
 const defaultConnectTimeout = 10 * time.Second
@@ -27,32 +24,42 @@ func (t *TimeoutConfigurer) Configure(cluster *envoy_cluster.Cluster) error {
 	cluster.ConnectTimeout = ptypes.DurationProto(t.Conf.GetConnectTimeoutOrDefault(defaultConnectTimeout))
 	switch t.Protocol {
 	case mesh_core.ProtocolHTTP, mesh_core.ProtocolHTTP2:
-		options := &envoy_upstream_http.HttpProtocolOptions{
-			CommonHttpProtocolOptions: &envoy_core.HttpProtocolOptions{
-				IdleTimeout: ptypes.DurationProto(t.Conf.GetHttp().GetIdleTimeout().AsDuration()),
-			},
+		// nolint:staticcheck keep deprecated options to be compatible with Envoy 1.16.x in Kuma 1.0.x
+		cluster.CommonHttpProtocolOptions = &envoy_core.HttpProtocolOptions{
+			IdleTimeout: ptypes.DurationProto(t.Conf.GetHttp().GetIdleTimeout().AsDuration()),
 		}
-		pbst, err := proto.MarshalAnyDeterministic(options)
-		if err != nil {
-			return err
-		}
-		cluster.TypedExtensionProtocolOptions = map[string]*any.Any{
-			"envoy.extensions.upstreams.http.v3.HttpProtocolOptions": pbst,
-		}
+
+		// options := &envoy_upstream_http.HttpProtocolOptions{
+		// 	CommonHttpProtocolOptions: &envoy_core.HttpProtocolOptions{
+		// 		IdleTimeout: ptypes.DurationProto(t.Conf.GetHttp().GetIdleTimeout().AsDuration()),
+		// 	},
+		// }
+		// pbst, err := proto.MarshalAnyDeterministic(options)
+		// if err != nil {
+		// 	return err
+		// }
+		// cluster.TypedExtensionProtocolOptions = map[string]*any.Any{
+		// 	"envoy.extensions.upstreams.http.v3.HttpProtocolOptions": pbst,
+		// }
 	case mesh_core.ProtocolGRPC:
 		if maxStreamDuration := t.Conf.GetGrpc().GetMaxStreamDuration().AsDuration(); maxStreamDuration != 0 {
-			options := &envoy_upstream_http.HttpProtocolOptions{
-				CommonHttpProtocolOptions: &envoy_core.HttpProtocolOptions{
-					MaxStreamDuration: ptypes.DurationProto(maxStreamDuration),
-				},
+			// nolint:staticcheck keep deprecated options to be compatible with Envoy 1.16.x in Kuma 1.0.x
+			cluster.CommonHttpProtocolOptions = &envoy_core.HttpProtocolOptions{
+				MaxStreamDuration: ptypes.DurationProto(maxStreamDuration),
 			}
-			pbst, err := proto.MarshalAnyDeterministic(options)
-			if err != nil {
-				return err
-			}
-			cluster.TypedExtensionProtocolOptions = map[string]*any.Any{
-				"envoy.extensions.upstreams.http.v3.HttpProtocolOptions": pbst,
-			}
+
+			// options := &envoy_upstream_http.HttpProtocolOptions{
+			// 	CommonHttpProtocolOptions: &envoy_core.HttpProtocolOptions{
+			// 		MaxStreamDuration: ptypes.DurationProto(maxStreamDuration),
+			// 	},
+			// }
+			// pbst, err := proto.MarshalAnyDeterministic(options)
+			// if err != nil {
+			// 	return err
+			// }
+			// cluster.TypedExtensionProtocolOptions = map[string]*any.Any{
+			// 	"envoy.extensions.upstreams.http.v3.HttpProtocolOptions": pbst,
+			// }
 		}
 	}
 	return nil

--- a/pkg/xds/envoy/listeners/v3/access_log_configurer.go
+++ b/pkg/xds/envoy/listeners/v3/access_log_configurer.go
@@ -109,16 +109,20 @@ func fileAccessLog(format *accesslog.AccessLogFormat, cfgStr *structpb.Struct) (
 	}
 
 	fileAccessLog := &access_loggers_file.FileAccessLog{
-		AccessLogFormat: &access_loggers_file.FileAccessLog_LogFormat{
-			LogFormat: &envoy_core.SubstitutionFormatString{
-				Format: &envoy_core.SubstitutionFormatString_TextFormatSource{
-					TextFormatSource: &envoy_core.DataSource{
-						Specifier: &envoy_core.DataSource_InlineString{
-							InlineString: format.String(),
-						},
-					},
-				},
-			},
+		// AccessLogFormat: &access_loggers_file.FileAccessLog_LogFormat{
+		// 	LogFormat: &envoy_core.SubstitutionFormatString{
+		// 		Format: &envoy_core.SubstitutionFormatString_TextFormatSource{
+		// 			TextFormatSource: &envoy_core.DataSource{
+		// 				Specifier: &envoy_core.DataSource_InlineString{
+		// 					InlineString: format.String(),
+		// 				},
+		// 			},
+		// 		},
+		// 	},
+		// },
+		AccessLogFormat: &access_loggers_file.FileAccessLog_Format{
+			// nolint:staticcheck keep deprecated options to be compatible with Envoy 1.16.x in Kuma 1.0.x
+			Format: format.String(),
 		},
 		Path: cfg.Path,
 	}

--- a/pkg/xds/envoy/listeners/v3/access_log_configurer.go
+++ b/pkg/xds/envoy/listeners/v3/access_log_configurer.go
@@ -121,7 +121,7 @@ func fileAccessLog(format *accesslog.AccessLogFormat, cfgStr *structpb.Struct) (
 		// 	},
 		// },
 		AccessLogFormat: &access_loggers_file.FileAccessLog_Format{
-			// nolint:staticcheck keep deprecated options to be compatible with Envoy 1.16.x in Kuma 1.0.x
+			// nolint:staticcheck // keep deprecated options to be compatible with Envoy 1.16.x in Kuma 1.0.x
 			Format: format.String(),
 		},
 		Path: cfg.Path,

--- a/pkg/xds/envoy/listeners/v3/http_access_log_configurer_test.go
+++ b/pkg/xds/envoy/listeners/v3/http_access_log_configurer_test.go
@@ -125,11 +125,9 @@ var _ = Describe("HttpAccessLogConfigurer", func() {
                   - name: envoy.access_loggers.file
                     typedConfig:
                       '@type': type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog
-                      logFormat:
-                        textFormatSource:
-                          inlineString: |+
-                            [%START_TIME%] demo "%REQ(:method)% %REQ(x-envoy-original-path?:path)% %PROTOCOL%" %RESPONSE_CODE% %RESPONSE_FLAGS% %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(x-envoy-upstream-service-time)% "%REQ(x-forwarded-for)%" "%REQ(user-agent)%" "%REQ(x-request-id)%" "%REQ(:authority)%" "web" "backend" "192.168.0.1" "%UPSTREAM_HOST%"
-            
+                      format: |+
+                        [%START_TIME%] demo "%REQ(:method)% %REQ(x-envoy-original-path?:path)% %PROTOCOL%" %RESPONSE_CODE% %RESPONSE_FLAGS% %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(x-envoy-upstream-service-time)% "%REQ(x-forwarded-for)%" "%REQ(user-agent)%" "%REQ(x-request-id)%" "%REQ(:authority)%" "web" "backend" "192.168.0.1" "%UPSTREAM_HOST%"
+
                       path: /tmp/log
                   httpFilters:
                   - name: envoy.filters.http.router

--- a/pkg/xds/envoy/listeners/v3/network_access_log_configurer_test.go
+++ b/pkg/xds/envoy/listeners/v3/network_access_log_configurer_test.go
@@ -111,8 +111,6 @@ var _ = Describe("NetworkAccessLogConfigurer", func() {
 				}),
 			},
 			expected: `
-            name: outbound:127.0.0.1:5432
-            trafficDirection: OUTBOUND
             address:
               socketAddress:
                 address: 127.0.0.1
@@ -126,14 +124,14 @@ var _ = Describe("NetworkAccessLogConfigurer", func() {
                   - name: envoy.access_loggers.file
                     typedConfig:
                       '@type': type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog
-                      logFormat:
-                        textFormatSource:
-                          inlineString: |+
-                            [%START_TIME%] %RESPONSE_FLAGS% demo 192.168.0.1(backend)->%UPSTREAM_HOST%(db) took %DURATION%ms, sent %BYTES_SENT% bytes, received: %BYTES_RECEIVED% bytes
-            
+                      format: |+
+                        [%START_TIME%] %RESPONSE_FLAGS% demo 192.168.0.1(backend)->%UPSTREAM_HOST%(db) took %DURATION%ms, sent %BYTES_SENT% bytes, received: %BYTES_RECEIVED% bytes
+
                       path: /tmp/log
                   cluster: db
                   statPrefix: db
+            name: outbound:127.0.0.1:5432
+            trafficDirection: OUTBOUND
 `,
 		}),
 		Entry("basic tcp_proxy with tcp access log", testCase{

--- a/pkg/xds/generator/testdata/outbound-proxy/03.envoy.golden.yaml
+++ b/pkg/xds/generator/testdata/outbound-proxy/03.envoy.golden.yaml
@@ -151,22 +151,21 @@ resources:
       edsConfig:
         ads: {}
         resourceApiVersion: V3
+    http2ProtocolOptions: {}
     lbPolicy: RANDOM
     name: api-grpc
     type: EDS
-    typedExtensionProtocolOptions:
-      envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
-        '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
-        explicitHttpConfig:
-          http2ProtocolOptions: {}
 - name: api-http
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
+    commonHttpProtocolOptions:
+      idleTimeout: 0s
     connectTimeout: 10s
     edsClusterConfig:
       edsConfig:
         ads: {}
         resourceApiVersion: V3
+    http2ProtocolOptions: {}
     name: api-http
     outlierDetection:
       enforcingConsecutive5xx: 100
@@ -175,19 +174,17 @@ resources:
       enforcingFailurePercentage: 0
       enforcingSuccessRate: 0
     type: EDS
-    typedExtensionProtocolOptions:
-      envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
-        '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
-        explicitHttpConfig:
-          http2ProtocolOptions: {}
 - name: api-http2
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
+    commonHttpProtocolOptions:
+      idleTimeout: 0s
     connectTimeout: 10s
     edsClusterConfig:
       edsConfig:
         ads: {}
         resourceApiVersion: V3
+    http2ProtocolOptions: {}
     lbPolicy: RING_HASH
     name: api-http2
     ringHashLbConfig:
@@ -195,11 +192,6 @@ resources:
       maximumRingSize: "1024"
       minimumRingSize: "64"
     type: EDS
-    typedExtensionProtocolOptions:
-      envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
-        '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
-        explicitHttpConfig:
-          http2ProtocolOptions: {}
 - name: api-tcp
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
@@ -208,16 +200,12 @@ resources:
       edsConfig:
         ads: {}
         resourceApiVersion: V3
+    http2ProtocolOptions: {}
     lbPolicy: LEAST_REQUEST
     leastRequestLbConfig:
       choiceCount: 4
     name: api-tcp
     type: EDS
-    typedExtensionProtocolOptions:
-      envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
-        '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
-        explicitHttpConfig:
-          http2ProtocolOptions: {}
 - name: backend
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
@@ -226,14 +214,10 @@ resources:
       edsConfig:
         ads: {}
         resourceApiVersion: V3
+    http2ProtocolOptions: {}
     lbPolicy: MAGLEV
     name: backend
     type: EDS
-    typedExtensionProtocolOptions:
-      envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
-        '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
-        explicitHttpConfig:
-          http2ProtocolOptions: {}
 - name: db
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
@@ -242,6 +226,7 @@ resources:
       edsConfig:
         ads: {}
         resourceApiVersion: V3
+    http2ProtocolOptions: {}
     lbSubsetConfig:
       fallbackPolicy: ANY_ENDPOINT
       subsetSelectors:
@@ -250,11 +235,6 @@ resources:
         - role
     name: db
     type: EDS
-    typedExtensionProtocolOptions:
-      envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
-        '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
-        explicitHttpConfig:
-          http2ProtocolOptions: {}
 - name: outbound:127.0.0.1:18080
   resource:
     '@type': type.googleapis.com/envoy.config.listener.v3.Listener
@@ -287,10 +267,8 @@ resources:
           - name: envoy.access_loggers.file
             typedConfig:
               '@type': type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog
-              logFormat:
-                textFormatSource:
-                  inlineString: |+
-                    [%START_TIME%] mesh1 "%REQ(:method)% %REQ(x-envoy-original-path?:path)% %PROTOCOL%" %RESPONSE_CODE% %RESPONSE_FLAGS% %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(x-envoy-upstream-service-time)% "%REQ(x-forwarded-for)%" "%REQ(user-agent)%" "%REQ(x-request-id)%" "%REQ(:authority)%" "gateway" "api-http" "10.0.0.1" "%UPSTREAM_HOST%"
+              format: |+
+                [%START_TIME%] mesh1 "%REQ(:method)% %REQ(x-envoy-original-path?:path)% %PROTOCOL%" %RESPONSE_CODE% %RESPONSE_FLAGS% %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(x-envoy-upstream-service-time)% "%REQ(x-forwarded-for)%" "%REQ(user-agent)%" "%REQ(x-request-id)%" "%REQ(:authority)%" "gateway" "api-http" "10.0.0.1" "%UPSTREAM_HOST%"
 
               path: /var/log
           httpFilters:

--- a/pkg/xds/generator/testdata/outbound-proxy/04.envoy.golden.yaml
+++ b/pkg/xds/generator/testdata/outbound-proxy/04.envoy.golden.yaml
@@ -110,11 +110,14 @@ resources:
 - name: api-http
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
+    commonHttpProtocolOptions:
+      idleTimeout: 0s
     connectTimeout: 10s
     edsClusterConfig:
       edsConfig:
         ads: {}
         resourceApiVersion: V3
+    http2ProtocolOptions: {}
     name: api-http
     outlierDetection:
       enforcingConsecutive5xx: 100
@@ -163,11 +166,6 @@ resources:
               resourceApiVersion: V3
         sni: api-http{mesh=mesh1}
     type: EDS
-    typedExtensionProtocolOptions:
-      envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
-        '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
-        explicitHttpConfig:
-          http2ProtocolOptions: {}
 - name: api-tcp
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
@@ -176,6 +174,7 @@ resources:
       edsConfig:
         ads: {}
         resourceApiVersion: V3
+    http2ProtocolOptions: {}
     lbPolicy: LEAST_REQUEST
     leastRequestLbConfig:
       choiceCount: 4
@@ -221,11 +220,6 @@ resources:
               resourceApiVersion: V3
         sni: api-tcp{mesh=mesh1}
     type: EDS
-    typedExtensionProtocolOptions:
-      envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
-        '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
-        explicitHttpConfig:
-          http2ProtocolOptions: {}
 - name: backend
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
@@ -234,6 +228,7 @@ resources:
       edsConfig:
         ads: {}
         resourceApiVersion: V3
+    http2ProtocolOptions: {}
     lbPolicy: MAGLEV
     name: backend
     transportSocket:
@@ -277,11 +272,6 @@ resources:
               resourceApiVersion: V3
         sni: backend{mesh=mesh1}
     type: EDS
-    typedExtensionProtocolOptions:
-      envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
-        '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
-        explicitHttpConfig:
-          http2ProtocolOptions: {}
 - name: db
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
@@ -290,6 +280,7 @@ resources:
       edsConfig:
         ads: {}
         resourceApiVersion: V3
+    http2ProtocolOptions: {}
     lbSubsetConfig:
       fallbackPolicy: ANY_ENDPOINT
       subsetSelectors:
@@ -385,11 +376,6 @@ resources:
                 resourceApiVersion: V3
           sni: db{mesh=mesh1,role=replica}
     type: EDS
-    typedExtensionProtocolOptions:
-      envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
-        '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
-        explicitHttpConfig:
-          http2ProtocolOptions: {}
 - name: outbound:127.0.0.1:18080
   resource:
     '@type': type.googleapis.com/envoy.config.listener.v3.Listener
@@ -424,10 +410,8 @@ resources:
           - name: envoy.access_loggers.file
             typedConfig:
               '@type': type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog
-              logFormat:
-                textFormatSource:
-                  inlineString: |+
-                    [%START_TIME%] mesh1 "%REQ(:method)% %REQ(x-envoy-original-path?:path)% %PROTOCOL%" %RESPONSE_CODE% %RESPONSE_FLAGS% %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(x-envoy-upstream-service-time)% "%REQ(x-forwarded-for)%" "%REQ(user-agent)%" "%REQ(x-request-id)%" "%REQ(:authority)%" "web" "api-http" "10.0.0.1" "%UPSTREAM_HOST%"
+              format: |+
+                [%START_TIME%] mesh1 "%REQ(:method)% %REQ(x-envoy-original-path?:path)% %PROTOCOL%" %RESPONSE_CODE% %RESPONSE_FLAGS% %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(x-envoy-upstream-service-time)% "%REQ(x-forwarded-for)%" "%REQ(user-agent)%" "%REQ(x-request-id)%" "%REQ(:authority)%" "web" "api-http" "10.0.0.1" "%UPSTREAM_HOST%"
 
               path: /var/log
           httpFilters:

--- a/pkg/xds/generator/testdata/outbound-proxy/05.envoy.golden.yaml
+++ b/pkg/xds/generator/testdata/outbound-proxy/05.envoy.golden.yaml
@@ -2,6 +2,8 @@ resources:
 - name: es
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
+    commonHttpProtocolOptions:
+      idleTimeout: 0s
     connectTimeout: 10s
     lbSubsetConfig:
       fallbackPolicy: ANY_ENDPOINT
@@ -27,11 +29,6 @@ resources:
                 kuma.io/protocol: http
     name: es
     type: STRICT_DNS
-    typedExtensionProtocolOptions:
-      envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
-        '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
-        commonHttpProtocolOptions:
-          idleTimeout: 0s
 - name: outbound:127.0.0.1:18081
   resource:
     '@type': type.googleapis.com/envoy.config.listener.v3.Listener

--- a/pkg/xds/generator/testdata/outbound-proxy/06.envoy.golden.yaml
+++ b/pkg/xds/generator/testdata/outbound-proxy/06.envoy.golden.yaml
@@ -2,7 +2,10 @@ resources:
 - name: es2
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
+    commonHttpProtocolOptions:
+      idleTimeout: 0s
     connectTimeout: 10s
+    http2ProtocolOptions: {}
     lbSubsetConfig:
       fallbackPolicy: ANY_ENDPOINT
       subsetSelectors:
@@ -27,11 +30,6 @@ resources:
                 kuma.io/protocol: http2
     name: es2
     type: STRICT_DNS
-    typedExtensionProtocolOptions:
-      envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
-        '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
-        explicitHttpConfig:
-          http2ProtocolOptions: {}
 - name: outbound:127.0.0.1:18082
   resource:
     '@type': type.googleapis.com/envoy.config.listener.v3.Listener

--- a/pkg/xds/generator/testdata/outbound-proxy/cluster-dots.envoy.golden.yaml
+++ b/pkg/xds/generator/testdata/outbound-proxy/cluster-dots.envoy.golden.yaml
@@ -24,13 +24,9 @@ resources:
       edsConfig:
         ads: {}
         resourceApiVersion: V3
+    http2ProtocolOptions: {}
     name: backend.kuma-system
     type: EDS
-    typedExtensionProtocolOptions:
-      envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
-        '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
-        explicitHttpConfig:
-          http2ProtocolOptions: {}
 - name: db
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
@@ -39,6 +35,7 @@ resources:
       edsConfig:
         ads: {}
         resourceApiVersion: V3
+    http2ProtocolOptions: {}
     lbSubsetConfig:
       fallbackPolicy: ANY_ENDPOINT
       subsetSelectors:
@@ -47,11 +44,6 @@ resources:
         - version
     name: db
     type: EDS
-    typedExtensionProtocolOptions:
-      envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
-        '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
-        explicitHttpConfig:
-          http2ProtocolOptions: {}
 - name: outbound:127.0.0.1:18080
   resource:
     '@type': type.googleapis.com/envoy.config.listener.v3.Listener

--- a/pkg/xds/generator/testdata/profile-source/1-envoy-config.golden.yaml
+++ b/pkg/xds/generator/testdata/profile-source/1-envoy-config.golden.yaml
@@ -37,6 +37,7 @@ resources:
       edsConfig:
         ads: {}
         resourceApiVersion: V3
+    http2ProtocolOptions: {}
     name: db
     transportSocket:
       name: envoy.transport_sockets.tls
@@ -79,11 +80,6 @@ resources:
               resourceApiVersion: V3
         sni: db{mesh=demo}
     type: EDS
-    typedExtensionProtocolOptions:
-      envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
-        '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
-        explicitHttpConfig:
-          http2ProtocolOptions: {}
 - name: elastic
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
@@ -98,6 +94,7 @@ resources:
       tcpHealthCheck: {}
       timeout: 4s
       unhealthyThreshold: 3
+    http2ProtocolOptions: {}
     name: elastic
     transportSocket:
       name: envoy.transport_sockets.tls
@@ -140,11 +137,6 @@ resources:
               resourceApiVersion: V3
         sni: elastic{mesh=demo}
     type: EDS
-    typedExtensionProtocolOptions:
-      envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
-        '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
-        explicitHttpConfig:
-          http2ProtocolOptions: {}
 - name: kuma:envoy:admin
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster

--- a/pkg/xds/generator/testdata/profile-source/2-envoy-config.golden.yaml
+++ b/pkg/xds/generator/testdata/profile-source/2-envoy-config.golden.yaml
@@ -37,6 +37,7 @@ resources:
       edsConfig:
         ads: {}
         resourceApiVersion: V3
+    http2ProtocolOptions: {}
     name: db
     transportSocket:
       name: envoy.transport_sockets.tls
@@ -79,11 +80,6 @@ resources:
               resourceApiVersion: V3
         sni: db{mesh=demo}
     type: EDS
-    typedExtensionProtocolOptions:
-      envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
-        '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
-        explicitHttpConfig:
-          http2ProtocolOptions: {}
 - name: elastic
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
@@ -98,6 +94,7 @@ resources:
       tcpHealthCheck: {}
       timeout: 4s
       unhealthyThreshold: 3
+    http2ProtocolOptions: {}
     name: elastic
     transportSocket:
       name: envoy.transport_sockets.tls
@@ -140,11 +137,6 @@ resources:
               resourceApiVersion: V3
         sni: elastic{mesh=demo}
     type: EDS
-    typedExtensionProtocolOptions:
-      envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
-        '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
-        explicitHttpConfig:
-          http2ProtocolOptions: {}
 - name: inbound:passthrough
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster

--- a/pkg/xds/generator/testdata/profile-source/3-envoy-config.golden.yaml
+++ b/pkg/xds/generator/testdata/profile-source/3-envoy-config.golden.yaml
@@ -37,6 +37,7 @@ resources:
       edsConfig:
         ads: {}
         resourceApiVersion: V3
+    http2ProtocolOptions: {}
     name: db
     transportSocket:
       name: envoy.transport_sockets.tls
@@ -79,11 +80,6 @@ resources:
               resourceApiVersion: V3
         sni: db{mesh=demo}
     type: EDS
-    typedExtensionProtocolOptions:
-      envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
-        '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
-        explicitHttpConfig:
-          http2ProtocolOptions: {}
 - name: elastic
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
@@ -98,6 +94,7 @@ resources:
       tcpHealthCheck: {}
       timeout: 4s
       unhealthyThreshold: 3
+    http2ProtocolOptions: {}
     name: elastic
     transportSocket:
       name: envoy.transport_sockets.tls
@@ -140,11 +137,6 @@ resources:
               resourceApiVersion: V3
         sni: elastic{mesh=demo}
     type: EDS
-    typedExtensionProtocolOptions:
-      envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
-        '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
-        explicitHttpConfig:
-          http2ProtocolOptions: {}
 - name: kuma:envoy:admin
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster

--- a/pkg/xds/generator/testdata/profile-source/4-envoy-config.golden.yaml
+++ b/pkg/xds/generator/testdata/profile-source/4-envoy-config.golden.yaml
@@ -37,6 +37,7 @@ resources:
       edsConfig:
         ads: {}
         resourceApiVersion: V3
+    http2ProtocolOptions: {}
     name: db
     transportSocket:
       name: envoy.transport_sockets.tls
@@ -79,11 +80,6 @@ resources:
               resourceApiVersion: V3
         sni: db{mesh=demo}
     type: EDS
-    typedExtensionProtocolOptions:
-      envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
-        '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
-        explicitHttpConfig:
-          http2ProtocolOptions: {}
 - name: elastic
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
@@ -98,6 +94,7 @@ resources:
       tcpHealthCheck: {}
       timeout: 4s
       unhealthyThreshold: 3
+    http2ProtocolOptions: {}
     name: elastic
     transportSocket:
       name: envoy.transport_sockets.tls
@@ -140,11 +137,6 @@ resources:
               resourceApiVersion: V3
         sni: elastic{mesh=demo}
     type: EDS
-    typedExtensionProtocolOptions:
-      envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
-        '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
-        explicitHttpConfig:
-          http2ProtocolOptions: {}
 - name: inbound:passthrough
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster

--- a/pkg/xds/generator/testdata/transparent-proxy/03.envoy.golden.yaml
+++ b/pkg/xds/generator/testdata/transparent-proxy/03.envoy.golden.yaml
@@ -52,10 +52,8 @@ resources:
           - name: envoy.access_loggers.file
             typedConfig:
               '@type': type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog
-              logFormat:
-                textFormatSource:
-                  inlineString: |+
-                    [%START_TIME%] %RESPONSE_FLAGS% default (unknown)->%UPSTREAM_HOST%(external) took %DURATION%ms, sent %BYTES_SENT% bytes, received: %BYTES_RECEIVED% bytes
+              format: |+
+                [%START_TIME%] %RESPONSE_FLAGS% default (unknown)->%UPSTREAM_HOST%(external) took %DURATION%ms, sent %BYTES_SENT% bytes, received: %BYTES_RECEIVED% bytes
 
               path: /var/log
           cluster: outbound:passthrough

--- a/test/e2e/compatibility/compatibility_suite_test.go
+++ b/test/e2e/compatibility/compatibility_suite_test.go
@@ -1,0 +1,36 @@
+package compatibility_test
+
+import (
+	"testing"
+
+	ginkgo_config "github.com/onsi/ginkgo/config"
+
+	"github.com/kumahq/kuma/test/framework"
+
+	"github.com/go-logr/logr"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+
+	"github.com/kumahq/kuma/pkg/core"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestE2ECompatibility(t *testing.T) {
+	if framework.IsK8sClustersStarted() {
+		RegisterFailHandler(Fail)
+		RunSpecs(t, "E2E Deploy Suite")
+	} else {
+		t.SkipNow()
+	}
+}
+
+var _ = BeforeSuite(func() {
+	core.SetLogger = func(l logr.Logger) {}
+	logf.SetLogger(zap.LoggerTo(GinkgoWriter, true))
+})
+
+func ShouldSkipCleanup() bool {
+	return CurrentGinkgoTestDescription().Failed && ginkgo_config.GinkgoConfig.FailFast
+}

--- a/test/e2e/compatibility/dp_compatibility_universal_test.go
+++ b/test/e2e/compatibility/dp_compatibility_universal_test.go
@@ -1,0 +1,53 @@
+package compatibility_test
+
+import (
+	"github.com/gruntwork-io/terratest/modules/retry"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/kumahq/kuma/pkg/config/core"
+	. "github.com/kumahq/kuma/test/framework"
+)
+
+var _ = Describe("Test Universal Compatibility", func() {
+
+	var cluster Cluster
+	var deployOptsFuncs []DeployOptionsFunc
+
+	BeforeEach(func() {
+		cluster = NewUniversalCluster(NewTestingT(), Kuma1, Verbose)
+		deployOptsFuncs = []DeployOptionsFunc{}
+
+		err := NewClusterSetup().
+			Install(Kuma(core.Standalone, deployOptsFuncs...)).
+			Setup(cluster)
+		Expect(err).ToNot(HaveOccurred())
+		err = cluster.VerifyKuma()
+		Expect(err).ToNot(HaveOccurred())
+
+		echoServerToken, err := cluster.GetKuma().GenerateDpToken("default", "echo-server_kuma-test_svc_8080")
+		Expect(err).ToNot(HaveOccurred())
+		demoClientToken, err := cluster.GetKuma().GenerateDpToken("default", "demo-client")
+		Expect(err).ToNot(HaveOccurred())
+
+		err = EchoServerUniversal(AppModeEchoServer, "default", "universal", echoServerToken, WithDPVersion("1.0.8"))(cluster)
+		Expect(err).ToNot(HaveOccurred())
+		err = DemoClientUniversal(AppModeDemoClient, "default", demoClientToken, WithDPVersion("1.0.8"))(cluster)
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	AfterEach(func() {
+		if ShouldSkipCleanup() {
+			return
+		}
+		Expect(cluster.DeleteKuma(deployOptsFuncs...)).To(Succeed())
+		Expect(cluster.DismissCluster()).To(Succeed())
+	})
+
+	It("client should access server", func() {
+		retry.DoWithRetry(cluster.GetTesting(), "check communication between services", DefaultRetries, DefaultTimeout, func() (string, error) {
+			_, _, err := cluster.Exec("", "", "demo-client", "curl", "-v", "-m", "3", "--fail", "localhost:4001")
+			return "", err
+		})
+	})
+})

--- a/test/e2e/compatibility/foo.go
+++ b/test/e2e/compatibility/foo.go
@@ -1,0 +1,3 @@
+package compatibility
+
+// Keep this one empty here to make go test happy that there are non-test files in this folder

--- a/test/framework/interface.go
+++ b/test/framework/interface.go
@@ -46,6 +46,7 @@ type deployOptions struct {
 	transparent bool
 	protocol    string
 	mesh        string
+	dpVersion   string
 }
 
 type DeployOptionsFunc func(*deployOptions)
@@ -89,6 +90,13 @@ func WithHDS(enabled bool) DeployOptionsFunc {
 func WithGlobalAddress(address string) DeployOptionsFunc {
 	return func(o *deployOptions) {
 		o.globalAddress = address
+	}
+}
+
+// WithDPVersion only works with Universal now
+func WithDPVersion(version string) DeployOptionsFunc {
+	return func(o *deployOptions) {
+		o.dpVersion = version
 	}
 }
 

--- a/test/framework/universal_cluster.go
+++ b/test/framework/universal_cluster.go
@@ -179,6 +179,12 @@ func (c *UniversalCluster) DeployApp(fs ...DeployOptionsFunc) error {
 
 	ip := app.ip
 
+	if opts.dpVersion != "" {
+		if err := app.OverrideDpVersion(opts.dpVersion); err != nil {
+			return err
+		}
+	}
+
 	err = c.CreateDP(app, opts.name, ip, dpyaml, token)
 	if err != nil {
 		return err


### PR DESCRIPTION
### Summary

Fix compatibility issue with this scenario:
* Use Kuma CP 1.0.8 and Kuma DP 1.0.8
* Upgrade Kuma CP to 1.1.x (DP still works and is on V2)
* Restart Kuma DP 1.0.8 (this will fetch V3 config which is not compatible with Envoy 1.16.x)

This would not be a problem on K8S since when you update CP, the next DP restart will spawn a new Kuma DP.

This PR changes the code to use Envoy's deprecated settings in 1.17.x to keep compatibility with Kuma DP 1.0.x (Envoy 1.16.x).

Another solution would be to
* Put DP version in `DataplaneMetadata` structure
* Change interface of all `Configure(X)` of envoy configurers to `Configure(X, EnvoyVersion)`
* Use proper Envoy settings depending on the Envoy version

This requires a refactor so I implemented a simpler solution at the cost of some warnings in 1.1.0.

I also added Universal E2E test that fetches "old" Kuma DP version and connects to the new CP. This test will require an internet connection to Bintray.

### Documentation

- [X] No docs
