### PR TITLE
chore(github) add Installation Method line item to issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -15,3 +15,4 @@ SUMMARY_GOES_HERE
 - Error logs
 - Configuration
 - Platform and Operating System
+- Installation Method (Helm, kumactl, AWS CloudFormation, etc.)


### PR DESCRIPTION
### Summary

Adds a line item to the "Additional Details & Logs" section of the GH issue template, as it is frequently left out.
