### PR TITLE
fix(kuma-cp) improve err message if $HOME is not defined

### DIFF
--- a/pkg/core/bootstrap/autoconfig.go
+++ b/pkg/core/bootstrap/autoconfig.go
@@ -41,7 +41,7 @@ func autoconfigureGeneral(cfg *kuma_cp.Config) error {
 	if cfg.General.WorkDir == "" {
 		home, err := os.UserHomeDir()
 		if err != nil {
-			return errors.Errorf( "failed to create a working directory inside $HOME: %v, " +
+			return errors.Errorf("failed to create a working directory inside $HOME: %v, "+
 				"please pick a working directory by setting KUMA_GENERAL_WORK_DIR manually", err)
 		}
 		cfg.General.WorkDir = path.Join(home, ".kuma")

--- a/pkg/core/bootstrap/autoconfig.go
+++ b/pkg/core/bootstrap/autoconfig.go
@@ -41,7 +41,8 @@ func autoconfigureGeneral(cfg *kuma_cp.Config) error {
 	if cfg.General.WorkDir == "" {
 		home, err := os.UserHomeDir()
 		if err != nil {
-			return err
+			return errors.Errorf( "failed to create a working directory inside $HOME: %v, " +
+				"please pick a working directory by setting KUMA_GENERAL_WORK_DIR manually", err)
 		}
 		cfg.General.WorkDir = path.Join(home, ".kuma")
 	}


### PR DESCRIPTION
### Summary

If $HOME is not defined error message will look like this:

```
Error: failed to create working directory inside $HOME: $HOME is not defined, please pick a working directory by setting KUMA_GENERAL_WORK_DIR manually
```

### Documentation

- [X] no docs
