### PR TITLE
test(e2e) permissive namespace delete

### DIFF
--- a/test/framework/k8s_cluster.go
+++ b/test/framework/k8s_cluster.go
@@ -120,8 +120,8 @@ func (c *K8sCluster) WaitNamespaceCreate(namespace string) {
 func (c *K8sCluster) WaitNamespaceDelete(namespace string) {
 	retry.DoWithRetry(c.t,
 		fmt.Sprintf("Wait for %s Namespace to terminate.", namespace),
-		DefaultRetries,
-		DefaultTimeout,
+		2*DefaultRetries,
+		2*DefaultTimeout,
 		func() (string, error) {
 			_, err := k8s.GetNamespaceE(c.t,
 				c.GetKubectlOptions(),


### PR DESCRIPTION
### Summary

Sometimes the deletion of the Namespace might take much more time than any other operation on the K8s cluster in the e2e tests.
This is specifically true in CPU-restricted environments like the CI. Especially with the Hybrid tests. We increase both the timeout and the
retry count making the total timeout 4 times larger. That should be enough or otherwise, there is probably an issue with the test.

### Documentation

- [ ] Not needed
