### PR TITLE
feat(ci/cd) wait for check before e2e/integration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -638,6 +638,7 @@ workflows:
         name: docker-compose
         requires:
         - images
+        - check
         # custom parameters
         use_local_kuma_images: true
     - example_minikube:
@@ -645,6 +646,7 @@ workflows:
         name: minikube_v1_16
         requires:
           - images
+          - check
         # custom parameters
         kubernetes_version: v1.16.15
         use_local_kuma_images: true
@@ -653,6 +655,7 @@ workflows:
         name: minikube_v1_18
         requires:
           - images
+          - check
         # custom parameters
         kubernetes_version: v1.18.16
         use_local_kuma_images: true
@@ -661,6 +664,7 @@ workflows:
         name: minikube_v1_20
         requires:
           - images
+          - check
         # custom parameters
         kubernetes_version: v1.20.4
         use_local_kuma_images: true
@@ -669,6 +673,7 @@ workflows:
         name: test/e2e
         requires:
           - images
+          - check
 
   kuma-master:
     jobs:
@@ -707,6 +712,7 @@ workflows:
           name: docker-compose
           requires:
             - images
+            - check
           # custom parameters
           use_local_kuma_images: true
       - example_minikube:
@@ -714,6 +720,7 @@ workflows:
           name: minikube_v1_14
           requires:
             - images
+            - check
           # custom parameters
           kubernetes_version: v1.14.10
           use_local_kuma_images: true
@@ -722,6 +729,7 @@ workflows:
           name: minikube_v1_15
           requires:
             - images
+            - check
           # custom parameters
           kubernetes_version: v1.15.12
           use_local_kuma_images: true
@@ -730,6 +738,7 @@ workflows:
           name: minikube_v1_16
           requires:
             - images
+            - check
           # custom parameters
           kubernetes_version: v1.16.15
           use_local_kuma_images: true
@@ -738,6 +747,7 @@ workflows:
           name: minikube_v1_17
           requires:
             - images
+            - check
           # custom parameters
           kubernetes_version: v1.17.17
           use_local_kuma_images: true
@@ -746,6 +756,7 @@ workflows:
           name: minikube_v1_18
           requires:
             - images
+            - check
           # custom parameters
           kubernetes_version: v1.18.16
           use_local_kuma_images: true
@@ -754,6 +765,7 @@ workflows:
           name: minikube_v1_19
           requires:
             - images
+            - check
           # custom parameters
           kubernetes_version: v1.19.8
           use_local_kuma_images: true
@@ -762,6 +774,7 @@ workflows:
           name: minikube_v1_20
           requires:
             - images
+            - check
           # custom parameters
           kubernetes_version: v1.20.4
           use_local_kuma_images: true
@@ -770,11 +783,13 @@ workflows:
           name: test/e2e
           requires:
             - images
+            - check
       - e2e:
           <<: *commit_workflow_filters
           name: test/e2e V2
           requires:
             - images
+            - check
           # custom parameters
           api: v2
 


### PR DESCRIPTION
### Summary

As `check` is running in parallel with `build/images` jobs,
and according to my experience looking at some of the last CI/CD
runs `build/images` is taking slightly more time than the `check`
itself, so it doesn't make sense if the only expectation from
not `requiring` it before running `e2e`-related jobs was to speed
it up.

What we are gaining by waiting for `check` to finish is much
quicker feedback when we forgot to run `make check` before pushing
new changes. It's not very rare to happen and without this
requirement, even if `check` fails, the whole spectrum of heavy
e2e tests will still run without a need, as we will have to still
run it again with the `make check` results.

Of course we can manually cancel that kind of job, but to achieve
this we would have to be always present at CircleCI console.

It has significant impact when we are beginning to introduce tests
which are run on automatically created infrastructure (i.e. EKS)
as it introduces real and unnecessary costs.

From my observations, the last CI/CD run times were:
- build (1m 20s) + images (3m 5s) = 4m 25s
- check = 2m 39s


