### PR TITLE
fix(kuma-cp) pick HTTP health checker version depending on service protocol

### DIFF
--- a/pkg/xds/envoy/clusters/configurers.go
+++ b/pkg/xds/envoy/clusters/configurers.go
@@ -95,13 +95,15 @@ func EdsCluster(name string) ClusterBuilderOpt {
 	})
 }
 
-func HealthCheck(healthCheck *mesh_core.HealthCheckResource) ClusterBuilderOpt {
+func HealthCheck(protocol mesh_core.Protocol, healthCheck *mesh_core.HealthCheckResource) ClusterBuilderOpt {
 	return ClusterBuilderOptFunc(func(config *ClusterBuilderConfig) {
 		config.AddV2(&v2.HealthCheckConfigurer{
 			HealthCheck: healthCheck,
+			Protocol:    protocol,
 		})
 		config.AddV3(&v3.HealthCheckConfigurer{
 			HealthCheck: healthCheck,
+			Protocol:    protocol,
 		})
 	})
 }

--- a/pkg/xds/envoy/clusters/v2/health_check_configurer.go
+++ b/pkg/xds/envoy/clusters/v2/health_check_configurer.go
@@ -17,6 +17,7 @@ import (
 
 type HealthCheckConfigurer struct {
 	HealthCheck *mesh_core.HealthCheckResource
+	Protocol    mesh_core.Protocol
 }
 
 var _ ClusterConfigurer = &HealthCheckConfigurer{}
@@ -75,6 +76,7 @@ func tcpHealthCheck(
 }
 
 func httpHealthCheck(
+	protocol mesh_core.Protocol,
 	httpConf *mesh_proto.HealthCheck_Conf_Http,
 ) *envoy_core.HealthCheck_HttpHealthCheck_ {
 	var expectedStatuses []*envoy_type.Int64Range
@@ -85,11 +87,16 @@ func httpHealthCheck(
 		)
 	}
 
+	codecClientType := envoy_type.CodecClientType_HTTP1
+	if protocol == mesh_core.ProtocolHTTP2 {
+		codecClientType = envoy_type.CodecClientType_HTTP2
+	}
+
 	httpHealthCheck := envoy_core.HealthCheck_HttpHealthCheck{
 		Path:                httpConf.Path,
 		RequestHeadersToAdd: mapHttpHeaders(httpConf.RequestHeadersToAdd),
 		ExpectedStatuses:    expectedStatuses,
-		CodecClientType:     envoy_type.CodecClientType_HTTP2,
+		CodecClientType:     codecClientType,
 	}
 
 	return &envoy_core.HealthCheck_HttpHealthCheck_{
@@ -159,7 +166,7 @@ func (e *HealthCheckConfigurer) Configure(cluster *envoy_api.Cluster) error {
 	}
 
 	if http := activeChecks.GetHttp(); http != nil {
-		healthCheck.HealthChecker = httpHealthCheck(http)
+		healthCheck.HealthChecker = httpHealthCheck(e.Protocol, http)
 	}
 
 	cluster.HealthChecks = append(cluster.HealthChecks, &healthCheck)

--- a/pkg/xds/envoy/clusters/v2/health_check_configurer_test.go
+++ b/pkg/xds/envoy/clusters/v2/health_check_configurer_test.go
@@ -31,7 +31,7 @@ var _ = Describe("HealthCheckConfigurer", func() {
 			// when
 			cluster, err := clusters.NewClusterBuilder(envoy.APIV2).
 				Configure(clusters.EdsCluster(given.clusterName)).
-				Configure(clusters.HealthCheck(given.healthCheck)).
+				Configure(clusters.HealthCheck(mesh_core.ProtocolHTTP, given.healthCheck)).
 				Configure(clusters.Timeout(mesh_core.ProtocolTCP, &mesh_proto.Timeout_Conf{ConnectTimeout: durationpb.New(5 * time.Second)})).
 				Build()
 
@@ -220,7 +220,6 @@ var _ = Describe("HealthCheckConfigurer", func() {
             - healthyThreshold: 2
               interval: 5s
               httpHealthCheck:
-                codecClientType: HTTP2
                 expectedStatuses:
                 - end: "201"
                   start: "200"

--- a/pkg/xds/envoy/clusters/v3/health_check_configurer_test.go
+++ b/pkg/xds/envoy/clusters/v3/health_check_configurer_test.go
@@ -31,7 +31,7 @@ var _ = Describe("HealthCheckConfigurer", func() {
 			// when
 			cluster, err := clusters.NewClusterBuilder(envoy.APIV3).
 				Configure(clusters.EdsCluster(given.clusterName)).
-				Configure(clusters.HealthCheck(given.healthCheck)).
+				Configure(clusters.HealthCheck(mesh_core.ProtocolHTTP, given.healthCheck)).
 				Configure(clusters.Timeout(mesh_core.ProtocolTCP, &mesh_proto.Timeout_Conf{ConnectTimeout: durationpb.New(5 * time.Second)})).
 				Build()
 
@@ -225,7 +225,6 @@ var _ = Describe("HealthCheckConfigurer", func() {
             - healthyThreshold: 2
               interval: 5s
               httpHealthCheck:
-                codecClientType: HTTP2
                 expectedStatuses:
                 - end: "201"
                   start: "200"

--- a/pkg/xds/generator/outbound_proxy_generator.go
+++ b/pkg/xds/generator/outbound_proxy_generator.go
@@ -171,7 +171,7 @@ func (o OutboundProxyGenerator) generateCDS(ctx xds_context.Context, proxy *mode
 			Configure(envoy_clusters.Timeout(protocol, clusters.Get(clusterName).Timeout())).
 			Configure(envoy_clusters.LbSubset(o.lbSubsets(tags))).
 			Configure(envoy_clusters.OutlierDetection(circuitBreaker)).
-			Configure(envoy_clusters.HealthCheck(healthCheck))
+			Configure(envoy_clusters.HealthCheck(protocol, healthCheck))
 
 		if clusters.Get(clusterName).HasExternalService() {
 			edsClusterBuilder.


### PR DESCRIPTION
### Summary

When configuring `HealthCheck.Http` Kuma implied it always HTTP2. That didn't work well with `httpbin.org`. 

### Full changelog

The current fix takes into account `protocol` which was set on the Service. But the fix has shortcomings. It doesn't allow creating an HTTP2 health checker for traffic that is treated as TCP or HTTP1.

Alternatively, we can introduce a new field `version` in `HealthCheck.Http` section:

```yaml
type: HealthCheck
mesh: default
name: internalhttpbin-check
sources: 
  - match: 
      kuma.io/service: '*'
destinations: 
  - match: 
      kuma.io/service: externalhttpbin
conf: 
  interval: 10s
  timeout: 2s
  unhealthyThreshold: 1
  healthyThreshold: 1
  healthyPanicThreshold: 0
  http: 
    version: v1
    path: /
```

### Issues resolved

Fix https://github.com/kumahq/kuma/issues/1700

### Documentation

- [ ] Link to the website [documentation PR](https://github.com/kumahq/kuma-website/pull/XXX)
