### PR TITLE
fix(e2e) should fail on particular group test failure

### DIFF
--- a/mk/e2e.new.mk
+++ b/mk/e2e.new.mk
@@ -54,7 +54,7 @@ test/e2e/test:
 	    K8SCLUSTERS="$(K8SCLUSTERS)" \
 	    KUMACTLBIN=${BUILD_ARTIFACTS_DIR}/kumactl/kumactl \
 	    API_VERSION="$(API_VERSION)" \
-		    $(GO_TEST) -v -timeout=45m $$t; \
+		    $(GO_TEST) -v -timeout=45m $$t || exit; \
     done
 
 # test/e2e/debug is used for quicker feedback of E2E tests (ex. debugging flaky tests)


### PR DESCRIPTION
### Summary

The e2e tests should fail when a particular test folder fails.

Today it does not see (look for `[Fail] Test Kubernetes/Universal deployment [It] should access allservices`:
https://app.circleci.com/pipelines/github/kumahq/kuma/6597/workflows/17010313-67fe-49ec-af0c-f39a72b81070/jobs/79119/parallel-runs/1/steps/1-108

### Documentation

- [ ] Internal
