### PR TITLE
fix(kuma-cp) KDS may delete ConfigMaps on Control Plane restarts

### DIFF
--- a/pkg/kds/context/context.go
+++ b/pkg/kds/context/context.go
@@ -22,6 +22,8 @@ type Context struct {
 	GlobalServerCallbacks []mux.Callbacks
 	GlobalProvidedFilter  reconcile.ResourceFilter
 	RemoteProvidedFilter  reconcile.ResourceFilter
+	// Configs contains the names of system.ConfigResource that will be transferred from Global to Remote
+	Configs []string
 }
 
 func DefaultContext(manager manager.ResourceManager, zone string) *Context {
@@ -29,6 +31,7 @@ func DefaultContext(manager manager.ResourceManager, zone string) *Context {
 		RemoteClientCtx:      context.Background(),
 		GlobalProvidedFilter: GlobalProvidedFilter(manager),
 		RemoteProvidedFilter: RemoteProvidedFilter(zone),
+		Configs:              []string{config_manager.ClusterIdConfigKey},
 	}
 }
 

--- a/pkg/kds/remote/components.go
+++ b/pkg/kds/remote/components.go
@@ -3,6 +3,8 @@ package remote
 import (
 	"github.com/pkg/errors"
 
+	"github.com/kumahq/kuma/pkg/core/config/manager"
+
 	"github.com/kumahq/kuma/pkg/config/core/resources/store"
 	"github.com/kumahq/kuma/pkg/core/runtime/component"
 	"github.com/kumahq/kuma/pkg/kds/mux"
@@ -103,6 +105,11 @@ func Callbacks(rt core_runtime.Runtime, syncer sync_store.ResourceSyncer, k8sSto
 			if rs.GetItemType() == mesh.DataplaneType {
 				return syncer.Sync(rs, sync_store.PrefilterBy(func(r model.Resource) bool {
 					return r.(*mesh.DataplaneResource).Spec.IsRemoteIngress(localZone)
+				}))
+			}
+			if rs.GetItemType() == system.ConfigType {
+				return syncer.Sync(rs, sync_store.PrefilterBy(func(r model.Resource) bool {
+					return r.GetMeta().GetName() == manager.ClusterIdConfigKey
 				}))
 			}
 			return syncer.Sync(rs)

--- a/pkg/kds/remote/components.go
+++ b/pkg/kds/remote/components.go
@@ -3,8 +3,6 @@ package remote
 import (
 	"github.com/pkg/errors"
 
-	"github.com/kumahq/kuma/pkg/core/config/manager"
-
 	"github.com/kumahq/kuma/pkg/config/core/resources/store"
 	"github.com/kumahq/kuma/pkg/core/runtime/component"
 	"github.com/kumahq/kuma/pkg/kds/mux"
@@ -109,7 +107,12 @@ func Callbacks(rt core_runtime.Runtime, syncer sync_store.ResourceSyncer, k8sSto
 			}
 			if rs.GetItemType() == system.ConfigType {
 				return syncer.Sync(rs, sync_store.PrefilterBy(func(r model.Resource) bool {
-					return r.GetMeta().GetName() == manager.ClusterIdConfigKey
+					for _, config := range rt.KDSContext().Configs {
+						if config == r.GetMeta().GetName() {
+							return true
+						}
+					}
+					return false
 				}))
 			}
 			return syncer.Sync(rs)

--- a/pkg/kds/remote/components_test.go
+++ b/pkg/kds/remote/components_test.go
@@ -8,6 +8,8 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
+	core_runtime "github.com/kumahq/kuma/pkg/core/runtime"
+
 	"github.com/kumahq/kuma/api/system/v1alpha1"
 	config_manager "github.com/kumahq/kuma/pkg/core/config/manager"
 
@@ -34,12 +36,21 @@ import (
 	"github.com/kumahq/kuma/pkg/test/kds/setup"
 )
 
+type testRuntimeContext struct {
+	core_runtime.Runtime
+	kds *kds_context.Context
+}
+
+func (t *testRuntimeContext) KDSContext() *kds_context.Context {
+	return t.kds
+}
+
 var _ = Describe("Remote Sync", func() {
 
 	remoteZone := "zone-1"
 
-	newPolicySink := func(zone string, resourceSyncer sync_store.ResourceSyncer, cs *grpc.MockClientStream) component.Component {
-		return kds_client.NewKDSSink(core.Log, remote.ConsumedTypes, kds_client.NewKDSStream(cs, remoteZone), remote.Callbacks(nil, resourceSyncer, false, zone, nil))
+	newPolicySink := func(zone string, resourceSyncer sync_store.ResourceSyncer, cs *grpc.MockClientStream, rt core_runtime.Runtime) component.Component {
+		return kds_client.NewKDSSink(core.Log, remote.ConsumedTypes, kds_client.NewKDSStream(cs, remoteZone), remote.Callbacks(rt, resourceSyncer, false, zone, nil))
 	}
 	start := func(comp component.Component, stop chan struct{}) {
 		go func() {
@@ -78,7 +89,9 @@ var _ = Describe("Remote Sync", func() {
 		globalStore = memory.NewStore()
 		wg := &sync.WaitGroup{}
 		wg.Add(1)
-		serverStream := setup.StartServer(globalStore, wg, "global", remote.ConsumedTypes, kds_context.GlobalProvidedFilter(manager.NewResourceManager(globalStore)))
+
+		kdsCtx := kds_context.DefaultContext(manager.NewResourceManager(globalStore), "global")
+		serverStream := setup.StartServer(globalStore, wg, "global", remote.ConsumedTypes, kdsCtx.GlobalProvidedFilter)
 
 		stop := make(chan struct{})
 		clientStream := serverStream.ClientStream(stop)
@@ -86,7 +99,7 @@ var _ = Describe("Remote Sync", func() {
 		remoteStore = memory.NewStore()
 		remoteSyncer = sync_store.NewResourceSyncer(core.Log, remoteStore)
 
-		start(newPolicySink(remoteZone, remoteSyncer, clientStream), stop)
+		start(newPolicySink(remoteZone, remoteSyncer, clientStream, &testRuntimeContext{kds: kdsCtx}), stop)
 		closeFunc = func() {
 			close(stop)
 		}


### PR DESCRIPTION
### Summary

If Kuma CP Global filters Configs before sending to the Remote, then Remote has to Prefilter Configs when Sync resources.

### Full changelog

* Add `PrefilterBy` on Remote for Configs
* Add test

### Issues resolved

Fix #XXX

### Documentation

- [ ] Link to the website [documentation PR](https://github.com/kumahq/kuma-website/pull/XXX)
