### PR TITLE
chore(kuma-dp) validate --name and --mesh when dataplane is provided

### DIFF
--- a/app/kuma-dp/cmd/run.go
+++ b/app/kuma-dp/cmd/run.go
@@ -57,6 +57,9 @@ func newRunCmd(rootCtx *RootContext) *cobra.Command {
 				return err
 			}
 			if dp != nil {
+				if cfg.Dataplane.Name != "" || cfg.Dataplane.Mesh != "" {
+					return errors.New("--name and --mesh cannot be specified when dataplane definition is provided. Mesh and name will be read from the dataplane definition.")
+				}
 				cfg.Dataplane.Mesh = dp.Meta.GetMesh()
 				cfg.Dataplane.Name = dp.Meta.GetName()
 			}

--- a/app/kuma-dp/cmd/run_test.go
+++ b/app/kuma-dp/cmd/run_test.go
@@ -185,6 +185,7 @@ var _ = Describe("run", func() {
 				envVars: map[string]string{
 					"KUMA_CONTROL_PLANE_API_SERVER_URL":  "http://localhost:1234",
 					"KUMA_DATAPLANE_NAME":                "example",
+					"KUMA_DATAPLANE_MESH":                "default",
 					"KUMA_DATAPLANE_ADMIN_PORT":          fmt.Sprintf("%d", port),
 					"KUMA_DATAPLANE_RUNTIME_BINARY_PATH": filepath.Join("testdata", "envoy-mock.sleep.sh"),
 					// Notice: KUMA_DATAPLANE_RUNTIME_CONFIG_DIR is not set in order to let `kuma-dp` to create a temporary directory
@@ -198,6 +199,7 @@ var _ = Describe("run", func() {
 				envVars: map[string]string{
 					"KUMA_CONTROL_PLANE_API_SERVER_URL":  "http://localhost:1234",
 					"KUMA_DATAPLANE_NAME":                "example",
+					"KUMA_DATAPLANE_MESH":                "default",
 					"KUMA_DATAPLANE_ADMIN_PORT":          fmt.Sprintf("%d", port),
 					"KUMA_DATAPLANE_RUNTIME_BINARY_PATH": filepath.Join("testdata", "envoy-mock.sleep.sh"),
 					"KUMA_DATAPLANE_RUNTIME_CONFIG_DIR":  tmpDir,
@@ -212,6 +214,7 @@ var _ = Describe("run", func() {
 				args: []string{
 					"--cp-address", "http://localhost:1234",
 					"--name", "example",
+					"--mesh", "default",
 					"--admin-port", fmt.Sprintf("%d", port),
 					"--binary-path", filepath.Join("testdata", "envoy-mock.sleep.sh"),
 					// Notice: --config-dir is not set in order to let `kuma-dp` to create a temporary directory
@@ -225,6 +228,7 @@ var _ = Describe("run", func() {
 				args: []string{
 					"--cp-address", "http://localhost:1234",
 					"--name", "example",
+					"--mesh", "default",
 					"--admin-port", fmt.Sprintf("%d", port),
 					"--binary-path", filepath.Join("testdata", "envoy-mock.sleep.sh"),
 					"--config-dir", tmpDir,
@@ -238,6 +242,7 @@ var _ = Describe("run", func() {
 				args: []string{
 					"--cp-address", "http://localhost:1234",
 					"--name", "example",
+					"--mesh", "default",
 					"--admin-port", fmt.Sprintf("%d", port),
 					"--binary-path", filepath.Join("testdata", "envoy-mock.sleep.sh"),
 					"--dataplane-token-file", filepath.Join("testdata", "token"),
@@ -251,6 +256,7 @@ var _ = Describe("run", func() {
 				envVars: map[string]string{
 					"KUMA_CONTROL_PLANE_API_SERVER_URL":  "http://localhost:1234",
 					"KUMA_DATAPLANE_NAME":                "example",
+					"KUMA_DATAPLANE_MESH":                "default",
 					"KUMA_DATAPLANE_ADMIN_PORT":          "",
 					"KUMA_DATAPLANE_RUNTIME_BINARY_PATH": filepath.Join("testdata", "envoy-mock.sleep.sh"),
 					// Notice: KUMA_DATAPLANE_RUNTIME_CONFIG_DIR is not set in order to let `kuma-dp` to create a temporary directory
@@ -265,6 +271,7 @@ var _ = Describe("run", func() {
 				args: []string{
 					"--cp-address", "http://localhost:1234",
 					"--name", "example",
+					"--mesh", "default",
 					"--admin-port", "",
 					"--binary-path", filepath.Join("testdata", "envoy-mock.sleep.sh"),
 					// Notice: --config-dir is not set in order to let `kuma-dp` to create a temporary directory
@@ -307,6 +314,7 @@ var _ = Describe("run", func() {
 			"run",
 			"--cp-address", "http://localhost:1234",
 			"--name", "example",
+			"--mesh", "default",
 			"--admin-port", fmt.Sprintf("%d", port),
 			"--binary-path", filepath.Join("testdata", "envoy-mock.sleep.sh"),
 		})
@@ -317,5 +325,27 @@ var _ = Describe("run", func() {
 		// then
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(ContainSubstring(fmt.Sprintf(`unable to find a free port in the range "%d" for Envoy Admin API to listen on`, port)))
+	})
+
+	It("should fail when name and mesh is provided with dataplane definition", func() {
+		// given
+		cmd := NewRootCmd(DefaultRootContext())
+		cmd.SetArgs([]string{
+			"run",
+			"--cp-address", "http://localhost:1234",
+			"--binary-path", filepath.Join("testdata", "envoy-mock.sleep.sh"),
+			"--dataplane-file", filepath.Join("testdata", "dataplane_template.yaml"),
+			"--dataplane-var", "name=example",
+			"--dataplane-var", "address=127.0.0.1",
+			"--name=xyz",
+			"--mesh=xyz",
+		})
+
+		// when
+		err := cmd.Execute()
+
+		// then
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(Equal("--name and --mesh cannot be specified when dataplane definition is provided. Mesh and name will be read from the dataplane definition."))
 	})
 })

--- a/pkg/config/app/kuma-dp/config.go
+++ b/pkg/config/app/kuma-dp/config.go
@@ -21,7 +21,7 @@ func DefaultConfig() Config {
 			},
 		},
 		Dataplane: Dataplane{
-			Mesh:      "default",
+			Mesh:      "",
 			Name:      "",                                                      // Dataplane name must be set explicitly
 			AdminPort: config_types.MustPortRange(30001, config_types.MaxPort), // by default, automatically choose a free port for Envoy Admin interface
 			DrainTime: 30 * time.Second,

--- a/pkg/config/app/kuma-dp/testdata/default-config.golden.yaml
+++ b/pkg/config/app/kuma-dp/testdata/default-config.golden.yaml
@@ -6,7 +6,6 @@ controlPlane:
   caCert: ""
   caCertFile: ""
 dataplane:
-  mesh: default
   drainTime: 30s
   bootstrapVersion: ""
 dataplaneRuntime:


### PR DESCRIPTION
### Summary

having an option to provide `--name` and `--mesh` with `--dataplane-file` is confusing because mesh and name in dataplane definition takes precedence. Added validation that you cannot use `--name` or `--mesh` with `--dataplane-file`.

This is a slightly breaking change because I had to change that `--mesh` not by default is not `default` but needs to be explicitly provided.

### Documentation

- [X] No docs
