### PR TITLE
chore(kuma-cp) add 'ginkgo unfocus'

### DIFF
--- a/mk/check.mk
+++ b/mk/check.mk
@@ -49,7 +49,11 @@ imports: ## Dev: Runs goimports in order to organize imports
 helm-docs: ## Dev: Runs helm-docs generator
 	$(HELM_DOCS_PATH) -s="file" --chart-search-root=./deployments/charts
 
+.PHONY: ginkgo/unfocus
+ginkgo/unfocus:
+	$(GOPATH_BIN_DIR)/ginkgo unfocus
+
 .PHONY: check
-check: generate fmt vet docs helm-lint golangci-lint imports tidy helm-docs ## Dev: Run code checks (go fmt, go vet, ...)
+check: generate fmt vet docs helm-lint golangci-lint imports tidy helm-docs ginkgo/unfocus ## Dev: Run code checks (go fmt, go vet, ...)
 	$(MAKE) generate manifests -C pkg/plugins/resources/k8s/native
 	git diff --quiet || test $$(git diff --name-only | grep -v -e 'go.mod$$' -e 'go.sum$$' | wc -l) -eq 0 || ( echo "The following changes (result of code generators and code checks) have been detected:" && git --no-pager diff && false ) # fail if Git working tree is dirty


### PR DESCRIPTION
### Summary

If you ever forgot to get rid of `FIt` or `FEntry` before the commit, then it's not the case anymore!

### Full changelog

* add `make ginkgo/unfocus` as a part of `make check`

