### PR TITLE
feat(kuma-cp) backward compatibility for external-service VIPs

### DIFF
--- a/pkg/dns/outbound.go
+++ b/pkg/dns/outbound.go
@@ -83,14 +83,20 @@ func VIPOutbounds(
 	outbounds := []*mesh_proto.Dataplane_Networking_Outbound{}
 	for _, service := range services {
 		entry := serviceVIPMap[service]
-		outbounds = append(outbounds,
-			&mesh_proto.Dataplane_Networking_Outbound{
+		outbounds = append(outbounds, &mesh_proto.Dataplane_Networking_Outbound{
+			Address: entry.ip,
+			Port:    entry.port,
+			Tags:    map[string]string{mesh_proto.ServiceTag: service},
+		})
+
+		// todo (lobkovilya): backwards compatibility, could be deleted in the next major release Kuma 1.2.x
+		if entry.port != VIPListenPort {
+			outbounds = append(outbounds, &mesh_proto.Dataplane_Networking_Outbound{
 				Address: entry.ip,
-				Port:    entry.port,
-				Tags: map[string]string{
-					mesh_proto.ServiceTag: service,
-				},
+				Port:    VIPListenPort,
+				Tags:    map[string]string{mesh_proto.ServiceTag: service},
 			})
+		}
 	}
 
 	return outbounds

--- a/pkg/dns/outbound_test.go
+++ b/pkg/dns/outbound_test.go
@@ -242,8 +242,16 @@ var _ = Describe("VIPOutbounds", func() {
         port: 1234
         tags:
           kuma.io/service: first-external-service
+      - address: 240.0.0.6
+        port: 80
+        tags:
+          kuma.io/service: first-external-service
       - address: 240.0.0.7
         port: 4321
+        tags:
+          kuma.io/service: second-external-service
+      - address: 240.0.0.7
+        port: 80
         tags:
           kuma.io/service: second-external-service
       - address: 240.0.0.2

--- a/pkg/plugins/runtime/k8s/controllers/pod_controller_test.go
+++ b/pkg/plugins/runtime/k8s/controllers/pod_controller_test.go
@@ -4,11 +4,12 @@ import (
 	"context"
 	"encoding/json"
 
-	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
-	"github.com/kumahq/kuma/pkg/plugins/resources/k8s"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
+
+	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
+	"github.com/kumahq/kuma/pkg/plugins/resources/k8s"
 
 	core_manager "github.com/kumahq/kuma/pkg/core/resources/manager"
 	"github.com/kumahq/kuma/pkg/dns/vips"

--- a/pkg/plugins/runtime/k8s/controllers/pod_controller_test.go
+++ b/pkg/plugins/runtime/k8s/controllers/pod_controller_test.go
@@ -4,10 +4,11 @@ import (
 	"context"
 	"encoding/json"
 
+	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
+	"github.com/kumahq/kuma/pkg/plugins/resources/k8s"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-
-	"github.com/kumahq/kuma/pkg/plugins/resources/k8s"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
 
 	core_manager "github.com/kumahq/kuma/pkg/core/resources/manager"
 	"github.com/kumahq/kuma/pkg/dns/vips"
@@ -450,5 +451,84 @@ var _ = Describe("PodReconciler", func() {
                 kuma.io/service: example_demo_svc_6061
                 kuma.io/protocol: tcp
 `))
+	})
+
+	It("should update Pods when ExternalService updated", func() {
+		err := kubeClient.Create(context.Background(), &mesh_k8s.Dataplane{
+			Mesh: "mesh-1",
+			ObjectMeta: kube_meta.ObjectMeta{
+				Namespace: "demo",
+				Name:      "dp-1",
+				OwnerReferences: []kube_meta.OwnerReference{{
+					Controller: utilpointer.BoolPtr(true),
+					Kind:       "Pod",
+					Name:       "dp-1",
+				}},
+			},
+			Spec: map[string]interface{}{
+				"networking": map[string]interface{}{},
+			},
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		err = kubeClient.Create(context.Background(), &mesh_k8s.Dataplane{
+			Mesh: "mesh-1",
+			ObjectMeta: kube_meta.ObjectMeta{
+				Namespace: "demo",
+				Name:      "dp-2",
+				OwnerReferences: []kube_meta.OwnerReference{{
+					Controller: utilpointer.BoolPtr(true),
+					Kind:       "Pod",
+					Name:       "dp-2",
+				}},
+			},
+			Spec: map[string]interface{}{
+				"networking": map[string]interface{}{},
+			},
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		err = kubeClient.Create(context.Background(), &mesh_k8s.Dataplane{
+			Mesh: "mesh-2",
+			ObjectMeta: kube_meta.ObjectMeta{
+				Namespace: "demo",
+				Name:      "dp-3",
+				OwnerReferences: []kube_meta.OwnerReference{{
+					Controller: utilpointer.BoolPtr(true),
+					Kind:       "Pod",
+					Name:       "dp-3",
+				}},
+			},
+			Spec: map[string]interface{}{
+				"networking": map[string]interface{}{},
+			},
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		mapper := &ExternalServiceToPodsMapper{
+			Client: kubeClient,
+		}
+		es := &mesh_k8s.ExternalService{
+			Mesh: "mesh-1",
+			ObjectMeta: kube_meta.ObjectMeta{
+				Namespace: "demo",
+				Name:      "es-1",
+			},
+			Spec: map[string]interface{}{
+				"networking": map[string]interface{}{
+					"address": "httpbin.org:443",
+				},
+				"tags": map[string]interface{}{
+					mesh_proto.ServiceTag: "httpbin",
+				},
+			},
+		}
+		requests := mapper.Map(handler.MapObject{Object: es})
+		requestsStr := []string{}
+		for _, r := range requests {
+			requestsStr = append(requestsStr, r.Name)
+		}
+		Expect(requestsStr).To(HaveLen(2))
+		Expect(requestsStr).To(ConsistOf("dp-1", "dp-2"))
 	})
 })

--- a/test/e2e/externalservices/externalservices_kubernetes_test.go
+++ b/test/e2e/externalservices/externalservices_kubernetes_test.go
@@ -172,6 +172,13 @@ metadata:
 		Expect(err).ToNot(HaveOccurred())
 		Expect(stderr).To(ContainSubstring("HTTP/1.1 200 OK"))
 		Expect(stdout).ToNot(ContainSubstring("externalservice-https-server"))
+
+		// todo (lobkovilya): check of backward compatibility, could be deleted in the next major release Kuma 1.2.x
+		stdout, stderr, err = cluster.ExecWithRetries(TestNamespace, clientPod.GetName(), "demo-client",
+			"curl", "-v", "-m", "3", "--fail", "http://external-service.mesh")
+		Expect(err).ToNot(HaveOccurred())
+		Expect(stderr).To(ContainSubstring("HTTP/1.1 200 OK"))
+		Expect(stdout).ToNot(ContainSubstring("externalservice-https-server"))
 	})
 
 	It("should route to external-service over tls", func() {


### PR DESCRIPTION
### Summary

Generate VIP outbound with port `:80` for ExternalServices that have another port

### Full changelog

* additional outbound for ExternalServices 
* check port `:80` in e2e
* add watcher of ExternalService resources for PodController

### Issues resolved

Fix #XXX

### Documentation

- [ ] Link to the website [documentation PR](https://github.com/kumahq/kuma-website/pull/XXX)
