### PR TITLE
fix(kuma-cp) Envoy config is created based on old Dataplane

### DIFF
--- a/pkg/xds/sync/components.go
+++ b/pkg/xds/sync/components.go
@@ -18,7 +18,8 @@ var (
 
 func defaultDataplaneProxyBuilder(rt core_runtime.Runtime, metadataTracker DataplaneMetadataTracker, apiVersion envoy.APIVersion) *DataplaneProxyBuilder {
 	return &DataplaneProxyBuilder{
-		ResManager:            rt.ResourceManager(),
+		CachingResManager:     rt.ReadOnlyResourceManager(),
+		NonCachingResManager:  rt.ResourceManager(),
 		LookupIP:              rt.LookupIP(),
 		DataSourceLoader:      rt.DataSourceLoader(),
 		MetadataTracker:       metadataTracker,

--- a/pkg/xds/sync/components.go
+++ b/pkg/xds/sync/components.go
@@ -18,7 +18,7 @@ var (
 
 func defaultDataplaneProxyBuilder(rt core_runtime.Runtime, metadataTracker DataplaneMetadataTracker, apiVersion envoy.APIVersion) *DataplaneProxyBuilder {
 	return &DataplaneProxyBuilder{
-		ResManager:            rt.ReadOnlyResourceManager(),
+		ResManager:            rt.ResourceManager(),
 		LookupIP:              rt.LookupIP(),
 		DataSourceLoader:      rt.DataSourceLoader(),
 		MetadataTracker:       metadataTracker,

--- a/test/e2e/healthcheck/healthcheck_hybrid_test.go
+++ b/test/e2e/healthcheck/healthcheck_hybrid_test.go
@@ -3,6 +3,7 @@ package healthcheck_test
 import (
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/gruntwork-io/terratest/modules/k8s"
 	"github.com/gruntwork-io/terratest/modules/retry"
@@ -125,23 +126,29 @@ metadata:
 
 		cmd := []string{"curl", "-v", "-m", "3", "--fail", "echo-server_kuma-test_svc_8080.mesh"}
 
-		checkInstance := func(instance string) {
+		checkInstances := func(instances ...string) {
+			set := map[string]bool{}
+
 			_, err = retry.DoWithRetryE(remoteK8s.GetTesting(), fmt.Sprintf("kubectl exec %s -- %s", pods[0].GetName(), strings.Join(cmd, " ")),
-				DefaultRetries, DefaultTimeout, func() (string, error) {
+				DefaultRetries, 500*time.Millisecond, func() (string, error) {
 					stdout, _, err := remoteK8s.Exec(TestNamespace, pods[0].GetName(), "demo-client", cmd...)
 					if err != nil {
 						return "", err
 					}
-					if !strings.Contains(stdout, instance) {
-						return "", errors.New("wrong instance")
+					for _, instance := range instances {
+						if strings.Contains(stdout, instance) {
+							set[instance] = true
+						}
+					}
+					if len(set) != len(instances) {
+						return "", errors.Errorf("checked %d/%d instances", len(set), len(instances))
 					}
 					return "", nil
 				},
 			)
 		}
 
-		checkInstance("echo-universal-1")
-		checkInstance("echo-universal-2")
+		checkInstances("echo-universal-1", "echo-universal-2")
 
 		var counter1, counter2, counter3 int
 		const numOfRequest = 100

--- a/test/e2e/healthcheck/healthcheck_hybrid_test.go
+++ b/test/e2e/healthcheck/healthcheck_hybrid_test.go
@@ -126,7 +126,7 @@ metadata:
 
 		cmd := []string{"curl", "-v", "-m", "3", "--fail", "echo-server_kuma-test_svc_8080.mesh"}
 
-		instances := []string{"echo-universal-1", "echo-universal-2"}
+		instances := []string{"echo-universal-1", "echo-universal-3"}
 		instanceSet := map[string]bool{}
 
 		_, err = retry.DoWithRetryE(remoteK8s.GetTesting(), fmt.Sprintf("kubectl exec %s -- %s", pods[0].GetName(), strings.Join(cmd, " ")),

--- a/test/e2e/healthcheck/healthcheck_hybrid_test.go
+++ b/test/e2e/healthcheck/healthcheck_hybrid_test.go
@@ -130,7 +130,7 @@ metadata:
 		instanceSet := map[string]bool{}
 
 		_, err = retry.DoWithRetryE(remoteK8s.GetTesting(), fmt.Sprintf("kubectl exec %s -- %s", pods[0].GetName(), strings.Join(cmd, " ")),
-			DefaultRetries, 500*time.Millisecond, func() (string, error) {
+			100, 500*time.Millisecond, func() (string, error) {
 				stdout, _, err := remoteK8s.Exec(TestNamespace, pods[0].GetName(), "demo-client", cmd...)
 				if err != nil {
 					return "", err


### PR DESCRIPTION
### Summary

Comment implied that we have to get Dataplane from a non-cached Store, but in practice, it was taken from a cached store:

```go
// we use non-cached ResourceManager to always fetch fresh version of the Dataplane.
// Otherwise, technically MeshCache can use newer version because it uses List operation instead of Get
if err := p.ResManager.Get(ctx, dataplane, core_store.GetBy(key)); err != nil {
    return nil, err
}
```

### Full changelog

* pass the second (non-cached) store to the proxy builder
* refactor e2e checker

### Issues resolved

Fix #XXX

### Documentation

- [ ] Link to the website [documentation PR](https://github.com/kumahq/kuma-website/pull/XXX)
