### PR TITLE
chore(kuma-cp) restore ability to extend GUI via embed

### DIFF
--- a/app/kuma-ui/pkg/resources/fs.go
+++ b/app/kuma-ui/pkg/resources/fs.go
@@ -8,7 +8,7 @@ import (
 //go:embed data
 var GuiData embed.FS
 
-func GuiFS() fs.FS {
+var GuiFS = func() fs.FS {
 	fsys, err := fs.Sub(GuiData, "data")
 	if err != nil {
 		panic(err)

--- a/deployments/go.mod
+++ b/deployments/go.mod
@@ -1,1 +1,0 @@
-module github.com/kumahq/kuma/deployments

--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,6 @@ require (
 	github.com/hoisie/mustache v0.0.0-20160804235033-6375acf62c69
 	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/kumahq/kuma/api v0.0.0-00010101000000-000000000000
-	github.com/kumahq/kuma/deployments v0.0.0-00010101000000-000000000000
 	github.com/kumahq/kuma/pkg/plugins/resources/k8s/native v0.0.0-00010101000000-000000000000
 	github.com/kumahq/kuma/pkg/transparentproxy/istio v0.0.0-00010101000000-000000000000
 	github.com/lib/pq v1.9.0
@@ -63,7 +62,6 @@ require (
 
 replace (
 	github.com/kumahq/kuma/api => ./api
-	github.com/kumahq/kuma/deployments => ./deployments
 	github.com/kumahq/kuma/pkg/plugins/resources/k8s/native => ./pkg/plugins/resources/k8s/native
 	github.com/kumahq/kuma/pkg/transparentproxy/istio => ./pkg/transparentproxy/istio
 


### PR DESCRIPTION
### Summary

* Ability to override Kuma GUI
* Remove Go module for deployments. It's not needed