### PR TITLE
test(e2e) skip all builtin DNS tests for APIv2

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -226,8 +226,6 @@ github.com/circonus-labs/circonusllhist v0.1.4/go.mod h1:kMXHVDlOchFAehlya5ePtbp
 github.com/clbanning/x2j v0.0.0-20191024224557-825249438eec/go.mod h1:jMjuTZXRI4dUb/I5gc9Hdhagfvm9+RyrPryS/auMzxE=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cloudflare/golz4 v0.0.0-20150217214814-ef862a3cdc58/go.mod h1:EOBUe0h4xcZ5GoxqC5SDxFQ8gwyZPKQoEzownBlhI80=
-github.com/cncf/udpa v0.0.2-0.20201211205326-cc1b757b3edd h1:Hy1EFDPdhjoQGPJVuGIP1CwjCHSRN3+pb821CcbPLC4=
-github.com/cncf/udpa v0.0.2-0.20201211205326-cc1b757b3edd/go.mod h1:HNVadOiXCy7Jk3R2knJ+qm++zkncJxxBMpjdGgJ+UJc=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20200629203442-efcf912fb354/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403 h1:cqQfy1jclcSy/FwLjemeg3SR1yaINm74aQyupQ0Bl8M=
@@ -343,7 +341,6 @@ github.com/emicklei/go-restful v2.9.6+incompatible/go.mod h1:otzb+WCGbkyDHkqmQmT
 github.com/emicklei/go-restful v2.14.2+incompatible/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
 github.com/emicklei/go-restful v2.15.0+incompatible h1:8KpYO/Xl/ZudZs5RNOEhWMBY4hmzlZhhRd9cu+jrZP4=
 github.com/emicklei/go-restful v2.15.0+incompatible/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
-github.com/envoyproxy/data-plane-api v0.0.0-20210105195927-01fb099f5a86/go.mod h1:ysQJ12w0R8EJ2rE11wHBGdm+4q7Ft5RTmABx23SOscc=
 github.com/envoyproxy/go-control-plane v0.6.9/go.mod h1:SBwIajubJHhxtWwsL9s8ss4safvEdbitLhGGK48rN6g=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
@@ -576,7 +573,6 @@ github.com/googleapis/gnostic v0.1.0/go.mod h1:sJBsCZ4ayReDTBIg8b9dl28c5xFWyhBTV
 github.com/googleapis/gnostic v0.2.2/go.mod h1:sJBsCZ4ayReDTBIg8b9dl28c5xFWyhBTVRp3pOg5EKY=
 github.com/googleapis/gnostic v0.3.1 h1:WeAefnSUHlBb0iJKwxFDZdbfGwkd7xRNuV+IpXMJhYk=
 github.com/googleapis/gnostic v0.3.1/go.mod h1:on+2t9HRStVgn95RSsFWFz+6Q0Snyqv1awfrALZdbtU=
-github.com/googleapis/googleapis v0.0.0-20210422004218-6b711581c9a6/go.mod h1:XrPm4xpez/lHHyE+8/G+NqQRcB4lg42HF9zQVTvxtXw=
 github.com/gophercloud/gophercloud v0.1.0 h1:P/nh25+rzXouhytV2pUHBb65fnds26Ghl8/391+sT5o=
 github.com/gophercloud/gophercloud v0.1.0/go.mod h1:vxM41WHh5uqHVBMZHzuwNOHh8XEoIEcSTewFxm1c5g8=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1 h1:EGx4pi6eqNxGaHF6qqu48+N2wcFQ5qg5FXgOdqsJ5d8=

--- a/test/e2e/externalservices/externalservices_kubernetes_test.go
+++ b/test/e2e/externalservices/externalservices_kubernetes_test.go
@@ -18,7 +18,10 @@ import (
 )
 
 var _ = Describe("Test ExternalServices on Kubernetes", func() {
-
+	if IsApiV2() {
+		fmt.Println("Test not supported on API v2")
+		return
+	}
 	meshDefaulMtlsOn := `
 apiVersion: kuma.io/v1alpha1
 kind: Mesh

--- a/test/e2e/externalservices/externalservices_universal_test.go
+++ b/test/e2e/externalservices/externalservices_universal_test.go
@@ -14,7 +14,10 @@ import (
 )
 
 var _ = Describe("Test ExternalServices on Universal", func() {
-
+	if IsApiV2() {
+		fmt.Println("Test not supported on API v2")
+		return
+	}
 	meshDefaulMtlsOn := `
 type: Mesh
 name: default

--- a/test/e2e/hybrid/kuma_hybrid_test.go
+++ b/test/e2e/hybrid/kuma_hybrid_test.go
@@ -14,7 +14,10 @@ import (
 )
 
 var _ = Describe("Test Kubernetes/Universal deployment", func() {
-
+	if IsApiV2() {
+		fmt.Println("Test not supported on API v2")
+		return
+	}
 	meshMTLSOn := func(mesh string) string {
 		return fmt.Sprintf(`
 type: Mesh

--- a/test/e2e/tracing/tracing_kubernetes_test.go
+++ b/test/e2e/tracing/tracing_kubernetes_test.go
@@ -17,7 +17,10 @@ import (
 )
 
 var _ = Describe("Tracing K8S", func() {
-
+	if IsApiV2() {
+		fmt.Println("Test not supported on API v2")
+		return
+	}
 	namespaceWithSidecarInjection := func(namespace string) string {
 		return fmt.Sprintf(`
 apiVersion: v1

--- a/test/framework/env.go
+++ b/test/framework/env.go
@@ -87,6 +87,10 @@ func HasApiVersion() bool {
 	return envIsPresent(envAPIVersion)
 }
 
+func IsApiV2() bool {
+	return GetApiVersion() == "v2"
+}
+
 func GetHelmChartPath() string {
 	return os.Getenv("HELM_CHART_PATH")
 }


### PR DESCRIPTION
### Summary

The Builtin DNS functionality is disabled for the deprecated APIv2. Skip the relevant tests in the E2E.
As the future is to completely move to Builtin DNS, we might just revert this logic and skip all tests for V2 with a couple of small exceptions.
