### PR TITLE
fix(kumactl) Check version after loading config.

### DIFF
--- a/app/kumactl/cmd/root.go
+++ b/app/kumactl/cmd/root.go
@@ -58,7 +58,11 @@ func NewRootCmd(root *kumactl_cmd.RootContext) *cobra.Command {
 				}
 			}
 
-			retval := root.LoadConfig()
+			err = root.LoadConfig()
+			if err != nil {
+				return err
+			}
+
 			client, err := root.CurrentApiClient()
 			if err != nil {
 				kumactlLog.Error(err, "Unable to get index client")
@@ -67,9 +71,9 @@ func NewRootCmd(root *kumactl_cmd.RootContext) *cobra.Command {
 			}
 
 			if kumaBuildVersion != nil && (kumaBuildVersion.Version != kuma_version.Build.Version || kumaBuildVersion.Tagline != kuma_version.Product) {
-				cmd.Println("WARNING: You are using kumactl version " + kuma_version.Build.Version + " for " + kuma_version.Product + ", but the server returned version: " + kumaBuildVersion.Tagline + " " + kumaBuildVersion.Version)
+				cmd.PrintErr("WARNING: You are using kumactl version " + kuma_version.Build.Version + " for " + kuma_version.Product + ", but the server returned version: " + kumaBuildVersion.Tagline + " " + kumaBuildVersion.Version + "\n")
 			}
-			return retval
+			return nil
 		},
 	}
 	// root flags

--- a/app/kumactl/cmd/root.go
+++ b/app/kumactl/cmd/root.go
@@ -42,12 +42,6 @@ func NewRootCmd(root *kumactl_cmd.RootContext) *cobra.Command {
 		Short: "Management tool for Kuma",
 		Long:  `Management tool for Kuma.`,
 		PersistentPreRunE: func(cmd *cobra.Command, _ []string) error {
-			client, err := root.CurrentApiClient()
-			if err != nil {
-				kumactlLog.Error(err, "Unable to get index client")
-			} else {
-				kumaBuildVersion, _ = client.GetVersion()
-			}
 			level, err := kuma_log.ParseLogLevel(args.logLevel)
 			if err != nil {
 				return err
@@ -57,16 +51,25 @@ func NewRootCmd(root *kumactl_cmd.RootContext) *cobra.Command {
 			// once command line flags have been parsed,
 			// avoid printing usage instructions
 			cmd.SilenceUsage = true
-			if kumaBuildVersion != nil && kumaBuildVersion.Version != kuma_version.Build.Version {
-				cmd.Println("Warning: Your kumactl version is " + kuma_version.Build.Version + " which is not the same as " + kumaBuildVersion.Version + " for CP. Update your kumactl.")
-			}
 			if root.IsFirstTimeUsage() {
 				root.Runtime.Config = kumactl_config.DefaultConfiguration()
 				if err := root.SaveConfig(); err != nil {
 					return err
 				}
 			}
-			return root.LoadConfig()
+
+			retval := root.LoadConfig()
+			client, err := root.CurrentApiClient()
+			if err != nil {
+				kumactlLog.Error(err, "Unable to get index client")
+			} else {
+				kumaBuildVersion, _ = client.GetVersion()
+			}
+
+			if kumaBuildVersion != nil && (kumaBuildVersion.Version != kuma_version.Build.Version || kumaBuildVersion.Tagline != kuma_version.Product) {
+				cmd.Println("WARNING: You are using kumactl version " + kuma_version.Build.Version + " for " + kuma_version.Product + ", but the server returned version: " + kumaBuildVersion.Tagline + " " + kumaBuildVersion.Version)
+			}
+			return retval
 		},
 	}
 	// root flags

--- a/app/kumactl/cmd/root.go
+++ b/app/kumactl/cmd/root.go
@@ -58,8 +58,7 @@ func NewRootCmd(root *kumactl_cmd.RootContext) *cobra.Command {
 				}
 			}
 
-			err = root.LoadConfig()
-			if err != nil {
+			if err := root.LoadConfig(); err != nil {
 				return err
 			}
 


### PR DESCRIPTION
### Summary

The version comparison in kumactl was not working - it would attempt to connect to kuma-cp to retrieve version prior to loading config and that retrieval would silently fail. This fix moves the API call to happen after config loads.

Also changed the error message to conform to what is specified in the ticket.

### Full changelog

* Fix kumactl / kuma-cp version comparison in kumactl.



