### PR TITLE
tests(*) don't install DNS on helm upgrade

### DIFF
--- a/test/e2e/helm/kuma_helm_upgrade_test.go
+++ b/test/e2e/helm/kuma_helm_upgrade_test.go
@@ -61,7 +61,6 @@ var _ = Describe("Test upgrading with Helm chart", func() {
 
 			err = NewClusterSetup().
 				Install(Kuma(core.Standalone, deployOptsFuncs...)).
-				Install(KumaDNS()).
 				Setup(cluster)
 			Expect(err).ToNot(HaveOccurred())
 


### PR DESCRIPTION
### Summary

As a result of https://github.com/kumahq/kuma/pull/1879 generated manifests from `kumactl install dns` contains:
```
WARNING: You are using kumactl version latest for Kuma, but the server returned version: Kuma 1.0.3
```
so the tests were failing.
During these tests DNS is not necessary, so I decided to remove it