### PR TITLE
fix(e2e) collect stdout only in kumactl e2e

### DIFF
--- a/test/framework/kumactl.go
+++ b/test/framework/kumactl.go
@@ -75,7 +75,7 @@ func (o *KumactlOptions) RunKumactlAndGetOutputV(verbose bool, args ...string) (
 		command.Logger = logger.Discard
 	}
 
-	return shell.RunCommandAndGetOutputE(o.t, command)
+	return shell.RunCommandAndGetStdOutE(o.t, command)
 }
 
 func (o *KumactlOptions) KumactlDelete(kumatype, name, mesh string) error {


### PR DESCRIPTION
### Summary

Changing one of the kumactl methods in e2e framework to run kumactl and get output only from stdout instead of combining them with stderr