### PR TITLE
fix(prometheus-sd) namespace source names for v1 API

### DIFF
--- a/app/kuma-prometheus-sd/pkg/discovery/xds/v1/converter_test.go
+++ b/app/kuma-prometheus-sd/pkg/discovery/xds/v1/converter_test.go
@@ -51,7 +51,7 @@ var _ = Describe("Converter", func() {
 					}},
 				},
 				expected: []*targetgroup.Group{{
-					Source: "kuma",
+					Source: "/meshes/demo/targets/backend-01/0",
 					Targets: []model.LabelSet{
 						{
 							"__address__": "192.168.0.1:1234",

--- a/pkg/config/app/kuma-prometheus-sd/config.go
+++ b/pkg/config/app/kuma-prometheus-sd/config.go
@@ -17,7 +17,7 @@ func DefaultConfig() Config {
 			Client: MonitoringAssignmentClientConfig{
 				Name:       "kuma_sd",
 				URL:        "grpc://localhost:5676",
-				ApiVersion: mads.API_V1_ALPHA1,
+				ApiVersion: mads.API_V1,
 			},
 		},
 		Prometheus: PrometheusConfig{

--- a/pkg/config/app/kuma-prometheus-sd/testdata/default-config.golden.yaml
+++ b/pkg/config/app/kuma-prometheus-sd/testdata/default-config.golden.yaml
@@ -2,6 +2,6 @@ monitoringAssignment:
   client:
     name: kuma_sd
     url: grpc://localhost:5676
-    apiVersion: v1alpha1
+    apiVersion: v1
 prometheus:
   outputFile: kuma.file_sd.json


### PR DESCRIPTION
### Summary

Though `targetgroup.Group.Source` is constant in the native Prometheus SD implementations, the kuma-prometheus-sd
does target diff tracking using this field in order to remove groups from the written file, and expects it to be unique.

### Full changelog

* Ensure that kuma-prometheus-sd uses namespaced source names for targetgroup.Groups, so diffs can be calculated

### Issues resolved

Fixes #1886

### Documentation

- [ ] Link to the website [documentation PR](https://github.com/kumahq/kuma-website/pull/XXX)
