### PR TITLE
feat(kuma-cp) generate outbounds for itself

### DIFF
--- a/pkg/dns/outbound.go
+++ b/pkg/dns/outbound.go
@@ -29,10 +29,6 @@ func VIPOutbounds(
 	serviceVIPMap := map[string]vipEntry{}
 	services := []string{}
 	for _, dataplane := range dataplanes {
-		if resourceKey == model.MetaToResourceKey(dataplane.Meta) {
-			continue
-		}
-
 		if dataplane.Spec.IsIngress() {
 			for _, service := range dataplane.Spec.Networking.Ingress.AvailableServices {
 				if service.Mesh == resourceKey.Mesh {

--- a/pkg/dns/outbound_test.go
+++ b/pkg/dns/outbound_test.go
@@ -74,11 +74,11 @@ var _ = Describe("VIPOutbounds", func() {
 		// when
 		outbounds := dns.VIPOutbounds(model.MetaToResourceKey(dataplane.Meta), dataplanes.Items, vipList, externalServices.Items)
 		// and
-		Expect(outbounds).To(HaveLen(4))
+		Expect(outbounds).To(HaveLen(5))
 		// and
-		Expect(outbounds[3].GetTags()[mesh_proto.ServiceTag]).To(Equal("service-5"))
+		Expect(outbounds[4].GetTags()[mesh_proto.ServiceTag]).To(Equal("service-5"))
 		// and
-		Expect(outbounds[3].Port).To(Equal(dns.VIPListenPort))
+		Expect(outbounds[4].Port).To(Equal(dns.VIPListenPort))
 	})
 
 	It("shouldn't add outbounds from other meshes", func() {
@@ -254,6 +254,10 @@ var _ = Describe("VIPOutbounds", func() {
         port: 80
         tags:
           kuma.io/service: second-external-service
+      - address: 240.0.0.1
+        port: 80
+        tags:
+          kuma.io/service: service-1
       - address: 240.0.0.2
         port: 80
         tags:

--- a/pkg/plugins/runtime/universal/outbound/outbound_test.go
+++ b/pkg/plugins/runtime/universal/outbound/outbound_test.go
@@ -100,9 +100,9 @@ var _ = Describe("UpdateOutbound", func() {
 			dp1 := mesh.NewDataplaneResource()
 			err = rm.Get(context.Background(), dp1, store.GetByKey("dp-1", "default"))
 			Expect(err).ToNot(HaveOccurred())
-			Expect(dp1.Spec.Networking.Outbound).To(HaveLen(1))
-			Expect(dp1.Spec.Networking.Outbound[0].Tags["kuma.io/service"]).To(Equal("service-2"))
-			Expect(dp1.Spec.Networking.Outbound[0].Address).To(Equal("240.0.0.2"))
+			Expect(dp1.Spec.Networking.Outbound).To(HaveLen(2))
+			Expect(dp1.Spec.Networking.Outbound[1].Tags["kuma.io/service"]).To(Equal("service-2"))
+			Expect(dp1.Spec.Networking.Outbound[1].Address).To(Equal("240.0.0.2"))
 		})
 
 		It("should not update dataplane outbounds when new service is added to another mesh", func() {
@@ -132,7 +132,7 @@ var _ = Describe("UpdateOutbound", func() {
 			dp1 := mesh.NewDataplaneResource()
 			err = rm.Get(context.Background(), dp1, store.GetByKey("dp-1", "default"))
 			Expect(err).ToNot(HaveOccurred())
-			Expect(dp1.Spec.Networking.Outbound).To(HaveLen(0))
+			Expect(dp1.Spec.Networking.Outbound).To(HaveLen(1))
 		})
 
 		It("should update dataplane outbounds when new service in the same mesh is added to an ingress", func() {
@@ -169,9 +169,9 @@ var _ = Describe("UpdateOutbound", func() {
 			dp1 := mesh.NewDataplaneResource()
 			err = rm.Get(context.Background(), dp1, store.GetByKey("dp-1", "default"))
 			Expect(err).ToNot(HaveOccurred())
-			Expect(dp1.Spec.Networking.Outbound).To(HaveLen(1))
-			Expect(dp1.Spec.Networking.Outbound[0].Tags["kuma.io/service"]).To(Equal("service-2"))
-			Expect(dp1.Spec.Networking.Outbound[0].Address).To(Equal("240.0.0.2"))
+			Expect(dp1.Spec.Networking.Outbound).To(HaveLen(2))
+			Expect(dp1.Spec.Networking.Outbound[1].Tags["kuma.io/service"]).To(Equal("service-2"))
+			Expect(dp1.Spec.Networking.Outbound[1].Address).To(Equal("240.0.0.2"))
 		})
 
 		It("shouldn't update dataplane outbounds when new service in a different mesh is added to an ingress", func() {
@@ -208,7 +208,7 @@ var _ = Describe("UpdateOutbound", func() {
 			dp1 := mesh.NewDataplaneResource()
 			err = rm.Get(context.Background(), dp1, store.GetByKey("dp-1", "default"))
 			Expect(err).ToNot(HaveOccurred())
-			Expect(dp1.Spec.Networking.Outbound).To(HaveLen(0))
+			Expect(dp1.Spec.Networking.Outbound).To(HaveLen(1))
 		})
 
 		It("should update dataplane outbounds when new service is added to an ingress in a different mesh", func() {
@@ -248,9 +248,9 @@ var _ = Describe("UpdateOutbound", func() {
 			dp1 := mesh.NewDataplaneResource()
 			err = rm.Get(context.Background(), dp1, store.GetByKey("dp-1", "default"))
 			Expect(err).ToNot(HaveOccurred())
-			Expect(dp1.Spec.Networking.Outbound).To(HaveLen(1))
-			Expect(dp1.Spec.Networking.Outbound[0].Tags["kuma.io/service"]).To(Equal("service-2"))
-			Expect(dp1.Spec.Networking.Outbound[0].Address).To(Equal("240.0.0.2"))
+			Expect(dp1.Spec.Networking.Outbound).To(HaveLen(2))
+			Expect(dp1.Spec.Networking.Outbound[1].Tags["kuma.io/service"]).To(Equal("service-2"))
+			Expect(dp1.Spec.Networking.Outbound[1].Address).To(Equal("240.0.0.2"))
 		})
 
 		Context("outbounds already updated", func() {
@@ -297,7 +297,7 @@ var _ = Describe("UpdateOutbound", func() {
 				dp1 := mesh.NewDataplaneResource()
 				err = rm.Get(context.Background(), dp1, store.GetByKey("dp-1", "default"))
 				Expect(err).ToNot(HaveOccurred())
-				Expect(dp1.Spec.Networking.Outbound).To(HaveLen(0))
+				Expect(dp1.Spec.Networking.Outbound).To(HaveLen(1))
 			})
 		})
 	})


### PR DESCRIPTION
### Summary

Generate outbound entries for the service itself, to be able to
communicate with the local service through envoy

### Issues resolved

Fix https://github.com/kumahq/kuma/issues/1742

### Documentation

- [ ] Link to the website [documentation PR](https://github.com/kumahq/kuma-website/pull/XXX)
