### PR TITLE
docs(*) introduce guides

### DIFF
--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -1,0 +1,1 @@
+Here are guides and tips that can help you develop and contribute to Kuma.

--- a/docs/guides/e2e-test-tips.md
+++ b/docs/guides/e2e-test-tips.md
@@ -1,0 +1,73 @@
+# E2E tests tips
+
+E2E tests are less stable and slower than unit tests therefore it's useful to know some tricks
+
+## Faster environment setup
+
+When e2e tests are executed here are the steps
+
+1) Build containers
+2) Start Kubernetes Cluster 2
+3) Start Kubernetes Cluster 2
+4) Execute tests
+
+If you use `-j` containers are build in parallel using all cores and 2) and 3) step is also parallelized.  Tests are executed as usual.
+
+```
+make -j test/e2e
+```
+
+## Execute single test
+
+Regular `make test/e2e` will execute all the tests in the project.
+
+If you want to execute single test you can change the code from `It()` to `FIt()` or `Describe()` to `FDescribe()` and then use `E2E_PKG_LIST`
+
+Example:
+```
+FIt("should access service locally and remotely", func() {
+...
+
+make test/e2e E2E_PKG_LIST=./test/e2e/deploy/... 
+```
+
+## Debug the test - do not clean up environment
+
+Even if you execute one test and it fails, our framework clean up the environment (delete Kubernetes clusters, containers etc.)
+
+When you use `make test/e2e/debug` and the test fails, execution will immediately stop and environment is not cleaned up.
+
+`test/e2e/debug` works with the same envs as `test/e2e` like `E2E_PKG_LIST`
+
+## Use K3D instead of KIND
+
+K3D is faster than KIND, but it is still experimental addition to Kuma.
+To use K3D in E2E tests add `K3D=true`
+
+```
+make test/e2e K3D=true 
+```
+
+## Decide which Kubernetes clusters will be created
+
+If you know you are running only universal tests you can skip creating Kubernetes clusters by setting
+```
+make test/e2e/debug K8SCLUSTERS= E2E_PKG_LIST=./test/e2e/trafficpermission/universal/...
+```
+
+or if the test need only 1 Kuberenetes cluster do this
+
+```
+make test/e2e/debug K8SCLUSTERS=kuma-1 E2E_PKG_LIST=./test/e2e/trafficpermission/universal/...
+```
+
+## Useful commands
+
+### Cleanup environment
+
+Running `make test/e2e/debug` can intentionally leave resources if test fails. Clean them up with   
+
+```
+make k3d/stop/all && docker stop $(docker ps -aq) # omit $ for fish
+```
+

--- a/docs/guides/new-feature.md
+++ b/docs/guides/new-feature.md
@@ -1,0 +1,25 @@
+# New feature
+
+## Design
+
+If this is a bigger feature, consider writing a proposal, so we can a void a situation that PR needs to be reimplemented.
+
+When designing a new feature, consider the following questions
+
+* How does it work on Kubernetes?
+* How does it work on Universal?
+* How does it work with multi-zone (hybrid) deployment?
+* Is it backwards compatible?
+* Does it affect projects that are based on Kuma?
+
+## Implementation
+
+* If possible, write E2E test that verifies the behavior
+* If a new behavior is introduced or the old is changed, write [docs](https://github.com/kumahq/kuma-website/).
+* Does it need changes in the [GUI](https://github.com/kumahq/kuma-gui)?
+
+## Deployment
+
+* How is deployed on Universal?
+* How is deployed on Kubernetes with kumactl?
+* How is deployed on Kubernetes with HELM?

--- a/docs/guides/upgrade-dependencies.md
+++ b/docs/guides/upgrade-dependencies.md
@@ -1,0 +1,21 @@
+# Upgrade dependencies
+
+Some dependencies upgrades requires extra steps
+
+## Go Control Plane
+
+To upgrade Go Control Plane you need to
+
+* Upgrade the version in go.mod
+* Regenerate imports `make generate/envoy-imports`
+* Fix copy pasted parts of the control plane `pkg/util/xds`
+
+## Envoy
+
+* Find and replace the old version with a new one
+* Upload binaries for Universal of every distro to PULP
+
+## Kubernetes client
+
+* Upgrade the version in go.mod
+* Upgrade manually `plugins/bootstrap/k8s/cache`


### PR DESCRIPTION
### Summary

Here is an idea. I see that sometimes we lack formal process or we have what is called [tribal knowledge](https://en.wikipedia.org/wiki/Tribal_knowledge)

I'd like to have a place that we can share tips and write some guides that can help develop the project.

Automation is always better than manual steps but sometimes we cannot avoid it.

More examples:
* Refresh RELEASE.md and move it here
* Create notes how to debug AKS/EKS tests