### PR TITLE
fix(kuma-cp) check for xds.Context in Bypass hook

### DIFF
--- a/pkg/plugins/bootstrap/k8s/xds/hooks/api_server_bypass.go
+++ b/pkg/plugins/bootstrap/k8s/xds/hooks/api_server_bypass.go
@@ -32,7 +32,7 @@ func NewApiServerBypass(address string, port uint32) ApiServerBypass {
 }
 
 func (h ApiServerBypass) Modify(resources *core_xds.ResourceSet, ctx xds_context.Context, proxy *core_xds.Proxy) error {
-	if ctx.Mesh.Resource.Spec.IsPassthrough() {
+	if proxy.Dataplane.Spec.IsIngress() || ctx.Mesh.Resource.Spec.IsPassthrough() {
 		return nil
 	}
 

--- a/pkg/xds/hooks/resource_set.go
+++ b/pkg/xds/hooks/resource_set.go
@@ -9,6 +9,10 @@ import (
 // Since resourceSet is an argument, you can add new, remove or modify the existing resources
 // To support V2 and V3, search the resource set for typeUrls for proper version
 // If you want to for example modify only inbound listeners, search for the resource origin of OriginInbound
+//
+// WARNING: Please, be aware that Hooks are being called also in Ingress Dataplanes
+//			and when method Modify is being called, the passed xds_context.Context
+//			will be empty
 type ResourceSetHook interface {
 	Modify(resourceSet *core_xds.ResourceSet, ctx xds_context.Context, proxy *core_xds.Proxy) error
 }

--- a/pkg/xds/hooks/resource_set.go
+++ b/pkg/xds/hooks/resource_set.go
@@ -11,8 +11,8 @@ import (
 // If you want to for example modify only inbound listeners, search for the resource origin of OriginInbound
 //
 // WARNING: Please, be aware that Hooks are being called also in Ingress Dataplanes
-//			and when method Modify is being called, the passed xds_context.Context
-//			will be empty
+//			and when method Modify is being called, the passed MeshContext
+//			inside xds_context.Context will be empty
 type ResourceSetHook interface {
 	Modify(resourceSet *core_xds.ResourceSet, ctx xds_context.Context, proxy *core_xds.Proxy) error
 }


### PR DESCRIPTION
### Summary

When creating normal Dataplanes and Ingress ones method `Modify`
is being called but in later scenario (Ingress) the passed
xds.Context is empty.

Here is the fix for K8s API Passthrough Bypass and also I'm adding
the comment with a warning about this fact