### PR TITLE
feat(kumactl) Add option to install Kong ingress

### DIFF
--- a/app/kumactl/cmd/completion/testdata/bash.golden
+++ b/app/kumactl/cmd/completion/testdata/bash.golden
@@ -2258,6 +2258,40 @@ _kumactl_install_dns()
     noun_aliases=()
 }
 
+_kumactl_install_gateway()
+{
+    last_command="kumactl_install_gateway"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--namespace=")
+    two_word_flags+=("--namespace")
+    local_nonpersistent_flags+=("--namespace=")
+    flags+=("--type=")
+    two_word_flags+=("--type")
+    local_nonpersistent_flags+=("--type=")
+    flags+=("--config-file=")
+    two_word_flags+=("--config-file")
+    flags+=("--log-level=")
+    two_word_flags+=("--log-level")
+    flags+=("--mesh=")
+    two_word_flags+=("--mesh")
+    two_word_flags+=("-m")
+
+    must_have_one_flag=()
+    must_have_one_flag+=("--type=")
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
 _kumactl_install_logging()
 {
     last_command="kumactl_install_logging"
@@ -2444,6 +2478,7 @@ _kumactl_install()
     commands+=("control-plane")
     commands+=("crds")
     commands+=("dns")
+    commands+=("gateway")
     commands+=("logging")
     commands+=("metrics")
     commands+=("tracing")

--- a/app/kumactl/cmd/completion/testdata/zsh.golden
+++ b/app/kumactl/cmd/completion/testdata/zsh.golden
@@ -943,7 +943,7 @@ function _kumactl_install_dns {
 function _kumactl_install_gateway {
   _arguments \
     '--namespace[namespace to install gateway to]:' \
-    '--type[type of gateway to install]:' \
+    '--type[type of gateway to install. Available types: '\''kong'\'']:' \
     '--config-file[path to the configuration file to use]:' \
     '--log-level[log level: one of off|info|debug]:' \
     '(-m --mesh)'{-m,--mesh}'[mesh to use]:'

--- a/app/kumactl/cmd/completion/testdata/zsh.golden
+++ b/app/kumactl/cmd/completion/testdata/zsh.golden
@@ -842,6 +842,7 @@ function _kumactl_install {
       "control-plane:Install Kuma Control Plane on Kubernetes"
       "crds:Install Kuma Custom Resource Definitions on Kubernetes"
       "dns:Install DNS to Kubernetes"
+      "gateway:Install ingress gateway on Kubernetes"
       "logging:Install Logging backend in Kubernetes cluster (Loki)"
       "metrics:Install Metrics backend in Kubernetes cluster (Prometheus + Grafana)"
       "tracing:Install Tracing backend in Kubernetes cluster (Jaeger)"
@@ -860,6 +861,9 @@ function _kumactl_install {
     ;;
   dns)
     _kumactl_install_dns
+    ;;
+  gateway)
+    _kumactl_install_gateway
     ;;
   logging)
     _kumactl_install_logging
@@ -931,6 +935,15 @@ function _kumactl_install_dns {
   _arguments \
     '--namespace[namespace to look for Kuma Control Plane service]:' \
     '--port[port of the Kuma DNS server]:' \
+    '--config-file[path to the configuration file to use]:' \
+    '--log-level[log level: one of off|info|debug]:' \
+    '(-m --mesh)'{-m,--mesh}'[mesh to use]:'
+}
+
+function _kumactl_install_gateway {
+  _arguments \
+    '--namespace[namespace to install gateway to]:' \
+    '--type[type of gateway to install]:' \
     '--config-file[path to the configuration file to use]:' \
     '--log-level[log level: one of off|info|debug]:' \
     '(-m --mesh)'{-m,--mesh}'[mesh to use]:'

--- a/app/kumactl/cmd/install/context/install_gateway_context.go
+++ b/app/kumactl/cmd/install/context/install_gateway_context.go
@@ -1,0 +1,18 @@
+package context
+
+type InstallGatewayArgs struct {
+	Type      string
+	Namespace string
+}
+
+type InstallGatewayContext struct {
+	Args InstallGatewayArgs
+}
+
+func DefaultInstallGatewayContext() InstallGatewayContext {
+	return InstallGatewayContext{
+		Args: InstallGatewayArgs{
+			Namespace: "kuma-gateway",
+		},
+	}
+}

--- a/app/kumactl/cmd/install/install.go
+++ b/app/kumactl/cmd/install/install.go
@@ -20,5 +20,6 @@ func NewInstallCmd(pctx *kumactl_cmd.RootContext) *cobra.Command {
 	cmd.AddCommand(newInstallDNS())
 	cmd.AddCommand(newInstallLogging())
 	cmd.AddCommand(newInstallTransparentProxy())
+	cmd.AddCommand(newInstallGatewayCmd(&pctx.InstallGatewayContext))
 	return cmd
 }

--- a/app/kumactl/cmd/install/install_gateway.go
+++ b/app/kumactl/cmd/install/install_gateway.go
@@ -1,0 +1,68 @@
+package install
+
+import (
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+
+	install_context "github.com/kumahq/kuma/app/kumactl/cmd/install/context"
+	kumactl_data "github.com/kumahq/kuma/app/kumactl/data"
+	"github.com/kumahq/kuma/app/kumactl/pkg/install/data"
+	"github.com/kumahq/kuma/app/kumactl/pkg/install/k8s"
+)
+
+type gatewayTemplateArgs struct {
+	Namespace string
+}
+
+func newInstallGatewayCmd(ctx *install_context.InstallGatewayContext) *cobra.Command {
+	args := ctx.Args
+	cmd := &cobra.Command{
+		Use:   "gateway",
+		Short: "Install ingress gateway on Kubernetes",
+		Long: `Install ingress gateway on Kubernetes in a 'kuma-gateway' namespace.
+This command requires that the KUBECONFIG environment is set`,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			if err := validateGWArgs(args); err != nil {
+				return err
+			}
+
+			templateArgs := gatewayTemplateArgs{
+				Namespace: args.Namespace,
+			}
+
+			templateFiles, err := data.ReadFiles(kumactl_data.InstallGatewayFS())
+			if err != nil {
+				return errors.Wrap(err, "Failed to read template files")
+			}
+
+			renderedFiles, err := renderFiles(templateFiles, templateArgs, simpleTemplateRenderer)
+
+			if err != nil {
+				return errors.Wrap(err, "Failed to render template files")
+			}
+
+			sortedResources, err := k8s.SortResourcesByKind(renderedFiles)
+			if err != nil {
+				return errors.Wrap(err, "Failed to sort resources by kind")
+			}
+
+			singleFile := data.JoinYAML(sortedResources)
+
+			if _, err := cmd.OutOrStdout().Write(singleFile.Data); err != nil {
+				return errors.Wrap(err, "Failed to output rendered resources")
+			}
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&args.Type, "type", args.Type, "type of gateway to install")
+	cmd.MarkFlagRequired("type")
+	cmd.Flags().StringVar(&args.Namespace, "namespace", args.Namespace, "namespace to install gateway to")
+	return cmd
+}
+
+func validateGWArgs(args install_context.InstallGatewayArgs) error {
+	if args.Type != "kong" {
+		return errors.New("Only gateway type 'kong' currently supported")
+	}
+	return nil
+}

--- a/app/kumactl/cmd/install/install_gateway.go
+++ b/app/kumactl/cmd/install/install_gateway.go
@@ -19,8 +19,7 @@ func newInstallGatewayCmd(ctx *install_context.InstallGatewayContext) *cobra.Com
 	cmd := &cobra.Command{
 		Use:   "gateway",
 		Short: "Install ingress gateway on Kubernetes",
-		Long: `Install ingress gateway on Kubernetes in a 'kuma-gateway' namespace.
-This command requires that the KUBECONFIG environment is set`,
+		Long:  "Install ingress gateway on Kubernetes in a 'kuma-gateway' namespace.",
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			if err := validateGWArgs(args); err != nil {
 				return err
@@ -54,7 +53,7 @@ This command requires that the KUBECONFIG environment is set`,
 			return nil
 		},
 	}
-	cmd.Flags().StringVar(&args.Type, "type", args.Type, "type of gateway to install")
+	cmd.Flags().StringVar(&args.Type, "type", args.Type, "type of gateway to install. Available types: 'kong'")
 	cmd.MarkFlagRequired("type")
 	cmd.Flags().StringVar(&args.Namespace, "namespace", args.Namespace, "namespace to install gateway to")
 	return cmd

--- a/app/kumactl/cmd/install/install_gateway_test.go
+++ b/app/kumactl/cmd/install/install_gateway_test.go
@@ -28,6 +28,11 @@ var _ = Describe("kumactl install gateway", func() {
 		goldenFile string
 	}
 
+	type testCaseErr struct {
+		extraArgs   []string
+		expectedErr string
+	}
+
 	BeforeEach(func() {
 		kuma_version.Build = kuma_version.BuildInfo{
 			Version:   "0.0.1",
@@ -38,7 +43,7 @@ var _ = Describe("kumactl install gateway", func() {
 	})
 
 	DescribeTable("should generate error",
-		func(given testCase) {
+		func(given testCaseErr) {
 			// given
 			rootCmd := cmd.DefaultRootCmd()
 			rootCmd.SetArgs(append([]string{"install", "gateway"}, given.extraArgs...))
@@ -49,17 +54,17 @@ var _ = Describe("kumactl install gateway", func() {
 			err := rootCmd.Execute()
 
 			// then
-			Expect(err).ToNot(BeNil())
+			Expect(err.Error()).To(Equal(given.expectedErr))
 		},
-		Entry("should fail due to lack of type", testCase{
-			extraArgs:  nil,
-			goldenFile: "",
+		Entry("should fail due to lack of type", testCaseErr{
+			extraArgs:   nil,
+			expectedErr: "required flag(s) \"type\" not set",
 		}),
-		Entry("should fail due to invalid type", testCase{
+		Entry("should fail due to invalid type", testCaseErr{
 			extraArgs: []string{
 				"--type", "invalidtype",
 			},
-			goldenFile: "",
+			expectedErr: "Only gateway type 'kong' currently supported",
 		}),
 	)
 

--- a/app/kumactl/cmd/install/install_gateway_test.go
+++ b/app/kumactl/cmd/install/install_gateway_test.go
@@ -1,0 +1,98 @@
+package install_test
+
+import (
+	"bytes"
+	"path/filepath"
+
+	kuma_version "github.com/kumahq/kuma/pkg/version"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+
+	"github.com/kumahq/kuma/app/kumactl/cmd"
+)
+
+var _ = Describe("kumactl install gateway", func() {
+
+	var stdout *bytes.Buffer
+	var stderr *bytes.Buffer
+
+	BeforeEach(func() {
+		stdout = &bytes.Buffer{}
+		stderr = &bytes.Buffer{}
+	})
+
+	type testCase struct {
+		extraArgs  []string
+		goldenFile string
+	}
+
+	BeforeEach(func() {
+		kuma_version.Build = kuma_version.BuildInfo{
+			Version:   "0.0.1",
+			GitTag:    "v0.0.1",
+			GitCommit: "91ce236824a9d875601679aa80c63783fb0e8725",
+			BuildDate: "2019-08-07T11:26:06Z",
+		}
+	})
+
+	DescribeTable("should generate error",
+		func(given testCase) {
+			// given
+			rootCmd := cmd.DefaultRootCmd()
+			rootCmd.SetArgs(append([]string{"install", "gateway"}, given.extraArgs...))
+			rootCmd.SetOut(stdout)
+			rootCmd.SetErr(stderr)
+
+			// when
+			err := rootCmd.Execute()
+
+			// then
+			Expect(err).ToNot(BeNil())
+		},
+		Entry("should fail due to lack of type", testCase{
+			extraArgs:  nil,
+			goldenFile: "",
+		}),
+		Entry("should fail due to invalid type", testCase{
+			extraArgs: []string{
+				"--type", "invalidtype",
+			},
+			goldenFile: "",
+		}),
+	)
+
+	DescribeTable("should generate Kubernetes resources",
+		func(given testCase) {
+			// given
+			rootCmd := cmd.DefaultRootCmd()
+			rootCmd.SetArgs(append([]string{"install", "gateway"}, given.extraArgs...))
+			rootCmd.SetOut(stdout)
+			rootCmd.SetErr(stderr)
+
+			// when
+			err := rootCmd.Execute()
+
+			// then
+			Expect(err).ToNot(HaveOccurred())
+			Expect(stderr.Bytes()).To(BeNil())
+
+			// and output matches golden files
+			actual := stdout.Bytes()
+			ExpectMatchesGoldenFiles(actual, filepath.Join("testdata", given.goldenFile))
+		},
+		Entry("should generate Kubernetes resources with default settings", testCase{
+			extraArgs: []string{
+				"--type", "kong",
+			},
+			goldenFile: "install-gateway.defaults.golden.yaml",
+		}),
+		Entry("should generate Kubernetes resources with custom settings", testCase{
+			extraArgs: []string{
+				"--type", "kong", "--namespace", "notdefault",
+			},
+			goldenFile: "install-gateway.overrides.golden.yaml",
+		}),
+	)
+})

--- a/app/kumactl/cmd/install/testdata/install-gateway.defaults.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-gateway.defaults.golden.yaml
@@ -4,11 +4,8 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: kuma-gateway
----
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: kuma-gateway
+  annotations:
+    kuma.io/sidecar-injection: enabled
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/app/kumactl/cmd/install/testdata/install-gateway.defaults.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-gateway.defaults.golden.yaml
@@ -1,0 +1,738 @@
+
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: kuma-gateway
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: kuma-gateway
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kong-serviceaccount
+  namespace: kuma-gateway
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: kongclusterplugins.configuration.konghq.com
+spec:
+  additionalPrinterColumns:
+  - JSONPath: .plugin
+    description: Name of the plugin
+    name: Plugin-Type
+    type: string
+  - JSONPath: .metadata.creationTimestamp
+    description: Age
+    name: Age
+    type: date
+  - JSONPath: .disabled
+    description: Indicates if the plugin is disabled
+    name: Disabled
+    priority: 1
+    type: boolean
+  - JSONPath: .config
+    description: Configuration of the plugin
+    name: Config
+    priority: 1
+    type: string
+  group: configuration.konghq.com
+  names:
+    kind: KongClusterPlugin
+    plural: kongclusterplugins
+    shortNames:
+    - kcp
+  scope: Cluster
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        config:
+          type: object
+        configFrom:
+          properties:
+            secretKeyRef:
+              properties:
+                key:
+                  type: string
+                name:
+                  type: string
+                namespace:
+                  type: string
+              required:
+              - name
+              - namespace
+              - key
+              type: object
+          type: object
+        disabled:
+          type: boolean
+        plugin:
+          type: string
+        protocols:
+          items:
+            enum:
+            - http
+            - https
+            - grpc
+            - grpcs
+            - tcp
+            - tls
+            type: string
+          type: array
+        run_on:
+          enum:
+          - first
+          - second
+          - all
+          type: string
+      required:
+      - plugin
+  version: v1
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: kongconsumers.configuration.konghq.com
+spec:
+  additionalPrinterColumns:
+  - JSONPath: .username
+    description: Username of a Kong Consumer
+    name: Username
+    type: string
+  - JSONPath: .metadata.creationTimestamp
+    description: Age
+    name: Age
+    type: date
+  group: configuration.konghq.com
+  names:
+    kind: KongConsumer
+    plural: kongconsumers
+    shortNames:
+    - kc
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        credentials:
+          items:
+            type: string
+          type: array
+        custom_id:
+          type: string
+        username:
+          type: string
+  version: v1
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: kongingresses.configuration.konghq.com
+spec:
+  group: configuration.konghq.com
+  names:
+    kind: KongIngress
+    plural: kongingresses
+    shortNames:
+    - ki
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        proxy:
+          properties:
+            connect_timeout:
+              minimum: 0
+              type: integer
+            path:
+              pattern: ^/.*$
+              type: string
+            protocol:
+              enum:
+              - http
+              - https
+              - grpc
+              - grpcs
+              - tcp
+              - tls
+              type: string
+            read_timeout:
+              minimum: 0
+              type: integer
+            retries:
+              minimum: 0
+              type: integer
+            write_timeout:
+              minimum: 0
+              type: integer
+          type: object
+        route:
+          properties:
+            headers:
+              additionalProperties:
+                items:
+                  type: string
+                type: array
+              type: object
+            https_redirect_status_code:
+              type: integer
+            methods:
+              items:
+                type: string
+              type: array
+            path_handling:
+              enum:
+              - v0
+              - v1
+              type: string
+            preserve_host:
+              type: boolean
+            protocols:
+              items:
+                enum:
+                - http
+                - https
+                - grpc
+                - grpcs
+                - tcp
+                - tls
+                type: string
+              type: array
+            regex_priority:
+              type: integer
+            request_buffering:
+              type: boolean
+            response_buffering:
+              type: boolean
+            snis:
+              items:
+                type: string
+              type: array
+            strip_path:
+              type: boolean
+        upstream:
+          properties:
+            algorithm:
+              enum:
+              - round-robin
+              - consistent-hashing
+              - least-connections
+              type: string
+            hash_fallback:
+              type: string
+            hash_fallback_header:
+              type: string
+            hash_on:
+              type: string
+            hash_on_cookie:
+              type: string
+            hash_on_cookie_path:
+              type: string
+            hash_on_header:
+              type: string
+            healthchecks:
+              properties:
+                active:
+                  properties:
+                    concurrency:
+                      minimum: 1
+                      type: integer
+                    healthy:
+                      properties:
+                        http_statuses:
+                          items:
+                            type: integer
+                          type: array
+                        interval:
+                          minimum: 0
+                          type: integer
+                        successes:
+                          minimum: 0
+                          type: integer
+                      type: object
+                    http_path:
+                      pattern: ^/.*$
+                      type: string
+                    timeout:
+                      minimum: 0
+                      type: integer
+                    unhealthy:
+                      properties:
+                        http_failures:
+                          minimum: 0
+                          type: integer
+                        http_statuses:
+                          items:
+                            type: integer
+                          type: array
+                        interval:
+                          minimum: 0
+                          type: integer
+                        tcp_failures:
+                          minimum: 0
+                          type: integer
+                        timeout:
+                          minimum: 0
+                          type: integer
+                      type: object
+                  type: object
+                passive:
+                  properties:
+                    healthy:
+                      properties:
+                        http_statuses:
+                          items:
+                            type: integer
+                          type: array
+                        interval:
+                          minimum: 0
+                          type: integer
+                        successes:
+                          minimum: 0
+                          type: integer
+                      type: object
+                    unhealthy:
+                      properties:
+                        http_failures:
+                          minimum: 0
+                          type: integer
+                        http_statuses:
+                          items:
+                            type: integer
+                          type: array
+                        interval:
+                          minimum: 0
+                          type: integer
+                        tcp_failures:
+                          minimum: 0
+                          type: integer
+                        timeout:
+                          minimum: 0
+                          type: integer
+                      type: object
+                  type: object
+                threshold:
+                  type: integer
+              type: object
+            host_header:
+              type: string
+            slots:
+              minimum: 10
+              type: integer
+          type: object
+  version: v1
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: kongplugins.configuration.konghq.com
+spec:
+  additionalPrinterColumns:
+  - JSONPath: .plugin
+    description: Name of the plugin
+    name: Plugin-Type
+    type: string
+  - JSONPath: .metadata.creationTimestamp
+    description: Age
+    name: Age
+    type: date
+  - JSONPath: .disabled
+    description: Indicates if the plugin is disabled
+    name: Disabled
+    priority: 1
+    type: boolean
+  - JSONPath: .config
+    description: Configuration of the plugin
+    name: Config
+    priority: 1
+    type: string
+  group: configuration.konghq.com
+  names:
+    kind: KongPlugin
+    plural: kongplugins
+    shortNames:
+    - kp
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        config:
+          type: object
+        configFrom:
+          properties:
+            secretKeyRef:
+              properties:
+                key:
+                  type: string
+                name:
+                  type: string
+              required:
+              - name
+              - key
+              type: object
+          type: object
+        disabled:
+          type: boolean
+        plugin:
+          type: string
+        protocols:
+          items:
+            enum:
+            - http
+            - https
+            - grpc
+            - grpcs
+            - tcp
+            - tls
+            type: string
+          type: array
+        run_on:
+          enum:
+          - first
+          - second
+          - all
+          type: string
+      required:
+      - plugin
+  version: v1
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: tcpingresses.configuration.konghq.com
+spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.loadBalancer.ingress[*].ip
+    description: Address of the load balancer
+    name: Address
+    type: string
+  - JSONPath: .metadata.creationTimestamp
+    description: Age
+    name: Age
+    type: date
+  group: configuration.konghq.com
+  names:
+    kind: TCPIngress
+    plural: tcpingresses
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          type: string
+        kind:
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            rules:
+              items:
+                properties:
+                  backend:
+                    properties:
+                      serviceName:
+                        type: string
+                      servicePort:
+                        format: int32
+                        type: integer
+                    type: object
+                  host:
+                    type: string
+                  port:
+                    format: int32
+                    type: integer
+                type: object
+              type: array
+            tls:
+              items:
+                properties:
+                  hosts:
+                    items:
+                      type: string
+                    type: array
+                  secretName:
+                    type: string
+                type: object
+              type: array
+          type: object
+        status:
+          type: object
+  version: v1beta1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: kong-ingress-clusterrole
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - endpoints
+  - nodes
+  - pods
+  - secrets
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - networking.k8s.io
+  - extensions
+  - networking.internal.knative.dev
+  resources:
+  - ingresses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - networking.k8s.io
+  - extensions
+  - networking.internal.knative.dev
+  resources:
+  - ingresses/status
+  verbs:
+  - update
+- apiGroups:
+  - configuration.konghq.com
+  resources:
+  - tcpingresses/status
+  verbs:
+  - update
+- apiGroups:
+  - configuration.konghq.com
+  resources:
+  - kongplugins
+  - kongclusterplugins
+  - kongcredentials
+  - kongconsumers
+  - kongingresses
+  - tcpingresses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - create
+  - get
+  - update
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: kong-ingress-clusterrole-nisa-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kong-ingress-clusterrole
+subjects:
+- kind: ServiceAccount
+  name: kong-serviceaccount
+  namespace: kuma-gateway
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: kong-validation-webhook
+  namespace: kuma-gateway
+spec:
+  ports:
+  - name: webhook
+    port: 443
+    protocol: TCP
+    targetPort: 8080
+  selector:
+    app: ingress-kong
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    service.beta.kubernetes.io/aws-load-balancer-backend-protocol: tcp
+    service.beta.kubernetes.io/aws-load-balancer-type: nlb
+  name: kong-proxy
+  namespace: kuma-gateway
+spec:
+  ports:
+  - name: proxy
+    port: 80
+    protocol: TCP
+    targetPort: 8000
+  - name: proxy-ssl
+    port: 443
+    protocol: TCP
+    targetPort: 8443
+  selector:
+    app: ingress-kong
+  type: LoadBalancer
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: ingress-kong
+  name: ingress-kong
+  namespace: kuma-gateway
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: ingress-kong
+  template:
+    metadata:
+      annotations:
+        kuma.io/gateway: enabled
+        prometheus.io/port: "8100"
+        prometheus.io/scrape: "true"
+        traffic.sidecar.istio.io/includeInboundPorts: ""
+      labels:
+        app: ingress-kong
+    spec:
+      containers:
+      - env:
+        - name: KONG_PROXY_LISTEN
+          value: 0.0.0.0:8000, 0.0.0.0:8443 ssl http2
+        - name: KONG_PORT_MAPS
+          value: 80:8000, 443:8443
+        - name: KONG_ADMIN_LISTEN
+          value: 127.0.0.1:8444 ssl
+        - name: KONG_STATUS_LISTEN
+          value: 0.0.0.0:8100
+        - name: KONG_DATABASE
+          value: "off"
+        - name: KONG_NGINX_WORKER_PROCESSES
+          value: "2"
+        - name: KONG_ADMIN_ACCESS_LOG
+          value: /dev/stdout
+        - name: KONG_ADMIN_ERROR_LOG
+          value: /dev/stderr
+        - name: KONG_PROXY_ERROR_LOG
+          value: /dev/stderr
+        image: kong:2.3
+        lifecycle:
+          preStop:
+            exec:
+              command:
+              - /bin/sh
+              - -c
+              - kong quit
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /status
+            port: 8100
+            scheme: HTTP
+          initialDelaySeconds: 5
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 1
+        name: proxy
+        ports:
+        - containerPort: 8000
+          name: proxy
+          protocol: TCP
+        - containerPort: 8443
+          name: proxy-ssl
+          protocol: TCP
+        - containerPort: 8100
+          name: metrics
+          protocol: TCP
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /status
+            port: 8100
+            scheme: HTTP
+          initialDelaySeconds: 5
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 1
+      - env:
+        - name: CONTROLLER_KONG_ADMIN_URL
+          value: https://127.0.0.1:8444
+        - name: CONTROLLER_KONG_ADMIN_TLS_SKIP_VERIFY
+          value: "true"
+        - name: CONTROLLER_PUBLISH_SERVICE
+          value: kong/kong-proxy
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+        image: kong/kubernetes-ingress-controller:1.2
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz
+            port: 10254
+            scheme: HTTP
+          initialDelaySeconds: 5
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 1
+        name: ingress-controller
+        ports:
+        - containerPort: 8080
+          name: webhook
+          protocol: TCP
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz
+            port: 10254
+            scheme: HTTP
+          initialDelaySeconds: 5
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 1
+      serviceAccountName: kong-serviceaccount

--- a/app/kumactl/cmd/install/testdata/install-gateway.overrides.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-gateway.overrides.golden.yaml
@@ -4,11 +4,8 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: notdefault
----
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: notdefault
+  annotations:
+    kuma.io/sidecar-injection: enabled
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/app/kumactl/cmd/install/testdata/install-gateway.overrides.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-gateway.overrides.golden.yaml
@@ -1,0 +1,738 @@
+
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: notdefault
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: notdefault
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kong-serviceaccount
+  namespace: notdefault
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: kongclusterplugins.configuration.konghq.com
+spec:
+  additionalPrinterColumns:
+  - JSONPath: .plugin
+    description: Name of the plugin
+    name: Plugin-Type
+    type: string
+  - JSONPath: .metadata.creationTimestamp
+    description: Age
+    name: Age
+    type: date
+  - JSONPath: .disabled
+    description: Indicates if the plugin is disabled
+    name: Disabled
+    priority: 1
+    type: boolean
+  - JSONPath: .config
+    description: Configuration of the plugin
+    name: Config
+    priority: 1
+    type: string
+  group: configuration.konghq.com
+  names:
+    kind: KongClusterPlugin
+    plural: kongclusterplugins
+    shortNames:
+    - kcp
+  scope: Cluster
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        config:
+          type: object
+        configFrom:
+          properties:
+            secretKeyRef:
+              properties:
+                key:
+                  type: string
+                name:
+                  type: string
+                namespace:
+                  type: string
+              required:
+              - name
+              - namespace
+              - key
+              type: object
+          type: object
+        disabled:
+          type: boolean
+        plugin:
+          type: string
+        protocols:
+          items:
+            enum:
+            - http
+            - https
+            - grpc
+            - grpcs
+            - tcp
+            - tls
+            type: string
+          type: array
+        run_on:
+          enum:
+          - first
+          - second
+          - all
+          type: string
+      required:
+      - plugin
+  version: v1
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: kongconsumers.configuration.konghq.com
+spec:
+  additionalPrinterColumns:
+  - JSONPath: .username
+    description: Username of a Kong Consumer
+    name: Username
+    type: string
+  - JSONPath: .metadata.creationTimestamp
+    description: Age
+    name: Age
+    type: date
+  group: configuration.konghq.com
+  names:
+    kind: KongConsumer
+    plural: kongconsumers
+    shortNames:
+    - kc
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        credentials:
+          items:
+            type: string
+          type: array
+        custom_id:
+          type: string
+        username:
+          type: string
+  version: v1
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: kongingresses.configuration.konghq.com
+spec:
+  group: configuration.konghq.com
+  names:
+    kind: KongIngress
+    plural: kongingresses
+    shortNames:
+    - ki
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        proxy:
+          properties:
+            connect_timeout:
+              minimum: 0
+              type: integer
+            path:
+              pattern: ^/.*$
+              type: string
+            protocol:
+              enum:
+              - http
+              - https
+              - grpc
+              - grpcs
+              - tcp
+              - tls
+              type: string
+            read_timeout:
+              minimum: 0
+              type: integer
+            retries:
+              minimum: 0
+              type: integer
+            write_timeout:
+              minimum: 0
+              type: integer
+          type: object
+        route:
+          properties:
+            headers:
+              additionalProperties:
+                items:
+                  type: string
+                type: array
+              type: object
+            https_redirect_status_code:
+              type: integer
+            methods:
+              items:
+                type: string
+              type: array
+            path_handling:
+              enum:
+              - v0
+              - v1
+              type: string
+            preserve_host:
+              type: boolean
+            protocols:
+              items:
+                enum:
+                - http
+                - https
+                - grpc
+                - grpcs
+                - tcp
+                - tls
+                type: string
+              type: array
+            regex_priority:
+              type: integer
+            request_buffering:
+              type: boolean
+            response_buffering:
+              type: boolean
+            snis:
+              items:
+                type: string
+              type: array
+            strip_path:
+              type: boolean
+        upstream:
+          properties:
+            algorithm:
+              enum:
+              - round-robin
+              - consistent-hashing
+              - least-connections
+              type: string
+            hash_fallback:
+              type: string
+            hash_fallback_header:
+              type: string
+            hash_on:
+              type: string
+            hash_on_cookie:
+              type: string
+            hash_on_cookie_path:
+              type: string
+            hash_on_header:
+              type: string
+            healthchecks:
+              properties:
+                active:
+                  properties:
+                    concurrency:
+                      minimum: 1
+                      type: integer
+                    healthy:
+                      properties:
+                        http_statuses:
+                          items:
+                            type: integer
+                          type: array
+                        interval:
+                          minimum: 0
+                          type: integer
+                        successes:
+                          minimum: 0
+                          type: integer
+                      type: object
+                    http_path:
+                      pattern: ^/.*$
+                      type: string
+                    timeout:
+                      minimum: 0
+                      type: integer
+                    unhealthy:
+                      properties:
+                        http_failures:
+                          minimum: 0
+                          type: integer
+                        http_statuses:
+                          items:
+                            type: integer
+                          type: array
+                        interval:
+                          minimum: 0
+                          type: integer
+                        tcp_failures:
+                          minimum: 0
+                          type: integer
+                        timeout:
+                          minimum: 0
+                          type: integer
+                      type: object
+                  type: object
+                passive:
+                  properties:
+                    healthy:
+                      properties:
+                        http_statuses:
+                          items:
+                            type: integer
+                          type: array
+                        interval:
+                          minimum: 0
+                          type: integer
+                        successes:
+                          minimum: 0
+                          type: integer
+                      type: object
+                    unhealthy:
+                      properties:
+                        http_failures:
+                          minimum: 0
+                          type: integer
+                        http_statuses:
+                          items:
+                            type: integer
+                          type: array
+                        interval:
+                          minimum: 0
+                          type: integer
+                        tcp_failures:
+                          minimum: 0
+                          type: integer
+                        timeout:
+                          minimum: 0
+                          type: integer
+                      type: object
+                  type: object
+                threshold:
+                  type: integer
+              type: object
+            host_header:
+              type: string
+            slots:
+              minimum: 10
+              type: integer
+          type: object
+  version: v1
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: kongplugins.configuration.konghq.com
+spec:
+  additionalPrinterColumns:
+  - JSONPath: .plugin
+    description: Name of the plugin
+    name: Plugin-Type
+    type: string
+  - JSONPath: .metadata.creationTimestamp
+    description: Age
+    name: Age
+    type: date
+  - JSONPath: .disabled
+    description: Indicates if the plugin is disabled
+    name: Disabled
+    priority: 1
+    type: boolean
+  - JSONPath: .config
+    description: Configuration of the plugin
+    name: Config
+    priority: 1
+    type: string
+  group: configuration.konghq.com
+  names:
+    kind: KongPlugin
+    plural: kongplugins
+    shortNames:
+    - kp
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        config:
+          type: object
+        configFrom:
+          properties:
+            secretKeyRef:
+              properties:
+                key:
+                  type: string
+                name:
+                  type: string
+              required:
+              - name
+              - key
+              type: object
+          type: object
+        disabled:
+          type: boolean
+        plugin:
+          type: string
+        protocols:
+          items:
+            enum:
+            - http
+            - https
+            - grpc
+            - grpcs
+            - tcp
+            - tls
+            type: string
+          type: array
+        run_on:
+          enum:
+          - first
+          - second
+          - all
+          type: string
+      required:
+      - plugin
+  version: v1
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: tcpingresses.configuration.konghq.com
+spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.loadBalancer.ingress[*].ip
+    description: Address of the load balancer
+    name: Address
+    type: string
+  - JSONPath: .metadata.creationTimestamp
+    description: Age
+    name: Age
+    type: date
+  group: configuration.konghq.com
+  names:
+    kind: TCPIngress
+    plural: tcpingresses
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          type: string
+        kind:
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            rules:
+              items:
+                properties:
+                  backend:
+                    properties:
+                      serviceName:
+                        type: string
+                      servicePort:
+                        format: int32
+                        type: integer
+                    type: object
+                  host:
+                    type: string
+                  port:
+                    format: int32
+                    type: integer
+                type: object
+              type: array
+            tls:
+              items:
+                properties:
+                  hosts:
+                    items:
+                      type: string
+                    type: array
+                  secretName:
+                    type: string
+                type: object
+              type: array
+          type: object
+        status:
+          type: object
+  version: v1beta1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: kong-ingress-clusterrole
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - endpoints
+  - nodes
+  - pods
+  - secrets
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - networking.k8s.io
+  - extensions
+  - networking.internal.knative.dev
+  resources:
+  - ingresses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - networking.k8s.io
+  - extensions
+  - networking.internal.knative.dev
+  resources:
+  - ingresses/status
+  verbs:
+  - update
+- apiGroups:
+  - configuration.konghq.com
+  resources:
+  - tcpingresses/status
+  verbs:
+  - update
+- apiGroups:
+  - configuration.konghq.com
+  resources:
+  - kongplugins
+  - kongclusterplugins
+  - kongcredentials
+  - kongconsumers
+  - kongingresses
+  - tcpingresses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - create
+  - get
+  - update
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: kong-ingress-clusterrole-nisa-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kong-ingress-clusterrole
+subjects:
+- kind: ServiceAccount
+  name: kong-serviceaccount
+  namespace: notdefault
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: kong-validation-webhook
+  namespace: notdefault
+spec:
+  ports:
+  - name: webhook
+    port: 443
+    protocol: TCP
+    targetPort: 8080
+  selector:
+    app: ingress-kong
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    service.beta.kubernetes.io/aws-load-balancer-backend-protocol: tcp
+    service.beta.kubernetes.io/aws-load-balancer-type: nlb
+  name: kong-proxy
+  namespace: notdefault
+spec:
+  ports:
+  - name: proxy
+    port: 80
+    protocol: TCP
+    targetPort: 8000
+  - name: proxy-ssl
+    port: 443
+    protocol: TCP
+    targetPort: 8443
+  selector:
+    app: ingress-kong
+  type: LoadBalancer
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: ingress-kong
+  name: ingress-kong
+  namespace: notdefault
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: ingress-kong
+  template:
+    metadata:
+      annotations:
+        kuma.io/gateway: enabled
+        prometheus.io/port: "8100"
+        prometheus.io/scrape: "true"
+        traffic.sidecar.istio.io/includeInboundPorts: ""
+      labels:
+        app: ingress-kong
+    spec:
+      containers:
+      - env:
+        - name: KONG_PROXY_LISTEN
+          value: 0.0.0.0:8000, 0.0.0.0:8443 ssl http2
+        - name: KONG_PORT_MAPS
+          value: 80:8000, 443:8443
+        - name: KONG_ADMIN_LISTEN
+          value: 127.0.0.1:8444 ssl
+        - name: KONG_STATUS_LISTEN
+          value: 0.0.0.0:8100
+        - name: KONG_DATABASE
+          value: "off"
+        - name: KONG_NGINX_WORKER_PROCESSES
+          value: "2"
+        - name: KONG_ADMIN_ACCESS_LOG
+          value: /dev/stdout
+        - name: KONG_ADMIN_ERROR_LOG
+          value: /dev/stderr
+        - name: KONG_PROXY_ERROR_LOG
+          value: /dev/stderr
+        image: kong:2.3
+        lifecycle:
+          preStop:
+            exec:
+              command:
+              - /bin/sh
+              - -c
+              - kong quit
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /status
+            port: 8100
+            scheme: HTTP
+          initialDelaySeconds: 5
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 1
+        name: proxy
+        ports:
+        - containerPort: 8000
+          name: proxy
+          protocol: TCP
+        - containerPort: 8443
+          name: proxy-ssl
+          protocol: TCP
+        - containerPort: 8100
+          name: metrics
+          protocol: TCP
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /status
+            port: 8100
+            scheme: HTTP
+          initialDelaySeconds: 5
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 1
+      - env:
+        - name: CONTROLLER_KONG_ADMIN_URL
+          value: https://127.0.0.1:8444
+        - name: CONTROLLER_KONG_ADMIN_TLS_SKIP_VERIFY
+          value: "true"
+        - name: CONTROLLER_PUBLISH_SERVICE
+          value: kong/kong-proxy
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+        image: kong/kubernetes-ingress-controller:1.2
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz
+            port: 10254
+            scheme: HTTP
+          initialDelaySeconds: 5
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 1
+        name: ingress-controller
+        ports:
+        - containerPort: 8080
+          name: webhook
+          protocol: TCP
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz
+            port: 10254
+            scheme: HTTP
+          initialDelaySeconds: 5
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 1
+      serviceAccountName: kong-serviceaccount

--- a/app/kumactl/data/fs.go
+++ b/app/kumactl/data/fs.go
@@ -31,3 +31,11 @@ func InstallTracingFS() fs.FS {
 	}
 	return fsys
 }
+
+func InstallGatewayFS() fs.FS {
+	fsys, err := fs.Sub(InstallData, "install/k8s/gateway")
+	if err != nil {
+		panic(err)
+	}
+	return fsys
+}

--- a/app/kumactl/data/install/k8s/gateway/kong/kong.yaml
+++ b/app/kumactl/data/install/k8s/gateway/kong/kong.yaml
@@ -1,0 +1,731 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ .Namespace }}
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: kongclusterplugins.configuration.konghq.com
+spec:
+  additionalPrinterColumns:
+  - JSONPath: .plugin
+    description: Name of the plugin
+    name: Plugin-Type
+    type: string
+  - JSONPath: .metadata.creationTimestamp
+    description: Age
+    name: Age
+    type: date
+  - JSONPath: .disabled
+    description: Indicates if the plugin is disabled
+    name: Disabled
+    priority: 1
+    type: boolean
+  - JSONPath: .config
+    description: Configuration of the plugin
+    name: Config
+    priority: 1
+    type: string
+  group: configuration.konghq.com
+  names:
+    kind: KongClusterPlugin
+    plural: kongclusterplugins
+    shortNames:
+    - kcp
+  scope: Cluster
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        config:
+          type: object
+        configFrom:
+          properties:
+            secretKeyRef:
+              properties:
+                key:
+                  type: string
+                name:
+                  type: string
+                namespace:
+                  type: string
+              required:
+              - name
+              - namespace
+              - key
+              type: object
+          type: object
+        disabled:
+          type: boolean
+        plugin:
+          type: string
+        protocols:
+          items:
+            enum:
+            - http
+            - https
+            - grpc
+            - grpcs
+            - tcp
+            - tls
+            type: string
+          type: array
+        run_on:
+          enum:
+          - first
+          - second
+          - all
+          type: string
+      required:
+      - plugin
+  version: v1
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: kongconsumers.configuration.konghq.com
+spec:
+  additionalPrinterColumns:
+  - JSONPath: .username
+    description: Username of a Kong Consumer
+    name: Username
+    type: string
+  - JSONPath: .metadata.creationTimestamp
+    description: Age
+    name: Age
+    type: date
+  group: configuration.konghq.com
+  names:
+    kind: KongConsumer
+    plural: kongconsumers
+    shortNames:
+    - kc
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        credentials:
+          items:
+            type: string
+          type: array
+        custom_id:
+          type: string
+        username:
+          type: string
+  version: v1
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: kongingresses.configuration.konghq.com
+spec:
+  group: configuration.konghq.com
+  names:
+    kind: KongIngress
+    plural: kongingresses
+    shortNames:
+    - ki
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        proxy:
+          properties:
+            connect_timeout:
+              minimum: 0
+              type: integer
+            path:
+              pattern: ^/.*$
+              type: string
+            protocol:
+              enum:
+              - http
+              - https
+              - grpc
+              - grpcs
+              - tcp
+              - tls
+              type: string
+            read_timeout:
+              minimum: 0
+              type: integer
+            retries:
+              minimum: 0
+              type: integer
+            write_timeout:
+              minimum: 0
+              type: integer
+          type: object
+        route:
+          properties:
+            headers:
+              additionalProperties:
+                items:
+                  type: string
+                type: array
+              type: object
+            https_redirect_status_code:
+              type: integer
+            methods:
+              items:
+                type: string
+              type: array
+            path_handling:
+              enum:
+              - v0
+              - v1
+              type: string
+            preserve_host:
+              type: boolean
+            protocols:
+              items:
+                enum:
+                - http
+                - https
+                - grpc
+                - grpcs
+                - tcp
+                - tls
+                type: string
+              type: array
+            regex_priority:
+              type: integer
+            request_buffering:
+              type: boolean
+            response_buffering:
+              type: boolean
+            snis:
+              items:
+                type: string
+              type: array
+            strip_path:
+              type: boolean
+        upstream:
+          properties:
+            algorithm:
+              enum:
+              - round-robin
+              - consistent-hashing
+              - least-connections
+              type: string
+            hash_fallback:
+              type: string
+            hash_fallback_header:
+              type: string
+            hash_on:
+              type: string
+            hash_on_cookie:
+              type: string
+            hash_on_cookie_path:
+              type: string
+            hash_on_header:
+              type: string
+            healthchecks:
+              properties:
+                active:
+                  properties:
+                    concurrency:
+                      minimum: 1
+                      type: integer
+                    healthy:
+                      properties:
+                        http_statuses:
+                          items:
+                            type: integer
+                          type: array
+                        interval:
+                          minimum: 0
+                          type: integer
+                        successes:
+                          minimum: 0
+                          type: integer
+                      type: object
+                    http_path:
+                      pattern: ^/.*$
+                      type: string
+                    timeout:
+                      minimum: 0
+                      type: integer
+                    unhealthy:
+                      properties:
+                        http_failures:
+                          minimum: 0
+                          type: integer
+                        http_statuses:
+                          items:
+                            type: integer
+                          type: array
+                        interval:
+                          minimum: 0
+                          type: integer
+                        tcp_failures:
+                          minimum: 0
+                          type: integer
+                        timeout:
+                          minimum: 0
+                          type: integer
+                      type: object
+                  type: object
+                passive:
+                  properties:
+                    healthy:
+                      properties:
+                        http_statuses:
+                          items:
+                            type: integer
+                          type: array
+                        interval:
+                          minimum: 0
+                          type: integer
+                        successes:
+                          minimum: 0
+                          type: integer
+                      type: object
+                    unhealthy:
+                      properties:
+                        http_failures:
+                          minimum: 0
+                          type: integer
+                        http_statuses:
+                          items:
+                            type: integer
+                          type: array
+                        interval:
+                          minimum: 0
+                          type: integer
+                        tcp_failures:
+                          minimum: 0
+                          type: integer
+                        timeout:
+                          minimum: 0
+                          type: integer
+                      type: object
+                  type: object
+                threshold:
+                  type: integer
+              type: object
+            host_header:
+              type: string
+            slots:
+              minimum: 10
+              type: integer
+          type: object
+  version: v1
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: kongplugins.configuration.konghq.com
+spec:
+  additionalPrinterColumns:
+  - JSONPath: .plugin
+    description: Name of the plugin
+    name: Plugin-Type
+    type: string
+  - JSONPath: .metadata.creationTimestamp
+    description: Age
+    name: Age
+    type: date
+  - JSONPath: .disabled
+    description: Indicates if the plugin is disabled
+    name: Disabled
+    priority: 1
+    type: boolean
+  - JSONPath: .config
+    description: Configuration of the plugin
+    name: Config
+    priority: 1
+    type: string
+  group: configuration.konghq.com
+  names:
+    kind: KongPlugin
+    plural: kongplugins
+    shortNames:
+    - kp
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        config:
+          type: object
+        configFrom:
+          properties:
+            secretKeyRef:
+              properties:
+                key:
+                  type: string
+                name:
+                  type: string
+              required:
+              - name
+              - key
+              type: object
+          type: object
+        disabled:
+          type: boolean
+        plugin:
+          type: string
+        protocols:
+          items:
+            enum:
+            - http
+            - https
+            - grpc
+            - grpcs
+            - tcp
+            - tls
+            type: string
+          type: array
+        run_on:
+          enum:
+          - first
+          - second
+          - all
+          type: string
+      required:
+      - plugin
+  version: v1
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: tcpingresses.configuration.konghq.com
+spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.loadBalancer.ingress[*].ip
+    description: Address of the load balancer
+    name: Address
+    type: string
+  - JSONPath: .metadata.creationTimestamp
+    description: Age
+    name: Age
+    type: date
+  group: configuration.konghq.com
+  names:
+    kind: TCPIngress
+    plural: tcpingresses
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          type: string
+        kind:
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            rules:
+              items:
+                properties:
+                  backend:
+                    properties:
+                      serviceName:
+                        type: string
+                      servicePort:
+                        format: int32
+                        type: integer
+                    type: object
+                  host:
+                    type: string
+                  port:
+                    format: int32
+                    type: integer
+                type: object
+              type: array
+            tls:
+              items:
+                properties:
+                  hosts:
+                    items:
+                      type: string
+                    type: array
+                  secretName:
+                    type: string
+                type: object
+              type: array
+          type: object
+        status:
+          type: object
+  version: v1beta1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kong-serviceaccount
+  namespace: {{ .Namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: kong-ingress-clusterrole
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - endpoints
+  - nodes
+  - pods
+  - secrets
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - networking.k8s.io
+  - extensions
+  - networking.internal.knative.dev
+  resources:
+  - ingresses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - networking.k8s.io
+  - extensions
+  - networking.internal.knative.dev
+  resources:
+  - ingresses/status
+  verbs:
+  - update
+- apiGroups:
+  - configuration.konghq.com
+  resources:
+  - tcpingresses/status
+  verbs:
+  - update
+- apiGroups:
+  - configuration.konghq.com
+  resources:
+  - kongplugins
+  - kongclusterplugins
+  - kongcredentials
+  - kongconsumers
+  - kongingresses
+  - tcpingresses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - create
+  - get
+  - update
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: kong-ingress-clusterrole-nisa-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kong-ingress-clusterrole
+subjects:
+- kind: ServiceAccount
+  name: kong-serviceaccount
+  namespace: {{ .Namespace }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    service.beta.kubernetes.io/aws-load-balancer-backend-protocol: tcp
+    service.beta.kubernetes.io/aws-load-balancer-type: nlb
+  name: kong-proxy
+  namespace: {{ .Namespace }}
+spec:
+  ports:
+  - name: proxy
+    port: 80
+    protocol: TCP
+    targetPort: 8000
+  - name: proxy-ssl
+    port: 443
+    protocol: TCP
+    targetPort: 8443
+  selector:
+    app: ingress-kong
+  type: LoadBalancer
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: kong-validation-webhook
+  namespace: {{ .Namespace }}
+spec:
+  ports:
+  - name: webhook
+    port: 443
+    protocol: TCP
+    targetPort: 8080
+  selector:
+    app: ingress-kong
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: ingress-kong
+  name: ingress-kong
+  namespace: {{ .Namespace }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: ingress-kong
+  template:
+    metadata:
+      annotations:
+        kuma.io/gateway: enabled
+        prometheus.io/port: "8100"
+        prometheus.io/scrape: "true"
+        traffic.sidecar.istio.io/includeInboundPorts: ""
+      labels:
+        app: ingress-kong
+    spec:
+      containers:
+      - env:
+        - name: KONG_PROXY_LISTEN
+          value: 0.0.0.0:8000, 0.0.0.0:8443 ssl http2
+        - name: KONG_PORT_MAPS
+          value: 80:8000, 443:8443
+        - name: KONG_ADMIN_LISTEN
+          value: 127.0.0.1:8444 ssl
+        - name: KONG_STATUS_LISTEN
+          value: 0.0.0.0:8100
+        - name: KONG_DATABASE
+          value: "off"
+        - name: KONG_NGINX_WORKER_PROCESSES
+          value: "2"
+        - name: KONG_ADMIN_ACCESS_LOG
+          value: /dev/stdout
+        - name: KONG_ADMIN_ERROR_LOG
+          value: /dev/stderr
+        - name: KONG_PROXY_ERROR_LOG
+          value: /dev/stderr
+        image: kong:2.3
+        lifecycle:
+          preStop:
+            exec:
+              command:
+              - /bin/sh
+              - -c
+              - kong quit
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /status
+            port: 8100
+            scheme: HTTP
+          initialDelaySeconds: 5
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 1
+        name: proxy
+        ports:
+        - containerPort: 8000
+          name: proxy
+          protocol: TCP
+        - containerPort: 8443
+          name: proxy-ssl
+          protocol: TCP
+        - containerPort: 8100
+          name: metrics
+          protocol: TCP
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /status
+            port: 8100
+            scheme: HTTP
+          initialDelaySeconds: 5
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 1
+      - env:
+        - name: CONTROLLER_KONG_ADMIN_URL
+          value: https://127.0.0.1:8444
+        - name: CONTROLLER_KONG_ADMIN_TLS_SKIP_VERIFY
+          value: "true"
+        - name: CONTROLLER_PUBLISH_SERVICE
+          value: kong/kong-proxy
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+        image: kong/kubernetes-ingress-controller:1.2
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz
+            port: 10254
+            scheme: HTTP
+          initialDelaySeconds: 5
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 1
+        name: ingress-controller
+        ports:
+        - containerPort: 8080
+          name: webhook
+          protocol: TCP
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz
+            port: 10254
+            scheme: HTTP
+          initialDelaySeconds: 5
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 1
+      serviceAccountName: kong-serviceaccount

--- a/app/kumactl/data/install/k8s/gateway/kong/kong.yaml
+++ b/app/kumactl/data/install/k8s/gateway/kong/kong.yaml
@@ -2,6 +2,8 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: {{ .Namespace }}
+  annotations:
+    kuma.io/sidecar-injection: enabled
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition

--- a/app/kumactl/data/install/k8s/gateway/namespace.yaml
+++ b/app/kumactl/data/install/k8s/gateway/namespace.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ .Namespace }}
+

--- a/app/kumactl/data/install/k8s/gateway/namespace.yaml
+++ b/app/kumactl/data/install/k8s/gateway/namespace.yaml
@@ -1,6 +1,0 @@
----
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: {{ .Namespace }}
-

--- a/app/kumactl/pkg/cmd/root_context.go
+++ b/app/kumactl/pkg/cmd/root_context.go
@@ -52,6 +52,7 @@ type RootContext struct {
 	InstallCpContext      install_context.InstallCpContext
 	InstallMetricsContext install_context.InstallMetricsContext
 	InstallCRDContext     install_context.InstallCrdsContext
+	InstallGatewayContext install_context.InstallGatewayContext
 }
 
 func DefaultRootContext() *RootContext {
@@ -86,6 +87,7 @@ func DefaultRootContext() *RootContext {
 		InstallCpContext:      install_context.DefaultInstallCpContext(),
 		InstallCRDContext:     install_context.DefaultInstallCrdsContext(),
 		InstallMetricsContext: install_context.DefaultInstallMetricsContext(),
+		InstallGatewayContext: install_context.DefaultInstallGatewayContext(),
 	}
 }
 


### PR DESCRIPTION
### Summary

Add option to install an ingress gateway to kubernetes. Currently only supports Kong ingress, but takes type on command line.

`kumactl install gateway --type kong | kubectl apply -f -`

### Full changelog

* Add option to install an ingress gateway.
