### PR TITLE
fix(e2e) eks e2e tests docker registry fix + add option to manually trigger workflows

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -658,6 +658,11 @@ jobs:
 
   images:
     executor: remote-docker
+    parameters:
+      docker_registry:
+        description: "Registry for container images"
+        type: string
+        default: "docker.io/kumahq"
     steps:
     - checkout
     # Mount files from the upstream jobs
@@ -667,7 +672,9 @@ jobs:
         version: 19.03.12
     - run:
         name: Build Docker images
-        command: make docker/build
+        command: |
+          make docker/build \
+            DOCKER_REGISTRY="<< parameters.docker_registry >>"
     - run:
         name: Save Docker images into TAR archives
         command: make docker/save
@@ -957,6 +964,7 @@ workflows:
         <<: *master_workflow_filters
         requires:
         - build
+        docker_registry: ${ECR_REGISTRY}
     - eks-e2e:
         <<: *master_workflow_filters
         name: test/e2e/eks

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,6 +78,15 @@ reusable:
            - /^release-.*/
            - gh-pages
 
+parameters:
+  run_workflow_eks_e2e:
+    default: true
+    type: boolean
+
+  run_workflow_clean_eks:
+    default: true
+    type: boolean
+
 executors:
   golang:
     docker:
@@ -937,6 +946,7 @@ workflows:
 #        ipv6: true
 
   clean-eks:
+    when: << pipeline.parameters.run_workflow_clean_eks >>
     triggers:
     - schedule:
         # run cleanup everyday at 02:00 - it's the last resort for cleanup of
@@ -949,6 +959,7 @@ workflows:
     - eks-delete-clusters
 
   e2e-eks:
+    when: << pipeline.parameters.run_workflow_eks_e2e >>
     triggers:
     - schedule:
         # run every Monday at 00:00


### PR DESCRIPTION
### Summary

As there where changes related to moving away from bintray, which
was sunset, I had to adjust EKS e2e tests configuration, as there
were wrong docker images being tagged during the process, as there
was mismatch between images build jobs and EKS tests

According to CircleCI, currently the only option to manually
trigger the workflow is to add pipeline parameters with default
values set to true, which then let's you manually call the API
endpoint with parameters set according to needs.

ref:
https://support.circleci.com/hc/en-us/articles/360050351292-How-to-trigger-a-workflow-via-CircleCI-API-v2