### PR TITLE
fix(kuma-cp) use ipv4 when ipv4 and ipv6 are available

### DIFF
--- a/pkg/transparentproxy/istio/tools/istio-iptables/pkg/cmd/root.go
+++ b/pkg/transparentproxy/istio/tools/istio-iptables/pkg/cmd/root.go
@@ -121,13 +121,11 @@ func constructConfig() *config.Config {
 		cfg.ProxyGID = cfg.ProxyUID
 	}
 
-	// Kuma modification start
-	hasIPv6, err := hasLocalIPv6()
+	podIP, err := getLocalIP()
 	if err != nil {
 		panic(err)
 	}
-	cfg.EnableInboundIPv6 = hasIPv6
-	// Kuma modification end
+	cfg.EnableInboundIPv6 = podIP.To4() == nil
 
 	// Lookup DNS nameservers. We only do this if DNS is enabled in case of some obscure theoretical
 	// case where reading /etc/resolv.conf could fail.
@@ -159,23 +157,6 @@ func getLocalIP() (net.IP, error) {
 	}
 	return nil, fmt.Errorf("no valid local IP address found")
 }
-
-// Kuma modification start
-func hasLocalIPv6() (bool, error) {
-	addrs, err := net.InterfaceAddrs()
-	if err != nil {
-		return false, err
-	}
-
-	for _, a := range addrs {
-		if ipnet, ok := a.(*net.IPNet); ok && !ipnet.IP.IsLoopback() && ipnet.IP.To4() == nil {
-			return true, nil
-		}
-	}
-	return false, nil
-}
-
-// Kuma modification end
 
 func handleError(err error) {
 	handleErrorWithCode(err, 1)


### PR DESCRIPTION
### Summary

When doing demo, Jakub realized something was wrong and Kuma was
not working on Google's GKE with Kubernetes 1.19.9 and `kuma-init`
containers injected to demos' services were failing without
any logs or errors.

Everything was working fine on GKE with Kubernetes 1.18.x though,
so we realized containers in the newer versions have attached
both, IPv4 and IPv6 IP addresses.

After adding `--verbose` flag to `kuma-init` we found the message:
```
ip6tables-restore v1.8.4 (legacy): ip6tables-restore: unable to
initialize table 'nat'

Error occurred at line: 1
```

so it reassured me the problem is related to IPv6, when tried to
manually play with `ip6tables` it became clear to me that
something is wrong with kernel modules related to iptables for ipv6
and then I figured out that GKE is not supporting IPv6 at all,
even if network interfaces are receiving IPv6 addresses.

Because in our code, if after asking for IP address of network
interface, we would receive IPv6 address first, we were assuming
we can use IPv6.

I rolled back to the solution where we are asking for nic
IPv4 addresses and if there is none, but there is an address
assigned, we are assuming it has to be IPv6.

It means every time when there will be both - IPv4 and IPv6
available, we will be using IPv4 (unfortunately)

