### PR TITLE
ci(*) fix external services e2e tests

### DIFF
--- a/test/e2e/externalservices/externalservices_kubernetes.go
+++ b/test/e2e/externalservices/externalservices_kubernetes.go
@@ -39,28 +39,6 @@ spec:
       passthrough: %s
 `
 
-	trafficRoute := `
-apiVersion: kuma.io/v1alpha1
-kind: TrafficRoute
-mesh: default
-metadata:
-  name: rule-example
-  namespace: default
-spec:
-  sources:
-  - match:
-      kuma.io/service: "*"
-  destinations:
-  - match:
-      kuma.io/service: external-service
-  conf:
-    split:
-    - weight: 1
-      destination:
-        kuma.io/service: external-service
-        id: "%s"
-`
-
 	externalService := `
 apiVersion: kuma.io/v1alpha1
 kind: ExternalService
@@ -119,12 +97,6 @@ metadata:
 		Expect(err).ToNot(HaveOccurred())
 
 		err = YamlK8s(fmt.Sprintf(meshDefaulMtlsOn, "false"))(cluster)
-		Expect(err).ToNot(HaveOccurred())
-
-		err = YamlK8s(fmt.Sprintf(externalService,
-			es1, es1,
-			"externalservice-http-server.externalservice-namespace.svc.cluster.local", 10080,
-			"false"))(cluster)
 		Expect(err).ToNot(HaveOccurred())
 
 		pods, err := k8s.ListPodsE(
@@ -189,9 +161,6 @@ metadata:
 			"false"))(cluster)
 		Expect(err).ToNot(HaveOccurred())
 
-		err = YamlK8s(fmt.Sprintf(trafficRoute, es1))(cluster)
-		Expect(err).ToNot(HaveOccurred())
-
 		// then you can access external service again
 		stdout, stderr, err := cluster.ExecWithRetries(TestNamespace, clientPod.GetName(), "demo-client",
 			"curl", "-v", "-m", "3", "--fail", "http://externalservice-http-server.externalservice-namespace:10080")
@@ -220,9 +189,6 @@ metadata:
 			es2, es2,
 			"externalservice-https-server.externalservice-namespace.svc.cluster.local", 10080,
 			"true"))(cluster)
-		Expect(err).ToNot(HaveOccurred())
-
-		err = YamlK8s(fmt.Sprintf(trafficRoute, es2))(cluster)
 		Expect(err).ToNot(HaveOccurred())
 
 		stdout, stderr, err := cluster.ExecWithRetries(TestNamespace, clientPod.GetName(), "demo-client",

--- a/test/e2e/externalservices/externalservices_universal.go
+++ b/test/e2e/externalservices/externalservices_universal.go
@@ -31,23 +31,6 @@ networking:
     passthrough: false
 `
 
-	trafficRoute := `
-type: TrafficRoute
-name: route-example
-mesh: default
-sources:
-- match:
-   kuma.io/service: "*"
-destinations:
-- match:
-   kuma.io/service: external-service-%s
-conf:
-  split:
-  - weight: 1
-    destination:
-      kuma.io/service: external-service-%s
-`
-
 	externalService := `
 type: ExternalService
 mesh: default
@@ -97,15 +80,6 @@ networking:
 
 		err = YamlUniversal(meshDefaulMtlsOn)(cluster)
 		Expect(err).ToNot(HaveOccurred())
-
-		externalServiceAddress := externalservice.From(cluster, externalservice.HttpServer).GetExternalAppAddress()
-		Expect(externalServiceAddress).ToNot(BeEmpty())
-
-		err = YamlUniversal(fmt.Sprintf(externalService,
-			es1, es1,
-			"kuma-3_externalservice-http-server:80",
-			"false", ""))(cluster)
-		Expect(err).ToNot(HaveOccurred())
 	})
 
 	AfterEach(func() {
@@ -120,7 +94,10 @@ networking:
 	})
 
 	It("should route to external-service", func() {
-		err := YamlUniversal(fmt.Sprintf(trafficRoute, es1, es1))(cluster)
+		err := YamlUniversal(fmt.Sprintf(externalService,
+			es1, es1,
+			"kuma-3_externalservice-http-server:80",
+			"false", ""))(cluster)
 		Expect(err).ToNot(HaveOccurred())
 
 		stdout, _, err := cluster.ExecWithRetries("", "", "demo-client",
@@ -137,13 +114,9 @@ networking:
 	})
 
 	It("should route to external-service over tls", func() {
-		// set the route to the secured external service
-		err := YamlUniversal(fmt.Sprintf(trafficRoute, es2, es2))(cluster)
-		Expect(err).ToNot(HaveOccurred())
-
 		// when set invalid certificate
 		otherCert := "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURMRENDQWhTZ0F3SUJBZ0lRSGRQaHhPZlhnV3VOeG9GbFYvRXdxVEFOQmdrcWhraUc5dzBCQVFzRkFEQVAKTVEwd0N3WURWUVFERXdScmRXMWhNQjRYRFRJd01Ea3hOakV5TWpnME5Gb1hEVE13TURreE5ERXlNamcwTkZvdwpEekVOTUFzR0ExVUVBeE1FYTNWdFlUQ0NBU0l3RFFZSktvWklodmNOQVFFQkJRQURnZ0VQQURDQ0FRb0NnZ0VCCkFPWkdiV2hTbFFTUnhGTnQ1cC8yV0NLRnlIWjNDdXdOZ3lMRVA3blM0Wlh5a3hzRmJZU3VWM2JJZ0Y3YlQvdXEKYTVRaXJlK0M2MGd1aEZicExjUGgyWjZVZmdJZDY5R2xRekhNVlljbUxHalZRdXlBdDRGTU1rVGZWRWw1STRPYQorMml0M0J2aWhWa0toVXo4eTVSUjVLYnFKZkdwNFoyMEZoNmZ0dG9DRmJlT0RtdkJzWUpGbVVRUytpZm95TVkvClAzUjAzU3U3ZzVpSXZuejd0bWt5ZG9OQzhuR1JEemRENUM4Zkp2clZJMVVYNkpSR3lMS3Q0NW9RWHQxbXhLMTAKNUthTjJ6TlYyV3RIc2FKcDlid3JQSCtKaVpHZVp5dnVoNVV3ckxkSENtcUs3c205VG9kR3p0VVpZMFZ6QWM0cQprWVZpWFk4Z1VqZk5tK2NRclBPMWtOOENBd0VBQWFPQmd6Q0JnREFPQmdOVkhROEJBZjhFQkFNQ0FxUXdIUVlEClZSMGxCQll3RkFZSUt3WUJCUVVIQXdFR0NDc0dBUVVGQndNQk1BOEdBMVVkRXdFQi93UUZNQU1CQWY4d0hRWUQKVlIwT0JCWUVGR01EQlBQaUJGSjNtdjJvQTlDVHFqZW1GVFYyTUI4R0ExVWRFUVFZTUJhQ0NXeHZZMkZzYUc5egpkSUlKYkc5allXeG9iM04wTUEwR0NTcUdTSWIzRFFFQkN3VUFBNElCQVFDLzE3UXdlT3BHZGIxTUVCSjhYUEc3CjNzSy91dG9XTFgxdGpmOFN1MURnYTZDRFQvZVRXSFpyV1JmODFLT1ZZMDdkbGU1U1JJREsxUWhmYkdHdEZQK1QKdlprcm9vdXNJOVVTMmFDV2xrZUNaV0dUbnF2TG1Eb091anFhZ0RvS1JSdWs0bVFkdE5Ob254aUwvd1p0VEZLaQorMWlOalVWYkxXaURYZEJMeG9SSVZkTE96cWIvTU54d0VsVXlhVERBa29wUXlPV2FURGtZUHJHbWFXamNzZlBHCmFPS293MHplK3pIVkZxVEhiam5DcUVWM2huc1V5UlV3c0JsbjkrakRKWGd3Wk0vdE1sVkpyWkNoMFNsZTlZNVoKTU9CMGZDZjZzVE1OUlRHZzVMcGw2dUlZTS81SU5wbUhWTW8zbjdNQlNucEVEQVVTMmJmL3VvNWdJaXE2WENkcAotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg=="
-		err = YamlUniversal(fmt.Sprintf(externalService,
+		err := YamlUniversal(fmt.Sprintf(externalService,
 			es2, es2,
 			"kuma-3_externalservice-https-server:443",
 			"true",


### PR DESCRIPTION
### Summary

Since we introduced External Service E2E tests, they were periodically failing.

I took a quest to find what's wrong and here are my findings:

The problem is TrafficRoutes.

For `should route to external-service` traffic routes do not even do anything because we have only one external service so applying
```
type: TrafficRoute
name: route-example
mesh: default
sources:
- match:
   kuma.io/service: "*"
destinations:
- match:
   kuma.io/service: external-service-1
conf:
  split:
  - weight: 1
    destination:
      kuma.io/service: external-service-1
```
changes nothing and we can just skip applying this TrafficRoute.

The flow of `should route to external-service over tls` is that
1) Introduce a second external service which response over TLS
2) Apply TrafficRoute to shift the traffic from `external-service-1` to `external-service-2`
3) Send requests to see if traffic is shifted to a TLS'd service

The problem is between the 2nd and 3rd steps. The test assumes that the CP will propagate changes to DP in 0ms.

I tried to fix this, those were my ideas
* Wait for more than `KUMA_XDS_SERVER_DATAPLANE_CONFIGURATION_REFRESH_INTERVAL` - it's flaky. Eventually, there will be a slowdown and the test will be flaky
* Wait for XDS stat changes in DataplaneInsights - this approach is promising although we cannot have a guarantee that something else will not trigger the update. There is 10s latency of saving those changes. We would need to assert that first there are no changes for X seconds (30s?) than there is a change that is a result of applying our TrafficRoute. That's lots of waiting
* Check Envoy Admin of demo-client and try to scrape Envoy config and look that TCPProxy was configured with a proper cluster. This has a disadvantage in that we are depending on our tests on internal Envoy config conventions, but I think that's fairly ok. However, we have to build some decent DSL to browse through the Envoy Config in tests so we are not polluting tests with tens of lines and make them unreadable. This would take a while and I'd do this once we schedule a time to invest in E2E fundamentals.

For this PR I'm removing TrafficRoute in ExternalServices as I feel it does not bring that much value. We can bring this back if we introduce E2E suite for TrafficRoute and have a solution to how to detect changes in Envoy in a decent way.

### Documentation

- [X] No docs.
