### PR TITLE
feat(kuma-cp) TrafficPermission for ExternalServices

### DIFF
--- a/pkg/core/permissions/matcher_test.go
+++ b/pkg/core/permissions/matcher_test.go
@@ -179,4 +179,214 @@ var _ = Describe("Match", func() {
 			},
 		}),
 	)
+
+	Context("MatchExternalServices", func() {
+		type testCase struct {
+			dataplane        *core_mesh.DataplaneResource
+			policies         []*core_mesh.TrafficPermissionResource
+			externalServices []*core_mesh.ExternalServiceResource
+			expected         map[string]bool
+		}
+
+		DescribeTable("should find the policy",
+			func(given testCase) {
+				manager := core_manager.NewResourceManager(memory.NewStore())
+				matcher := permissions.TrafficPermissionsMatcher{ResourceManager: manager}
+
+				err := manager.Create(context.Background(), core_mesh.NewMeshResource(), store.CreateByKey(core_model.DefaultMesh, core_model.NoMesh))
+				Expect(err).ToNot(HaveOccurred())
+
+				for _, p := range given.policies {
+					err := manager.Create(context.Background(), p, store.CreateByKey(p.Meta.GetName(), "default"))
+					Expect(err).ToNot(HaveOccurred())
+				}
+
+				es := &core_mesh.ExternalServiceResourceList{
+					Items: given.externalServices,
+				}
+				matchedEs, err := matcher.MatchExternalServices(context.Background(), given.dataplane, es)
+				Expect(err).ToNot(HaveOccurred())
+
+				Expect(given.expected).To(HaveLen(len(matchedEs)))
+				for _, externalService := range matchedEs {
+					Expect(given.expected[externalService.GetMeta().GetName()]).To(BeTrue())
+				}
+			},
+			Entry("should match external services that matches traffic permission", testCase{
+				dataplane: &core_mesh.DataplaneResource{
+					Meta: &model.ResourceMeta{
+						Mesh: "default",
+						Name: "dp1",
+					},
+					Spec: &mesh_proto.Dataplane{
+						Networking: &mesh_proto.Dataplane_Networking{
+							Address: "192.168.0.1",
+							Inbound: []*mesh_proto.Dataplane_Networking_Inbound{
+								{
+									Port:        8080,
+									ServicePort: 8081,
+									Tags: map[string]string{
+										"kuma.io/service": "web",
+									},
+								},
+							},
+							Outbound: []*mesh_proto.Dataplane_Networking_Outbound{
+								{
+									Port: 8080,
+									Tags: map[string]string{
+										"kuma.io/service": "httpbin",
+									},
+								},
+							},
+						},
+					},
+				},
+				externalServices: []*core_mesh.ExternalServiceResource{
+					{
+						Meta: &model.ResourceMeta{
+							Mesh: "default",
+							Name: "httpbin",
+						},
+						Spec: &mesh_proto.ExternalService{
+							Tags: map[string]string{
+								"kuma.io/service": "httpbin",
+							},
+							Networking: &mesh_proto.ExternalService_Networking{
+								Address: "httpbin.org",
+							},
+						},
+					},
+					{ // this won't be matched since there is no traffic permission for it
+						Meta: &model.ResourceMeta{
+							Mesh: "default",
+							Name: "google",
+						},
+						Spec: &mesh_proto.ExternalService{
+							Tags: map[string]string{
+								"kuma.io/service": "google",
+							},
+							Networking: &mesh_proto.ExternalService_Networking{
+								Address: "google.com",
+							},
+						},
+					},
+				},
+				policies: []*core_mesh.TrafficPermissionResource{
+					{
+						Meta: &model.ResourceMeta{
+							Mesh: "default",
+							Name: "web-to-httpbin",
+						},
+						Spec: &mesh_proto.TrafficPermission{
+							Sources: []*mesh_proto.Selector{
+								{
+									Match: map[string]string{
+										"kuma.io/service": "web",
+									},
+								},
+							},
+							Destinations: []*mesh_proto.Selector{
+								{
+									Match: map[string]string{
+										"kuma.io/service": "httpbin",
+									},
+								},
+							},
+						},
+					},
+				},
+				expected: map[string]bool{
+					"httpbin": true,
+				},
+			}),
+			Entry("should match all external services because of the traffic permission that matches all", testCase{
+				dataplane: &core_mesh.DataplaneResource{
+					Meta: &model.ResourceMeta{
+						Mesh: "default",
+						Name: "dp1",
+					},
+					Spec: &mesh_proto.Dataplane{
+						Networking: &mesh_proto.Dataplane_Networking{
+							Address: "192.168.0.1",
+							Inbound: []*mesh_proto.Dataplane_Networking_Inbound{
+								{
+									Port:        8080,
+									ServicePort: 8081,
+									Tags: map[string]string{
+										"kuma.io/service": "web",
+									},
+								},
+							},
+							Outbound: []*mesh_proto.Dataplane_Networking_Outbound{
+								{
+									Port: 8080,
+									Tags: map[string]string{
+										"kuma.io/service": "httpbin",
+									},
+								},
+							},
+						},
+					},
+				},
+				externalServices: []*core_mesh.ExternalServiceResource{
+					{
+						Meta: &model.ResourceMeta{
+							Mesh: "default",
+							Name: "httpbin",
+						},
+						Spec: &mesh_proto.ExternalService{
+							Tags: map[string]string{
+								"kuma.io/service": "httpbin",
+							},
+							Networking: &mesh_proto.ExternalService_Networking{
+								Address: "httpbin.org",
+							},
+						},
+					},
+					{ // this won't be matched since there is no traffic permission for it
+						Meta: &model.ResourceMeta{
+							Mesh: "default",
+							Name: "google",
+						},
+						Spec: &mesh_proto.ExternalService{
+							Tags: map[string]string{
+								"kuma.io/service": "google",
+							},
+							Networking: &mesh_proto.ExternalService_Networking{
+								Address: "google.com",
+							},
+						},
+					},
+				},
+				policies: []*core_mesh.TrafficPermissionResource{
+					{
+						Meta: &model.ResourceMeta{
+							Mesh: "default",
+							Name: "all",
+						},
+						Spec: &mesh_proto.TrafficPermission{
+							Sources: []*mesh_proto.Selector{
+								{
+									Match: map[string]string{
+										"kuma.io/service": "*",
+									},
+								},
+							},
+							Destinations: []*mesh_proto.Selector{
+								{
+									Match: map[string]string{
+										"kuma.io/service": "*",
+									},
+								},
+							},
+						},
+					},
+				},
+				expected: map[string]bool{
+					"httpbin": true,
+					"google":  true,
+				},
+			}),
+		)
+	})
 })

--- a/pkg/xds/sync/dataplane_proxy_builder.go
+++ b/pkg/xds/sync/dataplane_proxy_builder.go
@@ -92,6 +92,11 @@ func (p *DataplaneProxyBuilder) resolveRouting(
 		return nil, nil, err
 	}
 
+	matchedExternalServices, err := p.PermissionMatcher.MatchExternalServices(ctx, dataplane, externalServices)
+	if err != nil {
+		return nil, nil, err
+	}
+
 	// pick a single the most specific route for each outbound interface
 	routes, err := xds_topology.GetRoutes(ctx, dataplane, p.CachingResManager)
 	if err != nil {
@@ -102,7 +107,7 @@ func (p *DataplaneProxyBuilder) resolveRouting(
 	destinations := xds_topology.BuildDestinationMap(dataplane, routes)
 
 	// resolve all endpoints that match given selectors
-	outbound := xds_topology.BuildEndpointMap(meshContext.Resource, p.Zone, meshContext.Dataplanes.Items, externalServices.Items, p.DataSourceLoader)
+	outbound := xds_topology.BuildEndpointMap(meshContext.Resource, p.Zone, meshContext.Dataplanes.Items, matchedExternalServices, p.DataSourceLoader)
 
 	routing := &xds.Routing{
 		TrafficRoutes:   routes,


### PR DESCRIPTION
### Summary

TrafficPermission support for ExternalServices.
With regular services we have a sidecar on both ends, so we execute traffic permission on the destination side.

With ExternalServcies there is no sidecar on the destination end, so we cannot apply the policy.
However, if we have Mesh passthrough false we control all the traffic (if traffic is unfamiliar to a mesh, we block it).

We can use this capability to use TrafficPermission with ExternalServices. This means that if you don't have TrafficPermission for a given ExternalService, we will omit this ExternalService when generating Envoy config.
Omitting a service will result as we don't have ExternalService defined at all meaning that the traffic is blocked.

### Implementation

Implementation was tricky because with regular services we just match inbound of the dataplane, because we are blocking incoming traffic. Here we want to block the outgoing traffic from the dataplane.
We cannot match outbound of the dataplane and remove it because we need to mimic the same behavior as the service was in the mesh.

If we were to match outbound, the following policies

```
type: TrafficPermission
name: backend-to-httpbin
mesh: default
sources:
  - match:
      kuma.io/service: 'backend'
destinations:
  - match:
      kuma.io/service: 'httpbin'
---
type: TrafficPermission
name: web-to-httpbin
mesh: default
sources:
  - match:
      kuma.io/service: 'web'
destinations:
  - match:
      kuma.io/service: 'httpbin'
```

Would allow the traffic from both backend and web to httpbin, but this is not consistent with the current behavior!
We want to match *the most specific* policy for httpbin as it was a service in the mesh.

To do this, in the XDS watchdog I take all external services and match them one by one with traffic permissions.
This operation is common for all dataplanes in the given mesh so we could cache this but I don't think this will be a bottleneck with the majority of cases.

### Breaking change

This is a breaking change in my opinion and it should be merged only to master because previously we did not require Traffic Permission to External Services, we do now.

### Documentation

- [ ] In progress
