### PR TITLE
ci(*) fix external services V2 E2E tests

### DIFF
--- a/test/e2e/externalservices/externalservices_multizone_universal.go
+++ b/test/e2e/externalservices/externalservices_multizone_universal.go
@@ -14,6 +14,11 @@ import (
 )
 
 func ExternalServicesOnMultizoneUniversal() {
+	if IsApiV2() {
+		fmt.Println("Test not supported on API v2")
+		return
+	}
+
 	meshDefaulMtlsOn := `
 type: Mesh
 name: default


### PR DESCRIPTION
External services multizone test is not compatible with V2 because of builtin DNS