### PR TITLE
feat(kuma-cp) add hostname when sending traces to the collector

### DIFF
--- a/pkg/xds/envoy/listeners/v3/tracing_configurer.go
+++ b/pkg/xds/envoy/listeners/v3/tracing_configurer.go
@@ -62,6 +62,7 @@ func zipkinConfig(cfgStr *structpb.Struct, backendName string) (*envoy_trace.Tra
 		TraceId_128Bit:           cfg.TraceId128Bit,
 		CollectorEndpointVersion: apiVersion(&cfg, url),
 		SharedSpanContext:        cfg.SharedSpanContext,
+		CollectorHostname:        url.Host,
 	}
 	zipkinConfigAny, err := proto.MarshalAnyDeterministic(&zipkinConfig)
 	if err != nil {

--- a/pkg/xds/envoy/listeners/v3/tracing_configurer_test.go
+++ b/pkg/xds/envoy/listeners/v3/tracing_configurer_test.go
@@ -72,6 +72,7 @@ var _ = Describe("TracingConfigurer", func() {
                         collectorCluster: tracing:zipkin
                         collectorEndpoint: /v2/spans
                         collectorEndpointVersion: HTTP_JSON
+                        collectorHostname: zipkin.us:9090
             name: inbound:192.168.0.1:8080
             trafficDirection: INBOUND`,
 		}),
@@ -104,6 +105,7 @@ var _ = Describe("TracingConfigurer", func() {
                         collectorCluster: tracing:zipkin
                         collectorEndpoint: /v2/spans
                         collectorEndpointVersion: HTTP_JSON
+                        collectorHostname: zipkin.us:9090
             name: inbound:192.168.0.1:8080
             trafficDirection: INBOUND`,
 		}),


### PR DESCRIPTION
### Summary

When traces are sent to a backend the hostname was static `tracing`. This change set the proper host header so when tracing backend is behind a load balancer, the load balancer can route it by the host header.

This setting is only available in V3.

### Documentation

- [X] No docs, internal changes.
