### PR TITLE
Fix/install gateway namespace

### DIFF
--- a/app/kumactl/cmd/install/testdata/install-gateway.defaults.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-gateway.defaults.golden.yaml
@@ -694,7 +694,7 @@ spec:
         - name: CONTROLLER_KONG_ADMIN_TLS_SKIP_VERIFY
           value: "true"
         - name: CONTROLLER_PUBLISH_SERVICE
-          value: kong/kong-proxy
+          value: kuma-gateway/kong-proxy
         - name: POD_NAME
           valueFrom:
             fieldRef:

--- a/app/kumactl/cmd/install/testdata/install-gateway.overrides.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-gateway.overrides.golden.yaml
@@ -694,7 +694,7 @@ spec:
         - name: CONTROLLER_KONG_ADMIN_TLS_SKIP_VERIFY
           value: "true"
         - name: CONTROLLER_PUBLISH_SERVICE
-          value: kong/kong-proxy
+          value: notdefault/kong-proxy
         - name: POD_NAME
           valueFrom:
             fieldRef:

--- a/app/kumactl/data/install/k8s/gateway/kong/kong.yaml
+++ b/app/kumactl/data/install/k8s/gateway/kong/kong.yaml
@@ -692,7 +692,7 @@ spec:
         - name: CONTROLLER_KONG_ADMIN_TLS_SKIP_VERIFY
           value: "true"
         - name: CONTROLLER_PUBLISH_SERVICE
-          value: kong/kong-proxy
+          value: {{ .Namespace }}/kong-proxy
         - name: POD_NAME
           valueFrom:
             fieldRef:


### PR DESCRIPTION
### Summary

Ingress install command had hard-coded "kong" namespace value for CONTROLLER_PUBLISH_SERVICE env var. Needs to be whatever namespace is specified.
