### PR TITLE
fix(kuma-cp): Fix bug in order of dataplane for ingress

### DIFF
--- a/pkg/xds/ingress/dataplane.go
+++ b/pkg/xds/ingress/dataplane.go
@@ -23,9 +23,11 @@ type serviceKey struct {
 
 type serviceKeySlice []serviceKey
 
-func (s serviceKeySlice) Len() int           { return len(s) }
-func (s serviceKeySlice) Less(i, j int) bool { return s[i].mesh < s[j].mesh || s[i].tags < s[j].tags }
-func (s serviceKeySlice) Swap(i, j int)      { s[i], s[j] = s[j], s[i] }
+func (s serviceKeySlice) Len() int { return len(s) }
+func (s serviceKeySlice) Less(i, j int) bool {
+	return s[i].mesh < s[j].mesh || (s[i].mesh == s[j].mesh && s[i].tags < s[j].tags)
+}
+func (s serviceKeySlice) Swap(i, j int) { s[i], s[j] = s[j], s[i] }
 
 func (sk *serviceKey) String() string {
 	return fmt.Sprintf("%s.%s", sk.tags, sk.mesh)


### PR DESCRIPTION
The wrong order was causing Ingresses to get regenerated when it
wasn't necessary

Signed-off-by: Charly Molter <charly@koyeb.com>