### PR TITLE
feat(conf) nodeselector across all pods with HELM

### DIFF
--- a/app/kumactl/cmd/install/testdata/install-control-plane.with-ingress.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.with-ingress.golden.yaml
@@ -861,6 +861,10 @@ spec:
         app: kuma-ingress
     spec:
       serviceAccountName: kuma-ingress
+      nodeSelector:
+      
+        kubernetes.io/arch: amd64
+        kubernetes.io/os: linux
       containers:
         - name: ingress
           image: "docker.io/kumahq/kuma-dp:0.0.1"

--- a/deployments/charts/kuma/README.md
+++ b/deployments/charts/kuma/README.md
@@ -68,7 +68,9 @@ A Helm chart for the Kuma Control Plane
 | ingress.service.annotations | object | `{}` | Additional annotations to put on the Ingress service |
 | ingress.service.port | int | `10001` | Port on which Ingress is exposed |
 | ingress.annotations | object | `{}` | Additional deployment annotation |
+| ingress.nodeSelector | object | `{"kubernetes.io/arch":"amd64","kubernetes.io/os":"linux"}` | Node Selector for the Ingress pods |
 | kumactl.image.repository | string | `"kumactl"` | The kumactl image repository |
+| hooks.nodeSelector | object | `{"kubernetes.io/arch":"amd64","kubernetes.io/os":"linux"}` | Node selector for the HELM hooks |
 
 ## Custom Resource Definitions
 

--- a/deployments/charts/kuma/templates/cp-rbac.yaml
+++ b/deployments/charts/kuma/templates/cp-rbac.yaml
@@ -122,7 +122,7 @@ rules:
       - dataplanes/finalizers
     verbs:
       - "*"
-  # validate k8s token before issueing mTLS cert
+  # validate k8s token before issuing mTLS cert
   - apiGroups:
       - authentication.k8s.io
     resources:

--- a/deployments/charts/kuma/templates/ingress-deployment.yaml
+++ b/deployments/charts/kuma/templates/ingress-deployment.yaml
@@ -32,6 +32,10 @@ spec:
         app: kuma-ingress
     spec:
       serviceAccountName: {{ include "kuma.name" . }}-ingress
+      {{- with .Values.ingress.nodeSelector }}
+      nodeSelector:
+      {{ toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: ingress
           image: {{ include "kuma.formatImage" (dict "image" .Values.dataPlane.image "root" $) | quote }}

--- a/deployments/charts/kuma/templates/pre-delete-webhooks.yaml
+++ b/deployments/charts/kuma/templates/pre-delete-webhooks.yaml
@@ -71,6 +71,10 @@ spec:
     {{ include "kuma.labels" . | nindent 8 }}
     spec:
       serviceAccountName: {{ $serviceAccountName }}
+      {{- with .Values.hooks.nodeSelector }}
+      nodeSelector:
+      {{ toYaml . | nindent 8 }}
+      {{- end }}
       restartPolicy: OnFailure
       containers:
         - name: pre-delete-job

--- a/deployments/charts/kuma/templates/pre-install-patch-namespace-job.yaml
+++ b/deployments/charts/kuma/templates/pre-install-patch-namespace-job.yaml
@@ -72,6 +72,10 @@ spec:
     {{ include "kuma.labels" . | nindent 8 }}
     spec:
       serviceAccountName: {{ $serviceAccountName }}
+      {{- with .Values.hooks.nodeSelector }}
+      nodeSelector:
+      {{ toYaml . | nindent 8 }}
+      {{- end }}
       restartPolicy: OnFailure
       containers:
         - name: pre-install-job

--- a/deployments/charts/kuma/templates/pre-upgrade-install-missing-crds-job.yaml
+++ b/deployments/charts/kuma/templates/pre-upgrade-install-missing-crds-job.yaml
@@ -105,6 +105,10 @@ spec:
     {{ include "kuma.labels" . | nindent 8 }}
     spec:
       serviceAccountName: {{ $serviceAccountName }}
+      {{- with .Values.hooks.nodeSelector }}
+      nodeSelector:
+      {{ toYaml . | nindent 8 }}
+      {{- end }}
       restartPolicy: OnFailure
       containers:
         - name: pre-upgrade-job

--- a/deployments/charts/kuma/values.yaml
+++ b/deployments/charts/kuma/values.yaml
@@ -186,8 +186,18 @@ ingress:
     port: 10001
   # -- Additional deployment annotation
   annotations: {}
+  # -- Node Selector for the Ingress pods
+  nodeSelector:
+    kubernetes.io/os: linux
+    kubernetes.io/arch: amd64
 
 kumactl:
   image:
     # -- The kumactl image repository
     repository: kumactl
+
+hooks:
+  # -- Node selector for the HELM hooks
+  nodeSelector:
+    kubernetes.io/os: linux
+    kubernetes.io/arch: amd64


### PR DESCRIPTION
### Summary

Added node selectors to Ingress and HELM hooks. There was already setting to CP and CNI.

### Documentation

- [X] There are new entries in HELM readme

### Testing

- [X] Unit tests
- [X] E2E tests - we already deploy HELM in E2E tests
- [X] Manual testing on Universal - no tests, K8S only
- [X] Manual testing on Kubernetes
