### PR TITLE
fix(test) add missing option WithIPv6 when deploy test-server

### DIFF
--- a/test/framework/setup.go
+++ b/test/framework/setup.go
@@ -429,7 +429,8 @@ networking:
 			WithAppname("test-server"),
 			WithToken(token),
 			WithArgs(args),
-			WithYaml(appYaml))
+			WithYaml(appYaml),
+			WithIPv6(IsIPv6()))
 		return cluster.DeployApp(fs...)
 	}
 }


### PR DESCRIPTION
### Summary

Add missing option WithIPv6 when deploy test-server

### Full changelog

* [Implement ...]
* [Fix ...]

### Issues resolved

Fix #XXX

### Documentation

- [ ] Link to the website [documentation PR](https://github.com/kumahq/kuma-website/pull/XXX)

### Testing

- [ ] Unit tests
- [ ] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes 
