### PR TITLE
fix(kuma-cp) clear snapshot on mTLS disable

### DIFF
--- a/pkg/sds/server/v2/reconciler.go
+++ b/pkg/sds/server/v2/reconciler.go
@@ -66,7 +66,9 @@ func (d *DataplaneReconciler) Reconcile(dataplaneId core_model.ResourceKey) erro
 	if err := d.readOnlyResManager.Get(context.Background(), dataplane, core_store.GetBy(dataplaneId)); err != nil {
 		if core_store.IsResourceNotFound(err) {
 			sdsServerLog.V(1).Info("Dataplane not found. Clearing the Snapshot.", "dataplaneId", dataplaneId)
-			d.cache.ClearSnapshot(proxyID)
+			if err := d.Cleanup(dataplaneId); err != nil {
+				return errors.Wrap(err, "could not cleanup snapshot")
+			}
 			return nil
 		}
 		return err
@@ -79,7 +81,9 @@ func (d *DataplaneReconciler) Reconcile(dataplaneId core_model.ResourceKey) erro
 
 	if !mesh.MTLSEnabled() {
 		sdsServerLog.V(1).Info("mTLS for Mesh disabled. Clearing the Snapshot.", "dataplaneId", dataplaneId)
-		d.cache.ClearSnapshot(proxyID)
+		if err := d.Cleanup(dataplaneId); err != nil {
+			return errors.Wrap(err, "could not cleanup snapshot")
+		}
 		return nil
 	}
 

--- a/pkg/sds/server/v2/server.go
+++ b/pkg/sds/server/v2/server.go
@@ -76,6 +76,7 @@ func syncTracker(reconciler *DataplaneReconciler, refresh time.Duration, sdsMetr
 	return xds_callbacks.NewDataplaneSyncTracker(func(dataplaneId core_model.ResourceKey, streamId int64) util_watchdog.Watchdog {
 		return &util_watchdog.SimpleWatchdog{
 			NewTicker: func() *time.Ticker {
+				sdsMetrics.IncrementActiveWatchdogs(envoy_common.APIV2)
 				return time.NewTicker(refresh)
 			},
 			OnTick: func() error {
@@ -93,6 +94,7 @@ func syncTracker(reconciler *DataplaneReconciler, refresh time.Duration, sdsMetr
 				if err := reconciler.Cleanup(dataplaneId); err != nil {
 					sdsServerLog.Error(err, "could not cleanup sync", "dataplane", dataplaneId)
 				}
+				sdsMetrics.DecrementActiveWatchdogs(envoy_common.APIV2)
 			},
 		}
 	}), nil

--- a/pkg/sds/server/v3/reconciler.go
+++ b/pkg/sds/server/v3/reconciler.go
@@ -66,7 +66,9 @@ func (d *DataplaneReconciler) Reconcile(dataplaneId core_model.ResourceKey) erro
 	if err := d.readOnlyResManager.Get(context.Background(), dataplane, core_store.GetBy(dataplaneId)); err != nil {
 		if core_store.IsResourceNotFound(err) {
 			sdsServerLog.V(1).Info("Dataplane not found. Clearing the Snapshot.", "dataplaneId", dataplaneId)
-			d.cache.ClearSnapshot(proxyID)
+			if err := d.Cleanup(dataplaneId); err != nil {
+				return errors.Wrap(err, "could not cleanup snapshot")
+			}
 			return nil
 		}
 		return err
@@ -79,7 +81,9 @@ func (d *DataplaneReconciler) Reconcile(dataplaneId core_model.ResourceKey) erro
 
 	if !mesh.MTLSEnabled() {
 		sdsServerLog.V(1).Info("mTLS for Mesh disabled. Clearing the Snapshot.", "dataplaneId", dataplaneId)
-		d.cache.ClearSnapshot(proxyID)
+		if err := d.Cleanup(dataplaneId); err != nil {
+			return errors.Wrap(err, "could not cleanup snapshot")
+		}
 		return nil
 	}
 

--- a/pkg/sds/server/v3/server.go
+++ b/pkg/sds/server/v3/server.go
@@ -76,6 +76,7 @@ func syncTracker(reconciler *DataplaneReconciler, refresh time.Duration, sdsMetr
 	return xds_callbacks.NewDataplaneSyncTracker(func(dataplaneId core_model.ResourceKey, streamId int64) util_watchdog.Watchdog {
 		return &util_watchdog.SimpleWatchdog{
 			NewTicker: func() *time.Ticker {
+				sdsMetrics.IncrementActiveWatchdogs(envoy_common.APIV3)
 				return time.NewTicker(refresh)
 			},
 			OnTick: func() error {
@@ -93,6 +94,7 @@ func syncTracker(reconciler *DataplaneReconciler, refresh time.Duration, sdsMetr
 				if err := reconciler.Cleanup(dataplaneId); err != nil {
 					sdsServerLog.Error(err, "could not cleanup sync", "dataplane", dataplaneId)
 				}
+				sdsMetrics.DecrementActiveWatchdogs(envoy_common.APIV3)
 			},
 		}
 	}), nil

--- a/pkg/sds/server/v3/server_test.go
+++ b/pkg/sds/server/v3/server_test.go
@@ -169,10 +169,15 @@ var _ = Describe("SDS Server", func() {
 	})
 
 	BeforeEach(func() {
+		// make sure no insight is present
 		err := resManager.Delete(context.Background(), mesh_core.NewDataplaneInsightResource(), core_store.DeleteByKey("backend-01", "default"))
 		if !core_store.IsResourceNotFound(err) {
 			Expect(err).ToNot(HaveOccurred())
 		}
+		// and no watchdog is running
+		Eventually(func() float64 {
+			return test_metrics.FindMetric(metrics, "sds_watchdogs").GetGauge().GetValue()
+		}, "30s").Should(Equal(0.0))
 	})
 
 	newRequestForSecrets := func() envoy_discovery.DiscoveryRequest {
@@ -231,6 +236,9 @@ var _ = Describe("SDS Server", func() {
 		Eventually(func() *prometheus_client.Metric {
 			return test_metrics.FindMetric(metrics, "sds_generation")
 		}, "5s").ShouldNot(BeNil())
+		Eventually(func() float64 {
+			return test_metrics.FindMetric(metrics, "sds_watchdogs").GetGauge().GetValue()
+		}, "5s").Should(Equal(1.0))
 
 		close(done)
 	}, 60)
@@ -258,6 +266,11 @@ var _ = Describe("SDS Server", func() {
 			Expect(resp).ToNot(BeNil())
 			Expect(resp.Resources).To(HaveLen(2))
 			firstExchangeResponse = resp
+
+			// and wait for the insight
+			Eventually(func() error {
+				return resManager.Get(context.Background(), mesh_core.NewDataplaneInsightResource(), core_store.GetByKey("backend-01", "default"))
+			}, "30s", "1s").ShouldNot(HaveOccurred())
 			close(done)
 		}, 60)
 


### PR DESCRIPTION
### Summary

As a follow-up to a previous PR. We should also clear snapshot when mTLS is disabled, otherwise, we can delete watches.

### Documentation

- No docs, internal fixes

### Testing

- [X] Unit tests
- [X] E2E tests - mTLS still works
- [X] Manual testing on Universal
- [X] Manual testing on Kubernetes 
