### PR TITLE
tests(*) add universal multizone resilience tests

### DIFF
--- a/test/e2e/resilience/resilience_multizone_universal.go
+++ b/test/e2e/resilience/resilience_multizone_universal.go
@@ -67,7 +67,7 @@ func ResilienceMultizoneUniversal() {
 				return err
 			}
 
-			if ! strings.Contains(output, "Online") {
+			if !strings.Contains(output, "Online") {
 				return errors.New("remote zone is not online")
 			}
 
@@ -83,7 +83,7 @@ func ResilienceMultizoneUniversal() {
 				return err
 			}
 
-			if ! strings.Contains(output, "Offline") {
+			if !strings.Contains(output, "Offline") {
 				return errors.New("remote zone is not offline")
 			}
 

--- a/test/e2e/resilience/resilience_multizone_universal.go
+++ b/test/e2e/resilience/resilience_multizone_universal.go
@@ -1,0 +1,93 @@
+package resilience
+
+import (
+	"errors"
+	"strings"
+
+	"github.com/kumahq/kuma/pkg/config/core"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	. "github.com/kumahq/kuma/test/framework"
+)
+
+func ResilienceMultizoneUniversal() {
+	var global, remote_1 Cluster
+	var optsGlobal, optsRemote1 []DeployOptionsFunc
+
+	BeforeEach(func() {
+		clusters, err := NewUniversalClusters(
+			[]string{Kuma1, Kuma2},
+			Silent)
+		Expect(err).ToNot(HaveOccurred())
+
+		// Global
+		global = clusters.GetCluster(Kuma1)
+		optsGlobal = []DeployOptionsFunc{}
+		err = NewClusterSetup().
+			Install(Kuma(core.Global, optsGlobal...)).
+			Setup(global)
+		Expect(err).ToNot(HaveOccurred())
+		err = global.VerifyKuma()
+		Expect(err).ToNot(HaveOccurred())
+
+		globalCP := global.GetKuma()
+
+		// Cluster 1
+		remote_1 = clusters.GetCluster(Kuma2)
+		optsRemote1 = []DeployOptionsFunc{
+			WithGlobalAddress(globalCP.GetKDSServerAddress()),
+		}
+
+		err = NewClusterSetup().
+			Install(Kuma(core.Remote, optsRemote1...)).
+			Setup(remote_1)
+		Expect(err).ToNot(HaveOccurred())
+		err = remote_1.VerifyKuma()
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	E2EAfterEach(func() {
+		err := remote_1.DeleteKuma(optsRemote1...)
+		Expect(err).ToNot(HaveOccurred())
+		err = remote_1.DismissCluster()
+		Expect(err).ToNot(HaveOccurred())
+
+		err = global.DeleteKuma(optsGlobal...)
+		Expect(err).ToNot(HaveOccurred())
+		err = global.DismissCluster()
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	It("should mark zone as offline after remote control-plane is killed forcefully", func() {
+		Eventually(func() error {
+			output, err := global.GetKumactlOptions().RunKumactlAndGetOutput("inspect", "zones")
+			if err != nil {
+				return err
+			}
+
+			if ! strings.Contains(output, "Online") {
+				return errors.New("remote zone is not online")
+			}
+
+			return nil
+		}, "30s", "1s").ShouldNot(HaveOccurred())
+
+		_, _, err := remote_1.Exec("", "", AppModeCP, "pkill", "-9", "kuma-cp")
+		Expect(err).ToNot(HaveOccurred())
+
+		Eventually(func() error {
+			output, err := global.GetKumactlOptions().RunKumactlAndGetOutput("inspect", "zones")
+			if err != nil {
+				return err
+			}
+
+			if ! strings.Contains(output, "Offline") {
+				return errors.New("remote zone is not offline")
+			}
+
+			return nil
+		}, "30s", "1s").ShouldNot(HaveOccurred())
+	})
+}

--- a/test/e2e/resilience/resilience_multizone_universal_test.go
+++ b/test/e2e/resilience/resilience_multizone_universal_test.go
@@ -1,0 +1,9 @@
+package resilience_test
+
+import (
+	"github.com/kumahq/kuma/test/e2e/resilience"
+
+	. "github.com/onsi/ginkgo"
+)
+
+var _ = Describe("Test Multizone Resilience for Universal", resilience.ResilienceMultizoneUniversal)

--- a/test/e2e/resilience/resilience_suite_test.go
+++ b/test/e2e/resilience/resilience_suite_test.go
@@ -15,7 +15,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-func TestE2EExternalServices(t *testing.T) {
+func TestE2EResilience(t *testing.T) {
 	if framework.IsK8sClustersStarted() {
 		RegisterFailHandler(Fail)
 		RunSpecs(t, "Resilience tests")

--- a/test/e2e/resilience/resilience_suite_test.go
+++ b/test/e2e/resilience/resilience_suite_test.go
@@ -1,0 +1,30 @@
+package resilience_test
+
+import (
+	"testing"
+
+	"github.com/kumahq/kuma/test/framework"
+
+	"github.com/go-logr/logr"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+
+	"github.com/kumahq/kuma/pkg/core"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestE2EExternalServices(t *testing.T) {
+	if framework.IsK8sClustersStarted() {
+		RegisterFailHandler(Fail)
+		RunSpecs(t, "Resilience tests")
+	} else {
+		t.SkipNow()
+	}
+}
+
+var _ = BeforeSuite(func() {
+	core.SetLogger = func(l logr.Logger) {}
+	logf.SetLogger(zap.LoggerTo(GinkgoWriter, true))
+})


### PR DESCRIPTION
Add test for universal multizone (both - global and remote zones
are universal) when we will forcefully kill remote control-plane