### PR TITLE
fix(test) disable builtin dns for tests

### DIFF
--- a/test/e2e/healthcheck/universal/policy_http.go
+++ b/test/e2e/healthcheck/universal/policy_http.go
@@ -12,6 +12,10 @@ import (
 )
 
 func PolicyHTTP() {
+	if IsApiV2() {
+		fmt.Println("Test not supported on API v2")
+		return
+	}
 	healthCheck := func(method, status string) string {
 		return fmt.Sprintf(`
 type: HealthCheck
@@ -58,7 +62,8 @@ conf:
 		testServerToken, err := cluster.GetKuma().GenerateDpToken("default", "test-server")
 		Expect(err).ToNot(HaveOccurred())
 
-		err = DemoClientUniversal("dp-demo-client", "default", demoClientToken, WithTransparentProxy(true))(cluster)
+		err = DemoClientUniversal("dp-demo-client", "default", demoClientToken,
+			WithTransparentProxy(true), WithBuiltinDNS(true))(cluster)
 		Expect(err).ToNot(HaveOccurred())
 		err = TestServerUniversal("test-server", "default", testServerToken,
 			WithTransparentProxy(true), WithProtocol("http"))(cluster)

--- a/test/e2e/healthcheck/universal/policy_http.go
+++ b/test/e2e/healthcheck/universal/policy_http.go
@@ -58,8 +58,7 @@ conf:
 		testServerToken, err := cluster.GetKuma().GenerateDpToken("default", "test-server")
 		Expect(err).ToNot(HaveOccurred())
 
-		err = DemoClientUniversal("dp-demo-client", "default", demoClientToken,
-			WithTransparentProxy(true), WithBuiltinDNS(true))(cluster)
+		err = DemoClientUniversal("dp-demo-client", "default", demoClientToken, WithTransparentProxy(true))(cluster)
 		Expect(err).ToNot(HaveOccurred())
 		err = TestServerUniversal("test-server", "default", testServerToken,
 			WithTransparentProxy(true), WithProtocol("http"))(cluster)

--- a/test/e2e/healthcheck/universal/policy_tcp.go
+++ b/test/e2e/healthcheck/universal/policy_tcp.go
@@ -62,8 +62,7 @@ conf:
 		testServerToken, err := cluster.GetKuma().GenerateDpToken("default", "test-server")
 		Expect(err).ToNot(HaveOccurred())
 
-		err = DemoClientUniversal("dp-demo-client", "default", demoClientToken,
-			WithTransparentProxy(true), WithBuiltinDNS(true))(cluster)
+		err = DemoClientUniversal("dp-demo-client", "default", demoClientToken, WithTransparentProxy(true))(cluster)
 		Expect(err).ToNot(HaveOccurred())
 		err = TestServerUniversal("test-server", "default", testServerToken,
 			WithTransparentProxy(true), WithProtocol("tcp"))(cluster)
@@ -101,8 +100,7 @@ conf:
 
 		// check that test-server is unhealthy
 		cmd = []string{"/bin/bash", "-c", "\"echo request | nc test-server.mesh 80\""}
-		stdout, _, err = cluster.ExecWithRetries("", "", "dp-demo-client", cmd...)
-		Expect(err).ToNot(HaveOccurred())
+		stdout, _, _ = cluster.ExecWithRetries("", "", "dp-demo-client", cmd...)
 		Expect(stdout).To(BeEmpty())
 	})
 }

--- a/test/e2e/healthcheck/universal/policy_tcp.go
+++ b/test/e2e/healthcheck/universal/policy_tcp.go
@@ -13,6 +13,10 @@ import (
 )
 
 func PolicyTCP() {
+	if IsApiV2() {
+		fmt.Println("Test not supported on API v2")
+		return
+	}
 	healthCheck := func(send, recv string) string {
 		sendBase64 := base64.StdEncoding.EncodeToString([]byte(send))
 		recvBase64 := base64.StdEncoding.EncodeToString([]byte(recv))
@@ -62,7 +66,8 @@ conf:
 		testServerToken, err := cluster.GetKuma().GenerateDpToken("default", "test-server")
 		Expect(err).ToNot(HaveOccurred())
 
-		err = DemoClientUniversal("dp-demo-client", "default", demoClientToken, WithTransparentProxy(true))(cluster)
+		err = DemoClientUniversal("dp-demo-client", "default", demoClientToken,
+			WithTransparentProxy(true), WithBuiltinDNS(true))(cluster)
 		Expect(err).ToNot(HaveOccurred())
 		err = TestServerUniversal("test-server", "default", testServerToken,
 			WithTransparentProxy(true), WithProtocol("tcp"))(cluster)

--- a/test/e2e/healthcheck/universal/policy_tcp.go
+++ b/test/e2e/healthcheck/universal/policy_tcp.go
@@ -106,6 +106,9 @@ conf:
 		// check that test-server is unhealthy
 		cmd = []string{"/bin/bash", "-c", "\"echo request | nc test-server.mesh 80\""}
 		stdout, _, _ = cluster.ExecWithRetries("", "", "dp-demo-client", cmd...)
-		Expect(stdout).To(BeEmpty())
+
+		// there is no real attempt to setup a connection with test-server, but Envoy may return either
+		// empty response with EXIT_CODE = 0, or  'Ncat: Connection reset by peer.' with EXIT_CODE = 1
+		Expect(stdout).To(Or(BeEmpty(), ContainSubstring("Ncat: Connection reset by peer.")))
 	})
 }


### PR DESCRIPTION
### Summary

* `WithBuiltinDNS` doesn't work with V2, so get rid of this flag for health check tests. 
* when the host becomes unhealthy there is one more check to make sure requests won't work:

    ```go
    stdout, _, err = cluster.ExecWithRetries("", "", "dp-demo-client", "/bin/bash", "-c", "\"echo request | nc test-server.mesh 80\"")
    Expect(err).ToNot(HaveOccurred())
    Expect(stdout).To(BeEmpty())
    ```
    There is no traffic indeed, but sometimes `ExecWithRetries` returns `err` which is not `nil`. I dropped the error check and left only `stdout` check.

### Full changelog

* [Implement ...]
* [Fix ...]

### Issues resolved

Fix #XXX

### Documentation

- [ ] Link to the website [documentation PR](https://github.com/kumahq/kuma-website/pull/XXX)

### Testing

- [ ] Unit tests
- [ ] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes 
