### PR TITLE
chore(test) stop using the Ginkgo Done type

### DIFF
--- a/app/kuma-cp/cmd/cmd_k8s_test.go
+++ b/app/kuma-cp/cmd/cmd_k8s_test.go
@@ -9,6 +9,8 @@ import (
 	kube_core "k8s.io/api/core/v1"
 	kube_meta "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/kumahq/kuma/pkg/test"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
@@ -25,7 +27,7 @@ var _ = XDescribe("K8S CMD test", func() {
 	var k8sClient client.Client
 	var testEnv *envtest.Environment
 
-	BeforeEach(func(done Done) {
+	BeforeEach(test.Within(time.Minute, func() {
 		By("bootstrapping test environment")
 		testEnv = &envtest.Environment{
 			CRDDirectoryPaths:        []string{filepath.Join("..", "..", "..", "pkg", "plugins", "resources", "k8s", "native", "config", "crd", "bases")},
@@ -47,9 +49,7 @@ var _ = XDescribe("K8S CMD test", func() {
 		ctrl.GetConfigOrDie = func() *rest.Config {
 			return testEnv.Config
 		}
-
-		close(done)
-	}, 60)
+	}))
 
 	AfterEach(func() {
 		By("tearing down the test environment")

--- a/app/kuma-cp/cmd/run_test.go
+++ b/app/kuma-cp/cmd/run_test.go
@@ -5,6 +5,9 @@ import (
 	"io/ioutil"
 	"net/http"
 	"os"
+	"time"
+
+	"github.com/kumahq/kuma/pkg/test"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -60,7 +63,7 @@ func RunSmokeTest(factory ConfigFactory, workdir string) {
 			}
 		})
 
-		It("should be possible to run `kuma-cp run with default mode`", func(done Done) {
+		It("should be possible to run `kuma-cp run with default mode`", test.Within(time.Minute, func() {
 			// given
 			config := fmt.Sprintf(factory.GenerateConfig(), diagnosticsPort)
 			_, err := configFile.WriteString(config)
@@ -108,9 +111,6 @@ func RunSmokeTest(factory ConfigFactory, workdir string) {
 			// then
 			err = <-errCh
 			Expect(err).ToNot(HaveOccurred())
-
-			// complete
-			close(done)
-		}, 60)
+		}))
 	})
 }

--- a/app/kuma-dp/pkg/dataplane/dnsserver/dnsserver_test.go
+++ b/app/kuma-dp/pkg/dataplane/dnsserver/dnsserver_test.go
@@ -10,11 +10,13 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"time"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
 	kuma_dp "github.com/kumahq/kuma/pkg/config/app/kuma-dp"
+	"github.com/kumahq/kuma/pkg/test"
 )
 
 var _ = Describe("DNS Server", func() {
@@ -55,7 +57,7 @@ var _ = Describe("DNS Server", func() {
 	})
 
 	Describe("Run(..)", func() {
-		It("should generate bootstrap config file and start Envoy", func(done Done) {
+		It("should generate bootstrap config file and start Envoy", test.Within(10*time.Second, func() {
 			// given
 			cfg := kuma_dp.Config{
 				DNS: kuma_dp.DNS{
@@ -129,11 +131,9 @@ var _ = Describe("DNS Server", func() {
       rcode NXDOMAIN
     }
 }`))
-			// complete
-			close(done)
-		}, 10)
+		}))
 
-		It("should return an error if DNS Server crashes", func(done Done) {
+		It("should return an error if DNS Server crashes", test.Within(10*time.Second, func() {
 			// given
 			cfg := kuma_dp.Config{
 				DNS: kuma_dp.DNS{
@@ -167,12 +167,9 @@ var _ = Describe("DNS Server", func() {
 			exitError := err.(*exec.ExitError)
 			// then
 			Expect(exitError.ProcessState.ExitCode()).To(Equal(1))
+		}))
 
-			// complete
-			close(done)
-		}, 10)
-
-		It("should return an error if DNS Server binary path is not found", func(done Done) {
+		It("should return an error if DNS Server binary path is not found", test.Within(10*time.Second, func() {
 			// given
 			cfg := kuma_dp.Config{
 				DNS: kuma_dp.DNS{
@@ -193,9 +190,6 @@ var _ = Describe("DNS Server", func() {
 			Expect(dnsServer).To(BeNil())
 			// and
 			Expect(err.Error()).To(ContainSubstring("could not find binary in any of the following paths"))
-
-			// complete
-			close(done)
-		}, 10)
+		}))
 	})
 })

--- a/app/kuma-dp/pkg/dataplane/envoy/envoy_test.go
+++ b/app/kuma-dp/pkg/dataplane/envoy/envoy_test.go
@@ -16,6 +16,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	kuma_dp "github.com/kumahq/kuma/pkg/config/app/kuma-dp"
+	"github.com/kumahq/kuma/pkg/test"
 	"github.com/kumahq/kuma/pkg/xds/bootstrap/types"
 )
 
@@ -57,7 +58,7 @@ var _ = Describe("Envoy", func() {
 	})
 
 	Describe("Run(..)", func() {
-		It("should generate bootstrap config file and start Envoy", func(done Done) {
+		It("should generate bootstrap config file and start Envoy", test.Within(10*time.Second, func() {
 			// given
 			cfg := kuma_dp.Config{
 				Dataplane: kuma_dp.Dataplane{
@@ -124,11 +125,9 @@ var _ = Describe("Envoy", func() {
             node:
               id: example
 `))
-			// complete
-			close(done)
-		}, 10)
+		}))
 
-		It("should return an error if Envoy crashes", func(done Done) {
+		It("should return an error if Envoy crashes", test.Within(10*time.Second, func() {
 			// given
 			cfg := kuma_dp.Config{
 				DataplaneRuntime: kuma_dp.DataplaneRuntime{
@@ -165,12 +164,9 @@ var _ = Describe("Envoy", func() {
 			exitError := err.(*exec.ExitError)
 			// then
 			Expect(exitError.ProcessState.ExitCode()).To(Equal(1))
+		}))
 
-			// complete
-			close(done)
-		}, 10)
-
-		It("should return an error if Envoy binay path is not found", func(done Done) {
+		It("should return an error if Envoy binary path is not found", test.Within(10*time.Second, func() {
 			// given
 			cfg := kuma_dp.Config{
 				DataplaneRuntime: kuma_dp.DataplaneRuntime{
@@ -194,10 +190,7 @@ var _ = Describe("Envoy", func() {
 			Expect(dataplane).To(BeNil())
 			// and
 			Expect(err.Error()).To(ContainSubstring(("could not find binary in any of the following paths")))
-
-			// complete
-			close(done)
-		}, 10)
+		}))
 	})
 
 	Describe("Parse version", func() {

--- a/app/kuma-prometheus-sd/cmd/run_test.go
+++ b/app/kuma-prometheus-sd/cmd/run_test.go
@@ -1,6 +1,10 @@
 package cmd
 
 import (
+	"time"
+
+	"github.com/kumahq/kuma/pkg/test"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -27,7 +31,7 @@ var _ = Describe("run", func() {
 		}
 	})
 
-	XIt("should be possible to run `kuma-prometheus-sd run`", func(done Done) {
+	XIt("should be possible to run `kuma-prometheus-sd run`", test.Within(15*time.Second, func() {
 		// given
 		cmd := NewRootCmd()
 		cmd.SetArgs([]string{"run"})
@@ -50,8 +54,5 @@ var _ = Describe("run", func() {
 		// then
 		err := <-errCh
 		Expect(err).ToNot(HaveOccurred())
-
-		// complete
-		close(done)
-	}, 15)
+	}))
 })

--- a/pkg/api-server/index_endpoints_test.go
+++ b/pkg/api-server/index_endpoints_test.go
@@ -5,6 +5,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"os"
+	"time"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -12,6 +13,7 @@ import (
 	config "github.com/kumahq/kuma/pkg/config/api-server"
 	"github.com/kumahq/kuma/pkg/metrics"
 	"github.com/kumahq/kuma/pkg/plugins/resources/memory"
+	"github.com/kumahq/kuma/pkg/test"
 	kuma_version "github.com/kumahq/kuma/pkg/version"
 )
 
@@ -25,7 +27,7 @@ var _ = Describe("Index Endpoints", func() {
 		kuma_version.Build = backupBuildInfo
 	})
 
-	It("should return the version of Kuma Control Plane", func(done Done) {
+	It("should return the version of Kuma Control Plane", test.Within(5*time.Second, func() {
 		// given
 		kuma_version.Build = kuma_version.BuildInfo{
 			Version:   "1.2.3",
@@ -72,6 +74,5 @@ var _ = Describe("Index Endpoints", func() {
 		}`, hostname)
 
 		Expect(body).To(MatchJSON(expected))
-		close(done)
-	}, 5)
+	}))
 })

--- a/pkg/core/resources/manager/cache_test.go
+++ b/pkg/core/resources/manager/cache_test.go
@@ -12,6 +12,7 @@ import (
 	core_store "github.com/kumahq/kuma/pkg/core/resources/store"
 	core_metrics "github.com/kumahq/kuma/pkg/metrics"
 	"github.com/kumahq/kuma/pkg/plugins/resources/memory"
+	"github.com/kumahq/kuma/pkg/test"
 	. "github.com/kumahq/kuma/pkg/test/matchers"
 	test_metrics "github.com/kumahq/kuma/pkg/test/metrics"
 
@@ -166,7 +167,7 @@ var _ = Describe("Cached Resource Manager", func() {
 		Expect(hits + hitWaits).To(Equal(100.0))
 	})
 
-	It("should let concurrent List() queries for different types and meshes", func(done Done) {
+	It("should let concurrent List() queries for different types and meshes", test.Within(5*time.Second, func() {
 		// given ongoing TrafficLog from mesh slow that takes a lot of time to complete
 		go func() {
 			fetched := core_mesh.TrafficLogResourceList{}
@@ -187,7 +188,5 @@ var _ = Describe("Cached Resource Manager", func() {
 
 		// then first request does not block request for other type
 		Expect(err).ToNot(HaveOccurred())
-
-		close(done)
-	}, 5)
+	}))
 })

--- a/pkg/plugins/config/k8s/k8s_suite_test.go
+++ b/pkg/plugins/config/k8s/k8s_suite_test.go
@@ -2,6 +2,7 @@ package k8s_test
 
 import (
 	"testing"
+	"time"
 
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 
@@ -13,6 +14,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/envtest/printer"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+
+	"github.com/kumahq/kuma/pkg/test"
 
 	kube_core "k8s.io/api/core/v1"
 	// +kubebuilder:scaffold:imports
@@ -30,7 +33,7 @@ func TestKubernetes(t *testing.T) {
 		[]Reporter{printer.NewlineReporter{}})
 }
 
-var _ = BeforeSuite(func(done Done) {
+var _ = BeforeSuite(test.Within(time.Minute, func() {
 	logf.SetLogger(zap.LoggerTo(GinkgoWriter, true))
 
 	By("bootstrapping test environment")
@@ -48,9 +51,7 @@ var _ = BeforeSuite(func(done Done) {
 	k8sClient, err = client.New(cfg, client.Options{Scheme: k8sClientScheme})
 	Expect(err).ToNot(HaveOccurred())
 	Expect(k8sClient).ToNot(BeNil())
-
-	close(done)
-}, 60)
+}))
 
 var _ = AfterSuite(func() {
 	By("tearing down the test environment")

--- a/pkg/plugins/leader/postgres/leader_elector_test.go
+++ b/pkg/plugins/leader/postgres/leader_elector_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/kumahq/kuma/pkg/core/runtime/component"
 	common_postgres "github.com/kumahq/kuma/pkg/plugins/common/postgres"
 	leader_postgres "github.com/kumahq/kuma/pkg/plugins/leader/postgres"
+	"github.com/kumahq/kuma/pkg/test"
 )
 
 var _ = Describe("postgresLeaderElector", func() {
@@ -64,7 +65,7 @@ var _ = Describe("postgresLeaderElector", func() {
 		}
 	})
 
-	It("should elect only one leader", func(done Done) {
+	It("should elect only one leader", test.Within(30*time.Second, func() {
 		// given
 		acquiredLeaderCh := make(chan string)
 		lostLeaderCh := make(chan string)
@@ -109,7 +110,5 @@ var _ = Describe("postgresLeaderElector", func() {
 		newLead := <-acquiredLeaderCh
 		Expect(newLead).ToNot(Equal(lead))
 		Expect(electors[newLead].IsLeader()).To(BeTrue())
-
-		close(done)
-	}, 30)
+	}))
 })

--- a/pkg/plugins/resources/k8s/k8s_suite_test.go
+++ b/pkg/plugins/resources/k8s/k8s_suite_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"path/filepath"
 	"testing"
+	"time"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -34,6 +35,7 @@ import (
 
 	mesh_k8s "github.com/kumahq/kuma/pkg/plugins/resources/k8s/native/api/v1alpha1"
 	k8s_registry "github.com/kumahq/kuma/pkg/plugins/resources/k8s/native/pkg/registry"
+	"github.com/kumahq/kuma/pkg/test"
 	"github.com/kumahq/kuma/pkg/test/apis/sample/v1alpha1"
 
 	// +kubebuilder:scaffold:imports
@@ -52,7 +54,7 @@ func TestKubernetes(t *testing.T) {
 		[]Reporter{printer.NewlineReporter{}})
 }
 
-var _ = BeforeSuite(func(done Done) {
+var _ = BeforeSuite(test.Within(time.Minute, func() {
 	logf.SetLogger(zap.LoggerTo(GinkgoWriter, true))
 
 	By("bootstrapping test environment")
@@ -98,9 +100,7 @@ var _ = BeforeSuite(func(done Done) {
 	Expect(err).ToNot(HaveOccurred())
 
 	Expect(k8sClient.Create(context.Background(), &kube_core.Namespace{ObjectMeta: kube_meta.ObjectMeta{Name: "demo"}})).To(Succeed())
-
-	close(done)
-}, 60)
+}))
 
 var _ = AfterSuite(func() {
 	By("tearing down the test environment")

--- a/pkg/plugins/resources/k8s/native/api/v1alpha1/suite_test.go
+++ b/pkg/plugins/resources/k8s/native/api/v1alpha1/suite_test.go
@@ -19,6 +19,7 @@ package v1alpha1
 import (
 	"path/filepath"
 	"testing"
+	"time"
 
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 
@@ -31,6 +32,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/envtest/printer"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+
+	"github.com/kumahq/kuma/pkg/plugins/resources/k8s/native/pkg/test"
 )
 
 var cfg *rest.Config
@@ -45,7 +48,7 @@ func TestAPIs(t *testing.T) {
 		[]Reporter{printer.NewlineReporter{}})
 }
 
-var _ = BeforeSuite(func(done Done) {
+var _ = BeforeSuite(test.Within(time.Minute, func() {
 	logf.SetLogger(zap.LoggerTo(GinkgoWriter, true))
 
 	By("bootstrapping test environment")
@@ -63,9 +66,7 @@ var _ = BeforeSuite(func(done Done) {
 	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
 	Expect(err).ToNot(HaveOccurred())
 	Expect(k8sClient).ToNot(BeNil())
-
-	close(done)
-}, 60)
+}))
 
 var _ = AfterSuite(func() {
 	By("tearing down the test environment")

--- a/pkg/plugins/resources/k8s/native/controllers/suite_test.go
+++ b/pkg/plugins/resources/k8s/native/controllers/suite_test.go
@@ -19,6 +19,7 @@ package controllers
 import (
 	"path/filepath"
 	"testing"
+	"time"
 
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 
@@ -32,6 +33,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	meshv1alpha1 "github.com/kumahq/kuma/pkg/plugins/resources/k8s/native/api/v1alpha1"
+	"github.com/kumahq/kuma/pkg/plugins/resources/k8s/native/pkg/test"
 	// +kubebuilder:scaffold:imports
 )
 
@@ -47,7 +49,7 @@ func TestAPIs(t *testing.T) {
 		[]Reporter{printer.NewlineReporter{}})
 }
 
-var _ = BeforeSuite(func(done Done) {
+var _ = BeforeSuite(test.Within(time.Minute, func() {
 	logf.SetLogger(zap.LoggerTo(GinkgoWriter, true))
 
 	By("bootstrapping test environment")
@@ -70,9 +72,7 @@ var _ = BeforeSuite(func(done Done) {
 	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
 	Expect(err).ToNot(HaveOccurred())
 	Expect(k8sClient).ToNot(BeNil())
-
-	close(done)
-}, 60)
+}))
 
 var _ = AfterSuite(func() {
 	By("tearing down the test environment")

--- a/pkg/plugins/resources/k8s/native/pkg/test/within.go
+++ b/pkg/plugins/resources/k8s/native/pkg/test/within.go
@@ -1,0 +1,25 @@
+package test
+
+import (
+	"time"
+
+	"github.com/onsi/gomega"
+)
+
+// Within returns a function that executes the given test task in
+// a dedicated goroutine, asserting that it must complete within
+// the given timeout.
+//
+// See https://github.com/onsi/ginkgo/blob/v2/docs/MIGRATING_TO_V2.md#removed-async-testing
+func Within(timeout time.Duration, task func()) func() {
+	return func() {
+		done := make(chan interface{})
+
+		go func() {
+			defer close(done)
+			task()
+		}()
+
+		gomega.Eventually(done, timeout).Should(gomega.BeClosed())
+	}
+}

--- a/pkg/plugins/runtime/k8s/controllers/suite_test.go
+++ b/pkg/plugins/runtime/k8s/controllers/suite_test.go
@@ -3,6 +3,7 @@ package controllers_test
 import (
 	"path/filepath"
 	"testing"
+	"time"
 
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 
@@ -18,6 +19,7 @@ import (
 
 	meshv1alpha1 "github.com/kumahq/kuma/pkg/plugins/resources/k8s/native/api/v1alpha1"
 	k8scnicncfio "github.com/kumahq/kuma/pkg/plugins/runtime/k8s/apis/k8s.cni.cncf.io"
+	"github.com/kumahq/kuma/pkg/test"
 )
 
 var k8sClient client.Client
@@ -32,7 +34,7 @@ func TestAPIs(t *testing.T) {
 		[]Reporter{printer.NewlineReporter{}})
 }
 
-var _ = BeforeSuite(func(done Done) {
+var _ = BeforeSuite(test.Within(time.Minute, func() {
 	logf.SetLogger(zap.LoggerTo(GinkgoWriter, true))
 
 	By("bootstrapping test environment")
@@ -58,9 +60,7 @@ var _ = BeforeSuite(func(done Done) {
 	k8sClient, err = client.New(cfg, client.Options{Scheme: k8sClientScheme})
 	Expect(err).ToNot(HaveOccurred())
 	Expect(k8sClient).ToNot(BeNil())
-
-	close(done)
-}, 60)
+}))
 
 var _ = AfterSuite(func() {
 	By("tearing down the test environment")

--- a/pkg/plugins/runtime/k8s/webhooks/injector/injector_suite_test.go
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/injector_suite_test.go
@@ -19,6 +19,7 @@ package injector_test
 import (
 	"path/filepath"
 	"testing"
+	"time"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -31,6 +32,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	mesh_k8s "github.com/kumahq/kuma/pkg/plugins/resources/k8s/native/api/v1alpha1"
+	"github.com/kumahq/kuma/pkg/test"
 	// +kubebuilder:scaffold:imports
 )
 
@@ -46,7 +48,7 @@ func TestInjector(t *testing.T) {
 		[]Reporter{printer.NewlineReporter{}})
 }
 
-var _ = BeforeSuite(func(done Done) {
+var _ = BeforeSuite(test.Within(time.Minute, func() {
 	logf.SetLogger(zap.LoggerTo(GinkgoWriter, true))
 
 	By("bootstrapping test environment")
@@ -71,9 +73,7 @@ var _ = BeforeSuite(func(done Done) {
 	k8sClient, err = client.New(cfg, client.Options{Scheme: k8sClientScheme})
 	Expect(err).ToNot(HaveOccurred())
 	Expect(k8sClient).ToNot(BeNil())
-
-	close(done)
-}, 60)
+}))
 
 var _ = AfterSuite(func() {
 	By("tearing down the test environment")

--- a/pkg/plugins/secrets/k8s/k8s_suite_test.go
+++ b/pkg/plugins/secrets/k8s/k8s_suite_test.go
@@ -18,6 +18,7 @@ package k8s_test
 
 import (
 	"testing"
+	"time"
 
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 
@@ -31,6 +32,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	kube_core "k8s.io/api/core/v1"
+
+	"github.com/kumahq/kuma/pkg/test"
 	// +kubebuilder:scaffold:imports
 )
 
@@ -46,7 +49,7 @@ func TestKubernetes(t *testing.T) {
 		[]Reporter{printer.NewlineReporter{}})
 }
 
-var _ = BeforeSuite(func(done Done) {
+var _ = BeforeSuite(test.Within(time.Minute, func() {
 	logf.SetLogger(zap.LoggerTo(GinkgoWriter, true))
 
 	By("bootstrapping test environment")
@@ -64,9 +67,7 @@ var _ = BeforeSuite(func(done Done) {
 	k8sClient, err = client.New(cfg, client.Options{Scheme: k8sClientScheme})
 	Expect(err).ToNot(HaveOccurred())
 	Expect(k8sClient).ToNot(BeNil())
-
-	close(done)
-}, 60)
+}))
 
 var _ = AfterSuite(func() {
 	By("tearing down the test environment")

--- a/pkg/sds/server/v2/server_test.go
+++ b/pkg/sds/server/v2/server_test.go
@@ -190,7 +190,7 @@ var _ = Describe("SDS Server", func() {
 		}
 	}
 
-	It("should return CA and Identity cert when DP is authorized", func(done Done) {
+	It("should return CA and Identity cert when DP is authorized", test.Within(time.Minute, func() {
 		// given
 		ctx := metadata.AppendToOutgoingContext(context.Background(), "authorization", dpCredential)
 		stream, err := client.StreamSecrets(ctx)
@@ -239,16 +239,14 @@ var _ = Describe("SDS Server", func() {
 		Eventually(func() float64 {
 			return test_metrics.FindMetric(metrics, "sds_watchdogs").GetGauge().GetValue()
 		}, "5s").Should(Equal(1.0))
-
-		close(done)
-	}, 60)
+	}))
 
 	Context("should return new pair of + key", func() { // we cannot use DescribeTable because it does not support timeouts
 
 		var firstExchangeResponse *envoy_api.DiscoveryResponse
 		var stream envoy_discovery.SecretDiscoveryService_StreamSecretsClient
 
-		BeforeEach(func(done Done) {
+		BeforeEach(test.Within(time.Minute, func() {
 			// given
 			ctx := metadata.AppendToOutgoingContext(context.Background(), "authorization", dpCredential)
 			s, err := client.StreamSecrets(ctx)
@@ -271,14 +269,13 @@ var _ = Describe("SDS Server", func() {
 			Eventually(func() error {
 				return resManager.Get(context.Background(), mesh_core.NewDataplaneInsightResource(), core_store.GetByKey("backend-01", "default"))
 			}, "30s", "1s").ShouldNot(HaveOccurred())
-			close(done)
-		}, 60)
+		}))
 
 		AfterEach(func() {
 			Expect(stream.CloseSend()).To(Succeed())
 		})
 
-		It("should return pair when CA is changed", func(done Done) {
+		It("should return pair when CA is changed", test.Within(time.Minute, func() {
 			// when
 			meshRes := mesh_core.NewMeshResource()
 			Expect(resManager.Get(context.Background(), meshRes, core_store.GetByKey(model.DefaultMesh, model.NoMesh))).To(Succeed())
@@ -312,11 +309,9 @@ var _ = Describe("SDS Server", func() {
 				}
 				return nil
 			}, "30s", "1s").ShouldNot(HaveOccurred())
+		}))
 
-			close(done)
-		}, 60)
-
-		It("should return a new pair when cert expired", func(done Done) {
+		It("should return a new pair when cert expired", test.Within(time.Minute, func() {
 			// when time is moved 1s after 4/5 of 60s cert expiration
 			shiftedTime := now.Load().(time.Time).Add(49 * time.Second)
 			now.Store(shiftedTime)
@@ -333,11 +328,9 @@ var _ = Describe("SDS Server", func() {
 			// then certs are different
 			Expect(resp).ToNot(BeNil())
 			Expect(firstExchangeResponse.Resources).ToNot(Equal(resp.Resources))
+		}))
 
-			close(done)
-		}, 60)
-
-		It("should return a new pair when dataplane has changed", func(done Done) {
+		It("should return a new pair when dataplane has changed", test.Within(time.Minute, func() {
 			// when
 			dpRes := mesh_core.NewDataplaneResource()
 			Expect(resManager.Get(context.Background(), dpRes, core_store.GetByKey("backend-01", "default"))).To(Succeed())
@@ -358,12 +351,10 @@ var _ = Describe("SDS Server", func() {
 			// then certs are different
 			Expect(resp).ToNot(BeNil())
 			Expect(firstExchangeResponse.Resources).ToNot(Equal(resp.Resources))
-
-			close(done)
-		}, 60)
+		}))
 	})
 
-	It("should not return certs when DP is not authorized", func(done Done) {
+	It("should not return certs when DP is not authorized", test.Within(time.Minute, func() {
 		// given
 		stream, err := client.StreamSecrets(context.Background())
 		defer func() {
@@ -381,7 +372,5 @@ var _ = Describe("SDS Server", func() {
 
 		// then
 		Expect(err).To(MatchError("rpc error: code = Unknown desc = authentication failed: could not parse token: token contains an invalid number of segments"))
-
-		close(done)
-	}, 60)
+	}))
 })

--- a/pkg/test/within.go
+++ b/pkg/test/within.go
@@ -1,0 +1,27 @@
+package test
+
+import (
+	"time"
+
+	"github.com/onsi/ginkgo"
+	"github.com/onsi/gomega"
+)
+
+// Within returns a function that executes the given test task in
+// a dedicated goroutine, asserting that it must complete within
+// the given timeout.
+//
+// See https://github.com/onsi/ginkgo/blob/v2/docs/MIGRATING_TO_V2.md#removed-async-testing
+func Within(timeout time.Duration, task func()) func() {
+	return func() {
+		done := make(chan interface{})
+
+		go func() {
+			defer ginkgo.GinkgoRecover()
+			defer close(done)
+			task()
+		}()
+
+		gomega.Eventually(done, timeout).Should(gomega.BeClosed())
+	}
+}

--- a/pkg/util/watchdog/watchdog_test.go
+++ b/pkg/util/watchdog/watchdog_test.go
@@ -7,6 +7,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
+	"github.com/kumahq/kuma/pkg/test"
 	. "github.com/kumahq/kuma/pkg/util/watchdog"
 )
 
@@ -29,7 +30,7 @@ var _ = Describe("SimpleWatchdog", func() {
 		doneCh = make(chan struct{})
 	})
 
-	It("should call OnTick() on timer ticks", func(done Done) {
+	It("should call OnTick() on timer ticks", test.Within(5*time.Second, func() {
 		// given
 		watchdog := SimpleWatchdog{
 			NewTicker: func() *time.Ticker {
@@ -70,11 +71,9 @@ var _ = Describe("SimpleWatchdog", func() {
 
 		// then
 		<-doneCh
+	}))
 
-		close(done)
-	}, 5)
-
-	It("should call OnError() when OnTick() returns an error", func(done Done) {
+	It("should call OnError() when OnTick() returns an error", test.Within(5*time.Second, func() {
 		// given
 		expectedErr := fmt.Errorf("expected error")
 		// and
@@ -113,7 +112,5 @@ var _ = Describe("SimpleWatchdog", func() {
 
 		// then
 		<-doneCh
-
-		close(done)
-	}, 5)
+	}))
 })

--- a/pkg/xds/server/callbacks/dataplane_sync_tracker_test.go
+++ b/pkg/xds/server/callbacks/dataplane_sync_tracker_test.go
@@ -3,11 +3,13 @@ package callbacks_test
 import (
 	"context"
 	"sync/atomic"
+	"time"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
 	core_model "github.com/kumahq/kuma/pkg/core/resources/model"
+	"github.com/kumahq/kuma/pkg/test"
 	util_watchdog "github.com/kumahq/kuma/pkg/util/watchdog"
 	util_xds_v2 "github.com/kumahq/kuma/pkg/util/xds/v2"
 
@@ -73,7 +75,7 @@ var _ = Describe("Sync", func() {
 			// expect no panic
 		})
 
-		It("should create a Watchdog when Envoy presents a valid Node ID", func(done Done) {
+		It("should create a Watchdog when Envoy presents a valid Node ID", test.Within(5*time.Second, func() {
 			watchdogCh := make(chan core_model.ResourceKey)
 
 			// setup
@@ -129,9 +131,7 @@ var _ = Describe("Sync", func() {
 			_, watchdogIsRunning := <-watchdogCh
 			// then
 			Expect(watchdogIsRunning).To(BeFalse())
-
-			close(done)
-		}, 5)
+		}))
 
 		It("should start only one watchdog per dataplane", func() {
 			// setup


### PR DESCRIPTION
### Summary

As per the [Ginkgo v2 upgrade guide](https://github.com/onsi/ginkgo/blob/v2/docs/MIGRATING_TO_V2.md#removed-async-testing), using the Done type to signal
timed, asynchronous test functions is deprecated and doesn't work
correctly. Replacing all these usages with a local test helper removes
the Ginkgo deprecation warnings and (at least for my environment) makes
the tests reliably pass.

### Full changelog

N/A

### Issues resolved

N/A

### Documentation

N/A

### Testing

- [X] Unit tests
- [X] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes 
