### PR TITLE
fix(kuma-dp) set death signal on child processes

### DIFF
--- a/app/kuma-dp/pkg/dataplane/dnsserver/dnsserver.go
+++ b/app/kuma-dp/pkg/dataplane/dnsserver/dnsserver.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"syscall"
 	"text/template"
 
 	"github.com/pkg/errors"
@@ -149,6 +150,9 @@ func (s *DNSServer) Start(stop <-chan struct{}) error {
 	command := exec.CommandContext(ctx, resolvedPath, args...)
 	command.Stdout = s.opts.Stdout
 	command.Stderr = s.opts.Stderr
+	command.SysProcAttr = &syscall.SysProcAttr{
+		Pdeathsig: syscall.SIGKILL,
+	}
 
 	runLog.Info("starting DNS Server (coredns)", "args", args)
 

--- a/app/kuma-dp/pkg/dataplane/envoy/envoy.go
+++ b/app/kuma-dp/pkg/dataplane/envoy/envoy.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/kumahq/kuma/pkg/core/resources/model/rest"
@@ -167,9 +168,14 @@ func (e *Envoy) Start(stop <-chan struct{}) error {
 	if version != "" { // version is always send by Kuma CP, but we check empty for backwards compatibility reasons (new Kuma DP connects to old Kuma CP)
 		args = append(args, "--bootstrap-version", string(version))
 	}
+
 	command := exec.CommandContext(ctx, resolvedPath, args...)
 	command.Stdout = e.opts.Stdout
 	command.Stderr = e.opts.Stderr
+	command.SysProcAttr = &syscall.SysProcAttr{
+		Pdeathsig: syscall.SIGKILL,
+	}
+
 	runLog.Info("starting Envoy", "args", args)
 	if err := command.Start(); err != nil {
 		runLog.Error(err, "the envoy executable was found at "+resolvedPath+" but an error occurred when executing it")


### PR DESCRIPTION
### Summary

Set the death signal on Envoy and CoreDNS child processes. This causes
the kernel to send SIGKILL to these processes if the kuma-dp process exits
unexpectedly (e.g. panics or is killed). This improves the resiliency of
the dataplane since restarting would not encounter stale child processes.

### Full changelog

* Improve crash recovery by ensuring that Envoy and CoreDNS child processes are killed when kuma-dp dies unexpectedly.

### Issues resolved

N/A

### Documentation

N/A

### Testing

- [x] Unit tests
- [ ] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes 
