### PR TITLE
fix(kuma-dp) conditional compile syscall for linux

### DIFF
--- a/app/kuma-dp/pkg/dataplane/command/build_command_darwin.go
+++ b/app/kuma-dp/pkg/dataplane/command/build_command_darwin.go
@@ -1,0 +1,21 @@
+package command
+
+import (
+	"context"
+	"io"
+	"os/exec"
+)
+
+func BuildCommand(
+	ctx context.Context,
+	stdout io.Writer,
+	stderr io.Writer,
+	name string,
+	args ...string,
+) *exec.Cmd {
+	command := exec.CommandContext(ctx, name, args...)
+	command.Stdout = stdout
+	command.Stderr = stderr
+
+	return command
+}

--- a/app/kuma-dp/pkg/dataplane/command/build_command_linux.go
+++ b/app/kuma-dp/pkg/dataplane/command/build_command_linux.go
@@ -7,7 +7,7 @@ import (
 	"syscall"
 )
 
-func buildCommand(
+func BuildCommand(
 	ctx context.Context,
 	stdout io.Writer,
 	stderr io.Writer,

--- a/app/kuma-dp/pkg/dataplane/command/build_command_linux.go
+++ b/app/kuma-dp/pkg/dataplane/command/build_command_linux.go
@@ -1,0 +1,25 @@
+package command
+
+import (
+	"context"
+	"io"
+	"os/exec"
+	"syscall"
+)
+
+func buildCommand(
+	ctx context.Context,
+	stdout io.Writer,
+	stderr io.Writer,
+	name string,
+	args ...string,
+) *exec.Cmd {
+	command := exec.CommandContext(ctx, name, args...)
+	command.Stdout = stdout
+	command.Stderr = stderr
+	command.SysProcAttr = &syscall.SysProcAttr{
+		Pdeathsig: syscall.SIGKILL,
+	}
+
+	return command
+}

--- a/app/kuma-dp/pkg/dataplane/dnsserver/dnsserver.go
+++ b/app/kuma-dp/pkg/dataplane/dnsserver/dnsserver.go
@@ -7,10 +7,11 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"syscall"
 	"text/template"
 
 	"github.com/pkg/errors"
+
+	command_utils "github.com/kumahq/kuma/app/kuma-dp/pkg/dataplane/command"
 
 	kuma_dp "github.com/kumahq/kuma/pkg/config/app/kuma-dp"
 	"github.com/kumahq/kuma/pkg/core"
@@ -147,12 +148,7 @@ func (s *DNSServer) Start(stop <-chan struct{}) error {
 		"-quiet",
 	}
 
-	command := exec.CommandContext(ctx, resolvedPath, args...)
-	command.Stdout = s.opts.Stdout
-	command.Stderr = s.opts.Stderr
-	command.SysProcAttr = &syscall.SysProcAttr{
-		Pdeathsig: syscall.SIGKILL,
-	}
+	command := command_utils.BuildCommand(ctx, s.opts.Stdout, s.opts.Stderr, resolvedPath, args...)
 
 	runLog.Info("starting DNS Server (coredns)", "args", args)
 

--- a/app/kuma-dp/pkg/dataplane/envoy/envoy.go
+++ b/app/kuma-dp/pkg/dataplane/envoy/envoy.go
@@ -9,9 +9,9 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
-	"syscall"
 	"time"
 
+	command_utils "github.com/kumahq/kuma/app/kuma-dp/pkg/dataplane/command"
 	"github.com/kumahq/kuma/pkg/core/resources/model/rest"
 	pkg_log "github.com/kumahq/kuma/pkg/log"
 	"github.com/kumahq/kuma/pkg/xds/bootstrap/types"
@@ -169,12 +169,7 @@ func (e *Envoy) Start(stop <-chan struct{}) error {
 		args = append(args, "--bootstrap-version", string(version))
 	}
 
-	command := exec.CommandContext(ctx, resolvedPath, args...)
-	command.Stdout = e.opts.Stdout
-	command.Stderr = e.opts.Stderr
-	command.SysProcAttr = &syscall.SysProcAttr{
-		Pdeathsig: syscall.SIGKILL,
-	}
+	command := command_utils.BuildCommand(ctx, e.opts.Stdout, e.opts.Stderr, resolvedPath, args...)
 
 	runLog.Info("starting Envoy", "args", args)
 	if err := command.Start(); err != nil {


### PR DESCRIPTION
As `Pdeathsig` is a property of `syscall.SysProcAttr` available
only on linux, this PR is introducing conditional compilation
of these bits only for linux

This is a followup of https://github.com/kumahq/kuma/pull/2045