### PR TITLE
fix(test) TestE2ETrafficRouteUniversalMultizone is flaky

### DIFF
--- a/test/e2e/trafficroute/universal_multizone/traffic_route.go
+++ b/test/e2e/trafficroute/universal_multizone/traffic_route.go
@@ -137,7 +137,7 @@ routing:
 	It("should access all instances of the service", func() {
 		const trafficRoute = `
 type: TrafficRoute
-name: route-dc-to-echo
+name: three-way-route
 mesh: default
 sources:
   - match:
@@ -180,7 +180,7 @@ conf:
 	It("should route 100 percent of the traffic to the different service", func() {
 		const trafficRoute = `
 type: TrafficRoute
-name: route-dc-to-echo
+name: route-echo-to-backend
 mesh: default
 sources:
   - match:
@@ -218,7 +218,7 @@ conf:
 
 		trafficRoute := fmt.Sprintf(`
 type: TrafficRoute
-name: route-dc-to-echo
+name: route-20-80-split
 mesh: default
 sources:
   - match:


### PR DESCRIPTION
### Summary

When using `memory` store it enumerates the version always starting from "1".  If someone tries to quickly delete and create a resource with the same name, but with a different `conf` then the old `conf` might be cached, because resources are not distinguishable for the Cache. That's exactly what happened with the new e2e tests for TrafficRoute. 

As a solution, I just renamed policies in every test of the same suite. 

Failed CI: https://app.circleci.com/pipelines/github/kumahq/kuma/7627/workflows/5545f5e1-0f97-4d1d-af5c-8d02f6fcec4c/jobs/88377

@kumahq/kuma-maintainers this is a quickfix to make CI work, but maybe we should consider using random autogenerated versions for memory and postgres? 

### Full changelog

* [Implement ...]
* [Fix ...]

### Issues resolved

Fix #XXX

### Documentation

- [ ] Link to the website [documentation PR](https://github.com/kumahq/kuma-website/pull/XXX)

### Testing

- [ ] Unit tests
- [ ] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes 
