### PR TITLE
fix(tests) e2e master

### DIFF
--- a/test/e2e/kic/kubernetes/kong_ingress.go
+++ b/test/e2e/kic/kubernetes/kong_ingress.go
@@ -37,6 +37,11 @@ func testEchoServer(port int) error {
 }
 
 func KICKubernetes() {
+	if IsApiV2() {
+		fmt.Println("Test not supported on API v2")
+		return
+	}
+
 	namespaceWithSidecarInjection := func(namespace string) string {
 		return fmt.Sprintf(`
 apiVersion: v1

--- a/test/kind/cluster-ipv6-kuma-1.yaml
+++ b/test/kind/cluster-ipv6-kuma-1.yaml
@@ -4,7 +4,7 @@ apiVersion: kind.x-k8s.io/v1alpha4
 networking:
   ipFamily: ipv6
   apiServerAddress: 127.0.0.1
-  nodes:
+nodes:
 - role: control-plane
   kubeadmConfigPatches:
   - |


### PR DESCRIPTION
### Summary

- There was a small mistake in the structure of kind cluster config manifest file for ipv6
- Also DNS are available on API v3 only, so we have to skip `KIC` tests for API v2 e2e tests

### Testing

- [ ] Unit tests
- [x] E2E tests
- [ ] Manual testing on Universal
- [x] Manual testing on Kubernetes 
