### PR TITLE
fix(e2e) various e2e tooling fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,10 @@
 .PHONY: help
 help: ## Display this help screen
-	@grep -h -E '^[a-zA-Z0-9_/-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
+	@# Display top-level targets since they are the ones most developes will need.
+	@grep -h -E '^[a-zA-Z0-9_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort -k1 | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
+	@echo
+	@# Now show hierarchical targets
+	@grep -h -E '^[a-zA-Z0-9_-]+/[a-zA-Z0-9/_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort -k1 | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 
 include mk/dev.mk
 include mk/build.mk

--- a/docs/guides/e2e-test-tips.md
+++ b/docs/guides/e2e-test-tips.md
@@ -31,6 +31,26 @@ FIt("should access service locally and remotely", func() {
 make test/e2e E2E_PKG_LIST=./test/e2e/deploy/... 
 ```
 
+## Running e2e tests one at a time
+
+When you run `make test/e2e`, the Docker infrastructure will get torn down if any tests fail.
+In the case of failing tests, it can be useful to run one suit at a time, while leaving the Docker containers in place.
+
+To do this, first create the test environment:
+```
+make build/kumactl images test/e2e/k8s/start
+```
+
+Now you can run each test suite (exiting on any failures):
+```
+(
+    set -e
+    for t in $(go list ./test/e2e/...); do
+        make test/e2e/test E2E_PKG_LIST="$t"
+    done
+)
+```
+
 ## Debug the test - do not clean up environment
 
 Even if you execute one test and it fails, our framework clean up the environment (delete Kubernetes clusters, containers etc.)

--- a/mk/e2e.new.mk
+++ b/mk/e2e.new.mk
@@ -61,6 +61,8 @@ ifdef KUMA_DEFAULT_TIMEOUT
 	ENV_VARS += KUMA_DEFAULT_TIMEOUT=$(KUMA_DEFAULT_TIMEOUT)
 endif
 
+# We don't use `go list` here because Ginkgo requires disk path names,
+# not Go packages names.
 TEST_NAMES = $(shell ls -1 ./test/e2e)
 ALL_TESTS = $(addprefix ./test/e2e/, $(addsuffix /..., $(TEST_NAMES)))
 E2E_PKG_LIST ?= $(ALL_TESTS)

--- a/test/framework/deployments/externalservice/universal.go
+++ b/test/framework/deployments/externalservice/universal.go
@@ -47,7 +47,7 @@ func (u *universalDeployment) Deploy(cluster framework.Cluster) error {
 		EnvironmentVariables: []string{},
 		OtherOptions:         append([]string{"--name", cluster.Name() + "_" + u.Name(), "--network", "kind"}, u.publishPortsForDocker()...),
 	}
-	container, err := docker.RunAndGetIDE(cluster.GetTesting(), framework.KumaUniversalImage, &dockerOpts)
+	container, err := docker.RunAndGetIDE(cluster.GetTesting(), framework.GetUniversalImage(), &dockerOpts)
 	if err != nil {
 		return err
 	}

--- a/test/framework/env.go
+++ b/test/framework/env.go
@@ -76,7 +76,7 @@ func GetUniversalImage() string {
 		return os.Getenv("KUMA_UNIVERSAL_IMAGE")
 	}
 
-	return "kuma-universal"
+	return KumaUniversalImage
 }
 
 func GetApiVersion() string {

--- a/test/framework/universal_app.go
+++ b/test/framework/universal_app.go
@@ -222,7 +222,7 @@ func NewUniversalApp(t testing.TestingT, clusterName, dpName string, mode AppMod
 		opts.OtherOptions = append(opts.OtherOptions, "--sysctl", "net.ipv6.conf.all.disable_ipv6=1")
 	}
 	opts.OtherOptions = append(opts.OtherOptions, app.publishPortsForDocker()...)
-	container, err := docker.RunAndGetIDE(t, KumaUniversalImage, &opts)
+	container, err := docker.RunAndGetIDE(t, GetUniversalImage(), &opts)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
### Summary

* Prettify the "make help" to improve readability
* Add docstrings to useful make targets
* Simplify e2e test package discovery
* Add some more e2e test documentation
* Remove most uses of the "kuma-universal:latest" tag
* Consistently use the Kuma universal image name constant

### Full changelog

N/A

### Issues resolved

N/A

### Documentation

N/A

### Testing

- [x] Unit tests
- [x] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes 
