### PR TITLE
tests(kumactl) fix flaky order of headers

### DIFF
--- a/app/kumactl/cmd/config/config_control_planes_add.go
+++ b/app/kumactl/cmd/config/config_control_planes_add.go
@@ -6,6 +6,8 @@ import (
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
+	"github.com/kumahq/kuma/pkg/util/maps"
+
 	kumactl_cmd "github.com/kumahq/kuma/app/kumactl/pkg/cmd"
 	"github.com/kumahq/kuma/app/kumactl/pkg/config"
 	config_proto "github.com/kumahq/kuma/pkg/config/app/kumactl/v1alpha1"
@@ -45,10 +47,10 @@ func newConfigControlPlanesAddCmd(pctx *kumactl_cmd.RootContext) *cobra.Command 
 				},
 			}
 
-			for k, v := range args.headers {
+			for _, k := range maps.SortedKeys(args.headers) {
 				header := &config_proto.ControlPlaneCoordinates_Headers{
 					Key:   k,
-					Value: v,
+					Value: args.headers[k],
 				}
 				cp.Coordinates.ApiServer.Headers = append(cp.Coordinates.ApiServer.Headers, header)
 			}

--- a/app/kumactl/cmd/config/config_control_planes_add.go
+++ b/app/kumactl/cmd/config/config_control_planes_add.go
@@ -47,7 +47,7 @@ func newConfigControlPlanesAddCmd(pctx *kumactl_cmd.RootContext) *cobra.Command 
 				},
 			}
 
-			for _, k := range maps.SortedKeys(args.headers) {
+			for _, k := range maps.SortedKeys(args.headers) { // sort for stable test outputs
 				header := &config_proto.ControlPlaneCoordinates_Headers{
 					Key:   k,
 					Value: args.headers[k],

--- a/pkg/util/maps/maps_suite_test.go
+++ b/pkg/util/maps/maps_suite_test.go
@@ -1,0 +1,13 @@
+package maps_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestMaps(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Maps Suite")
+}

--- a/pkg/util/maps/sorted_keys.go
+++ b/pkg/util/maps/sorted_keys.go
@@ -1,0 +1,12 @@
+package maps
+
+import "sort"
+
+func SortedKeys(m map[string]string) []string {
+	var keys []string
+	for key := range m {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
+}

--- a/pkg/util/maps/sorted_keys_test.go
+++ b/pkg/util/maps/sorted_keys_test.go
@@ -1,0 +1,25 @@
+package maps_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/kumahq/kuma/pkg/util/maps"
+)
+
+var _ = Describe("SortedKeys", func() {
+	It("should return sorted keys", func() {
+		// given
+		m := map[string]string{
+			"c": "x",
+			"b": "y",
+			"a": "z",
+		}
+
+		// when
+		keys := maps.SortedKeys(m)
+
+		// then
+		Expect(keys).To(Equal([]string{"a", "b", "c"}))
+	})
+})


### PR DESCRIPTION
### Summary

Order of headers in the config was not deterministic

### Documentation

- No docs

### Testing

- [X] Unit tests
- [ ] E2E tests
- [X] Manual testing on Universal
- [X] Manual testing on Kubernetes 
