### PR TITLE
tests(kumactl) IPv6 not supported on KIC; skip test.

### DIFF
--- a/test/e2e/kic/kubernetes/kong_ingress.go
+++ b/test/e2e/kic/kubernetes/kong_ingress.go
@@ -37,6 +37,8 @@ func testEchoServer(port int) error {
 }
 
 func KICKubernetes() {
+	// IPv6 curently not supported by Kong Ingress Controller
+	// https://github.com/Kong/kubernetes-ingress-controller/issues/1017
 	if IsApiV2() || IsIPv6() {
 		fmt.Println("Test not supported on API v2 or IPv6")
 		return

--- a/test/e2e/kic/kubernetes/kong_ingress.go
+++ b/test/e2e/kic/kubernetes/kong_ingress.go
@@ -37,8 +37,8 @@ func testEchoServer(port int) error {
 }
 
 func KICKubernetes() {
-	if IsApiV2() {
-		fmt.Println("Test not supported on API v2")
+	if IsApiV2() || IsIPv6() {
+		fmt.Println("Test not supported on API v2 or IPv6")
 		return
 	}
 


### PR DESCRIPTION
Signed-off-by: Paul Parkanzky <paul.parkanzky@konghq.com>

### Summary

IPv6 not supported by KIC. Turning off e2e test when testing IPv6.

### Testing

- [ ] Unit tests
- [x] E2E tests
- [ ] Manual testing on Universal
- [x] Manual testing on Kubernetes 
