### PR TITLE
fix(e2e) clean up KUBECONFIG handling

### DIFF
--- a/docs/guides/e2e-test-tips.md
+++ b/docs/guides/e2e-test-tips.md
@@ -91,3 +91,15 @@ Running `make test/e2e/debug` can intentionally leave resources if test fails. C
 make k3d/stop/all && docker stop $(docker ps -aq) # omit $ for fish
 ```
 
+### Integration with direnv
+
+[direnv](https://direnv.net/) is a useful tool that can populate environment variables in your shell as you change directories.
+The Kuma build has an optional `dev/envrc` target that generates a `.envrc` file to set the `$CI_TOOLS_DIR` and `$KUBECONFIG` environment variables.
+This is useful to keeping the Kuma CI tools installation tidy in your Kuma workspace, and for conveniently accessing the Kind clusters that are provisioned by the e2e tests.
+
+```
+$ make dev/envrc
+direnv: loading ~/upstream/konghq/kuma/.envrc
+direnv: export +CI_TOOLS_DIR +KUBECONFIG
+```
+

--- a/mk/build.mk
+++ b/mk/build.mk
@@ -29,11 +29,14 @@ COREDNS_VERSION ?= v1.8.3
 COREDNS_TMP_DIRECTORY ?= $(BUILD_DIR)/coredns
 COREDNS_PLUGIN_CFG_PATH ?= $(TOP)/tools/builds/coredns/templates/plugin.cfg
 
+# List of binaries that we have release build rules for.
+BUILD_RELEASE_BINARIES := kuma-cp kuma-dp kumactl kuma-prometheus-sd coredns
+
 .PHONY: build
 build: build/release build/test
 
 .PHONY: build/release
-build/release: build/kuma-cp build/kuma-dp build/kumactl build/kuma-prometheus-sd build/coredns ## Dev: Build all binaries
+build/release: $(patsubst %,build/%,$(BUILD_RELEASE_BINARIES)) ## Dev: Build all binaries
 
 .PHONY: build/test
 build/test: build/test-server

--- a/mk/dev.mk
+++ b/mk/dev.mk
@@ -267,4 +267,7 @@ dev/envrc: $(KUBECONFIG_DIR)/kind-kuma-current ## Generate .envrc
 		echo "path_add KUBECONFIG $$c" ; \
 	done >> .envrc
 	@echo 'export KUBECONFIG' >> .envrc
+	@for prog in $(BUILD_RELEASE_BINARIES) ; do \
+		echo "PATH_add $(BUILD_ARTIFACTS_DIR)/$$prog" ; \
+	done >> .envrc
 	@direnv allow

--- a/mk/dev.mk
+++ b/mk/dev.mk
@@ -17,6 +17,10 @@ GOPATH_DIR := $(shell go env GOPATH | awk -F: '{print $$1}')
 GOPATH_BIN_DIR := $(GOPATH_DIR)/bin
 export PATH := $(CI_TOOLS_DIR):$(GOPATH_BIN_DIR):$(PATH)
 
+# The e2e tests depend on Kind kubeconfigs being in this directory,
+# so this is location should not be changed by developers.
+KUBECONFIG_DIR := $(HOME)/.kube
+
 PROTOC_PATH := $(CI_TOOLS_DIR)/protoc
 PROTOBUF_WKT_DIR := $(CI_TOOLS_DIR)/protobuf.d
 KUBEBUILDER_DIR := $(CI_TOOLS_DIR)/kubebuilder.d
@@ -242,3 +246,25 @@ changelog:
 		--start refs/heads/$(GEN_CHANGELOG_START_TAG) \
 		--branch refs/heads/$(GEN_CHANGELOG_BRANCH) > $(GEN_CHANGELOG_MD)
 	@echo "The generated changelog is in $(GEN_CHANGELOG_MD)"
+
+$(KUBECONFIG_DIR):
+	@mkdir -p $(KUBECONFIG_DIR)
+
+# kubectl always writes the current context into the first config file. When
+# debugging, it's common to switch contexts and we don't want to edit the Kind
+# config files (because then the integration tests have the wrong current
+# context). So we create this as a place for kubectl to write the interactive
+# current context.
+$(KUBECONFIG_DIR)/kind-kuma-current: $(KUBECONFIG_DIR)
+	@touch $@
+
+# Generate a .envrc that prepends e2e test suite configs to whatever
+# KUBECONFIG currently has, and stores CI tooling in .tools.
+.PHONY: dev/enrc
+dev/envrc: $(KUBECONFIG_DIR)/kind-kuma-current ## Generate .envrc
+	@echo 'export CI_TOOLS_DIR=$$(expand_path .tools)' > .envrc
+	@for c in $(patsubst %,$(KUBECONFIG_DIR)/kind-%-config,kuma $(K8SCLUSTERS)) $(KUBECONFIG_DIR)/kind-kuma-current ; do \
+		echo "path_add KUBECONFIG $$c" ; \
+	done >> .envrc
+	@echo 'export KUBECONFIG' >> .envrc
+	@direnv allow

--- a/mk/e2e.new.mk
+++ b/mk/e2e.new.mk
@@ -82,7 +82,6 @@ define gen-k8sclusters
 test/e2e/k8s/start/cluster/$1:
 	KIND_CONFIG=$(TOP)/test/kind/cluster$(KIND_CONFIG_IPV6)-$1.yaml \
 	KIND_CLUSTER_NAME=$1 \
-	KIND_KUBECONFIG=$(KIND_KUBECONFIG_DIR)/kind-$1-config \
 		$(MAKE) $(K8S_CLUSTER_TOOL)/start
 	KIND_CLUSTER_NAME=$1 \
 		$(MAKE) $(K8S_CLUSTER_TOOL)/load/images
@@ -90,7 +89,6 @@ test/e2e/k8s/start/cluster/$1:
 .PHONY: test/e2e/k8s/stop/cluster/$1
 test/e2e/k8s/stop/cluster/$1:
 	KIND_CLUSTER_NAME=$1 \
-	KIND_KUBECONFIG=$(KIND_KUBECONFIG_DIR)/kind-$1-config \
 		$(MAKE) $(K8S_CLUSTER_TOOL)/stop
 endef
 
@@ -100,10 +98,10 @@ $(foreach cluster, $(K8SCLUSTERS), $(eval $(call gen-k8sclusters,$(cluster))))
 test/e2e/list:
 	@echo $(ALL_TESTS)
 
-.PHONY: test/e2e/kind/start
+.PHONY: test/e2e/k8s/start
 test/e2e/k8s/start: $(K8SCLUSTERS_START_TARGETS)
 
-.PHONY: test/e2e/kind/stop
+.PHONY: test/e2e/k8s/stop
 test/e2e/k8s/stop: $(K8SCLUSTERS_STOP_TARGETS)
 
 .PHONY: test/e2e/test
@@ -127,7 +125,6 @@ test/e2e/debug: build/kumactl images test/e2e/k8s/start
 	API_VERSION="$(API_VERSION)" \
 	GINKGO_EDITOR_INTEGRATION=true \
 		ginkgo --failFast $(GOFLAGS) $(LD_FLAGS) $(E2E_PKG_LIST)
-	$(MAKE) test/e2e/k8s/stop
 
 # test/e2e/debug-universal is the same target as 'test/e2e/debug' but builds only 'kuma-universal' image
 # and doesn't start Kind clusters

--- a/mk/k3d.mk
+++ b/mk/k3d.mk
@@ -1,20 +1,3 @@
-EXAMPLE_NAMESPACE ?= kuma-example
-KIND_KUBECONFIG_DIR ?= $(HOME)/.kube
-KIND_KUBECONFIG ?= $(KIND_KUBECONFIG_DIR)/kind-kuma-config
-KIND_CLUSTER_NAME ?= kuma
-
-ifdef IPV6
-KIND_CONFIG ?= $(TOP)/test/kind/cluster-ipv6.yaml
-else
-KIND_CONFIG ?= $(TOP)/test/kind/cluster.yaml
-endif
-
-ifeq ($(KUMACTL_INSTALL_USE_LOCAL_IMAGES),true)
-	KUMACTL_INSTALL_CONTROL_PLANE_IMAGES := --control-plane-registry=$(DOCKER_REGISTRY) --dataplane-registry=$(DOCKER_REGISTRY) --dataplane-init-registry=$(DOCKER_REGISTRY)
-else
-	KUMACTL_INSTALL_CONTROL_PLANE_IMAGES :=
-endif
-
 CI_K3D_VERSION ?= v4.4.5
 
 K3D_PATH := $(CI_TOOLS_DIR)/k3d
@@ -41,7 +24,7 @@ k3d/start: ${KIND_KUBECONFIG_DIR}
 	@echo
 	@echo '>>> You need to manually run the following command in your shell: >>>'
 	@echo
-	@echo export KUBECONFIG="${KIND_KUBECONFIG}"
+	@echo export KUBECONFIG="$(KIND_KUBECONFIG)"
 	@echo
 	@echo '<<< ------------------------------------------------------------- <<<'
 	@echo
@@ -73,7 +56,7 @@ k3d/deploy/kuma: build/kumactl k3d/load
 	@KUBECONFIG=$(KIND_KUBECONFIG) kumactl install dns | kubectl apply -f -
 	@KUBECONFIG=$(KIND_KUBECONFIG) kubectl delete -n $(EXAMPLE_NAMESPACE) pod -l app=example-app
 	@until \
-    	KUBECONFIG=$(KIND_KUBECONFIG) kubectl wait -n kube-system --timeout=5s --for condition=Ready --all pods ; \
+	KUBECONFIG=$(KIND_KUBECONFIG) kubectl wait -n kube-system --timeout=5s --for condition=Ready --all pods ; \
     do \
     	echo "Waiting for the cluster to come up" && sleep 1; \
     done


### PR DESCRIPTION
### Summary

The integration tests depend on kubeconfig files being written to ~/.kube,
so remove the Makefile configurability of these since it can't ever work.

Add a target to generate a .envrc file to work with the e2e clusters
more easily.

### Full changelog

N/A

### Issues resolved

N/A

### Documentation

N/A

### Testing

- [x] Unit tests
- [x] E2E tests

E2E tests are failing for me locally with a docker problem, but CI seems happy.