### PR TITLE
fix(kuma-cp) matching endpoints by tags

### DIFF
--- a/pkg/core/xds/types.go
+++ b/pkg/core/xds/types.go
@@ -182,10 +182,7 @@ func (e Endpoint) HasLocality() bool {
 func (e Endpoint) ContainsTags(tags map[string]string) bool {
 	for otherKey, otherValue := range tags {
 		endpointValue, ok := e.Tags[otherKey]
-		if !ok {
-			continue
-		}
-		if otherValue != endpointValue {
+		if !ok || otherValue != endpointValue {
 			return false
 		}
 	}

--- a/pkg/core/xds/types_test.go
+++ b/pkg/core/xds/types_test.go
@@ -272,4 +272,56 @@ var _ = Describe("xDS", func() {
 			)
 		})
 	})
+
+	Describe("ContainsTags", func() {
+		// given
+		endpoint := core_xds.Endpoint{
+			Tags: map[string]string{
+				"kuma.io/service": "backend",
+				"version":         "v1",
+			},
+		}
+
+		It("should match single tag", func() {
+			// when
+			contains := endpoint.ContainsTags(map[string]string{
+				"kuma.io/service": "backend",
+			})
+
+			// then
+			Expect(contains).To(BeTrue())
+		})
+
+		It("should match all the tags", func() {
+			// when
+			contains := endpoint.ContainsTags(map[string]string{
+				"kuma.io/service": "backend",
+				"version":         "v1",
+			})
+
+			// then
+			Expect(contains).To(BeTrue())
+		})
+
+		It("should not match when value of a tag is different", func() {
+			// when
+			contains := endpoint.ContainsTags(map[string]string{
+				"kuma.io/service": "backend",
+				"version":         "v2",
+			})
+
+			// then
+			Expect(contains).To(BeFalse())
+		})
+
+		It("should not match when endpoint has no such tag", func() {
+			// when
+			contains := endpoint.ContainsTags(map[string]string{
+				"team": "xyz",
+			})
+
+			// then
+			Expect(contains).To(BeFalse())
+		})
+	})
 })


### PR DESCRIPTION
### Summary

We had a bug in `ContainsTags` function.
The problem was only visible if we had a traffic route over the tag that was only available in one instance. Then we mistakenly were picking instances that did not have the tag at all. 

Fixed the bug, added a bunch of tests.

### Documentation

- [X] No docs

### Testing

- [X] Unit tests
- [ ] E2E tests
- [ ] Manual testing on Universal
- [X] Manual testing on Kubernetes 
