### PR TITLE
chore(tests) add namespace to test deployments

### DIFF
--- a/test/e2e/externalservices/testdata/externalservice-http-server.yaml
+++ b/test/e2e/externalservices/testdata/externalservice-http-server.yaml
@@ -1,5 +1,11 @@
 ---
 apiVersion: v1
+kind: Namespace
+metadata:
+  name: externalservice-namespace
+
+---
+apiVersion: v1
 kind: Service
 metadata:
   name: externalservice-http-server
@@ -13,6 +19,7 @@ spec:
       targetPort: 80
   selector:
     app: externalservice-http-server
+
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/test/e2e/externalservices/testdata/externalservice-https-server.yaml
+++ b/test/e2e/externalservices/testdata/externalservice-https-server.yaml
@@ -1,5 +1,11 @@
 ---
 apiVersion: v1
+kind: Namespace
+metadata:
+  name: externalservice-namespace
+
+---
+apiVersion: v1
 kind: Service
 metadata:
   name: externalservice-https-server
@@ -13,6 +19,7 @@ spec:
       targetPort: 443
   selector:
     app: externalservice-https-server
+
 ---
 apiVersion: apps/v1
 kind: Deployment


### PR DESCRIPTION
### Summary

Add the namespace resource to the external service deployment YAML so
that it can be applied as a single step without any manual prerequisites.

### Full changelog

N/A

### Issues resolved

N/A

### Documentation

N/A

### Testing

```
$ k get ns
NAME                 STATUS   AGE
default              Active   2d18h
kube-node-lease      Active   2d18h
kube-public          Active   2d18h
kube-system          Active   2d18h
kuma-system          Active   2d17h
local-path-storage   Active   2d18h
```
```
$ k apply -f test/e2e/externalservices/testdata/externalservice-http-server.yaml
namespace/externalservice-namespace created
service/externalservice-http-server created
deployment.apps/externalservice-http-server created
```
```
$ k apply -f test/e2e/externalservices/testdata/externalservice-https-server.yaml
namespace/externalservice-namespace unchanged
service/externalservice-https-server created
deployment.apps/externalservice-https-server created
```
