### PR TITLE
fix(*) clip open files limit on Darwin

### DIFF
--- a/pkg/util/os/limits.go
+++ b/pkg/util/os/limits.go
@@ -2,6 +2,7 @@ package os
 
 import (
 	"fmt"
+	"runtime"
 
 	"golang.org/x/sys/unix"
 )
@@ -24,6 +25,14 @@ func RaiseFileLimit() error {
 	limit := unix.Rlimit{}
 	if err := unix.Getrlimit(unix.RLIMIT_NOFILE, &limit); err != nil {
 		return fmt.Errorf("failed to query open file limits: %w", err)
+	}
+
+	// Darwin sets the max to unlimited, but it is actually limited
+	// (typically to 24K) by the "kern.maxfilesperproc" systune.
+	// Since we only run on Darwin for test purposes, just clip this
+	// to a reasonable value.
+	if runtime.GOOS == "darwin" && limit.Max > 4096 {
+		limit.Max = 4096
 	}
 
 	return setFileLimit(limit.Max)


### PR DESCRIPTION
### Summary

On Darwin, we have to look at kernel systunes to find the real open
file limit. Rather than adding a lot of extra code for a non-production
platform, just clip it to a sensible default.

### Full changelog

N/A

### Issues resolved

Fix #2091 

### Documentation

N/A

### Testing

- [x] Unit tests
- [x] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes 
