### PR TITLE
fix(e2e) aks push images command fix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -431,7 +431,7 @@ jobs:
         command: |
           for image in kuma-cp kuma-dp kuma-init kumactl kuma-universal; do
             make docker/tag/${image} \
-              BINTRAY_REGISTRY="${AZURE_ACR_REGISTRY_FULLNAME}" \
+              DOCKER_REGISTRY="${AZURE_ACR_REGISTRY_FULLNAME}" \
               KUMA_VERSION="${TAG}" &
           done
 


### PR DESCRIPTION
### Summary

After changing names of env vars for tests in makefiles
(related to bintray deprecation) we forgot to change the name
of BINTRAY_REGISTRY -> DOCKER_REGISTRY for aks e2e job

### Testing

- [ ] Unit tests
- [ ] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes 
