### PR TITLE
tests(kuma-cp) skip header modification on API V2

### DIFF
--- a/test/e2e/trafficroute/universal_standalone/traffic_route.go
+++ b/test/e2e/trafficroute/universal_standalone/traffic_route.go
@@ -505,6 +505,9 @@ conf:
 		})
 
 		It("should modify host", func() {
+			if IsApiV2() {
+				return // host.fromPath is not available in API V2
+			}
 			const trafficRoute = `
 type: TrafficRoute
 name: modify-host


### PR DESCRIPTION
This functionality is not supported in API V2