### PR TITLE
fix(tests) dev_macos tests

### DIFF
--- a/pkg/util/os/limits.go
+++ b/pkg/util/os/limits.go
@@ -31,8 +31,8 @@ func RaiseFileLimit() error {
 	// (typically to 24K) by the "kern.maxfilesperproc" systune.
 	// Since we only run on Darwin for test purposes, just clip this
 	// to a reasonable value.
-	if runtime.GOOS == "darwin" && limit.Max > 4096 {
-		limit.Max = 4096
+	if runtime.GOOS == "darwin" && limit.Max > 10240 {
+		limit.Max = 10240
 	}
 
 	return setFileLimit(limit.Max)

--- a/pkg/util/os/limits_test.go
+++ b/pkg/util/os/limits_test.go
@@ -1,6 +1,8 @@
 package os
 
 import (
+	"runtime"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"golang.org/x/sys/unix"
@@ -19,8 +21,12 @@ var _ = Describe("File limits", func() {
 
 		Expect(RaiseFileLimit()).Should(Succeed())
 
-		// After raising, the current limit should be the max.
-		Expect(CurrentFileLimit()).Should(BeNumerically("==", initialLimits.Max))
+		// After raising, the current limit should be the 4096 on Darwin and max elsewhere.
+		if runtime.GOOS == "darwin" {
+			Expect(CurrentFileLimit()).Should(BeNumerically("==", 10240))
+		} else {
+			Expect(CurrentFileLimit()).Should(BeNumerically("==", initialLimits.Max))
+		}
 
 		// Restore the original limit.
 		Expect(setFileLimit(initialLimits.Cur)).Should(Succeed())


### PR DESCRIPTION
### Summary

- Test was not working on macos as the max ulimit was set manually
- I bumped the number of default "reasonable" value of ulimit
  for macos to 10240 as it was the default for my system and
  when it was smaller we couldn't restore the value after our tests
  because we were trying to set higher value then the "max" we set

### Testing

- [x] Unit tests
- [ ] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes 
