### PR TITLE
fix(kuma-dp) pass query parameters through the metrics hijacker

### DIFF
--- a/app/kuma-dp/pkg/dataplane/metrics/merge_test.go
+++ b/app/kuma-dp/pkg/dataplane/metrics/merge_test.go
@@ -1,4 +1,4 @@
-package metrics_test
+package metrics
 
 import (
 	"bufio"
@@ -9,8 +9,6 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
-
-	"github.com/kumahq/kuma/app/kuma-dp/pkg/dataplane/metrics"
 )
 
 func toLines(r io.Reader) (lines []string) {
@@ -34,7 +32,7 @@ var _ = Describe("Merge", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			actual := new(bytes.Buffer)
-			err = metrics.MergeClusters(input, actual)
+			err = MergeClusters(input, actual)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(toLines(actual)).To(ConsistOf(toLines(expected)))
 		},

--- a/app/kuma-dp/pkg/dataplane/metrics/metrics_suite_test.go
+++ b/app/kuma-dp/pkg/dataplane/metrics/metrics_suite_test.go
@@ -1,4 +1,4 @@
-package metrics_test
+package metrics
 
 import (
 	"testing"

--- a/app/kuma-dp/pkg/dataplane/metrics/server_test.go
+++ b/app/kuma-dp/pkg/dataplane/metrics/server_test.go
@@ -1,0 +1,35 @@
+package metrics
+
+import (
+	"net/url"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Rewriting the metrics URL", func() {
+	type testCase struct {
+		input     string
+		adminPort uint32
+		expected  string
+	}
+	DescribeTable("should",
+		func(given testCase) {
+			u, err := url.Parse(given.input)
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(rewriteMetricsURL(given.adminPort, u)).Should(Equal(given.expected))
+		},
+		Entry("use the admin port", testCase{
+			input:     "http://foo/bar",
+			adminPort: 99,
+			expected:  "http://127.0.0.1:99/stats/prometheus",
+		}),
+		Entry("preserve query parameters", testCase{
+			input:     "http://foo/bar?one=two&three=four",
+			adminPort: 80,
+			expected:  "http://127.0.0.1:80/stats/prometheus?one=two&three=four",
+		}),
+	)
+})


### PR DESCRIPTION
### Summary

The Envoy Prometheus endpoint supports passing a filtering regex in
the query parameters to limit the set of metrics that are returned.
This feature lets a metrics scraper scrape different sets of metrics
at different intervals.

### Full changelog

* Pass query parameters through the DP metrics endpoint so that metrics scrapers can sample subsets of the available metrics.

### Issues resolved

Updates #1755.

### Documentation

N/A

### Testing

- [x] Unit tests
- [x] E2E tests
- [x] Manual testing on Universal
- [ ] Manual testing on Kubernetes 
