### PR TITLE
fix(dockerfiles) add a user for kuma-cp

### DIFF
--- a/tools/releases/dockerfiles/Dockerfile.kuma-cp
+++ b/tools/releases/dockerfiles/Dockerfile.kuma-cp
@@ -5,11 +5,16 @@ ADD $KUMA_ROOT/build/artifacts-linux-amd64/kuma-cp/kuma-cp /usr/bin
 RUN mkdir -p /etc/kuma
 ADD $KUMA_ROOT/pkg/config/app/kuma-cp/kuma-cp.defaults.yaml /etc/kuma
 
-RUN mkdir /kuma
-COPY $KUMA_ROOT/tools/releases/templates/LICENSE /kuma
-COPY $KUMA_ROOT/tools/releases/templates/NOTICE /kuma
-COPY $KUMA_ROOT/tools/releases/templates/README /kuma
+COPY $KUMA_ROOT/tools/releases/templates/LICENSE \
+    $KUMA_ROOT/tools/releases/templates/README \
+    /kuma/
 
-USER nobody:nobody
+COPY $KUMA_ROOT/tools/releases/templates/NOTICE /kuma/
+
+RUN addgroup -S -g 6789 kuma-cp \
+ && adduser -S -D -G kuma-cp -u 6789 kuma-cp
+
+USER kuma-cp
+WORKDIR /home/kuma-cp
 
 ENTRYPOINT ["kuma-cp"]

--- a/tools/releases/dockerfiles/Dockerfile.kuma-dp
+++ b/tools/releases/dockerfiles/Dockerfile.kuma-dp
@@ -4,10 +4,11 @@ FROM envoyproxy/envoy-alpine:v1.17.1
 ADD $KUMA_ROOT/build/artifacts-linux-amd64/kuma-dp/kuma-dp /usr/bin
 ADD $KUMA_ROOT/build/artifacts-linux-amd64/coredns/coredns /usr/bin
 
-RUN mkdir /kuma
-COPY $KUMA_ROOT/tools/releases/templates/LICENSE /kuma
-COPY $KUMA_ROOT/tools/releases/templates/NOTICE /kuma
-COPY $KUMA_ROOT/tools/releases/templates/README /kuma
+COPY $KUMA_ROOT/tools/releases/templates/LICENSE \
+    $KUMA_ROOT/tools/releases/templates/README \
+    /kuma/
+
+COPY $KUMA_ROOT/tools/releases/templates/NOTICE /kuma/
 
 USER nobody:nobody
 

--- a/tools/releases/dockerfiles/Dockerfile.kuma-init
+++ b/tools/releases/dockerfiles/Dockerfile.kuma-init
@@ -6,10 +6,11 @@ RUN apt-get update && \
 
 ADD $KUMA_ROOT/build/artifacts-linux-amd64/kumactl/kumactl /usr/bin
 
-RUN mkdir /kuma
-COPY $KUMA_ROOT/tools/releases/templates/LICENSE /kuma
+COPY $KUMA_ROOT/tools/releases/templates/LICENSE \
+    $KUMA_ROOT/tools/releases/templates/README \
+    /kuma/
+
 COPY $KUMA_ROOT/tools/releases/templates/NOTICE-kumactl /kuma/NOTICE
-COPY $KUMA_ROOT/tools/releases/templates/README /kuma
 
 RUN adduser --system --disabled-password --group kumactl --uid 5678
 

--- a/tools/releases/dockerfiles/Dockerfile.kuma-prometheus-sd
+++ b/tools/releases/dockerfiles/Dockerfile.kuma-prometheus-sd
@@ -2,10 +2,11 @@ FROM alpine:3.13.3
 
 ADD $KUMA_ROOT/build/artifacts-linux-amd64/kuma-prometheus-sd/kuma-prometheus-sd /usr/bin
 
-RUN mkdir /kuma
-COPY $KUMA_ROOT/tools/releases/templates/LICENSE /kuma
-COPY $KUMA_ROOT/tools/releases/templates/NOTICE /kuma
-COPY $KUMA_ROOT/tools/releases/templates/README /kuma
+COPY $KUMA_ROOT/tools/releases/templates/LICENSE \
+    $KUMA_ROOT/tools/releases/templates/README \
+    /kuma/
+
+COPY $KUMA_ROOT/tools/releases/templates/NOTICE /kuma/
 
 USER nobody:nobody
 

--- a/tools/releases/dockerfiles/Dockerfile.kumactl
+++ b/tools/releases/dockerfiles/Dockerfile.kumactl
@@ -4,10 +4,11 @@ RUN apk add --no-cache curl
 
 ADD $KUMA_ROOT/build/artifacts-linux-amd64/kumactl/kumactl /usr/bin
 
-RUN mkdir /kuma
-COPY $KUMA_ROOT/tools/releases/templates/LICENSE /kuma
+COPY $KUMA_ROOT/tools/releases/templates/LICENSE \
+    $KUMA_ROOT/tools/releases/templates/README \
+    /kuma/
+
 COPY $KUMA_ROOT/tools/releases/templates/NOTICE-kumactl /kuma/NOTICE
-COPY $KUMA_ROOT/tools/releases/templates/README /kuma
 
 RUN addgroup -S -g 6789 kumactl \
  && adduser -S -D -G kumactl -u 6789 kumactl


### PR DESCRIPTION
### Summary

* "kuma-cp run" needs a home directory to store state, so run it using
  a standard unprivileged Kuma user account.

* Adjust all the Dockerfile COPY commands to minimize the image layers.

### Full changelog

* Fix missing home directories in the Kuma Docker images.

### Issues resolved

Fix #2128.

### Documentation

N/A

### Testing

- [x] Unit tests
- [x] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes 
