### PR TITLE
fix(kuma-cp) raise the regex program size limit

### DIFF
--- a/pkg/xds/bootstrap/template_v3.go
+++ b/pkg/xds/bootstrap/template_v3.go
@@ -54,6 +54,8 @@ layered_runtime:
   - name: kuma
     static_layer:
       envoy.restart_features.use_apple_api_for_dns_lookups: false
+      re2.max_program_size.error_level: 4294967295 # UINT32_MAX
+      re2.max_program_size.warn_level: 1000
 
 stats_config:
   stats_tags:

--- a/pkg/xds/bootstrap/testdata/bootstrap.k8s.golden.yaml
+++ b/pkg/xds/bootstrap/testdata/bootstrap.k8s.golden.yaml
@@ -49,6 +49,8 @@ layeredRuntime:
   - name: kuma
     staticLayer:
       envoy.restart_features.use_apple_api_for_dns_lookups: false
+      re2.max_program_size.error_level: 4294967295
+      re2.max_program_size.warn_level: 1000
 node:
   cluster: backend
   id: default.dp-1.default

--- a/pkg/xds/bootstrap/testdata/bootstrap.overridden.golden.yaml
+++ b/pkg/xds/bootstrap/testdata/bootstrap.overridden.golden.yaml
@@ -55,6 +55,8 @@ layeredRuntime:
   - name: kuma
     staticLayer:
       envoy.restart_features.use_apple_api_for_dns_lookups: false
+      re2.max_program_size.error_level: 4294967295
+      re2.max_program_size.warn_level: 1000
 node:
   cluster: backend
   id: default.dp-1.default

--- a/pkg/xds/bootstrap/testdata/bootstrap.universal.golden.yaml
+++ b/pkg/xds/bootstrap/testdata/bootstrap.universal.golden.yaml
@@ -49,6 +49,8 @@ layeredRuntime:
   - name: kuma
     staticLayer:
       envoy.restart_features.use_apple_api_for_dns_lookups: false
+      re2.max_program_size.error_level: 4294967295
+      re2.max_program_size.warn_level: 1000
 node:
   cluster: backend
   id: default.dp-1

--- a/pkg/xds/bootstrap/testdata/generator.custom-config-minimal-request.golden.yaml
+++ b/pkg/xds/bootstrap/testdata/generator.custom-config-minimal-request.golden.yaml
@@ -29,6 +29,8 @@ layeredRuntime:
   - name: kuma
     staticLayer:
       envoy.restart_features.use_apple_api_for_dns_lookups: false
+      re2.max_program_size.error_level: 4294967295
+      re2.max_program_size.warn_level: 1000
 node:
   cluster: backend
   id: mesh.name.namespace

--- a/pkg/xds/bootstrap/testdata/generator.custom-config.golden.yaml
+++ b/pkg/xds/bootstrap/testdata/generator.custom-config.golden.yaml
@@ -55,6 +55,8 @@ layeredRuntime:
   - name: kuma
     staticLayer:
       envoy.restart_features.use_apple_api_for_dns_lookups: false
+      re2.max_program_size.error_level: 4294967295
+      re2.max_program_size.warn_level: 1000
 node:
   cluster: backend
   id: mesh.name.namespace

--- a/pkg/xds/bootstrap/testdata/generator.default-config-minimal-request.golden.yaml
+++ b/pkg/xds/bootstrap/testdata/generator.default-config-minimal-request.golden.yaml
@@ -23,6 +23,8 @@ layeredRuntime:
   - name: kuma
     staticLayer:
       envoy.restart_features.use_apple_api_for_dns_lookups: false
+      re2.max_program_size.error_level: 4294967295
+      re2.max_program_size.warn_level: 1000
 node:
   cluster: backend
   id: mesh.name.namespace

--- a/pkg/xds/bootstrap/testdata/generator.default-config.golden.yaml
+++ b/pkg/xds/bootstrap/testdata/generator.default-config.golden.yaml
@@ -35,6 +35,8 @@ layeredRuntime:
   - name: kuma
     staticLayer:
       envoy.restart_features.use_apple_api_for_dns_lookups: false
+      re2.max_program_size.error_level: 4294967295
+      re2.max_program_size.warn_level: 1000
 node:
   cluster: backend
   id: mesh.name.namespace

--- a/pkg/xds/bootstrap/testdata/generator.default-config.kubernetes.golden.yaml
+++ b/pkg/xds/bootstrap/testdata/generator.default-config.kubernetes.golden.yaml
@@ -35,6 +35,8 @@ layeredRuntime:
   - name: kuma
     staticLayer:
       envoy.restart_features.use_apple_api_for_dns_lookups: false
+      re2.max_program_size.error_level: 4294967295
+      re2.max_program_size.warn_level: 1000
 node:
   cluster: backend
   id: mesh.name.namespace

--- a/pkg/xds/bootstrap/testdata/generator.default-config.kubernetes.ipv6.golden.yaml
+++ b/pkg/xds/bootstrap/testdata/generator.default-config.kubernetes.ipv6.golden.yaml
@@ -35,6 +35,8 @@ layeredRuntime:
   - name: kuma
     staticLayer:
       envoy.restart_features.use_apple_api_for_dns_lookups: false
+      re2.max_program_size.error_level: 4294967295
+      re2.max_program_size.warn_level: 1000
 node:
   cluster: backend
   id: mesh.name.namespace


### PR DESCRIPTION
### Summary

Even though regex program sizes are deprecated, Envoy still enforces
the default limit of 100 in the layered runtime. Since users have no
reasonable way to predict the size of some arbitrary regex or know
how that affect performance, just max out the limit. We have to use
UINT32_MAX here, because the actual check truncates the value. We also
set a warning limit to an arbitrary size value in case anyone looks at
logs and wants to optimize their regexes.

### Full changelog

N/A

### Issues resolved

Fix #2103.

### Documentation

N/A

### Testing

- [x] Unit tests
- [x] E2E tests
- [ ] Manual testing on Universal
- [x] Manual testing on Kubernetes 

After applying the new bootstrap, Envoy accepts a regex with a large program size, but logs a warning:
```
[2021-06-09 23:52:07.442][19][warning][misc] [source/common/common/regex.cc:100] regex '/static/[a-zA-Z0-9._-]{0,200}/[a-zA-Z0-9._-]{0,200}' RE2 program size of 2013 > max program size of 1000 set for the warn level threshold. Increase configured max program size if necessary.

```
