### PR TITLE
chore(*) drop deprecated Envoy options

### DIFF
--- a/pkg/xds/envoy/clusters/configurers.go
+++ b/pkg/xds/envoy/clusters/configurers.go
@@ -189,3 +189,9 @@ func Http2() ClusterBuilderOpt {
 		config.AddV3(&v3.Http2Configurer{})
 	})
 }
+
+func Http() ClusterBuilderOpt {
+	return ClusterBuilderOptFunc(func(config *ClusterBuilderConfig) {
+		config.AddV3(&v3.HttpConfigurer{})
+	})
+}

--- a/pkg/xds/envoy/clusters/v3/http2_configurer.go
+++ b/pkg/xds/envoy/clusters/v3/http2_configurer.go
@@ -3,6 +3,10 @@ package clusters
 import (
 	envoy_cluster "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
 	envoy_core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	envoy_upstream_http "github.com/envoyproxy/go-control-plane/envoy/extensions/upstreams/http/v3"
+	"github.com/golang/protobuf/ptypes/any"
+
+	"github.com/kumahq/kuma/pkg/util/proto"
 )
 
 type Http2Configurer struct {
@@ -11,25 +15,22 @@ type Http2Configurer struct {
 var _ ClusterConfigurer = &Http2Configurer{}
 
 func (p *Http2Configurer) Configure(c *envoy_cluster.Cluster) error {
-	// nolint:staticcheck // keep deprecated options to be compatible with Envoy 1.16.x in Kuma 1.0.x
-	c.Http2ProtocolOptions = &envoy_core.Http2ProtocolOptions{}
+	options := &envoy_upstream_http.HttpProtocolOptions{
+		UpstreamProtocolOptions: &envoy_upstream_http.HttpProtocolOptions_ExplicitHttpConfig_{
+			ExplicitHttpConfig: &envoy_upstream_http.HttpProtocolOptions_ExplicitHttpConfig{
+				ProtocolConfig: &envoy_upstream_http.HttpProtocolOptions_ExplicitHttpConfig_Http2ProtocolOptions{
+					Http2ProtocolOptions: &envoy_core.Http2ProtocolOptions{},
+				},
+			},
+		},
+	}
 
-	// options := &envoy_upstream_http.HttpProtocolOptions{
-	// 	UpstreamProtocolOptions: &envoy_upstream_http.HttpProtocolOptions_ExplicitHttpConfig_{
-	// 		ExplicitHttpConfig: &envoy_upstream_http.HttpProtocolOptions_ExplicitHttpConfig{
-	// 			ProtocolConfig: &envoy_upstream_http.HttpProtocolOptions_ExplicitHttpConfig_Http2ProtocolOptions{
-	// 				Http2ProtocolOptions: &envoy_core.Http2ProtocolOptions{},
-	// 			},
-	// 		},
-	// 	},
-	// }
-	//
-	// pbst, err := proto.MarshalAnyDeterministic(options)
-	// if err != nil {
-	// 	return err
-	// }
-	// c.TypedExtensionProtocolOptions = map[string]*any.Any{
-	// 	"envoy.extensions.upstreams.http.v3.HttpProtocolOptions": pbst,
-	// }
+	pbst, err := proto.MarshalAnyDeterministic(options)
+	if err != nil {
+		return err
+	}
+	c.TypedExtensionProtocolOptions = map[string]*any.Any{
+		"envoy.extensions.upstreams.http.v3.HttpProtocolOptions": pbst,
+	}
 	return nil
 }

--- a/pkg/xds/envoy/clusters/v3/http2_configurer_test.go
+++ b/pkg/xds/envoy/clusters/v3/http2_configurer_test.go
@@ -13,7 +13,12 @@ var _ = Describe("Http2Configurer", func() {
 
 	It("should generate proper Envoy config", func() {
 		// given
-		expected := `http2ProtocolOptions: {}`
+		expected := `
+        typedExtensionProtocolOptions:
+          envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+            '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+            explicitHttpConfig:
+              http2ProtocolOptions: {}`
 
 		// when
 		cluster, err := clusters.NewClusterBuilder(envoy.APIV3).

--- a/pkg/xds/envoy/clusters/v3/http_configurer.go
+++ b/pkg/xds/envoy/clusters/v3/http_configurer.go
@@ -2,22 +2,22 @@ package clusters
 
 import (
 	envoy_cluster "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
-	envoy_core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	envoy_config_core_v3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	envoy_upstream_http "github.com/envoyproxy/go-control-plane/envoy/extensions/upstreams/http/v3"
 )
 
-type Http2Configurer struct {
+type HttpConfigurer struct {
 }
 
-var _ ClusterConfigurer = &Http2Configurer{}
+var _ ClusterConfigurer = &HttpConfigurer{}
 
-func (p *Http2Configurer) Configure(c *envoy_cluster.Cluster) error {
+func (p *HttpConfigurer) Configure(c *envoy_cluster.Cluster) error {
 	return UpdateCommonHttpProtocolOptions(c, func(options *envoy_upstream_http.HttpProtocolOptions) {
 		if options.UpstreamProtocolOptions == nil {
 			options.UpstreamProtocolOptions = &envoy_upstream_http.HttpProtocolOptions_ExplicitHttpConfig_{
 				ExplicitHttpConfig: &envoy_upstream_http.HttpProtocolOptions_ExplicitHttpConfig{
-					ProtocolConfig: &envoy_upstream_http.HttpProtocolOptions_ExplicitHttpConfig_Http2ProtocolOptions{
-						Http2ProtocolOptions: &envoy_core.Http2ProtocolOptions{},
+					ProtocolConfig: &envoy_upstream_http.HttpProtocolOptions_ExplicitHttpConfig_HttpProtocolOptions{
+						HttpProtocolOptions: &envoy_config_core_v3.Http1ProtocolOptions{},
 					},
 				},
 			}

--- a/pkg/xds/envoy/clusters/v3/http_configurer_test.go
+++ b/pkg/xds/envoy/clusters/v3/http_configurer_test.go
@@ -1,0 +1,35 @@
+package clusters_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	util_proto "github.com/kumahq/kuma/pkg/util/proto"
+	"github.com/kumahq/kuma/pkg/xds/envoy"
+	"github.com/kumahq/kuma/pkg/xds/envoy/clusters"
+)
+
+var _ = Describe("HttpConfigurer", func() {
+
+	It("should generate proper Envoy config", func() {
+		// given
+		expected := `
+        typedExtensionProtocolOptions:
+          envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+            '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+            explicitHttpConfig:
+              httpProtocolOptions: {}`
+
+		// when
+		cluster, err := clusters.NewClusterBuilder(envoy.APIV3).
+			Configure(clusters.Http()).
+			Build()
+
+		// then
+		Expect(err).ToNot(HaveOccurred())
+
+		actual, err := util_proto.ToYAML(cluster)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(actual).To(MatchYAML(expected))
+	})
+})

--- a/pkg/xds/envoy/clusters/v3/timeout_configurer.go
+++ b/pkg/xds/envoy/clusters/v3/timeout_configurer.go
@@ -5,7 +5,11 @@ import (
 
 	envoy_cluster "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
 	envoy_core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	envoy_upstream_http "github.com/envoyproxy/go-control-plane/envoy/extensions/upstreams/http/v3"
 	"github.com/golang/protobuf/ptypes"
+	"github.com/golang/protobuf/ptypes/any"
+
+	"github.com/kumahq/kuma/pkg/util/proto"
 
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	mesh_core "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
@@ -24,42 +28,32 @@ func (t *TimeoutConfigurer) Configure(cluster *envoy_cluster.Cluster) error {
 	cluster.ConnectTimeout = ptypes.DurationProto(t.Conf.GetConnectTimeoutOrDefault(defaultConnectTimeout))
 	switch t.Protocol {
 	case mesh_core.ProtocolHTTP, mesh_core.ProtocolHTTP2:
-		// nolint:staticcheck // keep deprecated options to be compatible with Envoy 1.16.x in Kuma 1.0.x
-		cluster.CommonHttpProtocolOptions = &envoy_core.HttpProtocolOptions{
-			IdleTimeout: ptypes.DurationProto(t.Conf.GetHttp().GetIdleTimeout().AsDuration()),
+		options := &envoy_upstream_http.HttpProtocolOptions{
+			CommonHttpProtocolOptions: &envoy_core.HttpProtocolOptions{
+				IdleTimeout: ptypes.DurationProto(t.Conf.GetHttp().GetIdleTimeout().AsDuration()),
+			},
 		}
-
-		// options := &envoy_upstream_http.HttpProtocolOptions{
-		// 	CommonHttpProtocolOptions: &envoy_core.HttpProtocolOptions{
-		// 		IdleTimeout: ptypes.DurationProto(t.Conf.GetHttp().GetIdleTimeout().AsDuration()),
-		// 	},
-		// }
-		// pbst, err := proto.MarshalAnyDeterministic(options)
-		// if err != nil {
-		// 	return err
-		// }
-		// cluster.TypedExtensionProtocolOptions = map[string]*any.Any{
-		// 	"envoy.extensions.upstreams.http.v3.HttpProtocolOptions": pbst,
-		// }
+		pbst, err := proto.MarshalAnyDeterministic(options)
+		if err != nil {
+			return err
+		}
+		cluster.TypedExtensionProtocolOptions = map[string]*any.Any{
+			"envoy.extensions.upstreams.http.v3.HttpProtocolOptions": pbst,
+		}
 	case mesh_core.ProtocolGRPC:
 		if maxStreamDuration := t.Conf.GetGrpc().GetMaxStreamDuration().AsDuration(); maxStreamDuration != 0 {
-			// nolint:staticcheck // keep deprecated options to be compatible with Envoy 1.16.x in Kuma 1.0.x
-			cluster.CommonHttpProtocolOptions = &envoy_core.HttpProtocolOptions{
-				MaxStreamDuration: ptypes.DurationProto(maxStreamDuration),
+			options := &envoy_upstream_http.HttpProtocolOptions{
+				CommonHttpProtocolOptions: &envoy_core.HttpProtocolOptions{
+					MaxStreamDuration: ptypes.DurationProto(maxStreamDuration),
+				},
 			}
-
-			// options := &envoy_upstream_http.HttpProtocolOptions{
-			// 	CommonHttpProtocolOptions: &envoy_core.HttpProtocolOptions{
-			// 		MaxStreamDuration: ptypes.DurationProto(maxStreamDuration),
-			// 	},
-			// }
-			// pbst, err := proto.MarshalAnyDeterministic(options)
-			// if err != nil {
-			// 	return err
-			// }
-			// cluster.TypedExtensionProtocolOptions = map[string]*any.Any{
-			// 	"envoy.extensions.upstreams.http.v3.HttpProtocolOptions": pbst,
-			// }
+			pbst, err := proto.MarshalAnyDeterministic(options)
+			if err != nil {
+				return err
+			}
+			cluster.TypedExtensionProtocolOptions = map[string]*any.Any{
+				"envoy.extensions.upstreams.http.v3.HttpProtocolOptions": pbst,
+			}
 		}
 	}
 	return nil

--- a/pkg/xds/envoy/clusters/v3/update_common_http_protocol_options.go
+++ b/pkg/xds/envoy/clusters/v3/update_common_http_protocol_options.go
@@ -1,0 +1,32 @@
+package clusters
+
+import (
+	envoy_cluster "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
+	envoy_upstream_http "github.com/envoyproxy/go-control-plane/envoy/extensions/upstreams/http/v3"
+	"github.com/golang/protobuf/ptypes/any"
+	proto2 "google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/anypb"
+
+	"github.com/kumahq/kuma/pkg/util/proto"
+)
+
+func UpdateCommonHttpProtocolOptions(cluster *envoy_cluster.Cluster, fn func(*envoy_upstream_http.HttpProtocolOptions)) error {
+	if cluster.TypedExtensionProtocolOptions == nil {
+		cluster.TypedExtensionProtocolOptions = map[string]*any.Any{}
+	}
+	options := &envoy_upstream_http.HttpProtocolOptions{}
+	if any := cluster.TypedExtensionProtocolOptions["envoy.extensions.upstreams.http.v3.HttpProtocolOptions"]; any != nil {
+		if err := anypb.UnmarshalTo(any, options, proto2.UnmarshalOptions{}); err != nil {
+			return err
+		}
+	}
+
+	fn(options)
+
+	pbst, err := proto.MarshalAnyDeterministic(options)
+	if err != nil {
+		return err
+	}
+	cluster.TypedExtensionProtocolOptions["envoy.extensions.upstreams.http.v3.HttpProtocolOptions"] = pbst
+	return nil
+}

--- a/pkg/xds/envoy/listeners/v3/access_log_configurer.go
+++ b/pkg/xds/envoy/listeners/v3/access_log_configurer.go
@@ -109,20 +109,16 @@ func fileAccessLog(format *accesslog.AccessLogFormat, cfgStr *structpb.Struct) (
 	}
 
 	fileAccessLog := &access_loggers_file.FileAccessLog{
-		// AccessLogFormat: &access_loggers_file.FileAccessLog_LogFormat{
-		// 	LogFormat: &envoy_core.SubstitutionFormatString{
-		// 		Format: &envoy_core.SubstitutionFormatString_TextFormatSource{
-		// 			TextFormatSource: &envoy_core.DataSource{
-		// 				Specifier: &envoy_core.DataSource_InlineString{
-		// 					InlineString: format.String(),
-		// 				},
-		// 			},
-		// 		},
-		// 	},
-		// },
-		AccessLogFormat: &access_loggers_file.FileAccessLog_Format{
-			// nolint:staticcheck // keep deprecated options to be compatible with Envoy 1.16.x in Kuma 1.0.x
-			Format: format.String(),
+		AccessLogFormat: &access_loggers_file.FileAccessLog_LogFormat{
+			LogFormat: &envoy_core.SubstitutionFormatString{
+				Format: &envoy_core.SubstitutionFormatString_TextFormatSource{
+					TextFormatSource: &envoy_core.DataSource{
+						Specifier: &envoy_core.DataSource_InlineString{
+							InlineString: format.String(),
+						},
+					},
+				},
+			},
 		},
 		Path: cfg.Path,
 	}

--- a/pkg/xds/envoy/listeners/v3/http_access_log_configurer_test.go
+++ b/pkg/xds/envoy/listeners/v3/http_access_log_configurer_test.go
@@ -126,16 +126,17 @@ var _ = Describe("HttpAccessLogConfigurer", func() {
                   - name: envoy.access_loggers.file
                     typedConfig:
                       '@type': type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog
-                      format: |+
-                        [%START_TIME%] demo "%REQ(:method)% %REQ(x-envoy-original-path?:path)% %PROTOCOL%" %RESPONSE_CODE% %RESPONSE_FLAGS% %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(x-envoy-upstream-service-time)% "%REQ(x-forwarded-for)%" "%REQ(user-agent)%" "%REQ(x-request-id)%" "%REQ(:authority)%" "web" "backend" "192.168.0.1" "%UPSTREAM_HOST%"
-
+                      logFormat:
+                        textFormatSource:
+                          inlineString: |+
+                            [%START_TIME%] demo "%REQ(:method)% %REQ(x-envoy-original-path?:path)% %PROTOCOL%" %RESPONSE_CODE% %RESPONSE_FLAGS% %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(x-envoy-upstream-service-time)% "%REQ(x-forwarded-for)%" "%REQ(user-agent)%" "%REQ(x-request-id)%" "%REQ(:authority)%" "web" "backend" "192.168.0.1" "%UPSTREAM_HOST%"
+            
                       path: /tmp/log
                   httpFilters:
                   - name: envoy.filters.http.router
                   statPrefix: backend
             name: outbound:127.0.0.1:27070
-            trafficDirection: OUTBOUND
-`,
+            trafficDirection: OUTBOUND`,
 		}),
 		Entry("basic http_connection_manager with tcp access log", testCase{
 			listenerName:    "outbound:127.0.0.1:27070",

--- a/pkg/xds/envoy/listeners/v3/network_access_log_configurer_test.go
+++ b/pkg/xds/envoy/listeners/v3/network_access_log_configurer_test.go
@@ -131,15 +131,16 @@ var _ = Describe("NetworkAccessLogConfigurer", func() {
                   - name: envoy.access_loggers.file
                     typedConfig:
                       '@type': type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog
-                      format: |+
-                        [%START_TIME%] %RESPONSE_FLAGS% demo 192.168.0.1(backend)->%UPSTREAM_HOST%(db) took %DURATION%ms, sent %BYTES_SENT% bytes, received: %BYTES_RECEIVED% bytes
-
+                      logFormat:
+                        textFormatSource:
+                          inlineString: |+
+                            [%START_TIME%] %RESPONSE_FLAGS% demo 192.168.0.1(backend)->%UPSTREAM_HOST%(db) took %DURATION%ms, sent %BYTES_SENT% bytes, received: %BYTES_RECEIVED% bytes
+            
                       path: /tmp/log
                   cluster: db
                   statPrefix: db
             name: outbound:127.0.0.1:5432
-            trafficDirection: OUTBOUND
-`,
+            trafficDirection: OUTBOUND`,
 		}),
 		Entry("basic tcp_proxy with tcp access log", testCase{
 			listenerName:    "outbound:127.0.0.1:5432",

--- a/pkg/xds/generator/outbound_proxy_generator.go
+++ b/pkg/xds/generator/outbound_proxy_generator.go
@@ -191,6 +191,8 @@ func (o OutboundProxyGenerator) generateCDS(ctx xds_context.Context, proxy *mode
 						proxy.Dataplane.IsIPv6())).
 					Configure(envoy_clusters.ClientSideTLS(proxy.Routing.OutboundTargets[serviceName]))
 				switch protocol {
+				case mesh_core.ProtocolHTTP:
+					edsClusterBuilder.Configure(envoy_clusters.Http())
 				case mesh_core.ProtocolHTTP2, mesh_core.ProtocolGRPC:
 					edsClusterBuilder.Configure(envoy_clusters.Http2())
 				default:

--- a/pkg/xds/generator/testdata/outbound-proxy/03.envoy.golden.yaml
+++ b/pkg/xds/generator/testdata/outbound-proxy/03.envoy.golden.yaml
@@ -196,6 +196,8 @@ resources:
     typedExtensionProtocolOptions:
       envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
         '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+        commonHttpProtocolOptions:
+          idleTimeout: 0s
         explicitHttpConfig:
           http2ProtocolOptions: {}
 - name: api-http2
@@ -216,6 +218,8 @@ resources:
     typedExtensionProtocolOptions:
       envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
         '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+        commonHttpProtocolOptions:
+          idleTimeout: 0s
         explicitHttpConfig:
           http2ProtocolOptions: {}
 - name: api-tcp

--- a/pkg/xds/generator/testdata/outbound-proxy/03.envoy.golden.yaml
+++ b/pkg/xds/generator/testdata/outbound-proxy/03.envoy.golden.yaml
@@ -169,21 +169,22 @@ resources:
       edsConfig:
         ads: {}
         resourceApiVersion: V3
-    http2ProtocolOptions: {}
     lbPolicy: RANDOM
     name: api-grpc
     type: EDS
+    typedExtensionProtocolOptions:
+      envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+        '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+        explicitHttpConfig:
+          http2ProtocolOptions: {}
 - name: api-http
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
-    commonHttpProtocolOptions:
-      idleTimeout: 0s
     connectTimeout: 10s
     edsClusterConfig:
       edsConfig:
         ads: {}
         resourceApiVersion: V3
-    http2ProtocolOptions: {}
     name: api-http
     outlierDetection:
       enforcingConsecutive5xx: 100
@@ -192,17 +193,19 @@ resources:
       enforcingFailurePercentage: 0
       enforcingSuccessRate: 0
     type: EDS
+    typedExtensionProtocolOptions:
+      envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+        '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+        explicitHttpConfig:
+          http2ProtocolOptions: {}
 - name: api-http2
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
-    commonHttpProtocolOptions:
-      idleTimeout: 0s
     connectTimeout: 10s
     edsClusterConfig:
       edsConfig:
         ads: {}
         resourceApiVersion: V3
-    http2ProtocolOptions: {}
     lbPolicy: RING_HASH
     name: api-http2
     ringHashLbConfig:
@@ -210,6 +213,11 @@ resources:
       maximumRingSize: "1024"
       minimumRingSize: "64"
     type: EDS
+    typedExtensionProtocolOptions:
+      envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+        '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+        explicitHttpConfig:
+          http2ProtocolOptions: {}
 - name: api-tcp
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
@@ -218,12 +226,16 @@ resources:
       edsConfig:
         ads: {}
         resourceApiVersion: V3
-    http2ProtocolOptions: {}
     lbPolicy: LEAST_REQUEST
     leastRequestLbConfig:
       choiceCount: 4
     name: api-tcp
     type: EDS
+    typedExtensionProtocolOptions:
+      envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+        '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+        explicitHttpConfig:
+          http2ProtocolOptions: {}
 - name: backend
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
@@ -232,10 +244,14 @@ resources:
       edsConfig:
         ads: {}
         resourceApiVersion: V3
-    http2ProtocolOptions: {}
     lbPolicy: MAGLEV
     name: backend
     type: EDS
+    typedExtensionProtocolOptions:
+      envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+        '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+        explicitHttpConfig:
+          http2ProtocolOptions: {}
 - name: db-_0_
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
@@ -244,9 +260,13 @@ resources:
       edsConfig:
         ads: {}
         resourceApiVersion: V3
-    http2ProtocolOptions: {}
     name: db-_0_
     type: EDS
+    typedExtensionProtocolOptions:
+      envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+        '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+        explicitHttpConfig:
+          http2ProtocolOptions: {}
 - name: db-_1_
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
@@ -255,9 +275,13 @@ resources:
       edsConfig:
         ads: {}
         resourceApiVersion: V3
-    http2ProtocolOptions: {}
     name: db-_1_
     type: EDS
+    typedExtensionProtocolOptions:
+      envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+        '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+        explicitHttpConfig:
+          http2ProtocolOptions: {}
 - name: outbound:127.0.0.1:18080
   resource:
     '@type': type.googleapis.com/envoy.config.listener.v3.Listener
@@ -290,8 +314,10 @@ resources:
           - name: envoy.access_loggers.file
             typedConfig:
               '@type': type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog
-              format: |+
-                [%START_TIME%] mesh1 "%REQ(:method)% %REQ(x-envoy-original-path?:path)% %PROTOCOL%" %RESPONSE_CODE% %RESPONSE_FLAGS% %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(x-envoy-upstream-service-time)% "%REQ(x-forwarded-for)%" "%REQ(user-agent)%" "%REQ(x-request-id)%" "%REQ(:authority)%" "gateway" "api-http" "10.0.0.1" "%UPSTREAM_HOST%"
+              logFormat:
+                textFormatSource:
+                  inlineString: |+
+                    [%START_TIME%] mesh1 "%REQ(:method)% %REQ(x-envoy-original-path?:path)% %PROTOCOL%" %RESPONSE_CODE% %RESPONSE_FLAGS% %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(x-envoy-upstream-service-time)% "%REQ(x-forwarded-for)%" "%REQ(user-agent)%" "%REQ(x-request-id)%" "%REQ(:authority)%" "gateway" "api-http" "10.0.0.1" "%UPSTREAM_HOST%"
 
               path: /var/log
           httpFilters:

--- a/pkg/xds/generator/testdata/outbound-proxy/04.envoy.golden.yaml
+++ b/pkg/xds/generator/testdata/outbound-proxy/04.envoy.golden.yaml
@@ -128,14 +128,11 @@ resources:
 - name: api-http
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
-    commonHttpProtocolOptions:
-      idleTimeout: 0s
     connectTimeout: 10s
     edsClusterConfig:
       edsConfig:
         ads: {}
         resourceApiVersion: V3
-    http2ProtocolOptions: {}
     name: api-http
     outlierDetection:
       enforcingConsecutive5xx: 100
@@ -174,6 +171,11 @@ resources:
               resourceApiVersion: V3
         sni: api-http{mesh=mesh1}
     type: EDS
+    typedExtensionProtocolOptions:
+      envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+        '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+        explicitHttpConfig:
+          http2ProtocolOptions: {}
 - name: api-tcp
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
@@ -182,7 +184,6 @@ resources:
       edsConfig:
         ads: {}
         resourceApiVersion: V3
-    http2ProtocolOptions: {}
     lbPolicy: LEAST_REQUEST
     leastRequestLbConfig:
       choiceCount: 4
@@ -218,6 +219,11 @@ resources:
               resourceApiVersion: V3
         sni: api-tcp{mesh=mesh1}
     type: EDS
+    typedExtensionProtocolOptions:
+      envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+        '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+        explicitHttpConfig:
+          http2ProtocolOptions: {}
 - name: backend
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
@@ -226,7 +232,6 @@ resources:
       edsConfig:
         ads: {}
         resourceApiVersion: V3
-    http2ProtocolOptions: {}
     lbPolicy: MAGLEV
     name: backend
     transportSocket:
@@ -260,6 +265,11 @@ resources:
               resourceApiVersion: V3
         sni: backend{mesh=mesh1}
     type: EDS
+    typedExtensionProtocolOptions:
+      envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+        '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+        explicitHttpConfig:
+          http2ProtocolOptions: {}
 - name: db-_0_
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
@@ -268,7 +278,6 @@ resources:
       edsConfig:
         ads: {}
         resourceApiVersion: V3
-    http2ProtocolOptions: {}
     name: db-_0_
     transportSocket:
       name: envoy.transport_sockets.tls
@@ -301,6 +310,11 @@ resources:
               resourceApiVersion: V3
         sni: db{mesh=mesh1,role=master}
     type: EDS
+    typedExtensionProtocolOptions:
+      envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+        '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+        explicitHttpConfig:
+          http2ProtocolOptions: {}
 - name: db-_1_
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
@@ -309,7 +323,6 @@ resources:
       edsConfig:
         ads: {}
         resourceApiVersion: V3
-    http2ProtocolOptions: {}
     name: db-_1_
     transportSocket:
       name: envoy.transport_sockets.tls
@@ -342,6 +355,11 @@ resources:
               resourceApiVersion: V3
         sni: db{mesh=mesh1,role=replica}
     type: EDS
+    typedExtensionProtocolOptions:
+      envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+        '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+        explicitHttpConfig:
+          http2ProtocolOptions: {}
 - name: outbound:127.0.0.1:18080
   resource:
     '@type': type.googleapis.com/envoy.config.listener.v3.Listener
@@ -376,8 +394,10 @@ resources:
           - name: envoy.access_loggers.file
             typedConfig:
               '@type': type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog
-              format: |+
-                [%START_TIME%] mesh1 "%REQ(:method)% %REQ(x-envoy-original-path?:path)% %PROTOCOL%" %RESPONSE_CODE% %RESPONSE_FLAGS% %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(x-envoy-upstream-service-time)% "%REQ(x-forwarded-for)%" "%REQ(user-agent)%" "%REQ(x-request-id)%" "%REQ(:authority)%" "web" "api-http" "10.0.0.1" "%UPSTREAM_HOST%"
+              logFormat:
+                textFormatSource:
+                  inlineString: |+
+                    [%START_TIME%] mesh1 "%REQ(:method)% %REQ(x-envoy-original-path?:path)% %PROTOCOL%" %RESPONSE_CODE% %RESPONSE_FLAGS% %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(x-envoy-upstream-service-time)% "%REQ(x-forwarded-for)%" "%REQ(user-agent)%" "%REQ(x-request-id)%" "%REQ(:authority)%" "web" "api-http" "10.0.0.1" "%UPSTREAM_HOST%"
 
               path: /var/log
           httpFilters:

--- a/pkg/xds/generator/testdata/outbound-proxy/04.envoy.golden.yaml
+++ b/pkg/xds/generator/testdata/outbound-proxy/04.envoy.golden.yaml
@@ -174,6 +174,8 @@ resources:
     typedExtensionProtocolOptions:
       envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
         '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+        commonHttpProtocolOptions:
+          idleTimeout: 0s
         explicitHttpConfig:
           http2ProtocolOptions: {}
 - name: api-tcp

--- a/pkg/xds/generator/testdata/outbound-proxy/05.envoy.golden.yaml
+++ b/pkg/xds/generator/testdata/outbound-proxy/05.envoy.golden.yaml
@@ -2,8 +2,6 @@ resources:
 - name: es-_0_
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
-    commonHttpProtocolOptions:
-      idleTimeout: 0s
     connectTimeout: 10s
     dnsLookupFamily: V4_ONLY
     loadAssignment:
@@ -24,6 +22,11 @@ resources:
                 kuma.io/protocol: http
     name: es-_0_
     type: STRICT_DNS
+    typedExtensionProtocolOptions:
+      envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+        '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+        commonHttpProtocolOptions:
+          idleTimeout: 0s
 - name: outbound:127.0.0.1:18081
   resource:
     '@type': type.googleapis.com/envoy.config.listener.v3.Listener

--- a/pkg/xds/generator/testdata/outbound-proxy/05.envoy.golden.yaml
+++ b/pkg/xds/generator/testdata/outbound-proxy/05.envoy.golden.yaml
@@ -27,6 +27,8 @@ resources:
         '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
         commonHttpProtocolOptions:
           idleTimeout: 0s
+        explicitHttpConfig:
+          httpProtocolOptions: {}
 - name: outbound:127.0.0.1:18081
   resource:
     '@type': type.googleapis.com/envoy.config.listener.v3.Listener

--- a/pkg/xds/generator/testdata/outbound-proxy/06.envoy.golden.yaml
+++ b/pkg/xds/generator/testdata/outbound-proxy/06.envoy.golden.yaml
@@ -25,6 +25,8 @@ resources:
     typedExtensionProtocolOptions:
       envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
         '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+        commonHttpProtocolOptions:
+          idleTimeout: 0s
         explicitHttpConfig:
           http2ProtocolOptions: {}
 - name: outbound:127.0.0.1:18082

--- a/pkg/xds/generator/testdata/outbound-proxy/06.envoy.golden.yaml
+++ b/pkg/xds/generator/testdata/outbound-proxy/06.envoy.golden.yaml
@@ -2,11 +2,8 @@ resources:
 - name: es2-_0_
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
-    commonHttpProtocolOptions:
-      idleTimeout: 0s
     connectTimeout: 10s
     dnsLookupFamily: V4_ONLY
-    http2ProtocolOptions: {}
     loadAssignment:
       clusterName: es2-_0_
       endpoints:
@@ -25,6 +22,11 @@ resources:
                 kuma.io/protocol: http2
     name: es2-_0_
     type: STRICT_DNS
+    typedExtensionProtocolOptions:
+      envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+        '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+        explicitHttpConfig:
+          http2ProtocolOptions: {}
 - name: outbound:127.0.0.1:18082
   resource:
     '@type': type.googleapis.com/envoy.config.listener.v3.Listener

--- a/pkg/xds/generator/testdata/outbound-proxy/cluster-dots.envoy.golden.yaml
+++ b/pkg/xds/generator/testdata/outbound-proxy/cluster-dots.envoy.golden.yaml
@@ -24,9 +24,13 @@ resources:
       edsConfig:
         ads: {}
         resourceApiVersion: V3
-    http2ProtocolOptions: {}
     name: backend.kuma-system
     type: EDS
+    typedExtensionProtocolOptions:
+      envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+        '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+        explicitHttpConfig:
+          http2ProtocolOptions: {}
 - name: db-_0_
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
@@ -35,9 +39,13 @@ resources:
       edsConfig:
         ads: {}
         resourceApiVersion: V3
-    http2ProtocolOptions: {}
     name: db-_0_
     type: EDS
+    typedExtensionProtocolOptions:
+      envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+        '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+        explicitHttpConfig:
+          http2ProtocolOptions: {}
 - name: outbound:127.0.0.1:18080
   resource:
     '@type': type.googleapis.com/envoy.config.listener.v3.Listener

--- a/pkg/xds/generator/testdata/profile-source/1-envoy-config.golden.yaml
+++ b/pkg/xds/generator/testdata/profile-source/1-envoy-config.golden.yaml
@@ -37,7 +37,6 @@ resources:
       edsConfig:
         ads: {}
         resourceApiVersion: V3
-    http2ProtocolOptions: {}
     name: db
     transportSocket:
       name: envoy.transport_sockets.tls
@@ -70,6 +69,11 @@ resources:
               resourceApiVersion: V3
         sni: db{mesh=demo}
     type: EDS
+    typedExtensionProtocolOptions:
+      envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+        '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+        explicitHttpConfig:
+          http2ProtocolOptions: {}
 - name: elastic
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
@@ -84,7 +88,6 @@ resources:
       tcpHealthCheck: {}
       timeout: 4s
       unhealthyThreshold: 3
-    http2ProtocolOptions: {}
     name: elastic
     transportSocket:
       name: envoy.transport_sockets.tls
@@ -117,6 +120,11 @@ resources:
               resourceApiVersion: V3
         sni: elastic{mesh=demo}
     type: EDS
+    typedExtensionProtocolOptions:
+      envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+        '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+        explicitHttpConfig:
+          http2ProtocolOptions: {}
 - name: kuma:envoy:admin
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster

--- a/pkg/xds/generator/testdata/profile-source/2-envoy-config.golden.yaml
+++ b/pkg/xds/generator/testdata/profile-source/2-envoy-config.golden.yaml
@@ -37,7 +37,6 @@ resources:
       edsConfig:
         ads: {}
         resourceApiVersion: V3
-    http2ProtocolOptions: {}
     name: db
     transportSocket:
       name: envoy.transport_sockets.tls
@@ -70,6 +69,11 @@ resources:
               resourceApiVersion: V3
         sni: db{mesh=demo}
     type: EDS
+    typedExtensionProtocolOptions:
+      envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+        '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+        explicitHttpConfig:
+          http2ProtocolOptions: {}
 - name: elastic
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
@@ -84,7 +88,6 @@ resources:
       tcpHealthCheck: {}
       timeout: 4s
       unhealthyThreshold: 3
-    http2ProtocolOptions: {}
     name: elastic
     transportSocket:
       name: envoy.transport_sockets.tls
@@ -117,6 +120,11 @@ resources:
               resourceApiVersion: V3
         sni: elastic{mesh=demo}
     type: EDS
+    typedExtensionProtocolOptions:
+      envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+        '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+        explicitHttpConfig:
+          http2ProtocolOptions: {}
 - name: inbound:passthrough:ipv4
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster

--- a/pkg/xds/generator/testdata/profile-source/3-envoy-config.golden.yaml
+++ b/pkg/xds/generator/testdata/profile-source/3-envoy-config.golden.yaml
@@ -37,7 +37,6 @@ resources:
       edsConfig:
         ads: {}
         resourceApiVersion: V3
-    http2ProtocolOptions: {}
     name: db
     transportSocket:
       name: envoy.transport_sockets.tls
@@ -70,6 +69,11 @@ resources:
               resourceApiVersion: V3
         sni: db{mesh=demo}
     type: EDS
+    typedExtensionProtocolOptions:
+      envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+        '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+        explicitHttpConfig:
+          http2ProtocolOptions: {}
 - name: elastic
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
@@ -84,7 +88,6 @@ resources:
       tcpHealthCheck: {}
       timeout: 4s
       unhealthyThreshold: 3
-    http2ProtocolOptions: {}
     name: elastic
     transportSocket:
       name: envoy.transport_sockets.tls
@@ -117,6 +120,11 @@ resources:
               resourceApiVersion: V3
         sni: elastic{mesh=demo}
     type: EDS
+    typedExtensionProtocolOptions:
+      envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+        '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+        explicitHttpConfig:
+          http2ProtocolOptions: {}
 - name: kuma:envoy:admin
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster

--- a/pkg/xds/generator/testdata/profile-source/4-envoy-config.golden.yaml
+++ b/pkg/xds/generator/testdata/profile-source/4-envoy-config.golden.yaml
@@ -37,7 +37,6 @@ resources:
       edsConfig:
         ads: {}
         resourceApiVersion: V3
-    http2ProtocolOptions: {}
     name: db
     transportSocket:
       name: envoy.transport_sockets.tls
@@ -70,6 +69,11 @@ resources:
               resourceApiVersion: V3
         sni: db{mesh=demo}
     type: EDS
+    typedExtensionProtocolOptions:
+      envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+        '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+        explicitHttpConfig:
+          http2ProtocolOptions: {}
 - name: elastic
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
@@ -84,7 +88,6 @@ resources:
       tcpHealthCheck: {}
       timeout: 4s
       unhealthyThreshold: 3
-    http2ProtocolOptions: {}
     name: elastic
     transportSocket:
       name: envoy.transport_sockets.tls
@@ -117,6 +120,11 @@ resources:
               resourceApiVersion: V3
         sni: elastic{mesh=demo}
     type: EDS
+    typedExtensionProtocolOptions:
+      envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+        '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+        explicitHttpConfig:
+          http2ProtocolOptions: {}
 - name: inbound:passthrough:ipv4
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster

--- a/pkg/xds/generator/testdata/transparent-proxy/03.envoy.golden.yaml
+++ b/pkg/xds/generator/testdata/transparent-proxy/03.envoy.golden.yaml
@@ -52,8 +52,10 @@ resources:
           - name: envoy.access_loggers.file
             typedConfig:
               '@type': type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog
-              format: |+
-                [%START_TIME%] %RESPONSE_FLAGS% default (unknown)->%UPSTREAM_HOST%(external) took %DURATION%ms, sent %BYTES_SENT% bytes, received: %BYTES_RECEIVED% bytes
+              logFormat:
+                textFormatSource:
+                  inlineString: |+
+                    [%START_TIME%] %RESPONSE_FLAGS% default (unknown)->%UPSTREAM_HOST%(external) took %DURATION%ms, sent %BYTES_SENT% bytes, received: %BYTES_RECEIVED% bytes
 
               path: /var/log
           cluster: outbound:passthrough:ipv4

--- a/test/e2e/compatibility/dp_compatibility_universal.go
+++ b/test/e2e/compatibility/dp_compatibility_universal.go
@@ -29,9 +29,9 @@ func UniversalCompatibility() {
 		demoClientToken, err := cluster.GetKuma().GenerateDpToken("default", "demo-client")
 		Expect(err).ToNot(HaveOccurred())
 
-		err = EchoServerUniversal(AppModeEchoServer, "default", "universal", echoServerToken, WithDPVersion("1.0.8"))(cluster)
+		err = EchoServerUniversal(AppModeEchoServer, "default", "universal", echoServerToken, WithDPVersion("1.1.6"))(cluster)
 		Expect(err).ToNot(HaveOccurred())
-		err = DemoClientUniversal(AppModeDemoClient, "default", demoClientToken, WithDPVersion("1.0.8"))(cluster)
+		err = DemoClientUniversal(AppModeDemoClient, "default", demoClientToken, WithDPVersion("1.1.6"))(cluster)
 		Expect(err).ToNot(HaveOccurred())
 	})
 


### PR DESCRIPTION
### Summary

Remove some deprecated Envoy options that were kept for compatibility with Kuma 1.x

### Documentation

- [X] No docs

### Testing

- [X] Unit tests
- [X] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes 
