### PR TITLE
feat(mads) allow specifying fetch-timeout via query param

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -1088,6 +1088,7 @@ github.com/spf13/cast v1.3.1/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkU
 github.com/spf13/cobra v0.0.2-0.20171109065643-2da4a54c5cee/go.mod h1:1l0Ry5zgKvJasoi3XT1TypsSe7PqH0Sj9dhYf7v3XqQ=
 github.com/spf13/cobra v0.0.3/go.mod h1:1l0Ry5zgKvJasoi3XT1TypsSe7PqH0Sj9dhYf7v3XqQ=
 github.com/spf13/cobra v0.0.5/go.mod h1:3K3wKZymM7VvHMDS9+Akkh4K60UwM26emMESw8tLCHU=
+github.com/spf13/cobra v1.0.0 h1:6m/oheQuQ13N9ks4hubMG6BnvwOeaJrqSPLahSnczz8=
 github.com/spf13/cobra v1.0.0/go.mod h1:/6GTrnGXV9HjY+aR4k0oJ5tcvakLuG6EuKReYlHNrgE=
 github.com/spf13/jwalterweatherman v1.0.0/go.mod h1:cQK4TGJAtQXfYWX+Ddv3mKDzgVb68N+wFjFa4jdeBTo=
 github.com/spf13/jwalterweatherman v1.1.0 h1:ue6voC5bR5F8YxI5S67j9i582FU4Qvo2bmqnqMYADFk=

--- a/go.sum
+++ b/go.sum
@@ -1088,7 +1088,6 @@ github.com/spf13/cast v1.3.1/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkU
 github.com/spf13/cobra v0.0.2-0.20171109065643-2da4a54c5cee/go.mod h1:1l0Ry5zgKvJasoi3XT1TypsSe7PqH0Sj9dhYf7v3XqQ=
 github.com/spf13/cobra v0.0.3/go.mod h1:1l0Ry5zgKvJasoi3XT1TypsSe7PqH0Sj9dhYf7v3XqQ=
 github.com/spf13/cobra v0.0.5/go.mod h1:3K3wKZymM7VvHMDS9+Akkh4K60UwM26emMESw8tLCHU=
-github.com/spf13/cobra v1.0.0 h1:6m/oheQuQ13N9ks4hubMG6BnvwOeaJrqSPLahSnczz8=
 github.com/spf13/cobra v1.0.0/go.mod h1:/6GTrnGXV9HjY+aR4k0oJ5tcvakLuG6EuKReYlHNrgE=
 github.com/spf13/jwalterweatherman v1.0.0/go.mod h1:cQK4TGJAtQXfYWX+Ddv3mKDzgVb68N+wFjFa4jdeBTo=
 github.com/spf13/jwalterweatherman v1.1.0 h1:ue6voC5bR5F8YxI5S67j9i582FU4Qvo2bmqnqMYADFk=

--- a/pkg/mads/v1/service/http.go
+++ b/pkg/mads/v1/service/http.go
@@ -34,7 +34,7 @@ func (s *service) handleDiscovery(req *restful.Request, res *restful.Response) {
 	body, err := ioutil.ReadAll(req.Request.Body)
 	if err != nil {
 		writeBadRequestError(res, rest_error_types.Error{
-			Title:   "Can not read request body",
+			Title:   "Could not read request body",
 			Details: err.Error(),
 		})
 		return
@@ -44,7 +44,7 @@ func (s *service) handleDiscovery(req *restful.Request, res *restful.Response) {
 	err = jsonpb.UnmarshalString(string(body), discoveryReq)
 	if err != nil {
 		writeBadRequestError(res, rest_error_types.Error{
-			Title:   "Can not parse request body",
+			Title:   "Could not parse request body",
 			Details: err.Error(),
 		})
 		return
@@ -55,7 +55,7 @@ func (s *service) handleDiscovery(req *restful.Request, res *restful.Response) {
 	timeout, err := s.parseFetchTimeout(req.QueryParameter("fetch-timeout"))
 	if err != nil {
 		writeBadRequestError(res, rest_error_types.Error{
-			Title:   "Can not parse fetch-timeout",
+			Title:   "Could not parse fetch-timeout",
 			Details: err.Error(),
 		})
 		return

--- a/pkg/mads/v1/service_test.go
+++ b/pkg/mads/v1/service_test.go
@@ -459,7 +459,7 @@ var _ = Describe("MADS http service", func() {
 			Expect(discoveryRes.Resources).To(HaveLen(2))
 		})
 
-		FIt("should allow specifying the fetch timeout", func() {
+		It("should allow specifying the fetch timeout", func() {
 			// given
 			discoveryReq := envoy_v3.DiscoveryRequest{
 				VersionInfo:   "",

--- a/pkg/mads/v1/service_test.go
+++ b/pkg/mads/v1/service_test.go
@@ -476,7 +476,7 @@ var _ = Describe("MADS http service", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			// when
-			req, err := http.NewRequest("POST", monitoringAssignmentPath+"?fetch-timeout=1ms", strings.NewReader(reqBytes))
+			req, err := http.NewRequest("POST", monitoringAssignmentPath+"?fetch-timeout=1s", strings.NewReader(reqBytes))
 			Expect(err).ToNot(HaveOccurred())
 			req.Header.Add("content-type", "application/json")
 


### PR DESCRIPTION
### Summary

Follow up on #2121, adds a query parameter (`fetch-timeout`) to allow clients to specify how long a single HTTP long polling request should wait. 

Originally was thinking a [GRPC TimeoutValue and TimeoutUnit](https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md#requests) made sense as the format, but we use golang's `time.Duration` format elsewhere in the config, and a parser already exists for it, so went with that instead. 

If the timeout value is less than or equal to 0, the request does a sync fetch instead.

### Full changelog

* Add `fetch-timeout` query parameter to the MADS V1 HTTP endpoint
* Also fixes a bug with the error responses continuing the request even after a response has been sent

### Documentation

- Will document after native Prometheus SD is in 

### Testing

- [x] Unit tests
