### PR TITLE
feat(kuma-cp) add --verbose flag to kuma-init

### DIFF
--- a/pkg/plugins/runtime/k8s/webhooks/injector/injector.go
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/injector.go
@@ -451,6 +451,7 @@ func (i *KumaInjector) NewInitContainer(pod *kube_core.Pod) (kube_core.Container
 			excludeInboundPorts,
 			"--exclude-outbound-ports",
 			excludeOutboundPorts,
+			"--verbose",
 		}, dnsArg...),
 		SecurityContext: &kube_core.SecurityContext{
 			RunAsUser:  new(int64), // way to get pointer to int64(0)

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.01.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.01.golden.yaml
@@ -126,6 +126,7 @@ spec:
     - ""
     - --exclude-outbound-ports
     - ""
+    - --verbose
     - --skip-resolv-conf
     command:
     - /usr/bin/kumactl

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.02.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.02.golden.yaml
@@ -134,6 +134,7 @@ spec:
     - ""
     - --exclude-outbound-ports
     - ""
+    - --verbose
     - --skip-resolv-conf
     command:
     - /usr/bin/kumactl

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.03.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.03.golden.yaml
@@ -188,6 +188,7 @@ spec:
     - ""
     - --exclude-outbound-ports
     - ""
+    - --verbose
     - --skip-resolv-conf
     command:
     - /usr/bin/kumactl

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.04.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.04.golden.yaml
@@ -126,6 +126,7 @@ spec:
     - ""
     - --exclude-outbound-ports
     - ""
+    - --verbose
     - --skip-resolv-conf
     command:
     - /usr/bin/kumactl

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.05.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.05.golden.yaml
@@ -119,6 +119,7 @@ spec:
     - ""
     - --exclude-outbound-ports
     - ""
+    - --verbose
     - --skip-resolv-conf
     command:
     - /usr/bin/kumactl

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.06.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.06.golden.yaml
@@ -127,6 +127,7 @@ spec:
     - ""
     - --exclude-outbound-ports
     - ""
+    - --verbose
     - --skip-resolv-conf
     command:
     - /usr/bin/kumactl

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.07.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.07.golden.yaml
@@ -126,6 +126,7 @@ spec:
     - ""
     - --exclude-outbound-ports
     - ""
+    - --verbose
     - --skip-resolv-conf
     command:
     - /usr/bin/kumactl

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.08.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.08.golden.yaml
@@ -129,6 +129,7 @@ spec:
     - ""
     - --exclude-outbound-ports
     - ""
+    - --verbose
     - --skip-resolv-conf
     command:
     - /usr/bin/kumactl

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.09.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.09.golden.yaml
@@ -128,6 +128,7 @@ spec:
     - ""
     - --exclude-outbound-ports
     - ""
+    - --verbose
     - --skip-resolv-conf
     command:
     - /usr/bin/kumactl

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.11.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.11.golden.yaml
@@ -127,6 +127,7 @@ spec:
     - ""
     - --exclude-outbound-ports
     - ""
+    - --verbose
     - --skip-resolv-conf
     command:
     - /usr/bin/kumactl

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.12.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.12.golden.yaml
@@ -126,6 +126,7 @@ spec:
     - ""
     - --exclude-outbound-ports
     - ""
+    - --verbose
     - --skip-resolv-conf
     command:
     - /usr/bin/kumactl

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.13.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.13.golden.yaml
@@ -126,6 +126,7 @@ spec:
     - ""
     - --exclude-outbound-ports
     - ""
+    - --verbose
     - --skip-resolv-conf
     command:
     - /usr/bin/kumactl

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.14.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.14.golden.yaml
@@ -138,6 +138,7 @@ spec:
     - ""
     - --exclude-outbound-ports
     - ""
+    - --verbose
     - --skip-resolv-conf
     command:
     - /usr/bin/kumactl

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.15.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.15.golden.yaml
@@ -138,6 +138,7 @@ spec:
     - ""
     - --exclude-outbound-ports
     - ""
+    - --verbose
     - --skip-resolv-conf
     command:
     - /usr/bin/kumactl

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.16.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.16.golden.yaml
@@ -138,6 +138,7 @@ spec:
     - ""
     - --exclude-outbound-ports
     - ""
+    - --verbose
     - --skip-resolv-conf
     command:
     - /usr/bin/kumactl

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.17.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.17.golden.yaml
@@ -135,6 +135,7 @@ spec:
     - 1234,1235
     - --exclude-outbound-ports
     - "1236"
+    - --verbose
     - --skip-resolv-conf
     command:
     - /usr/bin/kumactl

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.18.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.18.golden.yaml
@@ -135,6 +135,7 @@ spec:
     - 1234,5678
     - --exclude-outbound-ports
     - 4321,7654
+    - --verbose
     - --skip-resolv-conf
     command:
     - /usr/bin/kumactl

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.19.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.19.golden.yaml
@@ -135,6 +135,7 @@ spec:
     - ""
     - --exclude-outbound-ports
     - ""
+    - --verbose
     - --skip-resolv-conf
     command:
     - /usr/bin/kumactl

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.21.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.21.golden.yaml
@@ -138,6 +138,7 @@ spec:
     - ""
     - --exclude-outbound-ports
     - ""
+    - --verbose
     - --skip-resolv-conf
     command:
     - /usr/bin/kumactl

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.22.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.22.golden.yaml
@@ -138,6 +138,7 @@ spec:
     - ""
     - --exclude-outbound-ports
     - ""
+    - --verbose
     - --skip-resolv-conf
     command:
     - /usr/bin/kumactl

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.23.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.23.golden.yaml
@@ -143,6 +143,7 @@ spec:
     - ""
     - --exclude-outbound-ports
     - ""
+    - --verbose
     - --skip-resolv-conf
     command:
     - /usr/bin/kumactl

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.24.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.24.golden.yaml
@@ -139,6 +139,7 @@ spec:
     - ""
     - --exclude-outbound-ports
     - ""
+    - --verbose
     - --skip-resolv-conf
     command:
     - /usr/bin/kumactl

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.25.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.25.golden.yaml
@@ -149,6 +149,7 @@ spec:
     - ""
     - --exclude-outbound-ports
     - ""
+    - --verbose
     - --skip-resolv-conf
     - --redirect-all-dns-traffic
     - --redirect-dns-port


### PR DESCRIPTION
### Summary

With this change, kuma-init which will be injected to k8s pods
will be run in verbose mode, which will make debugging much
easier

### Testing

- [ ] Unit tests
- [ ] E2E tests
- [ ] Manual testing on Universal
- [x] Manual testing on Kubernetes 
