### PR TITLE
feat(kuma-cp) add service identity injection

### DIFF
--- a/pkg/xds/envoy/filters/lua/service-identity-injection.lua
+++ b/pkg/xds/envoy/filters/lua/service-identity-injection.lua
@@ -1,0 +1,30 @@
+function envoy_on_request(request_handle)
+    xfcc = request_handle:headers():get("x-forwarded-client-cert")
+
+    if xfcc == nil or xfcc == '' then
+        return
+    end
+
+    spiffe = nil
+    service = nil
+
+    for str in string.gmatch(xfcc, "([^;]+)") do
+        uri_match_result = str:match("URI=(%S+)")
+        if uri_match_result ~= nil then
+            spiffe = uri_match_result
+            mesh = spiffe:match("spiffe://(%S+)/")
+            service = spiffe:match("spiffe://" .. mesh .. "/(%S+)")
+        end
+    end
+
+    if spiffe ~= nil then
+        request_handle:headers():add("X-Kuma-Forwarded-Client-Cert", spiffe)
+    end
+
+    if service ~= nil then
+        request_handle:headers():add("X-Kuma-Forwarded-Client-Service", service)
+    end
+end
+
+function envoy_on_response(handle)
+end

--- a/pkg/xds/envoy/filters/lua/service_indentity_injection_script.go
+++ b/pkg/xds/envoy/filters/lua/service_indentity_injection_script.go
@@ -1,0 +1,17 @@
+package lua
+
+import (
+	"embed"
+	"io/fs"
+)
+
+//go:embed service-identity-injection.lua
+var ServiceIdentityInjectionFile embed.FS
+
+func ServiceIdentityInjectionScript() (string, error) {
+	script, err := fs.ReadFile(ServiceIdentityInjectionFile, "service-identity-injection.lua")
+	if err != nil {
+		return "", err
+	}
+	return string(script), nil
+}

--- a/pkg/xds/envoy/listeners/configurers.go
+++ b/pkg/xds/envoy/listeners/configurers.go
@@ -73,12 +73,17 @@ func ServerSideMTLS(ctx xds_context.Context, metadata *core_xds.DataplaneMetadat
 	})
 }
 
-func HttpConnectionManager(statsName string, forwardClientCertDetails bool) FilterChainBuilderOpt {
+func HttpConnectionManager(statsName string) FilterChainBuilderOpt {
 	return FilterChainBuilderOptFunc(func(config *FilterChainBuilderConfig) {
 		config.AddV3(&v3.HttpConnectionManagerConfigurer{
-			StatsName:                statsName,
-			ForwardClientCertDetails: forwardClientCertDetails,
+			StatsName: statsName,
 		})
+	})
+}
+
+func ServiceIdentityInjection() FilterChainBuilderOpt {
+	return FilterChainBuilderOptFunc(func(config *FilterChainBuilderConfig) {
+		config.AddV3(&v3.ServiceIdentityInjectionConfigurer{})
 	})
 }
 

--- a/pkg/xds/envoy/listeners/v3/fault_injection_configurer_test.go
+++ b/pkg/xds/envoy/listeners/v3/fault_injection_configurer_test.go
@@ -22,7 +22,7 @@ var _ = Describe("FaultInjectionConfigurer", func() {
 		func(given testCase) {
 			// when
 			filterChain, err := NewFilterChainBuilder(envoy.APIV3).
-				Configure(HttpConnectionManager("stats", false)).
+				Configure(HttpConnectionManager("stats")).
 				Configure(FaultInjection(given.input)).
 				Build()
 			// then

--- a/pkg/xds/envoy/listeners/v3/grpc_stats_configurer_test.go
+++ b/pkg/xds/envoy/listeners/v3/grpc_stats_configurer_test.go
@@ -18,7 +18,7 @@ var _ = Describe("gRPCStatsConfigurer", func() {
 		func(given testCase) {
 			// when
 			filterChain, err := NewFilterChainBuilder(envoy.APIV3).
-				Configure(HttpConnectionManager("stats", false)).
+				Configure(HttpConnectionManager("stats")).
 				Configure(GrpcStats()).
 				Build()
 			// then

--- a/pkg/xds/envoy/listeners/v3/http_access_log_configurer_test.go
+++ b/pkg/xds/envoy/listeners/v3/http_access_log_configurer_test.go
@@ -63,7 +63,7 @@ var _ = Describe("HttpAccessLogConfigurer", func() {
 			listener, err := NewListenerBuilder(envoy.APIV3).
 				Configure(OutboundListener(given.listenerName, given.listenerAddress, given.listenerPort, given.listenerProtocol)).
 				Configure(FilterChain(NewFilterChainBuilder(envoy.APIV3).
-					Configure(HttpConnectionManager(given.statsName, false)).
+					Configure(HttpConnectionManager(given.statsName)).
 					Configure(HttpAccessLog(mesh, envoy.TrafficDirectionOutbound, sourceService, destinationService, given.backend, proxy)))).
 				Build()
 			// then

--- a/pkg/xds/envoy/listeners/v3/http_connection_manager_configurer.go
+++ b/pkg/xds/envoy/listeners/v3/http_connection_manager_configurer.go
@@ -10,7 +10,6 @@ import (
 
 type HttpConnectionManagerConfigurer struct {
 	StatsName                string
-	ForwardClientCertDetails bool
 }
 
 func (c *HttpConnectionManagerConfigurer) Configure(filterChain *envoy_listener.FilterChain) error {
@@ -21,13 +20,6 @@ func (c *HttpConnectionManagerConfigurer) Configure(filterChain *envoy_listener.
 			{Name: "envoy.filters.http.router"},
 		},
 		// notice that route configuration is left up to other configurers
-	}
-
-	if c.ForwardClientCertDetails {
-		config.ForwardClientCertDetails = envoy_hcm.HttpConnectionManager_SANITIZE_SET
-		config.SetCurrentClientCertDetails = &envoy_hcm.HttpConnectionManager_SetCurrentClientCertDetails{
-			Uri: true,
-		}
 	}
 
 	pbst, err := util_proto.MarshalAnyDeterministic(config)

--- a/pkg/xds/envoy/listeners/v3/http_connection_manager_configurer.go
+++ b/pkg/xds/envoy/listeners/v3/http_connection_manager_configurer.go
@@ -9,7 +9,7 @@ import (
 )
 
 type HttpConnectionManagerConfigurer struct {
-	StatsName                string
+	StatsName string
 }
 
 func (c *HttpConnectionManagerConfigurer) Configure(filterChain *envoy_listener.FilterChain) error {

--- a/pkg/xds/envoy/listeners/v3/http_connection_manager_configurer_test.go
+++ b/pkg/xds/envoy/listeners/v3/http_connection_manager_configurer_test.go
@@ -30,7 +30,7 @@ var _ = Describe("HttpConnectionManagerConfigurer", func() {
 			listener, err := NewListenerBuilder(envoy.APIV3).
 				Configure(InboundListener(given.listenerName, given.listenerAddress, given.listenerPort, given.listenerProtocol)).
 				Configure(FilterChain(NewFilterChainBuilder(envoy.APIV3).
-					Configure(HttpConnectionManager(given.statsName, true)))).
+					Configure(HttpConnectionManager(given.statsName)))).
 				Build()
 			// then
 			Expect(err).ToNot(HaveOccurred())

--- a/pkg/xds/envoy/listeners/v3/http_connection_manager_configurer_test.go
+++ b/pkg/xds/envoy/listeners/v3/http_connection_manager_configurer_test.go
@@ -58,9 +58,6 @@ var _ = Describe("HttpConnectionManagerConfigurer", func() {
               - name: envoy.filters.network.http_connection_manager
                 typedConfig:
                   '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
-                  forwardClientCertDetails: SANITIZE_SET
-                  setCurrentClientCertDetails:
-                    uri: true
                   statPrefix: localhost_8080
                   httpFilters:
                   - name: envoy.filters.http.router

--- a/pkg/xds/envoy/listeners/v3/http_inbound_routes_configurer_test.go
+++ b/pkg/xds/envoy/listeners/v3/http_inbound_routes_configurer_test.go
@@ -98,9 +98,6 @@ var _ = Describe("HttpInboundRouteConfigurer", func() {
               - name: envoy.filters.network.http_connection_manager
                 typedConfig:
                   '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
-                  forwardClientCertDetails: SANITIZE_SET
-                  setCurrentClientCertDetails:
-                    uri: true
                   httpFilters:
                   - name: envoy.filters.http.router
                   routeConfig:
@@ -165,9 +162,6 @@ var _ = Describe("HttpInboundRouteConfigurer", func() {
               - name: envoy.filters.network.http_connection_manager
                 typedConfig:
                   '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
-                  forwardClientCertDetails: SANITIZE_SET
-                  setCurrentClientCertDetails:
-                    uri: true
                   httpFilters:
                   - name: envoy.filters.http.router
                   routeConfig:
@@ -262,9 +256,6 @@ var _ = Describe("HttpInboundRouteConfigurer", func() {
               - name: envoy.filters.network.http_connection_manager
                 typedConfig:
                   '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
-                  forwardClientCertDetails: SANITIZE_SET
-                  setCurrentClientCertDetails:
-                    uri: true
                   httpFilters:
                   - name: envoy.filters.http.router
                   routeConfig:

--- a/pkg/xds/envoy/listeners/v3/http_inbound_routes_configurer_test.go
+++ b/pkg/xds/envoy/listeners/v3/http_inbound_routes_configurer_test.go
@@ -67,7 +67,7 @@ var _ = Describe("HttpInboundRouteConfigurer", func() {
 			listener, err := NewListenerBuilder(envoy_common.APIV3).
 				Configure(InboundListener(given.listenerName, given.listenerAddress, given.listenerPort, given.listenerProtocol)).
 				Configure(FilterChain(NewFilterChainBuilder(envoy_common.APIV3).
-					Configure(HttpConnectionManager(given.statsName, true)).
+					Configure(HttpConnectionManager(given.statsName)).
 					Configure(HttpInboundRoutes(given.service, given.routes)))).
 				Build()
 			// then

--- a/pkg/xds/envoy/listeners/v3/http_outbound_route_configurer_test.go
+++ b/pkg/xds/envoy/listeners/v3/http_outbound_route_configurer_test.go
@@ -34,7 +34,7 @@ var _ = Describe("HttpOutboundRouteConfigurer", func() {
 			listener, err := NewListenerBuilder(envoy_common.APIV3).
 				Configure(OutboundListener(given.listenerName, given.listenerAddress, given.listenerPort, given.listenerProtocol)).
 				Configure(FilterChain(NewFilterChainBuilder(envoy_common.APIV3).
-					Configure(HttpConnectionManager(given.statsName, false)).
+					Configure(HttpConnectionManager(given.statsName)).
 					Configure(HttpOutboundRoute(given.service, given.routes, given.dpTags)))).
 				Build()
 			// then

--- a/pkg/xds/envoy/listeners/v3/rate_limit_configurer_test.go
+++ b/pkg/xds/envoy/listeners/v3/rate_limit_configurer_test.go
@@ -20,7 +20,7 @@ var _ = Describe("RateLimitConfigurer", func() {
 		func(given testCase) {
 			// when
 			filterChain, err := NewFilterChainBuilder(envoy.APIV3).
-				Configure(HttpConnectionManager("stats", false)).
+				Configure(HttpConnectionManager("stats")).
 				Configure(RateLimit(given.input)).
 				Build()
 			// then

--- a/pkg/xds/envoy/listeners/v3/retry_configurer_test.go
+++ b/pkg/xds/envoy/listeners/v3/retry_configurer_test.go
@@ -37,7 +37,7 @@ var _ = Describe("RetryConfigurer", func() {
 			listener, err := NewListenerBuilder(envoy_common.APIV3).
 				Configure(OutboundListener(given.listenerName, given.listenerAddress, given.listenerPort, given.listenerProtocol)).
 				Configure(FilterChain(NewFilterChainBuilder(envoy_common.APIV3).
-					Configure(HttpConnectionManager(given.statsName, false)).
+					Configure(HttpConnectionManager(given.statsName)).
 					Configure(HttpOutboundRoute(
 						given.service,
 						given.routes,

--- a/pkg/xds/envoy/listeners/v3/service_identity_injection_configurer.go
+++ b/pkg/xds/envoy/listeners/v3/service_identity_injection_configurer.go
@@ -4,6 +4,7 @@ import (
 	envoy_listener "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
 	envoy_http_lua "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/lua/v3"
 	envoy_hcm "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
+
 	"github.com/kumahq/kuma/pkg/util/proto"
 )
 

--- a/pkg/xds/envoy/listeners/v3/service_identity_injection_configurer.go
+++ b/pkg/xds/envoy/listeners/v3/service_identity_injection_configurer.go
@@ -1,0 +1,73 @@
+package v3
+
+import (
+	envoy_listener "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
+	envoy_http_lua "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/lua/v3"
+	envoy_hcm "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
+	"github.com/kumahq/kuma/pkg/util/proto"
+)
+
+const serviceIdentityInjectionScript = `
+function envoy_on_request(request_handle)
+  xfcc = request_handle:headers():get("x-forwarded-client-cert")
+
+  if xfcc == nil or xfcc == '' then
+    return
+  end
+
+  spiffe = nil
+  service = nil
+
+  for str in string.gmatch(xfcc, "([^;]+)") do
+    uri_match_result = str:match("URI=(%S+)")
+    if uri_match_result ~= nil then
+      spiffe = uri_match_result
+      mesh = spiffe:match("spiffe://(%S+)/")
+      service = spiffe:match("spiffe://" .. mesh .. "/(%S+)")
+    end
+  end
+
+  if spiffe ~= nil then
+    request_handle:headers():add("X-Kuma-Forwarded-Client-Cert", spiffe)
+  end
+
+  if service ~= nil then
+    request_handle:headers():add("X-Kuma-Forwarded-Client-Service", service)
+  end
+
+end
+
+function envoy_on_response(handle)
+end
+`
+
+type ServiceIdentityInjectionConfigurer struct {
+}
+
+func (_ *ServiceIdentityInjectionConfigurer) Configure(filterChain *envoy_listener.FilterChain) error {
+	config := &envoy_http_lua.Lua{
+		InlineCode:  serviceIdentityInjectionScript,
+		SourceCodes: nil,
+	}
+
+	pbst, err := proto.MarshalAnyDeterministic(config)
+	if err != nil {
+		return err
+	}
+
+	return UpdateHTTPConnectionManager(filterChain, func(manager *envoy_hcm.HttpConnectionManager) error {
+		manager.ForwardClientCertDetails = envoy_hcm.HttpConnectionManager_SANITIZE_SET
+		manager.SetCurrentClientCertDetails = &envoy_hcm.HttpConnectionManager_SetCurrentClientCertDetails{
+			Uri: true,
+		}
+		manager.HttpFilters = append([]*envoy_hcm.HttpFilter{
+			{
+				Name: "envoy.filters.http.lua",
+				ConfigType: &envoy_hcm.HttpFilter_TypedConfig{
+					TypedConfig: pbst,
+				},
+			},
+		}, manager.HttpFilters...)
+		return nil
+	})
+}

--- a/pkg/xds/envoy/listeners/v3/service_identity_injection_configurer.go
+++ b/pkg/xds/envoy/listeners/v3/service_identity_injection_configurer.go
@@ -6,48 +6,20 @@ import (
 	envoy_hcm "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
 
 	"github.com/kumahq/kuma/pkg/util/proto"
+	"github.com/kumahq/kuma/pkg/xds/envoy/filters/lua"
 )
-
-const serviceIdentityInjectionScript = `
-function envoy_on_request(request_handle)
-  xfcc = request_handle:headers():get("x-forwarded-client-cert")
-
-  if xfcc == nil or xfcc == '' then
-    return
-  end
-
-  spiffe = nil
-  service = nil
-
-  for str in string.gmatch(xfcc, "([^;]+)") do
-    uri_match_result = str:match("URI=(%S+)")
-    if uri_match_result ~= nil then
-      spiffe = uri_match_result
-      mesh = spiffe:match("spiffe://(%S+)/")
-      service = spiffe:match("spiffe://" .. mesh .. "/(%S+)")
-    end
-  end
-
-  if spiffe ~= nil then
-    request_handle:headers():add("X-Kuma-Forwarded-Client-Cert", spiffe)
-  end
-
-  if service ~= nil then
-    request_handle:headers():add("X-Kuma-Forwarded-Client-Service", service)
-  end
-
-end
-
-function envoy_on_response(handle)
-end
-`
 
 type ServiceIdentityInjectionConfigurer struct {
 }
 
 func (_ *ServiceIdentityInjectionConfigurer) Configure(filterChain *envoy_listener.FilterChain) error {
+	script, err := lua.ServiceIdentityInjectionScript()
+	if err != nil {
+		return err
+	}
+
 	config := &envoy_http_lua.Lua{
-		InlineCode:  serviceIdentityInjectionScript,
+		InlineCode:  script,
 		SourceCodes: nil,
 	}
 

--- a/pkg/xds/envoy/listeners/v3/tracing_configurer_test.go
+++ b/pkg/xds/envoy/listeners/v3/tracing_configurer_test.go
@@ -28,7 +28,7 @@ var _ = Describe("TracingConfigurer", func() {
 			listener, err := NewListenerBuilder(envoy.APIV3).
 				Configure(InboundListener("inbound:192.168.0.1:8080", "192.168.0.1", 8080, xds.SocketAddressProtocolTCP)).
 				Configure(FilterChain(NewFilterChainBuilder(envoy.APIV3).
-					Configure(HttpConnectionManager("localhost:8080", false)).
+					Configure(HttpConnectionManager("localhost:8080")).
 					Configure(Tracing(given.backend)))).
 				Build()
 			// then

--- a/pkg/xds/generator/inbound_proxy_generator.go
+++ b/pkg/xds/generator/inbound_proxy_generator.go
@@ -73,19 +73,21 @@ func (g InboundProxyGenerator) Generate(ctx xds_context.Context, proxy *model.Pr
 			// configuration for HTTP case
 			case mesh_core.ProtocolHTTP, mesh_core.ProtocolHTTP2:
 				filterChainBuilder.
-					Configure(envoy_listeners.HttpConnectionManager(localClusterName, true)).
+					Configure(envoy_listeners.HttpConnectionManager(localClusterName)).
 					Configure(envoy_listeners.FaultInjection(proxy.Policies.FaultInjections[endpoint])).
 					Configure(envoy_listeners.RateLimit(proxy.Policies.RateLimits[endpoint])).
 					Configure(envoy_listeners.Tracing(proxy.Policies.TracingBackend)).
-					Configure(envoy_listeners.HttpInboundRoutes(service, routes))
+					Configure(envoy_listeners.HttpInboundRoutes(service, routes)).
+					Configure(envoy_listeners.ServiceIdentityInjection())
 			case mesh_core.ProtocolGRPC:
 				filterChainBuilder.
-					Configure(envoy_listeners.HttpConnectionManager(localClusterName, true)).
+					Configure(envoy_listeners.HttpConnectionManager(localClusterName)).
 					Configure(envoy_listeners.GrpcStats()).
 					Configure(envoy_listeners.FaultInjection(proxy.Policies.FaultInjections[endpoint])).
 					Configure(envoy_listeners.RateLimit(proxy.Policies.RateLimits[endpoint])).
 					Configure(envoy_listeners.Tracing(proxy.Policies.TracingBackend)).
-					Configure(envoy_listeners.HttpInboundRoutes(service, routes))
+					Configure(envoy_listeners.HttpInboundRoutes(service, routes)).
+					Configure(envoy_listeners.ServiceIdentityInjection())
 			case mesh_core.ProtocolKafka:
 				filterChainBuilder.
 					Configure(envoy_listeners.Kafka(localClusterName)).

--- a/pkg/xds/generator/outbound_proxy_generator.go
+++ b/pkg/xds/generator/outbound_proxy_generator.go
@@ -104,7 +104,7 @@ func (_ OutboundProxyGenerator) generateLDS(proxy *model.Proxy, routes envoy_com
 		switch protocol {
 		case mesh_core.ProtocolGRPC:
 			filterChainBuilder.
-				Configure(envoy_listeners.HttpConnectionManager(serviceName, false)).
+				Configure(envoy_listeners.HttpConnectionManager(serviceName)).
 				Configure(envoy_listeners.Tracing(proxy.Policies.TracingBackend)).
 				Configure(envoy_listeners.HttpAccessLog(meshName, envoy_common.TrafficDirectionOutbound, sourceService, serviceName, proxy.Policies.Logs[serviceName], proxy)).
 				Configure(envoy_listeners.HttpOutboundRoute(serviceName, routes, proxy.Dataplane.Spec.TagSet())).
@@ -112,7 +112,7 @@ func (_ OutboundProxyGenerator) generateLDS(proxy *model.Proxy, routes envoy_com
 				Configure(envoy_listeners.GrpcStats())
 		case mesh_core.ProtocolHTTP, mesh_core.ProtocolHTTP2:
 			filterChainBuilder.
-				Configure(envoy_listeners.HttpConnectionManager(serviceName, false)).
+				Configure(envoy_listeners.HttpConnectionManager(serviceName)).
 				Configure(envoy_listeners.Tracing(proxy.Policies.TracingBackend)).
 				Configure(envoy_listeners.HttpAccessLog(
 					meshName,

--- a/pkg/xds/generator/probe_generator.go
+++ b/pkg/xds/generator/probe_generator.go
@@ -49,7 +49,7 @@ func (g ProbeProxyGenerator) Generate(ctx xds_context.Context, proxy *model.Prox
 	probeListener, err := envoy_listeners.NewListenerBuilder(proxy.APIVersion).
 		Configure(envoy_listeners.InboundListener(listenerName, proxy.Dataplane.Spec.GetNetworking().GetAddress(), probes.Port, model.SocketAddressProtocolTCP)).
 		Configure(envoy_listeners.FilterChain(envoy_listeners.NewFilterChainBuilder(proxy.APIVersion).
-			Configure(envoy_listeners.HttpConnectionManager(listenerName, false)).
+			Configure(envoy_listeners.HttpConnectionManager(listenerName)).
 			Configure(envoy_listeners.HttpStaticRoute(envoy_routes.NewRouteConfigurationBuilder(proxy.APIVersion).
 				Configure(envoy_routes.VirtualHost(virtualHostBuilder)))))).
 		Configure(envoy_listeners.TransparentProxying(proxy.Dataplane.Spec.Networking.GetTransparentProxying())).

--- a/pkg/xds/generator/testdata/inbound-proxy/3-envoy-config.golden.yaml
+++ b/pkg/xds/generator/testdata/inbound-proxy/3-envoy-config.golden.yaml
@@ -114,6 +114,33 @@ resources:
           '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
           forwardClientCertDetails: SANITIZE_SET
           httpFilters:
+          - name: envoy.filters.http.lua
+            typedConfig:
+              '@type': type.googleapis.com/envoy.extensions.filters.http.lua.v3.Lua
+              inlineCode: |
+                function envoy_on_request(request_handle)
+                    if request_handle:connection():ssl() and request_handle:streamInfo():downstreamSslConnection() then
+                        local cert_uris = request_handle:streamInfo():downstreamSslConnection():uriSanPeerCertificate()
+                        for _, uri in pairs(cert_uris) do
+                            if uri:find("^spiffe://") ~= nil then
+                                request_handle:headers():add("X-Kuma-Forwarded-Client-Cert", uri)
+                            end
+
+                            local service = uri:match("^kuma://kuma.io/service/(.+)$")
+                            if service ~= nil and service ~= '' then
+                                request_handle:headers():add("X-Kuma-Forwarded-Client-Service", service)
+                            end
+
+                            local zone = uri:match("^kuma://kuma.io/zone/(.+)$")
+                            if zone ~= nil and zone ~= '' then
+                                request_handle:headers():add("X-Kuma-Forwarded-Client-Zone", zone)
+                            end
+                        end
+                    end
+                end
+
+                function envoy_on_response(handle)
+                end
           - name: envoy.filters.http.local_ratelimit
             typedConfig:
               '@type': type.googleapis.com/envoy.extensions.filters.http.local_ratelimit.v3.LocalRateLimit
@@ -310,6 +337,33 @@ resources:
           '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
           forwardClientCertDetails: SANITIZE_SET
           httpFilters:
+          - name: envoy.filters.http.lua
+            typedConfig:
+              '@type': type.googleapis.com/envoy.extensions.filters.http.lua.v3.Lua
+              inlineCode: |
+                function envoy_on_request(request_handle)
+                    if request_handle:connection():ssl() and request_handle:streamInfo():downstreamSslConnection() then
+                        local cert_uris = request_handle:streamInfo():downstreamSslConnection():uriSanPeerCertificate()
+                        for _, uri in pairs(cert_uris) do
+                            if uri:find("^spiffe://") ~= nil then
+                                request_handle:headers():add("X-Kuma-Forwarded-Client-Cert", uri)
+                            end
+
+                            local service = uri:match("^kuma://kuma.io/service/(.+)$")
+                            if service ~= nil and service ~= '' then
+                                request_handle:headers():add("X-Kuma-Forwarded-Client-Service", service)
+                            end
+
+                            local zone = uri:match("^kuma://kuma.io/zone/(.+)$")
+                            if zone ~= nil and zone ~= '' then
+                                request_handle:headers():add("X-Kuma-Forwarded-Client-Zone", zone)
+                            end
+                        end
+                    end
+                end
+
+                function envoy_on_response(handle)
+                end
           - name: envoy.filters.http.router
           routeConfig:
             name: inbound:backend3

--- a/pkg/xds/generator/testdata/inbound-proxy/4-envoy-config.golden.yaml
+++ b/pkg/xds/generator/testdata/inbound-proxy/4-envoy-config.golden.yaml
@@ -116,6 +116,33 @@ resources:
           '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
           forwardClientCertDetails: SANITIZE_SET
           httpFilters:
+          - name: envoy.filters.http.lua
+            typedConfig:
+              '@type': type.googleapis.com/envoy.extensions.filters.http.lua.v3.Lua
+              inlineCode: |
+                function envoy_on_request(request_handle)
+                    if request_handle:connection():ssl() and request_handle:streamInfo():downstreamSslConnection() then
+                        local cert_uris = request_handle:streamInfo():downstreamSslConnection():uriSanPeerCertificate()
+                        for _, uri in pairs(cert_uris) do
+                            if uri:find("^spiffe://") ~= nil then
+                                request_handle:headers():add("X-Kuma-Forwarded-Client-Cert", uri)
+                            end
+
+                            local service = uri:match("^kuma://kuma.io/service/(.+)$")
+                            if service ~= nil and service ~= '' then
+                                request_handle:headers():add("X-Kuma-Forwarded-Client-Service", service)
+                            end
+
+                            local zone = uri:match("^kuma://kuma.io/zone/(.+)$")
+                            if zone ~= nil and zone ~= '' then
+                                request_handle:headers():add("X-Kuma-Forwarded-Client-Zone", zone)
+                            end
+                        end
+                    end
+                end
+
+                function envoy_on_response(handle)
+                end
           - name: envoy.filters.http.local_ratelimit
             typedConfig:
               '@type': type.googleapis.com/envoy.extensions.filters.http.local_ratelimit.v3.LocalRateLimit
@@ -314,6 +341,33 @@ resources:
           '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
           forwardClientCertDetails: SANITIZE_SET
           httpFilters:
+          - name: envoy.filters.http.lua
+            typedConfig:
+              '@type': type.googleapis.com/envoy.extensions.filters.http.lua.v3.Lua
+              inlineCode: |
+                function envoy_on_request(request_handle)
+                    if request_handle:connection():ssl() and request_handle:streamInfo():downstreamSslConnection() then
+                        local cert_uris = request_handle:streamInfo():downstreamSslConnection():uriSanPeerCertificate()
+                        for _, uri in pairs(cert_uris) do
+                            if uri:find("^spiffe://") ~= nil then
+                                request_handle:headers():add("X-Kuma-Forwarded-Client-Cert", uri)
+                            end
+
+                            local service = uri:match("^kuma://kuma.io/service/(.+)$")
+                            if service ~= nil and service ~= '' then
+                                request_handle:headers():add("X-Kuma-Forwarded-Client-Service", service)
+                            end
+
+                            local zone = uri:match("^kuma://kuma.io/zone/(.+)$")
+                            if zone ~= nil and zone ~= '' then
+                                request_handle:headers():add("X-Kuma-Forwarded-Client-Zone", zone)
+                            end
+                        end
+                    end
+                end
+
+                function envoy_on_response(handle)
+                end
           - name: envoy.filters.http.router
           routeConfig:
             name: inbound:backend3

--- a/pkg/xds/generator/testdata/profile-source/3-envoy-config.golden.yaml
+++ b/pkg/xds/generator/testdata/profile-source/3-envoy-config.golden.yaml
@@ -191,6 +191,33 @@ resources:
           '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
           forwardClientCertDetails: SANITIZE_SET
           httpFilters:
+          - name: envoy.filters.http.lua
+            typedConfig:
+              '@type': type.googleapis.com/envoy.extensions.filters.http.lua.v3.Lua
+              inlineCode: |
+                function envoy_on_request(request_handle)
+                    if request_handle:connection():ssl() and request_handle:streamInfo():downstreamSslConnection() then
+                        local cert_uris = request_handle:streamInfo():downstreamSslConnection():uriSanPeerCertificate()
+                        for _, uri in pairs(cert_uris) do
+                            if uri:find("^spiffe://") ~= nil then
+                                request_handle:headers():add("X-Kuma-Forwarded-Client-Cert", uri)
+                            end
+
+                            local service = uri:match("^kuma://kuma.io/service/(.+)$")
+                            if service ~= nil and service ~= '' then
+                                request_handle:headers():add("X-Kuma-Forwarded-Client-Service", service)
+                            end
+
+                            local zone = uri:match("^kuma://kuma.io/zone/(.+)$")
+                            if zone ~= nil and zone ~= '' then
+                                request_handle:headers():add("X-Kuma-Forwarded-Client-Zone", zone)
+                            end
+                        end
+                    end
+                end
+
+                function envoy_on_response(handle)
+                end
           - name: envoy.filters.http.router
           routeConfig:
             name: inbound:backend

--- a/pkg/xds/generator/testdata/profile-source/4-envoy-config.golden.yaml
+++ b/pkg/xds/generator/testdata/profile-source/4-envoy-config.golden.yaml
@@ -212,6 +212,33 @@ resources:
           '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
           forwardClientCertDetails: SANITIZE_SET
           httpFilters:
+          - name: envoy.filters.http.lua
+            typedConfig:
+              '@type': type.googleapis.com/envoy.extensions.filters.http.lua.v3.Lua
+              inlineCode: |
+                function envoy_on_request(request_handle)
+                    if request_handle:connection():ssl() and request_handle:streamInfo():downstreamSslConnection() then
+                        local cert_uris = request_handle:streamInfo():downstreamSslConnection():uriSanPeerCertificate()
+                        for _, uri in pairs(cert_uris) do
+                            if uri:find("^spiffe://") ~= nil then
+                                request_handle:headers():add("X-Kuma-Forwarded-Client-Cert", uri)
+                            end
+
+                            local service = uri:match("^kuma://kuma.io/service/(.+)$")
+                            if service ~= nil and service ~= '' then
+                                request_handle:headers():add("X-Kuma-Forwarded-Client-Service", service)
+                            end
+
+                            local zone = uri:match("^kuma://kuma.io/zone/(.+)$")
+                            if zone ~= nil and zone ~= '' then
+                                request_handle:headers():add("X-Kuma-Forwarded-Client-Zone", zone)
+                            end
+                        end
+                    end
+                end
+
+                function envoy_on_response(handle)
+                end
           - name: envoy.filters.http.router
           routeConfig:
             name: inbound:backend

--- a/test/e2e/service_identity_injection/service_identity_injection_universal.go
+++ b/test/e2e/service_identity_injection/service_identity_injection_universal.go
@@ -81,6 +81,6 @@ mtls:
 
 		Expect(response.Received.Headers).To(HaveKeyWithValue("X-Kuma-Forwarded-Client-Cert", []string{"spiffe://default/dp-demo-client"}))
 		Expect(response.Received.Headers).To(HaveKeyWithValue("X-Kuma-Forwarded-Client-Service", []string{"dp-demo-client"}))
-		//Expect(response.Received.Headers).To(HaveKeyWithValue("X-Kuma-Forwarded-Client-Zone", []string{"eu-west-1"}))
+		// Expect(response.Received.Headers).To(HaveKeyWithValue("X-Kuma-Forwarded-Client-Zone", []string{"eu-west-1"}))
 	})
 }

--- a/test/e2e/service_identity_injection/service_identity_injection_universal.go
+++ b/test/e2e/service_identity_injection/service_identity_injection_universal.go
@@ -2,19 +2,18 @@ package service_identity_injection
 
 import (
 	"encoding/json"
+	"fmt"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	"github.com/kumahq/kuma/test/server/types"
-
 	"github.com/kumahq/kuma/pkg/config/core"
 	. "github.com/kumahq/kuma/test/framework"
+	"github.com/kumahq/kuma/test/server/types"
 )
 
 func ServiceIdentityInjectionUniversal() {
-	meshMTLSOn := func() string {
-		return `
+	mtlsEnabled := `
 type: Mesh
 name: default
 mtls:
@@ -23,7 +22,9 @@ mtls:
   - name: ca-1
     type: builtin
 `
-	}
+	mesh := "default"
+	demoClientAppName := "dp-demo-client"
+	demoClientAppZone := "eu-west-1"
 
 	var cluster Cluster
 	var deployOptsFuncs []DeployOptionsFunc
@@ -40,22 +41,40 @@ mtls:
 
 		err = NewClusterSetup().
 			Install(Kuma(core.Standalone, deployOptsFuncs...)).
-			Install(YamlUniversal(meshMTLSOn())).
+			Install(YamlUniversal(mtlsEnabled)).
 			Setup(cluster)
 		Expect(err).ToNot(HaveOccurred())
 
 		Expect(cluster.VerifyKuma()).To(Succeed())
 
-		demoClientToken, err := cluster.GetKuma().GenerateDpToken("default", "dp-demo-client")
+		demoClientToken, err := cluster.GetKuma().GenerateDpToken(mesh, demoClientAppName)
 		Expect(err).ToNot(HaveOccurred())
-		testServerToken, err := cluster.GetKuma().GenerateDpToken("default", "test-server")
+		testServerToken, err := cluster.GetKuma().GenerateDpToken(mesh, "test-server")
 		Expect(err).ToNot(HaveOccurred())
 
-		err = DemoClientUniversal("dp-demo-client", "default", demoClientToken,
+		demoClientDataplaneYaml := fmt.Sprintf(`
+type: Dataplane
+mesh: %s
+name: {{ name }}
+networking:
+  address: {{ address }}
+  inbound:
+  - port: 3000
+    tags:
+      kuma.io/service: %s
+      kuma.io/zone: %s
+      team: client-owners
+  transparentProxying:
+    redirectPortInbound: %s
+    redirectPortInboundV6: %s
+    redirectPortOutbound: %s
+`,
+	mesh, demoClientAppName, demoClientAppZone, RedirectPortInbound, RedirectPortInboundV6, RedirectPortOutbound)
+		err = DemoClientUniversalYaml(demoClientAppName, mesh, demoClientToken, demoClientDataplaneYaml,
 			WithTransparentProxy(true), WithBuiltinDNS(true))(cluster)
 		Expect(err).ToNot(HaveOccurred())
 
-		err = TestServerUniversal("test-server", "default", testServerToken,
+		err = TestServerUniversal("test-server", mesh, testServerToken,
 			WithArgs([]string{"echo"}),
 			WithTransparentProxy(true), WithProtocol("http"))(cluster)
 		Expect(err).ToNot(HaveOccurred())
@@ -75,12 +94,12 @@ mtls:
 	It("server should receive X-Kuma-Forwarded-Client-* headers", func() {
 		var response types.EchoResponse
 		cmd := []string{"curl", "--fail", "test-server.mesh/content"}
-		stdout, _, err := cluster.ExecWithRetries("", "", "dp-demo-client", cmd...)
+		stdout, _, err := cluster.ExecWithRetries("", "", demoClientAppName, cmd...)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(json.Unmarshal([]byte(stdout), &response)).To(Succeed())
 
-		Expect(response.Received.Headers).To(HaveKeyWithValue("X-Kuma-Forwarded-Client-Cert", []string{"spiffe://default/dp-demo-client"}))
-		Expect(response.Received.Headers).To(HaveKeyWithValue("X-Kuma-Forwarded-Client-Service", []string{"dp-demo-client"}))
-		// Expect(response.Received.Headers).To(HaveKeyWithValue("X-Kuma-Forwarded-Client-Zone", []string{"eu-west-1"}))
+		Expect(response.Received.Headers).To(HaveKeyWithValue("X-Kuma-Forwarded-Client-Cert", []string{fmt.Sprintf("spiffe://%s/%s", mesh, demoClientAppName)}))
+		Expect(response.Received.Headers).To(HaveKeyWithValue("X-Kuma-Forwarded-Client-Service", []string{demoClientAppName}))
+		Expect(response.Received.Headers).To(HaveKeyWithValue("X-Kuma-Forwarded-Client-Zone", []string{demoClientAppZone}))
 	})
 }

--- a/test/e2e/service_identity_injection/service_identity_injection_universal.go
+++ b/test/e2e/service_identity_injection/service_identity_injection_universal.go
@@ -69,7 +69,7 @@ networking:
     redirectPortInboundV6: %s
     redirectPortOutbound: %s
 `,
-	mesh, demoClientAppName, demoClientAppZone, RedirectPortInbound, RedirectPortInboundV6, RedirectPortOutbound)
+			mesh, demoClientAppName, demoClientAppZone, RedirectPortInbound, RedirectPortInboundV6, RedirectPortOutbound)
 		err = DemoClientUniversalYaml(demoClientAppName, mesh, demoClientToken, demoClientDataplaneYaml,
 			WithTransparentProxy(true), WithBuiltinDNS(true))(cluster)
 		Expect(err).ToNot(HaveOccurred())

--- a/test/e2e/service_identity_injection/service_identity_injection_universal.go
+++ b/test/e2e/service_identity_injection/service_identity_injection_universal.go
@@ -1,0 +1,98 @@
+package service_identity_injection
+
+import (
+	"strings"
+
+	"github.com/go-errors/errors"
+	"github.com/gruntwork-io/terratest/modules/retry"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/kumahq/kuma/pkg/config/core"
+	. "github.com/kumahq/kuma/test/framework"
+)
+
+func ServiceIdentityInjectionUniversal() {
+	meshMTLSOn := func() string {
+		return `
+type: Mesh
+name: default
+mtls:
+  enabledBackend: ca-1
+  backends:
+  - name: ca-1
+    type: builtin
+`
+	}
+
+	var cluster Cluster
+	var deployOptsFuncs []DeployOptionsFunc
+
+	BeforeEach(func() {
+		clusters, err := NewUniversalClusters(
+			[]string{Kuma3},
+			Silent)
+		Expect(err).ToNot(HaveOccurred())
+
+		// Global
+		cluster = clusters.GetCluster(Kuma3)
+		deployOptsFuncs = KumaUniversalDeployOpts
+
+		err = NewClusterSetup().
+			Install(Kuma(core.Standalone, deployOptsFuncs...)).
+			Install(YamlUniversal(meshMTLSOn())).
+			Setup(cluster)
+		Expect(err).ToNot(HaveOccurred())
+
+		err = cluster.VerifyKuma()
+		Expect(err).ToNot(HaveOccurred())
+
+		demoClientToken, err := cluster.GetKuma().GenerateDpToken("default", "demo-client")
+		Expect(err).ToNot(HaveOccurred())
+
+		echoServerToken, err := cluster.GetKuma().GenerateDpToken("default", "echo-server_kuma-test_svc_8080")
+		Expect(err).ToNot(HaveOccurred())
+
+		err = NewClusterSetup().
+			Install(DemoClientUniversal(AppModeDemoClient, "default", demoClientToken)).
+			Install(EchoServerUniversal(AppModeEchoServer, "default", "universal", echoServerToken)).
+			Setup(cluster)
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	AfterEach(func() {
+		if ShouldSkipCleanup() {
+			return
+		}
+		err := cluster.DeleteKuma(deployOptsFuncs...)
+		Expect(err).ToNot(HaveOccurred())
+
+		err = cluster.DismissCluster()
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	It("server should receive X-Kuma-Forwarded-Client-* headers", func() {
+		retry.DoWithRetry(cluster.GetTesting(), "curl local service",
+			DefaultRetries, DefaultTimeout,
+			func() (string, error) {
+				stdout, _, err := cluster.ExecWithRetries("", "", "demo-client",
+					"curl", "-v", "-m", "3", "--fail", "localhost:4001")
+				if err != nil {
+					return "should retry", err
+				}
+				if strings.Contains(stdout, "HTTP/1.1 200 OK") {
+					return "Accessing service successful", nil
+				}
+				return "should retry", errors.Errorf("should retry")
+			})
+
+		_, stderr, err := cluster.Exec("", "", "demo-client", "curl", "-v", "-m", "8", "--fail", "localhost:4001")
+		Expect(err).ToNot(HaveOccurred())
+		Expect(stderr).To(BeEmpty())
+
+		appStdout := cluster.(*UniversalCluster).GetApp(AppModeEchoServer).GetMainApp().Out()
+		Expect(appStdout).To(ContainSubstring("X-Kuma-Forwarded-Client-Cert: spiffe://default/demo-client"))
+		Expect(appStdout).To(ContainSubstring("X-Kuma-Forwarded-Client-Service: demo-client"))
+		Expect(appStdout).To(ContainSubstring("X-Kuma-Forwarded-Client-Zone: us-east-1"))
+	})
+}

--- a/test/e2e/service_identity_injection/service_identity_injection_universal.go
+++ b/test/e2e/service_identity_injection/service_identity_injection_universal.go
@@ -81,6 +81,6 @@ mtls:
 
 		Expect(response.Received.Headers).To(HaveKeyWithValue("X-Kuma-Forwarded-Client-Cert", []string{"spiffe://default/dp-demo-client"}))
 		Expect(response.Received.Headers).To(HaveKeyWithValue("X-Kuma-Forwarded-Client-Service", []string{"dp-demo-client"}))
-		Expect(response.Received.Headers).To(HaveKeyWithValue("X-Kuma-Forwarded-Client-Zone", []string{"us-east-1"}))
+		//Expect(response.Received.Headers).To(HaveKeyWithValue("X-Kuma-Forwarded-Client-Zone", []string{"eu-west-1"}))
 	})
 }

--- a/test/e2e/service_identity_injection/service_identity_injection_universal_suite_test.go
+++ b/test/e2e/service_identity_injection/service_identity_injection_universal_suite_test.go
@@ -1,0 +1,30 @@
+package service_identity_injection
+
+import (
+	"testing"
+
+	"github.com/kumahq/kuma/test/framework"
+
+	"github.com/go-logr/logr"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+
+	"github.com/kumahq/kuma/pkg/core"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestE2EServiceIdentityInjection(t *testing.T) {
+	if framework.IsK8sClustersStarted() {
+		RegisterFailHandler(Fail)
+		RunSpecs(t, "E2E Service Identity Injection Suite")
+	} else {
+		t.SkipNow()
+	}
+}
+
+var _ = BeforeSuite(func() {
+	core.SetLogger = func(l logr.Logger) {}
+	logf.SetLogger(zap.LoggerTo(GinkgoWriter, true))
+})

--- a/test/e2e/service_identity_injection/service_identity_injection_universal_test.go
+++ b/test/e2e/service_identity_injection/service_identity_injection_universal_test.go
@@ -1,0 +1,9 @@
+package service_identity_injection_test
+
+import (
+	. "github.com/onsi/ginkgo"
+
+	"github.com/kumahq/kuma/test/e2e/service_identity_injection"
+)
+
+var _ = Describe("Test Service Identity Injection on Universal deployment", service_identity_injection.ServiceIdentityInjectionUniversal)

--- a/test/framework/constants.go
+++ b/test/framework/constants.go
@@ -40,9 +40,9 @@ const (
 	kumaCPAPIPort        = 5681
 	kumaCPAPIPortFwdBase = 32000 + kumaCPAPIPort
 
-	redirectPortInbound   = "15006"
-	redirectPortInboundV6 = "15010"
-	redirectPortOutbound  = "15001"
+	RedirectPortInbound   = "15006"
+	RedirectPortInboundV6 = "15010"
+	RedirectPortOutbound  = "15001"
 	cidrIPv6              = "fd00:fd00::/64"
 )
 

--- a/test/framework/setup.go
+++ b/test/framework/setup.go
@@ -295,7 +295,7 @@ func EchoServerUniversal(name, mesh, echo, token string, fs ...DeployOptionsFunc
 		switch {
 		case opts.transparent:
 			appYaml = fmt.Sprintf(EchoServerDataplaneTransparentProxy, mesh, "8080", "80", opts.serviceName,
-				opts.protocol, opts.serviceVersion, redirectPortInbound, redirectPortInboundV6, redirectPortOutbound)
+				opts.protocol, opts.serviceVersion, RedirectPortInbound, RedirectPortInboundV6, RedirectPortOutbound)
 		case opts.serviceProbe:
 			appYaml = fmt.Sprintf(EchoServerDataplaneWithServiceProbe, mesh, "8080", "80", opts.serviceName,
 				opts.protocol, opts.serviceVersion)
@@ -418,17 +418,23 @@ spec:
 }
 
 func DemoClientUniversal(name, mesh, token string, fs ...DeployOptionsFunc) InstallFunc {
+	emptyYamlApp := ""
+	return DemoClientUniversalYaml(name, mesh, token, emptyYamlApp, fs...)
+}
+
+func DemoClientUniversalYaml(name, mesh, token, appYaml string, fs ...DeployOptionsFunc) InstallFunc {
 	return func(cluster Cluster) error {
 		opts := newDeployOpt(fs...)
 		args := []string{"ncat", "-lvk", "-p", "3000"}
-		appYaml := ""
-		if opts.transparent {
-			appYaml = fmt.Sprintf(DemoClientDataplaneTransparentProxy, mesh, "3000", name, redirectPortInbound, redirectPortInboundV6, redirectPortOutbound)
-		} else {
-			if opts.serviceProbe {
-				appYaml = fmt.Sprintf(DemoClientDataplaneWithServiceProbe, mesh, "13000", "3000", name, "80", "8080")
+		if appYaml == "" {
+			if opts.transparent {
+				appYaml = fmt.Sprintf(DemoClientDataplaneTransparentProxy, mesh, "3000", name, RedirectPortInbound, RedirectPortInboundV6, RedirectPortOutbound)
 			} else {
-				appYaml = fmt.Sprintf(DemoClientDataplane, mesh, "13000", "3000", name, "80", "8080")
+				if opts.serviceProbe {
+					appYaml = fmt.Sprintf(DemoClientDataplaneWithServiceProbe, mesh, "13000", "3000", name, "80", "8080")
+				} else {
+					appYaml = fmt.Sprintf(DemoClientDataplane, mesh, "13000", "3000", name, "80", "8080")
+				}
 			}
 		}
 		fs = append(fs, WithName(name), WithMesh(mesh), WithAppname(AppModeDemoClient), WithToken(token), WithArgs(args), WithYaml(appYaml), WithIPv6(IsIPv6()))
@@ -471,7 +477,7 @@ networking:
     redirectPortInbound: %s
     redirectPortInboundV6: %s
     redirectPortOutbound: %s
-`, mesh, "80", "8080", opts.serviceName, opts.protocol, opts.serviceVersion, redirectPortInbound, redirectPortInboundV6, redirectPortOutbound)
+`, mesh, "80", "8080", opts.serviceName, opts.protocol, opts.serviceVersion, RedirectPortInbound, RedirectPortInboundV6, RedirectPortOutbound)
 
 		fs = append(fs,
 			WithName(name),

--- a/test/framework/universal_app.go
+++ b/test/framework/universal_app.go
@@ -55,6 +55,7 @@ networking:
     tags:
       kuma.io/service: %s
       kuma.io/protocol: %s
+      kuma.io/zone: eu-west-1
       team: server-owners
       version: %s
 `
@@ -73,6 +74,7 @@ networking:
     tags:
       kuma.io/service: %s
       kuma.io/protocol: %s
+      kuma.io/zone: eu-west-1
       team: server-owners
       version: %s
 `
@@ -89,6 +91,7 @@ networking:
     tags:
       kuma.io/service: %s
       kuma.io/protocol: %s
+      kuma.io/zone: eu-west-1
       team: server-owners
       version: %s
   transparentProxying:
@@ -109,6 +112,7 @@ networking:
     servicePort: %s
     tags:
       kuma.io/service: %s
+      kuma.io/zone: us-east-1
       team: client-owners
   outbound:
   - port: 4000
@@ -135,6 +139,7 @@ networking:
       tcp: {}
     tags:
       kuma.io/service: %s
+      kuma.io/zone: us-east-1
       team: client-owners
   outbound:
   - port: 4000
@@ -158,6 +163,7 @@ networking:
   - port: %s
     tags:
       kuma.io/service: %s
+      kuma.io/zone: us-east-1
       team: client-owners
   transparentProxying:
     redirectPortInbound: %s
@@ -432,6 +438,10 @@ func (s *UniversalApp) getIP(isipv6 bool) (string, error) {
 		errString = "No IPv6 address found"
 	}
 	return "", errors.Errorf(errString)
+}
+
+func (s *UniversalApp) GetMainApp() *SshApp {
+	return s.mainApp
 }
 
 type SshApp struct {

--- a/test/framework/universal_app.go
+++ b/test/framework/universal_app.go
@@ -55,7 +55,6 @@ networking:
     tags:
       kuma.io/service: %s
       kuma.io/protocol: %s
-      kuma.io/zone: eu-west-1
       team: server-owners
       version: %s
 `
@@ -74,7 +73,6 @@ networking:
     tags:
       kuma.io/service: %s
       kuma.io/protocol: %s
-      kuma.io/zone: eu-west-1
       team: server-owners
       version: %s
 `
@@ -91,7 +89,6 @@ networking:
     tags:
       kuma.io/service: %s
       kuma.io/protocol: %s
-      kuma.io/zone: eu-west-1
       team: server-owners
       version: %s
   transparentProxying:
@@ -112,7 +109,6 @@ networking:
     servicePort: %s
     tags:
       kuma.io/service: %s
-      kuma.io/zone: us-east-1
       team: client-owners
   outbound:
   - port: 4000
@@ -139,7 +135,6 @@ networking:
       tcp: {}
     tags:
       kuma.io/service: %s
-      kuma.io/zone: us-east-1
       team: client-owners
   outbound:
   - port: 4000
@@ -163,7 +158,6 @@ networking:
   - port: %s
     tags:
       kuma.io/service: %s
-      kuma.io/zone: us-east-1
       team: client-owners
   transparentProxying:
     redirectPortInbound: %s


### PR DESCRIPTION
Signed-off-by: Jacek Ewertowski <jacek.ewertowski1@gmail.com>

### Summary

This pull request is a continuation of #1941. This change introduces forwarding headers:
- `X-Kuma-Forwarded-Client-Cert`
- `X-Kuma-Forwarded-Client-Service`
- `X-Kuma-Forwarded-Client-Zone`

These headers contain data extracted from a downstream SSL connection details in the Lua filter.

### Issues resolved

Fix #1256 

### Testing

I created a [repository](https://github.com/jewertow/kuma-sandbox) with a set of configurations that allow to quickly test this feature manually. To do this, follow instructions defined [here](https://github.com/jewertow/kuma-sandbox/tree/master/service-identity-injection).
