### PR TITLE
tests(kuma-dp) fix concurrent access to buffer

### DIFF
--- a/app/kuma-dp/cmd/run_test.go
+++ b/app/kuma-dp/cmd/run_test.go
@@ -3,8 +3,8 @@
 package cmd
 
 import (
-	"bytes"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"net"
 	"os"
@@ -110,10 +110,11 @@ var _ = Describe("run", func() {
 				Expect(err).ToNot(HaveOccurred())
 				return respBytes, "", nil
 			}
+			_, writer := io.Pipe()
 			cmd := NewRootCmd(rootCtx)
 			cmd.SetArgs(append([]string{"run"}, given.args...))
-			cmd.SetOut(&bytes.Buffer{})
-			cmd.SetErr(&bytes.Buffer{})
+			cmd.SetOut(writer)
+			cmd.SetErr(writer)
 
 			// when
 			By("starting the dataplane manager")

--- a/pkg/core/resources/apis/mesh/zone_ingress_validator_test.go
+++ b/pkg/core/resources/apis/mesh/zone_ingress_validator_test.go
@@ -145,6 +145,7 @@ var _ = Describe("Dataplane", func() {
                   region: eu
               - tags:
                   kuma.io/service: ""
+              - tags:
                   version: ""`,
 			expected: `
                 violations:
@@ -156,7 +157,9 @@ var _ = Describe("Dataplane", func() {
                   message: cannot be empty
                 - field: availableService[3].tags.tags["kuma.io/service"]
                   message: tag value cannot be empty
-                - field: availableService[3].tags.tags["version"]
+                - field: availableService[4].tags["kuma.io/service"]
+                  message: cannot be empty
+                - field: availableService[4].tags.tags["version"]
                   message: tag value cannot be empty`,
 		}),
 	)


### PR DESCRIPTION
`bytes.Buffer`  is not thread-safe. We are using it in kuma-dp `run_test` to replace stdout. Then both Envoy and built-in DNS writes to this buffer which results in data race detection.

The solution is to use `io.Pipe()` which returns reader and writer which are thread-safe.

### Documentation

- [X] No docs

### Testing

- [X] Unit tests
- [ ] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes 
