### PR TITLE
chore(kuma-cp) HELM 1.2.0-rc1

### DIFF
--- a/app/kumactl/cmd/install/testdata/install-control-plane.cni-enabled.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.cni-enabled.golden.yaml
@@ -865,7 +865,7 @@ spec:
         # priority scheduling and that its resources are reserved
         # if it ever gets evicted.
         scheduler.alpha.kubernetes.io/critical-pod: ''
-        checksum/config: 375efbde5a96f2582df3fb709986bb85ed3536c28fdc9a6e3c4486501f8174dc
+        checksum/config: 563bfdc6fdb48a0ad755c1d6f62ed532516d6ad9d95348e8a24a327496b4a79f
     spec:
       nodeSelector:
       
@@ -943,8 +943,8 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 737d1358e24137cdf1b4c543251d5cf58dcec1cb9b8e796fcbf73aa46e3bc857
-        checksum/tls-secrets: b6128110c0171fabe5ce618b2fc3e8fe8b6cdac7e1a8eb256b7a674c714dd874
+        checksum/config: c1d8cb4e957a7f48bbd8866c81f5a90ebb687608164c44eb2099b32be4886459
+        checksum/tls-secrets: 6c32c8520465f26e7ab2f2c4461c7dab507ba4fa2de2fa8b9ef8a7678e6845f6
       labels:
         app.kubernetes.io/name: kuma
         app.kubernetes.io/instance: kuma

--- a/app/kumactl/cmd/install/testdata/install-control-plane.defaults.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.defaults.golden.yaml
@@ -768,8 +768,8 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 737d1358e24137cdf1b4c543251d5cf58dcec1cb9b8e796fcbf73aa46e3bc857
-        checksum/tls-secrets: b6128110c0171fabe5ce618b2fc3e8fe8b6cdac7e1a8eb256b7a674c714dd874
+        checksum/config: c1d8cb4e957a7f48bbd8866c81f5a90ebb687608164c44eb2099b32be4886459
+        checksum/tls-secrets: 6c32c8520465f26e7ab2f2c4461c7dab507ba4fa2de2fa8b9ef8a7678e6845f6
       labels:
         app.kubernetes.io/name: kuma
         app.kubernetes.io/instance: kuma

--- a/app/kumactl/cmd/install/testdata/install-control-plane.global.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.global.golden.yaml
@@ -777,8 +777,8 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 737d1358e24137cdf1b4c543251d5cf58dcec1cb9b8e796fcbf73aa46e3bc857
-        checksum/tls-secrets: b6128110c0171fabe5ce618b2fc3e8fe8b6cdac7e1a8eb256b7a674c714dd874
+        checksum/config: c1d8cb4e957a7f48bbd8866c81f5a90ebb687608164c44eb2099b32be4886459
+        checksum/tls-secrets: 6c32c8520465f26e7ab2f2c4461c7dab507ba4fa2de2fa8b9ef8a7678e6845f6
       labels:
         app.kubernetes.io/name: kuma
         app.kubernetes.io/instance: kuma

--- a/app/kumactl/cmd/install/testdata/install-control-plane.override-env-vars.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.override-env-vars.golden.yaml
@@ -768,8 +768,8 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 737d1358e24137cdf1b4c543251d5cf58dcec1cb9b8e796fcbf73aa46e3bc857
-        checksum/tls-secrets: b6128110c0171fabe5ce618b2fc3e8fe8b6cdac7e1a8eb256b7a674c714dd874
+        checksum/config: c1d8cb4e957a7f48bbd8866c81f5a90ebb687608164c44eb2099b32be4886459
+        checksum/tls-secrets: 6c32c8520465f26e7ab2f2c4461c7dab507ba4fa2de2fa8b9ef8a7678e6845f6
       labels:
         app.kubernetes.io/name: kuma
         app.kubernetes.io/instance: kuma

--- a/app/kumactl/cmd/install/testdata/install-control-plane.overrides.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.overrides.golden.yaml
@@ -772,8 +772,8 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 1143b9fd6b0dd9591b450c90c4fa2fa109e582b02bf82140764f9980302b3603
-        checksum/tls-secrets: 47a8c27cf02b8244e9981c1360f00d868381935eccdcbfe44ee3518d4ad8527c
+        checksum/config: 020bde1c6e1d038671a83461c40411213c088e4dcaa1bfd253128cedf25fce3b
+        checksum/tls-secrets: 0c750735fe61e317ebb5398c4d0bc7ac565e3adff43efa869cc4b95dd8f721aa
       labels:
         app.kubernetes.io/name: kuma
         app.kubernetes.io/instance: kuma

--- a/app/kumactl/cmd/install/testdata/install-control-plane.with-ingress.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.with-ingress.golden.yaml
@@ -797,8 +797,8 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 737d1358e24137cdf1b4c543251d5cf58dcec1cb9b8e796fcbf73aa46e3bc857
-        checksum/tls-secrets: b6128110c0171fabe5ce618b2fc3e8fe8b6cdac7e1a8eb256b7a674c714dd874
+        checksum/config: c1d8cb4e957a7f48bbd8866c81f5a90ebb687608164c44eb2099b32be4886459
+        checksum/tls-secrets: 6c32c8520465f26e7ab2f2c4461c7dab507ba4fa2de2fa8b9ef8a7678e6845f6
       labels:
         app.kubernetes.io/name: kuma
         app.kubernetes.io/instance: kuma

--- a/app/kumactl/cmd/install/testdata/install-control-plane.zone.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.zone.golden.yaml
@@ -772,8 +772,8 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 737d1358e24137cdf1b4c543251d5cf58dcec1cb9b8e796fcbf73aa46e3bc857
-        checksum/tls-secrets: b6128110c0171fabe5ce618b2fc3e8fe8b6cdac7e1a8eb256b7a674c714dd874
+        checksum/config: c1d8cb4e957a7f48bbd8866c81f5a90ebb687608164c44eb2099b32be4886459
+        checksum/tls-secrets: 6c32c8520465f26e7ab2f2c4461c7dab507ba4fa2de2fa8b9ef8a7678e6845f6
       labels:
         app.kubernetes.io/name: kuma
         app.kubernetes.io/instance: kuma

--- a/deployments/charts/kuma/Chart.yaml
+++ b/deployments/charts/kuma/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: kuma
 description: A Helm chart for the Kuma Control Plane
 type: application
-version: 0.5.7
-appVersion: 1.1.6
+version: 0.6.0-rc1
+appVersion: 1.2.0-rc1
 home: https://github.com/kumahq/kuma
 maintainers:
   - name: austince

--- a/deployments/charts/kuma/README.md
+++ b/deployments/charts/kuma/README.md
@@ -2,7 +2,7 @@
 
 A Helm chart for the Kuma Control Plane
 
-![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![Version: 0.5.7](https://img.shields.io/badge/Version-0.5.7-informational?style=flat-square) ![AppVersion: 1.1.6](https://img.shields.io/badge/AppVersion-1.1.6-informational?style=flat-square)
+![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![Version: 0.6.0-rc1](https://img.shields.io/badge/Version-0.6.0--rc1-informational?style=flat-square) ![AppVersion: 1.2.0-rc1](https://img.shields.io/badge/AppVersion-1.2.0--rc1-informational?style=flat-square)
 
 **Homepage:** <https://github.com/kumahq/kuma>
 


### PR DESCRIPTION
Change HELM chart version to RC1. This way we can upgrade stable Kuma to RC1 using HELM without releasing the chart.

Keep in mind that when we tag `1.2.0-rc1`, the chart is not released because we have regex on `number.number.number`