### PR TITLE
fix(*) add release tagging script

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,7 +69,7 @@ reusable:
         branches:
           ignore: /.*/
         tags:
-          only: /^(\d+)\.(\d+)\.(\d+)$/
+          only: /^v?(\d+)\.(\d+)\.(\d+)$/
 
     # filters for the kuma-commit workflow
     master_workflow_filters: &master_workflow_filters

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -28,7 +28,7 @@ To release a new version of Kuma follow these steps:
 
 - [ ] Update the `CHANGELOG.md`. Use `make changelog` as a helper.
 - [ ] Double-check that all the new changes have been documented on the [kuma.io website](https://github.com/kumahq/kuma-website) by opening up a documentation PR with the new content for the new version of Kuma.
-- [ ] Create a new Git tag for the release.
+- [ ] Create a new Git tag for the release using the [make-release-tag.sh](./tools/release/make-release-tag.sh) script. This script takes 2 arguments, the name of the previous release tag and the name of the new release tag to create and create an annotated tag containing a summary of the commits in the release.
 - [ ] Push the Git tag. This will trigger the release job on CI.
 - [ ] Make sure the new binaries are available in [Bintray](https://bintray.com/kong/kuma).
 - [ ] Download the new Kuma version and double-check that it works with the demo app. Check that is works both in `universal` and `kubernetes` modes.

--- a/tools/releases/make-release-tag.sh
+++ b/tools/releases/make-release-tag.sh
@@ -1,0 +1,65 @@
+#! /usr/bin/env bash
+
+# make-release-tag.sh: This script assumes that you are on a branch and
+# have otherwise prepared the release. It creates an annotated tag with
+# a message containing the shortlog of commits from the previous version.
+
+readonly PROGNAME=$(basename "$0")
+readonly OLDVERS="$1"
+readonly NEWVERS="$2"
+
+if [ -z "$OLDVERS" ] || [ -z "$NEWVERS" ]; then
+    printf "Usage: %s OLDVERS NEWVERS\n" "$PROGNAME"
+    exit 1
+fi
+
+shopt -s extglob # Enable extended pattern matching in case switches.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+if [ -z "$(git tag --list "$OLDVERS")" ]; then
+    printf "%s: tag '%s' does not exist\n" "$PROGNAME" "$OLDVERS"
+    exit 1
+fi
+
+if [ -n "$(git tag --list "$NEWVERS")" ]; then
+    printf "%s: tag '%s' already exists\n" "$PROGNAME" "$NEWVERS"
+    exit 1
+fi
+
+case "$NEWVERS" in
+v+([0-9.])) ;;
+*)
+    printf "%s: tag '%s' must be of the form vX.Y.X\n" "$PROGNAME" "$NEWVERS"
+    exit 1
+    ;;
+esac
+
+git tag -F - "$NEWVERS" <<EOF
+Tag $NEWVERS release.
+
+$(git shortlog "$OLDVERS..HEAD")
+EOF
+
+printf "Created tag '%s'\n" "$NEWVERS"
+
+# People set up their remotes in different ways, so we need to check
+# which one to dry run against. Choose a remote name that pushes to the
+# kumahq org repository (i.e. not the user's Github fork).
+readonly REMOTE=$(git remote -v | awk '$2~/kumahq\/kuma/ && $3=="(push)" {print $1}' | head -n 1)
+if [ -z "$REMOTE" ]; then
+    printf "%s: unable to determine remote for %s\n" "$PROGNAME" "kumahq/kuma"
+    exit 1
+fi
+
+readonly BRANCH=$(git branch --show-current)
+
+printf "Testing whether commit can be pushed\n"
+git push --dry-run "$REMOTE" "$BRANCH"
+
+printf "Testing whether tag '%s' can be pushed\n" "$NEWVERS"
+git push --dry-run "$REMOTE" "$NEWVERS"
+
+printf "Run 'git push %s %s' to push the commit and then 'git push %s %s' to push the tag if you are happy\n" "$REMOTE" "$BRANCH" "$REMOTE" "$NEWVERS"


### PR DESCRIPTION
### Summary

Add a script to ensure that the release tag is an annotated tag that
contains a summary of commits since the previous release. The tag name
is required to match Go module semantic version numbering.

### Full changelog

* Fix version tagging to work with Go modules.

### Issues resolved

Fix #2073 

### Documentation

None.

### Testing
```
$ ./tools/releases/make-release-tag.sh 1.1.6 v99.99.0
Created tag 'v99.99.0'
Testing whether tag 'v99.99.0' can be pushed
To github.com:kumahq/kuma.git
 * [new tag]           v99.99.0 -> v99.99.0
Run 'git push origin v99.99.0' to push the tag if you are happy.
```
```
$ git show v99.99.0
tag v99.99.0
Tagger: James Peach <james.peach@konghq.com>
Date:   Tue Jun 15 07:56:43 2021 +1000

Tag v99.99.0 release.

Austin Cawley-Edwards (6):
      chore(*) add Installation Method line item to issue template (#1661)
      chore(crds) upgrade to apiextensions.k8s.io/v1 (#1108)
      feat(mads) implement v1 API (#1753)
      fix(prometheus-sd) namespace source names for v1 API (#1896)
      feat(mads) add support for HTTP long polling (#2121)
      feat(mads) allow specifying fetch-timeout via query param (#2148)

Bart Smykla (42):
      chore(*) gui update (#1657)
      feat(ci/cd) wait for check before e2e/integration (#1690)
      feat(*) remove overwhelming logs when delete crds (#1744)
      feat(tests) add eks as a target for e2e tests (#1684)
      chore(*) new gui version (#1773)
...
```
