### PR TITLE
chore(kuma-cp) add validators of pseudoheader and host modifications

### DIFF
--- a/pkg/core/resources/apis/mesh/traffic_route_validator.go
+++ b/pkg/core/resources/apis/mesh/traffic_route_validator.go
@@ -122,17 +122,24 @@ func (d *TrafficRouteResource) validateModificationHeaders(
 	headers *mesh_proto.TrafficRoute_Http_Modify_Headers,
 ) (err validators.ValidationError) {
 	for i, add := range headers.GetAdd() {
-		if add.GetName() == "" {
-			err.AddViolationAt(pathBuilder.Field("add").Index(i).Field("name"), "cannot be empty")
-		}
+		err.Add(validateHeaderName(pathBuilder.Field("add").Index(i).Field("name"), add.GetName()))
 		if add.GetValue() == "" {
 			err.AddViolationAt(pathBuilder.Field("add").Index(i).Field("value"), "cannot be empty")
 		}
 	}
 	for i, remove := range headers.GetRemove() {
-		if remove.GetName() == "" {
-			err.AddViolationAt(pathBuilder.Field("add").Index(i).Field("remove"), "cannot be empty")
-		}
+		err.Add(validateHeaderName(pathBuilder.Field("remove").Index(i).Field("name"), remove.GetName()))
+	}
+	return
+}
+
+func validateHeaderName(pathBuilder validators.PathBuilder, headerName string) (err validators.ValidationError) {
+	if headerName == "" {
+		err.AddViolationAt(pathBuilder, "cannot be empty")
+		return
+	}
+	if headerName[0] == ':' || headerName == "host" || headerName == "Host" {
+		err.AddViolationAt(pathBuilder, "host header and HTTP/2 pseudo-headers are not allowed to be modified")
 	}
 	return
 }

--- a/pkg/core/resources/apis/mesh/traffic_route_validator_test.go
+++ b/pkg/core/resources/apis/mesh/traffic_route_validator_test.go
@@ -541,13 +541,13 @@ var _ = Describe("TrafficRoute", func() {
                   message: cannot be empty
                 - field: conf.http[0].modify.requestHeaders.add[0].value
                   message: cannot be empty
-                - field: conf.http[0].modify.requestHeaders.add[0].remove
+                - field: conf.http[0].modify.requestHeaders.remove[0].name
                   message: cannot be empty
                 - field: conf.http[0].modify.responseHeaders.add[0].name
                   message: cannot be empty
                 - field: conf.http[0].modify.responseHeaders.add[0].value
                   message: cannot be empty
-                - field: conf.http[0].modify.responseHeaders.add[0].remove
+                - field: conf.http[0].modify.responseHeaders.remove[0].name
                   message: cannot be empty
                 - field: conf.http[1].modify.path.regex.pattern
                   message: cannot be empty
@@ -586,6 +586,65 @@ var _ = Describe("TrafficRoute", func() {
                 violations:
                 - field: conf.http[0].modify.path.rewritePrefix
                   message: can only be set when .http.match.path.prefix is not empty`,
+			}),
+			Entry("http - not allow some headers to be modified", testCase{
+				route: `
+                sources:
+                - match:
+                    kuma.io/service: web
+                destinations:
+                - match:
+                    kuma.io/service: backend
+                conf:
+                  http:
+                  - match:
+                      path:
+                        exact: "/offers"
+                    modify:
+                      requestHeaders:
+                        add:
+                        - name: 'host'
+                          value: xyz
+                        - name: 'Host'
+                          value: xyz
+                        - name: ':path'
+                          value: xyz
+                        remove:
+                        - name: 'host'
+                          value: xyz
+                      responseHeaders:
+                        add:
+                        - name: 'host'
+                          value: xyz
+                        - name: 'Host'
+                          value: xyz
+                        - name: ':path'
+                          value: xyz
+                        remove:
+                        - name: 'host'
+                          value: xyz
+                    destination:
+                      kuma.io/service: offers
+                  destination:
+                    kuma.io/service: backend`,
+				expected: `
+                violations:
+                - field: conf.http[0].modify.requestHeaders.add[0].name
+                  message: host header and HTTP/2 pseudo-headers are not allowed to be modified
+                - field: conf.http[0].modify.requestHeaders.add[1].name
+                  message: host header and HTTP/2 pseudo-headers are not allowed to be modified
+                - field: conf.http[0].modify.requestHeaders.add[2].name
+                  message: host header and HTTP/2 pseudo-headers are not allowed to be modified
+                - field: conf.http[0].modify.requestHeaders.remove[0].name
+                  message: host header and HTTP/2 pseudo-headers are not allowed to be modified
+                - field: conf.http[0].modify.responseHeaders.add[0].name
+                  message: host header and HTTP/2 pseudo-headers are not allowed to be modified
+                - field: conf.http[0].modify.responseHeaders.add[1].name
+                  message: host header and HTTP/2 pseudo-headers are not allowed to be modified
+                - field: conf.http[0].modify.responseHeaders.add[2].name
+                  message: host header and HTTP/2 pseudo-headers are not allowed to be modified
+                - field: conf.http[0].modify.responseHeaders.remove[0].name
+                  message: host header and HTTP/2 pseudo-headers are not allowed to be modified`,
 			}),
 		)
 	})

--- a/test/e2e/trafficroute/universal_standalone/traffic_route.go
+++ b/test/e2e/trafficroute/universal_standalone/traffic_route.go
@@ -523,10 +523,6 @@ conf:
     modify:
       host:
         value: "modified-host"
-      requestHeaders:
-        add:
-        - name: "host" # host section takes precedence
-          value: xyz
     destination:
       kuma.io/service: test-server
   - match:


### PR DESCRIPTION
### Summary

With Envoy 1.18.3 we can no longer modify host header in `requestHeaders` and `responseHeaders`.
This should have been caught in upgrade PR but it slipped out because of flaky support jobs test.

### Documentation

- [X] No docs

### Testing

- [X] Unit tests
- [X] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes 
