### PR TITLE
fix(kuma-cp) delete old dataplane-based ingress in PodController

### DIFF
--- a/pkg/defaults/signing_key.go
+++ b/pkg/defaults/signing_key.go
@@ -12,21 +12,22 @@ import (
 func (d *defaultsComponent) createZoneIngressSigningKeyIfNotExist(ctx context.Context) error {
 	signingKey, err := zoneingress.CreateSigningKey()
 	if err != nil {
-		return errors.Wrap(err, "could not create a signing key")
+		return errors.Wrap(err, "could not create a Zone Ingress signing key")
 	}
 	key := zoneingress.SigningKeyResourceKey()
 	err = d.resManager.Get(ctx, signingKey, core_store.GetBy(key))
 	if err == nil {
+		log.V(1).Info("Zone Ingress signing key already exists. Skip creating zone ingress signing key.")
 		return nil
 	}
 	if !core_store.IsResourceNotFound(err) {
 		return errors.Wrap(err, "could not retrieve a resource")
 	}
-	log.Info("trying to create zone ingress signing key")
+	log.Info("trying to create a Zone Ingress signing key")
 	if err := d.resManager.Create(ctx, signingKey, core_store.CreateBy(key)); err != nil {
-		log.V(1).Info("could not create Zone Ingress signing key", "err", err)
+		log.V(1).Info("could not create a Zone Ingress signing key", "err", err)
 		return errors.Wrap(err, "could not create a resource")
 	}
-	log.Info("zone ingress signing key created")
+	log.Info("Zone Ingress signing key created")
 	return nil
 }

--- a/pkg/defaults/signing_key.go
+++ b/pkg/defaults/signing_key.go
@@ -22,8 +22,11 @@ func (d *defaultsComponent) createZoneIngressSigningKeyIfNotExist(ctx context.Co
 	if !core_store.IsResourceNotFound(err) {
 		return errors.Wrap(err, "could not retrieve a resource")
 	}
+	log.Info("trying to create zone ingress signing key")
 	if err := d.resManager.Create(ctx, signingKey, core_store.CreateBy(key)); err != nil {
+		log.V(1).Info("could not create Zone Ingress signing key", "err", err)
 		return errors.Wrap(err, "could not create a resource")
 	}
+	log.Info("zone ingress signing key created")
 	return nil
 }

--- a/pkg/plugins/runtime/k8s/controllers/pod_controller_test.go
+++ b/pkg/plugins/runtime/k8s/controllers/pod_controller_test.go
@@ -532,4 +532,50 @@ var _ = Describe("PodReconciler", func() {
 		Expect(requestsStr).To(HaveLen(2))
 		Expect(requestsStr).To(ConsistOf("dp-1", "dp-2"))
 	})
+
+	It("should delete old dataplane-based Ingress and create new Zone Ingress", func() {
+		err := kubeClient.Create(context.Background(), &mesh_k8s.Dataplane{
+			Mesh: "mesh-1",
+			ObjectMeta: kube_meta.ObjectMeta{
+				Namespace: "kuma-system",
+				Name:      "pod-ingress",
+				OwnerReferences: []kube_meta.OwnerReference{{
+					Controller: utilpointer.BoolPtr(true),
+					Kind:       "Pod",
+					Name:       "pod-ingress",
+				}},
+			},
+			Spec: map[string]interface{}{
+				"networking": map[string]interface{}{
+					"ingress": map[string]interface{}{},
+				},
+			},
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		// given
+		req := kube_ctrl.Request{
+			NamespacedName: kube_types.NamespacedName{Namespace: "kuma-system", Name: "pod-ingress"},
+		}
+
+		// when
+		_, err = reconciler.Reconcile(req)
+
+		// then
+		Expect(err).ToNot(HaveOccurred())
+
+		zoneIngresses := &mesh_k8s.ZoneIngressList{}
+		err = kubeClient.List(context.Background(), zoneIngresses)
+		// and
+		Expect(err).ToNot(HaveOccurred())
+		// and
+		Expect(zoneIngresses.Items).To(HaveLen(1))
+
+		dataplanes := &mesh_k8s.DataplaneList{}
+		err = kubeClient.List(context.Background(), dataplanes)
+		// and
+		Expect(err).ToNot(HaveOccurred())
+		// and
+		Expect(dataplanes.Items).To(HaveLen(0))
+	})
 })


### PR DESCRIPTION
### Summary

During the upgrade to Kuma 1.2.0 a new Ingress pod may make a request to the old-versioned PodController.
This will inevitably cause a generation of both Dataplane Ingress resource and Zone Ingress resource.
That's why here we're deleting Dataplane Ingress resource.

### Full changelog

* [Implement ...]
* [Fix ...]

### Issues resolved

Fix #XXX

### Documentation

- [ ] Link to the website [documentation PR](https://github.com/kumahq/kuma-website/pull/XXX)

### Testing

- [x] Unit tests
- [ ] E2E tests
- [ ] Manual testing on Universal
- [x] Manual testing on Kubernetes 
