### PR TITLE
fix(kuma-cp) Clear snapshots from cache on disconnect

### DIFF
--- a/pkg/sds/server/v3/reconciler.go
+++ b/pkg/sds/server/v3/reconciler.go
@@ -112,9 +112,7 @@ func (d *DataplaneReconciler) Reconcile(proxyId *core_xds.ProxyId) error {
 }
 
 func (d *DataplaneReconciler) Cleanup(proxyId *core_xds.ProxyId) error {
-	if err := d.cache.SetSnapshot(proxyId.String(), envoy_cache.Snapshot{}); err != nil {
-		return err
-	}
+	d.cache.ClearSnapshot(proxyId.String())
 	d.Lock()
 	delete(d.proxySnapshotInfo, proxyId.String())
 	d.Unlock()

--- a/pkg/xds/server/v3/reconcile.go
+++ b/pkg/xds/server/v3/reconcile.go
@@ -30,10 +30,8 @@ type reconciler struct {
 }
 
 func (r *reconciler) Clear(proxyId *model.ProxyId) error {
-	// cache.Clear() operation does not push a new (empty) configuration to Envoy.
-	// That is why instead of calling cache.Clear() we set configuration to an empty Snapshot.
-	// This fake value will be removed from cache on Envoy disconnect.
-	return r.cacher.Cache(&envoy_core.Node{Id: proxyId.String()}, envoy_cache.Snapshot{})
+	r.cacher.Clear(&envoy_core.Node{Id: proxyId.String()})
+	return nil
 }
 
 func (r *reconciler) Reconcile(ctx xds_context.Context, proxy *model.Proxy) error {

--- a/pkg/xds/server/v3/reconcile_test.go
+++ b/pkg/xds/server/v3/reconcile_test.go
@@ -172,6 +172,22 @@ var _ = Describe("Reconcile", func() {
 			Expect(snapshot.Resources[envoy_types.Cluster].Version).To(Equal("v8"))
 			Expect(snapshot.Resources[envoy_types.Endpoint].Version).To(Equal("v9"))
 			Expect(snapshot.Resources[envoy_types.Secret].Version).To(Equal("v10"))
+
+			By("simulating clear")
+			// when
+			err = r.Clear(&proxy.Id)
+			Expect(err).ToNot(HaveOccurred())
+			snapshot, err = xdsContext.Cache().GetSnapshot("demo.example")
+
+			// then
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("no snapshot found"))
+
+			Expect(snapshot.Resources[envoy_types.Listener].Version).To(Equal(""))
+			Expect(snapshot.Resources[envoy_types.Route].Version).To(Equal(""))
+			Expect(snapshot.Resources[envoy_types.Cluster].Version).To(Equal(""))
+			Expect(snapshot.Resources[envoy_types.Endpoint].Version).To(Equal(""))
+			Expect(snapshot.Resources[envoy_types.Secret].Version).To(Equal(""))
 		})
 	})
 })


### PR DESCRIPTION
Previously we were pushing an empty snapshot on the cache when a dp was disconnecting.
This was causing the dp to get an empty snapshot after a restart.
This would cause listeners to disappear for a short time and causing the traffic going through the dp to fail.
We now clear the snapshot from the dp to avoid this behaviour.

Fix #2171 

### Testing

- [x] Unit tests
- [ ] E2E tests
- [x] Manual testing on Universal
- [ ] Manual testing on Kubernetes 
