### PR TITLE
chore(kumactl) remove validation service from install kong

### DIFF
--- a/app/kumactl/cmd/install/testdata/install-gateway-enterprise.defaults.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-gateway-enterprise.defaults.golden.yaml
@@ -603,20 +603,6 @@ spec:
     app: ingress-kong
   type: LoadBalancer
 ---
-apiVersion: v1
-kind: Service
-metadata:
-  name: kong-validation-webhook
-  namespace: kong-enterprise-gateway
-spec:
-  ports:
-  - name: webhook
-    port: 443
-    protocol: TCP
-    targetPort: 8080
-  selector:
-    app: ingress-kong
----
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/app/kumactl/cmd/install/testdata/install-gateway-enterprise.overrides.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-gateway-enterprise.overrides.golden.yaml
@@ -603,20 +603,6 @@ spec:
     app: ingress-kong
   type: LoadBalancer
 ---
-apiVersion: v1
-kind: Service
-metadata:
-  name: kong-validation-webhook
-  namespace: notdefault
-spec:
-  ports:
-  - name: webhook
-    port: 443
-    protocol: TCP
-    targetPort: 8080
-  selector:
-    app: ingress-kong
----
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/app/kumactl/cmd/install/testdata/install-gateway.defaults.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-gateway.defaults.golden.yaml
@@ -574,20 +574,6 @@ subjects:
 apiVersion: v1
 kind: Service
 metadata:
-  name: kong-validation-webhook
-  namespace: kuma-gateway
-spec:
-  ports:
-  - name: webhook
-    port: 443
-    protocol: TCP
-    targetPort: 8080
-  selector:
-    app: ingress-kong
----
-apiVersion: v1
-kind: Service
-metadata:
   annotations:
     service.beta.kubernetes.io/aws-load-balancer-backend-protocol: tcp
     service.beta.kubernetes.io/aws-load-balancer-type: nlb

--- a/app/kumactl/cmd/install/testdata/install-gateway.overrides.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-gateway.overrides.golden.yaml
@@ -574,20 +574,6 @@ subjects:
 apiVersion: v1
 kind: Service
 metadata:
-  name: kong-validation-webhook
-  namespace: notdefault
-spec:
-  ports:
-  - name: webhook
-    port: 443
-    protocol: TCP
-    targetPort: 8080
-  selector:
-    app: ingress-kong
----
-apiVersion: v1
-kind: Service
-metadata:
   annotations:
     service.beta.kubernetes.io/aws-load-balancer-backend-protocol: tcp
     service.beta.kubernetes.io/aws-load-balancer-type: nlb

--- a/app/kumactl/data/install/k8s/gateway-kong-enterprise/kong-enterprise/kong-enterprise.yaml
+++ b/app/kumactl/data/install/k8s/gateway-kong-enterprise/kong-enterprise/kong-enterprise.yaml
@@ -601,20 +601,6 @@ spec:
     app: ingress-kong
   type: LoadBalancer
 ---
-apiVersion: v1
-kind: Service
-metadata:
-  name: kong-validation-webhook
-  namespace: {{ .Namespace }}
-spec:
-  ports:
-  - name: webhook
-    port: 443
-    protocol: TCP
-    targetPort: 8080
-  selector:
-    app: ingress-kong
----
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/app/kumactl/data/install/k8s/gateway-kong/kong/kong.yaml
+++ b/app/kumactl/data/install/k8s/gateway-kong/kong/kong.yaml
@@ -591,20 +591,6 @@ spec:
     app: ingress-kong
   type: LoadBalancer
 ---
-apiVersion: v1
-kind: Service
-metadata:
-  name: kong-validation-webhook
-  namespace: {{ .Namespace }}
-spec:
-  ports:
-  - name: webhook
-    port: 443
-    protocol: TCP
-    targetPort: 8080
-  selector:
-    app: ingress-kong
----
 apiVersion: apps/v1
 kind: Deployment
 metadata:


### PR DESCRIPTION
### Summary

Validation service is not required since there is no validation hook.

- [X] No docs

### Testing

- [X] Unit tests
- [X] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes 
