### PR TITLE
chore(*) bump versions of logging, metrics, tracing

### DIFF
--- a/app/kumactl/cmd/install/testdata/install-gateway-enterprise.defaults.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-gateway-enterprise.defaults.golden.yaml
@@ -650,7 +650,7 @@ spec:
           value: /dev/stderr
         - name: KONG_PROXY_ERROR_LOG
           value: /dev/stderr
-        image: kong/kong-gateway:2.3.3.2-alpine
+        image: kong/kong-gateway:2.4.1.0-alpine
         lifecycle:
           preStop:
             exec:
@@ -706,7 +706,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.namespace
-        image: kong/kubernetes-ingress-controller:1.2
+        image: kong/kubernetes-ingress-controller:1.3
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/app/kumactl/cmd/install/testdata/install-gateway-enterprise.overrides.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-gateway-enterprise.overrides.golden.yaml
@@ -650,7 +650,7 @@ spec:
           value: /dev/stderr
         - name: KONG_PROXY_ERROR_LOG
           value: /dev/stderr
-        image: kong/kong-gateway:2.3.3.2-alpine
+        image: kong/kong-gateway:2.4.1.0-alpine
         lifecycle:
           preStop:
             exec:
@@ -706,7 +706,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.namespace
-        image: kong/kubernetes-ingress-controller:1.2
+        image: kong/kubernetes-ingress-controller:1.3
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/app/kumactl/cmd/install/testdata/install-gateway.defaults.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-gateway.defaults.golden.yaml
@@ -635,7 +635,7 @@ spec:
           value: /dev/stderr
         - name: KONG_PROXY_ERROR_LOG
           value: /dev/stderr
-        image: kong:2.3
+        image: kong:2.4
         lifecycle:
           preStop:
             exec:
@@ -691,7 +691,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.namespace
-        image: kong/kubernetes-ingress-controller:1.2
+        image: kong/kubernetes-ingress-controller:1.3
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/app/kumactl/cmd/install/testdata/install-gateway.overrides.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-gateway.overrides.golden.yaml
@@ -635,7 +635,7 @@ spec:
           value: /dev/stderr
         - name: KONG_PROXY_ERROR_LOG
           value: /dev/stderr
-        image: kong:2.3
+        image: kong:2.4
         lifecycle:
           preStop:
             exec:
@@ -691,7 +691,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.namespace
-        image: kong/kubernetes-ingress-controller:1.2
+        image: kong/kubernetes-ingress-controller:1.3
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/app/kumactl/cmd/install/testdata/install-logging.defaults.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-logging.defaults.golden.yaml
@@ -546,7 +546,7 @@ spec:
       serviceAccountName: loki-promtail
       containers:
         - name: promtail
-          image: "grafana/promtail:1.6.1"
+          image: "grafana/promtail:2.1.0"
           imagePullPolicy: IfNotPresent
           args:
             - "-config.file=/etc/promtail/promtail.yaml"
@@ -648,7 +648,7 @@ spec:
         []
       containers:
         - name: loki
-          image: "grafana/loki:2.1.0"
+          image: "grafana/loki:2.2.1"
           imagePullPolicy: IfNotPresent
           args:
             - "-config.file=/etc/loki/loki.yaml"

--- a/app/kumactl/cmd/install/testdata/install-logging.overrides.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-logging.overrides.golden.yaml
@@ -546,7 +546,7 @@ spec:
       serviceAccountName: loki-promtail
       containers:
         - name: promtail
-          image: "grafana/promtail:1.6.1"
+          image: "grafana/promtail:2.1.0"
           imagePullPolicy: IfNotPresent
           args:
             - "-config.file=/etc/promtail/promtail.yaml"
@@ -648,7 +648,7 @@ spec:
         []
       containers:
         - name: loki
-          image: "grafana/loki:2.1.0"
+          image: "grafana/loki:2.2.1"
           imagePullPolicy: IfNotPresent
           args:
             - "-config.file=/etc/loki/loki.yaml"

--- a/app/kumactl/cmd/install/testdata/install-metrics.defaults.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-metrics.defaults.golden.yaml
@@ -11785,7 +11785,7 @@ spec:
       serviceAccountName: prometheus-node-exporter
       containers:
         - name: prometheus-node-exporter
-          image: "prom/node-exporter:v1.1.1"
+          image: "prom/node-exporter:v1.1.2"
           imagePullPolicy: "IfNotPresent"
           args:
             - --path.procfs=/host/proc
@@ -11843,7 +11843,7 @@ spec:
         runAsUser: 472
       containers:
         - name: grafana
-          image: "grafana/grafana:7.4.3"
+          image: "grafana/grafana:7.5.8"
           imagePullPolicy: IfNotPresent
           volumeMounts:
             - name: config
@@ -12003,7 +12003,7 @@ spec:
       serviceAccountName: prometheus-kube-state-metrics
       containers:
         - name: prometheus-kube-state-metrics
-          image: "quay.io/coreos/kube-state-metrics:v1.9.7"
+          image: "quay.io/coreos/kube-state-metrics:v1.9.8"
           imagePullPolicy: "IfNotPresent"
           ports:
             - name: metrics
@@ -12038,7 +12038,7 @@ spec:
       serviceAccountName: prometheus-pushgateway
       containers:
         - name: prometheus-pushgateway
-          image: "prom/pushgateway:v1.4.0"
+          image: "prom/pushgateway:v1.4.1"
           imagePullPolicy: "IfNotPresent"
           args:
           ports:
@@ -12085,7 +12085,7 @@ spec:
               mountPath: /etc/config
               readOnly: true
         - name: prometheus-server
-          image: "prom/prometheus:v2.25.0"
+          image: "prom/prometheus:v2.27.1"
           imagePullPolicy: "IfNotPresent"
           args:
             - --storage.tsdb.retention.time=15d

--- a/app/kumactl/cmd/install/testdata/install-metrics.no-grafana.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-metrics.no-grafana.golden.yaml
@@ -759,7 +759,7 @@ spec:
       serviceAccountName: prometheus-node-exporter
       containers:
         - name: prometheus-node-exporter
-          image: "prom/node-exporter:v1.1.1"
+          image: "prom/node-exporter:v1.1.2"
           imagePullPolicy: "IfNotPresent"
           args:
             - --path.procfs=/host/proc
@@ -810,7 +810,7 @@ spec:
       serviceAccountName: prometheus-kube-state-metrics
       containers:
         - name: prometheus-kube-state-metrics
-          image: "quay.io/coreos/kube-state-metrics:v1.9.7"
+          image: "quay.io/coreos/kube-state-metrics:v1.9.8"
           imagePullPolicy: "IfNotPresent"
           ports:
             - name: metrics
@@ -845,7 +845,7 @@ spec:
       serviceAccountName: prometheus-pushgateway
       containers:
         - name: prometheus-pushgateway
-          image: "prom/pushgateway:v1.4.0"
+          image: "prom/pushgateway:v1.4.1"
           imagePullPolicy: "IfNotPresent"
           args:
           ports:
@@ -892,7 +892,7 @@ spec:
               mountPath: /etc/config
               readOnly: true
         - name: prometheus-server
-          image: "prom/prometheus:v2.25.0"
+          image: "prom/prometheus:v2.27.1"
           imagePullPolicy: "IfNotPresent"
           args:
             - --storage.tsdb.retention.time=15d

--- a/app/kumactl/cmd/install/testdata/install-metrics.no-prometheus.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-metrics.no-prometheus.golden.yaml
@@ -11064,7 +11064,7 @@ spec:
         runAsUser: 472
       containers:
         - name: grafana
-          image: "grafana/grafana:7.4.3"
+          image: "grafana/grafana:7.5.8"
           imagePullPolicy: IfNotPresent
           volumeMounts:
             - name: config

--- a/app/kumactl/cmd/install/testdata/install-metrics.overrides.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-metrics.overrides.golden.yaml
@@ -11785,7 +11785,7 @@ spec:
       serviceAccountName: prometheus-node-exporter
       containers:
         - name: prometheus-node-exporter
-          image: "prom/node-exporter:v1.1.1"
+          image: "prom/node-exporter:v1.1.2"
           imagePullPolicy: "IfNotPresent"
           args:
             - --path.procfs=/host/proc
@@ -11843,7 +11843,7 @@ spec:
         runAsUser: 472
       containers:
         - name: grafana
-          image: "grafana/grafana:7.4.3"
+          image: "grafana/grafana:7.5.8"
           imagePullPolicy: IfNotPresent
           volumeMounts:
             - name: config
@@ -12003,7 +12003,7 @@ spec:
       serviceAccountName: prometheus-kube-state-metrics
       containers:
         - name: prometheus-kube-state-metrics
-          image: "quay.io/coreos/kube-state-metrics:v1.9.7"
+          image: "quay.io/coreos/kube-state-metrics:v1.9.8"
           imagePullPolicy: "IfNotPresent"
           ports:
             - name: metrics
@@ -12038,7 +12038,7 @@ spec:
       serviceAccountName: prometheus-pushgateway
       containers:
         - name: prometheus-pushgateway
-          image: "prom/pushgateway:v1.4.0"
+          image: "prom/pushgateway:v1.4.1"
           imagePullPolicy: "IfNotPresent"
           args:
           ports:
@@ -12085,7 +12085,7 @@ spec:
               mountPath: /etc/config
               readOnly: true
         - name: prometheus-server
-          image: "prom/prometheus:v2.25.0"
+          image: "prom/prometheus:v2.27.1"
           imagePullPolicy: "IfNotPresent"
           args:
             - --storage.tsdb.retention.time=15d

--- a/app/kumactl/cmd/install/testdata/install-tracing.defaults.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-tracing.defaults.golden.yaml
@@ -54,7 +54,7 @@ items:
             -   env:
                   - name: COLLECTOR_ZIPKIN_HOST_PORT
                     value: "9411"
-                image: jaegertracing/all-in-one:1.22
+                image: jaegertracing/all-in-one:1.23
                 name: jaeger
                 ports:
                   - containerPort: 5775

--- a/app/kumactl/cmd/install/testdata/install-tracing.overrides.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-tracing.overrides.golden.yaml
@@ -54,7 +54,7 @@ items:
             -   env:
                   - name: COLLECTOR_ZIPKIN_HOST_PORT
                     value: "9411"
-                image: jaegertracing/all-in-one:1.22
+                image: jaegertracing/all-in-one:1.23
                 name: jaeger
                 ports:
                   - containerPort: 5775

--- a/app/kumactl/data/install/k8s/gateway-kong-enterprise/kong-enterprise/kong-enterprise.yaml
+++ b/app/kumactl/data/install/k8s/gateway-kong-enterprise/kong-enterprise/kong-enterprise.yaml
@@ -648,7 +648,7 @@ spec:
           value: /dev/stderr
         - name: KONG_PROXY_ERROR_LOG
           value: /dev/stderr
-        image: kong/kong-gateway:2.3.3.2-alpine
+        image: kong/kong-gateway:2.4.1.0-alpine
         lifecycle:
           preStop:
             exec:
@@ -704,7 +704,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.namespace
-        image: kong/kubernetes-ingress-controller:1.2
+        image: kong/kubernetes-ingress-controller:1.3
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/app/kumactl/data/install/k8s/gateway-kong/kong/kong.yaml
+++ b/app/kumactl/data/install/k8s/gateway-kong/kong/kong.yaml
@@ -633,7 +633,7 @@ spec:
           value: /dev/stderr
         - name: KONG_PROXY_ERROR_LOG
           value: /dev/stderr
-        image: kong:2.3
+        image: kong:2.4
         lifecycle:
           preStop:
             exec:
@@ -689,7 +689,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.namespace
-        image: kong/kubernetes-ingress-controller:1.2
+        image: kong/kubernetes-ingress-controller:1.3
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/app/kumactl/data/install/k8s/logging/loki/loki.yaml
+++ b/app/kumactl/data/install/k8s/logging/loki/loki.yaml
@@ -539,7 +539,7 @@ spec:
       serviceAccountName: loki-promtail
       containers:
         - name: promtail
-          image: "grafana/promtail:1.6.1"
+          image: "grafana/promtail:2.1.0"
           imagePullPolicy: IfNotPresent
           args:
             - "-config.file=/etc/promtail/promtail.yaml"
@@ -641,7 +641,7 @@ spec:
         []
       containers:
         - name: loki
-          image: "grafana/loki:2.1.0"
+          image: "grafana/loki:2.2.1"
           imagePullPolicy: IfNotPresent
           args:
             - "-config.file=/etc/loki/loki.yaml"

--- a/app/kumactl/data/install/k8s/metrics/grafana/grafana.yaml
+++ b/app/kumactl/data/install/k8s/metrics/grafana/grafana.yaml
@@ -271,7 +271,7 @@ spec:
         runAsUser: 472
       containers:
         - name: grafana
-          image: "grafana/grafana:7.4.3"
+          image: "grafana/grafana:7.5.8"
           imagePullPolicy: IfNotPresent
           volumeMounts:
             - name: config

--- a/app/kumactl/data/install/k8s/metrics/prometheus/kube-stats-metrics.yaml
+++ b/app/kumactl/data/install/k8s/metrics/prometheus/kube-stats-metrics.yaml
@@ -174,7 +174,7 @@ spec:
       serviceAccountName: prometheus-kube-state-metrics
       containers:
         - name: prometheus-kube-state-metrics
-          image: "quay.io/coreos/kube-state-metrics:v1.9.7"
+          image: "quay.io/coreos/kube-state-metrics:v1.9.8"
           imagePullPolicy: "IfNotPresent"
           ports:
             - name: metrics

--- a/app/kumactl/data/install/k8s/metrics/prometheus/node-exporter.yaml
+++ b/app/kumactl/data/install/k8s/metrics/prometheus/node-exporter.yaml
@@ -56,7 +56,7 @@ spec:
       serviceAccountName: prometheus-node-exporter
       containers:
         - name: prometheus-node-exporter
-          image: "prom/node-exporter:v1.1.1"
+          image: "prom/node-exporter:v1.1.2"
           imagePullPolicy: "IfNotPresent"
           args:
             - --path.procfs=/host/proc

--- a/app/kumactl/data/install/k8s/metrics/prometheus/pushgateway.yaml
+++ b/app/kumactl/data/install/k8s/metrics/prometheus/pushgateway.yaml
@@ -78,7 +78,7 @@ spec:
       serviceAccountName: prometheus-pushgateway
       containers:
         - name: prometheus-pushgateway
-          image: "prom/pushgateway:v1.4.0"
+          image: "prom/pushgateway:v1.4.1"
           imagePullPolicy: "IfNotPresent"
           args:
           ports:

--- a/app/kumactl/data/install/k8s/metrics/prometheus/server.yaml
+++ b/app/kumactl/data/install/k8s/metrics/prometheus/server.yaml
@@ -433,7 +433,7 @@ spec:
               mountPath: /etc/config
               readOnly: true
         - name: prometheus-server
-          image: "prom/prometheus:v2.25.0"
+          image: "prom/prometheus:v2.27.1"
           imagePullPolicy: "IfNotPresent"
           args:
             - --storage.tsdb.retention.time=15d

--- a/app/kumactl/data/install/k8s/tracing/jaeger/all-in-one-template.yaml
+++ b/app/kumactl/data/install/k8s/tracing/jaeger/all-in-one-template.yaml
@@ -47,7 +47,7 @@ items:
             -   env:
                   - name: COLLECTOR_ZIPKIN_HOST_PORT
                     value: "9411"
-                image: jaegertracing/all-in-one:1.22
+                image: jaegertracing/all-in-one:1.23
                 name: jaeger
                 ports:
                   - containerPort: 5775


### PR DESCRIPTION
### Summary

Loki 2.1.0 -> 2.2.1
Grafana 7.4.3 -> 7.5.8
Prometheus 2.25.0 -> 2.27.1
Jaeger 1.22 -> 1.23
Kong GW 2.3 -> 2.4
KIC 1.2 -> 1.3

### Documentation

- [ ] Not needed

### Testing

- [ ] Unit tests
- [ ] E2E tests
- [ ] Manual testing on Universal
- [x] Manual testing on Kubernetes 
