### PR TITLE
fix(kuma-dp) validate the DP proxy type

### DIFF
--- a/app/kuma-dp/cmd/run.go
+++ b/app/kuma-dp/cmd/run.go
@@ -57,18 +57,19 @@ func newRunCmd(rootCtx *RootContext) *cobra.Command {
 			}
 
 			var err error
-			if mesh_proto.ProxyType(cfg.Dataplane.ProxyType) == mesh_proto.IngressProxyType {
+			switch mesh_proto.ProxyType(cfg.Dataplane.ProxyType) {
+			case mesh_proto.IngressProxyType:
 				proxyResource, err = readZoneIngressResource(cmd, cfg)
-				if err != nil {
-					runLog.Error(err, "unable to read provided zone ingress")
-					return err
-				}
-			} else {
+			case mesh_proto.DataplaneProxyType:
 				proxyResource, err = readDataplaneResource(cmd, cfg)
-				if err != nil {
-					runLog.Error(err, "unable to read provided dataplane")
-					return err
-				}
+			default:
+				return errors.Errorf("invalid proxy type %q (must be either %q or %q)",
+					cfg.Dataplane.ProxyType, mesh_proto.DataplaneProxyType, mesh_proto.IngressProxyType)
+			}
+
+			if err != nil {
+				runLog.Error(err, "unable to read provided %s policy", cfg.Dataplane.ProxyType)
+				return err
 			}
 
 			if proxyResource != nil {

--- a/app/kuma-dp/cmd/run_test.go
+++ b/app/kuma-dp/cmd/run_test.go
@@ -359,4 +359,25 @@ var _ = Describe("run", func() {
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(ContainSubstring("--name and --mesh cannot be specified when dataplane definition is provided"))
 	})
+
+	It("should fail when the proxy type is unknown", func() {
+		// given
+		cmd := NewRootCmd(DefaultRootContext())
+		cmd.SetArgs([]string{
+			"run",
+			"--cp-address", "http://localhost:1234",
+			"--binary-path", filepath.Join("testdata", "envoy-mock.sleep.sh"),
+			"--dataplane-file", filepath.Join("testdata", "dataplane_template.yaml"),
+			"--dns-coredns-path", filepath.Join("testdata", "coredns-mock.sleep.sh"),
+			"--proxy-type", "phoney",
+		})
+
+		// when
+		err := cmd.Execute()
+
+		// then
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("invalid proxy type"))
+	})
+
 })

--- a/pkg/config/app/kuma-dp/config_test.go
+++ b/pkg/config/app/kuma-dp/config_test.go
@@ -11,6 +11,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
+	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	"github.com/kumahq/kuma/pkg/config"
 	kuma_dp "github.com/kumahq/kuma/pkg/config/app/kuma-dp"
 	config_types "github.com/kumahq/kuma/pkg/config/types"
@@ -137,4 +138,16 @@ var _ = Describe("Config", func() {
 		fmt.Println(err.Error())
 		Expect(err.Error()).To(Equal(`Invalid configuration: .ControlPlane is not valid: .Retry is not valid: .Backoff must be a positive duration; .Dataplane is not valid: .ProxyType is not valid: not-a-proxy is not a valid proxy type; .Mesh must be non-empty; .Name must be non-empty; .DrainTime must be positive; .DataplaneRuntime is not valid: .BinaryPath must be non-empty`))
 	})
+
+	It("should ensure the proxy type is supported", func() {
+		// given
+		cfg := kuma_dp.Config{}
+
+		Expect(config.Load(filepath.Join("testdata", "valid-config.input.yaml"), &cfg)).Should(Succeed())
+
+		// when
+		cfg.Dataplane.ProxyType = string(mesh_proto.GatewayProxyType)
+		Expect(cfg.Validate()).ShouldNot(Succeed())
+	})
+
 })


### PR DESCRIPTION
### Summary

Validate that the kuma-dp proxy type nust be "ingress" or "dataplane".

### Full changelog

* Fix kuma-dp `--proxy-type` flag validation

### Issues resolved

N/A

### Documentation

N/A

### Testing

- [x] Unit tests
- [x] E2E tests
- [x] Manual testing on Universal
- [ ] Manual testing on Kubernetes 
