### PR TITLE
log-rotation for helm-based cp installation

### DIFF
--- a/deployments/charts/kuma/README.md
+++ b/deployments/charts/kuma/README.md
@@ -15,6 +15,10 @@ A Helm chart for the Kuma Control Plane
 | patchSystemNamespace | bool | `true` | Whether or not to patch the target namespace with the system label |
 | installCrdsOnUpgrade | object | `{"enabled":true,"imagePullSecrets":[]}` | Whether ot not install new CRDs before upgrade  (if any were introduced    with the new version of Kuma) |
 | controlPlane.logLevel | string | `"info"` | Kuma CP log level: one of off,info,debug |
+| controlPlane.logOutputPath | string | `""` | Kuma CP log rotation path |
+| controlPlane.logMaxAge | int | `30` | Maximum number of days to retain old log files |
+| controlPlane.logMaxRetain | int | `1000` | Maximum number of the old log files to retain |
+| controlPlane.logMaxSize | int | `100` | Maximum size in megabytes of a log file before it gets rotated |
 | controlPlane.mode | string | `"standalone"` | Kuma CP modes: one of standalone,zone,global |
 | controlPlane.zone | string | `nil` | Kuma CP zone, if running multizone |
 | controlPlane.kdsGlobalAddress | string | `""` | Only used in `zone` mode |

--- a/deployments/charts/kuma/templates/cp-deployment.yaml
+++ b/deployments/charts/kuma/templates/cp-deployment.yaml
@@ -57,6 +57,12 @@ spec:
           args:
             - run
             - --log-level={{ .Values.controlPlane.logLevel }}
+            {{- if .Values.controlPlane.logOutputPath }}
+            - --log-max-age={{ .Values.controlPlane.logMaxAge }}
+            - --log-max-retained-files={{ .Values.controlPlane.logMaxRetain }}
+            - --log-max-size={{ .Values.controlPlane.logMaxSize }}
+            - --log-output-path={{ .Values.controlPlane.logOutputPath }}
+            {{- end }}
             - --config-file=/etc/kuma.io/kuma-control-plane/config.yaml
           ports:
             - containerPort: 5681

--- a/deployments/charts/kuma/values.yaml
+++ b/deployments/charts/kuma/values.yaml
@@ -18,6 +18,18 @@ controlPlane:
   # -- Kuma CP log level: one of off,info,debug
   logLevel: "info"
 
+  # -- Kuma CP log rotation path
+  logOutputPath: ""
+
+  # -- Maximum number of days to retain old log files
+  logMaxAge: 30
+
+  # -- Maximum number of the old log files to retain
+  logMaxRetain: 1000
+
+  # -- Maximum size in megabytes of a log file before it gets rotated
+  logMaxSize: 100
+
   # -- Kuma CP modes: one of standalone,zone,global
   mode: "standalone"
 


### PR DESCRIPTION
Signed-off-by: Tharun <rajendrantharun@live.com>

### Summary

The `log rotation` option is not available on helm-based Kuma installation. This PR introduces `log rotation for cp in helm charts.

### Full changelog

* [Implement ...]
* [Fix ...]

### Issues resolved

Fix #XXX

### Documentation

- [ ] Link to the website [documentation PR](https://github.com/kumahq/kuma-website/pull/XXX)

### Testing

- [ ] Unit tests
- [ ] E2E tests
- [ ] Manual testing on Universal
- [x] Manual testing on Kubernetes 
