### PR TITLE
chore(*) extend Default K8s client

### DIFF
--- a/app/kumactl/cmd/install/install_control_plane.go
+++ b/app/kumactl/cmd/install/install_control_plane.go
@@ -41,7 +41,7 @@ This command requires that the KUBECONFIG environment is set`,
 			var kubeClientConfig *rest.Config
 			if !args.WithoutKubernetesConnection {
 				var err error
-				kubeClientConfig, err = k8s.DefaultClientConfig()
+				kubeClientConfig, err = k8s.DefaultClientConfig("", "")
 				if err != nil {
 					return errors.Wrap(err, "could not detect Kubernetes configuration")
 				}

--- a/app/kumactl/cmd/install/install_crds.go
+++ b/app/kumactl/cmd/install/install_crds.go
@@ -44,7 +44,7 @@ func newInstallCrdsCmd(ctx *install_context.InstallCrdsContext) *cobra.Command {
 				return errors.Wrap(err, "Failed mapping CRD files with CRD names")
 			}
 
-			kubeClientConfig, err := k8s.DefaultClientConfig()
+			kubeClientConfig, err := k8s.DefaultClientConfig("", "")
 			if err != nil {
 				return errors.Wrap(err, "Could not detect Kubernetes configuration")
 			}

--- a/app/kumactl/cmd/install/install_dns.go
+++ b/app/kumactl/cmd/install/install_dns.go
@@ -51,7 +51,7 @@ func newInstallDNS() *cobra.Command {
 		Long: `Install the DNS forwarding to the CoreDNS ConfigMap in the configured Kubernetes Cluster.
 This command requires that the KUBECONFIG environment is set`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			kubeClientConfig, err := k8s.DefaultClientConfig()
+			kubeClientConfig, err := k8s.DefaultClientConfig("", "")
 			if err != nil {
 				return errors.Wrap(err, "could not detect Kubernetes configuration")
 			}

--- a/app/kumactl/pkg/install/k8s/client_config.go
+++ b/app/kumactl/pkg/install/k8s/client_config.go
@@ -7,9 +7,14 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 )
 
-func DefaultClientConfig() (*rest.Config, error) {
+func DefaultClientConfig(kubeconfig, context string) (*rest.Config, error) {
 	loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
-	configOverrides := &clientcmd.ConfigOverrides{}
+	loadingRules.DefaultClientConfig = &clientcmd.DefaultClientConfig
+	loadingRules.ExplicitPath = kubeconfig
+	configOverrides := &clientcmd.ConfigOverrides{
+		ClusterDefaults: clientcmd.ClusterDefaults,
+		CurrentContext:  context,
+	}
 	clientConfig := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loadingRules, configOverrides)
 	config, err := clientConfig.ClientConfig()
 	if err != nil {


### PR DESCRIPTION
### Summary

For the purposes of the CNI, we need this function to be more configurable.


### Documentation

- [ ] Not needed

### Testing

- [ ] Unit tests
- [x] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes 
