### PR TITLE
feat(kuma-cp) add SNI to TLSed ExternalServices

### DIFF
--- a/pkg/xds/envoy/clusters/v3/client_side_tls_configurer.go
+++ b/pkg/xds/envoy/clusters/v3/client_side_tls_configurer.go
@@ -1,6 +1,8 @@
 package clusters
 
 import (
+	"fmt"
+
 	envoy_cluster "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
 	envoy_core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	pstruct "github.com/golang/protobuf/ptypes/struct"
@@ -26,7 +28,9 @@ func (c *ClientSideTLSConfigurer) Configure(cluster *envoy_cluster.Cluster) erro
 				ep.ExternalService.ClientCert,
 				ep.ExternalService.ClientKey,
 				ep.ExternalService.AllowRenegotiation,
-				ep.Target)
+				ep.Target,
+				fmt.Sprintf("%s:%d", ep.Target, ep.Port),
+			)
 			if err != nil {
 				return err
 			}

--- a/pkg/xds/envoy/clusters/v3/client_side_tls_configurer_test.go
+++ b/pkg/xds/envoy/clusters/v3/client_side_tls_configurer_test.go
@@ -71,6 +71,7 @@ var _ = Describe("ClientSideTLSConfigurer", func() {
             typedConfig:
               '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
               commonTlsContext: {}
+              sni: httpbin.org:3000
         type: EDS
 `}),
 		Entry("cluster with mTLS and certs", testCase{
@@ -117,6 +118,7 @@ var _ = Describe("ClientSideTLSConfigurer", func() {
                       - exact: httpbin.org
                       trustedCa:
                         inlineBytes: Y2FjZXJ0
+                  sni: httpbin.org:3000
             type: EDS
 `}),
 	)

--- a/pkg/xds/envoy/tls/v3/tls.go
+++ b/pkg/xds/envoy/tls/v3/tls.go
@@ -201,7 +201,7 @@ func googleGrpcSdsSpecifier(context xds_context.Context, name string, metadata *
 	}, nil
 }
 
-func UpstreamTlsContextOutsideMesh(ca, cert, key []byte, allowRenegotiation bool, hostname string) (*envoy_tls.UpstreamTlsContext, error) {
+func UpstreamTlsContextOutsideMesh(ca, cert, key []byte, allowRenegotiation bool, hostname string, sni string) (*envoy_tls.UpstreamTlsContext, error) {
 	var tlsCertificates []*envoy_tls.TlsCertificate
 	if cert != nil && key != nil {
 		tlsCertificates = []*envoy_tls.TlsCertificate{
@@ -230,6 +230,7 @@ func UpstreamTlsContextOutsideMesh(ca, cert, key []byte, allowRenegotiation bool
 
 	return &envoy_tls.UpstreamTlsContext{
 		AllowRenegotiation: allowRenegotiation,
+		Sni:                sni,
 		CommonTlsContext: &envoy_tls.CommonTlsContext{
 			TlsCertificates:       tlsCertificates,
 			ValidationContextType: validationContextType,


### PR DESCRIPTION
### Summary

Some External Services like AWS Lambda are hidden behind a load balancer that requires SNI to route the traffic.
This PR adds an SNI header when TLS is enabled.

### Documentation

- [X] Internal changes only

### Testing

- [X] Unit tests
- [ ] E2E tests - I honestly don't know how to write an E2E test here. We would need to have an echo service that responds with received SNI. I don't want to introduce a dependency on AWS Lambda.
- [X] Manual testing on Universal
- [ ] Manual testing on Kubernetes 
