### PR TITLE
chore(*) upload coverage data to codecov

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -851,6 +851,21 @@ jobs:
         command: |
           export PATH=$HOME/go/bin:$PATH
           make << parameters.target >>
+    - run:
+        # Ref https://docs.codecov.com/docs/about-the-codecov-bash-uploader
+        name: "Push coverage to Codecov"
+        command: |
+          set -o errexit
+          curl --fail --location --silent --output codecov https://codecov.io/bash
+          readonly VERSION=$(grep -o 'VERSION=\"[0-9\.]*\"' codecov | cut -d'"' -f2)
+          readonly URL="https://raw.githubusercontent.com/codecov/codecov-bash"
+          for i in 1 256 512 ; do
+            echo checking SHA${i}SUM for version ${VERSION}
+            shasum --algorithm $i --check --ignore-missing <(
+              curl --location --silent "${URL}/${VERSION}/SHA${i}SUM"
+            )
+          done
+          bash ./codecov -f build/coverage/*.out
     - store_artifacts:
         path: build/coverage
         destination: /coverage


### PR DESCRIPTION
### Summary

Upload coverage data in the integration test job.

There's a little subtlety here that we may want to clean up. Since codecov stores coverage data for comparison, we want the comparison base to be consistent. However, the integration job takes the test targets as parameters, so for the `kuma-commit` workflow we will get coverage for both "integration" and "test" targets, but for `kuma-master` and `kuma-release` workflows the coverage for the "test" target will be omitted.

Since the integration job looks like a superset of the test job, we could just combine these into the same job. We need the "test" target for coverage since that's the only thing that crosses module boundaries.

### Full changelog

N/A

### Issues resolved

Fix #2058 

### Documentation

N/A

### Testing

Checked out the codecov comments below.