### PR TITLE
chore(*) remove Dataplane ProxyType accessor

### DIFF
--- a/api/mesh/v1alpha1/dataplane_helpers.go
+++ b/api/mesh/v1alpha1/dataplane_helpers.go
@@ -50,16 +50,6 @@ func (t ProxyType) IsValid() error {
 	return errors.Errorf("%s is not a valid proxy type", t)
 }
 
-func (d *Dataplane) ProxyType() ProxyType {
-	if d.IsIngress() {
-		return IngressProxyType
-	}
-	if d.GetNetworking().GetGateway() != nil {
-		return GatewayProxyType
-	}
-	return DataplaneProxyType
-}
-
 type InboundInterface struct {
 	DataplaneIP   string
 	DataplanePort uint32
@@ -396,15 +386,29 @@ func (d *Dataplane) GetIdentifyingService() string {
 	return ServiceUnknown
 }
 
+// IsIngress returns true if this Dataplane specifies an ingress
+// configuration.
+//
+// Deprecated in favor of ZoneIngress.
 func (d *Dataplane) IsIngress() bool {
 	if d.GetNetworking() == nil {
 		return false
 	}
-	return d.Networking.Ingress != nil
+	return d.GetNetworking().GetIngress() != nil
+}
+
+// IsDataplane returns true if this Dataplane specifies a gateway
+// configuration.
+func (d *Dataplane) IsGateway() bool {
+	if d.GetNetworking() == nil {
+		return false
+	}
+
+	return d.GetNetworking().GetGateway() != nil
 }
 
 func (d *Dataplane) HasPublicAddress() bool {
-	if d.Networking.Ingress == nil {
+	if !d.IsIngress() {
 		return false
 	}
 	return d.Networking.Ingress.PublicAddress != "" && d.Networking.Ingress.PublicPort != 0

--- a/api/mesh/v1alpha1/dataplane_helpers_test.go
+++ b/api/mesh/v1alpha1/dataplane_helpers_test.go
@@ -356,6 +356,42 @@ var _ = Describe("Dataplane with inbound", func() {
 	})
 })
 
+var _ = Describe("Dataplane classification", func() {
+	Describe("with normal networking", func() {
+		It("should be a dataplane", func() {
+			dp := Dataplane{
+				Networking: &Dataplane_Networking{},
+			}
+			Expect(dp.IsGateway()).To(BeFalse())
+			Expect(dp.IsIngress()).To(BeFalse())
+		})
+	})
+
+	Describe("with gateway networking", func() {
+		It("should be a gateway", func() {
+			gw := Dataplane{
+				Networking: &Dataplane_Networking{
+					Gateway: &Dataplane_Networking_Gateway{},
+				},
+			}
+			Expect(gw.IsGateway()).To(BeTrue())
+			Expect(gw.IsIngress()).To(BeFalse())
+		})
+	})
+
+	Describe("with ingress networking", func() {
+		It("should be an ingress gateway", func() {
+			in := Dataplane{
+				Networking: &Dataplane_Networking{
+					Ingress: &Dataplane_Networking_Ingress{},
+				},
+			}
+			Expect(in.IsGateway()).To(BeFalse())
+			Expect(in.IsIngress()).To(BeTrue())
+		})
+	})
+})
+
 var _ = Describe("Dataplane with gateway", func() {
 	d := Dataplane{
 		Networking: &Dataplane_Networking{

--- a/pkg/core/resources/apis/mesh/dataplane_overview_helpers.go
+++ b/pkg/core/resources/apis/mesh/dataplane_overview_helpers.go
@@ -31,7 +31,7 @@ func (t *DataplaneOverviewResource) GetStatus() (Status, []string) {
 
 	allInboundsOffline := len(errs) == len(t.Spec.Dataplane.Networking.Inbound)
 	allInboundsOnline := len(errs) == 0
-	if t.Spec.Dataplane.ProxyType() == mesh_proto.GatewayProxyType {
+	if t.Spec.Dataplane.IsGateway() {
 		allInboundsOffline = false
 		allInboundsOnline = true
 	}

--- a/pkg/kds/util/resource.go
+++ b/pkg/kds/util/resource.go
@@ -67,8 +67,8 @@ func AddSuffixToNames(rs []model.Resource, suffix string) {
 
 func ZoneTag(r model.Resource) string {
 	dp := r.GetSpec().(*mesh_proto.Dataplane)
-	if dp.Networking.GetGateway() != nil {
-		return dp.Networking.GetGateway().GetTags()[mesh_proto.ZoneTag]
+	if dp.IsGateway() {
+		return dp.GetNetworking().GetGateway().GetTags()[mesh_proto.ZoneTag]
 	}
 	return dp.GetNetworking().GetInbound()[0].GetTags()[mesh_proto.ZoneTag]
 }


### PR DESCRIPTION
### Summary

Remove the (*Dataplane) ProxyType(), which makes the concept of proxy
types confusing.

Since the introduction of ZoneIngress, there are two distinct proxy
types used by kuma-dp - Dataplane and ZoneIngress. Since these are
distict Go and Protobuf types, (*Dataplane) ProxyType() can't ever
return `IngressProxyType`, and by extension should never return
anything other than `DataplaneProxyType`.

To clarify the distinction, we use (*Dataplane) IsGateway(), which
indicates a Dataplane proxy type operating in gateway mode and matches
the existing IsIngress() API.

### Full changelog

N/A

### Issues resolved

N/A

### Documentation

N/A

### Testing

- [x] Unit tests
- [x] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes 
