### PR TITLE
fix(ci) fix codecov coverage file quoting

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -865,7 +865,7 @@ jobs:
               curl --location --silent "${URL}/${VERSION}/SHA${i}SUM"
             )
           done
-          bash ./codecov -f build/coverage/*.out
+          bash ./codecov -f "build/coverage/*.out"
     - store_artifacts:
         path: build/coverage
         destination: /coverage


### PR DESCRIPTION
### Summary

To upload multiple coverage files, we need to pass the glob to the codecov -f flag, and not let the shell expand the glob beforehand.
    
### Full changelog

N/A

### Issues resolved

N/A

### Documentation

N/A

### Testing

Manually inspected codecov logs and coverage data.