### PR TITLE
fix(*) enable Ginkgo recovery in goroutines

### DIFF
--- a/pkg/plugins/resources/k8s/native/pkg/test/within.go
+++ b/pkg/plugins/resources/k8s/native/pkg/test/within.go
@@ -3,6 +3,7 @@ package test
 import (
 	"time"
 
+	"github.com/onsi/ginkgo"
 	"github.com/onsi/gomega"
 )
 
@@ -16,6 +17,7 @@ func Within(timeout time.Duration, task func()) func() {
 		done := make(chan interface{})
 
 		go func() {
+			defer ginkgo.GinkgoRecover()
 			defer close(done)
 			task()
 		}()


### PR DESCRIPTION
### Summary

This fix was accidentally dropped from the review feedback in #2043. It
serves me right that I had to debug this when an assertion failed and
Ginkgo paniced.

### Full changelog

N/A

### Issues resolved

N/A

### Documentation

N/A

### Testing

- [x] Unit tests
- [ ] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes 
