### PR TITLE
fix(*) cni config - set constant name

### DIFF
--- a/deployments/charts/kuma/templates/cni-configmap.yaml
+++ b/deployments/charts/kuma/templates/cni-configmap.yaml
@@ -11,7 +11,7 @@ data:
   cni_network_config: |-
     {
       "cniVersion": "0.3.1",
-      "name": "{{ include "kuma.name" . }}-cni",
+      "name": "kuma-cni",
       "type": "kuma-cni",
       "log_level": "{{ .Values.cni.logLevel }}",
       "kubernetes": {


### PR DESCRIPTION
### Summary

As the binary is always called `kuma-cni` it will cause problems with the different names

### Testing

- [ ] Unit tests
- [ ] E2E tests
- [ ] Manual testing on Universal
- [x] Manual testing on Kubernetes 
