### PR TITLE
fix(*) allow RC tags in the release tagging script

### DIFF
--- a/tools/releases/make-release-tag.sh
+++ b/tools/releases/make-release-tag.sh
@@ -3,6 +3,13 @@
 # make-release-tag.sh: This script assumes that you are on a branch and
 # have otherwise prepared the release. It creates an annotated tag with
 # a message containing the shortlog of commits from the previous version.
+#
+# Usage: make-release-tag.sh OLDVERS NEWVERS
+#
+# Since the log from OLDVERS to NEWVERS is used to generate the commit
+# message for the annotated tag, OLDVERS should be the last "fully released"
+# version, i.e. it's not that helpful to see the log from a last RC in
+# the final release tag.
 
 readonly PROGNAME=$(basename "$0")
 readonly OLDVERS="$1"
@@ -30,7 +37,10 @@ if [ -n "$(git tag --list "$NEWVERS")" ]; then
 fi
 
 case "$NEWVERS" in
-v+([0-9.])) ;;
+# Match a leading 'v' followed by any combination of nimbers and
+# dots. Optional hyphen-separate trailer can contain anything.
+v+([0-9.])?([-]*))
+    ;;
 *)
     printf "%s: tag '%s' must be of the form vX.Y.X\n" "$PROGNAME" "$NEWVERS"
     exit 1

--- a/tools/releases/make-release-tag.sh
+++ b/tools/releases/make-release-tag.sh
@@ -37,8 +37,8 @@ if [ -n "$(git tag --list "$NEWVERS")" ]; then
 fi
 
 case "$NEWVERS" in
-# Match a leading 'v' followed by any combination of nimbers and
-# dots. Optional hyphen-separate trailer can contain anything.
+# Match a leading 'v' followed by any combination of numbers and
+# dots. Optional hyphen-separated trailer can contain anything.
 v+([0-9.])?([-]*))
     ;;
 *)


### PR DESCRIPTION
### Summary

Update the release tagging script to allow an optional qualifier string
after a hyphen.

### Full changelog
N/A

### Issues resolved
N/A

### Documentation
N/A

### Testing
```bash
$ ./tools/releases/make-release-tag.sh 1.2.0 v9.9.0-rc1
Created tag 'v9.9.0-rc1'.
Testing whether tag 'v9.9.0-rc1' can be pushed.
To github.com:kumahq/kuma.git
 * [new tag]           v9.9.0-rc1 -> v9.9.0-rc1
Run 'git push origin v9.9.0-rc1' to push the tag if you are happy.

$ git show v9.9.0-rc1 | head
tag v9.9.0-rc1
Tagger: James Peach <james.peach@konghq.com>
Date:   Tue Jun 29 07:56:15 2021 +1000

Tag v9.9.0-rc1 release.

Bart Smykla (4):
      chore(kuma-cp) new version of gui (#2187)
      fix(kuma-cp) supported versions fix (#2193)
      chore(kuma-cp) new gui version (#2219)

```
