### PR TITLE
chore(*) sort lists of resource types

### DIFF
--- a/pkg/kds/global/components.go
+++ b/pkg/kds/global/components.go
@@ -30,11 +30,13 @@ import (
 )
 
 var (
-	kdsGlobalLog  = core.Log.WithName("kds-global")
+	kdsGlobalLog = core.Log.WithName("kds-global")
+
+	// ProvidedTypes lists the resource types provided by the Global
+	// CP to the Zone CP.
 	ProvidedTypes = []model.ResourceType{
 		core_mesh.CircuitBreakerType,
 		core_mesh.DataplaneType,
-		core_mesh.ZoneIngressType,
 		core_mesh.ExternalServiceType,
 		core_mesh.FaultInjectionType,
 		core_mesh.HealthCheckType,
@@ -47,15 +49,19 @@ var (
 		core_mesh.TrafficPermissionType,
 		core_mesh.TrafficRouteType,
 		core_mesh.TrafficTraceType,
-		system.SecretType,
-		system.GlobalSecretType,
-		system.ConfigType,
-	}
-	ConsumedTypes = []model.ResourceType{
-		core_mesh.DataplaneType,
-		core_mesh.DataplaneInsightType,
 		core_mesh.ZoneIngressType,
+		system.ConfigType,
+		system.GlobalSecretType,
+		system.SecretType,
+	}
+
+	// ConsumedTypes lists the resource types consumed from the Zone
+	// CP by the Global CP.
+	ConsumedTypes = []model.ResourceType{
+		core_mesh.DataplaneInsightType,
+		core_mesh.DataplaneType,
 		core_mesh.ZoneIngressInsightType,
+		core_mesh.ZoneIngressType,
 	}
 )
 

--- a/pkg/kds/types.go
+++ b/pkg/kds/types.go
@@ -15,7 +15,7 @@ const (
 )
 
 var (
-	// SupportedTypes is a list of Kuma types that are exchanged by KDS peers.
+	// SupportedTypes is a list of Kuma types that may be exchanged by KDS peers.
 	SupportedTypes = []model.ResourceType{
 		mesh.CircuitBreakerType,
 		mesh.DataplaneInsightType,

--- a/pkg/kds/types.go
+++ b/pkg/kds/types.go
@@ -8,17 +8,18 @@ import (
 )
 
 const (
-	googleApis   = "type.googleapis.com/"
+	googleApis = "type.googleapis.com/"
+
+	// KumaResource is the type URL of the KumaResource protobuf.
 	KumaResource = googleApis + "kuma.mesh.v1alpha1.KumaResource"
 )
 
 var (
+	// SupportedTypes is a list of Kuma types that are exchanged by KDS peers.
 	SupportedTypes = []model.ResourceType{
 		mesh.CircuitBreakerType,
-		mesh.DataplaneType,
-		mesh.ZoneIngressType,
-		mesh.ZoneIngressInsightType,
 		mesh.DataplaneInsightType,
+		mesh.DataplaneType,
 		mesh.ExternalServiceType,
 		mesh.FaultInjectionType,
 		mesh.HealthCheckType,
@@ -31,8 +32,10 @@ var (
 		mesh.TrafficPermissionType,
 		mesh.TrafficRouteType,
 		mesh.TrafficTraceType,
-		system.SecretType,
-		system.GlobalSecretType,
+		mesh.ZoneIngressInsightType,
+		mesh.ZoneIngressType,
 		system.ConfigType,
+		system.GlobalSecretType,
+		system.SecretType,
 	}
 )

--- a/pkg/kds/zone/components.go
+++ b/pkg/kds/zone/components.go
@@ -26,6 +26,8 @@ import (
 var (
 	kdsZoneLog = core.Log.WithName("kds-zone")
 
+	// ProvidedTypes lists the resource types provided by the Zone
+	// CP to the Global CP.
 	ProvidedTypes = []model.ResourceType{
 		mesh.DataplaneInsightType,
 		mesh.DataplaneType,
@@ -33,7 +35,8 @@ var (
 		mesh.ZoneIngressType,
 	}
 
-	// ConsumedTypes is the list of Kuma resource types that a KDS instance will request from its peer.
+	// ConsumedTypes lists the resource types consumed from the
+	// Global CP by the Zone CP.
 	ConsumedTypes = []model.ResourceType{
 		mesh.CircuitBreakerType,
 		mesh.DataplaneType,

--- a/pkg/kds/zone/components.go
+++ b/pkg/kds/zone/components.go
@@ -24,17 +24,19 @@ import (
 )
 
 var (
-	kdsZoneLog    = core.Log.WithName("kds-zone")
+	kdsZoneLog = core.Log.WithName("kds-zone")
+
 	ProvidedTypes = []model.ResourceType{
-		mesh.ZoneIngressType,
-		mesh.ZoneIngressInsightType,
-		mesh.DataplaneType,
 		mesh.DataplaneInsightType,
+		mesh.DataplaneType,
+		mesh.ZoneIngressInsightType,
+		mesh.ZoneIngressType,
 	}
+
+	// ConsumedTypes is the list of Kuma resource types that a KDS instance will request from its peer.
 	ConsumedTypes = []model.ResourceType{
 		mesh.CircuitBreakerType,
 		mesh.DataplaneType,
-		mesh.ZoneIngressType,
 		mesh.ExternalServiceType,
 		mesh.FaultInjectionType,
 		mesh.HealthCheckType,
@@ -47,9 +49,10 @@ var (
 		mesh.TrafficPermissionType,
 		mesh.TrafficRouteType,
 		mesh.TrafficTraceType,
-		system.SecretType,
-		system.GlobalSecretType,
+		mesh.ZoneIngressType,
 		system.ConfigType,
+		system.GlobalSecretType,
+		system.SecretType,
 	}
 )
 


### PR DESCRIPTION
### Summary

Sort some of the lists of resource types that need to be updated when
adding new resources. This makes it easier to scan for duplicates and
absentees. Update some of the corresponding godoc comments.

This is a functional no-op of changes I've extracted from a private branch.
The main thing to look at is the godoc comments, where my explanations
might be wrong. 

### Full changelog

N/A

### Issues resolved

N/A

### Documentation

N/A

### Testing

- [x] Unit tests
- [x] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes 
