### PR TITLE
chore(kuma-dp) narrow the resource manager interface for auth

### DIFF
--- a/pkg/sds/server/v3/server.go
+++ b/pkg/sds/server/v3/server.go
@@ -40,7 +40,7 @@ func RegisterSDS(rt core_runtime.Runtime, sdsMetrics *sds_metrics.Metrics) error
 	if err != nil {
 		return err
 	}
-	authCallbacks := xds_auth.NewCallbacks(rt.ResourceManager(), authenticator, xds_auth.DPNotFoundRetry{}) // no need to retry on DP Not Found because we are creating DP in ADS before we initiate SDS
+	authCallbacks := xds_auth.NewCallbacks(rt.ReadOnlyResourceManager(), authenticator, xds_auth.DPNotFoundRetry{}) // no need to retry on DP Not Found because we are creating DP in ADS before we initiate SDS
 
 	reconciler := DataplaneReconciler{
 		resManager:         rt.ResourceManager(),

--- a/pkg/xds/auth/callbacks.go
+++ b/pkg/xds/auth/callbacks.go
@@ -28,7 +28,7 @@ type DPNotFoundRetry struct {
 	MaxTimes uint
 }
 
-func NewCallbacks(resManager core_manager.ResourceManager, authenticator Authenticator, dpNotFoundRetry DPNotFoundRetry) util_xds.Callbacks {
+func NewCallbacks(resManager core_manager.ReadOnlyResourceManager, authenticator Authenticator, dpNotFoundRetry DPNotFoundRetry) util_xds.Callbacks {
 	if dpNotFoundRetry.Backoff == 0 { // backoff cannot be 0
 		dpNotFoundRetry.Backoff = 1 * time.Millisecond
 	}
@@ -44,7 +44,7 @@ func NewCallbacks(resManager core_manager.ResourceManager, authenticator Authent
 // authCallback checks if the DiscoveryRequest is authorized, ie. if it has a valid Dataplane Token/Service Account Token.
 type authCallbacks struct {
 	util_xds.NoopCallbacks
-	resManager      core_manager.ResourceManager
+	resManager      core_manager.ReadOnlyResourceManager
 	authenticator   Authenticator
 	dpNotFoundRetry DPNotFoundRetry
 

--- a/pkg/xds/server/v3/components.go
+++ b/pkg/xds/server/v3/components.go
@@ -38,7 +38,7 @@ func RegisterXDS(
 	if err != nil {
 		return err
 	}
-	authCallbacks := auth.NewCallbacks(rt.ResourceManager(), authenticator, auth.DPNotFoundRetry{}) // no need to retry on DP Not Found because we are creating DP in DataplaneLifecycle callback
+	authCallbacks := auth.NewCallbacks(rt.ReadOnlyResourceManager(), authenticator, auth.DPNotFoundRetry{}) // no need to retry on DP Not Found because we are creating DP in DataplaneLifecycle callback
 
 	metadataTracker := xds_callbacks.NewDataplaneMetadataTracker()
 	connectionInfoTracker := xds_callbacks.NewConnectionInfoTracker()


### PR DESCRIPTION
### Summary

Authentication callbacks don't need to update a resource manager,
so narrow the required interface to ReadOnlyResourceManager.

### Full changelog

N/A

### Issues resolved

N/A

### Documentation

N/A

### Testing

- [x] Unit tests
- [x] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes 
