### PR TITLE
chore(kuma-dp) refactor dataplane resource loading

### DIFF
--- a/app/kuma-dp/cmd/dataplane.go
+++ b/app/kuma-dp/cmd/dataplane.go
@@ -8,52 +8,44 @@ import (
 
 	kuma_dp "github.com/kumahq/kuma/pkg/config/app/kuma-dp"
 	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
-	core_model "github.com/kumahq/kuma/pkg/core/resources/model"
+	"github.com/kumahq/kuma/pkg/core/resources/model"
 	"github.com/kumahq/kuma/pkg/core/resources/model/rest"
 	"github.com/kumahq/kuma/pkg/util/template"
 )
 
-func readDataplaneResource(cmd *cobra.Command, cfg *kuma_dp.Config) (*rest.Resource, error) {
-	return readResource(cmd, cfg, core_mesh.DataplaneType, core_model.ScopeMesh)
-}
-
-func readZoneIngressResource(cmd *cobra.Command, cfg *kuma_dp.Config) (*rest.Resource, error) {
-	return readResource(cmd, cfg, core_mesh.ZoneIngressType, core_model.ScopeGlobal)
-}
-
-func readResource(cmd *cobra.Command, cfg *kuma_dp.Config, typ core_model.ResourceType, scope core_model.ResourceScope) (*rest.Resource, error) {
+func readResource(cmd *cobra.Command, r *kuma_dp.DataplaneRuntime) (model.Resource, error) {
 	var b []byte
 	var err error
-	// load from file first
-	if cfg.DataplaneRuntime.ResourcePath == "-" {
+
+	// Load from file first.
+	switch r.ResourcePath {
+	case "":
+		if r.Resource != "" {
+			b = []byte(r.Resource)
+		}
+	case "-":
 		if b, err = ioutil.ReadAll(cmd.InOrStdin()); err != nil {
 			return nil, err
 		}
-	} else if cfg.DataplaneRuntime.ResourcePath != "" {
-		if b, err = ioutil.ReadFile(cfg.DataplaneRuntime.ResourcePath); err != nil {
+	default:
+		if b, err = ioutil.ReadFile(r.ResourcePath); err != nil {
 			return nil, errors.Wrap(err, "error while reading provided file")
 		}
-	}
-	// override with inline resource
-	if cfg.DataplaneRuntime.Resource != "" {
-		b = []byte(cfg.DataplaneRuntime.Resource)
 	}
 
 	if len(b) == 0 {
 		return nil, nil
 	}
 
-	b = template.Render(string(b), cfg.DataplaneRuntime.ResourceVars)
+	b = template.Render(string(b), r.ResourceVars)
 	runLog.Info("rendered resource", "resource", string(b))
 
-	res, err := rest.Unmarshall(b)
+	res, err := rest.UnmarshallToCore(b)
 	if err != nil {
 		return nil, err
 	}
-	if res.Meta.Type != string(typ) {
-		return nil, errors.Errorf("invalid resource of type: %s. Expected: %s", res.Meta.Type, typ)
-	}
-	if err := core_mesh.ValidateMeta(res.Meta.GetName(), res.Meta.GetMesh(), scope); err.HasViolations() {
+
+	if err := core_mesh.ValidateMeta(res.GetMeta().GetName(), res.GetMeta().GetMesh(), res.Scope()); err.HasViolations() {
 		return nil, &err
 	}
 

--- a/app/kuma-dp/cmd/run_test.go
+++ b/app/kuma-dp/cmd/run_test.go
@@ -357,7 +357,7 @@ var _ = Describe("run", func() {
 
 		// then
 		Expect(err).To(HaveOccurred())
-		Expect(err.Error()).To(ContainSubstring("--name and --mesh cannot be specified when dataplane definition is provided"))
+		Expect(err.Error()).To(ContainSubstring("--name and --mesh cannot be specified"))
 	})
 
 	It("should fail when the proxy type is unknown", func() {

--- a/pkg/core/resources/model/rest/resource.go
+++ b/pkg/core/resources/model/rest/resource.go
@@ -50,6 +50,25 @@ type Resource struct {
 	Spec model.ResourceSpec
 }
 
+// NewFromModel create a REST Resource from the given model Resource.
+func NewFromModel(m model.Resource) *Resource {
+	if m == nil {
+		return nil
+	}
+
+	meta := m.GetMeta()
+	return &Resource{
+		Meta: ResourceMeta{
+			Type:             string(m.GetType()),
+			Mesh:             meta.GetMesh(),
+			Name:             meta.GetName(),
+			CreationTime:     meta.GetCreationTime(),
+			ModificationTime: meta.GetModificationTime(),
+		},
+		Spec: m.GetSpec(),
+	}
+}
+
 type ResourceList struct {
 	Total uint32      `json:"total"`
 	Items []*Resource `json:"items"`


### PR DESCRIPTION
### Summary

Refactor the dataplane resource loading to make it oblivious to
the underlying resource types. This will later allow us to add
support for more dataplane resource types without changing any
code.

### Full changelog

N/A

### Issues resolved

N/A

### Documentation

N/A

### Testing

- [x] Unit tests
- [x] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes 
