### PR TITLE
docs(*) upgrade guide for 1.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,6 @@
 
 Changes:
 * fix: Dataplane/ZoneIngress/Zone status problem when control plane forcefully exits [#2246](https://github.com//kumahq/kuma/pull/2246)
-* chore: change default Kuma images convention (all images has v prefix) [#2237](https://github.com//kumahq/kuma/pull/2237)
 * chore: reduce memory usage by reducing cache key size [#2214](https://github.com//kumahq/kuma/pull/2214) [#2230](https://github.com//kumahq/kuma/pull/2230) 
   👍contributed by nhamlh
 * fix: ZoneIngress always shows up as 'offline' [#2209](https://github.com//kumahq/kuma/pull/2209)

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -6,6 +6,11 @@ with `x.y.z` being the version you are planning to upgrade to.
 If such a section does not exist, the upgrade you want to perform
 does not have any particular instructions.
 
+## Upgrade to `1.2.1`
+
+When Global is upgraded to `1.2.1` and Zone CP is still `1.2.0`, ZoneIngresses will always be listed as offline.
+After Zone CPs are upgraded to `1.2.1`, the status will work again. ZoneIngress status does not affect cross-zone traffic.
+
 ## Upgrade to `1.2.0`
 
 One of the changes introduced by Kuma 1.2.0 is renaming `Remote Control Planes` to `Zone Control Planes` and `Dataplane Ingress` to `Zone Ingress`. 


### PR DESCRIPTION
Leaving the note that during the multizone upgrade ZoneIngress will be offline, which does not affect the cross-zone traffic.
We are not releasing the version with `v` this time so removing this entry from the changelog.