### PR TITLE
chore(kuma-cp) refactor xDS metadata to store a generic resource

### DIFF
--- a/pkg/core/xds/metadata.go
+++ b/pkg/core/xds/metadata.go
@@ -6,12 +6,11 @@ import (
 	_struct "github.com/golang/protobuf/ptypes/struct"
 
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
-	util_proto "github.com/kumahq/kuma/pkg/util/proto"
-
-	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
-	"github.com/kumahq/kuma/pkg/core/resources/model/rest"
-
 	"github.com/kumahq/kuma/pkg/core"
+	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
+	"github.com/kumahq/kuma/pkg/core/resources/model"
+	"github.com/kumahq/kuma/pkg/core/resources/model/rest"
+	util_proto "github.com/kumahq/kuma/pkg/util/proto"
 )
 
 var metadataLog = core.Log.WithName("xds-server").WithName("metadata-tracker")
@@ -45,16 +44,15 @@ const (
 // This way, xDS server will be able to use Envoy node metadata
 // to generate xDS resources that depend on environment-specific configuration.
 type DataplaneMetadata struct {
-	DataplaneTokenPath  string
-	DataplaneToken      string
-	DataplaneResource   *core_mesh.DataplaneResource
-	ZoneIngressResource *core_mesh.ZoneIngressResource
-	AdminPort           uint32
-	DNSPort             uint32
-	EmptyDNSPort        uint32
-	DynamicMetadata     map[string]string
-	ProxyType           mesh_proto.ProxyType
-	Version             *mesh_proto.Version
+	DataplaneTokenPath string
+	DataplaneToken     string
+	Resource           model.Resource
+	AdminPort          uint32
+	DNSPort            uint32
+	EmptyDNSPort       uint32
+	DynamicMetadata    map[string]string
+	ProxyType          mesh_proto.ProxyType
+	Version            *mesh_proto.Version
 }
 
 func (m *DataplaneMetadata) GetDataplaneTokenPath() string {
@@ -71,18 +69,28 @@ func (m *DataplaneMetadata) GetDataplaneToken() string {
 	return m.DataplaneToken
 }
 
+// GetDataplaneResource returns the underlying DataplaneResource, if present.
+// If the resource is of a different type, it returns nil.
 func (m *DataplaneMetadata) GetDataplaneResource() *core_mesh.DataplaneResource {
-	if m == nil {
-		return nil
+	if m != nil {
+		if d, ok := m.Resource.(*core_mesh.DataplaneResource); ok {
+			return d
+		}
 	}
-	return m.DataplaneResource
+
+	return nil
 }
 
+// GetZoneIngressResource returns the underlying ZoneIngressResource, if present.
+// If the resource is of a different type, it returns nil.
 func (m *DataplaneMetadata) GetZoneIngressResource() *core_mesh.ZoneIngressResource {
-	if m == nil {
-		return nil
+	if m != nil {
+		if z, ok := m.Resource.(*core_mesh.ZoneIngressResource); ok {
+			return z
+		}
 	}
-	return m.ZoneIngressResource
+
+	return nil
 }
 
 func (m *DataplaneMetadata) GetProxyType() mesh_proto.ProxyType {
@@ -150,12 +158,14 @@ func DataplaneMetadataFromXdsMetadata(xdsMetadata *_struct.Struct) *DataplaneMet
 			metadataLog.Error(err, "invalid value in dataplane metadata", "field", fieldDataplaneDataplaneResource, "value", value)
 		}
 		switch r := res.(type) {
-		case *core_mesh.DataplaneResource:
-			metadata.DataplaneResource = r
-		case *core_mesh.ZoneIngressResource:
-			metadata.ZoneIngressResource = r
+		case *core_mesh.DataplaneResource,
+			*core_mesh.ZoneIngressResource:
+			metadata.Resource = r
 		default:
-			metadataLog.Error(err, "invalid value in dataplane metadata", "field", fieldDataplaneDataplaneResource, "value", value)
+			metadataLog.Error(err, "invalid dataplane resource type",
+				"resource", r.GetType(),
+				"field", fieldDataplaneDataplaneResource,
+				"value", value)
 		}
 	}
 	if value := xdsMetadata.Fields[fieldDynamicMetadata]; value != nil {

--- a/pkg/xds/server/callbacks/dataplane_lifecycle.go
+++ b/pkg/xds/server/callbacks/dataplane_lifecycle.go
@@ -105,22 +105,24 @@ func (d *DataplaneLifecycle) OnStreamRequest(streamID int64, request util_xds.Di
 	md := xds.DataplaneMetadataFromXdsMetadata(request.Metadata())
 
 	if md.GetProxyType() == mesh_proto.DataplaneProxyType && md.GetDataplaneResource() != nil {
-		lifecycleLog.Info("registering dataplane", "dataplane", md.GetDataplaneResource(), "streamID", streamID, "nodeID", request.NodeId())
-		if err := d.registerDataplane(md.GetDataplaneResource()); err != nil {
+		dp := md.GetDataplaneResource()
+		lifecycleLog.Info("registering dataplane", "dataplane", dp, "streamID", streamID, "nodeID", request.NodeId())
+		if err := d.registerDataplane(dp); err != nil {
 			return errors.Wrap(err, "could not register dataplane passed in kuma-dp run")
 		}
-		key := model.MetaToResourceKey(md.GetDataplaneResource().GetMeta())
+		key := model.MetaToResourceKey(dp.GetMeta())
 		d.createdDpForStream[streamID] = &key
 		d.proxyTypeForStream[streamID] = mesh_proto.DataplaneProxyType
 		return nil
 	}
 
-	if md.GetProxyType() == mesh_proto.IngressProxyType && md.ZoneIngressResource != nil {
-		lifecycleLog.Info("registering zone ingress", "zoneIngress", md.ZoneIngressResource, "streamID", streamID, "nodeID", request.NodeId())
-		if err := d.registerZoneIngress(md.ZoneIngressResource); err != nil {
+	if md.GetProxyType() == mesh_proto.IngressProxyType && md.GetZoneIngressResource() != nil {
+		zi := md.GetZoneIngressResource()
+		lifecycleLog.Info("registering zone ingress", "zoneIngress", zi, "streamID", streamID, "nodeID", request.NodeId())
+		if err := d.registerZoneIngress(zi); err != nil {
 			return errors.Wrap(err, "could not register zone ingress passed in kuma-dp run")
 		}
-		key := model.MetaToResourceKey(md.ZoneIngressResource.GetMeta())
+		key := model.MetaToResourceKey(zi.GetMeta())
 		d.createdDpForStream[streamID] = &key
 		d.proxyTypeForStream[streamID] = mesh_proto.IngressProxyType
 		return nil


### PR DESCRIPTION
### Summary

Rather than keeping separate typed fields in the Dataplane metadata
for the Dataplane and ZoneIngress resources, store a generic Resource
interface and return the underlying type through the accessors.

### Full changelog

N/A

### Issues resolved

N/A

### Documentation

N/A

### Testing

- [x] Unit tests
- [x] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes 
