### PR TITLE
chore(kuma-cp) change default number of insights subscriptions

### DIFF
--- a/pkg/api-server/config_ws_test.go
+++ b/pkg/api-server/config_ws_test.go
@@ -128,7 +128,7 @@ var _ = Describe("Config WS", func() {
 		  "metrics": {
 			"dataplane": {
 			  "enabled": true,
-			  "subscriptionLimit": 10
+			  "subscriptionLimit": 2
 			},
 			"mesh": {
 			  "maxResyncTimeout": "20s",

--- a/pkg/config/app/kuma-cp/config.go
+++ b/pkg/config/app/kuma-cp/config.go
@@ -177,7 +177,7 @@ func DefaultConfig() Config {
 		Metrics: &Metrics{
 			Dataplane: &DataplaneMetrics{
 				Enabled:           true,
-				SubscriptionLimit: 10,
+				SubscriptionLimit: 2,
 			},
 			Zone: &ZoneMetrics{
 				Enabled:           true,

--- a/pkg/config/app/kuma-cp/kuma-cp.defaults.yaml
+++ b/pkg/config/app/kuma-cp/kuma-cp.defaults.yaml
@@ -269,7 +269,7 @@ metrics:
     # Enables collecting metrics from Dataplane
     enabled: true # ENV: KUMA_METRICS_DATAPLANE_ENABLED
     # How many latest subscriptions will be stored in DataplaneInsight object, if equals 0 then unlimited
-    subscriptionLimit: 10 # ENV: KUMA_METRICS_DATAPLANE_SUBSCRIPTION_LIMIT
+    subscriptionLimit: 2 # ENV: KUMA_METRICS_DATAPLANE_SUBSCRIPTION_LIMIT
   zone:
     # Enables collecting metrics from Zone
     enabled: true # ENV: KUMA_METRICS_ZONE_ENABLED


### PR DESCRIPTION
### Summary

I think we overestimated the usefulness of DataplaneInsights subscriptions history.
Most of the time we check the current subscription for online/offline status, but not the previous ones.
Currently, there is a limit of 10 subscriptions in Insight. This can result in fairly big insight objects. Especially when we have many dataplanes and we are syncing Insights over KDS to global.
I think it's better to change the default subscriptions to 2. One for the current one and one before that.

For ZoneInsight I think we can leave 10, because we usually have only a few zones, maybe tens, not thousands like dataplanes. Also, we don't sync this over KDS. 

### Documentation

- [X] No docs, change in Kuma CP config.

### Testing

- [X] Unit tests
- [ ] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes 
