### PR TITLE
chore(*) make the authentication interface type oblivious

### DIFF
--- a/pkg/xds/auth/callbacks.go
+++ b/pkg/xds/auth/callbacks.go
@@ -119,30 +119,34 @@ func (a *authCallbacks) credential(streamID core_xds.StreamID) (Credential, erro
 
 func (a *authCallbacks) authenticate(credential Credential, req util_xds.DiscoveryRequest) error {
 	md := core_xds.DataplaneMetadataFromXdsMetadata(req.Metadata())
-	switch md.GetProxyType() {
-	case mesh_proto.IngressProxyType:
-		return a.authenticateZoneIngress(credential, req)
-	default:
-		return a.authenticateDataplane(credential, req)
-	}
-}
 
-func (a *authCallbacks) authenticateZoneIngress(credential Credential, req util_xds.DiscoveryRequest) error {
-	zoneIngress := core_mesh.NewZoneIngressResource()
-	md := core_xds.DataplaneMetadataFromXdsMetadata(req.Metadata())
-	if md.GetZoneIngressResource() != nil {
-		zoneIngress = md.GetZoneIngressResource()
-	} else {
+	// If we already have a resource from the xDS bootstrap, we can use that.
+	resource := md.Resource
+
+	// Otherwise, search for the pre-created resource.
+	if resource == nil {
 		proxyId, err := core_xds.ParseProxyIdFromString(req.NodeId())
 		if err != nil {
-			return errors.Wrap(err, "request must have a valid Proxy Id")
+			return errors.Wrap(err, "request must have a valid Proxy ID")
 		}
+
+		switch md.GetProxyType() {
+		case mesh_proto.IngressProxyType:
+			resource = core_mesh.NewZoneIngressResource()
+		case mesh_proto.DataplaneProxyType:
+			resource = core_mesh.NewDataplaneResource()
+		default:
+			return errors.Errorf("unsupported proxy type %q", md.GetProxyType())
+		}
+
 		backoff, _ := retry.NewConstant(a.dpNotFoundRetry.Backoff)
 		backoff = retry.WithMaxRetries(uint64(a.dpNotFoundRetry.MaxTimes), backoff)
 		err = retry.Do(context.Background(), backoff, func(ctx context.Context) error {
-			err := a.resManager.Get(ctx, zoneIngress, core_store.GetBy(proxyId.ToResourceKey()))
+			err := a.resManager.Get(ctx, resource, core_store.GetBy(proxyId.ToResourceKey()))
 			if core_store.IsResourceNotFound(err) {
-				return retry.RetryableError(errors.New("zoneIngress not found. Create ZoneIngress in Kuma CP first or pass it as an argument to kuma-dp"))
+				return retry.RetryableError(errors.Errorf(
+					"resource %q not found; create a %s in Kuma CP first or pass it as an argument to kuma-dp",
+					proxyId, resource.GetType()))
 			}
 			return err
 		})
@@ -151,40 +155,8 @@ func (a *authCallbacks) authenticateZoneIngress(credential Credential, req util_
 		}
 	}
 
-	if err := a.authenticator.AuthenticateZoneIngress(context.Background(), zoneIngress, credential); err != nil {
-		return errors.Wrap(err, "authentication failed")
-	}
-	return nil
-}
-
-func (a *authCallbacks) authenticateDataplane(credential Credential, req util_xds.DiscoveryRequest) error {
-	dataplane := core_mesh.NewDataplaneResource()
-	md := core_xds.DataplaneMetadataFromXdsMetadata(req.Metadata())
-	if md.GetDataplaneResource() != nil {
-		dataplane = md.GetDataplaneResource()
-	} else {
-		proxyId, err := core_xds.ParseProxyIdFromString(req.NodeId())
-		if err != nil {
-			return errors.Wrap(err, "request must have a valid Proxy Id")
-		}
-		backoff, _ := retry.NewConstant(a.dpNotFoundRetry.Backoff)
-		backoff = retry.WithMaxRetries(uint64(a.dpNotFoundRetry.MaxTimes), backoff)
-		err = retry.Do(context.Background(), backoff, func(ctx context.Context) error {
-			err := a.resManager.Get(ctx, dataplane, core_store.GetBy(proxyId.ToResourceKey()))
-			if core_store.IsResourceNotFound(err) {
-				return retry.RetryableError(errors.New("dataplane not found. Create Dataplane in Kuma CP first or pass it as an argument to kuma-dp"))
-			}
-			return err
-		})
-		if err != nil {
-			return err
-		}
-	}
-
-	if err := a.authenticator.Authenticate(context.Background(), dataplane, credential); err != nil {
-		return errors.Wrap(err, "authentication failed")
-	}
-	return nil
+	return errors.Wrap(a.authenticator.Authenticate(context.Background(), resource, credential),
+		"authentication failed")
 }
 
 func extractCredential(ctx context.Context) (Credential, error) {

--- a/pkg/xds/auth/callbacks_test.go
+++ b/pkg/xds/auth/callbacks_test.go
@@ -2,17 +2,18 @@ package auth_test
 
 import (
 	"context"
-	"errors"
 
 	envoy_api "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	envoy_core "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
 	envoy_server "github.com/envoyproxy/go-control-plane/pkg/server/v2"
 	pstruct "github.com/golang/protobuf/ptypes/struct"
+	"github.com/pkg/errors"
 	"google.golang.org/grpc/metadata"
 
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	core_manager "github.com/kumahq/kuma/pkg/core/resources/manager"
+	"github.com/kumahq/kuma/pkg/core/resources/model"
 	core_model "github.com/kumahq/kuma/pkg/core/resources/model"
 	"github.com/kumahq/kuma/pkg/core/resources/model/rest"
 	core_store "github.com/kumahq/kuma/pkg/core/resources/store"
@@ -32,19 +33,22 @@ type testAuthenticator struct {
 
 var _ auth.Authenticator = &testAuthenticator{}
 
-func (t *testAuthenticator) Authenticate(ctx context.Context, dataplane *core_mesh.DataplaneResource, credential auth.Credential) error {
-	t.callCounter++
-	if credential == "pass" {
-		return nil
+func (t *testAuthenticator) Authenticate(_ context.Context, resource model.Resource, credential auth.Credential) error {
+	switch resource := resource.(type) {
+	case *core_mesh.DataplaneResource:
+		t.callCounter++
+		if credential == "pass" {
+			return nil
+		}
+	case *core_mesh.ZoneIngressResource:
+		t.zoneCallCounter++
+		if credential == "zone pass" {
+			return nil
+		}
+	default:
+		return errors.Errorf("no matching authenticator for %s resource", resource.GetType())
 	}
-	return errors.New("invalid credential")
-}
 
-func (t *testAuthenticator) AuthenticateZoneIngress(ctx context.Context, zoneIngress *core_mesh.ZoneIngressResource, credential auth.Credential) error {
-	t.zoneCallCounter++
-	if credential == "zone pass" {
-		return nil
-	}
 	return errors.New("invalid credential")
 }
 
@@ -219,7 +223,7 @@ var _ = Describe("Auth Callbacks", func() {
 		})
 
 		// then
-		Expect(err).To(MatchError("retryable: dataplane not found. Create Dataplane in Kuma CP first or pass it as an argument to kuma-dp"))
+		Expect(err.Error()).To(ContainSubstring("not found"))
 	})
 
 	It("should throw an error on authentication fail", func() {

--- a/pkg/xds/auth/interfaces.go
+++ b/pkg/xds/auth/interfaces.go
@@ -3,12 +3,11 @@ package auth
 import (
 	"context"
 
-	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
+	"github.com/kumahq/kuma/pkg/core/resources/model"
 )
 
 type Credential = string
 
 type Authenticator interface {
-	Authenticate(ctx context.Context, dataplane *core_mesh.DataplaneResource, credential Credential) error
-	AuthenticateZoneIngress(ctx context.Context, zoneIngress *core_mesh.ZoneIngressResource, credential Credential) error
+	Authenticate(ctx context.Context, resource model.Resource, credential Credential) error
 }

--- a/pkg/xds/auth/universal/noop_authenticator.go
+++ b/pkg/xds/auth/universal/noop_authenticator.go
@@ -3,7 +3,10 @@ package universal
 import (
 	"context"
 
+	"github.com/pkg/errors"
+
 	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
+	"github.com/kumahq/kuma/pkg/core/resources/model"
 	"github.com/kumahq/kuma/pkg/xds/auth"
 )
 
@@ -14,10 +17,15 @@ func NewNoopAuthenticator() auth.Authenticator {
 type noopAuthenticator struct {
 }
 
-func (u *noopAuthenticator) Authenticate(ctx context.Context, dataplane *core_mesh.DataplaneResource, _ auth.Credential) error {
-	return nil
-}
+var _ auth.Authenticator = &noopAuthenticator{}
 
-func (u *noopAuthenticator) AuthenticateZoneIngress(ctx context.Context, zoneIngress *core_mesh.ZoneIngressResource, _ auth.Credential) error {
-	return nil
+func (u *noopAuthenticator) Authenticate(ctx context.Context, resource model.Resource, _ auth.Credential) error {
+	switch resource := resource.(type) {
+	case *core_mesh.DataplaneResource:
+		return nil
+	case *core_mesh.ZoneIngressResource:
+		return nil
+	default:
+		return errors.Errorf("no matching authenticator for %s resource", resource.GetType())
+	}
 }


### PR DESCRIPTION
### Summary

There are two proxy types that can be authenticated and in the future there may be more. Rather than adding a new method for authenticating each proxy type, switch to authenticating a generic model Resource and allow each authenticator implentation to type switch internally.
    
This allows the xDS authentication callbacks to be insensitive to the DP proxy type, except when fetching an existing resource, which needs to allocate an instance of the concrete type.

The other approach I considered was making each `Authenticator` implementation responsible for a authenticating a single type, then using a factory interface to choose the right instance. I didn't go with that, since there was more scaffolding and the benefits over the internal type switch weren't very clear.

### Full changelog

N/A

### Issues resolved

N/A

### Documentation

N/A
### Testing

- [x] Unit tests
- [x] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes 
