### PR TITLE
test(*) fix protobuf error string comparison

### DIFF
--- a/pkg/xds/generator/proxy_template_raw_source_test.go
+++ b/pkg/xds/generator/proxy_template_raw_source_test.go
@@ -22,7 +22,7 @@ var _ = Describe("ProxyTemplateRawSource", func() {
 		type testCase struct {
 			proxy *model.Proxy
 			raw   []*mesh_proto.ProxyTemplateRawResource
-			err   interface{}
+			err   string
 		}
 
 		DescribeTable("Avoid producing invalid Envoy xDS resources",
@@ -38,7 +38,7 @@ var _ = Describe("ProxyTemplateRawSource", func() {
 
 				// then
 				Expect(err).To(HaveOccurred())
-				Expect(err).To(MatchError(given.err))
+				Expect(err.Error()).To(ContainSubstring(given.err))
 				Expect(rs).To(BeNil())
 			},
 			Entry("should fail when `resource` field is empty", testCase{
@@ -67,7 +67,7 @@ var _ = Describe("ProxyTemplateRawSource", func() {
 					Version:  "raw-version",
 					Resource: ``,
 				}},
-				err: "raw.resources[0]{name=\"raw-name\"}.resource: proto: invalid empty type URL",
+				err: "invalid empty type URL",
 			}),
 			Entry("should fail when `resource` field is neither a YAML nor a JSON", testCase{
 				proxy: &model.Proxy{


### PR DESCRIPTION
### Summary

Protobuf error strings are deliberately unstable in order to discourage
code from binding to their contents. Stop binding to the full error string
in this test, since unrelated changes can trigger changes in the protobuf
error strings (the deterministic random package that enables error string
instability is seeded from a hash of the Go binary).

### Full changelog

N/A

### Issues resolved

N/A

### Documentation

N/A

### Testing

- [x] Unit tests
- [x] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes 
