### PR TITLE
fix(kuma-cp) allocate a new VIP for ExternalService host

### DIFF
--- a/pkg/dns/outbound.go
+++ b/pkg/dns/outbound.go
@@ -20,14 +20,15 @@ func VIPOutbounds(
 	resourceKey model.ResourceKey,
 	dataplanes []*core_mesh.DataplaneResource,
 	zoneIngresses []*core_mesh.ZoneIngressResource,
-	vips vips.List,
+	vipList vips.List,
 	externalServices []*core_mesh.ExternalServiceResource,
 ) []*mesh_proto.Dataplane_Networking_Outbound {
 	type vipEntry struct {
 		ip   string
 		port uint32
+		host bool
 	}
-	serviceVIPMap := map[string]vipEntry{}
+	serviceVIPMap := map[string][]vipEntry{}
 	services := []string{}
 	for _, dataplane := range dataplanes {
 		// backwards compatibility
@@ -37,9 +38,9 @@ func VIPOutbounds(
 					// Only add outbounds for services in the same mesh
 					inService := service.Tags[mesh_proto.ServiceTag]
 					if _, found := serviceVIPMap[inService]; !found {
-						vip, err := ForwardLookup(vips, inService)
+						vip, err := ForwardLookup(vipList, vips.NewServiceEntry(inService))
 						if err == nil {
-							serviceVIPMap[inService] = vipEntry{vip, VIPListenPort}
+							serviceVIPMap[inService] = append(serviceVIPMap[inService], vipEntry{vip, VIPListenPort, false})
 							services = append(services, inService)
 						}
 					}
@@ -49,9 +50,9 @@ func VIPOutbounds(
 			for _, inbound := range dataplane.Spec.GetNetworking().GetInbound() {
 				inService := inbound.GetTags()[mesh_proto.ServiceTag]
 				if _, found := serviceVIPMap[inService]; !found {
-					vip, err := ForwardLookup(vips, inService)
+					vip, err := ForwardLookup(vipList, vips.NewServiceEntry(inService))
 					if err == nil {
-						serviceVIPMap[inService] = vipEntry{vip, VIPListenPort}
+						serviceVIPMap[inService] = append(serviceVIPMap[inService], vipEntry{vip, VIPListenPort, false})
 						services = append(services, inService)
 					}
 				}
@@ -65,9 +66,9 @@ func VIPOutbounds(
 				// Only add outbounds for services in the same mesh
 				inService := service.Tags[mesh_proto.ServiceTag]
 				if _, found := serviceVIPMap[inService]; !found {
-					vip, err := ForwardLookup(vips, inService)
+					vip, err := ForwardLookup(vipList, vips.NewServiceEntry(inService))
 					if err == nil {
-						serviceVIPMap[inService] = vipEntry{vip, VIPListenPort}
+						serviceVIPMap[inService] = append(serviceVIPMap[inService], vipEntry{vip, VIPListenPort, false})
 						services = append(services, inService)
 					}
 				}
@@ -77,8 +78,9 @@ func VIPOutbounds(
 
 	for _, externalService := range externalServices {
 		inService := externalService.Spec.Tags[mesh_proto.ServiceTag]
+		host := externalService.Spec.GetHost()
 		if _, found := serviceVIPMap[inService]; !found {
-			vip, err := ForwardLookup(vips, inService)
+			vip1, err := ForwardLookup(vipList, vips.NewHostEntry(host))
 			if err == nil {
 				port := externalService.Spec.GetPort()
 				var p32 uint32
@@ -87,7 +89,19 @@ func VIPOutbounds(
 				} else {
 					p32 = uint32(p64)
 				}
-				serviceVIPMap[inService] = vipEntry{vip, p32}
+				serviceVIPMap[inService] = append(serviceVIPMap[inService], vipEntry{vip1, p32, true})
+				services = append(services, inService)
+			}
+			vip2, err := ForwardLookup(vipList, vips.NewServiceEntry(inService))
+			if err == nil {
+				port := externalService.Spec.GetPort()
+				var p32 uint32
+				if p64, err := strconv.ParseUint(port, 10, 32); err != nil {
+					p32 = VIPListenPort
+				} else {
+					p32 = uint32(p64)
+				}
+				serviceVIPMap[inService] = append(serviceVIPMap[inService], vipEntry{vip2, p32, false})
 				services = append(services, inService)
 			}
 		}
@@ -96,30 +110,34 @@ func VIPOutbounds(
 	sort.Strings(services)
 	outbounds := []*mesh_proto.Dataplane_Networking_Outbound{}
 	for _, service := range services {
-		entry := serviceVIPMap[service]
-		outbounds = append(outbounds, &mesh_proto.Dataplane_Networking_Outbound{
-			Address: entry.ip,
-			Port:    entry.port,
-			Tags:    map[string]string{mesh_proto.ServiceTag: service},
-		})
-
-		// todo (lobkovilya): backwards compatibility, could be deleted in the next major release Kuma 1.2.x
-		if entry.port != VIPListenPort {
+		entries := serviceVIPMap[service]
+		for _, entry := range entries {
 			outbounds = append(outbounds, &mesh_proto.Dataplane_Networking_Outbound{
 				Address: entry.ip,
-				Port:    VIPListenPort,
+				Port:    entry.port,
 				Tags:    map[string]string{mesh_proto.ServiceTag: service},
 			})
+
+			if !entry.host {
+				// todo (lobkovilya): backwards compatibility, could be deleted in the next major release Kuma 1.2.x
+				if entry.port != VIPListenPort {
+					outbounds = append(outbounds, &mesh_proto.Dataplane_Networking_Outbound{
+						Address: entry.ip,
+						Port:    VIPListenPort,
+						Tags:    map[string]string{mesh_proto.ServiceTag: service},
+					})
+				}
+			}
 		}
 	}
 
 	return outbounds
 }
 
-func ForwardLookup(vips vips.List, service string) (string, error) {
-	ip, found := vips[service]
+func ForwardLookup(vips vips.List, entry vips.Entry) (string, error) {
+	ip, found := vips[entry]
 	if !found {
-		return "", errors.Errorf("service [%s] not found", service)
+		return "", errors.Errorf("entry name [%s] not found", entry.Name)
 	}
 	return ip, nil
 }

--- a/pkg/dns/outbound_test.go
+++ b/pkg/dns/outbound_test.go
@@ -48,7 +48,7 @@ var _ = Describe("VIPOutbounds", func() {
 		for i := 1; i <= 5; i++ {
 			service := "service-" + strconv.Itoa(i)
 			vip := fmt.Sprintf("240.0.0.%d", i)
-			vipList[service] = vip
+			vipList[vips.NewServiceEntry(service)] = vip
 
 			dataplanes.Items = append(dataplanes.Items, &core_mesh.DataplaneResource{
 				Meta: &test_model.ResourceMeta{
@@ -104,8 +104,8 @@ var _ = Describe("VIPOutbounds", func() {
 
 		// given
 		vipList := vips.List{
-			"service-a": "240.0.0.1",
-			"service-b": "240.0.0.2",
+			vips.NewServiceEntry("service-a"): "240.0.0.1",
+			vips.NewServiceEntry("service-b"): "240.0.0.2",
 		}
 		services := []*mesh_proto.Dataplane_Networking_Ingress_AvailableService{
 			{
@@ -171,7 +171,7 @@ var _ = Describe("VIPOutbounds", func() {
 		for i := 1; i <= 5; i++ {
 			service := "service-" + strconv.Itoa(i)
 			vip := fmt.Sprintf("240.0.0.%d", i)
-			vipList[service] = vip
+			vipList[vips.NewServiceEntry(service)] = vip
 
 			otherDataplanes = append(otherDataplanes, &core_mesh.DataplaneResource{
 				Meta: &test_model.ResourceMeta{
@@ -229,9 +229,9 @@ var _ = Describe("VIPOutbounds", func() {
 				},
 			},
 		}
-		vipList["first-external-service"] = "240.0.0.6"
-		vipList["second-external-service"] = "240.0.0.7"
-		vipList["third-external-service"] = "240.0.0.8"
+		vipList[vips.NewServiceEntry("first-external-service")] = "240.0.0.6"
+		vipList[vips.NewServiceEntry("second-external-service")] = "240.0.0.7"
+		vipList[vips.NewServiceEntry("third-external-service")] = "240.0.0.8"
 
 		actual := &mesh_proto.Dataplane_Networking{}
 		actual.Outbound = dns.VIPOutbounds(model.MetaToResourceKey(dataplane.Meta), otherDataplanes, nil, vipList, externalServices)
@@ -299,10 +299,10 @@ var _ = Describe("VIPOutbounds", func() {
 		}
 
 		vipList := vips.List{
-			"old-ingress-svc-1": "240.0.0.0",
-			"old-ingress-svc-2": "240.0.0.1",
-			"new-ingress-svc-1": "240.0.0.2",
-			"new-ingress-svc-2": "240.0.0.3",
+			vips.NewServiceEntry("old-ingress-svc-1"): "240.0.0.0",
+			vips.NewServiceEntry("old-ingress-svc-2"): "240.0.0.1",
+			vips.NewServiceEntry("new-ingress-svc-1"): "240.0.0.2",
+			vips.NewServiceEntry("new-ingress-svc-2"): "240.0.0.3",
 		}
 
 		otherDataplanes := []*core_mesh.DataplaneResource{{

--- a/pkg/dns/server_test.go
+++ b/pkg/dns/server_test.go
@@ -60,8 +60,8 @@ var _ = Describe("DNS server", func() {
 		It("should resolve", func() {
 			// given
 			var err error
-			dnsResolver.SetVIPs(map[string]string{
-				"service": "240.0.0.1",
+			dnsResolver.SetVIPs(vips.List{
+				vips.NewServiceEntry("service"): "240.0.0.1",
 			})
 			ip, err = dnsResolver.ForwardLookupFQDN("service.mesh")
 			Expect(err).ToNot(HaveOccurred())
@@ -86,8 +86,8 @@ var _ = Describe("DNS server", func() {
 
 		It("should resolve concurrent", func() {
 			// given
-			dnsResolver.SetVIPs(map[string]string{
-				"service": "240.0.0.1",
+			dnsResolver.SetVIPs(vips.List{
+				vips.NewServiceEntry("service"): "240.0.0.1",
 			})
 			ip, err := dnsResolver.ForwardLookupFQDN("service.mesh")
 			Expect(err).ToNot(HaveOccurred())
@@ -118,8 +118,8 @@ var _ = Describe("DNS server", func() {
 
 		It("should resolve IPv6 concurrent", func() {
 			// given
-			dnsResolver.SetVIPs(map[string]string{
-				"service": "fd00::1",
+			dnsResolver.SetVIPs(vips.List{
+				vips.NewServiceEntry("service"): "fd00::1",
 			})
 			ip, err := dnsResolver.ForwardLookupFQDN("service.mesh")
 			Expect(err).ToNot(HaveOccurred())
@@ -151,8 +151,8 @@ var _ = Describe("DNS server", func() {
 		It("should not resolve", func() {
 			// given
 			var err error
-			dnsResolver.SetVIPs(map[string]string{
-				"service": "240.0.0.1",
+			dnsResolver.SetVIPs(vips.List{
+				vips.NewServiceEntry("service"): "240.0.0.1",
 			})
 			ip, err = dnsResolver.ForwardLookupFQDN("service.mesh")
 			Expect(err).ToNot(HaveOccurred())
@@ -177,7 +177,7 @@ var _ = Describe("DNS server", func() {
 
 		It("should not resolve when no vips", func() {
 			// given
-			dnsResolver.SetVIPs(map[string]string{})
+			dnsResolver.SetVIPs(vips.List{})
 
 			// when
 			client := new(dns.Client)
@@ -202,7 +202,7 @@ var _ = Describe("DNS server", func() {
 			// given
 			var err error
 			dnsResolver.SetVIPs(vips.List{
-				"my.service": "240.0.0.1",
+				vips.NewServiceEntry("my.service"): "240.0.0.1",
 			})
 			ip, err = dnsResolver.ForwardLookupFQDN("my.service.mesh")
 			Expect(err).ToNot(HaveOccurred())
@@ -229,7 +229,7 @@ var _ = Describe("DNS server", func() {
 			// given
 			var err error
 			dnsResolver.SetVIPs(vips.List{
-				"my-service_test-namespace_svc_80": "240.0.0.1",
+				vips.NewServiceEntry("my-service_test-namespace_svc_80"): "240.0.0.1",
 			})
 			ip, err = dnsResolver.ForwardLookupFQDN("my-service_test-namespace_svc_80.mesh")
 			Expect(err).ToNot(HaveOccurred())

--- a/pkg/dns/vips/interfaces.go
+++ b/pkg/dns/vips/interfaces.go
@@ -1,6 +1,56 @@
 package vips
 
-type List map[string]string
+import (
+	"fmt"
+	"sort"
+)
+
+type EntryType int
+
+const (
+	Service EntryType = iota
+	Host
+)
+
+type Entry struct {
+	Type EntryType `json:"type"`
+	Name string    `json:"name"`
+}
+
+func (e Entry) String() string {
+	return fmt.Sprintf("%v:%s", e.Type, e.Name)
+}
+
+func (e Entry) MarshalText() (text []byte, err error) {
+	return []byte(e.String()), nil
+}
+
+func (e *Entry) UnmarshalText(text []byte) error {
+	_, err := fmt.Sscanf(string(text), "%v:%s", &e.Type, &e.Name)
+	return err
+}
+
+func NewHostEntry(host string) Entry {
+	return Entry{Host, host}
+}
+
+func NewServiceEntry(name string) Entry {
+	return Entry{Service, name}
+}
+
+type EntrySet map[Entry]bool
+
+func (s EntrySet) ToArray() (entries []Entry) {
+	for entry := range s {
+		entries = append(entries, entry)
+	}
+	sort.SliceStable(entries, func(i, j int) bool {
+		return entries[i].String() < entries[j].String()
+	})
+	return
+}
+
+type List map[Entry]string
 
 func (vips List) Append(other List) {
 	for k, v := range other {
@@ -8,8 +58,8 @@ func (vips List) Append(other List) {
 	}
 }
 
-func (vips List) FQDNsByIPs() map[string]string {
-	ipToDomain := map[string]string{}
+func (vips List) FQDNsByIPs() map[string]Entry {
+	ipToDomain := map[string]Entry{}
 	for domain, ip := range vips {
 		ipToDomain[ip] = domain
 	}

--- a/pkg/dns/vips/persistence.go
+++ b/pkg/dns/vips/persistence.go
@@ -80,6 +80,7 @@ func (m *Persistence) unmarshal(config string) (List, error) {
 	if err := json.Unmarshal([]byte(config), &v); err == nil {
 		return v, nil
 	}
+	// backwards compatibility
 	backwardCompatible := map[string]string{}
 	if err := json.Unmarshal([]byte(config), &backwardCompatible); err != nil {
 		return nil, err

--- a/pkg/dns/vips/persistence.go
+++ b/pkg/dns/vips/persistence.go
@@ -64,8 +64,8 @@ func (m *Persistence) Get() (global List, meshed map[string]List, errs error) {
 		if resource.Spec.Config == "" {
 			continue
 		}
-		v := List{}
-		if err := json.Unmarshal([]byte(resource.Spec.Config), &v); err != nil {
+		v, err := m.unmarshal(resource.Spec.GetConfig())
+		if err != nil {
 			errs = multierr.Append(errs, err)
 			continue
 		}
@@ -75,23 +75,38 @@ func (m *Persistence) Get() (global List, meshed map[string]List, errs error) {
 	return
 }
 
+func (m *Persistence) unmarshal(config string) (List, error) {
+	v := List{}
+	if err := json.Unmarshal([]byte(config), &v); err == nil {
+		return v, nil
+	}
+	backwardCompatible := map[string]string{}
+	if err := json.Unmarshal([]byte(config), &backwardCompatible); err != nil {
+		return nil, err
+	}
+	v = List{}
+	for service, vip := range backwardCompatible {
+		v[NewServiceEntry(service)] = vip
+	}
+	return v, nil
+}
+
 func (m *Persistence) GetByMesh(mesh string) (List, error) {
 	name := fmt.Sprintf(template, mesh)
-	vips := List{}
 	resource := config_model.NewConfigResource()
 	err := m.configManager.Get(context.Background(), resource, store.GetByKey(name, ""))
 	if err != nil {
 		if store.IsResourceNotFound(err) {
-			return vips, nil
+			return List{}, nil
 		}
 		return nil, err
 	}
 
 	if resource.Spec.Config == "" {
-		return vips, nil
+		return List{}, nil
 	}
 
-	err = json.Unmarshal([]byte(resource.Spec.Config), &vips)
+	vips, err := m.unmarshal(resource.Spec.GetConfig())
 	if err != nil {
 		return nil, errors.Wrap(err, "could not unmarshal")
 	}

--- a/pkg/dns/vips/vips_suite_test.go
+++ b/pkg/dns/vips/vips_suite_test.go
@@ -1,0 +1,13 @@
+package vips_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestVIPs(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "VIPs Suite")
+}

--- a/pkg/dns/vips_allocator_test.go
+++ b/pkg/dns/vips_allocator_test.go
@@ -96,8 +96,8 @@ var _ = Describe("VIP Allocator", func() {
 		vipList, err = persistence.GetByMesh("mesh-2")
 		Expect(err).ToNot(HaveOccurred())
 
-		for _, service := range []string{"backend", "frontend", "web"} {
-			ip, err := r.ForwardLookup(service)
+		for _, service := range []string{"backend.mesh", "frontend.mesh", "web.mesh"} {
+			ip, err := r.ForwardLookupFQDN(service)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(ip).To(HavePrefix("240.0.0"))
 		}
@@ -111,8 +111,8 @@ var _ = Describe("VIP Allocator", func() {
 		// we add VIPs directly to the 'persistence' object
 		// that emulates situation when IPAM is fresh and doesn't aware of allocated VIPs
 		err := persistence.Set("mesh-1", vips.List{
-			"frontend": "240.0.0.0",
-			"backend":  "240.0.0.1",
+			vips.NewServiceEntry("frontend"): "240.0.0.0",
+			vips.NewServiceEntry("backend"):  "240.0.0.1",
 		})
 		Expect(err).ToNot(HaveOccurred())
 
@@ -127,9 +127,9 @@ var _ = Describe("VIP Allocator", func() {
 		Expect(err).ToNot(HaveOccurred())
 		// then
 		Expect(vipList).To(Equal(vips.List{
-			"frontend": "240.0.0.0",
-			"backend":  "240.0.0.1",
-			"database": "240.0.0.2",
+			vips.NewServiceEntry("frontend"): "240.0.0.0",
+			vips.NewServiceEntry("backend"):  "240.0.0.1",
+			vips.NewServiceEntry("database"): "240.0.0.2",
 		}))
 	})
 
@@ -259,13 +259,14 @@ var _ = Describe("BuildServiceSet", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		// then
-		Expect(serviceSet).To(Equal(dns.ServiceSet{
-			"backend":     true,
-			"frontend":    true,
-			"database":    true,
-			"metrics":     true,
-			"ingress-svc": true,
-			"es-backend":  true,
+		Expect(serviceSet).To(Equal(vips.EntrySet{
+			vips.NewServiceEntry("backend"):           true,
+			vips.NewServiceEntry("frontend"):          true,
+			vips.NewServiceEntry("database"):          true,
+			vips.NewServiceEntry("metrics"):           true,
+			vips.NewServiceEntry("ingress-svc"):       true,
+			vips.NewServiceEntry("es-backend"):        true,
+			vips.NewHostEntry("external.service.com"): true,
 		}))
 	})
 })
@@ -276,9 +277,9 @@ var _ = Describe("UpdateMeshedVIPs", func() {
 		vipsList := vips.List{}
 		ipam, err := dns.NewSimpleIPAM("240.0.0.0/4")
 		Expect(err).ToNot(HaveOccurred())
-		serviceSet := dns.ServiceSet{
-			"backend":  true,
-			"frontend": true,
+		serviceSet := vips.EntrySet{
+			vips.NewServiceEntry("backend"):  true,
+			vips.NewServiceEntry("frontend"): true,
 		}
 		// when
 		updated, err := dns.UpdateMeshedVIPs(vipsList, vipsList, ipam, serviceSet)
@@ -287,21 +288,21 @@ var _ = Describe("UpdateMeshedVIPs", func() {
 		Expect(err).ToNot(HaveOccurred())
 		Expect(updated).To(BeTrue())
 		Expect(vipsList).To(Equal(vips.List{
-			"backend":  "240.0.0.0",
-			"frontend": "240.0.0.1",
+			vips.NewServiceEntry("backend"):  "240.0.0.0",
+			vips.NewServiceEntry("frontend"): "240.0.0.1",
 		}))
 	})
 
 	It("should free IP for deleted service", func() {
 		// setup
 		vipsList := vips.List{
-			"backend":  "240.0.0.0",
-			"frontend": "240.0.0.1",
+			vips.NewServiceEntry("backend"):  "240.0.0.0",
+			vips.NewServiceEntry("frontend"): "240.0.0.1",
 		}
 		ipam, err := dns.NewSimpleIPAM("240.0.0.0/4")
 		Expect(err).ToNot(HaveOccurred())
-		serviceSet := dns.ServiceSet{
-			"backend": true,
+		serviceSet := vips.EntrySet{
+			vips.NewServiceEntry("backend"): true,
 		}
 		// when
 		updated, err := dns.UpdateMeshedVIPs(vipsList, vipsList, ipam, serviceSet)
@@ -309,21 +310,21 @@ var _ = Describe("UpdateMeshedVIPs", func() {
 		// then
 		Expect(updated).To(BeTrue())
 		Expect(vipsList).To(Equal(vips.List{
-			"backend": "240.0.0.0",
+			vips.NewServiceEntry("backend"): "240.0.0.0",
 		}))
 	})
 
 	It("should return updated=false if nothing changed", func() {
 		// setup
 		vipsList := vips.List{
-			"backend":  "240.0.0.0",
-			"frontend": "240.0.0.1",
+			vips.NewServiceEntry("backend"):  "240.0.0.0",
+			vips.NewServiceEntry("frontend"): "240.0.0.1",
 		}
 		ipam, err := dns.NewSimpleIPAM("240.0.0.0/4")
 		Expect(err).ToNot(HaveOccurred())
-		serviceSet := dns.ServiceSet{
-			"backend":  true,
-			"frontend": true,
+		serviceSet := vips.EntrySet{
+			vips.NewServiceEntry("backend"):  true,
+			vips.NewServiceEntry("frontend"): true,
 		}
 		// when
 		updated, err := dns.UpdateMeshedVIPs(vipsList, vipsList, ipam, serviceSet)
@@ -331,28 +332,28 @@ var _ = Describe("UpdateMeshedVIPs", func() {
 		// then
 		Expect(updated).To(BeFalse())
 		Expect(vipsList).To(Equal(vips.List{
-			"backend":  "240.0.0.0",
-			"frontend": "240.0.0.1",
+			vips.NewServiceEntry("backend"):  "240.0.0.0",
+			vips.NewServiceEntry("frontend"): "240.0.0.1",
 		}))
 	})
 
 	It("should generate the same VIP for services across meshes", func() {
 		// setup
 		global := vips.List{
-			"backend":  "240.0.0.0",
-			"frontend": "240.0.0.1",
-			"database": "240.0.0.10",
+			vips.NewServiceEntry("backend"):  "240.0.0.0",
+			vips.NewServiceEntry("frontend"): "240.0.0.1",
+			vips.NewServiceEntry("database"): "240.0.0.10",
 		}
 		meshed := vips.List{
-			"backend":  "240.0.0.0",
-			"frontend": "240.0.0.1",
+			vips.NewServiceEntry("backend"):  "240.0.0.0",
+			vips.NewServiceEntry("frontend"): "240.0.0.1",
 		}
 		ipam, err := dns.NewSimpleIPAM("240.0.0.0/4")
 		Expect(err).ToNot(HaveOccurred())
-		serviceSet := dns.ServiceSet{
-			"backend":  true,
-			"frontend": true,
-			"database": true,
+		serviceSet := vips.EntrySet{
+			vips.NewServiceEntry("backend"):  true,
+			vips.NewServiceEntry("frontend"): true,
+			vips.NewServiceEntry("database"): true,
 		}
 		// when
 		updated, err := dns.UpdateMeshedVIPs(global, meshed, ipam, serviceSet)
@@ -360,9 +361,9 @@ var _ = Describe("UpdateMeshedVIPs", func() {
 		// then
 		Expect(updated).To(BeTrue())
 		Expect(meshed).To(Equal(vips.List{
-			"backend":  "240.0.0.0",
-			"frontend": "240.0.0.1",
-			"database": "240.0.0.10",
+			vips.NewServiceEntry("backend"):  "240.0.0.0",
+			vips.NewServiceEntry("frontend"): "240.0.0.1",
+			vips.NewServiceEntry("database"): "240.0.0.10",
 		}))
 	})
 })

--- a/pkg/dns/vips_synchronizer_test.go
+++ b/pkg/dns/vips_synchronizer_test.go
@@ -78,18 +78,18 @@ var _ = Describe("DNS sync", func() {
 		It("should sync web to DNS resolver and to the follower", func() {
 			// then service "web" is synchronized to DNS Resolver
 			Eventually(func() error {
-				_, err := dnsResolver.ForwardLookup("web")
+				_, err := dnsResolver.ForwardLookupFQDN("web.mesh")
 				return err
 			}, "5s").ShouldNot(HaveOccurred())
-			ip, _ := dnsResolver.ForwardLookup("web")
+			ip, _ := dnsResolver.ForwardLookupFQDN("web.mesh")
 			Expect(ip).Should(HavePrefix("240.0.0"))
 
 			// and replicated to a follower
 			Eventually(func() error {
-				_, err := dnsResolverFollower.ForwardLookup("web")
+				_, err := dnsResolverFollower.ForwardLookupFQDN("web.mesh")
 				return err
 			}, "5s").ShouldNot(HaveOccurred())
-			ip2, _ := dnsResolverFollower.ForwardLookup("web")
+			ip2, _ := dnsResolverFollower.ForwardLookupFQDN("web.mesh")
 			Expect(ip).To(Equal(ip2))
 		})
 
@@ -125,18 +125,18 @@ var _ = Describe("DNS sync", func() {
 
 			// then service "backend" is synchronized to DNS Resolver
 			Eventually(func() error {
-				_, err := dnsResolver.ForwardLookup("backend")
+				_, err := dnsResolver.ForwardLookupFQDN("backend.mesh")
 				return err
 			}, "5s").ShouldNot(HaveOccurred())
-			ip, _ := dnsResolver.ForwardLookup("backend")
+			ip, _ := dnsResolver.ForwardLookupFQDN("backend.mesh")
 			Expect(ip).Should(HavePrefix("240.0.0"))
 
 			// and replicated to a follower
 			Eventually(func() error {
-				_, err := dnsResolverFollower.ForwardLookup("backend")
+				_, err := dnsResolverFollower.ForwardLookupFQDN("backend.mesh")
 				return err
 			}, "5s").ShouldNot(HaveOccurred())
-			ip2, _ := dnsResolverFollower.ForwardLookup("backend")
+			ip2, _ := dnsResolverFollower.ForwardLookupFQDN("backend.mesh")
 			Expect(ip).To(Equal(ip2))
 		})
 
@@ -147,13 +147,13 @@ var _ = Describe("DNS sync", func() {
 
 			// then service "web" is removed from DNS Resolver
 			Eventually(func() error {
-				_, err := dnsResolver.ForwardLookup("web")
+				_, err := dnsResolver.ForwardLookupFQDN("web.mesh")
 				return err
 			}, "5s").Should(MatchError("service [web] not found in domain [mesh]."))
 
 			// and replicated to a follower
 			Eventually(func() error {
-				_, err := dnsResolverFollower.ForwardLookup("web")
+				_, err := dnsResolverFollower.ForwardLookupFQDN("web.mesh")
 				return err
 			}, "5s").Should(MatchError("service [web] not found in domain [mesh]."))
 		})

--- a/pkg/plugins/runtime/universal/outbound/outbound_test.go
+++ b/pkg/plugins/runtime/universal/outbound/outbound_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/kumahq/kuma/pkg/dns/resolver"
+	"github.com/kumahq/kuma/pkg/dns/vips"
 	"github.com/kumahq/kuma/pkg/plugins/runtime/universal/outbound"
 
 	. "github.com/onsi/ginkgo"
@@ -40,9 +41,9 @@ var _ = Describe("UpdateOutbound", func() {
 		Expect(err).ToNot(HaveOccurred())
 		// and
 		r := resolver.NewDNSResolver("mesh")
-		r.SetVIPs(map[string]string{
-			"service-1": "240.0.0.1",
-			"service-2": "240.0.0.2",
+		r.SetVIPs(vips.List{
+			vips.NewServiceEntry("service-1"): "240.0.0.1",
+			vips.NewServiceEntry("service-2"): "240.0.0.2",
 		})
 		// and
 		vipOutboundsReconciler, err = outbound.NewVIPOutboundsReconciler(rm, rm, r, time.Second)

--- a/pkg/xds/generator/dns_generator_test.go
+++ b/pkg/xds/generator/dns_generator_test.go
@@ -8,6 +8,8 @@ import (
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
 
+	"github.com/kumahq/kuma/pkg/dns/vips"
+
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	mesh_core "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	model "github.com/kumahq/kuma/pkg/core/xds"
@@ -33,9 +35,9 @@ var _ = Describe("DNSGenerator", func() {
 			gen := &generator.DNSGenerator{}
 
 			dnsResolver := resolver.NewDNSResolver("mesh")
-			dnsResolver.SetVIPs(map[string]string{
-				"backend_test-ns_svc_8080": "240.0.0.0",
-				"httpbin":                  "240.0.0.1",
+			dnsResolver.SetVIPs(vips.List{
+				vips.NewServiceEntry("backend_test-ns_svc_8080"): "240.0.0.0",
+				vips.NewServiceEntry("httpbin"):                  "240.0.0.1",
 			})
 			ctx := xds_context.Context{
 				ConnectionInfo: xds_context.ConnectionInfo{

--- a/test/e2e/externalservices/externalservices_universal.go
+++ b/test/e2e/externalservices/externalservices_universal.go
@@ -123,29 +123,37 @@ networking:
 			"false", ""))(cluster)
 		Expect(err).ToNot(HaveOccurred())
 
+		// when access the first external service with .mesh
 		stdout, _, err := cluster.ExecWithRetries("", "", "demo-client",
 			"curl", "-v", "-m", "3", "--fail", "external-service-1.mesh")
+		// then
 		Expect(err).ToNot(HaveOccurred())
 		Expect(stdout).To(ContainSubstring("HTTP/1.1 200 OK"))
 		Expect(stdout).To(ContainSubstring("Echo 80"))
 		Expect(stdout).ToNot(ContainSubstring("HTTPS"))
 
+		// when access the first external service using hostname
 		stdout, _, err = cluster.ExecWithRetries("", "", "demo-client",
 			"curl", "-v", "-m", "3", "--fail", "kuma-3_externalservice-http-server-80-81:80")
+		// then
 		Expect(err).ToNot(HaveOccurred())
 		Expect(stdout).To(ContainSubstring("HTTP/1.1 200 OK"))
 		Expect(stdout).To(ContainSubstring("Echo 80"))
 		Expect(stdout).ToNot(ContainSubstring("HTTPS"))
 
+		// when access the second external service name using .mesh
 		stdout, _, err = cluster.ExecWithRetries("", "", "demo-client",
 			"curl", "-v", "-m", "3", "--fail", "external-service-2.mesh")
+		// then
 		Expect(err).ToNot(HaveOccurred())
 		Expect(stdout).To(ContainSubstring("HTTP/1.1 200 OK"))
 		Expect(stdout).To(ContainSubstring("Echo 81"))
 		Expect(stdout).ToNot(ContainSubstring("HTTPS"))
 
+		// when access the second external service using the same hostname as first but with different port
 		stdout, _, err = cluster.ExecWithRetries("", "", "demo-client",
 			"curl", "-v", "-m", "3", "--fail", "kuma-3_externalservice-http-server-80-81:81")
+		// then
 		Expect(err).ToNot(HaveOccurred())
 		Expect(stdout).To(ContainSubstring("HTTP/1.1 200 OK"))
 		Expect(stdout).To(ContainSubstring("Echo 81"))

--- a/test/framework/deployments/externalservice/kubernetes.go
+++ b/test/framework/deployments/externalservice/kubernetes.go
@@ -13,7 +13,7 @@ import (
 type k8SDeployment struct {
 	ip   string
 	name string
-	args []string
+	cmd  Command
 }
 
 var _ Deployment = &k8SDeployment{}
@@ -78,7 +78,7 @@ func (k *k8SDeployment) GetExternalAppAddress() string {
 }
 
 func (k *k8SDeployment) GetCert() string {
-	// We do not implement Runtime Ceritficate injection on K8s
+	// We do not implement Runtime Certificate injection on K8s
 	// The functionality is test on Universal which is good for now
 	panic("not implemented")
 }

--- a/test/framework/interface.go
+++ b/test/framework/interface.go
@@ -295,6 +295,7 @@ type Cluster interface {
 	Deploy(deployment Deployment) error
 	WithTimeout(timeout time.Duration) Cluster
 	WithRetries(retries int) Cluster
+	Verbose() bool
 
 	// K8s
 	GetKubectlOptions(namespace ...string) *k8s.KubectlOptions

--- a/test/framework/k8s_cluster.go
+++ b/test/framework/k8s_cluster.go
@@ -88,6 +88,10 @@ func (c *K8sCluster) WithTimeout(timeout time.Duration) Cluster {
 	return c
 }
 
+func (c *K8sCluster) Verbose() bool {
+	return c.verbose
+}
+
 func (c *K8sCluster) WithRetries(retries int) Cluster {
 	c.defaultRetries = retries
 

--- a/test/framework/k8s_clusters.go
+++ b/test/framework/k8s_clusters.go
@@ -62,6 +62,10 @@ func (cs *K8sClusters) WithTimeout(timeout time.Duration) Cluster {
 	return cs
 }
 
+func (c *K8sClusters) Verbose() bool {
+	return c.verbose
+}
+
 func (cs *K8sClusters) WithRetries(retries int) Cluster {
 	for _, c := range cs.clusters {
 		c.WithRetries(retries)

--- a/test/framework/universal_cluster.go
+++ b/test/framework/universal_cluster.go
@@ -69,6 +69,10 @@ func (c *UniversalCluster) DismissCluster() (errs error) {
 	return
 }
 
+func (c *UniversalCluster) Verbose() bool {
+	return c.verbose
+}
+
 func (c *UniversalCluster) DeployKuma(mode string, fs ...DeployOptionsFunc) error {
 	c.controlplane = NewUniversalControlPlane(c.t, mode, c.name, c, c.verbose)
 	opts := newDeployOpt(fs...)

--- a/test/framework/universal_clusters.go
+++ b/test/framework/universal_clusters.go
@@ -47,6 +47,10 @@ func (cs *UniversalClusters) WithTimeout(timeout time.Duration) Cluster {
 	return cs
 }
 
+func (cs *UniversalClusters) Verbose() bool {
+	return cs.verbose
+}
+
 func (cs *UniversalClusters) WithRetries(retries int) Cluster {
 	for _, c := range cs.clusters {
 		c.WithRetries(retries)


### PR DESCRIPTION
### Summary

Kuma allocates VIP on every new service. Every ExternalService represents a single Kuma service. If we have 2 ExternalServices:
```yaml
type: ExternalService
mesh: default
name: external-service-1
tags:
  kuma.io/service: external-service-1
networking:
  address: host.com:80
---
type: ExternalService
mesh: default
name: external-service-2
tags:
  kuma.io/service: external-service-2
networking:
  address: host.com:81
```
Then 2 VIPs will be allocated: `external-service-1: 240.0.0.1, external-service-2: 240.0.0.2`.
It will work fine while we consume services using `.mesh` domain. But if we'd like to consume services using `host.com`. Built-in DNS feature will resolve `host.com` either to `240.0.0.1` or `240.0.0.2`, so one of the services won't work properly.

Current PR introduces a new type of entry - host entry. Alongside service entries, Kuma will allocate `host.com: 240.0.0.3`. 

### Full changelog

* [Implement ...]
* [Fix ...]

### Issues resolved

Fix https://github.com/kumahq/kuma/issues/2176

### Documentation

- [ ] Link to the website [documentation PR](https://github.com/kumahq/kuma-website/pull/XXX)

### Testing

- [X] Unit tests
- [X] E2E tests
- [ ] Manual testing on Universal
- [X] Manual testing on Kubernetes 
