### PR TITLE
docs(*) add backwards compatibility to PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -21,3 +21,7 @@ Fix #XXX
 - [ ] E2E tests
 - [ ] Manual testing on Universal
 - [ ] Manual testing on Kubernetes 
+
+### Backwards compatibility
+
+- [ ] Add `backport-to-stable` label if the code is backwards compatible. Otherwise, list breaking changes.


### PR DESCRIPTION
### Summary

Add a reminder to think about backwards compatibility and either add `backport-to-stable` or list breaking changes.
