### PR TITLE
chore(*) introduce a mapping from proxy to resource types

### DIFF
--- a/pkg/core/resources/apis/mesh/proxy_type.go
+++ b/pkg/core/resources/apis/mesh/proxy_type.go
@@ -1,0 +1,19 @@
+package mesh
+
+import (
+	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
+	"github.com/kumahq/kuma/pkg/core/resources/model"
+)
+
+// ResourceTypeForProxy returns the model resource type that implements
+// the given mesh ProxyType.
+func ResourceTypeForProxy(p mesh_proto.ProxyType) model.ResourceType {
+	switch p {
+	case mesh_proto.IngressProxyType:
+		return ZoneIngressType
+	case mesh_proto.GatewayProxyType:
+		return DataplaneType
+	default:
+		return DataplaneType
+	}
+}


### PR DESCRIPTION
### Summary

Introduce a helper function to map from ProxyType to ResourceType. This
lets us collapse some internal helper functions in the authentication
callbacks and the bootstrap generator and make them generic. Adding a
new proxy type will be able to consume these facilities without needing
to add more type-specific helpers.

### Full changelog

N/A

### Issues resolved

N/A

### Documentation

N/A

### Testing

- [x] Unit tests
- [x] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes 
