### PR TITLE
chore(*) improve resource manager initialization readability

### DIFF
--- a/pkg/core/resources/manager/customizable_manager.go
+++ b/pkg/core/resources/manager/customizable_manager.go
@@ -2,6 +2,7 @@ package manager
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/kumahq/kuma/pkg/core/resources/model"
 	"github.com/kumahq/kuma/pkg/core/resources/store"
@@ -14,6 +15,9 @@ type CustomizableResourceManager interface {
 }
 
 func NewCustomizableResourceManager(defaultManager ResourceManager, customManagers map[model.ResourceType]ResourceManager) CustomizableResourceManager {
+	if customManagers == nil {
+		customManagers = map[model.ResourceType]ResourceManager{}
+	}
 	return &customizableResourceManager{
 		defaultManager: defaultManager,
 		customManagers: customManagers,
@@ -28,6 +32,9 @@ type customizableResourceManager struct {
 }
 
 func (m *customizableResourceManager) Customize(resourceType model.ResourceType, manager ResourceManager) {
+	if _, ok := m.customManagers[resourceType]; ok {
+		panic(fmt.Sprintf("resource type %q is already customized", resourceType))
+	}
 	m.customManagers[resourceType] = manager
 }
 

--- a/pkg/core/resources/manager/customizable_manager.go
+++ b/pkg/core/resources/manager/customizable_manager.go
@@ -2,7 +2,6 @@ package manager
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/kumahq/kuma/pkg/core/resources/model"
 	"github.com/kumahq/kuma/pkg/core/resources/store"
@@ -31,10 +30,9 @@ type customizableResourceManager struct {
 	customManagers map[model.ResourceType]ResourceManager
 }
 
+// Customize installs a new manager for the given type, overwriting any
+// existing manager for that type.
 func (m *customizableResourceManager) Customize(resourceType model.ResourceType, manager ResourceManager) {
-	if _, ok := m.customManagers[resourceType]; ok {
-		panic(fmt.Sprintf("resource type %q is already customized", resourceType))
-	}
 	m.customManagers[resourceType] = manager
 }
 


### PR DESCRIPTION
### Summary

This refactoring is a bit gratuitous, so I'm not that concerned if we don't want to merge it :-)

I was reading the resource manager setup and it was confusing how the type map was still being initialized after already being "consumed" by customizable resource manager.

### Full changelog

N/A

### Issues resolved

N/A

### Documentation

N/A

### Testing

- [x] Unit tests
- [x] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes 
