### PR TITLE
fix(kuma-cp) stop components on leader election lost

### DIFF
--- a/pkg/core/runtime/component/component.go
+++ b/pkg/core/runtime/component/component.go
@@ -96,14 +96,14 @@ func (cm *manager) startLeaderComponents(stop <-chan struct{}, errCh chan error)
 	closeLeaderCh := func() {
 		mutex.Lock()
 		defer mutex.Unlock()
-		if channels.IsClosed(leaderStopCh) {
+		if !channels.IsClosed(leaderStopCh) {
 			close(leaderStopCh)
 		}
 	}
 
 	cm.leaderElector.AddCallbacks(LeaderCallbacks{
 		OnStartedLeading: func() {
-			log.Info("Leader acquired")
+			log.Info("leader acquired")
 			mutex.Lock()
 			defer mutex.Unlock()
 			leaderStopCh = make(chan struct{})
@@ -118,7 +118,7 @@ func (cm *manager) startLeaderComponents(stop <-chan struct{}, errCh chan error)
 			}
 		},
 		OnStoppedLeading: func() {
-			log.Info("Leader lost")
+			log.Info("leader lost")
 			closeLeaderCh()
 		},
 	})

--- a/pkg/plugins/runtime/universal/outbound/outbound.go
+++ b/pkg/plugins/runtime/universal/outbound/outbound.go
@@ -18,7 +18,7 @@ import (
 	"github.com/kumahq/kuma/pkg/dns"
 )
 
-var log = core.Log.WithName("dns-vips-allocator")
+var log = core.Log.WithName("vip-outbounds-reconciler")
 
 type VIPOutboundsReconciler struct {
 	rorm      manager.ReadOnlyResourceManager

--- a/test/e2e/resilience/leader_election_postgres.go
+++ b/test/e2e/resilience/leader_election_postgres.go
@@ -1,0 +1,93 @@
+package resilience
+
+import (
+	"github.com/kumahq/kuma/pkg/config/core"
+	. "github.com/kumahq/kuma/test/framework"
+	"github.com/kumahq/kuma/test/framework/deployments/postgres"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func LeaderElectionPostgres() {
+	var standalone1, standalone2 Cluster
+	var standalone1Opts, standalone2Opts []DeployOptionsFunc
+
+	BeforeEach(func() {
+		clusters, err := NewUniversalClusters(
+			[]string{Kuma1, Kuma2},
+			Silent)
+		Expect(err).ToNot(HaveOccurred())
+		standalone1 = clusters.GetCluster(Kuma1)
+		standalone2 = clusters.GetCluster(Kuma2)
+
+		err = NewClusterSetup().
+			Install(postgres.Install(Kuma1)).
+			Setup(standalone1)
+		Expect(err).ToNot(HaveOccurred())
+		postgresInstance := postgres.From(standalone1, Kuma1)
+
+		// Standalone 1
+		standalone1Opts = KumaUniversalDeployOpts
+		standalone1Opts = append(standalone1Opts, WithPostgres(postgresInstance.GetEnvVars()))
+
+		err = NewClusterSetup().
+			Install(Kuma(core.Standalone, standalone1Opts...)).
+			Setup(standalone1)
+
+		Expect(err).ToNot(HaveOccurred())
+		Expect(standalone1.VerifyKuma()).To(Succeed())
+
+		// Standalone 2
+		standalone2Opts = KumaUniversalDeployOpts
+		standalone2Opts = append(standalone2Opts, WithPostgres(postgresInstance.GetEnvVars()))
+
+		err = NewClusterSetup().
+			Install(Kuma(core.Standalone, standalone2Opts...)).
+			Setup(standalone2)
+
+		Expect(err).ToNot(HaveOccurred())
+		Expect(standalone2.VerifyKuma()).To(Succeed())
+	})
+
+	E2EAfterEach(func() {
+		err := standalone1.DeleteKuma(standalone1Opts...)
+		Expect(err).ToNot(HaveOccurred())
+		err = standalone1.DismissCluster()
+		Expect(err).ToNot(HaveOccurred())
+
+		err = standalone2.DeleteKuma(standalone2Opts...)
+		Expect(err).ToNot(HaveOccurred())
+		err = standalone2.DismissCluster()
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	It("should elect only one leader and drop the leader on DB disconnect", func() {
+		// given two instances of the control plane connected to one postgres, only one is a leader
+		Eventually(func() (string, error) {
+			return standalone1.GetKuma().GetMetrics()
+		}, "30s", "1s").Should(ContainSubstring(`leader{zone="Standalone"} 1`))
+
+		metrics, err := standalone2.GetKuma().GetMetrics()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(metrics).To(ContainSubstring(`leader{zone="Standalone"} 0`))
+
+		// when CP 1 is killed
+		_, _, err = standalone1.Exec("", "", AppModeCP, "pkill", "-9", "kuma-cp")
+		Expect(err).ToNot(HaveOccurred())
+
+		// then CP 2 is leader
+		Eventually(func() (string, error) {
+			return standalone2.GetKuma().GetMetrics()
+		}, "30s", "1s").Should(ContainSubstring(`leader{zone="Standalone"} 1`))
+
+		// when postgres is down
+		err = standalone1.DeleteDeployment(postgres.AppPostgres + Kuma1)
+		Expect(err).ToNot(HaveOccurred())
+
+		// then CP 2 is not a leader anymore
+		Eventually(func() (string, error) {
+			return standalone2.GetKuma().GetMetrics()
+		}, "30s", "1s").Should(ContainSubstring(`leader{zone="Standalone"} 0`))
+	})
+}

--- a/test/e2e/resilience/leader_election_postgres_test.go
+++ b/test/e2e/resilience/leader_election_postgres_test.go
@@ -1,0 +1,9 @@
+package resilience_test
+
+import (
+	"github.com/kumahq/kuma/test/e2e/resilience"
+
+	. "github.com/onsi/ginkgo"
+)
+
+var _ = Describe("Test Leader Election with Postgres", resilience.LeaderElectionPostgres)

--- a/test/framework/interface.go
+++ b/test/framework/interface.go
@@ -293,6 +293,7 @@ type Cluster interface {
 	GetKumactlOptions() *KumactlOptions
 	Deployment(name string) Deployment
 	Deploy(deployment Deployment) error
+	DeleteDeployment(name string) error
 	WithTimeout(timeout time.Duration) Cluster
 	WithRetries(retries int) Cluster
 
@@ -312,6 +313,7 @@ type Cluster interface {
 type ControlPlane interface {
 	GetName() string
 	GetKumaCPLogs() (string, error)
+	GetMetrics() (string, error)
 	GetKDSServerAddress() string
 	GetGlobaStatusAPI() string
 	GenerateDpToken(mesh, appname string) (string, error)

--- a/test/framework/k8s_clusters.go
+++ b/test/framework/k8s_clusters.go
@@ -227,3 +227,12 @@ func (cs *K8sClusters) Deploy(deployment Deployment) error {
 	}
 	return nil
 }
+
+func (cs *K8sClusters) DeleteDeployment(deploymentName string) error {
+	for name, c := range cs.clusters {
+		if err := c.DeleteDeployment(deploymentName); err != nil {
+			return errors.Wrapf(err, "delete deployment %s failed on %s cluster", deploymentName, name)
+		}
+	}
+	return nil
+}

--- a/test/framework/k8s_controlplane.go
+++ b/test/framework/k8s_controlplane.go
@@ -247,6 +247,10 @@ func (c *K8sControlPlane) GetKDSServerAddress() string {
 		pod.Status.HostIP, strconv.FormatUint(uint64(kdsPort), 10))
 }
 
+func (c *K8sControlPlane) GetMetrics() (string, error) {
+	panic("not implemented")
+}
+
 func (c *K8sControlPlane) GetGlobaStatusAPI() string {
 	return "http://localhost:" + strconv.FormatUint(uint64(c.portFwd.localAPIPort), 10) + "/status/zones"
 }

--- a/test/framework/universal_cluster.go
+++ b/test/framework/universal_cluster.go
@@ -61,10 +61,11 @@ func (c *UniversalCluster) DismissCluster() (errs error) {
 			errs = multierr.Append(errs, err)
 		}
 	}
-	for _, deployment := range c.deployments {
+	for name, deployment := range c.deployments {
 		if err := deployment.Delete(c); err != nil {
 			errs = multierr.Append(errs, err)
 		}
+		delete(c.deployments, name)
 	}
 	return
 }
@@ -314,4 +315,16 @@ func (c *UniversalCluster) Deployment(name string) Deployment {
 func (c *UniversalCluster) Deploy(deployment Deployment) error {
 	c.deployments[deployment.Name()] = deployment
 	return deployment.Deploy(c)
+}
+
+func (c *UniversalCluster) DeleteDeployment(name string) error {
+	deployment, ok := c.deployments[name]
+	if !ok {
+		return errors.Errorf("deployment %s not found", name)
+	}
+	if err := deployment.Delete(c); err != nil {
+		return err
+	}
+	delete(c.deployments, name)
+	return nil
 }

--- a/test/framework/universal_clusters.go
+++ b/test/framework/universal_clusters.go
@@ -201,3 +201,12 @@ func (cs *UniversalClusters) Deploy(deployment Deployment) error {
 	}
 	return nil
 }
+
+func (cs *UniversalClusters) DeleteDeployment(deploymentName string) error {
+	for name, c := range cs.clusters {
+		if err := c.DeleteDeployment(deploymentName); err != nil {
+			return errors.Wrapf(err, "delete deployment %s failed on %s cluster", deploymentName, name)
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
### Summary

We were not stopping leader components on the lost leader event. 
This only affects Universal deployments, Kubernetes CP is killed when the leader is lost.

In a case when there are 2 instances (CP1, CP2)
1) CP1 is a leader, CP2 is not
2) Postgres is down
3) CP1 was still running leader components although there should be no leader in this case
4) CP1 has troubles connecting to Postgres but CP2 can connect
5) CP1 and CP2 is now a leader.

It's not that CP1 leader without Postgres connection can do much, but that should not be the case.

### Documentation

- [X] - no docs

### Testing

- [ ] Unit tests - tested with E2E test
- [X] E2E tests - added
- [X] Manual testing on Universal
- [X] Manual testing on Kubernetes - Kubernetes not affected
