### PR TITLE
fix(kumactl) use strings for stderr output test check

### DIFF
--- a/app/kumactl/cmd/completion/completion_test.go
+++ b/app/kumactl/cmd/completion/completion_test.go
@@ -40,7 +40,7 @@ var _ = Describe("kumactl completion", func() {
 
 			// then
 			Expect(err).ToNot(HaveOccurred())
-			Expect(stderr.Bytes()).To(BeNil())
+			Expect(stderr.String()).To(BeEmpty())
 
 			// and
 			actual := stdout.Bytes()

--- a/app/kumactl/cmd/install/install_control_plane_test.go
+++ b/app/kumactl/cmd/install/install_control_plane_test.go
@@ -71,7 +71,7 @@ var _ = Describe("kumactl install control-plane", func() {
 
 			// then command succeed
 			Expect(err).ToNot(HaveOccurred())
-			Expect(stderr.Bytes()).To(BeNil())
+			Expect(stderr.String()).To(BeEmpty())
 
 			// and output matches golden files
 			actual := stdout.Bytes()

--- a/app/kumactl/cmd/install/install_crds_test.go
+++ b/app/kumactl/cmd/install/install_crds_test.go
@@ -38,7 +38,7 @@ var _ = Describe("kumactl install crds", func() {
 			// then
 			Expect(err).ToNot(HaveOccurred())
 			// and
-			Expect(stderr.Bytes()).To(BeNil())
+			Expect(stderr.String()).To(BeEmpty())
 
 			// when
 			actual := stdout.Bytes()

--- a/app/kumactl/cmd/install/install_demo_test.go
+++ b/app/kumactl/cmd/install/install_demo_test.go
@@ -50,7 +50,7 @@ var _ = Describe("kumactl install demo", func() {
 
 			// then
 			Expect(err).ToNot(HaveOccurred())
-			Expect(stderr.Bytes()).To(BeNil())
+			Expect(stderr.String()).To(BeEmpty())
 
 			// and output matches golden files
 			actual := stdout.Bytes()

--- a/app/kumactl/cmd/install/install_gateway_test.go
+++ b/app/kumactl/cmd/install/install_gateway_test.go
@@ -50,7 +50,7 @@ var _ = Describe("kumactl install gateway", func() {
 
 			// then
 			Expect(err).ToNot(HaveOccurred())
-			Expect(stderr.Bytes()).To(BeNil())
+			Expect(stderr.String()).To(BeEmpty())
 
 			// and output matches golden files
 			actual := stdout.Bytes()

--- a/app/kumactl/cmd/install/install_logging_test.go
+++ b/app/kumactl/cmd/install/install_logging_test.go
@@ -50,7 +50,7 @@ var _ = Describe("kumactl install logging", func() {
 
 			// then
 			Expect(err).ToNot(HaveOccurred())
-			Expect(stderr.Bytes()).To(BeNil())
+			Expect(stderr.String()).To(BeEmpty())
 
 			// and output matches golden files
 			actual := stdout.Bytes()

--- a/app/kumactl/cmd/install/install_metrics_test.go
+++ b/app/kumactl/cmd/install/install_metrics_test.go
@@ -52,7 +52,7 @@ var _ = Describe("kumactl install metrics", func() {
 
 			// then
 			Expect(err).ToNot(HaveOccurred())
-			Expect(stderr.Bytes()).To(BeNil())
+			Expect(stderr.String()).To(BeEmpty())
 
 			// and output matches golden files
 			actual := stdout.Bytes()

--- a/app/kumactl/cmd/install/install_tracing_test.go
+++ b/app/kumactl/cmd/install/install_tracing_test.go
@@ -39,7 +39,7 @@ var _ = Describe("kumactl install tracing", func() {
 
 			// then
 			Expect(err).ToNot(HaveOccurred())
-			Expect(stderr.Bytes()).To(BeNil())
+			Expect(stderr.String()).To(BeEmpty())
 
 			// and output matches golden files
 			actual := stdout.Bytes()

--- a/app/kumactl/cmd/install/install_transparent_proxy_test.go
+++ b/app/kumactl/cmd/install/install_transparent_proxy_test.go
@@ -42,7 +42,7 @@ var _ = Describe("kumactl install tracing", func() {
 			// then
 			Expect(err).ToNot(HaveOccurred())
 			// and
-			Expect(stderr.Bytes()).To(BeNil())
+			Expect(stderr.String()).To(BeEmpty())
 
 			// when
 			regex, err := ioutil.ReadFile(filepath.Join("testdata", given.goldenFile))

--- a/app/kumactl/cmd/uninstall/uninstall_transparent_proxy_test.go
+++ b/app/kumactl/cmd/uninstall/uninstall_transparent_proxy_test.go
@@ -41,7 +41,7 @@ var _ = Describe("kumactl install tracing", func() {
 			// then
 			Expect(err).ToNot(HaveOccurred())
 			// and
-			Expect(stderr.Bytes()).To(BeNil())
+			Expect(stderr.String()).To(BeEmpty())
 
 			// when
 			regex, err := ioutil.ReadFile(filepath.Join("testdata", given.goldenFile))


### PR DESCRIPTION
### Summary

If we assert that kumactl standard error is empty using a byte buffer,
then the Ginkgo error shows a hex dump, which isn't that easy to read.
Switch to checking for an empty standard error string so that Ginkgo
shows any error messages directly in the test failure.

### Full changelog

N/A

### Issues resolved

N/A

### Documentation

N/A

### Testing

- [x] Unit tests
- [x] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes 

### Backwards compatibility

- [x] Add `backport-to-stable` label if the code is backwards compatible. Otherwise, list breaking changes.
