### PR TITLE
Fix sds config truncated on reconnect

### DIFF
--- a/pkg/xds/server/callbacks/dataplane_metadata_tracker.go
+++ b/pkg/xds/server/callbacks/dataplane_metadata_tracker.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/kumahq/kuma/pkg/core/xds"
 	util_xds "github.com/kumahq/kuma/pkg/util/xds"
+	"github.com/pkg/errors"
 )
 
 type DataplaneMetadataTracker struct {
@@ -27,7 +28,7 @@ func (d *DataplaneMetadataTracker) Metadata(streamId int64) *xds.DataplaneMetada
 	if found {
 		return metadata
 	} else {
-		return &xds.DataplaneMetadata{}
+		return nil
 	}
 }
 
@@ -47,6 +48,9 @@ func (d *DataplaneMetadataTracker) OnStreamRequest(stream int64, req util_xds.Di
 		// This holds true regardless of the acceptance of the discovery responses on the same stream.
 		// The node identifier should always be identical if present more than once on the stream.
 		// It is sufficient to only check the first message for the node identifier as a result.
+		if d.Metadata(stream) == nil {
+			return errors.New("Metadata is empty for stream")
+		}
 		return nil
 	}
 

--- a/pkg/xds/server/callbacks/dataplane_metadata_tracker.go
+++ b/pkg/xds/server/callbacks/dataplane_metadata_tracker.go
@@ -3,9 +3,10 @@ package callbacks
 import (
 	"sync"
 
+	"github.com/pkg/errors"
+
 	"github.com/kumahq/kuma/pkg/core/xds"
 	util_xds "github.com/kumahq/kuma/pkg/util/xds"
-	"github.com/pkg/errors"
 )
 
 type DataplaneMetadataTracker struct {

--- a/pkg/xds/sync/dataplane_proxy_builder.go
+++ b/pkg/xds/sync/dataplane_proxy_builder.go
@@ -5,6 +5,8 @@ import (
 
 	"github.com/kumahq/kuma/pkg/core/ratelimits"
 
+	"github.com/pkg/errors"
+
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	"github.com/kumahq/kuma/pkg/core"
 	"github.com/kumahq/kuma/pkg/core/datasource"
@@ -20,7 +22,6 @@ import (
 	xds_context "github.com/kumahq/kuma/pkg/xds/context"
 	"github.com/kumahq/kuma/pkg/xds/envoy"
 	xds_topology "github.com/kumahq/kuma/pkg/xds/topology"
-	"github.com/pkg/errors"
 )
 
 var syncLog = core.Log.WithName("sync")

--- a/pkg/xds/sync/dataplane_proxy_builder.go
+++ b/pkg/xds/sync/dataplane_proxy_builder.go
@@ -20,6 +20,7 @@ import (
 	xds_context "github.com/kumahq/kuma/pkg/xds/context"
 	"github.com/kumahq/kuma/pkg/xds/envoy"
 	xds_topology "github.com/kumahq/kuma/pkg/xds/topology"
+	"github.com/pkg/errors"
 )
 
 var syncLog = core.Log.WithName("sync")
@@ -56,12 +57,16 @@ func (p *DataplaneProxyBuilder) build(key core_model.ResourceKey, streamId int64
 	if err != nil {
 		return nil, err
 	}
+	metadata := p.MetadataTracker.Metadata(streamId)
+	if metadata == nil {
+		return nil, errors.New("Metadata is empty for stream")
+	}
 
 	proxy := &xds.Proxy{
 		Id:         xds.FromResourceKey(key),
 		APIVersion: p.apiVersion,
 		Dataplane:  dp,
-		Metadata:   p.MetadataTracker.Metadata(streamId),
+		Metadata:   metadata,
 		Routing:    *routing,
 		Policies:   *matchedPolicies,
 	}

--- a/pkg/xds/sync/dataplane_watchdog.go
+++ b/pkg/xds/sync/dataplane_watchdog.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/go-logr/logr"
+	"github.com/pkg/errors"
 
 	mesh_core "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	"github.com/kumahq/kuma/pkg/core/resources/store"
@@ -51,9 +52,13 @@ func NewDataplaneWatchdog(deps DataplaneWatchdogDependencies, proxyId *core_xds.
 
 func (d *DataplaneWatchdog) Sync() error {
 	ctx := context.Background()
+	metadata := d.metadataTracker.Metadata(d.streamId)
+	if metadata == nil {
+		return errors.New("Metadata is empty for stream")
+	}
 
 	if d.dpType == "" {
-		d.dpType = d.metadataTracker.Metadata(d.streamId).GetProxyType()
+		d.dpType = metadata.GetProxyType()
 	}
 	// backwards compatibility
 	if d.dpType == mesh_proto.DataplaneProxyType && !d.proxyTypeSettled {

--- a/pkg/xds/sync/ingress_proxy_builder.go
+++ b/pkg/xds/sync/ingress_proxy_builder.go
@@ -3,6 +3,8 @@ package sync
 import (
 	"context"
 
+	"github.com/pkg/errors"
+
 	"github.com/kumahq/kuma/pkg/core/dns/lookup"
 	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	"github.com/kumahq/kuma/pkg/core/resources/manager"
@@ -12,7 +14,6 @@ import (
 	"github.com/kumahq/kuma/pkg/xds/envoy"
 	"github.com/kumahq/kuma/pkg/xds/ingress"
 	xds_topology "github.com/kumahq/kuma/pkg/xds/topology"
-	"github.com/pkg/errors"
 )
 
 type IngressProxyBuilder struct {

--- a/pkg/xds/sync/ingress_proxy_builder.go
+++ b/pkg/xds/sync/ingress_proxy_builder.go
@@ -12,6 +12,7 @@ import (
 	"github.com/kumahq/kuma/pkg/xds/envoy"
 	"github.com/kumahq/kuma/pkg/xds/ingress"
 	xds_topology "github.com/kumahq/kuma/pkg/xds/topology"
+	"github.com/pkg/errors"
 )
 
 type IngressProxyBuilder struct {
@@ -46,11 +47,15 @@ func (p *IngressProxyBuilder) build(key core_model.ResourceKey, streamId int64) 
 		return nil, err
 	}
 
+	metadata := p.MetadataTracker.Metadata(streamId)
+	if metadata == nil {
+		return nil, errors.New("Metadata is empty for stream")
+	}
 	proxy := &xds.Proxy{
 		Id:          xds.FromResourceKey(key),
 		APIVersion:  p.apiVersion,
 		ZoneIngress: zoneIngress,
-		Metadata:    p.MetadataTracker.Metadata(streamId),
+		Metadata:    metadata,
 		Routing:     *routing,
 	}
 	return proxy, nil


### PR DESCRIPTION
### Summary

Fixes issue reported in #2102.

### Full changelog

- fix(kuma-cp) fix watchdog associated with the stream is not properly stopped
    This was generating invalid configuration because the metadata was empty for this stream.
    Fixes #2102
- fix(kuma-cp) explicit error when no metadata is present on stream

### Issues resolved

Fix #2102

### Testing

- [ ] Unit tests
- [ ] E2E tests
- [X] Manual testing on Universal
- [ ] Manual testing on Kubernetes 
