### PR TITLE
fix(ci) set KUBECONFIG for kumactl install

### DIFF
--- a/mk/k3d.mk
+++ b/mk/k3d.mk
@@ -50,7 +50,7 @@ k3d/load: image/kuma-cp image/kuma-dp image/kuma-init image/kuma-prometheus-sd i
 
 .PHONY: k3d/deploy/kuma
 k3d/deploy/kuma: build/kumactl k3d/load
-	@${BUILD_ARTIFACTS_DIR}/kumactl/kumactl install --mode $(KUMA_MODE) control-plane $(KUMACTL_INSTALL_CONTROL_PLANE_IMAGES) | KUBECONFIG=$(KIND_KUBECONFIG)  kubectl apply -f -
+	@KUBECONFIG=$(KIND_KUBECONFIG) $(BUILD_ARTIFACTS_DIR)/kumactl/kumactl install --mode $(KUMA_MODE) control-plane $(KUMACTL_INSTALL_CONTROL_PLANE_IMAGES) | KUBECONFIG=$(KIND_KUBECONFIG)  kubectl apply -f -
 	@KUBECONFIG=$(KIND_KUBECONFIG) kubectl wait --timeout=60s --for=condition=Available -n $(KUMA_NAMESPACE) deployment/kuma-control-plane
 	@KUBECONFIG=$(KIND_KUBECONFIG) kubectl wait --timeout=60s --for=condition=Ready -n $(KUMA_NAMESPACE) pods -l app=kuma-control-plane
 	@KUBECONFIG=$(KIND_KUBECONFIG) kumactl install dns | kubectl apply -f -

--- a/mk/kind.mk
+++ b/mk/kind.mk
@@ -119,8 +119,8 @@ kind/load/release: images/release kind/load/images/release
 kind/load/test: images/test kind/load/images/test
 
 .PHONY: kind/deploy/kuma
-kind/deploy/kuma: build/kumactl kind/load
-	@${BUILD_ARTIFACTS_DIR}/kumactl/kumactl install --mode $(KUMA_MODE) control-plane $(KUMACTL_INSTALL_CONTROL_PLANE_IMAGES) | KUBECONFIG=$(KIND_KUBECONFIG) kubectl apply -f -
+kind/deploy/kuma: #build/kumactl kind/load
+	@KUBECONFIG=$(KIND_KUBECONFIG) $(BUILD_ARTIFACTS_DIR)/kumactl/kumactl install --mode $(KUMA_MODE) control-plane $(KUMACTL_INSTALL_CONTROL_PLANE_IMAGES) | KUBECONFIG=$(KIND_KUBECONFIG) kubectl apply -f -
 	@KUBECONFIG=$(KIND_KUBECONFIG) kubectl wait --timeout=60s --for=condition=Available -n $(KUMA_NAMESPACE) deployment/kuma-control-plane
 	@KUBECONFIG=$(KIND_KUBECONFIG) kubectl wait --timeout=60s --for=condition=Ready -n $(KUMA_NAMESPACE) pods -l app=kuma-control-plane
 	@KUBECONFIG=$(KIND_KUBECONFIG) kumactl install dns | KUBECONFIG=$(KIND_KUBECONFIG) kubectl apply -f -
@@ -158,7 +158,7 @@ kind/deploy/kuma/local: kind/deploy/kuma
 
 .PHONY: kind/deploy/metrics
 kind/deploy/metrics: build/kumactl
-	@${BUILD_ARTIFACTS_DIR}/kumactl/kumactl install metrics $(KUMACTL_INSTALL_METRICS_IMAGES) | KUBECONFIG=$(KIND_KUBECONFIG) kubectl apply -f -
+	@KUBECONFIG=$(KIND_KUBECONFIG) ${BUILD_ARTIFACTS_DIR}/kumactl/kumactl install metrics $(KUMACTL_INSTALL_METRICS_IMAGES) | KUBECONFIG=$(KIND_KUBECONFIG) kubectl apply -f -
 	@KUBECONFIG=$(KIND_KUBECONFIG) kubectl wait --timeout=60s --for=condition=Ready -n kuma-metrics pods -l app=prometheus
 
 .PHONY: kind/deploy/metrics-server
@@ -166,7 +166,7 @@ kind/deploy/metrics-server:
 	@KUBECONFIG=$(KIND_KUBECONFIG) kubectl apply -f https://github.com/kubernetes-sigs/metrics-server/releases/download/v$(METRICS_SERVER_VERSION)/components.yaml
 	@KUBECONFIG=$(KIND_KUBECONFIG) kubectl patch -n kube-system deployment/metrics-server \
 		--patch='{"spec":{"template":{"spec":{"containers":[{"name":"metrics-server","args":["--cert-dir=/tmp", "--secure-port=4443", "--kubelet-insecure-tls", "--kubelet-preferred-address-types=InternalIP"]}]}}}}'
-	@KUBECONFIG=$(KIND_KUBECONFIG) kubectl wait --timeout=60s --for=condition=Available -n kube-system deployment/metrics-server
+	@KUBECONFIG=$(KIND_KUBECONFIG) kubectl wait --timeout=2m --for=condition=Available -n kube-system deployment/metrics-server
 
 .PHONY: kind/deploy/example-app
 kind/deploy/example-app:


### PR DESCRIPTION
### Summary

In #2084, we unexported KUBECONFIG so that targets would not use
the setting from the external environment. However, "kumactl install"
depends on KUBECONFIG, and not all the makefile targets were setting it
explictly. Update the remaining uses so that "kumactl install" always
targets the correct test cluster.

### Full changelog

N/A

### Issues resolved

N/A

### Documentation

N/A

### Testing

- [x] Unit tests
- [x] E2E tests
- [ ] Manual testing on Universal
- [x] Manual testing on Kubernetes 

### Backwards compatibility

- [x] Add `backport-to-stable` label if the code is backwards compatible. Otherwise, list breaking changes.
