### PR TITLE
refactor(kumactl) add install tracing context

### DIFF
--- a/app/kumactl/cmd/install/context/install_tracing_context.go
+++ b/app/kumactl/cmd/install/context/install_tracing_context.go
@@ -1,0 +1,17 @@
+package context
+
+type TracingTemplateArgs struct {
+	Namespace string
+}
+
+type InstallTracingContext struct {
+	TemplateArgs TracingTemplateArgs
+}
+
+func DefaultInstallTracingContext() InstallTracingContext {
+	return InstallTracingContext{
+		TemplateArgs: TracingTemplateArgs{
+			Namespace: "kuma-tracing",
+		},
+	}
+}

--- a/app/kumactl/cmd/install/install.go
+++ b/app/kumactl/cmd/install/install.go
@@ -16,7 +16,7 @@ func NewInstallCmd(pctx *kumactl_cmd.RootContext) *cobra.Command {
 	cmd.AddCommand(newInstallControlPlaneCmd(&pctx.InstallCpContext))
 	cmd.AddCommand(newInstallCrdsCmd(&pctx.InstallCRDContext))
 	cmd.AddCommand(newInstallMetrics(pctx))
-	cmd.AddCommand(newInstallTracing())
+	cmd.AddCommand(newInstallTracing(pctx))
 	cmd.AddCommand(newInstallDNS())
 	cmd.AddCommand(newInstallLogging())
 	cmd.AddCommand(newInstallTransparentProxy())

--- a/app/kumactl/cmd/install/install_tracing.go
+++ b/app/kumactl/cmd/install/install_tracing.go
@@ -4,6 +4,8 @@ import (
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
+	kumactl_cmd "github.com/kumahq/kuma/app/kumactl/pkg/cmd"
+
 	kumactl_data "github.com/kumahq/kuma/app/kumactl/data"
 	"github.com/kumahq/kuma/app/kumactl/pkg/install/data"
 	"github.com/kumahq/kuma/app/kumactl/pkg/install/k8s"
@@ -13,12 +15,8 @@ type tracingTemplateArgs struct {
 	Namespace string
 }
 
-func newInstallTracing() *cobra.Command {
-	args := struct {
-		Namespace string
-	}{
-		Namespace: "kuma-tracing",
-	}
+func newInstallTracing(pctx *kumactl_cmd.RootContext) *cobra.Command {
+	args := pctx.InstallTracingContext.TemplateArgs
 	cmd := &cobra.Command{
 		Use:   "tracing",
 		Short: "Install Tracing backend in Kubernetes cluster (Jaeger)",

--- a/app/kumactl/pkg/cmd/root_context.go
+++ b/app/kumactl/pkg/cmd/root_context.go
@@ -57,6 +57,7 @@ type RootContext struct {
 	InstallDemoContext                  install_context.InstallDemoContext
 	InstallGatewayKongContext           install_context.InstallGatewayKongContext
 	InstallGatewayKongEnterpriseContext install_context.InstallGatewayKongEnterpriseContext
+	InstallTracingContext               install_context.InstallTracingContext
 }
 
 func DefaultRootContext() *RootContext {
@@ -97,6 +98,7 @@ func DefaultRootContext() *RootContext {
 		InstallDemoContext:                  install_context.DefaultInstallDemoContext(),
 		InstallGatewayKongContext:           install_context.DefaultInstallGatewayKongContext(),
 		InstallGatewayKongEnterpriseContext: install_context.DefaultInstallGatewayKongEnterpriseContext(),
+		InstallTracingContext:               install_context.DefaultInstallTracingContext(),
 	}
 }
 


### PR DESCRIPTION
### Summary

refactor kumactl install tracing to move arguments to separate context

### Full changelog

* [Implement ...]
* [Fix ...]

### Issues resolved

Fix #XXX

### Documentation

- [ ] Link to the website [documentation PR](https://github.com/kumahq/kuma-website/pull/XXX)

### Testing

- [ ] Unit tests
- [ ] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes 

### Backwards compatibility

- [x] Add `backport-to-stable` label if the code is backwards compatible. Otherwise, list breaking changes.
