### PR TITLE
fix(*) allow verbose log levels

### DIFF
--- a/pkg/log/logger.go
+++ b/pkg/log/logger.go
@@ -69,7 +69,11 @@ func newZapLoggerTo(destWriter io.Writer, level LogLevel, opts ...zap.Option) *z
 	case OffLevel:
 		return zap.NewNop()
 	case DebugLevel:
-		lvl = zap.NewAtomicLevelAt(zap.DebugLevel)
+		// The value we pass here is the most verbose level that
+		// will end up being emitted through the `V(level int)`
+		// accessor. Passing -10 ensures that levels up to `V(10)`
+		// will work, which seems like plenty.
+		lvl = zap.NewAtomicLevelAt(-10)
 		opts = append(opts, zap.Development(), zap.AddStacktrace(zap.ErrorLevel))
 	default:
 		lvl = zap.NewAtomicLevelAt(zap.InfoLevel)


### PR DESCRIPTION
### Summary

When we are in debug logging mode, update the underlying zap log level
so that verbose logs up to level 10 will be emitted.

This fixes #2350

### Full changelog

N/A

### Issues resolved

N/A

### Documentation

N/A

### Testing

```
2021-07-12T15:53:53.666+1000	LEVEL(-2)	proxy-template-resolver	falling back to the default ProxyTemplate since there is no best match	{"dataplane": {"Mesh":"default","Name":"greenling"}, "templates": null}
```

- [x] Unit tests
- [x] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes 

### Backwards compatibility

- [x] Add `backport-to-stable` label if the code is backwards compatible. Otherwise, list breaking changes.
