### PR TITLE
chore(*) add xDS configurer adaptors

### DIFF
--- a/pkg/xds/envoy/listeners/configurers.go
+++ b/pkg/xds/envoy/listeners/configurers.go
@@ -12,254 +12,223 @@ import (
 )
 
 func GrpcStats() FilterChainBuilderOpt {
-	return FilterChainBuilderOptFunc(func(config *FilterChainBuilderConfig) {
-		config.AddV3(&v3.GrpcStatsConfigurer{})
-	})
+	return AddFilterChainConfigurer(&v3.GrpcStatsConfigurer{})
 }
 
 func Kafka(statsName string) FilterChainBuilderOpt {
-	return FilterChainBuilderOptFunc(func(config *FilterChainBuilderConfig) {
-		config.AddV3(&v3.KafkaConfigurer{
-			StatsName: statsName,
-		})
+	return AddFilterChainConfigurer(&v3.KafkaConfigurer{
+		StatsName: statsName,
 	})
 }
 
 func Tracing(backend *mesh_proto.TracingBackend, service string) FilterChainBuilderOpt {
-	return FilterChainBuilderOptFunc(func(config *FilterChainBuilderConfig) {
-		config.AddV3(&v3.TracingConfigurer{
-			Backend: backend,
-			Service: service,
-		})
+	return AddFilterChainConfigurer(&v3.TracingConfigurer{
+		Backend: backend,
+		Service: service,
 	})
 }
 
 func TLSInspector() ListenerBuilderOpt {
-	return ListenerBuilderOptFunc(func(config *ListenerBuilderConfig) {
-		config.AddV3(&v3.TLSInspectorConfigurer{})
-	})
+	return AddListenerConfigurer(&v3.TLSInspectorConfigurer{})
 }
 
 func OriginalDstForwarder() ListenerBuilderOpt {
-	return ListenerBuilderOptFunc(func(config *ListenerBuilderConfig) {
-		config.AddV3(&v3.OriginalDstForwarderConfigurer{})
-	})
+	return AddListenerConfigurer(&v3.OriginalDstForwarderConfigurer{})
 }
 
 func StaticEndpoints(virtualHostName string, paths []*envoy_common.StaticEndpointPath) FilterChainBuilderOpt {
-	return FilterChainBuilderOptFunc(func(config *FilterChainBuilderConfig) {
-		config.AddV3(&v3.StaticEndpointsConfigurer{
-			VirtualHostName: virtualHostName,
-			Paths:           paths,
-		})
+	return AddFilterChainConfigurer(&v3.StaticEndpointsConfigurer{
+		VirtualHostName: virtualHostName,
+		Paths:           paths,
 	})
 }
 
 func StaticTlsEndpoints(virtualHostName string, keyPair *tls.KeyPair, paths []*envoy_common.StaticEndpointPath) FilterChainBuilderOpt {
-	return FilterChainBuilderOptFunc(func(config *FilterChainBuilderConfig) {
-		config.AddV3(&v3.StaticEndpointsConfigurer{
-			VirtualHostName: virtualHostName,
-			Paths:           paths,
-			KeyPair:         keyPair,
-		})
+	return AddFilterChainConfigurer(&v3.StaticEndpointsConfigurer{
+		VirtualHostName: virtualHostName,
+		Paths:           paths,
+		KeyPair:         keyPair,
 	})
 }
 
 func ServerSideMTLS(ctx xds_context.Context, metadata *core_xds.DataplaneMetadata) FilterChainBuilderOpt {
-	return FilterChainBuilderOptFunc(func(config *FilterChainBuilderConfig) {
-		config.AddV3(&v3.ServerSideMTLSConfigurer{
-			Ctx:      ctx,
-			Metadata: metadata,
-		})
+	return AddFilterChainConfigurer(&v3.ServerSideMTLSConfigurer{
+		Ctx:      ctx,
+		Metadata: metadata,
 	})
 }
 
 func HttpConnectionManager(statsName string, forwardClientCertDetails bool) FilterChainBuilderOpt {
-	return FilterChainBuilderOptFunc(func(config *FilterChainBuilderConfig) {
-		config.AddV3(&v3.HttpConnectionManagerConfigurer{
-			StatsName:                statsName,
-			ForwardClientCertDetails: forwardClientCertDetails,
-		})
+	return AddFilterChainConfigurer(&v3.HttpConnectionManagerConfigurer{
+		StatsName:                statsName,
+		ForwardClientCertDetails: forwardClientCertDetails,
 	})
 }
 
 func FilterChainMatch(transport string, serverNames ...string) FilterChainBuilderOpt {
-	return FilterChainBuilderOptFunc(func(config *FilterChainBuilderConfig) {
-		config.AddV3(&v3.FilterChainMatchConfigurer{
-			ServerNames:       serverNames,
-			TransportProtocol: transport,
-		})
+	return AddFilterChainConfigurer(&v3.FilterChainMatchConfigurer{
+		ServerNames:       serverNames,
+		TransportProtocol: transport,
 	})
 }
 
 func SourceMatcher(address string) FilterChainBuilderOpt {
-	return FilterChainBuilderOptFunc(func(config *FilterChainBuilderConfig) {
-		config.AddV3(&v3.SourceMatcherConfigurer{
-			Address: address,
-		})
+	return AddFilterChainConfigurer(&v3.SourceMatcherConfigurer{
+		Address: address,
 	})
 }
 
 func InboundListener(listenerName string, address string, port uint32, protocol core_xds.SocketAddressProtocol) ListenerBuilderOpt {
-	return ListenerBuilderOptFunc(func(config *ListenerBuilderConfig) {
-		config.AddV3(&v3.InboundListenerConfigurer{
-			Protocol:     protocol,
-			ListenerName: listenerName,
-			Address:      address,
-			Port:         port,
-		})
+	return AddListenerConfigurer(&v3.InboundListenerConfigurer{
+		Protocol:     protocol,
+		ListenerName: listenerName,
+		Address:      address,
+		Port:         port,
 	})
 }
 
 func NetworkRBAC(statsName string, rbacEnabled bool, permission *mesh_core.TrafficPermissionResource) FilterChainBuilderOpt {
-	return FilterChainBuilderOptFunc(func(config *FilterChainBuilderConfig) {
-		if rbacEnabled {
-			config.AddV3(&v3.NetworkRBACConfigurer{
-				StatsName:  statsName,
-				Permission: permission,
-			})
-		}
+	if !rbacEnabled {
+		return FilterChainBuilderOptFunc(nil)
+	}
+
+	return AddFilterChainConfigurer(&v3.NetworkRBACConfigurer{
+		StatsName:  statsName,
+		Permission: permission,
 	})
 }
 
 func OutboundListener(listenerName string, address string, port uint32, protocol core_xds.SocketAddressProtocol) ListenerBuilderOpt {
-	return ListenerBuilderOptFunc(func(config *ListenerBuilderConfig) {
-		config.AddV3(&v3.OutboundListenerConfigurer{
-			Protocol:     protocol,
-			ListenerName: listenerName,
-			Address:      address,
-			Port:         port,
-		})
+	return AddListenerConfigurer(&v3.OutboundListenerConfigurer{
+		Protocol:     protocol,
+		ListenerName: listenerName,
+		Address:      address,
+		Port:         port,
 	})
 }
 
 func TransparentProxying(transparentProxying *mesh_proto.Dataplane_Networking_TransparentProxying) ListenerBuilderOpt {
 	virtual := transparentProxying.GetRedirectPortOutbound() != 0 && transparentProxying.GetRedirectPortInbound() != 0
-	return ListenerBuilderOptFunc(func(config *ListenerBuilderConfig) {
-		if virtual {
-			config.AddV3(&v3.TransparentProxyingConfigurer{})
-		}
-	})
+	if virtual {
+		return AddListenerConfigurer(&v3.TransparentProxyingConfigurer{})
+	}
+
+	return ListenerBuilderOptFunc(nil)
 }
 
 func NoBindToPort() ListenerBuilderOpt {
-	return ListenerBuilderOptFunc(func(config *ListenerBuilderConfig) {
-		config.AddV3(&v3.TransparentProxyingConfigurer{})
-	})
+	return AddListenerConfigurer(&v3.TransparentProxyingConfigurer{})
 }
 
 func TcpProxy(statsName string, clusters ...envoy_common.Cluster) FilterChainBuilderOpt {
-	return FilterChainBuilderOptFunc(func(config *FilterChainBuilderConfig) {
-		config.AddV3(&v3.TcpProxyConfigurer{
-			StatsName:   statsName,
-			Clusters:    clusters,
-			UseMetadata: false,
-		})
+	return AddFilterChainConfigurer(&v3.TcpProxyConfigurer{
+		StatsName:   statsName,
+		Clusters:    clusters,
+		UseMetadata: false,
 	})
 }
 
 func TcpProxyWithMetadata(statsName string, clusters ...envoy_common.Cluster) FilterChainBuilderOpt {
-	return FilterChainBuilderOptFunc(func(config *FilterChainBuilderConfig) {
-		config.AddV3(&v3.TcpProxyConfigurer{
-			StatsName:   statsName,
-			Clusters:    clusters,
-			UseMetadata: true,
-		})
+	return AddFilterChainConfigurer(&v3.TcpProxyConfigurer{
+		StatsName:   statsName,
+		Clusters:    clusters,
+		UseMetadata: true,
 	})
 }
 
 func FaultInjection(faultInjection *mesh_proto.FaultInjection) FilterChainBuilderOpt {
-	return FilterChainBuilderOptFunc(func(config *FilterChainBuilderConfig) {
-		config.AddV3(&v3.FaultInjectionConfigurer{
-			FaultInjection: faultInjection,
-		})
+	return AddFilterChainConfigurer(&v3.FaultInjectionConfigurer{
+		FaultInjection: faultInjection,
 	})
 }
 
 func RateLimit(rateLimits []*mesh_proto.RateLimit) FilterChainBuilderOpt {
-	return FilterChainBuilderOptFunc(func(config *FilterChainBuilderConfig) {
-		config.AddV3(&v3.RateLimitConfigurer{
-			RateLimits: rateLimits,
-		})
+	return AddFilterChainConfigurer(&v3.RateLimitConfigurer{
+		RateLimits: rateLimits,
 	})
 }
 
-func NetworkAccessLog(mesh string, trafficDirection envoy_common.TrafficDirection, sourceService string, destinationService string, backend *mesh_proto.LoggingBackend, proxy *core_xds.Proxy) FilterChainBuilderOpt {
-	return FilterChainBuilderOptFunc(func(config *FilterChainBuilderConfig) {
-		if backend != nil {
-			config.AddV3(&v3.NetworkAccessLogConfigurer{
-				AccessLogConfigurer: v3.AccessLogConfigurer{
-					Mesh:               mesh,
-					TrafficDirection:   trafficDirection,
-					SourceService:      sourceService,
-					DestinationService: destinationService,
-					Backend:            backend,
-					Proxy:              proxy,
-				},
-			})
-		}
+func NetworkAccessLog(
+	mesh string,
+	trafficDirection envoy_common.TrafficDirection,
+	sourceService string,
+	destinationService string,
+	backend *mesh_proto.LoggingBackend,
+	proxy *core_xds.Proxy,
+) FilterChainBuilderOpt {
+	if backend == nil {
+		return FilterChainBuilderOptFunc(nil)
+	}
+
+	return AddFilterChainConfigurer(&v3.NetworkAccessLogConfigurer{
+		AccessLogConfigurer: v3.AccessLogConfigurer{
+			Mesh:               mesh,
+			TrafficDirection:   trafficDirection,
+			SourceService:      sourceService,
+			DestinationService: destinationService,
+			Backend:            backend,
+			Proxy:              proxy,
+		},
 	})
 }
 
-func HttpAccessLog(mesh string, trafficDirection envoy_common.TrafficDirection, sourceService string, destinationService string, backend *mesh_proto.LoggingBackend, proxy *core_xds.Proxy) FilterChainBuilderOpt {
-	return FilterChainBuilderOptFunc(func(config *FilterChainBuilderConfig) {
-		if backend != nil {
-			config.AddV3(&v3.HttpAccessLogConfigurer{
-				AccessLogConfigurer: v3.AccessLogConfigurer{
-					Mesh:               mesh,
-					TrafficDirection:   trafficDirection,
-					SourceService:      sourceService,
-					DestinationService: destinationService,
-					Backend:            backend,
-					Proxy:              proxy,
-				},
-			})
-		}
+func HttpAccessLog(
+	mesh string,
+	trafficDirection envoy_common.TrafficDirection,
+	sourceService string, destinationService string,
+	backend *mesh_proto.LoggingBackend,
+	proxy *core_xds.Proxy,
+) FilterChainBuilderOpt {
+	if backend == nil {
+		return FilterChainBuilderOptFunc(nil)
+	}
+
+	return AddFilterChainConfigurer(&v3.HttpAccessLogConfigurer{
+		AccessLogConfigurer: v3.AccessLogConfigurer{
+			Mesh:               mesh,
+			TrafficDirection:   trafficDirection,
+			SourceService:      sourceService,
+			DestinationService: destinationService,
+			Backend:            backend,
+			Proxy:              proxy,
+		},
 	})
 }
 
 func HttpStaticRoute(builder *envoy_routes.RouteConfigurationBuilder) FilterChainBuilderOpt {
-	return FilterChainBuilderOptFunc(func(config *FilterChainBuilderConfig) {
-		config.AddV3(&v3.HttpStaticRouteConfigurer{
-			Builder: builder,
-		})
+	return AddFilterChainConfigurer(&v3.HttpStaticRouteConfigurer{
+		Builder: builder,
 	})
 }
 
 func HttpInboundRoutes(service string, routes envoy_common.Routes) FilterChainBuilderOpt {
-	return FilterChainBuilderOptFunc(func(config *FilterChainBuilderConfig) {
-		config.AddV3(&v3.HttpInboundRoutesConfigurer{
-			Service: service,
-			Routes:  routes,
-		})
+	return AddFilterChainConfigurer(&v3.HttpInboundRoutesConfigurer{
+		Service: service,
+		Routes:  routes,
 	})
 }
 
 func HttpOutboundRoute(service string, routes envoy_common.Routes, dpTags mesh_proto.MultiValueTagSet) FilterChainBuilderOpt {
-	return FilterChainBuilderOptFunc(func(config *FilterChainBuilderConfig) {
-		config.AddV3(&v3.HttpOutboundRouteConfigurer{
-			Service: service,
-			Routes:  routes,
-			DpTags:  dpTags,
-		})
+	return AddFilterChainConfigurer(&v3.HttpOutboundRouteConfigurer{
+		Service: service,
+		Routes:  routes,
+		DpTags:  dpTags,
 	})
 }
 
 func FilterChain(builder *FilterChainBuilder) ListenerBuilderOpt {
-	return ListenerBuilderOptFunc(func(config *ListenerBuilderConfig) {
-		config.AddV3(&ListenerFilterChainConfigurerV3{
-			builder: builder,
-		})
+	return AddListenerConfigurer(&ListenerFilterChainConfigurerV3{
+		builder: builder,
 	})
 }
 
 func MaxConnectAttempts(retry *mesh_core.RetryResource) FilterChainBuilderOpt {
-	return FilterChainBuilderOptFunc(func(config *FilterChainBuilderConfig) {
-		if retry != nil && retry.Spec.Conf.GetTcp() != nil {
-			config.AddV3(&v3.MaxConnectAttemptsConfigurer{
-				Retry: retry,
-			})
-		}
+	if retry == nil || retry.Spec.Conf.GetTcp() == nil {
+		return FilterChainBuilderOptFunc(nil)
+	}
+
+	return AddFilterChainConfigurer(&v3.MaxConnectAttemptsConfigurer{
+		Retry: retry,
 	})
 }
 
@@ -267,30 +236,26 @@ func Retry(
 	retry *mesh_core.RetryResource,
 	protocol mesh_core.Protocol,
 ) FilterChainBuilderOpt {
-	return FilterChainBuilderOptFunc(func(config *FilterChainBuilderConfig) {
-		if retry != nil {
-			config.AddV3(&v3.RetryConfigurer{
-				Retry:    retry,
-				Protocol: protocol,
-			})
-		}
+	if retry == nil {
+		return FilterChainBuilderOptFunc(nil)
+	}
+
+	return AddFilterChainConfigurer(&v3.RetryConfigurer{
+		Retry:    retry,
+		Protocol: protocol,
 	})
 }
 
 func Timeout(timeout *mesh_proto.Timeout_Conf, protocol mesh_core.Protocol) FilterChainBuilderOpt {
-	return FilterChainBuilderOptFunc(func(config *FilterChainBuilderConfig) {
-		config.AddV3(&v3.TimeoutConfigurer{
-			Conf:     timeout,
-			Protocol: protocol,
-		})
+	return AddFilterChainConfigurer(&v3.TimeoutConfigurer{
+		Conf:     timeout,
+		Protocol: protocol,
 	})
 }
 
 func DNS(vips map[string]string, emptyDnsPort uint32) ListenerBuilderOpt {
-	return ListenerBuilderOptFunc(func(config *ListenerBuilderConfig) {
-		config.AddV3(&v3.DNSConfigurer{
-			VIPs:         vips,
-			EmptyDNSPort: emptyDnsPort,
-		})
+	return AddListenerConfigurer(&v3.DNSConfigurer{
+		VIPs:         vips,
+		EmptyDNSPort: emptyDnsPort,
 	})
 }

--- a/pkg/xds/envoy/listeners/filter_chain_builder.go
+++ b/pkg/xds/envoy/listeners/filter_chain_builder.go
@@ -60,7 +60,7 @@ type FilterChainBuilderConfig struct {
 	ConfigurersV3 []v3.FilterChainConfigurer
 }
 
-// Add appends a given FilterChainConfigurer to the end of the chain.
+// AddV3 appends a given FilterChainConfigurer to the end of the chain.
 func (c *FilterChainBuilderConfig) AddV3(configurer v3.FilterChainConfigurer) {
 	c.ConfigurersV3 = append(c.ConfigurersV3, configurer)
 }
@@ -69,5 +69,15 @@ func (c *FilterChainBuilderConfig) AddV3(configurer v3.FilterChainConfigurer) {
 type FilterChainBuilderOptFunc func(config *FilterChainBuilderConfig)
 
 func (f FilterChainBuilderOptFunc) ApplyTo(config *FilterChainBuilderConfig) {
-	f(config)
+	if f != nil {
+		f(config)
+	}
+}
+
+// AddFilterChainConfigurer produces an option that applies the given
+// configurer to the filter chain.
+func AddFilterChainConfigurer(c v3.FilterChainConfigurer) FilterChainBuilderOpt {
+	return FilterChainBuilderOptFunc(func(config *FilterChainBuilderConfig) {
+		config.AddV3(c)
+	})
 }

--- a/pkg/xds/envoy/listeners/listener_builder.go
+++ b/pkg/xds/envoy/listeners/listener_builder.go
@@ -59,7 +59,7 @@ type ListenerBuilderConfig struct {
 	ConfigurersV3 []v3.ListenerConfigurer
 }
 
-// Add appends a given ListenerConfigurer to the end of the chain.
+// AddV3 appends a given ListenerConfigurer to the end of the chain.
 func (c *ListenerBuilderConfig) AddV3(configurer v3.ListenerConfigurer) {
 	c.ConfigurersV3 = append(c.ConfigurersV3, configurer)
 }
@@ -68,5 +68,15 @@ func (c *ListenerBuilderConfig) AddV3(configurer v3.ListenerConfigurer) {
 type ListenerBuilderOptFunc func(config *ListenerBuilderConfig)
 
 func (f ListenerBuilderOptFunc) ApplyTo(config *ListenerBuilderConfig) {
-	f(config)
+	if f != nil {
+		f(config)
+	}
+}
+
+// AddListenerConfigurer produces an option that applies the given
+// configurer to the listener.
+func AddListenerConfigurer(c v3.ListenerConfigurer) ListenerBuilderOpt {
+	return ListenerBuilderOptFunc(func(config *ListenerBuilderConfig) {
+		config.AddV3(c)
+	})
 }


### PR DESCRIPTION
### Summary

Add adaptors for the listener and filter chain configurers so that every
call site doesn't need to bounce through the the corresponding builder
configuration API.

### Full changelog

N/A

### Issues resolved

N/A

### Documentation

N/A

### Testing

- [x] Unit tests
- [x] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes 

### Backwards compatibility

- [x] Add `backport-to-stable` label if the code is backwards compatible. Otherwise, list breaking changes.
