### PR TITLE
fix(*) use the typed config for TLS Inspector

### DIFF
--- a/pkg/xds/envoy/listeners/v3/tls_inspector_configurer.go
+++ b/pkg/xds/envoy/listeners/v3/tls_inspector_configurer.go
@@ -2,7 +2,7 @@ package v3
 
 import (
 	envoy_listener "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
-	"github.com/golang/protobuf/ptypes/empty"
+	envoy_extensions_filters_listener_tls_inspector_v3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/listener/tls_inspector/v3"
 
 	"github.com/kumahq/kuma/pkg/util/proto"
 )
@@ -13,7 +13,7 @@ type TLSInspectorConfigurer struct {
 var _ ListenerConfigurer = &TLSInspectorConfigurer{}
 
 func (c *TLSInspectorConfigurer) Configure(l *envoy_listener.Listener) error {
-	any, err := proto.MarshalAnyDeterministic(&empty.Empty{})
+	any, err := proto.MarshalAnyDeterministic(&envoy_extensions_filters_listener_tls_inspector_v3.TlsInspector{})
 	if err != nil {
 		return err
 	}

--- a/pkg/xds/generator/testdata/admin/01.envoy-config.golden.yaml
+++ b/pkg/xds/generator/testdata/admin/01.envoy-config.golden.yaml
@@ -79,7 +79,6 @@ resources:
     listenerFilters:
     - name: envoy.filters.listener.tls_inspector
       typedConfig:
-        '@type': type.googleapis.com/google.protobuf.Empty
-        value: {}
+        '@type': type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
     name: kuma:envoy:admin
     trafficDirection: INBOUND

--- a/pkg/xds/generator/testdata/ingress/01.envoy.golden.yaml
+++ b/pkg/xds/generator/testdata/ingress/01.envoy.golden.yaml
@@ -78,7 +78,6 @@ resources:
     listenerFilters:
     - name: envoy.filters.listener.tls_inspector
       typedConfig:
-        '@type': type.googleapis.com/google.protobuf.Empty
-        value: {}
+        '@type': type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
     name: inbound:10.0.0.1:10001
     trafficDirection: INBOUND

--- a/pkg/xds/generator/testdata/ingress/02.envoy.golden.yaml
+++ b/pkg/xds/generator/testdata/ingress/02.envoy.golden.yaml
@@ -11,7 +11,6 @@ resources:
     listenerFilters:
     - name: envoy.filters.listener.tls_inspector
       typedConfig:
-        '@type': type.googleapis.com/google.protobuf.Empty
-        value: {}
+        '@type': type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
     name: inbound:10.0.0.1:10001
     trafficDirection: INBOUND

--- a/pkg/xds/generator/testdata/ingress/03.envoy.golden.yaml
+++ b/pkg/xds/generator/testdata/ingress/03.envoy.golden.yaml
@@ -116,7 +116,6 @@ resources:
     listenerFilters:
     - name: envoy.filters.listener.tls_inspector
       typedConfig:
-        '@type': type.googleapis.com/google.protobuf.Empty
-        value: {}
+        '@type': type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
     name: inbound:10.0.0.1:10001
     trafficDirection: INBOUND

--- a/pkg/xds/generator/testdata/ingress/04.envoy.golden.yaml
+++ b/pkg/xds/generator/testdata/ingress/04.envoy.golden.yaml
@@ -280,7 +280,6 @@ resources:
     listenerFilters:
     - name: envoy.filters.listener.tls_inspector
       typedConfig:
-        '@type': type.googleapis.com/google.protobuf.Empty
-        value: {}
+        '@type': type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
     name: inbound:10.0.0.1:10001
     trafficDirection: INBOUND

--- a/pkg/xds/generator/testdata/ingress/05.envoy.golden.yaml
+++ b/pkg/xds/generator/testdata/ingress/05.envoy.golden.yaml
@@ -44,7 +44,6 @@ resources:
     listenerFilters:
     - name: envoy.filters.listener.tls_inspector
       typedConfig:
-        '@type': type.googleapis.com/google.protobuf.Empty
-        value: {}
+        '@type': type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
     name: inbound:10.0.0.1:10001
     trafficDirection: INBOUND

--- a/pkg/xds/generator/testdata/profile-source/1-envoy-config.golden.yaml
+++ b/pkg/xds/generator/testdata/profile-source/1-envoy-config.golden.yaml
@@ -272,8 +272,7 @@ resources:
     listenerFilters:
     - name: envoy.filters.listener.tls_inspector
       typedConfig:
-        '@type': type.googleapis.com/google.protobuf.Empty
-        value: {}
+        '@type': type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
     name: kuma:envoy:admin
     trafficDirection: INBOUND
 - name: outbound:127.0.0.1:54321

--- a/pkg/xds/generator/testdata/profile-source/2-envoy-config.golden.yaml
+++ b/pkg/xds/generator/testdata/profile-source/2-envoy-config.golden.yaml
@@ -310,8 +310,7 @@ resources:
     listenerFilters:
     - name: envoy.filters.listener.tls_inspector
       typedConfig:
-        '@type': type.googleapis.com/google.protobuf.Empty
-        value: {}
+        '@type': type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
     name: kuma:envoy:admin
     trafficDirection: INBOUND
 - name: outbound:127.0.0.1:54321

--- a/pkg/xds/generator/testdata/profile-source/3-envoy-config.golden.yaml
+++ b/pkg/xds/generator/testdata/profile-source/3-envoy-config.golden.yaml
@@ -306,8 +306,7 @@ resources:
     listenerFilters:
     - name: envoy.filters.listener.tls_inspector
       typedConfig:
-        '@type': type.googleapis.com/google.protobuf.Empty
-        value: {}
+        '@type': type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
     name: kuma:envoy:admin
     trafficDirection: INBOUND
 - name: kuma:metrics:prometheus

--- a/pkg/xds/generator/testdata/profile-source/4-envoy-config.golden.yaml
+++ b/pkg/xds/generator/testdata/profile-source/4-envoy-config.golden.yaml
@@ -344,8 +344,7 @@ resources:
     listenerFilters:
     - name: envoy.filters.listener.tls_inspector
       typedConfig:
-        '@type': type.googleapis.com/google.protobuf.Empty
-        value: {}
+        '@type': type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
     name: kuma:envoy:admin
     trafficDirection: INBOUND
 - name: kuma:metrics:prometheus


### PR DESCRIPTION
### Summary

The TLS Inspector has its own typed config protobuf that we should use
for the filter rather than an empty protobuf.

### Full changelog

N/A

### Issues resolved

N/A

### Documentation

N/A

### Testing

- [x] Unit tests
- [x] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes 

### Backwards compatibility

- [x] Add `backport-to-stable` label if the code is backwards compatible. Otherwise, list breaking changes.
