### PR TITLE
refactor(xds) rename logger to have consistent naming style

### DIFF
--- a/pkg/xds/server/callbacks/dataplane_status_tracker.go
+++ b/pkg/xds/server/callbacks/dataplane_status_tracker.go
@@ -16,7 +16,7 @@ import (
 	util_xds "github.com/kumahq/kuma/pkg/util/xds"
 )
 
-var statusTrackerLog = core.Log.WithName("xds").WithName("statusTracker")
+var statusTrackerLog = core.Log.WithName("xds").WithName("status-tracker")
 
 type DataplaneStatusTracker interface {
 	util_xds.Callbacks


### PR DESCRIPTION
Signed-off-by: Aadhav Vignesh <aadhav.n1@gmail.com>

### Summary

rename logger names to be consistent in the xDS server package 

### Full changelog

* [Implement ...]
* [Fix ...]

### Issues resolved

Updates #2313 

### Documentation

- [ ] Link to the website [documentation PR](https://github.com/kumahq/kuma-website/pull/XXX)

### Testing

- [ ] Unit tests
- [ ] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes 

### Backwards compatibility

- [ ] Add `backport-to-stable` label if the code is backwards compatible. Otherwise, list breaking changes.
