### PR TITLE
chore(kuma-cp) improve VIP interface logging

### DIFF
--- a/pkg/dns/vips/interfaces.go
+++ b/pkg/dns/vips/interfaces.go
@@ -12,17 +12,28 @@ const (
 	Host
 )
 
+func (t EntryType) String() string {
+	switch t {
+	case Service:
+		return "service"
+	case Host:
+		return "host"
+	default:
+		return "undefined"
+	}
+}
+
 type Entry struct {
 	Type EntryType `json:"type"`
 	Name string    `json:"name"`
 }
 
 func (e Entry) String() string {
-	return fmt.Sprintf("%v:%s", e.Type, e.Name)
+	return fmt.Sprintf("%s:%s", e.Type, e.Name)
 }
 
 func (e Entry) MarshalText() (text []byte, err error) {
-	return []byte(e.String()), nil
+	return []byte(fmt.Sprintf("%d:%s", e.Type, e.Name)), nil
 }
 
 func (e *Entry) UnmarshalText(text []byte) error {
@@ -45,7 +56,9 @@ func (s EntrySet) ToArray() (entries []Entry) {
 		entries = append(entries, entry)
 	}
 	sort.SliceStable(entries, func(i, j int) bool {
-		return entries[i].String() < entries[j].String()
+		// Sort by entry type, then name.
+		return entries[i].Type < entries[j].Type ||
+			entries[i].Name < entries[j].Name
 	})
 	return
 }


### PR DESCRIPTION
### Summary

Improve the VIP entry stringer so that it show the name of the entry
type. This is shown in logs, where having the type name is a lot clearer.

### Full changelog

N/A

### Issues resolved

N/A

### Documentation

N/A

### Testing

- [x] Unit tests
- [x] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes 

### Backwards compatibility

- [x] Add `backport-to-stable` label if the code is backwards compatible. Otherwise, list breaking changes.
