### PR TITLE
chore(*) remove the GatewayProxyType constant

### DIFF
--- a/api/mesh/v1alpha1/dataplane_helpers.go
+++ b/api/mesh/v1alpha1/dataplane_helpers.go
@@ -39,12 +39,11 @@ type ProxyType string
 const (
 	DataplaneProxyType ProxyType = "dataplane"
 	IngressProxyType   ProxyType = "ingress"
-	GatewayProxyType   ProxyType = "gateway"
 )
 
 func (t ProxyType) IsValid() error {
 	switch t {
-	case DataplaneProxyType, IngressProxyType, GatewayProxyType:
+	case DataplaneProxyType, IngressProxyType:
 		return nil
 	}
 	return errors.Errorf("%s is not a valid proxy type", t)

--- a/pkg/config/app/kuma-dp/config_test.go
+++ b/pkg/config/app/kuma-dp/config_test.go
@@ -11,7 +11,6 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	"github.com/kumahq/kuma/pkg/config"
 	kuma_dp "github.com/kumahq/kuma/pkg/config/app/kuma-dp"
 	config_types "github.com/kumahq/kuma/pkg/config/types"
@@ -146,7 +145,7 @@ var _ = Describe("Config", func() {
 		Expect(config.Load(filepath.Join("testdata", "valid-config.input.yaml"), &cfg)).Should(Succeed())
 
 		// when
-		cfg.Dataplane.ProxyType = string(mesh_proto.GatewayProxyType)
+		cfg.Dataplane.ProxyType = string("gateway")
 		Expect(cfg.Validate()).ShouldNot(Succeed())
 	})
 

--- a/pkg/xds/bootstrap/generator.go
+++ b/pkg/xds/bootstrap/generator.go
@@ -95,7 +95,7 @@ func (b *bootstrapGenerator) Generate(ctx context.Context, request types.Bootstr
 			return nil, "", err
 		}
 		return b.generateFor(*proxyId, request, "ingress", adminPort)
-	case mesh_proto.DataplaneProxyType, mesh_proto.GatewayProxyType:
+	case mesh_proto.DataplaneProxyType:
 		proxyId := core_xds.BuildProxyId(request.Mesh, request.Name)
 		dataplane, err := b.dataplaneFor(ctx, request, proxyId)
 		if err != nil {

--- a/pkg/xds/sync/dataplane_watchdog.go
+++ b/pkg/xds/sync/dataplane_watchdog.go
@@ -70,7 +70,7 @@ func (d *DataplaneWatchdog) Sync() error {
 		d.proxyTypeSettled = true
 	}
 	switch d.dpType {
-	case mesh_proto.DataplaneProxyType, mesh_proto.GatewayProxyType:
+	case mesh_proto.DataplaneProxyType:
 		return d.syncDataplane()
 	case mesh_proto.IngressProxyType:
 		return d.syncIngress()
@@ -83,7 +83,7 @@ func (d *DataplaneWatchdog) Sync() error {
 func (d *DataplaneWatchdog) Cleanup() error {
 	proxyID := core_xds.FromResourceKey(d.key)
 	switch d.dpType {
-	case mesh_proto.DataplaneProxyType, mesh_proto.GatewayProxyType:
+	case mesh_proto.DataplaneProxyType:
 		return d.dataplaneReconciler.Clear(&proxyID)
 	case mesh_proto.IngressProxyType:
 		return d.ingressReconciler.Clear(&proxyID)


### PR DESCRIPTION
### Summary

The GatewayProxyType constant is not actually used anywhere, and creates
some confusion with a dataplane operating in gateway mode. Delete it to
remove any ambiguity.

### Full changelog

N/A

### Issues resolved

N/A

### Documentation

N/A

### Testing

- [x] Unit tests
- [x] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes 

### Backwards compatibility

- [x] Add `backport-to-stable` label if the code is backwards compatible. Otherwise, list breaking changes.
