### PR TITLE
chore(*) update remaining listener filter helpers

### DIFF
--- a/pkg/xds/envoy/listeners/configurers.go
+++ b/pkg/xds/envoy/listeners/configurers.go
@@ -204,10 +204,8 @@ func HttpStaticRoute(builder *envoy_routes.RouteConfigurationBuilder) FilterChai
 // HttpDynamicRoute configures the listener filter chain to dynamically request
 // the named RouteConfiguration.
 func HttpDynamicRoute(name string) FilterChainBuilderOpt {
-	return FilterChainBuilderOptFunc(func(config *FilterChainBuilderConfig) {
-		config.AddV3(&v3.HttpDynamicRouteConfigurer{
-			RouteName: name,
-		})
+	return AddFilterChainConfigurer(&v3.HttpDynamicRouteConfigurer{
+		RouteName: name,
 	})
 }
 

--- a/pkg/xds/envoy/listeners/v3/http_route_configurer_test.go
+++ b/pkg/xds/envoy/listeners/v3/http_route_configurer_test.go
@@ -56,9 +56,7 @@ var _ = Describe("HttpScopedRouteConfigurer", func() {
 			InboundListener("inbound", "127.0.0.1", 99, xds.SocketAddressProtocolTCP),
 			FilterChain(NewFilterChainBuilder(envoy_common.APIV3).Configure(
 				HttpConnectionManager("inbound", false),
-				FilterChainBuilderOptFunc(func(c *FilterChainBuilderConfig) {
-					c.AddV3(&HttpScopedRouteConfigurer{})
-				}),
+				AddFilterChainConfigurer(&HttpScopedRouteConfigurer{}),
 			)),
 		).Build()
 


### PR DESCRIPTION
### Summary

Update the remaining listener configurer helpers. These were omitted from
previous PRs due to merge conflicts.

### Full changelog

N/A

### Issues resolved

N/A

### Documentation

N/A

### Testing

- [x] Unit tests
- [x] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes 

### Backwards compatibility

- [x] Add `backport-to-stable` label if the code is backwards compatible. Otherwise, list breaking changes.
