### PR TITLE
fix(kuma-cp) add more listener configurers

### DIFF
--- a/pkg/xds/envoy/listeners/configurers.go
+++ b/pkg/xds/envoy/listeners/configurers.go
@@ -1,6 +1,9 @@
 package listeners
 
 import (
+	envoy_listener "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
+	"google.golang.org/protobuf/types/known/wrapperspb"
+
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	mesh_core "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	core_xds "github.com/kumahq/kuma/pkg/core/xds"
@@ -266,4 +269,26 @@ func DNS(vips map[string]string, emptyDnsPort uint32) ListenerBuilderOpt {
 		VIPs:         vips,
 		EmptyDNSPort: emptyDnsPort,
 	})
+}
+
+func ConnectionBufferLimit(bytes uint32) ListenerBuilderOpt {
+	return AddListenerConfigurer(
+		v3.ListenerMustConfigureFunc(func(l *envoy_listener.Listener) {
+			l.PerConnectionBufferLimitBytes = wrapperspb.UInt32(bytes)
+		}))
+}
+
+func EnableReusePort(enable bool) ListenerBuilderOpt {
+	return AddListenerConfigurer(
+		v3.ListenerMustConfigureFunc(func(l *envoy_listener.Listener) {
+			// TODO(jpeach) in Envoy 1.20, this field is deprecated in favor of EnableReusePort.
+			l.ReusePort = enable
+		}))
+}
+
+func EnableFreebind(enable bool) ListenerBuilderOpt {
+	return AddListenerConfigurer(
+		v3.ListenerMustConfigureFunc(func(l *envoy_listener.Listener) {
+			l.Freebind = wrapperspb.Bool(enable)
+		}))
 }

--- a/pkg/xds/envoy/listeners/v3/configurer.go
+++ b/pkg/xds/envoy/listeners/v3/configurer.go
@@ -17,3 +17,27 @@ type FilterChainConfigurer interface {
 	// Configure configures a single aspect on a given Envoy filter chain.
 	Configure(filterChain *envoy_listener.FilterChain) error
 }
+
+// ListenerConfigureFunc adapts a configuration function to the
+// ListenerConfigurer interface.
+type ListenerConfigureFunc func(listener *envoy_listener.Listener) error
+
+func (f ListenerConfigureFunc) Configure(listener *envoy_listener.Listener) error {
+	if f != nil {
+		return f(listener)
+	}
+
+	return nil
+}
+
+// ListenerMustConfigureFunc adapts a configuration function that never
+// fails to the ListenerConfigurer interface.
+type ListenerMustConfigureFunc func(listener *envoy_listener.Listener)
+
+func (f ListenerMustConfigureFunc) Configure(listener *envoy_listener.Listener) error {
+	if f != nil {
+		f(listener)
+	}
+
+	return nil
+}

--- a/pkg/xds/envoy/listeners/v3/listener_configurer_test.go
+++ b/pkg/xds/envoy/listeners/v3/listener_configurer_test.go
@@ -1,0 +1,68 @@
+package v3_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+
+	util_proto "github.com/kumahq/kuma/pkg/util/proto"
+	"github.com/kumahq/kuma/pkg/xds/envoy"
+	. "github.com/kumahq/kuma/pkg/xds/envoy/listeners"
+	v3 "github.com/kumahq/kuma/pkg/xds/envoy/listeners/v3"
+)
+
+var _ = Describe("Miscellaneous Listener configurers", func() {
+
+	type testCase struct {
+		opt      ListenerBuilderOpt
+		expected string
+	}
+
+	DescribeTable("should generate proper Envoy config",
+		func(given testCase) {
+			// when
+			listener := NewListenerBuilder(envoy.APIV3)
+
+			listener.Configure(given.opt)
+
+			// then
+			resource, err := listener.Build()
+			Expect(err).ToNot(HaveOccurred())
+
+			// when
+			actual, err := util_proto.ToYAML(resource)
+			Expect(err).ToNot(HaveOccurred())
+			// and
+			Expect(actual).To(MatchYAML(given.expected))
+		},
+		Entry("noop 1", testCase{
+			opt:      AddListenerConfigurer(v3.ListenerConfigureFunc(nil)),
+			expected: "{}",
+		}),
+		Entry("noop 2", testCase{
+			opt:      AddListenerConfigurer(v3.ListenerMustConfigureFunc(nil)),
+			expected: "{}",
+		}),
+		Entry("connection buffer limit", testCase{
+			opt:      ConnectionBufferLimit(123),
+			expected: "perConnectionBufferLimitBytes: 123",
+		}),
+		Entry("reuse port enabled", testCase{
+			opt:      EnableReusePort(true),
+			expected: "reusePort: true",
+		}),
+		Entry("reuse port disabled", testCase{
+			opt:      EnableReusePort(false),
+			expected: "{}",
+		}),
+		Entry("enable freebind", testCase{
+			opt:      EnableFreebind(true),
+			expected: "freebind: true",
+		}),
+		Entry("disable freebind", testCase{
+			opt:      EnableFreebind(false),
+			expected: "freebind: false",
+		}),
+	)
+
+})


### PR DESCRIPTION
### Summary

Add listener configurer helper adapters and some miscellaneous
configurers to set Listener fields.

### Full changelog

N/A

### Issues resolved

N/A

### Documentation

N/A

### Testing

- [x] Unit tests
- [x] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes 

### Backwards compatibility

- [x] Add `backport-to-stable` label if the code is backwards compatible. Otherwise, list breaking changes.
