### PR TITLE
chore(*) fix information log output message format

### DIFF
--- a/app/kuma-cp/cmd/root.go
+++ b/app/kuma-cp/cmd/root.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 
 	"github.com/spf13/cobra"
 
@@ -37,8 +38,13 @@ func newRootCmd() *cobra.Command {
 			}
 
 			if args.outputPath != "" {
-				fmt.Printf("logs will be stored in %v", args.outputPath)
-				core.SetLogger(core.NewLoggerWithRotation(level, args.outputPath, args.maxSize, args.maxBackups, args.maxAge))
+				output, err := filepath.Abs(args.outputPath)
+				if err != nil {
+					return err
+				}
+
+				fmt.Printf("%s: logs will be stored in %q\n", "kuma-cp", output)
+				core.SetLogger(core.NewLoggerWithRotation(level, output, args.maxSize, args.maxBackups, args.maxAge))
 			} else {
 				core.SetLogger(core.NewLogger(level))
 			}

--- a/app/kuma-dp/cmd/root.go
+++ b/app/kuma-dp/cmd/root.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 
 	"github.com/spf13/cobra"
 
@@ -35,8 +36,13 @@ func NewRootCmd(rootCtx *RootContext) *cobra.Command {
 				return err
 			}
 			if args.outputPath != "" {
-				fmt.Printf("logs will be stored in %v", args.outputPath)
-				core.SetLogger(core.NewLoggerWithRotation(level, args.outputPath, args.maxSize, args.maxBackups, args.maxAge))
+				output, err := filepath.Abs(args.outputPath)
+				if err != nil {
+					return err
+				}
+
+				fmt.Printf("%s: logs will be stored in %q\n", "kuma-dp", output)
+				core.SetLogger(core.NewLoggerWithRotation(level, output, args.maxSize, args.maxBackups, args.maxAge))
 			} else {
 				core.SetLogger(core.NewLogger(level))
 			}

--- a/app/kuma-prometheus-sd/cmd/root.go
+++ b/app/kuma-prometheus-sd/cmd/root.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 
 	"github.com/spf13/cobra"
 
@@ -35,8 +36,13 @@ func newRootCmd() *cobra.Command {
 				return err
 			}
 			if args.outputPath != "" {
-				fmt.Printf("logs will be stored in %v", args.outputPath)
-				core.SetLogger(core.NewLoggerWithRotation(level, args.outputPath, args.maxSize, args.maxBackups, args.maxAge))
+				output, err := filepath.Abs(args.outputPath)
+				if err != nil {
+					return err
+				}
+
+				fmt.Printf("%s: logs will be stored in %q\n", "kuma-prometheus-sd", output)
+				core.SetLogger(core.NewLoggerWithRotation(level, output, args.maxSize, args.maxBackups, args.maxAge))
 			} else {
 				core.SetLogger(core.NewLogger(level))
 			}


### PR DESCRIPTION
### Summary

When using a log output directory, the informational startup message
did not end in a newline, which causes garbled output if there is a
subsequent error. Add a newline and take the opportunity to quote and
emit the absolute log output path.

### Full changelog

N/A

### Issues resolved

This updates #2391.

### Documentation

N/A

### Testing

- [x] Unit tests
- [x] E2E tests
- [x] Manual testing on Universal
- [ ] Manual testing on Kubernetes 

### Backwards compatibility

- [x] Add `backport-to-stable` label if the code is backwards compatible. Otherwise, list breaking changes.
