### PR TITLE
fix(kuma-cp) set better keep-alive for bootstrap

### DIFF
--- a/pkg/xds/bootstrap/template_v3.go
+++ b/pkg/xds/bootstrap/template_v3.go
@@ -116,7 +116,10 @@ static_resources:
     upstream_connection_options:
       # configure a TCP keep-alive to detect and reconnect to the admin
       # server in the event of a TCP socket half open connection
-      tcp_keepalive: {}
+      tcp_keepalive:
+        keepalive_probes: 3
+        keepalive_time: 10
+        keepalive_interval: 10
     load_assignment:
       cluster_name: access_log_sink
       endpoints:
@@ -133,7 +136,10 @@ static_resources:
     upstream_connection_options:
       # configure a TCP keep-alive to detect and reconnect to the admin
       # server in the event of a TCP socket half open connection
-      tcp_keepalive: {}
+      tcp_keepalive:
+        keepalive_probes: 3
+        keepalive_time: 10
+        keepalive_interval: 10
     load_assignment:
       cluster_name: ads_cluster
       endpoints:

--- a/pkg/xds/bootstrap/testdata/bootstrap.k8s.golden.yaml
+++ b/pkg/xds/bootstrap/testdata/bootstrap.k8s.golden.yaml
@@ -60,7 +60,10 @@ staticResources:
     name: access_log_sink
     type: STATIC
     upstreamConnectionOptions:
-      tcpKeepalive: {}
+      tcpKeepalive:
+        keepaliveInterval: 10
+        keepaliveProbes: 3
+        keepaliveTime: 10
   - connectTimeout: 1s
     http2ProtocolOptions: {}
     loadAssignment:
@@ -88,7 +91,10 @@ staticResources:
         sni: localhost
     type: STRICT_DNS
     upstreamConnectionOptions:
-      tcpKeepalive: {}
+      tcpKeepalive:
+        keepaliveInterval: 10
+        keepaliveProbes: 3
+        keepaliveTime: 10
 statsConfig:
   statsTags:
   - regex: ^grpc\.((.+)\.)

--- a/pkg/xds/bootstrap/testdata/bootstrap.overridden.golden.yaml
+++ b/pkg/xds/bootstrap/testdata/bootstrap.overridden.golden.yaml
@@ -67,7 +67,10 @@ staticResources:
     name: access_log_sink
     type: STATIC
     upstreamConnectionOptions:
-      tcpKeepalive: {}
+      tcpKeepalive:
+        keepaliveInterval: 10
+        keepaliveProbes: 3
+        keepaliveTime: 10
   - connectTimeout: 1s
     http2ProtocolOptions: {}
     loadAssignment:
@@ -95,7 +98,10 @@ staticResources:
         sni: localhost
     type: STRICT_DNS
     upstreamConnectionOptions:
-      tcpKeepalive: {}
+      tcpKeepalive:
+        keepaliveInterval: 10
+        keepaliveProbes: 3
+        keepaliveTime: 10
 statsConfig:
   statsTags:
   - regex: ^grpc\.((.+)\.)

--- a/pkg/xds/bootstrap/testdata/bootstrap.universal.golden.yaml
+++ b/pkg/xds/bootstrap/testdata/bootstrap.universal.golden.yaml
@@ -60,7 +60,10 @@ staticResources:
     name: access_log_sink
     type: STATIC
     upstreamConnectionOptions:
-      tcpKeepalive: {}
+      tcpKeepalive:
+        keepaliveInterval: 10
+        keepaliveProbes: 3
+        keepaliveTime: 10
   - connectTimeout: 1s
     http2ProtocolOptions: {}
     loadAssignment:
@@ -88,7 +91,10 @@ staticResources:
         sni: localhost
     type: STRICT_DNS
     upstreamConnectionOptions:
-      tcpKeepalive: {}
+      tcpKeepalive:
+        keepaliveInterval: 10
+        keepaliveProbes: 3
+        keepaliveTime: 10
 statsConfig:
   statsTags:
   - regex: ^grpc\.((.+)\.)

--- a/pkg/xds/bootstrap/testdata/generator.custom-config-minimal-request.golden.yaml
+++ b/pkg/xds/bootstrap/testdata/generator.custom-config-minimal-request.golden.yaml
@@ -60,7 +60,10 @@ staticResources:
     name: access_log_sink
     type: STATIC
     upstreamConnectionOptions:
-      tcpKeepalive: {}
+      tcpKeepalive:
+        keepaliveInterval: 10
+        keepaliveProbes: 3
+        keepaliveTime: 10
   - connectTimeout: 2s
     http2ProtocolOptions: {}
     loadAssignment:
@@ -88,7 +91,10 @@ staticResources:
         sni: localhost
     type: STRICT_DNS
     upstreamConnectionOptions:
-      tcpKeepalive: {}
+      tcpKeepalive:
+        keepaliveInterval: 10
+        keepaliveProbes: 3
+        keepaliveTime: 10
 statsConfig:
   statsTags:
   - regex: ^grpc\.((.+)\.)

--- a/pkg/xds/bootstrap/testdata/generator.custom-config.golden.yaml
+++ b/pkg/xds/bootstrap/testdata/generator.custom-config.golden.yaml
@@ -74,7 +74,10 @@ staticResources:
     name: access_log_sink
     type: STATIC
     upstreamConnectionOptions:
-      tcpKeepalive: {}
+      tcpKeepalive:
+        keepaliveInterval: 10
+        keepaliveProbes: 3
+        keepaliveTime: 10
   - connectTimeout: 2s
     http2ProtocolOptions: {}
     loadAssignment:
@@ -102,7 +105,10 @@ staticResources:
         sni: localhost
     type: STRICT_DNS
     upstreamConnectionOptions:
-      tcpKeepalive: {}
+      tcpKeepalive:
+        keepaliveInterval: 10
+        keepaliveProbes: 3
+        keepaliveTime: 10
 statsConfig:
   statsTags:
   - regex: ^grpc\.((.+)\.)

--- a/pkg/xds/bootstrap/testdata/generator.default-config-minimal-request.golden.yaml
+++ b/pkg/xds/bootstrap/testdata/generator.default-config-minimal-request.golden.yaml
@@ -53,7 +53,10 @@ staticResources:
     name: access_log_sink
     type: STATIC
     upstreamConnectionOptions:
-      tcpKeepalive: {}
+      tcpKeepalive:
+        keepaliveInterval: 10
+        keepaliveProbes: 3
+        keepaliveTime: 10
   - connectTimeout: 1s
     http2ProtocolOptions: {}
     loadAssignment:
@@ -81,7 +84,10 @@ staticResources:
         sni: localhost
     type: STRICT_DNS
     upstreamConnectionOptions:
-      tcpKeepalive: {}
+      tcpKeepalive:
+        keepaliveInterval: 10
+        keepaliveProbes: 3
+        keepaliveTime: 10
 statsConfig:
   statsTags:
   - regex: ^grpc\.((.+)\.)

--- a/pkg/xds/bootstrap/testdata/generator.default-config.golden.yaml
+++ b/pkg/xds/bootstrap/testdata/generator.default-config.golden.yaml
@@ -69,7 +69,10 @@ staticResources:
     name: access_log_sink
     type: STATIC
     upstreamConnectionOptions:
-      tcpKeepalive: {}
+      tcpKeepalive:
+        keepaliveInterval: 10
+        keepaliveProbes: 3
+        keepaliveTime: 10
   - connectTimeout: 1s
     http2ProtocolOptions: {}
     loadAssignment:
@@ -97,7 +100,10 @@ staticResources:
         sni: localhost
     type: STRICT_DNS
     upstreamConnectionOptions:
-      tcpKeepalive: {}
+      tcpKeepalive:
+        keepaliveInterval: 10
+        keepaliveProbes: 3
+        keepaliveTime: 10
 statsConfig:
   statsTags:
   - regex: ^grpc\.((.+)\.)

--- a/pkg/xds/bootstrap/testdata/generator.default-config.kubernetes.golden.yaml
+++ b/pkg/xds/bootstrap/testdata/generator.default-config.kubernetes.golden.yaml
@@ -57,7 +57,10 @@ staticResources:
     name: access_log_sink
     type: STATIC
     upstreamConnectionOptions:
-      tcpKeepalive: {}
+      tcpKeepalive:
+        keepaliveInterval: 10
+        keepaliveProbes: 3
+        keepaliveTime: 10
   - connectTimeout: 1s
     http2ProtocolOptions: {}
     loadAssignment:
@@ -85,7 +88,10 @@ staticResources:
         sni: localhost
     type: STRICT_DNS
     upstreamConnectionOptions:
-      tcpKeepalive: {}
+      tcpKeepalive:
+        keepaliveInterval: 10
+        keepaliveProbes: 3
+        keepaliveTime: 10
 statsConfig:
   statsTags:
   - regex: ^grpc\.((.+)\.)

--- a/pkg/xds/bootstrap/testdata/generator.default-config.kubernetes.ipv6.golden.yaml
+++ b/pkg/xds/bootstrap/testdata/generator.default-config.kubernetes.ipv6.golden.yaml
@@ -57,7 +57,10 @@ staticResources:
     name: access_log_sink
     type: STATIC
     upstreamConnectionOptions:
-      tcpKeepalive: {}
+      tcpKeepalive:
+        keepaliveInterval: 10
+        keepaliveProbes: 3
+        keepaliveTime: 10
   - connectTimeout: 1s
     http2ProtocolOptions: {}
     loadAssignment:
@@ -85,7 +88,10 @@ staticResources:
         sni: fd00:a123::1
     type: STATIC
     upstreamConnectionOptions:
-      tcpKeepalive: {}
+      tcpKeepalive:
+        keepaliveInterval: 10
+        keepaliveProbes: 3
+        keepaliveTime: 10
 statsConfig:
   statsTags:
   - regex: ^grpc\.((.+)\.)


### PR DESCRIPTION
### Summary

In some cases, when zone-ingress pod in kubernetes was restarted in parallel with zone-cp and if it was very quickly recreated it was able to connect to old instance of zone-cp and as the default values for keep-alive stands that it will start sending keep-alive probes after 2h, so it was possible that our TCP connection will be in half-closed state.

### Testing

- [ ] Unit tests
- [ ] E2E tests
- [ ] Manual testing on Universal
- [x] Manual testing on Kubernetes 

### Backwards compatibility

- [x] Add `backport-to-stable` label if the code is backwards compatible. Otherwise, list breaking changes.
