### PR TITLE
fix(kuma-cp) handle missing connection info

### DIFF
--- a/pkg/xds/sync/dataplane_watchdog.go
+++ b/pkg/xds/sync/dataplane_watchdog.go
@@ -122,7 +122,10 @@ func (d *DataplaneWatchdog) syncDataplane() error {
 
 // syncIngress synces state of Ingress Dataplane. Notice that it does not use Mesh Hash yet because Ingress supports many Meshes.
 func (d *DataplaneWatchdog) syncIngress() error {
-	envoyCtx := d.xdsContextBuilder.buildContext(d.key)
+	envoyCtx, err := d.xdsContextBuilder.buildContext(d.key)
+	if err != nil {
+		return err
+	}
 	proxy, err := d.ingressProxyBuilder.build(d.key)
 	if err != nil {
 		return err


### PR DESCRIPTION
### Summary

https://github.com/kumahq/kuma/pull/2342/files#diff-4e677d8a7546b3383197877f4c14437d4b356b1ef10a13d7c81fdc8e05b45632R65 was merged without resolving the todo.

In a case when we spin down data plane proxy, technically we can remove connection info from the map and still have one more `Sync` in DP watchdog. When this happens, CP fails.

### Documentation

- [X] No docs

### Testing

- [ ] Unit tests
- [ ] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes 

### Backwards compatibility

- [X] Add `backport-to-stable` label if the code is backwards compatible. Otherwise, list breaking changes.
