### PR TITLE
chore(*) make port validation consistent

### DIFF
--- a/pkg/core/resources/apis/mesh/dataplane_validator_test.go
+++ b/pkg/core/resources/apis/mesh/dataplane_validator_test.go
@@ -464,9 +464,9 @@ var _ = Describe("Dataplane", func() {
 			expected: `
                 violations:
                 - field: networking.inbound[0].port
-                  message: port has to be in range of [1, 65535]
+                  message: port must be in the range [1, 65535]
                 - field: networking.inbound[1].port
-                  message: port has to be in range of [1, 65535]`,
+                  message: port must be in the range [1, 65535]`,
 		}),
 		Entry("networking.inbound: servicePort out of the range", testCase{
 			dataplane: `
@@ -486,7 +486,7 @@ var _ = Describe("Dataplane", func() {
 			expected: `
                 violations:
                 - field: networking.inbound[0].servicePort
-                  message: servicePort has to be in range of [0, 65535]`,
+                  message: port must be in the range [1, 65535]`,
 		}),
 		Entry("networking.inbound: invalid address", testCase{
 			dataplane: `
@@ -704,9 +704,9 @@ var _ = Describe("Dataplane", func() {
 			expected: `
                 violations:
                 - field: networking.outbound[0].port
-                  message: port has to be in range of [1, 65535]
+                  message: port must be in the range [1, 65535]
                 - field: networking.outbound[1].port
-                  message: port has to be in range of [1, 65535]`,
+                  message: port must be in the range [1, 65535]`,
 		}),
 		Entry("networking.outbound: invalid address", testCase{
 			dataplane: `
@@ -924,7 +924,7 @@ var _ = Describe("Dataplane", func() {
                 - field: networking.ingress.publicAddress.address
                   message: address has to be valid IP address or domain name
                 - field: networking.ingress.publicPort
-                  message: port has to be in range of [1, 65535]`,
+                  message: port must be in the range [1, 65535]`,
 		}),
 		Entry("inbound service address", testCase{
 			dataplane: `
@@ -1071,9 +1071,9 @@ var _ = Describe("Dataplane", func() {
 			expected: `
                 violations:
                 - field: probes.port
-                  message: port has to be in range of [1, 65535]
+                  message: port must be in the range [1, 65535]
                 - field: probes.endpoints[1].inboundPort
-                  message: port has to be in range of [1, 65535]
+                  message: port must be in the range [1, 65535]
                 - field: probes.endpoints[1].inboundPath
                   message: should be a valid URL Path
                 - field: probes.endpoints[1].path

--- a/pkg/core/resources/apis/mesh/externalservice_validator.go
+++ b/pkg/core/resources/apis/mesh/externalservice_validator.go
@@ -54,12 +54,12 @@ func validateExtarnalServiceAddress(path validators.PathBuilder, address string)
 		err.AddViolationAt(path.Field("address"), "address has to be a valid IP address or a domain name")
 	}
 
-	iport, e := strconv.Atoi(port)
+	iport, e := strconv.ParseUint(port, 10, 32)
 	if e != nil {
 		err.AddViolationAt(path.Field("address"), "unable to parse port in address")
 	}
-	if iport < 1 || iport > 65535 {
-		err.AddViolationAt(path.Field("address"), "port has to be in range of [1, 65535]")
-	}
+
+	err.Add(ValidatePort(path.Field("address"), uint32(iport)))
+
 	return err
 }

--- a/pkg/core/resources/apis/mesh/externalservice_validator_test.go
+++ b/pkg/core/resources/apis/mesh/externalservice_validator_test.go
@@ -157,7 +157,7 @@ var _ = Describe("ExternalService", func() {
                 - field: networking.address
                   message: unable to parse port in address
                 - field: networking.address
-                  message: port has to be in range of [1, 65535]`,
+                  message: port must be in the range [1, 65535]`,
 		}),
 		Entry("networking.address: invalid format IPv6", testCase{
 			dataplane: `
@@ -178,7 +178,7 @@ var _ = Describe("ExternalService", func() {
                 - field: networking.address
                   message: unable to parse port in address
                 - field: networking.address
-                  message: port has to be in range of [1, 65535]`,
+                  message: port must be in the range [1, 65535]`,
 		}),
 		Entry("networking: port out of range", testCase{
 			dataplane: `
@@ -193,7 +193,7 @@ var _ = Describe("ExternalService", func() {
 			expected: `
                 violations:
                 - field: networking.address
-                  message: port has to be in range of [1, 65535]`,
+                  message: port must be in the range [1, 65535]`,
 		}),
 		Entry("tags: empty service tag", testCase{
 			dataplane: `

--- a/pkg/core/resources/apis/mesh/mesh_validator.go
+++ b/pkg/core/resources/apis/mesh/mesh_validator.go
@@ -165,10 +165,7 @@ func validateDatadog(cfgStr *structpb.Struct) validators.ValidationError {
 		verr.AddViolation("address", "cannot be empty")
 	}
 
-	if cfg.Port > 0xFFFF || cfg.Port < 1 {
-		verr.AddViolation("port", "must be in the range 1 to 65535")
-	}
-
+	verr.Add(ValidatePort(validators.RootedAt("port"), cfg.GetPort()))
 	return verr
 }
 

--- a/pkg/core/resources/apis/mesh/validators.go
+++ b/pkg/core/resources/apis/mesh/validators.go
@@ -140,6 +140,17 @@ func ValidateThreshold(path validators.PathBuilder, threshold uint32) (err valid
 	return
 }
 
+// ValidatePort validates that port is a valid TCP or UDP port number.
+func ValidatePort(path validators.PathBuilder, port uint32) validators.ValidationError {
+	err := validators.ValidationError{}
+
+	if port == 0 || port > 65535 {
+		err.AddViolationAt(path, "port must be in the range [1, 65535]")
+	}
+
+	return err
+}
+
 func AllowedValuesHint(values ...string) string {
 	options := strings.Join(values, ", ")
 	if len(values) == 0 {

--- a/pkg/core/resources/apis/mesh/zone_ingress_validator.go
+++ b/pkg/core/resources/apis/mesh/zone_ingress_validator.go
@@ -26,15 +26,13 @@ func (r *ZoneIngressResource) validateNetworking(path validators.PathBuilder, ne
 	if networking.GetAdvertisedAddress() != "" {
 		err.Add(validateAddress(path.Field("advertisedAddress"), networking.GetAdvertisedAddress()))
 	}
-	if networking.GetPort() == 0 {
-		err.AddViolationAt(path.Field("port"), `port has to be defined`)
+
+	err.Add(ValidatePort(path.Field("port"), networking.GetPort()))
+
+	if networking.GetAdvertisedPort() != 0 {
+		err.Add(ValidatePort(path.Field("advertisedPort"), networking.GetAdvertisedPort()))
 	}
-	if networking.GetPort() > 65535 {
-		err.AddViolationAt(path.Field("port"), `port has to be in range of [1, 65535]`)
-	}
-	if networking.GetAdvertisedPort() > 65535 {
-		err.AddViolationAt(path.Field("advertisedPort"), `port has to be in range of [1, 65535]`)
-	}
+
 	return err
 }
 

--- a/pkg/core/resources/apis/mesh/zone_ingress_validator_test.go
+++ b/pkg/core/resources/apis/mesh/zone_ingress_validator_test.go
@@ -120,7 +120,7 @@ var _ = Describe("Dataplane", func() {
 			expected: `
                 violations:
                 - field: networking.port
-                  message: port has to be defined`,
+                  message: port must be in the range [1, 65535]`,
 		}),
 		Entry("invalid advertised address, port and available service", testCase{
 			dataplane: `
@@ -152,7 +152,7 @@ var _ = Describe("Dataplane", func() {
                 - field: networking.advertisedAddress.address
                   message: address has to be valid IP address or domain name
                 - field: networking.advertisedPort
-                  message: port has to be in range of [1, 65535]
+                  message: port must be in the range [1, 65535]
                 - field: availableService[2].tags["kuma.io/service"]
                   message: cannot be empty
                 - field: availableService[3].tags.tags["kuma.io/service"]


### PR DESCRIPTION
### Summary

Introduce a helper to make TCP/UDP port validation checks
consistent across the API.

### Full changelog

N/A

### Issues resolved

N/A

### Documentation

N/A

### Testing

- [x] Unit tests
- [x] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes 

### Backwards compatibility

- [x] Add `backport-to-stable` label if the code is backwards compatible. Otherwise, list breaking changes.
