### PR TITLE
chore(*) Kuma 1.2.3 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # CHANGELOG
 
+## [1.2.3]
+> Released on 2021/07/29
+ 
+Changes:
+* fix(kumactl) warn about fail to check the CP version [#2438](https://github.com//kumahq/kuma/pull/2438)
+* fix(kuma-cp) handle missing connection info [#2439](https://github.com//kumahq/kuma/pull/2439)
+* chore(xds) rename logger to have consistent naming style [#2375](https://github.com//kumahq/kuma/pull/2375)
+  👍contributed by burntcarrot
+* fix(kuma-cp) set better keep-alive for bootstrap
+* fix(kuma-dp) validate the DP proxy type [#2186](https://github.com//kumahq/kuma/pull/2186)
+* fix(kuma-cp) use the typed config for TLS Inspector [#2373](https://github.com//kumahq/kuma/pull/2373)
+
 ## [1.2.2]
 > Released on 2021/07/16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Changes:
 * fix(kuma-cp) handle missing connection info [#2439](https://github.com//kumahq/kuma/pull/2439)
 * chore(xds) rename logger to have consistent naming style [#2375](https://github.com//kumahq/kuma/pull/2375)
   👍contributed by burntcarrot
-* fix(kuma-cp) set better keep-alive for bootstrap
+* fix(kuma-cp) set better keep-alive for bootstrap [#2432](https://github.com//kumahq/kuma/pull/2432)
 * fix(kuma-dp) validate the DP proxy type [#2186](https://github.com//kumahq/kuma/pull/2186)
 * fix(kuma-cp) use the typed config for TLS Inspector [#2373](https://github.com//kumahq/kuma/pull/2373)
 


### PR DESCRIPTION
### Summary

Changelog for Kuma 1.2.3

### Backwards compatibility

- [X] Add `backport-to-stable` label if the code is backwards compatible. Otherwise, list breaking changes.
