### PR TITLE
chore(ci) drop explicit govet runs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -714,7 +714,7 @@ jobs:
     - run:
         name: "Download Go modules"
         command: |
-          make vet
+          go mod download
     # since execution of go commands might change contents of "go.sum", we have to save cache immediately
     - save_cache:
         key: go.mod-{{ .Branch }}-{{ checksum "go.sum" }}

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,10 +1,11 @@
 linters:
   enable:
-    - gocritic
-    - unconvert
     - bodyclose
-    - whitespace
+    - gocritic
+    - govet
     - misspell
+    - unconvert
+    - whitespace
 
 run:
   skip-files:

--- a/mk/check.mk
+++ b/mk/check.mk
@@ -11,10 +11,6 @@ fmt/go: ## Dev: Run go fmt
 fmt/proto: ## Dev: Run clang-format on .proto files
 	which $(CLANG_FORMAT_PATH) && find . -name '*.proto' | xargs -L 1 $(CLANG_FORMAT_PATH) -i || true
 
-.PHONY: vet
-vet: ## Dev: Run go vet
-	go vet $(GOFLAGS) ./...
-
 .PHONY: tidy
 tidy:
 	@TOP=$(shell pwd) && \
@@ -50,6 +46,6 @@ ginkgo/unfocus:
 	$(GOPATH_BIN_DIR)/ginkgo unfocus
 
 .PHONY: check
-check: generate fmt vet docs helm-lint golangci-lint imports tidy helm-docs ginkgo/unfocus ## Dev: Run code checks (go fmt, go vet, ...)
+check: generate fmt docs helm-lint golangci-lint imports tidy helm-docs ginkgo/unfocus ## Dev: Run code checks (go fmt, go vet, ...)
 	$(MAKE) generate manifests -C pkg/plugins/resources/k8s/native
 	git diff --quiet || test $$(git diff --name-only | grep -v -e 'go.mod$$' -e 'go.sum$$' | wc -l) -eq 0 || ( echo "The following changes (result of code generators and code checks) have been detected:" && git --no-pager diff && false ) # fail if Git working tree is dirty

--- a/mk/kind.mk
+++ b/mk/kind.mk
@@ -178,7 +178,7 @@ kind/deploy/example-app:
 	@KUBECONFIG=$(KIND_KUBECONFIG) kubectl apply -n $(EXAMPLE_NAMESPACE) -f dev/examples/k8s/example-app/example-app.yaml
 
 .PHONY: run/k8s
-run/k8s: fmt vet ## Dev: Run Control Plane locally in Kubernetes mode
+run/k8s: ## Dev: Run Control Plane locally in Kubernetes mode
 	@KUBECONFIG=$(KIND_KUBECONFIG) $(MAKE) crd/upgrade -C pkg/plugins/resources/k8s/native
 	KUBECONFIG=$(KIND_KUBECONFIG) \
 	KUMA_ENVIRONMENT=kubernetes \

--- a/mk/run.mk
+++ b/mk/run.mk
@@ -13,7 +13,7 @@ run/universal/postgres/ssl: POSTGRES_SSL_ROOT_CERT_PATH=$(TOOLS_DIR)/postgres/ss
 run/universal/postgres/ssl: run/universal/postgres ## Dev: Run Control Plane locally in universal mode with Postgres store and SSL enabled
 
 .PHONY: run/universal/postgres
-run/universal/postgres: fmt vet ## Dev: Run Control Plane locally in universal mode with Postgres store
+run/universal/postgres: ## Dev: Run Control Plane locally in universal mode with Postgres store
 	KUMA_ENVIRONMENT=universal \
 	KUMA_STORE_TYPE=postgres \
 	KUMA_STORE_POSTGRES_HOST=localhost \


### PR DESCRIPTION
### Summary

govet already runs as part of golangci-lint, so we can save some time
by not running the stand-alone version.

### Full changelog

N/A

### Issues resolved

N/A

### Documentation

N/A

### Testing

N/A

### Backwards compatibility

- [x] Add `backport-to-stable` label if the code is backwards compatible. Otherwise, list breaking changes.
