### PR TITLE
feat(*) register the gateway resource type

### DIFF
--- a/app/kumactl/cmd/gateway.go
+++ b/app/kumactl/cmd/gateway.go
@@ -1,0 +1,12 @@
+// +build gateway
+
+package cmd
+
+import (
+	kumactl_cmd "github.com/kumahq/kuma/app/kumactl/pkg/cmd"
+	gateway "github.com/kumahq/kuma/pkg/plugins/runtime/gateway/kumactl"
+)
+
+func init() {
+	kumactl_cmd.Plugins = append(kumactl_cmd.Plugins, &gateway.Plugin{})
+}

--- a/app/kumactl/cmd/root.go
+++ b/app/kumactl/cmd/root.go
@@ -109,7 +109,17 @@ func NewRootCmd(root *kumactl_cmd.RootContext) *cobra.Command {
 }
 
 func DefaultRootCmd() *cobra.Command {
-	return NewRootCmd(kumactl_cmd.DefaultRootContext())
+	root := kumactl_cmd.DefaultRootContext()
+	for _, p := range kumactl_cmd.Plugins {
+		p.CustomizeContext(root)
+	}
+
+	cmd := NewRootCmd(root)
+	for _, p := range kumactl_cmd.Plugins {
+		p.CustomizeCommand(cmd)
+	}
+
+	return cmd
 }
 
 // Execute adds all child commands to the root command and sets flags appropriately.

--- a/app/kumactl/pkg/cmd/find.go
+++ b/app/kumactl/pkg/cmd/find.go
@@ -1,0 +1,17 @@
+package cmd
+
+import "github.com/spf13/cobra"
+
+func FindSubCommand(cmd *cobra.Command, name ...string) *cobra.Command {
+	if len(name) == 0 {
+		return cmd
+	}
+
+	for _, command := range cmd.Commands() {
+		if command.Name() == name[0] {
+			return FindSubCommand(command, name[1:]...)
+		}
+	}
+
+	return nil
+}

--- a/app/kumactl/pkg/cmd/plugin.go
+++ b/app/kumactl/pkg/cmd/plugin.go
@@ -1,0 +1,16 @@
+package cmd
+
+import "github.com/spf13/cobra"
+
+type Plugin interface {
+	// CustomizeContext is a hook that allows a plugin to customize
+	// the kumactl root context before it is used to build the root
+	// command.
+	CustomizeContext(*RootContext)
+
+	// CustomizeCommand is a hook that allows a plugin to customize
+	// the kumactl root command after it has been created.
+	CustomizeCommand(*cobra.Command)
+}
+
+var Plugins []Plugin

--- a/mk/build.mk
+++ b/mk/build.mk
@@ -36,6 +36,13 @@ BUILD_RELEASE_BINARIES := kuma-cp kuma-dp kumactl kuma-prometheus-sd coredns
 # gateway plugin. Experimental means "for experiments", NOT "for production".
 BUILD_WITH_EXPERIMENTAL_GATEWAY ?= N
 
+# Build_Go_Application is a build command for the Kuma Go applications.
+ifeq ($(BUILD_WITH_EXPERIMENTAL_GATEWAY),N)
+Build_Go_Application = $(GO_BUILD) -o $(BUILD_ARTIFACTS_DIR)/$(notdir $@)/$(notdir $@) ./app/$(notdir $@)
+else
+Build_Go_Application = $(GO_BUILD) -tags gateway -o $(BUILD_ARTIFACTS_DIR)/$(notdir $@)/$(notdir $@) ./app/$(notdir $@)
+endif
+
 .PHONY: build
 build: build/release build/test
 
@@ -59,19 +66,15 @@ build/test/linux-amd64:
 
 .PHONY: build/kuma-cp
 build/kuma-cp: ## Dev: Build `Control Plane` binary
-ifeq ($(BUILD_WITH_EXPERIMENTAL_GATEWAY),N)
-	$(GO_BUILD) -o ${BUILD_ARTIFACTS_DIR}/kuma-cp/kuma-cp ./app/kuma-cp
-else
-	$(GO_BUILD) -tags gateway -o ${BUILD_ARTIFACTS_DIR}/kuma-cp/kuma-cp ./app/kuma-cp
-endif
+	$(Build_Go_Application)
 
 .PHONY: build/kuma-dp
 build/kuma-dp: ## Dev: Build `kuma-dp` binary
-	$(GO_BUILD) -o ${BUILD_ARTIFACTS_DIR}/kuma-dp/kuma-dp ./app/kuma-dp
+	$(Build_Go_Application)
 
 .PHONY: build/kumactl
 build/kumactl: ## Dev: Build `kumactl` binary
-	$(GO_BUILD) -o $(BUILD_ARTIFACTS_DIR)/kumactl/kumactl ./app/kumactl
+	$(Build_Go_Application)
 
 .PHONY: build/coredns
 build/coredns:

--- a/pkg/kds/global/components_test.go
+++ b/pkg/kds/global/components_test.go
@@ -175,6 +175,7 @@ var _ = Describe("Global Sync", func() {
 		excludeTypes := map[model.ResourceType]bool{
 			mesh.DataplaneInsightType:  true,
 			mesh.DataplaneOverviewType: true,
+			mesh.GatewayType:           true, // Gateways are zone-local.
 			mesh.ServiceInsightType:    true,
 			mesh.ServiceOverviewType:   true,
 			sample.TrafficRouteType:    true,

--- a/pkg/kds/server/server_test.go
+++ b/pkg/kds/server/server_test.go
@@ -83,6 +83,7 @@ var _ = Describe("KDS Server", func() {
 			kds_samples.ZoneIngress,
 			kds_samples.ZoneIngressInsight,
 			kds_samples.Config,
+			kds_samples.Gateway,
 		}).
 			To(HaveLen(len(kds.SupportedTypes)))
 

--- a/pkg/kds/zone/components_test.go
+++ b/pkg/kds/zone/components_test.go
@@ -151,6 +151,7 @@ var _ = Describe("Zone Sync", func() {
 		excludeTypes := map[model.ResourceType]bool{
 			mesh.DataplaneInsightType:  true,
 			mesh.DataplaneOverviewType: true,
+			mesh.GatewayType:           true, // Gateways are zone-local.
 			mesh.ServiceInsightType:    true,
 			mesh.ServiceOverviewType:   true,
 			sample.TrafficRouteType:    true,

--- a/pkg/plugins/resources/k8s/consistent_kind_type_test.go
+++ b/pkg/plugins/resources/k8s/consistent_kind_type_test.go
@@ -18,6 +18,7 @@ var IgnoredTypes = map[model.ResourceType]bool{
 	system.GlobalSecretType:     true,
 	system.ConfigType:           true,
 	mesh.ZoneIngressInsightType: true, // uses DataplaneInsight under the hood
+	mesh.GatewayType:            true, // Gateway is only in Universal.
 }
 
 var _ = Describe("Consistent Kind Types", func() {

--- a/pkg/plugins/runtime/gateway/enabled.go
+++ b/pkg/plugins/runtime/gateway/enabled.go
@@ -2,8 +2,42 @@
 
 package gateway
 
-import core_plugins "github.com/kumahq/kuma/pkg/core/plugins"
+import (
+	"github.com/kumahq/kuma/pkg/api-server/definitions"
+	core_plugins "github.com/kumahq/kuma/pkg/core/plugins"
+	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
+	"github.com/kumahq/kuma/pkg/core/resources/registry"
+	"github.com/kumahq/kuma/pkg/kds"
+	"github.com/kumahq/kuma/pkg/kds/global"
+	"github.com/kumahq/kuma/pkg/kds/zone"
+)
 
+// NOTE: this is non-deterministic in testing. Some tests will import
+// the plugin and trigger registration and some won't. This means that
+// whether the Gateway types are registered in tests depends on which
+// subset of tests are running.
 func init() {
+	registry.RegisterType(core_mesh.NewGatewayResource())
+	registry.RegistryListType(&core_mesh.GatewayResourceList{})
+
+	// A Gateway is local to a zone, which means that it propagates in one
+	// direction, from a zone CP up to a global CP. The reason for this
+	// is that the Kubernetes Gateway API is the native Kubernetes API
+	// for Kuma gateways. If we propagated a Universal Gateway resource
+	// to a Kubernetes zone, we would need to be able to transform Gateway
+	// resources from Universal -> Kubernetes and have to deal with namespace
+	// semantics and a lot of other unpleasantness.
+
+	kds.SupportedTypes = append(kds.SupportedTypes, core_mesh.GatewayType)
+	zone.ProvidedTypes = append(zone.ProvidedTypes, core_mesh.GatewayType)
+	global.ConsumedTypes = append(global.ConsumedTypes, core_mesh.GatewayType)
+
+	definitions.All = append(definitions.All,
+		definitions.ResourceWsDefinition{
+			Type: core_mesh.GatewayType,
+			Path: "gateways",
+		},
+	)
+
 	core_plugins.Register("gateway", &plugin{})
 }

--- a/pkg/plugins/runtime/gateway/kumactl/plugin.go
+++ b/pkg/plugins/runtime/gateway/kumactl/plugin.go
@@ -1,0 +1,47 @@
+package kumactl
+
+import (
+	"github.com/spf13/cobra"
+
+	kumactl_get "github.com/kumahq/kuma/app/kumactl/cmd/get"
+	kumactl_cmd "github.com/kumahq/kuma/app/kumactl/pkg/cmd"
+	"github.com/kumahq/kuma/pkg/api-server/definitions"
+	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
+	"github.com/kumahq/kuma/pkg/core/resources/registry"
+)
+
+type Plugin struct {
+	rootContext *kumactl_cmd.RootContext
+}
+
+func (p *Plugin) CustomizeContext(root *kumactl_cmd.RootContext) {
+	p.rootContext = root
+
+	registry.RegisterType(core_mesh.NewGatewayResource())
+	registry.RegistryListType(&core_mesh.GatewayResourceList{})
+
+	// Register the API resource so kumactl can find the URI.
+	definitions.All = append(definitions.All,
+		definitions.ResourceWsDefinition{
+			Type: core_mesh.GatewayType,
+			Path: "gateways",
+		},
+	)
+
+	root.TypeArgs["gateway"] = core_mesh.GatewayType
+}
+
+func (p *Plugin) CustomizeCommand(root *cobra.Command) {
+	get := kumactl_cmd.FindSubCommand(root, "get")
+
+	get.AddCommand(
+		kumactl_get.WithPaginationArgs(
+			kumactl_get.NewGetResourcesCmd(p.rootContext, "gateways", core_mesh.GatewayType, kumactl_get.BasicResourceTablePrinter),
+			&p.rootContext.ListContext,
+		),
+	)
+
+	get.AddCommand(
+		kumactl_get.NewGetResourceCmd(p.rootContext, "gateway", core_mesh.GatewayType, kumactl_get.BasicResourceTablePrinter),
+	)
+}

--- a/pkg/test/kds/samples/resources.go
+++ b/pkg/test/kds/samples/resources.go
@@ -311,4 +311,24 @@ var (
 			},
 		}},
 	}
+	Gateway = &mesh_proto.Gateway{
+		Sources: []*mesh_proto.Selector{{
+			Match: map[string]string{
+				"kuma.io/service": "gateway",
+			},
+		}},
+		Tags: map[string]string{
+			"gateway-name": "philip",
+		},
+		Conf: &mesh_proto.Gateway_Conf{
+			Listeners: []*mesh_proto.Gateway_Listener{{
+				Hostname: "philip.example.com",
+				Port:     8080,
+				Protocol: mesh_proto.Gateway_Listener_HTTP,
+				Tags: map[string]string{
+					"port": "8080",
+				},
+			}},
+		},
+	}
 )


### PR DESCRIPTION
### Summary

When the build flag is enabled, register the Gateway resource in the
kuma-cp and in kumactl. The latter adds a simple hook to let the plugin
modify the kumactl commands. This is likely to be refactored away as
more of the type bindings are generated.

### Full changelog

N/A

### Issues resolved

N/A

### Documentation

N/A

### Testing

- [x] Unit tests
- [x] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes 

### Backwards compatibility

- [x] Add `backport-to-stable` label if the code is backwards compatible. Otherwise, list breaking changes.
