### PR TITLE
fix(*) implement TextMarshaler for JSON keys

### DIFF
--- a/api/mesh/v1alpha1/dataplane_helpers.go
+++ b/api/mesh/v1alpha1/dataplane_helpers.go
@@ -1,6 +1,7 @@
 package v1alpha1
 
 import (
+	"encoding"
 	"fmt"
 	"net"
 	"reflect"
@@ -57,6 +58,14 @@ type InboundInterface struct {
 	WorkloadPort          uint32
 }
 
+// We need to implement TextMarshaler because InboundInterface is used
+// as a key for maps that are JSON encoded for logging.
+var _ encoding.TextMarshaler = InboundInterface{}
+
+func (i InboundInterface) MarshalText() ([]byte, error) {
+	return []byte(i.String()), nil
+}
+
 func (i InboundInterface) String() string {
 	return fmt.Sprintf("%s:%d:%d", i.DataplaneIP, i.DataplanePort, i.WorkloadPort)
 }
@@ -68,6 +77,14 @@ func (i *InboundInterface) IsServiceLess() bool {
 type OutboundInterface struct {
 	DataplaneIP   string
 	DataplanePort uint32
+}
+
+// We need to implement TextMarshaler because OutboundInterface is used
+// as a key for maps that are JSON encoded for logging.
+var _ encoding.TextMarshaler = OutboundInterface{}
+
+func (i OutboundInterface) MarshalText() ([]byte, error) {
+	return []byte(i.String()), nil
 }
 
 func (i OutboundInterface) String() string {


### PR DESCRIPTION
### Summary

Add TextMarshaler implementations for types that are uses as map keys.
These types are marshaled to JSON for logging, and the map key conversion
in this case requires encoding.TextMarshaler to be implemented. It is
quite confusing for users to see a marshaling error in the Kuma logs,
since it is difficult to distinguish from a real Kuma error.

### Full changelog

* Fix the error message formatting for xDS snapshot generation failure

### Issues resolved

Fix #2374.

### Documentation

N/A

### Testing

- [x] Unit tests
- [x] E2E tests
- [x] Manual testing on Universal
- [ ] Manual testing on Kubernetes 

### Backwards compatibility

- [x] Add `backport-to-stable` label if the code is backwards compatible. Otherwise, list breaking changes.
