### PR TITLE
chore(kuma-cp): simplify resourceWsDefinition and server init

### DIFF
--- a/pkg/api-server/definitions/all.go
+++ b/pkg/api-server/definitions/all.go
@@ -1,11 +1,6 @@
 package definitions
 
-var All = append(
-	DefaultCRUDLEndpoints,
-	ServiceInsightWsDefinition,
-)
-
-var DefaultCRUDLEndpoints = []ResourceWsDefinition{
+var All = []ResourceWsDefinition{
 	MeshWsDefinition,
 	MeshInsightWsDefinition,
 	DataplaneWsDefinition,
@@ -27,4 +22,5 @@ var DefaultCRUDLEndpoints = []ResourceWsDefinition{
 	GlobalSecretWsDefinition,
 	RetryWsDefinition,
 	TimeoutWsDefinition,
+	ServiceInsightWsDefinition,
 }

--- a/pkg/api-server/definitions/api.go
+++ b/pkg/api-server/definitions/api.go
@@ -12,8 +12,7 @@ func AllApis() core_rest.Api {
 func Apis(wss ...ResourceWsDefinition) core_rest.Api {
 	mapping := make(map[core_model.ResourceType]core_rest.ResourceApi)
 	for _, ws := range wss {
-		resourceType := ws.ResourceFactory().GetType()
-		mapping[resourceType] = core_rest.NewResourceApi(resourceType, ws.Path)
+		mapping[ws.Type] = core_rest.NewResourceApi(ws.Type, ws.Path)
 	}
 	return &core_rest.ApiDescriptor{
 		Resources: mapping,

--- a/pkg/api-server/definitions/circuit_breaker.go
+++ b/pkg/api-server/definitions/circuit_breaker.go
@@ -2,16 +2,9 @@ package definitions
 
 import (
 	"github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
-	"github.com/kumahq/kuma/pkg/core/resources/model"
 )
 
 var CircuitBreakerWsDefinition = ResourceWsDefinition{
-	Name: "Circuit Breaker",
+	Type: mesh.CircuitBreakerType,
 	Path: "circuit-breakers",
-	ResourceFactory: func() model.Resource {
-		return mesh.NewCircuitBreakerResource()
-	},
-	ResourceListFactory: func() model.ResourceList {
-		return &mesh.CircuitBreakerResourceList{}
-	},
 }

--- a/pkg/api-server/definitions/dataplane.go
+++ b/pkg/api-server/definitions/dataplane.go
@@ -1,17 +1,8 @@
 package definitions
 
-import (
-	"github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
-	"github.com/kumahq/kuma/pkg/core/resources/model"
-)
+import "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 
 var DataplaneWsDefinition = ResourceWsDefinition{
-	Name: "Dataplane",
+	Type: mesh.DataplaneType,
 	Path: "dataplanes",
-	ResourceFactory: func() model.Resource {
-		return mesh.NewDataplaneResource()
-	},
-	ResourceListFactory: func() model.ResourceList {
-		return &mesh.DataplaneResourceList{}
-	},
 }

--- a/pkg/api-server/definitions/dataplane_insight.go
+++ b/pkg/api-server/definitions/dataplane_insight.go
@@ -2,16 +2,9 @@ package definitions
 
 import (
 	"github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
-	"github.com/kumahq/kuma/pkg/core/resources/model"
 )
 
 var DataplaneInsightWsDefinition = ResourceWsDefinition{
-	Name: "Dataplane Insight",
+	Type: mesh.DataplaneInsightType,
 	Path: "dataplane-insights",
-	ResourceFactory: func() model.Resource {
-		return mesh.NewDataplaneInsightResource()
-	},
-	ResourceListFactory: func() model.ResourceList {
-		return &mesh.DataplaneInsightResourceList{}
-	},
 }

--- a/pkg/api-server/definitions/definition.go
+++ b/pkg/api-server/definitions/definition.go
@@ -1,12 +1,31 @@
 package definitions
 
-import "github.com/kumahq/kuma/pkg/core/resources/model"
+import (
+	"github.com/kumahq/kuma/pkg/core/resources/model"
+	"github.com/kumahq/kuma/pkg/core/resources/registry"
+)
 
 type ResourceWsDefinition struct {
-	Name                string
-	Path                string
-	ResourceFactory     func() model.Resource
-	ResourceListFactory func() model.ResourceList
-	ReadOnly            bool
-	Admin               bool
+	Type     model.ResourceType
+	Path     string
+	ReadOnly bool
+	Admin    bool
+}
+
+func (ws *ResourceWsDefinition) ResourceFactory() model.Resource {
+	m, err := registry.Global().NewObject(ws.Type)
+	if err != nil {
+		panic(err.Error())
+	}
+
+	return m
+}
+
+func (ws *ResourceWsDefinition) ResourceListFactory() model.ResourceList {
+	l, err := registry.Global().NewList(ws.Type)
+	if err != nil {
+		panic(err.Error())
+	}
+
+	return l
 }

--- a/pkg/api-server/definitions/external_service.go
+++ b/pkg/api-server/definitions/external_service.go
@@ -2,16 +2,9 @@ package definitions
 
 import (
 	"github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
-	"github.com/kumahq/kuma/pkg/core/resources/model"
 )
 
 var ExternalServiceWsDefinition = ResourceWsDefinition{
-	Name: "ExternalService",
+	Type: mesh.ExternalServiceType,
 	Path: "external-services",
-	ResourceFactory: func() model.Resource {
-		return mesh.NewExternalServiceResource()
-	},
-	ResourceListFactory: func() model.ResourceList {
-		return &mesh.ExternalServiceResourceList{}
-	},
 }

--- a/pkg/api-server/definitions/fault_injection.go
+++ b/pkg/api-server/definitions/fault_injection.go
@@ -2,16 +2,9 @@ package definitions
 
 import (
 	"github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
-	"github.com/kumahq/kuma/pkg/core/resources/model"
 )
 
 var FaultInjectionWsDefinition = ResourceWsDefinition{
-	Name: "Fault Injection",
+	Type: mesh.FaultInjectionType,
 	Path: "fault-injections",
-	ResourceFactory: func() model.Resource {
-		return mesh.NewFaultInjectionResource()
-	},
-	ResourceListFactory: func() model.ResourceList {
-		return &mesh.FaultInjectionResourceList{}
-	},
 }

--- a/pkg/api-server/definitions/global_secret.go
+++ b/pkg/api-server/definitions/global_secret.go
@@ -2,17 +2,10 @@ package definitions
 
 import (
 	"github.com/kumahq/kuma/pkg/core/resources/apis/system"
-	"github.com/kumahq/kuma/pkg/core/resources/model"
 )
 
 var GlobalSecretWsDefinition = ResourceWsDefinition{
-	Name: "GlobalSecret",
-	Path: "global-secrets",
-	ResourceFactory: func() model.Resource {
-		return system.NewGlobalSecretResource()
-	},
-	ResourceListFactory: func() model.ResourceList {
-		return &system.GlobalSecretResourceList{}
-	},
+	Type:  system.GlobalSecretType,
+	Path:  "global-secrets",
 	Admin: true,
 }

--- a/pkg/api-server/definitions/health_check.go
+++ b/pkg/api-server/definitions/health_check.go
@@ -2,16 +2,9 @@ package definitions
 
 import (
 	"github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
-	"github.com/kumahq/kuma/pkg/core/resources/model"
 )
 
 var HealthCheckWsDefinition = ResourceWsDefinition{
-	Name: "HealthCheck",
+	Type: mesh.HealthCheckType,
 	Path: "health-checks",
-	ResourceFactory: func() model.Resource {
-		return mesh.NewHealthCheckResource()
-	},
-	ResourceListFactory: func() model.ResourceList {
-		return &mesh.HealthCheckResourceList{}
-	},
 }

--- a/pkg/api-server/definitions/mesh.go
+++ b/pkg/api-server/definitions/mesh.go
@@ -1,17 +1,8 @@
 package definitions
 
-import (
-	"github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
-	"github.com/kumahq/kuma/pkg/core/resources/model"
-)
+import "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 
 var MeshWsDefinition = ResourceWsDefinition{
-	Name: "Mesh",
+	Type: mesh.MeshType,
 	Path: "meshes",
-	ResourceFactory: func() model.Resource {
-		return mesh.NewMeshResource()
-	},
-	ResourceListFactory: func() model.ResourceList {
-		return &mesh.MeshResourceList{}
-	},
 }

--- a/pkg/api-server/definitions/mesh_insight.go
+++ b/pkg/api-server/definitions/mesh_insight.go
@@ -2,16 +2,9 @@ package definitions
 
 import (
 	"github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
-	"github.com/kumahq/kuma/pkg/core/resources/model"
 )
 
 var MeshInsightWsDefinition = ResourceWsDefinition{
-	Name: "Mesh Insight",
+	Type: mesh.MeshType,
 	Path: "mesh-insights",
-	ResourceFactory: func() model.Resource {
-		return mesh.NewMeshInsightResource()
-	},
-	ResourceListFactory: func() model.ResourceList {
-		return &mesh.MeshInsightResourceList{}
-	},
 }

--- a/pkg/api-server/definitions/proxytemplate.go
+++ b/pkg/api-server/definitions/proxytemplate.go
@@ -2,16 +2,9 @@ package definitions
 
 import (
 	"github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
-	"github.com/kumahq/kuma/pkg/core/resources/model"
 )
 
 var ProxyTemplateWsDefinition = ResourceWsDefinition{
-	Name: "ProxyTemplate",
+	Type: mesh.ProxyTemplateType,
 	Path: "proxytemplates",
-	ResourceFactory: func() model.Resource {
-		return mesh.NewProxyTemplateResource()
-	},
-	ResourceListFactory: func() model.ResourceList {
-		return &mesh.ProxyTemplateResourceList{}
-	},
 }

--- a/pkg/api-server/definitions/rate_limit.go
+++ b/pkg/api-server/definitions/rate_limit.go
@@ -2,16 +2,9 @@ package definitions
 
 import (
 	"github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
-	"github.com/kumahq/kuma/pkg/core/resources/model"
 )
 
 var RateLimitWsDefinition = ResourceWsDefinition{
-	Name: "Rate Limit",
+	Type: mesh.RateLimitType,
 	Path: "rate-limits",
-	ResourceFactory: func() model.Resource {
-		return mesh.NewRateLimitResource()
-	},
-	ResourceListFactory: func() model.ResourceList {
-		return &mesh.RateLimitResourceList{}
-	},
 }

--- a/pkg/api-server/definitions/retry.go
+++ b/pkg/api-server/definitions/retry.go
@@ -2,16 +2,9 @@ package definitions
 
 import (
 	"github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
-	"github.com/kumahq/kuma/pkg/core/resources/model"
 )
 
 var RetryWsDefinition = ResourceWsDefinition{
-	Name: "Retry",
+	Type: mesh.RetryType,
 	Path: "retries",
-	ResourceFactory: func() model.Resource {
-		return mesh.NewRetryResource()
-	},
-	ResourceListFactory: func() model.ResourceList {
-		return &mesh.RetryResourceList{}
-	},
 }

--- a/pkg/api-server/definitions/secret.go
+++ b/pkg/api-server/definitions/secret.go
@@ -2,17 +2,10 @@ package definitions
 
 import (
 	"github.com/kumahq/kuma/pkg/core/resources/apis/system"
-	"github.com/kumahq/kuma/pkg/core/resources/model"
 )
 
 var SecretWsDefinition = ResourceWsDefinition{
-	Name: "Secret",
-	Path: "secrets",
-	ResourceFactory: func() model.Resource {
-		return system.NewSecretResource()
-	},
-	ResourceListFactory: func() model.ResourceList {
-		return &system.SecretResourceList{}
-	},
+	Type:  system.SecretType,
+	Path:  "secrets",
 	Admin: true,
 }

--- a/pkg/api-server/definitions/service_insight.go
+++ b/pkg/api-server/definitions/service_insight.go
@@ -2,16 +2,9 @@ package definitions
 
 import (
 	"github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
-	"github.com/kumahq/kuma/pkg/core/resources/model"
 )
 
 var ServiceInsightWsDefinition = ResourceWsDefinition{
-	Name: "Service Insight",
+	Type: mesh.ServiceInsightType,
 	Path: "service-insights",
-	ResourceFactory: func() model.Resource {
-		return mesh.NewServiceInsightResource()
-	},
-	ResourceListFactory: func() model.ResourceList {
-		return &mesh.ServiceInsightResourceList{}
-	},
 }

--- a/pkg/api-server/definitions/timeout.go
+++ b/pkg/api-server/definitions/timeout.go
@@ -2,16 +2,9 @@ package definitions
 
 import (
 	"github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
-	"github.com/kumahq/kuma/pkg/core/resources/model"
 )
 
 var TimeoutWsDefinition = ResourceWsDefinition{
-	Name: "Timeout",
+	Type: mesh.TimeoutType,
 	Path: "timeouts",
-	ResourceFactory: func() model.Resource {
-		return mesh.NewTimeoutResource()
-	},
-	ResourceListFactory: func() model.ResourceList {
-		return &mesh.TimeoutResourceList{}
-	},
 }

--- a/pkg/api-server/definitions/traffic_log.go
+++ b/pkg/api-server/definitions/traffic_log.go
@@ -2,16 +2,9 @@ package definitions
 
 import (
 	"github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
-	"github.com/kumahq/kuma/pkg/core/resources/model"
 )
 
 var TrafficLogWsDefinition = ResourceWsDefinition{
-	Name: "Traffic Logging",
+	Type: mesh.TrafficLogType,
 	Path: "traffic-logs",
-	ResourceFactory: func() model.Resource {
-		return mesh.NewTrafficLogResource()
-	},
-	ResourceListFactory: func() model.ResourceList {
-		return &mesh.TrafficLogResourceList{}
-	},
 }

--- a/pkg/api-server/definitions/traffic_permission.go
+++ b/pkg/api-server/definitions/traffic_permission.go
@@ -2,16 +2,9 @@ package definitions
 
 import (
 	"github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
-	"github.com/kumahq/kuma/pkg/core/resources/model"
 )
 
 var TrafficPermissionWsDefinition = ResourceWsDefinition{
-	Name: "Traffic Permission",
+	Type: mesh.TrafficPermissionType,
 	Path: "traffic-permissions",
-	ResourceFactory: func() model.Resource {
-		return mesh.NewTrafficPermissionResource()
-	},
-	ResourceListFactory: func() model.ResourceList {
-		return &mesh.TrafficPermissionResourceList{}
-	},
 }

--- a/pkg/api-server/definitions/traffic_route.go
+++ b/pkg/api-server/definitions/traffic_route.go
@@ -2,16 +2,9 @@ package definitions
 
 import (
 	"github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
-	"github.com/kumahq/kuma/pkg/core/resources/model"
 )
 
 var TrafficRouteWsDefinition = ResourceWsDefinition{
-	Name: "TrafficRoute",
+	Type: mesh.TrafficRouteType,
 	Path: "traffic-routes",
-	ResourceFactory: func() model.Resource {
-		return mesh.NewTrafficRouteResource()
-	},
-	ResourceListFactory: func() model.ResourceList {
-		return &mesh.TrafficRouteResourceList{}
-	},
 }

--- a/pkg/api-server/definitions/traffic_trace.go
+++ b/pkg/api-server/definitions/traffic_trace.go
@@ -2,16 +2,9 @@ package definitions
 
 import (
 	"github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
-	"github.com/kumahq/kuma/pkg/core/resources/model"
 )
 
 var TrafficTraceWsDefinition = ResourceWsDefinition{
-	Name: "Traffic Trace",
+	Type: mesh.TrafficTraceType,
 	Path: "traffic-traces",
-	ResourceFactory: func() model.Resource {
-		return mesh.NewTrafficTraceResource()
-	},
-	ResourceListFactory: func() model.ResourceList {
-		return &mesh.TrafficTraceResourceList{}
-	},
 }

--- a/pkg/api-server/definitions/zone-ingress.go
+++ b/pkg/api-server/definitions/zone-ingress.go
@@ -2,16 +2,9 @@ package definitions
 
 import (
 	"github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
-	"github.com/kumahq/kuma/pkg/core/resources/model"
 )
 
 var ZoneIngressWsDefinition = ResourceWsDefinition{
-	Name: "ZoneIngress",
+	Type: mesh.ZoneIngressType,
 	Path: "zone-ingresses",
-	ResourceFactory: func() model.Resource {
-		return mesh.NewZoneIngressResource()
-	},
-	ResourceListFactory: func() model.ResourceList {
-		return &mesh.ZoneIngressResourceList{}
-	},
 }

--- a/pkg/api-server/definitions/zone.go
+++ b/pkg/api-server/definitions/zone.go
@@ -2,16 +2,9 @@ package definitions
 
 import (
 	"github.com/kumahq/kuma/pkg/core/resources/apis/system"
-	"github.com/kumahq/kuma/pkg/core/resources/model"
 )
 
 var ZoneWsDefinition = ResourceWsDefinition{
-	Name: "Zone",
+	Type: system.ZoneType,
 	Path: "zones",
-	ResourceFactory: func() model.Resource {
-		return system.NewZoneResource()
-	},
-	ResourceListFactory: func() model.ResourceList {
-		return &system.ZoneResourceList{}
-	},
 }

--- a/pkg/api-server/definitions/zone_insight.go
+++ b/pkg/api-server/definitions/zone_insight.go
@@ -2,16 +2,9 @@ package definitions
 
 import (
 	"github.com/kumahq/kuma/pkg/core/resources/apis/system"
-	"github.com/kumahq/kuma/pkg/core/resources/model"
 )
 
 var ZoneInsightWsDefinition = ResourceWsDefinition{
-	Name: "Zone Insight",
+	Type: system.ZoneInsightType,
 	Path: "zone-insights",
-	ResourceFactory: func() model.Resource {
-		return system.NewZoneInsightResource()
-	},
-	ResourceListFactory: func() model.ResourceList {
-		return &system.ZoneInsightResourceList{}
-	},
 }

--- a/pkg/api-server/resource_endpoints.go
+++ b/pkg/api-server/resource_endpoints.go
@@ -48,8 +48,8 @@ func (r *resourceEndpoints) auth() restful.FilterFunction {
 func (r *resourceEndpoints) addFindEndpoint(ws *restful.WebService, pathPrefix string) {
 	ws.Route(ws.GET(pathPrefix+"/{name}").To(r.findResource).
 		Filter(r.auth()).
-		Doc(fmt.Sprintf("Get a %s", r.Name)).
-		Param(ws.PathParameter("name", fmt.Sprintf("Name of a %s", r.Name)).DataType("string")).
+		Doc(fmt.Sprintf("Get a %s", r.Path)).
+		Param(ws.PathParameter("name", fmt.Sprintf("Name of a %s", r.Path)).DataType("string")).
 		Returns(200, "OK", nil).
 		Returns(404, "Not found", nil))
 }
@@ -73,7 +73,7 @@ func (r *resourceEndpoints) findResource(request *restful.Request, response *res
 func (r *resourceEndpoints) addListEndpoint(ws *restful.WebService, pathPrefix string) {
 	ws.Route(ws.GET(pathPrefix).To(r.listResources).
 		Filter(r.auth()).
-		Doc(fmt.Sprintf("List of %s", r.Name)).
+		Doc(fmt.Sprintf("List of %s", r.Path)).
 		Param(ws.PathParameter("size", "size of page").DataType("int")).
 		Param(ws.PathParameter("offset", "offset of page to list").DataType("string")).
 		Returns(200, "OK", nil))
@@ -108,8 +108,8 @@ func (r *resourceEndpoints) addCreateOrUpdateEndpoint(ws *restful.WebService, pa
 	} else {
 		ws.Route(ws.PUT(pathPrefix+"/{name}").To(r.createOrUpdateResource).
 			Filter(r.auth()).
-			Doc(fmt.Sprintf("Updates a %s", r.Name)).
-			Param(ws.PathParameter("name", fmt.Sprintf("Name of the %s", r.Name)).DataType("string")).
+			Doc(fmt.Sprintf("Updates a %s", r.Path)).
+			Param(ws.PathParameter("name", fmt.Sprintf("Name of the %s", r.Path)).DataType("string")).
 			Returns(200, "OK", nil).
 			Returns(201, "Created", nil))
 	}
@@ -179,8 +179,8 @@ func (r *resourceEndpoints) addDeleteEndpoint(ws *restful.WebService, pathPrefix
 	} else {
 		ws.Route(ws.DELETE(pathPrefix+"/{name}").To(r.deleteResource).
 			Filter(r.auth()).
-			Doc(fmt.Sprintf("Deletes a %s", r.Name)).
-			Param(ws.PathParameter("name", fmt.Sprintf("Name of a %s", r.Name)).DataType("string")).
+			Doc(fmt.Sprintf("Deletes a %s", r.Path)).
+			Param(ws.PathParameter("name", fmt.Sprintf("Name of a %s", r.Path)).DataType("string")).
 			Returns(200, "OK", nil))
 	}
 }

--- a/pkg/api-server/sample_resource_definition_test.go
+++ b/pkg/api-server/sample_resource_definition_test.go
@@ -2,18 +2,11 @@ package api_server_test
 
 import (
 	"github.com/kumahq/kuma/pkg/api-server/definitions"
-	"github.com/kumahq/kuma/pkg/core/resources/model"
 	sample_model "github.com/kumahq/kuma/pkg/test/resources/apis/sample"
 )
 
 var SampleTrafficRouteWsDefinition = definitions.ResourceWsDefinition{
-	Name: "Sample Traffic Route",
-	Path: "sample-traffic-routes",
-	ResourceFactory: func() model.Resource {
-		return sample_model.NewTrafficRouteResource()
-	},
-	ResourceListFactory: func() model.ResourceList {
-		return &sample_model.TrafficRouteResourceList{}
-	},
+	Type:     sample_model.TrafficRouteType,
+	Path:     "sample-traffic-routes",
 	ReadOnly: false,
 }

--- a/pkg/api-server/server.go
+++ b/pkg/api-server/server.go
@@ -14,6 +14,8 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
+
 	"github.com/kumahq/kuma/pkg/api-server/customization"
 
 	"github.com/emicklei/go-restful"
@@ -29,7 +31,6 @@ import (
 	kuma_cp "github.com/kumahq/kuma/pkg/config/app/kuma-cp"
 	config_core "github.com/kumahq/kuma/pkg/config/core"
 	"github.com/kumahq/kuma/pkg/core"
-	"github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	"github.com/kumahq/kuma/pkg/core/resources/manager"
 	"github.com/kumahq/kuma/pkg/core/resources/model"
 	"github.com/kumahq/kuma/pkg/core/runtime"
@@ -146,7 +147,6 @@ func NewApiServer(resManager manager.ResourceManager, wsManager customization.AP
 }
 
 func addResourcesEndpoints(ws *restful.WebService, defs []definitions.ResourceWsDefinition, resManager manager.ResourceManager, cfg *kuma_cp.Config) {
-	config := cfg.ApiServer
 	dpOverviewEndpoints := dataplaneOverviewEndpoints{
 		resManager: resManager,
 	}
@@ -176,14 +176,10 @@ func addResourcesEndpoints(ws *restful.WebService, defs []definitions.ResourceWs
 			},
 		},
 	}
-	serviceInsightEndpoints.addCreateOrUpdateEndpoint(ws, "/meshes/{mesh}/"+definitions.ServiceInsightWsDefinition.Path)
-	serviceInsightEndpoints.addDeleteEndpoint(ws, "/meshes/{mesh}/"+definitions.ServiceInsightWsDefinition.Path)
-	serviceInsightEndpoints.addFindEndpoint(ws, "/meshes/{mesh}/"+definitions.ServiceInsightWsDefinition.Path)
-	serviceInsightEndpoints.addListEndpoint(ws, "/meshes/{mesh}/"+definitions.ServiceInsightWsDefinition.Path)
-	serviceInsightEndpoints.addListEndpoint(ws, "/"+definitions.ServiceInsightWsDefinition.Path) // listing all resources in all meshes
 
 	for _, definition := range defs {
-		if config.ReadOnly {
+		defType := definition.Type
+		if cfg.ApiServer.ReadOnly || (defType == mesh.DataplaneType && cfg.Mode == config_core.Global) || (defType != mesh.DataplaneType && cfg.Mode == config_core.Zone) {
 			definition.ReadOnly = true
 		}
 		endpoints := resourceEndpoints{
@@ -194,18 +190,27 @@ func addResourcesEndpoints(ws *restful.WebService, defs []definitions.ResourceWs
 				AllowFromLocalhost: cfg.ApiServer.Auth.AllowFromLocalhost,
 			},
 		}
-		switch definition.ResourceFactory().Scope() {
-		case model.ScopeMesh:
-			endpoints.addCreateOrUpdateEndpoint(ws, "/meshes/{mesh}/"+definition.Path)
-			endpoints.addDeleteEndpoint(ws, "/meshes/{mesh}/"+definition.Path)
-			endpoints.addFindEndpoint(ws, "/meshes/{mesh}/"+definition.Path)
-			endpoints.addListEndpoint(ws, "/meshes/{mesh}/"+definition.Path)
-			endpoints.addListEndpoint(ws, "/"+definition.Path) // listing all resources in all meshes
-		case model.ScopeGlobal:
-			endpoints.addCreateOrUpdateEndpoint(ws, "/"+definition.Path)
-			endpoints.addDeleteEndpoint(ws, "/"+definition.Path)
-			endpoints.addFindEndpoint(ws, "/"+definition.Path)
-			endpoints.addListEndpoint(ws, "/"+definition.Path)
+		switch defType {
+		case mesh.ServiceInsightType: // ServiceInsight has a custom endpoint
+			serviceInsightEndpoints.addCreateOrUpdateEndpoint(ws, "/meshes/{mesh}/"+definitions.ServiceInsightWsDefinition.Path)
+			serviceInsightEndpoints.addDeleteEndpoint(ws, "/meshes/{mesh}/"+definitions.ServiceInsightWsDefinition.Path)
+			serviceInsightEndpoints.addFindEndpoint(ws, "/meshes/{mesh}/"+definitions.ServiceInsightWsDefinition.Path)
+			serviceInsightEndpoints.addListEndpoint(ws, "/meshes/{mesh}/"+definitions.ServiceInsightWsDefinition.Path)
+			serviceInsightEndpoints.addListEndpoint(ws, "/"+definitions.ServiceInsightWsDefinition.Path) // listing all resources in all meshes
+		default:
+			switch definition.ResourceFactory().Scope() {
+			case model.ScopeMesh:
+				endpoints.addCreateOrUpdateEndpoint(ws, "/meshes/{mesh}/"+definition.Path)
+				endpoints.addDeleteEndpoint(ws, "/meshes/{mesh}/"+definition.Path)
+				endpoints.addFindEndpoint(ws, "/meshes/{mesh}/"+definition.Path)
+				endpoints.addListEndpoint(ws, "/meshes/{mesh}/"+definition.Path)
+				endpoints.addListEndpoint(ws, "/"+definition.Path) // listing all resources in all meshes
+			case model.ScopeGlobal:
+				endpoints.addCreateOrUpdateEndpoint(ws, "/"+definition.Path)
+				endpoints.addDeleteEndpoint(ws, "/"+definition.Path)
+				endpoints.addFindEndpoint(ws, "/"+definition.Path)
+				endpoints.addListEndpoint(ws, "/"+definition.Path)
+			}
 		}
 	}
 }
@@ -345,22 +350,7 @@ func (a *ApiServer) notAvailableHandler(writer http.ResponseWriter, request *htt
 
 func SetupServer(rt runtime.Runtime) error {
 	cfg := rt.Config()
-	enableGUI := cfg.Mode != config_core.Zone
-	if cfg.Mode != config_core.Standalone {
-		for i, definition := range definitions.All {
-			switch cfg.Mode {
-			case config_core.Global:
-				if definition.ResourceFactory().GetType() == mesh.DataplaneType {
-					definitions.All[i].ReadOnly = true
-				}
-			case config_core.Zone:
-				if definition.ResourceFactory().GetType() != mesh.DataplaneType {
-					definitions.All[i].ReadOnly = true
-				}
-			}
-		}
-	}
-	apiServer, err := NewApiServer(rt.ResourceManager(), rt.APIInstaller(), definitions.DefaultCRUDLEndpoints, &cfg, enableGUI, rt.Metrics())
+	apiServer, err := NewApiServer(rt.ResourceManager(), rt.APIInstaller(), definitions.All, &cfg, cfg.Mode != config_core.Zone, rt.Metrics())
 	if err != nil {
 		return err
 	}

--- a/pkg/api-server/service_insight_endpoints.go
+++ b/pkg/api-server/service_insight_endpoints.go
@@ -23,8 +23,8 @@ type serviceInsightEndpoints struct {
 func (s *serviceInsightEndpoints) addFindEndpoint(ws *restful.WebService, pathPrefix string) {
 	ws.Route(ws.GET(pathPrefix+"/{service}").To(s.findResource).
 		Filter(s.auth()).
-		Doc(fmt.Sprintf("Get a %s", s.Name)).
-		Param(ws.PathParameter("service", fmt.Sprintf("Name of a %s", s.Name)).DataType("string")).
+		Doc(fmt.Sprintf("Get a %s", s.Path)).
+		Param(ws.PathParameter("service", fmt.Sprintf("Name of a %s", s.Path)).DataType("string")).
 		Returns(200, "OK", nil).
 		Returns(404, "Not found", nil))
 }
@@ -56,7 +56,7 @@ func (s *serviceInsightEndpoints) findResource(request *restful.Request, respons
 func (s *serviceInsightEndpoints) addListEndpoint(ws *restful.WebService, pathPrefix string) {
 	ws.Route(ws.GET(pathPrefix).To(s.listResources).
 		Filter(s.auth()).
-		Doc(fmt.Sprintf("List of %s", s.Name)).
+		Doc(fmt.Sprintf("List of %s", s.Path)).
 		Param(ws.PathParameter("size", "size of page").DataType("int")).
 		Param(ws.PathParameter("offset", "offset of page to list").DataType("string")).
 		Returns(200, "OK", nil))


### PR DESCRIPTION
- Remove unused `Name` and extract methods to remove repetitive factory code
- Add readOnly switches in the server init rather than split in 2 different places

### Testing

It's a refactor and the original coverage is pretty good already.

### Backwards compatibility

- [x] Add `backport-to-stable` label if the code is backwards compatible. Otherwise, list breaking changes.
