### PR TITLE
feat(kuma-cp) generate gateway listeners

### DIFF
--- a/pkg/plugins/runtime/gateway/listener_generator.go
+++ b/pkg/plugins/runtime/gateway/listener_generator.go
@@ -1,21 +1,243 @@
 package gateway
 
 import (
-	"github.com/pkg/errors"
+	"context"
+	"fmt"
+	"time"
 
+	envoy_config_core_v3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	envoy_hcm "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
+	"github.com/pkg/errors"
+	"google.golang.org/protobuf/types/known/durationpb"
+	"google.golang.org/protobuf/types/known/wrapperspb"
+
+	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
+	"github.com/kumahq/kuma/pkg/core/policy"
+	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	"github.com/kumahq/kuma/pkg/core/resources/manager"
-	"github.com/kumahq/kuma/pkg/core/xds"
+	"github.com/kumahq/kuma/pkg/core/resources/store"
+	core_xds "github.com/kumahq/kuma/pkg/core/xds"
 	xds_context "github.com/kumahq/kuma/pkg/xds/context"
+	"github.com/kumahq/kuma/pkg/xds/envoy"
+	envoy_listeners "github.com/kumahq/kuma/pkg/xds/envoy/listeners"
+	v3 "github.com/kumahq/kuma/pkg/xds/envoy/listeners/v3"
+	envoy_names "github.com/kumahq/kuma/pkg/xds/envoy/names"
 	"github.com/kumahq/kuma/pkg/xds/generator"
 )
 
-// ListenerGenerator generates Kuma gateway listeners. Not implemented.
+const DefaultConnectionBuffer = 32 * 1024
+const DefaultRequestHeadersTimeoutMsec = 500 * time.Millisecond
+const DefaultStreamIdleTimeoutMsec = 5 * time.Second
+const DefaultConcurrentStreams = 100
+const DefaultInitialStreamWindowSize = 64 * 1024
+const DefaultInitialConnectionWindowSize = 1024 * 1024
+const DefaultIdleTimeout = 5 * time.Minute
+
+type gatewayPolicyAdaptor struct {
+	*core_mesh.GatewayResource
+}
+
+func (g gatewayPolicyAdaptor) Selectors() []*mesh_proto.Selector {
+	return g.Sources()
+}
+
+func findMatchingGateway(m manager.ReadOnlyResourceManager, dp *core_mesh.DataplaneResource) *core_mesh.GatewayResource {
+	gatewayList := &core_mesh.GatewayResourceList{}
+
+	if err := m.List(context.Background(), gatewayList, store.ListByMesh(dp.Meta.GetMesh())); err != nil {
+		return nil
+	}
+
+	candidates := make([]policy.DataplanePolicy, len(gatewayList.Items))
+	for i, gw := range gatewayList.Items {
+		candidates[i] = gatewayPolicyAdaptor{gw}
+	}
+
+	if p := policy.SelectDataplanePolicy(dp, candidates); p != nil {
+		return p.(gatewayPolicyAdaptor).GatewayResource
+	}
+
+	return nil
+}
+
+var _ policy.DataplanePolicy = gatewayPolicyAdaptor{}
+
+// ListenerGenerator generates Kuma gateway listeners.
 type ListenerGenerator struct {
 	Resources manager.ReadOnlyResourceManager
 }
 
 var _ generator.ResourceGenerator = ListenerGenerator{}
 
-func (ListenerGenerator) Generate(ctx xds_context.Context, proxy *xds.Proxy) (*xds.ResourceSet, error) {
-	return nil, errors.New("not implemented")
+func (l ListenerGenerator) Generate(_ xds_context.Context, proxy *core_xds.Proxy) (*core_xds.ResourceSet, error) {
+	gw := findMatchingGateway(l.Resources, proxy.Dataplane)
+	if gw == nil {
+		log.V(1).Info("no matching gateway for dataplane",
+			"name", proxy.Dataplane.Meta.GetName(),
+			"mesh", proxy.Dataplane.Meta.GetMesh(),
+		)
+
+		return nil, nil
+	}
+
+	log.V(1).Info(fmt.Sprintf("matched gateway %q to dataplane %q",
+		gw.Meta.GetName(), proxy.Dataplane.Meta.GetName()))
+
+	// Multiple listener specifications can have the same port. If
+	// they are compatible, then we can collapse those specifications
+	// down to a single listener.
+	collapsed := map[uint32][]*mesh_proto.Gateway_Listener{}
+	for _, ep := range gw.Spec.GetConf().GetListeners() {
+		collapsed[ep.GetPort()] = append(collapsed[ep.GetPort()], ep)
+	}
+
+	// A Gateway is a single service across all listeners.
+	service := proxy.Dataplane.Spec.GetIdentifyingService()
+
+	resources := core_xds.NewResourceSet()
+
+	// Generate a listener resource for each port.
+	for port, listeners := range collapsed {
+		protocol := listeners[0].GetProtocol()
+		address := proxy.Dataplane.Spec.GetNetworking().Address
+
+		log.V(1).Info("generating listener",
+			"address", address,
+			"port", port,
+			"protocol", protocol,
+		)
+
+		// TODO(jpeach) verify that the listeners are compatible.
+		// TODO(jpeach) hoist the compatibility check and use it in Gateway validation.
+
+		// This check forces all listeners on the port to have
+		// the same protocol, which is unnecessarily strict. We
+		// cal allow TLS and HTTPS on the same port, for example.
+		for i := range listeners {
+			if listeners[i].GetProtocol() != listeners[0].GetProtocol() {
+				return nil, errors.Errorf("cannot collapse listener protocols %s and %s",
+					listeners[i].GetProtocol(), listeners[0].GetProtocol(),
+				)
+			}
+		}
+
+		switch protocol {
+		case mesh_proto.Gateway_Listener_UDP:
+			fallthrough
+		case mesh_proto.Gateway_Listener_TCP:
+			fallthrough
+		case mesh_proto.Gateway_Listener_TLS:
+			fallthrough
+		case mesh_proto.Gateway_Listener_HTTPS:
+			return nil, errors.Errorf("unsupported protocol %q", protocol)
+		}
+
+		filters := envoy_listeners.NewFilterChainBuilder(proxy.APIVersion)
+
+		// For HTTP protocols, add the connection manager and
+		// (for now), send all traffic to the default route,
+		// just to keep the xDS snapshot consistent.
+		switch protocol {
+		case mesh_proto.Gateway_Listener_HTTP:
+			filters.Configure(
+				envoy_listeners.HttpConnectionManager(service, false),
+				envoy_listeners.HttpDynamicRoute(DefaultRouteName),
+			)
+		case mesh_proto.Gateway_Listener_HTTPS:
+			filters.Configure(
+				envoy_listeners.HttpConnectionManager(service, true),
+				envoy_listeners.HttpDynamicRoute(DefaultRouteName),
+			)
+		}
+
+		// Add edge proxy recommendations.
+		filters.Configure(
+			envoy_listeners.AddFilterChainConfigurer(
+				v3.HttpConnectionManagerMustConfigureFunc(func(hcm *envoy_hcm.HttpConnectionManager) {
+					hcm.ServerName = "Kuma Gateway"
+
+					hcm.NormalizePath = wrapperspb.Bool(true)
+					hcm.MergeSlashes = true
+
+					// TODO(jpeach) set path_with_escaped_slashes_action when we upgrade to Envoy v1.19.
+
+					hcm.RequestHeadersTimeout = durationpb.New(DefaultRequestHeadersTimeoutMsec)
+					hcm.StreamIdleTimeout = durationpb.New(DefaultStreamIdleTimeoutMsec)
+
+					hcm.CommonHttpProtocolOptions = &envoy_config_core_v3.HttpProtocolOptions{
+						IdleTimeout:                  durationpb.New(DefaultIdleTimeout),
+						HeadersWithUnderscoresAction: envoy_config_core_v3.HttpProtocolOptions_REJECT_REQUEST,
+					}
+
+					hcm.Http2ProtocolOptions = &envoy_config_core_v3.Http2ProtocolOptions{
+						MaxConcurrentStreams:        wrapperspb.UInt32(DefaultConcurrentStreams),
+						InitialStreamWindowSize:     wrapperspb.UInt32(DefaultInitialStreamWindowSize),
+						InitialConnectionWindowSize: wrapperspb.UInt32(DefaultInitialConnectionWindowSize),
+						AllowConnect:                true,
+					}
+				}),
+			),
+		)
+
+		// Tracing and logging have to be configured after the HttpConnectionManager is enabled.
+		filters.Configure(
+			envoy_listeners.Tracing(proxy.Policies.TracingBackend, service),
+			// XXX Logging policy doesn't work at all. The logging backend is selected by
+			// matching against outbound service names, and gateway dataplanes don't have
+			// any of those.
+			envoy_listeners.HttpAccessLog(
+				proxy.Dataplane.Meta.GetMesh(),
+				envoy.TrafficDirectionInbound,
+				service, // Source service is the gateway service.
+				"*",     // Destination service could be anywhere, depending on the routes.
+				proxy.Policies.Logs[service],
+				proxy,
+			),
+		)
+
+		// TODO(jpeach) add compressor filter.
+		// TODO(jpeach) add decompressor filter.
+		// TODO(jpeach) add grpc_web filter.
+		// TODO(jpeach) add grpc_stats filter.
+
+		listener := envoy_listeners.NewListenerBuilder(proxy.APIVersion)
+		listener.Configure(
+			envoy_listeners.InboundListener(
+				envoy_names.GetGatewayListenerName(gw.Meta.GetName(), protocol.String(), port),
+				address, port, core_xds.SocketAddressProtocolTCP),
+			// Limit default buffering for edge connections.
+			envoy_listeners.ConnectionBufferLimit(DefaultConnectionBuffer),
+			// Roughly balance incoming connections.
+			envoy_listeners.EnableReusePort(true),
+			// Always sniff for TLS.
+			envoy_listeners.TLSInspector(),
+		)
+
+		// TODO(jpeach) if proxy protocol is enabled, add the listener filter.
+
+		// Now, for each of the collapsed listeners on this port, configure the
+		for range listeners {
+			switch protocol {
+			case mesh_proto.Gateway_Listener_HTTPS:
+				// TODO(jpeach) add a SNI listener to match the hostname
+				// and apply the right set of dynamic HTTP routes.
+			case mesh_proto.Gateway_Listener_TLS:
+				// TODO(jpeach) add a SNI listener to match the hostname
+				// and apply the right set of dynamic TCP or TLS routes.
+			}
+		}
+
+		listener.Configure(
+			envoy_listeners.FilterChain(filters),
+		)
+
+		resourceSet, err := BuildResourceSet(listener)
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to generate listener for port %d", port)
+		}
+
+		resources.AddSet(resourceSet)
+	}
+
+	return resources, nil
 }

--- a/pkg/plugins/runtime/gateway/listener_generator_test.go
+++ b/pkg/plugins/runtime/gateway/listener_generator_test.go
@@ -1,21 +1,50 @@
 package gateway_test
 
 import (
+	"encoding/json"
+	"path"
+
 	envoy_types "github.com/envoyproxy/go-control-plane/pkg/cache/types"
+	"github.com/envoyproxy/go-control-plane/pkg/cache/v3"
 	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
 
-	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	core_model "github.com/kumahq/kuma/pkg/core/resources/model"
+	"github.com/kumahq/kuma/pkg/core/resources/model/rest"
 	"github.com/kumahq/kuma/pkg/core/runtime"
-	"github.com/kumahq/kuma/pkg/core/xds"
+	"github.com/kumahq/kuma/pkg/test/matchers"
 	xds_context "github.com/kumahq/kuma/pkg/xds/context"
-	"github.com/kumahq/kuma/pkg/xds/envoy"
 	xds_server "github.com/kumahq/kuma/pkg/xds/server/v3"
 )
 
 var _ = Describe("Gateway Listener", func() {
 	var rt runtime.Runtime
+
+	Do := func(gateway string) (cache.Snapshot, error) {
+		serverCtx := xds_server.NewXdsContext()
+		reconciler := xds_server.DefaultReconciler(rt, serverCtx)
+
+		Expect(StoreInlineFixture(rt, []byte(gateway))).To(Succeed())
+
+		// Unmarshal the gateway YAML again so that we can figure
+		// out which mesh it's in.
+		r, err := rest.UnmarshallToCore([]byte(gateway))
+		Expect(err).To(Succeed())
+
+		// We expect there to be a Dataplane fixture named
+		// "default" in the current mesh.
+		proxy := MakeDataplaneProxy(rt,
+			core_model.ResourceKey{Mesh: r.GetMeta().GetMesh(), Name: "default"})
+
+		Expect(proxy.Dataplane.Spec.IsBuiltinGateway()).To(BeTrue())
+
+		if err := reconciler.Reconcile(xds_context.Context{}, proxy); err != nil {
+			return cache.Snapshot{}, err
+		}
+
+		return serverCtx.Cache().GetSnapshot(proxy.Id.String())
+	}
 
 	BeforeEach(func() {
 		var err error
@@ -23,37 +52,138 @@ var _ = Describe("Gateway Listener", func() {
 		rt, err = BuildRuntime()
 		Expect(err).To(Succeed(), "build runtime instance")
 
-		Expect(StoreNamedFixture(rt, "mesh-default.yaml"))
-		Expect(StoreNamedFixture(rt, "dataplane-default.yaml"))
+		Expect(StoreNamedFixture(rt, "mesh-default.yaml")).To(Succeed())
+		Expect(StoreNamedFixture(rt, "dataplane-default.yaml")).To(Succeed())
+
+		Expect(StoreNamedFixture(rt, "mesh-tracing.yaml")).To(Succeed())
+		Expect(StoreNamedFixture(rt, "dataplane-tracing.yaml")).To(Succeed())
+		Expect(StoreNamedFixture(rt, "traffictrace.yaml")).To(Succeed())
+
+		Expect(StoreNamedFixture(rt, "mesh-logging.yaml")).To(Succeed())
+		Expect(StoreNamedFixture(rt, "dataplane-logging.yaml")).To(Succeed())
+		Expect(StoreNamedFixture(rt, "trafficlog.yaml")).To(Succeed())
 	})
 
-	It("should not be implemented", func() {
-		serverCtx := xds_server.NewXdsContext()
-		reconciler := xds_server.DefaultReconciler(rt, serverCtx)
+	DescribeTable("Generate Envoy xDS resources",
+		func(golden string, gateway string) {
+			snap, err := Do(gateway)
+			Expect(err).To(Succeed())
 
-		dp, err := FetchNamedFixture(rt, core_mesh.DataplaneType,
-			core_model.ResourceKey{Mesh: "default", Name: "default"})
-		Expect(err).To(Succeed())
+			out, err := json.MarshalIndent(
+				MakeProtoResource(snap.Resources[envoy_types.Listener]), "", "  ")
+			Expect(err).To(Succeed())
 
-		proxy := xds.Proxy{
-			Id:         xds.FromResourceKey(core_model.MetaToResourceKey(dp.GetMeta())),
-			APIVersion: envoy.APIV3,
-			Dataplane:  dp.(*core_mesh.DataplaneResource),
-			Metadata:   nil,
-			Routing:    xds.Routing{},
-			Policies:   xds.MatchedPolicies{},
-		}
+			Expect(out).To(matchers.MatchGoldenJSON(path.Join("testdata", golden)))
+		},
+		Entry("should generate a single listener",
+			"01-gateway-listener.yaml", `
+type: Gateway
+mesh: default
+name: edge-gateway
+sources:
+- match:
+    kuma.io/service: gateway-default
+conf:
+  listeners:
+  - port: 8080
+    protocol: HTTP
+    tags:
+      port: http/8080
+`),
+		Entry("should generate a multiple listeners",
+			"02-gateway-listener.yaml", `
+type: Gateway
+mesh: default
+name: edge-gateway
+sources:
+- match:
+    kuma.io/service: gateway-default
+conf:
+  listeners:
+  - port: 8080
+    protocol: HTTP
+    tags:
+      port: http/8080
+  - port: 9090
+    protocol: HTTP
+    tags:
+      port: http/9090
+`),
+		Entry("should generate listener tracing",
+			"03-gateway-listener.yaml", `
+type: Gateway
+mesh: tracing
+name: tracing-gateway
+sources:
+- match:
+    kuma.io/service: gateway-default
+conf:
+  listeners:
+  - port: 8080
+    protocol: HTTP
+    tags:
+      port: http/8080
+`),
+		Entry("should generate listener logging",
+			"04-gateway-listener.yaml", `
+type: Gateway
+mesh: logging
+name: logging-gateway
+sources:
+- match:
+    kuma.io/service: gateway-default
+conf:
+  listeners:
+  - port: 8080
+    protocol: HTTP
+    tags:
+      port: http/8080
+`),
+	)
 
-		Expect(proxy.Dataplane.Spec.IsBuiltinGateway()).To(BeTrue())
+	DescribeTable("fail to generate xDS resources",
+		func(errMsg string, gateway string) {
+			_, err := Do(gateway)
+			Expect(err).ToNot(Succeed())
+			Expect(err.Error()).To(ContainSubstring(errMsg))
+		},
 
-		// The gateway listener generator isn't implemented,
-		// so we expect this should fail.
-		err = reconciler.Reconcile(xds_context.Context{}, &proxy)
-		Expect(err).To(Not(Succeed()))
-		Expect(err.Error()).To(ContainSubstring("not implemented"))
+		Entry("incompatible listeners",
+			"cannot collapse listener protocols", `
+type: Gateway
+mesh: default
+name: edge-gateway
+sources:
+- match:
+    kuma.io/service: gateway-default
+conf:
+  listeners:
+  - port: 8080
+    protocol: HTTP
+    tags:
+      port: http/8080
+  - port: 8080
+    protocol: HTTPS
+    tags:
+      port: http/9090
+`,
+		),
 
-		snap, err := serverCtx.Cache().GetSnapshot(proxy.Id.String())
-		Expect(err).To(Not(Succeed()))
-		Expect(snap.Resources[envoy_types.Listener].Items).To(BeEmpty())
-	})
+		Entry("unsupported protocol",
+			"unsupported protocol", `
+type: Gateway
+mesh: default
+name: edge-gateway
+sources:
+- match:
+    kuma.io/service: gateway-default
+conf:
+  listeners:
+  - port: 443
+    protocol: HTTPS
+    tags:
+      port: http/443
+`,
+		),
+	)
 })

--- a/pkg/plugins/runtime/gateway/route_generator.go
+++ b/pkg/plugins/runtime/gateway/route_generator.go
@@ -1,8 +1,6 @@
 package gateway
 
 import (
-	"github.com/pkg/errors"
-
 	"github.com/kumahq/kuma/pkg/core/resources/manager"
 	"github.com/kumahq/kuma/pkg/core/xds"
 	xds_context "github.com/kumahq/kuma/pkg/xds/context"
@@ -19,7 +17,8 @@ type RouteGenerator struct {
 var _ generator.ResourceGenerator = &RouteGenerator{}
 
 func (r RouteGenerator) Generate(ctx xds_context.Context, proxy *xds.Proxy) (*xds.ResourceSet, error) {
-	return nil, errors.New("not implemented")
+	log.V(2).Info("Gateway route generation not implemented")
+	return nil, nil
 }
 
 // DefaultRouteName is the well-known name of the default route configuration.

--- a/pkg/plugins/runtime/gateway/suite_test.go
+++ b/pkg/plugins/runtime/gateway/suite_test.go
@@ -6,22 +6,119 @@ import (
 	"path"
 	"testing"
 
+	cache_v3 "github.com/envoyproxy/go-control-plane/pkg/cache/v3"
+	"github.com/golang/protobuf/proto"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
 	kuma_cp "github.com/kumahq/kuma/pkg/config/app/kuma-cp"
+	"github.com/kumahq/kuma/pkg/core/faultinjections"
+	"github.com/kumahq/kuma/pkg/core/logs"
+	"github.com/kumahq/kuma/pkg/core/permissions"
 	"github.com/kumahq/kuma/pkg/core/plugins"
+	"github.com/kumahq/kuma/pkg/core/ratelimits"
+	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	core_model "github.com/kumahq/kuma/pkg/core/resources/model"
 	"github.com/kumahq/kuma/pkg/core/resources/model/rest"
 	"github.com/kumahq/kuma/pkg/core/resources/registry"
 	"github.com/kumahq/kuma/pkg/core/resources/store"
 	"github.com/kumahq/kuma/pkg/core/runtime"
+	core_xds "github.com/kumahq/kuma/pkg/core/xds"
 	"github.com/kumahq/kuma/pkg/test"
 	test_runtime "github.com/kumahq/kuma/pkg/test/runtime"
+	util_proto "github.com/kumahq/kuma/pkg/util/proto"
+	xds_context "github.com/kumahq/kuma/pkg/xds/context"
+	"github.com/kumahq/kuma/pkg/xds/envoy"
+	"github.com/kumahq/kuma/pkg/xds/sync"
 )
 
 func TestGateway(t *testing.T) {
 	test.RunSpecs(t, "Gateway Suite")
+}
+
+type ProtoMessage struct {
+	Message proto.Message
+}
+
+func (p ProtoMessage) MarshalJSON() ([]byte, error) {
+	return util_proto.ToJSON(p.Message)
+}
+
+type ProtoResource struct {
+	Resources map[string]ProtoMessage
+}
+
+// MakeProtoResource wraps Go Control Plane resources in a map that
+// implements the json.Marshaler so that the resulting JSON fully
+// expands embedded Any protobufs (which are otherwise serialized
+// as byte arrays).
+func MakeProtoResource(resources cache_v3.Resources) ProtoResource {
+	result := ProtoResource{
+		Resources: map[string]ProtoMessage{},
+	}
+
+	for name, values := range resources.Items {
+		result.Resources[name] = ProtoMessage{
+			Message: values.Resource,
+		}
+	}
+
+	return result
+}
+
+type mockMetadataTracker struct{}
+
+func (m mockMetadataTracker) Metadata(dpKey core_model.ResourceKey) *core_xds.DataplaneMetadata {
+	return nil
+}
+
+func MakeDataplaneProxy(rt runtime.Runtime, key core_model.ResourceKey) *core_xds.Proxy {
+	b := sync.DataplaneProxyBuilder{
+		CachingResManager:    rt.ReadOnlyResourceManager(),
+		NonCachingResManager: rt.ResourceManager(),
+		LookupIP:             rt.LookupIP(),
+		DataSourceLoader:     rt.DataSourceLoader(),
+		MetadataTracker:      mockMetadataTracker{},
+		PermissionMatcher: permissions.TrafficPermissionsMatcher{
+			ResourceManager: rt.ReadOnlyResourceManager(),
+		},
+		LogsMatcher: logs.TrafficLogsMatcher{
+			ResourceManager: rt.ReadOnlyResourceManager(),
+		},
+		FaultInjectionMatcher: faultinjections.FaultInjectionMatcher{
+			ResourceManager: rt.ReadOnlyResourceManager(),
+		},
+		RateLimitMatcher: ratelimits.RateLimitMatcher{
+			ResourceManager: rt.ReadOnlyResourceManager(),
+		},
+		Zone:       rt.Config().Multizone.Zone.Name,
+		APIVersion: envoy.APIV3,
+	}
+
+	mesh := core_mesh.NewMeshResource()
+	Expect(rt.ReadOnlyResourceManager().Get(context.TODO(), mesh, store.GetByKey(key.Mesh, core_model.NoMesh))).
+		To(Succeed())
+
+	dataplanes := core_mesh.DataplaneResourceList{}
+	Expect(rt.ResourceManager().List(context.TODO(), &dataplanes, store.ListByMesh(key.Mesh))).To(Succeed())
+
+	proxy, err := b.Build(key, &xds_context.Context{
+		ControlPlane: &xds_context.ControlPlaneContext{
+			SdsTlsCert:        nil,
+			AdminProxyKeyPair: nil,
+			CLACache:          nil,
+			DNSResolver:       rt.DNSResolver(),
+		},
+		Mesh: xds_context.MeshContext{
+			Resource:   mesh,
+			Dataplanes: &dataplanes,
+		},
+		ConnectionInfo:   xds_context.ConnectionInfo{},
+		EnvoyAdminClient: nil,
+	})
+	Expect(err).To(Succeed())
+
+	return proxy
 }
 
 // FetchNamedFixture retrieves the named resource from the runtime
@@ -51,7 +148,12 @@ func StoreNamedFixture(rt runtime.Runtime, name string) error {
 		return err
 	}
 
-	r, err := rest.UnmarshallToCore(bytes)
+	return StoreInlineFixture(rt, bytes)
+}
+
+// StoreInlineFixture stores the given YAML object in the runtime resource manager.
+func StoreInlineFixture(rt runtime.Runtime, object []byte) error {
+	r, err := rest.UnmarshallToCore(object)
 	if err != nil {
 		return err
 	}

--- a/pkg/plugins/runtime/gateway/testdata/01-gateway-listener.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/01-gateway-listener.yaml
@@ -1,0 +1,64 @@
+{
+  "Resources": {
+    "edge-gateway:HTTP:8080": {
+      "name": "edge-gateway:HTTP:8080",
+      "address": {
+        "socketAddress": {
+          "address": "192.168.1.1",
+          "portValue": 8080
+        }
+      },
+      "filterChains": [
+        {
+          "filters": [
+            {
+              "name": "envoy.filters.network.http_connection_manager",
+              "typedConfig": {
+                "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
+                "statPrefix": "gateway-default",
+                "rds": {
+                  "configSource": {
+                    "ads": {},
+                    "resourceApiVersion": "V3"
+                  },
+                  "routeConfigName": "default-route"
+                },
+                "httpFilters": [
+                  {
+                    "name": "envoy.filters.http.router"
+                  }
+                ],
+                "commonHttpProtocolOptions": {
+                  "idleTimeout": "300s",
+                  "headersWithUnderscoresAction": "REJECT_REQUEST"
+                },
+                "http2ProtocolOptions": {
+                  "maxConcurrentStreams": 100,
+                  "initialStreamWindowSize": 65536,
+                  "initialConnectionWindowSize": 1048576,
+                  "allowConnect": true
+                },
+                "serverName": "Kuma Gateway",
+                "streamIdleTimeout": "5s",
+                "requestHeadersTimeout": "0.500s",
+                "normalizePath": true,
+                "mergeSlashes": true
+              }
+            }
+          ]
+        }
+      ],
+      "perConnectionBufferLimitBytes": 32768,
+      "listenerFilters": [
+        {
+          "name": "envoy.filters.listener.tls_inspector",
+          "typedConfig": {
+            "@type": "type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector"
+          }
+        }
+      ],
+      "trafficDirection": "INBOUND",
+      "reusePort": true
+    }
+  }
+}

--- a/pkg/plugins/runtime/gateway/testdata/02-gateway-listener.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/02-gateway-listener.yaml
@@ -1,0 +1,124 @@
+{
+  "Resources": {
+    "edge-gateway:HTTP:8080": {
+      "name": "edge-gateway:HTTP:8080",
+      "address": {
+        "socketAddress": {
+          "address": "192.168.1.1",
+          "portValue": 8080
+        }
+      },
+      "filterChains": [
+        {
+          "filters": [
+            {
+              "name": "envoy.filters.network.http_connection_manager",
+              "typedConfig": {
+                "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
+                "statPrefix": "gateway-default",
+                "rds": {
+                  "configSource": {
+                    "ads": {},
+                    "resourceApiVersion": "V3"
+                  },
+                  "routeConfigName": "default-route"
+                },
+                "httpFilters": [
+                  {
+                    "name": "envoy.filters.http.router"
+                  }
+                ],
+                "commonHttpProtocolOptions": {
+                  "idleTimeout": "300s",
+                  "headersWithUnderscoresAction": "REJECT_REQUEST"
+                },
+                "http2ProtocolOptions": {
+                  "maxConcurrentStreams": 100,
+                  "initialStreamWindowSize": 65536,
+                  "initialConnectionWindowSize": 1048576,
+                  "allowConnect": true
+                },
+                "serverName": "Kuma Gateway",
+                "streamIdleTimeout": "5s",
+                "requestHeadersTimeout": "0.500s",
+                "normalizePath": true,
+                "mergeSlashes": true
+              }
+            }
+          ]
+        }
+      ],
+      "perConnectionBufferLimitBytes": 32768,
+      "listenerFilters": [
+        {
+          "name": "envoy.filters.listener.tls_inspector",
+          "typedConfig": {
+            "@type": "type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector"
+          }
+        }
+      ],
+      "trafficDirection": "INBOUND",
+      "reusePort": true
+    },
+    "edge-gateway:HTTP:9090": {
+      "name": "edge-gateway:HTTP:9090",
+      "address": {
+        "socketAddress": {
+          "address": "192.168.1.1",
+          "portValue": 9090
+        }
+      },
+      "filterChains": [
+        {
+          "filters": [
+            {
+              "name": "envoy.filters.network.http_connection_manager",
+              "typedConfig": {
+                "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
+                "statPrefix": "gateway-default",
+                "rds": {
+                  "configSource": {
+                    "ads": {},
+                    "resourceApiVersion": "V3"
+                  },
+                  "routeConfigName": "default-route"
+                },
+                "httpFilters": [
+                  {
+                    "name": "envoy.filters.http.router"
+                  }
+                ],
+                "commonHttpProtocolOptions": {
+                  "idleTimeout": "300s",
+                  "headersWithUnderscoresAction": "REJECT_REQUEST"
+                },
+                "http2ProtocolOptions": {
+                  "maxConcurrentStreams": 100,
+                  "initialStreamWindowSize": 65536,
+                  "initialConnectionWindowSize": 1048576,
+                  "allowConnect": true
+                },
+                "serverName": "Kuma Gateway",
+                "streamIdleTimeout": "5s",
+                "requestHeadersTimeout": "0.500s",
+                "normalizePath": true,
+                "mergeSlashes": true
+              }
+            }
+          ]
+        }
+      ],
+      "perConnectionBufferLimitBytes": 32768,
+      "listenerFilters": [
+        {
+          "name": "envoy.filters.listener.tls_inspector",
+          "typedConfig": {
+            "@type": "type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector"
+          }
+        }
+      ],
+      "trafficDirection": "INBOUND",
+      "reusePort": true
+    }
+  }
+}

--- a/pkg/plugins/runtime/gateway/testdata/03-gateway-listener.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/03-gateway-listener.yaml
@@ -1,0 +1,79 @@
+{
+  "Resources": {
+    "tracing-gateway:HTTP:8080": {
+      "name": "tracing-gateway:HTTP:8080",
+      "address": {
+        "socketAddress": {
+          "address": "192.168.1.1",
+          "portValue": 8080
+        }
+      },
+      "filterChains": [
+        {
+          "filters": [
+            {
+              "name": "envoy.filters.network.http_connection_manager",
+              "typedConfig": {
+                "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
+                "statPrefix": "gateway-default",
+                "rds": {
+                  "configSource": {
+                    "ads": {},
+                    "resourceApiVersion": "V3"
+                  },
+                  "routeConfigName": "default-route"
+                },
+                "httpFilters": [
+                  {
+                    "name": "envoy.filters.http.router"
+                  }
+                ],
+                "tracing": {
+                  "overallSampling": {
+                    "value": 100
+                  },
+                  "provider": {
+                    "name": "envoy.zipkin",
+                    "typedConfig": {
+                      "@type": "type.googleapis.com/envoy.config.trace.v3.ZipkinConfig",
+                      "collectorCluster": "tracing:jaeger-collector",
+                      "collectorEndpoint": "/api/v2/spans",
+                      "collectorEndpointVersion": "HTTP_JSON",
+                      "collectorHostname": "jaeger-collector.kuma-tracing:9411"
+                    }
+                  }
+                },
+                "commonHttpProtocolOptions": {
+                  "idleTimeout": "300s",
+                  "headersWithUnderscoresAction": "REJECT_REQUEST"
+                },
+                "http2ProtocolOptions": {
+                  "maxConcurrentStreams": 100,
+                  "initialStreamWindowSize": 65536,
+                  "initialConnectionWindowSize": 1048576,
+                  "allowConnect": true
+                },
+                "serverName": "Kuma Gateway",
+                "streamIdleTimeout": "5s",
+                "requestHeadersTimeout": "0.500s",
+                "normalizePath": true,
+                "mergeSlashes": true
+              }
+            }
+          ]
+        }
+      ],
+      "perConnectionBufferLimitBytes": 32768,
+      "listenerFilters": [
+        {
+          "name": "envoy.filters.listener.tls_inspector",
+          "typedConfig": {
+            "@type": "type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector"
+          }
+        }
+      ],
+      "trafficDirection": "INBOUND",
+      "reusePort": true
+    }
+  }
+}

--- a/pkg/plugins/runtime/gateway/testdata/04-gateway-listener.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/04-gateway-listener.yaml
@@ -1,0 +1,64 @@
+{
+  "Resources": {
+    "logging-gateway:HTTP:8080": {
+      "name": "logging-gateway:HTTP:8080",
+      "address": {
+        "socketAddress": {
+          "address": "192.168.1.1",
+          "portValue": 8080
+        }
+      },
+      "filterChains": [
+        {
+          "filters": [
+            {
+              "name": "envoy.filters.network.http_connection_manager",
+              "typedConfig": {
+                "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
+                "statPrefix": "gateway-default",
+                "rds": {
+                  "configSource": {
+                    "ads": {},
+                    "resourceApiVersion": "V3"
+                  },
+                  "routeConfigName": "default-route"
+                },
+                "httpFilters": [
+                  {
+                    "name": "envoy.filters.http.router"
+                  }
+                ],
+                "commonHttpProtocolOptions": {
+                  "idleTimeout": "300s",
+                  "headersWithUnderscoresAction": "REJECT_REQUEST"
+                },
+                "http2ProtocolOptions": {
+                  "maxConcurrentStreams": 100,
+                  "initialStreamWindowSize": 65536,
+                  "initialConnectionWindowSize": 1048576,
+                  "allowConnect": true
+                },
+                "serverName": "Kuma Gateway",
+                "streamIdleTimeout": "5s",
+                "requestHeadersTimeout": "0.500s",
+                "normalizePath": true,
+                "mergeSlashes": true
+              }
+            }
+          ]
+        }
+      ],
+      "perConnectionBufferLimitBytes": 32768,
+      "listenerFilters": [
+        {
+          "name": "envoy.filters.listener.tls_inspector",
+          "typedConfig": {
+            "@type": "type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector"
+          }
+        }
+      ],
+      "trafficDirection": "INBOUND",
+      "reusePort": true
+    }
+  }
+}

--- a/pkg/plugins/runtime/gateway/testdata/dataplane-logging.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/dataplane-logging.yaml
@@ -1,5 +1,5 @@
 type: Dataplane
-mesh: default
+mesh: logging
 name: default
 networking:
   address: 192.168.1.1

--- a/pkg/plugins/runtime/gateway/testdata/dataplane-tracing.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/dataplane-tracing.yaml
@@ -1,5 +1,5 @@
 type: Dataplane
-mesh: default
+mesh: tracing
 name: default
 networking:
   address: 192.168.1.1

--- a/pkg/plugins/runtime/gateway/testdata/mesh-logging.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/mesh-logging.yaml
@@ -1,0 +1,14 @@
+type: Mesh
+name: logging
+logging:
+  defaultBackend: file
+  backends:
+    - name: logstash
+      format: '{"start_time": "%START_TIME%", "source": "%KUMA_SOURCE_SERVICE%", "destination": "%KUMA_DESTINATION_SERVICE%", "source_address": "%KUMA_SOURCE_ADDRESS_WITHOUT_PORT%", "destination_address": "%UPSTREAM_HOST%", "duration_millis": "%DURATION%", "bytes_received": "%BYTES_RECEIVED%", "bytes_sent": "%BYTES_SENT%"}'
+      type: tcp
+      conf:
+        address: 127.0.0.1:5000
+    - name: file
+      type: file
+      conf:
+        path: /tmp/access.log

--- a/pkg/plugins/runtime/gateway/testdata/mesh-tracing.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/mesh-tracing.yaml
@@ -1,0 +1,10 @@
+type: Mesh
+name: tracing
+tracing:
+  defaultBackend: jaeger-collector
+  backends:
+  - name: jaeger-collector
+    type: zipkin
+    sampling: 100.0
+    conf:
+      url: http://jaeger-collector.kuma-tracing:9411/api/v2/spans

--- a/pkg/plugins/runtime/gateway/testdata/trafficlog.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/trafficlog.yaml
@@ -1,0 +1,9 @@
+type: TrafficLog
+name: all-traffic
+mesh: logging
+sources:
+  - match:
+      kuma.io/service: '*'
+destinations:
+  - match:
+      kuma.io/service: '*'

--- a/pkg/plugins/runtime/gateway/testdata/traffictrace.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/traffictrace.yaml
@@ -1,0 +1,8 @@
+type: TrafficTrace
+name: trace-all
+mesh: tracing
+selectors:
+- match:
+    kuma.io/service: '*'
+conf:
+  backend: jaeger-collector

--- a/pkg/xds/envoy/names/resource_names.go
+++ b/pkg/xds/envoy/names/resource_names.go
@@ -70,3 +70,7 @@ func GetTracingClusterName(backendName string) string {
 func GetDNSListenerName() string {
 	return "kuma:dns"
 }
+
+func GetGatewayListenerName(gatewayName string, protoName string, port uint32) string {
+	return strings.Join([]string{gatewayName, protoName, strconv.Itoa(int(port))}, ":")
+}

--- a/pkg/xds/sync/components.go
+++ b/pkg/xds/sync/components.go
@@ -29,7 +29,7 @@ func defaultDataplaneProxyBuilder(rt core_runtime.Runtime, metadataTracker Datap
 		FaultInjectionMatcher: faultinjections.FaultInjectionMatcher{ResourceManager: rt.ReadOnlyResourceManager()},
 		RateLimitMatcher:      ratelimits.RateLimitMatcher{ResourceManager: rt.ReadOnlyResourceManager()},
 		Zone:                  rt.Config().Multizone.Zone.Name,
-		apiVersion:            apiVersion,
+		APIVersion:            apiVersion,
 	}
 }
 

--- a/pkg/xds/sync/dataplane_proxy_builder.go
+++ b/pkg/xds/sync/dataplane_proxy_builder.go
@@ -36,10 +36,10 @@ type DataplaneProxyBuilder struct {
 	RateLimitMatcher      ratelimits.RateLimitMatcher
 
 	Zone       string
-	apiVersion envoy.APIVersion
+	APIVersion envoy.APIVersion
 }
 
-func (p *DataplaneProxyBuilder) build(key core_model.ResourceKey, envoyContext *xds_context.Context) (*xds.Proxy, error) {
+func (p *DataplaneProxyBuilder) Build(key core_model.ResourceKey, envoyContext *xds_context.Context) (*xds.Proxy, error) {
 	ctx := context.Background()
 
 	dp, err := p.resolveDataplane(ctx, key)
@@ -59,7 +59,7 @@ func (p *DataplaneProxyBuilder) build(key core_model.ResourceKey, envoyContext *
 
 	proxy := &xds.Proxy{
 		Id:         xds.FromResourceKey(key),
-		APIVersion: p.apiVersion,
+		APIVersion: p.APIVersion,
 		Dataplane:  dp,
 		Metadata:   p.MetadataTracker.Metadata(key),
 		Routing:    *routing,

--- a/pkg/xds/sync/dataplane_watchdog.go
+++ b/pkg/xds/sync/dataplane_watchdog.go
@@ -106,7 +106,7 @@ func (d *DataplaneWatchdog) syncDataplane() error {
 	if err != nil {
 		return err
 	}
-	proxy, err := d.dataplaneProxyBuilder.build(d.key, envoyCtx)
+	proxy, err := d.dataplaneProxyBuilder.Build(d.key, envoyCtx)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
### Summary

Implement the initial Gateway listener generator. Match Gateway resources
to the corresponding Dataplanes and generate listener xDS resources.

### Full changelog

N/A

### Issues resolved

N/A

### Documentation

N/A

### Testing

- [x] Unit tests
- [x] E2E tests
- [x] Manual testing on Universal
- [ ] Manual testing on Kubernetes 

### Backwards compatibility

- [x] Add `backport-to-stable` label if the code is backwards compatible. Otherwise, list breaking changes.
