### PR TITLE
fix(kuma-cp): Sort services by name when selecting them

### DIFF
--- a/pkg/plugins/runtime/k8s/util/util.go
+++ b/pkg/plugins/runtime/k8s/util/util.go
@@ -2,6 +2,7 @@ package util
 
 import (
 	"fmt"
+	"sort"
 
 	kube_core "k8s.io/api/core/v1"
 	kube_labels "k8s.io/apimachinery/pkg/labels"
@@ -42,6 +43,10 @@ func FindServices(svcs *kube_core.ServiceList, predicates ...ServicePredicate) [
 			matching = append(matching, svc)
 		}
 	}
+	// Sort by name so that inbound order is similar across zones regardless of the order services got created.
+	sort.Slice(matching, func(i, j int) bool {
+		return matching[i].Name < matching[j].Name
+	})
 	return matching
 }
 

--- a/pkg/plugins/runtime/k8s/util/util_test.go
+++ b/pkg/plugins/runtime/k8s/util/util_test.go
@@ -1,6 +1,8 @@
 package util_test
 
 import (
+	"time"
+
 	"github.com/ghodss/yaml"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
@@ -64,19 +66,31 @@ var _ = Describe("Util", func() {
 		})
 	})
 
-	Describe("FindServices", func() {
-		It("should match Services by a predicate", func() {
-			// given
-			pod := &kube_core.Pod{
+	exampleTime := time.Date(2020, 01, 01, 01, 12, 00, 00, time.UTC)
+	DescribeTable("FindServices",
+		func(pod *kube_core.Pod, svcs *kube_core.ServiceList, matchSvcNames []string) {
+			// when
+			matchingServices := FindServices(svcs, AnySelector(), MatchServiceThatSelectsPod(pod))
+			// then
+			Expect(matchingServices).To(WithTransform(func(svcs []*kube_core.Service) []string {
+				var res []string
+				for i := range svcs {
+					res = append(res, svcs[i].Name)
+				}
+				return res
+			}, Equal(matchSvcNames)))
+		},
+		Entry("should match services by a predicate",
+			&kube_core.Pod{
 				ObjectMeta: kube_meta.ObjectMeta{
 					Labels: map[string]string{
 						"app":               "demo-app",
 						"pod-template-hash": "7cbbd658d5",
 					},
 				},
-			}
+			},
 			// and
-			svcs := &kube_core.ServiceList{
+			&kube_core.ServiceList{
 				Items: []kube_core.Service{
 					{
 						ObjectMeta: kube_meta.ObjectMeta{
@@ -106,15 +120,67 @@ var _ = Describe("Util", func() {
 						Spec: kube_core.ServiceSpec{},
 					},
 				},
-			}
-
-			// when
-			matchingServices := FindServices(svcs, AnySelector(), MatchServiceThatSelectsPod(pod))
-			// then
-			Expect(matchingServices).To(HaveLen(1))
-			Expect(matchingServices).To(ConsistOf(&svcs.Items[0]))
-		})
-	})
+			},
+			[]string{"demo-app"},
+		),
+		Entry("should match multiple services in order",
+			&kube_core.Pod{
+				ObjectMeta: kube_meta.ObjectMeta{
+					Labels: map[string]string{
+						"app":               "demo-app",
+						"pod-template-hash": "7cbbd658d5",
+					},
+				},
+			},
+			// and
+			&kube_core.ServiceList{
+				Items: []kube_core.Service{
+					{
+						ObjectMeta: kube_meta.ObjectMeta{
+							CreationTimestamp: kube_meta.NewTime(exampleTime),
+							Name:              "demo-app2",
+						},
+						Spec: kube_core.ServiceSpec{
+							Selector: map[string]string{
+								"app": "demo-app",
+							},
+						},
+					},
+					{
+						ObjectMeta: kube_meta.ObjectMeta{
+							CreationTimestamp: kube_meta.NewTime(exampleTime),
+							Name:              "demo-app",
+						},
+						Spec: kube_core.ServiceSpec{
+							Selector: map[string]string{
+								"app": "demo-app",
+							},
+						},
+					},
+					{
+						ObjectMeta: kube_meta.ObjectMeta{
+							CreationTimestamp: kube_meta.NewTime(exampleTime.Add(-time.Hour)),
+							Name:              "nginx",
+						},
+						Spec: kube_core.ServiceSpec{
+							Selector: map[string]string{
+								"app": "demo-app",
+							},
+						},
+					},
+					{
+						ObjectMeta: kube_meta.ObjectMeta{
+							CreationTimestamp: kube_meta.NewTime(exampleTime),
+							Name:              "kubernetes",
+							Namespace:         "default",
+						},
+						Spec: kube_core.ServiceSpec{},
+					},
+				},
+			},
+			[]string{"demo-app", "demo-app2", "nginx"},
+		),
+	)
 
 	Describe("CopyStringMap", func() {
 		It("should return nil if input is nil", func() {


### PR DESCRIPTION
The default sort in k8s is by CreationTimestamp.
In the case of a deployment created in 2 different k8s clusters if
the services were not created in the same order the inbounds would be
generated in a different order which was confusing to the user.

We therefore sort services by name which will always be correct across zones.

- For regular dataplanes it ensures that the resources are the same regardless of the order in which k8s services were created
- For gateways it ensures that the service name of the gateway is the same (as it's derived from the first service that matches).

Fix #2500 and #2170

Signed-off-by: Charly Molter <charly.molter@konghq.com>