### PR TITLE
fix(kuma-cp) deleted default policy is created on Kuma CP restart

### DIFF
--- a/pkg/core/resources/store/options.go
+++ b/pkg/core/resources/store/options.go
@@ -12,7 +12,6 @@ type CreateOptions struct {
 	Mesh         string
 	CreationTime time.Time
 	Owner        core_model.Resource
-	Synced       bool
 }
 
 type CreateOptionsFunc func(*CreateOptions)
@@ -48,26 +47,13 @@ func CreateWithOwner(owner core_model.Resource) CreateOptionsFunc {
 	}
 }
 
-func CreateSynced() CreateOptionsFunc {
-	return func(opts *CreateOptions) {
-		opts.Synced = true
-	}
-}
-
 type UpdateOptions struct {
 	ModificationTime time.Time
-	Synced           bool
 }
 
 func ModifiedAt(modificationTime time.Time) UpdateOptionsFunc {
 	return func(opts *UpdateOptions) {
 		opts.ModificationTime = modificationTime
-	}
-}
-
-func UpdateSynced() UpdateOptionsFunc {
-	return func(opts *UpdateOptions) {
-		opts.Synced = true
 	}
 }
 

--- a/pkg/kds/store/sync.go
+++ b/pkg/kds/store/sync.go
@@ -141,7 +141,6 @@ func (s *syncResourceStore) Sync(upstream model.ResourceList, fs ...SyncOptionFu
 		createOpts := []store.CreateOptionsFunc{
 			store.CreateBy(rk),
 			store.CreatedAt(creationTime),
-			store.CreateSynced(),
 		}
 		if opts.Zone != "" {
 			createOpts = append(createOpts, store.CreateWithOwner(zone))
@@ -157,7 +156,7 @@ func (s *syncResourceStore) Sync(upstream model.ResourceList, fs ...SyncOptionFu
 		// some stores manage ModificationTime time on they own (Kubernetes), in order to be consistent
 		// we set ModificationTime when we add to downstream store. This time is almost the same with ModificationTime
 		// from upstream store, because we update downstream only when resource have changed in upstream
-		if err := s.resourceStore.Update(ctx, r, store.ModifiedAt(now), store.UpdateSynced()); err != nil {
+		if err := s.resourceStore.Update(ctx, r, store.ModifiedAt(now)); err != nil {
 			return err
 		}
 	}

--- a/pkg/plugins/common/k8s/names.go
+++ b/pkg/plugins/common/k8s/names.go
@@ -18,6 +18,10 @@ const (
 	// k8sSynced identifies that resource was synced
 	K8sSynced = "k8s.kuma.io/synced"
 
+	// K8sProcessed identifies that resource was already processed on creation. Specifically it's used to avoid
+	// creation of default resources twice when Kuma CP restarts
+	K8sProcessed = "k8s.kuma.io/processed"
+
 	// Kubernetes secret type to differentiate Kuma System secrets. Secret is bound to a mesh
 	MeshSecretType = "system.kuma.io/secret"
 

--- a/pkg/plugins/common/k8s/names.go
+++ b/pkg/plugins/common/k8s/names.go
@@ -15,9 +15,6 @@ const (
 	// The value has a format of a Kubernetes label name.
 	k8sNameComponent = "k8s.kuma.io/name"
 
-	// k8sSynced identifies that resource was synced
-	K8sSynced = "k8s.kuma.io/synced"
-
 	// K8sProcessed identifies that resource was already processed on creation. Specifically it's used to avoid
 	// creation of default resources twice when Kuma CP restarts
 	K8sProcessed = "k8s.kuma.io/processed"

--- a/pkg/plugins/common/k8s/names.go
+++ b/pkg/plugins/common/k8s/names.go
@@ -15,9 +15,8 @@ const (
 	// The value has a format of a Kubernetes label name.
 	k8sNameComponent = "k8s.kuma.io/name"
 
-	// K8sProcessed identifies that resource was already processed on creation. Specifically it's used to avoid
-	// creation of default resources twice when Kuma CP restarts
-	K8sProcessed = "k8s.kuma.io/processed"
+	// K8sMeshDefaultsGenerated identifies that default resources for mesh were successfully generated
+	K8sMeshDefaultsGenerated = "k8s.kuma.io/mesh-defaults-generated"
 
 	// Kubernetes secret type to differentiate Kuma System secrets. Secret is bound to a mesh
 	MeshSecretType = "system.kuma.io/secret"

--- a/pkg/plugins/resources/k8s/store.go
+++ b/pkg/plugins/resources/k8s/store.go
@@ -60,10 +60,6 @@ func (s *KubernetesStore) Create(ctx context.Context, r core_model.Resource, fs 
 		}
 	}
 
-	if opts.Synced {
-		markAsSynced(obj)
-	}
-
 	if err := s.Client.Create(ctx, obj); err != nil {
 		if kube_apierrs.IsAlreadyExists(err) {
 			return store.ErrorResourceAlreadyExists(r.GetType(), opts.Name, opts.Mesh)
@@ -77,25 +73,10 @@ func (s *KubernetesStore) Create(ctx context.Context, r core_model.Resource, fs 
 	return nil
 }
 
-func markAsSynced(obj k8s_model.KubernetesObject) {
-	annotations := obj.GetAnnotations()
-	if annotations == nil {
-		annotations = map[string]string{}
-	}
-	annotations[k8s_common.K8sSynced] = "true"
-	obj.SetAnnotations(annotations)
-}
-
 func (s *KubernetesStore) Update(ctx context.Context, r core_model.Resource, fs ...store.UpdateOptionsFunc) error {
-	opts := store.NewUpdateOptions(fs...)
-
 	obj, err := s.Converter.ToKubernetesObject(r)
 	if err != nil {
 		return errors.Wrapf(err, "failed to convert core model of type %s into k8s counterpart", r.GetType())
-	}
-
-	if opts.Synced {
-		markAsSynced(obj)
 	}
 
 	if err := s.Client.Update(ctx, obj); err != nil {

--- a/pkg/plugins/runtime/k8s/controllers/mesh_defaults_controller.go
+++ b/pkg/plugins/runtime/k8s/controllers/mesh_defaults_controller.go
@@ -3,7 +3,6 @@ package controllers
 import (
 	"context"
 
-	common_k8s "github.com/kumahq/kuma/pkg/plugins/common/k8s"
 	"github.com/pkg/errors"
 	kube_core "k8s.io/api/core/v1"
 	kube_ctrl "sigs.k8s.io/controller-runtime"
@@ -17,6 +16,7 @@ import (
 	core_model "github.com/kumahq/kuma/pkg/core/resources/model"
 	"github.com/kumahq/kuma/pkg/core/resources/store"
 	defaults_mesh "github.com/kumahq/kuma/pkg/defaults/mesh"
+	common_k8s "github.com/kumahq/kuma/pkg/plugins/common/k8s"
 	"github.com/kumahq/kuma/pkg/plugins/resources/k8s"
 	mesh_k8s "github.com/kumahq/kuma/pkg/plugins/resources/k8s/native/api/v1alpha1"
 )

--- a/pkg/plugins/runtime/k8s/controllers/mesh_defaults_controller.go
+++ b/pkg/plugins/runtime/k8s/controllers/mesh_defaults_controller.go
@@ -1,6 +1,9 @@
 package controllers
 
 import (
+	"context"
+
+	common_k8s "github.com/kumahq/kuma/pkg/plugins/common/k8s"
 	"github.com/pkg/errors"
 	kube_core "k8s.io/api/core/v1"
 	kube_ctrl "sigs.k8s.io/controller-runtime"
@@ -8,8 +11,13 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
+	"github.com/kumahq/kuma/pkg/core"
+	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	"github.com/kumahq/kuma/pkg/core/resources/manager"
+	core_model "github.com/kumahq/kuma/pkg/core/resources/model"
+	"github.com/kumahq/kuma/pkg/core/resources/store"
 	defaults_mesh "github.com/kumahq/kuma/pkg/defaults/mesh"
+	"github.com/kumahq/kuma/pkg/plugins/resources/k8s"
 	mesh_k8s "github.com/kumahq/kuma/pkg/plugins/resources/k8s/native/api/v1alpha1"
 )
 
@@ -19,8 +27,28 @@ type MeshDefaultsReconciler struct {
 }
 
 func (r *MeshDefaultsReconciler) Reconcile(req kube_ctrl.Request) (kube_ctrl.Result, error) {
+	mesh := core_mesh.NewMeshResource()
+	if err := r.ResourceManager.Get(context.Background(), mesh, store.GetByKey(req.Name, core_model.NoMesh)); err != nil {
+		return kube_ctrl.Result{}, errors.Wrap(err, "could not get default mesh resources")
+	}
+
+	// Before creating default policies for the mesh we want to ensure that this mesh wasn't processed before.
+	// We can't rely on filtering by CreateFunc, because apparently it sends the create event every time resource
+	// is added to the underlying Informer. That's why on the Kuma CP restart Mesh will be processed the second time
+	if processed := mesh.GetMeta().(*k8s.KubernetesMetaAdapter).GetAnnotations()[common_k8s.K8sProcessed]; processed == "true" {
+		return kube_ctrl.Result{}, nil
+	}
+
 	if err := defaults_mesh.EnsureDefaultMeshResources(r.ResourceManager, req.Name); err != nil {
 		return kube_ctrl.Result{}, errors.Wrap(err, "could not create default mesh resources")
+	}
+
+	if mesh.GetMeta().(*k8s.KubernetesMetaAdapter).Annotations == nil {
+		mesh.GetMeta().(*k8s.KubernetesMetaAdapter).Annotations = map[string]string{}
+	}
+	mesh.GetMeta().(*k8s.KubernetesMetaAdapter).GetAnnotations()[common_k8s.K8sProcessed] = "true"
+	if err := r.ResourceManager.Update(context.Background(), mesh, store.ModifiedAt(core.Now())); err != nil {
+		return kube_ctrl.Result{}, errors.Wrap(err, "could not update default mesh resources")
 	}
 	return kube_ctrl.Result{}, nil
 }

--- a/pkg/plugins/runtime/k8s/controllers/mesh_defaults_controller_test.go
+++ b/pkg/plugins/runtime/k8s/controllers/mesh_defaults_controller_test.go
@@ -84,20 +84,15 @@ var _ = Describe("MeshDefaultsReconciler", func() {
 	It("should not create a new default policy if it was deleted", func() {
 
 		createMesh()
-
 		Expect(hasTrafficPermissions()).To(BeFalse())
 
 		reconcile()
-
 		Expect(hasTrafficPermissions()).To(BeTrue())
 
 		deleteTrafficPermission()
-
 		Expect(hasTrafficPermissions()).To(BeFalse())
 
 		reconcile()
-
 		Expect(hasTrafficPermissions()).To(BeFalse())
-
 	})
 })

--- a/pkg/plugins/runtime/k8s/controllers/mesh_defaults_controller_test.go
+++ b/pkg/plugins/runtime/k8s/controllers/mesh_defaults_controller_test.go
@@ -1,0 +1,103 @@
+package controllers_test
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	kube_types "k8s.io/apimachinery/pkg/types"
+	kube_ctrl "sigs.k8s.io/controller-runtime"
+	kube_client "sigs.k8s.io/controller-runtime/pkg/client"
+	kube_client_fake "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	kube_reconcile "sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
+	"github.com/kumahq/kuma/pkg/core/resources/apis/system"
+	resources_manager "github.com/kumahq/kuma/pkg/core/resources/manager"
+	"github.com/kumahq/kuma/pkg/core/resources/model"
+	core_store "github.com/kumahq/kuma/pkg/core/resources/store"
+	secret_cipher "github.com/kumahq/kuma/pkg/core/secrets/cipher"
+	secret_manager "github.com/kumahq/kuma/pkg/core/secrets/manager"
+	"github.com/kumahq/kuma/pkg/plugins/resources/k8s"
+	"github.com/kumahq/kuma/pkg/plugins/runtime/k8s/controllers"
+	secrets_k8s "github.com/kumahq/kuma/pkg/plugins/secrets/k8s"
+)
+
+var _ = Describe("MeshDefaultsReconciler", func() {
+
+	var kubeClient kube_client.Client
+	var resourceManager resources_manager.ResourceManager
+	var reconciler kube_reconcile.Reconciler
+
+	BeforeEach(func() {
+		kubeClient = kube_client_fake.NewFakeClientWithScheme(k8sClientScheme)
+		store, err := k8s.NewStore(kubeClient, k8sClientScheme, k8s.NewSimpleConverter())
+		Expect(err).ToNot(HaveOccurred())
+		secretStore, err := secrets_k8s.NewStore(kubeClient, kubeClient, "default")
+		Expect(err).ToNot(HaveOccurred())
+
+		resourceManager = resources_manager.NewResourceManager(store)
+		customizableManager := resources_manager.NewCustomizableResourceManager(resourceManager, nil)
+		customizableManager.Customize(
+			system.SecretType,
+			secret_manager.NewSecretManager(
+				secretStore,
+				secret_cipher.None(),
+				secret_manager.ValidateDelete(func(ctx context.Context, secretName string, secretMesh string) error { return nil })),
+		)
+
+		reconciler = &controllers.MeshDefaultsReconciler{
+			ResourceManager: customizableManager,
+		}
+	})
+
+	createMesh := func() {
+		Expect(
+			resourceManager.Create(context.Background(), mesh.NewMeshResource(), core_store.CreateByKey("default", model.NoMesh)),
+		).To(Succeed())
+	}
+
+	hasTrafficPermissions := func() bool {
+		trafficPermissions := &mesh.TrafficPermissionResourceList{}
+		Expect(
+			resourceManager.List(context.Background(), trafficPermissions, core_store.ListByMesh("default")),
+		).To(Succeed())
+		return len(trafficPermissions.Items) == 1
+	}
+
+	reconcile := func() {
+		_, err := reconciler.Reconcile(kube_ctrl.Request{
+			NamespacedName: kube_types.NamespacedName{
+				Name: "default",
+			},
+		})
+		Expect(err).ToNot(HaveOccurred())
+	}
+
+	deleteTrafficPermission := func() {
+		Expect(
+			resourceManager.Delete(context.Background(), mesh.NewTrafficPermissionResource(),
+				core_store.DeleteByKey("allow-all-default", "default")),
+		).To(Succeed())
+	}
+
+	It("should not create a new default policy if it was deleted", func() {
+
+		createMesh()
+
+		Expect(hasTrafficPermissions()).To(BeFalse())
+
+		reconcile()
+
+		Expect(hasTrafficPermissions()).To(BeTrue())
+
+		deleteTrafficPermission()
+
+		Expect(hasTrafficPermissions()).To(BeFalse())
+
+		reconcile()
+
+		Expect(hasTrafficPermissions()).To(BeFalse())
+
+	})
+})

--- a/pkg/plugins/runtime/k8s/controllers/mesh_defaults_controller_test.go
+++ b/pkg/plugins/runtime/k8s/controllers/mesh_defaults_controller_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	"github.com/kumahq/kuma/pkg/core/resources/apis/system"
 	resources_manager "github.com/kumahq/kuma/pkg/core/resources/manager"
-	"github.com/kumahq/kuma/pkg/core/resources/model"
+	core_model "github.com/kumahq/kuma/pkg/core/resources/model"
 	core_store "github.com/kumahq/kuma/pkg/core/resources/store"
 	secret_cipher "github.com/kumahq/kuma/pkg/core/secrets/cipher"
 	secret_manager "github.com/kumahq/kuma/pkg/core/secrets/manager"
@@ -53,7 +53,7 @@ var _ = Describe("MeshDefaultsReconciler", func() {
 
 	createMesh := func() {
 		Expect(
-			resourceManager.Create(context.Background(), mesh.NewMeshResource(), core_store.CreateByKey("default", model.NoMesh)),
+			resourceManager.Create(context.Background(), mesh.NewMeshResource(), core_store.CreateByKey("default", core_model.NoMesh)),
 		).To(Succeed())
 	}
 
@@ -82,7 +82,6 @@ var _ = Describe("MeshDefaultsReconciler", func() {
 	}
 
 	It("should not create a new default policy if it was deleted", func() {
-
 		createMesh()
 		Expect(hasTrafficPermissions()).To(BeFalse())
 

--- a/test/e2e/trafficpermission/kubernetes/e2e_suite_test.go
+++ b/test/e2e/trafficpermission/kubernetes/e2e_suite_test.go
@@ -1,0 +1,16 @@
+package kubernetes_test
+
+import (
+	"testing"
+
+	"github.com/kumahq/kuma/pkg/test"
+	"github.com/kumahq/kuma/test/framework"
+)
+
+func TestE2ETrafficPermissionKubernetes(t *testing.T) {
+	if framework.IsK8sClustersStarted() {
+		test.RunSpecs(t, "Traffic Permission Kubernetes Suite")
+	} else {
+		t.SkipNow()
+	}
+}

--- a/test/e2e/trafficpermission/kubernetes/traffic_permission_k8s.go
+++ b/test/e2e/trafficpermission/kubernetes/traffic_permission_k8s.go
@@ -5,10 +5,11 @@ import (
 	"time"
 
 	"github.com/gruntwork-io/terratest/modules/k8s"
-	config_core "github.com/kumahq/kuma/pkg/config/core"
-	. "github.com/kumahq/kuma/test/framework"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+
+	config_core "github.com/kumahq/kuma/pkg/config/core"
+	. "github.com/kumahq/kuma/test/framework"
 )
 
 func TrafficPermission() {
@@ -52,7 +53,6 @@ func TrafficPermission() {
 	}
 
 	It("should not create deleted default traffic permission after Kuma CP restart", func() {
-
 		Eventually(hasDefaultTrafficPermission, "30s", "1s").Should(BeTrue())
 
 		// when

--- a/test/e2e/trafficpermission/kubernetes/traffic_permission_k8s.go
+++ b/test/e2e/trafficpermission/kubernetes/traffic_permission_k8s.go
@@ -1,0 +1,70 @@
+package kubernetes
+
+import (
+	"strings"
+	"time"
+
+	"github.com/gruntwork-io/terratest/modules/k8s"
+	config_core "github.com/kumahq/kuma/pkg/config/core"
+	. "github.com/kumahq/kuma/test/framework"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TrafficPermission() {
+	var k8sCluster Cluster
+	var optsKubernetes = KumaK8sDeployOpts
+
+	E2EBeforeSuite(func() {
+		k8sClusters, err := NewK8sClusters([]string{Kuma1}, Silent)
+		Expect(err).ToNot(HaveOccurred())
+
+		k8sCluster = k8sClusters.GetCluster(Kuma1)
+
+		Expect(Kuma(config_core.Standalone, optsKubernetes...)(k8sCluster)).To(Succeed())
+		Expect(k8sCluster.VerifyKuma()).To(Succeed())
+	})
+
+	E2EAfterSuite(func() {
+		Expect(k8sCluster.DeleteKuma(optsKubernetes...)).To(Succeed())
+		Expect(k8sCluster.DismissCluster()).To(Succeed())
+	})
+
+	removeDefaultTrafficPermission := func() {
+		err := k8s.RunKubectlE(k8sCluster.GetTesting(), k8sCluster.GetKubectlOptions(), "delete", "trafficpermission", "allow-all-default")
+		Expect(err).ToNot(HaveOccurred())
+	}
+
+	hasDefaultTrafficPermission := func() bool {
+		out, err := k8s.RunKubectlAndGetOutputE(k8sCluster.GetTesting(), k8sCluster.GetKubectlOptions(), "get", "trafficpermissions")
+		if err != nil {
+			return false
+		}
+		return strings.Contains(out, "allow-all-default")
+	}
+
+	restartKumaCP := func() {
+		pods := k8sCluster.GetKuma().(*K8sControlPlane).GetKumaCPPods()
+		Expect(pods).To(HaveLen(1))
+		err := k8s.RunKubectlE(k8sCluster.GetTesting(), k8sCluster.GetKubectlOptions(), "delete", "pod", pods[0].GetName(), "-n", pods[0].GetNamespace())
+		Expect(err).ToNot(HaveOccurred())
+		Expect(k8sCluster.(*K8sCluster).WaitApp(KumaServiceName, KumaNamespace, 1)).To(Succeed())
+	}
+
+	It("should not create deleted default traffic permission after Kuma CP restart", func() {
+
+		Eventually(hasDefaultTrafficPermission, "30s", "1s").Should(BeTrue())
+
+		// when
+		removeDefaultTrafficPermission()
+		// then
+		Eventually(hasDefaultTrafficPermission, "30s", "1s").Should(BeFalse())
+
+		// when
+		restartKumaCP()
+		// and when
+		time.Sleep(10 * time.Second)
+		// then
+		Eventually(hasDefaultTrafficPermission, "30s", "1s").Should(BeFalse())
+	})
+}

--- a/test/e2e/trafficpermission/kubernetes/traffic_permission_k8s_test.go
+++ b/test/e2e/trafficpermission/kubernetes/traffic_permission_k8s_test.go
@@ -1,8 +1,9 @@
 package kubernetes_test
 
 import (
-	"github.com/kumahq/kuma/test/e2e/trafficpermission/kubernetes"
 	. "github.com/onsi/ginkgo"
+
+	"github.com/kumahq/kuma/test/e2e/trafficpermission/kubernetes"
 )
 
 var _ = Describe("Traffic Permission on Kubernetes", kubernetes.TrafficPermission)

--- a/test/e2e/trafficpermission/kubernetes/traffic_permission_k8s_test.go
+++ b/test/e2e/trafficpermission/kubernetes/traffic_permission_k8s_test.go
@@ -1,0 +1,8 @@
+package kubernetes_test
+
+import (
+	"github.com/kumahq/kuma/test/e2e/trafficpermission/kubernetes"
+	. "github.com/onsi/ginkgo"
+)
+
+var _ = Describe("Traffic Permission on Kubernetes", kubernetes.TrafficPermission)


### PR DESCRIPTION
### Summary

In the k8s controller, we're filtering events by their type (Create, Update, ...), but apparently, these events are related to the underlying Informer, so in our case, we will receive Create event every time Kuma CP restarts. This means that the default policy deleted by the user will be recreated after the Kuma CP restart.

Current PR annotates every mesh that was processed.

### Full changelog

* add `k8s.kuma.io/processed` annotation for Meshes
* cleanup stuff related to `k8s.kuma.io/synced` annotations since it's not used anymore

### Issues resolved

N/A

### Documentation

- [ ] Link to the website [documentation PR](https://github.com/kumahq/kuma-website/pull/XXX)

### Testing

- [X] Unit tests
- [x] E2E tests
- [ ] Manual testing on Universal
- [X] Manual testing on Kubernetes 

### Backwards compatibility

- [ ] Add `backport-to-stable` label if the code is backwards compatible. Otherwise, list breaking changes.
