### PR TITLE
chore(tests) replace ncat with test server

### DIFF
--- a/test/e2e/compatibility/dp_compatibility_universal.go
+++ b/test/e2e/compatibility/dp_compatibility_universal.go
@@ -31,7 +31,6 @@ func UniversalCompatibility() {
 
 		err = TestServerUniversal("test-server", "default", testServerToken,
 			WithArgs([]string{"echo", "--instance", "universal1"}),
-			WithTransparentProxy(true),
 			WithDPVersion("1.1.6"))(cluster)
 		Expect(err).ToNot(HaveOccurred())
 		err = DemoClientUniversal(AppModeDemoClient, "default", demoClientToken, WithDPVersion("1.1.6"), WithTransparentProxy(true))(cluster)

--- a/test/e2e/compatibility/dp_compatibility_universal.go
+++ b/test/e2e/compatibility/dp_compatibility_universal.go
@@ -24,14 +24,17 @@ func UniversalCompatibility() {
 		err = cluster.VerifyKuma()
 		Expect(err).ToNot(HaveOccurred())
 
-		echoServerToken, err := cluster.GetKuma().GenerateDpToken("default", "echo-server_kuma-test_svc_8080")
+		testServerToken, err := cluster.GetKuma().GenerateDpToken("default", "test-server")
 		Expect(err).ToNot(HaveOccurred())
 		demoClientToken, err := cluster.GetKuma().GenerateDpToken("default", "demo-client")
 		Expect(err).ToNot(HaveOccurred())
 
-		err = EchoServerUniversal(AppModeEchoServer, "default", "universal", echoServerToken, WithDPVersion("1.1.6"))(cluster)
+		err = TestServerUniversal("test-server", "default", testServerToken,
+			WithArgs([]string{"echo", "--instance", "universal1"}),
+			WithTransparentProxy(true),
+			WithDPVersion("1.1.6"))(cluster)
 		Expect(err).ToNot(HaveOccurred())
-		err = DemoClientUniversal(AppModeDemoClient, "default", demoClientToken, WithDPVersion("1.1.6"))(cluster)
+		err = DemoClientUniversal(AppModeDemoClient, "default", demoClientToken, WithDPVersion("1.1.6"), WithTransparentProxy(true))(cluster)
 		Expect(err).ToNot(HaveOccurred())
 	})
 
@@ -45,7 +48,7 @@ func UniversalCompatibility() {
 
 	It("client should access server", func() {
 		retry.DoWithRetry(cluster.GetTesting(), "check communication between services", DefaultRetries, DefaultTimeout, func() (string, error) {
-			_, _, err := cluster.Exec("", "", "demo-client", "curl", "-v", "-m", "3", "--fail", "localhost:4001")
+			_, _, err := cluster.Exec("", "", "demo-client", "curl", "-v", "-m", "3", "--fail", "test-server.mesh")
 			return "", err
 		})
 	})

--- a/test/e2e/deploy/kuma_deploy_global_zone.go
+++ b/test/e2e/deploy/kuma_deploy_global_zone.go
@@ -88,7 +88,6 @@ spec:
 			Install(Kuma(core.Zone, optsZone...)).
 			Install(YamlK8s(namespaceWithSidecarInjection(TestNamespace))).
 			Install(DemoClientK8s("default")).
-			Install(EchoServerK8s("default")).
 			Setup(c2)
 		Expect(err).ToNot(HaveOccurred())
 

--- a/test/e2e/deploy/kuma_deploy_universal.go
+++ b/test/e2e/deploy/kuma_deploy_universal.go
@@ -61,7 +61,7 @@ name: %s
 
 		globalCP := global.GetKuma()
 
-		echoServerToken, err := globalCP.GenerateDpToken(nonDefaultMesh, "echo-server_kuma-test_svc_8080")
+		testServerToken, err := globalCP.GenerateDpToken(nonDefaultMesh, "test-server")
 		Expect(err).ToNot(HaveOccurred())
 		demoClientToken, err := globalCP.GenerateDpToken(nonDefaultMesh, "demo-client")
 		Expect(err).ToNot(HaveOccurred())
@@ -80,7 +80,9 @@ name: %s
 
 		err = NewClusterSetup().
 			Install(Kuma(core.Zone, optsZone1...)).
-			Install(EchoServerUniversal(AppModeEchoServer, nonDefaultMesh, "universal1", echoServerToken, WithTransparentProxy(true))).
+			Install(TestServerUniversal("test-server", nonDefaultMesh, testServerToken,
+				WithArgs([]string{"echo", "--instance", "universal1"}),
+				WithTransparentProxy(true))).
 			Install(DemoClientUniversal(AppModeDemoClient, nonDefaultMesh, demoClientToken, WithTransparentProxy(true))).
 			Install(IngressUniversal(ingressTokenKuma3)).
 			Setup(zone1)
@@ -98,7 +100,9 @@ name: %s
 
 		err = NewClusterSetup().
 			Install(Kuma(core.Zone, optsZone2...)).
-			Install(EchoServerUniversal(AppModeEchoServer, nonDefaultMesh, "universal2", echoServerToken, WithTransparentProxy(true))).
+			Install(TestServerUniversal("test-server", nonDefaultMesh, testServerToken,
+				WithArgs([]string{"echo", "--instance", "universal2"}),
+				WithTransparentProxy(true))).
 			Install(DemoClientUniversal(AppModeDemoClient, nonDefaultMesh, demoClientToken, WithTransparentProxy(true))).
 			Install(IngressUniversal(ingressTokenKuma4)).
 			Setup(zone2)
@@ -132,7 +136,7 @@ name: %s
 			DefaultRetries, DefaultTimeout,
 			func() (string, error) {
 				stdout, _, err := zone1.ExecWithRetries("", "", "demo-client",
-					"curl", "-v", "-m", "3", "--fail", "echo-server_kuma-test_svc_8080.mesh")
+					"curl", "-v", "-m", "3", "--fail", "test-server.mesh")
 				if err != nil {
 					return "should retry", err
 				}
@@ -146,7 +150,7 @@ name: %s
 			DefaultRetries, DefaultTimeout,
 			func() (string, error) {
 				stdout, _, err := zone2.ExecWithRetries("", "", "demo-client",
-					"curl", "-v", "-m", "3", "--fail", "echo-server_kuma-test_svc_8080.mesh")
+					"curl", "-v", "-m", "3", "--fail", "test-server.mesh")
 				if err != nil {
 					return "should retry", err
 				}
@@ -164,7 +168,7 @@ name: %s
 		responses := 0
 		for i := 0; i < iterations; i++ {
 			stdout, _, err := zone1.ExecWithRetries("", "", "demo-client",
-				"curl", "-v", "-m", "3", "--fail", "echo-server_kuma-test_svc_8080.mesh")
+				"curl", "-v", "-m", "3", "--fail", "test-server.mesh")
 			Expect(err).ToNot(HaveOccurred())
 			Expect(stdout).To(ContainSubstring("HTTP/1.1 200 OK"))
 			Expect(stdout).To(ContainSubstring("universal"))
@@ -188,7 +192,7 @@ name: %s
 		responses := 0
 		for i := 0; i < iterations; i++ {
 			stdout, _, err := zone2.ExecWithRetries("", "", "demo-client",
-				"curl", "-v", "-m", "3", "--fail", "echo-server_kuma-test_svc_8080.mesh")
+				"curl", "-v", "-m", "3", "--fail", "test-server.mesh")
 			Expect(err).ToNot(HaveOccurred())
 			Expect(stdout).To(ContainSubstring("HTTP/1.1 200 OK"))
 			Expect(stdout).To(ContainSubstring("universal"))

--- a/test/e2e/deploy/kuma_deploy_universal.go
+++ b/test/e2e/deploy/kuma_deploy_universal.go
@@ -80,9 +80,7 @@ name: %s
 
 		err = NewClusterSetup().
 			Install(Kuma(core.Zone, optsZone1...)).
-			Install(TestServerUniversal("test-server", nonDefaultMesh, testServerToken,
-				WithArgs([]string{"echo", "--instance", "universal1"}),
-				WithTransparentProxy(true))).
+			Install(TestServerUniversal("test-server", nonDefaultMesh, testServerToken, WithArgs([]string{"echo", "--instance", "universal1"}))).
 			Install(DemoClientUniversal(AppModeDemoClient, nonDefaultMesh, demoClientToken, WithTransparentProxy(true))).
 			Install(IngressUniversal(ingressTokenKuma3)).
 			Setup(zone1)
@@ -100,9 +98,7 @@ name: %s
 
 		err = NewClusterSetup().
 			Install(Kuma(core.Zone, optsZone2...)).
-			Install(TestServerUniversal("test-server", nonDefaultMesh, testServerToken,
-				WithArgs([]string{"echo", "--instance", "universal2"}),
-				WithTransparentProxy(true))).
+			Install(TestServerUniversal("test-server", nonDefaultMesh, testServerToken, WithArgs([]string{"echo", "--instance", "universal2"}))).
 			Install(DemoClientUniversal(AppModeDemoClient, nonDefaultMesh, demoClientToken, WithTransparentProxy(true))).
 			Install(IngressUniversal(ingressTokenKuma4)).
 			Setup(zone2)

--- a/test/e2e/deploy/kuma_deploy_universal_transparent_proxy.go
+++ b/test/e2e/deploy/kuma_deploy_universal_transparent_proxy.go
@@ -34,8 +34,7 @@ func UniversalTransparentProxyDeployment() {
 
 		err = TestServerUniversal("test-server", "default", echoServerToken,
 			WithArgs([]string{"echo", "--instance", "universal"}),
-			WithServiceName("echo-server_kuma-test_svc_8080"),
-			WithTransparentProxy(true))(cluster)
+			WithServiceName("echo-server_kuma-test_svc_8080"))(cluster)
 		Expect(err).ToNot(HaveOccurred())
 		err = DemoClientUniversal(AppModeDemoClient, "default", demoClientToken, WithTransparentProxy(true))(cluster)
 		Expect(err).ToNot(HaveOccurred())

--- a/test/e2e/deploy/kuma_deploy_universal_transparent_proxy.go
+++ b/test/e2e/deploy/kuma_deploy_universal_transparent_proxy.go
@@ -32,7 +32,10 @@ func UniversalTransparentProxyDeployment() {
 		demoClientToken, err := cluster.GetKuma().GenerateDpToken("default", "demo-client")
 		Expect(err).ToNot(HaveOccurred())
 
-		err = EchoServerUniversal(AppModeEchoServer, "default", "universal", echoServerToken, WithTransparentProxy(true))(cluster)
+		err = TestServerUniversal("test-server", "default", echoServerToken,
+			WithArgs([]string{"echo", "--instance", "universal"}),
+			WithServiceName("echo-server_kuma-test_svc_8080"),
+			WithTransparentProxy(true))(cluster)
 		Expect(err).ToNot(HaveOccurred())
 		err = DemoClientUniversal(AppModeDemoClient, "default", demoClientToken, WithTransparentProxy(true))(cluster)
 		Expect(err).ToNot(HaveOccurred())

--- a/test/e2e/healthcheck/hybrid/healthcheck_hybrid.go
+++ b/test/e2e/healthcheck/hybrid/healthcheck_hybrid.go
@@ -86,18 +86,15 @@ metadata:
 			Install(Kuma(core.Zone, optsZoneUniversal...)).
 			Install(TestServerUniversal("test-server-1", "default", testServerToken,
 				WithArgs([]string{"echo", "--instance", "dp-universal-1"}),
-				WithProtocol("tcp"),
-				WithTransparentProxy(true))).
+				WithProtocol("tcp"))).
 			Install(TestServerUniversal("test-server-2", "default", testServerToken,
 				WithArgs([]string{"echo", "--instance", "dp-universal-2"}),
 				WithProtocol("tcp"),
 				ProxyOnly(),
-				ServiceProbe(),
-				WithTransparentProxy(true))).
+				ServiceProbe())).
 			Install(TestServerUniversal("test-server-3", "default", testServerToken,
 				WithArgs([]string{"echo", "--instance", "dp-universal-3"}),
-				WithProtocol("tcp"),
-				WithTransparentProxy(true))).
+				WithProtocol("tcp"))).
 			Install(IngressUniversal(ingressTokenKuma3)).
 			Setup(zoneUniversal)
 		Expect(err).ToNot(HaveOccurred())

--- a/test/e2e/healthcheck/universal/panic.go
+++ b/test/e2e/healthcheck/universal/panic.go
@@ -69,9 +69,7 @@ networking:
 		for i := 1; i <= 6; i++ {
 			dpName := fmt.Sprintf("dp-echo-%d", i)
 			response := fmt.Sprintf("universal-%d", i)
-			err = TestServerUniversal(dpName, "default", testServerToken,
-				WithArgs([]string{"echo", "--instance", response}),
-				WithTransparentProxy(true))(universalCluster)
+			err = TestServerUniversal(dpName, "default", testServerToken, WithArgs([]string{"echo", "--instance", response}))(universalCluster)
 			Expect(err).ToNot(HaveOccurred())
 		}
 		for i := 7; i <= 10; i++ {

--- a/test/e2e/healthcheck/universal/panic.go
+++ b/test/e2e/healthcheck/universal/panic.go
@@ -24,7 +24,7 @@ sources:
     kuma.io/service: '*'
 destinations:
 - match:
-    kuma.io/service: echo-server_kuma-test_svc_8080
+    kuma.io/service: test-server
 conf:
   interval: 10s
   timeout: 2s
@@ -45,7 +45,7 @@ networking:
   - port: 8080
     servicePort: 80
     tags:
-      kuma.io/service: echo-server_kuma-test_svc_8080
+      kuma.io/service: test-server
       kuma.io/protocol: http`, idx, idx)
 	}
 
@@ -61,7 +61,7 @@ networking:
 		err = universalCluster.VerifyKuma()
 		Expect(err).ToNot(HaveOccurred())
 
-		echoServerToken, err := universalCluster.GetKuma().GenerateDpToken("default", "echo-server_kuma-test_svc_8080")
+		testServerToken, err := universalCluster.GetKuma().GenerateDpToken("default", "test-server")
 		Expect(err).ToNot(HaveOccurred())
 		demoClientToken, err := universalCluster.GetKuma().GenerateDpToken("default", "demo-client")
 		Expect(err).ToNot(HaveOccurred())
@@ -69,7 +69,9 @@ networking:
 		for i := 1; i <= 6; i++ {
 			dpName := fmt.Sprintf("dp-echo-%d", i)
 			response := fmt.Sprintf("universal-%d", i)
-			err = EchoServerUniversal(dpName, "default", response, echoServerToken)(universalCluster)
+			err = TestServerUniversal(dpName, "default", testServerToken,
+				WithArgs([]string{"echo", "--instance", response}),
+				WithTransparentProxy(true))(universalCluster)
 			Expect(err).ToNot(HaveOccurred())
 		}
 		for i := 7; i <= 10; i++ {
@@ -92,7 +94,7 @@ networking:
 	It("should switch to panic mode and dismiss all requests", func() {
 		Eventually(func() bool {
 			stdout, _, _ := universalCluster.Exec("", "", "demo-client",
-				"curl", "-v", "echo-server_kuma-test_svc_8080.mesh")
+				"curl", "-v", "test-server.mesh")
 			return strings.Contains(stdout, "no healthy upstream")
 		}, "30s", "500ms").Should(BeTrue())
 	})

--- a/test/e2e/healthcheck/universal/policy_http.go
+++ b/test/e2e/healthcheck/universal/policy_http.go
@@ -61,9 +61,7 @@ conf:
 		err = DemoClientUniversal("dp-demo-client", "default", demoClientToken,
 			WithTransparentProxy(true))(cluster)
 		Expect(err).ToNot(HaveOccurred())
-		err = TestServerUniversal("test-server", "default", testServerToken,
-			WithArgs([]string{"health-check", "http"}),
-			WithTransparentProxy(true), WithProtocol("http"))(cluster)
+		err = TestServerUniversal("test-server", "default", testServerToken, WithArgs([]string{"health-check", "http"}))(cluster)
 		Expect(err).ToNot(HaveOccurred())
 	})
 

--- a/test/e2e/healthcheck/universal/policy_tcp.go
+++ b/test/e2e/healthcheck/universal/policy_tcp.go
@@ -67,7 +67,7 @@ conf:
 		Expect(err).ToNot(HaveOccurred())
 		err = TestServerUniversal("test-server", "default", testServerToken,
 			WithArgs([]string{"health-check", "tcp"}),
-			WithTransparentProxy(true), WithProtocol("tcp"))(cluster)
+			WithProtocol("tcp"))(cluster)
 		Expect(err).ToNot(HaveOccurred())
 	})
 

--- a/test/e2e/healthcheck/universal/service_probes.go
+++ b/test/e2e/healthcheck/universal/service_probes.go
@@ -23,12 +23,16 @@ func ServiceProbes() {
 		err = cluster.VerifyKuma()
 		Expect(err).ToNot(HaveOccurred())
 
-		echoServerToken, err := cluster.GetKuma().GenerateDpToken("default", "echo-server_kuma-test_svc_8080")
+		echoServerToken, err := cluster.GetKuma().GenerateDpToken("default", "test-server")
 		Expect(err).ToNot(HaveOccurred())
 		demoClientToken, err := cluster.GetKuma().GenerateDpToken("default", "dp-demo-client")
 		Expect(err).ToNot(HaveOccurred())
 
-		err = EchoServerUniversal("dp-echo-server", "default", "universal", echoServerToken, ProxyOnly(), ServiceProbe())(cluster)
+		err = TestServerUniversal("test-server", "default", echoServerToken,
+			WithArgs([]string{"echo", "--instance", "universal-1"}),
+			WithTransparentProxy(true),
+			ProxyOnly(),
+			ServiceProbe())(cluster)
 		Expect(err).ToNot(HaveOccurred())
 		err = DemoClientUniversal("dp-demo-client", "default", demoClientToken, ServiceProbe())(cluster)
 		Expect(err).ToNot(HaveOccurred())
@@ -44,7 +48,7 @@ func ServiceProbes() {
 
 	It("should update dataplane.inbound.health", func() {
 		Eventually(func() (string, error) {
-			output, err := cluster.GetKumactlOptions().RunKumactlAndGetOutputV(Verbose, "get", "dataplane", "dp-echo-server", "-oyaml")
+			output, err := cluster.GetKumactlOptions().RunKumactlAndGetOutputV(Verbose, "get", "dataplane", "test-server", "-oyaml")
 			if err != nil {
 				return "", err
 			}

--- a/test/e2e/healthcheck/universal/service_probes.go
+++ b/test/e2e/healthcheck/universal/service_probes.go
@@ -30,7 +30,6 @@ func ServiceProbes() {
 
 		err = TestServerUniversal("test-server", "default", echoServerToken,
 			WithArgs([]string{"echo", "--instance", "universal-1"}),
-			WithTransparentProxy(true),
 			ProxyOnly(),
 			ServiceProbe())(cluster)
 		Expect(err).ToNot(HaveOccurred())

--- a/test/e2e/helm/kuma_helm_deploy_global_zone.go
+++ b/test/e2e/helm/kuma_helm_deploy_global_zone.go
@@ -76,7 +76,6 @@ metadata:
 			Install(Kuma(core.Zone, optsZone...)).
 			Install(YamlK8s(namespaceWithSidecarInjection(TestNamespace))).
 			Install(DemoClientK8s("default")).
-			Install(EchoServerK8s("default")).
 			Setup(c2)
 		Expect(err).ToNot(HaveOccurred())
 

--- a/test/e2e/hybrid/kuma_hybrid.go
+++ b/test/e2e/hybrid/kuma_hybrid.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/kumahq/kuma/pkg/config/core"
 	. "github.com/kumahq/kuma/test/framework"
+	"github.com/kumahq/kuma/test/framework/deployments/testserver"
 )
 
 func KubernetesUniversalDeployment() {
@@ -69,7 +70,7 @@ metadata:
 
 		globalCP := global.GetKuma()
 
-		echoServerToken, err := globalCP.GenerateDpToken(nonDefaultMesh, "echo-server_kuma-test_svc_8080")
+		echoServerToken, err := globalCP.GenerateDpToken(nonDefaultMesh, "test-server")
 		Expect(err).ToNot(HaveOccurred())
 		demoClientToken, err := globalCP.GenerateDpToken(nonDefaultMesh, "demo-client")
 		Expect(err).ToNot(HaveOccurred())
@@ -103,7 +104,7 @@ metadata:
 			Install(Kuma(core.Zone, optsZone2...)).
 			Install(KumaDNS()).
 			Install(YamlK8s(namespaceWithSidecarInjection(TestNamespace))).
-			Install(EchoServerK8s(nonDefaultMesh)).
+			Install(testserver.Install(testserver.WithMesh(nonDefaultMesh))).
 			Install(DemoClientK8s(nonDefaultMesh)).
 			Setup(zone2)
 		Expect(err).ToNot(HaveOccurred())
@@ -119,7 +120,12 @@ metadata:
 
 		err = NewClusterSetup().
 			Install(Kuma(core.Zone, optsZone3...)).
-			Install(EchoServerUniversal(AppModeEchoServer, nonDefaultMesh, "universal", echoServerToken, WithTransparentProxy(true), WithBuiltinDNS(false))).
+			Install(TestServerUniversal("dp-echo", nonDefaultMesh, echoServerToken,
+				WithArgs([]string{"echo", "--instance", "echo-v1"}),
+				WithProtocol("http"),
+				WithServiceName("test-server"),
+				WithTransparentProxy(true),
+			)).
 			Install(DemoClientUniversal(AppModeDemoClient, nonDefaultMesh, demoClientToken, WithTransparentProxy(true), WithBuiltinDNS(false))).
 			Install(IngressUniversal(ingressTokenKuma3)).
 			Setup(zone3)
@@ -136,7 +142,7 @@ metadata:
 
 		err = NewClusterSetup().
 			Install(Kuma(core.Zone, optsZone4...)).
-			Install(DemoClientUniversal(AppModeDemoClient, nonDefaultMesh, demoClientToken)).
+			Install(DemoClientUniversal(AppModeDemoClient, nonDefaultMesh, demoClientToken, WithTransparentProxy(true))).
 			Install(IngressUniversal(ingressTokenKuma4)).
 			Setup(zone4)
 		Expect(err).ToNot(HaveOccurred())
@@ -192,19 +198,18 @@ metadata:
 			return nil
 		}, "30s", "1s").ShouldNot(HaveOccurred())
 
-		// todo (lobkovilya): echo-server is restarting because of ncat problem, uncomment this as soon as it will be replaces with test-server
-		// Eventually(func() error {
-		//	output, err := global.GetKumactlOptions().RunKumactlAndGetOutput("inspect", "dataplanes", "--mesh", "non-default")
-		//	if err != nil {
-		//		return err
-		//	}
-		//
-		//	re := regexp.MustCompile(`Online`)
-		//	if len(re.FindAllString(output, -1)) != 6 {
-		//		return errors.New("not all dataplanes are online")
-		//	}
-		//	return nil
-		// }, "30s", "1s").ShouldNot(HaveOccurred())
+		Eventually(func() error {
+			output, err := global.GetKumactlOptions().RunKumactlAndGetOutput("inspect", "dataplanes", "--mesh", "non-default")
+			if err != nil {
+				return err
+			}
+
+			re := regexp.MustCompile(`Online`)
+			if len(re.FindAllString(output, -1)) != 6 {
+				return errors.New("not all dataplanes are online")
+			}
+			return nil
+		}, "30s", "1s").ShouldNot(HaveOccurred())
 	})
 
 	It("should access allservices", func() {
@@ -223,7 +228,7 @@ metadata:
 
 		// k8s access remote k8s service
 		_, stderr, err := zone1.ExecWithRetries(TestNamespace, clientPod.GetName(), "demo-client",
-			"curl", "-v", "-m", "3", "--fail", "echo-server_kuma-test_svc_80.mesh")
+			"curl", "-v", "-m", "3", "--fail", "test-server_kuma-test_svc_80.mesh")
 		Expect(err).ToNot(HaveOccurred())
 		Expect(stderr).To(ContainSubstring("HTTP/1.1 200 OK"))
 
@@ -242,34 +247,34 @@ metadata:
 
 		// k8s access remote universal service
 		_, stderr, err = zone2.ExecWithRetries(TestNamespace, clientPod.GetName(), "demo-client",
-			"curl", "-v", "-m", "3", "--fail", "echo-server_kuma-test_svc_8080.mesh")
+			"curl", "-v", "-m", "3", "--fail", "test-server.mesh")
 		Expect(err).ToNot(HaveOccurred())
 		Expect(stderr).To(ContainSubstring("HTTP/1.1 200 OK"))
 
 		// Zone 3
 		// universal access remote k8s service
 		stdout, _, err := zone3.ExecWithRetries("", "", "demo-client",
-			"curl", "-v", "-m", "3", "--fail", "echo-server_kuma-test_svc_8080.mesh")
+			"curl", "-v", "-m", "3", "--fail", "test-server_kuma-test_svc_80.mesh")
 		Expect(err).ToNot(HaveOccurred())
 		Expect(stdout).To(ContainSubstring("HTTP/1.1 200 OK"))
 
 		// Zone 4
 		// universal access remote universal service
 		stdout, _, err = zone4.ExecWithRetries("", "", "demo-client",
-			"curl", "-v", "-m", "3", "--fail", "localhost:4001")
+			"curl", "-v", "-m", "3", "--fail", "test-server.mesh")
 		Expect(err).ToNot(HaveOccurred())
 		Expect(stdout).To(ContainSubstring("HTTP/1.1 200 OK"))
 	})
 
-	PIt("should support jobs with a sidecar", func() {
+	It("should support jobs with a sidecar", func() {
 		// when deploy job that connects to a service on other K8S cluster
-		err := DemoClientJobK8s(nonDefaultMesh, "echo-server_kuma-test_svc_80.mesh")(zone1)
+		err := DemoClientJobK8s(nonDefaultMesh, "test-server_kuma-test_svc_80.mesh")(zone1)
 
 		// then job is properly cleaned up and finished
 		Expect(err).ToNot(HaveOccurred())
 
 		// when deploy job that connects to a service on other Universal cluster
-		err = DemoClientJobK8s(nonDefaultMesh, "echo-server_kuma-test_svc_8080.mesh")(zone2)
+		err = DemoClientJobK8s(nonDefaultMesh, "test-server.mesh")(zone2)
 
 		// then job is properly cleaned up and finished
 		Expect(err).ToNot(HaveOccurred())

--- a/test/e2e/hybrid/kuma_hybrid.go
+++ b/test/e2e/hybrid/kuma_hybrid.go
@@ -122,9 +122,7 @@ metadata:
 			Install(Kuma(core.Zone, optsZone3...)).
 			Install(TestServerUniversal("dp-echo", nonDefaultMesh, echoServerToken,
 				WithArgs([]string{"echo", "--instance", "echo-v1"}),
-				WithProtocol("http"),
 				WithServiceName("test-server"),
-				WithTransparentProxy(true),
 			)).
 			Install(DemoClientUniversal(AppModeDemoClient, nonDefaultMesh, demoClientToken, WithTransparentProxy(true), WithBuiltinDNS(false))).
 			Install(IngressUniversal(ingressTokenKuma3)).

--- a/test/e2e/hybrid/kuma_hybrid_kube_global.go
+++ b/test/e2e/hybrid/kuma_hybrid_kube_global.go
@@ -48,9 +48,7 @@ func KubernetesUniversalDeploymentWhenGlobalIsOnK8S() {
 
 		err = NewClusterSetup().
 			Install(Kuma(core.Zone, optsZone...)).
-			Install(TestServerUniversal("test-server", "default", echoServerToken,
-				WithArgs([]string{"echo", "--instance", "universal-1"}),
-				WithTransparentProxy(true))).
+			Install(TestServerUniversal("test-server", "default", echoServerToken, WithArgs([]string{"echo", "--instance", "universal-1"}))).
 			Install(DemoClientUniversal(AppModeDemoClient, "default", demoClientToken, WithTransparentProxy(true))).
 			Install(IngressUniversal(ingressTokenKuma3)).
 			Setup(zoneCluster)

--- a/test/e2e/hybrid/kuma_hybrid_kube_global.go
+++ b/test/e2e/hybrid/kuma_hybrid_kube_global.go
@@ -1,12 +1,8 @@
 package hybrid
 
 import (
-	"strings"
-
-	"github.com/gruntwork-io/terratest/modules/retry"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"github.com/pkg/errors"
 
 	"github.com/kumahq/kuma/pkg/config/core"
 	. "github.com/kumahq/kuma/test/framework"
@@ -38,7 +34,7 @@ func KubernetesUniversalDeploymentWhenGlobalIsOnK8S() {
 		Expect(err).ToNot(HaveOccurred())
 		globalCP := globalCluster.GetKuma()
 
-		echoServerToken, err := globalCP.GenerateDpToken("default", "echo-server_kuma-test_svc_8080")
+		echoServerToken, err := globalCP.GenerateDpToken("default", "test-server")
 		Expect(err).ToNot(HaveOccurred())
 		demoClientToken, err := globalCP.GenerateDpToken("default", "demo-client")
 		Expect(err).ToNot(HaveOccurred())
@@ -52,8 +48,10 @@ func KubernetesUniversalDeploymentWhenGlobalIsOnK8S() {
 
 		err = NewClusterSetup().
 			Install(Kuma(core.Zone, optsZone...)).
-			Install(EchoServerUniversal(AppModeEchoServer, "default", "universal", echoServerToken)).
-			Install(DemoClientUniversal(AppModeDemoClient, "default", demoClientToken)).
+			Install(TestServerUniversal("test-server", "default", echoServerToken,
+				WithArgs([]string{"echo", "--instance", "universal-1"}),
+				WithTransparentProxy(true))).
+			Install(DemoClientUniversal(AppModeDemoClient, "default", demoClientToken, WithTransparentProxy(true))).
 			Install(IngressUniversal(ingressTokenKuma3)).
 			Setup(zoneCluster)
 		Expect(err).ToNot(HaveOccurred())
@@ -78,22 +76,8 @@ func KubernetesUniversalDeploymentWhenGlobalIsOnK8S() {
 
 	It("communication in between apps in zone works", func() {
 		stdout, _, err := zoneCluster.ExecWithRetries("", "", "demo-client",
-			"curl", "-v", "-m", "3", "--fail", "localhost:4001")
+			"curl", "-v", "-m", "3", "--fail", "test-server.mesh")
 		Expect(err).ToNot(HaveOccurred())
 		Expect(stdout).To(ContainSubstring("HTTP/1.1 200 OK"))
-
-		retry.DoWithRetry(zoneCluster.GetTesting(), "curl remote service",
-			DefaultRetries, DefaultTimeout,
-			func() (string, error) {
-				stdout, _, err = zoneCluster.ExecWithRetries("", "", "demo-client",
-					"curl", "-v", "-m", "3", "localhost:4001")
-				if err != nil {
-					return "should retry", err
-				}
-				if strings.Contains(stdout, "HTTP/1.1 200 OK") {
-					return "Accessing service successful", nil
-				}
-				return "should retry", errors.Errorf("should retry")
-			})
 	})
 }

--- a/test/e2e/ratelimit/ratelimit_universal.go
+++ b/test/e2e/ratelimit/ratelimit_universal.go
@@ -20,7 +20,7 @@ sources:
    kuma.io/service: "*"
 destinations:
 - match:
-   kuma.io/service: echo-server_kuma-test_svc_8080
+   kuma.io/service: test-server
 conf:
   http:
     requests: 2
@@ -50,7 +50,7 @@ conf:
 		demoClientToken, err := cluster.GetKuma().GenerateDpToken("default", "demo-client")
 		Expect(err).ToNot(HaveOccurred())
 
-		echoServerToken, err := cluster.GetKuma().GenerateDpToken("default", "echo-server_kuma-test_svc_8080")
+		testServerToken, err := cluster.GetKuma().GenerateDpToken("default", "test-server")
 		Expect(err).ToNot(HaveOccurred())
 
 		webToken, err := cluster.GetKuma().GenerateDpToken("default", "web")
@@ -60,7 +60,9 @@ conf:
 		Expect(err).ToNot(HaveOccurred())
 
 		err = NewClusterSetup().
-			Install(EchoServerUniversal(AppModeEchoServer, "default", "universal", echoServerToken, WithTransparentProxy(true))).
+			Install(TestServerUniversal("test-server", "default", testServerToken,
+				WithArgs([]string{"echo", "--instance", "universal-1"}),
+				WithTransparentProxy(true))).
 			Install(DemoClientUniversal(AppModeDemoClient, "default", demoClientToken, WithTransparentProxy(true))).
 			Install(DemoClientUniversal("web", "default", webToken, WithTransparentProxy(true))).
 			Setup(cluster)
@@ -85,7 +87,7 @@ conf:
 		return func() int {
 			succeeded := 0
 			for i := 0; i < total; i++ {
-				_, _, err := cluster.Exec("", "", client, "curl", "-v", "--fail", "echo-server_kuma-test_svc_8080.mesh")
+				_, _, err := cluster.Exec("", "", client, "curl", "-v", "--fail", "test-server.mesh")
 				if err == nil {
 					succeeded++
 				}
@@ -112,7 +114,7 @@ sources:
     kuma.io/service: "demo-client"
 destinations:
 - match:
-    kuma.io/service: echo-server_kuma-test_svc_8080
+    kuma.io/service: test-server
 conf:
   http:
     requests: 4
@@ -142,7 +144,7 @@ sources:
     kuma.io/service: "demo-client"
 destinations:
 - match:
-    kuma.io/service: echo-server_kuma-test_svc_8080
+    kuma.io/service: test-server
 conf:
   http:
     requests: 4
@@ -156,7 +158,7 @@ sources:
     kuma.io/service: "web"
 destinations:
 - match:
-    kuma.io/service: echo-server_kuma-test_svc_8080
+    kuma.io/service: test-server
 conf:
   http:
     requests: 1

--- a/test/e2e/ratelimit/ratelimit_universal.go
+++ b/test/e2e/ratelimit/ratelimit_universal.go
@@ -60,9 +60,7 @@ conf:
 		Expect(err).ToNot(HaveOccurred())
 
 		err = NewClusterSetup().
-			Install(TestServerUniversal("test-server", "default", testServerToken,
-				WithArgs([]string{"echo", "--instance", "universal-1"}),
-				WithTransparentProxy(true))).
+			Install(TestServerUniversal("test-server", "default", testServerToken, WithArgs([]string{"echo", "--instance", "universal-1"}))).
 			Install(DemoClientUniversal(AppModeDemoClient, "default", demoClientToken, WithTransparentProxy(true))).
 			Install(DemoClientUniversal("web", "default", webToken, WithTransparentProxy(true))).
 			Setup(cluster)

--- a/test/e2e/retry/retry_universal.go
+++ b/test/e2e/retry/retry_universal.go
@@ -46,9 +46,7 @@ func RetryOnUniversal() {
 
 		err = NewClusterSetup().
 			Install(DemoClientUniversal(AppModeDemoClient, "default", demoClientToken, WithTransparentProxy(true))).
-			Install(TestServerUniversal("test-server", "default", echoServerToken,
-				WithArgs([]string{"echo", "--instance", "universal"}),
-				WithTransparentProxy(true))).
+			Install(TestServerUniversal("test-server", "default", echoServerToken, WithArgs([]string{"echo", "--instance", "universal"}))).
 			Setup(cluster)
 		Expect(err).ToNot(HaveOccurred())
 	})

--- a/test/e2e/retry/retry_universal.go
+++ b/test/e2e/retry/retry_universal.go
@@ -95,7 +95,7 @@ conf:
 			DefaultRetries, DefaultTimeout,
 			func() (string, error) {
 				stdout, _, err := cluster.ExecWithRetries("", "", "demo-client",
-					"curl", "-v", "-m", "3", "--fail", "localhost:4001")
+					"curl", "-v", "-m", "3", "--fail", "test-server.mesh")
 				if err != nil {
 					return "should retry", err
 				}

--- a/test/e2e/timeout/timeout_universal.go
+++ b/test/e2e/timeout/timeout_universal.go
@@ -65,9 +65,7 @@ conf:
 		demoClientToken, err := universalCluster.GetKuma().GenerateDpToken("default", "demo-client")
 		Expect(err).ToNot(HaveOccurred())
 
-		err = TestServerUniversal("test-server", "default", echoServerToken,
-			WithArgs([]string{"echo", "--instance", "universal-1"}),
-			WithTransparentProxy(true))(universalCluster)
+		err = TestServerUniversal("test-server", "default", echoServerToken, WithArgs([]string{"echo", "--instance", "universal-1"}))(universalCluster)
 		Expect(err).ToNot(HaveOccurred())
 
 		err = DemoClientUniversal(AppModeDemoClient, "default", demoClientToken, WithTransparentProxy(true))(universalCluster)

--- a/test/e2e/timeout/timeout_universal.go
+++ b/test/e2e/timeout/timeout_universal.go
@@ -24,7 +24,7 @@ sources:
        kuma.io/service: demo-client
 destinations:
    - match:
-       kuma.io/service: echo-server_kuma-test_svc_8080
+       kuma.io/service: test-server
        kuma.io/protocol: http
 conf:
    delay:
@@ -41,7 +41,7 @@ sources:
     kuma.io/service: '*'
 destinations:
 - match:
-    kuma.io/service: echo-server_kuma-test_svc_8080
+    kuma.io/service: test-server
 conf:
   connectTimeout: 10s
   http:
@@ -60,13 +60,16 @@ conf:
 		err = universalCluster.VerifyKuma()
 		Expect(err).ToNot(HaveOccurred())
 
-		echoServerToken, err := universalCluster.GetKuma().GenerateDpToken("default", "echo-server_kuma-test_svc_8080")
+		echoServerToken, err := universalCluster.GetKuma().GenerateDpToken("default", "test-server")
 		Expect(err).ToNot(HaveOccurred())
 		demoClientToken, err := universalCluster.GetKuma().GenerateDpToken("default", "demo-client")
 		Expect(err).ToNot(HaveOccurred())
 
-		err = EchoServerUniversal(AppModeEchoServer, "default", "universal-1", echoServerToken)(universalCluster)
+		err = TestServerUniversal("test-server", "default", echoServerToken,
+			WithArgs([]string{"echo", "--instance", "universal-1"}),
+			WithTransparentProxy(true))(universalCluster)
 		Expect(err).ToNot(HaveOccurred())
+
 		err = DemoClientUniversal(AppModeDemoClient, "default", demoClientToken, WithTransparentProxy(true))(universalCluster)
 		Expect(err).ToNot(HaveOccurred())
 	})
@@ -82,13 +85,13 @@ conf:
 	It("should reset the connection by timeout", func() {
 		// check echo-server is up and running
 		stdout, _, err := universalCluster.ExecWithRetries("", "", "demo-client",
-			"curl", "-v", "--fail", "echo-server_kuma-test_svc_8080.mesh")
+			"curl", "-v", "--fail", "test-server.mesh")
 		Expect(err).ToNot(HaveOccurred())
 		Expect(stdout).To(ContainSubstring("HTTP/1.1 200 OK"))
 
 		start := time.Now()
 		_, _, err = universalCluster.Exec("", "", "demo-client",
-			"curl", "-v", "--fail", "echo-server_kuma-test_svc_8080.mesh")
+			"curl", "-v", "--fail", "test-server.mesh")
 		Expect(err).ToNot(HaveOccurred())
 		elapsed := time.Since(start)
 		Expect(elapsed > 5*time.Second).To(BeTrue())
@@ -100,7 +103,7 @@ conf:
 		// then
 		Eventually(func() bool {
 			stdout, _, _ := universalCluster.Exec("", "", "demo-client",
-				"curl", "-v", "echo-server_kuma-test_svc_8080.mesh")
+				"curl", "-v", "test-server.mesh")
 			return strings.Contains(stdout, "upstream request timeout")
 		}, "30s", "500ms").Should(BeTrue())
 	})

--- a/test/e2e/tracing/tracing_kubernetes.go
+++ b/test/e2e/tracing/tracing_kubernetes.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/kumahq/kuma/pkg/config/core"
 	. "github.com/kumahq/kuma/test/framework"
+	"github.com/kumahq/kuma/test/framework/deployments/testserver"
 	"github.com/kumahq/kuma/test/framework/deployments/tracing"
 )
 
@@ -69,7 +70,7 @@ spec:
 			Install(Kuma(core.Standalone, deployOptsFuncs...)).
 			Install(YamlK8s(namespaceWithSidecarInjection(TestNamespace))).
 			Install(DemoClientK8s("default")).
-			Install(EchoServerK8s("default")).
+			Install(testserver.Install()).
 			Install(tracing.Install()).
 			Setup(cluster)
 		Expect(err).ToNot(HaveOccurred())
@@ -108,7 +109,7 @@ spec:
 			DefaultRetries, DefaultTimeout,
 			func() (string, error) {
 				_, _, err := cluster.ExecWithRetries(TestNamespace, clientPod.GetName(), "demo-client",
-					"curl", "-v", "-m", "3", "--fail", "echo-server")
+					"curl", "-v", "-m", "3", "--fail", "test-server")
 				if err != nil {
 					return "", err
 				}
@@ -119,7 +120,7 @@ spec:
 					return "", err
 				}
 
-				expectedServices := []string{"demo-client_kuma-test_svc", "echo-server_kuma-test_svc_80", "jaeger-query"}
+				expectedServices := []string{"demo-client_kuma-test_svc", "jaeger-query", "test-server_kuma-test_svc_80"}
 				if !reflect.DeepEqual(services, expectedServices) {
 					return "", errors.Errorf("services not traced. Expected %q, got %q", expectedServices, services)
 				}

--- a/test/e2e/tracing/tracing_universal.go
+++ b/test/e2e/tracing/tracing_universal.go
@@ -53,14 +53,16 @@ selectors:
 		err = cluster.VerifyKuma()
 		Expect(err).ToNot(HaveOccurred())
 
-		echoServerToken, err := cluster.GetKuma().GenerateDpToken("default", "echo-server_kuma-test_svc_8080")
+		testServerToken, err := cluster.GetKuma().GenerateDpToken("default", "test-server")
 		Expect(err).ToNot(HaveOccurred())
 		demoClientToken, err := cluster.GetKuma().GenerateDpToken("default", "demo-client")
 		Expect(err).ToNot(HaveOccurred())
 
-		err = EchoServerUniversal(AppModeEchoServer, "default", "universal", echoServerToken)(cluster)
+		err = TestServerUniversal("test-server", "default", testServerToken,
+			WithArgs([]string{"echo", "--instance", "universal1"}),
+			WithTransparentProxy(true))(cluster)
 		Expect(err).ToNot(HaveOccurred())
-		err = DemoClientUniversal(AppModeDemoClient, "default", demoClientToken)(cluster)
+		err = DemoClientUniversal(AppModeDemoClient, "default", demoClientToken, WithTransparentProxy(true))(cluster)
 		Expect(err).ToNot(HaveOccurred())
 	})
 
@@ -81,7 +83,7 @@ selectors:
 
 		retry.DoWithRetry(cluster.GetTesting(), "check traced services", DefaultRetries, DefaultTimeout, func() (string, error) {
 			// when client sends requests to server
-			_, _, err := cluster.Exec("", "", "demo-client", "curl", "-v", "-m", "3", "--fail", "localhost:4001")
+			_, _, err := cluster.Exec("", "", "demo-client", "curl", "-v", "-m", "3", "--fail", "test-server.mesh")
 			if err != nil {
 				return "", err
 			}
@@ -92,7 +94,7 @@ selectors:
 				return "", err
 			}
 
-			expectedServices := []string{"demo-client", "echo-server_kuma-test_svc_8080", "jaeger-query"}
+			expectedServices := []string{"demo-client", "jaeger-query", "test-server"}
 			if !reflect.DeepEqual(services, expectedServices) {
 				return "", errors.Errorf("services not traced. Expected %q, got %q", expectedServices, services)
 			}

--- a/test/e2e/tracing/tracing_universal.go
+++ b/test/e2e/tracing/tracing_universal.go
@@ -58,9 +58,7 @@ selectors:
 		demoClientToken, err := cluster.GetKuma().GenerateDpToken("default", "demo-client")
 		Expect(err).ToNot(HaveOccurred())
 
-		err = TestServerUniversal("test-server", "default", testServerToken,
-			WithArgs([]string{"echo", "--instance", "universal1"}),
-			WithTransparentProxy(true))(cluster)
+		err = TestServerUniversal("test-server", "default", testServerToken, WithArgs([]string{"echo", "--instance", "universal1"}))(cluster)
 		Expect(err).ToNot(HaveOccurred())
 		err = DemoClientUniversal(AppModeDemoClient, "default", demoClientToken, WithTransparentProxy(true))(cluster)
 		Expect(err).ToNot(HaveOccurred())

--- a/test/e2e/trafficpermission/hybrid/traffic_permission_hybrid.go
+++ b/test/e2e/trafficpermission/hybrid/traffic_permission_hybrid.go
@@ -78,9 +78,7 @@ spec:
 
 		err = NewClusterSetup().
 			Install(Kuma(config_core.Zone, optsZoneUniversal...)).
-			Install(TestServerUniversal("test-server", "default", testServerToken,
-				WithArgs([]string{"echo", "--instance", "echo-v1"}),
-				WithTransparentProxy(true))).
+			Install(TestServerUniversal("test-server", "default", testServerToken, WithArgs([]string{"echo", "--instance", "echo-v1"}))).
 			Install(IngressUniversal(ingressTokenKuma3)).
 			Setup(zoneUniversal)
 		Expect(err).ToNot(HaveOccurred())

--- a/test/e2e/trafficpermission/hybrid/traffic_permission_hybrid.go
+++ b/test/e2e/trafficpermission/hybrid/traffic_permission_hybrid.go
@@ -66,7 +66,7 @@ spec:
 		Expect(err).ToNot(HaveOccurred())
 		globalCP := globalCluster.GetKuma()
 
-		echoServerToken, err := globalCP.GenerateDpToken("default", "echo-server_kuma-test_svc_8080")
+		testServerToken, err := globalCP.GenerateDpToken("default", "test-server")
 		Expect(err).ToNot(HaveOccurred())
 
 		// Zone universal
@@ -78,7 +78,9 @@ spec:
 
 		err = NewClusterSetup().
 			Install(Kuma(config_core.Zone, optsZoneUniversal...)).
-			Install(EchoServerUniversal(AppModeEchoServer, "default", "universal", echoServerToken)).
+			Install(TestServerUniversal("test-server", "default", testServerToken,
+				WithArgs([]string{"echo", "--instance", "echo-v1"}),
+				WithTransparentProxy(true))).
 			Install(IngressUniversal(ingressTokenKuma3)).
 			Setup(zoneUniversal)
 		Expect(err).ToNot(HaveOccurred())
@@ -154,16 +156,15 @@ spec:
 	})
 
 	trafficAllowed := func() {
-		stdout, _, err := zoneKube.ExecWithRetries(TestNamespace, clientPodName, "demo-client",
-			"curl", "-v", "-m", "3", "--fail", "echo-server_kuma-test_svc_8080.mesh")
+		_, _, err := zoneKube.ExecWithRetries(TestNamespace, clientPodName, "demo-client",
+			"curl", "-v", "-m", "3", "--fail", "test-server.mesh")
 		Expect(err).ToNot(HaveOccurred())
-		Expect(stdout).To(ContainSubstring("Echo universal"))
 	}
 
 	trafficBlocked := func() {
 		Eventually(func() error {
 			_, _, err := zoneKube.Exec(TestNamespace, clientPodName, "demo-client",
-				"curl", "-v", "-m", "3", "--fail", "echo-server_kuma-test_svc_8080.mesh")
+				"curl", "-v", "-m", "3", "--fail", "test-server.mesh")
 			return err
 		}, "30s", "1s").Should(HaveOccurred())
 	}
@@ -231,7 +232,7 @@ spec:
         kuma.io/service: demo-client_kuma-test_svc
   destinations:
     - match:
-        kuma.io/service: echo-server_kuma-test_svc_8080
+        kuma.io/service: test-server
 `
 		err := YamlK8s(yaml)(globalCluster)
 		Expect(err).ToNot(HaveOccurred())
@@ -258,7 +259,7 @@ spec:
         newtag: client
   destinations:
     - match:
-        kuma.io/service: echo-server_kuma-test_svc_8080
+        kuma.io/service: test-server
 `
 		err := YamlK8s(yaml)(globalCluster)
 		Expect(err).ToNot(HaveOccurred())

--- a/test/e2e/trafficpermission/universal/traffic_permission_universal.go
+++ b/test/e2e/trafficpermission/universal/traffic_permission_universal.go
@@ -39,10 +39,7 @@ mtls:
 		demoClientToken, err := universalCluster.GetKuma().GenerateDpToken("default", "demo-client")
 		Expect(err).ToNot(HaveOccurred())
 
-		err = TestServerUniversal("test-server", "default", testServerToken,
-			WithArgs([]string{"echo", "--instance", "echo-v1"}),
-			WithTransparentProxy(true),
-		)(universalCluster)
+		err = TestServerUniversal("test-server", "default", testServerToken, WithArgs([]string{"echo", "--instance", "echo-v1"}))(universalCluster)
 		Expect(err).ToNot(HaveOccurred())
 		err = DemoClientUniversal(AppModeDemoClient, "default", demoClientToken, WithTransparentProxy(true))(universalCluster)
 		Expect(err).ToNot(HaveOccurred())

--- a/test/e2e/trafficroute/universal_multizone/traffic_route.go
+++ b/test/e2e/trafficroute/universal_multizone/traffic_route.go
@@ -82,33 +82,23 @@ routing:
 			Install(Kuma(core.Zone, optsZone2...)).
 			Install(TestServerUniversal("dp-echo-1", defaultMesh, testServerToken,
 				WithArgs([]string{"echo", "--instance", "echo-v1"}),
-				WithProtocol("http"),
 				WithServiceVersion("v1"),
-				WithTransparentProxy(true),
 			)).
 			Install(TestServerUniversal("dp-echo-2", defaultMesh, testServerToken,
 				WithArgs([]string{"echo", "--instance", "echo-v2"}),
-				WithProtocol("http"),
 				WithServiceVersion("v2"),
-				WithTransparentProxy(true),
 			)).
 			Install(TestServerUniversal("dp-echo-3", defaultMesh, testServerToken,
 				WithArgs([]string{"echo", "--instance", "echo-v3"}),
-				WithProtocol("http"),
 				WithServiceVersion("v3"),
-				WithTransparentProxy(true),
 			)).
 			Install(TestServerUniversal("dp-echo-4", defaultMesh, testServerToken,
 				WithArgs([]string{"echo", "--instance", "echo-v4"}),
-				WithProtocol("http"),
 				WithServiceVersion("v4"),
-				WithTransparentProxy(true),
 			)).
 			Install(TestServerUniversal("dp-another-test", defaultMesh, anotherTestServerToken,
 				WithArgs([]string{"echo", "--instance", "another-test-server"}),
-				WithProtocol("http"),
 				WithServiceName("another-test-server"),
-				WithTransparentProxy(true),
 			)).
 			Install(IngressUniversal(ingressTokenKuma4)).
 			Setup(zone2)

--- a/test/e2e/trafficroute/universal_standalone/traffic_route.go
+++ b/test/e2e/trafficroute/universal_standalone/traffic_route.go
@@ -41,33 +41,23 @@ func KumaStandalone() {
 		err = NewClusterSetup().
 			Install(TestServerUniversal("dp-echo-1", defaultMesh, testServerToken,
 				WithArgs([]string{"echo", "--instance", "echo-v1"}),
-				WithProtocol("http"),
 				WithServiceVersion("v1"),
-				WithTransparentProxy(true),
 			)).
 			Install(TestServerUniversal("dp-echo-2", defaultMesh, testServerToken,
 				WithArgs([]string{"echo", "--instance", "echo-v2"}),
-				WithProtocol("http"),
 				WithServiceVersion("v2"),
-				WithTransparentProxy(true),
 			)).
 			Install(TestServerUniversal("dp-echo-3", defaultMesh, testServerToken,
 				WithArgs([]string{"echo", "--instance", "echo-v3"}),
-				WithProtocol("http"),
 				WithServiceVersion("v3"),
-				WithTransparentProxy(true),
 			)).
 			Install(TestServerUniversal("dp-echo-4", defaultMesh, testServerToken,
 				WithArgs([]string{"echo", "--instance", "echo-v4"}),
-				WithProtocol("http"),
 				WithServiceVersion("v4"),
-				WithTransparentProxy(true),
 			)).
 			Install(TestServerUniversal("dp-another-test", defaultMesh, anotherTestServerToken,
 				WithArgs([]string{"echo", "--instance", "another-test-server"}),
-				WithProtocol("http"),
 				WithServiceName("another-test-server"),
-				WithTransparentProxy(true),
 			)).
 			Install(DemoClientUniversal(AppModeDemoClient, defaultMesh, demoClientToken, WithTransparentProxy(true))).
 			Setup(universal)

--- a/test/framework/deployments/testserver/deployment.go
+++ b/test/framework/deployments/testserver/deployment.go
@@ -1,0 +1,59 @@
+package testserver
+
+import (
+	"github.com/pkg/errors"
+
+	"github.com/kumahq/kuma/test/framework"
+)
+
+type DeploymentOpts struct {
+	Mesh string
+}
+
+func DefaultDeploymentOpts() DeploymentOpts {
+	return DeploymentOpts{
+		Mesh: "default",
+	}
+}
+
+type DeploymentOptsFn = func(*DeploymentOpts)
+
+func WithMesh(mesh string) DeploymentOptsFn {
+	return func(opts *DeploymentOpts) {
+		opts.Mesh = mesh
+	}
+}
+
+type TestServer interface {
+}
+
+type Deployment interface {
+	framework.Deployment
+	TestServer
+}
+
+const DeploymentName = "test-server"
+
+func From(cluster framework.Cluster) TestServer {
+	return cluster.Deployment(DeploymentName).(TestServer)
+}
+
+func Install(fn ...DeploymentOptsFn) framework.InstallFunc {
+	opts := DefaultDeploymentOpts()
+	for _, f := range fn {
+		f(&opts)
+	}
+
+	return func(cluster framework.Cluster) error {
+		var deployment Deployment
+		switch cluster.(type) {
+		case *framework.K8sCluster:
+			deployment = &k8SDeployment{
+				opts: opts,
+			}
+		default:
+			return errors.New("invalid cluster")
+		}
+		return cluster.Deploy(deployment)
+	}
+}

--- a/test/framework/deployments/testserver/kubernetes.go
+++ b/test/framework/deployments/testserver/kubernetes.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/gruntwork-io/terratest/modules/k8s"
+
 	"github.com/kumahq/kuma/test/framework"
 )
 

--- a/test/framework/deployments/testserver/kubernetes.go
+++ b/test/framework/deployments/testserver/kubernetes.go
@@ -1,0 +1,109 @@
+package testserver
+
+import (
+	"fmt"
+
+	"github.com/gruntwork-io/terratest/modules/k8s"
+	"github.com/kumahq/kuma/test/framework"
+)
+
+type k8SDeployment struct {
+	opts DeploymentOpts
+}
+
+func (k *k8SDeployment) Name() string {
+	return "test-server"
+}
+
+const name = "test-server"
+
+const service = `
+apiVersion: v1
+kind: Service
+metadata:
+  name: test-server
+  namespace: kuma-test
+  annotations:
+    80.service.kuma.io/protocol: http
+spec:
+  ports:
+    - port: 80
+      name: http
+  selector:
+    app: test-server
+`
+
+const deployment = `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test-server
+  namespace: kuma-test
+  labels:
+    app: test-server
+spec:
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  selector:
+    matchLabels:
+      app: test-server
+  template:
+    metadata:
+      annotations:
+        kuma.io/mesh: %s
+      labels:
+        app: test-server
+    spec:
+      containers:
+        - name: test-server
+          image: %s
+          imagePullPolicy: IfNotPresent
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 80
+            initialDelaySeconds: 3
+            periodSeconds: 3
+          ports:
+            - containerPort: 80
+          command: [ "test-server" ]
+          args:
+            - echo
+            - "--instance"
+            - "echo"
+            - "--port"
+            - '80'
+          resources:
+            limits:
+              cpu: 50m
+              memory: 128Mi
+`
+
+func (k *k8SDeployment) Deploy(cluster framework.Cluster) error {
+	fn := framework.Combine(
+		framework.YamlK8s(service),
+		framework.YamlK8s(fmt.Sprintf(deployment, k.opts.Mesh, framework.GetUniversalImage())),
+		framework.WaitService(framework.TestNamespace, name),
+		framework.WaitNumPods(1, name),
+		framework.WaitPodsAvailable(framework.TestNamespace, name),
+	)
+	return fn(cluster)
+}
+
+func (k *k8SDeployment) Delete(cluster framework.Cluster) error {
+	k8s.KubectlDeleteFromString(
+		cluster.GetTesting(),
+		cluster.GetKubectlOptions(framework.TestNamespace),
+		service,
+	)
+	k8s.KubectlDeleteFromString(
+		cluster.GetTesting(),
+		cluster.GetKubectlOptions(framework.TestNamespace),
+		fmt.Sprintf(deployment, k.opts.Mesh, framework.GetUniversalImage()),
+	)
+	return nil
+}
+
+var _ Deployment = &k8SDeployment{}

--- a/test/framework/deployments/testserver/kubernetes.go
+++ b/test/framework/deployments/testserver/kubernetes.go
@@ -3,8 +3,6 @@ package testserver
 import (
 	"fmt"
 
-	"github.com/gruntwork-io/terratest/modules/k8s"
-
 	"github.com/kumahq/kuma/test/framework"
 )
 
@@ -94,16 +92,21 @@ func (k *k8SDeployment) Deploy(cluster framework.Cluster) error {
 }
 
 func (k *k8SDeployment) Delete(cluster framework.Cluster) error {
-	k8s.KubectlDeleteFromString(
-		cluster.GetTesting(),
-		cluster.GetKubectlOptions(framework.TestNamespace),
-		service,
-	)
-	k8s.KubectlDeleteFromString(
-		cluster.GetTesting(),
-		cluster.GetKubectlOptions(framework.TestNamespace),
-		fmt.Sprintf(deployment, k.opts.Mesh, framework.GetUniversalImage()),
-	)
+	// todo(jakubdyszkiewicz) right now we delete TestNamespace before we Dismiss the cluster
+	// This means that namespace is no longer available so the code below would throw an error
+	// If we ever switch DemoClient to be deployment and remove manual deletion of TestNamespace
+	// then we can rely on code below to delete tht deployment.
+
+	// k8s.KubectlDeleteFromString(
+	// 	cluster.GetTesting(),
+	// 	cluster.GetKubectlOptions(framework.TestNamespace),
+	// 	service,
+	// )
+	// k8s.KubectlDeleteFromString(
+	// 	cluster.GetTesting(),
+	// 	cluster.GetKubectlOptions(framework.TestNamespace),
+	// 	fmt.Sprintf(deployment, k.opts.Mesh, framework.GetUniversalImage()),
+	// )
 	return nil
 }
 

--- a/test/framework/setup.go
+++ b/test/framework/setup.go
@@ -181,161 +181,6 @@ func WaitPodsNotAvailable(namespace, app string) InstallFunc {
 	}
 }
 
-func EchoServerK8sIngress() InstallFunc {
-	ingress := `
-apiVersion: extensions/v1beta1
-kind: Ingress
-metadata:
-  namespace: kuma-test
-  name: k8s-ingress
-  annotations:
-    kubernetes.io/ingress.class: kong
-spec:
-  rules:
-  - http:
-      paths:
-      - path: /
-        backend:
-          serviceName: echo-server
-          servicePort: 80
-`
-	return YamlK8s(ingress)
-}
-
-func EchoServerK8sIngressWithMeshDNS() InstallFunc {
-	ingress := `
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: echo-server-externalname
-  namespace: kuma-test
-spec:
-  type: ExternalName
-  externalName: echo-server.kuma-test.svc.80.mesh
----
-apiVersion: extensions/v1beta1
-kind: Ingress
-metadata:
-  namespace: kuma-test
-  name: k8s-ingress-dot-mesh
-  annotations:
-    kubernetes.io/ingress.class: kong
-spec:
-  rules:
-  - http:
-      paths:
-      - path: /
-        backend:
-          serviceName: echo-server-externalname
-          servicePort: 80
-`
-	return YamlK8s(ingress)
-}
-
-func EchoServerK8s(mesh string) InstallFunc {
-	const name = "echo-server"
-	service := `
-apiVersion: v1
-kind: Service
-metadata:
-  name: echo-server
-  namespace: kuma-test
-  annotations:
-    80.service.kuma.io/protocol: http
-spec:
-  ports:
-    - port: 80
-      name: http
-  selector:
-    app: echo-server
-`
-	deployment := `
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: echo-server
-  namespace: kuma-test
-  labels:
-    app: echo-server
-spec:
-  strategy:
-    rollingUpdate:
-      maxSurge: 1
-      maxUnavailable: 0
-  selector:
-    matchLabels:
-      app: echo-server
-  template:
-    metadata:
-      annotations:
-        kuma.io/mesh: %s
-      labels:
-        app: echo-server
-    spec:
-      containers:
-        - name: echo-server
-          image: %s
-          imagePullPolicy: IfNotPresent
-          readinessProbe:
-            httpGet:
-              path: /
-              port: 80
-            initialDelaySeconds: 3
-            periodSeconds: 3
-          ports:
-            - containerPort: 80
-          command: [ "ncat" ]
-          args:
-            - -lk
-            - -p
-            - "80"
-            - --sh-exec
-            - '/usr/bin/printf "HTTP/1.1 200 OK\nContent-Length: 5\n\n Echo\n"'
-          resources:
-            limits:
-              cpu: 50m
-              memory: 128Mi
-
-`
-	return Combine(
-		YamlK8s(service),
-		YamlK8s(fmt.Sprintf(deployment, mesh, GetUniversalImage())),
-		WaitService(TestNamespace, name),
-		WaitNumPods(1, name),
-		WaitPodsAvailable(TestNamespace, name),
-	)
-}
-
-func EchoServerUniversal(name, mesh, echo, token string, fs ...DeployOptionsFunc) InstallFunc {
-	return func(cluster Cluster) error {
-		opts := newDeployOpt(fs...)
-		args := []string{"ncat", "-lk", "-p", "80", "--sh-exec", "'echo \"HTTP/1.1 200 OK\n\n Echo " + echo + "\n\"'"}
-		appYaml := ""
-		if opts.protocol == "" {
-			opts.protocol = "http"
-		}
-		if opts.serviceName == "" {
-			opts.serviceName = "echo-server_kuma-test_svc_8080"
-		}
-		if opts.serviceVersion == "" {
-			opts.serviceVersion = "v1"
-		}
-		switch {
-		case opts.transparent:
-			appYaml = fmt.Sprintf(EchoServerDataplaneTransparentProxy, mesh, "8080", "80", opts.serviceName,
-				opts.protocol, opts.serviceVersion, redirectPortInbound, redirectPortInboundV6, redirectPortOutbound)
-		case opts.serviceProbe:
-			appYaml = fmt.Sprintf(EchoServerDataplaneWithServiceProbe, mesh, "8080", "80", opts.serviceName,
-				opts.protocol, opts.serviceVersion)
-		default:
-			appYaml = fmt.Sprintf(EchoServerDataplane, mesh, "8080", "80", opts.serviceName, opts.protocol, opts.serviceVersion)
-		}
-		fs = append(fs, WithName(name), WithMesh(mesh), WithAppname(AppModeEchoServer), WithToken(token), WithArgs(args), WithYaml(appYaml), WithIPv6(IsIPv6()))
-		return cluster.DeployApp(fs...)
-	}
-}
-
 func IngressUniversalOldType(mesh, token string) InstallFunc {
 	return func(cluster Cluster) error {
 		uniCluster := cluster.(*UniversalCluster)
@@ -505,6 +350,14 @@ func TestServerUniversal(name, mesh, token string, fs ...DeployOptionsFunc) Inst
 		if opts.serviceName == "" {
 			opts.serviceName = "test-server"
 		}
+
+		serviceProbe := ""
+		if opts.serviceProbe {
+			serviceProbe =
+				`    serviceProbe:
+      tcp: {}`
+		}
+
 		args = append(args, "--port", "8080")
 		appYaml := fmt.Sprintf(`
 type: Dataplane
@@ -520,11 +373,12 @@ networking:
       kuma.io/protocol: %s
       version: %s
       team: server-owners
+%s
   transparentProxying:
     redirectPortInbound: %s
     redirectPortInboundV6: %s
     redirectPortOutbound: %s
-`, mesh, "80", "8080", opts.serviceName, opts.protocol, opts.serviceVersion, redirectPortInbound, redirectPortInboundV6, redirectPortOutbound)
+`, mesh, "80", "8080", opts.serviceName, opts.protocol, opts.serviceVersion, serviceProbe, redirectPortInbound, redirectPortInboundV6, redirectPortOutbound)
 
 		fs = append(fs,
 			WithName(name),

--- a/test/framework/setup.go
+++ b/test/framework/setup.go
@@ -384,6 +384,7 @@ networking:
 			WithName(name),
 			WithMesh(mesh),
 			WithAppname("test-server"),
+			WithTransparentProxy(true), // test server is always ment to use with transparent proxy
 			WithToken(token),
 			WithArgs(args),
 			WithYaml(appYaml),

--- a/test/framework/universal_cluster.go
+++ b/test/framework/universal_cluster.go
@@ -212,18 +212,20 @@ func (c *UniversalCluster) DeployApp(fs ...DeployOptionsFunc) error {
 		return err
 	}
 
+	if opts.dpVersion != "" {
+		// override needs to be before setting up transparent proxy.
+		// Otherwise, we won't be able to fetch specific Kuma DP version.
+		if err := app.OverrideDpVersion(opts.dpVersion); err != nil {
+			return err
+		}
+	}
+
 	builtindns := opts.builtindns == nil || *opts.builtindns
 	if transparent {
 		app.setupTransparent(c.apps[AppModeCP].ip, builtindns)
 	}
 
 	ip := app.ip
-
-	if opts.dpVersion != "" {
-		if err := app.OverrideDpVersion(opts.dpVersion); err != nil {
-			return err
-		}
-	}
 
 	err = c.CreateDP(app, opts.name, ip, dpyaml, token, builtindns)
 	if err != nil {


### PR DESCRIPTION
### Summary

So far we were using netcat as our "HTTP server", but this has caused several problems with testing.
Sometimes netcat was randomly failing. One time we forgot to add content-length header to the response etc, etc.
In the end, we figured out that we should use real HTTP server that has valid RFC implementation that supports connection pooling etc.
Some time ago, @lobkovilya introduced Test Server that is just Go application that uses HTTP server.
This PR replaces all usages of ncat as a test server.

It's already hard enough to get stable E2E tests, so this PR eliminates one of the problems.

I implemented Test Server on K8S as Deployment. I would love to do the same for Universal but it requires further refactor.

Note that netcat is still used for DemoClient but it's not really used, since all the requets are made by sshing into the pod/VM and execute curls.

### Documentation

- [X] No docs

### Testing

- [ ] Unit tests
- [X] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes 

### Backwards compatibility

- [X] Add `backport-to-stable` label if the code is backwards compatible. Otherwise, list breaking changes.