### PR TITLE
add importas to golangci-lint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -4,6 +4,7 @@ linters:
     - gci
     - gocritic
     - govet
+    - importas
     - misspell
     - unconvert
     - whitespace
@@ -22,6 +23,12 @@ linters-settings:
       - singleCaseSwitch
   gci:
     local-prefixes: github.com/kumahq/kuma
+  importas:
+    alias:
+    - pkg: github.com/kumahq/kuma/pkg/core/resources/apis/mesh
+      alias: core_mesh
+    - pkg: github.com/kumahq/kuma/api/mesh/v1alpha1
+      alias: mesh_proto
 
 issues:
   fix: true

--- a/app/kumactl/cmd/delete/delete_test.go
+++ b/app/kumactl/cmd/delete/delete_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/kumahq/kuma/app/kumactl/cmd"
 	kumactl_cmd "github.com/kumahq/kuma/app/kumactl/pkg/cmd"
 	config_proto "github.com/kumahq/kuma/pkg/config/app/kumactl/v1alpha1"
-	mesh_core "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
+	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	"github.com/kumahq/kuma/pkg/core/resources/apis/system"
 	core_model "github.com/kumahq/kuma/pkg/core/resources/model"
 	core_store "github.com/kumahq/kuma/pkg/core/resources/store"
@@ -141,79 +141,79 @@ var _ = Describe("kumactl delete ", func() {
 				Entry("circuit-breaker", testCase{
 					typ:             "circuit-breaker",
 					name:            "web",
-					resource:        func() core_model.Resource { return mesh_core.NewCircuitBreakerResource() },
+					resource:        func() core_model.Resource { return core_mesh.NewCircuitBreakerResource() },
 					expectedMessage: "deleted CircuitBreaker \"web\"\n",
 				}),
 				Entry("dataplanes", testCase{
 					typ:             "dataplane",
 					name:            "web",
-					resource:        func() core_model.Resource { return mesh_core.NewDataplaneResource() },
+					resource:        func() core_model.Resource { return core_mesh.NewDataplaneResource() },
 					expectedMessage: "deleted Dataplane \"web\"\n",
 				}),
 				Entry("external-services", testCase{
 					typ:             "external-service",
 					name:            "httpbin",
-					resource:        func() core_model.Resource { return mesh_core.NewExternalServiceResource() },
+					resource:        func() core_model.Resource { return core_mesh.NewExternalServiceResource() },
 					expectedMessage: "deleted ExternalService \"httpbin\"\n",
 				}),
 				Entry("fault-injections", testCase{
 					typ:             "fault-injection",
 					name:            "web",
-					resource:        func() core_model.Resource { return mesh_core.NewFaultInjectionResource() },
+					resource:        func() core_model.Resource { return core_mesh.NewFaultInjectionResource() },
 					expectedMessage: "deleted FaultInjection \"web\"\n",
 				}),
 				Entry("healthchecks", testCase{
 					typ:             "healthcheck",
 					name:            "web-to-backend",
-					resource:        func() core_model.Resource { return mesh_core.NewHealthCheckResource() },
+					resource:        func() core_model.Resource { return core_mesh.NewHealthCheckResource() },
 					expectedMessage: "deleted HealthCheck \"web-to-backend\"\n",
 				}),
 				Entry("proxytemplate", testCase{
 					typ:             "proxytemplate",
 					name:            "test-pt",
-					resource:        func() core_model.Resource { return mesh_core.NewProxyTemplateResource() },
+					resource:        func() core_model.Resource { return core_mesh.NewProxyTemplateResource() },
 					expectedMessage: "deleted ProxyTemplate \"test-pt\"\n",
 				}),
 				Entry("retries", testCase{
 					typ:             "retry",
 					name:            "web-to-backend",
-					resource:        func() core_model.Resource { return mesh_core.NewRetryResource() },
+					resource:        func() core_model.Resource { return core_mesh.NewRetryResource() },
 					expectedMessage: "deleted Retry \"web-to-backend\"\n",
 				}),
 				Entry("rate-limits", testCase{
 					typ:             "rate-limit",
 					name:            "100-rps",
-					resource:        func() core_model.Resource { return mesh_core.NewRateLimitResource() },
+					resource:        func() core_model.Resource { return core_mesh.NewRateLimitResource() },
 					expectedMessage: "deleted RateLimit \"100-rps\"\n",
 				}),
 				Entry("timeouts", testCase{
 					typ:             "timeout",
 					name:            "web",
-					resource:        func() core_model.Resource { return mesh_core.NewTimeoutResource() },
+					resource:        func() core_model.Resource { return core_mesh.NewTimeoutResource() },
 					expectedMessage: "deleted Timeout \"web\"\n",
 				}),
 				Entry("traffic-logs", testCase{
 					typ:             "traffic-log",
 					name:            "all-requests",
-					resource:        func() core_model.Resource { return mesh_core.NewTrafficLogResource() },
+					resource:        func() core_model.Resource { return core_mesh.NewTrafficLogResource() },
 					expectedMessage: "deleted TrafficLog \"all-requests\"\n",
 				}),
 				Entry("traffic-permissions", testCase{
 					typ:             "traffic-permission",
 					name:            "everyone-to-everyone",
-					resource:        func() core_model.Resource { return mesh_core.NewTrafficPermissionResource() },
+					resource:        func() core_model.Resource { return core_mesh.NewTrafficPermissionResource() },
 					expectedMessage: "deleted TrafficPermission \"everyone-to-everyone\"\n",
 				}),
 				Entry("traffic-routes", testCase{
 					typ:             "traffic-route",
 					name:            "web-to-backend",
-					resource:        func() core_model.Resource { return mesh_core.NewTrafficRouteResource() },
+					resource:        func() core_model.Resource { return core_mesh.NewTrafficRouteResource() },
 					expectedMessage: "deleted TrafficRoute \"web-to-backend\"\n",
 				}),
 				Entry("traffic-traces", testCase{
 					typ:             "traffic-trace",
 					name:            "web",
-					resource:        func() core_model.Resource { return mesh_core.NewTrafficTraceResource() },
+					resource:        func() core_model.Resource { return core_mesh.NewTrafficTraceResource() },
 					expectedMessage: "deleted TrafficTrace \"web\"\n",
 				}),
 				Entry("secrets", testCase{
@@ -258,7 +258,7 @@ var _ = Describe("kumactl delete ", func() {
 				Entry("meshes", testCase{
 					typ:             "mesh",
 					name:            "test-mesh",
-					resource:        func() core_model.Resource { return mesh_core.NewMeshResource() },
+					resource:        func() core_model.Resource { return core_mesh.NewMeshResource() },
 					expectedMessage: "deleted Mesh \"test-mesh\"\n",
 				}),
 				Entry("global-secrets", testCase{
@@ -293,55 +293,55 @@ var _ = Describe("kumactl delete ", func() {
 				Entry("dataplanes", testCase{
 					typ:             "dataplane",
 					name:            "web",
-					resource:        func() core_model.Resource { return mesh_core.NewDataplaneResource() },
+					resource:        func() core_model.Resource { return core_mesh.NewDataplaneResource() },
 					expectedMessage: "Error: there is no Dataplane with name \"web\"\n",
 				}),
 				Entry("healthchecks", testCase{
 					typ:             "healthcheck",
 					name:            "web-to-backend",
-					resource:        func() core_model.Resource { return mesh_core.NewHealthCheckResource() },
+					resource:        func() core_model.Resource { return core_mesh.NewHealthCheckResource() },
 					expectedMessage: "Error: there is no HealthCheck with name \"web-to-backend\"\n",
 				}),
 				Entry("retries", testCase{
 					typ:             "retry",
 					name:            "web-to-backend",
-					resource:        func() core_model.Resource { return mesh_core.NewRetryResource() },
+					resource:        func() core_model.Resource { return core_mesh.NewRetryResource() },
 					expectedMessage: "Error: there is no Retry with name \"web-to-backend\"\n",
 				}),
 				Entry("traffic-permissions", testCase{
 					typ:             "traffic-permission",
 					name:            "everyone-to-everyone",
-					resource:        func() core_model.Resource { return mesh_core.NewTrafficPermissionResource() },
+					resource:        func() core_model.Resource { return core_mesh.NewTrafficPermissionResource() },
 					expectedMessage: "Error: there is no TrafficPermission with name \"everyone-to-everyone\"\n",
 				}),
 				Entry("traffic-logs", testCase{
 					typ:             "traffic-log",
 					name:            "all-requests",
-					resource:        func() core_model.Resource { return mesh_core.NewTrafficLogResource() },
+					resource:        func() core_model.Resource { return core_mesh.NewTrafficLogResource() },
 					expectedMessage: "Error: there is no TrafficLog with name \"all-requests\"\n",
 				}),
 				Entry("traffic-routes", testCase{
 					typ:             "traffic-route",
 					name:            "web-to-backend",
-					resource:        func() core_model.Resource { return mesh_core.NewTrafficRouteResource() },
+					resource:        func() core_model.Resource { return core_mesh.NewTrafficRouteResource() },
 					expectedMessage: "Error: there is no TrafficRoute with name \"web-to-backend\"\n",
 				}),
 				Entry("traffic-traces", testCase{
 					typ:             "traffic-trace",
 					name:            "web",
-					resource:        func() core_model.Resource { return mesh_core.NewTrafficRouteResource() },
+					resource:        func() core_model.Resource { return core_mesh.NewTrafficRouteResource() },
 					expectedMessage: "Error: there is no TrafficTrace with name \"web\"\n",
 				}),
 				Entry("fault-injections", testCase{
 					typ:             "fault-injection",
 					name:            "web",
-					resource:        func() core_model.Resource { return mesh_core.NewFaultInjectionResource() },
+					resource:        func() core_model.Resource { return core_mesh.NewFaultInjectionResource() },
 					expectedMessage: "Error: there is no FaultInjection with name \"web\"\n",
 				}),
 				Entry("fault-injections", testCase{
 					typ:             "circuit-breaker",
 					name:            "web",
-					resource:        func() core_model.Resource { return mesh_core.NewCircuitBreakerResource() },
+					resource:        func() core_model.Resource { return core_mesh.NewCircuitBreakerResource() },
 					expectedMessage: "Error: there is no CircuitBreaker with name \"web\"\n",
 				}),
 				Entry("secret", testCase{

--- a/app/kumactl/cmd/get/get_circuit_breakers_test.go
+++ b/app/kumactl/cmd/get/get_circuit_breakers_test.go
@@ -16,7 +16,7 @@ import (
 	"google.golang.org/protobuf/types/known/durationpb"
 	"google.golang.org/protobuf/types/known/wrapperspb"
 
-	kuma_mesh "github.com/kumahq/kuma/api/mesh/v1alpha1"
+	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	"github.com/kumahq/kuma/app/kumactl/cmd"
 	kumactl_cmd "github.com/kumahq/kuma/app/kumactl/pkg/cmd"
 	config_proto "github.com/kumahq/kuma/pkg/config/app/kumactl/v1alpha1"
@@ -32,8 +32,8 @@ var _ = Describe("kumactl get circuit-breakers", func() {
 
 	circuitBreakerResources := []*mesh.CircuitBreakerResource{
 		{
-			Spec: &kuma_mesh.CircuitBreaker{
-				Sources: []*kuma_mesh.Selector{
+			Spec: &mesh_proto.CircuitBreaker{
+				Sources: []*mesh_proto.Selector{
 					{
 						Match: map[string]string{
 							"service": "frontend",
@@ -41,24 +41,24 @@ var _ = Describe("kumactl get circuit-breakers", func() {
 						},
 					},
 				},
-				Destinations: []*kuma_mesh.Selector{
+				Destinations: []*mesh_proto.Selector{
 					{
 						Match: map[string]string{
 							"service": "backend",
 						},
 					},
 				},
-				Conf: &kuma_mesh.CircuitBreaker_Conf{
+				Conf: &mesh_proto.CircuitBreaker_Conf{
 					Interval:                    &durationpb.Duration{Seconds: 5},
 					BaseEjectionTime:            &durationpb.Duration{Seconds: 5},
 					MaxEjectionPercent:          &wrapperspb.UInt32Value{Value: 50},
 					SplitExternalAndLocalErrors: false,
-					Detectors: &kuma_mesh.CircuitBreaker_Conf_Detectors{
-						TotalErrors:       &kuma_mesh.CircuitBreaker_Conf_Detectors_Errors{},
-						GatewayErrors:     &kuma_mesh.CircuitBreaker_Conf_Detectors_Errors{},
-						LocalErrors:       &kuma_mesh.CircuitBreaker_Conf_Detectors_Errors{},
-						StandardDeviation: &kuma_mesh.CircuitBreaker_Conf_Detectors_StandardDeviation{},
-						Failure:           &kuma_mesh.CircuitBreaker_Conf_Detectors_Failure{},
+					Detectors: &mesh_proto.CircuitBreaker_Conf_Detectors{
+						TotalErrors:       &mesh_proto.CircuitBreaker_Conf_Detectors_Errors{},
+						GatewayErrors:     &mesh_proto.CircuitBreaker_Conf_Detectors_Errors{},
+						LocalErrors:       &mesh_proto.CircuitBreaker_Conf_Detectors_Errors{},
+						StandardDeviation: &mesh_proto.CircuitBreaker_Conf_Detectors_StandardDeviation{},
+						Failure:           &mesh_proto.CircuitBreaker_Conf_Detectors_Failure{},
 					},
 				},
 			},
@@ -68,8 +68,8 @@ var _ = Describe("kumactl get circuit-breakers", func() {
 			},
 		},
 		{
-			Spec: &kuma_mesh.CircuitBreaker{
-				Sources: []*kuma_mesh.Selector{
+			Spec: &mesh_proto.CircuitBreaker{
+				Sources: []*mesh_proto.Selector{
 					{
 						Match: map[string]string{
 							"service": "web",
@@ -77,28 +77,28 @@ var _ = Describe("kumactl get circuit-breakers", func() {
 						},
 					},
 				},
-				Destinations: []*kuma_mesh.Selector{
+				Destinations: []*mesh_proto.Selector{
 					{
 						Match: map[string]string{
 							"service": "redis",
 						},
 					},
 				},
-				Conf: &kuma_mesh.CircuitBreaker_Conf{
+				Conf: &mesh_proto.CircuitBreaker_Conf{
 					Interval:                    &durationpb.Duration{Seconds: 5},
 					BaseEjectionTime:            &durationpb.Duration{Seconds: 5},
 					MaxEjectionPercent:          &wrapperspb.UInt32Value{Value: 50},
 					SplitExternalAndLocalErrors: false,
-					Detectors: &kuma_mesh.CircuitBreaker_Conf_Detectors{
-						TotalErrors:   &kuma_mesh.CircuitBreaker_Conf_Detectors_Errors{Consecutive: &wrapperspb.UInt32Value{Value: 20}},
-						GatewayErrors: &kuma_mesh.CircuitBreaker_Conf_Detectors_Errors{Consecutive: &wrapperspb.UInt32Value{Value: 10}},
-						LocalErrors:   &kuma_mesh.CircuitBreaker_Conf_Detectors_Errors{Consecutive: &wrapperspb.UInt32Value{Value: 2}},
-						StandardDeviation: &kuma_mesh.CircuitBreaker_Conf_Detectors_StandardDeviation{
+					Detectors: &mesh_proto.CircuitBreaker_Conf_Detectors{
+						TotalErrors:   &mesh_proto.CircuitBreaker_Conf_Detectors_Errors{Consecutive: &wrapperspb.UInt32Value{Value: 20}},
+						GatewayErrors: &mesh_proto.CircuitBreaker_Conf_Detectors_Errors{Consecutive: &wrapperspb.UInt32Value{Value: 10}},
+						LocalErrors:   &mesh_proto.CircuitBreaker_Conf_Detectors_Errors{Consecutive: &wrapperspb.UInt32Value{Value: 2}},
+						StandardDeviation: &mesh_proto.CircuitBreaker_Conf_Detectors_StandardDeviation{
 							RequestVolume: &wrapperspb.UInt32Value{Value: 20},
 							MinimumHosts:  &wrapperspb.UInt32Value{Value: 3},
 							Factor:        &wrapperspb.DoubleValue{Value: 1.9},
 						},
-						Failure: &kuma_mesh.CircuitBreaker_Conf_Detectors_Failure{
+						Failure: &mesh_proto.CircuitBreaker_Conf_Detectors_Failure{
 							RequestVolume: &wrapperspb.UInt32Value{Value: 20},
 							MinimumHosts:  &wrapperspb.UInt32Value{Value: 3},
 							Threshold:     &wrapperspb.UInt32Value{Value: 85},

--- a/app/kumactl/cmd/get/get_dataplanes_test.go
+++ b/app/kumactl/cmd/get/get_dataplanes_test.go
@@ -18,7 +18,7 @@ import (
 	"github.com/kumahq/kuma/app/kumactl/cmd"
 	kumactl_cmd "github.com/kumahq/kuma/app/kumactl/pkg/cmd"
 	config_proto "github.com/kumahq/kuma/pkg/config/app/kumactl/v1alpha1"
-	mesh_core "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
+	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	core_model "github.com/kumahq/kuma/pkg/core/resources/model"
 	core_store "github.com/kumahq/kuma/pkg/core/resources/store"
 	memory_resources "github.com/kumahq/kuma/pkg/plugins/resources/memory"
@@ -28,10 +28,10 @@ import (
 
 var _ = Describe("kumactl get dataplanes", func() {
 
-	var dataplanes []*mesh_core.DataplaneResource
+	var dataplanes []*core_mesh.DataplaneResource
 	BeforeEach(func() {
 		// setup
-		dataplanes = []*mesh_core.DataplaneResource{
+		dataplanes = []*core_mesh.DataplaneResource{
 			{
 				Meta: &test_model.ResourceMeta{
 					Mesh: "default",

--- a/app/kumactl/cmd/get/get_external_services_test.go
+++ b/app/kumactl/cmd/get/get_external_services_test.go
@@ -18,7 +18,7 @@ import (
 	"github.com/kumahq/kuma/app/kumactl/cmd"
 	kumactl_cmd "github.com/kumahq/kuma/app/kumactl/pkg/cmd"
 	config_proto "github.com/kumahq/kuma/pkg/config/app/kumactl/v1alpha1"
-	mesh_core "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
+	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	core_model "github.com/kumahq/kuma/pkg/core/resources/model"
 	core_store "github.com/kumahq/kuma/pkg/core/resources/store"
 	memory_resources "github.com/kumahq/kuma/pkg/plugins/resources/memory"
@@ -28,10 +28,10 @@ import (
 
 var _ = Describe("kumactl get external-services", func() {
 
-	var externalServices []*mesh_core.ExternalServiceResource
+	var externalServices []*core_mesh.ExternalServiceResource
 	BeforeEach(func() {
 		// setup
-		externalServices = []*mesh_core.ExternalServiceResource{
+		externalServices = []*core_mesh.ExternalServiceResource{
 			{
 				Meta: &test_model.ResourceMeta{
 					Mesh: "default",

--- a/app/kumactl/cmd/get/get_healthchecks_test.go
+++ b/app/kumactl/cmd/get/get_healthchecks_test.go
@@ -18,7 +18,7 @@ import (
 	"github.com/kumahq/kuma/app/kumactl/cmd"
 	kumactl_cmd "github.com/kumahq/kuma/app/kumactl/pkg/cmd"
 	config_proto "github.com/kumahq/kuma/pkg/config/app/kumactl/v1alpha1"
-	mesh_core "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
+	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	core_model "github.com/kumahq/kuma/pkg/core/resources/model"
 	core_store "github.com/kumahq/kuma/pkg/core/resources/store"
 	memory_resources "github.com/kumahq/kuma/pkg/plugins/resources/memory"
@@ -28,9 +28,9 @@ import (
 
 var _ = Describe("kumactl get healthchecks", func() {
 
-	var sampleHealthChecks []*mesh_core.HealthCheckResource
+	var sampleHealthChecks []*core_mesh.HealthCheckResource
 	BeforeEach(func() {
-		sampleHealthChecks = []*mesh_core.HealthCheckResource{
+		sampleHealthChecks = []*core_mesh.HealthCheckResource{
 			{
 				Meta: &test_model.ResourceMeta{
 					Mesh: "default",

--- a/app/kumactl/cmd/get/get_proxytemplates_test.go
+++ b/app/kumactl/cmd/get/get_proxytemplates_test.go
@@ -18,7 +18,7 @@ import (
 	"github.com/kumahq/kuma/app/kumactl/cmd"
 	kumactl_cmd "github.com/kumahq/kuma/app/kumactl/pkg/cmd"
 	config_proto "github.com/kumahq/kuma/pkg/config/app/kumactl/v1alpha1"
-	mesh_core "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
+	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	core_model "github.com/kumahq/kuma/pkg/core/resources/model"
 	core_store "github.com/kumahq/kuma/pkg/core/resources/store"
 	memory_resources "github.com/kumahq/kuma/pkg/plugins/resources/memory"
@@ -28,10 +28,10 @@ import (
 
 var _ = Describe("kumactl get proxytemplates", func() {
 
-	var sampleProxyTemplates []*mesh_core.ProxyTemplateResource
+	var sampleProxyTemplates []*core_mesh.ProxyTemplateResource
 
 	BeforeEach(func() {
-		sampleProxyTemplates = []*mesh_core.ProxyTemplateResource{
+		sampleProxyTemplates = []*core_mesh.ProxyTemplateResource{
 			{
 				Meta: &test_model.ResourceMeta{
 					Mesh: "default",

--- a/app/kumactl/cmd/get/get_retries_test.go
+++ b/app/kumactl/cmd/get/get_retries_test.go
@@ -18,7 +18,7 @@ import (
 	"github.com/kumahq/kuma/app/kumactl/cmd"
 	kumactl_cmd "github.com/kumahq/kuma/app/kumactl/pkg/cmd"
 	config_proto "github.com/kumahq/kuma/pkg/config/app/kumactl/v1alpha1"
-	mesh_core "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
+	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	core_model "github.com/kumahq/kuma/pkg/core/resources/model"
 	core_store "github.com/kumahq/kuma/pkg/core/resources/store"
 	memory_resources "github.com/kumahq/kuma/pkg/plugins/resources/memory"
@@ -27,10 +27,10 @@ import (
 )
 
 var _ = Describe("kumactl get retries", func() {
-	var sampleRetries []*mesh_core.RetryResource
+	var sampleRetries []*core_mesh.RetryResource
 
 	BeforeEach(func() {
-		sampleRetries = []*mesh_core.RetryResource{
+		sampleRetries = []*core_mesh.RetryResource{
 			{
 				Meta: &test_model.ResourceMeta{
 					Mesh: "default",

--- a/app/kumactl/cmd/get/get_traffic_routes_test.go
+++ b/app/kumactl/cmd/get/get_traffic_routes_test.go
@@ -18,7 +18,7 @@ import (
 	"github.com/kumahq/kuma/app/kumactl/cmd"
 	kumactl_cmd "github.com/kumahq/kuma/app/kumactl/pkg/cmd"
 	config_proto "github.com/kumahq/kuma/pkg/config/app/kumactl/v1alpha1"
-	mesh_core "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
+	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	core_model "github.com/kumahq/kuma/pkg/core/resources/model"
 	core_store "github.com/kumahq/kuma/pkg/core/resources/store"
 	memory_resources "github.com/kumahq/kuma/pkg/plugins/resources/memory"
@@ -28,10 +28,10 @@ import (
 
 var _ = Describe("kumactl get traffic-routes", func() {
 
-	var sampleTrafficRoutes []*mesh_core.TrafficRouteResource
+	var sampleTrafficRoutes []*core_mesh.TrafficRouteResource
 
 	BeforeEach(func() {
-		sampleTrafficRoutes = []*mesh_core.TrafficRouteResource{
+		sampleTrafficRoutes = []*core_mesh.TrafficRouteResource{
 			{
 				Meta: &test_model.ResourceMeta{
 					Mesh: "default",

--- a/app/kumactl/cmd/inspect/inspect_dataplanes.go
+++ b/app/kumactl/cmd/inspect/inspect_dataplanes.go
@@ -15,7 +15,7 @@ import (
 	"github.com/kumahq/kuma/app/kumactl/pkg/output"
 	"github.com/kumahq/kuma/app/kumactl/pkg/output/printers"
 	"github.com/kumahq/kuma/app/kumactl/pkg/output/table"
-	mesh_core "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
+	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	rest_types "github.com/kumahq/kuma/pkg/core/resources/model/rest"
 	util_proto "github.com/kumahq/kuma/pkg/util/proto"
 )
@@ -62,7 +62,7 @@ func newInspectDataplanesCmd(pctx *cmd.RootContext) *cobra.Command {
 	return cmd
 }
 
-func printDataplaneOverviews(now time.Time, dataplaneOverviews *mesh_core.DataplaneOverviewResourceList, out io.Writer) error {
+func printDataplaneOverviews(now time.Time, dataplaneOverviews *core_mesh.DataplaneOverviewResourceList, out io.Writer) error {
 	data := printers.Table{
 		Headers: []string{"MESH", "NAME", "TAGS", "STATUS", "LAST CONNECTED AGO", "LAST UPDATED AGO", "TOTAL UPDATES", "TOTAL ERRORS", "CERT REGENERATED AGO", "CERT EXPIRATION", "CERT REGENERATIONS", "KUMA-DP VERSION", "ENVOY VERSION", "NOTES"},
 		NextRow: func() func() []string {

--- a/app/kumactl/cmd/inspect/inspect_dataplanes_test.go
+++ b/app/kumactl/cmd/inspect/inspect_dataplanes_test.go
@@ -20,7 +20,7 @@ import (
 	kumactl_cmd "github.com/kumahq/kuma/app/kumactl/pkg/cmd"
 	"github.com/kumahq/kuma/app/kumactl/pkg/resources"
 	config_proto "github.com/kumahq/kuma/pkg/config/app/kumactl/v1alpha1"
-	mesh_core "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
+	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	"github.com/kumahq/kuma/pkg/core/resources/model"
 	test_model "github.com/kumahq/kuma/pkg/test/resources/model"
 	util_proto "github.com/kumahq/kuma/pkg/util/proto"
@@ -32,14 +32,14 @@ type testDataplaneOverviewClient struct {
 	receivedGateway bool
 	receivedIngress bool
 	total           uint32
-	overviews       []*mesh_core.DataplaneOverviewResource
+	overviews       []*core_mesh.DataplaneOverviewResource
 }
 
-func (c *testDataplaneOverviewClient) List(_ context.Context, _ string, tags map[string]string, gateway bool, ingress bool) (*mesh_core.DataplaneOverviewResourceList, error) {
+func (c *testDataplaneOverviewClient) List(_ context.Context, _ string, tags map[string]string, gateway bool, ingress bool) (*core_mesh.DataplaneOverviewResourceList, error) {
 	c.receivedTags = tags
 	c.receivedGateway = gateway
 	c.receivedIngress = ingress
-	return &mesh_core.DataplaneOverviewResourceList{
+	return &core_mesh.DataplaneOverviewResourceList{
 		Items: c.overviews,
 		Pagination: model.Pagination{
 			Total: c.total,
@@ -52,7 +52,7 @@ var _ resources.DataplaneOverviewClient = &testDataplaneOverviewClient{}
 var _ = Describe("kumactl inspect dataplanes", func() {
 
 	var now, t1, t2 time.Time
-	var sampleDataplaneOverview []*mesh_core.DataplaneOverviewResource
+	var sampleDataplaneOverview []*core_mesh.DataplaneOverviewResource
 
 	BeforeEach(func() {
 		now, _ = time.Parse(time.RFC3339, "2019-07-17T18:08:41+00:00")
@@ -60,7 +60,7 @@ var _ = Describe("kumactl inspect dataplanes", func() {
 		t2, _ = time.Parse(time.RFC3339, "2019-07-17T16:05:36.995+00:00")
 		time.Local = time.UTC
 
-		sampleDataplaneOverview = []*mesh_core.DataplaneOverviewResource{
+		sampleDataplaneOverview = []*core_mesh.DataplaneOverviewResource{
 			{
 				Meta: &test_model.ResourceMeta{
 					Mesh:             "default",

--- a/app/kumactl/pkg/output/json/json_test.go
+++ b/app/kumactl/pkg/output/json/json_test.go
@@ -13,7 +13,7 @@ import (
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	"github.com/kumahq/kuma/app/kumactl/pkg/output"
 	"github.com/kumahq/kuma/app/kumactl/pkg/output/json"
-	mesh_core "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
+	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	core_rest "github.com/kumahq/kuma/pkg/core/resources/model/rest"
 )
 
@@ -55,7 +55,7 @@ var _ = Describe("printer", func() {
 		Entry("format response from Kuma REST API", testCase{
 			obj: &core_rest.Resource{
 				Meta: core_rest.ResourceMeta{
-					Type:             string(mesh_core.MeshType),
+					Type:             string(core_mesh.MeshType),
 					Name:             "demo",
 					CreationTime:     t1,
 					ModificationTime: t2,

--- a/app/kumactl/pkg/output/yaml/yaml_test.go
+++ b/app/kumactl/pkg/output/yaml/yaml_test.go
@@ -13,7 +13,7 @@ import (
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	"github.com/kumahq/kuma/app/kumactl/pkg/output"
 	"github.com/kumahq/kuma/app/kumactl/pkg/output/yaml"
-	mesh_core "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
+	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	core_rest "github.com/kumahq/kuma/pkg/core/resources/model/rest"
 )
 
@@ -55,7 +55,7 @@ var _ = Describe("printer", func() {
 		Entry("format response from Kuma REST API", testCase{
 			obj: &core_rest.Resource{
 				Meta: core_rest.ResourceMeta{
-					Type:             string(mesh_core.MeshType),
+					Type:             string(core_mesh.MeshType),
 					Name:             "demo",
 					CreationTime:     t1,
 					ModificationTime: t2,

--- a/pkg/api-server/circuit_breaker_endpoints_test.go
+++ b/pkg/api-server/circuit_breaker_endpoints_test.go
@@ -13,7 +13,7 @@ import (
 	api_server "github.com/kumahq/kuma/pkg/api-server"
 	config "github.com/kumahq/kuma/pkg/config/api-server"
 	"github.com/kumahq/kuma/pkg/core"
-	mesh_core "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
+	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	"github.com/kumahq/kuma/pkg/core/resources/model"
 	"github.com/kumahq/kuma/pkg/core/resources/model/rest"
 	"github.com/kumahq/kuma/pkg/core/resources/store"
@@ -56,7 +56,7 @@ var _ = Describe("CircuitBreaker Endpoints", func() {
 
 	BeforeEach(func() {
 		// when
-		err := resourceStore.Create(context.Background(), mesh_core.NewMeshResource(), store.CreateByKey(model.DefaultMesh, model.NoMesh))
+		err := resourceStore.Create(context.Background(), core_mesh.NewMeshResource(), store.CreateByKey(model.DefaultMesh, model.NoMesh))
 		// then
 		Expect(err).ToNot(HaveOccurred())
 	})

--- a/pkg/api-server/dataplane_overview_endpoints_test.go
+++ b/pkg/api-server/dataplane_overview_endpoints_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/kumahq/kuma/api/mesh/v1alpha1"
 	api_server "github.com/kumahq/kuma/pkg/api-server"
 	config "github.com/kumahq/kuma/pkg/config/api-server"
-	mesh_core "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
+	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	"github.com/kumahq/kuma/pkg/core/resources/model"
 	"github.com/kumahq/kuma/pkg/core/resources/store"
 	"github.com/kumahq/kuma/pkg/metrics"
@@ -50,19 +50,19 @@ var _ = Describe("Dataplane Overview Endpoints", func() {
 	})
 
 	BeforeEach(func() {
-		err := resourceStore.Create(context.Background(), mesh_core.NewMeshResource(), store.CreateByKey("mesh1", model.NoMesh), store.CreatedAt(t1))
+		err := resourceStore.Create(context.Background(), core_mesh.NewMeshResource(), store.CreateByKey("mesh1", model.NoMesh), store.CreatedAt(t1))
 		Expect(err).ToNot(HaveOccurred())
 	})
 
 	createDpWithInsights := func(name string, dp *v1alpha1.Dataplane) {
-		dpResource := mesh_core.DataplaneResource{
+		dpResource := core_mesh.DataplaneResource{
 			Spec: dp,
 		}
 		err := resourceStore.Create(context.Background(), &dpResource, store.CreateByKey(name, "mesh1"), store.CreatedAt(t1))
 		Expect(err).ToNot(HaveOccurred())
 
 		sampleTime, _ := time.Parse(time.RFC3339, "2019-07-01T00:00:00+00:00")
-		insightResource := mesh_core.DataplaneInsightResource{
+		insightResource := core_mesh.DataplaneInsightResource{
 			Spec: &v1alpha1.DataplaneInsight{
 				Subscriptions: []*v1alpha1.DiscoverySubscription{
 					{

--- a/pkg/api-server/fault_injection_endpoints_test.go
+++ b/pkg/api-server/fault_injection_endpoints_test.go
@@ -13,7 +13,7 @@ import (
 	api_server "github.com/kumahq/kuma/pkg/api-server"
 	config "github.com/kumahq/kuma/pkg/config/api-server"
 	"github.com/kumahq/kuma/pkg/core"
-	mesh_core "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
+	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	"github.com/kumahq/kuma/pkg/core/resources/model"
 	"github.com/kumahq/kuma/pkg/core/resources/model/rest"
 	"github.com/kumahq/kuma/pkg/core/resources/store"
@@ -56,7 +56,7 @@ var _ = Describe("FaultInjection Endpoints", func() {
 
 	BeforeEach(func() {
 		// when
-		err := resourceStore.Create(context.Background(), mesh_core.NewMeshResource(), store.CreateByKey(model.DefaultMesh, model.NoMesh))
+		err := resourceStore.Create(context.Background(), core_mesh.NewMeshResource(), store.CreateByKey(model.DefaultMesh, model.NoMesh))
 		// then
 		Expect(err).ToNot(HaveOccurred())
 	})

--- a/pkg/api-server/global_secret_endpoints_test.go
+++ b/pkg/api-server/global_secret_endpoints_test.go
@@ -13,7 +13,7 @@ import (
 	api_server "github.com/kumahq/kuma/pkg/api-server"
 	config "github.com/kumahq/kuma/pkg/config/api-server"
 	"github.com/kumahq/kuma/pkg/core"
-	mesh_core "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
+	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	"github.com/kumahq/kuma/pkg/core/resources/model"
 	"github.com/kumahq/kuma/pkg/core/resources/model/rest"
 	"github.com/kumahq/kuma/pkg/core/resources/store"
@@ -56,7 +56,7 @@ var _ = Describe("GlobalSecret Endpoints", func() {
 
 	BeforeEach(func() {
 		// when
-		err := resourceStore.Create(context.Background(), mesh_core.NewMeshResource(), store.CreateByKey(model.DefaultMesh, model.NoMesh))
+		err := resourceStore.Create(context.Background(), core_mesh.NewMeshResource(), store.CreateByKey(model.DefaultMesh, model.NoMesh))
 		// then
 		Expect(err).ToNot(HaveOccurred())
 	})

--- a/pkg/api-server/health_check_endpoints_test.go
+++ b/pkg/api-server/health_check_endpoints_test.go
@@ -13,7 +13,7 @@ import (
 	api_server "github.com/kumahq/kuma/pkg/api-server"
 	config "github.com/kumahq/kuma/pkg/config/api-server"
 	"github.com/kumahq/kuma/pkg/core"
-	mesh_core "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
+	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	"github.com/kumahq/kuma/pkg/core/resources/model"
 	"github.com/kumahq/kuma/pkg/core/resources/model/rest"
 	"github.com/kumahq/kuma/pkg/core/resources/store"
@@ -56,7 +56,7 @@ var _ = Describe("HealthCheck Endpoints", func() {
 
 	BeforeEach(func() {
 		// when
-		err := resourceStore.Create(context.Background(), mesh_core.NewMeshResource(), store.CreateByKey(model.DefaultMesh, model.NoMesh))
+		err := resourceStore.Create(context.Background(), core_mesh.NewMeshResource(), store.CreateByKey(model.DefaultMesh, model.NoMesh))
 		// then
 		Expect(err).ToNot(HaveOccurred())
 	})

--- a/pkg/api-server/resource_endpoints_test.go
+++ b/pkg/api-server/resource_endpoints_test.go
@@ -12,7 +12,7 @@ import (
 
 	api_server "github.com/kumahq/kuma/pkg/api-server"
 	config "github.com/kumahq/kuma/pkg/config/api-server"
-	mesh_res "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
+	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	"github.com/kumahq/kuma/pkg/core/resources/model"
 	"github.com/kumahq/kuma/pkg/core/resources/model/rest"
 	"github.com/kumahq/kuma/pkg/core/resources/store"
@@ -58,7 +58,7 @@ var _ = Describe("Resource Endpoints", func() {
 
 	BeforeEach(func() {
 		// create default mesh
-		err := resourceStore.Create(context.Background(), mesh_res.NewMeshResource(), store.CreateByKey(mesh, model.NoMesh))
+		err := resourceStore.Create(context.Background(), core_mesh.NewMeshResource(), store.CreateByKey(mesh, model.NoMesh))
 		Expect(err).ToNot(HaveOccurred())
 	})
 
@@ -563,7 +563,7 @@ var _ = Describe("Resource Endpoints", func() {
 
 		It("should return 400 when mesh does not exist", func() {
 			// setup
-			err := resourceStore.Delete(context.Background(), mesh_res.NewMeshResource(), store.DeleteByKey(model.DefaultMesh, model.NoMesh))
+			err := resourceStore.Delete(context.Background(), core_mesh.NewMeshResource(), store.DeleteByKey(model.DefaultMesh, model.NoMesh))
 			Expect(err).ToNot(HaveOccurred())
 
 			// given

--- a/pkg/api-server/secret_endpoints_test.go
+++ b/pkg/api-server/secret_endpoints_test.go
@@ -13,7 +13,7 @@ import (
 	api_server "github.com/kumahq/kuma/pkg/api-server"
 	config "github.com/kumahq/kuma/pkg/config/api-server"
 	"github.com/kumahq/kuma/pkg/core"
-	mesh_core "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
+	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	"github.com/kumahq/kuma/pkg/core/resources/model"
 	"github.com/kumahq/kuma/pkg/core/resources/model/rest"
 	"github.com/kumahq/kuma/pkg/core/resources/store"
@@ -56,7 +56,7 @@ var _ = Describe("Secret Endpoints", func() {
 
 	BeforeEach(func() {
 		// when
-		err := resourceStore.Create(context.Background(), mesh_core.NewMeshResource(), store.CreateByKey(model.DefaultMesh, model.NoMesh))
+		err := resourceStore.Create(context.Background(), core_mesh.NewMeshResource(), store.CreateByKey(model.DefaultMesh, model.NoMesh))
 		// then
 		Expect(err).ToNot(HaveOccurred())
 	})

--- a/pkg/api-server/service_insight_endpoints_test.go
+++ b/pkg/api-server/service_insight_endpoints_test.go
@@ -14,7 +14,7 @@ import (
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	api_server "github.com/kumahq/kuma/pkg/api-server"
 	config "github.com/kumahq/kuma/pkg/config/api-server"
-	mesh_core "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
+	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	core_model "github.com/kumahq/kuma/pkg/core/resources/model"
 	"github.com/kumahq/kuma/pkg/core/resources/store"
 	"github.com/kumahq/kuma/pkg/metrics"
@@ -49,15 +49,15 @@ var _ = Describe("Service Insight Endpoints", func() {
 	})
 
 	BeforeEach(func() {
-		err := resourceStore.Create(context.Background(), mesh_core.NewMeshResource(), store.CreateByKey("mesh-1", core_model.NoMesh), store.CreatedAt(t1))
+		err := resourceStore.Create(context.Background(), core_mesh.NewMeshResource(), store.CreateByKey("mesh-1", core_model.NoMesh), store.CreatedAt(t1))
 		Expect(err).ToNot(HaveOccurred())
 
-		err = resourceStore.Create(context.Background(), mesh_core.NewMeshResource(), store.CreateByKey("mesh-2", core_model.NoMesh), store.CreatedAt(t1))
+		err = resourceStore.Create(context.Background(), core_mesh.NewMeshResource(), store.CreateByKey("mesh-2", core_model.NoMesh), store.CreatedAt(t1))
 		Expect(err).ToNot(HaveOccurred())
 	})
 
 	createServiceInsight := func(name, mesh string, serviceInsight *mesh_proto.ServiceInsight) {
-		serviceInsightResource := mesh_core.ServiceInsightResource{
+		serviceInsightResource := core_mesh.ServiceInsightResource{
 			Spec: serviceInsight,
 		}
 		err := resourceStore.Create(context.Background(), &serviceInsightResource, store.CreateByKey(name, mesh), store.CreatedAt(t1))

--- a/pkg/api-server/traffic_route_endpoints_test.go
+++ b/pkg/api-server/traffic_route_endpoints_test.go
@@ -13,7 +13,7 @@ import (
 	api_server "github.com/kumahq/kuma/pkg/api-server"
 	config "github.com/kumahq/kuma/pkg/config/api-server"
 	"github.com/kumahq/kuma/pkg/core"
-	mesh_core "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
+	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	"github.com/kumahq/kuma/pkg/core/resources/model"
 	"github.com/kumahq/kuma/pkg/core/resources/model/rest"
 	"github.com/kumahq/kuma/pkg/core/resources/store"
@@ -56,7 +56,7 @@ var _ = Describe("TrafficRoute Endpoints", func() {
 
 	BeforeEach(func() {
 		// when
-		err := resourceStore.Create(context.Background(), mesh_core.NewMeshResource(), store.CreateByKey(model.DefaultMesh, model.NoMesh))
+		err := resourceStore.Create(context.Background(), core_mesh.NewMeshResource(), store.CreateByKey(model.DefaultMesh, model.NoMesh))
 		// then
 		Expect(err).ToNot(HaveOccurred())
 	})

--- a/pkg/api-server/traffic_trace_endpoints_test.go
+++ b/pkg/api-server/traffic_trace_endpoints_test.go
@@ -13,7 +13,7 @@ import (
 	api_server "github.com/kumahq/kuma/pkg/api-server"
 	config "github.com/kumahq/kuma/pkg/config/api-server"
 	"github.com/kumahq/kuma/pkg/core"
-	mesh_core "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
+	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	"github.com/kumahq/kuma/pkg/core/resources/model"
 	"github.com/kumahq/kuma/pkg/core/resources/model/rest"
 	"github.com/kumahq/kuma/pkg/core/resources/store"
@@ -56,7 +56,7 @@ var _ = Describe("TrafficTrace Endpoints", func() {
 
 	BeforeEach(func() {
 		// when
-		err := resourceStore.Create(context.Background(), mesh_core.NewMeshResource(), store.CreateByKey(model.DefaultMesh, model.NoMesh))
+		err := resourceStore.Create(context.Background(), core_mesh.NewMeshResource(), store.CreateByKey(model.DefaultMesh, model.NoMesh))
 		// then
 		Expect(err).ToNot(HaveOccurred())
 	})

--- a/pkg/api-server/zone_overview_endpoints_test.go
+++ b/pkg/api-server/zone_overview_endpoints_test.go
@@ -13,7 +13,7 @@ import (
 	system_proto "github.com/kumahq/kuma/api/system/v1alpha1"
 	api_server "github.com/kumahq/kuma/pkg/api-server"
 	config "github.com/kumahq/kuma/pkg/config/api-server"
-	mesh_core "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
+	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	"github.com/kumahq/kuma/pkg/core/resources/apis/system"
 	core_model "github.com/kumahq/kuma/pkg/core/resources/model"
 	"github.com/kumahq/kuma/pkg/core/resources/store"
@@ -50,7 +50,7 @@ var _ = Describe("Zone Overview Endpoints", func() {
 	})
 
 	BeforeEach(func() {
-		err := resourceStore.Create(context.Background(), mesh_core.NewMeshResource(), store.CreateByKey(core_model.DefaultMesh, core_model.NoMesh), store.CreatedAt(t1))
+		err := resourceStore.Create(context.Background(), core_mesh.NewMeshResource(), store.CreateByKey(core_model.DefaultMesh, core_model.NoMesh), store.CreatedAt(t1))
 		Expect(err).ToNot(HaveOccurred())
 	})
 

--- a/pkg/core/faultinjections/matcher.go
+++ b/pkg/core/faultinjections/matcher.go
@@ -7,7 +7,7 @@ import (
 
 	manager_dataplane "github.com/kumahq/kuma/pkg/core/managers/apis/dataplane"
 	"github.com/kumahq/kuma/pkg/core/policy"
-	mesh_core "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
+	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	"github.com/kumahq/kuma/pkg/core/resources/manager"
 	"github.com/kumahq/kuma/pkg/core/resources/store"
 	core_xds "github.com/kumahq/kuma/pkg/core/xds"
@@ -17,15 +17,15 @@ type FaultInjectionMatcher struct {
 	ResourceManager manager.ReadOnlyResourceManager
 }
 
-func (f *FaultInjectionMatcher) Match(ctx context.Context, dataplane *mesh_core.DataplaneResource, mesh *mesh_core.MeshResource) (core_xds.FaultInjectionMap, error) {
-	faultInjections := &mesh_core.FaultInjectionResourceList{}
+func (f *FaultInjectionMatcher) Match(ctx context.Context, dataplane *core_mesh.DataplaneResource, mesh *core_mesh.MeshResource) (core_xds.FaultInjectionMap, error) {
+	faultInjections := &core_mesh.FaultInjectionResourceList{}
 	if err := f.ResourceManager.List(ctx, faultInjections, store.ListByMesh(dataplane.GetMeta().GetMesh())); err != nil {
 		return nil, errors.Wrap(err, "could not retrieve fault injections")
 	}
 	return BuildFaultInjectionMap(dataplane, mesh, faultInjections.Items)
 }
 
-func BuildFaultInjectionMap(dataplane *mesh_core.DataplaneResource, mesh *mesh_core.MeshResource, faultInjections []*mesh_core.FaultInjectionResource) (core_xds.FaultInjectionMap, error) {
+func BuildFaultInjectionMap(dataplane *core_mesh.DataplaneResource, mesh *core_mesh.MeshResource, faultInjections []*core_mesh.FaultInjectionResource) (core_xds.FaultInjectionMap, error) {
 	policies := make([]policy.ConnectionPolicy, len(faultInjections))
 	for i, faultInjection := range faultInjections {
 		policies[i] = faultInjection
@@ -40,7 +40,7 @@ func BuildFaultInjectionMap(dataplane *mesh_core.DataplaneResource, mesh *mesh_c
 
 	result := core_xds.FaultInjectionMap{}
 	for inbound, connectionPolicy := range policyMap {
-		result[inbound] = connectionPolicy.(*mesh_core.FaultInjectionResource).Spec
+		result[inbound] = connectionPolicy.(*core_mesh.FaultInjectionResource).Spec
 	}
 	return result, nil
 }

--- a/pkg/core/logs/matcher.go
+++ b/pkg/core/logs/matcher.go
@@ -8,7 +8,7 @@ import (
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	"github.com/kumahq/kuma/pkg/core"
 	"github.com/kumahq/kuma/pkg/core/policy"
-	mesh_core "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
+	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	"github.com/kumahq/kuma/pkg/core/resources/manager"
 	"github.com/kumahq/kuma/pkg/core/resources/model"
 	"github.com/kumahq/kuma/pkg/core/resources/store"
@@ -29,19 +29,19 @@ type TrafficLogsMatcher struct {
 	ResourceManager manager.ReadOnlyResourceManager
 }
 
-func (m *TrafficLogsMatcher) Match(ctx context.Context, dataplane *mesh_core.DataplaneResource) (core_xds.LogMap, error) {
-	logs := &mesh_core.TrafficLogResourceList{}
+func (m *TrafficLogsMatcher) Match(ctx context.Context, dataplane *core_mesh.DataplaneResource) (core_xds.LogMap, error) {
+	logs := &core_mesh.TrafficLogResourceList{}
 	if err := m.ResourceManager.List(ctx, logs, store.ListByMesh(dataplane.GetMeta().GetMesh())); err != nil {
 		return nil, errors.Wrap(err, "could not retrieve traffic logs")
 	}
-	mesh := mesh_core.NewMeshResource()
+	mesh := core_mesh.NewMeshResource()
 	if err := m.ResourceManager.Get(ctx, mesh, store.GetByKey(dataplane.GetMeta().GetMesh(), model.NoMesh)); err != nil {
 		return nil, err
 	}
 	return BuildTrafficLogMap(dataplane, mesh, logs.Items), nil
 }
 
-func BuildTrafficLogMap(dataplane *mesh_core.DataplaneResource, mesh *mesh_core.MeshResource, logs []*mesh_core.TrafficLogResource) core_xds.LogMap {
+func BuildTrafficLogMap(dataplane *core_mesh.DataplaneResource, mesh *core_mesh.MeshResource, logs []*core_mesh.TrafficLogResource) core_xds.LogMap {
 	backends := backendsByName(mesh)
 
 	policies := make([]policy.ConnectionPolicy, len(logs))
@@ -52,7 +52,7 @@ func BuildTrafficLogMap(dataplane *mesh_core.DataplaneResource, mesh *mesh_core.
 
 	logMap := core_xds.LogMap{}
 	for service, policy := range policyMap {
-		log := policy.(*mesh_core.TrafficLogResource)
+		log := policy.(*core_mesh.TrafficLogResource)
 		backend, found := backends[log.Spec.GetConf().GetBackend()]
 		if !found {
 			logger.Info("Logging backend is not found. Ignoring.", "backendName", log.Spec.GetConf().GetBackend(), "trafficLogName", log.GetMeta().GetName(), "trafficLogMesh", log.GetMeta().GetMesh())
@@ -63,7 +63,7 @@ func BuildTrafficLogMap(dataplane *mesh_core.DataplaneResource, mesh *mesh_core.
 	return logMap
 }
 
-func backendsByName(mesh *mesh_core.MeshResource) map[string]*mesh_proto.LoggingBackend {
+func backendsByName(mesh *core_mesh.MeshResource) map[string]*mesh_proto.LoggingBackend {
 	backendsByName := map[string]*mesh_proto.LoggingBackend{}
 	for _, backend := range mesh.Spec.GetLogging().GetBackends() {
 		backendsByName[backend.Name] = backend

--- a/pkg/core/managers/apis/dataplane/dataplane_manager_test.go
+++ b/pkg/core/managers/apis/dataplane/dataplane_manager_test.go
@@ -8,7 +8,7 @@ import (
 
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	"github.com/kumahq/kuma/pkg/core/managers/apis/dataplane"
-	mesh_core "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
+	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	"github.com/kumahq/kuma/pkg/core/resources/model"
 	"github.com/kumahq/kuma/pkg/core/resources/store"
 	"github.com/kumahq/kuma/pkg/plugins/resources/memory"
@@ -20,11 +20,11 @@ var _ = Describe("Dataplane Manager", func() {
 		// setup
 		s := memory.NewStore()
 		manager := dataplane.NewDataplaneManager(s, "zone-1")
-		err := s.Create(context.Background(), mesh_core.NewMeshResource(), store.CreateByKey(model.DefaultMesh, model.NoMesh))
+		err := s.Create(context.Background(), core_mesh.NewMeshResource(), store.CreateByKey(model.DefaultMesh, model.NoMesh))
 		Expect(err).ToNot(HaveOccurred())
 
 		// given
-		input := mesh_core.DataplaneResource{
+		input := core_mesh.DataplaneResource{
 			Spec: &mesh_proto.Dataplane{
 				Networking: &mesh_proto.Dataplane_Networking{
 					Address: "10.0.0.1",
@@ -45,7 +45,7 @@ var _ = Describe("Dataplane Manager", func() {
 		err = manager.Create(context.Background(), &input, store.CreateByKey("dp1", "default"))
 		Expect(err).ToNot(HaveOccurred())
 
-		actual := mesh_core.NewDataplaneResource()
+		actual := core_mesh.NewDataplaneResource()
 		err = s.Get(context.Background(), actual, store.GetByKey("dp1", "default"))
 		Expect(err).ToNot(HaveOccurred())
 
@@ -58,11 +58,11 @@ var _ = Describe("Dataplane Manager", func() {
 		// setup
 		s := memory.NewStore()
 		manager := dataplane.NewDataplaneManager(s, "zone-1")
-		err := s.Create(context.Background(), mesh_core.NewMeshResource(), store.CreateByKey(model.DefaultMesh, model.NoMesh))
+		err := s.Create(context.Background(), core_mesh.NewMeshResource(), store.CreateByKey(model.DefaultMesh, model.NoMesh))
 		Expect(err).ToNot(HaveOccurred())
 
 		// given
-		input := mesh_core.DataplaneResource{
+		input := core_mesh.DataplaneResource{
 			Spec: &mesh_proto.Dataplane{
 				Networking: &mesh_proto.Dataplane_Networking{
 					Address: "10.0.0.1",
@@ -82,7 +82,7 @@ var _ = Describe("Dataplane Manager", func() {
 		err = s.Create(context.Background(), &input, store.CreateByKey("dp1", "default"))
 		Expect(err).ToNot(HaveOccurred())
 
-		actual := mesh_core.NewDataplaneResource()
+		actual := core_mesh.NewDataplaneResource()
 		err = s.Get(context.Background(), actual, store.GetByKey("dp1", "default"))
 		Expect(err).ToNot(HaveOccurred())
 		Expect(len(actual.Spec.Networking.Inbound[0].Tags)).To(Equal(1))
@@ -95,7 +95,7 @@ var _ = Describe("Dataplane Manager", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		// then
-		actual = mesh_core.NewDataplaneResource()
+		actual = core_mesh.NewDataplaneResource()
 		err = s.Get(context.Background(), actual, store.GetByKey("dp1", "default"))
 		Expect(err).ToNot(HaveOccurred())
 		Expect(actual.Spec.Networking.Inbound).To(HaveLen(1))
@@ -106,11 +106,11 @@ var _ = Describe("Dataplane Manager", func() {
 		// setup
 		s := memory.NewStore()
 		manager := dataplane.NewDataplaneManager(s, "zone-1")
-		err := s.Create(context.Background(), mesh_core.NewMeshResource(), store.CreateByKey(model.DefaultMesh, model.NoMesh))
+		err := s.Create(context.Background(), core_mesh.NewMeshResource(), store.CreateByKey(model.DefaultMesh, model.NoMesh))
 		Expect(err).ToNot(HaveOccurred())
 
 		// given
-		input := mesh_core.DataplaneResource{
+		input := core_mesh.DataplaneResource{
 			Spec: &mesh_proto.Dataplane{
 				Networking: &mesh_proto.Dataplane_Networking{
 					Address: "10.0.0.1",
@@ -127,7 +127,7 @@ var _ = Describe("Dataplane Manager", func() {
 		err = manager.Create(context.Background(), &input, store.CreateByKey("dp1", "default"))
 		Expect(err).ToNot(HaveOccurred())
 
-		actual := mesh_core.NewDataplaneResource()
+		actual := core_mesh.NewDataplaneResource()
 		err = s.Get(context.Background(), actual, store.GetByKey("dp1", "default"))
 		Expect(err).ToNot(HaveOccurred())
 
@@ -140,11 +140,11 @@ var _ = Describe("Dataplane Manager", func() {
 		// setup
 		s := memory.NewStore()
 		manager := dataplane.NewDataplaneManager(s, "zone-1")
-		err := s.Create(context.Background(), mesh_core.NewMeshResource(), store.CreateByKey(model.DefaultMesh, model.NoMesh))
+		err := s.Create(context.Background(), core_mesh.NewMeshResource(), store.CreateByKey(model.DefaultMesh, model.NoMesh))
 		Expect(err).ToNot(HaveOccurred())
 
 		// given
-		input := mesh_core.DataplaneResource{
+		input := core_mesh.DataplaneResource{
 			Spec: &mesh_proto.Dataplane{
 				Networking: &mesh_proto.Dataplane_Networking{
 					Address: "10.0.0.1",
@@ -160,7 +160,7 @@ var _ = Describe("Dataplane Manager", func() {
 		err = s.Create(context.Background(), &input, store.CreateByKey("dp1", "default"))
 		Expect(err).ToNot(HaveOccurred())
 
-		actual := mesh_core.NewDataplaneResource()
+		actual := core_mesh.NewDataplaneResource()
 		err = s.Get(context.Background(), actual, store.GetByKey("dp1", "default"))
 		Expect(err).ToNot(HaveOccurred())
 		Expect(len(actual.Spec.Networking.Gateway.Tags)).To(Equal(1))
@@ -173,7 +173,7 @@ var _ = Describe("Dataplane Manager", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		// then
-		actual = mesh_core.NewDataplaneResource()
+		actual = core_mesh.NewDataplaneResource()
 		err = s.Get(context.Background(), actual, store.GetByKey("dp1", "default"))
 		Expect(err).ToNot(HaveOccurred())
 		// then
@@ -185,11 +185,11 @@ var _ = Describe("Dataplane Manager", func() {
 		// setup
 		s := memory.NewStore()
 		manager := dataplane.NewDataplaneManager(s, "zone-1")
-		err := s.Create(context.Background(), mesh_core.NewMeshResource(), store.CreateByKey(model.DefaultMesh, model.NoMesh))
+		err := s.Create(context.Background(), core_mesh.NewMeshResource(), store.CreateByKey(model.DefaultMesh, model.NoMesh))
 		Expect(err).ToNot(HaveOccurred())
 
 		// given
-		input := mesh_core.DataplaneResource{
+		input := core_mesh.DataplaneResource{
 			Spec: &mesh_proto.Dataplane{
 				Networking: &mesh_proto.Dataplane_Networking{
 					Address: "10.0.0.1",
@@ -212,7 +212,7 @@ var _ = Describe("Dataplane Manager", func() {
 		err = manager.Create(context.Background(), &input, store.CreateByKey("dp1", "default"))
 		Expect(err).ToNot(HaveOccurred())
 
-		actual := mesh_core.NewDataplaneResource()
+		actual := core_mesh.NewDataplaneResource()
 		err = s.Get(context.Background(), actual, store.GetByKey("dp1", "default"))
 		Expect(err).ToNot(HaveOccurred())
 		Expect(actual.Spec.Networking.Inbound[0].Health).ToNot(BeNil())

--- a/pkg/core/managers/apis/dataplaneinsight/dataplane_insight_manager_test.go
+++ b/pkg/core/managers/apis/dataplaneinsight/dataplane_insight_manager_test.go
@@ -10,7 +10,7 @@ import (
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	kuma_cp "github.com/kumahq/kuma/pkg/config/app/kuma-cp"
 	"github.com/kumahq/kuma/pkg/core/managers/apis/dataplaneinsight"
-	mesh_core "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
+	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	"github.com/kumahq/kuma/pkg/core/resources/store"
 	"github.com/kumahq/kuma/pkg/plugins/resources/memory"
 )
@@ -26,10 +26,10 @@ var _ = Describe("DataplaneInsight Manager", func() {
 		}
 		manager := dataplaneinsight.NewDataplaneInsightManager(s, cfg)
 
-		err := s.Create(context.Background(), mesh_core.NewDataplaneResource(), store.CreateByKey("di1", "default"))
+		err := s.Create(context.Background(), core_mesh.NewDataplaneResource(), store.CreateByKey("di1", "default"))
 		Expect(err).ToNot(HaveOccurred())
 
-		input := mesh_core.NewDataplaneInsightResource()
+		input := core_mesh.NewDataplaneInsightResource()
 		for i := 0; i < 10; i++ {
 			input.Spec.Subscriptions = append(input.Spec.Subscriptions, &mesh_proto.DiscoverySubscription{
 				Id: fmt.Sprintf("%d", i),
@@ -40,7 +40,7 @@ var _ = Describe("DataplaneInsight Manager", func() {
 		err = manager.Create(context.Background(), input, store.CreateByKey("di1", "default"))
 		Expect(err).ToNot(HaveOccurred())
 
-		actual := mesh_core.NewDataplaneInsightResource()
+		actual := core_mesh.NewDataplaneInsightResource()
 		err = s.Get(context.Background(), actual, store.GetByKey("di1", "default"))
 		Expect(err).ToNot(HaveOccurred())
 
@@ -59,10 +59,10 @@ var _ = Describe("DataplaneInsight Manager", func() {
 		}
 		manager := dataplaneinsight.NewDataplaneInsightManager(s, cfg)
 
-		err := s.Create(context.Background(), mesh_core.NewDataplaneResource(), store.CreateByKey("di1", "default"))
+		err := s.Create(context.Background(), core_mesh.NewDataplaneResource(), store.CreateByKey("di1", "default"))
 		Expect(err).ToNot(HaveOccurred())
 
-		input := mesh_core.NewDataplaneInsightResource()
+		input := core_mesh.NewDataplaneInsightResource()
 		for i := 0; i < 10; i++ {
 			input.Spec.Subscriptions = append(input.Spec.Subscriptions, &mesh_proto.DiscoverySubscription{
 				Id: fmt.Sprintf("%d", i),
@@ -73,7 +73,7 @@ var _ = Describe("DataplaneInsight Manager", func() {
 		err = manager.Create(context.Background(), input, store.CreateByKey("di1", "default"))
 		Expect(err).ToNot(HaveOccurred())
 
-		actual := mesh_core.NewDataplaneInsightResource()
+		actual := core_mesh.NewDataplaneInsightResource()
 		err = s.Get(context.Background(), actual, store.GetByKey("di1", "default"))
 		Expect(err).ToNot(HaveOccurred())
 

--- a/pkg/core/managers/apis/mesh/mesh_helpers.go
+++ b/pkg/core/managers/apis/mesh/mesh_helpers.go
@@ -6,10 +6,10 @@ import (
 	"github.com/pkg/errors"
 
 	core_ca "github.com/kumahq/kuma/pkg/core/ca"
-	mesh_core "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
+	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 )
 
-func EnsureEnabledCA(ctx context.Context, caManagers core_ca.Managers, mesh *mesh_core.MeshResource, meshName string) error {
+func EnsureEnabledCA(ctx context.Context, caManagers core_ca.Managers, mesh *core_mesh.MeshResource, meshName string) error {
 	if mesh.GetEnabledCertificateAuthorityBackend() != nil {
 		backend := mesh.GetEnabledCertificateAuthorityBackend()
 		caManager, exist := caManagers[backend.Type]

--- a/pkg/core/permissions/matcher.go
+++ b/pkg/core/permissions/matcher.go
@@ -7,7 +7,7 @@ import (
 
 	manager_dataplane "github.com/kumahq/kuma/pkg/core/managers/apis/dataplane"
 	"github.com/kumahq/kuma/pkg/core/policy"
-	mesh_core "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
+	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	"github.com/kumahq/kuma/pkg/core/resources/manager"
 	"github.com/kumahq/kuma/pkg/core/resources/store"
 	core_xds "github.com/kumahq/kuma/pkg/core/xds"
@@ -17,8 +17,8 @@ type TrafficPermissionsMatcher struct {
 	ResourceManager manager.ReadOnlyResourceManager
 }
 
-func (m *TrafficPermissionsMatcher) Match(ctx context.Context, dataplane *mesh_core.DataplaneResource, mesh *mesh_core.MeshResource) (core_xds.TrafficPermissionMap, error) {
-	permissions := &mesh_core.TrafficPermissionResourceList{}
+func (m *TrafficPermissionsMatcher) Match(ctx context.Context, dataplane *core_mesh.DataplaneResource, mesh *core_mesh.MeshResource) (core_xds.TrafficPermissionMap, error) {
+	permissions := &core_mesh.TrafficPermissionResourceList{}
 	if err := m.ResourceManager.List(ctx, permissions, store.ListByMesh(dataplane.GetMeta().GetMesh())); err != nil {
 		return nil, errors.Wrap(err, "could not retrieve traffic permissions")
 	}
@@ -27,9 +27,9 @@ func (m *TrafficPermissionsMatcher) Match(ctx context.Context, dataplane *mesh_c
 }
 
 func BuildTrafficPermissionMap(
-	dataplane *mesh_core.DataplaneResource,
-	mesh *mesh_core.MeshResource,
-	trafficPermissions []*mesh_core.TrafficPermissionResource,
+	dataplane *core_mesh.DataplaneResource,
+	mesh *core_mesh.MeshResource,
+	trafficPermissions []*core_mesh.TrafficPermissionResource,
 ) (core_xds.TrafficPermissionMap, error) {
 	policies := make([]policy.ConnectionPolicy, len(trafficPermissions))
 	for i, permission := range trafficPermissions {
@@ -45,18 +45,18 @@ func BuildTrafficPermissionMap(
 
 	result := core_xds.TrafficPermissionMap{}
 	for inbound, connectionPolicy := range policyMap {
-		result[inbound] = connectionPolicy.(*mesh_core.TrafficPermissionResource)
+		result[inbound] = connectionPolicy.(*core_mesh.TrafficPermissionResource)
 	}
 	return result, nil
 }
 
-func (m *TrafficPermissionsMatcher) MatchExternalServices(ctx context.Context, dataplane *mesh_core.DataplaneResource, externalServices *mesh_core.ExternalServiceResourceList) ([]*mesh_core.ExternalServiceResource, error) {
-	permissions := &mesh_core.TrafficPermissionResourceList{}
+func (m *TrafficPermissionsMatcher) MatchExternalServices(ctx context.Context, dataplane *core_mesh.DataplaneResource, externalServices *core_mesh.ExternalServiceResourceList) ([]*core_mesh.ExternalServiceResource, error) {
+	permissions := &core_mesh.TrafficPermissionResourceList{}
 	if err := m.ResourceManager.List(ctx, permissions, store.ListByMesh(dataplane.GetMeta().GetMesh())); err != nil {
 		return nil, errors.Wrap(err, "could not retrieve traffic permissions")
 	}
 
-	var matchedExternalServices []*mesh_core.ExternalServiceResource
+	var matchedExternalServices []*core_mesh.ExternalServiceResource
 
 	externalServicePermissions := m.BuildExternalServicesPermissionsMap(externalServices, permissions.Items)
 	for _, externalService := range externalServices.Items {
@@ -77,9 +77,9 @@ func (m *TrafficPermissionsMatcher) MatchExternalServices(ctx context.Context, d
 	return matchedExternalServices, nil
 }
 
-type ExternalServicePermissions map[string]*mesh_core.TrafficPermissionResource
+type ExternalServicePermissions map[string]*core_mesh.TrafficPermissionResource
 
-func (m *TrafficPermissionsMatcher) BuildExternalServicesPermissionsMap(externalServices *mesh_core.ExternalServiceResourceList, trafficPermissions []*mesh_core.TrafficPermissionResource) ExternalServicePermissions {
+func (m *TrafficPermissionsMatcher) BuildExternalServicesPermissionsMap(externalServices *core_mesh.ExternalServiceResourceList, trafficPermissions []*core_mesh.TrafficPermissionResource) ExternalServicePermissions {
 	policies := make([]policy.ConnectionPolicy, len(trafficPermissions))
 	for i, permission := range trafficPermissions {
 		policies[i] = permission
@@ -89,7 +89,7 @@ func (m *TrafficPermissionsMatcher) BuildExternalServicesPermissionsMap(external
 	for _, externalService := range externalServices.Items {
 		matchedPolicy := policy.SelectInboundConnectionPolicy(externalService.Spec.Tags, policies)
 		if matchedPolicy != nil {
-			result[externalService.GetMeta().GetName()] = matchedPolicy.(*mesh_core.TrafficPermissionResource)
+			result[externalService.GetMeta().GetName()] = matchedPolicy.(*core_mesh.TrafficPermissionResource)
 		}
 	}
 	return result

--- a/pkg/core/policy/dataplane_matcher_test.go
+++ b/pkg/core/policy/dataplane_matcher_test.go
@@ -10,7 +10,7 @@ import (
 
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	"github.com/kumahq/kuma/pkg/core/policy"
-	mesh_core "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
+	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	model "github.com/kumahq/kuma/pkg/core/xds"
 	test_model "github.com/kumahq/kuma/pkg/test/resources/model"
 )
@@ -33,13 +33,13 @@ var _ = Describe("Dataplane matcher", func() {
 			},
 			Entry("DataplanePolicy in the same mesh", testCase{
 				input: []policy.DataplanePolicy{
-					&mesh_core.ProxyTemplateResource{
+					&core_mesh.ProxyTemplateResource{
 						Meta: &test_model.ResourceMeta{
 							Mesh: "demo",
 							Name: "last",
 						},
 					},
-					&mesh_core.ProxyTemplateResource{
+					&core_mesh.ProxyTemplateResource{
 						Meta: &test_model.ResourceMeta{
 							Mesh: "demo",
 							Name: "first",
@@ -47,13 +47,13 @@ var _ = Describe("Dataplane matcher", func() {
 					},
 				},
 				expected: []policy.DataplanePolicy{
-					&mesh_core.ProxyTemplateResource{
+					&core_mesh.ProxyTemplateResource{
 						Meta: &test_model.ResourceMeta{
 							Mesh: "demo",
 							Name: "first",
 						},
 					},
-					&mesh_core.ProxyTemplateResource{
+					&core_mesh.ProxyTemplateResource{
 						Meta: &test_model.ResourceMeta{
 							Mesh: "demo",
 							Name: "last",
@@ -84,14 +84,14 @@ var _ = Describe("Dataplane matcher", func() {
 				}
 			},
 			Entry("there are no policies", testCase{
-				proxy:    &model.Proxy{Dataplane: mesh_core.NewDataplaneResource()},
+				proxy:    &model.Proxy{Dataplane: core_mesh.NewDataplaneResource()},
 				policies: nil,
 				expected: nil,
 			}),
 			Entry("policies have no selectors (latest should be selected)", testCase{
-				proxy: &model.Proxy{Dataplane: mesh_core.NewDataplaneResource()},
+				proxy: &model.Proxy{Dataplane: core_mesh.NewDataplaneResource()},
 				policies: []policy.DataplanePolicy{
-					&mesh_core.ProxyTemplateResource{
+					&core_mesh.ProxyTemplateResource{
 						Meta: &test_model.ResourceMeta{
 							Mesh:         "demo",
 							Name:         "b",
@@ -99,7 +99,7 @@ var _ = Describe("Dataplane matcher", func() {
 						},
 						Spec: &mesh_proto.ProxyTemplate{},
 					},
-					&mesh_core.ProxyTemplateResource{
+					&core_mesh.ProxyTemplateResource{
 						Meta: &test_model.ResourceMeta{
 							Mesh:         "demo",
 							Name:         "a",
@@ -108,7 +108,7 @@ var _ = Describe("Dataplane matcher", func() {
 						Spec: &mesh_proto.ProxyTemplate{},
 					},
 				},
-				expected: &mesh_core.ProxyTemplateResource{
+				expected: &core_mesh.ProxyTemplateResource{
 					Meta: &test_model.ResourceMeta{
 						Mesh:         "demo",
 						Name:         "b",
@@ -118,9 +118,9 @@ var _ = Describe("Dataplane matcher", func() {
 				},
 			}),
 			Entry("policies have empty selectors (latest should be selected)", testCase{
-				proxy: &model.Proxy{Dataplane: mesh_core.NewDataplaneResource()},
+				proxy: &model.Proxy{Dataplane: core_mesh.NewDataplaneResource()},
 				policies: []policy.DataplanePolicy{
-					&mesh_core.ProxyTemplateResource{
+					&core_mesh.ProxyTemplateResource{
 						Meta: &test_model.ResourceMeta{
 							Mesh:         "demo",
 							Name:         "b",
@@ -132,7 +132,7 @@ var _ = Describe("Dataplane matcher", func() {
 							},
 						},
 					},
-					&mesh_core.ProxyTemplateResource{
+					&core_mesh.ProxyTemplateResource{
 						Meta: &test_model.ResourceMeta{
 							Mesh:         "demo",
 							Name:         "a",
@@ -145,7 +145,7 @@ var _ = Describe("Dataplane matcher", func() {
 						},
 					},
 				},
-				expected: &mesh_core.ProxyTemplateResource{
+				expected: &core_mesh.ProxyTemplateResource{
 					Meta: &test_model.ResourceMeta{
 						Mesh:         "demo",
 						Name:         "b",
@@ -159,7 +159,7 @@ var _ = Describe("Dataplane matcher", func() {
 				},
 			}),
 			Entry("policies have non-empty selectors (the one with the highest number of matching key-value pairs should become the best match)", testCase{
-				proxy: &model.Proxy{Dataplane: &mesh_core.DataplaneResource{
+				proxy: &model.Proxy{Dataplane: &core_mesh.DataplaneResource{
 					Spec: &mesh_proto.Dataplane{
 						Networking: &mesh_proto.Dataplane_Networking{
 							Inbound: []*mesh_proto.Dataplane_Networking_Inbound{
@@ -180,7 +180,7 @@ var _ = Describe("Dataplane matcher", func() {
 					},
 				}},
 				policies: []policy.DataplanePolicy{
-					&mesh_core.ProxyTemplateResource{
+					&core_mesh.ProxyTemplateResource{
 						Meta: &test_model.ResourceMeta{
 							Mesh: "demo",
 							Name: "last",
@@ -196,7 +196,7 @@ var _ = Describe("Dataplane matcher", func() {
 							},
 						},
 					},
-					&mesh_core.ProxyTemplateResource{
+					&core_mesh.ProxyTemplateResource{
 						Meta: &test_model.ResourceMeta{
 							Mesh: "demo",
 							Name: "first",
@@ -219,7 +219,7 @@ var _ = Describe("Dataplane matcher", func() {
 						},
 					},
 				},
-				expected: &mesh_core.ProxyTemplateResource{
+				expected: &core_mesh.ProxyTemplateResource{
 					Meta: &test_model.ResourceMeta{
 						Mesh: "demo",
 						Name: "first",
@@ -243,7 +243,7 @@ var _ = Describe("Dataplane matcher", func() {
 				},
 			}),
 			Entry("two policies with the same rank (latest should be picked)", testCase{
-				proxy: &model.Proxy{Dataplane: &mesh_core.DataplaneResource{
+				proxy: &model.Proxy{Dataplane: &core_mesh.DataplaneResource{
 					Spec: &mesh_proto.Dataplane{
 						Networking: &mesh_proto.Dataplane_Networking{
 							Inbound: []*mesh_proto.Dataplane_Networking_Inbound{
@@ -259,7 +259,7 @@ var _ = Describe("Dataplane matcher", func() {
 					},
 				}},
 				policies: []policy.DataplanePolicy{
-					&mesh_core.ProxyTemplateResource{
+					&core_mesh.ProxyTemplateResource{
 						Meta: &test_model.ResourceMeta{
 							Mesh:         "demo",
 							Name:         "b",
@@ -275,7 +275,7 @@ var _ = Describe("Dataplane matcher", func() {
 							},
 						},
 					},
-					&mesh_core.ProxyTemplateResource{
+					&core_mesh.ProxyTemplateResource{
 						Meta: &test_model.ResourceMeta{
 							Mesh:         "demo",
 							Name:         "a",
@@ -292,7 +292,7 @@ var _ = Describe("Dataplane matcher", func() {
 						},
 					},
 				},
-				expected: &mesh_core.ProxyTemplateResource{
+				expected: &core_mesh.ProxyTemplateResource{
 					Meta: &test_model.ResourceMeta{
 						Mesh:         "demo",
 						Name:         "b",
@@ -310,7 +310,7 @@ var _ = Describe("Dataplane matcher", func() {
 				},
 			}),
 			Entry("gateway dataplane matches policies", testCase{
-				proxy: &model.Proxy{Dataplane: &mesh_core.DataplaneResource{
+				proxy: &model.Proxy{Dataplane: &core_mesh.DataplaneResource{
 					Spec: &mesh_proto.Dataplane{
 						Networking: &mesh_proto.Dataplane_Networking{
 							Gateway: &mesh_proto.Dataplane_Networking_Gateway{
@@ -324,7 +324,7 @@ var _ = Describe("Dataplane matcher", func() {
 					},
 				}},
 				policies: []policy.DataplanePolicy{
-					&mesh_core.ProxyTemplateResource{
+					&core_mesh.ProxyTemplateResource{
 						Meta: &test_model.ResourceMeta{
 							Mesh:         "demo",
 							Name:         "first",
@@ -341,7 +341,7 @@ var _ = Describe("Dataplane matcher", func() {
 						},
 					},
 				},
-				expected: &mesh_core.ProxyTemplateResource{
+				expected: &core_mesh.ProxyTemplateResource{
 					Meta: &test_model.ResourceMeta{
 						Mesh:         "demo",
 						Name:         "first",
@@ -359,9 +359,9 @@ var _ = Describe("Dataplane matcher", func() {
 				},
 			}),
 			Entry("none of policies have matching selectors", testCase{
-				proxy: &model.Proxy{Dataplane: mesh_core.NewDataplaneResource()},
+				proxy: &model.Proxy{Dataplane: core_mesh.NewDataplaneResource()},
 				policies: []policy.DataplanePolicy{
-					&mesh_core.ProxyTemplateResource{
+					&core_mesh.ProxyTemplateResource{
 						Meta: &test_model.ResourceMeta{
 							Mesh: "demo",
 							Name: "last",

--- a/pkg/core/ratelimits/matcher.go
+++ b/pkg/core/ratelimits/matcher.go
@@ -9,7 +9,7 @@ import (
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	manager_dataplane "github.com/kumahq/kuma/pkg/core/managers/apis/dataplane"
 	"github.com/kumahq/kuma/pkg/core/policy"
-	mesh_core "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
+	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	"github.com/kumahq/kuma/pkg/core/resources/manager"
 	"github.com/kumahq/kuma/pkg/core/resources/store"
 	core_xds "github.com/kumahq/kuma/pkg/core/xds"
@@ -19,8 +19,8 @@ type RateLimitMatcher struct {
 	ResourceManager manager.ReadOnlyResourceManager
 }
 
-func (m *RateLimitMatcher) Match(ctx context.Context, dataplane *mesh_core.DataplaneResource, mesh *mesh_core.MeshResource) (core_xds.RateLimitsMap, error) {
-	ratelimits := &mesh_core.RateLimitResourceList{}
+func (m *RateLimitMatcher) Match(ctx context.Context, dataplane *core_mesh.DataplaneResource, mesh *core_mesh.MeshResource) (core_xds.RateLimitsMap, error) {
+	ratelimits := &core_mesh.RateLimitResourceList{}
 	if err := m.ResourceManager.List(ctx, ratelimits, store.ListByMesh(dataplane.GetMeta().GetMesh())); err != nil {
 		return nil, errors.Wrap(err, "could not retrieve ratelimits")
 	}
@@ -29,9 +29,9 @@ func (m *RateLimitMatcher) Match(ctx context.Context, dataplane *mesh_core.Datap
 }
 
 func buildRateLimitMap(
-	dataplane *mesh_core.DataplaneResource,
-	mesh *mesh_core.MeshResource,
-	rateLimits []*mesh_core.RateLimitResource,
+	dataplane *core_mesh.DataplaneResource,
+	mesh *core_mesh.MeshResource,
+	rateLimits []*core_mesh.RateLimitResource,
 ) (core_xds.RateLimitsMap, error) {
 	policies := make([]policy.ConnectionPolicy, len(rateLimits))
 	for i, ratelimit := range rateLimits {
@@ -49,7 +49,7 @@ func buildRateLimitMap(
 	for inbound, connectionPolicies := range policyMap {
 		result[inbound] = []*mesh_proto.RateLimit{}
 		for _, policy := range connectionPolicies {
-			result[inbound] = append(result[inbound], policy.(*mesh_core.RateLimitResource).Spec)
+			result[inbound] = append(result[inbound], policy.(*core_mesh.RateLimitResource).Spec)
 		}
 	}
 	return result, nil
@@ -73,12 +73,12 @@ func buildRateLimitMap(
 //    - match:
 //        kuma.io/service: 'web-api'
 //        version: '1'
-func splitPoliciesBySourceMatch(rateLimits []*mesh_core.RateLimitResource) []*mesh_core.RateLimitResource {
-	result := []*mesh_core.RateLimitResource{}
+func splitPoliciesBySourceMatch(rateLimits []*core_mesh.RateLimitResource) []*core_mesh.RateLimitResource {
+	result := []*core_mesh.RateLimitResource{}
 
 	for _, rateLimit := range rateLimits {
 		for i := range rateLimit.Sources() {
-			newRateLimit := &mesh_core.RateLimitResource{
+			newRateLimit := &core_mesh.RateLimitResource{
 				Meta: rateLimit.GetMeta(),
 				Spec: proto.Clone(rateLimit.Spec).(*mesh_proto.RateLimit),
 			}

--- a/pkg/core/secrets/manager/validator.go
+++ b/pkg/core/secrets/manager/validator.go
@@ -9,7 +9,7 @@ import (
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	"github.com/kumahq/kuma/pkg/core"
 	"github.com/kumahq/kuma/pkg/core/ca"
-	mesh_core "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
+	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	"github.com/kumahq/kuma/pkg/core/resources/model"
 	core_store "github.com/kumahq/kuma/pkg/core/resources/store"
 	"github.com/kumahq/kuma/pkg/core/validators"
@@ -40,7 +40,7 @@ type secretValidator struct {
 }
 
 func (s *secretValidator) ValidateDelete(ctx context.Context, name string, mesh string) error {
-	meshRes := mesh_core.NewMeshResource()
+	meshRes := core_mesh.NewMeshResource()
 	err := s.store.Get(ctx, meshRes, core_store.GetByKey(mesh, model.NoMesh))
 	if err != nil {
 		if core_store.IsResourceNotFound(err) {

--- a/pkg/core/secrets/manager/validator_test.go
+++ b/pkg/core/secrets/manager/validator_test.go
@@ -13,7 +13,7 @@ import (
 	core_ca "github.com/kumahq/kuma/pkg/core/ca"
 	core_datasource "github.com/kumahq/kuma/pkg/core/datasource"
 	core_managers "github.com/kumahq/kuma/pkg/core/managers/apis/mesh"
-	mesh_core "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
+	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	core_manager "github.com/kumahq/kuma/pkg/core/resources/manager"
 	"github.com/kumahq/kuma/pkg/core/resources/model"
 	core_store "github.com/kumahq/kuma/pkg/core/resources/store"
@@ -43,7 +43,7 @@ var _ = Describe("Secret Validator", func() {
 		caManagers["builtin"] = ca_builtin.NewBuiltinCaManager(secManager)
 		caManagers["provided"] = ca_provided.NewProvidedCaManager(core_datasource.NewDataSourceLoader(secManager))
 
-		mesh := &mesh_core.MeshResource{
+		mesh := &core_mesh.MeshResource{
 			Spec: &mesh_proto.Mesh{
 				Mtls: &mesh_proto.Mesh_Mtls{
 					EnabledBackend: "ca-1",

--- a/pkg/core/xds/types.go
+++ b/pkg/core/xds/types.go
@@ -9,7 +9,7 @@ import (
 	"github.com/pkg/errors"
 
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
-	mesh_core "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
+	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	core_model "github.com/kumahq/kuma/pkg/core/resources/model"
 	envoy_common "github.com/kumahq/kuma/pkg/xds/envoy"
 )
@@ -37,10 +37,10 @@ func (id *ProxyId) ToResourceKey() core_model.ResourceKey {
 type ServiceName = string
 
 // RouteMap holds the most specific TrafficRoute for each outbound interface of a Dataplane.
-type RouteMap map[mesh_proto.OutboundInterface]*mesh_core.TrafficRouteResource
+type RouteMap map[mesh_proto.OutboundInterface]*core_mesh.TrafficRouteResource
 
 // TimeoutMap holds the most specific TimeoutResource for each OutboundInterface
-type TimeoutMap map[mesh_proto.OutboundInterface]*mesh_core.TimeoutResource
+type TimeoutMap map[mesh_proto.OutboundInterface]*core_mesh.TimeoutResource
 
 // TagSelectorSet is a set of unique TagSelectors.
 type TagSelectorSet []mesh_proto.TagSelector
@@ -85,19 +85,19 @@ type EndpointMap map[ServiceName][]Endpoint
 type LogMap map[ServiceName]*mesh_proto.LoggingBackend
 
 // HealthCheckMap holds the most specific HealthCheck for each reachable service.
-type HealthCheckMap map[ServiceName]*mesh_core.HealthCheckResource
+type HealthCheckMap map[ServiceName]*core_mesh.HealthCheckResource
 
 // CircuitBreakerMap holds the most specific CircuitBreaker for each reachable service.
-type CircuitBreakerMap map[ServiceName]*mesh_core.CircuitBreakerResource
+type CircuitBreakerMap map[ServiceName]*core_mesh.CircuitBreakerResource
 
 // RetryMap holds the most specific Retry for each reachable service.
-type RetryMap map[ServiceName]*mesh_core.RetryResource
+type RetryMap map[ServiceName]*core_mesh.RetryResource
 
 // FaultInjectionMap holds the most specific FaultInjectionResource for each InboundInterface
 type FaultInjectionMap map[mesh_proto.InboundInterface]*mesh_proto.FaultInjection
 
 // TrafficPermissionMap holds the most specific TrafficPermissionResource for each InboundInterface
-type TrafficPermissionMap map[mesh_proto.InboundInterface]*mesh_core.TrafficPermissionResource
+type TrafficPermissionMap map[mesh_proto.InboundInterface]*core_mesh.TrafficPermissionResource
 
 // RateLimitsMap holds all RateLimitResources for each InboundInterface
 type RateLimitsMap map[mesh_proto.InboundInterface][]*mesh_proto.RateLimit
@@ -117,8 +117,8 @@ const (
 type Proxy struct {
 	Id          ProxyId
 	APIVersion  envoy_common.APIVersion // todo(jakubdyszkiewicz) consider moving APIVersion here. pkg/core should not depend on pkg/xds. It should be other way around.
-	Dataplane   *mesh_core.DataplaneResource
-	ZoneIngress *mesh_core.ZoneIngressResource
+	Dataplane   *core_mesh.DataplaneResource
+	ZoneIngress *core_mesh.ZoneIngressResource
 	Metadata    *DataplaneMetadata
 	Routing     Routing
 	Policies    MatchedPolicies
@@ -136,7 +136,7 @@ type Routing struct {
 
 	// todo(lobkovilya): split Proxy struct into DataplaneProxy and IngressProxy
 	// TrafficRouteList is used only for generating configs for Ingress.
-	TrafficRouteList *mesh_core.TrafficRouteResourceList
+	TrafficRouteList *core_mesh.TrafficRouteResourceList
 }
 
 type MatchedPolicies struct {
@@ -145,7 +145,7 @@ type MatchedPolicies struct {
 	HealthChecks       HealthCheckMap
 	CircuitBreakers    CircuitBreakerMap
 	Retries            RetryMap
-	TrafficTrace       *mesh_core.TrafficTraceResource
+	TrafficTrace       *core_mesh.TrafficTraceResource
 	TracingBackend     *mesh_proto.TracingBackend
 	FaultInjections    FaultInjectionMap
 	Timeouts           TimeoutMap

--- a/pkg/defaults/components_test.go
+++ b/pkg/defaults/components_test.go
@@ -11,7 +11,7 @@ import (
 	system_proto "github.com/kumahq/kuma/api/system/v1alpha1"
 	kuma_cp "github.com/kumahq/kuma/pkg/config/app/kuma-cp"
 	"github.com/kumahq/kuma/pkg/config/core"
-	mesh_core "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
+	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	"github.com/kumahq/kuma/pkg/core/resources/apis/system"
 	core_manager "github.com/kumahq/kuma/pkg/core/resources/manager"
 	core_model "github.com/kumahq/kuma/pkg/core/resources/model"
@@ -45,13 +45,13 @@ var _ = Describe("Defaults Component", func() {
 
 			// then
 			Expect(err).ToNot(HaveOccurred())
-			err = manager.Get(context.Background(), mesh_core.NewMeshResource(), core_store.GetByKey(core_model.DefaultMesh, core_model.NoMesh))
+			err = manager.Get(context.Background(), core_mesh.NewMeshResource(), core_store.GetByKey(core_model.DefaultMesh, core_model.NoMesh))
 			Expect(err).ToNot(HaveOccurred())
 		})
 
 		It("should not override already created mesh", func() {
 			// given
-			mesh := &mesh_core.MeshResource{
+			mesh := &core_mesh.MeshResource{
 				Spec: &v1alpha1.Mesh{
 					Mtls: &v1alpha1.Mesh_Mtls{
 						EnabledBackend: "builtin",
@@ -71,7 +71,7 @@ var _ = Describe("Defaults Component", func() {
 			err = component.Start(nil)
 
 			// then
-			mesh = mesh_core.NewMeshResource()
+			mesh = core_mesh.NewMeshResource()
 			Expect(err).ToNot(HaveOccurred())
 			err = manager.Get(context.Background(), mesh, core_store.GetByKey(core_model.DefaultMesh, core_model.NoMesh))
 			Expect(err).ToNot(HaveOccurred())
@@ -99,7 +99,7 @@ var _ = Describe("Defaults Component", func() {
 
 			// then
 			Expect(err).ToNot(HaveOccurred())
-			err = manager.Get(context.Background(), mesh_core.NewMeshResource(), core_store.GetByKey("default", "default"))
+			err = manager.Get(context.Background(), core_mesh.NewMeshResource(), core_store.GetByKey("default", "default"))
 			Expect(core_store.IsResourceNotFound(err)).To(BeTrue())
 		})
 	})
@@ -127,7 +127,7 @@ var _ = Describe("Defaults Component", func() {
 			Expect(err).ToNot(HaveOccurred())
 			err = manager.Get(context.Background(), system.NewGlobalSecretResource(), core_store.GetByKey("zone-ingress-token-signing-key", core_model.NoMesh))
 			Expect(err).ToNot(HaveOccurred())
-			err = manager.Get(context.Background(), mesh_core.NewMeshResource(), core_store.GetByKey(core_model.DefaultMesh, core_model.NoMesh))
+			err = manager.Get(context.Background(), core_mesh.NewMeshResource(), core_store.GetByKey(core_model.DefaultMesh, core_model.NoMesh))
 			Expect(err).ToNot(HaveOccurred())
 		})
 

--- a/pkg/defaults/mesh.go
+++ b/pkg/defaults/mesh.go
@@ -3,7 +3,7 @@ package defaults
 import (
 	"context"
 
-	mesh_core "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
+	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	core_model "github.com/kumahq/kuma/pkg/core/resources/model"
 	core_store "github.com/kumahq/kuma/pkg/core/resources/store"
 )
@@ -13,7 +13,7 @@ var defaultMeshKey = core_model.ResourceKey{
 }
 
 func (d *defaultsComponent) createMeshIfNotExist(ctx context.Context) error {
-	mesh := mesh_core.NewMeshResource()
+	mesh := core_mesh.NewMeshResource()
 	err := d.resManager.Get(ctx, mesh, core_store.GetBy(defaultMeshKey))
 	if err == nil {
 		log.V(1).Info("default Mesh already exists. Skip creating default Mesh.")

--- a/pkg/dns/vips/persistence.go
+++ b/pkg/dns/vips/persistence.go
@@ -10,7 +10,7 @@ import (
 	"go.uber.org/multierr"
 
 	config_manager "github.com/kumahq/kuma/pkg/core/config/manager"
-	mesh_core "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
+	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	config_model "github.com/kumahq/kuma/pkg/core/resources/apis/system"
 	"github.com/kumahq/kuma/pkg/core/resources/manager"
 	"github.com/kumahq/kuma/pkg/core/resources/model"
@@ -132,7 +132,7 @@ func (m *Persistence) Set(mesh string, vips List) error {
 	resource.Spec.Config = string(jsonBytes)
 
 	if create {
-		meshRes := mesh_core.NewMeshResource()
+		meshRes := core_mesh.NewMeshResource()
 		if err := m.resourceManager.Get(ctx, meshRes, store.GetByKey(mesh, model.NoMesh)); err != nil {
 			return err
 		}

--- a/pkg/dns/vips/persistence_test.go
+++ b/pkg/dns/vips/persistence_test.go
@@ -7,7 +7,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	config_proto "github.com/kumahq/kuma/api/system/v1alpha1"
-	mesh_core "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
+	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	"github.com/kumahq/kuma/pkg/core/resources/apis/system"
 	"github.com/kumahq/kuma/pkg/core/resources/manager"
 	core_model "github.com/kumahq/kuma/pkg/core/resources/model"
@@ -79,13 +79,13 @@ var _ = Describe("Meshed Persistence", func() {
 
 	BeforeEach(func() {
 		rm = manager.NewResourceManager(memory.NewStore())
-		err := rm.Create(context.Background(), mesh_core.NewMeshResource(), core_store.CreateByKey("mesh-1", core_model.NoMesh))
+		err := rm.Create(context.Background(), core_mesh.NewMeshResource(), core_store.CreateByKey("mesh-1", core_model.NoMesh))
 		Expect(err).ToNot(HaveOccurred())
 
-		err = rm.Create(context.Background(), mesh_core.NewMeshResource(), core_store.CreateByKey("mesh-2", core_model.NoMesh))
+		err = rm.Create(context.Background(), core_mesh.NewMeshResource(), core_store.CreateByKey("mesh-2", core_model.NoMesh))
 		Expect(err).ToNot(HaveOccurred())
 
-		err = rm.Create(context.Background(), mesh_core.NewMeshResource(), core_store.CreateByKey("mesh-3", core_model.NoMesh))
+		err = rm.Create(context.Background(), core_mesh.NewMeshResource(), core_store.CreateByKey("mesh-3", core_model.NoMesh))
 		Expect(err).ToNot(HaveOccurred())
 	})
 

--- a/pkg/envoy/admin/client.go
+++ b/pkg/envoy/admin/client.go
@@ -15,14 +15,14 @@ import (
 	"github.com/pkg/errors"
 
 	kuma_cp "github.com/kumahq/kuma/pkg/config/app/kuma-cp"
-	mesh_core "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
+	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	"github.com/kumahq/kuma/pkg/core/resources/manager"
 	"github.com/kumahq/kuma/pkg/tokens/builtin/issuer"
 )
 
 type EnvoyAdminClient interface {
-	GenerateAPIToken(dataplane *mesh_core.DataplaneResource) (string, error)
-	PostQuit(dataplane *mesh_core.DataplaneResource) error
+	GenerateAPIToken(dataplane *core_mesh.DataplaneResource) (string, error)
+	PostQuit(dataplane *core_mesh.DataplaneResource) error
 }
 
 type envoyAdminClient struct {
@@ -57,7 +57,7 @@ const (
 	quitquitquit = "quitquitquit"
 )
 
-func (a *envoyAdminClient) GenerateAPIToken(dataplane *mesh_core.DataplaneResource) (string, error) {
+func (a *envoyAdminClient) GenerateAPIToken(dataplane *core_mesh.DataplaneResource) (string, error) {
 	mesh := dataplane.Meta.GetMesh()
 	key, err := a.getOrCreateSigningKey(mesh)
 	if err != nil {
@@ -82,7 +82,7 @@ func (a *envoyAdminClient) getOrCreateSigningKey(mesh string) (string, error) {
 	return string(key), nil
 }
 
-func (a *envoyAdminClient) adminAddress(dataplane *mesh_core.DataplaneResource) string {
+func (a *envoyAdminClient) adminAddress(dataplane *core_mesh.DataplaneResource) string {
 	ip := dataplane.GetIP()
 	// TODO: this will work perfectly fine with K8s, but will fail for Universal
 	// The real allocated admin port is part of the DP metadata, but it is attached to a particular CP,
@@ -93,7 +93,7 @@ func (a *envoyAdminClient) adminAddress(dataplane *mesh_core.DataplaneResource) 
 	return net.JoinHostPort(ip, strconv.FormatUint(uint64(portUint), 10))
 }
 
-func (a *envoyAdminClient) PostQuit(dataplane *mesh_core.DataplaneResource) error {
+func (a *envoyAdminClient) PostQuit(dataplane *core_mesh.DataplaneResource) error {
 	token, err := a.GenerateAPIToken(dataplane)
 	if err != nil {
 		return err

--- a/pkg/envoy/admin/client_test.go
+++ b/pkg/envoy/admin/client_test.go
@@ -4,7 +4,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	mesh_core "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
+	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	test_model "github.com/kumahq/kuma/pkg/test/resources/model"
 )
 
@@ -13,7 +13,7 @@ var _ = Describe("EnvoyAdminClient", func() {
 	Describe("GenerateAPIToken()", func() {
 		It("create and fetch same token for dp/mesh", func() {
 			// when
-			token1, err := eac.GenerateAPIToken(&mesh_core.DataplaneResource{
+			token1, err := eac.GenerateAPIToken(&core_mesh.DataplaneResource{
 				Meta: &test_model.ResourceMeta{
 					Name: "dp-1",
 					Mesh: testMesh,
@@ -22,7 +22,7 @@ var _ = Describe("EnvoyAdminClient", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			// and
-			token2, err := eac.GenerateAPIToken(&mesh_core.DataplaneResource{
+			token2, err := eac.GenerateAPIToken(&core_mesh.DataplaneResource{
 				Meta: &test_model.ResourceMeta{
 					Name: "dp-1",
 					Mesh: testMesh,
@@ -36,7 +36,7 @@ var _ = Describe("EnvoyAdminClient", func() {
 
 		It("two dps in same mesh", func() {
 			// when
-			token1, err := eac.GenerateAPIToken(&mesh_core.DataplaneResource{
+			token1, err := eac.GenerateAPIToken(&core_mesh.DataplaneResource{
 				Meta: &test_model.ResourceMeta{
 					Name: "dp-1",
 					Mesh: testMesh,
@@ -45,7 +45,7 @@ var _ = Describe("EnvoyAdminClient", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			// and
-			token2, err := eac.GenerateAPIToken(&mesh_core.DataplaneResource{
+			token2, err := eac.GenerateAPIToken(&core_mesh.DataplaneResource{
 				Meta: &test_model.ResourceMeta{
 					Name: "dp-2",
 					Mesh: testMesh,
@@ -59,7 +59,7 @@ var _ = Describe("EnvoyAdminClient", func() {
 
 		It("two dps in two meshes", func() {
 			// when
-			token1, err := eac.GenerateAPIToken(&mesh_core.DataplaneResource{
+			token1, err := eac.GenerateAPIToken(&core_mesh.DataplaneResource{
 				Meta: &test_model.ResourceMeta{
 					Name: "dp-1",
 					Mesh: testMesh,
@@ -68,7 +68,7 @@ var _ = Describe("EnvoyAdminClient", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			// and
-			token2, err := eac.GenerateAPIToken(&mesh_core.DataplaneResource{
+			token2, err := eac.GenerateAPIToken(&core_mesh.DataplaneResource{
 				Meta: &test_model.ResourceMeta{
 					Name: "dp-1",
 					Mesh: anotherMesh,

--- a/pkg/kds/cache/snapshot_test.go
+++ b/pkg/kds/cache/snapshot_test.go
@@ -8,7 +8,7 @@ import (
 	"google.golang.org/protobuf/types/known/anypb"
 
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
-	mesh_core "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
+	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	"github.com/kumahq/kuma/pkg/kds/cache"
 )
 
@@ -37,7 +37,7 @@ var _ = Describe("Snapshot", func() {
 
 			// when
 			snapshot = cache.NewSnapshotBuilder().
-				With(string(mesh_core.MeshType), []envoy_types.Resource{
+				With(string(core_mesh.MeshType), []envoy_types.Resource{
 					&mesh_proto.KumaResource{
 						Meta: &mesh_proto.KumaResource_Meta{Name: "mesh1", Mesh: "mesh1"},
 						Spec: mustMarshalAny(&mesh_proto.Mesh{}),
@@ -54,7 +54,7 @@ var _ = Describe("Snapshot", func() {
 			// when
 			var snapshot *cache.Snapshot
 			// then
-			Expect(snapshot.GetResources(string(mesh_core.MeshType))).To(BeNil())
+			Expect(snapshot.GetResources(string(core_mesh.MeshType))).To(BeNil())
 		})
 
 		It("should return Meshes", func() {
@@ -65,13 +65,13 @@ var _ = Describe("Snapshot", func() {
 			}
 			// when
 			snapshot := cache.NewSnapshotBuilder().
-				With(string(mesh_core.MeshType), []envoy_types.Resource{resources}).
+				With(string(core_mesh.MeshType), []envoy_types.Resource{resources}).
 				Build("v1")
 			// then
 			expected := map[string]envoy_types.Resource{
 				"mesh1.mesh1": resources,
 			}
-			Expect(snapshot.GetResources(string(mesh_core.MeshType))).To(Equal(expected))
+			Expect(snapshot.GetResources(string(core_mesh.MeshType))).To(Equal(expected))
 		})
 
 		It("should return `nil` for unsupported resource types", func() {
@@ -82,7 +82,7 @@ var _ = Describe("Snapshot", func() {
 			}
 			// when
 			snapshot := cache.NewSnapshotBuilder().
-				With(string(mesh_core.MeshType), []envoy_types.Resource{resources}).
+				With(string(core_mesh.MeshType), []envoy_types.Resource{resources}).
 				Build("v1")
 			// then
 			Expect(snapshot.GetResources("UnsupportedType")).To(BeNil())
@@ -94,7 +94,7 @@ var _ = Describe("Snapshot", func() {
 			// when
 			var snapshot *cache.Snapshot
 			// then
-			Expect(snapshot.GetVersion(string(mesh_core.MeshType))).To(Equal(""))
+			Expect(snapshot.GetVersion(string(core_mesh.MeshType))).To(Equal(""))
 		})
 
 		It("should return proper version for a supported resource type", func() {
@@ -105,10 +105,10 @@ var _ = Describe("Snapshot", func() {
 			}
 			// when
 			snapshot := cache.NewSnapshotBuilder().
-				With(string(mesh_core.MeshType), []envoy_types.Resource{resources}).
+				With(string(core_mesh.MeshType), []envoy_types.Resource{resources}).
 				Build("v1")
 			// then
-			Expect(snapshot.GetVersion(string(mesh_core.MeshType))).To(Equal("v1"))
+			Expect(snapshot.GetVersion(string(core_mesh.MeshType))).To(Equal("v1"))
 		})
 
 		It("should return an empty string for unsupported resource type", func() {
@@ -119,7 +119,7 @@ var _ = Describe("Snapshot", func() {
 			}
 			// when
 			snapshot := cache.NewSnapshotBuilder().
-				With(string(mesh_core.MeshType), []envoy_types.Resource{resources}).
+				With(string(core_mesh.MeshType), []envoy_types.Resource{resources}).
 				Build("v1")
 			// then
 			Expect(snapshot.GetVersion("unsupported type")).To(Equal(""))
@@ -131,7 +131,7 @@ var _ = Describe("Snapshot", func() {
 			// given
 			var snapshot *cache.Snapshot
 			// when
-			actual := snapshot.WithVersion(string(mesh_core.MeshType), "v1")
+			actual := snapshot.WithVersion(string(core_mesh.MeshType), "v1")
 			// then
 			Expect(actual).To(BeNil())
 		})
@@ -144,14 +144,14 @@ var _ = Describe("Snapshot", func() {
 			}
 			// when
 			snapshot := cache.NewSnapshotBuilder().
-				With(string(mesh_core.MeshType), []envoy_types.Resource{resources}).
+				With(string(core_mesh.MeshType), []envoy_types.Resource{resources}).
 				Build("v1")
 			// when
-			actual := snapshot.WithVersion(string(mesh_core.MeshType), "v2")
+			actual := snapshot.WithVersion(string(core_mesh.MeshType), "v2")
 			// then
-			Expect(actual.GetVersion(string(mesh_core.MeshType))).To(Equal("v2"))
+			Expect(actual.GetVersion(string(core_mesh.MeshType))).To(Equal("v2"))
 			// and
-			Expect(actual.GetVersion(string(mesh_core.CircuitBreakerType))).To(Equal("v1"))
+			Expect(actual.GetVersion(string(core_mesh.CircuitBreakerType))).To(Equal("v1"))
 		})
 
 		It("should return the same snapshot if version has not changed", func() {
@@ -162,12 +162,12 @@ var _ = Describe("Snapshot", func() {
 			}
 			// when
 			snapshot := cache.NewSnapshotBuilder().
-				With(string(mesh_core.MeshType), []envoy_types.Resource{resources}).
+				With(string(core_mesh.MeshType), []envoy_types.Resource{resources}).
 				Build("v1")
 			// when
-			actual := snapshot.WithVersion(string(mesh_core.MeshType), "v1")
+			actual := snapshot.WithVersion(string(core_mesh.MeshType), "v1")
 			// then
-			Expect(actual.GetVersion(string(mesh_core.MeshType))).To(Equal("v1"))
+			Expect(actual.GetVersion(string(core_mesh.MeshType))).To(Equal("v1"))
 			// and
 			Expect(actual).To(BeIdenticalTo(snapshot))
 		})
@@ -180,12 +180,12 @@ var _ = Describe("Snapshot", func() {
 			}
 			// when
 			snapshot := cache.NewSnapshotBuilder().
-				With(string(mesh_core.MeshType), []envoy_types.Resource{resources}).
+				With(string(core_mesh.MeshType), []envoy_types.Resource{resources}).
 				Build("v1")
 			// when
 			actual := snapshot.WithVersion("unsupported type", "v2")
 			// then
-			Expect(actual.GetVersion(string(mesh_core.MeshType))).To(Equal("v1"))
+			Expect(actual.GetVersion(string(core_mesh.MeshType))).To(Equal("v1"))
 			// and
 			Expect(actual).To(BeIdenticalTo(snapshot))
 		})

--- a/pkg/mads/generator/interfaces.go
+++ b/pkg/mads/generator/interfaces.go
@@ -1,13 +1,13 @@
 package generator
 
 import (
-	mesh_core "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
+	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	core_xds "github.com/kumahq/kuma/pkg/core/xds"
 )
 
 type Args struct {
-	Meshes     []*mesh_core.MeshResource
-	Dataplanes []*mesh_core.DataplaneResource
+	Meshes     []*core_mesh.MeshResource
+	Dataplanes []*core_mesh.DataplaneResource
 }
 
 type ResourceGenerator interface {

--- a/pkg/mads/util.go
+++ b/pkg/mads/util.go
@@ -9,18 +9,18 @@ import (
 	prom_util "github.com/prometheus/prometheus/util/strutil"
 
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
-	mesh_core "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
+	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 )
 
-func IndexMeshes(meshes []*mesh_core.MeshResource) map[string]*mesh_core.MeshResource {
-	index := make(map[string]*mesh_core.MeshResource)
+func IndexMeshes(meshes []*core_mesh.MeshResource) map[string]*core_mesh.MeshResource {
+	index := make(map[string]*core_mesh.MeshResource)
 	for _, mesh := range meshes {
 		index[mesh.Meta.GetName()] = mesh
 	}
 	return index
 }
 
-func Address(dataplane *mesh_core.DataplaneResource, endpoint *mesh_proto.PrometheusMetricsBackendConfig) string {
+func Address(dataplane *core_mesh.DataplaneResource, endpoint *mesh_proto.PrometheusMetricsBackendConfig) string {
 	// TODO: handle a case where Dataplane's IP is unknown
 	// For now, we export such a Dataplane with an empty IP address, so that the error state will be at least visible on the Prometheus side
 	return net.JoinHostPort(dataplane.GetIP(), strconv.FormatUint(uint64(endpoint.GetPort()), 10))
@@ -32,7 +32,7 @@ func MultiValue(values []string) string {
 	return "," + strings.Join(values, ",") + ","
 }
 
-func DataplaneLabels(dataplane *mesh_core.DataplaneResource) map[string]string {
+func DataplaneLabels(dataplane *core_mesh.DataplaneResource) map[string]string {
 	labels := map[string]string{}
 	// first, we copy user-defined tags
 	tags := dataplane.Spec.TagSet()
@@ -58,7 +58,7 @@ func DataplaneLabels(dataplane *mesh_core.DataplaneResource) map[string]string {
 	return labels
 }
 
-func DataplaneAssignmentName(dataplane *mesh_core.DataplaneResource) string {
+func DataplaneAssignmentName(dataplane *core_mesh.DataplaneResource) string {
 	// unique name, e.g. REST API uri
 	return fmt.Sprintf("/meshes/%s/dataplanes/%s", dataplane.Meta.GetMesh(), dataplane.Meta.GetName())
 }

--- a/pkg/mads/v1/generator/assignments_test.go
+++ b/pkg/mads/v1/generator/assignments_test.go
@@ -7,7 +7,7 @@ import (
 
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	observability_v1 "github.com/kumahq/kuma/api/observability/v1"
-	mesh_core "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
+	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	core_model "github.com/kumahq/kuma/pkg/core/resources/model"
 	core_xds "github.com/kumahq/kuma/pkg/core/xds"
 	"github.com/kumahq/kuma/pkg/mads/generator"
@@ -21,8 +21,8 @@ var _ = Describe("MonitoringAssignmentsGenerator", func() {
 	Describe("Generate()", func() {
 
 		type testCase struct {
-			meshes     []*mesh_core.MeshResource
-			dataplanes []*mesh_core.DataplaneResource
+			meshes     []*core_mesh.MeshResource
+			dataplanes []*core_mesh.DataplaneResource
 			expected   []*core_xds.Resource
 		}
 
@@ -44,7 +44,7 @@ var _ = Describe("MonitoringAssignmentsGenerator", func() {
 				expected: []*core_xds.Resource{},
 			}),
 			Entry("Dataplane without Mesh", testCase{
-				dataplanes: []*mesh_core.DataplaneResource{
+				dataplanes: []*core_mesh.DataplaneResource{
 					{
 						Meta: &test_model.ResourceMeta{
 							Name: "backend-01",
@@ -67,7 +67,7 @@ var _ = Describe("MonitoringAssignmentsGenerator", func() {
 				expected: []*core_xds.Resource{},
 			}),
 			Entry("Dataplane inside a Mesh without Prometheus enabled", testCase{
-				meshes: []*mesh_core.MeshResource{
+				meshes: []*core_mesh.MeshResource{
 					{
 						Meta: &test_model.ResourceMeta{
 							Name: "demo",
@@ -75,7 +75,7 @@ var _ = Describe("MonitoringAssignmentsGenerator", func() {
 						Spec: &mesh_proto.Mesh{},
 					},
 				},
-				dataplanes: []*mesh_core.DataplaneResource{
+				dataplanes: []*core_mesh.DataplaneResource{
 					{
 						Meta: &test_model.ResourceMeta{
 							Name: "backend-01",
@@ -106,7 +106,7 @@ var _ = Describe("MonitoringAssignmentsGenerator", func() {
 				expected: []*core_xds.Resource{},
 			}),
 			Entry("Dataplane without inbound interfaces", testCase{
-				meshes: []*mesh_core.MeshResource{
+				meshes: []*core_mesh.MeshResource{
 					{
 						Meta: &test_model.ResourceMeta{
 							Name: "demo",
@@ -128,7 +128,7 @@ var _ = Describe("MonitoringAssignmentsGenerator", func() {
 						},
 					},
 				},
-				dataplanes: []*mesh_core.DataplaneResource{
+				dataplanes: []*core_mesh.DataplaneResource{
 					{
 						Meta: &test_model.ResourceMeta{
 							Name: "gateway-01",
@@ -169,7 +169,7 @@ var _ = Describe("MonitoringAssignmentsGenerator", func() {
 				},
 			}),
 			Entry("Dataplane with multiple inbound interfaces", testCase{
-				meshes: []*mesh_core.MeshResource{
+				meshes: []*core_mesh.MeshResource{
 					{
 						Meta: &test_model.ResourceMeta{
 							Name: "demo",
@@ -191,7 +191,7 @@ var _ = Describe("MonitoringAssignmentsGenerator", func() {
 						},
 					},
 				},
-				dataplanes: []*mesh_core.DataplaneResource{
+				dataplanes: []*core_mesh.DataplaneResource{
 					{
 						Meta: &test_model.ResourceMeta{
 							Name: "backend-01",
@@ -250,7 +250,7 @@ var _ = Describe("MonitoringAssignmentsGenerator", func() {
 				},
 			}),
 			Entry("Dataplane with a user-defined plural tag", testCase{
-				meshes: []*mesh_core.MeshResource{
+				meshes: []*core_mesh.MeshResource{
 					{
 						Meta: &test_model.ResourceMeta{
 							Name: "demo",
@@ -272,7 +272,7 @@ var _ = Describe("MonitoringAssignmentsGenerator", func() {
 						},
 					},
 				},
-				dataplanes: []*mesh_core.DataplaneResource{
+				dataplanes: []*core_mesh.DataplaneResource{
 					{
 						Meta: &test_model.ResourceMeta{
 							Name: "backend-01",
@@ -318,7 +318,7 @@ var _ = Describe("MonitoringAssignmentsGenerator", func() {
 				},
 			}),
 			Entry("Dataplane with unsafe characters in tag's name and value", testCase{
-				meshes: []*mesh_core.MeshResource{
+				meshes: []*core_mesh.MeshResource{
 					{
 						Meta: &test_model.ResourceMeta{
 							Name: "demo",
@@ -340,7 +340,7 @@ var _ = Describe("MonitoringAssignmentsGenerator", func() {
 						},
 					},
 				},
-				dataplanes: []*mesh_core.DataplaneResource{
+				dataplanes: []*core_mesh.DataplaneResource{
 					{
 						Meta: &test_model.ResourceMeta{
 							Name: "backend-01",
@@ -387,7 +387,7 @@ var _ = Describe("MonitoringAssignmentsGenerator", func() {
 				},
 			}),
 			Entry("multiple Meshes and Dataplanes", testCase{
-				meshes: []*mesh_core.MeshResource{
+				meshes: []*core_mesh.MeshResource{
 					{
 						Meta: &test_model.ResourceMeta{
 							Name: "default",
@@ -430,7 +430,7 @@ var _ = Describe("MonitoringAssignmentsGenerator", func() {
 						},
 					},
 				},
-				dataplanes: []*mesh_core.DataplaneResource{
+				dataplanes: []*core_mesh.DataplaneResource{
 					{
 						Meta: &test_model.ResourceMeta{
 							Name: "backend-01",
@@ -520,7 +520,7 @@ var _ = Describe("MonitoringAssignmentsGenerator", func() {
 				},
 			}),
 			Entry("should include `k8s_kuma_io_namespace` and `k8s_kuma_io_name` labels on Kubernetes", testCase{
-				meshes: []*mesh_core.MeshResource{
+				meshes: []*core_mesh.MeshResource{
 					{
 						Meta: &test_model.ResourceMeta{
 							Name: "demo",
@@ -542,7 +542,7 @@ var _ = Describe("MonitoringAssignmentsGenerator", func() {
 						},
 					},
 				},
-				dataplanes: []*mesh_core.DataplaneResource{
+				dataplanes: []*core_mesh.DataplaneResource{
 					{
 						Meta: &test_model.ResourceMeta{
 							Name: "backend-5c89f4d995-85znn.my-namespace",

--- a/pkg/mads/v1/reconcile/snapshot_generator.go
+++ b/pkg/mads/v1/reconcile/snapshot_generator.go
@@ -5,7 +5,7 @@ import (
 
 	envoy_core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 
-	mesh_core "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
+	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	core_manager "github.com/kumahq/kuma/pkg/core/resources/manager"
 	core_store "github.com/kumahq/kuma/pkg/core/resources/store"
 	core_xds "github.com/kumahq/kuma/pkg/core/xds"
@@ -50,13 +50,13 @@ func (s *snapshotGenerator) GenerateSnapshot(ctx context.Context, _ *envoy_core.
 	return mads_v1_cache.NewSnapshot("", core_xds.ResourceList(resources).ToIndex()), nil
 }
 
-func (s *snapshotGenerator) getMeshesWithPrometheusEnabled(ctx context.Context) ([]*mesh_core.MeshResource, error) {
-	meshList := &mesh_core.MeshResourceList{}
+func (s *snapshotGenerator) getMeshesWithPrometheusEnabled(ctx context.Context) ([]*core_mesh.MeshResource, error) {
+	meshList := &core_mesh.MeshResourceList{}
 	if err := s.resourceManager.List(ctx, meshList); err != nil {
 		return nil, err
 	}
 
-	meshes := make([]*mesh_core.MeshResource, 0)
+	meshes := make([]*core_mesh.MeshResource, 0)
 	for _, mesh := range meshList.Items {
 		if mesh.HasPrometheusMetricsEnabled() {
 			meshes = append(meshes, mesh)
@@ -65,10 +65,10 @@ func (s *snapshotGenerator) getMeshesWithPrometheusEnabled(ctx context.Context) 
 	return meshes, nil
 }
 
-func (s *snapshotGenerator) getDataplanes(ctx context.Context, meshes []*mesh_core.MeshResource) ([]*mesh_core.DataplaneResource, error) {
-	dataplanes := make([]*mesh_core.DataplaneResource, 0)
+func (s *snapshotGenerator) getDataplanes(ctx context.Context, meshes []*core_mesh.MeshResource) ([]*core_mesh.DataplaneResource, error) {
+	dataplanes := make([]*core_mesh.DataplaneResource, 0)
 	for _, mesh := range meshes {
-		dataplaneList := &mesh_core.DataplaneResourceList{}
+		dataplaneList := &core_mesh.DataplaneResourceList{}
 		if err := s.resourceManager.List(ctx, dataplaneList, core_store.ListByMesh(mesh.Meta.GetName())); err != nil {
 			return nil, err
 		}

--- a/pkg/mads/v1/reconcile/snapshot_generator_test.go
+++ b/pkg/mads/v1/reconcile/snapshot_generator_test.go
@@ -10,7 +10,7 @@ import (
 
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	observability_v1 "github.com/kumahq/kuma/api/observability/v1"
-	mesh_core "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
+	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	core_manager "github.com/kumahq/kuma/pkg/core/resources/manager"
 	core_model "github.com/kumahq/kuma/pkg/core/resources/model"
 	core_store "github.com/kumahq/kuma/pkg/core/resources/store"
@@ -35,8 +35,8 @@ var _ = Describe("snapshotGenerator", func() {
 		})
 
 		type testCase struct {
-			meshes     []*mesh_core.MeshResource
-			dataplanes []*mesh_core.DataplaneResource
+			meshes     []*core_mesh.MeshResource
+			dataplanes []*core_mesh.DataplaneResource
 			expected   *mads_cache.Snapshot
 		}
 
@@ -70,7 +70,7 @@ var _ = Describe("snapshotGenerator", func() {
 				expected: mads_cache.NewSnapshot("", nil),
 			}),
 			Entry("no Meshes with Prometheus enabled", testCase{
-				meshes: []*mesh_core.MeshResource{
+				meshes: []*core_mesh.MeshResource{
 					{
 						Meta: &test_model.ResourceMeta{
 							Name: "default",
@@ -78,7 +78,7 @@ var _ = Describe("snapshotGenerator", func() {
 						Spec: &mesh_proto.Mesh{},
 					},
 				},
-				dataplanes: []*mesh_core.DataplaneResource{
+				dataplanes: []*core_mesh.DataplaneResource{
 					{
 						Meta: &test_model.ResourceMeta{
 							Name: "backend-01",
@@ -101,7 +101,7 @@ var _ = Describe("snapshotGenerator", func() {
 				expected: mads_cache.NewSnapshot("", nil),
 			}),
 			Entry("Mesh with Prometheus enabled but no Dataplanes", testCase{
-				meshes: []*mesh_core.MeshResource{
+				meshes: []*core_mesh.MeshResource{
 					{
 						Meta: &test_model.ResourceMeta{
 							Name: "default",
@@ -129,7 +129,7 @@ var _ = Describe("snapshotGenerator", func() {
 						},
 					},
 				},
-				dataplanes: []*mesh_core.DataplaneResource{
+				dataplanes: []*core_mesh.DataplaneResource{
 					{
 						Meta: &test_model.ResourceMeta{
 							Name: "backend-01",
@@ -152,7 +152,7 @@ var _ = Describe("snapshotGenerator", func() {
 				expected: mads_cache.NewSnapshot("", nil),
 			}),
 			Entry("Mesh with Prometheus enabled and some Dataplanes", testCase{
-				meshes: []*mesh_core.MeshResource{
+				meshes: []*core_mesh.MeshResource{
 					{
 						Meta: &test_model.ResourceMeta{
 							Name: "default",
@@ -179,7 +179,7 @@ var _ = Describe("snapshotGenerator", func() {
 						},
 					},
 				},
-				dataplanes: []*mesh_core.DataplaneResource{
+				dataplanes: []*core_mesh.DataplaneResource{
 					{
 						Meta: &test_model.ResourceMeta{
 							Name: "backend-01",

--- a/pkg/mads/v1/service_test.go
+++ b/pkg/mads/v1/service_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/kumahq/kuma/api/mesh/v1alpha1"
 	observability_v1 "github.com/kumahq/kuma/api/observability/v1"
 	mads_config "github.com/kumahq/kuma/pkg/config/mads"
-	mesh_core "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
+	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	core_manager "github.com/kumahq/kuma/pkg/core/resources/manager"
 	"github.com/kumahq/kuma/pkg/core/resources/model"
 	"github.com/kumahq/kuma/pkg/core/resources/store"
@@ -137,16 +137,16 @@ var _ = Describe("MADS http service", func() {
 	})
 
 	Describe("with resources", func() {
-		createMesh := func(mesh *mesh_core.MeshResource) error {
+		createMesh := func(mesh *core_mesh.MeshResource) error {
 			return resManager.Create(context.Background(), mesh, store.CreateByKey(mesh.GetMeta().GetName(), model.NoMesh))
 		}
 
-		createDataPlane := func(dp *mesh_core.DataplaneResource) error {
+		createDataPlane := func(dp *core_mesh.DataplaneResource) error {
 			err := resManager.Create(context.Background(), dp, store.CreateByKey(dp.Meta.GetName(), dp.GetMeta().GetMesh()))
 			return err
 		}
 
-		var mesh = &mesh_core.MeshResource{
+		var mesh = &core_mesh.MeshResource{
 			Meta: &test_model.ResourceMeta{
 				Name: "test",
 			},
@@ -163,7 +163,7 @@ var _ = Describe("MADS http service", func() {
 			},
 		}
 
-		var dp1 = &mesh_core.DataplaneResource{
+		var dp1 = &core_mesh.DataplaneResource{
 			Meta: &test_model.ResourceMeta{
 				Name: "dp-1",
 				Mesh: mesh.GetMeta().GetName(),
@@ -181,7 +181,7 @@ var _ = Describe("MADS http service", func() {
 			},
 		}
 
-		var dp2 = &mesh_core.DataplaneResource{
+		var dp2 = &core_mesh.DataplaneResource{
 			Meta: &test_model.ResourceMeta{
 				Name: "dp-2",
 				Mesh: mesh.GetMeta().GetName(),

--- a/pkg/mads/v1alpha1/generator/assignments.go
+++ b/pkg/mads/v1alpha1/generator/assignments.go
@@ -6,7 +6,7 @@ import (
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	observability_v1alpha1 "github.com/kumahq/kuma/api/observability/v1alpha1"
 	"github.com/kumahq/kuma/pkg/core"
-	mesh_core "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
+	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	core_xds "github.com/kumahq/kuma/pkg/core/xds"
 	"github.com/kumahq/kuma/pkg/mads"
 	"github.com/kumahq/kuma/pkg/mads/generator"
@@ -129,13 +129,13 @@ func (g MonitoringAssignmentsGenerator) Generate(args generator.Args) ([]*core_x
 	return resources, nil
 }
 
-func (_ MonitoringAssignmentsGenerator) addressLabel(dataplane *mesh_core.DataplaneResource, endpoint *mesh_proto.PrometheusMetricsBackendConfig) map[string]string {
+func (_ MonitoringAssignmentsGenerator) addressLabel(dataplane *core_mesh.DataplaneResource, endpoint *mesh_proto.PrometheusMetricsBackendConfig) map[string]string {
 	return map[string]string{
 		prom.AddressLabel: mads.Address(dataplane, endpoint),
 	}
 }
 
-func (g MonitoringAssignmentsGenerator) dataplaneLabels(dataplane *mesh_core.DataplaneResource, endpoint *mesh_proto.PrometheusMetricsBackendConfig) map[string]string {
+func (g MonitoringAssignmentsGenerator) dataplaneLabels(dataplane *core_mesh.DataplaneResource, endpoint *mesh_proto.PrometheusMetricsBackendConfig) map[string]string {
 	labels := mads.DataplaneLabels(dataplane)
 	// then, we apply mandatory Prometheus labels on top
 	labels[prom.SchemeLabel] = "http"

--- a/pkg/mads/v1alpha1/generator/assignments_test.go
+++ b/pkg/mads/v1alpha1/generator/assignments_test.go
@@ -7,7 +7,7 @@ import (
 
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	observability_proto "github.com/kumahq/kuma/api/observability/v1alpha1"
-	mesh_core "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
+	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	core_model "github.com/kumahq/kuma/pkg/core/resources/model"
 	core_xds "github.com/kumahq/kuma/pkg/core/xds"
 	mads_generator "github.com/kumahq/kuma/pkg/mads/generator"
@@ -21,8 +21,8 @@ var _ = Describe("MonitoringAssignmentsGenerator", func() {
 	Describe("Generate()", func() {
 
 		type testCase struct {
-			meshes     []*mesh_core.MeshResource
-			dataplanes []*mesh_core.DataplaneResource
+			meshes     []*core_mesh.MeshResource
+			dataplanes []*core_mesh.DataplaneResource
 			expected   []*core_xds.Resource
 		}
 
@@ -44,7 +44,7 @@ var _ = Describe("MonitoringAssignmentsGenerator", func() {
 				expected: []*core_xds.Resource{},
 			}),
 			Entry("Dataplane without Mesh", testCase{
-				dataplanes: []*mesh_core.DataplaneResource{
+				dataplanes: []*core_mesh.DataplaneResource{
 					{
 						Meta: &test_model.ResourceMeta{
 							Name: "backend-01",
@@ -67,7 +67,7 @@ var _ = Describe("MonitoringAssignmentsGenerator", func() {
 				expected: []*core_xds.Resource{},
 			}),
 			Entry("Dataplane inside a Mesh without Prometheus enabled", testCase{
-				meshes: []*mesh_core.MeshResource{
+				meshes: []*core_mesh.MeshResource{
 					{
 						Meta: &test_model.ResourceMeta{
 							Name: "demo",
@@ -75,7 +75,7 @@ var _ = Describe("MonitoringAssignmentsGenerator", func() {
 						Spec: &mesh_proto.Mesh{},
 					},
 				},
-				dataplanes: []*mesh_core.DataplaneResource{
+				dataplanes: []*core_mesh.DataplaneResource{
 					{
 						Meta: &test_model.ResourceMeta{
 							Name: "backend-01",
@@ -106,7 +106,7 @@ var _ = Describe("MonitoringAssignmentsGenerator", func() {
 				expected: []*core_xds.Resource{},
 			}),
 			Entry("Dataplane without inbound interfaces", testCase{
-				meshes: []*mesh_core.MeshResource{
+				meshes: []*core_mesh.MeshResource{
 					{
 						Meta: &test_model.ResourceMeta{
 							Name: "demo",
@@ -128,7 +128,7 @@ var _ = Describe("MonitoringAssignmentsGenerator", func() {
 						},
 					},
 				},
-				dataplanes: []*mesh_core.DataplaneResource{
+				dataplanes: []*core_mesh.DataplaneResource{
 					{
 						Meta: &test_model.ResourceMeta{
 							Name: "gateway-01",
@@ -173,7 +173,7 @@ var _ = Describe("MonitoringAssignmentsGenerator", func() {
 				},
 			}),
 			Entry("Dataplane with multiple inbound interfaces", testCase{
-				meshes: []*mesh_core.MeshResource{
+				meshes: []*core_mesh.MeshResource{
 					{
 						Meta: &test_model.ResourceMeta{
 							Name: "demo",
@@ -195,7 +195,7 @@ var _ = Describe("MonitoringAssignmentsGenerator", func() {
 						},
 					},
 				},
-				dataplanes: []*mesh_core.DataplaneResource{
+				dataplanes: []*core_mesh.DataplaneResource{
 					{
 						Meta: &test_model.ResourceMeta{
 							Name: "backend-01",
@@ -258,7 +258,7 @@ var _ = Describe("MonitoringAssignmentsGenerator", func() {
 				},
 			}),
 			Entry("Dataplane with a user-defined plural tag", testCase{
-				meshes: []*mesh_core.MeshResource{
+				meshes: []*core_mesh.MeshResource{
 					{
 						Meta: &test_model.ResourceMeta{
 							Name: "demo",
@@ -280,7 +280,7 @@ var _ = Describe("MonitoringAssignmentsGenerator", func() {
 						},
 					},
 				},
-				dataplanes: []*mesh_core.DataplaneResource{
+				dataplanes: []*core_mesh.DataplaneResource{
 					{
 						Meta: &test_model.ResourceMeta{
 							Name: "backend-01",
@@ -330,7 +330,7 @@ var _ = Describe("MonitoringAssignmentsGenerator", func() {
 				},
 			}),
 			Entry("Dataplane with unsafe characters in tag's name and value", testCase{
-				meshes: []*mesh_core.MeshResource{
+				meshes: []*core_mesh.MeshResource{
 					{
 						Meta: &test_model.ResourceMeta{
 							Name: "demo",
@@ -352,7 +352,7 @@ var _ = Describe("MonitoringAssignmentsGenerator", func() {
 						},
 					},
 				},
-				dataplanes: []*mesh_core.DataplaneResource{
+				dataplanes: []*core_mesh.DataplaneResource{
 					{
 						Meta: &test_model.ResourceMeta{
 							Name: "backend-01",
@@ -403,7 +403,7 @@ var _ = Describe("MonitoringAssignmentsGenerator", func() {
 				},
 			}),
 			Entry("multiple Meshes and Dataplanes", testCase{
-				meshes: []*mesh_core.MeshResource{
+				meshes: []*core_mesh.MeshResource{
 					{
 						Meta: &test_model.ResourceMeta{
 							Name: "default",
@@ -446,7 +446,7 @@ var _ = Describe("MonitoringAssignmentsGenerator", func() {
 						},
 					},
 				},
-				dataplanes: []*mesh_core.DataplaneResource{
+				dataplanes: []*core_mesh.DataplaneResource{
 					{
 						Meta: &test_model.ResourceMeta{
 							Name: "backend-01",
@@ -544,7 +544,7 @@ var _ = Describe("MonitoringAssignmentsGenerator", func() {
 				},
 			}),
 			Entry("should include `k8s_kuma_io_namespace` and `k8s_kuma_io_name` labels on Kubernetes", testCase{
-				meshes: []*mesh_core.MeshResource{
+				meshes: []*core_mesh.MeshResource{
 					{
 						Meta: &test_model.ResourceMeta{
 							Name: "demo",
@@ -566,7 +566,7 @@ var _ = Describe("MonitoringAssignmentsGenerator", func() {
 						},
 					},
 				},
-				dataplanes: []*mesh_core.DataplaneResource{
+				dataplanes: []*core_mesh.DataplaneResource{
 					{
 						Meta: &test_model.ResourceMeta{
 							Name: "backend-5c89f4d995-85znn.my-namespace",

--- a/pkg/mads/v1alpha1/reconcile/snapshot_generator.go
+++ b/pkg/mads/v1alpha1/reconcile/snapshot_generator.go
@@ -5,7 +5,7 @@ import (
 
 	envoy_core "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
 
-	mesh_core "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
+	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	core_manager "github.com/kumahq/kuma/pkg/core/resources/manager"
 	core_store "github.com/kumahq/kuma/pkg/core/resources/store"
 	core_xds "github.com/kumahq/kuma/pkg/core/xds"
@@ -50,13 +50,13 @@ func (s *snapshotGenerator) GenerateSnapshot(ctx context.Context, _ *envoy_core.
 	return mads_cache.NewSnapshot("", core_xds.ResourceList(resources).ToIndex()), nil
 }
 
-func (s *snapshotGenerator) getMeshesWithPrometheusEnabled(ctx context.Context) ([]*mesh_core.MeshResource, error) {
-	meshList := &mesh_core.MeshResourceList{}
+func (s *snapshotGenerator) getMeshesWithPrometheusEnabled(ctx context.Context) ([]*core_mesh.MeshResource, error) {
+	meshList := &core_mesh.MeshResourceList{}
 	if err := s.resourceManager.List(ctx, meshList); err != nil {
 		return nil, err
 	}
 
-	meshes := make([]*mesh_core.MeshResource, 0)
+	meshes := make([]*core_mesh.MeshResource, 0)
 	for _, mesh := range meshList.Items {
 		if mesh.HasPrometheusMetricsEnabled() {
 			meshes = append(meshes, mesh)
@@ -65,10 +65,10 @@ func (s *snapshotGenerator) getMeshesWithPrometheusEnabled(ctx context.Context) 
 	return meshes, nil
 }
 
-func (s *snapshotGenerator) getDataplanes(ctx context.Context, meshes []*mesh_core.MeshResource) ([]*mesh_core.DataplaneResource, error) {
-	dataplanes := make([]*mesh_core.DataplaneResource, 0)
+func (s *snapshotGenerator) getDataplanes(ctx context.Context, meshes []*core_mesh.MeshResource) ([]*core_mesh.DataplaneResource, error) {
+	dataplanes := make([]*core_mesh.DataplaneResource, 0)
 	for _, mesh := range meshes {
-		dataplaneList := &mesh_core.DataplaneResourceList{}
+		dataplaneList := &core_mesh.DataplaneResourceList{}
 		if err := s.resourceManager.List(ctx, dataplaneList, core_store.ListByMesh(mesh.Meta.GetName())); err != nil {
 			return nil, err
 		}

--- a/pkg/mads/v1alpha1/reconcile/snapshot_generator_test.go
+++ b/pkg/mads/v1alpha1/reconcile/snapshot_generator_test.go
@@ -10,7 +10,7 @@ import (
 
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	observability_proto "github.com/kumahq/kuma/api/observability/v1alpha1"
-	mesh_core "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
+	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	core_manager "github.com/kumahq/kuma/pkg/core/resources/manager"
 	core_model "github.com/kumahq/kuma/pkg/core/resources/model"
 	core_store "github.com/kumahq/kuma/pkg/core/resources/store"
@@ -35,8 +35,8 @@ var _ = Describe("snapshotGenerator", func() {
 		})
 
 		type testCase struct {
-			meshes     []*mesh_core.MeshResource
-			dataplanes []*mesh_core.DataplaneResource
+			meshes     []*core_mesh.MeshResource
+			dataplanes []*core_mesh.DataplaneResource
 			expected   *mads_cache.Snapshot
 		}
 
@@ -70,7 +70,7 @@ var _ = Describe("snapshotGenerator", func() {
 				expected: mads_cache.NewSnapshot("", nil),
 			}),
 			Entry("no Meshes with Prometheus enabled", testCase{
-				meshes: []*mesh_core.MeshResource{
+				meshes: []*core_mesh.MeshResource{
 					{
 						Meta: &test_model.ResourceMeta{
 							Name: "default",
@@ -78,7 +78,7 @@ var _ = Describe("snapshotGenerator", func() {
 						Spec: &mesh_proto.Mesh{},
 					},
 				},
-				dataplanes: []*mesh_core.DataplaneResource{
+				dataplanes: []*core_mesh.DataplaneResource{
 					{
 						Meta: &test_model.ResourceMeta{
 							Name: "backend-01",
@@ -101,7 +101,7 @@ var _ = Describe("snapshotGenerator", func() {
 				expected: mads_cache.NewSnapshot("", nil),
 			}),
 			Entry("Mesh with Prometheus enabled but no Dataplanes", testCase{
-				meshes: []*mesh_core.MeshResource{
+				meshes: []*core_mesh.MeshResource{
 					{
 						Meta: &test_model.ResourceMeta{
 							Name: "default",
@@ -129,7 +129,7 @@ var _ = Describe("snapshotGenerator", func() {
 						},
 					},
 				},
-				dataplanes: []*mesh_core.DataplaneResource{
+				dataplanes: []*core_mesh.DataplaneResource{
 					{
 						Meta: &test_model.ResourceMeta{
 							Name: "backend-01",
@@ -152,7 +152,7 @@ var _ = Describe("snapshotGenerator", func() {
 				expected: mads_cache.NewSnapshot("", nil),
 			}),
 			Entry("Mesh with Prometheus enabled and some Dataplanes", testCase{
-				meshes: []*mesh_core.MeshResource{
+				meshes: []*core_mesh.MeshResource{
 					{
 						Meta: &test_model.ResourceMeta{
 							Name: "default",
@@ -180,7 +180,7 @@ var _ = Describe("snapshotGenerator", func() {
 						},
 					},
 				},
-				dataplanes: []*mesh_core.DataplaneResource{
+				dataplanes: []*core_mesh.DataplaneResource{
 					{
 						Meta: &test_model.ResourceMeta{
 							Name: "backend-01",

--- a/pkg/plugins/ca/provided/manager.go
+++ b/pkg/plugins/ca/provided/manager.go
@@ -9,7 +9,7 @@ import (
 	"github.com/kumahq/kuma/pkg/core/ca"
 	ca_issuer "github.com/kumahq/kuma/pkg/core/ca/issuer"
 	"github.com/kumahq/kuma/pkg/core/datasource"
-	mesh_helper "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
+	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	"github.com/kumahq/kuma/pkg/core/validators"
 	"github.com/kumahq/kuma/pkg/plugins/ca/provided/config"
 	util_proto "github.com/kumahq/kuma/pkg/util/proto"
@@ -114,7 +114,7 @@ func (p *providedCaManager) GenerateDataplaneCert(ctx context.Context, mesh stri
 
 	var opts []ca_issuer.CertOptsFn
 	if backend.GetDpCert().GetRotation().GetExpiration() != "" {
-		duration, err := mesh_helper.ParseDuration(backend.GetDpCert().GetRotation().Expiration)
+		duration, err := core_mesh.ParseDuration(backend.GetDpCert().GetRotation().Expiration)
 		if err != nil {
 			return ca.KeyPair{}, err
 		}

--- a/pkg/plugins/resources/k8s/native/api/v1alpha1/circuitbreaker_types_helpers.go
+++ b/pkg/plugins/resources/k8s/native/api/v1alpha1/circuitbreaker_types_helpers.go
@@ -3,7 +3,7 @@ package v1alpha1
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
+	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	"github.com/kumahq/kuma/pkg/plugins/resources/k8s/native/pkg/model"
 	"github.com/kumahq/kuma/pkg/plugins/resources/k8s/native/pkg/registry"
 )
@@ -45,13 +45,13 @@ func (l *CircuitBreakerList) GetItems() []model.KubernetesObject {
 }
 
 func init() {
-	registry.RegisterObjectType(&proto.CircuitBreaker{}, &CircuitBreaker{
+	registry.RegisterObjectType(&mesh_proto.CircuitBreaker{}, &CircuitBreaker{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: GroupVersion.String(),
 			Kind:       "CircuitBreaker",
 		},
 	})
-	registry.RegisterListType(&proto.CircuitBreaker{}, &CircuitBreakerList{
+	registry.RegisterListType(&mesh_proto.CircuitBreaker{}, &CircuitBreakerList{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: GroupVersion.String(),
 			Kind:       "CircuitBreakerList",

--- a/pkg/plugins/resources/k8s/native/api/v1alpha1/dataplane_insight_types_helpers.go
+++ b/pkg/plugins/resources/k8s/native/api/v1alpha1/dataplane_insight_types_helpers.go
@@ -3,7 +3,7 @@ package v1alpha1
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
+	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	"github.com/kumahq/kuma/pkg/plugins/resources/k8s/native/pkg/model"
 	"github.com/kumahq/kuma/pkg/plugins/resources/k8s/native/pkg/registry"
 )
@@ -45,13 +45,13 @@ func (l *DataplaneInsightList) GetItems() []model.KubernetesObject {
 }
 
 func init() {
-	registry.RegisterObjectType(&proto.DataplaneInsight{}, &DataplaneInsight{
+	registry.RegisterObjectType(&mesh_proto.DataplaneInsight{}, &DataplaneInsight{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: GroupVersion.String(),
 			Kind:       "DataplaneInsight",
 		},
 	})
-	registry.RegisterListType(&proto.DataplaneInsight{}, &DataplaneInsightList{
+	registry.RegisterListType(&mesh_proto.DataplaneInsight{}, &DataplaneInsightList{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: GroupVersion.String(),
 			Kind:       "DataplaneInsightList",

--- a/pkg/plugins/resources/k8s/native/api/v1alpha1/dataplane_types_helpers.go
+++ b/pkg/plugins/resources/k8s/native/api/v1alpha1/dataplane_types_helpers.go
@@ -3,7 +3,7 @@ package v1alpha1
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
+	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	"github.com/kumahq/kuma/pkg/plugins/resources/k8s/native/pkg/model"
 	"github.com/kumahq/kuma/pkg/plugins/resources/k8s/native/pkg/registry"
 )
@@ -45,13 +45,13 @@ func (l *Dataplane) Scope() model.Scope {
 }
 
 func init() {
-	registry.RegisterObjectType(&proto.Dataplane{}, &Dataplane{
+	registry.RegisterObjectType(&mesh_proto.Dataplane{}, &Dataplane{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: GroupVersion.String(),
 			Kind:       "Dataplane",
 		},
 	})
-	registry.RegisterListType(&proto.Dataplane{}, &DataplaneList{
+	registry.RegisterListType(&mesh_proto.Dataplane{}, &DataplaneList{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: GroupVersion.String(),
 			Kind:       "DataplaneList",

--- a/pkg/plugins/resources/k8s/native/api/v1alpha1/externalservice_types_helpers.go
+++ b/pkg/plugins/resources/k8s/native/api/v1alpha1/externalservice_types_helpers.go
@@ -3,7 +3,7 @@ package v1alpha1
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
+	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	"github.com/kumahq/kuma/pkg/plugins/resources/k8s/native/pkg/model"
 	"github.com/kumahq/kuma/pkg/plugins/resources/k8s/native/pkg/registry"
 )
@@ -45,13 +45,13 @@ func (l *ExternalService) Scope() model.Scope {
 }
 
 func init() {
-	registry.RegisterObjectType(&proto.ExternalService{}, &ExternalService{
+	registry.RegisterObjectType(&mesh_proto.ExternalService{}, &ExternalService{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: GroupVersion.String(),
 			Kind:       "ExternalService",
 		},
 	})
-	registry.RegisterListType(&proto.ExternalService{}, &ExternalServiceList{
+	registry.RegisterListType(&mesh_proto.ExternalService{}, &ExternalServiceList{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: GroupVersion.String(),
 			Kind:       "ExternalServiceList",

--- a/pkg/plugins/resources/k8s/native/api/v1alpha1/faultinjection_types_helpers.go
+++ b/pkg/plugins/resources/k8s/native/api/v1alpha1/faultinjection_types_helpers.go
@@ -3,7 +3,7 @@ package v1alpha1
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
+	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	"github.com/kumahq/kuma/pkg/plugins/resources/k8s/native/pkg/model"
 	"github.com/kumahq/kuma/pkg/plugins/resources/k8s/native/pkg/registry"
 )
@@ -45,13 +45,13 @@ func (l *FaultInjectionList) GetItems() []model.KubernetesObject {
 }
 
 func init() {
-	registry.RegisterObjectType(&proto.FaultInjection{}, &FaultInjection{
+	registry.RegisterObjectType(&mesh_proto.FaultInjection{}, &FaultInjection{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: GroupVersion.String(),
 			Kind:       "FaultInjection",
 		},
 	})
-	registry.RegisterListType(&proto.FaultInjection{}, &FaultInjectionList{
+	registry.RegisterListType(&mesh_proto.FaultInjection{}, &FaultInjectionList{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: GroupVersion.String(),
 			Kind:       "FaultInjectionList",

--- a/pkg/plugins/resources/k8s/native/api/v1alpha1/healthcheck_types_helpers.go
+++ b/pkg/plugins/resources/k8s/native/api/v1alpha1/healthcheck_types_helpers.go
@@ -3,7 +3,7 @@ package v1alpha1
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
+	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	"github.com/kumahq/kuma/pkg/plugins/resources/k8s/native/pkg/model"
 	"github.com/kumahq/kuma/pkg/plugins/resources/k8s/native/pkg/registry"
 )
@@ -45,13 +45,13 @@ func (l *HealthCheckList) GetItems() []model.KubernetesObject {
 }
 
 func init() {
-	registry.RegisterObjectType(&proto.HealthCheck{}, &HealthCheck{
+	registry.RegisterObjectType(&mesh_proto.HealthCheck{}, &HealthCheck{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: GroupVersion.String(),
 			Kind:       "HealthCheck",
 		},
 	})
-	registry.RegisterListType(&proto.HealthCheck{}, &HealthCheckList{
+	registry.RegisterListType(&mesh_proto.HealthCheck{}, &HealthCheckList{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: GroupVersion.String(),
 			Kind:       "HealthCheckList",

--- a/pkg/plugins/resources/k8s/native/api/v1alpha1/mesh_insight_types_helpers.go
+++ b/pkg/plugins/resources/k8s/native/api/v1alpha1/mesh_insight_types_helpers.go
@@ -3,7 +3,7 @@ package v1alpha1
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
+	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	"github.com/kumahq/kuma/pkg/plugins/resources/k8s/native/pkg/model"
 	"github.com/kumahq/kuma/pkg/plugins/resources/k8s/native/pkg/registry"
 )
@@ -45,13 +45,13 @@ func (in *MeshInsightList) GetItems() []model.KubernetesObject {
 }
 
 func init() {
-	registry.RegisterObjectType(&proto.MeshInsight{}, &MeshInsight{
+	registry.RegisterObjectType(&mesh_proto.MeshInsight{}, &MeshInsight{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: GroupVersion.String(),
 			Kind:       "MeshInsight",
 		},
 	})
-	registry.RegisterListType(&proto.MeshInsight{}, &MeshInsightList{
+	registry.RegisterListType(&mesh_proto.MeshInsight{}, &MeshInsightList{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: GroupVersion.String(),
 			Kind:       "MeshInsightList",

--- a/pkg/plugins/resources/k8s/native/api/v1alpha1/mesh_types_helpers.go
+++ b/pkg/plugins/resources/k8s/native/api/v1alpha1/mesh_types_helpers.go
@@ -3,7 +3,7 @@ package v1alpha1
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
+	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	"github.com/kumahq/kuma/pkg/plugins/resources/k8s/native/pkg/model"
 	"github.com/kumahq/kuma/pkg/plugins/resources/k8s/native/pkg/registry"
 )
@@ -45,13 +45,13 @@ func (l *MeshList) GetItems() []model.KubernetesObject {
 }
 
 func init() {
-	registry.RegisterObjectType(&proto.Mesh{}, &Mesh{
+	registry.RegisterObjectType(&mesh_proto.Mesh{}, &Mesh{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: GroupVersion.String(),
 			Kind:       "Mesh",
 		},
 	})
-	registry.RegisterListType(&proto.Mesh{}, &MeshList{
+	registry.RegisterListType(&mesh_proto.Mesh{}, &MeshList{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: GroupVersion.String(),
 			Kind:       "MeshList",

--- a/pkg/plugins/resources/k8s/native/api/v1alpha1/proxytemplate_types_helpers.go
+++ b/pkg/plugins/resources/k8s/native/api/v1alpha1/proxytemplate_types_helpers.go
@@ -3,7 +3,7 @@ package v1alpha1
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
+	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	"github.com/kumahq/kuma/pkg/plugins/resources/k8s/native/pkg/model"
 	"github.com/kumahq/kuma/pkg/plugins/resources/k8s/native/pkg/registry"
 )
@@ -45,13 +45,13 @@ func (l *ProxyTemplateList) GetItems() []model.KubernetesObject {
 }
 
 func init() {
-	registry.RegisterObjectType(&proto.ProxyTemplate{}, &ProxyTemplate{
+	registry.RegisterObjectType(&mesh_proto.ProxyTemplate{}, &ProxyTemplate{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: GroupVersion.String(),
 			Kind:       "ProxyTemplate",
 		},
 	})
-	registry.RegisterListType(&proto.ProxyTemplate{}, &ProxyTemplateList{
+	registry.RegisterListType(&mesh_proto.ProxyTemplate{}, &ProxyTemplateList{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: GroupVersion.String(),
 			Kind:       "ProxyTemplateList",

--- a/pkg/plugins/resources/k8s/native/api/v1alpha1/ratelimit_types_helpers.go
+++ b/pkg/plugins/resources/k8s/native/api/v1alpha1/ratelimit_types_helpers.go
@@ -3,7 +3,7 @@ package v1alpha1
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
+	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	"github.com/kumahq/kuma/pkg/plugins/resources/k8s/native/pkg/model"
 	"github.com/kumahq/kuma/pkg/plugins/resources/k8s/native/pkg/registry"
 )
@@ -45,13 +45,13 @@ func (l *RateLimitList) GetItems() []model.KubernetesObject {
 }
 
 func init() {
-	registry.RegisterObjectType(&proto.RateLimit{}, &RateLimit{
+	registry.RegisterObjectType(&mesh_proto.RateLimit{}, &RateLimit{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: GroupVersion.String(),
 			Kind:       "RateLimit",
 		},
 	})
-	registry.RegisterListType(&proto.RateLimit{}, &RateLimitList{
+	registry.RegisterListType(&mesh_proto.RateLimit{}, &RateLimitList{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: GroupVersion.String(),
 			Kind:       "RateLimitList",

--- a/pkg/plugins/resources/k8s/native/api/v1alpha1/retry_types_helpers.go
+++ b/pkg/plugins/resources/k8s/native/api/v1alpha1/retry_types_helpers.go
@@ -3,7 +3,7 @@ package v1alpha1
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
+	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	"github.com/kumahq/kuma/pkg/plugins/resources/k8s/native/pkg/model"
 	"github.com/kumahq/kuma/pkg/plugins/resources/k8s/native/pkg/registry"
 )
@@ -45,13 +45,13 @@ func (l *RetryList) GetItems() []model.KubernetesObject {
 }
 
 func init() {
-	registry.RegisterObjectType(&proto.Retry{}, &Retry{
+	registry.RegisterObjectType(&mesh_proto.Retry{}, &Retry{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: GroupVersion.String(),
 			Kind:       "Retry",
 		},
 	})
-	registry.RegisterListType(&proto.Retry{}, &RetryList{
+	registry.RegisterListType(&mesh_proto.Retry{}, &RetryList{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: GroupVersion.String(),
 			Kind:       "RetryList",

--- a/pkg/plugins/resources/k8s/native/api/v1alpha1/service_insight_types_helpers.go
+++ b/pkg/plugins/resources/k8s/native/api/v1alpha1/service_insight_types_helpers.go
@@ -3,7 +3,7 @@ package v1alpha1
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
+	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	"github.com/kumahq/kuma/pkg/plugins/resources/k8s/native/pkg/model"
 	"github.com/kumahq/kuma/pkg/plugins/resources/k8s/native/pkg/registry"
 )
@@ -45,13 +45,13 @@ func (in *ServiceInsightList) GetItems() []model.KubernetesObject {
 }
 
 func init() {
-	registry.RegisterObjectType(&proto.ServiceInsight{}, &ServiceInsight{
+	registry.RegisterObjectType(&mesh_proto.ServiceInsight{}, &ServiceInsight{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: GroupVersion.String(),
 			Kind:       "ServiceInsight",
 		},
 	})
-	registry.RegisterListType(&proto.ServiceInsight{}, &ServiceInsightList{
+	registry.RegisterListType(&mesh_proto.ServiceInsight{}, &ServiceInsightList{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: GroupVersion.String(),
 			Kind:       "ServiceInsightList",

--- a/pkg/plugins/resources/k8s/native/api/v1alpha1/timeout_types_helpers.go
+++ b/pkg/plugins/resources/k8s/native/api/v1alpha1/timeout_types_helpers.go
@@ -3,7 +3,7 @@ package v1alpha1
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
+	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	"github.com/kumahq/kuma/pkg/plugins/resources/k8s/native/pkg/model"
 	"github.com/kumahq/kuma/pkg/plugins/resources/k8s/native/pkg/registry"
 )
@@ -45,13 +45,13 @@ func (l *TimeoutList) GetItems() []model.KubernetesObject {
 }
 
 func init() {
-	registry.RegisterObjectType(&proto.Timeout{}, &Timeout{
+	registry.RegisterObjectType(&mesh_proto.Timeout{}, &Timeout{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: GroupVersion.String(),
 			Kind:       "Timeout",
 		},
 	})
-	registry.RegisterListType(&proto.Timeout{}, &TimeoutList{
+	registry.RegisterListType(&mesh_proto.Timeout{}, &TimeoutList{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: GroupVersion.String(),
 			Kind:       "TimeoutList",

--- a/pkg/plugins/resources/k8s/native/api/v1alpha1/trafficlogging_types_helpers.go
+++ b/pkg/plugins/resources/k8s/native/api/v1alpha1/trafficlogging_types_helpers.go
@@ -3,7 +3,7 @@ package v1alpha1
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
+	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	"github.com/kumahq/kuma/pkg/plugins/resources/k8s/native/pkg/model"
 	"github.com/kumahq/kuma/pkg/plugins/resources/k8s/native/pkg/registry"
 )
@@ -45,13 +45,13 @@ func (l *TrafficLogList) GetItems() []model.KubernetesObject {
 }
 
 func init() {
-	registry.RegisterObjectType(&proto.TrafficLog{}, &TrafficLog{
+	registry.RegisterObjectType(&mesh_proto.TrafficLog{}, &TrafficLog{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: GroupVersion.String(),
 			Kind:       "TrafficLog",
 		},
 	})
-	registry.RegisterListType(&proto.TrafficLog{}, &TrafficLogList{
+	registry.RegisterListType(&mesh_proto.TrafficLog{}, &TrafficLogList{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: GroupVersion.String(),
 			Kind:       "TrafficLogList",

--- a/pkg/plugins/resources/k8s/native/api/v1alpha1/trafficpermission_types_helpers.go
+++ b/pkg/plugins/resources/k8s/native/api/v1alpha1/trafficpermission_types_helpers.go
@@ -3,7 +3,7 @@ package v1alpha1
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
+	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	"github.com/kumahq/kuma/pkg/plugins/resources/k8s/native/pkg/model"
 	"github.com/kumahq/kuma/pkg/plugins/resources/k8s/native/pkg/registry"
 )
@@ -45,13 +45,13 @@ func (l *TrafficPermissionList) GetItems() []model.KubernetesObject {
 }
 
 func init() {
-	registry.RegisterObjectType(&proto.TrafficPermission{}, &TrafficPermission{
+	registry.RegisterObjectType(&mesh_proto.TrafficPermission{}, &TrafficPermission{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: GroupVersion.String(),
 			Kind:       "TrafficPermission",
 		},
 	})
-	registry.RegisterListType(&proto.TrafficPermission{}, &TrafficPermissionList{
+	registry.RegisterListType(&mesh_proto.TrafficPermission{}, &TrafficPermissionList{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: GroupVersion.String(),
 			Kind:       "TrafficPermissionList",

--- a/pkg/plugins/resources/k8s/native/api/v1alpha1/trafficroute_types_helpers.go
+++ b/pkg/plugins/resources/k8s/native/api/v1alpha1/trafficroute_types_helpers.go
@@ -3,7 +3,7 @@ package v1alpha1
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
+	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	"github.com/kumahq/kuma/pkg/plugins/resources/k8s/native/pkg/model"
 	"github.com/kumahq/kuma/pkg/plugins/resources/k8s/native/pkg/registry"
 )
@@ -45,13 +45,13 @@ func (l *TrafficRouteList) GetItems() []model.KubernetesObject {
 }
 
 func init() {
-	registry.RegisterObjectType(&proto.TrafficRoute{}, &TrafficRoute{
+	registry.RegisterObjectType(&mesh_proto.TrafficRoute{}, &TrafficRoute{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: GroupVersion.String(),
 			Kind:       "TrafficRoute",
 		},
 	})
-	registry.RegisterListType(&proto.TrafficRoute{}, &TrafficRouteList{
+	registry.RegisterListType(&mesh_proto.TrafficRoute{}, &TrafficRouteList{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: GroupVersion.String(),
 			Kind:       "TrafficRouteList",

--- a/pkg/plugins/resources/k8s/native/api/v1alpha1/traffictrace_types_helpers.go
+++ b/pkg/plugins/resources/k8s/native/api/v1alpha1/traffictrace_types_helpers.go
@@ -3,7 +3,7 @@ package v1alpha1
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
+	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	"github.com/kumahq/kuma/pkg/plugins/resources/k8s/native/pkg/model"
 	"github.com/kumahq/kuma/pkg/plugins/resources/k8s/native/pkg/registry"
 )
@@ -45,13 +45,13 @@ func (l *TrafficTraceList) GetItems() []model.KubernetesObject {
 }
 
 func init() {
-	registry.RegisterObjectType(&proto.TrafficTrace{}, &TrafficTrace{
+	registry.RegisterObjectType(&mesh_proto.TrafficTrace{}, &TrafficTrace{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: GroupVersion.String(),
 			Kind:       "TrafficTrace",
 		},
 	})
-	registry.RegisterListType(&proto.TrafficTrace{}, &TrafficTraceList{
+	registry.RegisterListType(&mesh_proto.TrafficTrace{}, &TrafficTraceList{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: GroupVersion.String(),
 			Kind:       "TrafficTraceList",

--- a/pkg/plugins/resources/k8s/native/api/v1alpha1/zone_ingress_insight_types_helpers.go
+++ b/pkg/plugins/resources/k8s/native/api/v1alpha1/zone_ingress_insight_types_helpers.go
@@ -3,7 +3,7 @@ package v1alpha1
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
+	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	"github.com/kumahq/kuma/pkg/plugins/resources/k8s/native/pkg/model"
 	"github.com/kumahq/kuma/pkg/plugins/resources/k8s/native/pkg/registry"
 )
@@ -45,13 +45,13 @@ func (l *ZoneIngressInsightList) GetItems() []model.KubernetesObject {
 }
 
 func init() {
-	registry.RegisterObjectType(&proto.ZoneIngressInsight{}, &ZoneIngressInsight{
+	registry.RegisterObjectType(&mesh_proto.ZoneIngressInsight{}, &ZoneIngressInsight{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: GroupVersion.String(),
 			Kind:       "ZoneIngressInsight",
 		},
 	})
-	registry.RegisterListType(&proto.ZoneIngressInsight{}, &ZoneIngressInsightList{
+	registry.RegisterListType(&mesh_proto.ZoneIngressInsight{}, &ZoneIngressInsightList{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: GroupVersion.String(),
 			Kind:       "ZoneIngressInsightList",

--- a/pkg/plugins/resources/k8s/native/api/v1alpha1/zone_ingress_types_helpers.go
+++ b/pkg/plugins/resources/k8s/native/api/v1alpha1/zone_ingress_types_helpers.go
@@ -3,7 +3,7 @@ package v1alpha1
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
+	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	"github.com/kumahq/kuma/pkg/plugins/resources/k8s/native/pkg/model"
 	"github.com/kumahq/kuma/pkg/plugins/resources/k8s/native/pkg/registry"
 )
@@ -45,13 +45,13 @@ func (l *ZoneIngressList) GetItems() []model.KubernetesObject {
 }
 
 func init() {
-	registry.RegisterObjectType(&proto.ZoneIngress{}, &ZoneIngress{
+	registry.RegisterObjectType(&mesh_proto.ZoneIngress{}, &ZoneIngress{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: GroupVersion.String(),
 			Kind:       "ZoneIngress",
 		},
 	})
-	registry.RegisterListType(&proto.ZoneIngress{}, &ZoneIngressList{
+	registry.RegisterListType(&mesh_proto.ZoneIngress{}, &ZoneIngressList{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: GroupVersion.String(),
 			Kind:       "ZoneIngressList",

--- a/pkg/plugins/runtime/k8s/controllers/inbound_converter.go
+++ b/pkg/plugins/runtime/k8s/controllers/inbound_converter.go
@@ -8,7 +8,7 @@ import (
 	kube_core "k8s.io/api/core/v1"
 
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
-	mesh_core "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
+	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	util_k8s "github.com/kumahq/kuma/pkg/plugins/runtime/k8s/util"
 )
 
@@ -160,7 +160,7 @@ func ProtocolTagFor(svc *kube_core.Service, svcPort *kube_core.ServicePort) stri
 	if protocolValue == "" {
 		// if `appProtocol` or `<port>.service.kuma.io/protocol` is missing or has an empty value
 		// we want Dataplane to have a `protocol: tcp` tag in order to get user's attention
-		return mesh_core.ProtocolTCP
+		return core_mesh.ProtocolTCP
 	}
 	// if `appProtocol` or `<port>.service.kuma.io/protocol` field is present but has an invalid value
 	// we still want Dataplane to have a `protocol: <value as is>` tag in order to make it clear
@@ -182,7 +182,7 @@ func InboundTagsForPod(zone string, pod *kube_core.Pod) map[string]string {
 	if zone != "" {
 		tags[mesh_proto.ZoneTag] = zone
 	}
-	tags[mesh_proto.ProtocolTag] = mesh_core.ProtocolTCP
+	tags[mesh_proto.ProtocolTag] = core_mesh.ProtocolTCP
 	tags[mesh_proto.InstanceTag] = pod.Name
 
 	return tags

--- a/pkg/plugins/runtime/k8s/controllers/mesh_controller.go
+++ b/pkg/plugins/runtime/k8s/controllers/mesh_controller.go
@@ -13,7 +13,7 @@ import (
 
 	core_ca "github.com/kumahq/kuma/pkg/core/ca"
 	core_managers "github.com/kumahq/kuma/pkg/core/managers/apis/mesh"
-	mesh_core "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
+	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	"github.com/kumahq/kuma/pkg/core/resources/manager"
 	"github.com/kumahq/kuma/pkg/core/resources/store"
 	k8s_common "github.com/kumahq/kuma/pkg/plugins/common/k8s"
@@ -43,7 +43,7 @@ func (r *MeshReconciler) Reconcile(req kube_ctrl.Request) (kube_ctrl.Result, err
 		if kube_apierrs.IsNotFound(err) {
 			// Force delete associated resources. It will return an error ErrorResourceNotFound because Mesh was already deleted but we still need to cleanup resources
 			// Remove this part after https://github.com/kumahq/kuma/issues/1137 is implemented.
-			err := r.ResourceManager.Delete(ctx, mesh_core.NewMeshResource(), store.DeleteByKey(req.Name, req.Name))
+			err := r.ResourceManager.Delete(ctx, core_mesh.NewMeshResource(), store.DeleteByKey(req.Name, req.Name))
 			if err == nil || store.IsResourceNotFound(err) {
 				return kube_ctrl.Result{}, nil
 			}
@@ -53,7 +53,7 @@ func (r *MeshReconciler) Reconcile(req kube_ctrl.Request) (kube_ctrl.Result, err
 		return kube_ctrl.Result{}, err
 	}
 
-	meshResource := mesh_core.NewMeshResource()
+	meshResource := core_mesh.NewMeshResource()
 	if err := r.Converter.ToCoreResource(mesh, meshResource); err != nil {
 		log.Error(err, "unable to convert Mesh k8s object into core model")
 		return kube_ctrl.Result{}, err

--- a/pkg/plugins/runtime/k8s/plugin.go
+++ b/pkg/plugins/runtime/k8s/plugin.go
@@ -14,7 +14,7 @@ import (
 	managers_mesh "github.com/kumahq/kuma/pkg/core/managers/apis/mesh"
 	"github.com/kumahq/kuma/pkg/core/managers/apis/zone"
 	core_plugins "github.com/kumahq/kuma/pkg/core/plugins"
-	mesh_core "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
+	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	core_model "github.com/kumahq/kuma/pkg/core/resources/model"
 	core_registry "github.com/kumahq/kuma/pkg/core/resources/registry"
 	core_runtime "github.com/kumahq/kuma/pkg/core/runtime"
@@ -208,7 +208,7 @@ func addDefaulters(mgr kube_ctrl.Manager, converter k8s_common.Converter) error 
 
 	addDefaulter(mgr, mesh_k8s.GroupVersion.WithKind("Mesh"),
 		func() core_model.Resource {
-			return mesh_core.NewMeshResource()
+			return core_mesh.NewMeshResource()
 		}, converter)
 
 	return nil

--- a/pkg/plugins/runtime/k8s/webhooks/injector/injector.go
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/injector.go
@@ -17,7 +17,7 @@ import (
 
 	runtime_k8s "github.com/kumahq/kuma/pkg/config/plugins/runtime/k8s"
 	"github.com/kumahq/kuma/pkg/core"
-	mesh_core "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
+	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	core_model "github.com/kumahq/kuma/pkg/core/resources/model"
 	k8s_common "github.com/kumahq/kuma/pkg/plugins/common/k8s"
 	mesh_k8s "github.com/kumahq/kuma/pkg/plugins/resources/k8s/native/api/v1alpha1"
@@ -172,13 +172,13 @@ func meshName(pod *kube_core.Pod, ns *kube_core.Namespace) string {
 	return core_model.DefaultMesh
 }
 
-func (i *KumaInjector) meshFor(pod *kube_core.Pod, ns *kube_core.Namespace) (*mesh_core.MeshResource, error) {
+func (i *KumaInjector) meshFor(pod *kube_core.Pod, ns *kube_core.Namespace) (*core_mesh.MeshResource, error) {
 	meshName := meshName(pod, ns)
 	mesh := &mesh_k8s.Mesh{}
 	if err := i.client.Get(context.Background(), kube_types.NamespacedName{Name: meshName}, mesh); err != nil {
 		return nil, err
 	}
-	meshResource := mesh_core.NewMeshResource()
+	meshResource := core_mesh.NewMeshResource()
 	if err := i.converter.ToCoreResource(mesh, meshResource); err != nil {
 		return nil, err
 	}
@@ -440,7 +440,7 @@ func (i *KumaInjector) NewInitContainer(pod *kube_core.Pod) (kube_core.Container
 	}, nil
 }
 
-func (i *KumaInjector) NewAnnotations(pod *kube_core.Pod, mesh *mesh_core.MeshResource) (map[string]string, error) {
+func (i *KumaInjector) NewAnnotations(pod *kube_core.Pod, mesh *core_mesh.MeshResource) (map[string]string, error) {
 	annotations := map[string]string{
 		metadata.KumaMeshAnnotation:                             mesh.GetMeta().GetName(), // either user-defined value or default
 		metadata.KumaSidecarInjectedAnnotation:                  fmt.Sprintf("%t", true),

--- a/pkg/plugins/runtime/k8s/webhooks/mesh_validator.go
+++ b/pkg/plugins/runtime/k8s/webhooks/mesh_validator.go
@@ -8,7 +8,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	managers_mesh "github.com/kumahq/kuma/pkg/core/managers/apis/mesh"
-	mesh_core "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
+	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	"github.com/kumahq/kuma/pkg/core/resources/manager"
 	"github.com/kumahq/kuma/pkg/core/validators"
 	k8s_common "github.com/kumahq/kuma/pkg/plugins/common/k8s"
@@ -55,7 +55,7 @@ func (h *MeshValidator) ValidateDelete(ctx context.Context, req admission.Reques
 }
 
 func (h *MeshValidator) ValidateCreate(ctx context.Context, req admission.Request) admission.Response {
-	coreRes := mesh_core.NewMeshResource()
+	coreRes := core_mesh.NewMeshResource()
 	k8sRes := &mesh_k8s.Mesh{}
 	if err := h.decoder.Decode(req, k8sRes); err != nil {
 		return admission.Errored(http.StatusBadRequest, err)
@@ -73,7 +73,7 @@ func (h *MeshValidator) ValidateCreate(ctx context.Context, req admission.Reques
 }
 
 func (h *MeshValidator) ValidateUpdate(ctx context.Context, req admission.Request) admission.Response {
-	coreRes := mesh_core.NewMeshResource()
+	coreRes := core_mesh.NewMeshResource()
 	k8sRes := &mesh_k8s.Mesh{}
 	if err := h.decoder.DecodeRaw(req.Object, k8sRes); err != nil {
 		return admission.Errored(http.StatusBadRequest, err)
@@ -82,7 +82,7 @@ func (h *MeshValidator) ValidateUpdate(ctx context.Context, req admission.Reques
 		return admission.Errored(http.StatusInternalServerError, err)
 	}
 
-	oldCoreRes := mesh_core.NewMeshResource()
+	oldCoreRes := core_mesh.NewMeshResource()
 	oldK8sRes := &mesh_k8s.Mesh{}
 	if err := h.decoder.DecodeRaw(req.OldObject, oldK8sRes); err != nil {
 		return admission.Errored(http.StatusBadRequest, err)

--- a/pkg/plugins/runtime/k8s/webhooks/service_validator.go
+++ b/pkg/plugins/runtime/k8s/webhooks/service_validator.go
@@ -8,7 +8,7 @@ import (
 	kube_core "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
-	mesh_core "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
+	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	"github.com/kumahq/kuma/pkg/core/validators"
 )
 
@@ -41,9 +41,9 @@ func (v *ServiceValidator) validate(svc *kube_core.Service) error {
 	for _, svcPort := range svc.Spec.Ports {
 		protocolAnnotation := fmt.Sprintf("%d.service.kuma.io/protocol", svcPort.Port)
 		protocolAnnotationValue, exists := svc.Annotations[protocolAnnotation]
-		if exists && mesh_core.ParseProtocol(protocolAnnotationValue) == mesh_core.ProtocolUnknown {
+		if exists && core_mesh.ParseProtocol(protocolAnnotationValue) == core_mesh.ProtocolUnknown {
 			verr.AddViolationAt(validators.RootedAt("metadata").Field("annotations").Key(protocolAnnotation),
-				fmt.Sprintf("value %q is not valid. %s", protocolAnnotationValue, mesh_core.AllowedValuesHint(mesh_core.SupportedProtocols.Strings()...)))
+				fmt.Sprintf("value %q is not valid. %s", protocolAnnotationValue, core_mesh.AllowedValuesHint(core_mesh.SupportedProtocols.Strings()...)))
 		}
 	}
 	return verr.OrNil()

--- a/pkg/sds/server/v3/reconciler.go
+++ b/pkg/sds/server/v3/reconciler.go
@@ -16,7 +16,7 @@ import (
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	"github.com/kumahq/kuma/pkg/config/core/resources/store"
 	"github.com/kumahq/kuma/pkg/core"
-	mesh_core "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
+	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	core_manager "github.com/kumahq/kuma/pkg/core/resources/manager"
 	core_model "github.com/kumahq/kuma/pkg/core/resources/model"
 	core_store "github.com/kumahq/kuma/pkg/core/resources/store"
@@ -57,7 +57,7 @@ type snapshotInfo struct {
 }
 
 func (d *DataplaneReconciler) Reconcile(proxyId *core_xds.ProxyId) error {
-	dataplane := mesh_core.NewDataplaneResource()
+	dataplane := core_mesh.NewDataplaneResource()
 	if err := d.readOnlyResManager.Get(context.Background(), dataplane, core_store.GetBy(proxyId.ToResourceKey())); err != nil {
 		if core_store.IsResourceNotFound(err) {
 			sdsServerLog.V(1).Info("Dataplane not found. Clearing the Snapshot.", "dataplaneId", proxyId.ToResourceKey())
@@ -69,7 +69,7 @@ func (d *DataplaneReconciler) Reconcile(proxyId *core_xds.ProxyId) error {
 		return err
 	}
 
-	mesh := mesh_core.NewMeshResource()
+	mesh := core_mesh.NewMeshResource()
 	if err := d.readOnlyResManager.Get(context.Background(), mesh, core_store.GetByKey(dataplane.GetMeta().GetMesh(), core_model.NoMesh)); err != nil {
 		return errors.Wrap(err, "could not retrieve a mesh")
 	}
@@ -116,7 +116,7 @@ func (d *DataplaneReconciler) Cleanup(proxyId *core_xds.ProxyId) error {
 	return nil
 }
 
-func (d *DataplaneReconciler) shouldGenerateSnapshot(proxyID string, mesh *mesh_core.MeshResource, dataplane *mesh_core.DataplaneResource) (bool, string, error) {
+func (d *DataplaneReconciler) shouldGenerateSnapshot(proxyID string, mesh *core_mesh.MeshResource, dataplane *core_mesh.DataplaneResource) (bool, string, error) {
 	_, err := d.cache.GetSnapshot(proxyID)
 	if err != nil {
 		return true, "Snapshot does not exist", nil
@@ -150,7 +150,7 @@ func (d *DataplaneReconciler) setSnapshotInfo(proxyID string, info snapshotInfo)
 	d.proxySnapshotInfo[proxyID] = info
 }
 
-func (d *DataplaneReconciler) generateSnapshot(dataplane *mesh_core.DataplaneResource, mesh *mesh_core.MeshResource) (envoy_cache.Snapshot, snapshotInfo, error) {
+func (d *DataplaneReconciler) generateSnapshot(dataplane *core_mesh.DataplaneResource, mesh *core_mesh.MeshResource) (envoy_cache.Snapshot, snapshotInfo, error) {
 	requestor := sds_identity.Identity{
 		Services: dataplane.Spec.TagSet(),
 		Mesh:     dataplane.GetMeta().GetMesh(),
@@ -189,8 +189,8 @@ func (d *DataplaneReconciler) generateSnapshot(dataplane *mesh_core.DataplaneRes
 }
 
 func (d *DataplaneReconciler) updateInsights(dataplaneId core_model.ResourceKey, info snapshotInfo) error {
-	return core_manager.Upsert(d.resManager, dataplaneId, mesh_core.NewDataplaneInsightResource(), func(resource core_model.Resource) {
-		insight := resource.(*mesh_core.DataplaneInsightResource)
+	return core_manager.Upsert(d.resManager, dataplaneId, core_mesh.NewDataplaneInsightResource(), func(resource core_model.Resource) {
+		insight := resource.(*core_mesh.DataplaneInsightResource)
 		if err := insight.Spec.UpdateCert(core.Now(), info.expiration); err != nil {
 			sdsServerLog.Error(err, "could not update the certificate", "dataplaneId", dataplaneId)
 		}

--- a/pkg/sds/server/v3/server_test.go
+++ b/pkg/sds/server/v3/server_test.go
@@ -23,7 +23,7 @@ import (
 	kuma_cp "github.com/kumahq/kuma/pkg/config/app/kuma-cp"
 	dp_server_cfg "github.com/kumahq/kuma/pkg/config/dp-server"
 	"github.com/kumahq/kuma/pkg/core"
-	mesh_core "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
+	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	core_manager "github.com/kumahq/kuma/pkg/core/resources/manager"
 	"github.com/kumahq/kuma/pkg/core/resources/model"
 	core_store "github.com/kumahq/kuma/pkg/core/resources/store"
@@ -73,7 +73,7 @@ var _ = Describe("SDS Server", func() {
 		resManager = runtime.ResourceManager()
 
 		// setup default mesh with active mTLS and 2 CA
-		meshRes := mesh_core.MeshResource{
+		meshRes := core_mesh.MeshResource{
 			Spec: &mesh_proto.Mesh{
 				Mtls: &mesh_proto.Mesh_Mtls{
 					EnabledBackend: "ca-1",
@@ -104,7 +104,7 @@ var _ = Describe("SDS Server", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		// setup backend dataplane
-		dpRes := mesh_core.DataplaneResource{
+		dpRes := core_mesh.DataplaneResource{
 			Spec: &mesh_proto.Dataplane{
 				Networking: &mesh_proto.Dataplane_Networking{
 					Address: "192.168.0.1",
@@ -167,7 +167,7 @@ var _ = Describe("SDS Server", func() {
 
 	BeforeEach(func() {
 		// make sure no insight is present
-		err := resManager.Delete(context.Background(), mesh_core.NewDataplaneInsightResource(), core_store.DeleteByKey("backend-01", "default"))
+		err := resManager.Delete(context.Background(), core_mesh.NewDataplaneInsightResource(), core_store.DeleteByKey("backend-01", "default"))
 		if !core_store.IsResourceNotFound(err) {
 			Expect(err).ToNot(HaveOccurred())
 		}
@@ -211,7 +211,7 @@ var _ = Describe("SDS Server", func() {
 
 		// and insight is generated (insight is updated async, to does not have to be done before response is sent)
 		Eventually(func() error {
-			dpInsight := mesh_core.NewDataplaneInsightResource()
+			dpInsight := core_mesh.NewDataplaneInsightResource()
 			err := resManager.Get(context.Background(), dpInsight, core_store.GetByKey("backend-01", "default"))
 			if err != nil {
 				return err
@@ -265,7 +265,7 @@ var _ = Describe("SDS Server", func() {
 
 			// and wait for the insight
 			Eventually(func() error {
-				return resManager.Get(context.Background(), mesh_core.NewDataplaneInsightResource(), core_store.GetByKey("backend-01", "default"))
+				return resManager.Get(context.Background(), core_mesh.NewDataplaneInsightResource(), core_store.GetByKey("backend-01", "default"))
 			}, "30s", "1s").ShouldNot(HaveOccurred())
 		}))
 
@@ -275,7 +275,7 @@ var _ = Describe("SDS Server", func() {
 
 		It("should return pair when CA is changed", test.Within(time.Minute, func() {
 			// when
-			meshRes := mesh_core.NewMeshResource()
+			meshRes := core_mesh.NewMeshResource()
 			Expect(resManager.Get(context.Background(), meshRes, core_store.GetByKey(model.DefaultMesh, model.NoMesh))).To(Succeed())
 			meshRes.Spec.Mtls.EnabledBackend = "" // we need to first disable mTLS
 			Expect(resManager.Update(context.Background(), meshRes)).To(Succeed())
@@ -297,7 +297,7 @@ var _ = Describe("SDS Server", func() {
 
 			// and insight is generated (insight is updated async, to does not have to be done before response is sent)
 			Eventually(func() error {
-				dpInsight := mesh_core.NewDataplaneInsightResource()
+				dpInsight := core_mesh.NewDataplaneInsightResource()
 				err := resManager.Get(context.Background(), dpInsight, core_store.GetByKey("backend-01", "default"))
 				if err != nil {
 					return err
@@ -331,7 +331,7 @@ var _ = Describe("SDS Server", func() {
 
 		It("should return a new pair when dataplane has changed", test.Within(time.Minute, func() {
 			// when
-			dpRes := mesh_core.NewDataplaneResource()
+			dpRes := core_mesh.NewDataplaneResource()
 			Expect(resManager.Get(context.Background(), dpRes, core_store.GetByKey("backend-01", "default"))).To(Succeed())
 			dpRes.Spec.Networking.Inbound[0].Tags["version"] = "xyz"
 

--- a/pkg/xds/context/context.go
+++ b/pkg/xds/context/context.go
@@ -4,7 +4,7 @@ import (
 	"io/ioutil"
 
 	kuma_cp "github.com/kumahq/kuma/pkg/config/app/kuma-cp"
-	mesh_core "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
+	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	"github.com/kumahq/kuma/pkg/core/xds"
 	"github.com/kumahq/kuma/pkg/dns/resolver"
 	"github.com/kumahq/kuma/pkg/envoy/admin"
@@ -36,8 +36,8 @@ func (c Context) SDSLocation() string {
 }
 
 type MeshContext struct {
-	Resource   *mesh_core.MeshResource
-	Dataplanes *mesh_core.DataplaneResourceList
+	Resource   *core_mesh.MeshResource
+	Dataplanes *core_mesh.DataplaneResourceList
 	Hash       string
 }
 

--- a/pkg/xds/envoy/clusters/configurers.go
+++ b/pkg/xds/envoy/clusters/configurers.go
@@ -2,7 +2,7 @@ package clusters
 
 import (
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
-	mesh_core "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
+	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	core_xds "github.com/kumahq/kuma/pkg/core/xds"
 	xds_context "github.com/kumahq/kuma/pkg/xds/context"
 	"github.com/kumahq/kuma/pkg/xds/envoy"
@@ -10,13 +10,13 @@ import (
 	endpoints_v3 "github.com/kumahq/kuma/pkg/xds/envoy/endpoints/v3"
 )
 
-func OutlierDetection(circuitBreaker *mesh_core.CircuitBreakerResource) ClusterBuilderOpt {
+func OutlierDetection(circuitBreaker *core_mesh.CircuitBreakerResource) ClusterBuilderOpt {
 	return ClusterBuilderOptFunc(func(config *ClusterBuilderConfig) {
 		config.AddV3(&v3.OutlierDetectionConfigurer{CircuitBreaker: circuitBreaker})
 	})
 }
 
-func CircuitBreaker(circuitBreaker *mesh_core.CircuitBreakerResource) ClusterBuilderOpt {
+func CircuitBreaker(circuitBreaker *core_mesh.CircuitBreakerResource) ClusterBuilderOpt {
 	return ClusterBuilderOptFunc(func(config *ClusterBuilderConfig) {
 		config.AddV3(&v3.CircuitBreakerConfigurer{CircuitBreaker: circuitBreaker})
 	})
@@ -74,7 +74,7 @@ func EdsCluster(name string) ClusterBuilderOpt {
 	})
 }
 
-func HealthCheck(protocol mesh_core.Protocol, healthCheck *mesh_core.HealthCheckResource) ClusterBuilderOpt {
+func HealthCheck(protocol core_mesh.Protocol, healthCheck *core_mesh.HealthCheckResource) ClusterBuilderOpt {
 	return ClusterBuilderOptFunc(func(config *ClusterBuilderConfig) {
 		config.AddV3(&v3.HealthCheckConfigurer{
 			HealthCheck: healthCheck,
@@ -115,7 +115,7 @@ func LB(lb *mesh_proto.TrafficRoute_LoadBalancer) ClusterBuilderOpt {
 	})
 }
 
-func Timeout(protocol mesh_core.Protocol, conf *mesh_proto.Timeout_Conf) ClusterBuilderOpt {
+func Timeout(protocol core_mesh.Protocol, conf *mesh_proto.Timeout_Conf) ClusterBuilderOpt {
 	return ClusterBuilderOptFunc(func(config *ClusterBuilderConfig) {
 		config.AddV3(&v3.TimeoutConfigurer{
 			Protocol: protocol,
@@ -127,7 +127,7 @@ func Timeout(protocol mesh_core.Protocol, conf *mesh_proto.Timeout_Conf) Cluster
 func DefaultTimeout() ClusterBuilderOpt {
 	return ClusterBuilderOptFunc(func(config *ClusterBuilderConfig) {
 		config.AddV3(&v3.TimeoutConfigurer{
-			Protocol: mesh_core.ProtocolTCP,
+			Protocol: core_mesh.ProtocolTCP,
 		})
 	})
 }

--- a/pkg/xds/envoy/clusters/v3/circuit_breaker_configurer.go
+++ b/pkg/xds/envoy/clusters/v3/circuit_breaker_configurer.go
@@ -4,11 +4,11 @@ import (
 	envoy_cluster "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
 	envoy_config_core_v3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 
-	mesh_core "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
+	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 )
 
 type CircuitBreakerConfigurer struct {
-	CircuitBreaker *mesh_core.CircuitBreakerResource
+	CircuitBreaker *core_mesh.CircuitBreakerResource
 }
 
 var _ ClusterConfigurer = &CircuitBreakerConfigurer{}

--- a/pkg/xds/envoy/clusters/v3/circuit_breaker_configurer_test.go
+++ b/pkg/xds/envoy/clusters/v3/circuit_breaker_configurer_test.go
@@ -10,7 +10,7 @@ import (
 	"google.golang.org/protobuf/types/known/wrapperspb"
 
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
-	mesh_core "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
+	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	util_proto "github.com/kumahq/kuma/pkg/util/proto"
 	"github.com/kumahq/kuma/pkg/xds/envoy"
 	"github.com/kumahq/kuma/pkg/xds/envoy/clusters"
@@ -20,7 +20,7 @@ var _ = Describe("CircuitBreakerConfigurer", func() {
 
 	type testCase struct {
 		clusterName    string
-		circuitBreaker *mesh_core.CircuitBreakerResource
+		circuitBreaker *core_mesh.CircuitBreakerResource
 		expected       string
 	}
 
@@ -30,7 +30,7 @@ var _ = Describe("CircuitBreakerConfigurer", func() {
 			cluster, err := clusters.NewClusterBuilder(envoy.APIV3).
 				Configure(clusters.EdsCluster(given.clusterName)).
 				Configure(clusters.CircuitBreaker(given.circuitBreaker)).
-				Configure(clusters.Timeout(mesh_core.ProtocolTCP, &mesh_proto.Timeout_Conf{ConnectTimeout: durationpb.New(5 * time.Second)})).
+				Configure(clusters.Timeout(core_mesh.ProtocolTCP, &mesh_proto.Timeout_Conf{ConnectTimeout: durationpb.New(5 * time.Second)})).
 				Build()
 
 			// then
@@ -41,7 +41,7 @@ var _ = Describe("CircuitBreakerConfigurer", func() {
 			Expect(actual).To(MatchYAML(given.expected))
 		},
 		Entry("CircuitBreaker with thresholds", testCase{
-			circuitBreaker: &mesh_core.CircuitBreakerResource{
+			circuitBreaker: &core_mesh.CircuitBreakerResource{
 				Spec: &mesh_proto.CircuitBreaker{
 					Conf: &mesh_proto.CircuitBreaker_Conf{
 						Thresholds: &mesh_proto.CircuitBreaker_Conf_Thresholds{

--- a/pkg/xds/envoy/clusters/v3/client_side_mtls_configurer_test.go
+++ b/pkg/xds/envoy/clusters/v3/client_side_mtls_configurer_test.go
@@ -9,7 +9,7 @@ import (
 	"google.golang.org/protobuf/types/known/durationpb"
 
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
-	mesh_core "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
+	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	core_xds "github.com/kumahq/kuma/pkg/core/xds"
 	test_model "github.com/kumahq/kuma/pkg/test/resources/model"
 	util_proto "github.com/kumahq/kuma/pkg/util/proto"
@@ -35,7 +35,7 @@ var _ = Describe("EdsClusterConfigurer", func() {
 			cluster, err := clusters.NewClusterBuilder(envoy.APIV3).
 				Configure(clusters.EdsCluster(given.clusterName)).
 				Configure(clusters.ClientSideMTLS(given.ctx, given.metadata, given.clientService, given.tags)).
-				Configure(clusters.Timeout(mesh_core.ProtocolTCP, &mesh_proto.Timeout_Conf{ConnectTimeout: durationpb.New(5 * time.Second)})).
+				Configure(clusters.Timeout(core_mesh.ProtocolTCP, &mesh_proto.Timeout_Conf{ConnectTimeout: durationpb.New(5 * time.Second)})).
 				Build()
 
 			// then
@@ -56,7 +56,7 @@ var _ = Describe("EdsClusterConfigurer", func() {
 					SdsTlsCert: []byte("CERTIFICATE"),
 				},
 				Mesh: xds_context.MeshContext{
-					Resource: &mesh_core.MeshResource{
+					Resource: &core_mesh.MeshResource{
 						Meta: &test_model.ResourceMeta{
 							Name: "default",
 						},
@@ -124,7 +124,7 @@ var _ = Describe("EdsClusterConfigurer", func() {
 					SdsTlsCert: []byte("CERTIFICATE"),
 				},
 				Mesh: xds_context.MeshContext{
-					Resource: &mesh_core.MeshResource{
+					Resource: &core_mesh.MeshResource{
 						Meta: &test_model.ResourceMeta{
 							Name: "default",
 						},
@@ -239,7 +239,7 @@ var _ = Describe("EdsClusterConfigurer", func() {
 					SdsTlsCert: []byte("CERTIFICATE"),
 				},
 				Mesh: xds_context.MeshContext{
-					Resource: &mesh_core.MeshResource{
+					Resource: &core_mesh.MeshResource{
 						Meta: &test_model.ResourceMeta{
 							Name: "default",
 						},

--- a/pkg/xds/envoy/clusters/v3/client_side_tls_configurer_test.go
+++ b/pkg/xds/envoy/clusters/v3/client_side_tls_configurer_test.go
@@ -9,7 +9,7 @@ import (
 	"google.golang.org/protobuf/types/known/durationpb"
 
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
-	mesh_core "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
+	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	"github.com/kumahq/kuma/pkg/core/xds"
 	util_proto "github.com/kumahq/kuma/pkg/util/proto"
 	"github.com/kumahq/kuma/pkg/xds/envoy"
@@ -30,7 +30,7 @@ var _ = Describe("ClientSideTLSConfigurer", func() {
 			cluster, err := clusters.NewClusterBuilder(envoy.APIV3).
 				Configure(clusters.EdsCluster(given.clusterName)).
 				Configure(clusters.ClientSideTLS(given.endpoints)).
-				Configure(clusters.Timeout(mesh_core.ProtocolTCP, &mesh_proto.Timeout_Conf{ConnectTimeout: durationpb.New(5 * time.Second)})).
+				Configure(clusters.Timeout(core_mesh.ProtocolTCP, &mesh_proto.Timeout_Conf{ConnectTimeout: durationpb.New(5 * time.Second)})).
 				Build()
 
 			// then

--- a/pkg/xds/envoy/clusters/v3/dns_cluster_configurer_test.go
+++ b/pkg/xds/envoy/clusters/v3/dns_cluster_configurer_test.go
@@ -8,7 +8,7 @@ import (
 	"google.golang.org/protobuf/types/known/durationpb"
 
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
-	mesh_core "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
+	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	util_proto "github.com/kumahq/kuma/pkg/util/proto"
 	"github.com/kumahq/kuma/pkg/xds/envoy"
 	"github.com/kumahq/kuma/pkg/xds/envoy/clusters"
@@ -39,7 +39,7 @@ var _ = Describe("DNSClusterConfigurer", func() {
 		// when
 		cluster, err := clusters.NewClusterBuilder(envoy.APIV3).
 			Configure(clusters.DNSCluster(clusterName, address, port)).
-			Configure(clusters.Timeout(mesh_core.ProtocolTCP, &mesh_proto.Timeout_Conf{ConnectTimeout: durationpb.New(5 * time.Second)})).
+			Configure(clusters.Timeout(core_mesh.ProtocolTCP, &mesh_proto.Timeout_Conf{ConnectTimeout: durationpb.New(5 * time.Second)})).
 			Build()
 
 		// then

--- a/pkg/xds/envoy/clusters/v3/eds_cluster_configurer_test.go
+++ b/pkg/xds/envoy/clusters/v3/eds_cluster_configurer_test.go
@@ -8,7 +8,7 @@ import (
 	"google.golang.org/protobuf/types/known/durationpb"
 
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
-	mesh_core "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
+	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	util_proto "github.com/kumahq/kuma/pkg/util/proto"
 	"github.com/kumahq/kuma/pkg/xds/envoy"
 	"github.com/kumahq/kuma/pkg/xds/envoy/clusters"
@@ -32,7 +32,7 @@ var _ = Describe("EdsClusterConfigurer", func() {
 		// when
 		cluster, err := clusters.NewClusterBuilder(envoy.APIV3).
 			Configure(clusters.EdsCluster(clusterName)).
-			Configure(clusters.Timeout(mesh_core.ProtocolTCP, &mesh_proto.Timeout_Conf{ConnectTimeout: durationpb.New(5 * time.Second)})).
+			Configure(clusters.Timeout(core_mesh.ProtocolTCP, &mesh_proto.Timeout_Conf{ConnectTimeout: durationpb.New(5 * time.Second)})).
 			Build()
 
 		// then

--- a/pkg/xds/envoy/clusters/v3/health_check_configurer.go
+++ b/pkg/xds/envoy/clusters/v3/health_check_configurer.go
@@ -11,12 +11,12 @@ import (
 
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	"github.com/kumahq/kuma/pkg/core"
-	mesh_core "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
+	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 )
 
 type HealthCheckConfigurer struct {
-	HealthCheck *mesh_core.HealthCheckResource
-	Protocol    mesh_core.Protocol
+	HealthCheck *core_mesh.HealthCheckResource
+	Protocol    core_mesh.Protocol
 }
 
 var _ ClusterConfigurer = &HealthCheckConfigurer{}
@@ -75,7 +75,7 @@ func tcpHealthCheck(
 }
 
 func httpHealthCheck(
-	protocol mesh_core.Protocol,
+	protocol core_mesh.Protocol,
 	httpConf *mesh_proto.HealthCheck_Conf_Http,
 ) *envoy_core.HealthCheck_HttpHealthCheck_ {
 	var expectedStatuses []*envoy_type.Int64Range
@@ -87,7 +87,7 @@ func httpHealthCheck(
 	}
 
 	codecClientType := envoy_type.CodecClientType_HTTP1
-	if protocol == mesh_core.ProtocolHTTP2 {
+	if protocol == core_mesh.ProtocolHTTP2 {
 		codecClientType = envoy_type.CodecClientType_HTTP2
 	}
 

--- a/pkg/xds/envoy/clusters/v3/health_check_configurer_test.go
+++ b/pkg/xds/envoy/clusters/v3/health_check_configurer_test.go
@@ -10,7 +10,7 @@ import (
 	"google.golang.org/protobuf/types/known/wrapperspb"
 
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
-	mesh_core "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
+	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	util_proto "github.com/kumahq/kuma/pkg/util/proto"
 	"github.com/kumahq/kuma/pkg/xds/envoy"
 	"github.com/kumahq/kuma/pkg/xds/envoy/clusters"
@@ -20,7 +20,7 @@ var _ = Describe("HealthCheckConfigurer", func() {
 
 	type testCase struct {
 		clusterName string
-		healthCheck *mesh_core.HealthCheckResource
+		healthCheck *core_mesh.HealthCheckResource
 		expected    string
 	}
 
@@ -29,8 +29,8 @@ var _ = Describe("HealthCheckConfigurer", func() {
 			// when
 			cluster, err := clusters.NewClusterBuilder(envoy.APIV3).
 				Configure(clusters.EdsCluster(given.clusterName)).
-				Configure(clusters.HealthCheck(mesh_core.ProtocolHTTP, given.healthCheck)).
-				Configure(clusters.Timeout(mesh_core.ProtocolTCP, &mesh_proto.Timeout_Conf{ConnectTimeout: durationpb.New(5 * time.Second)})).
+				Configure(clusters.HealthCheck(core_mesh.ProtocolHTTP, given.healthCheck)).
+				Configure(clusters.Timeout(core_mesh.ProtocolTCP, &mesh_proto.Timeout_Conf{ConnectTimeout: durationpb.New(5 * time.Second)})).
 				Build()
 
 			// then
@@ -42,7 +42,7 @@ var _ = Describe("HealthCheckConfigurer", func() {
 		},
 		Entry("HealthCheck with neither active nor passive checks", testCase{
 			clusterName: "testCluster",
-			healthCheck: mesh_core.NewHealthCheckResource(),
+			healthCheck: core_mesh.NewHealthCheckResource(),
 			expected: `
             connectTimeout: 5s
             edsClusterConfig:
@@ -54,7 +54,7 @@ var _ = Describe("HealthCheckConfigurer", func() {
 		}),
 		Entry("HealthCheck with active checks", testCase{
 			clusterName: "testCluster",
-			healthCheck: &mesh_core.HealthCheckResource{
+			healthCheck: &core_mesh.HealthCheckResource{
 				Spec: &mesh_proto.HealthCheck{
 					Sources: []*mesh_proto.Selector{
 						{Match: mesh_proto.TagSelector{"kuma.io/service": "backend"}},
@@ -89,7 +89,7 @@ var _ = Describe("HealthCheckConfigurer", func() {
 		}),
 		Entry("HealthCheck with provided TCP Send/Receive properties", testCase{
 			clusterName: "testCluster",
-			healthCheck: &mesh_core.HealthCheckResource{
+			healthCheck: &core_mesh.HealthCheckResource{
 				Spec: &mesh_proto.HealthCheck{
 					Sources: []*mesh_proto.Selector{
 						{Match: mesh_proto.TagSelector{"kuma.io/service": "backend"}},
@@ -136,7 +136,7 @@ var _ = Describe("HealthCheckConfigurer", func() {
 		}),
 		Entry("HealthCheck with provided TCP Send only properties", testCase{
 			clusterName: "testCluster",
-			healthCheck: &mesh_core.HealthCheckResource{
+			healthCheck: &core_mesh.HealthCheckResource{
 				Spec: &mesh_proto.HealthCheck{
 					Sources: []*mesh_proto.Selector{
 						{Match: mesh_proto.TagSelector{"kuma.io/service": "backend"}},
@@ -176,7 +176,7 @@ var _ = Describe("HealthCheckConfigurer", func() {
 		}),
 		Entry("HealthCheck with provided HTTP configuration", testCase{
 			clusterName: "testCluster",
-			healthCheck: &mesh_core.HealthCheckResource{
+			healthCheck: &core_mesh.HealthCheckResource{
 				Spec: &mesh_proto.HealthCheck{
 					Sources: []*mesh_proto.Selector{
 						{Match: mesh_proto.TagSelector{"kuma.io/service": "backend"}},
@@ -237,7 +237,7 @@ var _ = Describe("HealthCheckConfigurer", func() {
 		}),
 		Entry("HealthCheck with provided both, TCP and HTTP configurations", testCase{
 			clusterName: "testCluster",
-			healthCheck: &mesh_core.HealthCheckResource{
+			healthCheck: &core_mesh.HealthCheckResource{
 				Spec: &mesh_proto.HealthCheck{
 					Sources: []*mesh_proto.Selector{
 						{Match: mesh_proto.TagSelector{"kuma.io/service": "backend"}},
@@ -317,7 +317,7 @@ var _ = Describe("HealthCheckConfigurer", func() {
 		}),
 		Entry("HealthCheck with jitter", testCase{
 			clusterName: "testCluster",
-			healthCheck: &mesh_core.HealthCheckResource{
+			healthCheck: &core_mesh.HealthCheckResource{
 				Spec: &mesh_proto.HealthCheck{
 					Sources: []*mesh_proto.Selector{
 						{Match: mesh_proto.TagSelector{"kuma.io/service": "backend"}},
@@ -356,7 +356,7 @@ var _ = Describe("HealthCheckConfigurer", func() {
 		}),
 		Entry("HealthCheck with panic threshold", testCase{
 			clusterName: "testCluster",
-			healthCheck: &mesh_core.HealthCheckResource{
+			healthCheck: &core_mesh.HealthCheckResource{
 				Spec: &mesh_proto.HealthCheck{
 					Sources: []*mesh_proto.Selector{
 						{Match: mesh_proto.TagSelector{"kuma.io/service": "backend"}},
@@ -393,7 +393,7 @@ var _ = Describe("HealthCheckConfigurer", func() {
 		}),
 		Entry("HealthCheck with panic threshold, fail traffic on panic", testCase{
 			clusterName: "testCluster",
-			healthCheck: &mesh_core.HealthCheckResource{
+			healthCheck: &core_mesh.HealthCheckResource{
 				Spec: &mesh_proto.HealthCheck{
 					Sources: []*mesh_proto.Selector{
 						{Match: mesh_proto.TagSelector{"kuma.io/service": "backend"}},
@@ -433,7 +433,7 @@ var _ = Describe("HealthCheckConfigurer", func() {
 		}),
 		Entry("HealthCheck with event log path", testCase{
 			clusterName: "testCluster",
-			healthCheck: &mesh_core.HealthCheckResource{
+			healthCheck: &core_mesh.HealthCheckResource{
 				Spec: &mesh_proto.HealthCheck{
 					Sources: []*mesh_proto.Selector{
 						{Match: mesh_proto.TagSelector{"kuma.io/service": "backend"}},

--- a/pkg/xds/envoy/clusters/v3/lb_configurer_test.go
+++ b/pkg/xds/envoy/clusters/v3/lb_configurer_test.go
@@ -9,7 +9,7 @@ import (
 	"google.golang.org/protobuf/types/known/durationpb"
 
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
-	mesh_core "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
+	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	util_proto "github.com/kumahq/kuma/pkg/util/proto"
 	"github.com/kumahq/kuma/pkg/xds/envoy"
 	"github.com/kumahq/kuma/pkg/xds/envoy/clusters"
@@ -29,7 +29,7 @@ var _ = Describe("Lb", func() {
 			cluster, err := clusters.NewClusterBuilder(envoy.APIV3).
 				Configure(clusters.EdsCluster(given.clusterName)).
 				Configure(clusters.LB(given.lb)).
-				Configure(clusters.Timeout(mesh_core.ProtocolTCP, &mesh_proto.Timeout_Conf{ConnectTimeout: durationpb.New(5 * time.Second)})).
+				Configure(clusters.Timeout(core_mesh.ProtocolTCP, &mesh_proto.Timeout_Conf{ConnectTimeout: durationpb.New(5 * time.Second)})).
 				Build()
 
 			// then

--- a/pkg/xds/envoy/clusters/v3/lb_subset_configurer_test.go
+++ b/pkg/xds/envoy/clusters/v3/lb_subset_configurer_test.go
@@ -9,7 +9,7 @@ import (
 	"google.golang.org/protobuf/types/known/durationpb"
 
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
-	mesh_core "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
+	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	util_proto "github.com/kumahq/kuma/pkg/util/proto"
 	"github.com/kumahq/kuma/pkg/xds/envoy"
 	"github.com/kumahq/kuma/pkg/xds/envoy/clusters"
@@ -29,7 +29,7 @@ var _ = Describe("LbSubset", func() {
 			cluster, err := clusters.NewClusterBuilder(envoy.APIV3).
 				Configure(clusters.EdsCluster(given.clusterName)).
 				Configure(clusters.LbSubset(given.tags)).
-				Configure(clusters.Timeout(mesh_core.ProtocolTCP, &mesh_proto.Timeout_Conf{ConnectTimeout: durationpb.New(5 * time.Second)})).
+				Configure(clusters.Timeout(core_mesh.ProtocolTCP, &mesh_proto.Timeout_Conf{ConnectTimeout: durationpb.New(5 * time.Second)})).
 				Build()
 
 			// then

--- a/pkg/xds/envoy/clusters/v3/outlier_detection_configurer.go
+++ b/pkg/xds/envoy/clusters/v3/outlier_detection_configurer.go
@@ -4,11 +4,11 @@ import (
 	envoy_cluster "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
 	"google.golang.org/protobuf/types/known/wrapperspb"
 
-	mesh_core "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
+	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 )
 
 type OutlierDetectionConfigurer struct {
-	CircuitBreaker *mesh_core.CircuitBreakerResource
+	CircuitBreaker *core_mesh.CircuitBreakerResource
 }
 
 var _ ClusterConfigurer = &OutlierDetectionConfigurer{}

--- a/pkg/xds/envoy/clusters/v3/outlier_detection_configurer_test.go
+++ b/pkg/xds/envoy/clusters/v3/outlier_detection_configurer_test.go
@@ -10,7 +10,7 @@ import (
 	"google.golang.org/protobuf/types/known/wrapperspb"
 
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
-	mesh_core "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
+	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	util_proto "github.com/kumahq/kuma/pkg/util/proto"
 	"github.com/kumahq/kuma/pkg/xds/envoy"
 	"github.com/kumahq/kuma/pkg/xds/envoy/clusters"
@@ -20,7 +20,7 @@ var _ = Describe("OutlierDetectionConfigurer", func() {
 
 	type testCase struct {
 		clusterName    string
-		circuitBreaker *mesh_core.CircuitBreakerResource
+		circuitBreaker *core_mesh.CircuitBreakerResource
 		expected       string
 	}
 
@@ -30,7 +30,7 @@ var _ = Describe("OutlierDetectionConfigurer", func() {
 			cluster, err := clusters.NewClusterBuilder(envoy.APIV3).
 				Configure(clusters.EdsCluster(given.clusterName)).
 				Configure(clusters.OutlierDetection(given.circuitBreaker)).
-				Configure(clusters.Timeout(mesh_core.ProtocolTCP, &mesh_proto.Timeout_Conf{ConnectTimeout: durationpb.New(5 * time.Second)})).
+				Configure(clusters.Timeout(core_mesh.ProtocolTCP, &mesh_proto.Timeout_Conf{ConnectTimeout: durationpb.New(5 * time.Second)})).
 				Build()
 
 			// then
@@ -41,7 +41,7 @@ var _ = Describe("OutlierDetectionConfigurer", func() {
 			Expect(actual).To(MatchYAML(given.expected))
 		},
 		Entry("CircuitBreaker with TotalError detector, default values", testCase{
-			circuitBreaker: &mesh_core.CircuitBreakerResource{
+			circuitBreaker: &core_mesh.CircuitBreakerResource{
 				Spec: &mesh_proto.CircuitBreaker{
 					Conf: &mesh_proto.CircuitBreaker_Conf{
 						Detectors: &mesh_proto.CircuitBreaker_Conf_Detectors{
@@ -65,7 +65,7 @@ var _ = Describe("OutlierDetectionConfigurer", func() {
             type: EDS`,
 		}),
 		Entry("CircuitBreaker with GatewayError detector, default values", testCase{
-			circuitBreaker: &mesh_core.CircuitBreakerResource{
+			circuitBreaker: &core_mesh.CircuitBreakerResource{
 				Spec: &mesh_proto.CircuitBreaker{
 					Conf: &mesh_proto.CircuitBreaker_Conf{
 						Detectors: &mesh_proto.CircuitBreaker_Conf_Detectors{
@@ -89,7 +89,7 @@ var _ = Describe("OutlierDetectionConfigurer", func() {
             type: EDS`,
 		}),
 		Entry("CircuitBreaker with LocalError detector, default values", testCase{
-			circuitBreaker: &mesh_core.CircuitBreakerResource{
+			circuitBreaker: &core_mesh.CircuitBreakerResource{
 				Spec: &mesh_proto.CircuitBreaker{
 					Conf: &mesh_proto.CircuitBreaker_Conf{
 						Detectors: &mesh_proto.CircuitBreaker_Conf_Detectors{
@@ -113,7 +113,7 @@ var _ = Describe("OutlierDetectionConfigurer", func() {
             type: EDS`,
 		}),
 		Entry("CircuitBreaker with all error detectors, custom values", testCase{
-			circuitBreaker: &mesh_core.CircuitBreakerResource{
+			circuitBreaker: &core_mesh.CircuitBreakerResource{
 				Spec: &mesh_proto.CircuitBreaker{
 					Conf: &mesh_proto.CircuitBreaker_Conf{
 						Detectors: &mesh_proto.CircuitBreaker_Conf_Detectors{
@@ -142,7 +142,7 @@ var _ = Describe("OutlierDetectionConfigurer", func() {
             type: EDS`,
 		}),
 		Entry("CircuitBreaker with StandardDeviation detector, default values", testCase{
-			circuitBreaker: &mesh_core.CircuitBreakerResource{
+			circuitBreaker: &core_mesh.CircuitBreakerResource{
 				Spec: &mesh_proto.CircuitBreaker{
 					Conf: &mesh_proto.CircuitBreaker_Conf{
 						Detectors: &mesh_proto.CircuitBreaker_Conf_Detectors{
@@ -167,7 +167,7 @@ var _ = Describe("OutlierDetectionConfigurer", func() {
             type: EDS`,
 		}),
 		Entry("CircuitBreaker with StandardDeviation detector, custom values", testCase{
-			circuitBreaker: &mesh_core.CircuitBreakerResource{
+			circuitBreaker: &core_mesh.CircuitBreakerResource{
 				Spec: &mesh_proto.CircuitBreaker{
 					Conf: &mesh_proto.CircuitBreaker_Conf{
 						Detectors: &mesh_proto.CircuitBreaker_Conf_Detectors{
@@ -199,7 +199,7 @@ var _ = Describe("OutlierDetectionConfigurer", func() {
             type: EDS`,
 		}),
 		Entry("CircuitBreaker with Failure detector, default values", testCase{
-			circuitBreaker: &mesh_core.CircuitBreakerResource{
+			circuitBreaker: &core_mesh.CircuitBreakerResource{
 				Spec: &mesh_proto.CircuitBreaker{
 					Conf: &mesh_proto.CircuitBreaker_Conf{
 						Detectors: &mesh_proto.CircuitBreaker_Conf_Detectors{
@@ -224,7 +224,7 @@ var _ = Describe("OutlierDetectionConfigurer", func() {
             type: EDS`,
 		}),
 		Entry("CircuitBreaker with Failure detector, custom values", testCase{
-			circuitBreaker: &mesh_core.CircuitBreakerResource{
+			circuitBreaker: &core_mesh.CircuitBreakerResource{
 				Spec: &mesh_proto.CircuitBreaker{
 					Conf: &mesh_proto.CircuitBreaker_Conf{
 						Detectors: &mesh_proto.CircuitBreaker_Conf_Detectors{

--- a/pkg/xds/envoy/clusters/v3/pass_through_cluster_configurer_test.go
+++ b/pkg/xds/envoy/clusters/v3/pass_through_cluster_configurer_test.go
@@ -8,7 +8,7 @@ import (
 	"google.golang.org/protobuf/types/known/durationpb"
 
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
-	mesh_core "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
+	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	util_proto "github.com/kumahq/kuma/pkg/util/proto"
 	"github.com/kumahq/kuma/pkg/xds/envoy"
 	"github.com/kumahq/kuma/pkg/xds/envoy/clusters"
@@ -29,7 +29,7 @@ var _ = Describe("PassThroughClusterConfigurer", func() {
 		// when
 		cluster, err := clusters.NewClusterBuilder(envoy.APIV3).
 			Configure(clusters.PassThroughCluster(clusterName)).
-			Configure(clusters.Timeout(mesh_core.ProtocolTCP, &mesh_proto.Timeout_Conf{ConnectTimeout: durationpb.New(5 * time.Second)})).
+			Configure(clusters.Timeout(core_mesh.ProtocolTCP, &mesh_proto.Timeout_Conf{ConnectTimeout: durationpb.New(5 * time.Second)})).
 			Build()
 
 		// then

--- a/pkg/xds/envoy/clusters/v3/static_cluster_configurer_test.go
+++ b/pkg/xds/envoy/clusters/v3/static_cluster_configurer_test.go
@@ -8,7 +8,7 @@ import (
 	"google.golang.org/protobuf/types/known/durationpb"
 
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
-	mesh_core "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
+	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	util_proto "github.com/kumahq/kuma/pkg/util/proto"
 	"github.com/kumahq/kuma/pkg/xds/envoy"
 	"github.com/kumahq/kuma/pkg/xds/envoy/clusters"
@@ -39,7 +39,7 @@ var _ = Describe("StaticClusterConfigurer", func() {
 		// when
 		cluster, err := clusters.NewClusterBuilder(envoy.APIV3).
 			Configure(clusters.StaticCluster(clusterName, address, port)).
-			Configure(clusters.Timeout(mesh_core.ProtocolTCP, &mesh_proto.Timeout_Conf{ConnectTimeout: durationpb.New(5 * time.Second)})).
+			Configure(clusters.Timeout(core_mesh.ProtocolTCP, &mesh_proto.Timeout_Conf{ConnectTimeout: durationpb.New(5 * time.Second)})).
 			Build()
 
 		// then
@@ -71,7 +71,7 @@ var _ = Describe("StaticClusterConfigurer", func() {
 		// when
 		cluster, err := clusters.NewClusterBuilder(envoy.APIV3).
 			Configure(clusters.StaticClusterUnixSocket(clusterName, path)).
-			Configure(clusters.Timeout(mesh_core.ProtocolTCP, &mesh_proto.Timeout_Conf{ConnectTimeout: durationpb.New(5 * time.Second)})).
+			Configure(clusters.Timeout(core_mesh.ProtocolTCP, &mesh_proto.Timeout_Conf{ConnectTimeout: durationpb.New(5 * time.Second)})).
 			Build()
 
 		// then

--- a/pkg/xds/envoy/clusters/v3/strict_dns_cluster_configurer_test.go
+++ b/pkg/xds/envoy/clusters/v3/strict_dns_cluster_configurer_test.go
@@ -8,7 +8,7 @@ import (
 	"google.golang.org/protobuf/types/known/durationpb"
 
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
-	mesh_core "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
+	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	"github.com/kumahq/kuma/pkg/core/xds"
 	util_proto "github.com/kumahq/kuma/pkg/util/proto"
 	"github.com/kumahq/kuma/pkg/xds/envoy"
@@ -52,7 +52,7 @@ var _ = Describe("StrictDNSClusterConfigurer", func() {
 					},
 				},
 			}, false)).
-			Configure(clusters.Timeout(mesh_core.ProtocolTCP, &mesh_proto.Timeout_Conf{ConnectTimeout: durationpb.New(5 * time.Second)})).
+			Configure(clusters.Timeout(core_mesh.ProtocolTCP, &mesh_proto.Timeout_Conf{ConnectTimeout: durationpb.New(5 * time.Second)})).
 			Build()
 
 		// then
@@ -97,7 +97,7 @@ var _ = Describe("StrictDNSClusterConfigurer", func() {
 					},
 				},
 			}, true)).
-			Configure(clusters.Timeout(mesh_core.ProtocolTCP, &mesh_proto.Timeout_Conf{ConnectTimeout: durationpb.New(5 * time.Second)})).
+			Configure(clusters.Timeout(core_mesh.ProtocolTCP, &mesh_proto.Timeout_Conf{ConnectTimeout: durationpb.New(5 * time.Second)})).
 			Build()
 
 		// then

--- a/pkg/xds/envoy/clusters/v3/timeout_configurer.go
+++ b/pkg/xds/envoy/clusters/v3/timeout_configurer.go
@@ -9,13 +9,13 @@ import (
 	"google.golang.org/protobuf/types/known/durationpb"
 
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
-	mesh_core "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
+	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 )
 
 const defaultConnectTimeout = 10 * time.Second
 
 type TimeoutConfigurer struct {
-	Protocol mesh_core.Protocol
+	Protocol core_mesh.Protocol
 	Conf     *mesh_proto.Timeout_Conf
 }
 
@@ -24,7 +24,7 @@ var _ ClusterConfigurer = &TimeoutConfigurer{}
 func (t *TimeoutConfigurer) Configure(cluster *envoy_cluster.Cluster) error {
 	cluster.ConnectTimeout = durationpb.New(t.Conf.GetConnectTimeoutOrDefault(defaultConnectTimeout))
 	switch t.Protocol {
-	case mesh_core.ProtocolHTTP, mesh_core.ProtocolHTTP2:
+	case core_mesh.ProtocolHTTP, core_mesh.ProtocolHTTP2:
 		err := UpdateCommonHttpProtocolOptions(cluster, func(options *envoy_upstream_http.HttpProtocolOptions) {
 			if options.CommonHttpProtocolOptions == nil {
 				options.CommonHttpProtocolOptions = &envoy_core.HttpProtocolOptions{}
@@ -34,7 +34,7 @@ func (t *TimeoutConfigurer) Configure(cluster *envoy_cluster.Cluster) error {
 		if err != nil {
 			return err
 		}
-	case mesh_core.ProtocolGRPC:
+	case core_mesh.ProtocolGRPC:
 		if maxStreamDuration := t.Conf.GetGrpc().GetMaxStreamDuration().AsDuration(); maxStreamDuration != 0 {
 			err := UpdateCommonHttpProtocolOptions(cluster, func(options *envoy_upstream_http.HttpProtocolOptions) {
 				if options.CommonHttpProtocolOptions == nil {

--- a/pkg/xds/envoy/listeners/configurers.go
+++ b/pkg/xds/envoy/listeners/configurers.go
@@ -5,7 +5,7 @@ import (
 	"google.golang.org/protobuf/types/known/wrapperspb"
 
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
-	mesh_core "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
+	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	core_xds "github.com/kumahq/kuma/pkg/core/xds"
 	"github.com/kumahq/kuma/pkg/tls"
 	xds_context "github.com/kumahq/kuma/pkg/xds/context"
@@ -90,7 +90,7 @@ func InboundListener(listenerName string, address string, port uint32, protocol 
 	})
 }
 
-func NetworkRBAC(statsName string, rbacEnabled bool, permission *mesh_core.TrafficPermissionResource) FilterChainBuilderOpt {
+func NetworkRBAC(statsName string, rbacEnabled bool, permission *core_mesh.TrafficPermissionResource) FilterChainBuilderOpt {
 	if !rbacEnabled {
 		return FilterChainBuilderOptFunc(nil)
 	}
@@ -233,7 +233,7 @@ func FilterChain(builder *FilterChainBuilder) ListenerBuilderOpt {
 	})
 }
 
-func MaxConnectAttempts(retry *mesh_core.RetryResource) FilterChainBuilderOpt {
+func MaxConnectAttempts(retry *core_mesh.RetryResource) FilterChainBuilderOpt {
 	if retry == nil || retry.Spec.Conf.GetTcp() == nil {
 		return FilterChainBuilderOptFunc(nil)
 	}
@@ -244,8 +244,8 @@ func MaxConnectAttempts(retry *mesh_core.RetryResource) FilterChainBuilderOpt {
 }
 
 func Retry(
-	retry *mesh_core.RetryResource,
-	protocol mesh_core.Protocol,
+	retry *core_mesh.RetryResource,
+	protocol core_mesh.Protocol,
 ) FilterChainBuilderOpt {
 	if retry == nil {
 		return FilterChainBuilderOptFunc(nil)
@@ -257,7 +257,7 @@ func Retry(
 	})
 }
 
-func Timeout(timeout *mesh_proto.Timeout_Conf, protocol mesh_core.Protocol) FilterChainBuilderOpt {
+func Timeout(timeout *mesh_proto.Timeout_Conf, protocol core_mesh.Protocol) FilterChainBuilderOpt {
 	return AddFilterChainConfigurer(&v3.TimeoutConfigurer{
 		Conf:     timeout,
 		Protocol: protocol,

--- a/pkg/xds/envoy/listeners/v3/http_access_log_configurer_test.go
+++ b/pkg/xds/envoy/listeners/v3/http_access_log_configurer_test.go
@@ -6,7 +6,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
-	mesh_core "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
+	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	core_xds "github.com/kumahq/kuma/pkg/core/xds"
 	util_proto "github.com/kumahq/kuma/pkg/util/proto"
 	"github.com/kumahq/kuma/pkg/xds/envoy"
@@ -34,7 +34,7 @@ var _ = Describe("HttpAccessLogConfigurer", func() {
 			destinationService := "backend"
 			proxy := &core_xds.Proxy{
 				Id: *core_xds.BuildProxyId("web", "example"),
-				Dataplane: &mesh_core.DataplaneResource{
+				Dataplane: &core_mesh.DataplaneResource{
 					Spec: &mesh_proto.Dataplane{
 						Networking: &mesh_proto.Dataplane_Networking{
 							Address: "192.168.0.1",

--- a/pkg/xds/envoy/listeners/v3/max_connect_attempts_configurer_test.go
+++ b/pkg/xds/envoy/listeners/v3/max_connect_attempts_configurer_test.go
@@ -6,7 +6,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
-	mesh_core "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
+	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	core_xds "github.com/kumahq/kuma/pkg/core/xds"
 	util_proto "github.com/kumahq/kuma/pkg/util/proto"
 	envoy_common "github.com/kumahq/kuma/pkg/xds/envoy"
@@ -28,7 +28,7 @@ var _ = Describe("MaxConnectAttemptsConfigurer", func() {
 	DescribeTable("should generate proper Envoy config",
 		func(given testCase) {
 			// given
-			retry := &mesh_core.RetryResource{
+			retry := &core_mesh.RetryResource{
 				Meta: nil,
 				Spec: &mesh_proto.Retry{
 					Sources:      nil,

--- a/pkg/xds/envoy/listeners/v3/network_access_log_configurer_test.go
+++ b/pkg/xds/envoy/listeners/v3/network_access_log_configurer_test.go
@@ -6,7 +6,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
-	mesh_core "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
+	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	core_xds "github.com/kumahq/kuma/pkg/core/xds"
 	util_proto "github.com/kumahq/kuma/pkg/util/proto"
 	envoy_common "github.com/kumahq/kuma/pkg/xds/envoy"
@@ -34,7 +34,7 @@ var _ = Describe("NetworkAccessLogConfigurer", func() {
 			destinationService := "db"
 			proxy := &core_xds.Proxy{
 				Id: *core_xds.BuildProxyId("example", "backend"),
-				Dataplane: &mesh_core.DataplaneResource{
+				Dataplane: &core_mesh.DataplaneResource{
 					Spec: &mesh_proto.Dataplane{
 						Networking: &mesh_proto.Dataplane_Networking{
 							Address: "192.168.0.1",

--- a/pkg/xds/envoy/listeners/v3/network_rbac_configurer.go
+++ b/pkg/xds/envoy/listeners/v3/network_rbac_configurer.go
@@ -8,7 +8,7 @@ import (
 	rbac "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/rbac/v3"
 
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
-	mesh_core "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
+	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	"github.com/kumahq/kuma/pkg/util/proto"
 	util_xds "github.com/kumahq/kuma/pkg/util/xds"
 	tls "github.com/kumahq/kuma/pkg/xds/envoy/tls/v3"
@@ -16,7 +16,7 @@ import (
 
 type NetworkRBACConfigurer struct {
 	StatsName  string
-	Permission *mesh_core.TrafficPermissionResource
+	Permission *core_mesh.TrafficPermissionResource
 }
 
 func (c *NetworkRBACConfigurer) Configure(filterChain *envoy_listener.FilterChain) error {
@@ -30,7 +30,7 @@ func (c *NetworkRBACConfigurer) Configure(filterChain *envoy_listener.FilterChai
 	return nil
 }
 
-func createRbacFilter(statsName string, permission *mesh_core.TrafficPermissionResource) (*envoy_listener.Filter, error) {
+func createRbacFilter(statsName string, permission *core_mesh.TrafficPermissionResource) (*envoy_listener.Filter, error) {
 	rbacRule := createRbacRule(statsName, permission)
 	rbacMarshalled, err := proto.MarshalAnyDeterministic(rbacRule)
 	if err != nil {
@@ -44,7 +44,7 @@ func createRbacFilter(statsName string, permission *mesh_core.TrafficPermissionR
 	}, nil
 }
 
-func createRbacRule(statsName string, permission *mesh_core.TrafficPermissionResource) *rbac.RBAC {
+func createRbacRule(statsName string, permission *core_mesh.TrafficPermissionResource) *rbac.RBAC {
 	policies := make(map[string]*rbac_config.Policy)
 	// We only create policy if Traffic Permission is selected. Otherwise we still need to build RBAC filter
 	// to restrict all the traffic coming to the dataplane.
@@ -61,7 +61,7 @@ func createRbacRule(statsName string, permission *mesh_core.TrafficPermissionRes
 	}
 }
 
-func createPolicy(permission *mesh_core.TrafficPermissionResource) *rbac_config.Policy {
+func createPolicy(permission *core_mesh.TrafficPermissionResource) *rbac_config.Policy {
 	principals := []*rbac_config.Principal{}
 
 	// build principals list: one per sources/destinations rule

--- a/pkg/xds/envoy/listeners/v3/network_rbac_configurer_test.go
+++ b/pkg/xds/envoy/listeners/v3/network_rbac_configurer_test.go
@@ -6,7 +6,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
-	mesh_core "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
+	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	"github.com/kumahq/kuma/pkg/core/xds"
 	test_model "github.com/kumahq/kuma/pkg/test/resources/model"
 	util_proto "github.com/kumahq/kuma/pkg/util/proto"
@@ -24,7 +24,7 @@ var _ = Describe("NetworkRbacConfigurer", func() {
 		statsName        string
 		clusters         []envoy_common.Cluster
 		rbacEnabled      bool
-		permission       *mesh_core.TrafficPermissionResource
+		permission       *core_mesh.TrafficPermissionResource
 		expected         string
 	}
 
@@ -56,7 +56,7 @@ var _ = Describe("NetworkRbacConfigurer", func() {
 				envoy_common.WithWeight(200),
 			)},
 			rbacEnabled: true,
-			permission: &mesh_core.TrafficPermissionResource{
+			permission: &core_mesh.TrafficPermissionResource{
 				Meta: &test_model.ResourceMeta{
 					Name: "tp-1",
 					Mesh: "default",
@@ -124,7 +124,7 @@ var _ = Describe("NetworkRbacConfigurer", func() {
 				envoy_common.WithWeight(200),
 			)},
 			rbacEnabled: false,
-			permission: &mesh_core.TrafficPermissionResource{
+			permission: &core_mesh.TrafficPermissionResource{
 				Meta: &test_model.ResourceMeta{
 					Name: "tp-1",
 					Mesh: "default",

--- a/pkg/xds/envoy/listeners/v3/retry_configurer_test.go
+++ b/pkg/xds/envoy/listeners/v3/retry_configurer_test.go
@@ -8,7 +8,7 @@ import (
 	"google.golang.org/protobuf/types/known/wrapperspb"
 
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
-	mesh_core "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
+	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	core_xds "github.com/kumahq/kuma/pkg/core/xds"
 	util_proto "github.com/kumahq/kuma/pkg/util/proto"
 	envoy_common "github.com/kumahq/kuma/pkg/xds/envoy"
@@ -25,8 +25,8 @@ var _ = Describe("RetryConfigurer", func() {
 		service          string
 		routes           envoy_common.Routes
 		dpTags           mesh_proto.MultiValueTagSet
-		protocol         mesh_core.Protocol
-		retry            *mesh_core.RetryResource
+		protocol         core_mesh.Protocol
+		retry            *core_mesh.RetryResource
 		expected         string
 	}
 
@@ -74,7 +74,7 @@ var _ = Describe("RetryConfigurer", func() {
 				},
 			},
 			protocol: "http",
-			retry: &mesh_core.RetryResource{
+			retry: &core_mesh.RetryResource{
 				Spec: &mesh_proto.Retry{
 					Conf: &mesh_proto.Retry_Conf{
 						Http: &mesh_proto.Retry_Conf_Http{
@@ -142,7 +142,7 @@ var _ = Describe("RetryConfigurer", func() {
 				},
 			},
 			protocol: "http",
-			retry: &mesh_core.RetryResource{
+			retry: &core_mesh.RetryResource{
 				Spec: &mesh_proto.Retry{
 					Conf: &mesh_proto.Retry_Conf{
 						Http: &mesh_proto.Retry_Conf_Http{
@@ -229,7 +229,7 @@ var _ = Describe("RetryConfigurer", func() {
 				},
 			},
 			protocol: "grpc",
-			retry: &mesh_core.RetryResource{
+			retry: &core_mesh.RetryResource{
 				Spec: &mesh_proto.Retry{
 					Conf: &mesh_proto.Retry_Conf{
 						Grpc: &mesh_proto.Retry_Conf_Grpc{
@@ -297,7 +297,7 @@ var _ = Describe("RetryConfigurer", func() {
 				},
 			},
 			protocol: "grpc",
-			retry: &mesh_core.RetryResource{
+			retry: &core_mesh.RetryResource{
 				Spec: &mesh_proto.Retry{
 					Conf: &mesh_proto.Retry_Conf{
 						Grpc: &mesh_proto.Retry_Conf_Grpc{

--- a/pkg/xds/envoy/listeners/v3/server_mtls_configurer_test.go
+++ b/pkg/xds/envoy/listeners/v3/server_mtls_configurer_test.go
@@ -6,7 +6,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
-	mesh_core "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
+	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	core_xds "github.com/kumahq/kuma/pkg/core/xds"
 	test_model "github.com/kumahq/kuma/pkg/test/resources/model"
 	util_proto "github.com/kumahq/kuma/pkg/util/proto"
@@ -64,7 +64,7 @@ var _ = Describe("ServerMtlsConfigurer", func() {
 					SdsTlsCert: []byte("CERTIFICATE"),
 				},
 				Mesh: xds_context.MeshContext{
-					Resource: &mesh_core.MeshResource{
+					Resource: &core_mesh.MeshResource{
 						Meta: &test_model.ResourceMeta{
 							Name: "default",
 						},
@@ -145,7 +145,7 @@ var _ = Describe("ServerMtlsConfigurer", func() {
 					SdsTlsCert: []byte("CERTIFICATE"),
 				},
 				Mesh: xds_context.MeshContext{
-					Resource: &mesh_core.MeshResource{
+					Resource: &core_mesh.MeshResource{
 						Meta: &test_model.ResourceMeta{
 							Name: "default",
 						},

--- a/pkg/xds/envoy/tls/v3/tls_test.go
+++ b/pkg/xds/envoy/tls/v3/tls_test.go
@@ -6,7 +6,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
-	mesh_core "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
+	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	core_xds "github.com/kumahq/kuma/pkg/core/xds"
 	test_model "github.com/kumahq/kuma/pkg/test/resources/model"
 	util_proto "github.com/kumahq/kuma/pkg/util/proto"
@@ -22,7 +22,7 @@ var _ = Describe("CreateDownstreamTlsContext()", func() {
 			// given
 			ctx := xds_context.Context{
 				Mesh: xds_context.MeshContext{
-					Resource: mesh_core.NewMeshResource(),
+					Resource: core_mesh.NewMeshResource(),
 				},
 			}
 			metadata := &core_xds.DataplaneMetadata{}
@@ -54,7 +54,7 @@ var _ = Describe("CreateDownstreamTlsContext()", func() {
 						SdsTlsCert: []byte("CERTIFICATE"),
 					},
 					Mesh: xds_context.MeshContext{
-						Resource: &mesh_core.MeshResource{
+						Resource: &core_mesh.MeshResource{
 							Meta: &test_model.ResourceMeta{
 								Name: "default",
 							},
@@ -197,7 +197,7 @@ var _ = Describe("CreateUpstreamTlsContext()", func() {
 			// given
 			ctx := xds_context.Context{
 				Mesh: xds_context.MeshContext{
-					Resource: mesh_core.NewMeshResource(),
+					Resource: core_mesh.NewMeshResource(),
 				},
 			}
 			metadata := &core_xds.DataplaneMetadata{}
@@ -230,7 +230,7 @@ var _ = Describe("CreateUpstreamTlsContext()", func() {
 						SdsTlsCert: []byte("CERTIFICATE"),
 					},
 					Mesh: xds_context.MeshContext{
-						Resource: &mesh_core.MeshResource{
+						Resource: &core_mesh.MeshResource{
 							Meta: &test_model.ResourceMeta{
 								Name: "default",
 							},

--- a/pkg/xds/generator/direct_access_proxy_generator.go
+++ b/pkg/xds/generator/direct_access_proxy_generator.go
@@ -8,7 +8,7 @@ import (
 
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	manager_dataplane "github.com/kumahq/kuma/pkg/core/managers/apis/dataplane"
-	mesh_core "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
+	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	core_xds "github.com/kumahq/kuma/pkg/core/xds"
 	xds_context "github.com/kumahq/kuma/pkg/xds/context"
 	envoy_common "github.com/kumahq/kuma/pkg/xds/envoy"
@@ -50,7 +50,7 @@ func (_ DirectAccessProxyGenerator) Generate(ctx xds_context.Context, proxy *cor
 			Configure(envoy_listeners.OutboundListener(name, endpoint.Address, endpoint.Port, core_xds.SocketAddressProtocolTCP)).
 			Configure(envoy_listeners.FilterChain(envoy_listeners.NewFilterChainBuilder(proxy.APIVersion).
 				Configure(envoy_listeners.TcpProxy(name, envoy_common.NewCluster(envoy_common.WithService("direct_access")))).
-				Configure(envoy_listeners.NetworkAccessLog(meshName, envoy_common.TrafficDirectionOutbound, sourceService, name, proxy.Policies.Logs[mesh_core.PassThroughService], proxy)))).
+				Configure(envoy_listeners.NetworkAccessLog(meshName, envoy_common.TrafficDirectionOutbound, sourceService, name, proxy.Policies.Logs[core_mesh.PassThroughService], proxy)))).
 			Configure(envoy_listeners.TransparentProxying(proxy.Dataplane.Spec.Networking.GetTransparentProxying())).
 			Build()
 		if err != nil {
@@ -78,7 +78,7 @@ func (_ DirectAccessProxyGenerator) Generate(ctx xds_context.Context, proxy *cor
 	return resources, nil
 }
 
-func directAccessEndpoints(dataplane *mesh_core.DataplaneResource, other *mesh_core.DataplaneResourceList, mesh *mesh_core.MeshResource) (Endpoints, error) {
+func directAccessEndpoints(dataplane *core_mesh.DataplaneResource, other *core_mesh.DataplaneResourceList, mesh *core_mesh.MeshResource) (Endpoints, error) {
 	// collect endpoints that are already created so we don't create 2 listeners with same IP:PORT
 	takenEndpoints, err := takenEndpoints(dataplane)
 	if err != nil {
@@ -121,7 +121,7 @@ func directAccessEndpoints(dataplane *mesh_core.DataplaneResource, other *mesh_c
 	return fromMap(endpoints), nil
 }
 
-func takenEndpoints(dataplane *mesh_core.DataplaneResource) (map[Endpoint]bool, error) {
+func takenEndpoints(dataplane *core_mesh.DataplaneResource) (map[Endpoint]bool, error) {
 	ofaces, err := dataplane.Spec.GetNetworking().GetOutboundInterfaces()
 	if err != nil {
 		return nil, err

--- a/pkg/xds/generator/dns_generator_test.go
+++ b/pkg/xds/generator/dns_generator_test.go
@@ -9,7 +9,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
-	mesh_core "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
+	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	model "github.com/kumahq/kuma/pkg/core/xds"
 	"github.com/kumahq/kuma/pkg/dns/resolver"
 	"github.com/kumahq/kuma/pkg/dns/vips"
@@ -47,7 +47,7 @@ var _ = Describe("DNSGenerator", func() {
 					DNSResolver: dnsResolver,
 				},
 				Mesh: xds_context.MeshContext{
-					Resource: &mesh_core.MeshResource{
+					Resource: &core_mesh.MeshResource{
 						Meta: &test_model.ResourceMeta{
 							Name: "default",
 						},
@@ -72,7 +72,7 @@ var _ = Describe("DNSGenerator", func() {
 			Expect(util_proto.FromYAML(dpBytes, &dataplane)).To(Succeed())
 			proxy := &model.Proxy{
 				Id: *model.BuildProxyId("", "side-car"),
-				Dataplane: &mesh_core.DataplaneResource{
+				Dataplane: &core_mesh.DataplaneResource{
 					Meta: &test_model.ResourceMeta{
 						Version: "1",
 					},

--- a/pkg/xds/generator/inbound_proxy_generator.go
+++ b/pkg/xds/generator/inbound_proxy_generator.go
@@ -4,7 +4,7 @@ import (
 	"github.com/pkg/errors"
 
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
-	mesh_core "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
+	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	"github.com/kumahq/kuma/pkg/core/validators"
 	model "github.com/kumahq/kuma/pkg/core/xds"
 	xds_context "github.com/kumahq/kuma/pkg/xds/context"
@@ -35,14 +35,14 @@ func (g InboundProxyGenerator) Generate(ctx xds_context.Context, proxy *model.Pr
 		}
 
 		iface := proxy.Dataplane.Spec.Networking.Inbound[i]
-		protocol := mesh_core.ParseProtocol(iface.GetProtocol())
+		protocol := core_mesh.ParseProtocol(iface.GetProtocol())
 
 		// generate CDS resource
 		localClusterName := envoy_names.GetLocalClusterName(endpoint.WorkloadPort)
 		clusterBuilder := envoy_clusters.NewClusterBuilder(proxy.APIVersion).
 			Configure(envoy_clusters.StaticCluster(localClusterName, endpoint.WorkloadIP, endpoint.WorkloadPort))
 		switch protocol {
-		case mesh_core.ProtocolHTTP2, mesh_core.ProtocolGRPC:
+		case core_mesh.ProtocolHTTP2, core_mesh.ProtocolGRPC:
 			clusterBuilder.Configure(envoy_clusters.Http2())
 		}
 		cluster, err := clusterBuilder.Build()
@@ -69,14 +69,14 @@ func (g InboundProxyGenerator) Generate(ctx xds_context.Context, proxy *model.Pr
 			filterChainBuilder := envoy_listeners.NewFilterChainBuilder(proxy.APIVersion)
 			switch protocol {
 			// configuration for HTTP case
-			case mesh_core.ProtocolHTTP, mesh_core.ProtocolHTTP2:
+			case core_mesh.ProtocolHTTP, core_mesh.ProtocolHTTP2:
 				filterChainBuilder.
 					Configure(envoy_listeners.HttpConnectionManager(localClusterName, true)).
 					Configure(envoy_listeners.FaultInjection(proxy.Policies.FaultInjections[endpoint])).
 					Configure(envoy_listeners.RateLimit(proxy.Policies.RateLimits[endpoint])).
 					Configure(envoy_listeners.Tracing(proxy.Policies.TracingBackend, service)).
 					Configure(envoy_listeners.HttpInboundRoutes(service, routes))
-			case mesh_core.ProtocolGRPC:
+			case core_mesh.ProtocolGRPC:
 				filterChainBuilder.
 					Configure(envoy_listeners.HttpConnectionManager(localClusterName, true)).
 					Configure(envoy_listeners.GrpcStats()).
@@ -84,11 +84,11 @@ func (g InboundProxyGenerator) Generate(ctx xds_context.Context, proxy *model.Pr
 					Configure(envoy_listeners.RateLimit(proxy.Policies.RateLimits[endpoint])).
 					Configure(envoy_listeners.Tracing(proxy.Policies.TracingBackend, service)).
 					Configure(envoy_listeners.HttpInboundRoutes(service, routes))
-			case mesh_core.ProtocolKafka:
+			case core_mesh.ProtocolKafka:
 				filterChainBuilder.
 					Configure(envoy_listeners.Kafka(localClusterName)).
 					Configure(envoy_listeners.TcpProxy(localClusterName, envoy_common.NewCluster(envoy_common.WithService(localClusterName))))
-			case mesh_core.ProtocolTCP:
+			case core_mesh.ProtocolTCP:
 				fallthrough
 			default:
 				// configuration for non-HTTP cases

--- a/pkg/xds/generator/inbound_proxy_generator_test.go
+++ b/pkg/xds/generator/inbound_proxy_generator_test.go
@@ -11,7 +11,7 @@ import (
 	"google.golang.org/protobuf/types/known/wrapperspb"
 
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
-	mesh_core "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
+	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	model "github.com/kumahq/kuma/pkg/core/xds"
 	. "github.com/kumahq/kuma/pkg/test/matchers"
 	test_model "github.com/kumahq/kuma/pkg/test/resources/model"
@@ -40,7 +40,7 @@ var _ = Describe("InboundProxyGenerator", func() {
 					SdsTlsCert: []byte("12345"),
 				},
 				Mesh: xds_context.MeshContext{
-					Resource: &mesh_core.MeshResource{
+					Resource: &core_mesh.MeshResource{
 						Meta: &test_model.ResourceMeta{
 							Name: "default",
 						},
@@ -65,7 +65,7 @@ var _ = Describe("InboundProxyGenerator", func() {
 			Expect(util_proto.FromYAML(dpBytes, &dataplane)).To(Succeed())
 			proxy := &model.Proxy{
 				Id: *model.BuildProxyId("", "side-car"),
-				Dataplane: &mesh_core.DataplaneResource{
+				Dataplane: &core_mesh.DataplaneResource{
 					Meta: &test_model.ResourceMeta{
 						Version: "1",
 					},
@@ -81,7 +81,7 @@ var _ = Describe("InboundProxyGenerator", func() {
 							DataplanePort:         80,
 							WorkloadIP:            "127.0.0.1",
 							WorkloadPort:          8080,
-						}: &mesh_core.TrafficPermissionResource{
+						}: &core_mesh.TrafficPermissionResource{
 							Meta: &test_model.ResourceMeta{
 								Name: "tp-1",
 								Mesh: "default",

--- a/pkg/xds/generator/ingress_generator_test.go
+++ b/pkg/xds/generator/ingress_generator_test.go
@@ -9,7 +9,7 @@ import (
 	"google.golang.org/protobuf/types/known/wrapperspb"
 
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
-	mesh_core "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
+	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	core_xds "github.com/kumahq/kuma/pkg/core/xds"
 	. "github.com/kumahq/kuma/pkg/test/matchers"
 	test_model "github.com/kumahq/kuma/pkg/test/resources/model"
@@ -24,7 +24,7 @@ var _ = Describe("IngressGenerator", func() {
 		dataplane       string
 		expected        string
 		outboundTargets core_xds.EndpointMap
-		trafficRoutes   *mesh_core.TrafficRouteResourceList
+		trafficRoutes   *core_mesh.TrafficRouteResourceList
 	}
 
 	DescribeTable("should generate Envoy xDS resources",
@@ -34,7 +34,7 @@ var _ = Describe("IngressGenerator", func() {
 			dataplane := &mesh_proto.Dataplane{}
 			Expect(util_proto.FromYAML([]byte(given.dataplane), dataplane)).To(Succeed())
 
-			zoneIngress, err := mesh_core.NewZoneIngressResourceFromDataplane(&mesh_core.DataplaneResource{
+			zoneIngress, err := core_mesh.NewZoneIngressResourceFromDataplane(&core_mesh.DataplaneResource{
 				Meta: &test_model.ResourceMeta{
 					Version: "1",
 				},
@@ -114,8 +114,8 @@ var _ = Describe("IngressGenerator", func() {
 					},
 				},
 			},
-			trafficRoutes: &mesh_core.TrafficRouteResourceList{
-				Items: []*mesh_core.TrafficRouteResource{
+			trafficRoutes: &core_mesh.TrafficRouteResourceList{
+				Items: []*core_mesh.TrafficRouteResource{
 					{
 						Spec: &mesh_proto.TrafficRoute{
 							Sources: []*mesh_proto.Selector{{
@@ -142,8 +142,8 @@ var _ = Describe("IngressGenerator", func() {
 `,
 			expected:        "02.envoy.golden.yaml",
 			outboundTargets: map[core_xds.ServiceName][]core_xds.Endpoint{},
-			trafficRoutes: &mesh_core.TrafficRouteResourceList{
-				Items: []*mesh_core.TrafficRouteResource{
+			trafficRoutes: &core_mesh.TrafficRouteResourceList{
+				Items: []*core_mesh.TrafficRouteResource{
 					{
 						Spec: &mesh_proto.TrafficRoute{
 							Sources: []*mesh_proto.Selector{{
@@ -206,8 +206,8 @@ var _ = Describe("IngressGenerator", func() {
 					},
 				},
 			},
-			trafficRoutes: &mesh_core.TrafficRouteResourceList{
-				Items: []*mesh_core.TrafficRouteResource{
+			trafficRoutes: &core_mesh.TrafficRouteResourceList{
+				Items: []*core_mesh.TrafficRouteResource{
 					{
 						Spec: &mesh_proto.TrafficRoute{
 							Sources: []*mesh_proto.Selector{{
@@ -362,8 +362,8 @@ var _ = Describe("IngressGenerator", func() {
 					},
 				},
 			},
-			trafficRoutes: &mesh_core.TrafficRouteResourceList{
-				Items: []*mesh_core.TrafficRouteResource{
+			trafficRoutes: &core_mesh.TrafficRouteResourceList{
+				Items: []*core_mesh.TrafficRouteResource{
 					{
 						Spec: &mesh_proto.TrafficRoute{
 							Sources: []*mesh_proto.Selector{{
@@ -484,8 +484,8 @@ var _ = Describe("IngressGenerator", func() {
 			outboundTargets: map[core_xds.ServiceName][]core_xds.Endpoint{
 				"backend": {},
 			},
-			trafficRoutes: &mesh_core.TrafficRouteResourceList{
-				Items: []*mesh_core.TrafficRouteResource{
+			trafficRoutes: &core_mesh.TrafficRouteResourceList{
+				Items: []*core_mesh.TrafficRouteResource{
 					{
 						Spec: &mesh_proto.TrafficRoute{
 							Sources: []*mesh_proto.Selector{{

--- a/pkg/xds/generator/outbound_proxy_generator.go
+++ b/pkg/xds/generator/outbound_proxy_generator.go
@@ -5,9 +5,9 @@ import (
 
 	"github.com/pkg/errors"
 
-	kuma_mesh "github.com/kumahq/kuma/api/mesh/v1alpha1"
+	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	"github.com/kumahq/kuma/pkg/core"
-	mesh_core "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
+	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	model "github.com/kumahq/kuma/pkg/core/xds"
 	xds_context "github.com/kumahq/kuma/pkg/xds/context"
 	envoy_common "github.com/kumahq/kuma/pkg/xds/envoy"
@@ -86,21 +86,21 @@ func (g OutboundProxyGenerator) Generate(ctx xds_context.Context, proxy *model.P
 	return resources, nil
 }
 
-func (_ OutboundProxyGenerator) generateLDS(proxy *model.Proxy, routes envoy_common.Routes, outbound *kuma_mesh.Dataplane_Networking_Outbound, protocol mesh_core.Protocol) (envoy_common.NamedResource, error) {
+func (_ OutboundProxyGenerator) generateLDS(proxy *model.Proxy, routes envoy_common.Routes, outbound *mesh_proto.Dataplane_Networking_Outbound, protocol core_mesh.Protocol) (envoy_common.NamedResource, error) {
 	oface := proxy.Dataplane.Spec.Networking.ToOutboundInterface(outbound)
 	meshName := proxy.Dataplane.Meta.GetMesh()
 	sourceService := proxy.Dataplane.Spec.GetIdentifyingService()
-	serviceName := outbound.GetTagsIncludingLegacy()[kuma_mesh.ServiceTag]
+	serviceName := outbound.GetTagsIncludingLegacy()[mesh_proto.ServiceTag]
 	outboundListenerName := envoy_names.GetOutboundListenerName(oface.DataplaneIP, oface.DataplanePort)
 	retryPolicy := proxy.Policies.Retries[serviceName]
-	var timeoutPolicyConf *kuma_mesh.Timeout_Conf
+	var timeoutPolicyConf *mesh_proto.Timeout_Conf
 	if timeoutPolicy := proxy.Policies.Timeouts[oface]; timeoutPolicy != nil {
 		timeoutPolicyConf = timeoutPolicy.Spec.GetConf()
 	}
 	filterChainBuilder := func() *envoy_listeners.FilterChainBuilder {
 		filterChainBuilder := envoy_listeners.NewFilterChainBuilder(proxy.APIVersion)
 		switch protocol {
-		case mesh_core.ProtocolGRPC:
+		case core_mesh.ProtocolGRPC:
 			filterChainBuilder.
 				Configure(envoy_listeners.HttpConnectionManager(serviceName, false)).
 				Configure(envoy_listeners.Tracing(proxy.Policies.TracingBackend, sourceService)).
@@ -108,7 +108,7 @@ func (_ OutboundProxyGenerator) generateLDS(proxy *model.Proxy, routes envoy_com
 				Configure(envoy_listeners.HttpOutboundRoute(serviceName, routes, proxy.Dataplane.Spec.TagSet())).
 				Configure(envoy_listeners.Retry(retryPolicy, protocol)).
 				Configure(envoy_listeners.GrpcStats())
-		case mesh_core.ProtocolHTTP, mesh_core.ProtocolHTTP2:
+		case core_mesh.ProtocolHTTP, core_mesh.ProtocolHTTP2:
 			filterChainBuilder.
 				Configure(envoy_listeners.HttpConnectionManager(serviceName, false)).
 				Configure(envoy_listeners.Tracing(proxy.Policies.TracingBackend, sourceService)).
@@ -122,7 +122,7 @@ func (_ OutboundProxyGenerator) generateLDS(proxy *model.Proxy, routes envoy_com
 				)).
 				Configure(envoy_listeners.HttpOutboundRoute(serviceName, routes, proxy.Dataplane.Spec.TagSet())).
 				Configure(envoy_listeners.Retry(retryPolicy, protocol))
-		case mesh_core.ProtocolKafka:
+		case core_mesh.ProtocolKafka:
 			filterChainBuilder.
 				Configure(envoy_listeners.Kafka(serviceName)).
 				Configure(envoy_listeners.TcpProxy(serviceName, routes.Clusters()...)).
@@ -136,7 +136,7 @@ func (_ OutboundProxyGenerator) generateLDS(proxy *model.Proxy, routes envoy_com
 				)).
 				Configure(envoy_listeners.MaxConnectAttempts(retryPolicy))
 
-		case mesh_core.ProtocolTCP:
+		case core_mesh.ProtocolTCP:
 			fallthrough
 		default:
 			// configuration for non-HTTP cases
@@ -189,9 +189,9 @@ func (o OutboundProxyGenerator) generateCDS(ctx xds_context.Context, proxy *mode
 						proxy.Dataplane.IsIPv6())).
 					Configure(envoy_clusters.ClientSideTLS(proxy.Routing.OutboundTargets[serviceName]))
 				switch protocol {
-				case mesh_core.ProtocolHTTP:
+				case core_mesh.ProtocolHTTP:
 					edsClusterBuilder.Configure(envoy_clusters.Http())
-				case mesh_core.ProtocolHTTP2, mesh_core.ProtocolGRPC:
+				case core_mesh.ProtocolHTTP2, core_mesh.ProtocolGRPC:
 					edsClusterBuilder.Configure(envoy_clusters.Http2())
 				default:
 				}
@@ -239,17 +239,17 @@ func (_ OutboundProxyGenerator) generateEDS(ctx xds_context.Context, services en
 }
 
 // inferProtocol infers protocol for the destination listener. It will only return HTTP when all endpoints are tagged with HTTP.
-func (_ OutboundProxyGenerator) inferProtocol(proxy *model.Proxy, clusters []envoy_common.Cluster) mesh_core.Protocol {
+func (_ OutboundProxyGenerator) inferProtocol(proxy *model.Proxy, clusters []envoy_common.Cluster) core_mesh.Protocol {
 	var allEndpoints []model.Endpoint
 	for _, cluster := range clusters {
-		serviceName := cluster.Tags()[kuma_mesh.ServiceTag]
+		serviceName := cluster.Tags()[mesh_proto.ServiceTag]
 		endpoints := model.EndpointList(proxy.Routing.OutboundTargets[serviceName])
 		allEndpoints = append(allEndpoints, endpoints...)
 	}
 	return InferServiceProtocol(allEndpoints)
 }
 
-func (_ OutboundProxyGenerator) determineRoutes(proxy *model.Proxy, outbound *kuma_mesh.Dataplane_Networking_Outbound, splitCounter *splitCounter) (routes envoy_common.Routes, err error) {
+func (_ OutboundProxyGenerator) determineRoutes(proxy *model.Proxy, outbound *mesh_proto.Dataplane_Networking_Outbound, splitCounter *splitCounter) (routes envoy_common.Routes, err error) {
 	oface := proxy.Dataplane.Spec.Networking.ToOutboundInterface(outbound)
 
 	route := proxy.Routing.TrafficRoutes[oface]
@@ -258,7 +258,7 @@ func (_ OutboundProxyGenerator) determineRoutes(proxy *model.Proxy, outbound *ku
 		return nil, nil
 	}
 
-	var timeoutConf *kuma_mesh.Timeout_Conf
+	var timeoutConf *mesh_proto.Timeout_Conf
 	if timeout := proxy.Policies.Timeouts[oface]; timeout != nil {
 		timeoutConf = timeout.Spec.GetConf()
 	}
@@ -268,10 +268,10 @@ func (_ OutboundProxyGenerator) determineRoutes(proxy *model.Proxy, outbound *ku
 	// If we have same split in many HTTP matches we can use the same cluster with different weight
 	clusterCache := map[string]string{}
 
-	clustersFromSplit := func(splits []*kuma_mesh.TrafficRoute_Split) []envoy_common.Cluster {
+	clustersFromSplit := func(splits []*mesh_proto.TrafficRoute_Split) []envoy_common.Cluster {
 		var clusters []envoy_common.Cluster
 		for _, destination := range splits {
-			service := destination.Destination[kuma_mesh.ServiceTag]
+			service := destination.Destination[mesh_proto.ServiceTag]
 			if destination.GetWeight().GetValue() == 0 {
 				// 0 assumes no traffic is passed there. Envoy doesn't support 0 weight, so instead of passing it to Envoy we just skip such cluster.
 				continue

--- a/pkg/xds/generator/outbound_proxy_generator_test.go
+++ b/pkg/xds/generator/outbound_proxy_generator_test.go
@@ -9,7 +9,7 @@ import (
 	"google.golang.org/protobuf/types/known/wrapperspb"
 
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
-	mesh_core "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
+	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	model "github.com/kumahq/kuma/pkg/core/xds"
 	. "github.com/kumahq/kuma/pkg/test/matchers"
 	test_model "github.com/kumahq/kuma/pkg/test/resources/model"
@@ -27,7 +27,7 @@ var _ = Describe("OutboundProxyGenerator", func() {
 	plainCtx := xds_context.Context{
 		ControlPlane: &xds_context.ControlPlaneContext{},
 		Mesh: xds_context.MeshContext{
-			Resource: &mesh_core.MeshResource{
+			Resource: &core_mesh.MeshResource{
 				Meta: meta,
 				Spec: &mesh_proto.Mesh{},
 			},
@@ -42,7 +42,7 @@ var _ = Describe("OutboundProxyGenerator", func() {
 			SdsTlsCert: []byte("12345"),
 		},
 		Mesh: xds_context.MeshContext{
-			Resource: &mesh_core.MeshResource{
+			Resource: &core_mesh.MeshResource{
 				Spec: &mesh_proto.Mesh{
 					Mtls: &mesh_proto.Mesh_Mtls{
 						EnabledBackend: "builtin",
@@ -160,7 +160,7 @@ var _ = Describe("OutboundProxyGenerator", func() {
 			}
 			proxy := &model.Proxy{
 				Id: *model.BuildProxyId("default", "side-car"),
-				Dataplane: &mesh_core.DataplaneResource{
+				Dataplane: &core_mesh.DataplaneResource{
 					Meta: &test_model.ResourceMeta{
 						Name:    "dp-1",
 						Mesh:    given.ctx.Mesh.Resource.Meta.GetName(),
@@ -174,7 +174,7 @@ var _ = Describe("OutboundProxyGenerator", func() {
 						mesh_proto.OutboundInterface{
 							DataplaneIP:   "127.0.0.1",
 							DataplanePort: 40001,
-						}: &mesh_core.TrafficRouteResource{
+						}: &core_mesh.TrafficRouteResource{
 							Spec: &mesh_proto.TrafficRoute{
 								Conf: &mesh_proto.TrafficRoute_Conf{
 									Destination: mesh_proto.MatchService("api-http"),
@@ -187,7 +187,7 @@ var _ = Describe("OutboundProxyGenerator", func() {
 						mesh_proto.OutboundInterface{
 							DataplaneIP:   "127.0.0.1",
 							DataplanePort: 40002,
-						}: &mesh_core.TrafficRouteResource{
+						}: &core_mesh.TrafficRouteResource{
 							Spec: &mesh_proto.TrafficRoute{
 								Conf: &mesh_proto.TrafficRoute_Conf{
 									Destination: mesh_proto.MatchService("api-tcp"),
@@ -204,7 +204,7 @@ var _ = Describe("OutboundProxyGenerator", func() {
 						mesh_proto.OutboundInterface{
 							DataplaneIP:   "127.0.0.1",
 							DataplanePort: 40003,
-						}: &mesh_core.TrafficRouteResource{
+						}: &core_mesh.TrafficRouteResource{
 							Spec: &mesh_proto.TrafficRoute{
 								Conf: &mesh_proto.TrafficRoute_Conf{
 									Destination: mesh_proto.MatchService("api-http2"),
@@ -223,7 +223,7 @@ var _ = Describe("OutboundProxyGenerator", func() {
 						mesh_proto.OutboundInterface{
 							DataplaneIP:   "127.0.0.1",
 							DataplanePort: 40004,
-						}: &mesh_core.TrafficRouteResource{
+						}: &core_mesh.TrafficRouteResource{
 							Spec: &mesh_proto.TrafficRoute{
 								Conf: &mesh_proto.TrafficRoute_Conf{
 									Destination: mesh_proto.MatchService("api-grpc"),
@@ -236,7 +236,7 @@ var _ = Describe("OutboundProxyGenerator", func() {
 						mesh_proto.OutboundInterface{
 							DataplaneIP:   "127.0.0.1",
 							DataplanePort: 18080,
-						}: &mesh_core.TrafficRouteResource{
+						}: &core_mesh.TrafficRouteResource{
 							Spec: &mesh_proto.TrafficRoute{
 								Conf: &mesh_proto.TrafficRoute_Conf{
 									Destination: mesh_proto.MatchService("backend"),
@@ -249,7 +249,7 @@ var _ = Describe("OutboundProxyGenerator", func() {
 						mesh_proto.OutboundInterface{
 							DataplaneIP:   "127.0.0.1",
 							DataplanePort: 54321,
-						}: &mesh_core.TrafficRouteResource{
+						}: &core_mesh.TrafficRouteResource{
 							Spec: &mesh_proto.TrafficRoute{
 								Conf: &mesh_proto.TrafficRoute_Conf{
 									Split: []*mesh_proto.TrafficRoute_Split{{
@@ -274,7 +274,7 @@ var _ = Describe("OutboundProxyGenerator", func() {
 						mesh_proto.OutboundInterface{
 							DataplaneIP:   "127.0.0.1",
 							DataplanePort: 18081,
-						}: &mesh_core.TrafficRouteResource{
+						}: &core_mesh.TrafficRouteResource{
 							Spec: &mesh_proto.TrafficRoute{
 								Conf: &mesh_proto.TrafficRoute_Conf{
 									Destination: mesh_proto.TagSelector{"kuma.io/service": "es", "kuma.io/protocol": "http"},
@@ -284,7 +284,7 @@ var _ = Describe("OutboundProxyGenerator", func() {
 						mesh_proto.OutboundInterface{
 							DataplaneIP:   "127.0.0.1",
 							DataplanePort: 18082,
-						}: &mesh_core.TrafficRouteResource{
+						}: &core_mesh.TrafficRouteResource{
 							Spec: &mesh_proto.TrafficRoute{
 								Conf: &mesh_proto.TrafficRoute_Conf{
 									Destination: mesh_proto.TagSelector{"kuma.io/service": "es2", "kuma.io/protocol": "http2"},
@@ -316,7 +316,7 @@ var _ = Describe("OutboundProxyGenerator", func() {
 						},
 					},
 					CircuitBreakers: model.CircuitBreakerMap{
-						"api-http": &mesh_core.CircuitBreakerResource{
+						"api-http": &core_mesh.CircuitBreakerResource{
 							Spec: &mesh_proto.CircuitBreaker{
 								Conf: &mesh_proto.CircuitBreaker_Conf{
 									Detectors: &mesh_proto.CircuitBreaker_Conf_Detectors{
@@ -501,7 +501,7 @@ var _ = Describe("OutboundProxyGenerator", func() {
 		}
 		proxy := &model.Proxy{
 			Id: *model.BuildProxyId("default", "side-car"),
-			Dataplane: &mesh_core.DataplaneResource{
+			Dataplane: &core_mesh.DataplaneResource{
 				Meta: &test_model.ResourceMeta{
 					Version: "1",
 				},
@@ -513,7 +513,7 @@ var _ = Describe("OutboundProxyGenerator", func() {
 					mesh_proto.OutboundInterface{
 						DataplaneIP:   "127.0.0.1",
 						DataplanePort: 18080,
-					}: &mesh_core.TrafficRouteResource{
+					}: &core_mesh.TrafficRouteResource{
 						Spec: &mesh_proto.TrafficRoute{
 							Conf: &mesh_proto.TrafficRoute_Conf{
 								Destination: mesh_proto.MatchService("backend.kuma-system"),
@@ -523,7 +523,7 @@ var _ = Describe("OutboundProxyGenerator", func() {
 					mesh_proto.OutboundInterface{
 						DataplaneIP:   "127.0.0.1",
 						DataplanePort: 54321,
-					}: &mesh_core.TrafficRouteResource{
+					}: &core_mesh.TrafficRouteResource{
 						Spec: &mesh_proto.TrafficRoute{
 							Conf: &mesh_proto.TrafficRoute_Conf{
 								Destination: mesh_proto.TagSelector{"kuma.io/service": "db", "version": "3.2.0"},

--- a/pkg/xds/generator/probe_generator_test.go
+++ b/pkg/xds/generator/probe_generator_test.go
@@ -8,7 +8,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
-	mesh_core "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
+	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	core_xds "github.com/kumahq/kuma/pkg/core/xds"
 	. "github.com/kumahq/kuma/pkg/test/matchers"
 	test_model "github.com/kumahq/kuma/pkg/test/resources/model"
@@ -32,7 +32,7 @@ var _ = Describe("ProbeGenerator", func() {
 			Expect(util_proto.FromYAML([]byte(given.dataplane), dataplane)).To(Succeed())
 
 			proxy := &core_xds.Proxy{
-				Dataplane: &mesh_core.DataplaneResource{
+				Dataplane: &core_mesh.DataplaneResource{
 					Meta: &test_model.ResourceMeta{
 						Version: "1",
 					},

--- a/pkg/xds/generator/prometheus_endpoint_generator.go
+++ b/pkg/xds/generator/prometheus_endpoint_generator.go
@@ -8,7 +8,7 @@ import (
 
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	manager_dataplane "github.com/kumahq/kuma/pkg/core/managers/apis/dataplane"
-	mesh_core "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
+	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	core_xds "github.com/kumahq/kuma/pkg/core/xds"
 	xds_context "github.com/kumahq/kuma/pkg/xds/context"
 	envoy_common "github.com/kumahq/kuma/pkg/xds/envoy"
@@ -155,6 +155,6 @@ func (g PrometheusEndpointGenerator) Generate(ctx xds_context.Context, proxy *co
 	return resources, nil
 }
 
-func secureMetrics(cfg *mesh_proto.PrometheusMetricsBackendConfig, mesh *mesh_core.MeshResource) bool {
+func secureMetrics(cfg *mesh_proto.PrometheusMetricsBackendConfig, mesh *core_mesh.MeshResource) bool {
 	return !cfg.SkipMTLS.GetValue() && mesh.MTLSEnabled()
 }

--- a/pkg/xds/generator/prometheus_endpoint_generator_test.go
+++ b/pkg/xds/generator/prometheus_endpoint_generator_test.go
@@ -9,7 +9,7 @@ import (
 	"google.golang.org/protobuf/types/known/wrapperspb"
 
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
-	mesh_core "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
+	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	core_xds "github.com/kumahq/kuma/pkg/core/xds"
 	. "github.com/kumahq/kuma/pkg/test/matchers"
 	test_model "github.com/kumahq/kuma/pkg/test/resources/model"
@@ -42,7 +42,7 @@ var _ = Describe("PrometheusEndpointGenerator", func() {
 		Entry("both Mesh and Dataplane have no Prometheus configuration", testCase{
 			ctx: xds_context.Context{
 				Mesh: xds_context.MeshContext{
-					Resource: &mesh_core.MeshResource{
+					Resource: &core_mesh.MeshResource{
 						Meta: &test_model.ResourceMeta{
 							Name: "demo",
 						},
@@ -52,7 +52,7 @@ var _ = Describe("PrometheusEndpointGenerator", func() {
 			},
 			proxy: &core_xds.Proxy{
 				Id: *core_xds.BuildProxyId("", "demo.backend-01"),
-				Dataplane: &mesh_core.DataplaneResource{
+				Dataplane: &core_mesh.DataplaneResource{
 					Meta: &test_model.ResourceMeta{
 						Name: "backend-01",
 						Mesh: "demo",
@@ -65,7 +65,7 @@ var _ = Describe("PrometheusEndpointGenerator", func() {
 		Entry("Dataplane has Prometheus configuration while Mesh doesn't", testCase{
 			ctx: xds_context.Context{
 				Mesh: xds_context.MeshContext{
-					Resource: &mesh_core.MeshResource{
+					Resource: &core_mesh.MeshResource{
 						Meta: &test_model.ResourceMeta{
 							Name: "demo",
 						},
@@ -76,7 +76,7 @@ var _ = Describe("PrometheusEndpointGenerator", func() {
 			proxy: &core_xds.Proxy{
 				Id:         *core_xds.BuildProxyId("", "demo.backend-01"),
 				APIVersion: envoy_common.APIV3,
-				Dataplane: &mesh_core.DataplaneResource{
+				Dataplane: &core_mesh.DataplaneResource{
 					Meta: &test_model.ResourceMeta{
 						Name: "backend-01",
 						Mesh: "demo",
@@ -97,7 +97,7 @@ var _ = Describe("PrometheusEndpointGenerator", func() {
 		Entry("both Mesh and Dataplane do have Prometheus configuration but dataplane metadata is unknown", testCase{
 			ctx: xds_context.Context{
 				Mesh: xds_context.MeshContext{
-					Resource: &mesh_core.MeshResource{
+					Resource: &core_mesh.MeshResource{
 						Meta: &test_model.ResourceMeta{
 							Name: "demo",
 						},
@@ -122,7 +122,7 @@ var _ = Describe("PrometheusEndpointGenerator", func() {
 			proxy: &core_xds.Proxy{
 				Id:         *core_xds.BuildProxyId("", "demo.backend-01"),
 				APIVersion: envoy_common.APIV3,
-				Dataplane: &mesh_core.DataplaneResource{
+				Dataplane: &core_mesh.DataplaneResource{
 					Meta: &test_model.ResourceMeta{
 						Name: "backend-01",
 						Mesh: "demo",
@@ -144,7 +144,7 @@ var _ = Describe("PrometheusEndpointGenerator", func() {
 		Entry("both Mesh and Dataplane do have Prometheus configuration but Admin API is not enabled on that dataplane", testCase{
 			ctx: xds_context.Context{
 				Mesh: xds_context.MeshContext{
-					Resource: &mesh_core.MeshResource{
+					Resource: &core_mesh.MeshResource{
 						Meta: &test_model.ResourceMeta{
 							Name: "demo",
 						},
@@ -169,7 +169,7 @@ var _ = Describe("PrometheusEndpointGenerator", func() {
 			proxy: &core_xds.Proxy{
 				Id:         *core_xds.BuildProxyId("", "demo.backend-01"),
 				APIVersion: envoy_common.APIV3,
-				Dataplane: &mesh_core.DataplaneResource{
+				Dataplane: &core_mesh.DataplaneResource{
 					Meta: &test_model.ResourceMeta{
 						Name: "backend-01",
 						Mesh: "demo",
@@ -215,7 +215,7 @@ var _ = Describe("PrometheusEndpointGenerator", func() {
 		Entry("should support a Dataplane without custom metrics configuration", testCase{
 			ctx: xds_context.Context{
 				Mesh: xds_context.MeshContext{
-					Resource: &mesh_core.MeshResource{
+					Resource: &core_mesh.MeshResource{
 						Meta: &test_model.ResourceMeta{
 							Name: "demo",
 						},
@@ -244,7 +244,7 @@ var _ = Describe("PrometheusEndpointGenerator", func() {
 			proxy: &core_xds.Proxy{
 				Id:         *core_xds.BuildProxyId("", "demo.backend-01"),
 				APIVersion: envoy_common.APIV3,
-				Dataplane: &mesh_core.DataplaneResource{
+				Dataplane: &core_mesh.DataplaneResource{
 					Meta: &test_model.ResourceMeta{
 						Name: "backend-01",
 						Mesh: "demo",
@@ -269,7 +269,7 @@ var _ = Describe("PrometheusEndpointGenerator", func() {
 		Entry("should support a Dataplane without metrics hijacker", testCase{
 			ctx: xds_context.Context{
 				Mesh: xds_context.MeshContext{
-					Resource: &mesh_core.MeshResource{
+					Resource: &core_mesh.MeshResource{
 						Meta: &test_model.ResourceMeta{
 							Name: "demo",
 						},
@@ -298,7 +298,7 @@ var _ = Describe("PrometheusEndpointGenerator", func() {
 			proxy: &core_xds.Proxy{
 				Id:         *core_xds.BuildProxyId("", "demo.backend-01"),
 				APIVersion: envoy_common.APIV3,
-				Dataplane: &mesh_core.DataplaneResource{
+				Dataplane: &core_mesh.DataplaneResource{
 					Meta: &test_model.ResourceMeta{
 						Name: "backend-01",
 						Mesh: "demo",
@@ -323,7 +323,7 @@ var _ = Describe("PrometheusEndpointGenerator", func() {
 		Entry("should support a Dataplane with custom metrics configuration", testCase{
 			ctx: xds_context.Context{
 				Mesh: xds_context.MeshContext{
-					Resource: &mesh_core.MeshResource{
+					Resource: &core_mesh.MeshResource{
 						Meta: &test_model.ResourceMeta{
 							Name: "demo",
 						},
@@ -348,7 +348,7 @@ var _ = Describe("PrometheusEndpointGenerator", func() {
 			proxy: &core_xds.Proxy{
 				Id:         *core_xds.BuildProxyId("", "demo.backend-01"),
 				APIVersion: envoy_common.APIV3,
-				Dataplane: &mesh_core.DataplaneResource{
+				Dataplane: &core_mesh.DataplaneResource{
 					Meta: &test_model.ResourceMeta{
 						Name: "backend-01",
 						Mesh: "demo",
@@ -387,7 +387,7 @@ var _ = Describe("PrometheusEndpointGenerator", func() {
 					SdsTlsCert: []byte("12345"),
 				},
 				Mesh: xds_context.MeshContext{
-					Resource: &mesh_core.MeshResource{
+					Resource: &core_mesh.MeshResource{
 						Meta: &test_model.ResourceMeta{
 							Name: "demo",
 						},
@@ -425,7 +425,7 @@ var _ = Describe("PrometheusEndpointGenerator", func() {
 			proxy: &core_xds.Proxy{
 				Id:         *core_xds.BuildProxyId("", "demo.backend-01"),
 				APIVersion: envoy_common.APIV3,
-				Dataplane: &mesh_core.DataplaneResource{
+				Dataplane: &core_mesh.DataplaneResource{
 					Meta: &test_model.ResourceMeta{
 						Name: "backend-01",
 						Mesh: "demo",
@@ -456,7 +456,7 @@ var _ = Describe("PrometheusEndpointGenerator", func() {
 					SdsTlsCert: []byte("12345"),
 				},
 				Mesh: xds_context.MeshContext{
-					Resource: &mesh_core.MeshResource{
+					Resource: &core_mesh.MeshResource{
 						Meta: &test_model.ResourceMeta{
 							Name: "demo",
 						},
@@ -493,7 +493,7 @@ var _ = Describe("PrometheusEndpointGenerator", func() {
 			proxy: &core_xds.Proxy{
 				Id:         *core_xds.BuildProxyId("", "demo.backend-01"),
 				APIVersion: envoy_common.APIV3,
-				Dataplane: &mesh_core.DataplaneResource{
+				Dataplane: &core_mesh.DataplaneResource{
 					Meta: &test_model.ResourceMeta{
 						Name: "backend-01",
 						Mesh: "demo",
@@ -524,7 +524,7 @@ var _ = Describe("PrometheusEndpointGenerator", func() {
 					SdsTlsCert: []byte("12345"),
 				},
 				Mesh: xds_context.MeshContext{
-					Resource: &mesh_core.MeshResource{
+					Resource: &core_mesh.MeshResource{
 						Meta: &test_model.ResourceMeta{
 							Name: "demo",
 						},
@@ -562,7 +562,7 @@ var _ = Describe("PrometheusEndpointGenerator", func() {
 			proxy: &core_xds.Proxy{
 				Id:         *core_xds.BuildProxyId("", "demo.backend-01"),
 				APIVersion: envoy_common.APIV3,
-				Dataplane: &mesh_core.DataplaneResource{
+				Dataplane: &core_mesh.DataplaneResource{
 					Meta: &test_model.ResourceMeta{
 						Name: "backend-01",
 						Mesh: "demo",
@@ -597,7 +597,7 @@ var _ = Describe("PrometheusEndpointGenerator", func() {
 				// given
 				ctx := xds_context.Context{
 					Mesh: xds_context.MeshContext{
-						Resource: &mesh_core.MeshResource{
+						Resource: &core_mesh.MeshResource{
 							Meta: &test_model.ResourceMeta{
 								Name: "demo",
 							},
@@ -622,7 +622,7 @@ var _ = Describe("PrometheusEndpointGenerator", func() {
 				proxy := &core_xds.Proxy{
 					Id:         *core_xds.BuildProxyId("", "demo.backend-01"),
 					APIVersion: envoy_common.APIV3,
-					Dataplane: &mesh_core.DataplaneResource{
+					Dataplane: &core_mesh.DataplaneResource{
 						Meta: &test_model.ResourceMeta{
 							Name: "backend-01",
 							Mesh: "demo",

--- a/pkg/xds/generator/protocol.go
+++ b/pkg/xds/generator/protocol.go
@@ -2,7 +2,7 @@ package generator
 
 import (
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
-	mesh_core "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
+	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	core_xds "github.com/kumahq/kuma/pkg/core/xds"
 )
 
@@ -11,12 +11,12 @@ var (
 	// HTTP has a protocol stack [HTTP, TCP],
 	// GRPC has a protocol stack [GRPC, HTTP2, TCP],
 	// TCP  has a protocol stack [TCP].
-	protocolStacks = map[mesh_core.Protocol]mesh_core.ProtocolList{
-		mesh_core.ProtocolGRPC:  {mesh_core.ProtocolGRPC, mesh_core.ProtocolHTTP2, mesh_core.ProtocolTCP},
-		mesh_core.ProtocolHTTP2: {mesh_core.ProtocolHTTP2, mesh_core.ProtocolTCP},
-		mesh_core.ProtocolHTTP:  {mesh_core.ProtocolHTTP, mesh_core.ProtocolTCP},
-		mesh_core.ProtocolKafka: {mesh_core.ProtocolKafka, mesh_core.ProtocolTCP},
-		mesh_core.ProtocolTCP:   {mesh_core.ProtocolTCP},
+	protocolStacks = map[core_mesh.Protocol]core_mesh.ProtocolList{
+		core_mesh.ProtocolGRPC:  {core_mesh.ProtocolGRPC, core_mesh.ProtocolHTTP2, core_mesh.ProtocolTCP},
+		core_mesh.ProtocolHTTP2: {core_mesh.ProtocolHTTP2, core_mesh.ProtocolTCP},
+		core_mesh.ProtocolHTTP:  {core_mesh.ProtocolHTTP, core_mesh.ProtocolTCP},
+		core_mesh.ProtocolKafka: {core_mesh.ProtocolKafka, core_mesh.ProtocolTCP},
+		core_mesh.ProtocolTCP:   {core_mesh.ProtocolTCP},
 	}
 )
 
@@ -28,20 +28,20 @@ var (
 // a common protocol between HTTP and TCP   is TCP,
 // a common protocol between GRPC and HTTP2 is HTTP2,
 // a common protocol between HTTP and HTTP2 is HTTP.
-func getCommonProtocol(one, another mesh_core.Protocol) mesh_core.Protocol {
+func getCommonProtocol(one, another core_mesh.Protocol) core_mesh.Protocol {
 	if one == another {
 		return one
 	}
-	if one == mesh_core.ProtocolUnknown || another == mesh_core.ProtocolUnknown {
-		return mesh_core.ProtocolUnknown
+	if one == core_mesh.ProtocolUnknown || another == core_mesh.ProtocolUnknown {
+		return core_mesh.ProtocolUnknown
 	}
 	oneProtocolStack, exist := protocolStacks[one]
 	if !exist {
-		return mesh_core.ProtocolUnknown
+		return core_mesh.ProtocolUnknown
 	}
 	anotherProtocolStack, exist := protocolStacks[another]
 	if !exist {
-		return mesh_core.ProtocolUnknown
+		return core_mesh.ProtocolUnknown
 	}
 	for _, firstProtocol := range oneProtocolStack {
 		for _, secondProtocol := range anotherProtocolStack {
@@ -50,17 +50,17 @@ func getCommonProtocol(one, another mesh_core.Protocol) mesh_core.Protocol {
 			}
 		}
 	}
-	return mesh_core.ProtocolUnknown
+	return core_mesh.ProtocolUnknown
 }
 
 // InferServiceProtocol returns a common protocol for a given group of endpoints.
-func InferServiceProtocol(endpoints []core_xds.Endpoint) mesh_core.Protocol {
+func InferServiceProtocol(endpoints []core_xds.Endpoint) core_mesh.Protocol {
 	if len(endpoints) == 0 {
-		return mesh_core.ProtocolUnknown
+		return core_mesh.ProtocolUnknown
 	}
-	serviceProtocol := mesh_core.ParseProtocol(endpoints[0].Tags[mesh_proto.ProtocolTag])
+	serviceProtocol := core_mesh.ParseProtocol(endpoints[0].Tags[mesh_proto.ProtocolTag])
 	for _, endpoint := range endpoints[1:] {
-		endpointProtocol := mesh_core.ParseProtocol(endpoint.Tags[mesh_proto.ProtocolTag])
+		endpointProtocol := core_mesh.ParseProtocol(endpoint.Tags[mesh_proto.ProtocolTag])
 		serviceProtocol = getCommonProtocol(serviceProtocol, endpointProtocol)
 	}
 	return serviceProtocol

--- a/pkg/xds/generator/protocol_private_test.go
+++ b/pkg/xds/generator/protocol_private_test.go
@@ -5,14 +5,14 @@ import (
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
 
-	mesh_core "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
+	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 )
 
 var _ = Describe("getCommonProtocol()", func() {
 	type testCase struct {
-		one      mesh_core.Protocol
-		another  mesh_core.Protocol
-		expected mesh_core.Protocol
+		one      core_mesh.Protocol
+		another  core_mesh.Protocol
+		expected core_mesh.Protocol
 	}
 
 	DescribeTable("should correctly determine common protocol",
@@ -23,89 +23,89 @@ var _ = Describe("getCommonProtocol()", func() {
 			Expect(actual).To(Equal(given.expected))
 		},
 		Entry("`unknown` and `unknown`", testCase{
-			one:      mesh_core.ProtocolUnknown,
-			another:  mesh_core.ProtocolUnknown,
-			expected: mesh_core.ProtocolUnknown,
+			one:      core_mesh.ProtocolUnknown,
+			another:  core_mesh.ProtocolUnknown,
+			expected: core_mesh.ProtocolUnknown,
 		}),
 		Entry("`unknown` and `http`", testCase{
-			one:      mesh_core.ProtocolUnknown,
-			another:  mesh_core.ProtocolHTTP,
-			expected: mesh_core.ProtocolUnknown,
+			one:      core_mesh.ProtocolUnknown,
+			another:  core_mesh.ProtocolHTTP,
+			expected: core_mesh.ProtocolUnknown,
 		}),
 		Entry("`http` and `unknown`", testCase{
-			one:      mesh_core.ProtocolHTTP,
-			another:  mesh_core.ProtocolUnknown,
-			expected: mesh_core.ProtocolUnknown,
+			one:      core_mesh.ProtocolHTTP,
+			another:  core_mesh.ProtocolUnknown,
+			expected: core_mesh.ProtocolUnknown,
 		}),
 		Entry("`unknown` and `tcp`", testCase{
-			one:      mesh_core.ProtocolUnknown,
-			another:  mesh_core.ProtocolTCP,
-			expected: mesh_core.ProtocolUnknown,
+			one:      core_mesh.ProtocolUnknown,
+			another:  core_mesh.ProtocolTCP,
+			expected: core_mesh.ProtocolUnknown,
 		}),
 		Entry("`tcp` and `unknown`", testCase{
-			one:      mesh_core.ProtocolTCP,
-			another:  mesh_core.ProtocolUnknown,
-			expected: mesh_core.ProtocolUnknown,
+			one:      core_mesh.ProtocolTCP,
+			another:  core_mesh.ProtocolUnknown,
+			expected: core_mesh.ProtocolUnknown,
 		}),
 		Entry("`http` and `tcp`", testCase{
-			one:      mesh_core.ProtocolHTTP,
-			another:  mesh_core.ProtocolTCP,
-			expected: mesh_core.ProtocolTCP,
+			one:      core_mesh.ProtocolHTTP,
+			another:  core_mesh.ProtocolTCP,
+			expected: core_mesh.ProtocolTCP,
 		}),
 		Entry("`tcp` and `http`", testCase{
-			one:      mesh_core.ProtocolTCP,
-			another:  mesh_core.ProtocolHTTP,
-			expected: mesh_core.ProtocolTCP,
+			one:      core_mesh.ProtocolTCP,
+			another:  core_mesh.ProtocolHTTP,
+			expected: core_mesh.ProtocolTCP,
 		}),
 		Entry("`http` and `http`", testCase{
-			one:      mesh_core.ProtocolHTTP,
-			another:  mesh_core.ProtocolHTTP,
-			expected: mesh_core.ProtocolHTTP,
+			one:      core_mesh.ProtocolHTTP,
+			another:  core_mesh.ProtocolHTTP,
+			expected: core_mesh.ProtocolHTTP,
 		}),
 		Entry("`tcp` and `tcp`", testCase{
-			one:      mesh_core.ProtocolTCP,
-			another:  mesh_core.ProtocolTCP,
-			expected: mesh_core.ProtocolTCP,
+			one:      core_mesh.ProtocolTCP,
+			another:  core_mesh.ProtocolTCP,
+			expected: core_mesh.ProtocolTCP,
 		}),
 		Entry("`http2` and `http2`", testCase{
-			one:      mesh_core.ProtocolHTTP2,
-			another:  mesh_core.ProtocolHTTP2,
-			expected: mesh_core.ProtocolHTTP2,
+			one:      core_mesh.ProtocolHTTP2,
+			another:  core_mesh.ProtocolHTTP2,
+			expected: core_mesh.ProtocolHTTP2,
 		}),
 		Entry("`http2` and `http`", testCase{
-			one:      mesh_core.ProtocolHTTP2,
-			another:  mesh_core.ProtocolHTTP,
-			expected: mesh_core.ProtocolTCP,
+			one:      core_mesh.ProtocolHTTP2,
+			another:  core_mesh.ProtocolHTTP,
+			expected: core_mesh.ProtocolTCP,
 		}),
 		Entry("`http2` and `tcp`", testCase{
-			one:      mesh_core.ProtocolHTTP2,
-			another:  mesh_core.ProtocolTCP,
-			expected: mesh_core.ProtocolTCP,
+			one:      core_mesh.ProtocolHTTP2,
+			another:  core_mesh.ProtocolTCP,
+			expected: core_mesh.ProtocolTCP,
 		}),
 		Entry("`grpc` and `grpc`", testCase{
-			one:      mesh_core.ProtocolGRPC,
-			another:  mesh_core.ProtocolGRPC,
-			expected: mesh_core.ProtocolGRPC,
+			one:      core_mesh.ProtocolGRPC,
+			another:  core_mesh.ProtocolGRPC,
+			expected: core_mesh.ProtocolGRPC,
 		}),
 		Entry("`grpc` and `http`", testCase{
-			one:      mesh_core.ProtocolGRPC,
-			another:  mesh_core.ProtocolHTTP,
-			expected: mesh_core.ProtocolTCP,
+			one:      core_mesh.ProtocolGRPC,
+			another:  core_mesh.ProtocolHTTP,
+			expected: core_mesh.ProtocolTCP,
 		}),
 		Entry("`grpc` and `http2`", testCase{
-			one:      mesh_core.ProtocolGRPC,
-			another:  mesh_core.ProtocolHTTP2,
-			expected: mesh_core.ProtocolHTTP2,
+			one:      core_mesh.ProtocolGRPC,
+			another:  core_mesh.ProtocolHTTP2,
+			expected: core_mesh.ProtocolHTTP2,
 		}),
 		Entry("`grpc` and `tcp`", testCase{
-			one:      mesh_core.ProtocolGRPC,
-			another:  mesh_core.ProtocolTCP,
-			expected: mesh_core.ProtocolTCP,
+			one:      core_mesh.ProtocolGRPC,
+			another:  core_mesh.ProtocolTCP,
+			expected: core_mesh.ProtocolTCP,
 		}),
 		Entry("`kafka` and `tcp`", testCase{
-			one:      mesh_core.ProtocolKafka,
-			another:  mesh_core.ProtocolTCP,
-			expected: mesh_core.ProtocolTCP,
+			one:      core_mesh.ProtocolKafka,
+			another:  core_mesh.ProtocolTCP,
+			expected: core_mesh.ProtocolTCP,
 		}),
 	)
 })

--- a/pkg/xds/generator/protocol_test.go
+++ b/pkg/xds/generator/protocol_test.go
@@ -5,7 +5,7 @@ import (
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
 
-	mesh_core "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
+	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	core_xds "github.com/kumahq/kuma/pkg/core/xds"
 	. "github.com/kumahq/kuma/pkg/xds/generator"
 )
@@ -14,7 +14,7 @@ var _ = Describe("InferServiceProtocol()", func() {
 
 	type testCase struct {
 		endpoints []core_xds.Endpoint
-		expected  mesh_core.Protocol
+		expected  core_mesh.Protocol
 	}
 
 	DescribeTable("should correctly infer common protocol for a group of endpoints",
@@ -26,119 +26,119 @@ var _ = Describe("InferServiceProtocol()", func() {
 		},
 		Entry("empty list", testCase{
 			endpoints: nil,
-			expected:  mesh_core.ProtocolUnknown,
+			expected:  core_mesh.ProtocolUnknown,
 		}),
 		Entry("one-item list: no `kuma.io/protocol` tag", testCase{
 			endpoints: []core_xds.Endpoint{
 				{Tags: map[string]string{"kuma.io/service": "backend"}},
 			},
-			expected: mesh_core.ProtocolUnknown,
+			expected: core_mesh.ProtocolUnknown,
 		}),
 		Entry("one-item list: `kuma.io/protocol: http`", testCase{
 			endpoints: []core_xds.Endpoint{
 				{Tags: map[string]string{"kuma.io/service": "backend", "kuma.io/protocol": "http"}},
 			},
-			expected: mesh_core.ProtocolHTTP,
+			expected: core_mesh.ProtocolHTTP,
 		}),
 		Entry("one-item list: `kuma.io/protocol: http2`", testCase{
 			endpoints: []core_xds.Endpoint{
 				{Tags: map[string]string{"kuma.io/service": "backend", "kuma.io/protocol": "http2"}},
 			},
-			expected: mesh_core.ProtocolHTTP2,
+			expected: core_mesh.ProtocolHTTP2,
 		}),
 		Entry("one-item list: `kuma.io/protocol: kafka`", testCase{
 			endpoints: []core_xds.Endpoint{
 				{Tags: map[string]string{"kuma.io/service": "kafka-broker", "kuma.io/protocol": "kafka"}},
 			},
-			expected: mesh_core.ProtocolKafka,
+			expected: core_mesh.ProtocolKafka,
 		}),
 		Entry("one-item list: `kuma.io/protocol: tcp`", testCase{
 			endpoints: []core_xds.Endpoint{
 				{Tags: map[string]string{"kuma.io/service": "backend", "kuma.io/protocol": "tcp"}},
 			},
-			expected: mesh_core.ProtocolTCP,
+			expected: core_mesh.ProtocolTCP,
 		}),
 		Entry("one-item list: `kuma.io/protocol: grpc`", testCase{
 			endpoints: []core_xds.Endpoint{
 				{Tags: map[string]string{"kuma.io/service": "backend", "kuma.io/protocol": "grpc"}},
 			},
-			expected: mesh_core.ProtocolGRPC,
+			expected: core_mesh.ProtocolGRPC,
 		}),
 		Entry("one-item list: `kuma.io/protocol: not-yet-supported-protocol`", testCase{
 			endpoints: []core_xds.Endpoint{
 				{Tags: map[string]string{"kuma.io/service": "backend", "kuma.io/protocol": "not-yet-supported-protocol"}},
 			},
-			expected: mesh_core.ProtocolUnknown,
+			expected: core_mesh.ProtocolUnknown,
 		}),
 		Entry("multi-item list: no `protocol` tag", testCase{
 			endpoints: []core_xds.Endpoint{
 				{Tags: map[string]string{"kuma.io/service": "backend", "region": "us"}},
 				{Tags: map[string]string{"kuma.io/service": "backend", "region": "eu"}},
 			},
-			expected: mesh_core.ProtocolUnknown,
+			expected: core_mesh.ProtocolUnknown,
 		}),
 		Entry("multi-item list: no `protocol` tag on some endpoints", testCase{
 			endpoints: []core_xds.Endpoint{
 				{Tags: map[string]string{"kuma.io/service": "backend", "region": "us", "kuma.io/protocol": "http"}},
 				{Tags: map[string]string{"kuma.io/service": "backend", "region": "eu"}},
 			},
-			expected: mesh_core.ProtocolUnknown,
+			expected: core_mesh.ProtocolUnknown,
 		}),
 		Entry("multi-item list: `kuma.io/protocol: http` on every endpoint", testCase{
 			endpoints: []core_xds.Endpoint{
 				{Tags: map[string]string{"kuma.io/service": "backend", "region": "us", "kuma.io/protocol": "http"}},
 				{Tags: map[string]string{"kuma.io/service": "backend", "region": "eu", "kuma.io/protocol": "http"}},
 			},
-			expected: mesh_core.ProtocolHTTP,
+			expected: core_mesh.ProtocolHTTP,
 		}),
 		Entry("multi-item list: `kuma.io/protocol: http` on every endpoint", testCase{
 			endpoints: []core_xds.Endpoint{
 				{Tags: map[string]string{"kuma.io/service": "backend", "region": "us", "kuma.io/protocol": "http2"}},
 				{Tags: map[string]string{"kuma.io/service": "backend", "region": "eu", "kuma.io/protocol": "http2"}},
 			},
-			expected: mesh_core.ProtocolHTTP2,
+			expected: core_mesh.ProtocolHTTP2,
 		}),
 		Entry("multi-item list: `kuma.io/protocol: tcp` on every endpoint", testCase{
 			endpoints: []core_xds.Endpoint{
 				{Tags: map[string]string{"kuma.io/service": "backend", "region": "us", "kuma.io/protocol": "tcp"}},
 				{Tags: map[string]string{"kuma.io/service": "backend", "region": "eu", "kuma.io/protocol": "tcp"}},
 			},
-			expected: mesh_core.ProtocolTCP,
+			expected: core_mesh.ProtocolTCP,
 		}),
 		Entry("multi-item list: `kuma.io/protocol: tcp` and `kuma.io/protocol: http`", testCase{
 			endpoints: []core_xds.Endpoint{
 				{Tags: map[string]string{"kuma.io/service": "backend", "region": "us", "kuma.io/protocol": "tcp"}},
 				{Tags: map[string]string{"kuma.io/service": "backend", "region": "eu", "kuma.io/protocol": "http"}},
 			},
-			expected: mesh_core.ProtocolTCP,
+			expected: core_mesh.ProtocolTCP,
 		}),
 		Entry("multi-item list: `kuma.io/protocol: grpc` on every endpoint", testCase{
 			endpoints: []core_xds.Endpoint{
 				{Tags: map[string]string{"kuma.io/service": "backend", "region": "us", "kuma.io/protocol": "grpc"}},
 				{Tags: map[string]string{"kuma.io/service": "backend", "region": "eu", "kuma.io/protocol": "grpc"}},
 			},
-			expected: mesh_core.ProtocolGRPC,
+			expected: core_mesh.ProtocolGRPC,
 		}),
 		Entry("multi-item list: `kuma.io/protocol: grpc` and `kuma.io/protocol: http`", testCase{
 			endpoints: []core_xds.Endpoint{
 				{Tags: map[string]string{"kuma.io/service": "backend", "region": "us", "kuma.io/protocol": "grpc"}},
 				{Tags: map[string]string{"kuma.io/service": "backend", "region": "eu", "kuma.io/protocol": "http"}},
 			},
-			expected: mesh_core.ProtocolTCP,
+			expected: core_mesh.ProtocolTCP,
 		}),
 		Entry("multi-item list: `kuma.io/protocol: grpc` and `kuma.io/protocol: http2`", testCase{
 			endpoints: []core_xds.Endpoint{
 				{Tags: map[string]string{"kuma.io/service": "backend", "region": "us", "kuma.io/protocol": "grpc"}},
 				{Tags: map[string]string{"kuma.io/service": "backend", "region": "eu", "kuma.io/protocol": "http2"}},
 			},
-			expected: mesh_core.ProtocolHTTP2,
+			expected: core_mesh.ProtocolHTTP2,
 		}),
 		Entry("multi-item list: `kuma.io/protocol: grpc` and `kuma.io/protocol: tcp`", testCase{
 			endpoints: []core_xds.Endpoint{
 				{Tags: map[string]string{"kuma.io/service": "backend", "region": "us", "kuma.io/protocol": "grpc"}},
 				{Tags: map[string]string{"kuma.io/service": "backend", "region": "eu", "kuma.io/protocol": "tcp"}},
 			},
-			expected: mesh_core.ProtocolTCP,
+			expected: core_mesh.ProtocolTCP,
 		}),
 	)
 })

--- a/pkg/xds/generator/proxy_template.go
+++ b/pkg/xds/generator/proxy_template.go
@@ -6,7 +6,7 @@ import (
 	"github.com/pkg/errors"
 
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
-	mesh_core "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
+	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	model "github.com/kumahq/kuma/pkg/core/xds"
 	util_envoy "github.com/kumahq/kuma/pkg/util/envoy"
 	xds_context "github.com/kumahq/kuma/pkg/xds/context"
@@ -96,7 +96,7 @@ func NewDefaultProxyProfile() ResourceGenerator {
 var DefaultTemplateResolver template.ProxyTemplateResolver = &template.StaticProxyTemplateResolver{
 	Template: &mesh_proto.ProxyTemplate{
 		Conf: &mesh_proto.ProxyTemplate_Conf{
-			Imports: []string{mesh_core.ProfileDefaultProxy},
+			Imports: []string{core_mesh.ProfileDefaultProxy},
 		},
 	},
 }
@@ -104,7 +104,7 @@ var DefaultTemplateResolver template.ProxyTemplateResolver = &template.StaticPro
 var predefinedProfiles = make(map[string]ResourceGenerator)
 
 func init() {
-	RegisterProfile(mesh_core.ProfileDefaultProxy, NewDefaultProxyProfile())
+	RegisterProfile(core_mesh.ProfileDefaultProxy, NewDefaultProxyProfile())
 	RegisterProfile(IngressProxy, CompositeResourceGenerator{AdminProxyGenerator{}, IngressGenerator{}})
 }
 

--- a/pkg/xds/generator/proxy_template_profile_source_test.go
+++ b/pkg/xds/generator/proxy_template_profile_source_test.go
@@ -12,7 +12,7 @@ import (
 	"google.golang.org/protobuf/types/known/durationpb"
 
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
-	mesh_core "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
+	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	model "github.com/kumahq/kuma/pkg/core/xds"
 	. "github.com/kumahq/kuma/pkg/test/matchers"
 	test_model "github.com/kumahq/kuma/pkg/test/resources/model"
@@ -83,7 +83,7 @@ var _ = Describe("ProxyTemplateProfileSource", func() {
 					CLACache: &dummyCLACache{outboundTargets: outboundTargets},
 				},
 				Mesh: xds_context.MeshContext{
-					Resource: &mesh_core.MeshResource{
+					Resource: &core_mesh.MeshResource{
 						Meta: &test_model.ResourceMeta{
 							Name: "demo",
 						},
@@ -100,7 +100,7 @@ var _ = Describe("ProxyTemplateProfileSource", func() {
 
 			proxy := &model.Proxy{
 				Id: *model.BuildProxyId("", "demo.backend-01"),
-				Dataplane: &mesh_core.DataplaneResource{
+				Dataplane: &core_mesh.DataplaneResource{
 					Meta: &test_model.ResourceMeta{
 						Name:    "backend-01",
 						Mesh:    "demo",
@@ -114,7 +114,7 @@ var _ = Describe("ProxyTemplateProfileSource", func() {
 						mesh_proto.OutboundInterface{
 							DataplaneIP:   "127.0.0.1",
 							DataplanePort: 54321,
-						}: &mesh_core.TrafficRouteResource{
+						}: &core_mesh.TrafficRouteResource{
 							Spec: &mesh_proto.TrafficRoute{
 								Conf: &mesh_proto.TrafficRoute_Conf{
 									Destination: mesh_proto.MatchService("db"),
@@ -124,7 +124,7 @@ var _ = Describe("ProxyTemplateProfileSource", func() {
 						mesh_proto.OutboundInterface{
 							DataplaneIP:   "127.0.0.1",
 							DataplanePort: 59200,
-						}: &mesh_core.TrafficRouteResource{
+						}: &core_mesh.TrafficRouteResource{
 							Spec: &mesh_proto.TrafficRoute{
 								Conf: &mesh_proto.TrafficRoute_Conf{
 									Destination: mesh_proto.MatchService("elastic"),
@@ -136,7 +136,7 @@ var _ = Describe("ProxyTemplateProfileSource", func() {
 				},
 				Policies: model.MatchedPolicies{
 					HealthChecks: model.HealthCheckMap{
-						"elastic": &mesh_core.HealthCheckResource{
+						"elastic": &core_mesh.HealthCheckResource{
 							Spec: &mesh_proto.HealthCheck{
 								Sources: []*mesh_proto.Selector{
 									{Match: mesh_proto.TagSelector{"kuma.io/service": "*"}},
@@ -204,7 +204,7 @@ var _ = Describe("ProxyTemplateProfileSource", func() {
               - port: 59200
                 service: elastic
 `,
-			profile:  mesh_core.ProfileDefaultProxy,
+			profile:  core_mesh.ProfileDefaultProxy,
 			expected: "1-envoy-config.golden.yaml",
 		}),
 		Entry("should support pre-defined `default-proxy` profile; transparent_proxying=true", testCase{
@@ -232,7 +232,7 @@ var _ = Describe("ProxyTemplateProfileSource", func() {
                 redirectPortOutbound: 15001
                 redirectPortInbound: 15006
 `,
-			profile:  mesh_core.ProfileDefaultProxy,
+			profile:  core_mesh.ProfileDefaultProxy,
 			expected: "2-envoy-config.golden.yaml",
 		}),
 		Entry("should support pre-defined `default-proxy` profile; transparent_proxying=false; prometheus_metrics=true", testCase{
@@ -267,7 +267,7 @@ var _ = Describe("ProxyTemplateProfileSource", func() {
               - port: 59200
                 service: elastic
 `,
-			profile:  mesh_core.ProfileDefaultProxy,
+			profile:  core_mesh.ProfileDefaultProxy,
 			expected: "3-envoy-config.golden.yaml",
 		}),
 		Entry("should support pre-defined `default-proxy` profile; transparent_proxying=true; prometheus_metrics=true", testCase{
@@ -305,7 +305,7 @@ var _ = Describe("ProxyTemplateProfileSource", func() {
                 redirectPortOutbound: 15001
                 redirectPortInbound: 15006
 `,
-			profile:  mesh_core.ProfileDefaultProxy,
+			profile:  core_mesh.ProfileDefaultProxy,
 			expected: "4-envoy-config.golden.yaml",
 		}),
 	)

--- a/pkg/xds/generator/proxy_template_raw_source_test.go
+++ b/pkg/xds/generator/proxy_template_raw_source_test.go
@@ -6,7 +6,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
-	mesh_core "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
+	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	model "github.com/kumahq/kuma/pkg/core/xds"
 	test_model "github.com/kumahq/kuma/pkg/test/resources/model"
 	util_proto "github.com/kumahq/kuma/pkg/util/proto"
@@ -44,7 +44,7 @@ var _ = Describe("ProxyTemplateRawSource", func() {
 			Entry("should fail when `resource` field is empty", testCase{
 				proxy: &model.Proxy{
 					Id: *model.BuildProxyId("", "side-car"),
-					Dataplane: &mesh_core.DataplaneResource{
+					Dataplane: &core_mesh.DataplaneResource{
 						Meta: &test_model.ResourceMeta{
 							Version: "v1",
 						},
@@ -72,7 +72,7 @@ var _ = Describe("ProxyTemplateRawSource", func() {
 			Entry("should fail when `resource` field is neither a YAML nor a JSON", testCase{
 				proxy: &model.Proxy{
 					Id: *model.BuildProxyId("", "side-car"),
-					Dataplane: &mesh_core.DataplaneResource{
+					Dataplane: &core_mesh.DataplaneResource{
 						Meta: &test_model.ResourceMeta{
 							Version: "v1",
 						},
@@ -100,7 +100,7 @@ var _ = Describe("ProxyTemplateRawSource", func() {
 			Entry("should fail when `resource` field has unknown @type", testCase{
 				proxy: &model.Proxy{
 					Id: *model.BuildProxyId("", "side-car"),
-					Dataplane: &mesh_core.DataplaneResource{
+					Dataplane: &core_mesh.DataplaneResource{
 						Meta: &test_model.ResourceMeta{
 							Version: "v1",
 						},
@@ -130,7 +130,7 @@ var _ = Describe("ProxyTemplateRawSource", func() {
 			Entry("should fail when `resource` field is a YAML without '@type' field", testCase{
 				proxy: &model.Proxy{
 					Id: *model.BuildProxyId("", "side-car"),
-					Dataplane: &mesh_core.DataplaneResource{
+					Dataplane: &core_mesh.DataplaneResource{
 						Meta: &test_model.ResourceMeta{
 							Version: "v1",
 						},
@@ -171,7 +171,7 @@ var _ = Describe("ProxyTemplateRawSource", func() {
 			Entry("should fail when `resource` field is an invalid xDS resource", testCase{
 				proxy: &model.Proxy{
 					Id: *model.BuildProxyId("", "side-car"),
-					Dataplane: &mesh_core.DataplaneResource{
+					Dataplane: &core_mesh.DataplaneResource{
 						Meta: &test_model.ResourceMeta{
 							Version: "v1",
 						},
@@ -247,7 +247,7 @@ var _ = Describe("ProxyTemplateRawSource", func() {
 			Entry("should support empty resource list", testCase{
 				proxy: &model.Proxy{
 					Id: *model.BuildProxyId("", "side-car"),
-					Dataplane: &mesh_core.DataplaneResource{
+					Dataplane: &core_mesh.DataplaneResource{
 						Meta: &test_model.ResourceMeta{
 							Version: "v1",
 						},
@@ -271,7 +271,7 @@ var _ = Describe("ProxyTemplateRawSource", func() {
 			Entry("should support Listener resource as YAML", testCase{
 				proxy: &model.Proxy{
 					Id: *model.BuildProxyId("", "side-car"),
-					Dataplane: &mesh_core.DataplaneResource{
+					Dataplane: &core_mesh.DataplaneResource{
 						Meta: &test_model.ResourceMeta{
 							Version: "v1",
 						},
@@ -332,7 +332,7 @@ var _ = Describe("ProxyTemplateRawSource", func() {
 			Entry("should support Cluster resource as YAML", testCase{
 				proxy: &model.Proxy{
 					Id: *model.BuildProxyId("", "side-car"),
-					Dataplane: &mesh_core.DataplaneResource{
+					Dataplane: &core_mesh.DataplaneResource{
 						Meta: &test_model.ResourceMeta{
 							Version: "v1",
 						},
@@ -391,7 +391,7 @@ var _ = Describe("ProxyTemplateRawSource", func() {
 			Entry("should support Cluster resource as JSON", testCase{
 				proxy: &model.Proxy{
 					Id: *model.BuildProxyId("", "side-car"),
-					Dataplane: &mesh_core.DataplaneResource{
+					Dataplane: &core_mesh.DataplaneResource{
 						Meta: &test_model.ResourceMeta{
 							Version: "v1",
 						},

--- a/pkg/xds/generator/proxy_template_test.go
+++ b/pkg/xds/generator/proxy_template_test.go
@@ -9,7 +9,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
-	mesh_core "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
+	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	model "github.com/kumahq/kuma/pkg/core/xds"
 	. "github.com/kumahq/kuma/pkg/test/matchers"
 	test_model "github.com/kumahq/kuma/pkg/test/resources/model"
@@ -41,7 +41,7 @@ var _ = Describe("ProxyTemplateGenerator", func() {
 						SdsTlsCert: []byte("12345"),
 					},
 					Mesh: xds_context.MeshContext{
-						Resource: &mesh_core.MeshResource{
+						Resource: &core_mesh.MeshResource{
 							Meta: &test_model.ResourceMeta{
 								Name: "demo",
 							},
@@ -61,7 +61,7 @@ var _ = Describe("ProxyTemplateGenerator", func() {
 			Entry("should fail when raw xDS resource is not valid", testCase{
 				proxy: &model.Proxy{
 					Id: *model.BuildProxyId("", "demo.backend-01"),
-					Dataplane: &mesh_core.DataplaneResource{
+					Dataplane: &core_mesh.DataplaneResource{
 						Meta: &test_model.ResourceMeta{
 							Name:    "backend-01",
 							Mesh:    "demo",
@@ -88,7 +88,7 @@ var _ = Describe("ProxyTemplateGenerator", func() {
 				template: &mesh_proto.ProxyTemplate{
 					Conf: &mesh_proto.ProxyTemplate_Conf{
 						Imports: []string{
-							mesh_core.ProfileDefaultProxy,
+							core_mesh.ProfileDefaultProxy,
 						},
 						Resources: []*mesh_proto.ProxyTemplateRawResource{{
 							Name:     "raw-name",
@@ -130,7 +130,7 @@ var _ = Describe("ProxyTemplateGenerator", func() {
 						SdsTlsCert: []byte("12345"),
 					},
 					Mesh: xds_context.MeshContext{
-						Resource: &mesh_core.MeshResource{
+						Resource: &core_mesh.MeshResource{
 							Meta: &test_model.ResourceMeta{
 								Name: "demo",
 							},
@@ -153,7 +153,7 @@ var _ = Describe("ProxyTemplateGenerator", func() {
 				Expect(util_proto.FromYAML([]byte(given.dataplane), dataplane)).To(Succeed())
 				proxy := &model.Proxy{
 					Id: *model.BuildProxyId("", "demo.backend-01"),
-					Dataplane: &mesh_core.DataplaneResource{
+					Dataplane: &core_mesh.DataplaneResource{
 						Meta: &test_model.ResourceMeta{
 							Name:    "backend-01",
 							Mesh:    "demo",

--- a/pkg/xds/generator/tracing_generator_test.go
+++ b/pkg/xds/generator/tracing_generator_test.go
@@ -8,7 +8,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
-	mesh_core "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
+	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	core_xds "github.com/kumahq/kuma/pkg/core/xds"
 	. "github.com/kumahq/kuma/pkg/test/matchers"
 	test_model "github.com/kumahq/kuma/pkg/test/resources/model"
@@ -41,7 +41,7 @@ var _ = Describe("TracingProxyGenerator", func() {
 		Entry("Mesh has no Tracing configuration", testCase{
 			proxy: &core_xds.Proxy{
 				Id: *core_xds.BuildProxyId("", "demo.backend-01"),
-				Dataplane: &mesh_core.DataplaneResource{
+				Dataplane: &core_mesh.DataplaneResource{
 					Meta: &test_model.ResourceMeta{
 						Name: "backend-01",
 						Mesh: "demo",
@@ -74,7 +74,7 @@ var _ = Describe("TracingProxyGenerator", func() {
 		Entry("should create cluster for Zipkin", testCase{
 			proxy: &core_xds.Proxy{
 				Id: *core_xds.BuildProxyId("", "demo.backend-01"),
-				Dataplane: &mesh_core.DataplaneResource{
+				Dataplane: &core_mesh.DataplaneResource{
 					Meta: &test_model.ResourceMeta{
 						Name: "backend-01",
 						Mesh: "demo",

--- a/pkg/xds/generator/transparent_proxy_generator.go
+++ b/pkg/xds/generator/transparent_proxy_generator.go
@@ -3,7 +3,7 @@ package generator
 import (
 	"github.com/pkg/errors"
 
-	mesh_core "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
+	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	model "github.com/kumahq/kuma/pkg/core/xds"
 	xds_context "github.com/kumahq/kuma/pkg/xds/context"
 	envoy_common "github.com/kumahq/kuma/pkg/xds/envoy"
@@ -78,7 +78,7 @@ func (_ TransparentProxyGenerator) generate(ctx xds_context.Context, proxy *mode
 		Configure(envoy_listeners.OutboundListener(outboundName, allIP, redirectPortOutbound, model.SocketAddressProtocolTCP)).
 		Configure(envoy_listeners.FilterChain(envoy_listeners.NewFilterChainBuilder(proxy.APIVersion).
 			Configure(envoy_listeners.TcpProxy(outboundName, envoy_common.NewCluster(envoy_common.WithService(outboundName)))).
-			Configure(envoy_listeners.NetworkAccessLog(meshName, envoy_common.TrafficDirectionUnspecified, sourceService, "external", proxy.Policies.Logs[mesh_core.PassThroughService], proxy)))).
+			Configure(envoy_listeners.NetworkAccessLog(meshName, envoy_common.TrafficDirectionUnspecified, sourceService, "external", proxy.Policies.Logs[core_mesh.PassThroughService], proxy)))).
 		Configure(envoy_listeners.OriginalDstForwarder()).
 		Build()
 	if err != nil {

--- a/pkg/xds/generator/transparent_proxy_generator_test.go
+++ b/pkg/xds/generator/transparent_proxy_generator_test.go
@@ -8,7 +8,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
-	mesh_core "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
+	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	model "github.com/kumahq/kuma/pkg/core/xds"
 	. "github.com/kumahq/kuma/pkg/test/matchers"
 	test_model "github.com/kumahq/kuma/pkg/test/resources/model"
@@ -31,7 +31,7 @@ var _ = Describe("TransparentProxyGenerator", func() {
 			gen := &generator.TransparentProxyGenerator{}
 			ctx := xds_context.Context{
 				Mesh: xds_context.MeshContext{
-					Resource: &mesh_core.MeshResource{
+					Resource: &core_mesh.MeshResource{
 						Meta: &test_model.ResourceMeta{
 							Name: "default",
 						},
@@ -57,7 +57,7 @@ var _ = Describe("TransparentProxyGenerator", func() {
 		Entry("transparent_proxying=false", testCase{
 			proxy: &model.Proxy{
 				Id: *model.BuildProxyId("", "side-car"),
-				Dataplane: &mesh_core.DataplaneResource{
+				Dataplane: &core_mesh.DataplaneResource{
 					Meta: &test_model.ResourceMeta{
 						Version: "v1",
 					},
@@ -69,7 +69,7 @@ var _ = Describe("TransparentProxyGenerator", func() {
 		Entry("transparent_proxying=true", testCase{
 			proxy: &model.Proxy{
 				Id: *model.BuildProxyId("", "side-car"),
-				Dataplane: &mesh_core.DataplaneResource{
+				Dataplane: &core_mesh.DataplaneResource{
 					Meta: &test_model.ResourceMeta{
 						Version: "v1",
 					},
@@ -100,7 +100,7 @@ var _ = Describe("TransparentProxyGenerator", func() {
 		Entry("transparent_proxying=true with logs", testCase{
 			proxy: &model.Proxy{
 				Id: *model.BuildProxyId("", "side-car"),
-				Dataplane: &mesh_core.DataplaneResource{
+				Dataplane: &core_mesh.DataplaneResource{
 					Meta: &test_model.ResourceMeta{
 						Version: "v1",
 					},
@@ -131,7 +131,7 @@ var _ = Describe("TransparentProxyGenerator", func() {
 		Entry("transparent_proxying=true ipv6", testCase{
 			proxy: &model.Proxy{
 				Id: *model.BuildProxyId("", "side-car"),
-				Dataplane: &mesh_core.DataplaneResource{
+				Dataplane: &core_mesh.DataplaneResource{
 					Meta: &test_model.ResourceMeta{
 						Version: "v1",
 					},

--- a/pkg/xds/ingress/outbound.go
+++ b/pkg/xds/ingress/outbound.go
@@ -2,12 +2,12 @@ package ingress
 
 import (
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
-	mesh_core "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
+	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	core_xds "github.com/kumahq/kuma/pkg/core/xds"
 	"github.com/kumahq/kuma/pkg/xds/envoy"
 )
 
-func BuildEndpointMap(destinations core_xds.DestinationMap, dataplanes []*mesh_core.DataplaneResource) core_xds.EndpointMap {
+func BuildEndpointMap(destinations core_xds.DestinationMap, dataplanes []*core_mesh.DataplaneResource) core_xds.EndpointMap {
 	if len(destinations) == 0 {
 		return nil
 	}

--- a/pkg/xds/server/v3/reconcile_test.go
+++ b/pkg/xds/server/v3/reconcile_test.go
@@ -13,7 +13,7 @@ import (
 
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	"github.com/kumahq/kuma/pkg/core"
-	mesh_core "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
+	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	xds_model "github.com/kumahq/kuma/pkg/core/xds"
 	test_model "github.com/kumahq/kuma/pkg/test/resources/model"
 	xds_context "github.com/kumahq/kuma/pkg/xds/context"
@@ -102,7 +102,7 @@ var _ = Describe("Reconcile", func() {
 			}
 
 			// given
-			dataplane := &mesh_core.DataplaneResource{
+			dataplane := &core_mesh.DataplaneResource{
 				Meta: &test_model.ResourceMeta{
 					Mesh:    "demo",
 					Name:    "example",

--- a/pkg/xds/server/v3/snapshot_generator_test.go
+++ b/pkg/xds/server/v3/snapshot_generator_test.go
@@ -8,7 +8,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
-	mesh_core "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
+	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	"github.com/kumahq/kuma/pkg/core/resources/manager"
 	model "github.com/kumahq/kuma/pkg/core/xds"
 	"github.com/kumahq/kuma/pkg/plugins/resources/memory"
@@ -44,7 +44,7 @@ var _ = Describe("Reconcile", func() {
 					SdsTlsCert: []byte("12345"),
 				},
 				Mesh: xds_context.MeshContext{
-					Resource: &mesh_core.MeshResource{
+					Resource: &core_mesh.MeshResource{
 						Meta: &test_model.ResourceMeta{
 							Name: "demo",
 						},
@@ -71,7 +71,7 @@ var _ = Describe("Reconcile", func() {
 			proxy := &model.Proxy{
 				Id:         *model.BuildProxyId("", "demo.web1"),
 				APIVersion: envoy_common.APIV3,
-				Dataplane: &mesh_core.DataplaneResource{
+				Dataplane: &core_mesh.DataplaneResource{
 					Meta: &test_model.ResourceMeta{
 						Name:    "web1",
 						Mesh:    "demo",
@@ -87,7 +87,7 @@ var _ = Describe("Reconcile", func() {
 							DataplanePort:         80,
 							WorkloadIP:            "127.0.0.1",
 							WorkloadPort:          8080,
-						}: &mesh_core.TrafficPermissionResource{
+						}: &core_mesh.TrafficPermissionResource{
 							Meta: &test_model.ResourceMeta{
 								Name: "tp-1",
 								Mesh: "default",

--- a/pkg/xds/sync/dataplane_watchdog.go
+++ b/pkg/xds/sync/dataplane_watchdog.go
@@ -8,7 +8,7 @@ import (
 
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	"github.com/kumahq/kuma/pkg/core"
-	mesh_core "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
+	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	core_model "github.com/kumahq/kuma/pkg/core/resources/model"
 	"github.com/kumahq/kuma/pkg/core/resources/store"
 	core_xds "github.com/kumahq/kuma/pkg/core/xds"
@@ -57,7 +57,7 @@ func (d *DataplaneWatchdog) Sync() error {
 	}
 	// backwards compatibility
 	if d.dpType == mesh_proto.DataplaneProxyType && !d.proxyTypeSettled {
-		dataplane := mesh_core.NewDataplaneResource()
+		dataplane := core_mesh.NewDataplaneResource()
 		if err := d.dataplaneProxyBuilder.CachingResManager.Get(ctx, dataplane, store.GetBy(d.key)); err != nil {
 			return err
 		}

--- a/pkg/xds/template/proxy_template_resolver.go
+++ b/pkg/xds/template/proxy_template_resolver.go
@@ -6,7 +6,7 @@ import (
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	"github.com/kumahq/kuma/pkg/core"
 	core_policy "github.com/kumahq/kuma/pkg/core/policy"
-	mesh_core "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
+	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	"github.com/kumahq/kuma/pkg/core/resources/manager"
 	core_model "github.com/kumahq/kuma/pkg/core/resources/model"
 	core_store "github.com/kumahq/kuma/pkg/core/resources/store"
@@ -28,7 +28,7 @@ type SimpleProxyTemplateResolver struct {
 func (r *SimpleProxyTemplateResolver) GetTemplate(proxy *model.Proxy) *mesh_proto.ProxyTemplate {
 	log := templateResolverLog.WithValues("dataplane", core_model.MetaToResourceKey(proxy.Dataplane.Meta))
 	ctx := context.Background()
-	templateList := &mesh_core.ProxyTemplateResourceList{}
+	templateList := &core_mesh.ProxyTemplateResourceList{}
 	if err := r.ReadOnlyResourceManager.List(ctx, templateList, core_store.ListByMesh(proxy.Dataplane.Meta.GetMesh())); err != nil {
 		templateResolverLog.Error(err, "failed to list ProxyTemplates")
 		return nil
@@ -41,7 +41,7 @@ func (r *SimpleProxyTemplateResolver) GetTemplate(proxy *model.Proxy) *mesh_prot
 
 	if bestMatchTemplate := core_policy.SelectDataplanePolicy(proxy.Dataplane, policies); bestMatchTemplate != nil {
 		log.V(2).Info("found the best matching ProxyTemplate", "proxytemplate", core_model.MetaToResourceKey(bestMatchTemplate.GetMeta()))
-		return bestMatchTemplate.(*mesh_core.ProxyTemplateResource).Spec
+		return bestMatchTemplate.(*core_mesh.ProxyTemplateResource).Spec
 	}
 
 	log.V(2).Info("no matching ProxyTemplate")

--- a/pkg/xds/template/proxy_template_resolver_test.go
+++ b/pkg/xds/template/proxy_template_resolver_test.go
@@ -7,7 +7,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
-	mesh_core "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
+	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	"github.com/kumahq/kuma/pkg/core/resources/manager"
 	"github.com/kumahq/kuma/pkg/core/resources/store"
 	model "github.com/kumahq/kuma/pkg/core/xds"
@@ -21,7 +21,7 @@ var _ = Describe("Reconcile", func() {
 		It("should return nil when there no other candidates", func() {
 			// given
 			proxy := &model.Proxy{
-				Dataplane: &mesh_core.DataplaneResource{
+				Dataplane: &core_mesh.DataplaneResource{
 					Meta: &test_model.ResourceMeta{
 						Mesh: "demo",
 					},
@@ -43,7 +43,7 @@ var _ = Describe("Reconcile", func() {
 		It("should use Client to list ProxyTemplates in the same Mesh as Dataplane", func() {
 			// given
 			proxy := &model.Proxy{
-				Dataplane: &mesh_core.DataplaneResource{
+				Dataplane: &core_mesh.DataplaneResource{
 					Meta: &test_model.ResourceMeta{
 						Mesh: "demo",
 					},
@@ -61,7 +61,7 @@ var _ = Describe("Reconcile", func() {
 				},
 			}
 
-			expected := &mesh_core.ProxyTemplateResource{
+			expected := &core_mesh.ProxyTemplateResource{
 				Meta: &test_model.ResourceMeta{
 					Mesh: "demo",
 					Name: "expected",
@@ -73,7 +73,7 @@ var _ = Describe("Reconcile", func() {
 				},
 			}
 
-			other := &mesh_core.ProxyTemplateResource{
+			other := &core_mesh.ProxyTemplateResource{
 				Meta: &test_model.ResourceMeta{
 					Mesh: "default",
 					Name: "other",
@@ -87,7 +87,7 @@ var _ = Describe("Reconcile", func() {
 
 			// setup
 			memStore := memory.NewStore()
-			for _, template := range []*mesh_core.ProxyTemplateResource{expected, other} {
+			for _, template := range []*core_mesh.ProxyTemplateResource{expected, other} {
 				err := memStore.Create(context.Background(), template, store.CreateByKey(template.Meta.GetName(), template.Meta.GetMesh()))
 				Expect(err).ToNot(HaveOccurred())
 			}
@@ -110,7 +110,7 @@ var _ = Describe("Reconcile", func() {
 		It("should return nil if there are no custom templates in a given Mesh", func() {
 			// given
 			proxy := &model.Proxy{
-				Dataplane: &mesh_core.DataplaneResource{
+				Dataplane: &core_mesh.DataplaneResource{
 					Meta: &test_model.ResourceMeta{
 						Mesh: "demo",
 					},

--- a/pkg/xds/topology/circuitbreakers.go
+++ b/pkg/xds/topology/circuitbreakers.go
@@ -4,18 +4,18 @@ import (
 	"context"
 
 	"github.com/kumahq/kuma/pkg/core/policy"
-	mesh_core "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
+	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	core_manager "github.com/kumahq/kuma/pkg/core/resources/manager"
 	core_store "github.com/kumahq/kuma/pkg/core/resources/store"
 	core_xds "github.com/kumahq/kuma/pkg/core/xds"
 )
 
 // GetCircuitBreakers resolves all CircuitBreakers applicable to a given Dataplane.
-func GetCircuitBreakers(ctx context.Context, dataplane *mesh_core.DataplaneResource, destinations core_xds.DestinationMap, manager core_manager.ReadOnlyResourceManager) (core_xds.CircuitBreakerMap, error) {
+func GetCircuitBreakers(ctx context.Context, dataplane *core_mesh.DataplaneResource, destinations core_xds.DestinationMap, manager core_manager.ReadOnlyResourceManager) (core_xds.CircuitBreakerMap, error) {
 	if len(destinations) == 0 {
 		return nil, nil
 	}
-	circuitBreakers := &mesh_core.CircuitBreakerResourceList{}
+	circuitBreakers := &core_mesh.CircuitBreakerResourceList{}
 	if err := manager.List(ctx, circuitBreakers, core_store.ListByMesh(dataplane.Meta.GetMesh())); err != nil {
 		return nil, err
 	}
@@ -23,7 +23,7 @@ func GetCircuitBreakers(ctx context.Context, dataplane *mesh_core.DataplaneResou
 }
 
 // BuildCircuitBreakerMap creates a map with circuit-breaking configuration per reachable service.
-func BuildCircuitBreakerMap(dataplane *mesh_core.DataplaneResource, destinations core_xds.DestinationMap, circuitBreakers []*mesh_core.CircuitBreakerResource) core_xds.CircuitBreakerMap {
+func BuildCircuitBreakerMap(dataplane *core_mesh.DataplaneResource, destinations core_xds.DestinationMap, circuitBreakers []*core_mesh.CircuitBreakerResource) core_xds.CircuitBreakerMap {
 	if len(destinations) == 0 || len(circuitBreakers) == 0 {
 		return nil
 	}
@@ -36,7 +36,7 @@ func BuildCircuitBreakerMap(dataplane *mesh_core.DataplaneResource, destinations
 
 	circuitBreakerMap := core_xds.CircuitBreakerMap{}
 	for service, policy := range policyMap {
-		circuitBreakerMap[service] = policy.(*mesh_core.CircuitBreakerResource)
+		circuitBreakerMap[service] = policy.(*core_mesh.CircuitBreakerResource)
 	}
 	return circuitBreakerMap
 }

--- a/pkg/xds/topology/healthchecks.go
+++ b/pkg/xds/topology/healthchecks.go
@@ -4,18 +4,18 @@ import (
 	"context"
 
 	"github.com/kumahq/kuma/pkg/core/policy"
-	mesh_core "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
+	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	core_manager "github.com/kumahq/kuma/pkg/core/resources/manager"
 	core_store "github.com/kumahq/kuma/pkg/core/resources/store"
 	core_xds "github.com/kumahq/kuma/pkg/core/xds"
 )
 
 // GetHealthChecks resolves all HealthChecks applicable to a given Dataplane.
-func GetHealthChecks(ctx context.Context, dataplane *mesh_core.DataplaneResource, destinations core_xds.DestinationMap, manager core_manager.ReadOnlyResourceManager) (core_xds.HealthCheckMap, error) {
+func GetHealthChecks(ctx context.Context, dataplane *core_mesh.DataplaneResource, destinations core_xds.DestinationMap, manager core_manager.ReadOnlyResourceManager) (core_xds.HealthCheckMap, error) {
 	if len(destinations) == 0 {
 		return nil, nil
 	}
-	healthChecks := &mesh_core.HealthCheckResourceList{}
+	healthChecks := &core_mesh.HealthCheckResourceList{}
 	if err := manager.List(ctx, healthChecks, core_store.ListByMesh(dataplane.Meta.GetMesh())); err != nil {
 		return nil, err
 	}
@@ -23,7 +23,7 @@ func GetHealthChecks(ctx context.Context, dataplane *mesh_core.DataplaneResource
 }
 
 // BuildHealthCheckMap creates a map with health-checking configuration per reachable service.
-func BuildHealthCheckMap(dataplane *mesh_core.DataplaneResource, destinations core_xds.DestinationMap, healthChecks []*mesh_core.HealthCheckResource) core_xds.HealthCheckMap {
+func BuildHealthCheckMap(dataplane *core_mesh.DataplaneResource, destinations core_xds.DestinationMap, healthChecks []*core_mesh.HealthCheckResource) core_xds.HealthCheckMap {
 	if len(destinations) == 0 || len(healthChecks) == 0 {
 		return nil
 	}
@@ -36,7 +36,7 @@ func BuildHealthCheckMap(dataplane *mesh_core.DataplaneResource, destinations co
 
 	healthCheckMap := core_xds.HealthCheckMap{}
 	for service, policy := range policyMap {
-		healthCheckMap[service] = policy.(*mesh_core.HealthCheckResource)
+		healthCheckMap[service] = policy.(*core_mesh.HealthCheckResource)
 	}
 	return healthCheckMap
 }

--- a/pkg/xds/topology/healthchecks_test.go
+++ b/pkg/xds/topology/healthchecks_test.go
@@ -10,7 +10,7 @@ import (
 	"google.golang.org/protobuf/types/known/durationpb"
 
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
-	mesh_core "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
+	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	core_manager "github.com/kumahq/kuma/pkg/core/resources/manager"
 	core_model "github.com/kumahq/kuma/pkg/core/resources/model"
 	core_store "github.com/kumahq/kuma/pkg/core/resources/store"
@@ -35,19 +35,19 @@ var _ = Describe("HealthCheck", func() {
 
 		It("should pick the best matching HealthCheck for each destination service", func() {
 			// given
-			mesh := &mesh_core.MeshResource{ // mesh that is relevant to this test case
+			mesh := &core_mesh.MeshResource{ // mesh that is relevant to this test case
 				Meta: &test_model.ResourceMeta{
 					Name: "demo",
 				},
 				Spec: &mesh_proto.Mesh{},
 			}
-			otherMesh := &mesh_core.MeshResource{ // mesh that is irrelevant to this test case
+			otherMesh := &core_mesh.MeshResource{ // mesh that is irrelevant to this test case
 				Meta: &test_model.ResourceMeta{
 					Name: "default",
 				},
 				Spec: &mesh_proto.Mesh{},
 			}
-			backend := &mesh_core.DataplaneResource{ // dataplane that is a source of traffic
+			backend := &core_mesh.DataplaneResource{ // dataplane that is a source of traffic
 				Meta: &test_model.ResourceMeta{
 					Mesh: "demo",
 					Name: "backend",
@@ -78,7 +78,7 @@ var _ = Describe("HealthCheck", func() {
 				"redis":   core_xds.TagSelectorSet{mesh_proto.MatchService("redis")},
 				"elastic": core_xds.TagSelectorSet{mesh_proto.MatchService("elastic")},
 			}
-			healthCheckRedis := &mesh_core.HealthCheckResource{ // health checks for `redis` service
+			healthCheckRedis := &core_mesh.HealthCheckResource{ // health checks for `redis` service
 				Meta: &test_model.ResourceMeta{
 					Mesh: "demo",
 					Name: "healthcheck-redis",
@@ -99,7 +99,7 @@ var _ = Describe("HealthCheck", func() {
 					},
 				},
 			}
-			healthCheckElastic := &mesh_core.HealthCheckResource{ // health checks for `elastic` service
+			healthCheckElastic := &core_mesh.HealthCheckResource{ // health checks for `elastic` service
 				Meta: &test_model.ResourceMeta{
 					Mesh: "demo",
 					Name: "healthcheck-elastic",
@@ -119,7 +119,7 @@ var _ = Describe("HealthCheck", func() {
 					},
 				},
 			}
-			healthCheckEverything := &mesh_core.HealthCheckResource{ // health checks for any service
+			healthCheckEverything := &core_mesh.HealthCheckResource{ // health checks for any service
 				Meta: &test_model.ResourceMeta{
 					Mesh: "default", // other mesh
 					Name: "healthcheck-everything",
@@ -171,9 +171,9 @@ var _ = Describe("HealthCheck", func() {
 				meta1.GetVersion() == meta2.GetVersion()
 		}
 		type testCase struct {
-			dataplane    *mesh_core.DataplaneResource
+			dataplane    *core_mesh.DataplaneResource
 			destinations core_xds.DestinationMap
-			healthChecks []*mesh_core.HealthCheckResource
+			healthChecks []*core_mesh.HealthCheckResource
 			expected     core_xds.HealthCheckMap
 		}
 		DescribeTable("should correctly pick a single the most specific HealthCheck for each outbound interface",
@@ -200,13 +200,13 @@ var _ = Describe("HealthCheck", func() {
 				Expect(healthChecks).Should(Equal(expectedHealthChecks))
 			},
 			Entry("Dataplane without outbound interfaces (and therefore no destinations)", testCase{
-				dataplane:    mesh_core.NewDataplaneResource(),
+				dataplane:    core_mesh.NewDataplaneResource(),
 				destinations: nil,
 				healthChecks: nil,
 				expected:     nil,
 			}),
 			Entry("if a destination service has no matching HealthChecks, none should be used", testCase{
-				dataplane: &mesh_core.DataplaneResource{
+				dataplane: &core_mesh.DataplaneResource{
 					Spec: &mesh_proto.Dataplane{
 						Networking: &mesh_proto.Dataplane_Networking{
 							Inbound: []*mesh_proto.Dataplane_Networking_Inbound{
@@ -227,7 +227,7 @@ var _ = Describe("HealthCheck", func() {
 				expected:     nil,
 			}),
 			Entry("due to TrafficRoutes, a Dataplane might have more destinations than outbound interfaces", testCase{
-				dataplane: &mesh_core.DataplaneResource{
+				dataplane: &core_mesh.DataplaneResource{
 					Spec: &mesh_proto.Dataplane{
 						Networking: &mesh_proto.Dataplane_Networking{
 							Inbound: []*mesh_proto.Dataplane_Networking_Inbound{
@@ -243,7 +243,7 @@ var _ = Describe("HealthCheck", func() {
 					"redis":   core_xds.TagSelectorSet{mesh_proto.MatchService("redis")},
 					"elastic": core_xds.TagSelectorSet{mesh_proto.MatchService("elastic")},
 				},
-				healthChecks: []*mesh_core.HealthCheckResource{
+				healthChecks: []*core_mesh.HealthCheckResource{
 					{
 						Meta: &test_model.ResourceMeta{
 							Name: "healthcheck-elastic",
@@ -284,12 +284,12 @@ var _ = Describe("HealthCheck", func() {
 					},
 				},
 				expected: core_xds.HealthCheckMap{
-					"redis": &mesh_core.HealthCheckResource{
+					"redis": &core_mesh.HealthCheckResource{
 						Meta: &test_model.ResourceMeta{
 							Name: "healthcheck-redis",
 						},
 					},
-					"elastic": &mesh_core.HealthCheckResource{
+					"elastic": &core_mesh.HealthCheckResource{
 						Meta: &test_model.ResourceMeta{
 							Name: "healthcheck-elastic",
 						},
@@ -297,7 +297,7 @@ var _ = Describe("HealthCheck", func() {
 				},
 			}),
 			Entry("HealthChecks should be picked by latest creation time given two equally specific HealthChecks", testCase{
-				dataplane: &mesh_core.DataplaneResource{
+				dataplane: &core_mesh.DataplaneResource{
 					Spec: &mesh_proto.Dataplane{
 						Networking: &mesh_proto.Dataplane_Networking{
 							Inbound: []*mesh_proto.Dataplane_Networking_Inbound{
@@ -312,7 +312,7 @@ var _ = Describe("HealthCheck", func() {
 				destinations: core_xds.DestinationMap{
 					"redis": core_xds.TagSelectorSet{mesh_proto.MatchService("redis")},
 				},
-				healthChecks: []*mesh_core.HealthCheckResource{
+				healthChecks: []*core_mesh.HealthCheckResource{
 					{
 						Meta: &test_model.ResourceMeta{
 							Name:         "healthcheck-everything-passive",
@@ -355,7 +355,7 @@ var _ = Describe("HealthCheck", func() {
 					},
 				},
 				expected: core_xds.HealthCheckMap{
-					"redis": &mesh_core.HealthCheckResource{
+					"redis": &core_mesh.HealthCheckResource{
 						Meta: &test_model.ResourceMeta{
 							Name: "healthcheck-everything-passive",
 						},
@@ -363,7 +363,7 @@ var _ = Describe("HealthCheck", func() {
 				},
 			}),
 			Entry("HealthCheck with a `source` selector by 2 tags should win over a HealthCheck with a `source` selector by 1 tag", testCase{
-				dataplane: &mesh_core.DataplaneResource{
+				dataplane: &core_mesh.DataplaneResource{
 					Spec: &mesh_proto.Dataplane{
 						Networking: &mesh_proto.Dataplane_Networking{
 							Inbound: []*mesh_proto.Dataplane_Networking_Inbound{
@@ -378,7 +378,7 @@ var _ = Describe("HealthCheck", func() {
 				destinations: core_xds.DestinationMap{
 					"redis": core_xds.TagSelectorSet{mesh_proto.MatchService("redis")},
 				},
-				healthChecks: []*mesh_core.HealthCheckResource{
+				healthChecks: []*core_mesh.HealthCheckResource{
 					{
 						Meta: &test_model.ResourceMeta{
 							Name: "less-specific",
@@ -419,7 +419,7 @@ var _ = Describe("HealthCheck", func() {
 					},
 				},
 				expected: core_xds.HealthCheckMap{
-					"redis": &mesh_core.HealthCheckResource{
+					"redis": &core_mesh.HealthCheckResource{
 						Meta: &test_model.ResourceMeta{
 							Name: "more-specific",
 						},
@@ -427,7 +427,7 @@ var _ = Describe("HealthCheck", func() {
 				},
 			}),
 			Entry("HealthCheck with a `source` selector by an exact value should win over a HealthCheck with a `source` selector by a wildcard value", testCase{
-				dataplane: &mesh_core.DataplaneResource{
+				dataplane: &core_mesh.DataplaneResource{
 					Spec: &mesh_proto.Dataplane{
 						Networking: &mesh_proto.Dataplane_Networking{
 							Inbound: []*mesh_proto.Dataplane_Networking_Inbound{
@@ -442,7 +442,7 @@ var _ = Describe("HealthCheck", func() {
 				destinations: core_xds.DestinationMap{
 					"redis": core_xds.TagSelectorSet{mesh_proto.MatchService("redis")},
 				},
-				healthChecks: []*mesh_core.HealthCheckResource{
+				healthChecks: []*core_mesh.HealthCheckResource{
 					{
 						Meta: &test_model.ResourceMeta{
 							Name: "less-specific",
@@ -483,7 +483,7 @@ var _ = Describe("HealthCheck", func() {
 					},
 				},
 				expected: core_xds.HealthCheckMap{
-					"redis": &mesh_core.HealthCheckResource{
+					"redis": &core_mesh.HealthCheckResource{
 						Meta: &test_model.ResourceMeta{
 							Name: "more-specific",
 						},
@@ -491,7 +491,7 @@ var _ = Describe("HealthCheck", func() {
 				},
 			}),
 			Entry("HealthCheck with a `destination` selector by an exact value should win over a HealthCheck with a `destination` selector by a wildcard value", testCase{
-				dataplane: &mesh_core.DataplaneResource{
+				dataplane: &core_mesh.DataplaneResource{
 					Spec: &mesh_proto.Dataplane{
 						Networking: &mesh_proto.Dataplane_Networking{
 							Inbound: []*mesh_proto.Dataplane_Networking_Inbound{
@@ -506,7 +506,7 @@ var _ = Describe("HealthCheck", func() {
 				destinations: core_xds.DestinationMap{
 					"redis": core_xds.TagSelectorSet{mesh_proto.MatchService("redis")},
 				},
-				healthChecks: []*mesh_core.HealthCheckResource{
+				healthChecks: []*core_mesh.HealthCheckResource{
 					{
 						Meta: &test_model.ResourceMeta{
 							Name: "less-specific",
@@ -547,7 +547,7 @@ var _ = Describe("HealthCheck", func() {
 					},
 				},
 				expected: core_xds.HealthCheckMap{
-					"redis": &mesh_core.HealthCheckResource{
+					"redis": &core_mesh.HealthCheckResource{
 						Meta: &test_model.ResourceMeta{
 							Name: "more-specific",
 						},
@@ -555,7 +555,7 @@ var _ = Describe("HealthCheck", func() {
 				},
 			}),
 			Entry("in case if HealthChecks have equal aggregate ranks, most specific one should be selected based on last creation time", testCase{
-				dataplane: &mesh_core.DataplaneResource{
+				dataplane: &core_mesh.DataplaneResource{
 					Spec: &mesh_proto.Dataplane{
 						Networking: &mesh_proto.Dataplane_Networking{
 							Inbound: []*mesh_proto.Dataplane_Networking_Inbound{
@@ -570,7 +570,7 @@ var _ = Describe("HealthCheck", func() {
 				destinations: core_xds.DestinationMap{
 					"redis": core_xds.TagSelectorSet{mesh_proto.MatchService("redis")},
 				},
-				healthChecks: []*mesh_core.HealthCheckResource{
+				healthChecks: []*core_mesh.HealthCheckResource{
 					{
 						Meta: &test_model.ResourceMeta{
 							Name:         "equally-specific-2",
@@ -613,7 +613,7 @@ var _ = Describe("HealthCheck", func() {
 					},
 				},
 				expected: core_xds.HealthCheckMap{
-					"redis": &mesh_core.HealthCheckResource{
+					"redis": &core_mesh.HealthCheckResource{
 						Meta: &test_model.ResourceMeta{
 							Name: "equally-specific-2",
 						},

--- a/pkg/xds/topology/outbound.go
+++ b/pkg/xds/topology/outbound.go
@@ -9,7 +9,7 @@ import (
 	"github.com/kumahq/kuma/api/system/v1alpha1"
 	"github.com/kumahq/kuma/pkg/core"
 	"github.com/kumahq/kuma/pkg/core/datasource"
-	mesh_core "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
+	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	core_xds "github.com/kumahq/kuma/pkg/core/xds"
 	"github.com/kumahq/kuma/pkg/xds/envoy"
 )
@@ -24,11 +24,11 @@ const (
 
 // BuildEndpointMap creates a map of all endpoints that match given selectors.
 func BuildEndpointMap(
-	mesh *mesh_core.MeshResource,
+	mesh *core_mesh.MeshResource,
 	zone string,
-	dataplanes []*mesh_core.DataplaneResource,
-	zoneIngresses []*mesh_core.ZoneIngressResource,
-	externalServices []*mesh_core.ExternalServiceResource,
+	dataplanes []*core_mesh.DataplaneResource,
+	zoneIngresses []*core_mesh.ZoneIngressResource,
+	externalServices []*core_mesh.ExternalServiceResource,
 	loader datasource.Loader,
 ) core_xds.EndpointMap {
 	outbound := BuildEdsEndpointMap(mesh, zone, dataplanes, zoneIngresses)
@@ -37,10 +37,10 @@ func BuildEndpointMap(
 }
 
 func BuildEdsEndpointMap(
-	mesh *mesh_core.MeshResource,
+	mesh *core_mesh.MeshResource,
 	zone string,
-	dataplanes []*mesh_core.DataplaneResource,
-	zoneIngresses []*mesh_core.ZoneIngressResource,
+	dataplanes []*core_mesh.DataplaneResource,
+	zoneIngresses []*core_mesh.ZoneIngressResource,
 ) core_xds.EndpointMap {
 	outbound := core_xds.EndpointMap{}
 	ingressInstances := fillIngressOutbounds(outbound, zoneIngresses, dataplanes, zone, mesh)
@@ -72,7 +72,7 @@ func BuildEdsEndpointMap(
 //    * backend-zone1-2 - weight: 2
 //    * ingress-zone2-1 - weight: 3
 //    * ingress-zone2-2 - weight: 3
-func fillDataplaneOutbounds(outbound core_xds.EndpointMap, dataplanes []*mesh_core.DataplaneResource, mesh *mesh_core.MeshResource, endpointWeight uint32) {
+func fillDataplaneOutbounds(outbound core_xds.EndpointMap, dataplanes []*core_mesh.DataplaneResource, mesh *core_mesh.MeshResource, endpointWeight uint32) {
 	for _, dataplane := range dataplanes {
 		if dataplane.Spec.IsIngress() {
 			continue
@@ -95,10 +95,10 @@ func fillDataplaneOutbounds(outbound core_xds.EndpointMap, dataplanes []*mesh_co
 
 func fillIngressOutbounds(
 	outbound core_xds.EndpointMap,
-	zoneIngresses []*mesh_core.ZoneIngressResource,
-	dataplanes []*mesh_core.DataplaneResource,
+	zoneIngresses []*core_mesh.ZoneIngressResource,
+	dataplanes []*core_mesh.DataplaneResource,
 	zone string,
-	mesh *mesh_core.MeshResource,
+	mesh *core_mesh.MeshResource,
 ) uint32 {
 	ingressInstances := map[string]bool{}
 
@@ -172,7 +172,7 @@ func fillIngressOutbounds(
 	return uint32(len(ingressInstances))
 }
 
-func fillExternalServicesOutbounds(outbound core_xds.EndpointMap, externalServices []*mesh_core.ExternalServiceResource, mesh *mesh_core.MeshResource, loader datasource.Loader) {
+func fillExternalServicesOutbounds(outbound core_xds.EndpointMap, externalServices []*core_mesh.ExternalServiceResource, mesh *core_mesh.MeshResource, loader datasource.Loader) {
 	for _, externalService := range externalServices {
 		service := externalService.Spec.GetService()
 
@@ -185,7 +185,7 @@ func fillExternalServicesOutbounds(outbound core_xds.EndpointMap, externalServic
 	}
 }
 
-func buildExternalServiceEndpoint(externalService *mesh_core.ExternalServiceResource, mesh *mesh_core.MeshResource, loader datasource.Loader) (*core_xds.Endpoint, error) {
+func buildExternalServiceEndpoint(externalService *core_mesh.ExternalServiceResource, mesh *core_mesh.MeshResource, loader datasource.Loader) (*core_xds.Endpoint, error) {
 	es := &core_xds.ExternalService{
 		TLSEnabled: externalService.Spec.GetNetworking().GetTls().GetEnabled(),
 		CaCert: convertToEnvoy(
@@ -229,7 +229,7 @@ func convertToEnvoy(ds *v1alpha1.DataSource, mesh string, loader datasource.Load
 	return data
 }
 
-func localityFromTags(mesh *mesh_core.MeshResource, priority uint32, tags map[string]string) *core_xds.Locality {
+func localityFromTags(mesh *core_mesh.MeshResource, priority uint32, tags map[string]string) *core_xds.Locality {
 	region, regionPresent := tags[mesh_proto.RegionTag]
 	zone, zonePresent := tags[mesh_proto.ZoneTag]
 	subZone, subZonePresent := tags[mesh_proto.SubZoneTag]

--- a/pkg/xds/topology/outbound_test.go
+++ b/pkg/xds/topology/outbound_test.go
@@ -7,7 +7,7 @@ import (
 
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	"github.com/kumahq/kuma/pkg/core/datasource"
-	mesh_core "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
+	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	"github.com/kumahq/kuma/pkg/core/secrets/cipher"
 	secret_manager "github.com/kumahq/kuma/pkg/core/secrets/manager"
 	secret_store "github.com/kumahq/kuma/pkg/core/secrets/store"
@@ -19,7 +19,7 @@ import (
 
 var _ = Describe("TrafficRoute", func() {
 	const defaultMeshName = "default"
-	defaultMeshWithMTLS := &mesh_core.MeshResource{
+	defaultMeshWithMTLS := &core_mesh.MeshResource{
 		Meta: &test_model.ResourceMeta{
 			Name: defaultMeshName,
 		},
@@ -29,7 +29,7 @@ var _ = Describe("TrafficRoute", func() {
 			},
 		},
 	}
-	defaultMeshWithoutMTLS := &mesh_core.MeshResource{
+	defaultMeshWithoutMTLS := &core_mesh.MeshResource{
 		Meta: &test_model.ResourceMeta{
 			Name: defaultMeshName,
 		},
@@ -39,7 +39,7 @@ var _ = Describe("TrafficRoute", func() {
 			},
 		},
 	}
-	defaultMeshWithLocality := &mesh_core.MeshResource{
+	defaultMeshWithLocality := &core_mesh.MeshResource{
 		Meta: &test_model.ResourceMeta{
 			Name: defaultMeshName,
 		},
@@ -60,7 +60,7 @@ var _ = Describe("TrafficRoute", func() {
 	Describe("GetOutboundTargets()", func() {
 		It("should pick proper dataplanes for each outbound destination", func() {
 			// given
-			backend := &mesh_core.DataplaneResource{ // dataplane that is a source of traffic
+			backend := &core_mesh.DataplaneResource{ // dataplane that is a source of traffic
 				Meta: &test_model.ResourceMeta{
 					Mesh: "demo",
 					Name: "backend",
@@ -87,7 +87,7 @@ var _ = Describe("TrafficRoute", func() {
 					},
 				},
 			}
-			redisV1 := &mesh_core.DataplaneResource{ // dataplane that must become a target
+			redisV1 := &core_mesh.DataplaneResource{ // dataplane that must become a target
 				Meta: &test_model.ResourceMeta{
 					Mesh: "demo",
 					Name: "redis-v1",
@@ -105,7 +105,7 @@ var _ = Describe("TrafficRoute", func() {
 					},
 				},
 			}
-			redisV3 := &mesh_core.DataplaneResource{ // dataplane that must be ingored (due to `version: v3`)
+			redisV3 := &core_mesh.DataplaneResource{ // dataplane that must be ingored (due to `version: v3`)
 				Meta: &test_model.ResourceMeta{
 					Mesh: "demo",
 					Name: "redis-v3",
@@ -123,7 +123,7 @@ var _ = Describe("TrafficRoute", func() {
 					},
 				},
 			}
-			elasticEU := &mesh_core.DataplaneResource{ // dataplane that must be ingored (due to `kuma.io/region: eu`)
+			elasticEU := &core_mesh.DataplaneResource{ // dataplane that must be ingored (due to `kuma.io/region: eu`)
 				Meta: &test_model.ResourceMeta{
 					Mesh: "demo",
 					Name: "elastic-eu",
@@ -141,7 +141,7 @@ var _ = Describe("TrafficRoute", func() {
 					},
 				},
 			}
-			elasticUS := &mesh_core.DataplaneResource{ // dataplane that must become a target
+			elasticUS := &core_mesh.DataplaneResource{ // dataplane that must become a target
 				Meta: &test_model.ResourceMeta{
 					Mesh: "demo",
 					Name: "elastic-us",
@@ -159,11 +159,11 @@ var _ = Describe("TrafficRoute", func() {
 					},
 				},
 			}
-			dataplanes := &mesh_core.DataplaneResourceList{
-				Items: []*mesh_core.DataplaneResource{backend, redisV1, redisV3, elasticEU, elasticUS},
+			dataplanes := &core_mesh.DataplaneResourceList{
+				Items: []*core_mesh.DataplaneResource{backend, redisV1, redisV3, elasticEU, elasticUS},
 			}
 
-			externalServices := &mesh_core.ExternalServiceResourceList{}
+			externalServices := &core_mesh.ExternalServiceResourceList{}
 
 			// when
 			targets := BuildEndpointMap(defaultMeshWithMTLS, "zone-1", dataplanes.Items, nil, externalServices.Items, dataSourceLoader)
@@ -243,9 +243,9 @@ var _ = Describe("TrafficRoute", func() {
 
 	Describe("BuildEndpointMap()", func() {
 		type testCase struct {
-			dataplanes       []*mesh_core.DataplaneResource
-			externalServices []*mesh_core.ExternalServiceResource
-			mesh             *mesh_core.MeshResource
+			dataplanes       []*core_mesh.DataplaneResource
+			externalServices []*core_mesh.ExternalServiceResource
+			mesh             *core_mesh.MeshResource
 			expected         core_xds.EndpointMap
 		}
 		DescribeTable("should include only those dataplanes that match given selectors",
@@ -256,12 +256,12 @@ var _ = Describe("TrafficRoute", func() {
 				Expect(endpoints).To(Equal(given.expected))
 			},
 			Entry("no dataplanes", testCase{
-				dataplanes: []*mesh_core.DataplaneResource{},
+				dataplanes: []*core_mesh.DataplaneResource{},
 				mesh:       defaultMeshWithMTLS,
 				expected:   core_xds.EndpointMap{},
 			}),
 			Entry("ingress in the list of dataplanes", testCase{
-				dataplanes: []*mesh_core.DataplaneResource{
+				dataplanes: []*core_mesh.DataplaneResource{
 					{
 						Meta: &test_model.ResourceMeta{Mesh: defaultMeshName},
 						Spec: &mesh_proto.Dataplane{
@@ -408,7 +408,7 @@ var _ = Describe("TrafficRoute", func() {
 				},
 			}),
 			Entry("ingresses in the list of dataplanes from different meshes", testCase{
-				dataplanes: []*mesh_core.DataplaneResource{
+				dataplanes: []*core_mesh.DataplaneResource{
 					{
 						Meta: &test_model.ResourceMeta{Mesh: defaultMeshName},
 						Spec: &mesh_proto.Dataplane{
@@ -476,7 +476,7 @@ var _ = Describe("TrafficRoute", func() {
 				},
 			}),
 			Entry("ingress is not included if mtls is off", testCase{
-				dataplanes: []*mesh_core.DataplaneResource{
+				dataplanes: []*core_mesh.DataplaneResource{
 					{
 						Meta: &test_model.ResourceMeta{Mesh: defaultMeshName},
 						Spec: &mesh_proto.Dataplane{
@@ -533,8 +533,8 @@ var _ = Describe("TrafficRoute", func() {
 				},
 			}),
 			Entry("external service no TLS", testCase{
-				dataplanes: []*mesh_core.DataplaneResource{},
-				externalServices: []*mesh_core.ExternalServiceResource{
+				dataplanes: []*core_mesh.DataplaneResource{},
+				externalServices: []*core_mesh.ExternalServiceResource{
 					{
 						Meta: &test_model.ResourceMeta{Mesh: defaultMeshName},
 						Spec: &mesh_proto.ExternalService{
@@ -560,8 +560,8 @@ var _ = Describe("TrafficRoute", func() {
 				},
 			}),
 			Entry("external service with TLS disabled", testCase{
-				dataplanes: []*mesh_core.DataplaneResource{},
-				externalServices: []*mesh_core.ExternalServiceResource{
+				dataplanes: []*core_mesh.DataplaneResource{},
+				externalServices: []*core_mesh.ExternalServiceResource{
 					{
 						Meta: &test_model.ResourceMeta{Mesh: defaultMeshName},
 						Spec: &mesh_proto.ExternalService{
@@ -589,8 +589,8 @@ var _ = Describe("TrafficRoute", func() {
 				},
 			}),
 			Entry("external service with TLS enabled", testCase{
-				dataplanes: []*mesh_core.DataplaneResource{},
-				externalServices: []*mesh_core.ExternalServiceResource{
+				dataplanes: []*core_mesh.DataplaneResource{},
+				externalServices: []*core_mesh.ExternalServiceResource{
 					{
 						Meta: &test_model.ResourceMeta{Mesh: defaultMeshName},
 						Spec: &mesh_proto.ExternalService{
@@ -618,8 +618,8 @@ var _ = Describe("TrafficRoute", func() {
 				},
 			}),
 			Entry("external service with TLS enabled and Locality", testCase{
-				dataplanes: []*mesh_core.DataplaneResource{},
-				externalServices: []*mesh_core.ExternalServiceResource{
+				dataplanes: []*core_mesh.DataplaneResource{},
+				externalServices: []*core_mesh.ExternalServiceResource{
 					{
 						Meta: &test_model.ResourceMeta{Mesh: defaultMeshName},
 						Spec: &mesh_proto.ExternalService{
@@ -648,7 +648,7 @@ var _ = Describe("TrafficRoute", func() {
 				},
 			}),
 			Entry("unhealthy dataplane", testCase{
-				dataplanes: []*mesh_core.DataplaneResource{
+				dataplanes: []*core_mesh.DataplaneResource{
 					{
 						Meta: &test_model.ResourceMeta{Name: "dp-1", Mesh: defaultMeshName},
 						Spec: &mesh_proto.Dataplane{

--- a/pkg/xds/topology/retries.go
+++ b/pkg/xds/topology/retries.go
@@ -4,7 +4,7 @@ import (
 	"context"
 
 	"github.com/kumahq/kuma/pkg/core/policy"
-	mesh_core "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
+	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	core_manager "github.com/kumahq/kuma/pkg/core/resources/manager"
 	core_store "github.com/kumahq/kuma/pkg/core/resources/store"
 	core_xds "github.com/kumahq/kuma/pkg/core/xds"
@@ -12,7 +12,7 @@ import (
 
 func GetRetries(
 	ctx context.Context,
-	dataplane *mesh_core.DataplaneResource,
+	dataplane *core_mesh.DataplaneResource,
 	destinations core_xds.DestinationMap,
 	manager core_manager.ReadOnlyResourceManager,
 ) (core_xds.RetryMap, error) {
@@ -20,7 +20,7 @@ func GetRetries(
 		return nil, nil
 	}
 
-	retries := &mesh_core.RetryResourceList{}
+	retries := &core_mesh.RetryResourceList{}
 	if err := manager.List(
 		ctx,
 		retries,
@@ -33,8 +33,8 @@ func GetRetries(
 }
 
 func BuildRetryMap(
-	dataplane *mesh_core.DataplaneResource,
-	retries []*mesh_core.RetryResource,
+	dataplane *core_mesh.DataplaneResource,
+	retries []*core_mesh.RetryResource,
 	destinations core_xds.DestinationMap,
 ) (core_xds.RetryMap, error) {
 	if len(retries) == 0 || len(destinations) == 0 {
@@ -54,7 +54,7 @@ func BuildRetryMap(
 
 	retriesMap := core_xds.RetryMap{}
 	for service, singlePolicy := range policyMap {
-		retriesMap[service] = singlePolicy.(*mesh_core.RetryResource)
+		retriesMap[service] = singlePolicy.(*core_mesh.RetryResource)
 	}
 
 	return retriesMap, nil

--- a/pkg/xds/topology/router_test.go
+++ b/pkg/xds/topology/router_test.go
@@ -10,7 +10,7 @@ import (
 	"google.golang.org/protobuf/types/known/wrapperspb"
 
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
-	mesh_core "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
+	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	core_manager "github.com/kumahq/kuma/pkg/core/resources/manager"
 	core_model "github.com/kumahq/kuma/pkg/core/resources/model"
 	core_store "github.com/kumahq/kuma/pkg/core/resources/store"
@@ -35,19 +35,19 @@ var _ = Describe("TrafficRoute", func() {
 
 		It("should pick the best matching Route for each outbound interface", func() {
 			// given
-			mesh := &mesh_core.MeshResource{ // mesh that is relevant to this test case
+			mesh := &core_mesh.MeshResource{ // mesh that is relevant to this test case
 				Meta: &test_model.ResourceMeta{
 					Name: "demo",
 				},
 				Spec: &mesh_proto.Mesh{},
 			}
-			otherMesh := &mesh_core.MeshResource{ // mesh that is irrelevant to this test case
+			otherMesh := &core_mesh.MeshResource{ // mesh that is irrelevant to this test case
 				Meta: &test_model.ResourceMeta{
 					Name: "default",
 				},
 				Spec: &mesh_proto.Mesh{},
 			}
-			backend := &mesh_core.DataplaneResource{ // dataplane that is a source of traffic
+			backend := &core_mesh.DataplaneResource{ // dataplane that is a source of traffic
 				Meta: &test_model.ResourceMeta{
 					Mesh: "demo",
 					Name: "backend",
@@ -74,7 +74,7 @@ var _ = Describe("TrafficRoute", func() {
 					},
 				},
 			}
-			routeRedis := &mesh_core.TrafficRouteResource{ // traffic route for `redis` service
+			routeRedis := &core_mesh.TrafficRouteResource{ // traffic route for `redis` service
 				Meta: &test_model.ResourceMeta{
 					Mesh: "demo",
 					Name: "route-to-redis",
@@ -105,7 +105,7 @@ var _ = Describe("TrafficRoute", func() {
 					},
 				},
 			}
-			routeElastic := &mesh_core.TrafficRouteResource{ // traffic route for `elastic` service
+			routeElastic := &core_mesh.TrafficRouteResource{ // traffic route for `elastic` service
 				Meta: &test_model.ResourceMeta{
 					Mesh: "demo",
 					Name: "route-to-elastic",
@@ -135,7 +135,7 @@ var _ = Describe("TrafficRoute", func() {
 					},
 				},
 			}
-			routeBlackhole := &mesh_core.TrafficRouteResource{ // traffic route that must be ignored (due to `mesh: default`)
+			routeBlackhole := &core_mesh.TrafficRouteResource{ // traffic route that must be ignored (due to `mesh: default`)
 				Meta: &test_model.ResourceMeta{
 					Mesh: "default", // other mesh
 					Name: "route-to-blackhole",
@@ -193,8 +193,8 @@ var _ = Describe("TrafficRoute", func() {
 				meta1.GetVersion() == meta2.GetVersion()
 		}
 		type testCase struct {
-			dataplane *mesh_core.DataplaneResource
-			routes    []*mesh_core.TrafficRouteResource
+			dataplane *core_mesh.DataplaneResource
+			routes    []*core_mesh.TrafficRouteResource
 			expected  core_xds.RouteMap
 		}
 		DescribeTable("should correctly pick a single the most specific route for each outbound interface",
@@ -222,13 +222,13 @@ var _ = Describe("TrafficRoute", func() {
 				}
 			},
 			Entry("Dataplane without outbound interfaces and no routes", testCase{
-				dataplane: mesh_core.NewDataplaneResource(),
+				dataplane: core_mesh.NewDataplaneResource(),
 				routes:    nil,
 				expected:  nil,
 			}),
 			Entry("Dataplane without outbound interfaces", testCase{
-				dataplane: mesh_core.NewDataplaneResource(),
-				routes: []*mesh_core.TrafficRouteResource{
+				dataplane: core_mesh.NewDataplaneResource(),
+				routes: []*core_mesh.TrafficRouteResource{
 					{
 						Spec: &mesh_proto.TrafficRoute{
 							Sources: []*mesh_proto.Selector{
@@ -253,7 +253,7 @@ var _ = Describe("TrafficRoute", func() {
 				expected: core_xds.RouteMap{},
 			}),
 			Entry("TrafficRoutes should be picked by latest creation time given two equally specific routes", testCase{
-				dataplane: &mesh_core.DataplaneResource{
+				dataplane: &core_mesh.DataplaneResource{
 					Spec: &mesh_proto.Dataplane{
 						Networking: &mesh_proto.Dataplane_Networking{
 							Inbound: []*mesh_proto.Dataplane_Networking_Inbound{
@@ -268,7 +268,7 @@ var _ = Describe("TrafficRoute", func() {
 						},
 					},
 				},
-				routes: []*mesh_core.TrafficRouteResource{
+				routes: []*core_mesh.TrafficRouteResource{
 					{
 						Meta: &test_model.ResourceMeta{
 							Name:         "everything-to-hollygrail",
@@ -322,7 +322,7 @@ var _ = Describe("TrafficRoute", func() {
 					mesh_proto.OutboundInterface{
 						DataplaneIP:   "127.0.0.1",
 						DataplanePort: 1234,
-					}: &mesh_core.TrafficRouteResource{
+					}: &core_mesh.TrafficRouteResource{
 						Meta: &test_model.ResourceMeta{
 							Name: "everything-to-hollygrail",
 						},
@@ -330,7 +330,7 @@ var _ = Describe("TrafficRoute", func() {
 				},
 			}),
 			Entry("TrafficRoute with a `source` selector by 2 tags should win over a TrafficRoute with a `source` selector by 1 tag", testCase{
-				dataplane: &mesh_core.DataplaneResource{
+				dataplane: &core_mesh.DataplaneResource{
 					Spec: &mesh_proto.Dataplane{
 						Networking: &mesh_proto.Dataplane_Networking{
 							Inbound: []*mesh_proto.Dataplane_Networking_Inbound{
@@ -345,7 +345,7 @@ var _ = Describe("TrafficRoute", func() {
 						},
 					},
 				},
-				routes: []*mesh_core.TrafficRouteResource{
+				routes: []*core_mesh.TrafficRouteResource{
 					{
 						Meta: &test_model.ResourceMeta{
 							Name: "less-specific",
@@ -397,7 +397,7 @@ var _ = Describe("TrafficRoute", func() {
 					mesh_proto.OutboundInterface{
 						DataplaneIP:   "127.0.0.1",
 						DataplanePort: 1234,
-					}: &mesh_core.TrafficRouteResource{
+					}: &core_mesh.TrafficRouteResource{
 						Meta: &test_model.ResourceMeta{
 							Name: "more-specific",
 						},
@@ -405,7 +405,7 @@ var _ = Describe("TrafficRoute", func() {
 				},
 			}),
 			Entry("TrafficRoute with a `source` selector by an exact value should win over a TrafficRoute with a `source` selector by a wildcard value", testCase{
-				dataplane: &mesh_core.DataplaneResource{
+				dataplane: &core_mesh.DataplaneResource{
 					Spec: &mesh_proto.Dataplane{
 						Networking: &mesh_proto.Dataplane_Networking{
 							Inbound: []*mesh_proto.Dataplane_Networking_Inbound{
@@ -420,7 +420,7 @@ var _ = Describe("TrafficRoute", func() {
 						},
 					},
 				},
-				routes: []*mesh_core.TrafficRouteResource{
+				routes: []*core_mesh.TrafficRouteResource{
 					{
 						Meta: &test_model.ResourceMeta{
 							Name: "less-specific",
@@ -472,7 +472,7 @@ var _ = Describe("TrafficRoute", func() {
 					mesh_proto.OutboundInterface{
 						DataplaneIP:   "127.0.0.1",
 						DataplanePort: 1234,
-					}: &mesh_core.TrafficRouteResource{
+					}: &core_mesh.TrafficRouteResource{
 						Meta: &test_model.ResourceMeta{
 							Name: "more-specific",
 						},
@@ -480,7 +480,7 @@ var _ = Describe("TrafficRoute", func() {
 				},
 			}),
 			Entry("TrafficRoute with a `destination` selector by an exact value should win over a TrafficRoute with a `destination` selector by a wildcard value", testCase{
-				dataplane: &mesh_core.DataplaneResource{
+				dataplane: &core_mesh.DataplaneResource{
 					Spec: &mesh_proto.Dataplane{
 						Networking: &mesh_proto.Dataplane_Networking{
 							Inbound: []*mesh_proto.Dataplane_Networking_Inbound{
@@ -495,7 +495,7 @@ var _ = Describe("TrafficRoute", func() {
 						},
 					},
 				},
-				routes: []*mesh_core.TrafficRouteResource{
+				routes: []*core_mesh.TrafficRouteResource{
 					{
 						Meta: &test_model.ResourceMeta{
 							Name: "less-specific",
@@ -547,7 +547,7 @@ var _ = Describe("TrafficRoute", func() {
 					mesh_proto.OutboundInterface{
 						DataplaneIP:   "127.0.0.1",
 						DataplanePort: 1234,
-					}: &mesh_core.TrafficRouteResource{
+					}: &core_mesh.TrafficRouteResource{
 						Meta: &test_model.ResourceMeta{
 							Name: "more-specific",
 						},
@@ -555,7 +555,7 @@ var _ = Describe("TrafficRoute", func() {
 				},
 			}),
 			Entry("in case if TrafficRoutes have equal aggregate ranks, most specific one should be selected based on last creation time", testCase{
-				dataplane: &mesh_core.DataplaneResource{
+				dataplane: &core_mesh.DataplaneResource{
 					Spec: &mesh_proto.Dataplane{
 						Networking: &mesh_proto.Dataplane_Networking{
 							Inbound: []*mesh_proto.Dataplane_Networking_Inbound{
@@ -570,7 +570,7 @@ var _ = Describe("TrafficRoute", func() {
 						},
 					},
 				},
-				routes: []*mesh_core.TrafficRouteResource{
+				routes: []*core_mesh.TrafficRouteResource{
 					{
 						Meta: &test_model.ResourceMeta{
 							Name:         "equally-specific-2",
@@ -624,7 +624,7 @@ var _ = Describe("TrafficRoute", func() {
 					mesh_proto.OutboundInterface{
 						DataplaneIP:   "127.0.0.1",
 						DataplanePort: 1234,
-					}: &mesh_core.TrafficRouteResource{
+					}: &core_mesh.TrafficRouteResource{
 						Meta: &test_model.ResourceMeta{
 							Name: "equally-specific-2",
 						},
@@ -640,7 +640,7 @@ var _ = Describe("TrafficRoute", func() {
 				Expect(routes).Should(Equal(given.expected))
 			},
 			Entry("if an outbound interface has no matching TrafficRoute, the default route should be used", testCase{
-				dataplane: &mesh_core.DataplaneResource{
+				dataplane: &core_mesh.DataplaneResource{
 					Spec: &mesh_proto.Dataplane{
 						Networking: &mesh_proto.Dataplane_Networking{
 							Inbound: []*mesh_proto.Dataplane_Networking_Inbound{
@@ -659,7 +659,7 @@ var _ = Describe("TrafficRoute", func() {
 						},
 					},
 				},
-				routes: []*mesh_core.TrafficRouteResource{
+				routes: []*core_mesh.TrafficRouteResource{
 					{
 						Meta: &PseudoMeta{
 							Name: "route-all-default",
@@ -689,7 +689,7 @@ var _ = Describe("TrafficRoute", func() {
 					mesh_proto.OutboundInterface{
 						DataplaneIP:   "127.0.0.1",
 						DataplanePort: 1234,
-					}: &mesh_core.TrafficRouteResource{
+					}: &core_mesh.TrafficRouteResource{
 						Meta: &PseudoMeta{
 							Name: "route-all-default",
 						},
@@ -715,7 +715,7 @@ var _ = Describe("TrafficRoute", func() {
 					mesh_proto.OutboundInterface{
 						DataplaneIP:   "127.0.0.1",
 						DataplanePort: 1235,
-					}: &mesh_core.TrafficRouteResource{
+					}: &core_mesh.TrafficRouteResource{
 						Meta: &PseudoMeta{
 							Name: "route-all-default",
 						},
@@ -741,7 +741,7 @@ var _ = Describe("TrafficRoute", func() {
 				},
 			}),
 			Entry("the default route should only be used if there is matching TrafficRoute for a given outbound interface", testCase{
-				dataplane: &mesh_core.DataplaneResource{
+				dataplane: &core_mesh.DataplaneResource{
 					Spec: &mesh_proto.Dataplane{
 						Networking: &mesh_proto.Dataplane_Networking{
 							Inbound: []*mesh_proto.Dataplane_Networking_Inbound{
@@ -760,7 +760,7 @@ var _ = Describe("TrafficRoute", func() {
 						},
 					},
 				},
-				routes: []*mesh_core.TrafficRouteResource{
+				routes: []*core_mesh.TrafficRouteResource{
 					{
 						Meta: &PseudoMeta{
 							Name: "route-all-default",
@@ -813,7 +813,7 @@ var _ = Describe("TrafficRoute", func() {
 					mesh_proto.OutboundInterface{
 						DataplaneIP:   "127.0.0.1",
 						DataplanePort: 1234,
-					}: &mesh_core.TrafficRouteResource{
+					}: &core_mesh.TrafficRouteResource{
 						Meta: &PseudoMeta{
 							Name: "route-all-default",
 						},
@@ -839,7 +839,7 @@ var _ = Describe("TrafficRoute", func() {
 					mesh_proto.OutboundInterface{
 						DataplaneIP:   "127.0.0.1",
 						DataplanePort: 1235,
-					}: &mesh_core.TrafficRouteResource{
+					}: &core_mesh.TrafficRouteResource{
 						Meta: &test_model.ResourceMeta{
 							Name: "everything-to-elastic-v1",
 						},
@@ -869,7 +869,7 @@ var _ = Describe("TrafficRoute", func() {
 
 	Describe("BuildDestinationMap()", func() {
 		type testCase struct {
-			dataplane *mesh_core.DataplaneResource
+			dataplane *core_mesh.DataplaneResource
 			routes    core_xds.RouteMap
 			expected  core_xds.DestinationMap
 		}
@@ -881,12 +881,12 @@ var _ = Describe("TrafficRoute", func() {
 				Expect(destinations).Should(Equal(given.expected))
 			},
 			Entry("Dataplane without outbound interfaces", testCase{
-				dataplane: mesh_core.NewDataplaneResource(),
+				dataplane: core_mesh.NewDataplaneResource(),
 				routes:    nil,
 				expected:  core_xds.DestinationMap{},
 			}),
 			Entry("Dataplane with outbound interfaces but no TrafficRoutes", testCase{
-				dataplane: &mesh_core.DataplaneResource{
+				dataplane: &core_mesh.DataplaneResource{
 					Spec: &mesh_proto.Dataplane{
 						Networking: &mesh_proto.Dataplane_Networking{
 							Outbound: []*mesh_proto.Dataplane_Networking_Outbound{
@@ -907,7 +907,7 @@ var _ = Describe("TrafficRoute", func() {
 				},
 			}),
 			Entry("Dataplane with outbound interfaces and TrafficRoutes", testCase{
-				dataplane: &mesh_core.DataplaneResource{
+				dataplane: &core_mesh.DataplaneResource{
 					Spec: &mesh_proto.Dataplane{
 						Networking: &mesh_proto.Dataplane_Networking{
 							Outbound: []*mesh_proto.Dataplane_Networking_Outbound{
@@ -921,7 +921,7 @@ var _ = Describe("TrafficRoute", func() {
 					mesh_proto.OutboundInterface{
 						DataplaneIP:   "127.0.0.1",
 						DataplanePort: 10001,
-					}: &mesh_core.TrafficRouteResource{
+					}: &core_mesh.TrafficRouteResource{
 						Spec: &mesh_proto.TrafficRoute{
 							Conf: &mesh_proto.TrafficRoute_Conf{
 								Split: []*mesh_proto.TrafficRoute_Split{
@@ -944,7 +944,7 @@ var _ = Describe("TrafficRoute", func() {
 					mesh_proto.OutboundInterface{
 						DataplaneIP:   "127.0.0.1",
 						DataplanePort: 10002,
-					}: &mesh_core.TrafficRouteResource{
+					}: &core_mesh.TrafficRouteResource{
 						Spec: &mesh_proto.TrafficRoute{
 							Conf: &mesh_proto.TrafficRoute_Conf{
 								Split: []*mesh_proto.TrafficRoute_Split{

--- a/pkg/xds/topology/traffictrace.go
+++ b/pkg/xds/topology/traffictrace.go
@@ -4,26 +4,26 @@ import (
 	"context"
 
 	core_policy "github.com/kumahq/kuma/pkg/core/policy"
-	mesh_core "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
+	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	core_manager "github.com/kumahq/kuma/pkg/core/resources/manager"
 	"github.com/kumahq/kuma/pkg/core/resources/store"
 )
 
-func GetTrafficTrace(ctx context.Context, dataplane *mesh_core.DataplaneResource, manager core_manager.ReadOnlyResourceManager) (*mesh_core.TrafficTraceResource, error) {
-	traces := mesh_core.TrafficTraceResourceList{}
+func GetTrafficTrace(ctx context.Context, dataplane *core_mesh.DataplaneResource, manager core_manager.ReadOnlyResourceManager) (*core_mesh.TrafficTraceResource, error) {
+	traces := core_mesh.TrafficTraceResourceList{}
 	if err := manager.List(ctx, &traces, store.ListByMesh(dataplane.GetMeta().GetMesh())); err != nil {
 		return nil, err
 	}
 	return SelectTrafficTrace(dataplane, traces.Items), nil
 }
 
-func SelectTrafficTrace(dataplane *mesh_core.DataplaneResource, traces []*mesh_core.TrafficTraceResource) *mesh_core.TrafficTraceResource {
+func SelectTrafficTrace(dataplane *core_mesh.DataplaneResource, traces []*core_mesh.TrafficTraceResource) *core_mesh.TrafficTraceResource {
 	policies := make([]core_policy.DataplanePolicy, len(traces))
 	for i, trace := range traces {
 		policies[i] = trace
 	}
 	if policy := core_policy.SelectDataplanePolicy(dataplane, policies); policy != nil {
-		return policy.(*mesh_core.TrafficTraceResource)
+		return policy.(*core_mesh.TrafficTraceResource)
 	}
 	return nil
 }


### PR DESCRIPTION
### Summary

SUMMARY_GOES_HERE

### Full changelog

* Add `importas` rule to golangci-lint
* fix import names

### Issues resolved

Fix #2459

### Documentation

- [ ] Link to the website [documentation PR](https://github.com/kumahq/kuma-website/pull/XXX)

### Testing

- [ ] Unit tests
- [ ] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes 

### Backwards compatibility

- [ ] Add `backport-to-stable` label if the code is backwards compatible. Otherwise, list breaking changes.
