### PR TITLE
chore(*) fix kumactl generate dataplane proxy-type flag in deprecated…

### DIFF
--- a/app/kumactl/cmd/generate/generate_dataplane_token.go
+++ b/app/kumactl/cmd/generate/generate_dataplane_token.go
@@ -59,7 +59,7 @@ $ kumactl generate dataplane-token --mesh demo --tag kuma.io/service=web,web-api
 	}
 	cmd.Flags().StringVar(&ctx.args.name, "name", "", "name of the Dataplane")
 	cmd.Flags().StringVar(&ctx.args.proxyType, "type", "", `type of the Dataplane ("dataplane", "ingress")`)
-	_ = cmd.Flags().MarkDeprecated("type", "please use --proxyType instead")
+	_ = cmd.Flags().MarkDeprecated("type", "please use --proxy-type instead")
 	cmd.Flags().StringVar(&ctx.args.proxyType, "proxy-type", "", `type of the Dataplane ("dataplane", "ingress")`)
 	cmd.Flags().StringToStringVar(&ctx.args.tags, "tag", nil, "required tag values for dataplane (split values by comma to provide multiple values)")
 	return cmd


### PR DESCRIPTION
… message

Signed-off-by: Tharun <rajendrantharun@live.com>

### Summary

SUMMARY_GOES_HERE

### Full changelog

* [Implement ...]
* fix wrong `generate data-plane` command's `proxy-type` field name in deprecated message.

### Issues resolved

Fix #2513

### Documentation

- [ ] Link to the website [documentation PR](https://github.com/kumahq/kuma-website/pull/XXX)

### Testing

- [ ] Unit tests
- [ ] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes 

### Backwards compatibility

- [ ] Add `backport-to-stable` label if the code is backwards compatible. Otherwise, list breaking changes.
