### PR TITLE
chore(ci) add test-server envrc support

### DIFF
--- a/mk/build.mk
+++ b/mk/build.mk
@@ -32,6 +32,9 @@ COREDNS_PLUGIN_CFG_PATH ?= $(TOP)/tools/builds/coredns/templates/plugin.cfg
 # List of binaries that we have release build rules for.
 BUILD_RELEASE_BINARIES := kuma-cp kuma-dp kumactl kuma-prometheus-sd coredns
 
+# List of binaries that we have test build roles for.
+BUILD_TEST_BINARIES := test-server
+
 # Setting this variable to any value other than 'N', enables the experimental Kuma
 # gateway plugin. Experimental means "for experiments", NOT "for production".
 BUILD_WITH_EXPERIMENTAL_GATEWAY ?= N
@@ -50,7 +53,7 @@ build: build/release build/test
 build/release: $(patsubst %,build/%,$(BUILD_RELEASE_BINARIES)) ## Dev: Build all binaries
 
 .PHONY: build/test
-build/test: build/test-server
+build/test: $(patsubst %,build/%,$(BUILD_TEST_BINARIES)) ## Dev: Build testing binaries
 
 .PHONY: build/linux-amd64
 build/linux-amd64:

--- a/mk/dev.mk
+++ b/mk/dev.mk
@@ -261,7 +261,7 @@ dev/envrc: $(KUBECONFIG_DIR)/kind-kuma-current ## Generate .envrc
 		echo "path_add KUBECONFIG $$c" ; \
 	done >> .envrc
 	@echo 'export KUBECONFIG' >> .envrc
-	@for prog in $(BUILD_RELEASE_BINARIES) ; do \
+	@for prog in $(BUILD_RELEASE_BINARIES) $(BUILD_TEST_BINARIES) ; do \
 		echo "PATH_add $(BUILD_ARTIFACTS_DIR)/$$prog" ; \
 	done >> .envrc
 	@direnv allow


### PR DESCRIPTION
### Summary

Automatically add the test-server build to the local path using the
`dev/envrc` build target.

### Full changelog

N/A

### Issues resolved

N/A

### Documentation

N/A

### Testing

- [x] Unit tests
- [x] E2E tests
- [x] Manual testing on Universal
- [ ] Manual testing on Kubernetes 

### Backwards compatibility

- [x] Add `backport-to-stable` label if the code is backwards compatible. Otherwise, list breaking changes.
