### PR TITLE
chore(logging) Move args to where they can be parameterized

### DIFF
--- a/app/kumactl/cmd/install/context/install_logging_context.go
+++ b/app/kumactl/cmd/install/context/install_logging_context.go
@@ -1,0 +1,17 @@
+package context
+
+type LoggingTemplateArgs struct {
+	Namespace string
+}
+
+type InstallLoggingContext struct {
+	TemplateArgs LoggingTemplateArgs
+}
+
+func DefaultInstallLoggingContext() InstallLoggingContext {
+	return InstallLoggingContext{
+		TemplateArgs: LoggingTemplateArgs{
+			Namespace: "kuma-logging",
+		},
+	}
+}

--- a/app/kumactl/cmd/install/install.go
+++ b/app/kumactl/cmd/install/install.go
@@ -18,7 +18,7 @@ func NewInstallCmd(pctx *kumactl_cmd.RootContext) *cobra.Command {
 	cmd.AddCommand(newInstallMetrics(pctx))
 	cmd.AddCommand(newInstallTracing(pctx))
 	cmd.AddCommand(newInstallDNS())
-	cmd.AddCommand(newInstallLogging())
+	cmd.AddCommand(newInstallLogging(pctx))
 	cmd.AddCommand(newInstallTransparentProxy())
 	cmd.AddCommand(newInstallDemoCmd(&pctx.InstallDemoContext))
 	cmd.AddCommand(newInstallGatewayCmd(pctx))

--- a/app/kumactl/cmd/install/install_logging.go
+++ b/app/kumactl/cmd/install/install_logging.go
@@ -5,6 +5,7 @@ import (
 	"github.com/spf13/cobra"
 
 	kumactl_data "github.com/kumahq/kuma/app/kumactl/data"
+	kumactl_cmd "github.com/kumahq/kuma/app/kumactl/pkg/cmd"
 	"github.com/kumahq/kuma/app/kumactl/pkg/install/data"
 	"github.com/kumahq/kuma/app/kumactl/pkg/install/k8s"
 )
@@ -13,12 +14,8 @@ type loggingTemplateArgs struct {
 	Namespace string
 }
 
-func newInstallLogging() *cobra.Command {
-	args := struct {
-		Namespace string
-	}{
-		Namespace: "kuma-logging",
-	}
+func newInstallLogging(pctx *kumactl_cmd.RootContext) *cobra.Command {
+	args := pctx.InstallLoggingContext.TemplateArgs
 	cmd := &cobra.Command{
 		Use:   "logging",
 		Short: "Install Logging backend in Kubernetes cluster (Loki)",

--- a/app/kumactl/pkg/cmd/root_context.go
+++ b/app/kumactl/pkg/cmd/root_context.go
@@ -58,6 +58,7 @@ type RootContext struct {
 	InstallGatewayKongContext           install_context.InstallGatewayKongContext
 	InstallGatewayKongEnterpriseContext install_context.InstallGatewayKongEnterpriseContext
 	InstallTracingContext               install_context.InstallTracingContext
+	InstallLoggingContext               install_context.InstallLoggingContext
 }
 
 func DefaultRootContext() *RootContext {
@@ -99,6 +100,7 @@ func DefaultRootContext() *RootContext {
 		InstallGatewayKongContext:           install_context.DefaultInstallGatewayKongContext(),
 		InstallGatewayKongEnterpriseContext: install_context.DefaultInstallGatewayKongEnterpriseContext(),
 		InstallTracingContext:               install_context.DefaultInstallTracingContext(),
+		InstallLoggingContext:               install_context.DefaultInstallLoggingContext(),
 	}
 }
 


### PR DESCRIPTION
Signed-off-by: Paul Parkanzky <paul.parkanzky@konghq.com>

### Summary

Move kumactl logging args out into context. This is needed for parameterization and consistent with other commands.

### Full changelog



### Issues resolved



### Documentation

- [ ] Link to the website [documentation PR](https://github.com/kumahq/kuma-website/pull/XXX)

### Testing

- [ ] Unit tests
- [ ] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes 

### Backwards compatibility

- [ ] Add `backport-to-stable` label if the code is backwards compatible. Otherwise, list breaking changes.
