### PR TITLE
feat(*) prepare kuma-[cd]p for windows compilation

### DIFF
--- a/app/kuma-dp/pkg/dataplane/command/build_command.go
+++ b/app/kuma-dp/pkg/dataplane/command/build_command.go
@@ -1,3 +1,5 @@
+// +build !linux
+
 package command
 
 import (

--- a/pkg/util/os/limits.go
+++ b/pkg/util/os/limits.go
@@ -1,3 +1,5 @@
+// +build !windows
+
 package os
 
 import (

--- a/pkg/util/os/limits_windows.go
+++ b/pkg/util/os/limits_windows.go
@@ -1,0 +1,13 @@
+package os
+
+import (
+	"math"
+)
+
+func RaiseFileLimit() error {
+	return nil
+}
+
+func CurrentFileLimit() (uint64, error) {
+	return math.MaxUint64, nil
+}


### PR DESCRIPTION
### Summary

With this changes `kuma-cp` and `kuma-dp` can be compiled on and for windows

### Issues resolved

no issue resolved, but I think these one are related:
- https://github.com/kumahq/kuma/issues/365
- https://github.com/kumahq/kuma/issues/366 (this one at least partially)

### Documentation

no documentation changes

### Testing

- [ ] Unit tests
- [ ] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes 

### Backwards compatibility

- [x] Add `backport-to-stable` label if the code is backwards compatible. Otherwise, list breaking changes.
