### PR TITLE
fix(e2e) get kds address for k8s fix

### DIFF
--- a/test/framework/k8s_controlplane.go
+++ b/test/framework/k8s_controlplane.go
@@ -226,16 +226,13 @@ func (c *K8sControlPlane) GetKDSServerAddress() string {
 	// As EKS and AWS generally returns dns records of load balancers instead of
 	//  IP addresses, accessing this data (hostname) was only tested there,
 	//  so the env var was created for that purpose
-	if UseLoadBalancer() && UseHostnameInsteadOfIP() {
+	if UseLoadBalancer() {
 		svc := c.GetKumaCPSvcs()[0]
 
-		ip, hostname := svc.Status.LoadBalancer.Ingress[0].IP, svc.Status.LoadBalancer.Ingress[0].Hostname
-		var address string
+		address := svc.Status.LoadBalancer.Ingress[0].IP
 
-		if ip != "" {
-			address = ip
-		} else if hostname != "" {
-			address = hostname
+		if UseHostnameInsteadOfIP() {
+			address = svc.Status.LoadBalancer.Ingress[0].Hostname
 		}
 
 		return "grpcs://" + address + ":" + strconv.FormatUint(loadBalancerKdsPort, 10)


### PR DESCRIPTION
Signed-off-by: Bart Smykla <bartek@smykla.com>

### Summary

it was wrong, as with just UseLoadBalancer set it was ignored
and the local port of kuma-cp used instead, which broke e2e tests
on AKS

### Full changelog

no changelog

### Issues resolved

no issue

### Documentation

- no documentation

### Testing

- [ ] Unit tests
- [x] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes 

### Backwards compatibility

- [x] Add `backport-to-stable` label if the code is backwards compatible. Otherwise, list breaking changes.
