### PR TITLE
fix(cp): Avoid nil dereferencing in dp validator

### DIFF
--- a/pkg/core/resources/apis/mesh/dataplane_validator.go
+++ b/pkg/core/resources/apis/mesh/dataplane_validator.go
@@ -21,6 +21,10 @@ func (d *DataplaneResource) Validate() error {
 
 	net := validators.RootedAt("networking")
 
+	if d.Spec.GetNetworking() == nil {
+		err.AddViolationAt(net, "must be defined")
+		return err.OrNil()
+	}
 	switch {
 	case d.Spec.IsIngress():
 		err.Add(validateIngressNetworking(d.Spec.GetNetworking()))

--- a/pkg/core/resources/apis/mesh/dataplane_validator.go
+++ b/pkg/core/resources/apis/mesh/dataplane_validator.go
@@ -25,6 +25,7 @@ func (d *DataplaneResource) Validate() error {
 		err.AddViolationAt(net, "must be defined")
 		return err.OrNil()
 	}
+
 	switch {
 	case d.Spec.IsIngress():
 		err.Add(validateIngressNetworking(d.Spec.GetNetworking()))

--- a/pkg/core/resources/apis/mesh/dataplane_validator_test.go
+++ b/pkg/core/resources/apis/mesh/dataplane_validator_test.go
@@ -299,6 +299,29 @@ var _ = Describe("Dataplane", func() {
                 - field: networking
                   message: has to contain at least one inbound interface or gateway`,
 		}),
+		Entry("missing networking", testCase{
+			dataplane: `
+                type: Dataplane
+                name: dp-1
+                mesh: default`,
+			expected: `
+                violations:
+                - field: networking
+                  message: must be defined`,
+		}),
+		Entry("networking empty", testCase{
+			dataplane: `
+                type: Dataplane
+                name: dp-1
+                mesh: default
+                networking: {}`,
+			expected: `
+                violations:
+                - field: networking
+                  message: has to contain at least one inbound interface or gateway
+                - field: networking.address
+                  message: address can't be empty`,
+		}),
 		Entry("networking.address: empty", testCase{
 			dataplane: `
                 type: Dataplane


### PR DESCRIPTION
### Summary

When the `networking` section was not set we were panicking


### Full changelog

* add a nil check and a validation error.

### Testing

- [x] Unit tests
- [ ] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes 

### Backwards compatibility

- [x] Add `backport-to-stable` label if the code is backwards compatible. Otherwise, list breaking changes.
