### PR TITLE
chore(ci) lint "builtin" directories

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -15,6 +15,9 @@ run:
     - pkg/xds/server/server.go # excluded to keep as close to original file from Envoy repository
     - pkg/xds/server/server_test.go # excluded to keep as close to original file from Envoy repository
   modules-download-mode: readonly
+  skip-dirs-use-default: false # The default skip omits "builtin" directories, which we have.
+  skip-dirs:
+  - (^|/)vendored($|/)
 
 linters-settings:
   gocritic:

--- a/pkg/plugins/ca/builtin/manager.go
+++ b/pkg/plugins/ca/builtin/manager.go
@@ -10,7 +10,7 @@ import (
 	system_proto "github.com/kumahq/kuma/api/system/v1alpha1"
 	core_ca "github.com/kumahq/kuma/pkg/core/ca"
 	ca_issuer "github.com/kumahq/kuma/pkg/core/ca/issuer"
-	mesh_helper "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
+	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	core_system "github.com/kumahq/kuma/pkg/core/resources/apis/system"
 	"github.com/kumahq/kuma/pkg/core/resources/manager"
 	core_model "github.com/kumahq/kuma/pkg/core/resources/model"
@@ -69,7 +69,7 @@ func (b *builtinCaManager) create(ctx context.Context, mesh string, backend *mes
 
 	var opts []certOptsFn
 	if cfg.GetCaCert().GetExpiration() != "" {
-		duration, err := mesh_helper.ParseDuration(cfg.GetCaCert().GetExpiration())
+		duration, err := core_mesh.ParseDuration(cfg.GetCaCert().GetExpiration())
 		if err != nil {
 			return err
 		}
@@ -130,7 +130,7 @@ func (b *builtinCaManager) GenerateDataplaneCert(ctx context.Context, mesh strin
 
 	var opts []ca_issuer.CertOptsFn
 	if backend.GetDpCert().GetRotation().GetExpiration() != "" {
-		duration, err := mesh_helper.ParseDuration(backend.GetDpCert().GetRotation().Expiration)
+		duration, err := core_mesh.ParseDuration(backend.GetDpCert().GetRotation().Expiration)
 		if err != nil {
 			return core_ca.KeyPair{}, err
 		}

--- a/pkg/plugins/ca/builtin/manager_test.go
+++ b/pkg/plugins/ca/builtin/manager_test.go
@@ -45,7 +45,7 @@ var _ = Describe("Builtin CA Manager", func() {
 
 	Context("Ensure", func() {
 		It("should create a CA", func() {
-			//given
+			// given
 			mesh := "default"
 			backend := &mesh_proto.CertificateAuthorityBackend{
 				Name: "builtin-1",
@@ -83,7 +83,7 @@ var _ = Describe("Builtin CA Manager", func() {
 		})
 
 		It("should create a configured CA", func() {
-			//given
+			// given
 			mesh := "default"
 			backend := &mesh_proto.CertificateAuthorityBackend{
 				Name: "builtin-1",
@@ -115,7 +115,7 @@ var _ = Describe("Builtin CA Manager", func() {
 
 	Context("GetRootCert", func() {
 		It("should retrieve created certs", func() {
-			//given
+			// given
 			mesh := "default"
 			backend := &mesh_proto.CertificateAuthorityBackend{
 				Name: "builtin-1",
@@ -151,7 +151,7 @@ var _ = Describe("Builtin CA Manager", func() {
 
 	Context("GenerateDataplaneCert", func() {
 		It("should generate dataplane certs", func() {
-			//given
+			// given
 			mesh := "default"
 			backend := &mesh_proto.CertificateAuthorityBackend{
 				Name: "builtin-1",

--- a/pkg/tokens/builtin/issuer/issuer.go
+++ b/pkg/tokens/builtin/issuer/issuer.go
@@ -9,13 +9,6 @@ import (
 
 type Token = string
 
-//type DpType = string
-//
-//const (
-//	DpTypeDataplane = "dataplane"
-//	DpTypeIngress   = "ingress"
-//)
-
 type DataplaneIdentity struct {
 	Name string
 	Mesh string

--- a/pkg/tokens/builtin/issuer/signing_key.go
+++ b/pkg/tokens/builtin/issuer/signing_key.go
@@ -8,18 +8,15 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/kumahq/kuma/pkg/core"
-	"github.com/kumahq/kuma/pkg/core/resources/manager"
+	"github.com/pkg/errors"
 
 	system_proto "github.com/kumahq/kuma/api/system/v1alpha1"
 	"github.com/kumahq/kuma/pkg/core/resources/apis/system"
+	"github.com/kumahq/kuma/pkg/core/resources/manager"
 	"github.com/kumahq/kuma/pkg/core/resources/model"
 	"github.com/kumahq/kuma/pkg/core/resources/store"
 	util_proto "github.com/kumahq/kuma/pkg/util/proto"
-	"github.com/pkg/errors"
 )
-
-var log = core.Log.WithName("tokens")
 
 const (
 	defaultRsaBits = 2048

--- a/pkg/tokens/builtin/server/webservice.go
+++ b/pkg/tokens/builtin/server/webservice.go
@@ -5,14 +5,13 @@ import (
 
 	"github.com/emicklei/go-restful"
 
-	"github.com/kumahq/kuma/pkg/tokens/builtin/zoneingress"
-
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	"github.com/kumahq/kuma/pkg/core"
 	"github.com/kumahq/kuma/pkg/core/rest/errors"
 	"github.com/kumahq/kuma/pkg/core/validators"
 	"github.com/kumahq/kuma/pkg/tokens/builtin/issuer"
 	"github.com/kumahq/kuma/pkg/tokens/builtin/server/types"
+	"github.com/kumahq/kuma/pkg/tokens/builtin/zoneingress"
 )
 
 var log = core.Log.WithName("dataplane-token-ws")

--- a/pkg/tokens/builtin/server/webservice_test.go
+++ b/pkg/tokens/builtin/server/webservice_test.go
@@ -15,11 +15,10 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/pkg/errors"
 
-	"github.com/kumahq/kuma/pkg/tokens/builtin/zoneingress"
-
 	"github.com/kumahq/kuma/pkg/tokens/builtin/issuer"
 	"github.com/kumahq/kuma/pkg/tokens/builtin/server"
 	"github.com/kumahq/kuma/pkg/tokens/builtin/server/types"
+	"github.com/kumahq/kuma/pkg/tokens/builtin/zoneingress"
 )
 
 type staticTokenIssuer struct {

--- a/pkg/tokens/builtin/zoneingress/signing_key.go
+++ b/pkg/tokens/builtin/zoneingress/signing_key.go
@@ -6,14 +6,14 @@ import (
 	"crypto/rsa"
 	"crypto/x509"
 
-	util_proto "github.com/kumahq/kuma/pkg/util/proto"
+	"github.com/pkg/errors"
 
 	system_proto "github.com/kumahq/kuma/api/system/v1alpha1"
 	"github.com/kumahq/kuma/pkg/core/resources/apis/system"
 	"github.com/kumahq/kuma/pkg/core/resources/manager"
 	core_model "github.com/kumahq/kuma/pkg/core/resources/model"
 	"github.com/kumahq/kuma/pkg/core/resources/store"
-	"github.com/pkg/errors"
+	util_proto "github.com/kumahq/kuma/pkg/util/proto"
 )
 
 const (


### PR DESCRIPTION
### Summary

The default configuration for golangci-lint skips directories named
"builtin" (see the `--skip-dirs-use-default` flag). Disable that so
that we can get full lint coverage.



### Full changelog

N/A

### Issues resolved

N/A

### Documentation

N/A

### Testing

- [x] Unit tests
- [x] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes 

### Backwards compatibility

- [x] Add `backport-to-stable` label if the code is backwards compatible. Otherwise, list breaking changes.
