### PR TITLE
tests(kumactl) Allow kuma-specific const to be overridden

### DIFF
--- a/test/framework/constants.go
+++ b/test/framework/constants.go
@@ -53,6 +53,7 @@ var HelmSubChartPrefix = ""
 var KumaNamespace = "kuma-system"
 var KumaServiceName = "kuma-control-plane"
 var KumaGlobalZoneSyncServiceName = "kuma-global-zone-sync"
+var DefaultTracingNamespace = "kuma-tracing"
 
 var CNIApp = "kuma-cni"
 var CNINamespace = "kube-system"

--- a/test/framework/deployments/tracing/kubernetes.go
+++ b/test/framework/deployments/tracing/kubernetes.go
@@ -45,7 +45,7 @@ func (t *k8SDeployment) Deploy(cluster framework.Cluster) error {
 	}
 
 	k8s.WaitUntilNumPodsCreated(cluster.GetTesting(),
-		cluster.GetKubectlOptions(tracingNamespace),
+		cluster.GetKubectlOptions(framework.DefaultTracingNamespace),
 		metav1.ListOptions{
 			LabelSelector: "app=jaeger",
 		},
@@ -54,7 +54,7 @@ func (t *k8SDeployment) Deploy(cluster framework.Cluster) error {
 		framework.DefaultTimeout)
 
 	pods := k8s.ListPods(cluster.GetTesting(),
-		cluster.GetKubectlOptions(tracingNamespace),
+		cluster.GetKubectlOptions(framework.DefaultTracingNamespace),
 		metav1.ListOptions{
 			LabelSelector: "app=jaeger",
 		},

--- a/test/framework/deployments/tracing/kubernetes.go
+++ b/test/framework/deployments/tracing/kubernetes.go
@@ -11,8 +11,6 @@ import (
 	"github.com/kumahq/kuma/test/framework"
 )
 
-const tracingNamespace = "kuma-tracing"
-
 type k8SDeployment struct {
 	port uint32
 }
@@ -64,7 +62,7 @@ func (t *k8SDeployment) Deploy(cluster framework.Cluster) error {
 	}
 
 	k8s.WaitUntilPodAvailable(cluster.GetTesting(),
-		cluster.GetKubectlOptions(tracingNamespace),
+		cluster.GetKubectlOptions(framework.DefaultTracingNamespace),
 		pods[0].Name,
 		framework.DefaultRetries,
 		framework.DefaultTimeout)
@@ -75,7 +73,7 @@ func (t *k8SDeployment) Deploy(cluster framework.Cluster) error {
 	}
 	t.port = port
 
-	cluster.(*framework.K8sCluster).PortForwardPod(tracingNamespace, pods[0].Name, port, 16686)
+	cluster.(*framework.K8sCluster).PortForwardPod(framework.DefaultTracingNamespace, pods[0].Name, port, 16686)
 	return nil
 }
 
@@ -92,6 +90,6 @@ func (t *k8SDeployment) Delete(cluster framework.Cluster) error {
 	if err != nil {
 		return err
 	}
-	cluster.(*framework.K8sCluster).WaitNamespaceDelete(tracingNamespace)
+	cluster.(*framework.K8sCluster).WaitNamespaceDelete(framework.DefaultTracingNamespace)
 	return nil
 }


### PR DESCRIPTION
Signed-off-by: Paul Parkanzky <paul.parkanzky@konghq.com>

### Summary

This constant needs to be up in the global constants list to be overridden.

### Full changelog


### Issues resolved



### Documentation

- [ ] Link to the website [documentation PR](https://github.com/kumahq/kuma-website/pull/XXX)

### Testing

- [ ] Unit tests
- [ ] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes 

### Backwards compatibility

- [ ] Add `backport-to-stable` label if the code is backwards compatible. Otherwise, list breaking changes.
