### PR TITLE
feat(kuma-cp) Return instance and cluster IDs

### DIFF
--- a/app/kumactl/cmd/root.go
+++ b/app/kumactl/cmd/root.go
@@ -87,7 +87,7 @@ func NewRootCmd(root *kumactl_cmd.RootContext) *cobra.Command {
 			if kumaBuildVersion == nil {
 				cmd.PrintErr("WARNING: Unable to confirm the server supports this kumactl version\n")
 			} else if kumaBuildVersion.Version != kuma_version.Build.Version || kumaBuildVersion.Tagline != kuma_version.Product {
-				cmd.PrintErr("WARNING: You are using kumactl version " + kuma_version.Build.Version + " for " + kuma_version.Product + ", but the server returned version: " + kumaBuildVersion.Tagline + " " + kumaBuildVersion.Version + " Server Instance Id: " + kumaBuildVersion.InstanceId + " Service Cluster Id: " + kumaBuildVersion.ClusterId + "\n")
+				cmd.PrintErr("WARNING: You are using kumactl version " + kuma_version.Build.Version + " for " + kuma_version.Product + ", but the server returned version: " + kumaBuildVersion.Tagline + " " + kumaBuildVersion.Version + "\n")
 			}
 			return nil
 		},

--- a/app/kumactl/cmd/root.go
+++ b/app/kumactl/cmd/root.go
@@ -87,7 +87,7 @@ func NewRootCmd(root *kumactl_cmd.RootContext) *cobra.Command {
 			if kumaBuildVersion == nil {
 				cmd.PrintErr("WARNING: Unable to confirm the server supports this kumactl version\n")
 			} else if kumaBuildVersion.Version != kuma_version.Build.Version || kumaBuildVersion.Tagline != kuma_version.Product {
-				cmd.PrintErr("WARNING: You are using kumactl version " + kuma_version.Build.Version + " for " + kuma_version.Product + ", but the server returned version: " + kumaBuildVersion.Tagline + " " + kumaBuildVersion.Version + "\n")
+				cmd.PrintErr("WARNING: You are using kumactl version " + kuma_version.Build.Version + " for " + kuma_version.Product + ", but the server returned version: " + kumaBuildVersion.Tagline + " " + kumaBuildVersion.Version + " Server Instance Id: " + kumaBuildVersion.InstanceId + " Service Cluster Id: " + kumaBuildVersion.ClusterId + "\n")
 			}
 			return nil
 		},

--- a/pkg/api-server/customization/customization_suite_test.go
+++ b/pkg/api-server/customization/customization_suite_test.go
@@ -40,12 +40,15 @@ func createTestApiServer(store store.ResourceStore, config *config_api_server.Ap
 
 	resources := manager.NewResourceManager(store)
 
+	getInstanceId := func() string { return "instance-id" }
+	getClusterId := func() string { return "cluster-id" }
+
 	if wsManager == nil {
 		wsManager = customization.NewAPIList()
 	}
 	cfg := kuma_cp.DefaultConfig()
 	cfg.ApiServer = config
-	apiServer, err := api_server.NewApiServer(resources, wsManager, registry.Global().ObjectDescriptors(core_model.HasWsEnabled()), &cfg, enableGUI, metrics)
+	apiServer, err := api_server.NewApiServer(resources, wsManager, registry.Global().ObjectDescriptors(core_model.HasWsEnabled()), &cfg, enableGUI, metrics, getInstanceId, getClusterId)
 	Expect(err).ToNot(HaveOccurred())
 	return apiServer
 }

--- a/pkg/api-server/index_endpoints.go
+++ b/pkg/api-server/index_endpoints.go
@@ -10,12 +10,11 @@ import (
 )
 
 var APIIndexResponseFn = kumaAPIIndexResponse
-var hostname string
-var instanceId string
-var clusterId string
 
 func addIndexWsEndpoints(ws *restful.WebService, getInstanceId func() string, getClusterId func() string) error {
 	hostname, err := os.Hostname()
+	var instanceId string
+	var clusterId string
 	if err != nil {
 		return err
 	}

--- a/pkg/api-server/index_endpoints_test.go
+++ b/pkg/api-server/index_endpoints_test.go
@@ -70,7 +70,9 @@ var _ = Describe("Index Endpoints", func() {
 		{
 			"hostname": "%s",
 			"tagline": "Kuma",
-			"version": "1.2.3"
+			"version": "1.2.3",
+			"instance_id": "instance-id",
+			"cluster_id": "cluster-id"
 		}`, hostname)
 
 		Expect(body).To(MatchJSON(expected))

--- a/pkg/api-server/index_endpoints_test.go
+++ b/pkg/api-server/index_endpoints_test.go
@@ -71,8 +71,8 @@ var _ = Describe("Index Endpoints", func() {
 			"hostname": "%s",
 			"tagline": "Kuma",
 			"version": "1.2.3",
-			"instance_id": "instance-id",
-			"cluster_id": "cluster-id"
+			"instanceId": "instance-id",
+			"clusterId": "cluster-id"
 		}`, hostname)
 
 		Expect(body).To(MatchJSON(expected))

--- a/pkg/api-server/resource_api_client_test.go
+++ b/pkg/api-server/resource_api_client_test.go
@@ -121,7 +121,9 @@ func createTestApiServer(store store.ResourceStore, config *config_api_server.Ap
 	wsManager := customization.NewAPIList()
 	cfg := kuma_cp.DefaultConfig()
 	cfg.ApiServer = config
-	apiServer, err := api_server.NewApiServer(resources, wsManager, defs, &cfg, enableGUI, metrics)
+	getInstanceId := func() string { return "instance-id" }
+	getClusterId := func() string { return "cluster-id" }
+	apiServer, err := api_server.NewApiServer(resources, wsManager, defs, &cfg, enableGUI, metrics, getInstanceId, getClusterId)
 	Expect(err).ToNot(HaveOccurred())
 	return apiServer
 }

--- a/pkg/api-server/server.go
+++ b/pkg/api-server/server.go
@@ -72,7 +72,7 @@ func init() {
 	}
 }
 
-func NewApiServer(resManager manager.ResourceManager, wsManager customization.APIInstaller, defs []model.ResourceTypeDescriptor, cfg *kuma_cp.Config, enableGUI bool, metrics metrics.Metrics) (*ApiServer, error) {
+func NewApiServer(resManager manager.ResourceManager, wsManager customization.APIInstaller, defs []model.ResourceTypeDescriptor, cfg *kuma_cp.Config, enableGUI bool, metrics metrics.Metrics, getInstanceId func() string, getClusterId func() string) (*ApiServer, error) {
 	serverConfig := cfg.ApiServer
 	container := restful.NewContainer()
 
@@ -102,7 +102,7 @@ func NewApiServer(resManager manager.ResourceManager, wsManager customization.AP
 	addResourcesEndpoints(ws, defs, resManager, cfg)
 	container.Add(ws)
 
-	if err := addIndexWsEndpoints(ws); err != nil {
+	if err := addIndexWsEndpoints(ws, getInstanceId, getClusterId); err != nil {
 		return nil, errors.Wrap(err, "could not create index webservice")
 	}
 	configWs, err := configWs(cfg)
@@ -338,7 +338,7 @@ func (a *ApiServer) notAvailableHandler(writer http.ResponseWriter, request *htt
 
 func SetupServer(rt runtime.Runtime) error {
 	cfg := rt.Config()
-	apiServer, err := NewApiServer(rt.ResourceManager(), rt.APIInstaller(), registry.Global().ObjectDescriptors(model.HasWsEnabled()), &cfg, cfg.Mode != config_core.Zone, rt.Metrics())
+	apiServer, err := NewApiServer(rt.ResourceManager(), rt.APIInstaller(), registry.Global().ObjectDescriptors(model.HasWsEnabled()), &cfg, cfg.Mode != config_core.Zone, rt.Metrics(), rt.GetInstanceId, rt.GetClusterId)
 	if err != nil {
 		return err
 	}

--- a/pkg/api-server/types/index.go
+++ b/pkg/api-server/types/index.go
@@ -4,6 +4,6 @@ type IndexResponse struct {
 	Hostname   string `json:"hostname"`
 	Tagline    string `json:"tagline"`
 	Version    string `json:"version"`
-	InstanceId string `json:"instance_id"`
-	ClusterId  string `json:"cluster_id"`
+	InstanceId string `json:"instanceId"`
+	ClusterId  string `json:"clusterId"`
 }

--- a/pkg/api-server/types/index.go
+++ b/pkg/api-server/types/index.go
@@ -1,7 +1,9 @@
 package types
 
 type IndexResponse struct {
-	Hostname string `json:"hostname"`
-	Tagline  string `json:"tagline"`
-	Version  string `json:"version"`
+	Hostname   string `json:"hostname"`
+	Tagline    string `json:"tagline"`
+	Version    string `json:"version"`
+	InstanceId string `json:"instance_id"`
+	ClusterId  string `json:"cluster_id"`
 }


### PR DESCRIPTION
Signed-off-by: Paul Parkanzky <paul.parkanzky@konghq.com>

### Summary

Return instance and cluster IDs in kuma-cp API status.

### Full changelog


### Issues resolved


### Documentation

- [ ] Link to the website [documentation PR](https://github.com/kumahq/kuma-website/pull/XXX)

### Testing

- [ ] Unit tests
- [ ] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes 

### Backwards compatibility

- [ ] Add `backport-to-stable` label if the code is backwards compatible. Otherwise, list breaking changes.
