### PR TITLE
feat(kuma-cp) add virtual host domain name configurer

### DIFF
--- a/pkg/xds/envoy/routes/configurers.go
+++ b/pkg/xds/envoy/routes/configurers.go
@@ -17,6 +17,18 @@ func CommonVirtualHost(name string) VirtualHostBuilderOpt {
 	)
 }
 
+func DomainNames(domainNames ...string) VirtualHostBuilderOpt {
+	if len(domainNames) == 0 {
+		return VirtualHostBuilderOptFunc(nil)
+	}
+
+	return AddVirtualHostConfigurer(
+		v3.VirtualHostMustConfigureFunc(func(vh *envoy_route.VirtualHost) {
+			vh.Domains = domainNames
+		}),
+	)
+}
+
 func Routes(routes envoy_common.Routes) VirtualHostBuilderOpt {
 	return AddVirtualHostConfigurer(
 		&v3.RoutesConfigurer{

--- a/pkg/xds/envoy/routes/virtual_host_builder.go
+++ b/pkg/xds/envoy/routes/virtual_host_builder.go
@@ -68,7 +68,9 @@ func (c *VirtualHostBuilderConfig) AddV3(configurer v3.VirtualHostConfigurer) {
 type VirtualHostBuilderOptFunc func(config *VirtualHostBuilderConfig)
 
 func (f VirtualHostBuilderOptFunc) ApplyTo(config *VirtualHostBuilderConfig) {
-	f(config)
+	if f != nil {
+		f(config)
+	}
 }
 
 // AddVirtualHostConfigurer production an option that adds the given


### PR DESCRIPTION

### Testing

- [x] Unit tests
- [x] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes 

### Backwards compatibility

- [-] Add `backport-to-stable` label if the code is backwards compatible. Otherwise, list breaking changes.
