### PR TITLE
feat(kuma-cp) add simple HTTP connection configurers

### DIFF
--- a/pkg/xds/envoy/listeners/configurers.go
+++ b/pkg/xds/envoy/listeners/configurers.go
@@ -2,12 +2,13 @@ package listeners
 
 import (
 	envoy_listener "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
-	"google.golang.org/protobuf/types/known/wrapperspb"
+	envoy_hcm "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
 
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	core_xds "github.com/kumahq/kuma/pkg/core/xds"
 	"github.com/kumahq/kuma/pkg/tls"
+	util_proto "github.com/kumahq/kuma/pkg/util/proto"
 	xds_context "github.com/kumahq/kuma/pkg/xds/context"
 	envoy_common "github.com/kumahq/kuma/pkg/xds/envoy"
 	v3 "github.com/kumahq/kuma/pkg/xds/envoy/listeners/v3"
@@ -273,7 +274,7 @@ func DNS(vips map[string]string, emptyDnsPort uint32) ListenerBuilderOpt {
 func ConnectionBufferLimit(bytes uint32) ListenerBuilderOpt {
 	return AddListenerConfigurer(
 		v3.ListenerMustConfigureFunc(func(l *envoy_listener.Listener) {
-			l.PerConnectionBufferLimitBytes = wrapperspb.UInt32(bytes)
+			l.PerConnectionBufferLimitBytes = util_proto.UInt32(bytes)
 		}))
 }
 
@@ -288,6 +289,40 @@ func EnableReusePort(enable bool) ListenerBuilderOpt {
 func EnableFreebind(enable bool) ListenerBuilderOpt {
 	return AddListenerConfigurer(
 		v3.ListenerMustConfigureFunc(func(l *envoy_listener.Listener) {
-			l.Freebind = wrapperspb.Bool(enable)
+			l.Freebind = util_proto.Bool(enable)
 		}))
+}
+
+// ServerHeader sets the value that the HttpConnectionManager will write
+// to the "Server" header in HTTP responses.
+func ServerHeader(name string) FilterChainBuilderOpt {
+	return AddFilterChainConfigurer(
+		v3.HttpConnectionManagerMustConfigureFunc(func(hcm *envoy_hcm.HttpConnectionManager) {
+			hcm.ServerName = name
+		}),
+	)
+}
+
+// EnablePathNormalization enables HTTP request path normalization.
+func EnablePathNormalization() FilterChainBuilderOpt {
+	return AddFilterChainConfigurer(
+		v3.HttpConnectionManagerMustConfigureFunc(func(hcm *envoy_hcm.HttpConnectionManager) {
+			hcm.NormalizePath = util_proto.Bool(true)
+			hcm.MergeSlashes = true
+
+			// TODO(jpeach) set path_with_escaped_slashes_action when we upgrade to Envoy v1.19.
+		}),
+	)
+}
+
+// StripHostPort strips the port component before matching the HTTP host
+// header (authority) to the available virtual hosts.
+func StripHostPort() FilterChainBuilderOpt {
+	return AddFilterChainConfigurer(
+		v3.HttpConnectionManagerMustConfigureFunc(func(hcm *envoy_hcm.HttpConnectionManager) {
+			hcm.StripPortMode = &envoy_hcm.HttpConnectionManager_StripAnyHostPort{
+				StripAnyHostPort: true,
+			}
+		}),
+	)
 }

--- a/pkg/xds/envoy/listeners/http_connection_manager_configurer_test.go
+++ b/pkg/xds/envoy/listeners/http_connection_manager_configurer_test.go
@@ -1,0 +1,83 @@
+package listeners_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+
+	util_proto "github.com/kumahq/kuma/pkg/util/proto"
+	"github.com/kumahq/kuma/pkg/xds/envoy"
+	. "github.com/kumahq/kuma/pkg/xds/envoy/listeners"
+)
+
+var _ = Describe("HttpConnectionManager Configurers", func() {
+	type Opt = FilterChainBuilderOpt
+
+	type testCase struct {
+		opts     []Opt
+		expected string
+	}
+
+	Context("V3", func() {
+		DescribeTable("should generate proper Envoy config",
+			func(given testCase) {
+				opts := append([]Opt{
+					HttpConnectionManager("test", false),
+				}, given.opts...)
+
+				// when
+				chain, err := NewFilterChainBuilder(envoy.APIV3).
+					Configure(opts...).
+					Build()
+				// then
+				Expect(err).ToNot(HaveOccurred())
+
+				// when
+				actual, err := util_proto.ToYAML(chain)
+				// then
+				Expect(err).ToNot(HaveOccurred())
+				// and
+				Expect(actual).To(MatchYAML(given.expected))
+			},
+			Entry("set the server header", testCase{
+				opts: []Opt{ServerHeader("test-server")},
+				expected: `
+          filters:
+          - name: envoy.filters.network.http_connection_manager
+            typedConfig:
+              '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+              httpFilters:
+              - name: envoy.filters.http.router
+              serverName: test-server
+              statPrefix: test`,
+			}),
+
+			Entry("set path normalization", testCase{
+				opts: []Opt{EnablePathNormalization()},
+				expected: `
+          filters:
+          - name: envoy.filters.network.http_connection_manager
+            typedConfig:
+              '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+              httpFilters:
+              - name: envoy.filters.http.router
+              mergeSlashes: true
+              normalizePath: true
+              statPrefix: test`,
+			}),
+
+			Entry("strip host port", testCase{
+				opts: []Opt{StripHostPort()},
+				expected: `
+          filters:
+          - name: envoy.filters.network.http_connection_manager
+            typedConfig:
+              '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+              httpFilters:
+              - name: envoy.filters.http.router
+              statPrefix: test
+              stripAnyHostPort: true`,
+			}),
+		)
+	})
+})


### PR DESCRIPTION
### Summary

Add a few HTTP connection manager configurers that are helpful
for gateway use cases.

### Full changelog

N/A

### Issues resolved

N/A

### Documentation

N/A

### Testing

- [x] Unit tests
- [x] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes 

### Backwards compatibility

- [x] Add `backport-to-stable` label if the code is backwards compatible. Otherwise, list breaking changes.
