### PR TITLE
fix(kuma-dp) improve envoy version parsing

### DIFF
--- a/app/kuma-dp/pkg/dataplane/envoy/envoy.go
+++ b/app/kuma-dp/pkg/dataplane/envoy/envoy.go
@@ -211,9 +211,10 @@ func (e *Envoy) version() (*EnvoyVersion, error) {
 	if err != nil {
 		return nil, errors.Wrap(err, fmt.Sprintf("the envoy excutable was found at %s but an error occurred when executing it with arg %s", resolvedPath, arg))
 	}
-	build := strings.Trim(string(output), "\n")
-	build = regexp.MustCompile(`:(.*)`).FindString(build)
-	build = strings.Trim(build, ":")
+	build := strings.ReplaceAll(string(output), "\r\n", "\n")
+	build = strings.Trim(build, "\n")
+	build = regexp.MustCompile(`version:(.*)`).FindString(build)
+	build = strings.Trim(build, "version:")
 	build = strings.Trim(build, " ")
 	version := regexp.MustCompile(`/([0-9.]+)/`).FindString(build)
 	version = strings.Trim(version, "/")

--- a/app/kuma-dp/pkg/dataplane/envoy/envoy_test.go
+++ b/app/kuma-dp/pkg/dataplane/envoy/envoy_test.go
@@ -194,7 +194,7 @@ var _ = Describe("Envoy", func() {
 	})
 
 	Describe("Parse version", func() {
-		It("should properly read envoy version", func() {
+		It("should properly read envoy version for unix-based systems", func() {
 			// given
 			cfg := kuma_dp.Config{
 				DataplaneRuntime: kuma_dp.DataplaneRuntime{
@@ -216,6 +216,30 @@ var _ = Describe("Envoy", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(version.Version).To(Equal("1.15.0"))
 			Expect(version.Build).To(Equal("50ef0945fa2c5da4bff7627c3abf41fdd3b7cffd/1.15.0/clean-getenvoy-2aa564b-envoy/RELEASE/BoringSSL"))
+		})
+
+		It("should properly read envoy version for windows", func() {
+			// given
+			cfg := kuma_dp.Config{
+				DataplaneRuntime: kuma_dp.DataplaneRuntime{
+					BinaryPath: filepath.Join("testdata", "envoy-mock-windows.exit-0.sh"),
+					ConfigDir:  configDir,
+				},
+			}
+
+			// when
+			dataplane, err := New(Opts{
+				Config: cfg,
+				Stdout: &bytes.Buffer{},
+				Stderr: &bytes.Buffer{},
+			})
+			Expect(err).ToNot(HaveOccurred())
+			version, err := dataplane.version()
+
+			// then
+			Expect(err).ToNot(HaveOccurred())
+			Expect(version.Version).To(Equal("1.19.0"))
+			Expect(version.Build).To(Equal("68fe53a889416fd8570506232052b06f5a531541/1.19.0/Modified/RELEASE/BoringSSL"))
 		})
 	})
 })

--- a/app/kuma-dp/pkg/dataplane/envoy/testdata/envoy-mock-windows.exit-0.sh
+++ b/app/kuma-dp/pkg/dataplane/envoy/testdata/envoy-mock-windows.exit-0.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+if [ "$1" = "--version" ];
+then
+  printf "\r\nC:\\\Users\\\kuma\\\envoy\\\versions\\\1.19.0\\\bin\\\envoy.exe  version: 68fe53a889416fd8570506232052b06f5a531541/1.19.0/Modified/RELEASE/BoringSSL\r\n\r\n"
+  exit 0
+fi
+# print arguments to verify in the test
+echo $@


### PR DESCRIPTION
### Summary

it fixes version parsing for windows
I also added test for windows

### Full changelog

no changelog

### Issues resolved

no issue

### Documentation

no documentation

### Testing

- [x] Unit tests
- [ ] E2E tests
- [x] Manual testing on Universal
- [ ] Manual testing on Kubernetes 

### Backwards compatibility

- [x] Add `backport-to-stable` label if the code is backwards compatible. Otherwise, list breaking changes.
