### PR TITLE
chore(*) run {a,e}ks e2e workflows only on master

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,13 +81,12 @@ reusable:
         tags:
           ignore: /.*/ # we don't want to run master workflow on commits with tag because use_local_kuma_images has to be false for all the jobs to pass
 
-    # filters for the eks-e2e workflow
+    # filters for the {a,e}ks-e2e workflow
     master_only_workflow_filters: &master_only_workflow_filters
       filters:
         branches:
           only:
             - master
-            - /^release-.*/
 
     # filters for the kuma-commit workflow
     commit_workflow_filters: &commit_workflow_filters


### PR DESCRIPTION
Signed-off-by: Bart Smykla <bartek@smykla.com>

### Summary

The tests for aks/eks were meant to run only for master, so this fixes it, and stops running cleaning jobs twice, every day

### Full changelog

no changelog

### Issues resolved

no issues

### Documentation

no documentation

### Testing

- [ ] Unit tests
- [ ] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes 

### Backwards compatibility

- [x] Add `backport-to-stable` label if the code is backwards compatible. Otherwise, list breaking changes.
