### PR TITLE
chore(kuma-cp) open CAProvider and MeshValidator for extensions

### DIFF
--- a/pkg/core/managers/apis/mesh/mesh_manager_suite_test.go
+++ b/pkg/core/managers/apis/mesh/mesh_manager_suite_test.go
@@ -1,4 +1,4 @@
-package mesh
+package mesh_test
 
 import (
 	"testing"

--- a/pkg/core/managers/apis/mesh/mesh_manager_test.go
+++ b/pkg/core/managers/apis/mesh/mesh_manager_test.go
@@ -1,4 +1,4 @@
-package mesh
+package mesh_test
 
 import (
 	"context"
@@ -10,6 +10,7 @@ import (
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	core_ca "github.com/kumahq/kuma/pkg/core/ca"
 	"github.com/kumahq/kuma/pkg/core/datasource"
+	"github.com/kumahq/kuma/pkg/core/managers/apis/mesh"
 	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	"github.com/kumahq/kuma/pkg/core/resources/apis/system"
 	"github.com/kumahq/kuma/pkg/core/resources/manager"
@@ -45,8 +46,8 @@ var _ = Describe("Mesh Manager", func() {
 		}
 
 		manager := manager.NewResourceManager(resStore)
-		validator := MeshValidator{CaManagers: caManagers, Store: resStore}
-		resManager = NewMeshManager(resStore, manager, caManagers, test_resources.Global(), validator)
+		validator := mesh.NewMeshValidator(caManagers, resStore)
+		resManager = mesh.NewMeshManager(resStore, manager, caManagers, test_resources.Global(), validator)
 	})
 
 	Describe("Create()", func() {

--- a/pkg/core/managers/apis/mesh/mesh_validator.go
+++ b/pkg/core/managers/apis/mesh/mesh_validator.go
@@ -7,27 +7,41 @@ import (
 
 	core_ca "github.com/kumahq/kuma/pkg/core/ca"
 	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
-	"github.com/kumahq/kuma/pkg/core/resources/store"
+	core_store "github.com/kumahq/kuma/pkg/core/resources/store"
 	"github.com/kumahq/kuma/pkg/core/validators"
 )
 
-type MeshValidator struct {
-	CaManagers core_ca.Managers
-	Store      store.ResourceStore
+type MeshValidator interface {
+	ValidateCreate(ctx context.Context, name string, resource *core_mesh.MeshResource) error
+	ValidateUpdate(ctx context.Context, previousMesh *core_mesh.MeshResource, newMesh *core_mesh.MeshResource) error
+	ValidateDelete(ctx context.Context, name string) error
 }
 
-func (m *MeshValidator) ValidateCreate(ctx context.Context, name string, resource *core_mesh.MeshResource) error {
-	if err := m.validateMTLSBackends(ctx, name, resource); err != nil {
+type meshValidator struct {
+	CaManagers core_ca.Managers
+	Store      core_store.ResourceStore
+}
+
+func NewMeshValidator(caManagers core_ca.Managers, store core_store.ResourceStore) MeshValidator {
+	return &meshValidator{
+		CaManagers: caManagers,
+		Store:      store,
+	}
+}
+
+func (m *meshValidator) ValidateCreate(ctx context.Context, name string, resource *core_mesh.MeshResource) error {
+	if err := ValidateMTLSBackends(ctx, m.CaManagers, name, resource); err != nil {
 		return err
 	}
 	return nil
 }
 
-func (m *MeshValidator) validateMTLSBackends(ctx context.Context, name string, resource *core_mesh.MeshResource) error {
+func ValidateMTLSBackends(ctx context.Context, caManagers core_ca.Managers, name string, resource *core_mesh.MeshResource) error {
 	verr := validators.ValidationError{}
 	path := validators.RootedAt("mtls").Field("backends")
+
 	for idx, backend := range resource.Spec.GetMtls().GetBackends() {
-		caManager, exist := m.CaManagers[backend.Type]
+		caManager, exist := caManagers[backend.Type]
 		if !exist {
 			verr.AddViolationAt(path.Index(idx).Field("type"), "could not find installed plugin for this type")
 			return verr.OrNil()
@@ -43,20 +57,27 @@ func (m *MeshValidator) validateMTLSBackends(ctx context.Context, name string, r
 	return verr.OrNil()
 }
 
-func (m *MeshValidator) ValidateUpdate(ctx context.Context, previousMesh *core_mesh.MeshResource, newMesh *core_mesh.MeshResource) error {
+func (m *meshValidator) ValidateUpdate(ctx context.Context, previousMesh *core_mesh.MeshResource, newMesh *core_mesh.MeshResource) error {
 	if err := m.validateMTLSBackendChange(previousMesh, newMesh); err != nil {
 		return err
 	}
-	if err := m.validateMTLSBackends(ctx, newMesh.Meta.GetName(), newMesh); err != nil {
+	if err := ValidateMTLSBackends(ctx, m.CaManagers, newMesh.Meta.GetName(), newMesh); err != nil {
 		return err
 	}
 	return nil
 }
 
-func (m *MeshValidator) ValidateDelete(ctx context.Context, name string) error {
+func (m *meshValidator) ValidateDelete(ctx context.Context, name string) error {
+	if err := ValidateNoActiveDP(ctx, name, m.Store); err != nil {
+		return err
+	}
+	return nil
+}
+
+func ValidateNoActiveDP(ctx context.Context, name string, store core_store.ResourceStore) error {
 	dps := core_mesh.DataplaneResourceList{}
 	validationErr := &validators.ValidationError{}
-	if err := m.Store.List(ctx, &dps, store.ListByMesh(name)); err != nil {
+	if err := store.List(ctx, &dps, core_store.ListByMesh(name)); err != nil {
 		return errors.Wrap(err, "unable to list Dataplanes")
 	}
 	if len(dps.Items) != 0 {
@@ -66,7 +87,7 @@ func (m *MeshValidator) ValidateDelete(ctx context.Context, name string) error {
 	return nil
 }
 
-func (m *MeshValidator) validateMTLSBackendChange(previousMesh *core_mesh.MeshResource, newMesh *core_mesh.MeshResource) error {
+func (m *meshValidator) validateMTLSBackendChange(previousMesh *core_mesh.MeshResource, newMesh *core_mesh.MeshResource) error {
 	verr := validators.ValidationError{}
 	if previousMesh.MTLSEnabled() && newMesh.MTLSEnabled() && previousMesh.Spec.GetMtls().GetEnabledBackend() != newMesh.Spec.GetMtls().GetEnabledBackend() {
 		verr.AddViolation("mtls.enabledBackend", "Changing CA when mTLS is enabled is forbidden. Disable mTLS first and then change the CA")

--- a/pkg/core/runtime/runtime.go
+++ b/pkg/core/runtime/runtime.go
@@ -10,6 +10,7 @@ import (
 	config_manager "github.com/kumahq/kuma/pkg/core/config/manager"
 	"github.com/kumahq/kuma/pkg/core/datasource"
 	"github.com/kumahq/kuma/pkg/core/dns/lookup"
+	core_managers "github.com/kumahq/kuma/pkg/core/managers/apis/mesh"
 	core_manager "github.com/kumahq/kuma/pkg/core/resources/manager"
 	core_store "github.com/kumahq/kuma/pkg/core/resources/store"
 	"github.com/kumahq/kuma/pkg/core/runtime/component"
@@ -21,6 +22,7 @@ import (
 	kds_context "github.com/kumahq/kuma/pkg/kds/context"
 	"github.com/kumahq/kuma/pkg/metrics"
 	xds_hooks "github.com/kumahq/kuma/pkg/xds/hooks"
+	"github.com/kumahq/kuma/pkg/xds/secrets"
 )
 
 // Runtime represents initialized application state.
@@ -55,8 +57,10 @@ type RuntimeContext interface {
 	EventReaderFactory() events.ListenerFactory
 	APIInstaller() api_server.APIInstaller
 	XDSHooks() *xds_hooks.Hooks
+	CAProvider() secrets.CaProvider
 	DpServer() *dp_server.DpServer
 	KDSContext() *kds_context.Context
+	MeshValidator() core_managers.MeshValidator
 	ShutdownCh() <-chan struct{}
 }
 
@@ -114,8 +118,10 @@ type runtimeContext struct {
 	erf        events.ListenerFactory
 	apim       api_server.APIInstaller
 	xdsh       *xds_hooks.Hooks
+	cap        secrets.CaProvider
 	dps        *dp_server.DpServer
 	kdsctx     *kds_context.Context
+	mv         core_managers.MeshValidator
 	shutdownCh <-chan struct{}
 }
 
@@ -190,12 +196,20 @@ func (rc *runtimeContext) DpServer() *dp_server.DpServer {
 	return rc.dps
 }
 
+func (rc *runtimeContext) CAProvider() secrets.CaProvider {
+	return rc.cap
+}
+
 func (rc *runtimeContext) XDSHooks() *xds_hooks.Hooks {
 	return rc.xdsh
 }
 
 func (rc *runtimeContext) KDSContext() *kds_context.Context {
 	return rc.kdsctx
+}
+
+func (rc *runtimeContext) MeshValidator() core_managers.MeshValidator {
+	return rc.mv
 }
 
 func (rc *runtimeContext) ShutdownCh() <-chan struct{} {

--- a/pkg/plugins/runtime/k8s/plugin.go
+++ b/pkg/plugins/runtime/k8s/plugin.go
@@ -11,7 +11,6 @@ import (
 
 	config_core "github.com/kumahq/kuma/pkg/config/core"
 	"github.com/kumahq/kuma/pkg/core"
-	managers_mesh "github.com/kumahq/kuma/pkg/core/managers/apis/mesh"
 	"github.com/kumahq/kuma/pkg/core/managers/apis/zone"
 	core_plugins "github.com/kumahq/kuma/pkg/core/plugins"
 	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
@@ -239,11 +238,7 @@ func addValidators(mgr kube_ctrl.Manager, rt core_runtime.Runtime, converter k8s
 	handler := k8s_webhooks.NewValidatingWebhook(converter, core_registry.Global(), k8s_registry.Global(), rt.Config().Mode, rt.Config().Store.Kubernetes.SystemNamespace)
 	composite.AddValidator(handler)
 
-	coreMeshValidator := managers_mesh.MeshValidator{
-		CaManagers: rt.CaManagers(),
-		Store:      rt.ResourceStore(),
-	}
-	k8sMeshValidator := k8s_webhooks.NewMeshValidatorWebhook(coreMeshValidator, converter, rt.ResourceManager())
+	k8sMeshValidator := k8s_webhooks.NewMeshValidatorWebhook(rt.MeshValidator(), converter, rt.ResourceManager())
 	composite.AddValidator(k8sMeshValidator)
 
 	coreZoneValidator := zone.Validator{Store: rt.ResourceStore()}

--- a/pkg/xds/server/components.go
+++ b/pkg/xds/server/components.go
@@ -65,7 +65,7 @@ func RegisterXDS(rt core_runtime.Runtime) error {
 	}
 
 	secrets, err := secrets.NewSecrets(
-		secrets.NewCaProvider(rt.CaManagers()),
+		rt.CAProvider(),
 		secrets.NewIdentityProvider(rt.CaManagers()),
 		rt.Metrics(),
 	)


### PR DESCRIPTION
### Summary

Expose CAProvider and MeshValidators as Runtime components.

### Issues resolved

No fix.

### Documentation

- [X] No docs, internal changes only.

### Testing

- [X] Unit tests
- [ ] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes 

### Backwards compatibility

- [X] Although this is not a breaking change - we don't want to backport it.
