### PR TITLE
feat(kuma-cp) validate that mesh has only one mtls backend

### DIFF
--- a/pkg/core/managers/apis/mesh/mesh_helpers.go
+++ b/pkg/core/managers/apis/mesh/mesh_helpers.go
@@ -9,9 +9,8 @@ import (
 	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 )
 
-func EnsureEnabledCA(ctx context.Context, caManagers core_ca.Managers, mesh *core_mesh.MeshResource, meshName string) error {
-	if mesh.GetEnabledCertificateAuthorityBackend() != nil {
-		backend := mesh.GetEnabledCertificateAuthorityBackend()
+func EnsureCAs(ctx context.Context, caManagers core_ca.Managers, mesh *core_mesh.MeshResource, meshName string) error {
+	for _, backend := range mesh.Spec.GetMtls().GetBackends() {
 		caManager, exist := caManagers[backend.Type]
 		if !exist { // this should be caught by validator earlier
 			return errors.Errorf("CA manager for type %s does not exist", backend.Type)

--- a/pkg/core/managers/apis/mesh/mesh_manager.go
+++ b/pkg/core/managers/apis/mesh/mesh_manager.go
@@ -71,7 +71,7 @@ func (m *meshManager) Create(ctx context.Context, resource core_model.Resource, 
 	if err := m.meshValidator.ValidateCreate(ctx, opts.Name, mesh); err != nil {
 		return err
 	}
-	if err := EnsureEnabledCA(ctx, m.caManagers, mesh, opts.Name); err != nil {
+	if err := EnsureCAs(ctx, m.caManagers, mesh, opts.Name); err != nil {
 		return err
 	}
 
@@ -138,7 +138,7 @@ func (m *meshManager) Update(ctx context.Context, resource core_model.Resource, 
 	if err := m.meshValidator.ValidateUpdate(ctx, currentMesh, mesh); err != nil {
 		return err
 	}
-	if err := EnsureEnabledCA(ctx, m.caManagers, mesh, mesh.Meta.GetName()); err != nil {
+	if err := EnsureCAs(ctx, m.caManagers, mesh, mesh.Meta.GetName()); err != nil {
 		return err
 	}
 	return m.store.Update(ctx, mesh, append(fs, core_store.ModifiedAt(time.Now()))...)

--- a/pkg/core/managers/apis/mesh/mesh_manager_test.go
+++ b/pkg/core/managers/apis/mesh/mesh_manager_test.go
@@ -68,10 +68,6 @@ var _ = Describe("Mesh Manager", func() {
 								Name: "builtin-1",
 								Type: "builtin",
 							},
-							{
-								Name: "builtin-2",
-								Type: "builtin",
-							},
 						},
 					},
 				},
@@ -200,10 +196,6 @@ var _ = Describe("Mesh Manager", func() {
 								Name: "ca-1",
 								Type: "provided",
 							},
-							{
-								Name: "ca-2",
-								Type: "provided",
-							},
 						},
 					},
 				},
@@ -211,7 +203,7 @@ var _ = Describe("Mesh Manager", func() {
 			err := resManager.Create(context.Background(), &mesh, store.CreateBy(resKey))
 
 			// then
-			Expect(err).To(MatchError("mtls.backends[0].config.cert: has to be defined; mtls.backends[0].config.key: has to be defined; mtls.backends[1].config.cert: has to be defined; mtls.backends[1].config.key: has to be defined"))
+			Expect(err).To(MatchError("mtls.backends[0].config.cert: has to be defined; mtls.backends[0].config.key: has to be defined"))
 		})
 	})
 
@@ -290,10 +282,6 @@ var _ = Describe("Mesh Manager", func() {
 								Name: "builtin-1",
 								Type: "builtin",
 							},
-							{
-								Name: "builtin-2",
-								Type: "builtin",
-							},
 						},
 					},
 				},
@@ -304,6 +292,7 @@ var _ = Describe("Mesh Manager", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			// when trying to change CA
+			mesh.Spec.Mtls.Backends[0].Name = "builtin-2"
 			mesh.Spec.Mtls.EnabledBackend = "builtin-2"
 			err = resManager.Update(context.Background(), &mesh)
 
@@ -336,10 +325,6 @@ var _ = Describe("Mesh Manager", func() {
 								Name: "builtin-1",
 								Type: "builtin",
 							},
-							{
-								Name: "builtin-2",
-								Type: "builtin",
-							},
 						},
 					},
 				},
@@ -350,6 +335,7 @@ var _ = Describe("Mesh Manager", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			// when trying to enable mTLS change CA
+			mesh.Spec.Mtls.Backends[0].Name = "builtin-2"
 			mesh.Spec.Mtls.EnabledBackend = "builtin-2"
 			err = resManager.Update(context.Background(), &mesh)
 

--- a/pkg/core/resources/apis/mesh/mesh_validator.go
+++ b/pkg/core/resources/apis/mesh/mesh_validator.go
@@ -13,6 +13,8 @@ import (
 	"github.com/kumahq/kuma/pkg/util/proto"
 )
 
+var AllowedMTLSBackends = 1
+
 func (m *MeshResource) Validate() error {
 	var verr validators.ValidationError
 	verr.AddError("mtls", validateMtls(m.Spec.Mtls))
@@ -27,6 +29,10 @@ func validateMtls(mtls *mesh_proto.Mesh_Mtls) validators.ValidationError {
 	if mtls == nil {
 		return verr
 	}
+	if len(mtls.GetBackends()) > AllowedMTLSBackends {
+		verr.AddViolationAt(validators.RootedAt("backends"), fmt.Sprintf("cannot have more than %d backends", AllowedMTLSBackends))
+	}
+
 	usedNames := map[string]bool{}
 	for i, backend := range mtls.GetBackends() {
 		if usedNames[backend.Name] {

--- a/pkg/core/resources/apis/mesh/mesh_validator_test.go
+++ b/pkg/core/resources/apis/mesh/mesh_validator_test.go
@@ -116,6 +116,8 @@ var _ = Describe("Mesh", func() {
                     type: builtin`,
 				expected: `
                 violations:
+                - field: mtls.backends
+                  message: cannot have more than 1 backends
                 - field: mtls.backends[1].name
                   message: '"backend-1" name is already used for another backend'`,
 			}),

--- a/pkg/plugins/runtime/k8s/controllers/mesh_controller.go
+++ b/pkg/plugins/runtime/k8s/controllers/mesh_controller.go
@@ -60,7 +60,7 @@ func (r *MeshReconciler) Reconcile(req kube_ctrl.Request) (kube_ctrl.Result, err
 	}
 
 	// Ensure CA Managers are created
-	if err := core_managers.EnsureEnabledCA(ctx, r.CaManagers, meshResource, meshResource.Meta.GetName()); err != nil {
+	if err := core_managers.EnsureCAs(ctx, r.CaManagers, meshResource, meshResource.Meta.GetName()); err != nil {
 		log.Error(err, "unable to ensure that mesh CAs are created")
 		return kube_ctrl.Result{}, err
 	}

--- a/test/e2e/trafficroute/universal_multizone/traffic_route.go
+++ b/test/e2e/trafficroute/universal_multizone/traffic_route.go
@@ -381,6 +381,7 @@ conf:
 			// or if we change the behaviour of ZoneIngress
 			if runtime.NumCPU() < 4 {
 				Skip("concurrency too low")
+				return
 			}
 
 			Eventually(func() (map[string]int, error) {


### PR DESCRIPTION
### Summary

During conversations with our users, we found out that it's confusing to define many backends. Since you cannot switch between them without disabling mTLS at this moment, we can just as well support one.

### Issues resolved

No fixes.

### Documentation

- [ ] Todo...

### Testing

- [X] Unit tests
- [ ] E2E tests
- [X] Manual testing on Universal
- [ ] Manual testing on Kubernetes 

### Backwards compatibility

- [X] It's a breaking change.
