### PR TITLE
feat(kuma-cp) remove provided ca cert validation

### DIFF
--- a/pkg/plugins/ca/provided/ca_cert_validator.go
+++ b/pkg/plugins/ca/provided/ca_cert_validator.go
@@ -33,14 +33,8 @@ func validateCaCert(signingPair util_tls.KeyPair) (verr validators.ValidationErr
 		if cert.KeyUsage&x509.KeyUsageCertSign == 0 {
 			verr.AddViolationAt(path, "key usage extension 'keyCertSign' must be set (see X509-SVID: 4.3. Key Usage)")
 		}
-		if cert.KeyUsage&x509.KeyUsageDigitalSignature != 0 {
-			verr.AddViolationAt(path, "key usage extension 'digitalSignature' must NOT be set (see X509-SVID: Appendix A. X.509 Field Reference)")
-		}
 		if cert.KeyUsage&x509.KeyUsageKeyAgreement != 0 {
 			verr.AddViolationAt(path, "key usage extension 'keyAgreement' must NOT be set (see X509-SVID: Appendix A. X.509 Field Reference)")
-		}
-		if cert.KeyUsage&x509.KeyUsageKeyEncipherment != 0 {
-			verr.AddViolationAt(path, "key usage extension 'keyEncipherment' must NOT be set (see X509-SVID: Appendix A. X.509 Field Reference)")
 		}
 	}
 	return

--- a/pkg/plugins/ca/provided/ca_cert_validator_test.go
+++ b/pkg/plugins/ca/provided/ca_cert_validator_test.go
@@ -201,29 +201,6 @@ bgeEDefxTxoTMgJ1urwl0KX6R9dbv9YWZWJXk2DQj6UwkMEyXpc+kw==
 				input: *keyPair,
 			}
 		}),
-		Entry("certificate with key usage extension `digitalSignature`", func() testCase {
-			// when
-			keyPair, err := NewSelfSignedCert(func() *x509.Certificate {
-				return &x509.Certificate{
-					SerialNumber:          big.NewInt(0),
-					BasicConstraintsValid: true,
-					IsCA:                  true,
-					KeyUsage: x509.KeyUsageCertSign |
-						x509.KeyUsageCRLSign | x509.KeyUsageDigitalSignature,
-				}
-			})
-			// then
-			Expect(err).ToNot(HaveOccurred())
-
-			return testCase{
-				expectedErr: `
-                violations:
-                - field: cert[0]
-                  message: "key usage extension 'digitalSignature' must NOT be set (see X509-SVID: Appendix A. X.509 Field Reference)"
-`,
-				input: *keyPair,
-			}
-		}),
 		Entry("certificate with key usage extension `keyAgreement`", func() testCase {
 			// when
 			keyPair, err := NewSelfSignedCert(func() *x509.Certificate {
@@ -243,29 +220,6 @@ bgeEDefxTxoTMgJ1urwl0KX6R9dbv9YWZWJXk2DQj6UwkMEyXpc+kw==
                 violations:
                 - field: cert[0]
                   message: "key usage extension 'keyAgreement' must NOT be set (see X509-SVID: Appendix A. X.509 Field Reference)"
-`,
-				input: *keyPair,
-			}
-		}),
-		Entry("certificate with key usage extension `keyEncipherment`", func() testCase {
-			// when
-			keyPair, err := NewSelfSignedCert(func() *x509.Certificate {
-				return &x509.Certificate{
-					SerialNumber:          big.NewInt(0),
-					BasicConstraintsValid: true,
-					IsCA:                  true,
-					KeyUsage: x509.KeyUsageCertSign |
-						x509.KeyUsageCRLSign | x509.KeyUsageKeyEncipherment,
-				}
-			})
-			// then
-			Expect(err).ToNot(HaveOccurred())
-
-			return testCase{
-				expectedErr: `
-                violations:
-                - field: cert[0]
-                  message: "key usage extension 'keyEncipherment' must NOT be set (see X509-SVID: Appendix A. X.509 Field Reference)"
 `,
 				input: *keyPair,
 			}
@@ -291,11 +245,7 @@ bgeEDefxTxoTMgJ1urwl0KX6R9dbv9YWZWJXk2DQj6UwkMEyXpc+kw==
                 - field: cert[0]
                   message: "key usage extension 'keyCertSign' must be set (see X509-SVID: 4.3. Key Usage)"
                 - field: cert[0]
-                  message: "key usage extension 'digitalSignature' must NOT be set (see X509-SVID: Appendix A. X.509 Field Reference)"
-                - field: cert[0]
                   message: "key usage extension 'keyAgreement' must NOT be set (see X509-SVID: Appendix A. X.509 Field Reference)"
-                - field: cert[0]
-                  message: "key usage extension 'keyEncipherment' must NOT be set (see X509-SVID: Appendix A. X.509 Field Reference)"
 `,
 				input: *keyPair,
 			}


### PR DESCRIPTION
### Summary

With these changes sub ca be used as provided ca

### Full changelog

* [Implement ...] subca
* [Fix ...] https://github.com/kumahq/kuma/issues/2063

### Issues resolved

Fix https://github.com/kumahq/kuma/issues/2063

### Documentation NA

- [ ] Link to the website [documentation PR] NA
### Testing

- [x] Unit tests
- [ ] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes 

### Backwards compatibility

- [ ] Add `backport-to-stable` label if the code is backwards compatible. Otherwise, list breaking changes.
