### PR TITLE
fix(ci) detect whether Docker is using an output chain

### DIFF
--- a/test/framework/universal_app.go
+++ b/test/framework/universal_app.go
@@ -406,6 +406,20 @@ func (s *UniversalApp) CreateDP(token, cpAddress, name, mesh, ip, dpyaml string,
 	s.dpApp = NewSshApp(s.verbose, s.ports[sshPort], []string{}, args)
 }
 
+// iptablesChainExists tests whether iptables believes the given chainName
+// has been created in the table given by tableName. If we can't run
+// the iptables command, the chain is assumed to exist (for backwards
+// compatibility) though subsequent commands that depend on it may
+// still fail.
+func (s *UniversalApp) iptablesChainExists(tableName string, chainName string) bool {
+	app := NewSshApp(s.verbose, s.ports[sshPort], []string{}, []string{
+		"iptables", "-t", tableName, "-L", chainName,
+	})
+
+	err := app.Run()
+	return err == nil
+}
+
 func (s *UniversalApp) setupTransparent(cpIp string, builtindns bool) {
 	args := []string{
 		"/usr/bin/kumactl", "install", "transparent-proxy",
@@ -417,7 +431,13 @@ func (s *UniversalApp) setupTransparent(cpIp string, builtindns bool) {
 		args = append(args,
 			"--skip-resolv-conf",
 			"--redirect-dns",
-			"--redirect-dns-upstream-target-chain", "DOCKER_OUTPUT")
+		)
+
+		if s.iptablesChainExists("nat", "DOCKER_OUTPUT") {
+			args = append(args,
+				"--redirect-dns-upstream-target-chain", "DOCKER_OUTPUT",
+			)
+		}
 	}
 
 	app := NewSshApp(s.verbose, s.ports[sshPort], []string{}, args)


### PR DESCRIPTION
### Summary

Not all Docker configurations end up generating a `DOCKER_OUTPUT`
iptables chain. Check whether that chain exists before attempting
to use it for transparent DNS forwarding.


### Full changelog

N/A

### Issues resolved

Fix #2585.

### Documentation

N/A
### Testing

- [x] Unit tests
- [x] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes 

### Backwards compatibility

- [x] Add `backport-to-stable` label if the code is backwards compatible. Otherwise, list breaking changes.
