### PR TITLE
fix(kumactl) print a newline with transparent proxy setup message

### DIFF
--- a/app/kumactl/cmd/install/install_transparent_proxy.go
+++ b/app/kumactl/cmd/install/install_transparent_proxy.go
@@ -213,7 +213,7 @@ func modifyIpTables(cmd *cobra.Command, args *transparentProxyArgs) error {
 	}
 
 	if !args.DryRun {
-		_, _ = cmd.OutOrStdout().Write([]byte("kumactl is about to apply the iptables rules that will enable transparent proxying on the machine. The SSH connection may drop. If that happens, just reconnect again."))
+		_, _ = cmd.OutOrStdout().Write([]byte("kumactl is about to apply the iptables rules that will enable transparent proxying on the machine. The SSH connection may drop. If that happens, just reconnect again.\n"))
 	}
 	output, err := tp.Setup(&config.TransparentProxyConfig{
 		DryRun:                 args.DryRun,


### PR DESCRIPTION
### Summary

Add a newline to the transparent proxy install message.

### Full changelog

N/A

### Issues resolved

Update #2625.

### Documentation

N/A

### Testing

- [x] Unit tests
- [x] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes 

### Backwards compatibility

- [x] Add `backport-to-stable` label if the code is backwards compatible. Otherwise, list breaking changes.
