### PR TITLE
chore(tests) parametrize kuma tracing in ZipkinCollectorURL

### DIFF
--- a/test/framework/deployments/tracing/kubernetes.go
+++ b/test/framework/deployments/tracing/kubernetes.go
@@ -18,7 +18,7 @@ type k8SDeployment struct {
 var _ Deployment = &k8SDeployment{}
 
 func (t *k8SDeployment) ZipkinCollectorURL() string {
-	return "http://jaeger-collector.kuma-tracing:9411/api/v2/spans"
+	return fmt.Sprintf("http://jaeger-collector.%s:9411/api/v2/spans", framework.DefaultTracingNamespace)
 }
 
 func (t *k8SDeployment) TracedServices() ([]string, error) {


### PR DESCRIPTION
### Summary

Parametrize Kuma tracing namespace in ZipkinCollectorURL

### Issues resolved

No issues.

### Documentation

No docs.

### Testing

- [ ] Unit tests
- [X] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes 

### Backwards compatibility

- [X] No backporting
