### PR TITLE
fix(kuma-cp) TLSInspector is causing tcp healthcheck failures

### DIFF
--- a/pkg/xds/generator/inbound_proxy_generator.go
+++ b/pkg/xds/generator/inbound_proxy_generator.go
@@ -105,7 +105,6 @@ func (g InboundProxyGenerator) Generate(ctx xds_context.Context, proxy *model.Pr
 
 		listenerBuilder := envoy_listeners.NewListenerBuilder(proxy.APIVersion).
 			Configure(envoy_listeners.InboundListener(inboundListenerName, endpoint.DataplaneIP, endpoint.DataplanePort, model.SocketAddressProtocolTCP)).
-			Configure(envoy_listeners.TLSInspector()).
 			Configure(envoy_listeners.TransparentProxying(proxy.Dataplane.Spec.Networking.GetTransparentProxying()))
 
 		switch ctx.Mesh.Resource.GetEnabledCertificateAuthorityBackend().GetMode() {
@@ -114,6 +113,7 @@ func (g InboundProxyGenerator) Generate(ctx xds_context.Context, proxy *model.Pr
 				Configure(envoy_listeners.FilterChain(filterChainBuilder(true)))
 		case mesh_proto.CertificateAuthorityBackend_PERMISSIVE:
 			listenerBuilder.
+				Configure(envoy_listeners.TLSInspector()).
 				Configure(envoy_listeners.FilterChain(filterChainBuilder(false).
 					Configure(envoy_listeners.FilterChainMatch("raw_buffer", nil, nil)))).
 				Configure(envoy_listeners.FilterChain(filterChainBuilder(false).

--- a/pkg/xds/generator/testdata/inbound-proxy/3-envoy-config.golden.yaml
+++ b/pkg/xds/generator/testdata/inbound-proxy/3-envoy-config.golden.yaml
@@ -70,10 +70,6 @@ resources:
                 ads: {}
                 resourceApiVersion: V3
           requireClientCertificate: true
-    listenerFilters:
-    - name: envoy.filters.listener.tls_inspector
-      typedConfig:
-        '@type': type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
     name: inbound:192.168.0.1:443
     trafficDirection: INBOUND
 - name: inbound:192.168.0.1:80
@@ -222,10 +218,6 @@ resources:
                 ads: {}
                 resourceApiVersion: V3
           requireClientCertificate: true
-    listenerFilters:
-    - name: envoy.filters.listener.tls_inspector
-      typedConfig:
-        '@type': type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
     name: inbound:192.168.0.1:80
     trafficDirection: INBOUND
 - name: inbound:192.168.0.2:443
@@ -267,10 +259,6 @@ resources:
                 ads: {}
                 resourceApiVersion: V3
           requireClientCertificate: true
-    listenerFilters:
-    - name: envoy.filters.listener.tls_inspector
-      typedConfig:
-        '@type': type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
     name: inbound:192.168.0.2:443
     trafficDirection: INBOUND
 - name: inbound:192.168.0.2:80
@@ -331,9 +319,5 @@ resources:
                 ads: {}
                 resourceApiVersion: V3
           requireClientCertificate: true
-    listenerFilters:
-    - name: envoy.filters.listener.tls_inspector
-      typedConfig:
-        '@type': type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
     name: inbound:192.168.0.2:80
     trafficDirection: INBOUND

--- a/pkg/xds/generator/testdata/inbound-proxy/4-envoy-config.golden.yaml
+++ b/pkg/xds/generator/testdata/inbound-proxy/4-envoy-config.golden.yaml
@@ -71,10 +71,6 @@ resources:
                 ads: {}
                 resourceApiVersion: V3
           requireClientCertificate: true
-    listenerFilters:
-    - name: envoy.filters.listener.tls_inspector
-      typedConfig:
-        '@type': type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
     name: inbound:192.168.0.1:443
     trafficDirection: INBOUND
 - name: inbound:192.168.0.1:80
@@ -224,10 +220,6 @@ resources:
                 ads: {}
                 resourceApiVersion: V3
           requireClientCertificate: true
-    listenerFilters:
-    - name: envoy.filters.listener.tls_inspector
-      typedConfig:
-        '@type': type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
     name: inbound:192.168.0.1:80
     trafficDirection: INBOUND
 - name: inbound:192.168.0.2:443
@@ -270,10 +262,6 @@ resources:
                 ads: {}
                 resourceApiVersion: V3
           requireClientCertificate: true
-    listenerFilters:
-    - name: envoy.filters.listener.tls_inspector
-      typedConfig:
-        '@type': type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
     name: inbound:192.168.0.2:443
     trafficDirection: INBOUND
 - name: inbound:192.168.0.2:80
@@ -335,9 +323,5 @@ resources:
                 ads: {}
                 resourceApiVersion: V3
           requireClientCertificate: true
-    listenerFilters:
-    - name: envoy.filters.listener.tls_inspector
-      typedConfig:
-        '@type': type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
     name: inbound:192.168.0.2:80
     trafficDirection: INBOUND

--- a/pkg/xds/generator/testdata/profile-source/1-envoy-config.golden.yaml
+++ b/pkg/xds/generator/testdata/profile-source/1-envoy-config.golden.yaml
@@ -180,10 +180,6 @@ resources:
                 ads: {}
                 resourceApiVersion: V3
           requireClientCertificate: true
-    listenerFilters:
-    - name: envoy.filters.listener.tls_inspector
-      typedConfig:
-        '@type': type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
     name: inbound:192.168.0.1:80
     trafficDirection: INBOUND
 - name: kuma:envoy:admin

--- a/pkg/xds/generator/testdata/profile-source/2-envoy-config.golden.yaml
+++ b/pkg/xds/generator/testdata/profile-source/2-envoy-config.golden.yaml
@@ -201,10 +201,6 @@ resources:
                 ads: {}
                 resourceApiVersion: V3
           requireClientCertificate: true
-    listenerFilters:
-    - name: envoy.filters.listener.tls_inspector
-      typedConfig:
-        '@type': type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
     name: inbound:192.168.0.1:80
     trafficDirection: INBOUND
 - name: inbound:passthrough:ipv4

--- a/pkg/xds/generator/testdata/profile-source/3-envoy-config.golden.yaml
+++ b/pkg/xds/generator/testdata/profile-source/3-envoy-config.golden.yaml
@@ -214,10 +214,6 @@ resources:
                 ads: {}
                 resourceApiVersion: V3
           requireClientCertificate: true
-    listenerFilters:
-    - name: envoy.filters.listener.tls_inspector
-      typedConfig:
-        '@type': type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
     name: inbound:192.168.0.1:80
     trafficDirection: INBOUND
 - name: kuma:envoy:admin

--- a/pkg/xds/generator/testdata/profile-source/4-envoy-config.golden.yaml
+++ b/pkg/xds/generator/testdata/profile-source/4-envoy-config.golden.yaml
@@ -235,10 +235,6 @@ resources:
                 ads: {}
                 resourceApiVersion: V3
           requireClientCertificate: true
-    listenerFilters:
-    - name: envoy.filters.listener.tls_inspector
-      typedConfig:
-        '@type': type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
     name: inbound:192.168.0.1:80
     trafficDirection: INBOUND
 - name: inbound:passthrough:ipv4

--- a/pkg/xds/generator/testdata/template-proxy/1-envoy-config.golden.yaml
+++ b/pkg/xds/generator/testdata/template-proxy/1-envoy-config.golden.yaml
@@ -91,10 +91,6 @@ resources:
                 ads: {}
                 resourceApiVersion: V3
           requireClientCertificate: true
-    listenerFilters:
-    - name: envoy.filters.listener.tls_inspector
-      typedConfig:
-        '@type': type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
     name: inbound:192.168.0.1:80
     trafficDirection: INBOUND
 - name: inbound:passthrough:ipv4

--- a/pkg/xds/server/v3/testdata/envoy-config.golden.yaml
+++ b/pkg/xds/server/v3/testdata/envoy-config.golden.yaml
@@ -91,10 +91,6 @@ resources:
                 ads: {}
                 resourceApiVersion: V3
           requireClientCertificate: true
-    listenerFilters:
-    - name: envoy.filters.listener.tls_inspector
-      typedConfig:
-        '@type': type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
     name: inbound:192.168.0.1:443
     trafficDirection: INBOUND
 - name: inbound:192.168.0.1:80
@@ -150,10 +146,6 @@ resources:
                 ads: {}
                 resourceApiVersion: V3
           requireClientCertificate: true
-    listenerFilters:
-    - name: envoy.filters.listener.tls_inspector
-      typedConfig:
-        '@type': type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
     name: inbound:192.168.0.1:80
     trafficDirection: INBOUND
 - name: inbound:192.168.0.2:443
@@ -196,10 +188,6 @@ resources:
                 ads: {}
                 resourceApiVersion: V3
           requireClientCertificate: true
-    listenerFilters:
-    - name: envoy.filters.listener.tls_inspector
-      typedConfig:
-        '@type': type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
     name: inbound:192.168.0.2:443
     trafficDirection: INBOUND
 - name: inbound:192.168.0.2:80
@@ -242,10 +230,6 @@ resources:
                 ads: {}
                 resourceApiVersion: V3
           requireClientCertificate: true
-    listenerFilters:
-    - name: envoy.filters.listener.tls_inspector
-      typedConfig:
-        '@type': type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
     name: inbound:192.168.0.2:80
     trafficDirection: INBOUND
 - name: inbound:passthrough:ipv4


### PR DESCRIPTION
### Summary

Just the fact that TLSInspector is configured is causing TCP health checks to fail (mTLS is off)

### Full changelog

* configure TLSInspector only when required

### Issues resolved

N/A

### Documentation

- [ ] Link to the website [documentation PR](https://github.com/kumahq/kuma-website/pull/XXX)

### Testing

- [ ] Unit tests
- [ ] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes 

### Backwards compatibility

- [x] Add `backport-to-stable` label if the code is backwards compatible. Otherwise, list breaking changes.
