### PR TITLE
chore(ci) use US locale for misspelling checks

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -33,6 +33,10 @@ linters-settings:
       alias: mesh_proto
     - pkg: github.com/kumahq/kuma/pkg/util/proto
       alias: util_proto
+  misspell:
+    locale: US
+    ignore-words:
+    - cancelled # US English should be "canceled", but this is in the Retry API, so we can't change it.
 
 issues:
   fix: true

--- a/app/kuma-cp/cmd/root.go
+++ b/app/kuma-cp/cmd/root.go
@@ -12,7 +12,7 @@ import (
 	"github.com/kumahq/kuma/pkg/core"
 	kuma_log "github.com/kumahq/kuma/pkg/log"
 
-	// import Envoy protobuf definitions so (un)marshalling Envoy protobuf works
+	// import Envoy protobuf definitions so (un)marshaling Envoy protobuf works
 	_ "github.com/kumahq/kuma/pkg/xds/envoy"
 )
 

--- a/app/kuma-cp/cmd/run_test.go
+++ b/app/kuma-cp/cmd/run_test.go
@@ -104,7 +104,7 @@ func RunSmokeTest(factory ConfigFactory, workdir string) {
 			}, "10s", "10ms").Should(BeTrue())
 
 			// when
-			By("signalling Control Plane to stop")
+			By("signaling Control Plane to stop")
 			close(stopCh)
 
 			// then

--- a/app/kuma-dp/cmd/run_test.go
+++ b/app/kuma-dp/cmd/run_test.go
@@ -155,7 +155,7 @@ var _ = Describe("run", func() {
 			}
 
 			// when
-			By("signalling the dataplane manager to stop")
+			By("signaling the dataplane manager to stop")
 			close(stopCh)
 
 			// then

--- a/app/kuma-prometheus-sd/cmd/run_test.go
+++ b/app/kuma-prometheus-sd/cmd/run_test.go
@@ -48,7 +48,7 @@ var _ = Describe("run", func() {
 		By("waiting for Kuma Prometheus SD to become ready")
 
 		// when
-		By("signalling Kuma Prometheus SD to stop")
+		By("signaling Kuma Prometheus SD to stop")
 		close(stopCh)
 
 		// then

--- a/app/kumactl/cmd/root.go
+++ b/app/kumactl/cmd/root.go
@@ -28,7 +28,7 @@ import (
 	_ "github.com/kumahq/kuma/pkg/plugins/runtime/gateway/register"
 	kuma_version "github.com/kumahq/kuma/pkg/version"
 
-	// import Envoy protobuf definitions so (un)marshalling Envoy protobuf works
+	// import Envoy protobuf definitions so (un)marshaling Envoy protobuf works
 	_ "github.com/kumahq/kuma/pkg/xds/envoy"
 )
 

--- a/pkg/core/runtime/reports/reports.go
+++ b/pkg/core/runtime/reports/reports.go
@@ -80,7 +80,7 @@ func fetchNumOfServices(rt core_runtime.Runtime) (int, int, error) {
 
 	externalServicesList := mesh.ExternalServiceResourceList{}
 	if err := rt.ReadOnlyResourceManager().List(context.Background(), &externalServicesList); err != nil {
-		return 0, 0, errors.Wrap(err, "coult not fetch external services")
+		return 0, 0, errors.Wrap(err, "could not fetch external services")
 	}
 	return internalServices, len(externalServicesList.Items), nil
 }

--- a/pkg/dns/vips_synchronizer.go
+++ b/pkg/dns/vips_synchronizer.go
@@ -50,7 +50,7 @@ func (d *vipsSynchronizer) Start(stop <-chan struct{}) error {
 		select {
 		case <-ticker.C:
 			if err := d.synchronize(); err != nil {
-				vipsSynchronizerLog.Error(err, "unable to synchronise")
+				vipsSynchronizerLog.Error(err, "unable to synchronize")
 			}
 		case <-stop:
 			vipsSynchronizerLog.Info("stopping")

--- a/pkg/envoy/accesslog/v3/field_operator.go
+++ b/pkg/envoy/accesslog/v3/field_operator.go
@@ -70,19 +70,19 @@ func (f FieldOperator) FormatTcpLogEntry(entry *accesslog_data.TCPAccessLogEntry
 	case CMD_BYTES_SENT:
 		return f.formatUint(entry.GetConnectionProperties().GetSentBytes())
 	case CMD_PROTOCOL:
-		return "", nil // replicate Envoy's behaviour
+		return "", nil // replicate Envoy's behavior
 	case CMD_RESPONSE_CODE:
-		return "0", nil // replicate Envoy's behaviour
+		return "0", nil // replicate Envoy's behavior
 	case CMD_RESPONSE_CODE_DETAILS:
-		return "", nil // replicate Envoy's behaviour
+		return "", nil // replicate Envoy's behavior
 	case CMD_REQUEST_DURATION:
-		return "", nil // replicate Envoy's behaviour
+		return "", nil // replicate Envoy's behavior
 	case CMD_RESPONSE_DURATION:
-		return "", nil // replicate Envoy's behaviour
+		return "", nil // replicate Envoy's behavior
 	case CMD_RESPONSE_TX_DURATION:
-		return "", nil // replicate Envoy's behaviour
+		return "", nil // replicate Envoy's behavior
 	case CMD_GRPC_STATUS:
-		return "", nil // replace Envoy's behaviour
+		return "", nil // replace Envoy's behavior
 	default:
 		return f.formatAccessLogCommon(entry.GetCommonProperties())
 	}

--- a/pkg/envoy/accesslog/v3/field_operator_test.go
+++ b/pkg/envoy/accesslog/v3/field_operator_test.go
@@ -251,19 +251,19 @@ var _ = Describe("FieldOperator", func() {
 			}),
 			Entry("PROTOCOL", testCase{
 				field:    "PROTOCOL",
-				expected: ``, // replicate Envoy's behaviour
+				expected: ``, // replicate Envoy's behavior
 			}),
 			Entry("RESPONSE_CODE", testCase{
 				field:    "RESPONSE_CODE",
-				expected: `0`, // replicate Envoy's behaviour
+				expected: `0`, // replicate Envoy's behavior
 			}),
 			Entry("RESPONSE_CODE_DETAILS", testCase{
 				field:    "RESPONSE_CODE_DETAILS",
-				expected: ``, // replicate Envoy's behaviour
+				expected: ``, // replicate Envoy's behavior
 			}),
 			Entry("REQUEST_DURATION: ``", testCase{
 				field:    "REQUEST_DURATION",
-				expected: ``, // replicate Envoy's behaviour
+				expected: ``, // replicate Envoy's behavior
 			}),
 			Entry("REQUEST_DURATION: `57` millis", testCase{
 				field: "REQUEST_DURATION",
@@ -272,11 +272,11 @@ var _ = Describe("FieldOperator", func() {
 						TimeToLastRxByte: util_proto.Duration(57000 * time.Microsecond),
 					},
 				},
-				expected: ``, // replicate Envoy's behaviour
+				expected: ``, // replicate Envoy's behavior
 			}),
 			Entry("RESPONSE_DURATION: ``", testCase{
 				field:    "RESPONSE_DURATION",
-				expected: ``, // replicate Envoy's behaviour
+				expected: ``, // replicate Envoy's behavior
 			}),
 			Entry("RESPONSE_DURATION: `102` millis", testCase{
 				field: "RESPONSE_DURATION",
@@ -285,11 +285,11 @@ var _ = Describe("FieldOperator", func() {
 						TimeToFirstUpstreamRxByte: util_proto.Duration(102000 * time.Microsecond),
 					},
 				},
-				expected: ``, // replicate Envoy's behaviour
+				expected: ``, // replicate Envoy's behavior
 			}),
 			Entry("RESPONSE_TX_DURATION: ``", testCase{
 				field:    "RESPONSE_TX_DURATION",
-				expected: ``, // replicate Envoy's behaviour
+				expected: ``, // replicate Envoy's behavior
 			}),
 			Entry("RESPONSE_TX_DURATION: no TimeToFirstUpstreamRxByte", testCase{
 				field: "RESPONSE_TX_DURATION",
@@ -298,7 +298,7 @@ var _ = Describe("FieldOperator", func() {
 						TimeToLastDownstreamTxByte: util_proto.Duration(123000 * time.Microsecond),
 					},
 				},
-				expected: ``, // replicate Envoy's behaviour
+				expected: ``, // replicate Envoy's behavior
 			}),
 			Entry("RESPONSE_TX_DURATION: no TimeToLastDownstreamTxByte", testCase{
 				field: "RESPONSE_TX_DURATION",
@@ -307,7 +307,7 @@ var _ = Describe("FieldOperator", func() {
 						TimeToFirstUpstreamRxByte: util_proto.Duration(102000 * time.Microsecond),
 					},
 				},
-				expected: ``, // replicate Envoy's behaviour
+				expected: ``, // replicate Envoy's behavior
 			}),
 			Entry("RESPONSE_TX_DURATION: `23` millis", testCase{
 				field: "RESPONSE_TX_DURATION",
@@ -317,7 +317,7 @@ var _ = Describe("FieldOperator", func() {
 						TimeToLastDownstreamTxByte: util_proto.Duration(123000 * time.Microsecond),
 					},
 				},
-				expected: ``, // replicate Envoy's behaviour
+				expected: ``, // replicate Envoy's behavior
 			}),
 		)
 	})

--- a/pkg/envoy/accesslog/v3/format.go
+++ b/pkg/envoy/accesslog/v3/format.go
@@ -8,7 +8,7 @@ import (
 )
 
 const (
-	unspecifiedValue = "-" // to replicate Envoy's behaviour
+	unspecifiedValue = "-" // to replicate Envoy's behavior
 )
 
 // AccessLogFormat represents the entire access log format string.
@@ -24,7 +24,7 @@ func (f *AccessLogFormat) FormatHttpLogEntry(entry *accesslog_data.HTTPAccessLog
 			return "", err
 		}
 		if value == "" {
-			value = unspecifiedValue // to replicate Envoy's behaviour
+			value = unspecifiedValue // to replicate Envoy's behavior
 		}
 		values[i] = value
 	}
@@ -39,7 +39,7 @@ func (f *AccessLogFormat) FormatTcpLogEntry(entry *accesslog_data.TCPAccessLogEn
 			return "", err
 		}
 		if value == "" {
-			value = unspecifiedValue // to replicate Envoy's behaviour
+			value = unspecifiedValue // to replicate Envoy's behavior
 		}
 		values[i] = value
 	}

--- a/pkg/envoy/accesslog/v3/format_parser_test.go
+++ b/pkg/envoy/accesslog/v3/format_parser_test.go
@@ -160,17 +160,17 @@ var _ = Describe("ParseFormat()", func() {
 			Entry("%PROTOCOL%", testCase{
 				format:       `%PROTOCOL%`,
 				expectedHTTP: `HTTP/1.1`,
-				expectedTCP:  `-`, // replicate Envoy's behaviour
+				expectedTCP:  `-`, // replicate Envoy's behavior
 			}),
 			Entry("%RESPONSE_CODE%", testCase{
 				format:       `%RESPONSE_CODE%`,
 				expectedHTTP: `200`,
-				expectedTCP:  `0`, // replicate Envoy's behaviour
+				expectedTCP:  `0`, // replicate Envoy's behavior
 			}),
 			Entry("%RESPONSE_CODE_DETAILS%", testCase{
 				format:       `%RESPONSE_CODE_DETAILS%`,
 				expectedHTTP: `response code details`,
-				expectedTCP:  `-`, // replicate Envoy's behaviour
+				expectedTCP:  `-`, // replicate Envoy's behavior
 			}),
 			Entry("%BYTES_SENT%", testCase{
 				format:       `%BYTES_SENT%`,
@@ -180,17 +180,17 @@ var _ = Describe("ParseFormat()", func() {
 			Entry("%REQUEST_DURATION%", testCase{
 				format:       `%REQUEST_DURATION%`,
 				expectedHTTP: `57`, // time in millis
-				expectedTCP:  `-`,  // replicate Envoy's behaviour
+				expectedTCP:  `-`,  // replicate Envoy's behavior
 			}),
 			Entry("%RESPONSE_DURATION%", testCase{
 				format:       `%RESPONSE_DURATION%`,
 				expectedHTTP: `102`, // time in millis
-				expectedTCP:  `-`,   // replicate Envoy's behaviour
+				expectedTCP:  `-`,   // replicate Envoy's behavior
 			}),
 			Entry("%RESPONSE_TX_DURATION%", testCase{
 				format:       `%RESPONSE_TX_DURATION%`,
 				expectedHTTP: `21`, // time in millis
-				expectedTCP:  `-`,  // replicate Envoy's behaviour
+				expectedTCP:  `-`,  // replicate Envoy's behavior
 			}),
 			Entry("%UPSTREAM_TRANSPORT_FAILURE_REASON%", testCase{
 				format:       `%UPSTREAM_TRANSPORT_FAILURE_REASON%`,
@@ -209,153 +209,153 @@ var _ = Describe("ParseFormat()", func() {
 			}),
 			Entry("%REQ()%", testCase{ // apparently, Envoy allows both `Header` and `AltHeader` to be empty
 				format:       `%REQ()%`,
-				expectedHTTP: `-`, // replicate Envoy's behaviour
-				expectedTCP:  `-`, // replicate Envoy's behaviour
+				expectedHTTP: `-`, // replicate Envoy's behavior
+				expectedTCP:  `-`, // replicate Envoy's behavior
 			}),
 			Entry("%REQ():10%", testCase{ // apparently, Envoy allows both `Header` and `AltHeader` to be empty
 				format:       `%REQ():10%`,
-				expectedHTTP: `-`, // replicate Envoy's behaviour
-				expectedTCP:  `-`, // replicate Envoy's behaviour
+				expectedHTTP: `-`, // replicate Envoy's behavior
+				expectedTCP:  `-`, // replicate Envoy's behavior
 			}),
 			Entry("%REQ(:authority)%", testCase{ // pseudo header
 				format:       `%REQ(:authority)%`,
 				expectedHTTP: `backend.internal:8080`,
-				expectedTCP:  `-`, // replicate Envoy's behaviour
+				expectedTCP:  `-`, // replicate Envoy's behavior
 			}),
 			Entry("%REQ(:authority):7%", testCase{ // max length
 				format:       `%REQ(:authority):7%`,
 				expectedHTTP: `backend`,
-				expectedTCP:  `-`, // replicate Envoy's behaviour
+				expectedTCP:  `-`, // replicate Envoy's behavior
 			}),
 			Entry("%REQ(x-missing-header?:authority)%", testCase{ // altHeader
 				format:       `%REQ(x-missing-header?:authority)%`,
 				expectedHTTP: `backend.internal:8080`,
-				expectedTCP:  `-`, // replicate Envoy's behaviour
+				expectedTCP:  `-`, // replicate Envoy's behavior
 			}),
 			Entry("%REQ(x-missing-header?:authority):7%", testCase{ // altHeader w/ maxLen
 				format:       `%REQ(x-missing-header?:authority):7%`,
 				expectedHTTP: `backend`,
-				expectedTCP:  `-`, // replicate Envoy's behaviour
+				expectedTCP:  `-`, // replicate Envoy's behavior
 			}),
 			Entry("%REQ(x-missing-header?:AUTHORITY):7%", testCase{ // uppercase altHeader w/ maxLen
 				format:       `%REQ(x-missing-header?:AUTHORITY):7%`,
 				expectedHTTP: `backend`,
-				expectedTCP:  `-`, // replicate Envoy's behaviour
+				expectedTCP:  `-`, // replicate Envoy's behavior
 			}),
 			Entry("%REQ(:authority?:path)%", testCase{ // header over altHeader
 				format:       `%REQ(:authority?:path)%`,
 				expectedHTTP: `backend.internal:8080`,
-				expectedTCP:  `-`, // replicate Envoy's behaviour
+				expectedTCP:  `-`, // replicate Envoy's behavior
 			}),
 			Entry("%REQ(:authority?:path):7%", testCase{ // header over altHeader w/ maxLen
 				format:       `%REQ(:authority?:path):7%`,
 				expectedHTTP: `backend`,
-				expectedTCP:  `-`, // replicate Envoy's behaviour
+				expectedTCP:  `-`, // replicate Envoy's behavior
 			}),
 			Entry("%REQ(:AUTHORITY?:path):7%", testCase{ // uppercase header over altHeader w/ maxLen
 				format:       `%REQ(:AUTHORITY?:path):7%`,
 				expectedHTTP: `backend`,
-				expectedTCP:  `-`, // replicate Envoy's behaviour
+				expectedTCP:  `-`, // replicate Envoy's behavior
 			}),
 			Entry("%RESP()%", testCase{ // apparently, Envoy allows both `Header` and `AltHeader` to be empty
 				format:       `%RESP()%`,
-				expectedHTTP: `-`, // replicate Envoy's behaviour
-				expectedTCP:  `-`, // replicate Envoy's behaviour
+				expectedHTTP: `-`, // replicate Envoy's behavior
+				expectedTCP:  `-`, // replicate Envoy's behavior
 			}),
 			Entry("%RESP():10%", testCase{ // apparently, Envoy allows both `Header` and `AltHeader` to be empty
 				format:       `%RESP():10%`,
-				expectedHTTP: `-`, // replicate Envoy's behaviour
-				expectedTCP:  `-`, // replicate Envoy's behaviour
+				expectedHTTP: `-`, // replicate Envoy's behavior
+				expectedTCP:  `-`, // replicate Envoy's behavior
 			}),
 			Entry("%RESP(server)%", testCase{ // pseudo header
 				format:       `%RESP(server)%`,
 				expectedHTTP: `Tomcat`,
-				expectedTCP:  `-`, // replicate Envoy's behaviour
+				expectedTCP:  `-`, // replicate Envoy's behavior
 			}),
 			Entry("%RESP(server):3%", testCase{ // max length
 				format:       `%RESP(server):3%`,
 				expectedHTTP: `Tom`,
-				expectedTCP:  `-`, // replicate Envoy's behaviour
+				expectedTCP:  `-`, // replicate Envoy's behavior
 			}),
 			Entry("%RESP(x-missing-header?server)%", testCase{ // altHeader
 				format:       `%RESP(x-missing-header?server)%`,
 				expectedHTTP: `Tomcat`,
-				expectedTCP:  `-`, // replicate Envoy's behaviour
+				expectedTCP:  `-`, // replicate Envoy's behavior
 			}),
 			Entry("%RESP(x-missing-header?server):3%", testCase{ // altHeader w/ maxLen
 				format:       `%RESP(x-missing-header?server):3%`,
 				expectedHTTP: `Tom`,
-				expectedTCP:  `-`, // replicate Envoy's behaviour
+				expectedTCP:  `-`, // replicate Envoy's behavior
 			}),
 			Entry("%RESP(x-missing-header?SERVER):3%", testCase{ // uppercase altHeader w/ maxLen
 				format:       `%RESP(x-missing-header?SERVER):3%`,
 				expectedHTTP: `Tom`,
-				expectedTCP:  `-`, // replicate Envoy's behaviour
+				expectedTCP:  `-`, // replicate Envoy's behavior
 			}),
 			Entry("%RESP(server?content-type)%", testCase{ // header over altHeader
 				format:       `%RESP(server?:content-type)%`,
 				expectedHTTP: `Tomcat`,
-				expectedTCP:  `-`, // replicate Envoy's behaviour
+				expectedTCP:  `-`, // replicate Envoy's behavior
 			}),
 			Entry("%RESP(server?content-type):3%", testCase{ // header over altHeader w/ maxLen
 				format:       `%RESP(server?content-type):3%`,
 				expectedHTTP: `Tom`,
-				expectedTCP:  `-`, // replicate Envoy's behaviour
+				expectedTCP:  `-`, // replicate Envoy's behavior
 			}),
 			Entry("%RESP(SERVER?content-type):3%", testCase{ // uppercase header over altHeader w/ maxLen
 				format:       `%RESP(SERVER?content-type):3%`,
 				expectedHTTP: `Tom`,
-				expectedTCP:  `-`, // replicate Envoy's behaviour
+				expectedTCP:  `-`, // replicate Envoy's behavior
 			}),
 			Entry("%TRAILER()%", testCase{ // apparently, Envoy allows both `Header` and `AltHeader` to be empty
 				format:       `%TRAILER()%`,
-				expectedHTTP: `-`, // replicate Envoy's behaviour
-				expectedTCP:  `-`, // replicate Envoy's behaviour
+				expectedHTTP: `-`, // replicate Envoy's behavior
+				expectedTCP:  `-`, // replicate Envoy's behavior
 			}),
 			Entry("%TRAILER():10%", testCase{ // apparently, Envoy allows both `Header` and `AltHeader` to be empty
 				format:       `%TRAILER():10%`,
-				expectedHTTP: `-`, // replicate Envoy's behaviour
-				expectedTCP:  `-`, // replicate Envoy's behaviour
+				expectedHTTP: `-`, // replicate Envoy's behavior
+				expectedTCP:  `-`, // replicate Envoy's behavior
 			}),
 			Entry("%TRAILER(grpc-status)%", testCase{ // pseudo header
 				format:       `%TRAILER(grpc-status)%`,
 				expectedHTTP: `14`,
-				expectedTCP:  `-`, // replicate Envoy's behaviour
+				expectedTCP:  `-`, // replicate Envoy's behavior
 			}),
 			Entry("%TRAILER(grpc-status):1%", testCase{ // max length
 				format:       `%TRAILER(grpc-status):1%`,
 				expectedHTTP: `1`,
-				expectedTCP:  `-`, // replicate Envoy's behaviour
+				expectedTCP:  `-`, // replicate Envoy's behavior
 			}),
 			Entry("%TRAILER(x-missing-header?grpc-status)%", testCase{ // altHeader
 				format:       `%TRAILER(x-missing-header?grpc-status)%`,
 				expectedHTTP: `14`,
-				expectedTCP:  `-`, // replicate Envoy's behaviour
+				expectedTCP:  `-`, // replicate Envoy's behavior
 			}),
 			Entry("%TRAILER(x-missing-header?grpc-status):1%", testCase{ // altHeader w/ maxLen
 				format:       `%TRAILER(x-missing-header?grpc-status):1%`,
 				expectedHTTP: `1`,
-				expectedTCP:  `-`, // replicate Envoy's behaviour
+				expectedTCP:  `-`, // replicate Envoy's behavior
 			}),
 			Entry("%TRAILER(x-missing-header?GRPC-STATUS):1%", testCase{ // uppercase altHeader w/ maxLen
 				format:       `%TRAILER(x-missing-header?GRPC-STATUS):1%`,
 				expectedHTTP: `1`,
-				expectedTCP:  `-`, // replicate Envoy's behaviour
+				expectedTCP:  `-`, // replicate Envoy's behavior
 			}),
 			Entry("%TRAILER(grpc-status?grpc-message)%", testCase{ // header over altHeader
 				format:       `%TRAILER(grpc-status?:grpc-message)%`,
 				expectedHTTP: `14`,
-				expectedTCP:  `-`, // replicate Envoy's behaviour
+				expectedTCP:  `-`, // replicate Envoy's behavior
 			}),
 			Entry("%TRAILER(grpc-status?grpc-message):1%", testCase{ // header over altHeader w/ maxLen
 				format:       `%TRAILER(grpc-status?grpc-message):1%`,
 				expectedHTTP: `1`,
-				expectedTCP:  `-`, // replicate Envoy's behaviour
+				expectedTCP:  `-`, // replicate Envoy's behavior
 			}),
 			Entry("%TRAILER(GRPC-STATUS?grpc-message):1%", testCase{ // uppercase header over altHeader w/ maxLen
 				format:       `%TRAILER(GRPC-STATUS?grpc-message):1%`,
 				expectedHTTP: `1`,
-				expectedTCP:  `-`, // replicate Envoy's behaviour
+				expectedTCP:  `-`, // replicate Envoy's behavior
 			}),
 			Entry("%DYNAMIC_METADATA()%", testCase{ // apparently, Envoy allows both `FilterNamespace` and `Path` to be empty
 				format:       `%DYNAMIC_METADATA()%`,

--- a/pkg/kds/server/type_adjust_callbacks.go
+++ b/pkg/kds/server/type_adjust_callbacks.go
@@ -11,9 +11,9 @@ import (
 // We are setting TypeURL for DiscoveryRequest/DiscoveryResponse for our resource name like "TrafficRoute" / "Mesh" etc.
 // but the actual resource which we are sending is kuma.mesh.v1alpha1.KumaResource
 //
-// The function which is marshalling DiscoveryResponse
+// The function which is marshaling DiscoveryResponse
 // func (r *RawResponse) GetDiscoveryResponse() (*discovery.DiscoveryResponse, error)
-// Ignores the TypeURL from marshalling operation and overrides it with TypeURL of the request.
+// Ignores the TypeURL from marshaling operation and overrides it with TypeURL of the request.
 // If we pass wrong TypeURL in envoy_api.DiscoveryResponse#Resources we won't be able to unmarshall it, therefore we need to adjust the type.
 type typeAdjustCallbacks struct {
 	util_xds_v3.NoopCallbacks

--- a/pkg/plugins/runtime/k8s/controllers/pod_converter_test.go
+++ b/pkg/plugins/runtime/k8s/controllers/pod_converter_test.go
@@ -453,7 +453,7 @@ var _ = Describe("InboundTagsForService(..)", func() {
 			podLabels: nil,
 			expected: map[string]string{
 				"kuma.io/service":  "example_demo_svc_80",
-				"kuma.io/protocol": "tcp", // we want Kuma's default behaviour to be explicit to a user
+				"kuma.io/protocol": "tcp", // we want Kuma's default behavior to be explicit to a user
 			},
 		}),
 		Entry("Pod with labels", testCase{
@@ -466,7 +466,7 @@ var _ = Describe("InboundTagsForService(..)", func() {
 				"app":              "example",
 				"version":          "0.1",
 				"kuma.io/service":  "example_demo_svc_80",
-				"kuma.io/protocol": "tcp", // we want Kuma's default behaviour to be explicit to a user
+				"kuma.io/protocol": "tcp", // we want Kuma's default behavior to be explicit to a user
 			},
 		}),
 		Entry("Pod with `service` label", testCase{
@@ -480,7 +480,7 @@ var _ = Describe("InboundTagsForService(..)", func() {
 				"app":              "example",
 				"version":          "0.1",
 				"kuma.io/service":  "example_demo_svc_80",
-				"kuma.io/protocol": "tcp", // we want Kuma's default behaviour to be explicit to a user
+				"kuma.io/protocol": "tcp", // we want Kuma's default behavior to be explicit to a user
 			},
 		}),
 		Entry("Service with a `<port>.service.kuma.io/protocol` annotation and an unknown value", testCase{
@@ -496,7 +496,7 @@ var _ = Describe("InboundTagsForService(..)", func() {
 				"app":              "example",
 				"version":          "0.1",
 				"kuma.io/service":  "example_demo_svc_80",
-				"kuma.io/protocol": "not-yet-supported-protocol", // we want Kuma's behaviour to be straightforward to a user (just copy annotation value "as is")
+				"kuma.io/protocol": "not-yet-supported-protocol", // we want Kuma's behavior to be straightforward to a user (just copy annotation value "as is")
 			},
 		}),
 		Entry("Service with a `<port>.service.kuma.io/protocol` annotation and a known value", testCase{
@@ -623,11 +623,11 @@ var _ = Describe("ProtocolTagFor(..)", func() {
 		},
 		Entry("no appProtocol", testCase{
 			appProtocol: nil,
-			expected:    "tcp", // we want Kuma's default behaviour to be explicit to a user
+			expected:    "tcp", // we want Kuma's default behavior to be explicit to a user
 		}),
 		Entry("appProtocol has an empty value", testCase{
 			appProtocol: utilpointer.StringPtr(""),
-			expected:    "tcp", // we want Kuma's default behaviour to be explicit to a user
+			expected:    "tcp", // we want Kuma's default behavior to be explicit to a user
 		}),
 		Entry("no appProtocol but with `<port>.service.kuma.io/protocol` annotation", testCase{
 			appProtocol: nil,
@@ -638,11 +638,11 @@ var _ = Describe("ProtocolTagFor(..)", func() {
 		}),
 		Entry("appProtocol has an unknown value", testCase{
 			appProtocol: utilpointer.StringPtr("not-yet-supported-protocol"),
-			expected:    "not-yet-supported-protocol", // we want Kuma's behaviour to be straightforward to a user (just copy appProtocol value "as is")
+			expected:    "not-yet-supported-protocol", // we want Kuma's behavior to be straightforward to a user (just copy appProtocol value "as is")
 		}),
 		Entry("appProtocol has a non-lowercase value", testCase{
 			appProtocol: utilpointer.StringPtr("HtTp"),
-			expected:    "HtTp", // we want Kuma's behaviour to be straightforward to a user (just copy appProtocol value "as is")
+			expected:    "HtTp", // we want Kuma's behavior to be straightforward to a user (just copy appProtocol value "as is")
 		}),
 		Entry("appProtocol has a known value: http", testCase{
 			appProtocol: utilpointer.StringPtr("http"),

--- a/pkg/plugins/runtime/k8s/webhooks/defaulter.go
+++ b/pkg/plugins/runtime/k8s/webhooks/defaulter.go
@@ -66,10 +66,10 @@ func (h *defaultingHandler) Handle(ctx context.Context, req admission.Request) a
 		return admission.Errored(http.StatusInternalServerError, err)
 	}
 
-	marshalled, err := json.Marshal(obj)
+	marshaled, err := json.Marshal(obj)
 	if err != nil {
 		return admission.Errored(http.StatusInternalServerError, err)
 	}
 
-	return admission.PatchResponseFromRaw(req.Object.Raw, marshalled)
+	return admission.PatchResponseFromRaw(req.Object.Raw, marshaled)
 }

--- a/pkg/util/proto/any.go
+++ b/pkg/util/proto/any.go
@@ -14,7 +14,7 @@ import (
 const googleApis = "type.googleapis.com/"
 
 // When saving Snapshot in SnapshotCache we generate version based on proto.Equal()
-// Therefore we need deterministic way of marshalling Any which is part of the Protobuf on which we execute Equal()
+// Therefore we need deterministic way of marshaling Any which is part of the Protobuf on which we execute Equal()
 //
 // Based on proto.MarshalAny
 func MarshalAnyDeterministic(pb proto.Message) (*any.Any, error) {

--- a/pkg/util/xds/v3/versioner.go
+++ b/pkg/util/xds/v3/versioner.go
@@ -24,7 +24,7 @@ func (v SnapshotAutoVersioner) Version(new, old Snapshot) Snapshot {
 	for _, typ := range new.GetSupportedTypes() {
 		version := new.GetVersion(typ)
 		if version != "" {
-			// favour a version assigned by resource generator
+			// favor a version assigned by resource generator
 			continue
 		}
 		if old != nil && v.equal(new.GetResources(typ), old.GetResources(typ)) {

--- a/pkg/util/xds/versioner.go
+++ b/pkg/util/xds/versioner.go
@@ -24,7 +24,7 @@ func (v SnapshotAutoVersioner) Version(new, old Snapshot) Snapshot {
 	for _, typ := range new.GetSupportedTypes() {
 		version := new.GetVersion(typ)
 		if version != "" {
-			// favour a version assigned by resource generator
+			// favor a version assigned by resource generator
 			continue
 		}
 		if old != nil && v.equal(new.GetResources(typ), old.GetResources(typ)) {

--- a/pkg/xds/bootstrap/generator.go
+++ b/pkg/xds/bootstrap/generator.go
@@ -31,7 +31,7 @@ import (
 	util_proto "github.com/kumahq/kuma/pkg/util/proto"
 	"github.com/kumahq/kuma/pkg/xds/bootstrap/types"
 
-	// import Envoy protobuf definitions so (un)marshalling Envoy protobuf works in tests (normally it is imported in root.go)
+	// import Envoy protobuf definitions so (un)marshaling Envoy protobuf works in tests (normally it is imported in root.go)
 	envoy_common "github.com/kumahq/kuma/pkg/xds/envoy"
 )
 

--- a/pkg/xds/cache/cla/cache_test.go
+++ b/pkg/xds/cache/cla/cache_test.go
@@ -146,9 +146,9 @@ var _ = Describe("ClusterLoadAssignment Cache", func() {
 				cla, err := claCache.GetCLA(context.Background(), "mesh-0", "", envoy_common.NewCluster(envoy_common.WithService("backend")), envoy_common.APIV3)
 				Expect(err).ToNot(HaveOccurred())
 
-				marshalled, err := json.Marshal(cla) // to imitate Read access to 'cla'
+				marshaled, err := json.Marshal(cla) // to imitate Read access to 'cla'
 				Expect(err).ToNot(HaveOccurred())
-				Expect(len(marshalled) > 0).To(BeTrue())
+				Expect(len(marshaled) > 0).To(BeTrue())
 				wg.Done()
 			}()
 		}

--- a/pkg/xds/envoy/listeners/v3/access_log_configurer.go
+++ b/pkg/xds/envoy/listeners/v3/access_log_configurer.go
@@ -89,14 +89,14 @@ func tcpAccessLog(format *accesslog.AccessLogFormat, cfgStr *structpb.Struct) (*
 	if err := format.ConfigureHttpLog(httpGrpcAccessLog); err != nil {
 		return nil, errors.Wrapf(err, "failed to configure %T according to the format string: %s", httpGrpcAccessLog, format)
 	}
-	marshalled, err := proto.MarshalAnyDeterministic(httpGrpcAccessLog)
+	marshaled, err := proto.MarshalAnyDeterministic(httpGrpcAccessLog)
 	if err != nil {
 		return nil, errors.Wrapf(err, "could not marshall %T", httpGrpcAccessLog)
 	}
 	return &envoy_accesslog.AccessLog{
 		Name: "envoy.access_loggers.http_grpc",
 		ConfigType: &envoy_accesslog.AccessLog_TypedConfig{
-			TypedConfig: marshalled,
+			TypedConfig: marshaled,
 		},
 	}, nil
 }
@@ -121,14 +121,14 @@ func fileAccessLog(format *accesslog.AccessLogFormat, cfgStr *structpb.Struct) (
 		},
 		Path: cfg.Path,
 	}
-	marshalled, err := proto.MarshalAnyDeterministic(fileAccessLog)
+	marshaled, err := proto.MarshalAnyDeterministic(fileAccessLog)
 	if err != nil {
 		return nil, errors.Wrapf(err, "could not marshall %T", fileAccessLog)
 	}
 	return &envoy_accesslog.AccessLog{
 		Name: "envoy.access_loggers.file",
 		ConfigType: &envoy_accesslog.AccessLog_TypedConfig{
-			TypedConfig: marshalled,
+			TypedConfig: marshaled,
 		},
 	}, nil
 }

--- a/pkg/xds/generator/prometheus_endpoint_generator.go
+++ b/pkg/xds/generator/prometheus_endpoint_generator.go
@@ -27,7 +27,7 @@ const OriginPrometheus = "prometheus"
 // When generating such a listener, it's important not to overshadow
 // a port that is already in use by the application or other Envoy listeners.
 // In the latter case we prefer not generate Prometheus endpoint at all
-// rather than introduce undeterministic behaviour.
+// rather than introduce undeterministic behavior.
 type PrometheusEndpointGenerator struct {
 }
 

--- a/test/e2e/trafficroute/universal_multizone/traffic_route.go
+++ b/test/e2e/trafficroute/universal_multizone/traffic_route.go
@@ -378,7 +378,7 @@ conf:
 			// If concurrency is low, we only initiate 2 connections to ZoneIngress which is not enough to cover all instances.
 			//
 			// We can adjust concurrency once https://github.com/kumahq/kuma/issues/1920 is fixed
-			// or if we change the behaviour of ZoneIngress
+			// or if we change the behavior of ZoneIngress
 			if runtime.NumCPU() < 4 {
 				Skip("concurrency too low")
 				return


### PR DESCRIPTION
### Summary

Use US locale for the misspell linter.

### Full changelog

N/A

### Issues resolved

N/A

### Documentation

N/A

### Testing

- [x] Unit tests
- [x] E2E tests
- [x] Manual testing on Universal
- [x] Manual testing on Kubernetes 

### Backwards compatibility

- [x] Add `backport-to-stable` label if the code is backwards compatible. Otherwise, list breaking changes.
