### PR TITLE
fix(ci) improve kumactl path detection

### DIFF
--- a/test/framework/constants.go
+++ b/test/framework/constants.go
@@ -28,7 +28,6 @@ const (
 	defaultKumactlConfig         = "${HOME}/.kumactl/%s-config"
 	defaultKubeConfigPathPattern = "${HOME}/.kube/kind-%s-config"
 
-	envKUMACTLBIN  = "KUMACTLBIN"
 	envK8SCLUSTERS = "K8SCLUSTERS"
 	envAPIVersion  = "API_VERSION"
 	envIPv6        = "IPV6"

--- a/test/framework/env.go
+++ b/test/framework/env.go
@@ -1,7 +1,11 @@
 package framework
 
 import (
+	"fmt"
 	"os"
+	"path"
+	"path/filepath"
+	"runtime"
 	"strconv"
 	"strings"
 	"time"
@@ -115,8 +119,13 @@ func IsIPv6() bool {
 	return envBool(envIPv6)
 }
 
+// GetKumactlBin returns the path to the kumactl program.
 func GetKumactlBin() string {
-	return os.Getenv(envKUMACTLBIN)
+	if path := os.Getenv("KUMACTLBIN"); path != "" {
+		return path
+	}
+
+	return path.Join(BuildArtifactsDir(), "kumactl", "kumactl")
 }
 
 func IsK8sClustersStarted() bool {
@@ -132,4 +141,20 @@ func envIsPresent(env string) bool {
 func envBool(env string) bool {
 	value, found := os.LookupEnv(env)
 	return found && strings.ToLower(value) == "true"
+}
+
+// BuildArtifactsDir returns the path for Kuma build artifacts.
+func BuildArtifactsDir() string {
+	// runtime.Caller returns the absolute path to this file on the
+	// local filesystem. From there, we can walk up to the directory
+	// tree to where we know the build artifacts are.
+	_, file, _, _ := runtime.Caller(0)
+
+	return path.Join(
+		filepath.Dir(file),
+		"..",
+		"..",
+		"build",
+		fmt.Sprintf("artifacts-%s-%s", runtime.GOOS, runtime.GOARCH),
+	)
 }


### PR DESCRIPTION
### Summary

Depending on the makefiles to set the `KUMACTLBIN` environment variable
so that the e2e tests can find kumactl makes it harder to run individual
tests using `go test`. We can automatically detect where the build
artifacts are, and use that path if `KUMACTLBIN` isn't set.

### Full changelog

N/A

### Issues resolved

N/A

### Documentation

N/A

### Testing

- [x] Unit tests
- [x] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes 

### Backwards compatibility

- [x] Add `backport-to-stable` label if the code is backwards compatible. Otherwise, list breaking changes.
