### PR TITLE
fix(kuma-cp) possible to delete resources on Zone CP

### DIFF
--- a/pkg/plugins/runtime/k8s/webhooks/validation.go
+++ b/pkg/plugins/runtime/k8s/webhooks/validation.go
@@ -21,6 +21,7 @@ import (
 	k8s_common "github.com/kumahq/kuma/pkg/plugins/common/k8s"
 	k8s_model "github.com/kumahq/kuma/pkg/plugins/resources/k8s/native/pkg/model"
 	k8s_registry "github.com/kumahq/kuma/pkg/plugins/resources/k8s/native/pkg/registry"
+	"github.com/kumahq/kuma/pkg/version"
 )
 
 func NewValidatingWebhook(converter k8s_common.Converter, coreRegistry core_registry.TypeRegistry, k8sRegistry k8s_registry.TypeRegistry, mode core.CpMode, systemNamespace string) k8s_common.AdmissionValidator {
@@ -130,8 +131,8 @@ func syncErrorResponse(resType core_model.ResourceType, cpMode core.CpMode, op v
 			Allowed: false,
 			Result: &metav1.Status{
 				Status: "Failure",
-				Message: fmt.Sprintf("You are trying to %s a %s on %s CP. In multizone setup, it should be only %sd on %s CP and synced to %s CP.",
-					strings.ToLower(string(op)), resType, cpMode, strings.ToLower(string(op)), otherCpMode, cpMode),
+				Message: fmt.Sprintf("Operation not allowed. %s resources like %s can be updated or deleted only "+
+					"from the %s control plane and not from a %s control plane.", version.Product, resType, strings.ToUpper(otherCpMode), strings.ToUpper(cpMode)),
 				Reason: "Forbidden",
 				Code:   403,
 				Details: &metav1.StatusDetails{

--- a/pkg/plugins/runtime/k8s/webhooks/validation.go
+++ b/pkg/plugins/runtime/k8s/webhooks/validation.go
@@ -157,10 +157,6 @@ func isKumaServiceAccount(userInfo authenticationv1.UserInfo, systemNamespace st
 	return false
 }
 
-func isDefaultMesh(resType core_model.ResourceType, obj k8s_model.KubernetesObject) bool {
-	return resType == core_mesh.MeshType && obj.GetName() == core_model.DefaultMesh && len(obj.GetSpec()) == 0
-}
-
 // validateResourceLocation validates if resources that suppose to be applied on Global are applied on Global and other way around
 func (h *validatingHandler) validateResourceLocation(resType core_model.ResourceType) admission.Response {
 	if err := system.ValidateLocation(resType, h.mode); err != nil {

--- a/pkg/plugins/runtime/k8s/webhooks/validation_test.go
+++ b/pkg/plugins/runtime/k8s/webhooks/validation_test.go
@@ -38,6 +38,7 @@ var _ = Describe("Validation", func() {
 		mode        core.CpMode
 		resp        kube_admission.Response
 		username    string
+		operation   admissionv1beta1.Operation
 	}
 	DescribeTable("Validation",
 		func(given testCase) {
@@ -63,6 +64,7 @@ var _ = Describe("Validation", func() {
 					UserInfo: authenticationv1.UserInfo{
 						Username: given.username,
 					},
+					Operation: given.operation,
 				},
 			}
 
@@ -121,31 +123,7 @@ var _ = Describe("Validation", func() {
 					},
 				},
 			},
-		}),
-		Entry("should pass default mesh on zone", testCase{
-			mode:        core.Zone,
-			objTemplate: &mesh_proto.Mesh{},
-			username:    "cli-user",
-			obj: `
-            {
-              "apiVersion":"kuma.io/v1alpha1",
-              "kind":"Mesh",
-              "mesh":"default",
-              "metadata":{
-                "name":"default",
-                "creationTimestamp":null
-              },
-              "spec":{}
-            }`,
-			resp: kube_admission.Response{
-				AdmissionResponse: admissionv1beta1.AdmissionResponse{
-					UID:     "12345",
-					Allowed: true,
-					Result: &kube_meta.Status{
-						Code: 200,
-					},
-				},
-			},
+			operation: admissionv1beta1.Create,
 		}),
 		Entry("should pass validation for synced policy from Global to Zone", testCase{
 			mode:        core.Zone,
@@ -199,6 +177,7 @@ var _ = Describe("Validation", func() {
 					},
 				},
 			},
+			operation: admissionv1beta1.Create,
 		}),
 		Entry("should pass validation for synced policy from Zone to Global", testCase{
 			mode:        core.Zone,
@@ -240,6 +219,7 @@ var _ = Describe("Validation", func() {
 					},
 				},
 			},
+			operation: admissionv1beta1.Create,
 		}),
 		Entry("should pass validation for not synced Dataplane in Zone", testCase{
 			mode:        core.Zone,
@@ -278,6 +258,7 @@ var _ = Describe("Validation", func() {
 					},
 				},
 			},
+			operation: admissionv1beta1.Create,
 		}),
 		Entry("should fail validation due to invalid spec", testCase{
 			mode:        core.Global,
@@ -329,6 +310,7 @@ var _ = Describe("Validation", func() {
 					},
 				},
 			},
+			operation: admissionv1beta1.Create,
 		}),
 		Entry("should fail validation due to applying policy manually on Zone CP", testCase{
 			mode:        core.Zone,
@@ -351,7 +333,7 @@ var _ = Describe("Validation", func() {
 					Allowed: false,
 					Result: &kube_meta.Status{
 						Status:  "Failure",
-						Message: "You are trying to apply a TrafficRoute on zone CP. In multizone setup, it should be only applied on global CP and synced to zone CP.",
+						Message: "You are trying to create a TrafficRoute on zone CP. In multizone setup, it should be only created on global CP and synced to zone CP.",
 						Reason:  "Forbidden",
 						Details: &kube_meta.StatusDetails{
 							Causes: []kube_meta.StatusCause{
@@ -366,6 +348,7 @@ var _ = Describe("Validation", func() {
 					},
 				},
 			},
+			operation: admissionv1beta1.Create,
 		}),
 		Entry("should fail validation due to applying Dataplane manually on Global CP", testCase{
 			mode:        core.Global,
@@ -389,7 +372,7 @@ var _ = Describe("Validation", func() {
 					Allowed: false,
 					Result: &kube_meta.Status{
 						Status:  "Failure",
-						Message: "You are trying to apply a Dataplane on global CP. In multizone setup, it should be only applied on zone CP and synced to global CP.",
+						Message: "You are trying to create a Dataplane on global CP. In multizone setup, it should be only created on zone CP and synced to global CP.",
 						Reason:  "Forbidden",
 						Details: &kube_meta.StatusDetails{
 							Causes: []kube_meta.StatusCause{
@@ -404,6 +387,7 @@ var _ = Describe("Validation", func() {
 					},
 				},
 			},
+			operation: admissionv1beta1.Create,
 		}),
 		Entry("should pass validation due to applying Zone on Global CP", testCase{
 			mode:        core.Global,
@@ -434,6 +418,7 @@ var _ = Describe("Validation", func() {
 					},
 				},
 			},
+			operation: admissionv1beta1.Create,
 		}),
 		Entry("should fail validation due to applying Zone on Zone CP", testCase{
 			mode:        core.Zone,
@@ -467,6 +452,7 @@ var _ = Describe("Validation", func() {
 					},
 				},
 			},
+			operation: admissionv1beta1.Create,
 		}),
 		Entry("should fail validation due to applying Zone on Standalone CP", testCase{
 			mode:        core.Standalone,
@@ -500,6 +486,7 @@ var _ = Describe("Validation", func() {
 					},
 				},
 			},
+			operation: admissionv1beta1.Create,
 		}),
 		Entry("should fail validation on missing mesh object", testCase{
 			mode:        core.Zone,
@@ -566,6 +553,109 @@ var _ = Describe("Validation", func() {
 					},
 				},
 			},
+			operation: admissionv1beta1.Create,
+		}),
+		Entry("should fail validation on DELETE in Zone CP", testCase{
+			mode:        core.Zone,
+			objTemplate: &mesh_proto.TrafficRoute{},
+			resp: kube_admission.Response{
+				AdmissionResponse: admissionv1beta1.AdmissionResponse{
+					UID:     "12345",
+					Allowed: false,
+					Result: &kube_meta.Status{
+						Status:  "Failure",
+						Message: "You are trying to delete a TrafficRoute on zone CP. In multizone setup, it should be only deleted on global CP and synced to zone CP.",
+						Reason:  "Forbidden",
+						Details: &kube_meta.StatusDetails{
+							Causes: []kube_meta.StatusCause{
+								{
+									Type:    "FieldValueInvalid",
+									Message: "cannot be empty",
+									Field:   "metadata.annotations[kuma.io/synced]",
+								},
+							},
+						},
+						Code: 403,
+					},
+				},
+			},
+			operation: admissionv1beta1.Delete,
+		}),
+		Entry("should fail validation on UPDATE in Zone CP", testCase{
+			mode:        core.Zone,
+			objTemplate: &mesh_proto.TrafficRoute{},
+			obj: `
+            {
+              "apiVersion":"kuma.io/v1alpha1",
+              "kind":"TrafficRoute",
+              "mesh":"demo",
+              "metadata":{
+                "name":"empty",
+                "creationTimestamp":null
+              },
+              "spec":{
+                "sources":[
+                  {
+                    "match":{
+                      "kuma.io/service":"web"
+                    }
+                  }
+                ],
+                "destinations":[
+                  {
+                    "match":{
+                      "kuma.io/service":"backend"
+                    }
+                  }
+                ],
+                "conf":{
+                 "split":[
+                  {
+                    "weight":100,
+                    "destination":{
+                      "kuma.io/service":"backend"
+                    }
+                  }
+                ]
+                }
+              }
+            }`,
+			resp: kube_admission.Response{
+				AdmissionResponse: admissionv1beta1.AdmissionResponse{
+					UID:     "12345",
+					Allowed: false,
+					Result: &kube_meta.Status{
+						Status:  "Failure",
+						Message: "You are trying to update a TrafficRoute on zone CP. In multizone setup, it should be only updated on global CP and synced to zone CP.",
+						Reason:  "Forbidden",
+						Details: &kube_meta.StatusDetails{
+							Causes: []kube_meta.StatusCause{
+								{
+									Type:    "FieldValueInvalid",
+									Message: "cannot be empty",
+									Field:   "metadata.annotations[kuma.io/synced]",
+								},
+							},
+						},
+						Code: 403,
+					},
+				},
+			},
+			operation: admissionv1beta1.Update,
+		}),
+		Entry("should pass validation on DELETE in Global CP", testCase{
+			mode:        core.Global,
+			objTemplate: &mesh_proto.TrafficRoute{},
+			resp: kube_admission.Response{
+				AdmissionResponse: admissionv1beta1.AdmissionResponse{
+					UID:     "12345",
+					Allowed: true,
+					Result: &kube_meta.Status{
+						Code: 200,
+					},
+				},
+			},
+			operation: admissionv1beta1.Delete,
 		}),
 	)
 })

--- a/pkg/plugins/runtime/k8s/webhooks/validation_test.go
+++ b/pkg/plugins/runtime/k8s/webhooks/validation_test.go
@@ -333,7 +333,7 @@ var _ = Describe("Validation", func() {
 					Allowed: false,
 					Result: &kube_meta.Status{
 						Status:  "Failure",
-						Message: "You are trying to create a TrafficRoute on zone CP. In multizone setup, it should be only created on global CP and synced to zone CP.",
+						Message: "Operation not allowed. Kuma resources like TrafficRoute can be updated or deleted only from the GLOBAL control plane and not from a ZONE control plane.",
 						Reason:  "Forbidden",
 						Details: &kube_meta.StatusDetails{
 							Causes: []kube_meta.StatusCause{
@@ -372,7 +372,7 @@ var _ = Describe("Validation", func() {
 					Allowed: false,
 					Result: &kube_meta.Status{
 						Status:  "Failure",
-						Message: "You are trying to create a Dataplane on global CP. In multizone setup, it should be only created on zone CP and synced to global CP.",
+						Message: "Operation not allowed. Kuma resources like Dataplane can be updated or deleted only from the ZONE control plane and not from a GLOBAL control plane.",
 						Reason:  "Forbidden",
 						Details: &kube_meta.StatusDetails{
 							Causes: []kube_meta.StatusCause{
@@ -564,7 +564,7 @@ var _ = Describe("Validation", func() {
 					Allowed: false,
 					Result: &kube_meta.Status{
 						Status:  "Failure",
-						Message: "You are trying to delete a TrafficRoute on zone CP. In multizone setup, it should be only deleted on global CP and synced to zone CP.",
+						Message: "Operation not allowed. Kuma resources like TrafficRoute can be updated or deleted only from the GLOBAL control plane and not from a ZONE control plane.",
 						Reason:  "Forbidden",
 						Details: &kube_meta.StatusDetails{
 							Causes: []kube_meta.StatusCause{
@@ -626,7 +626,7 @@ var _ = Describe("Validation", func() {
 					Allowed: false,
 					Result: &kube_meta.Status{
 						Status:  "Failure",
-						Message: "You are trying to update a TrafficRoute on zone CP. In multizone setup, it should be only updated on global CP and synced to zone CP.",
+						Message: "Operation not allowed. Kuma resources like TrafficRoute can be updated or deleted only from the GLOBAL control plane and not from a ZONE control plane.",
 						Reason:  "Forbidden",
 						Details: &kube_meta.StatusDetails{
 							Causes: []kube_meta.StatusCause{

--- a/test/e2e/deploy/kuma_deploy_global_zone.go
+++ b/test/e2e/deploy/kuma_deploy_global_zone.go
@@ -54,6 +54,8 @@ spec:
 `, namespace, policyname, weight)
 	}
 
+	errRegex := `Operation not allowed\. .* resources like TrafficRoute can be updated or deleted only from the GLOBAL control plane and not from a ZONE control plane\.`
+
 	var clusters Clusters
 	var c1, c2 Cluster
 	var global, zone ControlPlane
@@ -177,7 +179,7 @@ spec:
 		// Deny policy CREATE on zone
 		err := k8s.KubectlApplyFromStringE(c2.GetTesting(), c2.GetKubectlOptions(), policy_update)
 		Expect(err).To(HaveOccurred())
-		Expect(err.Error()).To(ContainSubstring("Operation not allowed. Kuma resources like TrafficRoute can be updated or deleted only from the GLOBAL control plane and not from a ZONE control plane."))
+		Expect(err.Error()).To(MatchRegexp(errRegex))
 
 		// Accept policy CREATE on global
 		err = k8s.KubectlApplyFromStringE(c1.GetTesting(), c1.GetKubectlOptions(), policy_create)
@@ -193,12 +195,12 @@ spec:
 		// Deny policy UPDATE on zone
 		err = k8s.KubectlApplyFromStringE(c2.GetTesting(), c2.GetKubectlOptions(), policy_update)
 		Expect(err).To(HaveOccurred())
-		Expect(err.Error()).To(ContainSubstring("Operation not allowed. Kuma resources like TrafficRoute can be updated or deleted only from the GLOBAL control plane and not from a ZONE control plane."))
+		Expect(err.Error()).To(MatchRegexp(errRegex))
 
 		// Deny policy DELETE on zone
 		err = k8s.KubectlDeleteFromStringE(c2.GetTesting(), c2.GetKubectlOptions(), policy_create)
 		Expect(err).To(HaveOccurred())
-		Expect(err.Error()).To(ContainSubstring("Operation not allowed. Kuma resources like TrafficRoute can be updated or deleted only from the GLOBAL control plane and not from a ZONE control plane."))
+		Expect(err.Error()).To(MatchRegexp(errRegex))
 
 		// Accept policy UPDATE on global
 		err = k8s.KubectlApplyFromStringE(c1.GetTesting(), c1.GetKubectlOptions(), policy_update)

--- a/test/e2e/deploy/kuma_deploy_global_zone.go
+++ b/test/e2e/deploy/kuma_deploy_global_zone.go
@@ -177,7 +177,7 @@ spec:
 		// Deny policy CREATE on zone
 		err := k8s.KubectlApplyFromStringE(c2.GetTesting(), c2.GetKubectlOptions(), policy_update)
 		Expect(err).To(HaveOccurred())
-		Expect(err.Error()).To(ContainSubstring("should be only created on global"))
+		Expect(err.Error()).To(ContainSubstring("Operation not allowed. Kuma resources like TrafficRoute can be updated or deleted only from the GLOBAL control plane and not from a ZONE control plane."))
 
 		// Accept policy CREATE on global
 		err = k8s.KubectlApplyFromStringE(c1.GetTesting(), c1.GetKubectlOptions(), policy_create)
@@ -193,12 +193,12 @@ spec:
 		// Deny policy UPDATE on zone
 		err = k8s.KubectlApplyFromStringE(c2.GetTesting(), c2.GetKubectlOptions(), policy_update)
 		Expect(err).To(HaveOccurred())
-		Expect(err.Error()).To(ContainSubstring("should be only updated on global"))
+		Expect(err.Error()).To(ContainSubstring("Operation not allowed. Kuma resources like TrafficRoute can be updated or deleted only from the GLOBAL control plane and not from a ZONE control plane."))
 
 		// Deny policy DELETE on zone
 		err = k8s.KubectlDeleteFromStringE(c2.GetTesting(), c2.GetKubectlOptions(), policy_create)
 		Expect(err).To(HaveOccurred())
-		Expect(err.Error()).To(ContainSubstring("should be only deleted on global"))
+		Expect(err.Error()).To(ContainSubstring("Operation not allowed. Kuma resources like TrafficRoute can be updated or deleted only from the GLOBAL control plane and not from a ZONE control plane."))
 
 		// Accept policy UPDATE on global
 		err = k8s.KubectlApplyFromStringE(c1.GetTesting(), c1.GetKubectlOptions(), policy_update)

--- a/test/e2e/deploy/kuma_deploy_global_zone.go
+++ b/test/e2e/deploy/kuma_deploy_global_zone.go
@@ -176,7 +176,8 @@ spec:
 
 		// Deny policy CREATE on zone
 		err := k8s.KubectlApplyFromStringE(c2.GetTesting(), c2.GetKubectlOptions(), policy_update)
-		Expect(err.Error()).To(ContainSubstring("should be only applied on global"))
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("should be only created on global"))
 
 		// Accept policy CREATE on global
 		err = k8s.KubectlApplyFromStringE(c1.GetTesting(), c1.GetKubectlOptions(), policy_create)
@@ -191,7 +192,13 @@ spec:
 
 		// Deny policy UPDATE on zone
 		err = k8s.KubectlApplyFromStringE(c2.GetTesting(), c2.GetKubectlOptions(), policy_update)
-		Expect(err.Error()).To(ContainSubstring("should be only applied on global"))
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("should be only updated on global"))
+
+		// Deny policy DELETE on zone
+		err = k8s.KubectlDeleteFromStringE(c2.GetTesting(),c2.GetKubectlOptions(), policy_create)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("should be only deleted on global"))
 
 		// Accept policy UPDATE on global
 		err = k8s.KubectlApplyFromStringE(c1.GetTesting(), c1.GetKubectlOptions(), policy_update)

--- a/test/e2e/deploy/kuma_deploy_global_zone.go
+++ b/test/e2e/deploy/kuma_deploy_global_zone.go
@@ -196,7 +196,7 @@ spec:
 		Expect(err.Error()).To(ContainSubstring("should be only updated on global"))
 
 		// Deny policy DELETE on zone
-		err = k8s.KubectlDeleteFromStringE(c2.GetTesting(),c2.GetKubectlOptions(), policy_create)
+		err = k8s.KubectlDeleteFromStringE(c2.GetTesting(), c2.GetKubectlOptions(), policy_create)
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(ContainSubstring("should be only deleted on global"))
 


### PR DESCRIPTION
### Summary

Webhook didn't check DELETE operations on Zone CP

### Full changelog

* fix webhook for DELETE
* add unit tests
* extend e2e test

### Issues resolved

N/A

### Documentation

N/A

### Testing

- [X] Unit tests
- [X] E2E tests
- [ ] Manual testing on Universal
- [X] Manual testing on Kubernetes 

### Backwards compatibility

- [ ] Add `backport-to-stable` label if the code is backwards compatible. Otherwise, list breaking changes.
