### PR TITLE
chore(*) update envoy to 1.18.4

### DIFF
--- a/test/dockerfiles/Dockerfile.universal
+++ b/test/dockerfiles/Dockerfile.universal
@@ -1,5 +1,5 @@
 # using Envoy's base to copy the Envoy binary
-FROM envoyproxy/envoy:v1.18.3 as envoy
+FROM envoyproxy/envoy:v1.18.4 as envoy
 
 FROM ubuntu:20.04
 

--- a/tools/releases/distros.sh
+++ b/tools/releases/distros.sh
@@ -12,7 +12,7 @@ PULP_HOST="https://api.pulp.konnect-prod.konghq.com"
 PULP_PACKAGE_TYPE="mesh"
 PULP_DIST_NAME="alpine"
 [ -z "$RELEASE_NAME" ] && RELEASE_NAME="kuma"
-ENVOY_VERSION=1.18.3
+ENVOY_VERSION=1.18.4
 [ -z "$KUMA_CONFIG_PATH" ] && KUMA_CONFIG_PATH=pkg/config/app/kuma-cp/kuma-cp.defaults.yaml
 
 function msg_green() {

--- a/tools/releases/dockerfiles/Dockerfile.kuma-dp
+++ b/tools/releases/dockerfiles/Dockerfile.kuma-dp
@@ -1,5 +1,5 @@
 # using Envoy's base to inherit the Envoy binary
-FROM envoyproxy/envoy-alpine:v1.18.3
+FROM envoyproxy/envoy-alpine:v1.18.4
 
 ADD $KUMA_ROOT/build/artifacts-linux-amd64/kuma-dp/kuma-dp /usr/bin
 ADD $KUMA_ROOT/build/artifacts-linux-amd64/coredns/coredns /usr/bin


### PR DESCRIPTION
### Summary

It includes latest security patch for high severity cve: https://nvd.nist.gov/vuln/detail/CVE-2021-32779

### Full changelog

no changelog

### Issues resolved

no issue

### Documentation

no documentation change

### Testing

- [ ] Unit tests
- [ ] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes 

### Backwards compatibility

- [x] Add `backport-to-stable` label if the code is backwards compatible. Otherwise, list breaking changes.
