### PR TITLE
ci(*) add rsync to the kuma-universal container

### DIFF
--- a/test/dockerfiles/Dockerfile.universal
+++ b/test/dockerfiles/Dockerfile.universal
@@ -10,7 +10,19 @@ RUN echo "# use this file to override default configuration of \`kuma-cp\`" > /k
 RUN apt update \
   && apt dist-upgrade -y \
   && DEBIAN_FRONTEND=noninteractive apt-get install -y \
-  tzdata openssh-server curl ncat vim net-tools iptables iproute2 dnsutils tmux strace tcpdump \
+    curl \
+    dnsutils \
+    iproute2 \
+    iptables \
+    ncat \
+    net-tools \
+    openssh-server \
+    rsync \
+    strace \
+    tcpdump \
+    tmux \
+    tzdata \
+    vim \
   && rm -rf /var/lib/apt/lists/*
 
 RUN ssh-keygen -A \


### PR DESCRIPTION
### Summary

rsync is handy for copying binaries into running containers,
so make sure it's already installed.

### Full changelog

N/A

### Issues resolved

N/A

### Documentation

N/A

### Testing

- [x] Unit tests
- [x] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes 

### Backwards compatibility

- [x] Add `backport-to-stable` label if the code is backwards compatible. Otherwise, list breaking changes.
