### PR TITLE
ci(*) initial gateway e2e tests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,7 @@ require (
 	github.com/gruntwork-io/terratest v0.30.15
 	github.com/hoisie/mustache v0.0.0-20160804235033-6375acf62c69
 	github.com/iancoleman/orderedmap v0.2.0
+	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51
 	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/kumahq/kuma/pkg/transparentproxy/istio v0.0.0-00010101000000-000000000000
 	github.com/kumahq/protoc-gen-kumadoc v0.1.7

--- a/go.sum
+++ b/go.sum
@@ -828,6 +828,8 @@ github.com/justinas/alice v1.2.0/go.mod h1:fN5HRH/reO/zrUflLfTN43t3vXvKzvZIENsNE
 github.com/k0kubun/colorstring v0.0.0-20150214042306-9440f1994b88/go.mod h1:3w7q1U84EfirKl04SVQ/s7nPm1ZPhiXd34z40TNz36k=
 github.com/k0kubun/pp v2.3.0+incompatible/go.mod h1:GWse8YhT0p8pT4ir3ZgBbfZild3tgzSScAn6HmfYukg=
 github.com/kardianos/osext v0.0.0-20190222173326-2bc1f35cddc0/go.mod h1:1NbS8ALrpOvjt0rHPNLyCIeMtbizbir8U//inJ+zuB8=
+github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 h1:Z9n2FFNUXsshfwJMBgNA0RU6/i7WVaAegv3PtuIHPMs=
+github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51/go.mod h1:CzGEWj7cYgsdH8dAjBGEr58BoE7ScuLd+fwFZ44+/x8=
 github.com/kelseyhightower/envconfig v1.4.0 h1:Im6hONhd3pLkfDFsbRgu68RDNkGF1r3dvMUtDTo2cv8=
 github.com/kelseyhightower/envconfig v1.4.0/go.mod h1:cccZRl6mQpaq41TPp5QxidR+Sa3axMbJDNb//FQX6Gg=
 github.com/kevinburke/ssh_config v0.0.0-20201106050909-4977a11b4351 h1:DowS9hvgyYSX4TO5NpyC606/Z4SxnNYbT+WX27or6Ck=

--- a/test/e2e/gateway/doc.go
+++ b/test/e2e/gateway/doc.go
@@ -1,0 +1,1 @@
+package gateway

--- a/test/e2e/gateway/gateway_suite_test.go
+++ b/test/e2e/gateway/gateway_suite_test.go
@@ -1,0 +1,11 @@
+package gateway
+
+import (
+	"testing"
+
+	"github.com/kumahq/kuma/pkg/test"
+)
+
+func TestE2EGateway(t *testing.T) {
+	test.RunSpecs(t, "E2E Gateway Suite")
+}

--- a/test/e2e/gateway/gateway_universal_test.go
+++ b/test/e2e/gateway/gateway_universal_test.go
@@ -1,0 +1,174 @@
+package gateway
+
+import (
+	"fmt"
+	"net/url"
+	"path"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	config_core "github.com/kumahq/kuma/pkg/config/core"
+	"github.com/kumahq/kuma/test/e2e/trafficroute/testutil"
+	. "github.com/kumahq/kuma/test/framework"
+)
+
+var _ = Describe("Test Gateway on Universal", GatewayOnUniversal)
+
+func GatewayOnUniversal() {
+	var cluster *UniversalCluster
+	var deployOptsFuncs []DeployOptionsFunc
+
+	EchoServerUniversal := func(name string) InstallFunc {
+		return func(cluster Cluster) error {
+			const service = "echo-service"
+			token, err := cluster.GetKuma().GenerateDpToken("default", service)
+			if err != nil {
+				return err
+			}
+
+			return TestServerUniversal(
+				name,
+				"default",
+				token,
+				WithArgs([]string{"echo", "--instance", "universal"}),
+				WithServiceName(service),
+			)(cluster)
+		}
+	}
+
+	// GatewayClientUniversal runs an empty container that will
+	// function as a client for a gateway.
+	GatewayClientUniversal := func(name string) InstallFunc {
+		return func(cluster Cluster) error {
+			return cluster.DeployApp(WithName(name), WithoutDataplane(), WithVerbose())
+		}
+	}
+
+	GatewayProxyUniversal := func(name string) InstallFunc {
+		return func(cluster Cluster) error {
+			token, err := cluster.GetKuma().GenerateDpToken("default", "edge-gateway")
+			if err != nil {
+				return err
+			}
+
+			dataplaneYaml := `
+type: Dataplane
+mesh: default
+name: {{ name }}
+networking:
+  address:  {{ address }}
+  gateway:
+    type: BUILTIN
+    tags:
+      kuma.io/service: edge-gateway
+`
+			return cluster.DeployApp(WithName(name), WithToken(token), WithYaml(dataplaneYaml), WithVerbose())
+		}
+	}
+
+	BeforeEach(func() {
+		cluster = NewUniversalCluster(NewTestingT(), Kuma1, Silent)
+		Expect(cluster).ToNot(BeNil())
+
+		deployOptsFuncs = KumaUniversalDeployOpts
+
+		Expect(NewClusterSetup().
+			Install(Kuma(config_core.Standalone, deployOptsFuncs...)).
+			Install(GatewayClientUniversal("gateway-client")).
+			Install(EchoServerUniversal("echo-server")).
+			Install(GatewayProxyUniversal("gateway-proxy")).
+			Setup(cluster),
+		).To(Succeed())
+
+		Expect(cluster.VerifyKuma()).To(Succeed())
+
+		// XXX For how the default traffic route make the gateway
+		// generate invalid clusters. Remove this once the gateway
+		// safely ignores this.
+		Expect(
+			cluster.GetKumactlOptions().KumactlDelete("traffic-route", "route-all-default", "default"),
+		).To(Succeed())
+
+		// Synchronize on the dataplanes coming up.
+		Eventually(func(g Gomega) {
+			dataplanes, err := cluster.GetKumactlOptions().KumactlList("dataplanes", "default")
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(dataplanes).Should(ContainElements("echo-server", "gateway-proxy"))
+		}, "600s", "1s").Should(Succeed())
+	})
+
+	E2EAfterEach(func() {
+		err := cluster.DeleteKuma(deployOptsFuncs...)
+		Expect(err).ToNot(HaveOccurred())
+
+		err = cluster.DismissCluster()
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	It("should proxy simple HTTP requests", func() {
+		Expect(
+			cluster.GetKumactlOptions().KumactlApplyFromString(`
+type: Gateway
+mesh: default
+name: edge-gateway
+sources:
+- match:
+    kuma.io/service: edge-gateway
+conf:
+  listeners:
+  - port: 8080
+    protocol: HTTP
+    hostname: example.kuma.io
+    tags:
+      hostname: example.kuma.io
+`),
+		).To(Succeed())
+
+		Expect(
+			cluster.GetKumactlOptions().KumactlApplyFromString(`
+type: TrafficRoute
+mesh: default
+name: edge-gateway
+sources:
+- match:
+    kuma.io/service: edge-gateway
+destinations:
+- match:
+    kuma.io/service: '*'
+conf:
+  http:
+  - match:
+      path:
+        prefix: /
+    destination:
+      kuma.io/service: echo-service
+  destination:
+    kuma.io/service: echo-service
+`),
+		).To(Succeed())
+
+		Expect(
+			cluster.GetKumactlOptions().KumactlList("gateways", "default"),
+		).To(ContainElement("edge-gateway"))
+
+		gateways, err := cluster.GetKumactlOptions().KumactlList("gateways", "default")
+		Expect(err).To(Succeed())
+		Expect(gateways).To(ContainElement("edge-gateway"))
+
+		Eventually(func(g Gomega) {
+			p := path.Join("test", url.PathEscape(GinkgoT().Name()))
+			target := fmt.Sprintf("http://%s:8080/%s",
+				cluster.GetApp("gateway-proxy").GetIP(), p)
+
+			response, err := testutil.CollectResponse(
+				cluster, "gateway-client", target,
+				testutil.WithHeader("Host", "example.kuma.io"),
+			)
+
+			g.Expect(err).To(Succeed())
+			g.Expect(response.Instance).To(Equal("universal"))
+			g.Expect(response.Received.Headers["Host"]).To(ContainElement("example.kuma.io"))
+		}, "30s", "1s").Should(Succeed())
+	})
+}

--- a/test/framework/interface.go
+++ b/test/framework/interface.go
@@ -56,9 +56,27 @@ type deployOptions struct {
 	mesh            string
 	dpVersion       string
 	kumactlFlow     bool
+	omitDataplane   bool
+	verbose         *bool
 }
 
 type DeployOptionsFunc func(*deployOptions)
+
+// WithoutDataplane suppresses the automatic configuration of kuma-dp
+// in the application container. This is useful when the test requires a
+// container that is not bound to the mesh.
+func WithoutDataplane() DeployOptionsFunc {
+	return func(o *deployOptions) {
+		o.omitDataplane = true
+	}
+}
+
+func WithVerbose() DeployOptionsFunc {
+	return func(o *deployOptions) {
+		enabled := true
+		o.verbose = &enabled
+	}
+}
 
 func WithPostgres(envVars map[string]string) DeployOptionsFunc {
 	return func(o *deployOptions) {
@@ -333,6 +351,6 @@ type ControlPlane interface {
 	GetMetrics() (string, error)
 	GetKDSServerAddress() string
 	GetGlobaStatusAPI() string
-	GenerateDpToken(mesh, appname string) (string, error)
+	GenerateDpToken(mesh, serviceName string) (string, error)
 	GenerateZoneIngressToken(zone string) (string, error)
 }

--- a/test/framework/setup.go
+++ b/test/framework/setup.go
@@ -446,7 +446,7 @@ networking:
 			WithName(name),
 			WithMesh(mesh),
 			WithAppname("test-server"),
-			WithTransparentProxy(true), // test server is always ment to use with transparent proxy
+			WithTransparentProxy(true), // test server is always meant to be used with transparent proxy
 			WithToken(token),
 			WithArgs(args),
 			WithYaml(appYaml),

--- a/test/framework/testing.go
+++ b/test/framework/testing.go
@@ -1,6 +1,7 @@
 package framework
 
 import (
+	"github.com/gruntwork-io/terratest/modules/logger"
 	"github.com/onsi/ginkgo"
 )
 
@@ -19,4 +20,9 @@ func (i *TestingT) Helper() {
 
 func (i *TestingT) Name() string {
 	return i.desc.FullTestText
+}
+
+// Logf logs a test progress message.
+func Logf(format string, args ...interface{}) {
+	logger.Default.Logf(ginkgo.GinkgoT(), format, args...)
 }

--- a/test/framework/universal_cluster.go
+++ b/test/framework/universal_cluster.go
@@ -197,6 +197,10 @@ func (c *UniversalCluster) DeployApp(fs ...DeployOptionsFunc) error {
 	transparent := opts.transparent
 	args := opts.appArgs
 
+	if opts.verbose == nil {
+		opts.verbose = &c.verbose
+	}
+
 	if opts.mesh == "" {
 		opts.mesh = "default"
 	}
@@ -206,48 +210,48 @@ func (c *UniversalCluster) DeployApp(fs ...DeployOptionsFunc) error {
 		caps = append(caps, "NET_ADMIN", "NET_RAW")
 	}
 
-	fmt.Printf("IPV6 is %v\n", opts.isipv6)
-	app, err := NewUniversalApp(c.t, c.name, opts.name, AppMode(appname), opts.isipv6, c.verbose, caps)
+	Logf("IPV6 is %v\n", opts.isipv6)
+	app, err := NewUniversalApp(c.t, c.name, opts.name, AppMode(appname), opts.isipv6, *opts.verbose, caps)
 	if err != nil {
 		return err
 	}
 
-	if opts.kumactlFlow {
-		dataplaneResource := template.Render(opts.appYaml, map[string]string{
-			"name":    opts.name,
-			"address": app.ip,
-		})
-		err := c.GetKumactlOptions().KumactlApplyFromString(string(dataplaneResource))
+	if !opts.omitDataplane {
+		if opts.kumactlFlow {
+			dataplaneResource := template.Render(opts.appYaml, map[string]string{
+				"name":    opts.name,
+				"address": app.ip,
+			})
+			err := c.GetKumactlOptions().KumactlApplyFromString(string(dataplaneResource))
+			if err != nil {
+				return err
+			}
+		}
+
+		if opts.dpVersion != "" {
+			// override needs to be before setting up transparent proxy.
+			// Otherwise, we won't be able to fetch specific Kuma DP version.
+			if err := app.OverrideDpVersion(opts.dpVersion); err != nil {
+				return err
+			}
+		}
+
+		builtindns := opts.builtindns == nil || *opts.builtindns
+		if transparent {
+			app.setupTransparent(c.apps[AppModeCP].ip, builtindns)
+		}
+
+		var dataplaneResource string
+		if opts.kumactlFlow {
+			dataplaneResource = ""
+		} else {
+			dataplaneResource = opts.appYaml
+		}
+
+		err = c.CreateDP(app, opts.name, opts.mesh, app.ip, dataplaneResource, token, builtindns)
 		if err != nil {
 			return err
 		}
-	}
-
-	if opts.dpVersion != "" {
-		// override needs to be before setting up transparent proxy.
-		// Otherwise, we won't be able to fetch specific Kuma DP version.
-		if err := app.OverrideDpVersion(opts.dpVersion); err != nil {
-			return err
-		}
-	}
-
-	builtindns := opts.builtindns == nil || *opts.builtindns
-	if transparent {
-		app.setupTransparent(c.apps[AppModeCP].ip, builtindns)
-	}
-
-	ip := app.ip
-
-	var dataplaneResource string
-	if opts.kumactlFlow {
-		dataplaneResource = ""
-	} else {
-		dataplaneResource = opts.appYaml
-	}
-
-	err = c.CreateDP(app, opts.name, opts.mesh, ip, dataplaneResource, token, builtindns)
-	if err != nil {
-		return err
 	}
 
 	if !opts.proxyOnly {
@@ -258,6 +262,7 @@ func (c *UniversalCluster) DeployApp(fs ...DeployOptionsFunc) error {
 		}
 	}
 
+	Logf("Started universal app %q in container %q", opts.name, app.container)
 	c.apps[opts.name] = app
 
 	return nil


### PR DESCRIPTION
Signed-off-by: James Peach <james.peach@konghq.com>

### Summary

SUMMARY_GOES_HERE

### Full changelog

* [Implement ...]
* [Fix ...]

### Issues resolved

Fix #XXX

### Documentation

- [ ] Link to the website [documentation PR](https://github.com/kumahq/kuma-website/pull/XXX)

### Testing

- [ ] Unit tests
- [ ] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes 

### Backwards compatibility

- [ ] Add `backport-to-stable` label if the code is backwards compatible. Otherwise, list breaking changes.
