### PR TITLE
fix(ci) docker-images path fix for images-kumactl

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1036,7 +1036,7 @@ jobs:
     - persist_to_workspace:
         root: build
         paths:
-        - docker
+        - docker-images
 
   example_docker-compose:
     executor: vm


### PR DESCRIPTION
### Summary

docker-images path fix for images-kumactl

### Full changelog

no changelog

### Issues resolved

no issues resolved

### Documentation

no documentation

### Testing

- [ ] Unit tests
- [ ] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes 

### Backwards compatibility

- [x] Add `backport-to-stable` label if the code is backwards compatible. Otherwise, list breaking changes.
