### PR TITLE
fix(kuma-cp) get rid of regex for parsing IPs

### DIFF
--- a/test/e2e/mtls/permissive/e2e_suite_test.go
+++ b/test/e2e/mtls/permissive/e2e_suite_test.go
@@ -1,4 +1,4 @@
-package mtls_test
+package permissive_test
 
 import (
 	"testing"
@@ -7,9 +7,9 @@ import (
 	"github.com/kumahq/kuma/test/framework"
 )
 
-func TestE2EMTLS(t *testing.T) {
+func TestE2EMTLSPermissive(t *testing.T) {
 	if framework.IsK8sClustersStarted() {
-		test.RunSpecs(t, "MTLS tests")
+		test.RunSpecs(t, "mTLS Permissive Suite")
 	} else {
 		t.SkipNow()
 	}

--- a/test/e2e/mtls/permissive/permissive_mode_test.go
+++ b/test/e2e/mtls/permissive/permissive_mode_test.go
@@ -1,0 +1,9 @@
+package permissive_test
+
+import (
+	. "github.com/onsi/ginkgo"
+
+	"github.com/kumahq/kuma/test/e2e/mtls/permissive"
+)
+
+var _ = Describe("Test Permissive mTLS", permissive.PermissiveMode)

--- a/test/e2e/mtls/standalone_universal_test.go
+++ b/test/e2e/mtls/standalone_universal_test.go
@@ -1,9 +1,0 @@
-package mtls_test
-
-import (
-	. "github.com/onsi/ginkgo"
-
-	"github.com/kumahq/kuma/test/e2e/mtls"
-)
-
-var _ = Describe("Test Standalone mTLS for Universal", mtls.StandaloneUniversal)

--- a/test/framework/universal_app.go
+++ b/test/framework/universal_app.go
@@ -273,6 +273,10 @@ func (s *UniversalApp) GetPublicPort(port string) string {
 	return s.ports[port]
 }
 
+func (s *UniversalApp) GetIP() string {
+	return s.ip
+}
+
 func (s *UniversalApp) Stop() error {
 	out, err := docker.StopE(s.t, []string{s.container}, &docker.StopOptions{Time: 1})
 	if err != nil {


### PR DESCRIPTION
### Summary

Why parse IPs if we already have them in UniversalApp. This should fix permissive mTLS tests for ipv6, but I wasn't able to run IPv6 tests on Docker for Mac. 

### Full changelog

* move tests to separate suite, otherwise it's not possible to focus a specific test
* get rid of parsing using regex

### Issues resolved

N/A

### Documentation

N/A

### Testing

- [ ] Unit tests
- [ ] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes 

### Backwards compatibility

- [ ] Add `backport-to-stable` label if the code is backwards compatible. Otherwise, list breaking changes.
