### PR TITLE
fix(tests) permissive mTLS for IPv6

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1293,11 +1293,14 @@ workflows:
           - images
           - check
 # keep this one disabled and enable only for development
-#    - e2e:
-#        <<: *commit_workflow_filters
-#        name: test/e2e-ipv6
-#        # custom parameters
-#        ipv6: true
+    - e2e:
+        <<: *commit_workflow_filters
+        name: test/e2e-ipv6
+        requires:
+          - images
+          - check
+        # custom parameters
+        ipv6: true
 
   clean-eks:
     when: << pipeline.parameters.run_workflow_clean_eks >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1293,14 +1293,11 @@ workflows:
           - images
           - check
 # keep this one disabled and enable only for development
-    - e2e:
-        <<: *commit_workflow_filters
-        name: test/e2e-ipv6
-        requires:
-          - images
-          - check
-        # custom parameters
-        ipv6: true
+#    - e2e:
+#        <<: *commit_workflow_filters
+#        name: test/e2e-ipv6
+#        # custom parameters
+#        ipv6: true
 
   clean-eks:
     when: << pipeline.parameters.run_workflow_clean_eks >>

--- a/test/e2e/mtls/permissive/permissive_mode.go
+++ b/test/e2e/mtls/permissive/permissive_mode.go
@@ -2,6 +2,7 @@ package permissive
 
 import (
 	"fmt"
+	"net"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -75,7 +76,7 @@ mtls:
 		}, "30s", "1s").ShouldNot(HaveOccurred())
 
 		// check the outside-mesh communication (using direct IP:PORT allows bypassing outbound listeners)
-		addr := fmt.Sprintf("%s:%d", universal.(*UniversalCluster).GetApp("test-server").GetIP(), 80)
+		addr := net.JoinHostPort(universal.(*UniversalCluster).GetApp("test-server").GetIP(), "80")
 		Eventually(func() error {
 			_, _, err := universal.Exec("", "", "demo-client", "curl", "-v", "-m", "3", "--fail", addr)
 			return err
@@ -96,7 +97,7 @@ mtls:
 		}, "30s", "1s").ShouldNot(HaveOccurred())
 
 		// check the outside-mesh communication (using direct IP:PORT allows bypassing outbound listeners)
-		addr := fmt.Sprintf("%s:%d", universal.(*UniversalCluster).GetApp("test-server").GetIP(), 80)
+		addr := net.JoinHostPort(universal.(*UniversalCluster).GetApp("test-server").GetIP(), "80")
 		Eventually(func() error {
 			_, _, err := universal.Exec("", "", "demo-client", "curl", "-v", "-m", "3", "--fail", addr)
 			return err
@@ -135,7 +136,7 @@ mtls:
 		// we're using curl with '--resolve' flag to verify certificate Common Name 'test-server.mesh'
 		host := universal.(*UniversalCluster).GetApp("test-server").GetIP()
 		Eventually(func() error {
-			cmd := []string{"curl", "-v", "-m", "3", "--resolve", fmt.Sprintf("test-server.mesh:80:%s", host), "--fail", "--cacert", "/kuma/server.crt", "https://test-server.mesh:80"}
+			cmd := []string{"curl", "-v", "-m", "3", "--resolve", fmt.Sprintf("test-server.mesh:80:[%s]", host), "--fail", "--cacert", "/kuma/server.crt", "https://test-server.mesh:80"}
 			_, _, err := universal.Exec("", "", "demo-client", cmd...)
 			return err
 		}, "30s", "1s").ShouldNot(HaveOccurred())


### PR DESCRIPTION
### Summary

Properly join host and port, important for IPv6 

### Full changelog

* [Implement ...]
* [Fix ...]

### Issues resolved

Fix #XXX

### Documentation

- [ ] Link to the website [documentation PR](https://github.com/kumahq/kuma-website/pull/XXX)

### Testing

- [ ] Unit tests
- [ ] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes 

### Backwards compatibility

- [ ] Add `backport-to-stable` label if the code is backwards compatible. Otherwise, list breaking changes.
