### PR TITLE
fix(kuma-cp) virtual probes with query

### DIFF
--- a/pkg/xds/generator/probe_generator.go
+++ b/pkg/xds/generator/probe_generator.go
@@ -1,6 +1,8 @@
 package generator
 
 import (
+	"net/url"
+
 	"github.com/pkg/errors"
 
 	model "github.com/kumahq/kuma/pkg/core/xds"
@@ -33,16 +35,24 @@ func (g ProbeProxyGenerator) Generate(ctx xds_context.Context, proxy *model.Prox
 		portSet[proxy.Dataplane.Spec.Networking.ToInboundInterface(inbound).WorkloadPort] = true
 	}
 	for _, endpoint := range probes.Endpoints {
+		matchURL, err := url.Parse(endpoint.Path)
+		if err != nil {
+			return nil, err
+		}
+		newURL, err := url.Parse(endpoint.InboundPath)
+		if err != nil {
+			return nil, err
+		}
 		if portSet[endpoint.InboundPort] {
 			virtualHostBuilder.Configure(
-				envoy_routes.Route(endpoint.Path, endpoint.InboundPath, names.GetLocalClusterName(endpoint.InboundPort), true))
+				envoy_routes.Route(matchURL.Path, newURL.Path, names.GetLocalClusterName(endpoint.InboundPort), true))
 		} else {
 			// On Kubernetes we are overriding probes for every container, but there is no guarantee that given
 			// probe will have an equivalent in inbound interface (ex. sidecar that is not selected by any service).
 			// In this situation there is no local cluster therefore we are sending redirect to a real destination.
 			// System responsible for using virtual probes needs to support redirect (kubelet on K8S supports it).
 			virtualHostBuilder.Configure(
-				envoy_routes.Redirect(endpoint.Path, endpoint.InboundPath, true, endpoint.InboundPort))
+				envoy_routes.Redirect(matchURL.Path, newURL.Path, true, endpoint.InboundPort))
 		}
 	}
 

--- a/pkg/xds/generator/probe_generator_test.go
+++ b/pkg/xds/generator/probe_generator_test.go
@@ -90,5 +90,19 @@ var _ = Describe("ProbeGenerator", func() {
 `,
 			expected: "03.envoy.golden.yaml",
 		}),
+		Entry("http probes with queries", testCase{
+			dataplane: `
+            networking:
+              inbound:
+              - port: 8080
+            probes:
+              port: 9000
+              endpoints:
+              - inboundPort: 8080
+                inboundPath: /healthz/probe?param1=value1&param2=value2
+                path: /8080/healthz/probe?param1=value1&param2=value2
+`,
+			expected: "04.envoy.golden.yaml",
+		}),
 	)
 })

--- a/pkg/xds/generator/testdata/probe/04.envoy.golden.yaml
+++ b/pkg/xds/generator/testdata/probe/04.envoy.golden.yaml
@@ -1,0 +1,35 @@
+resources:
+- name: probe:listener
+  resource:
+    '@type': type.googleapis.com/envoy.config.listener.v3.Listener
+    address:
+      socketAddress:
+        portValue: 9000
+    filterChains:
+    - filters:
+      - name: envoy.filters.network.http_connection_manager
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+          httpFilters:
+          - name: envoy.filters.http.router
+          routeConfig:
+            virtualHosts:
+            - domains:
+              - '*'
+              name: probe
+              routes:
+              - match:
+                  headers:
+                  - exactMatch: GET
+                    name: :method
+                  path: /8080/healthz/probe
+                route:
+                  cluster: localhost:8080
+                  regexRewrite:
+                    pattern:
+                      googleRe2: {}
+                      regex: .*
+                    substitution: /healthz/probe
+          statPrefix: probe_listener
+    name: probe:listener
+    trafficDirection: INBOUND

--- a/test/e2e/healthcheck/kubernetes/e2e_suite_test.go
+++ b/test/e2e/healthcheck/kubernetes/e2e_suite_test.go
@@ -1,0 +1,16 @@
+package kubernetes_test
+
+import (
+	"testing"
+
+	"github.com/kumahq/kuma/pkg/test"
+	"github.com/kumahq/kuma/test/framework"
+)
+
+func TestE2EHealthCheckKubernetes(t *testing.T) {
+	if framework.IsK8sClustersStarted() {
+		test.RunSpecs(t, "Health Check Kubernetes Suite")
+	} else {
+		t.SkipNow()
+	}
+}

--- a/test/e2e/healthcheck/kubernetes/healthcheck_kubernetes_test.go
+++ b/test/e2e/healthcheck/kubernetes/healthcheck_kubernetes_test.go
@@ -1,0 +1,9 @@
+package kubernetes_test
+
+import (
+	. "github.com/onsi/ginkgo"
+
+	"github.com/kumahq/kuma/test/e2e/healthcheck/kubernetes"
+)
+
+var _ = Describe("Test Virtual Probes on Kubernetes", kubernetes.VirtualProbes)

--- a/test/e2e/healthcheck/kubernetes/virtual_probes.go
+++ b/test/e2e/healthcheck/kubernetes/virtual_probes.go
@@ -15,7 +15,6 @@ import (
 )
 
 func VirtualProbes() {
-
 	namespaceWithSidecarInjection := func(namespace string) string {
 		return fmt.Sprintf(`
 apiVersion: v1

--- a/test/e2e/healthcheck/kubernetes/virtual_probes.go
+++ b/test/e2e/healthcheck/kubernetes/virtual_probes.go
@@ -55,10 +55,7 @@ func VirtualProbes() {
 	}
 
 	It("should deploy test-server with probes", func() {
-		Expect(testserver.Install(
-			testserver.WithArgs("--probes"),
-			testserver.WithHTTPProbes(),
-		)(k8sCluster)).To(Succeed())
+		Expect(testserver.Install()(k8sCluster)).To(Succeed())
 
 		for i := 0; i < 10; i++ {
 			time.Sleep(1 * time.Second)

--- a/test/e2e/healthcheck/kubernetes/virtual_probes.go
+++ b/test/e2e/healthcheck/kubernetes/virtual_probes.go
@@ -1,0 +1,82 @@
+package kubernetes
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/gruntwork-io/terratest/modules/k8s"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	config_core "github.com/kumahq/kuma/pkg/config/core"
+	. "github.com/kumahq/kuma/test/framework"
+	"github.com/kumahq/kuma/test/framework/deployments/testserver"
+)
+
+func VirtualProbes() {
+
+	namespaceWithSidecarInjection := func(namespace string) string {
+		return fmt.Sprintf(`
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: %s
+  annotations:
+    kuma.io/sidecar-injection: "enabled"
+`, namespace)
+	}
+
+	var k8sCluster Cluster
+	var optsKubernetes = KumaK8sDeployOpts
+
+	E2EBeforeSuite(func() {
+		k8sClusters, err := NewK8sClusters([]string{Kuma1}, Silent)
+		Expect(err).ToNot(HaveOccurred())
+
+		k8sCluster = k8sClusters.GetCluster(Kuma1)
+
+		Expect(Kuma(config_core.Standalone, optsKubernetes...)(k8sCluster)).To(Succeed())
+		Expect(YamlK8s(namespaceWithSidecarInjection(TestNamespace))(k8sCluster)).To(Succeed())
+		Expect(k8sCluster.VerifyKuma()).To(Succeed())
+	})
+
+	E2EAfterSuite(func() {
+		Expect(k8sCluster.DeleteNamespace(TestNamespace)).To(Succeed())
+		Expect(k8sCluster.DeleteKuma(optsKubernetes...)).To(Succeed())
+		Expect(k8sCluster.DismissCluster()).To(Succeed())
+	})
+
+	testServerReady := func() bool {
+		output, err := k8s.RunKubectlAndGetOutputE(k8sCluster.GetTesting(), k8sCluster.GetKubectlOptions(TestNamespace), "get", "pods")
+		if err != nil {
+			return false
+		}
+		lines := strings.Split(output, "\n")
+		if len(lines) != 2 {
+			return false
+		}
+		// 0:NAME 1:READY 2:STATUS 3:RESTARTS 4:AGE
+		words := strings.Fields(lines[1])
+		if len(words) != 5 {
+			return false
+		}
+		if words[1] == "2/2" && words[2] == "Running" && words[3] == "0" {
+			return true
+		}
+		return false
+	}
+
+	It("should deploy test-server with probes", func() {
+		Expect(testserver.Install(
+			testserver.WithArgs("--probes"),
+			testserver.WithHTTPProbes(),
+		)(k8sCluster)).To(Succeed())
+		Eventually(testServerReady, "5s", "100ms").Should(BeTrue())
+
+		for i := 0; i < 10; i++ {
+			time.Sleep(1 * time.Second)
+			Expect(testServerReady()).To(BeTrue())
+		}
+	})
+}

--- a/test/e2e/healthcheck/kubernetes/virtual_probes.go
+++ b/test/e2e/healthcheck/kubernetes/virtual_probes.go
@@ -59,7 +59,6 @@ func VirtualProbes() {
 			testserver.WithArgs("--probes"),
 			testserver.WithHTTPProbes(),
 		)(k8sCluster)).To(Succeed())
-		Eventually(testServerReady, "5s", "100ms").Should(BeTrue())
 
 		for i := 0; i < 10; i++ {
 			time.Sleep(1 * time.Second)

--- a/test/e2e/healthcheck/kubernetes/virtual_probes.go
+++ b/test/e2e/healthcheck/kubernetes/virtual_probes.go
@@ -1,7 +1,6 @@
 package kubernetes
 
 import (
-	"fmt"
 	"strings"
 	"time"
 
@@ -15,17 +14,6 @@ import (
 )
 
 func VirtualProbes() {
-	namespaceWithSidecarInjection := func(namespace string) string {
-		return fmt.Sprintf(`
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: %s
-  annotations:
-    kuma.io/sidecar-injection: "enabled"
-`, namespace)
-	}
-
 	var k8sCluster Cluster
 	var optsKubernetes = KumaK8sDeployOpts
 
@@ -36,7 +24,7 @@ metadata:
 		k8sCluster = k8sClusters.GetCluster(Kuma1)
 
 		Expect(Kuma(config_core.Standalone, optsKubernetes...)(k8sCluster)).To(Succeed())
-		Expect(YamlK8s(namespaceWithSidecarInjection(TestNamespace))(k8sCluster)).To(Succeed())
+		Expect(NamespaceWithSidecarInjection(TestNamespace)(k8sCluster)).To(Succeed())
 		Expect(k8sCluster.VerifyKuma()).To(Succeed())
 	})
 

--- a/test/framework/deployments/testserver/deployment.go
+++ b/test/framework/deployments/testserver/deployment.go
@@ -12,6 +12,7 @@ type DeploymentOpts struct {
 	Mesh            string
 	WithStatefulSet bool
 	Args            []string
+	WithHTTPProbes  bool
 	Replicas        int32
 }
 
@@ -60,6 +61,12 @@ func WithStatefulSet(apply bool) DeploymentOptsFn {
 func WithArgs(args ...string) DeploymentOptsFn {
 	return func(opts *DeploymentOpts) {
 		opts.Args = args
+	}
+}
+
+func WithHTTPProbes() DeploymentOptsFn {
+	return func(opts *DeploymentOpts) {
+		opts.WithHTTPProbes = true
 	}
 }
 

--- a/test/framework/deployments/testserver/deployment.go
+++ b/test/framework/deployments/testserver/deployment.go
@@ -12,7 +12,6 @@ type DeploymentOpts struct {
 	Mesh            string
 	WithStatefulSet bool
 	Args            []string
-	WithHTTPProbes  bool
 	Replicas        int32
 }
 
@@ -61,12 +60,6 @@ func WithStatefulSet(apply bool) DeploymentOptsFn {
 func WithArgs(args ...string) DeploymentOptsFn {
 	return func(opts *DeploymentOpts) {
 		opts.Args = args
-	}
-}
-
-func WithHTTPProbes() DeploymentOptsFn {
-	return func(opts *DeploymentOpts) {
-		opts.WithHTTPProbes = true
 	}
 }
 

--- a/test/framework/deployments/testserver/kubernetes.go
+++ b/test/framework/deployments/testserver/kubernetes.go
@@ -42,7 +42,7 @@ func (k *k8SDeployment) service() *corev1.Service {
 	}
 }
 
-func (k *k8SDeployment) deployment(probes bool) *appsv1.Deployment {
+func (k *k8SDeployment) deployment() *appsv1.Deployment {
 	return &appsv1.Deployment{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Deployment",
@@ -60,12 +60,12 @@ func (k *k8SDeployment) deployment(probes bool) *appsv1.Deployment {
 					MaxUnavailable: &intstr.IntOrString{Type: intstr.Int, IntVal: 0},
 				},
 			},
-			Template: k.podSpec(probes),
+			Template: k.podSpec(),
 		},
 	}
 }
 
-func (k *k8SDeployment) statefulSet(probes bool) *appsv1.StatefulSet {
+func (k *k8SDeployment) statefulSet() *appsv1.StatefulSet {
 	return &appsv1.StatefulSet{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "StatefulSet",
@@ -78,42 +78,12 @@ func (k *k8SDeployment) statefulSet(probes bool) *appsv1.StatefulSet {
 			Selector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{"app": k.Name()},
 			},
-			Template: k.podSpec(probes),
+			Template: k.podSpec(),
 		},
 	}
 }
 
-func (k *k8SDeployment) podSpec(probes bool) corev1.PodTemplateSpec {
-	readiness := &corev1.Probe{
-		Handler: corev1.Handler{
-			HTTPGet: &corev1.HTTPGetAction{Path: "/", Port: intstr.FromInt(80)},
-		},
-		InitialDelaySeconds: 3,
-		PeriodSeconds:       3,
-	}
-	var liveness *corev1.Probe
-	if probes {
-		readiness = &corev1.Probe{
-			Handler: corev1.Handler{
-				HTTPGet: &corev1.HTTPGetAction{
-					Path: `/probes?type=readiness`,
-					Port: intstr.FromInt(80),
-				},
-			},
-			InitialDelaySeconds: 3,
-			PeriodSeconds:       3,
-		}
-		liveness = &corev1.Probe{
-			Handler: corev1.Handler{
-				HTTPGet: &corev1.HTTPGetAction{
-					Path: `/probes?type=liveness`,
-					Port: intstr.FromInt(80),
-				},
-			},
-			InitialDelaySeconds: 3,
-			PeriodSeconds:       3,
-		}
-	}
+func (k *k8SDeployment) podSpec() corev1.PodTemplateSpec {
 	return corev1.PodTemplateSpec{
 		ObjectMeta: metav1.ObjectMeta{
 			Labels:      map[string]string{"app": k.Name()},
@@ -124,14 +94,32 @@ func (k *k8SDeployment) podSpec(probes bool) corev1.PodTemplateSpec {
 				{
 					Name:            k.Name(),
 					ImagePullPolicy: "IfNotPresent",
-					ReadinessProbe:  readiness,
-					LivenessProbe:   liveness,
-					Image:           framework.GetUniversalImage(),
+					ReadinessProbe: &corev1.Probe{
+						Handler: corev1.Handler{
+							HTTPGet: &corev1.HTTPGetAction{
+								Path: `/probes?type=readiness`,
+								Port: intstr.FromInt(80),
+							},
+						},
+						InitialDelaySeconds: 3,
+						PeriodSeconds:       3,
+					},
+					LivenessProbe: &corev1.Probe{
+						Handler: corev1.Handler{
+							HTTPGet: &corev1.HTTPGetAction{
+								Path: `/probes?type=liveness`,
+								Port: intstr.FromInt(80),
+							},
+						},
+						InitialDelaySeconds: 3,
+						PeriodSeconds:       3,
+					},
+					Image: framework.GetUniversalImage(),
 					Ports: []corev1.ContainerPort{
 						{ContainerPort: 80},
 					},
 					Command: []string{"test-server"},
-					Args:    append([]string{"echo", "--port", "80"}, k.opts.Args...),
+					Args:    append([]string{"echo", "--port", "80", "--probes"}, k.opts.Args...),
 					Resources: corev1.ResourceRequirements{
 						Limits: corev1.ResourceList{
 							"cpu":    resource.MustParse("500m"),
@@ -155,9 +143,9 @@ func meta(namespace string, name string) metav1.ObjectMeta {
 func (k *k8SDeployment) Deploy(cluster framework.Cluster) error {
 	var deplYaml framework.InstallFunc
 	if k.opts.WithStatefulSet {
-		deplYaml = framework.YamlK8sObject(k.statefulSet(k.opts.WithHTTPProbes))
+		deplYaml = framework.YamlK8sObject(k.statefulSet())
 	} else {
-		deplYaml = framework.YamlK8sObject(k.deployment(k.opts.WithHTTPProbes))
+		deplYaml = framework.YamlK8sObject(k.deployment())
 	}
 	fn := framework.Combine(
 		framework.YamlK8sObject(k.service()),


### PR DESCRIPTION
### Summary

When configuring readiness or liveness httpGet probes in Kubernetes `path` could consist of `path + query`, but when configuring `path` for Envoy route matching it's strictly only `path` (without `query`). That's why for probes with `query` matching didn't work properly.

### Full changelog

* Fix Envoy configuration
* Add e2e test

### Issues resolved

N/A

### Documentation

N/A

### Testing

- [X] Unit tests
- [X] E2E tests
- [ ] Manual testing on Universal
- [X] Manual testing on Kubernetes 

### Backwards compatibility

- [x] Add `backport-to-stable` label if the code is backwards compatible. Otherwise, list breaking changes.
