### PR TITLE
fix(ci) set logger names for KDS tests machinery

### DIFF
--- a/pkg/kds/zone/components_test.go
+++ b/pkg/kds/zone/components_test.go
@@ -45,7 +45,7 @@ var _ = Describe("Zone Sync", func() {
 	zoneName := "zone-1"
 
 	newPolicySink := func(zoneName string, resourceSyncer sync_store.ResourceSyncer, cs *grpc.MockClientStream, rt core_runtime.Runtime) component.Component {
-		return kds_client.NewKDSSink(core.Log, registry.Global().ObjectTypes(model.HasKDSFlag(model.ConsumedByZone)), kds_client.NewKDSStream(cs, zoneName, ""), zone.Callbacks(rt, resourceSyncer, false, zoneName, nil))
+		return kds_client.NewKDSSink(core.Log.WithName("kds-sink"), registry.Global().ObjectTypes(model.HasKDSFlag(model.ConsumedByZone)), kds_client.NewKDSStream(cs, zoneName, ""), zone.Callbacks(rt, resourceSyncer, false, zoneName, nil))
 	}
 	start := func(comp component.Component, stop chan struct{}) {
 		go func() {
@@ -92,7 +92,7 @@ var _ = Describe("Zone Sync", func() {
 		clientStream := serverStream.ClientStream(stop)
 
 		zoneStore = memory.NewStore()
-		zoneSyncer = sync_store.NewResourceSyncer(core.Log, zoneStore)
+		zoneSyncer = sync_store.NewResourceSyncer(core.Log.WithName("kds-syncer"), zoneStore)
 
 		start(newPolicySink(zoneName, zoneSyncer, clientStream, &testRuntimeContext{kds: kdsCtx}), stop)
 		closeFunc = func() {

--- a/pkg/test/kds/setup/client.go
+++ b/pkg/test/kds/setup/client.go
@@ -13,7 +13,7 @@ func StartClient(clientStreams []*grpc.MockClientStream, resourceTypes []model.R
 	for i := 0; i < len(clientStreams); i++ {
 		clientID := fmt.Sprintf("client-%d", i)
 		item := clientStreams[i]
-		comp := kds_client.NewKDSSink(core.Log.WithName("kds-"+clientID), resourceTypes, kds_client.NewKDSStream(item, clientID, ""), cb)
+		comp := kds_client.NewKDSSink(core.Log.WithName("kds").WithName(clientID), resourceTypes, kds_client.NewKDSStream(item, clientID, ""), cb)
 		go func() {
 			_ = comp.Start(stopCh)
 			_ = item.CloseSend()

--- a/pkg/test/kds/setup/client.go
+++ b/pkg/test/kds/setup/client.go
@@ -1,6 +1,8 @@
 package setup
 
 import (
+	"fmt"
+
 	"github.com/kumahq/kuma/pkg/core"
 	"github.com/kumahq/kuma/pkg/core/resources/model"
 	kds_client "github.com/kumahq/kuma/pkg/kds/client"
@@ -9,8 +11,9 @@ import (
 
 func StartClient(clientStreams []*grpc.MockClientStream, resourceTypes []model.ResourceType, stopCh chan struct{}, cb *kds_client.Callbacks) {
 	for i := 0; i < len(clientStreams); i++ {
+		clientID := fmt.Sprintf("client-%d", i)
 		item := clientStreams[i]
-		comp := kds_client.NewKDSSink(core.Log.Logger, resourceTypes, kds_client.NewKDSStream(item, "client-1", ""), cb)
+		comp := kds_client.NewKDSSink(core.Log.WithName("kds-"+clientID), resourceTypes, kds_client.NewKDSStream(item, clientID, ""), cb)
 		go func() {
 			_ = comp.Start(stopCh)
 			_ = item.CloseSend()

--- a/pkg/test/kds/setup/server.go
+++ b/pkg/test/kds/setup/server.go
@@ -52,7 +52,7 @@ func StartServer(store store.ResourceStore, wg *sync.WaitGroup, clusterID string
 		cfg:     kuma_cp.Config{},
 		metrics: metrics,
 	}
-	srv, err := kds_server.New(core.Log, rt, providedTypes, clusterID, 100*time.Millisecond, providedFilter, false)
+	srv, err := kds_server.New(core.Log.WithName("kds-"+clusterID), rt, providedTypes, clusterID, 100*time.Millisecond, providedFilter, false)
 	Expect(err).ToNot(HaveOccurred())
 	stream := test_grpc.MakeMockStream()
 	go func() {

--- a/pkg/test/kds/setup/server.go
+++ b/pkg/test/kds/setup/server.go
@@ -52,7 +52,7 @@ func StartServer(store store.ResourceStore, wg *sync.WaitGroup, clusterID string
 		cfg:     kuma_cp.Config{},
 		metrics: metrics,
 	}
-	srv, err := kds_server.New(core.Log.WithName("kds-"+clusterID), rt, providedTypes, clusterID, 100*time.Millisecond, providedFilter, false)
+	srv, err := kds_server.New(core.Log.WithName("kds").WithName(clusterID), rt, providedTypes, clusterID, 100*time.Millisecond, providedFilter, false)
 	Expect(err).ToNot(HaveOccurred())
 	stream := test_grpc.MakeMockStream()
 	go func() {


### PR DESCRIPTION
### Summary

When trying to debug KDS tests, it's not very obvious where log
messages are coming from. Make sure to set the logger name on all
the test machinery so that it is easier to find a starting point.

### Full changelog

N/A

### Issues resolved

N/A

### Documentation

N/A

### Testing

- [x] Unit tests
- [x] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes 

### Backwards compatibility

- [x] Add `backport-to-stable` label if the code is backwards compatible. Otherwise, list breaking changes.
