### PR TITLE
tests(*) bump concurrency to have better loadbalancing

### DIFF
--- a/test/framework/interface.go
+++ b/test/framework/interface.go
@@ -56,6 +56,7 @@ type deployOptions struct {
 	mesh            string
 	dpVersion       string
 	kumactlFlow     bool
+	concurrency     int
 }
 
 type DeployOptionsFunc func(*deployOptions)
@@ -268,6 +269,12 @@ func WithTransparentProxy(transparent bool) DeployOptionsFunc {
 func WithBuiltinDNS(builtindns bool) DeployOptionsFunc {
 	return func(o *deployOptions) {
 		o.builtindns = &builtindns
+	}
+}
+
+func WithConcurrency(concurrency int) DeployOptionsFunc {
+	return func(o *deployOptions) {
+		o.concurrency = concurrency
 	}
 }
 

--- a/test/framework/setup.go
+++ b/test/framework/setup.go
@@ -228,30 +228,6 @@ func WaitPodsNotAvailable(namespace, app string) InstallFunc {
 	}
 }
 
-func IngressUniversalOldType(mesh, token string) InstallFunc {
-	return func(cluster Cluster) error {
-		uniCluster := cluster.(*UniversalCluster)
-		isipv6 := IsIPv6()
-		verbose := false
-		app, err := NewUniversalApp(cluster.GetTesting(), uniCluster.name, AppIngress, AppIngress, isipv6, verbose, []string{})
-		if err != nil {
-			return err
-		}
-
-		app.CreateMainApp([]string{}, []string{})
-
-		err = app.mainApp.Start()
-		if err != nil {
-			return err
-		}
-		uniCluster.apps[AppIngress] = app
-
-		publicAddress := uniCluster.apps[AppIngress].ip
-		dpyaml := fmt.Sprintf(IngressDataplaneOldType, mesh, publicAddress, kdsPort, kdsPort)
-		return uniCluster.CreateDP(app, "ingress", mesh, app.ip, dpyaml, token, false)
-	}
-}
-
 func IngressUniversal(token string) InstallFunc {
 	return func(cluster Cluster) error {
 		uniCluster := cluster.(*UniversalCluster)

--- a/test/framework/universal_app.go
+++ b/test/framework/universal_app.go
@@ -370,7 +370,7 @@ func (s *UniversalApp) OverrideDpVersion(version string) error {
 	return nil
 }
 
-func (s *UniversalApp) CreateDP(token, cpAddress, name, mesh, ip, dpyaml string, builtindns, ingress bool) {
+func (s *UniversalApp) CreateDP(token, cpAddress, name, mesh, ip, dpyaml string, builtindns, ingress bool, concurrency int) {
 	// create the token file on the app container
 	err := NewSshApp(s.verbose, s.ports[sshPort], []string{}, []string{"printf ", "\"" + token + "\"", ">", "/kuma/token-" + name}).Run()
 	if err != nil {
@@ -399,6 +399,10 @@ func (s *UniversalApp) CreateDP(token, cpAddress, name, mesh, ip, dpyaml string,
 		args = append(args,
 			"--name="+name,
 			"--mesh="+mesh)
+	}
+
+	if concurrency > 0 {
+		args = append(args, "--concurrency", strconv.Itoa(concurrency))
 	}
 
 	if builtindns {

--- a/test/framework/universal_cluster.go
+++ b/test/framework/universal_cluster.go
@@ -176,17 +176,17 @@ func (c *UniversalCluster) DeleteNamespace(namespace string) error {
 	return nil
 }
 
-func (c *UniversalCluster) CreateDP(app *UniversalApp, name, mesh, ip, dpyaml, token string, builtindns bool) error {
+func (c *UniversalCluster) CreateDP(app *UniversalApp, name, mesh, ip, dpyaml, token string, builtindns bool, concurrency int) error {
 	cpIp := c.apps[AppModeCP].ip
 	cpAddress := "https://" + net.JoinHostPort(cpIp, "5678")
-	app.CreateDP(token, cpAddress, name, mesh, ip, dpyaml, builtindns, false)
+	app.CreateDP(token, cpAddress, name, mesh, ip, dpyaml, builtindns, false, concurrency)
 	return app.dpApp.Start()
 }
 
 func (c *UniversalCluster) CreateZoneIngress(app *UniversalApp, name, ip, dpyaml, token string, builtindns bool) error {
 	cpIp := c.apps[AppModeCP].ip
 	cpAddress := "https://" + net.JoinHostPort(cpIp, "5678")
-	app.CreateDP(token, cpAddress, name, "", ip, dpyaml, builtindns, true)
+	app.CreateDP(token, cpAddress, name, "", ip, dpyaml, builtindns, true, 0)
 	return app.dpApp.Start()
 }
 
@@ -245,7 +245,7 @@ func (c *UniversalCluster) DeployApp(fs ...DeployOptionsFunc) error {
 		dataplaneResource = opts.appYaml
 	}
 
-	err = c.CreateDP(app, opts.name, opts.mesh, ip, dataplaneResource, token, builtindns)
+	err = c.CreateDP(app, opts.name, opts.mesh, ip, dataplaneResource, token, builtindns, opts.concurrency)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
### Summary

Bump the concurrency of Envoy in E2E TrafficRoute tests to have a loadbalancing to every endpoint through ZoneIngress.

### Documentation

- No docs

### Testing

- [ ] Unit tests
- [X] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes 

### Backwards compatibility

- [X] Add `backport-to-stable` label if the code is backwards compatible. Otherwise, list breaking changes.
