### PR TITLE
perf(*) set Node only on the first DiscoveryRequest

### DIFF
--- a/pkg/xds/bootstrap/template_v3.go
+++ b/pkg/xds/bootstrap/template_v3.go
@@ -97,6 +97,7 @@ dynamic_resources:
   ads_config:
     api_type: GRPC
     transport_api_version: V3
+    set_node_on_first_message_only: true
     timeout: {{ .XdsConnectTimeout }}
     grpc_services:
     - envoy_grpc:

--- a/pkg/xds/bootstrap/testdata/bootstrap.k8s.golden.yaml
+++ b/pkg/xds/bootstrap/testdata/bootstrap.k8s.golden.yaml
@@ -7,6 +7,7 @@ dynamicResources:
       initialMetadata:
       - key: authorization
         value: token
+    setNodeOnFirstMessageOnly: true
     transportApiVersion: V3
   cdsConfig:
     ads: {}

--- a/pkg/xds/bootstrap/testdata/bootstrap.overridden.golden.yaml
+++ b/pkg/xds/bootstrap/testdata/bootstrap.overridden.golden.yaml
@@ -13,6 +13,7 @@ dynamicResources:
       initialMetadata:
       - key: authorization
         value: token
+    setNodeOnFirstMessageOnly: true
     transportApiVersion: V3
   cdsConfig:
     ads: {}

--- a/pkg/xds/bootstrap/testdata/bootstrap.universal.golden.yaml
+++ b/pkg/xds/bootstrap/testdata/bootstrap.universal.golden.yaml
@@ -7,6 +7,7 @@ dynamicResources:
       initialMetadata:
       - key: authorization
         value: token
+    setNodeOnFirstMessageOnly: true
     transportApiVersion: V3
   cdsConfig:
     ads: {}

--- a/pkg/xds/bootstrap/testdata/generator.custom-config-minimal-request.golden.yaml
+++ b/pkg/xds/bootstrap/testdata/generator.custom-config-minimal-request.golden.yaml
@@ -10,6 +10,7 @@ dynamicResources:
     grpcServices:
     - envoyGrpc:
         clusterName: ads_cluster
+    setNodeOnFirstMessageOnly: true
     transportApiVersion: V3
   cdsConfig:
     ads: {}

--- a/pkg/xds/bootstrap/testdata/generator.custom-config.golden.yaml
+++ b/pkg/xds/bootstrap/testdata/generator.custom-config.golden.yaml
@@ -13,6 +13,7 @@ dynamicResources:
       initialMetadata:
       - key: authorization
         value: token
+    setNodeOnFirstMessageOnly: true
     transportApiVersion: V3
   cdsConfig:
     ads: {}

--- a/pkg/xds/bootstrap/testdata/generator.default-config-minimal-request.golden.yaml
+++ b/pkg/xds/bootstrap/testdata/generator.default-config-minimal-request.golden.yaml
@@ -4,6 +4,7 @@ dynamicResources:
     grpcServices:
     - envoyGrpc:
         clusterName: ads_cluster
+    setNodeOnFirstMessageOnly: true
     transportApiVersion: V3
   cdsConfig:
     ads: {}

--- a/pkg/xds/bootstrap/testdata/generator.default-config.golden.yaml
+++ b/pkg/xds/bootstrap/testdata/generator.default-config.golden.yaml
@@ -13,6 +13,7 @@ dynamicResources:
       initialMetadata:
       - key: authorization
         value: token
+    setNodeOnFirstMessageOnly: true
     transportApiVersion: V3
   cdsConfig:
     ads: {}

--- a/pkg/xds/bootstrap/testdata/generator.default-config.kubernetes.golden.yaml
+++ b/pkg/xds/bootstrap/testdata/generator.default-config.kubernetes.golden.yaml
@@ -13,6 +13,7 @@ dynamicResources:
       initialMetadata:
       - key: authorization
         value: token
+    setNodeOnFirstMessageOnly: true
     transportApiVersion: V3
   cdsConfig:
     ads: {}

--- a/pkg/xds/bootstrap/testdata/generator.default-config.kubernetes.ipv6.golden.yaml
+++ b/pkg/xds/bootstrap/testdata/generator.default-config.kubernetes.ipv6.golden.yaml
@@ -13,6 +13,7 @@ dynamicResources:
       initialMetadata:
       - key: authorization
         value: token
+    setNodeOnFirstMessageOnly: true
     transportApiVersion: V3
   cdsConfig:
     ads: {}


### PR DESCRIPTION
### Summary

We can save traffic on the wire by setting Node only on the first DiscoveryRequest. The Control Plane is ready to support such a setting, we just never enabled it.

### Issues resolved

No issue.

### Documentation

- [X] No docs

### Testing

- [X] Unit tests
- [X] E2E tests
- [ ] Manual testing on Universal
- [X] Manual testing on Kubernetes 

### Backwards compatibility

- [X] Add `backport-to-stable` label if the code is backwards compatible. Otherwise, list breaking changes.
