### PR TITLE
chore(kuma-cp) KDS global mux filters

### DIFF
--- a/pkg/kds/context/context.go
+++ b/pkg/kds/context/context.go
@@ -10,6 +10,7 @@ import (
 	"github.com/kumahq/kuma/pkg/core/resources/manager"
 	"github.com/kumahq/kuma/pkg/core/resources/model"
 	"github.com/kumahq/kuma/pkg/core/resources/store"
+	"github.com/kumahq/kuma/pkg/kds/mux"
 	"github.com/kumahq/kuma/pkg/kds/reconcile"
 	"github.com/kumahq/kuma/pkg/kds/util"
 	"github.com/kumahq/kuma/pkg/tokens/builtin/zoneingress"
@@ -21,6 +22,7 @@ type Context struct {
 	ZoneClientCtx        context.Context
 	GlobalProvidedFilter reconcile.ResourceFilter
 	ZoneProvidedFilter   reconcile.ResourceFilter
+	GlobalServerFilters  []mux.Filter
 	// Configs contains the names of system.ConfigResource that will be transferred from Global to Zone
 	Configs map[string]bool
 }

--- a/pkg/kds/global/components.go
+++ b/pkg/kds/global/components.go
@@ -66,7 +66,7 @@ func Setup(rt runtime.Runtime) (err error) {
 		}()
 		return nil
 	})
-	return rt.Add(mux.NewServer(onSessionStarted, *rt.Config().Multizone.Global.KDS, rt.Metrics()))
+	return rt.Add(mux.NewServer(onSessionStarted, rt.KDSContext().GlobalServerFilters, *rt.Config().Multizone.Global.KDS, rt.Metrics()))
 }
 
 func createZoneIfAbsent(name string, resManager manager.ResourceManager) error {


### PR DESCRIPTION
### Summary

The ability to add many Callbacks was removed here https://github.com/kumahq/kuma/pull/2573
This PR brings back this functionality as more explicit Filters.

### Documentation

- [X] No docs

### Testing

- [ ] Unit tests
- [ ] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes 

### Backwards compatibility

- [X] Add `backport-to-stable` label if the code is backwards compatible. Otherwise, list breaking changes.
