### PR TITLE
chore(kuma-cp) minor Gateway updates

### DIFF
--- a/pkg/plugins/runtime/gateway/match/gateway.go
+++ b/pkg/plugins/runtime/gateway/match/gateway.go
@@ -7,7 +7,6 @@ import (
 	"github.com/kumahq/kuma/pkg/core/policy"
 	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	"github.com/kumahq/kuma/pkg/core/resources/manager"
-	"github.com/kumahq/kuma/pkg/core/resources/store"
 )
 
 type gatewayPolicyAdaptor struct {
@@ -24,7 +23,7 @@ func (g gatewayPolicyAdaptor) Selectors() []*mesh_proto.Selector {
 func Gateway(m manager.ReadOnlyResourceManager, dp *core_mesh.DataplaneResource) *core_mesh.GatewayResource {
 	gatewayList := &core_mesh.GatewayResourceList{}
 
-	if err := m.List(context.Background(), gatewayList, store.ListByMesh(dp.Meta.GetMesh())); err != nil {
+	if err := m.List(context.Background(), gatewayList); err != nil {
 		return nil
 	}
 


### PR DESCRIPTION
### Summary

Add a couple of minor updates to the Gateway plugin that don't change
any functionality:

* use the meshed manager to find Gateway resources
* cache and match GatewayRoute resources

### Full changelog

N/A

### Issues resolved

N/A

### Documentation

N/A

### Testing

- [x] Unit tests
- [x] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes 

### Backwards compatibility

- [x] Add `backport-to-stable` label if the code is backwards compatible. Otherwise, list breaking changes.
