### PR TITLE
fix(kuma-cp) fault injection matching

### DIFF
--- a/pkg/core/faultinjections/matcher.go
+++ b/pkg/core/faultinjections/matcher.go
@@ -36,11 +36,13 @@ func BuildFaultInjectionMap(dataplane *core_mesh.DataplaneResource, mesh *core_m
 		return nil, errors.Wrap(err, "could not fetch additional inbounds")
 	}
 	inbounds := append(dataplane.Spec.GetNetworking().GetInbound(), additionalInbounds...)
-	policyMap := policy.SelectInboundConnectionPolicies(dataplane, inbounds, policies)
+	policyMap := policy.SelectInboundConnectionMatchingPolicies(dataplane, inbounds, policies)
 
 	result := core_xds.FaultInjectionMap{}
-	for inbound, connectionPolicy := range policyMap {
-		result[inbound] = connectionPolicy.(*core_mesh.FaultInjectionResource).Spec
+	for inbound, connectionPolicies := range policyMap {
+		for _, connectionPolicy := range connectionPolicies {
+			result[inbound] = append(result[inbound], connectionPolicy.(*core_mesh.FaultInjectionResource).Spec)
+		}
 	}
 	return result, nil
 }

--- a/pkg/core/faultinjections/matcher_test.go
+++ b/pkg/core/faultinjections/matcher_test.go
@@ -86,7 +86,11 @@ var _ = Describe("Match", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(len(bestMatched)).To(Equal(len(given.expected)))
 			for key := range bestMatched {
-				Expect(bestMatched[key]).To(MatchProto(given.expected[key]))
+				elements := []interface{}{}
+				for _, expected := range given.expected[key] {
+					elements = append(elements, MatchProto(expected))
+				}
+				Expect(bestMatched[key]).To(ConsistOf(elements...))
 			}
 		},
 		Entry("1 inbound dataplane, 2 policies", testCase{
@@ -123,14 +127,16 @@ var _ = Describe("Match", func() {
 				mesh_proto.InboundInterface{
 					WorkloadIP:   "127.0.0.1",
 					WorkloadPort: 8080,
-				}: policyWithDestinationsFunc("fi2", time.Unix(1, 0), []*mesh_proto.Selector{
-					{
-						Match: map[string]string{
-							"service":          "*",
-							"kuma.io/protocol": "http",
+				}: {
+					policyWithDestinationsFunc("fi2", time.Unix(1, 0), []*mesh_proto.Selector{
+						{
+							Match: map[string]string{
+								"service":          "*",
+								"kuma.io/protocol": "http",
+							},
 						},
-					},
-				}).Spec,
+					}).Spec,
+				},
 			}}),
 		Entry("should apply policy only to the first inbound", testCase{
 			dataplane: dataplaneWithInboundsFunc([]*mesh_proto.Dataplane_Networking_Inbound{
@@ -167,14 +173,96 @@ var _ = Describe("Match", func() {
 				mesh_proto.InboundInterface{
 					WorkloadIP:   "127.0.0.1",
 					WorkloadPort: 8081,
-				}: policyWithDestinationsFunc("fi1", time.Unix(1, 0), []*mesh_proto.Selector{
+				}: {
+					policyWithDestinationsFunc("fi1", time.Unix(1, 0), []*mesh_proto.Selector{
+						{
+							Match: map[string]string{
+								"service":          "web-api",
+								"kuma.io/protocol": "http",
+							},
+						},
+					}).Spec,
+				},
+			},
+		}),
+		Entry("should select all policies matched for the inbound", testCase{
+			dataplane: dataplaneWithInboundsFunc([]*mesh_proto.Dataplane_Networking_Inbound{
+				{
+					ServicePort: 8080,
+					Tags: map[string]string{
+						"service":          "web",
+						"version":          "0.1",
+						"region":           "eu",
+						"kuma.io/protocol": "http",
+					},
+				},
+			}),
+			policies: []*mesh.FaultInjectionResource{
+				policyWithDestinationsFunc("fi1", time.Unix(1, 0), []*mesh_proto.Selector{
 					{
 						Match: map[string]string{
-							"service":          "web-api",
+							"service":          "*",
 							"kuma.io/protocol": "http",
 						},
 					},
-				}).Spec,
+				}),
+				policyWithDestinationsFunc("fi2", time.Unix(1, 0), []*mesh_proto.Selector{
+					{
+						Match: map[string]string{
+							"service":          "web",
+							"kuma.io/protocol": "http",
+						},
+					},
+				}),
+				policyWithDestinationsFunc("fi3", time.Unix(1, 0), []*mesh_proto.Selector{
+					{
+						Match: map[string]string{
+							"version":          "0.1",
+							"region":           "eu",
+							"kuma.io/protocol": "http",
+						},
+					},
+				}),
+				policyWithDestinationsFunc("fi4", time.Unix(1, 0), []*mesh_proto.Selector{
+					{
+						Match: map[string]string{
+							"region":           "us",
+							"kuma.io/protocol": "http",
+						},
+					},
+				}),
+			},
+			expected: core_xds.FaultInjectionMap{
+				mesh_proto.InboundInterface{
+					WorkloadIP:   "127.0.0.1",
+					WorkloadPort: 8080,
+				}: {
+					policyWithDestinationsFunc("fi1", time.Unix(1, 0), []*mesh_proto.Selector{
+						{
+							Match: map[string]string{
+								"service":          "*",
+								"kuma.io/protocol": "http",
+							},
+						},
+					}).Spec,
+					policyWithDestinationsFunc("fi2", time.Unix(1, 0), []*mesh_proto.Selector{
+						{
+							Match: map[string]string{
+								"service":          "web",
+								"kuma.io/protocol": "http",
+							},
+						},
+					}).Spec,
+					policyWithDestinationsFunc("fi3", time.Unix(1, 0), []*mesh_proto.Selector{
+						{
+							Match: map[string]string{
+								"version":          "0.1",
+								"region":           "eu",
+								"kuma.io/protocol": "http",
+							},
+						},
+					}).Spec,
+				},
 			},
 		}),
 	)

--- a/pkg/core/xds/types.go
+++ b/pkg/core/xds/types.go
@@ -95,7 +95,7 @@ type CircuitBreakerMap map[ServiceName]*core_mesh.CircuitBreakerResource
 type RetryMap map[ServiceName]*core_mesh.RetryResource
 
 // FaultInjectionMap holds the most specific FaultInjectionResource for each InboundInterface
-type FaultInjectionMap map[mesh_proto.InboundInterface]*mesh_proto.FaultInjection
+type FaultInjectionMap map[mesh_proto.InboundInterface][]*mesh_proto.FaultInjection
 
 // TrafficPermissionMap holds the most specific TrafficPermissionResource for each InboundInterface
 type TrafficPermissionMap map[mesh_proto.InboundInterface]*core_mesh.TrafficPermissionResource

--- a/pkg/core/xds/types.go
+++ b/pkg/core/xds/types.go
@@ -94,7 +94,7 @@ type CircuitBreakerMap map[ServiceName]*core_mesh.CircuitBreakerResource
 // RetryMap holds the most specific Retry for each reachable service.
 type RetryMap map[ServiceName]*core_mesh.RetryResource
 
-// FaultInjectionMap holds the most specific FaultInjectionResource for each InboundInterface
+// FaultInjectionMap holds all matched FaultInjectionResources for each InboundInterface
 type FaultInjectionMap map[mesh_proto.InboundInterface][]*mesh_proto.FaultInjection
 
 // TrafficPermissionMap holds the most specific TrafficPermissionResource for each InboundInterface

--- a/pkg/xds/envoy/listeners/filter_chain_configurers.go
+++ b/pkg/xds/envoy/listeners/filter_chain_configurers.go
@@ -100,9 +100,9 @@ func TcpProxyWithMetadata(statsName string, clusters ...envoy_common.Cluster) Fi
 	})
 }
 
-func FaultInjection(faultInjection *mesh_proto.FaultInjection) FilterChainBuilderOpt {
+func FaultInjection(faultInjections []*mesh_proto.FaultInjection) FilterChainBuilderOpt {
 	return AddFilterChainConfigurer(&v3.FaultInjectionConfigurer{
-		FaultInjection: faultInjection,
+		FaultInjections: faultInjections,
 	})
 }
 

--- a/pkg/xds/envoy/listeners/filter_chain_configurers.go
+++ b/pkg/xds/envoy/listeners/filter_chain_configurers.go
@@ -100,7 +100,7 @@ func TcpProxyWithMetadata(statsName string, clusters ...envoy_common.Cluster) Fi
 	})
 }
 
-func FaultInjection(faultInjections []*mesh_proto.FaultInjection) FilterChainBuilderOpt {
+func FaultInjection(faultInjections ...*mesh_proto.FaultInjection) FilterChainBuilderOpt {
 	return AddFilterChainConfigurer(&v3.FaultInjectionConfigurer{
 		FaultInjections: faultInjections,
 	})

--- a/pkg/xds/envoy/listeners/v3/fault_injection_configurer_test.go
+++ b/pkg/xds/envoy/listeners/v3/fault_injection_configurer_test.go
@@ -23,7 +23,7 @@ var _ = Describe("FaultInjectionConfigurer", func() {
 			// when
 			filterChain, err := NewFilterChainBuilder(envoy.APIV3).
 				Configure(HttpConnectionManager("stats", false)).
-				Configure(FaultInjection(given.input)).
+				Configure(FaultInjection(given.input...)).
 				Build()
 			// then
 			Expect(err).ToNot(HaveOccurred())

--- a/pkg/xds/envoy/listeners/v3/fault_injection_configurer_test.go
+++ b/pkg/xds/envoy/listeners/v3/fault_injection_configurer_test.go
@@ -15,7 +15,7 @@ import (
 
 var _ = Describe("FaultInjectionConfigurer", func() {
 	type testCase struct {
-		input    *mesh_proto.FaultInjection
+		input    []*mesh_proto.FaultInjection
 		expected string
 	}
 	DescribeTable("should generate proper Envoy config",
@@ -34,7 +34,7 @@ var _ = Describe("FaultInjectionConfigurer", func() {
 			Expect(actual).To(MatchYAML(given.expected))
 		},
 		Entry("basic input", testCase{
-			input: &mesh_proto.FaultInjection{
+			input: []*mesh_proto.FaultInjection{{
 				Sources: []*mesh_proto.Selector{
 					{
 						Match: map[string]string{
@@ -49,7 +49,7 @@ var _ = Describe("FaultInjectionConfigurer", func() {
 						Value:      util_proto.Duration(time.Second * 5),
 					},
 				},
-			},
+			}},
 
 			expected: `
             filters:
@@ -73,7 +73,7 @@ var _ = Describe("FaultInjectionConfigurer", func() {
                 statPrefix: stats`,
 		}),
 		Entry("2 policy selectors", testCase{
-			input: &mesh_proto.FaultInjection{
+			input: []*mesh_proto.FaultInjection{{
 				Sources: []*mesh_proto.Selector{
 					{
 						Match: map[string]string{
@@ -94,8 +94,7 @@ var _ = Describe("FaultInjectionConfigurer", func() {
 						Value:      util_proto.Duration(time.Second * 5),
 					},
 				},
-			},
-
+			}},
 			expected: `
             filters:
             - name: envoy.filters.network.http_connection_manager
@@ -116,6 +115,103 @@ var _ = Describe("FaultInjectionConfigurer", func() {
                         regex: '(.*&tag1=[^&]*value1m1[,&].*&tag2=[^&]*value2m1[,&].*|.*&tag1=[^&]*value1m2[,&].*&tag2=[^&]*value2m2[,&].*)'
                 - name: envoy.filters.http.router
                 statPrefix: stats`,
+		}),
+		Entry("should preserve the order of passed policies", testCase{
+			input: []*mesh_proto.FaultInjection{
+				{
+					Sources: []*mesh_proto.Selector{
+						{
+							Match: map[string]string{
+								"tag1": "value1",
+								"tag2": "value2",
+								"tag3": "value3",
+							},
+						},
+					},
+					Conf: &mesh_proto.FaultInjection_Conf{
+						Delay: &mesh_proto.FaultInjection_Conf_Delay{
+							Percentage: util_proto.Double(100),
+							Value:      util_proto.Duration(time.Second * 15),
+						},
+					},
+				},
+				{
+					Sources: []*mesh_proto.Selector{
+						{
+							Match: map[string]string{
+								"tag1": "value1",
+								"tag2": "value2",
+							},
+						},
+					},
+					Conf: &mesh_proto.FaultInjection_Conf{
+						Delay: &mesh_proto.FaultInjection_Conf_Delay{
+							Percentage: util_proto.Double(100),
+							Value:      util_proto.Duration(time.Second * 10),
+						},
+					},
+				},
+				{
+					Sources: []*mesh_proto.Selector{
+						{
+							Match: map[string]string{
+								"tag1": "*",
+								"tag2": "*",
+							},
+						},
+					},
+					Conf: &mesh_proto.FaultInjection_Conf{
+						Delay: &mesh_proto.FaultInjection_Conf_Delay{
+							Percentage: util_proto.Double(100),
+							Value:      util_proto.Duration(time.Second * 5),
+						},
+					},
+				},
+			},
+			expected: `
+            filters:
+             - name: envoy.filters.network.http_connection_manager
+               typedConfig:
+                 '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+                 httpFilters:
+                 - name: envoy.filters.http.fault
+                   typedConfig:
+                     '@type': type.googleapis.com/envoy.extensions.filters.http.fault.v3.HTTPFault
+                     delay:
+                       fixedDelay: 15s
+                       percentage:
+                         numerator: 100
+                     headers:
+                     - name: x-kuma-tags
+                       safeRegexMatch:
+                         googleRe2: {}
+                         regex: .*&tag1=[^&]*value1[,&].*&tag2=[^&]*value2[,&].*&tag3=[^&]*value3[,&].*
+                 - name: envoy.filters.http.fault
+                   typedConfig:
+                     '@type': type.googleapis.com/envoy.extensions.filters.http.fault.v3.HTTPFault
+                     delay:
+                       fixedDelay: 10s
+                       percentage:
+                         numerator: 100
+                     headers:
+                     - name: x-kuma-tags
+                       safeRegexMatch:
+                         googleRe2: {}
+                         regex: .*&tag1=[^&]*value1[,&].*&tag2=[^&]*value2[,&].*
+                 - name: envoy.filters.http.fault
+                   typedConfig:
+                     '@type': type.googleapis.com/envoy.extensions.filters.http.fault.v3.HTTPFault
+                     delay:
+                       fixedDelay: 5s
+                       percentage:
+                         numerator: 100
+                     headers:
+                     - name: x-kuma-tags
+                       safeRegexMatch:
+                         googleRe2: {}
+                         regex: .*&tag1=.*&tag2=.*
+                 - name: envoy.filters.http.router
+                 statPrefix: stats`,
 		}),
 	)
 })

--- a/pkg/xds/generator/inbound_proxy_generator.go
+++ b/pkg/xds/generator/inbound_proxy_generator.go
@@ -73,7 +73,7 @@ func (g InboundProxyGenerator) Generate(ctx xds_context.Context, proxy *model.Pr
 			case core_mesh.ProtocolHTTP, core_mesh.ProtocolHTTP2:
 				filterChainBuilder.
 					Configure(envoy_listeners.HttpConnectionManager(localClusterName, true)).
-					Configure(envoy_listeners.FaultInjection(proxy.Policies.FaultInjections[endpoint])).
+					Configure(envoy_listeners.FaultInjection(proxy.Policies.FaultInjections[endpoint]...)).
 					Configure(envoy_listeners.RateLimit(proxy.Policies.RateLimits.Inbound[endpoint])).
 					Configure(envoy_listeners.Tracing(proxy.Policies.TracingBackend, service)).
 					Configure(envoy_listeners.HttpInboundRoutes(service, routes))
@@ -81,7 +81,7 @@ func (g InboundProxyGenerator) Generate(ctx xds_context.Context, proxy *model.Pr
 				filterChainBuilder.
 					Configure(envoy_listeners.HttpConnectionManager(localClusterName, true)).
 					Configure(envoy_listeners.GrpcStats()).
-					Configure(envoy_listeners.FaultInjection(proxy.Policies.FaultInjections[endpoint])).
+					Configure(envoy_listeners.FaultInjection(proxy.Policies.FaultInjections[endpoint]...)).
 					Configure(envoy_listeners.RateLimit(proxy.Policies.RateLimits.Inbound[endpoint])).
 					Configure(envoy_listeners.Tracing(proxy.Policies.TracingBackend, service)).
 					Configure(envoy_listeners.HttpInboundRoutes(service, routes))

--- a/pkg/xds/generator/inbound_proxy_generator_test.go
+++ b/pkg/xds/generator/inbound_proxy_generator_test.go
@@ -112,7 +112,7 @@ var _ = Describe("InboundProxyGenerator", func() {
 							DataplanePort:         80,
 							WorkloadIP:            "127.0.0.1",
 							WorkloadPort:          8080,
-						}: &mesh_proto.FaultInjection{
+						}: []*mesh_proto.FaultInjection{{
 							Sources: []*mesh_proto.Selector{
 								{
 									Match: map[string]string{
@@ -133,7 +133,7 @@ var _ = Describe("InboundProxyGenerator", func() {
 									Value:      util_proto.Duration(time.Second * 5),
 								},
 							},
-						},
+						}},
 					},
 					RateLimits: model.RateLimitsMap{
 						Inbound: model.InboundRateLimitsMap{

--- a/test/e2e/matching/matching_suite_test.go
+++ b/test/e2e/matching/matching_suite_test.go
@@ -3,9 +3,14 @@ package matching_test
 import (
 	"testing"
 
+	. "github.com/onsi/ginkgo"
+
 	"github.com/kumahq/kuma/pkg/test"
+	"github.com/kumahq/kuma/test/e2e/matching"
 	"github.com/kumahq/kuma/test/framework"
 )
+
+var _ = Describe("Test Matching on Universal", matching.Universal)
 
 func TestE2EMatching(t *testing.T) {
 	if framework.IsK8sClustersStarted() {

--- a/test/e2e/matching/matching_suite_test.go
+++ b/test/e2e/matching/matching_suite_test.go
@@ -1,0 +1,16 @@
+package matching_test
+
+import (
+	"testing"
+
+	"github.com/kumahq/kuma/pkg/test"
+	"github.com/kumahq/kuma/test/framework"
+)
+
+func TestE2EMatching(t *testing.T) {
+	if framework.IsK8sClustersStarted() {
+		test.RunSpecs(t, "E2E Retry Suite")
+	} else {
+		t.SkipNow()
+	}
+}

--- a/test/e2e/matching/matching_universal.go
+++ b/test/e2e/matching/matching_universal.go
@@ -3,10 +3,11 @@ package matching
 import (
 	"strings"
 
-	"github.com/kumahq/kuma/pkg/config/core"
-	. "github.com/kumahq/kuma/test/framework"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+
+	"github.com/kumahq/kuma/pkg/config/core"
+	. "github.com/kumahq/kuma/test/framework"
 )
 
 func Universal() {

--- a/test/e2e/matching/matching_universal.go
+++ b/test/e2e/matching/matching_universal.go
@@ -1,0 +1,97 @@
+package matching
+
+import (
+	"strings"
+
+	"github.com/kumahq/kuma/pkg/config/core"
+	. "github.com/kumahq/kuma/test/framework"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func Universal() {
+	var universal Cluster
+	var optsUniversal = KumaUniversalDeployOpts
+
+	BeforeEach(func() {
+		clusters, err := NewUniversalClusters([]string{Kuma1}, Silent)
+		Expect(err).ToNot(HaveOccurred())
+
+		universal = clusters.GetCluster(Kuma1)
+
+		err = NewClusterSetup().
+			Install(Kuma(core.Standalone, optsUniversal...)).
+			Setup(universal)
+		Expect(err).ToNot(HaveOccurred())
+		err = universal.VerifyKuma()
+		Expect(err).ToNot(HaveOccurred())
+
+		demoClientToken1, err := universal.GetKuma().GenerateDpToken("default", "demo-client-1")
+		Expect(err).ToNot(HaveOccurred())
+		Expect(
+			DemoClientUniversal("demo-client-1", "default", demoClientToken1, WithTransparentProxy(true))(universal),
+		).To(Succeed())
+		demoClientToken2, err := universal.GetKuma().GenerateDpToken("default", "demo-client-2")
+		Expect(err).ToNot(HaveOccurred())
+		Expect(
+			DemoClientUniversal("demo-client-2", "default", demoClientToken2, WithTransparentProxy(true))(universal),
+		).To(Succeed())
+
+		testServerToken, err := universal.GetKuma().GenerateDpToken("default", "test-server")
+		Expect(err).ToNot(HaveOccurred())
+		Expect(
+			TestServerUniversal("test-server", "default", testServerToken,
+				WithArgs([]string{"echo", "--instance", "echo-v1"}))(universal),
+		).To(Succeed())
+	})
+
+	It("should both fault injections with the same destination proxy", func() {
+		Expect(YamlUniversal(`
+type: FaultInjection
+mesh: default
+name: fi1
+sources:
+   - match:
+       kuma.io/service: demo-client-1
+destinations:
+   - match:
+       kuma.io/service: test-server
+       kuma.io/protocol: http
+conf:
+   abort:
+     httpStatus: 401
+     percentage: 100`)(universal)).To(Succeed())
+
+		Expect(YamlUniversal(`
+type: FaultInjection
+mesh: default
+name: fi2
+sources:
+   - match:
+       kuma.io/service: demo-client-2
+destinations:
+   - match:
+       kuma.io/service: test-server
+       kuma.io/protocol: http
+conf:
+   abort:
+     httpStatus: 402
+     percentage: 100`)(universal)).To(Succeed())
+
+		Eventually(func() bool {
+			stdout, _, err := universal.Exec("", "", "demo-client-1", "curl", "-v", "test-server.mesh")
+			if err != nil {
+				return false
+			}
+			return strings.Contains(stdout, "HTTP/1.1 401 Unauthorized")
+		}, "10s", "100ms").Should(BeTrue())
+
+		Eventually(func() bool {
+			stdout, _, err := universal.Exec("", "", "demo-client-2", "curl", "-v", "test-server.mesh")
+			if err != nil {
+				return false
+			}
+			return strings.Contains(stdout, "HTTP/1.1 402 Payment Required")
+		}, "10s", "100ms").Should(BeTrue())
+	})
+}

--- a/test/e2e/matching/matching_universal.go
+++ b/test/e2e/matching/matching_universal.go
@@ -46,6 +46,11 @@ func Universal() {
 		).To(Succeed())
 	})
 
+	E2EAfterEach(func() {
+		Expect(universal.DeleteKuma(optsUniversal...)).To(Succeed())
+		Expect(universal.DismissCluster()).To(Succeed())
+	})
+
 	It("should both fault injections with the same destination proxy", func() {
 		Expect(YamlUniversal(`
 type: FaultInjection

--- a/test/e2e/matching/matching_universal_test.go
+++ b/test/e2e/matching/matching_universal_test.go
@@ -1,8 +1,9 @@
 package matching_test
 
 import (
-	"github.com/kumahq/kuma/test/e2e/matching"
 	. "github.com/onsi/ginkgo"
+
+	"github.com/kumahq/kuma/test/e2e/matching"
 )
 
 var _ = Describe("Test Matching on Universal", matching.Universal)

--- a/test/e2e/matching/matching_universal_test.go
+++ b/test/e2e/matching/matching_universal_test.go
@@ -1,9 +1,0 @@
-package matching_test
-
-import (
-	. "github.com/onsi/ginkgo"
-
-	"github.com/kumahq/kuma/test/e2e/matching"
-)
-
-var _ = Describe("Test Matching on Universal", matching.Universal)

--- a/test/e2e/matching/matching_universal_test.go
+++ b/test/e2e/matching/matching_universal_test.go
@@ -1,0 +1,8 @@
+package matching_test
+
+import (
+	"github.com/kumahq/kuma/test/e2e/matching"
+	. "github.com/onsi/ginkgo"
+)
+
+var _ = Describe("Test Matching on Universal", matching.Universal)


### PR DESCRIPTION
### Summary

Today if you apply 2 Fault Injections:
```yaml
type: FaultInjection
mesh: default
name: fi1
sources:
   - match:
       kuma.io/service: demo-client-1
destinations:
   - match:
       kuma.io/service: test-server
       kuma.io/protocol: http
conf:
   abort:
     httpStatus: 401
     percentage: 100
---
type: FaultInjection
mesh: default
name: fi2
sources:
   - match:
       kuma.io/service: demo-client-2
destinations:
   - match:
       kuma.io/service: test-server
       kuma.io/protocol: http
conf:
   abort:
     httpStatus: 402
     percentage: 100
```

Only the latest one will be applied and replace another one. 

### Full changelog

* Select all matched policies for the inbound and apply them all. We can do that because we rely on the HttpFault header matching

### Issues resolved

N/A

### Documentation

- [ ] Link to the website [documentation PR](https://github.com/kumahq/kuma-website/pull/XXX)

### Testing

- [X] Unit tests
- [X] E2E tests
- [X] Manual testing on Universal
- [ ] Manual testing on Kubernetes 

### Backwards compatibility

- [x] Add `backport-to-stable` label if the code is backwards compatible. Otherwise, list breaking changes.
