### PR TITLE
feat(kuma-cp) match gateway routes

### DIFF
--- a/pkg/plugins/runtime/gateway/gateway_route_generator.go
+++ b/pkg/plugins/runtime/gateway/gateway_route_generator.go
@@ -1,0 +1,69 @@
+package gateway
+
+import (
+	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
+	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
+	"github.com/kumahq/kuma/pkg/core/resources/model"
+	core_xds "github.com/kumahq/kuma/pkg/core/xds"
+	"github.com/kumahq/kuma/pkg/plugins/runtime/gateway/match"
+	xds_context "github.com/kumahq/kuma/pkg/xds/context"
+)
+
+func selectGatewayRoutes(in []model.Resource, accept func(resource *core_mesh.GatewayRouteResource) bool) []*core_mesh.GatewayRouteResource {
+	routes := make([]*core_mesh.GatewayRouteResource, 0, len(in))
+
+	for _, r := range in {
+		if trafficRoute, ok := r.(*core_mesh.GatewayRouteResource); ok {
+			if accept(trafficRoute) {
+				routes = append(routes, trafficRoute)
+			}
+		}
+	}
+
+	return routes
+}
+
+// GatewayRouteGenerator generates Kuma gateway routes from GatewayRoute resources.
+type GatewayRouteGenerator struct {
+}
+
+func (*GatewayRouteGenerator) SupportsProtocol(p mesh_proto.Gateway_Listener_Protocol) bool {
+	switch p {
+	case mesh_proto.Gateway_Listener_HTTP,
+		mesh_proto.Gateway_Listener_HTTPS:
+		return true
+	default:
+		return false
+	}
+}
+
+func (*GatewayRouteGenerator) GenerateHost(ctx xds_context.Context, info *GatewayResourceInfo) (*core_xds.ResourceSet, error) {
+	gatewayRoutes := selectGatewayRoutes(info.Host.Routes, func(route *core_mesh.GatewayRouteResource) bool {
+		// Wildcard virtual host accepts all routes.
+		if info.Host.Hostname == WildcardHostname {
+			return true
+		}
+
+		// If the route has no hostnames, it matches all virtualhosts.
+		names := route.Spec.GetConf().GetHttp().GetHostnames()
+		if len(names) == 0 {
+			return true
+		}
+
+		// Otherwise, match the virtualhost name to the route names.
+		return match.Hostnames(info.Host.Hostname, names...)
+	})
+
+	if len(gatewayRoutes) == 0 {
+		return nil, nil
+	}
+
+	resources := ResourceAggregator{}
+
+	log.V(1).Info("applying merged traffic routes",
+		"listener-port", info.Listener.Port,
+		"listener-name", info.Listener.ResourceName,
+	)
+
+	return resources.Get(), nil
+}

--- a/pkg/plugins/runtime/gateway/gateway_route_generator.go
+++ b/pkg/plugins/runtime/gateway/gateway_route_generator.go
@@ -9,7 +9,7 @@ import (
 	xds_context "github.com/kumahq/kuma/pkg/xds/context"
 )
 
-func selectGatewayRoutes(in []model.Resource, accept func(resource *core_mesh.GatewayRouteResource) bool) []*core_mesh.GatewayRouteResource {
+func filterGatewayRoutes(in []model.Resource, accept func(resource *core_mesh.GatewayRouteResource) bool) []*core_mesh.GatewayRouteResource {
 	routes := make([]*core_mesh.GatewayRouteResource, 0, len(in))
 
 	for _, r := range in {
@@ -28,17 +28,11 @@ type GatewayRouteGenerator struct {
 }
 
 func (*GatewayRouteGenerator) SupportsProtocol(p mesh_proto.Gateway_Listener_Protocol) bool {
-	switch p {
-	case mesh_proto.Gateway_Listener_HTTP,
-		mesh_proto.Gateway_Listener_HTTPS:
-		return true
-	default:
-		return false
-	}
+	return p == mesh_proto.Gateway_Listener_HTTP || p == mesh_proto.Gateway_Listener_HTTPS
 }
 
 func (*GatewayRouteGenerator) GenerateHost(ctx xds_context.Context, info *GatewayResourceInfo) (*core_xds.ResourceSet, error) {
-	gatewayRoutes := selectGatewayRoutes(info.Host.Routes, func(route *core_mesh.GatewayRouteResource) bool {
+	gatewayRoutes := filterGatewayRoutes(info.Host.Routes, func(route *core_mesh.GatewayRouteResource) bool {
 		// Wildcard virtual host accepts all routes.
 		if info.Host.Hostname == WildcardHostname {
 			return true

--- a/pkg/plugins/runtime/gateway/gateway_route_generator_test.go
+++ b/pkg/plugins/runtime/gateway/gateway_route_generator_test.go
@@ -1,0 +1,237 @@
+package gateway_test
+
+import (
+	"path"
+
+	"github.com/envoyproxy/go-control-plane/pkg/cache/v3"
+	"github.com/ghodss/yaml"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	core_model "github.com/kumahq/kuma/pkg/core/resources/model"
+	"github.com/kumahq/kuma/pkg/core/runtime"
+	"github.com/kumahq/kuma/pkg/test/matchers"
+	xds_server "github.com/kumahq/kuma/pkg/xds/server/v3"
+)
+
+var _ = Describe("Gateway Gateway Route", func() {
+	var rt runtime.Runtime
+	var dataplanes *DataplaneGenerator
+
+	Do := func() (cache.Snapshot, error) {
+		serverCtx := xds_server.NewXdsContext()
+		reconciler := xds_server.DefaultReconciler(rt, serverCtx)
+
+		// We expect there to be a Dataplane fixture named
+		// "default" in the current mesh.
+		ctx, proxy := MakeGeneratorContext(rt,
+			core_model.ResourceKey{Mesh: "default", Name: "default"})
+
+		Expect(proxy.Dataplane.Spec.IsBuiltinGateway()).To(BeTrue())
+
+		if err := reconciler.Reconcile(*ctx, proxy); err != nil {
+			return cache.Snapshot{}, err
+		}
+
+		return serverCtx.Cache().GetSnapshot(proxy.Id.String())
+	}
+
+	BeforeEach(func() {
+		var err error
+
+		rt, err = BuildRuntime()
+		Expect(err).To(Succeed(), "build runtime instance")
+
+		Expect(StoreNamedFixture(rt, "mesh-default.yaml")).To(Succeed())
+		Expect(StoreNamedFixture(rt, "dataplane-default.yaml")).To(Succeed())
+		Expect(StoreNamedFixture(rt, "gateway-default.yaml")).To(Succeed())
+
+		dataplanes = &DataplaneGenerator{Manager: rt.ResourceManager()}
+	})
+
+	It("should expand route hostnames into virtual hosts", func() {
+		dataplanes.Generate("echo-service") // TODO(jpeach) not used yet
+
+		// Given the default gateway has a wildcard listener.
+		Expect(StoreInlineFixture(rt, []byte(`
+type: Gateway
+mesh: default
+name: edge-gateway
+selectors:
+- match:
+    kuma.io/service: gateway-default
+conf:
+  listeners:
+  - port: 8080
+    protocol: HTTP
+    tags:
+      port: http/8080
+`))).To(Succeed())
+
+		// When we have a route with multiple hostnames that is
+		// attached to a listener with no hostname (i.e. a wildcard),
+		// we ought to generate distinct Envoy virtualhost entries
+		// for each hostname
+		Expect(StoreInlineFixture(rt, []byte(`
+type: GatewayRoute
+mesh: default
+name: echo-service
+selectors:
+- match:
+    kuma.io/service: gateway-default
+conf:
+  http:
+    hostnames:
+    - foo.example.com
+    - bar.example.com
+    - "*.example.com"
+    rules:
+    - matches:
+      - path:
+          match: EXACT
+          value: /
+      backends:
+      - destination:
+          kuma.io/service: echo-service
+`))).To(Succeed())
+
+		// when
+		snap, err := Do()
+		Expect(err).To(Succeed())
+
+		// then
+		Expect(yaml.Marshal(MakeProtoSnapshot(snap))).
+			To(matchers.MatchGoldenYAML(path.Join("testdata", "01-gateway-route.yaml")))
+	})
+
+	It("should create a wildcard virtual host", func() {
+		dataplanes.Generate("echo-service") // TODO(jpeach) not used yet
+
+		// Given the default gateway has a wildcard listener.
+		Expect(StoreInlineFixture(rt, []byte(`
+type: Gateway
+mesh: default
+name: edge-gateway
+selectors:
+- match:
+    kuma.io/service: gateway-default
+conf:
+  listeners:
+  - port: 8080
+    protocol: HTTP
+    tags:
+      port: http/8080
+`))).To(Succeed())
+
+		// Given a route with no hostnames.
+		Expect(StoreInlineFixture(rt, []byte(`
+type: GatewayRoute
+mesh: default
+name: echo-service
+selectors:
+- match:
+    kuma.io/service: gateway-default
+conf:
+  http:
+    rules:
+    - matches:
+      - path:
+          match: EXACT
+          value: /
+      backends:
+      - destination:
+          kuma.io/service: echo-service
+`))).To(Succeed())
+
+		// Given a route with hostnames.
+		Expect(StoreInlineFixture(rt, []byte(`
+type: GatewayRoute
+mesh: default
+name: echo-service-extra
+selectors:
+- match:
+    kuma.io/service: gateway-default
+conf:
+  http:
+    hostnames:
+    - extra.example.com
+    rules:
+    - matches:
+      - path:
+          match: EXACT
+          value: /
+      backends:
+      - destination:
+          kuma.io/service: echo-service
+`))).To(Succeed())
+
+		// when
+		snap, err := Do()
+		Expect(err).To(Succeed())
+
+		// then
+		Expect(yaml.Marshal(MakeProtoSnapshot(snap))).
+			To(matchers.MatchGoldenYAML(path.Join("testdata", "02-gateway-route.yaml")))
+	})
+
+	It("should match route hostnames on the listener", func() {
+		dataplanes.Generate("echo-service") // TODO(jpeach) not used yet
+
+		// Given a route with matching hostnames.
+		Expect(StoreInlineFixture(rt, []byte(`
+type: GatewayRoute
+mesh: default
+name: echo-service
+selectors:
+- match:
+    kuma.io/service: gateway-default
+conf:
+  http:
+    hostnames:
+    - echo.example.com
+    rules:
+    - matches:
+      - path:
+          match: EXACT
+          value: /service/echo
+      backends:
+      - destination:
+          kuma.io/service: echo-service
+`))).To(Succeed())
+
+		// Given a route with non-matching hostnames.
+		Expect(StoreInlineFixture(rt, []byte(`
+type: GatewayRoute
+mesh: default
+name: echo-service-2
+selectors:
+- match:
+    kuma.io/service: gateway-default
+conf:
+  http:
+    hostnames:
+    - foo.example.com
+    rules:
+    - matches:
+      - path:
+          match: EXACT
+          value: /service/foo
+      backends:
+      - destination:
+          kuma.io/service: echo-service
+`))).To(Succeed())
+
+		// TODO(jpeach) This test won't test anything until we
+		// implement route generation, because neither of the two
+		// GatewayRoute fixtures generate anything at all
+
+		// when
+		snap, err := Do()
+		Expect(err).To(Succeed())
+
+		// then
+		Expect(yaml.Marshal(MakeProtoSnapshot(snap))).
+			To(matchers.MatchGoldenYAML(path.Join("testdata", "03-gateway-route.yaml")))
+	})
+
+})

--- a/pkg/plugins/runtime/gateway/hostname_match_test.go
+++ b/pkg/plugins/runtime/gateway/hostname_match_test.go
@@ -1,0 +1,30 @@
+package gateway_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+
+	"github.com/kumahq/kuma/pkg/plugins/runtime/gateway/match"
+)
+
+var _ = Describe("Hostname matching", func() {
+	DescribeTable("should match",
+		func(hostname string, candidate string) {
+			Expect(match.Hostnames(hostname, candidate)).To(BeTrue())
+		},
+		Entry("", "foo.example.com", "foo.example.com"),
+		Entry("", "*.example.com", "foo.example.com"),
+		Entry("", "foo.example.com", "*.example.com"),
+		Entry("", "*.example.com", "*.example.com"),
+	)
+	DescribeTable("should not match",
+		func(hostname string, candidate string) {
+			Expect(match.Hostnames(hostname, candidate)).To(BeFalse())
+		},
+		Entry("", "foo.example.com", "bar.example.com"),
+		Entry("", "*.example.com", "foo.examples.com"),
+		Entry("", "foo.example.com", "*.examples.com"),
+		Entry("", "*.example.com", "*.examples.com"),
+	)
+})

--- a/pkg/plugins/runtime/gateway/match/hostnames.go
+++ b/pkg/plugins/runtime/gateway/match/hostnames.go
@@ -1,0 +1,50 @@
+package match
+
+import "strings"
+
+type hostname struct {
+	Host   string
+	Domain string
+}
+
+func (h *hostname) wildcard() bool {
+	return h.Host == "*"
+}
+
+func (h *hostname) matches(name string) bool {
+	n := makeHostname(name)
+
+	if h.wildcard() || n.wildcard() {
+		return h.Domain == n.Domain
+	}
+
+	return h.Host == n.Host && h.Domain == n.Domain
+}
+
+func makeHostname(name string) hostname {
+	parts := strings.SplitN(name, ".", 2)
+	return hostname{Host: parts[0], Domain: parts[1]}
+}
+
+// Hostnames returns true if target is a host or domain name match for
+// any of the given matches. All the hostnames are assumed to be fully
+// qualified (e.g. "foo.example.com") or wildcards (e.g. "*.example.com).
+//
+// Two hostnames match if
+//
+// 1. They are exactly equal, OR
+// 2. One of them is a domain wildcard and the domain part matches.
+func Hostnames(target string, matches ...string) bool {
+	targetHost := makeHostname(target)
+
+	for _, m := range matches {
+		if m == target {
+			return true
+		}
+		if targetHost.matches(m) {
+			return true
+		}
+	}
+
+	return false
+}

--- a/pkg/plugins/runtime/gateway/merge/routes.go
+++ b/pkg/plugins/runtime/gateway/merge/routes.go
@@ -1,0 +1,29 @@
+package merge
+
+import "github.com/kumahq/kuma/pkg/core/resources/model"
+
+// UniqueResources takes a slice of resources that may include duplicates
+// and returns a slice with no duplicates. Resources are considered
+// duplicates if they have the same type, mesh and name.
+func UniqueResources(all []model.Resource) []model.Resource {
+	type key struct {
+		key model.ResourceKey
+		typ model.ResourceType
+	}
+
+	set := map[key]model.Resource{}
+
+	for _, r := range all {
+		set[key{
+			key: model.MetaToResourceKey(r.GetMeta()),
+			typ: r.Descriptor().Name,
+		}] = r
+	}
+
+	var u []model.Resource
+	for _, m := range set {
+		u = append(u, m)
+	}
+
+	return u
+}

--- a/pkg/plugins/runtime/gateway/plugin.go
+++ b/pkg/plugins/runtime/gateway/plugin.go
@@ -58,6 +58,7 @@ func NewProxyProfile(manager manager.ReadOnlyResourceManager) generator.Resource
 				&RouteConfigurationGenerator{},
 				&VirtualHostGenerator{},
 				&TrafficRouteGenerator{},
+				&GatewayRouteGenerator{},
 			},
 		},
 	}

--- a/pkg/plugins/runtime/gateway/testdata/01-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/01-gateway-route.yaml
@@ -1,0 +1,70 @@
+Clusters:
+  Resources: {}
+Endpoints:
+  Resources: {}
+Listeners:
+  Resources:
+    edge-gateway:HTTP:8080:
+      address:
+        socketAddress:
+          address: 192.168.1.1
+          portValue: 8080
+      filterChains:
+      - filters:
+        - name: envoy.filters.network.http_connection_manager
+          typedConfig:
+            '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+            commonHttpProtocolOptions:
+              headersWithUnderscoresAction: REJECT_REQUEST
+              idleTimeout: 300s
+            http2ProtocolOptions:
+              allowConnect: true
+              initialConnectionWindowSize: 1048576
+              initialStreamWindowSize: 65536
+              maxConcurrentStreams: 100
+            httpFilters:
+            - name: envoy.filters.http.router
+            mergeSlashes: true
+            normalizePath: true
+            rds:
+              configSource:
+                ads: {}
+                resourceApiVersion: V3
+              routeConfigName: edge-gateway:HTTP:8080
+            requestHeadersTimeout: 0.500s
+            serverName: Kuma Gateway
+            statPrefix: gateway-default
+            streamIdleTimeout: 5s
+            stripAnyHostPort: true
+      listenerFilters:
+      - name: envoy.filters.listener.tls_inspector
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
+      name: edge-gateway:HTTP:8080
+      perConnectionBufferLimitBytes: 32768
+      reusePort: true
+      trafficDirection: INBOUND
+Routes:
+  Resources:
+    edge-gateway:HTTP:8080:
+      name: edge-gateway:HTTP:8080
+      requestHeadersToRemove:
+      - x-kuma-tags
+      validateClusters: false
+      virtualHosts:
+      - domains:
+        - foo.example.com
+        name: edge-gateway:HTTP:8080:foo.example.com
+      - domains:
+        - bar.example.com
+        name: edge-gateway:HTTP:8080:bar.example.com
+      - domains:
+        - '*.example.com'
+        name: edge-gateway:HTTP:8080:*.example.com
+      - domains:
+        - '*'
+        name: edge-gateway:HTTP:8080:*
+Runtimes:
+  Resources: {}
+Secrets:
+  Resources: {}

--- a/pkg/plugins/runtime/gateway/testdata/02-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/02-gateway-route.yaml
@@ -1,0 +1,64 @@
+Clusters:
+  Resources: {}
+Endpoints:
+  Resources: {}
+Listeners:
+  Resources:
+    edge-gateway:HTTP:8080:
+      address:
+        socketAddress:
+          address: 192.168.1.1
+          portValue: 8080
+      filterChains:
+      - filters:
+        - name: envoy.filters.network.http_connection_manager
+          typedConfig:
+            '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+            commonHttpProtocolOptions:
+              headersWithUnderscoresAction: REJECT_REQUEST
+              idleTimeout: 300s
+            http2ProtocolOptions:
+              allowConnect: true
+              initialConnectionWindowSize: 1048576
+              initialStreamWindowSize: 65536
+              maxConcurrentStreams: 100
+            httpFilters:
+            - name: envoy.filters.http.router
+            mergeSlashes: true
+            normalizePath: true
+            rds:
+              configSource:
+                ads: {}
+                resourceApiVersion: V3
+              routeConfigName: edge-gateway:HTTP:8080
+            requestHeadersTimeout: 0.500s
+            serverName: Kuma Gateway
+            statPrefix: gateway-default
+            streamIdleTimeout: 5s
+            stripAnyHostPort: true
+      listenerFilters:
+      - name: envoy.filters.listener.tls_inspector
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
+      name: edge-gateway:HTTP:8080
+      perConnectionBufferLimitBytes: 32768
+      reusePort: true
+      trafficDirection: INBOUND
+Routes:
+  Resources:
+    edge-gateway:HTTP:8080:
+      name: edge-gateway:HTTP:8080
+      requestHeadersToRemove:
+      - x-kuma-tags
+      validateClusters: false
+      virtualHosts:
+      - domains:
+        - extra.example.com
+        name: edge-gateway:HTTP:8080:extra.example.com
+      - domains:
+        - '*'
+        name: edge-gateway:HTTP:8080:*
+Runtimes:
+  Resources: {}
+Secrets:
+  Resources: {}

--- a/pkg/plugins/runtime/gateway/testdata/03-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/03-gateway-route.yaml
@@ -1,0 +1,67 @@
+Clusters:
+  Resources: {}
+Endpoints:
+  Resources: {}
+Listeners:
+  Resources:
+    edge-gateway:HTTP:8080:
+      address:
+        socketAddress:
+          address: 192.168.1.1
+          portValue: 8080
+      filterChains:
+      - filters:
+        - name: envoy.filters.network.http_connection_manager
+          typedConfig:
+            '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+            commonHttpProtocolOptions:
+              headersWithUnderscoresAction: REJECT_REQUEST
+              idleTimeout: 300s
+            http2ProtocolOptions:
+              allowConnect: true
+              initialConnectionWindowSize: 1048576
+              initialStreamWindowSize: 65536
+              maxConcurrentStreams: 100
+            httpFilters:
+            - name: envoy.filters.http.router
+            mergeSlashes: true
+            normalizePath: true
+            rds:
+              configSource:
+                ads: {}
+                resourceApiVersion: V3
+              routeConfigName: edge-gateway:HTTP:8080
+            requestHeadersTimeout: 0.500s
+            serverName: Kuma Gateway
+            statPrefix: gateway-default
+            streamIdleTimeout: 5s
+            stripAnyHostPort: true
+      listenerFilters:
+      - name: envoy.filters.listener.tls_inspector
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
+      name: edge-gateway:HTTP:8080
+      perConnectionBufferLimitBytes: 32768
+      reusePort: true
+      trafficDirection: INBOUND
+Routes:
+  Resources:
+    edge-gateway:HTTP:8080:
+      name: edge-gateway:HTTP:8080
+      requestHeadersToRemove:
+      - x-kuma-tags
+      validateClusters: false
+      virtualHosts:
+      - domains:
+        - echo.example.com
+        name: edge-gateway:HTTP:8080:echo.example.com
+        routes:
+        - match:
+            prefix: /
+          route:
+            weightedClusters:
+              totalWeight: 0
+Runtimes:
+  Resources: {}
+Secrets:
+  Resources: {}

--- a/pkg/plugins/runtime/gateway/traffic_route_generator.go
+++ b/pkg/plugins/runtime/gateway/traffic_route_generator.go
@@ -51,6 +51,14 @@ func (*TrafficRouteGenerator) GenerateHost(ctx xds_context.Context, info *Gatewa
 		return nil, nil
 	}
 
+	// TrafficRoute doesn't support wildcard hosts because there's
+	// no way to populate a virtualhost domain name from the route.
+	// We don't error here, because if we did, the default traffic
+	// route would always cause the error.
+	if info.Host.Hostname == WildcardHostname {
+		return nil, nil
+	}
+
 	log.V(1).Info("applying merged traffic routes",
 		"listener-port", info.Listener.Port,
 		"listener-name", info.Listener.ResourceName,

--- a/pkg/plugins/runtime/gateway/traffic_route_generator.go
+++ b/pkg/plugins/runtime/gateway/traffic_route_generator.go
@@ -18,7 +18,7 @@ import (
 	"github.com/kumahq/kuma/pkg/xds/generator"
 )
 
-func selectTrafficRoutes(in []model.Resource) []*core_mesh.TrafficRouteResource {
+func filterTrafficRoutes(in []model.Resource) []*core_mesh.TrafficRouteResource {
 	routes := make([]*core_mesh.TrafficRouteResource, 0, len(in))
 
 	for _, r := range in {
@@ -46,7 +46,7 @@ func (*TrafficRouteGenerator) SupportsProtocol(p mesh_proto.Gateway_Listener_Pro
 func (*TrafficRouteGenerator) GenerateHost(ctx xds_context.Context, info *GatewayResourceInfo) (*core_xds.ResourceSet, error) {
 	resources := ResourceAggregator{}
 
-	trafficRoute := merge.TrafficRoute(selectTrafficRoutes(info.Host.Routes)...)
+	trafficRoute := merge.TrafficRoute(filterTrafficRoutes(info.Host.Routes)...)
 	if trafficRoute == nil {
 		return nil, nil
 	}


### PR DESCRIPTION

### Summary

Update the binding between Gateway and GatewayRoute resources. This can
be a bit complex because both size can have an optional hostname and we
have to map that to Envoy's slightly different concept of virtual host.

### Full changelog

N/A

### Issues resolved

N/A

### Documentation

N/A

### Testing

- [x] Unit tests
- [x] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes 

### Backwards compatibility

- [x] Add `backport-to-stable` label if the code is backwards compatible. Otherwise, list breaking changes.
