### PR TITLE
feat(dns) internal dns should resolve AAAA records

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1298,11 +1298,11 @@ workflows:
           - images
           - check
 # keep this one disabled and enable only for development
-    - e2e:
-        <<: *commit_workflow_filters
-        name: test/e2e-ipv6
-        # custom parameters
-        ipv6: true
+#    - e2e:
+#        <<: *commit_workflow_filters
+#        name: test/e2e-ipv6
+#        # custom parameters
+#        ipv6: true
 
   clean-eks:
     when: << pipeline.parameters.run_workflow_clean_eks >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1298,11 +1298,11 @@ workflows:
           - images
           - check
 # keep this one disabled and enable only for development
-#    - e2e:
-#        <<: *commit_workflow_filters
-#        name: test/e2e-ipv6
-#        # custom parameters
-#        ipv6: true
+    - e2e:
+        <<: *commit_workflow_filters
+        name: test/e2e-ipv6
+        # custom parameters
+        ipv6: true
 
   clean-eks:
     when: << pipeline.parameters.run_workflow_clean_eks >>

--- a/pkg/dns/server.go
+++ b/pkg/dns/server.go
@@ -14,6 +14,7 @@ import (
 	"github.com/kumahq/kuma/pkg/core"
 	"github.com/kumahq/kuma/pkg/dns/resolver"
 	core_metrics "github.com/kumahq/kuma/pkg/metrics"
+	util_net "github.com/kumahq/kuma/pkg/util/net"
 )
 
 const dnsTTL = "60"
@@ -65,17 +66,20 @@ func (h *SimpleDNSServer) parseQuery(m *dns.Msg) {
 	for _, q := range m.Question {
 		switch q.Qtype {
 		case dns.TypeA, dns.TypeAAAA:
-			serverLog.V(1).Info("received a query for " + q.Name)
+			serverLog.Info("received a query", "name", q.Name, "type", q.Qtype)
 			ip, err := h.lookup(q.Name)
 			if err != nil {
-				serverLog.V(1).Info("unable to resolve", "Name", q.Name, "error", err.Error())
+				serverLog.V(1).Info("unable to resolve", "name", q.Name, "error", err.Error())
 				h.resolutionMetric.WithLabelValues("unresolved").Inc()
 				return
 			}
 			h.resolutionMetric.WithLabelValues("resolved").Inc()
 
 			recordType := "A"
-			if govalidator.IsIPv6(ip) {
+			if q.Qtype == dns.TypeAAAA {
+				recordType = "AAAA"
+				ip = util_net.ToV6(ip)
+			} else if govalidator.IsIPv6(ip) {
 				recordType = "AAAA"
 			}
 

--- a/pkg/dns/server.go
+++ b/pkg/dns/server.go
@@ -66,7 +66,7 @@ func (h *SimpleDNSServer) parseQuery(m *dns.Msg) {
 	for _, q := range m.Question {
 		switch q.Qtype {
 		case dns.TypeA, dns.TypeAAAA:
-			serverLog.Info("received a query", "name", q.Name, "type", q.Qtype)
+			serverLog.V(1).Info("received a query", "name", q.Name, "type", q.Qtype)
 			ip, err := h.lookup(q.Name)
 			if err != nil {
 				serverLog.V(1).Info("unable to resolve", "name", q.Name, "error", err.Error())

--- a/pkg/util/net/ips.go
+++ b/pkg/util/net/ips.go
@@ -1,6 +1,7 @@
 package net
 
 import (
+	"fmt"
 	"net"
 	"sort"
 
@@ -21,4 +22,13 @@ func GetAllIPs() ([]string, error) {
 	}
 	sort.Strings(result) // sort so IPv4 are the first elements in the list
 	return result, nil
+}
+
+// ToV6 return self if ip6 other return the v4 prefixed with ::ffff:
+func ToV6(ip string) string {
+	parsedIp := net.ParseIP(ip)
+	if parsedIp.To4() != nil {
+		return fmt.Sprintf("::ffff:%x:%x", uint32(parsedIp[12])<<8+uint32(parsedIp[13]), uint32(parsedIp[14])<<8+uint32(parsedIp[15]))
+	}
+	return ip
 }

--- a/pkg/util/net/ips_test.go
+++ b/pkg/util/net/ips_test.go
@@ -1,0 +1,18 @@
+package net_test
+
+import (
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+
+	"github.com/kumahq/kuma/pkg/util/net"
+)
+
+var _ = DescribeTable("ToV6",
+	func(given string, expected string) {
+		Expect(net.ToV6(given)).To(Equal(expected))
+	},
+	Entry("v6 already", "2001:db8::ff00:42:8329", "2001:db8::ff00:42:8329"),
+	Entry("v6 not compacted", "2001:0db8:0000:0000:0000:ff00:0042:8329", "2001:0db8:0000:0000:0000:ff00:0042:8329"),
+	Entry("v4 adds prefix", "240.0.0.0", "::ffff:f000:0"),
+	Entry("v4 adds prefix", "240.0.255.0", "::ffff:f000:ff00"),
+)

--- a/pkg/xds/envoy/listeners/listener_configurers.go
+++ b/pkg/xds/envoy/listeners/listener_configurers.go
@@ -61,7 +61,7 @@ func FilterChain(builder *FilterChainBuilder) ListenerBuilderOpt {
 	)
 }
 
-func DNS(vips map[string]string, emptyDnsPort uint32) ListenerBuilderOpt {
+func DNS(vips map[string][]string, emptyDnsPort uint32) ListenerBuilderOpt {
 	return AddListenerConfigurer(&v3.DNSConfigurer{
 		VIPs:         vips,
 		EmptyDNSPort: emptyDnsPort,

--- a/pkg/xds/envoy/listeners/v3/dns_configurer.go
+++ b/pkg/xds/envoy/listeners/v3/dns_configurer.go
@@ -14,7 +14,7 @@ import (
 )
 
 type DNSConfigurer struct {
-	VIPs         map[string]string
+	VIPs         map[string][]string
 	EmptyDNSPort uint32
 }
 
@@ -41,7 +41,7 @@ func (c *DNSConfigurer) dnsFilter() *envoy_dns.DnsFilterConfig {
 			Endpoint: &envoy_data_dns.DnsTable_DnsEndpoint{
 				EndpointConfig: &envoy_data_dns.DnsTable_DnsEndpoint_AddressList{
 					AddressList: &envoy_data_dns.DnsTable_AddressList{
-						Address: []string{ips},
+						Address: ips,
 					},
 				},
 			},

--- a/pkg/xds/envoy/listeners/v3/dns_configurer_test.go
+++ b/pkg/xds/envoy/listeners/v3/dns_configurer_test.go
@@ -15,7 +15,7 @@ import (
 var _ = Describe("DNSConfigurer", func() {
 
 	type testCase struct {
-		vips         map[string]string
+		vips         map[string][]string
 		emptyDnsPort uint32
 		expected     string
 	}
@@ -37,10 +37,10 @@ var _ = Describe("DNSConfigurer", func() {
 			Expect(actual).To(MatchYAML(given.expected))
 		},
 		Entry("basic TCP listener", testCase{
-			vips: map[string]string{
-				"something.mesh": "240.0.0.0",
-				"something.com":  "240.0.0.0",
-				"backend.mesh":   "240.0.0.1",
+			vips: map[string][]string{
+				"something.mesh": {"240.0.0.0"},
+				"something.com":  {"240.0.0.0"},
+				"backend.mesh":   {"240.0.0.1", "::2"},
 			},
 			emptyDnsPort: 53002,
 			expected: `
@@ -71,6 +71,7 @@ var _ = Describe("DNSConfigurer", func() {
                         addressList:
                           address:
                           - 240.0.0.1
+                          - ::2
                       name: backend.mesh
                     - answerTtl: 30s
                       endpoint:

--- a/pkg/xds/generator/dns_generator.go
+++ b/pkg/xds/generator/dns_generator.go
@@ -2,6 +2,7 @@ package generator
 
 import (
 	core_xds "github.com/kumahq/kuma/pkg/core/xds"
+	util_net "github.com/kumahq/kuma/pkg/util/net"
 	xds_context "github.com/kumahq/kuma/pkg/xds/context"
 	envoy_listeners "github.com/kumahq/kuma/pkg/xds/envoy/listeners"
 	"github.com/kumahq/kuma/pkg/xds/envoy/names"
@@ -24,10 +25,14 @@ func (g DNSGenerator) Generate(ctx xds_context.Context, proxy *core_xds.Proxy) (
 		return nil, nil // DNS only makes sense when transparent proxy is used
 	}
 
-	vips := map[string]string{}
+	vips := map[string][]string{}
 	for _, dnsOutbound := range proxy.Routing.VipDomains {
 		for _, domain := range dnsOutbound.Domains {
-			vips[domain] = dnsOutbound.Address
+			vips[domain] = []string{dnsOutbound.Address}
+			v6 := util_net.ToV6(dnsOutbound.Address)
+			if v6 != dnsOutbound.Address { // It's already a v6
+				vips[domain] = append(vips[domain], v6)
+			}
 		}
 	}
 

--- a/pkg/xds/generator/dns_generator_test.go
+++ b/pkg/xds/generator/dns_generator_test.go
@@ -59,6 +59,7 @@ var _ = Describe("DNSGenerator", func() {
 					VipDomains: []model.VIPDomains{
 						{Address: "240.0.0.1", Domains: []string{"httpbin.mesh"}},
 						{Address: "240.0.0.0", Domains: []string{"backend.test-ns.svc.8080.mesh", "backend_test-ns_svc_8080.mesh"}},
+						{Address: "2001:db8::ff00:42:8329", Domains: []string{"frontend.test-ns.svc.8080.mesh", "frontend_test-ns_svc_8080.mesh"}},
 					},
 				},
 				Metadata: &model.DataplaneMetadata{

--- a/pkg/xds/generator/testdata/dns/1-envoy-config.golden.yaml
+++ b/pkg/xds/generator/testdata/dns/1-envoy-config.golden.yaml
@@ -29,18 +29,33 @@ resources:
                 addressList:
                   address:
                   - 240.0.0.0
+                  - ::ffff:f000:0
               name: backend.test-ns.svc.8080.mesh
             - answerTtl: 30s
               endpoint:
                 addressList:
                   address:
                   - 240.0.0.0
+                  - ::ffff:f000:0
               name: backend_test-ns_svc_8080.mesh
             - answerTtl: 30s
               endpoint:
                 addressList:
                   address:
+                  - 2001:db8::ff00:42:8329
+              name: frontend.test-ns.svc.8080.mesh
+            - answerTtl: 30s
+              endpoint:
+                addressList:
+                  address:
+                  - 2001:db8::ff00:42:8329
+              name: frontend_test-ns_svc_8080.mesh
+            - answerTtl: 30s
+              endpoint:
+                addressList:
+                  address:
                   - 240.0.0.1
+                  - ::ffff:f000:1
               name: httpbin.mesh
         statPrefix: kuma_dns
     name: kuma:dns


### PR DESCRIPTION
### Summary

In the past we were sometimes running into issues in dual stack setup
because we would only assign a v4 address and only A records would work.

Leverage Envoy's :ffff prefix to be able to have AAAA and an A record
when using a v4 cidr

### Full changelog

* Add multiple ips to envoy dns filter
* Add v6 address when using v4 only leveraging [envoy :ffff prefix](https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/core/v3/address.proto.html#config-core-v3-socketaddress)

### Testing

- [x] Unit tests
- [ ] E2E tests
- [x] Manual testing on Universal
- [ ] Manual testing on Kubernetes 

### Backwards compatibility

- [x] Add `backport-to-stable` label if the code is backwards compatible. Otherwise, list breaking changes.
