### PR TITLE
fix(kuma-cp) pick all matched traffic permissions

### DIFF
--- a/pkg/core/permissions/matcher.go
+++ b/pkg/core/permissions/matcher.go
@@ -41,11 +41,13 @@ func BuildTrafficPermissionMap(
 		return nil, errors.Wrap(err, "could not fetch additional inbounds")
 	}
 	inbounds := append(dataplane.Spec.GetNetworking().GetInbound(), additionalInbounds...)
-	policyMap := policy.SelectInboundConnectionPolicies(dataplane, inbounds, policies)
+	policyMap := policy.SelectInboundConnectionMatchingPolicies(dataplane, inbounds, policies)
 
 	result := core_xds.TrafficPermissionMap{}
-	for inbound, connectionPolicy := range policyMap {
-		result[inbound] = connectionPolicy.(*core_mesh.TrafficPermissionResource)
+	for inbound, connectionPolicies := range policyMap {
+		for _, connectionPolicy := range connectionPolicies {
+			result[inbound] = append(result[inbound], connectionPolicy.(*core_mesh.TrafficPermissionResource))
+		}
 	}
 	return result, nil
 }

--- a/pkg/core/policy/connection_matcher.go
+++ b/pkg/core/policy/connection_matcher.go
@@ -138,22 +138,6 @@ func SelectConnectionPolicies(dataplane *core_mesh.DataplaneResource, destinatio
 	return policyMap
 }
 
-// SelectInboundConnectionPolicies picks a single the most specific policy for each inbound interface of a given Dataplane.
-// For each inbound we pick a policy that matches the most destination tags with inbound tags
-// Sources part of matched policies are later used in Envoy config to apply it only for connection that matches sources
-func SelectInboundConnectionPolicies(dataplane *core_mesh.DataplaneResource, inbounds []*mesh_proto.Dataplane_Networking_Inbound, policies []ConnectionPolicy) InboundConnectionPolicyMap {
-	sort.Stable(ConnectionPolicyByName(policies)) // sort to avoid flakiness
-	policiesMap := make(InboundConnectionPolicyMap)
-	for _, inbound := range inbounds {
-		if bestPolicy := SelectInboundConnectionPolicy(inbound.Tags, policies); bestPolicy != nil {
-			iface := dataplane.Spec.GetNetworking().ToInboundInterface(inbound)
-			policiesMap[iface] = bestPolicy
-		}
-	}
-
-	return policiesMap
-}
-
 // SelectInboundConnectionAllPolicies picks all matching policies for each inbound interface of a given Dataplane.
 func SelectInboundConnectionMatchingPolicies(dataplane *core_mesh.DataplaneResource, inbounds []*mesh_proto.Dataplane_Networking_Inbound, policies []ConnectionPolicy) InboundConnectionPoliciesMap {
 	sort.Stable(ConnectionPolicyByName(policies)) // sort to avoid flakiness

--- a/pkg/core/xds/types.go
+++ b/pkg/core/xds/types.go
@@ -97,8 +97,8 @@ type RetryMap map[ServiceName]*core_mesh.RetryResource
 // FaultInjectionMap holds all matched FaultInjectionResources for each InboundInterface
 type FaultInjectionMap map[mesh_proto.InboundInterface][]*mesh_proto.FaultInjection
 
-// TrafficPermissionMap holds the most specific TrafficPermissionResource for each InboundInterface
-type TrafficPermissionMap map[mesh_proto.InboundInterface]*core_mesh.TrafficPermissionResource
+// TrafficPermissionMap holds all matched TrafficPermissionResources for each InboundInterface
+type TrafficPermissionMap map[mesh_proto.InboundInterface][]*core_mesh.TrafficPermissionResource
 
 // InboundRateLimitsMap holds all RateLimitResources for each InboundInterface
 type InboundRateLimitsMap map[mesh_proto.InboundInterface][]*mesh_proto.RateLimit

--- a/pkg/xds/envoy/listeners/filter_chain_configurers.go
+++ b/pkg/xds/envoy/listeners/filter_chain_configurers.go
@@ -73,7 +73,7 @@ func SourceMatcher(address string) FilterChainBuilderOpt {
 	})
 }
 
-func NetworkRBAC(statsName string, rbacEnabled bool, permission *core_mesh.TrafficPermissionResource) FilterChainBuilderOpt {
+func NetworkRBAC(statsName string, rbacEnabled bool, permission ...*core_mesh.TrafficPermissionResource) FilterChainBuilderOpt {
 	if !rbacEnabled {
 		return FilterChainBuilderOptFunc(nil)
 	}

--- a/pkg/xds/generator/inbound_proxy_generator.go
+++ b/pkg/xds/generator/inbound_proxy_generator.go
@@ -100,7 +100,7 @@ func (g InboundProxyGenerator) Generate(ctx xds_context.Context, proxy *model.Pr
 					Configure(envoy_listeners.ServerSideMTLS(ctx))
 			}
 			return filterChainBuilder.
-				Configure(envoy_listeners.NetworkRBAC(inboundListenerName, ctx.Mesh.Resource.MTLSEnabled(), proxy.Policies.TrafficPermissions[endpoint]))
+				Configure(envoy_listeners.NetworkRBAC(inboundListenerName, ctx.Mesh.Resource.MTLSEnabled(), proxy.Policies.TrafficPermissions[endpoint]...))
 		}
 
 		listenerBuilder := envoy_listeners.NewListenerBuilder(proxy.APIVersion).

--- a/pkg/xds/generator/inbound_proxy_generator_test.go
+++ b/pkg/xds/generator/inbound_proxy_generator_test.go
@@ -80,7 +80,7 @@ var _ = Describe("InboundProxyGenerator", func() {
 							DataplanePort:         80,
 							WorkloadIP:            "127.0.0.1",
 							WorkloadPort:          8080,
-						}: &core_mesh.TrafficPermissionResource{
+						}: []*core_mesh.TrafficPermissionResource{{
 							Meta: &test_model.ResourceMeta{
 								Name: "tp-1",
 								Mesh: "default",
@@ -103,7 +103,7 @@ var _ = Describe("InboundProxyGenerator", func() {
 									},
 								},
 							},
-						},
+						}},
 					},
 					FaultInjections: model.FaultInjectionMap{
 						mesh_proto.InboundInterface{

--- a/pkg/xds/generator/prometheus_endpoint_generator.go
+++ b/pkg/xds/generator/prometheus_endpoint_generator.go
@@ -126,7 +126,7 @@ func (g PrometheusEndpointGenerator) Generate(ctx xds_context.Context, proxy *co
 					},
 				})).
 				Configure(envoy_listeners.ServerSideMTLS(ctx)).
-				Configure(envoy_listeners.NetworkRBAC(prometheusListenerName, ctx.Mesh.Resource.MTLSEnabled(), proxy.Policies.TrafficPermissions[iface])),
+				Configure(envoy_listeners.NetworkRBAC(prometheusListenerName, ctx.Mesh.Resource.MTLSEnabled(), proxy.Policies.TrafficPermissions[iface]...)),
 			)).
 			Build()
 	} else {

--- a/pkg/xds/server/v3/snapshot_generator_test.go
+++ b/pkg/xds/server/v3/snapshot_generator_test.go
@@ -85,7 +85,7 @@ var _ = Describe("Reconcile", func() {
 							DataplanePort:         80,
 							WorkloadIP:            "127.0.0.1",
 							WorkloadPort:          8080,
-						}: &core_mesh.TrafficPermissionResource{
+						}: []*core_mesh.TrafficPermissionResource{{
 							Meta: &test_model.ResourceMeta{
 								Name: "tp-1",
 								Mesh: "default",
@@ -109,7 +109,7 @@ var _ = Describe("Reconcile", func() {
 								},
 							},
 						},
-					},
+						}},
 				},
 				Metadata: &model.DataplaneMetadata{},
 			}


### PR DESCRIPTION
### Summary

Same as https://github.com/kumahq/kuma/pull/2757, but for Traffic Permissions. Since we apply them on the inbound, probably we can pick all matched policies (not a single one). 

Because of this change, we can delete the function `SelectInboundConnectionPolicies`.

### Full changelog

* [Implement ...]
* [Fix ...]

### Issues resolved

Fix #XXX

### Documentation

- [ ] Link to the website [documentation PR](https://github.com/kumahq/kuma-website/pull/XXX)

### Testing

- [X] Unit tests
- [X] E2E tests
- [X] Manual testing on Universal
- [ ] Manual testing on Kubernetes 

### Backwards compatibility

- [ ] Add `backport-to-stable` label if the code is backwards compatible. Otherwise, list breaking changes.
