### PR TITLE
Adds support for specifying specific IP for cloud provider load balan…

### DIFF
--- a/deployments/charts/kuma/templates/cp-global-sync-service.yaml
+++ b/deployments/charts/kuma/templates/cp-global-sync-service.yaml
@@ -10,6 +10,9 @@ metadata:
     {{- end }}
 spec:
   type: {{ .Values.controlPlane.globalZoneSyncService.type }}
+  {{- if .Values.controlPlane.globalZoneSyncService.loadBalancerIP }}
+  loadBalancerIP: {{ .Values.controlPlane.globalZoneSyncService.loadBalancerIP }}
+  {{- end }}
   ports:
     - port: {{ .Values.controlPlane.globalZoneSyncService.port }}
   {{- if eq .Values.controlPlane.globalZoneSyncService.type "NodePort" }}

--- a/deployments/charts/kuma/templates/cp-service.yaml
+++ b/deployments/charts/kuma/templates/cp-service.yaml
@@ -29,7 +29,7 @@ spec:
     - port: 5653
       name: dns-server
       protocol: UDP
-  {{- end }}
+    {{- end }}
   selector:
     app: {{ include "kuma.name" . }}-control-plane
   {{- include "kuma.selectorLabels" . | nindent 4 }}

--- a/deployments/charts/kuma/templates/ingress-service.yaml
+++ b/deployments/charts/kuma/templates/ingress-service.yaml
@@ -12,6 +12,9 @@ metadata:
     {{- end }}
 spec:
   type: {{ .Values.ingress.service.type }}
+  {{- if .Values.ingress.service.loadBalancerIP }}
+  loadBalancerIP: {{ .Values.ingress.service.loadBalancerIP }}
+  {{- end }}
   ports:
     - port: {{ .Values.ingress.service.port }}
       protocol: TCP

--- a/deployments/charts/kuma/values.yaml
+++ b/deployments/charts/kuma/values.yaml
@@ -73,6 +73,8 @@ controlPlane:
   globalZoneSyncService:
     # -- Service type of the Global-zone sync
     type: LoadBalancer
+    # -- (string) Optionally specify IP to be used by cloud provider when configuring load balancer
+    loadBalancerIP:
     # -- Additional annotations to put on the Global Zone Sync Service
     annotations: { }
     # -- Port on which Global Zone Sync Service is exposed
@@ -178,6 +180,8 @@ ingress:
   service:
     # -- Service type of the Ingress
     type: LoadBalancer
+    # -- (string) Optionally specify IP to be used by cloud provider when configuring load balancer
+    loadBalancerIP:
     # -- Additional annotations to put on the Ingress service
     annotations: { }
     # -- Port on which Ingress is exposed


### PR DESCRIPTION
### Summary

Adds support for specifying specific IP for cloud provider load balancers, see: https://kubernetes.io/docs/concepts/services-networking/service/\#loadbalancer or https://docs.microsoft.com/en-us/azure/aks/static-ip\#create-a-service-using-the-static-ip-address

### Full changelog

* added ability to configure loadBalancerIP to for control plane service

### Documentation

- documented in deployments/charts/kuma/values.yaml

### Testing

- [X] Manual testing on Kubernetes 

### Backwards compatibility

- [X] Add `backport-to-stable` label if the code is backwards compatible. Otherwise, list breaking changes.
