### PR TITLE
fix(*) send tool output to stdout

### DIFF
--- a/app/kuma-cp/cmd/root.go
+++ b/app/kuma-cp/cmd/root.go
@@ -58,16 +58,21 @@ func newRootCmd() *cobra.Command {
 			return nil
 		},
 	}
+
+	cmd.SetOut(os.Stdout)
+
 	// root flags
 	cmd.PersistentFlags().StringVar(&args.logLevel, "log-level", kuma_log.InfoLevel.String(), kuma_cmd.UsageOptions("log level", kuma_log.OffLevel, kuma_log.InfoLevel, kuma_log.DebugLevel))
 	cmd.PersistentFlags().StringVar(&args.outputPath, "log-output-path", args.outputPath, "path to the file that will be filled with logs. Example: if we set it to /tmp/kuma.log then after the file is rotated we will have /tmp/kuma-2021-06-07T09-15-18.265.log")
 	cmd.PersistentFlags().IntVar(&args.maxBackups, "log-max-retained-files", 1000, "maximum number of the old log files to retain")
 	cmd.PersistentFlags().IntVar(&args.maxSize, "log-max-size", 100, "maximum size in megabytes of a log file before it gets rotated")
 	cmd.PersistentFlags().IntVar(&args.maxAge, "log-max-age", 30, "maximum number of days to retain old log files based on the timestamp encoded in their filename")
+
 	// sub-commands
 	cmd.AddCommand(newRunCmd())
 	cmd.AddCommand(newMigrateCmd())
 	cmd.AddCommand(version.NewVersionCmd())
+
 	return cmd
 }
 

--- a/app/kuma-dp/cmd/root.go
+++ b/app/kuma-dp/cmd/root.go
@@ -35,6 +35,7 @@ func NewRootCmd(rootCtx *RootContext) *cobra.Command {
 			if err != nil {
 				return err
 			}
+
 			if args.outputPath != "" {
 				output, err := filepath.Abs(args.outputPath)
 				if err != nil {
@@ -55,15 +56,20 @@ func NewRootCmd(rootCtx *RootContext) *cobra.Command {
 			return nil
 		},
 	}
+
+	cmd.SetOut(os.Stdout)
+
 	// root flags
 	cmd.PersistentFlags().StringVar(&args.logLevel, "log-level", kuma_log.InfoLevel.String(), kuma_cmd.UsageOptions("log level", kuma_log.OffLevel, kuma_log.InfoLevel, kuma_log.DebugLevel))
 	cmd.PersistentFlags().StringVar(&args.outputPath, "log-output-path", args.outputPath, "path to the file that will be filled with logs. Example: if we set it to /tmp/kuma.log then after the file is rotated we will have /tmp/kuma-2021-06-07T09-15-18.265.log")
 	cmd.PersistentFlags().IntVar(&args.maxBackups, "log-max-retained-files", 1000, "maximum number of the old log files to retain")
 	cmd.PersistentFlags().IntVar(&args.maxSize, "log-max-size", 100, "maximum size in megabytes of a log file before it gets rotated")
 	cmd.PersistentFlags().IntVar(&args.maxAge, "log-max-age", 30, "maximum number of days to retain old log files based on the timestamp encoded in their filename")
+
 	// sub-commands
 	cmd.AddCommand(newRunCmd(rootCtx))
 	cmd.AddCommand(version.NewVersionCmd())
+
 	return cmd
 }
 

--- a/app/kumactl/cmd/root.go
+++ b/app/kumactl/cmd/root.go
@@ -92,11 +92,15 @@ func NewRootCmd(root *kumactl_cmd.RootContext) *cobra.Command {
 			return nil
 		},
 	}
+
+	cmd.SetOut(os.Stdout)
+
 	// root flags
 	cmd.PersistentFlags().StringVar(&root.Args.ConfigFile, "config-file", "", "path to the configuration file to use")
 	cmd.PersistentFlags().StringVarP(&root.Args.Mesh, "mesh", "m", "default", "mesh to use")
 	cmd.PersistentFlags().StringVar(&args.logLevel, "log-level", kuma_log.OffLevel.String(), kuma_cmd.UsageOptions("log level", kuma_log.OffLevel, kuma_log.InfoLevel, kuma_log.DebugLevel))
 	cmd.PersistentFlags().BoolVar(&args.noConfig, "no-config", false, "if set no config file and config directory will be created")
+
 	// sub-commands
 	cmd.AddCommand(apply.NewApplyCmd(root))
 	cmd.AddCommand(completion.NewCompletionCommand(root))


### PR DESCRIPTION
### Summary

Cobra defaults to writing all output to stderr. Change each root command
to set the standard output stream to stdout so that normal and error
output is separated as expected.

```
$ kumactl version 
WARNING: Unable to confirm the server supports this kumactl version
Kuma: 1.2.0-233-g731d6e34
$ kumactl version 2>/dev/null
Kuma: 1.2.0-233-g731d6e34
$ 
```

### Full changelog

* Fix the Kuma command-line tools to correctly send normal output to standard out and errors to standard error.

### Issues resolved

Fix #2786

### Documentation

N/A

### Testing

- [x] Unit tests
- [x] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes 

### Backwards compatibility

- [x] Add `backport-to-stable` label if the code is backwards compatible. Otherwise, list breaking changes.
