### PR TITLE
chore(ci) remove from dependabot conf reference to go.mod

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,24 +6,6 @@ updates:
       interval: "weekly"
     labels:
       - "dependencies"
-  - package-ecosystem: "gomod"
-    directory: "/api/"
-    schedule:
-      interval: "weekly"
-    labels:
-      - "dependencies"
-  - package-ecosystem: "gomod"
-    directory: "/pkg/plugins/resources/k8s/native/"
-    schedule:
-      interval: "weekly"
-    labels:
-      - "dependencies"
-  - package-ecosystem: "gomod"
-    directory: "/tools/releases/changelog"
-    schedule:
-      interval: "weekly"
-    labels:
-      - "dependencies"
   - package-ecosystem: "docker"
     directory: "/tools/releases/dockerfiles"
     schedule:


### PR DESCRIPTION
These go.mod were removed, there's no good reason to keep them around

### Backwards compatibility

- [x] Add `backport-to-stable` label if the code is backwards compatible. Otherwise, list breaking changes.
