### PR TITLE
chore(*) migrate from closed channel to context for app lifetime

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -34,6 +34,8 @@ linters-settings:
       alias: mesh_proto
     - pkg: github.com/kumahq/kuma/pkg/util/proto
       alias: util_proto
+    - pkg: github.com/kumahq/kuma/pkg/cmd
+      alias: kuma_cmd
   gomodguard:
     blocked:
       modules:

--- a/app/kuma-cp/cmd/root.go
+++ b/app/kuma-cp/cmd/root.go
@@ -65,7 +65,7 @@ func newRootCmd() *cobra.Command {
 	cmd.PersistentFlags().IntVar(&args.maxSize, "log-max-size", 100, "maximum size in megabytes of a log file before it gets rotated")
 	cmd.PersistentFlags().IntVar(&args.maxAge, "log-max-age", 30, "maximum number of days to retain old log files based on the timestamp encoded in their filename")
 	// sub-commands
-	cmd.AddCommand(newRunCmd())
+	cmd.AddCommand(newRunCmdWithOpts(kuma_cmd.DefaultRunCmdOpts))
 	cmd.AddCommand(newMigrateCmd())
 	cmd.AddCommand(version.NewVersionCmd())
 	return cmd

--- a/app/kuma-cp/cmd/run.go
+++ b/app/kuma-cp/cmd/run.go
@@ -8,10 +8,10 @@ import (
 
 	api_server "github.com/kumahq/kuma/pkg/api-server"
 	"github.com/kumahq/kuma/pkg/clusterid"
+	"github.com/kumahq/kuma/pkg/cmd"
 	"github.com/kumahq/kuma/pkg/config"
 	kuma_cp "github.com/kumahq/kuma/pkg/config/app/kuma-cp"
 	config_core "github.com/kumahq/kuma/pkg/config/core"
-	"github.com/kumahq/kuma/pkg/core"
 	"github.com/kumahq/kuma/pkg/core/bootstrap"
 	"github.com/kumahq/kuma/pkg/defaults"
 	"github.com/kumahq/kuma/pkg/diagnostics"
@@ -39,17 +39,7 @@ const gracefullyShutdownDuration = 3 * time.Second
 // reasonably have enough descriptors to accept all its clients.
 const minOpenFileLimit = 4096
 
-func newRunCmd() *cobra.Command {
-	return newRunCmdWithOpts(runCmdOpts{
-		SetupSignalHandler: core.SetupSignalHandler,
-	})
-}
-
-type runCmdOpts struct {
-	SetupSignalHandler func() (stopCh <-chan struct{})
-}
-
-func newRunCmdWithOpts(opts runCmdOpts) *cobra.Command {
+func newRunCmdWithOpts(opts cmd.RunCmdOpts) *cobra.Command {
 	args := struct {
 		configPath string
 	}{}
@@ -64,8 +54,8 @@ func newRunCmdWithOpts(opts runCmdOpts) *cobra.Command {
 				runLog.Error(err, "could not load the configuration")
 				return err
 			}
-			closeCh := opts.SetupSignalHandler()
-			rt, err := bootstrap.Bootstrap(cfg, closeCh)
+			ctx := opts.SetupSignalHandler()
+			rt, err := bootstrap.Bootstrap(ctx, cfg)
 			if err != nil {
 				runLog.Error(err, "unable to set up Control Plane runtime")
 				return err
@@ -184,7 +174,7 @@ func newRunCmdWithOpts(opts runCmdOpts) *cobra.Command {
 			}
 
 			runLog.Info("starting Control Plane", "version", kuma_version.Build.Version)
-			if err := rt.Start(closeCh); err != nil {
+			if err := rt.Start(ctx.Done()); err != nil {
 				runLog.Error(err, "problem running Control Plane")
 				return err
 			}

--- a/app/kuma-dp/cmd/root.go
+++ b/app/kuma-dp/cmd/root.go
@@ -18,7 +18,7 @@ var (
 )
 
 // NewRootCmd represents the base command when called without any subcommands.
-func NewRootCmd(rootCtx *RootContext) *cobra.Command {
+func NewRootCmd(opts kuma_cmd.RunCmdOpts, rootCtx *RootContext) *cobra.Command {
 	args := struct {
 		logLevel   string
 		outputPath string
@@ -62,13 +62,13 @@ func NewRootCmd(rootCtx *RootContext) *cobra.Command {
 	cmd.PersistentFlags().IntVar(&args.maxSize, "log-max-size", 100, "maximum size in megabytes of a log file before it gets rotated")
 	cmd.PersistentFlags().IntVar(&args.maxAge, "log-max-age", 30, "maximum number of days to retain old log files based on the timestamp encoded in their filename")
 	// sub-commands
-	cmd.AddCommand(newRunCmd(rootCtx))
+	cmd.AddCommand(newRunCmd(opts, rootCtx))
 	cmd.AddCommand(version.NewVersionCmd())
 	return cmd
 }
 
 func DefaultRootCmd() *cobra.Command {
-	return NewRootCmd(DefaultRootContext())
+	return NewRootCmd(kuma_cmd.DefaultRunCmdOpts, DefaultRootContext())
 }
 
 // Execute adds all child commands to the root command and sets flags appropriately.

--- a/app/kuma-dp/cmd/root_test.go
+++ b/app/kuma-dp/cmd/root_test.go
@@ -3,12 +3,14 @@ package cmd
 import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+
+	kuma_cmd "github.com/kumahq/kuma/pkg/cmd"
 )
 
 var _ = Describe("root", func() {
 	It("should be possible to run `kuma-dp` without a sub-command", func() {
 		// given
-		cmd := NewRootCmd(DefaultRootContext())
+		cmd := NewRootCmd(kuma_cmd.DefaultRunCmdOpts, DefaultRootContext())
 		cmd.SetArgs([]string{})
 		// when
 		err := cmd.Execute()

--- a/app/kuma-dp/cmd/run_test.go
+++ b/app/kuma-dp/cmd/run_test.go
@@ -3,6 +3,7 @@
 package cmd
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -18,36 +19,26 @@ import (
 	. "github.com/onsi/gomega"
 
 	"github.com/kumahq/kuma/app/kuma-dp/pkg/dataplane/envoy"
+	kuma_cmd "github.com/kumahq/kuma/pkg/cmd"
 	kumadp "github.com/kumahq/kuma/pkg/config/app/kuma-dp"
-	"github.com/kumahq/kuma/pkg/core"
 	"github.com/kumahq/kuma/pkg/test"
 	"github.com/kumahq/kuma/pkg/xds/bootstrap/types"
 )
 
 var _ = Describe("run", func() {
 
-	var backupSetupSignalHandler func() <-chan struct{}
-
-	BeforeEach(func() {
-		backupSetupSignalHandler = core.SetupSignalHandler
-	})
-	AfterEach(func() {
-		core.SetupSignalHandler = backupSetupSignalHandler
-	})
-
-	var stopCh chan struct{}
-
-	BeforeEach(func() {
-		stopCh = make(chan struct{})
-
-		core.SetupSignalHandler = func() <-chan struct{} {
-			return stopCh
-		}
-	})
+	var cancel func()
+	var ctx context.Context
+	opts := kuma_cmd.RunCmdOpts{
+		SetupSignalHandler: func() context.Context {
+			return ctx
+		},
+	}
 
 	var tmpDir string
 
 	BeforeEach(func() {
+		ctx, cancel = context.WithCancel(context.Background())
 		var err error
 		tmpDir, err = ioutil.TempDir("", "")
 		Expect(err).ToNot(HaveOccurred())
@@ -110,7 +101,7 @@ var _ = Describe("run", func() {
 				return respBytes, "", nil
 			}
 			_, writer := io.Pipe()
-			cmd := NewRootCmd(rootCtx)
+			cmd := NewRootCmd(opts, rootCtx)
 			cmd.SetArgs(append([]string{"run"}, given.args...))
 			cmd.SetOut(writer)
 			cmd.SetErr(writer)
@@ -156,7 +147,7 @@ var _ = Describe("run", func() {
 
 			// when
 			By("signaling the dataplane manager to stop")
-			close(stopCh)
+			cancel()
 
 			// then
 			err = <-errCh
@@ -317,7 +308,7 @@ var _ = Describe("run", func() {
 		defer l.Close()
 
 		// given
-		cmd := NewRootCmd(DefaultRootContext())
+		cmd := NewRootCmd(opts, DefaultRootContext())
 		cmd.SetArgs([]string{
 			"run",
 			"--cp-address", "http://localhost:1234",
@@ -338,7 +329,7 @@ var _ = Describe("run", func() {
 
 	It("should fail when name and mesh is provided with dataplane definition", func() {
 		// given
-		cmd := NewRootCmd(DefaultRootContext())
+		cmd := NewRootCmd(opts, DefaultRootContext())
 		cmd.SetArgs([]string{
 			"run",
 			"--cp-address", "http://localhost:1234",
@@ -361,7 +352,7 @@ var _ = Describe("run", func() {
 
 	It("should fail when the proxy type is unknown", func() {
 		// given
-		cmd := NewRootCmd(DefaultRootContext())
+		cmd := NewRootCmd(opts, DefaultRootContext())
 		cmd.SetArgs([]string{
 			"run",
 			"--cp-address", "http://localhost:1234",

--- a/app/kuma-prometheus-sd/cmd/root.go
+++ b/app/kuma-prometheus-sd/cmd/root.go
@@ -18,7 +18,7 @@ var (
 )
 
 // newRootCmd represents the base command when called without any subcommands.
-func newRootCmd() *cobra.Command {
+func NewRootCmd(opts kuma_cmd.RunCmdOpts) *cobra.Command {
 	args := struct {
 		logLevel   string
 		outputPath string
@@ -60,13 +60,13 @@ func newRootCmd() *cobra.Command {
 	cmd.PersistentFlags().IntVar(&args.maxSize, "log-max-size", 100, "maximum size in megabytes of a log file before it gets rotated")
 	cmd.PersistentFlags().IntVar(&args.maxAge, "log-max-age", 30, "maximum number of days to retain old log files based on the timestamp encoded in their filename")
 	// sub-commands
-	cmd.AddCommand(newRunCmd())
+	cmd.AddCommand(newRunCmdWithOpts(opts))
 	cmd.AddCommand(version.NewVersionCmd())
 	return cmd
 }
 
 func DefaultRootCmd() *cobra.Command {
-	return newRootCmd()
+	return NewRootCmd(kuma_cmd.DefaultRunCmdOpts)
 }
 
 // Execute adds all child commands to the root command and sets flags appropriately.

--- a/app/kuma-prometheus-sd/cmd/root_helper_test.go
+++ b/app/kuma-prometheus-sd/cmd/root_helper_test.go
@@ -1,6 +1,1 @@
 package cmd
-
-var (
-	// make `newRootCmd` available to `cmd_test`
-	NewRootCmd = newRootCmd
-)

--- a/app/kuma-prometheus-sd/cmd/root_test.go
+++ b/app/kuma-prometheus-sd/cmd/root_test.go
@@ -10,7 +10,7 @@ import (
 var _ = Describe("root", func() {
 	It("should be possible to run `kuma-prometheus-sd` without a sub-command", func() {
 		// given
-		cmd := NewRootCmd()
+		cmd := DefaultRootCmd()
 		cmd.SetArgs([]string{})
 		// when
 		err := cmd.Execute()

--- a/app/kuma-prometheus-sd/cmd/run.go
+++ b/app/kuma-prometheus-sd/cmd/run.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"context"
 	"path/filepath"
 
 	"github.com/pkg/errors"
@@ -11,9 +10,9 @@ import (
 	"github.com/kumahq/kuma/app/kuma-prometheus-sd/pkg/discovery/xds"
 	"github.com/kumahq/kuma/app/kuma-prometheus-sd/pkg/discovery/xds/common"
 	util_log "github.com/kumahq/kuma/app/kuma-prometheus-sd/pkg/util/go-kit/log"
+	"github.com/kumahq/kuma/pkg/cmd"
 	"github.com/kumahq/kuma/pkg/config"
 	kuma_promsd "github.com/kumahq/kuma/pkg/config/app/kuma-prometheus-sd"
-	"github.com/kumahq/kuma/pkg/core"
 	util_os "github.com/kumahq/kuma/pkg/util/os"
 )
 
@@ -21,12 +20,7 @@ var (
 	runLog = prometheusSdLog.WithName("run")
 )
 
-var (
-	// overridable by unit tests
-	setupSignalHandler = core.SetupSignalHandler
-)
-
-func newRunCmd() *cobra.Command {
+func newRunCmdWithOpts(opts cmd.RunCmdOpts) *cobra.Command {
 	cfg := kuma_promsd.DefaultConfig()
 	cmd := &cobra.Command{
 		Use:   "run",
@@ -50,8 +44,7 @@ func newRunCmd() *cobra.Command {
 				return errors.Wrapf(err, "unable to write to directory %q", outputDir)
 			}
 
-			ctx, cancel := context.WithCancel(context.Background())
-			defer cancel()
+			ctx := opts.SetupSignalHandler()
 
 			discoverer, err := xds.NewDiscoverer(
 				common.DiscoveryConfig{
@@ -68,7 +61,6 @@ func newRunCmd() *cobra.Command {
 			discovery := adapter.NewAdapter(ctx, cfg.Prometheus.OutputFile, "xds_sd", discoverer, util_log.NewLogger(runLog.WithName("xds_sd"), "adapter"))
 			discovery.Run()
 
-			<-setupSignalHandler()
 			return nil
 		},
 	}

--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/go-logr/zapr v0.1.1
 	github.com/golang-migrate/migrate/v4 v4.14.1
 	github.com/golang/protobuf v1.5.2
+	github.com/google/uuid v1.2.0
 	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0
 	github.com/gruntwork-io/terratest v0.30.15
 	github.com/hoisie/mustache v0.0.0-20160804235033-6375acf62c69

--- a/pkg/clusterid/cluster_id_test.go
+++ b/pkg/clusterid/cluster_id_test.go
@@ -1,6 +1,8 @@
 package clusterid_test
 
 import (
+	"context"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
@@ -22,7 +24,7 @@ var _ = Describe("Cluster ID", func() {
 	It("should create and set cluster ID", func() {
 		// given runtime with cluster ID components
 		cfg := kuma_cp.DefaultConfig()
-		builder, err := runtime.BuilderFor(cfg)
+		builder, err := runtime.BuilderFor(context.Background(), cfg)
 		Expect(err).ToNot(HaveOccurred())
 		runtime, err := builder.Build()
 		Expect(err).ToNot(HaveOccurred())

--- a/pkg/cmd/util.go
+++ b/pkg/cmd/util.go
@@ -1,0 +1,15 @@
+package cmd
+
+import (
+	"context"
+
+	"github.com/kumahq/kuma/pkg/core"
+)
+
+type RunCmdOpts struct {
+	SetupSignalHandler func() context.Context
+}
+
+var DefaultRunCmdOpts = RunCmdOpts{
+	SetupSignalHandler: core.SetupSignalHandler,
+}

--- a/pkg/core/alias.go
+++ b/pkg/core/alias.go
@@ -1,25 +1,42 @@
 package core
 
 import (
+	"context"
+	"os"
+	"os/signal"
+	"syscall"
 	"time"
 
-	kube_uuid "k8s.io/apimachinery/pkg/util/uuid"
+	"github.com/google/uuid"
 	kube_log "sigs.k8s.io/controller-runtime/pkg/log"
-	kube_signals "sigs.k8s.io/controller-runtime/pkg/manager/signals"
 
 	kuma_log "github.com/kumahq/kuma/pkg/log"
 )
 
 var (
+	// TODO remove dependency on kubernetes see: https://github.com/kumahq/kuma/issues/2798
 	Log                   = kube_log.Log
 	NewLogger             = kuma_log.NewLogger
 	NewLoggerWithRotation = kuma_log.NewLoggerWithRotation
 	SetLogger             = kube_log.SetLogger
 	Now                   = time.Now
 
-	SetupSignalHandler = kube_signals.SetupSignalHandler
+	SetupSignalHandler = func() context.Context {
+		ctx, cancel := context.WithCancel(context.Background())
+		c := make(chan os.Signal, 2)
+		signal.Notify(c, os.Interrupt, syscall.SIGTERM)
+		go func() {
+			s := <-c
+			Log.Info("Received signal, stopping instance", "signal", s.String())
+			cancel()
+			s = <-c
+			Log.Info("Received second signal, force exit", "signal", s.String())
+			os.Exit(1)
+		}()
+		return ctx
+	}
 
 	NewUUID = func() string {
-		return string(kube_uuid.NewUUID())
+		return uuid.New().String()
 	}
 )

--- a/pkg/core/bootstrap/bootstrap.go
+++ b/pkg/core/bootstrap/bootstrap.go
@@ -44,11 +44,11 @@ import (
 	"github.com/kumahq/kuma/pkg/xds/secrets"
 )
 
-func buildRuntime(cfg kuma_cp.Config, closeCh <-chan struct{}) (core_runtime.Runtime, error) {
+func buildRuntime(appCtx context.Context, cfg kuma_cp.Config) (core_runtime.Runtime, error) {
 	if err := autoconfigure(&cfg); err != nil {
 		return nil, err
 	}
-	builder, err := core_runtime.BuilderFor(cfg, closeCh)
+	builder, err := core_runtime.BuilderFor(appCtx, cfg)
 	if err != nil {
 		return nil, err
 	}
@@ -140,8 +140,8 @@ func initializeMetrics(builder *core_runtime.Builder) error {
 	return nil
 }
 
-func Bootstrap(cfg kuma_cp.Config, closeCh <-chan struct{}) (core_runtime.Runtime, error) {
-	runtime, err := buildRuntime(cfg, closeCh)
+func Bootstrap(appCtx context.Context, cfg kuma_cp.Config) (core_runtime.Runtime, error) {
+	runtime, err := buildRuntime(appCtx, cfg)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/core/runtime/builder.go
+++ b/pkg/core/runtime/builder.go
@@ -56,34 +56,34 @@ var _ BuilderContext = &Builder{}
 
 // Builder represents a multi-step initialization process.
 type Builder struct {
-	cfg        kuma_cp.Config
-	cm         component.Manager
-	rs         core_store.ResourceStore
-	ss         store.SecretStore
-	cs         core_store.ResourceStore
-	rm         core_manager.CustomizableResourceManager
-	rom        core_manager.ReadOnlyResourceManager
-	cam        core_ca.Managers
-	dsl        datasource.Loader
-	ext        context.Context
-	dns        resolver.DNSResolver
-	configm    config_manager.ConfigManager
-	leadInfo   component.LeaderInfo
-	lif        lookup.LookupIPFunc
-	eac        admin.EnvoyAdminClient
-	metrics    metrics.Metrics
-	erf        events.ListenerFactory
-	apim       api_server.APIManager
-	xdsh       *xds_hooks.Hooks
-	cap        secrets.CaProvider
-	dps        *dp_server.DpServer
-	kdsctx     *kds_context.Context
-	mv         core_managers.MeshValidator
-	shutdownCh <-chan struct{}
+	cfg      kuma_cp.Config
+	cm       component.Manager
+	rs       core_store.ResourceStore
+	ss       store.SecretStore
+	cs       core_store.ResourceStore
+	rm       core_manager.CustomizableResourceManager
+	rom      core_manager.ReadOnlyResourceManager
+	cam      core_ca.Managers
+	dsl      datasource.Loader
+	ext      context.Context
+	dns      resolver.DNSResolver
+	configm  config_manager.ConfigManager
+	leadInfo component.LeaderInfo
+	lif      lookup.LookupIPFunc
+	eac      admin.EnvoyAdminClient
+	metrics  metrics.Metrics
+	erf      events.ListenerFactory
+	apim     api_server.APIManager
+	xdsh     *xds_hooks.Hooks
+	cap      secrets.CaProvider
+	dps      *dp_server.DpServer
+	kdsctx   *kds_context.Context
+	mv       core_managers.MeshValidator
+	appCtx   context.Context
 	*runtimeInfo
 }
 
-func BuilderFor(cfg kuma_cp.Config, closeCh <-chan struct{}) (*Builder, error) {
+func BuilderFor(appCtx context.Context, cfg kuma_cp.Config) (*Builder, error) {
 	hostname, err := os.Hostname()
 	if err != nil {
 		return nil, errors.Wrap(err, "could not get hostname")
@@ -96,7 +96,7 @@ func BuilderFor(cfg kuma_cp.Config, closeCh <-chan struct{}) (*Builder, error) {
 		runtimeInfo: &runtimeInfo{
 			instanceId: fmt.Sprintf("%s-%s", hostname, suffix),
 		},
-		shutdownCh: closeCh,
+		appCtx: appCtx,
 	}, nil
 }
 
@@ -278,28 +278,28 @@ func (b *Builder) Build() (Runtime, error) {
 	return &runtime{
 		RuntimeInfo: b.runtimeInfo,
 		RuntimeContext: &runtimeContext{
-			cfg:        b.cfg,
-			rm:         b.rm,
-			rom:        b.rom,
-			rs:         b.rs,
-			ss:         b.ss,
-			cam:        b.cam,
-			dsl:        b.dsl,
-			ext:        b.ext,
-			dns:        b.dns,
-			configm:    b.configm,
-			leadInfo:   b.leadInfo,
-			lif:        b.lif,
-			eac:        b.eac,
-			metrics:    b.metrics,
-			erf:        b.erf,
-			apim:       b.apim,
-			xdsh:       b.xdsh,
-			cap:        b.cap,
-			dps:        b.dps,
-			kdsctx:     b.kdsctx,
-			mv:         b.mv,
-			shutdownCh: b.shutdownCh,
+			cfg:      b.cfg,
+			rm:       b.rm,
+			rom:      b.rom,
+			rs:       b.rs,
+			ss:       b.ss,
+			cam:      b.cam,
+			dsl:      b.dsl,
+			ext:      b.ext,
+			dns:      b.dns,
+			configm:  b.configm,
+			leadInfo: b.leadInfo,
+			lif:      b.lif,
+			eac:      b.eac,
+			metrics:  b.metrics,
+			erf:      b.erf,
+			apim:     b.apim,
+			xdsh:     b.xdsh,
+			cap:      b.cap,
+			dps:      b.dps,
+			kdsctx:   b.kdsctx,
+			mv:       b.mv,
+			appCtx:   b.appCtx,
 		},
 		Manager: b.cm,
 	}, nil
@@ -371,6 +371,6 @@ func (b *Builder) KDSContext() *kds_context.Context {
 func (b *Builder) MeshValidator() core_managers.MeshValidator {
 	return b.mv
 }
-func (b *Builder) ShutdownCh() <-chan struct{} {
-	return b.shutdownCh
+func (b *Builder) AppCtx() context.Context {
+	return b.appCtx
 }

--- a/pkg/core/runtime/runtime.go
+++ b/pkg/core/runtime/runtime.go
@@ -61,7 +61,7 @@ type RuntimeContext interface {
 	DpServer() *dp_server.DpServer
 	KDSContext() *kds_context.Context
 	MeshValidator() core_managers.MeshValidator
-	ShutdownCh() <-chan struct{}
+	AppContext() context.Context
 }
 
 var _ Runtime = &runtime{}
@@ -100,29 +100,29 @@ func (i *runtimeInfo) GetClusterId() string {
 var _ RuntimeContext = &runtimeContext{}
 
 type runtimeContext struct {
-	cfg        kuma_cp.Config
-	rm         core_manager.ResourceManager
-	rs         core_store.ResourceStore
-	ss         store.SecretStore
-	cs         core_store.ResourceStore
-	rom        core_manager.ReadOnlyResourceManager
-	cam        ca.Managers
-	dsl        datasource.Loader
-	ext        context.Context
-	dns        resolver.DNSResolver
-	configm    config_manager.ConfigManager
-	leadInfo   component.LeaderInfo
-	lif        lookup.LookupIPFunc
-	eac        admin.EnvoyAdminClient
-	metrics    metrics.Metrics
-	erf        events.ListenerFactory
-	apim       api_server.APIInstaller
-	xdsh       *xds_hooks.Hooks
-	cap        secrets.CaProvider
-	dps        *dp_server.DpServer
-	kdsctx     *kds_context.Context
-	mv         core_managers.MeshValidator
-	shutdownCh <-chan struct{}
+	cfg      kuma_cp.Config
+	rm       core_manager.ResourceManager
+	rs       core_store.ResourceStore
+	ss       store.SecretStore
+	cs       core_store.ResourceStore
+	rom      core_manager.ReadOnlyResourceManager
+	cam      ca.Managers
+	dsl      datasource.Loader
+	ext      context.Context
+	dns      resolver.DNSResolver
+	configm  config_manager.ConfigManager
+	leadInfo component.LeaderInfo
+	lif      lookup.LookupIPFunc
+	eac      admin.EnvoyAdminClient
+	metrics  metrics.Metrics
+	erf      events.ListenerFactory
+	apim     api_server.APIInstaller
+	xdsh     *xds_hooks.Hooks
+	cap      secrets.CaProvider
+	dps      *dp_server.DpServer
+	kdsctx   *kds_context.Context
+	mv       core_managers.MeshValidator
+	appCtx   context.Context
 }
 
 func (rc *runtimeContext) Metrics() metrics.Metrics {
@@ -212,6 +212,6 @@ func (rc *runtimeContext) MeshValidator() core_managers.MeshValidator {
 	return rc.mv
 }
 
-func (rc *runtimeContext) ShutdownCh() <-chan struct{} {
-	return rc.shutdownCh
+func (rc *runtimeContext) AppContext() context.Context {
+	return rc.appCtx
 }

--- a/pkg/envoy/admin/admin_suite_test.go
+++ b/pkg/envoy/admin/admin_suite_test.go
@@ -32,7 +32,7 @@ var _ = BeforeSuite(func() {
 
 	// setup the runtime
 	cfg := kuma_cp.DefaultConfig()
-	builder, err := runtime.BuilderFor(cfg)
+	builder, err := runtime.BuilderFor(context.Background(), cfg)
 	Expect(err).ToNot(HaveOccurred())
 	runtime, err := builder.Build()
 	Expect(err).ToNot(HaveOccurred())

--- a/pkg/plugins/bootstrap/k8s/plugin.go
+++ b/pkg/plugins/bootstrap/k8s/plugin.go
@@ -58,7 +58,7 @@ func (p *plugin) BeforeBootstrap(b *core_runtime.Builder, _ core_plugins.PluginC
 		return err
 	}
 
-	secretClient, err := secretClient(b.Config().Store.Kubernetes.SystemNamespace, config, scheme, mgr.GetRESTMapper(), b.ShutdownCh())
+	secretClient, err := secretClient(b.AppCtx(), b.Config().Store.Kubernetes.SystemNamespace, config, scheme, mgr.GetRESTMapper())
 	if err != nil {
 		return err
 	}
@@ -80,7 +80,7 @@ func (p *plugin) BeforeBootstrap(b *core_runtime.Builder, _ core_plugins.PluginC
 // If we try to use regular cached client for Secrets then we will see following error: E1126 10:42:52.097662       1 reflector.go:178] pkg/mod/k8s.io/client-go@v0.18.9/tools/cache/reflector.go:125: Failed to list *v1.Secret: secrets is forbidden: User "system:serviceaccount:kuma-system:kuma-control-plane" cannot list resource "secrets" in API group "" at the cluster scope
 // We cannot specify this Namespace parameter for the main cache in ControllerManager because it affect all the resources, therefore we need separate client with cache for Secrets.
 // The alternative was to use non-cached client, but it had performance problems.
-func secretClient(systemNamespace string, config *rest.Config, scheme *kube_runtime.Scheme, restMapper meta.RESTMapper, closeCh <-chan struct{}) (kube_client.Client, error) {
+func secretClient(appCtx context.Context, systemNamespace string, config *rest.Config, scheme *kube_runtime.Scheme, restMapper meta.RESTMapper) (kube_client.Client, error) {
 	resyncPeriod := 10 * time.Hour // default resyncPeriod in Kubernetes
 	kubeCache, err := kuma_kube_cache.New(config, cache.Options{
 		Scheme:    scheme,
@@ -108,13 +108,13 @@ func secretClient(systemNamespace string, config *rest.Config, scheme *kube_runt
 	// According to ControllerManager code, cache needs to start before all the Runnables (our Components)
 	// So we need separate go routine to start a cache and then wait for cache
 	go func() {
-		if err := kubeCache.Start(closeCh); err != nil {
+		if err := kubeCache.Start(appCtx.Done()); err != nil {
 			// According to implementations, there is no case when error is returned. It just for the Runnable contract.
 			log.Error(err, "could not start the secret k8s cache")
 		}
 	}()
 
-	if ok := kubeCache.WaitForCacheSync(closeCh); !ok {
+	if ok := kubeCache.WaitForCacheSync(appCtx.Done()); !ok {
 		// ControllerManager ignores case when WaitForCacheSync returns false.
 		// It might be a better idea to return an error and stop the Control Plane altogether, but sticking to return error for now.
 		core.Log.Error(errors.New("could not sync secret cache"), "failed to wait for cache")

--- a/pkg/plugins/config/k8s/store.go
+++ b/pkg/plugins/config/k8s/store.go
@@ -71,7 +71,7 @@ func (s *KubernetesStore) Create(ctx context.Context, r core_model.Resource, fs 
 			return errors.Wrap(err, "failed to set owner reference for object")
 		}
 	}
-	if err := s.client.Create(context.Background(), cm); err != nil {
+	if err := s.client.Create(ctx, cm); err != nil {
 		return err
 	}
 	r.SetMeta(&KubernetesMetaAdapter{cm.ObjectMeta})
@@ -93,7 +93,7 @@ func (s *KubernetesStore) Update(ctx context.Context, r core_model.Resource, fs 
 			configMapKey: configRes.Spec.Config,
 		},
 	}
-	if err := s.client.Update(context.Background(), cm); err != nil {
+	if err := s.client.Update(ctx, cm); err != nil {
 		if kube_apierrs.IsConflict(err) {
 			return core_store.ErrorResourceConflict(r.Descriptor().Name, r.GetMeta().GetName(), r.GetMeta().GetMesh())
 		}
@@ -122,7 +122,7 @@ func (s *KubernetesStore) Delete(ctx context.Context, r core_model.Resource, fs 
 			configMapKey: configRes.Spec.Config,
 		},
 	}
-	return s.client.Delete(context.Background(), cm)
+	return s.client.Delete(ctx, cm)
 }
 func (s *KubernetesStore) Get(ctx context.Context, r core_model.Resource, fs ...core_store.GetOptionsFunc) error {
 	configRes, ok := r.(*config_model.ConfigResource)

--- a/pkg/plugins/runtime/gateway/suite_test.go
+++ b/pkg/plugins/runtime/gateway/suite_test.go
@@ -223,7 +223,7 @@ func StoreFixture(mgr manager.ResourceManager, r core_model.Resource) error {
 // BuildRuntime returns a fabricated test Runtime instance with which
 // the gateway plugin is registered.
 func BuildRuntime() (runtime.Runtime, error) {
-	builder, err := test_runtime.BuilderFor(kuma_cp.DefaultConfig())
+	builder, err := test_runtime.BuilderFor(context.Background(), kuma_cp.DefaultConfig())
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/test/runtime/runtime.go
+++ b/pkg/test/runtime/runtime.go
@@ -1,6 +1,7 @@
 package runtime
 
 import (
+	"context"
 	"net"
 
 	"github.com/kumahq/kuma/pkg/api-server/customization"
@@ -49,9 +50,8 @@ func (i *TestRuntimeInfo) GetClusterId() string {
 	return i.ClusterId
 }
 
-func BuilderFor(cfg kuma_cp.Config) (*core_runtime.Builder, error) {
-	stopCh := make(chan struct{})
-	builder, err := core_runtime.BuilderFor(cfg, stopCh)
+func BuilderFor(appCtx context.Context, cfg kuma_cp.Config) (*core_runtime.Builder, error) {
+	builder, err := core_runtime.BuilderFor(appCtx, cfg)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/xds/server/callbacks/dataplane_lifecycle_test.go
+++ b/pkg/xds/server/callbacks/dataplane_lifecycle_test.go
@@ -27,13 +27,14 @@ var _ = Describe("Dataplane Lifecycle", func() {
 
 	var resManager core_manager.ResourceManager
 	var callbacks envoy_server.Callbacks
-	var shutdown chan struct{}
+	var cancel func()
+	var ctx context.Context
 
 	BeforeEach(func() {
 		store := memory.NewStore()
 		resManager = core_manager.NewResourceManager(store)
-		shutdown = make(chan struct{})
-		callbacks = util_xds_v3.AdaptCallbacks(DataplaneCallbacksToXdsCallbacks(NewDataplaneLifecycle(resManager, shutdown)))
+		ctx, cancel = context.WithCancel(context.Background())
+		callbacks = util_xds_v3.AdaptCallbacks(DataplaneCallbacksToXdsCallbacks(NewDataplaneLifecycle(ctx, resManager)))
 
 		err := resManager.Create(context.Background(), core_mesh.NewMeshResource(), core_store.CreateByKey(core_model.DefaultMesh, core_model.NoMesh))
 		Expect(err).ToNot(HaveOccurred())
@@ -46,7 +47,7 @@ var _ = Describe("Dataplane Lifecycle", func() {
 				Id: "default.backend-01",
 				Metadata: &structpb.Struct{
 					Fields: map[string]*structpb.Value{
-						"dataplane.resource": &structpb.Value{
+						"dataplane.resource": {
 							Kind: &structpb.Value_StringValue{
 								StringValue: `
                                 {
@@ -144,7 +145,7 @@ var _ = Describe("Dataplane Lifecycle", func() {
 				Id: "default.backend-01",
 				Metadata: &structpb.Struct{
 					Fields: map[string]*structpb.Value{
-						"dataplane.resource": &structpb.Value{
+						"dataplane.resource": {
 							Kind: &structpb.Value_StringValue{
 								StringValue: `
                                 {
@@ -178,7 +179,8 @@ var _ = Describe("Dataplane Lifecycle", func() {
 		err := callbacks.OnStreamRequest(streamId, &req)
 		Expect(err).ToNot(HaveOccurred())
 
-		close(shutdown)
+		cancel()
+		cancel()
 		// when
 		callbacks.OnStreamClosed(streamId)
 
@@ -207,7 +209,7 @@ var _ = Describe("Dataplane Lifecycle", func() {
 						Id: nodeID,
 						Metadata: &structpb.Struct{
 							Fields: map[string]*structpb.Value{
-								"dataplane.resource": &structpb.Value{
+								"dataplane.resource": {
 									Kind: &structpb.Value_StringValue{
 										StringValue: fmt.Sprintf(`
                                 {

--- a/pkg/xds/server/v3/components.go
+++ b/pkg/xds/server/v3/components.go
@@ -57,7 +57,7 @@ func RegisterXDS(
 		util_xds_v3.AdaptCallbacks(authCallbacks),
 		util_xds_v3.AdaptCallbacks(xds_callbacks.DataplaneCallbacksToXdsCallbacks(xds_callbacks.NewDataplaneSyncTracker(watchdogFactory.New))),
 		util_xds_v3.AdaptCallbacks(xds_callbacks.DataplaneCallbacksToXdsCallbacks(metadataTracker)),
-		util_xds_v3.AdaptCallbacks(xds_callbacks.DataplaneCallbacksToXdsCallbacks(xds_callbacks.NewDataplaneLifecycle(rt.ResourceManager(), rt.ShutdownCh()))),
+		util_xds_v3.AdaptCallbacks(xds_callbacks.DataplaneCallbacksToXdsCallbacks(xds_callbacks.NewDataplaneLifecycle(rt.AppContext(), rt.ResourceManager()))),
 		util_xds_v3.AdaptCallbacks(DefaultDataplaneStatusTracker(rt, envoyCpCtx.Secrets)),
 		util_xds_v3.AdaptCallbacks(xds_callbacks.NewNackBackoff(rt.Config().XdsServer.NACKBackoff)),
 		newResourceWarmingForcer(xdsContext.Cache(), xdsContext.Hasher()),


### PR DESCRIPTION
This is required because newer versions of the controller-runtime
will rely on context instead of a closed channel to indicate that
the app should shutdown

Signed-off-by: Charly Molter <charly.molter@konghq.com>

- [x] Add `backport-to-stable` label if the code is backwards compatible. Otherwise, list breaking changes.
