### PR TITLE
chore(kuma-cp) rename mTLS configuration parameter for clarity

### DIFF
--- a/pkg/xds/envoy/clusters/configurers.go
+++ b/pkg/xds/envoy/clusters/configurers.go
@@ -22,12 +22,12 @@ func CircuitBreaker(circuitBreaker *core_mesh.CircuitBreakerResource) ClusterBui
 	})
 }
 
-func ClientSideMTLS(ctx xds_context.Context, clientService string, tags []envoy.Tags) ClusterBuilderOpt {
+func ClientSideMTLS(ctx xds_context.Context, upstreamService string, tags []envoy.Tags) ClusterBuilderOpt {
 	return ClusterBuilderOptFunc(func(config *ClusterBuilderConfig) {
 		config.AddV3(&v3.ClientSideMTLSConfigurer{
-			Ctx:           ctx,
-			ClientService: clientService,
-			Tags:          tags,
+			Ctx:             ctx,
+			UpstreamService: upstreamService,
+			Tags:            tags,
 		})
 	})
 }
@@ -36,9 +36,9 @@ func ClientSideMTLS(ctx xds_context.Context, clientService string, tags []envoy.
 func UnknownDestinationClientSideMTLS(ctx xds_context.Context) ClusterBuilderOpt {
 	return ClusterBuilderOptFunc(func(config *ClusterBuilderConfig) {
 		config.AddV3(&v3.ClientSideMTLSConfigurer{
-			Ctx:           ctx,
-			ClientService: "*",
-			Tags:          nil,
+			Ctx:             ctx,
+			UpstreamService: "*",
+			Tags:            nil,
 		})
 	})
 }

--- a/pkg/xds/envoy/clusters/v3/client_side_mtls_configurer.go
+++ b/pkg/xds/envoy/clusters/v3/client_side_mtls_configurer.go
@@ -14,9 +14,9 @@ import (
 )
 
 type ClientSideMTLSConfigurer struct {
-	Ctx           xds_context.Context
-	ClientService string
-	Tags          []envoy.Tags
+	Ctx             xds_context.Context
+	UpstreamService string
+	Tags            []envoy.Tags
 }
 
 var _ ClusterConfigurer = &ClientSideTLSConfigurer{}
@@ -61,7 +61,7 @@ func (c *ClientSideMTLSConfigurer) Configure(cluster *envoy_cluster.Cluster) err
 }
 
 func (c *ClientSideMTLSConfigurer) createTransportSocket(sni string) (*envoy_core.TransportSocket, error) {
-	tlsContext, err := envoy_tls.CreateUpstreamTlsContext(c.Ctx, c.ClientService, sni)
+	tlsContext, err := envoy_tls.CreateUpstreamTlsContext(c.Ctx, c.UpstreamService, sni)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
### Summary

The service name that is passed to the `ClientSideMTLS` configurer
is the used to validate the name the upstream provides in its server
certificate. It's less confusing if we call this field `UpstreamService`.

### Full changelog

N/A

### Issues resolved

N/A

### Documentation

N/A

### Testing

- [x] Unit tests
- [x] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes 

### Backwards compatibility

- [x] Add `backport-to-stable` label if the code is backwards compatible. Otherwise, list breaking changes.
