### PR TITLE
chore(*) remove unnecessary go-kit dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/envoyproxy/protoc-gen-validate v0.4.1
 	github.com/ghodss/yaml v1.0.0
 	github.com/go-git/go-git/v5 v5.4.2
-	github.com/go-kit/kit v0.11.0
+	github.com/go-kit/kit v0.11.0 // indirect
 	github.com/go-logr/logr v0.1.0
 	github.com/go-logr/zapr v0.1.1
 	github.com/golang-migrate/migrate/v4 v4.14.1

--- a/pkg/insights/components.go
+++ b/pkg/insights/components.go
@@ -1,7 +1,6 @@
 package insights
 
 import (
-	"github.com/go-kit/kit/ratelimit"
 	"golang.org/x/time/rate"
 
 	"github.com/kumahq/kuma/pkg/core/resources/registry"
@@ -15,7 +14,7 @@ func Setup(rt runtime.Runtime) error {
 		EventReaderFactory: rt.EventReaderFactory(),
 		MinResyncTimeout:   rt.Config().Metrics.Mesh.MinResyncTimeout,
 		MaxResyncTimeout:   rt.Config().Metrics.Mesh.MaxResyncTimeout,
-		RateLimiterFactory: func() ratelimit.Allower {
+		RateLimiterFactory: func() *rate.Limiter {
 			return rate.NewLimiter(rate.Every(rt.Config().Metrics.Mesh.MinResyncTimeout), 50)
 		},
 		Registry: registry.Global(),

--- a/pkg/insights/resyncer.go
+++ b/pkg/insights/resyncer.go
@@ -6,8 +6,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/go-kit/kit/ratelimit"
 	"github.com/pkg/errors"
+	"golang.org/x/time/rate"
 
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	"github.com/kumahq/kuma/pkg/core"
@@ -36,7 +36,7 @@ type Config struct {
 	MinResyncTimeout   time.Duration
 	MaxResyncTimeout   time.Duration
 	Tick               func(d time.Duration) <-chan time.Time
-	RateLimiterFactory func() ratelimit.Allower
+	RateLimiterFactory func() *rate.Limiter
 }
 
 type resyncer struct {
@@ -45,10 +45,10 @@ type resyncer struct {
 	minResyncTimeout   time.Duration
 	maxResyncTimeout   time.Duration
 	tick               func(d time.Duration) <-chan time.Time
-	rateLimiterFactory func() ratelimit.Allower
+	rateLimiterFactory func() *rate.Limiter
 	meshInsightMux     sync.Mutex
 	serviceInsightMux  sync.Mutex
-	rateLimiters       map[string]ratelimit.Allower
+	rateLimiters       map[string]*rate.Limiter
 	registry           registry.TypeRegistry
 }
 
@@ -67,7 +67,7 @@ func NewResyncer(config *Config) component.Component {
 		eventFactory:       config.EventReaderFactory,
 		rm:                 config.ResourceManager,
 		rateLimiterFactory: config.RateLimiterFactory,
-		rateLimiters:       map[string]ratelimit.Allower{},
+		rateLimiters:       map[string]*rate.Limiter{},
 		registry:           config.Registry,
 	}
 
@@ -141,7 +141,7 @@ func (r *resyncer) Start(stop <-chan struct{}) error {
 	}
 }
 
-func (r *resyncer) getRateLimiter(mesh string) ratelimit.Allower {
+func (r *resyncer) getRateLimiter(mesh string) *rate.Limiter {
 	if _, ok := r.rateLimiters[mesh]; !ok {
 		r.rateLimiters[mesh] = r.rateLimiterFactory()
 	}


### PR DESCRIPTION
### Summary

Wrapping the Go rate limiter in an interface from go-kit doesn't have
any advantages at this point. Getter to just remove the dependency.

### Full changelog

N/A

### Issues resolved

N/A

### Documentation

N/A

### Testing

- [x] Unit tests
- [x] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes 

### Backwards compatibility

- [x] Add `backport-to-stable` label if the code is backwards compatible. Otherwise, list breaking changes.
