### PR TITLE
fix(kuma-cp) delete kuma.io/region and kuma.io/sub-zone

### DIFF
--- a/api/mesh/v1alpha1/dataplane_helpers.go
+++ b/api/mesh/v1alpha1/dataplane_helpers.go
@@ -18,9 +18,7 @@ const (
 	ServiceUnknown = "unknown"
 
 	// Locality related tags
-	RegionTag  = "kuma.io/region"
-	ZoneTag    = "kuma.io/zone"
-	SubZoneTag = "kuma.io/sub-zone"
+	ZoneTag = "kuma.io/zone"
 
 	// Optional tag that has a reserved meaning in Kuma.
 	// If absent, Kuma will treat application's protocol as opaque TCP.

--- a/pkg/core/xds/types.go
+++ b/pkg/core/xds/types.go
@@ -60,9 +60,7 @@ type ExternalService struct {
 }
 
 type Locality struct {
-	Region   string
 	Zone     string
-	SubZone  string
 	Priority uint32
 }
 
@@ -196,7 +194,7 @@ func (e Endpoint) LocalityString() string {
 	if e.Locality == nil {
 		return ""
 	}
-	return e.Locality.Region + "/" + e.Locality.Zone + "/" + e.Locality.SubZone
+	return e.Locality.Zone
 }
 
 func (e Endpoint) HasLocality() bool {

--- a/pkg/plugins/runtime/k8s/controllers/configmap_controller_test.go
+++ b/pkg/plugins/runtime/k8s/controllers/configmap_controller_test.go
@@ -32,7 +32,7 @@ var _ = Describe("DataplaneToMeshMapper", func() {
 							{
 								Instances: 2,
 								Mesh:      "mesh-1",
-								Tags:      map[string]string{mesh_proto.ServiceTag: "redis", "version": "v2", mesh_proto.RegionTag: "eu"},
+								Tags:      map[string]string{mesh_proto.ServiceTag: "redis", "version": "v2"},
 							},
 							{
 								Instances: 3,

--- a/pkg/xds/envoy/endpoints/v3/endpoints.go
+++ b/pkg/xds/envoy/endpoints/v3/endpoints.go
@@ -116,9 +116,7 @@ func (l LocalityLbEndpointsMap) Get(ep core_xds.Endpoint) *envoy_endpoint.Locali
 		priority := uint32(0)
 		if ep.HasLocality() {
 			locality = &envoy_core.Locality{
-				Region:  ep.Locality.Region,
-				Zone:    ep.Locality.Zone,
-				SubZone: ep.Locality.SubZone,
+				Zone: ep.Locality.Zone,
 			}
 			priority = ep.Locality.Priority
 		}

--- a/pkg/xds/envoy/endpoints/v3/endpoints_test.go
+++ b/pkg/xds/envoy/endpoints/v3/endpoints_test.go
@@ -169,13 +169,13 @@ var _ = Describe("Endpoints", func() {
 					{
 						Target: "192.168.0.1",
 						Port:   8081,
-						Tags:   map[string]string{"kuma.io/service": "backend", "kuma.io/region": "us", "kuma.io/zone": "west"},
+						Tags:   map[string]string{"kuma.io/service": "backend", "region": "us", "kuma.io/zone": "west"},
 						Weight: 1,
 					},
 					{
 						Target: "192.168.0.2",
 						Port:   8082,
-						Tags:   map[string]string{"kuma.io/service": "backend", "kuma.io/region": "eu", "kuma.io/zone": "west"},
+						Tags:   map[string]string{"kuma.io/service": "backend", "region": "eu", "kuma.io/zone": "west"},
 						Weight: 2,
 					},
 				},
@@ -191,10 +191,10 @@ var _ = Describe("Endpoints", func() {
                     metadata:
                       filterMetadata:
                         envoy.lb:
-                          kuma.io/region: us
+                          region: us
                           kuma.io/zone: west
                         envoy.transport_socket_match:
-                          kuma.io/region: us
+                          region: us
                           kuma.io/zone: west
                     loadBalancingWeight: 1
                   - endpoint:
@@ -205,10 +205,10 @@ var _ = Describe("Endpoints", func() {
                     metadata:
                       filterMetadata:
                         envoy.lb:
-                          kuma.io/region: eu
+                          region: eu
                           kuma.io/zone: west
                         envoy.transport_socket_match:
-                          kuma.io/region: eu
+                          region: eu
                           kuma.io/zone: west
                     loadBalancingWeight: 2
 `,

--- a/pkg/xds/topology/outbound.go
+++ b/pkg/xds/topology/outbound.go
@@ -231,17 +231,15 @@ func convertToEnvoy(ds *v1alpha1.DataSource, mesh string, loader datasource.Load
 }
 
 func localityFromTags(mesh *core_mesh.MeshResource, priority uint32, tags map[string]string) *core_xds.Locality {
-	region, regionPresent := tags[mesh_proto.RegionTag]
 	zone, zonePresent := tags[mesh_proto.ZoneTag]
-	subZone, subZonePresent := tags[mesh_proto.SubZoneTag]
 
-	if !regionPresent && !zonePresent && !subZonePresent {
+	if !zonePresent {
 		// this means that we are running in standalone since in multi-zone Kuma always adds Zone tag automatically
 		return nil
 	}
 
 	if !mesh.Spec.GetRouting().GetLocalityAwareLoadBalancing() {
-		// we want to set the Locality even when localityAwareLoadbalancing is enabled
+		// we want to set the Locality even when localityAwareLoadBalancing is enabled
 		// If we set the locality we have an extra visibility about this in /clusters etc.
 		// Kuma's LocalityAwareLoadBalancing feature is based only on Priority therefore when it's disabled we need to set Priority to local
 		//
@@ -251,9 +249,7 @@ func localityFromTags(mesh *core_mesh.MeshResource, priority uint32, tags map[st
 	}
 
 	return &core_xds.Locality{
-		Region:   region,
 		Zone:     zone,
-		SubZone:  subZone,
 		Priority: priority,
 	}
 }

--- a/pkg/xds/topology/outbound_test.go
+++ b/pkg/xds/topology/outbound_test.go
@@ -70,12 +70,12 @@ var _ = Describe("TrafficRoute", func() {
 						Address: "192.168.0.1",
 						Inbound: []*mesh_proto.Dataplane_Networking_Inbound{
 							{
-								Tags:        map[string]string{mesh_proto.ServiceTag: "backend", mesh_proto.RegionTag: "eu"},
+								Tags:        map[string]string{mesh_proto.ServiceTag: "backend", mesh_proto.ZoneTag: "eu"},
 								Port:        8080,
 								ServicePort: 18080,
 							},
 							{
-								Tags:        map[string]string{mesh_proto.ServiceTag: "frontend", mesh_proto.RegionTag: "eu"},
+								Tags:        map[string]string{mesh_proto.ServiceTag: "frontend", mesh_proto.ZoneTag: "eu"},
 								Port:        7070,
 								ServicePort: 17070,
 							},
@@ -123,7 +123,7 @@ var _ = Describe("TrafficRoute", func() {
 					},
 				},
 			}
-			elasticEU := &core_mesh.DataplaneResource{ // dataplane that must be ingored (due to `kuma.io/region: eu`)
+			elasticEU := &core_mesh.DataplaneResource{ // dataplane that must be ingored (due to `kuma.io/zone: eu`)
 				Meta: &test_model.ResourceMeta{
 					Mesh: "demo",
 					Name: "elastic-eu",
@@ -133,7 +133,7 @@ var _ = Describe("TrafficRoute", func() {
 						Address: "192.168.0.5",
 						Inbound: []*mesh_proto.Dataplane_Networking_Inbound{
 							{
-								Tags:        map[string]string{mesh_proto.ServiceTag: "elastic", mesh_proto.RegionTag: "eu"},
+								Tags:        map[string]string{mesh_proto.ServiceTag: "elastic", mesh_proto.ZoneTag: "eu"},
 								Port:        9200,
 								ServicePort: 49200,
 							},
@@ -151,7 +151,7 @@ var _ = Describe("TrafficRoute", func() {
 						Address: "192.168.0.6",
 						Inbound: []*mesh_proto.Dataplane_Networking_Inbound{
 							{
-								Tags:        map[string]string{mesh_proto.ServiceTag: "elastic", mesh_proto.RegionTag: "us"},
+								Tags:        map[string]string{mesh_proto.ServiceTag: "elastic", mesh_proto.ZoneTag: "us"},
 								Port:        9200,
 								ServicePort: 59200,
 							},
@@ -193,19 +193,19 @@ var _ = Describe("TrafficRoute", func() {
 					Port:   9200,
 					Tags: map[string]string{
 						mesh_proto.ServiceTag: "elastic",
-						mesh_proto.RegionTag:  "eu",
+						mesh_proto.ZoneTag:    "eu",
 					},
 					Locality: &core_xds.Locality{
-						Region: "eu",
+						Zone: "eu",
 					},
 					Weight: 1,
 				},
 				{
 					Target: "192.168.0.6",
 					Port:   9200,
-					Tags:   map[string]string{mesh_proto.ServiceTag: "elastic", mesh_proto.RegionTag: "us"},
+					Tags:   map[string]string{mesh_proto.ServiceTag: "elastic", mesh_proto.ZoneTag: "us"},
 					Locality: &core_xds.Locality{
-						Region: "us",
+						Zone: "us",
 					},
 					Weight: 1,
 				},
@@ -216,10 +216,10 @@ var _ = Describe("TrafficRoute", func() {
 					Port:   7070,
 					Tags: map[string]string{
 						mesh_proto.ServiceTag: "frontend",
-						mesh_proto.RegionTag:  "eu",
+						mesh_proto.ZoneTag:    "eu",
 					},
 					Locality: &core_xds.Locality{
-						Region: "eu",
+						Zone: "eu",
 					},
 					Weight: 1,
 				},
@@ -230,10 +230,10 @@ var _ = Describe("TrafficRoute", func() {
 					Port:   8080,
 					Tags: map[string]string{
 						mesh_proto.ServiceTag: "backend",
-						mesh_proto.RegionTag:  "eu",
+						mesh_proto.ZoneTag:    "eu",
 					},
 					Locality: &core_xds.Locality{
-						Region: "eu",
+						Zone: "eu",
 					},
 					Weight: 1,
 				},
@@ -294,7 +294,7 @@ var _ = Describe("TrafficRoute", func() {
 										{
 											Instances: 2,
 											Mesh:      defaultMeshName,
-											Tags:      map[string]string{mesh_proto.ServiceTag: "redis", "version": "v2", mesh_proto.RegionTag: "eu"},
+											Tags:      map[string]string{mesh_proto.ServiceTag: "redis", "version": "v2", mesh_proto.ZoneTag: "eu"},
 										},
 										{
 											Instances: 3,
@@ -323,7 +323,7 @@ var _ = Describe("TrafficRoute", func() {
 										{
 											Instances: 2,
 											Mesh:      defaultMeshName,
-											Tags:      map[string]string{mesh_proto.ServiceTag: "redis", "version": "v2", mesh_proto.RegionTag: "eu"},
+											Tags:      map[string]string{mesh_proto.ServiceTag: "redis", "version": "v2", mesh_proto.ZoneTag: "eu"},
 										},
 										{
 											Instances: 3,
@@ -352,7 +352,7 @@ var _ = Describe("TrafficRoute", func() {
 										{
 											Instances: 2,
 											Mesh:      defaultMeshName,
-											Tags:      map[string]string{mesh_proto.ServiceTag: "redis", "version": "v2", mesh_proto.RegionTag: "eu"},
+											Tags:      map[string]string{mesh_proto.ServiceTag: "redis", "version": "v2", mesh_proto.ZoneTag: "eu"},
 										},
 										{
 											Instances: 3,
@@ -371,9 +371,9 @@ var _ = Describe("TrafficRoute", func() {
 						{
 							Target: "192.168.0.100",
 							Port:   12345,
-							Tags:   map[string]string{mesh_proto.ServiceTag: "redis", "version": "v2", mesh_proto.RegionTag: "eu"},
+							Tags:   map[string]string{mesh_proto.ServiceTag: "redis", "version": "v2", mesh_proto.ZoneTag: "eu"},
 							Locality: &core_xds.Locality{
-								Region: "eu",
+								Zone: "eu",
 							},
 							Weight: 2,
 						},
@@ -386,9 +386,9 @@ var _ = Describe("TrafficRoute", func() {
 						{
 							Target: "192.168.0.101",
 							Port:   12345,
-							Tags:   map[string]string{mesh_proto.ServiceTag: "redis", "version": "v2", mesh_proto.RegionTag: "eu"},
+							Tags:   map[string]string{mesh_proto.ServiceTag: "redis", "version": "v2", mesh_proto.ZoneTag: "eu"},
 							Locality: &core_xds.Locality{
-								Region: "eu",
+								Zone: "eu",
 							},
 							Weight: 2,
 						},
@@ -441,7 +441,7 @@ var _ = Describe("TrafficRoute", func() {
 										{
 											Instances: 2,
 											Mesh:      defaultMeshName,
-											Tags:      map[string]string{mesh_proto.ServiceTag: "redis", "version": "v2", mesh_proto.RegionTag: "eu"},
+											Tags:      map[string]string{mesh_proto.ServiceTag: "redis", "version": "v2", mesh_proto.ZoneTag: "eu"},
 										},
 										{
 											Instances: 3,
@@ -460,9 +460,9 @@ var _ = Describe("TrafficRoute", func() {
 						{
 							Target: "192.168.0.100",
 							Port:   12345,
-							Tags:   map[string]string{mesh_proto.ServiceTag: "redis", "version": "v2", mesh_proto.RegionTag: "eu"},
+							Tags:   map[string]string{mesh_proto.ServiceTag: "redis", "version": "v2", mesh_proto.ZoneTag: "eu"},
 							Locality: &core_xds.Locality{
-								Region: "eu",
+								Zone: "eu",
 							},
 							Weight: 2,
 						},
@@ -507,7 +507,7 @@ var _ = Describe("TrafficRoute", func() {
 										{
 											Instances: 2,
 											Mesh:      defaultMeshName,
-											Tags:      map[string]string{mesh_proto.ServiceTag: "redis", "version": "v2", mesh_proto.RegionTag: "eu"},
+											Tags:      map[string]string{mesh_proto.ServiceTag: "redis", "version": "v2", mesh_proto.ZoneTag: "eu"},
 										},
 										{
 											Instances: 3,
@@ -629,7 +629,7 @@ var _ = Describe("TrafficRoute", func() {
 									Enabled: true,
 								},
 							},
-							Tags: map[string]string{mesh_proto.ServiceTag: "redis", mesh_proto.RegionTag: "us", mesh_proto.ZoneTag: "west"},
+							Tags: map[string]string{mesh_proto.ServiceTag: "redis", mesh_proto.ZoneTag: "us"},
 						},
 					},
 				},
@@ -639,9 +639,9 @@ var _ = Describe("TrafficRoute", func() {
 						{
 							Target:          "httpbin.org",
 							Port:            80,
-							Tags:            map[string]string{mesh_proto.ServiceTag: "redis", mesh_proto.RegionTag: "us", mesh_proto.ZoneTag: "west", mesh_proto.ExternalServiceTag: ""},
+							Tags:            map[string]string{mesh_proto.ServiceTag: "redis", mesh_proto.ZoneTag: "us", mesh_proto.ExternalServiceTag: ""},
 							Weight:          1,
-							Locality:        &core_xds.Locality{Region: "us", Zone: "west", Priority: 1},
+							Locality:        &core_xds.Locality{Zone: "us", Priority: 1},
 							ExternalService: &core_xds.ExternalService{TLSEnabled: true},
 						},
 					},


### PR DESCRIPTION
### Summary

Until proper support of locality weighted load balancing https://github.com/kumahq/kuma/issues/2689 these tags may confuse users, because they have no effect on how envoy load balance requests.

### Full changelog

* delete `kuma.io/region`
* delete `kuma.io/sub-zone`
* update unit tests

### Issues resolved

N/A

### Documentation

Already fixed

### Testing

- [X] Unit tests
- [ ] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes 

### Backwards compatibility

- [x] Add `backport-to-stable` label if the code is backwards compatible. Otherwise, list breaking changes.
