### PR TITLE
fix(kuma-cp) remove insight update rate limit burst

### DIFF
--- a/pkg/insights/components.go
+++ b/pkg/insights/components.go
@@ -15,7 +15,7 @@ func Setup(rt runtime.Runtime) error {
 		MinResyncTimeout:   rt.Config().Metrics.Mesh.MinResyncTimeout,
 		MaxResyncTimeout:   rt.Config().Metrics.Mesh.MaxResyncTimeout,
 		RateLimiterFactory: func() *rate.Limiter {
-			return rate.NewLimiter(rate.Every(rt.Config().Metrics.Mesh.MinResyncTimeout), 50)
+			return rate.NewLimiter(rate.Every(rt.Config().Metrics.Mesh.MinResyncTimeout), 0)
 		},
 		Registry: registry.Global(),
 	})


### PR DESCRIPTION
### Summary

The token burst that is configured for the insight update rate limit
allows the update rate to burst up to 50 times before stabilizing to the
desired rate. This would typically happen when kuma-cp starts up and all
the dataplanes reconnect, which is precisely the time when you want the
rate limit to apply for operational stability.

### Full changelog

N/A

### Issues resolved

N/A

### Documentation

N/A

### Testing

- [x] Unit tests
- [x] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes 

### Backwards compatibility

- [x] Add `backport-to-stable` label if the code is backwards compatible. Otherwise, list breaking changes.
