### PR TITLE
chore(*) small adjustments for windows compilation

### DIFF
--- a/pkg/transparentproxy/config/config.go
+++ b/pkg/transparentproxy/config/config.go
@@ -1,10 +1,12 @@
 package config
 
-import "github.com/kumahq/kuma/pkg/transparentproxy/istio"
+import (
+	"github.com/kumahq/kuma/pkg/transparentproxy/istio/config"
+)
 
 // TransparentProxyConfig defines the configuration for all transparent
 // proxy configurations, not just the Istio one.
 //
 // We alias the types in reverse here to avoid an import loop (the Istio
 // submodule depending on Kuma for the config type).
-type TransparentProxyConfig = istio.TransparentProxyConfig
+type TransparentProxyConfig = config.TransparentProxyConfig

--- a/pkg/transparentproxy/istio/config/config.go
+++ b/pkg/transparentproxy/istio/config/config.go
@@ -1,4 +1,4 @@
-package istio
+package config
 
 type TransparentProxyConfig struct {
 	DryRun                 bool

--- a/pkg/transparentproxy/istio/istio.go
+++ b/pkg/transparentproxy/istio/istio.go
@@ -3,6 +3,7 @@ package istio
 import (
 	"os"
 
+	"github.com/kumahq/kuma/pkg/transparentproxy/istio/config"
 	"github.com/pkg/errors"
 	"github.com/spf13/viper"
 
@@ -23,7 +24,7 @@ func NewIstioTransparentProxy() *IstioTransparentProxy {
 	return &IstioTransparentProxy{}
 }
 
-func (tp *IstioTransparentProxy) Setup(cfg *TransparentProxyConfig) (string, error) {
+func (tp *IstioTransparentProxy) Setup(cfg *config.TransparentProxyConfig) (string, error) {
 	viper.Set(constants.EnvoyPort, cfg.RedirectPortOutBound)
 	viper.Set(constants.InboundCapturePort, cfg.RedirectPortInBound)
 	viper.Set(constants.InboundCapturePortV6, cfg.RedirectPortInBoundV6)

--- a/pkg/xds/envoy/sockets.go
+++ b/pkg/xds/envoy/sockets.go
@@ -2,16 +2,17 @@ package envoy
 
 import (
 	"fmt"
+	"os"
 )
 
 // AccessLogSocketName generates a socket path that will fit the Unix socket path limitation of 108 chars
 func AccessLogSocketName(name, mesh string) string {
-	return socketName(fmt.Sprintf("/tmp/kuma-al-%s-%s", name, mesh))
+	return socketName(fmt.Sprintf("%s%skuma-al-%s-%s", os.TempDir(), string(os.PathSeparator), name, mesh))
 }
 
 // MetricsHijackerSocketName generates a socket path that will fit the Unix socket path limitation of 108 chars
 func MetricsHijackerSocketName(name, mesh string) string {
-	return socketName(fmt.Sprintf("/tmp/kuma-mh-%s-%s", name, mesh))
+	return socketName(fmt.Sprintf("%s%skuma-mh-%s-%s", os.TempDir(), string(os.PathSeparator), name, mesh))
 }
 
 func socketName(s string) string {


### PR DESCRIPTION
### Summary

Had to move config.go to separate package as when it was in istio
dirictory, when compiling for windows it was failing as it was
trying to compile all transparent proxy logic, which is unix os
specific

Also adjusted sockets code to produce valid paths of unix sockets
for envoy logs for any os

### Full changelog

no changelog

### Issues resolved

no issue resolved

### Documentation

no documentation

### Testing

- [ ] Unit tests
- [ ] E2E tests
- [x] Manual testing on Universal
- [ ] Manual testing on Kubernetes 

### Backwards compatibility

- [x] Add `backport-to-stable` label if the code is backwards compatible. Otherwise, list breaking changes.
