### PR TITLE
fix(kumactl) Only warn about version compatibility where it makes sense

### DIFF
--- a/app/kumactl/cmd/apply/apply.go
+++ b/app/kumactl/cmd/apply/apply.go
@@ -57,6 +57,10 @@ Apply a resource from external URL
 $ kumactl apply -f https://example.com/resource.yaml
 `,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := pctx.CheckServerVersionCompatibility(); err != nil {
+				cmd.PrintErrln(err)
+			}
+
 			var b []byte
 			var err error
 

--- a/app/kumactl/cmd/delete/delete.go
+++ b/app/kumactl/cmd/delete/delete.go
@@ -27,6 +27,10 @@ func NewDeleteCmd(pctx *kumactl_cmd.RootContext) *cobra.Command {
 		Long:  `Delete Kuma resources.`,
 		Args:  cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := pctx.CheckServerVersionCompatibility(); err != nil {
+				cmd.PrintErrln(err)
+			}
+
 			resourceTypeArg := args[0]
 			name := args[1]
 

--- a/app/kumactl/cmd/generate/generate.go
+++ b/app/kumactl/cmd/generate/generate.go
@@ -7,14 +7,23 @@ import (
 )
 
 func NewGenerateCmd(pctx *kumactl_cmd.RootContext) *cobra.Command {
-	cmd := &cobra.Command{
+	generateCmd := &cobra.Command{
 		Use:   "generate",
 		Short: "Generate resources, tokens, etc",
 		Long:  `Generate resources, tokens, etc.`,
 	}
+	generateCmd.PersistentPreRunE = func(cmd *cobra.Command, args []string) error {
+		if err := kumactl_cmd.RunParentPreRunE(generateCmd, args); err != nil {
+			return err
+		}
+		if err := pctx.CheckServerVersionCompatibility(); err != nil {
+			cmd.PrintErrln(err)
+		}
+		return nil
+	}
 	// sub-commands
-	cmd.AddCommand(NewGenerateDataplaneTokenCmd(pctx))
-	cmd.AddCommand(NewGenerateZoneIngressTokenCmd(pctx))
-	cmd.AddCommand(NewGenerateCertificateCmd(pctx))
-	return cmd
+	generateCmd.AddCommand(NewGenerateDataplaneTokenCmd(pctx))
+	generateCmd.AddCommand(NewGenerateZoneIngressTokenCmd(pctx))
+	generateCmd.AddCommand(NewGenerateCertificateCmd(pctx))
+	return generateCmd
 }

--- a/app/kumactl/cmd/get/get.go
+++ b/app/kumactl/cmd/get/get.go
@@ -11,18 +11,27 @@ import (
 )
 
 func NewGetCmd(pctx *kumactl_cmd.RootContext) *cobra.Command {
-	cmd := &cobra.Command{
+	getCmd := &cobra.Command{
 		Use:   "get",
 		Short: "Show Kuma resources",
 		Long:  `Show Kuma resources.`,
 	}
-	// flags
-	cmd.PersistentFlags().StringVarP(&pctx.GetContext.Args.OutputFormat, "output", "o", string(output.TableFormat), kuma_cmd.UsageOptions("output format", output.TableFormat, output.YAMLFormat, output.JSONFormat))
-	for _, cmdInst := range pctx.Runtime.Registry.ObjectDescriptors(model.HasKumactlEnabled()) {
-		cmd.AddCommand(WithPaginationArgs(NewGetResourcesCmd(pctx, cmdInst), &pctx.ListContext))
-		cmd.AddCommand(NewGetResourceCmd(pctx, cmdInst))
+	getCmd.PersistentPreRunE = func(cmd *cobra.Command, args []string) error {
+		if err := kumactl_cmd.RunParentPreRunE(getCmd, args); err != nil {
+			return err
+		}
+		if err := pctx.CheckServerVersionCompatibility(); err != nil {
+			cmd.PrintErrln(err)
+		}
+		return nil
 	}
-	return cmd
+	// flags
+	getCmd.PersistentFlags().StringVarP(&pctx.GetContext.Args.OutputFormat, "output", "o", string(output.TableFormat), kuma_cmd.UsageOptions("output format", output.TableFormat, output.YAMLFormat, output.JSONFormat))
+	for _, cmdInst := range pctx.Runtime.Registry.ObjectDescriptors(model.HasKumactlEnabled()) {
+		getCmd.AddCommand(WithPaginationArgs(NewGetResourcesCmd(pctx, cmdInst), &pctx.ListContext))
+		getCmd.AddCommand(NewGetResourceCmd(pctx, cmdInst))
+	}
+	return getCmd
 }
 
 func WithPaginationArgs(cmd *cobra.Command, ctx *get_context.ListContext) *cobra.Command {

--- a/app/kumactl/cmd/inspect/inspect.go
+++ b/app/kumactl/cmd/inspect/inspect.go
@@ -9,18 +9,27 @@ import (
 )
 
 func NewInspectCmd(pctx *kumactl_cmd.RootContext) *cobra.Command {
-	cmd := &cobra.Command{
+	inspectCmd := &cobra.Command{
 		Use:   "inspect",
 		Short: "Inspect Kuma resources",
 		Long:  `Inspect Kuma resources.`,
 	}
+	inspectCmd.PersistentPreRunE = func(cmd *cobra.Command, args []string) error {
+		if err := kumactl_cmd.RunParentPreRunE(inspectCmd, args); err != nil {
+			return err
+		}
+		if err := pctx.CheckServerVersionCompatibility(); err != nil {
+			cmd.PrintErrln(err)
+		}
+		return nil
+	}
 	// flags
-	cmd.PersistentFlags().StringVarP(&pctx.InspectContext.Args.OutputFormat, "output", "o", string(output.TableFormat), kuma_cmd.UsageOptions("output format", output.TableFormat, output.YAMLFormat, output.JSONFormat))
+	inspectCmd.PersistentFlags().StringVarP(&pctx.InspectContext.Args.OutputFormat, "output", "o", string(output.TableFormat), kuma_cmd.UsageOptions("output format", output.TableFormat, output.YAMLFormat, output.JSONFormat))
 	// sub-commands
-	cmd.AddCommand(newInspectDataplanesCmd(pctx))
-	cmd.AddCommand(newInspectZoneIngressesCmd(pctx))
-	cmd.AddCommand(newInspectZonesCmd(pctx))
-	cmd.AddCommand(newInspectMeshesCmd(pctx))
-	cmd.AddCommand(newInspectServicesCmd(pctx))
-	return cmd
+	inspectCmd.AddCommand(newInspectDataplanesCmd(pctx))
+	inspectCmd.AddCommand(newInspectZoneIngressesCmd(pctx))
+	inspectCmd.AddCommand(newInspectZonesCmd(pctx))
+	inspectCmd.AddCommand(newInspectMeshesCmd(pctx))
+	inspectCmd.AddCommand(newInspectServicesCmd(pctx))
+	return inspectCmd
 }

--- a/app/kumactl/cmd/root.go
+++ b/app/kumactl/cmd/root.go
@@ -66,10 +66,6 @@ func NewRootCmd(root *kumactl_cmd.RootContext) *cobra.Command {
 				return err
 			}
 
-			if err := root.CheckServerVersionCompatibility(); err != nil {
-				cmd.PrintErrln(err)
-			}
-
 			return nil
 		},
 	}

--- a/app/kumactl/cmd/root.go
+++ b/app/kumactl/cmd/root.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"context"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -18,7 +17,6 @@ import (
 	kumactl_cmd "github.com/kumahq/kuma/app/kumactl/pkg/cmd"
 	kumactl_config "github.com/kumahq/kuma/app/kumactl/pkg/config"
 	kumactl_errors "github.com/kumahq/kuma/app/kumactl/pkg/errors"
-	"github.com/kumahq/kuma/pkg/api-server/types"
 	kuma_cmd "github.com/kumahq/kuma/pkg/cmd"
 	"github.com/kumahq/kuma/pkg/cmd/version"
 	"github.com/kumahq/kuma/pkg/core"
@@ -26,15 +24,9 @@ import (
 
 	// Register gateway resources.
 	_ "github.com/kumahq/kuma/pkg/plugins/runtime/gateway/register"
-	kuma_version "github.com/kumahq/kuma/pkg/version"
 
 	// import Envoy protobuf definitions so (un)marshaling Envoy protobuf works
 	_ "github.com/kumahq/kuma/pkg/xds/envoy"
-)
-
-var (
-	kumactlLog       = core.Log.WithName("kumactl")
-	kumaBuildVersion *types.IndexResponse
 )
 
 // newRootCmd represents the base command when called without any subcommands.
@@ -74,21 +66,10 @@ func NewRootCmd(root *kumactl_cmd.RootContext) *cobra.Command {
 				return err
 			}
 
-			client, err := root.CurrentApiClient()
-			if err != nil {
-				kumactlLog.Error(err, "Unable to get index client")
-			} else {
-				kumaBuildVersion, err = client.GetVersion(context.Background())
-				if err != nil {
-					kumactlLog.Error(err, "Unable to retrieve server version")
-				}
+			if err := root.CheckServerVersionCompatibility(); err != nil {
+				cmd.PrintErrln(err)
 			}
 
-			if kumaBuildVersion == nil {
-				cmd.PrintErr("WARNING: Unable to confirm the server supports this kumactl version\n")
-			} else if kumaBuildVersion.Version != kuma_version.Build.Version || kumaBuildVersion.Tagline != kuma_version.Product {
-				cmd.PrintErr("WARNING: You are using kumactl version " + kuma_version.Build.Version + " for " + kuma_version.Product + ", but the server returned version: " + kumaBuildVersion.Tagline + " " + kumaBuildVersion.Version + "\n")
-			}
 			return nil
 		},
 	}

--- a/app/kumactl/pkg/cmd/util.go
+++ b/app/kumactl/pkg/cmd/util.go
@@ -1,0 +1,16 @@
+package cmd
+
+import "github.com/spf13/cobra"
+
+// RunParentPreRunE checks if the parent command has a PersistentPreRunE set and
+// executes it. This is for use in PersistentPreRun and is necessary because
+// only the first PersistentPreRun* of the command's ancestors is executed by
+// cobra.
+func RunParentPreRunE(cmd *cobra.Command, args []string) error {
+	if p := cmd.Parent(); p != nil && p.PersistentPreRunE != nil {
+		if err := p.PersistentPreRunE(p, args); err != nil {
+			return err
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
### Summary

#### fix(kumactl) Only warn about version compatibility where it makes sense

Warn for: apply, delete, generate, get, inspect
Don't warn for: completion, config, install, uninstall, version

### Full changelog

* Only warn about version compatibility where it makes sense

### Testing

- [x] Unit tests
- [ ] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes 

### Backwards compatibility

- [ ] Add `backport-to-stable` label if the code is backwards compatible. Otherwise, list breaking changes.
