### PR TITLE
fix(tests) fix test expectations due to package-level variable

### DIFF
--- a/app/kumactl/cmd/config/config_control_planes_add_test.go
+++ b/app/kumactl/cmd/config/config_control_planes_add_test.go
@@ -150,7 +150,8 @@ var _ = Describe("kumactl config control-planes add", func() {
 			// then
 			Expect(err).To(MatchError(`provided address is not valid Kuma Control Plane API Server`))
 			// and
-			Expect(outbuf.String()).To(Equal(`Error: provided address is not valid Kuma Control Plane API Server
+			Expect(outbuf.String()).To(Equal(`WARNING: Unable to confirm the server supports this kumactl version
+Error: provided address is not valid Kuma Control Plane API Server
 `))
 		})
 	})
@@ -217,6 +218,7 @@ var _ = Describe("kumactl config control-planes add", func() {
 				configFile: "config-control-planes-add.01.initial.yaml",
 				goldenFile: "config-control-planes-add.01.golden.yaml",
 				expectedOut: `
+WARNING: Unable to confirm the server supports this kumactl version
 added Control Plane "example"
 switched active Control Plane to "example"
 `,

--- a/app/kumactl/cmd/root.go
+++ b/app/kumactl/cmd/root.go
@@ -33,8 +33,7 @@ import (
 )
 
 var (
-	kumactlLog       = core.Log.WithName("kumactl")
-	kumaBuildVersion *types.IndexResponse
+	kumactlLog = core.Log.WithName("kumactl")
 )
 
 // newRootCmd represents the base command when called without any subcommands.
@@ -73,6 +72,8 @@ func NewRootCmd(root *kumactl_cmd.RootContext) *cobra.Command {
 			if err := root.LoadConfig(); err != nil {
 				return err
 			}
+
+			var kumaBuildVersion *types.IndexResponse
 
 			client, err := root.CurrentApiClient()
 			if err != nil {


### PR DESCRIPTION
### Summary

In these two tests we _can't_ contact the API server and so the warning is printed by the compiled `kumactl`. This line 

https://github.com/michaelbeaumont/kuma/blob/1333e7c965a15bed2527cf69977931021add4c35/app/kumactl/cmd/root.go#L79 

is being hit and thus we aren't initializing `kumaBuildVersion`, but `kumaBuildVersion` is nevertheless `!= nil`. With `FIt` we can see that whether we run the other tests determines if these pass or fail.

### Full changelog

* fix(tests) fix test expectations due to global variable

### Testing

- [x] Unit tests
- [x] E2E tests
-  ~Manual testing on Universal~
-  ~Manual testing on Kubernetes~ 

### Backwards compatibility

-  ~Add `backport-to-stable` label if the code is backwards compatible. Otherwise, list breaking changes.~
