### PR TITLE
feat(kuma-cp) generate GatewayRoute clusters

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,6 @@ require (
 	github.com/envoyproxy/protoc-gen-validate v0.4.1
 	github.com/ghodss/yaml v1.0.0
 	github.com/go-git/go-git/v5 v5.4.2
-	github.com/go-kit/kit v0.11.0 // indirect
 	github.com/go-logr/logr v0.1.0
 	github.com/go-logr/zapr v0.1.1
 	github.com/golang-migrate/migrate/v4 v4.14.1
@@ -24,6 +23,7 @@ require (
 	github.com/gruntwork-io/terratest v0.30.15
 	github.com/hoisie/mustache v0.0.0-20160804235033-6375acf62c69
 	github.com/iancoleman/orderedmap v0.2.0
+	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51
 	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/kumahq/kuma/pkg/transparentproxy/istio v0.0.0-00010101000000-000000000000
 	github.com/kumahq/protoc-gen-kumadoc v0.1.7

--- a/go.sum
+++ b/go.sum
@@ -766,6 +766,8 @@ github.com/justinas/alice v1.2.0/go.mod h1:fN5HRH/reO/zrUflLfTN43t3vXvKzvZIENsNE
 github.com/k0kubun/colorstring v0.0.0-20150214042306-9440f1994b88/go.mod h1:3w7q1U84EfirKl04SVQ/s7nPm1ZPhiXd34z40TNz36k=
 github.com/k0kubun/pp v2.3.0+incompatible/go.mod h1:GWse8YhT0p8pT4ir3ZgBbfZild3tgzSScAn6HmfYukg=
 github.com/kardianos/osext v0.0.0-20190222173326-2bc1f35cddc0/go.mod h1:1NbS8ALrpOvjt0rHPNLyCIeMtbizbir8U//inJ+zuB8=
+github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 h1:Z9n2FFNUXsshfwJMBgNA0RU6/i7WVaAegv3PtuIHPMs=
+github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51/go.mod h1:CzGEWj7cYgsdH8dAjBGEr58BoE7ScuLd+fwFZ44+/x8=
 github.com/kelseyhightower/envconfig v1.4.0 h1:Im6hONhd3pLkfDFsbRgu68RDNkGF1r3dvMUtDTo2cv8=
 github.com/kelseyhightower/envconfig v1.4.0/go.mod h1:cccZRl6mQpaq41TPp5QxidR+Sa3axMbJDNb//FQX6Gg=
 github.com/kevinburke/ssh_config v0.0.0-20201106050909-4977a11b4351 h1:DowS9hvgyYSX4TO5NpyC606/Z4SxnNYbT+WX27or6Ck=

--- a/pkg/plugins/runtime/gateway/builder.go
+++ b/pkg/plugins/runtime/gateway/builder.go
@@ -1,6 +1,7 @@
 package gateway
 
 import (
+	"github.com/golang/protobuf/proto"
 	"github.com/pkg/errors"
 
 	"github.com/kumahq/kuma/pkg/core/xds"
@@ -55,4 +56,12 @@ func (r *ResourceAggregator) Add(set *xds.ResourceSet, err error) error {
 
 	r.ResourceSet.AddSet(set)
 	return nil
+}
+
+func NewResource(name string, resource proto.Message) *xds.Resource {
+	return &xds.Resource{
+		Name:     name,
+		Origin:   OriginGateway,
+		Resource: resource,
+	}
 }

--- a/pkg/plugins/runtime/gateway/gateway_route_generator_test.go
+++ b/pkg/plugins/runtime/gateway/gateway_route_generator_test.go
@@ -49,10 +49,27 @@ var _ = Describe("Gateway Gateway Route", func() {
 
 		dataplanes = &DataplaneGenerator{Manager: rt.ResourceManager()}
 
-		// TODO(jpeach) dataplane resources won't be used in the
-		// tests until the GatewayRoute generator starts generating
-		// endpoints.
 		dataplanes.Generate("echo-service")
+		dataplanes.Generate("echo-mirror")
+		dataplanes.Generate("exact-header-match")
+		dataplanes.Generate("regex-header-match")
+
+		// Add dataplane resources for all the services used in the test suite.
+		for _, service := range []string{
+			"echo-exact",
+			"echo-mirror",
+			"echo-prefix",
+			"echo-regex",
+			"echo-service",
+			"exact-header-match",
+			"exact-query-match",
+			"exact-service",
+			"prefix-service",
+			"regex-header-match",
+			"regex-query-match",
+		} {
+			dataplanes.Generate(service)
+		}
 	})
 
 	DescribeTable("generate matching resources",

--- a/pkg/plugins/runtime/gateway/route_table_generator.go
+++ b/pkg/plugins/runtime/gateway/route_table_generator.go
@@ -1,12 +1,19 @@
 package gateway
 
 import (
+	"context"
 	"sort"
 
+	"github.com/pkg/errors"
+
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
+	"github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	core_xds "github.com/kumahq/kuma/pkg/core/xds"
 	"github.com/kumahq/kuma/pkg/plugins/runtime/gateway/route"
 	xds_context "github.com/kumahq/kuma/pkg/xds/context"
+	"github.com/kumahq/kuma/pkg/xds/envoy"
+	"github.com/kumahq/kuma/pkg/xds/envoy/clusters"
+	"github.com/kumahq/kuma/pkg/xds/generator"
 )
 
 // RouteTableGenerator generates Envoy xDS resources gateway routes from
@@ -19,7 +26,7 @@ func (*RouteTableGenerator) SupportsProtocol(mesh_proto.Gateway_Listener_Protoco
 }
 
 // GenerateHost generates xDS resources for the current route table.
-func (*RouteTableGenerator) GenerateHost(ctx xds_context.Context, info *GatewayResourceInfo) (*core_xds.ResourceSet, error) {
+func (r *RouteTableGenerator) GenerateHost(ctx xds_context.Context, info *GatewayResourceInfo) (*core_xds.ResourceSet, error) {
 	resources := ResourceAggregator{}
 
 	// Sort routing table entries so the most specific match comes first.
@@ -82,12 +89,128 @@ func (*RouteTableGenerator) GenerateHost(ctx xds_context.Context, info *GatewayR
 		info.Resources.VirtualHost.Configure(route.VirtualHostRoute(&routeBuilder))
 	}
 
-	// TODO(jpeach) walk the routing table and generate clusters
-	// (including the mirror cluster). Hopefully we can use the
-	// envoy.Cluster type for this.
+	destinations, err := makeRouteDestinations(&info.RouteTable)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := resources.Add(r.generateClusters(ctx, info, destinations)); err != nil {
+		return nil, err
+	}
+
+	if err := resources.Add(r.generateEndpointAssignments(ctx, info, destinations)); err != nil {
+		return nil, err
+	}
 
 	// TODO(jpeach) Once we drop TrafficRoute, generate resources
 	// for info.Resources.VirtualHost here instead of in generator.go
 
 	return resources.Get(), nil
+}
+
+func (r *RouteTableGenerator) generateEndpointAssignments(
+	ctx xds_context.Context,
+	info *GatewayResourceInfo,
+	destinations map[string]route.Destination,
+) (*core_xds.ResourceSet, error) {
+	resources := core_xds.NewResourceSet()
+
+	// TODO(jpeach) Don't generate load assignments for external services.
+
+	for name, dest := range destinations {
+		// The CLA cache needs an envoy.Cluster but only looks
+		// at the fields we populate here.
+		cluster := envoy.NewCluster(
+			envoy.WithName(name),
+			envoy.WithService(dest.Destination[mesh_proto.ServiceTag]),
+			envoy.WithTags(dest.Destination),
+		)
+
+		loadAssignment, err := ctx.ControlPlane.CLACache.GetCLA(
+			context.Background(),
+			ctx.Mesh.Resource.GetMeta().GetName(),
+			ctx.Mesh.Hash,
+			cluster,
+			info.Proxy.APIVersion,
+		)
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to build LoadAssignment for cluster %q", name)
+		}
+
+		resources.Add(NewResource(name, loadAssignment))
+	}
+
+	return resources, nil
+}
+
+func (r *RouteTableGenerator) generateClusters(
+	ctx xds_context.Context,
+	info *GatewayResourceInfo,
+	destinations map[string]route.Destination,
+) (*core_xds.ResourceSet, error) {
+	resources := ResourceAggregator{}
+
+	for name, dest := range destinations {
+		protocol := generator.InferServiceProtocol([]core_xds.Endpoint{{
+			Tags: dest.Destination,
+		}})
+
+		builder := clusters.NewClusterBuilder(info.Proxy.APIVersion).Configure(
+			clusters.EdsCluster(name),
+			clusters.Timeout(protocol, nil /* TODO(jpeach) default timeout */),
+			clusters.CircuitBreaker(nil /* TODO(jpeach) uses default */),
+			clusters.OutlierDetection(nil /* TODO(jpeach) uses default */),
+			clusters.HealthCheck(protocol, nil /* TODO(jpeach) uses default */),
+			clusters.LB(nil /* TODO(jpeach) uses default Round Robin*/),
+		)
+
+		// Assuming this is an intra-Mesh service, enable mTLS.
+		builder.Configure(
+			clusters.ClientSideMTLS(ctx, dest.Destination[mesh_proto.ServiceTag], []envoy.Tags{dest.Destination}),
+		)
+
+		// TODO(jpeach) External services are "strict DNS" clusters and don't use mTLS.
+
+		switch protocol {
+		case mesh.ProtocolHTTP:
+			builder.Configure(clusters.Http())
+		case mesh.ProtocolHTTP2, mesh.ProtocolGRPC:
+			builder.Configure(clusters.Http2())
+		}
+
+		if err := resources.Add(BuildResourceSet(builder)); err != nil {
+			return nil, err
+		}
+	}
+
+	return resources.Get(), nil
+}
+
+// makeRouteDestinations builds a map of all the destinations in the
+// route table, indexed by cluster name. This de-duplicates the destinations
+// by name and ensures we only have to generate the name once.
+func makeRouteDestinations(table *route.Table) (map[string]route.Destination, error) {
+	destinations := map[string]route.Destination{}
+
+	for _, e := range table.Entries {
+		if m := e.Mirror; m != nil {
+			name, err := route.DestinationClusterName(m.Forward)
+			if err != nil {
+				return nil, err
+			}
+
+			destinations[name] = m.Forward
+		}
+
+		for _, d := range e.Action.Forward {
+			name, err := route.DestinationClusterName(d)
+			if err != nil {
+				return nil, err
+			}
+
+			destinations[name] = d
+		}
+	}
+
+	return destinations, nil
 }

--- a/pkg/plugins/runtime/gateway/suite_test.go
+++ b/pkg/plugins/runtime/gateway/suite_test.go
@@ -245,6 +245,7 @@ type DataplaneGenerator struct {
 	Mesh      string
 	Addresser *ipam.IPAM
 	Manager   manager.ResourceManager
+	NextPort  uint32
 }
 
 // Generate creates a single Dataplane resource.
@@ -278,6 +279,10 @@ func (d *DataplaneGenerator) init() {
 		d.Addresser = i
 		d.Addresser.ReserveFirstAndLast()
 	}
+
+	if d.NextPort == 0 {
+		d.NextPort = 20000
+	}
 }
 
 func (d *DataplaneGenerator) generate(
@@ -293,6 +298,8 @@ func (d *DataplaneGenerator) generate(
 	addr, err := d.Addresser.Allocate()
 	Expect(err).To(Succeed())
 
+	d.NextPort++
+
 	dp := core_mesh.NewDataplaneResource()
 	dp.SetMeta(&rest.ResourceMeta{
 		Type:             string(dp.Descriptor().Name),
@@ -305,8 +312,8 @@ func (d *DataplaneGenerator) generate(
 		Address: addr.String(),
 		Inbound: []*mesh_proto.Dataplane_Networking_Inbound{
 			&mesh_proto.Dataplane_Networking_Inbound{
-				Port:        20011,
-				ServicePort: 10011,
+				Port:        d.NextPort,
+				ServicePort: d.NextPort,
 				Tags: map[string]string{
 					mesh_proto.ServiceTag:  serviceName,
 					mesh_proto.ProtocolTag: "http",

--- a/pkg/plugins/runtime/gateway/testdata/01-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/01-gateway-route.yaml
@@ -1,7 +1,31 @@
 Clusters:
-  Resources: {}
+  Resources:
+    echo-service:
+      connectTimeout: 10s
+      edsClusterConfig:
+        edsConfig:
+          ads: {}
+          resourceApiVersion: V3
+      name: echo-service
+      type: EDS
 Endpoints:
-  Resources: {}
+  Resources:
+    echo-service:
+      clusterName: echo-service
+      endpoints:
+      - lbEndpoints:
+        - endpoint:
+            address:
+              socketAddress:
+                address: 192.168.1.9
+                portValue: 20009
+          loadBalancingWeight: 1
+          metadata:
+            filterMetadata:
+              envoy.lb:
+                kuma.io/protocol: http
+              envoy.transport_socket_match:
+                kuma.io/protocol: http
 Listeners:
   Resources:
     edge-gateway:HTTP:8080:

--- a/pkg/plugins/runtime/gateway/testdata/01-traffic-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/01-traffic-route.yaml
@@ -25,7 +25,7 @@ Endpoints:
             address:
               socketAddress:
                 address: 192.168.1.1
-                portValue: 20011
+                portValue: 20001
           loadBalancingWeight: 1
           metadata:
             filterMetadata:
@@ -37,7 +37,7 @@ Endpoints:
             address:
               socketAddress:
                 address: 192.168.1.2
-                portValue: 20011
+                portValue: 20002
           loadBalancingWeight: 1
           metadata:
             filterMetadata:
@@ -49,7 +49,7 @@ Endpoints:
             address:
               socketAddress:
                 address: 192.168.1.3
-                portValue: 20011
+                portValue: 20003
           loadBalancingWeight: 1
           metadata:
             filterMetadata:
@@ -61,7 +61,7 @@ Endpoints:
             address:
               socketAddress:
                 address: 192.168.1.4
-                portValue: 20011
+                portValue: 20004
           loadBalancingWeight: 1
           metadata:
             filterMetadata:
@@ -73,7 +73,7 @@ Endpoints:
             address:
               socketAddress:
                 address: 192.168.1.5
-                portValue: 20011
+                portValue: 20005
           loadBalancingWeight: 1
           metadata:
             filterMetadata:

--- a/pkg/plugins/runtime/gateway/testdata/02-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/02-gateway-route.yaml
@@ -1,7 +1,31 @@
 Clusters:
-  Resources: {}
+  Resources:
+    echo-service:
+      connectTimeout: 10s
+      edsClusterConfig:
+        edsConfig:
+          ads: {}
+          resourceApiVersion: V3
+      name: echo-service
+      type: EDS
 Endpoints:
-  Resources: {}
+  Resources:
+    echo-service:
+      clusterName: echo-service
+      endpoints:
+      - lbEndpoints:
+        - endpoint:
+            address:
+              socketAddress:
+                address: 192.168.1.9
+                portValue: 20009
+          loadBalancingWeight: 1
+          metadata:
+            filterMetadata:
+              envoy.lb:
+                kuma.io/protocol: http
+              envoy.transport_socket_match:
+                kuma.io/protocol: http
 Listeners:
   Resources:
     edge-gateway:HTTP:8080:

--- a/pkg/plugins/runtime/gateway/testdata/02-traffic-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/02-traffic-route.yaml
@@ -25,7 +25,7 @@ Endpoints:
             address:
               socketAddress:
                 address: 192.168.1.1
-                portValue: 20011
+                portValue: 20001
           loadBalancingWeight: 1
           metadata:
             filterMetadata:
@@ -37,7 +37,7 @@ Endpoints:
             address:
               socketAddress:
                 address: 192.168.1.2
-                portValue: 20011
+                portValue: 20002
           loadBalancingWeight: 1
           metadata:
             filterMetadata:

--- a/pkg/plugins/runtime/gateway/testdata/03-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/03-gateway-route.yaml
@@ -1,7 +1,31 @@
 Clusters:
-  Resources: {}
+  Resources:
+    echo-service:
+      connectTimeout: 10s
+      edsClusterConfig:
+        edsConfig:
+          ads: {}
+          resourceApiVersion: V3
+      name: echo-service
+      type: EDS
 Endpoints:
-  Resources: {}
+  Resources:
+    echo-service:
+      clusterName: echo-service
+      endpoints:
+      - lbEndpoints:
+        - endpoint:
+            address:
+              socketAddress:
+                address: 192.168.1.9
+                portValue: 20009
+          loadBalancingWeight: 1
+          metadata:
+            filterMetadata:
+              envoy.lb:
+                kuma.io/protocol: http
+              envoy.transport_socket_match:
+                kuma.io/protocol: http
 Listeners:
   Resources:
     edge-gateway:HTTP:8080:

--- a/pkg/plugins/runtime/gateway/testdata/03-traffic-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/03-traffic-route.yaml
@@ -70,7 +70,7 @@ Endpoints:
             address:
               socketAddress:
                 address: 192.168.1.2
-                portValue: 20011
+                portValue: 20002
           loadBalancingWeight: 1
           metadata:
             filterMetadata:
@@ -88,7 +88,7 @@ Endpoints:
             address:
               socketAddress:
                 address: 192.168.1.3
-                portValue: 20011
+                portValue: 20003
           loadBalancingWeight: 1
           metadata:
             filterMetadata:
@@ -106,7 +106,7 @@ Endpoints:
             address:
               socketAddress:
                 address: 192.168.1.4
-                portValue: 20011
+                portValue: 20004
           loadBalancingWeight: 1
           metadata:
             filterMetadata:
@@ -124,7 +124,7 @@ Endpoints:
             address:
               socketAddress:
                 address: 192.168.1.1
-                portValue: 20011
+                portValue: 20001
           loadBalancingWeight: 1
           metadata:
             filterMetadata:

--- a/pkg/plugins/runtime/gateway/testdata/04-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/04-gateway-route.yaml
@@ -1,7 +1,41 @@
 Clusters:
-  Resources: {}
+  Resources:
+    echo-mirror-303ee71109a987aa:
+      connectTimeout: 10s
+      edsClusterConfig:
+        edsConfig:
+          ads: {}
+          resourceApiVersion: V3
+      name: echo-mirror-303ee71109a987aa
+      type: EDS
+    echo-service:
+      connectTimeout: 10s
+      edsClusterConfig:
+        edsConfig:
+          ads: {}
+          resourceApiVersion: V3
+      name: echo-service
+      type: EDS
 Endpoints:
-  Resources: {}
+  Resources:
+    echo-mirror-303ee71109a987aa:
+      clusterName: echo-mirror-303ee71109a987aa
+    echo-service:
+      clusterName: echo-service
+      endpoints:
+      - lbEndpoints:
+        - endpoint:
+            address:
+              socketAddress:
+                address: 192.168.1.9
+                portValue: 20009
+          loadBalancingWeight: 1
+          metadata:
+            filterMetadata:
+              envoy.lb:
+                kuma.io/protocol: http
+              envoy.transport_socket_match:
+                kuma.io/protocol: http
 Listeners:
   Resources:
     edge-gateway:HTTP:8080:

--- a/pkg/plugins/runtime/gateway/testdata/04-traffic-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/04-traffic-route.yaml
@@ -25,7 +25,7 @@ Endpoints:
             address:
               socketAddress:
                 address: 192.168.1.1
-                portValue: 20011
+                portValue: 20001
           loadBalancingWeight: 1
           metadata:
             filterMetadata:
@@ -37,7 +37,7 @@ Endpoints:
             address:
               socketAddress:
                 address: 192.168.1.2
-                portValue: 20011
+                portValue: 20002
           loadBalancingWeight: 1
           metadata:
             filterMetadata:

--- a/pkg/plugins/runtime/gateway/testdata/06-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/06-gateway-route.yaml
@@ -1,7 +1,41 @@
 Clusters:
-  Resources: {}
+  Resources:
+    echo-mirror-303ee71109a987aa:
+      connectTimeout: 10s
+      edsClusterConfig:
+        edsConfig:
+          ads: {}
+          resourceApiVersion: V3
+      name: echo-mirror-303ee71109a987aa
+      type: EDS
+    echo-service:
+      connectTimeout: 10s
+      edsClusterConfig:
+        edsConfig:
+          ads: {}
+          resourceApiVersion: V3
+      name: echo-service
+      type: EDS
 Endpoints:
-  Resources: {}
+  Resources:
+    echo-mirror-303ee71109a987aa:
+      clusterName: echo-mirror-303ee71109a987aa
+    echo-service:
+      clusterName: echo-service
+      endpoints:
+      - lbEndpoints:
+        - endpoint:
+            address:
+              socketAddress:
+                address: 192.168.1.9
+                portValue: 20009
+          loadBalancingWeight: 1
+          metadata:
+            filterMetadata:
+              envoy.lb:
+                kuma.io/protocol: http
+              envoy.transport_socket_match:
+                kuma.io/protocol: http
 Listeners:
   Resources:
     edge-gateway:HTTP:8080:

--- a/pkg/plugins/runtime/gateway/testdata/07-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/07-gateway-route.yaml
@@ -1,7 +1,31 @@
 Clusters:
-  Resources: {}
+  Resources:
+    echo-service:
+      connectTimeout: 10s
+      edsClusterConfig:
+        edsConfig:
+          ads: {}
+          resourceApiVersion: V3
+      name: echo-service
+      type: EDS
 Endpoints:
-  Resources: {}
+  Resources:
+    echo-service:
+      clusterName: echo-service
+      endpoints:
+      - lbEndpoints:
+        - endpoint:
+            address:
+              socketAddress:
+                address: 192.168.1.9
+                portValue: 20009
+          loadBalancingWeight: 1
+          metadata:
+            filterMetadata:
+              envoy.lb:
+                kuma.io/protocol: http
+              envoy.transport_socket_match:
+                kuma.io/protocol: http
 Listeners:
   Resources:
     edge-gateway:HTTP:8080:

--- a/pkg/plugins/runtime/gateway/testdata/08-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/08-gateway-route.yaml
@@ -1,7 +1,55 @@
 Clusters:
-  Resources: {}
+  Resources:
+    exact-service:
+      connectTimeout: 10s
+      edsClusterConfig:
+        edsConfig:
+          ads: {}
+          resourceApiVersion: V3
+      name: exact-service
+      type: EDS
+    prefix-service:
+      connectTimeout: 10s
+      edsClusterConfig:
+        edsConfig:
+          ads: {}
+          resourceApiVersion: V3
+      name: prefix-service
+      type: EDS
 Endpoints:
-  Resources: {}
+  Resources:
+    exact-service:
+      clusterName: exact-service
+      endpoints:
+      - lbEndpoints:
+        - endpoint:
+            address:
+              socketAddress:
+                address: 192.168.1.12
+                portValue: 20012
+          loadBalancingWeight: 1
+          metadata:
+            filterMetadata:
+              envoy.lb:
+                kuma.io/protocol: http
+              envoy.transport_socket_match:
+                kuma.io/protocol: http
+    prefix-service:
+      clusterName: prefix-service
+      endpoints:
+      - lbEndpoints:
+        - endpoint:
+            address:
+              socketAddress:
+                address: 192.168.1.13
+                portValue: 20013
+          loadBalancingWeight: 1
+          metadata:
+            filterMetadata:
+              envoy.lb:
+                kuma.io/protocol: http
+              envoy.transport_socket_match:
+                kuma.io/protocol: http
 Listeners:
   Resources:
     edge-gateway:HTTP:8080:

--- a/pkg/plugins/runtime/gateway/testdata/09-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/09-gateway-route.yaml
@@ -1,7 +1,31 @@
 Clusters:
-  Resources: {}
+  Resources:
+    echo-service:
+      connectTimeout: 10s
+      edsClusterConfig:
+        edsConfig:
+          ads: {}
+          resourceApiVersion: V3
+      name: echo-service
+      type: EDS
 Endpoints:
-  Resources: {}
+  Resources:
+    echo-service:
+      clusterName: echo-service
+      endpoints:
+      - lbEndpoints:
+        - endpoint:
+            address:
+              socketAddress:
+                address: 192.168.1.9
+                portValue: 20009
+          loadBalancingWeight: 1
+          metadata:
+            filterMetadata:
+              envoy.lb:
+                kuma.io/protocol: http
+              envoy.transport_socket_match:
+                kuma.io/protocol: http
 Listeners:
   Resources:
     edge-gateway:HTTP:8080:

--- a/pkg/plugins/runtime/gateway/testdata/10-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/10-gateway-route.yaml
@@ -1,7 +1,55 @@
 Clusters:
-  Resources: {}
+  Resources:
+    exact-header-match:
+      connectTimeout: 10s
+      edsClusterConfig:
+        edsConfig:
+          ads: {}
+          resourceApiVersion: V3
+      name: exact-header-match
+      type: EDS
+    regex-header-match:
+      connectTimeout: 10s
+      edsClusterConfig:
+        edsConfig:
+          ads: {}
+          resourceApiVersion: V3
+      name: regex-header-match
+      type: EDS
 Endpoints:
-  Resources: {}
+  Resources:
+    exact-header-match:
+      clusterName: exact-header-match
+      endpoints:
+      - lbEndpoints:
+        - endpoint:
+            address:
+              socketAddress:
+                address: 192.168.1.10
+                portValue: 20010
+          loadBalancingWeight: 1
+          metadata:
+            filterMetadata:
+              envoy.lb:
+                kuma.io/protocol: http
+              envoy.transport_socket_match:
+                kuma.io/protocol: http
+    regex-header-match:
+      clusterName: regex-header-match
+      endpoints:
+      - lbEndpoints:
+        - endpoint:
+            address:
+              socketAddress:
+                address: 192.168.1.14
+                portValue: 20014
+          loadBalancingWeight: 1
+          metadata:
+            filterMetadata:
+              envoy.lb:
+                kuma.io/protocol: http
+              envoy.transport_socket_match:
+                kuma.io/protocol: http
 Listeners:
   Resources:
     edge-gateway:HTTP:8080:

--- a/pkg/plugins/runtime/gateway/testdata/11-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/11-gateway-route.yaml
@@ -1,7 +1,55 @@
 Clusters:
-  Resources: {}
+  Resources:
+    exact-query-match:
+      connectTimeout: 10s
+      edsClusterConfig:
+        edsConfig:
+          ads: {}
+          resourceApiVersion: V3
+      name: exact-query-match
+      type: EDS
+    regex-query-match:
+      connectTimeout: 10s
+      edsClusterConfig:
+        edsConfig:
+          ads: {}
+          resourceApiVersion: V3
+      name: regex-query-match
+      type: EDS
 Endpoints:
-  Resources: {}
+  Resources:
+    exact-query-match:
+      clusterName: exact-query-match
+      endpoints:
+      - lbEndpoints:
+        - endpoint:
+            address:
+              socketAddress:
+                address: 192.168.1.11
+                portValue: 20011
+          loadBalancingWeight: 1
+          metadata:
+            filterMetadata:
+              envoy.lb:
+                kuma.io/protocol: http
+              envoy.transport_socket_match:
+                kuma.io/protocol: http
+    regex-query-match:
+      clusterName: regex-query-match
+      endpoints:
+      - lbEndpoints:
+        - endpoint:
+            address:
+              socketAddress:
+                address: 192.168.1.15
+                portValue: 20015
+          loadBalancingWeight: 1
+          metadata:
+            filterMetadata:
+              envoy.lb:
+                kuma.io/protocol: http
+              envoy.transport_socket_match:
+                kuma.io/protocol: http
 Listeners:
   Resources:
     edge-gateway:HTTP:8080:

--- a/pkg/plugins/runtime/gateway/testdata/12-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/12-gateway-route.yaml
@@ -1,7 +1,31 @@
 Clusters:
-  Resources: {}
+  Resources:
+    echo-service:
+      connectTimeout: 10s
+      edsClusterConfig:
+        edsConfig:
+          ads: {}
+          resourceApiVersion: V3
+      name: echo-service
+      type: EDS
 Endpoints:
-  Resources: {}
+  Resources:
+    echo-service:
+      clusterName: echo-service
+      endpoints:
+      - lbEndpoints:
+        - endpoint:
+            address:
+              socketAddress:
+                address: 192.168.1.9
+                portValue: 20009
+          loadBalancingWeight: 1
+          metadata:
+            filterMetadata:
+              envoy.lb:
+                kuma.io/protocol: http
+              envoy.transport_socket_match:
+                kuma.io/protocol: http
 Listeners:
   Resources:
     edge-gateway:HTTP:8080:

--- a/pkg/plugins/runtime/gateway/testdata/13-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/13-gateway-route.yaml
@@ -1,7 +1,79 @@
 Clusters:
-  Resources: {}
+  Resources:
+    echo-exact:
+      connectTimeout: 10s
+      edsClusterConfig:
+        edsConfig:
+          ads: {}
+          resourceApiVersion: V3
+      name: echo-exact
+      type: EDS
+    echo-prefix:
+      connectTimeout: 10s
+      edsClusterConfig:
+        edsConfig:
+          ads: {}
+          resourceApiVersion: V3
+      name: echo-prefix
+      type: EDS
+    echo-regex:
+      connectTimeout: 10s
+      edsClusterConfig:
+        edsConfig:
+          ads: {}
+          resourceApiVersion: V3
+      name: echo-regex
+      type: EDS
 Endpoints:
-  Resources: {}
+  Resources:
+    echo-exact:
+      clusterName: echo-exact
+      endpoints:
+      - lbEndpoints:
+        - endpoint:
+            address:
+              socketAddress:
+                address: 192.168.1.5
+                portValue: 20005
+          loadBalancingWeight: 1
+          metadata:
+            filterMetadata:
+              envoy.lb:
+                kuma.io/protocol: http
+              envoy.transport_socket_match:
+                kuma.io/protocol: http
+    echo-prefix:
+      clusterName: echo-prefix
+      endpoints:
+      - lbEndpoints:
+        - endpoint:
+            address:
+              socketAddress:
+                address: 192.168.1.7
+                portValue: 20007
+          loadBalancingWeight: 1
+          metadata:
+            filterMetadata:
+              envoy.lb:
+                kuma.io/protocol: http
+              envoy.transport_socket_match:
+                kuma.io/protocol: http
+    echo-regex:
+      clusterName: echo-regex
+      endpoints:
+      - lbEndpoints:
+        - endpoint:
+            address:
+              socketAddress:
+                address: 192.168.1.8
+                portValue: 20008
+          loadBalancingWeight: 1
+          metadata:
+            filterMetadata:
+              envoy.lb:
+                kuma.io/protocol: http
+              envoy.transport_socket_match:
+                kuma.io/protocol: http
 Listeners:
   Resources:
     edge-gateway:HTTP:8080:

--- a/pkg/plugins/runtime/gateway/testdata/14-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/14-gateway-route.yaml
@@ -1,7 +1,31 @@
 Clusters:
-  Resources: {}
+  Resources:
+    echo-service:
+      connectTimeout: 10s
+      edsClusterConfig:
+        edsConfig:
+          ads: {}
+          resourceApiVersion: V3
+      name: echo-service
+      type: EDS
 Endpoints:
-  Resources: {}
+  Resources:
+    echo-service:
+      clusterName: echo-service
+      endpoints:
+      - lbEndpoints:
+        - endpoint:
+            address:
+              socketAddress:
+                address: 192.168.1.9
+                portValue: 20009
+          loadBalancingWeight: 1
+          metadata:
+            filterMetadata:
+              envoy.lb:
+                kuma.io/protocol: http
+              envoy.transport_socket_match:
+                kuma.io/protocol: http
 Listeners:
   Resources:
     edge-gateway:HTTP:8080:

--- a/test/e2e/gateway/gateway_suite_test.go
+++ b/test/e2e/gateway/gateway_suite_test.go
@@ -1,0 +1,21 @@
+package gateway_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+
+	"github.com/kumahq/kuma/pkg/test"
+	"github.com/kumahq/kuma/test/e2e/gateway"
+	"github.com/kumahq/kuma/test/framework"
+)
+
+var _ = Describe("Test Gateway on Universal", gateway.GatewayOnUniversal)
+
+func TestE2EGateway(t *testing.T) {
+	if framework.IsK8sClustersStarted() {
+		test.RunSpecs(t, "E2E Gateway Suite")
+	} else {
+		t.SkipNow()
+	}
+}

--- a/test/e2e/gateway/gateway_universal.go
+++ b/test/e2e/gateway/gateway_universal.go
@@ -1,0 +1,190 @@
+package gateway
+
+import (
+	"errors"
+	"fmt"
+	"net/url"
+	"path"
+	"strings"
+
+	"github.com/gruntwork-io/terratest/modules/shell"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	config_core "github.com/kumahq/kuma/pkg/config/core"
+	"github.com/kumahq/kuma/test/e2e/trafficroute/testutil"
+	. "github.com/kumahq/kuma/test/framework"
+)
+
+func GatewayOnUniversal() {
+	var cluster *UniversalCluster
+
+	EchoServerUniversal := func(name string) InstallFunc {
+		return func(cluster Cluster) error {
+			const service = "echo-service"
+			token, err := cluster.GetKuma().GenerateDpToken("default", service)
+			if err != nil {
+				return err
+			}
+
+			return TestServerUniversal(
+				name,
+				"default",
+				token,
+				WithArgs([]string{"echo", "--instance", "universal"}),
+				WithServiceName(service),
+			)(cluster)
+		}
+	}
+
+	// GatewayClientUniversal runs an empty container that will
+	// function as a client for a gateway.
+	GatewayClientUniversal := func(name string) InstallFunc {
+		return func(cluster Cluster) error {
+			return cluster.DeployApp(WithName(name), WithoutDataplane(), WithVerbose())
+		}
+	}
+
+	GatewayProxyUniversal := func(name string) InstallFunc {
+		return func(cluster Cluster) error {
+			token, err := cluster.GetKuma().GenerateDpToken("default", "edge-gateway")
+			if err != nil {
+				return err
+			}
+
+			dataplaneYaml := `
+type: Dataplane
+mesh: default
+name: {{ name }}
+networking:
+  address:  {{ address }}
+  gateway:
+    type: BUILTIN
+    tags:
+      kuma.io/service: edge-gateway
+`
+			return cluster.DeployApp(
+				WithKumactlFlow(),
+				WithName(name),
+				WithToken(token),
+				WithVerbose(),
+				WithYaml(dataplaneYaml),
+			)
+		}
+	}
+
+	BeforeEach(func() {
+		cluster = NewUniversalCluster(NewTestingT(), Kuma1, Silent)
+		Expect(cluster).ToNot(BeNil())
+
+		deployOpts := append(KumaUniversalDeployOpts, WithVerbose())
+
+		err := NewClusterSetup().
+			Install(Kuma(config_core.Standalone, deployOpts...)).
+			Install(GatewayClientUniversal("gateway-client")).
+			Install(EchoServerUniversal("echo-server")).
+			Install(GatewayProxyUniversal("gateway-proxy")).
+			Setup(cluster)
+
+		// OK, this is messed up. The makefile rule that builds the
+		// kuma-universal:latest image that is used for e2e tests
+		// always rebuilds Kuma with Gateway disabled. This means
+		// that by default, no Gateway tests will work, so we use the
+		// `WithKumactlFlow` option to detect the unsupported gateway
+		// type early (when kumactl creates the dataplane resource),
+		// and skip the remaining tests.
+		var shellErr *shell.ErrWithCmdOutput
+		if errors.As(err, &shellErr) {
+			if strings.Contains(shellErr.Output.Combined(), "unsupported gateway type") {
+				Skip("kuma-cp builtin Gateway support is not enabled")
+			}
+		}
+
+		// Otherwise, we expect the cluster build to succeed.
+		Expect(err).To(Succeed())
+
+		Expect(cluster.VerifyKuma()).To(Succeed())
+
+		// TODO(jpeach) For how the default traffic route make
+		// the gateway generate invalid clusters. Remove this when
+		// we yank TrafficRoute support.
+		Expect(
+			cluster.GetKumactlOptions().KumactlDelete("traffic-route", "route-all-default", "default"),
+		).To(Succeed())
+
+		// Synchronize on the dataplanes coming up.
+		Eventually(func(g Gomega) {
+			dataplanes, err := cluster.GetKumactlOptions().KumactlList("dataplanes", "default")
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(dataplanes).Should(ContainElements("echo-server", "gateway-proxy"))
+		}, "60s", "1s").Should(Succeed())
+	})
+
+	E2EAfterEach(func() {
+		Expect(cluster.DismissCluster()).ToNot(HaveOccurred())
+	})
+
+	It("should proxy simple HTTP requests", func() {
+		Expect(
+			cluster.GetKumactlOptions().KumactlApplyFromString(`
+type: Gateway
+mesh: default
+name: edge-gateway
+selectors:
+- match:
+    kuma.io/service: edge-gateway
+conf:
+  listeners:
+  - port: 8080
+    protocol: HTTP
+    hostname: example.kuma.io
+    tags:
+      hostname: example.kuma.io
+`),
+		).To(Succeed())
+
+		Expect(
+			cluster.GetKumactlOptions().KumactlApplyFromString(`
+type: GatewayRoute
+mesh: default
+name: edge-gateway
+selectors:
+- match:
+    kuma.io/service: edge-gateway
+conf:
+  http:
+    rules:
+    - matches:
+      - path:
+          match: PREFIX
+          value: /
+      backends:
+      - destination:
+          kuma.io/service: echo-service
+`),
+		).To(Succeed())
+
+		Expect(
+			cluster.GetKumactlOptions().KumactlList("gateways", "default"),
+		).To(ContainElement("edge-gateway"))
+
+		gateways, err := cluster.GetKumactlOptions().KumactlList("gateways", "default")
+		Expect(err).To(Succeed())
+		Expect(gateways).To(ContainElement("edge-gateway"))
+
+		Eventually(func(g Gomega) {
+			p := path.Join("test", url.PathEscape(GinkgoT().Name()))
+			target := fmt.Sprintf("http://%s:8080/%s",
+				cluster.GetApp("gateway-proxy").GetIP(), p)
+
+			response, err := testutil.CollectResponse(
+				cluster, "gateway-client", target,
+				testutil.WithHeader("Host", "example.kuma.io"),
+			)
+
+			g.Expect(err).To(Succeed())
+			g.Expect(response.Instance).To(Equal("universal"))
+			g.Expect(response.Received.Headers["Host"]).To(ContainElement("example.kuma.io"))
+		}, "30s", "1s").Should(Succeed())
+	})
+}

--- a/test/framework/interface.go
+++ b/test/framework/interface.go
@@ -57,9 +57,28 @@ type deployOptions struct {
 	dpVersion       string
 	kumactlFlow     bool
 	concurrency     int
+	omitDataplane   bool
+	verbose         *bool
 }
 
 type DeployOptionsFunc func(*deployOptions)
+
+// WithoutDataplane suppresses the automatic configuration of kuma-dp
+// in the application container. This is useful when the test requires a
+// container that is not bound to the mesh.
+func WithoutDataplane() DeployOptionsFunc {
+	return func(o *deployOptions) {
+		o.omitDataplane = true
+	}
+}
+
+// WithVerbose enables verbose mode on the deployment.
+func WithVerbose() DeployOptionsFunc {
+	return func(o *deployOptions) {
+		enabled := true
+		o.verbose = &enabled
+	}
+}
 
 func WithPostgres(envVars map[string]string) DeployOptionsFunc {
 	return func(o *deployOptions) {
@@ -340,6 +359,6 @@ type ControlPlane interface {
 	GetMetrics() (string, error)
 	GetKDSServerAddress() string
 	GetGlobaStatusAPI() string
-	GenerateDpToken(mesh, appname string) (string, error)
+	GenerateDpToken(mesh, serviceName string) (string, error)
 	GenerateZoneIngressToken(zone string) (string, error)
 }

--- a/test/framework/setup.go
+++ b/test/framework/setup.go
@@ -451,7 +451,7 @@ networking:
 			WithName(name),
 			WithMesh(mesh),
 			WithAppname("test-server"),
-			WithTransparentProxy(true), // test server is always ment to use with transparent proxy
+			WithTransparentProxy(true), // test server is always meant to be used with transparent proxy
 			WithToken(token),
 			WithArgs(args),
 			WithYaml(appYaml),

--- a/test/framework/testing.go
+++ b/test/framework/testing.go
@@ -1,6 +1,7 @@
 package framework
 
 import (
+	"github.com/gruntwork-io/terratest/modules/logger"
 	"github.com/onsi/ginkgo"
 )
 
@@ -19,4 +20,9 @@ func (i *TestingT) Helper() {
 
 func (i *TestingT) Name() string {
 	return i.desc.FullTestText
+}
+
+// Logf logs a test progress message.
+func Logf(format string, args ...interface{}) {
+	logger.Default.Logf(ginkgo.GinkgoT(), format, args...)
 }


### PR DESCRIPTION
Add cluster and load assignment support to the GatewayRoute generator.
This makes simple end-to-end Gateway configurations work.

Signed-off-by: James Peach <james.peach@konghq.com>

### Summary

SUMMARY_GOES_HERE

### Full changelog

* [Implement ...]
* [Fix ...]

### Issues resolved

Fix #XXX

### Documentation

- [ ] Link to the website [documentation PR](https://github.com/kumahq/kuma-website/pull/XXX)

### Testing

- [ ] Unit tests
- [ ] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes 

### Backwards compatibility

- [ ] Add `backport-to-stable` label if the code is backwards compatible. Otherwise, list breaking changes.
