### PR TITLE
fix(kuma-cp) Limit number of postgres connection by default

### DIFF
--- a/pkg/api-server/config_ws_test.go
+++ b/pkg/api-server/config_ws_test.go
@@ -288,6 +288,8 @@ var _ = Describe("Config WS", func() {
               "port": 15432,
               "maxReconnectInterval": "1m0s",
               "minReconnectInterval": "10s",
+	      "maxIdleConnections": 50,
+	      "maxOpenConnections": 50,
               "tls": {
                 "certPath": "",
                 "keyPath": "",

--- a/pkg/api-server/config_ws_test.go
+++ b/pkg/api-server/config_ws_test.go
@@ -288,8 +288,8 @@ var _ = Describe("Config WS", func() {
               "port": 15432,
               "maxReconnectInterval": "1m0s",
               "minReconnectInterval": "10s",
-	      "maxIdleConnections": 50,
-	      "maxOpenConnections": 50,
+              "maxIdleConnections": 50,
+              "maxOpenConnections": 50,
               "tls": {
                 "certPath": "",
                 "keyPath": "",

--- a/pkg/config/app/kuma-cp/kuma-cp.defaults.yaml
+++ b/pkg/config/app/kuma-cp/kuma-cp.defaults.yaml
@@ -28,10 +28,10 @@ store:
     connectionTimeout: 5 # ENV: KUMA_STORE_POSTGRES_CONNECTION_TIMEOUT
     # Maximum number of open connections to the database
     # `0` value means number of open connections is unlimited
-    maxOpenConnections: 0 # ENV: KUMA_STORE_POSTGRES_MAX_OPEN_CONNECTIONS
+    maxOpenConnections: 50 # ENV: KUMA_STORE_POSTGRES_MAX_OPEN_CONNECTIONS
     # Maximum number of connections in the idle connection pool
     # <0 value means no idle connections and 0 means default max idle connections
-    maxIdleConnections: 0  # ENV: KUMA_STORE_POSTGRES_MAX_IDLE_CONNECTIONS
+    maxIdleConnections: 50  # ENV: KUMA_STORE_POSTGRES_MAX_IDLE_CONNECTIONS
     # TLS settings
     tls:
       # Mode of TLS connection. Available values (disable, verifyNone, verifyCa, verifyFull)

--- a/pkg/config/plugins/resources/postgres/config.go
+++ b/pkg/config/plugins/resources/postgres/config.go
@@ -129,7 +129,8 @@ func DefaultPostgresStoreConfig() *PostgresStoreConfig {
 		Password:             "kuma",
 		DbName:               "kuma",
 		ConnectionTimeout:    5,
-		MaxOpenConnections:   0, // number of open connections is unlimited
+		MaxOpenConnections:   50, // 0 for unlimited
+		MaxIdleConnections:   50, // 0 for unlimited
 		TLS:                  DefaultTLSPostgresStoreConfig(),
 		MinReconnectInterval: 10 * time.Second,
 		MaxReconnectInterval: 60 * time.Second,


### PR DESCRIPTION
Signed-off-by: Paul Parkanzky <paul.parkanzky@konghq.com>

### Summary

CP previously did not limit number of postgres connections. In our performance benchmarking, we determined this can cause significant problems when connecting large numbers of dataplanes. This is configurable via env variables, but this PR limits by default.

### Full changelog

* Limit number of postgres connections by default.

### Issues resolved


### Documentation

- [ ] Link to the website [documentation PR](https://github.com/kumahq/kuma-website/pull/XXX)

### Testing

- [x] Unit tests
- [x] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes 

### Backwards compatibility

- [x] Add `backport-to-stable` label if the code is backwards compatible. Otherwise, list breaking changes.
