### PR TITLE
chore(*) enable gofmt simplify mode

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -3,6 +3,7 @@ linters:
     - bodyclose
     - gci
     - gocritic
+    - gofmt
     - gomodguard
     - govet
     - importas
@@ -48,6 +49,8 @@ linters-settings:
     locale: US
     ignore-words:
     - cancelled # US English should be "canceled", but this is in the Retry API, so we can't change it.
+  gofmt:
+    simplify: true
 
 issues:
   fix: true

--- a/pkg/core/managers/apis/external_service/externalservice_manager_test.go
+++ b/pkg/core/managers/apis/external_service/externalservice_manager_test.go
@@ -65,14 +65,14 @@ var _ = Describe("ExternalService Manager", func() {
 			ratelimit := core_mesh.RateLimitResource{
 				Spec: &mesh_proto.RateLimit{
 					Sources: []*mesh_proto.Selector{
-						&mesh_proto.Selector{
+						{
 							Match: map[string]string{
 								"kuma.io/service": "service1",
 							},
 						},
 					},
 					Destinations: []*mesh_proto.Selector{
-						&mesh_proto.Selector{
+						{
 							Match: map[string]string{
 								"kuma.io/service": "service2",
 							},
@@ -122,14 +122,14 @@ var _ = Describe("ExternalService Manager", func() {
 			ratelimit := core_mesh.RateLimitResource{
 				Spec: &mesh_proto.RateLimit{
 					Sources: []*mesh_proto.Selector{
-						&mesh_proto.Selector{
+						{
 							Match: map[string]string{
 								"kuma.io/service": "service1",
 							},
 						},
 					},
 					Destinations: []*mesh_proto.Selector{
-						&mesh_proto.Selector{
+						{
 							Match: map[string]string{
 								"kuma.io/service": "*",
 							},
@@ -179,14 +179,14 @@ var _ = Describe("ExternalService Manager", func() {
 			ratelimit := core_mesh.RateLimitResource{
 				Spec: &mesh_proto.RateLimit{
 					Sources: []*mesh_proto.Selector{
-						&mesh_proto.Selector{
+						{
 							Match: map[string]string{
 								"kuma.io/service": "service1",
 							},
 						},
 					},
 					Destinations: []*mesh_proto.Selector{
-						&mesh_proto.Selector{
+						{
 							Match: map[string]string{
 								"kuma.io/service": "service2",
 								"version":         "v1",
@@ -247,14 +247,14 @@ var _ = Describe("ExternalService Manager", func() {
 			ratelimit := core_mesh.RateLimitResource{
 				Spec: &mesh_proto.RateLimit{
 					Sources: []*mesh_proto.Selector{
-						&mesh_proto.Selector{
+						{
 							Match: map[string]string{
 								"kuma.io/service": "service1",
 							},
 						},
 					},
 					Destinations: []*mesh_proto.Selector{
-						&mesh_proto.Selector{
+						{
 							Match: map[string]string{
 								"kuma.io/service": "service2",
 							},
@@ -307,14 +307,14 @@ var _ = Describe("ExternalService Manager", func() {
 			ratelimit := core_mesh.RateLimitResource{
 				Spec: &mesh_proto.RateLimit{
 					Sources: []*mesh_proto.Selector{
-						&mesh_proto.Selector{
+						{
 							Match: map[string]string{
 								"kuma.io/service": "service1",
 							},
 						},
 					},
 					Destinations: []*mesh_proto.Selector{
-						&mesh_proto.Selector{
+						{
 							Match: map[string]string{
 								"kuma.io/service": "service3",
 								"version":         "v1",

--- a/pkg/core/managers/apis/ratelimit/ratelimit_manager_test.go
+++ b/pkg/core/managers/apis/ratelimit/ratelimit_manager_test.go
@@ -50,14 +50,14 @@ var _ = Describe("RateLimit Manager", func() {
 			ratelimit := core_mesh.RateLimitResource{
 				Spec: &mesh_proto.RateLimit{
 					Sources: []*mesh_proto.Selector{
-						&mesh_proto.Selector{
+						{
 							Match: map[string]string{
 								"kuma.io/service": "service1",
 							},
 						},
 					},
 					Destinations: []*mesh_proto.Selector{
-						&mesh_proto.Selector{
+						{
 							Match: map[string]string{
 								"kuma.io/service": "service2",
 								"version":         "v1",
@@ -90,14 +90,14 @@ var _ = Describe("RateLimit Manager", func() {
 			ratelimit := core_mesh.RateLimitResource{
 				Spec: &mesh_proto.RateLimit{
 					Sources: []*mesh_proto.Selector{
-						&mesh_proto.Selector{
+						{
 							Match: map[string]string{
 								"kuma.io/service": "service1",
 							},
 						},
 					},
 					Destinations: []*mesh_proto.Selector{
-						&mesh_proto.Selector{
+						{
 							Match: map[string]string{
 								"kuma.io/service": "*",
 								"version":         "v1",
@@ -145,14 +145,14 @@ var _ = Describe("RateLimit Manager", func() {
 			ratelimit := core_mesh.RateLimitResource{
 				Spec: &mesh_proto.RateLimit{
 					Sources: []*mesh_proto.Selector{
-						&mesh_proto.Selector{
+						{
 							Match: map[string]string{
 								"kuma.io/service": "service1",
 							},
 						},
 					},
 					Destinations: []*mesh_proto.Selector{
-						&mesh_proto.Selector{
+						{
 							Match: map[string]string{
 								"kuma.io/service": "service2",
 							},
@@ -202,14 +202,14 @@ var _ = Describe("RateLimit Manager", func() {
 			ratelimit := core_mesh.RateLimitResource{
 				Spec: &mesh_proto.RateLimit{
 					Sources: []*mesh_proto.Selector{
-						&mesh_proto.Selector{
+						{
 							Match: map[string]string{
 								"kuma.io/service": "service1",
 							},
 						},
 					},
 					Destinations: []*mesh_proto.Selector{
-						&mesh_proto.Selector{
+						{
 							Match: map[string]string{
 								"kuma.io/service": "*",
 							},
@@ -259,14 +259,14 @@ var _ = Describe("RateLimit Manager", func() {
 			ratelimit := core_mesh.RateLimitResource{
 				Spec: &mesh_proto.RateLimit{
 					Sources: []*mesh_proto.Selector{
-						&mesh_proto.Selector{
+						{
 							Match: map[string]string{
 								"kuma.io/service": "service1",
 							},
 						},
 					},
 					Destinations: []*mesh_proto.Selector{
-						&mesh_proto.Selector{
+						{
 							Match: map[string]string{
 								"kuma.io/service": "service2",
 								"version":         "v1",
@@ -312,14 +312,14 @@ var _ = Describe("RateLimit Manager", func() {
 			ratelimit := core_mesh.RateLimitResource{
 				Spec: &mesh_proto.RateLimit{
 					Sources: []*mesh_proto.Selector{
-						&mesh_proto.Selector{
+						{
 							Match: map[string]string{
 								"kuma.io/service": "service1",
 							},
 						},
 					},
 					Destinations: []*mesh_proto.Selector{
-						&mesh_proto.Selector{
+						{
 							Match: map[string]string{
 								"kuma.io/service": "service2",
 								"version":         "v1",
@@ -370,14 +370,14 @@ var _ = Describe("RateLimit Manager", func() {
 			ratelimit := core_mesh.RateLimitResource{
 				Spec: &mesh_proto.RateLimit{
 					Sources: []*mesh_proto.Selector{
-						&mesh_proto.Selector{
+						{
 							Match: map[string]string{
 								"kuma.io/service": "service1",
 							},
 						},
 					},
 					Destinations: []*mesh_proto.Selector{
-						&mesh_proto.Selector{
+						{
 							Match: map[string]string{
 								"kuma.io/service": "service2",
 							},
@@ -430,14 +430,14 @@ var _ = Describe("RateLimit Manager", func() {
 			ratelimit := core_mesh.RateLimitResource{
 				Spec: &mesh_proto.RateLimit{
 					Sources: []*mesh_proto.Selector{
-						&mesh_proto.Selector{
+						{
 							Match: map[string]string{
 								"kuma.io/service": "service1",
 							},
 						},
 					},
 					Destinations: []*mesh_proto.Selector{
-						&mesh_proto.Selector{
+						{
 							Match: map[string]string{
 								"kuma.io/service": "service2",
 							},
@@ -498,14 +498,14 @@ var _ = Describe("RateLimit Manager", func() {
 			ratelimit := core_mesh.RateLimitResource{
 				Spec: &mesh_proto.RateLimit{
 					Sources: []*mesh_proto.Selector{
-						&mesh_proto.Selector{
+						{
 							Match: map[string]string{
 								"kuma.io/service": "service1",
 							},
 						},
 					},
 					Destinations: []*mesh_proto.Selector{
-						&mesh_proto.Selector{
+						{
 							Match: map[string]string{
 								"kuma.io/service": "*",
 							},

--- a/pkg/core/permissions/matcher_test.go
+++ b/pkg/core/permissions/matcher_test.go
@@ -174,8 +174,8 @@ var _ = Describe("Match", func() {
 				},
 			},
 			expected: map[mesh_proto.InboundInterface]string{
-				mesh_proto.InboundInterface{DataplaneAdvertisedIP: "192.168.0.1", DataplaneIP: "192.168.0.1", WorkloadIP: "127.0.0.1", WorkloadPort: 8081, DataplanePort: 8080}: "more-specific-kong-to-web",
-				mesh_proto.InboundInterface{DataplaneAdvertisedIP: "192.168.0.1", DataplaneIP: "192.168.0.1", WorkloadIP: "127.0.0.1", WorkloadPort: 1234, DataplanePort: 1234}: "metrics",
+				{DataplaneAdvertisedIP: "192.168.0.1", DataplaneIP: "192.168.0.1", WorkloadIP: "127.0.0.1", WorkloadPort: 8081, DataplanePort: 8080}: "more-specific-kong-to-web",
+				{DataplaneAdvertisedIP: "192.168.0.1", DataplaneIP: "192.168.0.1", WorkloadIP: "127.0.0.1", WorkloadPort: 1234, DataplanePort: 1234}: "metrics",
 			},
 		}),
 	)

--- a/pkg/core/xds/metadata_test.go
+++ b/pkg/core/xds/metadata_test.go
@@ -33,17 +33,17 @@ var _ = Describe("DataplaneMetadataFromXdsMetadata", func() {
 		Entry("from non-empty node", testCase{
 			node: &structpb.Struct{
 				Fields: map[string]*structpb.Value{
-					"dataplane.admin.port": &structpb.Value{
+					"dataplane.admin.port": {
 						Kind: &structpb.Value_StringValue{
 							StringValue: "1234",
 						},
 					},
-					"dataplane.dns.port": &structpb.Value{
+					"dataplane.dns.port": {
 						Kind: &structpb.Value_StringValue{
 							StringValue: "8000",
 						},
 					},
-					"dataplane.dns.empty.port": &structpb.Value{
+					"dataplane.dns.empty.port": {
 						Kind: &structpb.Value_StringValue{
 							StringValue: "8001",
 						},
@@ -75,7 +75,7 @@ var _ = Describe("DataplaneMetadataFromXdsMetadata", func() {
 
 		node := &structpb.Struct{
 			Fields: map[string]*structpb.Value{
-				"version": &structpb.Value{
+				"version": {
 					Kind: &structpb.Value_StructValue{
 						StructValue: util_proto.MustToStruct(version),
 					},

--- a/pkg/plugins/runtime/gateway/merge/traffic_route_test.go
+++ b/pkg/plugins/runtime/gateway/merge/traffic_route_test.go
@@ -59,7 +59,7 @@ var _ = Describe("TrafficRoute", func() {
 				Spec: &mesh_proto.TrafficRoute{
 					Conf: &mesh_proto.TrafficRoute_Conf{
 						Split: []*mesh_proto.TrafficRoute_Split{
-							&mesh_proto.TrafficRoute_Split{
+							{
 								Weight: util_proto.UInt32(1),
 								Destination: map[string]string{
 									mesh_proto.ServiceTag: "bar-service",

--- a/pkg/plugins/runtime/gateway/suite_test.go
+++ b/pkg/plugins/runtime/gateway/suite_test.go
@@ -304,7 +304,7 @@ func (d *DataplaneGenerator) generate(
 	dp.Spec.Networking = &mesh_proto.Dataplane_Networking{
 		Address: addr.String(),
 		Inbound: []*mesh_proto.Dataplane_Networking_Inbound{
-			&mesh_proto.Dataplane_Networking_Inbound{
+			{
 				Port:        20011,
 				ServicePort: 10011,
 				Tags: map[string]string{

--- a/pkg/util/xds/v3/callbacks_chain_test.go
+++ b/pkg/util/xds/v3/callbacks_chain_test.go
@@ -73,7 +73,7 @@ var _ = Describe("CallbacksChain", func() {
 
 			// then
 			Expect(calls).To(Equal([]methodCall{
-				methodCall{"1st", "OnStreamOpen()", []interface{}{ctx, streamID, typ}},
+				{"1st", "OnStreamOpen()", []interface{}{ctx, streamID, typ}},
 			}))
 			// and
 			Expect(err).To(MatchError("1st: OnStreamOpen()"))

--- a/pkg/xds/envoy/listeners/v3/http_outbound_route_configurer_test.go
+++ b/pkg/xds/envoy/listeners/v3/http_outbound_route_configurer_test.go
@@ -131,17 +131,17 @@ var _ = Describe("HttpOutboundRouteConfigurer", func() {
 							},
 						},
 						Headers: map[string]*mesh_proto.TrafficRoute_Http_Match_StringMatcher{
-							"x-custom-header-a": &mesh_proto.TrafficRoute_Http_Match_StringMatcher{
+							"x-custom-header-a": {
 								MatcherType: &mesh_proto.TrafficRoute_Http_Match_StringMatcher_Prefix{
 									Prefix: "prefix",
 								},
 							},
-							"x-custom-header-b": &mesh_proto.TrafficRoute_Http_Match_StringMatcher{
+							"x-custom-header-b": {
 								MatcherType: &mesh_proto.TrafficRoute_Http_Match_StringMatcher_Exact{
 									Exact: "exact",
 								},
 							},
-							"x-custom-header-c": &mesh_proto.TrafficRoute_Http_Match_StringMatcher{
+							"x-custom-header-c": {
 								MatcherType: &mesh_proto.TrafficRoute_Http_Match_StringMatcher_Regex{
 									Regex: "^regex$",
 								},

--- a/pkg/xds/server/callbacks/dataplane_callbacks_test.go
+++ b/pkg/xds/server/callbacks/dataplane_callbacks_test.go
@@ -47,7 +47,7 @@ var _ = Describe("Dataplane Callbacks", func() {
 			Id: "default.example",
 			Metadata: &structpb.Struct{
 				Fields: map[string]*structpb.Value{
-					"dataplane.token": &structpb.Value{
+					"dataplane.token": {
 						Kind: &structpb.Value_StringValue{
 							StringValue: "token",
 						},

--- a/pkg/xds/server/callbacks/dataplane_metadata_tracker_test.go
+++ b/pkg/xds/server/callbacks/dataplane_metadata_tracker_test.go
@@ -26,7 +26,7 @@ var _ = Describe("Dataplane Metadata Tracker", func() {
 			Id: "default.example",
 			Metadata: &structpb.Struct{
 				Fields: map[string]*structpb.Value{
-					"dataplane.token": &structpb.Value{
+					"dataplane.token": {
 						Kind: &structpb.Value_StringValue{
 							StringValue: "token",
 						},

--- a/tools/docs/generate.go
+++ b/tools/docs/generate.go
@@ -66,7 +66,7 @@ func main() {
 	format := GetenvOr("FORMAT", "markdown")
 
 	apps := map[string]command{
-		path.Join(prefix, "kuma-cp"): command{
+		path.Join(prefix, "kuma-cp"): {
 			command: kuma_cp.DefaultRootCmd(),
 			header: &doc.GenManHeader{
 				Title:   "KUMA-CP",
@@ -75,7 +75,7 @@ func main() {
 				Manual:  version.Product,
 			},
 		},
-		path.Join(prefix, "kuma-dp"): command{
+		path.Join(prefix, "kuma-dp"): {
 			command: kuma_dp.DefaultRootCmd(),
 			header: &doc.GenManHeader{
 				Title:   "KUMA-DP",
@@ -84,7 +84,7 @@ func main() {
 				Manual:  version.Product,
 			},
 		},
-		path.Join(prefix, "kuma-prometheus-sd"): command{
+		path.Join(prefix, "kuma-prometheus-sd"): {
 			command: kuma_prometheus_sd.DefaultRootCmd(),
 			header: &doc.GenManHeader{
 				Title:   "KUMA-PROMETHEUS-SD",
@@ -93,7 +93,7 @@ func main() {
 				Manual:  version.Product,
 			},
 		},
-		path.Join(prefix, "kumactl"): command{
+		path.Join(prefix, "kumactl"): {
 			command: kumactl.DefaultRootCmd(),
 			header: &doc.GenManHeader{
 				Title:   "KUMACTL",


### PR DESCRIPTION
### Summary

Enable gofmt in simplify mode in the linter config and let it update
all the sources.

### Full changelog

N/A

### Issues resolved

N/A

### Documentation

N/A

### Testing

- [x] Unit tests
- [x] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes 

### Backwards compatibility

- [ x Add `backport-to-stable` label if the code is backwards compatible. Otherwise, list breaking changes.
