### PR TITLE
chore(kumactl) migrate install resources from rbac API v1beta1 to v1

### DIFF
--- a/app/kumactl/cmd/install/testdata/install-gateway-enterprise.defaults.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-gateway-enterprise.defaults.golden.yaml
@@ -486,7 +486,7 @@ status:
   conditions: []
   storedVersions: []
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: kong-ingress-clusterrole
@@ -568,7 +568,7 @@ rules:
   - get
   - update
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: kong-ingress-clusterrole-nisa-binding

--- a/app/kumactl/cmd/install/testdata/install-gateway-enterprise.overrides.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-gateway-enterprise.overrides.golden.yaml
@@ -486,7 +486,7 @@ status:
   conditions: []
   storedVersions: []
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: kong-ingress-clusterrole
@@ -568,7 +568,7 @@ rules:
   - get
   - update
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: kong-ingress-clusterrole-nisa-binding

--- a/app/kumactl/cmd/install/testdata/install-gateway.defaults.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-gateway.defaults.golden.yaml
@@ -476,7 +476,7 @@ status:
   conditions: []
   storedVersions: []
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: kong-ingress-clusterrole
@@ -558,7 +558,7 @@ rules:
   - get
   - update
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: kong-ingress-clusterrole-nisa-binding

--- a/app/kumactl/cmd/install/testdata/install-gateway.overrides.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-gateway.overrides.golden.yaml
@@ -476,7 +476,7 @@ status:
   conditions: []
   storedVersions: []
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: kong-ingress-clusterrole
@@ -558,7 +558,7 @@ rules:
   - get
   - update
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: kong-ingress-clusterrole-nisa-binding

--- a/app/kumactl/cmd/install/testdata/install-metrics.defaults.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-metrics.defaults.golden.yaml
@@ -11486,7 +11486,7 @@ metadata:
   name: grafana-clusterrole
 rules: []
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
@@ -11496,7 +11496,7 @@ metadata:
 rules:
   []
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
@@ -11597,7 +11597,7 @@ rules:
       - list
       - watch
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
@@ -11607,7 +11607,7 @@ metadata:
 rules:
   []
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
@@ -11659,7 +11659,7 @@ roleRef:
   name: grafana-clusterrole
   apiGroup: rbac.authorization.k8s.io
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
@@ -11675,7 +11675,7 @@ roleRef:
   kind: ClusterRole
   name: prometheus-alertmanager
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
@@ -11691,7 +11691,7 @@ roleRef:
   kind: ClusterRole
   name: prometheus-kube-state-metrics
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
@@ -11707,7 +11707,7 @@ roleRef:
   kind: ClusterRole
   name: prometheus-pushgateway
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
@@ -11723,7 +11723,7 @@ roleRef:
   kind: ClusterRole
   name: prometheus-server
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: grafana
@@ -11736,7 +11736,7 @@ rules:
     verbs:          ['use']
     resourceNames:  [grafana]
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: grafana

--- a/app/kumactl/cmd/install/testdata/install-metrics.no-grafana.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-metrics.no-grafana.golden.yaml
@@ -415,7 +415,7 @@ spec:
     requests:
       storage: "8Gi"
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
@@ -425,7 +425,7 @@ metadata:
 rules:
   []
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
@@ -462,7 +462,7 @@ rules:
     verbs:
       - get
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
@@ -472,7 +472,7 @@ metadata:
 rules:
   []
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
@@ -573,7 +573,7 @@ rules:
       - list
       - watch
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
@@ -589,7 +589,7 @@ roleRef:
   kind: ClusterRole
   name: prometheus-kube-state-metrics
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
@@ -605,7 +605,7 @@ roleRef:
   kind: ClusterRole
   name: prometheus-pushgateway
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
@@ -621,7 +621,7 @@ roleRef:
   kind: ClusterRole
   name: prometheus-server
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:

--- a/app/kumactl/cmd/install/testdata/install-metrics.no-prometheus.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-metrics.no-prometheus.golden.yaml
@@ -11094,7 +11094,7 @@ roleRef:
   name: grafana-clusterrole
   apiGroup: rbac.authorization.k8s.io
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: grafana
@@ -11107,7 +11107,7 @@ rules:
     verbs:          ['use']
     resourceNames:  [grafana]
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: grafana

--- a/app/kumactl/cmd/install/testdata/install-metrics.overrides.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-metrics.overrides.golden.yaml
@@ -11486,7 +11486,7 @@ metadata:
   name: grafana-clusterrole
 rules: []
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
@@ -11496,7 +11496,7 @@ metadata:
 rules:
   []
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
@@ -11597,7 +11597,7 @@ rules:
       - list
       - watch
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
@@ -11607,7 +11607,7 @@ metadata:
 rules:
   []
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
@@ -11659,7 +11659,7 @@ roleRef:
   name: grafana-clusterrole
   apiGroup: rbac.authorization.k8s.io
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
@@ -11675,7 +11675,7 @@ roleRef:
   kind: ClusterRole
   name: prometheus-alertmanager
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
@@ -11691,7 +11691,7 @@ roleRef:
   kind: ClusterRole
   name: prometheus-kube-state-metrics
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
@@ -11707,7 +11707,7 @@ roleRef:
   kind: ClusterRole
   name: prometheus-pushgateway
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
@@ -11723,7 +11723,7 @@ roleRef:
   kind: ClusterRole
   name: prometheus-server
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: grafana
@@ -11736,7 +11736,7 @@ rules:
     verbs:          ['use']
     resourceNames:  [grafana]
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: grafana

--- a/app/kumactl/data/install/k8s/gateway-kong-enterprise/kong-enterprise/kong-enterprise.yaml
+++ b/app/kumactl/data/install/k8s/gateway-kong-enterprise/kong-enterprise/kong-enterprise.yaml
@@ -484,7 +484,7 @@ metadata:
   name: kong-serviceaccount
   namespace: {{ .Namespace }}
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: kong-ingress-clusterrole
@@ -566,7 +566,7 @@ rules:
   - get
   - update
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: kong-ingress-clusterrole-nisa-binding

--- a/app/kumactl/data/install/k8s/gateway-kong/kong/kong.yaml
+++ b/app/kumactl/data/install/k8s/gateway-kong/kong/kong.yaml
@@ -474,7 +474,7 @@ metadata:
   name: kong-serviceaccount
   namespace: {{ .Namespace }}
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: kong-ingress-clusterrole
@@ -556,7 +556,7 @@ rules:
   - get
   - update
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: kong-ingress-clusterrole-nisa-binding

--- a/app/kumactl/data/install/k8s/metrics/grafana/grafana.yaml
+++ b/app/kumactl/data/install/k8s/metrics/grafana/grafana.yaml
@@ -228,7 +228,7 @@ roleRef:
   name: grafana-clusterrole
   apiGroup: rbac.authorization.k8s.io
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: grafana
@@ -241,7 +241,7 @@ rules:
     verbs:          ['use']
     resourceNames:  [grafana]
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: grafana

--- a/app/kumactl/data/install/k8s/metrics/prometheus/alertmanager.yaml
+++ b/app/kumactl/data/install/k8s/metrics/prometheus/alertmanager.yaml
@@ -42,7 +42,7 @@ metadata:
   name: prometheus-alertmanager
   namespace: {{ .Namespace }}
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
@@ -52,7 +52,7 @@ metadata:
 rules:
   []
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:

--- a/app/kumactl/data/install/k8s/metrics/prometheus/kube-stats-metrics.yaml
+++ b/app/kumactl/data/install/k8s/metrics/prometheus/kube-stats-metrics.yaml
@@ -8,7 +8,7 @@ metadata:
   name: prometheus-kube-state-metrics
   namespace: {{ .Namespace }}
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
@@ -109,7 +109,7 @@ rules:
       - list
       - watch
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:

--- a/app/kumactl/data/install/k8s/metrics/prometheus/pushgateway.yaml
+++ b/app/kumactl/data/install/k8s/metrics/prometheus/pushgateway.yaml
@@ -8,7 +8,7 @@ metadata:
   name: prometheus-pushgateway
   namespace: {{ .Namespace }}
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
@@ -18,7 +18,7 @@ metadata:
 rules:
   []
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:

--- a/app/kumactl/data/install/k8s/metrics/prometheus/server.yaml
+++ b/app/kumactl/data/install/k8s/metrics/prometheus/server.yaml
@@ -336,7 +336,7 @@ metadata:
   name: prometheus-server
   namespace: {{ .Namespace }}
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
@@ -373,7 +373,7 @@ rules:
     verbs:
       - get
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:


### PR DESCRIPTION
### Summary

This version was removed in k8s v1.22 which makes using the `install` command difficult, v1 has been available since k8s 1.8.

### Testing

- [ ] Unit tests
- [ ] E2E tests
- [ ] Manual testing on Universal
- [x] Manual testing on Kubernetes 

### Backwards compatibility

- [x] Add `backport-to-stable` label if the code is backwards compatible. Otherwise, list breaking changes.
