### PR TITLE
feat(metrics) add zone selector to Kuma Service to Service dashboard

### DIFF
--- a/app/kumactl/cmd/install/testdata/install-metrics.defaults.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-metrics.defaults.golden.yaml
@@ -4746,12 +4746,12 @@ data:
               "steppedLine": false,
               "targets": [
                 {
-                  "expr": "sum(irate(envoy_cluster_upstream_cx_tx_bytes_total{kuma_io_service=\"$source_service\",envoy_cluster_name=\"$destination_cluster\",mesh=\"$mesh\"}[1m]))",
+                  "expr": "sum(irate(envoy_cluster_upstream_cx_tx_bytes_total{kuma_io_service=\"$source_service\",envoy_cluster_name=\"$destination_cluster\",kuma_io_zone=~\"$zone\",mesh=\"$mesh\"}[1m]))",
                   "legendFormat": "Bytes sent",
                   "refId": "A"
                 },
                 {
-                  "expr": "sum(irate(envoy_cluster_upstream_cx_rx_bytes_total{kuma_io_service=\"$source_service\",envoy_cluster_name=\"$destination_cluster\",mesh=\"$mesh\"}[1m]))",
+                  "expr": "sum(irate(envoy_cluster_upstream_cx_rx_bytes_total{kuma_io_service=\"$source_service\",envoy_cluster_name=\"$destination_cluster\",kuma_io_zone=~\"$zone\",mesh=\"$mesh\"}[1m]))",
                   "legendFormat": "Bytes received",
                   "refId": "B"
                 }
@@ -4850,44 +4850,44 @@ data:
               "steppedLine": false,
               "targets": [
                 {
-                  "expr": "sum(irate(envoy_cluster_upstream_cx_destroy_remote_with_active_rq{kuma_io_service=\"$source_service\",envoy_cluster_name=\"$destination_cluster\",mesh=\"$mesh\"}[1m]))",
+                  "expr": "sum(irate(envoy_cluster_upstream_cx_destroy_remote_with_active_rq{kuma_io_service=\"$source_service\",envoy_cluster_name=\"$destination_cluster\",kuma_io_zone=~\"$zone\",mesh=\"$mesh\"}[1m]))",
                   "hide": true,
                   "legendFormat": "Connection destroyed by the client",
                   "refId": "A"
                 },
                 {
-                  "expr": "sum(irate(envoy_cluster_upstream_cx_connect_timeout{kuma_io_service=\"$source_service\",envoy_cluster_name=\"$destination_cluster\",mesh=\"$mesh\"}[1m]))",
+                  "expr": "sum(irate(envoy_cluster_upstream_cx_connect_timeout{kuma_io_service=\"$source_service\",envoy_cluster_name=\"$destination_cluster\",kuma_io_zone=~\"$zone\",mesh=\"$mesh\"}[1m]))",
                   "legendFormat": "Connection timeout",
                   "refId": "B"
                 },
                 {
-                  "expr": "sum(irate(envoy_cluster_upstream_cx_destroy_local_with_active_rq{kuma_io_service=\"$source_service\",envoy_cluster_name=\"$destination_cluster\",mesh=\"$mesh\"}[1m]))",
+                  "expr": "sum(irate(envoy_cluster_upstream_cx_destroy_local_with_active_rq{kuma_io_service=\"$source_service\",envoy_cluster_name=\"$destination_cluster\",kuma_io_zone=~\"$zone\",mesh=\"$mesh\"}[1m]))",
                   "hide": true,
                   "legendFormat": "Connection destroyed by local Envoy",
                   "refId": "C"
                 },
                 {
-                  "expr": "sum(irate(envoy_cluster_upstream_rq_pending_failure_eject{kuma_io_service=\"$source_service\",envoy_cluster_name=\"$destination_cluster\",mesh=\"$mesh\"}[1m]))",
+                  "expr": "sum(irate(envoy_cluster_upstream_rq_pending_failure_eject{kuma_io_service=\"$source_service\",envoy_cluster_name=\"$destination_cluster\",kuma_io_zone=~\"$zone\",mesh=\"$mesh\"}[1m]))",
                   "legendFormat": "Pending failure ejection",
                   "refId": "D"
                 },
                 {
-                  "expr": "sum(irate(envoy_cluster_upstream_rq_pending_overflow{kuma_io_service=\"$source_service\",envoy_cluster_name=\"$destination_cluster\",mesh=\"$mesh\"}[1m]))",
+                  "expr": "sum(irate(envoy_cluster_upstream_rq_pending_overflow{kuma_io_service=\"$source_service\",envoy_cluster_name=\"$destination_cluster\",kuma_io_zone=~\"$zone\",mesh=\"$mesh\"}[1m]))",
                   "legendFormat": "Pending overflow",
                   "refId": "E"
                 },
                 {
-                  "expr": "sum(irate(envoy_cluster_upstream_rq_timeout{kuma_io_service=\"$source_service\",envoy_cluster_name=\"$destination_cluster\",mesh=\"$mesh\"}[1m]))",
+                  "expr": "sum(irate(envoy_cluster_upstream_rq_timeout{kuma_io_service=\"$source_service\",envoy_cluster_name=\"$destination_cluster\",kuma_io_zone=~\"$zone\",mesh=\"$mesh\"}[1m]))",
                   "legendFormat": "Request timeout",
                   "refId": "F"
                 },
                 {
-                  "expr": "sum(irate(envoy_cluster_upstream_rq_rx_reset{kuma_io_service=\"$source_service\",envoy_cluster_name=\"$destination_cluster\",mesh=\"$mesh\"}[1m]))",
+                  "expr": "sum(irate(envoy_cluster_upstream_rq_rx_reset{kuma_io_service=\"$source_service\",envoy_cluster_name=\"$destination_cluster\",kuma_io_zone=~\"$zone\",mesh=\"$mesh\"}[1m]))",
                   "legendFormat": "Response reset",
                   "refId": "G"
                 },
                 {
-                  "expr": "sum(irate(envoy_cluster_upstream_rq_tx_reset{kuma_io_service=\"$source_service\",envoy_cluster_name=\"$destination_cluster\",mesh=\"$mesh\"}[1m]))",
+                  "expr": "sum(irate(envoy_cluster_upstream_rq_tx_reset{kuma_io_service=\"$source_service\",envoy_cluster_name=\"$destination_cluster\",kuma_io_zone=~\"$zone\",mesh=\"$mesh\"}[1m]))",
                   "legendFormat": "Request reset",
                   "refId": "H"
                 }
@@ -4983,7 +4983,7 @@ data:
               "steppedLine": false,
               "targets": [
                 {
-                  "expr": "sum(envoy_cluster_upstream_cx_active{kuma_io_service=\"$source_service\",envoy_cluster_name=\"$destination_cluster\",mesh=\"$mesh\"})",
+                  "expr": "sum(envoy_cluster_upstream_cx_active{kuma_io_service=\"$source_service\",envoy_cluster_name=\"$destination_cluster\",kuma_io_zone=~\"$zone\",mesh=\"$mesh\"})",
                   "legendFormat": "Connections",
                   "refId": "A"
                 }
@@ -5079,7 +5079,7 @@ data:
               "steppedLine": false,
               "targets": [
                 {
-                  "expr": "max(histogram_quantile(0.99, irate(envoy_cluster_upstream_cx_connect_ms_bucket{kuma_io_service=\"$source_service\",envoy_cluster_name=\"$destination_cluster\",mesh=\"$mesh\"}[1m])))",
+                  "expr": "max(histogram_quantile(0.99, irate(envoy_cluster_upstream_cx_connect_ms_bucket{kuma_io_service=\"$source_service\",envoy_cluster_name=\"$destination_cluster\",kuma_io_zone=~\"$zone\",mesh=\"$mesh\"}[1m])))",
                   "legendFormat": "Time",
                   "refId": "A"
                 }
@@ -5176,7 +5176,7 @@ data:
               "steppedLine": false,
               "targets": [
                 {
-                  "expr": "max(histogram_quantile(0.99, irate(envoy_cluster_upstream_cx_length_ms_bucket{kuma_io_service=\"$source_service\",envoy_cluster_name=\"$destination_cluster\",mesh=\"$mesh\"}[1m])))",
+                  "expr": "max(histogram_quantile(0.99, irate(envoy_cluster_upstream_cx_length_ms_bucket{kuma_io_service=\"$source_service\",envoy_cluster_name=\"$destination_cluster\",kuma_io_zone=~\"$zone\",mesh=\"$mesh\"}[1m])))",
                   "legendFormat": "Time",
                   "refId": "A"
                 }
@@ -5293,21 +5293,21 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "max(histogram_quantile(0.99, rate(envoy_cluster_upstream_rq_time_bucket{kuma_io_service=\"$source_service\",mesh=\"$mesh\",envoy_cluster_name=\"$destination_cluster\"}[1m])))",
+              "expr": "max(histogram_quantile(0.99, rate(envoy_cluster_upstream_rq_time_bucket{kuma_io_service=\"$source_service\",kuma_io_zone=~\"$zone\",mesh=\"$mesh\",envoy_cluster_name=\"$destination_cluster\"}[1m])))",
               "hide": false,
               "interval": "",
               "legendFormat": "p99",
               "refId": "A"
             },
             {
-              "expr": "max(histogram_quantile(0.95, rate(envoy_cluster_upstream_rq_time_bucket{kuma_io_service=\"$source_service\",mesh=\"$mesh\",envoy_cluster_name=\"$destination_cluster\"}[1m])))",
+              "expr": "max(histogram_quantile(0.95, rate(envoy_cluster_upstream_rq_time_bucket{kuma_io_service=\"$source_service\",kuma_io_zone=~\"$zone\",mesh=\"$mesh\",envoy_cluster_name=\"$destination_cluster\"}[1m])))",
               "hide": false,
               "interval": "",
               "legendFormat": "p95",
               "refId": "C"
             },
             {
-              "expr": "max(histogram_quantile(0.50, rate(envoy_cluster_upstream_rq_time_bucket{kuma_io_service=\"$source_service\",mesh=\"$mesh\",envoy_cluster_name=\"$destination_cluster\"}[1m])))",
+              "expr": "max(histogram_quantile(0.50, rate(envoy_cluster_upstream_rq_time_bucket{kuma_io_service=\"$source_service\",kuma_io_zone=~\"$zone\",mesh=\"$mesh\",envoy_cluster_name=\"$destination_cluster\"}[1m])))",
               "hide": false,
               "interval": "",
               "legendFormat": "p50",
@@ -5616,7 +5616,7 @@ data:
               "steppedLine": false,
               "targets": [
                 {
-                  "expr": "sum(envoy_cluster_health_check_healthy{kuma_io_service=\"$source_service\",envoy_cluster_name=\"$destination_cluster\",mesh=\"$mesh\"}) / sum(envoy_cluster_membership_total{kuma_io_service=\"$source_service\",envoy_cluster_name=\"$destination_cluster\",mesh=\"$mesh\"})",
+                  "expr": "sum(envoy_cluster_health_check_healthy{kuma_io_service=\"$source_service\",envoy_cluster_name=\"$destination_cluster\",kuma_io_zone=~\"$zone\",mesh=\"$mesh\"}) / sum(envoy_cluster_membership_total{kuma_io_service=\"$source_service\",envoy_cluster_name=\"$destination_cluster\",kuma_io_zone=~\"$zone\",mesh=\"$mesh\"})",
                   "legendFormat": "Healthy destinations",
                   "refId": "A"
                 }
@@ -5731,20 +5731,20 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(irate(envoy_cluster_upstream_cx_overflow{kuma_io_service=\"$source_service\",envoy_cluster_name=\"$destination_cluster\",mesh=\"$mesh\"}[1m]))",
+              "expr": "sum(irate(envoy_cluster_upstream_cx_overflow{kuma_io_service=\"$source_service\",envoy_cluster_name=\"$destination_cluster\",kuma_io_zone=~\"$zone\",mesh=\"$mesh\"}[1m]))",
               "interval": "",
               "legendFormat": "Connection overflow",
               "refId": "A"
             },
             {
-              "expr": "sum(irate(envoy_cluster_upstream_rq_pending_overflow{kuma_io_service=\"$source_service\",envoy_cluster_name=\"$destination_cluster\",mesh=\"$mesh\"}[1m]))",
+              "expr": "sum(irate(envoy_cluster_upstream_rq_pending_overflow{kuma_io_service=\"$source_service\",envoy_cluster_name=\"$destination_cluster\",kuma_io_zone=~\"$zone\",mesh=\"$mesh\"}[1m]))",
               "hide": false,
               "interval": "",
               "legendFormat": "Pending request overflow",
               "refId": "B"
             },
             {
-              "expr": "sum(irate(envoy_cluster_upstream_rq_retry_overflow{kuma_io_service=\"$source_service\",envoy_cluster_name=\"$destination_cluster\",mesh=\"$mesh\"}[1m]))",
+              "expr": "sum(irate(envoy_cluster_upstream_rq_retry_overflow{kuma_io_service=\"$source_service\",envoy_cluster_name=\"$destination_cluster\",kuma_io_zone=~\"$zone\",mesh=\"$mesh\"}[1m]))",
               "hide": false,
               "interval": "",
               "legendFormat": "Retry overflow",
@@ -5846,7 +5846,7 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "1 - sum(envoy_cluster_outlier_detection_ejections_active{kuma_io_service=\"$source_service\",envoy_cluster_name=\"$destination_cluster\",mesh=\"$mesh\"}) / sum(envoy_cluster_membership_total{kuma_io_service=\"$source_service\",envoy_cluster_name=\"$destination_cluster\",mesh=\"$mesh\"})",
+              "expr": "1 - sum(envoy_cluster_outlier_detection_ejections_active{kuma_io_service=\"$source_service\",envoy_cluster_name=\"$destination_cluster\",kuma_io_zone=~\"$zone\",mesh=\"$mesh\"}) / sum(envoy_cluster_membership_total{kuma_io_service=\"$source_service\",envoy_cluster_name=\"$destination_cluster\",kuma_io_zone=~\"$zone\",mesh=\"$mesh\"})",
               "interval": "",
               "legendFormat": "Healthy destinations",
               "refId": "A"
@@ -5923,6 +5923,29 @@ data:
               "query": "label_values(envoy_server_live, mesh)",
               "refId": "Prometheus-mesh-Variable-Query"
             },
+            "refresh": 1,
+            "regex": "",
+            "skipUrlSync": false,
+            "sort": 0,
+            "tagValuesQuery": "",
+            "tags": [],
+            "tagsQuery": "",
+            "type": "query",
+            "useTags": false
+          },
+          {
+            "allFormat": "wildcard",
+            "allValue": null,
+            "current": {},
+            "datasource": "Prometheus",
+            "definition": "label_values(envoy_server_live{mesh=\"$mesh\"}, kuma_io_zone)",
+            "hide": 0,
+            "includeAll": true,
+            "label": "Zone",
+            "multi": true,
+            "name": "zone",
+            "options": [],
+            "query": "label_values(envoy_server_live{mesh=\"$mesh\"}, kuma_io_zone)",
             "refresh": 1,
             "regex": "",
             "skipUrlSync": false,

--- a/app/kumactl/cmd/install/testdata/install-metrics.no-prometheus.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-metrics.no-prometheus.golden.yaml
@@ -4369,12 +4369,12 @@ data:
               "steppedLine": false,
               "targets": [
                 {
-                  "expr": "sum(irate(envoy_cluster_upstream_cx_tx_bytes_total{kuma_io_service=\"$source_service\",envoy_cluster_name=\"$destination_cluster\",mesh=\"$mesh\"}[1m]))",
+                  "expr": "sum(irate(envoy_cluster_upstream_cx_tx_bytes_total{kuma_io_service=\"$source_service\",envoy_cluster_name=\"$destination_cluster\",kuma_io_zone=~\"$zone\",mesh=\"$mesh\"}[1m]))",
                   "legendFormat": "Bytes sent",
                   "refId": "A"
                 },
                 {
-                  "expr": "sum(irate(envoy_cluster_upstream_cx_rx_bytes_total{kuma_io_service=\"$source_service\",envoy_cluster_name=\"$destination_cluster\",mesh=\"$mesh\"}[1m]))",
+                  "expr": "sum(irate(envoy_cluster_upstream_cx_rx_bytes_total{kuma_io_service=\"$source_service\",envoy_cluster_name=\"$destination_cluster\",kuma_io_zone=~\"$zone\",mesh=\"$mesh\"}[1m]))",
                   "legendFormat": "Bytes received",
                   "refId": "B"
                 }
@@ -4473,44 +4473,44 @@ data:
               "steppedLine": false,
               "targets": [
                 {
-                  "expr": "sum(irate(envoy_cluster_upstream_cx_destroy_remote_with_active_rq{kuma_io_service=\"$source_service\",envoy_cluster_name=\"$destination_cluster\",mesh=\"$mesh\"}[1m]))",
+                  "expr": "sum(irate(envoy_cluster_upstream_cx_destroy_remote_with_active_rq{kuma_io_service=\"$source_service\",envoy_cluster_name=\"$destination_cluster\",kuma_io_zone=~\"$zone\",mesh=\"$mesh\"}[1m]))",
                   "hide": true,
                   "legendFormat": "Connection destroyed by the client",
                   "refId": "A"
                 },
                 {
-                  "expr": "sum(irate(envoy_cluster_upstream_cx_connect_timeout{kuma_io_service=\"$source_service\",envoy_cluster_name=\"$destination_cluster\",mesh=\"$mesh\"}[1m]))",
+                  "expr": "sum(irate(envoy_cluster_upstream_cx_connect_timeout{kuma_io_service=\"$source_service\",envoy_cluster_name=\"$destination_cluster\",kuma_io_zone=~\"$zone\",mesh=\"$mesh\"}[1m]))",
                   "legendFormat": "Connection timeout",
                   "refId": "B"
                 },
                 {
-                  "expr": "sum(irate(envoy_cluster_upstream_cx_destroy_local_with_active_rq{kuma_io_service=\"$source_service\",envoy_cluster_name=\"$destination_cluster\",mesh=\"$mesh\"}[1m]))",
+                  "expr": "sum(irate(envoy_cluster_upstream_cx_destroy_local_with_active_rq{kuma_io_service=\"$source_service\",envoy_cluster_name=\"$destination_cluster\",kuma_io_zone=~\"$zone\",mesh=\"$mesh\"}[1m]))",
                   "hide": true,
                   "legendFormat": "Connection destroyed by local Envoy",
                   "refId": "C"
                 },
                 {
-                  "expr": "sum(irate(envoy_cluster_upstream_rq_pending_failure_eject{kuma_io_service=\"$source_service\",envoy_cluster_name=\"$destination_cluster\",mesh=\"$mesh\"}[1m]))",
+                  "expr": "sum(irate(envoy_cluster_upstream_rq_pending_failure_eject{kuma_io_service=\"$source_service\",envoy_cluster_name=\"$destination_cluster\",kuma_io_zone=~\"$zone\",mesh=\"$mesh\"}[1m]))",
                   "legendFormat": "Pending failure ejection",
                   "refId": "D"
                 },
                 {
-                  "expr": "sum(irate(envoy_cluster_upstream_rq_pending_overflow{kuma_io_service=\"$source_service\",envoy_cluster_name=\"$destination_cluster\",mesh=\"$mesh\"}[1m]))",
+                  "expr": "sum(irate(envoy_cluster_upstream_rq_pending_overflow{kuma_io_service=\"$source_service\",envoy_cluster_name=\"$destination_cluster\",kuma_io_zone=~\"$zone\",mesh=\"$mesh\"}[1m]))",
                   "legendFormat": "Pending overflow",
                   "refId": "E"
                 },
                 {
-                  "expr": "sum(irate(envoy_cluster_upstream_rq_timeout{kuma_io_service=\"$source_service\",envoy_cluster_name=\"$destination_cluster\",mesh=\"$mesh\"}[1m]))",
+                  "expr": "sum(irate(envoy_cluster_upstream_rq_timeout{kuma_io_service=\"$source_service\",envoy_cluster_name=\"$destination_cluster\",kuma_io_zone=~\"$zone\",mesh=\"$mesh\"}[1m]))",
                   "legendFormat": "Request timeout",
                   "refId": "F"
                 },
                 {
-                  "expr": "sum(irate(envoy_cluster_upstream_rq_rx_reset{kuma_io_service=\"$source_service\",envoy_cluster_name=\"$destination_cluster\",mesh=\"$mesh\"}[1m]))",
+                  "expr": "sum(irate(envoy_cluster_upstream_rq_rx_reset{kuma_io_service=\"$source_service\",envoy_cluster_name=\"$destination_cluster\",kuma_io_zone=~\"$zone\",mesh=\"$mesh\"}[1m]))",
                   "legendFormat": "Response reset",
                   "refId": "G"
                 },
                 {
-                  "expr": "sum(irate(envoy_cluster_upstream_rq_tx_reset{kuma_io_service=\"$source_service\",envoy_cluster_name=\"$destination_cluster\",mesh=\"$mesh\"}[1m]))",
+                  "expr": "sum(irate(envoy_cluster_upstream_rq_tx_reset{kuma_io_service=\"$source_service\",envoy_cluster_name=\"$destination_cluster\",kuma_io_zone=~\"$zone\",mesh=\"$mesh\"}[1m]))",
                   "legendFormat": "Request reset",
                   "refId": "H"
                 }
@@ -4606,7 +4606,7 @@ data:
               "steppedLine": false,
               "targets": [
                 {
-                  "expr": "sum(envoy_cluster_upstream_cx_active{kuma_io_service=\"$source_service\",envoy_cluster_name=\"$destination_cluster\",mesh=\"$mesh\"})",
+                  "expr": "sum(envoy_cluster_upstream_cx_active{kuma_io_service=\"$source_service\",envoy_cluster_name=\"$destination_cluster\",kuma_io_zone=~\"$zone\",mesh=\"$mesh\"})",
                   "legendFormat": "Connections",
                   "refId": "A"
                 }
@@ -4702,7 +4702,7 @@ data:
               "steppedLine": false,
               "targets": [
                 {
-                  "expr": "max(histogram_quantile(0.99, irate(envoy_cluster_upstream_cx_connect_ms_bucket{kuma_io_service=\"$source_service\",envoy_cluster_name=\"$destination_cluster\",mesh=\"$mesh\"}[1m])))",
+                  "expr": "max(histogram_quantile(0.99, irate(envoy_cluster_upstream_cx_connect_ms_bucket{kuma_io_service=\"$source_service\",envoy_cluster_name=\"$destination_cluster\",kuma_io_zone=~\"$zone\",mesh=\"$mesh\"}[1m])))",
                   "legendFormat": "Time",
                   "refId": "A"
                 }
@@ -4799,7 +4799,7 @@ data:
               "steppedLine": false,
               "targets": [
                 {
-                  "expr": "max(histogram_quantile(0.99, irate(envoy_cluster_upstream_cx_length_ms_bucket{kuma_io_service=\"$source_service\",envoy_cluster_name=\"$destination_cluster\",mesh=\"$mesh\"}[1m])))",
+                  "expr": "max(histogram_quantile(0.99, irate(envoy_cluster_upstream_cx_length_ms_bucket{kuma_io_service=\"$source_service\",envoy_cluster_name=\"$destination_cluster\",kuma_io_zone=~\"$zone\",mesh=\"$mesh\"}[1m])))",
                   "legendFormat": "Time",
                   "refId": "A"
                 }
@@ -4916,21 +4916,21 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "max(histogram_quantile(0.99, rate(envoy_cluster_upstream_rq_time_bucket{kuma_io_service=\"$source_service\",mesh=\"$mesh\",envoy_cluster_name=\"$destination_cluster\"}[1m])))",
+              "expr": "max(histogram_quantile(0.99, rate(envoy_cluster_upstream_rq_time_bucket{kuma_io_service=\"$source_service\",kuma_io_zone=~\"$zone\",mesh=\"$mesh\",envoy_cluster_name=\"$destination_cluster\"}[1m])))",
               "hide": false,
               "interval": "",
               "legendFormat": "p99",
               "refId": "A"
             },
             {
-              "expr": "max(histogram_quantile(0.95, rate(envoy_cluster_upstream_rq_time_bucket{kuma_io_service=\"$source_service\",mesh=\"$mesh\",envoy_cluster_name=\"$destination_cluster\"}[1m])))",
+              "expr": "max(histogram_quantile(0.95, rate(envoy_cluster_upstream_rq_time_bucket{kuma_io_service=\"$source_service\",kuma_io_zone=~\"$zone\",mesh=\"$mesh\",envoy_cluster_name=\"$destination_cluster\"}[1m])))",
               "hide": false,
               "interval": "",
               "legendFormat": "p95",
               "refId": "C"
             },
             {
-              "expr": "max(histogram_quantile(0.50, rate(envoy_cluster_upstream_rq_time_bucket{kuma_io_service=\"$source_service\",mesh=\"$mesh\",envoy_cluster_name=\"$destination_cluster\"}[1m])))",
+              "expr": "max(histogram_quantile(0.50, rate(envoy_cluster_upstream_rq_time_bucket{kuma_io_service=\"$source_service\",kuma_io_zone=~\"$zone\",mesh=\"$mesh\",envoy_cluster_name=\"$destination_cluster\"}[1m])))",
               "hide": false,
               "interval": "",
               "legendFormat": "p50",
@@ -5239,7 +5239,7 @@ data:
               "steppedLine": false,
               "targets": [
                 {
-                  "expr": "sum(envoy_cluster_health_check_healthy{kuma_io_service=\"$source_service\",envoy_cluster_name=\"$destination_cluster\",mesh=\"$mesh\"}) / sum(envoy_cluster_membership_total{kuma_io_service=\"$source_service\",envoy_cluster_name=\"$destination_cluster\",mesh=\"$mesh\"})",
+                  "expr": "sum(envoy_cluster_health_check_healthy{kuma_io_service=\"$source_service\",envoy_cluster_name=\"$destination_cluster\",kuma_io_zone=~\"$zone\",mesh=\"$mesh\"}) / sum(envoy_cluster_membership_total{kuma_io_service=\"$source_service\",envoy_cluster_name=\"$destination_cluster\",kuma_io_zone=~\"$zone\",mesh=\"$mesh\"})",
                   "legendFormat": "Healthy destinations",
                   "refId": "A"
                 }
@@ -5354,20 +5354,20 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(irate(envoy_cluster_upstream_cx_overflow{kuma_io_service=\"$source_service\",envoy_cluster_name=\"$destination_cluster\",mesh=\"$mesh\"}[1m]))",
+              "expr": "sum(irate(envoy_cluster_upstream_cx_overflow{kuma_io_service=\"$source_service\",envoy_cluster_name=\"$destination_cluster\",kuma_io_zone=~\"$zone\",mesh=\"$mesh\"}[1m]))",
               "interval": "",
               "legendFormat": "Connection overflow",
               "refId": "A"
             },
             {
-              "expr": "sum(irate(envoy_cluster_upstream_rq_pending_overflow{kuma_io_service=\"$source_service\",envoy_cluster_name=\"$destination_cluster\",mesh=\"$mesh\"}[1m]))",
+              "expr": "sum(irate(envoy_cluster_upstream_rq_pending_overflow{kuma_io_service=\"$source_service\",envoy_cluster_name=\"$destination_cluster\",kuma_io_zone=~\"$zone\",mesh=\"$mesh\"}[1m]))",
               "hide": false,
               "interval": "",
               "legendFormat": "Pending request overflow",
               "refId": "B"
             },
             {
-              "expr": "sum(irate(envoy_cluster_upstream_rq_retry_overflow{kuma_io_service=\"$source_service\",envoy_cluster_name=\"$destination_cluster\",mesh=\"$mesh\"}[1m]))",
+              "expr": "sum(irate(envoy_cluster_upstream_rq_retry_overflow{kuma_io_service=\"$source_service\",envoy_cluster_name=\"$destination_cluster\",kuma_io_zone=~\"$zone\",mesh=\"$mesh\"}[1m]))",
               "hide": false,
               "interval": "",
               "legendFormat": "Retry overflow",
@@ -5469,7 +5469,7 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "1 - sum(envoy_cluster_outlier_detection_ejections_active{kuma_io_service=\"$source_service\",envoy_cluster_name=\"$destination_cluster\",mesh=\"$mesh\"}) / sum(envoy_cluster_membership_total{kuma_io_service=\"$source_service\",envoy_cluster_name=\"$destination_cluster\",mesh=\"$mesh\"})",
+              "expr": "1 - sum(envoy_cluster_outlier_detection_ejections_active{kuma_io_service=\"$source_service\",envoy_cluster_name=\"$destination_cluster\",kuma_io_zone=~\"$zone\",mesh=\"$mesh\"}) / sum(envoy_cluster_membership_total{kuma_io_service=\"$source_service\",envoy_cluster_name=\"$destination_cluster\",kuma_io_zone=~\"$zone\",mesh=\"$mesh\"})",
               "interval": "",
               "legendFormat": "Healthy destinations",
               "refId": "A"
@@ -5546,6 +5546,29 @@ data:
               "query": "label_values(envoy_server_live, mesh)",
               "refId": "Prometheus-mesh-Variable-Query"
             },
+            "refresh": 1,
+            "regex": "",
+            "skipUrlSync": false,
+            "sort": 0,
+            "tagValuesQuery": "",
+            "tags": [],
+            "tagsQuery": "",
+            "type": "query",
+            "useTags": false
+          },
+          {
+            "allFormat": "wildcard",
+            "allValue": null,
+            "current": {},
+            "datasource": "Prometheus",
+            "definition": "label_values(envoy_server_live{mesh=\"$mesh\"}, kuma_io_zone)",
+            "hide": 0,
+            "includeAll": true,
+            "label": "Zone",
+            "multi": true,
+            "name": "zone",
+            "options": [],
+            "query": "label_values(envoy_server_live{mesh=\"$mesh\"}, kuma_io_zone)",
             "refresh": 1,
             "regex": "",
             "skipUrlSync": false,

--- a/app/kumactl/cmd/install/testdata/install-metrics.overrides.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-metrics.overrides.golden.yaml
@@ -4746,12 +4746,12 @@ data:
               "steppedLine": false,
               "targets": [
                 {
-                  "expr": "sum(irate(envoy_cluster_upstream_cx_tx_bytes_total{kuma_io_service=\"$source_service\",envoy_cluster_name=\"$destination_cluster\",mesh=\"$mesh\"}[1m]))",
+                  "expr": "sum(irate(envoy_cluster_upstream_cx_tx_bytes_total{kuma_io_service=\"$source_service\",envoy_cluster_name=\"$destination_cluster\",kuma_io_zone=~\"$zone\",mesh=\"$mesh\"}[1m]))",
                   "legendFormat": "Bytes sent",
                   "refId": "A"
                 },
                 {
-                  "expr": "sum(irate(envoy_cluster_upstream_cx_rx_bytes_total{kuma_io_service=\"$source_service\",envoy_cluster_name=\"$destination_cluster\",mesh=\"$mesh\"}[1m]))",
+                  "expr": "sum(irate(envoy_cluster_upstream_cx_rx_bytes_total{kuma_io_service=\"$source_service\",envoy_cluster_name=\"$destination_cluster\",kuma_io_zone=~\"$zone\",mesh=\"$mesh\"}[1m]))",
                   "legendFormat": "Bytes received",
                   "refId": "B"
                 }
@@ -4850,44 +4850,44 @@ data:
               "steppedLine": false,
               "targets": [
                 {
-                  "expr": "sum(irate(envoy_cluster_upstream_cx_destroy_remote_with_active_rq{kuma_io_service=\"$source_service\",envoy_cluster_name=\"$destination_cluster\",mesh=\"$mesh\"}[1m]))",
+                  "expr": "sum(irate(envoy_cluster_upstream_cx_destroy_remote_with_active_rq{kuma_io_service=\"$source_service\",envoy_cluster_name=\"$destination_cluster\",kuma_io_zone=~\"$zone\",mesh=\"$mesh\"}[1m]))",
                   "hide": true,
                   "legendFormat": "Connection destroyed by the client",
                   "refId": "A"
                 },
                 {
-                  "expr": "sum(irate(envoy_cluster_upstream_cx_connect_timeout{kuma_io_service=\"$source_service\",envoy_cluster_name=\"$destination_cluster\",mesh=\"$mesh\"}[1m]))",
+                  "expr": "sum(irate(envoy_cluster_upstream_cx_connect_timeout{kuma_io_service=\"$source_service\",envoy_cluster_name=\"$destination_cluster\",kuma_io_zone=~\"$zone\",mesh=\"$mesh\"}[1m]))",
                   "legendFormat": "Connection timeout",
                   "refId": "B"
                 },
                 {
-                  "expr": "sum(irate(envoy_cluster_upstream_cx_destroy_local_with_active_rq{kuma_io_service=\"$source_service\",envoy_cluster_name=\"$destination_cluster\",mesh=\"$mesh\"}[1m]))",
+                  "expr": "sum(irate(envoy_cluster_upstream_cx_destroy_local_with_active_rq{kuma_io_service=\"$source_service\",envoy_cluster_name=\"$destination_cluster\",kuma_io_zone=~\"$zone\",mesh=\"$mesh\"}[1m]))",
                   "hide": true,
                   "legendFormat": "Connection destroyed by local Envoy",
                   "refId": "C"
                 },
                 {
-                  "expr": "sum(irate(envoy_cluster_upstream_rq_pending_failure_eject{kuma_io_service=\"$source_service\",envoy_cluster_name=\"$destination_cluster\",mesh=\"$mesh\"}[1m]))",
+                  "expr": "sum(irate(envoy_cluster_upstream_rq_pending_failure_eject{kuma_io_service=\"$source_service\",envoy_cluster_name=\"$destination_cluster\",kuma_io_zone=~\"$zone\",mesh=\"$mesh\"}[1m]))",
                   "legendFormat": "Pending failure ejection",
                   "refId": "D"
                 },
                 {
-                  "expr": "sum(irate(envoy_cluster_upstream_rq_pending_overflow{kuma_io_service=\"$source_service\",envoy_cluster_name=\"$destination_cluster\",mesh=\"$mesh\"}[1m]))",
+                  "expr": "sum(irate(envoy_cluster_upstream_rq_pending_overflow{kuma_io_service=\"$source_service\",envoy_cluster_name=\"$destination_cluster\",kuma_io_zone=~\"$zone\",mesh=\"$mesh\"}[1m]))",
                   "legendFormat": "Pending overflow",
                   "refId": "E"
                 },
                 {
-                  "expr": "sum(irate(envoy_cluster_upstream_rq_timeout{kuma_io_service=\"$source_service\",envoy_cluster_name=\"$destination_cluster\",mesh=\"$mesh\"}[1m]))",
+                  "expr": "sum(irate(envoy_cluster_upstream_rq_timeout{kuma_io_service=\"$source_service\",envoy_cluster_name=\"$destination_cluster\",kuma_io_zone=~\"$zone\",mesh=\"$mesh\"}[1m]))",
                   "legendFormat": "Request timeout",
                   "refId": "F"
                 },
                 {
-                  "expr": "sum(irate(envoy_cluster_upstream_rq_rx_reset{kuma_io_service=\"$source_service\",envoy_cluster_name=\"$destination_cluster\",mesh=\"$mesh\"}[1m]))",
+                  "expr": "sum(irate(envoy_cluster_upstream_rq_rx_reset{kuma_io_service=\"$source_service\",envoy_cluster_name=\"$destination_cluster\",kuma_io_zone=~\"$zone\",mesh=\"$mesh\"}[1m]))",
                   "legendFormat": "Response reset",
                   "refId": "G"
                 },
                 {
-                  "expr": "sum(irate(envoy_cluster_upstream_rq_tx_reset{kuma_io_service=\"$source_service\",envoy_cluster_name=\"$destination_cluster\",mesh=\"$mesh\"}[1m]))",
+                  "expr": "sum(irate(envoy_cluster_upstream_rq_tx_reset{kuma_io_service=\"$source_service\",envoy_cluster_name=\"$destination_cluster\",kuma_io_zone=~\"$zone\",mesh=\"$mesh\"}[1m]))",
                   "legendFormat": "Request reset",
                   "refId": "H"
                 }
@@ -4983,7 +4983,7 @@ data:
               "steppedLine": false,
               "targets": [
                 {
-                  "expr": "sum(envoy_cluster_upstream_cx_active{kuma_io_service=\"$source_service\",envoy_cluster_name=\"$destination_cluster\",mesh=\"$mesh\"})",
+                  "expr": "sum(envoy_cluster_upstream_cx_active{kuma_io_service=\"$source_service\",envoy_cluster_name=\"$destination_cluster\",kuma_io_zone=~\"$zone\",mesh=\"$mesh\"})",
                   "legendFormat": "Connections",
                   "refId": "A"
                 }
@@ -5079,7 +5079,7 @@ data:
               "steppedLine": false,
               "targets": [
                 {
-                  "expr": "max(histogram_quantile(0.99, irate(envoy_cluster_upstream_cx_connect_ms_bucket{kuma_io_service=\"$source_service\",envoy_cluster_name=\"$destination_cluster\",mesh=\"$mesh\"}[1m])))",
+                  "expr": "max(histogram_quantile(0.99, irate(envoy_cluster_upstream_cx_connect_ms_bucket{kuma_io_service=\"$source_service\",envoy_cluster_name=\"$destination_cluster\",kuma_io_zone=~\"$zone\",mesh=\"$mesh\"}[1m])))",
                   "legendFormat": "Time",
                   "refId": "A"
                 }
@@ -5176,7 +5176,7 @@ data:
               "steppedLine": false,
               "targets": [
                 {
-                  "expr": "max(histogram_quantile(0.99, irate(envoy_cluster_upstream_cx_length_ms_bucket{kuma_io_service=\"$source_service\",envoy_cluster_name=\"$destination_cluster\",mesh=\"$mesh\"}[1m])))",
+                  "expr": "max(histogram_quantile(0.99, irate(envoy_cluster_upstream_cx_length_ms_bucket{kuma_io_service=\"$source_service\",envoy_cluster_name=\"$destination_cluster\",kuma_io_zone=~\"$zone\",mesh=\"$mesh\"}[1m])))",
                   "legendFormat": "Time",
                   "refId": "A"
                 }
@@ -5293,21 +5293,21 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "max(histogram_quantile(0.99, rate(envoy_cluster_upstream_rq_time_bucket{kuma_io_service=\"$source_service\",mesh=\"$mesh\",envoy_cluster_name=\"$destination_cluster\"}[1m])))",
+              "expr": "max(histogram_quantile(0.99, rate(envoy_cluster_upstream_rq_time_bucket{kuma_io_service=\"$source_service\",kuma_io_zone=~\"$zone\",mesh=\"$mesh\",envoy_cluster_name=\"$destination_cluster\"}[1m])))",
               "hide": false,
               "interval": "",
               "legendFormat": "p99",
               "refId": "A"
             },
             {
-              "expr": "max(histogram_quantile(0.95, rate(envoy_cluster_upstream_rq_time_bucket{kuma_io_service=\"$source_service\",mesh=\"$mesh\",envoy_cluster_name=\"$destination_cluster\"}[1m])))",
+              "expr": "max(histogram_quantile(0.95, rate(envoy_cluster_upstream_rq_time_bucket{kuma_io_service=\"$source_service\",kuma_io_zone=~\"$zone\",mesh=\"$mesh\",envoy_cluster_name=\"$destination_cluster\"}[1m])))",
               "hide": false,
               "interval": "",
               "legendFormat": "p95",
               "refId": "C"
             },
             {
-              "expr": "max(histogram_quantile(0.50, rate(envoy_cluster_upstream_rq_time_bucket{kuma_io_service=\"$source_service\",mesh=\"$mesh\",envoy_cluster_name=\"$destination_cluster\"}[1m])))",
+              "expr": "max(histogram_quantile(0.50, rate(envoy_cluster_upstream_rq_time_bucket{kuma_io_service=\"$source_service\",kuma_io_zone=~\"$zone\",mesh=\"$mesh\",envoy_cluster_name=\"$destination_cluster\"}[1m])))",
               "hide": false,
               "interval": "",
               "legendFormat": "p50",
@@ -5616,7 +5616,7 @@ data:
               "steppedLine": false,
               "targets": [
                 {
-                  "expr": "sum(envoy_cluster_health_check_healthy{kuma_io_service=\"$source_service\",envoy_cluster_name=\"$destination_cluster\",mesh=\"$mesh\"}) / sum(envoy_cluster_membership_total{kuma_io_service=\"$source_service\",envoy_cluster_name=\"$destination_cluster\",mesh=\"$mesh\"})",
+                  "expr": "sum(envoy_cluster_health_check_healthy{kuma_io_service=\"$source_service\",envoy_cluster_name=\"$destination_cluster\",kuma_io_zone=~\"$zone\",mesh=\"$mesh\"}) / sum(envoy_cluster_membership_total{kuma_io_service=\"$source_service\",envoy_cluster_name=\"$destination_cluster\",kuma_io_zone=~\"$zone\",mesh=\"$mesh\"})",
                   "legendFormat": "Healthy destinations",
                   "refId": "A"
                 }
@@ -5731,20 +5731,20 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(irate(envoy_cluster_upstream_cx_overflow{kuma_io_service=\"$source_service\",envoy_cluster_name=\"$destination_cluster\",mesh=\"$mesh\"}[1m]))",
+              "expr": "sum(irate(envoy_cluster_upstream_cx_overflow{kuma_io_service=\"$source_service\",envoy_cluster_name=\"$destination_cluster\",kuma_io_zone=~\"$zone\",mesh=\"$mesh\"}[1m]))",
               "interval": "",
               "legendFormat": "Connection overflow",
               "refId": "A"
             },
             {
-              "expr": "sum(irate(envoy_cluster_upstream_rq_pending_overflow{kuma_io_service=\"$source_service\",envoy_cluster_name=\"$destination_cluster\",mesh=\"$mesh\"}[1m]))",
+              "expr": "sum(irate(envoy_cluster_upstream_rq_pending_overflow{kuma_io_service=\"$source_service\",envoy_cluster_name=\"$destination_cluster\",kuma_io_zone=~\"$zone\",mesh=\"$mesh\"}[1m]))",
               "hide": false,
               "interval": "",
               "legendFormat": "Pending request overflow",
               "refId": "B"
             },
             {
-              "expr": "sum(irate(envoy_cluster_upstream_rq_retry_overflow{kuma_io_service=\"$source_service\",envoy_cluster_name=\"$destination_cluster\",mesh=\"$mesh\"}[1m]))",
+              "expr": "sum(irate(envoy_cluster_upstream_rq_retry_overflow{kuma_io_service=\"$source_service\",envoy_cluster_name=\"$destination_cluster\",kuma_io_zone=~\"$zone\",mesh=\"$mesh\"}[1m]))",
               "hide": false,
               "interval": "",
               "legendFormat": "Retry overflow",
@@ -5846,7 +5846,7 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "1 - sum(envoy_cluster_outlier_detection_ejections_active{kuma_io_service=\"$source_service\",envoy_cluster_name=\"$destination_cluster\",mesh=\"$mesh\"}) / sum(envoy_cluster_membership_total{kuma_io_service=\"$source_service\",envoy_cluster_name=\"$destination_cluster\",mesh=\"$mesh\"})",
+              "expr": "1 - sum(envoy_cluster_outlier_detection_ejections_active{kuma_io_service=\"$source_service\",envoy_cluster_name=\"$destination_cluster\",kuma_io_zone=~\"$zone\",mesh=\"$mesh\"}) / sum(envoy_cluster_membership_total{kuma_io_service=\"$source_service\",envoy_cluster_name=\"$destination_cluster\",kuma_io_zone=~\"$zone\",mesh=\"$mesh\"})",
               "interval": "",
               "legendFormat": "Healthy destinations",
               "refId": "A"
@@ -5923,6 +5923,29 @@ data:
               "query": "label_values(envoy_server_live, mesh)",
               "refId": "Prometheus-mesh-Variable-Query"
             },
+            "refresh": 1,
+            "regex": "",
+            "skipUrlSync": false,
+            "sort": 0,
+            "tagValuesQuery": "",
+            "tags": [],
+            "tagsQuery": "",
+            "type": "query",
+            "useTags": false
+          },
+          {
+            "allFormat": "wildcard",
+            "allValue": null,
+            "current": {},
+            "datasource": "Prometheus",
+            "definition": "label_values(envoy_server_live{mesh=\"$mesh\"}, kuma_io_zone)",
+            "hide": 0,
+            "includeAll": true,
+            "label": "Zone",
+            "multi": true,
+            "name": "zone",
+            "options": [],
+            "query": "label_values(envoy_server_live{mesh=\"$mesh\"}, kuma_io_zone)",
             "refresh": 1,
             "regex": "",
             "skipUrlSync": false,

--- a/app/kumactl/data/install/k8s/metrics/grafana/kuma-service-to-service.json
+++ b/app/kumactl/data/install/k8s/metrics/grafana/kuma-service-to-service.json
@@ -81,12 +81,12 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(irate(envoy_cluster_upstream_cx_tx_bytes_total{kuma_io_service=\"$source_service\",envoy_cluster_name=\"$destination_cluster\",mesh=\"$mesh\"}[1m]))",
+              "expr": "sum(irate(envoy_cluster_upstream_cx_tx_bytes_total{kuma_io_service=\"$source_service\",envoy_cluster_name=\"$destination_cluster\",kuma_io_zone=~\"$zone\",mesh=\"$mesh\"}[1m]))",
               "legendFormat": "Bytes sent",
               "refId": "A"
             },
             {
-              "expr": "sum(irate(envoy_cluster_upstream_cx_rx_bytes_total{kuma_io_service=\"$source_service\",envoy_cluster_name=\"$destination_cluster\",mesh=\"$mesh\"}[1m]))",
+              "expr": "sum(irate(envoy_cluster_upstream_cx_rx_bytes_total{kuma_io_service=\"$source_service\",envoy_cluster_name=\"$destination_cluster\",kuma_io_zone=~\"$zone\",mesh=\"$mesh\"}[1m]))",
               "legendFormat": "Bytes received",
               "refId": "B"
             }
@@ -185,44 +185,44 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(irate(envoy_cluster_upstream_cx_destroy_remote_with_active_rq{kuma_io_service=\"$source_service\",envoy_cluster_name=\"$destination_cluster\",mesh=\"$mesh\"}[1m]))",
+              "expr": "sum(irate(envoy_cluster_upstream_cx_destroy_remote_with_active_rq{kuma_io_service=\"$source_service\",envoy_cluster_name=\"$destination_cluster\",kuma_io_zone=~\"$zone\",mesh=\"$mesh\"}[1m]))",
               "hide": true,
               "legendFormat": "Connection destroyed by the client",
               "refId": "A"
             },
             {
-              "expr": "sum(irate(envoy_cluster_upstream_cx_connect_timeout{kuma_io_service=\"$source_service\",envoy_cluster_name=\"$destination_cluster\",mesh=\"$mesh\"}[1m]))",
+              "expr": "sum(irate(envoy_cluster_upstream_cx_connect_timeout{kuma_io_service=\"$source_service\",envoy_cluster_name=\"$destination_cluster\",kuma_io_zone=~\"$zone\",mesh=\"$mesh\"}[1m]))",
               "legendFormat": "Connection timeout",
               "refId": "B"
             },
             {
-              "expr": "sum(irate(envoy_cluster_upstream_cx_destroy_local_with_active_rq{kuma_io_service=\"$source_service\",envoy_cluster_name=\"$destination_cluster\",mesh=\"$mesh\"}[1m]))",
+              "expr": "sum(irate(envoy_cluster_upstream_cx_destroy_local_with_active_rq{kuma_io_service=\"$source_service\",envoy_cluster_name=\"$destination_cluster\",kuma_io_zone=~\"$zone\",mesh=\"$mesh\"}[1m]))",
               "hide": true,
               "legendFormat": "Connection destroyed by local Envoy",
               "refId": "C"
             },
             {
-              "expr": "sum(irate(envoy_cluster_upstream_rq_pending_failure_eject{kuma_io_service=\"$source_service\",envoy_cluster_name=\"$destination_cluster\",mesh=\"$mesh\"}[1m]))",
+              "expr": "sum(irate(envoy_cluster_upstream_rq_pending_failure_eject{kuma_io_service=\"$source_service\",envoy_cluster_name=\"$destination_cluster\",kuma_io_zone=~\"$zone\",mesh=\"$mesh\"}[1m]))",
               "legendFormat": "Pending failure ejection",
               "refId": "D"
             },
             {
-              "expr": "sum(irate(envoy_cluster_upstream_rq_pending_overflow{kuma_io_service=\"$source_service\",envoy_cluster_name=\"$destination_cluster\",mesh=\"$mesh\"}[1m]))",
+              "expr": "sum(irate(envoy_cluster_upstream_rq_pending_overflow{kuma_io_service=\"$source_service\",envoy_cluster_name=\"$destination_cluster\",kuma_io_zone=~\"$zone\",mesh=\"$mesh\"}[1m]))",
               "legendFormat": "Pending overflow",
               "refId": "E"
             },
             {
-              "expr": "sum(irate(envoy_cluster_upstream_rq_timeout{kuma_io_service=\"$source_service\",envoy_cluster_name=\"$destination_cluster\",mesh=\"$mesh\"}[1m]))",
+              "expr": "sum(irate(envoy_cluster_upstream_rq_timeout{kuma_io_service=\"$source_service\",envoy_cluster_name=\"$destination_cluster\",kuma_io_zone=~\"$zone\",mesh=\"$mesh\"}[1m]))",
               "legendFormat": "Request timeout",
               "refId": "F"
             },
             {
-              "expr": "sum(irate(envoy_cluster_upstream_rq_rx_reset{kuma_io_service=\"$source_service\",envoy_cluster_name=\"$destination_cluster\",mesh=\"$mesh\"}[1m]))",
+              "expr": "sum(irate(envoy_cluster_upstream_rq_rx_reset{kuma_io_service=\"$source_service\",envoy_cluster_name=\"$destination_cluster\",kuma_io_zone=~\"$zone\",mesh=\"$mesh\"}[1m]))",
               "legendFormat": "Response reset",
               "refId": "G"
             },
             {
-              "expr": "sum(irate(envoy_cluster_upstream_rq_tx_reset{kuma_io_service=\"$source_service\",envoy_cluster_name=\"$destination_cluster\",mesh=\"$mesh\"}[1m]))",
+              "expr": "sum(irate(envoy_cluster_upstream_rq_tx_reset{kuma_io_service=\"$source_service\",envoy_cluster_name=\"$destination_cluster\",kuma_io_zone=~\"$zone\",mesh=\"$mesh\"}[1m]))",
               "legendFormat": "Request reset",
               "refId": "H"
             }
@@ -318,7 +318,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(envoy_cluster_upstream_cx_active{kuma_io_service=\"$source_service\",envoy_cluster_name=\"$destination_cluster\",mesh=\"$mesh\"})",
+              "expr": "sum(envoy_cluster_upstream_cx_active{kuma_io_service=\"$source_service\",envoy_cluster_name=\"$destination_cluster\",kuma_io_zone=~\"$zone\",mesh=\"$mesh\"})",
               "legendFormat": "Connections",
               "refId": "A"
             }
@@ -414,7 +414,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "max(histogram_quantile(0.99, irate(envoy_cluster_upstream_cx_connect_ms_bucket{kuma_io_service=\"$source_service\",envoy_cluster_name=\"$destination_cluster\",mesh=\"$mesh\"}[1m])))",
+              "expr": "max(histogram_quantile(0.99, irate(envoy_cluster_upstream_cx_connect_ms_bucket{kuma_io_service=\"$source_service\",envoy_cluster_name=\"$destination_cluster\",kuma_io_zone=~\"$zone\",mesh=\"$mesh\"}[1m])))",
               "legendFormat": "Time",
               "refId": "A"
             }
@@ -511,7 +511,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "max(histogram_quantile(0.99, irate(envoy_cluster_upstream_cx_length_ms_bucket{kuma_io_service=\"$source_service\",envoy_cluster_name=\"$destination_cluster\",mesh=\"$mesh\"}[1m])))",
+              "expr": "max(histogram_quantile(0.99, irate(envoy_cluster_upstream_cx_length_ms_bucket{kuma_io_service=\"$source_service\",envoy_cluster_name=\"$destination_cluster\",kuma_io_zone=~\"$zone\",mesh=\"$mesh\"}[1m])))",
               "legendFormat": "Time",
               "refId": "A"
             }
@@ -628,21 +628,21 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "max(histogram_quantile(0.99, rate(envoy_cluster_upstream_rq_time_bucket{kuma_io_service=\"$source_service\",mesh=\"$mesh\",envoy_cluster_name=\"$destination_cluster\"}[1m])))",
+          "expr": "max(histogram_quantile(0.99, rate(envoy_cluster_upstream_rq_time_bucket{kuma_io_service=\"$source_service\",kuma_io_zone=~\"$zone\",mesh=\"$mesh\",envoy_cluster_name=\"$destination_cluster\"}[1m])))",
           "hide": false,
           "interval": "",
           "legendFormat": "p99",
           "refId": "A"
         },
         {
-          "expr": "max(histogram_quantile(0.95, rate(envoy_cluster_upstream_rq_time_bucket{kuma_io_service=\"$source_service\",mesh=\"$mesh\",envoy_cluster_name=\"$destination_cluster\"}[1m])))",
+          "expr": "max(histogram_quantile(0.95, rate(envoy_cluster_upstream_rq_time_bucket{kuma_io_service=\"$source_service\",kuma_io_zone=~\"$zone\",mesh=\"$mesh\",envoy_cluster_name=\"$destination_cluster\"}[1m])))",
           "hide": false,
           "interval": "",
           "legendFormat": "p95",
           "refId": "C"
         },
         {
-          "expr": "max(histogram_quantile(0.50, rate(envoy_cluster_upstream_rq_time_bucket{kuma_io_service=\"$source_service\",mesh=\"$mesh\",envoy_cluster_name=\"$destination_cluster\"}[1m])))",
+          "expr": "max(histogram_quantile(0.50, rate(envoy_cluster_upstream_rq_time_bucket{kuma_io_service=\"$source_service\",kuma_io_zone=~\"$zone\",mesh=\"$mesh\",envoy_cluster_name=\"$destination_cluster\"}[1m])))",
           "hide": false,
           "interval": "",
           "legendFormat": "p50",
@@ -951,7 +951,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(envoy_cluster_health_check_healthy{kuma_io_service=\"$source_service\",envoy_cluster_name=\"$destination_cluster\",mesh=\"$mesh\"}) / sum(envoy_cluster_membership_total{kuma_io_service=\"$source_service\",envoy_cluster_name=\"$destination_cluster\",mesh=\"$mesh\"})",
+              "expr": "sum(envoy_cluster_health_check_healthy{kuma_io_service=\"$source_service\",envoy_cluster_name=\"$destination_cluster\",kuma_io_zone=~\"$zone\",mesh=\"$mesh\"}) / sum(envoy_cluster_membership_total{kuma_io_service=\"$source_service\",envoy_cluster_name=\"$destination_cluster\",kuma_io_zone=~\"$zone\",mesh=\"$mesh\"})",
               "legendFormat": "Healthy destinations",
               "refId": "A"
             }
@@ -1066,20 +1066,20 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(irate(envoy_cluster_upstream_cx_overflow{kuma_io_service=\"$source_service\",envoy_cluster_name=\"$destination_cluster\",mesh=\"$mesh\"}[1m]))",
+          "expr": "sum(irate(envoy_cluster_upstream_cx_overflow{kuma_io_service=\"$source_service\",envoy_cluster_name=\"$destination_cluster\",kuma_io_zone=~\"$zone\",mesh=\"$mesh\"}[1m]))",
           "interval": "",
           "legendFormat": "Connection overflow",
           "refId": "A"
         },
         {
-          "expr": "sum(irate(envoy_cluster_upstream_rq_pending_overflow{kuma_io_service=\"$source_service\",envoy_cluster_name=\"$destination_cluster\",mesh=\"$mesh\"}[1m]))",
+          "expr": "sum(irate(envoy_cluster_upstream_rq_pending_overflow{kuma_io_service=\"$source_service\",envoy_cluster_name=\"$destination_cluster\",kuma_io_zone=~\"$zone\",mesh=\"$mesh\"}[1m]))",
           "hide": false,
           "interval": "",
           "legendFormat": "Pending request overflow",
           "refId": "B"
         },
         {
-          "expr": "sum(irate(envoy_cluster_upstream_rq_retry_overflow{kuma_io_service=\"$source_service\",envoy_cluster_name=\"$destination_cluster\",mesh=\"$mesh\"}[1m]))",
+          "expr": "sum(irate(envoy_cluster_upstream_rq_retry_overflow{kuma_io_service=\"$source_service\",envoy_cluster_name=\"$destination_cluster\",kuma_io_zone=~\"$zone\",mesh=\"$mesh\"}[1m]))",
           "hide": false,
           "interval": "",
           "legendFormat": "Retry overflow",
@@ -1181,7 +1181,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "1 - sum(envoy_cluster_outlier_detection_ejections_active{kuma_io_service=\"$source_service\",envoy_cluster_name=\"$destination_cluster\",mesh=\"$mesh\"}) / sum(envoy_cluster_membership_total{kuma_io_service=\"$source_service\",envoy_cluster_name=\"$destination_cluster\",mesh=\"$mesh\"})",
+          "expr": "1 - sum(envoy_cluster_outlier_detection_ejections_active{kuma_io_service=\"$source_service\",envoy_cluster_name=\"$destination_cluster\",kuma_io_zone=~\"$zone\",mesh=\"$mesh\"}) / sum(envoy_cluster_membership_total{kuma_io_service=\"$source_service\",envoy_cluster_name=\"$destination_cluster\",kuma_io_zone=~\"$zone\",mesh=\"$mesh\"})",
           "interval": "",
           "legendFormat": "Healthy destinations",
           "refId": "A"
@@ -1258,6 +1258,29 @@
           "query": "label_values(envoy_server_live, mesh)",
           "refId": "Prometheus-mesh-Variable-Query"
         },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allFormat": "wildcard",
+        "allValue": null,
+        "current": {},
+        "datasource": "Prometheus",
+        "definition": "label_values(envoy_server_live{mesh=\"$mesh\"}, kuma_io_zone)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Zone",
+        "multi": true,
+        "name": "zone",
+        "options": [],
+        "query": "label_values(envoy_server_live{mesh=\"$mesh\"}, kuma_io_zone)",
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,


### PR DESCRIPTION
### Summary

Add Zone selector to the Service to Service dashboard:
![service_service-zone_selector](https://user-images.githubusercontent.com/2266568/135822960-7d5d0557-e46e-496f-befe-3d9359868e0c.png)

standalone:
![service_service-zone_selector_standalone](https://user-images.githubusercontent.com/2266568/135822971-a6fa7e5f-1f7f-4193-ac25-f7f569476dae.png)

### Testing

- [x] Manual testing on Universal
- [x] Manual testing on Kubernetes 

### Backwards compatibility

- [x] Add `backport-to-stable` label if the code is backwards compatible. Otherwise, list breaking changes.
