### PR TITLE
fix(kuma-cp) disable zone

### DIFF
--- a/pkg/kds/context/context.go
+++ b/pkg/kds/context/context.go
@@ -44,19 +44,16 @@ func DefaultContext(manager manager.ResourceManager, zone string) *Context {
 func GlobalProvidedFilter(rm manager.ResourceManager, configs map[string]bool) reconcile.ResourceFilter {
 	return func(clusterID string, r model.Resource) bool {
 		resType := r.Descriptor().Name
-		if resType == mesh.ZoneIngressType {
-			return r.(*mesh.ZoneIngressResource).Spec.GetZone() != clusterID
-		}
 		if resType == system.ConfigType && !configs[r.GetMeta().GetName()] {
 			return false
 		}
 		if resType == system.GlobalSecretType {
 			return zoneingress.IsSigningKeyResource(model.MetaToResourceKey(r.GetMeta()))
 		}
-		if resType != mesh.DataplaneType {
+		if resType != mesh.DataplaneType && resType != mesh.ZoneIngressType {
 			return true
 		}
-		if !r.(*mesh.DataplaneResource).Spec.IsIngress() {
+		if resType == mesh.DataplaneType && !r.(*mesh.DataplaneResource).Spec.IsIngress() {
 			return false
 		}
 		if clusterID == util.ZoneTag(r) {

--- a/pkg/kds/util/resource.go
+++ b/pkg/kds/util/resource.go
@@ -65,11 +65,17 @@ func AddSuffixToNames(rs []model.Resource, suffix string) {
 }
 
 func ZoneTag(r model.Resource) string {
-	dp := r.GetSpec().(*mesh_proto.Dataplane)
-	if dp.GetNetworking().GetGateway() != nil {
-		return dp.GetNetworking().GetGateway().GetTags()[mesh_proto.ZoneTag]
+	switch res := r.GetSpec().(type) {
+	case *mesh_proto.Dataplane:
+		if res.GetNetworking().GetGateway() != nil {
+			return res.GetNetworking().GetGateway().GetTags()[mesh_proto.ZoneTag]
+		}
+		return res.GetNetworking().GetInbound()[0].GetTags()[mesh_proto.ZoneTag]
+	case *mesh_proto.ZoneIngress:
+		return res.GetZone()
+	default:
+		return ""
 	}
-	return dp.GetNetworking().GetInbound()[0].GetTags()[mesh_proto.ZoneTag]
 }
 
 func toResources(resourceType model.ResourceType, krs []*mesh_proto.KumaResource) (model.ResourceList, error) {

--- a/test/e2e/deploy/kuma_deploy_universal.go
+++ b/test/e2e/deploy/kuma_deploy_universal.go
@@ -5,12 +5,12 @@ import (
 	"strings"
 
 	"github.com/gruntwork-io/terratest/modules/retry"
-	. "github.com/kumahq/kuma/test/e2e/trafficroute/testutil"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/pkg/errors"
 
 	"github.com/kumahq/kuma/pkg/config/core"
+	. "github.com/kumahq/kuma/test/e2e/trafficroute/testutil"
 	. "github.com/kumahq/kuma/test/framework"
 )
 


### PR DESCRIPTION
### Summary

A bug that didn't allow users to disable a zone.

### Full changelog

* add e2e test
* fix the bug

### Issues resolved

N/A

### Documentation

N/A

### Testing

- [ ] Unit tests
- [X] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes 

### Backwards compatibility

- [X] Add `backport-to-stable` label if the code is backwards compatible. Otherwise, list breaking changes.
