### PR TITLE
fix(kumactl) don't refer to a specific namespace in install cmd help

### DIFF
--- a/app/kumactl/cmd/install/install_control_plane.go
+++ b/app/kumactl/cmd/install/install_control_plane.go
@@ -21,7 +21,7 @@ func newInstallControlPlaneCmd(ctx *install_context.InstallCpContext) *cobra.Com
 	cmd := &cobra.Command{
 		Use:   "control-plane",
 		Short: "Install Kuma Control Plane on Kubernetes",
-		Long: `Install Kuma Control Plane on Kubernetes in a 'kuma-system' namespace.
+		Long: `Install Kuma Control Plane on Kubernetes in its own namespace.
 This command requires that the KUBECONFIG environment is set`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			if err := validateArgs(args); err != nil {

--- a/app/kumactl/cmd/install/install_demo.go
+++ b/app/kumactl/cmd/install/install_demo.go
@@ -20,7 +20,7 @@ func newInstallDemoCmd(ctx *install_context.InstallDemoContext) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "demo",
 		Short: "Install Kuma demo on Kubernetes",
-		Long:  "Install Kuma demo on Kubernetes in a 'kuma-demo' namespace.",
+		Long:  "Install Kuma demo on Kubernetes in its own namespace.",
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			if err := validateDemoArgs(args); err != nil {
 				return err

--- a/app/kumactl/cmd/install/install_gateway.go
+++ b/app/kumactl/cmd/install/install_gateway.go
@@ -10,7 +10,7 @@ func newInstallGatewayCmd(pctx *kumactl_cmd.RootContext) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "gateway",
 		Short: "Install ingress gateway on Kubernetes",
-		Long:  "Install ingress gateway on Kubernetes in a 'kuma-gateway' namespace.",
+		Long:  "Install ingress gateway on Kubernetes in its own namespace.",
 	}
 	// sub-commands
 	cmd.AddCommand(newInstallGatewayKongCmd(&pctx.InstallGatewayKongContext))

--- a/app/kumactl/cmd/install/install_gateway_kong.go
+++ b/app/kumactl/cmd/install/install_gateway_kong.go
@@ -15,7 +15,7 @@ func newInstallGatewayKongCmd(ctx *install_context.InstallGatewayKongContext) *c
 	cmd := &cobra.Command{
 		Use:   "kong",
 		Short: "Install Kong ingress gateway on Kubernetes",
-		Long:  "Install Kong ingress gateway on Kubernetes in a 'kuma-gateway' namespace.",
+		Long:  "Install Kong ingress gateway on Kubernetes in its own namespace.",
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			templateFiles, err := data.ReadFiles(kumactl_data.InstallGatewayKongFS())
 			if err != nil {

--- a/app/kumactl/cmd/install/install_gateway_kong_enterprise.go
+++ b/app/kumactl/cmd/install/install_gateway_kong_enterprise.go
@@ -22,7 +22,7 @@ func newInstallGatewayKongEnterpriseCmd(ctx *install_context.InstallGatewayKongE
 	cmd := &cobra.Command{
 		Use:   "kong-enterprise",
 		Short: "Install Kong ingress gateway on Kubernetes",
-		Long:  "Install Kong ingress gateway on Kubernetes in a 'kuma-gateway' namespace.",
+		Long:  "Install Kong ingress gateway on Kubernetes in its own namespace.",
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			templateFiles, err := data.ReadFiles(kumactl_data.InstallGatewayKongEnterpriseFS())
 			if err != nil {

--- a/app/kumactl/cmd/install/install_logging.go
+++ b/app/kumactl/cmd/install/install_logging.go
@@ -19,7 +19,7 @@ func newInstallLogging(pctx *kumactl_cmd.RootContext) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "logging",
 		Short: "Install Logging backend in Kubernetes cluster (Loki)",
-		Long:  `Install Logging backend in Kubernetes cluster (Loki) in a 'kuma-logging' namespace`,
+		Long:  `Install Logging backend in Kubernetes cluster (Loki) in its own namespace.`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			templateArgs := loggingTemplateArgs{
 				Namespace: args.Namespace,

--- a/app/kumactl/cmd/install/install_metrics.go
+++ b/app/kumactl/cmd/install/install_metrics.go
@@ -18,7 +18,7 @@ func newInstallMetrics(pctx *kumactl_cmd.RootContext) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "metrics",
 		Short: "Install Metrics backend in Kubernetes cluster (Prometheus + Grafana)",
-		Long:  `Install Metrics backend in Kubernetes cluster (Prometheus + Grafana) in a kuma-metrics namespace`,
+		Long:  `Install Metrics backend in Kubernetes cluster (Prometheus + Grafana) in its own namespace.`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			args.Mesh = pctx.Args.Mesh
 

--- a/app/kumactl/cmd/install/install_tracing.go
+++ b/app/kumactl/cmd/install/install_tracing.go
@@ -19,7 +19,7 @@ func newInstallTracing(pctx *kumactl_cmd.RootContext) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "tracing",
 		Short: "Install Tracing backend in Kubernetes cluster (Jaeger)",
-		Long:  `Install Tracing backend in Kubernetes cluster (Jaeger) in a 'kuma-tracing' namespace`,
+		Long:  `Install Tracing backend in Kubernetes cluster (Jaeger) in its own namespace.`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			templateArgs := tracingTemplateArgs{
 				Namespace: args.Namespace,

--- a/docs/cmd/kumactl/kumactl_install_control-plane.md
+++ b/docs/cmd/kumactl/kumactl_install_control-plane.md
@@ -4,7 +4,7 @@ Install Kuma Control Plane on Kubernetes
 
 ### Synopsis
 
-Install Kuma Control Plane on Kubernetes in a 'kuma-system' namespace.
+Install Kuma Control Plane on Kubernetes in its own namespace.
 This command requires that the KUBECONFIG environment is set
 
 ```

--- a/docs/cmd/kumactl/kumactl_install_demo.md
+++ b/docs/cmd/kumactl/kumactl_install_demo.md
@@ -4,7 +4,7 @@ Install Kuma demo on Kubernetes
 
 ### Synopsis
 
-Install Kuma demo on Kubernetes in a 'kuma-demo' namespace.
+Install Kuma demo on Kubernetes in its own namespace.
 
 ```
 kumactl install demo [flags]

--- a/docs/cmd/kumactl/kumactl_install_gateway.md
+++ b/docs/cmd/kumactl/kumactl_install_gateway.md
@@ -4,7 +4,7 @@ Install ingress gateway on Kubernetes
 
 ### Synopsis
 
-Install ingress gateway on Kubernetes in a 'kuma-gateway' namespace.
+Install ingress gateway on Kubernetes in its own namespace.
 
 ### Options
 

--- a/docs/cmd/kumactl/kumactl_install_gateway_kong-enterprise.md
+++ b/docs/cmd/kumactl/kumactl_install_gateway_kong-enterprise.md
@@ -4,7 +4,7 @@ Install Kong ingress gateway on Kubernetes
 
 ### Synopsis
 
-Install Kong ingress gateway on Kubernetes in a 'kuma-gateway' namespace.
+Install Kong ingress gateway on Kubernetes in its own namespace.
 
 ```
 kumactl install gateway kong-enterprise [flags]

--- a/docs/cmd/kumactl/kumactl_install_gateway_kong.md
+++ b/docs/cmd/kumactl/kumactl_install_gateway_kong.md
@@ -4,7 +4,7 @@ Install Kong ingress gateway on Kubernetes
 
 ### Synopsis
 
-Install Kong ingress gateway on Kubernetes in a 'kuma-gateway' namespace.
+Install Kong ingress gateway on Kubernetes in its own namespace.
 
 ```
 kumactl install gateway kong [flags]

--- a/docs/cmd/kumactl/kumactl_install_logging.md
+++ b/docs/cmd/kumactl/kumactl_install_logging.md
@@ -4,7 +4,7 @@ Install Logging backend in Kubernetes cluster (Loki)
 
 ### Synopsis
 
-Install Logging backend in Kubernetes cluster (Loki) in a 'kuma-logging' namespace
+Install Logging backend in Kubernetes cluster (Loki) in its own namespace.
 
 ```
 kumactl install logging [flags]

--- a/docs/cmd/kumactl/kumactl_install_metrics.md
+++ b/docs/cmd/kumactl/kumactl_install_metrics.md
@@ -4,7 +4,7 @@ Install Metrics backend in Kubernetes cluster (Prometheus + Grafana)
 
 ### Synopsis
 
-Install Metrics backend in Kubernetes cluster (Prometheus + Grafana) in a kuma-metrics namespace
+Install Metrics backend in Kubernetes cluster (Prometheus + Grafana) in its own namespace.
 
 ```
 kumactl install metrics [flags]

--- a/docs/cmd/kumactl/kumactl_install_tracing.md
+++ b/docs/cmd/kumactl/kumactl_install_tracing.md
@@ -4,7 +4,7 @@ Install Tracing backend in Kubernetes cluster (Jaeger)
 
 ### Synopsis
 
-Install Tracing backend in Kubernetes cluster (Jaeger) in a 'kuma-tracing' namespace
+Install Tracing backend in Kubernetes cluster (Jaeger) in its own namespace.
 
 ```
 kumactl install tracing [flags]


### PR DESCRIPTION
### Summary

Because it's configurable via a CLI switch.
