### PR TITLE
fix(dev_ubuntu): ensure sudo is available

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -119,6 +119,11 @@ commands:
           if [ -r /etc/os-release ]; then source /etc/os-release; fi
           case "$ID" in
           ubuntu)
+            if ! command -v sudo 2>&1 >/dev/null; then
+              apt update
+              apt install -y sudo
+            fi
+
             sudo apt update
             sudo env DEBIAN_FRONTEND=noninteractive apt install -y curl git make unzip gcc
             ;;


### PR DESCRIPTION
### Summary

This alters the circleci to ensure sudo is available for the dev_ubuntu-focussed pipeline.

### Full changelog

* Fix circleci config to ensure dev_ubuntu has sudo installed

### Testing

- [ ] Unit tests
- [ ] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes 

### Backwards compatibility
