### PR TITLE
chore(kuma-cp) check PEM certificate loading errors

### DIFF
--- a/pkg/api-server/server.go
+++ b/pkg/api-server/server.go
@@ -329,16 +329,18 @@ func configureMTLS(certsDir string) (*tls.Config, error) {
 				continue
 			}
 			if !strings.HasSuffix(file.Name(), ".pem") && !strings.HasSuffix(file.Name(), ".crt") {
-				log.Info("skipping file, all the client certificates has to have .pem or .crt extension", "file", file.Name())
+				log.Info("skipping file without .pem or .crt extension", "file", file.Name())
 				continue
 			}
 			log.Info("adding client certificate", "file", file.Name())
 			path := filepath.Join(certsDir, file.Name())
 			caCert, err := ioutil.ReadFile(path)
 			if err != nil {
-				return nil, errors.Wrapf(err, "could not read certificate %s", path)
+				return nil, errors.Wrapf(err, "could not read certificate %q", path)
 			}
-			clientCertPool.AppendCertsFromPEM(caCert)
+			if !clientCertPool.AppendCertsFromPEM(caCert) {
+				return nil, errors.Errorf("failed to load PEM client certificate from %q", path)
+			}
 		}
 		tlsConfig.ClientCAs = clientCertPool
 	}


### PR DESCRIPTION
### Summary

When loading certificates for the "clientCerts" authenticator, check
whether the certificate PEM object loads successfully.

### Full changelog

* `kuma-cp` now checks that PEM certificates in the "apiServer.auth.clientCertsDir" directory load correctly

### Issues resolved

N/A

### Documentation

N/A

### Testing

- [x] Unit tests
- [x] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes 

### Backwards compatibility

- [x] Add `backport-to-stable` label if the code is backwards compatible. Otherwise, list breaking changes.
