### PR TITLE
fix(kuma-cp) locality-aware lb for external-services

### DIFF
--- a/test/framework/deployments/externalservice/universal.go
+++ b/test/framework/deployments/externalservice/universal.go
@@ -1,6 +1,7 @@
 package externalservice
 
 import (
+	"fmt"
 	"strconv"
 
 	"github.com/gruntwork-io/terratest/modules/docker"
@@ -27,12 +28,17 @@ type universalDeployment struct {
 
 var _ Deployment = &universalDeployment{}
 
-var UniversalAppEchoServer = Command([]string{"ncat", "-lk", "-p", "80", "--sh-exec", "'echo \"HTTP/1.1 200 OK\n\n Echo 80\n\"'"})
-var UniversalAppEchoServer81 = Command([]string{"ncat", "-lk", "-p", "81", "--sh-exec", "'echo \"HTTP/1.1 200 OK\n\n Echo 81\n\"'"})
+var UniversalAppEchoServer = ExternalServiceCommand(80, "Echo 80")
+var UniversalAppEchoServer81 = ExternalServiceCommand(81, "Echo 81")
 var UniversalAppHttpsEchoServer = Command([]string{"ncat",
 	"-lk", "-p", "443",
 	"--ssl", "--ssl-cert", "/server-cert.pem", "--ssl-key", "/server-key.pem",
 	"--sh-exec", "'echo \"HTTP/1.1 200 OK\n\n HTTPS Echo\n\"'"})
+
+var ExternalServiceCommand = func(port uint32, message string) Command {
+	return []string{"ncat", "-lk", "-p", fmt.Sprintf("%d", port), "--sh-exec",
+		fmt.Sprintf("'echo \"HTTP/1.1 200 OK\n\n%s\n\"'", message)}
+}
 
 func (u *universalDeployment) Name() string {
 	return DeploymentName + u.name


### PR DESCRIPTION
### Summary

If locality-aware load balancing is enabled, we should respect `kuma.io/zone` tags on external services.

### Full changelog

* add e2e test
* set different priorities depending on `kuma.io/zone`

### Issues resolved

N/A

### Documentation

- [ ] Link to the website [documentation PR](https://github.com/kumahq/kuma-website/pull/XXX)

### Testing

- [X] Unit tests
- [X] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes 

### Backwards compatibility

- [X] Add `backport-to-stable` label if the code is backwards compatible. Otherwise, list breaking changes.
