### PR TITLE
fix(ci) preserve existing PATH in CircleCI tasks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -133,7 +133,7 @@ commands:
         # See https://golang.org/doc/install#tarball
         command: |
           curl --progress-bar --fail --location https://dl.google.com/go/go<<parameters.go_version>>.<<parameters.go_os>>-<<parameters.go_arch>>.tar.gz | tar -xz -C $HOME
-          echo "export PATH=$HOME/go/bin:$PATH" >> $BASH_ENV
+          echo 'export PATH=$HOME/go/bin:$PATH' >> $BASH_ENV
 
 executors:
   golang:
@@ -207,8 +207,8 @@ jobs:
     - run:
         name: "Setup Environment"
         command: |
-          echo "export PATH=$HOME/.local/bin:$PATH" >> $BASH_ENV
-          echo "export PATH=$HOME/bin:$PATH" >> $BASH_ENV
+          echo 'export PATH=$HOME/.local/bin:$PATH' >> $BASH_ENV
+          echo 'export PATH=$HOME/bin:$PATH' >> $BASH_ENV
           echo "export TAG=${CIRCLE_SHA1:0:7}" >> $BASH_ENV
           echo "export CLUSTER_1=<< parameters.prefix >>-${CIRCLE_SHA1:0:7}-1" >> $BASH_ENV
           echo "export CLUSTER_2=<< parameters.prefix >>-${CIRCLE_SHA1:0:7}-2" >> $BASH_ENV
@@ -423,8 +423,8 @@ jobs:
     - run:
         name: "Setup Environment"
         command: |
-          echo "export PATH=$HOME/.local/bin:$PATH" >> $BASH_ENV
-          echo "export PATH=$HOME/bin:$PATH" >> $BASH_ENV
+          echo 'export PATH=$HOME/.local/bin:$PATH' >> $BASH_ENV
+          echo 'export PATH=$HOME/bin:$PATH' >> $BASH_ENV
           echo "export TAG=${CIRCLE_SHA1:0:7}" >> $BASH_ENV
           echo "export CLUSTER_1=<< parameters.prefix >>-${CIRCLE_SHA1:0:7}-1" >> $BASH_ENV
           echo "export CLUSTER_2=<< parameters.prefix >>-${CIRCLE_SHA1:0:7}-2" >> $BASH_ENV


### PR DESCRIPTION
### Summary

We use "$BASH_ENV" to prepend to "$PATH", since "$BASH_ENV" works like
bashrc and is the recommended way to adjust the path across tasks in
CircleCI.
    
However, every bash execution will source "$BASH_ENV", so we need to
make sure that we are quoting properly. We want to update "$PATH", not
to reset it to a value that we sampled earlier in the CI workflow. This
particularly matters in the Makefile targets, that assume path
modifications with a Makefile actually work.

### Full changelog

N/A

### Issues resolved

Updates #2911.

### Documentation

N/A

### Testing

- [x] Unit tests
- [x] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes 

### Backwards compatibility

- [x] Add `backport-to-stable` label if the code is backwards compatible. Otherwise, list breaking changes.
