### PR TITLE
fix(tests) make kic test configurable

### DIFF
--- a/test/e2e/kic/kubernetes/kong_ingress.go
+++ b/test/e2e/kic/kubernetes/kong_ingress.go
@@ -131,7 +131,7 @@ metadata:
 		Expect(kubernetes.DismissCluster()).To(Succeed())
 	})
 	It("should install kong ingress into default namespace", func() {
-		ingressNamespace = kic.DefaultIngressNamespace
+		ingressNamespace = DefaultGatewayNamespace
 		// given kong ingress
 		err := NewClusterSetup().
 			Install(kic.KongIngressController()).

--- a/test/framework/constants.go
+++ b/test/framework/constants.go
@@ -53,6 +53,7 @@ var KumaNamespace = "kuma-system"
 var KumaServiceName = "kuma-control-plane"
 var KumaGlobalZoneSyncServiceName = "kuma-global-zone-sync"
 var DefaultTracingNamespace = "kuma-tracing"
+var DefaultGatewayNamespace = "kuma-gateway"
 
 var CNIApp = "kuma-cni"
 var CNINamespace = "kube-system"

--- a/test/framework/deployments/kic/deployment.go
+++ b/test/framework/deployments/kic/deployment.go
@@ -68,7 +68,7 @@ func KongIngressNodePort(fs ...deployOptionsFunc) framework.InstallFunc {
 	proxy_ssl_port := NodePortHTTPS()
 	opts := newDeployOpt(fs...)
 	if opts.namespace == "" {
-		opts.namespace = DefaultIngressNamespace
+		opts.namespace = framework.DefaultGatewayNamespace
 	}
 	nodeport := `
 apiVersion: v1

--- a/test/framework/deployments/kic/kubernetes.go
+++ b/test/framework/deployments/kic/kubernetes.go
@@ -16,13 +16,11 @@ type k8sDeployment struct {
 	ingressNamespace string
 }
 
-var DefaultIngressNamespace = "kuma-gateway"
 var DefaultNodePortHTTP = 30080
 var DefaultNodePortHTTPS = 30443
 
-var _ Deployment = &k8sDeployment{
-	DefaultIngressNamespace,
-}
+var _ Deployment = &k8sDeployment{}
+
 var ingressApp = "ingress-kong"
 
 func NodePortHTTP() int {
@@ -64,7 +62,7 @@ func (t *k8sDeployment) Deploy(cluster framework.Cluster) error {
 	var err error
 	if t.ingressNamespace == "" {
 		yaml, err = cluster.GetKumactlOptions().RunKumactlAndGetOutputV(framework.Verbose, "install", "gateway", "kong")
-		t.ingressNamespace = DefaultIngressNamespace
+		t.ingressNamespace = framework.DefaultGatewayNamespace
 	} else {
 		yaml, err = cluster.GetKumactlOptions().RunKumactlAndGetOutputV(framework.Verbose, "install", "gateway", "kong", "--namespace", t.ingressNamespace)
 	}


### PR DESCRIPTION
### Summary

Enable setting the expected default namespace when running these tests.