### PR TITLE
feat(kuma-cp) user token enabled by default

### DIFF
--- a/pkg/api-server/auth_test.go
+++ b/pkg/api-server/auth_test.go
@@ -12,6 +12,7 @@ import (
 
 	config "github.com/kumahq/kuma/pkg/config/api-server"
 	"github.com/kumahq/kuma/pkg/metrics"
+	"github.com/kumahq/kuma/pkg/plugins/authn/api-server/certs"
 	"github.com/kumahq/kuma/pkg/plugins/resources/memory"
 	"github.com/kumahq/kuma/pkg/tls"
 	http2 "github.com/kumahq/kuma/pkg/util/http"
@@ -38,6 +39,7 @@ var _ = Describe("Auth test", func() {
 		cfg := config.DefaultApiServerConfig()
 		cfg.HTTPS.TlsCertFile = certPath
 		cfg.HTTPS.TlsKeyFile = keyPath
+		cfg.Authn.Type = certs.PluginName
 		cfg.Auth.ClientCertsDir = filepath.Join("..", "..", "test", "certs", "client")
 		apiServer := createTestApiServer(resourceStore, cfg, true, metrics)
 		httpsPort = cfg.HTTPS.Port

--- a/pkg/api-server/config_ws_test.go
+++ b/pkg/api-server/config_ws_test.go
@@ -56,7 +56,7 @@ var _ = Describe("Config WS", func() {
 			},
 			"authn": {
 			  "localhostIsAdmin": true,
-			  "type": "clientCerts",
+			  "type": "tokens",
 			  "tokens": {
 			    "bootstrapAdminToken": true
 			  }

--- a/pkg/api-server/server.go
+++ b/pkg/api-server/server.go
@@ -33,6 +33,7 @@ import (
 	"github.com/kumahq/kuma/pkg/core/resources/registry"
 	"github.com/kumahq/kuma/pkg/core/runtime"
 	"github.com/kumahq/kuma/pkg/metrics"
+	"github.com/kumahq/kuma/pkg/plugins/authn/api-server/certs"
 	"github.com/kumahq/kuma/pkg/tokens/builtin"
 	tokens_rbac "github.com/kumahq/kuma/pkg/tokens/builtin/rbac"
 	tokens_server "github.com/kumahq/kuma/pkg/tokens/builtin/server"
@@ -281,7 +282,7 @@ func (a *ApiServer) startHttpServer(errChan chan error) *http.Server {
 
 func (a *ApiServer) startHttpsServer(errChan chan error) *http.Server {
 	var tlsConfig *tls.Config
-	if a.config.Authn.Type == "clientCerts" {
+	if a.config.Authn.Type == certs.PluginName {
 		tlsC, err := configureMTLS(a.config.Auth.ClientCertsDir)
 		if err != nil {
 			errChan <- err

--- a/pkg/config/api-server/config.go
+++ b/pkg/config/api-server/config.go
@@ -125,7 +125,7 @@ func DefaultApiServerConfig() *ApiServerConfig {
 			ClientCertsDir: "",
 		},
 		Authn: ApiServerAuthn{
-			Type:             "clientCerts",
+			Type:             "tokens",
 			LocalhostIsAdmin: true,
 			Tokens: ApiServerAuthnTokens{
 				BootstrapAdminToken: true,

--- a/pkg/config/app/kuma-cp/kuma-cp.defaults.yaml
+++ b/pkg/config/app/kuma-cp/kuma-cp.defaults.yaml
@@ -134,8 +134,8 @@ apiServer:
     clientCertsDir: "" # ENV: KUMA_API_SERVER_AUTH_CLIENT_CERTS_DIR
   # Api Server Authentication configuration
   authn:
-    # Type of authentication mechanism (available values: "clientCerts")
-    type: clientCerts # ENV: KUMA_API_SERVER_AUTHN_TYPE
+    # Type of authentication mechanism (available values: "adminClientCerts", "tokens")
+    type: tokens # ENV: KUMA_API_SERVER_AUTHN_TYPE
     # Localhost is authenticated as a user admin of group admin
     localhostIsAdmin: true # ENV: KUMA_API_SERVER_AUTHN_LOCALHOST_IS_ADMIN
     # Configuration for tokens authentication

--- a/pkg/plugins/authn/api-server/certs/authenticator.go
+++ b/pkg/plugins/authn/api-server/certs/authenticator.go
@@ -6,6 +6,7 @@ import (
 	"github.com/kumahq/kuma/pkg/core/user"
 )
 
+// backwards compatibility with Kuma 1.3.x
 func ClientCertAuthenticator(request *restful.Request, response *restful.Response, chain *restful.FilterChain) {
 	if user.FromCtx(request.Request.Context()) == nil && // do not overwrite existing user
 		request.Request.TLS != nil &&

--- a/pkg/plugins/authn/api-server/certs/plugin.go
+++ b/pkg/plugins/authn/api-server/certs/plugin.go
@@ -2,10 +2,13 @@ package certs
 
 import (
 	"github.com/kumahq/kuma/pkg/api-server/authn"
+	"github.com/kumahq/kuma/pkg/core"
 	"github.com/kumahq/kuma/pkg/core/plugins"
 )
 
-const PluginName = "clientCerts"
+const PluginName = "adminClientCerts"
+
+var log = core.Log.WithName("plugins").WithName("authn").WithName("api-server").WithName("certs")
 
 type plugin struct {
 }
@@ -17,5 +20,6 @@ func init() {
 var _ plugins.AuthnAPIServerPlugin = plugin{}
 
 func (c plugin) NewAuthenticator(_ plugins.PluginContext) (authn.Authenticator, error) {
+	log.Info("WARNING: admin client certificates are deprecated. Please migrate to user token as API Server authentication mechanism.")
 	return ClientCertAuthenticator, nil
 }

--- a/tools/e2e/examples/docker-compose/docker-compose.yaml
+++ b/tools/e2e/examples/docker-compose/docker-compose.yaml
@@ -18,6 +18,7 @@ services:
     # DNS name of the Kuma xDS server
     - KUMA_GENERAL_TLS_CERT_FILE=/certs/server/cert.pem
     - KUMA_GENERAL_TLS_KEY_FILE=/certs/server/key.pem
+    - KUMA_API_SERVER_AUTHN_TYPE=adminClientCerts
     - KUMA_API_SERVER_AUTH_CLIENT_CERTS_DIR=/certs/client
     expose:
     - "5678"


### PR DESCRIPTION
### Summary

Change user token to be default authn mechanism

### Full changelog

* User token authenticator by default
* Deprecate admin client certs
* Change `clientCerts` to `adminClientCerts`

### Documentation

- [X] https://github.com/kumahq/kuma-website/pull/554

### Testing

- [X] Unit tests
- [X] E2E tests
- [X] Manual testing on Universal
- [ ] Manual testing on Kubernetes 

### Backwards compatibility

- [X] No backporting.
