### PR TITLE
chore(ci) split e2e deployment options

### DIFF
--- a/test/e2e/auth/auth_universal.go
+++ b/test/e2e/auth/auth_universal.go
@@ -10,7 +10,7 @@ import (
 
 func AuthUniversal() {
 	var cluster Cluster
-	var deployOptsFuncs []DeployOptionsFunc
+	var deployOptsFuncs []KumaDeploymentOption
 
 	BeforeEach(func() {
 		cluster = NewUniversalCluster(NewTestingT(), Kuma3, Silent)

--- a/test/e2e/compatibility/dp_compatibility_universal.go
+++ b/test/e2e/compatibility/dp_compatibility_universal.go
@@ -11,7 +11,7 @@ import (
 
 func UniversalCompatibility() {
 	var cluster Cluster
-	var deployOptsFuncs []DeployOptionsFunc
+	var deployOptsFuncs []KumaDeploymentOption
 
 	BeforeEach(func() {
 		cluster = NewUniversalCluster(NewTestingT(), Kuma3, Silent)

--- a/test/e2e/deploy/kuma_deploy_universal_transparent_proxy.go
+++ b/test/e2e/deploy/kuma_deploy_universal_transparent_proxy.go
@@ -14,7 +14,7 @@ import (
 
 func UniversalTransparentProxyDeployment() {
 	var cluster Cluster
-	var deployOptsFuncs []DeployOptionsFunc
+	var deployOptsFuncs []KumaDeploymentOption
 
 	BeforeEach(func() {
 		cluster = NewUniversalCluster(NewTestingT(), Kuma3, Silent)

--- a/test/e2e/externalservices/externalservices_hostheader.go
+++ b/test/e2e/externalservices/externalservices_hostheader.go
@@ -12,7 +12,6 @@ import (
 
 func ExternalServiceHostHeader() {
 	var cluster Cluster
-	var deployOptsFuncs []DeployOptionsFunc
 
 	externalService := `
 type: ExternalService
@@ -29,10 +28,9 @@ networking:
 
 	BeforeEach(func() {
 		cluster = NewUniversalCluster(NewTestingT(), Kuma3, Silent)
-		deployOptsFuncs = KumaUniversalDeployOpts
 
 		err := NewClusterSetup().
-			Install(Kuma(core.Standalone, deployOptsFuncs...)).
+			Install(Kuma(core.Standalone, KumaUniversalDeployOpts...)).
 			Install(YamlUniversal(externalService)).
 			Setup(cluster)
 		Expect(err).ToNot(HaveOccurred())
@@ -51,7 +49,7 @@ networking:
 		if ShouldSkipCleanup() {
 			return
 		}
-		Expect(cluster.DeleteKuma(deployOptsFuncs...)).To(Succeed())
+		Expect(cluster.DeleteKuma(KumaUniversalDeployOpts...)).To(Succeed())
 		Expect(cluster.DismissCluster()).To(Succeed())
 	})
 

--- a/test/e2e/externalservices/externalservices_universal.go
+++ b/test/e2e/externalservices/externalservices_universal.go
@@ -44,7 +44,6 @@ networking:
 	es2 := "2"
 
 	var cluster Cluster
-	var deployOptsFuncs []DeployOptionsFunc
 
 	BeforeEach(func() {
 		clusters, err := NewUniversalClusters(
@@ -54,10 +53,9 @@ networking:
 
 		// Global
 		cluster = clusters.GetCluster(Kuma3)
-		deployOptsFuncs = KumaUniversalDeployOpts
 
 		err = NewClusterSetup().
-			Install(Kuma(core.Standalone, deployOptsFuncs...)).
+			Install(Kuma(core.Standalone, KumaUniversalDeployOpts...)).
 			Setup(cluster)
 		Expect(err).ToNot(HaveOccurred())
 		err = cluster.VerifyKuma()
@@ -82,7 +80,7 @@ networking:
 		if ShouldSkipCleanup() {
 			return
 		}
-		err := cluster.DeleteKuma(deployOptsFuncs...)
+		err := cluster.DeleteKuma(KumaUniversalDeployOpts...)
 		Expect(err).ToNot(HaveOccurred())
 
 		err = cluster.DismissCluster()

--- a/test/e2e/healthcheck/universal/panic.go
+++ b/test/e2e/healthcheck/universal/panic.go
@@ -13,7 +13,6 @@ import (
 
 func HealthCheckPanicThreshold() {
 	var universalCluster Cluster
-	var deployOptsFuncs []DeployOptionsFunc
 
 	healthCheck := `
 type: HealthCheck
@@ -51,10 +50,9 @@ networking:
 
 	BeforeEach(func() {
 		universalCluster = NewUniversalCluster(NewTestingT(), Kuma3, Silent)
-		deployOptsFuncs = KumaUniversalDeployOpts
 
 		err := NewClusterSetup().
-			Install(Kuma(core.Standalone, deployOptsFuncs...)).
+			Install(Kuma(core.Standalone, KumaUniversalDeployOpts...)).
 			Install(YamlUniversal(healthCheck)).
 			Setup(universalCluster)
 		Expect(err).ToNot(HaveOccurred())
@@ -85,7 +83,7 @@ networking:
 		if ShouldSkipCleanup() {
 			return
 		}
-		Expect(universalCluster.DeleteKuma(deployOptsFuncs...)).To(Succeed())
+		Expect(universalCluster.DeleteKuma(KumaUniversalDeployOpts...)).To(Succeed())
 		Expect(universalCluster.DismissCluster()).To(Succeed())
 	})
 

--- a/test/e2e/healthcheck/universal/policy_http.go
+++ b/test/e2e/healthcheck/universal/policy_http.go
@@ -39,14 +39,12 @@ conf:
 	}
 
 	var cluster Cluster
-	var deployOptsFuncs []DeployOptionsFunc
 
 	BeforeEach(func() {
 		cluster = NewUniversalCluster(NewTestingT(), Kuma3, Verbose)
-		deployOptsFuncs = KumaUniversalDeployOpts
 
 		err := NewClusterSetup().
-			Install(Kuma(config_core.Standalone, deployOptsFuncs...)).
+			Install(Kuma(config_core.Standalone, KumaUniversalDeployOpts...)).
 			Install(YamlUniversal(healthCheck("health", "200"))).
 			Setup(cluster)
 		Expect(err).ToNot(HaveOccurred())
@@ -69,7 +67,7 @@ conf:
 		if ShouldSkipCleanup() {
 			return
 		}
-		Expect(cluster.DeleteKuma(deployOptsFuncs...)).To(Succeed())
+		Expect(cluster.DeleteKuma(KumaUniversalDeployOpts...)).To(Succeed())
 		Expect(cluster.DismissCluster()).To(Succeed())
 	})
 

--- a/test/e2e/healthcheck/universal/policy_tcp.go
+++ b/test/e2e/healthcheck/universal/policy_tcp.go
@@ -43,14 +43,12 @@ conf:
 	}
 
 	var cluster Cluster
-	var deployOptsFuncs []DeployOptionsFunc
 
 	BeforeEach(func() {
 		cluster = NewUniversalCluster(NewTestingT(), Kuma3, Verbose)
-		deployOptsFuncs = KumaUniversalDeployOpts
 
 		err := NewClusterSetup().
-			Install(Kuma(config_core.Standalone, deployOptsFuncs...)).
+			Install(Kuma(config_core.Standalone, KumaUniversalDeployOpts...)).
 			Install(YamlUniversal(healthCheck("foo", "bar"))).
 			Setup(cluster)
 		Expect(err).ToNot(HaveOccurred())
@@ -75,7 +73,7 @@ conf:
 		if ShouldSkipCleanup() {
 			return
 		}
-		Expect(cluster.DeleteKuma(deployOptsFuncs...)).To(Succeed())
+		Expect(cluster.DeleteKuma(KumaUniversalDeployOpts...)).To(Succeed())
 		Expect(cluster.DismissCluster()).To(Succeed())
 	})
 

--- a/test/e2e/healthcheck/universal/service_probes.go
+++ b/test/e2e/healthcheck/universal/service_probes.go
@@ -10,14 +10,12 @@ import (
 
 func ServiceProbes() {
 	var cluster Cluster
-	var deployOptsFuncs []DeployOptionsFunc
 
 	BeforeEach(func() {
 		cluster = NewUniversalCluster(NewTestingT(), Kuma3, Silent)
-		deployOptsFuncs = KumaUniversalDeployOpts
 
 		err := NewClusterSetup().
-			Install(Kuma(core.Standalone, deployOptsFuncs...)).
+			Install(Kuma(core.Standalone, KumaUniversalDeployOpts...)).
 			Setup(cluster)
 		Expect(err).ToNot(HaveOccurred())
 		err = cluster.VerifyKuma()
@@ -41,7 +39,7 @@ func ServiceProbes() {
 		if ShouldSkipCleanup() {
 			return
 		}
-		Expect(cluster.DeleteKuma(deployOptsFuncs...)).To(Succeed())
+		Expect(cluster.DeleteKuma(KumaUniversalDeployOpts...)).To(Succeed())
 		Expect(cluster.DismissCluster()).To(Succeed())
 	})
 

--- a/test/e2e/mtls/universal/mtls_backends.go
+++ b/test/e2e/mtls/universal/mtls_backends.go
@@ -11,14 +11,12 @@ import (
 
 func MTLSUniversal() {
 	var universalCluster Cluster
-	var deployOptsFuncs []DeployOptionsFunc
 
 	E2EBeforeSuite(func() {
 		universalCluster = NewUniversalCluster(NewTestingT(), Kuma1, Silent)
-		deployOptsFuncs = KumaUniversalDeployOpts
 
 		err := NewClusterSetup().
-			Install(Kuma(config_core.Standalone, deployOptsFuncs...)).
+			Install(Kuma(config_core.Standalone, KumaUniversalDeployOpts...)).
 			Setup(universalCluster)
 		Expect(err).ToNot(HaveOccurred())
 		err = universalCluster.VerifyKuma()
@@ -53,7 +51,7 @@ name: default`
 	})
 
 	E2EAfterSuite(func() {
-		Expect(universalCluster.DeleteKuma(deployOptsFuncs...)).To(Succeed())
+		Expect(universalCluster.DeleteKuma(KumaUniversalDeployOpts...)).To(Succeed())
 		Expect(universalCluster.DismissCluster()).To(Succeed())
 	})
 

--- a/test/e2e/ratelimit/ratelimit_universal.go
+++ b/test/e2e/ratelimit/ratelimit_universal.go
@@ -11,7 +11,6 @@ import (
 
 func RateLimitOnUniversal() {
 	var cluster Cluster
-	var deployOptsFuncs []DeployOptionsFunc
 	rateLimitPolicy := `
 type: RateLimit
 mesh: default
@@ -41,10 +40,9 @@ conf:
 
 		// Global
 		cluster = clusters.GetCluster(Kuma3)
-		deployOptsFuncs = KumaUniversalDeployOpts
 
 		err = NewClusterSetup().
-			Install(Kuma(core.Standalone, deployOptsFuncs...)).
+			Install(Kuma(core.Standalone, KumaUniversalDeployOpts...)).
 			Setup(cluster)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -76,7 +74,7 @@ conf:
 		if ShouldSkipCleanup() {
 			return
 		}
-		err := cluster.DeleteKuma(deployOptsFuncs...)
+		err := cluster.DeleteKuma(KumaUniversalDeployOpts...)
 		Expect(err).ToNot(HaveOccurred())
 
 		err = cluster.DismissCluster()

--- a/test/e2e/resilience/leader_election_postgres.go
+++ b/test/e2e/resilience/leader_election_postgres.go
@@ -11,7 +11,7 @@ import (
 
 func LeaderElectionPostgres() {
 	var standalone1, standalone2 Cluster
-	var standalone1Opts, standalone2Opts []DeployOptionsFunc
+	var standalone1Opts, standalone2Opts []KumaDeploymentOption
 
 	BeforeEach(func() {
 		clusters, err := NewUniversalClusters(

--- a/test/e2e/resilience/resilience_multizone_universal_postgres.go
+++ b/test/e2e/resilience/resilience_multizone_universal_postgres.go
@@ -13,7 +13,7 @@ import (
 
 func ResilienceMultizoneUniversalPostgres() {
 	var global, zoneUniversal Cluster
-	var optsGlobal, optsZone1 []DeployOptionsFunc
+	var optsGlobal, optsZone1 []KumaDeploymentOption
 
 	BeforeEach(func() {
 		clusters, err := NewUniversalClusters(
@@ -23,14 +23,14 @@ func ResilienceMultizoneUniversalPostgres() {
 
 		// Global
 		global = clusters.GetCluster(Kuma1)
-		optsGlobal = []DeployOptionsFunc{}
+		optsGlobal = []KumaDeploymentOption{}
 
 		err = NewClusterSetup().
 			Install(postgres.Install(Kuma1)).
 			Setup(global)
 		Expect(err).ToNot(HaveOccurred())
 
-		optsGlobal = []DeployOptionsFunc{
+		optsGlobal = []KumaDeploymentOption{
 			WithPostgres(postgres.From(global, Kuma1).GetEnvVars()),
 			WithEnv("KUMA_METRICS_ZONE_IDLE_TIMEOUT", "10s"),
 		}
@@ -52,7 +52,7 @@ func ResilienceMultizoneUniversalPostgres() {
 			Setup(zoneUniversal)
 		Expect(err).ToNot(HaveOccurred())
 
-		optsZone1 = []DeployOptionsFunc{
+		optsZone1 = []KumaDeploymentOption{
 			WithGlobalAddress(globalCP.GetKDSServerAddress()),
 			WithPostgres(postgres.From(zoneUniversal, Kuma2).GetEnvVars()),
 			WithEnv("KUMA_METRICS_DATAPLANE_IDLE_TIMEOUT", "10s"),

--- a/test/e2e/resilience/resilience_standalone_universal.go
+++ b/test/e2e/resilience/resilience_standalone_universal.go
@@ -24,7 +24,7 @@ func ResilienceStandaloneUniversal() {
 			Setup(universal)
 		Expect(err).ToNot(HaveOccurred())
 
-		optsUniversal = []DeployOptionsFunc{
+		optsUniversal = []KumaDeploymentOption{
 			WithPostgres(postgres.From(universal, Kuma1).GetEnvVars()),
 			WithEnv("KUMA_METRICS_DATAPLANE_IDLE_TIMEOUT", "10s"),
 		}

--- a/test/e2e/retry/retry_universal.go
+++ b/test/e2e/retry/retry_universal.go
@@ -15,7 +15,6 @@ import (
 
 func RetryOnUniversal() {
 	var cluster Cluster
-	var deployOptsFuncs []DeployOptionsFunc
 
 	BeforeEach(func() {
 		clusters, err := NewUniversalClusters(
@@ -25,10 +24,9 @@ func RetryOnUniversal() {
 
 		// Global
 		cluster = clusters.GetCluster(Kuma3)
-		deployOptsFuncs = KumaUniversalDeployOpts
 
 		err = NewClusterSetup().
-			Install(Kuma(core.Standalone, deployOptsFuncs...)).
+			Install(Kuma(core.Standalone, KumaUniversalDeployOpts...)).
 			Setup(cluster)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -55,7 +53,7 @@ func RetryOnUniversal() {
 		if ShouldSkipCleanup() {
 			return
 		}
-		err := cluster.DeleteKuma(deployOptsFuncs...)
+		err := cluster.DeleteKuma(KumaUniversalDeployOpts...)
 		Expect(err).ToNot(HaveOccurred())
 
 		err = cluster.DismissCluster()

--- a/test/e2e/timeout/timeout_universal.go
+++ b/test/e2e/timeout/timeout_universal.go
@@ -13,7 +13,6 @@ import (
 
 func TimeoutPolicyOnUniversal() {
 	var universalCluster Cluster
-	var deployOptsFuncs []DeployOptionsFunc
 
 	faultInjection := `
 type: FaultInjection
@@ -50,10 +49,9 @@ conf:
 
 	BeforeEach(func() {
 		universalCluster = NewUniversalCluster(NewTestingT(), Kuma3, Silent)
-		deployOptsFuncs = KumaUniversalDeployOpts
 
 		err := NewClusterSetup().
-			Install(Kuma(core.Standalone, deployOptsFuncs...)).
+			Install(Kuma(core.Standalone, KumaUniversalDeployOpts...)).
 			Install(YamlUniversal(faultInjection)).
 			Setup(universalCluster)
 		Expect(err).ToNot(HaveOccurred())
@@ -76,7 +74,7 @@ conf:
 		if ShouldSkipCleanup() {
 			return
 		}
-		Expect(universalCluster.DeleteKuma(deployOptsFuncs...)).To(Succeed())
+		Expect(universalCluster.DeleteKuma(KumaUniversalDeployOpts...)).To(Succeed())
 		Expect(universalCluster.DismissCluster()).To(Succeed())
 	})
 

--- a/test/e2e/tracing/tracing_universal.go
+++ b/test/e2e/tracing/tracing_universal.go
@@ -39,14 +39,12 @@ selectors:
 `
 
 	var cluster Cluster
-	var deployOptsFuncs []DeployOptionsFunc
 
 	BeforeEach(func() {
 		cluster = NewUniversalCluster(NewTestingT(), Kuma3, Silent)
-		deployOptsFuncs = KumaUniversalDeployOpts
 
 		err := NewClusterSetup().
-			Install(Kuma(core.Standalone, deployOptsFuncs...)).
+			Install(Kuma(core.Standalone, KumaUniversalDeployOpts...)).
 			Install(tracing.Install()).
 			Setup(cluster)
 		Expect(err).ToNot(HaveOccurred())
@@ -68,7 +66,7 @@ selectors:
 		if ShouldSkipCleanup() {
 			return
 		}
-		Expect(cluster.DeleteKuma(deployOptsFuncs...)).To(Succeed())
+		Expect(cluster.DeleteKuma(KumaUniversalDeployOpts...)).To(Succeed())
 		Expect(cluster.DismissCluster()).To(Succeed())
 	})
 

--- a/test/e2e/trafficpermission/universal/traffic_permission_universal.go
+++ b/test/e2e/trafficpermission/universal/traffic_permission_universal.go
@@ -10,7 +10,6 @@ import (
 
 func TrafficPermissionUniversal() {
 	var universalCluster Cluster
-	var deployOptsFuncs []DeployOptionsFunc
 
 	meshDefaulMtlsOn := `
 type: Mesh
@@ -24,10 +23,9 @@ mtls:
 
 	E2EBeforeSuite(func() {
 		universalCluster = NewUniversalCluster(NewTestingT(), Kuma1, Silent)
-		deployOptsFuncs = KumaUniversalDeployOpts
 
 		err := NewClusterSetup().
-			Install(Kuma(config_core.Standalone, deployOptsFuncs...)).
+			Install(Kuma(config_core.Standalone, KumaUniversalDeployOpts...)).
 			Install(YamlUniversal(meshDefaulMtlsOn)).
 			Setup(universalCluster)
 		Expect(err).ToNot(HaveOccurred())
@@ -77,7 +75,7 @@ destinations:
 	})
 
 	E2EAfterSuite(func() {
-		Expect(universalCluster.DeleteKuma(deployOptsFuncs...)).To(Succeed())
+		Expect(universalCluster.DeleteKuma(KumaUniversalDeployOpts...)).To(Succeed())
 		Expect(universalCluster.DismissCluster()).To(Succeed())
 	})
 

--- a/test/e2e/virtualoutbound/virtualoutbound_universal.go
+++ b/test/e2e/virtualoutbound/virtualoutbound_universal.go
@@ -12,7 +12,6 @@ import (
 
 func VirtualOutboundOnUniversal() {
 	var cluster Cluster
-	var deployOptsFuncs []DeployOptionsFunc
 
 	BeforeEach(func() {
 		clusters, err := NewUniversalClusters(
@@ -22,10 +21,9 @@ func VirtualOutboundOnUniversal() {
 
 		// Global
 		cluster = clusters.GetCluster(Kuma3)
-		deployOptsFuncs = KumaUniversalDeployOpts
 
 		err = NewClusterSetup().
-			Install(Kuma(core.Standalone, deployOptsFuncs...)).
+			Install(Kuma(core.Standalone, KumaUniversalDeployOpts...)).
 			Setup(cluster)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -53,7 +51,7 @@ func VirtualOutboundOnUniversal() {
 		if ShouldSkipCleanup() {
 			return
 		}
-		err := cluster.DeleteKuma(deployOptsFuncs...)
+		err := cluster.DeleteKuma(KumaUniversalDeployOpts...)
 		Expect(err).ToNot(HaveOccurred())
 
 		err = cluster.DismissCluster()

--- a/test/framework/constants.go
+++ b/test/framework/constants.go
@@ -63,6 +63,6 @@ var KumaCPImageRepo = "kuma-cp"
 var KumaDPImageRepo = "kuma-dp"
 var KumaInitImageRepo = "kuma-init"
 
-var KumaUniversalDeployOpts []DeployOptionsFunc
-var KumaK8sDeployOpts []DeployOptionsFunc
-var KumaZoneK8sDeployOpts []DeployOptionsFunc
+var KumaUniversalDeployOpts []KumaDeploymentOption
+var KumaK8sDeployOpts []KumaDeploymentOption
+var KumaZoneK8sDeployOpts []KumaDeploymentOption

--- a/test/framework/k8s_clusters.go
+++ b/test/framework/k8s_clusters.go
@@ -8,6 +8,8 @@ import (
 	"github.com/gruntwork-io/terratest/modules/k8s"
 	"github.com/gruntwork-io/terratest/modules/testing"
 	"github.com/pkg/errors"
+
+	"github.com/kumahq/kuma/pkg/config/core"
 )
 
 type K8sClusters struct {
@@ -15,6 +17,8 @@ type K8sClusters struct {
 	clusters map[string]*K8sCluster
 	verbose  bool
 }
+
+var _ Clusters = &K8sClusters{}
 
 func NewK8sClusters(clusterNames []string, verbose bool) (Clusters, error) {
 	if len(clusterNames) < 1 || len(clusterNames) > maxClusters {
@@ -104,9 +108,9 @@ func (cs *K8sClusters) GetCluster(name string) Cluster {
 	return c
 }
 
-func (cs *K8sClusters) DeployKuma(mode string, fs ...DeployOptionsFunc) error {
+func (cs *K8sClusters) DeployKuma(mode core.CpMode, opt ...KumaDeploymentOption) error {
 	for name, c := range cs.clusters {
-		if err := c.DeployKuma(mode, fs...); err != nil {
+		if err := c.DeployKuma(mode, opt...); err != nil {
 			return errors.Wrapf(err, "Deploy Kuma on %s failed: %v", name, err)
 		}
 	}
@@ -114,9 +118,9 @@ func (cs *K8sClusters) DeployKuma(mode string, fs ...DeployOptionsFunc) error {
 	return nil
 }
 
-func (cs *K8sClusters) UpgradeKuma(mode string, fs ...DeployOptionsFunc) error {
+func (cs *K8sClusters) UpgradeKuma(mode string, opt ...KumaDeploymentOption) error {
 	for name, c := range cs.clusters {
-		if err := c.UpgradeKuma(mode, fs...); err != nil {
+		if err := c.UpgradeKuma(mode, opt...); err != nil {
 			return errors.Wrapf(err, "Upgrade Kuma on %s failed: %v", name, err)
 		}
 	}
@@ -138,11 +142,11 @@ func (cs *K8sClusters) VerifyKuma() error {
 	return nil
 }
 
-func (cs *K8sClusters) DeleteKuma(opts ...DeployOptionsFunc) error {
+func (cs *K8sClusters) DeleteKuma(opt ...KumaDeploymentOption) error {
 	failed := []string{}
 
 	for name, c := range cs.clusters {
-		if err := c.DeleteKuma(opts...); err != nil {
+		if err := c.DeleteKuma(opt...); err != nil {
 			fmt.Printf("Delete Kuma on %s failed", name)
 			failed = append(failed, name)
 		}
@@ -184,9 +188,9 @@ func (c *K8sClusters) GetKumactlOptions() *KumactlOptions {
 	return nil
 }
 
-func (cs *K8sClusters) DeployApp(fs ...DeployOptionsFunc) error {
+func (cs *K8sClusters) DeployApp(opt ...AppDeploymentOption) error {
 	for name, c := range cs.clusters {
-		if err := c.DeployApp(fs...); err != nil {
+		if err := c.DeployApp(opt...); err != nil {
 			return errors.Wrapf(err, "unable to deploy on %s", name)
 		}
 	}

--- a/test/framework/universal_cluster.go
+++ b/test/framework/universal_cluster.go
@@ -27,6 +27,8 @@ type UniversalCluster struct {
 	defaultRetries int
 }
 
+var _ Cluster = &UniversalCluster{}
+
 func NewUniversalCluster(t *TestingT, name string, verbose bool) *UniversalCluster {
 	return &UniversalCluster{
 		t:              t,
@@ -75,13 +77,15 @@ func (c *UniversalCluster) Verbose() bool {
 	return c.verbose
 }
 
-func (c *UniversalCluster) DeployKuma(mode string, fs ...DeployOptionsFunc) error {
-	c.controlplane = NewUniversalControlPlane(c.t, mode, c.name, c, c.verbose)
-	opts := newDeployOpt(fs...)
+func (c *UniversalCluster) DeployKuma(mode core.CpMode, opt ...KumaDeploymentOption) error {
+	var opts kumaDeploymentOptions
 
+	opts.apply(opt...)
 	if opts.installationMode != KumactlInstallationMode {
 		return errors.Errorf("universal clusters only support the '%s' installation mode but got '%s'", KumactlInstallationMode, opts.installationMode)
 	}
+
+	c.controlplane = NewUniversalControlPlane(c.t, mode, c.name, c, c.verbose)
 
 	cmd := []string{"kuma-cp", "run"}
 	env := []string{"KUMA_MODE=" + mode, "KUMA_DNS_SERVER_PORT=53"}
@@ -172,7 +176,7 @@ func (c *UniversalCluster) VerifyKuma() error {
 	return c.controlplane.kumactl.RunKumactl("get", "dataplanes")
 }
 
-func (c *UniversalCluster) DeleteKuma(opts ...DeployOptionsFunc) error {
+func (c *UniversalCluster) DeleteKuma(...KumaDeploymentOption) error {
 	err := c.apps[AppModeCP].Stop()
 	delete(c.apps, AppModeCP)
 	c.controlplane = nil
@@ -214,8 +218,9 @@ func (c *UniversalCluster) CreateZoneIngress(app *UniversalApp, name, ip, dpyaml
 	return app.dpApp.Start()
 }
 
-func (c *UniversalCluster) DeployApp(fs ...DeployOptionsFunc) error {
-	opts := newDeployOpt(fs...)
+func (c *UniversalCluster) DeployApp(opt ...AppDeploymentOption) error {
+	var opts appDeploymentOptions
+	opts.apply(opt...)
 	appname := opts.appname
 	token := opts.token
 	transparent := opts.transparent

--- a/test/framework/universal_clusters.go
+++ b/test/framework/universal_clusters.go
@@ -7,6 +7,8 @@ import (
 	"github.com/gruntwork-io/terratest/modules/k8s"
 	"github.com/gruntwork-io/terratest/modules/testing"
 	"github.com/pkg/errors"
+
+	"github.com/kumahq/kuma/pkg/config/core"
 )
 
 type UniversalClusters struct {
@@ -14,6 +16,8 @@ type UniversalClusters struct {
 	clusters map[string]*UniversalCluster
 	verbose  bool
 }
+
+var _ Clusters = &UniversalClusters{}
 
 func NewUniversalClusters(clusterNames []string, verbose bool) (Clusters, error) {
 	if len(clusterNames) < 1 || len(clusterNames) > maxClusters {
@@ -82,9 +86,9 @@ func (cs *UniversalClusters) GetCluster(name string) Cluster {
 	return c
 }
 
-func (cs *UniversalClusters) DeployKuma(mode string, fs ...DeployOptionsFunc) error {
+func (cs *UniversalClusters) DeployKuma(mode core.CpMode, opt ...KumaDeploymentOption) error {
 	for name, c := range cs.clusters {
-		if err := c.DeployKuma(mode, fs...); err != nil {
+		if err := c.DeployKuma(mode, opt...); err != nil {
 			return errors.Wrapf(err, "Deploy Kuma on %s failed: %v", name, err)
 		}
 	}
@@ -106,7 +110,7 @@ func (cs *UniversalClusters) VerifyKuma() error {
 	return nil
 }
 
-func (cs *UniversalClusters) DeleteKuma(opts ...DeployOptionsFunc) error {
+func (cs *UniversalClusters) DeleteKuma(opts ...KumaDeploymentOption) error {
 	failed := []string{}
 
 	for name, c := range cs.clusters {
@@ -152,9 +156,9 @@ func (c *UniversalClusters) GetKumactlOptions() *KumactlOptions {
 	return nil
 }
 
-func (cs *UniversalClusters) DeployApp(fs ...DeployOptionsFunc) error {
+func (cs *UniversalClusters) DeployApp(opt ...AppDeploymentOption) error {
 	for name, c := range cs.clusters {
-		if err := c.DeployApp(fs...); err != nil {
+		if err := c.DeployApp(opt...); err != nil {
 			return errors.Wrapf(err, "unable to deploy on %s", name)
 		}
 	}


### PR DESCRIPTION
### Summary

It's hard to understand which deployment options only apply to the Kuma
control plane, and which apply to arbitrarry applications. Split the
options in two, and fix up all the relevant option types so that we have
strong typing all the way down, and it's obvious which options apply to
which tasks.


### Full changelog

N/A

### Issues resolved

N/A

### Documentation

N/A

### Testing

- [x] Unit tests
- [x] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes 

### Backwards compatibility

- [x] Add `backport-to-stable` label if the code is backwards compatible. Otherwise, list breaking changes.
