### PR TITLE
fix(kuma-cp) enable secrets support for Gateway resources

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -956,7 +956,7 @@ jobs:
     - attach_workspace:
         at: build
     - setup_remote_docker:
-        version: 19.03.12
+        version: 20.10.7
     - run:
         name: Build Docker images
         command: |
@@ -986,7 +986,7 @@ jobs:
     - attach_workspace:
         at: build
     - setup_remote_docker:
-        version: 19.03.12
+        version: 20.10.7
     - run:
         name: Build kumactl's Docker image
         command: |

--- a/mk/e2e.new.mk
+++ b/mk/e2e.new.mk
@@ -138,8 +138,5 @@ test/e2e/debug-universal: build/kumactl images/test
 
 .PHONY: test/e2e
 test/e2e: build/kumactl images test/e2e/k8s/start
-	$(MAKE) test/e2e/test || \
-	(ret=$$?; \
-	$(MAKE) test/e2e/k8s/stop && \
-	exit $$ret)
+	$(MAKE) test/e2e/test || (ret=$$?; $(MAKE) test/e2e/k8s/stop && exit $$ret)
 	$(MAKE) test/e2e/k8s/stop

--- a/pkg/plugins/runtime/gateway/plugin.go
+++ b/pkg/plugins/runtime/gateway/plugin.go
@@ -45,6 +45,7 @@ func NewProxyProfile(manager manager.ReadOnlyResourceManager) generator.Resource
 	return generator.CompositeResourceGenerator{
 		generator.AdminProxyGenerator{},
 		generator.PrometheusEndpointGenerator{},
+		generator.SecretsProxyGenerator{},
 		generator.TracingProxyGenerator{},
 		generator.TransparentProxyGenerator{},
 		generator.DNSGenerator{},

--- a/test/dockerfiles/Dockerfile.universal
+++ b/test/dockerfiles/Dockerfile.universal
@@ -1,7 +1,7 @@
 # using Envoy's base to copy the Envoy binary
 FROM envoyproxy/envoy:v1.18.4 as envoy
 
-FROM ubuntu:20.04
+FROM ubuntu:21.04
 
 RUN mkdir /kuma
 RUN echo "# use this file to override default configuration of \`kuma-cp\`" > /kuma/kuma-cp.conf \

--- a/test/framework/kumactl.go
+++ b/test/framework/kumactl.go
@@ -14,6 +14,8 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/kumahq/kuma/pkg/config/core"
+	core_model "github.com/kumahq/kuma/pkg/core/resources/model"
+	"github.com/kumahq/kuma/pkg/core/resources/model/rest"
 )
 
 type KumactlOptions struct {
@@ -45,44 +47,44 @@ func NewKumactlOptions(t testing.TestingT, cpname string, verbose bool) (*Kumact
 	}, nil
 }
 
-func (o *KumactlOptions) RunKumactl(args ...string) error {
-	out, err := o.RunKumactlAndGetOutput(args...)
+func (k *KumactlOptions) RunKumactl(args ...string) error {
+	out, err := k.RunKumactlAndGetOutput(args...)
 	if err != nil {
 		return errors.Wrapf(err, out)
 	}
 	return nil
 }
 
-func (o *KumactlOptions) RunKumactlAndGetOutput(args ...string) (string, error) {
-	return o.RunKumactlAndGetOutputV(o.Verbose, args...)
+func (k *KumactlOptions) RunKumactlAndGetOutput(args ...string) (string, error) {
+	return k.RunKumactlAndGetOutputV(k.Verbose, args...)
 }
 
-func (o *KumactlOptions) RunKumactlAndGetOutputV(verbose bool, args ...string) (string, error) {
+func (k *KumactlOptions) RunKumactlAndGetOutputV(verbose bool, args ...string) (string, error) {
 	cmdArgs := []string{}
-	if o.ConfigPath != "" {
-		cmdArgs = append(cmdArgs, "--config-file", o.ConfigPath)
+	if k.ConfigPath != "" {
+		cmdArgs = append(cmdArgs, "--config-file", k.ConfigPath)
 	}
 
 	cmdArgs = append(cmdArgs, args...)
 	command := shell.Command{
-		Command: o.Kumactl,
+		Command: k.Kumactl,
 		Args:    cmdArgs,
-		Env:     o.Env,
+		Env:     k.Env,
 	}
 
 	if !verbose {
 		command.Logger = logger.Discard
 	}
 
-	return shell.RunCommandAndGetStdOutE(o.t, command)
+	return shell.RunCommandAndGetStdOutE(k.t, command)
 }
 
-func (o *KumactlOptions) KumactlDelete(kumatype, name, mesh string) error {
-	return o.RunKumactl("delete", kumatype, name, "--mesh", mesh)
+func (k *KumactlOptions) KumactlDelete(kumatype, name, mesh string) error {
+	return k.RunKumactl("delete", kumatype, name, "--mesh", mesh)
 }
 
-func (o *KumactlOptions) KumactlList(kumatype, mesh string) ([]string, error) {
-	out, err := o.RunKumactlAndGetOutput("get", kumatype, "--mesh", mesh, "-o", "json")
+func (k *KumactlOptions) KumactlList(kumatype, mesh string) ([]string, error) {
+	out, err := k.RunKumactlAndGetOutput("get", kumatype, "--mesh", mesh, "-o", "json")
 	if err != nil {
 		return nil, err
 	}
@@ -106,19 +108,19 @@ func (o *KumactlOptions) KumactlList(kumatype, mesh string) ([]string, error) {
 	return items, nil
 }
 
-func (o *KumactlOptions) KumactlApply(configPath string) error {
-	return o.RunKumactl("apply", "-f", configPath)
+func (k *KumactlOptions) KumactlApply(configPath string) error {
+	return k.RunKumactl("apply", "-f", configPath)
 }
 
-func (o *KumactlOptions) KumactlApplyFromString(configData string) error {
-	tmpfile, err := storeConfigToTempFile(o.t.Name(), configData)
+func (k *KumactlOptions) KumactlApplyFromString(configData string) error {
+	tmpfile, err := storeConfigToTempFile(k.t.Name(), configData)
 	if err != nil {
 		return err
 	}
 
 	defer os.Remove(tmpfile)
 
-	return o.KumactlApply(tmpfile)
+	return k.KumactlApply(tmpfile)
 }
 
 func storeConfigToTempFile(name string, configData string) (string, error) {
@@ -135,7 +137,7 @@ func storeConfigToTempFile(name string, configData string) (string, error) {
 	return tmpfile.Name(), err
 }
 
-func (o *KumactlOptions) KumactlInstallCP(mode string, args ...string) (string, error) {
+func (k *KumactlOptions) KumactlInstallCP(mode string, args ...string) (string, error) {
 	cmd := []string{
 		"install", "control-plane",
 	}
@@ -143,7 +145,7 @@ func (o *KumactlOptions) KumactlInstallCP(mode string, args ...string) (string, 
 	cmd = append(cmd, "--mode", mode)
 	switch mode {
 	case core.Zone:
-		cmd = append(cmd, "--zone", o.CPName)
+		cmd = append(cmd, "--zone", k.CPName)
 		fallthrough
 	case core.Global:
 		if !UseLoadBalancer() {
@@ -153,29 +155,29 @@ func (o *KumactlOptions) KumactlInstallCP(mode string, args ...string) (string, 
 
 	cmd = append(cmd, args...)
 
-	return o.RunKumactlAndGetOutputV(
+	return k.RunKumactlAndGetOutputV(
 		false, // silence the log output of Install
 		cmd...)
 }
 
-func (o *KumactlOptions) KumactlInstallDNS(args ...string) (string, error) {
+func (k *KumactlOptions) KumactlInstallDNS(args ...string) (string, error) {
 	args = append([]string{"install", "dns"}, args...)
 
-	return o.RunKumactlAndGetOutputV(
+	return k.RunKumactlAndGetOutputV(
 		false, // silence the log output of Install
 		args...)
 }
 
-func (o *KumactlOptions) KumactlInstallMetrics() (string, error) {
-	return o.RunKumactlAndGetOutput("install", "metrics")
+func (k *KumactlOptions) KumactlInstallMetrics() (string, error) {
+	return k.RunKumactlAndGetOutput("install", "metrics")
 }
 
-func (o *KumactlOptions) KumactlInstallTracing() (string, error) {
-	return o.RunKumactlAndGetOutput("install", "tracing")
+func (k *KumactlOptions) KumactlInstallTracing() (string, error) {
+	return k.RunKumactlAndGetOutput("install", "tracing")
 }
 
-func (o *KumactlOptions) KumactlConfigControlPlanesAdd(name, address, token string) error {
-	_, err := retry.DoWithRetryE(o.t, "kumactl config control-planes add", DefaultRetries, DefaultTimeout,
+func (k *KumactlOptions) KumactlConfigControlPlanesAdd(name, address, token string) error {
+	_, err := retry.DoWithRetryE(k.t, "kumactl config control-planes add", DefaultRetries, DefaultTimeout,
 		func() (string, error) {
 			args := []string{
 				"config", "control-planes", "add",
@@ -189,7 +191,7 @@ func (o *KumactlOptions) KumactlConfigControlPlanesAdd(name, address, token stri
 					"--auth-conf", "token="+token,
 				)
 			}
-			err := o.RunKumactl(args...)
+			err := k.RunKumactl(args...)
 
 			if err != nil {
 				return "Unable to register Kuma CP. Try again.", err
@@ -199,4 +201,29 @@ func (o *KumactlOptions) KumactlConfigControlPlanesAdd(name, address, token stri
 		})
 
 	return err
+}
+
+// KumactlUpdateObject fetches an object and updates it after the update function is applied to it.
+func (k *KumactlOptions) KumactlUpdateObject(
+	typeName string,
+	objectName string,
+	update func(core_model.Resource) core_model.Resource,
+) error {
+	out, err := k.RunKumactlAndGetOutput("get", typeName, objectName, "-o", "yaml")
+	if err != nil {
+		return errors.Wrapf(err, "failed to get %q object %q", typeName, objectName)
+	}
+
+	resource, err := rest.UnmarshallToCore([]byte(out))
+	if err != nil {
+		return errors.Wrapf(err, "failed to unmarshal %q object %q", typeName, objectName)
+	}
+
+	updated := rest.NewFromModel(update(resource))
+	json, err := updated.MarshalJSON()
+	if err != nil {
+		return errors.Wrapf(err, "failed to marshal JSON for %q object %q", typeName, objectName)
+	}
+
+	return k.KumactlApplyFromString(string(json))
 }

--- a/test/framework/universal_app.go
+++ b/test/framework/universal_app.go
@@ -246,7 +246,7 @@ func NewUniversalApp(t testing.TestingT, clusterName, dpName string, mode AppMod
 			return "Success", nil
 		})
 
-	fmt.Printf("Node IP %s\n", app.ip)
+	Logf("Node IP %s", app.ip)
 
 	return app, nil
 }
@@ -509,12 +509,12 @@ func NewSshApp(verbose bool, port string, env []string, args []string) *SshApp {
 }
 
 func (s *SshApp) Run() error {
-	fmt.Printf("Running %v\n", s.cmd)
+	Logf("Running %v", s.cmd)
 	return s.cmd.Run()
 }
 
 func (s *SshApp) Start() error {
-	fmt.Printf("Starting %v\n", s.cmd)
+	Logf("Starting %v", s.cmd)
 	return s.cmd.Start()
 }
 

--- a/test/framework/universal_controlplane.go
+++ b/test/framework/universal_controlplane.go
@@ -9,6 +9,7 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/kumahq/kuma/pkg/config/core"
+	core_model "github.com/kumahq/kuma/pkg/core/resources/model"
 )
 
 type UniversalControlPlane struct {
@@ -107,4 +108,12 @@ func (c *UniversalControlPlane) GenerateZoneIngressToken(zone string) (string, e
 		}
 		return sshApp.Out(), nil
 	})
+}
+
+func (c *UniversalControlPlane) UpdateObject(
+	typeName string,
+	objectName string,
+	update func(object core_model.Resource) core_model.Resource,
+) error {
+	return c.kumactl.KumactlUpdateObject(typeName, objectName, update)
 }


### PR DESCRIPTION
### Summary

Add the secrets generator to the Gateway proxy template. This fixes
mTLS between the gateway proxy and upstream services in the mesh.

### Full changelog

N/A

### Issues resolved

N/A

### Documentation

N/A

### Testing

- [x] Unit tests
- [x] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes 

### Backwards compatibility

- [x] Add `backport-to-stable` label if the code is backwards compatible. Otherwise, list breaking changes.
