### PR TITLE
ci: fix IPv6 integration tests

### DIFF
--- a/test/e2e/gateway/gateway_universal.go
+++ b/test/e2e/gateway/gateway_universal.go
@@ -3,6 +3,7 @@ package gateway
 import (
 	"errors"
 	"fmt"
+	"net"
 	"net/url"
 	"path"
 	"strings"
@@ -173,9 +174,9 @@ conf:
 		Expect(gateways).To(ContainElement("edge-gateway"))
 
 		Eventually(func(g Gomega) {
+			host := net.JoinHostPort(cluster.GetApp("gateway-proxy").GetIP(), "8080")
 			p := path.Join("test", url.PathEscape(GinkgoT().Name()))
-			target := fmt.Sprintf("http://%s:8080/%s",
-				cluster.GetApp("gateway-proxy").GetIP(), p)
+			target := fmt.Sprintf("http://%s/%s", host, p)
 
 			response, err := testutil.CollectResponse(
 				cluster, "gateway-client", target,

--- a/test/framework/interface.go
+++ b/test/framework/interface.go
@@ -47,6 +47,7 @@ type kumaDeploymentOptions struct {
 
 func (k *kumaDeploymentOptions) apply(opts ...KumaDeploymentOption) {
 	// Set defaults.
+	k.isipv6 = IsIPv6()
 	k.installationMode = KumactlInstallationMode
 	k.env = map[string]string{}
 
@@ -97,6 +98,7 @@ type appDeploymentOptions struct {
 
 func (d *appDeploymentOptions) apply(opts ...AppDeploymentOption) {
 	// Set defaults.
+	d.isipv6 = IsIPv6()
 
 	// Apply options.
 	for _, o := range opts {


### PR DESCRIPTION
### Summary

Add e2e option defaults to propagate the IPv6 flag down from the build
environment. Individual tests can still override this, but the default
should be OK for the majority of uses.
    
Fix IP address URL construction in the gateway tests by joining the host
and port fields correctly for IPv6 test cases.

### Full changelog

N/A

### Issues resolved

Update #2911 

### Documentation

N/A

### Testing

- [x] Unit tests
- [x] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes 

### Backwards compatibility

- [x] Add `backport-to-stable` label if the code is backwards compatible. Otherwise, list breaking changes.
