### PR TITLE
fix(kuma-cp) allow only one healthcheck

### DIFF
--- a/pkg/core/resources/apis/mesh/health_check_validator.go
+++ b/pkg/core/resources/apis/mesh/health_check_validator.go
@@ -112,6 +112,9 @@ func (d *HealthCheckResource) validateConf() (err validators.ValidationError) {
 	if d.Spec.Conf.GetHttp() != nil {
 		err.Add(d.validateConfHttp(path.Field("http")))
 	}
+	if d.Spec.Conf.GetTcp() != nil && d.Spec.Conf.GetHttp() != nil {
+		err.AddViolationAt(path, "http and tcp cannot be defined at the same time")
+	}
 	return
 }
 

--- a/pkg/core/resources/apis/mesh/health_check_validator_test.go
+++ b/pkg/core/resources/apis/mesh/health_check_validator_test.go
@@ -177,6 +177,31 @@ var _ = Describe("HealthCheck", func() {
                   message: has to be defined and cannot be empty
 `,
 			}),
+			Entry("http and tcp configuration", testCase{
+				healthCheck: `
+                sources:
+                - match:
+                    kuma.io/service: web
+                    region: eu
+                destinations:
+                - match:
+                    kuma.io/service: backend
+                conf:
+                  interval: 3s
+                  timeout: 10s
+                  unhealthyThreshold: 3
+                  healthyThreshold: 1
+                  http: {}
+                  tcp: {}
+`,
+				expected: `
+                violations:
+                - field: conf.http.path
+                  message: has to be defined and cannot be empty
+                - field: conf
+                  message: http and tcp cannot be defined at the same time
+`,
+			}),
 		)
 	})
 })


### PR DESCRIPTION
### Summary

https://github.com/envoyproxy/envoy/blame/f4a88f969cfb58b36efcf649fc25e5c85e7e9f5c/source/common/upstream/cluster_factory_impl.cc#L124
Only one item in the Envoy health check list is allowed therefore we need extra validation until this is changed.

### Issues resolved

Fix #2966

### Documentation

- [X] https://github.com/kumahq/kuma-website/pull/564

### Testing

- [X] Unit tests
- [ ] E2E tests
- [X] Manual testing on Universal
- [ ] Manual testing on Kubernetes 

### Backwards compatibility

- [X] Add `backport-to-stable` label if the code is backwards compatible. Otherwise, list breaking changes.
