### PR TITLE
feat(kumactl) show the effective Dataplane address

### DIFF
--- a/app/kumactl/cmd/get/get_dataplanes_test.go
+++ b/app/kumactl/cmd/get/get_dataplanes_test.go
@@ -3,9 +3,7 @@ package get_test
 import (
 	"bytes"
 	"context"
-	"io/ioutil"
 	"path/filepath"
-	"strings"
 	"time"
 
 	. "github.com/onsi/ginkgo"
@@ -21,6 +19,7 @@ import (
 	core_store "github.com/kumahq/kuma/pkg/core/resources/store"
 	memory_resources "github.com/kumahq/kuma/pkg/plugins/resources/memory"
 	test_kumactl "github.com/kumahq/kuma/pkg/test/kumactl"
+	"github.com/kumahq/kuma/pkg/test/matchers"
 	test_model "github.com/kumahq/kuma/pkg/test/resources/model"
 )
 
@@ -114,7 +113,7 @@ var _ = Describe("kumactl get dataplanes", func() {
 			outputFormat string
 			pagination   string
 			goldenFile   string
-			matcher      func(interface{}) gomega_types.GomegaMatcher
+			matcher      func(path string) gomega_types.GomegaMatcher
 		}
 
 		DescribeTable("kumactl get dataplanes -o table|json|yaml",
@@ -125,48 +124,37 @@ var _ = Describe("kumactl get dataplanes", func() {
 					"get", "dataplanes"}, given.outputFormat, given.pagination))
 
 				// when
-				err := rootCmd.Execute()
+				Expect(rootCmd.Execute()).ToNot(HaveOccurred())
 				// then
-				Expect(err).ToNot(HaveOccurred())
-
-				// when
-				expected, err := ioutil.ReadFile(filepath.Join("testdata", given.goldenFile))
-				// then
-				Expect(err).ToNot(HaveOccurred())
-				// and
-				Expect(buf.String()).To(given.matcher(expected))
+				Expect(buf.String()).To(given.matcher(
+					filepath.Join("testdata", given.goldenFile),
+				))
 			},
 			Entry("should support Table output by default", testCase{
 				outputFormat: "",
 				goldenFile:   "get-dataplanes.golden.txt",
-				matcher: func(expected interface{}) gomega_types.GomegaMatcher {
-					return WithTransform(strings.TrimSpace, Equal(strings.TrimSpace(string(expected.([]byte)))))
-				},
+				matcher:      matchers.MatchGoldenEqual,
 			}),
 			Entry("should support Table output explicitly", testCase{
 				outputFormat: "-otable",
 				goldenFile:   "get-dataplanes.golden.txt",
-				matcher: func(expected interface{}) gomega_types.GomegaMatcher {
-					return WithTransform(strings.TrimSpace, Equal(strings.TrimSpace(string(expected.([]byte)))))
-				},
+				matcher:      matchers.MatchGoldenEqual,
 			}),
 			Entry("should support pagination", testCase{
 				outputFormat: "-otable",
 				goldenFile:   "get-dataplanes.pagination.golden.txt",
 				pagination:   "--size=1",
-				matcher: func(expected interface{}) gomega_types.GomegaMatcher {
-					return WithTransform(strings.TrimSpace, Equal(strings.TrimSpace(string(expected.([]byte)))))
-				},
+				matcher:      matchers.MatchGoldenEqual,
 			}),
 			Entry("should support JSON output", testCase{
 				outputFormat: "-ojson",
 				goldenFile:   "get-dataplanes.golden.json",
-				matcher:      MatchJSON,
+				matcher:      matchers.MatchGoldenJSON,
 			}),
 			Entry("should support YAML output", testCase{
 				outputFormat: "-oyaml",
 				goldenFile:   "get-dataplanes.golden.yaml",
-				matcher:      MatchYAML,
+				matcher:      matchers.MatchGoldenYAML,
 			}),
 		)
 	})

--- a/app/kumactl/cmd/get/table_printer.go
+++ b/app/kumactl/cmd/get/table_printer.go
@@ -14,13 +14,18 @@ import (
 // CustomTablePrinters are used to define different ways to print entities in table format.
 var CustomTablePrinters = map[model.ResourceType]TablePrinter{
 	mesh.DataplaneType: RowPrinter{
-		Headers: []string{"MESH", "NAME", "TAGS", "AGE"},
+		Headers: []string{"MESH", "NAME", "TAGS", "ADDRESS", "AGE"},
 		RowFn: func(rootTime time.Time, item model.Resource) []string {
 			dataplane := item.(*mesh.DataplaneResource)
+			address := dataplane.Spec.GetNetworking().GetAdvertisedAddress()
+			if address == "" {
+				address = dataplane.Spec.GetNetworking().GetAddress()
+			}
 			return []string{
-				dataplane.Meta.GetMesh(),                                        // MESH
-				dataplane.Meta.GetName(),                                        // NAME,
-				dataplane.Spec.TagSet().String(),                                // TAGS
+				dataplane.Meta.GetMesh(),         // MESH
+				dataplane.Meta.GetName(),         // NAME,
+				dataplane.Spec.TagSet().String(), // TAGS
+				address,                          // ADDRESS
 				table.TimeSince(dataplane.Meta.GetModificationTime(), rootTime), // AGE
 			}
 		},

--- a/app/kumactl/cmd/get/testdata/get-dataplane.golden.txt
+++ b/app/kumactl/cmd/get/testdata/get-dataplane.golden.txt
@@ -1,2 +1,2 @@
-MESH      NAME          TAGS                                AGE
-default   dataplane-1   service=metrics,mobile version=v1   292y
+MESH      NAME          TAGS                                ADDRESS     AGE
+default   dataplane-1   service=metrics,mobile version=v1   127.0.0.1   292y

--- a/app/kumactl/cmd/get/testdata/get-dataplanes.golden.json
+++ b/app/kumactl/cmd/get/testdata/get-dataplanes.golden.json
@@ -1,54 +1,54 @@
 {
-    "total": 2,
-    "items": [
-      {
-        "mesh": "default",
-        "name": "experiment",
-        "creationTime": "0001-01-01T00:00:00Z",
-        "modificationTime": "0001-01-01T00:00:00Z",
-        "networking": {
-          "address": "127.0.0.1",
-          "inbound": [
-            {
-              "port": 8080,
-              "servicePort": 80,
-              "tags": {
-                "service": "mobile",
-                "version": "v1"
-              }
-            },
-            {
-              "port": 8090,
-              "servicePort": 90,
-              "tags": {
-                "service": "metrics",
-                "version": "v1"
-              }
+  "total": 2,
+  "items": [
+    {
+      "type": "Dataplane",
+      "mesh": "default",
+      "name": "experiment",
+      "creationTime": "0001-01-01T00:00:00Z",
+      "modificationTime": "0001-01-01T00:00:00Z",
+      "networking": {
+        "address": "127.0.0.1",
+        "inbound": [
+          {
+            "port": 8080,
+            "servicePort": 80,
+            "tags": {
+              "service": "mobile",
+              "version": "v1"
             }
-          ]
-        },
-        "type": "Dataplane"
-      },
-      {
-        "mesh": "default",
-        "name": "example",
-        "creationTime": "0001-01-01T00:00:00Z",
-        "modificationTime": "0001-01-01T00:00:00Z",
-        "networking": {
-          "address": "127.0.0.2",
-          "inbound": [
-            {
-              "port": 8080,
-              "servicePort": 80,
-              "tags": {
-                "service": "web",
-                "version": "v2"
-              }
+          },
+          {
+            "port": 8090,
+            "servicePort": 90,
+            "tags": {
+              "service": "metrics",
+              "version": "v1"
             }
-          ]
-        },
-        "type": "Dataplane"
+          }
+        ]
       }
-    ],
-    "next": null
+    },
+    {
+      "type": "Dataplane",
+      "mesh": "default",
+      "name": "example",
+      "creationTime": "0001-01-01T00:00:00Z",
+      "modificationTime": "0001-01-01T00:00:00Z",
+      "networking": {
+        "address": "127.0.0.2",
+        "inbound": [
+          {
+            "port": 8080,
+            "servicePort": 80,
+            "tags": {
+              "service": "web",
+              "version": "v2"
+            }
+          }
+        ]
+      }
+    }
+  ],
+  "next": null
 }

--- a/app/kumactl/cmd/get/testdata/get-dataplanes.golden.txt
+++ b/app/kumactl/cmd/get/testdata/get-dataplanes.golden.txt
@@ -1,3 +1,3 @@
-MESH      NAME         TAGS                                AGE
-default   experiment   service=metrics,mobile version=v1   292y
-default   example      service=web version=v2              292y
+MESH      NAME         TAGS                                ADDRESS     AGE
+default   experiment   service=metrics,mobile version=v1   127.0.0.1   292y
+default   example      service=web version=v2              127.0.0.2   292y

--- a/app/kumactl/cmd/get/testdata/get-dataplanes.golden.yaml
+++ b/app/kumactl/cmd/get/testdata/get-dataplanes.golden.yaml
@@ -1,8 +1,7 @@
-total: 2
 items:
-- creationTime: 0001-01-01T00:00:00Z
+- creationTime: "0001-01-01T00:00:00Z"
   mesh: default
-  modificationTime: 0001-01-01T00:00:00Z
+  modificationTime: "0001-01-01T00:00:00Z"
   name: experiment
   networking:
     address: 127.0.0.1
@@ -18,9 +17,9 @@ items:
         service: metrics
         version: v1
   type: Dataplane
-- creationTime: 0001-01-01T00:00:00Z
+- creationTime: "0001-01-01T00:00:00Z"
   mesh: default
-  modificationTime: 0001-01-01T00:00:00Z
+  modificationTime: "0001-01-01T00:00:00Z"
   name: example
   networking:
     address: 127.0.0.2
@@ -32,3 +31,4 @@ items:
         version: v2
   type: Dataplane
 next: null
+total: 2

--- a/app/kumactl/cmd/get/testdata/get-dataplanes.pagination.golden.txt
+++ b/app/kumactl/cmd/get/testdata/get-dataplanes.pagination.golden.txt
@@ -1,4 +1,4 @@
-MESH      NAME      TAGS                     AGE
-default   example   service=web version=v2   292y
+MESH      NAME      TAGS                     ADDRESS     AGE
+default   example   service=web version=v2   127.0.0.2   292y
 
 Rerun command with --offset=1 argument to retrieve more resources


### PR DESCRIPTION
### Summary

Show the effective Dataplane address in the Dataplanes listing output.
The effective address is the advertised address if it is present, otherwise
the networking address. The address is one of the most important properties
of the Dataplane, so it's useful to make it more accessible here.

### Full changelog

* Show the effective Dataplane address in kumactl output

### Issues resolved

N/A

### Documentation

N/A

### Testing

- [x] Unit tests
- [x] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes 

### Backwards compatibility

- [x] Add `backport-to-stable` label if the code is backwards compatible. Otherwise, list breaking changes.
