### PR TITLE
chore(*) update Go build comments

### DIFF
--- a/app/kuma-cp/cmd/cmd_standalone_postgres_test.go
+++ b/app/kuma-cp/cmd/cmd_standalone_postgres_test.go
@@ -1,3 +1,4 @@
+//go:build integration
 // +build integration
 
 package cmd

--- a/app/kuma-dp/cmd/run_test.go
+++ b/app/kuma-dp/cmd/run_test.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package cmd

--- a/app/kuma-dp/pkg/dataplane/command/build_command.go
+++ b/app/kuma-dp/pkg/dataplane/command/build_command.go
@@ -1,3 +1,4 @@
+//go:build !linux
 // +build !linux
 
 package command

--- a/app/kuma-dp/pkg/dataplane/dnsserver/dnsserver_test.go
+++ b/app/kuma-dp/pkg/dataplane/dnsserver/dnsserver_test.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package dnsserver

--- a/app/kuma-dp/pkg/dataplane/envoy/envoy_test.go
+++ b/app/kuma-dp/pkg/dataplane/envoy/envoy_test.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package envoy

--- a/app/kumactl/cmd/install/install_transparent_proxy.go
+++ b/app/kumactl/cmd/install/install_transparent_proxy.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package install

--- a/app/kumactl/cmd/uninstall/uninstall_transparent_proxy.go
+++ b/app/kumactl/cmd/uninstall/uninstall_transparent_proxy.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package uninstall

--- a/pkg/core/resources/apis/mesh/dataplane_validator_gateway.go
+++ b/pkg/core/resources/apis/mesh/dataplane_validator_gateway.go
@@ -1,3 +1,4 @@
+//go:build gateway
 // +build gateway
 
 package mesh

--- a/pkg/plugins/leader/postgres/leader_elector_test.go
+++ b/pkg/plugins/leader/postgres/leader_elector_test.go
@@ -1,3 +1,4 @@
+//go:build integration
 // +build integration
 
 package postgres_test

--- a/pkg/plugins/resources/postgres/migrate_test.go
+++ b/pkg/plugins/resources/postgres/migrate_test.go
@@ -1,3 +1,4 @@
+//go:build integration
 // +build integration
 
 package postgres

--- a/pkg/plugins/resources/postgres/store_template_test.go
+++ b/pkg/plugins/resources/postgres/store_template_test.go
@@ -1,3 +1,4 @@
+//go:build integration
 // +build integration
 
 package postgres

--- a/pkg/plugins/runtime/gateway/enabled.go
+++ b/pkg/plugins/runtime/gateway/enabled.go
@@ -1,3 +1,4 @@
+//go:build gateway
 // +build gateway
 
 package gateway

--- a/pkg/plugins/runtime/gateway/register/enabled.go
+++ b/pkg/plugins/runtime/gateway/register/enabled.go
@@ -1,3 +1,4 @@
+//go:build gateway
 // +build gateway
 
 package register

--- a/pkg/util/os/limits.go
+++ b/pkg/util/os/limits.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package os

--- a/test/release/release_suite_test.go
+++ b/test/release/release_suite_test.go
@@ -1,3 +1,4 @@
+//go:build release
 // +build release
 
 package release_test


### PR DESCRIPTION
### Summary

Running "make check" with Go 1.17 updates the build comments. These
comments are harmless to earlier Go releases.


### Full changelog

N/A

### Issues resolved

N/A

### Documentation

N/A

### Testing

- [x] Unit tests
- [x] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes 

### Backwards compatibility

- [x] Add `backport-to-stable` label if the code is backwards compatible. Otherwise, list breaking changes.
