### PR TITLE
fix(*) fix builtin gateway when adding to insights

### DIFF
--- a/pkg/insights/resyncer.go
+++ b/pkg/insights/resyncer.go
@@ -219,7 +219,7 @@ func (r *resyncer) createOrUpdateServiceInsight(mesh string) error {
 			addDpToInsight(insight, svc, status)
 		}
 
-		for _, inbound := range networking.Inbound {
+		for _, inbound := range networking.GetInbound() {
 			addDpToInsight(insight, inbound.GetService(), status)
 		}
 	}


### PR DESCRIPTION
### Summary

As according to our validators
https://github.com/kumahq/kuma/blob/c89ac43e1d46a16ad37f8898dbd932cda4b034dd/pkg/core/resources/apis/mesh/dataplane_validator.go#L34-L63
both gateways (delegated and builtin) cannot contain inbounds
I added builtin gateway to skip trying to add its inbounds to the
dataplane list of insight resources.

I also refactored this parts of code to use protobuf's builtin
associate `Get[...]` functions which handles nils better (i.e.
in `dpOverview.Spec.GetDataplane().GetNetworking()` if
`dpOverview.Spec.Dataplane` will be `nil` it won't crash.

Also removed nested if statement and used `continue` to skip
to the next loop iteration instead of using `else` branch.

### Full changelog

n/a

### Issues resolved

n/a

### Documentation

n/a

### Testing

- [ ] Unit tests
- [ ] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes 

### Backwards compatibility

- [x] Add `backport-to-stable` label if the code is backwards compatible. Otherwise, list breaking changes.
