### PR TITLE
fix(tests) restore WithCtlOpt to test/framework

### DIFF
--- a/test/framework/interface.go
+++ b/test/framework/interface.go
@@ -29,6 +29,7 @@ type kumaDeploymentOptions struct {
 	verbose *bool
 
 	// cp specific
+	ctlOpts              map[string]string
 	globalAddress        string
 	installationMode     InstallationMode
 	skipDefaultMesh      bool
@@ -253,6 +254,18 @@ func WithCNI() KumaDeploymentOption {
 func WithGlobalAddress(address string) KumaDeploymentOption {
 	return KumaOptionFunc(func(o *kumaDeploymentOptions) {
 		o.globalAddress = address
+	})
+}
+
+// WithCtlOpt allows arbitrary options to be passed to kuma, which is important
+// for using test/framework in other libraries where additional options may have
+// been added.
+func WithCtlOpt(name, value string) KumaDeploymentOption {
+	return KumaOptionFunc(func(o *kumaDeploymentOptions) {
+		if o.ctlOpts == nil {
+			o.ctlOpts = map[string]string{}
+		}
+		o.ctlOpts[name] = value
 	})
 }
 

--- a/test/framework/k8s_cluster.go
+++ b/test/framework/k8s_cluster.go
@@ -326,6 +326,10 @@ func (c *K8sCluster) yamlForKumaViaKubectl(mode string, opts *kumaDeploymentOpti
 		argsMap["--env-var"] = fmt.Sprintf("KUMA_DNS_SERVER_CIDR=%s", cidrIPv6)
 	}
 
+	for opt, value := range opts.ctlOpts {
+		argsMap[opt] = value
+	}
+
 	var args []string
 	for k, v := range argsMap {
 		args = append(args, k, v)


### PR DESCRIPTION
### Summary

This function is useful for using `test/framework` elsewhere, when additional options have been added to the executable.