### PR TITLE
fix(kuma-cp) ensure all backends that are added one by one

### DIFF
--- a/pkg/plugins/ca/builtin/manager.go
+++ b/pkg/plugins/ca/builtin/manager.go
@@ -35,6 +35,10 @@ var _ core_ca.Manager = &builtinCaManager{}
 func (b *builtinCaManager) EnsureBackends(ctx context.Context, mesh string, backends []*mesh_proto.CertificateAuthorityBackend) error {
 	for _, backend := range backends {
 		_, err := b.getCa(ctx, mesh, backend.Name)
+		if err == nil { // CA is there, nothing to ensure
+			continue
+		}
+
 		if !core_store.IsResourceNotFound(err) {
 			return err
 		}


### PR DESCRIPTION
### Summary

EnsureBackends returned when the first backend was already ensured.

### Issues resolved

No issue was created.

### Documentation

- [X] No docs

### Testing

- [X] Unit tests
- [ ] E2E tests
- [X] Manual testing on Universal
- [ ] Manual testing on Kubernetes 

### Backwards compatibility

- [X] Add `backport-to-stable` label if the code is backwards compatible. Otherwise, list breaking changes.
