### PR TITLE
feat(kuma-prometheus-sd) add deprecation notice

### DIFF
--- a/app/kuma-prometheus-sd/README.md
+++ b/app/kuma-prometheus-sd/README.md
@@ -1,5 +1,11 @@
 # kuma-prometheus-sd
 
+## DEPRECATION NOTICE
+
+`kuma-prometheus-sd` has been deprecated in favor of
+the native [`kuma_sd`](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#kuma_sd_config)
+that is builtin to Prometheus 2.29 and later.
+
 ## Overview
 
 `kuma-prometheus-sd` is an **adapter** that integrates `Prometheus` service discovery mechanism with [Kuma](https://kuma.io) Service Mesh.

--- a/app/kuma-prometheus-sd/cmd/root.go
+++ b/app/kuma-prometheus-sd/cmd/root.go
@@ -28,8 +28,11 @@ func NewRootCmd(opts kuma_cmd.RunCmdOpts) *cobra.Command {
 	}{}
 	cmd := &cobra.Command{
 		Use:   "kuma-prometheus-sd",
-		Short: "Prometheus service discovery adapter for native integration with Kuma",
-		Long:  `Prometheus service discovery adapter for native integration with Kuma.`,
+		Short: "[DEPRECATED] Prometheus service discovery adapter for native integration with Kuma",
+		Long: `[DEPRECATED] Prometheus service discovery adapter for native integration with Kuma.
+It has been superseded by the native kuma_sd in Prometheus as of Prometheus 2.29.
+See: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#kuma_sd_config
+`,
 		PersistentPreRunE: func(cmd *cobra.Command, _ []string) error {
 			level, err := kuma_log.ParseLogLevel(args.logLevel)
 			if err != nil {
@@ -50,6 +53,11 @@ func NewRootCmd(opts kuma_cmd.RunCmdOpts) *cobra.Command {
 			// avoid printing usage instructions
 			cmd.SilenceUsage = true
 
+			if cmd.Name() != "help" {
+				fmt.Println(`kuma-prometheus-sd is DEPRECATED and will be removed in a future version.
+It has been superseded by the native kuma_sd in Prometheus as of Prometheus 2.29.
+See: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#kuma_sd_config`)
+			}
 			return nil
 		},
 	}

--- a/docs/cmd/kuma-prometheus-sd/kuma-prometheus-sd.md
+++ b/docs/cmd/kuma-prometheus-sd/kuma-prometheus-sd.md
@@ -1,10 +1,13 @@
 ## kuma-prometheus-sd
 
-Prometheus service discovery adapter for native integration with Kuma
+[DEPRECATED] Prometheus service discovery adapter for native integration with Kuma
 
 ### Synopsis
 
-Prometheus service discovery adapter for native integration with Kuma.
+[DEPRECATED] Prometheus service discovery adapter for native integration with Kuma.
+It has been superseded by the native kuma_sd in Prometheus as of Prometheus 2.29.
+See: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#kuma_sd_config
+
 
 ### Options
 

--- a/docs/cmd/kuma-prometheus-sd/kuma-prometheus-sd_run.md
+++ b/docs/cmd/kuma-prometheus-sd/kuma-prometheus-sd_run.md
@@ -32,5 +32,5 @@ kuma-prometheus-sd run [flags]
 
 ### SEE ALSO
 
-* [kuma-prometheus-sd](kuma-prometheus-sd.md)	 - Prometheus service discovery adapter for native integration with Kuma
+* [kuma-prometheus-sd](kuma-prometheus-sd.md)	 - [DEPRECATED] Prometheus service discovery adapter for native integration with Kuma
 

--- a/docs/cmd/kuma-prometheus-sd/kuma-prometheus-sd_version.md
+++ b/docs/cmd/kuma-prometheus-sd/kuma-prometheus-sd_version.md
@@ -29,5 +29,5 @@ kuma-prometheus-sd version [flags]
 
 ### SEE ALSO
 
-* [kuma-prometheus-sd](kuma-prometheus-sd.md)	 - Prometheus service discovery adapter for native integration with Kuma
+* [kuma-prometheus-sd](kuma-prometheus-sd.md)	 - [DEPRECATED] Prometheus service discovery adapter for native integration with Kuma
 


### PR DESCRIPTION
Signed-off-by: austin ce <austin.cawley@gmail.com>

### Summary

Having multiple SD mechanisms is causing confusion (see [slack thread](https://kuma-mesh.slack.com/archives/CN2GN4HE1/p1634897635033500)).
This starts the process of deprecating and removing the old `kuma-prometheus-sd` adapter.

### Full changelog

* Add deprecation log message to `kuma-prometheus-sd`

### Issues resolved

Fix #2852

### Documentation


### Testing

- [ ] Unit tests
- [ ] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes 

### Backwards compatibility

- [x] Add `backport-to-stable` label if the code is backwards compatible. Otherwise, list breaking changes.
Could break people's scripts if they are relying on the stdout of `kuma-prometheus-sd` anywhere, but that seems unlikely / not a true public interface.

