### PR TITLE
fix(kumactl) duplicate TLS certificate usage

### DIFF
--- a/pkg/tls/cert.go
+++ b/pkg/tls/cert.go
@@ -82,7 +82,7 @@ func newCert(commonName string, certType CertType, hosts ...string) (x509.Certif
 		NotAfter:              notAfter,
 		IsCA:                  true,
 		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
-		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		ExtKeyUsage:           []x509.ExtKeyUsage{},
 		BasicConstraintsValid: true,
 	}
 	switch certType {


### PR DESCRIPTION
### Summary

Fix duplication of the TLS certificate key usage field that occurs when
generating server certificates.

### Full changelog

* TLS server certificates generated by kumactl no longer duplicate the key usage attribute

### Issues resolved

N/A

### Documentation

N/A

### Testing

- [x] Unit tests
- [x] E2E tests
- [x] Manual testing on Universal
- [ ] Manual testing on Kubernetes 

### Backwards compatibility

- [x] Add `backport-to-stable` label if the code is backwards compatible. Otherwise, list breaking changes.
