### PR TITLE
chore(kumactl) add command argument count parameters

### DIFF
--- a/app/kumactl/cmd/apply/apply.go
+++ b/app/kumactl/cmd/apply/apply.go
@@ -56,7 +56,8 @@ name: demo
 Apply a resource from external URL
 $ kumactl apply -f https://example.com/resource.yaml
 `,
-		RunE: func(cmd *cobra.Command, args []string) error {
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			if err := pctx.CheckServerVersionCompatibility(); err != nil {
 				cmd.PrintErrln(err)
 			}

--- a/app/kumactl/cmd/completion/completion.go
+++ b/app/kumactl/cmd/completion/completion.go
@@ -42,7 +42,8 @@ func newBashCommand(pctx *kumactl_cmd.RootContext) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "bash",
 		Short: "Output shell completions for bash",
-		RunE: func(cmd *cobra.Command, args []string) error {
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			return cmd.Parent().Parent().GenBashCompletion(cmd.OutOrStdout())
 		},
 	}
@@ -53,7 +54,8 @@ func newFishCommand(pctx *kumactl_cmd.RootContext) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "fish",
 		Short: "Output shell completions for fish",
-		RunE: func(cmd *cobra.Command, args []string) error {
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			return cmd.Parent().Parent().GenFishCompletion(cmd.OutOrStdout(), true)
 		},
 	}
@@ -64,7 +66,8 @@ func newZshCommand(pctx *kumactl_cmd.RootContext) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "zsh",
 		Short: "Output shell completions for zsh",
-		RunE: func(cmd *cobra.Command, args []string) error {
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			return cmd.Parent().Parent().GenZshCompletion(cmd.OutOrStdout())
 		},
 	}

--- a/app/kumactl/cmd/config/config_control_planes_add.go
+++ b/app/kumactl/cmd/config/config_control_planes_add.go
@@ -32,6 +32,7 @@ func newConfigControlPlanesAddCmd(pctx *kumactl_cmd.RootContext) *cobra.Command 
 		Use:   "add",
 		Short: "Add a Control Plane",
 		Long:  `Add a Control Plane.`,
+		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			if err := validateArgs(args, pctx.Runtime.AuthnPlugins); err != nil {
 				return err

--- a/app/kumactl/cmd/config/config_control_planes_list.go
+++ b/app/kumactl/cmd/config/config_control_planes_list.go
@@ -13,6 +13,7 @@ func newConfigControlPlanesListCmd(pctx *kumactl_cmd.RootContext) *cobra.Command
 		Use:   "list",
 		Short: "List Control Planes",
 		Long:  `List Control Planes.`,
+		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			context, _ := pctx.CurrentContext()
 

--- a/app/kumactl/cmd/config/config_control_planes_remove.go
+++ b/app/kumactl/cmd/config/config_control_planes_remove.go
@@ -15,6 +15,7 @@ func newConfigControlPlanesRemoveCmd(pctx *kumactl_cmd.RootContext) *cobra.Comma
 		Use:   "remove",
 		Short: "Remove a Control Plane",
 		Long:  `Remove a Control Plane.`,
+		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			cfg := pctx.Config()
 			if !cfg.RemoveControlPlane(args.name) {

--- a/app/kumactl/cmd/config/config_control_planes_switch.go
+++ b/app/kumactl/cmd/config/config_control_planes_switch.go
@@ -15,6 +15,7 @@ func newConfigControlPlanesSwitchCmd(pctx *kumactl_cmd.RootContext) *cobra.Comma
 		Use:   "switch",
 		Short: "Switch active Control Plane",
 		Long:  `Switch active Control Plane.`,
+		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			cfg := pctx.Config()
 			if !cfg.SwitchContext(args.name) {

--- a/app/kumactl/cmd/config/config_view.go
+++ b/app/kumactl/cmd/config/config_view.go
@@ -13,6 +13,7 @@ func newConfigViewCmd(pctx *kumactl_cmd.RootContext) *cobra.Command {
 		Use:   "view",
 		Short: "Show kumactl config",
 		Long:  `Show kumactl config.`,
+		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			cfg := pctx.Config()
 			contents, err := util_proto.ToYAML(cfg)

--- a/app/kumactl/cmd/generate/generate_certificate.go
+++ b/app/kumactl/cmd/generate/generate_certificate.go
@@ -40,6 +40,7 @@ func NewGenerateCertificateCmd(pctx *kumactl_cmd.RootContext) *cobra.Command {
 
   # Generate a TLS certificate for use by a client of an HTTPS server, i.e. by the 'kumactl generate dataplane-token' command
   kumactl generate tls-certificate --type=client`,
+		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			if ctx.args.certType != "client" && ctx.args.certType != "server" {
 				return errors.New(`--type has to be either "client" or "server"`)

--- a/app/kumactl/cmd/generate/generate_dataplane_token.go
+++ b/app/kumactl/cmd/generate/generate_dataplane_token.go
@@ -38,6 +38,7 @@ $ kumactl generate dataplane-token --type ingress
 Generate token bound by tag
 $ kumactl generate dataplane-token --mesh demo --tag kuma.io/service=web,web-api
 `,
+		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			client, err := pctx.CurrentDataplaneTokenClient()
 			if err != nil {

--- a/app/kumactl/cmd/generate/generate_signing_key.go
+++ b/app/kumactl/cmd/generate/generate_signing_key.go
@@ -34,6 +34,7 @@ metadata:
 type: system.kuma.io/global-secret
 " | kubectl apply -f - 
 `,
+		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			key, err := ctx.GenerateContext.NewSigningKey()
 			if err != nil {

--- a/app/kumactl/cmd/generate/generate_zoneingress_token.go
+++ b/app/kumactl/cmd/generate/generate_zoneingress_token.go
@@ -25,6 +25,7 @@ func NewGenerateZoneIngressTokenCmd(pctx *kumactl_cmd.RootContext) *cobra.Comman
 Generate token bound by zone
 $ kumactl generate zone-ingress-token --zone zone-1
 `,
+		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			client, err := pctx.CurrentZoneIngressTokenClient()
 			if err != nil {

--- a/app/kumactl/cmd/get/get_circuit_breakers_test.go
+++ b/app/kumactl/cmd/get/get_circuit_breakers_test.go
@@ -142,15 +142,10 @@ var _ = Describe("kumactl get circuit-breakers", func() {
 
 		DescribeTable("kumactl get circuit-breakers -o table|json|yaml",
 			func(given testCase) {
-				// given
-				rootCmd.SetArgs(append([]string{
-					"--config-file", filepath.Join("..", "testdata", "sample-kumactl.config.yaml"),
-					"get", "circuit-breakers"}, given.outputFormat, given.pagination))
-
 				// when
-				err := rootCmd.Execute()
-				// then
-				Expect(err).ToNot(HaveOccurred())
+				Expect(
+					ExecuteRootCommand(rootCmd, "circuit-breakers", given.outputFormat, given.pagination),
+				).To(Succeed())
 
 				// when
 				expected, err := ioutil.ReadFile(filepath.Join("testdata", given.goldenFile))

--- a/app/kumactl/cmd/get/get_dataplanes_test.go
+++ b/app/kumactl/cmd/get/get_dataplanes_test.go
@@ -118,13 +118,11 @@ var _ = Describe("kumactl get dataplanes", func() {
 
 		DescribeTable("kumactl get dataplanes -o table|json|yaml",
 			func(given testCase) {
-				// given
-				rootCmd.SetArgs(append([]string{
-					"--config-file", filepath.Join("..", "testdata", "sample-kumactl.config.yaml"),
-					"get", "dataplanes"}, given.outputFormat, given.pagination))
-
 				// when
-				Expect(rootCmd.Execute()).ToNot(HaveOccurred())
+				Expect(
+					ExecuteRootCommand(rootCmd, "dataplanes", given.outputFormat, given.pagination),
+				).To(Succeed())
+
 				// then
 				Expect(buf.String()).To(given.matcher(
 					filepath.Join("testdata", given.goldenFile),

--- a/app/kumactl/cmd/get/get_external_services_test.go
+++ b/app/kumactl/cmd/get/get_external_services_test.go
@@ -99,15 +99,10 @@ var _ = Describe("kumactl get external-services", func() {
 
 		DescribeTable("kumactl get external-services -o table|json|yaml",
 			func(given testCase) {
-				// given
-				rootCmd.SetArgs(append([]string{
-					"--config-file", filepath.Join("..", "testdata", "sample-kumactl.config.yaml"),
-					"get", "external-services"}, given.outputFormat, given.pagination))
-
 				// when
-				err := rootCmd.Execute()
-				// then
-				Expect(err).ToNot(HaveOccurred())
+				Expect(
+					ExecuteRootCommand(rootCmd, "external-services", given.outputFormat, given.pagination),
+				).To(Succeed())
 
 				// when
 				expected, err := ioutil.ReadFile(filepath.Join("testdata", given.goldenFile))

--- a/app/kumactl/cmd/get/get_fault_injections_test.go
+++ b/app/kumactl/cmd/get/get_fault_injections_test.go
@@ -136,15 +136,10 @@ var _ = Describe("kumactl get fault-injections", func() {
 
 		DescribeTable("kumactl get fault-injections -o table|json|yaml",
 			func(given testCase) {
-				// given
-				rootCmd.SetArgs(append([]string{
-					"--config-file", filepath.Join("..", "testdata", "sample-kumactl.config.yaml"),
-					"get", "fault-injections"}, given.outputFormat, given.pagination))
-
 				// when
-				err := rootCmd.Execute()
-				// then
-				Expect(err).ToNot(HaveOccurred())
+				Expect(
+					ExecuteRootCommand(rootCmd, "fault-injections", given.outputFormat, given.pagination),
+				).To(Succeed())
 
 				// when
 				expected, err := ioutil.ReadFile(filepath.Join("testdata", given.goldenFile))

--- a/app/kumactl/cmd/get/get_global_secrets_test.go
+++ b/app/kumactl/cmd/get/get_global_secrets_test.go
@@ -82,18 +82,13 @@ var _ = Describe("kumactl get global-secrets", func() {
 			goldenFile   string
 		}
 
-		DescribeTable("kumactl get secrets -o table|json|yaml",
+		DescribeTable("kumactl get global-secrets -o table|json|yaml",
 			func(given testCase) {
-				// given
-				rootCmd.SetArgs(append([]string{
-					"--config-file", filepath.Join("..", "testdata", "sample-kumactl.config.yaml"),
-					"get", "global-secrets"}, given.outputFormat))
-
 				// when
-				err := rootCmd.Execute()
+				Expect(
+					ExecuteRootCommand(rootCmd, "global-secrets", given.outputFormat, ""),
+				).To(Succeed())
 
-				// then
-				Expect(err).ToNot(HaveOccurred())
 				Expect(buf.String()).To(MatchGoldenEqual(filepath.Join("testdata", given.goldenFile)))
 			},
 			Entry("should support Table output by default", testCase{

--- a/app/kumactl/cmd/get/get_healthchecks_test.go
+++ b/app/kumactl/cmd/get/get_healthchecks_test.go
@@ -89,15 +89,10 @@ var _ = Describe("kumactl get healthchecks", func() {
 
 		DescribeTable("kumactl get healthchecks -o table|json|yaml",
 			func(given testCase) {
-				// given
-				rootCmd.SetArgs(append([]string{
-					"--config-file", filepath.Join("..", "testdata", "sample-kumactl.config.yaml"),
-					"get", "healthchecks"}, given.outputFormat, given.pagination))
-
 				// when
-				err := rootCmd.Execute()
-				// then
-				Expect(err).ToNot(HaveOccurred())
+				Expect(
+					ExecuteRootCommand(rootCmd, "healthchecks", given.outputFormat, given.pagination),
+				).To(Succeed())
 
 				// when
 				expected, err := ioutil.ReadFile(filepath.Join("testdata", given.goldenFile))

--- a/app/kumactl/cmd/get/get_meshes_test.go
+++ b/app/kumactl/cmd/get/get_meshes_test.go
@@ -162,15 +162,10 @@ var _ = Describe("kumactl get meshes", func() {
 
 		DescribeTable("kumactl get meshes -o table|json|yaml",
 			func(given testCase) {
-				// given
-				rootCmd.SetArgs(append([]string{
-					"--config-file", filepath.Join("..", "testdata", "sample-kumactl.config.yaml"),
-					"get", "meshes"}, given.outputFormat, given.pagination))
-
 				// when
-				err := rootCmd.Execute()
-				// then
-				Expect(err).ToNot(HaveOccurred())
+				Expect(
+					ExecuteRootCommand(rootCmd, "meshes", given.outputFormat, given.pagination),
+				).To(Succeed())
 
 				// when
 				expected, err := ioutil.ReadFile(filepath.Join("testdata", given.goldenFile))

--- a/app/kumactl/cmd/get/get_proxytemplates_test.go
+++ b/app/kumactl/cmd/get/get_proxytemplates_test.go
@@ -90,15 +90,10 @@ var _ = Describe("kumactl get proxytemplates", func() {
 
 		DescribeTable("kumactl get proxytemplates -o table|json|yaml",
 			func(given testCase) {
-				// given
-				rootCmd.SetArgs(append([]string{
-					"--config-file", filepath.Join("..", "testdata", "sample-kumactl.config.yaml"),
-					"get", "proxytemplates"}, given.outputFormat, given.pagination))
-
 				// when
-				err := rootCmd.Execute()
-				// then
-				Expect(err).ToNot(HaveOccurred())
+				Expect(
+					ExecuteRootCommand(rootCmd, "proxytemplates", given.outputFormat, given.pagination),
+				).To(Succeed())
 
 				// when
 				expected, err := ioutil.ReadFile(filepath.Join("testdata", given.goldenFile))

--- a/app/kumactl/cmd/get/get_ratelimits_test.go
+++ b/app/kumactl/cmd/get/get_ratelimits_test.go
@@ -109,15 +109,10 @@ var _ = Describe("kumactl get rate-limits", func() {
 
 		DescribeTable("kumactl get rate-limits -o table|json|yaml",
 			func(given testCase) {
-				// given
-				rootCmd.SetArgs(append([]string{
-					"--config-file", filepath.Join("..", "testdata", "sample-kumactl.config.yaml"),
-					"get", "rate-limits"}, given.outputFormat, given.pagination))
-
 				// when
-				err := rootCmd.Execute()
-				// then
-				Expect(err).ToNot(HaveOccurred())
+				Expect(
+					ExecuteRootCommand(rootCmd, "rate-limits", given.outputFormat, given.pagination),
+				).To(Succeed())
 
 				// when
 				expected, err := ioutil.ReadFile(filepath.Join("testdata", given.goldenFile))

--- a/app/kumactl/cmd/get/get_resource.go
+++ b/app/kumactl/cmd/get/get_resource.go
@@ -20,7 +20,7 @@ func NewGetResourceCmd(pctx *kumactl_cmd.RootContext, desc core_model.ResourceTy
 		Use:   fmt.Sprintf("%s NAME", desc.KumactlArg),
 		Short: fmt.Sprintf("Show a single %s resource", desc.Name),
 		Long:  fmt.Sprintf("Show a single %s resource.", desc.Name),
-		Args:  cobra.MinimumNArgs(1),
+		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			rs, err := pctx.CurrentResourceStore()
 			if err != nil {

--- a/app/kumactl/cmd/get/get_resources.go
+++ b/app/kumactl/cmd/get/get_resources.go
@@ -20,6 +20,7 @@ func NewGetResourcesCmd(pctx *kumactl_cmd.RootContext, desc model.ResourceTypeDe
 		Use:   desc.KumactlListArg,
 		Short: fmt.Sprintf("Show %s", desc.Name),
 		Long:  fmt.Sprintf("Show %s entities.", desc.Name),
+		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			rs, err := pctx.CurrentResourceStore()
 			if err != nil {

--- a/app/kumactl/cmd/get/get_retries_test.go
+++ b/app/kumactl/cmd/get/get_retries_test.go
@@ -91,22 +91,10 @@ var _ = Describe("kumactl get retries", func() {
 
 		DescribeTable("kumactl get retries -o table|json|yaml",
 			func(given testCase) {
-				// given
-				rootCmd.SetArgs(append(
-					[]string{
-						"--config-file",
-						filepath.Join("..", "testdata", "sample-kumactl.config.yaml"),
-						"get",
-						"retries",
-					},
-					given.outputFormat,
-					given.pagination,
-				))
-
 				// when
-				err := rootCmd.Execute()
-				// then
-				Expect(err).ToNot(HaveOccurred())
+				Expect(
+					ExecuteRootCommand(rootCmd, "retries", given.outputFormat, given.pagination),
+				).To(Succeed())
 
 				// when
 				testDataPath := filepath.Join("testdata", given.goldenFile)

--- a/app/kumactl/cmd/get/get_secrets_test.go
+++ b/app/kumactl/cmd/get/get_secrets_test.go
@@ -87,15 +87,10 @@ var _ = Describe("kumactl get secrets", func() {
 
 		DescribeTable("kumactl get secrets -o table|json|yaml",
 			func(given testCase) {
-				// given
-				rootCmd.SetArgs(append([]string{
-					"--config-file", filepath.Join("..", "testdata", "sample-kumactl.config.yaml"),
-					"get", "secrets"}, given.outputFormat))
-
 				// when
-				err := rootCmd.Execute()
-				// then
-				Expect(err).ToNot(HaveOccurred())
+				Expect(
+					ExecuteRootCommand(rootCmd, "secrets", given.outputFormat, ""),
+				).To(Succeed())
 
 				// when
 				expected, err := ioutil.ReadFile(filepath.Join("testdata", given.goldenFile))

--- a/app/kumactl/cmd/get/get_single_resource_test.go
+++ b/app/kumactl/cmd/get/get_single_resource_test.go
@@ -100,8 +100,8 @@ var _ = Describe("kumactl get [resource] NAME", func() {
 
 			// then
 			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(Equal("requires at least 1 arg(s), only received 0"))
-			Expect(outbuf.String()).To(MatchRegexp(`Error: requires at least 1 arg\(s\), only received 0`))
+			Expect(err.Error()).To(Equal("accepts 1 arg(s), received 0"))
+			Expect(outbuf.String()).To(MatchRegexp(`Error: accepts 1 arg\(s\), received 0`))
 		},
 		entries...,
 	)

--- a/app/kumactl/cmd/get/get_test.go
+++ b/app/kumactl/cmd/get/get_test.go
@@ -1,6 +1,8 @@
 package get_test
 
 import (
+	"path/filepath"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/spf13/cobra"
@@ -22,6 +24,26 @@ func hasSubCommand(cmd *cobra.Command, sub string) bool {
 	}
 
 	return false
+}
+
+func ExecuteRootCommand(cmd *cobra.Command, resourceName string, formatOpt string, pageOpt string) error {
+	args := []string{
+		"--config-file",
+		filepath.Join("..", "testdata", "sample-kumactl.config.yaml"),
+		"get",
+		resourceName,
+	}
+
+	if formatOpt != "" {
+		args = append(args, formatOpt)
+	}
+
+	if pageOpt != "" {
+		args = append(args, pageOpt)
+	}
+
+	cmd.SetArgs(args)
+	return cmd.Execute()
 }
 
 var _ = Describe("kumactl get ", func() {

--- a/app/kumactl/cmd/get/get_traffic_logs_test.go
+++ b/app/kumactl/cmd/get/get_traffic_logs_test.go
@@ -115,15 +115,10 @@ var _ = Describe("kumactl get traffic-logs", func() {
 
 		DescribeTable("kumactl get traffic-logs -o table|json|yaml",
 			func(given testCase) {
-				// given
-				rootCmd.SetArgs(append([]string{
-					"--config-file", filepath.Join("..", "testdata", "sample-kumactl.config.yaml"),
-					"get", "traffic-logs"}, given.outputFormat, given.pagination))
-
 				// when
-				err := rootCmd.Execute()
-				// then
-				Expect(err).ToNot(HaveOccurred())
+				Expect(
+					ExecuteRootCommand(rootCmd, "traffic-logs", given.outputFormat, given.pagination),
+				).To(Succeed())
 
 				// when
 				expected, err := ioutil.ReadFile(filepath.Join("testdata", given.goldenFile))

--- a/app/kumactl/cmd/get/get_traffic_routes_test.go
+++ b/app/kumactl/cmd/get/get_traffic_routes_test.go
@@ -90,15 +90,10 @@ var _ = Describe("kumactl get traffic-routes", func() {
 
 		DescribeTable("kumactl get traffic-routes -o table|json|yaml",
 			func(given testCase) {
-				// given
-				rootCmd.SetArgs(append([]string{
-					"--config-file", filepath.Join("..", "testdata", "sample-kumactl.config.yaml"),
-					"get", "traffic-routes"}, given.outputFormat, given.pagination))
-
 				// when
-				err := rootCmd.Execute()
-				// then
-				Expect(err).ToNot(HaveOccurred())
+				Expect(
+					ExecuteRootCommand(rootCmd, "traffic-routes", given.outputFormat, given.pagination),
+				).To(Succeed())
 
 				// when
 				expected, err := ioutil.ReadFile(filepath.Join("testdata", given.goldenFile))

--- a/app/kumactl/cmd/get/get_traffic_traces_test.go
+++ b/app/kumactl/cmd/get/get_traffic_traces_test.go
@@ -99,15 +99,10 @@ var _ = Describe("kumactl get traffic-traces", func() {
 
 		DescribeTable("kumactl get traffic-traces -o table|json|yaml",
 			func(given testCase) {
-				// given
-				rootCmd.SetArgs(append([]string{
-					"--config-file", filepath.Join("..", "testdata", "sample-kumactl.config.yaml"),
-					"get", "traffic-traces"}, given.outputFormat, given.pagination))
-
 				// when
-				err := rootCmd.Execute()
-				// then
-				Expect(err).ToNot(HaveOccurred())
+				Expect(
+					ExecuteRootCommand(rootCmd, "traffic-traces", given.outputFormat, given.pagination),
+				).To(Succeed())
 
 				// when
 				expected, err := ioutil.ReadFile(filepath.Join("testdata", given.goldenFile))

--- a/app/kumactl/cmd/get/get_trafficpermissions_test.go
+++ b/app/kumactl/cmd/get/get_trafficpermissions_test.go
@@ -109,15 +109,10 @@ var _ = Describe("kumactl get traffic-permissions", func() {
 
 		DescribeTable("kumactl get traffic-permissions -o table|json|yaml",
 			func(given testCase) {
-				// given
-				rootCmd.SetArgs(append([]string{
-					"--config-file", filepath.Join("..", "testdata", "sample-kumactl.config.yaml"),
-					"get", "traffic-permissions"}, given.outputFormat, given.pagination))
-
 				// when
-				err := rootCmd.Execute()
-				// then
-				Expect(err).ToNot(HaveOccurred())
+				Expect(
+					ExecuteRootCommand(rootCmd, "traffic-permissions", given.outputFormat, given.pagination),
+				).To(Succeed())
 
 				// when
 				expected, err := ioutil.ReadFile(filepath.Join("testdata", given.goldenFile))

--- a/app/kumactl/cmd/get/get_zone-ingresses_test.go
+++ b/app/kumactl/cmd/get/get_zone-ingresses_test.go
@@ -98,16 +98,10 @@ var _ = Describe("kumactl get zone-ingresses", func() {
 
 		DescribeTable("kumactl get zone-ingresses -o table|json|yaml",
 			func(given testCase) {
-				// given
-				rootCmd.SetArgs(append([]string{
-					"--config-file", filepath.Join("..", "testdata", "sample-kumactl.config.yaml"),
-					"get", "zone-ingresses"}, given.outputFormat, given.pagination))
-
 				// when
-				err := rootCmd.Execute()
-				// then
-				Expect(err).ToNot(HaveOccurred())
-
+				Expect(
+					ExecuteRootCommand(rootCmd, "zone-ingresses", given.outputFormat, given.pagination),
+				).To(Succeed())
 				// when
 				expected, err := ioutil.ReadFile(filepath.Join("testdata", given.goldenFile))
 				// then

--- a/app/kumactl/cmd/get/get_zones_test.go
+++ b/app/kumactl/cmd/get/get_zones_test.go
@@ -72,15 +72,10 @@ var _ = Describe("kumactl get zones", func() {
 
 		DescribeTable("kumactl get zones -o table|json|yaml",
 			func(given testCase) {
-				// given
-				rootCmd.SetArgs(append([]string{
-					"--config-file", filepath.Join("..", "testdata", "sample-kumactl.config.yaml"),
-					"get", "zones"}, given.outputFormat, given.pagination))
-
 				// when
-				err := rootCmd.Execute()
-				// then
-				Expect(err).ToNot(HaveOccurred())
+				Expect(
+					ExecuteRootCommand(rootCmd, "zones", given.outputFormat, given.pagination),
+				).To(Succeed())
 
 				// when
 				expected, err := ioutil.ReadFile(filepath.Join("testdata", given.goldenFile))


### PR DESCRIPTION
### Summary

Add cobra argument count specifiers to all the kumactl subcommands. This
improve command-line validation and lets cobra emit better error messages.

### Full changelog

* Improved kumactl argument validation.

### Issues resolved

N/A

### Documentation

N/A

### Testing

- [x] Unit tests
- [x] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes 

### Backwards compatibility

- [x] Add `backport-to-stable` label if the code is backwards compatible. Otherwise, list breaking changes.
