### PR TITLE
tests(e2e) fix tests if using ipv6 locally

### DIFF
--- a/test/framework/universal_app.go
+++ b/test/framework/universal_app.go
@@ -229,7 +229,7 @@ func NewUniversalApp(t testing.TestingT, clusterName, dpName string, mode AppMod
 		// Here we make sure the IPv6 address is not allocated to the container unless explicitly requested.
 		opts.OtherOptions = append(opts.OtherOptions, "--sysctl", "net.ipv6.conf.all.disable_ipv6=1")
 	}
-	opts.OtherOptions = append(opts.OtherOptions, app.publishPortsForDocker()...)
+	opts.OtherOptions = append(opts.OtherOptions, app.publishPortsForDocker(isipv6)...)
 	container, err := docker.RunAndGetIDE(t, GetUniversalImage(), &opts)
 	if err != nil {
 		return nil, err
@@ -262,9 +262,16 @@ func (s *UniversalApp) allocatePublicPortsFor(ports ...string) {
 	}
 }
 
-func (s *UniversalApp) publishPortsForDocker() (args []string) {
+func (s *UniversalApp) publishPortsForDocker(isipv6 bool) (args []string) {
+	// If we aren't using IPv6 in the container then we only want to listen on
+	// IPv4 interfaces to prevent resolving 'localhost' to the IPv6 address of
+	// the container and having the container not respond.
+	ip := "0.0.0.0:"
+	if isipv6 {
+		ip = ""
+	}
 	for port, pubPort := range s.ports {
-		args = append(args, "--publish="+pubPort+":"+port)
+		args = append(args, "--publish="+ip+pubPort+":"+port)
 	}
 	return
 }


### PR DESCRIPTION
### Summary

If `ipisv6` is `false` but the host is using `ipv6`, docker listens on `ipv6` and `ipv4` ports while `ipv6` is disabled in the container, causing connections to the `kuma-universal` container to fail when using `"localhost"`. This makes docker listen only on `ipv4`.

### Backwards compatibility

- [x] Add `backport-to-stable` label if the code is backwards compatible. Otherwise, list breaking changes.
