### PR TITLE
chore(ci) fix k8s_api_bypass test to work when using k3d

### DIFF
--- a/mk/k3d.mk
+++ b/mk/k3d.mk
@@ -43,7 +43,7 @@ k3d/load/images:
     	$(KUMA_CP_DOCKER_IMAGE) $(KUMA_DP_DOCKER_IMAGE) \
     	$(KUMA_INIT_DOCKER_IMAGE) $(KUMA_PROMETHEUS_SD_DOCKER_IMAGE) \
     	$(KUMACTL_DOCKER_IMAGE) kuma-universal:latest \
-    	--cluster=$(KIND_CLUSTER_NAME) --trace
+    	--cluster=$(KIND_CLUSTER_NAME) --verbose
 
 .PHONY: k3d/load
 k3d/load: image/kuma-cp image/kuma-dp image/kuma-init image/kuma-prometheus-sd image/kumactl docker/build/kuma-universal k3d/load/images

--- a/test/e2e/k8s_api_bypass/k8s_api_bypass.go
+++ b/test/e2e/k8s_api_bypass/k8s_api_bypass.go
@@ -99,22 +99,22 @@ metadata:
 		header := fmt.Sprintf("Authorization: Bearer %s", token)
 		url := fmt.Sprintf("%s/api", apiServer)
 
-		cmd := fmt.Sprintf("curl --cacert %s --header %q -X GET -v -m 3 --fail %s", caCert, header, url)
+		cmd := fmt.Sprintf("curl -s --cacert %s --header %q -o /dev/null -w '%%{http_code}\\n' -m 3 --fail %s", caCert, header, url)
 
 		// given Mesh with passthrough enabled then communication with API Server works
-		_, stderr, err := cluster.ExecWithRetries(TestNamespace, clientPod.GetName(), "demo-client",
+		stdout, _, err := cluster.ExecWithRetries(TestNamespace, clientPod.GetName(), "demo-client",
 			"bash", "-c", cmd)
 		Expect(err).ToNot(HaveOccurred())
-		Expect(stderr).To(ContainSubstring("HTTP/2 200"))
+		Expect(stdout).To(Equal("200"))
 
 		// when passthrough is disabled on the Mesh
 		err = YamlK8s(fmt.Sprintf(meshDefaultMtlsOn, "false"))(cluster)
 		Expect(err).ToNot(HaveOccurred())
 
 		// then communication with API Server still works
-		_, stderr, err = cluster.ExecWithRetries(TestNamespace, clientPod.GetName(), "demo-client",
+		stdout, _, err = cluster.ExecWithRetries(TestNamespace, clientPod.GetName(), "demo-client",
 			"bash", "-c", cmd)
 		Expect(err).ToNot(HaveOccurred())
-		Expect(stderr).To(ContainSubstring("HTTP/2 200"))
+		Expect(stdout).To(Equal("200"))
 	})
 }


### PR DESCRIPTION
k3d api-server is http/1.1 which was making the matcher fail.
Changed the matcher to something more strict (only check the status code).

### Backwards compatibility

- [x] Add `backport-to-stable` label if the code is backwards compatible. Otherwise, list breaking changes.
