### PR TITLE
feat(ci) notify other repo about push to master

### DIFF
--- a/.github/scripts/parsePR.js
+++ b/.github/scripts/parsePR.js
@@ -1,0 +1,49 @@
+module.exports = async ({
+  github = {},
+  owner = 'kumahq',
+  repo = 'kuma',
+}, foundPR = null) => {
+  if (!foundPR) {
+    return null
+  }
+
+  try {
+    const { number, title } = foundPR;
+
+    const { data = {} } = await github.rest.pulls.get({
+      owner,
+      repo,
+      pull_number: number,
+    });
+
+    const {
+      user = {},
+      merged_by: mergedBy = {},
+      labels: fullLabels = [],
+    } = data;
+
+    const labels = fullLabels.map(({ id, name, description }) => ({
+      id,
+      name,
+      description,
+    }));
+
+    return {
+      number: number,
+      title: title,
+      openedBy: {
+        login: user.login,
+        id: user.id,
+      },
+      mergedBy: {
+        login: mergedBy.login,
+        id: mergedBy.id,
+      },
+      labels,
+    };
+  } catch (e) {
+    console.error(e);
+  }
+
+  return null;
+};

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -1,0 +1,46 @@
+name: "Push"
+
+on:
+  push:
+    branches:
+    - master
+
+  workflow_dispatch:
+
+jobs:
+  notify-about-push:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2 # necessary to have access to scripts directory
+
+    - uses: jwalton/gh-find-current-pr@v1
+      id: findPR
+      with:
+        state: all
+
+    - name: "Notify other repositories about push to master"
+      uses: actions/github-script@v5
+      with:
+        github-token: ${{ secrets.NOTIFY_GH_TOKEN }}
+        script: |
+          const parsePR = require('./.github/scripts/parsePR.js');
+          const { repository = 'kumahq/kuma', payload } = context;
+          const { before, after, commits = [] } = payload;
+          const [ owner, repo ] = repository.split('/');
+          const pr = await parsePR(
+            { github, owner, repo },
+            ${{ toJSON(steps.findPR.outputs) }},
+          );
+
+          github.rest.repos.createDispatchEvent({
+            owner: '${{ secrets.NOTIFY_OWNER }}',
+            repo: '${{ secrets.NOTIFY_REPO }}',
+            event_type: '${{ secrets.NOTIFY_EVENT_TYPE }}',
+            client_payload: {
+              before,
+              after,
+              pr,
+              commits: commits.map(({ id }) => id),
+            },
+          });


### PR DESCRIPTION
### Summary

This PR introduces boilerplate for sending dispatch_event to other
repositories when any code will hit the master

### Full changelog

no changelog

### Issues resolved

no issues resolved

### Documentation

no documentation

### Testing

- [ ] Unit tests
- [ ] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes 

### Backwards compatibility

- [ ] Add `backport-to-stable` label if the code is backwards compatible. Otherwise, list breaking changes.
