### PR TITLE
chore(ci) run ipv4 e2e using k3d instead of kind

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -893,6 +893,7 @@ jobs:
                   export API_VERSION=<< parameters.api >>
                   export GINKGO_XUNIT_RESULTS_DIR=/tmp/xunit
                   export BUILD_WITH_EXPERIMENTAL_GATEWAY=Y
+                  export K3D=true
                   make test/e2e
             - store_test_results:
                 path: /tmp/xunit


### PR DESCRIPTION
Restrict this to only ipv4 tests until we figure out v6 on k3d

Following https://github.com/k3s-io/k3s/issues/284 as it looks like v6 support is imminent.

### Backwards compatibility

- [x] Add `backport-to-stable` label if the code is backwards compatible. Otherwise, list breaking changes.
