### PR TITLE
chore(ci) refactor hybrid e2e tests to speed them up

### DIFF
--- a/test/e2e/hybrid/globalkubernetes/e2e_suite_test.go
+++ b/test/e2e/hybrid/globalkubernetes/e2e_suite_test.go
@@ -1,0 +1,21 @@
+package globalkubernetes_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+
+	"github.com/kumahq/kuma/pkg/test"
+	"github.com/kumahq/kuma/test/e2e/hybrid/globalkubernetes"
+	"github.com/kumahq/kuma/test/framework"
+)
+
+func TestE2EDeploy(t *testing.T) {
+	if framework.IsK8sClustersStarted() {
+		test.RunSpecs(t, "E2E Deploy Suite")
+	} else {
+		t.SkipNow()
+	}
+}
+
+var _ = Describe("Test Kubernetes/Universal deployment when Global is on K8S", globalkubernetes.KubernetesUniversalDeploymentWhenGlobalIsOnK8S)

--- a/test/e2e/hybrid/globalkubernetes/kuma_hybrid_kube_global.go
+++ b/test/e2e/hybrid/globalkubernetes/kuma_hybrid_kube_global.go
@@ -1,4 +1,4 @@
-package hybrid
+package globalkubernetes
 
 import (
 	. "github.com/onsi/ginkgo"

--- a/test/e2e/hybrid/globaluniversal/e2e_suite_test.go
+++ b/test/e2e/hybrid/globaluniversal/e2e_suite_test.go
@@ -1,9 +1,12 @@
-package hybrid_test
+package globaluniversal_test
 
 import (
 	"testing"
 
+	. "github.com/onsi/ginkgo"
+
 	"github.com/kumahq/kuma/pkg/test"
+	"github.com/kumahq/kuma/test/e2e/hybrid/globaluniversal"
 	"github.com/kumahq/kuma/test/framework"
 )
 
@@ -14,3 +17,5 @@ func TestE2EDeploy(t *testing.T) {
 		t.SkipNow()
 	}
 }
+
+var _ = Describe("Test Kubernetes/Universal deployment", globaluniversal.KubernetesUniversalDeployment)

--- a/test/e2e/hybrid/globaluniversal/kuma_hybrid.go
+++ b/test/e2e/hybrid/globaluniversal/kuma_hybrid.go
@@ -1,4 +1,4 @@
-package hybrid
+package globaluniversal
 
 import (
 	"fmt"
@@ -45,7 +45,7 @@ metadata:
 	const nonDefaultMesh = "non-default"
 	const defaultMesh = "default"
 
-	BeforeEach(func() {
+	BeforeSuite(func() {
 		k8sClusters, err := NewK8sClusters(
 			[]string{Kuma1, Kuma2},
 			Silent)
@@ -148,7 +148,7 @@ metadata:
 		Expect(err).ToNot(HaveOccurred())
 	})
 
-	AfterEach(func() {
+	AfterSuite(func() {
 		if ShouldSkipCleanup() {
 			return
 		}

--- a/test/e2e/hybrid/kuma_hybrid_kube_global_test.go
+++ b/test/e2e/hybrid/kuma_hybrid_kube_global_test.go
@@ -1,9 +1,0 @@
-package hybrid_test
-
-import (
-	. "github.com/onsi/ginkgo"
-
-	"github.com/kumahq/kuma/test/e2e/hybrid"
-)
-
-var _ = Describe("Test Kubernetes/Universal deployment when Global is on K8S", hybrid.KubernetesUniversalDeploymentWhenGlobalIsOnK8S)

--- a/test/e2e/hybrid/kuma_hybrid_test.go
+++ b/test/e2e/hybrid/kuma_hybrid_test.go
@@ -1,9 +1,0 @@
-package hybrid_test
-
-import (
-	. "github.com/onsi/ginkgo"
-
-	"github.com/kumahq/kuma/test/e2e/hybrid"
-)
-
-var _ = Describe("Test Kubernetes/Universal deployment", hybrid.KubernetesUniversalDeployment)


### PR DESCRIPTION
Don't recreate CP and apps for every tests as we're only asserting that things are
the way we want

Signed-off-by: Charly Molter <charly.molter@konghq.com>

### Summary

SUMMARY_GOES_HERE

### Full changelog

* [Implement ...]
* [Fix ...]

### Issues resolved

Fix #XXX

### Documentation

- [ ] Link to the website [documentation PR](https://github.com/kumahq/kuma-website/pull/XXX)

### Testing

- [ ] Unit tests
- [ ] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes 

### Backwards compatibility

- [ ] Add `backport-to-stable` label if the code is backwards compatible. Otherwise, list breaking changes.
