### PR TITLE
fix(ci) correct runtime builder ordering

### DIFF
--- a/pkg/core/datasource/loader.go
+++ b/pkg/core/datasource/loader.go
@@ -50,6 +50,9 @@ func (l *loader) Load(ctx context.Context, mesh string, source *system_proto.Dat
 }
 
 func (l *loader) loadSecret(ctx context.Context, mesh string, secret string) ([]byte, error) {
+	if l.secretManager == nil {
+		return nil, errors.New("no resource manager")
+	}
 	resource := system.NewSecretResource()
 	if err := l.secretManager.Get(ctx, resource, core_store.GetByKey(secret, mesh)); err != nil {
 		return nil, err

--- a/pkg/test/runtime/runtime.go
+++ b/pkg/test/runtime/runtime.go
@@ -58,21 +58,21 @@ func BuilderFor(appCtx context.Context, cfg kuma_cp.Config) (*core_runtime.Build
 	if err != nil {
 		return nil, err
 	}
+
 	builder.
 		WithComponentManager(component.NewManager(leader_memory.NewAlwaysLeaderElector())).
-		WithResourceStore(resources_memory.NewStore())
-
-	metrics, _ := metrics.NewMetrics("Standalone")
-	builder.WithMetrics(metrics)
-
-	builder.WithSecretStore(secret_store.NewSecretStore(builder.ResourceStore()))
-	builder.WithDataSourceLoader(datasource.NewDataSourceLoader(builder.ResourceManager()))
-	builder.WithMeshValidator(mesh_managers.NewMeshValidator(builder.CaManagers(), builder.ResourceStore()))
+		WithResourceStore(resources_memory.NewStore()).
+		WithSecretStore(secret_store.NewSecretStore(builder.ResourceStore())).
+		WithMeshValidator(mesh_managers.NewMeshValidator(builder.CaManagers(), builder.ResourceStore()))
 
 	rm := newResourceManager(builder)
 	builder.WithResourceManager(rm).
 		WithReadOnlyResourceManager(rm)
 
+	metrics, _ := metrics.NewMetrics("Standalone")
+	builder.WithMetrics(metrics)
+
+	builder.WithDataSourceLoader(datasource.NewDataSourceLoader(builder.ResourceManager()))
 	builder.WithCaManager("builtin", builtin.NewBuiltinCaManager(builder.ResourceManager()))
 	builder.WithLeaderInfo(&component.LeaderInfoComponent{})
 	builder.WithLookupIP(net.LookupIP)


### PR DESCRIPTION
### Summary

Building a core Runtime object has non-obvious dependencies. The ordering
for building the test runtime was broken because we need to ensure that
the resource manager and its dependencies are present before adding the
datasource loader. The previous order resulted in the datasource loader
failing in tests because it had a nil resource manager.

### Full changelog

N/A


### Issues resolved

N/A

### Documentation

N/A

### Testing

- [x] Unit tests
- [x] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes 

### Backwards compatibility

- [x] Add `backport-to-stable` label if the code is backwards compatible. Otherwise, list breaking changes.
