### PR TITLE
feat(kuma-cp) access to generate zone ingress token

### DIFF
--- a/app/kumactl/pkg/tokens/client_test.go
+++ b/app/kumactl/pkg/tokens/client_test.go
@@ -37,7 +37,7 @@ var _ = Describe("Tokens Client", func() {
 
 	BeforeEach(func() {
 		container := restful.NewContainer()
-		container.Add(tokens_server.NewWebservice(&staticTokenIssuer{}, &zoneIngressStaticTokenIssuer{}, access.NoopGenerateDpTokenAccess{}))
+		container.Add(tokens_server.NewWebservice(&staticTokenIssuer{}, &zoneIngressStaticTokenIssuer{}, access.NoopDpTokenAccess{}))
 		server = httptest.NewServer(container.ServeMux)
 	})
 

--- a/app/kumactl/pkg/tokens/zoneingress_client_test.go
+++ b/app/kumactl/pkg/tokens/zoneingress_client_test.go
@@ -37,7 +37,7 @@ var _ = Describe("Zone Ingress Tokens Client", func() {
 
 	BeforeEach(func() {
 		container := restful.NewContainer()
-		container.Add(tokens_server.NewWebservice(&staticTokenIssuer{}, &zoneIngressStaticTokenIssuer{}, access.NoopGenerateDpTokenAccess{}))
+		container.Add(tokens_server.NewWebservice(&staticTokenIssuer{}, &zoneIngressStaticTokenIssuer{}, access.NoopDpTokenAccess{}))
 		server = httptest.NewServer(container.ServeMux)
 	})
 

--- a/pkg/api-server/customization/customization_suite_test.go
+++ b/pkg/api-server/customization/customization_suite_test.go
@@ -57,8 +57,8 @@ func createTestApiServer(store store.ResourceStore, config *config_api_server.Ap
 		func() string { return "cluster-id" },
 		certs.ClientCertAuthenticator,
 		runtime.Access{
-			ResourceAccess:               resources_access.NewAdminResourceAccess(cfg.Access.Static.AdminResources),
-			GenerateDataplaneTokenAccess: nil,
+			ResourceAccess:       resources_access.NewAdminResourceAccess(cfg.Access.Static.AdminResources),
+			DataplaneTokenAccess: nil,
 		},
 	)
 	Expect(err).ToNot(HaveOccurred())

--- a/pkg/api-server/resource_api_client_test.go
+++ b/pkg/api-server/resource_api_client_test.go
@@ -132,8 +132,8 @@ func createTestApiServer(store store.ResourceStore, config *config_api_server.Ap
 		func() string { return "cluster-id" },
 		certs.ClientCertAuthenticator,
 		runtime.Access{
-			ResourceAccess:               resources_access.NewAdminResourceAccess(cfg.Access.Static.AdminResources),
-			GenerateDataplaneTokenAccess: nil,
+			ResourceAccess:       resources_access.NewAdminResourceAccess(cfg.Access.Static.AdminResources),
+			DataplaneTokenAccess: nil,
 		},
 	)
 	Expect(err).ToNot(HaveOccurred())

--- a/pkg/api-server/server.go
+++ b/pkg/api-server/server.go
@@ -140,7 +140,7 @@ func NewApiServer(
 		config: *serverConfig,
 	}
 
-	dpWs, err := dataplaneTokenWs(resManager, access.GenerateDataplaneTokenAccess)
+	dpWs, err := dataplaneTokenWs(resManager, access.DataplaneTokenAccess)
 	if err != nil {
 		return nil, err
 	}
@@ -227,7 +227,7 @@ func addResourcesEndpoints(ws *restful.WebService, defs []model.ResourceTypeDesc
 	}
 }
 
-func dataplaneTokenWs(resManager manager.ResourceManager, access tokens_access.GenerateDataplaneTokenAccess) (*restful.WebService, error) {
+func dataplaneTokenWs(resManager manager.ResourceManager, access tokens_access.DataplaneTokenAccess) (*restful.WebService, error) {
 	dpIssuer, err := builtin.NewDataplaneTokenIssuer(resManager)
 	if err != nil {
 		return nil, err

--- a/pkg/core/bootstrap/bootstrap.go
+++ b/pkg/core/bootstrap/bootstrap.go
@@ -108,8 +108,8 @@ func buildRuntime(appCtx context.Context, cfg kuma_cp.Config) (core_runtime.Runt
 	builder.WithKDSContext(kds_context.DefaultContext(builder.ResourceManager(), cfg.Multizone.Zone.Name))
 
 	builder.WithAccess(core_runtime.Access{
-		ResourceAccess:               resources_access.NewAdminResourceAccess(builder.Config().Access.Static.AdminResources),
-		GenerateDataplaneTokenAccess: tokens_access.NewStaticGenerateDataplaneTokenAccess(builder.Config().Access.Static.GenerateDPToken),
+		ResourceAccess:       resources_access.NewAdminResourceAccess(builder.Config().Access.Static.AdminResources),
+		DataplaneTokenAccess: tokens_access.NewStaticGenerateDataplaneTokenAccess(builder.Config().Access.Static.GenerateDPToken),
 	})
 
 	if err := initializeAPIServerAuthenticator(builder); err != nil {

--- a/pkg/core/runtime/runtime.go
+++ b/pkg/core/runtime/runtime.go
@@ -71,8 +71,8 @@ type RuntimeContext interface {
 }
 
 type Access struct {
-	ResourceAccess               resources_access.ResourceAccess
-	GenerateDataplaneTokenAccess tokens_access.GenerateDataplaneTokenAccess
+	ResourceAccess       resources_access.ResourceAccess
+	DataplaneTokenAccess tokens_access.DataplaneTokenAccess
 }
 
 var _ Runtime = &runtime{}

--- a/pkg/test/runtime/runtime.go
+++ b/pkg/test/runtime/runtime.go
@@ -85,8 +85,8 @@ func BuilderFor(appCtx context.Context, cfg kuma_cp.Config) (*core_runtime.Build
 	builder.WithCAProvider(secrets.NewCaProvider(builder.CaManagers()))
 	builder.WithAPIServerAuthenticator(certs.ClientCertAuthenticator)
 	builder.WithAccess(core_runtime.Access{
-		ResourceAccess:               resources_access.NewAdminResourceAccess(builder.Config().Access.Static.AdminResources),
-		GenerateDataplaneTokenAccess: tokens_access.NewStaticGenerateDataplaneTokenAccess(builder.Config().Access.Static.GenerateDPToken),
+		ResourceAccess:       resources_access.NewAdminResourceAccess(builder.Config().Access.Static.AdminResources),
+		DataplaneTokenAccess: tokens_access.NewStaticGenerateDataplaneTokenAccess(builder.Config().Access.Static.GenerateDPToken),
 	})
 
 	_ = initializeConfigManager(cfg, builder)

--- a/pkg/tokens/builtin/access/access.go
+++ b/pkg/tokens/builtin/access/access.go
@@ -4,6 +4,7 @@ import (
 	"github.com/kumahq/kuma/pkg/core/user"
 )
 
-type GenerateDataplaneTokenAccess interface {
-	ValidateGenerate(name string, mesh string, tags map[string][]string, tokenType string, user user.User) error
+type DataplaneTokenAccess interface {
+	ValidateGenerateDataplaneToken(name string, mesh string, tags map[string][]string, user user.User) error
+	ValidateGenerateZoneIngressToken(zone string, user user.User) error
 }

--- a/pkg/tokens/builtin/access/noop.go
+++ b/pkg/tokens/builtin/access/noop.go
@@ -2,11 +2,15 @@ package access
 
 import "github.com/kumahq/kuma/pkg/core/user"
 
-type NoopGenerateDpTokenAccess struct {
+type NoopDpTokenAccess struct {
 }
 
-var _ GenerateDataplaneTokenAccess = NoopGenerateDpTokenAccess{}
+var _ DataplaneTokenAccess = NoopDpTokenAccess{}
 
-func (n NoopGenerateDpTokenAccess) ValidateGenerate(name string, mesh string, tags map[string][]string, tokenType string, user user.User) error {
+func (n NoopDpTokenAccess) ValidateGenerateDataplaneToken(name string, mesh string, tags map[string][]string, user user.User) error {
+	return nil
+}
+
+func (n NoopDpTokenAccess) ValidateGenerateZoneIngressToken(zone string, user user.User) error {
 	return nil
 }

--- a/pkg/tokens/builtin/access/static.go
+++ b/pkg/tokens/builtin/access/static.go
@@ -11,9 +11,9 @@ type staticGenerateDataplaneTokenAccess struct {
 	groups    map[string]bool
 }
 
-var _ GenerateDataplaneTokenAccess = &staticGenerateDataplaneTokenAccess{}
+var _ DataplaneTokenAccess = &staticGenerateDataplaneTokenAccess{}
 
-func NewStaticGenerateDataplaneTokenAccess(cfg config_access.GenerateDPTokenStaticAccessConfig) GenerateDataplaneTokenAccess {
+func NewStaticGenerateDataplaneTokenAccess(cfg config_access.GenerateDPTokenStaticAccessConfig) DataplaneTokenAccess {
 	s := &staticGenerateDataplaneTokenAccess{
 		usernames: map[string]bool{},
 		groups:    map[string]bool{},
@@ -27,13 +27,15 @@ func NewStaticGenerateDataplaneTokenAccess(cfg config_access.GenerateDPTokenStat
 	return s
 }
 
-func (s *staticGenerateDataplaneTokenAccess) ValidateGenerate(
-	name string,
-	mesh string,
-	tags map[string][]string,
-	tokenType string,
-	user user.User,
-) error {
+func (s *staticGenerateDataplaneTokenAccess) ValidateGenerateDataplaneToken(name string, mesh string, tags map[string][]string, user user.User) error {
+	return s.validateAccess(user)
+}
+
+func (s *staticGenerateDataplaneTokenAccess) ValidateGenerateZoneIngressToken(zone string, user user.User) error {
+	return s.validateAccess(user)
+}
+
+func (s *staticGenerateDataplaneTokenAccess) validateAccess(user user.User) error {
 	allowed := s.usernames[user.Name]
 	for _, group := range user.Groups {
 		if s.groups[group] {

--- a/pkg/tokens/builtin/server/webservice.go
+++ b/pkg/tokens/builtin/server/webservice.go
@@ -21,13 +21,13 @@ var log = core.Log.WithName("dataplane-token-ws")
 type tokenWebService struct {
 	issuer            issuer.DataplaneTokenIssuer
 	zoneIngressIssuer zoneingress.TokenIssuer
-	access            access.GenerateDataplaneTokenAccess
+	access            access.DataplaneTokenAccess
 }
 
 func NewWebservice(
 	issuer issuer.DataplaneTokenIssuer,
 	zoneIngressIssuer zoneingress.TokenIssuer,
-	access access.GenerateDataplaneTokenAccess,
+	access access.DataplaneTokenAccess,
 ) *restful.WebService {
 	ws := tokenWebService{
 		issuer:            issuer,
@@ -63,11 +63,10 @@ func (d *tokenWebService) handleIdentityRequest(request *restful.Request, respon
 		return
 	}
 
-	if err := d.access.ValidateGenerate(
+	if err := d.access.ValidateGenerateDataplaneToken(
 		idReq.Name,
 		idReq.Mesh,
 		idReq.Tags,
-		idReq.Type,
 		user.FromCtx(request.Request.Context()),
 	); err != nil {
 		errors.HandleError(response, err, "Could not issue a token")
@@ -96,6 +95,11 @@ func (d *tokenWebService) handleZoneIngressIdentityRequest(request *restful.Requ
 	if err := request.ReadEntity(&idReq); err != nil {
 		log.Error(err, "Could not read a request")
 		response.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	if err := d.access.ValidateGenerateZoneIngressToken(idReq.Zone, user.FromCtx(request.Request.Context())); err != nil {
+		errors.HandleError(response, err, "Could not issue a token")
 		return
 	}
 

--- a/pkg/tokens/builtin/server/webservice_test.go
+++ b/pkg/tokens/builtin/server/webservice_test.go
@@ -55,7 +55,7 @@ var _ = Describe("Dataplane Token Webservice", func() {
 	var url string
 
 	BeforeEach(func() {
-		ws := server.NewWebservice(&staticTokenIssuer{credentials}, &zoneIngressStaticTokenIssuer{}, &access.NoopGenerateDpTokenAccess{})
+		ws := server.NewWebservice(&staticTokenIssuer{credentials}, &zoneIngressStaticTokenIssuer{}, &access.NoopDpTokenAccess{})
 
 		container := restful.NewContainer()
 		container.Add(ws)


### PR DESCRIPTION
### Summary

Access to generate Zone Ingress token

### Full changelog

* Add access validation to generate zone ingress token
* Remove `tokenType` from generate dp token action since it should be long gone.

### Issues resolved

No issue

### Documentation

- [X] No docs, internal changes in the code. UX stays the same

### Testing

- [X] Unit tests
- [ ] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes 

### Backwards compatibility

- [X] No backporting.
