### PR TITLE
Allow creating secrets for the not yet existing mesh

### DIFF
--- a/pkg/plugins/runtime/k8s/webhooks/secret_validator.go
+++ b/pkg/plugins/runtime/k8s/webhooks/secret_validator.go
@@ -107,9 +107,7 @@ func (v *SecretValidator) validateMeshSecret(ctx context.Context, verr *validato
 		Name: meshOfSecret(secret),
 	}
 	if err := v.Client.Get(ctx, key, &mesh); err != nil {
-		if kube_apierrs.IsNotFound(err) {
-			verr.AddViolationAt(validators.RootedAt("metadata").Field("labels").Key(meshLabel), "mesh does not exist")
-		} else {
+		if !kube_apierrs.IsNotFound(err) {
 			return errors.Wrap(err, "could not fetch mesh")
 		}
 	}

--- a/pkg/plugins/runtime/k8s/webhooks/secret_validator_test.go
+++ b/pkg/plugins/runtime/k8s/webhooks/secret_validator_test.go
@@ -176,7 +176,7 @@ var _ = Describe("ServiceValidator", func() {
             uid: ""
 `,
 		}),
-		Entry("should not allow Secret with mesh that does not exist", testCase{
+		Entry("should allow Secret with mesh that does not exist", testCase{
 			request: `
             apiVersion: admission.k8s.io/v1
             kind: AdmissionReview
@@ -202,21 +202,11 @@ var _ = Describe("ServiceValidator", func() {
               operation: CREATE
 `,
 			expected: `
-            allowed: false
-            status:
-              code: 422
-              details:
-                causes:
-                - field: metadata.labels["kuma.io/mesh"]
-                  message: mesh does not exist
-                  reason: FieldValueInvalid
-                kind: Secret
-                name: sec-1
-              message: 'metadata.labels["kuma.io/mesh"]: mesh does not exist'
-              metadata: {}
-              reason: Invalid
-              status: Failure
-            uid: ""
+              allowed: true
+              status:
+                code: 200
+                metadata: {}
+              uid: ""
 `,
 		}),
 		Entry("should not allow switching mesh in Secret", testCase{


### PR DESCRIPTION
### Summary

Allow creating secrets for the mesh which does not exists. This will unblock the flow where mesh have to be created with the mTLS turned on as otherwise secrets can't be created before the mesh exists.

### Full changelog

* Fix #2722

### Issues resolved

Fix #2722

### Documentation

### Testing

- [X] Unit tests

### Backwards compatibility

