### PR TITLE
chore(*) consolidate RSA key generation policy

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -37,6 +37,8 @@ linters-settings:
       alias: system_proto
     - pkg: github.com/kumahq/kuma/pkg/util/proto
       alias: util_proto
+    - pkg: github.com/kumahq/kuma/pkg/util/rsa
+      alias: util_rsa
     - pkg: github.com/kumahq/kuma/pkg/cmd
       alias: kuma_cmd
     - pkg: github.com/kumahq/kuma/pkg/plugins/bootstrap/k8s

--- a/pkg/core/ca/issuer/issuer.go
+++ b/pkg/core/ca/issuer/issuer.go
@@ -3,7 +3,6 @@ package issuer
 import (
 	"crypto"
 	"crypto/rand"
-	"crypto/rsa"
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
@@ -17,10 +16,10 @@ import (
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	"github.com/kumahq/kuma/pkg/core"
 	util_tls "github.com/kumahq/kuma/pkg/tls"
+	util_rsa "github.com/kumahq/kuma/pkg/util/rsa"
 )
 
 const (
-	DefaultRsaBits                    = 2048
 	DefaultAllowedClockSkew           = 10 * time.Second
 	DefaultWorkloadCertValidityPeriod = 24 * time.Hour
 )
@@ -40,7 +39,7 @@ func NewWorkloadCert(ca util_tls.KeyPair, mesh string, tags mesh_proto.MultiValu
 		return nil, errors.Wrap(err, "failed to load CA key pair")
 	}
 
-	workloadKey, err := rsa.GenerateKey(rand.Reader, DefaultRsaBits)
+	workloadKey, err := util_rsa.GenerateKey(util_rsa.DefaultKeySize)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to generate a private key")
 	}

--- a/pkg/plugins/authn/api-server/tokens/issuer/signing_key.go
+++ b/pkg/plugins/authn/api-server/tokens/issuer/signing_key.go
@@ -2,7 +2,6 @@ package issuer
 
 import (
 	"context"
-	"crypto/rand"
 	"crypto/rsa"
 	"fmt"
 	"sort"
@@ -21,7 +20,6 @@ import (
 )
 
 const (
-	defaultRsaBits   = 2048
 	signingKeyPrefix = "user-token-signing-key-"
 
 	DefaultSerialNumber = 1
@@ -126,7 +124,7 @@ func signingKeySerialNumber(secretName string) (int, error) {
 }
 
 func NewSigningKey() ([]byte, error) {
-	key, err := rsa.GenerateKey(rand.Reader, defaultRsaBits)
+	key, err := util_rsa.GenerateKey(util_rsa.DefaultKeySize)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to generate RSA key")
 	}

--- a/pkg/plugins/ca/builtin/ca.go
+++ b/pkg/plugins/ca/builtin/ca.go
@@ -3,7 +3,6 @@ package builtin
 import (
 	"crypto"
 	"crypto/rand"
-	"crypto/rsa"
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"math/big"
@@ -16,10 +15,10 @@ import (
 	"github.com/kumahq/kuma/pkg/core"
 	core_ca "github.com/kumahq/kuma/pkg/core/ca"
 	util_tls "github.com/kumahq/kuma/pkg/tls"
+	util_rsa "github.com/kumahq/kuma/pkg/util/rsa"
 )
 
 const (
-	DefaultRsaBits              = 2048
 	DefaultAllowedClockSkew     = 10 * time.Second
 	DefaultCACertValidityPeriod = 10 * 365 * 24 * time.Hour
 )
@@ -35,9 +34,9 @@ func withExpirationTime(expiration time.Duration) certOptsFn {
 
 func newRootCa(mesh string, rsaBits int, certOpts ...certOptsFn) (*core_ca.KeyPair, error) {
 	if rsaBits == 0 {
-		rsaBits = DefaultRsaBits
+		rsaBits = util_rsa.DefaultKeySize
 	}
-	key, err := rsa.GenerateKey(rand.Reader, rsaBits)
+	key, err := util_rsa.GenerateKey(rsaBits)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to generate a private key")
 	}

--- a/pkg/tls/cert.go
+++ b/pkg/tls/cert.go
@@ -3,7 +3,6 @@ package tls
 import (
 	"crypto"
 	"crypto/rand"
-	"crypto/rsa"
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"math/big"
@@ -11,10 +10,11 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+
+	util_rsa "github.com/kumahq/kuma/pkg/util/rsa"
 )
 
 var (
-	DefaultRsaBits        = 2048
 	DefaultValidityPeriod = 10 * 365 * 24 * time.Hour
 )
 
@@ -26,7 +26,7 @@ const (
 )
 
 func NewSelfSignedCert(commonName string, certType CertType, hosts ...string) (KeyPair, error) {
-	key, err := rsa.GenerateKey(rand.Reader, DefaultRsaBits)
+	key, err := util_rsa.GenerateKey(util_rsa.DefaultKeySize)
 	if err != nil {
 		return KeyPair{}, errors.Wrap(err, "failed to generate TLS key")
 	}

--- a/pkg/tokens/builtin/issuer/signing_key.go
+++ b/pkg/tokens/builtin/issuer/signing_key.go
@@ -2,8 +2,6 @@ package issuer
 
 import (
 	"context"
-	"crypto/rand"
-	"crypto/rsa"
 	"crypto/x509"
 	"fmt"
 	"strings"
@@ -16,11 +14,10 @@ import (
 	"github.com/kumahq/kuma/pkg/core/resources/model"
 	"github.com/kumahq/kuma/pkg/core/resources/store"
 	util_proto "github.com/kumahq/kuma/pkg/util/proto"
+	util_rsa "github.com/kumahq/kuma/pkg/util/rsa"
 )
 
 const (
-	defaultRsaBits = 2048
-
 	DataplaneTokenPrefix        = "dataplane-token"
 	EnvoyAdminClientTokenPrefix = "envoy-admin-client-token"
 )
@@ -44,7 +41,7 @@ func SigningKeyResourceKey(prefix, meshName string) model.ResourceKey {
 }
 
 func NewSigningKey() ([]byte, error) {
-	key, err := rsa.GenerateKey(rand.Reader, defaultRsaBits)
+	key, err := util_rsa.GenerateKey(util_rsa.DefaultKeySize)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to generate RSA key")
 	}

--- a/pkg/tokens/builtin/zoneingress/signing_key.go
+++ b/pkg/tokens/builtin/zoneingress/signing_key.go
@@ -2,8 +2,6 @@ package zoneingress
 
 import (
 	"context"
-	"crypto/rand"
-	"crypto/rsa"
 	"crypto/x509"
 
 	"github.com/pkg/errors"
@@ -14,10 +12,10 @@ import (
 	core_model "github.com/kumahq/kuma/pkg/core/resources/model"
 	"github.com/kumahq/kuma/pkg/core/resources/store"
 	util_proto "github.com/kumahq/kuma/pkg/util/proto"
+	util_rsa "github.com/kumahq/kuma/pkg/util/rsa"
 )
 
 const (
-	defaultRsaBits = 2048
 	signingKeyName = "zone-ingress-token-signing-key"
 )
 
@@ -49,9 +47,9 @@ func GetSigningKey(manager manager.ReadOnlyResourceManager) ([]byte, error) {
 
 func CreateSigningKey() (*system.GlobalSecretResource, error) {
 	res := system.NewGlobalSecretResource()
-	key, err := rsa.GenerateKey(rand.Reader, defaultRsaBits)
+	key, err := util_rsa.GenerateKey(util_rsa.DefaultKeySize)
 	if err != nil {
-		return res, errors.Wrap(err, "failed to generate rsa key")
+		return res, errors.Wrap(err, "failed to generate RSA key")
 	}
 	res.Spec = &system_proto.Secret{
 		Data: util_proto.Bytes(x509.MarshalPKCS1PrivateKey(key)),

--- a/pkg/util/rsa/keygen.go
+++ b/pkg/util/rsa/keygen.go
@@ -1,0 +1,13 @@
+package rsa
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+)
+
+const DefaultKeySize = 2048
+
+// GenerateKey generates a new default RSA keypair.
+func GenerateKey(bits int) (*rsa.PrivateKey, error) {
+	return rsa.GenerateKey(rand.Reader, bits)
+}


### PR DESCRIPTION
### Summary

Consolidate the RSA default key length policy into a single
helper utility.

### Full changelog

N/A


### Issues resolved

Fix #3017.

### Documentation

N/A

### Testing

- [x] Unit tests
- [x] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes 

### Backwards compatibility

- [ ] Add `backport-to-stable` label if the code is backwards compatible. Otherwise, list breaking changes.
