### PR TITLE
fix(kuma-cp) ensure HTTP router filter ordering

### DIFF
--- a/pkg/util/proto/any.go
+++ b/pkg/util/proto/any.go
@@ -27,6 +27,14 @@ func MarshalAnyDeterministic(pb proto.Message) (*any.Any, error) {
 	return &any.Any{TypeUrl: googleApis + proto.MessageName(pb), Value: buffer.Bytes()}, nil
 }
 
+func MustMarshalAny(pb proto.Message) *any.Any {
+	msg, err := MarshalAnyDeterministic(pb)
+	if err != nil {
+		panic(err.Error())
+	}
+	return msg
+}
+
 func UnmarshalAnyTo(src *anypb.Any, dst proto2.Message) error {
 	return anypb.UnmarshalTo(src, dst, proto2.UnmarshalOptions{})
 }

--- a/pkg/xds/envoy/listeners/v3/fault_injection_configurer.go
+++ b/pkg/xds/envoy/listeners/v3/fault_injection_configurer.go
@@ -56,7 +56,7 @@ func (f *FaultInjectionConfigurer) Configure(filterChain *envoy_listener.FilterC
 	}
 
 	return UpdateHTTPConnectionManager(filterChain, func(manager *envoy_hcm.HttpConnectionManager) error {
-		manager.HttpFilters = append(httpFilters, manager.HttpFilters...)
+		manager.HttpFilters = append(manager.HttpFilters, httpFilters...)
 		return nil
 	})
 }

--- a/pkg/xds/envoy/listeners/v3/grpc_stats_configurer.go
+++ b/pkg/xds/envoy/listeners/v3/grpc_stats_configurer.go
@@ -25,14 +25,13 @@ func (g *GrpcStatsConfigurer) Configure(filterChain *envoy_listener.FilterChain)
 		return err
 	}
 	return UpdateHTTPConnectionManager(filterChain, func(manager *envoy_hcm.HttpConnectionManager) error {
-		manager.HttpFilters = append([]*envoy_hcm.HttpFilter{
-			{
+		manager.HttpFilters = append(manager.HttpFilters,
+			&envoy_hcm.HttpFilter{
 				Name: "envoy.filters.http.grpc_stats",
 				ConfigType: &envoy_hcm.HttpFilter_TypedConfig{
 					TypedConfig: pbst,
 				},
-			},
-		}, manager.HttpFilters...)
+			})
 		return nil
 	})
 }

--- a/pkg/xds/envoy/listeners/v3/http_connection_manager_configurer.go
+++ b/pkg/xds/envoy/listeners/v3/http_connection_manager_configurer.go
@@ -15,11 +15,9 @@ type HttpConnectionManagerConfigurer struct {
 
 func (c *HttpConnectionManagerConfigurer) Configure(filterChain *envoy_listener.FilterChain) error {
 	config := &envoy_hcm.HttpConnectionManager{
-		StatPrefix: util_xds.SanitizeMetric(c.StatsName),
-		CodecType:  envoy_hcm.HttpConnectionManager_AUTO,
-		HttpFilters: []*envoy_hcm.HttpFilter{
-			{Name: "envoy.filters.http.router"},
-		},
+		StatPrefix:  util_xds.SanitizeMetric(c.StatsName),
+		CodecType:   envoy_hcm.HttpConnectionManager_AUTO,
+		HttpFilters: []*envoy_hcm.HttpFilter{},
 		// notice that route configuration is left up to other configurers
 	}
 

--- a/pkg/xds/envoy/listeners/v3/rate_limit_configurer.go
+++ b/pkg/xds/envoy/listeners/v3/rate_limit_configurer.go
@@ -28,14 +28,13 @@ func (r *RateLimitConfigurer) Configure(filterChain *envoy_listener.FilterChain)
 	}
 
 	return UpdateHTTPConnectionManager(filterChain, func(manager *envoy_hcm.HttpConnectionManager) error {
-		manager.HttpFilters = append([]*envoy_hcm.HttpFilter{
-			{
+		manager.HttpFilters = append(manager.HttpFilters,
+			&envoy_hcm.HttpFilter{
 				Name: "envoy.filters.http.local_ratelimit",
 				ConfigType: &envoy_hcm.HttpFilter_TypedConfig{
 					TypedConfig: pbst,
 				},
-			},
-		}, manager.HttpFilters...)
+			})
 		return nil
 	})
 }

--- a/pkg/xds/envoy/listeners/v3/static_endpoints_configurer.go
+++ b/pkg/xds/envoy/listeners/v3/static_endpoints_configurer.go
@@ -53,11 +53,9 @@ func (c *StaticEndpointsConfigurer) Configure(filterChain *envoy_listener.Filter
 	}
 
 	config := &envoy_hcm.HttpConnectionManager{
-		StatPrefix: util_xds.SanitizeMetric(c.VirtualHostName),
-		CodecType:  envoy_hcm.HttpConnectionManager_AUTO,
-		HttpFilters: []*envoy_hcm.HttpFilter{{
-			Name: "envoy.filters.http.router",
-		}},
+		StatPrefix:  util_xds.SanitizeMetric(c.VirtualHostName),
+		CodecType:   envoy_hcm.HttpConnectionManager_AUTO,
+		HttpFilters: []*envoy_hcm.HttpFilter{},
 		RouteSpecifier: &envoy_hcm.HttpConnectionManager_RouteConfig{
 			RouteConfig: &envoy_route.RouteConfiguration{
 				VirtualHosts: []*envoy_route.VirtualHost{{

--- a/pkg/xds/generator/testdata/inbound-proxy/3-envoy-config.golden.yaml
+++ b/pkg/xds/generator/testdata/inbound-proxy/3-envoy-config.golden.yaml
@@ -104,10 +104,6 @@ resources:
           '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
           forwardClientCertDetails: SANITIZE_SET
           httpFilters:
-          - name: envoy.filters.http.local_ratelimit
-            typedConfig:
-              '@type': type.googleapis.com/envoy.extensions.filters.http.local_ratelimit.v3.LocalRateLimit
-              statPrefix: rate_limit
           - name: envoy.filters.http.fault
             typedConfig:
               '@type': type.googleapis.com/envoy.extensions.filters.http.fault.v3.HTTPFault
@@ -120,6 +116,10 @@ resources:
                 safeRegexMatch:
                   googleRe2: {}
                   regex: .*&kuma.io/service=[^&]*frontend[,&].*
+          - name: envoy.filters.http.local_ratelimit
+            typedConfig:
+              '@type': type.googleapis.com/envoy.extensions.filters.http.local_ratelimit.v3.LocalRateLimit
+              statPrefix: rate_limit
           - name: envoy.filters.http.router
           routeConfig:
             name: inbound:backend1

--- a/pkg/xds/generator/testdata/inbound-proxy/4-envoy-config.golden.yaml
+++ b/pkg/xds/generator/testdata/inbound-proxy/4-envoy-config.golden.yaml
@@ -106,10 +106,6 @@ resources:
           '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
           forwardClientCertDetails: SANITIZE_SET
           httpFilters:
-          - name: envoy.filters.http.local_ratelimit
-            typedConfig:
-              '@type': type.googleapis.com/envoy.extensions.filters.http.local_ratelimit.v3.LocalRateLimit
-              statPrefix: rate_limit
           - name: envoy.filters.http.fault
             typedConfig:
               '@type': type.googleapis.com/envoy.extensions.filters.http.fault.v3.HTTPFault
@@ -122,6 +118,10 @@ resources:
                 safeRegexMatch:
                   googleRe2: {}
                   regex: .*&kuma.io/service=[^&]*frontend[,&].*
+          - name: envoy.filters.http.local_ratelimit
+            typedConfig:
+              '@type': type.googleapis.com/envoy.extensions.filters.http.local_ratelimit.v3.LocalRateLimit
+              statPrefix: rate_limit
           - name: envoy.filters.http.router
           routeConfig:
             name: inbound:backend1

--- a/pkg/xds/generator/testdata/inbound-proxy/5-envoy-config.golden.yaml
+++ b/pkg/xds/generator/testdata/inbound-proxy/5-envoy-config.golden.yaml
@@ -140,10 +140,6 @@ resources:
           '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
           forwardClientCertDetails: SANITIZE_SET
           httpFilters:
-          - name: envoy.filters.http.local_ratelimit
-            typedConfig:
-              '@type': type.googleapis.com/envoy.extensions.filters.http.local_ratelimit.v3.LocalRateLimit
-              statPrefix: rate_limit
           - name: envoy.filters.http.fault
             typedConfig:
               '@type': type.googleapis.com/envoy.extensions.filters.http.fault.v3.HTTPFault
@@ -156,6 +152,10 @@ resources:
                 safeRegexMatch:
                   googleRe2: {}
                   regex: .*&kuma.io/service=[^&]*frontend[,&].*
+          - name: envoy.filters.http.local_ratelimit
+            typedConfig:
+              '@type': type.googleapis.com/envoy.extensions.filters.http.local_ratelimit.v3.LocalRateLimit
+              statPrefix: rate_limit
           - name: envoy.filters.http.router
           routeConfig:
             name: inbound:backend1
@@ -257,10 +257,6 @@ resources:
           '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
           forwardClientCertDetails: SANITIZE_SET
           httpFilters:
-          - name: envoy.filters.http.local_ratelimit
-            typedConfig:
-              '@type': type.googleapis.com/envoy.extensions.filters.http.local_ratelimit.v3.LocalRateLimit
-              statPrefix: rate_limit
           - name: envoy.filters.http.fault
             typedConfig:
               '@type': type.googleapis.com/envoy.extensions.filters.http.fault.v3.HTTPFault
@@ -273,6 +269,10 @@ resources:
                 safeRegexMatch:
                   googleRe2: {}
                   regex: .*&kuma.io/service=[^&]*frontend[,&].*
+          - name: envoy.filters.http.local_ratelimit
+            typedConfig:
+              '@type': type.googleapis.com/envoy.extensions.filters.http.local_ratelimit.v3.LocalRateLimit
+              statPrefix: rate_limit
           - name: envoy.filters.http.router
           routeConfig:
             name: inbound:backend1
@@ -376,10 +376,6 @@ resources:
           '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
           forwardClientCertDetails: SANITIZE_SET
           httpFilters:
-          - name: envoy.filters.http.local_ratelimit
-            typedConfig:
-              '@type': type.googleapis.com/envoy.extensions.filters.http.local_ratelimit.v3.LocalRateLimit
-              statPrefix: rate_limit
           - name: envoy.filters.http.fault
             typedConfig:
               '@type': type.googleapis.com/envoy.extensions.filters.http.fault.v3.HTTPFault
@@ -392,6 +388,10 @@ resources:
                 safeRegexMatch:
                   googleRe2: {}
                   regex: .*&kuma.io/service=[^&]*frontend[,&].*
+          - name: envoy.filters.http.local_ratelimit
+            typedConfig:
+              '@type': type.googleapis.com/envoy.extensions.filters.http.local_ratelimit.v3.LocalRateLimit
+              statPrefix: rate_limit
           - name: envoy.filters.http.router
           routeConfig:
             name: inbound:backend1

--- a/pkg/xds/generator/testdata/inbound-proxy/6-envoy-config.golden.yaml
+++ b/pkg/xds/generator/testdata/inbound-proxy/6-envoy-config.golden.yaml
@@ -142,10 +142,6 @@ resources:
           '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
           forwardClientCertDetails: SANITIZE_SET
           httpFilters:
-          - name: envoy.filters.http.local_ratelimit
-            typedConfig:
-              '@type': type.googleapis.com/envoy.extensions.filters.http.local_ratelimit.v3.LocalRateLimit
-              statPrefix: rate_limit
           - name: envoy.filters.http.fault
             typedConfig:
               '@type': type.googleapis.com/envoy.extensions.filters.http.fault.v3.HTTPFault
@@ -158,6 +154,10 @@ resources:
                 safeRegexMatch:
                   googleRe2: {}
                   regex: .*&kuma.io/service=[^&]*frontend[,&].*
+          - name: envoy.filters.http.local_ratelimit
+            typedConfig:
+              '@type': type.googleapis.com/envoy.extensions.filters.http.local_ratelimit.v3.LocalRateLimit
+              statPrefix: rate_limit
           - name: envoy.filters.http.router
           routeConfig:
             name: inbound:backend1
@@ -259,10 +259,6 @@ resources:
           '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
           forwardClientCertDetails: SANITIZE_SET
           httpFilters:
-          - name: envoy.filters.http.local_ratelimit
-            typedConfig:
-              '@type': type.googleapis.com/envoy.extensions.filters.http.local_ratelimit.v3.LocalRateLimit
-              statPrefix: rate_limit
           - name: envoy.filters.http.fault
             typedConfig:
               '@type': type.googleapis.com/envoy.extensions.filters.http.fault.v3.HTTPFault
@@ -275,6 +271,10 @@ resources:
                 safeRegexMatch:
                   googleRe2: {}
                   regex: .*&kuma.io/service=[^&]*frontend[,&].*
+          - name: envoy.filters.http.local_ratelimit
+            typedConfig:
+              '@type': type.googleapis.com/envoy.extensions.filters.http.local_ratelimit.v3.LocalRateLimit
+              statPrefix: rate_limit
           - name: envoy.filters.http.router
           routeConfig:
             name: inbound:backend1
@@ -378,10 +378,6 @@ resources:
           '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
           forwardClientCertDetails: SANITIZE_SET
           httpFilters:
-          - name: envoy.filters.http.local_ratelimit
-            typedConfig:
-              '@type': type.googleapis.com/envoy.extensions.filters.http.local_ratelimit.v3.LocalRateLimit
-              statPrefix: rate_limit
           - name: envoy.filters.http.fault
             typedConfig:
               '@type': type.googleapis.com/envoy.extensions.filters.http.fault.v3.HTTPFault
@@ -394,6 +390,10 @@ resources:
                 safeRegexMatch:
                   googleRe2: {}
                   regex: .*&kuma.io/service=[^&]*frontend[,&].*
+          - name: envoy.filters.http.local_ratelimit
+            typedConfig:
+              '@type': type.googleapis.com/envoy.extensions.filters.http.local_ratelimit.v3.LocalRateLimit
+              statPrefix: rate_limit
           - name: envoy.filters.http.router
           routeConfig:
             name: inbound:backend1

--- a/pkg/xds/generator/testdata/tracing/zipkin.envoy-config-https.golden.yaml
+++ b/pkg/xds/generator/testdata/tracing/zipkin.envoy-config-https.golden.yaml
@@ -14,10 +14,10 @@ resources:
                 address: zipkin.us
                 portValue: 9090
     name: tracing:zipkin
-    type: STRICT_DNS
     transportSocket:
-          name: envoy.transport_sockets.tls
-          typedConfig:
-            '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
-            allowRenegotiation: true
-            sni: zipkin.us
+      name: envoy.transport_sockets.tls
+      typedConfig:
+        '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
+        allowRenegotiation: true
+        sni: zipkin.us
+    type: STRICT_DNS


### PR DESCRIPTION
### Summary

The HTTP connection manager filter chain must terminate with the router
filter. Each time a filter is added, the configurer needs to be careful
to prepend itself to the chain to ensure that the router remains last.
This makes it hard to reason about the ordering of filters, since it
will be the reverse of the configurer application order, and it makes
it unnecessarily tricky to write new configurers.

So the easiest approach is for the builder to simply ensure that there
is always a router filter appended when it builds the filter chain.
Since it is a filter chain builder, it's reasonable for it to know
something about filter chain semantics. We might need to do something
more complicated if we ever need to set any fields in the router, but
for now it seems reasonable to stick with simplicity.

### Full changelog

N/A

### Issues resolved

N/A

### Documentation

N/A

### Testing

- [x] Unit tests
- [x] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes 

### Backwards compatibility

- [x] Add `backport-to-stable` label if the code is backwards compatible. Otherwise, list breaking changes.
