### PR TITLE
chore(ci) remove some circleci jobs, skip testcontainer if no docker

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -605,28 +605,6 @@ jobs:
 
           wait
 
-  dev_golang:
-    docker:
-    - image: *golang_image
-    environment:
-      GO_VERSION: *go_version
-      GO111MODULE: "on"
-    steps:
-    - checkout
-    - run:
-        name: "Install pre-requirements"
-        # `unzip` is necessary to install `protoc`
-        command: apt update && apt install -y unzip
-    - run:
-        name: "Install all development tools"
-        command: make dev/tools
-    - run:
-        name: "Build all binaries"
-        command: make build
-    - run:
-        name: "Run unit tests"
-        command: GO_TEST_OPTS='-p 2' make test
-
   dev_ubuntu:
     docker:
     - image: ubuntu:20.04
@@ -734,38 +712,10 @@ jobs:
         command: make check
 
   test:
-    executor: golang
-    resource_class: medium
-    parameters:
-      target:
-        description: The test make target.
-        type: string
-        default: test
-    steps:
-    - checkout
-    - restore_cache:
-        keys:
-        # prefer the exact match
-        - go.mod-{{ .Branch }}-{{ checksum "go.sum" }}
-    - run:
-        name: "Install pre-requirements"
-        # `unzip` is necessary to install `protoc`
-        command: apt update && apt install -y unzip
-    - run:
-        name: "Install all development tools"
-        command: make dev/tools
-    - run:
-        name: "Run unit tests"
-        command: GO_TEST_OPTS='-p 2' make << parameters.target >>
-    - store_artifacts:
-        path: build/coverage
-        destination: /coverage
-
-  integration:
     executor: vm
     parameters:
       target:
-        description: The integration make target.
+        description: The test make target.
         type: string
         default: test
     environment:
@@ -791,7 +741,7 @@ jobs:
         command: |
           make dev/tools
     - run:
-        name: "Run integration tests"
+        name: "Run tests"
         command: |
           export GINKGO_XUNIT_RESULTS_DIR=/tmp/xunit
           make << parameters.target >>
@@ -1166,7 +1116,7 @@ workflows:
         <<: *commit_workflow_filters
         requires:
         - go_cache
-    - integration:
+    - test:
         <<: *commit_workflow_filters
         requires:
         - check
@@ -1289,7 +1239,6 @@ workflows:
 
   kuma-master:
     jobs:
-      - dev_golang: *master_workflow_filters
       - dev_mac: *master_workflow_filters
       - dev_ubuntu: *master_workflow_filters
       - go_cache: *master_workflow_filters
@@ -1302,10 +1251,6 @@ workflows:
           requires:
             - go_cache
       - test:
-          <<: *master_workflow_filters
-          requires:
-            - check
-      - integration:
           <<: *master_workflow_filters
           requires:
             - check
@@ -1391,23 +1336,12 @@ workflows:
         <<: *helm_release_workflow_filters
         requires:
           - go_cache
-        name: test-release
-        target: test/release
-    - test:
-        <<: *release_workflow_filters
-        requires:
-        - go_cache
-    - integration:
-        <<: *release_workflow_filters
-        requires:
-        - go_cache
+        target: test test/release
     - release:
         <<: *release_workflow_filters
         requires:
         - check
         - test
-        - test-release
-        - integration
     - helm-release:
         <<: *helm_release_workflow_filters
         requires:

--- a/app/kuma-cp/cmd/cmd_suite_test.go
+++ b/app/kuma-cp/cmd/cmd_suite_test.go
@@ -19,9 +19,12 @@ package cmd
 import (
 	"testing"
 
+	"github.com/testcontainers/testcontainers-go"
+
 	"github.com/kumahq/kuma/pkg/test"
 )
 
 func TestCmd(t *testing.T) {
+	testcontainers.SkipIfProviderIsNotHealthy(t)
 	test.RunSpecs(t, "CMD Suite")
 }

--- a/pkg/plugins/leader/postgres/postgres_suite_test.go
+++ b/pkg/plugins/leader/postgres/postgres_suite_test.go
@@ -3,9 +3,12 @@ package postgres
 import (
 	"testing"
 
+	"github.com/testcontainers/testcontainers-go"
+
 	"github.com/kumahq/kuma/pkg/test"
 )
 
 func TestPostgresLeader(t *testing.T) {
+	testcontainers.SkipIfProviderIsNotHealthy(t)
 	test.RunSpecs(t, "Postgres Leader Suite")
 }

--- a/pkg/plugins/resources/postgres/store_suite_test.go
+++ b/pkg/plugins/resources/postgres/store_suite_test.go
@@ -5,6 +5,7 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/testcontainers/testcontainers-go"
 
 	"github.com/kumahq/kuma/pkg/test"
 	test_postgres "github.com/kumahq/kuma/pkg/test/store/postgres"
@@ -13,6 +14,7 @@ import (
 var c test_postgres.PostgresContainer
 
 func TestPostgresStore(t *testing.T) {
+	testcontainers.SkipIfProviderIsNotHealthy(t)
 	BeforeSuite(func() {
 		c = test_postgres.PostgresContainer{WithTLS: true}
 		Expect(c.Start()).To(Succeed())


### PR DESCRIPTION
### Summary

Some tests targets were redundant and not useful anymore so we removed them.
In some cases docker is not available within the targets. In this case we simply skip the test

### Backwards compatibility

- [x] Add `backport-to-stable` label if the code is backwards compatible. Otherwise, list breaking changes.
