### PR TITLE
chore(kuma-cp) default config open to extensions

### DIFF
--- a/pkg/config/app/kuma-cp/config.go
+++ b/pkg/config/app/kuma-cp/config.go
@@ -161,7 +161,7 @@ func (c *Config) Sanitize() {
 	c.Diagnostics.Sanitize()
 }
 
-func DefaultConfig() Config {
+var DefaultConfig = func() Config {
 	return Config{
 		Environment:                core.UniversalEnvironment,
 		Mode:                       core.Standalone,

--- a/pkg/config/app/kuma-dp/config.go
+++ b/pkg/config/app/kuma-dp/config.go
@@ -12,7 +12,7 @@ import (
 	config_types "github.com/kumahq/kuma/pkg/config/types"
 )
 
-func DefaultConfig() Config {
+var DefaultConfig = func() Config {
 	return Config{
 		ControlPlane: ControlPlane{
 			URL: "https://localhost:5678",

--- a/pkg/config/app/kuma-prometheus-sd/config.go
+++ b/pkg/config/app/kuma-prometheus-sd/config.go
@@ -10,7 +10,7 @@ import (
 	"github.com/kumahq/kuma/pkg/mads"
 )
 
-func DefaultConfig() Config {
+var DefaultConfig = func() Config {
 	return Config{
 		MonitoringAssignment: MonitoringAssignmentConfig{
 			Client: MonitoringAssignmentClientConfig{


### PR DESCRIPTION
### Summary

Open DefaultConfig to modify from projects that build on top of Kuma

### Full changelog

* DefaultConfig is now a var to a func. Why not just var to struct? I had race conditions in `./app/kuma-cp/cmd/...` because tests were overriding `DefaultConfig` var. 

### Issues resolved

No issue

### Documentation

- [X] No docs

### Testing

- [X] Unit tests
- [ ] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes 

### Backwards compatibility

- [X] No backporting
