### PR TITLE
chore(kuma-dp) clean bootstrap code

### DIFF
--- a/app/kuma-dp/cmd/context.go
+++ b/app/kuma-dp/cmd/context.go
@@ -15,7 +15,7 @@ import (
 // RootContext contains variables, functions and components that can be overridden when extending kuma-dp or running the test.
 type RootContext struct {
 	ComponentManager         component.Manager
-	BootstrapGenerator       envoy.BootstrapConfigFactoryFunc
+	BootstrapGenerator       envoy.BootstrapConfigGenerator
 	BootstrapDynamicMetadata map[string]string
 	Config                   *kumadp.Config
 	LogLevel                 log.LogLevel

--- a/app/kuma-dp/cmd/run.go
+++ b/app/kuma-dp/cmd/run.go
@@ -176,9 +176,6 @@ func newRunCmd(opts kuma_cmd.RunCmdOpts, rootCtx *RootContext) *cobra.Command {
 			}
 
 			if cfg.DNS.Enabled {
-				opts.DNSPort = cfg.DNS.EnvoyDNSPort
-				opts.EmptyDNSPort = cfg.DNS.CoreDNSEmptyPort
-
 				dnsOpts := &dnsserver.Opts{
 					Config: *cfg,
 					Stdout: cmd.OutOrStdout(),

--- a/app/kuma-dp/cmd/run_test.go
+++ b/app/kuma-dp/cmd/run_test.go
@@ -95,11 +95,11 @@ var _ = Describe("run", func() {
 
 			// given
 			rootCtx := DefaultRootContext()
-			rootCtx.BootstrapGenerator = func(_ string, cfg kumadp.Config, _ envoy.BootstrapParams) ([]byte, error) {
+			rootCtx.BootstrapGenerator = envoy.BootstrapConfigGeneratorFunc(func(_ string, cfg kumadp.Config, _ envoy.BootstrapParams) ([]byte, error) {
 				respBytes, err := ioutil.ReadFile(filepath.Join("testdata", "bootstrap-config.golden.yaml"))
 				Expect(err).ToNot(HaveOccurred())
 				return respBytes, nil
-			}
+			})
 			_, writer := io.Pipe()
 			cmd := NewRootCmd(opts, rootCtx)
 			cmd.SetArgs(append([]string{"run"}, given.args...))

--- a/app/kuma-dp/pkg/dataplane/envoy/envoy_test.go
+++ b/app/kuma-dp/pkg/dataplane/envoy/envoy_test.go
@@ -21,6 +21,12 @@ import (
 	"github.com/kumahq/kuma/pkg/test"
 )
 
+type StaticBootstrapConfigGenerator string
+
+func (s StaticBootstrapConfigGenerator) Generate(_ string, _ kuma_dp.Config, _ BootstrapParams) ([]byte, error) {
+	return []byte(s), nil
+}
+
 var _ = Describe("Envoy", func() {
 
 	var configDir string
@@ -90,10 +96,8 @@ var _ = Describe("Envoy", func() {
 					ConfigDir:  configDir,
 				},
 			}
-			sampleConfig := func(string, kuma_dp.Config, BootstrapParams) ([]byte, error) {
-				return []byte(`node:
-  id: example`), nil
-			}
+			sampleConfig := StaticBootstrapConfigGenerator(`node:
+  id: example`)
 			expectedConfigFile := filepath.Join(configDir, "bootstrap.yaml")
 
 			By("starting a mock dataplane")
@@ -154,10 +158,8 @@ var _ = Describe("Envoy", func() {
 				},
 			}
 
-			sampleConfig := func(string, kuma_dp.Config, BootstrapParams) ([]byte, error) {
-				return []byte(`node:
-  id: example`), nil
-			}
+			sampleConfig := StaticBootstrapConfigGenerator(`node:
+  id: example`)
 
 			expectedConfigFile := filepath.Join(configDir, "bootstrap.yaml")
 
@@ -196,15 +198,12 @@ var _ = Describe("Envoy", func() {
 					ConfigDir:  configDir,
 				},
 			}
-			sampleConfig := func(string, kuma_dp.Config, BootstrapParams) ([]byte, error) {
-				return nil, nil
-			}
 
 			By("starting a mock dataplane")
 			// when
 			dataplane, err := New(Opts{
 				Config:    cfg,
-				Generator: sampleConfig,
+				Generator: StaticBootstrapConfigGenerator(""),
 				Stdout:    &bytes.Buffer{},
 				Stderr:    &bytes.Buffer{},
 			})
@@ -235,15 +234,12 @@ var _ = Describe("Envoy", func() {
 					ConfigDir:  configDir,
 				},
 			}
-			sampleConfig := func(string, kuma_dp.Config, BootstrapParams) ([]byte, error) {
-				return nil, nil
-			}
 
 			By("starting a mock dataplane")
 			// when
 			dataplane, err := New(Opts{
 				Config:    cfg,
-				Generator: sampleConfig,
+				Generator: StaticBootstrapConfigGenerator(""),
 				Stdout:    &bytes.Buffer{},
 				Stderr:    &bytes.Buffer{},
 			})

--- a/app/kuma-dp/pkg/dataplane/envoy/remote_bootstrap.go
+++ b/app/kuma-dp/pkg/dataplane/envoy/remote_bootstrap.go
@@ -24,9 +24,8 @@ type remoteBootstrap struct {
 	client *http.Client
 }
 
-func NewRemoteBootstrapGenerator(client *http.Client) BootstrapConfigFactoryFunc {
-	rb := remoteBootstrap{client: client}
-	return rb.Generate
+func NewRemoteBootstrapGenerator(client *http.Client) BootstrapConfigGenerator {
+	return &remoteBootstrap{client: client}
 }
 
 var (
@@ -139,8 +138,10 @@ func (b *remoteBootstrap) requestForBootstrap(url *net_url.URL, cfg kuma_dp.Conf
 			},
 		},
 		DynamicMetadata: params.DynamicMetadata,
-		DNSPort:         params.DNSPort,
-		EmptyDNSPort:    params.EmptyDNSPort,
+	}
+	if cfg.DNS.Enabled {
+		request.DNSPort = cfg.DNS.CoreDNSPort
+		request.EmptyDNSPort = cfg.DNS.CoreDNSEmptyPort
 	}
 	jsonBytes, err := json.Marshal(request)
 	if err != nil {


### PR DESCRIPTION
- Remove a redundant parameter in the bootstrap config.
- Switch bootstrapFactory to an interface to make code more modular

### Backwards compatibility

- [x] Add `backport-to-stable` label if the code is backwards compatible. Otherwise, list breaking changes.
