### PR TITLE
feat(disableipv6) don't add v6 in DNS when v6 is disabled

### DIFF
--- a/pkg/xds/generator/dns_generator_test.go
+++ b/pkg/xds/generator/dns_generator_test.go
@@ -89,5 +89,9 @@ var _ = Describe("DNSGenerator", func() {
 			dataplaneFile: "2-dataplane.input.yaml",
 			expected:      "2-envoy-config.golden.yaml",
 		}),
+		Entry("03. DNS enabled no ipv6", testCase{
+			dataplaneFile: "3-dataplane.input.yaml",
+			expected:      "3-envoy-config.golden.yaml",
+		}),
 	)
 })

--- a/pkg/xds/generator/testdata/dns/3-dataplane.input.yaml
+++ b/pkg/xds/generator/testdata/dns/3-dataplane.input.yaml
@@ -10,5 +10,4 @@ networking:
         kuma.io/service: httpbin
   transparentProxying:
     redirectPortOutbound: 15001
-    redirectPortInboundV6: 15002
     redirectPortInbound: 15003

--- a/pkg/xds/generator/testdata/dns/3-envoy-config.golden.yaml
+++ b/pkg/xds/generator/testdata/dns/3-envoy-config.golden.yaml
@@ -1,0 +1,48 @@
+resources:
+- name: kuma:dns
+  resource:
+    '@type': type.googleapis.com/envoy.config.listener.v3.Listener
+    address:
+      socketAddress:
+        address: 127.0.0.1
+        portValue: 53001
+        protocol: UDP
+    listenerFilters:
+    - name: envoy.filters.udp.dns_filter
+      typedConfig:
+        '@type': type.googleapis.com/envoy.extensions.filters.udp.dns_filter.v3alpha.DnsFilterConfig
+        clientConfig:
+          maxPendingLookups: "256"
+          upstreamResolvers:
+          - socketAddress:
+              address: 127.0.0.1
+              portValue: 53002
+        serverConfig:
+          inlineDnsTable:
+            knownSuffixes:
+            - safeRegex:
+                googleRe2: {}
+                regex: .*
+            virtualDomains:
+            - answerTtl: 30s
+              endpoint:
+                addressList:
+                  address:
+                  - 240.0.0.0
+              name: backend.test-ns.svc.8080.mesh
+            - answerTtl: 30s
+              endpoint:
+                addressList:
+                  address:
+                  - 240.0.0.0
+              name: backend_test-ns_svc_8080.mesh
+            - answerTtl: 30s
+              endpoint:
+                addressList:
+                  address:
+                  - 240.0.0.1
+              name: httpbin.mesh
+        statPrefix: kuma_dns
+    name: kuma:dns
+    reusePort: true
+    trafficDirection: INBOUND

--- a/pkg/xds/generator/testdata/tracing/zipkin.envoy-config-https.golden.yaml
+++ b/pkg/xds/generator/testdata/tracing/zipkin.envoy-config-https.golden.yaml
@@ -14,10 +14,10 @@ resources:
                 address: zipkin.us
                 portValue: 9090
     name: tracing:zipkin
-    type: STRICT_DNS
     transportSocket:
-          name: envoy.transport_sockets.tls
-          typedConfig:
-            '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
-            allowRenegotiation: true
-            sni: zipkin.us
+      name: envoy.transport_sockets.tls
+      typedConfig:
+        '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
+        allowRenegotiation: true
+        sni: zipkin.us
+    type: STRICT_DNS


### PR DESCRIPTION
If there's no port forward for v6 we shouldn't add v6 ips in the config

### Backwards compatibility

- [x] Add `backport-to-stable` label if the code is backwards compatible. Otherwise, list breaking changes.
