### PR TITLE
feat(*) add more global resources to GlobalInsights

### DIFF
--- a/pkg/api-server/global_insights_endpoints.go
+++ b/pkg/api-server/global_insights_endpoints.go
@@ -1,21 +1,35 @@
 package api_server
 
 import (
+	"strings"
 	"time"
 
 	"github.com/emicklei/go-restful"
 
 	"github.com/kumahq/kuma/pkg/core"
 	"github.com/kumahq/kuma/pkg/core/resources/access"
-	"github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	"github.com/kumahq/kuma/pkg/core/resources/apis/system"
 	"github.com/kumahq/kuma/pkg/core/resources/manager"
+	"github.com/kumahq/kuma/pkg/core/resources/model"
+	"github.com/kumahq/kuma/pkg/core/resources/registry"
 	rest_errors "github.com/kumahq/kuma/pkg/core/rest/errors"
 )
 
 type globalInsightsEndpoints struct {
 	resManager     manager.ResourceManager
 	resourceAccess access.ResourceAccess
+	resources      map[string]globalInsightsStat
+}
+
+func newGlobalInsightsEndpoints(
+	resManager manager.ResourceManager,
+	resourceAccess access.ResourceAccess,
+) *globalInsightsEndpoints {
+	return &globalInsightsEndpoints{
+		resManager:     resManager,
+		resourceAccess: resourceAccess,
+		resources:      map[string]globalInsightsStat{},
+	}
 }
 
 type globalInsightsStat struct {
@@ -23,20 +37,16 @@ type globalInsightsStat struct {
 }
 
 type globalInsightsResponse struct {
-	Type          string             `json:"type"`
-	CreationTime  time.Time          `json:"creationTime"`
-	Meshes        globalInsightsStat `json:"meshes"`
-	Zones         globalInsightsStat `json:"zones"`
-	ZoneIngresses globalInsightsStat `json:"zoneIngresses"`
+	Type         string                        `json:"type"`
+	CreationTime time.Time                     `json:"creationTime"`
+	Resources    map[string]globalInsightsStat `json:"resources"`
 }
 
-func newGlobalInsightsResponse(meshes, zones, zoneIngresses globalInsightsStat) *globalInsightsResponse {
+func newGlobalInsightsResponse(resources map[string]globalInsightsStat) *globalInsightsResponse {
 	return &globalInsightsResponse{
-		Type:          "GlobalInsights",
-		CreationTime:  core.Now(),
-		Meshes:        meshes,
-		Zones:         zones,
-		ZoneIngresses: zoneIngresses,
+		Type:         "GlobalInsights",
+		CreationTime: core.Now(),
+		Resources:    resources,
 	}
 }
 
@@ -47,29 +57,25 @@ func (r *globalInsightsEndpoints) addEndpoint(ws *restful.WebService) {
 }
 
 func (r *globalInsightsEndpoints) inspectGlobalResources(request *restful.Request, response *restful.Response) {
-	meshes := &mesh.MeshResourceList{}
-	if err := r.resManager.List(request.Request.Context(), meshes); err != nil {
-		rest_errors.HandleError(response, err, "Could not retrieve global insights")
-		return
+	for _, descriptor := range registry.Global().ObjectDescriptors() {
+		if descriptor.Scope != model.ScopeGlobal ||
+			descriptor.Name == system.ConfigType ||
+			strings.HasSuffix(string(descriptor.Name), "Insight") {
+			continue
+		}
+
+		resources := descriptor.NewList()
+		if err := r.resManager.List(request.Request.Context(), resources); err != nil {
+			rest_errors.HandleError(response, err, "Could not retrieve global insights")
+			return
+		}
+
+		r.resources[string(descriptor.Name)] = globalInsightsStat{
+			Total: uint32(len(resources.GetItems())),
+		}
 	}
 
-	zones := &system.ZoneResourceList{}
-	if err := r.resManager.List(request.Request.Context(), zones); err != nil {
-		rest_errors.HandleError(response, err, "Could not retrieve global insights")
-		return
-	}
-
-	zoneIngresses := &mesh.ZoneIngressResourceList{}
-	if err := r.resManager.List(request.Request.Context(), zoneIngresses); err != nil {
-		rest_errors.HandleError(response, err, "Could not retrieve global insights")
-		return
-	}
-
-	insights := newGlobalInsightsResponse(
-		globalInsightsStat{Total: uint32(len(meshes.Items))},
-		globalInsightsStat{Total: uint32(len(zones.Items))},
-		globalInsightsStat{Total: uint32(len(zoneIngresses.Items))},
-	)
+	insights := newGlobalInsightsResponse(r.resources)
 
 	if err := response.WriteAsJson(insights); err != nil {
 		rest_errors.HandleError(response, err, "Could not retrieve global insights")

--- a/pkg/api-server/global_insights_endpoints_test.go
+++ b/pkg/api-server/global_insights_endpoints_test.go
@@ -100,14 +100,19 @@ var _ = Describe("Global Insights Endpoints", func() {
 {
   "type": "GlobalInsights",
   "creationTime": "2018-07-17T16:05:36.995Z",
-  "meshes": {
-    "total": 3
-  },
-  "zones": {
-    "total": 2
-  },
-  "zoneIngresses": {
-    "total": 1
+  "resources": {
+    "GlobalSecret": {
+      "total": 0
+    },
+    "Mesh": {
+      "total": 3
+    },
+    "Zone": {
+      "total": 2
+    },
+    "ZoneIngress": {
+      "total": 1
+    }
   }
 }
 `

--- a/pkg/api-server/server.go
+++ b/pkg/api-server/server.go
@@ -183,10 +183,10 @@ func addResourcesEndpoints(ws *restful.WebService, defs []model.ResourceTypeDesc
 	zoneIngressOverviewEndpoints.addFindEndpoint(ws)
 	zoneIngressOverviewEndpoints.addListEndpoint(ws)
 
-	globalInsightsEndpoints := newGlobalInsightsEndpoints(
-		resManager,
-		resourceAccess,
-	)
+	globalInsightsEndpoints := globalInsightsEndpoints{
+		resManager:     resManager,
+		resourceAccess: resourceAccess,
+	}
 	globalInsightsEndpoints.addEndpoint(ws)
 
 	for _, definition := range defs {

--- a/pkg/api-server/server.go
+++ b/pkg/api-server/server.go
@@ -183,10 +183,10 @@ func addResourcesEndpoints(ws *restful.WebService, defs []model.ResourceTypeDesc
 	zoneIngressOverviewEndpoints.addFindEndpoint(ws)
 	zoneIngressOverviewEndpoints.addListEndpoint(ws)
 
-	globalInsightsEndpoints := globalInsightsEndpoints{
-		resManager:     resManager,
-		resourceAccess: resourceAccess,
-	}
+	globalInsightsEndpoints := newGlobalInsightsEndpoints(
+		resManager,
+		resourceAccess,
+	)
 	globalInsightsEndpoints.addEndpoint(ws)
 
 	for _, definition := range defs {


### PR DESCRIPTION
### Summary
Any global resource, which is not `Config` or suffixed by `Insight`
will be returned in GlobalInsights endpoint

Example response:
```json
{
 "type": "GlobalInsights",
 "creationTime": "2021-11-05T08:11:37.880477+01:00",
 "resources": {
  "GlobalSecret": {
   "total": 3
  },
  "Mesh": {
   "total": 1
  },
  "Zone": {
   "total": 0
  },
  "ZoneIngress": {
   "total": 0
  }
 }
}

```

### Full changelog

no changelog

### Issues resolved

no issue resolved

### Documentation

- [x] Link to the website: https://github.com/kumahq/kuma-website/pull/580

### Testing

- [x] Unit tests
- [ ] E2E tests
- [x] Manual testing on Universal
- [ ] Manual testing on Kubernetes 

### Backwards compatibility

- [ ] Add `backport-to-stable` label if the code is backwards compatible. Otherwise, list breaking changes.
