### PR TITLE
fix(kuma-cp) make cluster names contextually unique

### DIFF
--- a/pkg/plugins/runtime/gateway/builder.go
+++ b/pkg/plugins/runtime/gateway/builder.go
@@ -45,7 +45,20 @@ func (r *ResourceAggregator) Get() *xds.ResourceSet {
 	return r.ResourceSet
 }
 
-func (r *ResourceAggregator) Add(set *xds.ResourceSet, err error) error {
+func (r *ResourceAggregator) Add(resource *xds.Resource, err error) error {
+	if err != nil {
+		return err
+	}
+
+	if r.ResourceSet == nil {
+		r.ResourceSet = xds.NewResourceSet()
+	}
+
+	r.ResourceSet.Add(resource)
+	return nil
+}
+
+func (r *ResourceAggregator) AddSet(set *xds.ResourceSet, err error) error {
 	if err != nil {
 		return err
 	}

--- a/pkg/plugins/runtime/gateway/filter_chain_generator.go
+++ b/pkg/plugins/runtime/gateway/filter_chain_generator.go
@@ -67,6 +67,10 @@ func (*HTTPFilterChainGenerator) GenerateHost(ctx xds_context.Context, info *Gat
 	// HTTP listeners get a single filter chain for all hostnames. So
 	// if there's already a filter chain, we have nothing to do.
 	if info.Resources.FilterChain != nil {
+		log.V(1).Info("updating existing filter chain",
+			"hostname", info.Host.Hostname,
+		)
+
 		return nil, nil
 	}
 

--- a/pkg/plugins/runtime/gateway/generator.go
+++ b/pkg/plugins/runtime/gateway/generator.go
@@ -176,23 +176,20 @@ func (g Generator) Generate(ctx xds_context.Context, proxy *core_xds.Proxy) (*co
 					continue
 				}
 
-				generated, err := generator.GenerateHost(ctx, &info)
-				if err != nil {
+				if err := resources.AddSet(generator.GenerateHost(ctx, &info)); err != nil {
 					return nil, errors.Wrapf(err, "%T failed to generate resources for dataplane %q",
 						generator, proxy.Id)
 				}
-
-				resources.AddSet(generated)
 			}
 		}
 
 		info.Resources.Listener.Configure(envoy_listeners.FilterChain(info.Resources.FilterChain))
 
-		if err := resources.Add(BuildResourceSet(info.Resources.Listener)); err != nil {
+		if err := resources.AddSet(BuildResourceSet(info.Resources.Listener)); err != nil {
 			return nil, errors.Wrapf(err, "failed to build listener resource")
 		}
 
-		if err := resources.Add(BuildResourceSet(info.Resources.RouteConfiguration)); err != nil {
+		if err := resources.AddSet(BuildResourceSet(info.Resources.RouteConfiguration)); err != nil {
 			return nil, errors.Wrapf(err, "failed to build route configuration resource")
 		}
 	}

--- a/pkg/plugins/runtime/gateway/route/builders.go
+++ b/pkg/plugins/runtime/gateway/route/builders.go
@@ -5,10 +5,12 @@ import (
 	"fmt"
 	"sort"
 
+	envoy_cluster_v3 "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
 	envoy_config_route "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
 	"github.com/pkg/errors"
 
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
+	util_proto "github.com/kumahq/kuma/pkg/util/proto"
 	"github.com/kumahq/kuma/pkg/xds/envoy"
 )
 
@@ -61,24 +63,14 @@ func (f RouteMustConfigureFunc) Configure(r *envoy_config_route.Route) error {
 
 // DestinationClusterName generates a unique cluster name for the
 // destination. The destination must contain at least a service tag.
-func DestinationClusterName(d Destination) (string, error) {
+func DestinationClusterName(d *Destination, c *envoy_cluster_v3.Cluster) (string, error) {
 	serviceName := d.Destination[mesh_proto.ServiceTag]
 	if serviceName == "" {
 		return "", errors.Errorf("missing %s tag", mesh_proto.ServiceTag)
 	}
 
-	clusterName := serviceName
-
-	if len(d.Destination) == 1 {
-		return clusterName, nil
-	}
-
 	// If cluster is splitting the target service with selector tags,
-	// hash the tag names to generate a unique cluster name. This is
-	// a stateless uniqifier so that different xDS resource generators
-	// can use the same tags to arrive at the same cluster name without
-	// coordination.
-
+	// hash the tag names to generate a unique cluster name.
 	var keys []string
 	for k := range d.Destination {
 		keys = append(keys, k)
@@ -93,9 +85,15 @@ func DestinationClusterName(d Destination) (string, error) {
 		h.Write([]byte(d.Destination[k]))
 	}
 
+	any, err := util_proto.MarshalAnyDeterministic(c)
+	if err != nil {
+		return "", err
+	}
+
+	h.Write([]byte(any.GetTypeUrl()))
+	h.Write(any.GetValue())
+
 	// The qualifier is 16 hex digits. Unscientifically balancing the length
 	// of the hex against the likelihood of collisions.
-	clusterName = fmt.Sprintf("%s-%x", serviceName, h.Sum(nil)[:8])
-
-	return clusterName, nil
+	return fmt.Sprintf("%s-%x", serviceName, h.Sum(nil)[:8]), nil
 }

--- a/pkg/plugins/runtime/gateway/route/table.go
+++ b/pkg/plugins/runtime/gateway/route/table.go
@@ -91,6 +91,11 @@ type Destination struct {
 	Destination envoy.Tags
 	Weight      uint32
 
+	// Name is the globally unique name for this destination instance.
+	// It takes into account not only the service that it targets, but
+	// also the configuration context.
+	Name string
+
 	// Kuma connection policies for traffic forwarded to
 	// this destination.
 	Policies map[model.ResourceType]model.Resource

--- a/pkg/plugins/runtime/gateway/testdata/gateway-http-multihost.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/gateway-http-multihost.yaml
@@ -1,0 +1,25 @@
+type: Gateway
+mesh: default
+name: gateway-multihost
+selectors:
+- match:
+    kuma.io/service: gateway-multihost
+conf:
+  listeners:
+  - hostname: one.example.com
+    port: 9080
+    protocol: HTTP
+    tags:
+      hostname: one.example.com
+  - hostname: two.example.com
+    port: 9080
+    protocol: HTTP
+    tags:
+      hostname: two.example.com
+  - hostname: three.example.com
+    port: 9080
+    protocol: HTTP
+    tags:
+      hostname: three.example.com
+
+

--- a/pkg/plugins/runtime/gateway/testdata/gateway-https-multihost.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/gateway-https-multihost.yaml
@@ -1,0 +1,35 @@
+type: Gateway
+mesh: default
+name: gateway-multihost
+selectors:
+- match:
+    kuma.io/service: gateway-multihost
+conf:
+  listeners:
+  - hostname: one.example.com
+    port: 9443
+    protocol: HTTPS
+    tags:
+      hostname: one.example.com
+    tls:
+      mode: TERMINATE
+      certificates:
+      - secret: echo-example-com-server-cert
+  - hostname: two.example.com
+    port: 9443
+    protocol: HTTPS
+    tags:
+      hostname: two.example.com
+    tls:
+      mode: TERMINATE
+      certificates:
+      - secret: echo-example-com-server-cert
+  - hostname: three.example.com
+    port: 9443
+    protocol: HTTPS
+    tags:
+      hostname: three.example.com
+    tls:
+      mode: TERMINATE
+      certificates:
+      - secret: echo-example-com-server-cert

--- a/pkg/plugins/runtime/gateway/testdata/http/01-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/01-gateway-route.yaml
@@ -1,12 +1,12 @@
 Clusters:
   Resources:
-    echo-service:
+    echo-service-07fd732a85aa6a99:
       connectTimeout: 10s
       edsClusterConfig:
         edsConfig:
           ads: {}
           resourceApiVersion: V3
-      name: echo-service
+      name: echo-service-07fd732a85aa6a99
       type: EDS
       typedExtensionProtocolOptions:
         envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
@@ -17,8 +17,8 @@ Clusters:
             httpProtocolOptions: {}
 Endpoints:
   Resources:
-    echo-service:
-      clusterName: echo-service
+    echo-service-07fd732a85aa6a99:
+      clusterName: echo-service-07fd732a85aa6a99
       endpoints:
       - lbEndpoints:
         - endpoint:
@@ -101,7 +101,7 @@ Routes:
           route:
             weightedClusters:
               clusters:
-              - name: echo-service
+              - name: echo-service-07fd732a85aa6a99
                 weight: 1
               totalWeight: 1
       - domains:
@@ -113,7 +113,7 @@ Routes:
           route:
             weightedClusters:
               clusters:
-              - name: echo-service
+              - name: echo-service-07fd732a85aa6a99
                 weight: 1
               totalWeight: 1
       - domains:
@@ -125,7 +125,7 @@ Routes:
           route:
             weightedClusters:
               clusters:
-              - name: echo-service
+              - name: echo-service-07fd732a85aa6a99
                 weight: 1
               totalWeight: 1
       - domains:

--- a/pkg/plugins/runtime/gateway/testdata/http/02-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/02-gateway-route.yaml
@@ -1,6 +1,6 @@
 Clusters:
   Resources:
-    echo-service:
+    echo-service-5a416c39037aa8f6:
       circuitBreakers:
         thresholds:
         - maxConnections: 1024
@@ -12,7 +12,7 @@ Clusters:
         edsConfig:
           ads: {}
           resourceApiVersion: V3
-      name: echo-service
+      name: echo-service-5a416c39037aa8f6
       outlierDetection:
         enforcingConsecutive5xx: 0
         enforcingConsecutiveGatewayFailure: 0
@@ -27,10 +27,41 @@ Clusters:
             idleTimeout: 3600s
           explicitHttpConfig:
             httpProtocolOptions: {}
+    echo-service-07fd732a85aa6a99:
+      connectTimeout: 10s
+      edsClusterConfig:
+        edsConfig:
+          ads: {}
+          resourceApiVersion: V3
+      name: echo-service-07fd732a85aa6a99
+      type: EDS
+      typedExtensionProtocolOptions:
+        envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+          '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+          commonHttpProtocolOptions:
+            idleTimeout: 0s
+          explicitHttpConfig:
+            httpProtocolOptions: {}
 Endpoints:
   Resources:
-    echo-service:
-      clusterName: echo-service
+    echo-service-5a416c39037aa8f6:
+      clusterName: echo-service-5a416c39037aa8f6
+      endpoints:
+      - lbEndpoints:
+        - endpoint:
+            address:
+              socketAddress:
+                address: 192.168.1.6
+                portValue: 20006
+          loadBalancingWeight: 1
+          metadata:
+            filterMetadata:
+              envoy.lb:
+                kuma.io/protocol: http
+              envoy.transport_socket_match:
+                kuma.io/protocol: http
+    echo-service-07fd732a85aa6a99:
+      clusterName: echo-service-07fd732a85aa6a99
       endpoints:
       - lbEndpoints:
         - endpoint:
@@ -113,7 +144,7 @@ Routes:
           route:
             weightedClusters:
               clusters:
-              - name: echo-service
+              - name: echo-service-07fd732a85aa6a99
                 weight: 1
               totalWeight: 1
       - domains:
@@ -125,7 +156,7 @@ Routes:
           route:
             weightedClusters:
               clusters:
-              - name: echo-service
+              - name: echo-service-5a416c39037aa8f6
                 weight: 1
               totalWeight: 1
 Runtimes:

--- a/pkg/plugins/runtime/gateway/testdata/http/03-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/03-gateway-route.yaml
@@ -1,6 +1,6 @@
 Clusters:
   Resources:
-    echo-service:
+    echo-service-5a416c39037aa8f6:
       circuitBreakers:
         thresholds:
         - maxConnections: 1024
@@ -12,7 +12,7 @@ Clusters:
         edsConfig:
           ads: {}
           resourceApiVersion: V3
-      name: echo-service
+      name: echo-service-5a416c39037aa8f6
       outlierDetection:
         enforcingConsecutive5xx: 0
         enforcingConsecutiveGatewayFailure: 0
@@ -29,8 +29,8 @@ Clusters:
             httpProtocolOptions: {}
 Endpoints:
   Resources:
-    echo-service:
-      clusterName: echo-service
+    echo-service-5a416c39037aa8f6:
+      clusterName: echo-service-5a416c39037aa8f6
       endpoints:
       - lbEndpoints:
         - endpoint:
@@ -113,7 +113,7 @@ Routes:
           route:
             weightedClusters:
               clusters:
-              - name: echo-service
+              - name: echo-service-5a416c39037aa8f6
                 weight: 1
               totalWeight: 1
 Runtimes:

--- a/pkg/plugins/runtime/gateway/testdata/http/04-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/04-gateway-route.yaml
@@ -1,6 +1,6 @@
 Clusters:
   Resources:
-    echo-mirror-303ee71109a987aa:
+    echo-mirror-eb192462fe75ad40:
       circuitBreakers:
         thresholds:
         - maxConnections: 1024
@@ -12,7 +12,7 @@ Clusters:
         edsConfig:
           ads: {}
           resourceApiVersion: V3
-      name: echo-mirror-303ee71109a987aa
+      name: echo-mirror-eb192462fe75ad40
       outlierDetection:
         enforcingConsecutive5xx: 0
         enforcingConsecutiveGatewayFailure: 0
@@ -27,7 +27,7 @@ Clusters:
             idleTimeout: 3600s
           explicitHttpConfig:
             httpProtocolOptions: {}
-    echo-service:
+    echo-service-5a416c39037aa8f6:
       circuitBreakers:
         thresholds:
         - maxConnections: 1024
@@ -39,7 +39,7 @@ Clusters:
         edsConfig:
           ads: {}
           resourceApiVersion: V3
-      name: echo-service
+      name: echo-service-5a416c39037aa8f6
       outlierDetection:
         enforcingConsecutive5xx: 0
         enforcingConsecutiveGatewayFailure: 0
@@ -56,10 +56,10 @@ Clusters:
             httpProtocolOptions: {}
 Endpoints:
   Resources:
-    echo-mirror-303ee71109a987aa:
-      clusterName: echo-mirror-303ee71109a987aa
-    echo-service:
-      clusterName: echo-service
+    echo-mirror-eb192462fe75ad40:
+      clusterName: echo-mirror-eb192462fe75ad40
+    echo-service-5a416c39037aa8f6:
+      clusterName: echo-service-5a416c39037aa8f6
       endpoints:
       - lbEndpoints:
         - endpoint:
@@ -141,14 +141,14 @@ Routes:
             path: /
           route:
             requestMirrorPolicies:
-            - cluster: echo-mirror-303ee71109a987aa
+            - cluster: echo-mirror-eb192462fe75ad40
               runtimeFraction:
                 defaultValue:
                   denominator: TEN_THOUSAND
                   numerator: 10
             weightedClusters:
               clusters:
-              - name: echo-service
+              - name: echo-service-5a416c39037aa8f6
                 weight: 1
               totalWeight: 1
 Runtimes:

--- a/pkg/plugins/runtime/gateway/testdata/http/06-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/06-gateway-route.yaml
@@ -1,6 +1,6 @@
 Clusters:
   Resources:
-    echo-mirror-303ee71109a987aa:
+    echo-mirror-eb192462fe75ad40:
       circuitBreakers:
         thresholds:
         - maxConnections: 1024
@@ -12,7 +12,7 @@ Clusters:
         edsConfig:
           ads: {}
           resourceApiVersion: V3
-      name: echo-mirror-303ee71109a987aa
+      name: echo-mirror-eb192462fe75ad40
       outlierDetection:
         enforcingConsecutive5xx: 0
         enforcingConsecutiveGatewayFailure: 0
@@ -27,7 +27,7 @@ Clusters:
             idleTimeout: 3600s
           explicitHttpConfig:
             httpProtocolOptions: {}
-    echo-service:
+    echo-service-5a416c39037aa8f6:
       circuitBreakers:
         thresholds:
         - maxConnections: 1024
@@ -39,7 +39,7 @@ Clusters:
         edsConfig:
           ads: {}
           resourceApiVersion: V3
-      name: echo-service
+      name: echo-service-5a416c39037aa8f6
       outlierDetection:
         enforcingConsecutive5xx: 0
         enforcingConsecutiveGatewayFailure: 0
@@ -56,10 +56,10 @@ Clusters:
             httpProtocolOptions: {}
 Endpoints:
   Resources:
-    echo-mirror-303ee71109a987aa:
-      clusterName: echo-mirror-303ee71109a987aa
-    echo-service:
-      clusterName: echo-service
+    echo-mirror-eb192462fe75ad40:
+      clusterName: echo-mirror-eb192462fe75ad40
+    echo-service-5a416c39037aa8f6:
+      clusterName: echo-service-5a416c39037aa8f6
       endpoints:
       - lbEndpoints:
         - endpoint:
@@ -160,14 +160,14 @@ Routes:
           - delete-another
           route:
             requestMirrorPolicies:
-            - cluster: echo-mirror-303ee71109a987aa
+            - cluster: echo-mirror-eb192462fe75ad40
               runtimeFraction:
                 defaultValue:
                   denominator: TEN_THOUSAND
                   numerator: 10
             weightedClusters:
               clusters:
-              - name: echo-service
+              - name: echo-service-5a416c39037aa8f6
                 weight: 1
               totalWeight: 1
 Runtimes:

--- a/pkg/plugins/runtime/gateway/testdata/http/07-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/07-gateway-route.yaml
@@ -1,6 +1,6 @@
 Clusters:
   Resources:
-    echo-service:
+    echo-service-5a416c39037aa8f6:
       circuitBreakers:
         thresholds:
         - maxConnections: 1024
@@ -12,7 +12,7 @@ Clusters:
         edsConfig:
           ads: {}
           resourceApiVersion: V3
-      name: echo-service
+      name: echo-service-5a416c39037aa8f6
       outlierDetection:
         enforcingConsecutive5xx: 0
         enforcingConsecutiveGatewayFailure: 0
@@ -29,8 +29,8 @@ Clusters:
             httpProtocolOptions: {}
 Endpoints:
   Resources:
-    echo-service:
-      clusterName: echo-service
+    echo-service-5a416c39037aa8f6:
+      clusterName: echo-service-5a416c39037aa8f6
       endpoints:
       - lbEndpoints:
         - endpoint:
@@ -113,7 +113,7 @@ Routes:
           route:
             weightedClusters:
               clusters:
-              - name: echo-service
+              - name: echo-service-5a416c39037aa8f6
                 weight: 1
               totalWeight: 1
         - match:
@@ -121,7 +121,7 @@ Routes:
           route:
             weightedClusters:
               clusters:
-              - name: echo-service
+              - name: echo-service-5a416c39037aa8f6
                 weight: 1
               totalWeight: 1
 Runtimes:

--- a/pkg/plugins/runtime/gateway/testdata/http/08-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/08-gateway-route.yaml
@@ -1,6 +1,6 @@
 Clusters:
   Resources:
-    exact-service:
+    exact-service-09493d2d54b2a972:
       circuitBreakers:
         thresholds:
         - maxConnections: 1024
@@ -12,7 +12,7 @@ Clusters:
         edsConfig:
           ads: {}
           resourceApiVersion: V3
-      name: exact-service
+      name: exact-service-09493d2d54b2a972
       outlierDetection:
         enforcingConsecutive5xx: 0
         enforcingConsecutiveGatewayFailure: 0
@@ -27,7 +27,7 @@ Clusters:
             idleTimeout: 3600s
           explicitHttpConfig:
             httpProtocolOptions: {}
-    prefix-service:
+    prefix-service-5061ee504b81a555:
       circuitBreakers:
         thresholds:
         - maxConnections: 1024
@@ -39,7 +39,7 @@ Clusters:
         edsConfig:
           ads: {}
           resourceApiVersion: V3
-      name: prefix-service
+      name: prefix-service-5061ee504b81a555
       outlierDetection:
         enforcingConsecutive5xx: 0
         enforcingConsecutiveGatewayFailure: 0
@@ -56,8 +56,8 @@ Clusters:
             httpProtocolOptions: {}
 Endpoints:
   Resources:
-    exact-service:
-      clusterName: exact-service
+    exact-service-09493d2d54b2a972:
+      clusterName: exact-service-09493d2d54b2a972
       endpoints:
       - lbEndpoints:
         - endpoint:
@@ -72,8 +72,8 @@ Endpoints:
                 kuma.io/protocol: http
               envoy.transport_socket_match:
                 kuma.io/protocol: http
-    prefix-service:
-      clusterName: prefix-service
+    prefix-service-5061ee504b81a555:
+      clusterName: prefix-service-5061ee504b81a555
       endpoints:
       - lbEndpoints:
         - endpoint:
@@ -156,7 +156,7 @@ Routes:
           route:
             weightedClusters:
               clusters:
-              - name: exact-service
+              - name: exact-service-09493d2d54b2a972
                 weight: 1
               totalWeight: 1
         - match:
@@ -164,7 +164,7 @@ Routes:
           route:
             weightedClusters:
               clusters:
-              - name: prefix-service
+              - name: prefix-service-5061ee504b81a555
                 weight: 1
               totalWeight: 1
 Runtimes:

--- a/pkg/plugins/runtime/gateway/testdata/http/09-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/09-gateway-route.yaml
@@ -1,6 +1,6 @@
 Clusters:
   Resources:
-    echo-service:
+    echo-service-5a416c39037aa8f6:
       circuitBreakers:
         thresholds:
         - maxConnections: 1024
@@ -12,7 +12,7 @@ Clusters:
         edsConfig:
           ads: {}
           resourceApiVersion: V3
-      name: echo-service
+      name: echo-service-5a416c39037aa8f6
       outlierDetection:
         enforcingConsecutive5xx: 0
         enforcingConsecutiveGatewayFailure: 0
@@ -29,8 +29,8 @@ Clusters:
             httpProtocolOptions: {}
 Endpoints:
   Resources:
-    echo-service:
-      clusterName: echo-service
+    echo-service-5a416c39037aa8f6:
+      clusterName: echo-service-5a416c39037aa8f6
       endpoints:
       - lbEndpoints:
         - endpoint:
@@ -115,7 +115,7 @@ Routes:
           route:
             weightedClusters:
               clusters:
-              - name: echo-service
+              - name: echo-service-5a416c39037aa8f6
                 weight: 1
               totalWeight: 1
 Runtimes:

--- a/pkg/plugins/runtime/gateway/testdata/http/10-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/10-gateway-route.yaml
@@ -1,6 +1,6 @@
 Clusters:
   Resources:
-    exact-header-match:
+    exact-header-match-f6b57a6b55557c81:
       circuitBreakers:
         thresholds:
         - maxConnections: 1024
@@ -12,7 +12,7 @@ Clusters:
         edsConfig:
           ads: {}
           resourceApiVersion: V3
-      name: exact-header-match
+      name: exact-header-match-f6b57a6b55557c81
       outlierDetection:
         enforcingConsecutive5xx: 0
         enforcingConsecutiveGatewayFailure: 0
@@ -27,7 +27,7 @@ Clusters:
             idleTimeout: 3600s
           explicitHttpConfig:
             httpProtocolOptions: {}
-    regex-header-match:
+    regex-header-match-ad0dd92f37b8a38d:
       circuitBreakers:
         thresholds:
         - maxConnections: 1024
@@ -39,7 +39,7 @@ Clusters:
         edsConfig:
           ads: {}
           resourceApiVersion: V3
-      name: regex-header-match
+      name: regex-header-match-ad0dd92f37b8a38d
       outlierDetection:
         enforcingConsecutive5xx: 0
         enforcingConsecutiveGatewayFailure: 0
@@ -56,8 +56,8 @@ Clusters:
             httpProtocolOptions: {}
 Endpoints:
   Resources:
-    exact-header-match:
-      clusterName: exact-header-match
+    exact-header-match-f6b57a6b55557c81:
+      clusterName: exact-header-match-f6b57a6b55557c81
       endpoints:
       - lbEndpoints:
         - endpoint:
@@ -72,8 +72,8 @@ Endpoints:
                 kuma.io/protocol: http
               envoy.transport_socket_match:
                 kuma.io/protocol: http
-    regex-header-match:
-      clusterName: regex-header-match
+    regex-header-match-ad0dd92f37b8a38d:
+      clusterName: regex-header-match-ad0dd92f37b8a38d
       endpoints:
       - lbEndpoints:
         - endpoint:
@@ -164,7 +164,7 @@ Routes:
           route:
             weightedClusters:
               clusters:
-              - name: regex-header-match
+              - name: regex-header-match-ad0dd92f37b8a38d
                 weight: 1
               totalWeight: 1
         - match:
@@ -174,7 +174,7 @@ Routes:
           route:
             weightedClusters:
               clusters:
-              - name: exact-header-match
+              - name: exact-header-match-f6b57a6b55557c81
                 weight: 1
               totalWeight: 1
         - match:
@@ -184,7 +184,7 @@ Routes:
           route:
             weightedClusters:
               clusters:
-              - name: exact-header-match
+              - name: exact-header-match-f6b57a6b55557c81
                 weight: 1
               totalWeight: 1
 Runtimes:

--- a/pkg/plugins/runtime/gateway/testdata/http/11-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/11-gateway-route.yaml
@@ -1,6 +1,6 @@
 Clusters:
   Resources:
-    exact-query-match:
+    exact-query-match-cc1370f58a3b5330:
       circuitBreakers:
         thresholds:
         - maxConnections: 1024
@@ -12,7 +12,7 @@ Clusters:
         edsConfig:
           ads: {}
           resourceApiVersion: V3
-      name: exact-query-match
+      name: exact-query-match-cc1370f58a3b5330
       outlierDetection:
         enforcingConsecutive5xx: 0
         enforcingConsecutiveGatewayFailure: 0
@@ -27,7 +27,7 @@ Clusters:
             idleTimeout: 3600s
           explicitHttpConfig:
             httpProtocolOptions: {}
-    regex-query-match:
+    regex-query-match-3804d7b8516d7323:
       circuitBreakers:
         thresholds:
         - maxConnections: 1024
@@ -39,7 +39,7 @@ Clusters:
         edsConfig:
           ads: {}
           resourceApiVersion: V3
-      name: regex-query-match
+      name: regex-query-match-3804d7b8516d7323
       outlierDetection:
         enforcingConsecutive5xx: 0
         enforcingConsecutiveGatewayFailure: 0
@@ -56,8 +56,8 @@ Clusters:
             httpProtocolOptions: {}
 Endpoints:
   Resources:
-    exact-query-match:
-      clusterName: exact-query-match
+    exact-query-match-cc1370f58a3b5330:
+      clusterName: exact-query-match-cc1370f58a3b5330
       endpoints:
       - lbEndpoints:
         - endpoint:
@@ -72,8 +72,8 @@ Endpoints:
                 kuma.io/protocol: http
               envoy.transport_socket_match:
                 kuma.io/protocol: http
-    regex-query-match:
-      clusterName: regex-query-match
+    regex-query-match-3804d7b8516d7323:
+      clusterName: regex-query-match-3804d7b8516d7323
       endpoints:
       - lbEndpoints:
         - endpoint:
@@ -166,7 +166,7 @@ Routes:
           route:
             weightedClusters:
               clusters:
-              - name: regex-query-match
+              - name: regex-query-match-3804d7b8516d7323
                 weight: 1
               totalWeight: 1
         - match:
@@ -177,7 +177,7 @@ Routes:
           route:
             weightedClusters:
               clusters:
-              - name: exact-query-match
+              - name: exact-query-match-cc1370f58a3b5330
                 weight: 1
               totalWeight: 1
         - match:
@@ -188,7 +188,7 @@ Routes:
           route:
             weightedClusters:
               clusters:
-              - name: exact-query-match
+              - name: exact-query-match-cc1370f58a3b5330
                 weight: 1
               totalWeight: 1
 Runtimes:

--- a/pkg/plugins/runtime/gateway/testdata/http/12-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/12-gateway-route.yaml
@@ -1,6 +1,6 @@
 Clusters:
   Resources:
-    echo-service:
+    echo-service-5a416c39037aa8f6:
       circuitBreakers:
         thresholds:
         - maxConnections: 1024
@@ -12,7 +12,7 @@ Clusters:
         edsConfig:
           ads: {}
           resourceApiVersion: V3
-      name: echo-service
+      name: echo-service-5a416c39037aa8f6
       outlierDetection:
         enforcingConsecutive5xx: 0
         enforcingConsecutiveGatewayFailure: 0
@@ -29,8 +29,8 @@ Clusters:
             httpProtocolOptions: {}
 Endpoints:
   Resources:
-    echo-service:
-      clusterName: echo-service
+    echo-service-5a416c39037aa8f6:
+      clusterName: echo-service-5a416c39037aa8f6
       endpoints:
       - lbEndpoints:
         - endpoint:
@@ -118,7 +118,7 @@ Routes:
           route:
             weightedClusters:
               clusters:
-              - name: echo-service
+              - name: echo-service-5a416c39037aa8f6
                 weight: 1
               totalWeight: 1
         - match:
@@ -131,7 +131,7 @@ Routes:
           route:
             weightedClusters:
               clusters:
-              - name: echo-service
+              - name: echo-service-5a416c39037aa8f6
                 weight: 1
               totalWeight: 1
         - match:
@@ -144,7 +144,7 @@ Routes:
           route:
             weightedClusters:
               clusters:
-              - name: echo-service
+              - name: echo-service-5a416c39037aa8f6
                 weight: 1
               totalWeight: 1
 Runtimes:

--- a/pkg/plugins/runtime/gateway/testdata/http/13-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/13-gateway-route.yaml
@@ -1,6 +1,6 @@
 Clusters:
   Resources:
-    echo-exact:
+    echo-exact-ad4e3a31db1bf217:
       circuitBreakers:
         thresholds:
         - maxConnections: 1024
@@ -12,7 +12,7 @@ Clusters:
         edsConfig:
           ads: {}
           resourceApiVersion: V3
-      name: echo-exact
+      name: echo-exact-ad4e3a31db1bf217
       outlierDetection:
         enforcingConsecutive5xx: 0
         enforcingConsecutiveGatewayFailure: 0
@@ -27,7 +27,7 @@ Clusters:
             idleTimeout: 3600s
           explicitHttpConfig:
             httpProtocolOptions: {}
-    echo-prefix:
+    echo-prefix-d0e5ba63b0c9b9f0:
       circuitBreakers:
         thresholds:
         - maxConnections: 1024
@@ -39,7 +39,7 @@ Clusters:
         edsConfig:
           ads: {}
           resourceApiVersion: V3
-      name: echo-prefix
+      name: echo-prefix-d0e5ba63b0c9b9f0
       outlierDetection:
         enforcingConsecutive5xx: 0
         enforcingConsecutiveGatewayFailure: 0
@@ -54,7 +54,7 @@ Clusters:
             idleTimeout: 3600s
           explicitHttpConfig:
             httpProtocolOptions: {}
-    echo-regex:
+    echo-regex-627905e7b1c2eb33:
       circuitBreakers:
         thresholds:
         - maxConnections: 1024
@@ -66,7 +66,7 @@ Clusters:
         edsConfig:
           ads: {}
           resourceApiVersion: V3
-      name: echo-regex
+      name: echo-regex-627905e7b1c2eb33
       outlierDetection:
         enforcingConsecutive5xx: 0
         enforcingConsecutiveGatewayFailure: 0
@@ -83,8 +83,8 @@ Clusters:
             httpProtocolOptions: {}
 Endpoints:
   Resources:
-    echo-exact:
-      clusterName: echo-exact
+    echo-exact-ad4e3a31db1bf217:
+      clusterName: echo-exact-ad4e3a31db1bf217
       endpoints:
       - lbEndpoints:
         - endpoint:
@@ -99,8 +99,8 @@ Endpoints:
                 kuma.io/protocol: http
               envoy.transport_socket_match:
                 kuma.io/protocol: http
-    echo-prefix:
-      clusterName: echo-prefix
+    echo-prefix-d0e5ba63b0c9b9f0:
+      clusterName: echo-prefix-d0e5ba63b0c9b9f0
       endpoints:
       - lbEndpoints:
         - endpoint:
@@ -115,8 +115,8 @@ Endpoints:
                 kuma.io/protocol: http
               envoy.transport_socket_match:
                 kuma.io/protocol: http
-    echo-regex:
-      clusterName: echo-regex
+    echo-regex-627905e7b1c2eb33:
+      clusterName: echo-regex-627905e7b1c2eb33
       endpoints:
       - lbEndpoints:
         - endpoint:
@@ -199,7 +199,7 @@ Routes:
           route:
             weightedClusters:
               clusters:
-              - name: echo-exact
+              - name: echo-exact-ad4e3a31db1bf217
                 weight: 1
               totalWeight: 1
         - match:
@@ -207,7 +207,7 @@ Routes:
           route:
             weightedClusters:
               clusters:
-              - name: echo-prefix
+              - name: echo-prefix-d0e5ba63b0c9b9f0
                 weight: 1
               totalWeight: 1
         - match:
@@ -215,7 +215,7 @@ Routes:
           route:
             weightedClusters:
               clusters:
-              - name: echo-prefix
+              - name: echo-prefix-d0e5ba63b0c9b9f0
                 weight: 1
               totalWeight: 1
         - match:
@@ -225,7 +225,7 @@ Routes:
           route:
             weightedClusters:
               clusters:
-              - name: echo-regex
+              - name: echo-regex-627905e7b1c2eb33
                 weight: 1
               totalWeight: 1
 Runtimes:

--- a/pkg/plugins/runtime/gateway/testdata/http/14-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/14-gateway-route.yaml
@@ -1,6 +1,6 @@
 Clusters:
   Resources:
-    echo-service:
+    echo-service-5a416c39037aa8f6:
       circuitBreakers:
         thresholds:
         - maxConnections: 1024
@@ -12,7 +12,7 @@ Clusters:
         edsConfig:
           ads: {}
           resourceApiVersion: V3
-      name: echo-service
+      name: echo-service-5a416c39037aa8f6
       outlierDetection:
         enforcingConsecutive5xx: 0
         enforcingConsecutiveGatewayFailure: 0
@@ -29,8 +29,8 @@ Clusters:
             httpProtocolOptions: {}
 Endpoints:
   Resources:
-    echo-service:
-      clusterName: echo-service
+    echo-service-5a416c39037aa8f6:
+      clusterName: echo-service-5a416c39037aa8f6
       endpoints:
       - lbEndpoints:
         - endpoint:
@@ -117,7 +117,7 @@ Routes:
             hostRewriteLiteral: newhost.example.com
             weightedClusters:
               clusters:
-              - name: echo-service
+              - name: echo-service-5a416c39037aa8f6
                 weight: 1
               totalWeight: 1
 Runtimes:

--- a/pkg/plugins/runtime/gateway/testdata/http/15-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/15-gateway-route.yaml
@@ -1,6 +1,6 @@
 Clusters:
   Resources:
-    api-service:
+    api-service-6b688a06cd66f5c9:
       circuitBreakers:
         thresholds:
         - maxConnections: 1024
@@ -12,7 +12,7 @@ Clusters:
         edsConfig:
           ads: {}
           resourceApiVersion: V3
-      name: api-service
+      name: api-service-6b688a06cd66f5c9
       outlierDetection:
         enforcingConsecutive5xx: 0
         enforcingConsecutiveGatewayFailure: 0
@@ -27,7 +27,7 @@ Clusters:
             idleTimeout: 20s
           explicitHttpConfig:
             httpProtocolOptions: {}
-    echo-mirror:
+    echo-mirror-5c286df2bcbe50d6:
       circuitBreakers:
         thresholds:
         - maxConnections: 1024
@@ -39,7 +39,7 @@ Clusters:
         edsConfig:
           ads: {}
           resourceApiVersion: V3
-      name: echo-mirror
+      name: echo-mirror-5c286df2bcbe50d6
       outlierDetection:
         enforcingConsecutive5xx: 0
         enforcingConsecutiveGatewayFailure: 0
@@ -54,7 +54,7 @@ Clusters:
             idleTimeout: 30s
           explicitHttpConfig:
             httpProtocolOptions: {}
-    echo-service:
+    echo-service-b5c2b60cba392c4e:
       circuitBreakers:
         thresholds:
         - maxConnections: 1024
@@ -66,7 +66,7 @@ Clusters:
         edsConfig:
           ads: {}
           resourceApiVersion: V3
-      name: echo-service
+      name: echo-service-b5c2b60cba392c4e
       outlierDetection:
         enforcingConsecutive5xx: 0
         enforcingConsecutiveGatewayFailure: 0
@@ -83,8 +83,8 @@ Clusters:
             httpProtocolOptions: {}
 Endpoints:
   Resources:
-    api-service:
-      clusterName: api-service
+    api-service-6b688a06cd66f5c9:
+      clusterName: api-service-6b688a06cd66f5c9
       endpoints:
       - lbEndpoints:
         - endpoint:
@@ -99,8 +99,8 @@ Endpoints:
                 kuma.io/protocol: http
               envoy.transport_socket_match:
                 kuma.io/protocol: http
-    echo-mirror:
-      clusterName: echo-mirror
+    echo-mirror-5c286df2bcbe50d6:
+      clusterName: echo-mirror-5c286df2bcbe50d6
       endpoints:
       - lbEndpoints:
         - endpoint:
@@ -115,8 +115,8 @@ Endpoints:
                 kuma.io/protocol: http
               envoy.transport_socket_match:
                 kuma.io/protocol: http
-    echo-service:
-      clusterName: echo-service
+    echo-service-b5c2b60cba392c4e:
+      clusterName: echo-service-b5c2b60cba392c4e
       endpoints:
       - lbEndpoints:
         - endpoint:
@@ -199,7 +199,7 @@ Routes:
           route:
             weightedClusters:
               clusters:
-              - name: api-service
+              - name: api-service-6b688a06cd66f5c9
                 weight: 1
               totalWeight: 1
         - match:
@@ -207,20 +207,20 @@ Routes:
           route:
             weightedClusters:
               clusters:
-              - name: api-service
+              - name: api-service-6b688a06cd66f5c9
                 weight: 1
               totalWeight: 1
         - match:
             prefix: /
           route:
             requestMirrorPolicies:
-            - cluster: echo-mirror
+            - cluster: echo-mirror-5c286df2bcbe50d6
               runtimeFraction:
                 defaultValue:
                   numerator: 1
             weightedClusters:
               clusters:
-              - name: echo-service
+              - name: echo-service-b5c2b60cba392c4e
                 weight: 1
               totalWeight: 1
 Runtimes:

--- a/pkg/plugins/runtime/gateway/testdata/http/17-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/17-gateway-route.yaml
@@ -1,6 +1,6 @@
 Clusters:
   Resources:
-    api-service:
+    api-service-19fcb7995aa98119:
       circuitBreakers:
         thresholds:
         - maxConnections: 1024
@@ -18,7 +18,7 @@ Clusters:
         tcpHealthCheck: {}
         timeout: 20s
         unhealthyThreshold: 2
-      name: api-service
+      name: api-service-19fcb7995aa98119
       outlierDetection:
         enforcingConsecutive5xx: 0
         enforcingConsecutiveGatewayFailure: 0
@@ -33,7 +33,7 @@ Clusters:
             idleTimeout: 3600s
           explicitHttpConfig:
             httpProtocolOptions: {}
-    echo-mirror:
+    echo-mirror-2e2ba113e4d991ba:
       circuitBreakers:
         thresholds:
         - maxConnections: 1024
@@ -51,7 +51,7 @@ Clusters:
         tcpHealthCheck: {}
         timeout: 30s
         unhealthyThreshold: 3
-      name: echo-mirror
+      name: echo-mirror-2e2ba113e4d991ba
       outlierDetection:
         enforcingConsecutive5xx: 0
         enforcingConsecutiveGatewayFailure: 0
@@ -66,7 +66,7 @@ Clusters:
             idleTimeout: 3600s
           explicitHttpConfig:
             httpProtocolOptions: {}
-    echo-service:
+    echo-service-eb4ea372d99abf73:
       circuitBreakers:
         thresholds:
         - maxConnections: 1024
@@ -84,7 +84,7 @@ Clusters:
         tcpHealthCheck: {}
         timeout: 10s
         unhealthyThreshold: 1
-      name: echo-service
+      name: echo-service-eb4ea372d99abf73
       outlierDetection:
         enforcingConsecutive5xx: 0
         enforcingConsecutiveGatewayFailure: 0
@@ -101,8 +101,8 @@ Clusters:
             httpProtocolOptions: {}
 Endpoints:
   Resources:
-    api-service:
-      clusterName: api-service
+    api-service-19fcb7995aa98119:
+      clusterName: api-service-19fcb7995aa98119
       endpoints:
       - lbEndpoints:
         - endpoint:
@@ -117,8 +117,8 @@ Endpoints:
                 kuma.io/protocol: http
               envoy.transport_socket_match:
                 kuma.io/protocol: http
-    echo-mirror:
-      clusterName: echo-mirror
+    echo-mirror-2e2ba113e4d991ba:
+      clusterName: echo-mirror-2e2ba113e4d991ba
       endpoints:
       - lbEndpoints:
         - endpoint:
@@ -133,8 +133,8 @@ Endpoints:
                 kuma.io/protocol: http
               envoy.transport_socket_match:
                 kuma.io/protocol: http
-    echo-service:
-      clusterName: echo-service
+    echo-service-eb4ea372d99abf73:
+      clusterName: echo-service-eb4ea372d99abf73
       endpoints:
       - lbEndpoints:
         - endpoint:
@@ -217,7 +217,7 @@ Routes:
           route:
             weightedClusters:
               clusters:
-              - name: api-service
+              - name: api-service-19fcb7995aa98119
                 weight: 1
               totalWeight: 1
         - match:
@@ -225,20 +225,20 @@ Routes:
           route:
             weightedClusters:
               clusters:
-              - name: api-service
+              - name: api-service-19fcb7995aa98119
                 weight: 1
               totalWeight: 1
         - match:
             prefix: /
           route:
             requestMirrorPolicies:
-            - cluster: echo-mirror
+            - cluster: echo-mirror-2e2ba113e4d991ba
               runtimeFraction:
                 defaultValue:
                   numerator: 1
             weightedClusters:
               clusters:
-              - name: echo-service
+              - name: echo-service-eb4ea372d99abf73
                 weight: 1
               totalWeight: 1
 Runtimes:

--- a/pkg/plugins/runtime/gateway/testdata/http/18-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/18-gateway-route.yaml
@@ -1,6 +1,6 @@
 Clusters:
   Resources:
-    external-httpbin:
+    external-httpbin-4a2cc28cd5e983f1:
       circuitBreakers:
         thresholds:
         - maxConnections: 1024
@@ -25,7 +25,7 @@ Clusters:
                   kuma.io/protocol: http
                 envoy.transport_socket_match:
                   kuma.io/protocol: http
-      name: external-httpbin
+      name: external-httpbin-4a2cc28cd5e983f1
       outlierDetection:
         enforcingConsecutive5xx: 0
         enforcingConsecutiveGatewayFailure: 0
@@ -110,7 +110,7 @@ Routes:
           route:
             weightedClusters:
               clusters:
-              - name: external-httpbin
+              - name: external-httpbin-4a2cc28cd5e983f1
                 weight: 1
               totalWeight: 1
 Runtimes:

--- a/pkg/plugins/runtime/gateway/testdata/http/19-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/19-gateway-route.yaml
@@ -1,6 +1,6 @@
 Clusters:
   Resources:
-    external-httpbin:
+    external-httpbin-241b25f6d3fc3b49:
       circuitBreakers:
         thresholds:
         - maxConnections: 1024
@@ -27,7 +27,7 @@ Clusters:
                 envoy.transport_socket_match:
                   kuma.io/external-service-name: external-httpbin
                   kuma.io/protocol: http2
-      name: external-httpbin
+      name: external-httpbin-241b25f6d3fc3b49
       outlierDetection:
         enforcingConsecutive5xx: 0
         enforcingConsecutiveGatewayFailure: 0
@@ -123,7 +123,7 @@ Routes:
           route:
             weightedClusters:
               clusters:
-              - name: external-httpbin
+              - name: external-httpbin-241b25f6d3fc3b49
                 weight: 1
               totalWeight: 1
 Runtimes:

--- a/pkg/plugins/runtime/gateway/testdata/http/20-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/20-gateway-route.yaml
@@ -1,21 +1,22 @@
 Clusters:
   Resources:
-    api-service-49c6d22609eca2d2:
+    echo-service-b5c2b60cba392c4e:
       circuitBreakers:
         thresholds:
-        - maxRetries: 20
-      connectTimeout: 5s
+        - maxConnections: 1024
+          maxPendingRequests: 1024
+          maxRequests: 1024
+          maxRetries: 3
+      connectTimeout: 10s
       edsClusterConfig:
         edsConfig:
           ads: {}
           resourceApiVersion: V3
-      name: api-service-49c6d22609eca2d2
+      name: echo-service-b5c2b60cba392c4e
       outlierDetection:
-        baseEjectionTime: 20s
-        consecutiveLocalOriginFailure: 20
         enforcingConsecutive5xx: 0
         enforcingConsecutiveGatewayFailure: 0
-        enforcingConsecutiveLocalOriginFailure: 100
+        enforcingConsecutiveLocalOriginFailure: 0
         enforcingFailurePercentage: 0
         enforcingSuccessRate: 0
       type: EDS
@@ -23,25 +24,26 @@ Clusters:
         envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
           '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
           commonHttpProtocolOptions:
-            idleTimeout: 3600s
+            idleTimeout: 10s
           explicitHttpConfig:
             httpProtocolOptions: {}
-    echo-mirror-f534124491f4385f:
+    echo-service-cff7b41a9764f367:
       circuitBreakers:
         thresholds:
-        - maxRetries: 20
-      connectTimeout: 5s
+        - maxConnections: 1024
+          maxPendingRequests: 1024
+          maxRequests: 1024
+          maxRetries: 3
+      connectTimeout: 300s
       edsClusterConfig:
         edsConfig:
           ads: {}
           resourceApiVersion: V3
-      name: echo-mirror-f534124491f4385f
+      name: echo-service-cff7b41a9764f367
       outlierDetection:
-        baseEjectionTime: 30s
-        consecutiveLocalOriginFailure: 30
         enforcingConsecutive5xx: 0
         enforcingConsecutiveGatewayFailure: 0
-        enforcingConsecutiveLocalOriginFailure: 100
+        enforcingConsecutiveLocalOriginFailure: 0
         enforcingFailurePercentage: 0
         enforcingSuccessRate: 0
       type: EDS
@@ -49,25 +51,26 @@ Clusters:
         envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
           '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
           commonHttpProtocolOptions:
-            idleTimeout: 3600s
+            idleTimeout: 30s
           explicitHttpConfig:
             httpProtocolOptions: {}
-    echo-service-48cd7f2dbb98df84:
+    echo-service-dbfe9218dfa3ba0c:
       circuitBreakers:
         thresholds:
-        - maxRetries: 10
-      connectTimeout: 5s
+        - maxConnections: 1024
+          maxPendingRequests: 1024
+          maxRequests: 1024
+          maxRetries: 3
+      connectTimeout: 20s
       edsClusterConfig:
         edsConfig:
           ads: {}
           resourceApiVersion: V3
-      name: echo-service-48cd7f2dbb98df84
+      name: echo-service-dbfe9218dfa3ba0c
       outlierDetection:
-        baseEjectionTime: 10s
-        consecutiveLocalOriginFailure: 10
         enforcingConsecutive5xx: 0
         enforcingConsecutiveGatewayFailure: 0
-        enforcingConsecutiveLocalOriginFailure: 100
+        enforcingConsecutiveLocalOriginFailure: 0
         enforcingFailurePercentage: 0
         enforcingSuccessRate: 0
       type: EDS
@@ -75,20 +78,20 @@ Clusters:
         envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
           '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
           commonHttpProtocolOptions:
-            idleTimeout: 3600s
+            idleTimeout: 20s
           explicitHttpConfig:
             httpProtocolOptions: {}
 Endpoints:
   Resources:
-    api-service-49c6d22609eca2d2:
-      clusterName: api-service-49c6d22609eca2d2
+    echo-service-b5c2b60cba392c4e:
+      clusterName: echo-service-b5c2b60cba392c4e
       endpoints:
       - lbEndpoints:
         - endpoint:
             address:
               socketAddress:
-                address: 192.168.1.1
-                portValue: 20001
+                address: 192.168.1.6
+                portValue: 20006
           loadBalancingWeight: 1
           metadata:
             filterMetadata:
@@ -96,15 +99,15 @@ Endpoints:
                 kuma.io/protocol: http
               envoy.transport_socket_match:
                 kuma.io/protocol: http
-    echo-mirror-f534124491f4385f:
-      clusterName: echo-mirror-f534124491f4385f
+    echo-service-cff7b41a9764f367:
+      clusterName: echo-service-cff7b41a9764f367
       endpoints:
       - lbEndpoints:
         - endpoint:
             address:
               socketAddress:
-                address: 192.168.1.3
-                portValue: 20003
+                address: 192.168.1.6
+                portValue: 20006
           loadBalancingWeight: 1
           metadata:
             filterMetadata:
@@ -112,8 +115,8 @@ Endpoints:
                 kuma.io/protocol: http
               envoy.transport_socket_match:
                 kuma.io/protocol: http
-    echo-service-48cd7f2dbb98df84:
-      clusterName: echo-service-48cd7f2dbb98df84
+    echo-service-dbfe9218dfa3ba0c:
+      clusterName: echo-service-dbfe9218dfa3ba0c
       endpoints:
       - lbEndpoints:
         - endpoint:
@@ -130,11 +133,11 @@ Endpoints:
                 kuma.io/protocol: http
 Listeners:
   Resources:
-    edge-gateway:HTTP:8080:
+    gateway-multihost:HTTP:9080:
       address:
         socketAddress:
           address: 192.168.1.1
-          portValue: 8080
+          portValue: 9080
       filterChains:
       - filters:
         - name: envoy.filters.network.http_connection_manager
@@ -165,59 +168,62 @@ Listeners:
               configSource:
                 ads: {}
                 resourceApiVersion: V3
-              routeConfigName: edge-gateway:HTTP:8080
+              routeConfigName: gateway-multihost:HTTP:9080
             requestHeadersTimeout: 0.500s
             serverName: Kuma Gateway
-            statPrefix: gateway-default
+            statPrefix: gateway-multihost
             streamIdleTimeout: 5s
             stripAnyHostPort: true
       listenerFilters:
       - name: envoy.filters.listener.tls_inspector
         typedConfig:
           '@type': type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
-      name: edge-gateway:HTTP:8080
+      name: gateway-multihost:HTTP:9080
       perConnectionBufferLimitBytes: 32768
       reusePort: true
       trafficDirection: INBOUND
 Routes:
   Resources:
-    edge-gateway:HTTP:8080:
-      name: edge-gateway:HTTP:8080
+    gateway-multihost:HTTP:9080:
+      name: gateway-multihost:HTTP:9080
       requestHeadersToRemove:
       - x-kuma-tags
       validateClusters: false
       virtualHosts:
       - domains:
-        - echo.example.com
-        name: edge-gateway:HTTP:8080:echo.example.com
+        - two.example.com
+        name: gateway-multihost:HTTP:9080:two.example.com
         routes:
-        - match:
-            path: /api
-          route:
-            weightedClusters:
-              clusters:
-              - name: api-service-49c6d22609eca2d2
-                weight: 1
-              totalWeight: 1
-        - match:
-            prefix: /api/
-          route:
-            weightedClusters:
-              clusters:
-              - name: api-service-49c6d22609eca2d2
-                weight: 1
-              totalWeight: 1
         - match:
             prefix: /
           route:
-            requestMirrorPolicies:
-            - cluster: echo-mirror-f534124491f4385f
-              runtimeFraction:
-                defaultValue:
-                  numerator: 1
             weightedClusters:
               clusters:
-              - name: echo-service-48cd7f2dbb98df84
+              - name: echo-service-dbfe9218dfa3ba0c
+                weight: 1
+              totalWeight: 1
+      - domains:
+        - three.example.com
+        name: gateway-multihost:HTTP:9080:three.example.com
+        routes:
+        - match:
+            prefix: /
+          route:
+            weightedClusters:
+              clusters:
+              - name: echo-service-cff7b41a9764f367
+                weight: 1
+              totalWeight: 1
+      - domains:
+        - one.example.com
+        name: gateway-multihost:HTTP:9080:one.example.com
+        routes:
+        - match:
+            prefix: /
+          route:
+            weightedClusters:
+              clusters:
+              - name: echo-service-b5c2b60cba392c4e
                 weight: 1
               totalWeight: 1
 Runtimes:

--- a/pkg/plugins/runtime/gateway/testdata/https/01-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/01-gateway-route.yaml
@@ -1,12 +1,12 @@
 Clusters:
   Resources:
-    echo-service:
+    echo-service-07fd732a85aa6a99:
       connectTimeout: 10s
       edsClusterConfig:
         edsConfig:
           ads: {}
           resourceApiVersion: V3
-      name: echo-service
+      name: echo-service-07fd732a85aa6a99
       type: EDS
       typedExtensionProtocolOptions:
         envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
@@ -17,8 +17,8 @@ Clusters:
             httpProtocolOptions: {}
 Endpoints:
   Resources:
-    echo-service:
-      clusterName: echo-service
+    echo-service-07fd732a85aa6a99:
+      clusterName: echo-service-07fd732a85aa6a99
       endpoints:
       - lbEndpoints:
         - endpoint:
@@ -101,7 +101,7 @@ Routes:
           route:
             weightedClusters:
               clusters:
-              - name: echo-service
+              - name: echo-service-07fd732a85aa6a99
                 weight: 1
               totalWeight: 1
       - domains:
@@ -113,7 +113,7 @@ Routes:
           route:
             weightedClusters:
               clusters:
-              - name: echo-service
+              - name: echo-service-07fd732a85aa6a99
                 weight: 1
               totalWeight: 1
       - domains:
@@ -125,7 +125,7 @@ Routes:
           route:
             weightedClusters:
               clusters:
-              - name: echo-service
+              - name: echo-service-07fd732a85aa6a99
                 weight: 1
               totalWeight: 1
       - domains:

--- a/pkg/plugins/runtime/gateway/testdata/https/02-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/02-gateway-route.yaml
@@ -1,6 +1,6 @@
 Clusters:
   Resources:
-    echo-service:
+    echo-service-5a416c39037aa8f6:
       circuitBreakers:
         thresholds:
         - maxConnections: 1024
@@ -12,7 +12,7 @@ Clusters:
         edsConfig:
           ads: {}
           resourceApiVersion: V3
-      name: echo-service
+      name: echo-service-5a416c39037aa8f6
       outlierDetection:
         enforcingConsecutive5xx: 0
         enforcingConsecutiveGatewayFailure: 0
@@ -27,10 +27,41 @@ Clusters:
             idleTimeout: 3600s
           explicitHttpConfig:
             httpProtocolOptions: {}
+    echo-service-07fd732a85aa6a99:
+      connectTimeout: 10s
+      edsClusterConfig:
+        edsConfig:
+          ads: {}
+          resourceApiVersion: V3
+      name: echo-service-07fd732a85aa6a99
+      type: EDS
+      typedExtensionProtocolOptions:
+        envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+          '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+          commonHttpProtocolOptions:
+            idleTimeout: 0s
+          explicitHttpConfig:
+            httpProtocolOptions: {}
 Endpoints:
   Resources:
-    echo-service:
-      clusterName: echo-service
+    echo-service-5a416c39037aa8f6:
+      clusterName: echo-service-5a416c39037aa8f6
+      endpoints:
+      - lbEndpoints:
+        - endpoint:
+            address:
+              socketAddress:
+                address: 192.168.1.6
+                portValue: 20006
+          loadBalancingWeight: 1
+          metadata:
+            filterMetadata:
+              envoy.lb:
+                kuma.io/protocol: http
+              envoy.transport_socket_match:
+                kuma.io/protocol: http
+    echo-service-07fd732a85aa6a99:
+      clusterName: echo-service-07fd732a85aa6a99
       endpoints:
       - lbEndpoints:
         - endpoint:
@@ -113,7 +144,7 @@ Routes:
           route:
             weightedClusters:
               clusters:
-              - name: echo-service
+              - name: echo-service-07fd732a85aa6a99
                 weight: 1
               totalWeight: 1
       - domains:
@@ -125,7 +156,7 @@ Routes:
           route:
             weightedClusters:
               clusters:
-              - name: echo-service
+              - name: echo-service-5a416c39037aa8f6
                 weight: 1
               totalWeight: 1
 Runtimes:

--- a/pkg/plugins/runtime/gateway/testdata/https/03-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/03-gateway-route.yaml
@@ -1,6 +1,6 @@
 Clusters:
   Resources:
-    echo-service:
+    echo-service-5a416c39037aa8f6:
       circuitBreakers:
         thresholds:
         - maxConnections: 1024
@@ -12,7 +12,7 @@ Clusters:
         edsConfig:
           ads: {}
           resourceApiVersion: V3
-      name: echo-service
+      name: echo-service-5a416c39037aa8f6
       outlierDetection:
         enforcingConsecutive5xx: 0
         enforcingConsecutiveGatewayFailure: 0
@@ -29,8 +29,8 @@ Clusters:
             httpProtocolOptions: {}
 Endpoints:
   Resources:
-    echo-service:
-      clusterName: echo-service
+    echo-service-5a416c39037aa8f6:
+      clusterName: echo-service-5a416c39037aa8f6
       endpoints:
       - lbEndpoints:
         - endpoint:
@@ -142,7 +142,7 @@ Routes:
           route:
             weightedClusters:
               clusters:
-              - name: echo-service
+              - name: echo-service-5a416c39037aa8f6
                 weight: 1
               totalWeight: 1
 Runtimes:

--- a/pkg/plugins/runtime/gateway/testdata/https/04-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/04-gateway-route.yaml
@@ -1,6 +1,6 @@
 Clusters:
   Resources:
-    echo-mirror-303ee71109a987aa:
+    echo-mirror-eb192462fe75ad40:
       circuitBreakers:
         thresholds:
         - maxConnections: 1024
@@ -12,7 +12,7 @@ Clusters:
         edsConfig:
           ads: {}
           resourceApiVersion: V3
-      name: echo-mirror-303ee71109a987aa
+      name: echo-mirror-eb192462fe75ad40
       outlierDetection:
         enforcingConsecutive5xx: 0
         enforcingConsecutiveGatewayFailure: 0
@@ -27,7 +27,7 @@ Clusters:
             idleTimeout: 3600s
           explicitHttpConfig:
             httpProtocolOptions: {}
-    echo-service:
+    echo-service-5a416c39037aa8f6:
       circuitBreakers:
         thresholds:
         - maxConnections: 1024
@@ -39,7 +39,7 @@ Clusters:
         edsConfig:
           ads: {}
           resourceApiVersion: V3
-      name: echo-service
+      name: echo-service-5a416c39037aa8f6
       outlierDetection:
         enforcingConsecutive5xx: 0
         enforcingConsecutiveGatewayFailure: 0
@@ -56,10 +56,10 @@ Clusters:
             httpProtocolOptions: {}
 Endpoints:
   Resources:
-    echo-mirror-303ee71109a987aa:
-      clusterName: echo-mirror-303ee71109a987aa
-    echo-service:
-      clusterName: echo-service
+    echo-mirror-eb192462fe75ad40:
+      clusterName: echo-mirror-eb192462fe75ad40
+    echo-service-5a416c39037aa8f6:
+      clusterName: echo-service-5a416c39037aa8f6
       endpoints:
       - lbEndpoints:
         - endpoint:
@@ -170,14 +170,14 @@ Routes:
             path: /
           route:
             requestMirrorPolicies:
-            - cluster: echo-mirror-303ee71109a987aa
+            - cluster: echo-mirror-eb192462fe75ad40
               runtimeFraction:
                 defaultValue:
                   denominator: TEN_THOUSAND
                   numerator: 10
             weightedClusters:
               clusters:
-              - name: echo-service
+              - name: echo-service-5a416c39037aa8f6
                 weight: 1
               totalWeight: 1
 Runtimes:

--- a/pkg/plugins/runtime/gateway/testdata/https/06-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/06-gateway-route.yaml
@@ -1,6 +1,6 @@
 Clusters:
   Resources:
-    echo-mirror-303ee71109a987aa:
+    echo-mirror-eb192462fe75ad40:
       circuitBreakers:
         thresholds:
         - maxConnections: 1024
@@ -12,7 +12,7 @@ Clusters:
         edsConfig:
           ads: {}
           resourceApiVersion: V3
-      name: echo-mirror-303ee71109a987aa
+      name: echo-mirror-eb192462fe75ad40
       outlierDetection:
         enforcingConsecutive5xx: 0
         enforcingConsecutiveGatewayFailure: 0
@@ -27,7 +27,7 @@ Clusters:
             idleTimeout: 3600s
           explicitHttpConfig:
             httpProtocolOptions: {}
-    echo-service:
+    echo-service-5a416c39037aa8f6:
       circuitBreakers:
         thresholds:
         - maxConnections: 1024
@@ -39,7 +39,7 @@ Clusters:
         edsConfig:
           ads: {}
           resourceApiVersion: V3
-      name: echo-service
+      name: echo-service-5a416c39037aa8f6
       outlierDetection:
         enforcingConsecutive5xx: 0
         enforcingConsecutiveGatewayFailure: 0
@@ -56,10 +56,10 @@ Clusters:
             httpProtocolOptions: {}
 Endpoints:
   Resources:
-    echo-mirror-303ee71109a987aa:
-      clusterName: echo-mirror-303ee71109a987aa
-    echo-service:
-      clusterName: echo-service
+    echo-mirror-eb192462fe75ad40:
+      clusterName: echo-mirror-eb192462fe75ad40
+    echo-service-5a416c39037aa8f6:
+      clusterName: echo-service-5a416c39037aa8f6
       endpoints:
       - lbEndpoints:
         - endpoint:
@@ -189,14 +189,14 @@ Routes:
           - delete-another
           route:
             requestMirrorPolicies:
-            - cluster: echo-mirror-303ee71109a987aa
+            - cluster: echo-mirror-eb192462fe75ad40
               runtimeFraction:
                 defaultValue:
                   denominator: TEN_THOUSAND
                   numerator: 10
             weightedClusters:
               clusters:
-              - name: echo-service
+              - name: echo-service-5a416c39037aa8f6
                 weight: 1
               totalWeight: 1
 Runtimes:

--- a/pkg/plugins/runtime/gateway/testdata/https/07-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/07-gateway-route.yaml
@@ -1,6 +1,6 @@
 Clusters:
   Resources:
-    echo-service:
+    echo-service-5a416c39037aa8f6:
       circuitBreakers:
         thresholds:
         - maxConnections: 1024
@@ -12,7 +12,7 @@ Clusters:
         edsConfig:
           ads: {}
           resourceApiVersion: V3
-      name: echo-service
+      name: echo-service-5a416c39037aa8f6
       outlierDetection:
         enforcingConsecutive5xx: 0
         enforcingConsecutiveGatewayFailure: 0
@@ -29,8 +29,8 @@ Clusters:
             httpProtocolOptions: {}
 Endpoints:
   Resources:
-    echo-service:
-      clusterName: echo-service
+    echo-service-5a416c39037aa8f6:
+      clusterName: echo-service-5a416c39037aa8f6
       endpoints:
       - lbEndpoints:
         - endpoint:
@@ -142,7 +142,7 @@ Routes:
           route:
             weightedClusters:
               clusters:
-              - name: echo-service
+              - name: echo-service-5a416c39037aa8f6
                 weight: 1
               totalWeight: 1
         - match:
@@ -150,7 +150,7 @@ Routes:
           route:
             weightedClusters:
               clusters:
-              - name: echo-service
+              - name: echo-service-5a416c39037aa8f6
                 weight: 1
               totalWeight: 1
 Runtimes:

--- a/pkg/plugins/runtime/gateway/testdata/https/08-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/08-gateway-route.yaml
@@ -1,6 +1,6 @@
 Clusters:
   Resources:
-    exact-service:
+    exact-service-09493d2d54b2a972:
       circuitBreakers:
         thresholds:
         - maxConnections: 1024
@@ -12,7 +12,7 @@ Clusters:
         edsConfig:
           ads: {}
           resourceApiVersion: V3
-      name: exact-service
+      name: exact-service-09493d2d54b2a972
       outlierDetection:
         enforcingConsecutive5xx: 0
         enforcingConsecutiveGatewayFailure: 0
@@ -27,7 +27,7 @@ Clusters:
             idleTimeout: 3600s
           explicitHttpConfig:
             httpProtocolOptions: {}
-    prefix-service:
+    prefix-service-5061ee504b81a555:
       circuitBreakers:
         thresholds:
         - maxConnections: 1024
@@ -39,7 +39,7 @@ Clusters:
         edsConfig:
           ads: {}
           resourceApiVersion: V3
-      name: prefix-service
+      name: prefix-service-5061ee504b81a555
       outlierDetection:
         enforcingConsecutive5xx: 0
         enforcingConsecutiveGatewayFailure: 0
@@ -56,8 +56,8 @@ Clusters:
             httpProtocolOptions: {}
 Endpoints:
   Resources:
-    exact-service:
-      clusterName: exact-service
+    exact-service-09493d2d54b2a972:
+      clusterName: exact-service-09493d2d54b2a972
       endpoints:
       - lbEndpoints:
         - endpoint:
@@ -72,8 +72,8 @@ Endpoints:
                 kuma.io/protocol: http
               envoy.transport_socket_match:
                 kuma.io/protocol: http
-    prefix-service:
-      clusterName: prefix-service
+    prefix-service-5061ee504b81a555:
+      clusterName: prefix-service-5061ee504b81a555
       endpoints:
       - lbEndpoints:
         - endpoint:
@@ -185,7 +185,7 @@ Routes:
           route:
             weightedClusters:
               clusters:
-              - name: exact-service
+              - name: exact-service-09493d2d54b2a972
                 weight: 1
               totalWeight: 1
         - match:
@@ -193,7 +193,7 @@ Routes:
           route:
             weightedClusters:
               clusters:
-              - name: prefix-service
+              - name: prefix-service-5061ee504b81a555
                 weight: 1
               totalWeight: 1
 Runtimes:

--- a/pkg/plugins/runtime/gateway/testdata/https/09-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/09-gateway-route.yaml
@@ -1,6 +1,6 @@
 Clusters:
   Resources:
-    echo-service:
+    echo-service-5a416c39037aa8f6:
       circuitBreakers:
         thresholds:
         - maxConnections: 1024
@@ -12,7 +12,7 @@ Clusters:
         edsConfig:
           ads: {}
           resourceApiVersion: V3
-      name: echo-service
+      name: echo-service-5a416c39037aa8f6
       outlierDetection:
         enforcingConsecutive5xx: 0
         enforcingConsecutiveGatewayFailure: 0
@@ -29,8 +29,8 @@ Clusters:
             httpProtocolOptions: {}
 Endpoints:
   Resources:
-    echo-service:
-      clusterName: echo-service
+    echo-service-5a416c39037aa8f6:
+      clusterName: echo-service-5a416c39037aa8f6
       endpoints:
       - lbEndpoints:
         - endpoint:
@@ -144,7 +144,7 @@ Routes:
           route:
             weightedClusters:
               clusters:
-              - name: echo-service
+              - name: echo-service-5a416c39037aa8f6
                 weight: 1
               totalWeight: 1
 Runtimes:

--- a/pkg/plugins/runtime/gateway/testdata/https/10-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/10-gateway-route.yaml
@@ -1,6 +1,6 @@
 Clusters:
   Resources:
-    exact-header-match:
+    exact-header-match-f6b57a6b55557c81:
       circuitBreakers:
         thresholds:
         - maxConnections: 1024
@@ -12,7 +12,7 @@ Clusters:
         edsConfig:
           ads: {}
           resourceApiVersion: V3
-      name: exact-header-match
+      name: exact-header-match-f6b57a6b55557c81
       outlierDetection:
         enforcingConsecutive5xx: 0
         enforcingConsecutiveGatewayFailure: 0
@@ -27,7 +27,7 @@ Clusters:
             idleTimeout: 3600s
           explicitHttpConfig:
             httpProtocolOptions: {}
-    regex-header-match:
+    regex-header-match-ad0dd92f37b8a38d:
       circuitBreakers:
         thresholds:
         - maxConnections: 1024
@@ -39,7 +39,7 @@ Clusters:
         edsConfig:
           ads: {}
           resourceApiVersion: V3
-      name: regex-header-match
+      name: regex-header-match-ad0dd92f37b8a38d
       outlierDetection:
         enforcingConsecutive5xx: 0
         enforcingConsecutiveGatewayFailure: 0
@@ -56,8 +56,8 @@ Clusters:
             httpProtocolOptions: {}
 Endpoints:
   Resources:
-    exact-header-match:
-      clusterName: exact-header-match
+    exact-header-match-f6b57a6b55557c81:
+      clusterName: exact-header-match-f6b57a6b55557c81
       endpoints:
       - lbEndpoints:
         - endpoint:
@@ -72,8 +72,8 @@ Endpoints:
                 kuma.io/protocol: http
               envoy.transport_socket_match:
                 kuma.io/protocol: http
-    regex-header-match:
-      clusterName: regex-header-match
+    regex-header-match-ad0dd92f37b8a38d:
+      clusterName: regex-header-match-ad0dd92f37b8a38d
       endpoints:
       - lbEndpoints:
         - endpoint:
@@ -193,7 +193,7 @@ Routes:
           route:
             weightedClusters:
               clusters:
-              - name: regex-header-match
+              - name: regex-header-match-ad0dd92f37b8a38d
                 weight: 1
               totalWeight: 1
         - match:
@@ -203,7 +203,7 @@ Routes:
           route:
             weightedClusters:
               clusters:
-              - name: exact-header-match
+              - name: exact-header-match-f6b57a6b55557c81
                 weight: 1
               totalWeight: 1
         - match:
@@ -213,7 +213,7 @@ Routes:
           route:
             weightedClusters:
               clusters:
-              - name: exact-header-match
+              - name: exact-header-match-f6b57a6b55557c81
                 weight: 1
               totalWeight: 1
 Runtimes:

--- a/pkg/plugins/runtime/gateway/testdata/https/11-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/11-gateway-route.yaml
@@ -1,6 +1,6 @@
 Clusters:
   Resources:
-    exact-query-match:
+    exact-query-match-cc1370f58a3b5330:
       circuitBreakers:
         thresholds:
         - maxConnections: 1024
@@ -12,7 +12,7 @@ Clusters:
         edsConfig:
           ads: {}
           resourceApiVersion: V3
-      name: exact-query-match
+      name: exact-query-match-cc1370f58a3b5330
       outlierDetection:
         enforcingConsecutive5xx: 0
         enforcingConsecutiveGatewayFailure: 0
@@ -27,7 +27,7 @@ Clusters:
             idleTimeout: 3600s
           explicitHttpConfig:
             httpProtocolOptions: {}
-    regex-query-match:
+    regex-query-match-3804d7b8516d7323:
       circuitBreakers:
         thresholds:
         - maxConnections: 1024
@@ -39,7 +39,7 @@ Clusters:
         edsConfig:
           ads: {}
           resourceApiVersion: V3
-      name: regex-query-match
+      name: regex-query-match-3804d7b8516d7323
       outlierDetection:
         enforcingConsecutive5xx: 0
         enforcingConsecutiveGatewayFailure: 0
@@ -56,8 +56,8 @@ Clusters:
             httpProtocolOptions: {}
 Endpoints:
   Resources:
-    exact-query-match:
-      clusterName: exact-query-match
+    exact-query-match-cc1370f58a3b5330:
+      clusterName: exact-query-match-cc1370f58a3b5330
       endpoints:
       - lbEndpoints:
         - endpoint:
@@ -72,8 +72,8 @@ Endpoints:
                 kuma.io/protocol: http
               envoy.transport_socket_match:
                 kuma.io/protocol: http
-    regex-query-match:
-      clusterName: regex-query-match
+    regex-query-match-3804d7b8516d7323:
+      clusterName: regex-query-match-3804d7b8516d7323
       endpoints:
       - lbEndpoints:
         - endpoint:
@@ -195,7 +195,7 @@ Routes:
           route:
             weightedClusters:
               clusters:
-              - name: regex-query-match
+              - name: regex-query-match-3804d7b8516d7323
                 weight: 1
               totalWeight: 1
         - match:
@@ -206,7 +206,7 @@ Routes:
           route:
             weightedClusters:
               clusters:
-              - name: exact-query-match
+              - name: exact-query-match-cc1370f58a3b5330
                 weight: 1
               totalWeight: 1
         - match:
@@ -217,7 +217,7 @@ Routes:
           route:
             weightedClusters:
               clusters:
-              - name: exact-query-match
+              - name: exact-query-match-cc1370f58a3b5330
                 weight: 1
               totalWeight: 1
 Runtimes:

--- a/pkg/plugins/runtime/gateway/testdata/https/12-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/12-gateway-route.yaml
@@ -1,6 +1,6 @@
 Clusters:
   Resources:
-    echo-service:
+    echo-service-5a416c39037aa8f6:
       circuitBreakers:
         thresholds:
         - maxConnections: 1024
@@ -12,7 +12,7 @@ Clusters:
         edsConfig:
           ads: {}
           resourceApiVersion: V3
-      name: echo-service
+      name: echo-service-5a416c39037aa8f6
       outlierDetection:
         enforcingConsecutive5xx: 0
         enforcingConsecutiveGatewayFailure: 0
@@ -29,8 +29,8 @@ Clusters:
             httpProtocolOptions: {}
 Endpoints:
   Resources:
-    echo-service:
-      clusterName: echo-service
+    echo-service-5a416c39037aa8f6:
+      clusterName: echo-service-5a416c39037aa8f6
       endpoints:
       - lbEndpoints:
         - endpoint:
@@ -147,7 +147,7 @@ Routes:
           route:
             weightedClusters:
               clusters:
-              - name: echo-service
+              - name: echo-service-5a416c39037aa8f6
                 weight: 1
               totalWeight: 1
         - match:
@@ -160,7 +160,7 @@ Routes:
           route:
             weightedClusters:
               clusters:
-              - name: echo-service
+              - name: echo-service-5a416c39037aa8f6
                 weight: 1
               totalWeight: 1
         - match:
@@ -173,7 +173,7 @@ Routes:
           route:
             weightedClusters:
               clusters:
-              - name: echo-service
+              - name: echo-service-5a416c39037aa8f6
                 weight: 1
               totalWeight: 1
 Runtimes:

--- a/pkg/plugins/runtime/gateway/testdata/https/14-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/14-gateway-route.yaml
@@ -1,6 +1,6 @@
 Clusters:
   Resources:
-    echo-service:
+    echo-service-5a416c39037aa8f6:
       circuitBreakers:
         thresholds:
         - maxConnections: 1024
@@ -12,7 +12,7 @@ Clusters:
         edsConfig:
           ads: {}
           resourceApiVersion: V3
-      name: echo-service
+      name: echo-service-5a416c39037aa8f6
       outlierDetection:
         enforcingConsecutive5xx: 0
         enforcingConsecutiveGatewayFailure: 0
@@ -29,8 +29,8 @@ Clusters:
             httpProtocolOptions: {}
 Endpoints:
   Resources:
-    echo-service:
-      clusterName: echo-service
+    echo-service-5a416c39037aa8f6:
+      clusterName: echo-service-5a416c39037aa8f6
       endpoints:
       - lbEndpoints:
         - endpoint:
@@ -146,7 +146,7 @@ Routes:
             hostRewriteLiteral: newhost.example.com
             weightedClusters:
               clusters:
-              - name: echo-service
+              - name: echo-service-5a416c39037aa8f6
                 weight: 1
               totalWeight: 1
 Runtimes:

--- a/pkg/plugins/runtime/gateway/testdata/https/15-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/15-gateway-route.yaml
@@ -1,6 +1,6 @@
 Clusters:
   Resources:
-    api-service:
+    api-service-6b688a06cd66f5c9:
       circuitBreakers:
         thresholds:
         - maxConnections: 1024
@@ -12,7 +12,7 @@ Clusters:
         edsConfig:
           ads: {}
           resourceApiVersion: V3
-      name: api-service
+      name: api-service-6b688a06cd66f5c9
       outlierDetection:
         enforcingConsecutive5xx: 0
         enforcingConsecutiveGatewayFailure: 0
@@ -27,7 +27,7 @@ Clusters:
             idleTimeout: 20s
           explicitHttpConfig:
             httpProtocolOptions: {}
-    echo-mirror:
+    echo-mirror-5c286df2bcbe50d6:
       circuitBreakers:
         thresholds:
         - maxConnections: 1024
@@ -39,7 +39,7 @@ Clusters:
         edsConfig:
           ads: {}
           resourceApiVersion: V3
-      name: echo-mirror
+      name: echo-mirror-5c286df2bcbe50d6
       outlierDetection:
         enforcingConsecutive5xx: 0
         enforcingConsecutiveGatewayFailure: 0
@@ -54,7 +54,7 @@ Clusters:
             idleTimeout: 30s
           explicitHttpConfig:
             httpProtocolOptions: {}
-    echo-service:
+    echo-service-b5c2b60cba392c4e:
       circuitBreakers:
         thresholds:
         - maxConnections: 1024
@@ -66,7 +66,7 @@ Clusters:
         edsConfig:
           ads: {}
           resourceApiVersion: V3
-      name: echo-service
+      name: echo-service-b5c2b60cba392c4e
       outlierDetection:
         enforcingConsecutive5xx: 0
         enforcingConsecutiveGatewayFailure: 0
@@ -83,8 +83,8 @@ Clusters:
             httpProtocolOptions: {}
 Endpoints:
   Resources:
-    api-service:
-      clusterName: api-service
+    api-service-6b688a06cd66f5c9:
+      clusterName: api-service-6b688a06cd66f5c9
       endpoints:
       - lbEndpoints:
         - endpoint:
@@ -99,8 +99,8 @@ Endpoints:
                 kuma.io/protocol: http
               envoy.transport_socket_match:
                 kuma.io/protocol: http
-    echo-mirror:
-      clusterName: echo-mirror
+    echo-mirror-5c286df2bcbe50d6:
+      clusterName: echo-mirror-5c286df2bcbe50d6
       endpoints:
       - lbEndpoints:
         - endpoint:
@@ -115,8 +115,8 @@ Endpoints:
                 kuma.io/protocol: http
               envoy.transport_socket_match:
                 kuma.io/protocol: http
-    echo-service:
-      clusterName: echo-service
+    echo-service-b5c2b60cba392c4e:
+      clusterName: echo-service-b5c2b60cba392c4e
       endpoints:
       - lbEndpoints:
         - endpoint:
@@ -228,7 +228,7 @@ Routes:
           route:
             weightedClusters:
               clusters:
-              - name: api-service
+              - name: api-service-6b688a06cd66f5c9
                 weight: 1
               totalWeight: 1
         - match:
@@ -236,20 +236,20 @@ Routes:
           route:
             weightedClusters:
               clusters:
-              - name: api-service
+              - name: api-service-6b688a06cd66f5c9
                 weight: 1
               totalWeight: 1
         - match:
             prefix: /
           route:
             requestMirrorPolicies:
-            - cluster: echo-mirror
+            - cluster: echo-mirror-5c286df2bcbe50d6
               runtimeFraction:
                 defaultValue:
                   numerator: 1
             weightedClusters:
               clusters:
-              - name: echo-service
+              - name: echo-service-b5c2b60cba392c4e
                 weight: 1
               totalWeight: 1
 Runtimes:

--- a/pkg/plugins/runtime/gateway/testdata/https/16-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/16-gateway-route.yaml
@@ -1,6 +1,6 @@
 Clusters:
   Resources:
-    api-service:
+    api-service-49c6d22609eca2d2:
       circuitBreakers:
         thresholds:
         - maxRetries: 20
@@ -9,7 +9,7 @@ Clusters:
         edsConfig:
           ads: {}
           resourceApiVersion: V3
-      name: api-service
+      name: api-service-49c6d22609eca2d2
       outlierDetection:
         baseEjectionTime: 20s
         consecutiveLocalOriginFailure: 20
@@ -26,7 +26,7 @@ Clusters:
             idleTimeout: 3600s
           explicitHttpConfig:
             httpProtocolOptions: {}
-    echo-mirror:
+    echo-mirror-f534124491f4385f:
       circuitBreakers:
         thresholds:
         - maxRetries: 20
@@ -35,7 +35,7 @@ Clusters:
         edsConfig:
           ads: {}
           resourceApiVersion: V3
-      name: echo-mirror
+      name: echo-mirror-f534124491f4385f
       outlierDetection:
         baseEjectionTime: 30s
         consecutiveLocalOriginFailure: 30
@@ -52,7 +52,7 @@ Clusters:
             idleTimeout: 3600s
           explicitHttpConfig:
             httpProtocolOptions: {}
-    echo-service:
+    echo-service-48cd7f2dbb98df84:
       circuitBreakers:
         thresholds:
         - maxRetries: 10
@@ -61,7 +61,7 @@ Clusters:
         edsConfig:
           ads: {}
           resourceApiVersion: V3
-      name: echo-service
+      name: echo-service-48cd7f2dbb98df84
       outlierDetection:
         baseEjectionTime: 10s
         consecutiveLocalOriginFailure: 10
@@ -80,8 +80,8 @@ Clusters:
             httpProtocolOptions: {}
 Endpoints:
   Resources:
-    api-service:
-      clusterName: api-service
+    api-service-49c6d22609eca2d2:
+      clusterName: api-service-49c6d22609eca2d2
       endpoints:
       - lbEndpoints:
         - endpoint:
@@ -96,8 +96,8 @@ Endpoints:
                 kuma.io/protocol: http
               envoy.transport_socket_match:
                 kuma.io/protocol: http
-    echo-mirror:
-      clusterName: echo-mirror
+    echo-mirror-f534124491f4385f:
+      clusterName: echo-mirror-f534124491f4385f
       endpoints:
       - lbEndpoints:
         - endpoint:
@@ -112,8 +112,8 @@ Endpoints:
                 kuma.io/protocol: http
               envoy.transport_socket_match:
                 kuma.io/protocol: http
-    echo-service:
-      clusterName: echo-service
+    echo-service-48cd7f2dbb98df84:
+      clusterName: echo-service-48cd7f2dbb98df84
       endpoints:
       - lbEndpoints:
         - endpoint:
@@ -225,7 +225,7 @@ Routes:
           route:
             weightedClusters:
               clusters:
-              - name: api-service
+              - name: api-service-49c6d22609eca2d2
                 weight: 1
               totalWeight: 1
         - match:
@@ -233,20 +233,20 @@ Routes:
           route:
             weightedClusters:
               clusters:
-              - name: api-service
+              - name: api-service-49c6d22609eca2d2
                 weight: 1
               totalWeight: 1
         - match:
             prefix: /
           route:
             requestMirrorPolicies:
-            - cluster: echo-mirror
+            - cluster: echo-mirror-f534124491f4385f
               runtimeFraction:
                 defaultValue:
                   numerator: 1
             weightedClusters:
               clusters:
-              - name: echo-service
+              - name: echo-service-48cd7f2dbb98df84
                 weight: 1
               totalWeight: 1
 Runtimes:

--- a/pkg/plugins/runtime/gateway/testdata/https/17-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/17-gateway-route.yaml
@@ -1,6 +1,6 @@
 Clusters:
   Resources:
-    api-service:
+    api-service-19fcb7995aa98119:
       circuitBreakers:
         thresholds:
         - maxConnections: 1024
@@ -18,7 +18,7 @@ Clusters:
         tcpHealthCheck: {}
         timeout: 20s
         unhealthyThreshold: 2
-      name: api-service
+      name: api-service-19fcb7995aa98119
       outlierDetection:
         enforcingConsecutive5xx: 0
         enforcingConsecutiveGatewayFailure: 0
@@ -33,7 +33,7 @@ Clusters:
             idleTimeout: 3600s
           explicitHttpConfig:
             httpProtocolOptions: {}
-    echo-mirror:
+    echo-mirror-2e2ba113e4d991ba:
       circuitBreakers:
         thresholds:
         - maxConnections: 1024
@@ -51,7 +51,7 @@ Clusters:
         tcpHealthCheck: {}
         timeout: 30s
         unhealthyThreshold: 3
-      name: echo-mirror
+      name: echo-mirror-2e2ba113e4d991ba
       outlierDetection:
         enforcingConsecutive5xx: 0
         enforcingConsecutiveGatewayFailure: 0
@@ -66,7 +66,7 @@ Clusters:
             idleTimeout: 3600s
           explicitHttpConfig:
             httpProtocolOptions: {}
-    echo-service:
+    echo-service-eb4ea372d99abf73:
       circuitBreakers:
         thresholds:
         - maxConnections: 1024
@@ -84,7 +84,7 @@ Clusters:
         tcpHealthCheck: {}
         timeout: 10s
         unhealthyThreshold: 1
-      name: echo-service
+      name: echo-service-eb4ea372d99abf73
       outlierDetection:
         enforcingConsecutive5xx: 0
         enforcingConsecutiveGatewayFailure: 0
@@ -101,8 +101,8 @@ Clusters:
             httpProtocolOptions: {}
 Endpoints:
   Resources:
-    api-service:
-      clusterName: api-service
+    api-service-19fcb7995aa98119:
+      clusterName: api-service-19fcb7995aa98119
       endpoints:
       - lbEndpoints:
         - endpoint:
@@ -117,8 +117,8 @@ Endpoints:
                 kuma.io/protocol: http
               envoy.transport_socket_match:
                 kuma.io/protocol: http
-    echo-mirror:
-      clusterName: echo-mirror
+    echo-mirror-2e2ba113e4d991ba:
+      clusterName: echo-mirror-2e2ba113e4d991ba
       endpoints:
       - lbEndpoints:
         - endpoint:
@@ -133,8 +133,8 @@ Endpoints:
                 kuma.io/protocol: http
               envoy.transport_socket_match:
                 kuma.io/protocol: http
-    echo-service:
-      clusterName: echo-service
+    echo-service-eb4ea372d99abf73:
+      clusterName: echo-service-eb4ea372d99abf73
       endpoints:
       - lbEndpoints:
         - endpoint:
@@ -246,7 +246,7 @@ Routes:
           route:
             weightedClusters:
               clusters:
-              - name: api-service
+              - name: api-service-19fcb7995aa98119
                 weight: 1
               totalWeight: 1
         - match:
@@ -254,20 +254,20 @@ Routes:
           route:
             weightedClusters:
               clusters:
-              - name: api-service
+              - name: api-service-19fcb7995aa98119
                 weight: 1
               totalWeight: 1
         - match:
             prefix: /
           route:
             requestMirrorPolicies:
-            - cluster: echo-mirror
+            - cluster: echo-mirror-2e2ba113e4d991ba
               runtimeFraction:
                 defaultValue:
                   numerator: 1
             weightedClusters:
               clusters:
-              - name: echo-service
+              - name: echo-service-eb4ea372d99abf73
                 weight: 1
               totalWeight: 1
 Runtimes:

--- a/pkg/plugins/runtime/gateway/testdata/https/18-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/18-gateway-route.yaml
@@ -1,6 +1,6 @@
 Clusters:
   Resources:
-    external-httpbin:
+    external-httpbin-4a2cc28cd5e983f1:
       circuitBreakers:
         thresholds:
         - maxConnections: 1024
@@ -25,7 +25,7 @@ Clusters:
                   kuma.io/protocol: http
                 envoy.transport_socket_match:
                   kuma.io/protocol: http
-      name: external-httpbin
+      name: external-httpbin-4a2cc28cd5e983f1
       outlierDetection:
         enforcingConsecutive5xx: 0
         enforcingConsecutiveGatewayFailure: 0
@@ -139,7 +139,7 @@ Routes:
           route:
             weightedClusters:
               clusters:
-              - name: external-httpbin
+              - name: external-httpbin-4a2cc28cd5e983f1
                 weight: 1
               totalWeight: 1
 Runtimes:

--- a/pkg/plugins/runtime/gateway/testdata/https/19-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/19-gateway-route.yaml
@@ -1,6 +1,6 @@
 Clusters:
   Resources:
-    external-httpbin:
+    external-httpbin-241b25f6d3fc3b49:
       circuitBreakers:
         thresholds:
         - maxConnections: 1024
@@ -27,7 +27,7 @@ Clusters:
                 envoy.transport_socket_match:
                   kuma.io/external-service-name: external-httpbin
                   kuma.io/protocol: http2
-      name: external-httpbin
+      name: external-httpbin-241b25f6d3fc3b49
       outlierDetection:
         enforcingConsecutive5xx: 0
         enforcingConsecutiveGatewayFailure: 0
@@ -152,7 +152,7 @@ Routes:
           route:
             weightedClusters:
               clusters:
-              - name: external-httpbin
+              - name: external-httpbin-241b25f6d3fc3b49
                 weight: 1
               totalWeight: 1
 Runtimes:

--- a/pkg/plugins/runtime/gateway/testdata/https/20-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/20-gateway-route.yaml
@@ -1,18 +1,18 @@
 Clusters:
   Resources:
-    echo-exact-ad4e3a31db1bf217:
+    echo-service-b5c2b60cba392c4e:
       circuitBreakers:
         thresholds:
         - maxConnections: 1024
           maxPendingRequests: 1024
           maxRequests: 1024
           maxRetries: 3
-      connectTimeout: 5s
+      connectTimeout: 10s
       edsClusterConfig:
         edsConfig:
           ads: {}
           resourceApiVersion: V3
-      name: echo-exact-ad4e3a31db1bf217
+      name: echo-service-b5c2b60cba392c4e
       outlierDetection:
         enforcingConsecutive5xx: 0
         enforcingConsecutiveGatewayFailure: 0
@@ -24,22 +24,22 @@ Clusters:
         envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
           '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
           commonHttpProtocolOptions:
-            idleTimeout: 3600s
+            idleTimeout: 10s
           explicitHttpConfig:
             httpProtocolOptions: {}
-    echo-prefix-d0e5ba63b0c9b9f0:
+    echo-service-cff7b41a9764f367:
       circuitBreakers:
         thresholds:
         - maxConnections: 1024
           maxPendingRequests: 1024
           maxRequests: 1024
           maxRetries: 3
-      connectTimeout: 5s
+      connectTimeout: 300s
       edsClusterConfig:
         edsConfig:
           ads: {}
           resourceApiVersion: V3
-      name: echo-prefix-d0e5ba63b0c9b9f0
+      name: echo-service-cff7b41a9764f367
       outlierDetection:
         enforcingConsecutive5xx: 0
         enforcingConsecutiveGatewayFailure: 0
@@ -51,22 +51,22 @@ Clusters:
         envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
           '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
           commonHttpProtocolOptions:
-            idleTimeout: 3600s
+            idleTimeout: 30s
           explicitHttpConfig:
             httpProtocolOptions: {}
-    echo-regex-627905e7b1c2eb33:
+    echo-service-dbfe9218dfa3ba0c:
       circuitBreakers:
         thresholds:
         - maxConnections: 1024
           maxPendingRequests: 1024
           maxRequests: 1024
           maxRetries: 3
-      connectTimeout: 5s
+      connectTimeout: 20s
       edsClusterConfig:
         edsConfig:
           ads: {}
           resourceApiVersion: V3
-      name: echo-regex-627905e7b1c2eb33
+      name: echo-service-dbfe9218dfa3ba0c
       outlierDetection:
         enforcingConsecutive5xx: 0
         enforcingConsecutiveGatewayFailure: 0
@@ -78,20 +78,20 @@ Clusters:
         envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
           '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
           commonHttpProtocolOptions:
-            idleTimeout: 3600s
+            idleTimeout: 20s
           explicitHttpConfig:
             httpProtocolOptions: {}
 Endpoints:
   Resources:
-    echo-exact-ad4e3a31db1bf217:
-      clusterName: echo-exact-ad4e3a31db1bf217
+    echo-service-b5c2b60cba392c4e:
+      clusterName: echo-service-b5c2b60cba392c4e
       endpoints:
       - lbEndpoints:
         - endpoint:
             address:
               socketAddress:
-                address: 192.168.1.2
-                portValue: 20002
+                address: 192.168.1.6
+                portValue: 20006
           loadBalancingWeight: 1
           metadata:
             filterMetadata:
@@ -99,15 +99,15 @@ Endpoints:
                 kuma.io/protocol: http
               envoy.transport_socket_match:
                 kuma.io/protocol: http
-    echo-prefix-d0e5ba63b0c9b9f0:
-      clusterName: echo-prefix-d0e5ba63b0c9b9f0
+    echo-service-cff7b41a9764f367:
+      clusterName: echo-service-cff7b41a9764f367
       endpoints:
       - lbEndpoints:
         - endpoint:
             address:
               socketAddress:
-                address: 192.168.1.4
-                portValue: 20004
+                address: 192.168.1.6
+                portValue: 20006
           loadBalancingWeight: 1
           metadata:
             filterMetadata:
@@ -115,15 +115,15 @@ Endpoints:
                 kuma.io/protocol: http
               envoy.transport_socket_match:
                 kuma.io/protocol: http
-    echo-regex-627905e7b1c2eb33:
-      clusterName: echo-regex-627905e7b1c2eb33
+    echo-service-dbfe9218dfa3ba0c:
+      clusterName: echo-service-dbfe9218dfa3ba0c
       endpoints:
       - lbEndpoints:
         - endpoint:
             address:
               socketAddress:
-                address: 192.168.1.5
-                portValue: 20005
+                address: 192.168.1.6
+                portValue: 20006
           loadBalancingWeight: 1
           metadata:
             filterMetadata:
@@ -133,18 +133,18 @@ Endpoints:
                 kuma.io/protocol: http
 Listeners:
   Resources:
-    edge-gateway:HTTPS:8080:
+    gateway-multihost:HTTPS:9443:
       address:
         socketAddress:
           address: 192.168.1.1
-          portValue: 8080
+          portValue: 9443
       filterChains:
       - filterChainMatch:
           applicationProtocols:
           - h2
           - http/1.1
           serverNames:
-          - echo.example.com
+          - two.example.com
           transportProtocol: tls
         filters:
         - name: envoy.filters.network.http_connection_manager
@@ -175,10 +175,126 @@ Listeners:
               configSource:
                 ads: {}
                 resourceApiVersion: V3
-              routeConfigName: edge-gateway:HTTPS:8080
+              routeConfigName: gateway-multihost:HTTPS:9443
             requestHeadersTimeout: 0.500s
             serverName: Kuma Gateway
-            statPrefix: gateway-default
+            statPrefix: gateway-multihost
+            streamIdleTimeout: 5s
+            stripAnyHostPort: true
+        transportSocket:
+          name: envoy.transport_sockets.tls
+          typedConfig:
+            '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext
+            commonTlsContext:
+              alpnProtocols:
+              - h2
+              - http/1.1
+              tlsCertificateSdsSecretConfigs:
+              - name: cert.rsa:secret:echo-example-com-server-cert
+                sdsConfig:
+                  ads: {}
+                  resourceApiVersion: V3
+              tlsParams:
+                tlsMinimumProtocolVersion: TLSv1_2
+            requireClientCertificate: false
+      - filterChainMatch:
+          applicationProtocols:
+          - h2
+          - http/1.1
+          serverNames:
+          - three.example.com
+          transportProtocol: tls
+        filters:
+        - name: envoy.filters.network.http_connection_manager
+          typedConfig:
+            '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+            commonHttpProtocolOptions:
+              headersWithUnderscoresAction: REJECT_REQUEST
+              idleTimeout: 300s
+            http2ProtocolOptions:
+              allowConnect: true
+              initialConnectionWindowSize: 1048576
+              initialStreamWindowSize: 65536
+              maxConcurrentStreams: 100
+            httpFilters:
+            - name: gzip-compress
+              typedConfig:
+                '@type': type.googleapis.com/envoy.extensions.filters.http.compressor.v3.Compressor
+                compressorLibrary:
+                  name: gzip
+                  typedConfig:
+                    '@type': type.googleapis.com/envoy.extensions.compression.gzip.compressor.v3.Gzip
+                responseDirectionConfig:
+                  disableOnEtagHeader: true
+            - name: envoy.filters.http.router
+            mergeSlashes: true
+            normalizePath: true
+            rds:
+              configSource:
+                ads: {}
+                resourceApiVersion: V3
+              routeConfigName: gateway-multihost:HTTPS:9443
+            requestHeadersTimeout: 0.500s
+            serverName: Kuma Gateway
+            statPrefix: gateway-multihost
+            streamIdleTimeout: 5s
+            stripAnyHostPort: true
+        transportSocket:
+          name: envoy.transport_sockets.tls
+          typedConfig:
+            '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext
+            commonTlsContext:
+              alpnProtocols:
+              - h2
+              - http/1.1
+              tlsCertificateSdsSecretConfigs:
+              - name: cert.rsa:secret:echo-example-com-server-cert
+                sdsConfig:
+                  ads: {}
+                  resourceApiVersion: V3
+              tlsParams:
+                tlsMinimumProtocolVersion: TLSv1_2
+            requireClientCertificate: false
+      - filterChainMatch:
+          applicationProtocols:
+          - h2
+          - http/1.1
+          serverNames:
+          - one.example.com
+          transportProtocol: tls
+        filters:
+        - name: envoy.filters.network.http_connection_manager
+          typedConfig:
+            '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+            commonHttpProtocolOptions:
+              headersWithUnderscoresAction: REJECT_REQUEST
+              idleTimeout: 300s
+            http2ProtocolOptions:
+              allowConnect: true
+              initialConnectionWindowSize: 1048576
+              initialStreamWindowSize: 65536
+              maxConcurrentStreams: 100
+            httpFilters:
+            - name: gzip-compress
+              typedConfig:
+                '@type': type.googleapis.com/envoy.extensions.filters.http.compressor.v3.Compressor
+                compressorLibrary:
+                  name: gzip
+                  typedConfig:
+                    '@type': type.googleapis.com/envoy.extensions.compression.gzip.compressor.v3.Gzip
+                responseDirectionConfig:
+                  disableOnEtagHeader: true
+            - name: envoy.filters.http.router
+            mergeSlashes: true
+            normalizePath: true
+            rds:
+              configSource:
+                ads: {}
+                resourceApiVersion: V3
+              routeConfigName: gateway-multihost:HTTPS:9443
+            requestHeadersTimeout: 0.500s
+            serverName: Kuma Gateway
+            statPrefix: gateway-multihost
             streamIdleTimeout: 5s
             stripAnyHostPort: true
         transportSocket:
@@ -201,21 +317,21 @@ Listeners:
       - name: envoy.filters.listener.tls_inspector
         typedConfig:
           '@type': type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
-      name: edge-gateway:HTTPS:8080
+      name: gateway-multihost:HTTPS:9443
       perConnectionBufferLimitBytes: 32768
       reusePort: true
       trafficDirection: INBOUND
 Routes:
   Resources:
-    edge-gateway:HTTPS:8080:
-      name: edge-gateway:HTTPS:8080
+    gateway-multihost:HTTPS:9443:
+      name: gateway-multihost:HTTPS:9443
       requestHeadersToRemove:
       - x-kuma-tags
       validateClusters: false
       virtualHosts:
       - domains:
-        - echo.example.com
-        name: edge-gateway:HTTPS:8080:echo.example.com
+        - two.example.com
+        name: gateway-multihost:HTTPS:9443:two.example.com
         requireTls: ALL
         responseHeadersToAdd:
         - append: false
@@ -224,37 +340,47 @@ Routes:
             value: max-age=31536000; includeSubDomains
         routes:
         - match:
-            path: /match/bar
+            prefix: /
           route:
             weightedClusters:
               clusters:
-              - name: echo-exact-ad4e3a31db1bf217
+              - name: echo-service-dbfe9218dfa3ba0c
                 weight: 1
               totalWeight: 1
+      - domains:
+        - three.example.com
+        name: gateway-multihost:HTTPS:9443:three.example.com
+        requireTls: ALL
+        responseHeadersToAdd:
+        - append: false
+          header:
+            key: Strict-Transport-Security
+            value: max-age=31536000; includeSubDomains
+        routes:
         - match:
-            path: /match/baz
+            prefix: /
           route:
             weightedClusters:
               clusters:
-              - name: echo-prefix-d0e5ba63b0c9b9f0
+              - name: echo-service-cff7b41a9764f367
                 weight: 1
               totalWeight: 1
+      - domains:
+        - one.example.com
+        name: gateway-multihost:HTTPS:9443:one.example.com
+        requireTls: ALL
+        responseHeadersToAdd:
+        - append: false
+          header:
+            key: Strict-Transport-Security
+            value: max-age=31536000; includeSubDomains
+        routes:
         - match:
-            prefix: /match/baz/
+            prefix: /
           route:
             weightedClusters:
               clusters:
-              - name: echo-prefix-d0e5ba63b0c9b9f0
-                weight: 1
-              totalWeight: 1
-        - match:
-            safeRegex:
-              googleRe2: {}
-              regex: /match/foo
-          route:
-            weightedClusters:
-              clusters:
-              - name: echo-regex-627905e7b1c2eb33
+              - name: echo-service-b5c2b60cba392c4e
                 weight: 1
               totalWeight: 1
 Runtimes:


### PR DESCRIPTION
### Summary

For Gateway, it is not good enough to create unique cluster names by
combining the service name and tags. The same service name and tags can be
referenced by different listeners and have different connection policies
applied. When this happens, the different cluster policies are lost
because the cluster resources are uniqified based on the resource name.

The fix is to include a hash the contents of the cluster to in its name to
guarantee that each unique cluster hane has a unique configuration. This
makes the cluster names less friendly for humans, but gives us assurances
that the connection policies always generate distinct clusters.

### Full changelog

N/A

### Issues resolved

N/A

### Documentation

N/A

### Testing

- [x] Unit tests
- [x] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes 

### Backwards compatibility

- [ ] Add `backport-to-stable` label if the code is backwards compatible. Otherwise, list breaking changes.
