### PR TITLE
fix(kuma-cp) pass the new spec when updating resource on universal

### DIFF
--- a/pkg/api-server/resource_endpoints.go
+++ b/pkg/api-server/resource_endpoints.go
@@ -172,6 +172,8 @@ func (r *resourceEndpoints) createResource(ctx context.Context, name string, mes
 }
 
 func (r *resourceEndpoints) updateResource(ctx context.Context, res model.Resource, restRes rest.Resource, response *restful.Response) {
+	_ = res.SetSpec(restRes.Spec)
+
 	if err := r.resourceAccess.ValidateUpdate(
 		model.ResourceKey{Mesh: res.GetMeta().GetMesh(), Name: res.GetMeta().GetName()},
 		res.GetSpec(),
@@ -182,7 +184,6 @@ func (r *resourceEndpoints) updateResource(ctx context.Context, res model.Resour
 		return
 	}
 
-	_ = res.SetSpec(restRes.Spec)
 	if err := r.resManager.Update(ctx, res); err != nil {
 		rest_errors.HandleError(response, err, "Could not update a resource")
 	} else {


### PR DESCRIPTION
### Summary

We passed the old spec to `ValidateUpdate`

### Issues resolved

No issue

### Documentation

- [X] No docs

### Testing

- [ ] Unit tests
- [ ] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes 

### Backwards compatibility

- [X] No backporting.
