### PR TITLE
feat(kuma-cp) automatically enable gzip content on gateways

### DIFF
--- a/pkg/plugins/runtime/gateway/filter_chain_generator.go
+++ b/pkg/plugins/runtime/gateway/filter_chain_generator.go
@@ -267,6 +267,7 @@ func newFilterChain(ctx xds_context.Context, info *GatewayResourceInfo) *envoy_l
 
 	// Tracing and logging have to be configured after the HttpConnectionManager is enabled.
 	builder.Configure(
+		envoy_listeners.DefaultCompressorFilter(),
 		envoy_listeners.Tracing(info.Proxy.Policies.TracingBackend, service),
 		// TODO(jpeach) Logging policy doesn't work at all. The logging backend is
 		// selected by matching against outbound service names, and gateway dataplanes
@@ -280,11 +281,6 @@ func newFilterChain(ctx xds_context.Context, info *GatewayResourceInfo) *envoy_l
 			info.Proxy,
 		),
 	)
-
-	// TODO(jpeach) add compressor filter.
-	// TODO(jpeach) add decompressor filter.
-	// TODO(jpeach) add grpc_web filter.
-	// TODO(jpeach) add grpc_stats filter.
 
 	// TODO(jpeach) if proxy protocol is enabled, add the proxy protocol listener filter.
 

--- a/pkg/plugins/runtime/gateway/testdata/01-gateway-listener.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/01-gateway-listener.yaml
@@ -18,6 +18,15 @@ Resources:
             initialStreamWindowSize: 65536
             maxConcurrentStreams: 100
           httpFilters:
+          - name: gzip-compress
+            typedConfig:
+              '@type': type.googleapis.com/envoy.extensions.filters.http.compressor.v3.Compressor
+              compressorLibrary:
+                name: gzip
+                typedConfig:
+                  '@type': type.googleapis.com/envoy.extensions.compression.gzip.compressor.v3.Gzip
+              responseDirectionConfig:
+                disableOnEtagHeader: true
           - name: envoy.filters.http.router
           mergeSlashes: true
           normalizePath: true

--- a/pkg/plugins/runtime/gateway/testdata/02-gateway-listener.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/02-gateway-listener.yaml
@@ -18,6 +18,15 @@ Resources:
             initialStreamWindowSize: 65536
             maxConcurrentStreams: 100
           httpFilters:
+          - name: gzip-compress
+            typedConfig:
+              '@type': type.googleapis.com/envoy.extensions.filters.http.compressor.v3.Compressor
+              compressorLibrary:
+                name: gzip
+                typedConfig:
+                  '@type': type.googleapis.com/envoy.extensions.compression.gzip.compressor.v3.Gzip
+              responseDirectionConfig:
+                disableOnEtagHeader: true
           - name: envoy.filters.http.router
           mergeSlashes: true
           normalizePath: true
@@ -58,6 +67,15 @@ Resources:
             initialStreamWindowSize: 65536
             maxConcurrentStreams: 100
           httpFilters:
+          - name: gzip-compress
+            typedConfig:
+              '@type': type.googleapis.com/envoy.extensions.filters.http.compressor.v3.Compressor
+              compressorLibrary:
+                name: gzip
+                typedConfig:
+                  '@type': type.googleapis.com/envoy.extensions.compression.gzip.compressor.v3.Gzip
+              responseDirectionConfig:
+                disableOnEtagHeader: true
           - name: envoy.filters.http.router
           mergeSlashes: true
           normalizePath: true

--- a/pkg/plugins/runtime/gateway/testdata/03-gateway-listener.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/03-gateway-listener.yaml
@@ -18,6 +18,15 @@ Resources:
             initialStreamWindowSize: 65536
             maxConcurrentStreams: 100
           httpFilters:
+          - name: gzip-compress
+            typedConfig:
+              '@type': type.googleapis.com/envoy.extensions.filters.http.compressor.v3.Compressor
+              compressorLibrary:
+                name: gzip
+                typedConfig:
+                  '@type': type.googleapis.com/envoy.extensions.compression.gzip.compressor.v3.Gzip
+              responseDirectionConfig:
+                disableOnEtagHeader: true
           - name: envoy.filters.http.router
           mergeSlashes: true
           normalizePath: true

--- a/pkg/plugins/runtime/gateway/testdata/04-gateway-listener.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/04-gateway-listener.yaml
@@ -18,6 +18,15 @@ Resources:
             initialStreamWindowSize: 65536
             maxConcurrentStreams: 100
           httpFilters:
+          - name: gzip-compress
+            typedConfig:
+              '@type': type.googleapis.com/envoy.extensions.filters.http.compressor.v3.Compressor
+              compressorLibrary:
+                name: gzip
+                typedConfig:
+                  '@type': type.googleapis.com/envoy.extensions.compression.gzip.compressor.v3.Gzip
+              responseDirectionConfig:
+                disableOnEtagHeader: true
           - name: envoy.filters.http.router
           mergeSlashes: true
           normalizePath: true

--- a/pkg/plugins/runtime/gateway/testdata/05-gateway-listener.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/05-gateway-listener.yaml
@@ -25,6 +25,15 @@ Resources:
             initialStreamWindowSize: 65536
             maxConcurrentStreams: 100
           httpFilters:
+          - name: gzip-compress
+            typedConfig:
+              '@type': type.googleapis.com/envoy.extensions.filters.http.compressor.v3.Compressor
+              compressorLibrary:
+                name: gzip
+                typedConfig:
+                  '@type': type.googleapis.com/envoy.extensions.compression.gzip.compressor.v3.Gzip
+              responseDirectionConfig:
+                disableOnEtagHeader: true
           - name: envoy.filters.http.router
           mergeSlashes: true
           normalizePath: true
@@ -74,6 +83,15 @@ Resources:
             initialStreamWindowSize: 65536
             maxConcurrentStreams: 100
           httpFilters:
+          - name: gzip-compress
+            typedConfig:
+              '@type': type.googleapis.com/envoy.extensions.filters.http.compressor.v3.Compressor
+              compressorLibrary:
+                name: gzip
+                typedConfig:
+                  '@type': type.googleapis.com/envoy.extensions.compression.gzip.compressor.v3.Gzip
+              responseDirectionConfig:
+                disableOnEtagHeader: true
           - name: envoy.filters.http.router
           mergeSlashes: true
           normalizePath: true
@@ -123,6 +141,15 @@ Resources:
             initialStreamWindowSize: 65536
             maxConcurrentStreams: 100
           httpFilters:
+          - name: gzip-compress
+            typedConfig:
+              '@type': type.googleapis.com/envoy.extensions.filters.http.compressor.v3.Compressor
+              compressorLibrary:
+                name: gzip
+                typedConfig:
+                  '@type': type.googleapis.com/envoy.extensions.compression.gzip.compressor.v3.Gzip
+              responseDirectionConfig:
+                disableOnEtagHeader: true
           - name: envoy.filters.http.router
           mergeSlashes: true
           normalizePath: true

--- a/pkg/plugins/runtime/gateway/testdata/http/01-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/01-gateway-route.yaml
@@ -54,6 +54,15 @@ Listeners:
               initialStreamWindowSize: 65536
               maxConcurrentStreams: 100
             httpFilters:
+            - name: gzip-compress
+              typedConfig:
+                '@type': type.googleapis.com/envoy.extensions.filters.http.compressor.v3.Compressor
+                compressorLibrary:
+                  name: gzip
+                  typedConfig:
+                    '@type': type.googleapis.com/envoy.extensions.compression.gzip.compressor.v3.Gzip
+                responseDirectionConfig:
+                  disableOnEtagHeader: true
             - name: envoy.filters.http.router
             mergeSlashes: true
             normalizePath: true

--- a/pkg/plugins/runtime/gateway/testdata/http/02-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/02-gateway-route.yaml
@@ -66,6 +66,15 @@ Listeners:
               initialStreamWindowSize: 65536
               maxConcurrentStreams: 100
             httpFilters:
+            - name: gzip-compress
+              typedConfig:
+                '@type': type.googleapis.com/envoy.extensions.filters.http.compressor.v3.Compressor
+                compressorLibrary:
+                  name: gzip
+                  typedConfig:
+                    '@type': type.googleapis.com/envoy.extensions.compression.gzip.compressor.v3.Gzip
+                responseDirectionConfig:
+                  disableOnEtagHeader: true
             - name: envoy.filters.http.router
             mergeSlashes: true
             normalizePath: true

--- a/pkg/plugins/runtime/gateway/testdata/http/03-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/03-gateway-route.yaml
@@ -66,6 +66,15 @@ Listeners:
               initialStreamWindowSize: 65536
               maxConcurrentStreams: 100
             httpFilters:
+            - name: gzip-compress
+              typedConfig:
+                '@type': type.googleapis.com/envoy.extensions.filters.http.compressor.v3.Compressor
+                compressorLibrary:
+                  name: gzip
+                  typedConfig:
+                    '@type': type.googleapis.com/envoy.extensions.compression.gzip.compressor.v3.Gzip
+                responseDirectionConfig:
+                  disableOnEtagHeader: true
             - name: envoy.filters.http.router
             mergeSlashes: true
             normalizePath: true

--- a/pkg/plugins/runtime/gateway/testdata/http/04-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/04-gateway-route.yaml
@@ -95,6 +95,15 @@ Listeners:
               initialStreamWindowSize: 65536
               maxConcurrentStreams: 100
             httpFilters:
+            - name: gzip-compress
+              typedConfig:
+                '@type': type.googleapis.com/envoy.extensions.filters.http.compressor.v3.Compressor
+                compressorLibrary:
+                  name: gzip
+                  typedConfig:
+                    '@type': type.googleapis.com/envoy.extensions.compression.gzip.compressor.v3.Gzip
+                responseDirectionConfig:
+                  disableOnEtagHeader: true
             - name: envoy.filters.http.router
             mergeSlashes: true
             normalizePath: true

--- a/pkg/plugins/runtime/gateway/testdata/http/05-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/05-gateway-route.yaml
@@ -23,6 +23,15 @@ Listeners:
               initialStreamWindowSize: 65536
               maxConcurrentStreams: 100
             httpFilters:
+            - name: gzip-compress
+              typedConfig:
+                '@type': type.googleapis.com/envoy.extensions.filters.http.compressor.v3.Compressor
+                compressorLibrary:
+                  name: gzip
+                  typedConfig:
+                    '@type': type.googleapis.com/envoy.extensions.compression.gzip.compressor.v3.Gzip
+                responseDirectionConfig:
+                  disableOnEtagHeader: true
             - name: envoy.filters.http.router
             mergeSlashes: true
             normalizePath: true

--- a/pkg/plugins/runtime/gateway/testdata/http/06-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/06-gateway-route.yaml
@@ -95,6 +95,15 @@ Listeners:
               initialStreamWindowSize: 65536
               maxConcurrentStreams: 100
             httpFilters:
+            - name: gzip-compress
+              typedConfig:
+                '@type': type.googleapis.com/envoy.extensions.filters.http.compressor.v3.Compressor
+                compressorLibrary:
+                  name: gzip
+                  typedConfig:
+                    '@type': type.googleapis.com/envoy.extensions.compression.gzip.compressor.v3.Gzip
+                responseDirectionConfig:
+                  disableOnEtagHeader: true
             - name: envoy.filters.http.router
             mergeSlashes: true
             normalizePath: true

--- a/pkg/plugins/runtime/gateway/testdata/http/07-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/07-gateway-route.yaml
@@ -66,6 +66,15 @@ Listeners:
               initialStreamWindowSize: 65536
               maxConcurrentStreams: 100
             httpFilters:
+            - name: gzip-compress
+              typedConfig:
+                '@type': type.googleapis.com/envoy.extensions.filters.http.compressor.v3.Compressor
+                compressorLibrary:
+                  name: gzip
+                  typedConfig:
+                    '@type': type.googleapis.com/envoy.extensions.compression.gzip.compressor.v3.Gzip
+                responseDirectionConfig:
+                  disableOnEtagHeader: true
             - name: envoy.filters.http.router
             mergeSlashes: true
             normalizePath: true

--- a/pkg/plugins/runtime/gateway/testdata/http/08-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/08-gateway-route.yaml
@@ -109,6 +109,15 @@ Listeners:
               initialStreamWindowSize: 65536
               maxConcurrentStreams: 100
             httpFilters:
+            - name: gzip-compress
+              typedConfig:
+                '@type': type.googleapis.com/envoy.extensions.filters.http.compressor.v3.Compressor
+                compressorLibrary:
+                  name: gzip
+                  typedConfig:
+                    '@type': type.googleapis.com/envoy.extensions.compression.gzip.compressor.v3.Gzip
+                responseDirectionConfig:
+                  disableOnEtagHeader: true
             - name: envoy.filters.http.router
             mergeSlashes: true
             normalizePath: true

--- a/pkg/plugins/runtime/gateway/testdata/http/09-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/09-gateway-route.yaml
@@ -66,6 +66,15 @@ Listeners:
               initialStreamWindowSize: 65536
               maxConcurrentStreams: 100
             httpFilters:
+            - name: gzip-compress
+              typedConfig:
+                '@type': type.googleapis.com/envoy.extensions.filters.http.compressor.v3.Compressor
+                compressorLibrary:
+                  name: gzip
+                  typedConfig:
+                    '@type': type.googleapis.com/envoy.extensions.compression.gzip.compressor.v3.Gzip
+                responseDirectionConfig:
+                  disableOnEtagHeader: true
             - name: envoy.filters.http.router
             mergeSlashes: true
             normalizePath: true

--- a/pkg/plugins/runtime/gateway/testdata/http/10-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/10-gateway-route.yaml
@@ -109,6 +109,15 @@ Listeners:
               initialStreamWindowSize: 65536
               maxConcurrentStreams: 100
             httpFilters:
+            - name: gzip-compress
+              typedConfig:
+                '@type': type.googleapis.com/envoy.extensions.filters.http.compressor.v3.Compressor
+                compressorLibrary:
+                  name: gzip
+                  typedConfig:
+                    '@type': type.googleapis.com/envoy.extensions.compression.gzip.compressor.v3.Gzip
+                responseDirectionConfig:
+                  disableOnEtagHeader: true
             - name: envoy.filters.http.router
             mergeSlashes: true
             normalizePath: true

--- a/pkg/plugins/runtime/gateway/testdata/http/11-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/11-gateway-route.yaml
@@ -109,6 +109,15 @@ Listeners:
               initialStreamWindowSize: 65536
               maxConcurrentStreams: 100
             httpFilters:
+            - name: gzip-compress
+              typedConfig:
+                '@type': type.googleapis.com/envoy.extensions.filters.http.compressor.v3.Compressor
+                compressorLibrary:
+                  name: gzip
+                  typedConfig:
+                    '@type': type.googleapis.com/envoy.extensions.compression.gzip.compressor.v3.Gzip
+                responseDirectionConfig:
+                  disableOnEtagHeader: true
             - name: envoy.filters.http.router
             mergeSlashes: true
             normalizePath: true

--- a/pkg/plugins/runtime/gateway/testdata/http/12-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/12-gateway-route.yaml
@@ -66,6 +66,15 @@ Listeners:
               initialStreamWindowSize: 65536
               maxConcurrentStreams: 100
             httpFilters:
+            - name: gzip-compress
+              typedConfig:
+                '@type': type.googleapis.com/envoy.extensions.filters.http.compressor.v3.Compressor
+                compressorLibrary:
+                  name: gzip
+                  typedConfig:
+                    '@type': type.googleapis.com/envoy.extensions.compression.gzip.compressor.v3.Gzip
+                responseDirectionConfig:
+                  disableOnEtagHeader: true
             - name: envoy.filters.http.router
             mergeSlashes: true
             normalizePath: true

--- a/pkg/plugins/runtime/gateway/testdata/http/13-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/13-gateway-route.yaml
@@ -152,6 +152,15 @@ Listeners:
               initialStreamWindowSize: 65536
               maxConcurrentStreams: 100
             httpFilters:
+            - name: gzip-compress
+              typedConfig:
+                '@type': type.googleapis.com/envoy.extensions.filters.http.compressor.v3.Compressor
+                compressorLibrary:
+                  name: gzip
+                  typedConfig:
+                    '@type': type.googleapis.com/envoy.extensions.compression.gzip.compressor.v3.Gzip
+                responseDirectionConfig:
+                  disableOnEtagHeader: true
             - name: envoy.filters.http.router
             mergeSlashes: true
             normalizePath: true

--- a/pkg/plugins/runtime/gateway/testdata/http/14-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/14-gateway-route.yaml
@@ -66,6 +66,15 @@ Listeners:
               initialStreamWindowSize: 65536
               maxConcurrentStreams: 100
             httpFilters:
+            - name: gzip-compress
+              typedConfig:
+                '@type': type.googleapis.com/envoy.extensions.filters.http.compressor.v3.Compressor
+                compressorLibrary:
+                  name: gzip
+                  typedConfig:
+                    '@type': type.googleapis.com/envoy.extensions.compression.gzip.compressor.v3.Gzip
+                responseDirectionConfig:
+                  disableOnEtagHeader: true
             - name: envoy.filters.http.router
             mergeSlashes: true
             normalizePath: true

--- a/pkg/plugins/runtime/gateway/testdata/http/15-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/15-gateway-route.yaml
@@ -152,6 +152,15 @@ Listeners:
               initialStreamWindowSize: 65536
               maxConcurrentStreams: 100
             httpFilters:
+            - name: gzip-compress
+              typedConfig:
+                '@type': type.googleapis.com/envoy.extensions.filters.http.compressor.v3.Compressor
+                compressorLibrary:
+                  name: gzip
+                  typedConfig:
+                    '@type': type.googleapis.com/envoy.extensions.compression.gzip.compressor.v3.Gzip
+                responseDirectionConfig:
+                  disableOnEtagHeader: true
             - name: envoy.filters.http.router
             mergeSlashes: true
             normalizePath: true

--- a/pkg/plugins/runtime/gateway/testdata/http/16-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/16-gateway-route.yaml
@@ -149,6 +149,15 @@ Listeners:
               initialStreamWindowSize: 65536
               maxConcurrentStreams: 100
             httpFilters:
+            - name: gzip-compress
+              typedConfig:
+                '@type': type.googleapis.com/envoy.extensions.filters.http.compressor.v3.Compressor
+                compressorLibrary:
+                  name: gzip
+                  typedConfig:
+                    '@type': type.googleapis.com/envoy.extensions.compression.gzip.compressor.v3.Gzip
+                responseDirectionConfig:
+                  disableOnEtagHeader: true
             - name: envoy.filters.http.router
             mergeSlashes: true
             normalizePath: true

--- a/pkg/plugins/runtime/gateway/testdata/http/17-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/17-gateway-route.yaml
@@ -170,6 +170,15 @@ Listeners:
               initialStreamWindowSize: 65536
               maxConcurrentStreams: 100
             httpFilters:
+            - name: gzip-compress
+              typedConfig:
+                '@type': type.googleapis.com/envoy.extensions.filters.http.compressor.v3.Compressor
+                compressorLibrary:
+                  name: gzip
+                  typedConfig:
+                    '@type': type.googleapis.com/envoy.extensions.compression.gzip.compressor.v3.Gzip
+                responseDirectionConfig:
+                  disableOnEtagHeader: true
             - name: envoy.filters.http.router
             mergeSlashes: true
             normalizePath: true

--- a/pkg/plugins/runtime/gateway/testdata/http/18-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/18-gateway-route.yaml
@@ -63,6 +63,15 @@ Listeners:
               initialStreamWindowSize: 65536
               maxConcurrentStreams: 100
             httpFilters:
+            - name: gzip-compress
+              typedConfig:
+                '@type': type.googleapis.com/envoy.extensions.filters.http.compressor.v3.Compressor
+                compressorLibrary:
+                  name: gzip
+                  typedConfig:
+                    '@type': type.googleapis.com/envoy.extensions.compression.gzip.compressor.v3.Gzip
+                responseDirectionConfig:
+                  disableOnEtagHeader: true
             - name: envoy.filters.http.router
             mergeSlashes: true
             normalizePath: true

--- a/pkg/plugins/runtime/gateway/testdata/http/19-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/19-gateway-route.yaml
@@ -76,6 +76,15 @@ Listeners:
               initialStreamWindowSize: 65536
               maxConcurrentStreams: 100
             httpFilters:
+            - name: gzip-compress
+              typedConfig:
+                '@type': type.googleapis.com/envoy.extensions.filters.http.compressor.v3.Compressor
+                compressorLibrary:
+                  name: gzip
+                  typedConfig:
+                    '@type': type.googleapis.com/envoy.extensions.compression.gzip.compressor.v3.Gzip
+                responseDirectionConfig:
+                  disableOnEtagHeader: true
             - name: envoy.filters.http.router
             mergeSlashes: true
             normalizePath: true

--- a/pkg/plugins/runtime/gateway/testdata/https/01-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/01-gateway-route.yaml
@@ -54,6 +54,15 @@ Listeners:
               initialStreamWindowSize: 65536
               maxConcurrentStreams: 100
             httpFilters:
+            - name: gzip-compress
+              typedConfig:
+                '@type': type.googleapis.com/envoy.extensions.filters.http.compressor.v3.Compressor
+                compressorLibrary:
+                  name: gzip
+                  typedConfig:
+                    '@type': type.googleapis.com/envoy.extensions.compression.gzip.compressor.v3.Gzip
+                responseDirectionConfig:
+                  disableOnEtagHeader: true
             - name: envoy.filters.http.router
             mergeSlashes: true
             normalizePath: true

--- a/pkg/plugins/runtime/gateway/testdata/https/02-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/02-gateway-route.yaml
@@ -66,6 +66,15 @@ Listeners:
               initialStreamWindowSize: 65536
               maxConcurrentStreams: 100
             httpFilters:
+            - name: gzip-compress
+              typedConfig:
+                '@type': type.googleapis.com/envoy.extensions.filters.http.compressor.v3.Compressor
+                compressorLibrary:
+                  name: gzip
+                  typedConfig:
+                    '@type': type.googleapis.com/envoy.extensions.compression.gzip.compressor.v3.Gzip
+                responseDirectionConfig:
+                  disableOnEtagHeader: true
             - name: envoy.filters.http.router
             mergeSlashes: true
             normalizePath: true

--- a/pkg/plugins/runtime/gateway/testdata/https/03-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/03-gateway-route.yaml
@@ -73,6 +73,15 @@ Listeners:
               initialStreamWindowSize: 65536
               maxConcurrentStreams: 100
             httpFilters:
+            - name: gzip-compress
+              typedConfig:
+                '@type': type.googleapis.com/envoy.extensions.filters.http.compressor.v3.Compressor
+                compressorLibrary:
+                  name: gzip
+                  typedConfig:
+                    '@type': type.googleapis.com/envoy.extensions.compression.gzip.compressor.v3.Gzip
+                responseDirectionConfig:
+                  disableOnEtagHeader: true
             - name: envoy.filters.http.router
             mergeSlashes: true
             normalizePath: true

--- a/pkg/plugins/runtime/gateway/testdata/https/04-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/04-gateway-route.yaml
@@ -102,6 +102,15 @@ Listeners:
               initialStreamWindowSize: 65536
               maxConcurrentStreams: 100
             httpFilters:
+            - name: gzip-compress
+              typedConfig:
+                '@type': type.googleapis.com/envoy.extensions.filters.http.compressor.v3.Compressor
+                compressorLibrary:
+                  name: gzip
+                  typedConfig:
+                    '@type': type.googleapis.com/envoy.extensions.compression.gzip.compressor.v3.Gzip
+                responseDirectionConfig:
+                  disableOnEtagHeader: true
             - name: envoy.filters.http.router
             mergeSlashes: true
             normalizePath: true

--- a/pkg/plugins/runtime/gateway/testdata/https/05-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/05-gateway-route.yaml
@@ -30,6 +30,15 @@ Listeners:
               initialStreamWindowSize: 65536
               maxConcurrentStreams: 100
             httpFilters:
+            - name: gzip-compress
+              typedConfig:
+                '@type': type.googleapis.com/envoy.extensions.filters.http.compressor.v3.Compressor
+                compressorLibrary:
+                  name: gzip
+                  typedConfig:
+                    '@type': type.googleapis.com/envoy.extensions.compression.gzip.compressor.v3.Gzip
+                responseDirectionConfig:
+                  disableOnEtagHeader: true
             - name: envoy.filters.http.router
             mergeSlashes: true
             normalizePath: true

--- a/pkg/plugins/runtime/gateway/testdata/https/06-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/06-gateway-route.yaml
@@ -102,6 +102,15 @@ Listeners:
               initialStreamWindowSize: 65536
               maxConcurrentStreams: 100
             httpFilters:
+            - name: gzip-compress
+              typedConfig:
+                '@type': type.googleapis.com/envoy.extensions.filters.http.compressor.v3.Compressor
+                compressorLibrary:
+                  name: gzip
+                  typedConfig:
+                    '@type': type.googleapis.com/envoy.extensions.compression.gzip.compressor.v3.Gzip
+                responseDirectionConfig:
+                  disableOnEtagHeader: true
             - name: envoy.filters.http.router
             mergeSlashes: true
             normalizePath: true

--- a/pkg/plugins/runtime/gateway/testdata/https/07-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/07-gateway-route.yaml
@@ -73,6 +73,15 @@ Listeners:
               initialStreamWindowSize: 65536
               maxConcurrentStreams: 100
             httpFilters:
+            - name: gzip-compress
+              typedConfig:
+                '@type': type.googleapis.com/envoy.extensions.filters.http.compressor.v3.Compressor
+                compressorLibrary:
+                  name: gzip
+                  typedConfig:
+                    '@type': type.googleapis.com/envoy.extensions.compression.gzip.compressor.v3.Gzip
+                responseDirectionConfig:
+                  disableOnEtagHeader: true
             - name: envoy.filters.http.router
             mergeSlashes: true
             normalizePath: true

--- a/pkg/plugins/runtime/gateway/testdata/https/08-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/08-gateway-route.yaml
@@ -116,6 +116,15 @@ Listeners:
               initialStreamWindowSize: 65536
               maxConcurrentStreams: 100
             httpFilters:
+            - name: gzip-compress
+              typedConfig:
+                '@type': type.googleapis.com/envoy.extensions.filters.http.compressor.v3.Compressor
+                compressorLibrary:
+                  name: gzip
+                  typedConfig:
+                    '@type': type.googleapis.com/envoy.extensions.compression.gzip.compressor.v3.Gzip
+                responseDirectionConfig:
+                  disableOnEtagHeader: true
             - name: envoy.filters.http.router
             mergeSlashes: true
             normalizePath: true

--- a/pkg/plugins/runtime/gateway/testdata/https/09-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/09-gateway-route.yaml
@@ -73,6 +73,15 @@ Listeners:
               initialStreamWindowSize: 65536
               maxConcurrentStreams: 100
             httpFilters:
+            - name: gzip-compress
+              typedConfig:
+                '@type': type.googleapis.com/envoy.extensions.filters.http.compressor.v3.Compressor
+                compressorLibrary:
+                  name: gzip
+                  typedConfig:
+                    '@type': type.googleapis.com/envoy.extensions.compression.gzip.compressor.v3.Gzip
+                responseDirectionConfig:
+                  disableOnEtagHeader: true
             - name: envoy.filters.http.router
             mergeSlashes: true
             normalizePath: true

--- a/pkg/plugins/runtime/gateway/testdata/https/10-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/10-gateway-route.yaml
@@ -116,6 +116,15 @@ Listeners:
               initialStreamWindowSize: 65536
               maxConcurrentStreams: 100
             httpFilters:
+            - name: gzip-compress
+              typedConfig:
+                '@type': type.googleapis.com/envoy.extensions.filters.http.compressor.v3.Compressor
+                compressorLibrary:
+                  name: gzip
+                  typedConfig:
+                    '@type': type.googleapis.com/envoy.extensions.compression.gzip.compressor.v3.Gzip
+                responseDirectionConfig:
+                  disableOnEtagHeader: true
             - name: envoy.filters.http.router
             mergeSlashes: true
             normalizePath: true

--- a/pkg/plugins/runtime/gateway/testdata/https/11-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/11-gateway-route.yaml
@@ -116,6 +116,15 @@ Listeners:
               initialStreamWindowSize: 65536
               maxConcurrentStreams: 100
             httpFilters:
+            - name: gzip-compress
+              typedConfig:
+                '@type': type.googleapis.com/envoy.extensions.filters.http.compressor.v3.Compressor
+                compressorLibrary:
+                  name: gzip
+                  typedConfig:
+                    '@type': type.googleapis.com/envoy.extensions.compression.gzip.compressor.v3.Gzip
+                responseDirectionConfig:
+                  disableOnEtagHeader: true
             - name: envoy.filters.http.router
             mergeSlashes: true
             normalizePath: true

--- a/pkg/plugins/runtime/gateway/testdata/https/12-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/12-gateway-route.yaml
@@ -73,6 +73,15 @@ Listeners:
               initialStreamWindowSize: 65536
               maxConcurrentStreams: 100
             httpFilters:
+            - name: gzip-compress
+              typedConfig:
+                '@type': type.googleapis.com/envoy.extensions.filters.http.compressor.v3.Compressor
+                compressorLibrary:
+                  name: gzip
+                  typedConfig:
+                    '@type': type.googleapis.com/envoy.extensions.compression.gzip.compressor.v3.Gzip
+                responseDirectionConfig:
+                  disableOnEtagHeader: true
             - name: envoy.filters.http.router
             mergeSlashes: true
             normalizePath: true

--- a/pkg/plugins/runtime/gateway/testdata/https/13-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/13-gateway-route.yaml
@@ -159,6 +159,15 @@ Listeners:
               initialStreamWindowSize: 65536
               maxConcurrentStreams: 100
             httpFilters:
+            - name: gzip-compress
+              typedConfig:
+                '@type': type.googleapis.com/envoy.extensions.filters.http.compressor.v3.Compressor
+                compressorLibrary:
+                  name: gzip
+                  typedConfig:
+                    '@type': type.googleapis.com/envoy.extensions.compression.gzip.compressor.v3.Gzip
+                responseDirectionConfig:
+                  disableOnEtagHeader: true
             - name: envoy.filters.http.router
             mergeSlashes: true
             normalizePath: true

--- a/pkg/plugins/runtime/gateway/testdata/https/14-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/14-gateway-route.yaml
@@ -73,6 +73,15 @@ Listeners:
               initialStreamWindowSize: 65536
               maxConcurrentStreams: 100
             httpFilters:
+            - name: gzip-compress
+              typedConfig:
+                '@type': type.googleapis.com/envoy.extensions.filters.http.compressor.v3.Compressor
+                compressorLibrary:
+                  name: gzip
+                  typedConfig:
+                    '@type': type.googleapis.com/envoy.extensions.compression.gzip.compressor.v3.Gzip
+                responseDirectionConfig:
+                  disableOnEtagHeader: true
             - name: envoy.filters.http.router
             mergeSlashes: true
             normalizePath: true

--- a/pkg/plugins/runtime/gateway/testdata/https/15-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/15-gateway-route.yaml
@@ -159,6 +159,15 @@ Listeners:
               initialStreamWindowSize: 65536
               maxConcurrentStreams: 100
             httpFilters:
+            - name: gzip-compress
+              typedConfig:
+                '@type': type.googleapis.com/envoy.extensions.filters.http.compressor.v3.Compressor
+                compressorLibrary:
+                  name: gzip
+                  typedConfig:
+                    '@type': type.googleapis.com/envoy.extensions.compression.gzip.compressor.v3.Gzip
+                responseDirectionConfig:
+                  disableOnEtagHeader: true
             - name: envoy.filters.http.router
             mergeSlashes: true
             normalizePath: true

--- a/pkg/plugins/runtime/gateway/testdata/https/16-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/16-gateway-route.yaml
@@ -156,6 +156,15 @@ Listeners:
               initialStreamWindowSize: 65536
               maxConcurrentStreams: 100
             httpFilters:
+            - name: gzip-compress
+              typedConfig:
+                '@type': type.googleapis.com/envoy.extensions.filters.http.compressor.v3.Compressor
+                compressorLibrary:
+                  name: gzip
+                  typedConfig:
+                    '@type': type.googleapis.com/envoy.extensions.compression.gzip.compressor.v3.Gzip
+                responseDirectionConfig:
+                  disableOnEtagHeader: true
             - name: envoy.filters.http.router
             mergeSlashes: true
             normalizePath: true

--- a/pkg/plugins/runtime/gateway/testdata/https/17-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/17-gateway-route.yaml
@@ -177,6 +177,15 @@ Listeners:
               initialStreamWindowSize: 65536
               maxConcurrentStreams: 100
             httpFilters:
+            - name: gzip-compress
+              typedConfig:
+                '@type': type.googleapis.com/envoy.extensions.filters.http.compressor.v3.Compressor
+                compressorLibrary:
+                  name: gzip
+                  typedConfig:
+                    '@type': type.googleapis.com/envoy.extensions.compression.gzip.compressor.v3.Gzip
+                responseDirectionConfig:
+                  disableOnEtagHeader: true
             - name: envoy.filters.http.router
             mergeSlashes: true
             normalizePath: true

--- a/pkg/plugins/runtime/gateway/testdata/https/18-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/18-gateway-route.yaml
@@ -70,6 +70,15 @@ Listeners:
               initialStreamWindowSize: 65536
               maxConcurrentStreams: 100
             httpFilters:
+            - name: gzip-compress
+              typedConfig:
+                '@type': type.googleapis.com/envoy.extensions.filters.http.compressor.v3.Compressor
+                compressorLibrary:
+                  name: gzip
+                  typedConfig:
+                    '@type': type.googleapis.com/envoy.extensions.compression.gzip.compressor.v3.Gzip
+                responseDirectionConfig:
+                  disableOnEtagHeader: true
             - name: envoy.filters.http.router
             mergeSlashes: true
             normalizePath: true

--- a/pkg/plugins/runtime/gateway/testdata/https/19-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/19-gateway-route.yaml
@@ -83,6 +83,15 @@ Listeners:
               initialStreamWindowSize: 65536
               maxConcurrentStreams: 100
             httpFilters:
+            - name: gzip-compress
+              typedConfig:
+                '@type': type.googleapis.com/envoy.extensions.filters.http.compressor.v3.Compressor
+                compressorLibrary:
+                  name: gzip
+                  typedConfig:
+                    '@type': type.googleapis.com/envoy.extensions.compression.gzip.compressor.v3.Gzip
+                responseDirectionConfig:
+                  disableOnEtagHeader: true
             - name: envoy.filters.http.router
             mergeSlashes: true
             normalizePath: true

--- a/pkg/xds/envoy/listeners/filter_chain_configurers.go
+++ b/pkg/xds/envoy/listeners/filter_chain_configurers.go
@@ -1,6 +1,9 @@
 package listeners
 
 import (
+	envoy_config_core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	envoy_extensions_compression_gzip_compressor_v3 "github.com/envoyproxy/go-control-plane/envoy/extensions/compression/gzip/compressor/v3"
+	envoy_extensions_filters_http_compressor_v3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/compressor/v3"
 	envoy_hcm "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
 
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
@@ -235,6 +238,32 @@ func StripHostPort() FilterChainBuilderOpt {
 			hcm.StripPortMode = &envoy_hcm.HttpConnectionManager_StripAnyHostPort{
 				StripAnyHostPort: true,
 			}
+		}),
+	)
+}
+
+// DefaultCompressorFilter adds a gzip compressor filter in its default configuration.
+func DefaultCompressorFilter() FilterChainBuilderOpt {
+	return AddFilterChainConfigurer(
+		v3.HttpConnectionManagerMustConfigureFunc(func(hcm *envoy_hcm.HttpConnectionManager) {
+			c := envoy_extensions_filters_http_compressor_v3.Compressor{
+				CompressorLibrary: &envoy_config_core.TypedExtensionConfig{
+					Name:        "gzip",
+					TypedConfig: util_proto.MustMarshalAny(&envoy_extensions_compression_gzip_compressor_v3.Gzip{}),
+				},
+				ResponseDirectionConfig: &envoy_extensions_filters_http_compressor_v3.Compressor_ResponseDirectionConfig{
+					DisableOnEtagHeader: true,
+				},
+			}
+
+			gzip := &envoy_hcm.HttpFilter{
+				Name: "gzip-compress",
+				ConfigType: &envoy_hcm.HttpFilter_TypedConfig{
+					TypedConfig: util_proto.MustMarshalAny(&c),
+				},
+			}
+
+			hcm.HttpFilters = append(hcm.HttpFilters, gzip)
 		}),
 	)
 }


### PR DESCRIPTION
### Summary

Always configure the compressor filter to enable gzip compression if
the client negotiates the relevant content types. This is a safe and
conservative default that can benefit many clients.

### Full changelog

N/A

### Issues resolved

N/A

### Documentation

N/A

### Testing

- [x] Unit tests
- [x] E2E tests
- [x] Manual testing on Universal
- [ ] Manual testing on Kubernetes 

### Backwards compatibility

- [ ] Add `backport-to-stable` label if the code is backwards compatible. Otherwise, list breaking changes.
