### PR TITLE
tests: fix postgres in tests if using IPv6 locally

### DIFF
--- a/tools/postgres/pg_hba.conf
+++ b/tools/postgres/pg_hba.conf
@@ -1,3 +1,3 @@
 # TYPE  DATABASE        USER            ADDRESS                 METHOD
 local	all				all										trust
-hostssl all             all             0.0.0.0/0               cert
+hostssl	all				all				all						cert


### PR DESCRIPTION
### Summary

Otherwise we get an error like:

```
cannot connect to DB: pq: no pg_hba.conf entry for host "fd00::1", user "kuma", database "kuma", SSL encryption
```