### PR TITLE
chore(*) scripts for build, publish and fetch Envoy binaries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,3 @@ build/
 
 # Release artifacts
 .cr-release-packages
-
-# Fetched Envoy source code
-out/envoy-sources

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ build/
 
 # Release artifacts
 .cr-release-packages
+
+# Fetched Envoy source code
+out/envoy-sources

--- a/Makefile
+++ b/Makefile
@@ -25,3 +25,4 @@ include mk/k3d.mk
 include mk/e2e.mk
 include mk/e2e.new.mk
 include mk/docs.mk
+include mk/envoy.mk

--- a/mk/build.mk
+++ b/mk/build.mk
@@ -31,7 +31,7 @@ COREDNS_TMP_DIRECTORY ?= $(BUILD_DIR)/coredns
 COREDNS_PLUGIN_CFG_PATH ?= $(TOP)/tools/builds/coredns/templates/plugin.cfg
 
 # List of binaries that we have release build rules for.
-BUILD_RELEASE_BINARIES := kuma-cp kuma-dp kumactl kuma-prometheus-sd coredns
+BUILD_RELEASE_BINARIES := kuma-cp kuma-dp kumactl kuma-prometheus-sd coredns envoy
 
 # List of binaries that we have test build roles for.
 BUILD_TEST_BINARIES := test-server

--- a/mk/docker.mk
+++ b/mk/docker.mk
@@ -66,7 +66,7 @@ docker/build/kuma-universal: build/artifacts-linux-amd64/kuma-cp/kuma-cp build/a
 image/kuma-cp: build/kuma-cp/linux-amd64 docker/build/kuma-cp ## Dev: Rebuild `kuma-cp` Docker image
 
 .PHONY: image/kuma-dp
-image/kuma-dp: build/kuma-dp/linux-amd64 build/coredns/linux-amd64 docker/build/kuma-dp ## Dev: Rebuild `kuma-dp` Docker image
+image/kuma-dp: build/kuma-dp/linux-amd64 build/coredns/linux-amd64 build/artifacts-linux-amd64/envoy docker/build/kuma-dp ## Dev: Rebuild `kuma-dp` Docker image
 
 .PHONY: image/kumactl
 image/kumactl: build/kumactl/linux-amd64 docker/build/kumactl ## Dev: Rebuild `kumactl` Docker image

--- a/mk/docker.mk
+++ b/mk/docker.mk
@@ -66,7 +66,7 @@ docker/build/kuma-universal: build/artifacts-linux-amd64/kuma-cp/kuma-cp build/a
 image/kuma-cp: build/kuma-cp/linux-amd64 docker/build/kuma-cp ## Dev: Rebuild `kuma-cp` Docker image
 
 .PHONY: image/kuma-dp
-image/kuma-dp: build/kuma-dp/linux-amd64 build/coredns/linux-amd64 build/artifacts-linux-amd64/envoy docker/build/kuma-dp ## Dev: Rebuild `kuma-dp` Docker image
+image/kuma-dp: build/kuma-dp/linux-amd64 build/coredns/linux-amd64 build/artifacts-linux-amd64/envoy/envoy docker/build/kuma-dp ## Dev: Rebuild `kuma-dp` Docker image
 
 .PHONY: image/kumactl
 image/kumactl: build/kumactl/linux-amd64 docker/build/kumactl ## Dev: Rebuild `kumactl` Docker image

--- a/mk/envoy.mk
+++ b/mk/envoy.mk
@@ -15,7 +15,7 @@ build/envoy:
 build/artifacts-%-amd64/envoy:
 ifeq ($(BUILD_ENVOY_FROM_SOURCES),true)
 	ENVOY_TAG=${ENVOY_TAG} \
-	ENVOY_COMMIT_HASH=${ENV./tools/envoy/build_darwin.shOY_COMMIT_HASH} \
+	ENVOY_COMMIT_HASH=${ENVOY_COMMIT_HASH} \
 	SOURCE_DIR=${SOURCE_DIR} \
 	BINARY_PATH=$@ ./tools/envoy/build_$*.sh
 else

--- a/mk/envoy.mk
+++ b/mk/envoy.mk
@@ -7,7 +7,7 @@ ifndef TMPDIR
 endif
 
 BUILD_ENVOY_FROM_SOURCES ?= false
-
+KUMA_DIR ?= .
 # Target 'build/envoy' allows to put Envoy binary under the build/artifacts-$GOOS-$GOARCH directory.
 # Depending on the flag BUILD_ENVOY_FROM_SOURCES this target either fetches Envoy from binary registry or
 # builds from sources. It's possible to build binaries for darwin, linux and centos7 by specifying GOOS variable.
@@ -21,10 +21,12 @@ ifeq ($(BUILD_ENVOY_FROM_SOURCES),true)
 	ENVOY_TAG=${ENVOY_TAG} \
 	ENVOY_COMMIT_HASH=${ENVOY_COMMIT_HASH} \
 	SOURCE_DIR=${SOURCE_DIR} \
-	BINARY_PATH=$@ ./tools/envoy/build_$*.sh
+	KUMA_DIR=${KUMA_DIR} \
+	BAZEL_BUILD_EXTRA_OPTIONS=${BAZEL_BUILD_EXTRA_OPTIONS} \
+	BINARY_PATH=$@ ${KUMA_DIR}/tools/envoy/build_$*.sh
 else
 	ENVOY_TAG=${ENVOY_TAG} \
 	ENVOY_COMMIT_HASH=${ENVOY_COMMIT_HASH} \
 	BINARY_PATH=$@ \
-	ENVOY_DISTRO=$* ./tools/envoy/fetch.sh
+	ENVOY_DISTRO=$* ${KUMA_DIR}/tools/envoy/fetch.sh
 endif

--- a/mk/envoy.mk
+++ b/mk/envoy.mk
@@ -13,7 +13,7 @@ BUILD_ENVOY_FROM_SOURCES ?= false
 # builds from sources. It's possible to build binaries for darwin, linux and centos7 by specifying GOOS variable.
 # Envoy version could be specified either by ENVOY_TAG or ENVOY_COMMIT_HASH, the latter takes precedence.
 .PHONY: build/envoy
-build/envoy:
+build/envoy: ## Envoy: build or fetch envoy binaries
 	$(MAKE) build/artifacts-${GOOS}-${GOARCH}/envoy/envoy
 
 build/artifacts-%-amd64/envoy/envoy:

--- a/mk/envoy.mk
+++ b/mk/envoy.mk
@@ -8,11 +8,15 @@ endif
 
 BUILD_ENVOY_FROM_SOURCES ?= false
 
+# Target 'build/envoy' allows to put Envoy binary under the build/artifacts-$GOOS-$GOARCH directory.
+# Depending on the flag BUILD_ENVOY_FROM_SOURCES this target either fetches Envoy from binary registry or
+# builds from sources. It's possible to build binaries for darwin, linux and centos7 by specifying GOOS variable.
+# Envoy version could be specified either by ENVOY_TAG or ENVOY_COMMIT_HASH, the latter takes precedence.
 .PHONY: build/envoy
 build/envoy:
-	$(MAKE) build/artifacts-${GOOS}-${GOARCH}/envoy
+	$(MAKE) build/artifacts-${GOOS}-${GOARCH}/envoy/envoy
 
-build/artifacts-%-amd64/envoy:
+build/artifacts-%-amd64/envoy/envoy:
 ifeq ($(BUILD_ENVOY_FROM_SOURCES),true)
 	ENVOY_TAG=${ENVOY_TAG} \
 	ENVOY_COMMIT_HASH=${ENVOY_COMMIT_HASH} \

--- a/mk/envoy.mk
+++ b/mk/envoy.mk
@@ -1,6 +1,11 @@
 ENVOY_TAG ?= v1.18.4
 ENVOY_COMMIT_HASH ?=
 
+SOURCE_DIR ?= ${TMPDIR}envoy-sources
+ifndef TMPDIR
+	SOURCE_DIR ?= /tmp/envoy-sources
+endif
+
 BUILD_ENVOY_FROM_SOURCES ?= false
 
 .PHONY: build/envoy
@@ -10,7 +15,8 @@ build/envoy:
 build/artifacts-%-amd64/envoy:
 ifeq ($(BUILD_ENVOY_FROM_SOURCES),true)
 	ENVOY_TAG=${ENVOY_TAG} \
-	ENVOY_COMMIT_HASH=${ENVOY_COMMIT_HASH} \
+	ENVOY_COMMIT_HASH=${ENV./tools/envoy/build_darwin.shOY_COMMIT_HASH} \
+	SOURCE_DIR=${SOURCE_DIR} \
 	BINARY_PATH=$@ ./tools/envoy/build_$*.sh
 else
 	ENVOY_TAG=${ENVOY_TAG} \

--- a/mk/envoy.mk
+++ b/mk/envoy.mk
@@ -1,0 +1,20 @@
+ENVOY_TAG ?= v1.18.4
+ENVOY_COMMIT_HASH ?=
+
+BUILD_ENVOY_FROM_SOURCES ?= false
+
+.PHONY: build/envoy
+build/envoy:
+	$(MAKE) build/artifacts-${GOOS}-${GOARCH}/envoy
+
+build/artifacts-%-amd64/envoy:
+ifeq ($(BUILD_ENVOY_FROM_SOURCES),true)
+	ENVOY_TAG=${ENVOY_TAG} \
+	ENVOY_COMMIT_HASH=${ENVOY_COMMIT_HASH} \
+	BINARY_PATH=$@ ./tools/envoy/build_$*.sh
+else
+	ENVOY_TAG=${ENVOY_TAG} \
+	ENVOY_COMMIT_HASH=${ENVOY_COMMIT_HASH} \
+	BINARY_PATH=$@ \
+	ENVOY_DISTRO=$* ./tools/envoy/fetch.sh
+endif

--- a/test/dockerfiles/Dockerfile.universal
+++ b/test/dockerfiles/Dockerfile.universal
@@ -37,6 +37,7 @@ COPY --from=envoy /usr/local/bin/envoy /usr/local/bin/envoy
 
 ADD $KUMA_ROOT/build/artifacts-linux-amd64/kuma-cp/kuma-cp /usr/bin
 ADD $KUMA_ROOT/build/artifacts-linux-amd64/kuma-dp/kuma-dp /usr/bin
+ADD $KUMA_ROOT/build/artifacts-linux-amd64/envoy /usr/bin
 ADD $KUMA_ROOT/build/artifacts-linux-amd64/coredns/coredns /usr/bin
 ADD $KUMA_ROOT/build/artifacts-linux-amd64/kumactl/kumactl /usr/bin
 ADD $KUMA_ROOT/build/artifacts-linux-amd64/test-server/test-server /usr/bin

--- a/test/dockerfiles/Dockerfile.universal
+++ b/test/dockerfiles/Dockerfile.universal
@@ -37,7 +37,7 @@ COPY --from=envoy /usr/local/bin/envoy /usr/local/bin/envoy
 
 ADD $KUMA_ROOT/build/artifacts-linux-amd64/kuma-cp/kuma-cp /usr/bin
 ADD $KUMA_ROOT/build/artifacts-linux-amd64/kuma-dp/kuma-dp /usr/bin
-ADD $KUMA_ROOT/build/artifacts-linux-amd64/envoy /usr/bin
+ADD $KUMA_ROOT/build/artifacts-linux-amd64/envoy/envoy /usr/bin
 ADD $KUMA_ROOT/build/artifacts-linux-amd64/coredns/coredns /usr/bin
 ADD $KUMA_ROOT/build/artifacts-linux-amd64/kumactl/kumactl /usr/bin
 ADD $KUMA_ROOT/build/artifacts-linux-amd64/test-server/test-server /usr/bin

--- a/test/dockerfiles/Dockerfile.universal.dockerignore
+++ b/test/dockerfiles/Dockerfile.universal.dockerignore
@@ -1,7 +1,7 @@
 *
 !build/artifacts-linux-amd64/kuma-cp/kuma-cp
 !build/artifacts-linux-amd64/kuma-dp/kuma-dp
-!build/artifacts-linux-amd64/envoy
+!build/artifacts-linux-amd64/envoy/envoy
 !build/artifacts-linux-amd64/kumactl/kumactl
 !build/artifacts-linux-amd64/coredns/coredns
 !build/artifacts-linux-amd64/test-server/test-server

--- a/test/dockerfiles/Dockerfile.universal.dockerignore
+++ b/test/dockerfiles/Dockerfile.universal.dockerignore
@@ -1,6 +1,7 @@
 *
 !build/artifacts-linux-amd64/kuma-cp/kuma-cp
 !build/artifacts-linux-amd64/kuma-dp/kuma-dp
+!build/artifacts-linux-amd64/envoy
 !build/artifacts-linux-amd64/kumactl/kumactl
 !build/artifacts-linux-amd64/coredns/coredns
 !build/artifacts-linux-amd64/test-server/test-server

--- a/tools/common.sh
+++ b/tools/common.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+function msg_green() {
+  builtin echo -en "\033[1;32m"
+  echo "$@"
+  builtin echo -en "\033[0m"
+}
+
+function msg_red() {
+  builtin echo -en "\033[1;31m" >&2
+  echo "$@" >&2
+  builtin echo -en "\033[0m" >&2
+}
+
+function msg_yellow() {
+  builtin echo -en "\033[1;33m"
+  echo "$@"
+  builtin echo -en "\033[0m"
+}
+
+function msg() {
+  builtin echo -en "\033[1m"
+  echo "$@"
+  builtin echo -en "\033[0m"
+}
+
+function msg_err() {
+  msg_red $@
+  exit 1
+}

--- a/tools/envoy/Dockerfile.build-centos7
+++ b/tools/envoy/Dockerfile.build-centos7
@@ -1,0 +1,8 @@
+ARG ENVOY_BUILD_IMAGE
+FROM $ENVOY_BUILD_IMAGE
+
+ARG BUILD_CMD
+
+RUN mkdir /build /source
+COPY out/envoy-sources /envoy-sources
+RUN bash -c "pushd /envoy-sources && $BUILD_CMD"

--- a/tools/envoy/Dockerfile.build-centos7
+++ b/tools/envoy/Dockerfile.build-centos7
@@ -4,5 +4,5 @@ FROM $ENVOY_BUILD_IMAGE
 ARG BUILD_CMD
 
 RUN mkdir /build /source
-COPY out/envoy-sources /envoy-sources
+COPY . /envoy-sources/
 RUN bash -c "pushd /envoy-sources && $BUILD_CMD"

--- a/tools/envoy/Dockerfile.build-centos7
+++ b/tools/envoy/Dockerfile.build-centos7
@@ -3,6 +3,16 @@ FROM $ENVOY_BUILD_IMAGE
 
 ARG BUILD_CMD
 
+# based on the fix https://github.com/envoyproxy/envoy/pull/18426, could be deleted as soon as it'll be merged
+RUN git clone https://gn.googlesource.com/gn && \
+    pushd gn && \
+    git checkout 45aa842fb41d79e149b46fac8ad71728856e15b9 && \
+    python build/gen.py && \
+    ninja -C out && \
+    mv -f out/gn /usr/local/bin/gn && \
+    chmod +x /usr/local/bin/gn && \
+    popd
+
 RUN mkdir /build /source
 COPY . /envoy-sources/
 RUN bash -c "pushd /envoy-sources && $BUILD_CMD"

--- a/tools/envoy/Dockerfile.build-centos7.dockerignore
+++ b/tools/envoy/Dockerfile.build-centos7.dockerignore
@@ -1,0 +1,3 @@
+# Overrides standard .dockerignore file from the project's root directory.
+# It's important to have it empty because we're running 'docker build' with envoy's
+# source directory as a workspace and by default it's $TMPDIR/envoy-sources.

--- a/tools/envoy/Dockerfile.build-centos7.dockerignore
+++ b/tools/envoy/Dockerfile.build-centos7.dockerignore
@@ -1,0 +1,2 @@
+*
+!out/envoy-sources

--- a/tools/envoy/Dockerfile.build-centos7.dockerignore
+++ b/tools/envoy/Dockerfile.build-centos7.dockerignore
@@ -1,2 +1,0 @@
-*
-!out/envoy-sources

--- a/tools/envoy/Dockerfile.build-ubuntu
+++ b/tools/envoy/Dockerfile.build-ubuntu
@@ -1,0 +1,14 @@
+ARG ENVOY_BUILD_IMAGE
+FROM $ENVOY_BUILD_IMAGE
+
+ARG BUILD_CMD
+
+RUN groupadd --gid $(id -g) -f envoygroup \
+  && useradd -o --uid $(id -u) --gid $(id -g) --no-create-home --home-dir /build envoybuild \
+  && usermod -a -G pcap envoybuild \
+  && mkdir /build /source \
+  && chown envoybuild:envoygroup /build /source
+
+COPY out/envoy-sources /envoy-sources
+
+RUN sudo -EHs -u envoybuild bash -c "pushd /envoy-sources && $BUILD_CMD"

--- a/tools/envoy/Dockerfile.build-ubuntu
+++ b/tools/envoy/Dockerfile.build-ubuntu
@@ -9,6 +9,5 @@ RUN groupadd --gid $(id -g) -f envoygroup \
   && mkdir /build /source \
   && chown envoybuild:envoygroup /build /source
 
-COPY out/envoy-sources /envoy-sources
-
+COPY . /envoy-sources/
 RUN sudo -EHs -u envoybuild bash -c "pushd /envoy-sources && $BUILD_CMD"

--- a/tools/envoy/Dockerfile.build-ubuntu.dockerignore
+++ b/tools/envoy/Dockerfile.build-ubuntu.dockerignore
@@ -1,0 +1,3 @@
+# Overrides standard .dockerignore file from the project's root directory.
+# It's important to have it empty because we're running 'docker build' with envoy's
+# source directory as a workspace and by default it's $TMPDIR/envoy-sources.

--- a/tools/envoy/Dockerfile.build-ubuntu.dockerignore
+++ b/tools/envoy/Dockerfile.build-ubuntu.dockerignore
@@ -1,0 +1,2 @@
+*
+!out/envoy-sources

--- a/tools/envoy/Dockerfile.build-ubuntu.dockerignore
+++ b/tools/envoy/Dockerfile.build-ubuntu.dockerignore
@@ -1,2 +1,0 @@
-*
-!out/envoy-sources

--- a/tools/envoy/README.md
+++ b/tools/envoy/README.md
@@ -2,7 +2,7 @@
 
 The current directory contains tools for building, publishing and fetching Envoy binaries.
 
-There is a new Makefile target `build/envoy` that places an `envoy` binary in `build/artifacts-$OS-$ARCH/` directory.
+There is a new Makefile target `build/envoy` that places an `envoy` binary in `build/artifacts-$GOOS-$GOARCH/` directory.
 The default behaviour of that target – fetching binaries from [download.konghq.com](download.konghq.com) since it makes more sense for
 overwhelming majority of users. However, there is a variable `BUILD_ENVOY_FROM_SOURCES` that allows to build Envoy from 
 source code. 

--- a/tools/envoy/README.md
+++ b/tools/envoy/README.md
@@ -1,0 +1,40 @@
+# Tools for Envoy
+
+The current directory contains tools for building, publishing and fetching Envoy binaries.
+
+There is a new Makefile target `build/envoy` that places an `envoy` binary in `build/artifacts-$OS-$ARCH/` directory.
+The default behaviour of that target – fetching binaries from [download.konghq.com](download.konghq.com) since it makes more sense for
+overwhelming majority of users. However, there is a variable `BUILD_ENVOY_FROM_SOURCES` that allows to build Envoy from 
+source code. 
+
+### Usage
+
+Download the latest supported Envoy binary for your host OS: 
+```shell
+$ make build/envoy
+```
+
+Download the latest supported Envoy binary for specified system:
+```shell
+$ GOOS=linux make build/envoy # supported OS: linux, centos7 and darwin
+```
+
+Download the specific Envoy tag:
+```shell
+$ ENVOY_TAG=v1.18.4 make build/envoy
+```
+
+Download the specific Envoy commit hash (if it exists in [download.konghq.com](download.konghq.com)):
+```shell
+$ ENVOY_COMMIT_HASH=bef18019d8fc33a4ed6aca3679aff2100241ac5e make build/envoy
+```
+
+If desired commit hash doesn't exist, it could be built from sources:
+```shell
+$ ENVOY_COMMIT_HASH=bef18019d8fc33a4ed6aca3679aff2100241ac5e BUILD_ENVOY_FROM_SOURCES=true make build/envoy
+```
+
+When building from sources its still possible to specify OS:
+```shell
+$ GOOS=linux ENVOY_COMMIT_HASH=bef18019d8fc33a4ed6aca3679aff2100241ac5e BUILD_ENVOY_FROM_SOURCES=true make build/envoy
+```

--- a/tools/envoy/build_centos7.sh
+++ b/tools/envoy/build_centos7.sh
@@ -12,7 +12,7 @@ SOURCE_DIR="${SOURCE_DIR}" ./tools/envoy/fetch_sources.sh
 
 BUILD_CMD=${BUILD_CMD:-"BAZEL_BUILD_EXTRA_OPTIONS=\"${BAZEL_BUILD_EXTRA_OPTIONS:-}\" ./ci/do_ci.sh bazel.release.server_only"}
 
-ENVOY_BUILD_SHA=$(curl --silent https://raw.githubusercontent.com/envoyproxy/envoy/"${ENVOY_TAG}"/.bazelrc | grep envoyproxy/envoy-build-ubuntu | sed -e 's#.*envoyproxy/envoy-build-ubuntu:\(.*\)#\1#'| uniq)
+ENVOY_BUILD_SHA=$(curl --fail --location --silent https://raw.githubusercontent.com/envoyproxy/envoy/"${ENVOY_TAG}"/.bazelrc | grep envoyproxy/envoy-build-ubuntu | sed -e 's#.*envoyproxy/envoy-build-ubuntu:\(.*\)#\1#'| uniq)
 ENVOY_BUILD_IMAGE="envoyproxy/envoy-build-centos:${ENVOY_BUILD_SHA}"
 LOCAL_BUILD_IMAGE="envoy-builder:${ENVOY_TAG}"
 

--- a/tools/envoy/build_centos7.sh
+++ b/tools/envoy/build_centos7.sh
@@ -1,19 +1,18 @@
 #!/bin/bash
 
-set -e
+set -o errexit
+set -o pipefail
+set -o nounset
 
 echo "Building Envoy for CentOS 7"
 
-BINARY_PATH=${BINARY_PATH:-"out/envoy"}
-BINARY_DIR=$(dirname ${BINARY_PATH})
-mkdir -p "${BINARY_DIR}"
+mkdir -p "$(dirname ${BINARY_PATH})"
 
-SOURCE_DIR=${SOURCE_DIR:-"out/envoy-sources"}
 SOURCE_DIR="${SOURCE_DIR}" ./tools/envoy/fetch_sources.sh
 
-BUILD_CMD=${BUILD_CMD:-"BAZEL_BUILD_EXTRA_OPTIONS=\"${BAZEL_BUILD_EXTRA_OPTIONS}\" ./ci/do_ci.sh bazel.release.server_only"}
+BUILD_CMD=${BUILD_CMD:-"BAZEL_BUILD_EXTRA_OPTIONS=\"${BAZEL_BUILD_EXTRA_OPTIONS:-}\" ./ci/do_ci.sh bazel.release.server_only"}
 
-ENVOY_BUILD_SHA=$(curl -s https://raw.githubusercontent.com/envoyproxy/envoy/"${ENVOY_TAG}"/.bazelrc | grep envoyproxy/envoy-build-ubuntu | sed -e 's#.*envoyproxy/envoy-build-ubuntu:\(.*\)#\1#'| uniq)
+ENVOY_BUILD_SHA=$(curl --silent https://raw.githubusercontent.com/envoyproxy/envoy/"${ENVOY_TAG}"/.bazelrc | grep envoyproxy/envoy-build-ubuntu | sed -e 's#.*envoyproxy/envoy-build-ubuntu:\(.*\)#\1#'| uniq)
 ENVOY_BUILD_IMAGE="envoyproxy/envoy-build-centos:${ENVOY_BUILD_SHA}"
 LOCAL_BUILD_IMAGE="envoy-builder:${ENVOY_TAG}"
 

--- a/tools/envoy/build_centos7.sh
+++ b/tools/envoy/build_centos7.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+set -e
+
+echo "Building Envoy for CentOS 7"
+
+BINARY_PATH=${BINARY_PATH:-"out/envoy"}
+BINARY_DIR=$(dirname ${BINARY_PATH})
+mkdir -p "${BINARY_DIR}"
+
+SOURCE_DIR=${SOURCE_DIR:-"out/envoy-sources"}
+SOURCE_DIR="${SOURCE_DIR}" ./tools/envoy/fetch_sources.sh
+
+BUILD_CMD=${BUILD_CMD:-"BAZEL_BUILD_EXTRA_OPTIONS=\"${BAZEL_BUILD_EXTRA_OPTIONS}\" ./ci/do_ci.sh bazel.release.server_only"}
+
+ENVOY_BUILD_SHA=$(curl -s https://raw.githubusercontent.com/envoyproxy/envoy/"${ENVOY_TAG}"/.bazelrc | grep envoyproxy/envoy-build-ubuntu | sed -e 's#.*envoyproxy/envoy-build-ubuntu:\(.*\)#\1#'| uniq)
+ENVOY_BUILD_IMAGE="envoyproxy/envoy-build-centos:${ENVOY_BUILD_SHA}"
+LOCAL_BUILD_IMAGE="envoy-builder:${ENVOY_TAG}"
+
+docker build -t "${LOCAL_BUILD_IMAGE}" --progress=plain \
+  --build-arg ENVOY_BUILD_IMAGE="${ENVOY_BUILD_IMAGE}" \
+  --build-arg BUILD_CMD="${BUILD_CMD}" \
+  -f tools/envoy/Dockerfile.build-centos7 .
+
+# copy out the binary
+id=$(docker create "${LOCAL_BUILD_IMAGE}")
+docker cp "$id":/envoy-sources/linux/amd64/build_release_stripped/envoy "${BINARY_PATH}"
+docker rm -v "$id"

--- a/tools/envoy/build_centos7.sh
+++ b/tools/envoy/build_centos7.sh
@@ -19,9 +19,9 @@ LOCAL_BUILD_IMAGE="envoy-builder:${ENVOY_TAG}"
 docker build -t "${LOCAL_BUILD_IMAGE}" --progress=plain \
   --build-arg ENVOY_BUILD_IMAGE="${ENVOY_BUILD_IMAGE}" \
   --build-arg BUILD_CMD="${BUILD_CMD}" \
-  -f tools/envoy/Dockerfile.build-centos7 .
+  -f tools/envoy/Dockerfile.build-centos7 "${SOURCE_DIR}"
 
 # copy out the binary
 id=$(docker create "${LOCAL_BUILD_IMAGE}")
-docker cp "$id":/envoy-sources/linux/amd64/build_release_stripped/envoy "${BINARY_PATH}"
+docker cp "$id":/envoy-sources/linux/amd64/build_envoy_release_stripped/envoy "${BINARY_PATH}"
 docker rm -v "$id"

--- a/tools/envoy/build_centos7.sh
+++ b/tools/envoy/build_centos7.sh
@@ -8,7 +8,7 @@ echo "Building Envoy for CentOS 7"
 
 mkdir -p "$(dirname ${BINARY_PATH})"
 
-SOURCE_DIR="${SOURCE_DIR}" ./tools/envoy/fetch_sources.sh
+SOURCE_DIR="${SOURCE_DIR}" "${KUMA_DIR:-.}/tools/envoy/fetch_sources.sh"
 
 BUILD_CMD=${BUILD_CMD:-"BAZEL_BUILD_EXTRA_OPTIONS=\"${BAZEL_BUILD_EXTRA_OPTIONS:-}\" ./ci/do_ci.sh bazel.release.server_only"}
 

--- a/tools/envoy/build_darwin.sh
+++ b/tools/envoy/build_darwin.sh
@@ -8,7 +8,7 @@ echo "Building Envoy for Darwin"
 
 mkdir -p "$(dirname ${BINARY_PATH})"
 
-SOURCE_DIR="${SOURCE_DIR}" ./tools/envoy/fetch_sources.sh
+SOURCE_DIR="${SOURCE_DIR}" "${KUMA_DIR:-.}/tools/envoy/fetch_sources.sh"
 
 pushd "${SOURCE_DIR}"
 

--- a/tools/envoy/build_darwin.sh
+++ b/tools/envoy/build_darwin.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+set -e
+
+echo "Building Envoy for Darwin"
+
+BINARY_PATH=${BINARY_PATH:-"out/envoy"}
+BINARY_DIR=$(dirname ${BINARY_PATH})
+mkdir -p "${BINARY_DIR}"
+
+SOURCE_DIR=${SOURCE_DIR:-"out/envoy-sources"}
+SOURCE_DIR="${SOURCE_DIR}" ./tools/envoy/fetch_sources.sh
+
+pushd "${SOURCE_DIR}"
+
+BAZEL_BUILD_EXTRA_OPTIONS=${BAZEL_BUILD_EXTRA_OPTIONS:-""}
+read -ra BAZEL_BUILD_EXTRA_OPTIONS <<< "${BAZEL_BUILD_EXTRA_OPTIONS}"
+BAZEL_BUILD_OPTIONS=(
+    "--curses=no"
+    --show_task_finish
+    --verbose_failures
+    "--action_env=PATH=/usr/local/bin:/opt/local/bin:/usr/bin:/bin"
+    "--define" "wasm=disabled"
+    "${BAZEL_BUILD_EXTRA_OPTIONS[@]}")
+bazel build "${BAZEL_BUILD_OPTIONS[@]}" -c opt //source/exe:envoy-static
+
+popd
+
+cp ${SOURCE_DIR}/bazel-bin/source/exe/envoy-static ${BINARY_PATH}
+

--- a/tools/envoy/build_darwin.sh
+++ b/tools/envoy/build_darwin.sh
@@ -1,14 +1,13 @@
 #!/bin/bash
 
-set -e
+set -o errexit
+set -o pipefail
+set -o nounset
 
 echo "Building Envoy for Darwin"
 
-BINARY_PATH=${BINARY_PATH:-"out/envoy"}
-BINARY_DIR=$(dirname ${BINARY_PATH})
-mkdir -p "${BINARY_DIR}"
+mkdir -p "$(dirname ${BINARY_PATH})"
 
-SOURCE_DIR=${SOURCE_DIR:-"out/envoy-sources"}
 SOURCE_DIR="${SOURCE_DIR}" ./tools/envoy/fetch_sources.sh
 
 pushd "${SOURCE_DIR}"
@@ -21,7 +20,7 @@ BAZEL_BUILD_OPTIONS=(
     --verbose_failures
     "--action_env=PATH=/usr/local/bin:/opt/local/bin:/usr/bin:/bin"
     "--define" "wasm=disabled"
-    "${BAZEL_BUILD_EXTRA_OPTIONS[@]}")
+    "${BAZEL_BUILD_EXTRA_OPTIONS[@]+"${BAZEL_BUILD_EXTRA_OPTIONS[@]}"}")
 bazel build "${BAZEL_BUILD_OPTIONS[@]}" -c opt //source/exe:envoy-static
 
 popd

--- a/tools/envoy/build_linux.sh
+++ b/tools/envoy/build_linux.sh
@@ -21,9 +21,9 @@ echo "BUILD_CMD=${BUILD_CMD}"
 docker build -t "${LOCAL_BUILD_IMAGE}" --progress=plain \
   --build-arg ENVOY_BUILD_IMAGE="${ENVOY_BUILD_IMAGE}" \
   --build-arg BUILD_CMD="${BUILD_CMD}" \
-  -f tools/envoy/Dockerfile.build-ubuntu .
+  -f tools/envoy/Dockerfile.build-ubuntu "${SOURCE_DIR}"
 
 # copy out the binary
 id=$(docker create "${LOCAL_BUILD_IMAGE}")
-docker cp "$id":/envoy-sources/linux/amd64/build_release_stripped/envoy "${BINARY_PATH}"
+docker cp "$id":/envoy-sources/linux/amd64/build_envoy_release_stripped/envoy "${BINARY_PATH}"
 docker rm -v "$id"

--- a/tools/envoy/build_linux.sh
+++ b/tools/envoy/build_linux.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+set -e
+
+echo "Building Envoy for Linux"
+
+BINARY_PATH=${BINARY_PATH:-"out/envoy"}
+BINARY_DIR=$(dirname ${BINARY_PATH})
+mkdir -p "${BINARY_DIR}"
+
+SOURCE_DIR=${SOURCE_DIR:-"out/envoy-sources"}
+SOURCE_DIR="${SOURCE_DIR}" ./tools/envoy/fetch_sources.sh
+
+BUILD_CMD=${BUILD_CMD:-"BAZEL_BUILD_EXTRA_OPTIONS=\"${BAZEL_BUILD_EXTRA_OPTIONS}\" ./ci/do_ci.sh bazel.release.server_only"}
+
+ENVOY_BUILD_SHA=$(curl -s https://raw.githubusercontent.com/envoyproxy/envoy/"${ENVOY_TAG}"/.bazelrc | grep envoyproxy/envoy-build-ubuntu | sed -e 's#.*envoyproxy/envoy-build-ubuntu:\(.*\)#\1#'| uniq)
+ENVOY_BUILD_IMAGE="envoyproxy/envoy-build-ubuntu:${ENVOY_BUILD_SHA}"
+LOCAL_BUILD_IMAGE="envoy-builder:${ENVOY_TAG}"
+
+echo "BUILD_CMD=${BUILD_CMD}"
+
+docker build -t "${LOCAL_BUILD_IMAGE}" --progress=plain \
+  --build-arg ENVOY_BUILD_IMAGE="${ENVOY_BUILD_IMAGE}" \
+  --build-arg BUILD_CMD="${BUILD_CMD}" \
+  -f tools/envoy/Dockerfile.build-ubuntu .
+
+# copy out the binary
+id=$(docker create "${LOCAL_BUILD_IMAGE}")
+docker cp "$id":/envoy-sources/linux/amd64/build_release_stripped/envoy "${BINARY_PATH}"
+docker rm -v "$id"

--- a/tools/envoy/build_linux.sh
+++ b/tools/envoy/build_linux.sh
@@ -8,7 +8,7 @@ echo "Building Envoy for Linux"
 
 mkdir -p "$(dirname ${BINARY_PATH})"
 
-SOURCE_DIR="${SOURCE_DIR}" ./tools/envoy/fetch_sources.sh
+SOURCE_DIR="${SOURCE_DIR}" "${KUMA_DIR:-.}/tools/envoy/fetch_sources.sh"
 
 BUILD_CMD=${BUILD_CMD:-"BAZEL_BUILD_EXTRA_OPTIONS=\"${BAZEL_BUILD_EXTRA_OPTIONS:-}\" ./ci/do_ci.sh bazel.release.server_only"}
 

--- a/tools/envoy/build_linux.sh
+++ b/tools/envoy/build_linux.sh
@@ -12,7 +12,7 @@ SOURCE_DIR="${SOURCE_DIR}" ./tools/envoy/fetch_sources.sh
 
 BUILD_CMD=${BUILD_CMD:-"BAZEL_BUILD_EXTRA_OPTIONS=\"${BAZEL_BUILD_EXTRA_OPTIONS:-}\" ./ci/do_ci.sh bazel.release.server_only"}
 
-ENVOY_BUILD_SHA=$(curl --silent https://raw.githubusercontent.com/envoyproxy/envoy/"${ENVOY_TAG}"/.bazelrc | grep envoyproxy/envoy-build-ubuntu | sed -e 's#.*envoyproxy/envoy-build-ubuntu:\(.*\)#\1#'| uniq)
+ENVOY_BUILD_SHA=$(curl --fail --location --silent https://raw.githubusercontent.com/envoyproxy/envoy/"${ENVOY_TAG}"/.bazelrc | grep envoyproxy/envoy-build-ubuntu | sed -e 's#.*envoyproxy/envoy-build-ubuntu:\(.*\)#\1#'| uniq)
 ENVOY_BUILD_IMAGE="envoyproxy/envoy-build-ubuntu:${ENVOY_BUILD_SHA}"
 LOCAL_BUILD_IMAGE="envoy-builder:${ENVOY_TAG}"
 

--- a/tools/envoy/build_linux.sh
+++ b/tools/envoy/build_linux.sh
@@ -1,19 +1,18 @@
 #!/bin/bash
 
-set -e
+set -o errexit
+set -o pipefail
+set -o nounset
 
 echo "Building Envoy for Linux"
 
-BINARY_PATH=${BINARY_PATH:-"out/envoy"}
-BINARY_DIR=$(dirname ${BINARY_PATH})
-mkdir -p "${BINARY_DIR}"
+mkdir -p "$(dirname ${BINARY_PATH})"
 
-SOURCE_DIR=${SOURCE_DIR:-"out/envoy-sources"}
 SOURCE_DIR="${SOURCE_DIR}" ./tools/envoy/fetch_sources.sh
 
-BUILD_CMD=${BUILD_CMD:-"BAZEL_BUILD_EXTRA_OPTIONS=\"${BAZEL_BUILD_EXTRA_OPTIONS}\" ./ci/do_ci.sh bazel.release.server_only"}
+BUILD_CMD=${BUILD_CMD:-"BAZEL_BUILD_EXTRA_OPTIONS=\"${BAZEL_BUILD_EXTRA_OPTIONS:-}\" ./ci/do_ci.sh bazel.release.server_only"}
 
-ENVOY_BUILD_SHA=$(curl -s https://raw.githubusercontent.com/envoyproxy/envoy/"${ENVOY_TAG}"/.bazelrc | grep envoyproxy/envoy-build-ubuntu | sed -e 's#.*envoyproxy/envoy-build-ubuntu:\(.*\)#\1#'| uniq)
+ENVOY_BUILD_SHA=$(curl --silent https://raw.githubusercontent.com/envoyproxy/envoy/"${ENVOY_TAG}"/.bazelrc | grep envoyproxy/envoy-build-ubuntu | sed -e 's#.*envoyproxy/envoy-build-ubuntu:\(.*\)#\1#'| uniq)
 ENVOY_BUILD_IMAGE="envoyproxy/envoy-build-ubuntu:${ENVOY_BUILD_SHA}"
 LOCAL_BUILD_IMAGE="envoy-builder:${ENVOY_TAG}"
 

--- a/tools/envoy/fetch.sh
+++ b/tools/envoy/fetch.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+
+# This script fetches Envoy binary from download.konghq.com
+#
+# Requires:
+# - $BINARY_PATH, path where binary will be fetched, for example 'out/envoy'
+# - $ENVOY_DISTRO, name of the distributive (i.e darwin, linux)
+#
+# Optional:
+# - $ENVOY_TAG, git tag to reference specific revision
+# - $ENVOY_COMMIT_HASH, hash of the git commit. If specified, then $ENVOY_TAG will be ignored
+#
+# at least one of $ENVOY_TAG or $ENVOY_COMMIT_HASH should be specified
+
+set -e
+
+function msg_red() {
+  builtin echo -en "\033[1;31m" >&2
+  echo "$@" >&2
+  builtin echo -en "\033[0m" >&2
+}
+
+function msg_err() {
+  msg_red "$@"
+  exit 1
+}
+
+function download_envoy() {
+    local binary_name=$1
+    echo "Downloading ${binary_name}"
+
+    local status=$(curl -# -L -o "${BINARY_PATH}" --write-out %{http_code} --output /dev/null \
+    "https://download.konghq.com/mesh-alpine/${binary_name}")
+
+  [ -f "${BINARY_PATH}" ] && chmod +x "${BINARY_PATH}"
+  [ "$status" -ne "200" ] && msg_err "Error: failed downloading Envoy" || true
+}
+
+[[ -z "${BINARY_PATH}" ]] && msg_err "Error: BINARY_PATH is not specified"
+[[ -z "${ENVOY_DISTRO}" ]] && msg_err "Error: ENVOY_DISTRO is not specified"
+[[ -z "${ENVOY_TAG}" ]] && [[ -z "${ENVOY_COMMIT_HASH}" ]] && msg_err "Error: either ENVOY_TAG or ENVOY_COMMIT_HASH should be specified"
+
+if [ "${ENVOY_DISTRO}" == "linux" ]; then
+  ENVOY_DISTRO="alpine"
+fi
+
+if [[ -n "${ENVOY_COMMIT_HASH}" ]]; then
+  ENVOY_SHORT_HASH=${ENVOY_COMMIT_HASH:0:8}
+  BINARY_NAME=$(curl -s https://download.konghq.com/mesh-alpine/ \
+    | grep "${ENVOY_SHORT_HASH}" | grep "${ENVOY_DISTRO}" | sed -e 's#.*<li><a href=".*">\(.*\)</a></li>#\1#')
+
+  download_envoy "${BINARY_NAME}"
+  exit 0
+fi
+
+if [[ -n "${ENVOY_TAG}" ]]; then
+  ENVOY_VERSION=${ENVOY_TAG:1}
+  BINARY_NAME="envoy-${ENVOY_VERSION}-${ENVOY_DISTRO}"
+
+  download_envoy "${BINARY_NAME}"
+  exit 0
+fi
+
+
+

--- a/tools/envoy/fetch.sh
+++ b/tools/envoy/fetch.sh
@@ -16,16 +16,7 @@ set -o errexit
 set -o pipefail
 set -o nounset
 
-function msg_red() {
-  builtin echo -en "\033[1;31m" >&2
-  echo "$@" >&2
-  builtin echo -en "\033[0m" >&2
-}
-
-function msg_err() {
-  msg_red "$@"
-  exit 1
-}
+source "$(dirname "$(dirname "$0")")/common.sh" # relative path to ../common.sh
 
 function download_envoy() {
     local binary_name=$1

--- a/tools/envoy/fetch.sh
+++ b/tools/envoy/fetch.sh
@@ -16,7 +16,7 @@ set -o errexit
 set -o pipefail
 set -o nounset
 
-source "$(dirname "$(dirname "$0")")/common.sh" # relative path to ../common.sh
+source "$(dirname -- "${BASH_SOURCE[0]}")/../common.sh"
 
 function download_envoy() {
     local binary_name=$1

--- a/tools/envoy/fetch_sources.sh
+++ b/tools/envoy/fetch_sources.sh
@@ -15,7 +15,7 @@ set -o errexit
 set -o pipefail
 set -o nounset
 
-source "$(dirname "$(dirname "$0")")/common.sh" # relative path to ../common.sh
+source "$(dirname -- "${BASH_SOURCE[0]}")/../common.sh"
 
 ENVOY_TAG=${ENVOY_TAG:-}
 ENVOY_COMMIT_HASH=${ENVOY_COMMIT_HASH:-}

--- a/tools/envoy/fetch_sources.sh
+++ b/tools/envoy/fetch_sources.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+# This script fetches Envoy source code to $SOURCE_DIR
+#
+# Requires:
+# - $SOURCE_DIR, a directory where sources will be placed
+#
+# Optional:
+# - $ENVOY_TAG, git tag to reference specific revision
+# - $ENVOY_COMMIT_HASH, hash of the git commit. If specified, then $ENVOY_TAG will be ignored
+#
+# at least one of $ENVOY_TAG or $ENVOY_COMMIT_HASH should be specified
+set -e
+
+function msg_red() {
+  builtin echo -en "\033[1;31m" >&2
+  echo "$@" >&2
+  builtin echo -en "\033[0m" >&2
+}
+
+function msg_err() {
+  msg_red "$@"
+  exit 1
+}
+
+[[ -z "${SOURCE_DIR}" ]] && msg_err "Error: SOURCE_DIR is not specified"
+[[ -z "${ENVOY_TAG}" ]] && [[ -z "${ENVOY_COMMIT_HASH}" ]] && msg_err "Error: either ENVOY_TAG or ENVOY_COMMIT_HASH should be specified"
+
+# clone Envoy repo if not exists
+if [[ ! -d "${SOURCE_DIR}" ]]; then
+  git clone https://github.com/envoyproxy/envoy.git ${SOURCE_DIR}
+else
+  echo "Envoy source directory already exists, just fetching"
+  pushd ${SOURCE_DIR} && git fetch --all && popd
+fi
+
+pushd ${SOURCE_DIR}
+
+ENVOY_COMMIT_HASH=${ENVOY_COMMIT_HASH:-$(git rev-list -n 1 "${ENVOY_TAG}")}
+
+echo "ENVOY_TAG=${ENVOY_TAG}"
+echo "ENVOY_COMMIT_HASH=${ENVOY_COMMIT_HASH}"
+
+git reset --hard ${ENVOY_COMMIT_HASH}
+
+popd

--- a/tools/envoy/fetch_sources.sh
+++ b/tools/envoy/fetch_sources.sh
@@ -15,16 +15,7 @@ set -o errexit
 set -o pipefail
 set -o nounset
 
-function msg_red() {
-  builtin echo -en "\033[1;31m" >&2
-  echo "$@" >&2
-  builtin echo -en "\033[0m" >&2
-}
-
-function msg_err() {
-  msg_red "$@"
-  exit 1
-}
+source "$(dirname "$(dirname "$0")")/common.sh" # relative path to ../common.sh
 
 ENVOY_TAG=${ENVOY_TAG:-}
 ENVOY_COMMIT_HASH=${ENVOY_COMMIT_HASH:-}

--- a/tools/envoy/publish.sh
+++ b/tools/envoy/publish.sh
@@ -9,7 +9,7 @@ set -o errexit
 set -o pipefail
 set -o nounset
 
-source "$(dirname "$(dirname "$0")")/common.sh" # relative path to ../common.sh
+source "$(dirname -- "${BASH_SOURCE[0]}")/../common.sh"
 
 if [ $# -eq 0 ]; then
     echo "Usage: ./publish.sh path_to_envoy"

--- a/tools/envoy/publish.sh
+++ b/tools/envoy/publish.sh
@@ -9,10 +9,7 @@ set -o errexit
 set -o pipefail
 set -o nounset
 
-function msg_err() {
-  echo $@
-  exit 1
-}
+source "$(dirname "$(dirname "$0")")/common.sh" # relative path to ../common.sh
 
 if [ $# -eq 0 ]; then
     echo "Usage: ./publish.sh path_to_envoy"

--- a/tools/envoy/publish.sh
+++ b/tools/envoy/publish.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+# This script publishes binary passed to $1
+#
+# Requirements
+# * Docker
+
+set -e
+
+function msg_err() {
+  echo $@
+  exit 1
+}
+
+if [ $# -eq 0 ]; then
+    echo "Usage: ./publish.sh path_to_envoy"
+    echo "Example: ./publish.sh out/envoy-v1.20.0"
+    exit 1
+fi
+
+BINARY_PATH=$1
+
+PULP_HOST="https://api.pulp.konnect-prod.konghq.com"
+PULP_PACKAGE_TYPE="mesh"
+PULP_DIST_NAME="alpine"
+
+[ -z "$PULP_USERNAME" ] && msg_err "PULP_USERNAME required"
+[ -z "$PULP_PASSWORD" ] && msg_err "PULP_PASSWORD required"
+
+docker run --rm \
+        -e PULP_USERNAME=${PULP_USERNAME} -e PULP_PASSWORD=${PULP_PASSWORD} \
+        -e PULP_HOST=${PULP_HOST} \
+        -v "${PWD}":/files:ro -it kong/release-script \
+        --file /files/"${BINARY_PATH}" \
+        --package-type ${PULP_PACKAGE_TYPE} --dist-name ${PULP_DIST_NAME} --publish

--- a/tools/envoy/publish.sh
+++ b/tools/envoy/publish.sh
@@ -5,7 +5,9 @@
 # Requirements
 # * Docker
 
-set -e
+set -o errexit
+set -o pipefail
+set -o nounset
 
 function msg_err() {
   echo $@
@@ -28,7 +30,8 @@ PULP_DIST_NAME="alpine"
 [ -z "$PULP_PASSWORD" ] && msg_err "PULP_PASSWORD required"
 
 docker run --rm \
-        -e PULP_USERNAME=${PULP_USERNAME} -e PULP_PASSWORD=${PULP_PASSWORD} \
+        -e PULP_USERNAME=${PULP_USERNAME} \
+        -e PULP_PASSWORD=${PULP_PASSWORD} \
         -e PULP_HOST=${PULP_HOST} \
         -v "${PWD}":/files:ro -it kong/release-script \
         --file /files/"${BINARY_PATH}" \

--- a/tools/releases/distros.sh
+++ b/tools/releases/distros.sh
@@ -2,6 +2,8 @@
 
 set -e
 
+source "$(dirname "$(dirname "$0")")/common.sh" # relative path to ../common.sh
+
 GOARCH=(amd64)
 
 # first component is the distribution name, second is the system - must map to
@@ -14,35 +16,6 @@ PULP_DIST_NAME="alpine"
 [ -z "$RELEASE_NAME" ] && RELEASE_NAME="kuma"
 ENVOY_VERSION=1.18.4
 [ -z "$KUMA_CONFIG_PATH" ] && KUMA_CONFIG_PATH=pkg/config/app/kuma-cp/kuma-cp.defaults.yaml
-
-function msg_green() {
-  builtin echo -en "\033[1;32m"
-  echo "$@"
-  builtin echo -en "\033[0m"
-}
-
-function msg_red() {
-  builtin echo -en "\033[1;31m" >&2
-  echo "$@" >&2
-  builtin echo -en "\033[0m" >&2
-}
-
-function msg_yellow() {
-  builtin echo -en "\033[1;33m"
-  echo "$@"
-  builtin echo -en "\033[0m"
-}
-
-function msg() {
-  builtin echo -en "\033[1m"
-  echo "$@"
-  builtin echo -en "\033[0m"
-}
-
-function msg_err() {
-  msg_red $@
-  exit 1
-}
 
 function get_envoy() {
   local distro=$1

--- a/tools/releases/distros.sh
+++ b/tools/releases/distros.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-source "$(dirname "$(dirname "$0")")/common.sh" # relative path to ../common.sh
+source "$(dirname -- "${BASH_SOURCE[0]}")/../common.sh"
 
 GOARCH=(amd64)
 

--- a/tools/releases/docker.sh
+++ b/tools/releases/docker.sh
@@ -2,38 +2,11 @@
 
 set -e
 
+source "$(dirname "$(dirname "$0")")/common.sh" # relative path to ../common.sh
+
 [ -z "$KUMA_DOCKER_REPO" ] && KUMA_DOCKER_REPO="docker.io"
 [ -z "$KUMA_DOCKER_REPO_ORG" ] && KUMA_DOCKER_REPO_ORG=${KUMA_DOCKER_REPO}/kumahq
 KUMA_COMPONENTS=("kuma-cp" "kuma-dp" "kumactl" "kuma-init" "kuma-prometheus-sd")
-
-function msg_green() {
-  builtin echo -en "\033[1;32m"
-  echo "$@"
-  builtin echo -en "\033[0m"
-}
-
-function msg_red() {
-  builtin echo -en "\033[1;31m" >&2
-  echo "$@" >&2
-  builtin echo -en "\033[0m" >&2
-}
-
-function msg_yellow() {
-  builtin echo -en "\033[1;33m"
-  echo "$@"
-  builtin echo -en "\033[0m"
-}
-
-function msg() {
-  builtin echo -en "\033[1m"
-  echo "$@"
-  builtin echo -en "\033[0m"
-}
-
-function msg_err() {
-  msg_red "$@"
-  exit 1
-}
 
 function build() {
   for component in "${KUMA_COMPONENTS[@]}"; do

--- a/tools/releases/docker.sh
+++ b/tools/releases/docker.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-source "$(dirname "$(dirname "$0")")/common.sh" # relative path to ../common.sh
+source "$(dirname -- "${BASH_SOURCE[0]}")/../common.sh"
 
 [ -z "$KUMA_DOCKER_REPO" ] && KUMA_DOCKER_REPO="docker.io"
 [ -z "$KUMA_DOCKER_REPO_ORG" ] && KUMA_DOCKER_REPO_ORG=${KUMA_DOCKER_REPO}/kumahq

--- a/tools/releases/dockerfiles/Dockerfile.kuma-dp
+++ b/tools/releases/dockerfiles/Dockerfile.kuma-dp
@@ -1,8 +1,7 @@
 FROM frolvlad/alpine-glibc:alpine-3.14_glibc-2.33
 
-COPY --from=envoyproxy/envoy-alpine:v1.18.4 /usr/local/bin/envoy /usr/local/bin
-
 ADD $KUMA_ROOT/build/artifacts-linux-amd64/kuma-dp/kuma-dp /usr/bin
+ADD $KUMA_ROOT/build/artifacts-linux-amd64/envoy /usr/bin
 ADD $KUMA_ROOT/build/artifacts-linux-amd64/coredns/coredns /usr/bin
 
 COPY $KUMA_ROOT/tools/releases/templates/LICENSE \

--- a/tools/releases/dockerfiles/Dockerfile.kuma-dp
+++ b/tools/releases/dockerfiles/Dockerfile.kuma-dp
@@ -1,7 +1,7 @@
 FROM frolvlad/alpine-glibc:alpine-3.14_glibc-2.33
 
 ADD $KUMA_ROOT/build/artifacts-linux-amd64/kuma-dp/kuma-dp /usr/bin
-ADD $KUMA_ROOT/build/artifacts-linux-amd64/envoy /usr/bin
+ADD $KUMA_ROOT/build/artifacts-linux-amd64/envoy/envoy /usr/bin
 ADD $KUMA_ROOT/build/artifacts-linux-amd64/coredns/coredns /usr/bin
 
 COPY $KUMA_ROOT/tools/releases/templates/LICENSE \

--- a/tools/releases/dockerfiles/Dockerfile.kuma-dp.dockerignore
+++ b/tools/releases/dockerfiles/Dockerfile.kuma-dp.dockerignore
@@ -1,6 +1,7 @@
 *
 !build/artifacts-linux-amd64/kuma-dp/kuma-dp
 !build/artifacts-linux-amd64/coredns/coredns
+!build/artifacts-linux-amd64/envoy
 !tools/releases/templates/LICENSE
 !tools/releases/templates/NOTICE
 !tools/releases/templates/README

--- a/tools/releases/dockerfiles/Dockerfile.kuma-dp.dockerignore
+++ b/tools/releases/dockerfiles/Dockerfile.kuma-dp.dockerignore
@@ -1,7 +1,7 @@
 *
 !build/artifacts-linux-amd64/kuma-dp/kuma-dp
 !build/artifacts-linux-amd64/coredns/coredns
-!build/artifacts-linux-amd64/envoy
+!build/artifacts-linux-amd64/envoy/envoy
 !tools/releases/templates/LICENSE
 !tools/releases/templates/NOTICE
 !tools/releases/templates/README

--- a/tools/releases/helm.sh
+++ b/tools/releases/helm.sh
@@ -2,6 +2,8 @@
 
 set -e
 
+source "$(dirname "$(dirname "$0")")/common.sh" # relative path to ../common.sh
+
 [ -z "$GH_OWNER" ] && GH_OWNER="kumahq"
 [ -z "$GH_REPO" ] && GH_REPO="charts"
 CHARTS_REPO_URL="https://$GH_OWNER.github.io/$GH_REPO"
@@ -10,38 +12,6 @@ CHARTS_PACKAGE_PATH=".cr-release-packages"
 CHARTS_INDEX_FILE="index.yaml"
 GH_PAGES_BRANCH="gh-pages"
 [ -z "$GH_REPO_URL" ] && GH_REPO_URL="git@github.com:${GH_OWNER}/${GH_REPO}.git"
-
-function msg_green {
-  builtin echo -en "\033[1;32m"
-  echo "$@"
-  builtin echo -en "\033[0m"
-}
-
-function msg_red() {
-  builtin echo -en "\033[1;31m" >&2
-  echo "$@" >&2
-  builtin echo -en "\033[0m" >&2
-}
-
-
-function msg_yellow() {
-    builtin echo -en "\033[1;33m"
-    echo "$@"
-    builtin echo -en "\033[0m"
-}
-
-
-function msg() {
-    builtin echo -en "\033[1m"
-    echo "$@"
-    builtin echo -en "\033[0m"
-}
-
-
-function msg_err() {
-  msg_red $@
-  exit 1
-}
 
 function package {
   # First package all the charts

--- a/tools/releases/helm.sh
+++ b/tools/releases/helm.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-source "$(dirname "$(dirname "$0")")/common.sh" # relative path to ../common.sh
+source "$(dirname -- "${BASH_SOURCE[0]}")/../common.sh"
 
 [ -z "$GH_OWNER" ] && GH_OWNER="kumahq"
 [ -z "$GH_REPO" ] && GH_REPO="charts"


### PR DESCRIPTION
### Summary

Current PR introduces targets `make build/envoy` that allows to build and fetch Envoy binaries (see [README.md](https://github.com/kumahq/kuma/blob/6b19d6d4fe620bca2c3de36175b758df26fe2885/tools/envoy/README.md)).

Also, current PR changes the way `kuma-dp` image obtains Envoy binary. Previously we copied Envoy binary from `envoyproxy/envoy-alpine` image:
```
COPY --from=envoyproxy/envoy-alpine:v1.18.4 /usr/local/bin/envoy /usr/local/bin
```
Now we copy the binary from `build/artifact-*` directory:
```
ADD $KUMA_ROOT/build/artifacts-linux-amd64/envoy /usr/bin
```

In order for Envoy binary to appear in `build/artifacts-*` directory, we must call `make build/artifacts-darwin-amd64/envoy` target. This is not a `.PHONY` target which means it won't run if binary already exists. 

Target `build/artifacts-%-amd64/envoy` runs in 2 modes: fetch required binary from download.konghq.com or build the binary from source code. Modes could be switched using `BUILD_ENVOY_FROM_SOURCES` variable, default behavior is fetching so `BUILD_ENVOY_FROM_SOURCES=false`.

_Note: This PR doesn't affect CI or change the Envoy version. These changes will be presented in another PRs._

### Full changelog

* kuma-dp and kuma-universal images are built using Envoy binary fetched from download.konghq.com

### Issues resolved

N/A

### Documentation

- [ ] Link to the website [documentation PR](https://github.com/kumahq/kuma-website/pull/XXX)

### Testing

- [ ] Unit tests
- [ ] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes 

### Backwards compatibility

- [ ] Add `backport-to-stable` label if the code is backwards compatible. Otherwise, list breaking changes.
