### PR TITLE
fix(kuma-cp) create new object from resource descriptor

### DIFF
--- a/pkg/core/resources/apis/mesh/resource_descriptor_test.go
+++ b/pkg/core/resources/apis/mesh/resource_descriptor_test.go
@@ -1,0 +1,16 @@
+package mesh
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Resource Descriptor", func() {
+	It("should create new object from descriptor", func() {
+		Expect(NewDataplaneResource().Descriptor().NewObject()).ToNot(BeNil())
+	})
+
+	It("should create new list from descriptor", func() {
+		Expect(NewDataplaneResource().Descriptor().NewList()).ToNot(BeNil())
+	})
+})

--- a/pkg/core/resources/registry/registry.go
+++ b/pkg/core/resources/registry/registry.go
@@ -72,7 +72,7 @@ func (t *typeRegistry) RegisterType(res model.ResourceTypeDescriptor) error {
 	if previous, ok := t.descriptors[res.Name]; ok {
 		return errors.Errorf("duplicate registration of ResourceType under name %q: previous=%#v new=%#v", res.Name, previous, reflect.TypeOf(res.Resource).Elem().String())
 	}
-	t.descriptors[res.Name] = model.InitDescriptor(res)
+	t.descriptors[res.Name] = res
 	return nil
 }
 


### PR DESCRIPTION
### Summary

It is not an issue with the current code but it's a trap that we can easily fall into.

`ResourceDescriptor` has a method `NewObject()`, but in order to call it, it needs to set internal `objectType` and `listType` fields. Those fields are set by `InitDescriptor()` method which is only called when the descriptor is put into `ResourceRegistry`.

The problem is that the `ResourceDescriptor` can also be retrieved from `.Descriptor()` method of the object and this copy of an object does not contain initiated `objectType` and `listType` which results in panic.

I moved the retrieving resource type to `NewObject` itself, I don't think we should be able to create an object which requires extra initialization, especially if the object is copied around instead of passing a pointer.

The alternative would be to template `resource-gen` with `model.InitDescriptor` when the descriptor is generated in the code, but I don't like the fact we can create a struct that is not functional.

### Issues resolved

No issues.

### Documentation

- [X] No docs, internal changes.

### Testing

- [X] Unit tests
- [ ] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes 

### Backwards compatibility

- [X] No backporting
