### PR TITLE
fix(kuma-cp) correct conf key in mtls validation in mesh

### DIFF
--- a/pkg/core/managers/apis/mesh/mesh_manager_test.go
+++ b/pkg/core/managers/apis/mesh/mesh_manager_test.go
@@ -203,7 +203,7 @@ var _ = Describe("Mesh Manager", func() {
 			err := resManager.Create(context.Background(), &mesh, store.CreateBy(resKey))
 
 			// then
-			Expect(err).To(MatchError("mtls.backends[0].config.cert: has to be defined; mtls.backends[0].config.key: has to be defined"))
+			Expect(err).To(MatchError("mtls.backends[0].conf.cert: has to be defined; mtls.backends[0].conf.key: has to be defined"))
 		})
 	})
 

--- a/pkg/core/managers/apis/mesh/mesh_validator.go
+++ b/pkg/core/managers/apis/mesh/mesh_validator.go
@@ -47,7 +47,7 @@ func ValidateMTLSBackends(ctx context.Context, caManagers core_ca.Managers, name
 			return verr.OrNil()
 		} else if err := caManager.ValidateBackend(ctx, name, backend); err != nil {
 			if configErr, ok := err.(*validators.ValidationError); ok {
-				verr.AddErrorAt(path.Index(idx).Field("config"), *configErr)
+				verr.AddErrorAt(path.Index(idx).Field("conf"), *configErr)
 			} else {
 				verr.AddViolationAt(path.Index(idx), err.Error())
 				return err


### PR DESCRIPTION
we were using config instead of conf which was incorrect

### Backwards compatibility

- [x] Add `backport-to-stable` label if the code is backwards compatible. Otherwise, list breaking changes.
