### PR TITLE
chore(kumactl) remove install CRDs filter function

### DIFF
--- a/app/kumactl/cmd/install/context/install_crds_context.go
+++ b/app/kumactl/cmd/install/context/install_crds_context.go
@@ -34,16 +34,5 @@ func DefaultInstallCrdsContext() InstallCrdsContext {
 
 			return crdFiles, nil
 		},
-		FilterCrdNamesToInstall: func(names []string) []string {
-			var result []string
-
-			for _, name := range names {
-				if strings.HasSuffix(name, "kuma.io") {
-					result = append(result, name)
-				}
-			}
-
-			return result
-		},
 	}
 }

--- a/app/kumactl/cmd/install/install_crds.go
+++ b/app/kumactl/cmd/install/install_crds.go
@@ -57,8 +57,7 @@ func newInstallCrdsCmd(ctx *install_context.InstallCrdsContext) *cobra.Command {
 				return errors.Wrap(err, "Failed obtaining CRDs from Kubernetes cluster")
 			}
 
-			installedCrds := ctx.FilterCrdNamesToInstall(getCrdNamesFromList(crds))
-			for _, installedCrdName := range installedCrds {
+			for _, installedCrdName := range getCrdNamesFromList(crds) {
 				delete(crdsToInstallMap, installedCrdName)
 			}
 


### PR DESCRIPTION
### Summary

When kumactl tries to install CRDs that aren't already present, we don't
need to filter the names of the CRDs that are already installed to. The
map of installation candidates already contains only Kuma CRDs, and if we
attempt to delete an entry that is not present, that's a harmless no-op.

### Full changelog

N/A

### Issues resolved

N/A

### Documentation

N/A

### Testing

- [x] Unit tests
- [x] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes 

### Backwards compatibility

- [x] Add `backport-to-stable` label if the code is backwards compatible. Otherwise, list breaking changes.
