### PR TITLE
feat(kuma-dp) Add conf to disable service vip

### DIFF
--- a/pkg/api-server/config_ws_test.go
+++ b/pkg/api-server/config_ws_test.go
@@ -98,7 +98,8 @@ var _ = Describe("Config WS", func() {
 		  "dnsServer": {
 			"CIDR": "240.0.0.0/4",
 			"domain": "mesh",
-			"port": 5653
+			"port": 5653,
+			"serviceVipEnabled": true
 		  },
 		  "dpServer": {
 			"auth": {

--- a/pkg/config/app/kuma-cp/kuma-cp.defaults.yaml
+++ b/pkg/config/app/kuma-cp/kuma-cp.defaults.yaml
@@ -315,6 +315,8 @@ dnsServer:
   port: 5653 # ENV: KUMA_DNS_SERVER_PORT
   # The CIDR range used to allocate
   CIDR: "240.0.0.0/4" # ENV: KUMA_DNS_SERVER_CIDR
+  # Will create a service "<kuma.io/service>.mesh" dns entry for every service.
+  serviceVipEnabled: true # ENV: KUMA_DNS_SERVER_SERVICE_VIP_ENABLED
 
 # Multizone mode
 multizone:

--- a/pkg/config/dns-server/config.go
+++ b/pkg/config/dns-server/config.go
@@ -15,6 +15,8 @@ type DNSServerConfig struct {
 	Port uint32 `yaml:"port" envconfig:"kuma_dns_server_port"`
 	// CIDR used to allocate virtual IPs from
 	CIDR string `yaml:"CIDR" envconfig:"kuma_dns_server_cidr"`
+	// ServiceVipEnabled will create a service "<kuma.io/service>.mesh" dns entry for every service.
+	ServiceVipEnabled bool `yaml:"serviceVipEnabled" envconfig:"kuma_dns_server_service_vip_enabled"`
 }
 
 func (g *DNSServerConfig) Sanitize() {
@@ -35,8 +37,9 @@ var _ config.Config = &DNSServerConfig{}
 
 func DefaultDNSServerConfig() *DNSServerConfig {
 	return &DNSServerConfig{
-		Domain: "mesh",
-		Port:   5653,
-		CIDR:   "240.0.0.0/4",
+		ServiceVipEnabled: true,
+		Domain:            "mesh",
+		Port:              5653,
+		CIDR:              "240.0.0.0/4",
 	}
 }

--- a/pkg/config/loader_test.go
+++ b/pkg/config/loader_test.go
@@ -212,6 +212,7 @@ var _ = Describe("Config loader", func() {
 			Expect(cfg.DNSServer.Domain).To(Equal("test-domain"))
 			Expect(cfg.DNSServer.Port).To(Equal(uint32(15653)))
 			Expect(cfg.DNSServer.CIDR).To(Equal("127.1.0.0/16"))
+			Expect(cfg.DNSServer.ServiceVipEnabled).To(BeFalse())
 
 			Expect(cfg.XdsServer.DataplaneStatusFlushInterval).To(Equal(7 * time.Second))
 			Expect(cfg.XdsServer.DataplaneConfigurationRefreshInterval).To(Equal(21 * time.Second))
@@ -404,6 +405,7 @@ dnsServer:
   domain: test-domain
   port: 15653
   CIDR: 127.1.0.0/16
+  serviceVipEnabled: false
 defaults:
   skipMeshCreation: true
 diagnostics:
@@ -550,6 +552,7 @@ access:
 				"KUMA_DNS_SERVER_DOMAIN":                                                                   "test-domain",
 				"KUMA_DNS_SERVER_PORT":                                                                     "15653",
 				"KUMA_DNS_SERVER_CIDR":                                                                     "127.1.0.0/16",
+				"KUMA_DNS_SERVER_SERVICE_VIP_ENABLED":                                                      "false",
 				"KUMA_MODE":                                                                                "zone",
 				"KUMA_MULTIZONE_GLOBAL_KDS_GRPC_PORT":                                                      "1234",
 				"KUMA_MULTIZONE_GLOBAL_KDS_REFRESH_INTERVAL":                                               "2s",

--- a/pkg/dns/vips_synchronizer_test.go
+++ b/pkg/dns/vips_synchronizer_test.go
@@ -32,7 +32,7 @@ var _ = Describe("DNS sync", func() {
 		cfgManager := config_manager.NewConfigManager(memory)
 		dnsResolver = resolver.NewDNSResolver("mesh")
 
-		vipAllocator, err := dns.NewVIPsAllocator(resManager, cfgManager, "240.0.0.0/24", dnsResolver)
+		vipAllocator, err := dns.NewVIPsAllocator(resManager, cfgManager, true, "240.0.0.0/24", dnsResolver)
 		Expect(err).ToNot(HaveOccurred())
 		go func() {
 			Expect(vipAllocator.Start(stop)).ToNot(HaveOccurred())

--- a/pkg/plugins/runtime/k8s/plugin.go
+++ b/pkg/plugins/runtime/k8s/plugin.go
@@ -180,6 +180,7 @@ func addDNS(mgr kube_ctrl.Manager, rt core_runtime.Runtime, converter k8s_common
 	vipsAllocator, err := dns.NewVIPsAllocator(
 		rt.ResourceManager(),
 		rt.ConfigManager(),
+		rt.Config().DNSServer.ServiceVipEnabled,
 		rt.Config().DNSServer.CIDR,
 		rt.DNSResolver(),
 	)

--- a/pkg/plugins/runtime/universal/plugin.go
+++ b/pkg/plugins/runtime/universal/plugin.go
@@ -31,6 +31,7 @@ func addDNS(rt core_runtime.Runtime) error {
 	vipsAllocator, err := dns.NewVIPsAllocator(
 		rt.ReadOnlyResourceManager(),
 		rt.ConfigManager(),
+		rt.Config().DNSServer.ServiceVipEnabled,
 		rt.Config().DNSServer.CIDR,
 		rt.DNSResolver(),
 	)

--- a/test/e2e/virtualoutbound/virtualoutbound_k8s.go
+++ b/test/e2e/virtualoutbound/virtualoutbound_k8s.go
@@ -26,12 +26,15 @@ metadata:
 	}
 
 	var k8sCluster Cluster
-	var optsKubernetes = KumaK8sDeployOpts
+	var optsKubernetes = append(KumaK8sDeployOpts,
+		WithEnv("KUMA_DNS_SERVER_SERVICE_VIP_ENABLED", "false"),
+	)
 
 	BeforeEach(func() {
 		c, err := NewK8SCluster(NewTestingT(), Kuma1, Silent)
 		Expect(err).ToNot(HaveOccurred())
 		k8sCluster = c
+
 		err = NewClusterSetup().
 			Install(Kuma(config_core.Standalone, optsKubernetes...)).
 			Install(YamlK8s(namespaceWithSidecarInjection(TestNamespace))).
@@ -48,6 +51,51 @@ metadata:
 		Expect(k8sCluster.DeleteKuma(optsKubernetes...)).To(Succeed())
 		Expect(k8sCluster.DeleteNamespace(TestNamespace)).To(Succeed())
 		Expect(k8sCluster.DismissCluster()).To(Succeed())
+	})
+
+	It("doesn't support default vips", func() {
+		virtualOutboundAll := `
+apiVersion: kuma.io/v1alpha1
+kind: VirtualOutbound
+mesh: default
+metadata:
+  name: instance
+spec:
+  selectors:
+  - match:
+      kuma.io/service: "*"
+  conf:
+    host: "{{.svc}}.foo"
+    port: "8080"
+    parameters:
+    - name: "svc"
+      tagKey: "kuma.io/service"
+`
+		err := YamlK8s(virtualOutboundAll)(k8sCluster)
+		Expect(err).ToNot(HaveOccurred())
+		// when client sends requests to server
+		pods, err := k8s.ListPodsE(
+			k8sCluster.GetTesting(),
+			k8sCluster.GetKubectlOptions(TestNamespace),
+			metav1.ListOptions{
+				LabelSelector: fmt.Sprintf("app=%s", "demo-client"),
+			},
+		)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(pods).To(HaveLen(1))
+
+		clientPod := pods[0]
+		// Succeed with virtual-outbound
+		stdout, stderr, err := k8sCluster.ExecWithRetries(TestNamespace, clientPod.GetName(), "demo-client",
+			"curl", "-v", "-m", "3", "--fail", "test-server_kuma-test_svc_80.foo:8080")
+		Expect(err).ToNot(HaveOccurred())
+		Expect(stderr).To(ContainSubstring("HTTP/1.1 200 OK"))
+		Expect(stdout).To(ContainSubstring(`"instance":"test-server`))
+
+		// Fails with built in vip (it's disabled in conf)
+		_, _, err = k8sCluster.Exec(TestNamespace, clientPod.GetName(), "demo-client",
+			"curl", "-v", "-m", "3", "--fail", "test-server_kuma-test_svc_80.mesh:80")
+		Expect(err).To(HaveOccurred())
 	})
 
 	It("virtual outbounds on statefulSet", func() {


### PR DESCRIPTION
Add a switch to make `<kuma.io/service>.mesh` generation optional.

Motivation:

- It is only useful in a restricted set of cases (mix universal/k8s, universal only...).
- It generates a lot of configuration (1 listener per service, entries in the dns filter...)
- VirtualOutbound can do all this and more

This adds a switch to turn the generation of these off.
In future versions we should remove it altogether and suggest generating specific virtual-outbound instead.

### Documentation

- [x] Link to the website [documentation PR](https://github.com/kumahq/kuma-website/pull/584)

### Testing

- [x] Unit tests
- [x] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes 

### Backwards compatibility

- [ ] Add `backport-to-stable` label if the code is backwards compatible. Otherwise, list breaking changes.
