### PR TITLE
Disable reporting by default (#3070)

### DIFF
--- a/pkg/api-server/config_ws_test.go
+++ b/pkg/api-server/config_ws_test.go
@@ -177,7 +177,7 @@ var _ = Describe("Config WS", func() {
 			}
 		  },
 		  "reports": {
-			"enabled": true
+			"enabled": false
 		  },
 		  "runtime": {
 			"kubernetes": {

--- a/pkg/config/app/kuma-cp/config.go
+++ b/pkg/config/app/kuma-cp/config.go
@@ -191,7 +191,7 @@ var DefaultConfig = func() Config {
 			},
 		},
 		Reports: &Reports{
-			Enabled: true,
+			Enabled: false,
 		},
 		General:     DefaultGeneralConfig(),
 		GuiServer:   gui_server.DefaultGuiServerConfig(),

--- a/pkg/config/app/kuma-cp/kuma-cp.defaults.yaml
+++ b/pkg/config/app/kuma-cp/kuma-cp.defaults.yaml
@@ -290,7 +290,7 @@ metrics:
 # Reports configuration
 reports:
   # If true then usage stats will be reported
-  enabled: true # ENV: KUMA_REPORTS_ENABLED
+  enabled: false # ENV: KUMA_REPORTS_ENABLED
 
 # General configuration
 general:


### PR DESCRIPTION
There is reporting code in Kuma that sends data to
kong-hf.konghq.com by default. This commit switches
the default to false for now.

Updates #3050.

Signed-off-by: Hart Hoover <hart.hoover@gmail.com>

### Backwards compatibility

- [x] Add `backport-to-stable` label if the code is backwards compatible. Otherwise, list breaking changes.
