### PR TITLE
fix(.github) use `pull_request_target` in GH workflow

### DIFF
--- a/.github/workflows/pr-merged.yaml
+++ b/.github/workflows/pr-merged.yaml
@@ -1,7 +1,7 @@
 name: "Notify about merged PRs"
 
 on:
-  pull_request:
+  pull_request_target:
     types: [closed]
     branches:
       - master


### PR DESCRIPTION
It's OK to use `pull_request_target` because we're not checking out/executing any code from forks.
See [the warning about this event type](https://docs.github.com/en/actions/learn-github-actions/events-that-trigger-workflows#pull_request_target)
