### PR TITLE
feat(ci) auto merge backport PRs after kuma-commit

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,9 +1,29 @@
 pull_request_rules:
-  - name: backport patches to stable branch
-    conditions:
-      - base=master
-      - label=backport-to-stable
-    actions:
-      backport:
-        branches:
-          - release-1.4
+- name: backport patches to stable branch
+  conditions:
+  - base=master
+  - label=backport-to-stable
+  actions:
+    backport:
+      branches:
+      - release-1.4
+
+- name: automatically approve backport PRs
+  conditions:
+  - and:
+    - base~=^release-.*
+    - title~=^(.*)\(backport \#(.*)\)$
+  actions:
+    review:
+      type: APPROVE
+      message: automatically approving backport PR
+
+- name: automatically merge backport PRs
+  conditions:
+  - and:
+    - base~=^release-.*
+    - title~=^(.*)\(backport \#(.*)\)$
+    - check-success=kuma-commit
+  actions:
+    merge:
+      method: squash


### PR DESCRIPTION
### Summary

It's unnecessary to have approval on backport PRs, as well when kuma-commit succeed we can safely merge the PR

### Full changelog

no changelog

### Issues resolved

no issue resolved

### Documentation

no documentation change

### Testing

- [ ] Unit tests
- [ ] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes 

### Backwards compatibility

- [x] Add `backport-to-stable` label if the code is backwards compatible. Otherwise, list breaking changes.
