### PR TITLE
fix(ci) disable auto approve backport prs

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -8,16 +8,6 @@ pull_request_rules:
       branches:
       - release-1.4
 
-- name: automatically approve backport PRs
-  conditions:
-  - and:
-    - base~=^release-.*
-    - title~=^(.*)\(backport \#(.*)\)$
-  actions:
-    review:
-      type: APPROVE
-      message: automatically approving backport PR
-
 - name: automatically merge backport PRs
   conditions:
   - and:


### PR DESCRIPTION
### Summary

As mergify is the autor of this PRs it cannot aprove its own PRs

### Full changelog

no changelog

### Issues resolved

no issue resolved

### Documentation

no documentation

### Testing

- [ ] Unit tests
- [ ] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes 

### Backwards compatibility

- [x] Add `backport-to-stable` label if the code is backwards compatible. Otherwise, list breaking changes.
