### PR TITLE
fix(kuma-dp) parse Envoy version

### DIFF
--- a/app/kuma-dp/pkg/dataplane/envoy/envoy.go
+++ b/app/kuma-dp/pkg/dataplane/envoy/envoy.go
@@ -226,10 +226,13 @@ func (e *Envoy) version() (*EnvoyVersion, error) {
 	build = regexp.MustCompile(`version:(.*)`).FindString(build)
 	build = strings.Trim(build, "version:")
 	build = strings.Trim(build, " ")
-	version := regexp.MustCompile(`/([0-9.]+)/`).FindString(build)
-	version = strings.Trim(version, "/")
+
+	parts := strings.Split(build, "/")
+	if len(parts) != 5 { // revision/build_version_number/revision_status/build_type/ssl_version
+		return nil, errors.Errorf("wrong Envoy build format: %s", build)
+	}
 	return &EnvoyVersion{
 		Build:   build,
-		Version: version,
+		Version: parts[1],
 	}, nil
 }

--- a/app/kuma-dp/pkg/dataplane/envoy/envoy_test.go
+++ b/app/kuma-dp/pkg/dataplane/envoy/envoy_test.go
@@ -279,6 +279,30 @@ var _ = Describe("Envoy", func() {
 			Expect(version.Build).To(Equal("50ef0945fa2c5da4bff7627c3abf41fdd3b7cffd/1.15.0/clean-getenvoy-2aa564b-envoy/RELEASE/BoringSSL"))
 		})
 
+		It("should properly read envoy version with label for unix-based systems", func() {
+			// given
+			cfg := kuma_dp.Config{
+				DataplaneRuntime: kuma_dp.DataplaneRuntime{
+					BinaryPath: filepath.Join("testdata", "envoy-mock.with-label.sh"),
+					ConfigDir:  configDir,
+				},
+			}
+
+			// when
+			dataplane, err := New(Opts{
+				Config: cfg,
+				Stdout: &bytes.Buffer{},
+				Stderr: &bytes.Buffer{},
+			})
+			Expect(err).ToNot(HaveOccurred())
+			version, err := dataplane.version()
+
+			// then
+			Expect(err).ToNot(HaveOccurred())
+			Expect(version.Version).To(Equal("1.20.0-dev"))
+			Expect(version.Build).To(Equal("50ef0945fa2c5da4bff7627c3abf41fdd3b7cffd/1.20.0-dev/clean-getenvoy-2aa564b-envoy/RELEASE/BoringSSL"))
+		})
+
 		It("should properly read envoy version for windows", func() {
 			// given
 			cfg := kuma_dp.Config{

--- a/app/kuma-dp/pkg/dataplane/envoy/testdata/envoy-mock.with-label.sh
+++ b/app/kuma-dp/pkg/dataplane/envoy/testdata/envoy-mock.with-label.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+if [ "$1" = "--version" ];
+then
+  printf "\nenvoy  version: 50ef0945fa2c5da4bff7627c3abf41fdd3b7cffd/1.20.0-dev/clean-getenvoy-2aa564b-envoy/RELEASE/BoringSSL\n\n"
+  exit 0
+fi
+
+# print arguments to verify in the test
+echo $@


### PR DESCRIPTION
### Summary

Envoy version may have `label` - https://github.com/envoyproxy/envoy/blob/main/source/common/version/version.cc#L67, this PR adds support of such type of version

### Full changelog

* parse version with labels (i.e `1.20.1-dev`)

### Issues resolved

N/A

### Documentation

N/A

### Testing

- [ ] Unit tests
- [ ] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes 

### Backwards compatibility

- [ ] Add `backport-to-stable` label if the code is backwards compatible. Otherwise, list breaking changes.
