### PR TITLE
fix(kuma-cp) validate newly generated xDS snapshots

### DIFF
--- a/pkg/plugins/runtime/gateway/testdata/http/10-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/10-gateway-route.yaml
@@ -161,6 +161,7 @@ Routes:
               safeRegexMatch:
                 googleRe2: {}
                 regex: .*sh
+            prefix: /
           route:
             weightedClusters:
               clusters:
@@ -171,6 +172,7 @@ Routes:
             headers:
             - exactMatch: application/json
               name: Content-Type
+            prefix: /
           route:
             weightedClusters:
               clusters:
@@ -181,6 +183,7 @@ Routes:
             headers:
             - exactMatch: gibberish
               name: Language
+            prefix: /
           route:
             weightedClusters:
               clusters:

--- a/pkg/plugins/runtime/gateway/testdata/http/11-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/11-gateway-route.yaml
@@ -152,6 +152,7 @@ Routes:
         name: edge-gateway:HTTP:8080:echo.example.com
         routes:
         - match:
+            prefix: /
             queryParameters:
             - name: Content-Type
               stringMatch:
@@ -170,6 +171,7 @@ Routes:
                 weight: 1
               totalWeight: 1
         - match:
+            prefix: /
             queryParameters:
             - name: Content-Type
               stringMatch:
@@ -181,6 +183,7 @@ Routes:
                 weight: 1
               totalWeight: 1
         - match:
+            prefix: /
             queryParameters:
             - name: Language
               stringMatch:

--- a/pkg/plugins/runtime/gateway/testdata/https/10-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/10-gateway-route.yaml
@@ -190,6 +190,7 @@ Routes:
               safeRegexMatch:
                 googleRe2: {}
                 regex: .*sh
+            prefix: /
           route:
             weightedClusters:
               clusters:
@@ -200,6 +201,7 @@ Routes:
             headers:
             - exactMatch: application/json
               name: Content-Type
+            prefix: /
           route:
             weightedClusters:
               clusters:
@@ -210,6 +212,7 @@ Routes:
             headers:
             - exactMatch: gibberish
               name: Language
+            prefix: /
           route:
             weightedClusters:
               clusters:

--- a/pkg/plugins/runtime/gateway/testdata/https/11-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/11-gateway-route.yaml
@@ -181,6 +181,7 @@ Routes:
             value: max-age=31536000; includeSubDomains
         routes:
         - match:
+            prefix: /
             queryParameters:
             - name: Content-Type
               stringMatch:
@@ -199,6 +200,7 @@ Routes:
                 weight: 1
               totalWeight: 1
         - match:
+            prefix: /
             queryParameters:
             - name: Content-Type
               stringMatch:
@@ -210,6 +212,7 @@ Routes:
                 weight: 1
               totalWeight: 1
         - match:
+            prefix: /
             queryParameters:
             - name: Language
               stringMatch:

--- a/pkg/xds/server/v3/reconcile.go
+++ b/pkg/xds/server/v3/reconcile.go
@@ -37,33 +37,72 @@ func (r *reconciler) Reconcile(ctx xds_context.Context, proxy *model.Proxy) erro
 	node := &envoy_core.Node{Id: proxy.Id.String()}
 	snapshot, err := r.generator.GenerateSnapshot(ctx, proxy)
 	if err != nil {
-		reconcileLog.Error(err, "failed to generate a snapshot", "node", node, "proxy", proxy)
-		return err
+		return errors.Wrapf(err, "failed to generate a snapshot")
 	}
-	if err := snapshot.Consistent(); err != nil {
-		reconcileLog.Error(err, "inconsistent snapshot", "snapshot", snapshot, "proxy", proxy)
-	}
-	// to avoid assigning a new version every time,
-	// compare with the previous snapshot and reuse its version whenever possible,
+
+	// To avoid assigning a new version every time, compare with
+	// the previous snapshot and reuse its version whenever possible,
 	// fallback to UUID otherwise
 	previous, err := r.cacher.Get(node)
 	if err != nil {
 		previous = envoy_cache.Snapshot{}
 	}
-	snapshot = r.autoVersion(previous, snapshot)
-	if err := r.cacher.Cache(node, snapshot); err != nil {
-		reconcileLog.Error(err, "failed to store snapshot", "snapshot", snapshot, "proxy", proxy)
+
+	snapshot, changed := autoVersion(previous, snapshot)
+
+	// Validate the resources we reconciled before sending them
+	// to Envoy. This ensures that we have as much in-band error
+	// information as possible, which is especially useful for tests
+	// that don't actually program an Envoy instance.
+	if changed {
+		for _, resources := range snapshot.Resources {
+			for name, resource := range resources.Items {
+				if err := validateResource(resource.Resource); err != nil {
+					return errors.Wrapf(err, "invalid resource %q", name)
+				}
+			}
+		}
+
+		if err := snapshot.Consistent(); err != nil {
+			reconcileLog.Error(err, "inconsistent snapshot", "snapshot", snapshot, "proxy", proxy)
+			return errors.Wrap(err, "inconsistent snapshot")
+		}
 	}
+
+	if err := r.cacher.Cache(node, snapshot); err != nil {
+		return errors.Wrap(err, "failed to store snapshot")
+	}
+
 	return nil
 }
 
-func (r *reconciler) autoVersion(old envoy_cache.Snapshot, new envoy_cache.Snapshot) envoy_cache.Snapshot {
+func validateResource(r envoy_types.Resource) error {
+	switch v := r.(type) {
+	// Newer go-control-plane versions have `ValidateAll()` method, that accumulates as many validation errors as possible.
+	case interface{ ValidateAll() error }:
+		return v.ValidateAll()
+	// Older go-control-plane stops validation at the first error.
+	case interface{ Validate() error }:
+		return v.Validate()
+	default:
+		return nil
+	}
+}
+
+func autoVersion(old envoy_cache.Snapshot, new envoy_cache.Snapshot) (envoy_cache.Snapshot, bool) {
 	new.Resources[envoy_types.Listener] = reuseVersion(old.Resources[envoy_types.Listener], new.Resources[envoy_types.Listener])
 	new.Resources[envoy_types.Route] = reuseVersion(old.Resources[envoy_types.Route], new.Resources[envoy_types.Route])
 	new.Resources[envoy_types.Cluster] = reuseVersion(old.Resources[envoy_types.Cluster], new.Resources[envoy_types.Cluster])
 	new.Resources[envoy_types.Endpoint] = reuseVersion(old.Resources[envoy_types.Endpoint], new.Resources[envoy_types.Endpoint])
 	new.Resources[envoy_types.Secret] = reuseVersion(old.Resources[envoy_types.Secret], new.Resources[envoy_types.Secret])
-	return new
+
+	for resourceType, resource := range new.Resources {
+		if old.Resources[resourceType].Version != resource.Version {
+			return new, true
+		}
+	}
+
+	return new, false
 }
 
 func reuseVersion(old, new envoy_cache.Resources) envoy_cache.Resources {

--- a/pkg/xds/server/v3/reconcile_test.go
+++ b/pkg/xds/server/v3/reconcile_test.go
@@ -2,21 +2,40 @@ package v3
 
 import (
 	envoy_cluster "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
+	envoy_core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	envoy_endpoint "github.com/envoyproxy/go-control-plane/envoy/config/endpoint/v3"
 	envoy_listener "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
 	envoy_route "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
+	envoy_hcm "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
 	envoy_auth "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
 	envoy_types "github.com/envoyproxy/go-control-plane/pkg/cache/types"
 	envoy_cache "github.com/envoyproxy/go-control-plane/pkg/cache/v3"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"google.golang.org/protobuf/types/known/anypb"
 
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	xds_model "github.com/kumahq/kuma/pkg/core/xds"
 	test_model "github.com/kumahq/kuma/pkg/test/resources/model"
+	"github.com/kumahq/kuma/pkg/util/proto"
 	xds_context "github.com/kumahq/kuma/pkg/xds/context"
 )
+
+func hcmForRoute(routeName string) *anypb.Any {
+	hcm := envoy_hcm.HttpConnectionManager{
+		RouteSpecifier: &envoy_hcm.HttpConnectionManager_Rds{
+			Rds: &envoy_hcm.Rds{
+				RouteConfigName: routeName,
+			},
+		},
+	}
+
+	a, err := proto.MarshalAnyDeterministic(&hcm)
+	Expect(err).To(Succeed())
+
+	return a
+}
 
 var _ = Describe("Reconcile", func() {
 	Describe("reconciler", func() {
@@ -31,7 +50,26 @@ var _ = Describe("Reconcile", func() {
 				envoy_types.Listener: {
 					Items: map[string]envoy_types.ResourceWithTtl{
 						"listener": {
-							Resource: &envoy_listener.Listener{},
+							Resource: &envoy_listener.Listener{
+								Address: &envoy_core.Address{
+									Address: &envoy_core.Address_SocketAddress{
+										SocketAddress: &envoy_core.SocketAddress{
+											Address: "127.0.0.1",
+											PortSpecifier: &envoy_core.SocketAddress_PortValue{
+												PortValue: 99,
+											},
+										},
+									},
+								},
+								FilterChains: []*envoy_listener.FilterChain{{
+									Filters: []*envoy_listener.Filter{{
+										Name: "envoy.filters.network.http_connection_manager",
+										ConfigType: &envoy_listener.Filter_TypedConfig{
+											TypedConfig: hcmForRoute("route"),
+										},
+									}},
+								}},
+							},
 						},
 					},
 				},
@@ -45,14 +83,25 @@ var _ = Describe("Reconcile", func() {
 				envoy_types.Cluster: {
 					Items: map[string]envoy_types.ResourceWithTtl{
 						"cluster": {
-							Resource: &envoy_cluster.Cluster{},
+							Resource: &envoy_cluster.Cluster{
+								Name:                 "cluster",
+								ClusterDiscoveryType: &envoy_cluster.Cluster_Type{Type: envoy_cluster.Cluster_EDS},
+								EdsClusterConfig: &envoy_cluster.Cluster_EdsClusterConfig{
+									EdsConfig: &envoy_core.ConfigSource{
+										ResourceApiVersion: envoy_core.ApiVersion_V3,
+										ConfigSourceSpecifier: &envoy_core.ConfigSource_Ads{
+											Ads: &envoy_core.AggregatedConfigSource{},
+										},
+									},
+								},
+							},
 						},
 					},
 				},
 				envoy_types.Endpoint: {
 					Items: map[string]envoy_types.ResourceWithTtl{
-						"endpoint": {
-							Resource: &envoy_endpoint.ClusterLoadAssignment{},
+						"cluster": {
+							Resource: &envoy_endpoint.ClusterLoadAssignment{ClusterName: "cluster"},
 						},
 					},
 				},


### PR DESCRIPTION
### Summary

The xDS resource validation is built in to the Go packages, as well as the
Envoy xDS client. Running the validation before we swap the xDS snapshot
in the cache prevents Kuma from sending known-bad configuration to Envoy.

Validation is particularly helpful in tests, since we can ensure that
Kuma is generating valid xDS resources even without a running Envoy to
send them to. This check found a case where the Gateway generator would
generate routes without the require path match.

### Full changelog

N/A

### Issues resolved

Fix #2537.

### Documentation

N/A

### Testing

- [x] Unit tests
- [x] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes 

### Backwards compatibility

- [x] Add `backport-to-stable` label if the code is backwards compatible. Otherwise, list breaking changes.
