### PR TITLE
fix(pkg/version) add 1.4.0 to compatibility matrix

### DIFF
--- a/pkg/version/compatibility.go
+++ b/pkg/version/compatibility.go
@@ -53,6 +53,9 @@ var CompatibilityMatrix = Compatibility{
 		"~1.3.0": {
 			Envoy: "~1.18.4",
 		},
+		"~1.4.0": {
+			Envoy: "~1.18.4",
+		},
 	},
 }
 


### PR DESCRIPTION
Right now, the release is failing the `test/release/compatibility_test.go` (rightly). Apparently this test isn't executed for RCs (and should probably run on `master`)