### PR TITLE
chore(ci) install latest kubectl version

### DIFF
--- a/mk/dev.mk
+++ b/mk/dev.mk
@@ -67,9 +67,11 @@ dev/tools/all: dev/install/protoc dev/install/protobuf-wellknown-types \
 	dev/install/protoc-gen-go dev/install/protoc-gen-validate \
 	dev/install/protoc-gen-kumadoc \
 	dev/install/ginkgo \
-	dev/install/kubebuilder dev/install/kustomize \
 	dev/install/kubectl \
-	dev/install/kind dev/install/k3d \
+	dev/install/kubebuilder \
+	dev/install/kustomize \
+	dev/install/kind \
+	dev/install/k3d \
 	dev/install/minikube \
 	dev/install/golangci-lint \
 	dev/install/helm3 \


### PR DESCRIPTION
### Summary

`make dev/install/kubebuilder` installs kubectl so `make dev/install/kubectl` does nothing because `kubectl` already exists. On top of that, kubectl is with outdated version.

The fix is to execute `make dev/install/kubectl` before `make dev/install/kubebuilder`.

In case you are asking whether we even need kubebuilder. I think we don't but it installs etcd and kube-apiserver which is used for kubernetes unit tests. 

### Issues resolved

No reported issues

### Documentation

- [X] No docs, internal changes.

### Testing

- [ ] Unit tests
- [X] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes 

### Backwards compatibility

- [X] Add `backport-to-stable` label if the code is backwards compatible. Otherwise, list breaking changes.
