### PR TITLE
build(circleci) fix dev_mac

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -162,7 +162,7 @@ executors:
   mac:
     resource_class: large
     macos:
-      xcode: "11.6.0"
+      xcode: "12.5.1"
     environment:
       GO_VERSION: *go_version
       GO111MODULE: "on"


### PR DESCRIPTION
We need at least Big Sur to get rid of expired LetsEncrypt cert.