### PR TITLE
chore(kuma-cp) allow gateway listeners to omit tags

### DIFF
--- a/pkg/core/resources/apis/mesh/gateway_validator.go
+++ b/pkg/core/resources/apis/mesh/gateway_validator.go
@@ -111,11 +111,12 @@ func validateGatewayConf(path validators.PathBuilder, conf *mesh_proto.Gateway_C
 			}
 		}
 
+		// Listener tags are optional, but if given, must not contain
+		// various tags that are well-known properties of Dataplanes.
 		err.Add(ValidateSelector(
 			path.Index(i).Field("tags"),
 			l.GetTags(),
 			ValidateSelectorOpts{
-				RequireAtLeastOneTag: true,
 				ExtraTagKeyValidators: []TagKeyValidatorFunc{
 					SelectorKeyNotInSet(
 						mesh_proto.ExternalServiceTag,

--- a/pkg/core/resources/apis/mesh/gateway_validator_test.go
+++ b/pkg/core/resources/apis/mesh/gateway_validator_test.go
@@ -41,6 +41,21 @@ conf:
     tags:
       name: https`,
 		),
+		Entry("HTTPS listener without tags", `
+type: Gateway
+name: gateway
+mesh: default
+selectors:
+  - match:
+      kuma.io/service: gateway
+tags:
+  product: edge
+conf:
+  listeners:
+  - hostname: www-1.example.com
+    port: 443
+    protocol: HTTP`,
+		),
 	)
 
 	DescribeErrorCases(


### PR DESCRIPTION
### Summary

There's no strong reason to require Gateway listeners to specify tags
(though it is useful), so remove the requirement that they must have tags.


### Full changelog
N/A

### Issues resolved
N/A

### Documentation
N/A

### Testing

- [x] Unit tests
- [x] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes 

### Backwards compatibility

- [x] Add `backport-to-stable` label if the code is backwards compatible. Otherwise, list breaking changes.
