### PR TITLE
refactor(*): move from io/ioutil to io and os packages

### DIFF
--- a/app/kuma-cp/cmd/run_test.go
+++ b/app/kuma-cp/cmd/run_test.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"time"
@@ -54,7 +53,7 @@ func RunSmokeTest(factory ConfigFactory, workdir string) {
 			Expect(err).NotTo(HaveOccurred())
 			diagnosticsPort = freePort
 
-			file, err := ioutil.TempFile("", "*")
+			file, err := os.CreateTemp("", "*")
 			Expect(err).ToNot(HaveOccurred())
 			configFile = file
 		})

--- a/app/kuma-dp/cmd/dataplane.go
+++ b/app/kuma-dp/cmd/dataplane.go
@@ -1,7 +1,8 @@
 package cmd
 
 import (
-	"io/ioutil"
+	"io"
+	"os"
 
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -24,11 +25,11 @@ func readResource(cmd *cobra.Command, r *kuma_dp.DataplaneRuntime) (model.Resour
 			b = []byte(r.Resource)
 		}
 	case "-":
-		if b, err = ioutil.ReadAll(cmd.InOrStdin()); err != nil {
+		if b, err = io.ReadAll(cmd.InOrStdin()); err != nil {
 			return nil, err
 		}
 	default:
-		if b, err = ioutil.ReadFile(r.ResourcePath); err != nil {
+		if b, err = os.ReadFile(r.ResourcePath); err != nil {
 			return nil, errors.Wrap(err, "error while reading provided file")
 		}
 	}

--- a/app/kuma-dp/cmd/run.go
+++ b/app/kuma-dp/cmd/run.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -101,7 +100,7 @@ func newRunCmd(opts kuma_cmd.RunCmdOpts, rootCtx *RootContext) *cobra.Command {
 			}
 
 			if cfg.DataplaneRuntime.ConfigDir == "" || cfg.DNS.ConfigDir == "" {
-				tmpDir, err = ioutil.TempDir("", "kuma-dp-")
+				tmpDir, err = os.MkdirTemp("", "kuma-dp-")
 				if err != nil {
 					runLog.Error(err, "unable to create a temporary directory to store generated configuration")
 					return err
@@ -134,7 +133,7 @@ func newRunCmd(opts kuma_cmd.RunCmdOpts, rootCtx *RootContext) *cobra.Command {
 			}
 
 			if cfg.ControlPlane.CaCert == "" && cfg.ControlPlane.CaCertFile != "" {
-				cert, err := ioutil.ReadFile(cfg.ControlPlane.CaCertFile)
+				cert, err := os.ReadFile(cfg.ControlPlane.CaCertFile)
 				if err != nil {
 					return errors.Wrapf(err, "could not read certificate file %s", cfg.ControlPlane.CaCertFile)
 				}
@@ -250,5 +249,5 @@ func writeFile(filename string, data []byte, perm os.FileMode) error {
 	if err := os.MkdirAll(filepath.Dir(filename), perm); err != nil {
 		return err
 	}
-	return ioutil.WriteFile(filename, data, perm)
+	return os.WriteFile(filename, data, perm)
 }

--- a/app/kuma-dp/cmd/run_test.go
+++ b/app/kuma-dp/cmd/run_test.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"os"
 	"path/filepath"
@@ -40,7 +39,7 @@ var _ = Describe("run", func() {
 	BeforeEach(func() {
 		ctx, cancel = context.WithCancel(context.Background())
 		var err error
-		tmpDir, err = ioutil.TempDir("", "")
+		tmpDir, err = os.MkdirTemp("", "")
 		Expect(err).ToNot(HaveOccurred())
 	})
 	AfterEach(func() {
@@ -96,7 +95,7 @@ var _ = Describe("run", func() {
 			// given
 			rootCtx := DefaultRootContext()
 			rootCtx.BootstrapGenerator = func(_ string, cfg kumadp.Config, _ envoy.BootstrapParams) ([]byte, error) {
-				respBytes, err := ioutil.ReadFile(filepath.Join("testdata", "bootstrap-config.golden.yaml"))
+				respBytes, err := os.ReadFile(filepath.Join("testdata", "bootstrap-config.golden.yaml"))
 				Expect(err).ToNot(HaveOccurred())
 				return respBytes, nil
 			}
@@ -118,7 +117,7 @@ var _ = Describe("run", func() {
 			var pid int64
 			By("waiting for dataplane (Envoy) to get started")
 			Eventually(func() bool {
-				data, err := ioutil.ReadFile(pidFile)
+				data, err := os.ReadFile(pidFile)
 				if err != nil {
 					return false
 				}
@@ -130,7 +129,7 @@ var _ = Describe("run", func() {
 
 			By("verifying the arguments Envoy was launched with")
 			// when
-			cmdline, err := ioutil.ReadFile(cmdlineFile)
+			cmdline, err := os.ReadFile(cmdlineFile)
 			// then
 			Expect(err).ToNot(HaveOccurred())
 			// and

--- a/app/kuma-dp/pkg/config/validate.go
+++ b/app/kuma-dp/pkg/config/validate.go
@@ -1,7 +1,7 @@
 package config
 
 import (
-	"io/ioutil"
+	"os"
 	"unicode"
 
 	"github.com/golang-jwt/jwt/v4"
@@ -22,7 +22,7 @@ func ValidateTokenPath(path string) error {
 		return errors.Errorf("token under file %s is empty", path)
 	}
 
-	rawToken, err := ioutil.ReadFile(path)
+	rawToken, err := os.ReadFile(path)
 	if err != nil {
 		return errors.Wrapf(err, "could not read the token in the file %s", path)
 	}

--- a/app/kuma-dp/pkg/config/validate_test.go
+++ b/app/kuma-dp/pkg/config/validate_test.go
@@ -2,7 +2,6 @@ package config_test
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 
 	. "github.com/onsi/ginkgo"
@@ -17,7 +16,7 @@ var _ = Describe("ValidateTokenPath", func() {
 	var tokenFile *os.File
 
 	BeforeEach(func() {
-		tf, err := ioutil.TempFile("", "")
+		tf, err := os.CreateTemp("", "")
 		Expect(err).ToNot(HaveOccurred())
 		tokenFile = tf
 	})
@@ -66,7 +65,7 @@ var _ = Describe("ValidateTokenPath", func() {
 		DescribeTable("should fail with invalid token",
 			func(given testCase) {
 				// setup
-				invalidTokenFile, err := ioutil.TempFile("", "")
+				invalidTokenFile, err := os.CreateTemp("", "")
 				Expect(err).ToNot(HaveOccurred())
 
 				_, err = invalidTokenFile.Write([]byte(given.token))

--- a/app/kuma-dp/pkg/dataplane/dnsserver/config_file.go
+++ b/app/kuma-dp/pkg/dataplane/dnsserver/config_file.go
@@ -1,7 +1,6 @@
 package dnsserver
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -22,5 +21,5 @@ func writeFile(filename string, data []byte, perm os.FileMode) error {
 	if err := os.MkdirAll(filepath.Dir(filename), 0755); err != nil {
 		return err
 	}
-	return ioutil.WriteFile(filename, data, perm)
+	return os.WriteFile(filename, data, perm)
 }

--- a/app/kuma-dp/pkg/dataplane/dnsserver/config_file_test.go
+++ b/app/kuma-dp/pkg/dataplane/dnsserver/config_file_test.go
@@ -1,7 +1,6 @@
 package dnsserver
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -18,7 +17,7 @@ var _ = Describe("Config File", func() {
 
 		BeforeEach(func() {
 			var err error
-			configDir, err = ioutil.TempDir("", "")
+			configDir, err = os.MkdirTemp("", "")
 			Expect(err).ToNot(HaveOccurred())
 		})
 		AfterEach(func() {
@@ -48,7 +47,7 @@ var _ = Describe("Config File", func() {
 			Expect(filename).To(Equal(filepath.Join(configDir, "Corefile")))
 
 			// when
-			actual, err := ioutil.ReadFile(filename)
+			actual, err := os.ReadFile(filename)
 			// then
 			Expect(err).ToNot(HaveOccurred())
 			// and

--- a/app/kuma-dp/pkg/dataplane/dnsserver/dnsserver_test.go
+++ b/app/kuma-dp/pkg/dataplane/dnsserver/dnsserver_test.go
@@ -6,7 +6,6 @@ package dnsserver
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -26,7 +25,7 @@ var _ = Describe("DNS Server", func() {
 
 	BeforeEach(func() {
 		var err error
-		configDir, err = ioutil.TempDir("", "")
+		configDir, err = os.MkdirTemp("", "")
 		Expect(err).ToNot(HaveOccurred())
 	})
 	AfterEach(func() {
@@ -116,7 +115,7 @@ var _ = Describe("DNS Server", func() {
 
 			By("verifying the contents DNS Server config file")
 			// when
-			actual, err := ioutil.ReadFile(expectedConfigFile)
+			actual, err := os.ReadFile(expectedConfigFile)
 			// then
 			Expect(err).ToNot(HaveOccurred())
 			// and

--- a/app/kuma-dp/pkg/dataplane/envoy/bootstrap_file.go
+++ b/app/kuma-dp/pkg/dataplane/envoy/bootstrap_file.go
@@ -1,7 +1,6 @@
 package envoy
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -22,5 +21,5 @@ func writeFile(filename string, data []byte, perm os.FileMode) error {
 	if err := os.MkdirAll(filepath.Dir(filename), 0755); err != nil {
 		return err
 	}
-	return ioutil.WriteFile(filename, data, perm)
+	return os.WriteFile(filename, data, perm)
 }

--- a/app/kuma-dp/pkg/dataplane/envoy/bootstrap_file_test.go
+++ b/app/kuma-dp/pkg/dataplane/envoy/bootstrap_file_test.go
@@ -1,7 +1,6 @@
 package envoy
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -18,7 +17,7 @@ var _ = Describe("Bootstrap File", func() {
 
 		BeforeEach(func() {
 			var err error
-			configDir, err = ioutil.TempDir("", "")
+			configDir, err = os.MkdirTemp("", "")
 			Expect(err).ToNot(HaveOccurred())
 		})
 		AfterEach(func() {
@@ -48,7 +47,7 @@ var _ = Describe("Bootstrap File", func() {
 			Expect(filename).To(Equal(filepath.Join(configDir, "bootstrap.yaml")))
 
 			// when
-			actual, err := ioutil.ReadFile(filename)
+			actual, err := os.ReadFile(filename)
 			// then
 			Expect(err).ToNot(HaveOccurred())
 			// and

--- a/app/kuma-dp/pkg/dataplane/envoy/envoy_test.go
+++ b/app/kuma-dp/pkg/dataplane/envoy/envoy_test.go
@@ -6,7 +6,6 @@ package envoy
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -27,7 +26,7 @@ var _ = Describe("Envoy", func() {
 
 	BeforeEach(func() {
 		var err error
-		configDir, err = ioutil.TempDir("", "")
+		configDir, err = os.MkdirTemp("", "")
 		Expect(err).ToNot(HaveOccurred())
 	})
 
@@ -131,7 +130,7 @@ var _ = Describe("Envoy", func() {
 
 			By("verifying the contents Envoy config file")
 			// when
-			actual, err := ioutil.ReadFile(expectedConfigFile)
+			actual, err := os.ReadFile(expectedConfigFile)
 			// then
 			Expect(err).ToNot(HaveOccurred())
 			// and

--- a/app/kuma-dp/pkg/dataplane/envoy/remote_bootstrap.go
+++ b/app/kuma-dp/pkg/dataplane/envoy/remote_bootstrap.go
@@ -6,9 +6,10 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 	net_url "net/url"
+	"os"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -106,7 +107,7 @@ func (b *remoteBootstrap) requestForBootstrap(url *net_url.URL, cfg kuma_dp.Conf
 	}
 	token := ""
 	if cfg.DataplaneRuntime.TokenPath != "" {
-		tokenData, err := ioutil.ReadFile(cfg.DataplaneRuntime.TokenPath)
+		tokenData, err := os.ReadFile(cfg.DataplaneRuntime.TokenPath)
 		if err != nil {
 			return nil, err
 		}
@@ -152,7 +153,7 @@ func (b *remoteBootstrap) requestForBootstrap(url *net_url.URL, cfg kuma_dp.Conf
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
-		bodyBytes, err := ioutil.ReadAll(resp.Body)
+		bodyBytes, err := io.ReadAll(resp.Body)
 		if err != nil {
 			return nil, errors.Wrapf(err, "Unable to read the response with status code: %d. Make sure you are using https URL", resp.StatusCode)
 		}
@@ -167,7 +168,7 @@ func (b *remoteBootstrap) requestForBootstrap(url *net_url.URL, cfg kuma_dp.Conf
 		}
 		return nil, errors.Errorf("unexpected status code: %d", resp.StatusCode)
 	}
-	respBytes, err := ioutil.ReadAll(resp.Body)
+	respBytes, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, errors.Wrap(err, "could not read the body of the response")
 	}

--- a/app/kuma-dp/pkg/dataplane/envoy/remote_bootstrap_test.go
+++ b/app/kuma-dp/pkg/dataplane/envoy/remote_bootstrap_test.go
@@ -2,9 +2,10 @@ package envoy
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -45,11 +46,11 @@ var _ = Describe("Remote Bootstrap", func() {
 		defer server.Close()
 		mux.HandleFunc("/bootstrap", func(writer http.ResponseWriter, req *http.Request) {
 			defer GinkgoRecover()
-			body, err := ioutil.ReadAll(req.Body)
+			body, err := io.ReadAll(req.Body)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(body).To(MatchJSON(given.expectedBootstrapRequest))
 
-			response, err := ioutil.ReadFile(filepath.Join("testdata", "remote-bootstrap-config.golden.yaml"))
+			response, err := os.ReadFile(filepath.Join("testdata", "remote-bootstrap-config.golden.yaml"))
 			Expect(err).ToNot(HaveOccurred())
 			_, err = writer.Write(response)
 			Expect(err).ToNot(HaveOccurred())
@@ -223,7 +224,7 @@ var _ = Describe("Remote Bootstrap", func() {
 				writer.WriteHeader(404)
 				i++
 			} else {
-				response, err := ioutil.ReadFile(filepath.Join("testdata", "remote-bootstrap-config.golden.yaml"))
+				response, err := os.ReadFile(filepath.Join("testdata", "remote-bootstrap-config.golden.yaml"))
 				Expect(err).ToNot(HaveOccurred())
 				_, err = writer.Write(response)
 				Expect(err).ToNot(HaveOccurred())

--- a/app/kumactl/cmd/apply/apply.go
+++ b/app/kumactl/cmd/apply/apply.go
@@ -4,8 +4,9 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
+	"os"
 	"strings"
 	"time"
 
@@ -66,7 +67,7 @@ $ kumactl apply -f https://example.com/resource.yaml
 			var err error
 
 			if ctx.args.file == "-" {
-				b, err = ioutil.ReadAll(cmd.InOrStdin())
+				b, err = io.ReadAll(cmd.InOrStdin())
 				if err != nil {
 					return err
 				}
@@ -88,12 +89,12 @@ $ kumactl apply -f https://example.com/resource.yaml
 						return errors.Wrap(err, "error while retrieving URL")
 					}
 					defer resp.Body.Close()
-					b, err = ioutil.ReadAll(resp.Body)
+					b, err = io.ReadAll(resp.Body)
 					if err != nil {
 						return errors.Wrap(err, "error while reading provided file")
 					}
 				} else {
-					b, err = ioutil.ReadFile(ctx.args.file)
+					b, err = os.ReadFile(ctx.args.file)
 					if err != nil {
 						return errors.Wrap(err, "error while reading provided file")
 					}

--- a/app/kumactl/cmd/config/config_control_planes_add_test.go
+++ b/app/kumactl/cmd/config/config_control_planes_add_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -31,7 +30,7 @@ var _ = Describe("kumactl config control-planes add", func() {
 
 	BeforeEach(func() {
 		var err error
-		configFile, err = ioutil.TempFile("", "")
+		configFile, err = os.CreateTemp("", "")
 		Expect(err).ToNot(HaveOccurred())
 	})
 	AfterEach(func() {
@@ -181,9 +180,9 @@ var _ = Describe("kumactl config control-planes add", func() {
 		DescribeTable("should add a new Control Plane by name and address",
 			func(given testCase) {
 				// setup
-				initial, err := ioutil.ReadFile(filepath.Join("testdata", given.configFile))
+				initial, err := os.ReadFile(filepath.Join("testdata", given.configFile))
 				Expect(err).ToNot(HaveOccurred())
-				err = ioutil.WriteFile(configFile.Name(), initial, 0600)
+				err = os.WriteFile(configFile.Name(), initial, 0600)
 				Expect(err).ToNot(HaveOccurred())
 
 				// setup cp index server for validation to pass
@@ -211,13 +210,13 @@ var _ = Describe("kumactl config control-planes add", func() {
 				Expect(err).ToNot(HaveOccurred())
 
 				// when
-				expectedWithPlaceholder, err := ioutil.ReadFile(filepath.Join("testdata", given.goldenFile))
+				expectedWithPlaceholder, err := os.ReadFile(filepath.Join("testdata", given.goldenFile))
 				// then
 				Expect(err).ToNot(HaveOccurred())
 				expected := strings.ReplaceAll(string(expectedWithPlaceholder), "http://placeholder-address", fmt.Sprintf("http://localhost:%d", port))
 
 				// when
-				actual, err := ioutil.ReadFile(configFile.Name())
+				actual, err := os.ReadFile(configFile.Name())
 				// then
 				Expect(err).ToNot(HaveOccurred())
 

--- a/app/kumactl/cmd/config/config_control_planes_list_test.go
+++ b/app/kumactl/cmd/config/config_control_planes_list_test.go
@@ -2,7 +2,7 @@ package config_test
 
 import (
 	"bytes"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -31,7 +31,7 @@ var _ = Describe("kumactl config control-planes list", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		// when
-		expected, err := ioutil.ReadFile(filepath.Join("testdata", "config-control-planes-list.golden.txt"))
+		expected, err := os.ReadFile(filepath.Join("testdata", "config-control-planes-list.golden.txt"))
 		// then
 		Expect(err).ToNot(HaveOccurred())
 		// and

--- a/app/kumactl/cmd/config/config_control_planes_remove_test.go
+++ b/app/kumactl/cmd/config/config_control_planes_remove_test.go
@@ -2,7 +2,6 @@ package config_test
 
 import (
 	"bytes"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -22,7 +21,7 @@ var _ = Describe("kumactl config control-planes remove", func() {
 
 	BeforeEach(func() {
 		var err error
-		configFile, err = ioutil.TempFile("", "")
+		configFile, err = os.CreateTemp("", "")
 		Expect(err).ToNot(HaveOccurred())
 	})
 	AfterEach(func() {
@@ -88,9 +87,9 @@ var _ = Describe("kumactl config control-planes remove", func() {
 		DescribeTable("should remove an existing Control Plane",
 			func(given testCase) {
 				// setup
-				initial, err := ioutil.ReadFile(filepath.Join("testdata", given.configFile))
+				initial, err := os.ReadFile(filepath.Join("testdata", given.configFile))
 				Expect(err).ToNot(HaveOccurred())
-				err = ioutil.WriteFile(configFile.Name(), initial, 0600)
+				err = os.WriteFile(configFile.Name(), initial, 0600)
 				Expect(err).ToNot(HaveOccurred())
 
 				// given
@@ -103,12 +102,12 @@ var _ = Describe("kumactl config control-planes remove", func() {
 				Expect(err).ToNot(HaveOccurred())
 
 				// when
-				expected, err := ioutil.ReadFile(filepath.Join("testdata", given.goldenFile))
+				expected, err := os.ReadFile(filepath.Join("testdata", given.goldenFile))
 				// then
 				Expect(err).ToNot(HaveOccurred())
 
 				// when
-				actual, err := ioutil.ReadFile(configFile.Name())
+				actual, err := os.ReadFile(configFile.Name())
 				// then
 				Expect(err).ToNot(HaveOccurred())
 

--- a/app/kumactl/cmd/config/config_control_planes_switch_test.go
+++ b/app/kumactl/cmd/config/config_control_planes_switch_test.go
@@ -2,7 +2,6 @@ package config_test
 
 import (
 	"bytes"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -22,7 +21,7 @@ var _ = Describe("kumactl config control-planes use", func() {
 
 	BeforeEach(func() {
 		var err error
-		configFile, err = ioutil.TempFile("", "")
+		configFile, err = os.CreateTemp("", "")
 		Expect(err).ToNot(HaveOccurred())
 	})
 	AfterEach(func() {
@@ -86,9 +85,9 @@ var _ = Describe("kumactl config control-planes use", func() {
 		DescribeTable("should switch to an existing Control Plane",
 			func(given testCase) {
 				// setup
-				initial, err := ioutil.ReadFile(filepath.Join("testdata", given.configFile))
+				initial, err := os.ReadFile(filepath.Join("testdata", given.configFile))
 				Expect(err).ToNot(HaveOccurred())
-				err = ioutil.WriteFile(configFile.Name(), initial, 0600)
+				err = os.WriteFile(configFile.Name(), initial, 0600)
 				Expect(err).ToNot(HaveOccurred())
 
 				// given
@@ -101,12 +100,12 @@ var _ = Describe("kumactl config control-planes use", func() {
 				Expect(err).ToNot(HaveOccurred())
 
 				// when
-				expected, err := ioutil.ReadFile(filepath.Join("testdata", given.goldenFile))
+				expected, err := os.ReadFile(filepath.Join("testdata", given.goldenFile))
 				// then
 				Expect(err).ToNot(HaveOccurred())
 
 				// when
-				actual, err := ioutil.ReadFile(configFile.Name())
+				actual, err := os.ReadFile(configFile.Name())
 				// then
 				Expect(err).ToNot(HaveOccurred())
 

--- a/app/kumactl/cmd/config/config_view_test.go
+++ b/app/kumactl/cmd/config/config_view_test.go
@@ -2,7 +2,7 @@ package config_test
 
 import (
 	"bytes"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 
 	. "github.com/onsi/ginkgo"
@@ -30,7 +30,7 @@ var _ = Describe("kumactl config view", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		// when
-		expected, err := ioutil.ReadFile(filepath.Join("testdata", "config-view.golden.yaml"))
+		expected, err := os.ReadFile(filepath.Join("testdata", "config-view.golden.yaml"))
 		// then
 		Expect(err).ToNot(HaveOccurred())
 		// and

--- a/app/kumactl/cmd/generate/generate_certificate_test.go
+++ b/app/kumactl/cmd/generate/generate_certificate_test.go
@@ -3,7 +3,7 @@ package generate_test
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"reflect"
 
@@ -43,12 +43,12 @@ var _ = Describe("kumactl generate tls-certificate", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		// and
-		keyBytes, err := ioutil.ReadAll(keyFile)
+		keyBytes, err := io.ReadAll(keyFile)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(string(keyBytes)).To(Equal("KEY"))
 
 		// and
-		certBytes, err := ioutil.ReadAll(certFile)
+		certBytes, err := io.ReadAll(certFile)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(string(certBytes)).To(Equal("CERT"))
 
@@ -62,11 +62,11 @@ var _ = Describe("kumactl generate tls-certificate", func() {
 	}
 
 	BeforeEach(func() {
-		key, err := ioutil.TempFile("", "")
+		key, err := os.CreateTemp("", "")
 		Expect(err).ToNot(HaveOccurred())
 		keyFile = key
 
-		cert, err := ioutil.TempFile("", "")
+		cert, err := os.CreateTemp("", "")
 		Expect(err).ToNot(HaveOccurred())
 		certFile = cert
 

--- a/app/kumactl/cmd/get/get_circuit_breakers_test.go
+++ b/app/kumactl/cmd/get/get_circuit_breakers_test.go
@@ -3,7 +3,7 @@ package get_test
 import (
 	"bytes"
 	"context"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 	"time"
@@ -148,7 +148,7 @@ var _ = Describe("kumactl get circuit-breakers", func() {
 				).To(Succeed())
 
 				// when
-				expected, err := ioutil.ReadFile(filepath.Join("testdata", given.goldenFile))
+				expected, err := os.ReadFile(filepath.Join("testdata", given.goldenFile))
 				// then
 				Expect(err).ToNot(HaveOccurred())
 				// and

--- a/app/kumactl/cmd/get/get_external_services_test.go
+++ b/app/kumactl/cmd/get/get_external_services_test.go
@@ -3,7 +3,7 @@ package get_test
 import (
 	"bytes"
 	"context"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 	"time"
@@ -105,7 +105,7 @@ var _ = Describe("kumactl get external-services", func() {
 				).To(Succeed())
 
 				// when
-				expected, err := ioutil.ReadFile(filepath.Join("testdata", given.goldenFile))
+				expected, err := os.ReadFile(filepath.Join("testdata", given.goldenFile))
 				// then
 				Expect(err).ToNot(HaveOccurred())
 				// and

--- a/app/kumactl/cmd/get/get_fault_injections_test.go
+++ b/app/kumactl/cmd/get/get_fault_injections_test.go
@@ -3,7 +3,7 @@ package get_test
 import (
 	"bytes"
 	"context"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 	"time"
@@ -142,7 +142,7 @@ var _ = Describe("kumactl get fault-injections", func() {
 				).To(Succeed())
 
 				// when
-				expected, err := ioutil.ReadFile(filepath.Join("testdata", given.goldenFile))
+				expected, err := os.ReadFile(filepath.Join("testdata", given.goldenFile))
 				// then
 				Expect(err).ToNot(HaveOccurred())
 				// and

--- a/app/kumactl/cmd/get/get_healthchecks_test.go
+++ b/app/kumactl/cmd/get/get_healthchecks_test.go
@@ -3,7 +3,7 @@ package get_test
 import (
 	"bytes"
 	"context"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 	"time"
@@ -95,7 +95,7 @@ var _ = Describe("kumactl get healthchecks", func() {
 				).To(Succeed())
 
 				// when
-				expected, err := ioutil.ReadFile(filepath.Join("testdata", given.goldenFile))
+				expected, err := os.ReadFile(filepath.Join("testdata", given.goldenFile))
 				// then
 				Expect(err).ToNot(HaveOccurred())
 				// and

--- a/app/kumactl/cmd/get/get_meshes_test.go
+++ b/app/kumactl/cmd/get/get_meshes_test.go
@@ -3,7 +3,7 @@ package get_test
 import (
 	"bytes"
 	"context"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 	"time"
@@ -168,7 +168,7 @@ var _ = Describe("kumactl get meshes", func() {
 				).To(Succeed())
 
 				// when
-				expected, err := ioutil.ReadFile(filepath.Join("testdata", given.goldenFile))
+				expected, err := os.ReadFile(filepath.Join("testdata", given.goldenFile))
 				// then
 				Expect(err).ToNot(HaveOccurred())
 				// and

--- a/app/kumactl/cmd/get/get_proxytemplates_test.go
+++ b/app/kumactl/cmd/get/get_proxytemplates_test.go
@@ -3,7 +3,7 @@ package get_test
 import (
 	"bytes"
 	"context"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 	"time"
@@ -96,7 +96,7 @@ var _ = Describe("kumactl get proxytemplates", func() {
 				).To(Succeed())
 
 				// when
-				expected, err := ioutil.ReadFile(filepath.Join("testdata", given.goldenFile))
+				expected, err := os.ReadFile(filepath.Join("testdata", given.goldenFile))
 				// then
 				Expect(err).ToNot(HaveOccurred())
 				// and

--- a/app/kumactl/cmd/get/get_ratelimits_test.go
+++ b/app/kumactl/cmd/get/get_ratelimits_test.go
@@ -3,7 +3,7 @@ package get_test
 import (
 	"bytes"
 	"context"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 	"time"
@@ -115,7 +115,7 @@ var _ = Describe("kumactl get rate-limits", func() {
 				).To(Succeed())
 
 				// when
-				expected, err := ioutil.ReadFile(filepath.Join("testdata", given.goldenFile))
+				expected, err := os.ReadFile(filepath.Join("testdata", given.goldenFile))
 				// then
 				Expect(err).ToNot(HaveOccurred())
 				// and

--- a/app/kumactl/cmd/get/get_retries_test.go
+++ b/app/kumactl/cmd/get/get_retries_test.go
@@ -3,7 +3,7 @@ package get_test
 import (
 	"bytes"
 	"context"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 	"time"
@@ -98,7 +98,7 @@ var _ = Describe("kumactl get retries", func() {
 
 				// when
 				testDataPath := filepath.Join("testdata", given.goldenFile)
-				expected, err := ioutil.ReadFile(testDataPath)
+				expected, err := os.ReadFile(testDataPath)
 				// then
 				Expect(err).ToNot(HaveOccurred())
 				// and

--- a/app/kumactl/cmd/get/get_secrets_test.go
+++ b/app/kumactl/cmd/get/get_secrets_test.go
@@ -3,7 +3,7 @@ package get_test
 import (
 	"bytes"
 	"context"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 	"time"
@@ -93,7 +93,7 @@ var _ = Describe("kumactl get secrets", func() {
 				).To(Succeed())
 
 				// when
-				expected, err := ioutil.ReadFile(filepath.Join("testdata", given.goldenFile))
+				expected, err := os.ReadFile(filepath.Join("testdata", given.goldenFile))
 				// then
 				Expect(err).ToNot(HaveOccurred())
 				// and

--- a/app/kumactl/cmd/get/get_traffic_logs_test.go
+++ b/app/kumactl/cmd/get/get_traffic_logs_test.go
@@ -3,7 +3,7 @@ package get_test
 import (
 	"bytes"
 	"context"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 	"time"
@@ -121,7 +121,7 @@ var _ = Describe("kumactl get traffic-logs", func() {
 				).To(Succeed())
 
 				// when
-				expected, err := ioutil.ReadFile(filepath.Join("testdata", given.goldenFile))
+				expected, err := os.ReadFile(filepath.Join("testdata", given.goldenFile))
 				// then
 				Expect(err).ToNot(HaveOccurred())
 				// and

--- a/app/kumactl/cmd/get/get_traffic_routes_test.go
+++ b/app/kumactl/cmd/get/get_traffic_routes_test.go
@@ -3,7 +3,7 @@ package get_test
 import (
 	"bytes"
 	"context"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 	"time"
@@ -96,7 +96,7 @@ var _ = Describe("kumactl get traffic-routes", func() {
 				).To(Succeed())
 
 				// when
-				expected, err := ioutil.ReadFile(filepath.Join("testdata", given.goldenFile))
+				expected, err := os.ReadFile(filepath.Join("testdata", given.goldenFile))
 				// then
 				Expect(err).ToNot(HaveOccurred())
 				// and

--- a/app/kumactl/cmd/get/get_traffic_traces_test.go
+++ b/app/kumactl/cmd/get/get_traffic_traces_test.go
@@ -3,7 +3,7 @@ package get_test
 import (
 	"bytes"
 	"context"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 	"time"
@@ -105,7 +105,7 @@ var _ = Describe("kumactl get traffic-traces", func() {
 				).To(Succeed())
 
 				// when
-				expected, err := ioutil.ReadFile(filepath.Join("testdata", given.goldenFile))
+				expected, err := os.ReadFile(filepath.Join("testdata", given.goldenFile))
 				// then
 				Expect(err).ToNot(HaveOccurred())
 				// and

--- a/app/kumactl/cmd/get/get_trafficpermissions_test.go
+++ b/app/kumactl/cmd/get/get_trafficpermissions_test.go
@@ -3,7 +3,7 @@ package get_test
 import (
 	"bytes"
 	"context"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 	"time"
@@ -115,7 +115,7 @@ var _ = Describe("kumactl get traffic-permissions", func() {
 				).To(Succeed())
 
 				// when
-				expected, err := ioutil.ReadFile(filepath.Join("testdata", given.goldenFile))
+				expected, err := os.ReadFile(filepath.Join("testdata", given.goldenFile))
 				// then
 				Expect(err).ToNot(HaveOccurred())
 				// and

--- a/app/kumactl/cmd/get/get_zone-ingresses_test.go
+++ b/app/kumactl/cmd/get/get_zone-ingresses_test.go
@@ -3,7 +3,7 @@ package get_test
 import (
 	"bytes"
 	"context"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 	"time"
@@ -103,7 +103,7 @@ var _ = Describe("kumactl get zone-ingresses", func() {
 					ExecuteRootCommand(rootCmd, "zone-ingresses", given.outputFormat, given.pagination),
 				).To(Succeed())
 				// when
-				expected, err := ioutil.ReadFile(filepath.Join("testdata", given.goldenFile))
+				expected, err := os.ReadFile(filepath.Join("testdata", given.goldenFile))
 				// then
 				Expect(err).ToNot(HaveOccurred())
 				// and

--- a/app/kumactl/cmd/get/get_zones_test.go
+++ b/app/kumactl/cmd/get/get_zones_test.go
@@ -3,7 +3,7 @@ package get_test
 import (
 	"bytes"
 	"context"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 	"time"
@@ -78,7 +78,7 @@ var _ = Describe("kumactl get zones", func() {
 				).To(Succeed())
 
 				// when
-				expected, err := ioutil.ReadFile(filepath.Join("testdata", given.goldenFile))
+				expected, err := os.ReadFile(filepath.Join("testdata", given.goldenFile))
 				// then
 				Expect(err).ToNot(HaveOccurred())
 				// and

--- a/app/kumactl/cmd/inspect/inspect_services_test.go
+++ b/app/kumactl/cmd/inspect/inspect_services_test.go
@@ -3,7 +3,7 @@ package inspect_test
 import (
 	"bytes"
 	"context"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 	"time"
@@ -113,7 +113,7 @@ var _ = Describe("kumactl inspect services", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			// when
-			expected, err := ioutil.ReadFile(filepath.Join("testdata", given.goldenFile))
+			expected, err := os.ReadFile(filepath.Join("testdata", given.goldenFile))
 			// then
 			Expect(err).ToNot(HaveOccurred())
 			// and

--- a/app/kumactl/cmd/install/install_gateway_kong_enterprise.go
+++ b/app/kumactl/cmd/install/install_gateway_kong_enterprise.go
@@ -1,7 +1,7 @@
 package install
 
 import (
-	"io/ioutil"
+	"os"
 
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -29,7 +29,7 @@ func newInstallGatewayKongEnterpriseCmd(ctx *install_context.InstallGatewayKongE
 				return errors.Wrap(err, "Failed to read template files")
 			}
 
-			licenseBytes, err := ioutil.ReadFile(args.LicensePath)
+			licenseBytes, err := os.ReadFile(args.LicensePath)
 			if err != nil {
 				return errors.Wrap(err, "Failed to read license file")
 			}

--- a/app/kumactl/cmd/install/install_helpers_test.go
+++ b/app/kumactl/cmd/install/install_helpers_test.go
@@ -1,7 +1,7 @@
 package install_test
 
 import (
-	"io/ioutil"
+	"os"
 
 	. "github.com/onsi/gomega"
 
@@ -16,10 +16,10 @@ func ExpectMatchesGoldenFiles(actual []byte, goldenFilePath string) {
 		if actual[len(actual)-1] != '\n' {
 			actual = append(actual, '\n')
 		}
-		err := ioutil.WriteFile(goldenFilePath, actual, 0664)
+		err := os.WriteFile(goldenFilePath, actual, 0664)
 		Expect(err).ToNot(HaveOccurred())
 	}
-	expected, err := ioutil.ReadFile(goldenFilePath)
+	expected, err := os.ReadFile(goldenFilePath)
 	Expect(err).ToNot(HaveOccurred())
 	expectedManifests := data.SplitYAML(data.File{Data: expected})
 

--- a/app/kumactl/cmd/install/install_transparent_proxy.go
+++ b/app/kumactl/cmd/install/install_transparent_proxy.go
@@ -6,8 +6,8 @@ package install
 import (
 	"bufio"
 	"fmt"
-	"io/ioutil"
 	"net"
+	"os"
 	os_user "os/user"
 	"regexp"
 	"runtime"
@@ -295,7 +295,7 @@ func storeFirewalld(cmd *cobra.Command, args *transparentProxyArgs, output strin
 
 func modifyResolvConf(cmd *cobra.Command, args *transparentProxyArgs) error {
 	kumaCPLine := fmt.Sprintf("nameserver %s", args.KumaCpIP.String())
-	content, err := ioutil.ReadFile("/etc/resolv.conf")
+	content, err := os.ReadFile("/etc/resolv.conf")
 	if err != nil {
 		return errors.Wrap(err, "unable to open /etc/resolv.conf")
 	}
@@ -308,11 +308,11 @@ func modifyResolvConf(cmd *cobra.Command, args *transparentProxyArgs) error {
 	}
 
 	if !strings.Contains(string(content), kumaCPLine) {
-		err = ioutil.WriteFile("/etc/resolv.conf.kuma-backup", content, 0644)
+		err = os.WriteFile("/etc/resolv.conf.kuma-backup", content, 0644)
 		if err != nil {
 			return errors.Wrap(err, "unable to open /etc/resolv.conf.kuma-backup")
 		}
-		err = ioutil.WriteFile("/etc/resolv.conf", []byte(newcontent), 0644)
+		err = os.WriteFile("/etc/resolv.conf", []byte(newcontent), 0644)
 		if err != nil {
 			return errors.Wrap(err, "unable to write /etc/resolv.conf")
 		}

--- a/app/kumactl/cmd/install/install_transparent_proxy_test.go
+++ b/app/kumactl/cmd/install/install_transparent_proxy_test.go
@@ -3,7 +3,7 @@ package install_test
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"regexp"
 
@@ -45,7 +45,7 @@ var _ = Describe("kumactl install tracing", func() {
 			Expect(stderr.String()).To(BeEmpty())
 
 			// when
-			regex, err := ioutil.ReadFile(filepath.Join("testdata", given.goldenFile))
+			regex, err := os.ReadFile(filepath.Join("testdata", given.goldenFile))
 			// then
 			Expect(err).ToNot(HaveOccurred())
 			// and

--- a/app/kumactl/cmd/root_test.go
+++ b/app/kumactl/cmd/root_test.go
@@ -1,7 +1,6 @@
 package cmd_test
 
 import (
-	"io/ioutil"
 	"os"
 
 	. "github.com/onsi/ginkgo"
@@ -21,7 +20,7 @@ var _ = Describe("kumactl root cmd", func() {
 	var backupDefaultConfigFile string
 
 	BeforeEach(func() {
-		file, err := ioutil.TempFile("", "")
+		file, err := os.CreateTemp("", "")
 		Expect(err).To(Succeed())
 		// we have to remove file. Config is created only if file does not exist already
 		Expect(os.Remove(file.Name())).To(Succeed())
@@ -65,7 +64,7 @@ controlPlanes:
   name: local
 currentContext: local
 `
-		bytes, err := ioutil.ReadFile(config.DefaultConfigFile)
+		bytes, err := os.ReadFile(config.DefaultConfigFile)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(bytes).To(MatchYAML(expected))
 	})

--- a/app/kumactl/cmd/uninstall/uninstall_transparent_proxy.go
+++ b/app/kumactl/cmd/uninstall/uninstall_transparent_proxy.go
@@ -4,7 +4,6 @@
 package uninstall
 
 import (
-	"io/ioutil"
 	"os"
 	"runtime"
 
@@ -46,13 +45,13 @@ func newUninstallTransparentProxy() *cobra.Command {
 			}
 
 			if _, err := os.Stat("/etc/resolv.conf.kuma-backup"); !os.IsNotExist(err) {
-				content, err := ioutil.ReadFile("/etc/resolv.conf.kuma-backup")
+				content, err := os.ReadFile("/etc/resolv.conf.kuma-backup")
 				if err != nil {
 					return errors.Wrap(err, "unable to open /etc/resolv.conf.kuma-backup")
 				}
 
 				if !args.DryRun {
-					err = ioutil.WriteFile("/etc/resolv.conf", content, 0644)
+					err = os.WriteFile("/etc/resolv.conf", content, 0644)
 					if err != nil {
 						return errors.Wrap(err, "unable to write /etc/resolv.conf")
 					}

--- a/app/kumactl/cmd/uninstall/uninstall_transparent_proxy_test.go
+++ b/app/kumactl/cmd/uninstall/uninstall_transparent_proxy_test.go
@@ -2,7 +2,7 @@ package uninstall_test
 
 import (
 	"bytes"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"regexp"
 
@@ -44,7 +44,7 @@ var _ = Describe("kumactl install tracing", func() {
 			Expect(stderr.String()).To(BeEmpty())
 
 			// when
-			regex, err := ioutil.ReadFile(filepath.Join("testdata", given.goldenFile))
+			regex, err := os.ReadFile(filepath.Join("testdata", given.goldenFile))
 			// then
 			Expect(err).ToNot(HaveOccurred())
 			// and

--- a/app/kumactl/pkg/config/io.go
+++ b/app/kumactl/pkg/config/io.go
@@ -1,7 +1,6 @@
 package config
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -24,7 +23,7 @@ func Load(file string, cfg *config_proto.Configuration) error {
 		}
 	}
 	if util_files.FileExists(configFile) {
-		if contents, err := ioutil.ReadFile(configFile); err != nil {
+		if contents, err := os.ReadFile(configFile); err != nil {
 			return errors.Wrapf(err, "Failed to read configuration from file %q", configFile)
 		} else if err := util_proto.FromYAML(contents, cfg); err != nil {
 			return errors.Wrapf(err, "Failed to parse configuration from file %q", configFile)
@@ -48,7 +47,7 @@ func Save(file string, cfg *config_proto.Configuration) error {
 			return errors.Wrapf(err, "Failed to create a directory %q", dir)
 		}
 	}
-	if err := ioutil.WriteFile(configFile, contents, 0600); err != nil {
+	if err := os.WriteFile(configFile, contents, 0600); err != nil {
 		return errors.Wrapf(err, "Failed to write configuration into file %q", configFile)
 	}
 	return nil

--- a/app/kumactl/pkg/config/validate.go
+++ b/app/kumactl/pkg/config/validate.go
@@ -3,7 +3,7 @@ package config
 import (
 	"crypto/tls"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"time"
 
@@ -37,7 +37,7 @@ func ValidateCpCoordinates(cp *kumactl_config.ControlPlane) error {
 	if resp.StatusCode != 200 {
 		return errors.New("Control Plane API Server is not responding")
 	}
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return errors.Wrap(err, "could not read body from the Control Plane API Server")
 	}

--- a/app/kumactl/pkg/install/data/files.go
+++ b/app/kumactl/pkg/install/data/files.go
@@ -1,8 +1,8 @@
 package data
 
 import (
+	"io"
 	"io/fs"
-	"io/ioutil"
 
 	"github.com/pkg/errors"
 )
@@ -51,7 +51,7 @@ func ReadFile(fileSys fs.FS, file string) (File, error) {
 	if err != nil {
 		return File{}, err
 	}
-	b, err := ioutil.ReadAll(f)
+	b, err := io.ReadAll(f)
 	if err != nil {
 		return File{}, err
 	}

--- a/app/kumactl/pkg/output/json/json_test.go
+++ b/app/kumactl/pkg/output/json/json_test.go
@@ -2,7 +2,7 @@ package json_test
 
 import (
 	"bytes"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"time"
 
@@ -41,7 +41,7 @@ var _ = Describe("printer", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			// when
-			expected, err := ioutil.ReadFile(filepath.Join("testdata", given.goldenFile))
+			expected, err := os.ReadFile(filepath.Join("testdata", given.goldenFile))
 			// then
 			Expect(err).ToNot(HaveOccurred())
 

--- a/app/kumactl/pkg/output/table/printer_test.go
+++ b/app/kumactl/pkg/output/table/printer_test.go
@@ -2,7 +2,7 @@ package table_test
 
 import (
 	"bytes"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 
 	. "github.com/onsi/ginkgo"
@@ -35,7 +35,7 @@ var _ = Describe("printer", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			// when
-			expected, err := ioutil.ReadFile(filepath.Join("testdata", given.goldenFile))
+			expected, err := os.ReadFile(filepath.Join("testdata", given.goldenFile))
 			// then
 			Expect(err).ToNot(HaveOccurred())
 

--- a/app/kumactl/pkg/output/yaml/yaml_test.go
+++ b/app/kumactl/pkg/output/yaml/yaml_test.go
@@ -2,7 +2,7 @@ package yaml_test
 
 import (
 	"bytes"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"time"
 
@@ -41,7 +41,7 @@ var _ = Describe("printer", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			// when
-			expected, err := ioutil.ReadFile(filepath.Join("testdata", given.goldenFile))
+			expected, err := os.ReadFile(filepath.Join("testdata", given.goldenFile))
 			// then
 			Expect(err).ToNot(HaveOccurred())
 

--- a/app/kumactl/pkg/resources/apiserver_client_test.go
+++ b/app/kumactl/pkg/resources/apiserver_client_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 	"strings"
@@ -30,7 +30,7 @@ var _ = Describe("httpApiServerClient", func() {
 						Expect(req.URL.String()).To(Equal("/"))
 						return &http.Response{
 							StatusCode: http.StatusOK,
-							Body:       ioutil.NopCloser(bytes.NewBufferString(buildVersion)),
+							Body:       io.NopCloser(bytes.NewBufferString(buildVersion)),
 						}, nil
 					}),
 				},
@@ -52,7 +52,7 @@ var _ = Describe("httpApiServerClient", func() {
 					Transport: RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
 						return &http.Response{
 							StatusCode: http.StatusBadRequest,
-							Body:       ioutil.NopCloser(strings.NewReader("some error from server")),
+							Body:       io.NopCloser(strings.NewReader("some error from server")),
 						}, nil
 					}),
 				},

--- a/app/kumactl/pkg/resources/dataplane_overview_client_test.go
+++ b/app/kumactl/pkg/resources/dataplane_overview_client_test.go
@@ -3,7 +3,7 @@ package resources
 import (
 	"bufio"
 	"context"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -37,7 +37,7 @@ var _ = Describe("httpDataplaneOverviewClient", func() {
 						}
 						return &http.Response{
 							StatusCode: http.StatusOK,
-							Body:       ioutil.NopCloser(bufio.NewReader(file)),
+							Body:       io.NopCloser(bufio.NewReader(file)),
 						}, nil
 					}),
 				},
@@ -71,7 +71,7 @@ var _ = Describe("httpDataplaneOverviewClient", func() {
 						}
 						return &http.Response{
 							StatusCode: http.StatusOK,
-							Body:       ioutil.NopCloser(bufio.NewReader(file)),
+							Body:       io.NopCloser(bufio.NewReader(file)),
 						}, nil
 					}),
 				},
@@ -95,7 +95,7 @@ var _ = Describe("httpDataplaneOverviewClient", func() {
 					Transport: RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
 						return &http.Response{
 							StatusCode: http.StatusBadRequest,
-							Body:       ioutil.NopCloser(strings.NewReader("some error from server")),
+							Body:       io.NopCloser(strings.NewReader("some error from server")),
 						}, nil
 					}),
 				},

--- a/app/kumactl/pkg/resources/request.go
+++ b/app/kumactl/pkg/resources/request.go
@@ -3,7 +3,7 @@ package resources
 import (
 	"context"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 
 	error_types "github.com/kumahq/kuma/pkg/core/rest/errors/types"
@@ -16,7 +16,7 @@ func doRequest(client util_http.Client, ctx context.Context, req *http.Request) 
 		return 0, nil, err
 	}
 	defer resp.Body.Close()
-	b, err := ioutil.ReadAll(resp.Body)
+	b, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return resp.StatusCode, nil, err
 	}

--- a/app/kumactl/pkg/tokens/client.go
+++ b/app/kumactl/pkg/tokens/client.go
@@ -3,7 +3,7 @@ package tokens
 import (
 	"bytes"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 
 	"github.com/pkg/errors"
@@ -50,7 +50,7 @@ func (h *httpDataplaneTokenClient) Generate(name string, mesh string, tags map[s
 		return "", errors.Wrap(err, "could not execute the request")
 	}
 	defer resp.Body.Close()
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return "", errors.Wrap(err, "could not read a body of the request")
 	}

--- a/app/kumactl/pkg/tokens/zoneingress_client.go
+++ b/app/kumactl/pkg/tokens/zoneingress_client.go
@@ -3,7 +3,7 @@ package tokens
 import (
 	"bytes"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 
 	"github.com/pkg/errors"
@@ -47,7 +47,7 @@ func (h *httpZoneIngressTokenClient) Generate(zone string) (string, error) {
 		return "", errors.Wrap(err, "could not execute the request")
 	}
 	defer resp.Body.Close()
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return "", errors.Wrap(err, "could not read a body of the request")
 	}

--- a/pkg/api-server/auth_test.go
+++ b/pkg/api-server/auth_test.go
@@ -2,9 +2,10 @@ package api_server_test
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net"
 	"net/http"
+	"os"
 	"path/filepath"
 
 	. "github.com/onsi/ginkgo"
@@ -110,7 +111,7 @@ var _ = Describe("Auth test", func() {
 		// then
 		Expect(err).ToNot(HaveOccurred())
 		Expect(resp.StatusCode).To(Equal(403))
-		body, err := ioutil.ReadAll(resp.Body)
+		body, err := io.ReadAll(resp.Body)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(resp.Body.Close()).To(Succeed())
 		Expect(string(body)).To(MatchJSON(`{"title": "Access Denied", "details": "user \"mesh-system:anonymous/mesh-system:unauthenticated\" cannot access the resource of type \"Secret\""}`))
@@ -123,7 +124,7 @@ var _ = Describe("Auth test", func() {
 		// then
 		Expect(err).ToNot(HaveOccurred())
 		Expect(resp.StatusCode).To(Equal(403))
-		body, err := ioutil.ReadAll(resp.Body)
+		body, err := io.ReadAll(resp.Body)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(resp.Body.Close()).To(Succeed())
 		Expect(string(body)).To(MatchJSON(`{"title": "Access Denied", "details": "user \"mesh-system:anonymous/mesh-system:unauthenticated\" cannot access the resource of type \"Secret\""}`))
@@ -134,13 +135,13 @@ var _ = Describe("Auth test", func() {
 func createCertsForIP(ip string) (certPath string, keyPath string) {
 	keyPair, err := tls.NewSelfSignedCert("kuma", tls.ServerCertType, tls.DefaultKeyType, "localhost", ip)
 	Expect(err).ToNot(HaveOccurred())
-	dir, err := ioutil.TempDir("", "temp-certs")
+	dir, err := os.MkdirTemp("", "temp-certs")
 	Expect(err).ToNot(HaveOccurred())
 	certPath = dir + "/cert.pem"
 	keyPath = dir + "/cert.key"
-	err = ioutil.WriteFile(certPath, keyPair.CertPEM, 0600)
+	err = os.WriteFile(certPath, keyPair.CertPEM, 0600)
 	Expect(err).ToNot(HaveOccurred())
-	err = ioutil.WriteFile(keyPath, keyPair.KeyPEM, 0600)
+	err = os.WriteFile(keyPath, keyPair.KeyPEM, 0600)
 	Expect(err).ToNot(HaveOccurred())
 	return
 }

--- a/pkg/api-server/circuit_breaker_endpoints_test.go
+++ b/pkg/api-server/circuit_breaker_endpoints_test.go
@@ -2,7 +2,7 @@ package api_server_test
 
 import (
 	"context"
-	"io/ioutil"
+	"io"
 	"time"
 
 	"github.com/ghodss/yaml"
@@ -117,7 +117,7 @@ var _ = Describe("CircuitBreaker Endpoints", func() {
 			// then
 			Expect(response.StatusCode).To(Equal(200))
 			// when
-			body, err := ioutil.ReadAll(response.Body)
+			body, err := io.ReadAll(response.Body)
 			// then
 			Expect(err).ToNot(HaveOccurred())
 

--- a/pkg/api-server/config_ws_test.go
+++ b/pkg/api-server/config_ws_test.go
@@ -2,7 +2,7 @@ package api_server_test
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 
@@ -45,7 +45,7 @@ var _ = Describe("Config WS", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		// then
-		body, err := ioutil.ReadAll(resp.Body)
+		body, err := io.ReadAll(resp.Body)
 		Expect(err).ToNot(HaveOccurred())
 
 		json := fmt.Sprintf(`

--- a/pkg/api-server/customization/api_manager_test.go
+++ b/pkg/api-server/customization/api_manager_test.go
@@ -2,7 +2,7 @@ package customization_test
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 
@@ -55,7 +55,7 @@ var _ = Describe("API Manager", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		// then
-		body, err := ioutil.ReadAll(resp.Body)
+		body, err := io.ReadAll(resp.Body)
 		Expect(err).ToNot(HaveOccurred())
 
 		// when

--- a/pkg/api-server/dataplane_overview_endpoints_test.go
+++ b/pkg/api-server/dataplane_overview_endpoints_test.go
@@ -3,7 +3,7 @@ package api_server_test
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"time"
 
@@ -237,7 +237,7 @@ var _ = Describe("Dataplane Overview Endpoints", func() {
 
 			// then
 			Expect(response.StatusCode).To(Equal(200))
-			body, err := ioutil.ReadAll(response.Body)
+			body, err := io.ReadAll(response.Body)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(body).To(MatchJSON(dp1Json))
 		})
@@ -255,7 +255,7 @@ var _ = Describe("Dataplane Overview Endpoints", func() {
 
 				// then
 				Expect(response.StatusCode).To(Equal(200))
-				body, err := ioutil.ReadAll(response.Body)
+				body, err := io.ReadAll(response.Body)
 				Expect(err).ToNot(HaveOccurred())
 
 				Expect(string(body)).To(MatchJSON(tc.expectedJson))

--- a/pkg/api-server/fault_injection_endpoints_test.go
+++ b/pkg/api-server/fault_injection_endpoints_test.go
@@ -2,7 +2,7 @@ package api_server_test
 
 import (
 	"context"
-	"io/ioutil"
+	"io"
 	"time"
 
 	"github.com/ghodss/yaml"
@@ -109,7 +109,7 @@ var _ = Describe("FaultInjection Endpoints", func() {
 			// then
 			Expect(response.StatusCode).To(Equal(200))
 			// when
-			body, err := ioutil.ReadAll(response.Body)
+			body, err := io.ReadAll(response.Body)
 			// then
 			Expect(err).ToNot(HaveOccurred())
 

--- a/pkg/api-server/global_insights_endpoints_test.go
+++ b/pkg/api-server/global_insights_endpoints_test.go
@@ -2,7 +2,7 @@ package api_server_test
 
 import (
 	"context"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"time"
 
@@ -125,7 +125,7 @@ var _ = Describe("Global Insights Endpoints", func() {
 
 			// then
 			Expect(response.StatusCode).To(Equal(200))
-			body, err := ioutil.ReadAll(response.Body)
+			body, err := io.ReadAll(response.Body)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(body).To(MatchJSON(globalInsightsJSON))
 		})

--- a/pkg/api-server/global_secret_endpoints_test.go
+++ b/pkg/api-server/global_secret_endpoints_test.go
@@ -2,7 +2,7 @@ package api_server_test
 
 import (
 	"context"
-	"io/ioutil"
+	"io"
 	"time"
 
 	"github.com/ghodss/yaml"
@@ -91,7 +91,7 @@ var _ = Describe("GlobalSecret Endpoints", func() {
 			// then
 			Expect(response.StatusCode).To(Equal(200))
 			// when
-			body, err := ioutil.ReadAll(response.Body)
+			body, err := io.ReadAll(response.Body)
 			// then
 			Expect(err).ToNot(HaveOccurred())
 

--- a/pkg/api-server/health_check_endpoints_test.go
+++ b/pkg/api-server/health_check_endpoints_test.go
@@ -2,7 +2,7 @@ package api_server_test
 
 import (
 	"context"
-	"io/ioutil"
+	"io"
 	"time"
 
 	"github.com/ghodss/yaml"
@@ -102,7 +102,7 @@ var _ = Describe("HealthCheck Endpoints", func() {
 			// then
 			Expect(response.StatusCode).To(Equal(200))
 			// when
-			body, err := ioutil.ReadAll(response.Body)
+			body, err := io.ReadAll(response.Body)
 			// then
 			Expect(err).ToNot(HaveOccurred())
 

--- a/pkg/api-server/index_endpoints_test.go
+++ b/pkg/api-server/index_endpoints_test.go
@@ -2,7 +2,7 @@ package api_server_test
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 	"time"
@@ -60,7 +60,7 @@ var _ = Describe("Index Endpoints", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		// then
-		body, err := ioutil.ReadAll(resp.Body)
+		body, err := io.ReadAll(resp.Body)
 		Expect(err).ToNot(HaveOccurred())
 
 		hostname, err := os.Hostname()

--- a/pkg/api-server/mesh_endpoints_test.go
+++ b/pkg/api-server/mesh_endpoints_test.go
@@ -3,7 +3,7 @@ package api_server_test
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"time"
 
 	. "github.com/onsi/ginkgo"
@@ -59,7 +59,7 @@ var _ = Describe("Resource Endpoints", func() {
 
 			// then
 			Expect(response.StatusCode).To(Equal(200))
-			body, err := ioutil.ReadAll(response.Body)
+			body, err := io.ReadAll(response.Body)
 			Expect(err).ToNot(HaveOccurred())
 			json := `
 			{
@@ -103,7 +103,7 @@ var _ = Describe("Resource Endpoints", func() {
 				"creationTime": "2018-07-17T16:05:36.995Z",
 				"modificationTime": "2018-07-17T16:05:36.995Z"
 			}`
-			body, err := ioutil.ReadAll(response.Body)
+			body, err := io.ReadAll(response.Body)
 			Expect(err).ToNot(HaveOccurred())
 
 			Expect(string(body)).To(Or(

--- a/pkg/api-server/read_only_resource_endpoints_test.go
+++ b/pkg/api-server/read_only_resource_endpoints_test.go
@@ -1,7 +1,7 @@
 package api_server_test
 
 import (
-	"io/ioutil"
+	"io"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -88,7 +88,7 @@ var _ = Describe("Read only Resource Endpoints", func() {
 
 			// then
 			Expect(response.StatusCode).To(Equal(405))
-			body, err := ioutil.ReadAll(response.Body)
+			body, err := io.ReadAll(response.Body)
 
 			Expect(err).NotTo(HaveOccurred())
 			Expect(string(body)).To(Equal(
@@ -105,7 +105,7 @@ var _ = Describe("Read only Resource Endpoints", func() {
 
 			// then
 			Expect(response.StatusCode).To(Equal(405))
-			body, err := ioutil.ReadAll(response.Body)
+			body, err := io.ReadAll(response.Body)
 
 			Expect(err).NotTo(HaveOccurred())
 			Expect(string(body)).To(Equal(

--- a/pkg/api-server/resource_endpoints_test.go
+++ b/pkg/api-server/resource_endpoints_test.go
@@ -3,7 +3,7 @@ package api_server_test
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 
 	"github.com/emicklei/go-restful"
@@ -72,7 +72,7 @@ var _ = Describe("Resource Endpoints", func() {
 
 			// then
 			Expect(response.StatusCode).To(Equal(200))
-			body, err := ioutil.ReadAll(response.Body)
+			body, err := io.ReadAll(response.Body)
 			Expect(err).ToNot(HaveOccurred())
 			json := `
 			{
@@ -94,7 +94,7 @@ var _ = Describe("Resource Endpoints", func() {
 			Expect(response.StatusCode).To(Equal(404))
 
 			// and
-			bytes, err := ioutil.ReadAll(response.Body)
+			bytes, err := io.ReadAll(response.Body)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(bytes).To(MatchJSON(`
 			{
@@ -132,7 +132,7 @@ var _ = Describe("Resource Endpoints", func() {
 				"modificationTime": "0001-01-01T00:00:00Z",
 				"path": "/sample-path"
 			}`
-			body, err := ioutil.ReadAll(response.Body)
+			body, err := io.ReadAll(response.Body)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(body).To(Or(
 				MatchJSON(fmt.Sprintf(`{"total": %d, "items": [%s,%s], "next": null}`, 2, json1, json2)),
@@ -172,7 +172,7 @@ var _ = Describe("Resource Endpoints", func() {
 				"modificationTime": "0001-01-01T00:00:00Z",
 				"path": "/sample-path"
 			}`
-			body, err := ioutil.ReadAll(response.Body)
+			body, err := io.ReadAll(response.Body)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(body).To(Or(
 				MatchJSON(fmt.Sprintf(`{"total": %d, "items": [%s,%s], "next": null}`, 2, json1, json2)),
@@ -218,7 +218,7 @@ var _ = Describe("Resource Endpoints", func() {
 				],
 				"next": "http://%s/sample-traffic-routes?offset=2&size=2"
 			}`, client.address)
-			body, err := ioutil.ReadAll(response.Body)
+			body, err := io.ReadAll(response.Body)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(body).To(MatchJSON(json))
 
@@ -246,7 +246,7 @@ var _ = Describe("Resource Endpoints", func() {
 				],
 				"next": null
 			}`
-			body, err = ioutil.ReadAll(response.Body)
+			body, err = io.ReadAll(response.Body)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(body).To(MatchJSON(json))
 		})
@@ -262,7 +262,7 @@ var _ = Describe("Resource Endpoints", func() {
 			// then
 			Expect(response.StatusCode).To(Equal(400))
 			// and
-			bytes, err := ioutil.ReadAll(response.Body)
+			bytes, err := io.ReadAll(response.Body)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(bytes).To(MatchJSON(`
 			{
@@ -289,7 +289,7 @@ var _ = Describe("Resource Endpoints", func() {
 			// then
 			Expect(response.StatusCode).To(Equal(400))
 			// and
-			bytes, err := ioutil.ReadAll(response.Body)
+			bytes, err := io.ReadAll(response.Body)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(bytes).To(MatchJSON(`
 			{
@@ -316,7 +316,7 @@ var _ = Describe("Resource Endpoints", func() {
 			// then
 			Expect(response.StatusCode).To(Equal(400))
 			// and
-			bytes, err := ioutil.ReadAll(response.Body)
+			bytes, err := io.ReadAll(response.Body)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(bytes).To(MatchJSON(`
 			{
@@ -398,7 +398,7 @@ var _ = Describe("Resource Endpoints", func() {
 			Expect(response.StatusCode).To(Equal(400))
 
 			// and
-			bytes, err := ioutil.ReadAll(response.Body)
+			bytes, err := io.ReadAll(response.Body)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(bytes).To(MatchJSON(`
 			{
@@ -432,7 +432,7 @@ var _ = Describe("Resource Endpoints", func() {
 			Expect(response.StatusCode).To(Equal(400))
 
 			// and
-			bytes, err := ioutil.ReadAll(response.Body)
+			bytes, err := io.ReadAll(response.Body)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(bytes).To(MatchJSON(`
 			{
@@ -466,7 +466,7 @@ var _ = Describe("Resource Endpoints", func() {
 			Expect(response.StatusCode).To(Equal(400))
 
 			// and
-			bytes, err := ioutil.ReadAll(response.Body)
+			bytes, err := io.ReadAll(response.Body)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(bytes).To(MatchJSON(`
 			{
@@ -499,7 +499,7 @@ var _ = Describe("Resource Endpoints", func() {
 			Expect(response.StatusCode).To(Equal(400))
 
 			// when
-			respBytes, err := ioutil.ReadAll(response.Body)
+			respBytes, err := io.ReadAll(response.Body)
 
 			// then
 			Expect(err).ToNot(HaveOccurred())
@@ -539,7 +539,7 @@ var _ = Describe("Resource Endpoints", func() {
 			Expect(response.StatusCode).To(Equal(400))
 
 			// when
-			respBytes, err := ioutil.ReadAll(response.Body)
+			respBytes, err := io.ReadAll(response.Body)
 
 			// then
 			Expect(err).ToNot(HaveOccurred())
@@ -582,7 +582,7 @@ var _ = Describe("Resource Endpoints", func() {
 			response := client.put(res)
 
 			// when
-			respBytes, err := ioutil.ReadAll(response.Body)
+			respBytes, err := io.ReadAll(response.Body)
 
 			// then
 			Expect(err).ToNot(HaveOccurred())
@@ -627,7 +627,7 @@ var _ = Describe("Resource Endpoints", func() {
 			Expect(response.StatusCode).To(Equal(404))
 
 			// and
-			bytes, err := ioutil.ReadAll(response.Body)
+			bytes, err := io.ReadAll(response.Body)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(bytes).To(MatchJSON(`
 			{

--- a/pkg/api-server/secret_endpoints_test.go
+++ b/pkg/api-server/secret_endpoints_test.go
@@ -2,7 +2,7 @@ package api_server_test
 
 import (
 	"context"
-	"io/ioutil"
+	"io"
 	"time"
 
 	"github.com/ghodss/yaml"
@@ -92,7 +92,7 @@ var _ = Describe("Secret Endpoints", func() {
 			// then
 			Expect(response.StatusCode).To(Equal(200))
 			// when
-			body, err := ioutil.ReadAll(response.Body)
+			body, err := io.ReadAll(response.Body)
 			// then
 			Expect(err).ToNot(HaveOccurred())
 

--- a/pkg/api-server/server.go
+++ b/pkg/api-server/server.go
@@ -7,9 +7,9 @@ import (
 	"crypto/x509"
 	"encoding/json"
 	"io"
-	"io/ioutil"
 	"net"
 	"net/http"
+	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -323,7 +323,7 @@ func configureMTLS(certsDir string) (*tls.Config, error) {
 	if certsDir != "" {
 		log.Info("loading client certificates")
 		clientCertPool := x509.NewCertPool()
-		files, err := ioutil.ReadDir(certsDir)
+		files, err := os.ReadDir(certsDir)
 		if err != nil {
 			return nil, err
 		}
@@ -337,7 +337,7 @@ func configureMTLS(certsDir string) (*tls.Config, error) {
 			}
 			log.Info("adding client certificate", "file", file.Name())
 			path := filepath.Join(certsDir, file.Name())
-			caCert, err := ioutil.ReadFile(path)
+			caCert, err := os.ReadFile(path)
 			if err != nil {
 				return nil, errors.Wrapf(err, "could not read certificate %q", path)
 			}

--- a/pkg/api-server/server_gui_test.go
+++ b/pkg/api-server/server_gui_test.go
@@ -2,8 +2,9 @@ package api_server_test
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -68,14 +69,14 @@ var _ = Describe("GUI Server", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			// when
-			received, err := ioutil.ReadAll(resp.Body)
+			received, err := io.ReadAll(resp.Body)
 
 			// then
 			Expect(resp.Body.Close()).To(Succeed())
 			Expect(err).ToNot(HaveOccurred())
 
 			// when
-			fileContent, err := ioutil.ReadFile(filepath.Join("..", "..", "app", "kuma-ui", "pkg", "resources", "data", given.expectedFile))
+			fileContent, err := os.ReadFile(filepath.Join("..", "..", "app", "kuma-ui", "pkg", "resources", "data", given.expectedFile))
 
 			// then
 			Expect(err).ToNot(HaveOccurred())
@@ -112,7 +113,7 @@ var _ = Describe("GUI Server", func() {
 				Expect(err).ToNot(HaveOccurred())
 
 				// when
-				received, err := ioutil.ReadAll(resp.Body)
+				received, err := io.ReadAll(resp.Body)
 
 				// then
 				Expect(resp.Body.Close()).To(Succeed())

--- a/pkg/api-server/service_insight_endpoints_test.go
+++ b/pkg/api-server/service_insight_endpoints_test.go
@@ -2,7 +2,7 @@ package api_server_test
 
 import (
 	"context"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 	"time"
@@ -150,7 +150,7 @@ var _ = Describe("Service Insight Endpoints", func() {
 
 			// then
 			Expect(response.StatusCode).To(Equal(200))
-			body, err := ioutil.ReadAll(response.Body)
+			body, err := io.ReadAll(response.Body)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(body).To(MatchJSON(expected))
 		})
@@ -177,7 +177,7 @@ var _ = Describe("Service Insight Endpoints", func() {
 
 			// then
 			Expect(response.StatusCode).To(Equal(200))
-			body, err := ioutil.ReadAll(response.Body)
+			body, err := io.ReadAll(response.Body)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(body).To(MatchJSON(expected))
 		})
@@ -195,7 +195,7 @@ var _ = Describe("Service Insight Endpoints", func() {
 
 			// then
 			Expect(response.StatusCode).To(Equal(200))
-			body, err := ioutil.ReadAll(response.Body)
+			body, err := io.ReadAll(response.Body)
 			Expect(err).ToNot(HaveOccurred())
 
 			expected := strings.ReplaceAll(given.expected, "{{address}}", apiServer.Address())

--- a/pkg/api-server/traffic_route_endpoints_test.go
+++ b/pkg/api-server/traffic_route_endpoints_test.go
@@ -2,7 +2,7 @@ package api_server_test
 
 import (
 	"context"
-	"io/ioutil"
+	"io"
 	"time"
 
 	"github.com/ghodss/yaml"
@@ -110,7 +110,7 @@ var _ = Describe("TrafficRoute Endpoints", func() {
 			// then
 			Expect(response.StatusCode).To(Equal(200))
 			// when
-			body, err := ioutil.ReadAll(response.Body)
+			body, err := io.ReadAll(response.Body)
 			// then
 			Expect(err).ToNot(HaveOccurred())
 

--- a/pkg/api-server/traffic_trace_endpoints_test.go
+++ b/pkg/api-server/traffic_trace_endpoints_test.go
@@ -2,7 +2,7 @@ package api_server_test
 
 import (
 	"context"
-	"io/ioutil"
+	"io"
 	"time"
 
 	"github.com/ghodss/yaml"
@@ -97,7 +97,7 @@ var _ = Describe("TrafficTrace Endpoints", func() {
 			// then
 			Expect(response.StatusCode).To(Equal(200))
 			// when
-			body, err := ioutil.ReadAll(response.Body)
+			body, err := io.ReadAll(response.Body)
 			// then
 			Expect(err).ToNot(HaveOccurred())
 

--- a/pkg/api-server/versions_ws_test.go
+++ b/pkg/api-server/versions_ws_test.go
@@ -2,7 +2,7 @@ package api_server_test
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"path"
 
@@ -39,7 +39,7 @@ var _ = Describe("Versions WS", func() {
 		}, "3s").ShouldNot(HaveOccurred())
 
 		// then
-		bytes, err := ioutil.ReadAll(resp.Body)
+		bytes, err := io.ReadAll(resp.Body)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(bytes).To(matchers.MatchGoldenJSON(path.Join("testdata", "versions.json")))
 	})

--- a/pkg/api-server/zone_overview_endpoints_test.go
+++ b/pkg/api-server/zone_overview_endpoints_test.go
@@ -3,7 +3,7 @@ package api_server_test
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"time"
 
@@ -160,7 +160,7 @@ var _ = Describe("Zone Overview Endpoints", func() {
 
 			// then
 			Expect(response.StatusCode).To(Equal(200))
-			body, err := ioutil.ReadAll(response.Body)
+			body, err := io.ReadAll(response.Body)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(body).To(MatchJSON(zone1Json))
 		})
@@ -172,7 +172,7 @@ var _ = Describe("Zone Overview Endpoints", func() {
 
 			// then
 			Expect(response.StatusCode).To(Equal(200))
-			body, err := ioutil.ReadAll(response.Body)
+			body, err := io.ReadAll(response.Body)
 			Expect(err).ToNot(HaveOccurred())
 
 			Expect(string(body)).To(MatchJSON(fmt.Sprintf(`{"total": 3, "items": [%s,%s,%s], "next": null}`, zone1Json, zone2Json, zone3Json)))

--- a/pkg/config/app/kuma-dp/config_test.go
+++ b/pkg/config/app/kuma-dp/config_test.go
@@ -2,7 +2,6 @@ package kumadp_test
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -119,7 +118,7 @@ var _ = Describe("Config", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		// when
-		expected, err := ioutil.ReadFile(filepath.Join("testdata", "default-config.golden.yaml"))
+		expected, err := os.ReadFile(filepath.Join("testdata", "default-config.golden.yaml"))
 		// then
 		Expect(err).ToNot(HaveOccurred())
 		// and

--- a/pkg/config/app/kuma-prometheus-sd/config_test.go
+++ b/pkg/config/app/kuma-prometheus-sd/config_test.go
@@ -1,7 +1,6 @@
 package kuma_prometheus_sd_test
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -84,7 +83,7 @@ var _ = Describe("Config", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		// when
-		expected, err := ioutil.ReadFile(filepath.Join("testdata", "default-config.golden.yaml"))
+		expected, err := os.ReadFile(filepath.Join("testdata", "default-config.golden.yaml"))
 		// then
 		Expect(err).ToNot(HaveOccurred())
 		// and

--- a/pkg/config/loader.go
+++ b/pkg/config/loader.go
@@ -1,9 +1,6 @@
 package config
 
 import (
-
-	// we use gopkg.in/yaml.v2 because it supports time.Duration
-	"io/ioutil"
 	"os"
 
 	"github.com/kelseyhightower/envconfig"
@@ -34,7 +31,7 @@ func loadFromFile(file string, cfg Config) error {
 	if !fileExists(file) {
 		return errors.Errorf("Failed to access configuration file %q", file)
 	}
-	if contents, err := ioutil.ReadFile(file); err != nil {
+	if contents, err := os.ReadFile(file); err != nil {
 		return errors.Wrapf(err, "Failed to read configuration from file %q", file)
 	} else if err := yaml.Unmarshal(contents, cfg); err != nil {
 		return errors.Wrapf(err, "Failed to parse configuration from file %q", file)

--- a/pkg/config/loader_test.go
+++ b/pkg/config/loader_test.go
@@ -1,7 +1,6 @@
 package config_test
 
 import (
-	"io/ioutil"
 	"os"
 	"time"
 
@@ -23,7 +22,7 @@ var _ = Describe("Config loader", func() {
 
 	BeforeEach(func() {
 		os.Clearenv()
-		file, err := ioutil.TempFile("", "*")
+		file, err := os.CreateTemp("", "*")
 		Expect(err).ToNot(HaveOccurred())
 		configFile = file
 	})
@@ -47,7 +46,7 @@ var _ = Describe("Config loader", func() {
 	DescribeTable("should load config",
 		func(given testCase) {
 			// given file with sample config
-			file, err := ioutil.TempFile("", "*")
+			file, err := os.CreateTemp("", "*")
 			Expect(err).ToNot(HaveOccurred())
 			_, err = file.WriteString(given.yamlFileConfig)
 			Expect(err).ToNot(HaveOccurred())
@@ -605,7 +604,7 @@ access:
 
 	It("should override via env var", func() {
 		// given file with sample cfg
-		file, err := ioutil.TempFile("", "*")
+		file, err := os.CreateTemp("", "*")
 		Expect(err).ToNot(HaveOccurred())
 		_, err = file.WriteString("environment: kubernetes")
 		Expect(err).ToNot(HaveOccurred())

--- a/pkg/config/multizone/multicluster.go
+++ b/pkg/config/multizone/multicluster.go
@@ -2,8 +2,8 @@ package multizone
 
 import (
 	"crypto/x509"
-	"io/ioutil"
 	"net/url"
+	"os"
 	"time"
 
 	"github.com/asaskevich/govalidator"
@@ -72,7 +72,7 @@ func (r *ZoneConfig) Validate() error {
 		rootCaFile := r.KDS.RootCAFile
 		if rootCaFile != "" {
 			roots := x509.NewCertPool()
-			caCert, err := ioutil.ReadFile(rootCaFile)
+			caCert, err := os.ReadFile(rootCaFile)
 			if err != nil {
 				return errors.Wrapf(err, "could not read certificate %s", rootCaFile)
 			}

--- a/pkg/config/plugins/runtime/universal/config_test.go
+++ b/pkg/config/plugins/runtime/universal/config_test.go
@@ -1,7 +1,7 @@
 package universal_test
 
 import (
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"time"
 
@@ -37,7 +37,7 @@ var _ = Describe("Config", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		// when
-		expected, err := ioutil.ReadFile(filepath.Join("testdata", "default-config.golden.yaml"))
+		expected, err := os.ReadFile(filepath.Join("testdata", "default-config.golden.yaml"))
 		// then
 		Expect(err).ToNot(HaveOccurred())
 		// and

--- a/pkg/config/xds/bootstrap/config_test.go
+++ b/pkg/config/xds/bootstrap/config_test.go
@@ -1,7 +1,6 @@
 package bootstrap_test
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -94,7 +93,7 @@ var _ = Describe("BootstrappServerConfig", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		// when
-		expected, err := ioutil.ReadFile(filepath.Join("testdata", "default-config.golden.yaml"))
+		expected, err := os.ReadFile(filepath.Join("testdata", "default-config.golden.yaml"))
 		// then
 		Expect(err).ToNot(HaveOccurred())
 		// and

--- a/pkg/core/bootstrap/autoconfig.go
+++ b/pkg/core/bootstrap/autoconfig.go
@@ -2,7 +2,6 @@ package bootstrap
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"strings"
@@ -140,7 +139,7 @@ func tryReadKeyPair(dir workDir) (string, string, error) {
 		}
 	}()
 
-	certPEM, err := ioutil.ReadFile(crtFile.Name())
+	certPEM, err := os.ReadFile(crtFile.Name())
 	if err != nil {
 		return "", "", err
 	}
@@ -156,7 +155,7 @@ func tryReadKeyPair(dir workDir) (string, string, error) {
 			autoconfigureLog.Error(err, "failed to close TLS key file")
 		}
 	}()
-	keyPEM, err := ioutil.ReadFile(keyFile.Name())
+	keyPEM, err := os.ReadFile(keyFile.Name())
 	if err != nil {
 		return "", "", err
 	}
@@ -176,7 +175,7 @@ func saveKeyPair(pair tls.KeyPair, dir workDir) (string, string, error) {
 			autoconfigureLog.Error(err, "failed to close TLS cert file")
 		}
 	}()
-	if err := ioutil.WriteFile(crtFile.Name(), pair.CertPEM, os.ModeTemporary); err != nil {
+	if err := os.WriteFile(crtFile.Name(), pair.CertPEM, os.ModeTemporary); err != nil {
 		return "", "", errors.Wrapf(err, "failed to save TLS cert into a file %q", crtFile.Name())
 	}
 
@@ -189,7 +188,7 @@ func saveKeyPair(pair tls.KeyPair, dir workDir) (string, string, error) {
 			autoconfigureLog.Error(err, "failed to close TLS key file")
 		}
 	}()
-	if err := ioutil.WriteFile(keyFile.Name(), pair.KeyPEM, os.ModeTemporary); err != nil {
+	if err := os.WriteFile(keyFile.Name(), pair.KeyPEM, os.ModeTemporary); err != nil {
 		return "", "", errors.Wrapf(err, "failed to save TLS key into a file %q", keyFile.Name())
 	}
 

--- a/pkg/core/datasource/loader.go
+++ b/pkg/core/datasource/loader.go
@@ -2,7 +2,7 @@ package datasource
 
 import (
 	"context"
-	"io/ioutil"
+	"os"
 
 	"github.com/pkg/errors"
 
@@ -39,7 +39,7 @@ func (l *loader) Load(ctx context.Context, mesh string, source *system_proto.Dat
 	case *system_proto.DataSource_InlineString:
 		data, err = []byte(source.GetInlineString()), nil
 	case *system_proto.DataSource_File:
-		data, err = ioutil.ReadFile(source.GetFile())
+		data, err = os.ReadFile(source.GetFile())
 	default:
 		return nil, errors.New("unsupported type of the DataSource")
 	}

--- a/pkg/core/datasource/loader_test.go
+++ b/pkg/core/datasource/loader_test.go
@@ -2,7 +2,6 @@ package datasource_test
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 
 	. "github.com/onsi/ginkgo"
@@ -69,9 +68,9 @@ var _ = Describe("DataSource Loader", func() {
 	Context("File", func() {
 		It("should load from file", func() {
 			// given
-			file, err := ioutil.TempFile("", "")
+			file, err := os.CreateTemp("", "")
 			Expect(err).ToNot(HaveOccurred())
-			err = ioutil.WriteFile(file.Name(), []byte("abc"), os.ModeAppend)
+			err = os.WriteFile(file.Name(), []byte("abc"), os.ModeAppend)
 			Expect(err).ToNot(HaveOccurred())
 
 			// when

--- a/pkg/hds/tracker/healthcheck_generator_test.go
+++ b/pkg/hds/tracker/healthcheck_generator_test.go
@@ -2,7 +2,7 @@ package tracker
 
 import (
 	"context"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"time"
 
@@ -54,7 +54,7 @@ var _ = Describe("HDS Snapshot generator", func() {
 			yml, err := util_proto.ToYAML(snapshot.GetResources(cache.HealthCheckSpecifierType)["hcs"])
 			Expect(err).ToNot(HaveOccurred())
 
-			golden, err := ioutil.ReadFile(filepath.Join("testdata", given.goldenFile))
+			golden, err := os.ReadFile(filepath.Join("testdata", given.goldenFile))
 			Expect(err).ToNot(HaveOccurred())
 			Expect(golden).To(MatchYAML(yml))
 		},

--- a/pkg/kds/mux/client.go
+++ b/pkg/kds/mux/client.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"crypto/tls"
 	"crypto/x509"
-	"io/ioutil"
 	"net/url"
+	"os"
 
 	"github.com/pkg/errors"
 	"google.golang.org/grpc"
@@ -121,7 +121,7 @@ func tlsConfig(rootCaFile string) (*tls.Config, error) {
 		}, nil
 	}
 	roots := x509.NewCertPool()
-	caCert, err := ioutil.ReadFile(rootCaFile)
+	caCert, err := os.ReadFile(rootCaFile)
 	if err != nil {
 		return nil, errors.Wrapf(err, "could not read certificate %s", rootCaFile)
 	}

--- a/pkg/mads/v1/service/http.go
+++ b/pkg/mads/v1/service/http.go
@@ -2,7 +2,7 @@ package service
 
 import (
 	"context"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"time"
 
@@ -31,7 +31,7 @@ func (s *service) RegisterRoutes(ws *restful.WebService) {
 }
 
 func (s *service) handleDiscovery(req *restful.Request, res *restful.Response) {
-	body, err := ioutil.ReadAll(req.Request.Body)
+	body, err := io.ReadAll(req.Request.Body)
 	if err != nil {
 		writeBadRequestError(res, rest_error_types.Error{
 			Title:   "Could not read request body",

--- a/pkg/mads/v1/service_test.go
+++ b/pkg/mads/v1/service_test.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"strings"
 	"time"
@@ -99,7 +98,7 @@ var _ = Describe("MADS http service", func() {
 		Expect(resp.StatusCode).To(Equal(http.StatusOK))
 
 		// when
-		respBody, err := ioutil.ReadAll(resp.Body)
+		respBody, err := io.ReadAll(resp.Body)
 
 		// then
 		Expect(err).ToNot(HaveOccurred())
@@ -129,7 +128,7 @@ var _ = Describe("MADS http service", func() {
 		Expect(resp.StatusCode).To(Equal(http.StatusNotModified))
 
 		// when
-		respBody, err = ioutil.ReadAll(resp.Body)
+		respBody, err = io.ReadAll(resp.Body)
 
 		// then
 		Expect(err).ToNot(HaveOccurred())
@@ -248,7 +247,7 @@ var _ = Describe("MADS http service", func() {
 			Expect(resp.StatusCode).To(Equal(http.StatusOK))
 
 			// when
-			respBody, err := ioutil.ReadAll(resp.Body)
+			respBody, err := io.ReadAll(resp.Body)
 
 			// then
 			Expect(err).ToNot(HaveOccurred())
@@ -291,7 +290,7 @@ var _ = Describe("MADS http service", func() {
 			Expect(resp.StatusCode).To(Equal(http.StatusNotModified))
 
 			// when
-			respBody, err = ioutil.ReadAll(resp.Body)
+			respBody, err = io.ReadAll(resp.Body)
 
 			// then
 			Expect(err).ToNot(HaveOccurred())
@@ -323,7 +322,7 @@ var _ = Describe("MADS http service", func() {
 			Expect(resp.StatusCode).To(Equal(http.StatusOK))
 
 			// when
-			respBody, err := ioutil.ReadAll(resp.Body)
+			respBody, err := io.ReadAll(resp.Body)
 
 			// then
 			Expect(err).ToNot(HaveOccurred())
@@ -360,7 +359,7 @@ var _ = Describe("MADS http service", func() {
 			Expect(resp.StatusCode).To(Equal(http.StatusOK))
 
 			// when
-			respBody, err = ioutil.ReadAll(resp.Body)
+			respBody, err = io.ReadAll(resp.Body)
 
 			// then
 			Expect(err).ToNot(HaveOccurred())
@@ -400,7 +399,7 @@ var _ = Describe("MADS http service", func() {
 			Expect(resp.StatusCode).To(Equal(http.StatusOK))
 
 			// when
-			respBody, err := ioutil.ReadAll(resp.Body)
+			respBody, err := io.ReadAll(resp.Body)
 
 			// then
 			Expect(err).ToNot(HaveOccurred())
@@ -446,7 +445,7 @@ var _ = Describe("MADS http service", func() {
 			Expect(resp2.StatusCode).To(Equal(http.StatusOK))
 
 			// when
-			respBody, err = ioutil.ReadAll(resp2.Body)
+			respBody, err = io.ReadAll(resp2.Body)
 
 			// then
 			Expect(err).ToNot(HaveOccurred())
@@ -543,7 +542,7 @@ var _ = Describe("MADS http service", func() {
 			Expect(resp.StatusCode).To(Equal(http.StatusOK))
 
 			// when
-			respBody, err := ioutil.ReadAll(resp.Body)
+			respBody, err := io.ReadAll(resp.Body)
 
 			// then
 			Expect(err).ToNot(HaveOccurred())

--- a/pkg/plugins/authn/api-server/tokens/ws/client/client.go
+++ b/pkg/plugins/authn/api-server/tokens/ws/client/client.go
@@ -3,7 +3,7 @@ package client
 import (
 	"bytes"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"time"
 
@@ -50,7 +50,7 @@ func (h *httpUserTokenClient) Generate(name string, groups []string, validFor ti
 		return "", errors.Wrap(err, "could not execute the request")
 	}
 	defer resp.Body.Close()
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return "", errors.Wrap(err, "could not read a body of the request")
 	}

--- a/pkg/plugins/ca/provided/ca_cert_validator_test.go
+++ b/pkg/plugins/ca/provided/ca_cert_validator_test.go
@@ -4,8 +4,8 @@ import (
 	"crypto/rand"
 	"crypto/rsa"
 	"crypto/x509"
-	"io/ioutil"
 	"math/big"
+	"os"
 	"path/filepath"
 
 	"github.com/ghodss/yaml"
@@ -22,9 +22,9 @@ var _ = Describe("ValidateCaCert()", func() {
 
 	It("should accept proper CA certificates", func() {
 		// when
-		cert, err := ioutil.ReadFile(filepath.Join("testdata", "ca.pem"))
+		cert, err := os.ReadFile(filepath.Join("testdata", "ca.pem"))
 		Expect(err).ToNot(HaveOccurred())
-		key, err := ioutil.ReadFile(filepath.Join("testdata", "ca.key"))
+		key, err := os.ReadFile(filepath.Join("testdata", "ca.key"))
 		Expect(err).ToNot(HaveOccurred())
 
 		signingPair := &util_tls.KeyPair{

--- a/pkg/plugins/ca/provided/manager_test.go
+++ b/pkg/plugins/ca/provided/manager_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"crypto/x509"
 	"encoding/pem"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"time"
 
@@ -180,7 +180,7 @@ var _ = Describe("Provided CA", func() {
 	Context("GetRootCert", func() {
 		It("should load return root certs", func() {
 			// given
-			expectedCert, err := ioutil.ReadFile(filepath.Join("testdata", "ca.pem"))
+			expectedCert, err := os.ReadFile(filepath.Join("testdata", "ca.pem"))
 			Expect(err).ToNot(HaveOccurred())
 
 			// when

--- a/pkg/plugins/resources/remote/store.go
+++ b/pkg/plugins/resources/remote/store.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strconv"
 
@@ -180,7 +180,7 @@ func (s *remoteStore) doRequest(ctx context.Context, req *http.Request) (int, []
 		return 0, nil, err
 	}
 	defer resp.Body.Close()
-	b, err := ioutil.ReadAll(resp.Body)
+	b, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return resp.StatusCode, nil, err
 	}

--- a/pkg/plugins/resources/remote/store_test.go
+++ b/pkg/plugins/resources/remote/store_test.go
@@ -4,7 +4,7 @@ import (
 	"bufio"
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -42,7 +42,7 @@ var _ = Describe("RemoteStore", func() {
 				}
 				return &http.Response{
 					StatusCode: http.StatusOK,
-					Body:       ioutil.NopCloser(bufio.NewReader(file)),
+					Body:       io.NopCloser(bufio.NewReader(file)),
 				}, nil
 			}),
 		}
@@ -60,7 +60,7 @@ var _ = Describe("RemoteStore", func() {
 			Transport: RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
 				return &http.Response{
 					StatusCode: code,
-					Body:       ioutil.NopCloser(strings.NewReader(errorMsg)),
+					Body:       io.NopCloser(strings.NewReader(errorMsg)),
 				}, nil
 			}),
 		}
@@ -159,7 +159,7 @@ var _ = Describe("RemoteStore", func() {
 			name := "res-1"
 			store := setupStore("create_update.json", func(req *http.Request) {
 				Expect(req.URL.Path).To(Equal(fmt.Sprintf("/meshes/default/traffic-routes/%s", name)))
-				bytes, err := ioutil.ReadAll(req.Body)
+				bytes, err := io.ReadAll(req.Body)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(bytes).To(MatchJSON(`{"mesh":"default","name":"res-1","path":"/some-path","type":"SampleTrafficRoute","creationTime": "0001-01-01T00:00:00Z","modificationTime": "0001-01-01T00:00:00Z"}`))
 			})
@@ -181,7 +181,7 @@ var _ = Describe("RemoteStore", func() {
 			meshName := "someMesh"
 			store := setupStore("create_update.json", func(req *http.Request) {
 				Expect(req.URL.Path).To(Equal(fmt.Sprintf("/meshes/%s", meshName)))
-				bytes, err := ioutil.ReadAll(req.Body)
+				bytes, err := io.ReadAll(req.Body)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(bytes).To(MatchJSON(`{"name":"someMesh","type":"Mesh","creationTime": "0001-01-01T00:00:00Z","modificationTime": "0001-01-01T00:00:00Z"}`))
 			})
@@ -235,7 +235,7 @@ var _ = Describe("RemoteStore", func() {
 			name := "res-1"
 			store := setupStore("create_update.json", func(req *http.Request) {
 				Expect(req.URL.Path).To(Equal(fmt.Sprintf("/meshes/default/traffic-routes/%s", name)))
-				bytes, err := ioutil.ReadAll(req.Body)
+				bytes, err := io.ReadAll(req.Body)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(bytes).To(MatchJSON(`{"mesh":"default","name":"res-1","path":"/some-path","type":"SampleTrafficRoute","creationTime": "0001-01-01T00:00:00Z","modificationTime": "0001-01-01T00:00:00Z"}`))
 			})
@@ -261,7 +261,7 @@ var _ = Describe("RemoteStore", func() {
 			meshName := "someMesh"
 			store := setupStore("create_update.json", func(req *http.Request) {
 				Expect(req.URL.Path).To(Equal(fmt.Sprintf("/meshes/%s", meshName)))
-				bytes, err := ioutil.ReadAll(req.Body)
+				bytes, err := io.ReadAll(req.Body)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(bytes).To(MatchJSON(`{"name":"someMesh","mtls":{"enabledBackend":"builtin","backends":[{"name":"builtin","type":"builtin"}]},"name":"someMesh","type":"Mesh","creationTime": "0001-01-01T00:00:00Z","modificationTime": "0001-01-01T00:00:00Z"}`))
 			})

--- a/pkg/plugins/runtime/gateway/suite_test.go
+++ b/pkg/plugins/runtime/gateway/suite_test.go
@@ -3,7 +3,7 @@ package gateway_test
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path"
 	"testing"
 
@@ -185,7 +185,7 @@ func FetchNamedFixture(
 // StoreNamedFixture reads the given YAML file name from the testdata
 // directory, then stores it in the runtime resource manager.
 func StoreNamedFixture(rt runtime.Runtime, name string) error {
-	bytes, err := ioutil.ReadFile(path.Join("testdata", name))
+	bytes, err := os.ReadFile(path.Join("testdata", name))
 	if err != nil {
 		return err
 	}

--- a/pkg/plugins/runtime/k8s/controllers/pod_converter_test.go
+++ b/pkg/plugins/runtime/k8s/controllers/pod_converter_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 
 	"github.com/ghodss/yaml"
@@ -88,7 +88,7 @@ var _ = Describe("PodToDataplane(..)", func() {
 			// given
 			// pod
 			pod := &kube_core.Pod{}
-			bytes, err := ioutil.ReadFile(filepath.Join("testdata", given.pod))
+			bytes, err := os.ReadFile(filepath.Join("testdata", given.pod))
 			Expect(err).ToNot(HaveOccurred())
 			err = yaml.Unmarshal(bytes, pod)
 			Expect(err).ToNot(HaveOccurred())
@@ -96,7 +96,7 @@ var _ = Describe("PodToDataplane(..)", func() {
 			// services for pod
 			services := []*kube_core.Service{}
 			if given.servicesForPod != "" {
-				bytes, err = ioutil.ReadFile(filepath.Join("testdata", given.servicesForPod))
+				bytes, err = os.ReadFile(filepath.Join("testdata", given.servicesForPod))
 				Expect(err).ToNot(HaveOccurred())
 				YAMLs := util_yaml.SplitYAML(string(bytes))
 				services, err = ParseServices(YAMLs)
@@ -106,7 +106,7 @@ var _ = Describe("PodToDataplane(..)", func() {
 			// other services
 			var serviceGetter kube_client.Reader
 			if given.otherServices != "" {
-				bytes, err = ioutil.ReadFile(filepath.Join("testdata", given.otherServices))
+				bytes, err = os.ReadFile(filepath.Join("testdata", given.otherServices))
 				Expect(err).ToNot(HaveOccurred())
 				YAMLs := util_yaml.SplitYAML(string(bytes))
 				services, err := ParseServices(YAMLs)
@@ -119,7 +119,7 @@ var _ = Describe("PodToDataplane(..)", func() {
 			// other dataplanes
 			var otherDataplanes []*mesh_k8s.Dataplane
 			if given.otherDataplanes != "" {
-				bytes, err = ioutil.ReadFile(filepath.Join("testdata", given.otherDataplanes))
+				bytes, err = os.ReadFile(filepath.Join("testdata", given.otherDataplanes))
 				Expect(err).ToNot(HaveOccurred())
 				YAMLs := util_yaml.SplitYAML(string(bytes))
 				otherDataplanes, err = ParseDataplanes(YAMLs)
@@ -141,7 +141,7 @@ var _ = Describe("PodToDataplane(..)", func() {
 
 			actual, err := json.Marshal(dataplane)
 			Expect(err).ToNot(HaveOccurred())
-			expected, err := ioutil.ReadFile(filepath.Join("testdata", given.dataplane))
+			expected, err := os.ReadFile(filepath.Join("testdata", given.dataplane))
 			Expect(err).ToNot(HaveOccurred())
 			Expect(actual).To(MatchYAML(expected))
 		},
@@ -238,13 +238,13 @@ var _ = Describe("PodToDataplane(..)", func() {
 			// given
 			// pod
 			pod := &kube_core.Pod{}
-			bytes, err := ioutil.ReadFile(filepath.Join("testdata", "ingress", given.pod))
+			bytes, err := os.ReadFile(filepath.Join("testdata", "ingress", given.pod))
 			Expect(err).ToNot(HaveOccurred())
 			err = yaml.Unmarshal(bytes, pod)
 			Expect(err).ToNot(HaveOccurred())
 
 			// services for pod
-			bytes, err = ioutil.ReadFile(filepath.Join("testdata", "ingress", given.servicesForPod))
+			bytes, err = os.ReadFile(filepath.Join("testdata", "ingress", given.servicesForPod))
 			Expect(err).ToNot(HaveOccurred())
 			YAMLs := util_yaml.SplitYAML(string(bytes))
 			services, err := ParseServices(YAMLs)
@@ -253,7 +253,7 @@ var _ = Describe("PodToDataplane(..)", func() {
 			// node
 			var nodeGetter kube_client.Reader
 			if given.node != "" {
-				bytes, err = ioutil.ReadFile(filepath.Join("testdata", "ingress", given.node))
+				bytes, err = os.ReadFile(filepath.Join("testdata", "ingress", given.node))
 				Expect(err).ToNot(HaveOccurred())
 				nodeGetter = fakeNodeReader(bytes)
 			}

--- a/pkg/plugins/runtime/k8s/webhooks/injector/injector.go
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/injector.go
@@ -3,7 +3,7 @@ package injector
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"sort"
 	"strconv"
 	"strings"
@@ -41,7 +41,7 @@ func New(
 ) (*KumaInjector, error) {
 	var caCert string
 	if cfg.CaCertFile != "" {
-		bytes, err := ioutil.ReadFile(cfg.CaCertFile)
+		bytes, err := os.ReadFile(cfg.CaCertFile)
 		if err != nil {
 			return nil, errors.Wrapf(err, "could not read provided CA cert file %s", cfg.CaCertFile)
 		}

--- a/pkg/plugins/runtime/k8s/webhooks/injector/injector_test.go
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/injector_test.go
@@ -3,7 +3,7 @@ package injector_test
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 
 	"github.com/ghodss/yaml"
@@ -64,7 +64,7 @@ var _ = Describe("Injector", func() {
 
 			By("loading input Pod")
 			// when
-			input, err := ioutil.ReadFile(inputFile)
+			input, err := os.ReadFile(inputFile)
 			// then
 			Expect(err).ToNot(HaveOccurred())
 			// when

--- a/pkg/test/matchers/golden.go
+++ b/pkg/test/matchers/golden.go
@@ -1,7 +1,7 @@
 package matchers
 
 import (
-	"io/ioutil"
+	"os"
 
 	"github.com/onsi/gomega"
 	"github.com/onsi/gomega/types"
@@ -58,12 +58,12 @@ func (g *GoldenYAMLMatcher) Match(actual interface{}) (success bool, err error) 
 		if actualContent[len(actualContent)-1] != '\n' {
 			actualContent += "\n"
 		}
-		err := ioutil.WriteFile(g.GoldenFilePath, []byte(actualContent), 0644)
+		err := os.WriteFile(g.GoldenFilePath, []byte(actualContent), 0644)
 		if err != nil {
 			return false, errors.Wrap(err, "could not update golden file")
 		}
 	}
-	expected, err := ioutil.ReadFile(g.GoldenFilePath)
+	expected, err := os.ReadFile(g.GoldenFilePath)
 	if err != nil {
 		return false, errors.Wrap(err, "could not read golden file")
 	}

--- a/pkg/tokens/builtin/server/webservice_test.go
+++ b/pkg/tokens/builtin/server/webservice_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -89,7 +89,7 @@ var _ = Describe("Dataplane Token Webservice", func() {
 		Expect(resp.StatusCode).To(Equal(200))
 
 		// when
-		respBody, err := ioutil.ReadAll(resp.Body)
+		respBody, err := io.ReadAll(resp.Body)
 
 		// then
 		Expect(err).ToNot(HaveOccurred())

--- a/pkg/transparentproxy/firewalld/firewalld.go
+++ b/pkg/transparentproxy/firewalld/firewalld.go
@@ -2,7 +2,6 @@ package firewalld
 
 import (
 	"encoding/xml"
-	"io/ioutil"
 	"os"
 	"regexp"
 	"strconv"
@@ -93,7 +92,7 @@ func (fit *FirewalldIptablesTranslator) getPersistentDirect() (*Direct, error) {
 		}
 	}
 
-	data, err := ioutil.ReadFile(fit.directlXMLPath)
+	data, err := os.ReadFile(fit.directlXMLPath)
 	if err != nil {
 		return nil, err
 	}
@@ -108,7 +107,7 @@ func (fit *FirewalldIptablesTranslator) getPersistentDirect() (*Direct, error) {
 
 func (fit *FirewalldIptablesTranslator) store(direct *Direct) (string, error) {
 	if !fit.dryRun {
-		err := ioutil.WriteFile(fit.directlXMLPath, direct.Bytes(), 0644) // -rw-r--r--.  1 root root  191 Mar 18 07:58 direct.xml
+		err := os.WriteFile(fit.directlXMLPath, direct.Bytes(), 0644) // -rw-r--r--.  1 root root  191 Mar 18 07:58 direct.xml
 		if err != nil {
 			return "", err
 		}

--- a/pkg/transparentproxy/istio/tools/istio-iptables/pkg/cmd/run.go
+++ b/pkg/transparentproxy/istio/tools/istio-iptables/pkg/cmd/run.go
@@ -16,7 +16,6 @@ package cmd
 import (
 	"bufio"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"os"
 	"strings"
@@ -789,7 +788,7 @@ func (iptConfigurator *IptablesConfigurator) executeIptablesRestoreCommand(isIpv
 		filename = fmt.Sprintf("ip6tables-rules-%d.txt", time.Now().UnixNano())
 		cmd = constants.IP6TABLESRESTORE
 	}
-	rulesFile, err := ioutil.TempFile("", filename)
+	rulesFile, err := os.CreateTemp("", filename)
 	if err != nil {
 		return fmt.Errorf("unable to create iptables-restore file: %v", err)
 	}

--- a/pkg/util/http/tls.go
+++ b/pkg/util/http/tls.go
@@ -3,8 +3,8 @@ package http
 import (
 	"crypto/tls"
 	"crypto/x509"
-	"io/ioutil"
 	"net/http"
+	"os"
 
 	"github.com/pkg/errors"
 )
@@ -17,7 +17,7 @@ func ConfigureMTLS(httpClient *http.Client, caCert string, clientCert string, cl
 	if caCert == "" {
 		transport.TLSClientConfig.InsecureSkipVerify = true
 	} else {
-		certBytes, err := ioutil.ReadFile(caCert)
+		certBytes, err := os.ReadFile(caCert)
 		if err != nil {
 			return errors.Wrap(err, "could not read CA cert")
 		}

--- a/pkg/util/os/fs.go
+++ b/pkg/util/os/fs.go
@@ -1,20 +1,19 @@
 package os
 
 import (
-	"io/ioutil"
 	"os"
 
 	"github.com/pkg/errors"
 )
 
 func TryWriteToDir(dir string) error {
-	file, err := ioutil.TempFile(dir, "write-access-check")
+	file, err := os.CreateTemp(dir, "write-access-check")
 	if err != nil {
 		if os.IsNotExist(err) {
 			if err := os.MkdirAll(dir, os.ModeDir|0755); err != nil {
 				return errors.Wrapf(err, "unable to create a directory %q", dir)
 			}
-			file, err = ioutil.TempFile(dir, "write-access-check")
+			file, err = os.CreateTemp(dir, "write-access-check")
 		}
 		if err != nil {
 			return errors.Wrapf(err, "unable to create temporary files in directory %q", dir)

--- a/pkg/xds/bootstrap/generator.go
+++ b/pkg/xds/bootstrap/generator.go
@@ -5,7 +5,7 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"sort"
 	"strings"
 
@@ -258,7 +258,7 @@ func (b *bootstrapGenerator) caCert(request types.BootstrapRequest) ([]byte, err
 		origin = "request .CaCert"
 	case b.xdsCertFile != "":
 		var err error
-		cert, err = ioutil.ReadFile(b.xdsCertFile)
+		cert, err = os.ReadFile(b.xdsCertFile)
 		origin = "file " + b.xdsCertFile
 		if err != nil {
 			return nil, errors.Wrapf(err, "failed getting cert from %s", origin)
@@ -301,7 +301,7 @@ func (s SANSet) slice() []string {
 }
 
 func hostsAndIPsFromCertFile(dpServerCertFile string) (SANSet, error) {
-	certBytes, err := ioutil.ReadFile(dpServerCertFile)
+	certBytes, err := os.ReadFile(dpServerCertFile)
 	if err != nil {
 		return nil, errors.Wrap(err, "could not read certificate")
 	}

--- a/pkg/xds/bootstrap/handler.go
+++ b/pkg/xds/bootstrap/handler.go
@@ -2,7 +2,7 @@ package bootstrap
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net"
 	"net/http"
 
@@ -22,7 +22,7 @@ type BootstrapHandler struct {
 }
 
 func (b *BootstrapHandler) Handle(resp http.ResponseWriter, req *http.Request) {
-	bytes, err := ioutil.ReadAll(req.Body)
+	bytes, err := io.ReadAll(req.Body)
 	if err != nil {
 		log.Error(err, "Could not read a request")
 		resp.WriteHeader(http.StatusInternalServerError)

--- a/pkg/xds/bootstrap/server_test.go
+++ b/pkg/xds/bootstrap/server_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"path/filepath"
 	"strconv"
@@ -144,7 +144,7 @@ var _ = Describe("Bootstrap Server", func() {
 
 			// then
 			Expect(err).ToNot(HaveOccurred())
-			received, err := ioutil.ReadAll(resp.Body)
+			received, err := io.ReadAll(resp.Body)
 			Expect(resp.Body.Close()).To(Succeed())
 			Expect(err).ToNot(HaveOccurred())
 
@@ -217,7 +217,7 @@ var _ = Describe("Bootstrap Server", func() {
 		resp, err := httpClient.Post(baseUrl+"/bootstrap", "application/json", strings.NewReader(json))
 		// then
 		Expect(err).ToNot(HaveOccurred())
-		bytes, err := ioutil.ReadAll(resp.Body)
+		bytes, err := io.ReadAll(resp.Body)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(resp.Body.Close()).To(Succeed())
 		Expect(resp.StatusCode).To(Equal(422))

--- a/pkg/xds/generator/admin_proxy_generator_test.go
+++ b/pkg/xds/generator/admin_proxy_generator_test.go
@@ -1,7 +1,7 @@
 package generator_test
 
 import (
-	"io/ioutil"
+	"os"
 	"path/filepath"
 
 	. "github.com/onsi/ginkgo"
@@ -33,7 +33,7 @@ var _ = Describe("AdminProxyGenerator", func() {
 
 			// dataplane
 			dataplane := core_mesh.NewDataplaneResource()
-			bytes, err := ioutil.ReadFile(filepath.Join("testdata", "admin", given.dataplaneFile))
+			bytes, err := os.ReadFile(filepath.Join("testdata", "admin", given.dataplaneFile))
 			Expect(err).ToNot(HaveOccurred())
 			parseResource(bytes, dataplane)
 

--- a/pkg/xds/generator/direct_access_proxy_generator_test.go
+++ b/pkg/xds/generator/direct_access_proxy_generator_test.go
@@ -1,7 +1,7 @@
 package generator_test
 
 import (
-	"io/ioutil"
+	"os"
 	"path/filepath"
 
 	"github.com/ghodss/yaml"
@@ -49,13 +49,13 @@ var _ = Describe("DirectAccessProxyGenerator", func() {
 
 			// dataplane
 			dataplane := core_mesh.NewDataplaneResource()
-			bytes, err := ioutil.ReadFile(filepath.Join("testdata", "direct-access", given.dataplaneFile))
+			bytes, err := os.ReadFile(filepath.Join("testdata", "direct-access", given.dataplaneFile))
 			Expect(err).ToNot(HaveOccurred())
 			parseResource(bytes, dataplane)
 
 			// all dataplanes
 			var dataplanes []*core_mesh.DataplaneResource
-			dpsBytes, err := ioutil.ReadFile(filepath.Join("testdata", "direct-access", given.dataplanesFile))
+			dpsBytes, err := os.ReadFile(filepath.Join("testdata", "direct-access", given.dataplanesFile))
 			Expect(err).ToNot(HaveOccurred())
 			dpYamls := util_yaml.SplitYAML(string(dpsBytes))
 			for _, dpYAML := range dpYamls {
@@ -66,7 +66,7 @@ var _ = Describe("DirectAccessProxyGenerator", func() {
 
 			// mesh
 			mesh := core_mesh.NewMeshResource()
-			bytes, err = ioutil.ReadFile(filepath.Join("testdata", "direct-access", given.meshFile))
+			bytes, err = os.ReadFile(filepath.Join("testdata", "direct-access", given.meshFile))
 			Expect(err).ToNot(HaveOccurred())
 			parseResource(bytes, mesh)
 

--- a/pkg/xds/generator/dns_generator_test.go
+++ b/pkg/xds/generator/dns_generator_test.go
@@ -1,7 +1,7 @@
 package generator_test
 
 import (
-	"io/ioutil"
+	"os"
 	"path/filepath"
 
 	. "github.com/onsi/ginkgo"
@@ -43,7 +43,7 @@ var _ = Describe("DNSGenerator", func() {
 			}
 
 			dataplane := mesh_proto.Dataplane{}
-			dpBytes, err := ioutil.ReadFile(filepath.Join("testdata", "dns", given.dataplaneFile))
+			dpBytes, err := os.ReadFile(filepath.Join("testdata", "dns", given.dataplaneFile))
 			Expect(err).ToNot(HaveOccurred())
 			Expect(util_proto.FromYAML(dpBytes, &dataplane)).To(Succeed())
 			proxy := &model.Proxy{

--- a/pkg/xds/generator/inbound_proxy_generator_test.go
+++ b/pkg/xds/generator/inbound_proxy_generator_test.go
@@ -1,7 +1,7 @@
 package generator_test
 
 import (
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"time"
 
@@ -59,7 +59,7 @@ var _ = Describe("InboundProxyGenerator", func() {
 			}
 
 			dataplane := mesh_proto.Dataplane{}
-			dpBytes, err := ioutil.ReadFile(filepath.Join("testdata", "inbound-proxy", given.dataplaneFile))
+			dpBytes, err := os.ReadFile(filepath.Join("testdata", "inbound-proxy", given.dataplaneFile))
 			Expect(err).ToNot(HaveOccurred())
 			Expect(util_proto.FromYAML(dpBytes, &dataplane)).To(Succeed())
 			proxy := &model.Proxy{

--- a/pkg/xds/generator/proxy_template_test.go
+++ b/pkg/xds/generator/proxy_template_test.go
@@ -1,7 +1,7 @@
 package generator_test
 
 import (
-	"io/ioutil"
+	"os"
 	"path/filepath"
 
 	. "github.com/onsi/ginkgo"
@@ -112,7 +112,7 @@ var _ = Describe("ProxyTemplateGenerator", func() {
 			func(given testCase) {
 				// setup
 				proxyTemplate := mesh_proto.ProxyTemplate{}
-				ptBytes, err := ioutil.ReadFile(filepath.Join("testdata", "template-proxy", given.proxyTemplateFile))
+				ptBytes, err := os.ReadFile(filepath.Join("testdata", "template-proxy", given.proxyTemplateFile))
 				Expect(err).ToNot(HaveOccurred())
 				Expect(util_proto.FromYAML(ptBytes, &proxyTemplate)).To(Succeed())
 				gen := &generator.ProxyTemplateGenerator{

--- a/pkg/xds/server/v3/snapshot_generator_test.go
+++ b/pkg/xds/server/v3/snapshot_generator_test.go
@@ -1,7 +1,7 @@
 package v3
 
 import (
-	"io/ioutil"
+	"os"
 	"path/filepath"
 
 	. "github.com/onsi/ginkgo"
@@ -62,7 +62,7 @@ var _ = Describe("Reconcile", func() {
 			}
 
 			dataplane := mesh_proto.Dataplane{}
-			dpBytes, err := ioutil.ReadFile(filepath.Join("testdata", "dataplane.input.yaml"))
+			dpBytes, err := os.ReadFile(filepath.Join("testdata", "dataplane.input.yaml"))
 			Expect(err).ToNot(HaveOccurred())
 			Expect(util_proto.FromYAML(dpBytes, &dataplane)).To(Succeed())
 

--- a/test/framework/k8s_cluster.go
+++ b/test/framework/k8s_cluster.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"os"
@@ -729,7 +728,7 @@ func (c *K8sCluster) deleteCRDs() (errs error) {
 
 	if err := cmd.Run(); err != nil {
 		errs = multierr.Append(errs, err)
-	} else if tmpfile, err := ioutil.TempFile("", "crds.yaml"); err != nil {
+	} else if tmpfile, err := os.CreateTemp("", "crds.yaml"); err != nil {
 		errs = multierr.Append(errs, err)
 	} else {
 		defer os.Remove(tmpfile.Name()) // clean up

--- a/test/framework/kumactl.go
+++ b/test/framework/kumactl.go
@@ -3,7 +3,6 @@ package framework
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net/url"
 	"os"
 
@@ -126,7 +125,7 @@ func (k *KumactlOptions) KumactlApplyFromString(configData string) error {
 func storeConfigToTempFile(name string, configData string) (string, error) {
 	escapedTestName := url.PathEscape(name)
 
-	tmpfile, err := ioutil.TempFile("", escapedTestName)
+	tmpfile, err := os.CreateTemp("", escapedTestName)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
### Summary

The `io/ioutil` package has been deprecated in Go 1.16 (See https://golang.org/doc/go1.16#ioutil). This PR replaces the existing `io/ioutil` functions with their new definitions in `io` and `os` packages.

### Full changelog

- Move from `io/ioutil` to `io` and `os` packages

### Issues resolved

N/A

### Documentation

N/A

### Testing

- [x] Unit tests
- [x] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes 

### Backwards compatibility

- [x] Add `backport-to-stable` label if the code is backwards compatible. Otherwise, list breaking changes.
