### PR TITLE
chore(kuma-cp) remove dp token from xds metadata

### DIFF
--- a/pkg/core/xds/metadata.go
+++ b/pkg/core/xds/metadata.go
@@ -18,7 +18,6 @@ var metadataLog = core.Log.WithName("xds-server").WithName("metadata-tracker")
 const (
 	// Supported Envoy node metadata fields.
 
-	fieldDataplaneToken             = "dataplane.token"
 	fieldDataplaneAdminPort         = "dataplane.admin.port"
 	fieldDataplaneDNSPort           = "dataplane.dns.port"
 	fieldDataplaneDNSEmptyPort      = "dataplane.dns.empty.port"
@@ -43,7 +42,6 @@ const (
 // This way, xDS server will be able to use Envoy node metadata
 // to generate xDS resources that depend on environment-specific configuration.
 type DataplaneMetadata struct {
-	DataplaneToken  string
 	Resource        model.Resource
 	AdminPort       uint32
 	DNSPort         uint32
@@ -51,13 +49,6 @@ type DataplaneMetadata struct {
 	DynamicMetadata map[string]string
 	ProxyType       mesh_proto.ProxyType
 	Version         *mesh_proto.Version
-}
-
-func (m *DataplaneMetadata) GetDataplaneToken() string {
-	if m == nil {
-		return ""
-	}
-	return m.DataplaneToken
 }
 
 // GetDataplaneResource returns the underlying DataplaneResource, if present.
@@ -130,9 +121,6 @@ func DataplaneMetadataFromXdsMetadata(xdsMetadata *structpb.Struct) *DataplaneMe
 	metadata := DataplaneMetadata{}
 	if xdsMetadata == nil {
 		return &metadata
-	}
-	if field := xdsMetadata.Fields[fieldDataplaneToken]; field != nil {
-		metadata.DataplaneToken = field.GetStringValue()
 	}
 	if field := xdsMetadata.Fields[fieldDataplaneProxyType]; field != nil {
 		metadata.ProxyType = mesh_proto.ProxyType(field.GetStringValue())

--- a/pkg/xds/bootstrap/template_v3.go
+++ b/pkg/xds/bootstrap/template_v3.go
@@ -232,7 +232,6 @@ func genConfig(parameters configParameters) (*envoy_bootstrap_v3.Bootstrap, erro
 	}
 
 	if parameters.DataplaneToken != "" {
-		res.Node.Metadata.Fields["dataplane.token"] = util_proto.MustNewValueForStruct(parameters.DataplaneToken)
 		if res.HdsConfig != nil {
 			for _, n := range res.HdsConfig.GrpcServices {
 				n.InitialMetadata = []*envoy_core_v3.HeaderValue{

--- a/pkg/xds/bootstrap/testdata/bootstrap.k8s.golden.yaml
+++ b/pkg/xds/bootstrap/testdata/bootstrap.k8s.golden.yaml
@@ -37,7 +37,6 @@ node:
   id: default.dp-1.default
   metadata:
     dataplane.proxyType: dataplane
-    dataplane.token: token
     version:
       envoy:
         build: hash/1.15.0/RELEASE

--- a/pkg/xds/bootstrap/testdata/bootstrap.overridden.golden.yaml
+++ b/pkg/xds/bootstrap/testdata/bootstrap.overridden.golden.yaml
@@ -44,7 +44,6 @@ node:
   metadata:
     dataplane.admin.port: "1234"
     dataplane.proxyType: dataplane
-    dataplane.token: token
     version:
       envoy:
         build: hash/1.15.0/RELEASE

--- a/pkg/xds/bootstrap/testdata/bootstrap.universal.golden.yaml
+++ b/pkg/xds/bootstrap/testdata/bootstrap.universal.golden.yaml
@@ -37,7 +37,6 @@ node:
   id: default.dp-1
   metadata:
     dataplane.proxyType: dataplane
-    dataplane.token: token
     version:
       envoy:
         build: hash/1.15.0/RELEASE

--- a/pkg/xds/bootstrap/testdata/generator.custom-config.golden.yaml
+++ b/pkg/xds/bootstrap/testdata/generator.custom-config.golden.yaml
@@ -66,7 +66,6 @@ node:
           ]
         }
       }
-    dataplane.token: token
     dynamicMetadata:
       test: value
     version:

--- a/pkg/xds/bootstrap/testdata/generator.default-config.golden.yaml
+++ b/pkg/xds/bootstrap/testdata/generator.default-config.golden.yaml
@@ -46,7 +46,6 @@ node:
     dataplane.dns.empty.port: "53002"
     dataplane.dns.port: "53001"
     dataplane.proxyType: dataplane
-    dataplane.token: token
     version:
       envoy:
         build: hash/1.15.0/RELEASE

--- a/pkg/xds/bootstrap/testdata/generator.default-config.kubernetes.golden.yaml
+++ b/pkg/xds/bootstrap/testdata/generator.default-config.kubernetes.golden.yaml
@@ -34,7 +34,6 @@ node:
   metadata:
     dataplane.admin.port: "1234"
     dataplane.proxyType: dataplane
-    dataplane.token: token
     version:
       envoy:
         build: hash/1.15.0/RELEASE

--- a/pkg/xds/bootstrap/testdata/generator.default-config.kubernetes.ipv6.golden.yaml
+++ b/pkg/xds/bootstrap/testdata/generator.default-config.kubernetes.ipv6.golden.yaml
@@ -34,7 +34,6 @@ node:
   metadata:
     dataplane.admin.port: "1234"
     dataplane.proxyType: dataplane
-    dataplane.token: token
     version:
       envoy:
         build: hash/1.15.0/RELEASE

--- a/pkg/xds/envoy/clusters/v3/client_side_mtls_configurer_test.go
+++ b/pkg/xds/envoy/clusters/v3/client_side_mtls_configurer_test.go
@@ -7,7 +7,6 @@ import (
 
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
-	core_xds "github.com/kumahq/kuma/pkg/core/xds"
 	test_model "github.com/kumahq/kuma/pkg/test/resources/model"
 	util_proto "github.com/kumahq/kuma/pkg/util/proto"
 	xds_context "github.com/kumahq/kuma/pkg/xds/context"
@@ -22,7 +21,6 @@ var _ = Describe("EdsClusterConfigurer", func() {
 		clientService string
 		tags          []envoy.Tags
 		ctx           xds_context.Context
-		metadata      *core_xds.DataplaneMetadata
 		expected      string
 	}
 
@@ -211,9 +209,6 @@ var _ = Describe("EdsClusterConfigurer", func() {
 						},
 					},
 				},
-			},
-			metadata: &core_xds.DataplaneMetadata{
-				DataplaneToken: "token",
 			},
 			tags: []envoy.Tags{
 				{

--- a/pkg/xds/server/callbacks/dataplane_metadata_tracker_test.go
+++ b/pkg/xds/server/callbacks/dataplane_metadata_tracker_test.go
@@ -26,9 +26,9 @@ var _ = Describe("Dataplane Metadata Tracker", func() {
 			Id: "default.example",
 			Metadata: &structpb.Struct{
 				Fields: map[string]*structpb.Value{
-					"dataplane.token": {
+					"dataplane.dns.port": {
 						Kind: &structpb.Value_StringValue{
-							StringValue: "token",
+							StringValue: "9090",
 						},
 					},
 				},
@@ -48,7 +48,7 @@ var _ = Describe("Dataplane Metadata Tracker", func() {
 		metadata := tracker.Metadata(dpKey)
 
 		// then
-		Expect(metadata.GetDataplaneToken()).To(Equal("token"))
+		Expect(metadata.GetDNSPort()).To(Equal(uint32(9090)))
 
 		// when
 		callbacks.OnStreamClosed(streamId)
@@ -75,6 +75,6 @@ var _ = Describe("Dataplane Metadata Tracker", func() {
 		metadata := tracker.Metadata(dpKey)
 
 		// then
-		Expect(metadata.GetDataplaneToken()).To(Equal("token"))
+		Expect(metadata.GetDNSPort()).To(Equal(uint32(9090)))
 	})
 })


### PR DESCRIPTION
### Summary

Remove DP token from XDS Metadata since it's not needed anymore.
It was used when secrets were served over separate SDS connections.

### Issues resolved

No issues.

### Documentation

- [X] No docs.

### Testing

- [X] Unit tests
- [ ] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes 

### Backwards compatibility

- [X] Add `backport-to-stable` label if the code is backwards compatible. Otherwise, list breaking changes.
