### PR TITLE
feat(kumactl) upgrade KIC to 2.0

### DIFF
--- a/app/kumactl/cmd/install/testdata/install-gateway-enterprise.defaults.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-gateway-enterprise.defaults.golden.yaml
@@ -23,147 +23,86 @@ stringData:
   license: |
     {"license": "test"}
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: kongclusterplugins.configuration.konghq.com
 spec:
-  additionalPrinterColumns:
-  - JSONPath: .plugin
-    description: Name of the plugin
-    name: Plugin-Type
-    type: string
-  - JSONPath: .metadata.creationTimestamp
-    description: Age
-    name: Age
-    type: date
-  - JSONPath: .disabled
-    description: Indicates if the plugin is disabled
-    name: Disabled
-    priority: 1
-    type: boolean
-  - JSONPath: .config
-    description: Configuration of the plugin
-    name: Config
-    priority: 1
-    type: string
   group: configuration.konghq.com
   names:
     kind: KongClusterPlugin
+    listKind: KongClusterPluginList
     plural: kongclusterplugins
     shortNames:
     - kcp
+    singular: kongclusterplugin
+  preserveUnknownFields: false
   scope: Cluster
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      properties:
-        config:
-          type: object
-        configFrom:
-          properties:
-            secretKeyRef:
-              properties:
-                key:
-                  type: string
-                name:
-                  type: string
-                namespace:
-                  type: string
-              required:
-              - name
-              - namespace
-              - key
-              type: object
-          type: object
-        disabled:
-          type: boolean
-        plugin:
-          type: string
-        protocols:
-          items:
-            enum:
-            - http
-            - https
-            - grpc
-            - grpcs
-            - tcp
-            - tls
+  versions:
+  - additionalPrinterColumns:
+    - description: Name of the plugin
+      jsonPath: .plugin
+      name: Plugin-Type
+      type: string
+    - description: Age
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - description: Indicates if the plugin is disabled
+      jsonPath: .disabled
+      name: Disabled
+      priority: 1
+      type: boolean
+    - description: Configuration of the plugin
+      jsonPath: .config
+      name: Config
+      priority: 1
+      type: string
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: KongClusterPlugin is the Schema for the kongclusterplugins API
+        properties:
+          config:
+            description: Config contains the plugin configuration.
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+          configFrom:
+            description: ConfigFrom references a secret containing the plugin configuration.
+            properties:
+              secretKeyRef:
+                description: NamespacedSecretValueFromSource represents the source
+                  of a secret value specifying the secret namespace
+                properties:
+                  key:
+                    description: the key containing the value
+                    type: string
+                  name:
+                    description: the secret containing the key
+                    type: string
+                  namespace:
+                    description: The namespace containing the secret
+                    type: string
+                required:
+                - key
+                - name
+                - namespace
+                type: object
+            type: object
+          consumerRef:
+            description: ConsumerRef is a reference to a particular consumer
             type: string
-          type: array
-        run_on:
-          enum:
-          - first
-          - second
-          - all
-          type: string
-      required:
-      - plugin
-  version: v1
----
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
-  name: kongconsumers.configuration.konghq.com
-spec:
-  additionalPrinterColumns:
-  - JSONPath: .username
-    description: Username of a Kong Consumer
-    name: Username
-    type: string
-  - JSONPath: .metadata.creationTimestamp
-    description: Age
-    name: Age
-    type: date
-  group: configuration.konghq.com
-  names:
-    kind: KongConsumer
-    plural: kongconsumers
-    shortNames:
-    - kc
-  scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      properties:
-        credentials:
-          items:
+          disabled:
+            description: Disabled set if the plugin is disabled or not
+            type: boolean
+          plugin:
+            description: PluginName is the name of the plugin to which to apply the
+              config
             type: string
-          type: array
-        custom_id:
-          type: string
-        username:
-          type: string
-  version: v1
----
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
-  name: kongingresses.configuration.konghq.com
-spec:
-  group: configuration.konghq.com
-  names:
-    kind: KongIngress
-    plural: kongingresses
-    shortNames:
-    - ki
-  scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      properties:
-        proxy:
-          properties:
-            connect_timeout:
-              minimum: 0
-              type: integer
-            path:
-              pattern: ^/.*$
-              type: string
-            protocol:
+          protocols:
+            description: Protocols configures plugin to run on requests received on
+              specific protocols.
+            items:
               enum:
               - http
               - https
@@ -171,40 +110,116 @@ spec:
               - grpcs
               - tcp
               - tls
+              - udp
               type: string
-            read_timeout:
-              minimum: 0
-              type: integer
-            retries:
-              minimum: 0
-              type: integer
-            write_timeout:
-              minimum: 0
-              type: integer
-          type: object
-        route:
-          properties:
-            headers:
-              additionalProperties:
-                items:
-                  type: string
-                type: array
-              type: object
-            https_redirect_status_code:
-              type: integer
-            methods:
-              items:
+            type: array
+          run_on:
+            description: RunOn configures the plugin to run on the first or the second
+              or both nodes in case of a service mesh deployment.
+            enum:
+            - first
+            - second
+            - all
+            type: string
+        required:
+        - plugin
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: kongconsumers.configuration.konghq.com
+spec:
+  group: configuration.konghq.com
+  names:
+    kind: KongConsumer
+    listKind: KongConsumerList
+    plural: kongconsumers
+    shortNames:
+    - kc
+    singular: kongconsumer
+  preserveUnknownFields: false
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Username of a Kong Consumer
+      jsonPath: .username
+      name: Username
+      type: string
+    - description: Age
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: KongConsumer is the Schema for the kongconsumers API
+        properties:
+          credentials:
+            description: Credentials are references to secrets containing a credential
+              to be provisioned in Kong.
+            items:
+              type: string
+            type: array
+          custom_id:
+            description: CustomID existing unique ID for the consumer - useful for
+              mapping Kong with users in your existing database
+            type: string
+          username:
+            description: Username unique username of the consumer.
+            type: string
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: kongingresses.configuration.konghq.com
+spec:
+  group: configuration.konghq.com
+  names:
+    kind: KongIngress
+    listKind: KongIngressList
+    plural: kongingresses
+    shortNames:
+    - ki
+    singular: kongingress
+  preserveUnknownFields: false
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: KongIngress is the Schema for the kongingresses API
+        properties:
+          proxy:
+            properties:
+              connect_timeout:
+                minimum: 0
+                type: integer
+              path:
+                pattern: ^/.*$
                 type: string
-              type: array
-            path_handling:
-              enum:
-              - v0
-              - v1
-              type: string
-            preserve_host:
-              type: boolean
-            protocols:
-              items:
+              protocol:
                 enum:
                 - http
                 - https
@@ -212,273 +227,650 @@ spec:
                 - grpcs
                 - tcp
                 - tls
+                - udp
                 type: string
-              type: array
-            regex_priority:
-              type: integer
-            request_buffering:
-              type: boolean
-            response_buffering:
-              type: boolean
-            snis:
-              items:
+              read_timeout:
+                minimum: 0
+                type: integer
+              retries:
+                minimum: 0
+                type: integer
+              write_timeout:
+                minimum: 0
+                type: integer
+            type: object
+          route:
+            description: Route represents a Route in Kong. Read https://getkong.org/docs/0.13.x/admin-api/#Route-object
+            properties:
+              headers:
+                additionalProperties:
+                  items:
+                    type: string
+                  type: array
+                type: object
+              https_redirect_status_code:
+                type: integer
+              methods:
+                items:
+                  type: string
+                type: array
+              path_handling:
+                enum:
+                - v0
+                - v1
                 type: string
-              type: array
-            strip_path:
-              type: boolean
-        upstream:
-          properties:
-            algorithm:
-              enum:
-              - round-robin
-              - consistent-hashing
-              - least-connections
-              type: string
-            hash_fallback:
-              type: string
-            hash_fallback_header:
-              type: string
-            hash_on:
-              type: string
-            hash_on_cookie:
-              type: string
-            hash_on_cookie_path:
-              type: string
-            hash_on_header:
-              type: string
-            healthchecks:
-              properties:
-                active:
-                  properties:
-                    concurrency:
-                      minimum: 1
-                      type: integer
-                    healthy:
-                      properties:
-                        http_statuses:
-                          items:
+              preserve_host:
+                type: boolean
+              protocols:
+                items:
+                  enum:
+                  - http
+                  - https
+                  - grpc
+                  - grpcs
+                  - tcp
+                  - tls
+                  - udp
+                  type: string
+                type: array
+              regex_priority:
+                type: integer
+              request_buffering:
+                description: "Kong buffers requests and responses by default. Buffering
+                  is not always desired, for instance if large payloads are being
+                  proxied using HTTP 1.1 chunked encoding. \n The request and response
+                  route buffering options are enabled by default and allow the user
+                  to disable buffering if desired for their use case. \n SEE ALSO:
+                  - https://github.com/Kong/kong/pull/6057 - https://docs.konghq.com/2.2.x/admin-api/#route-object"
+                type: boolean
+              response_buffering:
+                type: boolean
+              snis:
+                items:
+                  type: string
+                type: array
+              strip_path:
+                type: boolean
+            type: object
+          upstream:
+            description: Upstream represents an Upstream in Kong.
+            properties:
+              algorithm:
+                enum:
+                - round-robin
+                - consistent-hashing
+                - least-connections
+                type: string
+              hash_fallback:
+                type: string
+              hash_fallback_header:
+                type: string
+              hash_on:
+                type: string
+              hash_on_cookie:
+                type: string
+              hash_on_cookie_path:
+                type: string
+              hash_on_header:
+                type: string
+              healthchecks:
+                description: Healthcheck represents a health-check config of an upstream
+                  in Kong.
+                properties:
+                  active:
+                    description: ActiveHealthcheck configures active health check
+                      probing.
+                    properties:
+                      concurrency:
+                        minimum: 1
+                        type: integer
+                      healthy:
+                        description: Healthy configures thresholds and HTTP status
+                          codes to mark targets healthy for an upstream.
+                        properties:
+                          http_statuses:
+                            items:
+                              type: integer
+                            type: array
+                          interval:
+                            minimum: 0
                             type: integer
-                          type: array
-                        interval:
-                          minimum: 0
-                          type: integer
-                        successes:
-                          minimum: 0
-                          type: integer
-                      type: object
-                    http_path:
-                      pattern: ^/.*$
-                      type: string
-                    timeout:
-                      minimum: 0
-                      type: integer
-                    unhealthy:
-                      properties:
-                        http_failures:
-                          minimum: 0
-                          type: integer
-                        http_statuses:
-                          items:
+                          successes:
+                            minimum: 0
                             type: integer
-                          type: array
-                        interval:
-                          minimum: 0
-                          type: integer
-                        tcp_failures:
-                          minimum: 0
-                          type: integer
-                        timeout:
-                          minimum: 0
-                          type: integer
-                      type: object
-                  type: object
-                passive:
-                  properties:
-                    healthy:
-                      properties:
-                        http_statuses:
-                          items:
+                        type: object
+                      http_path:
+                        pattern: ^/.*$
+                        type: string
+                      timeout:
+                        minimum: 0
+                        type: integer
+                      type:
+                        type: string
+                      unhealthy:
+                        description: Unhealthy configures thresholds and HTTP status
+                          codes to mark targets unhealthy.
+                        properties:
+                          http_failures:
+                            minimum: 0
                             type: integer
-                          type: array
-                        interval:
-                          minimum: 0
-                          type: integer
-                        successes:
-                          minimum: 0
-                          type: integer
-                      type: object
-                    unhealthy:
-                      properties:
-                        http_failures:
-                          minimum: 0
-                          type: integer
-                        http_statuses:
-                          items:
+                          http_statuses:
+                            items:
+                              type: integer
+                            type: array
+                          interval:
+                            minimum: 0
                             type: integer
-                          type: array
-                        interval:
-                          minimum: 0
-                          type: integer
-                        tcp_failures:
-                          minimum: 0
-                          type: integer
-                        timeout:
-                          minimum: 0
-                          type: integer
-                      type: object
-                  type: object
-                threshold:
-                  type: integer
-              type: object
-            host_header:
-              type: string
-            slots:
-              minimum: 10
-              type: integer
-          type: object
-  version: v1
+                          tcp_failures:
+                            minimum: 0
+                            type: integer
+                          timeout:
+                            minimum: 0
+                            type: integer
+                        type: object
+                    type: object
+                  passive:
+                    description: PassiveHealthcheck configures passive checks around
+                      passive health checks.
+                    properties:
+                      healthy:
+                        description: Healthy configures thresholds and HTTP status
+                          codes to mark targets healthy for an upstream.
+                        properties:
+                          http_statuses:
+                            items:
+                              type: integer
+                            type: array
+                          interval:
+                            minimum: 0
+                            type: integer
+                          successes:
+                            minimum: 0
+                            type: integer
+                        type: object
+                      unhealthy:
+                        description: Unhealthy configures thresholds and HTTP status
+                          codes to mark targets unhealthy.
+                        properties:
+                          http_failures:
+                            minimum: 0
+                            type: integer
+                          http_statuses:
+                            items:
+                              type: integer
+                            type: array
+                          interval:
+                            minimum: 0
+                            type: integer
+                          tcp_failures:
+                            minimum: 0
+                            type: integer
+                          timeout:
+                            minimum: 0
+                            type: integer
+                        type: object
+                    type: object
+                  threshold:
+                    type: integer
+                type: object
+              host_header:
+                type: string
+              slots:
+                minimum: 10
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: kongplugins.configuration.konghq.com
 spec:
-  additionalPrinterColumns:
-  - JSONPath: .plugin
-    description: Name of the plugin
-    name: Plugin-Type
-    type: string
-  - JSONPath: .metadata.creationTimestamp
-    description: Age
-    name: Age
-    type: date
-  - JSONPath: .disabled
-    description: Indicates if the plugin is disabled
-    name: Disabled
-    priority: 1
-    type: boolean
-  - JSONPath: .config
-    description: Configuration of the plugin
-    name: Config
-    priority: 1
-    type: string
   group: configuration.konghq.com
   names:
     kind: KongPlugin
+    listKind: KongPluginList
     plural: kongplugins
     shortNames:
     - kp
+    singular: kongplugin
+  preserveUnknownFields: false
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      properties:
-        config:
-          type: object
-        configFrom:
-          properties:
-            secretKeyRef:
-              properties:
-                key:
-                  type: string
-                name:
-                  type: string
-              required:
-              - name
-              - key
-              type: object
-          type: object
-        disabled:
-          type: boolean
-        plugin:
-          type: string
-        protocols:
-          items:
-            enum:
-            - http
-            - https
-            - grpc
-            - grpcs
-            - tcp
-            - tls
+  versions:
+  - additionalPrinterColumns:
+    - description: Name of the plugin
+      jsonPath: .plugin
+      name: Plugin-Type
+      type: string
+    - description: Age
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - description: Indicates if the plugin is disabled
+      jsonPath: .disabled
+      name: Disabled
+      priority: 1
+      type: boolean
+    - description: Configuration of the plugin
+      jsonPath: .config
+      name: Config
+      priority: 1
+      type: string
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: KongPlugin is the Schema for the kongplugins API
+        properties:
+          config:
+            description: Config contains the plugin configuration.
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+          configFrom:
+            description: ConfigFrom references a secret containing the plugin configuration.
+            properties:
+              secretKeyRef:
+                description: SecretValueFromSource represents the source of a secret
+                  value
+                properties:
+                  key:
+                    description: the key containing the value
+                    type: string
+                  name:
+                    description: the secret containing the key
+                    type: string
+                required:
+                - key
+                - name
+                type: object
+            type: object
+          disabled:
+            description: Disabled set if the plugin is disabled or not
+            type: boolean
+          plugin:
+            description: PluginName is the name of the plugin to which to apply the
+              config
             type: string
-          type: array
-        run_on:
-          enum:
-          - first
-          - second
-          - all
-          type: string
-      required:
-      - plugin
-  version: v1
+          protocols:
+            description: Protocols configures plugin to run on requests received on
+              specific protocols.
+            items:
+              enum:
+              - http
+              - https
+              - grpc
+              - grpcs
+              - tcp
+              - tls
+              - udp
+              type: string
+            type: array
+          run_on:
+            description: RunOn configures the plugin to run on the first or the second
+              or both nodes in case of a service mesh deployment.
+            enum:
+            - first
+            - second
+            - all
+            type: string
+        required:
+        - plugin
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.6.2
+  creationTimestamp: null
   name: tcpingresses.configuration.konghq.com
 spec:
-  additionalPrinterColumns:
-  - JSONPath: .status.loadBalancer.ingress[*].ip
-    description: Address of the load balancer
-    name: Address
-    type: string
-  - JSONPath: .metadata.creationTimestamp
-    description: Age
-    name: Age
-    type: date
   group: configuration.konghq.com
   names:
     kind: TCPIngress
+    listKind: TCPIngressList
     plural: tcpingresses
+    singular: tcpingress
+  preserveUnknownFields: false
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      properties:
-        apiVersion:
-          type: string
-        kind:
-          type: string
-        metadata:
-          type: object
-        spec:
-          properties:
-            rules:
-              items:
-                properties:
-                  backend:
-                    properties:
-                      serviceName:
-                        type: string
-                      servicePort:
-                        format: int32
-                        type: integer
-                    type: object
-                  host:
-                    type: string
-                  port:
-                    format: int32
-                    type: integer
-                type: object
-              type: array
-            tls:
-              items:
-                properties:
-                  hosts:
-                    items:
+  versions:
+  - additionalPrinterColumns:
+    - description: Address of the load balancer
+      jsonPath: .status.loadBalancer.ingress[*].ip
+      name: Address
+      type: string
+    - description: Age
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: TCPIngress is the Schema for the tcpingresses API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: TCPIngressSpec defines the desired state of TCPIngress
+            properties:
+              rules:
+                description: A list of rules used to configure the Ingress.
+                items:
+                  description: IngressRule represents a rule to apply against incoming
+                    requests. Matching is performed based on an (optional) SNI and
+                    port.
+                  properties:
+                    backend:
+                      description: Backend defines the referenced service endpoint
+                        to which the traffic will be forwarded to.
+                      properties:
+                        serviceName:
+                          description: Specifies the name of the referenced service.
+                          type: string
+                        servicePort:
+                          description: Specifies the port of the referenced service.
+                          format: int32
+                          maximum: 65535
+                          minimum: 1
+                          type: integer
+                      required:
+                      - serviceName
+                      - servicePort
+                      type: object
+                    host:
+                      description: Host is the fully qualified domain name of a network
+                        host, as defined by RFC 3986. If a Host is specified, the
+                        protocol must be TLS over TCP. A plain-text TCP request cannot
+                        be routed based on Host. It can only be routed based on Port.
                       type: string
+                    port:
+                      description: Port is the port on which to accept TCP or TLS
+                        over TCP sessions and route. It is a required field. If a
+                        Host is not specified, the requested are routed based only
+                        on Port.
+                      format: int32
+                      maximum: 65535
+                      minimum: 1
+                      type: integer
+                  required:
+                  - backend
+                  type: object
+                type: array
+              tls:
+                description: TLS configuration. This is similar to the `tls` section
+                  in the Ingress resource in networking.v1beta1 group. The mapping
+                  of SNIs to TLS cert-key pair defined here will be used for HTTP
+                  Ingress rules as well. Once can define the mapping in this resource
+                  or the original Ingress resource, both have the same effect.
+                items:
+                  description: IngressTLS describes the transport layer security.
+                  properties:
+                    hosts:
+                      description: Hosts are a list of hosts included in the TLS certificate.
+                        The values in this list must match the name/s used in the
+                        tlsSecret. Defaults to the wildcard host setting for the loadbalancer
+                        controller fulfilling this Ingress, if left unspecified.
+                      items:
+                        type: string
+                      type: array
+                    secretName:
+                      description: SecretName is the name of the secret used to terminate
+                        SSL traffic.
+                      type: string
+                  type: object
+                type: array
+            type: object
+          status:
+            description: TCPIngressStatus defines the observed state of TCPIngress
+            properties:
+              loadBalancer:
+                description: LoadBalancer contains the current status of the load-balancer.
+                properties:
+                  ingress:
+                    description: Ingress is a list containing ingress points for the
+                      load-balancer. Traffic intended for the service should be sent
+                      to these ingress points.
+                    items:
+                      description: 'LoadBalancerIngress represents the status of a
+                        load-balancer ingress point: traffic intended for the service
+                        should be sent to an ingress point.'
+                      properties:
+                        hostname:
+                          description: Hostname is set for load-balancer ingress points
+                            that are DNS based (typically AWS load-balancers)
+                          type: string
+                        ip:
+                          description: IP is set for load-balancer ingress points
+                            that are IP based (typically GCE or OpenStack load-balancers)
+                          type: string
+                        ports:
+                          description: Ports is a list of records of service ports
+                            If used, every port defined in the service should have
+                            an entry in it
+                          items:
+                            properties:
+                              error:
+                                description: 'Error is to record the problem with
+                                  the service port The format of the error shall comply
+                                  with the following rules: - built-in error values
+                                  shall be specified in this file and those shall
+                                  use   CamelCase names - cloud provider specific
+                                  error values must have names that comply with the   format
+                                  foo.example.com/CamelCase. --- The regex it matches
+                                  is (dns1123SubdomainFmt/)?(qualifiedNameFmt)'
+                                maxLength: 316
+                                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                                type: string
+                              port:
+                                description: Port is the port number of the service
+                                  port of which status is recorded here
+                                format: int32
+                                type: integer
+                              protocol:
+                                default: TCP
+                                description: 'Protocol is the protocol of the service
+                                  port of which status is recorded here The supported
+                                  values are: "TCP", "UDP", "SCTP"'
+                                type: string
+                            required:
+                            - port
+                            - protocol
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      type: object
                     type: array
-                  secretName:
-                    type: string
                 type: object
-              type: array
-          type: object
-        status:
-          type: object
-  version: v1beta1
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.6.2
+  creationTimestamp: null
+  name: udpingresses.configuration.konghq.com
+spec:
+  group: configuration.konghq.com
+  names:
+    kind: UDPIngress
+    listKind: UDPIngressList
+    plural: udpingresses
+    singular: udpingress
+  preserveUnknownFields: false
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Address of the load balancer
+      jsonPath: .status.loadBalancer.ingress[*].ip
+      name: Address
+      type: string
+    - description: Age
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: UDPIngress is the Schema for the udpingresses API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: UDPIngressSpec defines the desired state of UDPIngress
+            properties:
+              rules:
+                description: A list of rules used to configure the Ingress.
+                items:
+                  description: UDPIngressRule represents a rule to apply against incoming
+                    requests wherein no Host matching is available for request routing,
+                    only the port is used to match requests.
+                  properties:
+                    backend:
+                      description: Backend defines the Kubernetes service which accepts
+                        traffic from the listening Port defined above.
+                      properties:
+                        serviceName:
+                          description: Specifies the name of the referenced service.
+                          type: string
+                        servicePort:
+                          description: Specifies the port of the referenced service.
+                          format: int32
+                          maximum: 65535
+                          minimum: 1
+                          type: integer
+                      required:
+                      - serviceName
+                      - servicePort
+                      type: object
+                    port:
+                      description: Port indicates the port for the Kong proxy to accept
+                        incoming traffic on, which will then be routed to the service
+                        Backend.
+                      type: integer
+                  required:
+                  - backend
+                  - port
+                  type: object
+                type: array
+            type: object
+          status:
+            description: UDPIngressStatus defines the observed state of UDPIngress
+            properties:
+              loadBalancer:
+                description: LoadBalancer contains the current status of the load-balancer.
+                properties:
+                  ingress:
+                    description: Ingress is a list containing ingress points for the
+                      load-balancer. Traffic intended for the service should be sent
+                      to these ingress points.
+                    items:
+                      description: 'LoadBalancerIngress represents the status of a
+                        load-balancer ingress point: traffic intended for the service
+                        should be sent to an ingress point.'
+                      properties:
+                        hostname:
+                          description: Hostname is set for load-balancer ingress points
+                            that are DNS based (typically AWS load-balancers)
+                          type: string
+                        ip:
+                          description: IP is set for load-balancer ingress points
+                            that are IP based (typically GCE or OpenStack load-balancers)
+                          type: string
+                        ports:
+                          description: Ports is a list of records of service ports
+                            If used, every port defined in the service should have
+                            an entry in it
+                          items:
+                            properties:
+                              error:
+                                description: 'Error is to record the problem with
+                                  the service port The format of the error shall comply
+                                  with the following rules: - built-in error values
+                                  shall be specified in this file and those shall
+                                  use   CamelCase names - cloud provider specific
+                                  error values must have names that comply with the   format
+                                  foo.example.com/CamelCase. --- The regex it matches
+                                  is (dns1123SubdomainFmt/)?(qualifiedNameFmt)'
+                                maxLength: 316
+                                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                                type: string
+                              port:
+                                description: Port is the port number of the service
+                                  port of which status is recorded here
+                                format: int32
+                                type: integer
+                              protocol:
+                                default: TCP
+                                description: 'Protocol is the protocol of the service
+                                  port of which status is recorded here The supported
+                                  values are: "TCP", "UDP", "SCTP"'
+                                type: string
+                            required:
+                            - port
+                            - protocol
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      type: object
+                    type: array
+                type: object
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
 status:
   acceptedNames:
     kind: ""
@@ -489,14 +881,49 @@ status:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: kong-ingress-clusterrole
+  creationTimestamp: null
+  name: kong-ingress
 rules:
 - apiGroups:
   - ""
   resources:
   - endpoints
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - endpoints/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - ""
+  resources:
   - nodes
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
   - pods
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
   - secrets
   verbs:
   - list
@@ -504,9 +931,11 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - nodes
+  - secrets/status
   verbs:
   - get
+  - patch
+  - update
 - apiGroups:
   - ""
   resources:
@@ -516,8 +945,126 @@ rules:
   - list
   - watch
 - apiGroups:
-  - networking.k8s.io
+  - ""
+  resources:
+  - services/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - configuration.konghq.com
+  resources:
+  - kongclusterplugins
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - configuration.konghq.com
+  resources:
+  - kongclusterplugins/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - configuration.konghq.com
+  resources:
+  - kongconsumers
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - configuration.konghq.com
+  resources:
+  - kongconsumers/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - configuration.konghq.com
+  resources:
+  - kongingresses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - configuration.konghq.com
+  resources:
+  - kongingresses/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - configuration.konghq.com
+  resources:
+  - kongplugins
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - configuration.konghq.com
+  resources:
+  - kongplugins/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - configuration.konghq.com
+  resources:
+  - tcpingresses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - configuration.konghq.com
+  resources:
+  - tcpingresses/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - configuration.konghq.com
+  resources:
+  - udpingresses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - configuration.konghq.com
+  resources:
+  - udpingresses/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
   - extensions
+  resources:
+  - ingresses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - extensions
+  resources:
+  - ingresses/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
   - networking.internal.knative.dev
   resources:
   - ingresses
@@ -526,56 +1073,108 @@ rules:
   - list
   - watch
 - apiGroups:
+  - networking.internal.knative.dev
+  resources:
+  - ingresses/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - gatewayclasses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - gatewayclasses/status
+  verbs:
+  - get
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - gateways
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - gateways/status
+  verbs:
+  - get
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingresses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingresses/status
+  verbs:
+  - get
+  - patch
+  - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kong-ingress
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kong-ingress
+subjects:
+- kind: ServiceAccount
+  name: kong-serviceaccount
+  namespace: kong-enterprise-gateway
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: kong-leader-election
+  namespace: kong-enterprise-gateway
+rules:
+- apiGroups:
+  - ""
+  - coordination.k8s.io
+  resources:
+  - configmaps
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
   - ""
   resources:
   - events
   verbs:
   - create
   - patch
-- apiGroups:
-  - networking.k8s.io
-  - extensions
-  - networking.internal.knative.dev
-  resources:
-  - ingresses/status
-  verbs:
-  - update
-- apiGroups:
-  - configuration.konghq.com
-  resources:
-  - tcpingresses/status
-  verbs:
-  - update
-- apiGroups:
-  - configuration.konghq.com
-  resources:
-  - kongplugins
-  - kongclusterplugins
-  - kongcredentials
-  - kongconsumers
-  - kongingresses
-  - tcpingresses
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - ""
-  resources:
-  - configmaps
-  verbs:
-  - create
-  - get
-  - update
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
+kind: RoleBinding
 metadata:
-  name: kong-ingress-clusterrole-nisa-binding
+  name: kong-leader-election
+  namespace: kong-enterprise-gateway
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: kong-ingress-clusterrole
+  kind: Role
+  name: kong-leader-election
 subjects:
 - kind: ServiceAccount
   name: kong-serviceaccount
@@ -603,6 +1202,20 @@ spec:
     app: ingress-kong
   type: LoadBalancer
 ---
+apiVersion: v1
+kind: Service
+metadata:
+  name: kong-validation-webhook
+  namespace: kong-enterprise-gateway
+spec:
+  ports:
+  - name: webhook
+    port: 443
+    protocol: TCP
+    targetPort: 8080
+  selector:
+    app: ingress-kong
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -619,8 +1232,6 @@ spec:
     metadata:
       annotations:
         kuma.io/gateway: enabled
-        prometheus.io/port: "8100"
-        prometheus.io/scrape: "true"
         traffic.sidecar.istio.io/includeInboundPorts: ""
       labels:
         app: ingress-kong
@@ -650,7 +1261,7 @@ spec:
           value: /dev/stderr
         - name: KONG_PROXY_ERROR_LOG
           value: /dev/stderr
-        image: kong/kong-gateway:2.4.1.0-alpine
+        image: kong/kong-gateway:2.5
         lifecycle:
           preStop:
             exec:
@@ -706,7 +1317,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.namespace
-        image: kong/kubernetes-ingress-controller:1.3
+        image: kong/kubernetes-ingress-controller:2.0.5
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3
@@ -723,10 +1334,13 @@ spec:
         - containerPort: 8080
           name: webhook
           protocol: TCP
+        - containerPort: 10255
+          name: cmetrics
+          protocol: TCP
         readinessProbe:
           failureThreshold: 3
           httpGet:
-            path: /healthz
+            path: /readyz
             port: 10254
             scheme: HTTP
           initialDelaySeconds: 5

--- a/app/kumactl/cmd/install/testdata/install-gateway-enterprise.overrides.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-gateway-enterprise.overrides.golden.yaml
@@ -23,147 +23,86 @@ stringData:
   license: |
     {"license": "test"}
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: kongclusterplugins.configuration.konghq.com
 spec:
-  additionalPrinterColumns:
-  - JSONPath: .plugin
-    description: Name of the plugin
-    name: Plugin-Type
-    type: string
-  - JSONPath: .metadata.creationTimestamp
-    description: Age
-    name: Age
-    type: date
-  - JSONPath: .disabled
-    description: Indicates if the plugin is disabled
-    name: Disabled
-    priority: 1
-    type: boolean
-  - JSONPath: .config
-    description: Configuration of the plugin
-    name: Config
-    priority: 1
-    type: string
   group: configuration.konghq.com
   names:
     kind: KongClusterPlugin
+    listKind: KongClusterPluginList
     plural: kongclusterplugins
     shortNames:
     - kcp
+    singular: kongclusterplugin
+  preserveUnknownFields: false
   scope: Cluster
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      properties:
-        config:
-          type: object
-        configFrom:
-          properties:
-            secretKeyRef:
-              properties:
-                key:
-                  type: string
-                name:
-                  type: string
-                namespace:
-                  type: string
-              required:
-              - name
-              - namespace
-              - key
-              type: object
-          type: object
-        disabled:
-          type: boolean
-        plugin:
-          type: string
-        protocols:
-          items:
-            enum:
-            - http
-            - https
-            - grpc
-            - grpcs
-            - tcp
-            - tls
+  versions:
+  - additionalPrinterColumns:
+    - description: Name of the plugin
+      jsonPath: .plugin
+      name: Plugin-Type
+      type: string
+    - description: Age
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - description: Indicates if the plugin is disabled
+      jsonPath: .disabled
+      name: Disabled
+      priority: 1
+      type: boolean
+    - description: Configuration of the plugin
+      jsonPath: .config
+      name: Config
+      priority: 1
+      type: string
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: KongClusterPlugin is the Schema for the kongclusterplugins API
+        properties:
+          config:
+            description: Config contains the plugin configuration.
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+          configFrom:
+            description: ConfigFrom references a secret containing the plugin configuration.
+            properties:
+              secretKeyRef:
+                description: NamespacedSecretValueFromSource represents the source
+                  of a secret value specifying the secret namespace
+                properties:
+                  key:
+                    description: the key containing the value
+                    type: string
+                  name:
+                    description: the secret containing the key
+                    type: string
+                  namespace:
+                    description: The namespace containing the secret
+                    type: string
+                required:
+                - key
+                - name
+                - namespace
+                type: object
+            type: object
+          consumerRef:
+            description: ConsumerRef is a reference to a particular consumer
             type: string
-          type: array
-        run_on:
-          enum:
-          - first
-          - second
-          - all
-          type: string
-      required:
-      - plugin
-  version: v1
----
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
-  name: kongconsumers.configuration.konghq.com
-spec:
-  additionalPrinterColumns:
-  - JSONPath: .username
-    description: Username of a Kong Consumer
-    name: Username
-    type: string
-  - JSONPath: .metadata.creationTimestamp
-    description: Age
-    name: Age
-    type: date
-  group: configuration.konghq.com
-  names:
-    kind: KongConsumer
-    plural: kongconsumers
-    shortNames:
-    - kc
-  scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      properties:
-        credentials:
-          items:
+          disabled:
+            description: Disabled set if the plugin is disabled or not
+            type: boolean
+          plugin:
+            description: PluginName is the name of the plugin to which to apply the
+              config
             type: string
-          type: array
-        custom_id:
-          type: string
-        username:
-          type: string
-  version: v1
----
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
-  name: kongingresses.configuration.konghq.com
-spec:
-  group: configuration.konghq.com
-  names:
-    kind: KongIngress
-    plural: kongingresses
-    shortNames:
-    - ki
-  scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      properties:
-        proxy:
-          properties:
-            connect_timeout:
-              minimum: 0
-              type: integer
-            path:
-              pattern: ^/.*$
-              type: string
-            protocol:
+          protocols:
+            description: Protocols configures plugin to run on requests received on
+              specific protocols.
+            items:
               enum:
               - http
               - https
@@ -171,40 +110,116 @@ spec:
               - grpcs
               - tcp
               - tls
+              - udp
               type: string
-            read_timeout:
-              minimum: 0
-              type: integer
-            retries:
-              minimum: 0
-              type: integer
-            write_timeout:
-              minimum: 0
-              type: integer
-          type: object
-        route:
-          properties:
-            headers:
-              additionalProperties:
-                items:
-                  type: string
-                type: array
-              type: object
-            https_redirect_status_code:
-              type: integer
-            methods:
-              items:
+            type: array
+          run_on:
+            description: RunOn configures the plugin to run on the first or the second
+              or both nodes in case of a service mesh deployment.
+            enum:
+            - first
+            - second
+            - all
+            type: string
+        required:
+        - plugin
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: kongconsumers.configuration.konghq.com
+spec:
+  group: configuration.konghq.com
+  names:
+    kind: KongConsumer
+    listKind: KongConsumerList
+    plural: kongconsumers
+    shortNames:
+    - kc
+    singular: kongconsumer
+  preserveUnknownFields: false
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Username of a Kong Consumer
+      jsonPath: .username
+      name: Username
+      type: string
+    - description: Age
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: KongConsumer is the Schema for the kongconsumers API
+        properties:
+          credentials:
+            description: Credentials are references to secrets containing a credential
+              to be provisioned in Kong.
+            items:
+              type: string
+            type: array
+          custom_id:
+            description: CustomID existing unique ID for the consumer - useful for
+              mapping Kong with users in your existing database
+            type: string
+          username:
+            description: Username unique username of the consumer.
+            type: string
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: kongingresses.configuration.konghq.com
+spec:
+  group: configuration.konghq.com
+  names:
+    kind: KongIngress
+    listKind: KongIngressList
+    plural: kongingresses
+    shortNames:
+    - ki
+    singular: kongingress
+  preserveUnknownFields: false
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: KongIngress is the Schema for the kongingresses API
+        properties:
+          proxy:
+            properties:
+              connect_timeout:
+                minimum: 0
+                type: integer
+              path:
+                pattern: ^/.*$
                 type: string
-              type: array
-            path_handling:
-              enum:
-              - v0
-              - v1
-              type: string
-            preserve_host:
-              type: boolean
-            protocols:
-              items:
+              protocol:
                 enum:
                 - http
                 - https
@@ -212,273 +227,650 @@ spec:
                 - grpcs
                 - tcp
                 - tls
+                - udp
                 type: string
-              type: array
-            regex_priority:
-              type: integer
-            request_buffering:
-              type: boolean
-            response_buffering:
-              type: boolean
-            snis:
-              items:
+              read_timeout:
+                minimum: 0
+                type: integer
+              retries:
+                minimum: 0
+                type: integer
+              write_timeout:
+                minimum: 0
+                type: integer
+            type: object
+          route:
+            description: Route represents a Route in Kong. Read https://getkong.org/docs/0.13.x/admin-api/#Route-object
+            properties:
+              headers:
+                additionalProperties:
+                  items:
+                    type: string
+                  type: array
+                type: object
+              https_redirect_status_code:
+                type: integer
+              methods:
+                items:
+                  type: string
+                type: array
+              path_handling:
+                enum:
+                - v0
+                - v1
                 type: string
-              type: array
-            strip_path:
-              type: boolean
-        upstream:
-          properties:
-            algorithm:
-              enum:
-              - round-robin
-              - consistent-hashing
-              - least-connections
-              type: string
-            hash_fallback:
-              type: string
-            hash_fallback_header:
-              type: string
-            hash_on:
-              type: string
-            hash_on_cookie:
-              type: string
-            hash_on_cookie_path:
-              type: string
-            hash_on_header:
-              type: string
-            healthchecks:
-              properties:
-                active:
-                  properties:
-                    concurrency:
-                      minimum: 1
-                      type: integer
-                    healthy:
-                      properties:
-                        http_statuses:
-                          items:
+              preserve_host:
+                type: boolean
+              protocols:
+                items:
+                  enum:
+                  - http
+                  - https
+                  - grpc
+                  - grpcs
+                  - tcp
+                  - tls
+                  - udp
+                  type: string
+                type: array
+              regex_priority:
+                type: integer
+              request_buffering:
+                description: "Kong buffers requests and responses by default. Buffering
+                  is not always desired, for instance if large payloads are being
+                  proxied using HTTP 1.1 chunked encoding. \n The request and response
+                  route buffering options are enabled by default and allow the user
+                  to disable buffering if desired for their use case. \n SEE ALSO:
+                  - https://github.com/Kong/kong/pull/6057 - https://docs.konghq.com/2.2.x/admin-api/#route-object"
+                type: boolean
+              response_buffering:
+                type: boolean
+              snis:
+                items:
+                  type: string
+                type: array
+              strip_path:
+                type: boolean
+            type: object
+          upstream:
+            description: Upstream represents an Upstream in Kong.
+            properties:
+              algorithm:
+                enum:
+                - round-robin
+                - consistent-hashing
+                - least-connections
+                type: string
+              hash_fallback:
+                type: string
+              hash_fallback_header:
+                type: string
+              hash_on:
+                type: string
+              hash_on_cookie:
+                type: string
+              hash_on_cookie_path:
+                type: string
+              hash_on_header:
+                type: string
+              healthchecks:
+                description: Healthcheck represents a health-check config of an upstream
+                  in Kong.
+                properties:
+                  active:
+                    description: ActiveHealthcheck configures active health check
+                      probing.
+                    properties:
+                      concurrency:
+                        minimum: 1
+                        type: integer
+                      healthy:
+                        description: Healthy configures thresholds and HTTP status
+                          codes to mark targets healthy for an upstream.
+                        properties:
+                          http_statuses:
+                            items:
+                              type: integer
+                            type: array
+                          interval:
+                            minimum: 0
                             type: integer
-                          type: array
-                        interval:
-                          minimum: 0
-                          type: integer
-                        successes:
-                          minimum: 0
-                          type: integer
-                      type: object
-                    http_path:
-                      pattern: ^/.*$
-                      type: string
-                    timeout:
-                      minimum: 0
-                      type: integer
-                    unhealthy:
-                      properties:
-                        http_failures:
-                          minimum: 0
-                          type: integer
-                        http_statuses:
-                          items:
+                          successes:
+                            minimum: 0
                             type: integer
-                          type: array
-                        interval:
-                          minimum: 0
-                          type: integer
-                        tcp_failures:
-                          minimum: 0
-                          type: integer
-                        timeout:
-                          minimum: 0
-                          type: integer
-                      type: object
-                  type: object
-                passive:
-                  properties:
-                    healthy:
-                      properties:
-                        http_statuses:
-                          items:
+                        type: object
+                      http_path:
+                        pattern: ^/.*$
+                        type: string
+                      timeout:
+                        minimum: 0
+                        type: integer
+                      type:
+                        type: string
+                      unhealthy:
+                        description: Unhealthy configures thresholds and HTTP status
+                          codes to mark targets unhealthy.
+                        properties:
+                          http_failures:
+                            minimum: 0
                             type: integer
-                          type: array
-                        interval:
-                          minimum: 0
-                          type: integer
-                        successes:
-                          minimum: 0
-                          type: integer
-                      type: object
-                    unhealthy:
-                      properties:
-                        http_failures:
-                          minimum: 0
-                          type: integer
-                        http_statuses:
-                          items:
+                          http_statuses:
+                            items:
+                              type: integer
+                            type: array
+                          interval:
+                            minimum: 0
                             type: integer
-                          type: array
-                        interval:
-                          minimum: 0
-                          type: integer
-                        tcp_failures:
-                          minimum: 0
-                          type: integer
-                        timeout:
-                          minimum: 0
-                          type: integer
-                      type: object
-                  type: object
-                threshold:
-                  type: integer
-              type: object
-            host_header:
-              type: string
-            slots:
-              minimum: 10
-              type: integer
-          type: object
-  version: v1
+                          tcp_failures:
+                            minimum: 0
+                            type: integer
+                          timeout:
+                            minimum: 0
+                            type: integer
+                        type: object
+                    type: object
+                  passive:
+                    description: PassiveHealthcheck configures passive checks around
+                      passive health checks.
+                    properties:
+                      healthy:
+                        description: Healthy configures thresholds and HTTP status
+                          codes to mark targets healthy for an upstream.
+                        properties:
+                          http_statuses:
+                            items:
+                              type: integer
+                            type: array
+                          interval:
+                            minimum: 0
+                            type: integer
+                          successes:
+                            minimum: 0
+                            type: integer
+                        type: object
+                      unhealthy:
+                        description: Unhealthy configures thresholds and HTTP status
+                          codes to mark targets unhealthy.
+                        properties:
+                          http_failures:
+                            minimum: 0
+                            type: integer
+                          http_statuses:
+                            items:
+                              type: integer
+                            type: array
+                          interval:
+                            minimum: 0
+                            type: integer
+                          tcp_failures:
+                            minimum: 0
+                            type: integer
+                          timeout:
+                            minimum: 0
+                            type: integer
+                        type: object
+                    type: object
+                  threshold:
+                    type: integer
+                type: object
+              host_header:
+                type: string
+              slots:
+                minimum: 10
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: kongplugins.configuration.konghq.com
 spec:
-  additionalPrinterColumns:
-  - JSONPath: .plugin
-    description: Name of the plugin
-    name: Plugin-Type
-    type: string
-  - JSONPath: .metadata.creationTimestamp
-    description: Age
-    name: Age
-    type: date
-  - JSONPath: .disabled
-    description: Indicates if the plugin is disabled
-    name: Disabled
-    priority: 1
-    type: boolean
-  - JSONPath: .config
-    description: Configuration of the plugin
-    name: Config
-    priority: 1
-    type: string
   group: configuration.konghq.com
   names:
     kind: KongPlugin
+    listKind: KongPluginList
     plural: kongplugins
     shortNames:
     - kp
+    singular: kongplugin
+  preserveUnknownFields: false
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      properties:
-        config:
-          type: object
-        configFrom:
-          properties:
-            secretKeyRef:
-              properties:
-                key:
-                  type: string
-                name:
-                  type: string
-              required:
-              - name
-              - key
-              type: object
-          type: object
-        disabled:
-          type: boolean
-        plugin:
-          type: string
-        protocols:
-          items:
-            enum:
-            - http
-            - https
-            - grpc
-            - grpcs
-            - tcp
-            - tls
+  versions:
+  - additionalPrinterColumns:
+    - description: Name of the plugin
+      jsonPath: .plugin
+      name: Plugin-Type
+      type: string
+    - description: Age
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - description: Indicates if the plugin is disabled
+      jsonPath: .disabled
+      name: Disabled
+      priority: 1
+      type: boolean
+    - description: Configuration of the plugin
+      jsonPath: .config
+      name: Config
+      priority: 1
+      type: string
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: KongPlugin is the Schema for the kongplugins API
+        properties:
+          config:
+            description: Config contains the plugin configuration.
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+          configFrom:
+            description: ConfigFrom references a secret containing the plugin configuration.
+            properties:
+              secretKeyRef:
+                description: SecretValueFromSource represents the source of a secret
+                  value
+                properties:
+                  key:
+                    description: the key containing the value
+                    type: string
+                  name:
+                    description: the secret containing the key
+                    type: string
+                required:
+                - key
+                - name
+                type: object
+            type: object
+          disabled:
+            description: Disabled set if the plugin is disabled or not
+            type: boolean
+          plugin:
+            description: PluginName is the name of the plugin to which to apply the
+              config
             type: string
-          type: array
-        run_on:
-          enum:
-          - first
-          - second
-          - all
-          type: string
-      required:
-      - plugin
-  version: v1
+          protocols:
+            description: Protocols configures plugin to run on requests received on
+              specific protocols.
+            items:
+              enum:
+              - http
+              - https
+              - grpc
+              - grpcs
+              - tcp
+              - tls
+              - udp
+              type: string
+            type: array
+          run_on:
+            description: RunOn configures the plugin to run on the first or the second
+              or both nodes in case of a service mesh deployment.
+            enum:
+            - first
+            - second
+            - all
+            type: string
+        required:
+        - plugin
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.6.2
+  creationTimestamp: null
   name: tcpingresses.configuration.konghq.com
 spec:
-  additionalPrinterColumns:
-  - JSONPath: .status.loadBalancer.ingress[*].ip
-    description: Address of the load balancer
-    name: Address
-    type: string
-  - JSONPath: .metadata.creationTimestamp
-    description: Age
-    name: Age
-    type: date
   group: configuration.konghq.com
   names:
     kind: TCPIngress
+    listKind: TCPIngressList
     plural: tcpingresses
+    singular: tcpingress
+  preserveUnknownFields: false
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      properties:
-        apiVersion:
-          type: string
-        kind:
-          type: string
-        metadata:
-          type: object
-        spec:
-          properties:
-            rules:
-              items:
-                properties:
-                  backend:
-                    properties:
-                      serviceName:
-                        type: string
-                      servicePort:
-                        format: int32
-                        type: integer
-                    type: object
-                  host:
-                    type: string
-                  port:
-                    format: int32
-                    type: integer
-                type: object
-              type: array
-            tls:
-              items:
-                properties:
-                  hosts:
-                    items:
+  versions:
+  - additionalPrinterColumns:
+    - description: Address of the load balancer
+      jsonPath: .status.loadBalancer.ingress[*].ip
+      name: Address
+      type: string
+    - description: Age
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: TCPIngress is the Schema for the tcpingresses API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: TCPIngressSpec defines the desired state of TCPIngress
+            properties:
+              rules:
+                description: A list of rules used to configure the Ingress.
+                items:
+                  description: IngressRule represents a rule to apply against incoming
+                    requests. Matching is performed based on an (optional) SNI and
+                    port.
+                  properties:
+                    backend:
+                      description: Backend defines the referenced service endpoint
+                        to which the traffic will be forwarded to.
+                      properties:
+                        serviceName:
+                          description: Specifies the name of the referenced service.
+                          type: string
+                        servicePort:
+                          description: Specifies the port of the referenced service.
+                          format: int32
+                          maximum: 65535
+                          minimum: 1
+                          type: integer
+                      required:
+                      - serviceName
+                      - servicePort
+                      type: object
+                    host:
+                      description: Host is the fully qualified domain name of a network
+                        host, as defined by RFC 3986. If a Host is specified, the
+                        protocol must be TLS over TCP. A plain-text TCP request cannot
+                        be routed based on Host. It can only be routed based on Port.
                       type: string
+                    port:
+                      description: Port is the port on which to accept TCP or TLS
+                        over TCP sessions and route. It is a required field. If a
+                        Host is not specified, the requested are routed based only
+                        on Port.
+                      format: int32
+                      maximum: 65535
+                      minimum: 1
+                      type: integer
+                  required:
+                  - backend
+                  type: object
+                type: array
+              tls:
+                description: TLS configuration. This is similar to the `tls` section
+                  in the Ingress resource in networking.v1beta1 group. The mapping
+                  of SNIs to TLS cert-key pair defined here will be used for HTTP
+                  Ingress rules as well. Once can define the mapping in this resource
+                  or the original Ingress resource, both have the same effect.
+                items:
+                  description: IngressTLS describes the transport layer security.
+                  properties:
+                    hosts:
+                      description: Hosts are a list of hosts included in the TLS certificate.
+                        The values in this list must match the name/s used in the
+                        tlsSecret. Defaults to the wildcard host setting for the loadbalancer
+                        controller fulfilling this Ingress, if left unspecified.
+                      items:
+                        type: string
+                      type: array
+                    secretName:
+                      description: SecretName is the name of the secret used to terminate
+                        SSL traffic.
+                      type: string
+                  type: object
+                type: array
+            type: object
+          status:
+            description: TCPIngressStatus defines the observed state of TCPIngress
+            properties:
+              loadBalancer:
+                description: LoadBalancer contains the current status of the load-balancer.
+                properties:
+                  ingress:
+                    description: Ingress is a list containing ingress points for the
+                      load-balancer. Traffic intended for the service should be sent
+                      to these ingress points.
+                    items:
+                      description: 'LoadBalancerIngress represents the status of a
+                        load-balancer ingress point: traffic intended for the service
+                        should be sent to an ingress point.'
+                      properties:
+                        hostname:
+                          description: Hostname is set for load-balancer ingress points
+                            that are DNS based (typically AWS load-balancers)
+                          type: string
+                        ip:
+                          description: IP is set for load-balancer ingress points
+                            that are IP based (typically GCE or OpenStack load-balancers)
+                          type: string
+                        ports:
+                          description: Ports is a list of records of service ports
+                            If used, every port defined in the service should have
+                            an entry in it
+                          items:
+                            properties:
+                              error:
+                                description: 'Error is to record the problem with
+                                  the service port The format of the error shall comply
+                                  with the following rules: - built-in error values
+                                  shall be specified in this file and those shall
+                                  use   CamelCase names - cloud provider specific
+                                  error values must have names that comply with the   format
+                                  foo.example.com/CamelCase. --- The regex it matches
+                                  is (dns1123SubdomainFmt/)?(qualifiedNameFmt)'
+                                maxLength: 316
+                                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                                type: string
+                              port:
+                                description: Port is the port number of the service
+                                  port of which status is recorded here
+                                format: int32
+                                type: integer
+                              protocol:
+                                default: TCP
+                                description: 'Protocol is the protocol of the service
+                                  port of which status is recorded here The supported
+                                  values are: "TCP", "UDP", "SCTP"'
+                                type: string
+                            required:
+                            - port
+                            - protocol
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      type: object
                     type: array
-                  secretName:
-                    type: string
                 type: object
-              type: array
-          type: object
-        status:
-          type: object
-  version: v1beta1
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.6.2
+  creationTimestamp: null
+  name: udpingresses.configuration.konghq.com
+spec:
+  group: configuration.konghq.com
+  names:
+    kind: UDPIngress
+    listKind: UDPIngressList
+    plural: udpingresses
+    singular: udpingress
+  preserveUnknownFields: false
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Address of the load balancer
+      jsonPath: .status.loadBalancer.ingress[*].ip
+      name: Address
+      type: string
+    - description: Age
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: UDPIngress is the Schema for the udpingresses API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: UDPIngressSpec defines the desired state of UDPIngress
+            properties:
+              rules:
+                description: A list of rules used to configure the Ingress.
+                items:
+                  description: UDPIngressRule represents a rule to apply against incoming
+                    requests wherein no Host matching is available for request routing,
+                    only the port is used to match requests.
+                  properties:
+                    backend:
+                      description: Backend defines the Kubernetes service which accepts
+                        traffic from the listening Port defined above.
+                      properties:
+                        serviceName:
+                          description: Specifies the name of the referenced service.
+                          type: string
+                        servicePort:
+                          description: Specifies the port of the referenced service.
+                          format: int32
+                          maximum: 65535
+                          minimum: 1
+                          type: integer
+                      required:
+                      - serviceName
+                      - servicePort
+                      type: object
+                    port:
+                      description: Port indicates the port for the Kong proxy to accept
+                        incoming traffic on, which will then be routed to the service
+                        Backend.
+                      type: integer
+                  required:
+                  - backend
+                  - port
+                  type: object
+                type: array
+            type: object
+          status:
+            description: UDPIngressStatus defines the observed state of UDPIngress
+            properties:
+              loadBalancer:
+                description: LoadBalancer contains the current status of the load-balancer.
+                properties:
+                  ingress:
+                    description: Ingress is a list containing ingress points for the
+                      load-balancer. Traffic intended for the service should be sent
+                      to these ingress points.
+                    items:
+                      description: 'LoadBalancerIngress represents the status of a
+                        load-balancer ingress point: traffic intended for the service
+                        should be sent to an ingress point.'
+                      properties:
+                        hostname:
+                          description: Hostname is set for load-balancer ingress points
+                            that are DNS based (typically AWS load-balancers)
+                          type: string
+                        ip:
+                          description: IP is set for load-balancer ingress points
+                            that are IP based (typically GCE or OpenStack load-balancers)
+                          type: string
+                        ports:
+                          description: Ports is a list of records of service ports
+                            If used, every port defined in the service should have
+                            an entry in it
+                          items:
+                            properties:
+                              error:
+                                description: 'Error is to record the problem with
+                                  the service port The format of the error shall comply
+                                  with the following rules: - built-in error values
+                                  shall be specified in this file and those shall
+                                  use   CamelCase names - cloud provider specific
+                                  error values must have names that comply with the   format
+                                  foo.example.com/CamelCase. --- The regex it matches
+                                  is (dns1123SubdomainFmt/)?(qualifiedNameFmt)'
+                                maxLength: 316
+                                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                                type: string
+                              port:
+                                description: Port is the port number of the service
+                                  port of which status is recorded here
+                                format: int32
+                                type: integer
+                              protocol:
+                                default: TCP
+                                description: 'Protocol is the protocol of the service
+                                  port of which status is recorded here The supported
+                                  values are: "TCP", "UDP", "SCTP"'
+                                type: string
+                            required:
+                            - port
+                            - protocol
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      type: object
+                    type: array
+                type: object
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
 status:
   acceptedNames:
     kind: ""
@@ -489,14 +881,49 @@ status:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: kong-ingress-clusterrole
+  creationTimestamp: null
+  name: kong-ingress
 rules:
 - apiGroups:
   - ""
   resources:
   - endpoints
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - endpoints/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - ""
+  resources:
   - nodes
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
   - pods
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
   - secrets
   verbs:
   - list
@@ -504,9 +931,11 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - nodes
+  - secrets/status
   verbs:
   - get
+  - patch
+  - update
 - apiGroups:
   - ""
   resources:
@@ -516,8 +945,126 @@ rules:
   - list
   - watch
 - apiGroups:
-  - networking.k8s.io
+  - ""
+  resources:
+  - services/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - configuration.konghq.com
+  resources:
+  - kongclusterplugins
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - configuration.konghq.com
+  resources:
+  - kongclusterplugins/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - configuration.konghq.com
+  resources:
+  - kongconsumers
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - configuration.konghq.com
+  resources:
+  - kongconsumers/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - configuration.konghq.com
+  resources:
+  - kongingresses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - configuration.konghq.com
+  resources:
+  - kongingresses/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - configuration.konghq.com
+  resources:
+  - kongplugins
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - configuration.konghq.com
+  resources:
+  - kongplugins/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - configuration.konghq.com
+  resources:
+  - tcpingresses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - configuration.konghq.com
+  resources:
+  - tcpingresses/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - configuration.konghq.com
+  resources:
+  - udpingresses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - configuration.konghq.com
+  resources:
+  - udpingresses/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
   - extensions
+  resources:
+  - ingresses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - extensions
+  resources:
+  - ingresses/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
   - networking.internal.knative.dev
   resources:
   - ingresses
@@ -526,56 +1073,108 @@ rules:
   - list
   - watch
 - apiGroups:
+  - networking.internal.knative.dev
+  resources:
+  - ingresses/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - gatewayclasses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - gatewayclasses/status
+  verbs:
+  - get
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - gateways
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - gateways/status
+  verbs:
+  - get
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingresses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingresses/status
+  verbs:
+  - get
+  - patch
+  - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kong-ingress
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kong-ingress
+subjects:
+- kind: ServiceAccount
+  name: kong-serviceaccount
+  namespace: notdefault
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: kong-leader-election
+  namespace: notdefault
+rules:
+- apiGroups:
+  - ""
+  - coordination.k8s.io
+  resources:
+  - configmaps
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
   - ""
   resources:
   - events
   verbs:
   - create
   - patch
-- apiGroups:
-  - networking.k8s.io
-  - extensions
-  - networking.internal.knative.dev
-  resources:
-  - ingresses/status
-  verbs:
-  - update
-- apiGroups:
-  - configuration.konghq.com
-  resources:
-  - tcpingresses/status
-  verbs:
-  - update
-- apiGroups:
-  - configuration.konghq.com
-  resources:
-  - kongplugins
-  - kongclusterplugins
-  - kongcredentials
-  - kongconsumers
-  - kongingresses
-  - tcpingresses
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - ""
-  resources:
-  - configmaps
-  verbs:
-  - create
-  - get
-  - update
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
+kind: RoleBinding
 metadata:
-  name: kong-ingress-clusterrole-nisa-binding
+  name: kong-leader-election
+  namespace: notdefault
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: kong-ingress-clusterrole
+  kind: Role
+  name: kong-leader-election
 subjects:
 - kind: ServiceAccount
   name: kong-serviceaccount
@@ -603,6 +1202,20 @@ spec:
     app: ingress-kong
   type: LoadBalancer
 ---
+apiVersion: v1
+kind: Service
+metadata:
+  name: kong-validation-webhook
+  namespace: notdefault
+spec:
+  ports:
+  - name: webhook
+    port: 443
+    protocol: TCP
+    targetPort: 8080
+  selector:
+    app: ingress-kong
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -619,8 +1232,6 @@ spec:
     metadata:
       annotations:
         kuma.io/gateway: enabled
-        prometheus.io/port: "8100"
-        prometheus.io/scrape: "true"
         traffic.sidecar.istio.io/includeInboundPorts: ""
       labels:
         app: ingress-kong
@@ -650,7 +1261,7 @@ spec:
           value: /dev/stderr
         - name: KONG_PROXY_ERROR_LOG
           value: /dev/stderr
-        image: kong/kong-gateway:2.4.1.0-alpine
+        image: kong/kong-gateway:2.5
         lifecycle:
           preStop:
             exec:
@@ -706,7 +1317,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.namespace
-        image: kong/kubernetes-ingress-controller:1.3
+        image: kong/kubernetes-ingress-controller:2.0.5
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3
@@ -723,10 +1334,13 @@ spec:
         - containerPort: 8080
           name: webhook
           protocol: TCP
+        - containerPort: 10255
+          name: cmetrics
+          protocol: TCP
         readinessProbe:
           failureThreshold: 3
           httpGet:
-            path: /healthz
+            path: /readyz
             port: 10254
             scheme: HTTP
           initialDelaySeconds: 5

--- a/app/kumactl/cmd/install/testdata/install-gateway.defaults.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-gateway.defaults.golden.yaml
@@ -13,147 +13,86 @@ metadata:
   name: kong-serviceaccount
   namespace: kuma-gateway
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: kongclusterplugins.configuration.konghq.com
 spec:
-  additionalPrinterColumns:
-  - JSONPath: .plugin
-    description: Name of the plugin
-    name: Plugin-Type
-    type: string
-  - JSONPath: .metadata.creationTimestamp
-    description: Age
-    name: Age
-    type: date
-  - JSONPath: .disabled
-    description: Indicates if the plugin is disabled
-    name: Disabled
-    priority: 1
-    type: boolean
-  - JSONPath: .config
-    description: Configuration of the plugin
-    name: Config
-    priority: 1
-    type: string
   group: configuration.konghq.com
   names:
     kind: KongClusterPlugin
+    listKind: KongClusterPluginList
     plural: kongclusterplugins
     shortNames:
     - kcp
+    singular: kongclusterplugin
+  preserveUnknownFields: false
   scope: Cluster
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      properties:
-        config:
-          type: object
-        configFrom:
-          properties:
-            secretKeyRef:
-              properties:
-                key:
-                  type: string
-                name:
-                  type: string
-                namespace:
-                  type: string
-              required:
-              - name
-              - namespace
-              - key
-              type: object
-          type: object
-        disabled:
-          type: boolean
-        plugin:
-          type: string
-        protocols:
-          items:
-            enum:
-            - http
-            - https
-            - grpc
-            - grpcs
-            - tcp
-            - tls
+  versions:
+  - additionalPrinterColumns:
+    - description: Name of the plugin
+      jsonPath: .plugin
+      name: Plugin-Type
+      type: string
+    - description: Age
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - description: Indicates if the plugin is disabled
+      jsonPath: .disabled
+      name: Disabled
+      priority: 1
+      type: boolean
+    - description: Configuration of the plugin
+      jsonPath: .config
+      name: Config
+      priority: 1
+      type: string
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: KongClusterPlugin is the Schema for the kongclusterplugins API
+        properties:
+          config:
+            description: Config contains the plugin configuration.
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+          configFrom:
+            description: ConfigFrom references a secret containing the plugin configuration.
+            properties:
+              secretKeyRef:
+                description: NamespacedSecretValueFromSource represents the source
+                  of a secret value specifying the secret namespace
+                properties:
+                  key:
+                    description: the key containing the value
+                    type: string
+                  name:
+                    description: the secret containing the key
+                    type: string
+                  namespace:
+                    description: The namespace containing the secret
+                    type: string
+                required:
+                - key
+                - name
+                - namespace
+                type: object
+            type: object
+          consumerRef:
+            description: ConsumerRef is a reference to a particular consumer
             type: string
-          type: array
-        run_on:
-          enum:
-          - first
-          - second
-          - all
-          type: string
-      required:
-      - plugin
-  version: v1
----
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
-  name: kongconsumers.configuration.konghq.com
-spec:
-  additionalPrinterColumns:
-  - JSONPath: .username
-    description: Username of a Kong Consumer
-    name: Username
-    type: string
-  - JSONPath: .metadata.creationTimestamp
-    description: Age
-    name: Age
-    type: date
-  group: configuration.konghq.com
-  names:
-    kind: KongConsumer
-    plural: kongconsumers
-    shortNames:
-    - kc
-  scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      properties:
-        credentials:
-          items:
+          disabled:
+            description: Disabled set if the plugin is disabled or not
+            type: boolean
+          plugin:
+            description: PluginName is the name of the plugin to which to apply the
+              config
             type: string
-          type: array
-        custom_id:
-          type: string
-        username:
-          type: string
-  version: v1
----
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
-  name: kongingresses.configuration.konghq.com
-spec:
-  group: configuration.konghq.com
-  names:
-    kind: KongIngress
-    plural: kongingresses
-    shortNames:
-    - ki
-  scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      properties:
-        proxy:
-          properties:
-            connect_timeout:
-              minimum: 0
-              type: integer
-            path:
-              pattern: ^/.*$
-              type: string
-            protocol:
+          protocols:
+            description: Protocols configures plugin to run on requests received on
+              specific protocols.
+            items:
               enum:
               - http
               - https
@@ -161,40 +100,116 @@ spec:
               - grpcs
               - tcp
               - tls
+              - udp
               type: string
-            read_timeout:
-              minimum: 0
-              type: integer
-            retries:
-              minimum: 0
-              type: integer
-            write_timeout:
-              minimum: 0
-              type: integer
-          type: object
-        route:
-          properties:
-            headers:
-              additionalProperties:
-                items:
-                  type: string
-                type: array
-              type: object
-            https_redirect_status_code:
-              type: integer
-            methods:
-              items:
+            type: array
+          run_on:
+            description: RunOn configures the plugin to run on the first or the second
+              or both nodes in case of a service mesh deployment.
+            enum:
+            - first
+            - second
+            - all
+            type: string
+        required:
+        - plugin
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: kongconsumers.configuration.konghq.com
+spec:
+  group: configuration.konghq.com
+  names:
+    kind: KongConsumer
+    listKind: KongConsumerList
+    plural: kongconsumers
+    shortNames:
+    - kc
+    singular: kongconsumer
+  preserveUnknownFields: false
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Username of a Kong Consumer
+      jsonPath: .username
+      name: Username
+      type: string
+    - description: Age
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: KongConsumer is the Schema for the kongconsumers API
+        properties:
+          credentials:
+            description: Credentials are references to secrets containing a credential
+              to be provisioned in Kong.
+            items:
+              type: string
+            type: array
+          custom_id:
+            description: CustomID existing unique ID for the consumer - useful for
+              mapping Kong with users in your existing database
+            type: string
+          username:
+            description: Username unique username of the consumer.
+            type: string
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: kongingresses.configuration.konghq.com
+spec:
+  group: configuration.konghq.com
+  names:
+    kind: KongIngress
+    listKind: KongIngressList
+    plural: kongingresses
+    shortNames:
+    - ki
+    singular: kongingress
+  preserveUnknownFields: false
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: KongIngress is the Schema for the kongingresses API
+        properties:
+          proxy:
+            properties:
+              connect_timeout:
+                minimum: 0
+                type: integer
+              path:
+                pattern: ^/.*$
                 type: string
-              type: array
-            path_handling:
-              enum:
-              - v0
-              - v1
-              type: string
-            preserve_host:
-              type: boolean
-            protocols:
-              items:
+              protocol:
                 enum:
                 - http
                 - https
@@ -202,273 +217,650 @@ spec:
                 - grpcs
                 - tcp
                 - tls
+                - udp
                 type: string
-              type: array
-            regex_priority:
-              type: integer
-            request_buffering:
-              type: boolean
-            response_buffering:
-              type: boolean
-            snis:
-              items:
+              read_timeout:
+                minimum: 0
+                type: integer
+              retries:
+                minimum: 0
+                type: integer
+              write_timeout:
+                minimum: 0
+                type: integer
+            type: object
+          route:
+            description: Route represents a Route in Kong. Read https://getkong.org/docs/0.13.x/admin-api/#Route-object
+            properties:
+              headers:
+                additionalProperties:
+                  items:
+                    type: string
+                  type: array
+                type: object
+              https_redirect_status_code:
+                type: integer
+              methods:
+                items:
+                  type: string
+                type: array
+              path_handling:
+                enum:
+                - v0
+                - v1
                 type: string
-              type: array
-            strip_path:
-              type: boolean
-        upstream:
-          properties:
-            algorithm:
-              enum:
-              - round-robin
-              - consistent-hashing
-              - least-connections
-              type: string
-            hash_fallback:
-              type: string
-            hash_fallback_header:
-              type: string
-            hash_on:
-              type: string
-            hash_on_cookie:
-              type: string
-            hash_on_cookie_path:
-              type: string
-            hash_on_header:
-              type: string
-            healthchecks:
-              properties:
-                active:
-                  properties:
-                    concurrency:
-                      minimum: 1
-                      type: integer
-                    healthy:
-                      properties:
-                        http_statuses:
-                          items:
+              preserve_host:
+                type: boolean
+              protocols:
+                items:
+                  enum:
+                  - http
+                  - https
+                  - grpc
+                  - grpcs
+                  - tcp
+                  - tls
+                  - udp
+                  type: string
+                type: array
+              regex_priority:
+                type: integer
+              request_buffering:
+                description: "Kong buffers requests and responses by default. Buffering
+                  is not always desired, for instance if large payloads are being
+                  proxied using HTTP 1.1 chunked encoding. \n The request and response
+                  route buffering options are enabled by default and allow the user
+                  to disable buffering if desired for their use case. \n SEE ALSO:
+                  - https://github.com/Kong/kong/pull/6057 - https://docs.konghq.com/2.2.x/admin-api/#route-object"
+                type: boolean
+              response_buffering:
+                type: boolean
+              snis:
+                items:
+                  type: string
+                type: array
+              strip_path:
+                type: boolean
+            type: object
+          upstream:
+            description: Upstream represents an Upstream in Kong.
+            properties:
+              algorithm:
+                enum:
+                - round-robin
+                - consistent-hashing
+                - least-connections
+                type: string
+              hash_fallback:
+                type: string
+              hash_fallback_header:
+                type: string
+              hash_on:
+                type: string
+              hash_on_cookie:
+                type: string
+              hash_on_cookie_path:
+                type: string
+              hash_on_header:
+                type: string
+              healthchecks:
+                description: Healthcheck represents a health-check config of an upstream
+                  in Kong.
+                properties:
+                  active:
+                    description: ActiveHealthcheck configures active health check
+                      probing.
+                    properties:
+                      concurrency:
+                        minimum: 1
+                        type: integer
+                      healthy:
+                        description: Healthy configures thresholds and HTTP status
+                          codes to mark targets healthy for an upstream.
+                        properties:
+                          http_statuses:
+                            items:
+                              type: integer
+                            type: array
+                          interval:
+                            minimum: 0
                             type: integer
-                          type: array
-                        interval:
-                          minimum: 0
-                          type: integer
-                        successes:
-                          minimum: 0
-                          type: integer
-                      type: object
-                    http_path:
-                      pattern: ^/.*$
-                      type: string
-                    timeout:
-                      minimum: 0
-                      type: integer
-                    unhealthy:
-                      properties:
-                        http_failures:
-                          minimum: 0
-                          type: integer
-                        http_statuses:
-                          items:
+                          successes:
+                            minimum: 0
                             type: integer
-                          type: array
-                        interval:
-                          minimum: 0
-                          type: integer
-                        tcp_failures:
-                          minimum: 0
-                          type: integer
-                        timeout:
-                          minimum: 0
-                          type: integer
-                      type: object
-                  type: object
-                passive:
-                  properties:
-                    healthy:
-                      properties:
-                        http_statuses:
-                          items:
+                        type: object
+                      http_path:
+                        pattern: ^/.*$
+                        type: string
+                      timeout:
+                        minimum: 0
+                        type: integer
+                      type:
+                        type: string
+                      unhealthy:
+                        description: Unhealthy configures thresholds and HTTP status
+                          codes to mark targets unhealthy.
+                        properties:
+                          http_failures:
+                            minimum: 0
                             type: integer
-                          type: array
-                        interval:
-                          minimum: 0
-                          type: integer
-                        successes:
-                          minimum: 0
-                          type: integer
-                      type: object
-                    unhealthy:
-                      properties:
-                        http_failures:
-                          minimum: 0
-                          type: integer
-                        http_statuses:
-                          items:
+                          http_statuses:
+                            items:
+                              type: integer
+                            type: array
+                          interval:
+                            minimum: 0
                             type: integer
-                          type: array
-                        interval:
-                          minimum: 0
-                          type: integer
-                        tcp_failures:
-                          minimum: 0
-                          type: integer
-                        timeout:
-                          minimum: 0
-                          type: integer
-                      type: object
-                  type: object
-                threshold:
-                  type: integer
-              type: object
-            host_header:
-              type: string
-            slots:
-              minimum: 10
-              type: integer
-          type: object
-  version: v1
+                          tcp_failures:
+                            minimum: 0
+                            type: integer
+                          timeout:
+                            minimum: 0
+                            type: integer
+                        type: object
+                    type: object
+                  passive:
+                    description: PassiveHealthcheck configures passive checks around
+                      passive health checks.
+                    properties:
+                      healthy:
+                        description: Healthy configures thresholds and HTTP status
+                          codes to mark targets healthy for an upstream.
+                        properties:
+                          http_statuses:
+                            items:
+                              type: integer
+                            type: array
+                          interval:
+                            minimum: 0
+                            type: integer
+                          successes:
+                            minimum: 0
+                            type: integer
+                        type: object
+                      unhealthy:
+                        description: Unhealthy configures thresholds and HTTP status
+                          codes to mark targets unhealthy.
+                        properties:
+                          http_failures:
+                            minimum: 0
+                            type: integer
+                          http_statuses:
+                            items:
+                              type: integer
+                            type: array
+                          interval:
+                            minimum: 0
+                            type: integer
+                          tcp_failures:
+                            minimum: 0
+                            type: integer
+                          timeout:
+                            minimum: 0
+                            type: integer
+                        type: object
+                    type: object
+                  threshold:
+                    type: integer
+                type: object
+              host_header:
+                type: string
+              slots:
+                minimum: 10
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: kongplugins.configuration.konghq.com
 spec:
-  additionalPrinterColumns:
-  - JSONPath: .plugin
-    description: Name of the plugin
-    name: Plugin-Type
-    type: string
-  - JSONPath: .metadata.creationTimestamp
-    description: Age
-    name: Age
-    type: date
-  - JSONPath: .disabled
-    description: Indicates if the plugin is disabled
-    name: Disabled
-    priority: 1
-    type: boolean
-  - JSONPath: .config
-    description: Configuration of the plugin
-    name: Config
-    priority: 1
-    type: string
   group: configuration.konghq.com
   names:
     kind: KongPlugin
+    listKind: KongPluginList
     plural: kongplugins
     shortNames:
     - kp
+    singular: kongplugin
+  preserveUnknownFields: false
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      properties:
-        config:
-          type: object
-        configFrom:
-          properties:
-            secretKeyRef:
-              properties:
-                key:
-                  type: string
-                name:
-                  type: string
-              required:
-              - name
-              - key
-              type: object
-          type: object
-        disabled:
-          type: boolean
-        plugin:
-          type: string
-        protocols:
-          items:
-            enum:
-            - http
-            - https
-            - grpc
-            - grpcs
-            - tcp
-            - tls
+  versions:
+  - additionalPrinterColumns:
+    - description: Name of the plugin
+      jsonPath: .plugin
+      name: Plugin-Type
+      type: string
+    - description: Age
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - description: Indicates if the plugin is disabled
+      jsonPath: .disabled
+      name: Disabled
+      priority: 1
+      type: boolean
+    - description: Configuration of the plugin
+      jsonPath: .config
+      name: Config
+      priority: 1
+      type: string
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: KongPlugin is the Schema for the kongplugins API
+        properties:
+          config:
+            description: Config contains the plugin configuration.
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+          configFrom:
+            description: ConfigFrom references a secret containing the plugin configuration.
+            properties:
+              secretKeyRef:
+                description: SecretValueFromSource represents the source of a secret
+                  value
+                properties:
+                  key:
+                    description: the key containing the value
+                    type: string
+                  name:
+                    description: the secret containing the key
+                    type: string
+                required:
+                - key
+                - name
+                type: object
+            type: object
+          disabled:
+            description: Disabled set if the plugin is disabled or not
+            type: boolean
+          plugin:
+            description: PluginName is the name of the plugin to which to apply the
+              config
             type: string
-          type: array
-        run_on:
-          enum:
-          - first
-          - second
-          - all
-          type: string
-      required:
-      - plugin
-  version: v1
+          protocols:
+            description: Protocols configures plugin to run on requests received on
+              specific protocols.
+            items:
+              enum:
+              - http
+              - https
+              - grpc
+              - grpcs
+              - tcp
+              - tls
+              - udp
+              type: string
+            type: array
+          run_on:
+            description: RunOn configures the plugin to run on the first or the second
+              or both nodes in case of a service mesh deployment.
+            enum:
+            - first
+            - second
+            - all
+            type: string
+        required:
+        - plugin
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.6.2
+  creationTimestamp: null
   name: tcpingresses.configuration.konghq.com
 spec:
-  additionalPrinterColumns:
-  - JSONPath: .status.loadBalancer.ingress[*].ip
-    description: Address of the load balancer
-    name: Address
-    type: string
-  - JSONPath: .metadata.creationTimestamp
-    description: Age
-    name: Age
-    type: date
   group: configuration.konghq.com
   names:
     kind: TCPIngress
+    listKind: TCPIngressList
     plural: tcpingresses
+    singular: tcpingress
+  preserveUnknownFields: false
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      properties:
-        apiVersion:
-          type: string
-        kind:
-          type: string
-        metadata:
-          type: object
-        spec:
-          properties:
-            rules:
-              items:
-                properties:
-                  backend:
-                    properties:
-                      serviceName:
-                        type: string
-                      servicePort:
-                        format: int32
-                        type: integer
-                    type: object
-                  host:
-                    type: string
-                  port:
-                    format: int32
-                    type: integer
-                type: object
-              type: array
-            tls:
-              items:
-                properties:
-                  hosts:
-                    items:
+  versions:
+  - additionalPrinterColumns:
+    - description: Address of the load balancer
+      jsonPath: .status.loadBalancer.ingress[*].ip
+      name: Address
+      type: string
+    - description: Age
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: TCPIngress is the Schema for the tcpingresses API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: TCPIngressSpec defines the desired state of TCPIngress
+            properties:
+              rules:
+                description: A list of rules used to configure the Ingress.
+                items:
+                  description: IngressRule represents a rule to apply against incoming
+                    requests. Matching is performed based on an (optional) SNI and
+                    port.
+                  properties:
+                    backend:
+                      description: Backend defines the referenced service endpoint
+                        to which the traffic will be forwarded to.
+                      properties:
+                        serviceName:
+                          description: Specifies the name of the referenced service.
+                          type: string
+                        servicePort:
+                          description: Specifies the port of the referenced service.
+                          format: int32
+                          maximum: 65535
+                          minimum: 1
+                          type: integer
+                      required:
+                      - serviceName
+                      - servicePort
+                      type: object
+                    host:
+                      description: Host is the fully qualified domain name of a network
+                        host, as defined by RFC 3986. If a Host is specified, the
+                        protocol must be TLS over TCP. A plain-text TCP request cannot
+                        be routed based on Host. It can only be routed based on Port.
                       type: string
+                    port:
+                      description: Port is the port on which to accept TCP or TLS
+                        over TCP sessions and route. It is a required field. If a
+                        Host is not specified, the requested are routed based only
+                        on Port.
+                      format: int32
+                      maximum: 65535
+                      minimum: 1
+                      type: integer
+                  required:
+                  - backend
+                  type: object
+                type: array
+              tls:
+                description: TLS configuration. This is similar to the `tls` section
+                  in the Ingress resource in networking.v1beta1 group. The mapping
+                  of SNIs to TLS cert-key pair defined here will be used for HTTP
+                  Ingress rules as well. Once can define the mapping in this resource
+                  or the original Ingress resource, both have the same effect.
+                items:
+                  description: IngressTLS describes the transport layer security.
+                  properties:
+                    hosts:
+                      description: Hosts are a list of hosts included in the TLS certificate.
+                        The values in this list must match the name/s used in the
+                        tlsSecret. Defaults to the wildcard host setting for the loadbalancer
+                        controller fulfilling this Ingress, if left unspecified.
+                      items:
+                        type: string
+                      type: array
+                    secretName:
+                      description: SecretName is the name of the secret used to terminate
+                        SSL traffic.
+                      type: string
+                  type: object
+                type: array
+            type: object
+          status:
+            description: TCPIngressStatus defines the observed state of TCPIngress
+            properties:
+              loadBalancer:
+                description: LoadBalancer contains the current status of the load-balancer.
+                properties:
+                  ingress:
+                    description: Ingress is a list containing ingress points for the
+                      load-balancer. Traffic intended for the service should be sent
+                      to these ingress points.
+                    items:
+                      description: 'LoadBalancerIngress represents the status of a
+                        load-balancer ingress point: traffic intended for the service
+                        should be sent to an ingress point.'
+                      properties:
+                        hostname:
+                          description: Hostname is set for load-balancer ingress points
+                            that are DNS based (typically AWS load-balancers)
+                          type: string
+                        ip:
+                          description: IP is set for load-balancer ingress points
+                            that are IP based (typically GCE or OpenStack load-balancers)
+                          type: string
+                        ports:
+                          description: Ports is a list of records of service ports
+                            If used, every port defined in the service should have
+                            an entry in it
+                          items:
+                            properties:
+                              error:
+                                description: 'Error is to record the problem with
+                                  the service port The format of the error shall comply
+                                  with the following rules: - built-in error values
+                                  shall be specified in this file and those shall
+                                  use   CamelCase names - cloud provider specific
+                                  error values must have names that comply with the   format
+                                  foo.example.com/CamelCase. --- The regex it matches
+                                  is (dns1123SubdomainFmt/)?(qualifiedNameFmt)'
+                                maxLength: 316
+                                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                                type: string
+                              port:
+                                description: Port is the port number of the service
+                                  port of which status is recorded here
+                                format: int32
+                                type: integer
+                              protocol:
+                                default: TCP
+                                description: 'Protocol is the protocol of the service
+                                  port of which status is recorded here The supported
+                                  values are: "TCP", "UDP", "SCTP"'
+                                type: string
+                            required:
+                            - port
+                            - protocol
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      type: object
                     type: array
-                  secretName:
-                    type: string
                 type: object
-              type: array
-          type: object
-        status:
-          type: object
-  version: v1beta1
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.6.2
+  creationTimestamp: null
+  name: udpingresses.configuration.konghq.com
+spec:
+  group: configuration.konghq.com
+  names:
+    kind: UDPIngress
+    listKind: UDPIngressList
+    plural: udpingresses
+    singular: udpingress
+  preserveUnknownFields: false
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Address of the load balancer
+      jsonPath: .status.loadBalancer.ingress[*].ip
+      name: Address
+      type: string
+    - description: Age
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: UDPIngress is the Schema for the udpingresses API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: UDPIngressSpec defines the desired state of UDPIngress
+            properties:
+              rules:
+                description: A list of rules used to configure the Ingress.
+                items:
+                  description: UDPIngressRule represents a rule to apply against incoming
+                    requests wherein no Host matching is available for request routing,
+                    only the port is used to match requests.
+                  properties:
+                    backend:
+                      description: Backend defines the Kubernetes service which accepts
+                        traffic from the listening Port defined above.
+                      properties:
+                        serviceName:
+                          description: Specifies the name of the referenced service.
+                          type: string
+                        servicePort:
+                          description: Specifies the port of the referenced service.
+                          format: int32
+                          maximum: 65535
+                          minimum: 1
+                          type: integer
+                      required:
+                      - serviceName
+                      - servicePort
+                      type: object
+                    port:
+                      description: Port indicates the port for the Kong proxy to accept
+                        incoming traffic on, which will then be routed to the service
+                        Backend.
+                      type: integer
+                  required:
+                  - backend
+                  - port
+                  type: object
+                type: array
+            type: object
+          status:
+            description: UDPIngressStatus defines the observed state of UDPIngress
+            properties:
+              loadBalancer:
+                description: LoadBalancer contains the current status of the load-balancer.
+                properties:
+                  ingress:
+                    description: Ingress is a list containing ingress points for the
+                      load-balancer. Traffic intended for the service should be sent
+                      to these ingress points.
+                    items:
+                      description: 'LoadBalancerIngress represents the status of a
+                        load-balancer ingress point: traffic intended for the service
+                        should be sent to an ingress point.'
+                      properties:
+                        hostname:
+                          description: Hostname is set for load-balancer ingress points
+                            that are DNS based (typically AWS load-balancers)
+                          type: string
+                        ip:
+                          description: IP is set for load-balancer ingress points
+                            that are IP based (typically GCE or OpenStack load-balancers)
+                          type: string
+                        ports:
+                          description: Ports is a list of records of service ports
+                            If used, every port defined in the service should have
+                            an entry in it
+                          items:
+                            properties:
+                              error:
+                                description: 'Error is to record the problem with
+                                  the service port The format of the error shall comply
+                                  with the following rules: - built-in error values
+                                  shall be specified in this file and those shall
+                                  use   CamelCase names - cloud provider specific
+                                  error values must have names that comply with the   format
+                                  foo.example.com/CamelCase. --- The regex it matches
+                                  is (dns1123SubdomainFmt/)?(qualifiedNameFmt)'
+                                maxLength: 316
+                                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                                type: string
+                              port:
+                                description: Port is the port number of the service
+                                  port of which status is recorded here
+                                format: int32
+                                type: integer
+                              protocol:
+                                default: TCP
+                                description: 'Protocol is the protocol of the service
+                                  port of which status is recorded here The supported
+                                  values are: "TCP", "UDP", "SCTP"'
+                                type: string
+                            required:
+                            - port
+                            - protocol
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      type: object
+                    type: array
+                type: object
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
 status:
   acceptedNames:
     kind: ""
@@ -479,14 +871,49 @@ status:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: kong-ingress-clusterrole
+  creationTimestamp: null
+  name: kong-ingress
 rules:
 - apiGroups:
   - ""
   resources:
   - endpoints
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - endpoints/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - ""
+  resources:
   - nodes
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
   - pods
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
   - secrets
   verbs:
   - list
@@ -494,9 +921,11 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - nodes
+  - secrets/status
   verbs:
   - get
+  - patch
+  - update
 - apiGroups:
   - ""
   resources:
@@ -506,8 +935,126 @@ rules:
   - list
   - watch
 - apiGroups:
-  - networking.k8s.io
+  - ""
+  resources:
+  - services/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - configuration.konghq.com
+  resources:
+  - kongclusterplugins
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - configuration.konghq.com
+  resources:
+  - kongclusterplugins/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - configuration.konghq.com
+  resources:
+  - kongconsumers
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - configuration.konghq.com
+  resources:
+  - kongconsumers/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - configuration.konghq.com
+  resources:
+  - kongingresses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - configuration.konghq.com
+  resources:
+  - kongingresses/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - configuration.konghq.com
+  resources:
+  - kongplugins
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - configuration.konghq.com
+  resources:
+  - kongplugins/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - configuration.konghq.com
+  resources:
+  - tcpingresses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - configuration.konghq.com
+  resources:
+  - tcpingresses/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - configuration.konghq.com
+  resources:
+  - udpingresses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - configuration.konghq.com
+  resources:
+  - udpingresses/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
   - extensions
+  resources:
+  - ingresses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - extensions
+  resources:
+  - ingresses/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
   - networking.internal.knative.dev
   resources:
   - ingresses
@@ -516,56 +1063,108 @@ rules:
   - list
   - watch
 - apiGroups:
+  - networking.internal.knative.dev
+  resources:
+  - ingresses/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - gatewayclasses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - gatewayclasses/status
+  verbs:
+  - get
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - gateways
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - gateways/status
+  verbs:
+  - get
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingresses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingresses/status
+  verbs:
+  - get
+  - patch
+  - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kong-ingress
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kong-ingress
+subjects:
+- kind: ServiceAccount
+  name: kong-serviceaccount
+  namespace: kuma-gateway
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: kong-leader-election
+  namespace: kuma-gateway
+rules:
+- apiGroups:
+  - ""
+  - coordination.k8s.io
+  resources:
+  - configmaps
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
   - ""
   resources:
   - events
   verbs:
   - create
   - patch
-- apiGroups:
-  - networking.k8s.io
-  - extensions
-  - networking.internal.knative.dev
-  resources:
-  - ingresses/status
-  verbs:
-  - update
-- apiGroups:
-  - configuration.konghq.com
-  resources:
-  - tcpingresses/status
-  verbs:
-  - update
-- apiGroups:
-  - configuration.konghq.com
-  resources:
-  - kongplugins
-  - kongclusterplugins
-  - kongcredentials
-  - kongconsumers
-  - kongingresses
-  - tcpingresses
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - ""
-  resources:
-  - configmaps
-  verbs:
-  - create
-  - get
-  - update
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
+kind: RoleBinding
 metadata:
-  name: kong-ingress-clusterrole-nisa-binding
+  name: kong-leader-election
+  namespace: kuma-gateway
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: kong-ingress-clusterrole
+  kind: Role
+  name: kong-leader-election
 subjects:
 - kind: ServiceAccount
   name: kong-serviceaccount
@@ -593,6 +1192,20 @@ spec:
     app: ingress-kong
   type: LoadBalancer
 ---
+apiVersion: v1
+kind: Service
+metadata:
+  name: kong-validation-webhook
+  namespace: kuma-gateway
+spec:
+  ports:
+  - name: webhook
+    port: 443
+    protocol: TCP
+    targetPort: 8080
+  selector:
+    app: ingress-kong
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -609,8 +1222,6 @@ spec:
     metadata:
       annotations:
         kuma.io/gateway: enabled
-        prometheus.io/port: "8100"
-        prometheus.io/scrape: "true"
         traffic.sidecar.istio.io/includeInboundPorts: ""
       labels:
         app: ingress-kong
@@ -635,7 +1246,7 @@ spec:
           value: /dev/stderr
         - name: KONG_PROXY_ERROR_LOG
           value: /dev/stderr
-        image: kong:2.4
+        image: kong:2.5
         lifecycle:
           preStop:
             exec:
@@ -691,7 +1302,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.namespace
-        image: kong/kubernetes-ingress-controller:1.3
+        image: kong/kubernetes-ingress-controller:2.0.5
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3
@@ -708,10 +1319,13 @@ spec:
         - containerPort: 8080
           name: webhook
           protocol: TCP
+        - containerPort: 10255
+          name: cmetrics
+          protocol: TCP
         readinessProbe:
           failureThreshold: 3
           httpGet:
-            path: /healthz
+            path: /readyz
             port: 10254
             scheme: HTTP
           initialDelaySeconds: 5

--- a/app/kumactl/cmd/install/testdata/install-gateway.overrides.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-gateway.overrides.golden.yaml
@@ -13,147 +13,86 @@ metadata:
   name: kong-serviceaccount
   namespace: notdefault
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: kongclusterplugins.configuration.konghq.com
 spec:
-  additionalPrinterColumns:
-  - JSONPath: .plugin
-    description: Name of the plugin
-    name: Plugin-Type
-    type: string
-  - JSONPath: .metadata.creationTimestamp
-    description: Age
-    name: Age
-    type: date
-  - JSONPath: .disabled
-    description: Indicates if the plugin is disabled
-    name: Disabled
-    priority: 1
-    type: boolean
-  - JSONPath: .config
-    description: Configuration of the plugin
-    name: Config
-    priority: 1
-    type: string
   group: configuration.konghq.com
   names:
     kind: KongClusterPlugin
+    listKind: KongClusterPluginList
     plural: kongclusterplugins
     shortNames:
     - kcp
+    singular: kongclusterplugin
+  preserveUnknownFields: false
   scope: Cluster
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      properties:
-        config:
-          type: object
-        configFrom:
-          properties:
-            secretKeyRef:
-              properties:
-                key:
-                  type: string
-                name:
-                  type: string
-                namespace:
-                  type: string
-              required:
-              - name
-              - namespace
-              - key
-              type: object
-          type: object
-        disabled:
-          type: boolean
-        plugin:
-          type: string
-        protocols:
-          items:
-            enum:
-            - http
-            - https
-            - grpc
-            - grpcs
-            - tcp
-            - tls
+  versions:
+  - additionalPrinterColumns:
+    - description: Name of the plugin
+      jsonPath: .plugin
+      name: Plugin-Type
+      type: string
+    - description: Age
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - description: Indicates if the plugin is disabled
+      jsonPath: .disabled
+      name: Disabled
+      priority: 1
+      type: boolean
+    - description: Configuration of the plugin
+      jsonPath: .config
+      name: Config
+      priority: 1
+      type: string
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: KongClusterPlugin is the Schema for the kongclusterplugins API
+        properties:
+          config:
+            description: Config contains the plugin configuration.
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+          configFrom:
+            description: ConfigFrom references a secret containing the plugin configuration.
+            properties:
+              secretKeyRef:
+                description: NamespacedSecretValueFromSource represents the source
+                  of a secret value specifying the secret namespace
+                properties:
+                  key:
+                    description: the key containing the value
+                    type: string
+                  name:
+                    description: the secret containing the key
+                    type: string
+                  namespace:
+                    description: The namespace containing the secret
+                    type: string
+                required:
+                - key
+                - name
+                - namespace
+                type: object
+            type: object
+          consumerRef:
+            description: ConsumerRef is a reference to a particular consumer
             type: string
-          type: array
-        run_on:
-          enum:
-          - first
-          - second
-          - all
-          type: string
-      required:
-      - plugin
-  version: v1
----
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
-  name: kongconsumers.configuration.konghq.com
-spec:
-  additionalPrinterColumns:
-  - JSONPath: .username
-    description: Username of a Kong Consumer
-    name: Username
-    type: string
-  - JSONPath: .metadata.creationTimestamp
-    description: Age
-    name: Age
-    type: date
-  group: configuration.konghq.com
-  names:
-    kind: KongConsumer
-    plural: kongconsumers
-    shortNames:
-    - kc
-  scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      properties:
-        credentials:
-          items:
+          disabled:
+            description: Disabled set if the plugin is disabled or not
+            type: boolean
+          plugin:
+            description: PluginName is the name of the plugin to which to apply the
+              config
             type: string
-          type: array
-        custom_id:
-          type: string
-        username:
-          type: string
-  version: v1
----
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
-  name: kongingresses.configuration.konghq.com
-spec:
-  group: configuration.konghq.com
-  names:
-    kind: KongIngress
-    plural: kongingresses
-    shortNames:
-    - ki
-  scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      properties:
-        proxy:
-          properties:
-            connect_timeout:
-              minimum: 0
-              type: integer
-            path:
-              pattern: ^/.*$
-              type: string
-            protocol:
+          protocols:
+            description: Protocols configures plugin to run on requests received on
+              specific protocols.
+            items:
               enum:
               - http
               - https
@@ -161,40 +100,116 @@ spec:
               - grpcs
               - tcp
               - tls
+              - udp
               type: string
-            read_timeout:
-              minimum: 0
-              type: integer
-            retries:
-              minimum: 0
-              type: integer
-            write_timeout:
-              minimum: 0
-              type: integer
-          type: object
-        route:
-          properties:
-            headers:
-              additionalProperties:
-                items:
-                  type: string
-                type: array
-              type: object
-            https_redirect_status_code:
-              type: integer
-            methods:
-              items:
+            type: array
+          run_on:
+            description: RunOn configures the plugin to run on the first or the second
+              or both nodes in case of a service mesh deployment.
+            enum:
+            - first
+            - second
+            - all
+            type: string
+        required:
+        - plugin
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: kongconsumers.configuration.konghq.com
+spec:
+  group: configuration.konghq.com
+  names:
+    kind: KongConsumer
+    listKind: KongConsumerList
+    plural: kongconsumers
+    shortNames:
+    - kc
+    singular: kongconsumer
+  preserveUnknownFields: false
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Username of a Kong Consumer
+      jsonPath: .username
+      name: Username
+      type: string
+    - description: Age
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: KongConsumer is the Schema for the kongconsumers API
+        properties:
+          credentials:
+            description: Credentials are references to secrets containing a credential
+              to be provisioned in Kong.
+            items:
+              type: string
+            type: array
+          custom_id:
+            description: CustomID existing unique ID for the consumer - useful for
+              mapping Kong with users in your existing database
+            type: string
+          username:
+            description: Username unique username of the consumer.
+            type: string
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: kongingresses.configuration.konghq.com
+spec:
+  group: configuration.konghq.com
+  names:
+    kind: KongIngress
+    listKind: KongIngressList
+    plural: kongingresses
+    shortNames:
+    - ki
+    singular: kongingress
+  preserveUnknownFields: false
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: KongIngress is the Schema for the kongingresses API
+        properties:
+          proxy:
+            properties:
+              connect_timeout:
+                minimum: 0
+                type: integer
+              path:
+                pattern: ^/.*$
                 type: string
-              type: array
-            path_handling:
-              enum:
-              - v0
-              - v1
-              type: string
-            preserve_host:
-              type: boolean
-            protocols:
-              items:
+              protocol:
                 enum:
                 - http
                 - https
@@ -202,273 +217,650 @@ spec:
                 - grpcs
                 - tcp
                 - tls
+                - udp
                 type: string
-              type: array
-            regex_priority:
-              type: integer
-            request_buffering:
-              type: boolean
-            response_buffering:
-              type: boolean
-            snis:
-              items:
+              read_timeout:
+                minimum: 0
+                type: integer
+              retries:
+                minimum: 0
+                type: integer
+              write_timeout:
+                minimum: 0
+                type: integer
+            type: object
+          route:
+            description: Route represents a Route in Kong. Read https://getkong.org/docs/0.13.x/admin-api/#Route-object
+            properties:
+              headers:
+                additionalProperties:
+                  items:
+                    type: string
+                  type: array
+                type: object
+              https_redirect_status_code:
+                type: integer
+              methods:
+                items:
+                  type: string
+                type: array
+              path_handling:
+                enum:
+                - v0
+                - v1
                 type: string
-              type: array
-            strip_path:
-              type: boolean
-        upstream:
-          properties:
-            algorithm:
-              enum:
-              - round-robin
-              - consistent-hashing
-              - least-connections
-              type: string
-            hash_fallback:
-              type: string
-            hash_fallback_header:
-              type: string
-            hash_on:
-              type: string
-            hash_on_cookie:
-              type: string
-            hash_on_cookie_path:
-              type: string
-            hash_on_header:
-              type: string
-            healthchecks:
-              properties:
-                active:
-                  properties:
-                    concurrency:
-                      minimum: 1
-                      type: integer
-                    healthy:
-                      properties:
-                        http_statuses:
-                          items:
+              preserve_host:
+                type: boolean
+              protocols:
+                items:
+                  enum:
+                  - http
+                  - https
+                  - grpc
+                  - grpcs
+                  - tcp
+                  - tls
+                  - udp
+                  type: string
+                type: array
+              regex_priority:
+                type: integer
+              request_buffering:
+                description: "Kong buffers requests and responses by default. Buffering
+                  is not always desired, for instance if large payloads are being
+                  proxied using HTTP 1.1 chunked encoding. \n The request and response
+                  route buffering options are enabled by default and allow the user
+                  to disable buffering if desired for their use case. \n SEE ALSO:
+                  - https://github.com/Kong/kong/pull/6057 - https://docs.konghq.com/2.2.x/admin-api/#route-object"
+                type: boolean
+              response_buffering:
+                type: boolean
+              snis:
+                items:
+                  type: string
+                type: array
+              strip_path:
+                type: boolean
+            type: object
+          upstream:
+            description: Upstream represents an Upstream in Kong.
+            properties:
+              algorithm:
+                enum:
+                - round-robin
+                - consistent-hashing
+                - least-connections
+                type: string
+              hash_fallback:
+                type: string
+              hash_fallback_header:
+                type: string
+              hash_on:
+                type: string
+              hash_on_cookie:
+                type: string
+              hash_on_cookie_path:
+                type: string
+              hash_on_header:
+                type: string
+              healthchecks:
+                description: Healthcheck represents a health-check config of an upstream
+                  in Kong.
+                properties:
+                  active:
+                    description: ActiveHealthcheck configures active health check
+                      probing.
+                    properties:
+                      concurrency:
+                        minimum: 1
+                        type: integer
+                      healthy:
+                        description: Healthy configures thresholds and HTTP status
+                          codes to mark targets healthy for an upstream.
+                        properties:
+                          http_statuses:
+                            items:
+                              type: integer
+                            type: array
+                          interval:
+                            minimum: 0
                             type: integer
-                          type: array
-                        interval:
-                          minimum: 0
-                          type: integer
-                        successes:
-                          minimum: 0
-                          type: integer
-                      type: object
-                    http_path:
-                      pattern: ^/.*$
-                      type: string
-                    timeout:
-                      minimum: 0
-                      type: integer
-                    unhealthy:
-                      properties:
-                        http_failures:
-                          minimum: 0
-                          type: integer
-                        http_statuses:
-                          items:
+                          successes:
+                            minimum: 0
                             type: integer
-                          type: array
-                        interval:
-                          minimum: 0
-                          type: integer
-                        tcp_failures:
-                          minimum: 0
-                          type: integer
-                        timeout:
-                          minimum: 0
-                          type: integer
-                      type: object
-                  type: object
-                passive:
-                  properties:
-                    healthy:
-                      properties:
-                        http_statuses:
-                          items:
+                        type: object
+                      http_path:
+                        pattern: ^/.*$
+                        type: string
+                      timeout:
+                        minimum: 0
+                        type: integer
+                      type:
+                        type: string
+                      unhealthy:
+                        description: Unhealthy configures thresholds and HTTP status
+                          codes to mark targets unhealthy.
+                        properties:
+                          http_failures:
+                            minimum: 0
                             type: integer
-                          type: array
-                        interval:
-                          minimum: 0
-                          type: integer
-                        successes:
-                          minimum: 0
-                          type: integer
-                      type: object
-                    unhealthy:
-                      properties:
-                        http_failures:
-                          minimum: 0
-                          type: integer
-                        http_statuses:
-                          items:
+                          http_statuses:
+                            items:
+                              type: integer
+                            type: array
+                          interval:
+                            minimum: 0
                             type: integer
-                          type: array
-                        interval:
-                          minimum: 0
-                          type: integer
-                        tcp_failures:
-                          minimum: 0
-                          type: integer
-                        timeout:
-                          minimum: 0
-                          type: integer
-                      type: object
-                  type: object
-                threshold:
-                  type: integer
-              type: object
-            host_header:
-              type: string
-            slots:
-              minimum: 10
-              type: integer
-          type: object
-  version: v1
+                          tcp_failures:
+                            minimum: 0
+                            type: integer
+                          timeout:
+                            minimum: 0
+                            type: integer
+                        type: object
+                    type: object
+                  passive:
+                    description: PassiveHealthcheck configures passive checks around
+                      passive health checks.
+                    properties:
+                      healthy:
+                        description: Healthy configures thresholds and HTTP status
+                          codes to mark targets healthy for an upstream.
+                        properties:
+                          http_statuses:
+                            items:
+                              type: integer
+                            type: array
+                          interval:
+                            minimum: 0
+                            type: integer
+                          successes:
+                            minimum: 0
+                            type: integer
+                        type: object
+                      unhealthy:
+                        description: Unhealthy configures thresholds and HTTP status
+                          codes to mark targets unhealthy.
+                        properties:
+                          http_failures:
+                            minimum: 0
+                            type: integer
+                          http_statuses:
+                            items:
+                              type: integer
+                            type: array
+                          interval:
+                            minimum: 0
+                            type: integer
+                          tcp_failures:
+                            minimum: 0
+                            type: integer
+                          timeout:
+                            minimum: 0
+                            type: integer
+                        type: object
+                    type: object
+                  threshold:
+                    type: integer
+                type: object
+              host_header:
+                type: string
+              slots:
+                minimum: 10
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: kongplugins.configuration.konghq.com
 spec:
-  additionalPrinterColumns:
-  - JSONPath: .plugin
-    description: Name of the plugin
-    name: Plugin-Type
-    type: string
-  - JSONPath: .metadata.creationTimestamp
-    description: Age
-    name: Age
-    type: date
-  - JSONPath: .disabled
-    description: Indicates if the plugin is disabled
-    name: Disabled
-    priority: 1
-    type: boolean
-  - JSONPath: .config
-    description: Configuration of the plugin
-    name: Config
-    priority: 1
-    type: string
   group: configuration.konghq.com
   names:
     kind: KongPlugin
+    listKind: KongPluginList
     plural: kongplugins
     shortNames:
     - kp
+    singular: kongplugin
+  preserveUnknownFields: false
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      properties:
-        config:
-          type: object
-        configFrom:
-          properties:
-            secretKeyRef:
-              properties:
-                key:
-                  type: string
-                name:
-                  type: string
-              required:
-              - name
-              - key
-              type: object
-          type: object
-        disabled:
-          type: boolean
-        plugin:
-          type: string
-        protocols:
-          items:
-            enum:
-            - http
-            - https
-            - grpc
-            - grpcs
-            - tcp
-            - tls
+  versions:
+  - additionalPrinterColumns:
+    - description: Name of the plugin
+      jsonPath: .plugin
+      name: Plugin-Type
+      type: string
+    - description: Age
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - description: Indicates if the plugin is disabled
+      jsonPath: .disabled
+      name: Disabled
+      priority: 1
+      type: boolean
+    - description: Configuration of the plugin
+      jsonPath: .config
+      name: Config
+      priority: 1
+      type: string
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: KongPlugin is the Schema for the kongplugins API
+        properties:
+          config:
+            description: Config contains the plugin configuration.
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+          configFrom:
+            description: ConfigFrom references a secret containing the plugin configuration.
+            properties:
+              secretKeyRef:
+                description: SecretValueFromSource represents the source of a secret
+                  value
+                properties:
+                  key:
+                    description: the key containing the value
+                    type: string
+                  name:
+                    description: the secret containing the key
+                    type: string
+                required:
+                - key
+                - name
+                type: object
+            type: object
+          disabled:
+            description: Disabled set if the plugin is disabled or not
+            type: boolean
+          plugin:
+            description: PluginName is the name of the plugin to which to apply the
+              config
             type: string
-          type: array
-        run_on:
-          enum:
-          - first
-          - second
-          - all
-          type: string
-      required:
-      - plugin
-  version: v1
+          protocols:
+            description: Protocols configures plugin to run on requests received on
+              specific protocols.
+            items:
+              enum:
+              - http
+              - https
+              - grpc
+              - grpcs
+              - tcp
+              - tls
+              - udp
+              type: string
+            type: array
+          run_on:
+            description: RunOn configures the plugin to run on the first or the second
+              or both nodes in case of a service mesh deployment.
+            enum:
+            - first
+            - second
+            - all
+            type: string
+        required:
+        - plugin
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.6.2
+  creationTimestamp: null
   name: tcpingresses.configuration.konghq.com
 spec:
-  additionalPrinterColumns:
-  - JSONPath: .status.loadBalancer.ingress[*].ip
-    description: Address of the load balancer
-    name: Address
-    type: string
-  - JSONPath: .metadata.creationTimestamp
-    description: Age
-    name: Age
-    type: date
   group: configuration.konghq.com
   names:
     kind: TCPIngress
+    listKind: TCPIngressList
     plural: tcpingresses
+    singular: tcpingress
+  preserveUnknownFields: false
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      properties:
-        apiVersion:
-          type: string
-        kind:
-          type: string
-        metadata:
-          type: object
-        spec:
-          properties:
-            rules:
-              items:
-                properties:
-                  backend:
-                    properties:
-                      serviceName:
-                        type: string
-                      servicePort:
-                        format: int32
-                        type: integer
-                    type: object
-                  host:
-                    type: string
-                  port:
-                    format: int32
-                    type: integer
-                type: object
-              type: array
-            tls:
-              items:
-                properties:
-                  hosts:
-                    items:
+  versions:
+  - additionalPrinterColumns:
+    - description: Address of the load balancer
+      jsonPath: .status.loadBalancer.ingress[*].ip
+      name: Address
+      type: string
+    - description: Age
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: TCPIngress is the Schema for the tcpingresses API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: TCPIngressSpec defines the desired state of TCPIngress
+            properties:
+              rules:
+                description: A list of rules used to configure the Ingress.
+                items:
+                  description: IngressRule represents a rule to apply against incoming
+                    requests. Matching is performed based on an (optional) SNI and
+                    port.
+                  properties:
+                    backend:
+                      description: Backend defines the referenced service endpoint
+                        to which the traffic will be forwarded to.
+                      properties:
+                        serviceName:
+                          description: Specifies the name of the referenced service.
+                          type: string
+                        servicePort:
+                          description: Specifies the port of the referenced service.
+                          format: int32
+                          maximum: 65535
+                          minimum: 1
+                          type: integer
+                      required:
+                      - serviceName
+                      - servicePort
+                      type: object
+                    host:
+                      description: Host is the fully qualified domain name of a network
+                        host, as defined by RFC 3986. If a Host is specified, the
+                        protocol must be TLS over TCP. A plain-text TCP request cannot
+                        be routed based on Host. It can only be routed based on Port.
                       type: string
+                    port:
+                      description: Port is the port on which to accept TCP or TLS
+                        over TCP sessions and route. It is a required field. If a
+                        Host is not specified, the requested are routed based only
+                        on Port.
+                      format: int32
+                      maximum: 65535
+                      minimum: 1
+                      type: integer
+                  required:
+                  - backend
+                  type: object
+                type: array
+              tls:
+                description: TLS configuration. This is similar to the `tls` section
+                  in the Ingress resource in networking.v1beta1 group. The mapping
+                  of SNIs to TLS cert-key pair defined here will be used for HTTP
+                  Ingress rules as well. Once can define the mapping in this resource
+                  or the original Ingress resource, both have the same effect.
+                items:
+                  description: IngressTLS describes the transport layer security.
+                  properties:
+                    hosts:
+                      description: Hosts are a list of hosts included in the TLS certificate.
+                        The values in this list must match the name/s used in the
+                        tlsSecret. Defaults to the wildcard host setting for the loadbalancer
+                        controller fulfilling this Ingress, if left unspecified.
+                      items:
+                        type: string
+                      type: array
+                    secretName:
+                      description: SecretName is the name of the secret used to terminate
+                        SSL traffic.
+                      type: string
+                  type: object
+                type: array
+            type: object
+          status:
+            description: TCPIngressStatus defines the observed state of TCPIngress
+            properties:
+              loadBalancer:
+                description: LoadBalancer contains the current status of the load-balancer.
+                properties:
+                  ingress:
+                    description: Ingress is a list containing ingress points for the
+                      load-balancer. Traffic intended for the service should be sent
+                      to these ingress points.
+                    items:
+                      description: 'LoadBalancerIngress represents the status of a
+                        load-balancer ingress point: traffic intended for the service
+                        should be sent to an ingress point.'
+                      properties:
+                        hostname:
+                          description: Hostname is set for load-balancer ingress points
+                            that are DNS based (typically AWS load-balancers)
+                          type: string
+                        ip:
+                          description: IP is set for load-balancer ingress points
+                            that are IP based (typically GCE or OpenStack load-balancers)
+                          type: string
+                        ports:
+                          description: Ports is a list of records of service ports
+                            If used, every port defined in the service should have
+                            an entry in it
+                          items:
+                            properties:
+                              error:
+                                description: 'Error is to record the problem with
+                                  the service port The format of the error shall comply
+                                  with the following rules: - built-in error values
+                                  shall be specified in this file and those shall
+                                  use   CamelCase names - cloud provider specific
+                                  error values must have names that comply with the   format
+                                  foo.example.com/CamelCase. --- The regex it matches
+                                  is (dns1123SubdomainFmt/)?(qualifiedNameFmt)'
+                                maxLength: 316
+                                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                                type: string
+                              port:
+                                description: Port is the port number of the service
+                                  port of which status is recorded here
+                                format: int32
+                                type: integer
+                              protocol:
+                                default: TCP
+                                description: 'Protocol is the protocol of the service
+                                  port of which status is recorded here The supported
+                                  values are: "TCP", "UDP", "SCTP"'
+                                type: string
+                            required:
+                            - port
+                            - protocol
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      type: object
                     type: array
-                  secretName:
-                    type: string
                 type: object
-              type: array
-          type: object
-        status:
-          type: object
-  version: v1beta1
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.6.2
+  creationTimestamp: null
+  name: udpingresses.configuration.konghq.com
+spec:
+  group: configuration.konghq.com
+  names:
+    kind: UDPIngress
+    listKind: UDPIngressList
+    plural: udpingresses
+    singular: udpingress
+  preserveUnknownFields: false
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Address of the load balancer
+      jsonPath: .status.loadBalancer.ingress[*].ip
+      name: Address
+      type: string
+    - description: Age
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: UDPIngress is the Schema for the udpingresses API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: UDPIngressSpec defines the desired state of UDPIngress
+            properties:
+              rules:
+                description: A list of rules used to configure the Ingress.
+                items:
+                  description: UDPIngressRule represents a rule to apply against incoming
+                    requests wherein no Host matching is available for request routing,
+                    only the port is used to match requests.
+                  properties:
+                    backend:
+                      description: Backend defines the Kubernetes service which accepts
+                        traffic from the listening Port defined above.
+                      properties:
+                        serviceName:
+                          description: Specifies the name of the referenced service.
+                          type: string
+                        servicePort:
+                          description: Specifies the port of the referenced service.
+                          format: int32
+                          maximum: 65535
+                          minimum: 1
+                          type: integer
+                      required:
+                      - serviceName
+                      - servicePort
+                      type: object
+                    port:
+                      description: Port indicates the port for the Kong proxy to accept
+                        incoming traffic on, which will then be routed to the service
+                        Backend.
+                      type: integer
+                  required:
+                  - backend
+                  - port
+                  type: object
+                type: array
+            type: object
+          status:
+            description: UDPIngressStatus defines the observed state of UDPIngress
+            properties:
+              loadBalancer:
+                description: LoadBalancer contains the current status of the load-balancer.
+                properties:
+                  ingress:
+                    description: Ingress is a list containing ingress points for the
+                      load-balancer. Traffic intended for the service should be sent
+                      to these ingress points.
+                    items:
+                      description: 'LoadBalancerIngress represents the status of a
+                        load-balancer ingress point: traffic intended for the service
+                        should be sent to an ingress point.'
+                      properties:
+                        hostname:
+                          description: Hostname is set for load-balancer ingress points
+                            that are DNS based (typically AWS load-balancers)
+                          type: string
+                        ip:
+                          description: IP is set for load-balancer ingress points
+                            that are IP based (typically GCE or OpenStack load-balancers)
+                          type: string
+                        ports:
+                          description: Ports is a list of records of service ports
+                            If used, every port defined in the service should have
+                            an entry in it
+                          items:
+                            properties:
+                              error:
+                                description: 'Error is to record the problem with
+                                  the service port The format of the error shall comply
+                                  with the following rules: - built-in error values
+                                  shall be specified in this file and those shall
+                                  use   CamelCase names - cloud provider specific
+                                  error values must have names that comply with the   format
+                                  foo.example.com/CamelCase. --- The regex it matches
+                                  is (dns1123SubdomainFmt/)?(qualifiedNameFmt)'
+                                maxLength: 316
+                                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                                type: string
+                              port:
+                                description: Port is the port number of the service
+                                  port of which status is recorded here
+                                format: int32
+                                type: integer
+                              protocol:
+                                default: TCP
+                                description: 'Protocol is the protocol of the service
+                                  port of which status is recorded here The supported
+                                  values are: "TCP", "UDP", "SCTP"'
+                                type: string
+                            required:
+                            - port
+                            - protocol
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      type: object
+                    type: array
+                type: object
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
 status:
   acceptedNames:
     kind: ""
@@ -479,14 +871,49 @@ status:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: kong-ingress-clusterrole
+  creationTimestamp: null
+  name: kong-ingress
 rules:
 - apiGroups:
   - ""
   resources:
   - endpoints
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - endpoints/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - ""
+  resources:
   - nodes
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
   - pods
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
   - secrets
   verbs:
   - list
@@ -494,9 +921,11 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - nodes
+  - secrets/status
   verbs:
   - get
+  - patch
+  - update
 - apiGroups:
   - ""
   resources:
@@ -506,8 +935,126 @@ rules:
   - list
   - watch
 - apiGroups:
-  - networking.k8s.io
+  - ""
+  resources:
+  - services/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - configuration.konghq.com
+  resources:
+  - kongclusterplugins
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - configuration.konghq.com
+  resources:
+  - kongclusterplugins/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - configuration.konghq.com
+  resources:
+  - kongconsumers
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - configuration.konghq.com
+  resources:
+  - kongconsumers/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - configuration.konghq.com
+  resources:
+  - kongingresses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - configuration.konghq.com
+  resources:
+  - kongingresses/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - configuration.konghq.com
+  resources:
+  - kongplugins
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - configuration.konghq.com
+  resources:
+  - kongplugins/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - configuration.konghq.com
+  resources:
+  - tcpingresses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - configuration.konghq.com
+  resources:
+  - tcpingresses/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - configuration.konghq.com
+  resources:
+  - udpingresses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - configuration.konghq.com
+  resources:
+  - udpingresses/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
   - extensions
+  resources:
+  - ingresses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - extensions
+  resources:
+  - ingresses/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
   - networking.internal.knative.dev
   resources:
   - ingresses
@@ -516,56 +1063,108 @@ rules:
   - list
   - watch
 - apiGroups:
+  - networking.internal.knative.dev
+  resources:
+  - ingresses/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - gatewayclasses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - gatewayclasses/status
+  verbs:
+  - get
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - gateways
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - gateways/status
+  verbs:
+  - get
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingresses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingresses/status
+  verbs:
+  - get
+  - patch
+  - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kong-ingress
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kong-ingress
+subjects:
+- kind: ServiceAccount
+  name: kong-serviceaccount
+  namespace: notdefault
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: kong-leader-election
+  namespace: notdefault
+rules:
+- apiGroups:
+  - ""
+  - coordination.k8s.io
+  resources:
+  - configmaps
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
   - ""
   resources:
   - events
   verbs:
   - create
   - patch
-- apiGroups:
-  - networking.k8s.io
-  - extensions
-  - networking.internal.knative.dev
-  resources:
-  - ingresses/status
-  verbs:
-  - update
-- apiGroups:
-  - configuration.konghq.com
-  resources:
-  - tcpingresses/status
-  verbs:
-  - update
-- apiGroups:
-  - configuration.konghq.com
-  resources:
-  - kongplugins
-  - kongclusterplugins
-  - kongcredentials
-  - kongconsumers
-  - kongingresses
-  - tcpingresses
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - ""
-  resources:
-  - configmaps
-  verbs:
-  - create
-  - get
-  - update
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
+kind: RoleBinding
 metadata:
-  name: kong-ingress-clusterrole-nisa-binding
+  name: kong-leader-election
+  namespace: notdefault
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: kong-ingress-clusterrole
+  kind: Role
+  name: kong-leader-election
 subjects:
 - kind: ServiceAccount
   name: kong-serviceaccount
@@ -593,6 +1192,20 @@ spec:
     app: ingress-kong
   type: LoadBalancer
 ---
+apiVersion: v1
+kind: Service
+metadata:
+  name: kong-validation-webhook
+  namespace: notdefault
+spec:
+  ports:
+  - name: webhook
+    port: 443
+    protocol: TCP
+    targetPort: 8080
+  selector:
+    app: ingress-kong
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -609,8 +1222,6 @@ spec:
     metadata:
       annotations:
         kuma.io/gateway: enabled
-        prometheus.io/port: "8100"
-        prometheus.io/scrape: "true"
         traffic.sidecar.istio.io/includeInboundPorts: ""
       labels:
         app: ingress-kong
@@ -635,7 +1246,7 @@ spec:
           value: /dev/stderr
         - name: KONG_PROXY_ERROR_LOG
           value: /dev/stderr
-        image: kong:2.4
+        image: kong:2.5
         lifecycle:
           preStop:
             exec:
@@ -691,7 +1302,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.namespace
-        image: kong/kubernetes-ingress-controller:1.3
+        image: kong/kubernetes-ingress-controller:2.0.5
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3
@@ -708,10 +1319,13 @@ spec:
         - containerPort: 8080
           name: webhook
           protocol: TCP
+        - containerPort: 10255
+          name: cmetrics
+          protocol: TCP
         readinessProbe:
           failureThreshold: 3
           httpGet:
-            path: /healthz
+            path: /readyz
             port: 10254
             scheme: HTTP
           initialDelaySeconds: 5

--- a/app/kumactl/data/install/k8s/gateway-kong-enterprise/kong-enterprise/kong-enterprise.yaml
+++ b/app/kumactl/data/install/k8s/gateway-kong-enterprise/kong-enterprise/kong-enterprise.yaml
@@ -5,157 +5,86 @@ metadata:
   annotations:
     kuma.io/sidecar-injection: enabled
 ---
-apiVersion: v1
-kind: Secret
-metadata:
-  name: kong-enterprise-license
-  namespace: {{ .Namespace }}
-type: Opaque
-stringData:
-  license: |
-    {{ .LicenseText }}
----
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: kongclusterplugins.configuration.konghq.com
 spec:
-  additionalPrinterColumns:
-  - JSONPath: .plugin
-    description: Name of the plugin
-    name: Plugin-Type
-    type: string
-  - JSONPath: .metadata.creationTimestamp
-    description: Age
-    name: Age
-    type: date
-  - JSONPath: .disabled
-    description: Indicates if the plugin is disabled
-    name: Disabled
-    priority: 1
-    type: boolean
-  - JSONPath: .config
-    description: Configuration of the plugin
-    name: Config
-    priority: 1
-    type: string
   group: configuration.konghq.com
   names:
     kind: KongClusterPlugin
+    listKind: KongClusterPluginList
     plural: kongclusterplugins
     shortNames:
     - kcp
+    singular: kongclusterplugin
+  preserveUnknownFields: false
   scope: Cluster
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      properties:
-        config:
-          type: object
-        configFrom:
-          properties:
-            secretKeyRef:
-              properties:
-                key:
-                  type: string
-                name:
-                  type: string
-                namespace:
-                  type: string
-              required:
-              - name
-              - namespace
-              - key
-              type: object
-          type: object
-        disabled:
-          type: boolean
-        plugin:
-          type: string
-        protocols:
-          items:
-            enum:
-            - http
-            - https
-            - grpc
-            - grpcs
-            - tcp
-            - tls
+  versions:
+  - additionalPrinterColumns:
+    - description: Name of the plugin
+      jsonPath: .plugin
+      name: Plugin-Type
+      type: string
+    - description: Age
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - description: Indicates if the plugin is disabled
+      jsonPath: .disabled
+      name: Disabled
+      priority: 1
+      type: boolean
+    - description: Configuration of the plugin
+      jsonPath: .config
+      name: Config
+      priority: 1
+      type: string
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: KongClusterPlugin is the Schema for the kongclusterplugins API
+        properties:
+          config:
+            description: Config contains the plugin configuration.
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+          configFrom:
+            description: ConfigFrom references a secret containing the plugin configuration.
+            properties:
+              secretKeyRef:
+                description: NamespacedSecretValueFromSource represents the source
+                  of a secret value specifying the secret namespace
+                properties:
+                  key:
+                    description: the key containing the value
+                    type: string
+                  name:
+                    description: the secret containing the key
+                    type: string
+                  namespace:
+                    description: The namespace containing the secret
+                    type: string
+                required:
+                - key
+                - name
+                - namespace
+                type: object
+            type: object
+          consumerRef:
+            description: ConsumerRef is a reference to a particular consumer
             type: string
-          type: array
-        run_on:
-          enum:
-          - first
-          - second
-          - all
-          type: string
-      required:
-      - plugin
-  version: v1
----
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
-  name: kongconsumers.configuration.konghq.com
-spec:
-  additionalPrinterColumns:
-  - JSONPath: .username
-    description: Username of a Kong Consumer
-    name: Username
-    type: string
-  - JSONPath: .metadata.creationTimestamp
-    description: Age
-    name: Age
-    type: date
-  group: configuration.konghq.com
-  names:
-    kind: KongConsumer
-    plural: kongconsumers
-    shortNames:
-    - kc
-  scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      properties:
-        credentials:
-          items:
+          disabled:
+            description: Disabled set if the plugin is disabled or not
+            type: boolean
+          plugin:
+            description: PluginName is the name of the plugin to which to apply the
+              config
             type: string
-          type: array
-        custom_id:
-          type: string
-        username:
-          type: string
-  version: v1
----
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
-  name: kongingresses.configuration.konghq.com
-spec:
-  group: configuration.konghq.com
-  names:
-    kind: KongIngress
-    plural: kongingresses
-    shortNames:
-    - ki
-  scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      properties:
-        proxy:
-          properties:
-            connect_timeout:
-              minimum: 0
-              type: integer
-            path:
-              pattern: ^/.*$
-              type: string
-            protocol:
+          protocols:
+            description: Protocols configures plugin to run on requests received on
+              specific protocols.
+            items:
               enum:
               - http
               - https
@@ -163,40 +92,116 @@ spec:
               - grpcs
               - tcp
               - tls
+              - udp
               type: string
-            read_timeout:
-              minimum: 0
-              type: integer
-            retries:
-              minimum: 0
-              type: integer
-            write_timeout:
-              minimum: 0
-              type: integer
-          type: object
-        route:
-          properties:
-            headers:
-              additionalProperties:
-                items:
-                  type: string
-                type: array
-              type: object
-            https_redirect_status_code:
-              type: integer
-            methods:
-              items:
+            type: array
+          run_on:
+            description: RunOn configures the plugin to run on the first or the second
+              or both nodes in case of a service mesh deployment.
+            enum:
+            - first
+            - second
+            - all
+            type: string
+        required:
+        - plugin
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: kongconsumers.configuration.konghq.com
+spec:
+  group: configuration.konghq.com
+  names:
+    kind: KongConsumer
+    listKind: KongConsumerList
+    plural: kongconsumers
+    shortNames:
+    - kc
+    singular: kongconsumer
+  preserveUnknownFields: false
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Username of a Kong Consumer
+      jsonPath: .username
+      name: Username
+      type: string
+    - description: Age
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: KongConsumer is the Schema for the kongconsumers API
+        properties:
+          credentials:
+            description: Credentials are references to secrets containing a credential
+              to be provisioned in Kong.
+            items:
+              type: string
+            type: array
+          custom_id:
+            description: CustomID existing unique ID for the consumer - useful for
+              mapping Kong with users in your existing database
+            type: string
+          username:
+            description: Username unique username of the consumer.
+            type: string
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: kongingresses.configuration.konghq.com
+spec:
+  group: configuration.konghq.com
+  names:
+    kind: KongIngress
+    listKind: KongIngressList
+    plural: kongingresses
+    shortNames:
+    - ki
+    singular: kongingress
+  preserveUnknownFields: false
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: KongIngress is the Schema for the kongingresses API
+        properties:
+          proxy:
+            properties:
+              connect_timeout:
+                minimum: 0
+                type: integer
+              path:
+                pattern: ^/.*$
                 type: string
-              type: array
-            path_handling:
-              enum:
-              - v0
-              - v1
-              type: string
-            preserve_host:
-              type: boolean
-            protocols:
-              items:
+              protocol:
                 enum:
                 - http
                 - https
@@ -204,273 +209,650 @@ spec:
                 - grpcs
                 - tcp
                 - tls
+                - udp
                 type: string
-              type: array
-            regex_priority:
-              type: integer
-            request_buffering:
-              type: boolean
-            response_buffering:
-              type: boolean
-            snis:
-              items:
+              read_timeout:
+                minimum: 0
+                type: integer
+              retries:
+                minimum: 0
+                type: integer
+              write_timeout:
+                minimum: 0
+                type: integer
+            type: object
+          route:
+            description: Route represents a Route in Kong. Read https://getkong.org/docs/0.13.x/admin-api/#Route-object
+            properties:
+              headers:
+                additionalProperties:
+                  items:
+                    type: string
+                  type: array
+                type: object
+              https_redirect_status_code:
+                type: integer
+              methods:
+                items:
+                  type: string
+                type: array
+              path_handling:
+                enum:
+                - v0
+                - v1
                 type: string
-              type: array
-            strip_path:
-              type: boolean
-        upstream:
-          properties:
-            algorithm:
-              enum:
-              - round-robin
-              - consistent-hashing
-              - least-connections
-              type: string
-            hash_fallback:
-              type: string
-            hash_fallback_header:
-              type: string
-            hash_on:
-              type: string
-            hash_on_cookie:
-              type: string
-            hash_on_cookie_path:
-              type: string
-            hash_on_header:
-              type: string
-            healthchecks:
-              properties:
-                active:
-                  properties:
-                    concurrency:
-                      minimum: 1
-                      type: integer
-                    healthy:
-                      properties:
-                        http_statuses:
-                          items:
+              preserve_host:
+                type: boolean
+              protocols:
+                items:
+                  enum:
+                  - http
+                  - https
+                  - grpc
+                  - grpcs
+                  - tcp
+                  - tls
+                  - udp
+                  type: string
+                type: array
+              regex_priority:
+                type: integer
+              request_buffering:
+                description: "Kong buffers requests and responses by default. Buffering
+                  is not always desired, for instance if large payloads are being
+                  proxied using HTTP 1.1 chunked encoding. \n The request and response
+                  route buffering options are enabled by default and allow the user
+                  to disable buffering if desired for their use case. \n SEE ALSO:
+                  - https://github.com/Kong/kong/pull/6057 - https://docs.konghq.com/2.2.x/admin-api/#route-object"
+                type: boolean
+              response_buffering:
+                type: boolean
+              snis:
+                items:
+                  type: string
+                type: array
+              strip_path:
+                type: boolean
+            type: object
+          upstream:
+            description: Upstream represents an Upstream in Kong.
+            properties:
+              algorithm:
+                enum:
+                - round-robin
+                - consistent-hashing
+                - least-connections
+                type: string
+              hash_fallback:
+                type: string
+              hash_fallback_header:
+                type: string
+              hash_on:
+                type: string
+              hash_on_cookie:
+                type: string
+              hash_on_cookie_path:
+                type: string
+              hash_on_header:
+                type: string
+              healthchecks:
+                description: Healthcheck represents a health-check config of an upstream
+                  in Kong.
+                properties:
+                  active:
+                    description: ActiveHealthcheck configures active health check
+                      probing.
+                    properties:
+                      concurrency:
+                        minimum: 1
+                        type: integer
+                      healthy:
+                        description: Healthy configures thresholds and HTTP status
+                          codes to mark targets healthy for an upstream.
+                        properties:
+                          http_statuses:
+                            items:
+                              type: integer
+                            type: array
+                          interval:
+                            minimum: 0
                             type: integer
-                          type: array
-                        interval:
-                          minimum: 0
-                          type: integer
-                        successes:
-                          minimum: 0
-                          type: integer
-                      type: object
-                    http_path:
-                      pattern: ^/.*$
-                      type: string
-                    timeout:
-                      minimum: 0
-                      type: integer
-                    unhealthy:
-                      properties:
-                        http_failures:
-                          minimum: 0
-                          type: integer
-                        http_statuses:
-                          items:
+                          successes:
+                            minimum: 0
                             type: integer
-                          type: array
-                        interval:
-                          minimum: 0
-                          type: integer
-                        tcp_failures:
-                          minimum: 0
-                          type: integer
-                        timeout:
-                          minimum: 0
-                          type: integer
-                      type: object
-                  type: object
-                passive:
-                  properties:
-                    healthy:
-                      properties:
-                        http_statuses:
-                          items:
+                        type: object
+                      http_path:
+                        pattern: ^/.*$
+                        type: string
+                      timeout:
+                        minimum: 0
+                        type: integer
+                      type:
+                        type: string
+                      unhealthy:
+                        description: Unhealthy configures thresholds and HTTP status
+                          codes to mark targets unhealthy.
+                        properties:
+                          http_failures:
+                            minimum: 0
                             type: integer
-                          type: array
-                        interval:
-                          minimum: 0
-                          type: integer
-                        successes:
-                          minimum: 0
-                          type: integer
-                      type: object
-                    unhealthy:
-                      properties:
-                        http_failures:
-                          minimum: 0
-                          type: integer
-                        http_statuses:
-                          items:
+                          http_statuses:
+                            items:
+                              type: integer
+                            type: array
+                          interval:
+                            minimum: 0
                             type: integer
-                          type: array
-                        interval:
-                          minimum: 0
-                          type: integer
-                        tcp_failures:
-                          minimum: 0
-                          type: integer
-                        timeout:
-                          minimum: 0
-                          type: integer
-                      type: object
-                  type: object
-                threshold:
-                  type: integer
-              type: object
-            host_header:
-              type: string
-            slots:
-              minimum: 10
-              type: integer
-          type: object
-  version: v1
+                          tcp_failures:
+                            minimum: 0
+                            type: integer
+                          timeout:
+                            minimum: 0
+                            type: integer
+                        type: object
+                    type: object
+                  passive:
+                    description: PassiveHealthcheck configures passive checks around
+                      passive health checks.
+                    properties:
+                      healthy:
+                        description: Healthy configures thresholds and HTTP status
+                          codes to mark targets healthy for an upstream.
+                        properties:
+                          http_statuses:
+                            items:
+                              type: integer
+                            type: array
+                          interval:
+                            minimum: 0
+                            type: integer
+                          successes:
+                            minimum: 0
+                            type: integer
+                        type: object
+                      unhealthy:
+                        description: Unhealthy configures thresholds and HTTP status
+                          codes to mark targets unhealthy.
+                        properties:
+                          http_failures:
+                            minimum: 0
+                            type: integer
+                          http_statuses:
+                            items:
+                              type: integer
+                            type: array
+                          interval:
+                            minimum: 0
+                            type: integer
+                          tcp_failures:
+                            minimum: 0
+                            type: integer
+                          timeout:
+                            minimum: 0
+                            type: integer
+                        type: object
+                    type: object
+                  threshold:
+                    type: integer
+                type: object
+              host_header:
+                type: string
+              slots:
+                minimum: 10
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: kongplugins.configuration.konghq.com
 spec:
-  additionalPrinterColumns:
-  - JSONPath: .plugin
-    description: Name of the plugin
-    name: Plugin-Type
-    type: string
-  - JSONPath: .metadata.creationTimestamp
-    description: Age
-    name: Age
-    type: date
-  - JSONPath: .disabled
-    description: Indicates if the plugin is disabled
-    name: Disabled
-    priority: 1
-    type: boolean
-  - JSONPath: .config
-    description: Configuration of the plugin
-    name: Config
-    priority: 1
-    type: string
   group: configuration.konghq.com
   names:
     kind: KongPlugin
+    listKind: KongPluginList
     plural: kongplugins
     shortNames:
     - kp
+    singular: kongplugin
+  preserveUnknownFields: false
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      properties:
-        config:
-          type: object
-        configFrom:
-          properties:
-            secretKeyRef:
-              properties:
-                key:
-                  type: string
-                name:
-                  type: string
-              required:
-              - name
-              - key
-              type: object
-          type: object
-        disabled:
-          type: boolean
-        plugin:
-          type: string
-        protocols:
-          items:
-            enum:
-            - http
-            - https
-            - grpc
-            - grpcs
-            - tcp
-            - tls
+  versions:
+  - additionalPrinterColumns:
+    - description: Name of the plugin
+      jsonPath: .plugin
+      name: Plugin-Type
+      type: string
+    - description: Age
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - description: Indicates if the plugin is disabled
+      jsonPath: .disabled
+      name: Disabled
+      priority: 1
+      type: boolean
+    - description: Configuration of the plugin
+      jsonPath: .config
+      name: Config
+      priority: 1
+      type: string
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: KongPlugin is the Schema for the kongplugins API
+        properties:
+          config:
+            description: Config contains the plugin configuration.
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+          configFrom:
+            description: ConfigFrom references a secret containing the plugin configuration.
+            properties:
+              secretKeyRef:
+                description: SecretValueFromSource represents the source of a secret
+                  value
+                properties:
+                  key:
+                    description: the key containing the value
+                    type: string
+                  name:
+                    description: the secret containing the key
+                    type: string
+                required:
+                - key
+                - name
+                type: object
+            type: object
+          disabled:
+            description: Disabled set if the plugin is disabled or not
+            type: boolean
+          plugin:
+            description: PluginName is the name of the plugin to which to apply the
+              config
             type: string
-          type: array
-        run_on:
-          enum:
-          - first
-          - second
-          - all
-          type: string
-      required:
-      - plugin
-  version: v1
+          protocols:
+            description: Protocols configures plugin to run on requests received on
+              specific protocols.
+            items:
+              enum:
+              - http
+              - https
+              - grpc
+              - grpcs
+              - tcp
+              - tls
+              - udp
+              type: string
+            type: array
+          run_on:
+            description: RunOn configures the plugin to run on the first or the second
+              or both nodes in case of a service mesh deployment.
+            enum:
+            - first
+            - second
+            - all
+            type: string
+        required:
+        - plugin
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.6.2
+  creationTimestamp: null
   name: tcpingresses.configuration.konghq.com
 spec:
-  additionalPrinterColumns:
-  - JSONPath: .status.loadBalancer.ingress[*].ip
-    description: Address of the load balancer
-    name: Address
-    type: string
-  - JSONPath: .metadata.creationTimestamp
-    description: Age
-    name: Age
-    type: date
   group: configuration.konghq.com
   names:
     kind: TCPIngress
+    listKind: TCPIngressList
     plural: tcpingresses
+    singular: tcpingress
+  preserveUnknownFields: false
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      properties:
-        apiVersion:
-          type: string
-        kind:
-          type: string
-        metadata:
-          type: object
-        spec:
-          properties:
-            rules:
-              items:
-                properties:
-                  backend:
-                    properties:
-                      serviceName:
-                        type: string
-                      servicePort:
-                        format: int32
-                        type: integer
-                    type: object
-                  host:
-                    type: string
-                  port:
-                    format: int32
-                    type: integer
-                type: object
-              type: array
-            tls:
-              items:
-                properties:
-                  hosts:
-                    items:
+  versions:
+  - additionalPrinterColumns:
+    - description: Address of the load balancer
+      jsonPath: .status.loadBalancer.ingress[*].ip
+      name: Address
+      type: string
+    - description: Age
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: TCPIngress is the Schema for the tcpingresses API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: TCPIngressSpec defines the desired state of TCPIngress
+            properties:
+              rules:
+                description: A list of rules used to configure the Ingress.
+                items:
+                  description: IngressRule represents a rule to apply against incoming
+                    requests. Matching is performed based on an (optional) SNI and
+                    port.
+                  properties:
+                    backend:
+                      description: Backend defines the referenced service endpoint
+                        to which the traffic will be forwarded to.
+                      properties:
+                        serviceName:
+                          description: Specifies the name of the referenced service.
+                          type: string
+                        servicePort:
+                          description: Specifies the port of the referenced service.
+                          format: int32
+                          maximum: 65535
+                          minimum: 1
+                          type: integer
+                      required:
+                      - serviceName
+                      - servicePort
+                      type: object
+                    host:
+                      description: Host is the fully qualified domain name of a network
+                        host, as defined by RFC 3986. If a Host is specified, the
+                        protocol must be TLS over TCP. A plain-text TCP request cannot
+                        be routed based on Host. It can only be routed based on Port.
                       type: string
+                    port:
+                      description: Port is the port on which to accept TCP or TLS
+                        over TCP sessions and route. It is a required field. If a
+                        Host is not specified, the requested are routed based only
+                        on Port.
+                      format: int32
+                      maximum: 65535
+                      minimum: 1
+                      type: integer
+                  required:
+                  - backend
+                  type: object
+                type: array
+              tls:
+                description: TLS configuration. This is similar to the `tls` section
+                  in the Ingress resource in networking.v1beta1 group. The mapping
+                  of SNIs to TLS cert-key pair defined here will be used for HTTP
+                  Ingress rules as well. Once can define the mapping in this resource
+                  or the original Ingress resource, both have the same effect.
+                items:
+                  description: IngressTLS describes the transport layer security.
+                  properties:
+                    hosts:
+                      description: Hosts are a list of hosts included in the TLS certificate.
+                        The values in this list must match the name/s used in the
+                        tlsSecret. Defaults to the wildcard host setting for the loadbalancer
+                        controller fulfilling this Ingress, if left unspecified.
+                      items:
+                        type: string
+                      type: array
+                    secretName:
+                      description: SecretName is the name of the secret used to terminate
+                        SSL traffic.
+                      type: string
+                  type: object
+                type: array
+            type: object
+          status:
+            description: TCPIngressStatus defines the observed state of TCPIngress
+            properties:
+              loadBalancer:
+                description: LoadBalancer contains the current status of the load-balancer.
+                properties:
+                  ingress:
+                    description: Ingress is a list containing ingress points for the
+                      load-balancer. Traffic intended for the service should be sent
+                      to these ingress points.
+                    items:
+                      description: 'LoadBalancerIngress represents the status of a
+                        load-balancer ingress point: traffic intended for the service
+                        should be sent to an ingress point.'
+                      properties:
+                        hostname:
+                          description: Hostname is set for load-balancer ingress points
+                            that are DNS based (typically AWS load-balancers)
+                          type: string
+                        ip:
+                          description: IP is set for load-balancer ingress points
+                            that are IP based (typically GCE or OpenStack load-balancers)
+                          type: string
+                        ports:
+                          description: Ports is a list of records of service ports
+                            If used, every port defined in the service should have
+                            an entry in it
+                          items:
+                            properties:
+                              error:
+                                description: 'Error is to record the problem with
+                                  the service port The format of the error shall comply
+                                  with the following rules: - built-in error values
+                                  shall be specified in this file and those shall
+                                  use   CamelCase names - cloud provider specific
+                                  error values must have names that comply with the   format
+                                  foo.example.com/CamelCase. --- The regex it matches
+                                  is (dns1123SubdomainFmt/)?(qualifiedNameFmt)'
+                                maxLength: 316
+                                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                                type: string
+                              port:
+                                description: Port is the port number of the service
+                                  port of which status is recorded here
+                                format: int32
+                                type: integer
+                              protocol:
+                                default: TCP
+                                description: 'Protocol is the protocol of the service
+                                  port of which status is recorded here The supported
+                                  values are: "TCP", "UDP", "SCTP"'
+                                type: string
+                            required:
+                            - port
+                            - protocol
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      type: object
                     type: array
-                  secretName:
-                    type: string
                 type: object
-              type: array
-          type: object
-        status:
-          type: object
-  version: v1beta1
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.6.2
+  creationTimestamp: null
+  name: udpingresses.configuration.konghq.com
+spec:
+  group: configuration.konghq.com
+  names:
+    kind: UDPIngress
+    listKind: UDPIngressList
+    plural: udpingresses
+    singular: udpingress
+  preserveUnknownFields: false
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Address of the load balancer
+      jsonPath: .status.loadBalancer.ingress[*].ip
+      name: Address
+      type: string
+    - description: Age
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: UDPIngress is the Schema for the udpingresses API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: UDPIngressSpec defines the desired state of UDPIngress
+            properties:
+              rules:
+                description: A list of rules used to configure the Ingress.
+                items:
+                  description: UDPIngressRule represents a rule to apply against incoming
+                    requests wherein no Host matching is available for request routing,
+                    only the port is used to match requests.
+                  properties:
+                    backend:
+                      description: Backend defines the Kubernetes service which accepts
+                        traffic from the listening Port defined above.
+                      properties:
+                        serviceName:
+                          description: Specifies the name of the referenced service.
+                          type: string
+                        servicePort:
+                          description: Specifies the port of the referenced service.
+                          format: int32
+                          maximum: 65535
+                          minimum: 1
+                          type: integer
+                      required:
+                      - serviceName
+                      - servicePort
+                      type: object
+                    port:
+                      description: Port indicates the port for the Kong proxy to accept
+                        incoming traffic on, which will then be routed to the service
+                        Backend.
+                      type: integer
+                  required:
+                  - backend
+                  - port
+                  type: object
+                type: array
+            type: object
+          status:
+            description: UDPIngressStatus defines the observed state of UDPIngress
+            properties:
+              loadBalancer:
+                description: LoadBalancer contains the current status of the load-balancer.
+                properties:
+                  ingress:
+                    description: Ingress is a list containing ingress points for the
+                      load-balancer. Traffic intended for the service should be sent
+                      to these ingress points.
+                    items:
+                      description: 'LoadBalancerIngress represents the status of a
+                        load-balancer ingress point: traffic intended for the service
+                        should be sent to an ingress point.'
+                      properties:
+                        hostname:
+                          description: Hostname is set for load-balancer ingress points
+                            that are DNS based (typically AWS load-balancers)
+                          type: string
+                        ip:
+                          description: IP is set for load-balancer ingress points
+                            that are IP based (typically GCE or OpenStack load-balancers)
+                          type: string
+                        ports:
+                          description: Ports is a list of records of service ports
+                            If used, every port defined in the service should have
+                            an entry in it
+                          items:
+                            properties:
+                              error:
+                                description: 'Error is to record the problem with
+                                  the service port The format of the error shall comply
+                                  with the following rules: - built-in error values
+                                  shall be specified in this file and those shall
+                                  use   CamelCase names - cloud provider specific
+                                  error values must have names that comply with the   format
+                                  foo.example.com/CamelCase. --- The regex it matches
+                                  is (dns1123SubdomainFmt/)?(qualifiedNameFmt)'
+                                maxLength: 316
+                                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                                type: string
+                              port:
+                                description: Port is the port number of the service
+                                  port of which status is recorded here
+                                format: int32
+                                type: integer
+                              protocol:
+                                default: TCP
+                                description: 'Protocol is the protocol of the service
+                                  port of which status is recorded here The supported
+                                  values are: "TCP", "UDP", "SCTP"'
+                                type: string
+                            required:
+                            - port
+                            - protocol
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      type: object
+                    type: array
+                type: object
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
 status:
   acceptedNames:
     kind: ""
@@ -485,16 +867,79 @@ metadata:
   namespace: {{ .Namespace }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: kong-leader-election
+  namespace: {{ .Namespace }}
+rules:
+- apiGroups:
+  - ""
+  - coordination.k8s.io
+  resources:
+  - configmaps
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+---
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: kong-ingress-clusterrole
+  creationTimestamp: null
+  name: kong-ingress
 rules:
 - apiGroups:
   - ""
   resources:
   - endpoints
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - endpoints/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - ""
+  resources:
   - nodes
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
   - pods
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
   - secrets
   verbs:
   - list
@@ -502,9 +947,11 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - nodes
+  - secrets/status
   verbs:
   - get
+  - patch
+  - update
 - apiGroups:
   - ""
   resources:
@@ -514,8 +961,126 @@ rules:
   - list
   - watch
 - apiGroups:
-  - networking.k8s.io
+  - ""
+  resources:
+  - services/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - configuration.konghq.com
+  resources:
+  - kongclusterplugins
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - configuration.konghq.com
+  resources:
+  - kongclusterplugins/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - configuration.konghq.com
+  resources:
+  - kongconsumers
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - configuration.konghq.com
+  resources:
+  - kongconsumers/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - configuration.konghq.com
+  resources:
+  - kongingresses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - configuration.konghq.com
+  resources:
+  - kongingresses/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - configuration.konghq.com
+  resources:
+  - kongplugins
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - configuration.konghq.com
+  resources:
+  - kongplugins/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - configuration.konghq.com
+  resources:
+  - tcpingresses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - configuration.konghq.com
+  resources:
+  - tcpingresses/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - configuration.konghq.com
+  resources:
+  - udpingresses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - configuration.konghq.com
+  resources:
+  - udpingresses/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
   - extensions
+  resources:
+  - ingresses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - extensions
+  resources:
+  - ingresses/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
   - networking.internal.knative.dev
   resources:
   - ingresses
@@ -524,56 +1089,80 @@ rules:
   - list
   - watch
 - apiGroups:
-  - ""
-  resources:
-  - events
-  verbs:
-  - create
-  - patch
-- apiGroups:
-  - networking.k8s.io
-  - extensions
   - networking.internal.knative.dev
   resources:
   - ingresses/status
   verbs:
+  - get
+  - patch
   - update
 - apiGroups:
-  - configuration.konghq.com
+  - networking.k8s.io
   resources:
-  - tcpingresses/status
-  verbs:
-  - update
-- apiGroups:
-  - configuration.konghq.com
-  resources:
-  - kongplugins
-  - kongclusterplugins
-  - kongcredentials
-  - kongconsumers
-  - kongingresses
-  - tcpingresses
+  - gatewayclasses
   verbs:
   - get
   - list
   - watch
 - apiGroups:
-  - ""
+  - networking.k8s.io
   resources:
-  - configmaps
+  - gatewayclasses/status
   verbs:
-  - create
   - get
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - gateways
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - gateways/status
+  verbs:
+  - get
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingresses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingresses/status
+  verbs:
+  - get
+  - patch
   - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: kong-leader-election
+  namespace: {{ .Namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: kong-leader-election
+subjects:
+- kind: ServiceAccount
+  name: kong-serviceaccount
+  namespace: {{ .Namespace }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: kong-ingress-clusterrole-nisa-binding
+  name: kong-ingress
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: kong-ingress-clusterrole
+  name: kong-ingress
 subjects:
 - kind: ServiceAccount
   name: kong-serviceaccount
@@ -601,6 +1190,20 @@ spec:
     app: ingress-kong
   type: LoadBalancer
 ---
+apiVersion: v1
+kind: Service
+metadata:
+  name: kong-validation-webhook
+  namespace: {{ .Namespace }}
+spec:
+  ports:
+  - name: webhook
+    port: 443
+    protocol: TCP
+    targetPort: 8080
+  selector:
+    app: ingress-kong
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -617,19 +1220,12 @@ spec:
     metadata:
       annotations:
         kuma.io/gateway: enabled
-        prometheus.io/port: "8100"
-        prometheus.io/scrape: "true"
         traffic.sidecar.istio.io/includeInboundPorts: ""
       labels:
         app: ingress-kong
     spec:
       containers:
       - env:
-        - name: KONG_LICENSE_DATA
-          valueFrom:
-            secretKeyRef:
-              key: license
-              name: kong-enterprise-license
         - name: KONG_PROXY_LISTEN
           value: 0.0.0.0:8000, 0.0.0.0:8443 ssl http2
         - name: KONG_PORT_MAPS
@@ -648,7 +1244,7 @@ spec:
           value: /dev/stderr
         - name: KONG_PROXY_ERROR_LOG
           value: /dev/stderr
-        image: kong/kong-gateway:2.4.1.0-alpine
+        image: kong:2.5
         lifecycle:
           preStop:
             exec:
@@ -704,7 +1300,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.namespace
-        image: kong/kubernetes-ingress-controller:1.3
+        image: kong/kubernetes-ingress-controller:2.0.5
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3
@@ -721,16 +1317,17 @@ spec:
         - containerPort: 8080
           name: webhook
           protocol: TCP
+        - containerPort: 10255
+          name: cmetrics
+          protocol: TCP
         readinessProbe:
           failureThreshold: 3
           httpGet:
-            path: /healthz
+            path: /readyz
             port: 10254
             scheme: HTTP
           initialDelaySeconds: 5
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 1
-      imagePullSecrets:
-      - name: kong-enterprise-edition-docker
       serviceAccountName: kong-serviceaccount

--- a/app/kumactl/data/install/k8s/gateway-kong-enterprise/kong-enterprise/kong-enterprise.yaml
+++ b/app/kumactl/data/install/k8s/gateway-kong-enterprise/kong-enterprise/kong-enterprise.yaml
@@ -1226,6 +1226,11 @@ spec:
     spec:
       containers:
       - env:
+        - name: KONG_LICENSE_DATA
+          valueFrom:
+            secretKeyRef:
+              key: license
+              name: kong-enterprise-license
         - name: KONG_PROXY_LISTEN
           value: 0.0.0.0:8000, 0.0.0.0:8443 ssl http2
         - name: KONG_PORT_MAPS
@@ -1244,7 +1249,7 @@ spec:
           value: /dev/stderr
         - name: KONG_PROXY_ERROR_LOG
           value: /dev/stderr
-        image: kong:2.5
+        image: kong/kong-gateway:2.5
         lifecycle:
           preStop:
             exec:
@@ -1330,4 +1335,16 @@ spec:
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 1
+      imagePullSecrets:
+      - name: kong-enterprise-edition-docker
       serviceAccountName: kong-serviceaccount
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: kong-enterprise-license
+  namespace: {{ .Namespace }}
+type: Opaque
+stringData:
+  license: |
+    {{ .LicenseText }}

--- a/app/kumactl/data/install/k8s/gateway-kong/kong/kong.yaml
+++ b/app/kumactl/data/install/k8s/gateway-kong/kong/kong.yaml
@@ -5,147 +5,86 @@ metadata:
   annotations:
     kuma.io/sidecar-injection: enabled
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: kongclusterplugins.configuration.konghq.com
 spec:
-  additionalPrinterColumns:
-  - JSONPath: .plugin
-    description: Name of the plugin
-    name: Plugin-Type
-    type: string
-  - JSONPath: .metadata.creationTimestamp
-    description: Age
-    name: Age
-    type: date
-  - JSONPath: .disabled
-    description: Indicates if the plugin is disabled
-    name: Disabled
-    priority: 1
-    type: boolean
-  - JSONPath: .config
-    description: Configuration of the plugin
-    name: Config
-    priority: 1
-    type: string
   group: configuration.konghq.com
   names:
     kind: KongClusterPlugin
+    listKind: KongClusterPluginList
     plural: kongclusterplugins
     shortNames:
     - kcp
+    singular: kongclusterplugin
+  preserveUnknownFields: false
   scope: Cluster
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      properties:
-        config:
-          type: object
-        configFrom:
-          properties:
-            secretKeyRef:
-              properties:
-                key:
-                  type: string
-                name:
-                  type: string
-                namespace:
-                  type: string
-              required:
-              - name
-              - namespace
-              - key
-              type: object
-          type: object
-        disabled:
-          type: boolean
-        plugin:
-          type: string
-        protocols:
-          items:
-            enum:
-            - http
-            - https
-            - grpc
-            - grpcs
-            - tcp
-            - tls
+  versions:
+  - additionalPrinterColumns:
+    - description: Name of the plugin
+      jsonPath: .plugin
+      name: Plugin-Type
+      type: string
+    - description: Age
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - description: Indicates if the plugin is disabled
+      jsonPath: .disabled
+      name: Disabled
+      priority: 1
+      type: boolean
+    - description: Configuration of the plugin
+      jsonPath: .config
+      name: Config
+      priority: 1
+      type: string
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: KongClusterPlugin is the Schema for the kongclusterplugins API
+        properties:
+          config:
+            description: Config contains the plugin configuration.
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+          configFrom:
+            description: ConfigFrom references a secret containing the plugin configuration.
+            properties:
+              secretKeyRef:
+                description: NamespacedSecretValueFromSource represents the source
+                  of a secret value specifying the secret namespace
+                properties:
+                  key:
+                    description: the key containing the value
+                    type: string
+                  name:
+                    description: the secret containing the key
+                    type: string
+                  namespace:
+                    description: The namespace containing the secret
+                    type: string
+                required:
+                - key
+                - name
+                - namespace
+                type: object
+            type: object
+          consumerRef:
+            description: ConsumerRef is a reference to a particular consumer
             type: string
-          type: array
-        run_on:
-          enum:
-          - first
-          - second
-          - all
-          type: string
-      required:
-      - plugin
-  version: v1
----
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
-  name: kongconsumers.configuration.konghq.com
-spec:
-  additionalPrinterColumns:
-  - JSONPath: .username
-    description: Username of a Kong Consumer
-    name: Username
-    type: string
-  - JSONPath: .metadata.creationTimestamp
-    description: Age
-    name: Age
-    type: date
-  group: configuration.konghq.com
-  names:
-    kind: KongConsumer
-    plural: kongconsumers
-    shortNames:
-    - kc
-  scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      properties:
-        credentials:
-          items:
+          disabled:
+            description: Disabled set if the plugin is disabled or not
+            type: boolean
+          plugin:
+            description: PluginName is the name of the plugin to which to apply the
+              config
             type: string
-          type: array
-        custom_id:
-          type: string
-        username:
-          type: string
-  version: v1
----
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
-  name: kongingresses.configuration.konghq.com
-spec:
-  group: configuration.konghq.com
-  names:
-    kind: KongIngress
-    plural: kongingresses
-    shortNames:
-    - ki
-  scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      properties:
-        proxy:
-          properties:
-            connect_timeout:
-              minimum: 0
-              type: integer
-            path:
-              pattern: ^/.*$
-              type: string
-            protocol:
+          protocols:
+            description: Protocols configures plugin to run on requests received on
+              specific protocols.
+            items:
               enum:
               - http
               - https
@@ -153,40 +92,116 @@ spec:
               - grpcs
               - tcp
               - tls
+              - udp
               type: string
-            read_timeout:
-              minimum: 0
-              type: integer
-            retries:
-              minimum: 0
-              type: integer
-            write_timeout:
-              minimum: 0
-              type: integer
-          type: object
-        route:
-          properties:
-            headers:
-              additionalProperties:
-                items:
-                  type: string
-                type: array
-              type: object
-            https_redirect_status_code:
-              type: integer
-            methods:
-              items:
+            type: array
+          run_on:
+            description: RunOn configures the plugin to run on the first or the second
+              or both nodes in case of a service mesh deployment.
+            enum:
+            - first
+            - second
+            - all
+            type: string
+        required:
+        - plugin
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: kongconsumers.configuration.konghq.com
+spec:
+  group: configuration.konghq.com
+  names:
+    kind: KongConsumer
+    listKind: KongConsumerList
+    plural: kongconsumers
+    shortNames:
+    - kc
+    singular: kongconsumer
+  preserveUnknownFields: false
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Username of a Kong Consumer
+      jsonPath: .username
+      name: Username
+      type: string
+    - description: Age
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: KongConsumer is the Schema for the kongconsumers API
+        properties:
+          credentials:
+            description: Credentials are references to secrets containing a credential
+              to be provisioned in Kong.
+            items:
+              type: string
+            type: array
+          custom_id:
+            description: CustomID existing unique ID for the consumer - useful for
+              mapping Kong with users in your existing database
+            type: string
+          username:
+            description: Username unique username of the consumer.
+            type: string
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: kongingresses.configuration.konghq.com
+spec:
+  group: configuration.konghq.com
+  names:
+    kind: KongIngress
+    listKind: KongIngressList
+    plural: kongingresses
+    shortNames:
+    - ki
+    singular: kongingress
+  preserveUnknownFields: false
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: KongIngress is the Schema for the kongingresses API
+        properties:
+          proxy:
+            properties:
+              connect_timeout:
+                minimum: 0
+                type: integer
+              path:
+                pattern: ^/.*$
                 type: string
-              type: array
-            path_handling:
-              enum:
-              - v0
-              - v1
-              type: string
-            preserve_host:
-              type: boolean
-            protocols:
-              items:
+              protocol:
                 enum:
                 - http
                 - https
@@ -194,273 +209,650 @@ spec:
                 - grpcs
                 - tcp
                 - tls
+                - udp
                 type: string
-              type: array
-            regex_priority:
-              type: integer
-            request_buffering:
-              type: boolean
-            response_buffering:
-              type: boolean
-            snis:
-              items:
+              read_timeout:
+                minimum: 0
+                type: integer
+              retries:
+                minimum: 0
+                type: integer
+              write_timeout:
+                minimum: 0
+                type: integer
+            type: object
+          route:
+            description: Route represents a Route in Kong. Read https://getkong.org/docs/0.13.x/admin-api/#Route-object
+            properties:
+              headers:
+                additionalProperties:
+                  items:
+                    type: string
+                  type: array
+                type: object
+              https_redirect_status_code:
+                type: integer
+              methods:
+                items:
+                  type: string
+                type: array
+              path_handling:
+                enum:
+                - v0
+                - v1
                 type: string
-              type: array
-            strip_path:
-              type: boolean
-        upstream:
-          properties:
-            algorithm:
-              enum:
-              - round-robin
-              - consistent-hashing
-              - least-connections
-              type: string
-            hash_fallback:
-              type: string
-            hash_fallback_header:
-              type: string
-            hash_on:
-              type: string
-            hash_on_cookie:
-              type: string
-            hash_on_cookie_path:
-              type: string
-            hash_on_header:
-              type: string
-            healthchecks:
-              properties:
-                active:
-                  properties:
-                    concurrency:
-                      minimum: 1
-                      type: integer
-                    healthy:
-                      properties:
-                        http_statuses:
-                          items:
+              preserve_host:
+                type: boolean
+              protocols:
+                items:
+                  enum:
+                  - http
+                  - https
+                  - grpc
+                  - grpcs
+                  - tcp
+                  - tls
+                  - udp
+                  type: string
+                type: array
+              regex_priority:
+                type: integer
+              request_buffering:
+                description: "Kong buffers requests and responses by default. Buffering
+                  is not always desired, for instance if large payloads are being
+                  proxied using HTTP 1.1 chunked encoding. \n The request and response
+                  route buffering options are enabled by default and allow the user
+                  to disable buffering if desired for their use case. \n SEE ALSO:
+                  - https://github.com/Kong/kong/pull/6057 - https://docs.konghq.com/2.2.x/admin-api/#route-object"
+                type: boolean
+              response_buffering:
+                type: boolean
+              snis:
+                items:
+                  type: string
+                type: array
+              strip_path:
+                type: boolean
+            type: object
+          upstream:
+            description: Upstream represents an Upstream in Kong.
+            properties:
+              algorithm:
+                enum:
+                - round-robin
+                - consistent-hashing
+                - least-connections
+                type: string
+              hash_fallback:
+                type: string
+              hash_fallback_header:
+                type: string
+              hash_on:
+                type: string
+              hash_on_cookie:
+                type: string
+              hash_on_cookie_path:
+                type: string
+              hash_on_header:
+                type: string
+              healthchecks:
+                description: Healthcheck represents a health-check config of an upstream
+                  in Kong.
+                properties:
+                  active:
+                    description: ActiveHealthcheck configures active health check
+                      probing.
+                    properties:
+                      concurrency:
+                        minimum: 1
+                        type: integer
+                      healthy:
+                        description: Healthy configures thresholds and HTTP status
+                          codes to mark targets healthy for an upstream.
+                        properties:
+                          http_statuses:
+                            items:
+                              type: integer
+                            type: array
+                          interval:
+                            minimum: 0
                             type: integer
-                          type: array
-                        interval:
-                          minimum: 0
-                          type: integer
-                        successes:
-                          minimum: 0
-                          type: integer
-                      type: object
-                    http_path:
-                      pattern: ^/.*$
-                      type: string
-                    timeout:
-                      minimum: 0
-                      type: integer
-                    unhealthy:
-                      properties:
-                        http_failures:
-                          minimum: 0
-                          type: integer
-                        http_statuses:
-                          items:
+                          successes:
+                            minimum: 0
                             type: integer
-                          type: array
-                        interval:
-                          minimum: 0
-                          type: integer
-                        tcp_failures:
-                          minimum: 0
-                          type: integer
-                        timeout:
-                          minimum: 0
-                          type: integer
-                      type: object
-                  type: object
-                passive:
-                  properties:
-                    healthy:
-                      properties:
-                        http_statuses:
-                          items:
+                        type: object
+                      http_path:
+                        pattern: ^/.*$
+                        type: string
+                      timeout:
+                        minimum: 0
+                        type: integer
+                      type:
+                        type: string
+                      unhealthy:
+                        description: Unhealthy configures thresholds and HTTP status
+                          codes to mark targets unhealthy.
+                        properties:
+                          http_failures:
+                            minimum: 0
                             type: integer
-                          type: array
-                        interval:
-                          minimum: 0
-                          type: integer
-                        successes:
-                          minimum: 0
-                          type: integer
-                      type: object
-                    unhealthy:
-                      properties:
-                        http_failures:
-                          minimum: 0
-                          type: integer
-                        http_statuses:
-                          items:
+                          http_statuses:
+                            items:
+                              type: integer
+                            type: array
+                          interval:
+                            minimum: 0
                             type: integer
-                          type: array
-                        interval:
-                          minimum: 0
-                          type: integer
-                        tcp_failures:
-                          minimum: 0
-                          type: integer
-                        timeout:
-                          minimum: 0
-                          type: integer
-                      type: object
-                  type: object
-                threshold:
-                  type: integer
-              type: object
-            host_header:
-              type: string
-            slots:
-              minimum: 10
-              type: integer
-          type: object
-  version: v1
+                          tcp_failures:
+                            minimum: 0
+                            type: integer
+                          timeout:
+                            minimum: 0
+                            type: integer
+                        type: object
+                    type: object
+                  passive:
+                    description: PassiveHealthcheck configures passive checks around
+                      passive health checks.
+                    properties:
+                      healthy:
+                        description: Healthy configures thresholds and HTTP status
+                          codes to mark targets healthy for an upstream.
+                        properties:
+                          http_statuses:
+                            items:
+                              type: integer
+                            type: array
+                          interval:
+                            minimum: 0
+                            type: integer
+                          successes:
+                            minimum: 0
+                            type: integer
+                        type: object
+                      unhealthy:
+                        description: Unhealthy configures thresholds and HTTP status
+                          codes to mark targets unhealthy.
+                        properties:
+                          http_failures:
+                            minimum: 0
+                            type: integer
+                          http_statuses:
+                            items:
+                              type: integer
+                            type: array
+                          interval:
+                            minimum: 0
+                            type: integer
+                          tcp_failures:
+                            minimum: 0
+                            type: integer
+                          timeout:
+                            minimum: 0
+                            type: integer
+                        type: object
+                    type: object
+                  threshold:
+                    type: integer
+                type: object
+              host_header:
+                type: string
+              slots:
+                minimum: 10
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: kongplugins.configuration.konghq.com
 spec:
-  additionalPrinterColumns:
-  - JSONPath: .plugin
-    description: Name of the plugin
-    name: Plugin-Type
-    type: string
-  - JSONPath: .metadata.creationTimestamp
-    description: Age
-    name: Age
-    type: date
-  - JSONPath: .disabled
-    description: Indicates if the plugin is disabled
-    name: Disabled
-    priority: 1
-    type: boolean
-  - JSONPath: .config
-    description: Configuration of the plugin
-    name: Config
-    priority: 1
-    type: string
   group: configuration.konghq.com
   names:
     kind: KongPlugin
+    listKind: KongPluginList
     plural: kongplugins
     shortNames:
     - kp
+    singular: kongplugin
+  preserveUnknownFields: false
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      properties:
-        config:
-          type: object
-        configFrom:
-          properties:
-            secretKeyRef:
-              properties:
-                key:
-                  type: string
-                name:
-                  type: string
-              required:
-              - name
-              - key
-              type: object
-          type: object
-        disabled:
-          type: boolean
-        plugin:
-          type: string
-        protocols:
-          items:
-            enum:
-            - http
-            - https
-            - grpc
-            - grpcs
-            - tcp
-            - tls
+  versions:
+  - additionalPrinterColumns:
+    - description: Name of the plugin
+      jsonPath: .plugin
+      name: Plugin-Type
+      type: string
+    - description: Age
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - description: Indicates if the plugin is disabled
+      jsonPath: .disabled
+      name: Disabled
+      priority: 1
+      type: boolean
+    - description: Configuration of the plugin
+      jsonPath: .config
+      name: Config
+      priority: 1
+      type: string
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: KongPlugin is the Schema for the kongplugins API
+        properties:
+          config:
+            description: Config contains the plugin configuration.
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+          configFrom:
+            description: ConfigFrom references a secret containing the plugin configuration.
+            properties:
+              secretKeyRef:
+                description: SecretValueFromSource represents the source of a secret
+                  value
+                properties:
+                  key:
+                    description: the key containing the value
+                    type: string
+                  name:
+                    description: the secret containing the key
+                    type: string
+                required:
+                - key
+                - name
+                type: object
+            type: object
+          disabled:
+            description: Disabled set if the plugin is disabled or not
+            type: boolean
+          plugin:
+            description: PluginName is the name of the plugin to which to apply the
+              config
             type: string
-          type: array
-        run_on:
-          enum:
-          - first
-          - second
-          - all
-          type: string
-      required:
-      - plugin
-  version: v1
+          protocols:
+            description: Protocols configures plugin to run on requests received on
+              specific protocols.
+            items:
+              enum:
+              - http
+              - https
+              - grpc
+              - grpcs
+              - tcp
+              - tls
+              - udp
+              type: string
+            type: array
+          run_on:
+            description: RunOn configures the plugin to run on the first or the second
+              or both nodes in case of a service mesh deployment.
+            enum:
+            - first
+            - second
+            - all
+            type: string
+        required:
+        - plugin
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.6.2
+  creationTimestamp: null
   name: tcpingresses.configuration.konghq.com
 spec:
-  additionalPrinterColumns:
-  - JSONPath: .status.loadBalancer.ingress[*].ip
-    description: Address of the load balancer
-    name: Address
-    type: string
-  - JSONPath: .metadata.creationTimestamp
-    description: Age
-    name: Age
-    type: date
   group: configuration.konghq.com
   names:
     kind: TCPIngress
+    listKind: TCPIngressList
     plural: tcpingresses
+    singular: tcpingress
+  preserveUnknownFields: false
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      properties:
-        apiVersion:
-          type: string
-        kind:
-          type: string
-        metadata:
-          type: object
-        spec:
-          properties:
-            rules:
-              items:
-                properties:
-                  backend:
-                    properties:
-                      serviceName:
-                        type: string
-                      servicePort:
-                        format: int32
-                        type: integer
-                    type: object
-                  host:
-                    type: string
-                  port:
-                    format: int32
-                    type: integer
-                type: object
-              type: array
-            tls:
-              items:
-                properties:
-                  hosts:
-                    items:
+  versions:
+  - additionalPrinterColumns:
+    - description: Address of the load balancer
+      jsonPath: .status.loadBalancer.ingress[*].ip
+      name: Address
+      type: string
+    - description: Age
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: TCPIngress is the Schema for the tcpingresses API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: TCPIngressSpec defines the desired state of TCPIngress
+            properties:
+              rules:
+                description: A list of rules used to configure the Ingress.
+                items:
+                  description: IngressRule represents a rule to apply against incoming
+                    requests. Matching is performed based on an (optional) SNI and
+                    port.
+                  properties:
+                    backend:
+                      description: Backend defines the referenced service endpoint
+                        to which the traffic will be forwarded to.
+                      properties:
+                        serviceName:
+                          description: Specifies the name of the referenced service.
+                          type: string
+                        servicePort:
+                          description: Specifies the port of the referenced service.
+                          format: int32
+                          maximum: 65535
+                          minimum: 1
+                          type: integer
+                      required:
+                      - serviceName
+                      - servicePort
+                      type: object
+                    host:
+                      description: Host is the fully qualified domain name of a network
+                        host, as defined by RFC 3986. If a Host is specified, the
+                        protocol must be TLS over TCP. A plain-text TCP request cannot
+                        be routed based on Host. It can only be routed based on Port.
                       type: string
+                    port:
+                      description: Port is the port on which to accept TCP or TLS
+                        over TCP sessions and route. It is a required field. If a
+                        Host is not specified, the requested are routed based only
+                        on Port.
+                      format: int32
+                      maximum: 65535
+                      minimum: 1
+                      type: integer
+                  required:
+                  - backend
+                  type: object
+                type: array
+              tls:
+                description: TLS configuration. This is similar to the `tls` section
+                  in the Ingress resource in networking.v1beta1 group. The mapping
+                  of SNIs to TLS cert-key pair defined here will be used for HTTP
+                  Ingress rules as well. Once can define the mapping in this resource
+                  or the original Ingress resource, both have the same effect.
+                items:
+                  description: IngressTLS describes the transport layer security.
+                  properties:
+                    hosts:
+                      description: Hosts are a list of hosts included in the TLS certificate.
+                        The values in this list must match the name/s used in the
+                        tlsSecret. Defaults to the wildcard host setting for the loadbalancer
+                        controller fulfilling this Ingress, if left unspecified.
+                      items:
+                        type: string
+                      type: array
+                    secretName:
+                      description: SecretName is the name of the secret used to terminate
+                        SSL traffic.
+                      type: string
+                  type: object
+                type: array
+            type: object
+          status:
+            description: TCPIngressStatus defines the observed state of TCPIngress
+            properties:
+              loadBalancer:
+                description: LoadBalancer contains the current status of the load-balancer.
+                properties:
+                  ingress:
+                    description: Ingress is a list containing ingress points for the
+                      load-balancer. Traffic intended for the service should be sent
+                      to these ingress points.
+                    items:
+                      description: 'LoadBalancerIngress represents the status of a
+                        load-balancer ingress point: traffic intended for the service
+                        should be sent to an ingress point.'
+                      properties:
+                        hostname:
+                          description: Hostname is set for load-balancer ingress points
+                            that are DNS based (typically AWS load-balancers)
+                          type: string
+                        ip:
+                          description: IP is set for load-balancer ingress points
+                            that are IP based (typically GCE or OpenStack load-balancers)
+                          type: string
+                        ports:
+                          description: Ports is a list of records of service ports
+                            If used, every port defined in the service should have
+                            an entry in it
+                          items:
+                            properties:
+                              error:
+                                description: 'Error is to record the problem with
+                                  the service port The format of the error shall comply
+                                  with the following rules: - built-in error values
+                                  shall be specified in this file and those shall
+                                  use   CamelCase names - cloud provider specific
+                                  error values must have names that comply with the   format
+                                  foo.example.com/CamelCase. --- The regex it matches
+                                  is (dns1123SubdomainFmt/)?(qualifiedNameFmt)'
+                                maxLength: 316
+                                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                                type: string
+                              port:
+                                description: Port is the port number of the service
+                                  port of which status is recorded here
+                                format: int32
+                                type: integer
+                              protocol:
+                                default: TCP
+                                description: 'Protocol is the protocol of the service
+                                  port of which status is recorded here The supported
+                                  values are: "TCP", "UDP", "SCTP"'
+                                type: string
+                            required:
+                            - port
+                            - protocol
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      type: object
                     type: array
-                  secretName:
-                    type: string
                 type: object
-              type: array
-          type: object
-        status:
-          type: object
-  version: v1beta1
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.6.2
+  creationTimestamp: null
+  name: udpingresses.configuration.konghq.com
+spec:
+  group: configuration.konghq.com
+  names:
+    kind: UDPIngress
+    listKind: UDPIngressList
+    plural: udpingresses
+    singular: udpingress
+  preserveUnknownFields: false
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Address of the load balancer
+      jsonPath: .status.loadBalancer.ingress[*].ip
+      name: Address
+      type: string
+    - description: Age
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: UDPIngress is the Schema for the udpingresses API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: UDPIngressSpec defines the desired state of UDPIngress
+            properties:
+              rules:
+                description: A list of rules used to configure the Ingress.
+                items:
+                  description: UDPIngressRule represents a rule to apply against incoming
+                    requests wherein no Host matching is available for request routing,
+                    only the port is used to match requests.
+                  properties:
+                    backend:
+                      description: Backend defines the Kubernetes service which accepts
+                        traffic from the listening Port defined above.
+                      properties:
+                        serviceName:
+                          description: Specifies the name of the referenced service.
+                          type: string
+                        servicePort:
+                          description: Specifies the port of the referenced service.
+                          format: int32
+                          maximum: 65535
+                          minimum: 1
+                          type: integer
+                      required:
+                      - serviceName
+                      - servicePort
+                      type: object
+                    port:
+                      description: Port indicates the port for the Kong proxy to accept
+                        incoming traffic on, which will then be routed to the service
+                        Backend.
+                      type: integer
+                  required:
+                  - backend
+                  - port
+                  type: object
+                type: array
+            type: object
+          status:
+            description: UDPIngressStatus defines the observed state of UDPIngress
+            properties:
+              loadBalancer:
+                description: LoadBalancer contains the current status of the load-balancer.
+                properties:
+                  ingress:
+                    description: Ingress is a list containing ingress points for the
+                      load-balancer. Traffic intended for the service should be sent
+                      to these ingress points.
+                    items:
+                      description: 'LoadBalancerIngress represents the status of a
+                        load-balancer ingress point: traffic intended for the service
+                        should be sent to an ingress point.'
+                      properties:
+                        hostname:
+                          description: Hostname is set for load-balancer ingress points
+                            that are DNS based (typically AWS load-balancers)
+                          type: string
+                        ip:
+                          description: IP is set for load-balancer ingress points
+                            that are IP based (typically GCE or OpenStack load-balancers)
+                          type: string
+                        ports:
+                          description: Ports is a list of records of service ports
+                            If used, every port defined in the service should have
+                            an entry in it
+                          items:
+                            properties:
+                              error:
+                                description: 'Error is to record the problem with
+                                  the service port The format of the error shall comply
+                                  with the following rules: - built-in error values
+                                  shall be specified in this file and those shall
+                                  use   CamelCase names - cloud provider specific
+                                  error values must have names that comply with the   format
+                                  foo.example.com/CamelCase. --- The regex it matches
+                                  is (dns1123SubdomainFmt/)?(qualifiedNameFmt)'
+                                maxLength: 316
+                                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                                type: string
+                              port:
+                                description: Port is the port number of the service
+                                  port of which status is recorded here
+                                format: int32
+                                type: integer
+                              protocol:
+                                default: TCP
+                                description: 'Protocol is the protocol of the service
+                                  port of which status is recorded here The supported
+                                  values are: "TCP", "UDP", "SCTP"'
+                                type: string
+                            required:
+                            - port
+                            - protocol
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      type: object
+                    type: array
+                type: object
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
 status:
   acceptedNames:
     kind: ""
@@ -475,16 +867,79 @@ metadata:
   namespace: {{ .Namespace }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: kong-leader-election
+  namespace: {{ .Namespace }}
+rules:
+- apiGroups:
+  - ""
+  - coordination.k8s.io
+  resources:
+  - configmaps
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+---
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: kong-ingress-clusterrole
+  creationTimestamp: null
+  name: kong-ingress
 rules:
 - apiGroups:
   - ""
   resources:
   - endpoints
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - endpoints/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - ""
+  resources:
   - nodes
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
   - pods
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
   - secrets
   verbs:
   - list
@@ -492,9 +947,11 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - nodes
+  - secrets/status
   verbs:
   - get
+  - patch
+  - update
 - apiGroups:
   - ""
   resources:
@@ -504,8 +961,126 @@ rules:
   - list
   - watch
 - apiGroups:
-  - networking.k8s.io
+  - ""
+  resources:
+  - services/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - configuration.konghq.com
+  resources:
+  - kongclusterplugins
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - configuration.konghq.com
+  resources:
+  - kongclusterplugins/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - configuration.konghq.com
+  resources:
+  - kongconsumers
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - configuration.konghq.com
+  resources:
+  - kongconsumers/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - configuration.konghq.com
+  resources:
+  - kongingresses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - configuration.konghq.com
+  resources:
+  - kongingresses/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - configuration.konghq.com
+  resources:
+  - kongplugins
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - configuration.konghq.com
+  resources:
+  - kongplugins/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - configuration.konghq.com
+  resources:
+  - tcpingresses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - configuration.konghq.com
+  resources:
+  - tcpingresses/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - configuration.konghq.com
+  resources:
+  - udpingresses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - configuration.konghq.com
+  resources:
+  - udpingresses/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
   - extensions
+  resources:
+  - ingresses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - extensions
+  resources:
+  - ingresses/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
   - networking.internal.knative.dev
   resources:
   - ingresses
@@ -514,56 +1089,80 @@ rules:
   - list
   - watch
 - apiGroups:
-  - ""
-  resources:
-  - events
-  verbs:
-  - create
-  - patch
-- apiGroups:
-  - networking.k8s.io
-  - extensions
   - networking.internal.knative.dev
   resources:
   - ingresses/status
   verbs:
+  - get
+  - patch
   - update
 - apiGroups:
-  - configuration.konghq.com
+  - networking.k8s.io
   resources:
-  - tcpingresses/status
-  verbs:
-  - update
-- apiGroups:
-  - configuration.konghq.com
-  resources:
-  - kongplugins
-  - kongclusterplugins
-  - kongcredentials
-  - kongconsumers
-  - kongingresses
-  - tcpingresses
+  - gatewayclasses
   verbs:
   - get
   - list
   - watch
 - apiGroups:
-  - ""
+  - networking.k8s.io
   resources:
-  - configmaps
+  - gatewayclasses/status
   verbs:
-  - create
   - get
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - gateways
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - gateways/status
+  verbs:
+  - get
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingresses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingresses/status
+  verbs:
+  - get
+  - patch
   - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: kong-leader-election
+  namespace: {{ .Namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: kong-leader-election
+subjects:
+- kind: ServiceAccount
+  name: kong-serviceaccount
+  namespace: {{ .Namespace }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: kong-ingress-clusterrole-nisa-binding
+  name: kong-ingress
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: kong-ingress-clusterrole
+  name: kong-ingress
 subjects:
 - kind: ServiceAccount
   name: kong-serviceaccount
@@ -591,6 +1190,20 @@ spec:
     app: ingress-kong
   type: LoadBalancer
 ---
+apiVersion: v1
+kind: Service
+metadata:
+  name: kong-validation-webhook
+  namespace: {{ .Namespace }}
+spec:
+  ports:
+  - name: webhook
+    port: 443
+    protocol: TCP
+    targetPort: 8080
+  selector:
+    app: ingress-kong
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -607,8 +1220,6 @@ spec:
     metadata:
       annotations:
         kuma.io/gateway: enabled
-        prometheus.io/port: "8100"
-        prometheus.io/scrape: "true"
         traffic.sidecar.istio.io/includeInboundPorts: ""
       labels:
         app: ingress-kong
@@ -633,7 +1244,7 @@ spec:
           value: /dev/stderr
         - name: KONG_PROXY_ERROR_LOG
           value: /dev/stderr
-        image: kong:2.4
+        image: kong:2.5
         lifecycle:
           preStop:
             exec:
@@ -689,7 +1300,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.namespace
-        image: kong/kubernetes-ingress-controller:1.3
+        image: kong/kubernetes-ingress-controller:2.0.5
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3
@@ -706,10 +1317,13 @@ spec:
         - containerPort: 8080
           name: webhook
           protocol: TCP
+        - containerPort: 10255
+          name: cmetrics
+          protocol: TCP
         readinessProbe:
           failureThreshold: 3
           httpGet:
-            path: /healthz
+            path: /readyz
             port: 10254
             scheme: HTTP
           initialDelaySeconds: 5


### PR DESCRIPTION
### Summary

Bump KIC versions to 2.0

Resources adapted from https://bit.ly/k4k8s and https://bit.ly/k4k8s-enterprise-install
* Added `{{ .Namespace }}` template
* Added sidecar injection annotation to namespace
* Added license secret creation from `--license-path` as before

### Testing

- [x] Manual testing on Kubernetes 
  - Ran through https://docs.konghq.com/kubernetes-ingress-controller/2.0.x/guides/getting-started/

### Backwards compatibility

- [x] Add `backport-to-stable` label if the code is backwards compatible. Otherwise, list breaking changes.
  - It's breaking if users are expecting consistent behavior across patch versions and isn't urgent enough to backport.
