### PR TITLE
chore(kuma-dp) send reports to tls endpoint

### DIFF
--- a/pkg/core/runtime/reports/reports.go
+++ b/pkg/core/runtime/reports/reports.go
@@ -2,6 +2,7 @@ package reports
 
 import (
 	"context"
+	"crypto/tls"
 	"fmt"
 	"net"
 	"os"
@@ -24,7 +25,7 @@ import (
 const (
 	pingInterval = 3600
 	pingHost     = "kong-hf.konghq.com"
-	pingPort     = 61831
+	pingPort     = 61832
 )
 
 var (
@@ -158,8 +159,9 @@ func (b *reportsBuffer) dispatch(rt core_runtime.Runtime, host string, port int,
 		return err
 	}
 
-	conn, err := net.Dial("tcp", net.JoinHostPort(host,
-		strconv.FormatUint(uint64(port), 10)))
+	conf := &tls.Config{}
+	conn, err := tls.Dial("tcp", net.JoinHostPort(host,
+		strconv.FormatUint(uint64(port), 10)), conf)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
### Summary

Instead of sending data as a raw bytes to tcp endpoint, now they
will be sent to TLS protected endpoint

### Full changelog

no changelog

### Issues resolved

no issues resolved

### Documentation

no documentation changes

### Testing

- [ ] Unit tests
- [ ] E2E tests
- [x] Manual testing on Universal
- [ ] Manual testing on Kubernetes 

### Backwards compatibility

- [x] Add `backport-to-stable` label if the code is backwards compatible. Otherwise, list breaking changes.
