### PR TITLE
test(*) disable KIC E2E tests on Kind

### DIFF
--- a/test/e2e/kic/kubernetes/kong_ingress.go
+++ b/test/e2e/kic/kubernetes/kong_ingress.go
@@ -88,7 +88,13 @@ func KICKubernetes() {
 	// IPv6 curently not supported by Kong Ingress Controller
 	// https://github.com/Kong/kubernetes-ingress-controller/issues/1017
 	if IsIPv6() {
-		fmt.Println("Test not supported on API v2 or IPv6")
+		fmt.Println("Test not supported on IPv6")
+		return
+	}
+	if !IsK3D() {
+		// KIC 2.0 when started with service type LoadBalancer requires external IP to be provisioned before it's healthy.
+		// KIND cannot provision external IP, K3D can.
+		fmt.Println("Test not supported on KIND")
 		return
 	}
 

--- a/test/framework/env.go
+++ b/test/framework/env.go
@@ -115,6 +115,10 @@ func IsIPv6() bool {
 	return envBool(envIPv6)
 }
 
+func IsK3D() bool {
+	return envBool("K3D")
+}
+
 // GetKumactlBin returns the path to the kumactl program.
 func GetKumactlBin() string {
 	if path := os.Getenv("KUMACTLBIN"); path != "" {


### PR DESCRIPTION
### Summary

Disable KIC tests on Kind.
### Issues resolved

No issues.

### Documentation

- No docs.

### Testing

- [ ] Unit tests
- [X] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes

### Backwards compatibility

- [X] Update [`UPGRADE.md`](UPGRADE.md) with any steps users will need to take
      when upgrading.
- [X] Add `backport-to-stable` label if the code is backwards compatible. Otherwise, list breaking changes.
