### PR TITLE
feat(kuma-cp): support Retry policy for Gateways

### DIFF
--- a/pkg/plugins/runtime/gateway/generator.go
+++ b/pkg/plugins/runtime/gateway/generator.go
@@ -341,11 +341,21 @@ func RedistributeWildcardRoutes(
 		}
 
 		for _, n := range names {
+			host, ok := hostsByName[n]
+
+			// When generating a new implicit virtualhost,
+			// initialize it by shallow copying from the
+			// wildcard source.
+			if !ok {
+				host = wild
+				host.Routes = nil
+			}
+
 			// Note that if we already have a virtualhost for this
 			// name, and add the route to it, it might be a duplicate.
-			host := hostsByName[n]
-			host.Hostname = n
 			host.Routes = append(host.Routes, r)
+			host.Hostname = n
+
 			hostsByName[n] = host
 		}
 	}

--- a/pkg/plugins/runtime/gateway/match/policy.go
+++ b/pkg/plugins/runtime/gateway/match/policy.go
@@ -1,6 +1,8 @@
 package match
 
 import (
+	"sort"
+
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	"github.com/kumahq/kuma/pkg/core/policy"
 	"github.com/kumahq/kuma/pkg/core/resources/model"
@@ -40,4 +42,21 @@ func ConnectionPoliciesBySource(
 	}
 
 	return matches
+}
+
+// OldestPolicy returns the resource that has the earliest creation time.
+func OldestPolicy(policies []model.Resource) model.Resource {
+	if len(policies) == 0 {
+		return nil
+	}
+
+	// Copy to avoid reordering the input argument.
+	sorted := make([]model.Resource, len(policies))
+	copy(sorted, policies)
+
+	sort.Slice(sorted, func(i, j int) bool {
+		return sorted[i].GetMeta().GetCreationTime().Before(sorted[j].GetMeta().GetCreationTime())
+	})
+
+	return sorted[0]
 }

--- a/pkg/plugins/runtime/gateway/route/util.go
+++ b/pkg/plugins/runtime/gateway/route/util.go
@@ -1,0 +1,28 @@
+package route
+
+import (
+	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
+	core_xds "github.com/kumahq/kuma/pkg/core/xds"
+	"github.com/kumahq/kuma/pkg/xds/generator"
+)
+
+func InferServiceProtocol(endpoints []core_xds.Endpoint) core_mesh.Protocol {
+	protocol := generator.InferServiceProtocol(endpoints)
+
+	// HTTP is a better default than "unknown".
+	if protocol == core_mesh.ProtocolUnknown {
+		return core_mesh.ProtocolHTTP
+	}
+
+	return protocol
+}
+
+func InferForwardingProtocol(destinations []Destination) core_mesh.Protocol {
+	var endpoints []core_xds.Endpoint
+
+	for _, d := range destinations {
+		endpoints = append(endpoints, core_xds.Endpoint{Tags: d.Destination})
+	}
+
+	return InferServiceProtocol(endpoints)
+}

--- a/pkg/plugins/runtime/gateway/route_table_generator.go
+++ b/pkg/plugins/runtime/gateway/route_table_generator.go
@@ -4,7 +4,10 @@ import (
 	"sort"
 
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
+	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
+	"github.com/kumahq/kuma/pkg/core/resources/model"
 	core_xds "github.com/kumahq/kuma/pkg/core/xds"
+	"github.com/kumahq/kuma/pkg/plugins/runtime/gateway/match"
 	"github.com/kumahq/kuma/pkg/plugins/runtime/gateway/route"
 	xds_context "github.com/kumahq/kuma/pkg/xds/context"
 	envoy_names "github.com/kumahq/kuma/pkg/xds/envoy/names"
@@ -41,7 +44,6 @@ func (r *RouteTableGenerator) GenerateHost(ctx xds_context.Context, info *Gatewa
 		)
 	}
 
-	// TODO(jpeach) match the Retry policy for this virtual host.
 	// TODO(jpeach) match the FaultInjection policy for this virtual host.
 
 	// TODO(jpeach) apply additional virtual host configuration.
@@ -60,6 +62,14 @@ func (r *RouteTableGenerator) GenerateHost(ctx xds_context.Context, info *Gatewa
 
 			route.RouteActionRedirect(e.Action.Redirect),
 			route.RouteActionForward(e.Action.Forward),
+		)
+
+		// Generate a retry policy for this route, if there is one.
+		routeBuilder.Configure(
+			retryRouteConfigurers(
+				route.InferForwardingProtocol(e.Action.Forward),
+				retryPolicyFor(e.Action.Forward),
+			)...,
 		)
 
 		for _, m := range e.Match.ExactHeader {
@@ -109,4 +119,109 @@ func (r *RouteTableGenerator) GenerateHost(ctx xds_context.Context, info *Gatewa
 	info.Resources.RouteConfiguration.Configure(envoy_routes.VirtualHost(vh))
 
 	return resources.Get(), nil
+}
+
+// retryRouteConfigurers returns the set of route configurers needed to implement the retry policy (if there is one).
+func retryRouteConfigurers(protocol core_mesh.Protocol, retry *core_mesh.RetryResource) []route.RouteConfigurer {
+	if retry == nil {
+		return nil
+	}
+
+	methodStrings := func(methods []mesh_proto.HttpMethod) []string {
+		var names []string
+		for _, m := range methods {
+			if m != mesh_proto.HttpMethod_NONE {
+				names = append(names, m.String())
+			}
+		}
+		return names
+	}
+
+	grpcConditionStrings := func(conditions []mesh_proto.Retry_Conf_Grpc_RetryOn) []string {
+		var names []string
+		for _, c := range conditions {
+			names = append(names, c.String())
+		}
+		return names
+	}
+
+	configurers := []route.RouteConfigurer{
+		route.RouteActionRetryDefault(protocol),
+	}
+
+	switch protocol {
+	case core_mesh.ProtocolHTTP, core_mesh.ProtocolHTTP2:
+		conf := retry.Spec.GetConf().GetHttp()
+		configurers = append(configurers,
+			route.RouteActionRetryOnStatus(conf.GetRetriableStatusCodes()...),
+			route.RouteActionRetryMethods(methodStrings(conf.GetRetriableMethods())...),
+			route.RouteActionRetryTimeout(conf.GetPerTryTimeout().AsDuration()),
+			route.RouteActionRetryCount(conf.GetNumRetries().GetValue()),
+			route.RouteActionRetryBackoff(
+				conf.GetBackOff().GetBaseInterval().AsDuration(),
+				conf.GetBackOff().GetMaxInterval().AsDuration()),
+		)
+	case core_mesh.ProtocolGRPC:
+		conf := retry.Spec.GetConf().GetGrpc()
+		configurers = append(configurers,
+			route.RouteActionRetryOnConditions(grpcConditionStrings(conf.GetRetryOn())...),
+			route.RouteActionRetryTimeout(conf.GetPerTryTimeout().AsDuration()),
+			route.RouteActionRetryCount(conf.GetNumRetries().GetValue()),
+			route.RouteActionRetryBackoff(
+				conf.GetBackOff().GetBaseInterval().AsDuration(),
+				conf.GetBackOff().GetMaxInterval().AsDuration()),
+		)
+	}
+
+	return configurers
+}
+
+// retryPolicyFor returns the retry policy for the given forwarding
+// action. This is conceptually a bit subtle because a forwarding target
+// can have multiple destinations, each of which is a distinct service.
+// However, there are some relatively obvious rules that we can use to
+// determine policy.
+//
+// 1. If all the destinations are the same service, use that policy.
+// 2. If there are multiple destinations, prefer a wildcard policy.
+// 3. Everything else being equal, older policies are preferred.
+func retryPolicyFor(destinations []route.Destination) *core_mesh.RetryResource {
+	seenNames := map[string]bool{}
+	servicePolicies := map[string][]model.Resource{}
+
+	// Index all the retry policies by service name.
+	for _, d := range destinations {
+		p, ok := d.Policies[core_mesh.RetryType]
+		if !ok {
+			continue
+		}
+
+		if seenNames[p.GetMeta().GetName()] {
+			continue
+		}
+
+		svc := d.Destination[mesh_proto.ServiceTag]
+		servicePolicies[svc] = append(servicePolicies[svc], p)
+		seenNames[p.GetMeta().GetName()] = true
+	}
+
+	var candidates []model.Resource
+
+	// If we are forwarding to multiple services, no one service
+	// would be the most specific match, so we should choose the
+	// wildcard policy. Otherwise, we can just take the oldest of
+	// all the matches, since there's no better way to discriminate.
+	candidates = append(candidates, servicePolicies[mesh_proto.MatchAllTag]...)
+	if len(candidates) == 0 {
+		for _, p := range servicePolicies {
+			candidates = append(candidates, p...)
+		}
+	}
+
+	oldest := match.OldestPolicy(candidates)
+	if retry, ok := oldest.(*core_mesh.RetryResource); ok {
+		return retry
+	}
+
+	return nil // TODO(jpeach) default retry policy
 }

--- a/pkg/plugins/runtime/gateway/testdata/http/01-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/01-gateway-route.yaml
@@ -1,24 +1,36 @@
 Clusters:
   Resources:
-    echo-service-07fd732a85aa6a99:
-      connectTimeout: 10s
+    echo-service-5a416c39037aa8f6:
+      circuitBreakers:
+        thresholds:
+        - maxConnections: 1024
+          maxPendingRequests: 1024
+          maxRequests: 1024
+          maxRetries: 3
+      connectTimeout: 5s
       edsClusterConfig:
         edsConfig:
           ads: {}
           resourceApiVersion: V3
-      name: echo-service-07fd732a85aa6a99
+      name: echo-service-5a416c39037aa8f6
+      outlierDetection:
+        enforcingConsecutive5xx: 0
+        enforcingConsecutiveGatewayFailure: 0
+        enforcingConsecutiveLocalOriginFailure: 0
+        enforcingFailurePercentage: 0
+        enforcingSuccessRate: 0
       type: EDS
       typedExtensionProtocolOptions:
         envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
           '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
           commonHttpProtocolOptions:
-            idleTimeout: 0s
+            idleTimeout: 3600s
           explicitHttpConfig:
             httpProtocolOptions: {}
 Endpoints:
   Resources:
-    echo-service-07fd732a85aa6a99:
-      clusterName: echo-service-07fd732a85aa6a99
+    echo-service-5a416c39037aa8f6:
+      clusterName: echo-service-5a416c39037aa8f6
       endpoints:
       - lbEndpoints:
         - endpoint:
@@ -99,9 +111,16 @@ Routes:
         - match:
             path: /
           route:
+            retryPolicy:
+              numRetries: 5
+              perTryTimeout: 16s
+              retryBackOff:
+                baseInterval: 0.025s
+                maxInterval: 0.250s
+              retryOn: gateway-error,connect-failure,refused-stream
             weightedClusters:
               clusters:
-              - name: echo-service-07fd732a85aa6a99
+              - name: echo-service-5a416c39037aa8f6
                 weight: 1
               totalWeight: 1
       - domains:
@@ -111,9 +130,16 @@ Routes:
         - match:
             path: /
           route:
+            retryPolicy:
+              numRetries: 5
+              perTryTimeout: 16s
+              retryBackOff:
+                baseInterval: 0.025s
+                maxInterval: 0.250s
+              retryOn: gateway-error,connect-failure,refused-stream
             weightedClusters:
               clusters:
-              - name: echo-service-07fd732a85aa6a99
+              - name: echo-service-5a416c39037aa8f6
                 weight: 1
               totalWeight: 1
       - domains:
@@ -123,9 +149,16 @@ Routes:
         - match:
             path: /
           route:
+            retryPolicy:
+              numRetries: 5
+              perTryTimeout: 16s
+              retryBackOff:
+                baseInterval: 0.025s
+                maxInterval: 0.250s
+              retryOn: gateway-error,connect-failure,refused-stream
             weightedClusters:
               clusters:
-              - name: echo-service-07fd732a85aa6a99
+              - name: echo-service-5a416c39037aa8f6
                 weight: 1
               totalWeight: 1
       - domains:

--- a/pkg/plugins/runtime/gateway/testdata/http/02-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/02-gateway-route.yaml
@@ -27,41 +27,10 @@ Clusters:
             idleTimeout: 3600s
           explicitHttpConfig:
             httpProtocolOptions: {}
-    echo-service-07fd732a85aa6a99:
-      connectTimeout: 10s
-      edsClusterConfig:
-        edsConfig:
-          ads: {}
-          resourceApiVersion: V3
-      name: echo-service-07fd732a85aa6a99
-      type: EDS
-      typedExtensionProtocolOptions:
-        envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
-          '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
-          commonHttpProtocolOptions:
-            idleTimeout: 0s
-          explicitHttpConfig:
-            httpProtocolOptions: {}
 Endpoints:
   Resources:
     echo-service-5a416c39037aa8f6:
       clusterName: echo-service-5a416c39037aa8f6
-      endpoints:
-      - lbEndpoints:
-        - endpoint:
-            address:
-              socketAddress:
-                address: 192.168.1.6
-                portValue: 20006
-          loadBalancingWeight: 1
-          metadata:
-            filterMetadata:
-              envoy.lb:
-                kuma.io/protocol: http
-              envoy.transport_socket_match:
-                kuma.io/protocol: http
-    echo-service-07fd732a85aa6a99:
-      clusterName: echo-service-07fd732a85aa6a99
       endpoints:
       - lbEndpoints:
         - endpoint:
@@ -142,9 +111,16 @@ Routes:
         - match:
             path: /
           route:
+            retryPolicy:
+              numRetries: 5
+              perTryTimeout: 16s
+              retryBackOff:
+                baseInterval: 0.025s
+                maxInterval: 0.250s
+              retryOn: gateway-error,connect-failure,refused-stream
             weightedClusters:
               clusters:
-              - name: echo-service-07fd732a85aa6a99
+              - name: echo-service-5a416c39037aa8f6
                 weight: 1
               totalWeight: 1
       - domains:
@@ -154,6 +130,13 @@ Routes:
         - match:
             path: /
           route:
+            retryPolicy:
+              numRetries: 5
+              perTryTimeout: 16s
+              retryBackOff:
+                baseInterval: 0.025s
+                maxInterval: 0.250s
+              retryOn: gateway-error,connect-failure,refused-stream
             weightedClusters:
               clusters:
               - name: echo-service-5a416c39037aa8f6

--- a/pkg/plugins/runtime/gateway/testdata/http/03-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/03-gateway-route.yaml
@@ -111,6 +111,13 @@ Routes:
         - match:
             path: /service/echo
           route:
+            retryPolicy:
+              numRetries: 5
+              perTryTimeout: 16s
+              retryBackOff:
+                baseInterval: 0.025s
+                maxInterval: 0.250s
+              retryOn: gateway-error,connect-failure,refused-stream
             weightedClusters:
               clusters:
               - name: echo-service-5a416c39037aa8f6

--- a/pkg/plugins/runtime/gateway/testdata/http/04-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/04-gateway-route.yaml
@@ -146,6 +146,13 @@ Routes:
                 defaultValue:
                   denominator: TEN_THOUSAND
                   numerator: 10
+            retryPolicy:
+              numRetries: 5
+              perTryTimeout: 16s
+              retryBackOff:
+                baseInterval: 0.025s
+                maxInterval: 0.250s
+              retryOn: gateway-error,connect-failure,refused-stream
             weightedClusters:
               clusters:
               - name: echo-service-5a416c39037aa8f6

--- a/pkg/plugins/runtime/gateway/testdata/http/06-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/06-gateway-route.yaml
@@ -165,6 +165,13 @@ Routes:
                 defaultValue:
                   denominator: TEN_THOUSAND
                   numerator: 10
+            retryPolicy:
+              numRetries: 5
+              perTryTimeout: 16s
+              retryBackOff:
+                baseInterval: 0.025s
+                maxInterval: 0.250s
+              retryOn: gateway-error,connect-failure,refused-stream
             weightedClusters:
               clusters:
               - name: echo-service-5a416c39037aa8f6

--- a/pkg/plugins/runtime/gateway/testdata/http/07-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/07-gateway-route.yaml
@@ -111,6 +111,13 @@ Routes:
         - match:
             path: /api
           route:
+            retryPolicy:
+              numRetries: 5
+              perTryTimeout: 16s
+              retryBackOff:
+                baseInterval: 0.025s
+                maxInterval: 0.250s
+              retryOn: gateway-error,connect-failure,refused-stream
             weightedClusters:
               clusters:
               - name: echo-service-5a416c39037aa8f6
@@ -119,6 +126,13 @@ Routes:
         - match:
             prefix: /api/
           route:
+            retryPolicy:
+              numRetries: 5
+              perTryTimeout: 16s
+              retryBackOff:
+                baseInterval: 0.025s
+                maxInterval: 0.250s
+              retryOn: gateway-error,connect-failure,refused-stream
             weightedClusters:
               clusters:
               - name: echo-service-5a416c39037aa8f6

--- a/pkg/plugins/runtime/gateway/testdata/http/08-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/08-gateway-route.yaml
@@ -154,6 +154,13 @@ Routes:
         - match:
             path: /api
           route:
+            retryPolicy:
+              numRetries: 5
+              perTryTimeout: 16s
+              retryBackOff:
+                baseInterval: 0.025s
+                maxInterval: 0.250s
+              retryOn: gateway-error,connect-failure,refused-stream
             weightedClusters:
               clusters:
               - name: exact-service-09493d2d54b2a972
@@ -162,6 +169,13 @@ Routes:
         - match:
             prefix: /api/
           route:
+            retryPolicy:
+              numRetries: 5
+              perTryTimeout: 16s
+              retryBackOff:
+                baseInterval: 0.025s
+                maxInterval: 0.250s
+              retryOn: gateway-error,connect-failure,refused-stream
             weightedClusters:
               clusters:
               - name: prefix-service-5061ee504b81a555

--- a/pkg/plugins/runtime/gateway/testdata/http/09-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/09-gateway-route.yaml
@@ -113,6 +113,13 @@ Routes:
               googleRe2: {}
               regex: ^/api/v[0-9]+$
           route:
+            retryPolicy:
+              numRetries: 5
+              perTryTimeout: 16s
+              retryBackOff:
+                baseInterval: 0.025s
+                maxInterval: 0.250s
+              retryOn: gateway-error,connect-failure,refused-stream
             weightedClusters:
               clusters:
               - name: echo-service-5a416c39037aa8f6

--- a/pkg/plugins/runtime/gateway/testdata/http/10-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/10-gateway-route.yaml
@@ -163,6 +163,13 @@ Routes:
                 regex: .*sh
             prefix: /
           route:
+            retryPolicy:
+              numRetries: 5
+              perTryTimeout: 16s
+              retryBackOff:
+                baseInterval: 0.025s
+                maxInterval: 0.250s
+              retryOn: gateway-error,connect-failure,refused-stream
             weightedClusters:
               clusters:
               - name: regex-header-match-ad0dd92f37b8a38d
@@ -174,6 +181,13 @@ Routes:
               name: Content-Type
             prefix: /
           route:
+            retryPolicy:
+              numRetries: 5
+              perTryTimeout: 16s
+              retryBackOff:
+                baseInterval: 0.025s
+                maxInterval: 0.250s
+              retryOn: gateway-error,connect-failure,refused-stream
             weightedClusters:
               clusters:
               - name: exact-header-match-f6b57a6b55557c81
@@ -185,6 +199,13 @@ Routes:
               name: Language
             prefix: /
           route:
+            retryPolicy:
+              numRetries: 5
+              perTryTimeout: 16s
+              retryBackOff:
+                baseInterval: 0.025s
+                maxInterval: 0.250s
+              retryOn: gateway-error,connect-failure,refused-stream
             weightedClusters:
               clusters:
               - name: exact-header-match-f6b57a6b55557c81

--- a/pkg/plugins/runtime/gateway/testdata/http/11-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/11-gateway-route.yaml
@@ -165,6 +165,13 @@ Routes:
                   googleRe2: {}
                   regex: .*sh
           route:
+            retryPolicy:
+              numRetries: 5
+              perTryTimeout: 16s
+              retryBackOff:
+                baseInterval: 0.025s
+                maxInterval: 0.250s
+              retryOn: gateway-error,connect-failure,refused-stream
             weightedClusters:
               clusters:
               - name: regex-query-match-3804d7b8516d7323
@@ -177,6 +184,13 @@ Routes:
               stringMatch:
                 exact: application/json
           route:
+            retryPolicy:
+              numRetries: 5
+              perTryTimeout: 16s
+              retryBackOff:
+                baseInterval: 0.025s
+                maxInterval: 0.250s
+              retryOn: gateway-error,connect-failure,refused-stream
             weightedClusters:
               clusters:
               - name: exact-query-match-cc1370f58a3b5330
@@ -189,6 +203,13 @@ Routes:
               stringMatch:
                 exact: gibberish
           route:
+            retryPolicy:
+              numRetries: 5
+              perTryTimeout: 16s
+              retryBackOff:
+                baseInterval: 0.025s
+                maxInterval: 0.250s
+              retryOn: gateway-error,connect-failure,refused-stream
             weightedClusters:
               clusters:
               - name: exact-query-match-cc1370f58a3b5330

--- a/pkg/plugins/runtime/gateway/testdata/http/12-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/12-gateway-route.yaml
@@ -116,6 +116,13 @@ Routes:
               name: Language
             path: /lang/json
           route:
+            retryPolicy:
+              numRetries: 5
+              perTryTimeout: 16s
+              retryBackOff:
+                baseInterval: 0.025s
+                maxInterval: 0.250s
+              retryOn: gateway-error,connect-failure,refused-stream
             weightedClusters:
               clusters:
               - name: echo-service-5a416c39037aa8f6
@@ -129,6 +136,13 @@ Routes:
               name: Content-Type
             path: /app/json
           route:
+            retryPolicy:
+              numRetries: 5
+              perTryTimeout: 16s
+              retryBackOff:
+                baseInterval: 0.025s
+                maxInterval: 0.250s
+              retryOn: gateway-error,connect-failure,refused-stream
             weightedClusters:
               clusters:
               - name: echo-service-5a416c39037aa8f6
@@ -142,6 +156,13 @@ Routes:
               name: Language
             prefix: /lang/json/
           route:
+            retryPolicy:
+              numRetries: 5
+              perTryTimeout: 16s
+              retryBackOff:
+                baseInterval: 0.025s
+                maxInterval: 0.250s
+              retryOn: gateway-error,connect-failure,refused-stream
             weightedClusters:
               clusters:
               - name: echo-service-5a416c39037aa8f6

--- a/pkg/plugins/runtime/gateway/testdata/http/13-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/13-gateway-route.yaml
@@ -197,6 +197,13 @@ Routes:
         - match:
             path: /match/bar
           route:
+            retryPolicy:
+              numRetries: 5
+              perTryTimeout: 16s
+              retryBackOff:
+                baseInterval: 0.025s
+                maxInterval: 0.250s
+              retryOn: gateway-error,connect-failure,refused-stream
             weightedClusters:
               clusters:
               - name: echo-exact-ad4e3a31db1bf217
@@ -205,6 +212,13 @@ Routes:
         - match:
             path: /match/baz
           route:
+            retryPolicy:
+              numRetries: 5
+              perTryTimeout: 16s
+              retryBackOff:
+                baseInterval: 0.025s
+                maxInterval: 0.250s
+              retryOn: gateway-error,connect-failure,refused-stream
             weightedClusters:
               clusters:
               - name: echo-prefix-d0e5ba63b0c9b9f0
@@ -213,6 +227,13 @@ Routes:
         - match:
             prefix: /match/baz/
           route:
+            retryPolicy:
+              numRetries: 5
+              perTryTimeout: 16s
+              retryBackOff:
+                baseInterval: 0.025s
+                maxInterval: 0.250s
+              retryOn: gateway-error,connect-failure,refused-stream
             weightedClusters:
               clusters:
               - name: echo-prefix-d0e5ba63b0c9b9f0
@@ -223,6 +244,13 @@ Routes:
               googleRe2: {}
               regex: /match/foo
           route:
+            retryPolicy:
+              numRetries: 5
+              perTryTimeout: 16s
+              retryBackOff:
+                baseInterval: 0.025s
+                maxInterval: 0.250s
+              retryOn: gateway-error,connect-failure,refused-stream
             weightedClusters:
               clusters:
               - name: echo-regex-627905e7b1c2eb33

--- a/pkg/plugins/runtime/gateway/testdata/http/14-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/14-gateway-route.yaml
@@ -115,6 +115,13 @@ Routes:
             path: /app/json
           route:
             hostRewriteLiteral: newhost.example.com
+            retryPolicy:
+              numRetries: 5
+              perTryTimeout: 16s
+              retryBackOff:
+                baseInterval: 0.025s
+                maxInterval: 0.250s
+              retryOn: gateway-error,connect-failure,refused-stream
             weightedClusters:
               clusters:
               - name: echo-service-5a416c39037aa8f6

--- a/pkg/plugins/runtime/gateway/testdata/http/15-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/15-gateway-route.yaml
@@ -197,6 +197,13 @@ Routes:
         - match:
             path: /api
           route:
+            retryPolicy:
+              numRetries: 5
+              perTryTimeout: 16s
+              retryBackOff:
+                baseInterval: 0.025s
+                maxInterval: 0.250s
+              retryOn: gateway-error,connect-failure,refused-stream
             weightedClusters:
               clusters:
               - name: api-service-6b688a06cd66f5c9
@@ -205,6 +212,13 @@ Routes:
         - match:
             prefix: /api/
           route:
+            retryPolicy:
+              numRetries: 5
+              perTryTimeout: 16s
+              retryBackOff:
+                baseInterval: 0.025s
+                maxInterval: 0.250s
+              retryOn: gateway-error,connect-failure,refused-stream
             weightedClusters:
               clusters:
               - name: api-service-6b688a06cd66f5c9
@@ -218,6 +232,13 @@ Routes:
               runtimeFraction:
                 defaultValue:
                   numerator: 1
+            retryPolicy:
+              numRetries: 5
+              perTryTimeout: 16s
+              retryBackOff:
+                baseInterval: 0.025s
+                maxInterval: 0.250s
+              retryOn: gateway-error,connect-failure,refused-stream
             weightedClusters:
               clusters:
               - name: echo-service-b5c2b60cba392c4e

--- a/pkg/plugins/runtime/gateway/testdata/http/16-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/16-gateway-route.yaml
@@ -194,6 +194,13 @@ Routes:
         - match:
             path: /api
           route:
+            retryPolicy:
+              numRetries: 5
+              perTryTimeout: 16s
+              retryBackOff:
+                baseInterval: 0.025s
+                maxInterval: 0.250s
+              retryOn: gateway-error,connect-failure,refused-stream
             weightedClusters:
               clusters:
               - name: api-service-49c6d22609eca2d2
@@ -202,6 +209,13 @@ Routes:
         - match:
             prefix: /api/
           route:
+            retryPolicy:
+              numRetries: 5
+              perTryTimeout: 16s
+              retryBackOff:
+                baseInterval: 0.025s
+                maxInterval: 0.250s
+              retryOn: gateway-error,connect-failure,refused-stream
             weightedClusters:
               clusters:
               - name: api-service-49c6d22609eca2d2
@@ -215,6 +229,13 @@ Routes:
               runtimeFraction:
                 defaultValue:
                   numerator: 1
+            retryPolicy:
+              numRetries: 5
+              perTryTimeout: 16s
+              retryBackOff:
+                baseInterval: 0.025s
+                maxInterval: 0.250s
+              retryOn: gateway-error,connect-failure,refused-stream
             weightedClusters:
               clusters:
               - name: echo-service-48cd7f2dbb98df84

--- a/pkg/plugins/runtime/gateway/testdata/http/17-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/17-gateway-route.yaml
@@ -215,6 +215,13 @@ Routes:
         - match:
             path: /api
           route:
+            retryPolicy:
+              numRetries: 5
+              perTryTimeout: 16s
+              retryBackOff:
+                baseInterval: 0.025s
+                maxInterval: 0.250s
+              retryOn: gateway-error,connect-failure,refused-stream
             weightedClusters:
               clusters:
               - name: api-service-19fcb7995aa98119
@@ -223,6 +230,13 @@ Routes:
         - match:
             prefix: /api/
           route:
+            retryPolicy:
+              numRetries: 5
+              perTryTimeout: 16s
+              retryBackOff:
+                baseInterval: 0.025s
+                maxInterval: 0.250s
+              retryOn: gateway-error,connect-failure,refused-stream
             weightedClusters:
               clusters:
               - name: api-service-19fcb7995aa98119
@@ -236,6 +250,13 @@ Routes:
               runtimeFraction:
                 defaultValue:
                   numerator: 1
+            retryPolicy:
+              numRetries: 5
+              perTryTimeout: 16s
+              retryBackOff:
+                baseInterval: 0.025s
+                maxInterval: 0.250s
+              retryOn: gateway-error,connect-failure,refused-stream
             weightedClusters:
               clusters:
               - name: echo-service-eb4ea372d99abf73

--- a/pkg/plugins/runtime/gateway/testdata/http/18-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/18-gateway-route.yaml
@@ -108,6 +108,13 @@ Routes:
         - match:
             prefix: /
           route:
+            retryPolicy:
+              numRetries: 5
+              perTryTimeout: 16s
+              retryBackOff:
+                baseInterval: 0.025s
+                maxInterval: 0.250s
+              retryOn: gateway-error,connect-failure,refused-stream
             weightedClusters:
               clusters:
               - name: external-httpbin-2528f53d03636b9d

--- a/pkg/plugins/runtime/gateway/testdata/http/19-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/19-gateway-route.yaml
@@ -120,6 +120,13 @@ Routes:
         - match:
             prefix: /
           route:
+            retryPolicy:
+              numRetries: 5
+              perTryTimeout: 16s
+              retryBackOff:
+                baseInterval: 0.025s
+                maxInterval: 0.250s
+              retryOn: gateway-error,connect-failure,refused-stream
             weightedClusters:
               clusters:
               - name: external-httpbin-374dddb882a5e651

--- a/pkg/plugins/runtime/gateway/testdata/http/20-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/20-gateway-route.yaml
@@ -197,6 +197,13 @@ Routes:
         - match:
             prefix: /
           route:
+            retryPolicy:
+              numRetries: 5
+              perTryTimeout: 16s
+              retryBackOff:
+                baseInterval: 0.025s
+                maxInterval: 0.250s
+              retryOn: gateway-error,connect-failure,refused-stream
             weightedClusters:
               clusters:
               - name: echo-service-dbfe9218dfa3ba0c
@@ -209,6 +216,13 @@ Routes:
         - match:
             prefix: /
           route:
+            retryPolicy:
+              numRetries: 5
+              perTryTimeout: 16s
+              retryBackOff:
+                baseInterval: 0.025s
+                maxInterval: 0.250s
+              retryOn: gateway-error,connect-failure,refused-stream
             weightedClusters:
               clusters:
               - name: echo-service-cff7b41a9764f367
@@ -221,6 +235,13 @@ Routes:
         - match:
             prefix: /
           route:
+            retryPolicy:
+              numRetries: 5
+              perTryTimeout: 16s
+              retryBackOff:
+                baseInterval: 0.025s
+                maxInterval: 0.250s
+              retryOn: gateway-error,connect-failure,refused-stream
             weightedClusters:
               clusters:
               - name: echo-service-b5c2b60cba392c4e

--- a/pkg/plugins/runtime/gateway/testdata/https/01-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/01-gateway-route.yaml
@@ -1,24 +1,36 @@
 Clusters:
   Resources:
-    echo-service-07fd732a85aa6a99:
-      connectTimeout: 10s
+    echo-service-5a416c39037aa8f6:
+      circuitBreakers:
+        thresholds:
+        - maxConnections: 1024
+          maxPendingRequests: 1024
+          maxRequests: 1024
+          maxRetries: 3
+      connectTimeout: 5s
       edsClusterConfig:
         edsConfig:
           ads: {}
           resourceApiVersion: V3
-      name: echo-service-07fd732a85aa6a99
+      name: echo-service-5a416c39037aa8f6
+      outlierDetection:
+        enforcingConsecutive5xx: 0
+        enforcingConsecutiveGatewayFailure: 0
+        enforcingConsecutiveLocalOriginFailure: 0
+        enforcingFailurePercentage: 0
+        enforcingSuccessRate: 0
       type: EDS
       typedExtensionProtocolOptions:
         envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
           '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
           commonHttpProtocolOptions:
-            idleTimeout: 0s
+            idleTimeout: 3600s
           explicitHttpConfig:
             httpProtocolOptions: {}
 Endpoints:
   Resources:
-    echo-service-07fd732a85aa6a99:
-      clusterName: echo-service-07fd732a85aa6a99
+    echo-service-5a416c39037aa8f6:
+      clusterName: echo-service-5a416c39037aa8f6
       endpoints:
       - lbEndpoints:
         - endpoint:
@@ -99,9 +111,16 @@ Routes:
         - match:
             path: /
           route:
+            retryPolicy:
+              numRetries: 5
+              perTryTimeout: 16s
+              retryBackOff:
+                baseInterval: 0.025s
+                maxInterval: 0.250s
+              retryOn: gateway-error,connect-failure,refused-stream
             weightedClusters:
               clusters:
-              - name: echo-service-07fd732a85aa6a99
+              - name: echo-service-5a416c39037aa8f6
                 weight: 1
               totalWeight: 1
       - domains:
@@ -111,9 +130,16 @@ Routes:
         - match:
             path: /
           route:
+            retryPolicy:
+              numRetries: 5
+              perTryTimeout: 16s
+              retryBackOff:
+                baseInterval: 0.025s
+                maxInterval: 0.250s
+              retryOn: gateway-error,connect-failure,refused-stream
             weightedClusters:
               clusters:
-              - name: echo-service-07fd732a85aa6a99
+              - name: echo-service-5a416c39037aa8f6
                 weight: 1
               totalWeight: 1
       - domains:
@@ -123,9 +149,16 @@ Routes:
         - match:
             path: /
           route:
+            retryPolicy:
+              numRetries: 5
+              perTryTimeout: 16s
+              retryBackOff:
+                baseInterval: 0.025s
+                maxInterval: 0.250s
+              retryOn: gateway-error,connect-failure,refused-stream
             weightedClusters:
               clusters:
-              - name: echo-service-07fd732a85aa6a99
+              - name: echo-service-5a416c39037aa8f6
                 weight: 1
               totalWeight: 1
       - domains:

--- a/pkg/plugins/runtime/gateway/testdata/https/02-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/02-gateway-route.yaml
@@ -27,41 +27,10 @@ Clusters:
             idleTimeout: 3600s
           explicitHttpConfig:
             httpProtocolOptions: {}
-    echo-service-07fd732a85aa6a99:
-      connectTimeout: 10s
-      edsClusterConfig:
-        edsConfig:
-          ads: {}
-          resourceApiVersion: V3
-      name: echo-service-07fd732a85aa6a99
-      type: EDS
-      typedExtensionProtocolOptions:
-        envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
-          '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
-          commonHttpProtocolOptions:
-            idleTimeout: 0s
-          explicitHttpConfig:
-            httpProtocolOptions: {}
 Endpoints:
   Resources:
     echo-service-5a416c39037aa8f6:
       clusterName: echo-service-5a416c39037aa8f6
-      endpoints:
-      - lbEndpoints:
-        - endpoint:
-            address:
-              socketAddress:
-                address: 192.168.1.6
-                portValue: 20006
-          loadBalancingWeight: 1
-          metadata:
-            filterMetadata:
-              envoy.lb:
-                kuma.io/protocol: http
-              envoy.transport_socket_match:
-                kuma.io/protocol: http
-    echo-service-07fd732a85aa6a99:
-      clusterName: echo-service-07fd732a85aa6a99
       endpoints:
       - lbEndpoints:
         - endpoint:
@@ -142,9 +111,16 @@ Routes:
         - match:
             path: /
           route:
+            retryPolicy:
+              numRetries: 5
+              perTryTimeout: 16s
+              retryBackOff:
+                baseInterval: 0.025s
+                maxInterval: 0.250s
+              retryOn: gateway-error,connect-failure,refused-stream
             weightedClusters:
               clusters:
-              - name: echo-service-07fd732a85aa6a99
+              - name: echo-service-5a416c39037aa8f6
                 weight: 1
               totalWeight: 1
       - domains:
@@ -154,6 +130,13 @@ Routes:
         - match:
             path: /
           route:
+            retryPolicy:
+              numRetries: 5
+              perTryTimeout: 16s
+              retryBackOff:
+                baseInterval: 0.025s
+                maxInterval: 0.250s
+              retryOn: gateway-error,connect-failure,refused-stream
             weightedClusters:
               clusters:
               - name: echo-service-5a416c39037aa8f6

--- a/pkg/plugins/runtime/gateway/testdata/https/03-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/03-gateway-route.yaml
@@ -140,6 +140,13 @@ Routes:
         - match:
             path: /service/echo
           route:
+            retryPolicy:
+              numRetries: 5
+              perTryTimeout: 16s
+              retryBackOff:
+                baseInterval: 0.025s
+                maxInterval: 0.250s
+              retryOn: gateway-error,connect-failure,refused-stream
             weightedClusters:
               clusters:
               - name: echo-service-5a416c39037aa8f6

--- a/pkg/plugins/runtime/gateway/testdata/https/04-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/04-gateway-route.yaml
@@ -175,6 +175,13 @@ Routes:
                 defaultValue:
                   denominator: TEN_THOUSAND
                   numerator: 10
+            retryPolicy:
+              numRetries: 5
+              perTryTimeout: 16s
+              retryBackOff:
+                baseInterval: 0.025s
+                maxInterval: 0.250s
+              retryOn: gateway-error,connect-failure,refused-stream
             weightedClusters:
               clusters:
               - name: echo-service-5a416c39037aa8f6

--- a/pkg/plugins/runtime/gateway/testdata/https/06-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/06-gateway-route.yaml
@@ -194,6 +194,13 @@ Routes:
                 defaultValue:
                   denominator: TEN_THOUSAND
                   numerator: 10
+            retryPolicy:
+              numRetries: 5
+              perTryTimeout: 16s
+              retryBackOff:
+                baseInterval: 0.025s
+                maxInterval: 0.250s
+              retryOn: gateway-error,connect-failure,refused-stream
             weightedClusters:
               clusters:
               - name: echo-service-5a416c39037aa8f6

--- a/pkg/plugins/runtime/gateway/testdata/https/07-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/07-gateway-route.yaml
@@ -140,6 +140,13 @@ Routes:
         - match:
             path: /api
           route:
+            retryPolicy:
+              numRetries: 5
+              perTryTimeout: 16s
+              retryBackOff:
+                baseInterval: 0.025s
+                maxInterval: 0.250s
+              retryOn: gateway-error,connect-failure,refused-stream
             weightedClusters:
               clusters:
               - name: echo-service-5a416c39037aa8f6
@@ -148,6 +155,13 @@ Routes:
         - match:
             prefix: /api/
           route:
+            retryPolicy:
+              numRetries: 5
+              perTryTimeout: 16s
+              retryBackOff:
+                baseInterval: 0.025s
+                maxInterval: 0.250s
+              retryOn: gateway-error,connect-failure,refused-stream
             weightedClusters:
               clusters:
               - name: echo-service-5a416c39037aa8f6

--- a/pkg/plugins/runtime/gateway/testdata/https/08-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/08-gateway-route.yaml
@@ -183,6 +183,13 @@ Routes:
         - match:
             path: /api
           route:
+            retryPolicy:
+              numRetries: 5
+              perTryTimeout: 16s
+              retryBackOff:
+                baseInterval: 0.025s
+                maxInterval: 0.250s
+              retryOn: gateway-error,connect-failure,refused-stream
             weightedClusters:
               clusters:
               - name: exact-service-09493d2d54b2a972
@@ -191,6 +198,13 @@ Routes:
         - match:
             prefix: /api/
           route:
+            retryPolicy:
+              numRetries: 5
+              perTryTimeout: 16s
+              retryBackOff:
+                baseInterval: 0.025s
+                maxInterval: 0.250s
+              retryOn: gateway-error,connect-failure,refused-stream
             weightedClusters:
               clusters:
               - name: prefix-service-5061ee504b81a555

--- a/pkg/plugins/runtime/gateway/testdata/https/09-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/09-gateway-route.yaml
@@ -142,6 +142,13 @@ Routes:
               googleRe2: {}
               regex: ^/api/v[0-9]+$
           route:
+            retryPolicy:
+              numRetries: 5
+              perTryTimeout: 16s
+              retryBackOff:
+                baseInterval: 0.025s
+                maxInterval: 0.250s
+              retryOn: gateway-error,connect-failure,refused-stream
             weightedClusters:
               clusters:
               - name: echo-service-5a416c39037aa8f6

--- a/pkg/plugins/runtime/gateway/testdata/https/10-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/10-gateway-route.yaml
@@ -192,6 +192,13 @@ Routes:
                 regex: .*sh
             prefix: /
           route:
+            retryPolicy:
+              numRetries: 5
+              perTryTimeout: 16s
+              retryBackOff:
+                baseInterval: 0.025s
+                maxInterval: 0.250s
+              retryOn: gateway-error,connect-failure,refused-stream
             weightedClusters:
               clusters:
               - name: regex-header-match-ad0dd92f37b8a38d
@@ -203,6 +210,13 @@ Routes:
               name: Content-Type
             prefix: /
           route:
+            retryPolicy:
+              numRetries: 5
+              perTryTimeout: 16s
+              retryBackOff:
+                baseInterval: 0.025s
+                maxInterval: 0.250s
+              retryOn: gateway-error,connect-failure,refused-stream
             weightedClusters:
               clusters:
               - name: exact-header-match-f6b57a6b55557c81
@@ -214,6 +228,13 @@ Routes:
               name: Language
             prefix: /
           route:
+            retryPolicy:
+              numRetries: 5
+              perTryTimeout: 16s
+              retryBackOff:
+                baseInterval: 0.025s
+                maxInterval: 0.250s
+              retryOn: gateway-error,connect-failure,refused-stream
             weightedClusters:
               clusters:
               - name: exact-header-match-f6b57a6b55557c81

--- a/pkg/plugins/runtime/gateway/testdata/https/11-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/11-gateway-route.yaml
@@ -194,6 +194,13 @@ Routes:
                   googleRe2: {}
                   regex: .*sh
           route:
+            retryPolicy:
+              numRetries: 5
+              perTryTimeout: 16s
+              retryBackOff:
+                baseInterval: 0.025s
+                maxInterval: 0.250s
+              retryOn: gateway-error,connect-failure,refused-stream
             weightedClusters:
               clusters:
               - name: regex-query-match-3804d7b8516d7323
@@ -206,6 +213,13 @@ Routes:
               stringMatch:
                 exact: application/json
           route:
+            retryPolicy:
+              numRetries: 5
+              perTryTimeout: 16s
+              retryBackOff:
+                baseInterval: 0.025s
+                maxInterval: 0.250s
+              retryOn: gateway-error,connect-failure,refused-stream
             weightedClusters:
               clusters:
               - name: exact-query-match-cc1370f58a3b5330
@@ -218,6 +232,13 @@ Routes:
               stringMatch:
                 exact: gibberish
           route:
+            retryPolicy:
+              numRetries: 5
+              perTryTimeout: 16s
+              retryBackOff:
+                baseInterval: 0.025s
+                maxInterval: 0.250s
+              retryOn: gateway-error,connect-failure,refused-stream
             weightedClusters:
               clusters:
               - name: exact-query-match-cc1370f58a3b5330

--- a/pkg/plugins/runtime/gateway/testdata/https/12-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/12-gateway-route.yaml
@@ -145,6 +145,13 @@ Routes:
               name: Language
             path: /lang/json
           route:
+            retryPolicy:
+              numRetries: 5
+              perTryTimeout: 16s
+              retryBackOff:
+                baseInterval: 0.025s
+                maxInterval: 0.250s
+              retryOn: gateway-error,connect-failure,refused-stream
             weightedClusters:
               clusters:
               - name: echo-service-5a416c39037aa8f6
@@ -158,6 +165,13 @@ Routes:
               name: Content-Type
             path: /app/json
           route:
+            retryPolicy:
+              numRetries: 5
+              perTryTimeout: 16s
+              retryBackOff:
+                baseInterval: 0.025s
+                maxInterval: 0.250s
+              retryOn: gateway-error,connect-failure,refused-stream
             weightedClusters:
               clusters:
               - name: echo-service-5a416c39037aa8f6
@@ -171,6 +185,13 @@ Routes:
               name: Language
             prefix: /lang/json/
           route:
+            retryPolicy:
+              numRetries: 5
+              perTryTimeout: 16s
+              retryBackOff:
+                baseInterval: 0.025s
+                maxInterval: 0.250s
+              retryOn: gateway-error,connect-failure,refused-stream
             weightedClusters:
               clusters:
               - name: echo-service-5a416c39037aa8f6

--- a/pkg/plugins/runtime/gateway/testdata/https/13-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/13-gateway-route.yaml
@@ -226,6 +226,13 @@ Routes:
         - match:
             path: /match/bar
           route:
+            retryPolicy:
+              numRetries: 5
+              perTryTimeout: 16s
+              retryBackOff:
+                baseInterval: 0.025s
+                maxInterval: 0.250s
+              retryOn: gateway-error,connect-failure,refused-stream
             weightedClusters:
               clusters:
               - name: echo-exact-ad4e3a31db1bf217
@@ -234,6 +241,13 @@ Routes:
         - match:
             path: /match/baz
           route:
+            retryPolicy:
+              numRetries: 5
+              perTryTimeout: 16s
+              retryBackOff:
+                baseInterval: 0.025s
+                maxInterval: 0.250s
+              retryOn: gateway-error,connect-failure,refused-stream
             weightedClusters:
               clusters:
               - name: echo-prefix-d0e5ba63b0c9b9f0
@@ -242,6 +256,13 @@ Routes:
         - match:
             prefix: /match/baz/
           route:
+            retryPolicy:
+              numRetries: 5
+              perTryTimeout: 16s
+              retryBackOff:
+                baseInterval: 0.025s
+                maxInterval: 0.250s
+              retryOn: gateway-error,connect-failure,refused-stream
             weightedClusters:
               clusters:
               - name: echo-prefix-d0e5ba63b0c9b9f0
@@ -252,6 +273,13 @@ Routes:
               googleRe2: {}
               regex: /match/foo
           route:
+            retryPolicy:
+              numRetries: 5
+              perTryTimeout: 16s
+              retryBackOff:
+                baseInterval: 0.025s
+                maxInterval: 0.250s
+              retryOn: gateway-error,connect-failure,refused-stream
             weightedClusters:
               clusters:
               - name: echo-regex-627905e7b1c2eb33

--- a/pkg/plugins/runtime/gateway/testdata/https/14-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/14-gateway-route.yaml
@@ -144,6 +144,13 @@ Routes:
             path: /app/json
           route:
             hostRewriteLiteral: newhost.example.com
+            retryPolicy:
+              numRetries: 5
+              perTryTimeout: 16s
+              retryBackOff:
+                baseInterval: 0.025s
+                maxInterval: 0.250s
+              retryOn: gateway-error,connect-failure,refused-stream
             weightedClusters:
               clusters:
               - name: echo-service-5a416c39037aa8f6

--- a/pkg/plugins/runtime/gateway/testdata/https/15-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/15-gateway-route.yaml
@@ -226,6 +226,13 @@ Routes:
         - match:
             path: /api
           route:
+            retryPolicy:
+              numRetries: 5
+              perTryTimeout: 16s
+              retryBackOff:
+                baseInterval: 0.025s
+                maxInterval: 0.250s
+              retryOn: gateway-error,connect-failure,refused-stream
             weightedClusters:
               clusters:
               - name: api-service-6b688a06cd66f5c9
@@ -234,6 +241,13 @@ Routes:
         - match:
             prefix: /api/
           route:
+            retryPolicy:
+              numRetries: 5
+              perTryTimeout: 16s
+              retryBackOff:
+                baseInterval: 0.025s
+                maxInterval: 0.250s
+              retryOn: gateway-error,connect-failure,refused-stream
             weightedClusters:
               clusters:
               - name: api-service-6b688a06cd66f5c9
@@ -247,6 +261,13 @@ Routes:
               runtimeFraction:
                 defaultValue:
                   numerator: 1
+            retryPolicy:
+              numRetries: 5
+              perTryTimeout: 16s
+              retryBackOff:
+                baseInterval: 0.025s
+                maxInterval: 0.250s
+              retryOn: gateway-error,connect-failure,refused-stream
             weightedClusters:
               clusters:
               - name: echo-service-b5c2b60cba392c4e

--- a/pkg/plugins/runtime/gateway/testdata/https/16-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/16-gateway-route.yaml
@@ -223,6 +223,13 @@ Routes:
         - match:
             path: /api
           route:
+            retryPolicy:
+              numRetries: 5
+              perTryTimeout: 16s
+              retryBackOff:
+                baseInterval: 0.025s
+                maxInterval: 0.250s
+              retryOn: gateway-error,connect-failure,refused-stream
             weightedClusters:
               clusters:
               - name: api-service-49c6d22609eca2d2
@@ -231,6 +238,13 @@ Routes:
         - match:
             prefix: /api/
           route:
+            retryPolicy:
+              numRetries: 5
+              perTryTimeout: 16s
+              retryBackOff:
+                baseInterval: 0.025s
+                maxInterval: 0.250s
+              retryOn: gateway-error,connect-failure,refused-stream
             weightedClusters:
               clusters:
               - name: api-service-49c6d22609eca2d2
@@ -244,6 +258,13 @@ Routes:
               runtimeFraction:
                 defaultValue:
                   numerator: 1
+            retryPolicy:
+              numRetries: 5
+              perTryTimeout: 16s
+              retryBackOff:
+                baseInterval: 0.025s
+                maxInterval: 0.250s
+              retryOn: gateway-error,connect-failure,refused-stream
             weightedClusters:
               clusters:
               - name: echo-service-48cd7f2dbb98df84

--- a/pkg/plugins/runtime/gateway/testdata/https/17-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/17-gateway-route.yaml
@@ -244,6 +244,13 @@ Routes:
         - match:
             path: /api
           route:
+            retryPolicy:
+              numRetries: 5
+              perTryTimeout: 16s
+              retryBackOff:
+                baseInterval: 0.025s
+                maxInterval: 0.250s
+              retryOn: gateway-error,connect-failure,refused-stream
             weightedClusters:
               clusters:
               - name: api-service-19fcb7995aa98119
@@ -252,6 +259,13 @@ Routes:
         - match:
             prefix: /api/
           route:
+            retryPolicy:
+              numRetries: 5
+              perTryTimeout: 16s
+              retryBackOff:
+                baseInterval: 0.025s
+                maxInterval: 0.250s
+              retryOn: gateway-error,connect-failure,refused-stream
             weightedClusters:
               clusters:
               - name: api-service-19fcb7995aa98119
@@ -265,6 +279,13 @@ Routes:
               runtimeFraction:
                 defaultValue:
                   numerator: 1
+            retryPolicy:
+              numRetries: 5
+              perTryTimeout: 16s
+              retryBackOff:
+                baseInterval: 0.025s
+                maxInterval: 0.250s
+              retryOn: gateway-error,connect-failure,refused-stream
             weightedClusters:
               clusters:
               - name: echo-service-eb4ea372d99abf73

--- a/pkg/plugins/runtime/gateway/testdata/https/18-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/18-gateway-route.yaml
@@ -137,6 +137,13 @@ Routes:
         - match:
             prefix: /
           route:
+            retryPolicy:
+              numRetries: 5
+              perTryTimeout: 16s
+              retryBackOff:
+                baseInterval: 0.025s
+                maxInterval: 0.250s
+              retryOn: gateway-error,connect-failure,refused-stream
             weightedClusters:
               clusters:
               - name: external-httpbin-2528f53d03636b9d

--- a/pkg/plugins/runtime/gateway/testdata/https/19-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/19-gateway-route.yaml
@@ -149,6 +149,13 @@ Routes:
         - match:
             prefix: /
           route:
+            retryPolicy:
+              numRetries: 5
+              perTryTimeout: 16s
+              retryBackOff:
+                baseInterval: 0.025s
+                maxInterval: 0.250s
+              retryOn: gateway-error,connect-failure,refused-stream
             weightedClusters:
               clusters:
               - name: external-httpbin-374dddb882a5e651

--- a/pkg/plugins/runtime/gateway/testdata/https/20-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/20-gateway-route.yaml
@@ -342,6 +342,13 @@ Routes:
         - match:
             prefix: /
           route:
+            retryPolicy:
+              numRetries: 5
+              perTryTimeout: 16s
+              retryBackOff:
+                baseInterval: 0.025s
+                maxInterval: 0.250s
+              retryOn: gateway-error,connect-failure,refused-stream
             weightedClusters:
               clusters:
               - name: echo-service-dbfe9218dfa3ba0c
@@ -360,6 +367,13 @@ Routes:
         - match:
             prefix: /
           route:
+            retryPolicy:
+              numRetries: 5
+              perTryTimeout: 16s
+              retryBackOff:
+                baseInterval: 0.025s
+                maxInterval: 0.250s
+              retryOn: gateway-error,connect-failure,refused-stream
             weightedClusters:
               clusters:
               - name: echo-service-cff7b41a9764f367
@@ -378,6 +392,13 @@ Routes:
         - match:
             prefix: /
           route:
+            retryPolicy:
+              numRetries: 5
+              perTryTimeout: 16s
+              retryBackOff:
+                baseInterval: 0.025s
+                maxInterval: 0.250s
+              retryOn: gateway-error,connect-failure,refused-stream
             weightedClusters:
               clusters:
               - name: echo-service-b5c2b60cba392c4e

--- a/pkg/xds/envoy/listeners/v3/retry_configurer.go
+++ b/pkg/xds/envoy/listeners/v3/retry_configurer.go
@@ -17,7 +17,7 @@ const (
 		"refused-stream"
 	HttpRetryOnRetriableStatusCodes = "connect-failure,refused-stream," +
 		"retriable-status-codes"
-	GrpcRetryOnAll = "cancelled,connect-failure," +
+	GrpcRetryOnDefault = "cancelled,connect-failure," +
 		"gateway-error,refused-stream,reset,resource-exhausted,unavailable"
 )
 
@@ -34,7 +34,7 @@ func genGrpcRetryPolicy(
 	}
 
 	policy := envoy_route.RetryPolicy{
-		RetryOn:       GrpcRetryOnAll,
+		RetryOn:       GrpcRetryOnDefault,
 		PerTryTimeout: conf.PerTryTimeout,
 	}
 


### PR DESCRIPTION
### Summary

Add Retry support to Gateway routes. This takes a different approach
from mesh, but populating the retry policy on the routing route action.
Since Retry is a connection policy that matches a sources and destination,
the routing step is the best place to attach the policy since at that
point we know both the source and the destination services. The only
complication is when we are forwarding to a weighted cluster composed
of multiple services, where the selected policy may not be especially
obvious.

### Full changelog

N/A

### Issues resolved

Fix #3319.

### Documentation

N/A

### Testing

- [x] Unit tests
- [x] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes

### Backwards compatibility

- [ ] Update [`UPGRADE.md`](UPGRADE.md) with any steps users will need to take
      when upgrading.
- [ ] Add `backport-to-stable` label if the code is backwards compatible. Otherwise, list breaking changes.
