### PR TITLE
ci: disable commitlint footer rules

### DIFF
--- a/.github/commitlint.config.js
+++ b/.github/commitlint.config.js
@@ -2,4 +2,8 @@ module.exports = {
   extends: ["@commitlint/config-conventional"],
   helpUrl:
     "https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#commit-message-format",
+  rules: {
+    "footer-max-line-length": [0],
+    "footer-leading-blank": [0],
+  },
 };


### PR DESCRIPTION
### Summary

The specifics of the footer aren't super important for us.