### PR TITLE
ci: fix failing mac CI because of unsupported instance size

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -160,7 +160,7 @@ executors:
       GO111MODULE: "on"
 
   mac:
-    resource_class: large
+    resource_class: medium
     macos:
       xcode: "12.5.1"
     environment:


### PR DESCRIPTION
### Summary

We are not allowed to use "large" mac instances so let's use "medium"

### Documentation

- [x] No docs

### Testing

- Only CI change (added the job here to check it was working).

### Backwards compatibility

- [x] No need for changing UPGRADE.md
- [x] Add `backport-to-stable` label if the code is backwards compatible. Otherwise, list breaking changes.
