### PR TITLE
ci(.github): run PR checks when edited

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -1,6 +1,13 @@
 name: "Lint PRs"
 
-on: pull_request
+on:
+  pull_request:
+    types:
+      - edited
+      - opened
+      - reopened
+      - synchronized
+
 
 jobs:
   # This job checks all PR commits and the PR title using


### PR DESCRIPTION
### Summary

Only `edited` is not [a default event type](https://docs.github.com/en/actions/learn-github-actions/events-that-trigger-workflows#pull_request).