### PR TITLE
feat(kuma-cp): sidecar injection webhook based on labels

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -11,7 +11,7 @@ does not have any particular instructions.
 ### Kubernetes
 
 Please migrate your `kuma.io/sidecar-injection` annotations to labels.
-The new version still supports annotation, but to have a guarantee that application can only start with sidecar, you must use label instead of annotation. 
+The new version still supports annotation, but to have a guarantee that applications can only start with sidecar, you must use label instead of annotation. 
 
 ## Upgrade to `1.4.0`
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,6 +8,11 @@ does not have any particular instructions.
 
 ## Upcoming release
 
+### Kubernetes
+
+Please migrate your `kuma.io/sidecar-injection` annotations to labels.
+The new version still supports annotation, but to have a guarantee that application can only start with sidecar, you must use label instead of annotation. 
+
 ## Upgrade to `1.4.0`
 
 Starting with this version, the default API server authentication method is user

--- a/app/kumactl/cmd/install/context/install_control_plane_context.go
+++ b/app/kumactl/cmd/install/context/install_control_plane_context.go
@@ -71,7 +71,7 @@ func DefaultInstallCpContext() InstallCpContext {
 			ControlPlane_image_tag:                  kuma_version.Build.GitTag,
 			ControlPlane_service_name:               "kuma-control-plane",
 			ControlPlane_envVars:                    map[string]string{},
-			ControlPlane_injectorFailurePolicy:      "Ignore",
+			ControlPlane_injectorFailurePolicy:      "Fail",
 			DataPlane_image_registry:                "docker.io/kumahq",
 			DataPlane_image_repository:              "kuma-dp",
 			DataPlane_image_tag:                     kuma_version.Build.GitTag,

--- a/app/kumactl/cmd/install/install_control_plane.go
+++ b/app/kumactl/cmd/install/install_control_plane.go
@@ -118,7 +118,7 @@ This command requires that the KUBECONFIG environment is set`,
 	cmd.Flags().StringVar(&args.ControlPlane_tls_apiServer_clientCertsSecret, "tls-api-server-client-certs-secret", args.ControlPlane_tls_apiServer_clientCertsSecret, "Secret that contains list of .pem certificates that can access admin endpoints of Kuma API on HTTPS")
 	cmd.Flags().StringVar(&args.ControlPlane_tls_kdsGlobalServer_secret, "tls-kds-global-server-secret", args.ControlPlane_tls_kdsGlobalServer_secret, "Secret that contains tls.crt, key.crt for protecting cross cluster communication")
 	cmd.Flags().StringVar(&args.ControlPlane_tls_kdsZoneClient_secret, "tls-kds-zone-client-secret", args.ControlPlane_tls_kdsZoneClient_secret, "Secret that contains ca.crt which was used to sign KDS Global server. Used for CP verification")
-	cmd.Flags().StringVar(&args.ControlPlane_injectorFailurePolicy, "injector-failure-policy", args.ControlPlane_injectorFailurePolicy, "failue policy of the mutating web hook implemented by the Kuma Injector component")
+	cmd.Flags().StringVar(&args.ControlPlane_injectorFailurePolicy, "injector-failure-policy", args.ControlPlane_injectorFailurePolicy, "failure policy of the mutating web hook implemented by the Kuma Injector component")
 	cmd.Flags().StringToStringVar(&args.ControlPlane_envVars, "env-var", args.ControlPlane_envVars, "environment variables that will be passed to the control plane")
 	cmd.Flags().StringVar(&args.DataPlane_image_registry, "dataplane-registry", args.DataPlane_image_registry, "registry for the image of the Kuma DataPlane component")
 	cmd.Flags().StringVar(&args.DataPlane_image_repository, "dataplane-repository", args.DataPlane_image_repository, "repository for the image of the Kuma DataPlane component")

--- a/app/kumactl/cmd/install/testdata/install-control-plane.cni-enabled.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.cni-enabled.golden.yaml
@@ -1082,7 +1082,7 @@ spec:
     metadata:
       annotations:
         checksum/config: bd9040893dba92c246c9f15b8e5c5fdbbccabfeb97201a967595c7c13f24356c
-        checksum/tls-secrets: 67e1c21135f2c9ac6e7c1c33a036bbabab1250b9be164c9d275eae816b69b805
+        checksum/tls-secrets: 5f337216840fad68c3d519633e8a1fb5c9f4fc6c4303497f65c0309135a00e21
       labels:
         app.kubernetes.io/name: kuma
         app.kubernetes.io/instance: kuma
@@ -1250,9 +1250,53 @@ webhooks:
     
       
     sideEffects: None
+  - name: namespace-kuma-injector.kuma.io
+    admissionReviewVersions: ["v1"]
+    failurePolicy: Fail
+    namespaceSelector:
+      matchLabels:
+        kuma.io/sidecar-injection: enabled
+    clientConfig:
+      caBundle: XYZ
+      service:
+        namespace: kuma-system
+        name: kuma-control-plane
+        path: /inject-sidecar
+    rules:
+      - apiGroups:
+          - ""
+        apiVersions:
+          - v1
+        operations:
+          - CREATE
+        resources:
+          - pods
+    sideEffects: None
+  - name: pods-kuma-injector.kuma.io
+    admissionReviewVersions: ["v1"]
+    failurePolicy: Fail
+    objectSelector:
+      matchLabels:
+        kuma.io/sidecar-injection: enabled
+    clientConfig:
+      caBundle: XYZ
+      service:
+        namespace: kuma-system
+        name: kuma-control-plane
+        path: /inject-sidecar
+    rules:
+      - apiGroups:
+          - ""
+        apiVersions:
+          - v1
+        operations:
+          - CREATE
+        resources:
+          - pods
+    sideEffects: None
   - name: kuma-injector.kuma.io
     admissionReviewVersions: ["v1"]
-    failurePolicy: Ignore
+    failurePolicy: Ignore 
     clientConfig:
       caBundle: XYZ
       service:

--- a/app/kumactl/cmd/install/testdata/install-control-plane.defaults.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.defaults.golden.yaml
@@ -907,7 +907,7 @@ spec:
     metadata:
       annotations:
         checksum/config: bd9040893dba92c246c9f15b8e5c5fdbbccabfeb97201a967595c7c13f24356c
-        checksum/tls-secrets: 67e1c21135f2c9ac6e7c1c33a036bbabab1250b9be164c9d275eae816b69b805
+        checksum/tls-secrets: 5f337216840fad68c3d519633e8a1fb5c9f4fc6c4303497f65c0309135a00e21
       labels:
         app.kubernetes.io/name: kuma
         app.kubernetes.io/instance: kuma
@@ -1075,9 +1075,53 @@ webhooks:
     
       
     sideEffects: None
+  - name: namespace-kuma-injector.kuma.io
+    admissionReviewVersions: ["v1"]
+    failurePolicy: Fail
+    namespaceSelector:
+      matchLabels:
+        kuma.io/sidecar-injection: enabled
+    clientConfig:
+      caBundle: XYZ
+      service:
+        namespace: kuma-system
+        name: kuma-control-plane
+        path: /inject-sidecar
+    rules:
+      - apiGroups:
+          - ""
+        apiVersions:
+          - v1
+        operations:
+          - CREATE
+        resources:
+          - pods
+    sideEffects: None
+  - name: pods-kuma-injector.kuma.io
+    admissionReviewVersions: ["v1"]
+    failurePolicy: Fail
+    objectSelector:
+      matchLabels:
+        kuma.io/sidecar-injection: enabled
+    clientConfig:
+      caBundle: XYZ
+      service:
+        namespace: kuma-system
+        name: kuma-control-plane
+        path: /inject-sidecar
+    rules:
+      - apiGroups:
+          - ""
+        apiVersions:
+          - v1
+        operations:
+          - CREATE
+        resources:
+          - pods
+    sideEffects: None
   - name: kuma-injector.kuma.io
     admissionReviewVersions: ["v1"]
-    failurePolicy: Ignore
+    failurePolicy: Ignore 
     clientConfig:
       caBundle: XYZ
       service:

--- a/app/kumactl/cmd/install/testdata/install-control-plane.global.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.global.golden.yaml
@@ -916,7 +916,7 @@ spec:
     metadata:
       annotations:
         checksum/config: bd9040893dba92c246c9f15b8e5c5fdbbccabfeb97201a967595c7c13f24356c
-        checksum/tls-secrets: 67e1c21135f2c9ac6e7c1c33a036bbabab1250b9be164c9d275eae816b69b805
+        checksum/tls-secrets: 5f337216840fad68c3d519633e8a1fb5c9f4fc6c4303497f65c0309135a00e21
       labels:
         app.kubernetes.io/name: kuma
         app.kubernetes.io/instance: kuma
@@ -1081,9 +1081,53 @@ webhooks:
     
       
     sideEffects: None
+  - name: namespace-kuma-injector.kuma.io
+    admissionReviewVersions: ["v1"]
+    failurePolicy: Fail
+    namespaceSelector:
+      matchLabels:
+        kuma.io/sidecar-injection: enabled
+    clientConfig:
+      caBundle: XYZ
+      service:
+        namespace: kuma-system
+        name: kuma-control-plane
+        path: /inject-sidecar
+    rules:
+      - apiGroups:
+          - ""
+        apiVersions:
+          - v1
+        operations:
+          - CREATE
+        resources:
+          - pods
+    sideEffects: None
+  - name: pods-kuma-injector.kuma.io
+    admissionReviewVersions: ["v1"]
+    failurePolicy: Fail
+    objectSelector:
+      matchLabels:
+        kuma.io/sidecar-injection: enabled
+    clientConfig:
+      caBundle: XYZ
+      service:
+        namespace: kuma-system
+        name: kuma-control-plane
+        path: /inject-sidecar
+    rules:
+      - apiGroups:
+          - ""
+        apiVersions:
+          - v1
+        operations:
+          - CREATE
+        resources:
+          - pods
+    sideEffects: None
   - name: kuma-injector.kuma.io
     admissionReviewVersions: ["v1"]
-    failurePolicy: Ignore
+    failurePolicy: Ignore 
     clientConfig:
       caBundle: XYZ
       service:

--- a/app/kumactl/cmd/install/testdata/install-control-plane.override-env-vars.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.override-env-vars.golden.yaml
@@ -907,7 +907,7 @@ spec:
     metadata:
       annotations:
         checksum/config: bd9040893dba92c246c9f15b8e5c5fdbbccabfeb97201a967595c7c13f24356c
-        checksum/tls-secrets: 67e1c21135f2c9ac6e7c1c33a036bbabab1250b9be164c9d275eae816b69b805
+        checksum/tls-secrets: 5f337216840fad68c3d519633e8a1fb5c9f4fc6c4303497f65c0309135a00e21
       labels:
         app.kubernetes.io/name: kuma
         app.kubernetes.io/instance: kuma
@@ -1075,9 +1075,53 @@ webhooks:
     
       
     sideEffects: None
+  - name: namespace-kuma-injector.kuma.io
+    admissionReviewVersions: ["v1"]
+    failurePolicy: Fail
+    namespaceSelector:
+      matchLabels:
+        kuma.io/sidecar-injection: enabled
+    clientConfig:
+      caBundle: XYZ
+      service:
+        namespace: kuma-system
+        name: kuma-control-plane
+        path: /inject-sidecar
+    rules:
+      - apiGroups:
+          - ""
+        apiVersions:
+          - v1
+        operations:
+          - CREATE
+        resources:
+          - pods
+    sideEffects: None
+  - name: pods-kuma-injector.kuma.io
+    admissionReviewVersions: ["v1"]
+    failurePolicy: Fail
+    objectSelector:
+      matchLabels:
+        kuma.io/sidecar-injection: enabled
+    clientConfig:
+      caBundle: XYZ
+      service:
+        namespace: kuma-system
+        name: kuma-control-plane
+        path: /inject-sidecar
+    rules:
+      - apiGroups:
+          - ""
+        apiVersions:
+          - v1
+        operations:
+          - CREATE
+        resources:
+          - pods
+    sideEffects: None
   - name: kuma-injector.kuma.io
     admissionReviewVersions: ["v1"]
-    failurePolicy: Ignore
+    failurePolicy: Ignore 
     clientConfig:
       caBundle: XYZ
       service:

--- a/app/kumactl/cmd/install/testdata/install-control-plane.overrides.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.overrides.golden.yaml
@@ -911,7 +911,7 @@ spec:
     metadata:
       annotations:
         checksum/config: 243da0d686658ca26902677cd16971d2ec72fe4453dbb0b09c09ea96b423d4ce
-        checksum/tls-secrets: 4d6f0e89dd8efed9a9eb2523670c3224b440db9ef34d41cce63ec46dd8ab5b41
+        checksum/tls-secrets: 12e245aa8f7469c6fcbc3fc3c91c376d33ecc6298869b68332d21c56aa5c38d4
       labels:
         app.kubernetes.io/name: kuma
         app.kubernetes.io/instance: kuma
@@ -1119,9 +1119,53 @@ webhooks:
     
       
     sideEffects: None
-  - name: kuma-injector.kuma.io
+  - name: namespace-kuma-injector.kuma.io
     admissionReviewVersions: ["v1"]
     failurePolicy: Crash
+    namespaceSelector:
+      matchLabels:
+        kuma.io/sidecar-injection: enabled
+    clientConfig:
+      caBundle: XYZ
+      service:
+        namespace: kuma
+        name: kuma-ctrl-plane
+        path: /inject-sidecar
+    rules:
+      - apiGroups:
+          - ""
+        apiVersions:
+          - v1
+        operations:
+          - CREATE
+        resources:
+          - pods
+    sideEffects: None
+  - name: pods-kuma-injector.kuma.io
+    admissionReviewVersions: ["v1"]
+    failurePolicy: Crash
+    objectSelector:
+      matchLabels:
+        kuma.io/sidecar-injection: enabled
+    clientConfig:
+      caBundle: XYZ
+      service:
+        namespace: kuma
+        name: kuma-ctrl-plane
+        path: /inject-sidecar
+    rules:
+      - apiGroups:
+          - ""
+        apiVersions:
+          - v1
+        operations:
+          - CREATE
+        resources:
+          - pods
+    sideEffects: None
+  - name: kuma-injector.kuma.io
+    admissionReviewVersions: ["v1"]
+    failurePolicy: Ignore 
     clientConfig:
       caBundle: XYZ
       service:

--- a/app/kumactl/cmd/install/testdata/install-control-plane.with-ingress.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.with-ingress.golden.yaml
@@ -936,7 +936,7 @@ spec:
     metadata:
       annotations:
         checksum/config: bd9040893dba92c246c9f15b8e5c5fdbbccabfeb97201a967595c7c13f24356c
-        checksum/tls-secrets: 67e1c21135f2c9ac6e7c1c33a036bbabab1250b9be164c9d275eae816b69b805
+        checksum/tls-secrets: 5f337216840fad68c3d519633e8a1fb5c9f4fc6c4303497f65c0309135a00e21
       labels:
         app.kubernetes.io/name: kuma
         app.kubernetes.io/instance: kuma
@@ -1220,9 +1220,53 @@ webhooks:
     
       
     sideEffects: None
+  - name: namespace-kuma-injector.kuma.io
+    admissionReviewVersions: ["v1"]
+    failurePolicy: Fail
+    namespaceSelector:
+      matchLabels:
+        kuma.io/sidecar-injection: enabled
+    clientConfig:
+      caBundle: XYZ
+      service:
+        namespace: kuma-system
+        name: kuma-control-plane
+        path: /inject-sidecar
+    rules:
+      - apiGroups:
+          - ""
+        apiVersions:
+          - v1
+        operations:
+          - CREATE
+        resources:
+          - pods
+    sideEffects: None
+  - name: pods-kuma-injector.kuma.io
+    admissionReviewVersions: ["v1"]
+    failurePolicy: Fail
+    objectSelector:
+      matchLabels:
+        kuma.io/sidecar-injection: enabled
+    clientConfig:
+      caBundle: XYZ
+      service:
+        namespace: kuma-system
+        name: kuma-control-plane
+        path: /inject-sidecar
+    rules:
+      - apiGroups:
+          - ""
+        apiVersions:
+          - v1
+        operations:
+          - CREATE
+        resources:
+          - pods
+    sideEffects: None
   - name: kuma-injector.kuma.io
     admissionReviewVersions: ["v1"]
-    failurePolicy: Ignore
+    failurePolicy: Ignore 
     clientConfig:
       caBundle: XYZ
       service:

--- a/app/kumactl/cmd/install/testdata/install-control-plane.zone.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.zone.golden.yaml
@@ -911,7 +911,7 @@ spec:
     metadata:
       annotations:
         checksum/config: bd9040893dba92c246c9f15b8e5c5fdbbccabfeb97201a967595c7c13f24356c
-        checksum/tls-secrets: 67e1c21135f2c9ac6e7c1c33a036bbabab1250b9be164c9d275eae816b69b805
+        checksum/tls-secrets: 5f337216840fad68c3d519633e8a1fb5c9f4fc6c4303497f65c0309135a00e21
       labels:
         app.kubernetes.io/name: kuma
         app.kubernetes.io/instance: kuma
@@ -1083,9 +1083,53 @@ webhooks:
     
       
     sideEffects: None
+  - name: namespace-kuma-injector.kuma.io
+    admissionReviewVersions: ["v1"]
+    failurePolicy: Fail
+    namespaceSelector:
+      matchLabels:
+        kuma.io/sidecar-injection: enabled
+    clientConfig:
+      caBundle: XYZ
+      service:
+        namespace: kuma-system
+        name: kuma-control-plane
+        path: /inject-sidecar
+    rules:
+      - apiGroups:
+          - ""
+        apiVersions:
+          - v1
+        operations:
+          - CREATE
+        resources:
+          - pods
+    sideEffects: None
+  - name: pods-kuma-injector.kuma.io
+    admissionReviewVersions: ["v1"]
+    failurePolicy: Fail
+    objectSelector:
+      matchLabels:
+        kuma.io/sidecar-injection: enabled
+    clientConfig:
+      caBundle: XYZ
+      service:
+        namespace: kuma-system
+        name: kuma-control-plane
+        path: /inject-sidecar
+    rules:
+      - apiGroups:
+          - ""
+        apiVersions:
+          - v1
+        operations:
+          - CREATE
+        resources:
+          - pods
+    sideEffects: None
   - name: kuma-injector.kuma.io
     admissionReviewVersions: ["v1"]
-    failurePolicy: Ignore
+    failurePolicy: Ignore 
     clientConfig:
       caBundle: XYZ
       service:

--- a/deployments/charts/kuma/README.md
+++ b/deployments/charts/kuma/README.md
@@ -26,7 +26,7 @@ A Helm chart for the Kuma Control Plane
 | controlPlane.autoscaling.metrics | list | `[{"resource":{"name":"cpu","target":{"averageUtilization":80,"type":"Utilization"}},"type":"Resource"}]` | For clusters that do support autoscaling/v2beta, use metrics |
 | controlPlane.nodeSelector | object | `{"kubernetes.io/arch":"amd64","kubernetes.io/os":"linux"}` | Node selector for the Kuma Control Plane pods |
 | controlPlane.affinity | object | `{}` | Affinity placement rule for the Kuma Control Plane pods |
-| controlPlane.injectorFailurePolicy | string | `"Ignore"` | Failure policy of the mutating webhook implemented by the Kuma Injector component |
+| controlPlane.injectorFailurePolicy | string | `"Fail"` | Failure policy of the mutating webhook implemented by the Kuma Injector component |
 | controlPlane.service.name | string | `nil` | Optionally override of the Kuma Control Plane Service's name |
 | controlPlane.service.type | string | `"ClusterIP"` | Service type of the Kuma Control Plane |
 | controlPlane.service.annotations | object | `{}` | Additional annotations to put on the Kuma Control Plane |

--- a/deployments/charts/kuma/templates/cp-webhooks-and-secrets.yaml
+++ b/deployments/charts/kuma/templates/cp-webhooks-and-secrets.yaml
@@ -104,9 +104,53 @@ webhooks:
           - virtualoutbounds
     {{ .Values.controlPlane.webhooks.ownerReference.additionalRules | nindent 6 }}
     sideEffects: None
-  - name: kuma-injector.kuma.io
+  - name: namespace-kuma-injector.kuma.io
     admissionReviewVersions: ["v1"]
     failurePolicy: {{ .Values.controlPlane.injectorFailurePolicy }}
+    namespaceSelector:
+      matchLabels:
+        kuma.io/sidecar-injection: enabled
+    clientConfig:
+      caBundle: {{ $caBundle }}
+      service:
+        namespace: {{ .Release.Namespace }}
+        name: {{ include "kuma.controlPlane.serviceName" . }}
+        path: /inject-sidecar
+    rules:
+      - apiGroups:
+          - ""
+        apiVersions:
+          - v1
+        operations:
+          - CREATE
+        resources:
+          - pods
+    sideEffects: None
+  - name: pods-kuma-injector.kuma.io
+    admissionReviewVersions: ["v1"]
+    failurePolicy: {{ .Values.controlPlane.injectorFailurePolicy }}
+    objectSelector:
+      matchLabels:
+        kuma.io/sidecar-injection: enabled
+    clientConfig:
+      caBundle: {{ $caBundle }}
+      service:
+        namespace: {{ .Release.Namespace }}
+        name: {{ include "kuma.controlPlane.serviceName" . }}
+        path: /inject-sidecar
+    rules:
+      - apiGroups:
+          - ""
+        apiVersions:
+          - v1
+        operations:
+          - CREATE
+        resources:
+          - pods
+    sideEffects: None
+  - name: kuma-injector.kuma.io
+    admissionReviewVersions: ["v1"]
+    failurePolicy: Ignore {{/* Failure policy is hardcoded as Ignore because any other mode will cause CP to be unable to start after all instances are down */}}
     clientConfig:
       caBundle: {{ $caBundle }}
       service:

--- a/deployments/charts/kuma/values.yaml
+++ b/deployments/charts/kuma/values.yaml
@@ -60,7 +60,7 @@ controlPlane:
   affinity: {}
 
   # -- Failure policy of the mutating webhook implemented by the Kuma Injector component
-  injectorFailurePolicy: Ignore
+  injectorFailurePolicy: Fail
 
   service:
     # -- (string) Optionally override of the Kuma Control Plane Service's name
@@ -195,7 +195,7 @@ ingress:
   nodeSelector:
     kubernetes.io/os: linux
     kubernetes.io/arch: amd64
-  
+
   # -- Affinity placement rule for the Kuma Ingress pods
   affinity: {}
 

--- a/docs/cmd/kumactl/kumactl_install_control-plane.md
+++ b/docs/cmd/kumactl/kumactl_install_control-plane.md
@@ -38,7 +38,7 @@ kumactl install control-plane [flags]
       --ingress-drain-time string                   drain time for Envoy proxy (default "30s")
       --ingress-enabled                             install Kuma with an Ingress deployment, using the Data Plane image
       --ingress-use-node-port                       use NodePort instead of LoadBalancer for the Ingress Service
-      --injector-failure-policy string              failue policy of the mutating web hook implemented by the Kuma Injector component (default "Ignore")
+      --injector-failure-policy string              failue policy of the mutating web hook implemented by the Kuma Injector component (default "Fail")
       --kds-global-address string                   URL of Global Kuma CP (example: grpcs://192.168.0.1:5685)
       --mode string                                 kuma cp modes: one of standalone|zone|global (default "standalone")
       --namespace string                            namespace to install Kuma Control Plane to (default "kuma-system")

--- a/docs/cmd/kumactl/kumactl_install_control-plane.md
+++ b/docs/cmd/kumactl/kumactl_install_control-plane.md
@@ -38,7 +38,7 @@ kumactl install control-plane [flags]
       --ingress-drain-time string                   drain time for Envoy proxy (default "30s")
       --ingress-enabled                             install Kuma with an Ingress deployment, using the Data Plane image
       --ingress-use-node-port                       use NodePort instead of LoadBalancer for the Ingress Service
-      --injector-failure-policy string              failue policy of the mutating web hook implemented by the Kuma Injector component (default "Fail")
+      --injector-failure-policy string              failure policy of the mutating web hook implemented by the Kuma Injector component (default "Fail")
       --kds-global-address string                   URL of Global Kuma CP (example: grpcs://192.168.0.1:5685)
       --mode string                                 kuma cp modes: one of standalone|zone|global (default "standalone")
       --namespace string                            namespace to install Kuma Control Plane to (default "kuma-system")

--- a/pkg/plugins/runtime/k8s/controllers/inbound_converter.go
+++ b/pkg/plugins/runtime/k8s/controllers/inbound_converter.go
@@ -124,7 +124,8 @@ func InboundInterfacesFor(zone string, pod *kube_core.Pod, services []*kube_core
 func InboundTagsForService(zone string, pod *kube_core.Pod, svc *kube_core.Service, svcPort *kube_core.ServicePort) map[string]string {
 	tags := util_k8s.CopyStringMap(pod.Labels)
 	for key, value := range tags {
-		if value == "" {
+		// we don't want to convert labels like kuma.io/sidecar-injection: enabled into tag
+		if strings.HasPrefix(key, "kuma.io/") || value == "" {
 			delete(tags, key)
 		}
 	}

--- a/pkg/plugins/runtime/k8s/controllers/inbound_converter.go
+++ b/pkg/plugins/runtime/k8s/controllers/inbound_converter.go
@@ -9,6 +9,7 @@ import (
 
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
+	"github.com/kumahq/kuma/pkg/plugins/runtime/k8s/metadata"
 	util_k8s "github.com/kumahq/kuma/pkg/plugins/runtime/k8s/util"
 )
 
@@ -124,9 +125,12 @@ func InboundInterfacesFor(zone string, pod *kube_core.Pod, services []*kube_core
 func InboundTagsForService(zone string, pod *kube_core.Pod, svc *kube_core.Service, svcPort *kube_core.ServicePort) map[string]string {
 	tags := util_k8s.CopyStringMap(pod.Labels)
 	for key, value := range tags {
-		// we don't want to convert labels like
-		// kuma.io/sidecar-injection, kuma.io/service, k8s.kuma.io/namespace etc.
-		if strings.Contains(key, "kuma.io/") || value == "" {
+		if key == metadata.KumaSidecarInjectionAnnotation || value == "" {
+			delete(tags, key)
+		} else if metadata.IsReservedPrefix(key) {
+			// we don't want to convert labels like
+			// kuma.io/sidecar-injection, kuma.io/service, k8s.kuma.io/namespace etc.
+			converterLog.Info("ignoring label when converting labels to tags, because it uses reserved Kuma prefix", "label", key, "pod", pod.Name)
 			delete(tags, key)
 		}
 	}

--- a/pkg/plugins/runtime/k8s/controllers/inbound_converter.go
+++ b/pkg/plugins/runtime/k8s/controllers/inbound_converter.go
@@ -124,8 +124,9 @@ func InboundInterfacesFor(zone string, pod *kube_core.Pod, services []*kube_core
 func InboundTagsForService(zone string, pod *kube_core.Pod, svc *kube_core.Service, svcPort *kube_core.ServicePort) map[string]string {
 	tags := util_k8s.CopyStringMap(pod.Labels)
 	for key, value := range tags {
-		// we don't want to convert labels like kuma.io/sidecar-injection: enabled into tag
-		if strings.HasPrefix(key, "kuma.io/") || value == "" {
+		// we don't want to convert labels like
+		// kuma.io/sidecar-injection, kuma.io/service, k8s.kuma.io/namespace etc.
+		if strings.Contains(key, "kuma.io/") || value == "" {
 			delete(tags, key)
 		}
 	}

--- a/pkg/plugins/runtime/k8s/controllers/inbound_converter.go
+++ b/pkg/plugins/runtime/k8s/controllers/inbound_converter.go
@@ -127,7 +127,7 @@ func InboundTagsForService(zone string, pod *kube_core.Pod, svc *kube_core.Servi
 	for key, value := range tags {
 		if key == metadata.KumaSidecarInjectionAnnotation || value == "" {
 			delete(tags, key)
-		} else if metadata.IsReservedPrefix(key) {
+		} else if strings.Contains(key, "kuma.io/") {
 			// we don't want to convert labels like
 			// kuma.io/sidecar-injection, kuma.io/service, k8s.kuma.io/namespace etc.
 			converterLog.Info("ignoring label when converting labels to tags, because it uses reserved Kuma prefix", "label", key, "pod", pod.Name)

--- a/pkg/plugins/runtime/k8s/controllers/testdata/01.pod.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/01.pod.yaml
@@ -4,6 +4,7 @@ metadata:
   labels:
     app: example
     version: "0.1"
+    kuma.io/sidecar-injection: enabled
 spec:
   containers:
     - ports: []

--- a/pkg/plugins/runtime/k8s/metadata/annotations.go
+++ b/pkg/plugins/runtime/k8s/metadata/annotations.go
@@ -70,12 +70,6 @@ const (
 	KumaTrafficExcludeOutboundPorts = "traffic.kuma.io/exclude-outbound-ports"
 )
 
-func IsReservedPrefix(annotation string) bool {
-	return strings.HasPrefix(annotation, "kuma.io/") ||
-		strings.HasPrefix(annotation, "traffic.kuma.io/") ||
-		strings.HasPrefix(annotation, "prometheus.metrics.kuma.io/")
-}
-
 // Annotations that are being automatically set by the Kuma Sidecar Injector.
 const (
 	KumaSidecarInjectedAnnotation                  = "kuma.io/sidecar-injected"

--- a/pkg/plugins/runtime/k8s/metadata/annotations.go
+++ b/pkg/plugins/runtime/k8s/metadata/annotations.go
@@ -70,6 +70,12 @@ const (
 	KumaTrafficExcludeOutboundPorts = "traffic.kuma.io/exclude-outbound-ports"
 )
 
+func IsReservedPrefix(annotation string) bool {
+	return strings.HasPrefix(annotation, "kuma.io/") ||
+		strings.HasPrefix(annotation, "traffic.kuma.io/") ||
+		strings.HasPrefix(annotation, "prometheus.metrics.kuma.io/")
+}
+
 // Annotations that are being automatically set by the Kuma Sidecar Injector.
 const (
 	KumaSidecarInjectedAnnotation                  = "kuma.io/sidecar-injected"

--- a/pkg/plugins/runtime/k8s/webhooks/injector/injector.go
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/injector.go
@@ -143,7 +143,7 @@ func (i *KumaInjector) needInject(pod *kube_core.Pod, ns *kube_core.Namespace) (
 	}
 	if exist {
 		if !enabled {
-			log.V(1).Info("pod has kuma.io/sidecar-injection: disabled label")
+			log.V(1).Info(`pod has "kuma.io/sidecar-injection: disabled" label`)
 		}
 		return enabled, nil
 	}
@@ -157,7 +157,7 @@ func (i *KumaInjector) needInject(pod *kube_core.Pod, ns *kube_core.Namespace) (
 	if exist {
 		log.Info(annotationWarningMsg, "pod", pod.Name, "namespace", ns.Name)
 		if !enabled {
-			log.V(1).Info("pod has kuma.io/sidecar-injection: disabled annotation")
+			log.V(1).Info(`pod has "kuma.io/sidecar-injection: disabled" annotation`)
 		}
 		return enabled, nil
 	}
@@ -168,7 +168,7 @@ func (i *KumaInjector) needInject(pod *kube_core.Pod, ns *kube_core.Namespace) (
 	}
 	if exist {
 		if !enabled {
-			log.V(1).Info("namespace has kuma.io/sidecar-injection: disabled label")
+			log.V(1).Info(`namespace has "kuma.io/sidecar-injection: disabled" label`)
 		}
 		return enabled, nil
 	}
@@ -181,7 +181,7 @@ func (i *KumaInjector) needInject(pod *kube_core.Pod, ns *kube_core.Namespace) (
 	if exist {
 		log.Info(annotationWarningMsg, "namespace", ns.Name)
 		if !enabled {
-			log.V(1).Info("namespace has kuma.io/sidecar-injection: disabled annotation")
+			log.V(1).Info(`namespace has "kuma.io/sidecar-injection: disabled" annotation`)
 		}
 		return enabled, nil
 	}

--- a/pkg/plugins/runtime/k8s/webhooks/injector/injector.go
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/injector.go
@@ -147,16 +147,6 @@ func (i *KumaInjector) needInject(pod *kube_core.Pod, ns *kube_core.Namespace) (
 		}
 		return enabled, nil
 	}
-	enabled, exist, err = metadata.Annotations(ns.Labels).GetEnabled(metadata.KumaSidecarInjectionAnnotation)
-	if err != nil {
-		return false, err
-	}
-	if exist {
-		if !enabled {
-			log.V(1).Info("namespace has kuma.io/sidecar-injection: disabled label")
-		}
-		return enabled, nil
-	}
 
 	// support annotations for backwards compatibility
 	annotationWarningMsg := "WARNING: you are using kuma.io/sidecar-injection as annotation. Please migrate it to label to have strong guarantee that application can only start with sidecar"
@@ -171,6 +161,19 @@ func (i *KumaInjector) needInject(pod *kube_core.Pod, ns *kube_core.Namespace) (
 		}
 		return enabled, nil
 	}
+
+	enabled, exist, err = metadata.Annotations(ns.Labels).GetEnabled(metadata.KumaSidecarInjectionAnnotation)
+	if err != nil {
+		return false, err
+	}
+	if exist {
+		if !enabled {
+			log.V(1).Info("namespace has kuma.io/sidecar-injection: disabled label")
+		}
+		return enabled, nil
+	}
+
+	// support annotations for backwards compatibility
 	enabled, exist, err = metadata.Annotations(ns.Annotations).GetEnabled(metadata.KumaSidecarInjectionAnnotation)
 	if err != nil {
 		return false, err

--- a/pkg/plugins/runtime/k8s/webhooks/injector/injector.go
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/injector.go
@@ -159,11 +159,13 @@ func (i *KumaInjector) needInject(pod *kube_core.Pod, ns *kube_core.Namespace) (
 	}
 
 	// support annotations for backwards compatibility
+	annotationWarningMsg := "WARNING: you are using kuma.io/sidecar-injection as annotation. Please migrate it to label to have strong guarantee that application can only start with sidecar"
 	enabled, exist, err = metadata.Annotations(pod.Annotations).GetEnabled(metadata.KumaSidecarInjectionAnnotation)
 	if err != nil {
 		return false, err
 	}
 	if exist {
+		log.Info(annotationWarningMsg, "pod", pod.Name, "namespace", ns.Name)
 		if !enabled {
 			log.V(1).Info("pod has kuma.io/sidecar-injection: disabled annotation")
 		}
@@ -174,6 +176,7 @@ func (i *KumaInjector) needInject(pod *kube_core.Pod, ns *kube_core.Namespace) (
 		return false, err
 	}
 	if exist {
+		log.Info(annotationWarningMsg, "namespace", ns.Name)
 		if !enabled {
 			log.V(1).Info("namespace has kuma.io/sidecar-injection: disabled annotation")
 		}

--- a/pkg/plugins/runtime/k8s/webhooks/injector/injector.go
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/injector.go
@@ -129,7 +129,37 @@ func (i *KumaInjector) needInject(pod *kube_core.Pod, ns *kube_core.Namespace) (
 		log.V(1).Info("pod fulfills exception requirements")
 		return false, nil
 	}
-	enabled, exist, err := metadata.Annotations(pod.Annotations).GetEnabled(metadata.KumaSidecarInjectionAnnotation)
+
+	for _, container := range pod.Spec.Containers {
+		if container.Name == util.KumaSidecarContainerName {
+			log.V(1).Info("pod already has Kuma sidecar")
+			return false, nil
+		}
+	}
+
+	enabled, exist, err := metadata.Annotations(pod.Labels).GetEnabled(metadata.KumaSidecarInjectionAnnotation)
+	if err != nil {
+		return false, err
+	}
+	if exist {
+		if !enabled {
+			log.V(1).Info("pod has kuma.io/sidecar-injection: disabled label")
+		}
+		return enabled, nil
+	}
+	enabled, exist, err = metadata.Annotations(ns.Labels).GetEnabled(metadata.KumaSidecarInjectionAnnotation)
+	if err != nil {
+		return false, err
+	}
+	if exist {
+		if !enabled {
+			log.V(1).Info("namespace has kuma.io/sidecar-injection: disabled label")
+		}
+		return enabled, nil
+	}
+
+	// support annotations for backwards compatibility
+	enabled, exist, err = metadata.Annotations(pod.Annotations).GetEnabled(metadata.KumaSidecarInjectionAnnotation)
 	if err != nil {
 		return false, err
 	}

--- a/test/e2e/compatibility/cp_compatibility_kubernetes_multizone.go
+++ b/test/e2e/compatibility/cp_compatibility_kubernetes_multizone.go
@@ -104,7 +104,7 @@ func CpCompatibilityMultizoneKubernetes() {
 
 		err = NewClusterSetup().
 			Install(Kuma(core.Zone, zoneDeployOptsFuncs...)).
-			Install(NamespaceWithSidecarInjection(TestNamespace)).
+			Install(NamespaceWithSidecarInjectionOnAnnotation(TestNamespace)).
 			Setup(zoneCluster)
 		Expect(err).ToNot(HaveOccurred())
 

--- a/test/framework/setup.go
+++ b/test/framework/setup.go
@@ -221,6 +221,9 @@ metadata:
 `, namespace))
 }
 
+// NamespaceWithSidecarInjectionOnAnnotation creates namespace with sidecar-injection annotation
+// Since we still support annotations for backwards compatibility, we should also test it.
+// Use NamespaceWithSidecarInjection unless you want to explicitly check backwards compatibility.
 func NamespaceWithSidecarInjectionOnAnnotation(namespace string) InstallFunc {
 	return YamlK8s(fmt.Sprintf(`
 apiVersion: v1

--- a/test/framework/setup.go
+++ b/test/framework/setup.go
@@ -221,6 +221,17 @@ metadata:
 `, namespace))
 }
 
+func NamespaceWithSidecarInjectionOnAnnotation(namespace string) InstallFunc {
+	return YamlK8s(fmt.Sprintf(`
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: %s
+  annotations:
+    kuma.io/sidecar-injection: "enabled"
+`, namespace))
+}
+
 func DemoClientJobK8s(namespace, mesh, destination string) InstallFunc {
 	const name = "demo-job-client"
 	job := &batchv1.Job{

--- a/test/framework/setup.go
+++ b/test/framework/setup.go
@@ -216,7 +216,7 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: %s
-  annotations:
+  labels:
     kuma.io/sidecar-injection: "enabled"
 `, namespace))
 }


### PR DESCRIPTION
### Summary

Added 2 webhooks with the condition on `kuma.io/sidecar-injection` *label*.
This is the only way of filtering pods to which we can inject the sidecar. Right now we are relying on annotation, but to have this guarantee of sidecar injection, we need to rely on label.

I added 2 new hooks
* hook with the condition on namespace with labels `kuma.io/sidecar-injection: enabled` with policy Fail
* hook with the condition on pod with labels `kuma.io/sidecar-injection: enabled` with policy Fail

For backwards compatibility, we still support annotation, so the current hook with Ignore strategy stays as is.

### Issues resolved

Fix #3293

### Documentation

- [X] https://github.com/kumahq/kuma-website/pull/619

### Testing

- [X] Unit tests
- [X] E2E tests
- [ ] Manual testing on Universal
- [X] Manual testing on Kubernetes

### Backwards compatibility

It is still backwards compatible with annotations although we recommend (upgrade.md, docs, logs) using labels now.

- [X] Update [`UPGRADE.md`](UPGRADE.md) with any steps users will need to take
      when upgrading. 
- [X] Add `backport-to-stable` label if the code is backwards compatible. Otherwise, list breaking changes.
