### PR TITLE
feat(kuma-cp): support Gateway request timeouts

### DIFF
--- a/pkg/plugins/runtime/gateway/match/policy.go
+++ b/pkg/plugins/runtime/gateway/match/policy.go
@@ -6,6 +6,7 @@ import (
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	"github.com/kumahq/kuma/pkg/core/policy"
 	"github.com/kumahq/kuma/pkg/core/resources/model"
+	"github.com/kumahq/kuma/pkg/plugins/runtime/gateway/route"
 )
 
 // ToConnectionPolicies casts a ResourceList to a slice of ConnectionPolicy.
@@ -59,4 +60,59 @@ func OldestPolicy(policies []model.Resource) model.Resource {
 	})
 
 	return sorted[0]
+}
+
+// BestConnectionPolicyForDestination returns the retry policy for the collection
+// of forwarding target. This is conceptually a bit subtle because a
+// forwarding target can have multiple destinations, each of which is a
+// distinct service.  However, there are some relatively obvious rules that
+// we can use to determine policy.
+//
+// 1. If all the destinations are the same service, use that policy.
+// 2. If there are multiple destinations, prefer a wildcard policy.
+// 3. Everything else being equal, older policies are preferred.
+func BestConnectionPolicyForDestination(
+	destinations []route.Destination,
+	policyType model.ResourceType,
+) model.Resource {
+	seenNames := map[string]bool{}
+	servicePolicies := map[string][]model.Resource{}
+
+	// Index all the policies by service name.
+	for _, d := range destinations {
+		p, ok := d.Policies[policyType]
+		if !ok {
+			continue
+		}
+
+		if seenNames[p.GetMeta().GetName()] {
+			continue
+		}
+
+		// Index this policy by its destination service.
+		c := p.(policy.ConnectionPolicy)
+		for _, selector := range c.Destinations() {
+			svc := selector.GetMatch()[mesh_proto.ServiceTag]
+			if svc == d.Destination[mesh_proto.ServiceTag] || svc == mesh_proto.MatchAllTag {
+				servicePolicies[svc] = append(servicePolicies[svc], p)
+			}
+		}
+
+		seenNames[p.GetMeta().GetName()] = true
+	}
+
+	var candidates []model.Resource
+
+	// If we are forwarding to multiple services, no one service
+	// would be the most specific match, so we should choose the
+	// wildcard policy. Otherwise, we can just take the oldest of
+	// all the matches, since there's no better way to discriminate.
+	candidates = append(candidates, servicePolicies[mesh_proto.MatchAllTag]...)
+	if len(candidates) == 0 {
+		for _, p := range servicePolicies {
+			candidates = append(candidates, p...)
+		}
+	}
+
+	return OldestPolicy(candidates)
 }

--- a/pkg/plugins/runtime/gateway/match/suite_test.go
+++ b/pkg/plugins/runtime/gateway/match/suite_test.go
@@ -1,0 +1,166 @@
+package match_test
+
+import (
+	"testing"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
+	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
+	model "github.com/kumahq/kuma/pkg/core/resources/model"
+	"github.com/kumahq/kuma/pkg/core/resources/model/rest"
+	"github.com/kumahq/kuma/pkg/plugins/runtime/gateway/match"
+	"github.com/kumahq/kuma/pkg/plugins/runtime/gateway/route"
+	"github.com/kumahq/kuma/pkg/test"
+)
+
+func TestMatches(t *testing.T) {
+	test.RunSpecs(t, "Match Suite")
+}
+
+var _ = Describe("Match Destination Policy", func() {
+	Named := func(name string, resource model.Resource) model.Resource {
+		resource.SetMeta(&rest.ResourceMeta{
+			Type:             string(resource.Descriptor().Name),
+			Mesh:             "default",
+			Name:             name,
+			CreationTime:     time.Now(),
+			ModificationTime: time.Now(),
+		})
+
+		return resource
+	}
+
+	SpecFor := func(svc string) *mesh_proto.Timeout {
+		return &mesh_proto.Timeout{
+			Destinations: []*mesh_proto.Selector{{
+				Match: map[string]string{mesh_proto.ServiceTag: svc},
+			}},
+		}
+	}
+
+	It("should return nil for no policies", func() {
+		// given
+		d := []route.Destination{{}, {}}
+		// then
+		Expect(match.BestConnectionPolicyForDestination(d, core_mesh.TimeoutType)).To(BeNil())
+	})
+
+	It("should deduplicate a single policy for multiple destinations", func() {
+		// given
+		p := Named("default-policy", &core_mesh.TimeoutResource{
+			Spec: &mesh_proto.Timeout{
+				Destinations: []*mesh_proto.Selector{{
+					Match: map[string]string{mesh_proto.ServiceTag: "foo-service"},
+				}, {
+					Match: map[string]string{mesh_proto.ServiceTag: "bar-service"},
+				}, {
+					Match: map[string]string{mesh_proto.ServiceTag: "baz-service"},
+				}},
+			},
+		})
+
+		d := []route.Destination{{
+			Destination: map[string]string{mesh_proto.ServiceTag: "foo-service"},
+			Policies:    map[model.ResourceType]model.Resource{core_mesh.TimeoutType: p},
+		}, {
+			Destination: map[string]string{mesh_proto.ServiceTag: "bar-service"},
+			Policies:    map[model.ResourceType]model.Resource{core_mesh.TimeoutType: p},
+		}, {
+			Destination: map[string]string{mesh_proto.ServiceTag: "baz-service"},
+			Policies:    map[model.ResourceType]model.Resource{core_mesh.TimeoutType: p},
+		}}
+
+		// when
+		policy := match.BestConnectionPolicyForDestination(d, core_mesh.TimeoutType)
+
+		// then
+		Expect(policy).ToNot(BeNil())
+		Expect(policy.GetMeta().GetName()).To(Equal("default-policy"))
+	})
+
+	It("should prefer wildcard policy for multiple destinations", func() {
+		// given
+		d := []route.Destination{{
+			Destination: map[string]string{mesh_proto.ServiceTag: "foo-service"},
+			Policies: map[model.ResourceType]model.Resource{
+				core_mesh.TimeoutType: Named("foo-policy", &core_mesh.TimeoutResource{
+					Spec: SpecFor("foo-service"),
+				}),
+			},
+		}, {
+			Destination: map[string]string{mesh_proto.ServiceTag: "bar-service"},
+			Policies: map[model.ResourceType]model.Resource{
+				core_mesh.TimeoutType: Named("bar-policy", &core_mesh.TimeoutResource{
+					Spec: SpecFor("bar-service"),
+				}),
+			},
+		}, {
+			Destination: map[string]string{mesh_proto.ServiceTag: "baz-service"},
+			Policies: map[model.ResourceType]model.Resource{
+				core_mesh.TimeoutType: Named("wildcard-policy", &core_mesh.TimeoutResource{
+					Spec: SpecFor(mesh_proto.MatchAllTag),
+				}),
+			},
+		}}
+
+		// when
+		policy := match.BestConnectionPolicyForDestination(d, core_mesh.TimeoutType)
+
+		// then
+		Expect(policy).ToNot(BeNil())
+		Expect(policy.GetMeta().GetName()).To(Equal("wildcard-policy"))
+	})
+
+	It("should prefer the oldest policy", func() {
+		TimeFrom := func(spec string) time.Time {
+			t, err := time.Parse(time.RFC822, spec)
+			Expect(err).ToNot(HaveOccurred())
+			return t
+		}
+
+		SetCreationTime := func(r model.Resource, t time.Time) {
+			meta := r.GetMeta().(*rest.ResourceMeta)
+			meta.CreationTime = t
+			r.SetMeta(meta)
+		}
+
+		// given
+		d := []route.Destination{{
+			Destination: map[string]string{mesh_proto.ServiceTag: "foo-service"},
+			Policies: map[model.ResourceType]model.Resource{
+				core_mesh.TimeoutType: Named("foo-policy", &core_mesh.TimeoutResource{
+					Spec: SpecFor("foo-service"),
+				}),
+			},
+		}, {
+			Destination: map[string]string{mesh_proto.ServiceTag: "bar-service"},
+			Policies: map[model.ResourceType]model.Resource{
+				core_mesh.TimeoutType: Named("bar-policy", &core_mesh.TimeoutResource{
+					Spec: SpecFor("bar-service"),
+				}),
+			},
+		}, {
+			Destination: map[string]string{mesh_proto.ServiceTag: "baz-service"},
+			Policies: map[model.ResourceType]model.Resource{
+				core_mesh.TimeoutType: Named("baz-policy", &core_mesh.TimeoutResource{
+					Spec: SpecFor("baz-service"),
+				}),
+			},
+		}}
+
+		SetCreationTime(d[0].Policies[core_mesh.TimeoutType], TimeFrom("02 Jan 06 00:01 UTC"))
+		SetCreationTime(d[1].Policies[core_mesh.TimeoutType], TimeFrom("02 Jan 06 00:00 UTC"))
+		SetCreationTime(d[2].Policies[core_mesh.TimeoutType], TimeFrom("02 Jan 06 00:03 UTC"))
+
+		// when
+		policy := match.BestConnectionPolicyForDestination(d, core_mesh.TimeoutType)
+
+		// then
+		Expect(policy).ToNot(BeNil())
+		Expect(policy.GetMeta().GetName()).To(Equal("bar-policy"))
+	})
+
+})

--- a/pkg/plugins/runtime/gateway/route/configurers.go
+++ b/pkg/plugins/runtime/gateway/route/configurers.go
@@ -487,6 +487,21 @@ func RouteActionRetryOnConditions(conditionNames ...string) RouteConfigurer {
 	})
 }
 
+// RouteActionRequestTimeout sets the total timeout for an upstream request.
+func RouteActionRequestTimeout(timeout time.Duration) RouteConfigurer {
+	if timeout == 0 {
+		return RouteConfigureFunc(nil)
+	}
+
+	return RouteConfigureFunc(func(r *envoy_config_route.Route) error {
+		if p := r.GetRoute(); p != nil {
+			p.Timeout = util_proto.Duration(timeout)
+		}
+
+		return nil
+	})
+}
+
 // VirtualHostRoute creates an option to add the route builder to a
 // virtual host. On execution, the builder will build the route and append
 // it to the virtual host. Since Envoy evaluates route matches in order,

--- a/pkg/plugins/runtime/gateway/testdata/http/01-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/01-gateway-route.yaml
@@ -118,6 +118,7 @@ Routes:
                 baseInterval: 0.025s
                 maxInterval: 0.250s
               retryOn: gateway-error,connect-failure,refused-stream
+            timeout: 15s
             weightedClusters:
               clusters:
               - name: echo-service-5a416c39037aa8f6
@@ -137,6 +138,7 @@ Routes:
                 baseInterval: 0.025s
                 maxInterval: 0.250s
               retryOn: gateway-error,connect-failure,refused-stream
+            timeout: 15s
             weightedClusters:
               clusters:
               - name: echo-service-5a416c39037aa8f6
@@ -156,6 +158,7 @@ Routes:
                 baseInterval: 0.025s
                 maxInterval: 0.250s
               retryOn: gateway-error,connect-failure,refused-stream
+            timeout: 15s
             weightedClusters:
               clusters:
               - name: echo-service-5a416c39037aa8f6

--- a/pkg/plugins/runtime/gateway/testdata/http/02-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/02-gateway-route.yaml
@@ -118,6 +118,7 @@ Routes:
                 baseInterval: 0.025s
                 maxInterval: 0.250s
               retryOn: gateway-error,connect-failure,refused-stream
+            timeout: 15s
             weightedClusters:
               clusters:
               - name: echo-service-5a416c39037aa8f6
@@ -137,6 +138,7 @@ Routes:
                 baseInterval: 0.025s
                 maxInterval: 0.250s
               retryOn: gateway-error,connect-failure,refused-stream
+            timeout: 15s
             weightedClusters:
               clusters:
               - name: echo-service-5a416c39037aa8f6

--- a/pkg/plugins/runtime/gateway/testdata/http/03-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/03-gateway-route.yaml
@@ -118,6 +118,7 @@ Routes:
                 baseInterval: 0.025s
                 maxInterval: 0.250s
               retryOn: gateway-error,connect-failure,refused-stream
+            timeout: 15s
             weightedClusters:
               clusters:
               - name: echo-service-5a416c39037aa8f6

--- a/pkg/plugins/runtime/gateway/testdata/http/04-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/04-gateway-route.yaml
@@ -153,6 +153,7 @@ Routes:
                 baseInterval: 0.025s
                 maxInterval: 0.250s
               retryOn: gateway-error,connect-failure,refused-stream
+            timeout: 15s
             weightedClusters:
               clusters:
               - name: echo-service-5a416c39037aa8f6

--- a/pkg/plugins/runtime/gateway/testdata/http/06-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/06-gateway-route.yaml
@@ -172,6 +172,7 @@ Routes:
                 baseInterval: 0.025s
                 maxInterval: 0.250s
               retryOn: gateway-error,connect-failure,refused-stream
+            timeout: 15s
             weightedClusters:
               clusters:
               - name: echo-service-5a416c39037aa8f6

--- a/pkg/plugins/runtime/gateway/testdata/http/07-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/07-gateway-route.yaml
@@ -118,6 +118,7 @@ Routes:
                 baseInterval: 0.025s
                 maxInterval: 0.250s
               retryOn: gateway-error,connect-failure,refused-stream
+            timeout: 15s
             weightedClusters:
               clusters:
               - name: echo-service-5a416c39037aa8f6
@@ -133,6 +134,7 @@ Routes:
                 baseInterval: 0.025s
                 maxInterval: 0.250s
               retryOn: gateway-error,connect-failure,refused-stream
+            timeout: 15s
             weightedClusters:
               clusters:
               - name: echo-service-5a416c39037aa8f6

--- a/pkg/plugins/runtime/gateway/testdata/http/08-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/08-gateway-route.yaml
@@ -161,6 +161,7 @@ Routes:
                 baseInterval: 0.025s
                 maxInterval: 0.250s
               retryOn: gateway-error,connect-failure,refused-stream
+            timeout: 15s
             weightedClusters:
               clusters:
               - name: exact-service-09493d2d54b2a972
@@ -176,6 +177,7 @@ Routes:
                 baseInterval: 0.025s
                 maxInterval: 0.250s
               retryOn: gateway-error,connect-failure,refused-stream
+            timeout: 15s
             weightedClusters:
               clusters:
               - name: prefix-service-5061ee504b81a555

--- a/pkg/plugins/runtime/gateway/testdata/http/09-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/09-gateway-route.yaml
@@ -120,6 +120,7 @@ Routes:
                 baseInterval: 0.025s
                 maxInterval: 0.250s
               retryOn: gateway-error,connect-failure,refused-stream
+            timeout: 15s
             weightedClusters:
               clusters:
               - name: echo-service-5a416c39037aa8f6

--- a/pkg/plugins/runtime/gateway/testdata/http/10-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/10-gateway-route.yaml
@@ -170,6 +170,7 @@ Routes:
                 baseInterval: 0.025s
                 maxInterval: 0.250s
               retryOn: gateway-error,connect-failure,refused-stream
+            timeout: 15s
             weightedClusters:
               clusters:
               - name: regex-header-match-ad0dd92f37b8a38d
@@ -188,6 +189,7 @@ Routes:
                 baseInterval: 0.025s
                 maxInterval: 0.250s
               retryOn: gateway-error,connect-failure,refused-stream
+            timeout: 15s
             weightedClusters:
               clusters:
               - name: exact-header-match-f6b57a6b55557c81
@@ -206,6 +208,7 @@ Routes:
                 baseInterval: 0.025s
                 maxInterval: 0.250s
               retryOn: gateway-error,connect-failure,refused-stream
+            timeout: 15s
             weightedClusters:
               clusters:
               - name: exact-header-match-f6b57a6b55557c81

--- a/pkg/plugins/runtime/gateway/testdata/http/11-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/11-gateway-route.yaml
@@ -172,6 +172,7 @@ Routes:
                 baseInterval: 0.025s
                 maxInterval: 0.250s
               retryOn: gateway-error,connect-failure,refused-stream
+            timeout: 15s
             weightedClusters:
               clusters:
               - name: regex-query-match-3804d7b8516d7323
@@ -191,6 +192,7 @@ Routes:
                 baseInterval: 0.025s
                 maxInterval: 0.250s
               retryOn: gateway-error,connect-failure,refused-stream
+            timeout: 15s
             weightedClusters:
               clusters:
               - name: exact-query-match-cc1370f58a3b5330
@@ -210,6 +212,7 @@ Routes:
                 baseInterval: 0.025s
                 maxInterval: 0.250s
               retryOn: gateway-error,connect-failure,refused-stream
+            timeout: 15s
             weightedClusters:
               clusters:
               - name: exact-query-match-cc1370f58a3b5330

--- a/pkg/plugins/runtime/gateway/testdata/http/12-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/12-gateway-route.yaml
@@ -123,6 +123,7 @@ Routes:
                 baseInterval: 0.025s
                 maxInterval: 0.250s
               retryOn: gateway-error,connect-failure,refused-stream
+            timeout: 15s
             weightedClusters:
               clusters:
               - name: echo-service-5a416c39037aa8f6
@@ -143,6 +144,7 @@ Routes:
                 baseInterval: 0.025s
                 maxInterval: 0.250s
               retryOn: gateway-error,connect-failure,refused-stream
+            timeout: 15s
             weightedClusters:
               clusters:
               - name: echo-service-5a416c39037aa8f6
@@ -163,6 +165,7 @@ Routes:
                 baseInterval: 0.025s
                 maxInterval: 0.250s
               retryOn: gateway-error,connect-failure,refused-stream
+            timeout: 15s
             weightedClusters:
               clusters:
               - name: echo-service-5a416c39037aa8f6

--- a/pkg/plugins/runtime/gateway/testdata/http/13-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/13-gateway-route.yaml
@@ -204,6 +204,7 @@ Routes:
                 baseInterval: 0.025s
                 maxInterval: 0.250s
               retryOn: gateway-error,connect-failure,refused-stream
+            timeout: 15s
             weightedClusters:
               clusters:
               - name: echo-exact-ad4e3a31db1bf217
@@ -219,6 +220,7 @@ Routes:
                 baseInterval: 0.025s
                 maxInterval: 0.250s
               retryOn: gateway-error,connect-failure,refused-stream
+            timeout: 15s
             weightedClusters:
               clusters:
               - name: echo-prefix-d0e5ba63b0c9b9f0
@@ -234,6 +236,7 @@ Routes:
                 baseInterval: 0.025s
                 maxInterval: 0.250s
               retryOn: gateway-error,connect-failure,refused-stream
+            timeout: 15s
             weightedClusters:
               clusters:
               - name: echo-prefix-d0e5ba63b0c9b9f0
@@ -251,6 +254,7 @@ Routes:
                 baseInterval: 0.025s
                 maxInterval: 0.250s
               retryOn: gateway-error,connect-failure,refused-stream
+            timeout: 15s
             weightedClusters:
               clusters:
               - name: echo-regex-627905e7b1c2eb33

--- a/pkg/plugins/runtime/gateway/testdata/http/14-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/14-gateway-route.yaml
@@ -122,6 +122,7 @@ Routes:
                 baseInterval: 0.025s
                 maxInterval: 0.250s
               retryOn: gateway-error,connect-failure,refused-stream
+            timeout: 15s
             weightedClusters:
               clusters:
               - name: echo-service-5a416c39037aa8f6

--- a/pkg/plugins/runtime/gateway/testdata/http/15-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/15-gateway-route.yaml
@@ -204,6 +204,7 @@ Routes:
                 baseInterval: 0.025s
                 maxInterval: 0.250s
               retryOn: gateway-error,connect-failure,refused-stream
+            timeout: 20s
             weightedClusters:
               clusters:
               - name: api-service-6b688a06cd66f5c9
@@ -219,6 +220,7 @@ Routes:
                 baseInterval: 0.025s
                 maxInterval: 0.250s
               retryOn: gateway-error,connect-failure,refused-stream
+            timeout: 20s
             weightedClusters:
               clusters:
               - name: api-service-6b688a06cd66f5c9
@@ -239,6 +241,7 @@ Routes:
                 baseInterval: 0.025s
                 maxInterval: 0.250s
               retryOn: gateway-error,connect-failure,refused-stream
+            timeout: 10s
             weightedClusters:
               clusters:
               - name: echo-service-b5c2b60cba392c4e

--- a/pkg/plugins/runtime/gateway/testdata/http/16-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/16-gateway-route.yaml
@@ -201,6 +201,7 @@ Routes:
                 baseInterval: 0.025s
                 maxInterval: 0.250s
               retryOn: gateway-error,connect-failure,refused-stream
+            timeout: 15s
             weightedClusters:
               clusters:
               - name: api-service-49c6d22609eca2d2
@@ -216,6 +217,7 @@ Routes:
                 baseInterval: 0.025s
                 maxInterval: 0.250s
               retryOn: gateway-error,connect-failure,refused-stream
+            timeout: 15s
             weightedClusters:
               clusters:
               - name: api-service-49c6d22609eca2d2
@@ -236,6 +238,7 @@ Routes:
                 baseInterval: 0.025s
                 maxInterval: 0.250s
               retryOn: gateway-error,connect-failure,refused-stream
+            timeout: 15s
             weightedClusters:
               clusters:
               - name: echo-service-48cd7f2dbb98df84

--- a/pkg/plugins/runtime/gateway/testdata/http/17-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/17-gateway-route.yaml
@@ -222,6 +222,7 @@ Routes:
                 baseInterval: 0.025s
                 maxInterval: 0.250s
               retryOn: gateway-error,connect-failure,refused-stream
+            timeout: 15s
             weightedClusters:
               clusters:
               - name: api-service-19fcb7995aa98119
@@ -237,6 +238,7 @@ Routes:
                 baseInterval: 0.025s
                 maxInterval: 0.250s
               retryOn: gateway-error,connect-failure,refused-stream
+            timeout: 15s
             weightedClusters:
               clusters:
               - name: api-service-19fcb7995aa98119
@@ -257,6 +259,7 @@ Routes:
                 baseInterval: 0.025s
                 maxInterval: 0.250s
               retryOn: gateway-error,connect-failure,refused-stream
+            timeout: 15s
             weightedClusters:
               clusters:
               - name: echo-service-eb4ea372d99abf73

--- a/pkg/plugins/runtime/gateway/testdata/http/18-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/18-gateway-route.yaml
@@ -115,6 +115,7 @@ Routes:
                 baseInterval: 0.025s
                 maxInterval: 0.250s
               retryOn: gateway-error,connect-failure,refused-stream
+            timeout: 15s
             weightedClusters:
               clusters:
               - name: external-httpbin-2528f53d03636b9d

--- a/pkg/plugins/runtime/gateway/testdata/http/19-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/19-gateway-route.yaml
@@ -127,6 +127,7 @@ Routes:
                 baseInterval: 0.025s
                 maxInterval: 0.250s
               retryOn: gateway-error,connect-failure,refused-stream
+            timeout: 15s
             weightedClusters:
               clusters:
               - name: external-httpbin-374dddb882a5e651

--- a/pkg/plugins/runtime/gateway/testdata/http/20-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/20-gateway-route.yaml
@@ -204,6 +204,7 @@ Routes:
                 baseInterval: 0.025s
                 maxInterval: 0.250s
               retryOn: gateway-error,connect-failure,refused-stream
+            timeout: 20s
             weightedClusters:
               clusters:
               - name: echo-service-dbfe9218dfa3ba0c
@@ -223,6 +224,7 @@ Routes:
                 baseInterval: 0.025s
                 maxInterval: 0.250s
               retryOn: gateway-error,connect-failure,refused-stream
+            timeout: 30s
             weightedClusters:
               clusters:
               - name: echo-service-cff7b41a9764f367
@@ -242,6 +244,7 @@ Routes:
                 baseInterval: 0.025s
                 maxInterval: 0.250s
               retryOn: gateway-error,connect-failure,refused-stream
+            timeout: 10s
             weightedClusters:
               clusters:
               - name: echo-service-b5c2b60cba392c4e

--- a/pkg/plugins/runtime/gateway/testdata/https/01-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/01-gateway-route.yaml
@@ -118,6 +118,7 @@ Routes:
                 baseInterval: 0.025s
                 maxInterval: 0.250s
               retryOn: gateway-error,connect-failure,refused-stream
+            timeout: 15s
             weightedClusters:
               clusters:
               - name: echo-service-5a416c39037aa8f6
@@ -137,6 +138,7 @@ Routes:
                 baseInterval: 0.025s
                 maxInterval: 0.250s
               retryOn: gateway-error,connect-failure,refused-stream
+            timeout: 15s
             weightedClusters:
               clusters:
               - name: echo-service-5a416c39037aa8f6
@@ -156,6 +158,7 @@ Routes:
                 baseInterval: 0.025s
                 maxInterval: 0.250s
               retryOn: gateway-error,connect-failure,refused-stream
+            timeout: 15s
             weightedClusters:
               clusters:
               - name: echo-service-5a416c39037aa8f6

--- a/pkg/plugins/runtime/gateway/testdata/https/02-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/02-gateway-route.yaml
@@ -118,6 +118,7 @@ Routes:
                 baseInterval: 0.025s
                 maxInterval: 0.250s
               retryOn: gateway-error,connect-failure,refused-stream
+            timeout: 15s
             weightedClusters:
               clusters:
               - name: echo-service-5a416c39037aa8f6
@@ -137,6 +138,7 @@ Routes:
                 baseInterval: 0.025s
                 maxInterval: 0.250s
               retryOn: gateway-error,connect-failure,refused-stream
+            timeout: 15s
             weightedClusters:
               clusters:
               - name: echo-service-5a416c39037aa8f6

--- a/pkg/plugins/runtime/gateway/testdata/https/03-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/03-gateway-route.yaml
@@ -147,6 +147,7 @@ Routes:
                 baseInterval: 0.025s
                 maxInterval: 0.250s
               retryOn: gateway-error,connect-failure,refused-stream
+            timeout: 15s
             weightedClusters:
               clusters:
               - name: echo-service-5a416c39037aa8f6

--- a/pkg/plugins/runtime/gateway/testdata/https/04-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/04-gateway-route.yaml
@@ -182,6 +182,7 @@ Routes:
                 baseInterval: 0.025s
                 maxInterval: 0.250s
               retryOn: gateway-error,connect-failure,refused-stream
+            timeout: 15s
             weightedClusters:
               clusters:
               - name: echo-service-5a416c39037aa8f6

--- a/pkg/plugins/runtime/gateway/testdata/https/06-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/06-gateway-route.yaml
@@ -201,6 +201,7 @@ Routes:
                 baseInterval: 0.025s
                 maxInterval: 0.250s
               retryOn: gateway-error,connect-failure,refused-stream
+            timeout: 15s
             weightedClusters:
               clusters:
               - name: echo-service-5a416c39037aa8f6

--- a/pkg/plugins/runtime/gateway/testdata/https/07-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/07-gateway-route.yaml
@@ -147,6 +147,7 @@ Routes:
                 baseInterval: 0.025s
                 maxInterval: 0.250s
               retryOn: gateway-error,connect-failure,refused-stream
+            timeout: 15s
             weightedClusters:
               clusters:
               - name: echo-service-5a416c39037aa8f6
@@ -162,6 +163,7 @@ Routes:
                 baseInterval: 0.025s
                 maxInterval: 0.250s
               retryOn: gateway-error,connect-failure,refused-stream
+            timeout: 15s
             weightedClusters:
               clusters:
               - name: echo-service-5a416c39037aa8f6

--- a/pkg/plugins/runtime/gateway/testdata/https/08-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/08-gateway-route.yaml
@@ -190,6 +190,7 @@ Routes:
                 baseInterval: 0.025s
                 maxInterval: 0.250s
               retryOn: gateway-error,connect-failure,refused-stream
+            timeout: 15s
             weightedClusters:
               clusters:
               - name: exact-service-09493d2d54b2a972
@@ -205,6 +206,7 @@ Routes:
                 baseInterval: 0.025s
                 maxInterval: 0.250s
               retryOn: gateway-error,connect-failure,refused-stream
+            timeout: 15s
             weightedClusters:
               clusters:
               - name: prefix-service-5061ee504b81a555

--- a/pkg/plugins/runtime/gateway/testdata/https/09-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/09-gateway-route.yaml
@@ -149,6 +149,7 @@ Routes:
                 baseInterval: 0.025s
                 maxInterval: 0.250s
               retryOn: gateway-error,connect-failure,refused-stream
+            timeout: 15s
             weightedClusters:
               clusters:
               - name: echo-service-5a416c39037aa8f6

--- a/pkg/plugins/runtime/gateway/testdata/https/10-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/10-gateway-route.yaml
@@ -199,6 +199,7 @@ Routes:
                 baseInterval: 0.025s
                 maxInterval: 0.250s
               retryOn: gateway-error,connect-failure,refused-stream
+            timeout: 15s
             weightedClusters:
               clusters:
               - name: regex-header-match-ad0dd92f37b8a38d
@@ -217,6 +218,7 @@ Routes:
                 baseInterval: 0.025s
                 maxInterval: 0.250s
               retryOn: gateway-error,connect-failure,refused-stream
+            timeout: 15s
             weightedClusters:
               clusters:
               - name: exact-header-match-f6b57a6b55557c81
@@ -235,6 +237,7 @@ Routes:
                 baseInterval: 0.025s
                 maxInterval: 0.250s
               retryOn: gateway-error,connect-failure,refused-stream
+            timeout: 15s
             weightedClusters:
               clusters:
               - name: exact-header-match-f6b57a6b55557c81

--- a/pkg/plugins/runtime/gateway/testdata/https/11-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/11-gateway-route.yaml
@@ -201,6 +201,7 @@ Routes:
                 baseInterval: 0.025s
                 maxInterval: 0.250s
               retryOn: gateway-error,connect-failure,refused-stream
+            timeout: 15s
             weightedClusters:
               clusters:
               - name: regex-query-match-3804d7b8516d7323
@@ -220,6 +221,7 @@ Routes:
                 baseInterval: 0.025s
                 maxInterval: 0.250s
               retryOn: gateway-error,connect-failure,refused-stream
+            timeout: 15s
             weightedClusters:
               clusters:
               - name: exact-query-match-cc1370f58a3b5330
@@ -239,6 +241,7 @@ Routes:
                 baseInterval: 0.025s
                 maxInterval: 0.250s
               retryOn: gateway-error,connect-failure,refused-stream
+            timeout: 15s
             weightedClusters:
               clusters:
               - name: exact-query-match-cc1370f58a3b5330

--- a/pkg/plugins/runtime/gateway/testdata/https/12-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/12-gateway-route.yaml
@@ -152,6 +152,7 @@ Routes:
                 baseInterval: 0.025s
                 maxInterval: 0.250s
               retryOn: gateway-error,connect-failure,refused-stream
+            timeout: 15s
             weightedClusters:
               clusters:
               - name: echo-service-5a416c39037aa8f6
@@ -172,6 +173,7 @@ Routes:
                 baseInterval: 0.025s
                 maxInterval: 0.250s
               retryOn: gateway-error,connect-failure,refused-stream
+            timeout: 15s
             weightedClusters:
               clusters:
               - name: echo-service-5a416c39037aa8f6
@@ -192,6 +194,7 @@ Routes:
                 baseInterval: 0.025s
                 maxInterval: 0.250s
               retryOn: gateway-error,connect-failure,refused-stream
+            timeout: 15s
             weightedClusters:
               clusters:
               - name: echo-service-5a416c39037aa8f6

--- a/pkg/plugins/runtime/gateway/testdata/https/13-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/13-gateway-route.yaml
@@ -233,6 +233,7 @@ Routes:
                 baseInterval: 0.025s
                 maxInterval: 0.250s
               retryOn: gateway-error,connect-failure,refused-stream
+            timeout: 15s
             weightedClusters:
               clusters:
               - name: echo-exact-ad4e3a31db1bf217
@@ -248,6 +249,7 @@ Routes:
                 baseInterval: 0.025s
                 maxInterval: 0.250s
               retryOn: gateway-error,connect-failure,refused-stream
+            timeout: 15s
             weightedClusters:
               clusters:
               - name: echo-prefix-d0e5ba63b0c9b9f0
@@ -263,6 +265,7 @@ Routes:
                 baseInterval: 0.025s
                 maxInterval: 0.250s
               retryOn: gateway-error,connect-failure,refused-stream
+            timeout: 15s
             weightedClusters:
               clusters:
               - name: echo-prefix-d0e5ba63b0c9b9f0
@@ -280,6 +283,7 @@ Routes:
                 baseInterval: 0.025s
                 maxInterval: 0.250s
               retryOn: gateway-error,connect-failure,refused-stream
+            timeout: 15s
             weightedClusters:
               clusters:
               - name: echo-regex-627905e7b1c2eb33

--- a/pkg/plugins/runtime/gateway/testdata/https/14-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/14-gateway-route.yaml
@@ -151,6 +151,7 @@ Routes:
                 baseInterval: 0.025s
                 maxInterval: 0.250s
               retryOn: gateway-error,connect-failure,refused-stream
+            timeout: 15s
             weightedClusters:
               clusters:
               - name: echo-service-5a416c39037aa8f6

--- a/pkg/plugins/runtime/gateway/testdata/https/15-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/15-gateway-route.yaml
@@ -233,6 +233,7 @@ Routes:
                 baseInterval: 0.025s
                 maxInterval: 0.250s
               retryOn: gateway-error,connect-failure,refused-stream
+            timeout: 20s
             weightedClusters:
               clusters:
               - name: api-service-6b688a06cd66f5c9
@@ -248,6 +249,7 @@ Routes:
                 baseInterval: 0.025s
                 maxInterval: 0.250s
               retryOn: gateway-error,connect-failure,refused-stream
+            timeout: 20s
             weightedClusters:
               clusters:
               - name: api-service-6b688a06cd66f5c9
@@ -268,6 +270,7 @@ Routes:
                 baseInterval: 0.025s
                 maxInterval: 0.250s
               retryOn: gateway-error,connect-failure,refused-stream
+            timeout: 10s
             weightedClusters:
               clusters:
               - name: echo-service-b5c2b60cba392c4e

--- a/pkg/plugins/runtime/gateway/testdata/https/16-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/16-gateway-route.yaml
@@ -230,6 +230,7 @@ Routes:
                 baseInterval: 0.025s
                 maxInterval: 0.250s
               retryOn: gateway-error,connect-failure,refused-stream
+            timeout: 15s
             weightedClusters:
               clusters:
               - name: api-service-49c6d22609eca2d2
@@ -245,6 +246,7 @@ Routes:
                 baseInterval: 0.025s
                 maxInterval: 0.250s
               retryOn: gateway-error,connect-failure,refused-stream
+            timeout: 15s
             weightedClusters:
               clusters:
               - name: api-service-49c6d22609eca2d2
@@ -265,6 +267,7 @@ Routes:
                 baseInterval: 0.025s
                 maxInterval: 0.250s
               retryOn: gateway-error,connect-failure,refused-stream
+            timeout: 15s
             weightedClusters:
               clusters:
               - name: echo-service-48cd7f2dbb98df84

--- a/pkg/plugins/runtime/gateway/testdata/https/17-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/17-gateway-route.yaml
@@ -251,6 +251,7 @@ Routes:
                 baseInterval: 0.025s
                 maxInterval: 0.250s
               retryOn: gateway-error,connect-failure,refused-stream
+            timeout: 15s
             weightedClusters:
               clusters:
               - name: api-service-19fcb7995aa98119
@@ -266,6 +267,7 @@ Routes:
                 baseInterval: 0.025s
                 maxInterval: 0.250s
               retryOn: gateway-error,connect-failure,refused-stream
+            timeout: 15s
             weightedClusters:
               clusters:
               - name: api-service-19fcb7995aa98119
@@ -286,6 +288,7 @@ Routes:
                 baseInterval: 0.025s
                 maxInterval: 0.250s
               retryOn: gateway-error,connect-failure,refused-stream
+            timeout: 15s
             weightedClusters:
               clusters:
               - name: echo-service-eb4ea372d99abf73

--- a/pkg/plugins/runtime/gateway/testdata/https/18-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/18-gateway-route.yaml
@@ -144,6 +144,7 @@ Routes:
                 baseInterval: 0.025s
                 maxInterval: 0.250s
               retryOn: gateway-error,connect-failure,refused-stream
+            timeout: 15s
             weightedClusters:
               clusters:
               - name: external-httpbin-2528f53d03636b9d

--- a/pkg/plugins/runtime/gateway/testdata/https/19-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/19-gateway-route.yaml
@@ -156,6 +156,7 @@ Routes:
                 baseInterval: 0.025s
                 maxInterval: 0.250s
               retryOn: gateway-error,connect-failure,refused-stream
+            timeout: 15s
             weightedClusters:
               clusters:
               - name: external-httpbin-374dddb882a5e651

--- a/pkg/plugins/runtime/gateway/testdata/https/20-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/20-gateway-route.yaml
@@ -349,6 +349,7 @@ Routes:
                 baseInterval: 0.025s
                 maxInterval: 0.250s
               retryOn: gateway-error,connect-failure,refused-stream
+            timeout: 20s
             weightedClusters:
               clusters:
               - name: echo-service-dbfe9218dfa3ba0c
@@ -374,6 +375,7 @@ Routes:
                 baseInterval: 0.025s
                 maxInterval: 0.250s
               retryOn: gateway-error,connect-failure,refused-stream
+            timeout: 30s
             weightedClusters:
               clusters:
               - name: echo-service-cff7b41a9764f367
@@ -399,6 +401,7 @@ Routes:
                 baseInterval: 0.025s
                 maxInterval: 0.250s
               retryOn: gateway-error,connect-failure,refused-stream
+            timeout: 10s
             weightedClusters:
               clusters:
               - name: echo-service-b5c2b60cba392c4e


### PR DESCRIPTION
### Summary

Add support for setting the upstream request timeout for Gateway routes.
This uses the same policy selection criteria that we use for upstream
retries.

### Full changelog

N/A

### Issues resolved

Fix #3318

### Documentation

N/A

### Testing

- [x] Unit tests
- [x] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes

### Backwards compatibility

- [ ] ~~Update [`UPGRADE.md`](UPGRADE.md) with any steps users will need to take when upgrading.~~
- [ ] ~~Add `backport-to-stable` label if the code is backwards compatible. Otherwise, list breaking changes~~
