### PR TITLE
ci(.github): remove unnecessary commit message rules

### DIFF
--- a/.github/commitlint.config.js
+++ b/.github/commitlint.config.js
@@ -3,7 +3,9 @@ module.exports = {
   helpUrl:
     "https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#commit-message-format",
   rules: {
+    "body-max-line-length": [0],
     "footer-max-line-length": [0],
     "footer-leading-blank": [0],
+    "header-max-length": [0],
   },
 };


### PR DESCRIPTION
### Summary

We don't care about line lengths ever