### PR TITLE
fix(kuma-cp): set the accesslog policy for Gateway listeners

### DIFF
--- a/pkg/plugins/runtime/gateway/filter_chain_generator.go
+++ b/pkg/plugins/runtime/gateway/filter_chain_generator.go
@@ -19,6 +19,7 @@ import (
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	system_proto "github.com/kumahq/kuma/api/system/v1alpha1"
 	"github.com/kumahq/kuma/pkg/core/datasource"
+	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	"github.com/kumahq/kuma/pkg/core/validators"
 	core_xds "github.com/kumahq/kuma/pkg/core/xds"
 	"github.com/kumahq/kuma/pkg/tls"
@@ -273,15 +274,19 @@ func newFilterChain(ctx xds_context.Context, info *GatewayResourceInfo) *envoy_l
 	builder.Configure(
 		envoy_listeners.DefaultCompressorFilter(),
 		envoy_listeners.Tracing(info.Proxy.Policies.TracingBackend, service),
-		// TODO(jpeach) Logging policy doesn't work at all. The logging backend is
-		// selected by matching against outbound service names, and gateway dataplanes
-		// don't have any of those.
+		// In mesh proxies, the access log is configured on the outbound
+		// listener, which is why we index the Logs slice by destination
+		// service name.  A Gateway listener by definition forwards traffic
+		// to multiple destinations, so rather than making up some arbitrary
+		// rules about which destination service we should accept here, we
+		// match the log policy for the generic pass through service. This
+		// will be the only policy available for a Dataplane with no outbounds.
 		envoy_listeners.HttpAccessLog(
 			ctx.Mesh.Resource.Meta.GetName(),
 			envoy.TrafficDirectionInbound,
-			service, // Source service is the gateway service.
-			"*",     // Destination service could be anywhere, depending on the routes.
-			info.Proxy.Policies.Logs[service],
+			service,                // Source service is the gateway service.
+			mesh_proto.MatchAllTag, // Destination service could be anywhere, depending on the routes.
+			info.Proxy.Policies.Logs[core_mesh.PassThroughService],
 			info.Proxy,
 		),
 	)

--- a/pkg/plugins/runtime/gateway/testdata/04-gateway-listener.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/04-gateway-listener.yaml
@@ -9,6 +9,15 @@ Resources:
       - name: envoy.filters.network.http_connection_manager
         typedConfig:
           '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+          accessLog:
+          - name: envoy.access_loggers.file
+            typedConfig:
+              '@type': type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog
+              logFormat:
+                textFormatSource:
+                  inlineString: |
+                    [%START_TIME%] logging "%REQ(:method)% %REQ(x-envoy-original-path?:path)% %PROTOCOL%" %RESPONSE_CODE% %RESPONSE_FLAGS% %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(x-envoy-upstream-service-time)% "%REQ(x-forwarded-for)%" "%REQ(user-agent)%" "%REQ(x-b3-traceid?x-datadog-traceid)%" "%REQ(x-request-id)%" "%REQ(:authority)%" "gateway-default" "*" "192.168.1.1" "%UPSTREAM_HOST%"
+              path: /tmp/access.log
           commonHttpProtocolOptions:
             headersWithUnderscoresAction: REJECT_REQUEST
             idleTimeout: 300s


### PR DESCRIPTION
### Summary

Gateway listeners can forward to any destination, and don't have
outbounds. This means that the only available log policy is the one that
matches the implict "pass_through" outbound. In practice, the this means
that the matching policy should have a wildcard destination service.

### Full changelog

N/A

### Issues resolved

Fix #3316

### Documentation

N/A

### Testing

- [x] Unit tests
- [x] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes

### Backwards compatibility

- [ ] ~~Update [`UPGRADE.md`](UPGRADE.md) with any steps users will need to take when upgrading.~~
- [ ] ~~Add `backport-to-stable` label if the code is backwards compatible. Otherwise, list breaking changes.~~
