### PR TITLE
feat(kmesh-cp) add kubernetes tags automatically

### DIFF
--- a/pkg/plugins/runtime/k8s/controllers/inbound_converter.go
+++ b/pkg/plugins/runtime/k8s/controllers/inbound_converter.go
@@ -12,6 +12,8 @@ import (
 	util_k8s "github.com/kumahq/kuma/pkg/plugins/runtime/k8s/util"
 )
 
+const NamespaceTag = "k8s.kuma.io/namespace"
+
 func inboundForService(zone string, pod *kube_core.Pod, service *kube_core.Service) (ifaces []*mesh_proto.Dataplane_Networking_Inbound) {
 	for _, svcPort := range service.Spec.Ports {
 		if svcPort.Protocol != "" && svcPort.Protocol != kube_core.ProtocolTCP {
@@ -131,6 +133,7 @@ func InboundTagsForService(zone string, pod *kube_core.Pod, svc *kube_core.Servi
 	if tags == nil {
 		tags = make(map[string]string)
 	}
+	tags[NamespaceTag] = pod.Namespace
 	tags[mesh_proto.ServiceTag] = util_k8s.ServiceTagFor(svc, svcPort)
 	if zone != "" {
 		tags[mesh_proto.ZoneTag] = zone
@@ -174,6 +177,7 @@ func InboundTagsForPod(zone string, pod *kube_core.Pod) map[string]string {
 	if tags == nil {
 		tags = make(map[string]string)
 	}
+	tags[NamespaceTag] = pod.Namespace
 	tags[mesh_proto.ServiceTag] = fmt.Sprintf("%s_%s_svc", nameFromPod(pod), pod.Namespace)
 	if zone != "" {
 		tags[mesh_proto.ZoneTag] = zone

--- a/pkg/plugins/runtime/k8s/controllers/inbound_converter.go
+++ b/pkg/plugins/runtime/k8s/controllers/inbound_converter.go
@@ -2,6 +2,7 @@ package controllers
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -12,7 +13,11 @@ import (
 	util_k8s "github.com/kumahq/kuma/pkg/plugins/runtime/k8s/util"
 )
 
-const NamespaceTag = "k8s.kuma.io/namespace"
+const (
+	KubeNamespaceTag = "k8s.kuma.io/namespace"
+	KubeServiceTag   = "k8s.kuma.io/service-name"
+	KubePortTag      = "k8s.kuma.io/service-port"
+)
 
 func inboundForService(zone string, pod *kube_core.Pod, service *kube_core.Service) (ifaces []*mesh_proto.Dataplane_Networking_Inbound) {
 	for _, svcPort := range service.Spec.Ports {
@@ -133,7 +138,9 @@ func InboundTagsForService(zone string, pod *kube_core.Pod, svc *kube_core.Servi
 	if tags == nil {
 		tags = make(map[string]string)
 	}
-	tags[NamespaceTag] = pod.Namespace
+	tags[KubeNamespaceTag] = pod.Namespace
+	tags[KubeServiceTag] = svc.Name
+	tags[KubePortTag] = strconv.Itoa(int(svcPort.Port))
 	tags[mesh_proto.ServiceTag] = util_k8s.ServiceTagFor(svc, svcPort)
 	if zone != "" {
 		tags[mesh_proto.ZoneTag] = zone
@@ -177,7 +184,7 @@ func InboundTagsForPod(zone string, pod *kube_core.Pod) map[string]string {
 	if tags == nil {
 		tags = make(map[string]string)
 	}
-	tags[NamespaceTag] = pod.Namespace
+	tags[KubeNamespaceTag] = pod.Namespace
 	tags[mesh_proto.ServiceTag] = fmt.Sprintf("%s_%s_svc", nameFromPod(pod), pod.Namespace)
 	if zone != "" {
 		tags[mesh_proto.ZoneTag] = zone

--- a/pkg/plugins/runtime/k8s/controllers/pod_controller_test.go
+++ b/pkg/plugins/runtime/k8s/controllers/pod_controller_test.go
@@ -389,12 +389,14 @@ var _ = Describe("PodReconciler", func() {
                 app: sample
                 kuma.io/protocol: http
                 kuma.io/service: example_demo_svc_80
+                k8s.kuma.io/namespace: demo
             - health: {} 
               port: 6060
               tags:
                 app: sample
                 kuma.io/service: example_demo_svc_6061
                 kuma.io/protocol: tcp
+                k8s.kuma.io/namespace: demo
 `))
 	})
 
@@ -463,12 +465,14 @@ var _ = Describe("PodReconciler", func() {
                 app: sample
                 kuma.io/protocol: http
                 kuma.io/service: example_demo_svc_80
+                k8s.kuma.io/namespace: demo
             - health: {} 
               port: 6060
               tags:
                 app: sample
                 kuma.io/service: example_demo_svc_6061
                 kuma.io/protocol: tcp
+                k8s.kuma.io/namespace: demo
 `))
 	})
 

--- a/pkg/plugins/runtime/k8s/controllers/pod_controller_test.go
+++ b/pkg/plugins/runtime/k8s/controllers/pod_controller_test.go
@@ -389,6 +389,8 @@ var _ = Describe("PodReconciler", func() {
                 app: sample
                 kuma.io/protocol: http
                 kuma.io/service: example_demo_svc_80
+                k8s.kuma.io/service-name: example
+                k8s.kuma.io/service-port: "80"
                 k8s.kuma.io/namespace: demo
             - health: {} 
               port: 6060
@@ -396,6 +398,8 @@ var _ = Describe("PodReconciler", func() {
                 app: sample
                 kuma.io/service: example_demo_svc_6061
                 kuma.io/protocol: tcp
+                k8s.kuma.io/service-name: example
+                k8s.kuma.io/service-port: "6061"
                 k8s.kuma.io/namespace: demo
 `))
 	})
@@ -465,6 +469,8 @@ var _ = Describe("PodReconciler", func() {
                 app: sample
                 kuma.io/protocol: http
                 kuma.io/service: example_demo_svc_80
+                k8s.kuma.io/service-name: example
+                k8s.kuma.io/service-port: "80"
                 k8s.kuma.io/namespace: demo
             - health: {} 
               port: 6060
@@ -472,6 +478,8 @@ var _ = Describe("PodReconciler", func() {
                 app: sample
                 kuma.io/service: example_demo_svc_6061
                 kuma.io/protocol: tcp
+                k8s.kuma.io/service-name: example
+                k8s.kuma.io/service-port: "6061"
                 k8s.kuma.io/namespace: demo
 `))
 	})

--- a/pkg/plugins/runtime/k8s/controllers/pod_converter_test.go
+++ b/pkg/plugins/runtime/k8s/controllers/pod_converter_test.go
@@ -2,7 +2,6 @@ package controllers_test
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -139,11 +138,9 @@ var _ = Describe("PodToDataplane(..)", func() {
 			// then
 			Expect(err).ToNot(HaveOccurred())
 
-			actual, err := json.Marshal(dataplane)
+			actual, err := yaml.Marshal(dataplane)
 			Expect(err).ToNot(HaveOccurred())
-			expected, err := os.ReadFile(filepath.Join("testdata", given.dataplane))
-			Expect(err).ToNot(HaveOccurred())
-			Expect(actual).To(MatchYAML(expected))
+			Expect(actual).To(MatchGoldenYAML("testdata", given.dataplane))
 		},
 		Entry("01.Pod with 2 Services", testCase{
 			pod:            "01.pod.yaml",
@@ -378,7 +375,8 @@ var _ = Describe("InboundTagsForService(..)", func() {
 			// given
 			pod := &kube_core.Pod{
 				ObjectMeta: kube_meta.ObjectMeta{
-					Labels: given.podLabels,
+					Namespace: "test",
+					Labels:    given.podLabels,
 				},
 			}
 			// and
@@ -413,8 +411,9 @@ var _ = Describe("InboundTagsForService(..)", func() {
 			isGateway: false,
 			podLabels: nil,
 			expected: map[string]string{
-				"kuma.io/service":  "example_demo_svc_80",
-				"kuma.io/protocol": "tcp", // we want Kuma's default behavior to be explicit to a user
+				"kuma.io/service":       "example_demo_svc_80",
+				"kuma.io/protocol":      "tcp", // we want Kuma's default behavior to be explicit to a user
+				"k8s.kuma.io/namespace": "test",
 			},
 		}),
 		Entry("Pod with labels", testCase{
@@ -424,10 +423,11 @@ var _ = Describe("InboundTagsForService(..)", func() {
 				"version": "0.1",
 			},
 			expected: map[string]string{
-				"app":              "example",
-				"version":          "0.1",
-				"kuma.io/service":  "example_demo_svc_80",
-				"kuma.io/protocol": "tcp", // we want Kuma's default behavior to be explicit to a user
+				"app":                   "example",
+				"version":               "0.1",
+				"kuma.io/service":       "example_demo_svc_80",
+				"kuma.io/protocol":      "tcp", // we want Kuma's default behavior to be explicit to a user
+				"k8s.kuma.io/namespace": "test",
 			},
 		}),
 		Entry("Pod with `service` label", testCase{
@@ -438,10 +438,11 @@ var _ = Describe("InboundTagsForService(..)", func() {
 				"version":         "0.1",
 			},
 			expected: map[string]string{
-				"app":              "example",
-				"version":          "0.1",
-				"kuma.io/service":  "example_demo_svc_80",
-				"kuma.io/protocol": "tcp", // we want Kuma's default behavior to be explicit to a user
+				"app":                   "example",
+				"version":               "0.1",
+				"kuma.io/service":       "example_demo_svc_80",
+				"kuma.io/protocol":      "tcp", // we want Kuma's default behavior to be explicit to a user
+				"k8s.kuma.io/namespace": "test",
 			},
 		}),
 		Entry("Service with a `<port>.service.kuma.io/protocol` annotation and an unknown value", testCase{
@@ -454,10 +455,11 @@ var _ = Describe("InboundTagsForService(..)", func() {
 				"80.service.kuma.io/protocol": "not-yet-supported-protocol",
 			},
 			expected: map[string]string{
-				"app":              "example",
-				"version":          "0.1",
-				"kuma.io/service":  "example_demo_svc_80",
-				"kuma.io/protocol": "not-yet-supported-protocol", // we want Kuma's behavior to be straightforward to a user (just copy annotation value "as is")
+				"app":                   "example",
+				"version":               "0.1",
+				"kuma.io/service":       "example_demo_svc_80",
+				"kuma.io/protocol":      "not-yet-supported-protocol", // we want Kuma's behavior to be straightforward to a user (just copy annotation value "as is")
+				"k8s.kuma.io/namespace": "test",
 			},
 		}),
 		Entry("Service with a `<port>.service.kuma.io/protocol` annotation and a known value", testCase{
@@ -470,10 +472,11 @@ var _ = Describe("InboundTagsForService(..)", func() {
 				"80.service.kuma.io/protocol": "http",
 			},
 			expected: map[string]string{
-				"app":              "example",
-				"version":          "0.1",
-				"kuma.io/service":  "example_demo_svc_80",
-				"kuma.io/protocol": "http",
+				"app":                   "example",
+				"version":               "0.1",
+				"kuma.io/service":       "example_demo_svc_80",
+				"kuma.io/protocol":      "http",
+				"k8s.kuma.io/namespace": "test",
 			},
 		}),
 		Entry("Service with appProtocol and a known value", testCase{
@@ -484,10 +487,11 @@ var _ = Describe("InboundTagsForService(..)", func() {
 			},
 			appProtocol: utilpointer.StringPtr("http"),
 			expected: map[string]string{
-				"app":              "example",
-				"version":          "0.1",
-				"kuma.io/service":  "example_demo_svc_80",
-				"kuma.io/protocol": "http",
+				"app":                   "example",
+				"version":               "0.1",
+				"kuma.io/service":       "example_demo_svc_80",
+				"kuma.io/protocol":      "http",
+				"k8s.kuma.io/namespace": "test",
 			},
 		}),
 		Entry("Inject a zone tag if Zone is set", testCase{
@@ -498,11 +502,12 @@ var _ = Describe("InboundTagsForService(..)", func() {
 				"version": "0.1",
 			},
 			expected: map[string]string{
-				"app":                  "example",
-				"version":              "0.1",
-				mesh_proto.ServiceTag:  "example_demo_svc_80",
-				mesh_proto.ZoneTag:     "zone-1",
-				mesh_proto.ProtocolTag: "tcp",
+				"app":                   "example",
+				"version":               "0.1",
+				mesh_proto.ServiceTag:   "example_demo_svc_80",
+				mesh_proto.ZoneTag:      "zone-1",
+				mesh_proto.ProtocolTag:  "tcp",
+				"k8s.kuma.io/namespace": "test",
 			},
 		}),
 		Entry("Pod with empty labels", testCase{
@@ -512,9 +517,10 @@ var _ = Describe("InboundTagsForService(..)", func() {
 				"version": "",
 			},
 			expected: map[string]string{
-				"app":              "example",
-				"kuma.io/service":  "example_demo_svc_80",
-				"kuma.io/protocol": "tcp",
+				"app":                   "example",
+				"kuma.io/service":       "example_demo_svc_80",
+				"kuma.io/protocol":      "tcp",
+				"k8s.kuma.io/namespace": "test",
 			},
 		}),
 	)

--- a/pkg/plugins/runtime/k8s/controllers/pod_converter_test.go
+++ b/pkg/plugins/runtime/k8s/controllers/pod_converter_test.go
@@ -375,7 +375,7 @@ var _ = Describe("InboundTagsForService(..)", func() {
 			// given
 			pod := &kube_core.Pod{
 				ObjectMeta: kube_meta.ObjectMeta{
-					Namespace: "test",
+					Namespace: "demo",
 					Labels:    given.podLabels,
 				},
 			}
@@ -415,7 +415,7 @@ var _ = Describe("InboundTagsForService(..)", func() {
 				"kuma.io/protocol":         "tcp", // we want Kuma's default behavior to be explicit to a user
 				"k8s.kuma.io/service-name": "example",
 				"k8s.kuma.io/service-port": "80",
-				"k8s.kuma.io/namespace":    "test",
+				"k8s.kuma.io/namespace":    "demo",
 			},
 		}),
 		Entry("Pod with labels", testCase{
@@ -431,7 +431,7 @@ var _ = Describe("InboundTagsForService(..)", func() {
 				"kuma.io/protocol":         "tcp", // we want Kuma's default behavior to be explicit to a user
 				"k8s.kuma.io/service-name": "example",
 				"k8s.kuma.io/service-port": "80",
-				"k8s.kuma.io/namespace":    "test",
+				"k8s.kuma.io/namespace":    "demo",
 			},
 		}),
 		Entry("Pod with `service` label", testCase{
@@ -448,7 +448,7 @@ var _ = Describe("InboundTagsForService(..)", func() {
 				"kuma.io/protocol":         "tcp", // we want Kuma's default behavior to be explicit to a user
 				"k8s.kuma.io/service-name": "example",
 				"k8s.kuma.io/service-port": "80",
-				"k8s.kuma.io/namespace":    "test",
+				"k8s.kuma.io/namespace":    "demo",
 			},
 		}),
 		Entry("Service with a `<port>.service.kuma.io/protocol` annotation and an unknown value", testCase{
@@ -467,7 +467,7 @@ var _ = Describe("InboundTagsForService(..)", func() {
 				"kuma.io/protocol":         "not-yet-supported-protocol", // we want Kuma's behavior to be straightforward to a user (just copy annotation value "as is")
 				"k8s.kuma.io/service-name": "example",
 				"k8s.kuma.io/service-port": "80",
-				"k8s.kuma.io/namespace":    "test",
+				"k8s.kuma.io/namespace":    "demo",
 			},
 		}),
 		Entry("Service with a `<port>.service.kuma.io/protocol` annotation and a known value", testCase{
@@ -486,7 +486,7 @@ var _ = Describe("InboundTagsForService(..)", func() {
 				"kuma.io/protocol":         "http",
 				"k8s.kuma.io/service-name": "example",
 				"k8s.kuma.io/service-port": "80",
-				"k8s.kuma.io/namespace":    "test",
+				"k8s.kuma.io/namespace":    "demo",
 			},
 		}),
 		Entry("Service with appProtocol and a known value", testCase{
@@ -503,7 +503,7 @@ var _ = Describe("InboundTagsForService(..)", func() {
 				"kuma.io/protocol":         "http",
 				"k8s.kuma.io/service-name": "example",
 				"k8s.kuma.io/service-port": "80",
-				"k8s.kuma.io/namespace":    "test",
+				"k8s.kuma.io/namespace":    "demo",
 			},
 		}),
 		Entry("Inject a zone tag if Zone is set", testCase{
@@ -521,7 +521,7 @@ var _ = Describe("InboundTagsForService(..)", func() {
 				mesh_proto.ProtocolTag:     "tcp",
 				"k8s.kuma.io/service-name": "example",
 				"k8s.kuma.io/service-port": "80",
-				"k8s.kuma.io/namespace":    "test",
+				"k8s.kuma.io/namespace":    "demo",
 			},
 		}),
 		Entry("Pod with empty labels", testCase{
@@ -536,7 +536,7 @@ var _ = Describe("InboundTagsForService(..)", func() {
 				"kuma.io/protocol":         "tcp",
 				"k8s.kuma.io/service-name": "example",
 				"k8s.kuma.io/service-port": "80",
-				"k8s.kuma.io/namespace":    "test",
+				"k8s.kuma.io/namespace":    "demo",
 			},
 		}),
 	)

--- a/pkg/plugins/runtime/k8s/controllers/pod_converter_test.go
+++ b/pkg/plugins/runtime/k8s/controllers/pod_converter_test.go
@@ -411,9 +411,11 @@ var _ = Describe("InboundTagsForService(..)", func() {
 			isGateway: false,
 			podLabels: nil,
 			expected: map[string]string{
-				"kuma.io/service":       "example_demo_svc_80",
-				"kuma.io/protocol":      "tcp", // we want Kuma's default behavior to be explicit to a user
-				"k8s.kuma.io/namespace": "test",
+				"kuma.io/service":          "example_demo_svc_80",
+				"kuma.io/protocol":         "tcp", // we want Kuma's default behavior to be explicit to a user
+				"k8s.kuma.io/service-name": "example",
+				"k8s.kuma.io/service-port": "80",
+				"k8s.kuma.io/namespace":    "test",
 			},
 		}),
 		Entry("Pod with labels", testCase{
@@ -423,11 +425,13 @@ var _ = Describe("InboundTagsForService(..)", func() {
 				"version": "0.1",
 			},
 			expected: map[string]string{
-				"app":                   "example",
-				"version":               "0.1",
-				"kuma.io/service":       "example_demo_svc_80",
-				"kuma.io/protocol":      "tcp", // we want Kuma's default behavior to be explicit to a user
-				"k8s.kuma.io/namespace": "test",
+				"app":                      "example",
+				"version":                  "0.1",
+				"kuma.io/service":          "example_demo_svc_80",
+				"kuma.io/protocol":         "tcp", // we want Kuma's default behavior to be explicit to a user
+				"k8s.kuma.io/service-name": "example",
+				"k8s.kuma.io/service-port": "80",
+				"k8s.kuma.io/namespace":    "test",
 			},
 		}),
 		Entry("Pod with `service` label", testCase{
@@ -438,11 +442,13 @@ var _ = Describe("InboundTagsForService(..)", func() {
 				"version":         "0.1",
 			},
 			expected: map[string]string{
-				"app":                   "example",
-				"version":               "0.1",
-				"kuma.io/service":       "example_demo_svc_80",
-				"kuma.io/protocol":      "tcp", // we want Kuma's default behavior to be explicit to a user
-				"k8s.kuma.io/namespace": "test",
+				"app":                      "example",
+				"version":                  "0.1",
+				"kuma.io/service":          "example_demo_svc_80",
+				"kuma.io/protocol":         "tcp", // we want Kuma's default behavior to be explicit to a user
+				"k8s.kuma.io/service-name": "example",
+				"k8s.kuma.io/service-port": "80",
+				"k8s.kuma.io/namespace":    "test",
 			},
 		}),
 		Entry("Service with a `<port>.service.kuma.io/protocol` annotation and an unknown value", testCase{
@@ -455,11 +461,13 @@ var _ = Describe("InboundTagsForService(..)", func() {
 				"80.service.kuma.io/protocol": "not-yet-supported-protocol",
 			},
 			expected: map[string]string{
-				"app":                   "example",
-				"version":               "0.1",
-				"kuma.io/service":       "example_demo_svc_80",
-				"kuma.io/protocol":      "not-yet-supported-protocol", // we want Kuma's behavior to be straightforward to a user (just copy annotation value "as is")
-				"k8s.kuma.io/namespace": "test",
+				"app":                      "example",
+				"version":                  "0.1",
+				"kuma.io/service":          "example_demo_svc_80",
+				"kuma.io/protocol":         "not-yet-supported-protocol", // we want Kuma's behavior to be straightforward to a user (just copy annotation value "as is")
+				"k8s.kuma.io/service-name": "example",
+				"k8s.kuma.io/service-port": "80",
+				"k8s.kuma.io/namespace":    "test",
 			},
 		}),
 		Entry("Service with a `<port>.service.kuma.io/protocol` annotation and a known value", testCase{
@@ -472,11 +480,13 @@ var _ = Describe("InboundTagsForService(..)", func() {
 				"80.service.kuma.io/protocol": "http",
 			},
 			expected: map[string]string{
-				"app":                   "example",
-				"version":               "0.1",
-				"kuma.io/service":       "example_demo_svc_80",
-				"kuma.io/protocol":      "http",
-				"k8s.kuma.io/namespace": "test",
+				"app":                      "example",
+				"version":                  "0.1",
+				"kuma.io/service":          "example_demo_svc_80",
+				"kuma.io/protocol":         "http",
+				"k8s.kuma.io/service-name": "example",
+				"k8s.kuma.io/service-port": "80",
+				"k8s.kuma.io/namespace":    "test",
 			},
 		}),
 		Entry("Service with appProtocol and a known value", testCase{
@@ -487,11 +497,13 @@ var _ = Describe("InboundTagsForService(..)", func() {
 			},
 			appProtocol: utilpointer.StringPtr("http"),
 			expected: map[string]string{
-				"app":                   "example",
-				"version":               "0.1",
-				"kuma.io/service":       "example_demo_svc_80",
-				"kuma.io/protocol":      "http",
-				"k8s.kuma.io/namespace": "test",
+				"app":                      "example",
+				"version":                  "0.1",
+				"kuma.io/service":          "example_demo_svc_80",
+				"kuma.io/protocol":         "http",
+				"k8s.kuma.io/service-name": "example",
+				"k8s.kuma.io/service-port": "80",
+				"k8s.kuma.io/namespace":    "test",
 			},
 		}),
 		Entry("Inject a zone tag if Zone is set", testCase{
@@ -502,12 +514,14 @@ var _ = Describe("InboundTagsForService(..)", func() {
 				"version": "0.1",
 			},
 			expected: map[string]string{
-				"app":                   "example",
-				"version":               "0.1",
-				mesh_proto.ServiceTag:   "example_demo_svc_80",
-				mesh_proto.ZoneTag:      "zone-1",
-				mesh_proto.ProtocolTag:  "tcp",
-				"k8s.kuma.io/namespace": "test",
+				"app":                      "example",
+				"version":                  "0.1",
+				mesh_proto.ServiceTag:      "example_demo_svc_80",
+				mesh_proto.ZoneTag:         "zone-1",
+				mesh_proto.ProtocolTag:     "tcp",
+				"k8s.kuma.io/service-name": "example",
+				"k8s.kuma.io/service-port": "80",
+				"k8s.kuma.io/namespace":    "test",
 			},
 		}),
 		Entry("Pod with empty labels", testCase{
@@ -517,10 +531,12 @@ var _ = Describe("InboundTagsForService(..)", func() {
 				"version": "",
 			},
 			expected: map[string]string{
-				"app":                   "example",
-				"kuma.io/service":       "example_demo_svc_80",
-				"kuma.io/protocol":      "tcp",
-				"k8s.kuma.io/namespace": "test",
+				"app":                      "example",
+				"kuma.io/service":          "example_demo_svc_80",
+				"kuma.io/protocol":         "tcp",
+				"k8s.kuma.io/service-name": "example",
+				"k8s.kuma.io/service-port": "80",
+				"k8s.kuma.io/namespace":    "test",
 			},
 		}),
 	)

--- a/pkg/plugins/runtime/k8s/controllers/testdata/01.dataplane.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/01.dataplane.yaml
@@ -5,35 +5,39 @@ spec:
   networking:
     address: 192.168.0.1
     inbound:
-      - port: 8080
-        tags:
-          app: example
-          kuma.io/protocol: http
-          kuma.io/service: example_demo_svc_80
-          version: "0.1"
-          kuma.io/zone: "zone-1"
-      - port: 8443
-        tags:
-          app: example
-          kuma.io/protocol: tcp
-          kuma.io/service: example_demo_svc_443
-          version: "0.1"
-          kuma.io/zone: "zone-1"
-      - port: 7070
-        health:
-          ready: true
-        tags:
-          app: example
-          kuma.io/protocol: MONGO
-          kuma.io/service: sample_playground_svc_7071
-          version: "0.1"
-          kuma.io/zone: "zone-1"
-      - port: 6060
-        health:
-          ready: true
-        tags:
-          app: example
-          kuma.io/protocol: tcp
-          kuma.io/service: sample_playground_svc_6061
-          version: "0.1"
-          kuma.io/zone: "zone-1"
+    - port: 8080
+      tags:
+        app: example
+        k8s.kuma.io/namespace: demo
+        kuma.io/protocol: http
+        kuma.io/service: example_demo_svc_80
+        kuma.io/zone: zone-1
+        version: "0.1"
+    - port: 8443
+      tags:
+        app: example
+        k8s.kuma.io/namespace: demo
+        kuma.io/protocol: tcp
+        kuma.io/service: example_demo_svc_443
+        kuma.io/zone: zone-1
+        version: "0.1"
+    - health:
+        ready: true
+      port: 7070
+      tags:
+        app: example
+        k8s.kuma.io/namespace: demo
+        kuma.io/protocol: MONGO
+        kuma.io/service: sample_playground_svc_7071
+        kuma.io/zone: zone-1
+        version: "0.1"
+    - health:
+        ready: true
+      port: 6060
+      tags:
+        app: example
+        k8s.kuma.io/namespace: demo
+        kuma.io/protocol: tcp
+        kuma.io/service: sample_playground_svc_6061
+        kuma.io/zone: zone-1
+        version: "0.1"

--- a/pkg/plugins/runtime/k8s/controllers/testdata/01.dataplane.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/01.dataplane.yaml
@@ -9,6 +9,8 @@ spec:
       tags:
         app: example
         k8s.kuma.io/namespace: demo
+        k8s.kuma.io/service-name: example
+        k8s.kuma.io/service-port: "80"
         kuma.io/protocol: http
         kuma.io/service: example_demo_svc_80
         kuma.io/zone: zone-1
@@ -17,6 +19,8 @@ spec:
       tags:
         app: example
         k8s.kuma.io/namespace: demo
+        k8s.kuma.io/service-name: example
+        k8s.kuma.io/service-port: "443"
         kuma.io/protocol: tcp
         kuma.io/service: example_demo_svc_443
         kuma.io/zone: zone-1
@@ -27,6 +31,8 @@ spec:
       tags:
         app: example
         k8s.kuma.io/namespace: demo
+        k8s.kuma.io/service-name: sample
+        k8s.kuma.io/service-port: "7071"
         kuma.io/protocol: MONGO
         kuma.io/service: sample_playground_svc_7071
         kuma.io/zone: zone-1
@@ -37,6 +43,8 @@ spec:
       tags:
         app: example
         k8s.kuma.io/namespace: demo
+        k8s.kuma.io/service-name: sample
+        k8s.kuma.io/service-port: "6061"
         kuma.io/protocol: tcp
         kuma.io/service: sample_playground_svc_6061
         kuma.io/zone: zone-1

--- a/pkg/plugins/runtime/k8s/controllers/testdata/02.dataplane.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/02.dataplane.yaml
@@ -9,6 +9,8 @@ spec:
       tags:
         app: example
         k8s.kuma.io/namespace: demo
+        k8s.kuma.io/service-name: example
+        k8s.kuma.io/service-port: "80"
         kuma.io/protocol: tcp
         kuma.io/service: example_demo_svc_80
         kuma.io/zone: zone-1

--- a/pkg/plugins/runtime/k8s/controllers/testdata/02.dataplane.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/02.dataplane.yaml
@@ -5,19 +5,20 @@ spec:
   networking:
     address: 192.168.0.1
     inbound:
-      - port: 8080
-        tags:
-          app: example
-          kuma.io/protocol: tcp
-          kuma.io/service: example_demo_svc_80
-          version: "0.1"
-          kuma.io/zone: "zone-1"
+    - port: 8080
+      tags:
+        app: example
+        k8s.kuma.io/namespace: demo
+        kuma.io/protocol: tcp
+        kuma.io/service: example_demo_svc_80
+        kuma.io/zone: zone-1
+        version: "0.1"
     outbound:
-      - address: 10.108.144.24
-        port: 443
-        tags:
-          kuma.io/service: test-app_playground_svc_443
-      - address: 10.108.144.24
-        port: 80
-        tags:
-          kuma.io/service: test-app_playground_svc_80
+    - address: 10.108.144.24
+      port: 443
+      tags:
+        kuma.io/service: test-app_playground_svc_443
+    - address: 10.108.144.24
+      port: 80
+      tags:
+        kuma.io/service: test-app_playground_svc_80

--- a/pkg/plugins/runtime/k8s/controllers/testdata/03.dataplane.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/03.dataplane.yaml
@@ -8,6 +8,8 @@ spec:
       tags:
         app: example
         k8s.kuma.io/namespace: demo
+        k8s.kuma.io/service-name: example
+        k8s.kuma.io/service-port: "80"
         kuma.io/protocol: tcp
         kuma.io/service: example_demo_svc_80
         kuma.io/zone: zone-1

--- a/pkg/plugins/runtime/k8s/controllers/testdata/03.dataplane.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/03.dataplane.yaml
@@ -7,7 +7,8 @@ spec:
     gateway:
       tags:
         app: example
-        kuma.io/service: example_demo_svc_80
+        k8s.kuma.io/namespace: demo
         kuma.io/protocol: tcp
+        kuma.io/service: example_demo_svc_80
+        kuma.io/zone: zone-1
         version: "0.1"
-        kuma.io/zone: "zone-1"

--- a/pkg/plugins/runtime/k8s/controllers/testdata/04.dataplane.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/04.dataplane.yaml
@@ -5,28 +5,29 @@ spec:
   networking:
     address: 192.168.0.1
     inbound:
-      - port: 8080
-        tags:
-          app: example
-          kuma.io/protocol: tcp
-          kuma.io/service: example_demo_svc_80
-          version: "0.1"
-          kuma.io/zone: "zone-1"
+    - port: 8080
+      tags:
+        app: example
+        k8s.kuma.io/namespace: demo
+        kuma.io/protocol: tcp
+        kuma.io/service: example_demo_svc_80
+        kuma.io/zone: zone-1
+        version: "0.1"
     outbound:
-      - address: 10.108.144.25
-        port: 80
-        tags:
-          kuma.io/service: second-test-app_playground_svc_80
-      - address: 10.108.144.24
-        port: 443
-        tags:
-          kuma.io/service: test-app_playground_svc_443
-      - address: 10.108.144.24
-        port: 80
-        tags:
-          kuma.io/service: test-app_playground_svc_80
+    - address: 10.108.144.25
+      port: 80
+      tags:
+        kuma.io/service: second-test-app_playground_svc_80
+    - address: 10.108.144.24
+      port: 443
+      tags:
+        kuma.io/service: test-app_playground_svc_443
+    - address: 10.108.144.24
+      port: 80
+      tags:
+        kuma.io/service: test-app_playground_svc_80
     transparentProxying:
       directAccessServices:
-        - '*'
+      - '*'
       redirectPortInbound: 15006
       redirectPortOutbound: 15001

--- a/pkg/plugins/runtime/k8s/controllers/testdata/04.dataplane.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/04.dataplane.yaml
@@ -9,6 +9,8 @@ spec:
       tags:
         app: example
         k8s.kuma.io/namespace: demo
+        k8s.kuma.io/service-name: example
+        k8s.kuma.io/service-port: "80"
         kuma.io/protocol: tcp
         kuma.io/service: example_demo_svc_80
         kuma.io/zone: zone-1

--- a/pkg/plugins/runtime/k8s/controllers/testdata/05.dataplane.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/05.dataplane.yaml
@@ -5,29 +5,30 @@ spec:
   networking:
     address: 192.168.0.1
     inbound:
-      - port: 8080
-        tags:
-          app: example
-          kuma.io/protocol: tcp
-          kuma.io/service: example_demo_svc_80
-          version: "0.1"
-          kuma.io/zone: "zone-1"
+    - port: 8080
+      tags:
+        app: example
+        k8s.kuma.io/namespace: demo
+        kuma.io/protocol: tcp
+        kuma.io/service: example_demo_svc_80
+        kuma.io/zone: zone-1
+        version: "0.1"
     outbound:
-      - address: 10.108.144.25
-        port: 80
-        tags:
-          kuma.io/service: second-test-app_playground_svc_80
-      - address: 10.108.144.24
-        port: 443
-        tags:
-          kuma.io/service: test-app_playground_svc_443
-      - address: 10.108.144.24
-        port: 80
-        tags:
-          kuma.io/service: test-app_playground_svc_80
+    - address: 10.108.144.25
+      port: 80
+      tags:
+        kuma.io/service: second-test-app_playground_svc_80
+    - address: 10.108.144.24
+      port: 443
+      tags:
+        kuma.io/service: test-app_playground_svc_443
+    - address: 10.108.144.24
+      port: 80
+      tags:
+        kuma.io/service: test-app_playground_svc_80
     transparentProxying:
       directAccessServices:
-        - test-app_playground_svc_80
-        - test-app_playground_svc_443
+      - test-app_playground_svc_80
+      - test-app_playground_svc_443
       redirectPortInbound: 15006
       redirectPortOutbound: 15001

--- a/pkg/plugins/runtime/k8s/controllers/testdata/05.dataplane.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/05.dataplane.yaml
@@ -9,6 +9,8 @@ spec:
       tags:
         app: example
         k8s.kuma.io/namespace: demo
+        k8s.kuma.io/service-name: example
+        k8s.kuma.io/service-port: "80"
         kuma.io/protocol: tcp
         kuma.io/service: example_demo_svc_80
         kuma.io/zone: zone-1

--- a/pkg/plugins/runtime/k8s/controllers/testdata/06.dataplane.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/06.dataplane.yaml
@@ -9,6 +9,8 @@ spec:
       tags:
         app: example
         k8s.kuma.io/namespace: demo
+        k8s.kuma.io/service-name: example
+        k8s.kuma.io/service-port: "80"
         kuma.io/instance: example
         kuma.io/protocol: tcp
         kuma.io/service: example_demo_svc_80
@@ -18,6 +20,8 @@ spec:
       tags:
         app: example
         k8s.kuma.io/namespace: demo
+        k8s.kuma.io/service-name: example
+        k8s.kuma.io/service-port: "443"
         kuma.io/instance: example
         kuma.io/protocol: tcp
         kuma.io/service: example_demo_svc_443

--- a/pkg/plugins/runtime/k8s/controllers/testdata/06.dataplane.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/06.dataplane.yaml
@@ -5,25 +5,27 @@ spec:
   networking:
     address: 192.168.0.1
     inbound:
-      - port: 8080
-        tags:
-          app: example
-          kuma.io/instance: example
-          kuma.io/protocol: tcp
-          kuma.io/service: example_demo_svc_80
-          version: "0.1"
-          kuma.io/zone: "zone-1"
-      - port: 8443
-        tags:
-          app: example
-          kuma.io/instance: example
-          kuma.io/protocol: tcp
-          kuma.io/service: example_demo_svc_443
-          version: "0.1"
-          kuma.io/zone: "zone-1"
+    - port: 8080
+      tags:
+        app: example
+        k8s.kuma.io/namespace: demo
+        kuma.io/instance: example
+        kuma.io/protocol: tcp
+        kuma.io/service: example_demo_svc_80
+        kuma.io/zone: zone-1
+        version: "0.1"
+    - port: 8443
+      tags:
+        app: example
+        k8s.kuma.io/namespace: demo
+        kuma.io/instance: example
+        kuma.io/protocol: tcp
+        kuma.io/service: example_demo_svc_443
+        kuma.io/zone: zone-1
+        version: "0.1"
     outbound:
-      - address: 10.244.0.25
-        port: 80
-        tags:
-          kuma.io/instance: test-app-0
-          kuma.io/service: test-app_playground_svc_80
+    - address: 10.244.0.25
+      port: 80
+      tags:
+        kuma.io/instance: test-app-0
+        kuma.io/service: test-app_playground_svc_80

--- a/pkg/plugins/runtime/k8s/controllers/testdata/07.dataplane.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/07.dataplane.yaml
@@ -14,6 +14,8 @@ spec:
       tags:
         app: example
         k8s.kuma.io/namespace: demo
+        k8s.kuma.io/service-name: sample
+        k8s.kuma.io/service-port: "7071"
         kuma.io/protocol: tcp
         kuma.io/service: sample_playground_svc_7071
         kuma.io/zone: zone-1

--- a/pkg/plugins/runtime/k8s/controllers/testdata/07.dataplane.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/07.dataplane.yaml
@@ -10,10 +10,11 @@ spec:
   networking:
     address: 192.168.0.1
     inbound:
-      - port: 7070
-        tags:
-          app: example
-          kuma.io/protocol: tcp
-          kuma.io/service: sample_playground_svc_7071
-          version: "0.1"
-          kuma.io/zone: "zone-1"
+    - port: 7070
+      tags:
+        app: example
+        k8s.kuma.io/namespace: demo
+        kuma.io/protocol: tcp
+        kuma.io/service: sample_playground_svc_7071
+        kuma.io/zone: zone-1
+        version: "0.1"

--- a/pkg/plugins/runtime/k8s/controllers/testdata/08.dataplane.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/08.dataplane.yaml
@@ -9,6 +9,8 @@ spec:
       tags:
         app: example
         k8s.kuma.io/namespace: demo
+        k8s.kuma.io/service-name: example
+        k8s.kuma.io/service-port: "80"
         kuma.io/protocol: tcp
         kuma.io/service: example_demo_svc_80
         kuma.io/zone: zone-1

--- a/pkg/plugins/runtime/k8s/controllers/testdata/08.dataplane.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/08.dataplane.yaml
@@ -5,13 +5,14 @@ spec:
   networking:
     address: 192.168.0.1
     inbound:
-      - port: 8080
-        tags:
-          app: example
-          kuma.io/protocol: tcp
-          kuma.io/service: example_demo_svc_80
-          version: "0.1"
-          kuma.io/zone: "zone-1"
+    - port: 8080
+      tags:
+        app: example
+        k8s.kuma.io/namespace: demo
+        kuma.io/protocol: tcp
+        kuma.io/service: example_demo_svc_80
+        kuma.io/zone: zone-1
+        version: "0.1"
     transparentProxying:
       redirectPortInbound: 15006
       redirectPortOutbound: 15001

--- a/pkg/plugins/runtime/k8s/controllers/testdata/09.dataplane.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/09.dataplane.yaml
@@ -5,10 +5,11 @@ spec:
   networking:
     address: 10.244.0.8
     inbound:
-      - port: 10001
-        tags:
-          app: kuma-ingress
-          kuma.io/protocol: tcp
-          kuma.io/service: kuma-ingress_kuma-system_svc_10001
-          kuma.io/zone: zone-1
-          pod-template-hash: 74c9b794cf
+    - port: 10001
+      tags:
+        app: kuma-ingress
+        k8s.kuma.io/namespace: kuma-system
+        kuma.io/protocol: tcp
+        kuma.io/service: kuma-ingress_kuma-system_svc_10001
+        kuma.io/zone: zone-1
+        pod-template-hash: 74c9b794cf

--- a/pkg/plugins/runtime/k8s/controllers/testdata/09.dataplane.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/09.dataplane.yaml
@@ -9,6 +9,8 @@ spec:
       tags:
         app: kuma-ingress
         k8s.kuma.io/namespace: kuma-system
+        k8s.kuma.io/service-name: kuma-ingress
+        k8s.kuma.io/service-port: "10001"
         kuma.io/protocol: tcp
         kuma.io/service: kuma-ingress_kuma-system_svc_10001
         kuma.io/zone: zone-1

--- a/pkg/plugins/runtime/k8s/controllers/testdata/10.dataplane.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/10.dataplane.yaml
@@ -5,33 +5,36 @@ spec:
   networking:
     address: 192.168.0.1
     inbound:
-      - port: 8080
-        tags:
-          app: example
-          kuma.io/protocol: http
-          kuma.io/service: example_demo_svc_80
-          kuma.io/zone: zone-1
-          version: "0.1"
-      - port: 8443
-        tags:
-          app: example
-          kuma.io/protocol: tcp
-          kuma.io/service: example_demo_svc_443
-          kuma.io/zone: zone-1
-          version: "0.1"
-      - port: 7070
-        tags:
-          app: example
-          kuma.io/protocol: MONGO
-          kuma.io/service: sample_playground_svc_7071
-          kuma.io/zone: zone-1
-          version: "0.1"
+    - port: 8080
+      tags:
+        app: example
+        k8s.kuma.io/namespace: demo
+        kuma.io/protocol: http
+        kuma.io/service: example_demo_svc_80
+        kuma.io/zone: zone-1
+        version: "0.1"
+    - port: 8443
+      tags:
+        app: example
+        k8s.kuma.io/namespace: demo
+        kuma.io/protocol: tcp
+        kuma.io/service: example_demo_svc_443
+        kuma.io/zone: zone-1
+        version: "0.1"
+    - port: 7070
+      tags:
+        app: example
+        k8s.kuma.io/namespace: demo
+        kuma.io/protocol: MONGO
+        kuma.io/service: sample_playground_svc_7071
+        kuma.io/zone: zone-1
+        version: "0.1"
   probes:
     endpoints:
-      - inboundPath: /metrics
-        inboundPort: 8080
-        path: /8080/metrics
-      - inboundPath: /metrics
-        inboundPort: 3001
-        path: /3001/metrics
+    - inboundPath: /metrics
+      inboundPort: 8080
+      path: /8080/metrics
+    - inboundPath: /metrics
+      inboundPort: 3001
+      path: /3001/metrics
     port: 19000

--- a/pkg/plugins/runtime/k8s/controllers/testdata/10.dataplane.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/10.dataplane.yaml
@@ -9,6 +9,8 @@ spec:
       tags:
         app: example
         k8s.kuma.io/namespace: demo
+        k8s.kuma.io/service-name: example
+        k8s.kuma.io/service-port: "80"
         kuma.io/protocol: http
         kuma.io/service: example_demo_svc_80
         kuma.io/zone: zone-1
@@ -17,6 +19,8 @@ spec:
       tags:
         app: example
         k8s.kuma.io/namespace: demo
+        k8s.kuma.io/service-name: example
+        k8s.kuma.io/service-port: "443"
         kuma.io/protocol: tcp
         kuma.io/service: example_demo_svc_443
         kuma.io/zone: zone-1
@@ -25,6 +29,8 @@ spec:
       tags:
         app: example
         k8s.kuma.io/namespace: demo
+        k8s.kuma.io/service-name: sample
+        k8s.kuma.io/service-port: "7071"
         kuma.io/protocol: MONGO
         kuma.io/service: sample_playground_svc_7071
         kuma.io/zone: zone-1

--- a/pkg/plugins/runtime/k8s/controllers/testdata/11.dataplane.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/11.dataplane.yaml
@@ -5,27 +5,30 @@ spec:
   networking:
     address: 192.168.0.1
     inbound:
-      - port: 8080
-        health:
-          ready: true
-        tags:
-          app: example
-          kuma.io/protocol: http
-          kuma.io/service: example_demo_svc_80
-          kuma.io/zone: zone-1
-          version: "0.1"
-      - port: 8443
-        tags:
-          app: example
-          kuma.io/protocol: tcp
-          kuma.io/service: example_demo_svc_443
-          kuma.io/zone: zone-1
-          version: "0.1"
-      - port: 7070
-        health: {}
-        tags:
-          app: example
-          kuma.io/protocol: MONGO
-          kuma.io/service: sample_playground_svc_7071
-          kuma.io/zone: zone-1
-          version: "0.1"
+    - health:
+        ready: true
+      port: 8080
+      tags:
+        app: example
+        k8s.kuma.io/namespace: demo
+        kuma.io/protocol: http
+        kuma.io/service: example_demo_svc_80
+        kuma.io/zone: zone-1
+        version: "0.1"
+    - port: 8443
+      tags:
+        app: example
+        k8s.kuma.io/namespace: demo
+        kuma.io/protocol: tcp
+        kuma.io/service: example_demo_svc_443
+        kuma.io/zone: zone-1
+        version: "0.1"
+    - health: {}
+      port: 7070
+      tags:
+        app: example
+        k8s.kuma.io/namespace: demo
+        kuma.io/protocol: MONGO
+        kuma.io/service: sample_playground_svc_7071
+        kuma.io/zone: zone-1
+        version: "0.1"

--- a/pkg/plugins/runtime/k8s/controllers/testdata/11.dataplane.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/11.dataplane.yaml
@@ -11,6 +11,8 @@ spec:
       tags:
         app: example
         k8s.kuma.io/namespace: demo
+        k8s.kuma.io/service-name: example
+        k8s.kuma.io/service-port: "80"
         kuma.io/protocol: http
         kuma.io/service: example_demo_svc_80
         kuma.io/zone: zone-1
@@ -19,6 +21,8 @@ spec:
       tags:
         app: example
         k8s.kuma.io/namespace: demo
+        k8s.kuma.io/service-name: example
+        k8s.kuma.io/service-port: "443"
         kuma.io/protocol: tcp
         kuma.io/service: example_demo_svc_443
         kuma.io/zone: zone-1
@@ -28,6 +32,8 @@ spec:
       tags:
         app: example
         k8s.kuma.io/namespace: demo
+        k8s.kuma.io/service-name: sample
+        k8s.kuma.io/service-port: "7071"
         kuma.io/protocol: MONGO
         kuma.io/service: sample_playground_svc_7071
         kuma.io/zone: zone-1

--- a/pkg/plugins/runtime/k8s/controllers/testdata/12.dataplane.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/12.dataplane.yaml
@@ -5,27 +5,30 @@ spec:
   networking:
     address: 192.168.0.1
     inbound:
-      - port: 8080
-        health: {}
-        tags:
-          app: example
-          kuma.io/protocol: http
-          kuma.io/service: example_demo_svc_80
-          kuma.io/zone: zone-1
-          version: "0.1"
-      - port: 8443
-        health: {}
-        tags:
-          app: example
-          kuma.io/protocol: tcp
-          kuma.io/service: example_demo_svc_443
-          kuma.io/zone: zone-1
-          version: "0.1"
-      - port: 7070
-        health: {}
-        tags:
-          app: example
-          kuma.io/protocol: MONGO
-          kuma.io/service: sample_playground_svc_7071
-          kuma.io/zone: zone-1
-          version: "0.1"
+    - health: {}
+      port: 8080
+      tags:
+        app: example
+        k8s.kuma.io/namespace: demo
+        kuma.io/protocol: http
+        kuma.io/service: example_demo_svc_80
+        kuma.io/zone: zone-1
+        version: "0.1"
+    - health: {}
+      port: 8443
+      tags:
+        app: example
+        k8s.kuma.io/namespace: demo
+        kuma.io/protocol: tcp
+        kuma.io/service: example_demo_svc_443
+        kuma.io/zone: zone-1
+        version: "0.1"
+    - health: {}
+      port: 7070
+      tags:
+        app: example
+        k8s.kuma.io/namespace: demo
+        kuma.io/protocol: MONGO
+        kuma.io/service: sample_playground_svc_7071
+        kuma.io/zone: zone-1
+        version: "0.1"

--- a/pkg/plugins/runtime/k8s/controllers/testdata/12.dataplane.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/12.dataplane.yaml
@@ -10,6 +10,8 @@ spec:
       tags:
         app: example
         k8s.kuma.io/namespace: demo
+        k8s.kuma.io/service-name: example
+        k8s.kuma.io/service-port: "80"
         kuma.io/protocol: http
         kuma.io/service: example_demo_svc_80
         kuma.io/zone: zone-1
@@ -19,6 +21,8 @@ spec:
       tags:
         app: example
         k8s.kuma.io/namespace: demo
+        k8s.kuma.io/service-name: example
+        k8s.kuma.io/service-port: "443"
         kuma.io/protocol: tcp
         kuma.io/service: example_demo_svc_443
         kuma.io/zone: zone-1
@@ -28,6 +32,8 @@ spec:
       tags:
         app: example
         k8s.kuma.io/namespace: demo
+        k8s.kuma.io/service-name: sample
+        k8s.kuma.io/service-port: "7071"
         kuma.io/protocol: MONGO
         kuma.io/service: sample_playground_svc_7071
         kuma.io/zone: zone-1

--- a/pkg/plugins/runtime/k8s/controllers/testdata/13.dataplane.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/13.dataplane.yaml
@@ -5,13 +5,14 @@ spec:
   networking:
     address: 192.168.0.1
     inbound:
-      - health:
-          ready: true
-        port: 49151
-        tags:
-          app: example
-          kuma.io/instance: example
-          kuma.io/protocol: tcp
-          kuma.io/service: example_demo_svc
-          kuma.io/zone: zone-1
-          version: "0.1"
+    - health:
+        ready: true
+      port: 49151
+      tags:
+        app: example
+        k8s.kuma.io/namespace: demo
+        kuma.io/instance: example
+        kuma.io/protocol: tcp
+        kuma.io/service: example_demo_svc
+        kuma.io/zone: zone-1
+        version: "0.1"

--- a/pkg/plugins/runtime/k8s/controllers/testdata/14.dataplane.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/14.dataplane.yaml
@@ -7,6 +7,7 @@ spec:
     gateway:
       tags:
         app: example
+        k8s.kuma.io/namespace: demo
         kuma.io/instance: example
         kuma.io/protocol: tcp
         kuma.io/service: example_demo_svc

--- a/pkg/plugins/runtime/k8s/controllers/testdata/15.dataplane.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/15.dataplane.yaml
@@ -9,6 +9,8 @@ spec:
       tags:
         app: example
         k8s.kuma.io/namespace: demo
+        k8s.kuma.io/service-name: example
+        k8s.kuma.io/service-port: "80"
         kuma.io/protocol: tcp
         kuma.io/service: example_demo_svc_80
         kuma.io/zone: zone-1

--- a/pkg/plugins/runtime/k8s/controllers/testdata/15.dataplane.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/15.dataplane.yaml
@@ -5,13 +5,14 @@ spec:
   networking:
     address: fd00::1
     inbound:
-      - port: 8080
-        tags:
-          app: example
-          kuma.io/protocol: tcp
-          kuma.io/service: example_demo_svc_80
-          version: "0.1"
-          kuma.io/zone: "zone-1"
+    - port: 8080
+      tags:
+        app: example
+        k8s.kuma.io/namespace: demo
+        kuma.io/protocol: tcp
+        kuma.io/service: example_demo_svc_80
+        kuma.io/zone: zone-1
+        version: "0.1"
     transparentProxying:
       redirectPortInbound: 15006
       redirectPortInboundV6: 15010

--- a/test/e2e/trafficpermission/hybrid/traffic_permission_hybrid.go
+++ b/test/e2e/trafficpermission/hybrid/traffic_permission_hybrid.go
@@ -137,12 +137,7 @@ spec:
 	})
 
 	E2EAfterSuite(func() {
-		err := globalCluster.DeleteKuma(optsGlobal...)
-		Expect(err).ToNot(HaveOccurred())
-		err = globalCluster.DismissCluster()
-		Expect(err).ToNot(HaveOccurred())
-
-		err = zoneUniversal.DeleteKuma(optsZoneUniversal...)
+		err := zoneUniversal.DeleteKuma(optsZoneUniversal...)
 		Expect(err).ToNot(HaveOccurred())
 		err = zoneUniversal.DismissCluster()
 		Expect(err).ToNot(HaveOccurred())
@@ -150,6 +145,11 @@ spec:
 		err = zoneKube.DeleteKuma(optsZoneKube...)
 		Expect(err).ToNot(HaveOccurred())
 		err = zoneKube.DismissCluster()
+		Expect(err).ToNot(HaveOccurred())
+
+		err = globalCluster.DeleteKuma(optsGlobal...)
+		Expect(err).ToNot(HaveOccurred())
+		err = globalCluster.DismissCluster()
 		Expect(err).ToNot(HaveOccurred())
 	})
 
@@ -228,6 +228,33 @@ spec:
   sources:
     - match:
         kuma.io/service: demo-client_kuma-test_svc
+  destinations:
+    - match:
+        kuma.io/service: test-server
+`
+		err := YamlK8s(yaml)(globalCluster)
+		Expect(err).ToNot(HaveOccurred())
+
+		// then
+		trafficAllowed()
+	})
+
+	It("should allow the traffic with k8s.kuma.io/namespace", func() {
+		// given
+		removeDefaultTrafficPermission()
+		trafficBlocked()
+
+		// when
+		yaml := `
+apiVersion: kuma.io/v1alpha1
+kind: TrafficPermission
+mesh: default
+metadata:
+  name: example-on-namespace
+spec:
+  sources:
+    - match:
+        k8s.kuma.io/namespace: kuma-test
   destinations:
     - match:
         kuma.io/service: test-server


### PR DESCRIPTION
### Summary

Add `k8s.kuma.io/namespace` tag automatically so we can build policy based on it.

### Issues resolved

Fix #3367

### Documentation

- [X] https://github.com/kumahq/kuma-website/pull/623

### Testing

- [X] Unit tests
- [X] E2E tests
- [X] No testing on Universal
- [X] Manual testing on Kubernetes

### Backwards compatibility

- [X] No changes in UPGRADE.md
- [X] Add `backport-to-stable` label if the code is backwards compatible. Otherwise, list breaking changes.
