### PR TITLE
test(*): fix postgress tests permissions

### DIFF
--- a/tools/postgres/Dockerfile
+++ b/tools/postgres/Dockerfile
@@ -4,8 +4,8 @@ COPY pg_hba.conf /var/lib/postgresql/pg_hba.conf
 COPY certs/rootCA.crt /var/lib/postgresql/rootCA.crt
 COPY certs/postgres.server.crt /var/lib/postgresql/postgres.server.crt
 COPY certs/postgres.server.key /var/lib/postgresql/postgres.server.key
-RUN chown postgres /var/lib/postgresql/postgres.server.key && \
-    chmod 600 /var/lib/postgresql/postgres.server.key
+RUN chown -R postgres /var/lib/postgresql && \
+	chmod 600 /var/lib/postgresql/postgres.server.key
 CMD ["-c", "ssl=on", "-c", "ssl_cert_file=/var/lib/postgresql/postgres.server.crt", "-c", "ssl_key_file=/var/lib/postgresql/postgres.server.key", "-c", "ssl_ca_file=/var/lib/postgresql/rootCA.crt", "-c", "hba_file=/var/lib/postgresql/pg_hba.conf"]
 FROM postgres:latest AS pg-standard
 


### PR DESCRIPTION
### Summary

Postgres tests were failing on my local machines. It turned out it was a problem with permissions.

### Issues resolved

No issues reported.

### Documentation

No docs

### Testing

- [X] Unit tests
- [ ] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes

### Backwards compatibility

- [X] No UPGRADE.md
- [X] Add `backport-to-stable` label if the code is backwards compatible. Otherwise, list breaking changes.
