### PR TITLE
refactor(runtime/k8s): refactor dp container handling

### DIFF
--- a/pkg/config/plugins/runtime/k8s/config.go
+++ b/pkg/config/plugins/runtime/k8s/config.go
@@ -22,36 +22,38 @@ func DefaultKubernetesRuntimeConfig() *KubernetesRuntimeConfig {
 			VirtualProbesEnabled: true,
 			VirtualProbesPort:    9000,
 			SidecarContainer: SidecarContainer{
-				Image:                 "kuma/kuma-dp:latest",
 				RedirectPortInbound:   15006,
 				RedirectPortInboundV6: 15010,
 				RedirectPortOutbound:  15001,
-				UID:                   5678,
-				GID:                   5678,
-				AdminPort:             9901,
-				DrainTime:             30 * time.Second,
+				DataplaneContainer: DataplaneContainer{
+					Image:     "kuma/kuma-dp:latest",
+					UID:       5678,
+					GID:       5678,
+					AdminPort: 9901,
+					DrainTime: 30 * time.Second,
 
-				ReadinessProbe: SidecarReadinessProbe{
-					InitialDelaySeconds: 1,
-					TimeoutSeconds:      3,
-					PeriodSeconds:       5,
-					SuccessThreshold:    1,
-					FailureThreshold:    12,
-				},
-				LivenessProbe: SidecarLivenessProbe{
-					InitialDelaySeconds: 60,
-					TimeoutSeconds:      3,
-					PeriodSeconds:       5,
-					FailureThreshold:    12,
-				},
-				Resources: SidecarResources{
-					Requests: SidecarResourceRequests{
-						CPU:    "50m",
-						Memory: "64Mi",
+					ReadinessProbe: SidecarReadinessProbe{
+						InitialDelaySeconds: 1,
+						TimeoutSeconds:      3,
+						PeriodSeconds:       5,
+						SuccessThreshold:    1,
+						FailureThreshold:    12,
 					},
-					Limits: SidecarResourceLimits{
-						CPU:    "1000m",
-						Memory: "512Mi",
+					LivenessProbe: SidecarLivenessProbe{
+						InitialDelaySeconds: 60,
+						TimeoutSeconds:      3,
+						PeriodSeconds:       5,
+						FailureThreshold:    12,
+					},
+					Resources: SidecarResources{
+						Requests: SidecarResourceRequests{
+							CPU:    "50m",
+							Memory: "64Mi",
+						},
+						Limits: SidecarResourceLimits{
+							CPU:    "1000m",
+							Memory: "512Mi",
+						},
 					},
 				},
 			},
@@ -144,16 +146,10 @@ type SidecarTraffic struct {
 	ExcludeOutboundPorts []uint32 `yaml:"excludeOutboundPorts" envconfig:"kuma_runtime_kubernetes_sidecar_traffic_exclude_outbound_ports"`
 }
 
-// SidecarContainer defines configuration of the Kuma sidecar container.
-type SidecarContainer struct {
+// DataplaneContainer defines the configuration of a Kuma dataplane proxy container.
+type DataplaneContainer struct {
 	// Image name.
 	Image string `yaml:"image,omitempty" envconfig:"kuma_runtime_kubernetes_injector_sidecar_container_image"`
-	// Redirect port for inbound traffic.
-	RedirectPortInbound uint32 `yaml:"redirectPortInbound,omitempty" envconfig:"kuma_runtime_kubernetes_injector_sidecar_container_redirect_port_inbound"`
-	// Redirect port for inbound IPv6 traffic.
-	RedirectPortInboundV6 uint32 `yaml:"redirectPortInboundV6,omitempty" envconfig:"kuma_runtime_kubernetes_injector_sidecar_container_redirect_port_inbound_v6"`
-	// Redirect port for outbound traffic.
-	RedirectPortOutbound uint32 `yaml:"redirectPortOutbound,omitempty" envconfig:"kuma_runtime_kubernetes_injector_sidecar_container_redirect_port_outbound"`
 	// User ID.
 	UID int64 `yaml:"uid,omitempty" envconfig:"kuma_runtime_kubernetes_injector_sidecar_container_uid"`
 	// Group ID.
@@ -170,6 +166,17 @@ type SidecarContainer struct {
 	Resources SidecarResources `yaml:"resources,omitempty"`
 	// EnvVars are additional environment variables that can be placed on Kuma DP sidecar
 	EnvVars map[string]string `yaml:"envVars" envconfig:"kuma_runtime_kubernetes_injector_sidecar_container_env_vars"`
+}
+
+// SidecarContainer defines configuration of the Kuma sidecar container.
+type SidecarContainer struct {
+	DataplaneContainer `yaml:",inline"`
+	// Redirect port for inbound traffic.
+	RedirectPortInbound uint32 `yaml:"redirectPortInbound,omitempty" envconfig:"kuma_runtime_kubernetes_injector_sidecar_container_redirect_port_inbound"`
+	// Redirect port for inbound IPv6 traffic.
+	RedirectPortInboundV6 uint32 `yaml:"redirectPortInboundV6,omitempty" envconfig:"kuma_runtime_kubernetes_injector_sidecar_container_redirect_port_inbound_v6"`
+	// Redirect port for outbound traffic.
+	RedirectPortOutbound uint32 `yaml:"redirectPortOutbound,omitempty" envconfig:"kuma_runtime_kubernetes_injector_sidecar_container_redirect_port_outbound"`
 }
 
 // SidecarReadinessProbe defines periodic probe of container service readiness.

--- a/pkg/plugins/runtime/k8s/containers/factory.go
+++ b/pkg/plugins/runtime/k8s/containers/factory.go
@@ -1,0 +1,260 @@
+package containers
+
+import (
+	"fmt"
+	"sort"
+	"strconv"
+
+	kube_core "k8s.io/api/core/v1"
+	kube_api "k8s.io/apimachinery/pkg/api/resource"
+	kube_intstr "k8s.io/apimachinery/pkg/util/intstr"
+
+	runtime_k8s "github.com/kumahq/kuma/pkg/config/plugins/runtime/k8s"
+	core_model "github.com/kumahq/kuma/pkg/core/resources/model"
+	"github.com/kumahq/kuma/pkg/plugins/runtime/k8s/metadata"
+)
+
+type EnvVarsByName []kube_core.EnvVar
+
+func (a EnvVarsByName) Len() int      { return len(a) }
+func (a EnvVarsByName) Swap(i, j int) { a[i], a[j] = a[j], a[i] }
+func (a EnvVarsByName) Less(i, j int) bool {
+	return a[i].Name < a[j].Name
+}
+
+type DataplaneProxyFactory struct {
+	ControlPlaneURL    string
+	ControlPlaneCACert string
+	ContainerConfig    runtime_k8s.DataplaneContainer
+	BuiltinDNS         runtime_k8s.BuiltinDNS
+}
+
+func (i *DataplaneProxyFactory) proxyConcurrencyFor(annotations map[string]string) (int64, error) {
+	count, ok, err := metadata.Annotations(annotations).GetUint32(metadata.KumaSidecarConcurrencyAnnotation)
+	if ok {
+		return int64(count), err
+	}
+
+	// Note that validation requires the resource limit is not empty.
+	cpuRequest := kube_api.MustParse(i.ContainerConfig.Resources.Limits.CPU)
+	ncpu := cpuRequest.MilliValue() / 1000
+	if ncpu < 2 {
+		// Only autotune to down to 2 to mitigate the latency
+		// risk if a worker thread blocks.
+		ncpu = 2
+	}
+
+	return ncpu, nil
+}
+
+func meshName(annotations map[string]string, ns *kube_core.Namespace) string {
+	if mesh, exist := metadata.Annotations(annotations).GetString(metadata.KumaMeshAnnotation); exist {
+		return mesh
+	}
+	if mesh, exist := metadata.Annotations(ns.Annotations).GetString(metadata.KumaMeshAnnotation); exist {
+		return mesh
+	}
+	return core_model.DefaultMesh
+}
+
+func (i *DataplaneProxyFactory) NewContainer(
+	annotations map[string]string,
+	ns *kube_core.Namespace,
+) (kube_core.Container, error) {
+	mesh := meshName(annotations, ns)
+	env, err := i.sidecarEnvVars(mesh, annotations)
+	if err != nil {
+		return kube_core.Container{}, err
+	}
+
+	cpuCount, err := i.proxyConcurrencyFor(annotations)
+	if err != nil {
+		return kube_core.Container{}, err
+	}
+
+	args := []string{
+		"run",
+		"--log-level=info",
+	}
+
+	if cpuCount > 0 {
+		args = append(args,
+			"--concurrency="+strconv.FormatInt(cpuCount, 10))
+	}
+
+	return kube_core.Container{
+		Image:           i.ContainerConfig.Image,
+		ImagePullPolicy: kube_core.PullIfNotPresent,
+		Args:            args,
+		Env:             env,
+		SecurityContext: &kube_core.SecurityContext{
+			RunAsUser:  &i.ContainerConfig.UID,
+			RunAsGroup: &i.ContainerConfig.GID,
+		},
+		LivenessProbe: &kube_core.Probe{
+			Handler: kube_core.Handler{
+				HTTPGet: &kube_core.HTTPGetAction{
+					Path: "/ready",
+					Port: kube_intstr.IntOrString{
+						IntVal: int32(i.ContainerConfig.AdminPort),
+					},
+				},
+			},
+			InitialDelaySeconds: i.ContainerConfig.LivenessProbe.InitialDelaySeconds,
+			TimeoutSeconds:      i.ContainerConfig.LivenessProbe.TimeoutSeconds,
+			PeriodSeconds:       i.ContainerConfig.LivenessProbe.PeriodSeconds,
+			SuccessThreshold:    1,
+			FailureThreshold:    i.ContainerConfig.LivenessProbe.FailureThreshold,
+		},
+		ReadinessProbe: &kube_core.Probe{
+			Handler: kube_core.Handler{
+				HTTPGet: &kube_core.HTTPGetAction{
+					Path: "/ready",
+					Port: kube_intstr.IntOrString{
+						IntVal: int32(i.ContainerConfig.AdminPort),
+					},
+				},
+			},
+			InitialDelaySeconds: i.ContainerConfig.ReadinessProbe.InitialDelaySeconds,
+			TimeoutSeconds:      i.ContainerConfig.ReadinessProbe.TimeoutSeconds,
+			PeriodSeconds:       i.ContainerConfig.ReadinessProbe.PeriodSeconds,
+			SuccessThreshold:    i.ContainerConfig.ReadinessProbe.SuccessThreshold,
+			FailureThreshold:    i.ContainerConfig.ReadinessProbe.FailureThreshold,
+		},
+		Resources: kube_core.ResourceRequirements{
+			Requests: kube_core.ResourceList{
+				kube_core.ResourceCPU:    kube_api.MustParse(i.ContainerConfig.Resources.Requests.CPU),
+				kube_core.ResourceMemory: kube_api.MustParse(i.ContainerConfig.Resources.Requests.Memory),
+			},
+			Limits: kube_core.ResourceList{
+				kube_core.ResourceCPU:    kube_api.MustParse(i.ContainerConfig.Resources.Limits.CPU),
+				kube_core.ResourceMemory: kube_api.MustParse(i.ContainerConfig.Resources.Limits.Memory),
+			},
+		},
+	}, nil
+}
+
+func (i *DataplaneProxyFactory) sidecarEnvVars(mesh string, podAnnotations map[string]string) ([]kube_core.EnvVar, error) {
+	envVars := map[string]kube_core.EnvVar{
+		"KUMA_CONTROL_PLANE_URL": {
+			Name:  "KUMA_CONTROL_PLANE_URL",
+			Value: i.ControlPlaneURL,
+		},
+		"KUMA_DATAPLANE_MESH": {
+			Name:  "KUMA_DATAPLANE_MESH",
+			Value: mesh,
+		},
+		"KUMA_DATAPLANE_NAME": {
+			Name: "KUMA_DATAPLANE_NAME",
+			// notice that Pod name might not be available at this time (in case of Deployment, ReplicaSet, etc)
+			// that is why we have to use a runtime reference to POD_NAME instead
+			Value: "$(POD_NAME).$(POD_NAMESPACE)", // variable references get expanded by Kubernetes
+		},
+		"KUMA_DATAPLANE_ADMIN_PORT": {
+			Name:  "KUMA_DATAPLANE_ADMIN_PORT",
+			Value: fmt.Sprintf("%d", i.ContainerConfig.AdminPort),
+		},
+		"KUMA_DATAPLANE_DRAIN_TIME": {
+			Name:  "KUMA_DATAPLANE_DRAIN_TIME",
+			Value: i.ContainerConfig.DrainTime.String(),
+		},
+		"KUMA_DATAPLANE_RUNTIME_TOKEN_PATH": {
+			Name:  "KUMA_DATAPLANE_RUNTIME_TOKEN_PATH",
+			Value: "/var/run/secrets/kubernetes.io/serviceaccount/token",
+		},
+		"KUMA_CONTROL_PLANE_CA_CERT": {
+			Name:  "KUMA_CONTROL_PLANE_CA_CERT",
+			Value: i.ControlPlaneCACert,
+		},
+	}
+	if i.BuiltinDNS.Enabled {
+		envVars["KUMA_DNS_ENABLED"] = kube_core.EnvVar{
+			Name:  "KUMA_DNS_ENABLED",
+			Value: "true",
+		}
+
+		envVars["KUMA_DNS_CORE_DNS_PORT"] = kube_core.EnvVar{
+			Name:  "KUMA_DNS_CORE_DNS_PORT",
+			Value: strconv.FormatInt(int64(i.BuiltinDNS.Port), 10),
+		}
+
+		envVars["KUMA_DNS_CORE_DNS_EMPTY_PORT"] = kube_core.EnvVar{
+			Name:  "KUMA_DNS_CORE_DNS_EMPTY_PORT",
+			Value: strconv.FormatInt(int64(i.BuiltinDNS.Port+1), 10),
+		}
+
+		envVars["KUMA_DNS_ENVOY_DNS_PORT"] = kube_core.EnvVar{
+			Name:  "KUMA_DNS_ENVOY_DNS_PORT",
+			Value: strconv.FormatInt(int64(i.BuiltinDNS.Port+2), 10),
+		}
+
+		envVars["KUMA_DNS_CORE_DNS_BINARY_PATH"] = kube_core.EnvVar{
+			Name:  "KUMA_DNS_CORE_DNS_BINARY_PATH",
+			Value: "coredns",
+		}
+	} else {
+		envVars["KUMA_DNS_ENABLED"] = kube_core.EnvVar{
+			Name:  "KUMA_DNS_ENABLED",
+			Value: "false",
+		}
+	}
+
+	// override defaults with cfg env vars
+	for envName, envVal := range i.ContainerConfig.EnvVars {
+		envVars[envName] = kube_core.EnvVar{
+			Name:  envName,
+			Value: envVal,
+		}
+	}
+
+	// override defaults and cfg env vars with annotations
+	annotationEnvVars, err := metadata.Annotations(podAnnotations).GetMap(metadata.KumaSidecarEnvVarsAnnotation)
+	if err != nil {
+		return nil, err
+	}
+	for envName, envVal := range annotationEnvVars {
+		envVars[envName] = kube_core.EnvVar{
+			Name:  envName,
+			Value: envVal,
+		}
+	}
+
+	var result []kube_core.EnvVar
+	for _, v := range envVars {
+		result = append(result, v)
+	}
+	sort.Stable(EnvVarsByName(result))
+
+	// those values needs to be added before other vars, otherwise expressions like "$(POD_NAME).$(POD_NAMESPACE)" won't be evaluated
+	result = append([]kube_core.EnvVar{
+		{
+			Name: "POD_NAME",
+			ValueFrom: &kube_core.EnvVarSource{
+				FieldRef: &kube_core.ObjectFieldSelector{
+					APIVersion: "v1",
+					FieldPath:  "metadata.name",
+				},
+			},
+		},
+		{
+			Name: "POD_NAMESPACE",
+			ValueFrom: &kube_core.EnvVarSource{
+				FieldRef: &kube_core.ObjectFieldSelector{
+					APIVersion: "v1",
+					FieldPath:  "metadata.namespace",
+				},
+			},
+		},
+		{
+			Name: "INSTANCE_IP",
+			ValueFrom: &kube_core.EnvVarSource{
+				FieldRef: &kube_core.ObjectFieldSelector{
+					APIVersion: "v1",
+					FieldPath:  "status.podIP",
+				},
+			},
+		},
+	}, result...)
+
+	return result, nil
+}


### PR DESCRIPTION
### Summary

Previously part of #3109, this allows creating `kuma-dp` containers outside of the injector package.