### PR TITLE
fix(kuma-cp): use the hostname for gateway stats

### DIFF
--- a/pkg/plugins/runtime/gateway/route_table_generator.go
+++ b/pkg/plugins/runtime/gateway/route_table_generator.go
@@ -10,7 +10,6 @@ import (
 	"github.com/kumahq/kuma/pkg/plugins/runtime/gateway/match"
 	"github.com/kumahq/kuma/pkg/plugins/runtime/gateway/route"
 	xds_context "github.com/kumahq/kuma/pkg/xds/context"
-	envoy_names "github.com/kumahq/kuma/pkg/xds/envoy/names"
 	envoy_routes "github.com/kumahq/kuma/pkg/xds/envoy/routes"
 )
 
@@ -28,7 +27,7 @@ func (r *RouteTableGenerator) GenerateHost(ctx xds_context.Context, info *Gatewa
 	resources := ResourceAggregator{}
 
 	vh := envoy_routes.NewVirtualHostBuilder(info.Proxy.APIVersion).Configure(
-		envoy_routes.CommonVirtualHost(envoy_names.Join(info.Listener.ResourceName, info.Host.Hostname)),
+		envoy_routes.CommonVirtualHost(info.Host.Hostname),
 		envoy_routes.DomainNames(info.Host.Hostname),
 	)
 

--- a/pkg/plugins/runtime/gateway/testdata/http/01-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/01-gateway-route.yaml
@@ -106,7 +106,7 @@ Routes:
       virtualHosts:
       - domains:
         - foo.example.com
-        name: edge-gateway:HTTP:8080:foo.example.com
+        name: foo.example.com
         routes:
         - match:
             path: /
@@ -126,7 +126,7 @@ Routes:
               totalWeight: 1
       - domains:
         - bar.example.com
-        name: edge-gateway:HTTP:8080:bar.example.com
+        name: bar.example.com
         routes:
         - match:
             path: /
@@ -146,7 +146,7 @@ Routes:
               totalWeight: 1
       - domains:
         - '*.example.com'
-        name: edge-gateway:HTTP:8080:*.example.com
+        name: '*.example.com'
         routes:
         - match:
             path: /
@@ -166,7 +166,7 @@ Routes:
               totalWeight: 1
       - domains:
         - '*'
-        name: edge-gateway:HTTP:8080:*
+        name: '*'
 Runtimes:
   Resources: {}
 Secrets:

--- a/pkg/plugins/runtime/gateway/testdata/http/02-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/02-gateway-route.yaml
@@ -106,7 +106,7 @@ Routes:
       virtualHosts:
       - domains:
         - extra.example.com
-        name: edge-gateway:HTTP:8080:extra.example.com
+        name: extra.example.com
         routes:
         - match:
             path: /
@@ -126,7 +126,7 @@ Routes:
               totalWeight: 1
       - domains:
         - '*'
-        name: edge-gateway:HTTP:8080:*
+        name: '*'
         routes:
         - match:
             path: /

--- a/pkg/plugins/runtime/gateway/testdata/http/03-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/03-gateway-route.yaml
@@ -106,7 +106,7 @@ Routes:
       virtualHosts:
       - domains:
         - echo.example.com
-        name: edge-gateway:HTTP:8080:echo.example.com
+        name: echo.example.com
         routes:
         - match:
             path: /service/echo

--- a/pkg/plugins/runtime/gateway/testdata/http/04-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/04-gateway-route.yaml
@@ -135,7 +135,7 @@ Routes:
       virtualHosts:
       - domains:
         - echo.example.com
-        name: edge-gateway:HTTP:8080:echo.example.com
+        name: echo.example.com
         routes:
         - match:
             path: /

--- a/pkg/plugins/runtime/gateway/testdata/http/05-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/05-gateway-route.yaml
@@ -63,7 +63,7 @@ Routes:
       virtualHosts:
       - domains:
         - echo.example.com
-        name: edge-gateway:HTTP:8080:echo.example.com
+        name: echo.example.com
         routes:
         - match:
             path: /

--- a/pkg/plugins/runtime/gateway/testdata/http/06-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/06-gateway-route.yaml
@@ -135,7 +135,7 @@ Routes:
       virtualHosts:
       - domains:
         - echo.example.com
-        name: edge-gateway:HTTP:8080:echo.example.com
+        name: echo.example.com
         routes:
         - match:
             path: /

--- a/pkg/plugins/runtime/gateway/testdata/http/07-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/07-gateway-route.yaml
@@ -106,7 +106,7 @@ Routes:
       virtualHosts:
       - domains:
         - echo.example.com
-        name: edge-gateway:HTTP:8080:echo.example.com
+        name: echo.example.com
         routes:
         - match:
             path: /api

--- a/pkg/plugins/runtime/gateway/testdata/http/08-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/08-gateway-route.yaml
@@ -149,7 +149,7 @@ Routes:
       virtualHosts:
       - domains:
         - echo.example.com
-        name: edge-gateway:HTTP:8080:echo.example.com
+        name: echo.example.com
         routes:
         - match:
             path: /api

--- a/pkg/plugins/runtime/gateway/testdata/http/09-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/09-gateway-route.yaml
@@ -106,7 +106,7 @@ Routes:
       virtualHosts:
       - domains:
         - echo.example.com
-        name: edge-gateway:HTTP:8080:echo.example.com
+        name: echo.example.com
         routes:
         - match:
             safeRegex:

--- a/pkg/plugins/runtime/gateway/testdata/http/10-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/10-gateway-route.yaml
@@ -149,7 +149,7 @@ Routes:
       virtualHosts:
       - domains:
         - echo.example.com
-        name: edge-gateway:HTTP:8080:echo.example.com
+        name: echo.example.com
         routes:
         - match:
             headers:

--- a/pkg/plugins/runtime/gateway/testdata/http/11-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/11-gateway-route.yaml
@@ -149,7 +149,7 @@ Routes:
       virtualHosts:
       - domains:
         - echo.example.com
-        name: edge-gateway:HTTP:8080:echo.example.com
+        name: echo.example.com
         routes:
         - match:
             prefix: /

--- a/pkg/plugins/runtime/gateway/testdata/http/12-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/12-gateway-route.yaml
@@ -106,7 +106,7 @@ Routes:
       virtualHosts:
       - domains:
         - echo.example.com
-        name: edge-gateway:HTTP:8080:echo.example.com
+        name: echo.example.com
         routes:
         - match:
             headers:

--- a/pkg/plugins/runtime/gateway/testdata/http/13-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/13-gateway-route.yaml
@@ -192,7 +192,7 @@ Routes:
       virtualHosts:
       - domains:
         - echo.example.com
-        name: edge-gateway:HTTP:8080:echo.example.com
+        name: echo.example.com
         routes:
         - match:
             path: /match/bar

--- a/pkg/plugins/runtime/gateway/testdata/http/14-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/14-gateway-route.yaml
@@ -106,7 +106,7 @@ Routes:
       virtualHosts:
       - domains:
         - echo.example.com
-        name: edge-gateway:HTTP:8080:echo.example.com
+        name: echo.example.com
         routes:
         - match:
             headers:

--- a/pkg/plugins/runtime/gateway/testdata/http/15-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/15-gateway-route.yaml
@@ -192,7 +192,7 @@ Routes:
       virtualHosts:
       - domains:
         - echo.example.com
-        name: edge-gateway:HTTP:8080:echo.example.com
+        name: echo.example.com
         routes:
         - match:
             path: /api

--- a/pkg/plugins/runtime/gateway/testdata/http/16-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/16-gateway-route.yaml
@@ -189,7 +189,7 @@ Routes:
       virtualHosts:
       - domains:
         - echo.example.com
-        name: edge-gateway:HTTP:8080:echo.example.com
+        name: echo.example.com
         routes:
         - match:
             path: /api

--- a/pkg/plugins/runtime/gateway/testdata/http/17-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/17-gateway-route.yaml
@@ -210,7 +210,7 @@ Routes:
       virtualHosts:
       - domains:
         - echo.example.com
-        name: edge-gateway:HTTP:8080:echo.example.com
+        name: echo.example.com
         routes:
         - match:
             path: /api

--- a/pkg/plugins/runtime/gateway/testdata/http/18-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/18-gateway-route.yaml
@@ -103,7 +103,7 @@ Routes:
       virtualHosts:
       - domains:
         - echo.example.com
-        name: edge-gateway:HTTP:8080:echo.example.com
+        name: echo.example.com
         routes:
         - match:
             prefix: /

--- a/pkg/plugins/runtime/gateway/testdata/http/19-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/19-gateway-route.yaml
@@ -115,7 +115,7 @@ Routes:
       virtualHosts:
       - domains:
         - echo.example.com
-        name: edge-gateway:HTTP:8080:echo.example.com
+        name: echo.example.com
         routes:
         - match:
             prefix: /

--- a/pkg/plugins/runtime/gateway/testdata/http/20-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/20-gateway-route.yaml
@@ -192,7 +192,7 @@ Routes:
       virtualHosts:
       - domains:
         - two.example.com
-        name: gateway-multihost:HTTP:9080:two.example.com
+        name: two.example.com
         routes:
         - match:
             prefix: /
@@ -212,7 +212,7 @@ Routes:
               totalWeight: 1
       - domains:
         - three.example.com
-        name: gateway-multihost:HTTP:9080:three.example.com
+        name: three.example.com
         routes:
         - match:
             prefix: /
@@ -232,7 +232,7 @@ Routes:
               totalWeight: 1
       - domains:
         - one.example.com
-        name: gateway-multihost:HTTP:9080:one.example.com
+        name: one.example.com
         routes:
         - match:
             prefix: /

--- a/pkg/plugins/runtime/gateway/testdata/https/01-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/01-gateway-route.yaml
@@ -106,7 +106,7 @@ Routes:
       virtualHosts:
       - domains:
         - foo.example.com
-        name: edge-gateway:HTTP:8080:foo.example.com
+        name: foo.example.com
         routes:
         - match:
             path: /
@@ -126,7 +126,7 @@ Routes:
               totalWeight: 1
       - domains:
         - bar.example.com
-        name: edge-gateway:HTTP:8080:bar.example.com
+        name: bar.example.com
         routes:
         - match:
             path: /
@@ -146,7 +146,7 @@ Routes:
               totalWeight: 1
       - domains:
         - '*.example.com'
-        name: edge-gateway:HTTP:8080:*.example.com
+        name: '*.example.com'
         routes:
         - match:
             path: /
@@ -166,7 +166,7 @@ Routes:
               totalWeight: 1
       - domains:
         - '*'
-        name: edge-gateway:HTTP:8080:*
+        name: '*'
 Runtimes:
   Resources: {}
 Secrets:

--- a/pkg/plugins/runtime/gateway/testdata/https/02-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/02-gateway-route.yaml
@@ -106,7 +106,7 @@ Routes:
       virtualHosts:
       - domains:
         - extra.example.com
-        name: edge-gateway:HTTP:8080:extra.example.com
+        name: extra.example.com
         routes:
         - match:
             path: /
@@ -126,7 +126,7 @@ Routes:
               totalWeight: 1
       - domains:
         - '*'
-        name: edge-gateway:HTTP:8080:*
+        name: '*'
         routes:
         - match:
             path: /

--- a/pkg/plugins/runtime/gateway/testdata/https/03-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/03-gateway-route.yaml
@@ -129,7 +129,7 @@ Routes:
       virtualHosts:
       - domains:
         - echo.example.com
-        name: edge-gateway:HTTPS:8080:echo.example.com
+        name: echo.example.com
         requireTls: ALL
         responseHeadersToAdd:
         - append: false

--- a/pkg/plugins/runtime/gateway/testdata/https/04-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/04-gateway-route.yaml
@@ -158,7 +158,7 @@ Routes:
       virtualHosts:
       - domains:
         - echo.example.com
-        name: edge-gateway:HTTPS:8080:echo.example.com
+        name: echo.example.com
         requireTls: ALL
         responseHeadersToAdd:
         - append: false

--- a/pkg/plugins/runtime/gateway/testdata/https/05-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/05-gateway-route.yaml
@@ -86,7 +86,7 @@ Routes:
       virtualHosts:
       - domains:
         - echo.example.com
-        name: edge-gateway:HTTPS:8080:echo.example.com
+        name: echo.example.com
         requireTls: ALL
         responseHeadersToAdd:
         - append: false

--- a/pkg/plugins/runtime/gateway/testdata/https/06-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/06-gateway-route.yaml
@@ -158,7 +158,7 @@ Routes:
       virtualHosts:
       - domains:
         - echo.example.com
-        name: edge-gateway:HTTPS:8080:echo.example.com
+        name: echo.example.com
         requireTls: ALL
         responseHeadersToAdd:
         - append: false

--- a/pkg/plugins/runtime/gateway/testdata/https/07-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/07-gateway-route.yaml
@@ -129,7 +129,7 @@ Routes:
       virtualHosts:
       - domains:
         - echo.example.com
-        name: edge-gateway:HTTPS:8080:echo.example.com
+        name: echo.example.com
         requireTls: ALL
         responseHeadersToAdd:
         - append: false

--- a/pkg/plugins/runtime/gateway/testdata/https/08-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/08-gateway-route.yaml
@@ -172,7 +172,7 @@ Routes:
       virtualHosts:
       - domains:
         - echo.example.com
-        name: edge-gateway:HTTPS:8080:echo.example.com
+        name: echo.example.com
         requireTls: ALL
         responseHeadersToAdd:
         - append: false

--- a/pkg/plugins/runtime/gateway/testdata/https/09-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/09-gateway-route.yaml
@@ -129,7 +129,7 @@ Routes:
       virtualHosts:
       - domains:
         - echo.example.com
-        name: edge-gateway:HTTPS:8080:echo.example.com
+        name: echo.example.com
         requireTls: ALL
         responseHeadersToAdd:
         - append: false

--- a/pkg/plugins/runtime/gateway/testdata/https/10-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/10-gateway-route.yaml
@@ -172,7 +172,7 @@ Routes:
       virtualHosts:
       - domains:
         - echo.example.com
-        name: edge-gateway:HTTPS:8080:echo.example.com
+        name: echo.example.com
         requireTls: ALL
         responseHeadersToAdd:
         - append: false

--- a/pkg/plugins/runtime/gateway/testdata/https/11-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/11-gateway-route.yaml
@@ -172,7 +172,7 @@ Routes:
       virtualHosts:
       - domains:
         - echo.example.com
-        name: edge-gateway:HTTPS:8080:echo.example.com
+        name: echo.example.com
         requireTls: ALL
         responseHeadersToAdd:
         - append: false

--- a/pkg/plugins/runtime/gateway/testdata/https/12-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/12-gateway-route.yaml
@@ -129,7 +129,7 @@ Routes:
       virtualHosts:
       - domains:
         - echo.example.com
-        name: edge-gateway:HTTPS:8080:echo.example.com
+        name: echo.example.com
         requireTls: ALL
         responseHeadersToAdd:
         - append: false

--- a/pkg/plugins/runtime/gateway/testdata/https/13-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/13-gateway-route.yaml
@@ -215,7 +215,7 @@ Routes:
       virtualHosts:
       - domains:
         - echo.example.com
-        name: edge-gateway:HTTPS:8080:echo.example.com
+        name: echo.example.com
         requireTls: ALL
         responseHeadersToAdd:
         - append: false

--- a/pkg/plugins/runtime/gateway/testdata/https/14-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/14-gateway-route.yaml
@@ -129,7 +129,7 @@ Routes:
       virtualHosts:
       - domains:
         - echo.example.com
-        name: edge-gateway:HTTPS:8080:echo.example.com
+        name: echo.example.com
         requireTls: ALL
         responseHeadersToAdd:
         - append: false

--- a/pkg/plugins/runtime/gateway/testdata/https/15-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/15-gateway-route.yaml
@@ -215,7 +215,7 @@ Routes:
       virtualHosts:
       - domains:
         - echo.example.com
-        name: edge-gateway:HTTPS:8080:echo.example.com
+        name: echo.example.com
         requireTls: ALL
         responseHeadersToAdd:
         - append: false

--- a/pkg/plugins/runtime/gateway/testdata/https/16-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/16-gateway-route.yaml
@@ -212,7 +212,7 @@ Routes:
       virtualHosts:
       - domains:
         - echo.example.com
-        name: edge-gateway:HTTPS:8080:echo.example.com
+        name: echo.example.com
         requireTls: ALL
         responseHeadersToAdd:
         - append: false

--- a/pkg/plugins/runtime/gateway/testdata/https/17-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/17-gateway-route.yaml
@@ -233,7 +233,7 @@ Routes:
       virtualHosts:
       - domains:
         - echo.example.com
-        name: edge-gateway:HTTPS:8080:echo.example.com
+        name: echo.example.com
         requireTls: ALL
         responseHeadersToAdd:
         - append: false

--- a/pkg/plugins/runtime/gateway/testdata/https/18-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/18-gateway-route.yaml
@@ -126,7 +126,7 @@ Routes:
       virtualHosts:
       - domains:
         - echo.example.com
-        name: edge-gateway:HTTPS:8080:echo.example.com
+        name: echo.example.com
         requireTls: ALL
         responseHeadersToAdd:
         - append: false

--- a/pkg/plugins/runtime/gateway/testdata/https/19-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/19-gateway-route.yaml
@@ -138,7 +138,7 @@ Routes:
       virtualHosts:
       - domains:
         - echo.example.com
-        name: edge-gateway:HTTPS:8080:echo.example.com
+        name: echo.example.com
         requireTls: ALL
         responseHeadersToAdd:
         - append: false

--- a/pkg/plugins/runtime/gateway/testdata/https/20-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/20-gateway-route.yaml
@@ -331,7 +331,7 @@ Routes:
       virtualHosts:
       - domains:
         - two.example.com
-        name: gateway-multihost:HTTPS:9443:two.example.com
+        name: two.example.com
         requireTls: ALL
         responseHeadersToAdd:
         - append: false
@@ -357,7 +357,7 @@ Routes:
               totalWeight: 1
       - domains:
         - three.example.com
-        name: gateway-multihost:HTTPS:9443:three.example.com
+        name: three.example.com
         requireTls: ALL
         responseHeadersToAdd:
         - append: false
@@ -383,7 +383,7 @@ Routes:
               totalWeight: 1
       - domains:
         - one.example.com
-        name: gateway-multihost:HTTPS:9443:one.example.com
+        name: one.example.com
         requireTls: ALL
         responseHeadersToAdd:
         - append: false


### PR DESCRIPTION
### Summary

The virtualhost name field is used for Envoy metrics, so using the
actual hostname in this field rather than a xDS resource name results
in Prometheus labels that are a lot more useable.

### Full changelog

N/A

### Issues resolved

Fix #3320

### Documentation

N/A

### Testing

- [x] Unit tests
- [x] E2E tests
- [ ] ~~Manual testing on Universal~~
- [ ] ~~Manual testing on Kubernetes~~

### Backwards compatibility

- [ ] ~~Update [`UPGRADE.md`](UPGRADE.md) with any steps users will need to take when upgrading.~~
- [ ] ~~Add `backport-to-stable` label if the code is backwards compatible. Otherwise, list breaking changes.~~
