### PR TITLE
fix(gateway): don't reset status when reconciling

### DIFF
--- a/pkg/plugins/runtime/k8s/controllers/gatewayapi/gateway_controller.go
+++ b/pkg/plugins/runtime/k8s/controllers/gatewayapi/gateway_controller.go
@@ -88,10 +88,6 @@ func (r *GatewayReconciler) Reconcile(ctx context.Context, req kube_ctrl.Request
 
 	r.updateStatus(gateway, svc, deployment)
 
-	if err := r.Get(ctx, req.NamespacedName, gateway); err != nil {
-		return kube_ctrl.Result{}, errors.Wrap(err, "unable to get Gateway")
-	}
-
 	if err := r.Client.Status().Update(ctx, gateway); err != nil {
 		return kube_ctrl.Result{}, errors.Wrap(err, "unable to update Gateway status")
 	}


### PR DESCRIPTION
Remove the call to `Get` which resets the previous `updateStatus`