### PR TITLE
feat(kuma-cp): add gateway support for local rate limiting

### DIFF
--- a/pkg/plugins/runtime/gateway/filter_chain_generator.go
+++ b/pkg/plugins/runtime/gateway/filter_chain_generator.go
@@ -272,6 +272,9 @@ func newFilterChain(ctx xds_context.Context, info *GatewayResourceInfo) *envoy_l
 
 	// Tracing and logging have to be configured after the HttpConnectionManager is enabled.
 	builder.Configure(
+		// Force the ratelimit filter to always be present. This
+		// is a no-op unless we later add a per-route configuration.
+		envoy_listeners.RateLimit([]*mesh_proto.RateLimit{nil}),
 		envoy_listeners.DefaultCompressorFilter(),
 		envoy_listeners.Tracing(info.Proxy.Policies.TracingBackend, service),
 		// In mesh proxies, the access log is configured on the outbound

--- a/pkg/plugins/runtime/gateway/route_table_generator.go
+++ b/pkg/plugins/runtime/gateway/route_table_generator.go
@@ -11,6 +11,7 @@ import (
 	"github.com/kumahq/kuma/pkg/plugins/runtime/gateway/route"
 	xds_context "github.com/kumahq/kuma/pkg/xds/context"
 	envoy_routes "github.com/kumahq/kuma/pkg/xds/envoy/routes"
+	v3 "github.com/kumahq/kuma/pkg/xds/envoy/routes/v3"
 )
 
 // RouteTableGenerator generates Envoy xDS resources gateway routes from
@@ -75,6 +76,18 @@ func (r *RouteTableGenerator) GenerateHost(ctx xds_context.Context, info *Gatewa
 			timeout := t.(*core_mesh.TimeoutResource)
 			routeBuilder.Configure(
 				route.RouteActionRequestTimeout(timeout.Spec.GetConf().GetHttp().GetRequestTimeout().AsDuration()),
+			)
+		}
+
+		if r := match.BestConnectionPolicyForDestination(e.Action.Forward, core_mesh.RateLimitType); r != nil {
+			ratelimit := r.(*core_mesh.RateLimitResource)
+			conf, err := v3.NewRateLimitConfiguration(ratelimit.Spec.GetConf().GetHttp())
+			if err != nil {
+				return nil, err
+			}
+
+			routeBuilder.Configure(
+				route.RoutePerFilterConfig("envoy.filters.http.local_ratelimit", conf),
 			)
 		}
 

--- a/pkg/plugins/runtime/gateway/testdata/01-gateway-listener.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/01-gateway-listener.yaml
@@ -18,6 +18,10 @@ Resources:
             initialStreamWindowSize: 65536
             maxConcurrentStreams: 100
           httpFilters:
+          - name: envoy.filters.http.local_ratelimit
+            typedConfig:
+              '@type': type.googleapis.com/envoy.extensions.filters.http.local_ratelimit.v3.LocalRateLimit
+              statPrefix: rate_limit
           - name: gzip-compress
             typedConfig:
               '@type': type.googleapis.com/envoy.extensions.filters.http.compressor.v3.Compressor

--- a/pkg/plugins/runtime/gateway/testdata/02-gateway-listener.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/02-gateway-listener.yaml
@@ -18,6 +18,10 @@ Resources:
             initialStreamWindowSize: 65536
             maxConcurrentStreams: 100
           httpFilters:
+          - name: envoy.filters.http.local_ratelimit
+            typedConfig:
+              '@type': type.googleapis.com/envoy.extensions.filters.http.local_ratelimit.v3.LocalRateLimit
+              statPrefix: rate_limit
           - name: gzip-compress
             typedConfig:
               '@type': type.googleapis.com/envoy.extensions.filters.http.compressor.v3.Compressor
@@ -67,6 +71,10 @@ Resources:
             initialStreamWindowSize: 65536
             maxConcurrentStreams: 100
           httpFilters:
+          - name: envoy.filters.http.local_ratelimit
+            typedConfig:
+              '@type': type.googleapis.com/envoy.extensions.filters.http.local_ratelimit.v3.LocalRateLimit
+              statPrefix: rate_limit
           - name: gzip-compress
             typedConfig:
               '@type': type.googleapis.com/envoy.extensions.filters.http.compressor.v3.Compressor

--- a/pkg/plugins/runtime/gateway/testdata/03-gateway-listener.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/03-gateway-listener.yaml
@@ -18,6 +18,10 @@ Resources:
             initialStreamWindowSize: 65536
             maxConcurrentStreams: 100
           httpFilters:
+          - name: envoy.filters.http.local_ratelimit
+            typedConfig:
+              '@type': type.googleapis.com/envoy.extensions.filters.http.local_ratelimit.v3.LocalRateLimit
+              statPrefix: rate_limit
           - name: gzip-compress
             typedConfig:
               '@type': type.googleapis.com/envoy.extensions.filters.http.compressor.v3.Compressor

--- a/pkg/plugins/runtime/gateway/testdata/04-gateway-listener.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/04-gateway-listener.yaml
@@ -27,6 +27,10 @@ Resources:
             initialStreamWindowSize: 65536
             maxConcurrentStreams: 100
           httpFilters:
+          - name: envoy.filters.http.local_ratelimit
+            typedConfig:
+              '@type': type.googleapis.com/envoy.extensions.filters.http.local_ratelimit.v3.LocalRateLimit
+              statPrefix: rate_limit
           - name: gzip-compress
             typedConfig:
               '@type': type.googleapis.com/envoy.extensions.filters.http.compressor.v3.Compressor

--- a/pkg/plugins/runtime/gateway/testdata/05-gateway-listener.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/05-gateway-listener.yaml
@@ -25,6 +25,10 @@ Resources:
             initialStreamWindowSize: 65536
             maxConcurrentStreams: 100
           httpFilters:
+          - name: envoy.filters.http.local_ratelimit
+            typedConfig:
+              '@type': type.googleapis.com/envoy.extensions.filters.http.local_ratelimit.v3.LocalRateLimit
+              statPrefix: rate_limit
           - name: gzip-compress
             typedConfig:
               '@type': type.googleapis.com/envoy.extensions.filters.http.compressor.v3.Compressor
@@ -83,6 +87,10 @@ Resources:
             initialStreamWindowSize: 65536
             maxConcurrentStreams: 100
           httpFilters:
+          - name: envoy.filters.http.local_ratelimit
+            typedConfig:
+              '@type': type.googleapis.com/envoy.extensions.filters.http.local_ratelimit.v3.LocalRateLimit
+              statPrefix: rate_limit
           - name: gzip-compress
             typedConfig:
               '@type': type.googleapis.com/envoy.extensions.filters.http.compressor.v3.Compressor
@@ -141,6 +149,10 @@ Resources:
             initialStreamWindowSize: 65536
             maxConcurrentStreams: 100
           httpFilters:
+          - name: envoy.filters.http.local_ratelimit
+            typedConfig:
+              '@type': type.googleapis.com/envoy.extensions.filters.http.local_ratelimit.v3.LocalRateLimit
+              statPrefix: rate_limit
           - name: gzip-compress
             typedConfig:
               '@type': type.googleapis.com/envoy.extensions.filters.http.compressor.v3.Compressor

--- a/pkg/plugins/runtime/gateway/testdata/http/01-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/01-gateway-route.yaml
@@ -66,6 +66,10 @@ Listeners:
               initialStreamWindowSize: 65536
               maxConcurrentStreams: 100
             httpFilters:
+            - name: envoy.filters.http.local_ratelimit
+              typedConfig:
+                '@type': type.googleapis.com/envoy.extensions.filters.http.local_ratelimit.v3.LocalRateLimit
+                statPrefix: rate_limit
             - name: gzip-compress
               typedConfig:
                 '@type': type.googleapis.com/envoy.extensions.filters.http.compressor.v3.Compressor

--- a/pkg/plugins/runtime/gateway/testdata/http/02-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/02-gateway-route.yaml
@@ -66,6 +66,10 @@ Listeners:
               initialStreamWindowSize: 65536
               maxConcurrentStreams: 100
             httpFilters:
+            - name: envoy.filters.http.local_ratelimit
+              typedConfig:
+                '@type': type.googleapis.com/envoy.extensions.filters.http.local_ratelimit.v3.LocalRateLimit
+                statPrefix: rate_limit
             - name: gzip-compress
               typedConfig:
                 '@type': type.googleapis.com/envoy.extensions.filters.http.compressor.v3.Compressor

--- a/pkg/plugins/runtime/gateway/testdata/http/03-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/03-gateway-route.yaml
@@ -66,6 +66,10 @@ Listeners:
               initialStreamWindowSize: 65536
               maxConcurrentStreams: 100
             httpFilters:
+            - name: envoy.filters.http.local_ratelimit
+              typedConfig:
+                '@type': type.googleapis.com/envoy.extensions.filters.http.local_ratelimit.v3.LocalRateLimit
+                statPrefix: rate_limit
             - name: gzip-compress
               typedConfig:
                 '@type': type.googleapis.com/envoy.extensions.filters.http.compressor.v3.Compressor

--- a/pkg/plugins/runtime/gateway/testdata/http/04-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/04-gateway-route.yaml
@@ -95,6 +95,10 @@ Listeners:
               initialStreamWindowSize: 65536
               maxConcurrentStreams: 100
             httpFilters:
+            - name: envoy.filters.http.local_ratelimit
+              typedConfig:
+                '@type': type.googleapis.com/envoy.extensions.filters.http.local_ratelimit.v3.LocalRateLimit
+                statPrefix: rate_limit
             - name: gzip-compress
               typedConfig:
                 '@type': type.googleapis.com/envoy.extensions.filters.http.compressor.v3.Compressor

--- a/pkg/plugins/runtime/gateway/testdata/http/05-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/05-gateway-route.yaml
@@ -23,6 +23,10 @@ Listeners:
               initialStreamWindowSize: 65536
               maxConcurrentStreams: 100
             httpFilters:
+            - name: envoy.filters.http.local_ratelimit
+              typedConfig:
+                '@type': type.googleapis.com/envoy.extensions.filters.http.local_ratelimit.v3.LocalRateLimit
+                statPrefix: rate_limit
             - name: gzip-compress
               typedConfig:
                 '@type': type.googleapis.com/envoy.extensions.filters.http.compressor.v3.Compressor

--- a/pkg/plugins/runtime/gateway/testdata/http/06-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/06-gateway-route.yaml
@@ -95,6 +95,10 @@ Listeners:
               initialStreamWindowSize: 65536
               maxConcurrentStreams: 100
             httpFilters:
+            - name: envoy.filters.http.local_ratelimit
+              typedConfig:
+                '@type': type.googleapis.com/envoy.extensions.filters.http.local_ratelimit.v3.LocalRateLimit
+                statPrefix: rate_limit
             - name: gzip-compress
               typedConfig:
                 '@type': type.googleapis.com/envoy.extensions.filters.http.compressor.v3.Compressor

--- a/pkg/plugins/runtime/gateway/testdata/http/07-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/07-gateway-route.yaml
@@ -66,6 +66,10 @@ Listeners:
               initialStreamWindowSize: 65536
               maxConcurrentStreams: 100
             httpFilters:
+            - name: envoy.filters.http.local_ratelimit
+              typedConfig:
+                '@type': type.googleapis.com/envoy.extensions.filters.http.local_ratelimit.v3.LocalRateLimit
+                statPrefix: rate_limit
             - name: gzip-compress
               typedConfig:
                 '@type': type.googleapis.com/envoy.extensions.filters.http.compressor.v3.Compressor

--- a/pkg/plugins/runtime/gateway/testdata/http/08-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/08-gateway-route.yaml
@@ -109,6 +109,10 @@ Listeners:
               initialStreamWindowSize: 65536
               maxConcurrentStreams: 100
             httpFilters:
+            - name: envoy.filters.http.local_ratelimit
+              typedConfig:
+                '@type': type.googleapis.com/envoy.extensions.filters.http.local_ratelimit.v3.LocalRateLimit
+                statPrefix: rate_limit
             - name: gzip-compress
               typedConfig:
                 '@type': type.googleapis.com/envoy.extensions.filters.http.compressor.v3.Compressor

--- a/pkg/plugins/runtime/gateway/testdata/http/09-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/09-gateway-route.yaml
@@ -66,6 +66,10 @@ Listeners:
               initialStreamWindowSize: 65536
               maxConcurrentStreams: 100
             httpFilters:
+            - name: envoy.filters.http.local_ratelimit
+              typedConfig:
+                '@type': type.googleapis.com/envoy.extensions.filters.http.local_ratelimit.v3.LocalRateLimit
+                statPrefix: rate_limit
             - name: gzip-compress
               typedConfig:
                 '@type': type.googleapis.com/envoy.extensions.filters.http.compressor.v3.Compressor

--- a/pkg/plugins/runtime/gateway/testdata/http/10-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/10-gateway-route.yaml
@@ -109,6 +109,10 @@ Listeners:
               initialStreamWindowSize: 65536
               maxConcurrentStreams: 100
             httpFilters:
+            - name: envoy.filters.http.local_ratelimit
+              typedConfig:
+                '@type': type.googleapis.com/envoy.extensions.filters.http.local_ratelimit.v3.LocalRateLimit
+                statPrefix: rate_limit
             - name: gzip-compress
               typedConfig:
                 '@type': type.googleapis.com/envoy.extensions.filters.http.compressor.v3.Compressor

--- a/pkg/plugins/runtime/gateway/testdata/http/11-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/11-gateway-route.yaml
@@ -109,6 +109,10 @@ Listeners:
               initialStreamWindowSize: 65536
               maxConcurrentStreams: 100
             httpFilters:
+            - name: envoy.filters.http.local_ratelimit
+              typedConfig:
+                '@type': type.googleapis.com/envoy.extensions.filters.http.local_ratelimit.v3.LocalRateLimit
+                statPrefix: rate_limit
             - name: gzip-compress
               typedConfig:
                 '@type': type.googleapis.com/envoy.extensions.filters.http.compressor.v3.Compressor

--- a/pkg/plugins/runtime/gateway/testdata/http/12-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/12-gateway-route.yaml
@@ -66,6 +66,10 @@ Listeners:
               initialStreamWindowSize: 65536
               maxConcurrentStreams: 100
             httpFilters:
+            - name: envoy.filters.http.local_ratelimit
+              typedConfig:
+                '@type': type.googleapis.com/envoy.extensions.filters.http.local_ratelimit.v3.LocalRateLimit
+                statPrefix: rate_limit
             - name: gzip-compress
               typedConfig:
                 '@type': type.googleapis.com/envoy.extensions.filters.http.compressor.v3.Compressor

--- a/pkg/plugins/runtime/gateway/testdata/http/14-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/14-gateway-route.yaml
@@ -66,6 +66,10 @@ Listeners:
               initialStreamWindowSize: 65536
               maxConcurrentStreams: 100
             httpFilters:
+            - name: envoy.filters.http.local_ratelimit
+              typedConfig:
+                '@type': type.googleapis.com/envoy.extensions.filters.http.local_ratelimit.v3.LocalRateLimit
+                statPrefix: rate_limit
             - name: gzip-compress
               typedConfig:
                 '@type': type.googleapis.com/envoy.extensions.filters.http.compressor.v3.Compressor

--- a/pkg/plugins/runtime/gateway/testdata/http/15-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/15-gateway-route.yaml
@@ -152,6 +152,10 @@ Listeners:
               initialStreamWindowSize: 65536
               maxConcurrentStreams: 100
             httpFilters:
+            - name: envoy.filters.http.local_ratelimit
+              typedConfig:
+                '@type': type.googleapis.com/envoy.extensions.filters.http.local_ratelimit.v3.LocalRateLimit
+                statPrefix: rate_limit
             - name: gzip-compress
               typedConfig:
                 '@type': type.googleapis.com/envoy.extensions.filters.http.compressor.v3.Compressor

--- a/pkg/plugins/runtime/gateway/testdata/http/16-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/16-gateway-route.yaml
@@ -149,6 +149,10 @@ Listeners:
               initialStreamWindowSize: 65536
               maxConcurrentStreams: 100
             httpFilters:
+            - name: envoy.filters.http.local_ratelimit
+              typedConfig:
+                '@type': type.googleapis.com/envoy.extensions.filters.http.local_ratelimit.v3.LocalRateLimit
+                statPrefix: rate_limit
             - name: gzip-compress
               typedConfig:
                 '@type': type.googleapis.com/envoy.extensions.filters.http.compressor.v3.Compressor

--- a/pkg/plugins/runtime/gateway/testdata/http/17-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/17-gateway-route.yaml
@@ -170,6 +170,10 @@ Listeners:
               initialStreamWindowSize: 65536
               maxConcurrentStreams: 100
             httpFilters:
+            - name: envoy.filters.http.local_ratelimit
+              typedConfig:
+                '@type': type.googleapis.com/envoy.extensions.filters.http.local_ratelimit.v3.LocalRateLimit
+                statPrefix: rate_limit
             - name: gzip-compress
               typedConfig:
                 '@type': type.googleapis.com/envoy.extensions.filters.http.compressor.v3.Compressor

--- a/pkg/plugins/runtime/gateway/testdata/http/18-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/18-gateway-route.yaml
@@ -63,6 +63,10 @@ Listeners:
               initialStreamWindowSize: 65536
               maxConcurrentStreams: 100
             httpFilters:
+            - name: envoy.filters.http.local_ratelimit
+              typedConfig:
+                '@type': type.googleapis.com/envoy.extensions.filters.http.local_ratelimit.v3.LocalRateLimit
+                statPrefix: rate_limit
             - name: gzip-compress
               typedConfig:
                 '@type': type.googleapis.com/envoy.extensions.filters.http.compressor.v3.Compressor

--- a/pkg/plugins/runtime/gateway/testdata/http/19-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/19-gateway-route.yaml
@@ -75,6 +75,10 @@ Listeners:
               initialStreamWindowSize: 65536
               maxConcurrentStreams: 100
             httpFilters:
+            - name: envoy.filters.http.local_ratelimit
+              typedConfig:
+                '@type': type.googleapis.com/envoy.extensions.filters.http.local_ratelimit.v3.LocalRateLimit
+                statPrefix: rate_limit
             - name: gzip-compress
               typedConfig:
                 '@type': type.googleapis.com/envoy.extensions.filters.http.compressor.v3.Compressor

--- a/pkg/plugins/runtime/gateway/testdata/http/20-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/20-gateway-route.yaml
@@ -152,6 +152,10 @@ Listeners:
               initialStreamWindowSize: 65536
               maxConcurrentStreams: 100
             httpFilters:
+            - name: envoy.filters.http.local_ratelimit
+              typedConfig:
+                '@type': type.googleapis.com/envoy.extensions.filters.http.local_ratelimit.v3.LocalRateLimit
+                statPrefix: rate_limit
             - name: gzip-compress
               typedConfig:
                 '@type': type.googleapis.com/envoy.extensions.filters.http.compressor.v3.Compressor

--- a/pkg/plugins/runtime/gateway/testdata/http/21-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/21-gateway-route.yaml
@@ -1,6 +1,6 @@
 Clusters:
   Resources:
-    echo-exact-ad4e3a31db1bf217:
+    api-service-f8ae3d759cc477a6:
       circuitBreakers:
         thresholds:
         - maxConnections: 1024
@@ -12,7 +12,7 @@ Clusters:
         edsConfig:
           ads: {}
           resourceApiVersion: V3
-      name: echo-exact-ad4e3a31db1bf217
+      name: api-service-f8ae3d759cc477a6
       outlierDetection:
         enforcingConsecutive5xx: 0
         enforcingConsecutiveGatewayFailure: 0
@@ -27,7 +27,7 @@ Clusters:
             idleTimeout: 3600s
           explicitHttpConfig:
             httpProtocolOptions: {}
-    echo-prefix-d0e5ba63b0c9b9f0:
+    echo-mirror-712ce3acc3cececc:
       circuitBreakers:
         thresholds:
         - maxConnections: 1024
@@ -39,7 +39,7 @@ Clusters:
         edsConfig:
           ads: {}
           resourceApiVersion: V3
-      name: echo-prefix-d0e5ba63b0c9b9f0
+      name: echo-mirror-712ce3acc3cececc
       outlierDetection:
         enforcingConsecutive5xx: 0
         enforcingConsecutiveGatewayFailure: 0
@@ -54,7 +54,7 @@ Clusters:
             idleTimeout: 3600s
           explicitHttpConfig:
             httpProtocolOptions: {}
-    echo-regex-627905e7b1c2eb33:
+    echo-service-5a416c39037aa8f6:
       circuitBreakers:
         thresholds:
         - maxConnections: 1024
@@ -66,7 +66,7 @@ Clusters:
         edsConfig:
           ads: {}
           resourceApiVersion: V3
-      name: echo-regex-627905e7b1c2eb33
+      name: echo-service-5a416c39037aa8f6
       outlierDetection:
         enforcingConsecutive5xx: 0
         enforcingConsecutiveGatewayFailure: 0
@@ -83,15 +83,15 @@ Clusters:
             httpProtocolOptions: {}
 Endpoints:
   Resources:
-    echo-exact-ad4e3a31db1bf217:
-      clusterName: echo-exact-ad4e3a31db1bf217
+    api-service-f8ae3d759cc477a6:
+      clusterName: api-service-f8ae3d759cc477a6
       endpoints:
       - lbEndpoints:
         - endpoint:
             address:
               socketAddress:
-                address: 192.168.1.2
-                portValue: 20002
+                address: 192.168.1.1
+                portValue: 20001
           loadBalancingWeight: 1
           metadata:
             filterMetadata:
@@ -99,15 +99,15 @@ Endpoints:
                 kuma.io/protocol: http
               envoy.transport_socket_match:
                 kuma.io/protocol: http
-    echo-prefix-d0e5ba63b0c9b9f0:
-      clusterName: echo-prefix-d0e5ba63b0c9b9f0
+    echo-mirror-712ce3acc3cececc:
+      clusterName: echo-mirror-712ce3acc3cececc
       endpoints:
       - lbEndpoints:
         - endpoint:
             address:
               socketAddress:
-                address: 192.168.1.4
-                portValue: 20004
+                address: 192.168.1.3
+                portValue: 20003
           loadBalancingWeight: 1
           metadata:
             filterMetadata:
@@ -115,15 +115,15 @@ Endpoints:
                 kuma.io/protocol: http
               envoy.transport_socket_match:
                 kuma.io/protocol: http
-    echo-regex-627905e7b1c2eb33:
-      clusterName: echo-regex-627905e7b1c2eb33
+    echo-service-5a416c39037aa8f6:
+      clusterName: echo-service-5a416c39037aa8f6
       endpoints:
       - lbEndpoints:
         - endpoint:
             address:
               socketAddress:
-                address: 192.168.1.5
-                portValue: 20005
+                address: 192.168.1.6
+                portValue: 20006
           loadBalancingWeight: 1
           metadata:
             filterMetadata:
@@ -199,7 +199,7 @@ Routes:
         name: echo.example.com
         routes:
         - match:
-            path: /match/bar
+            path: /api
           route:
             retryPolicy:
               numRetries: 5
@@ -211,11 +211,27 @@ Routes:
             timeout: 15s
             weightedClusters:
               clusters:
-              - name: echo-exact-ad4e3a31db1bf217
+              - name: api-service-f8ae3d759cc477a6
                 weight: 1
               totalWeight: 1
+          typedPerFilterConfig:
+            envoy.filters.http.local_ratelimit:
+              '@type': type.googleapis.com/envoy.extensions.filters.http.local_ratelimit.v3.LocalRateLimit
+              filterEnabled:
+                defaultValue:
+                  numerator: 100
+                runtimeKey: local_rate_limit_enabled
+              filterEnforced:
+                defaultValue:
+                  numerator: 100
+                runtimeKey: local_rate_limit_enforced
+              statPrefix: rate_limit
+              tokenBucket:
+                fillInterval: 20s
+                maxTokens: 1
+                tokensPerFill: 1
         - match:
-            path: /match/baz
+            prefix: /api/
           route:
             retryPolicy:
               numRetries: 5
@@ -227,12 +243,33 @@ Routes:
             timeout: 15s
             weightedClusters:
               clusters:
-              - name: echo-prefix-d0e5ba63b0c9b9f0
+              - name: api-service-f8ae3d759cc477a6
                 weight: 1
               totalWeight: 1
+          typedPerFilterConfig:
+            envoy.filters.http.local_ratelimit:
+              '@type': type.googleapis.com/envoy.extensions.filters.http.local_ratelimit.v3.LocalRateLimit
+              filterEnabled:
+                defaultValue:
+                  numerator: 100
+                runtimeKey: local_rate_limit_enabled
+              filterEnforced:
+                defaultValue:
+                  numerator: 100
+                runtimeKey: local_rate_limit_enforced
+              statPrefix: rate_limit
+              tokenBucket:
+                fillInterval: 20s
+                maxTokens: 1
+                tokensPerFill: 1
         - match:
-            prefix: /match/baz/
+            prefix: /
           route:
+            requestMirrorPolicies:
+            - cluster: echo-mirror-712ce3acc3cececc
+              runtimeFraction:
+                defaultValue:
+                  numerator: 1
             retryPolicy:
               numRetries: 5
               perTryTimeout: 16s
@@ -243,27 +280,25 @@ Routes:
             timeout: 15s
             weightedClusters:
               clusters:
-              - name: echo-prefix-d0e5ba63b0c9b9f0
+              - name: echo-service-5a416c39037aa8f6
                 weight: 1
               totalWeight: 1
-        - match:
-            safeRegex:
-              googleRe2: {}
-              regex: /match/foo
-          route:
-            retryPolicy:
-              numRetries: 5
-              perTryTimeout: 16s
-              retryBackOff:
-                baseInterval: 0.025s
-                maxInterval: 0.250s
-              retryOn: gateway-error,connect-failure,refused-stream
-            timeout: 15s
-            weightedClusters:
-              clusters:
-              - name: echo-regex-627905e7b1c2eb33
-                weight: 1
-              totalWeight: 1
+          typedPerFilterConfig:
+            envoy.filters.http.local_ratelimit:
+              '@type': type.googleapis.com/envoy.extensions.filters.http.local_ratelimit.v3.LocalRateLimit
+              filterEnabled:
+                defaultValue:
+                  numerator: 100
+                runtimeKey: local_rate_limit_enabled
+              filterEnforced:
+                defaultValue:
+                  numerator: 100
+                runtimeKey: local_rate_limit_enforced
+              statPrefix: rate_limit
+              tokenBucket:
+                fillInterval: 10s
+                maxTokens: 1
+                tokensPerFill: 1
 Runtimes:
   Resources: {}
 Secrets:

--- a/pkg/plugins/runtime/gateway/testdata/https/01-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/01-gateway-route.yaml
@@ -66,6 +66,10 @@ Listeners:
               initialStreamWindowSize: 65536
               maxConcurrentStreams: 100
             httpFilters:
+            - name: envoy.filters.http.local_ratelimit
+              typedConfig:
+                '@type': type.googleapis.com/envoy.extensions.filters.http.local_ratelimit.v3.LocalRateLimit
+                statPrefix: rate_limit
             - name: gzip-compress
               typedConfig:
                 '@type': type.googleapis.com/envoy.extensions.filters.http.compressor.v3.Compressor

--- a/pkg/plugins/runtime/gateway/testdata/https/02-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/02-gateway-route.yaml
@@ -66,6 +66,10 @@ Listeners:
               initialStreamWindowSize: 65536
               maxConcurrentStreams: 100
             httpFilters:
+            - name: envoy.filters.http.local_ratelimit
+              typedConfig:
+                '@type': type.googleapis.com/envoy.extensions.filters.http.local_ratelimit.v3.LocalRateLimit
+                statPrefix: rate_limit
             - name: gzip-compress
               typedConfig:
                 '@type': type.googleapis.com/envoy.extensions.filters.http.compressor.v3.Compressor

--- a/pkg/plugins/runtime/gateway/testdata/https/03-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/03-gateway-route.yaml
@@ -73,6 +73,10 @@ Listeners:
               initialStreamWindowSize: 65536
               maxConcurrentStreams: 100
             httpFilters:
+            - name: envoy.filters.http.local_ratelimit
+              typedConfig:
+                '@type': type.googleapis.com/envoy.extensions.filters.http.local_ratelimit.v3.LocalRateLimit
+                statPrefix: rate_limit
             - name: gzip-compress
               typedConfig:
                 '@type': type.googleapis.com/envoy.extensions.filters.http.compressor.v3.Compressor

--- a/pkg/plugins/runtime/gateway/testdata/https/05-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/05-gateway-route.yaml
@@ -30,6 +30,10 @@ Listeners:
               initialStreamWindowSize: 65536
               maxConcurrentStreams: 100
             httpFilters:
+            - name: envoy.filters.http.local_ratelimit
+              typedConfig:
+                '@type': type.googleapis.com/envoy.extensions.filters.http.local_ratelimit.v3.LocalRateLimit
+                statPrefix: rate_limit
             - name: gzip-compress
               typedConfig:
                 '@type': type.googleapis.com/envoy.extensions.filters.http.compressor.v3.Compressor

--- a/pkg/plugins/runtime/gateway/testdata/https/06-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/06-gateway-route.yaml
@@ -102,6 +102,10 @@ Listeners:
               initialStreamWindowSize: 65536
               maxConcurrentStreams: 100
             httpFilters:
+            - name: envoy.filters.http.local_ratelimit
+              typedConfig:
+                '@type': type.googleapis.com/envoy.extensions.filters.http.local_ratelimit.v3.LocalRateLimit
+                statPrefix: rate_limit
             - name: gzip-compress
               typedConfig:
                 '@type': type.googleapis.com/envoy.extensions.filters.http.compressor.v3.Compressor

--- a/pkg/plugins/runtime/gateway/testdata/https/07-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/07-gateway-route.yaml
@@ -73,6 +73,10 @@ Listeners:
               initialStreamWindowSize: 65536
               maxConcurrentStreams: 100
             httpFilters:
+            - name: envoy.filters.http.local_ratelimit
+              typedConfig:
+                '@type': type.googleapis.com/envoy.extensions.filters.http.local_ratelimit.v3.LocalRateLimit
+                statPrefix: rate_limit
             - name: gzip-compress
               typedConfig:
                 '@type': type.googleapis.com/envoy.extensions.filters.http.compressor.v3.Compressor

--- a/pkg/plugins/runtime/gateway/testdata/https/08-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/08-gateway-route.yaml
@@ -116,6 +116,10 @@ Listeners:
               initialStreamWindowSize: 65536
               maxConcurrentStreams: 100
             httpFilters:
+            - name: envoy.filters.http.local_ratelimit
+              typedConfig:
+                '@type': type.googleapis.com/envoy.extensions.filters.http.local_ratelimit.v3.LocalRateLimit
+                statPrefix: rate_limit
             - name: gzip-compress
               typedConfig:
                 '@type': type.googleapis.com/envoy.extensions.filters.http.compressor.v3.Compressor

--- a/pkg/plugins/runtime/gateway/testdata/https/09-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/09-gateway-route.yaml
@@ -73,6 +73,10 @@ Listeners:
               initialStreamWindowSize: 65536
               maxConcurrentStreams: 100
             httpFilters:
+            - name: envoy.filters.http.local_ratelimit
+              typedConfig:
+                '@type': type.googleapis.com/envoy.extensions.filters.http.local_ratelimit.v3.LocalRateLimit
+                statPrefix: rate_limit
             - name: gzip-compress
               typedConfig:
                 '@type': type.googleapis.com/envoy.extensions.filters.http.compressor.v3.Compressor

--- a/pkg/plugins/runtime/gateway/testdata/https/10-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/10-gateway-route.yaml
@@ -116,6 +116,10 @@ Listeners:
               initialStreamWindowSize: 65536
               maxConcurrentStreams: 100
             httpFilters:
+            - name: envoy.filters.http.local_ratelimit
+              typedConfig:
+                '@type': type.googleapis.com/envoy.extensions.filters.http.local_ratelimit.v3.LocalRateLimit
+                statPrefix: rate_limit
             - name: gzip-compress
               typedConfig:
                 '@type': type.googleapis.com/envoy.extensions.filters.http.compressor.v3.Compressor

--- a/pkg/plugins/runtime/gateway/testdata/https/11-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/11-gateway-route.yaml
@@ -116,6 +116,10 @@ Listeners:
               initialStreamWindowSize: 65536
               maxConcurrentStreams: 100
             httpFilters:
+            - name: envoy.filters.http.local_ratelimit
+              typedConfig:
+                '@type': type.googleapis.com/envoy.extensions.filters.http.local_ratelimit.v3.LocalRateLimit
+                statPrefix: rate_limit
             - name: gzip-compress
               typedConfig:
                 '@type': type.googleapis.com/envoy.extensions.filters.http.compressor.v3.Compressor

--- a/pkg/plugins/runtime/gateway/testdata/https/12-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/12-gateway-route.yaml
@@ -73,6 +73,10 @@ Listeners:
               initialStreamWindowSize: 65536
               maxConcurrentStreams: 100
             httpFilters:
+            - name: envoy.filters.http.local_ratelimit
+              typedConfig:
+                '@type': type.googleapis.com/envoy.extensions.filters.http.local_ratelimit.v3.LocalRateLimit
+                statPrefix: rate_limit
             - name: gzip-compress
               typedConfig:
                 '@type': type.googleapis.com/envoy.extensions.filters.http.compressor.v3.Compressor

--- a/pkg/plugins/runtime/gateway/testdata/https/13-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/13-gateway-route.yaml
@@ -159,6 +159,10 @@ Listeners:
               initialStreamWindowSize: 65536
               maxConcurrentStreams: 100
             httpFilters:
+            - name: envoy.filters.http.local_ratelimit
+              typedConfig:
+                '@type': type.googleapis.com/envoy.extensions.filters.http.local_ratelimit.v3.LocalRateLimit
+                statPrefix: rate_limit
             - name: gzip-compress
               typedConfig:
                 '@type': type.googleapis.com/envoy.extensions.filters.http.compressor.v3.Compressor

--- a/pkg/plugins/runtime/gateway/testdata/https/14-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/14-gateway-route.yaml
@@ -73,6 +73,10 @@ Listeners:
               initialStreamWindowSize: 65536
               maxConcurrentStreams: 100
             httpFilters:
+            - name: envoy.filters.http.local_ratelimit
+              typedConfig:
+                '@type': type.googleapis.com/envoy.extensions.filters.http.local_ratelimit.v3.LocalRateLimit
+                statPrefix: rate_limit
             - name: gzip-compress
               typedConfig:
                 '@type': type.googleapis.com/envoy.extensions.filters.http.compressor.v3.Compressor

--- a/pkg/plugins/runtime/gateway/testdata/https/15-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/15-gateway-route.yaml
@@ -159,6 +159,10 @@ Listeners:
               initialStreamWindowSize: 65536
               maxConcurrentStreams: 100
             httpFilters:
+            - name: envoy.filters.http.local_ratelimit
+              typedConfig:
+                '@type': type.googleapis.com/envoy.extensions.filters.http.local_ratelimit.v3.LocalRateLimit
+                statPrefix: rate_limit
             - name: gzip-compress
               typedConfig:
                 '@type': type.googleapis.com/envoy.extensions.filters.http.compressor.v3.Compressor

--- a/pkg/plugins/runtime/gateway/testdata/https/16-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/16-gateway-route.yaml
@@ -156,6 +156,10 @@ Listeners:
               initialStreamWindowSize: 65536
               maxConcurrentStreams: 100
             httpFilters:
+            - name: envoy.filters.http.local_ratelimit
+              typedConfig:
+                '@type': type.googleapis.com/envoy.extensions.filters.http.local_ratelimit.v3.LocalRateLimit
+                statPrefix: rate_limit
             - name: gzip-compress
               typedConfig:
                 '@type': type.googleapis.com/envoy.extensions.filters.http.compressor.v3.Compressor

--- a/pkg/plugins/runtime/gateway/testdata/https/17-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/17-gateway-route.yaml
@@ -177,6 +177,10 @@ Listeners:
               initialStreamWindowSize: 65536
               maxConcurrentStreams: 100
             httpFilters:
+            - name: envoy.filters.http.local_ratelimit
+              typedConfig:
+                '@type': type.googleapis.com/envoy.extensions.filters.http.local_ratelimit.v3.LocalRateLimit
+                statPrefix: rate_limit
             - name: gzip-compress
               typedConfig:
                 '@type': type.googleapis.com/envoy.extensions.filters.http.compressor.v3.Compressor

--- a/pkg/plugins/runtime/gateway/testdata/https/18-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/18-gateway-route.yaml
@@ -70,6 +70,10 @@ Listeners:
               initialStreamWindowSize: 65536
               maxConcurrentStreams: 100
             httpFilters:
+            - name: envoy.filters.http.local_ratelimit
+              typedConfig:
+                '@type': type.googleapis.com/envoy.extensions.filters.http.local_ratelimit.v3.LocalRateLimit
+                statPrefix: rate_limit
             - name: gzip-compress
               typedConfig:
                 '@type': type.googleapis.com/envoy.extensions.filters.http.compressor.v3.Compressor

--- a/pkg/plugins/runtime/gateway/testdata/https/19-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/19-gateway-route.yaml
@@ -82,6 +82,10 @@ Listeners:
               initialStreamWindowSize: 65536
               maxConcurrentStreams: 100
             httpFilters:
+            - name: envoy.filters.http.local_ratelimit
+              typedConfig:
+                '@type': type.googleapis.com/envoy.extensions.filters.http.local_ratelimit.v3.LocalRateLimit
+                statPrefix: rate_limit
             - name: gzip-compress
               typedConfig:
                 '@type': type.googleapis.com/envoy.extensions.filters.http.compressor.v3.Compressor

--- a/pkg/plugins/runtime/gateway/testdata/https/20-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/20-gateway-route.yaml
@@ -159,6 +159,10 @@ Listeners:
               initialStreamWindowSize: 65536
               maxConcurrentStreams: 100
             httpFilters:
+            - name: envoy.filters.http.local_ratelimit
+              typedConfig:
+                '@type': type.googleapis.com/envoy.extensions.filters.http.local_ratelimit.v3.LocalRateLimit
+                statPrefix: rate_limit
             - name: gzip-compress
               typedConfig:
                 '@type': type.googleapis.com/envoy.extensions.filters.http.compressor.v3.Compressor
@@ -217,6 +221,10 @@ Listeners:
               initialStreamWindowSize: 65536
               maxConcurrentStreams: 100
             httpFilters:
+            - name: envoy.filters.http.local_ratelimit
+              typedConfig:
+                '@type': type.googleapis.com/envoy.extensions.filters.http.local_ratelimit.v3.LocalRateLimit
+                statPrefix: rate_limit
             - name: gzip-compress
               typedConfig:
                 '@type': type.googleapis.com/envoy.extensions.filters.http.compressor.v3.Compressor
@@ -275,6 +283,10 @@ Listeners:
               initialStreamWindowSize: 65536
               maxConcurrentStreams: 100
             httpFilters:
+            - name: envoy.filters.http.local_ratelimit
+              typedConfig:
+                '@type': type.googleapis.com/envoy.extensions.filters.http.local_ratelimit.v3.LocalRateLimit
+                statPrefix: rate_limit
             - name: gzip-compress
               typedConfig:
                 '@type': type.googleapis.com/envoy.extensions.filters.http.compressor.v3.Compressor

--- a/pkg/plugins/runtime/gateway/testdata/https/21-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/21-gateway-route.yaml
@@ -1,6 +1,6 @@
 Clusters:
   Resources:
-    echo-mirror-eb192462fe75ad40:
+    api-service-f8ae3d759cc477a6:
       circuitBreakers:
         thresholds:
         - maxConnections: 1024
@@ -12,7 +12,34 @@ Clusters:
         edsConfig:
           ads: {}
           resourceApiVersion: V3
-      name: echo-mirror-eb192462fe75ad40
+      name: api-service-f8ae3d759cc477a6
+      outlierDetection:
+        enforcingConsecutive5xx: 0
+        enforcingConsecutiveGatewayFailure: 0
+        enforcingConsecutiveLocalOriginFailure: 0
+        enforcingFailurePercentage: 0
+        enforcingSuccessRate: 0
+      type: EDS
+      typedExtensionProtocolOptions:
+        envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+          '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+          commonHttpProtocolOptions:
+            idleTimeout: 3600s
+          explicitHttpConfig:
+            httpProtocolOptions: {}
+    echo-mirror-712ce3acc3cececc:
+      circuitBreakers:
+        thresholds:
+        - maxConnections: 1024
+          maxPendingRequests: 1024
+          maxRequests: 1024
+          maxRetries: 3
+      connectTimeout: 5s
+      edsClusterConfig:
+        edsConfig:
+          ads: {}
+          resourceApiVersion: V3
+      name: echo-mirror-712ce3acc3cececc
       outlierDetection:
         enforcingConsecutive5xx: 0
         enforcingConsecutiveGatewayFailure: 0
@@ -56,8 +83,38 @@ Clusters:
             httpProtocolOptions: {}
 Endpoints:
   Resources:
-    echo-mirror-eb192462fe75ad40:
-      clusterName: echo-mirror-eb192462fe75ad40
+    api-service-f8ae3d759cc477a6:
+      clusterName: api-service-f8ae3d759cc477a6
+      endpoints:
+      - lbEndpoints:
+        - endpoint:
+            address:
+              socketAddress:
+                address: 192.168.1.1
+                portValue: 20001
+          loadBalancingWeight: 1
+          metadata:
+            filterMetadata:
+              envoy.lb:
+                kuma.io/protocol: http
+              envoy.transport_socket_match:
+                kuma.io/protocol: http
+    echo-mirror-712ce3acc3cececc:
+      clusterName: echo-mirror-712ce3acc3cececc
+      endpoints:
+      - lbEndpoints:
+        - endpoint:
+            address:
+              socketAddress:
+                address: 192.168.1.3
+                portValue: 20003
+          loadBalancingWeight: 1
+          metadata:
+            filterMetadata:
+              envoy.lb:
+                kuma.io/protocol: http
+              envoy.transport_socket_match:
+                kuma.io/protocol: http
     echo-service-5a416c39037aa8f6:
       clusterName: echo-service-5a416c39037aa8f6
       endpoints:
@@ -171,14 +228,77 @@ Routes:
             value: max-age=31536000; includeSubDomains
         routes:
         - match:
-            path: /
+            path: /api
+          route:
+            retryPolicy:
+              numRetries: 5
+              perTryTimeout: 16s
+              retryBackOff:
+                baseInterval: 0.025s
+                maxInterval: 0.250s
+              retryOn: gateway-error,connect-failure,refused-stream
+            timeout: 15s
+            weightedClusters:
+              clusters:
+              - name: api-service-f8ae3d759cc477a6
+                weight: 1
+              totalWeight: 1
+          typedPerFilterConfig:
+            envoy.filters.http.local_ratelimit:
+              '@type': type.googleapis.com/envoy.extensions.filters.http.local_ratelimit.v3.LocalRateLimit
+              filterEnabled:
+                defaultValue:
+                  numerator: 100
+                runtimeKey: local_rate_limit_enabled
+              filterEnforced:
+                defaultValue:
+                  numerator: 100
+                runtimeKey: local_rate_limit_enforced
+              statPrefix: rate_limit
+              tokenBucket:
+                fillInterval: 20s
+                maxTokens: 1
+                tokensPerFill: 1
+        - match:
+            prefix: /api/
+          route:
+            retryPolicy:
+              numRetries: 5
+              perTryTimeout: 16s
+              retryBackOff:
+                baseInterval: 0.025s
+                maxInterval: 0.250s
+              retryOn: gateway-error,connect-failure,refused-stream
+            timeout: 15s
+            weightedClusters:
+              clusters:
+              - name: api-service-f8ae3d759cc477a6
+                weight: 1
+              totalWeight: 1
+          typedPerFilterConfig:
+            envoy.filters.http.local_ratelimit:
+              '@type': type.googleapis.com/envoy.extensions.filters.http.local_ratelimit.v3.LocalRateLimit
+              filterEnabled:
+                defaultValue:
+                  numerator: 100
+                runtimeKey: local_rate_limit_enabled
+              filterEnforced:
+                defaultValue:
+                  numerator: 100
+                runtimeKey: local_rate_limit_enforced
+              statPrefix: rate_limit
+              tokenBucket:
+                fillInterval: 20s
+                maxTokens: 1
+                tokensPerFill: 1
+        - match:
+            prefix: /
           route:
             requestMirrorPolicies:
-            - cluster: echo-mirror-eb192462fe75ad40
+            - cluster: echo-mirror-712ce3acc3cececc
               runtimeFraction:
                 defaultValue:
-                  denominator: TEN_THOUSAND
-                  numerator: 10
+                  numerator: 1
             retryPolicy:
               numRetries: 5
               perTryTimeout: 16s
@@ -192,6 +312,22 @@ Routes:
               - name: echo-service-5a416c39037aa8f6
                 weight: 1
               totalWeight: 1
+          typedPerFilterConfig:
+            envoy.filters.http.local_ratelimit:
+              '@type': type.googleapis.com/envoy.extensions.filters.http.local_ratelimit.v3.LocalRateLimit
+              filterEnabled:
+                defaultValue:
+                  numerator: 100
+                runtimeKey: local_rate_limit_enabled
+              filterEnforced:
+                defaultValue:
+                  numerator: 100
+                runtimeKey: local_rate_limit_enforced
+              statPrefix: rate_limit
+              tokenBucket:
+                fillInterval: 10s
+                maxTokens: 1
+                tokensPerFill: 1
 Runtimes:
   Resources: {}
 Secrets:

--- a/pkg/xds/envoy/routes/v3/ratelimit.go
+++ b/pkg/xds/envoy/routes/v3/ratelimit.go
@@ -1,0 +1,58 @@
+package v3
+
+import (
+	envoy_config_core_v3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	envoy_extensions_filters_http_local_ratelimit_v3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/local_ratelimit/v3"
+	envoy_type_v3 "github.com/envoyproxy/go-control-plane/envoy/type/v3"
+	"github.com/golang/protobuf/ptypes/any"
+
+	"github.com/kumahq/kuma/api/mesh/v1alpha1"
+	"github.com/kumahq/kuma/pkg/util/proto"
+)
+
+func NewRateLimitConfiguration(rlHttp *v1alpha1.RateLimit_Conf_Http) (*any.Any, error) {
+	var status *envoy_type_v3.HttpStatus
+	var responseHeaders []*envoy_config_core_v3.HeaderValueOption
+	if rlHttp.GetOnRateLimit() != nil {
+		status = &envoy_type_v3.HttpStatus{
+			Code: envoy_type_v3.StatusCode(rlHttp.GetOnRateLimit().GetStatus().GetValue()),
+		}
+		responseHeaders = []*envoy_config_core_v3.HeaderValueOption{}
+		for _, h := range rlHttp.GetOnRateLimit().GetHeaders() {
+			responseHeaders = append(responseHeaders, &envoy_config_core_v3.HeaderValueOption{
+				Header: &envoy_config_core_v3.HeaderValue{
+					Key:   h.GetKey(),
+					Value: h.GetValue(),
+				},
+				Append: h.GetAppend(),
+			})
+		}
+	}
+
+	config := &envoy_extensions_filters_http_local_ratelimit_v3.LocalRateLimit{
+		StatPrefix: "rate_limit",
+		Status:     status,
+		TokenBucket: &envoy_type_v3.TokenBucket{
+			MaxTokens:     rlHttp.GetRequests(),
+			TokensPerFill: proto.UInt32(rlHttp.GetRequests()),
+			FillInterval:  rlHttp.GetInterval(),
+		},
+		FilterEnabled: &envoy_config_core_v3.RuntimeFractionalPercent{
+			DefaultValue: &envoy_type_v3.FractionalPercent{
+				Numerator:   100,
+				Denominator: envoy_type_v3.FractionalPercent_HUNDRED,
+			},
+			RuntimeKey: "local_rate_limit_enabled",
+		},
+		FilterEnforced: &envoy_config_core_v3.RuntimeFractionalPercent{
+			DefaultValue: &envoy_type_v3.FractionalPercent{
+				Numerator:   100,
+				Denominator: envoy_type_v3.FractionalPercent_HUNDRED,
+			},
+			RuntimeKey: "local_rate_limit_enforced",
+		},
+		ResponseHeadersToAdd: responseHeaders,
+	}
+
+	return proto.MarshalAnyDeterministic(config)
+}

--- a/test/server/types/echo_response.go
+++ b/test/server/types/echo_response.go
@@ -6,7 +6,10 @@ type EchoResponse struct {
 }
 
 type EchoResponseReceived struct {
-	Method  string              `json:"method"`
-	Path    string              `json:"path"`
-	Headers map[string][]string `json:"headers"`
+	// StatusCode is the HTTP response code. The echo server never
+	// emits this, but it can be fabricated by curl output formatting.
+	StatusCode int                 `json:"status,omitempty"`
+	Method     string              `json:"method"`
+	Path       string              `json:"path"`
+	Headers    map[string][]string `json:"headers"`
 }


### PR DESCRIPTION
### Summary

Add Gateway support for local rate limits. This works similarly to
other connection policies that are implemented on Envoy routes - the
most specifc source and destination match is made for each route.

For simplicity, we unconditionally enable the rate limit filter on the
HTTP connection manager. That is a no-op until we actually configure a
rate limit using the per-route configuration.

### Full changelog

N/A

### Issues resolved

Fix #3393.

### Documentation

N/A

### Testing

- [x] Unit tests
- [x] E2E tests
- [x] Manual testing on Universal
- [ ] ~~Manual testing on Kubernetes~~

### Backwards compatibility

- [ ] ~~Update [`UPGRADE.md`](UPGRADE.md) with any steps users will need to take when upgrading.~~
- [ ] ~~Add `backport-to-stable` label if the code is backwards compatible. Otherwise, list breaking changes.~~
