### PR TITLE
fix(ci): display name of vars not interpolate them

### DIFF
--- a/tools/releases/docker.sh
+++ b/tools/releases/docker.sh
@@ -73,8 +73,8 @@ function main() {
     shift
   done
 
-  [ -z "$DOCKER_USERNAME" ] && msg_err "$DOCKER_USERNAME required"
-  [ -z "$DOCKER_API_KEY" ] && msg_err "$DOCKER_API_KEY required"
+  [ -z "$DOCKER_USERNAME" ] && msg_err "\$DOCKER_USERNAME required"
+  [ -z "$DOCKER_API_KEY" ] && msg_err "\$DOCKER_API_KEY required"
   [ -z "$KUMA_VERSION" ] && msg_err "Error: --version required"
 
   case $op in


### PR DESCRIPTION
### Summary

Currently if these env vars are missing, we are printing `required` as the env vars are interpolated to empty strings

### Full changelog

* [Implement ...]
* [Fix ...]

### Issues resolved

Fix #XXX

### Documentation

- [ ] Link to the website [documentation PR](https://github.com/kumahq/kuma-website/pull/XXX)

### Testing

- [ ] Unit tests
- [ ] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes

### Backwards compatibility

- [ ] Update [`UPGRADE.md`](UPGRADE.md) with any steps users will need to take
      when upgrading.
- [ ] Add `backport-to-stable` label if the code is backwards compatible. Otherwise, list breaking changes.
