### PR TITLE
chore(ci): bump patch versions of minikube/k8s

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1141,7 +1141,7 @@ workflows:
           - images
           - check
         # custom parameters
-        kubernetes_version: v1.18.16
+        kubernetes_version: v1.18.20
         use_local_kuma_images: true
     - example_minikube:
         <<: *commit_workflow_filters
@@ -1150,7 +1150,7 @@ workflows:
           - images
           - check
         # custom parameters
-        kubernetes_version: v1.20.4
+        kubernetes_version: v1.20.13
         use_local_kuma_images: true
     - e2e:
         <<: *commit_workflow_filters


### PR DESCRIPTION
### Summary

SUMMARY_GOES_HERE

### Full changelog

* [Implement ...]
* [Fix ...]

### Issues resolved

Fix #XXX

### Documentation

- [ ] Link to the website [documentation PR](https://github.com/kumahq/kuma-website/pull/XXX)

### Testing

- [ ] Unit tests
- [ ] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes

### Backwards compatibility

- [ ] Update [`UPGRADE.md`](UPGRADE.md) with any steps users will need to take
      when upgrading.
- [ ] Add `backport-to-stable` label if the code is backwards compatible. Otherwise, list breaking changes.
