### PR TITLE
chore(config): remove ability to disable insights

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,6 +8,11 @@ does not have any particular instructions.
 
 ## Upcoming release
 
+### Any type
+
+It is not possible to remove computing stats with: `kuma.metrics.dataplane.enabled` and `kuma.metrics.zone.enabled` (the configurations are removed).
+These stats are useful to Kuma internally and can't be turned off.
+
 ### Kubernetes
 
 Please migrate your `kuma.io/sidecar-injection` annotations to labels.

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -10,8 +10,9 @@ does not have any particular instructions.
 
 ### Any type
 
-It is not possible to remove computing stats with: `kuma.metrics.dataplane.enabled` and `kuma.metrics.zone.enabled` (the configurations are removed).
-These stats are useful to Kuma internally and can't be turned off.
+The `kuma.metrics.dataplane.enabled` and `kuma.metrics.zone.enabled` configurations have been removed.
+
+Kuma always generate the corresponding metrics.
 
 ### Kubernetes
 

--- a/pkg/api-server/config_ws_test.go
+++ b/pkg/api-server/config_ws_test.go
@@ -133,7 +133,6 @@ var _ = Describe("Config WS", func() {
 		  },
 		  "metrics": {
 			"dataplane": {
-			  "enabled": true,
 			  "subscriptionLimit": 2,
 			  "idleTimeout": "5m0s"
 			},
@@ -142,7 +141,6 @@ var _ = Describe("Config WS", func() {
 			  "minResyncTimeout": "1s"
 			},
 			"zone": {
-			  "enabled": true,
 			  "subscriptionLimit": 10,
 			  "idleTimeout": "5m0s"
 			}

--- a/pkg/config/app/kuma-cp/config.go
+++ b/pkg/config/app/kuma-cp/config.go
@@ -53,7 +53,6 @@ func (m *Metrics) Validate() error {
 }
 
 type DataplaneMetrics struct {
-	Enabled           bool          `yaml:"enabled" envconfig:"kuma_metrics_dataplane_enabled"`
 	SubscriptionLimit int           `yaml:"subscriptionLimit" envconfig:"kuma_metrics_dataplane_subscription_limit"`
 	IdleTimeout       time.Duration `yaml:"idleTimeout" envconfig:"kuma_metrics_dataplane_idle_timeout"`
 }
@@ -69,7 +68,6 @@ func (d *DataplaneMetrics) Validate() error {
 }
 
 type ZoneMetrics struct {
-	Enabled           bool          `yaml:"enabled" envconfig:"kuma_metrics_zone_enabled"`
 	SubscriptionLimit int           `yaml:"subscriptionLimit" envconfig:"kuma_metrics_zone_subscription_limit"`
 	IdleTimeout       time.Duration `yaml:"idleTimeout" envconfig:"kuma_metrics_zone_idle_timeout"`
 }
@@ -176,12 +174,10 @@ var DefaultConfig = func() Config {
 		},
 		Metrics: &Metrics{
 			Dataplane: &DataplaneMetrics{
-				Enabled:           true,
 				SubscriptionLimit: 2,
 				IdleTimeout:       5 * time.Minute,
 			},
 			Zone: &ZoneMetrics{
-				Enabled:           true,
 				SubscriptionLimit: 10,
 				IdleTimeout:       5 * time.Minute,
 			},

--- a/pkg/config/loader_test.go
+++ b/pkg/config/loader_test.go
@@ -218,12 +218,10 @@ var _ = Describe("Config loader", func() {
 			Expect(cfg.XdsServer.DataplaneConfigurationRefreshInterval).To(Equal(21 * time.Second))
 			Expect(cfg.XdsServer.NACKBackoff).To(Equal(10 * time.Second))
 
-			Expect(cfg.Metrics.Zone.Enabled).To(BeFalse())
 			Expect(cfg.Metrics.Zone.SubscriptionLimit).To(Equal(23))
 			Expect(cfg.Metrics.Zone.IdleTimeout).To(Equal(2 * time.Minute))
 			Expect(cfg.Metrics.Mesh.MinResyncTimeout).To(Equal(35 * time.Second))
 			Expect(cfg.Metrics.Mesh.MaxResyncTimeout).To(Equal(27 * time.Second))
-			Expect(cfg.Metrics.Dataplane.Enabled).To(BeFalse())
 			Expect(cfg.Metrics.Dataplane.SubscriptionLimit).To(Equal(47))
 			Expect(cfg.Metrics.Dataplane.IdleTimeout).To(Equal(1 * time.Minute))
 
@@ -418,7 +416,6 @@ xdsServer:
   nackBackoff: 10s
 metrics:
   zone:
-    enabled: false
     subscriptionLimit: 23
     idleTimeout: 2m
   mesh:
@@ -426,7 +423,6 @@ metrics:
     maxResyncTimeout: 27s
   dataplane:
     subscriptionLimit: 47
-    enabled: false
     idleTimeout: 1m
 dpServer:
   tlsCertFile: /test/path
@@ -573,11 +569,9 @@ access:
 				"KUMA_XDS_SERVER_DATAPLANE_STATUS_FLUSH_INTERVAL":                                          "7s",
 				"KUMA_XDS_SERVER_DATAPLANE_CONFIGURATION_REFRESH_INTERVAL":                                 "21s",
 				"KUMA_XDS_SERVER_NACK_BACKOFF":                                                             "10s",
-				"KUMA_METRICS_ZONE_ENABLED":                                                                "false",
 				"KUMA_METRICS_ZONE_SUBSCRIPTION_LIMIT":                                                     "23",
 				"KUMA_METRICS_ZONE_IDLE_TIMEOUT":                                                           "2m",
 				"KUMA_METRICS_MESH_MAX_RESYNC_TIMEOUT":                                                     "27s",
-				"KUMA_METRICS_DATAPLANE_ENABLED":                                                           "false",
 				"KUMA_METRICS_MESH_MIN_RESYNC_TIMEOUT":                                                     "35s",
 				"KUMA_METRICS_DATAPLANE_SUBSCRIPTION_LIMIT":                                                "47",
 				"KUMA_METRICS_DATAPLANE_IDLE_TIMEOUT":                                                      "1m",

--- a/pkg/core/managers/apis/dataplaneinsight/dataplane_insight_manager.go
+++ b/pkg/core/managers/apis/dataplaneinsight/dataplane_insight_manager.go
@@ -3,6 +3,7 @@ package dataplaneinsight
 import (
 	"context"
 
+	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	kuma_cp "github.com/kumahq/kuma/pkg/config/app/kuma-cp"
 	"github.com/kumahq/kuma/pkg/core"
 	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
@@ -46,11 +47,8 @@ func (m *dataplaneInsightManager) Update(ctx context.Context, resource core_mode
 }
 
 func (m *dataplaneInsightManager) limitSubscription(dpInsight *core_mesh.DataplaneInsightResource) {
-	if !m.config.Enabled {
-		dpInsight.Spec.Subscriptions = nil
-		return
-	}
 	if m.config.SubscriptionLimit == 0 {
+		dpInsight.Spec.Subscriptions = []*mesh_proto.DiscoverySubscription{}
 		return
 	}
 	if len(dpInsight.Spec.Subscriptions) <= m.config.SubscriptionLimit {

--- a/pkg/core/managers/apis/dataplaneinsight/dataplane_insight_manager_test.go
+++ b/pkg/core/managers/apis/dataplaneinsight/dataplane_insight_manager_test.go
@@ -21,7 +21,6 @@ var _ = Describe("DataplaneInsight Manager", func() {
 		// setup
 		s := memory.NewStore()
 		cfg := &kuma_cp.DataplaneMetrics{
-			Enabled:           true,
 			SubscriptionLimit: 3,
 		}
 		manager := dataplaneinsight.NewDataplaneInsightManager(s, cfg)
@@ -51,11 +50,11 @@ var _ = Describe("DataplaneInsight Manager", func() {
 		Expect(actual.Spec.Subscriptions[2].Id).To(Equal("9"))
 	})
 
-	It("should cleanup subscriptions if disabled", func() {
+	It("should have 0 subscriptions if limit is 0", func() {
 		// setup
 		s := memory.NewStore()
 		cfg := &kuma_cp.DataplaneMetrics{
-			Enabled: false,
+			SubscriptionLimit: 0,
 		}
 		manager := dataplaneinsight.NewDataplaneInsightManager(s, cfg)
 

--- a/pkg/core/managers/apis/zoneingressinsight/zone_ingress_insight_manager.go
+++ b/pkg/core/managers/apis/zoneingressinsight/zone_ingress_insight_manager.go
@@ -3,6 +3,7 @@ package zoneingressinsight
 import (
 	"context"
 
+	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	kuma_cp "github.com/kumahq/kuma/pkg/config/app/kuma-cp"
 	"github.com/kumahq/kuma/pkg/core"
 	"github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
@@ -46,11 +47,8 @@ func (m *zoneIngressInsightManager) Update(ctx context.Context, resource core_mo
 }
 
 func (m *zoneIngressInsightManager) limitSubscription(zoneIngressInsight *mesh.ZoneIngressInsightResource) {
-	if !m.config.Enabled {
-		zoneIngressInsight.Spec.Subscriptions = nil
-		return
-	}
 	if m.config.SubscriptionLimit == 0 {
+		zoneIngressInsight.Spec.Subscriptions = []*mesh_proto.DiscoverySubscription{}
 		return
 	}
 	if len(zoneIngressInsight.Spec.Subscriptions) <= m.config.SubscriptionLimit {

--- a/pkg/core/managers/apis/zoneingressinsight/zone_ingress_insight_manager_test.go
+++ b/pkg/core/managers/apis/zoneingressinsight/zone_ingress_insight_manager_test.go
@@ -22,7 +22,6 @@ var _ = Describe("ZoneIngressInsight Manager", func() {
 		// setup
 		s := memory.NewStore()
 		cfg := &kuma_cp.DataplaneMetrics{
-			Enabled:           true,
 			SubscriptionLimit: 3,
 		}
 		manager := zoneingressinsight.NewZoneIngressInsightManager(s, cfg)
@@ -52,11 +51,11 @@ var _ = Describe("ZoneIngressInsight Manager", func() {
 		Expect(actual.Spec.Subscriptions[2].Id).To(Equal("9"))
 	})
 
-	It("should cleanup subscriptions if disabled", func() {
+	It("should cleanup subscriptions if limit is 0", func() {
 		// setup
 		s := memory.NewStore()
 		cfg := &kuma_cp.DataplaneMetrics{
-			Enabled: false,
+			SubscriptionLimit: 0,
 		}
 		manager := zoneingressinsight.NewZoneIngressInsightManager(s, cfg)
 

--- a/pkg/core/managers/apis/zoneinsight/zone_insight_manager.go
+++ b/pkg/core/managers/apis/zoneinsight/zone_insight_manager.go
@@ -3,6 +3,7 @@ package zoneinsight
 import (
 	"context"
 
+	system_proto "github.com/kumahq/kuma/api/system/v1alpha1"
 	kuma_cp "github.com/kumahq/kuma/pkg/config/app/kuma-cp"
 	"github.com/kumahq/kuma/pkg/core"
 	"github.com/kumahq/kuma/pkg/core/resources/apis/system"
@@ -46,11 +47,8 @@ func (m *zoneInsightManager) Update(ctx context.Context, resource core_model.Res
 }
 
 func (m *zoneInsightManager) limitSubscription(zoneInsight *system.ZoneInsightResource) {
-	if !m.config.Enabled {
-		zoneInsight.Spec.Subscriptions = nil
-		return
-	}
 	if m.config.SubscriptionLimit == 0 {
+		zoneInsight.Spec.Subscriptions = []*system_proto.KDSSubscription{}
 		return
 	}
 	if len(zoneInsight.Spec.Subscriptions) <= m.config.SubscriptionLimit {

--- a/pkg/core/managers/apis/zoneinsight/zone_insight_manager_test.go
+++ b/pkg/core/managers/apis/zoneinsight/zone_insight_manager_test.go
@@ -22,7 +22,6 @@ var _ = Describe("ZoneInsight Manager", func() {
 		// setup
 		s := memory.NewStore()
 		cfg := &kuma_cp.ZoneMetrics{
-			Enabled:           true,
 			SubscriptionLimit: 3,
 		}
 		manager := zoneinsight.NewZoneInsightManager(s, cfg)
@@ -52,11 +51,11 @@ var _ = Describe("ZoneInsight Manager", func() {
 		Expect(actual.Spec.Subscriptions[2].Id).To(Equal("9"))
 	})
 
-	It("should cleanup subscriptions if disabled", func() {
+	It("should cleanup subscriptions if limit is 0", func() {
 		// setup
 		s := memory.NewStore()
 		cfg := &kuma_cp.ZoneMetrics{
-			Enabled: false,
+			SubscriptionLimit: 0,
 		}
 		manager := zoneinsight.NewZoneInsightManager(s, cfg)
 


### PR DESCRIPTION
### Summary

remove `kuma.metrics.dataplane.enabled` and `kuma.metrics.zone.enabled` as insights are required internally anyway.

### Issues resolved

Fix #2565

### Documentation

- config are not updated

### Testing

- [x] Unit tests
- ~~[ ] E2E tests~~
- ~~[ ] Manual testing on Universal~~
- ~~[ ] Manual testing on Kubernetes~~

### Backwards compatibility

- [x] Update [`UPGRADE.md`](UPGRADE.md) with any steps users will need to take
      when upgrading.
- ~~[x] Add `backport-to-stable` label if the code is backwards compatible. Otherwise, list breaking changes.~~ BREAKING CHANGE: it's now impossible to disable insights and the related configuration was removed

