### PR TITLE
chore(kuma-cp): remove uncached Kubernetes readers

### DIFF
--- a/pkg/plugins/runtime/k8s/controllers/gatewayapi/gateway_controller.go
+++ b/pkg/plugins/runtime/k8s/controllers/gatewayapi/gateway_controller.go
@@ -31,8 +31,7 @@ const controllerName = "gateways.kuma.io/controller"
 // GatewayReconciler reconciles a GatewayAPI Gateway object.
 type GatewayReconciler struct {
 	kube_client.Client
-	Reader kube_client.Reader
-	Log    logr.Logger
+	Log logr.Logger
 
 	Scheme          *kube_runtime.Scheme
 	Converter       k8s_common.Converter

--- a/pkg/plugins/runtime/k8s/controllers/gatewayapi/http_route_controller.go
+++ b/pkg/plugins/runtime/k8s/controllers/gatewayapi/http_route_controller.go
@@ -26,8 +26,7 @@ import (
 // HTTPRouteReconciler reconciles a GatewayAPI object into Kuma-native objects
 type HTTPRouteReconciler struct {
 	kube_client.Client
-	Reader kube_client.Reader
-	Log    logr.Logger
+	Log logr.Logger
 
 	Scheme          *kube_runtime.Scheme
 	Converter       k8s_common.Converter

--- a/pkg/plugins/runtime/k8s/controllers/mesh_controller.go
+++ b/pkg/plugins/runtime/k8s/controllers/mesh_controller.go
@@ -21,8 +21,7 @@ import (
 // MeshReconciler reconciles a Mesh object
 type MeshReconciler struct {
 	kube_client.Client
-	Reader kube_client.Reader
-	Log    logr.Logger
+	Log logr.Logger
 
 	Scheme          *kube_runtime.Scheme
 	Converter       k8s_common.Converter

--- a/pkg/plugins/runtime/k8s/plugin.go
+++ b/pkg/plugins/runtime/k8s/plugin.go
@@ -125,7 +125,6 @@ func addMeshReconciler(mgr kube_ctrl.Manager, rt core_runtime.Runtime, converter
 	}
 	reconciler := &k8s_controllers.MeshReconciler{
 		Client:          mgr.GetClient(),
-		Reader:          mgr.GetAPIReader(),
 		Log:             core.Log.WithName("controllers").WithName("Mesh"),
 		Scheme:          mgr.GetScheme(),
 		Converter:       converter,

--- a/pkg/plugins/runtime/k8s/plugin_gateway.go
+++ b/pkg/plugins/runtime/k8s/plugin_gateway.go
@@ -70,7 +70,6 @@ func addGatewayReconciler(mgr kube_ctrl.Manager, rt core_runtime.Runtime, conver
 
 	gatewayAPIGatewayReconciler := &gatewayapi_controllers.GatewayReconciler{
 		Client:          mgr.GetClient(),
-		Reader:          mgr.GetAPIReader(),
 		Log:             core.Log.WithName("controllers").WithName("gatewayapi").WithName("Gateway"),
 		Scheme:          mgr.GetScheme(),
 		Converter:       converter,
@@ -84,7 +83,6 @@ func addGatewayReconciler(mgr kube_ctrl.Manager, rt core_runtime.Runtime, conver
 
 	gatewayAPIHTTPRouteReconciler := &gatewayapi_controllers.HTTPRouteReconciler{
 		Client:          mgr.GetClient(),
-		Reader:          mgr.GetAPIReader(),
 		Log:             core.Log.WithName("controllers").WithName("gatewayapi").WithName("HTTPRoute"),
 		Scheme:          mgr.GetScheme(),
 		Converter:       converter,


### PR DESCRIPTION
### Summary

None of the Kubernetes code ever used the uncached readers that
are returned from `GetAPIReader`, so we can remove them.

### Full changelog

N/A

### Issues resolved

N/A

### Documentation

N/A

### Testing

- [x] Unit tests
- [x] E2E tests
- [ ] ~~Manual testing on Universal~~
- [ ] ~~Manual testing on Kubernetes~~

### Backwards compatibility

- [ ] ~~Update [`UPGRADE.md`](UPGRADE.md) with any steps users will need to take when upgrading.~~
- [ ] ~~Add `backport-to-stable` label if the code is backwards compatible. Otherwise, list breaking changes.~~
