### PR TITLE
fix(ci): Don't use wget to install runc

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -159,9 +159,10 @@ commands:
         name: "Update runc"
         # See https://github.com/rancher/k3d/issues/807 (runc's default version on the instance fails k3d)
         command: |
-          sudo wget -O /usr/bin/runc https://github.com/opencontainers/runc/releases/download/v1.0.2/runc.amd64
-          sudo chown root:root /usr/bin/runc ; sudo chmod o+x /usr/bin/runc
-
+          if [[ `uname -s` == "Linux" ]]; then
+            sudo sh -c 'curl -s --fail --location https://github.com/opencontainers/runc/releases/download/v1.0.3/runc.amd64 > /usr/bin/runc'
+            sudo chown root:root /usr/bin/runc ; sudo chmod o+x /usr/bin/runc
+          fi
 
 executors:
   golang:


### PR DESCRIPTION
Not all build vms have wget

Signed-off-by: Charly Molter <charly.molter@konghq.com>

### Summary

SUMMARY_GOES_HERE

### Full changelog

* [Implement ...]
* [Fix ...]

### Issues resolved

Fix #XXX

### Documentation

- [ ] Link to the website [documentation PR](https://github.com/kumahq/kuma-website/pull/XXX)

### Testing

- [ ] Unit tests
- [ ] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes

### Backwards compatibility

- [ ] Update [`UPGRADE.md`](UPGRADE.md) with any steps users will need to take
      when upgrading.
- [ ] Add `backport-to-stable` label if the code is backwards compatible. Otherwise, list breaking changes.
