### PR TITLE
fix(kuma-cp) do not override other dataplane with dp lifecycle

### DIFF
--- a/mk/e2e.new.mk
+++ b/mk/e2e.new.mk
@@ -130,7 +130,7 @@ test/e2e/test:
 test/e2e/debug: build/kumactl images test/e2e/k8s/start
 	K8SCLUSTERS="$(K8SCLUSTERS)" \
 	KUMACTLBIN=${BUILD_ARTIFACTS_DIR}/kumactl/kumactl \
-	API_VERSION="$(API_VERSION)" \
+	$(ENV_VARS) \
 	GINKGO_EDITOR_INTEGRATION=true \
 		ginkgo --failFast $(GOFLAGS) $(LD_FLAGS) $(E2E_PKG_LIST)
 
@@ -140,7 +140,7 @@ test/e2e/debug: build/kumactl images test/e2e/k8s/start
 test/e2e/debug-universal: build/kumactl images/test
 	K8SCLUSTERS="$(K8SCLUSTERS)" \
 	KUMACTLBIN=${BUILD_ARTIFACTS_DIR}/kumactl/kumactl \
-	API_VERSION="$(API_VERSION)" \
+	$(ENV_VARS) \
 	GINKGO_EDITOR_INTEGRATION=true \
 		ginkgo --failFast $(GOFLAGS) $(LD_FLAGS) $(E2E_PKG_LIST)
 

--- a/pkg/util/proto/proto.go
+++ b/pkg/util/proto/proto.go
@@ -96,3 +96,7 @@ func MustToStruct(message proto.Message) *structpb.Struct {
 	}
 	return str
 }
+
+func IsEmpty(message proto.Message) bool {
+	return proto.Size(message) == 0
+}

--- a/pkg/xds/auth/callbacks.go
+++ b/pkg/xds/auth/callbacks.go
@@ -110,7 +110,7 @@ func (a *authCallbacks) credential(streamID core_xds.StreamID) (Credential, erro
 	if !exists {
 		return "", errors.Errorf("there is no context for stream ID %d", streamID)
 	}
-	credential, err := extractCredential(ctx)
+	credential, err := ExtractCredential(ctx)
 	if err != nil {
 		return "", errors.Wrap(err, "could not extract credential from DiscoveryRequest")
 	}
@@ -159,7 +159,7 @@ func (a *authCallbacks) authenticate(credential Credential, req util_xds.Discove
 		"authentication failed")
 }
 
-func extractCredential(ctx context.Context) (Credential, error) {
+func ExtractCredential(ctx context.Context) (Credential, error) {
 	metadata, ok := metadata.FromIncomingContext(ctx)
 	if !ok {
 		return "", errors.Errorf("request has no metadata")

--- a/pkg/xds/server/callbacks/dataplane_lifecycle.go
+++ b/pkg/xds/server/callbacks/dataplane_lifecycle.go
@@ -140,6 +140,8 @@ func (d *DataplaneLifecycle) registerDataplane(ctx context.Context, dp *core_mes
 // For example, if you spin down CP, then DP, then start CP, the old DP is still there for a couple of minutes (see pkg/gc).
 // We could check if Dataplane is identical, but CP may alter Dataplane resource after is connected.
 // What we do instead is that we use current data plane proxy credential to check if we can manage already registered Dataplane.
+// The assumption is that if you have a token that can manage the old Dataplane.
+// You can delete it and create a new one, so we can simplify this manual process by just replacing it.
 func (d *DataplaneLifecycle) validateUpsert(ctx context.Context, existing model.Resource) error {
 	if util_proto.IsEmpty(existing.GetSpec()) { // existing DP is empty, resource does not exist
 		return nil

--- a/pkg/xds/server/callbacks/dataplane_lifecycle_test.go
+++ b/pkg/xds/server/callbacks/dataplane_lifecycle_test.go
@@ -107,7 +107,7 @@ var _ = Describe("Dataplane Lifecycle", func() {
 		Expect(core_store.IsResourceNotFound(err)).To(BeTrue())
 	})
 
-	It("should not override other DP", func() {
+	It("should not override extisting DP with different service", func() {
 		// given already created DP
 		dp := &core_mesh.DataplaneResource{
 			Meta: &model.ResourceMeta{

--- a/pkg/xds/server/v3/components.go
+++ b/pkg/xds/server/v3/components.go
@@ -57,7 +57,7 @@ func RegisterXDS(
 		util_xds_v3.AdaptCallbacks(authCallbacks),
 		util_xds_v3.AdaptCallbacks(xds_callbacks.DataplaneCallbacksToXdsCallbacks(xds_callbacks.NewDataplaneSyncTracker(watchdogFactory.New))),
 		util_xds_v3.AdaptCallbacks(xds_callbacks.DataplaneCallbacksToXdsCallbacks(metadataTracker)),
-		util_xds_v3.AdaptCallbacks(xds_callbacks.DataplaneCallbacksToXdsCallbacks(xds_callbacks.NewDataplaneLifecycle(rt.AppContext(), rt.ResourceManager()))),
+		util_xds_v3.AdaptCallbacks(xds_callbacks.DataplaneCallbacksToXdsCallbacks(xds_callbacks.NewDataplaneLifecycle(rt.AppContext(), rt.ResourceManager(), authenticator))),
 		util_xds_v3.AdaptCallbacks(DefaultDataplaneStatusTracker(rt, envoyCpCtx.Secrets)),
 		util_xds_v3.AdaptCallbacks(xds_callbacks.NewNackBackoff(rt.Config().XdsServer.NACKBackoff)),
 		newResourceWarmingForcer(xdsContext.Cache(), xdsContext.Hasher()),

--- a/test/e2e/auth/dp/auth_dp_suite_test.go
+++ b/test/e2e/auth/dp/auth_dp_suite_test.go
@@ -3,7 +3,10 @@ package auth_test
 import (
 	"testing"
 
+	. "github.com/onsi/ginkgo"
+
 	"github.com/kumahq/kuma/pkg/test"
+	auth "github.com/kumahq/kuma/test/e2e/auth/dp"
 	"github.com/kumahq/kuma/test/framework"
 )
 
@@ -14,3 +17,5 @@ func TestE2EDpAuth(t *testing.T) {
 		t.SkipNow()
 	}
 }
+
+var _ = Describe("Test Universal", auth.DpAuthUniversal)

--- a/test/e2e/auth/dp/auth_dp_suite_test.go
+++ b/test/e2e/auth/dp/auth_dp_suite_test.go
@@ -1,0 +1,16 @@
+package auth_test
+
+import (
+	"testing"
+
+	"github.com/kumahq/kuma/pkg/test"
+	"github.com/kumahq/kuma/test/framework"
+)
+
+func TestE2EDpAuth(t *testing.T) {
+	if framework.IsK8sClustersStarted() {
+		test.RunSpecs(t, "E2E Auth DP Suite")
+	} else {
+		t.SkipNow()
+	}
+}

--- a/test/e2e/auth/dp/dp_auth_universal.go
+++ b/test/e2e/auth/dp/dp_auth_universal.go
@@ -1,0 +1,85 @@
+package auth
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/kumahq/kuma/pkg/config/core"
+	. "github.com/kumahq/kuma/test/framework"
+)
+
+func DpAuthUniversal() {
+	var cluster Cluster
+	var deployOptsFuncs []KumaDeploymentOption
+
+	E2EBeforeSuite(func() {
+		cluster = NewUniversalCluster(NewTestingT(), Kuma3, Silent)
+		deployOptsFuncs = KumaUniversalDeployOpts
+
+		err := NewClusterSetup().
+			Install(Kuma(core.Standalone, deployOptsFuncs...)).
+			Setup(cluster)
+		Expect(err).ToNot(HaveOccurred())
+		err = cluster.VerifyKuma()
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	E2EAfterSuite(func() {
+		Expect(cluster.DeleteKuma(deployOptsFuncs...)).To(Succeed())
+		Expect(cluster.DismissCluster()).To(Succeed())
+	})
+
+	It("should not be able to override someone else Dataplane", func() {
+		// given other dataplane
+		dp := `
+type: Dataplane
+mesh: default
+name: dp-01
+networking:
+  address: 192.168.0.1
+  inbound:
+  - port: 8080
+    tags:
+      kuma.io/service: not-test-server
+`
+		Expect(YamlUniversal(dp)(cluster)).To(Succeed())
+
+		// when trying to spin up dataplane with same name but token bound to a different service
+		dpToken, err := cluster.GetKuma().GenerateDpToken("default", "test-server")
+		Expect(err).ToNot(HaveOccurred())
+		err = TestServerUniversal("dp-01", "default", dpToken, WithServiceName("test-server"))(cluster)
+		Expect(err).ToNot(HaveOccurred())
+
+		// then
+		Eventually(func() (string, error) {
+			return cluster.GetKuma().GetKumaCPLogs()
+		}, "30s", "1s").Should(ContainSubstring("you are trying to override existing dataplane to which you don't have an access"))
+	})
+
+	It("should be able to override old Dataplane of same service", func() {
+		// given
+		dp := `
+type: Dataplane
+mesh: default
+name: dp-02
+networking:
+  address: 192.168.0.2
+  inbound:
+  - port: 8080
+    tags:
+      kuma.io/service: test-server
+`
+		Expect(YamlUniversal(dp)(cluster)).To(Succeed())
+
+		// when
+		dpToken, err := cluster.GetKuma().GenerateDpToken("default", "test-server")
+		Expect(err).ToNot(HaveOccurred())
+		err = TestServerUniversal("dp-02", "default", dpToken, WithServiceName("test-server"))(cluster)
+		Expect(err).ToNot(HaveOccurred())
+
+		// then
+		Eventually(func() (string, error) {
+			return cluster.GetKumactlOptions().RunKumactlAndGetOutput("get", "dataplanes", "-oyaml")
+		}, "30s", "1s").ShouldNot(ContainSubstring("192.168.0.2"))
+	})
+}

--- a/test/e2e/auth/dp/dp_auth_universal_test.go
+++ b/test/e2e/auth/dp/dp_auth_universal_test.go
@@ -1,9 +1,0 @@
-package auth_test
-
-import (
-	. "github.com/onsi/ginkgo"
-
-	"github.com/kumahq/kuma/test/e2e/auth/dp"
-)
-
-var _ = Describe("Test Universal", auth.DpAuthUniversal)

--- a/test/e2e/auth/dp/dp_auth_universal_test.go
+++ b/test/e2e/auth/dp/dp_auth_universal_test.go
@@ -1,0 +1,9 @@
+package auth_test
+
+import (
+	. "github.com/onsi/ginkgo"
+
+	"github.com/kumahq/kuma/test/e2e/auth/dp"
+)
+
+var _ = Describe("Test Universal", auth.DpAuthUniversal)

--- a/test/framework/universal_controlplane.go
+++ b/test/framework/universal_controlplane.go
@@ -42,7 +42,7 @@ func (c *UniversalControlPlane) GetName() string {
 }
 
 func (c *UniversalControlPlane) GetKumaCPLogs() (string, error) {
-	panic("not implemented")
+	return c.cluster.apps[AppModeCP].mainApp.Out(), nil
 }
 
 func (c *UniversalControlPlane) GetKDSServerAddress() string {


### PR DESCRIPTION
### Summary

With the current implementation of DP lifecycle, you could override other DP when the new token is was issued for mesh + kuma.io/service tag

### Issues resolved

No issue reported.

### Documentation

- [X] No extra docs, internal changes only

### Testing

- [X] Unit tests
- [X] E2E tests
- [X] Manual testing on Universal
- [ ] Manual testing on Kubernetes

### Backwards compatibility

- [X] No UPGRADE.md notes
- [X] Add `backport-to-stable` label if the code is backwards compatible. Otherwise, list breaking changes.
