### PR TITLE
fix(ci): fix flaky mads test

### DIFF
--- a/pkg/mads/v1/service_test.go
+++ b/pkg/mads/v1/service_test.go
@@ -459,7 +459,7 @@ var _ = Describe("MADS http service", func() {
 			Expect(discoveryRes.Resources).To(HaveLen(2))
 		})
 
-		It("should allow specifying the fetch timeout", func() {
+		It("should return straightaway on first request with a fetch timeout", func() {
 			// given
 			discoveryReq := envoy_v3.DiscoveryRequest{
 				VersionInfo:   "",


### PR DESCRIPTION
This test was making timing assumptions which causes can cause CI to be flaky
It seems this test still makes sense with the dataplane creation race.