### PR TITLE
chore(e2e): regularize test framework cluster creation

### DIFF
--- a/test/e2e/compatibility/cp_compatibility_kubernetes_multizone.go
+++ b/test/e2e/compatibility/cp_compatibility_kubernetes_multizone.go
@@ -47,13 +47,9 @@ func CpCompatibilityMultizoneKubernetes() {
 
 	BeforeEach(func() {
 		// Global CP
-		c, err := NewK8sClusterWithTimeout(
-			NewTestingT(),
-			Kuma1,
-			Silent,
-			6*time.Second)
-		Expect(err).ToNot(HaveOccurred())
-		globalCluster = c.WithRetries(60)
+		globalCluster = NewK8sCluster(NewTestingT(), Kuma1, Silent).
+			WithTimeout(6 * time.Second).
+			WithRetries(60)
 
 		globalReleaseName = fmt.Sprintf(
 			"kuma-%s",
@@ -69,7 +65,7 @@ func CpCompatibilityMultizoneKubernetes() {
 			WithoutHelmOpt("global.image.tag"),
 			WithHelmOpt("global.image.registry", UpstreamImageRegistry))
 
-		err = NewClusterSetup().
+		err := NewClusterSetup().
 			Install(Kuma(core.Global, globalDeployOptsFuncs...)).
 			Setup(globalCluster)
 		Expect(err).ToNot(HaveOccurred())
@@ -77,13 +73,9 @@ func CpCompatibilityMultizoneKubernetes() {
 		Expect(globalCluster.VerifyKuma()).To(Succeed())
 
 		// Zone CP
-		c, err = NewK8sClusterWithTimeout(
-			NewTestingT(),
-			Kuma2,
-			Silent,
-			6*time.Second)
-		Expect(err).ToNot(HaveOccurred())
-		zoneCluster = c.WithRetries(60)
+		zoneCluster = NewK8sCluster(NewTestingT(), Kuma2, Silent).
+			WithTimeout(6 * time.Second).
+			WithRetries(60)
 
 		zoneReleaseName = fmt.Sprintf(
 			"kuma-%s",

--- a/test/e2e/helm/kuma_helm_deploy_autoscaling.go
+++ b/test/e2e/helm/kuma_helm_deploy_autoscaling.go
@@ -21,14 +21,9 @@ func ControlPlaneAutoscalingWithHelmChart() {
 	var deployOptsFuncs = KumaK8sDeployOpts
 
 	BeforeEach(func() {
-		c, err := NewK8sClusterWithTimeout(
-			NewTestingT(),
-			Kuma1,
-			Silent,
-			6*time.Second)
-		Expect(err).ToNot(HaveOccurred())
-
-		cluster = c.WithRetries(60)
+		cluster = NewK8sCluster(NewTestingT(), Kuma1, Silent).
+			WithTimeout(6 * time.Second).
+			WithRetries(60)
 
 		releaseName := fmt.Sprintf(
 			"kuma-%s",
@@ -41,7 +36,7 @@ func ControlPlaneAutoscalingWithHelmChart() {
 			WithHelmOpt("controlPlane.autoscaling.minReplicas", strconv.Itoa(minReplicas)),
 			WithCNI())
 
-		err = NewClusterSetup().
+		err := NewClusterSetup().
 			Install(Kuma(core.Standalone, deployOptsFuncs...)).
 			Setup(cluster)
 		Expect(err).ToNot(HaveOccurred())

--- a/test/e2e/helm/kuma_helm_deploy_multi_apps.go
+++ b/test/e2e/helm/kuma_helm_deploy_multi_apps.go
@@ -39,14 +39,9 @@ metadata:
 	var deployOptsFuncs = KumaK8sDeployOpts
 
 	BeforeEach(func() {
-		c, err := NewK8sClusterWithTimeout(
-			NewTestingT(),
-			Kuma1,
-			Silent,
-			6*time.Second)
-		Expect(err).ToNot(HaveOccurred())
-
-		cluster = c.WithRetries(60)
+		cluster = NewK8sCluster(NewTestingT(), Kuma1, Silent).
+			WithTimeout(6 * time.Second).
+			WithRetries(60)
 
 		releaseName := fmt.Sprintf(
 			"kuma-%s",
@@ -59,7 +54,7 @@ metadata:
 			WithCPReplicas(3),         // test HA capability
 			WithCNI())
 
-		err = NewClusterSetup().
+		err := NewClusterSetup().
 			Install(Kuma(core.Standalone, deployOptsFuncs...)).
 			Install(YamlK8s(defaultMesh)).
 			Setup(cluster)

--- a/test/e2e/helm/kuma_helm_upgrade.go
+++ b/test/e2e/helm/kuma_helm_upgrade.go
@@ -39,14 +39,10 @@ func UpgradingWithHelmChart() {
 	DescribeTable(
 		"should successfully upgrade Kuma via Helm",
 		func(given testCase) {
-			c, err := NewK8sClusterWithTimeout(
-				NewTestingT(),
-				Kuma1,
-				Silent,
-				6*time.Second)
-			Expect(err).ToNot(HaveOccurred())
+			cluster = NewK8sCluster(NewTestingT(), Kuma1, Silent).
+				WithTimeout(6 * time.Second).
+				WithRetries(60)
 
-			cluster = c.WithRetries(60)
 			InitCluster(cluster)
 
 			releaseName := fmt.Sprintf(
@@ -63,7 +59,7 @@ func UpgradingWithHelmChart() {
 				WithoutHelmOpt("global.image.tag"),
 				WithHelmOpt("global.image.registry", UpstreamImageRegistry))
 
-			err = NewClusterSetup().
+			err := NewClusterSetup().
 				Install(Kuma(core.Standalone, deployOptsFuncs...)).
 				Setup(cluster)
 			Expect(err).ToNot(HaveOccurred())

--- a/test/e2e/k8s_api_bypass/k8s_api_bypass.go
+++ b/test/e2e/k8s_api_bypass/k8s_api_bypass.go
@@ -46,12 +46,9 @@ metadata:
 	var deployOptsFuncs = KumaK8sDeployOpts
 
 	BeforeEach(func() {
-		c, err := NewK8SCluster(NewTestingT(), Kuma1, Silent)
-		Expect(err).ToNot(HaveOccurred())
+		cluster = NewK8sCluster(NewTestingT(), Kuma1, Silent)
 
-		cluster = c.(*K8sCluster)
-
-		err = NewClusterSetup().
+		err := NewClusterSetup().
 			Install(Kuma(core.Standalone, deployOptsFuncs...)).
 			Install(YamlK8s(namespaceWithSidecarInjection(TestNamespace))).
 			Install(DemoClientK8s("default")).

--- a/test/e2e/tracing/tracing_kubernetes.go
+++ b/test/e2e/tracing/tracing_kubernetes.go
@@ -63,10 +63,8 @@ spec:
 	var deployOptsFuncs = KumaK8sDeployOpts
 
 	BeforeEach(func() {
-		c, err := NewK8SCluster(NewTestingT(), Kuma1, Silent)
-		Expect(err).ToNot(HaveOccurred())
-		cluster = c
-		err = NewClusterSetup().
+		cluster = NewK8sCluster(NewTestingT(), Kuma1, Silent)
+		err := NewClusterSetup().
 			Install(Kuma(core.Standalone, deployOptsFuncs...)).
 			Install(YamlK8s(namespaceWithSidecarInjection(TestNamespace))).
 			Install(DemoClientK8s("default")).

--- a/test/e2e/virtualoutbound/virtualoutbound_k8s.go
+++ b/test/e2e/virtualoutbound/virtualoutbound_k8s.go
@@ -31,11 +31,9 @@ metadata:
 	)
 
 	BeforeEach(func() {
-		c, err := NewK8SCluster(NewTestingT(), Kuma1, Silent)
-		Expect(err).ToNot(HaveOccurred())
-		k8sCluster = c
+		k8sCluster = NewK8sCluster(NewTestingT(), Kuma1, Silent)
 
-		err = NewClusterSetup().
+		err := NewClusterSetup().
 			Install(Kuma(config_core.Standalone, optsKubernetes...)).
 			Install(YamlK8s(namespaceWithSidecarInjection(TestNamespace))).
 			Install(DemoClientK8s("default")).

--- a/test/framework/exec_util.go
+++ b/test/framework/exec_util.go
@@ -41,7 +41,10 @@ func (c *K8sCluster) ExecWithOptions(options ExecOptions) (string, string, error
 	config, err := k8s.LoadApiClientConfigE(c.kubeconfig, "")
 	Expect(err).NotTo(HaveOccurred())
 
-	req := c.clientset.CoreV1().RESTClient().Post().
+	clientset, err := k8s.GetKubernetesClientFromOptionsE(c.t, c.GetKubectlOptions())
+	Expect(err).NotTo(HaveOccurred())
+
+	req := clientset.CoreV1().RESTClient().Post().
 		Resource("pods").
 		Name(options.PodName).
 		Namespace(options.Namespace).

--- a/test/framework/k8s_clusters.go
+++ b/test/framework/k8s_clusters.go
@@ -2,7 +2,6 @@ package framework
 
 import (
 	"fmt"
-	"os"
 	"time"
 
 	"github.com/gruntwork-io/terratest/modules/k8s"
@@ -30,24 +29,9 @@ func NewK8sClusters(clusterNames []string, verbose bool) (Clusters, error) {
 	clusters := map[string]*K8sCluster{}
 
 	for i, name := range clusterNames {
-		clusters[name] = &K8sCluster{
-			t:                   t,
-			name:                name,
-			kubeconfig:          os.ExpandEnv(fmt.Sprintf(defaultKubeConfigPathPattern, name)),
-			loPort:              uint32(kumaCPAPIPortFwdBase + i*1000),
-			hiPort:              uint32(kumaCPAPIPortFwdBase + (i+1)*1000 - 1),
-			forwardedPortsChans: map[uint32]chan struct{}{},
-			verbose:             verbose,
-			deployments:         map[string]Deployment{},
-			defaultTimeout:      GetDefaultTimeout(),
-			defaultRetries:      GetDefaultRetries(),
-		}
-
-		var err error
-		clusters[name].clientset, err = k8s.GetKubernetesClientFromOptionsE(t, clusters[name].GetKubectlOptions())
-		if err != nil {
-			return nil, errors.Wrapf(err, "error in getting access to K8S")
-		}
+		clusters[name] = NewK8sCluster(t, name, verbose)
+		clusters[name].loPort = uint32(kumaCPAPIPortFwdBase + i*1000)
+		clusters[name].hiPort = uint32(kumaCPAPIPortFwdBase + (i+1)*1000 - 1)
 	}
 
 	return &K8sClusters{


### PR DESCRIPTION
### Summary

Make initializing a Kubernetes cluster have the same function signature as
initializing a Universal cluster. This also lets us remove the additional
timeout helper for Kubernetes clusters, and makes code that uses the
different cluster types more similar.


### Full changelog

N/A

### Issues resolved

N/A

### Documentation

N/A

### Testing

- [x] Unit tests
- [x] E2E tests
- [ ] ~~Manual testing on Universal~~
- [ ] ~~Manual testing on Kubernetes~~

### Backwards compatibility

- [ ] ~~Update [`UPGRADE.md`](UPGRADE.md) with any steps users will need to take when upgrading.~~
- [ ] ~~Add `backport-to-stable` label if the code is backwards compatible. Otherwise, list breaking changes.~~
