### PR TITLE
chore(*) release Kuma 1.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,36 +12,23 @@ Changes:
 * test: fix postgress tests permissions [#3443](https://github.com//kumahq/kuma/pull/3443)
 * feat: add affinity to CP and Ingress pods [#3036](https://github.com//kumahq/kuma/pull/3036)
   👍contributed by @andrey-dubnik
-* chore: bump github.com/gruntwork-io/terratest [#3433](https://github.com//kumahq/kuma/pull/3433)
 * chore: bump github.com/golang-jwt/jwt/v4 from 4.1.0 to 4.2.0 [#3432](https://github.com//kumahq/kuma/pull/3432)
 * feat: consolidate tokens logic to support expiration, rotation, revocation and RSA256
-* ci: fix failing mac CI because of unsupported instance size [#3408](https://github.com//kumahq/kuma/pull/3408)
 * fix:: simplify cluster creation with endpoints [#3403](https://github.com//kumahq/kuma/pull/3403)
 * fix: enable metrics hijacker for current version of Kuma [#3405](https://github.com//kumahq/kuma/pull/3405)
 * fix: switch to mTLS when CP communicates with Envoy Admin [#3353](https://github.com//kumahq/kuma/pull/3353)
-* test: disable KIC E2E tests on Kind [#3398](https://github.com//kumahq/kuma/pull/3398)
 * chore: bump github.com/spiffe/spire from 0.12.3 to 1.1.1 [#3388](https://github.com//kumahq/kuma/pull/3388)
 * chore: bump github.com/spf13/viper from 1.8.1 to 1.9.0 [#3389](https://github.com//kumahq/kuma/pull/3389)
 * fix: validate cp url in dp conf [#3357](https://github.com//kumahq/kuma/pull/3357)
 * chore: send reports to tls endpoint [#3361](https://github.com//kumahq/kuma/pull/3361)
 * chore: check explicit service account name [#3228](https://github.com//kumahq/kuma/pull/3228)
 * feat: inspect other dependencies versions [#3352](https://github.com//kumahq/kuma/pull/3352)
-* chore: upgrade minikube to v1.24.0 [#3269](https://github.com//kumahq/kuma/pull/3269)
 * chore: add area/gateway label [#3263](https://github.com//kumahq/kuma/pull/3263)
-* build: notify about merged PRs on release branch [#3289](https://github.com//kumahq/kuma/pull/3289)
 * chore: remove dp token from xds metadata [#3282](https://github.com//kumahq/kuma/pull/3282)
 * refactor: move from io/ioutil to io and os packages [#3265](https://github.com//kumahq/kuma/pull/3265)
   👍contributed by @Juneezee
-* build: github notify about merged PRs workflow [#3258](https://github.com//kumahq/kuma/pull/3258)
 * fix: validate newly generated xDS snapshots [#3195](https://github.com//kumahq/kuma/pull/3195)
-* chore: remove RBAC generator [#3176](https://github.com//kumahq/kuma/pull/3176)
-* fix: run test/release also for RCs [#3208](https://github.com//kumahq/kuma/pull/3208)
-* chore: bump k8s.io/apiextensions-apiserver from 0.22.3 to 0.22.4 [#3218](https://github.com//kumahq/kuma/pull/3218)
-* chore: bump github.com/testcontainers/testcontainers-go [#3221](https://github.com//kumahq/kuma/pull/3221)
-* chore: bump github.com/gruntwork-io/terratest [#3222](https://github.com//kumahq/kuma/pull/3222)
-* build: fix dev_mac [#3209](https://github.com//kumahq/kuma/pull/3209)
-* chore: install latest kubectl version [#3207](https://github.com//kumahq/kuma/pull/3207)
-* tests: fix golden files after Helm chart update [#3205](https://github.com//kumahq/kuma/pull/3205)
+* chore: bump k8s.io/apiextensions-apiserver from 0.22.3 to 0.22.4 [#3218](https://github.com//kumahq/kuma/pull/3218)[s
 * chore: bump helm chart version to 0.8 [#3202](https://github.com//kumahq/kuma/pull/3202)
 
 ## [1.4.0]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,8 @@ Changes:
 * feat: add affinity to CP and Ingress pods [#3036](https://github.com//kumahq/kuma/pull/3036)
   👍contributed by @andrey-dubnik
 * chore: bump github.com/golang-jwt/jwt/v4 from 4.1.0 to 4.2.0 [#3432](https://github.com//kumahq/kuma/pull/3432)
-* feat: consolidate tokens logic to support expiration, rotation, revocation and RSA256
-* fix:: simplify cluster creation with endpoints [#3403](https://github.com//kumahq/kuma/pull/3403)
+* feat: consolidate tokens logic to support expiration, rotation, revocation and RSA256 [#3376](https://github.com/kumahq/kuma/pull/3376)
+* fix: simplify cluster creation with endpoints [#3403](https://github.com//kumahq/kuma/pull/3403)
 * fix: enable metrics hijacker for current version of Kuma [#3405](https://github.com//kumahq/kuma/pull/3405)
 * fix: switch to mTLS when CP communicates with Envoy Admin [#3353](https://github.com//kumahq/kuma/pull/3353)
 * chore: bump github.com/spiffe/spire from 0.12.3 to 1.1.1 [#3388](https://github.com//kumahq/kuma/pull/3388)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,49 @@
 # CHANGELOG
 
+## [1.4.1]
+> Released on TBD
+
+Changes:
+* feat: add kubernetes tags automatically [#3439](https://github.com//kumahq/kuma/pull/3439)
+* perf: update Mesh and ServiceInsights only when really needed [#3463](https://github.com//kumahq/kuma/pull/3463)
+* perf: eliminate uneccessary JSON marshalling [#3483](https://github.com//kumahq/kuma/pull/3483)
+* feat: sidecar injection webhook based on labels [#3417](https://github.com//kumahq/kuma/pull/3417)
+* chore: upgrade gui to new version [#3454](https://github.com//kumahq/kuma/pull/3454)
+* test: fix postgress tests permissions [#3443](https://github.com//kumahq/kuma/pull/3443)
+* feat: add affinity to CP and Ingress pods [#3036](https://github.com//kumahq/kuma/pull/3036)
+  👍contributed by @andrey-dubnik
+* chore: bump github.com/gruntwork-io/terratest [#3433](https://github.com//kumahq/kuma/pull/3433)
+* chore: bump github.com/golang-jwt/jwt/v4 from 4.1.0 to 4.2.0 [#3432](https://github.com//kumahq/kuma/pull/3432)
+* feat: consolidate tokens logic to support expiration, rotation, revocation and RSA256
+* ci: fix failing mac CI because of unsupported instance size [#3408](https://github.com//kumahq/kuma/pull/3408)
+* fix:: simplify cluster creation with endpoints [#3403](https://github.com//kumahq/kuma/pull/3403)
+* fix: enable metrics hijacker for current version of Kuma [#3405](https://github.com//kumahq/kuma/pull/3405)
+* fix: switch to mTLS when CP communicates with Envoy Admin [#3353](https://github.com//kumahq/kuma/pull/3353)
+* test: disable KIC E2E tests on Kind [#3398](https://github.com//kumahq/kuma/pull/3398)
+* chore: bump github.com/spiffe/spire from 0.12.3 to 1.1.1 [#3388](https://github.com//kumahq/kuma/pull/3388)
+* chore: bump github.com/spf13/viper from 1.8.1 to 1.9.0 [#3389](https://github.com//kumahq/kuma/pull/3389)
+* fix: validate cp url in dp conf [#3357](https://github.com//kumahq/kuma/pull/3357)
+* chore: send reports to tls endpoint [#3361](https://github.com//kumahq/kuma/pull/3361)
+* chore: check explicit service account name [#3228](https://github.com//kumahq/kuma/pull/3228)
+* feat: inspect other dependencies versions [#3352](https://github.com//kumahq/kuma/pull/3352)
+* chore: upgrade minikube to v1.24.0 [#3269](https://github.com//kumahq/kuma/pull/3269)
+* chore: add area/gateway label [#3263](https://github.com//kumahq/kuma/pull/3263)
+* build: notify about merged PRs on release branch [#3289](https://github.com//kumahq/kuma/pull/3289)
+* chore: remove dp token from xds metadata [#3282](https://github.com//kumahq/kuma/pull/3282)
+* refactor: move from io/ioutil to io and os packages [#3265](https://github.com//kumahq/kuma/pull/3265)
+  👍contributed by @Juneezee
+* build: github notify about merged PRs workflow [#3258](https://github.com//kumahq/kuma/pull/3258)
+* fix: validate newly generated xDS snapshots [#3195](https://github.com//kumahq/kuma/pull/3195)
+* chore: remove RBAC generator [#3176](https://github.com//kumahq/kuma/pull/3176)
+* fix: run test/release also for RCs [#3208](https://github.com//kumahq/kuma/pull/3208)
+* chore: bump k8s.io/apiextensions-apiserver from 0.22.3 to 0.22.4 [#3218](https://github.com//kumahq/kuma/pull/3218)
+* chore: bump github.com/testcontainers/testcontainers-go [#3221](https://github.com//kumahq/kuma/pull/3221)
+* chore: bump github.com/gruntwork-io/terratest [#3222](https://github.com//kumahq/kuma/pull/3222)
+* build: fix dev_mac [#3209](https://github.com//kumahq/kuma/pull/3209)
+* chore: install latest kubectl version [#3207](https://github.com//kumahq/kuma/pull/3207)
+* tests: fix golden files after Helm chart update [#3205](https://github.com//kumahq/kuma/pull/3205)
+* chore: bump helm chart version to 0.8 [#3202](https://github.com//kumahq/kuma/pull/3202)
+
 ## [1.4.0]
 > Released on 2021/11/22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # CHANGELOG
 
 ## [1.4.1]
-> Released on TBD
+> Released on 2021/12/15
 
 Changes:
 * feat: add kubernetes tags automatically [#3439](https://github.com//kumahq/kuma/pull/3439)

--- a/app/kumactl/cmd/install/testdata/install-control-plane.cni-enabled.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.cni-enabled.golden.yaml
@@ -938,7 +938,7 @@ spec:
         # priority scheduling and that its resources are reserved
         # if it ever gets evicted.
         scheduler.alpha.kubernetes.io/critical-pod: ''
-        checksum/config: ca82ff690209d56387b55783e5b94a934daee0dae2ca3c508cc8f1c63a6fc954
+        checksum/config: 04fda1a8e72d1c66f7648beee2738557d5b18e3eb4ffbb0b9c94c4d1106521fc
     spec:
       nodeSelector:
       
@@ -1016,8 +1016,8 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: bd9040893dba92c246c9f15b8e5c5fdbbccabfeb97201a967595c7c13f24356c
-        checksum/tls-secrets: 5f337216840fad68c3d519633e8a1fb5c9f4fc6c4303497f65c0309135a00e21
+        checksum/config: 1458b4c23aeef8ef647bc61e48108682315cc7a51ceebdcc7a2f3b0b70923dc1
+        checksum/tls-secrets: d262aff32362895b4ff2559c48c3dda8e72f6fbd95150ee31b360b84410a71fd
       labels:
         app.kubernetes.io/name: kuma
         app.kubernetes.io/instance: kuma

--- a/app/kumactl/cmd/install/testdata/install-control-plane.defaults.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.defaults.golden.yaml
@@ -841,8 +841,8 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: bd9040893dba92c246c9f15b8e5c5fdbbccabfeb97201a967595c7c13f24356c
-        checksum/tls-secrets: 5f337216840fad68c3d519633e8a1fb5c9f4fc6c4303497f65c0309135a00e21
+        checksum/config: 1458b4c23aeef8ef647bc61e48108682315cc7a51ceebdcc7a2f3b0b70923dc1
+        checksum/tls-secrets: d262aff32362895b4ff2559c48c3dda8e72f6fbd95150ee31b360b84410a71fd
       labels:
         app.kubernetes.io/name: kuma
         app.kubernetes.io/instance: kuma

--- a/app/kumactl/cmd/install/testdata/install-control-plane.global.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.global.golden.yaml
@@ -850,8 +850,8 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: bd9040893dba92c246c9f15b8e5c5fdbbccabfeb97201a967595c7c13f24356c
-        checksum/tls-secrets: 5f337216840fad68c3d519633e8a1fb5c9f4fc6c4303497f65c0309135a00e21
+        checksum/config: 1458b4c23aeef8ef647bc61e48108682315cc7a51ceebdcc7a2f3b0b70923dc1
+        checksum/tls-secrets: d262aff32362895b4ff2559c48c3dda8e72f6fbd95150ee31b360b84410a71fd
       labels:
         app.kubernetes.io/name: kuma
         app.kubernetes.io/instance: kuma

--- a/app/kumactl/cmd/install/testdata/install-control-plane.override-env-vars.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.override-env-vars.golden.yaml
@@ -841,8 +841,8 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: bd9040893dba92c246c9f15b8e5c5fdbbccabfeb97201a967595c7c13f24356c
-        checksum/tls-secrets: 5f337216840fad68c3d519633e8a1fb5c9f4fc6c4303497f65c0309135a00e21
+        checksum/config: 1458b4c23aeef8ef647bc61e48108682315cc7a51ceebdcc7a2f3b0b70923dc1
+        checksum/tls-secrets: d262aff32362895b4ff2559c48c3dda8e72f6fbd95150ee31b360b84410a71fd
       labels:
         app.kubernetes.io/name: kuma
         app.kubernetes.io/instance: kuma

--- a/app/kumactl/cmd/install/testdata/install-control-plane.overrides.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.overrides.golden.yaml
@@ -845,8 +845,8 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 243da0d686658ca26902677cd16971d2ec72fe4453dbb0b09c09ea96b423d4ce
-        checksum/tls-secrets: 12e245aa8f7469c6fcbc3fc3c91c376d33ecc6298869b68332d21c56aa5c38d4
+        checksum/config: 2469963cc25625850293897d643bcc58ddf07eb9aa5095b1860cc96c2041ad3c
+        checksum/tls-secrets: 1b96fa4d966eb78ff90532995cc25e63c1c79d33c1318709df256d7cc1d7a642
       labels:
         app.kubernetes.io/name: kuma
         app.kubernetes.io/instance: kuma

--- a/app/kumactl/cmd/install/testdata/install-control-plane.with-ingress.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.with-ingress.golden.yaml
@@ -870,8 +870,8 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: bd9040893dba92c246c9f15b8e5c5fdbbccabfeb97201a967595c7c13f24356c
-        checksum/tls-secrets: 5f337216840fad68c3d519633e8a1fb5c9f4fc6c4303497f65c0309135a00e21
+        checksum/config: 1458b4c23aeef8ef647bc61e48108682315cc7a51ceebdcc7a2f3b0b70923dc1
+        checksum/tls-secrets: d262aff32362895b4ff2559c48c3dda8e72f6fbd95150ee31b360b84410a71fd
       labels:
         app.kubernetes.io/name: kuma
         app.kubernetes.io/instance: kuma

--- a/app/kumactl/cmd/install/testdata/install-control-plane.zone.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.zone.golden.yaml
@@ -845,8 +845,8 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: bd9040893dba92c246c9f15b8e5c5fdbbccabfeb97201a967595c7c13f24356c
-        checksum/tls-secrets: 5f337216840fad68c3d519633e8a1fb5c9f4fc6c4303497f65c0309135a00e21
+        checksum/config: 1458b4c23aeef8ef647bc61e48108682315cc7a51ceebdcc7a2f3b0b70923dc1
+        checksum/tls-secrets: d262aff32362895b4ff2559c48c3dda8e72f6fbd95150ee31b360b84410a71fd
       labels:
         app.kubernetes.io/name: kuma
         app.kubernetes.io/instance: kuma

--- a/deployments/charts/kuma/Chart.yaml
+++ b/deployments/charts/kuma/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: kuma
 description: A Helm chart for the Kuma Control Plane
 type: application
-version: 0.8.0
-appVersion: 1.4.0
+version: 0.8.1
+appVersion: 1.4.1
 home: https://github.com/kumahq/kuma
 maintainers:
   - name: austince

--- a/deployments/charts/kuma/README.md
+++ b/deployments/charts/kuma/README.md
@@ -2,7 +2,7 @@
 
 A Helm chart for the Kuma Control Plane
 
-![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![Version: 0.8.0](https://img.shields.io/badge/Version-0.8.0-informational?style=flat-square) ![AppVersion: 1.4.0](https://img.shields.io/badge/AppVersion-1.4.0-informational?style=flat-square)
+![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![Version: 0.8.1](https://img.shields.io/badge/Version-0.8.1-informational?style=flat-square) ![AppVersion: 1.4.1](https://img.shields.io/badge/AppVersion-1.4.1-informational?style=flat-square)
 
 **Homepage:** <https://github.com/kumahq/kuma>
 

--- a/go.mod
+++ b/go.mod
@@ -90,6 +90,7 @@ require (
 	github.com/cenkalti/backoff v2.2.1+incompatible // indirect
 	github.com/census-instrumentation/opencensus-proto v0.2.1 // indirect
 	github.com/cespare/xxhash/v2 v2.1.2 // indirect
+	github.com/cncf/udpa v0.0.2-0.20210930031921-04548b0d99d4 // indirect
 	github.com/cncf/udpa/go v0.0.0-20210930031921-04548b0d99d4 // indirect
 	github.com/cncf/xds/go v0.0.0-20211011173535-cb28da3451f1 // indirect
 	github.com/containerd/cgroups v1.0.1 // indirect
@@ -102,6 +103,7 @@ require (
 	github.com/docker/go-connections v0.4.0 // indirect
 	github.com/docker/go-units v0.4.0 // indirect
 	github.com/emirpasic/gods v1.12.0 // indirect
+	github.com/envoyproxy/data-plane-api v0.0.0-20211214235436-bc055e45633a // indirect
 	github.com/evanphx/json-patch v4.11.0+incompatible // indirect
 	github.com/fatih/color v1.12.0 // indirect
 	github.com/form3tech-oss/jwt-go v3.2.5+incompatible // indirect
@@ -119,6 +121,7 @@ require (
 	github.com/google/go-cmp v0.5.6 // indirect
 	github.com/google/gofuzz v1.1.0 // indirect
 	github.com/googleapis/gnostic v0.5.5 // indirect
+	github.com/googleapis/googleapis v0.0.0-20211213225419-429d35c835fd // indirect
 	github.com/gruntwork-io/go-commons v0.8.0 // indirect
 	github.com/hashicorp/errwrap v1.0.0 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -324,6 +324,8 @@ github.com/circonus-labs/circonusllhist v0.1.3/go.mod h1:kMXHVDlOchFAehlya5ePtbp
 github.com/clbanning/x2j v0.0.0-20191024224557-825249438eec/go.mod h1:jMjuTZXRI4dUb/I5gc9Hdhagfvm9+RyrPryS/auMzxE=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cloudflare/golz4 v0.0.0-20150217214814-ef862a3cdc58/go.mod h1:EOBUe0h4xcZ5GoxqC5SDxFQ8gwyZPKQoEzownBlhI80=
+github.com/cncf/udpa v0.0.2-0.20210930031921-04548b0d99d4 h1:wpEyKyEcpeWcd/TkerLPiiixarxbuYivojDmv7gTUjE=
+github.com/cncf/udpa v0.0.2-0.20210930031921-04548b0d99d4/go.mod h1:HNVadOiXCy7Jk3R2knJ+qm++zkncJxxBMpjdGgJ+UJc=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20200629203442-efcf912fb354/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
@@ -529,6 +531,8 @@ github.com/emicklei/go-restful v2.15.0+incompatible/go.mod h1:otzb+WCGbkyDHkqmQm
 github.com/emicklei/go-restful/v3 v3.7.1/go.mod h1:6n3XBCmQQb25CM2LCACGz8ukIrRry+4bhvbpWn3mrbc=
 github.com/emirpasic/gods v1.12.0 h1:QAUIPSaCu4G+POclxeqb3F+WPpdKqFGlw36+yOzGlrg=
 github.com/emirpasic/gods v1.12.0/go.mod h1:YfzfFFoVP/catgzJb4IKIqXjX78Ha8FMSDh3ymbK86o=
+github.com/envoyproxy/data-plane-api v0.0.0-20211214235436-bc055e45633a h1:/skaQa6hLeiAfl+10NYidQTCJhaWpyPzbRRR248LxCg=
+github.com/envoyproxy/data-plane-api v0.0.0-20211214235436-bc055e45633a/go.mod h1:ysQJ12w0R8EJ2rE11wHBGdm+4q7Ft5RTmABx23SOscc=
 github.com/envoyproxy/protoc-gen-validate v0.0.14/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/envoyproxy/protoc-gen-validate v0.6.2 h1:JiO+kJTpmYGjEodY7O1Zk8oZcNz1+f30UtwtXoFUPzE=
@@ -835,6 +839,8 @@ github.com/googleapis/gnostic v0.4.1/go.mod h1:LRhVm6pbyptWbWbuZ38d1eyptfvIytN3i
 github.com/googleapis/gnostic v0.5.1/go.mod h1:6U4PtQXGIEt/Z3h5MAT7FNofLnw9vXk2cUuW7uA/OeU=
 github.com/googleapis/gnostic v0.5.5 h1:9fHAtK0uDfpveeqqo1hkEZJcFvYXAiCN3UutL8F9xHw=
 github.com/googleapis/gnostic v0.5.5/go.mod h1:7+EbHbldMins07ALC74bsA81Ovc97DwqyJO1AENw9kA=
+github.com/googleapis/googleapis v0.0.0-20211213225419-429d35c835fd h1:OkSMI+vez7b3HMpUwe+zIEqrg+9L0wgbcIyWUxmS4z8=
+github.com/googleapis/googleapis v0.0.0-20211213225419-429d35c835fd/go.mod h1:XrPm4xpez/lHHyE+8/G+NqQRcB4lg42HF9zQVTvxtXw=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
 github.com/gordonklaus/ineffassign v0.0.0-20200309095847-7953dde2c7bf/go.mod h1:cuNKsD1zp2v6XfE/orVX2QE1LC+i254ceGcVeDT3pTU=
 github.com/gorilla/context v1.1.1/go.mod h1:kBGZzfjB9CEq2AlWe17Uuf7NDRt0dE0s8S51q0aT7Yg=


### PR DESCRIPTION
### Summary

Release the Kuma 1.4.1

### Full changelog

No changelog

### Issues resolved

No issues resolved

### Documentation

- [ ] Link to the website [documentation PR](https://github.com/kumahq/kuma-website/pull/XXX)

### Testing

- [ ] Unit tests
- [ ] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes

### Backwards compatibility

- [ ] Update [`UPGRADE.md`](UPGRADE.md) with any steps users will need to take
      when upgrading.
- [ ] Add `backport-to-stable` label if the code is backwards compatible. Otherwise, list breaking changes.
