### PR TITLE
chore(e2e): apply test namespace helper

### DIFF
--- a/test/e2e/deploy/kuma_deploy_global_zone.go
+++ b/test/e2e/deploy/kuma_deploy_global_zone.go
@@ -12,17 +12,6 @@ import (
 )
 
 func ZoneAndGlobal() {
-	namespaceWithSidecarInjection := func(namespace string) string {
-		return fmt.Sprintf(`
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: %s
-  annotations:
-    kuma.io/sidecar-injection: "enabled"
-`, namespace)
-	}
-
 	trafficRoutePolicy := func(namespace string, policyname string, weight int) string {
 		return fmt.Sprintf(`
 apiVersion: kuma.io/v1alpha1
@@ -82,7 +71,7 @@ spec:
 
 		err = NewClusterSetup().
 			Install(Kuma(core.Zone, optsZone...)).
-			Install(YamlK8s(namespaceWithSidecarInjection(TestNamespace))).
+			Install(NamespaceWithSidecarInjection(TestNamespace)).
 			Install(DemoClientK8s("default")).
 			Setup(c2)
 		Expect(err).ToNot(HaveOccurred())

--- a/test/e2e/externalservices/externalservices_kubernetes.go
+++ b/test/e2e/externalservices/externalservices_kubernetes.go
@@ -66,17 +66,6 @@ spec:
 
 `
 
-	namespaceWithSidecarInjection := func(namespace string) string {
-		return fmt.Sprintf(`
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: %s
-  annotations:
-    kuma.io/sidecar-injection: "enabled"
-`, namespace)
-	}
-
 	var cluster Cluster
 	var clientPod *v1.Pod
 	var deployOptsFuncs = KumaK8sDeployOpts
@@ -91,7 +80,7 @@ metadata:
 		cluster = clusters.GetCluster(Kuma1)
 		err = NewClusterSetup().
 			Install(Kuma(core.Standalone, deployOptsFuncs...)).
-			Install(YamlK8s(namespaceWithSidecarInjection(TestNamespace))).
+			Install(NamespaceWithSidecarInjection(TestNamespace)).
 			Install(DemoClientK8s("default")).
 			Install(externalservice.Install(externalservice.HttpServer, []string{})).
 			Install(externalservice.Install(externalservice.HttpsServer, []string{})).

--- a/test/e2e/healthcheck/hybrid/healthcheck_hybrid.go
+++ b/test/e2e/healthcheck/hybrid/healthcheck_hybrid.go
@@ -32,17 +32,6 @@ spec:
 `, mesh)
 	}
 
-	namespaceWithSidecarInjection := func(namespace string) string {
-		return fmt.Sprintf(`
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: %s
-  annotations:
-    kuma.io/sidecar-injection: "enabled"
-`, namespace)
-	}
-
 	var globalK8s, zoneK8s, zoneUniversal Cluster
 	var optsGlobalK8s, optsZoneK8s, optsZoneUniversal = KumaK8sDeployOpts, KumaZoneK8sDeployOpts, KumaUniversalDeployOpts
 
@@ -67,7 +56,7 @@ metadata:
 		zoneK8s = k8sClusters.GetCluster(Kuma2)
 		err = NewClusterSetup().
 			Install(Kuma(core.Zone, optsZoneK8s...)).
-			Install(YamlK8s(namespaceWithSidecarInjection(TestNamespace))).
+			Install(NamespaceWithSidecarInjection(TestNamespace)).
 			Install(DemoClientK8s("default")).
 			Setup(zoneK8s)
 		Expect(err).ToNot(HaveOccurred())

--- a/test/e2e/helm/kuma_helm_deploy_global_zone.go
+++ b/test/e2e/helm/kuma_helm_deploy_global_zone.go
@@ -20,17 +20,6 @@ import (
 )
 
 func ZoneAndGlobalWithHelmChart() {
-	namespaceWithSidecarInjection := func(namespace string) string {
-		return fmt.Sprintf(`
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: %s
-  annotations:
-    kuma.io/sidecar-injection: "enabled"
-`, namespace)
-	}
-
 	var clusters Clusters
 	var c1, c2 Cluster
 	var global, zone ControlPlane
@@ -74,7 +63,7 @@ metadata:
 
 		err = NewClusterSetup().
 			Install(Kuma(core.Zone, optsZone...)).
-			Install(YamlK8s(namespaceWithSidecarInjection(TestNamespace))).
+			Install(NamespaceWithSidecarInjection(TestNamespace)).
 			Install(DemoClientK8s("default")).
 			Setup(c2)
 		Expect(err).ToNot(HaveOccurred())

--- a/test/e2e/helm/kuma_helm_deploy_multi_apps.go
+++ b/test/e2e/helm/kuma_helm_deploy_multi_apps.go
@@ -17,17 +17,6 @@ import (
 )
 
 func AppDeploymentWithHelmChart() {
-	namespaceWithSidecarInjection := func(namespace string) string {
-		return fmt.Sprintf(`
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: %s
-  annotations:
-    kuma.io/sidecar-injection: "enabled"
-`, namespace)
-	}
-
 	defaultMesh := `
 apiVersion: kuma.io/v1alpha1
 kind: Mesh
@@ -66,7 +55,7 @@ metadata:
 		Expect(err).ToNot(HaveOccurred())
 
 		err = NewClusterSetup().
-			Install(YamlK8s(namespaceWithSidecarInjection(TestNamespace))).
+			Install(NamespaceWithSidecarInjection(TestNamespace)).
 			Install(DemoClientK8s("default")).
 			Install(testserver.Install()).
 			Setup(cluster)

--- a/test/e2e/hybrid/globaluniversal/kuma_hybrid.go
+++ b/test/e2e/hybrid/globaluniversal/kuma_hybrid.go
@@ -28,17 +28,6 @@ mtls:
 `, mesh)
 	}
 
-	namespaceWithSidecarInjection := func(namespace string) string {
-		return fmt.Sprintf(`
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: %s
-  annotations:
-    kuma.io/sidecar-injection: "enabled"
-`, namespace)
-	}
-
 	var global, zone1, zone2, zone3, zone4 Cluster
 	var optsGlobal, optsZone1, optsZone2, optsZone3, optsZone4 = KumaUniversalDeployOpts, KumaZoneK8sDeployOpts, KumaZoneK8sDeployOpts, KumaUniversalDeployOpts, KumaUniversalDeployOpts
 
@@ -86,7 +75,7 @@ metadata:
 		err = NewClusterSetup().
 			Install(Kuma(core.Zone, optsZone1...)).
 			Install(KumaDNS()).
-			Install(YamlK8s(namespaceWithSidecarInjection(TestNamespace))).
+			Install(NamespaceWithSidecarInjection(TestNamespace)).
 			Install(DemoClientK8s(nonDefaultMesh)).
 			Setup(zone1)
 		Expect(err).ToNot(HaveOccurred())
@@ -103,7 +92,7 @@ metadata:
 		err = NewClusterSetup().
 			Install(Kuma(core.Zone, optsZone2...)).
 			Install(KumaDNS()).
-			Install(YamlK8s(namespaceWithSidecarInjection(TestNamespace))).
+			Install(NamespaceWithSidecarInjection(TestNamespace)).
 			Install(testserver.Install(testserver.WithMesh(nonDefaultMesh), testserver.WithServiceAccount("sa-test"))).
 			Install(DemoClientK8s(nonDefaultMesh)).
 			Setup(zone2)

--- a/test/e2e/k8s_api_bypass/k8s_api_bypass.go
+++ b/test/e2e/k8s_api_bypass/k8s_api_bypass.go
@@ -30,17 +30,6 @@ spec:
       passthrough: %s
 `
 
-	namespaceWithSidecarInjection := func(namespace string) string {
-		return fmt.Sprintf(`
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: %s
-  annotations:
-    kuma.io/sidecar-injection: "enabled"
-`, namespace)
-	}
-
 	var cluster *K8sCluster
 	var clientPod *v1.Pod
 	var deployOptsFuncs = KumaK8sDeployOpts
@@ -53,7 +42,7 @@ metadata:
 
 		err = NewClusterSetup().
 			Install(Kuma(core.Standalone, deployOptsFuncs...)).
-			Install(YamlK8s(namespaceWithSidecarInjection(TestNamespace))).
+			Install(NamespaceWithSidecarInjection(TestNamespace)).
 			Install(DemoClientK8s("default")).
 			Setup(cluster)
 		Expect(err).ToNot(HaveOccurred())
@@ -76,11 +65,7 @@ metadata:
 		clientPod = &pods[0]
 	})
 
-	AfterEach(func() {
-		if ShouldSkipCleanup() {
-			return
-		}
-
+	E2EAfterEach(func() {
 		err := cluster.DeleteNamespace(TestNamespace)
 		Expect(err).ToNot(HaveOccurred())
 

--- a/test/e2e/kic/kubernetes/kong_ingress.go
+++ b/test/e2e/kic/kubernetes/kong_ingress.go
@@ -98,16 +98,6 @@ func KICKubernetes() {
 		return
 	}
 
-	namespaceWithSidecarInjection := func(namespace string) string {
-		return fmt.Sprintf(`
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: %s
-  annotations:
-    kuma.io/sidecar-injection: "enabled"
-`, namespace)
-	}
 	var ingressNamespace string
 	var altIngressNamespace = "kuma-yawetag"
 	var kubernetes Cluster
@@ -119,7 +109,7 @@ metadata:
 		kubernetes = k8sClusters.GetCluster(Kuma1)
 		err = NewClusterSetup().
 			Install(Kuma(config_core.Standalone, kubernetesOps...)).
-			Install(YamlK8s(namespaceWithSidecarInjection(TestNamespace))).
+			Install(NamespaceWithSidecarInjection(TestNamespace)).
 			Install(testserver.Install()).
 			Setup(kubernetes)
 		Expect(err).ToNot(HaveOccurred())

--- a/test/e2e/trafficpermission/hybrid/traffic_permission_hybrid.go
+++ b/test/e2e/trafficpermission/hybrid/traffic_permission_hybrid.go
@@ -17,17 +17,6 @@ func TrafficPermissionHybrid() {
 	var optsGlobal, optsZoneUniversal, optsZoneKube = KumaK8sDeployOpts, KumaUniversalDeployOpts, KumaZoneK8sDeployOpts
 	var clientPodName string
 
-	namespaceWithSidecarInjection := func(namespace string) string {
-		return fmt.Sprintf(`
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: %s
-  annotations:
-    kuma.io/sidecar-injection: "enabled"
-`, namespace)
-	}
-
 	meshMTLSOn := func(mesh string) string {
 		return fmt.Sprintf(`
 apiVersion: kuma.io/v1alpha1
@@ -92,7 +81,7 @@ spec:
 
 		err = NewClusterSetup().
 			Install(Kuma(config_core.Zone, optsZoneKube...)).
-			Install(YamlK8s(namespaceWithSidecarInjection(TestNamespace))).
+			Install(NamespaceWithSidecarInjection(TestNamespace)).
 			Install(DemoClientK8s("default")).
 			Setup(zoneKube)
 		Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
### Summary

A number of places in the e2e test suite were manually applying the test
namespace to enable sidecar injection. There is already a framework
helper to so that, so apply it consistently to make it obvious which
approach is preferred.


### Full changelog

N/A

### Issues resolved

N/A

### Documentation

N/A

### Testing

- [x] Unit tests
- [x] E2E tests
- [ ] ~~Manual testing on Universal~~
- [ ] ~~Manual testing on Kubernetes~~

### Backwards compatibility

- [ ] ~~Update [`UPGRADE.md`](UPGRADE.md) with any steps users will need to take when upgrading.~~
- [ ] ~~Add `backport-to-stable` label if the code is backwards compatible. Otherwise, list breaking changes.~~
