### PR TITLE
feat(kuma-cp): enable client side gRPC keepalive

### DIFF
--- a/pkg/kds/mux/client.go
+++ b/pkg/kds/mux/client.go
@@ -11,6 +11,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/keepalive"
 	"google.golang.org/grpc/metadata"
 
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
@@ -53,6 +54,11 @@ func (c *client) Start(stop <-chan struct{}) (errs error) {
 	dialOpts = append(dialOpts, grpc.WithDefaultCallOptions(
 		grpc.MaxCallSendMsgSize(int(c.config.MaxMsgSize)),
 		grpc.MaxCallRecvMsgSize(int(c.config.MaxMsgSize))),
+		grpc.WithKeepaliveParams(keepalive.ClientParameters{
+			Time:                grpcKeepAliveTime,
+			Timeout:             grpcKeepAliveTime,
+			PermitWithoutStream: true,
+		}),
 	)
 	switch u.Scheme {
 	case "grpc":


### PR DESCRIPTION
### Summary

With gRPC communication there are 2 types of keepalive healthchecks in place:
* L4 TCP keepalive
* L7 (application level) gRPC keepalive

Almost a year ago we enabled L7 keepalive on the server-side (Global CP) with [this PR](https://github.com/kumahq/kuma/pull/1580).
This enables Global CP to detect whether Zone CP is down in case that it was not gracefully shut down.

However, we did not enable gRPC keepalive on the client side. After experimenting with the following setup:
* Global CP deployed on the server connected to the local network
* Zone CP deployed on my Macbook connected to the local network

When I plug out the network cable from my server, I noticed that eventually (after a couple of minutes) Zone CP on my Macbook detected that Global CP is down. Wireshark confirmed that is the case

![image](https://user-images.githubusercontent.com/5459824/146533136-db28b749-f1f4-4cdc-b5be-f78e4c445d92.png)

In Go, every TCP client sets TCP keepalive by default https://pkg.go.dev/net#Dialer
```
	// KeepAlive specifies the interval between keep-alive
	// probes for an active network connection.
	// If zero, keep-alive probes are sent with a default value
	// (currently 15 seconds), if supported by the protocol and operating
	// system. Network protocols or operating systems that do
	// not support keep-alives ignore this field.
	// If negative, keep-alive probes are disabled.
	KeepAlive time.Duration
```

This is great. However, in production deployments, our users run a high availability setup with a load balancer in front of all instances in Global CP.

```
Global CP <---> Load Balancer <---> Zone CP
```

This means that TCP keepalive that originates in Zone CP checks a TCP connection for the load balancer.
What load balancer is doing with this information is up for the load balancer implementation. This makes keepalive not really reliable since it depends on the load balancer implementation.

The solution is to use L7 keepalive also on the client-side. This way the load balancer has to pass it to Global CP because it is just application data like any other.

### Issues resolved

No issues reported.

### Documentation

No docs, internal changes.

### Testing

I did manual testing since I'm not sure how to test it with E2E test.

```
2021-12-17T11:34:05.772+0100	DEBUG	kds-zone	OnStreamClosed	{"streamid": 1}
2021-12-17T11:34:05.772+0100	ERROR	kds-mux-client	KDS stream failed prematurely, will restart in background	{"client-id": "macbook", "error": "rpc error: code = Unavailable desc = keepalive ping failed to receive ACK within timeout"}
```

- [ ] Unit tests
- [ ] E2E tests
- [X] Manual testing on Universal
- [ ] Manual testing on Kubernetes

### Backwards compatibility

- [X] No UPGRADE.md instructions
- [X] Add `backport-to-stable` label if the code is backwards compatible. Otherwise, list breaking changes.
