### PR TITLE
fix(ci): set kubebuilder assets directory

### DIFF
--- a/mk/dev.mk
+++ b/mk/dev.mk
@@ -281,4 +281,5 @@ dev/envrc: $(KUBECONFIG_DIR)/kind-kuma-current ## Generate .envrc
 	@for prog in $(BUILD_RELEASE_BINARIES) $(BUILD_TEST_BINARIES) ; do \
 		echo "PATH_add $(BUILD_ARTIFACTS_DIR)/$$prog" ; \
 	done >> .envrc
+	@echo 'export KUBEBUILDER_ASSETS=$${CI_TOOLS_DIR}' >> .envrc
 	@direnv allow

--- a/mk/test.mk
+++ b/mk/test.mk
@@ -10,10 +10,10 @@ BUILD_COVERAGE_DIR ?= $(BUILD_DIR)/coverage
 COVERAGE_PROFILE := $(BUILD_COVERAGE_DIR)/coverage.out
 COVERAGE_REPORT_HTML := $(BUILD_COVERAGE_DIR)/coverage.html
 
-# exports below are required for K8S unit tests
-export TEST_ASSET_KUBE_APISERVER=$(KUBE_APISERVER_PATH)
-export TEST_ASSET_ETCD=$(ETCD_PATH)
-export TEST_ASSET_KUBECTL=$(KUBECTL_PATH)
+# This environment variable sets where the kubebuilder envtest framework looks
+# for etcd and other tools that is consumes. The `dev/install/kubebuilder` make
+# target guaranteed to link these tools into $CI_TOOLS_DIR.
+export KUBEBUILDER_ASSETS=$(CI_TOOLS_DIR)
 
 .PHONY: test
 test: ${COVERAGE_PROFILE} ## Dev: Run tests for all modules

--- a/pkg/plugins/resources/k8s/native/Makefile
+++ b/pkg/plugins/resources/k8s/native/Makefile
@@ -8,13 +8,10 @@ GOPATH_DIR := $(shell go env GOPATH | awk -F: '{print $$1}')
 GOPATH_BIN_DIR := $(GOPATH_DIR)/bin
 export PATH := $(CI_TOOLS_DIR):$(GOPATH_BIN_DIR):$(PATH)
 
-KUBE_APISERVER_PATH := $(CI_TOOLS_DIR)/kube-apiserver
-ETCD_PATH := $(CI_TOOLS_DIR)/etcd
-KUBECTL_PATH := $(CI_TOOLS_DIR)/kubectl
-
-export TEST_ASSET_KUBE_APISERVER=$(KUBE_APISERVER_PATH)
-export TEST_ASSET_ETCD=$(ETCD_PATH)
-export TEST_ASSET_KUBECTL=$(KUBECTL_PATH)
+# This environment variable sets where the kubebuilder envtest framework looks
+# for etcd and other tools that is consumes. The `dev/install/kubebuilder` make
+# target guaranteed to link these tools into $CI_TOOLS_DIR.
+export KUBEBUILDER_ASSETS=$(CI_TOOLS_DIR)
 
 CONTROLLER_GEN := go run -mod=mod sigs.k8s.io/controller-tools/cmd/controller-gen
 RESOURCE_GEN := go run -mod=mod ../../../../../tools/resource-gen/main.go


### PR DESCRIPTION
### Summary

The `dev/tools` make target installs testing dependencies into
`$CI_TOOLS_DIR`, but the wiring between this and the kubebuilder envtest
framework was broken. Make sure that we set the `KUBEBUILDER_ASSETS`
environment variable so that the envtest framework can find its
dependencies correctly.

### Full changelog
N/A


### Issues resolved
N/A


### Documentation
N/A


### Testing

- [x] Unit tests
- [x] E2E tests
- [ ] ~~Manual testing on Universal~~
- [ ] ~~Manual testing on Kubernetes~~

### Backwards compatibility

- [ ] ~~Update [`UPGRADE.md`](UPGRADE.md) with any steps users will need to take when upgrading.~~
- [ ] ~~Add `backport-to-stable` label if the code is backwards compatible. Otherwise, list breaking changes.~~
