### PR TITLE
fix(kuma-cp): add cp selector to global sync service

### DIFF
--- a/app/kumactl/cmd/install/testdata/install-control-plane.global.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.global.golden.yaml
@@ -1148,6 +1148,7 @@ spec:
     - port: 5685
       name: global-zone-sync
   selector:
+    app: kuma-control-plane
   
     app.kubernetes.io/name: kuma
     app.kubernetes.io/instance: kuma

--- a/deployments/charts/kuma/templates/cp-global-sync-service.yaml
+++ b/deployments/charts/kuma/templates/cp-global-sync-service.yaml
@@ -20,5 +20,6 @@ spec:
   {{- end }}
       name: global-zone-sync
   selector:
+    app: {{ include "kuma.name" . }}-control-plane
   {{ include "kuma.selectorLabels" . | nindent 4 }}
   {{- end }}


### PR DESCRIPTION
### Summary

CP selector in Global Remote Sync service was missing.
It was ok, because in Global CP was the only component that was running with `app.kubernetes.io/name: kuma`, so it was always selected, but we should select the control plane explicitly in case a new component will arrive in the future next to Global CP.

### Issues resolved

No reported issues.

### Documentation

No docs.

### Testing

- [X] Unit tests
- [X] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes

### Backwards compatibility

- [X] Update [`UPGRADE.md`](UPGRADE.md) with any steps users will need to take
      when upgrading.
- [X] Add `backport-to-stable` label if the code is backwards compatible. Otherwise, list breaking changes.
