### PR TITLE
ci(*): build CoreDNS only if binary is not present

### DIFF
--- a/mk/build.mk
+++ b/mk/build.mk
@@ -82,6 +82,7 @@ build/kumactl: ## Dev: Build `kumactl` binary
 
 .PHONY: build/coredns
 build/coredns:
+ifeq (,$(wildcard $(BUILD_ARTIFACTS_DIR)/coredns/coredns))
 	rm -rf "$(COREDNS_TMP_DIRECTORY)"
 	git clone --branch $(COREDNS_VERSION) --depth 1 $(COREDNS_GIT_REPOSITORY) $(COREDNS_TMP_DIRECTORY)
 	cp $(COREDNS_PLUGIN_CFG_PATH) $(COREDNS_TMP_DIRECTORY)
@@ -90,6 +91,9 @@ build/coredns:
 		go get github.com/coredns/alternate && \
 		$(GO_BUILD_COREDNS) -ldflags="-s -w -X github.com/coredns/coredns/coremain.GitCommit=$(shell git describe --dirty --always)" -o $(BUILD_ARTIFACTS_DIR)/coredns/coredns
 	rm -rf "$(COREDNS_TMP_DIRECTORY)"
+else
+	echo "CoreDNS is already built. If you want to rebuild it, remove the binary: rm $(BUILD_ARTIFACTS_DIR)/coredns/coredns"
+endif
 
 .PHONY: build/kuma-prometheus-sd
 build/kuma-prometheus-sd: ## Dev: Build `kuma-prometheus-sd` binary


### PR DESCRIPTION
### Summary

Building CoreDNS on EVERY `make build` does not make sense, especially since it clones GitHub repo, adds stuff, etc. every time.
CoreDNS has not changed once since we introduced it half a year ago.

I propose a change to only build CoreDNS when it's not already built. This way CI will always build the newest version, but on a local machine, I can execute several `make build` and it's not doing all those operations every time. 

### Issues resolved

No reported issues.

### Documentation

CI changes.

### Testing

- [ ] Unit tests
- [ ] E2E tests
- [X] Manual testing on Universal
- [ ] Manual testing on Kubernetes

### Backwards compatibility

- [X] No UPGRADE.md
- [X] Add `backport-to-stable` label if the code is backwards compatible. Otherwise, list breaking changes.
