### PR TITLE
test(*): add test/e2e/debug-fast target

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -917,7 +917,7 @@ jobs:
     - run:
         name: Build Docker images
         command: |
-          make docker/build \
+          make images \
             DOCKER_REGISTRY="<< parameters.docker_registry >>"
     - run:
         name: Save Docker images into TAR archives
@@ -947,7 +947,7 @@ jobs:
     - run:
         name: Build kumactl's Docker image
         command: |
-          make docker/build/kumactl \
+          make image/kumactl \
             DOCKER_REGISTRY="<< parameters.docker_registry >>"
     - run:
         name: Save kumactl's Docker image into TAR archives

--- a/mk/docker.mk
+++ b/mk/docker.mk
@@ -63,22 +63,35 @@ docker/build/kuma-universal: build/artifacts-linux-amd64/kuma-cp/kuma-cp build/a
 	docker tag kuma-universal $(KUMA_UNIVERSAL_DOCKER_IMAGE)
 
 .PHONY: image/kuma-cp
-image/kuma-cp: build/kuma-cp/linux-amd64 docker/build/kuma-cp ## Dev: Rebuild `kuma-cp` Docker image
+image/kuma-cp: ## Dev: Rebuild `kuma-cp` Docker image
+	$(MAKE) build/kuma-cp/linux-amd64
+	$(MAKE) docker/build/kuma-cp
 
 .PHONY: image/kuma-dp
-image/kuma-dp: build/kuma-dp/linux-amd64 build/coredns/linux-amd64 build/artifacts-linux-amd64/envoy/envoy docker/build/kuma-dp ## Dev: Rebuild `kuma-dp` Docker image
+image/kuma-dp: build/artifacts-linux-amd64/envoy/envoy ## Dev: Rebuild `kuma-dp` Docker image
+	$(MAKE) build/kuma-dp/linux-amd64
+	$(MAKE) build/coredns/linux-amd64
+	$(MAKE) docker/build/kuma-dp
 
 .PHONY: image/kumactl
-image/kumactl: build/kumactl/linux-amd64 docker/build/kumactl ## Dev: Rebuild `kumactl` Docker image
+image/kumactl:
+	$(MAKE) build/kumactl/linux-amd64
+	$(MAKE) docker/build/kumactl ## Dev: Rebuild `kumactl` Docker image
 
 .PHONY: image/kuma-init
-image/kuma-init: docker/build/kuma-init ## Dev: Rebuild `kuma-init` Docker image
+image/kuma-init: ## Dev: Rebuild `kuma-init` Docker image
+	$(MAKE) build/kumactl/linux-amd64
+	$(MAKE) docker/build/kuma-init
 
 .PHONY: image/kuma-prometheus-sd
-image/kuma-prometheus-sd: build/kuma-prometheus-sd/linux-amd64 docker/build/kuma-prometheus-sd ## Dev: Rebuild `kuma-prometheus-sd` Docker image
+image/kuma-prometheus-sd: ## Dev: Rebuild `kuma-prometheus-sd` Docker image
+	$(MAKE) build/kuma-prometheus-sd/linux-amd64
+	$(MAKE) docker/build/kuma-prometheus-sd
 
 .PHONY: image/kuma-universal
-image/kuma-universal: build/linux-amd64 docker/build/kuma-universal
+image/kuma-universal:
+	$(MAKE) build/linux-amd64
+	$(MAKE) docker/build/kuma-universal
 
 .PHONY: images
 images: images/release images/test ## Dev: Rebuild release and tesst Docker images

--- a/mk/e2e.new.mk
+++ b/mk/e2e.new.mk
@@ -115,9 +115,8 @@ test/e2e/list:
 	@echo $(ALL_TESTS)
 
 .PHONY: test/e2e/k8s/start
-test/e2e/k8s/start:
-	$(MAKE) $(K8SCLUSTERS_START_TARGETS)
-	$(MAKE) $(K8SCLUSTERS_LOAD_IMAGES_TARGETS)
+test/e2e/k8s/start: $(K8SCLUSTERS_START_TARGETS)
+	$(MAKE) $(K8SCLUSTERS_LOAD_IMAGES_TARGETS) # execute after start targets
 
 .PHONY: test/e2e/k8s/stop
 test/e2e/k8s/stop: $(K8SCLUSTERS_STOP_TARGETS)

--- a/mk/e2e.new.mk
+++ b/mk/e2e.new.mk
@@ -151,8 +151,7 @@ test/e2e/debug: build/kumactl images test/e2e/k8s/start
 .PHONY: test/e2e/debug-fast
 test/e2e/debug-fast:
 	$(MAKE) $(K8SCLUSTERS_START_TARGETS) & # start K8S clusters in the background since it takes the most time
-	$(MAKE) images/release
-	$(MAKE) images/test # build test images only after release images because all binaries should be already built.
+	$(MAKE) images
 	$(MAKE) build/kumactl
 	$(MAKE) $(K8SCLUSTERS_LOAD_IMAGES_TARGETS) # K3D is able to load images before the cluster is ready. It retries if cluster is not able to handle images yet.
 	$(MAKE) $(K8SCLUSTERS_WAIT_TARGETS) # there is no easy way of waiting for processes in the background so just wait for K8S clusters

--- a/mk/e2e.new.mk
+++ b/mk/e2e.new.mk
@@ -1,6 +1,8 @@
 K8SCLUSTERS = kuma-1 kuma-2
 K8SCLUSTERS_START_TARGETS = $(addprefix test/e2e/k8s/start/cluster/, $(K8SCLUSTERS))
 K8SCLUSTERS_STOP_TARGETS  = $(addprefix test/e2e/k8s/stop/cluster/, $(K8SCLUSTERS))
+K8SCLUSTERS_LOAD_IMAGES_TARGETS  = $(addprefix test/e2e/k8s/load/images/, $(K8SCLUSTERS))
+K8SCLUSTERS_WAIT_TARGETS  = $(addprefix test/e2e/k8s/wait/, $(K8SCLUSTERS))
 API_VERSION ?= v3
 # export `IPV6=true` to enable IPv6 testing
 
@@ -91,8 +93,14 @@ test/e2e/k8s/start/cluster/$1:
 	KIND_CONFIG=$(TOP)/test/kind/cluster$(KIND_CONFIG_IPV6)-$1.yaml \
 	KIND_CLUSTER_NAME=$1 \
 		$(MAKE) $(K8S_CLUSTER_TOOL)/start
-	KIND_CLUSTER_NAME=$1 \
-		$(MAKE) $(K8S_CLUSTER_TOOL)/load/images
+
+.PHONY: test/e2e/k8s/load/images/$1
+test/e2e/k8s/load/images/$1:
+	KIND_CLUSTER_NAME=$1 $(MAKE) $(K8S_CLUSTER_TOOL)/load/images
+
+.PHONY: test/e2e/k8s/wait/$1
+test/e2e/k8s/wait/$1:
+	KIND_CLUSTER_NAME=$1 $(MAKE) $(K8S_CLUSTER_TOOL)/wait
 
 .PHONY: test/e2e/k8s/stop/cluster/$1
 test/e2e/k8s/stop/cluster/$1:
@@ -107,7 +115,9 @@ test/e2e/list:
 	@echo $(ALL_TESTS)
 
 .PHONY: test/e2e/k8s/start
-test/e2e/k8s/start: $(K8SCLUSTERS_START_TARGETS)
+test/e2e/k8s/start:
+	$(MAKE) $(K8SCLUSTERS_START_TARGETS)
+	$(MAKE) $(K8SCLUSTERS_LOAD_IMAGES_TARGETS)
 
 .PHONY: test/e2e/k8s/stop
 test/e2e/k8s/stop: $(K8SCLUSTERS_STOP_TARGETS)
@@ -133,12 +143,31 @@ test/e2e/debug: build/kumactl images test/e2e/k8s/start
 	$(ENV_VARS) \
 	GINKGO_EDITOR_INTEGRATION=true \
 		ginkgo --failFast $(GOFLAGS) $(LD_FLAGS) $(E2E_PKG_LIST)
+	$(MAKE) test/e2e/k8s/stop
+
+# test/e2e/debug-fast is an experimental target tested with K3D=true.
+# test/e2e/debug-fast is an equivalent of test/e2e/debug, but with the goal to minimize time for test to start running.
+# Run only with -j and K3D=true
+.PHONY: test/e2e/debug-fast
+test/e2e/debug-fast:
+	$(MAKE) $(K8SCLUSTERS_START_TARGETS) & # start K8S clusters in the background since it takes the most time
+	$(MAKE) images/release
+	$(MAKE) images/test # build test images only after release images because all binaries should be already built.
+	$(MAKE) build/kumactl
+	$(MAKE) $(K8SCLUSTERS_LOAD_IMAGES_TARGETS) # K3D is able to load images before the cluster is ready. It retries if cluster is not able to handle images yet.
+	$(MAKE) $(K8SCLUSTERS_WAIT_TARGETS) # there is no easy way of waiting for processes in the background so just wait for K8S clusters
+	K8SCLUSTERS="$(K8SCLUSTERS)" \
+	KUMACTLBIN=${BUILD_ARTIFACTS_DIR}/kumactl/kumactl \
+	$(ENV_VARS) \
+	GINKGO_EDITOR_INTEGRATION=true \
+		ginkgo --failFast $(GOFLAGS) $(LD_FLAGS) $(E2E_PKG_LIST)
+	$(MAKE) test/e2e/k8s/stop
 
 # test/e2e/debug-universal is the same target as 'test/e2e/debug' but builds only 'kuma-universal' image
 # and doesn't start Kind clusters
 .PHONY: test/e2e/debug-universal
 test/e2e/debug-universal: build/kumactl images/test
-	K8SCLUSTERS="$(K8SCLUSTERS)" \
+	K8SCLUSTERS="" \
 	KUMACTLBIN=${BUILD_ARTIFACTS_DIR}/kumactl/kumactl \
 	$(ENV_VARS) \
 	GINKGO_EDITOR_INTEGRATION=true \

--- a/mk/k3d.mk
+++ b/mk/k3d.mk
@@ -20,9 +20,7 @@ k3d/start: ${KIND_KUBECONFIG_DIR} k3d/network/create
 			  --network kind \
 			  --port "$(PORT_PREFIX)80-$(PORT_PREFIX)89:30080-30089@server:0" \
 			  --timeout 120s && \
-	until \
-		 KUBECONFIG=$(KIND_KUBECONFIG) kubectl wait -n kube-system --timeout=5s --for condition=Ready --all pods ; \
-	do echo "Waiting for the cluster to come up" && sleep 1; done
+	$(MAKE) k3d/wait
 	@echo
 	@echo '>>> You need to manually run the following command in your shell: >>>'
 	@echo
@@ -30,6 +28,12 @@ k3d/start: ${KIND_KUBECONFIG_DIR} k3d/network/create
 	@echo
 	@echo '<<< ------------------------------------------------------------- <<<'
 	@echo
+
+.PHONY: k3d/wait
+k3d/wait:
+	until \
+		 KUBECONFIG=$(KIND_KUBECONFIG) kubectl wait -n kube-system --timeout=5s --for condition=Ready --all pods ; \
+	do echo "Waiting for the cluster to come up" && sleep 1; done
 
 .PHONY: k3d/stop
 k3d/stop:

--- a/mk/kind.mk
+++ b/mk/kind.mk
@@ -55,9 +55,7 @@ kind/start: ${KUBECONFIG_DIR}
 			--kubeconfig $(KIND_KUBECONFIG) \
 			--quiet --wait 120s && \
 		KUBECONFIG=$(KIND_KUBECONFIG) kubectl scale deployment --replicas 1 coredns --namespace kube-system && \
-		until \
-			KUBECONFIG=$(KIND_KUBECONFIG) kubectl wait -n kube-system --timeout=5s --for condition=Ready --all pods ; \
-		do echo "Waiting for the cluster to come up" && sleep 1; done )
+		$(MAKE) kind/wait)
 	@echo
 	@echo '>>> You need to manually run the following command in your shell: >>>'
 	@echo
@@ -65,6 +63,12 @@ kind/start: ${KUBECONFIG_DIR}
 	@echo
 	@echo '<<< ------------------------------------------------------------- <<<'
 	@echo
+
+.PHONY: kind/wait
+kind/wait:
+	until \
+		KUBECONFIG=$(KIND_KUBECONFIG) kubectl wait -n kube-system --timeout=5s --for condition=Ready --all pods ; \
+	do echo "Waiting for the cluster to come up" && sleep 1; done
 
 .PHONY: kind/stop
 kind/stop:


### PR DESCRIPTION
### Summary

This PR adds `test/e2e/debug-fast` target. I spent some time on how to optimize the time for E2E to start to increase our development velocity.
With this target, a full E2E test (build binaries, images, load them to k8s cluster) with both Kubernetes clusters can start in only **40 seconds** on my machine.
Just a simple `k3d/start` (1 K8S cluster) even without image loading takes 30s.

`image*` targets were not compatible with parallel execution.
For example: `image/kuma-cp` depends on both `build/kuma-cp/linux-amd64` and `docker/build/kuma-cp`.
`docker/build/kuma-cp` depends on a binary build by `build/kuma-cp/linux-amd64`.
Execute it with `-j` and see that `docker/build/kuma-cp` complains because there is no binary yet.
That's why I forced order of those targets within `image*`. This way `make -j images` can build everything in parallel.

Ideally, this target should be also a default target executed on CI, but since I have a bad experience with parallel execution in the makefile (you can run into races) I'd rather keep this target as experimental for now.

### Issues resolved

No reported issues.

### Documentation

No docs.

### Testing

- [ ] Unit tests
- [X] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes

### Backwards compatibility

- [X] No UPGRADE.md
- [X] Add `backport-to-stable` label if the code is backwards compatible. Otherwise, list breaking changes.
