### PR TITLE
chore(*): fix package names in Auth DP E2E tests

### DIFF
--- a/test/e2e/auth/dp/auth_dp_suite_test.go
+++ b/test/e2e/auth/dp/auth_dp_suite_test.go
@@ -1,4 +1,4 @@
-package auth_test
+package dp_test
 
 import (
 	"testing"
@@ -6,7 +6,7 @@ import (
 	. "github.com/onsi/ginkgo"
 
 	"github.com/kumahq/kuma/pkg/test"
-	auth "github.com/kumahq/kuma/test/e2e/auth/dp"
+	"github.com/kumahq/kuma/test/e2e/auth/dp"
 	"github.com/kumahq/kuma/test/framework"
 )
 
@@ -18,4 +18,4 @@ func TestE2EDpAuth(t *testing.T) {
 	}
 }
 
-var _ = Describe("Test Universal", auth.DpAuthUniversal)
+var _ = Describe("Test Universal", dp.DpAuthUniversal)

--- a/test/e2e/auth/dp/dp_auth_universal.go
+++ b/test/e2e/auth/dp/dp_auth_universal.go
@@ -1,4 +1,4 @@
-package auth
+package dp
 
 import (
 	. "github.com/onsi/ginkgo"


### PR DESCRIPTION
### Summary

Fix package names to be consistent.

### Issues resolved

No reported issues

### Documentation

No docs

### Testing

- [ ] Unit tests
- [X] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes

### Backwards compatibility

- [X] No UPGRADE.md
- [X] Add `backport-to-stable` label if the code is backwards compatible. Otherwise, list breaking changes.
