### PR TITLE
tests(kuma-cp): add kubernetes mTLS permissions test

### DIFF
--- a/test/e2e/gateway/gateway_kubernetes.go
+++ b/test/e2e/gateway/gateway_kubernetes.go
@@ -275,5 +275,29 @@ spec:
 		})
 
 		It("should proxy simple HTTP requests", ProxySimpleRequests("/", "kubernetes"))
+
+		// In mTLS mode, only the presence of TrafficPermission rules allow services to receive
+		// traffic, so removing the permission should cause requests to fail. We use this to
+		// prove that mTLS is enabled
+		It("should fail without TrafficPermission", func() {
+			Expect(k8s.RunKubectlE(cluster.GetTesting(), cluster.GetKubectlOptions(),
+				"delete", "trafficpermission", "allow-all-default")).To(Succeed())
+
+			Eventually(func(g Gomega) {
+				target := fmt.Sprintf("http://%s/%s",
+					net.JoinHostPort(GatewayInstanceAddress("edge-gateway"), "8080"),
+					path.Join("test", url.PathEscape(GinkgoT().Name())),
+				)
+
+				status, err := testutil.CollectFailure(
+					cluster, "gateway-client", target,
+					testutil.FromKubernetesPod(ClientNamespace, "gateway-client"),
+					testutil.WithHeader("Host", "example.kuma.io"),
+				)
+
+				g.Expect(err).To(Succeed())
+				g.Expect(status.ResponseCode).To(Equal(503))
+			}, "30s", "1s").Should(Succeed())
+		})
 	})
 }

--- a/test/framework/exec_util.go
+++ b/test/framework/exec_util.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/url"
 	"strings"
+	"time"
 
 	"github.com/gruntwork-io/terratest/modules/k8s"
 	"github.com/gruntwork-io/terratest/modules/retry"
@@ -31,75 +32,99 @@ type ExecOptions struct {
 	CaptureStderr bool
 	// If false, whitespace in std{err,out} will be removed.
 	PreserveWhitespace bool
+
+	Retries int
+	Timeout time.Duration
 }
 
 // ExecWithOptions executes a command in the specified container,
 // returning stdout, stderr and error. `options` allowed for
 // additional parameters to be passed.
 func (c *K8sCluster) ExecWithOptions(options ExecOptions) (string, string, error) {
-	const tty = false
-	config, err := k8s.LoadApiClientConfigE(c.kubeconfig, "")
-	Expect(err).NotTo(HaveOccurred())
+	kubectlExec := func() (string, string, error) {
+		const tty = false
+		config, err := k8s.LoadApiClientConfigE(c.kubeconfig, "")
+		Expect(err).NotTo(HaveOccurred())
 
-	clientset, err := k8s.GetKubernetesClientFromOptionsE(c.t, c.GetKubectlOptions())
-	Expect(err).NotTo(HaveOccurred())
+		clientset, err := k8s.GetKubernetesClientFromOptionsE(c.t, c.GetKubectlOptions())
+		Expect(err).NotTo(HaveOccurred())
 
-	req := clientset.CoreV1().RESTClient().Post().
-		Resource("pods").
-		Name(options.PodName).
-		Namespace(options.Namespace).
-		SubResource("exec").
-		Param("container", options.ContainerName)
+		req := clientset.CoreV1().RESTClient().Post().
+			Resource("pods").
+			Name(options.PodName).
+			Namespace(options.Namespace).
+			SubResource("exec").
+			Param("container", options.ContainerName)
 
-	req.VersionedParams(&kube_core.PodExecOptions{
-		Container: options.ContainerName,
-		Command:   options.Command,
-		Stdin:     true,
-		Stdout:    options.CaptureStdout,
-		Stderr:    options.CaptureStderr,
-		TTY:       tty,
-	}, scheme.ParameterCodec)
+		req.VersionedParams(&kube_core.PodExecOptions{
+			Container: options.ContainerName,
+			Command:   options.Command,
+			Stdin:     true,
+			Stdout:    options.CaptureStdout,
+			Stderr:    options.CaptureStderr,
+			TTY:       tty,
+		}, scheme.ParameterCodec)
 
-	var stdout, stderr bytes.Buffer
-	err = executeK8s("POST", req.URL(), config, strings.NewReader(""), &stdout, &stderr, tty)
+		var stdout, stderr bytes.Buffer
+		err = executeK8s("POST", req.URL(), config, strings.NewReader(""), &stdout, &stderr, tty)
 
-	if options.PreserveWhitespace {
-		return stdout.String(), stderr.String(), err
+		if options.PreserveWhitespace {
+			return stdout.String(), stderr.String(), err
+		}
+
+		return strings.TrimSpace(stdout.String()), strings.TrimSpace(stderr.String()), err
 	}
-	return strings.TrimSpace(stdout.String()), strings.TrimSpace(stderr.String()), err
-}
 
-// Exec executes a command in the
-// specified container and return stdout, stderr and error
-func (c *K8sCluster) Exec(namespace, podName, containerName string, cmd ...string) (string, string, error) {
-	return c.ExecWithOptions(ExecOptions{
-		Command:       cmd,
-		Namespace:     namespace,
-		PodName:       podName,
-		ContainerName: containerName,
-
-		Stdin:              nil,
-		CaptureStdout:      true,
-		CaptureStderr:      true,
-		PreserveWhitespace: false,
-	})
-}
-
-func (c *K8sCluster) ExecWithRetries(namespace, podName, containerName string, cmd ...string) (string, string, error) {
 	var stdout string
 	var stderr string
 	_, err := retry.DoWithRetryE(
 		c.t,
-		fmt.Sprintf("kubectl exec -- %s", strings.Join(cmd, " ")),
-		DefaultRetries,
-		DefaultTimeout,
+		fmt.Sprintf("kubectl exec -c %q -n %q %s -- %s",
+			options.ContainerName,
+			options.Namespace,
+			options.PodName,
+			strings.Join(options.Command, " ")),
+		options.Retries,
+		options.Timeout,
 		func() (string, error) {
 			var err error
-			stdout, stderr, err = c.Exec(namespace, podName, containerName, cmd...)
+			stdout, stderr, err = kubectlExec()
 			return "", err
 		},
 	)
 	return stdout, stderr, err
+}
+
+// Exec executes a command in the specified container and return stdout,
+// stderr and error.
+func (c *K8sCluster) Exec(namespace, podName, containerName string, cmd ...string) (string, string, error) {
+	return c.ExecWithOptions(ExecOptions{
+		Command:            cmd,
+		Namespace:          namespace,
+		PodName:            podName,
+		ContainerName:      containerName,
+		CaptureStdout:      true,
+		CaptureStderr:      true,
+		PreserveWhitespace: false,
+		Retries:            0,
+	})
+}
+
+// ExecWithRetries executes a command in the specified container and
+// return stdout, stderr and error. It retries a default number of times
+// if the command fails.
+func (c *K8sCluster) ExecWithRetries(namespace, podName, containerName string, cmd ...string) (string, string, error) {
+	return c.ExecWithOptions(ExecOptions{
+		Command:            cmd,
+		Namespace:          namespace,
+		PodName:            podName,
+		ContainerName:      containerName,
+		CaptureStdout:      true,
+		CaptureStderr:      true,
+		PreserveWhitespace: false,
+		Retries:            DefaultRetries,
+		Timeout:            DefaultTimeout,
+	})
 }
 
 func executeK8s(method string, url *url.URL, config *restclient.Config, stdin io.Reader, stdout, stderr io.Writer, tty bool) error {

--- a/test/framework/k8s_controlplane.go
+++ b/test/framework/k8s_controlplane.go
@@ -364,8 +364,8 @@ func (c *K8sControlPlane) UpdateObject(
 		return err
 	}
 
-	if err := scheme.Convert(u, obj, nil); err != nil {
-		return nil
+	if err := scheme.Convert(&u, obj, nil); err != nil {
+		return err
 	}
 
 	obj = update(obj)


### PR DESCRIPTION
### Summary

Enable the mTLS permissions test for Gateway in Kubernetes zones. This
exercises a couple of new code paths in the test framework, so we needed
to fix a bug in the mesh deployment update option and improve debugging
and option handling in some other places.

### Full changelog

N/A

### Issues resolved

Update #3510

### Documentation

N/A

### Testing

- [x] Unit tests
- [x] E2E tests
- [ ] ~~Manual testing on Universal~~
- [ ] ~~Manual testing on Kubernetes~~

### Backwards compatibility

- [ ] ~~Update [`UPGRADE.md`](UPGRADE.md) with any steps users will need to take when upgrading.~~
- [ ] ~~Add `backport-to-stable` label if the code is backwards compatible. Otherwise, list breaking changes.~~
