### PR TITLE
fix(build): move API makefile to the main build system

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,8 @@ help: ## Display this help screen
 	done
 
 include mk/dev.mk
+
+include mk/api.mk
 include mk/build.mk
 include mk/check.mk
 include mk/test.mk


### PR DESCRIPTION
### Summary

Merge `api/Makefile` back to `mk/api.mk`. This consolidates the build and
removes some duplication of protobuf configuration.  The main issue is
that protoc binds the proto search path and the output path in surprising
and undocumented ways. So, depending on the context, we have to either
change into the "api" directory, or add it to the search path.

### Full changelog

N/A

### Issues resolved

Fix #2495.

### Documentation

N/A

### Testing

- [x] Unit tests
- [x] E2E tests
- [ ] ~~Manual testing on Universal~~
- [ ] ~~Manual testing on Kubernetes~~

### Backwards compatibility

- [ ] ~~Update [`UPGRADE.md`](UPGRADE.md) with any steps users will need to take when upgrading.~~
- [ ] ~~Add `backport-to-stable` label if the code is backwards compatible. Otherwise, list breaking changes.~~
