### PR TITLE
feat(kumactl) Add Tracing and Logging Backend Type in CLI

### DIFF
--- a/app/kumactl/cmd/get/testdata/get-mesh.golden.txt
+++ b/app/kumactl/cmd/get/testdata/get-mesh.golden.txt
@@ -1,2 +1,2 @@
-NAME     mTLS                METRICS                   LOGGING          TRACING                LOCALITY   AGE
-mesh-1   builtin/builtin-1   prometheus/prometheus-1   logstash, file   zipkin-us, zipkin-eu   on         292y
+NAME     mTLS                METRICS                   LOGGING                   TRACING                              LOCALITY   AGE
+mesh-1   builtin/builtin-1   prometheus/prometheus-1   tcp/logstash, file/file   zipkin/zipkin-us, zipkin/zipkin-eu   on         292y

--- a/app/kumactl/cmd/get/testdata/get-meshes.golden.txt
+++ b/app/kumactl/cmd/get/testdata/get-meshes.golden.txt
@@ -1,3 +1,3 @@
-NAME    mTLS                METRICS                   LOGGING          TRACING                LOCALITY   AGE
-mesh1   builtin/builtin-1   prometheus/prometheus-1   logstash, file   zipkin-us, zipkin-eu   on         292y
-mesh2   off                 off                       off              off                    off        292y
+NAME    mTLS                METRICS                   LOGGING                   TRACING                              LOCALITY   AGE
+mesh1   builtin/builtin-1   prometheus/prometheus-1   tcp/logstash, file/file   zipkin/zipkin-us, zipkin/zipkin-eu   on         292y
+mesh2   off                 off                       off                       off                                  off        292y

--- a/app/kumactl/cmd/get/testdata/get-meshes.pagination.golden.txt
+++ b/app/kumactl/cmd/get/testdata/get-meshes.pagination.golden.txt
@@ -1,4 +1,4 @@
-NAME    mTLS                METRICS                   LOGGING          TRACING                LOCALITY   AGE
-mesh1   builtin/builtin-1   prometheus/prometheus-1   logstash, file   zipkin-us, zipkin-eu   on         292y
+NAME    mTLS                METRICS                   LOGGING                   TRACING                              LOCALITY   AGE
+mesh1   builtin/builtin-1   prometheus/prometheus-1   tcp/logstash, file/file   zipkin/zipkin-us, zipkin/zipkin-eu   on         292y
 
 Rerun command with --offset=1 argument to retrieve more resources

--- a/pkg/core/resources/apis/mesh/mesh_helpers.go
+++ b/pkg/core/resources/apis/mesh/mesh_helpers.go
@@ -58,7 +58,8 @@ func (m *MeshResource) GetTracingBackend(name string) *mesh_proto.TracingBackend
 func (m *MeshResource) GetLoggingBackends() string {
 	var backends []string
 	for _, backend := range m.Spec.GetLogging().GetBackends() {
-		backends = append(backends, backend.GetName())
+		backend := fmt.Sprintf("%s/%s", backend.GetType(), backend.GetName())
+		backends = append(backends, backend)
 	}
 	return strings.Join(backends, ", ")
 }
@@ -68,7 +69,8 @@ func (m *MeshResource) GetLoggingBackends() string {
 func (m *MeshResource) GetTracingBackends() string {
 	var backends []string
 	for _, backend := range m.Spec.GetTracing().GetBackends() {
-		backends = append(backends, backend.GetName())
+		backend := fmt.Sprintf("%s/%s", backend.GetType(), backend.GetName())
+		backends = append(backends, backend)
 	}
 	return strings.Join(backends, ", ")
 }

--- a/pkg/core/resources/apis/mesh/mesh_helpers_test.go
+++ b/pkg/core/resources/apis/mesh/mesh_helpers_test.go
@@ -195,7 +195,7 @@ var _ = Describe("MeshResource", func() {
 				},
 			}
 			backends := mesh.GetLoggingBackends()
-			Expect(backends).To(Equal("logstash-1, file-1"))
+			Expect(backends).To(Equal("logstash/logstash-1, file/file-1"))
 		})
 		It("should return default logging backend if logging backends is empty", func() {
 			mesh := &MeshResource{
@@ -237,7 +237,7 @@ var _ = Describe("MeshResource", func() {
 			}
 
 			backends := mesh.GetTracingBackends()
-			Expect(backends).To(Equal("zipkin-us, zipkin-eu"))
+			Expect(backends).To(Equal("zipkin/zipkin-us, zipkin/zipkin-eu"))
 		})
 		It("should return default tracing backend if tracing backends is empty", func() {
 			mesh := &MeshResource{


### PR DESCRIPTION
### Summary

This PR introduces tracing and logging backend type in the cli table output along with its name.

### Full changelog

* Updated mesh_helpers file to include `type`

### Issues resolved

Fix #3345

### Documentation

- [ ] Link to the website [documentation PR](https://github.com/kumahq/kuma-website/pull/XXX)

### Testing

- [x] Unit tests
- [ ] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes

### Backwards compatibility

- [ ] Update [`UPGRADE.md`](UPGRADE.md) with any steps users will need to take
      when upgrading.
- [ ] Add `backport-to-stable` label if the code is backwards compatible. Otherwise, list breaking changes.
