### PR TITLE
fix(kumactl): print meta before spec for Kuma resources

### DIFF
--- a/app/kumactl/cmd/apply/apply_test.go
+++ b/app/kumactl/cmd/apply/apply_test.go
@@ -414,9 +414,9 @@ var _ = Describe("kumactl apply", func() {
 mesh: default
 modificationTime: "0001-01-01T00:00:00Z"
 name: sample
+type: Dataplane
 networking:
   address: 2.2.2.2
-type: Dataplane
 `))
 	})
 
@@ -461,7 +461,8 @@ type: Dataplane
 			err := rootCmd.Execute()
 
 			// then
-			Expect(err).To(MatchError(given.err))
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring(given.err))
 		},
 		Entry("no mesh", testCase{
 			resource: `
@@ -485,7 +486,7 @@ mesh: default
 networking:
   inbound: 0 # should be a string
 `,
-			err: "YAML contains invalid resource: invalid Dataplane object \"dp-1\": json: cannot unmarshal number into Go value of type []json.RawMessage",
+			err: `YAML contains invalid resource: invalid Dataplane object "dp-1"`,
 		}),
 		Entry("no resource", testCase{
 			resource: ``,

--- a/app/kumactl/cmd/get/testdata/get-circuit-breaker.golden.yaml
+++ b/app/kumactl/cmd/get/testdata/get-circuit-breaker.golden.yaml
@@ -1,3 +1,8 @@
+creationTime: "0001-01-01T00:00:00Z"
+mesh: default
+modificationTime: "0001-01-01T00:00:00Z"
+name: circuit-breaker-1
+type: CircuitBreaker
 conf:
   baseEjectionTime: 5s
   detectors:
@@ -8,15 +13,10 @@ conf:
     totalErrors: {}
   interval: 5s
   maxEjectionPercent: 50
-creationTime: "0001-01-01T00:00:00Z"
 destinations:
 - match:
     service: backend
-mesh: default
-modificationTime: "0001-01-01T00:00:00Z"
-name: circuit-breaker-1
 sources:
 - match:
     service: frontend
     version: "0.1"
-type: CircuitBreaker

--- a/app/kumactl/cmd/get/testdata/get-dataplane.golden.yaml
+++ b/app/kumactl/cmd/get/testdata/get-dataplane.golden.yaml
@@ -2,6 +2,7 @@ creationTime: "0001-01-01T00:00:00Z"
 mesh: default
 modificationTime: "0001-01-01T00:00:00Z"
 name: dataplane-1
+type: Dataplane
 networking:
   address: 127.0.0.1
   inbound:
@@ -15,4 +16,3 @@ networking:
     tags:
       service: metrics
       version: v1
-type: Dataplane

--- a/app/kumactl/cmd/get/testdata/get-fault-injection.golden.yaml
+++ b/app/kumactl/cmd/get/testdata/get-fault-injection.golden.yaml
@@ -1,13 +1,13 @@
-conf:
-  abort:
-    httpStatus: 500
-    percentage: 50
 creationTime: "0001-01-01T00:00:00Z"
 mesh: default
 modificationTime: "0001-01-01T00:00:00Z"
 name: fault-injection-1
+type: FaultInjection
+conf:
+  abort:
+    httpStatus: 500
+    percentage: 50
 sources:
 - match:
     service: frontend
     version: "0.1"
-type: FaultInjection

--- a/app/kumactl/cmd/get/testdata/get-global-secret.golden.yaml
+++ b/app/kumactl/cmd/get/testdata/get-global-secret.golden.yaml
@@ -1,5 +1,5 @@
 creationTime: "0001-01-01T00:00:00Z"
-data: dGVzdDIK
 modificationTime: "0001-01-01T00:00:00Z"
 name: global-secret-1
 type: GlobalSecret
+data: dGVzdDIK

--- a/app/kumactl/cmd/get/testdata/get-healthcheck.golden.yaml
+++ b/app/kumactl/cmd/get/testdata/get-healthcheck.golden.yaml
@@ -1,16 +1,16 @@
+creationTime: "0001-01-01T00:00:00Z"
+mesh: default
+modificationTime: "0001-01-01T00:00:00Z"
+name: healthcheck-1
+type: HealthCheck
 conf:
   healthyThreshold: 1
   interval: 10s
   timeout: 2s
   unhealthyThreshold: 3
-creationTime: "0001-01-01T00:00:00Z"
 destinations:
 - match:
     service: backend
-mesh: default
-modificationTime: "0001-01-01T00:00:00Z"
-name: healthcheck-1
 sources:
 - match:
     service: web
-type: HealthCheck

--- a/app/kumactl/cmd/get/testdata/get-mesh.golden.yaml
+++ b/app/kumactl/cmd/get/testdata/get-mesh.golden.yaml
@@ -1,4 +1,7 @@
 creationTime: "0001-01-01T00:00:00Z"
+modificationTime: "0001-01-01T00:00:00Z"
+name: mesh-1
+type: Mesh
 logging:
   backends:
   - conf:
@@ -17,13 +20,11 @@ metrics:
     name: prometheus-1
     type: prometheus
   enabledBackend: prometheus-1
-modificationTime: "0001-01-01T00:00:00Z"
 mtls:
   backends:
   - name: builtin-1
     type: builtin
   enabledBackend: builtin-1
-name: mesh-1
 routing:
   localityAwareLoadBalancing: true
 tracing:
@@ -36,4 +37,3 @@ tracing:
       url: http://zipkin.eu:8080/v1/spans
     name: zipkin-eu
     type: zipkin
-type: Mesh

--- a/app/kumactl/cmd/get/testdata/get-proxytemplate.golden.yaml
+++ b/app/kumactl/cmd/get/testdata/get-proxytemplate.golden.yaml
@@ -1,11 +1,11 @@
-conf:
-  imports:
-  - default-proxy
 creationTime: "0001-01-01T00:00:00Z"
 mesh: default
 modificationTime: "0001-01-01T00:00:00Z"
 name: proxytemplate-1
+type: ProxyTemplate
+conf:
+  imports:
+  - default-proxy
 selectors:
 - match:
     service: backend
-type: ProxyTemplate

--- a/app/kumactl/cmd/get/testdata/get-rate-limit.golden.yaml
+++ b/app/kumactl/cmd/get/testdata/get-rate-limit.golden.yaml
@@ -1,13 +1,13 @@
 creationTime: "0001-01-01T00:00:00Z"
+mesh: default
+modificationTime: "0001-01-01T00:00:00Z"
+name: rate-limit-1
+type: RateLimit
 destinations:
 - match:
     env: dev
     service: backend1
-mesh: default
-modificationTime: "0001-01-01T00:00:00Z"
-name: rate-limit-1
 sources:
 - match:
     service: web1
     version: "1.0"
-type: RateLimit

--- a/app/kumactl/cmd/get/testdata/get-retry.golden.yaml
+++ b/app/kumactl/cmd/get/testdata/get-retry.golden.yaml
@@ -1,3 +1,8 @@
+creationTime: "0001-01-01T00:00:00Z"
+mesh: default
+modificationTime: "0001-01-01T00:00:00Z"
+name: retry-1
+type: Retry
 conf:
   http:
     backOff:
@@ -8,14 +13,9 @@ conf:
     retriableStatusCodes:
     - 500
     - 501
-creationTime: "0001-01-01T00:00:00Z"
 destinations:
 - match:
     service: backend
-mesh: default
-modificationTime: "0001-01-01T00:00:00Z"
-name: retry-1
 sources:
 - match:
     service: web
-type: Retry

--- a/app/kumactl/cmd/get/testdata/get-secret.golden.yaml
+++ b/app/kumactl/cmd/get/testdata/get-secret.golden.yaml
@@ -1,6 +1,6 @@
 creationTime: "0001-01-01T00:00:00Z"
-data: dGVzdDIK
 mesh: default
 modificationTime: "0001-01-01T00:00:00Z"
 name: secret-1
 type: Secret
+data: dGVzdDIK

--- a/app/kumactl/cmd/get/testdata/get-traffic-log.golden.yaml
+++ b/app/kumactl/cmd/get/testdata/get-traffic-log.golden.yaml
@@ -1,15 +1,15 @@
+creationTime: "0001-01-01T00:00:00Z"
+mesh: default
+modificationTime: "0001-01-01T00:00:00Z"
+name: traffic-log-1
+type: TrafficLog
 conf:
   backend: file
-creationTime: "0001-01-01T00:00:00Z"
 destinations:
 - match:
     env: dev
     service: backend1
-mesh: default
-modificationTime: "0001-01-01T00:00:00Z"
-name: traffic-log-1
 sources:
 - match:
     service: web1
     version: "1.0"
-type: TrafficLog

--- a/app/kumactl/cmd/get/testdata/get-traffic-permission.golden.yaml
+++ b/app/kumactl/cmd/get/testdata/get-traffic-permission.golden.yaml
@@ -1,13 +1,13 @@
 creationTime: "0001-01-01T00:00:00Z"
+mesh: default
+modificationTime: "0001-01-01T00:00:00Z"
+name: traffic-permission-1
+type: TrafficPermission
 destinations:
 - match:
     env: dev
     service: backend1
-mesh: default
-modificationTime: "0001-01-01T00:00:00Z"
-name: traffic-permission-1
 sources:
 - match:
     service: web1
     version: "1.0"
-type: TrafficPermission

--- a/app/kumactl/cmd/get/testdata/get-traffic-route.golden.yaml
+++ b/app/kumactl/cmd/get/testdata/get-traffic-route.golden.yaml
@@ -1,17 +1,17 @@
+creationTime: "0001-01-01T00:00:00Z"
+mesh: default
+modificationTime: "0001-01-01T00:00:00Z"
+name: traffic-route-1
+type: TrafficRoute
 conf:
   split:
   - destination:
       service: redis
       version: "1.0"
     weight: 90
-creationTime: "0001-01-01T00:00:00Z"
 destinations:
 - match:
     service: redis
-mesh: default
-modificationTime: "0001-01-01T00:00:00Z"
-name: traffic-route-1
 sources:
 - match:
     service: backend
-type: TrafficRoute

--- a/app/kumactl/cmd/get/testdata/get-traffic-trace.golden.yaml
+++ b/app/kumactl/cmd/get/testdata/get-traffic-trace.golden.yaml
@@ -1,11 +1,11 @@
-conf:
-  backend: zipkin
 creationTime: "0001-01-01T00:00:00Z"
 mesh: default
 modificationTime: "0001-01-01T00:00:00Z"
 name: traffic-trace-1
+type: TrafficTrace
+conf:
+  backend: zipkin
 selectors:
 - match:
     service: web1
     version: "1.0"
-type: TrafficTrace

--- a/app/kumactl/pkg/output/yaml/printer.go
+++ b/app/kumactl/pkg/output/yaml/printer.go
@@ -1,11 +1,14 @@
 package yaml
 
 import (
+	"bytes"
 	"io"
 
 	"github.com/ghodss/yaml"
 
 	"github.com/kumahq/kuma/app/kumactl/pkg/output"
+	"github.com/kumahq/kuma/pkg/core/resources/model/rest"
+	util_proto "github.com/kumahq/kuma/pkg/util/proto"
 )
 
 func NewPrinter() output.Printer {
@@ -16,11 +19,38 @@ var _ output.Printer = &printer{}
 
 type printer struct{}
 
-func (p *printer) Print(obj interface{}, out io.Writer) error {
+func print(obj interface{}, out io.Writer) error {
 	b, err := yaml.Marshal(obj)
 	if err != nil {
 		return err
 	}
 	_, err = out.Write(b)
 	return err
+}
+
+func (p *printer) Print(obj interface{}, out io.Writer) error {
+	// The common case is printing a single Kuma resource, in which
+	// case showing the meta and then the spec is more readable than
+	// showing fields in an arbitrary order. This partially addresses
+	// https://github.com/kumahq/kuma/issues/679.
+	switch obj := obj.(type) {
+	case *rest.Resource:
+		if err := print(obj.Meta, out); err != nil {
+			return err
+		}
+
+		b, err := util_proto.ToYAML(obj.Spec)
+		if err != nil {
+			return err
+		}
+		// Don't emit an empty YAML object that would cause a
+		// subsequent parse failure.
+		if len(b) == 0 || bytes.HasPrefix(b, []byte("{}")) {
+			return nil
+		}
+		_, err = out.Write(b)
+		return err
+	default:
+		return print(obj, out)
+	}
 }

--- a/app/kumactl/pkg/output/yaml/testdata/mesh.golden.yaml
+++ b/app/kumactl/pkg/output/yaml/testdata/mesh.golden.yaml
@@ -1,9 +1,9 @@
 creationTime: "2018-07-17T16:05:36.995Z"
 modificationTime: "2019-07-17T16:05:36.995Z"
+name: demo
+type: Mesh
 mtls:
   backends:
   - name: builtin-1
     type: builtin
   enabledBackend: builtin-1
-name: demo
-type: Mesh

--- a/app/kumactl/pkg/output/yaml/yaml_test.go
+++ b/app/kumactl/pkg/output/yaml/yaml_test.go
@@ -2,7 +2,6 @@ package yaml_test
 
 import (
 	"bytes"
-	"os"
 	"path/filepath"
 	"time"
 
@@ -15,6 +14,7 @@ import (
 	"github.com/kumahq/kuma/app/kumactl/pkg/output/yaml"
 	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	core_rest "github.com/kumahq/kuma/pkg/core/resources/model/rest"
+	. "github.com/kumahq/kuma/pkg/test/matchers"
 )
 
 var _ = Describe("printer", func() {
@@ -39,14 +39,8 @@ var _ = Describe("printer", func() {
 			err := printer.Print(given.obj, buf)
 			// then
 			Expect(err).ToNot(HaveOccurred())
-
-			// when
-			expected, err := os.ReadFile(filepath.Join("testdata", given.goldenFile))
-			// then
-			Expect(err).ToNot(HaveOccurred())
-
 			// and
-			Expect(buf.String()).To(Equal(string(expected)))
+			Expect(buf.String()).To(MatchGoldenYAML(filepath.Join("testdata", given.goldenFile)))
 		},
 		Entry("format `nil` value", testCase{
 			obj:        nil,

--- a/test/framework/kumactl.go
+++ b/test/framework/kumactl.go
@@ -215,7 +215,7 @@ func (k *KumactlOptions) KumactlUpdateObject(
 
 	resource, err := rest.UnmarshallToCore([]byte(out))
 	if err != nil {
-		return errors.Wrapf(err, "failed to unmarshal %q object %q", typeName, objectName)
+		return errors.Wrapf(err, "failed to unmarshal %q object %q: %q", typeName, objectName, out)
 	}
 
 	updated := rest.NewFromModel(update(resource))


### PR DESCRIPTION
### Summary

When printing Kuma resources as YAML, it's a better user experience to
show the metadata fields (including the type and name) up front, rather
than the fields being in an arbitrary order.

This change is not a complete fix for the issue, but by tweaking the
kumactl get printer, we can make a small change that improves the user
experience in most cases.

### Full changelog

N/A

### Issues resolved

Update #679

### Documentation

N/A

### Testing

- [x] Unit tests
- [x] E2E tests
- [ ] ~~Manual testing on Universal~~
- [ ] ~~Manual testing on Kubernetes~~

### Backwards compatibility

- [ ] ~~Update [`UPGRADE.md`](UPGRADE.md) with any steps users will need to take when upgrading.~~
- [ ] ~~Add `backport-to-stable` label if the code is backwards compatible. Otherwise, list breaking changes.~~
