### PR TITLE
fix(kumactl): ignore any unregistered CRDs, not only from the root chart

### DIFF
--- a/app/kumactl/cmd/install/render_helm_files.go
+++ b/app/kumactl/cmd/install/render_helm_files.go
@@ -24,7 +24,7 @@ import (
 func unregisteredCRD(scheme *kube_runtime.Scheme, chartFile *data.File) bool {
 	types := scheme.AllKnownTypes()
 
-	if !strings.HasPrefix(chartFile.FullPath, "crds/") {
+	if !strings.Contains(chartFile.FullPath, "crds/") {
 		return false
 	}
 


### PR DESCRIPTION
### Summary

We were filtering out unregistered CRDs too loosely.