### PR TITLE
ci: stop applying dependabot on release branches

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,14 +6,6 @@ updates:
       interval: "weekly"
     labels:
       - "dependencies"
-  - package-ecosystem: "gomod"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-    labels:
-      - "dependencies"
-      - "release-1.4"
-    target-branch: "release-1.4"
   - package-ecosystem: "docker"
     directory: "/tools/releases/dockerfiles"
     schedule:


### PR DESCRIPTION
As we're not systematically backporting changes we shouldn't do dependabot
on release branches


### Documentation

- ~~[ ] Link to the website [documentation PR](https://github.com/kumahq/kuma-website/pull/XXX)~~

### Testing

- ~~[ ] Unit tests~~
- ~~[ ] E2E tests~~
- ~~[ ] Manual testing on Universal~~
- ~~[ ] Manual testing on Kubernetes~~

### Backwards compatibility

- ~~[ ] Update [`UPGRADE.md`](/UPGRADE.md) with any steps users will need to take when upgrading.~~
- ~~[ ] Add `backport-to-stable` label if the code follows our [backporting policy](/CONTRIBUTING.md#backporting)~~
