### PR TITLE
fix(build): fix make test targets for individual components

### DIFF
--- a/mk/test.mk
+++ b/mk/test.mk
@@ -29,12 +29,12 @@ coverage: ${COVERAGE_PROFILE}
 
 .PHONY: test/kuma-cp
 test/kuma-cp: PKG_LIST=./app/kuma-cp/... ./pkg/config/app/kuma-cp/...
-test/kuma-cp: test/kuma ## Dev: Run `kuma-cp` tests only
+test/kuma-cp: test ## Dev: Run `kuma-cp` tests only
 
 .PHONY: test/kuma-dp
 test/kuma-dp: PKG_LIST=./app/kuma-dp/... ./pkg/config/app/kuma-dp/...
-test/kuma-dp: test/kuma ## Dev: Run `kuma-dp` tests only
+test/kuma-dp: test ## Dev: Run `kuma-dp` tests only
 
 .PHONY: test/kumactl
 test/kumactl: PKG_LIST=./app/kumactl/... ./pkg/config/app/kumactl/...
-test/kumactl: test/kuma ## Dev: Run `kumactl` tests only
+test/kumactl: test ## Dev: Run `kumactl` tests only


### PR DESCRIPTION
### Summary

`make` targets for running test for individual components is broken. This PR introduces the correct targets for the components.

### Full changelog

N/A

### Issues resolved

N/A

### Documentation

N/A

### Testing

- [x] Unit tests
- [x] E2E tests
- [ ] ~~Manual testing on Universal~~
- [ ] ~~Manual testing on Kubernetes~~

### Backwards compatibility

- [ ] ~~Update [`UPGRADE.md`](/UPGRADE.md) with any steps users will need to take when upgrading.~~
- [ ] ~~Add `backport-to-stable` label if the code follows our [backporting policy](/CONTRIBUTING.md#backporting)~~
