### PR TITLE
chore(e2e): switch Kubernetes update helper to use apply

### DIFF
--- a/test/framework/k8s_cluster.go
+++ b/test/framework/k8s_cluster.go
@@ -575,6 +575,10 @@ func (c *K8sCluster) DeployKuma(mode core.CpMode, opt ...KumaDeploymentOption) e
 						panic(err.Error())
 					}
 
+					// Note that at this point we might have lost some Kubernetes
+					// resource metadata. That probably doesn't matter for Mesh objects
+					// though.
+
 					return meshObj
 				})
 			if err != nil {

--- a/test/framework/k8s_controlplane.go
+++ b/test/framework/k8s_controlplane.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"net"
 	"net/http"
-	"os"
 	"strconv"
 
 	http_helper "github.com/gruntwork-io/terratest/modules/http-helper"
@@ -382,15 +381,10 @@ func (c *K8sControlPlane) UpdateObject(
 		return err
 	}
 
-	KubectlReplaceFromStringE := func(t testing.TestingT, options *k8s.KubectlOptions, configData string) error {
-		tmpfile, err := k8s.StoreConfigToTempFileE(t, configData)
-		if err != nil {
-			return err
-		}
-		defer os.Remove(tmpfile)
-
-		return k8s.RunKubectlE(t, options, "replace", "-f", tmpfile)
+	if err := k8s.KubectlApplyFromStringE(c.t, c.GetKubectlOptions(), string(yaml)); err != nil {
+		return errors.Wrapf(err, "failed to update %s object %q with: %q",
+			typeName, objectName, yaml)
 	}
 
-	return KubectlReplaceFromStringE(c.t, c.GetKubectlOptions(), string(yaml))
+	return nil
 }


### PR DESCRIPTION
### Summary

The Kubernetes cluster object update helper works by doing a "kubectl
get", updating the deserialized result, then doing a "kubectl replace".
The intention is to set exactly what the test specifies without worrying
about patch and merge behavior.

Howwever, replacement requires the resource version to be current and when
Kuma converts Kubernetes objects to internal API resources, it does not
preserve all the Kubernetes metadata. It seems like this can lead to test
failures where the wrong resource version is used, though my understanding
was that kubectl internally ought to fetch the latest resource version
(though maybe it only does that once, and can lose race conditions).

At any rate, switching to "kubectl apply" ought to be OK for the current
uses of this mechanism, and should be more robust in CI.


### Full changelog

N/A

### Issues resolved

N/A

### Documentation

N/A

### Testing

- [x] Unit tests
- [x] E2E tests
- [ ] ~~Manual testing on Universal~~
- [ ] ~~Manual testing on Kubernetes~~

### Backwards compatibility

- [ ] ~~Update [`UPGRADE.md`](/UPGRADE.md) with any steps users will need to take when upgrading.~~
- [ ] ~~Add `backport-to-stable` label if the code follows our [backporting policy](/CONTRIBUTING.md#backporting)~~
