### PR TITLE
refactor(gateway): garbage collect Kuma Gateway resources owned by Gateway API resources

### DIFF
--- a/pkg/plugins/runtime/k8s/controllers/gatewayapi/common.go
+++ b/pkg/plugins/runtime/k8s/controllers/gatewayapi/common.go
@@ -4,13 +4,17 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/golang/protobuf/proto"
 	"github.com/pkg/errors"
 	kube_apierrs "k8s.io/apimachinery/pkg/api/errors"
+	kube_meta "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kube_types "k8s.io/apimachinery/pkg/types"
 	kube_client "sigs.k8s.io/controller-runtime/pkg/client"
 	gatewayapi "sigs.k8s.io/gateway-api/apis/v1alpha2"
 
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
+	k8s_model "github.com/kumahq/kuma/pkg/plugins/resources/k8s/native/pkg/model"
+	k8s_registry "github.com/kumahq/kuma/pkg/plugins/resources/k8s/native/pkg/registry"
 )
 
 const controllerName = gatewayapi.GatewayController("gateways.kuma.io/controller")
@@ -34,4 +38,82 @@ func serviceTagForGateway(name kube_types.NamespacedName) map[string]string {
 	return map[string]string{
 		mesh_proto.ServiceTag: fmt.Sprintf("%s_%s_gateway", name.Name, name.Namespace),
 	}
+}
+
+// reconcileLabelledObjectSet manages a set of owned kuma objects based on
+// labels with the owner key.
+// ownedType tells us what type the owned object is.
+// ownedSpec should be set to nil if the object shouldn't exist.
+func reconcileLabelledObject(
+	ctx context.Context,
+	registry k8s_registry.TypeRegistry,
+	client kube_client.Client,
+	owner kube_types.NamespacedName,
+	ownedType k8s_registry.ResourceType,
+	ownedSpec proto.Message,
+) error {
+	// First we list which existing objects are owned by this owner.
+	// We expect either 0 or 1 and depending on whether routeSpec is nil
+	// we either create an object or update or delete the existing one.
+	ownerLabelValue := fmt.Sprintf("%s-%s", owner.Namespace, owner.Name)
+	labels := kube_client.MatchingLabels{
+		ownerLabel: ownerLabelValue,
+	}
+
+	ownedList, err := registry.NewList(ownedType)
+	if err != nil {
+		return errors.Wrapf(err, "could not create list of owned %T", ownedType)
+	}
+
+	if err := client.List(ctx, ownedList, labels); err != nil {
+		return err
+	}
+
+	if l := len(ownedList.GetItems()); l > 1 {
+		return fmt.Errorf("internal error: found %d items labeled as owned by this object, expected either zero or one", l)
+	}
+
+	var existing k8s_model.KubernetesObject
+	if items := ownedList.GetItems(); len(items) == 1 {
+		existing = items[0]
+	}
+
+	if ownedSpec == nil {
+		if existing != nil {
+			if err := client.Delete(ctx, existing); err != nil && !kube_apierrs.IsNotFound(err) {
+				return err
+			}
+		}
+		return nil
+	}
+
+	if existing != nil {
+		existing.SetSpec(ownedSpec)
+
+		if err := client.Update(ctx, existing); err != nil {
+			return errors.Wrapf(err, "could not update owned %T", ownedType)
+		}
+		return nil
+	}
+
+	owned, err := registry.NewObject(ownedType)
+	if err != nil {
+		return errors.Wrapf(err, "could not get new %T from registry", ownedType)
+	}
+
+	owned.SetObjectMeta(
+		&kube_meta.ObjectMeta{
+			GenerateName: fmt.Sprintf("%s-", ownerLabelValue),
+			Labels: map[string]string{
+				ownerLabel: ownerLabelValue,
+			},
+		},
+	)
+	owned.SetSpec(ownedSpec)
+
+	if err := client.Create(ctx, owned); err != nil {
+		return errors.Wrapf(err, "could not create owned %T", ownedType)
+	}
+
+	return nil
 }

--- a/pkg/plugins/runtime/k8s/controllers/gatewayapi/http_route_controller.go
+++ b/pkg/plugins/runtime/k8s/controllers/gatewayapi/http_route_controller.go
@@ -2,7 +2,6 @@ package gatewayapi
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
@@ -16,8 +15,7 @@ import (
 
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	"github.com/kumahq/kuma/pkg/core/resources/manager"
-	k8s_common "github.com/kumahq/kuma/pkg/plugins/common/k8s"
-	mesh_k8s "github.com/kumahq/kuma/pkg/plugins/resources/k8s/native/api/v1alpha1"
+	k8s_registry "github.com/kumahq/kuma/pkg/plugins/resources/k8s/native/pkg/registry"
 	k8s_util "github.com/kumahq/kuma/pkg/plugins/runtime/k8s/util"
 )
 
@@ -27,7 +25,7 @@ type HTTPRouteReconciler struct {
 	Log logr.Logger
 
 	Scheme          *kube_runtime.Scheme
-	Converter       k8s_common.Converter
+	TypeRegistry    k8s_registry.TypeRegistry
 	SystemNamespace string
 	ResourceManager manager.ResourceManager
 }
@@ -39,7 +37,7 @@ const (
 	RefNotPermitted            = "RefNotPermitted"
 )
 
-const ownerLabel = "gateways.kuma.io/owner"
+const ownerLabel = "gateways.kuma.io/gateway.networking.k8s.io-owner"
 
 // Reconcile handles transforming a gateway-api HTTPRoute into a Kuma
 // GatewayRoute and managing the status of the gateway-api objects.
@@ -47,7 +45,8 @@ func (r *HTTPRouteReconciler) Reconcile(ctx context.Context, req kube_ctrl.Reque
 	httpRoute := &gatewayapi.HTTPRoute{}
 	if err := r.Get(ctx, req.NamespacedName, httpRoute); err != nil {
 		if kube_apierrs.IsNotFound(err) {
-			return kube_ctrl.Result{}, nil
+			err := reconcileLabelledObject(ctx, r.TypeRegistry, r.Client, req.NamespacedName, &mesh_proto.GatewayRoute{}, nil)
+			return kube_ctrl.Result{}, errors.Wrap(err, "could not delete owned GatewayRoute.kuma.io")
 		}
 
 		return kube_ctrl.Result{}, err
@@ -56,11 +55,11 @@ func (r *HTTPRouteReconciler) Reconcile(ctx context.Context, req kube_ctrl.Reque
 
 	spec, conditions, err := r.gapiToKumaRoutes(ctx, mesh, httpRoute)
 	if err != nil {
-		return kube_ctrl.Result{}, errors.Wrap(err, "error generating GatewayRoute")
+		return kube_ctrl.Result{}, errors.Wrap(err, "error generating GatewayRoute.kuma.io")
 	}
 
-	if err := reconcileLabelledObject(ctx, r.Client, req.NamespacedName, spec); err != nil {
-		return kube_ctrl.Result{}, errors.Wrap(err, "could not CreateOrUpdate GatewayRoutes")
+	if err := reconcileLabelledObject(ctx, r.TypeRegistry, r.Client, req.NamespacedName, &mesh_proto.GatewayRoute{}, spec); err != nil {
+		return kube_ctrl.Result{}, errors.Wrap(err, "could not reconcile owned GatewayRoute.kuma.io")
 	}
 
 	if err := r.updateStatus(ctx, httpRoute, conditions); err != nil {
@@ -163,71 +162,6 @@ func (r *HTTPRouteReconciler) shouldHandleParentRef(
 	}
 
 	return class.Spec.ControllerName == controllerName, nil
-}
-
-// reconcileLabelledObjectSet manages a set of owned objects based on labeling
-// with the owner key and indexed by the service tag and listener tag.
-func reconcileLabelledObject(
-	ctx context.Context,
-	client kube_client.Client,
-	owner kube_types.NamespacedName,
-	routeSpec *mesh_proto.GatewayRoute,
-) error {
-	// First we list which existing objects are owned by this route.
-	// We expect either 0 or 1 and depending on whether routeSpec is nil
-	// we either create an object or update or delete the existing
-	ownerLabelValue := fmt.Sprintf("%s-%s", owner.Namespace, owner.Name)
-	labels := kube_client.MatchingLabels{
-		ownerLabel: ownerLabelValue,
-	}
-
-	list := &mesh_k8s.GatewayRouteList{}
-	if err := client.List(ctx, list, labels); err != nil {
-		return err
-	}
-
-	if l := len(list.Items); l > 1 {
-		return fmt.Errorf("internal error: found %d items labeled as owned by this object, expected either zero or one", l)
-	}
-
-	var existing *mesh_k8s.GatewayRoute
-	if len(list.Items) == 1 {
-		existing = &list.Items[0]
-	}
-
-	if routeSpec == nil {
-		if existing != nil {
-			if err := client.Delete(ctx, existing); err != nil && !kube_apierrs.IsNotFound(err) {
-				return err
-			}
-		}
-		return nil
-	}
-
-	if existing != nil {
-		existing.Spec = routeSpec
-
-		if err := client.Update(ctx, existing); err != nil {
-			return errors.Wrap(err, "could not update GatewayRoute")
-		}
-		return nil
-	}
-
-	route := &mesh_k8s.GatewayRoute{
-		ObjectMeta: kube_meta.ObjectMeta{
-			GenerateName: fmt.Sprintf("%s-", ownerLabelValue),
-			Labels: map[string]string{
-				ownerLabel: ownerLabelValue,
-			},
-		},
-		Spec: routeSpec,
-	}
-
-	if err := client.Create(ctx, route); err != nil {
-		return errors.Wrap(err, "could not create GatewayRoute")
-	}
-
-	return nil
 }
 
 func (r *HTTPRouteReconciler) SetupWithManager(mgr kube_ctrl.Manager) error {

--- a/pkg/plugins/runtime/k8s/plugin_gateway.go
+++ b/pkg/plugins/runtime/k8s/plugin_gateway.go
@@ -13,7 +13,7 @@ import (
 	"github.com/kumahq/kuma/pkg/core"
 	core_runtime "github.com/kumahq/kuma/pkg/core/runtime"
 	k8s_common "github.com/kumahq/kuma/pkg/plugins/common/k8s"
-	"github.com/kumahq/kuma/pkg/plugins/resources/k8s/native/pkg/registry"
+	k8s_registry "github.com/kumahq/kuma/pkg/plugins/resources/k8s/native/pkg/registry"
 	"github.com/kumahq/kuma/pkg/plugins/runtime/k8s/containers"
 	controllers "github.com/kumahq/kuma/pkg/plugins/runtime/k8s/controllers"
 	gatewayapi_controllers "github.com/kumahq/kuma/pkg/plugins/runtime/k8s/controllers/gatewayapi"
@@ -37,8 +37,8 @@ func crdsPresent(mgr kube_ctrl.Manager) bool {
 func gatewayPresent() bool {
 	// If we haven't registered our type, we're not reconciling GatewayInstance
 	// or gatewayapi objects.
-	if _, err := registry.Global().NewObject(&mesh_proto.Gateway{}); err != nil {
-		var unknownTypeError *registry.UnknownTypeError
+	if _, err := k8s_registry.Global().NewObject(&mesh_proto.Gateway{}); err != nil {
+		var unknownTypeError *k8s_registry.UnknownTypeError
 		if errors.As(err, &unknownTypeError) {
 			return false
 		}
@@ -102,7 +102,7 @@ func addGatewayReconcilers(mgr kube_ctrl.Manager, rt core_runtime.Runtime, conve
 		Client:          mgr.GetClient(),
 		Log:             core.Log.WithName("controllers").WithName("gatewayapi").WithName("Gateway"),
 		Scheme:          mgr.GetScheme(),
-		Converter:       converter,
+		TypeRegistry:    k8s_registry.Global(),
 		SystemNamespace: rt.Config().Store.Kubernetes.SystemNamespace,
 		ProxyFactory:    proxyFactory,
 		ResourceManager: rt.ResourceManager(),
@@ -115,7 +115,7 @@ func addGatewayReconcilers(mgr kube_ctrl.Manager, rt core_runtime.Runtime, conve
 		Client:          mgr.GetClient(),
 		Log:             core.Log.WithName("controllers").WithName("gatewayapi").WithName("HTTPRoute"),
 		Scheme:          mgr.GetScheme(),
-		Converter:       converter,
+		TypeRegistry:    k8s_registry.Global(),
 		SystemNamespace: rt.Config().Store.Kubernetes.SystemNamespace,
 		ResourceManager: rt.ResourceManager(),
 	}


### PR DESCRIPTION
### Summary

This simulates owner references so that deletion of namespaced Gateway API objects causes cluster-scoped Kuma objects to be garbage collected.

Closes #3517 