### PR TITLE
fix(build): fix gomega matchers for inspect resources command test

### DIFF
--- a/app/kumactl/cmd/inspect/inspect_dataplanes_test.go
+++ b/app/kumactl/cmd/inspect/inspect_dataplanes_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"path/filepath"
-	"strings"
 	"time"
 
 	. "github.com/onsi/ginkgo"
@@ -426,16 +425,7 @@ var _ = Describe("kumactl inspect dataplanes", func() {
 		type testCase struct {
 			outputFormat string
 			goldenFile   string
-			matcher      func(interface{}) gomega_types.GomegaMatcher
-		}
-
-		byLine := func(s string) []string {
-			lines := strings.Split(s, "\n")
-			var trimmedLines []string
-			for _, line := range lines {
-				trimmedLines = append(trimmedLines, strings.TrimSpace(line))
-			}
-			return trimmedLines
+			matcher      func(path ...string) gomega_types.GomegaMatcher
 		}
 
 		DescribeTable("kumactl inspect dataplanes -o table|json|yaml",
@@ -450,31 +440,27 @@ var _ = Describe("kumactl inspect dataplanes", func() {
 
 				// then
 				Expect(err).ToNot(HaveOccurred())
-				Expect(buf.String()).To(matchers.MatchGoldenEqual("testdata", given.goldenFile))
+				Expect(buf.String()).To(given.matcher("testdata", given.goldenFile))
 			},
 			Entry("should support Table output by default", testCase{
 				outputFormat: "",
 				goldenFile:   "inspect-dataplanes.golden.txt",
-				matcher: func(expected interface{}) gomega_types.GomegaMatcher {
-					return WithTransform(byLine, Equal(byLine(string(expected.([]byte)))))
-				},
+				matcher:      matchers.MatchGoldenEqual,
 			}),
 			Entry("should support Table output explicitly", testCase{
 				outputFormat: "-otable",
 				goldenFile:   "inspect-dataplanes.golden.txt",
-				matcher: func(expected interface{}) gomega_types.GomegaMatcher {
-					return WithTransform(byLine, Equal(byLine(string(expected.([]byte)))))
-				},
+				matcher:      matchers.MatchGoldenEqual,
 			}),
 			Entry("should support JSON output", testCase{
 				outputFormat: "-ojson",
 				goldenFile:   "inspect-dataplanes.golden.json",
-				matcher:      MatchJSON,
+				matcher:      matchers.MatchGoldenJSON,
 			}),
 			Entry("should support YAML output", testCase{
 				outputFormat: "-oyaml",
 				goldenFile:   "inspect-dataplanes.golden.yaml",
-				matcher:      MatchYAML,
+				matcher:      matchers.MatchGoldenYAML,
 			}),
 		)
 

--- a/app/kumactl/cmd/inspect/inspect_meshes_test.go
+++ b/app/kumactl/cmd/inspect/inspect_meshes_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"path/filepath"
-	"strings"
 	"time"
 
 	. "github.com/onsi/ginkgo"
@@ -98,7 +97,7 @@ var _ = Describe("kumactl inspect meshes", func() {
 		type testCase struct {
 			outputFormat string
 			goldenFile   string
-			matcher      func(interface{}) gomega_types.GomegaMatcher
+			matcher      func(path ...string) gomega_types.GomegaMatcher
 		}
 
 		DescribeTable("kumactl inspect meshes -o table|json|yaml",
@@ -112,31 +111,27 @@ var _ = Describe("kumactl inspect meshes", func() {
 				err := rootCmd.Execute()
 				// then
 				Expect(err).ToNot(HaveOccurred())
-				Expect(buf.String()).To(matchers.MatchGoldenEqual("testdata", given.goldenFile))
+				Expect(buf.String()).To(given.matcher("testdata", given.goldenFile))
 			},
 			Entry("should support Table output by default", testCase{
 				outputFormat: "",
 				goldenFile:   "inspect-meshes.golden.txt",
-				matcher: func(expected interface{}) gomega_types.GomegaMatcher {
-					return WithTransform(strings.TrimSpace, Equal(strings.TrimSpace(string(expected.([]byte)))))
-				},
+				matcher:      matchers.MatchGoldenEqual,
 			}),
 			Entry("should support Table output explicitly", testCase{
 				outputFormat: "-otable",
 				goldenFile:   "inspect-meshes.golden.txt",
-				matcher: func(expected interface{}) gomega_types.GomegaMatcher {
-					return WithTransform(strings.TrimSpace, Equal(strings.TrimSpace(string(expected.([]byte)))))
-				},
+				matcher:      matchers.MatchGoldenEqual,
 			}),
 			Entry("should support JSON output", testCase{
 				outputFormat: "-ojson",
 				goldenFile:   "inspect-meshes.golden.json",
-				matcher:      MatchJSON,
+				matcher:      matchers.MatchGoldenJSON,
 			}),
 			Entry("should support YAML output", testCase{
 				outputFormat: "-oyaml",
 				goldenFile:   "inspect-meshes.golden.yaml",
-				matcher:      MatchYAML,
+				matcher:      matchers.MatchGoldenYAML,
 			}),
 		)
 	})

--- a/app/kumactl/cmd/inspect/inspect_zoneingresses_test.go
+++ b/app/kumactl/cmd/inspect/inspect_zoneingresses_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"path/filepath"
-	"strings"
 	"time"
 
 	. "github.com/onsi/ginkgo"
@@ -266,7 +265,7 @@ var _ = Describe("kumactl inspect zone-ingresses", func() {
 		type testCase struct {
 			outputFormat string
 			goldenFile   string
-			matcher      func(interface{}) gomega_types.GomegaMatcher
+			matcher      func(path ...string) gomega_types.GomegaMatcher
 		}
 
 		DescribeTable("kumactl inspect zone-ingresses -o table|json|yaml",
@@ -285,26 +284,22 @@ var _ = Describe("kumactl inspect zone-ingresses", func() {
 			Entry("should support Table output by default", testCase{
 				outputFormat: "",
 				goldenFile:   "inspect-zone-ingresses.golden.txt",
-				matcher: func(expected interface{}) gomega_types.GomegaMatcher {
-					return WithTransform(strings.TrimSpace, Equal(strings.TrimSpace(string(expected.([]byte)))))
-				},
+				matcher:      matchers.MatchGoldenEqual,
 			}),
 			Entry("should support Table output explicitly", testCase{
 				outputFormat: "-otable",
 				goldenFile:   "inspect-zone-ingresses.golden.txt",
-				matcher: func(expected interface{}) gomega_types.GomegaMatcher {
-					return WithTransform(strings.TrimSpace, Equal(strings.TrimSpace(string(expected.([]byte)))))
-				},
+				matcher:      matchers.MatchGoldenEqual,
 			}),
 			Entry("should support JSON output", testCase{
 				outputFormat: "-ojson",
 				goldenFile:   "inspect-zone-ingresses.golden.json",
-				matcher:      MatchJSON,
+				matcher:      matchers.MatchGoldenJSON,
 			}),
 			Entry("should support YAML output", testCase{
 				outputFormat: "-oyaml",
 				goldenFile:   "inspect-zone-ingress.golden.yaml",
-				matcher:      MatchYAML,
+				matcher:      matchers.MatchGoldenYAML,
 			}),
 		)
 	})

--- a/app/kumactl/cmd/inspect/inspect_zones_test.go
+++ b/app/kumactl/cmd/inspect/inspect_zones_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"path/filepath"
-	"strings"
 	"time"
 
 	. "github.com/onsi/ginkgo"
@@ -239,7 +238,7 @@ var _ = Describe("kumactl inspect zones", func() {
 		type testCase struct {
 			outputFormat string
 			goldenFile   string
-			matcher      func(interface{}) gomega_types.GomegaMatcher
+			matcher      func(path ...string) gomega_types.GomegaMatcher
 		}
 
 		DescribeTable("kumactl inspect zones -o table|json|yaml",
@@ -258,26 +257,22 @@ var _ = Describe("kumactl inspect zones", func() {
 			Entry("should support Table output by default", testCase{
 				outputFormat: "",
 				goldenFile:   "inspect-zones.golden.txt",
-				matcher: func(expected interface{}) gomega_types.GomegaMatcher {
-					return WithTransform(strings.TrimSpace, Equal(strings.TrimSpace(string(expected.([]byte)))))
-				},
+				matcher:      matchers.MatchGoldenEqual,
 			}),
 			Entry("should support Table output explicitly", testCase{
 				outputFormat: "-otable",
 				goldenFile:   "inspect-zones.golden.txt",
-				matcher: func(expected interface{}) gomega_types.GomegaMatcher {
-					return WithTransform(strings.TrimSpace, Equal(strings.TrimSpace(string(expected.([]byte)))))
-				},
+				matcher:      matchers.MatchGoldenEqual,
 			}),
 			Entry("should support JSON output", testCase{
 				outputFormat: "-ojson",
 				goldenFile:   "inspect-zones.golden.json",
-				matcher:      MatchJSON,
+				matcher:      matchers.MatchGoldenJSON,
 			}),
 			Entry("should support YAML output", testCase{
 				outputFormat: "-oyaml",
 				goldenFile:   "inspect-zone.golden.yaml",
-				matcher:      MatchYAML,
+				matcher:      matchers.MatchGoldenYAML,
 			}),
 		)
 	})

--- a/app/kumactl/cmd/inspect/testdata/inspect-services.golden.yaml
+++ b/app/kumactl/cmd/inspect/testdata/inspect-services.golden.yaml
@@ -1,29 +1,29 @@
 items:
-  - creationTime: "0001-01-01T00:00:00Z"
-    dataplanes:
-      online: 5
-      total: 10
-    mesh: mesh-1
-    modificationTime: "0001-01-01T00:00:00Z"
-    name: backend
-    status: partially_degraded
-    type: ServiceOverview
-  - creationTime: "0001-01-01T00:00:00Z"
-    dataplanes:
-      online: 20
-      total: 20
-    mesh: mesh-1
-    modificationTime: "0001-01-01T00:00:00Z"
-    name: web
-    status: online
-    type: ServiceOverview
-  - creationTime: "0001-01-01T00:00:00Z"
-    dataplanes:
-      total: 5
-    mesh: mesh-1
-    modificationTime: "0001-01-01T00:00:00Z"
-    name: orders
-    status: offline
-    type: ServiceOverview
+- creationTime: "0001-01-01T00:00:00Z"
+  dataplanes:
+    online: 5
+    total: 10
+  mesh: mesh-1
+  modificationTime: "0001-01-01T00:00:00Z"
+  name: backend
+  status: partially_degraded
+  type: ServiceOverview
+- creationTime: "0001-01-01T00:00:00Z"
+  dataplanes:
+    online: 20
+    total: 20
+  mesh: mesh-1
+  modificationTime: "0001-01-01T00:00:00Z"
+  name: web
+  status: online
+  type: ServiceOverview
+- creationTime: "0001-01-01T00:00:00Z"
+  dataplanes:
+    total: 5
+  mesh: mesh-1
+  modificationTime: "0001-01-01T00:00:00Z"
+  name: orders
+  status: offline
+  type: ServiceOverview
 next: null
 total: 3


### PR DESCRIPTION


### Summary

Currently, the `inspect` command has some dead code related to the old `gomega matchers` and also matcher's for `JSON` and `YAML` referring to old matcher's.

This PR introduces the latest gomega wrappers to inspect resources test cases and clean up dead code.

### Full changelog

* [Implement ...]
* [Fix ...]

### Issues resolved

Fix #XXX

### Documentation

- [ ] Link to the website [documentation PR](https://github.com/kumahq/kuma-website/pull/XXX)

### Testing

- [ ] Unit tests
- [ ] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes

### Backwards compatibility

- [ ] Update [`UPGRADE.md`](/UPGRADE.md) with any steps users will need to take when upgrading.
- [ ] Add `backport-to-stable` label if the code follows our [backporting policy](/CONTRIBUTING.md#backporting)
