### PR TITLE
chore(e2e): consolidate gateway tests

### DIFF
--- a/test/e2e/gateway/gateway_kubernetes.go
+++ b/test/e2e/gateway/gateway_kubernetes.go
@@ -2,10 +2,7 @@ package gateway
 
 import (
 	"bytes"
-	"fmt"
 	"net"
-	"net/url"
-	"path"
 	"strings"
 	"text/template"
 
@@ -14,7 +11,6 @@ import (
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	config_core "github.com/kumahq/kuma/pkg/config/core"
 	"github.com/kumahq/kuma/test/e2e/trafficroute/testutil"
 	. "github.com/kumahq/kuma/test/framework"
@@ -27,6 +23,8 @@ func GatewayOnKubernetes() {
 	// ClientNamespace is a namespace to deploy gateway client
 	// applications. Mesh sidecar injection is not enabled there.
 	const ClientNamespace = "kuma-client"
+
+	const GatewayPort = "8080"
 
 	EchoServerApp := func(name string) InstallFunc {
 		return testserver.Install(
@@ -114,8 +112,8 @@ spec:
 		)
 	}
 
-	// GatewayInstanceAddress find the address of the gateway instance service.
-	GatewayInstanceAddress := func(instanceName string) string {
+	// GatewayAddress find the address of the gateway instance service named instanceName.
+	GatewayAddress := func(instanceName string) string {
 		services, err := k8s.ListServicesE(cluster.GetTesting(), cluster.GetKubectlOptions(TestNamespace), metav1.ListOptions{})
 		Expect(err).To(Succeed())
 
@@ -229,75 +227,80 @@ spec:
 		Expect(cluster.DismissCluster()).To(Succeed())
 	})
 
-	// ProxySimpleRequests tests that basic HTTP requests are proxied to the echo-server.
-	ProxySimpleRequests := func(prefix string, instance string) func() {
-		return func() {
-			Eventually(func(g Gomega) {
-				target := fmt.Sprintf("http://%s/%s",
-					net.JoinHostPort(GatewayInstanceAddress("edge-gateway"), "8080"),
-					path.Join(prefix, "test", url.PathEscape(GinkgoT().Name())),
-				)
-
-				response, err := testutil.CollectResponse(
-					cluster, "gateway-client", target,
-					testutil.FromKubernetesPod(ClientNamespace, "gateway-client"),
-					testutil.WithHeader("Host", "example.kuma.io"),
-				)
-
-				g.Expect(err).To(Succeed())
-				g.Expect(response.Instance).To(Equal(instance))
-				g.Expect(response.Received.Headers["Host"]).To(ContainElement("example.kuma.io"))
-			}, "60s", "1s").Should(Succeed())
-		}
-	}
-
-	Context("when MTLS is disabled", func() {
+	Context("when mTLS is disabled", func() {
 		BeforeEach(func() {
 			DeployCluster(KumaK8sDeployOpts...)
 		})
 
-		It("should proxy simple HTTP requests", ProxySimpleRequests("/", "kubernetes"))
+		It("should proxy simple HTTP requests", func() {
+			ProxySimpleRequests(cluster, "kubernetes",
+				net.JoinHostPort(GatewayAddress("edge-gateway"), GatewayPort),
+				testutil.FromKubernetesPod(ClientNamespace, "gateway-client"))
+		})
 	})
 
 	Context("when mTLS is enabled", func() {
 		BeforeEach(func() {
-			mtls := WithMeshUpdate("default", func(mesh *mesh_proto.Mesh) *mesh_proto.Mesh {
-				mesh.Mtls = &mesh_proto.Mesh_Mtls{
-					EnabledBackend: "builtin",
-					Backends: []*mesh_proto.CertificateAuthorityBackend{
-						{Name: "builtin", Type: "builtin"},
-					},
-				}
-				return mesh
-			})
-
-			DeployCluster(append(KumaK8sDeployOpts, mtls)...)
+			DeployCluster(append(KumaK8sDeployOpts, OptEnableMeshMTLS)...)
 		})
 
-		It("should proxy simple HTTP requests", ProxySimpleRequests("/", "kubernetes"))
+		It("should proxy simple HTTP requests", func() {
+			ProxySimpleRequests(cluster, "kubernetes",
+				net.JoinHostPort(GatewayAddress("edge-gateway"), GatewayPort),
+				testutil.FromKubernetesPod(ClientNamespace, "gateway-client"))
+		})
 
 		// In mTLS mode, only the presence of TrafficPermission rules allow services to receive
 		// traffic, so removing the permission should cause requests to fail. We use this to
 		// prove that mTLS is enabled
 		It("should fail without TrafficPermission", func() {
-			Expect(k8s.RunKubectlE(cluster.GetTesting(), cluster.GetKubectlOptions(),
-				"delete", "trafficpermission", "allow-all-default")).To(Succeed())
+			ProxyRequestsWithMissingPermission(cluster,
+				net.JoinHostPort(GatewayAddress("edge-gateway"), GatewayPort),
+				testutil.FromKubernetesPod(ClientNamespace, "gateway-client"))
+		})
+	})
 
-			Eventually(func(g Gomega) {
-				target := fmt.Sprintf("http://%s/%s",
-					net.JoinHostPort(GatewayInstanceAddress("edge-gateway"), "8080"),
-					path.Join("test", url.PathEscape(GinkgoT().Name())),
-				)
+	Context("when targeting an external service", func() {
+		// TODO match universal test cases
+	})
 
-				status, err := testutil.CollectFailure(
-					cluster, "gateway-client", target,
-					testutil.FromKubernetesPod(ClientNamespace, "gateway-client"),
-					testutil.WithHeader("Host", "example.kuma.io"),
-				)
+	Context("when targeting a HTTPS gateway", func() {
+		// TODO match universal test cases
+	})
 
-				g.Expect(err).To(Succeed())
-				g.Expect(status.ResponseCode).To(Equal(503))
-			}, "30s", "1s").Should(Succeed())
+	Context("when a rate limit is configured", func() {
+		BeforeEach(func() {
+			DeployCluster(KumaK8sDeployOpts...)
+		})
+
+		JustBeforeEach(func() {
+			Expect(k8s.KubectlApplyFromStringE(
+				cluster.GetTesting(),
+				cluster.GetKubectlOptions(), `
+apiVersion: kuma.io/v1alpha1
+kind: RateLimit
+metadata:
+  name: echo-rate-limit
+mesh: default
+spec:
+  sources:
+  - match:
+      kuma.io/service: edge-gateway
+  destinations:
+  - match:
+      kuma.io/service: echo-server_kuma-test_svc_80 # Matches the echo-server we deployed.
+  conf:
+    http:
+      requests: 5
+      interval: 10s
+`),
+			).To(Succeed())
+		})
+
+		It("should be rate limited", func() {
+			ProxyRequestsWithRateLimit(cluster,
+				net.JoinHostPort(GatewayAddress("edge-gateway"), GatewayPort),
+				testutil.FromKubernetesPod(ClientNamespace, "gateway-client"))
 		})
 	})
 }

--- a/test/e2e/gateway/utils.go
+++ b/test/e2e/gateway/utils.go
@@ -1,0 +1,119 @@
+package gateway
+
+import (
+	"fmt"
+	"net/url"
+	"path"
+
+	"github.com/gruntwork-io/terratest/modules/k8s"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
+	"github.com/kumahq/kuma/test/e2e/trafficroute/testutil"
+	"github.com/kumahq/kuma/test/framework"
+)
+
+// OptEnableMeshMTLS is a Kuma deployment option that enables mTLS on the default Mesh.
+var OptEnableMeshMTLS = framework.WithMeshUpdate(
+	"default",
+	func(mesh *mesh_proto.Mesh) *mesh_proto.Mesh {
+		mesh.Mtls = &mesh_proto.Mesh_Mtls{
+			EnabledBackend: "builtin",
+			Backends: []*mesh_proto.CertificateAuthorityBackend{
+				{Name: "builtin", Type: "builtin"},
+			},
+		}
+		return mesh
+	},
+)
+
+// ProxySimpleRequests tests that basic HTTP requests are proxied to the echo-server.
+func ProxySimpleRequests(cluster framework.Cluster, instance string, gateway string, opts ...testutil.CollectResponsesOptsFn) {
+	framework.Logf("expecting 200 response from %q", gateway)
+	Eventually(func(g Gomega) {
+		target := fmt.Sprintf("http://%s/%s",
+			gateway, path.Join("test", url.PathEscape(GinkgoT().Name())),
+		)
+
+		opts = append(opts, testutil.WithHeader("Host", "example.kuma.io"))
+		response, err := testutil.CollectResponse(cluster, "gateway-client", target, opts...)
+
+		g.Expect(err).To(Succeed())
+		g.Expect(response.Instance).To(Equal(instance))
+		g.Expect(response.Received.Headers["Host"]).To(ContainElement("example.kuma.io"))
+	}, "60s", "1s").Should(Succeed())
+}
+
+// ProxySecureRequests tests that basic HTTPS requests are proxied to the echo-server.
+func ProxySecureRequests(cluster framework.Cluster, instance string, gateway string, opts ...testutil.CollectResponsesOptsFn) {
+	framework.Logf("expecting 200 response from %q", gateway)
+	Eventually(func(g Gomega) {
+		target := fmt.Sprintf("https://%s/%s",
+			gateway, path.Join("https", "test", url.PathEscape(GinkgoT().Name())),
+		)
+
+		opts = append(opts,
+			testutil.Insecure(),
+			testutil.WithHeader("Host", "example.kuma.io"))
+		response, err := testutil.CollectResponse(cluster, "gateway-client", target, opts...)
+
+		g.Expect(err).To(Succeed())
+		g.Expect(response.Instance).To(Equal(instance))
+		g.Expect(response.Received.Headers["Host"]).To(ContainElement("example.kuma.io"))
+	}, "60s", "1s").Should(Succeed())
+}
+
+// ProxyRequestsWithMissingPermission deletes the default TrafficPermission and expects
+// that to cause proxying requests to fail.
+//
+// In mTLS mode, only the presence of TrafficPermission rules allow services to receive
+// traffic, so removing the permission should cause requests to fail. We use this to
+// prove that mTLS is enabled.
+func ProxyRequestsWithMissingPermission(cluster framework.Cluster, gateway string, opts ...testutil.CollectResponsesOptsFn) {
+	const PermissionName = "allow-all-default"
+
+	framework.Logf("deleting TrafficPermission %q", PermissionName)
+	if cluster.GetKubectlOptions() == nil {
+		Expect(cluster.GetKumactlOptions().KumactlDelete(
+			"traffic-permission", PermissionName, "default"),
+		).To(Succeed())
+	} else {
+		Expect(k8s.RunKubectlE(cluster.GetTesting(), cluster.GetKubectlOptions(),
+			"delete", "trafficpermission", PermissionName),
+		).To(Succeed())
+	}
+
+	framework.Logf("expecting 503 response from %q", gateway)
+	Eventually(func(g Gomega) {
+		target := fmt.Sprintf("http://%s/%s",
+			gateway, path.Join("test", url.PathEscape(GinkgoT().Name())),
+		)
+
+		opts = append(opts, testutil.WithHeader("Host", "example.kuma.io"))
+		status, err := testutil.CollectFailure(cluster, "gateway-client", target, opts...)
+
+		g.Expect(err).To(Succeed())
+		g.Expect(status.ResponseCode).To(Equal(503))
+	}, "30s", "1s").Should(Succeed())
+}
+
+// ProxyRequestsWithRateLimit tests that requests to gateway are rate-limited with a 429 response.
+func ProxyRequestsWithRateLimit(cluster framework.Cluster, gateway string, opts ...testutil.CollectResponsesOptsFn) {
+	framework.Logf("expecting 429 response from %q", gateway)
+	Eventually(func(g Gomega) {
+		target := fmt.Sprintf("http://%s/%s",
+			gateway, path.Join("test", url.PathEscape(GinkgoT().Name())),
+		)
+
+		opts = append(opts,
+			testutil.NoFail(),
+			testutil.OutputFormat(`{ "received": { "status": %{response_code} } }`),
+			testutil.WithHeader("Host", "example.kuma.io"),
+		)
+		response, err := testutil.CollectResponse(cluster, "gateway-client", target, opts...)
+
+		g.Expect(err).To(Succeed())
+		g.Expect(response.Received.StatusCode).To(Equal(429))
+	}, "30s", "1s").Should(Succeed())
+}


### PR DESCRIPTION
### Summary

Refactor the Gateway e2e tests so that they follow a more consistent code
structure and we can hoist out common parts of the tests. This makes it
easier to see what tests are enabled for universal and gateway zones, and
reduces the amount of code we need to copy between the two test suites.

### Full changelog

N/A

### Issues resolved

Update #3510

### Documentation

N/A

### Testing

- [x] Unit tests
- [x] E2E tests
- [ ] ~~Manual testing on Universal~~
- [ ] ~~Manual testing on Kubernetes~~

### Backwards compatibility

- [ ] ~~Update [`UPGRADE.md`](/UPGRADE.md) with any steps users will need to take when upgrading.~~
- [ ] ~~Add `backport-to-stable` label if the code follows our [backporting policy](/CONTRIBUTING.md#backporting)~~
