### PR TITLE
ci(e2e): use tunnel from terratest instead of our own

### DIFF
--- a/test/e2e/helm/kuma_helm_deploy_global_zone.go
+++ b/test/e2e/helm/kuma_helm_deploy_global_zone.go
@@ -108,9 +108,9 @@ func ZoneAndGlobalWithHelmChart() {
 	It("Should deploy Zone and Global on 2 clusters", func() {
 		clustersStatus := api_server.Zones{}
 		Eventually(func() (bool, error) {
-			status, response := http_helper.HttpGet(c1.GetTesting(), global.GetGlobaStatusAPI(), nil)
+			status, response := http_helper.HttpGet(c1.GetTesting(), global.GetGlobalStatusAPI(), nil)
 			if status != http.StatusOK {
-				return false, errors.Errorf("unable to contact server %s with status %d", global.GetGlobaStatusAPI(), status)
+				return false, errors.Errorf("unable to contact server %s with status %d", global.GetGlobalStatusAPI(), status)
 			}
 			err := json.Unmarshal([]byte(response), &clustersStatus)
 			if err != nil {

--- a/test/framework/constants.go
+++ b/test/framework/constants.go
@@ -34,8 +34,7 @@ const (
 
 	confPath = "/kuma/kuma-cp.conf"
 
-	kumaCPAPIPort        = 5681
-	kumaCPAPIPortFwdBase = 32000 + kumaCPAPIPort
+	kumaCPAPIPort = 5681
 
 	redirectPortInbound   = "15006"
 	redirectPortInboundV6 = "15010"

--- a/test/framework/interface.go
+++ b/test/framework/interface.go
@@ -449,7 +449,7 @@ type ControlPlane interface {
 	GetKumaCPLogs() (string, error)
 	GetMetrics() (string, error)
 	GetKDSServerAddress() string
-	GetGlobaStatusAPI() string
+	GetGlobalStatusAPI() string
 	GetAPIServerAddress() string
 	GenerateDpToken(mesh, serviceName string) (string, error)
 	GenerateZoneIngressToken(zone string) (string, error)

--- a/test/framework/k8s_clusters.go
+++ b/test/framework/k8s_clusters.go
@@ -28,10 +28,8 @@ func NewK8sClusters(clusterNames []string, verbose bool) (Clusters, error) {
 
 	clusters := map[string]*K8sCluster{}
 
-	for i, name := range clusterNames {
+	for _, name := range clusterNames {
 		clusters[name] = NewK8sCluster(t, name, verbose)
-		clusters[name].loPort = uint32(kumaCPAPIPortFwdBase + i*1000)
-		clusters[name].hiPort = uint32(kumaCPAPIPortFwdBase + (i+1)*1000 - 1)
 	}
 
 	return &K8sClusters{

--- a/test/framework/universal_controlplane.go
+++ b/test/framework/universal_controlplane.go
@@ -49,7 +49,7 @@ func (c *UniversalControlPlane) GetKDSServerAddress() string {
 	return "grpcs://" + net.JoinHostPort(c.cluster.apps[AppModeCP].ip, "5685")
 }
 
-func (c *UniversalControlPlane) GetGlobaStatusAPI() string {
+func (c *UniversalControlPlane) GetGlobalStatusAPI() string {
 	panic("not implemented")
 }
 


### PR DESCRIPTION
### Summary

This removes duplicated code and might fix flakiness on the helm upgrade tests

### Testing

- [ ] Unit tests
- [x] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes

