### PR TITLE
ci(circleci): speed up dev_mac job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -686,7 +686,7 @@ jobs:
     - run:
         name: "Run unit tests"
         command: |
-          GO_TEST_OPTS='-p 2' make test
+          make test
 
   go_cache:
     executor: golang


### PR DESCRIPTION
### Summary

Remove parallelism limit on dev_mac job which likely slowed down the whole build
Tests of this showed tests taking about half the time it does currently.