### PR TITLE
chore(*): add posibility to customize Kuma images

### DIFF
--- a/mk/k3d.mk
+++ b/mk/k3d.mk
@@ -50,11 +50,7 @@ k3d/stop/all:
 
 .PHONY: k3d/load/images
 k3d/load/images:
-	@k3d image import \
-    	$(KUMA_CP_DOCKER_IMAGE) $(KUMA_DP_DOCKER_IMAGE) \
-    	$(KUMA_INIT_DOCKER_IMAGE) $(KUMA_PROMETHEUS_SD_DOCKER_IMAGE) \
-    	$(KUMACTL_DOCKER_IMAGE) $(KUMA_UNIVERSAL_DOCKER_IMAGE) \
-    	--cluster=$(KIND_CLUSTER_NAME) --verbose
+	@k3d image import $(KUMA_IMAGES) --cluster=$(KIND_CLUSTER_NAME) --verbose
 
 .PHONY: k3d/load
 k3d/load: images k3d/load/images

--- a/mk/kind.mk
+++ b/mk/kind.mk
@@ -80,47 +80,12 @@ kind/stop/all:
 	@kind delete clusters --all
 	@rm -f $(KUBECONFIG_DIR)/kind-kuma-*
 
-.PHONY: kind/load/control-plane
-kind/load/control-plane:
-	@kind load docker-image $(KUMA_CP_DOCKER_IMAGE) --name=$(KIND_CLUSTER_NAME)
-
-.PHONY: kind/load/kuma-dp
-kind/load/kuma-dp:
-	@kind load docker-image $(KUMA_DP_DOCKER_IMAGE) --name=$(KIND_CLUSTER_NAME)
-
-.PHONY: kind/load/kuma-init
-kind/load/kuma-init:
-	@kind load docker-image $(KUMA_INIT_DOCKER_IMAGE) --name=$(KIND_CLUSTER_NAME)
-
-.PHONY: kind/load/kuma-prometheus-sd
-kind/load/kuma-prometheus-sd:
-	@kind load docker-image $(KUMA_PROMETHEUS_SD_DOCKER_IMAGE) --name=$(KIND_CLUSTER_NAME)
-
-.PHONY: kind/load/kumactl
-kind/load/kumactl:
-	@kind load docker-image $(KUMACTL_DOCKER_IMAGE) --name=$(KIND_CLUSTER_NAME)
-
-.PHONY: kind/load/kuma-universal
-kind/load/kuma-universal:
-	@kind load docker-image $(KUMA_UNIVERSAL_DOCKER_IMAGE) --name=$(KIND_CLUSTER_NAME)
-
 .PHONY: kind/load/images
-kind/load/images: kind/load/images/release kind/load/images/test
-
-.PHONY: kind/load/images/release
-kind/load/images/release: kind/load/control-plane kind/load/kuma-dp kind/load/kuma-init kind/load/kuma-prometheus-sd kind/load/kumactl
-
-.PHONY: kind/load/images/test
-kind/load/images/test: kind/load/kuma-universal
+kind/load/images:
+	for image in ${KUMA_IMAGES}; do kind load docker-image $$image --name=$(KIND_CLUSTER_NAME); done
 
 .PHONY: kind/load
-kind/load: kind/load/release kind/load/test
-
-.PHONY: kind/load/release
-kind/load/release: images/release kind/load/images/release
-
-.PHONY: kind/load/test
-kind/load/test: images/test kind/load/images/test
+kind/load: images kind/load/images
 
 .PHONY: kind/deploy/kuma
 kind/deploy/kuma: build/kumactl kind/load

--- a/test/framework/k8s_cluster.go
+++ b/test/framework/k8s_cluster.go
@@ -210,10 +210,13 @@ func (c *K8sCluster) deployKumaViaKubectl(mode string, opts *kumaDeploymentOptio
 
 func (c *K8sCluster) yamlForKumaViaKubectl(mode string, opts *kumaDeploymentOptions) (string, error) {
 	argsMap := map[string]string{
-		"--namespace":               KumaNamespace,
-		"--control-plane-registry":  KumaImageRegistry,
-		"--dataplane-registry":      KumaImageRegistry,
-		"--dataplane-init-registry": KumaImageRegistry,
+		"--namespace":                 KumaNamespace,
+		"--control-plane-registry":    KumaImageRegistry,
+		"--control-plane-repository":  KumaCPImageRepo,
+		"--dataplane-registry":        KumaImageRegistry,
+		"--dataplane-repository":      KumaDPImageRepo,
+		"--dataplane-init-registry":   KumaImageRegistry,
+		"--dataplane-init-repository": KumaInitImageRepo,
 	}
 
 	if HasGlobalImageRegistry() {

--- a/tools/releases/docker.sh
+++ b/tools/releases/docker.sh
@@ -6,7 +6,7 @@ source "$(dirname -- "${BASH_SOURCE[0]}")/../common.sh"
 
 [ -z "$KUMA_DOCKER_REPO" ] && KUMA_DOCKER_REPO="docker.io"
 [ -z "$KUMA_DOCKER_REPO_ORG" ] && KUMA_DOCKER_REPO_ORG=${KUMA_DOCKER_REPO}/kumahq
-KUMA_COMPONENTS=("kuma-cp" "kuma-dp" "kumactl" "kuma-init" "kuma-prometheus-sd")
+[ -z "$KUMA_COMPONENTS" ] && KUMA_COMPONENTS=("kuma-cp" "kuma-dp" "kumactl" "kuma-init" "kuma-prometheus-sd")
 
 function build() {
   for component in "${KUMA_COMPONENTS[@]}"; do


### PR DESCRIPTION
### Summary

Enable projects that build on top of Kuma to be able to include new docker containers

### Full changelog

* Add possibility to add new image targets when `make images`, `make docker/save` and `make docker/load`, `make k3d/load`, `make kind/load` are executed
* Remove load target separation in Kind to be consistent with K3D
* Add explicit images to `kumactl install control-plane`, so we are able to override images. it's already done for HELM install.
* Add possibility to override list of images in `docker.sh` script.

### Issues resolved

No issues reported.

### Documentation

No docs, internal changes only.

### Testing

- [X] ~Unit tests~
- [X] E2E tests
- [X] ~Manual testing on Universal~
- [X] Manual testing on Kubernetes

### Backwards compatibility

- [X] ~Update [`UPGRADE.md`](/UPGRADE.md) with any steps users will need to take when upgrading.~
- [X] ~Add `backport-to-stable` label if the code follows our [backporting policy](/CONTRIBUTING.md#backporting)~
