### PR TITLE
feature(kuma-cp): allow custom files in chart cm

### DIFF
--- a/app/kumactl/cmd/install/testdata/install-control-plane.cni-enabled.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.cni-enabled.golden.yaml
@@ -1369,7 +1369,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: bd9040893dba92c246c9f15b8e5c5fdbbccabfeb97201a967595c7c13f24356c
+        checksum/config: 486b6c2a6232d5d70b97988847fd8a856fb59ea0302e5ebdd8202c454d98bead
         checksum/tls-secrets: 9989f326d1d8a37eb4b96619945c8ad41abcf9ad5517155c33def64542d69b88
       labels:
         app.kubernetes.io/name: kuma

--- a/app/kumactl/cmd/install/testdata/install-control-plane.defaults.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.defaults.golden.yaml
@@ -1194,7 +1194,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: bd9040893dba92c246c9f15b8e5c5fdbbccabfeb97201a967595c7c13f24356c
+        checksum/config: 486b6c2a6232d5d70b97988847fd8a856fb59ea0302e5ebdd8202c454d98bead
         checksum/tls-secrets: 9989f326d1d8a37eb4b96619945c8ad41abcf9ad5517155c33def64542d69b88
       labels:
         app.kubernetes.io/name: kuma

--- a/app/kumactl/cmd/install/testdata/install-control-plane.global.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.global.golden.yaml
@@ -1204,7 +1204,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: bd9040893dba92c246c9f15b8e5c5fdbbccabfeb97201a967595c7c13f24356c
+        checksum/config: 486b6c2a6232d5d70b97988847fd8a856fb59ea0302e5ebdd8202c454d98bead
         checksum/tls-secrets: 9989f326d1d8a37eb4b96619945c8ad41abcf9ad5517155c33def64542d69b88
       labels:
         app.kubernetes.io/name: kuma

--- a/app/kumactl/cmd/install/testdata/install-control-plane.override-env-vars.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.override-env-vars.golden.yaml
@@ -1194,7 +1194,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: bd9040893dba92c246c9f15b8e5c5fdbbccabfeb97201a967595c7c13f24356c
+        checksum/config: 486b6c2a6232d5d70b97988847fd8a856fb59ea0302e5ebdd8202c454d98bead
         checksum/tls-secrets: 9989f326d1d8a37eb4b96619945c8ad41abcf9ad5517155c33def64542d69b88
       labels:
         app.kubernetes.io/name: kuma

--- a/app/kumactl/cmd/install/testdata/install-control-plane.overrides.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.overrides.golden.yaml
@@ -1198,7 +1198,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 243da0d686658ca26902677cd16971d2ec72fe4453dbb0b09c09ea96b423d4ce
+        checksum/config: 745fdaaea267fe3c09b45b32b924aca47359ba073d39ada90e7a8f8e5cd41115
         checksum/tls-secrets: acef35bb9732451f2f5472d3e565881af066a912f5940b0e5811386d7beafdcf
       labels:
         app.kubernetes.io/name: kuma

--- a/app/kumactl/cmd/install/testdata/install-control-plane.with-ingress.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.with-ingress.golden.yaml
@@ -1223,7 +1223,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: bd9040893dba92c246c9f15b8e5c5fdbbccabfeb97201a967595c7c13f24356c
+        checksum/config: 486b6c2a6232d5d70b97988847fd8a856fb59ea0302e5ebdd8202c454d98bead
         checksum/tls-secrets: 9989f326d1d8a37eb4b96619945c8ad41abcf9ad5517155c33def64542d69b88
       labels:
         app.kubernetes.io/name: kuma

--- a/app/kumactl/cmd/install/testdata/install-control-plane.zone.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.zone.golden.yaml
@@ -1198,7 +1198,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: bd9040893dba92c246c9f15b8e5c5fdbbccabfeb97201a967595c7c13f24356c
+        checksum/config: 486b6c2a6232d5d70b97988847fd8a856fb59ea0302e5ebdd8202c454d98bead
         checksum/tls-secrets: 9989f326d1d8a37eb4b96619945c8ad41abcf9ad5517155c33def64542d69b88
       labels:
         app.kubernetes.io/name: kuma

--- a/deployments/charts/kuma/README.md
+++ b/deployments/charts/kuma/README.md
@@ -48,6 +48,8 @@ A Helm chart for the Kuma Control Plane
 | controlPlane.image.repository | string | `"kuma-cp"` | Kuma CP image repository |
 | controlPlane.secrets | list of { Env: string, Secret: string, Key: string } | `nil` | Secrets to add as environment variables, where `Env` is the name of the env variable, `Secret` is the name of the Secret, and `Key` is the key of the Secret value to use |
 | controlPlane.envVars | object | `{}` | Additional environment variables that will be passed to the control plane |
+| controlPlane.extraConfigMaps | list | `[]` | Additional config maps to mount into the control plane, with optional inline values |
+| controlPlane.extraSecrets | list | `[]` | Additional secrets to mount into the control plane |
 | controlPlane.webhooks.validator.additionalRules | string | `""` | Additional rules to apply on Kuma validator webhook. Useful when building custom policy on top of Kuma. |
 | controlPlane.webhooks.ownerReference.additionalRules | string | `""` | Additional rules to apply on Kuma owner reference webhook. Useful when building custom policy on top of Kuma. |
 | cni.enabled | bool | `false` | Install Kuma with CNI instead of proxy init container |

--- a/deployments/charts/kuma/templates/cp-configmap.yaml
+++ b/deployments/charts/kuma/templates/cp-configmap.yaml
@@ -13,3 +13,23 @@ data:
     {{ if .Values.controlPlane.config }}
     {{ .Values.controlPlane.config | nindent 4 }}
     {{ end }}
+
+{{- $kumaLabels := include "kuma.labels" . -}}
+{{- $releaseNamespace := .Release.Namespace}}
+{{- range $extraConfigMap := .Values.controlPlane.extraConfigMaps }}
+{{- if $extraConfigMap.values }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ $extraConfigMap.name }}
+  namespace: {{ $releaseNamespace }}
+  labels:
+  {{- $kumaLabels | nindent 4 }}
+data:
+  {{- range $fileName, $fileContents := $extraConfigMap.values }}
+  {{- $fileName | nindent 2 }}: |
+  {{- $fileContents | nindent 4 }}
+  {{- end }}
+{{- end }}
+{{- end }}

--- a/deployments/charts/kuma/templates/cp-deployment.yaml
+++ b/deployments/charts/kuma/templates/cp-deployment.yaml
@@ -148,6 +148,16 @@ spec:
               mountPath: /var/run/secrets/kuma.io/kds-client-tls-cert
               readOnly: true
           {{- end }}
+          {{- range $extraConfigMap := .Values.controlPlane.extraConfigMaps }}
+            - name: {{ $extraConfigMap.name }}
+              mountPath: {{ $extraConfigMap.mountPath }}
+              readOnly: {{ $extraConfigMap.readOnly }}
+          {{- end }}
+          {{- range $extraSecret := .Values.controlPlane.extraSecrets }}
+            - name: {{ $extraSecret.name }}
+              mountPath: {{ $extraSecret.mountPath }}
+              readOnly: {{ $extraSecret.readOnly }}
+          {{- end }}
       volumes:
         {{- if .Values.controlPlane.tls.general.secretName }}
         - name: general-tls-cert
@@ -186,3 +196,13 @@ spec:
         - name: {{ include "kuma.name" . }}-control-plane-config
           configMap:
             name: {{ include "kuma.name" . }}-control-plane-config
+        {{- range $extraConfigMap := .Values.controlPlane.extraConfigMaps }}
+        - name: {{ $extraConfigMap.name }}
+          configMap:
+            name: {{ $extraConfigMap.name }}
+        {{- end }}
+        {{- range $extraSecret := .Values.controlPlane.extraSecrets }}
+        - name: {{ $extraSecret.name }}
+          secret:
+            secretName: {{ $extraSecret.name }}
+        {{- end }}

--- a/deployments/charts/kuma/values.yaml
+++ b/deployments/charts/kuma/values.yaml
@@ -134,6 +134,21 @@ controlPlane:
   # -- Additional environment variables that will be passed to the control plane
   envVars: { }
 
+  # -- Additional config maps to mount into the control plane, with optional inline values
+  extraConfigMaps: [ ]
+#    - name: extra-config
+#      mountPath: /etc/extra-config
+#      readOnly: true
+#      values:
+#        extra-config-key: |
+#          extra-config-value
+
+  # -- Additional secrets to mount into the control plane
+  extraSecrets: [ ]
+#    - name: extra-config
+#      mountPath: /etc/extra-config
+#      readOnly: true
+
   webhooks:
     validator:
       # -- Additional rules to apply on Kuma validator webhook. Useful when building custom policy on top of Kuma.


### PR DESCRIPTION
The initial motivation for this is to allow the appropriate
CA file for the Postgres instance to be specified when
running kuma-cp in universal mode and then configured with
KUMA_STORE_POSTGRES_TLS_CA_PATH

Signed-off-by: Will Betts <will.betts@equalexperts.com>
