### PR TITLE
feat(gateway): support Gateway API ReferencePolicy for HTTPRoutes

### DIFF
--- a/pkg/plugins/runtime/k8s/controllers/gatewayapi/http_route_controller.go
+++ b/pkg/plugins/runtime/k8s/controllers/gatewayapi/http_route_controller.go
@@ -36,6 +36,7 @@ const (
 	ObjectTypeUnknownOrInvalid = "ObjectTypeUnknownOrInvalid"
 	ObjectNotFound             = "ObjectNotFound"
 	RefInvalid                 = "RefInvalid"
+	RefNotPermitted            = "RefNotPermitted"
 )
 
 const ownerLabel = "gateways.kuma.io/owner"

--- a/pkg/plugins/runtime/k8s/controllers/gatewayapi/policy/policy.go
+++ b/pkg/plugins/runtime/k8s/controllers/gatewayapi/policy/policy.go
@@ -1,0 +1,104 @@
+package policy
+
+import (
+	"context"
+	"reflect"
+
+	"github.com/pkg/errors"
+	kube_schema "k8s.io/apimachinery/pkg/runtime/schema"
+	kube_client "sigs.k8s.io/controller-runtime/pkg/client"
+	gatewayapi "sigs.k8s.io/gateway-api/apis/v1alpha2"
+)
+
+var httpRouteGK = kube_schema.GroupKind{Group: gatewayapi.GroupName, Kind: "HTTPRoute"}
+
+type PolicyReference struct {
+	from        gatewayapi.ReferencePolicyFrom
+	toNamespace gatewayapi.Namespace
+	to          gatewayapi.ReferencePolicyTo
+}
+
+func (pr *PolicyReference) ToNamespace() string {
+	return string(pr.toNamespace)
+}
+
+func FromHTTPRouteIn(namespace string) gatewayapi.ReferencePolicyFrom {
+	return gatewayapi.ReferencePolicyFrom{
+		Kind:      gatewayapi.Kind(httpRouteGK.Kind),
+		Group:     gatewayapi.Group(httpRouteGK.Group),
+		Namespace: gatewayapi.Namespace(namespace),
+	}
+}
+
+func PolicyReferenceBackend(from gatewayapi.ReferencePolicyFrom, to gatewayapi.BackendObjectReference) PolicyReference {
+	return PolicyReference{
+		from: from,
+		to: gatewayapi.ReferencePolicyTo{
+			Kind:  *to.Kind,
+			Group: *to.Group,
+			Name:  &to.Name,
+		},
+		toNamespace: *to.Namespace,
+	}
+}
+
+func PolicyReferenceSecret(from gatewayapi.ReferencePolicyFrom, to gatewayapi.SecretObjectReference) PolicyReference {
+	return PolicyReference{
+		from: from,
+		to: gatewayapi.ReferencePolicyTo{
+			Kind:  *to.Kind,
+			Group: *to.Group,
+			Name:  &to.Name,
+		},
+		toNamespace: *to.Namespace,
+	}
+}
+
+// IsReferencePermitted returns whether the given reference is permitted with respect
+// to ReferencePolicies.
+func IsReferencePermitted(
+	ctx context.Context,
+	client kube_client.Client,
+	reference PolicyReference,
+) (bool, error) {
+	if reference.from.Namespace == reference.toNamespace {
+		return true, nil
+	}
+
+	policies := &gatewayapi.ReferencePolicyList{}
+	if err := client.List(ctx, policies, kube_client.InNamespace(reference.toNamespace)); err != nil {
+		return false, errors.Wrap(err, "failed to list ReferencePolicies")
+	}
+
+	for _, policy := range policies.Items {
+		if !someFromMatches(reference.from, policy.Spec.From) {
+			continue
+		}
+
+		if someToMatches(reference.to, policy.Spec.To) {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}
+
+func someFromMatches(from gatewayapi.ReferencePolicyFrom, permitted []gatewayapi.ReferencePolicyFrom) bool {
+	for _, permittedFrom := range permitted {
+		if reflect.DeepEqual(permittedFrom, from) {
+			return true
+		}
+	}
+	return false
+}
+
+func someToMatches(to gatewayapi.ReferencePolicyTo, permitted []gatewayapi.ReferencePolicyTo) bool {
+	for _, permittedTo := range permitted {
+		if permittedTo.Group == to.Group &&
+			permittedTo.Kind == to.Kind &&
+			(permittedTo.Name == nil || *permittedTo.Name == "" || *permittedTo.Name == *to.Name) {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/plugins/runtime/k8s/controllers/gatewayapi/policy/policy_suite_test.go
+++ b/pkg/plugins/runtime/k8s/controllers/gatewayapi/policy/policy_suite_test.go
@@ -1,0 +1,11 @@
+package policy_test
+
+import (
+	"testing"
+
+	"github.com/kumahq/kuma/pkg/test"
+)
+
+func TestReferencePolicy(t *testing.T) {
+	test.RunSpecs(t, "Gateway API ReferencePolicy support")
+}

--- a/pkg/plugins/runtime/k8s/controllers/gatewayapi/policy/policy_test.go
+++ b/pkg/plugins/runtime/k8s/controllers/gatewayapi/policy/policy_test.go
@@ -1,0 +1,170 @@
+package policy_test
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	kube_meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kube_runtime "k8s.io/apimachinery/pkg/runtime"
+	kube_client_fake "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	gatewayapi "sigs.k8s.io/gateway-api/apis/v1alpha2"
+
+	"github.com/kumahq/kuma/pkg/plugins/bootstrap/k8s"
+	mesh_k8s "github.com/kumahq/kuma/pkg/plugins/resources/k8s/native/api/v1alpha1"
+	"github.com/kumahq/kuma/pkg/plugins/runtime/k8s/controllers/gatewayapi/policy"
+)
+
+var k8sScheme *kube_runtime.Scheme
+
+var _ = BeforeSuite(func() {
+	var err error
+	k8sScheme, err = k8s.NewScheme()
+	Expect(err).NotTo(HaveOccurred())
+})
+
+const (
+	defaultNs = "default"
+	otherNs   = "other"
+)
+
+var (
+	simplePolicy = gatewayapi.ReferencePolicy{
+		ObjectMeta: kube_meta.ObjectMeta{
+			Name:      "basic",
+			Namespace: otherNs,
+		},
+		Spec: gatewayapi.ReferencePolicySpec{
+			From: []gatewayapi.ReferencePolicyFrom{
+				{
+					Group:     gatewayapi.Group(gatewayapi.GroupName),
+					Kind:      gatewayapi.Kind("HTTPRoute"),
+					Namespace: gatewayapi.Namespace(defaultNs),
+				},
+			},
+			To: []gatewayapi.ReferencePolicyTo{
+				{
+					Group: gatewayapi.Group(""),
+					Kind:  gatewayapi.Kind("Service"),
+				},
+			},
+		},
+	}
+
+	// References
+	coreGroup = gatewayapi.Group("")
+	svcKind   = gatewayapi.Kind("Service")
+	somePort  = gatewayapi.PortNumber(80)
+
+	toDefaultNs  = gatewayapi.Namespace(defaultNs)
+	toDefaultSvc = gatewayapi.BackendObjectReference{
+		Group:     &coreGroup,
+		Kind:      &svcKind,
+		Name:      "svc",
+		Namespace: &toDefaultNs,
+		Port:      &somePort,
+	}
+
+	toOtherNs  = gatewayapi.Namespace(otherNs)
+	toOtherSvc = gatewayapi.BackendObjectReference{
+		Group:     &coreGroup,
+		Kind:      &svcKind,
+		Name:      "svc",
+		Namespace: &toOtherNs,
+		Port:      &somePort,
+	}
+
+	kumaGroup          = gatewayapi.Group(mesh_k8s.GroupVersion.Group)
+	externalSvcKind    = gatewayapi.Kind("ExternalService")
+	toOtherExternalSvc = gatewayapi.BackendObjectReference{
+		Group:     &kumaGroup,
+		Kind:      &externalSvcKind,
+		Name:      "ext-svc",
+		Namespace: &toOtherNs,
+	}
+)
+
+var _ = Describe("ReferencePolicy support", func() {
+	It("permits same namespace references", func() {
+		kubeClient := kube_client_fake.NewClientBuilder().WithScheme(k8sScheme).WithObjects(
+			&simplePolicy,
+		).Build()
+
+		ref := policy.PolicyReferenceBackend(policy.FromHTTPRouteIn(defaultNs), toDefaultSvc)
+		permitted, err := policy.IsReferencePermitted(
+			context.Background(),
+			kubeClient,
+			ref,
+		)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(permitted).To(BeTrue())
+	})
+	Context("respects basic specs", func() {
+		It("permitted for matching .to and .from", func() {
+			kubeClient := kube_client_fake.NewClientBuilder().WithScheme(k8sScheme).WithObjects(
+				&simplePolicy,
+			).Build()
+
+			ref := policy.PolicyReferenceBackend(policy.FromHTTPRouteIn(defaultNs), toOtherSvc)
+			permitted, err := policy.IsReferencePermitted(
+				context.Background(),
+				kubeClient,
+				ref,
+			)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(permitted).To(BeTrue())
+		})
+		It("denies for missing .from GroupKind", func() {
+			kubeClient := kube_client_fake.NewClientBuilder().WithScheme(k8sScheme).WithObjects(
+				&simplePolicy,
+			).Build()
+
+			ref := policy.PolicyReferenceBackend(policy.FromHTTPRouteIn(defaultNs), toOtherExternalSvc)
+			permitted, err := policy.IsReferencePermitted(
+				context.Background(),
+				kubeClient,
+				ref,
+			)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(permitted).To(BeFalse())
+		})
+		It("checks names in .from", func() {
+			policyWithName := simplePolicy.DeepCopy()
+			permittedToExtSvcName := gatewayapi.ObjectName("specific-permitted-ext-svc")
+			policyWithName.Spec.To = append(policyWithName.Spec.To,
+				gatewayapi.ReferencePolicyTo{
+					Group: kumaGroup,
+					Kind:  externalSvcKind,
+					Name:  &permittedToExtSvcName,
+				},
+			)
+
+			kubeClient := kube_client_fake.NewClientBuilder().WithScheme(k8sScheme).WithObjects(
+				policyWithName,
+			).Build()
+
+			By("denying if the name doesn't match")
+			ref := policy.PolicyReferenceBackend(policy.FromHTTPRouteIn(defaultNs), toOtherExternalSvc)
+			permitted, err := policy.IsReferencePermitted(
+				context.Background(),
+				kubeClient,
+				ref,
+			)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(permitted).To(BeFalse())
+
+			By("permitting if the name matches")
+			toOtherSpecificExternalSvc := toOtherExternalSvc.DeepCopy()
+			toOtherSpecificExternalSvc.Name = permittedToExtSvcName
+
+			ref = policy.PolicyReferenceBackend(policy.FromHTTPRouteIn(defaultNs), *toOtherSpecificExternalSvc)
+			permitted, err = policy.IsReferencePermitted(
+				context.Background(),
+				kubeClient,
+				ref,
+			)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(permitted).To(BeTrue())
+		})
+	})
+})


### PR DESCRIPTION
### Summary

This PR adds [CORE conformance level support](https://gateway-api.sigs.k8s.io/v1alpha2/references/cross-namespace-references/#conformance-level) for checking `ReferencePolicy`s when handling `HTTPRoute` references.

Part of #3615