### PR TITLE
improvement(metadata): Include name of annotation to parse error message

### DIFF
--- a/pkg/plugins/runtime/k8s/metadata/annotations.go
+++ b/pkg/plugins/runtime/k8s/metadata/annotations.go
@@ -104,10 +104,6 @@ const (
 	AnnotationFalse    = "false"
 )
 
-const (
-	errValueCastFailed = "value of annotation %q can't be casted: %s"
-)
-
 type Annotations map[string]string
 
 func (a Annotations) GetEnabled(key string) (bool, bool, error) {
@@ -132,7 +128,7 @@ func (a Annotations) GetUint32(key string) (uint32, bool, error) {
 	}
 	u, err := strconv.ParseUint(value, 10, 32)
 	if err != nil {
-		return 0, true, errors.Errorf(errValueCastFailed, key, err.Error())
+		return 0, true, errors.Errorf("failed to parse annotation %q: %s", key, err.Error())
 	}
 	return uint32(u), true, nil
 }
@@ -152,7 +148,7 @@ func (a Annotations) GetBool(key string) (bool, bool, error) {
 	}
 	b, err := strconv.ParseBool(value)
 	if err != nil {
-		return false, false, errors.Errorf(errValueCastFailed, key, err.Error())
+		return false, false, errors.Errorf("failed to parse annotation %q: %s", key, err.Error())
 	}
 	return b, true, nil
 }

--- a/pkg/plugins/runtime/k8s/metadata/annotations.go
+++ b/pkg/plugins/runtime/k8s/metadata/annotations.go
@@ -104,6 +104,10 @@ const (
 	AnnotationFalse    = "false"
 )
 
+const (
+	errValueCastFailed = "value of annotation %q can't be casted: %s"
+)
+
 type Annotations map[string]string
 
 func (a Annotations) GetEnabled(key string) (bool, bool, error) {
@@ -128,7 +132,7 @@ func (a Annotations) GetUint32(key string) (uint32, bool, error) {
 	}
 	u, err := strconv.ParseUint(value, 10, 32)
 	if err != nil {
-		return 0, true, err
+		return 0, true, errors.Errorf(errValueCastFailed, key, err.Error())
 	}
 	return uint32(u), true, nil
 }
@@ -148,7 +152,7 @@ func (a Annotations) GetBool(key string) (bool, bool, error) {
 	}
 	b, err := strconv.ParseBool(value)
 	if err != nil {
-		return false, false, err
+		return false, false, errors.Errorf(errValueCastFailed, key, err.Error())
 	}
 	return b, true, nil
 }

--- a/pkg/plugins/runtime/k8s/metadata/annotations_test.go
+++ b/pkg/plugins/runtime/k8s/metadata/annotations_test.go
@@ -57,7 +57,7 @@ var _ = Describe("Kubernetes Annotations", func() {
 			}
 
 			_, _, err := metadata.Annotations(annotations).GetUint32("key1")
-			Expect(err.Error()).To(ContainSubstring("value of annotation \"key1\" can't be casted: strconv.ParseUint: parsing \"dummy\": invalid syntax"))
+			Expect(err.Error()).To(ContainSubstring("failed to parse annotation \"key1\": strconv.ParseUint: parsing \"dummy\": invalid syntax"))
 		})
 	})
 
@@ -79,7 +79,7 @@ var _ = Describe("Kubernetes Annotations", func() {
 			}
 
 			_, _, err := metadata.Annotations(annotations).GetBool("key1")
-			Expect(err.Error()).To(ContainSubstring("value of annotation \"key1\" can't be casted: strconv.ParseBool: parsing \"dummy\": invalid syntax"))
+			Expect(err.Error()).To(ContainSubstring("failed to parse annotation \"key1\": strconv.ParseBool: parsing \"dummy\": invalid syntax"))
 		})
 	})
 

--- a/pkg/plugins/runtime/k8s/metadata/annotations_test.go
+++ b/pkg/plugins/runtime/k8s/metadata/annotations_test.go
@@ -38,6 +38,51 @@ var _ = Describe("Kubernetes Annotations", func() {
 		})
 	})
 
+	Context("GetUint32()", func() {
+		It("should parse value to uint32", func() {
+			// given
+			annotations := map[string]string{
+				"key1": "100",
+			}
+
+			val, hasKey, err := metadata.Annotations(annotations).GetUint32("key1")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(hasKey).To(Equal(true))
+			Expect(val).To(Equal(uint32(100)))
+		})
+
+		It("should return error if value has wrong format", func() {
+			annotations := map[string]string{
+				"key1": "dummy",
+			}
+
+			_, _, err := metadata.Annotations(annotations).GetUint32("key1")
+			Expect(err.Error()).To(ContainSubstring("value of annotation \"key1\" can't be casted: strconv.ParseUint: parsing \"dummy\": invalid syntax"))
+		})
+	})
+
+	Context("GetBool()", func() {
+		It("should parse value to bool", func() {
+			annotations := map[string]string{
+				"key1": "true",
+			}
+
+			val, hasKey, err := metadata.Annotations(annotations).GetBool("key1")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(hasKey).To(Equal(true))
+			Expect(val).To(Equal(true))
+		})
+
+		It("should return error if value has wrong format", func() {
+			annotations := map[string]string{
+				"key1": "dummy",
+			}
+
+			_, _, err := metadata.Annotations(annotations).GetBool("key1")
+			Expect(err.Error()).To(ContainSubstring("value of annotation \"key1\" can't be casted: strconv.ParseBool: parsing \"dummy\": invalid syntax"))
+		})
+	})
+
 	Context("GetMap()", func() {
 		It("should parse value to map", func() {
 			// given


### PR DESCRIPTION
Signed-off-by: ChinYing-Li <chinying.li@mail.utoronto.ca>

### Summary

Introduce a new error message template when casting of annotation value failed. Introduced unit tests for `GetUint32` and `GetBool`.

Any suggestion is appreciated!

### Full changelog

* Include name of annotation to parse error message

### Issues resolved

Fix #2690 

### Documentation

- [ ] Link to the website [documentation PR](https://github.com/kumahq/kuma-website/pull/XXX)

### Testing

- [x] Unit tests
- [ ] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes

### Backwards compatibility

- [ ] Update [`UPGRADE.md`](/UPGRADE.md) with any steps users will need to take when upgrading.
- [ ] Add `backport-to-stable` label if the code follows our [backporting policy](/CONTRIBUTING.md#backporting)
