### PR TITLE
chore(kuma-cp): consolidate mesh defaults creation

### DIFF
--- a/pkg/defaults/mesh/circuit_breaker.go
+++ b/pkg/defaults/mesh/circuit_breaker.go
@@ -1,11 +1,8 @@
 package mesh
 
 import (
-	"fmt"
-
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
-	"github.com/kumahq/kuma/pkg/core/resources/model"
 	util_proto "github.com/kumahq/kuma/pkg/util/proto"
 )
 
@@ -26,12 +23,4 @@ var defaultCircuitBreakerResource = &core_mesh.CircuitBreakerResource{
 			},
 		},
 	},
-}
-
-// CircuitBreaker needs to contain mesh name inside it. Otherwise if the name is the same (ex. "allow-all") creating new mesh would fail because there is already resource of name "allow-all" which is unique key on K8S
-func defaultCircuitBreakerKey(meshName string) model.ResourceKey {
-	return model.ResourceKey{
-		Mesh: meshName,
-		Name: fmt.Sprintf("circuit-breaker-all-%s", meshName),
-	}
 }

--- a/pkg/defaults/mesh/retry.go
+++ b/pkg/defaults/mesh/retry.go
@@ -1,12 +1,10 @@
 package mesh
 
 import (
-	"fmt"
 	"time"
 
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
-	"github.com/kumahq/kuma/pkg/core/resources/model"
 	util_proto "github.com/kumahq/kuma/pkg/util/proto"
 )
 
@@ -48,14 +46,4 @@ var defaultRetryResource = &core_mesh.RetryResource{
 			},
 		},
 	},
-}
-
-// Retry needs to contain mesh name inside it. Otherwise if the name is the
-//  same (ex. "retry-all") creating new mesh would fail because there is already
-//  resource of name "retry-all" which is unique key on K8S
-func defaultRetryKey(meshName string) model.ResourceKey {
-	return model.ResourceKey{
-		Mesh: meshName,
-		Name: fmt.Sprintf("retry-all-%s", meshName),
-	}
 }

--- a/pkg/defaults/mesh/timeout.go
+++ b/pkg/defaults/mesh/timeout.go
@@ -1,12 +1,10 @@
 package mesh
 
 import (
-	"fmt"
 	"time"
 
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
-	"github.com/kumahq/kuma/pkg/core/resources/model"
 	util_proto "github.com/kumahq/kuma/pkg/util/proto"
 )
 
@@ -32,12 +30,4 @@ var defaultTimeoutResource = &core_mesh.TimeoutResource{
 			},
 		},
 	},
-}
-
-// Timeout needs to contain mesh name inside it. Otherwise if the name is the same (ex. "allow-all") creating new mesh would fail because there is already resource of name "allow-all" which is unique key on K8S
-func defaultTimeoutKey(meshName string) model.ResourceKey {
-	return model.ResourceKey{
-		Mesh: meshName,
-		Name: fmt.Sprintf("timeout-all-%s", meshName),
-	}
 }

--- a/pkg/defaults/mesh/traffic_permission.go
+++ b/pkg/defaults/mesh/traffic_permission.go
@@ -1,11 +1,8 @@
 package mesh
 
 import (
-	"fmt"
-
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
-	"github.com/kumahq/kuma/pkg/core/resources/model"
 )
 
 var defaultTrafficPermissionResource = &core_mesh.TrafficPermissionResource{
@@ -25,12 +22,4 @@ var defaultTrafficPermissionResource = &core_mesh.TrafficPermissionResource{
 			},
 		},
 	},
-}
-
-// TrafficPermission needs to contain mesh name inside it. Otherwise if the name is the same (ex. "allow-all") creating new mesh would fail because there is already resource of name "allow-all" which is unique key on K8S
-func defaultTrafficPermissionKey(meshName string) model.ResourceKey {
-	return model.ResourceKey{
-		Mesh: meshName,
-		Name: fmt.Sprintf("allow-all-%s", meshName),
-	}
 }

--- a/pkg/defaults/mesh/traffic_route.go
+++ b/pkg/defaults/mesh/traffic_route.go
@@ -1,11 +1,8 @@
 package mesh
 
 import (
-	"fmt"
-
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
-	"github.com/kumahq/kuma/pkg/core/resources/model"
 )
 
 var defaultTrafficRouteResource = &core_mesh.TrafficRouteResource{
@@ -23,12 +20,4 @@ var defaultTrafficRouteResource = &core_mesh.TrafficRouteResource{
 			},
 		},
 	},
-}
-
-// TrafficRoute needs to contain mesh name inside it. Otherwise if the name is the same (ex. "allow-all") creating new mesh would fail because there is already resource of name "allow-all" which is unique key on K8S
-func defaultTrafficRouteKey(meshName string) model.ResourceKey {
-	return model.ResourceKey{
-		Mesh: meshName,
-		Name: fmt.Sprintf("route-all-%s", meshName),
-	}
 }


### PR DESCRIPTION
### Summary

Further consolidate the code that creates default mesh resources.

### Full changelog

N/A

### Issues resolved

Update #2540

### Documentation

N/A

### Testing

- [x] Unit tests
- [x] E2E tests
- [ ] ~~Manual testing on Universal~~
- [ ] ~~Manual testing on Kubernetes~~

### Backwards compatibility

- [ ] ~~Update [`UPGRADE.md`](/UPGRADE.md) with any steps users will need to take when upgrading.~~
- [ ] ~~Add `backport-to-stable` label if the code follows our [backporting policy](/CONTRIBUTING.md#backporting)~~
