### PR TITLE
ci(e2e): correct bad retry on apply

### DIFF
--- a/test/framework/k8s_controlplane.go
+++ b/test/framework/k8s_controlplane.go
@@ -335,7 +335,7 @@ func (c *K8sControlPlane) UpdateObject(
 		return errors.Errorf("no serializer for %q", runtime.ContentTypeYAML)
 	}
 
-	_, err = retry.DoWithRetryableErrorsE(c.t, "update object", map[string]string{"conflict": "Error from server \\(Conflict\\)"}, 5, time.Second, func() (string, error) {
+	_, err = retry.DoWithRetryableErrorsE(c.t, "update object", map[string]string{"Error from server \\(Conflict\\)": "object conflict"}, 5, time.Second, func() (string, error) {
 		out, err := k8s.RunKubectlAndGetOutputE(c.t, c.GetKubectlOptions(), "get", typeName, objectName, "-o", "yaml")
 		if err != nil {
 			return "", err


### PR DESCRIPTION
### Summary

we switched around the message and the regex so the retry wasn't working

### Testing

- [ ] Unit tests
- [x] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes

### Backwards compatibility

- ~~[ ] Update [`UPGRADE.md`](/UPGRADE.md) with any steps users will need to take when upgrading.~~
- ~~[ ] Add `backport-to-stable` label if the code follows our [backporting policy](/CONTRIBUTING.md#backporting)~~
