### PR TITLE
chore(*): add posibility to customize images on release

### DIFF
--- a/tools/releases/docker.sh
+++ b/tools/releases/docker.sh
@@ -6,10 +6,10 @@ source "$(dirname -- "${BASH_SOURCE[0]}")/../common.sh"
 
 [ -z "$KUMA_DOCKER_REPO" ] && KUMA_DOCKER_REPO="docker.io"
 [ -z "$KUMA_DOCKER_REPO_ORG" ] && KUMA_DOCKER_REPO_ORG=${KUMA_DOCKER_REPO}/kumahq
-[ -z "$KUMA_COMPONENTS" ] && KUMA_COMPONENTS=("kuma-cp" "kuma-dp" "kumactl" "kuma-init" "kuma-prometheus-sd")
+[ -z "$KUMA_COMPONENTS" ] && KUMA_COMPONENTS="kuma-cp kuma-dp kumactl kuma-init kuma-prometheus-sd"
 
 function build() {
-  for component in "${KUMA_COMPONENTS[@]}"; do
+  for component in ${KUMA_COMPONENTS}; do
     msg "Building $component..."
     docker build --build-arg KUMA_ROOT="$(pwd)" -t $KUMA_DOCKER_REPO_ORG/"$component":"$KUMA_VERSION" \
       -f tools/releases/dockerfiles/Dockerfile."$component" .
@@ -29,7 +29,7 @@ function docker_logout() {
 function push() {
   docker_login
 
-  for component in "${KUMA_COMPONENTS[@]}"; do
+  for component in ${KUMA_COMPONENTS}; do
     msg "Pushing $component:$KUMA_VERSION ..."
     docker push $KUMA_DOCKER_REPO_ORG/"$component":"$KUMA_VERSION"
     msg_green "... done!"


### PR DESCRIPTION
### Summary

There is no way to override bash array with env var. Switching to string.

### Issues resolved

No issues

### Documentation

- [X] No docs

### Testing

- [ ] Unit tests
- [ ] E2E tests
- [X] Manual testing on Universal
- [ ] Manual testing on Kubernetes

### Backwards compatibility

- ~[X] Update [`UPGRADE.md`](/UPGRADE.md) with any steps users will need to take when upgrading.~
- ~[X] Add `backport-to-stable` label if the code follows our [backporting policy](/CONTRIBUTING.md#backporting)~
