### PR TITLE
fix(dataplane)!: disallow using 0.0.0.0 in networking.address for dp

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -21,8 +21,9 @@ The new version still supports annotation, but to have a guarantee that applicat
 
 ### Universal
 
-We removed support for old Ingress (`Dataplane#networking.ingress`) from pre 1.2 days.
-If you are still using it, please migrate to `ZoneIngress` first (see `Upgrade to 1.2.0` section).
+- We removed support for old Ingress (`Dataplane#networking.ingress`) from pre 1.2 days.
+  If you are still using it, please migrate to `ZoneIngress` first (see `Upgrade to 1.2.0` section).
+- You can't use 0.0.0.0 or :: in `networking.address` most of the time using loopback is what people intended.
 
 ## Upgrade to `1.4.0`
 

--- a/pkg/core/resources/apis/mesh/dataplane_validator.go
+++ b/pkg/core/resources/apis/mesh/dataplane_validator.go
@@ -118,6 +118,9 @@ func validateAddress(path validators.PathBuilder, address string) validators.Val
 		err.AddViolationAt(path.Field("address"), "address can't be empty")
 		return err
 	}
+	if address == "0.0.0.0" || address == "::" {
+		err.AddViolationAt(path.Field("address"), "must not be 0.0.0.0 or ::")
+	}
 	if !govalidator.IsIP(address) && !govalidator.IsDNSName(address) {
 		err.AddViolationAt(path.Field("address"), "address has to be valid IP address or domain name")
 	}

--- a/pkg/core/resources/apis/mesh/dataplane_validator_test.go
+++ b/pkg/core/resources/apis/mesh/dataplane_validator_test.go
@@ -215,6 +215,38 @@ var _ = Describe("Dataplane", func() {
 			// and
 			Expect(actual).To(MatchYAML(given.expected))
 		},
+		Entry("networking.address: can't use 0.0.0.0", testCase{
+			dataplane: `
+                type: Dataplane
+                name: dp-1
+                mesh: default
+                networking:
+                  address: 0.0.0.0
+                  inbound:
+                    - port: 8080
+                      tags:
+                        kuma.io/service: backend`,
+			expected: `
+                violations:
+                - field: networking.address
+                  message: 'must not be 0.0.0.0 or ::'`,
+		}),
+		Entry("networking.address: can't use ::", testCase{
+			dataplane: `
+                type: Dataplane
+                name: dp-1
+                mesh: default
+                networking:
+                  address: "::"
+                  inbound:
+                    - port: 8080
+                      tags:
+                        kuma.io/service: backend`,
+			expected: `
+                violations:
+                - field: networking.address
+                  message: 'must not be 0.0.0.0 or ::'`,
+		}),
 		Entry("networking: not enough inbound interfaces and no gateway", testCase{
 			dataplane: `
                 type: Dataplane


### PR DESCRIPTION

### Summary

This doesn't really makes sense, is error prone and might accidently
expose services outside of the mesh, we therefore disallow it.

### Issues resolved

Fix #3640

### Documentation

- [ ] Link to the website [documentation PR](https://github.com/kumahq/kuma-website/pull/XXX)

### Testing

- [x] Unit tests
- [ ] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes

### Backwards compatibility

- [x] Update [`UPGRADE.md`](/UPGRADE.md) with any steps users will need to take when upgrading.
- ~~[ ] Add `backport-to-stable` label if the code follows our [backporting policy](/CONTRIBUTING.md#backporting)~~
