### PR TITLE
feat(gateway): respect AllowedRoutes on Gateways

### DIFF
--- a/pkg/plugins/runtime/k8s/controllers/gatewayapi/attachment/attachment.go
+++ b/pkg/plugins/runtime/k8s/controllers/gatewayapi/attachment/attachment.go
@@ -1,0 +1,164 @@
+package attachment
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+	kube_core "k8s.io/api/core/v1"
+	kube_apierrs "k8s.io/apimachinery/pkg/api/errors"
+	kube_meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kube_labels "k8s.io/apimachinery/pkg/labels"
+	kube_types "k8s.io/apimachinery/pkg/types"
+	kube_client "sigs.k8s.io/controller-runtime/pkg/client"
+	gatewayapi "sigs.k8s.io/gateway-api/apis/v1alpha2"
+
+	"github.com/kumahq/kuma/pkg/plugins/runtime/k8s/controllers/gatewayapi/common"
+)
+
+type Attachment int
+
+const (
+	// Unknown means we shouldn't report on whether it's attached or not
+	Unknown Attachment = iota
+	// NotPermitted means the route isn't allowed to attach to the ref
+	NotPermitted
+	// Invalid means the route points to a nonexistent parent
+	// or is otherwise invalid
+	Invalid
+	// Allowed means we could successfully attach
+	Allowed
+)
+
+// findRouteListenerAttachment reports whether this ref is allowed to attach to
+// the Gateway or specific Listener.
+// refSectionName is nil if the ref refers to the whole Gateway.
+func findRouteListenerAttachment(
+	gateway *gatewayapi.Gateway,
+	routeNs kube_client.Object,
+	refSectionName *gatewayapi.SectionName,
+) (Attachment, error) {
+	// Build a map of whether attaching to each listener is possible
+	listeners := map[gatewayapi.SectionName]Attachment{}
+
+	for _, l := range gateway.Spec.Listeners {
+		ns := l.AllowedRoutes.Namespaces
+
+		// The gateway controller ensures Kinds is either empty or contains
+		// HTTPRoute, so we can ignore it here.
+
+		// From determines whether we are permitted to attach to this ParentRef
+		switch *ns.From {
+		case gatewayapi.NamespacesFromSelector:
+			// TODO, the gateway controller/webhook should verify this isn't an
+			// error
+			selector, err := kube_meta.LabelSelectorAsSelector(ns.Selector)
+			if err != nil {
+				return Unknown, errors.Wrap(err, "internal error: couldn't convert to selector")
+			}
+
+			if !selector.Matches(kube_labels.Set(routeNs.GetLabels())) {
+				listeners[l.Name] = NotPermitted
+				continue
+			}
+		case gatewayapi.NamespacesFromSame:
+			if gateway.Namespace != routeNs.GetName() {
+				listeners[l.Name] = NotPermitted
+				continue
+			}
+		case gatewayapi.NamespacesFromAll:
+		}
+
+		return Allowed, nil
+	}
+
+	sectionName := ""
+	if refSectionName != nil {
+		sectionName = string(*refSectionName)
+	}
+
+	// Look through the potential Listeners:
+	// If it's our specific listener, we return that status
+	for name, status := range listeners {
+		if string(name) == sectionName {
+			return status, nil
+		}
+	}
+
+	// If we don't find our listener, our ref is invalid
+	if sectionName != "" {
+		return Invalid, nil
+	}
+
+	// If we aren't attaching to a specific listener then
+	// as soon as one attaches we're attached (see ParentRef.Name docs)
+	for _, status := range listeners {
+		if status == Allowed {
+			return Allowed, nil
+		}
+	}
+
+	return NotPermitted, nil
+}
+
+// getParentRefGateway returns a kuma-class Gateway if one was found,
+// otherwise it returns nil.
+func getParentRefGateway(
+	ctx context.Context,
+	client kube_client.Client,
+	fromNamespace string,
+	ref gatewayapi.ParentRef,
+) (*gatewayapi.Gateway, error) {
+	name := string(ref.Name)
+	// Group and Kind both have default values
+	group := string(*ref.Group)
+	kind := string(*ref.Kind)
+
+	namespace := fromNamespace
+	if ns := ref.Namespace; ns != nil {
+		namespace = string(*ns)
+	}
+
+	if group != gatewayapi.GroupName || kind != "Gateway" {
+		return nil, nil
+	}
+
+	gateway := &gatewayapi.Gateway{}
+
+	if err := client.Get(ctx, kube_types.NamespacedName{Namespace: namespace, Name: name}, gateway); err != nil {
+		if kube_apierrs.IsNotFound(err) {
+			return nil, nil
+		} else {
+			return nil, err
+		}
+	}
+
+	class, err := common.GetGatewayClass(ctx, client, gateway.Spec.GatewayClassName)
+	if err != nil {
+		return nil, err
+	}
+
+	if class.Spec.ControllerName != common.ControllerName {
+		return nil, nil
+	}
+
+	return gateway, nil
+}
+
+// EvaluateParentRefAttachment reports whether a route in the given namespace can attach
+// via the given ParentRef.
+func EvaluateParentRefAttachment(
+	ctx context.Context,
+	client kube_client.Client,
+	routeNs *kube_core.Namespace,
+	ref gatewayapi.ParentRef,
+) (Attachment, error) {
+	gateway, err := getParentRefGateway(ctx, client, routeNs.GetName(), ref)
+	if err != nil {
+		return Unknown, errors.Wrap(err, "couldn't find Gateway referrent")
+	}
+	if gateway == nil {
+		return Unknown, nil
+	}
+
+	return findRouteListenerAttachment(gateway, routeNs, ref.SectionName)
+}

--- a/pkg/plugins/runtime/k8s/controllers/gatewayapi/attachment/attachment_suite_test.go
+++ b/pkg/plugins/runtime/k8s/controllers/gatewayapi/attachment/attachment_suite_test.go
@@ -1,0 +1,11 @@
+package attachment_test
+
+import (
+	"testing"
+
+	"github.com/kumahq/kuma/pkg/test"
+)
+
+func TestAllowedRoutes(t *testing.T) {
+	test.RunSpecs(t, "Gateway API AllowedRoutes support")
+}

--- a/pkg/plugins/runtime/k8s/controllers/gatewayapi/attachment/attachment_test.go
+++ b/pkg/plugins/runtime/k8s/controllers/gatewayapi/attachment/attachment_test.go
@@ -1,0 +1,253 @@
+package attachment_test
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	kube_core "k8s.io/api/core/v1"
+	kube_meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kube_runtime "k8s.io/apimachinery/pkg/runtime"
+	kube_client "sigs.k8s.io/controller-runtime/pkg/client"
+	kube_client_fake "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	gatewayapi "sigs.k8s.io/gateway-api/apis/v1alpha2"
+
+	"github.com/kumahq/kuma/pkg/plugins/bootstrap/k8s"
+	"github.com/kumahq/kuma/pkg/plugins/runtime/k8s/controllers/gatewayapi/attachment"
+	"github.com/kumahq/kuma/pkg/plugins/runtime/k8s/controllers/gatewayapi/common"
+)
+
+var k8sScheme *kube_runtime.Scheme
+
+var _ = BeforeSuite(func() {
+	var err error
+	k8sScheme, err = k8s.NewScheme()
+	Expect(err).NotTo(HaveOccurred())
+})
+
+var _ = Describe("AllowedRoutes support", func() {
+	var kubeClient kube_client.Client
+	BeforeEach(func() {
+		kubeClient = kube_client_fake.NewClientBuilder().WithScheme(k8sScheme).WithObjects(
+			gatewayClass,
+			gateway,
+			gatewayMultipleListeners,
+			defaultRouteNs,
+			otherRouteNs,
+		).Build()
+
+	})
+	Context("default AllowedRoutes", func() {
+		var simpleRef gatewayapi.ParentRef
+		BeforeEach(func() {
+			simpleRef = *gatewayRef.DeepCopy()
+			simpleRef.Name = gatewayapi.ObjectName(gateway.Name)
+		})
+
+		It("allows from same namespace", func() {
+			simpleRef.SectionName = &simpleListenerName
+			res, err := attachment.EvaluateParentRefAttachment(
+				context.Background(),
+				kubeClient,
+				defaultRouteNs,
+				simpleRef,
+			)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(res).To(Equal(attachment.Allowed))
+		})
+		It("allows from same namespace for all listeners", func() {
+			simpleRef.SectionName = nil
+			res, err := attachment.EvaluateParentRefAttachment(
+				context.Background(),
+				kubeClient,
+				defaultRouteNs,
+				simpleRef,
+			)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(res).To(Equal(attachment.Allowed))
+		})
+		It("denies from other namespace", func() {
+			simpleRef.SectionName = &simpleListenerName
+			ns := gatewayapi.Namespace(defaultNs)
+			simpleRef.Namespace = &ns
+
+			res, err := attachment.EvaluateParentRefAttachment(
+				context.Background(),
+				kubeClient,
+				otherRouteNs,
+				simpleRef,
+			)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(res).To(Equal(attachment.NotPermitted))
+		})
+		It("denies from other namespace for all listeners", func() {
+			simpleRef.SectionName = nil
+			ns := gatewayapi.Namespace(defaultNs)
+			simpleRef.Namespace = &ns
+
+			res, err := attachment.EvaluateParentRefAttachment(
+				context.Background(),
+				kubeClient,
+				otherRouteNs,
+				simpleRef,
+			)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(res).To(Equal(attachment.NotPermitted))
+		})
+	})
+	Context("FromAll", func() {
+		var parentRef gatewayapi.ParentRef
+		BeforeEach(func() {
+			parentRef = *gatewayRef.DeepCopy()
+			parentRef.Name = gatewayapi.ObjectName(gatewayMultipleListeners.Name)
+		})
+
+		It("allows route from same NS", func() {
+			parentRef.SectionName = &allNsListenerName
+
+			res, err := attachment.EvaluateParentRefAttachment(
+				context.Background(),
+				kubeClient,
+				defaultRouteNs,
+				parentRef,
+			)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(res).To(Equal(attachment.Allowed))
+		})
+		It("allows route from other NS", func() {
+			parentRef.SectionName = &allNsListenerName
+			ns := gatewayapi.Namespace(defaultNs)
+			parentRef.Namespace = &ns
+
+			res, err := attachment.EvaluateParentRefAttachment(
+				context.Background(),
+				kubeClient,
+				otherRouteNs,
+				parentRef,
+			)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(res).To(Equal(attachment.Allowed))
+		})
+		It("allows from other NS for all listeners", func() {
+			ns := gatewayapi.Namespace(defaultNs)
+			parentRef.Namespace = &ns
+
+			res, err := attachment.EvaluateParentRefAttachment(
+				context.Background(),
+				kubeClient,
+				otherRouteNs,
+				parentRef,
+			)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(res).To(Equal(attachment.Allowed))
+		})
+	})
+})
+
+var (
+	defaultNs    = "default"
+	otherNs      = "other"
+	fromAll      = gatewayapi.NamespacesFromAll
+	fromSame     = gatewayapi.NamespacesFromSame
+	gatewayGroup = gatewayapi.Group(gatewayapi.GroupName)
+	gatewayKind  = gatewayapi.Kind("Gateway")
+
+	listenerReady = []kube_meta.Condition{
+		{
+			Type:   string(gatewayapi.ListenerConditionReady),
+			Status: kube_meta.ConditionTrue,
+		},
+	}
+
+	simpleListenerName = gatewayapi.SectionName("simple")
+	simpleListener     = gatewayapi.Listener{
+		Name:     simpleListenerName,
+		Port:     gatewayapi.PortNumber(80),
+		Protocol: gatewayapi.HTTPProtocolType,
+		AllowedRoutes: &gatewayapi.AllowedRoutes{
+			Namespaces: &gatewayapi.RouteNamespaces{
+				From: &fromSame,
+			},
+		},
+	}
+	allNsListenerName = gatewayapi.SectionName("allNS")
+	allNsListener     = gatewayapi.Listener{
+		Name:     allNsListenerName,
+		Port:     gatewayapi.PortNumber(80),
+		Protocol: gatewayapi.HTTPProtocolType,
+		AllowedRoutes: &gatewayapi.AllowedRoutes{
+			Namespaces: &gatewayapi.RouteNamespaces{
+				From: &fromAll,
+			},
+		},
+	}
+	gatewayClass = &gatewayapi.GatewayClass{
+		ObjectMeta: kube_meta.ObjectMeta{
+			Name: "kuma",
+		},
+		Spec: gatewayapi.GatewayClassSpec{
+			ControllerName: common.ControllerName,
+		},
+	}
+	gateway = &gatewayapi.Gateway{
+		ObjectMeta: kube_meta.ObjectMeta{
+			Name:      "gateway",
+			Namespace: defaultNs,
+		},
+		Spec: gatewayapi.GatewaySpec{
+			GatewayClassName: "kuma",
+			Listeners: []gatewayapi.Listener{
+				simpleListener,
+			},
+		},
+		Status: gatewayapi.GatewayStatus{
+			Listeners: []gatewayapi.ListenerStatus{
+				{
+					Name:       simpleListenerName,
+					Conditions: listenerReady,
+				},
+			},
+		},
+	}
+	gatewayRef = gatewayapi.ParentRef{
+		Group: &gatewayGroup,
+		Kind:  &gatewayKind,
+	}
+
+	gatewayMultipleListeners = &gatewayapi.Gateway{
+		ObjectMeta: kube_meta.ObjectMeta{
+			Name:      "multigateway",
+			Namespace: defaultNs,
+		},
+		Spec: gatewayapi.GatewaySpec{
+			GatewayClassName: "kuma",
+			Listeners: []gatewayapi.Listener{
+				simpleListener,
+				allNsListener,
+			},
+		},
+		Status: gatewayapi.GatewayStatus{
+			Listeners: []gatewayapi.ListenerStatus{
+				{
+					Name:       simpleListenerName,
+					Conditions: listenerReady,
+				},
+				{
+					Name:       allNsListenerName,
+					Conditions: listenerReady,
+				},
+			},
+		},
+	}
+
+	defaultRouteNs = &kube_core.Namespace{
+		ObjectMeta: kube_meta.ObjectMeta{
+			Name: defaultNs,
+		},
+	}
+	otherRouteNs = &kube_core.Namespace{
+		ObjectMeta: kube_meta.ObjectMeta{
+			Name: otherNs,
+		},
+	}
+)


### PR DESCRIPTION
### Summary

This PR enforces the `AllowedRoutes` field on `Gateway` `Listeners` and sets the status accordingly on `HTTPRoute` `RouteParentStatus`.

Closes #3624 

~Blocked by https://github.com/kumahq/kuma/pull/3709~

### Testing

- [x] Unit tests
- [x] Manual testing on Kubernetes
