### PR TITLE
refactor(k8s): remove GetBool method and use GetEnabled

### DIFF
--- a/pkg/plugins/runtime/k8s/controllers/pod_controller.go
+++ b/pkg/plugins/runtime/k8s/controllers/pod_controller.go
@@ -109,7 +109,7 @@ func (r *PodReconciler) Reconcile(ctx context.Context, req kube_ctrl.Request) (k
 	}
 
 	// only Pods with injected Kuma need a Dataplane descriptor
-	injected, exist, err := metadata.Annotations(pod.Annotations).GetBool(metadata.KumaSidecarInjectedAnnotation)
+	injected, exist, err := metadata.Annotations(pod.Annotations).GetEnabled(metadata.KumaSidecarInjectedAnnotation)
 	if err != nil {
 		return kube_ctrl.Result{}, err
 	}

--- a/pkg/plugins/runtime/k8s/controllers/service_controller.go
+++ b/pkg/plugins/runtime/k8s/controllers/service_controller.go
@@ -59,7 +59,7 @@ func (r *ServiceReconciler) Reconcile(ctx context.Context, req kube_ctrl.Request
 	if annotations == nil {
 		annotations = metadata.Annotations{}
 	}
-	ignored, _, err := annotations.GetBool(metadata.KumaIgnoreAnnotation)
+	ignored, _, err := annotations.GetEnabled(metadata.KumaIgnoreAnnotation)
 	if err != nil {
 		return kube_ctrl.Result{}, errors.Wrapf(err, "unable to retrieve %s annotation for %s", metadata.KumaIgnoreAnnotation, svc.Name)
 	}

--- a/pkg/plugins/runtime/k8s/metadata/annotations.go
+++ b/pkg/plugins/runtime/k8s/metadata/annotations.go
@@ -117,7 +117,7 @@ func (a Annotations) GetEnabled(key string) (bool, bool, error) {
 	case AnnotationDisabled, AnnotationFalse:
 		return false, true, nil
 	default:
-		return false, true, errors.Errorf("annotation \"%s\" has wrong value \"%s\", available values are: \"enabled\", \"disabled\"", key, value)
+		return false, true, errors.Errorf("annotation \"%s\" has wrong value \"%s\"", key, value)
 	}
 }
 
@@ -139,18 +139,6 @@ func (a Annotations) GetString(key string) (string, bool) {
 		return "", false
 	}
 	return value, true
-}
-
-func (a Annotations) GetBool(key string) (bool, bool, error) {
-	value, ok := a[key]
-	if !ok {
-		return false, false, nil
-	}
-	b, err := strconv.ParseBool(value)
-	if err != nil {
-		return false, false, errors.Errorf("failed to parse annotation %q: %s", key, err.Error())
-	}
-	return b, true, nil
 }
 
 // GetMap returns map from annotation. Example: "kuma.io/sidecar-env-vars: TEST1=1;TEST2=2"

--- a/pkg/plugins/runtime/k8s/metadata/annotations_test.go
+++ b/pkg/plugins/runtime/k8s/metadata/annotations_test.go
@@ -2,6 +2,7 @@ package metadata_test
 
 import (
 	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
 
 	"github.com/kumahq/kuma/pkg/plugins/runtime/k8s/metadata"
@@ -10,33 +11,39 @@ import (
 var _ = Describe("Kubernetes Annotations", func() {
 
 	Describe("GetEnabled()", func() {
-		It("should parse value to bool", func() {
-			annotations := map[string]string{
-				"key1": "enabled",
-				"key2": "disabled",
-				"key3": "true",
-				"key4": "false",
-			}
-			enabled, exist, err := metadata.Annotations(annotations).GetEnabled("key1")
+		type testCase struct {
+			input    string
+			expected bool
+		}
+		annotations := map[string]string{
+			"key1": "enabled",
+			"key2": "disabled",
+			"key3": "true",
+			"key4": "false",
+		}
+		DescribeTable("should parse value to bool", func(given testCase) {
+			enabled, exist, err := metadata.Annotations(annotations).GetEnabled(given.input)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(enabled).To(BeTrue())
+			Expect(enabled).To(Equal(given.expected))
 			Expect(exist).To(BeTrue())
-
-			enabled, exist, err = metadata.Annotations(annotations).GetEnabled("key2")
-			Expect(err).ToNot(HaveOccurred())
-			Expect(enabled).To(BeFalse())
-			Expect(exist).To(BeTrue())
-
-			val, exist, err := metadata.Annotations(annotations).GetEnabled("key3")
-			Expect(err).ToNot(HaveOccurred())
-			Expect(val).To(BeTrue())
-			Expect(exist).To(BeTrue())
-
-			val, exist, err = metadata.Annotations(annotations).GetEnabled("key4")
-			Expect(err).ToNot(HaveOccurred())
-			Expect(val).To(BeFalse())
-			Expect(exist).To(BeTrue())
-		})
+		},
+			Entry("enabled", testCase{
+				input:    "key1",
+				expected: true,
+			}),
+			Entry("disabled", testCase{
+				input:    "key2",
+				expected: false,
+			}),
+			Entry("true", testCase{
+				input:    "key3",
+				expected: true,
+			}),
+			Entry("false", testCase{
+				input:    "key4",
+				expected: false,
+			}),
+		)
 
 		It("should return error if value is wrong", func() {
 			annotations := map[string]string{

--- a/pkg/plugins/runtime/k8s/metadata/annotations_test.go
+++ b/pkg/plugins/runtime/k8s/metadata/annotations_test.go
@@ -9,11 +9,13 @@ import (
 
 var _ = Describe("Kubernetes Annotations", func() {
 
-	Context("GetEnabled()", func() {
+	Describe("GetEnabled()", func() {
 		It("should parse value to bool", func() {
 			annotations := map[string]string{
 				"key1": "enabled",
 				"key2": "disabled",
+				"key3": "true",
+				"key4": "false",
 			}
 			enabled, exist, err := metadata.Annotations(annotations).GetEnabled("key1")
 			Expect(err).ToNot(HaveOccurred())
@@ -24,6 +26,16 @@ var _ = Describe("Kubernetes Annotations", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(enabled).To(BeFalse())
 			Expect(exist).To(BeTrue())
+
+			val, exist, err := metadata.Annotations(annotations).GetEnabled("key3")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(val).To(BeTrue())
+			Expect(exist).To(BeTrue())
+
+			val, exist, err = metadata.Annotations(annotations).GetEnabled("key4")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(val).To(BeFalse())
+			Expect(exist).To(BeTrue())
 		})
 
 		It("should return error if value is wrong", func() {
@@ -32,7 +44,7 @@ var _ = Describe("Kubernetes Annotations", func() {
 			}
 			enabled, exist, err := metadata.Annotations(annotations).GetEnabled("key1")
 			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("annotation \"key1\" has wrong value \"not-enabled-at-all\", available values are: \"enabled\", \"disabled\""))
+			Expect(err.Error()).To(ContainSubstring("annotation \"key1\" has wrong value \"not-enabled-at-all\""))
 			Expect(enabled).To(BeFalse())
 			Expect(exist).To(BeTrue())
 		})
@@ -58,28 +70,6 @@ var _ = Describe("Kubernetes Annotations", func() {
 
 			_, _, err := metadata.Annotations(annotations).GetUint32("key1")
 			Expect(err.Error()).To(ContainSubstring("failed to parse annotation \"key1\": strconv.ParseUint: parsing \"dummy\": invalid syntax"))
-		})
-	})
-
-	Context("GetBool()", func() {
-		It("should parse value to bool", func() {
-			annotations := map[string]string{
-				"key1": "true",
-			}
-
-			val, hasKey, err := metadata.Annotations(annotations).GetBool("key1")
-			Expect(err).ToNot(HaveOccurred())
-			Expect(hasKey).To(Equal(true))
-			Expect(val).To(Equal(true))
-		})
-
-		It("should return error if value has wrong format", func() {
-			annotations := map[string]string{
-				"key1": "dummy",
-			}
-
-			_, _, err := metadata.Annotations(annotations).GetBool("key1")
-			Expect(err.Error()).To(ContainSubstring("failed to parse annotation \"key1\": strconv.ParseBool: parsing \"dummy\": invalid syntax"))
 		})
 	})
 

--- a/pkg/plugins/runtime/k8s/util/util.go
+++ b/pkg/plugins/runtime/k8s/util/util.go
@@ -46,7 +46,7 @@ func Ignored() ServicePredicate {
 		if svc.Annotations == nil {
 			return false
 		}
-		ignore, _, _ := metadata.Annotations(svc.Annotations).GetBool(metadata.KumaIgnoreAnnotation)
+		ignore, _, _ := metadata.Annotations(svc.Annotations).GetEnabled(metadata.KumaIgnoreAnnotation)
 		return ignore
 	}
 }


### PR DESCRIPTION
### Summary

This PR removed the `GetBool method` and uses `GetEnabled` as a replacement.

P.S - (50th PR 😄)

### Full changelog

* [Implement ...]
* [Fix ...]

### Issues resolved

Fix #2338

### Documentation

- [ ] Link to the website [documentation PR](https://github.com/kumahq/kuma-website/pull/XXX)

### Testing

- [ ] Unit tests
- [ ] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes

### Backwards compatibility

- [ ] Update [`UPGRADE.md`](/UPGRADE.md) with any steps users will need to take when upgrading.
- [ ] Add `backport-to-stable` label if the code follows our [backporting policy](/CONTRIBUTING.md#backporting)
