### PR TITLE
feat(gateway): reconcile relevant HTTPRoutes when Gateways change

### DIFF
--- a/pkg/plugins/runtime/k8s/controllers/gatewayapi/http_route_controller.go
+++ b/pkg/plugins/runtime/k8s/controllers/gatewayapi/http_route_controller.go
@@ -11,6 +11,9 @@ import (
 	kube_types "k8s.io/apimachinery/pkg/types"
 	kube_ctrl "sigs.k8s.io/controller-runtime"
 	kube_client "sigs.k8s.io/controller-runtime/pkg/client"
+	kube_handler "sigs.k8s.io/controller-runtime/pkg/handler"
+	kube_reconcile "sigs.k8s.io/controller-runtime/pkg/reconcile"
+	kube_source "sigs.k8s.io/controller-runtime/pkg/source"
 	gatewayapi "sigs.k8s.io/gateway-api/apis/v1alpha2"
 
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
@@ -164,8 +167,61 @@ func (r *HTTPRouteReconciler) shouldHandleParentRef(
 	return class.Spec.ControllerName == controllerName, nil
 }
 
+// routesForGateway returns a function that calculates which routes might
+// be affected by changes in a Gateway so they can be reconciled.
+func routesForGateway(l logr.Logger, client kube_client.Client) kube_handler.MapFunc {
+	l = l.WithName("routesForGateway")
+
+	return func(obj kube_client.Object) []kube_reconcile.Request {
+		gateway, ok := obj.(*gatewayapi.Gateway)
+		if !ok {
+			l.Error(nil, "unexpected error converting to be mapped %T object to Gateway", obj)
+			return nil
+		}
+
+		var routes gatewayapi.HTTPRouteList
+		if err := client.List(context.Background(), &routes); err != nil {
+			l.Error(err, "unexpected error listing HTTPRoutes in cluster")
+			return nil
+		}
+
+		var requests []kube_reconcile.Request
+		for _, route := range routes.Items {
+			for _, parentRef := range route.Spec.ParentRefs {
+				// We're looking at all HTTPRoutes, at some point one may
+				// reference a different kind of object.
+				matches := *parentRef.Group == gatewayapi.GroupName &&
+					*parentRef.Kind == "Gateway"
+
+				referencedNamespace := route.Namespace
+				if parentRef.Namespace != nil {
+					referencedNamespace = string(*parentRef.Namespace)
+				}
+
+				matches = matches &&
+					(referencedNamespace == gateway.Namespace) &&
+					(string(parentRef.Name) == gateway.Name)
+
+				// We don't care whether a specific listener is referenced
+
+				if matches {
+					requests = append(requests, kube_reconcile.Request{
+						NamespacedName: kube_client.ObjectKeyFromObject(&route),
+					})
+				}
+			}
+		}
+
+		return requests
+	}
+}
+
 func (r *HTTPRouteReconciler) SetupWithManager(mgr kube_ctrl.Manager) error {
 	return kube_ctrl.NewControllerManagedBy(mgr).
 		For(&gatewayapi.HTTPRoute{}).
+		Watches(
+			&kube_source.Kind{Type: &gatewayapi.Gateway{}},
+			kube_handler.EnqueueRequestsFromMapFunc(routesForGateway(r.Log, r.Client)),
+		).
 		Complete(r)
 }


### PR DESCRIPTION
### Summary

The motivation here is keeping the `HTTPRoute` object statuses up to date.