### PR TITLE
refactor(kuma-cp): unify mesh determination for k8s objects

### DIFF
--- a/pkg/plugins/runtime/k8s/controllers/gateway_converter.go
+++ b/pkg/plugins/runtime/k8s/controllers/gateway_converter.go
@@ -18,13 +18,13 @@ import (
 
 // createorUpdateBuiltinGatewayDataplane manages the dataplane for a pod
 // belonging to a built-in Kuma gateway.
-func (r *PodReconciler) createorUpdateBuiltinGatewayDataplane(ctx context.Context, pod *kube_core.Pod) error {
+func (r *PodReconciler) createorUpdateBuiltinGatewayDataplane(ctx context.Context, pod *kube_core.Pod, ns *kube_core.Namespace) error {
 	dataplane := &mesh_k8s.Dataplane{
 		ObjectMeta: kube_meta.ObjectMeta{
 			Namespace: pod.Namespace,
 			Name:      pod.Name,
 		},
-		Mesh: k8s_util.MeshFor(pod),
+		Mesh: k8s_util.MeshOf(pod, ns),
 	}
 
 	tagsAnnotation, ok := pod.Annotations[metadata.KumaTagsAnnotation]

--- a/pkg/plugins/runtime/k8s/controllers/gateway_instance_controller.go
+++ b/pkg/plugins/runtime/k8s/controllers/gateway_instance_controller.go
@@ -30,7 +30,7 @@ import (
 	"github.com/kumahq/kuma/pkg/plugins/runtime/k8s/containers"
 	ctrls_util "github.com/kumahq/kuma/pkg/plugins/runtime/k8s/controllers/util"
 	"github.com/kumahq/kuma/pkg/plugins/runtime/k8s/metadata"
-	util_k8s "github.com/kumahq/kuma/pkg/plugins/runtime/k8s/util"
+	k8s_util "github.com/kumahq/kuma/pkg/plugins/runtime/k8s/util"
 )
 
 // GatewayInstanceReconciler reconciles a GatewayInstance object.
@@ -168,7 +168,7 @@ func (r *GatewayInstanceReconciler) createOrUpdateDeployment(
 				deployment = obj.(*kube_apps.Deployment)
 			}
 
-			container, err := r.ProxyFactory.NewContainer(gatewayInstance.Annotations, &ns)
+			container, err := r.ProxyFactory.NewContainer(gatewayInstance, &ns)
 			if err != nil {
 				return nil, errors.Wrap(err, "unable to create gateway container")
 			}
@@ -177,7 +177,7 @@ func (r *GatewayInstanceReconciler) createOrUpdateDeployment(
 				container.Resources = *res
 			}
 
-			container.Name = util_k8s.KumaGatewayContainerName
+			container.Name = k8s_util.KumaGatewayContainerName
 
 			podSpec := kube_core.PodSpec{
 				Containers: []kube_core.Container{container},
@@ -191,7 +191,7 @@ func (r *GatewayInstanceReconciler) createOrUpdateDeployment(
 			annotations := map[string]string{
 				metadata.KumaGatewayAnnotation: metadata.AnnotationBuiltin,
 				metadata.KumaTagsAnnotation:    string(jsonTags),
-				metadata.KumaMeshAnnotation:    util_k8s.MeshFor(gatewayInstance),
+				metadata.KumaMeshAnnotation:    k8s_util.MeshOf(gatewayInstance, &ns),
 			}
 
 			labels := k8sSelector(gatewayInstance.Name)

--- a/pkg/plugins/runtime/k8s/controllers/pod_controller_test.go
+++ b/pkg/plugins/runtime/k8s/controllers/pod_controller_test.go
@@ -37,6 +37,11 @@ var _ = Describe("PodReconciler", func() {
 
 	BeforeEach(func() {
 		kubeClient = kube_client_fake.NewClientBuilder().WithScheme(k8sClientScheme).WithObjects(
+			&kube_core.Namespace{
+				ObjectMeta: kube_meta.ObjectMeta{
+					Name: "demo",
+				},
+			},
 			&kube_core.Pod{
 				ObjectMeta: kube_meta.ObjectMeta{
 					Namespace: "demo",

--- a/pkg/plugins/runtime/k8s/controllers/pod_converter.go
+++ b/pkg/plugins/runtime/k8s/controllers/pod_converter.go
@@ -32,11 +32,12 @@ func (p *PodConverter) PodToDataplane(
 	ctx context.Context,
 	dataplane *mesh_k8s.Dataplane,
 	pod *kube_core.Pod,
+	ns *kube_core.Namespace,
 	services []*kube_core.Service,
 	others []*mesh_k8s.Dataplane,
 ) error {
-	dataplane.Mesh = util_k8s.MeshFor(pod)
-	dataplaneProto, err := p.DataplaneFor(ctx, pod, services, others)
+	dataplane.Mesh = util_k8s.MeshOf(pod, ns)
+	dataplaneProto, err := p.dataplaneFor(ctx, pod, services, others)
 	if err != nil {
 		return err
 	}
@@ -54,7 +55,7 @@ func (p *PodConverter) PodToIngress(ctx context.Context, zoneIngress *mesh_k8s.Z
 	return nil
 }
 
-func (p *PodConverter) DataplaneFor(
+func (p *PodConverter) dataplaneFor(
 	ctx context.Context,
 	pod *kube_core.Pod,
 	services []*kube_core.Service,

--- a/pkg/plugins/runtime/k8s/controllers/pod_converter_test.go
+++ b/pkg/plugins/runtime/k8s/controllers/pod_converter_test.go
@@ -102,6 +102,12 @@ var _ = Describe("PodToDataplane(..)", func() {
 				Expect(err).ToNot(HaveOccurred())
 			}
 
+			namespace := kube_core.Namespace{
+				ObjectMeta: kube_meta.ObjectMeta{
+					Name: pod.Namespace,
+				},
+			}
+
 			// other services
 			var serviceGetter kube_client.Reader
 			if given.otherServices != "" {
@@ -133,7 +139,7 @@ var _ = Describe("PodToDataplane(..)", func() {
 
 			// when
 			dataplane := &mesh_k8s.Dataplane{}
-			err = converter.PodToDataplane(context.Background(), dataplane, pod, services, otherDataplanes)
+			err = converter.PodToDataplane(context.Background(), dataplane, pod, &namespace, services, otherDataplanes)
 
 			// then
 			Expect(err).ToNot(HaveOccurred())
@@ -322,13 +328,19 @@ var _ = Describe("PodToDataplane(..)", func() {
 				err := yaml.Unmarshal([]byte(given.pod), pod)
 				Expect(err).ToNot(HaveOccurred())
 
+				namespace := kube_core.Namespace{
+					ObjectMeta: kube_meta.ObjectMeta{
+						Name: pod.Namespace,
+					},
+				}
+
 				services, err := ParseServices(given.services)
 				Expect(err).ToNot(HaveOccurred())
 
 				dataplane := &mesh_k8s.Dataplane{}
 
 				// when
-				err = converter.PodToDataplane(context.Background(), dataplane, pod, services, nil)
+				err = converter.PodToDataplane(context.Background(), dataplane, pod, &namespace, services, nil)
 
 				// then
 				Expect(err).To(HaveOccurred())

--- a/pkg/plugins/runtime/k8s/util/util.go
+++ b/pkg/plugins/runtime/k8s/util/util.go
@@ -135,13 +135,17 @@ func CopyStringMap(in map[string]string) map[string]string {
 	return out
 }
 
-func MeshFor(obj kube_meta.Object) string {
-	mesh, exist := metadata.Annotations(obj.GetAnnotations()).GetString(metadata.KumaMeshAnnotation)
-	if !exist || mesh == "" {
-		return model.DefaultMesh
+// MeshOf returns the mesh of the given object according to its own annotations
+// or those of its namespace.
+func MeshOf(obj kube_meta.Object, namespace *kube_core.Namespace) string {
+	if mesh, exists := metadata.Annotations(obj.GetAnnotations()).GetString(metadata.KumaMeshAnnotation); exists && mesh != "" {
+		return mesh
+	}
+	if mesh, exists := metadata.Annotations(namespace.GetAnnotations()).GetString(metadata.KumaMeshAnnotation); exists && mesh != "" {
+		return mesh
 	}
 
-	return mesh
+	return model.DefaultMesh
 }
 
 // ServiceTagFor returns the canonical service name for a Kubernetes service,

--- a/pkg/plugins/runtime/k8s/util/util_test.go
+++ b/pkg/plugins/runtime/k8s/util/util_test.go
@@ -183,10 +183,11 @@ var _ = Describe("Util", func() {
 		),
 	)
 
-	Describe("MeshFor(..)", func() {
+	Describe("MeshOf(..)", func() {
 
 		type testCase struct {
 			podAnnotations map[string]string
+			nsAnnotations  map[string]string
 			expected       string
 		}
 
@@ -198,9 +199,14 @@ var _ = Describe("Util", func() {
 						Annotations: given.podAnnotations,
 					},
 				}
+				ns := &kube_core.Namespace{
+					ObjectMeta: kube_meta.ObjectMeta{
+						Annotations: given.nsAnnotations,
+					},
+				}
 
 				// then
-				Expect(util.MeshFor(pod)).To(Equal(given.expected))
+				Expect(util.MeshOf(pod, ns)).To(Equal(given.expected))
 			},
 			Entry("Pod without annotations", testCase{
 				podAnnotations: nil,
@@ -214,6 +220,15 @@ var _ = Describe("Util", func() {
 			}),
 			Entry("Pod with non-empty `kuma.io/mesh` annotation", testCase{
 				podAnnotations: map[string]string{
+					"kuma.io/mesh": "demo",
+				},
+				expected: "demo",
+			}),
+			Entry("Pod with empty `kuma.io/mesh` annotation, Namespace with annotation", testCase{
+				podAnnotations: map[string]string{
+					"kuma.io/mesh": "",
+				},
+				nsAnnotations: map[string]string{
 					"kuma.io/mesh": "demo",
 				},
 				expected: "demo",


### PR DESCRIPTION
### Summary

~I'm not yet quite sure if this change can break anything...~
In fact I think it fixes a bug when computing the mesh of pods when there's a mesh annotation on the Namespace.

### Issues resolved

Closes #3514 