### PR TITLE
refactor(gateway): use Patch to reconcile GatewayInstances's owned objects

### DIFF
--- a/pkg/plugins/runtime/k8s/controllers/gateway_instance_controller.go
+++ b/pkg/plugins/runtime/k8s/controllers/gateway_instance_controller.go
@@ -59,14 +59,14 @@ func (r *GatewayInstanceReconciler) Reconcile(ctx context.Context, req kube_ctrl
 
 	svc, err := r.createOrUpdateService(ctx, gatewayInstance)
 	if err != nil {
-		return kube_ctrl.Result{}, errors.Wrap(err, "unable to create Service for Gateway")
+		return kube_ctrl.Result{}, errors.Wrap(err, "unable to reconcile Service for Gateway")
 	}
 
 	var deployment *kube_apps.Deployment
 	if svc != nil {
 		deployment, err = r.createOrUpdateDeployment(ctx, gatewayInstance)
 		if err != nil {
-			return kube_ctrl.Result{}, errors.Wrap(err, "unable to create Deployment for Gateway")
+			return kube_ctrl.Result{}, errors.Wrap(err, "unable to reconcile Deployment for Gateway")
 		}
 	}
 
@@ -76,7 +76,7 @@ func (r *GatewayInstanceReconciler) Reconcile(ctx context.Context, req kube_ctrl
 		if kube_apierrs.IsNotFound(err) {
 			return kube_ctrl.Result{}, nil
 		}
-		return kube_ctrl.Result{}, errors.Wrap(err, "unable to update GatewayInstance status")
+		return kube_ctrl.Result{}, errors.Wrap(err, "unable to patch GatewayInstance status")
 	}
 
 	return kube_ctrl.Result{}, nil
@@ -134,7 +134,7 @@ func (r *GatewayInstanceReconciler) createOrUpdateService(
 		},
 	)
 	if err != nil {
-		return nil, errors.Wrap(err, "unable to create or update Service for GatewayInstance")
+		return nil, err
 	}
 
 	if obj == nil {
@@ -213,7 +213,7 @@ func (r *GatewayInstanceReconciler) createOrUpdateDeployment(
 		},
 	)
 	if err != nil {
-		return nil, errors.Wrap(err, "unable to create or update Service for GatewayInstance")
+		return nil, err
 	}
 
 	return obj.(*kube_apps.Deployment), nil

--- a/pkg/plugins/runtime/k8s/controllers/util/controlled.go
+++ b/pkg/plugins/runtime/k8s/controllers/util/controlled.go
@@ -62,6 +62,8 @@ func ManageControlledObject(
 			return nil, fmt.Errorf("expected runtime.Object to be client.Object")
 		}
 
+		original := item.DeepCopyObject().(kube_client.Object)
+
 		obj, err := mutate(item)
 		if err != nil {
 			return nil, errors.Wrap(err, "couldn't mutate object for update")
@@ -77,8 +79,8 @@ func ManageControlledObject(
 			return nil, errors.Wrap(err, "unable to set object's controller reference")
 		}
 
-		if err := client.Update(ctx, obj); err != nil {
-			return nil, errors.Wrap(err, "couldn't update object")
+		if err := client.Patch(ctx, obj, kube_client.MergeFrom(original)); err != nil {
+			return nil, errors.Wrap(err, "couldn't patch object")
 		}
 		return obj, nil
 	default:


### PR DESCRIPTION
### Summary

Reduces noisy error messages/unnecessary reconciliations.