### PR TITLE
fix(kuma-cp): fix missing label sidecar injection

### DIFF
--- a/app/kumactl/cmd/install/testdata/install-demo.defaults.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-demo.defaults.golden.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: kuma-demo
-  annotations:
+  labels:
     kuma.io/sidecar-injection: enabled
 ---
 apiVersion: v1

--- a/app/kumactl/cmd/install/testdata/install-demo.overrides.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-demo.overrides.golden.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: not-kuma-demo
-  annotations:
+  labels:
     kuma.io/sidecar-injection: enabled
 ---
 apiVersion: v1

--- a/app/kumactl/cmd/install/testdata/install-gateway-enterprise.defaults.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-gateway-enterprise.defaults.golden.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: kong-enterprise-gateway
-  annotations:
+  labels:
     kuma.io/sidecar-injection: enabled
 ---
 apiVersion: v1

--- a/app/kumactl/cmd/install/testdata/install-gateway-enterprise.overrides.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-gateway-enterprise.overrides.golden.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: notdefault
-  annotations:
+  labels:
     kuma.io/sidecar-injection: enabled
 ---
 apiVersion: v1

--- a/app/kumactl/cmd/install/testdata/install-gateway.defaults.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-gateway.defaults.golden.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: kuma-gateway
-  annotations:
+  labels:
     kuma.io/sidecar-injection: enabled
 ---
 apiVersion: v1

--- a/app/kumactl/cmd/install/testdata/install-gateway.overrides.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-gateway.overrides.golden.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: notdefault
-  annotations:
+  labels:
     kuma.io/sidecar-injection: enabled
 ---
 apiVersion: v1

--- a/app/kumactl/cmd/install/testdata/install-metrics.defaults.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-metrics.defaults.golden.yaml
@@ -4,8 +4,9 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: kuma-metrics
-  annotations:
+  labels:
     kuma.io/sidecar-injection: enabled
+  annotations:
     kuma.io/mesh: default
 ---
 apiVersion: policy/v1beta1
@@ -11944,7 +11945,7 @@ spec:
       labels:
         component: "node-exporter"
         app: prometheus
-      annotations:
+      labels:
         kuma.io/sidecar-injection: "disabled" # disabled for now, injecting DP crashes K8S cluster
     spec:
       serviceAccountName: prometheus-node-exporter

--- a/app/kumactl/cmd/install/testdata/install-metrics.no-grafana.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-metrics.no-grafana.golden.yaml
@@ -4,8 +4,9 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: kuma-metrics
-  annotations:
+  labels:
     kuma.io/sidecar-injection: enabled
+  annotations:
     kuma.io/mesh: default
 ---
 apiVersion: v1
@@ -766,7 +767,7 @@ spec:
       labels:
         component: "node-exporter"
         app: prometheus
-      annotations:
+      labels:
         kuma.io/sidecar-injection: "disabled" # disabled for now, injecting DP crashes K8S cluster
     spec:
       serviceAccountName: prometheus-node-exporter

--- a/app/kumactl/cmd/install/testdata/install-metrics.no-prometheus.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-metrics.no-prometheus.golden.yaml
@@ -4,8 +4,9 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: kuma-metrics
-  annotations:
+  labels:
     kuma.io/sidecar-injection: enabled
+  annotations:
     kuma.io/mesh: default
 ---
 apiVersion: policy/v1beta1

--- a/app/kumactl/cmd/install/testdata/install-metrics.overrides.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-metrics.overrides.golden.yaml
@@ -4,8 +4,9 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: kuma
-  annotations:
+  labels:
     kuma.io/sidecar-injection: enabled
+  annotations:
     kuma.io/mesh: mesh-1
 ---
 apiVersion: policy/v1beta1
@@ -11944,7 +11945,7 @@ spec:
       labels:
         component: "node-exporter"
         app: prometheus
-      annotations:
+      labels:
         kuma.io/sidecar-injection: "disabled" # disabled for now, injecting DP crashes K8S cluster
     spec:
       serviceAccountName: prometheus-node-exporter

--- a/app/kumactl/data/install/k8s/demo/demo.yaml
+++ b/app/kumactl/data/install/k8s/demo/demo.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: {{ .Namespace }}
-  annotations:
+  labels:
     kuma.io/sidecar-injection: enabled
 ---
 apiVersion: apps/v1

--- a/app/kumactl/data/install/k8s/gateway-kong-enterprise/kong-enterprise/kong-enterprise.yaml
+++ b/app/kumactl/data/install/k8s/gateway-kong-enterprise/kong-enterprise/kong-enterprise.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: {{ .Namespace }}
-  annotations:
+  labels:
     kuma.io/sidecar-injection: enabled
 ---
 apiVersion: apiextensions.k8s.io/v1

--- a/app/kumactl/data/install/k8s/gateway-kong/kong/kong.yaml
+++ b/app/kumactl/data/install/k8s/gateway-kong/kong/kong.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: {{ .Namespace }}
-  annotations:
+  labels:
     kuma.io/sidecar-injection: enabled
 ---
 apiVersion: apiextensions.k8s.io/v1

--- a/app/kumactl/data/install/k8s/metrics/namespace.yaml
+++ b/app/kumactl/data/install/k8s/metrics/namespace.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: {{ .Namespace }}
-  annotations:
+  labels:
     kuma.io/sidecar-injection: enabled
+  annotations:
     kuma.io/mesh: {{ .Mesh }}

--- a/app/kumactl/data/install/k8s/metrics/prometheus/node-exporter.yaml
+++ b/app/kumactl/data/install/k8s/metrics/prometheus/node-exporter.yaml
@@ -50,7 +50,7 @@ spec:
       labels:
         component: "node-exporter"
         app: prometheus
-      annotations:
+      labels:
         kuma.io/sidecar-injection: "disabled" # disabled for now, injecting DP crashes K8S cluster
     spec:
       serviceAccountName: prometheus-node-exporter

--- a/pkg/plugins/runtime/k8s/controllers/namespace_controller_test.go
+++ b/pkg/plugins/runtime/k8s/controllers/namespace_controller_test.go
@@ -31,7 +31,7 @@ var _ = Describe("NamespaceReconciler", func() {
 				ObjectMeta: kube_meta.ObjectMeta{
 					Name:      "non-system-ns-with-sidecar-injection",
 					Namespace: "non-system-ns-with-sidecar-injection",
-					Annotations: map[string]string{
+					Labels: map[string]string{
 						"kuma.io/sidecar-injection": "enabled",
 					},
 				},

--- a/pkg/plugins/runtime/k8s/controllers/service_controller_test.go
+++ b/pkg/plugins/runtime/k8s/controllers/service_controller_test.go
@@ -28,7 +28,7 @@ var _ = Describe("ServiceReconciler", func() {
 			&kube_core.Namespace{
 				ObjectMeta: kube_meta.ObjectMeta{
 					Name: "non-system-ns-with-sidecar-injection",
-					Annotations: map[string]string{
+					Labels: map[string]string{
 						metadata.KumaSidecarInjectionAnnotation: metadata.AnnotationEnabled,
 					},
 				},
@@ -36,7 +36,7 @@ var _ = Describe("ServiceReconciler", func() {
 			&kube_core.Namespace{
 				ObjectMeta: kube_meta.ObjectMeta{
 					Name: "non-system-ns-without-sidecar-injection",
-					Annotations: map[string]string{
+					Labels: map[string]string{
 						metadata.KumaIngressAnnotation: metadata.AnnotationEnabled,
 					},
 				},


### PR DESCRIPTION
### Summary

We can now use either labels or annotations for the kuma.io/sidecar-injected
annotation. We were missing the support for label in the service and namespace controllers.

We also switched the demo to use labels instead of annotations

### Documentation

- ~~[ ] Link to the website [documentation PR](https://github.com/kumahq/kuma-website/pull/XXX)~~

### Testing

- [x] Unit tests
- [ ] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes

### Backwards compatibility

- ~~[ ] Update [`UPGRADE.md`](/UPGRADE.md) with any steps users will need to take when upgrading.~~
- ~~[ ] Add `backport-to-stable` label if the code follows our [backporting policy](/CONTRIBUTING.md#backporting)~~
