### PR TITLE
chore(scripts) adjust run scripts to set experimental gateway flag

### DIFF
--- a/mk/run.mk
+++ b/mk/run.mk
@@ -29,6 +29,7 @@ run/universal/postgres: ## Dev: Run Control Plane locally in universal mode with
 	$(GO_RUN) ./app/kuma-cp/main.go migrate up --log-level=debug
 
 	KUMA_ENVIRONMENT=universal \
+	KUMA_EXPERIMENTAL_GATEWAY=true \
 	KUMA_STORE_TYPE=postgres \
 	KUMA_STORE_POSTGRES_HOST=localhost \
 	KUMA_STORE_POSTGRES_PORT=15432 \
@@ -61,6 +62,7 @@ config_dump/example/envoy: ## Dev: Dump effective configuration of example Envoy
 run/universal/memory: ## Dev: Run Control Plane locally in universal mode with in-memory store
 	KUMA_ENVIRONMENT=universal \
 	KUMA_STORE_TYPE=memory \
+	KUMA_EXPERIMENTAL_GATEWAY=true \
 	$(GO_RUN) ./app/kuma-cp/main.go run --log-level=debug
 
 .PHONY: start/postgres


### PR DESCRIPTION
Signed-off-by: Tomasz Wylężek <tomwylezek@gmail.com>

### Summary

Adjust running script with experimental flag set to true
### Full changelog

- Change `make run/universal/memory` & `make run/universal/postgres` to have flag `KUMA_EXPERIMENTAL_GATEWAY` set to true

### Issues resolved

Fix #XXX

### Documentation

- [ ] Link to the website [documentation PR](https://github.com/kumahq/kuma-website/pull/XXX)

### Testing

- [ ] Unit tests
- [ ] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes

### Backwards compatibility

- [ ] Update [`UPGRADE.md`](/UPGRADE.md) with any steps users will need to take when upgrading.
- [ ] Add `backport-to-stable` label if the code follows our [backporting policy](/CONTRIBUTING.md#backporting)
