### PR TITLE
feat(helm): add imagePullSecrets support

### DIFF
--- a/deployments/charts/README.md
+++ b/deployments/charts/README.md
@@ -4,4 +4,3 @@ In addition to the `kumactl install` command, Kuma offers a set of Helm charts t
 Kuma on Kubernetes.
 
 These charts are compatible with Helm 3+.
-

--- a/deployments/charts/kuma/README.md
+++ b/deployments/charts/kuma/README.md
@@ -12,10 +12,10 @@ A Helm chart for the Kuma Control Plane
 |-----|------|---------|-------------|
 | global.image.registry | string | `"docker.io/kumahq"` | Default registry for all Kuma Images |
 | global.image.tag | string | `nil` | The default tag for all Kuma images, which itself defaults to .Chart.AppVersion |
-| global.imagePullSecrets | list | `[]` | `imagePullSecrets` that should be added to all Kuma component Service Accounts |
+| global.imagePullSecrets | list | `[]` | Add `imagePullSecrets` to all the service accounts used for Kuma components |
 | patchSystemNamespace | bool | `true` | Whether to patch the target namespace with the system label |
 | installCrdsOnUpgrade.enabled | bool | `true` | Whether or not install new CRDs before upgrade (if any were introduced with the new version of Kuma) |
-| installCrdsOnUpgrade.imagePullSecrets | list | `[]` | `imagePullSecrets` that should be added to the Service Account for installing new CRDs (*deprecated* - Use .global.imagePullSecrets instead) |
+| installCrdsOnUpgrade.imagePullSecrets | list | `[]` | The `imagePullSecrets` to attach to the Service Account running CRD installation.  This field will be deprecated in a future release, please use .global.imagePullSecrets |
 | controlPlane.logLevel | string | `"info"` | Kuma CP log level: one of off,info,debug |
 | controlPlane.mode | string | `"standalone"` | Kuma CP modes: one of standalone,zone,global |
 | controlPlane.zone | string | `nil` | Kuma CP zone, if running multizone |
@@ -38,7 +38,7 @@ A Helm chart for the Kuma Control Plane
 | controlPlane.globalZoneSyncService.annotations | object | `{}` | Additional annotations to put on the Global Zone Sync Service |
 | controlPlane.globalZoneSyncService.port | int | `5685` | Port on which Global Zone Sync Service is exposed |
 | controlPlane.defaults.skipMeshCreation | bool | `false` | Whether to skip creating the default Mesh |
-| controlPlane.resources | string | `nil` | Optionally override the resource spec |
+| controlPlane.resources | string | the resources will be chosen based on the mode | Optionally override the resource spec |
 | controlPlane.tls.general.secretName | string | `""` | Secret that contains tls.crt, tls.key [and ca.crt when no controlPlane.tls.general.caSecretName specified] for protecting Kuma in-cluster communication |
 | controlPlane.tls.general.caSecretName | string | `""` | Secret that contains ca.crt that was used to sign cert for protecting Kuma in-cluster communication (ca.crt present in this secret have precedence over the one provided in the controlPlane.tls.general.secretName) |
 | controlPlane.tls.general.caBundle | string | `""` | Base64 encoded CA certificate (the same as in controlPlane.tls.general.secret#ca.crt) |

--- a/deployments/charts/kuma/README.md
+++ b/deployments/charts/kuma/README.md
@@ -15,7 +15,7 @@ A Helm chart for the Kuma Control Plane
 | global.imagePullSecrets | list | `[]` | Add `imagePullSecrets` to all the service accounts used for Kuma components |
 | patchSystemNamespace | bool | `true` | Whether to patch the target namespace with the system label |
 | installCrdsOnUpgrade.enabled | bool | `true` | Whether or not install new CRDs before upgrade (if any were introduced with the new version of Kuma) |
-| installCrdsOnUpgrade.imagePullSecrets | list | `[]` | The `imagePullSecrets` to attach to the Service Account running CRD installation.  This field will be deprecated in a future release, please use .global.imagePullSecrets |
+| installCrdsOnUpgrade.imagePullSecrets | list | `[]` | The `imagePullSecrets` to attach to the Service Account running CRD installation. This field will be deprecated in a future release, please use .global.imagePullSecrets |
 | controlPlane.logLevel | string | `"info"` | Kuma CP log level: one of off,info,debug |
 | controlPlane.mode | string | `"standalone"` | Kuma CP modes: one of standalone,zone,global |
 | controlPlane.zone | string | `nil` | Kuma CP zone, if running multizone |
@@ -38,7 +38,7 @@ A Helm chart for the Kuma Control Plane
 | controlPlane.globalZoneSyncService.annotations | object | `{}` | Additional annotations to put on the Global Zone Sync Service |
 | controlPlane.globalZoneSyncService.port | int | `5685` | Port on which Global Zone Sync Service is exposed |
 | controlPlane.defaults.skipMeshCreation | bool | `false` | Whether to skip creating the default Mesh |
-| controlPlane.resources | string | the resources will be chosen based on the mode | Optionally override the resource spec |
+| controlPlane.resources | string | `nil` | Optionally override the resource spec |
 | controlPlane.tls.general.secretName | string | `""` | Secret that contains tls.crt, tls.key [and ca.crt when no controlPlane.tls.general.caSecretName specified] for protecting Kuma in-cluster communication |
 | controlPlane.tls.general.caSecretName | string | `""` | Secret that contains ca.crt that was used to sign cert for protecting Kuma in-cluster communication (ca.crt present in this secret have precedence over the one provided in the controlPlane.tls.general.secretName) |
 | controlPlane.tls.general.caBundle | string | `""` | Base64 encoded CA certificate (the same as in controlPlane.tls.general.secret#ca.crt) |

--- a/deployments/charts/kuma/README.md
+++ b/deployments/charts/kuma/README.md
@@ -12,8 +12,10 @@ A Helm chart for the Kuma Control Plane
 |-----|------|---------|-------------|
 | global.image.registry | string | `"docker.io/kumahq"` | Default registry for all Kuma Images |
 | global.image.tag | string | `nil` | The default tag for all Kuma images, which itself defaults to .Chart.AppVersion |
+| global.imagePullSecrets | list | `[]` | `imagePullSecrets` that should be added to all Kuma component Service Accounts |
 | patchSystemNamespace | bool | `true` | Whether to patch the target namespace with the system label |
-| installCrdsOnUpgrade | object | `{"enabled":true,"imagePullSecrets":[]}` | Whether ot not install new CRDs before upgrade  (if any were introduced    with the new version of Kuma) |
+| installCrdsOnUpgrade.enabled | bool | `true` | Whether or not install new CRDs before upgrade (if any were introduced with the new version of Kuma) |
+| installCrdsOnUpgrade.imagePullSecrets | list | `[]` | `imagePullSecrets` that should be added to the Service Account for installing new CRDs (*deprecated* - Use .global.imagePullSecrets instead) |
 | controlPlane.logLevel | string | `"info"` | Kuma CP log level: one of off,info,debug |
 | controlPlane.mode | string | `"standalone"` | Kuma CP modes: one of standalone,zone,global |
 | controlPlane.zone | string | `nil` | Kuma CP zone, if running multizone |

--- a/deployments/charts/kuma/templates/cni-rbac.yaml
+++ b/deployments/charts/kuma/templates/cni-rbac.yaml
@@ -6,6 +6,12 @@ metadata:
   namespace: kube-system
   labels:
   {{ include "kuma.cniLabels" . | nindent 4 }}
+{{- with .Values.global.imagePullSecrets }}
+imagePullSecrets:
+  {{- range . }}
+  - name: {{ . | quote }}
+  {{- end }}
+{{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/deployments/charts/kuma/templates/cp-rbac.yaml
+++ b/deployments/charts/kuma/templates/cp-rbac.yaml
@@ -5,6 +5,12 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
   {{- include "kuma.labels" . | nindent 4 }}
+{{- with .Values.global.imagePullSecrets }}
+imagePullSecrets:
+  {{- range . }}
+  - name: {{ . | quote }}
+  {{- end }}
+{{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/deployments/charts/kuma/templates/ingress-rbac.yaml
+++ b/deployments/charts/kuma/templates/ingress-rbac.yaml
@@ -6,4 +6,10 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
   {{- include "kuma.labels" . | nindent 4 }}
+{{- with .Values.global.imagePullSecrets }}
+imagePullSecrets:
+  {{- range . }}
+  - name: {{ . | quote }}
+  {{- end }}
+{{- end }}
 {{- end }}

--- a/deployments/charts/kuma/templates/pre-delete-webhooks.yaml
+++ b/deployments/charts/kuma/templates/pre-delete-webhooks.yaml
@@ -12,6 +12,12 @@ metadata:
     "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded,hook-failed"
   labels:
   {{- include "kuma.labels" . | nindent 4 }}
+{{- with .Values.global.imagePullSecrets }}
+imagePullSecrets:
+  {{- range . }}
+  - name: {{ . | quote }}
+  {{- end }}
+{{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/deployments/charts/kuma/templates/pre-install-patch-namespace-job.yaml
+++ b/deployments/charts/kuma/templates/pre-install-patch-namespace-job.yaml
@@ -10,6 +10,12 @@ metadata:
     "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded,hook-failed"
   labels:
   {{- include "kuma.labels" . | nindent 4 }}
+{{- with .Values.global.imagePullSecrets }}
+imagePullSecrets:
+  {{- range . }}
+  - name: {{ . | quote }}
+  {{- end }}
+{{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/deployments/charts/kuma/templates/pre-upgrade-install-missing-crds-job.yaml
+++ b/deployments/charts/kuma/templates/pre-upgrade-install-missing-crds-job.yaml
@@ -10,7 +10,7 @@ metadata:
     "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded,hook-failed"
   labels:
   {{- include "kuma.labels" . | nindent 4 }}
-{{- with .Values.installCrdsOnUpgrade.imagePullSecrets }}
+{{- with concat .Values.installCrdsOnUpgrade.imagePullSecrets .Values.global.imagePullSecrets | uniq }}
 imagePullSecrets:
   {{- range . }}
   - name: {{ . | quote }}

--- a/deployments/charts/kuma/values.yaml
+++ b/deployments/charts/kuma/values.yaml
@@ -4,18 +4,18 @@ global:
     registry: "docker.io/kumahq"
     # -- The default tag for all Kuma images, which itself defaults to .Chart.AppVersion
     tag:
-  # -- Add imagePullSecrets to all the service accounts used for Kuma components
-  imagePullSecrets: [ ]
+  # -- Add `imagePullSecrets` to all the service accounts used for Kuma components
+  imagePullSecrets: []
 
 # -- Whether to patch the target namespace with the system label
 patchSystemNamespace: true
 
-# -- Whether ot not install new CRDs before upgrade  (if any were introduced
-#    with the new version of Kuma)
 installCrdsOnUpgrade:
+  # -- Whether or not install new CRDs before upgrade (if any were introduced with the new version of Kuma)
   enabled: true
-  # -- This field will be deprecated in a future release, please use .global.imagePullSecrets
-  imagePullSecrets: [ ]
+  # -- The `imagePullSecrets` to attach to the Service Account running CRD installation.
+  # This field will be deprecated in a future release, please use .global.imagePullSecrets
+  imagePullSecrets: []
 
 controlPlane:
   # -- Kuma CP log level: one of off,info,debug

--- a/deployments/charts/kuma/values.yaml
+++ b/deployments/charts/kuma/values.yaml
@@ -4,6 +4,8 @@ global:
     registry: "docker.io/kumahq"
     # -- The default tag for all Kuma images, which itself defaults to .Chart.AppVersion
     tag:
+  # -- Add imagePullSecrets to all the service accounts used for Kuma components
+  imagePullSecrets: [ ]
 
 # -- Whether to patch the target namespace with the system label
 patchSystemNamespace: true
@@ -12,6 +14,7 @@ patchSystemNamespace: true
 #    with the new version of Kuma)
 installCrdsOnUpgrade:
   enabled: true
+  # -- This field will be deprecated in a future release, please use .global.imagePullSecrets
   imagePullSecrets: [ ]
 
 controlPlane:


### PR DESCRIPTION
### Summary

This PR adds support to specify `imagePullSecrets`
for all Kuma component Service Accounts.

It also deprecates the individual `imagePullSecrets`
field for the CRD install job, maintaining backward
compatibility while instructing users to use the new
field.

### Issues resolved

Resolves #3751

Signed-off-by: John Harris <john.harris@konghq.com>