### PR TITLE
fix(gateway): don't replace Service spec in GatewayInstance controller

### DIFF
--- a/pkg/plugins/runtime/k8s/controllers/gateway_instance_controller.go
+++ b/pkg/plugins/runtime/k8s/controllers/gateway_instance_controller.go
@@ -131,11 +131,9 @@ func (r *GatewayInstanceReconciler) createOrUpdateService(
 				})
 			}
 
-			service.Spec = kube_core.ServiceSpec{
-				Selector: k8sSelector(gatewayInstance.Name),
-				Ports:    ports,
-				Type:     gatewayInstance.Spec.ServiceType,
-			}
+			service.Spec.Selector = k8sSelector(gatewayInstance.Name)
+			service.Spec.Ports = ports
+			service.Spec.Type = gatewayInstance.Spec.ServiceType
 
 			return service, nil
 		},


### PR DESCRIPTION
### Summary

The Patch created by ManageControlledObject from this function causes errors when reconciling as is.