### PR TITLE
feat(kuma-cp): support NodePort in GatewayInstance

### DIFF
--- a/pkg/plugins/runtime/k8s/controllers/gateway_instance_controller.go
+++ b/pkg/plugins/runtime/k8s/controllers/gateway_instance_controller.go
@@ -124,11 +124,15 @@ func (r *GatewayInstanceReconciler) createOrUpdateService(
 			var ports []kube_core.ServicePort
 
 			for _, listener := range gateway.Spec.GetConf().GetListeners() {
-				ports = append(ports, kube_core.ServicePort{
+				servicePort := kube_core.ServicePort{
 					Name:     strconv.Itoa(int(listener.Port)),
 					Protocol: kube_core.ProtocolTCP,
 					Port:     int32(listener.Port),
-				})
+				}
+				if gatewayInstance.Spec.ServiceType == kube_core.ServiceTypeNodePort {
+					servicePort.NodePort = int32(listener.Port)
+				}
+				ports = append(ports, servicePort)
 			}
 
 			service.Spec.Selector = k8sSelector(gatewayInstance.Name)

--- a/test/e2e/gateway/gateway_helm.go
+++ b/test/e2e/gateway/gateway_helm.go
@@ -105,8 +105,16 @@ spec:
 		Expect(err).ToNot(HaveOccurred())
 
 		Eventually(func(g Gomega) {
+			// given
+			address := "http://"+net.JoinHostPort("localhost", GatewayNodePort)
+			if Config.IPV6 {
+				// With IPV6, KIND forwards to the host but it works only on IPV6.
+				// Just localhost:30800 will resolve to 127.0.0.1:30800 therefore we need explicit IPV6
+				address = "http://"+net.JoinHostPort("::1", GatewayNodePort)
+			}
+
 			// when
-			req, err := http.NewRequest("GET", "http://"+net.JoinHostPort("localhost", GatewayNodePort), nil)
+			req, err := http.NewRequest("GET", address, nil)
 			g.Expect(err).ToNot(HaveOccurred())
 			req.Host = "example.kuma.io"
 			resp, err := http.DefaultClient.Do(req)

--- a/test/e2e/gateway/gateway_helm.go
+++ b/test/e2e/gateway/gateway_helm.go
@@ -2,20 +2,27 @@ package gateway
 
 import (
 	"fmt"
+	"net"
+	"net/http"
 	"strings"
 	"time"
 
-	"github.com/gruntwork-io/terratest/modules/k8s"
 	"github.com/gruntwork-io/terratest/modules/random"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
 	"github.com/kumahq/kuma/pkg/config/core"
 	. "github.com/kumahq/kuma/test/framework"
+	"github.com/kumahq/kuma/test/framework/deployments/testserver"
 )
 
 func GatewayHELM() {
 	var cluster Cluster
+
+	// We deploy GatewayInstance with Service of type NodePort and port 30080
+	// This will expose it on Kubernetes node, but the node is hidden in docker, so it has to be exposed further
+	// to the VM on which the test is run. In k3d.mk we explicitly expose a range of ports including this one.
+	const GatewayNodePort = "30080"
 
 	BeforeEach(func() {
 		cluster = NewK8sCluster(NewTestingT(), Kuma1, Silent).
@@ -29,6 +36,8 @@ func GatewayHELM() {
 				WithHelmOpt("experimental.gateway", "true"),
 				WithHelmReleaseName(fmt.Sprintf("kuma-%s", strings.ToLower(random.UniqueId()))),
 			)).
+			Install(NamespaceWithSidecarInjection(TestNamespace)).
+			Install(testserver.Install()).
 			Setup(cluster)
 		Expect(err).ToNot(HaveOccurred())
 	})
@@ -37,15 +46,25 @@ func GatewayHELM() {
 		if ShouldSkipCleanup() {
 			return
 		}
+		Expect(cluster.DeleteNamespace(TestNamespace)).To(Succeed())
 		Expect(cluster.DeleteKuma()).To(Succeed())
 		Expect(cluster.DismissCluster()).To(Succeed())
 	})
 
 	It("should check if Gateway CRD is installed", func() {
-		// when
-		Expect(k8s.KubectlApplyFromStringE(
-			cluster.GetTesting(),
-			cluster.GetKubectlOptions(TestNamespace), `
+		// given gateway with route to the deployed test server
+		err := NewClusterSetup().
+			Install(YamlK8s(`
+apiVersion: kuma.io/v1alpha1
+kind: GatewayInstance
+metadata:
+  name: edge-gateway
+spec:
+  replicas: 1
+  serviceType: NodePort
+  tags:
+    kuma.io/service: edge-gateway`)).
+			Install(YamlK8s(`
 apiVersion: kuma.io/v1alpha1
 kind: Gateway
 metadata:
@@ -57,17 +76,45 @@ spec:
       kuma.io/service: edge-gateway
   conf:
     listeners:
-    - port: 8080
+    - port: 30080
       protocol: HTTP
       hostname: example.kuma.io
       tags:
-        hostname: example.kuma.io
-`),
-		).To(Succeed())
+        hostname: example.kuma.io`)).
+			Install(YamlK8s(`
+apiVersion: kuma.io/v1alpha1
+kind: GatewayRoute
+metadata:
+  name: edge-gateway
+mesh: default
+spec:
+  selectors:
+  - match:
+      kuma.io/service: edge-gateway
+  conf:
+    http:
+      rules:
+      - matches:
+        - path:
+            match: PREFIX
+            value: /
+        backends:
+        - destination:
+            kuma.io/service: test-server_kuma-test_svc_80`)).
+			Setup(cluster)
+		Expect(err).ToNot(HaveOccurred())
 
-		// then
-		Expect(
-			cluster.GetKumactlOptions().KumactlList("gateways", "default"),
-		).To(ContainElement("edge-gateway"))
+		Eventually(func(g Gomega) {
+			// when
+			req, err := http.NewRequest("GET", "http://"+net.JoinHostPort("localhost", GatewayNodePort), nil)
+			g.Expect(err).ToNot(HaveOccurred())
+			req.Host = "example.kuma.io"
+			resp, err := http.DefaultClient.Do(req)
+
+			// then
+			g.Expect(err).ToNot(HaveOccurred())
+			defer resp.Body.Close()
+			g.Expect(resp.StatusCode).To(Equal(200))
+		}, "30s", "1s").Should(Succeed())
 	})
 }

--- a/test/e2e/gateway/gateway_helm.go
+++ b/test/e2e/gateway/gateway_helm.go
@@ -106,11 +106,11 @@ spec:
 
 		Eventually(func(g Gomega) {
 			// given
-			address := "http://"+net.JoinHostPort("localhost", GatewayNodePort)
+			address := "http://" + net.JoinHostPort("localhost", GatewayNodePort)
 			if Config.IPV6 {
 				// With IPV6, KIND forwards to the host but it works only on IPV6.
 				// Just localhost:30800 will resolve to 127.0.0.1:30800 therefore we need explicit IPV6
-				address = "http://"+net.JoinHostPort("::1", GatewayNodePort)
+				address = "http://" + net.JoinHostPort("::1", GatewayNodePort)
 			}
 
 			// when


### PR DESCRIPTION
### Summary

After discussion with @michaelbeaumont we figured out that the best way is to do 1:1 port to nodeport, so this PR implements this behavior.

### Issues resolved

Fix #3578

### Documentation

No docs for Gateway yet.

### Testing

- [ ] Unit tests
- [X] E2E tests
- [ ] Manual testing on Universal
- [X] Manual testing on Kubernetes

### Backwards compatibility

~- [ ] Update [`UPGRADE.md`](/UPGRADE.md) with any steps users will need to take when upgrading.~
~- [ ] Add `backport-to-stable` label if the code follows our [backporting policy](/CONTRIBUTING.md#backporting)~
