### PR TITLE
feat(kuma-cp): add service name to inspect API

### DIFF
--- a/pkg/api-server/inspect_endpoints.go
+++ b/pkg/api-server/inspect_endpoints.go
@@ -10,6 +10,7 @@ import (
 	system_proto "github.com/kumahq/kuma/api/system/v1alpha1"
 	api_server_types "github.com/kumahq/kuma/pkg/api-server/types"
 	kuma_cp "github.com/kumahq/kuma/pkg/config/app/kuma-cp"
+	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	core_model "github.com/kumahq/kuma/pkg/core/resources/model"
 	"github.com/kumahq/kuma/pkg/core/resources/model/rest"
 	"github.com/kumahq/kuma/pkg/core/resources/registry"
@@ -28,16 +29,16 @@ func (f fakeDataSourceLoader) Load(ctx context.Context, mesh string, source *sys
 	return []byte("secret"), nil
 }
 
-func getMatchedPolicies(cfg *kuma_cp.Config, meshContext xds_context.MeshContext, dataplaneKey core_model.ResourceKey) (*core_xds.MatchedPolicies, error) {
+func getMatchedPolicies(cfg *kuma_cp.Config, meshContext xds_context.MeshContext, dataplaneKey core_model.ResourceKey) (*core_xds.MatchedPolicies, *core_mesh.DataplaneResource, error) {
 	proxyBuilder := sync.DefaultDataplaneProxyBuilder(
 		&fakeDataSourceLoader{},
 		*cfg,
 		callbacks.NewDataplaneMetadataTracker(),
 		envoy.APIV3)
 	if proxy, err := proxyBuilder.Build(dataplaneKey, meshContext); err != nil {
-		return nil, err
+		return nil, nil, err
 	} else {
-		return &proxy.Policies, nil
+		return &proxy.Policies, proxy.Dataplane, nil
 	}
 }
 
@@ -76,13 +77,13 @@ func inspectDataplane(cfg *kuma_cp.Config, builder xds_context.MeshContextBuilde
 			return
 		}
 
-		matchedPolicies, err := getMatchedPolicies(cfg, meshContext, core_model.ResourceKey{Mesh: meshName, Name: dataplaneName})
+		matchedPolicies, dp, err := getMatchedPolicies(cfg, meshContext, core_model.ResourceKey{Mesh: meshName, Name: dataplaneName})
 		if err != nil {
 			rest_errors.HandleError(response, err, "Could not get MatchedPolicies")
 			return
 		}
 
-		entries := newDataplaneInspectResponse(matchedPolicies)
+		entries := newDataplaneInspectResponse(matchedPolicies, dp)
 		result := &api_server_types.DataplaneInspectEntryList{
 			Items: entries,
 			Total: uint32(len(entries)),
@@ -114,18 +115,19 @@ func inspectPolicies(
 
 		for _, dp := range meshContext.Resources.Dataplanes().Items {
 			dpKey := core_model.MetaToResourceKey(dp.GetMeta())
-			matchedPolicies, err := getMatchedPolicies(cfg, meshContext, dpKey)
+			matchedPolicies, _, err := getMatchedPolicies(cfg, meshContext, dpKey)
 			if err != nil {
 				rest_errors.HandleError(response, err, fmt.Sprintf("Could not get MatchedPolicies for %v", dpKey))
 				return
 			}
-			for policy, attachments := range core_xds.GroupByPolicy(matchedPolicies) {
+			for policy, attachments := range core_xds.GroupByPolicy(matchedPolicies, dp.Spec.Networking) {
 				if policy.Type == resType && policy.Key.Name == policyName && policy.Key.Mesh == meshName {
 					attachmentList := []api_server_types.AttachmentEntry{}
 					for _, attachment := range attachments {
 						attachmentList = append(attachmentList, api_server_types.AttachmentEntry{
-							Type: attachment.Type.String(),
-							Name: attachment.Name,
+							Type:    attachment.Type.String(),
+							Name:    attachment.Name,
+							Service: attachment.Service,
 						})
 					}
 					result.Items = append(result.Items, &api_server_types.PolicyInspectEntry{
@@ -148,8 +150,8 @@ func inspectPolicies(
 	}
 }
 
-func newDataplaneInspectResponse(matchedPolicies *core_xds.MatchedPolicies) []*api_server_types.DataplaneInspectEntry {
-	attachmentMap := core_xds.GroupByAttachment(matchedPolicies)
+func newDataplaneInspectResponse(matchedPolicies *core_xds.MatchedPolicies, dp *core_mesh.DataplaneResource) []*api_server_types.DataplaneInspectEntry {
+	attachmentMap := core_xds.GroupByAttachment(matchedPolicies, dp.Spec.Networking)
 
 	entries := make([]*api_server_types.DataplaneInspectEntry, 0, len(attachmentMap))
 	attachments := []core_xds.Attachment{}
@@ -162,8 +164,9 @@ func newDataplaneInspectResponse(matchedPolicies *core_xds.MatchedPolicies) []*a
 	for _, attachment := range attachments {
 		entry := &api_server_types.DataplaneInspectEntry{
 			AttachmentEntry: api_server_types.AttachmentEntry{
-				Type: attachment.Type.String(),
-				Name: attachment.Name,
+				Type:    attachment.Type.String(),
+				Name:    attachment.Name,
+				Service: attachment.Service,
 			},
 			MatchedPolicies: map[core_model.ResourceType][]*rest.Resource{},
 		}

--- a/pkg/api-server/testdata/inspect_changed_state_after.json
+++ b/pkg/api-server/testdata/inspect_changed_state_after.json
@@ -9,7 +9,8 @@
    "attachments": [
     {
      "type": "inbound",
-     "name": "192.168.0.1:80:81"
+     "name": "192.168.0.1:80:81",
+     "service": "redis"
     }
    ]
   }

--- a/pkg/api-server/testdata/inspect_changed_state_before.json
+++ b/pkg/api-server/testdata/inspect_changed_state_before.json
@@ -9,7 +9,8 @@
    "attachments": [
     {
      "type": "inbound",
-     "name": "192.168.0.1:80:81"
+     "name": "192.168.0.1:80:81",
+     "service": "backend"
     }
    ]
   },
@@ -21,7 +22,8 @@
    "attachments": [
     {
      "type": "inbound",
-     "name": "192.168.0.1:80:81"
+     "name": "192.168.0.1:80:81",
+     "service": "redis"
     }
    ]
   }

--- a/pkg/api-server/testdata/inspect_circuit-breaker.json
+++ b/pkg/api-server/testdata/inspect_circuit-breaker.json
@@ -9,11 +9,13 @@
    "attachments": [
     {
      "type": "service",
-     "name": "gateway"
+     "name": "gateway",
+     "service": "gateway"
     },
     {
      "type": "service",
-     "name": "redis"
+     "name": "redis",
+     "service": "redis"
     }
    ]
   },
@@ -25,7 +27,8 @@
    "attachments": [
     {
      "type": "service",
-     "name": "gateway"
+     "name": "gateway",
+     "service": "gateway"
     }
    ]
   }

--- a/pkg/api-server/testdata/inspect_dataplane.json
+++ b/pkg/api-server/testdata/inspect_dataplane.json
@@ -4,6 +4,7 @@
   {
    "type": "inbound",
    "name": "192.168.0.1:80:81",
+   "service": "backend",
    "matchedPolicies": {
     "FaultInjection": [
      {
@@ -91,6 +92,7 @@
   {
    "type": "outbound",
    "name": "192.168.0.2:8080",
+   "service": "web",
    "matchedPolicies": {
     "Timeout": [
      {
@@ -134,6 +136,7 @@
   {
    "type": "service",
    "name": "gateway",
+   "service": "gateway",
    "matchedPolicies": {
     "HealthCheck": [
      {
@@ -169,6 +172,7 @@
   {
    "type": "service",
    "name": "postgres",
+   "service": "postgres",
    "matchedPolicies": {
     "HealthCheck": [
      {
@@ -204,6 +208,7 @@
   {
    "type": "service",
    "name": "redis",
+   "service": "redis",
    "matchedPolicies": {
     "HealthCheck": [
      {
@@ -239,6 +244,7 @@
   {
    "type": "service",
    "name": "web",
+   "service": "web",
    "matchedPolicies": {
     "HealthCheck": [
      {

--- a/pkg/api-server/testdata/inspect_fault-injection.json
+++ b/pkg/api-server/testdata/inspect_fault-injection.json
@@ -9,11 +9,13 @@
    "attachments": [
     {
      "type": "inbound",
-     "name": "192.168.0.1:80:81"
+     "name": "192.168.0.1:80:81",
+     "service": "backend"
     },
     {
      "type": "inbound",
-     "name": "192.168.0.2:80:81"
+     "name": "192.168.0.2:80:81",
+     "service": "redis"
     }
    ]
   },
@@ -25,7 +27,8 @@
    "attachments": [
     {
      "type": "inbound",
-     "name": "192.168.0.1:80:81"
+     "name": "192.168.0.1:80:81",
+     "service": "gateway"
     }
    ]
   }

--- a/pkg/api-server/testdata/inspect_health-check.json
+++ b/pkg/api-server/testdata/inspect_health-check.json
@@ -9,11 +9,13 @@
    "attachments": [
     {
      "type": "service",
-     "name": "gateway"
+     "name": "gateway",
+     "service": "gateway"
     },
     {
      "type": "service",
-     "name": "redis"
+     "name": "redis",
+     "service": "redis"
     }
    ]
   },
@@ -25,7 +27,8 @@
    "attachments": [
     {
      "type": "service",
-     "name": "gateway"
+     "name": "gateway",
+     "service": "gateway"
     }
    ]
   }

--- a/pkg/api-server/testdata/inspect_rate-limit.json
+++ b/pkg/api-server/testdata/inspect_rate-limit.json
@@ -9,11 +9,13 @@
    "attachments": [
     {
      "type": "inbound",
-     "name": "192.168.0.1:80:81"
+     "name": "192.168.0.1:80:81",
+     "service": "gateway"
     },
     {
      "type": "outbound",
-     "name": "192.168.0.4:8080"
+     "name": "192.168.0.4:8080",
+     "service": "es"
     }
    ]
   }

--- a/pkg/api-server/testdata/inspect_retry.json
+++ b/pkg/api-server/testdata/inspect_retry.json
@@ -9,11 +9,13 @@
    "attachments": [
     {
      "type": "service",
-     "name": "gateway"
+     "name": "gateway",
+     "service": "gateway"
     },
     {
      "type": "service",
-     "name": "redis"
+     "name": "redis",
+     "service": "redis"
     }
    ]
   },
@@ -25,7 +27,8 @@
    "attachments": [
     {
      "type": "service",
-     "name": "gateway"
+     "name": "gateway",
+     "service": "gateway"
     }
    ]
   }

--- a/pkg/api-server/testdata/inspect_timeout.json
+++ b/pkg/api-server/testdata/inspect_timeout.json
@@ -9,11 +9,13 @@
    "attachments": [
     {
      "type": "outbound",
-     "name": "192.168.0.2:8080"
+     "name": "192.168.0.2:8080",
+     "service": "redis"
     },
     {
      "type": "outbound",
-     "name": "192.168.0.3:8080"
+     "name": "192.168.0.3:8080",
+     "service": "gateway"
     }
    ]
   },
@@ -25,7 +27,8 @@
    "attachments": [
     {
      "type": "outbound",
-     "name": "192.168.0.2:8080"
+     "name": "192.168.0.2:8080",
+     "service": "gateway"
     }
    ]
   }

--- a/pkg/api-server/testdata/inspect_traffic-log.json
+++ b/pkg/api-server/testdata/inspect_traffic-log.json
@@ -9,11 +9,13 @@
    "attachments": [
     {
      "type": "service",
-     "name": "gateway"
+     "name": "gateway",
+     "service": "gateway"
     },
     {
      "type": "service",
-     "name": "redis"
+     "name": "redis",
+     "service": "redis"
     }
    ]
   },
@@ -25,7 +27,8 @@
    "attachments": [
     {
      "type": "service",
-     "name": "gateway"
+     "name": "gateway",
+     "service": "gateway"
     }
    ]
   }

--- a/pkg/api-server/testdata/inspect_traffic-permission.json
+++ b/pkg/api-server/testdata/inspect_traffic-permission.json
@@ -9,7 +9,8 @@
    "attachments": [
     {
      "type": "inbound",
-     "name": "192.168.0.1:80:81"
+     "name": "192.168.0.1:80:81",
+     "service": "backend"
     }
    ]
   },
@@ -21,7 +22,8 @@
    "attachments": [
     {
      "type": "inbound",
-     "name": "192.168.0.1:80:81"
+     "name": "192.168.0.1:80:81",
+     "service": "redis"
     }
    ]
   },
@@ -33,7 +35,8 @@
    "attachments": [
     {
      "type": "inbound",
-     "name": "192.168.0.1:80:81"
+     "name": "192.168.0.1:80:81",
+     "service": "gateway"
     }
    ]
   }

--- a/pkg/api-server/testdata/inspect_traffic-route.json
+++ b/pkg/api-server/testdata/inspect_traffic-route.json
@@ -9,11 +9,13 @@
    "attachments": [
     {
      "type": "outbound",
-     "name": "192.168.0.2:8080"
+     "name": "192.168.0.2:8080",
+     "service": "redis"
     },
     {
      "type": "outbound",
-     "name": "192.168.0.4:8080"
+     "name": "192.168.0.4:8080",
+     "service": "web"
     }
    ]
   },
@@ -25,11 +27,13 @@
    "attachments": [
     {
      "type": "outbound",
-     "name": "192.168.0.2:8080"
+     "name": "192.168.0.2:8080",
+     "service": "gateway"
     },
     {
      "type": "outbound",
-     "name": "192.168.0.4:8080"
+     "name": "192.168.0.4:8080",
+     "service": "web"
     }
    ]
   }

--- a/pkg/api-server/testdata/inspect_traffic-trace.json
+++ b/pkg/api-server/testdata/inspect_traffic-trace.json
@@ -9,7 +9,8 @@
    "attachments": [
     {
      "type": "dataplane",
-     "name": ""
+     "name": "",
+     "service": ""
     }
    ]
   },
@@ -21,7 +22,8 @@
    "attachments": [
     {
      "type": "dataplane",
-     "name": ""
+     "name": "",
+     "service": ""
     }
    ]
   },
@@ -33,7 +35,8 @@
    "attachments": [
     {
      "type": "dataplane",
-     "name": ""
+     "name": "",
+     "service": ""
     }
    ]
   }

--- a/pkg/api-server/types/inspect.go
+++ b/pkg/api-server/types/inspect.go
@@ -10,8 +10,9 @@ import (
 )
 
 type AttachmentEntry struct {
-	Type string `json:"type"`
-	Name string `json:"name"`
+	Type    string `json:"type"`
+	Name    string `json:"name"`
+	Service string `json:"service"`
 }
 
 type ResourceKeyEntry struct {
@@ -54,6 +55,7 @@ func (rec *DataplaneInspectEntryReceiver) UnmarshalJSON(bytes []byte) error {
 	type intermediate struct {
 		Type            string                                        `json:"type"`
 		Name            string                                        `json:"name"`
+		Service         string                                        `json:"service"`
 		MatchedPolicies map[core_model.ResourceType][]json.RawMessage `json:"matchedPolicies"`
 	}
 	inter := &intermediate{}
@@ -63,6 +65,7 @@ func (rec *DataplaneInspectEntryReceiver) UnmarshalJSON(bytes []byte) error {
 	}
 	rec.Type = inter.Type
 	rec.Name = inter.Name
+	rec.Service = inter.Service
 	rec.MatchedPolicies = map[core_model.ResourceType][]*rest.Resource{}
 
 	for typ, rawList := range inter.MatchedPolicies {

--- a/pkg/api-server/types/inspect_test.go
+++ b/pkg/api-server/types/inspect_test.go
@@ -40,8 +40,9 @@ var _ = Describe("Marshal DataplaneInspectEntry", func() {
 		Entry("full example", testCase{
 			input: &types.DataplaneInspectEntry{
 				AttachmentEntry: types.AttachmentEntry{
-					Type: "inbound",
-					Name: "192.168.0.1:80",
+					Type:    "inbound",
+					Name:    "192.168.0.1:80",
+					Service: "web",
 				},
 				MatchedPolicies: map[model.ResourceType][]*rest.Resource{
 					core_mesh.TimeoutType: {
@@ -99,8 +100,9 @@ var _ = Describe("Unmarshal DataplaneInspectEntry", func() {
 			inputFile: "full_example.json",
 			output: &types.DataplaneInspectEntry{
 				AttachmentEntry: types.AttachmentEntry{
-					Type: "inbound",
-					Name: "192.168.0.1:80",
+					Type:    "inbound",
+					Name:    "192.168.0.1:80",
+					Service: "web",
 				},
 				MatchedPolicies: map[model.ResourceType][]*rest.Resource{
 					core_mesh.TimeoutType: {

--- a/pkg/api-server/types/testdata/empty.json
+++ b/pkg/api-server/types/testdata/empty.json
@@ -1,5 +1,6 @@
 {
   "type": "",
   "name": "",
+  "service": "",
   "matchedPolicies": null
 }

--- a/pkg/api-server/types/testdata/full_example.json
+++ b/pkg/api-server/types/testdata/full_example.json
@@ -1,6 +1,7 @@
 {
   "type": "inbound",
   "name": "192.168.0.1:80",
+  "service": "web",
   "matchedPolicies": {
     "Timeout": [
       {


### PR DESCRIPTION
### Summary

I tested the new policy matching visible in the GUI and it's great. However

![image](https://user-images.githubusercontent.com/5459824/151583428-f14c0149-68a1-4356-b883-08d53133271e.png)

Inbound / Outbound attachments are really cryptic to end-user. I added `service` field to the API, so we know which inbound/outbound is represented by which service. This way we can improve the GUI so instead of `240.0.0.0:80` we can say `240.0.0.0:80 (demo-app_kuma_svc_500)` or `demo-app_kuma_svc_500 (240.0.0.0:80)`

### Issues resolved

No issues reported.

### Documentation

- [ ] Link to the website [documentation PR](https://github.com/kumahq/kuma-website/pull/XXX)

### Testing

- [X] Unit tests
- [ ] E2E tests
- [X] Manual testing on Universal
- [ ] Manual testing on Kubernetes

### Backwards compatibility

~- [ ] Update [`UPGRADE.md`](/UPGRADE.md) with any steps users will need to take when upgrading.~
~- [ ] Add `backport-to-stable` label if the code follows our [backporting policy](/CONTRIBUTING.md#backporting)~
