### PR TITLE
chore(zone-ingress): delete deprecated env KUMA_DATAPLANE_ADMIN_PORT

### DIFF
--- a/app/kumactl/cmd/install/testdata/install-control-plane.with-ingress.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.with-ingress.golden.yaml
@@ -1614,8 +1614,6 @@ spec:
               value: /var/run/secrets/kuma.io/tls-cert/ca.crt
             - name: KUMA_DATAPLANE_NAME
               value: $(POD_NAME).$(POD_NAMESPACE)
-            - name: KUMA_DATAPLANE_ADMIN_PORT
-              value: "9901"
             - name: KUMA_DATAPLANE_DRAIN_TIME
               value: 60s
             - name: KUMA_DATAPLANE_RUNTIME_TOKEN_PATH

--- a/deployments/charts/kuma/templates/ingress-deployment.yaml
+++ b/deployments/charts/kuma/templates/ingress-deployment.yaml
@@ -71,8 +71,6 @@ spec:
               value: /var/run/secrets/kuma.io/tls-cert/ca.crt
             - name: KUMA_DATAPLANE_NAME
               value: $(POD_NAME).$(POD_NAMESPACE)
-            - name: KUMA_DATAPLANE_ADMIN_PORT
-              value: "9901"
             - name: KUMA_DATAPLANE_DRAIN_TIME
               value: {{ .Values.ingress.drainTime }}
             - name: KUMA_DATAPLANE_RUNTIME_TOKEN_PATH


### PR DESCRIPTION
### Summary

https://github.com/kumahq/kuma/pull/3739 deprecates `KUMA_DATAPLANE_ADMIN_PORT`, but `ingress-deployment.yaml` is still using it

### Full changelog

* Get rid of `KUMA_DATAPLANE_ADMIN_PORT`

### Issues resolved

N/A

### Documentation

- [ ] Link to the website [documentation PR](https://github.com/kumahq/kuma-website/pull/XXX)

### Testing

- [X] Unit tests
- [ ] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes

### Backwards compatibility

~- [ ] Update [`UPGRADE.md`](/UPGRADE.md) with any steps users will need to take when upgrading.~
~- [ ] Add `backport-to-stable` label if the code follows our [backporting policy](/CONTRIBUTING.md#backporting)~
