### PR TITLE
fix(e2e): escape env vars in e2e test

### DIFF
--- a/test/framework/client/collect.go
+++ b/test/framework/client/collect.go
@@ -6,7 +6,6 @@ import (
 	"net/url"
 	"os"
 	"path"
-	"strings"
 	"sync"
 
 	"github.com/gruntwork-io/terratest/modules/k8s"
@@ -14,6 +13,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/kumahq/kuma/test/framework"
+	"github.com/kumahq/kuma/test/framework/utils"
 	"github.com/kumahq/kuma/test/server/types"
 )
 
@@ -35,7 +35,7 @@ func DefaultCollectResponsesOpts() CollectResponsesOpts {
 		NumberOfRequests: 10,
 		Method:           "GET",
 		Headers:          map[string]string{},
-		ShellEscaped:     ShellEscape,
+		ShellEscaped:     utils.ShellEscape,
 		Flags: []string{
 			"--fail",
 		},
@@ -211,10 +211,6 @@ func CollectResponse(
 	}
 
 	return *response, nil
-}
-
-func ShellEscape(arg string) string {
-	return fmt.Sprintf("'%s'", strings.ReplaceAll(arg, "'", "\\'"))
 }
 
 // FailureResponse is the JSON output for a Curl command. Note that the available

--- a/test/framework/deployments/externalservice/universal.go
+++ b/test/framework/deployments/externalservice/universal.go
@@ -74,7 +74,6 @@ func (u *universalDeployment) Deploy(cluster framework.Cluster) error {
 	u.container = container
 
 	port := u.ports["22"]
-	env := []string{}
 
 	// ceritficates
 	cert, key, err := framework.CreateCertsFor("localhost", ip, name)
@@ -82,19 +81,19 @@ func (u *universalDeployment) Deploy(cluster framework.Cluster) error {
 		return err
 	}
 
-	err = framework.NewSshApp(u.verbose, port, env, []string{"printf ", "--", "\"" + cert + "\"", ">", "/server-cert.pem"}).Run()
+	err = framework.NewSshApp(u.verbose, port, nil, []string{"printf ", "--", "\"" + cert + "\"", ">", "/server-cert.pem"}).Run()
 	if err != nil {
 		panic(err)
 	}
 
-	err = framework.NewSshApp(u.verbose, port, env, []string{"printf ", "--", "\"" + key + "\"", ">", "/server-key.pem"}).Run()
+	err = framework.NewSshApp(u.verbose, port, nil, []string{"printf ", "--", "\"" + key + "\"", ">", "/server-key.pem"}).Run()
 	if err != nil {
 		panic(err)
 	}
 
 	u.cert = cert
 	for _, arg := range u.commands {
-		u.app = framework.NewSshApp(u.verbose, port, env, arg)
+		u.app = framework.NewSshApp(u.verbose, port, nil, arg)
 		err = u.app.Start()
 		if err != nil {
 			return err

--- a/test/framework/setup.go
+++ b/test/framework/setup.go
@@ -182,7 +182,7 @@ func zoneRelatedResource(
 			return err
 		}
 
-		app.CreateMainApp([]string{}, []string{})
+		app.CreateMainApp(nil, []string{})
 
 		err = app.mainApp.Start()
 		if err != nil {

--- a/test/framework/universal_cluster.go
+++ b/test/framework/universal_cluster.go
@@ -95,36 +95,35 @@ func (c *UniversalCluster) DeployKuma(mode core.CpMode, opt ...KumaDeploymentOpt
 
 	c.controlplane = NewUniversalControlPlane(c.t, mode, c.name, c, c.verbose)
 
-	cmd := []string{"kuma-cp", "run"}
-	env := []string{"KUMA_MODE=" + mode, "KUMA_DNS_SERVER_PORT=53"}
+	env := map[string]string{"KUMA_MODE": mode, "KUMA_DNS_SERVER_PORT": "53"}
 
-	caps := []string{}
 	for k, v := range c.opts.env {
-		env = append(env, fmt.Sprintf("%s=%s", k, v))
+		env[k] = v
 	}
 	if c.opts.globalAddress != "" {
-		env = append(env, "KUMA_MULTIZONE_ZONE_GLOBAL_ADDRESS="+c.opts.globalAddress)
+		env["KUMA_MULTIZONE_ZONE_GLOBAL_ADDRESS"] = c.opts.globalAddress
 	}
 	if c.opts.hdsDisabled {
-		env = append(env, "KUMA_DP_SERVER_HDS_ENABLED=false")
+		env["KUMA_DP_SERVER_HDS_ENABLED"] = "false"
 	}
 
 	if Config.XDSApiVersion != "" {
-		env = append(env, "KUMA_BOOTSTRAP_SERVER_API_VERSION="+Config.XDSApiVersion)
+		env["KUMA_BOOTSTRAP_SERVER_API_VERSION"] = Config.XDSApiVersion
 	}
 
 	if Config.CIDR != "" {
-		env = append(env, fmt.Sprintf("KUMA_DNS_SERVER_CIDR=\"%s\"", Config.CIDR))
+		env["KUMA_DNS_SERVER_CIDR"] = Config.CIDR
 	}
 
+	cmd := []string{"kuma-cp", "run"}
 	switch mode {
 	case core.Zone:
-		env = append(env, "KUMA_MULTIZONE_ZONE_NAME="+c.name)
+		env["KUMA_MULTIZONE_ZONE_NAME"] = c.name
 	case core.Global:
 		cmd = append(cmd, "--config-file", "/kuma/kuma-cp.conf")
 	}
 
-	app, err := NewUniversalApp(c.t, c.name, AppModeCP, AppModeCP, c.opts.isipv6, true, caps)
+	app, err := NewUniversalApp(c.t, c.name, AppModeCP, AppModeCP, c.opts.isipv6, true, []string{})
 	if err != nil {
 		return err
 	}
@@ -176,7 +175,7 @@ func (c *UniversalCluster) retrieveAdminToken() (string, error) {
 		DefaultRetries,
 		DefaultTimeout,
 		func() (string, error) {
-			sshApp := NewSshApp(c.verbose, c.apps[AppModeCP].ports["22"], []string{}, []string{"curl",
+			sshApp := NewSshApp(c.verbose, c.apps[AppModeCP].ports["22"], nil, []string{"curl",
 				"--fail", "--show-error",
 				"http://localhost:5681/global-secrets/admin-user-token"})
 			if err := sshApp.Run(); err != nil {
@@ -336,7 +335,7 @@ func (c *UniversalCluster) DeployApp(opt ...AppDeploymentOption) error {
 	}
 
 	if !opts.proxyOnly {
-		app.CreateMainApp([]string{}, args)
+		app.CreateMainApp(nil, args)
 		err = app.mainApp.Start()
 		if err != nil {
 			return err
@@ -346,7 +345,7 @@ func (c *UniversalCluster) DeployApp(opt ...AppDeploymentOption) error {
 	return nil
 }
 
-func runPostgresMigration(kumaCP *UniversalApp, envVars []string) error {
+func runPostgresMigration(kumaCP *UniversalApp, envVars map[string]string) error {
 	args := []string{
 		"/usr/bin/kuma-cp", "migrate", "up",
 	}
@@ -356,7 +355,7 @@ func runPostgresMigration(kumaCP *UniversalApp, envVars []string) error {
 		return errors.New("missing public port: 22")
 	}
 
-	app := NewSshApp(true, sshPort, envVars, args)
+	app := NewSshApp(kumaCP.verbose, sshPort, envVars, args)
 	if err := app.Run(); err != nil {
 		return errors.Errorf("db migration err: %s\nstderr :%s\nstdout %s", err.Error(), app.Err(), app.Out())
 	}
@@ -381,7 +380,7 @@ func (c *UniversalCluster) Exec(namespace, podName, appname string, cmd ...strin
 	if !ok {
 		return "", "", errors.Errorf("App %s not found", appname)
 	}
-	sshApp := NewSshApp(false, app.ports[sshPort], []string{}, cmd)
+	sshApp := NewSshApp(c.verbose, app.ports[sshPort], nil, cmd)
 	err := sshApp.Run()
 	return sshApp.Out(), sshApp.Err(), err
 }
@@ -399,7 +398,7 @@ func (c *UniversalCluster) ExecWithRetries(namespace, podName, appname string, c
 			if !ok {
 				return "", errors.Errorf("App %s not found", appname)
 			}
-			sshApp := NewSshApp(false, app.ports[sshPort], []string{}, cmd)
+			sshApp := NewSshApp(c.verbose, app.ports[sshPort], nil, cmd)
 			err := sshApp.Run()
 			stdout = sshApp.Out()
 			stderr = sshApp.Err()

--- a/test/framework/universal_controlplane.go
+++ b/test/framework/universal_controlplane.go
@@ -59,7 +59,7 @@ func (c *UniversalControlPlane) GetAPIServerAddress() string {
 
 func (c *UniversalControlPlane) GetMetrics() (string, error) {
 	return retry.DoWithRetryE(c.t, "fetching CP metrics", DefaultRetries, DefaultTimeout, func() (string, error) {
-		sshApp := NewSshApp(c.verbose, c.cluster.apps[AppModeCP].ports["22"], []string{}, []string{"curl",
+		sshApp := NewSshApp(c.verbose, c.cluster.apps[AppModeCP].ports["22"], nil, []string{"curl",
 			"--fail", "--show-error",
 			"http://localhost:5680/metrics"})
 		if err := sshApp.Run(); err != nil {
@@ -87,7 +87,7 @@ func (c *UniversalControlPlane) generateToken(
 			sshApp := NewSshApp(
 				c.verbose,
 				c.cluster.apps[AppModeCP].ports["22"],
-				[]string{},
+				nil,
 				[]string{"curl",
 					"--fail", "--show-error",
 					"-H", "\"Content-Type: application/json\"",

--- a/test/framework/utils/utils.go
+++ b/test/framework/utils/utils.go
@@ -1,0 +1,10 @@
+package utils
+
+import (
+	"fmt"
+	"strings"
+)
+
+func ShellEscape(arg string) string {
+	return fmt.Sprintf("'%s'", strings.ReplaceAll(arg, "'", "\\'"))
+}


### PR DESCRIPTION
### Summary

- This was causing issues when passing a json in env var
- Also do some minor cleanup on the framework

### Testing

- [ ] Unit tests
- [x] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes

### Backwards compatibility

- ~~[ ] Update [`UPGRADE.md`](/UPGRADE.md) with any steps users will need to take when upgrading.~~
- ~~[ ] Add `backport-to-stable` label if the code follows our [backporting policy](/CONTRIBUTING.md#backporting)~~
