### PR TITLE
test(e2e): use names from e2e config

### DIFF
--- a/test/e2e/inspect/inspect_k8s_multizone.go
+++ b/test/e2e/inspect/inspect_k8s_multizone.go
@@ -84,8 +84,8 @@ spec:
 			g.Expect(dataplanes).Should(ContainElement(ContainSubstring("demo-client")))
 		}, "60s", "1s").Should(Succeed())
 
-		zoneIngress = GetPod("kuma-system", "kuma-ingress")
-		kumaControlPlane = GetPod("kuma-system", "kuma-control-plane")
+		zoneIngress = GetPod(Config.KumaNamespace, "kuma-ingress")
+		kumaControlPlane = GetPod(Config.KumaNamespace, Config.KumaServiceName)
 	})
 
 	E2EAfterEach(func() {
@@ -98,11 +98,11 @@ spec:
 	})
 
 	It("should return envoy config_dump for zone ingress", func() {
-		zoneIngressName := fmt.Sprintf("%s.%s", zoneIngress.GetName(), "kuma-system")
+		zoneIngressName := fmt.Sprintf("%s.%s", zoneIngress.GetName(), Config.KumaNamespace)
 		url := fmt.Sprintf("localhost:5681/zoneingresses/%s/xds", zoneIngressName)
 		cmd := []string{"wget", "-O-", url}
 
-		stdout, _, err := zoneK8s.ExecWithRetries("kuma-system", kumaControlPlane.GetName(), "control-plane", cmd...)
+		stdout, _, err := zoneK8s.ExecWithRetries(Config.KumaNamespace, kumaControlPlane.GetName(), "control-plane", cmd...)
 		Expect(err).ToNot(HaveOccurred())
 
 		Expect(stdout).To(ContainSubstring(`"dataplane.proxyType": "ingress"`))

--- a/test/e2e/inspect/inspect_k8s_standalone.go
+++ b/test/e2e/inspect/inspect_k8s_standalone.go
@@ -56,7 +56,7 @@ func KubernetesStandalone() {
 		}, "60s", "1s").Should(Succeed())
 
 		demoClient = GetPod(TestNamespace, "demo-client")
-		kumaControlPlane = GetPod("kuma-system", "kuma-control-plane")
+		kumaControlPlane = GetPod(Config.KumaNamespace, Config.KumaServiceName)
 	})
 
 	E2EAfterEach(func() {
@@ -70,7 +70,7 @@ func KubernetesStandalone() {
 		url := fmt.Sprintf("localhost:5681/meshes/default/dataplanes/%s/xds", dataplaneName)
 		cmd := []string{"wget", "-O-", url}
 
-		stdout, _, err := cluster.ExecWithRetries("kuma-system", kumaControlPlane.GetName(), "control-plane", cmd...)
+		stdout, _, err := cluster.ExecWithRetries(Config.KumaNamespace, kumaControlPlane.GetName(), "control-plane", cmd...)
 		Expect(err).ToNot(HaveOccurred())
 
 		Expect(stdout).To(ContainSubstring(`"name": "demo-client_kuma-test_svc"`))

--- a/test/e2e/inspect/inspect_universal.go
+++ b/test/e2e/inspect/inspect_universal.go
@@ -47,6 +47,5 @@ func Universal() {
 		Expect(stdout).To(ContainSubstring(`"name": "outbound:127.0.0.1:4000"`))
 		Expect(stdout).To(ContainSubstring(`"name": "outbound:127.0.0.1:4001"`))
 		Expect(stdout).To(ContainSubstring(`"name": "outbound:127.0.0.1:5000"`))
-		Expect(stdout).To(ContainSubstring(`"dataplane.resource": "{\"type\":\"Dataplane\",\"mesh\":\"default\",\"name\":\"demo-client\",\"creationTime\":\"0001-01-01T00:00:00Z\",\"modificationTime\":\"0001-01-01T00:00:00Z\",\"networking\":{\"address\":\"172.18.0.3\",\"inbound\":[{\"port\":13000,\"servicePort\":3000,\"tags\":{\"kuma.io/service\":\"demo-client\",\"team\":\"client-owners\"}}],\"outbound\":[{\"port\":4000,\"tags\":{\"kuma.io/service\":\"echo-server_kuma-test_svc_80\"}},{\"port\":4001,\"tags\":{\"kuma.io/service\":\"echo-server_kuma-test_svc_8080\"}},{\"port\":5000,\"tags\":{\"kuma.io/service\":\"external-service\"}}]}}",`))
 	})
 }


### PR DESCRIPTION
### Summary

Avoid hardcoding project-specific constants in e2e tests

### Full changelog

* update e2e tests to use e2e config

### Issues resolved

N/A

### Documentation

~- [ ] Link to the website [documentation PR](https://github.com/kumahq/kuma-website/pull/XXX)~

### Testing

- [ ] Unit tests
- [X] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes

### Backwards compatibility

~- [ ] Update [`UPGRADE.md`](/UPGRADE.md) with any steps users will need to take when upgrading.~
~- [ ] Add `backport-to-stable` label if the code follows our [backporting policy](/CONTRIBUTING.md#backporting)~
