### PR TITLE
test(e2e): disable k8s Inspect API tests

### DIFF
--- a/test/e2e/inspect/inspect_suite_test.go
+++ b/test/e2e/inspect/inspect_suite_test.go
@@ -10,8 +10,10 @@ import (
 )
 
 var _ = Describe("Test Inspect API on Universal", inspect.Universal)
-var _ = Describe("Test Inspect API on Kubernetes Standalone", inspect.KubernetesStandalone)
-var _ = Describe("Test Inspect API on Kubernetes Multizone", inspect.KubernetesMultizone)
+
+// Disabling tests to implement them later using `kumactl` instead of `wget`
+var _ = XDescribe("Test Inspect API on Kubernetes Standalone", inspect.KubernetesStandalone)
+var _ = XDescribe("Test Inspect API on Kubernetes Multizone", inspect.KubernetesMultizone)
 
 func TestE2EInspectAPI(t *testing.T) {
 	test.RunSpecs(t, "E2E Inspect API Suite")


### PR DESCRIPTION
### Summary

We don't want to use `wget` to work with Inspect API in e2e tests, `kumactl` is more preferable. So disable tests while `kumactl` support is not there. 

### Full changelog

* disable `Test Inspect API on Kubernetes Standalone`
* disable `Test Inspect API on Kubernetes Multizone`

### Issues resolved

N/A

### Documentation

~- [ ] Link to the website [documentation PR](https://github.com/kumahq/kuma-website/pull/XXX)~

### Testing

- [ ] Unit tests
- [ ] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes

### Backwards compatibility

~- [ ] Update [`UPGRADE.md`](/UPGRADE.md) with any steps users will need to take when upgrading.~
~- [ ] Add `backport-to-stable` label if the code follows our [backporting policy](/CONTRIBUTING.md#backporting)~
