### PR TITLE
feat(kumactl): inspect api support

### DIFF
--- a/app/kumactl/cmd/completion/testdata/bash.golden
+++ b/app/kumactl/cmd/completion/testdata/bash.golden
@@ -2763,6 +2763,73 @@ _kumactl_help()
     noun_aliases=()
 }
 
+_kumactl_inspect_circuit-breaker()
+{
+    last_command="kumactl_inspect_circuit-breaker"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--api-timeout=")
+    two_word_flags+=("--api-timeout")
+    flags+=("--config-file=")
+    two_word_flags+=("--config-file")
+    flags+=("--log-level=")
+    two_word_flags+=("--log-level")
+    flags+=("--mesh=")
+    two_word_flags+=("--mesh")
+    two_word_flags+=("-m")
+    flags+=("--no-config")
+    flags+=("--output=")
+    two_word_flags+=("--output")
+    two_word_flags+=("-o")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_kumactl_inspect_dataplane()
+{
+    last_command="kumactl_inspect_dataplane"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--config-dump")
+    flags+=("--api-timeout=")
+    two_word_flags+=("--api-timeout")
+    flags+=("--config-file=")
+    two_word_flags+=("--config-file")
+    flags+=("--log-level=")
+    two_word_flags+=("--log-level")
+    flags+=("--mesh=")
+    two_word_flags+=("--mesh")
+    two_word_flags+=("-m")
+    flags+=("--no-config")
+    flags+=("--output=")
+    two_word_flags+=("--output")
+    two_word_flags+=("-o")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
 _kumactl_inspect_dataplanes()
 {
     last_command="kumactl_inspect_dataplanes"
@@ -2781,6 +2848,72 @@ _kumactl_inspect_dataplanes()
     flags+=("--ingress")
     flags+=("--tag=")
     two_word_flags+=("--tag")
+    flags+=("--api-timeout=")
+    two_word_flags+=("--api-timeout")
+    flags+=("--config-file=")
+    two_word_flags+=("--config-file")
+    flags+=("--log-level=")
+    two_word_flags+=("--log-level")
+    flags+=("--mesh=")
+    two_word_flags+=("--mesh")
+    two_word_flags+=("-m")
+    flags+=("--no-config")
+    flags+=("--output=")
+    two_word_flags+=("--output")
+    two_word_flags+=("-o")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_kumactl_inspect_fault-injection()
+{
+    last_command="kumactl_inspect_fault-injection"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--api-timeout=")
+    two_word_flags+=("--api-timeout")
+    flags+=("--config-file=")
+    two_word_flags+=("--config-file")
+    flags+=("--log-level=")
+    two_word_flags+=("--log-level")
+    flags+=("--mesh=")
+    two_word_flags+=("--mesh")
+    two_word_flags+=("-m")
+    flags+=("--no-config")
+    flags+=("--output=")
+    two_word_flags+=("--output")
+    two_word_flags+=("-o")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_kumactl_inspect_healthcheck()
+{
+    last_command="kumactl_inspect_healthcheck"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
     flags+=("--api-timeout=")
     two_word_flags+=("--api-timeout")
     flags+=("--config-file=")
@@ -2833,9 +2966,273 @@ _kumactl_inspect_meshes()
     noun_aliases=()
 }
 
+_kumactl_inspect_proxytemplate()
+{
+    last_command="kumactl_inspect_proxytemplate"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--api-timeout=")
+    two_word_flags+=("--api-timeout")
+    flags+=("--config-file=")
+    two_word_flags+=("--config-file")
+    flags+=("--log-level=")
+    two_word_flags+=("--log-level")
+    flags+=("--mesh=")
+    two_word_flags+=("--mesh")
+    two_word_flags+=("-m")
+    flags+=("--no-config")
+    flags+=("--output=")
+    two_word_flags+=("--output")
+    two_word_flags+=("-o")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_kumactl_inspect_rate-limit()
+{
+    last_command="kumactl_inspect_rate-limit"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--api-timeout=")
+    two_word_flags+=("--api-timeout")
+    flags+=("--config-file=")
+    two_word_flags+=("--config-file")
+    flags+=("--log-level=")
+    two_word_flags+=("--log-level")
+    flags+=("--mesh=")
+    two_word_flags+=("--mesh")
+    two_word_flags+=("-m")
+    flags+=("--no-config")
+    flags+=("--output=")
+    two_word_flags+=("--output")
+    two_word_flags+=("-o")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_kumactl_inspect_retry()
+{
+    last_command="kumactl_inspect_retry"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--api-timeout=")
+    two_word_flags+=("--api-timeout")
+    flags+=("--config-file=")
+    two_word_flags+=("--config-file")
+    flags+=("--log-level=")
+    two_word_flags+=("--log-level")
+    flags+=("--mesh=")
+    two_word_flags+=("--mesh")
+    two_word_flags+=("-m")
+    flags+=("--no-config")
+    flags+=("--output=")
+    two_word_flags+=("--output")
+    two_word_flags+=("-o")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
 _kumactl_inspect_services()
 {
     last_command="kumactl_inspect_services"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--api-timeout=")
+    two_word_flags+=("--api-timeout")
+    flags+=("--config-file=")
+    two_word_flags+=("--config-file")
+    flags+=("--log-level=")
+    two_word_flags+=("--log-level")
+    flags+=("--mesh=")
+    two_word_flags+=("--mesh")
+    two_word_flags+=("-m")
+    flags+=("--no-config")
+    flags+=("--output=")
+    two_word_flags+=("--output")
+    two_word_flags+=("-o")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_kumactl_inspect_timeout()
+{
+    last_command="kumactl_inspect_timeout"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--api-timeout=")
+    two_word_flags+=("--api-timeout")
+    flags+=("--config-file=")
+    two_word_flags+=("--config-file")
+    flags+=("--log-level=")
+    two_word_flags+=("--log-level")
+    flags+=("--mesh=")
+    two_word_flags+=("--mesh")
+    two_word_flags+=("-m")
+    flags+=("--no-config")
+    flags+=("--output=")
+    two_word_flags+=("--output")
+    two_word_flags+=("-o")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_kumactl_inspect_traffic-log()
+{
+    last_command="kumactl_inspect_traffic-log"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--api-timeout=")
+    two_word_flags+=("--api-timeout")
+    flags+=("--config-file=")
+    two_word_flags+=("--config-file")
+    flags+=("--log-level=")
+    two_word_flags+=("--log-level")
+    flags+=("--mesh=")
+    two_word_flags+=("--mesh")
+    two_word_flags+=("-m")
+    flags+=("--no-config")
+    flags+=("--output=")
+    two_word_flags+=("--output")
+    two_word_flags+=("-o")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_kumactl_inspect_traffic-permission()
+{
+    last_command="kumactl_inspect_traffic-permission"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--api-timeout=")
+    two_word_flags+=("--api-timeout")
+    flags+=("--config-file=")
+    two_word_flags+=("--config-file")
+    flags+=("--log-level=")
+    two_word_flags+=("--log-level")
+    flags+=("--mesh=")
+    two_word_flags+=("--mesh")
+    two_word_flags+=("-m")
+    flags+=("--no-config")
+    flags+=("--output=")
+    two_word_flags+=("--output")
+    two_word_flags+=("-o")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_kumactl_inspect_traffic-route()
+{
+    last_command="kumactl_inspect_traffic-route"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--api-timeout=")
+    two_word_flags+=("--api-timeout")
+    flags+=("--config-file=")
+    two_word_flags+=("--config-file")
+    flags+=("--log-level=")
+    two_word_flags+=("--log-level")
+    flags+=("--mesh=")
+    two_word_flags+=("--mesh")
+    two_word_flags+=("-m")
+    flags+=("--no-config")
+    flags+=("--output=")
+    two_word_flags+=("--output")
+    two_word_flags+=("-o")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_kumactl_inspect_traffic-trace()
+{
+    last_command="kumactl_inspect_traffic-trace"
 
     command_aliases=()
 
@@ -2932,6 +3329,40 @@ _kumactl_inspect_zoneegresses()
     noun_aliases=()
 }
 
+_kumactl_inspect_zoneingress()
+{
+    last_command="kumactl_inspect_zoneingress"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--config-dump")
+    flags+=("--api-timeout=")
+    two_word_flags+=("--api-timeout")
+    flags+=("--config-file=")
+    two_word_flags+=("--config-file")
+    flags+=("--log-level=")
+    two_word_flags+=("--log-level")
+    flags+=("--mesh=")
+    two_word_flags+=("--mesh")
+    two_word_flags+=("-m")
+    flags+=("--no-config")
+    flags+=("--output=")
+    two_word_flags+=("--output")
+    two_word_flags+=("-o")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
 _kumactl_inspect_zones()
 {
     last_command="kumactl_inspect_zones"
@@ -2972,11 +3403,24 @@ _kumactl_inspect()
     command_aliases=()
 
     commands=()
+    commands+=("circuit-breaker")
+    commands+=("dataplane")
     commands+=("dataplanes")
+    commands+=("fault-injection")
+    commands+=("healthcheck")
     commands+=("meshes")
+    commands+=("proxytemplate")
+    commands+=("rate-limit")
+    commands+=("retry")
     commands+=("services")
+    commands+=("timeout")
+    commands+=("traffic-log")
+    commands+=("traffic-permission")
+    commands+=("traffic-route")
+    commands+=("traffic-trace")
     commands+=("zone-ingresses")
     commands+=("zoneegresses")
+    commands+=("zoneingress")
     commands+=("zones")
 
     flags=()

--- a/app/kumactl/cmd/inspect/inspect.go
+++ b/app/kumactl/cmd/inspect/inspect.go
@@ -6,6 +6,8 @@ import (
 	kumactl_cmd "github.com/kumahq/kuma/app/kumactl/pkg/cmd"
 	"github.com/kumahq/kuma/app/kumactl/pkg/output"
 	kuma_cmd "github.com/kumahq/kuma/pkg/cmd"
+	core_model "github.com/kumahq/kuma/pkg/core/resources/model"
+	"github.com/kumahq/kuma/pkg/core/resources/registry"
 )
 
 func NewInspectCmd(pctx *kumactl_cmd.RootContext) *cobra.Command {
@@ -27,10 +29,16 @@ func NewInspectCmd(pctx *kumactl_cmd.RootContext) *cobra.Command {
 	inspectCmd.PersistentFlags().StringVarP(&pctx.InspectContext.Args.OutputFormat, "output", "o", string(output.TableFormat), kuma_cmd.UsageOptions("output format", output.TableFormat, output.YAMLFormat, output.JSONFormat))
 	// sub-commands
 	inspectCmd.AddCommand(newInspectDataplanesCmd(pctx))
+	inspectCmd.AddCommand(newInspectDataplaneCmd(pctx))
 	inspectCmd.AddCommand(newInspectZoneIngressesCmd(pctx))
+	inspectCmd.AddCommand(newInspectZoneIngressCmd(pctx))
 	inspectCmd.AddCommand(newInspectZoneEgressesCmd(pctx))
 	inspectCmd.AddCommand(newInspectZonesCmd(pctx))
 	inspectCmd.AddCommand(newInspectMeshesCmd(pctx))
 	inspectCmd.AddCommand(newInspectServicesCmd(pctx))
+
+	for _, desc := range registry.Global().ObjectDescriptors(core_model.AllowedToInspect()) {
+		inspectCmd.AddCommand(newInspectPolicyCmd(desc, pctx))
+	}
 	return inspectCmd
 }

--- a/app/kumactl/cmd/inspect/inspect_dataplane.go
+++ b/app/kumactl/cmd/inspect/inspect_dataplane.go
@@ -1,0 +1,60 @@
+package inspect
+
+import (
+	"context"
+	"fmt"
+	"text/template"
+
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+
+	"github.com/kumahq/kuma/app/kumactl/pkg/cmd"
+)
+
+var dataplaneInspectTemplate = "{{ range .Items }}" +
+	"{{ .AttachmentEntry | FormatAttachment }}:\n" +
+	"{{ range $typ, $policies := .MatchedPolicies }}" +
+	"  {{ $typ }}\n" +
+	"    {{ range $policies }}{{ .Meta.Name }}\n{{ end }}" +
+	"{{ end }}" +
+	"\n" +
+	"{{ end }}"
+
+func newInspectDataplaneCmd(pctx *cmd.RootContext) *cobra.Command {
+	tmpl, err := template.New("dataplane_inspect").Funcs(template.FuncMap{
+		"FormatAttachment": attachmentToStr(true),
+	}).Parse(dataplaneInspectTemplate)
+	if err != nil {
+		panic("unable to parse template")
+	}
+	var configDump bool
+	cmd := &cobra.Command{
+		Use:   "dataplane NAME",
+		Short: "Inspect Dataplane",
+		Long:  "Inspect Dataplane.",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client, err := pctx.CurrentDataplaneInspectClient()
+			if err != nil {
+				return errors.Wrap(err, "failed to create a dataplane inspect client")
+			}
+			name := args[0]
+			if configDump {
+				bytes, err := client.InspectConfigDump(context.Background(), pctx.CurrentMesh(), name)
+				if err != nil {
+					return err
+				}
+				_, err = fmt.Fprint(cmd.OutOrStdout(), string(bytes))
+				return err
+			} else {
+				entryList, err := client.InspectPolicies(context.Background(), pctx.CurrentMesh(), name)
+				if err != nil {
+					return err
+				}
+				return tmpl.Execute(cmd.OutOrStdout(), entryList)
+			}
+		},
+	}
+	cmd.PersistentFlags().BoolVar(&configDump, "config-dump", false, "if set then the command returns envoy config dump for provided dataplane")
+	return cmd
+}

--- a/app/kumactl/cmd/inspect/inspect_dataplane_test.go
+++ b/app/kumactl/cmd/inspect/inspect_dataplane_test.go
@@ -1,0 +1,94 @@
+package inspect_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"os"
+	"path"
+	"path/filepath"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+	gomega_types "github.com/onsi/gomega/types"
+	"github.com/spf13/cobra"
+
+	"github.com/kumahq/kuma/app/kumactl/cmd"
+	"github.com/kumahq/kuma/app/kumactl/pkg/resources"
+	api_server_types "github.com/kumahq/kuma/pkg/api-server/types"
+	"github.com/kumahq/kuma/pkg/core/resources/registry"
+	test_kumactl "github.com/kumahq/kuma/pkg/test/kumactl"
+	"github.com/kumahq/kuma/pkg/test/matchers"
+	util_http "github.com/kumahq/kuma/pkg/util/http"
+)
+
+type testDataplaneInspectClient struct {
+	response *api_server_types.DataplaneInspectEntryList
+}
+
+func (t *testDataplaneInspectClient) InspectPolicies(ctx context.Context, mesh, name string) (*api_server_types.DataplaneInspectEntryList, error) {
+	return t.response, nil
+}
+
+func (t *testDataplaneInspectClient) InspectConfigDump(ctx context.Context, mesh, name string) ([]byte, error) {
+	return nil, nil
+}
+
+var _ resources.DataplaneInspectClient = &testDataplaneInspectClient{}
+
+var _ = Describe("kumactl inspect dataplane", func() {
+
+	var rootCmd *cobra.Command
+	var buf *bytes.Buffer
+
+	BeforeEach(func() {
+		rawResponse, err := os.ReadFile(path.Join("testdata", "inspect-dataplane.server-response.json"))
+		Expect(err).ToNot(HaveOccurred())
+
+		receiver := &api_server_types.DataplaneInspectEntryListReceiver{
+			NewResource: registry.Global().NewObject,
+		}
+		Expect(json.Unmarshal(rawResponse, receiver)).To(Succeed())
+
+		testClient := &testDataplaneInspectClient{
+			response: &receiver.DataplaneInspectEntryList,
+		}
+
+		rootCtx, err := test_kumactl.MakeRootContext(time.Now(), nil)
+		Expect(err).ToNot(HaveOccurred())
+
+		rootCtx.Runtime.NewDataplaneInspectClient = func(client util_http.Client) resources.DataplaneInspectClient {
+			return testClient
+		}
+
+		rootCmd = cmd.NewRootCmd(rootCtx)
+		buf = &bytes.Buffer{}
+		rootCmd.SetOut(buf)
+	})
+
+	type testCase struct {
+		goldenFile string
+		matcher    func(path ...string) gomega_types.GomegaMatcher
+	}
+	DescribeTable("kumactl inspect dataplane",
+		func(given testCase) {
+			// given
+			rootCmd.SetArgs([]string{
+				"--config-file", filepath.Join("..", "testdata", "sample-kumactl.config.yaml"),
+				"inspect", "dataplane", "backend-1"})
+
+			// when
+			err := rootCmd.Execute()
+
+			// then
+			Expect(err).ToNot(HaveOccurred())
+			Expect(buf.String()).To(given.matcher("testdata", given.goldenFile))
+		},
+		Entry("default output", testCase{
+			goldenFile: "inspect-dataplane.golden.txt",
+			matcher:    matchers.MatchGoldenEqual,
+		}),
+	)
+})

--- a/app/kumactl/cmd/inspect/inspect_policy.go
+++ b/app/kumactl/cmd/inspect/inspect_policy.go
@@ -42,8 +42,8 @@ func newInspectPolicyCmd(policyDesc core_model.ResourceTypeDescriptor, pctx *cmd
 
 	cmd := &cobra.Command{
 		Use:   fmt.Sprintf("%s NAME", policyDesc.KumactlArg),
-		Short: fmt.Sprintf("Inspect %s", policyDesc.KumactlArg),
-		Long:  fmt.Sprintf("Inspect %s.", policyDesc.KumactlArg),
+		Short: fmt.Sprintf("Inspect %s", policyDesc.Name),
+		Long:  fmt.Sprintf("Inspect %s.", policyDesc.Name),
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			client, err := pctx.CurrentPolicyInspectClient()

--- a/app/kumactl/cmd/inspect/inspect_policy.go
+++ b/app/kumactl/cmd/inspect/inspect_policy.go
@@ -1,0 +1,81 @@
+package inspect
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"text/template"
+
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+
+	"github.com/kumahq/kuma/app/kumactl/pkg/cmd"
+	api_server_types "github.com/kumahq/kuma/pkg/api-server/types"
+	core_model "github.com/kumahq/kuma/pkg/core/resources/model"
+)
+
+var policyInspectTemplate = "Affected data plane proxies:\n\n" +
+	"{{ range .Items }}" +
+	"  {{ .DataplaneKey.Name }}" +
+	"{{ if . | PrintAttachments }}" +
+	":\n" +
+	"{{ range .Attachments }}" +
+	"    {{ . | FormatAttachment }}\n" +
+	"{{ end }}" +
+	"{{ end }}" +
+	"\n" +
+	"{{ end }}"
+
+func newInspectPolicyCmd(policyDesc core_model.ResourceTypeDescriptor, pctx *cmd.RootContext) *cobra.Command {
+	tmpl, err := template.New("policy_inspect").Funcs(template.FuncMap{
+		"FormatAttachment": attachmentToStr(false),
+		"PrintAttachments": func(e api_server_types.PolicyInspectEntry) bool {
+			if len(e.Attachments) == 1 && e.Attachments[0].Type == "dataplane" {
+				return false
+			}
+			return true
+		},
+	}).Parse(policyInspectTemplate)
+	if err != nil {
+		panic("unable to parse template")
+	}
+
+	cmd := &cobra.Command{
+		Use:   fmt.Sprintf("%s NAME", policyDesc.KumactlArg),
+		Short: fmt.Sprintf("Inspect %s", policyDesc.KumactlArg),
+		Long:  fmt.Sprintf("Inspect %s.", policyDesc.KumactlArg),
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client, err := pctx.CurrentPolicyInspectClient()
+			if err != nil {
+				return errors.Wrap(err, "failed to create a policy inspect client")
+			}
+			name := args[0]
+			entryList, err := client.Inspect(context.Background(), policyDesc, pctx.CurrentMesh(), name)
+			if err != nil {
+				return err
+			}
+			return tmpl.Execute(cmd.OutOrStdout(), entryList)
+		},
+	}
+	return cmd
+}
+
+func attachmentToStr(upperCase bool) func(api_server_types.AttachmentEntry) string {
+	return func(a api_server_types.AttachmentEntry) string {
+		typeToStr := func(t string) string {
+			if upperCase {
+				return strings.ToUpper(t)
+			}
+			return t
+		}
+		switch a.Type {
+		case "dataplane":
+			return typeToStr(a.Type)
+		case "service":
+			return fmt.Sprintf("%s %s", typeToStr(a.Type), a.Name)
+		default:
+			return fmt.Sprintf("%s %s(%s)", typeToStr(a.Type), a.Name, a.Service)
+		}
+	}
+}

--- a/app/kumactl/cmd/inspect/inspect_policy_test.go
+++ b/app/kumactl/cmd/inspect/inspect_policy_test.go
@@ -1,0 +1,95 @@
+package inspect_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"os"
+	"path"
+	"path/filepath"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+
+	"github.com/kumahq/kuma/app/kumactl/cmd"
+	"github.com/kumahq/kuma/app/kumactl/pkg/resources"
+	api_server_types "github.com/kumahq/kuma/pkg/api-server/types"
+	"github.com/kumahq/kuma/pkg/core/resources/model"
+	test_kumactl "github.com/kumahq/kuma/pkg/test/kumactl"
+	"github.com/kumahq/kuma/pkg/test/matchers"
+	util_http "github.com/kumahq/kuma/pkg/util/http"
+)
+
+type testPolicyInspectClient struct {
+	response *api_server_types.PolicyInspectEntryList
+}
+
+func (t *testPolicyInspectClient) Inspect(ctx context.Context, policyDesc model.ResourceTypeDescriptor, mesh, name string) (*api_server_types.PolicyInspectEntryList, error) {
+	return t.response, nil
+}
+
+var _ resources.PolicyInspectClient = &testPolicyInspectClient{}
+
+var _ = Describe("kumactl inspect POLICY", func() {
+
+	type testCase struct {
+		goldenFile         string
+		serverResponseFile string
+		cmdArgs            []string
+	}
+	DescribeTable("kumactl inspect dataplane",
+		func(given testCase) {
+			// given
+			rawResponse, err := os.ReadFile(path.Join("testdata", given.serverResponseFile))
+			Expect(err).ToNot(HaveOccurred())
+
+			entryList := &api_server_types.PolicyInspectEntryList{}
+			Expect(json.Unmarshal(rawResponse, entryList)).To(Succeed())
+
+			rootCtx, err := test_kumactl.MakeRootContext(time.Now(), nil)
+			Expect(err).ToNot(HaveOccurred())
+
+			rootCtx.Runtime.NewPolicyInspectClient = func(client util_http.Client) resources.PolicyInspectClient {
+				return &testPolicyInspectClient{
+					response: entryList,
+				}
+			}
+
+			rootCmd := cmd.NewRootCmd(rootCtx)
+			buf := &bytes.Buffer{}
+			rootCmd.SetOut(buf)
+
+			rootCmd.SetArgs(append([]string{"--config-file", filepath.Join("..", "testdata", "sample-kumactl.config.yaml")},
+				given.cmdArgs...))
+
+			// when
+			err = rootCmd.Execute()
+
+			// then
+			Expect(err).ToNot(HaveOccurred())
+			Expect(buf.String()).To(matchers.MatchGoldenEqual("testdata", given.goldenFile))
+		},
+		Entry("inbound policy", testCase{
+			goldenFile:         "inspect-traffic-permission.golden.txt",
+			serverResponseFile: "inspect-traffic-permission.server-response.json",
+			cmdArgs:            []string{"inspect", "traffic-permission", "tp1"},
+		}),
+		Entry("outbound policy", testCase{
+			goldenFile:         "inspect-timeout.golden.txt",
+			serverResponseFile: "inspect-timeout.server-response.json",
+			cmdArgs:            []string{"inspect", "timeout", "t1"},
+		}),
+		Entry("service policy", testCase{
+			goldenFile:         "inspect-health-check.golden.txt",
+			serverResponseFile: "inspect-health-check.server-response.json",
+			cmdArgs:            []string{"inspect", "healthcheck", "hc1"},
+		}),
+		Entry("dataplane policy", testCase{
+			goldenFile:         "inspect-traffic-trace.golden.txt",
+			serverResponseFile: "inspect-traffic-trace.server-response.json",
+			cmdArgs:            []string{"inspect", "traffic-trace", "tt1"},
+		}),
+	)
+})

--- a/app/kumactl/cmd/inspect/inspect_zoneingress.go
+++ b/app/kumactl/cmd/inspect/inspect_zoneingress.go
@@ -1,0 +1,43 @@
+package inspect
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+
+	"github.com/kumahq/kuma/app/kumactl/pkg/cmd"
+)
+
+const inspectZoneIngressError = "Policies are not applied on ZoneIngress, please use '--config-dump' flag to get " +
+	"envoy config dump of the ZoneIngress"
+
+func newInspectZoneIngressCmd(pctx *cmd.RootContext) *cobra.Command {
+	var configDump bool
+	cmd := &cobra.Command{
+		Use:   "zoneingress NAME",
+		Short: "Inspect ZoneIngress",
+		Long:  "Inspect ZoneIngress.",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if !configDump {
+				_, err := fmt.Fprintln(cmd.OutOrStderr(), inspectZoneIngressError)
+				return err
+			}
+			client, err := pctx.CurrentZoneIngressInspectClient()
+			if err != nil {
+				return errors.Wrap(err, "failed to create a zoneingress inspect client")
+			}
+			name := args[0]
+			bytes, err := client.InspectConfigDump(context.Background(), name)
+			if err != nil {
+				return err
+			}
+			_, err = fmt.Fprint(cmd.OutOrStdout(), string(bytes))
+			return err
+		},
+	}
+	cmd.PersistentFlags().BoolVar(&configDump, "config-dump", false, "if set then the command returns envoy config dump for provided dataplane")
+	return cmd
+}

--- a/app/kumactl/cmd/inspect/testdata/inspect-dataplane.golden.txt
+++ b/app/kumactl/cmd/inspect/testdata/inspect-dataplane.golden.txt
@@ -1,0 +1,22 @@
+DATAPLANE:
+  TrafficTrace
+    backends-eu
+
+INBOUND 127.0.0.1:10010:10011(backend):
+  TrafficPermission
+    allow-all-default
+
+OUTBOUND 127.0.0.1:10006(gateway):
+  Timeout
+    timeout-all-default
+  TrafficRoute
+    route-all-default
+
+SERVICE gateway:
+  CircuitBreaker
+    circuit-breaker-all-default
+  HealthCheck
+    gateway-to-backend
+  Retry
+    retry-all-default
+

--- a/app/kumactl/cmd/inspect/testdata/inspect-dataplane.server-response.json
+++ b/app/kumactl/cmd/inspect/testdata/inspect-dataplane.server-response.json
@@ -1,0 +1,258 @@
+{
+  "total": 4,
+  "items": [
+    {
+      "type": "dataplane",
+      "name": "",
+      "service": "",
+      "matchedPolicies": {
+        "TrafficTrace": [
+          {
+            "type": "TrafficTrace",
+            "mesh": "default",
+            "name": "backends-eu",
+            "creationTime": "2022-02-06T15:31:26.424855+01:00",
+            "modificationTime": "2022-02-06T15:31:26.424855+01:00",
+            "selectors": [
+              {
+                "match": {
+                  "kuma.io/service": "backend"
+                }
+              }
+            ],
+            "conf": {
+              "backend": "zipkin-eu"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "type": "inbound",
+      "name": "127.0.0.1:10010:10011",
+      "service": "backend",
+      "matchedPolicies": {
+        "TrafficPermission": [
+          {
+            "type": "TrafficPermission",
+            "mesh": "default",
+            "name": "allow-all-default",
+            "creationTime": "2022-02-04T17:55:46.426279+01:00",
+            "modificationTime": "2022-02-04T17:55:46.426279+01:00",
+            "sources": [
+              {
+                "match": {
+                  "kuma.io/service": "*"
+                }
+              }
+            ],
+            "destinations": [
+              {
+                "match": {
+                  "kuma.io/service": "*"
+                }
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "type": "outbound",
+      "name": "127.0.0.1:10006",
+      "service": "gateway",
+      "matchedPolicies": {
+        "Timeout": [
+          {
+            "type": "Timeout",
+            "mesh": "default",
+            "name": "timeout-all-default",
+            "creationTime": "2022-02-04T17:55:46.426752+01:00",
+            "modificationTime": "2022-02-04T17:55:46.426752+01:00",
+            "sources": [
+              {
+                "match": {
+                  "kuma.io/service": "*"
+                }
+              }
+            ],
+            "destinations": [
+              {
+                "match": {
+                  "kuma.io/service": "*"
+                }
+              }
+            ],
+            "conf": {
+              "connectTimeout": "5s",
+              "tcp": {
+                "idleTimeout": "3600s"
+              },
+              "http": {
+                "requestTimeout": "15s",
+                "idleTimeout": "3600s"
+              },
+              "grpc": {
+                "streamIdleTimeout": "300s"
+              }
+            }
+          }
+        ],
+        "TrafficRoute": [
+          {
+            "type": "TrafficRoute",
+            "mesh": "default",
+            "name": "route-all-default",
+            "creationTime": "2022-02-04T17:55:46.426489+01:00",
+            "modificationTime": "2022-02-04T17:55:46.426489+01:00",
+            "sources": [
+              {
+                "match": {
+                  "kuma.io/service": "*"
+                }
+              }
+            ],
+            "destinations": [
+              {
+                "match": {
+                  "kuma.io/service": "*"
+                }
+              }
+            ],
+            "conf": {
+              "loadBalancer": {
+                "roundRobin": {}
+              },
+              "destination": {
+                "kuma.io/service": "gateway"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "type": "service",
+      "name": "gateway",
+      "service": "gateway",
+      "matchedPolicies": {
+        "CircuitBreaker": [
+          {
+            "type": "CircuitBreaker",
+            "mesh": "default",
+            "name": "circuit-breaker-all-default",
+            "creationTime": "2022-02-04T17:55:46.426951+01:00",
+            "modificationTime": "2022-02-04T17:55:46.426951+01:00",
+            "sources": [
+              {
+                "match": {
+                  "kuma.io/service": "*"
+                }
+              }
+            ],
+            "destinations": [
+              {
+                "match": {
+                  "kuma.io/service": "*"
+                }
+              }
+            ],
+            "conf": {
+              "thresholds": {
+                "maxConnections": 1024,
+                "maxPendingRequests": 1024,
+                "maxRetries": 3,
+                "maxRequests": 1024
+              }
+            }
+          }
+        ],
+        "HealthCheck": [
+          {
+            "type": "HealthCheck",
+            "mesh": "default",
+            "name": "gateway-to-backend",
+            "creationTime": "2022-02-06T15:31:21.499862+01:00",
+            "modificationTime": "2022-02-06T15:31:21.499862+01:00",
+            "sources": [
+              {
+                "match": {
+                  "kuma.io/service": "backend"
+                }
+              }
+            ],
+            "destinations": [
+              {
+                "match": {
+                  "kuma.io/service": "gateway"
+                }
+              }
+            ],
+            "conf": {
+              "interval": "10s",
+              "timeout": "2s",
+              "unhealthyThreshold": 3,
+              "healthyThreshold": 1,
+              "healthyPanicThreshold": 0,
+              "failTrafficOnPanic": true,
+              "eventLogPath": "/Users/lobkovilya/Documents/kuma/trafficroutes/logs2",
+              "alwaysLogHealthCheckFailures": true,
+              "noTrafficInterval": "1s",
+              "tcp": {
+                "send": "Zm9v",
+                "receive": [
+                  "YmFy"
+                ]
+              },
+              "reuseConnection": true
+            }
+          }
+        ],
+        "Retry": [
+          {
+            "type": "Retry",
+            "mesh": "default",
+            "name": "retry-all-default",
+            "creationTime": "2022-02-04T17:55:46.427127+01:00",
+            "modificationTime": "2022-02-04T17:55:46.427127+01:00",
+            "sources": [
+              {
+                "match": {
+                  "kuma.io/service": "*"
+                }
+              }
+            ],
+            "destinations": [
+              {
+                "match": {
+                  "kuma.io/service": "*"
+                }
+              }
+            ],
+            "conf": {
+              "http": {
+                "numRetries": 5,
+                "perTryTimeout": "16s",
+                "backOff": {
+                  "baseInterval": "0.025s",
+                  "maxInterval": "0.250s"
+                }
+              },
+              "tcp": {
+                "maxConnectAttempts": 5
+              },
+              "grpc": {
+                "numRetries": 5,
+                "perTryTimeout": "16s",
+                "backOff": {
+                  "baseInterval": "0.025s",
+                  "maxInterval": "0.250s"
+                }
+              }
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/app/kumactl/cmd/inspect/testdata/inspect-health-check.golden.txt
+++ b/app/kumactl/cmd/inspect/testdata/inspect-health-check.golden.txt
@@ -1,0 +1,13 @@
+Affected data plane proxies:
+
+  backend-1:
+    service gateway
+    service web
+
+  web-1:
+    service gateway
+
+  redis-1:
+    service gateway
+    service web
+

--- a/app/kumactl/cmd/inspect/testdata/inspect-health-check.server-response.json
+++ b/app/kumactl/cmd/inspect/testdata/inspect-health-check.server-response.json
@@ -1,0 +1,54 @@
+{
+  "total": 1,
+  "items": [
+    {
+      "dataplane": {
+        "mesh": "default",
+        "name": "backend-1"
+      },
+      "attachments": [
+        {
+          "type": "service",
+          "name": "gateway",
+          "service": "gateway"
+        },
+        {
+          "type": "service",
+          "name": "web",
+          "service": "web"
+        }
+      ]
+    },
+    {
+      "dataplane": {
+        "mesh": "default",
+        "name": "web-1"
+      },
+      "attachments": [
+        {
+          "type": "service",
+          "name": "gateway",
+          "service": "gateway"
+        }
+      ]
+    },
+    {
+      "dataplane": {
+        "mesh": "default",
+        "name": "redis-1"
+      },
+      "attachments": [
+        {
+          "type": "service",
+          "name": "gateway",
+          "service": "gateway"
+        },
+        {
+          "type": "service",
+          "name": "web",
+          "service": "web"
+        }
+      ]
+    }
+  ]
+}

--- a/app/kumactl/cmd/inspect/testdata/inspect-timeout.golden.txt
+++ b/app/kumactl/cmd/inspect/testdata/inspect-timeout.golden.txt
@@ -1,0 +1,13 @@
+Affected data plane proxies:
+
+  backend-1:
+    outbound 127.0.0.1:10006(gateway)
+    outbound 127.0.0.1:10007(web)
+    outbound 127.0.0.1:10008(redis)
+
+  redis-1:
+    outbound 127.0.0.1:10006(gateway)
+    outbound 127.0.0.1:10007(web)
+    outbound 127.0.0.1:10008(backend)
+    outbound 127.0.0.1:10009(payments)
+

--- a/app/kumactl/cmd/inspect/testdata/inspect-timeout.server-response.json
+++ b/app/kumactl/cmd/inspect/testdata/inspect-timeout.server-response.json
@@ -1,0 +1,56 @@
+{
+  "total": 1,
+  "items": [
+    {
+      "dataplane": {
+        "mesh": "default",
+        "name": "backend-1"
+      },
+      "attachments": [
+        {
+          "type": "outbound",
+          "name": "127.0.0.1:10006",
+          "service": "gateway"
+        },
+        {
+          "type": "outbound",
+          "name": "127.0.0.1:10007",
+          "service": "web"
+        },
+        {
+          "type": "outbound",
+          "name": "127.0.0.1:10008",
+          "service": "redis"
+        }
+      ]
+    },
+    {
+      "dataplane": {
+        "mesh": "default",
+        "name": "redis-1"
+      },
+      "attachments": [
+        {
+          "type": "outbound",
+          "name": "127.0.0.1:10006",
+          "service": "gateway"
+        },
+        {
+          "type": "outbound",
+          "name": "127.0.0.1:10007",
+          "service": "web"
+        },
+        {
+          "type": "outbound",
+          "name": "127.0.0.1:10008",
+          "service": "backend"
+        },
+        {
+          "type": "outbound",
+          "name": "127.0.0.1:10009",
+          "service": "payments"
+        }
+      ]
+    }
+  ]
+}

--- a/app/kumactl/cmd/inspect/testdata/inspect-traffic-permission.golden.txt
+++ b/app/kumactl/cmd/inspect/testdata/inspect-traffic-permission.golden.txt
@@ -1,0 +1,10 @@
+Affected data plane proxies:
+
+  backend-1:
+    inbound 127.0.0.1:10010:10011(backend)
+    inbound 127.0.0.1:20010:20011(backend-admin)
+    inbound 127.0.0.1:30010:30011(backend-api)
+
+  web-1:
+    inbound 127.0.0.1:10020:10021(web)
+

--- a/app/kumactl/cmd/inspect/testdata/inspect-traffic-permission.server-response.json
+++ b/app/kumactl/cmd/inspect/testdata/inspect-traffic-permission.server-response.json
@@ -1,0 +1,41 @@
+{
+  "total": 2,
+  "items": [
+    {
+      "dataplane": {
+        "mesh": "default",
+        "name": "backend-1"
+      },
+      "attachments": [
+        {
+          "type": "inbound",
+          "name": "127.0.0.1:10010:10011",
+          "service": "backend"
+        },
+        {
+          "type": "inbound",
+          "name": "127.0.0.1:20010:20011",
+          "service": "backend-admin"
+        },
+        {
+          "type": "inbound",
+          "name": "127.0.0.1:30010:30011",
+          "service": "backend-api"
+        }
+      ]
+    },
+    {
+      "dataplane": {
+        "mesh": "default",
+        "name": "web-1"
+      },
+      "attachments": [
+        {
+          "type": "inbound",
+          "name": "127.0.0.1:10020:10021",
+          "service": "web"
+        }
+      ]
+    }
+  ]
+}

--- a/app/kumactl/cmd/inspect/testdata/inspect-traffic-trace.golden.txt
+++ b/app/kumactl/cmd/inspect/testdata/inspect-traffic-trace.golden.txt
@@ -1,0 +1,5 @@
+Affected data plane proxies:
+
+  backend-1
+  web-1
+  redis-1

--- a/app/kumactl/cmd/inspect/testdata/inspect-traffic-trace.server-response.json
+++ b/app/kumactl/cmd/inspect/testdata/inspect-traffic-trace.server-response.json
@@ -1,0 +1,44 @@
+{
+  "total": 1,
+  "items": [
+    {
+      "dataplane": {
+        "mesh": "default",
+        "name": "backend-1"
+      },
+      "attachments": [
+        {
+          "type": "dataplane",
+          "name": "",
+          "service": ""
+        }
+      ]
+    },
+    {
+      "dataplane": {
+        "mesh": "default",
+        "name": "web-1"
+      },
+      "attachments": [
+        {
+          "type": "dataplane",
+          "name": "",
+          "service": ""
+        }
+      ]
+    },
+    {
+      "dataplane": {
+        "mesh": "default",
+        "name": "redis-1"
+      },
+      "attachments": [
+        {
+          "type": "dataplane",
+          "name": "",
+          "service": ""
+        }
+      ]
+    }
+  ]
+}

--- a/app/kumactl/pkg/cmd/root_context.go
+++ b/app/kumactl/pkg/cmd/root_context.go
@@ -40,6 +40,9 @@ type RootRuntime struct {
 	NewBaseAPIServerClient       func(*config_proto.ControlPlaneCoordinates_ApiServer, time.Duration) (util_http.Client, error)
 	NewResourceStore             func(util_http.Client) core_store.ResourceStore
 	NewDataplaneOverviewClient   func(util_http.Client) kumactl_resources.DataplaneOverviewClient
+	NewDataplaneInspectClient    func(util_http.Client) kumactl_resources.DataplaneInspectClient
+	NewZoneIngressInspectClient  func(util_http.Client) kumactl_resources.ZoneIngressInspectClient
+	NewPolicyInspectClient       func(util_http.Client) kumactl_resources.PolicyInspectClient
 	NewZoneIngressOverviewClient func(util_http.Client) kumactl_resources.ZoneIngressOverviewClient
 	NewZoneEgressOverviewClient  func(util_http.Client) kumactl_resources.ZoneEgressOverviewClient
 	NewZoneOverviewClient        func(util_http.Client) kumactl_resources.ZoneOverviewClient
@@ -88,6 +91,9 @@ func DefaultRootContext() *RootContext {
 				return kumactl_resources.NewResourceStore(client, registry.Global().ObjectDescriptors())
 			},
 			NewDataplaneOverviewClient:   kumactl_resources.NewDataplaneOverviewClient,
+			NewDataplaneInspectClient:    kumactl_resources.NewDataplaneInspectClient,
+			NewZoneIngressInspectClient:  kumactl_resources.NewZoneIngressInspectClient,
+			NewPolicyInspectClient:       kumactl_resources.NewPolicyInspectClient,
 			NewZoneIngressOverviewClient: kumactl_resources.NewZoneIngressOverviewClient,
 			NewZoneEgressOverviewClient:  kumactl_resources.NewZoneEgressOverviewClient,
 			NewZoneOverviewClient:        kumactl_resources.NewZoneOverviewClient,
@@ -193,6 +199,30 @@ func (rc *RootContext) CurrentDataplaneOverviewClient() (kumactl_resources.Datap
 		return nil, err
 	}
 	return rc.Runtime.NewDataplaneOverviewClient(client), nil
+}
+
+func (rc *RootContext) CurrentDataplaneInspectClient() (kumactl_resources.DataplaneInspectClient, error) {
+	client, err := rc.BaseAPIServerClient()
+	if err != nil {
+		return nil, err
+	}
+	return rc.Runtime.NewDataplaneInspectClient(client), nil
+}
+
+func (rc *RootContext) CurrentZoneIngressInspectClient() (kumactl_resources.ZoneIngressInspectClient, error) {
+	client, err := rc.BaseAPIServerClient()
+	if err != nil {
+		return nil, err
+	}
+	return rc.Runtime.NewZoneIngressInspectClient(client), nil
+}
+
+func (rc *RootContext) CurrentPolicyInspectClient() (kumactl_resources.PolicyInspectClient, error) {
+	client, err := rc.BaseAPIServerClient()
+	if err != nil {
+		return nil, err
+	}
+	return rc.Runtime.NewPolicyInspectClient(client), nil
 }
 
 func (rc *RootContext) CurrentZoneOverviewClient() (kumactl_resources.ZoneOverviewClient, error) {

--- a/app/kumactl/pkg/resources/dataplane_inspect_client.go
+++ b/app/kumactl/pkg/resources/dataplane_inspect_client.go
@@ -1,0 +1,76 @@
+package resources
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/pkg/errors"
+
+	api_server_types "github.com/kumahq/kuma/pkg/api-server/types"
+	"github.com/kumahq/kuma/pkg/core/resources/registry"
+	util_http "github.com/kumahq/kuma/pkg/util/http"
+)
+
+type DataplaneInspectClient interface {
+	InspectPolicies(ctx context.Context, mesh, name string) (*api_server_types.DataplaneInspectEntryList, error)
+	InspectConfigDump(ctx context.Context, mesh, name string) ([]byte, error)
+}
+
+func NewDataplaneInspectClient(client util_http.Client) DataplaneInspectClient {
+	return &httpDataplaneInspectClient{
+		Client: client,
+	}
+}
+
+type httpDataplaneInspectClient struct {
+	Client util_http.Client
+}
+
+var _ DataplaneInspectClient = &httpDataplaneInspectClient{}
+
+func (h *httpDataplaneInspectClient) InspectPolicies(ctx context.Context, mesh, name string) (*api_server_types.DataplaneInspectEntryList, error) {
+	resUrl, err := url.Parse(fmt.Sprintf("/meshes/%s/dataplanes/%s/policies", mesh, name))
+	if err != nil {
+		return nil, errors.Wrap(err, "could not construct the url")
+	}
+	req, err := http.NewRequest("GET", resUrl.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+	statusCode, b, err := doRequest(h.Client, ctx, req)
+	if err != nil {
+		return nil, err
+	}
+	if statusCode != 200 {
+		return nil, errors.Errorf("(%d): %s", statusCode, string(b))
+	}
+	receiver := &api_server_types.DataplaneInspectEntryListReceiver{
+		NewResource: registry.Global().NewObject,
+	}
+	if err := json.Unmarshal(b, receiver); err != nil {
+		return nil, err
+	}
+	return &receiver.DataplaneInspectEntryList, nil
+}
+
+func (h *httpDataplaneInspectClient) InspectConfigDump(ctx context.Context, mesh, name string) ([]byte, error) {
+	resUrl, err := url.Parse(fmt.Sprintf("/meshes/%s/dataplanes/%s/xds", mesh, name))
+	if err != nil {
+		return nil, errors.Wrap(err, "could not construct the url")
+	}
+	req, err := http.NewRequest("GET", resUrl.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+	statusCode, b, err := doRequest(h.Client, ctx, req)
+	if err != nil {
+		return nil, err
+	}
+	if statusCode != 200 {
+		return nil, errors.Errorf("(%d): %s", statusCode, string(b))
+	}
+	return b, nil
+}

--- a/app/kumactl/pkg/resources/policy_inspect_client.go
+++ b/app/kumactl/pkg/resources/policy_inspect_client.go
@@ -1,0 +1,54 @@
+package resources
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/pkg/errors"
+
+	api_server_types "github.com/kumahq/kuma/pkg/api-server/types"
+	core_model "github.com/kumahq/kuma/pkg/core/resources/model"
+	util_http "github.com/kumahq/kuma/pkg/util/http"
+)
+
+type PolicyInspectClient interface {
+	Inspect(ctx context.Context, policyDesc core_model.ResourceTypeDescriptor, mesh, name string) (*api_server_types.PolicyInspectEntryList, error)
+}
+
+func NewPolicyInspectClient(client util_http.Client) PolicyInspectClient {
+	return &httpPolicyInspectClient{
+		Client: client,
+	}
+}
+
+var _ PolicyInspectClient = &httpPolicyInspectClient{}
+
+type httpPolicyInspectClient struct {
+	Client util_http.Client
+}
+
+func (h *httpPolicyInspectClient) Inspect(ctx context.Context, policyDesc core_model.ResourceTypeDescriptor, mesh, name string) (*api_server_types.PolicyInspectEntryList, error) {
+	resUrl, err := url.Parse(fmt.Sprintf("/meshes/%s/%s/%s/dataplanes", mesh, policyDesc.WsPath, name))
+	if err != nil {
+		return nil, errors.Wrap(err, "could not construct the url")
+	}
+	req, err := http.NewRequest("GET", resUrl.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+	statusCode, b, err := doRequest(h.Client, ctx, req)
+	if err != nil {
+		return nil, err
+	}
+	if statusCode != 200 {
+		return nil, errors.Errorf("(%d): %s", statusCode, string(b))
+	}
+	entryList := &api_server_types.PolicyInspectEntryList{}
+	if err := json.Unmarshal(b, entryList); err != nil {
+		return nil, err
+	}
+	return entryList, nil
+}

--- a/app/kumactl/pkg/resources/zoneingress_inspect_client.go
+++ b/app/kumactl/pkg/resources/zoneingress_inspect_client.go
@@ -1,0 +1,47 @@
+package resources
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/pkg/errors"
+
+	util_http "github.com/kumahq/kuma/pkg/util/http"
+)
+
+type ZoneIngressInspectClient interface {
+	InspectConfigDump(ctx context.Context, name string) ([]byte, error)
+}
+
+func NewZoneIngressInspectClient(client util_http.Client) ZoneIngressInspectClient {
+	return &httpZoneIngressInspectClient{
+		Client: client,
+	}
+}
+
+type httpZoneIngressInspectClient struct {
+	Client util_http.Client
+}
+
+var _ ZoneIngressInspectClient = &httpZoneIngressInspectClient{}
+
+func (h *httpZoneIngressInspectClient) InspectConfigDump(ctx context.Context, name string) ([]byte, error) {
+	resUrl, err := url.Parse(fmt.Sprintf("/zoneingresses/%s/xds", name))
+	if err != nil {
+		return nil, errors.Wrap(err, "could not construct the url")
+	}
+	req, err := http.NewRequest("GET", resUrl.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+	statusCode, b, err := doRequest(h.Client, ctx, req)
+	if err != nil {
+		return nil, err
+	}
+	if statusCode != 200 {
+		return nil, errors.Errorf("(%d): %s", statusCode, string(b))
+	}
+	return b, nil
+}

--- a/docs/cmd/kumactl/kumactl_inspect.md
+++ b/docs/cmd/kumactl/kumactl_inspect.md
@@ -26,10 +26,23 @@ Inspect Kuma resources.
 ### SEE ALSO
 
 * [kumactl](kumactl.md)	 - Management tool for Kuma
+* [kumactl inspect circuit-breaker](kumactl_inspect_circuit-breaker.md)	 - Inspect circuit-breaker
+* [kumactl inspect dataplane](kumactl_inspect_dataplane.md)	 - Inspect Dataplane
 * [kumactl inspect dataplanes](kumactl_inspect_dataplanes.md)	 - Inspect Dataplanes
+* [kumactl inspect fault-injection](kumactl_inspect_fault-injection.md)	 - Inspect fault-injection
+* [kumactl inspect healthcheck](kumactl_inspect_healthcheck.md)	 - Inspect healthcheck
 * [kumactl inspect meshes](kumactl_inspect_meshes.md)	 - Inspect Meshes
+* [kumactl inspect proxytemplate](kumactl_inspect_proxytemplate.md)	 - Inspect proxytemplate
+* [kumactl inspect rate-limit](kumactl_inspect_rate-limit.md)	 - Inspect rate-limit
+* [kumactl inspect retry](kumactl_inspect_retry.md)	 - Inspect retry
 * [kumactl inspect services](kumactl_inspect_services.md)	 - Inspect Services
+* [kumactl inspect timeout](kumactl_inspect_timeout.md)	 - Inspect timeout
+* [kumactl inspect traffic-log](kumactl_inspect_traffic-log.md)	 - Inspect traffic-log
+* [kumactl inspect traffic-permission](kumactl_inspect_traffic-permission.md)	 - Inspect traffic-permission
+* [kumactl inspect traffic-route](kumactl_inspect_traffic-route.md)	 - Inspect traffic-route
+* [kumactl inspect traffic-trace](kumactl_inspect_traffic-trace.md)	 - Inspect traffic-trace
 * [kumactl inspect zone-ingresses](kumactl_inspect_zone-ingresses.md)	 - Inspect Zone Ingresses
 * [kumactl inspect zoneegresses](kumactl_inspect_zoneegresses.md)	 - Inspect Zone Egresses
+* [kumactl inspect zoneingress](kumactl_inspect_zoneingress.md)	 - Inspect ZoneIngress
 * [kumactl inspect zones](kumactl_inspect_zones.md)	 - Inspect Zones
 

--- a/docs/cmd/kumactl/kumactl_inspect.md
+++ b/docs/cmd/kumactl/kumactl_inspect.md
@@ -26,21 +26,21 @@ Inspect Kuma resources.
 ### SEE ALSO
 
 * [kumactl](kumactl.md)	 - Management tool for Kuma
-* [kumactl inspect circuit-breaker](kumactl_inspect_circuit-breaker.md)	 - Inspect circuit-breaker
+* [kumactl inspect circuit-breaker](kumactl_inspect_circuit-breaker.md)	 - Inspect CircuitBreaker
 * [kumactl inspect dataplane](kumactl_inspect_dataplane.md)	 - Inspect Dataplane
 * [kumactl inspect dataplanes](kumactl_inspect_dataplanes.md)	 - Inspect Dataplanes
-* [kumactl inspect fault-injection](kumactl_inspect_fault-injection.md)	 - Inspect fault-injection
-* [kumactl inspect healthcheck](kumactl_inspect_healthcheck.md)	 - Inspect healthcheck
+* [kumactl inspect fault-injection](kumactl_inspect_fault-injection.md)	 - Inspect FaultInjection
+* [kumactl inspect healthcheck](kumactl_inspect_healthcheck.md)	 - Inspect HealthCheck
 * [kumactl inspect meshes](kumactl_inspect_meshes.md)	 - Inspect Meshes
-* [kumactl inspect proxytemplate](kumactl_inspect_proxytemplate.md)	 - Inspect proxytemplate
-* [kumactl inspect rate-limit](kumactl_inspect_rate-limit.md)	 - Inspect rate-limit
-* [kumactl inspect retry](kumactl_inspect_retry.md)	 - Inspect retry
+* [kumactl inspect proxytemplate](kumactl_inspect_proxytemplate.md)	 - Inspect ProxyTemplate
+* [kumactl inspect rate-limit](kumactl_inspect_rate-limit.md)	 - Inspect RateLimit
+* [kumactl inspect retry](kumactl_inspect_retry.md)	 - Inspect Retry
 * [kumactl inspect services](kumactl_inspect_services.md)	 - Inspect Services
-* [kumactl inspect timeout](kumactl_inspect_timeout.md)	 - Inspect timeout
-* [kumactl inspect traffic-log](kumactl_inspect_traffic-log.md)	 - Inspect traffic-log
-* [kumactl inspect traffic-permission](kumactl_inspect_traffic-permission.md)	 - Inspect traffic-permission
-* [kumactl inspect traffic-route](kumactl_inspect_traffic-route.md)	 - Inspect traffic-route
-* [kumactl inspect traffic-trace](kumactl_inspect_traffic-trace.md)	 - Inspect traffic-trace
+* [kumactl inspect timeout](kumactl_inspect_timeout.md)	 - Inspect Timeout
+* [kumactl inspect traffic-log](kumactl_inspect_traffic-log.md)	 - Inspect TrafficLog
+* [kumactl inspect traffic-permission](kumactl_inspect_traffic-permission.md)	 - Inspect TrafficPermission
+* [kumactl inspect traffic-route](kumactl_inspect_traffic-route.md)	 - Inspect TrafficRoute
+* [kumactl inspect traffic-trace](kumactl_inspect_traffic-trace.md)	 - Inspect TrafficTrace
 * [kumactl inspect zone-ingresses](kumactl_inspect_zone-ingresses.md)	 - Inspect Zone Ingresses
 * [kumactl inspect zoneegresses](kumactl_inspect_zoneegresses.md)	 - Inspect Zone Egresses
 * [kumactl inspect zoneingress](kumactl_inspect_zoneingress.md)	 - Inspect ZoneIngress

--- a/docs/cmd/kumactl/kumactl_inspect_circuit-breaker.md
+++ b/docs/cmd/kumactl/kumactl_inspect_circuit-breaker.md
@@ -1,0 +1,33 @@
+## kumactl inspect circuit-breaker
+
+Inspect CircuitBreaker
+
+### Synopsis
+
+Inspect CircuitBreaker.
+
+```
+kumactl inspect circuit-breaker NAME [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for circuit-breaker
+```
+
+### Options inherited from parent commands
+
+```
+      --api-timeout duration   the timeout for api calls. It includes connection time, any redirects, and reading the response body. A timeout of zero means no timeout (default 1m0s)
+      --config-file string     path to the configuration file to use
+      --log-level string       log level: one of off|info|debug (default "off")
+  -m, --mesh string            mesh to use (default "default")
+      --no-config              if set no config file and config directory will be created
+  -o, --output string          output format: one of table|yaml|json (default "table")
+```
+
+### SEE ALSO
+
+* [kumactl inspect](kumactl_inspect.md)	 - Inspect Kuma resources
+

--- a/docs/cmd/kumactl/kumactl_inspect_dataplane.md
+++ b/docs/cmd/kumactl/kumactl_inspect_dataplane.md
@@ -1,0 +1,34 @@
+## kumactl inspect dataplane
+
+Inspect Dataplane
+
+### Synopsis
+
+Inspect Dataplane.
+
+```
+kumactl inspect dataplane NAME [flags]
+```
+
+### Options
+
+```
+      --config-dump   if set then the command returns envoy config dump for provided dataplane
+  -h, --help          help for dataplane
+```
+
+### Options inherited from parent commands
+
+```
+      --api-timeout duration   the timeout for api calls. It includes connection time, any redirects, and reading the response body. A timeout of zero means no timeout (default 1m0s)
+      --config-file string     path to the configuration file to use
+      --log-level string       log level: one of off|info|debug (default "off")
+  -m, --mesh string            mesh to use (default "default")
+      --no-config              if set no config file and config directory will be created
+  -o, --output string          output format: one of table|yaml|json (default "table")
+```
+
+### SEE ALSO
+
+* [kumactl inspect](kumactl_inspect.md)	 - Inspect Kuma resources
+

--- a/docs/cmd/kumactl/kumactl_inspect_fault-injection.md
+++ b/docs/cmd/kumactl/kumactl_inspect_fault-injection.md
@@ -1,0 +1,33 @@
+## kumactl inspect fault-injection
+
+Inspect FaultInjection
+
+### Synopsis
+
+Inspect FaultInjection.
+
+```
+kumactl inspect fault-injection NAME [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for fault-injection
+```
+
+### Options inherited from parent commands
+
+```
+      --api-timeout duration   the timeout for api calls. It includes connection time, any redirects, and reading the response body. A timeout of zero means no timeout (default 1m0s)
+      --config-file string     path to the configuration file to use
+      --log-level string       log level: one of off|info|debug (default "off")
+  -m, --mesh string            mesh to use (default "default")
+      --no-config              if set no config file and config directory will be created
+  -o, --output string          output format: one of table|yaml|json (default "table")
+```
+
+### SEE ALSO
+
+* [kumactl inspect](kumactl_inspect.md)	 - Inspect Kuma resources
+

--- a/docs/cmd/kumactl/kumactl_inspect_healthcheck.md
+++ b/docs/cmd/kumactl/kumactl_inspect_healthcheck.md
@@ -1,0 +1,33 @@
+## kumactl inspect healthcheck
+
+Inspect HealthCheck
+
+### Synopsis
+
+Inspect HealthCheck.
+
+```
+kumactl inspect healthcheck NAME [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for healthcheck
+```
+
+### Options inherited from parent commands
+
+```
+      --api-timeout duration   the timeout for api calls. It includes connection time, any redirects, and reading the response body. A timeout of zero means no timeout (default 1m0s)
+      --config-file string     path to the configuration file to use
+      --log-level string       log level: one of off|info|debug (default "off")
+  -m, --mesh string            mesh to use (default "default")
+      --no-config              if set no config file and config directory will be created
+  -o, --output string          output format: one of table|yaml|json (default "table")
+```
+
+### SEE ALSO
+
+* [kumactl inspect](kumactl_inspect.md)	 - Inspect Kuma resources
+

--- a/docs/cmd/kumactl/kumactl_inspect_proxytemplate.md
+++ b/docs/cmd/kumactl/kumactl_inspect_proxytemplate.md
@@ -1,0 +1,33 @@
+## kumactl inspect proxytemplate
+
+Inspect ProxyTemplate
+
+### Synopsis
+
+Inspect ProxyTemplate.
+
+```
+kumactl inspect proxytemplate NAME [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for proxytemplate
+```
+
+### Options inherited from parent commands
+
+```
+      --api-timeout duration   the timeout for api calls. It includes connection time, any redirects, and reading the response body. A timeout of zero means no timeout (default 1m0s)
+      --config-file string     path to the configuration file to use
+      --log-level string       log level: one of off|info|debug (default "off")
+  -m, --mesh string            mesh to use (default "default")
+      --no-config              if set no config file and config directory will be created
+  -o, --output string          output format: one of table|yaml|json (default "table")
+```
+
+### SEE ALSO
+
+* [kumactl inspect](kumactl_inspect.md)	 - Inspect Kuma resources
+

--- a/docs/cmd/kumactl/kumactl_inspect_rate-limit.md
+++ b/docs/cmd/kumactl/kumactl_inspect_rate-limit.md
@@ -1,0 +1,33 @@
+## kumactl inspect rate-limit
+
+Inspect RateLimit
+
+### Synopsis
+
+Inspect RateLimit.
+
+```
+kumactl inspect rate-limit NAME [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for rate-limit
+```
+
+### Options inherited from parent commands
+
+```
+      --api-timeout duration   the timeout for api calls. It includes connection time, any redirects, and reading the response body. A timeout of zero means no timeout (default 1m0s)
+      --config-file string     path to the configuration file to use
+      --log-level string       log level: one of off|info|debug (default "off")
+  -m, --mesh string            mesh to use (default "default")
+      --no-config              if set no config file and config directory will be created
+  -o, --output string          output format: one of table|yaml|json (default "table")
+```
+
+### SEE ALSO
+
+* [kumactl inspect](kumactl_inspect.md)	 - Inspect Kuma resources
+

--- a/docs/cmd/kumactl/kumactl_inspect_retry.md
+++ b/docs/cmd/kumactl/kumactl_inspect_retry.md
@@ -1,0 +1,33 @@
+## kumactl inspect retry
+
+Inspect Retry
+
+### Synopsis
+
+Inspect Retry.
+
+```
+kumactl inspect retry NAME [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for retry
+```
+
+### Options inherited from parent commands
+
+```
+      --api-timeout duration   the timeout for api calls. It includes connection time, any redirects, and reading the response body. A timeout of zero means no timeout (default 1m0s)
+      --config-file string     path to the configuration file to use
+      --log-level string       log level: one of off|info|debug (default "off")
+  -m, --mesh string            mesh to use (default "default")
+      --no-config              if set no config file and config directory will be created
+  -o, --output string          output format: one of table|yaml|json (default "table")
+```
+
+### SEE ALSO
+
+* [kumactl inspect](kumactl_inspect.md)	 - Inspect Kuma resources
+

--- a/docs/cmd/kumactl/kumactl_inspect_timeout.md
+++ b/docs/cmd/kumactl/kumactl_inspect_timeout.md
@@ -1,0 +1,33 @@
+## kumactl inspect timeout
+
+Inspect Timeout
+
+### Synopsis
+
+Inspect Timeout.
+
+```
+kumactl inspect timeout NAME [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for timeout
+```
+
+### Options inherited from parent commands
+
+```
+      --api-timeout duration   the timeout for api calls. It includes connection time, any redirects, and reading the response body. A timeout of zero means no timeout (default 1m0s)
+      --config-file string     path to the configuration file to use
+      --log-level string       log level: one of off|info|debug (default "off")
+  -m, --mesh string            mesh to use (default "default")
+      --no-config              if set no config file and config directory will be created
+  -o, --output string          output format: one of table|yaml|json (default "table")
+```
+
+### SEE ALSO
+
+* [kumactl inspect](kumactl_inspect.md)	 - Inspect Kuma resources
+

--- a/docs/cmd/kumactl/kumactl_inspect_traffic-log.md
+++ b/docs/cmd/kumactl/kumactl_inspect_traffic-log.md
@@ -1,0 +1,33 @@
+## kumactl inspect traffic-log
+
+Inspect TrafficLog
+
+### Synopsis
+
+Inspect TrafficLog.
+
+```
+kumactl inspect traffic-log NAME [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for traffic-log
+```
+
+### Options inherited from parent commands
+
+```
+      --api-timeout duration   the timeout for api calls. It includes connection time, any redirects, and reading the response body. A timeout of zero means no timeout (default 1m0s)
+      --config-file string     path to the configuration file to use
+      --log-level string       log level: one of off|info|debug (default "off")
+  -m, --mesh string            mesh to use (default "default")
+      --no-config              if set no config file and config directory will be created
+  -o, --output string          output format: one of table|yaml|json (default "table")
+```
+
+### SEE ALSO
+
+* [kumactl inspect](kumactl_inspect.md)	 - Inspect Kuma resources
+

--- a/docs/cmd/kumactl/kumactl_inspect_traffic-permission.md
+++ b/docs/cmd/kumactl/kumactl_inspect_traffic-permission.md
@@ -1,0 +1,33 @@
+## kumactl inspect traffic-permission
+
+Inspect TrafficPermission
+
+### Synopsis
+
+Inspect TrafficPermission.
+
+```
+kumactl inspect traffic-permission NAME [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for traffic-permission
+```
+
+### Options inherited from parent commands
+
+```
+      --api-timeout duration   the timeout for api calls. It includes connection time, any redirects, and reading the response body. A timeout of zero means no timeout (default 1m0s)
+      --config-file string     path to the configuration file to use
+      --log-level string       log level: one of off|info|debug (default "off")
+  -m, --mesh string            mesh to use (default "default")
+      --no-config              if set no config file and config directory will be created
+  -o, --output string          output format: one of table|yaml|json (default "table")
+```
+
+### SEE ALSO
+
+* [kumactl inspect](kumactl_inspect.md)	 - Inspect Kuma resources
+

--- a/docs/cmd/kumactl/kumactl_inspect_traffic-route.md
+++ b/docs/cmd/kumactl/kumactl_inspect_traffic-route.md
@@ -1,0 +1,33 @@
+## kumactl inspect traffic-route
+
+Inspect TrafficRoute
+
+### Synopsis
+
+Inspect TrafficRoute.
+
+```
+kumactl inspect traffic-route NAME [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for traffic-route
+```
+
+### Options inherited from parent commands
+
+```
+      --api-timeout duration   the timeout for api calls. It includes connection time, any redirects, and reading the response body. A timeout of zero means no timeout (default 1m0s)
+      --config-file string     path to the configuration file to use
+      --log-level string       log level: one of off|info|debug (default "off")
+  -m, --mesh string            mesh to use (default "default")
+      --no-config              if set no config file and config directory will be created
+  -o, --output string          output format: one of table|yaml|json (default "table")
+```
+
+### SEE ALSO
+
+* [kumactl inspect](kumactl_inspect.md)	 - Inspect Kuma resources
+

--- a/docs/cmd/kumactl/kumactl_inspect_traffic-trace.md
+++ b/docs/cmd/kumactl/kumactl_inspect_traffic-trace.md
@@ -1,0 +1,33 @@
+## kumactl inspect traffic-trace
+
+Inspect TrafficTrace
+
+### Synopsis
+
+Inspect TrafficTrace.
+
+```
+kumactl inspect traffic-trace NAME [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for traffic-trace
+```
+
+### Options inherited from parent commands
+
+```
+      --api-timeout duration   the timeout for api calls. It includes connection time, any redirects, and reading the response body. A timeout of zero means no timeout (default 1m0s)
+      --config-file string     path to the configuration file to use
+      --log-level string       log level: one of off|info|debug (default "off")
+  -m, --mesh string            mesh to use (default "default")
+      --no-config              if set no config file and config directory will be created
+  -o, --output string          output format: one of table|yaml|json (default "table")
+```
+
+### SEE ALSO
+
+* [kumactl inspect](kumactl_inspect.md)	 - Inspect Kuma resources
+

--- a/docs/cmd/kumactl/kumactl_inspect_zoneingress.md
+++ b/docs/cmd/kumactl/kumactl_inspect_zoneingress.md
@@ -1,0 +1,34 @@
+## kumactl inspect zoneingress
+
+Inspect ZoneIngress
+
+### Synopsis
+
+Inspect ZoneIngress.
+
+```
+kumactl inspect zoneingress NAME [flags]
+```
+
+### Options
+
+```
+      --config-dump   if set then the command returns envoy config dump for provided dataplane
+  -h, --help          help for zoneingress
+```
+
+### Options inherited from parent commands
+
+```
+      --api-timeout duration   the timeout for api calls. It includes connection time, any redirects, and reading the response body. A timeout of zero means no timeout (default 1m0s)
+      --config-file string     path to the configuration file to use
+      --log-level string       log level: one of off|info|debug (default "off")
+  -m, --mesh string            mesh to use (default "default")
+      --no-config              if set no config file and config directory will be created
+  -o, --output string          output format: one of table|yaml|json (default "table")
+```
+
+### SEE ALSO
+
+* [kumactl inspect](kumactl_inspect.md)	 - Inspect Kuma resources
+

--- a/pkg/api-server/types/inspect_test.go
+++ b/pkg/api-server/types/inspect_test.go
@@ -126,6 +126,23 @@ var _ = Describe("Unmarshal DataplaneInspectEntry", func() {
 		}),
 	)
 
+	It("should unmarshal DataplaneInspectEntryList", func() {
+		// given
+		input, err := os.ReadFile(path.Join("testdata", "dataplane_inspect_entry_list.json"))
+		Expect(err).ToNot(HaveOccurred())
+
+		// when
+		receiver := &types.DataplaneInspectEntryListReceiver{
+			NewResource: registry.Global().NewObject,
+		}
+		Expect(json.Unmarshal(input, receiver)).To(Succeed())
+		entryList := receiver.DataplaneInspectEntryList
+
+		// then
+		Expect(entryList.Total).To(Equal(uint32(3)))
+		Expect(entryList.Items).To(HaveLen(3))
+	})
+
 	DescribeTable("should return error",
 		func(given testCase) {
 			inputFile, err := os.Open(path.Join("testdata", given.inputFile))

--- a/pkg/api-server/types/testdata/dataplane_inspect_entry_list.json
+++ b/pkg/api-server/types/testdata/dataplane_inspect_entry_list.json
@@ -1,0 +1,191 @@
+{
+  "total": 3,
+  "items": [
+    {
+      "type": "inbound",
+      "name": "127.0.0.1:10010:10011",
+      "service": "backend",
+      "matchedPolicies": {
+        "TrafficPermission": [
+          {
+            "type": "TrafficPermission",
+            "mesh": "default",
+            "name": "allow-all-default",
+            "creationTime": "2022-02-04T12:42:09.91128+01:00",
+            "modificationTime": "2022-02-04T12:42:09.91128+01:00",
+            "sources": [
+              {
+                "match": {
+                  "kuma.io/service": "*"
+                }
+              }
+            ],
+            "destinations": [
+              {
+                "match": {
+                  "kuma.io/service": "*"
+                }
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "type": "outbound",
+      "name": "127.0.0.1:10006",
+      "service": "gateway",
+      "matchedPolicies": {
+        "Timeout": [
+          {
+            "type": "Timeout",
+            "mesh": "default",
+            "name": "timeout-all-default",
+            "creationTime": "2022-02-04T12:42:09.912324+01:00",
+            "modificationTime": "2022-02-04T12:42:09.912324+01:00",
+            "sources": [
+              {
+                "match": {
+                  "kuma.io/service": "*"
+                }
+              }
+            ],
+            "destinations": [
+              {
+                "match": {
+                  "kuma.io/service": "*"
+                }
+              }
+            ],
+            "conf": {
+              "connectTimeout": "5s",
+              "tcp": {
+                "idleTimeout": "3600s"
+              },
+              "http": {
+                "requestTimeout": "15s",
+                "idleTimeout": "3600s"
+              },
+              "grpc": {
+                "streamIdleTimeout": "300s"
+              }
+            }
+          }
+        ],
+        "TrafficRoute": [
+          {
+            "type": "TrafficRoute",
+            "mesh": "default",
+            "name": "route-all-default",
+            "creationTime": "2022-02-04T12:42:09.911501+01:00",
+            "modificationTime": "2022-02-04T12:42:09.911501+01:00",
+            "sources": [
+              {
+                "match": {
+                  "kuma.io/service": "*"
+                }
+              }
+            ],
+            "destinations": [
+              {
+                "match": {
+                  "kuma.io/service": "*"
+                }
+              }
+            ],
+            "conf": {
+              "loadBalancer": {
+                "roundRobin": {}
+              },
+              "destination": {
+                "kuma.io/service": "gateway"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "type": "service",
+      "name": "gateway",
+      "service": "gateway",
+      "matchedPolicies": {
+        "CircuitBreaker": [
+          {
+            "type": "CircuitBreaker",
+            "mesh": "default",
+            "name": "circuit-breaker-all-default",
+            "creationTime": "2022-02-04T12:42:09.912978+01:00",
+            "modificationTime": "2022-02-04T12:42:09.912978+01:00",
+            "sources": [
+              {
+                "match": {
+                  "kuma.io/service": "*"
+                }
+              }
+            ],
+            "destinations": [
+              {
+                "match": {
+                  "kuma.io/service": "*"
+                }
+              }
+            ],
+            "conf": {
+              "thresholds": {
+                "maxConnections": 1024,
+                "maxPendingRequests": 1024,
+                "maxRetries": 3,
+                "maxRequests": 1024
+              }
+            }
+          }
+        ],
+        "Retry": [
+          {
+            "type": "Retry",
+            "mesh": "default",
+            "name": "retry-all-default",
+            "creationTime": "2022-02-04T12:42:09.913215+01:00",
+            "modificationTime": "2022-02-04T12:42:09.913215+01:00",
+            "sources": [
+              {
+                "match": {
+                  "kuma.io/service": "*"
+                }
+              }
+            ],
+            "destinations": [
+              {
+                "match": {
+                  "kuma.io/service": "*"
+                }
+              }
+            ],
+            "conf": {
+              "http": {
+                "numRetries": 5,
+                "perTryTimeout": "16s",
+                "backOff": {
+                  "baseInterval": "0.025s",
+                  "maxInterval": "0.250s"
+                }
+              },
+              "tcp": {
+                "maxConnectAttempts": 5
+              },
+              "grpc": {
+                "numRetries": 5,
+                "perTryTimeout": "16s",
+                "backOff": {
+                  "baseInterval": "0.025s",
+                  "maxInterval": "0.250s"
+                }
+              }
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/test/e2e/inspect/inspect_k8s_multizone.go
+++ b/test/e2e/inspect/inspect_k8s_multizone.go
@@ -99,8 +99,7 @@ spec:
 
 	It("should return envoy config_dump for zone ingress", func() {
 		zoneIngressName := fmt.Sprintf("%s.%s", zoneIngress.GetName(), Config.KumaNamespace)
-		url := fmt.Sprintf("localhost:5681/zoneingresses/%s/xds", zoneIngressName)
-		cmd := []string{"wget", "-O-", url}
+		cmd := []string{"kumactl", "inspect", "zoneingress", zoneIngressName, "--config-dump"}
 
 		stdout, _, err := zoneK8s.ExecWithRetries(Config.KumaNamespace, kumaControlPlane.GetName(), "control-plane", cmd...)
 		Expect(err).ToNot(HaveOccurred())

--- a/test/e2e/inspect/inspect_k8s_standalone.go
+++ b/test/e2e/inspect/inspect_k8s_standalone.go
@@ -67,8 +67,7 @@ func KubernetesStandalone() {
 
 	It("should return envoy config_dump", func() {
 		dataplaneName := fmt.Sprintf("%s.%s", demoClient.GetName(), TestNamespace)
-		url := fmt.Sprintf("localhost:5681/meshes/default/dataplanes/%s/xds", dataplaneName)
-		cmd := []string{"wget", "-O-", url}
+		cmd := []string{"kumactl", "inspect", "dataplane", dataplaneName, "--config-dump"}
 
 		stdout, _, err := cluster.ExecWithRetries(Config.KumaNamespace, kumaControlPlane.GetName(), "control-plane", cmd...)
 		Expect(err).ToNot(HaveOccurred())

--- a/test/e2e/inspect/inspect_suite_test.go
+++ b/test/e2e/inspect/inspect_suite_test.go
@@ -11,9 +11,8 @@ import (
 
 var _ = Describe("Test Inspect API on Universal", inspect.Universal)
 
-// Disabling tests to implement them later using `kumactl` instead of `wget`
-var _ = XDescribe("Test Inspect API on Kubernetes Standalone", inspect.KubernetesStandalone)
-var _ = XDescribe("Test Inspect API on Kubernetes Multizone", inspect.KubernetesMultizone)
+var _ = Describe("Test Inspect API on Kubernetes Standalone", inspect.KubernetesStandalone)
+var _ = Describe("Test Inspect API on Kubernetes Multizone", inspect.KubernetesMultizone)
 
 func TestE2EInspectAPI(t *testing.T) {
 	test.RunSpecs(t, "E2E Inspect API Suite")


### PR DESCRIPTION
### Summary

Current PR introduces new commands for `kumactl` that enable people to use Inspect API.
New commands:
 * `$ kumactl inspect dataplane NAME` – see what policies were applied for the DPP
 * `$ kumactl inspect dataplane NAME --config-dump` – see envoy config dump for DPP
 * `$ kumactl inspect zoneingress NAME --config-dump` – see envoy config dump for ZoneIngress
 * `$ kumactl inspect POLICY NAME` -- see what DPPs are affected by policy

### Full changelog

* introduce new `kumactl` commands
* enable Inspect API e2e tests

### Issues resolved

Fix https://github.com/kumahq/kuma/issues/3730

### Documentation

- [ ] Link to the website [documentation PR](https://github.com/kumahq/kuma-website/pull/XXX) WIP

### Testing

- [X] Unit tests
- [X] E2E tests
- [X] Manual testing on Universal
- [X] Manual testing on Kubernetes

### Backwards compatibility

~- [ ] Update [`UPGRADE.md`](/UPGRADE.md) with any steps users will need to take when upgrading.~
~- [ ] Add `backport-to-stable` label if the code follows our [backporting policy](/CONTRIBUTING.md#backporting)~
