### PR TITLE
feat(kuma-cp): add support for custom inbound policies

### DIFF
--- a/pkg/core/xds/matched_policies.go
+++ b/pkg/core/xds/matched_policies.go
@@ -11,9 +11,10 @@ import (
 
 type MatchedPolicies struct {
 	// Inbound(Listener) -> Policy
-	TrafficPermissions TrafficPermissionMap
-	FaultInjections    FaultInjectionMap
-	RateLimitsInbound  InboundRateLimitsMap
+	TrafficPermissions    TrafficPermissionMap
+	FaultInjections       FaultInjectionMap
+	RateLimitsInbound     InboundRateLimitsMap
+	CustomInboundPolicies []map[mesh_proto.InboundInterface]core_model.Resource
 
 	// Service(Cluster) -> Policy
 	TrafficLogs     TrafficLogMap
@@ -182,6 +183,11 @@ func getInboundMatchedPolicies(matchedPolicies *MatchedPolicies) map[mesh_proto.
 	for inbound, rlList := range matchedPolicies.RateLimitsInbound {
 		for _, rl := range rlList {
 			result[inbound] = append(result[inbound], rl)
+		}
+	}
+	for _, customPolicy := range matchedPolicies.CustomInboundPolicies {
+		for inbound, customList := range customPolicy {
+			result[inbound] = append(result[inbound], customList)
 		}
 	}
 


### PR DESCRIPTION
### Summary

Add ability to add custom inbound policies to MatchedPolicies structure.

### Full changelog

* New `CustomInboundPolicies` field

### Issues resolved

N/A

### Documentation

~- [ ] Link to the website [documentation PR](https://github.com/kumahq/kuma-website/pull/XXX)~

### Testing

- [ ] Unit tests
- [ ] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes

### Backwards compatibility

~- [ ] Update [`UPGRADE.md`](/UPGRADE.md) with any steps users will need to take when upgrading.~
~- [ ] Add `backport-to-stable` label if the code follows our [backporting policy](/CONTRIBUTING.md#backporting)~
