### PR TITLE
fix(grafana): update to latest grafana plugin version

### DIFF
--- a/app/kumactl/cmd/install/testdata/install-metrics.defaults.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-metrics.defaults.golden.yaml
@@ -11945,7 +11945,6 @@ spec:
       labels:
         component: "node-exporter"
         app: prometheus
-      labels:
         kuma.io/sidecar-injection: "disabled" # disabled for now, injecting DP crashes K8S cluster
     spec:
       serviceAccountName: prometheus-node-exporter
@@ -12010,7 +12009,7 @@ spec:
       initContainers:
         - name: init-plugins
           image: alpine
-          command: [ '/bin/sh', '-c', 'wget -O /tmp/kuma.zip https://github.com/kumahq/kuma-grafana-datasource/releases/download/v0.0.3/kumahq-kuma-datasource-0.0.3.zip && unzip /tmp/kuma.zip -d /var/lib/grafana/plugins/ && rm /tmp/kuma.zip']
+          command: [ '/bin/sh', '-c', 'wget -O /tmp/kuma.zip https://github.com/kumahq/kuma-grafana-datasource/releases/download/v0.1.0/kumahq-kuma-datasource-0.1.0.zip && unzip /tmp/kuma.zip -d /var/lib/grafana/plugins/ && rm /tmp/kuma.zip']
           volumeMounts:
             - name: plugins-volume
               mountPath: /var/lib/grafana/plugins

--- a/app/kumactl/cmd/install/testdata/install-metrics.no-grafana.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-metrics.no-grafana.golden.yaml
@@ -767,7 +767,6 @@ spec:
       labels:
         component: "node-exporter"
         app: prometheus
-      labels:
         kuma.io/sidecar-injection: "disabled" # disabled for now, injecting DP crashes K8S cluster
     spec:
       serviceAccountName: prometheus-node-exporter

--- a/app/kumactl/cmd/install/testdata/install-metrics.no-prometheus.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-metrics.no-prometheus.golden.yaml
@@ -11218,7 +11218,7 @@ spec:
       initContainers:
         - name: init-plugins
           image: alpine
-          command: [ '/bin/sh', '-c', 'wget -O /tmp/kuma.zip https://github.com/kumahq/kuma-grafana-datasource/releases/download/v0.0.3/kumahq-kuma-datasource-0.0.3.zip && unzip /tmp/kuma.zip -d /var/lib/grafana/plugins/ && rm /tmp/kuma.zip']
+          command: [ '/bin/sh', '-c', 'wget -O /tmp/kuma.zip https://github.com/kumahq/kuma-grafana-datasource/releases/download/v0.1.0/kumahq-kuma-datasource-0.1.0.zip && unzip /tmp/kuma.zip -d /var/lib/grafana/plugins/ && rm /tmp/kuma.zip']
           volumeMounts:
             - name: plugins-volume
               mountPath: /var/lib/grafana/plugins

--- a/app/kumactl/cmd/install/testdata/install-metrics.overrides.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-metrics.overrides.golden.yaml
@@ -11945,7 +11945,6 @@ spec:
       labels:
         component: "node-exporter"
         app: prometheus
-      labels:
         kuma.io/sidecar-injection: "disabled" # disabled for now, injecting DP crashes K8S cluster
     spec:
       serviceAccountName: prometheus-node-exporter
@@ -12010,7 +12009,7 @@ spec:
       initContainers:
         - name: init-plugins
           image: alpine
-          command: [ '/bin/sh', '-c', 'wget -O /tmp/kuma.zip https://github.com/kumahq/kuma-grafana-datasource/releases/download/v0.0.3/kumahq-kuma-datasource-0.0.3.zip && unzip /tmp/kuma.zip -d /var/lib/grafana/plugins/ && rm /tmp/kuma.zip']
+          command: [ '/bin/sh', '-c', 'wget -O /tmp/kuma.zip https://github.com/kumahq/kuma-grafana-datasource/releases/download/v0.1.0/kumahq-kuma-datasource-0.1.0.zip && unzip /tmp/kuma.zip -d /var/lib/grafana/plugins/ && rm /tmp/kuma.zip']
           volumeMounts:
             - name: plugins-volume
               mountPath: /var/lib/grafana/plugins

--- a/app/kumactl/data/install/k8s/metrics/grafana/grafana.yaml
+++ b/app/kumactl/data/install/k8s/metrics/grafana/grafana.yaml
@@ -305,7 +305,7 @@ spec:
       initContainers:
         - name: init-plugins
           image: alpine
-          command: [ '/bin/sh', '-c', 'wget -O /tmp/kuma.zip https://github.com/kumahq/kuma-grafana-datasource/releases/download/v0.0.3/kumahq-kuma-datasource-0.0.3.zip && unzip /tmp/kuma.zip -d /var/lib/grafana/plugins/ && rm /tmp/kuma.zip']
+          command: [ '/bin/sh', '-c', 'wget -O /tmp/kuma.zip https://github.com/kumahq/kuma-grafana-datasource/releases/download/v0.1.0/kumahq-kuma-datasource-0.1.0.zip && unzip /tmp/kuma.zip -d /var/lib/grafana/plugins/ && rm /tmp/kuma.zip']
           volumeMounts:
             - name: plugins-volume
               mountPath: /var/lib/grafana/plugins

--- a/app/kumactl/data/install/k8s/metrics/prometheus/node-exporter.yaml
+++ b/app/kumactl/data/install/k8s/metrics/prometheus/node-exporter.yaml
@@ -50,7 +50,6 @@ spec:
       labels:
         component: "node-exporter"
         app: prometheus
-      labels:
         kuma.io/sidecar-injection: "disabled" # disabled for now, injecting DP crashes K8S cluster
     spec:
       serviceAccountName: prometheus-node-exporter


### PR DESCRIPTION
### Summary

- use version 0.1.0
- fix an error in the prometheus helm chart

### Testing

- [ ] Unit tests
- [ ] E2E tests
- [ ] Manual testing on Universal
- [x] Manual testing on Kubernetes

### Backwards compatibility

- ~~[ ] Update [`UPGRADE.md`](/UPGRADE.md) with any steps users will need to take when upgrading.~~
- ~~[ ] Add `backport-to-stable` label if the code follows our [backporting policy](/CONTRIBUTING.md#backporting)~~
