### PR TITLE
chore(ci): tests are not properly distributed across workers

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -870,6 +870,11 @@ jobs:
             - run:
                 name: "Run IPv4 E2E tests"
                 command: |
+                  echo $(circleci tests glob ./test/e2e/*)
+                  circleci tests glob ./test/e2e/* | xargs -n 1 echo
+                  echo $(circleci tests glob ./test/e2e/* | circleci tests split --total=$(ls test/e2e | wc -l))
+                  circleci tests glob ./test/e2e/* | circleci tests split --total=$(ls test/e2e | wc -l) | xargs -n 1 echo
+                  echo $(circleci tests glob ./test/e2e/* | circleci tests split --total=$(ls test/e2e | wc -l) | xargs printf "./%s/... ")
                   export CI_K3S_VERSION=<< parameters.k3sVersion >>
                   export E2E_PKG_LIST=$(circleci tests glob ./test/e2e/* | circleci tests split --total=$(ls test/e2e | wc -l) | xargs printf "./%s/... ")
                   export API_VERSION=<< parameters.api >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -855,7 +855,7 @@ jobs:
             - run:
                 name: "Run IPv6 E2E tests"
                 command: |
-                  export E2E_PKG_LIST=$(circleci tests glob ./test/e2e/* | circleci tests split --total=$(ls test/e2e | wc -l) | xargs printf "./%s/... ")
+                  export E2E_PKG_LIST=$(circleci tests glob ./test/e2e/* | circleci tests split | xargs printf "./%s/... ")
                   export API_VERSION=<< parameters.api >>
                   export IPV6=true
                   export KUMA_DEFAULT_RETRIES=60
@@ -870,10 +870,6 @@ jobs:
             - run:
                 name: "Run IPv4 E2E tests"
                 command: |
-                  echo $(circleci tests glob ./test/e2e/*)
-                  echo $(circleci tests glob ./test/e2e/* | circleci tests split)
-                  echo $(circleci tests glob ./test/e2e/* | circleci tests split --total=$(ls test/e2e | wc -l))
-                  echo $(ls test/e2e | wc -l)
                   export CI_K3S_VERSION=<< parameters.k3sVersion >>
                   export E2E_PKG_LIST=$(circleci tests glob ./test/e2e/* | circleci tests split | xargs printf "./%s/... ")
                   export API_VERSION=<< parameters.api >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -871,12 +871,11 @@ jobs:
                 name: "Run IPv4 E2E tests"
                 command: |
                   echo $(circleci tests glob ./test/e2e/*)
-                  circleci tests glob ./test/e2e/* | xargs -n 1 echo
+                  echo $(circleci tests glob ./test/e2e/* | circleci tests split)
                   echo $(circleci tests glob ./test/e2e/* | circleci tests split --total=$(ls test/e2e | wc -l))
-                  circleci tests glob ./test/e2e/* | circleci tests split --total=$(ls test/e2e | wc -l) | xargs -n 1 echo
-                  echo $(circleci tests glob ./test/e2e/* | circleci tests split --total=$(ls test/e2e | wc -l) | xargs printf "./%s/... ")
+                  echo $(ls test/e2e | wc -l)
                   export CI_K3S_VERSION=<< parameters.k3sVersion >>
-                  export E2E_PKG_LIST=$(circleci tests glob ./test/e2e/* | circleci tests split --total=$(ls test/e2e | wc -l) | xargs printf "./%s/... ")
+                  export E2E_PKG_LIST=$(circleci tests glob ./test/e2e/* | circleci tests split | xargs printf "./%s/... ")
                   export API_VERSION=<< parameters.api >>
                   export GINKGO_XUNIT_RESULTS_DIR=/tmp/xunit
                   export K3D=true

--- a/test/e2e/inspect/inspect_k8s_multizone.go
+++ b/test/e2e/inspect/inspect_k8s_multizone.go
@@ -16,7 +16,6 @@ import (
 func KubernetesMultizone() {
 	var globalK8s, zoneK8s *K8sCluster
 	var zoneIngress *kube_core.Pod
-	var kumaControlPlane *kube_core.Pod
 
 	meshMTLSOn := func(mesh string) string {
 		return fmt.Sprintf(`
@@ -85,7 +84,6 @@ spec:
 		}, "60s", "1s").Should(Succeed())
 
 		zoneIngress = GetPod(Config.KumaNamespace, "kuma-ingress")
-		kumaControlPlane = GetPod(Config.KumaNamespace, Config.KumaServiceName)
 	})
 
 	E2EAfterEach(func() {

--- a/test/e2e/inspect/inspect_k8s_multizone.go
+++ b/test/e2e/inspect/inspect_k8s_multizone.go
@@ -99,9 +99,7 @@ spec:
 
 	It("should return envoy config_dump for zone ingress", func() {
 		zoneIngressName := fmt.Sprintf("%s.%s", zoneIngress.GetName(), Config.KumaNamespace)
-		cmd := []string{"kumactl", "inspect", "zoneingress", zoneIngressName, "--config-dump"}
-
-		stdout, _, err := zoneK8s.ExecWithRetries(Config.KumaNamespace, kumaControlPlane.GetName(), "control-plane", cmd...)
+		stdout, err := zoneK8s.GetKumactlOptions().RunKumactlAndGetOutput("inspect", "zoneingress", zoneIngressName, "--config-dump")
 		Expect(err).ToNot(HaveOccurred())
 
 		Expect(stdout).To(ContainSubstring(`"dataplane.proxyType": "ingress"`))

--- a/test/e2e/inspect/inspect_k8s_standalone.go
+++ b/test/e2e/inspect/inspect_k8s_standalone.go
@@ -67,9 +67,7 @@ func KubernetesStandalone() {
 
 	It("should return envoy config_dump", func() {
 		dataplaneName := fmt.Sprintf("%s.%s", demoClient.GetName(), TestNamespace)
-		cmd := []string{"kumactl", "inspect", "dataplane", dataplaneName, "--config-dump"}
-
-		stdout, _, err := cluster.ExecWithRetries(Config.KumaNamespace, kumaControlPlane.GetName(), "control-plane", cmd...)
+		stdout, err := cluster.GetKumactlOptions().RunKumactlAndGetOutput("inspect", "dataplane", dataplaneName, "--config-dump")
 		Expect(err).ToNot(HaveOccurred())
 
 		Expect(stdout).To(ContainSubstring(`"name": "demo-client_kuma-test_svc"`))

--- a/test/e2e/inspect/inspect_k8s_standalone.go
+++ b/test/e2e/inspect/inspect_k8s_standalone.go
@@ -16,7 +16,6 @@ import (
 func KubernetesStandalone() {
 	var cluster *K8sCluster
 	var demoClient *kube_core.Pod
-	var kumaControlPlane *kube_core.Pod
 
 	GetPod := func(namespace, app string) *kube_core.Pod {
 		pods, err := k8s.ListPodsE(
@@ -56,7 +55,6 @@ func KubernetesStandalone() {
 		}, "60s", "1s").Should(Succeed())
 
 		demoClient = GetPod(TestNamespace, "demo-client")
-		kumaControlPlane = GetPod(Config.KumaNamespace, Config.KumaServiceName)
 	})
 
 	E2EAfterEach(func() {


### PR DESCRIPTION
### Summary

Using flag `--total` in 
```
export E2E_PKG_LIST=$(circleci tests glob ./test/e2e/* | circleci tests split --total=$(ls test/e2e | wc -l) | xargs printf "./%s/... ")
```
is incorrect. According to circle-ci, it defines how many workers you have rather than how many tests you have:
```
By default, the number of containers is specified by the parallelism key. You can manually set this by using the --total flag.
```

### Full changelog

* [Implement ...]
* [Fix ...]

### Issues resolved

Fix #XXX

### Documentation

- [ ] Link to the website [documentation PR](https://github.com/kumahq/kuma-website/pull/XXX)

### Testing

- [ ] Unit tests
- [ ] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes

### Backwards compatibility

- [ ] Update [`UPGRADE.md`](/UPGRADE.md) with any steps users will need to take when upgrading.
- [ ] Add `backport-to-stable` label if the code follows our [backporting policy](/CONTRIBUTING.md#backporting)
