### PR TITLE
fix(k8s): reconcile serviceMaps when using mesh namespace annotation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -149,7 +149,6 @@ require (
 	github.com/morikuni/aec v1.0.0 // indirect
 	github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f // indirect
 	github.com/natefinch/lumberjack v2.0.0+incompatible // indirect
-	github.com/nxadm/tail v1.4.8 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.0.2 // indirect
 	github.com/opencontainers/runc v1.0.2 // indirect
@@ -184,7 +183,6 @@ require (
 	google.golang.org/appengine v1.6.7 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/ini.v1 v1.66.2 // indirect
-	gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 	k8s.io/component-base v0.23.4 // indirect

--- a/pkg/plugins/runtime/k8s/controllers/configmap_controller_test.go
+++ b/pkg/plugins/runtime/k8s/controllers/configmap_controller_test.go
@@ -1,19 +1,29 @@
-package controllers
+package controllers_test
 
 import (
+	"context"
+	"fmt"
+	"sort"
+	"time"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	kube_core "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kube_client "sigs.k8s.io/controller-runtime/pkg/client"
 
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	"github.com/kumahq/kuma/pkg/log"
 	"github.com/kumahq/kuma/pkg/plugins/resources/k8s"
 	mesh_k8s "github.com/kumahq/kuma/pkg/plugins/resources/k8s/native/api/v1alpha1"
+	"github.com/kumahq/kuma/pkg/plugins/runtime/k8s/controllers"
+	"github.com/kumahq/kuma/pkg/plugins/runtime/k8s/metadata"
 )
 
 var _ = Describe("DataplaneToMeshMapper", func() {
 	It("should map ingress to list of meshes", func() {
 		l := log.NewLogger(log.InfoLevel)
-		mapper := DataplaneToMeshMapper(l, "ns", k8s.NewSimpleConverter())
+		mapper := controllers.DataplaneToMeshMapper(l, "ns", k8s.NewSimpleConverter())
 		requests := mapper(&mesh_k8s.Dataplane{
 			Mesh: "mesh-1",
 			Spec: mesh_k8s.ToSpec(&mesh_proto.Dataplane{
@@ -35,4 +45,135 @@ var _ = Describe("DataplaneToMeshMapper", func() {
 		Expect(requestsStr).To(HaveLen(1))
 		Expect(requestsStr).To(ConsistOf("kuma-mesh-1-dns-vips"))
 	})
+})
+
+var _ = Describe("ServiceToConfigMapMapper", func() {
+	ctx := context.Background()
+	var nsName string
+	defaultNs := kube_core.Namespace{
+		ObjectMeta: metav1.ObjectMeta{},
+	}
+	AfterEach(func() {
+		ns := kube_core.Namespace{}
+		key := kube_client.ObjectKey{Name: nsName}
+		Expect(k8sClient.Get(ctx, key, &ns)).To(Succeed())
+		Expect(k8sClient.Delete(ctx, &ns)).To(Succeed())
+	})
+	BeforeEach(func() {
+		nsName = fmt.Sprintf("srv-to-configmap-mapper-%d", time.Now().UnixMilli())
+	})
+	serviceFn := func(selector map[string]string) kube_core.Service {
+		return kube_core.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "svc",
+			},
+			Spec: kube_core.ServiceSpec{
+				Selector: selector,
+				Ports: []kube_core.ServicePort{
+					{Port: 80},
+				},
+			},
+		}
+	}
+	podFn := func(name string, labels map[string]string, annotations map[string]string) kube_core.Pod {
+		return kube_core.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        name,
+				Labels:      labels,
+				Annotations: annotations,
+			},
+			Spec: kube_core.PodSpec{
+				Containers: []kube_core.Container{
+					{Name: "foo", Image: "busybox"},
+				},
+			},
+		}
+	}
+	DescribeTable("should map services to list of config maps",
+		func(givenService kube_core.Service, givenNamespace kube_core.Namespace, givenPods []kube_core.Pod, expectedMeshes []string) {
+			l := log.NewLogger(log.InfoLevel)
+			givenNamespace.Name = nsName
+			Expect(k8sClient.Create(ctx, &givenNamespace)).To(Succeed())
+			givenService.Namespace = givenNamespace.Name
+			Expect(k8sClient.Create(ctx, &givenService)).To(Succeed())
+			for _, pod := range givenPods {
+				pod.Namespace = givenNamespace.Name
+				Expect(k8sClient.Create(ctx, &pod)).To(Succeed())
+			}
+			mapper := controllers.ServiceToConfigMapsMapper(k8sClient, l, "ns")
+			requests := mapper(&givenService)
+			requestsStr := []string{}
+			for _, r := range requests {
+				requestsStr = append(requestsStr, r.Name)
+			}
+			sort.Strings(requestsStr)
+			Expect(requestsStr).To(Equal(expectedMeshes))
+		},
+		Entry("no pod match",
+			serviceFn(map[string]string{"app": "app1"}),
+			defaultNs,
+			[]kube_core.Pod{
+				podFn("pod1", map[string]string{"app": "app2"}, nil),
+				podFn("pod2", map[string]string{"app": "app2"}, map[string]string{metadata.KumaMeshAnnotation: "mesh2"}),
+			},
+			[]string{},
+		),
+		Entry("namespace not annotated selects only matching pods",
+			serviceFn(map[string]string{"app": "app1"}),
+			defaultNs,
+			[]kube_core.Pod{
+				podFn("pod1", map[string]string{"app": "app1"}, nil),
+				podFn("pod2", map[string]string{"app": "app2"}, map[string]string{metadata.KumaMeshAnnotation: "mesh2"}),
+			},
+			[]string{"kuma-default-dns-vips"},
+		),
+		Entry("namespace not annotated pod annotated selects only matching pods",
+			serviceFn(map[string]string{"app": "app1"}),
+			defaultNs,
+			[]kube_core.Pod{
+				podFn("pod1", map[string]string{"app": "app1"}, map[string]string{metadata.KumaMeshAnnotation: "mesh1"}),
+				podFn("pod2", map[string]string{"app": "app2"}, map[string]string{metadata.KumaMeshAnnotation: "mesh2"}),
+			},
+			[]string{"kuma-mesh1-dns-vips"},
+		),
+		Entry("namespace not annotated pod annotated matches on multiple meshes",
+			serviceFn(map[string]string{"app": "app1"}),
+			defaultNs,
+			[]kube_core.Pod{
+				podFn("pod1", map[string]string{"app": "app1"}, map[string]string{metadata.KumaMeshAnnotation: "mesh1"}),
+				podFn("pod2", map[string]string{"app": "app1"}, map[string]string{metadata.KumaMeshAnnotation: "mesh2"}),
+			},
+			[]string{"kuma-mesh1-dns-vips", "kuma-mesh2-dns-vips"},
+		),
+		Entry("namespace annotated pod not annotated",
+			serviceFn(map[string]string{"app": "app1"}),
+			kube_core.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						metadata.KumaMeshAnnotation: "mesh1",
+					},
+				},
+			},
+			[]kube_core.Pod{
+				podFn("pod1", map[string]string{"app": "app1"}, nil),
+				podFn("pod2", map[string]string{"app": "app1"}, nil),
+			},
+			[]string{"kuma-mesh1-dns-vips"},
+		),
+		Entry("namespace annotated pod annotated",
+			serviceFn(map[string]string{"app": "app1"}),
+			kube_core.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						metadata.KumaMeshAnnotation: "mesh1",
+					},
+				},
+			},
+			[]kube_core.Pod{
+				podFn("pod1", map[string]string{"app": "app1"}, map[string]string{metadata.KumaMeshAnnotation: "mesh2"}),
+				podFn("pod2", map[string]string{"app": "app1"}, nil),
+			},
+			[]string{"kuma-mesh1-dns-vips", "kuma-mesh2-dns-vips"},
+		),
+	)
 })

--- a/pkg/plugins/runtime/k8s/controllers/suite_test.go
+++ b/pkg/plugins/runtime/k8s/controllers/suite_test.go
@@ -20,7 +20,7 @@ var testEnv *envtest.Environment
 var k8sClientScheme *runtime.Scheme
 
 func TestAPIs(t *testing.T) {
-	test.RunSpecs(t, "Namespace Controller Suite")
+	test.RunSpecs(t, "K8s Controller Suite")
 }
 
 var _ = BeforeSuite(test.Within(time.Minute, func() {


### PR DESCRIPTION
### Summary

We were not looking at annotations on the namespace when looking
at config map that need to be reconciled when service changes.

This would cause issue if pods were not individually annotated.

### Testing

- [ ] Unit tests
- [ ] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes

### Backwards compatibility

- ~~[ ] Update [`UPGRADE.md`](/UPGRADE.md) with any steps users will need to take when upgrading.~~
- ~~[ ] Add `backport-to-stable` label if the code follows our [backporting policy](/CONTRIBUTING.md#backporting)~~
