### PR TITLE
fix(*): do not annotate gateway services with ingress upstream

### DIFF
--- a/pkg/plugins/runtime/k8s/controllers/gateway_instance_controller.go
+++ b/pkg/plugins/runtime/k8s/controllers/gateway_instance_controller.go
@@ -115,6 +115,9 @@ func (r *GatewayInstanceReconciler) createOrUpdateService(
 				ObjectMeta: kube_meta.ObjectMeta{
 					Namespace:    gatewayInstance.Namespace,
 					GenerateName: fmt.Sprintf("%s-", gatewayInstance.Name),
+					Annotations: map[string]string{
+						metadata.KumaGatewayAnnotation: metadata.AnnotationBuiltin,
+					},
 				},
 			}
 			if obj != nil {

--- a/pkg/plugins/runtime/k8s/controllers/service_controller.go
+++ b/pkg/plugins/runtime/k8s/controllers/service_controller.go
@@ -37,6 +37,10 @@ func (r *ServiceReconciler) Reconcile(ctx context.Context, req kube_ctrl.Request
 		return kube_ctrl.Result{}, errors.Wrapf(err, "unable to fetch Service %s", req.NamespacedName.Name)
 	}
 
+	if svc.GetAnnotations()[metadata.KumaGatewayAnnotation] == metadata.AnnotationBuiltin {
+		return kube_ctrl.Result{}, nil
+	}
+
 	namespace := &kube_core.Namespace{}
 	if err := r.Get(ctx, kube_types.NamespacedName{Name: svc.GetNamespace()}, namespace); err != nil {
 		if kube_apierrs.IsNotFound(err) {


### PR DESCRIPTION
### Summary

Do not annotate gateway instance service with `ingress.kubernetes.io/service-upstream: true`

### Issues resolved

No issues reported

### Documentation

- [X] No docs

### Testing

- [X] Unit tests
- [ ] E2E tests
- [ ] Manual testing on Universal
- [X] Manual testing on Kubernetes

### Backwards compatibility

~- [ ] Update [`UPGRADE.md`](/UPGRADE.md) with any steps users will need to take when upgrading.~
~- [ ] Add `backport-to-stable` label if the code follows our [backporting policy](/CONTRIBUTING.md#backporting)~
