### PR TITLE
fix(inspect-api): flaky multizone k8s test

### DIFF
--- a/test/e2e/inspect/inspect_k8s_multizone.go
+++ b/test/e2e/inspect/inspect_k8s_multizone.go
@@ -97,10 +97,13 @@ spec:
 
 	It("should return envoy config_dump for zone ingress", func() {
 		zoneIngressName := fmt.Sprintf("%s.%s", zoneIngress.GetName(), Config.KumaNamespace)
-		stdout, err := zoneK8s.GetKumactlOptions().RunKumactlAndGetOutput("inspect", "zoneingress", zoneIngressName, "--config-dump")
-		Expect(err).ToNot(HaveOccurred())
+		Eventually(func(g Gomega) {
+			stdout, err := zoneK8s.GetKumactlOptions().RunKumactlAndGetOutput("inspect", "zoneingress", zoneIngressName, "--config-dump")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(stdout).To(ContainSubstring(`"dataplane.proxyType": "ingress"`))
 
-		Expect(stdout).To(ContainSubstring(`"dataplane.proxyType": "ingress"`))
-		Expect(stdout).To(ContainSubstring(`"demo-client_kuma-test_svc{mesh=default}"`))
+			// filterChainMatches could be available not immediately
+			g.Expect(stdout).To(ContainSubstring(`"demo-client_kuma-test_svc{mesh=default}"`))
+		}, "30s", "1s").Should(Succeed())
 	})
 }

--- a/test/e2e/inspect/inspect_k8s_multizone.go
+++ b/test/e2e/inspect/inspect_k8s_multizone.go
@@ -99,8 +99,8 @@ spec:
 		zoneIngressName := fmt.Sprintf("%s.%s", zoneIngress.GetName(), Config.KumaNamespace)
 		Eventually(func(g Gomega) {
 			stdout, err := zoneK8s.GetKumactlOptions().RunKumactlAndGetOutput("inspect", "zoneingress", zoneIngressName, "--config-dump")
-			Expect(err).ToNot(HaveOccurred())
-			Expect(stdout).To(ContainSubstring(`"dataplane.proxyType": "ingress"`))
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(stdout).To(ContainSubstring(`"dataplane.proxyType": "ingress"`))
 
 			// filterChainMatches could be available not immediately
 			g.Expect(stdout).To(ContainSubstring(`"demo-client_kuma-test_svc{mesh=default}"`))


### PR DESCRIPTION
### Summary

Test checks envoy config dump and tries to find filterChainMatch rule, that could be available not immediately.

### Full changelog

* [Implement ...]
* [Fix ...]

### Issues resolved

Fix #XXX

### Documentation

- [ ] Link to the website [documentation PR](https://github.com/kumahq/kuma-website/pull/XXX)

### Testing

- [ ] Unit tests
- [ ] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes

### Backwards compatibility

- [ ] Update [`UPGRADE.md`](/UPGRADE.md) with any steps users will need to take when upgrading.
- [ ] Add `backport-to-stable` label if the code follows our [backporting policy](/CONTRIBUTING.md#backporting)
