### PR TITLE
fix(kuma-cp): do not update unchanged insights

### DIFF
--- a/pkg/kds/context/context.go
+++ b/pkg/kds/context/context.go
@@ -5,7 +5,9 @@ import (
 	"reflect"
 	"strings"
 
+	"github.com/pkg/errors"
 	"google.golang.org/protobuf/proto"
+	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	"google.golang.org/protobuf/types/known/wrapperspb"
 
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
@@ -23,8 +25,6 @@ import (
 	zone_tokens "github.com/kumahq/kuma/pkg/tokens/builtin/zone"
 	"github.com/kumahq/kuma/pkg/tokens/builtin/zoneingress"
 	"github.com/kumahq/kuma/pkg/util/rsa"
-	"github.com/pkg/errors"
-	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 )
 
 var log = core.Log.WithName("kds")
@@ -84,7 +84,6 @@ type specWithDiscoverySubscriptions interface {
 // the field has only local relevance. This prevents reconciliation from unnecessarily
 // deeming the object to have changed.
 func MapInsightResourcesZeroGeneration(r model.Resource) (model.Resource, error) {
-
 	if spec, ok := r.GetSpec().(specWithDiscoverySubscriptions); ok {
 		spec = proto.Clone(spec).(specWithDiscoverySubscriptions)
 		for _, sub := range spec.GetSubscriptions() {

--- a/pkg/kds/context/context.go
+++ b/pkg/kds/context/context.go
@@ -2,10 +2,13 @@ package context
 
 import (
 	"context"
+	"reflect"
 	"strings"
 
+	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/wrapperspb"
 
+	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	system_proto "github.com/kumahq/kuma/api/system/v1alpha1"
 	"github.com/kumahq/kuma/pkg/core"
 	config_manager "github.com/kumahq/kuma/pkg/core/config/manager"
@@ -20,6 +23,8 @@ import (
 	zone_tokens "github.com/kumahq/kuma/pkg/tokens/builtin/zone"
 	"github.com/kumahq/kuma/pkg/tokens/builtin/zoneingress"
 	"github.com/kumahq/kuma/pkg/util/rsa"
+	"github.com/pkg/errors"
+	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 )
 
 var log = core.Log.WithName("kds")
@@ -47,8 +52,58 @@ func DefaultContext(manager manager.ResourceManager, zone string) *Context {
 		GlobalProvidedFilter: GlobalProvidedFilter(manager, configs),
 		ZoneProvidedFilter:   ZoneProvidedFilter(zone),
 		Configs:              configs,
-		GlobalResourceMapper: MapZoneTokenSigningKeyGlobalToPublicKey(ctx, manager),
+		GlobalResourceMapper: CompositeResourceMapper(
+			MapZoneTokenSigningKeyGlobalToPublicKey(ctx, manager),
+			MapInsightResourcesZeroGeneration,
+		),
 	}
+}
+
+// CompositeResourceMapper combines the given ResourceMappers into
+// a single ResourceMapper which calls each in order. If an error
+// occurs, the first one is returned and no further mappers are executed.
+func CompositeResourceMapper(mappers ...reconcile.ResourceMapper) reconcile.ResourceMapper {
+	return func(r model.Resource) (model.Resource, error) {
+		var err error
+		for _, mapper := range mappers {
+			r, err = mapper(r)
+			if err != nil {
+				return r, err
+			}
+		}
+		return r, nil
+	}
+}
+
+type specWithDiscoverySubscriptions interface {
+	GetSubscriptions() []*mesh_proto.DiscoverySubscription
+	ProtoReflect() protoreflect.Message
+}
+
+// MapInsightResourcesZeroGeneration zeros "generation" field in resources for which
+// the field has only local relevance. This prevents reconciliation from unnecessarily
+// deeming the object to have changed.
+func MapInsightResourcesZeroGeneration(r model.Resource) (model.Resource, error) {
+
+	if spec, ok := r.GetSpec().(specWithDiscoverySubscriptions); ok {
+		spec = proto.Clone(spec).(specWithDiscoverySubscriptions)
+		for _, sub := range spec.GetSubscriptions() {
+			sub.Generation = 0
+		}
+
+		meta := r.GetMeta()
+		resType := reflect.TypeOf(r).Elem()
+
+		newR := reflect.New(resType).Interface().(model.Resource)
+		newR.SetMeta(meta)
+		if err := newR.SetSpec(spec.(model.ResourceSpec)); err != nil {
+			panic(errors.Wrap(err, "error setting spec on resource"))
+		}
+
+		return newR, nil
+	}
+
+	return r, nil
 }
 
 func MapZoneTokenSigningKeyGlobalToPublicKey(

--- a/pkg/kds/context/context_test.go
+++ b/pkg/kds/context/context_test.go
@@ -60,10 +60,10 @@ var _ = Describe("Context", func() {
 					},
 					Spec: &mesh_proto.DataplaneInsight{
 						Subscriptions: []*mesh_proto.DiscoverySubscription{
-							&mesh_proto.DiscoverySubscription{
+							{
 								Generation: 10,
 							},
-							&mesh_proto.DiscoverySubscription{
+							{
 								Generation: 15,
 							},
 						},
@@ -75,10 +75,10 @@ var _ = Describe("Context", func() {
 					},
 					Spec: &mesh_proto.DataplaneInsight{
 						Subscriptions: []*mesh_proto.DiscoverySubscription{
-							&mesh_proto.DiscoverySubscription{
+							{
 								Generation: 0,
 							},
-							&mesh_proto.DiscoverySubscription{
+							{
 								Generation: 0,
 							},
 						},
@@ -92,10 +92,10 @@ var _ = Describe("Context", func() {
 					},
 					Spec: &mesh_proto.ZoneIngressInsight{
 						Subscriptions: []*mesh_proto.DiscoverySubscription{
-							&mesh_proto.DiscoverySubscription{
+							{
 								Generation: 10,
 							},
-							&mesh_proto.DiscoverySubscription{
+							{
 								Generation: 15,
 							},
 						},
@@ -107,10 +107,10 @@ var _ = Describe("Context", func() {
 					},
 					Spec: &mesh_proto.ZoneIngressInsight{
 						Subscriptions: []*mesh_proto.DiscoverySubscription{
-							&mesh_proto.DiscoverySubscription{
+							{
 								Generation: 0,
 							},
-							&mesh_proto.DiscoverySubscription{
+							{
 								Generation: 0,
 							},
 						},
@@ -124,10 +124,10 @@ var _ = Describe("Context", func() {
 					},
 					Spec: &mesh_proto.ZoneEgressInsight{
 						Subscriptions: []*mesh_proto.DiscoverySubscription{
-							&mesh_proto.DiscoverySubscription{
+							{
 								Generation: 10,
 							},
-							&mesh_proto.DiscoverySubscription{
+							{
 								Generation: 15,
 							},
 						},
@@ -139,10 +139,10 @@ var _ = Describe("Context", func() {
 					},
 					Spec: &mesh_proto.ZoneEgressInsight{
 						Subscriptions: []*mesh_proto.DiscoverySubscription{
-							&mesh_proto.DiscoverySubscription{
+							{
 								Generation: 0,
 							},
-							&mesh_proto.DiscoverySubscription{
+							{
 								Generation: 0,
 							},
 						},
@@ -156,14 +156,14 @@ var _ = Describe("Context", func() {
 					},
 					Spec: &mesh_proto.CircuitBreaker{
 						Sources: []*mesh_proto.Selector{
-							&mesh_proto.Selector{
+							{
 								Match: map[string]string{
 									"match1": "source",
 								},
 							},
 						},
 						Destinations: []*mesh_proto.Selector{
-							&mesh_proto.Selector{
+							{
 								Match: map[string]string{
 									"match2": "dest",
 								},
@@ -180,14 +180,14 @@ var _ = Describe("Context", func() {
 					},
 					Spec: &mesh_proto.CircuitBreaker{
 						Sources: []*mesh_proto.Selector{
-							&mesh_proto.Selector{
+							{
 								Match: map[string]string{
 									"match1": "source",
 								},
 							},
 						},
 						Destinations: []*mesh_proto.Selector{
-							&mesh_proto.Selector{
+							{
 								Match: map[string]string{
 									"match2": "dest",
 								},

--- a/pkg/kds/context/context_test.go
+++ b/pkg/kds/context/context_test.go
@@ -59,11 +59,17 @@ var _ = Describe("Context", func() {
 						Name: "dpi-1",
 					},
 					Spec: &mesh_proto.DataplaneInsight{
+						MTLS: &mesh_proto.DataplaneInsight_MTLS{
+							IssuedBackend:     "test",
+							SupportedBackends: []string{"one", "two"},
+						},
 						Subscriptions: []*mesh_proto.DiscoverySubscription{
 							{
+								Id:         "sub1",
 								Generation: 10,
 							},
 							{
+								Id:         "sub2",
 								Generation: 15,
 							},
 						},
@@ -74,11 +80,17 @@ var _ = Describe("Context", func() {
 						Name: "dpi-1",
 					},
 					Spec: &mesh_proto.DataplaneInsight{
+						MTLS: &mesh_proto.DataplaneInsight_MTLS{
+							IssuedBackend:     "test",
+							SupportedBackends: []string{"one", "two"},
+						},
 						Subscriptions: []*mesh_proto.DiscoverySubscription{
 							{
+								Id:         "sub1",
 								Generation: 0,
 							},
 							{
+								Id:         "sub2",
 								Generation: 0,
 							},
 						},
@@ -93,10 +105,12 @@ var _ = Describe("Context", func() {
 					Spec: &mesh_proto.ZoneIngressInsight{
 						Subscriptions: []*mesh_proto.DiscoverySubscription{
 							{
-								Generation: 10,
+								ControlPlaneInstanceId: "ID1",
+								Generation:             10,
 							},
 							{
-								Generation: 15,
+								ControlPlaneInstanceId: "ID2",
+								Generation:             15,
 							},
 						},
 					},
@@ -108,10 +122,12 @@ var _ = Describe("Context", func() {
 					Spec: &mesh_proto.ZoneIngressInsight{
 						Subscriptions: []*mesh_proto.DiscoverySubscription{
 							{
-								Generation: 0,
+								ControlPlaneInstanceId: "ID1",
+								Generation:             0,
 							},
 							{
-								Generation: 0,
+								ControlPlaneInstanceId: "ID2",
+								Generation:             0,
 							},
 						},
 					},

--- a/pkg/kds/context/context_test.go
+++ b/pkg/kds/context/context_test.go
@@ -4,6 +4,7 @@ import (
 	stdcontext "context"
 	"fmt"
 
+	"github.com/golang/protobuf/proto"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
@@ -27,6 +28,179 @@ import (
 )
 
 var _ = Describe("Context", func() {
+	Describe("GlobalResourceMapper", func() {
+		var rm manager.ResourceManager
+		var mapper reconcile.ResourceMapper
+
+		type testCase struct {
+			resource model.Resource
+			expect   model.Resource
+		}
+
+		BeforeEach(func() {
+			rm = manager.NewResourceManager(memory.NewStore())
+			defaultContext := context.DefaultContext(rm, "zone")
+			mapper = defaultContext.GlobalResourceMapper
+		})
+
+		DescribeTable("should zero generation field",
+			func(given testCase) {
+				// when
+				out, _ := mapper(given.resource)
+
+				// then
+				Expect(out.GetMeta()).To(Equal(given.expect.GetMeta()))
+				Expect(out.Descriptor()).To(Equal(given.expect.Descriptor()))
+				Expect(proto.Equal(out.GetSpec(), given.expect.GetSpec())).To(BeTrue())
+			},
+			Entry("should zero generation on DataplaneInsight", testCase{
+				resource: &core_mesh.DataplaneInsightResource{
+					Meta: &test_model.ResourceMeta{
+						Name: "dpi-1",
+					},
+					Spec: &mesh_proto.DataplaneInsight{
+						Subscriptions: []*mesh_proto.DiscoverySubscription{
+							&mesh_proto.DiscoverySubscription{
+								Generation: 10,
+							},
+							&mesh_proto.DiscoverySubscription{
+								Generation: 15,
+							},
+						},
+					},
+				},
+				expect: &core_mesh.DataplaneInsightResource{
+					Meta: &test_model.ResourceMeta{
+						Name: "dpi-1",
+					},
+					Spec: &mesh_proto.DataplaneInsight{
+						Subscriptions: []*mesh_proto.DiscoverySubscription{
+							&mesh_proto.DiscoverySubscription{
+								Generation: 0,
+							},
+							&mesh_proto.DiscoverySubscription{
+								Generation: 0,
+							},
+						},
+					},
+				},
+			}),
+			Entry("should zero generation on ZoneIngressInsight", testCase{
+				resource: &core_mesh.ZoneIngressInsightResource{
+					Meta: &test_model.ResourceMeta{
+						Name: "zii-1",
+					},
+					Spec: &mesh_proto.ZoneIngressInsight{
+						Subscriptions: []*mesh_proto.DiscoverySubscription{
+							&mesh_proto.DiscoverySubscription{
+								Generation: 10,
+							},
+							&mesh_proto.DiscoverySubscription{
+								Generation: 15,
+							},
+						},
+					},
+				},
+				expect: &core_mesh.ZoneIngressInsightResource{
+					Meta: &test_model.ResourceMeta{
+						Name: "zii-1",
+					},
+					Spec: &mesh_proto.ZoneIngressInsight{
+						Subscriptions: []*mesh_proto.DiscoverySubscription{
+							&mesh_proto.DiscoverySubscription{
+								Generation: 0,
+							},
+							&mesh_proto.DiscoverySubscription{
+								Generation: 0,
+							},
+						},
+					},
+				},
+			}),
+			Entry("should zero generation on ZoneEgressInsight", testCase{
+				resource: &core_mesh.ZoneEgressInsightResource{
+					Meta: &test_model.ResourceMeta{
+						Name: "zei-1",
+					},
+					Spec: &mesh_proto.ZoneEgressInsight{
+						Subscriptions: []*mesh_proto.DiscoverySubscription{
+							&mesh_proto.DiscoverySubscription{
+								Generation: 10,
+							},
+							&mesh_proto.DiscoverySubscription{
+								Generation: 15,
+							},
+						},
+					},
+				},
+				expect: &core_mesh.ZoneEgressInsightResource{
+					Meta: &test_model.ResourceMeta{
+						Name: "zei-1",
+					},
+					Spec: &mesh_proto.ZoneEgressInsight{
+						Subscriptions: []*mesh_proto.DiscoverySubscription{
+							&mesh_proto.DiscoverySubscription{
+								Generation: 0,
+							},
+							&mesh_proto.DiscoverySubscription{
+								Generation: 0,
+							},
+						},
+					},
+				},
+			}),
+			Entry("should not change non-insight", testCase{
+				resource: &core_mesh.CircuitBreakerResource{
+					Meta: &test_model.ResourceMeta{
+						Name: "cb-1",
+					},
+					Spec: &mesh_proto.CircuitBreaker{
+						Sources: []*mesh_proto.Selector{
+							&mesh_proto.Selector{
+								Match: map[string]string{
+									"match1": "source",
+								},
+							},
+						},
+						Destinations: []*mesh_proto.Selector{
+							&mesh_proto.Selector{
+								Match: map[string]string{
+									"match2": "dest",
+								},
+							},
+						},
+						Conf: &mesh_proto.CircuitBreaker_Conf{
+							SplitExternalAndLocalErrors: true,
+						},
+					},
+				},
+				expect: &core_mesh.CircuitBreakerResource{
+					Meta: &test_model.ResourceMeta{
+						Name: "cb-1",
+					},
+					Spec: &mesh_proto.CircuitBreaker{
+						Sources: []*mesh_proto.Selector{
+							&mesh_proto.Selector{
+								Match: map[string]string{
+									"match1": "source",
+								},
+							},
+						},
+						Destinations: []*mesh_proto.Selector{
+							&mesh_proto.Selector{
+								Match: map[string]string{
+									"match2": "dest",
+								},
+							},
+						},
+						Conf: &mesh_proto.CircuitBreaker_Conf{
+							SplitExternalAndLocalErrors: true,
+						},
+					},
+				},
+			}),
+		)
+	})
 	Describe("GlobalProvidedFilter", func() {
 		var rm manager.ResourceManager
 		var predicate reconcile.ResourceFilter


### PR DESCRIPTION
Signed-off-by: Paul Parkanzky <paul.parkanzky@konghq.com>

### Summary

DataplaneInsights-related resources include a monotonically increasing "generation" field, which is updated regardless of whether the resource has changed. This causes reconciliation within KDS to see them as changing when they have not. Added a ResourceMapper to zero out this field on Global control plane.

### Full changelog

* Fix issue where Dataplane-related Insights are unnecessarily reconciled.

### Issues resolved

Fix #3783

### Documentation

- [ ] Link to the website [documentation PR](https://github.com/kumahq/kuma-website/pull/XXX)

### Testing

- [x] Unit tests
- [ ] E2E tests
- [x] Manual testing on Universal
- [x] Manual testing on Kubernetes

### Backwards compatibility

- [ ] Update [`UPGRADE.md`](/UPGRADE.md) with any steps users will need to take when upgrading.
- [ ] Add `backport-to-stable` label if the code follows our [backporting policy](/CONTRIBUTING.md#backporting)
