### PR TITLE
test(e2e/ratelimit): increase polling interval

### DIFF
--- a/test/e2e/ratelimit/ratelimit_universal.go
+++ b/test/e2e/ratelimit/ratelimit_universal.go
@@ -109,7 +109,7 @@ conf:
 		}
 	}
 
-	It("should limit to 2 requests per 5 sec", func() {
+	It("should apply limit to client", func() {
 		// demo-client specific RateLimit works
 		Eventually(verifyRateLimit("demo-client", 5), "60s", "1s").Should(Equal(2))
 		// verify determinism by running it once again with shorter timeout
@@ -136,9 +136,9 @@ conf:
 		Expect(err).ToNot(HaveOccurred())
 
 		// demo-client specific RateLimit works
-		Eventually(verifyRateLimit("demo-client", 5), "60s", "1s").Should(Equal(4))
+		Eventually(verifyRateLimit("demo-client", 5), "60s", "10s").Should(Equal(4))
 		// verify determinism by running it once again with shorter timeout
-		Eventually(verifyRateLimit("demo-client", 5), "30s", "1s").Should(Equal(4))
+		Eventually(verifyRateLimit("demo-client", 5), "30s", "10s").Should(Equal(4))
 
 		// catch-all RateLimit still works
 		Eventually(verifyRateLimit("web", 5), "60s", "1s").Should(Equal(2))


### PR DESCRIPTION
### Summary

The bucket interval is 10s so if we only wait 1s inbetween tries, we
won't ever let the bucket empty.