### PR TITLE
refactor(gateway): refactor `GatewayResourceInfo` to `GatewayListenerInfo`

### DIFF
--- a/pkg/plugins/runtime/gateway/cluster_generator.go
+++ b/pkg/plugins/runtime/gateway/cluster_generator.go
@@ -31,7 +31,7 @@ func (*ClusterGenerator) SupportsProtocol(mesh_proto.MeshGateway_Listener_Protoc
 }
 
 // GenerateHost generates clusters for all the services targeted in the current route table.
-func (c *ClusterGenerator) GenerateHost(ctx xds_context.Context, info *GatewayResourceInfo) (*core_xds.ResourceSet, error) {
+func (c *ClusterGenerator) GenerateHost(ctx xds_context.Context, info *GatewayListenerInfo, host gatewayHostInfo) (*core_xds.ResourceSet, error) {
 	resources := ResourceAggregator{}
 
 	// If there is a service name conflict between external services
@@ -42,7 +42,7 @@ func (c *ClusterGenerator) GenerateHost(ctx xds_context.Context, info *GatewayRe
 	// an array of endpoint and checks whether the first entry is from
 	// an external service. Because the dataplane endpoints happen to be
 	// generated first, the mesh service will have priority.
-	for _, dest := range routeDestinations(&info.RouteTable) {
+	for _, dest := range routeDestinations(host.RouteTable) {
 		matched := match.ExternalService(info.ExternalServices, mesh_proto.TagSelector(dest.Destination))
 
 		// If there are zone egresses present we want to direct the traffic
@@ -118,7 +118,7 @@ func (c *ClusterGenerator) GenerateHost(ctx xds_context.Context, info *GatewayRe
 
 func (c *ClusterGenerator) generateMeshCluster(
 	mesh *core_mesh.MeshResource,
-	info *GatewayResourceInfo,
+	info *GatewayListenerInfo,
 	dest *route.Destination,
 	upstreamServiceName string,
 ) (*core_xds.Resource, error) {
@@ -143,7 +143,7 @@ func (c *ClusterGenerator) generateMeshCluster(
 
 func (c *ClusterGenerator) generateExternalCluster(
 	ctx xds_context.Context,
-	info *GatewayResourceInfo,
+	info *GatewayListenerInfo,
 	service core_mesh.ExternalServiceResourceList,
 	dest *route.Destination,
 ) (*core_xds.Resource, error) {

--- a/pkg/plugins/runtime/gateway/connection_policy_generator.go
+++ b/pkg/plugins/runtime/gateway/connection_policy_generator.go
@@ -21,24 +21,24 @@ func (*ConnectionPolicyGenerator) SupportsProtocol(p mesh_proto.MeshGateway_List
 	return true
 }
 
-func (g *ConnectionPolicyGenerator) GenerateHost(ctx xds_context.Context, info *GatewayResourceInfo) (*core_xds.ResourceSet, error) {
-	for _, e := range info.RouteTable.Entries {
+func (g *ConnectionPolicyGenerator) GenerateHost(ctx xds_context.Context, info *GatewayListenerInfo, host gatewayHostInfo) (*core_xds.ResourceSet, error) {
+	for _, e := range host.RouteTable.Entries {
 		for i, destination := range e.Action.Forward {
-			e.Action.Forward[i].Policies = mapPoliciesForDestination(destination.Destination, info)
+			e.Action.Forward[i].Policies = mapPoliciesForDestination(destination.Destination, info, host.Host)
 		}
 		if e.Mirror != nil {
-			e.Mirror.Forward.Policies = mapPoliciesForDestination(e.Mirror.Forward.Destination, info)
+			e.Mirror.Forward.Policies = mapPoliciesForDestination(e.Mirror.Forward.Destination, info, host.Host)
 		}
 	}
 
 	return nil, nil
 }
 
-func mapPoliciesForDestination(destination envoy.Tags, info *GatewayResourceInfo) map[model.ResourceType]model.Resource {
+func mapPoliciesForDestination(destination envoy.Tags, info *GatewayListenerInfo, host GatewayHost) map[model.ResourceType]model.Resource {
 	policies := map[model.ResourceType]model.Resource{}
 
 	for _, policyType := range ConnectionPolicyTypes {
-		if policy := matchConnectionPolicy(info.Host.Policies[policyType], destination); policy != nil {
+		if policy := matchConnectionPolicy(host.Policies[policyType], destination); policy != nil {
 			policies[policyType] = policy
 		}
 	}

--- a/pkg/plugins/runtime/gateway/listener_generator.go
+++ b/pkg/plugins/runtime/gateway/listener_generator.go
@@ -30,7 +30,7 @@ func (*ListenerGenerator) SupportsProtocol(p mesh_proto.MeshGateway_Listener_Pro
 	}
 }
 
-func (*ListenerGenerator) GenerateHost(ctx xds_context.Context, info *GatewayResourceInfo) (*core_xds.ResourceSet, error) {
+func (*ListenerGenerator) GenerateHost(ctx xds_context.Context, info *GatewayListenerInfo, _ gatewayHostInfo) (*core_xds.ResourceSet, error) {
 	// TODO(jpeach) what we really need to do here is build the
 	// listener once, then generate a HTTP filter chain for each
 	// host on the same HTTPConnectionManager. Each HTTP filter

--- a/pkg/plugins/runtime/gateway/route_configuration_generator.go
+++ b/pkg/plugins/runtime/gateway/route_configuration_generator.go
@@ -23,7 +23,7 @@ func (*RouteConfigurationGenerator) SupportsProtocol(p mesh_proto.MeshGateway_Li
 	}
 }
 
-func (*RouteConfigurationGenerator) GenerateHost(ctx xds_context.Context, info *GatewayResourceInfo) (*core_xds.ResourceSet, error) {
+func (*RouteConfigurationGenerator) GenerateHost(ctx xds_context.Context, info *GatewayListenerInfo, _ gatewayHostInfo) (*core_xds.ResourceSet, error) {
 	if info.Resources.RouteConfiguration != nil {
 		return nil, nil
 	}

--- a/pkg/plugins/runtime/gateway/route_table_generator.go
+++ b/pkg/plugins/runtime/gateway/route_table_generator.go
@@ -24,12 +24,12 @@ func (*RouteTableGenerator) SupportsProtocol(mesh_proto.MeshGateway_Listener_Pro
 }
 
 // GenerateHost generates xDS resources for the current route table.
-func (r *RouteTableGenerator) GenerateHost(ctx xds_context.Context, info *GatewayResourceInfo) (*core_xds.ResourceSet, error) {
+func (r *RouteTableGenerator) GenerateHost(ctx xds_context.Context, info *GatewayListenerInfo, host gatewayHostInfo) (*core_xds.ResourceSet, error) {
 	resources := ResourceAggregator{}
 
 	vh := envoy_routes.NewVirtualHostBuilder(info.Proxy.APIVersion).Configure(
-		envoy_routes.CommonVirtualHost(info.Host.Hostname),
-		envoy_routes.DomainNames(info.Host.Hostname),
+		envoy_routes.CommonVirtualHost(host.Host.Hostname),
+		envoy_routes.DomainNames(host.Host.Hostname),
 	)
 
 	// Ensure that we get TLS on HTTPS protocol listeners.
@@ -49,9 +49,9 @@ func (r *RouteTableGenerator) GenerateHost(ctx xds_context.Context, info *Gatewa
 	// TODO(jpeach) apply additional virtual host configuration.
 
 	// Sort routing table entries so the most specific match comes first.
-	sort.Sort(route.Sorter(info.RouteTable.Entries))
+	sort.Sort(route.Sorter(host.RouteTable.Entries))
 
-	for _, e := range info.RouteTable.Entries {
+	for _, e := range host.RouteTable.Entries {
 		routeBuilder := route.RouteBuilder{}
 
 		routeBuilder.Configure(


### PR DESCRIPTION
### Summary

`Host` isn't mutated inside `GenerateHost` and both `Host` and `RouteTable`
are replaced on `GatewayResourceInfo` each time we call `GenerateHost`.

Behavior doesn't change.