### PR TITLE
feat(ci): use workflow from kumahq/.github repo

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,34 +10,6 @@ on:
 
 jobs:
   create-branch:
-    runs-on: ubuntu-latest
-    env:
-      INCREASE_MAJOR_VERSION: ${{ github.event.inputs.increaseMajor }}
-    steps:
-      - name: git checkout
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-      - name: create branch and tag
-        run: |
-          OLD_VERSION=$(git describe --abbrev=0 --tags)
-          IFS=. read -r major minor patch <<< "$OLD_VERSION"
-          if [ $INCREASE_MAJOR_VERSION == "true" ]; then
-            RELEASE_BRANCH="release-$((++major)).0" 
-            NEW_VERSION="$major.0.0-rc1"
-          else
-            RELEASE_BRANCH="release-$major.$((++minor))" 
-            NEW_VERSION="$major.$minor.0-rc1"
-          fi
-
-          # create branch 'release-$major.$minor'
-          git --version
-          git config user.name "github-actions[bot]"
-          git config user.email "<41898282+github-actions[bot]@users.noreply.github.com>"
-          git branch $RELEASE_BRANCH
-          
-          # create a new tag
-          bash ./tools/releases/make-release-tag.sh $OLD_VERSION $NEW_VERSION
-          
-          # push
-          git push --atomic origin $RELEASE_BRANCH $NEW_VERSION
+    uses: kumahq/.github/.github/workflows/release.yaml@main
+    with:
+      increaseMajor: ${{ github.event.inputs.increaseMajor == 'true' }}


### PR DESCRIPTION
### Summary

Move Release workflow to `kumahq/.github` repo and reuse it from there

### Full changelog

* [Implement ...]
* [Fix ...]

### Issues resolved

Fix #XXX

### Documentation

- [ ] Link to the website [documentation PR](https://github.com/kumahq/kuma-website/pull/XXX)

### Testing

- [ ] Unit tests
- [ ] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes

### Backwards compatibility

- [ ] Update [`UPGRADE.md`](/UPGRADE.md) with any steps users will need to take when upgrading.
- [ ] Add `backport-to-stable` label if the code follows our [backporting policy](/CONTRIBUTING.md#backporting)
