### PR TITLE
fix(*): fix order for zoneegress

### DIFF
--- a/pkg/xds/generator/egress/generator.go
+++ b/pkg/xds/generator/egress/generator.go
@@ -83,16 +83,20 @@ func (g Generator) Generate(
 			resources.AddSet(rs)
 		}
 
-		listener, err := listenerBuilder.Build()
-		if err != nil {
-			return nil, err
-		}
+		// If the resources are empty after all generator pass, it means there is filter chain,
+		// if there is no filter chain there is no need to build a listener
+		if !resources.Empty() {
+			listener, err := listenerBuilder.Build()
+			if err != nil {
+				return nil, err
+			}
 
-		resources.Add(&core_xds.Resource{
-			Name:     listener.GetName(),
-			Origin:   OriginEgress,
-			Resource: listener,
-		})
+			resources.Add(&core_xds.Resource{
+				Name:     listener.GetName(),
+				Origin:   OriginEgress,
+				Resource: listener,
+			})
+		}
 	}
 
 	return resources, nil

--- a/pkg/xds/sync/egress_proxy_builder.go
+++ b/pkg/xds/sync/egress_proxy_builder.go
@@ -2,6 +2,7 @@ package sync
 
 import (
 	"context"
+	"sort"
 
 	"github.com/kumahq/kuma/pkg/core/datasource"
 	"github.com/kumahq/kuma/pkg/core/dns/lookup"
@@ -69,6 +70,11 @@ func (p *EgressProxyBuilder) Build(
 		}
 	}
 
+	// It's done for achieving stable xds config
+	sort.Slice(zoneIngresses, func(a, b int) bool {
+		return zoneIngresses[a].GetMeta().GetName() < zoneIngresses[b].GetMeta().GetName()
+	})
+
 	var meshResourcesList []*xds.MeshResources
 
 	for _, mesh := range meshes {
@@ -82,6 +88,11 @@ func (p *EgressProxyBuilder) Build(
 		trafficPermissions := meshCtx.Resources.TrafficPermissions().Items
 		trafficRoutes := meshCtx.Resources.TrafficRoutes().Items
 		externalServices := meshCtx.Resources.ExternalServices().Items
+
+		// It's done for achieving stable xds config
+		sort.Slice(externalServices, func(a, b int) bool {
+			return externalServices[a].GetMeta().GetName() < externalServices[b].GetMeta().GetName()
+		})
 
 		meshResources := &xds.MeshResources{
 			Mesh:             mesh,


### PR DESCRIPTION
### Summary

Fix order for zoneegresses + don't create listener when no listener filters

### Full changelog

n/a

### Issues resolved

n/a

### Documentation

- [ ] Link to the website [documentation PR](https://github.com/kumahq/kuma-website/pull/XXX)

### Testing

- [ ] Unit tests
- [ ] E2E tests
- [x] Manual testing on Universal
- [x] Manual testing on Kubernetes

### Backwards compatibility

- [ ] Update [`UPGRADE.md`](/UPGRADE.md) with any steps users will need to take when upgrading.
- [ ] Add `backport-to-stable` label if the code follows our [backporting policy](/CONTRIBUTING.md#backporting)
