### PR TITLE
fix(kuma-cp): handle zone token sync with old versions of cp

### DIFF
--- a/pkg/kds/client/stream.go
+++ b/pkg/kds/client/stream.go
@@ -65,6 +65,11 @@ func (s *stream) DiscoveryRequest(resourceType model.ResourceType) error {
 				Fields: map[string]*structpb.Value{
 					kds.MetadataFieldVersion: {Kind: &structpb.Value_StructValue{StructValue: cpVersion}},
 					kds.MetadataFieldConfig:  {Kind: &structpb.Value_StringValue{StringValue: s.cpConfig}},
+					kds.MetadataFeatures: {Kind: &structpb.Value_ListValue{ListValue: &structpb.ListValue{
+						Values: []*structpb.Value{
+							{Kind: &structpb.Value_StringValue{StringValue: kds.FeatureZoneToken}},
+						},
+					}}},
 				},
 			},
 		},

--- a/pkg/kds/context/context_test.go
+++ b/pkg/kds/context/context_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/kumahq/kuma/pkg/core/resources/model"
 	"github.com/kumahq/kuma/pkg/core/resources/registry"
 	core_store "github.com/kumahq/kuma/pkg/core/resources/store"
+	"github.com/kumahq/kuma/pkg/kds"
 	"github.com/kumahq/kuma/pkg/kds/context"
 	"github.com/kumahq/kuma/pkg/kds/reconcile"
 	"github.com/kumahq/kuma/pkg/plugins/resources/memory"
@@ -249,7 +250,7 @@ var _ = Describe("Context", func() {
 			}
 
 			// when
-			ok := predicate(clusterID, dp)
+			ok := predicate(clusterID, kds.Features{}, dp)
 
 			// then
 			Expect(ok).To(BeFalse())
@@ -269,13 +270,13 @@ var _ = Describe("Context", func() {
 			}
 
 			// when
-			ok := predicate(clusterID, config1)
+			ok := predicate(clusterID, kds.Features{}, config1)
 
 			// then
 			Expect(ok).To(BeTrue())
 
 			// when
-			ok = predicate(clusterID, config2)
+			ok = predicate(clusterID, kds.Features{}, config2)
 
 			// then
 			Expect(ok).To(BeFalse())
@@ -284,7 +285,9 @@ var _ = Describe("Context", func() {
 		DescribeTable("global secrets",
 			func(given testCase) {
 				// when
-				ok := predicate(clusterID, given.resource)
+				ok := predicate(clusterID, kds.Features{
+					kds.FeatureZoneToken: true,
+				}, given.resource)
 
 				// then
 				Expect(ok).To(Equal(given.expect))
@@ -327,7 +330,7 @@ var _ = Describe("Context", func() {
 				}
 
 				// when
-				ok := predicate(clusterID, given.resource)
+				ok := predicate(clusterID, kds.Features{}, given.resource)
 
 				// then
 				Expect(ok).To(Equal(given.expect))
@@ -417,7 +420,7 @@ var _ = Describe("Context", func() {
 			DescribeTable("returned predicate function",
 				func(given testCase) {
 					// when
-					ok := predicate(clusterID, given.resource)
+					ok := predicate(clusterID, kds.Features{}, given.resource)
 
 					// then
 					Expect(ok).To(BeTrue())

--- a/pkg/kds/features.go
+++ b/pkg/kds/features.go
@@ -1,0 +1,13 @@
+package kds
+
+// Features is a set of available features for the control plane.
+// If by any chance we get into a situation that we need to execute a logic conditionally on capabilities of control plane,
+// instead of defining conditions on version which is fragile, we can define a condition based on features.
+type Features map[string]bool
+
+func (f Features) HasFeature(feature string) bool {
+	return f[feature]
+}
+
+// FeatureZoneToken means that the zone control plane can handle incoming Zone Token from global control plane.
+const FeatureZoneToken string = "zone-token"

--- a/pkg/kds/types.go
+++ b/pkg/kds/types.go
@@ -8,4 +8,5 @@ const (
 
 	MetadataFieldConfig  = "config"
 	MetadataFieldVersion = "version"
+	MetadataFeatures     = "features"
 )

--- a/pkg/kds/zone/components.go
+++ b/pkg/kds/zone/components.go
@@ -108,7 +108,7 @@ func Callbacks(rt core_runtime.Runtime, syncer sync_store.ResourceSyncer, k8sSto
 					return util.ResourceNameHasAtLeastOneOfPrefixes(
 						r.GetMeta().GetName(),
 						zoneingress.ZoneIngressSigningKeyPrefix,
-						zone_tokens.SigningKeyPrefix,
+						zone_tokens.SigningPublicKeyPrefix,
 					)
 				}))
 			}


### PR DESCRIPTION
### Summary

There were two problems with syncing zone token

1. In zone CP we had a filter on `SigningKeyPrefix` instead of `SigningPublicKeyPrefix` so whenever either of cp restarted, zone cp was trying to recreate the new zone token public signing key, but it was already there so zone CP responded in NACK, global cp was trying to send those resources again and we had a loop.
The fix for that is in pkg/kds/zone/components.go

2. There was the same problem but with the newest global cp and old zone cp. I think that KDS filtering in Sync is faulty and we need to figure out a better solution for it. In the meantime, we need to provide a way for users to upgrade CP, so I introduced a concept of _features_ similar to what I want to do for XDS https://github.com/kumahq/kuma/issues/3713
This way Global CP has information on whether we should sync or not Zone Token.

### Issues resolved

Fix #3843

### Documentation

No docs

### Testing

- [X] Unit tests
- [ ] E2E tests
- [X] Manual testing on Universal
- [ ] Manual testing on Kubernetes

### Backwards compatibility

~- [ ] Update [`UPGRADE.md`](/UPGRADE.md) with any steps users will need to take when upgrading.~
- [X] Add `backport-to-stable` label if the code follows our [backporting policy](/CONTRIBUTING.md#backporting)
