### PR TITLE
ci: use v tag prefix in create release branch workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,13 +21,13 @@ jobs:
       - name: create branch and tag
         run: |
           OLD_VERSION=$(git describe --abbrev=0 --tags)
-          IFS=. read -r major minor patch <<< "$OLD_VERSION"
+          IFS=. read -r major minor patch <<< "${OLD_VERSION#v}"
           if [ $INCREASE_MAJOR_VERSION == "true" ]; then
             RELEASE_BRANCH="release-$((++major)).0" 
-            NEW_VERSION="$major.0.0-rc1"
+            NEW_VERSION="v$major.0.0-rc1"
           else
             RELEASE_BRANCH="release-$major.$((++minor))" 
-            NEW_VERSION="$major.$minor.0-rc1"
+            NEW_VERSION="v$major.$minor.0-rc1"
           fi
 
           # create branch 'release-$major.$minor'

--- a/tools/releases/make-release-tag.sh
+++ b/tools/releases/make-release-tag.sh
@@ -38,12 +38,10 @@ if [ -n "$(git tag --list "$NEWVERS")" ]; then
 fi
 
 case "$NEWVERS" in
-# TODO: Match a leading 'v' followed by any combination of numbers and
-# dots. Optional hyphen-separated trailer can contain anything.
-+([0-9.])?([-]*))
+v+([0-9.])?([-]*))
     ;;
 *)
-    printf "%s: tag '%s' must be of the form X.Y.X\n" "$PROGNAME" "$NEWVERS"
+    printf "%s: tag '%s' must be of the form vX.Y.X\n" "$PROGNAME" "$NEWVERS"
     exit 1
     ;;
 esac


### PR DESCRIPTION
### Summary

This creates new tags with a `v` prefix and supports old tags with and without the prefix.

Part of #2073 