### PR TITLE
fix(kuma-cp): fix getting certs for zoneegress

### DIFF
--- a/pkg/xds/generator/secrets_generator.go
+++ b/pkg/xds/generator/secrets_generator.go
@@ -74,8 +74,6 @@ func createZoneEgressSecrets(
 			continue
 		}
 
-		resources = core_xds.NewResourceSet()
-
 		identity, ca, err := ctx.ControlPlane.Secrets.GetForZoneEgress(
 			proxy.ZoneEgressProxy.ZoneEgressResource,
 			meshResources.Mesh,

--- a/pkg/xds/generator/testdata/secrets/envoy-config-egress.golden.yaml
+++ b/pkg/xds/generator/testdata/secrets/envoy-config-egress.golden.yaml
@@ -1,4 +1,40 @@
 resources:
+- name: identity_cert:secret:mesh-1
+  resource:
+    '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.Secret
+    name: identity_cert:secret:mesh-1
+    tlsCertificate:
+      certificateChain:
+        inlineBytes: Q0VSVA==
+      privateKey:
+        inlineBytes: S0VZ
+- name: identity_cert:secret:mesh-2
+  resource:
+    '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.Secret
+    name: identity_cert:secret:mesh-2
+    tlsCertificate:
+      certificateChain:
+        inlineBytes: Q0VSVA==
+      privateKey:
+        inlineBytes: S0VZ
+- name: identity_cert:secret:mesh-3
+  resource:
+    '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.Secret
+    name: identity_cert:secret:mesh-3
+    tlsCertificate:
+      certificateChain:
+        inlineBytes: Q0VSVA==
+      privateKey:
+        inlineBytes: S0VZ
+- name: identity_cert:secret:mesh-4
+  resource:
+    '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.Secret
+    name: identity_cert:secret:mesh-4
+    tlsCertificate:
+      certificateChain:
+        inlineBytes: Q0VSVA==
+      privateKey:
+        inlineBytes: S0VZ
 - name: identity_cert:secret:mesh-5
   resource:
     '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.Secret
@@ -8,6 +44,34 @@ resources:
         inlineBytes: Q0VSVA==
       privateKey:
         inlineBytes: S0VZ
+- name: mesh_ca:secret:mesh-1
+  resource:
+    '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.Secret
+    name: mesh_ca:secret:mesh-1
+    validationContext:
+      trustedCa:
+        inlineBytes: Q0E=
+- name: mesh_ca:secret:mesh-2
+  resource:
+    '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.Secret
+    name: mesh_ca:secret:mesh-2
+    validationContext:
+      trustedCa:
+        inlineBytes: Q0E=
+- name: mesh_ca:secret:mesh-3
+  resource:
+    '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.Secret
+    name: mesh_ca:secret:mesh-3
+    validationContext:
+      trustedCa:
+        inlineBytes: Q0E=
+- name: mesh_ca:secret:mesh-4
+  resource:
+    '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.Secret
+    name: mesh_ca:secret:mesh-4
+    validationContext:
+      trustedCa:
+        inlineBytes: Q0E=
 - name: mesh_ca:secret:mesh-5
   resource:
     '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.Secret

--- a/pkg/xds/secrets/secrets.go
+++ b/pkg/xds/secrets/secrets.go
@@ -133,7 +133,10 @@ func (s *secrets) get(
 		return nil, nil, nil
 	}
 
+	meshName := mesh.GetMeta().GetName()
+
 	resourceKey := model.MetaToResourceKey(resource.GetMeta())
+	resourceKey.Mesh = meshName
 	certs := s.certs(resourceKey)
 
 	if shouldGenerate, reason := s.shouldGenerateCerts(
@@ -146,7 +149,7 @@ func (s *secrets) get(
 			string(resource.Descriptor().Name), resourceKey, "reason", reason,
 		)
 
-		certs, err := s.generateCerts(mesh.GetMeta().GetName(), tags, mesh)
+		certs, err := s.generateCerts(meshName, tags, mesh)
 		if err != nil {
 			return nil, nil, errors.Wrap(err, "could not generate certificates")
 		}


### PR DESCRIPTION
### Summary

The certs were always returned the same as the cache key was not
considering the mesh name (was always asking identifying itself
with the cache key "zone egress")

+ removal of cleaning resource list in a loop, which was a bug

### Full changelog

n/a

### Issues resolved

n/a

### Documentation

n/a

### Testing

- [ ] Unit tests
- [ ] E2E tests
- [x] Manual testing on Universal
- [x] Manual testing on Kubernetes

### Backwards compatibility

- [ ] Update [`UPGRADE.md`](/UPGRADE.md) with any steps users will need to take when upgrading.
- [ ] Add `backport-to-stable` label if the code follows our [backporting policy](/CONTRIBUTING.md#backporting)
