### PR TITLE
fix(kuma-cp): zero generation on insights provided by zone cp

### DIFF
--- a/pkg/kds/context/context.go
+++ b/pkg/kds/context/context.go
@@ -39,6 +39,7 @@ type Context struct {
 	Configs map[string]bool
 
 	GlobalResourceMapper reconcile.ResourceMapper
+	ZoneResourceMapper   reconcile.ResourceMapper
 }
 
 func DefaultContext(manager manager.ResourceManager, zone string) *Context {
@@ -53,10 +54,8 @@ func DefaultContext(manager manager.ResourceManager, zone string) *Context {
 		GlobalProvidedFilter: GlobalProvidedFilter(manager, configs),
 		ZoneProvidedFilter:   ZoneProvidedFilter(zone),
 		Configs:              configs,
-		GlobalResourceMapper: CompositeResourceMapper(
-			MapZoneTokenSigningKeyGlobalToPublicKey(ctx, manager),
-			MapInsightResourcesZeroGeneration,
-		),
+		GlobalResourceMapper: MapZoneTokenSigningKeyGlobalToPublicKey(ctx, manager),
+		ZoneResourceMapper:   MapInsightResourcesZeroGeneration,
 	}
 }
 

--- a/pkg/kds/context/context_test.go
+++ b/pkg/kds/context/context_test.go
@@ -29,7 +29,7 @@ import (
 )
 
 var _ = Describe("Context", func() {
-	Describe("GlobalResourceMapper", func() {
+	Describe("ZoneResourceMapper", func() {
 		var rm manager.ResourceManager
 		var mapper reconcile.ResourceMapper
 
@@ -41,7 +41,7 @@ var _ = Describe("Context", func() {
 		BeforeEach(func() {
 			rm = manager.NewResourceManager(memory.NewStore())
 			defaultContext := context.DefaultContext(rm, "zone")
-			mapper = defaultContext.GlobalResourceMapper
+			mapper = defaultContext.ZoneResourceMapper
 		})
 
 		DescribeTable("should zero generation field",

--- a/pkg/kds/zone/components.go
+++ b/pkg/kds/zone/components.go
@@ -14,7 +14,6 @@ import (
 	"github.com/kumahq/kuma/pkg/core/runtime/component"
 	kds_client "github.com/kumahq/kuma/pkg/kds/client"
 	"github.com/kumahq/kuma/pkg/kds/mux"
-	"github.com/kumahq/kuma/pkg/kds/reconcile"
 	kds_server "github.com/kumahq/kuma/pkg/kds/server"
 	sync_store "github.com/kumahq/kuma/pkg/kds/store"
 	"github.com/kumahq/kuma/pkg/kds/util"
@@ -34,7 +33,7 @@ func Setup(rt core_runtime.Runtime) error {
 	kdsCtx := rt.KDSContext()
 	kdsServer, err := kds_server.New(kdsZoneLog, rt, reg.ObjectTypes(model.HasKDSFlag(model.ProvidedByZone)),
 		zone, rt.Config().Multizone.Zone.KDS.RefreshInterval,
-		kdsCtx.ZoneProvidedFilter, reconcile.NoopResourceMapper, false)
+		kdsCtx.ZoneProvidedFilter, kdsCtx.ZoneResourceMapper, false)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
### Summary

Global CP does not provide Insights with generations, Zone CP does.

I could remove CompositeResourceMapper, but I have a feeling that it will be used soon.

### Issues resolved

Fix #3840

### Documentation

No docs

### Testing

- [X] Unit tests
- [ ] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes

### Backwards compatibility

~- [ ] Update [`UPGRADE.md`](/UPGRADE.md) with any steps users will need to take when upgrading.~
- [X] Add `backport-to-stable` label if the code follows our [backporting policy](/CONTRIBUTING.md#backporting)
