### PR TITLE
fix(kuma-cp): filter out secrets that are not used

### DIFF
--- a/pkg/xds/generator/egress/external_services_generator.go
+++ b/pkg/xds/generator/egress/external_services_generator.go
@@ -133,7 +133,7 @@ func (*ExternalServicesGenerator) addFilterChains(
 	sniUsed := map[string]bool{}
 
 	for _, es := range meshResources.ExternalServices {
-		serviceName := es.GetMeta().GetName()
+		serviceName := es.Spec.GetService()
 
 		endpoints := endpointMap[serviceName]
 

--- a/pkg/xds/generator/egress/testdata/03.mixed-services.golden.yaml
+++ b/pkg/xds/generator/egress/testdata/03.mixed-services.golden.yaml
@@ -49,17 +49,17 @@ resources:
           metadata:
             filterMetadata:
               envoy.lb:
-                kuma.io/external-service-name: externalservice-1
+                kuma.io/external-service-name: externalservice-2
                 kuma.io/protocol: http2
                 mesh: mesh-1
               envoy.transport_socket_match:
-                kuma.io/external-service-name: externalservice-1
+                kuma.io/external-service-name: externalservice-2
                 kuma.io/protocol: http2
                 mesh: mesh-1
     name: mesh-1:externalservice-2
     transportSocketMatches:
     - match:
-        kuma.io/external-service-name: externalservice-1
+        kuma.io/external-service-name: externalservice-2
         kuma.io/protocol: http2
         mesh: mesh-1
       name: httpbin.io
@@ -224,6 +224,60 @@ resources:
                 route:
                   cluster: mesh-1:externalservice-1
           statPrefix: externalservice-1
+      transportSocket:
+        name: envoy.transport_sockets.tls
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext
+          commonTlsContext:
+            combinedValidationContext:
+              defaultValidationContext:
+                matchSubjectAltNames:
+                - prefix: spiffe://mesh-1/
+              validationContextSdsSecretConfig:
+                name: mesh_ca:secret:mesh-1
+                sdsConfig:
+                  ads: {}
+                  resourceApiVersion: V3
+            tlsCertificateSdsSecretConfigs:
+            - name: identity_cert:secret:mesh-1
+              sdsConfig:
+                ads: {}
+                resourceApiVersion: V3
+          requireClientCertificate: true
+    - filterChainMatch:
+        serverNames:
+        - externalservice-2{mesh=mesh-1}
+        transportProtocol: tls
+      filters:
+      - name: envoy.filters.network.rbac
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.filters.network.rbac.v3.RBAC
+          rules:
+            policies:
+              allow-all-traffic:
+                permissions:
+                - any: true
+                principals:
+                - any: true
+          statPrefix: externalservice-2.
+      - name: envoy.filters.network.http_connection_manager
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+          httpFilters:
+          - name: envoy.filters.http.router
+          routeConfig:
+            name: outbound:externalservice-2
+            validateClusters: false
+            virtualHosts:
+            - domains:
+              - '*'
+              name: externalservice-2
+              routes:
+              - match:
+                  prefix: /
+                route:
+                  cluster: mesh-1:externalservice-2
+          statPrefix: externalservice-2
       transportSocket:
         name: envoy.transport_sockets.tls
         typedConfig:

--- a/pkg/xds/generator/egress/testdata/05.mixed-services-with-custom-trafficpermissions.golden.yaml
+++ b/pkg/xds/generator/egress/testdata/05.mixed-services-with-custom-trafficpermissions.golden.yaml
@@ -49,17 +49,17 @@ resources:
           metadata:
             filterMetadata:
               envoy.lb:
-                kuma.io/external-service-name: externalservice-1
+                kuma.io/external-service-name: externalservice-2
                 kuma.io/protocol: http2
                 mesh: mesh-1
               envoy.transport_socket_match:
-                kuma.io/external-service-name: externalservice-1
+                kuma.io/external-service-name: externalservice-2
                 kuma.io/protocol: http2
                 mesh: mesh-1
     name: mesh-1:externalservice-2
     transportSocketMatches:
     - match:
-        kuma.io/external-service-name: externalservice-1
+        kuma.io/external-service-name: externalservice-2
         kuma.io/protocol: http2
         mesh: mesh-1
       name: httpbin.io
@@ -226,6 +226,54 @@ resources:
                 route:
                   cluster: mesh-1:externalservice-1
           statPrefix: externalservice-1
+      transportSocket:
+        name: envoy.transport_sockets.tls
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext
+          commonTlsContext:
+            combinedValidationContext:
+              defaultValidationContext:
+                matchSubjectAltNames:
+                - prefix: spiffe://mesh-1/
+              validationContextSdsSecretConfig:
+                name: mesh_ca:secret:mesh-1
+                sdsConfig:
+                  ads: {}
+                  resourceApiVersion: V3
+            tlsCertificateSdsSecretConfigs:
+            - name: identity_cert:secret:mesh-1
+              sdsConfig:
+                ads: {}
+                resourceApiVersion: V3
+          requireClientCertificate: true
+    - filterChainMatch:
+        serverNames:
+        - externalservice-2{mesh=mesh-1}
+        transportProtocol: tls
+      filters:
+      - name: envoy.filters.network.rbac
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.filters.network.rbac.v3.RBAC
+          rules: {}
+          statPrefix: externalservice-2.
+      - name: envoy.filters.network.http_connection_manager
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+          httpFilters:
+          - name: envoy.filters.http.router
+          routeConfig:
+            name: outbound:externalservice-2
+            validateClusters: false
+            virtualHosts:
+            - domains:
+              - '*'
+              name: externalservice-2
+              routes:
+              - match:
+                  prefix: /
+                route:
+                  cluster: mesh-1:externalservice-2
+          statPrefix: externalservice-2
       transportSocket:
         name: envoy.transport_sockets.tls
         typedConfig:

--- a/pkg/xds/generator/egress/testdata/input/03.mixed-services.yaml
+++ b/pkg/xds/generator/egress/testdata/input/03.mixed-services.yaml
@@ -68,7 +68,7 @@ networking:
   address: kuma.io:80
 ---
 type: ExternalService
-name: externalservice-1
+name: externalservice-2
 mesh: mesh-1
 tags:
   kuma.io/service: externalservice-2

--- a/pkg/xds/generator/egress/testdata/input/05.mixed-services-with-custom-trafficpermissions.yaml
+++ b/pkg/xds/generator/egress/testdata/input/05.mixed-services-with-custom-trafficpermissions.yaml
@@ -68,7 +68,7 @@ networking:
   address: kuma.io:80
 ---
 type: ExternalService
-name: externalservice-1
+name: externalservice-2
 mesh: mesh-1
 tags:
   kuma.io/service: externalservice-2

--- a/pkg/xds/generator/secrets_generator.go
+++ b/pkg/xds/generator/secrets_generator.go
@@ -74,6 +74,16 @@ func createZoneEgressSecrets(
 			continue
 		}
 
+		if len(meshResources.ExternalServices) == 0 {
+			// https://github.com/envoyproxy/envoy/issues/9310
+			// Envoy has a behavior that if you include a secret over ADS that is not referenced anywhere
+			// all secrets are stuck in warming state.
+			// We need to only deliver secrets that are used in other parts of config.
+			// ZoneEgress only use identity and CA certs for external services.
+			// For internal services it just passes the traffic to ZoneIngress through SNI
+			continue
+		}
+
 		identity, ca, err := ctx.ControlPlane.Secrets.GetForZoneEgress(
 			proxy.ZoneEgressProxy.ZoneEgressResource,
 			meshResources.Mesh,

--- a/pkg/xds/generator/secrets_generator_test.go
+++ b/pkg/xds/generator/secrets_generator_test.go
@@ -191,56 +191,19 @@ var _ = Describe("SecretsGenerator", func() {
 									},
 								},
 							},
-						},
-						{
-							Mesh: &core_mesh.MeshResource{
-								Meta: &test_model.ResourceMeta{
-									Name: "mesh-3",
-								},
-								Spec: &mesh_proto.Mesh{
-									Mtls: &mesh_proto.Mesh_Mtls{
-										EnabledBackend: "ca-1",
-										Backends: []*mesh_proto.CertificateAuthorityBackend{
-											{
-												Name: "ca-1",
-												Type: "builtin",
-											},
-										},
+							// only meshes with external services are taken into account
+							ExternalServices: []*core_mesh.ExternalServiceResource{
+								{
+									Meta: &test_model.ResourceMeta{
+										Name: "es-mesh-2",
+										Mesh: "mesh-2",
 									},
-								},
-							},
-						},
-						{
-							Mesh: &core_mesh.MeshResource{
-								Meta: &test_model.ResourceMeta{
-									Name: "mesh-4",
-								},
-								Spec: &mesh_proto.Mesh{
-									Mtls: &mesh_proto.Mesh_Mtls{
-										EnabledBackend: "ca-1",
-										Backends: []*mesh_proto.CertificateAuthorityBackend{
-											{
-												Name: "ca-1",
-												Type: "builtin",
-											},
+									Spec: &mesh_proto.ExternalService{
+										Networking: &mesh_proto.ExternalService_Networking{
+											Address: "example.com:80",
 										},
-									},
-								},
-							},
-						},
-						{
-							Mesh: &core_mesh.MeshResource{
-								Meta: &test_model.ResourceMeta{
-									Name: "mesh-5",
-								},
-								Spec: &mesh_proto.Mesh{
-									Mtls: &mesh_proto.Mesh_Mtls{
-										EnabledBackend: "ca-1",
-										Backends: []*mesh_proto.CertificateAuthorityBackend{
-											{
-												Name: "ca-1",
-												Type: "builtin",
-											},
+										Tags: map[string]string{
+											"kuma.io/service": "service2",
 										},
 									},
 								},

--- a/pkg/xds/generator/testdata/secrets/envoy-config-egress.golden.yaml
+++ b/pkg/xds/generator/testdata/secrets/envoy-config-egress.golden.yaml
@@ -1,13 +1,4 @@
 resources:
-- name: identity_cert:secret:mesh-1
-  resource:
-    '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.Secret
-    name: identity_cert:secret:mesh-1
-    tlsCertificate:
-      certificateChain:
-        inlineBytes: Q0VSVA==
-      privateKey:
-        inlineBytes: S0VZ
 - name: identity_cert:secret:mesh-2
   resource:
     '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.Secret
@@ -17,65 +8,10 @@ resources:
         inlineBytes: Q0VSVA==
       privateKey:
         inlineBytes: S0VZ
-- name: identity_cert:secret:mesh-3
-  resource:
-    '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.Secret
-    name: identity_cert:secret:mesh-3
-    tlsCertificate:
-      certificateChain:
-        inlineBytes: Q0VSVA==
-      privateKey:
-        inlineBytes: S0VZ
-- name: identity_cert:secret:mesh-4
-  resource:
-    '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.Secret
-    name: identity_cert:secret:mesh-4
-    tlsCertificate:
-      certificateChain:
-        inlineBytes: Q0VSVA==
-      privateKey:
-        inlineBytes: S0VZ
-- name: identity_cert:secret:mesh-5
-  resource:
-    '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.Secret
-    name: identity_cert:secret:mesh-5
-    tlsCertificate:
-      certificateChain:
-        inlineBytes: Q0VSVA==
-      privateKey:
-        inlineBytes: S0VZ
-- name: mesh_ca:secret:mesh-1
-  resource:
-    '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.Secret
-    name: mesh_ca:secret:mesh-1
-    validationContext:
-      trustedCa:
-        inlineBytes: Q0E=
 - name: mesh_ca:secret:mesh-2
   resource:
     '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.Secret
     name: mesh_ca:secret:mesh-2
-    validationContext:
-      trustedCa:
-        inlineBytes: Q0E=
-- name: mesh_ca:secret:mesh-3
-  resource:
-    '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.Secret
-    name: mesh_ca:secret:mesh-3
-    validationContext:
-      trustedCa:
-        inlineBytes: Q0E=
-- name: mesh_ca:secret:mesh-4
-  resource:
-    '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.Secret
-    name: mesh_ca:secret:mesh-4
-    validationContext:
-      trustedCa:
-        inlineBytes: Q0E=
-- name: mesh_ca:secret:mesh-5
-  resource:
-    '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.Secret
-    name: mesh_ca:secret:mesh-5
     validationContext:
       trustedCa:
         inlineBytes: Q0E=


### PR DESCRIPTION
### Summary

We discovered two problems with external services and zone egress

1. We took the name of the external service instead of kuma.io/service tag from the service
2. We cannot provide all secrets to ZoneEgress. We can only use the ones that are referenced by the rest of the config. Otherwise, all secrets are stuck in a warming state.

### Issues resolved

No issues reported.

### Documentation

No docs.

### Testing

- [X] Unit tests
- [X] E2E tests (in separate PR)
- [ ] Manual testing on Universal
- [X] Manual testing on Kubernetes

### Backwards compatibility

~- [ ] Update [`UPGRADE.md`](/UPGRADE.md) with any steps users will need to take when upgrading.~
- [X] Add `backport-to-stable` label if the code follows our [backporting policy](/CONTRIBUTING.md#backporting)
