### PR TITLE
test(e2e/ratelimit): mark as pending while we investigate flakiness

### DIFF
--- a/test/e2e/ratelimit/e2e_suite_test.go
+++ b/test/e2e/ratelimit/e2e_suite_test.go
@@ -13,4 +13,5 @@ func TestE2E(t *testing.T) {
 	test.RunSpecs(t, "E2E RateLimit Suite")
 }
 
-var _ = Describe("Test RateLimit on Universal", ratelimit.RateLimitOnUniversal)
+// Pending while we fix the flakiness of checking the rate limit
+var _ = XDescribe("Test RateLimit on Universal", ratelimit.RateLimitOnUniversal)


### PR DESCRIPTION
### Summary

The check is still flaky.