### PR TITLE
chore(*): embed verify kuma calls in kuma deploy

### DIFF
--- a/test/e2e/auth/auth_universal.go
+++ b/test/e2e/auth/auth_universal.go
@@ -18,8 +18,6 @@ func AuthUniversal() {
 			Install(Kuma(core.Standalone)).
 			Setup(cluster)
 		Expect(err).ToNot(HaveOccurred())
-		err = cluster.VerifyKuma()
-		Expect(err).ToNot(HaveOccurred())
 	})
 
 	AfterEach(func() {

--- a/test/e2e/auth/dp/dp_auth_universal.go
+++ b/test/e2e/auth/dp/dp_auth_universal.go
@@ -18,8 +18,6 @@ func DpAuthUniversal() {
 			Install(Kuma(core.Standalone)).
 			Setup(cluster)
 		Expect(err).ToNot(HaveOccurred())
-		err = cluster.VerifyKuma()
-		Expect(err).ToNot(HaveOccurred())
 	})
 
 	E2EAfterSuite(func() {

--- a/test/e2e/compatibility/cp_compatibility_kubernetes_multizone.go
+++ b/test/e2e/compatibility/cp_compatibility_kubernetes_multizone.go
@@ -83,7 +83,6 @@ func CpCompatibilityMultizoneKubernetes() {
 			)).
 			Setup(globalCluster)
 		Expect(err).ToNot(HaveOccurred())
-		Expect(globalCluster.VerifyKuma()).To(Succeed())
 
 		// Start a zone
 		err = NewClusterSetup().
@@ -98,8 +97,6 @@ func CpCompatibilityMultizoneKubernetes() {
 			Install(NamespaceWithSidecarInjectionOnAnnotation(TestNamespace)).
 			Setup(zoneCluster)
 		Expect(err).ToNot(HaveOccurred())
-
-		Expect(zoneCluster.VerifyKuma()).To(Succeed())
 
 		// and new resource is created on Global
 		err = YamlK8s(`

--- a/test/e2e/compatibility/dp_compatibility_universal.go
+++ b/test/e2e/compatibility/dp_compatibility_universal.go
@@ -19,8 +19,6 @@ func UniversalCompatibility() {
 			Install(Kuma(core.Standalone)).
 			Setup(cluster)
 		Expect(err).ToNot(HaveOccurred())
-		err = cluster.VerifyKuma()
-		Expect(err).ToNot(HaveOccurred())
 
 		testServerToken, err := cluster.GetKuma().GenerateDpToken("default", "test-server")
 		Expect(err).ToNot(HaveOccurred())

--- a/test/e2e/deploy/kuma_deploy_global_zone.go
+++ b/test/e2e/deploy/kuma_deploy_global_zone.go
@@ -78,16 +78,6 @@ spec:
 		zone = c2.GetKuma()
 		Expect(zone).ToNot(BeNil())
 
-		// when
-		err = c1.VerifyKuma()
-		// then
-		Expect(err).ToNot(HaveOccurred())
-
-		// when
-		err = c2.VerifyKuma()
-		// then
-		Expect(err).ToNot(HaveOccurred())
-
 		// then
 		logs1, err := global.GetKumaCPLogs()
 		Expect(err).ToNot(HaveOccurred())

--- a/test/e2e/deploy/kuma_deploy_universal.go
+++ b/test/e2e/deploy/kuma_deploy_universal.go
@@ -55,8 +55,6 @@ name: %s
 			Install(YamlUniversal(meshMTLSOff(defaultMesh))).
 			Setup(global)
 		Expect(err).ToNot(HaveOccurred())
-		err = global.VerifyKuma()
-		Expect(err).ToNot(HaveOccurred())
 
 		globalCP := global.GetKuma()
 
@@ -84,8 +82,6 @@ name: %s
 			Install(IngressUniversal(ingressTokenKuma3)).
 			Setup(zone1)
 		Expect(err).ToNot(HaveOccurred())
-		err = zone1.VerifyKuma()
-		Expect(err).ToNot(HaveOccurred())
 
 		// Cluster 2
 		zone2 = clusters.GetCluster(Kuma4)
@@ -101,8 +97,6 @@ name: %s
 			Install(DemoClientUniversal(AppModeDemoClient, nonDefaultMesh, demoClientToken, WithTransparentProxy(true))).
 			Install(IngressUniversal(ingressTokenKuma4)).
 			Setup(zone2)
-		Expect(err).ToNot(HaveOccurred())
-		err = zone2.VerifyKuma()
 		Expect(err).ToNot(HaveOccurred())
 	})
 

--- a/test/e2e/deploy/kuma_deploy_universal_transparent_proxy.go
+++ b/test/e2e/deploy/kuma_deploy_universal_transparent_proxy.go
@@ -22,8 +22,6 @@ func UniversalTransparentProxyDeployment() {
 			Install(Kuma(core.Standalone)).
 			Setup(cluster)
 		Expect(err).ToNot(HaveOccurred())
-		err = cluster.VerifyKuma()
-		Expect(err).ToNot(HaveOccurred())
 
 		echoServerToken, err := cluster.GetKuma().GenerateDpToken("default", "echo-server_kuma-test_svc_8080")
 		Expect(err).ToNot(HaveOccurred())

--- a/test/e2e/externalservices/externalservices_hostheader.go
+++ b/test/e2e/externalservices/externalservices_hostheader.go
@@ -34,9 +34,6 @@ networking:
 			Setup(cluster)
 		Expect(err).ToNot(HaveOccurred())
 
-		err = cluster.VerifyKuma()
-		Expect(err).ToNot(HaveOccurred())
-
 		demoClientToken, err := cluster.GetKuma().GenerateDpToken("default", "dp-demo-client")
 		Expect(err).ToNot(HaveOccurred())
 

--- a/test/e2e/externalservices/externalservices_kubernetes.go
+++ b/test/e2e/externalservices/externalservices_kubernetes.go
@@ -85,8 +85,6 @@ spec:
 			Install(externalservice.Install(externalservice.HttpsServer, []string{})).
 			Setup(cluster)
 		Expect(err).ToNot(HaveOccurred())
-		err = cluster.VerifyKuma()
-		Expect(err).ToNot(HaveOccurred())
 
 		err = YamlK8s(fmt.Sprintf(meshDefaulMtlsOn, "false"))(cluster)
 		Expect(err).ToNot(HaveOccurred())

--- a/test/e2e/externalservices/externalservices_multizone_universal.go
+++ b/test/e2e/externalservices/externalservices_multizone_universal.go
@@ -78,8 +78,6 @@ networking:
 			Install(YamlUniversal(fmt.Sprintf(meshDefaulMtlsOn, "false"))).
 			Setup(global)
 		Expect(err).ToNot(HaveOccurred())
-		err = global.VerifyKuma()
-		Expect(err).ToNot(HaveOccurred())
 
 		globalCP := global.GetKuma()
 
@@ -97,8 +95,6 @@ networking:
 			Install(DemoClientUniversal(AppModeDemoClient, defaultMesh, demoClientToken, WithTransparentProxy(true))).
 			Setup(zone1)
 		Expect(err).ToNot(HaveOccurred())
-		err = zone1.VerifyKuma()
-		Expect(err).ToNot(HaveOccurred())
 
 		// Cluster 2
 		zone2 = clusters.GetCluster(Kuma5)
@@ -110,8 +106,6 @@ networking:
 			)).
 			Install(DemoClientUniversal(AppModeDemoClient, defaultMesh, demoClientToken, WithTransparentProxy(true))).
 			Setup(zone2)
-		Expect(err).ToNot(HaveOccurred())
-		err = zone2.VerifyKuma()
 		Expect(err).ToNot(HaveOccurred())
 	})
 

--- a/test/e2e/externalservices/externalservices_universal.go
+++ b/test/e2e/externalservices/externalservices_universal.go
@@ -58,8 +58,6 @@ networking:
 			Install(Kuma(core.Standalone)).
 			Setup(cluster)
 		Expect(err).ToNot(HaveOccurred())
-		err = cluster.VerifyKuma()
-		Expect(err).ToNot(HaveOccurred())
 
 		demoClientToken, err := cluster.GetKuma().GenerateDpToken("default", "demo-client")
 		Expect(err).ToNot(HaveOccurred())

--- a/test/e2e/gateway/hybrid/gateway_hybrid.go
+++ b/test/e2e/gateway/hybrid/gateway_hybrid.go
@@ -29,7 +29,6 @@ func GatewayHybrid() {
 			).
 			Setup(global)
 		Expect(err).ToNot(HaveOccurred())
-		Expect(global.VerifyKuma()).To(Succeed())
 
 		k8sZone = NewK8sCluster(NewTestingT(), Kuma1, Silent)
 		err = NewClusterSetup().

--- a/test/e2e/healthcheck/hybrid/healthcheck_hybrid.go
+++ b/test/e2e/healthcheck/hybrid/healthcheck_hybrid.go
@@ -84,8 +84,6 @@ spec:
 			Install(IngressUniversal(ingressTokenKuma3)).
 			Setup(zoneUniversal)
 		Expect(err).ToNot(HaveOccurred())
-		err = zoneUniversal.VerifyKuma()
-		Expect(err).ToNot(HaveOccurred())
 	})
 
 	AfterEach(func() {

--- a/test/e2e/healthcheck/kubernetes/virtual_probes.go
+++ b/test/e2e/healthcheck/kubernetes/virtual_probes.go
@@ -25,7 +25,6 @@ func VirtualProbes() {
 
 		Expect(Kuma(config_core.Standalone)(k8sCluster)).To(Succeed())
 		Expect(NamespaceWithSidecarInjection(TestNamespace)(k8sCluster)).To(Succeed())
-		Expect(k8sCluster.VerifyKuma()).To(Succeed())
 	})
 
 	E2EAfterSuite(func() {

--- a/test/e2e/healthcheck/universal/panic.go
+++ b/test/e2e/healthcheck/universal/panic.go
@@ -56,8 +56,6 @@ networking:
 			Install(YamlUniversal(healthCheck)).
 			Setup(universalCluster)
 		Expect(err).ToNot(HaveOccurred())
-		err = universalCluster.VerifyKuma()
-		Expect(err).ToNot(HaveOccurred())
 
 		testServerToken, err := universalCluster.GetKuma().GenerateDpToken("default", "test-server")
 		Expect(err).ToNot(HaveOccurred())

--- a/test/e2e/healthcheck/universal/policy_http.go
+++ b/test/e2e/healthcheck/universal/policy_http.go
@@ -48,8 +48,6 @@ conf:
 			Install(YamlUniversal(healthCheck("health", "200"))).
 			Setup(cluster)
 		Expect(err).ToNot(HaveOccurred())
-		err = cluster.VerifyKuma()
-		Expect(err).ToNot(HaveOccurred())
 
 		demoClientToken, err := cluster.GetKuma().GenerateDpToken("default", "dp-demo-client")
 		Expect(err).ToNot(HaveOccurred())

--- a/test/e2e/healthcheck/universal/policy_tcp.go
+++ b/test/e2e/healthcheck/universal/policy_tcp.go
@@ -52,8 +52,6 @@ conf:
 			Install(YamlUniversal(healthCheck("foo", "bar"))).
 			Setup(cluster)
 		Expect(err).ToNot(HaveOccurred())
-		err = cluster.VerifyKuma()
-		Expect(err).ToNot(HaveOccurred())
 
 		demoClientToken, err := cluster.GetKuma().GenerateDpToken("default", "dp-demo-client")
 		Expect(err).ToNot(HaveOccurred())

--- a/test/e2e/healthcheck/universal/service_probes.go
+++ b/test/e2e/healthcheck/universal/service_probes.go
@@ -18,8 +18,6 @@ func ServiceProbes() {
 			Install(Kuma(core.Standalone)).
 			Setup(cluster)
 		Expect(err).ToNot(HaveOccurred())
-		err = cluster.VerifyKuma()
-		Expect(err).ToNot(HaveOccurred())
 
 		echoServerToken, err := cluster.GetKuma().GenerateDpToken("default", "test-server")
 		Expect(err).ToNot(HaveOccurred())

--- a/test/e2e/helm/kuma_helm_deploy_global_zone.go
+++ b/test/e2e/helm/kuma_helm_deploy_global_zone.go
@@ -68,16 +68,6 @@ func ZoneAndGlobalWithHelmChart() {
 		zone = c2.GetKuma()
 		Expect(zone).ToNot(BeNil())
 
-		// when
-		err = c1.VerifyKuma()
-		// then
-		Expect(err).ToNot(HaveOccurred())
-
-		// when
-		err = c2.VerifyKuma()
-		// then
-		Expect(err).ToNot(HaveOccurred())
-
 		// then
 		logs1, err := global.GetKumaCPLogs()
 		Expect(err).ToNot(HaveOccurred())

--- a/test/e2e/helm/kuma_helm_upgrade.go
+++ b/test/e2e/helm/kuma_helm_upgrade.go
@@ -62,8 +62,6 @@ func UpgradingWithHelmChart() {
 				Setup(cluster)
 			Expect(err).ToNot(HaveOccurred())
 
-			Expect(cluster.VerifyKuma()).To(Succeed())
-
 			k8sCluster := cluster.(*K8sCluster)
 
 			err = k8sCluster.UpgradeKuma(core.Standalone, WithHelmReleaseName(releaseName))

--- a/test/e2e/hybrid/globalkubernetes/kuma_hybrid_kube_global.go
+++ b/test/e2e/hybrid/globalkubernetes/kuma_hybrid_kube_global.go
@@ -29,8 +29,6 @@ func KubernetesUniversalDeploymentWhenGlobalIsOnK8S() {
 			Install(Kuma(core.Global)).
 			Setup(globalCluster)
 		Expect(err).ToNot(HaveOccurred())
-		err = globalCluster.VerifyKuma()
-		Expect(err).ToNot(HaveOccurred())
 		globalCP := globalCluster.GetKuma()
 
 		echoServerToken, err := globalCP.GenerateDpToken("default", "test-server")
@@ -49,8 +47,6 @@ func KubernetesUniversalDeploymentWhenGlobalIsOnK8S() {
 			Install(DemoClientUniversal(AppModeDemoClient, "default", demoClientToken, WithTransparentProxy(true))).
 			Install(IngressUniversal(ingressTokenKuma3)).
 			Setup(zoneCluster)
-		Expect(err).ToNot(HaveOccurred())
-		err = zoneCluster.VerifyKuma()
 		Expect(err).ToNot(HaveOccurred())
 	})
 

--- a/test/e2e/hybrid/globaluniversal/kuma_hybrid.go
+++ b/test/e2e/hybrid/globaluniversal/kuma_hybrid.go
@@ -53,8 +53,6 @@ mtls:
 			Install(YamlUniversal(meshMTLSOn(defaultMesh))).
 			Setup(global)
 		Expect(err).ToNot(HaveOccurred())
-		err = global.VerifyKuma()
-		Expect(err).ToNot(HaveOccurred())
 
 		globalCP := global.GetKuma()
 
@@ -77,8 +75,6 @@ mtls:
 			Install(DemoClientK8s(nonDefaultMesh)).
 			Setup(zone1)
 		Expect(err).ToNot(HaveOccurred())
-		err = zone1.VerifyKuma()
-		Expect(err).ToNot(HaveOccurred())
 
 		// K8s Cluster 2
 		zone2 = k8sClusters.GetCluster(Kuma2)
@@ -94,8 +90,6 @@ mtls:
 			Install(testserver.Install(testserver.WithMesh(nonDefaultMesh), testserver.WithServiceAccount("sa-test"))).
 			Install(DemoClientK8s(nonDefaultMesh)).
 			Setup(zone2)
-		Expect(err).ToNot(HaveOccurred())
-		err = zone2.VerifyKuma()
 		Expect(err).ToNot(HaveOccurred())
 
 		// Universal Cluster 3
@@ -113,8 +107,6 @@ mtls:
 			Install(IngressUniversal(ingressTokenKuma3)).
 			Setup(zone3)
 		Expect(err).ToNot(HaveOccurred())
-		err = zone3.VerifyKuma()
-		Expect(err).ToNot(HaveOccurred())
 
 		// Universal Cluster 4
 		zone4 = universalClusters.GetCluster(Kuma4)
@@ -126,8 +118,6 @@ mtls:
 			Install(DemoClientUniversal(AppModeDemoClient, nonDefaultMesh, demoClientToken, WithTransparentProxy(true))).
 			Install(IngressUniversal(ingressTokenKuma4)).
 			Setup(zone4)
-		Expect(err).ToNot(HaveOccurred())
-		err = zone4.VerifyKuma()
 		Expect(err).ToNot(HaveOccurred())
 	})
 

--- a/test/e2e/jobs/jobs.go
+++ b/test/e2e/jobs/jobs.go
@@ -24,8 +24,6 @@ func Jobs() {
 			Install(testserver.Install()).
 			Setup(kubernetes)
 		Expect(err).ToNot(HaveOccurred())
-		err = kubernetes.VerifyKuma()
-		Expect(err).ToNot(HaveOccurred())
 	})
 
 	E2EAfterSuite(func() {

--- a/test/e2e/kic/kong_ingress.go
+++ b/test/e2e/kic/kong_ingress.go
@@ -112,8 +112,6 @@ func KICKubernetes() {
 			Install(testserver.Install()).
 			Setup(kubernetes)
 		Expect(err).ToNot(HaveOccurred())
-		err = kubernetes.VerifyKuma()
-		Expect(err).ToNot(HaveOccurred())
 	})
 	E2EAfterEach(func() {
 		err := k8s.RunKubectlE(kubernetes.GetTesting(), kubernetes.GetKubectlOptions(), "delete", "ingress", "--all", "-n", "kuma-test")

--- a/test/e2e/matching/matching_universal.go
+++ b/test/e2e/matching/matching_universal.go
@@ -23,8 +23,6 @@ func Universal() {
 			Install(Kuma(core.Standalone)).
 			Setup(universal)
 		Expect(err).ToNot(HaveOccurred())
-		err = universal.VerifyKuma()
-		Expect(err).ToNot(HaveOccurred())
 
 		demoClientToken1, err := universal.GetKuma().GenerateDpToken("default", "demo-client-1")
 		Expect(err).ToNot(HaveOccurred())

--- a/test/e2e/membership/universal/membership_universal.go
+++ b/test/e2e/membership/universal/membership_universal.go
@@ -17,8 +17,6 @@ func MembershipUniversal() {
 			Install(Kuma(core.Standalone)).
 			Setup(cluster)
 		Expect(err).ToNot(HaveOccurred())
-		err = cluster.VerifyKuma()
-		Expect(err).ToNot(HaveOccurred())
 	})
 
 	E2EAfterSuite(func() {

--- a/test/e2e/mtls/permissive/permissive_mode.go
+++ b/test/e2e/mtls/permissive/permissive_mode.go
@@ -21,7 +21,6 @@ func PermissiveMode() {
 		universal = clusters.GetCluster(Kuma1)
 		// This option is important for introducing update delays into to enable PERMISSIVE mTLS test
 		Expect(Kuma(core.Standalone, WithEnv("KUMA_XDS_SERVER_DATAPLANE_CONFIGURATION_REFRESH_INTERVAL", "1s"))(universal)).To(Succeed())
-		Expect(universal.VerifyKuma()).To(Succeed())
 	})
 
 	E2EAfterEach(func() {

--- a/test/e2e/mtls/universal/mtls_backends.go
+++ b/test/e2e/mtls/universal/mtls_backends.go
@@ -19,8 +19,6 @@ func MTLSUniversal() {
 			Install(Kuma(config_core.Standalone)).
 			Setup(universalCluster)
 		Expect(err).ToNot(HaveOccurred())
-		err = universalCluster.VerifyKuma()
-		Expect(err).ToNot(HaveOccurred())
 
 		testServerToken, err := universalCluster.GetKuma().GenerateDpToken("default", "test-server")
 		Expect(err).ToNot(HaveOccurred())

--- a/test/e2e/ownership/multizone_universal.go
+++ b/test/e2e/ownership/multizone_universal.go
@@ -19,14 +19,12 @@ func MultizoneUniversal() {
 		// Global
 		global = clusters.GetCluster(Kuma1)
 		Expect(Kuma(core.Global)(global)).To(Succeed())
-		Expect(global.VerifyKuma()).To(Succeed())
 
 		// Cluster 1
 		zoneUniversal = clusters.GetCluster(Kuma2)
 		Expect(Kuma(core.Zone,
 			WithGlobalAddress(global.GetKuma().GetKDSServerAddress()))(zoneUniversal),
 		).To(Succeed())
-		Expect(zoneUniversal.VerifyKuma()).To(Succeed())
 	})
 
 	E2EAfterEach(func() {

--- a/test/e2e/ratelimit/ratelimit_universal.go
+++ b/test/e2e/ratelimit/ratelimit_universal.go
@@ -65,9 +65,6 @@ conf:
 			Install(externalservice.Install(externalservice.HttpServer, externalservice.UniversalAppEchoServer81)).
 			Setup(cluster)
 		Expect(err).ToNot(HaveOccurred())
-
-		err = cluster.VerifyKuma()
-		Expect(err).ToNot(HaveOccurred())
 	})
 
 	E2EAfterSuite(func() {

--- a/test/e2e/reachableservices/reachableservices_universal.go
+++ b/test/e2e/reachableservices/reachableservices_universal.go
@@ -18,8 +18,6 @@ func ReachableServicesOnUniversal() {
 			Install(Kuma(config_core.Standalone)).
 			Setup(cluster)
 		Expect(err).ToNot(HaveOccurred())
-		err = cluster.VerifyKuma()
-		Expect(err).ToNot(HaveOccurred())
 
 		firstTestServerToken, err := cluster.GetKuma().GenerateDpToken("default", "first-test-server")
 		Expect(err).ToNot(HaveOccurred())

--- a/test/e2e/resilience/leader_election_postgres.go
+++ b/test/e2e/resilience/leader_election_postgres.go
@@ -32,7 +32,6 @@ func LeaderElectionPostgres() {
 			Setup(standalone1)
 
 		Expect(err).ToNot(HaveOccurred())
-		Expect(standalone1.VerifyKuma()).To(Succeed())
 
 		// Standalone 2
 		err = NewClusterSetup().
@@ -40,7 +39,6 @@ func LeaderElectionPostgres() {
 			Setup(standalone2)
 
 		Expect(err).ToNot(HaveOccurred())
-		Expect(standalone2.VerifyKuma()).To(Succeed())
 	})
 
 	E2EAfterEach(func() {

--- a/test/e2e/resilience/resilience_multizone_universal.go
+++ b/test/e2e/resilience/resilience_multizone_universal.go
@@ -26,8 +26,6 @@ func ResilienceMultizoneUniversal() {
 			Install(Kuma(core.Global)).
 			Setup(global)
 		Expect(err).ToNot(HaveOccurred())
-		err = global.VerifyKuma()
-		Expect(err).ToNot(HaveOccurred())
 
 		globalCP := global.GetKuma()
 
@@ -36,8 +34,6 @@ func ResilienceMultizoneUniversal() {
 		err = NewClusterSetup().
 			Install(Kuma(core.Zone, WithGlobalAddress(globalCP.GetKDSServerAddress()))).
 			Setup(zone1)
-		Expect(err).ToNot(HaveOccurred())
-		err = zone1.VerifyKuma()
 		Expect(err).ToNot(HaveOccurred())
 	})
 

--- a/test/e2e/resilience/resilience_multizone_universal_postgres.go
+++ b/test/e2e/resilience/resilience_multizone_universal_postgres.go
@@ -35,8 +35,6 @@ func ResilienceMultizoneUniversalPostgres() {
 			)).
 			Setup(global)
 		Expect(err).ToNot(HaveOccurred())
-		err = global.VerifyKuma()
-		Expect(err).ToNot(HaveOccurred())
 
 		globalCP := global.GetKuma()
 
@@ -55,9 +53,6 @@ func ResilienceMultizoneUniversalPostgres() {
 				WithEnv("KUMA_METRICS_DATAPLANE_IDLE_TIMEOUT", "10s"),
 			)).
 			Setup(zoneUniversal)
-		Expect(err).ToNot(HaveOccurred())
-
-		err = zoneUniversal.VerifyKuma()
 		Expect(err).ToNot(HaveOccurred())
 	})
 

--- a/test/e2e/resilience/resilience_standalone_universal.go
+++ b/test/e2e/resilience/resilience_standalone_universal.go
@@ -30,8 +30,6 @@ func ResilienceStandaloneUniversal() {
 			)).
 			Setup(universal)
 		Expect(err).ToNot(HaveOccurred())
-		err = universal.VerifyKuma()
-		Expect(err).ToNot(HaveOccurred())
 
 		demoClientToken, err := universal.GetKuma().GenerateDpToken("default", "demo-client")
 		Expect(err).ToNot(HaveOccurred())

--- a/test/e2e/retry/retry_universal.go
+++ b/test/e2e/retry/retry_universal.go
@@ -30,9 +30,6 @@ func RetryOnUniversal() {
 			Setup(cluster)
 		Expect(err).ToNot(HaveOccurred())
 
-		err = cluster.VerifyKuma()
-		Expect(err).ToNot(HaveOccurred())
-
 		demoClientToken, err := cluster.GetKuma().GenerateDpToken("default", "demo-client")
 		Expect(err).ToNot(HaveOccurred())
 

--- a/test/e2e/timeout/timeout_universal.go
+++ b/test/e2e/timeout/timeout_universal.go
@@ -55,8 +55,6 @@ conf:
 			Install(YamlUniversal(faultInjection)).
 			Setup(universalCluster)
 		Expect(err).ToNot(HaveOccurred())
-		err = universalCluster.VerifyKuma()
-		Expect(err).ToNot(HaveOccurred())
 
 		echoServerToken, err := universalCluster.GetKuma().GenerateDpToken("default", "test-server")
 		Expect(err).ToNot(HaveOccurred())

--- a/test/e2e/tracing/tracing_universal.go
+++ b/test/e2e/tracing/tracing_universal.go
@@ -48,8 +48,6 @@ selectors:
 			Install(tracing.Install()).
 			Setup(cluster)
 		Expect(err).ToNot(HaveOccurred())
-		err = cluster.VerifyKuma()
-		Expect(err).ToNot(HaveOccurred())
 
 		testServerToken, err := cluster.GetKuma().GenerateDpToken("default", "test-server")
 		Expect(err).ToNot(HaveOccurred())

--- a/test/e2e/trafficpermission/hybrid/traffic_permission_hybrid.go
+++ b/test/e2e/trafficpermission/hybrid/traffic_permission_hybrid.go
@@ -50,8 +50,6 @@ spec:
 			Install(YamlK8s(meshMTLSOn("default"))).
 			Setup(globalCluster)
 		Expect(err).ToNot(HaveOccurred())
-		err = globalCluster.VerifyKuma()
-		Expect(err).ToNot(HaveOccurred())
 		globalCP := globalCluster.GetKuma()
 
 		testServerToken, err := globalCP.GenerateDpToken("default", "test-server")
@@ -70,8 +68,6 @@ spec:
 			Install(IngressUniversal(ingressTokenKuma3)).
 			Setup(zoneUniversal)
 		Expect(err).ToNot(HaveOccurred())
-		err = zoneUniversal.VerifyKuma()
-		Expect(err).ToNot(HaveOccurred())
 
 		// Zone kubernetes
 		zoneKube = k8sClusters.GetCluster(Kuma2)
@@ -83,8 +79,6 @@ spec:
 			Install(NamespaceWithSidecarInjection(TestNamespace)).
 			Install(DemoClientK8s("default")).
 			Setup(zoneKube)
-		Expect(err).ToNot(HaveOccurred())
-		err = zoneKube.VerifyKuma()
 		Expect(err).ToNot(HaveOccurred())
 
 		pods, err := k8s.ListPodsE(

--- a/test/e2e/trafficpermission/kubernetes/traffic_permission_k8s.go
+++ b/test/e2e/trafficpermission/kubernetes/traffic_permission_k8s.go
@@ -22,7 +22,6 @@ func TrafficPermission() {
 		k8sCluster = k8sClusters.GetCluster(Kuma1)
 
 		Expect(Kuma(config_core.Standalone)(k8sCluster)).To(Succeed())
-		Expect(k8sCluster.VerifyKuma()).To(Succeed())
 	})
 
 	E2EAfterSuite(func() {

--- a/test/e2e/trafficpermission/universal/traffic_permission_universal.go
+++ b/test/e2e/trafficpermission/universal/traffic_permission_universal.go
@@ -29,8 +29,6 @@ mtls:
 			Install(YamlUniversal(meshDefaulMtlsOn)).
 			Setup(universalCluster)
 		Expect(err).ToNot(HaveOccurred())
-		err = universalCluster.VerifyKuma()
-		Expect(err).ToNot(HaveOccurred())
 
 		testServerToken, err := universalCluster.GetKuma().GenerateDpToken("default", "test-server")
 		Expect(err).ToNot(HaveOccurred())

--- a/test/e2e/trafficroute/universal_multizone/traffic_route.go
+++ b/test/e2e/trafficroute/universal_multizone/traffic_route.go
@@ -43,8 +43,6 @@ routing:
 			Install(YamlUniversal(meshMTLSOn(defaultMesh, "false"))).
 			Setup(global)
 		Expect(err).ToNot(HaveOccurred())
-		err = global.VerifyKuma()
-		Expect(err).ToNot(HaveOccurred())
 
 		globalCP := global.GetKuma()
 
@@ -71,8 +69,6 @@ routing:
 				WithServiceVersion("v1"),
 			)).
 			Setup(zone1)
-		Expect(err).ToNot(HaveOccurred())
-		err = zone1.VerifyKuma()
 		Expect(err).ToNot(HaveOccurred())
 
 		// Cluster 2
@@ -102,8 +98,6 @@ routing:
 			)).
 			Install(IngressUniversal(ingressTokenKuma4)).
 			Setup(zone2)
-		Expect(err).ToNot(HaveOccurred())
-		err = zone2.VerifyKuma()
 		Expect(err).ToNot(HaveOccurred())
 	})
 

--- a/test/e2e/trafficroute/universal_standalone/traffic_route.go
+++ b/test/e2e/trafficroute/universal_standalone/traffic_route.go
@@ -28,8 +28,6 @@ func KumaStandalone() {
 			Install(Kuma(core.Standalone)).
 			Setup(universal)
 		Expect(err).ToNot(HaveOccurred())
-		err = universal.VerifyKuma()
-		Expect(err).ToNot(HaveOccurred())
 
 		testServerToken, err := universal.GetKuma().GenerateDpToken(defaultMesh, "test-server")
 		Expect(err).ToNot(HaveOccurred())

--- a/test/e2e/virtualoutbound/virtualoutbound_universal.go
+++ b/test/e2e/virtualoutbound/virtualoutbound_universal.go
@@ -27,9 +27,6 @@ func VirtualOutboundOnUniversal() {
 			Setup(cluster)
 		Expect(err).ToNot(HaveOccurred())
 
-		err = cluster.VerifyKuma()
-		Expect(err).ToNot(HaveOccurred())
-
 		_ = cluster.GetKumactlOptions().RunKumactl("delete", "virtual-outbound", "instances")
 		_ = cluster.GetKumactlOptions().RunKumactl("delete", "virtual-outbound", "all")
 

--- a/test/framework/k8s_cluster.go
+++ b/test/framework/k8s_cluster.go
@@ -456,7 +456,7 @@ func (c *K8sCluster) DeployKuma(mode core.CpMode, opt ...KumaDeploymentOption) e
 		}
 	}
 
-	return nil
+	return c.VerifyKuma()
 }
 
 func (c *K8sCluster) UpgradeKuma(mode string, opt ...KumaDeploymentOption) error {

--- a/test/framework/universal_cluster.go
+++ b/test/framework/universal_cluster.go
@@ -167,7 +167,7 @@ func (c *UniversalCluster) DeployKuma(mode core.CpMode, opt ...KumaDeploymentOpt
 		}
 	}
 
-	return nil
+	return c.VerifyKuma()
 }
 
 func (c *UniversalCluster) retrieveAdminToken() (string, error) {


### PR DESCRIPTION
### Summary

Embed VerifyKuma in KumaDeploy. I'd love to remove VerifyKuma but it's still used after CP restart in resilience test

### Issues resolved

No issues reported.

### Documentation

No docs.

### Testing

- [ ] Unit tests
- [X] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes

### Backwards compatibility

~- [ ] Update [`UPGRADE.md`](/UPGRADE.md) with any steps users will need to take when upgrading.~
~- [ ] Add `backport-to-stable` label if the code follows our [backporting policy](/CONTRIBUTING.md#backporting)~
