### PR TITLE
chore(*): rename experimental gateway in kuma-cp.default.config

### DIFF
--- a/pkg/api-server/config_ws_test.go
+++ b/pkg/api-server/config_ws_test.go
@@ -344,7 +344,7 @@ var _ = Describe("Config WS", func() {
             }
           },
           "experimental": {
-            "gateway": false
+            "meshGateway": false
           }
         }
 		`, port, cfg.HTTPS.Port)

--- a/pkg/config/app/kuma-cp/config.go
+++ b/pkg/config/app/kuma-cp/config.go
@@ -314,5 +314,5 @@ func DefaultGeneralConfig() *GeneralConfig {
 
 type ExperimentalConfig struct {
 	// If true, experimental built-in gateway is enabled.
-	MeshGateway bool `yaml:"gateway" envconfig:"KUMA_EXPERIMENTAL_MESHGATEWAY"`
+	MeshGateway bool `yaml:"meshGateway" envconfig:"KUMA_EXPERIMENTAL_MESHGATEWAY"`
 }

--- a/pkg/config/app/kuma-cp/kuma-cp.defaults.yaml
+++ b/pkg/config/app/kuma-cp/kuma-cp.defaults.yaml
@@ -432,4 +432,4 @@ access:
 # Configuration of experimental features of Kuma
 experimental:
   # If true, experimental built-in gateway is enabled
-  gateway: false # ENV: KUMA_EXPERIMENTAL_MESHGATEWAY
+  meshGateway: false # ENV: KUMA_EXPERIMENTAL_MESHGATEWAY

--- a/pkg/config/loader_test.go
+++ b/pkg/config/loader_test.go
@@ -465,7 +465,7 @@ access:
       users: ["zt-admin1", "zt-admin2"]
       groups: ["zt-group1", "zt-group2"]
 experimental:
-  gateway: true
+  meshGateway: true
 `,
 		}),
 		Entry("from env variables", testCase{


### PR DESCRIPTION
### Summary

SUMMARY_GOES_HERE

### Full changelog

* [Implement ...]
* [Fix ...]

### Issues resolved

Fix #XXX

### Documentation

- [ ] Link to the website [documentation PR](https://github.com/kumahq/kuma-website/pull/XXX)

### Testing

- [X] Unit tests
- [ ] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes

### Backwards compatibility

- [ ] Update [`UPGRADE.md`](/UPGRADE.md) with any steps users will need to take when upgrading.
- [X] Add `backport-to-stable` label if the code follows our [backporting policy](/CONTRIBUTING.md#backporting)
