### PR TITLE
fix(*): drop additional meta in KDS

### DIFF
--- a/pkg/kds/util/meta.go
+++ b/pkg/kds/util/meta.go
@@ -5,47 +5,33 @@ import (
 
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	"github.com/kumahq/kuma/pkg/core/resources/model"
-	"github.com/kumahq/kuma/pkg/util/proto"
 )
 
+// KDS ResourceMeta only contains name and mesh.
+// The rest is managed by the receiver of resources anyways. See ResourceSyncer#Sync
 type resourceMeta struct {
-	name             string
-	version          string
-	mesh             string
-	creationTime     *time.Time
-	modificationTime *time.Time
+	name string
+	mesh string
 }
 
 func NewResourceMeta(name, mesh, version string, creationTime, modificationTime time.Time) model.ResourceMeta {
 	return &resourceMeta{
-		name:             name,
-		mesh:             mesh,
-		version:          version,
-		creationTime:     &creationTime,
-		modificationTime: &modificationTime,
+		name: name,
+		mesh: mesh,
 	}
 }
 
 func CloneResourceMetaWithNewName(meta model.ResourceMeta, name string) model.ResourceMeta {
-	creationTime := meta.GetCreationTime()
-	modificationTime := meta.GetModificationTime()
-
 	return &resourceMeta{
-		name:             name,
-		version:          meta.GetVersion(),
-		mesh:             meta.GetMesh(),
-		creationTime:     &creationTime,
-		modificationTime: &modificationTime,
+		name: name,
+		mesh: meta.GetMesh(),
 	}
 }
 
 func kumaResourceMetaToResourceMeta(meta *mesh_proto.KumaResource_Meta) model.ResourceMeta {
 	return &resourceMeta{
-		name:             meta.Name,
-		mesh:             meta.Mesh,
-		version:          meta.Version,
-		creationTime:     proto.MustTimestampFromProto(meta.CreationTime),
-		modificationTime: proto.MustTimestampFromProto(meta.ModificationTime),
+		name: meta.Name,
+		mesh: meta.Mesh,
 	}
 }
 
@@ -58,7 +44,7 @@ func (r *resourceMeta) GetNameExtensions() model.ResourceNameExtensions {
 }
 
 func (r *resourceMeta) GetVersion() string {
-	return r.version
+	return ""
 }
 
 func (r *resourceMeta) GetMesh() string {
@@ -66,9 +52,9 @@ func (r *resourceMeta) GetMesh() string {
 }
 
 func (r *resourceMeta) GetCreationTime() time.Time {
-	return *r.creationTime
+	return time.Unix(0, 0)
 }
 
 func (r *resourceMeta) GetModificationTime() time.Time {
-	return *r.modificationTime
+	return time.Unix(0, 0)
 }

--- a/pkg/kds/util/resource.go
+++ b/pkg/kds/util/resource.go
@@ -35,11 +35,10 @@ func ToEnvoyResources(rlist model.ResourceList) ([]envoy_types.Resource, error) 
 		}
 		rv = append(rv, &mesh_proto.KumaResource{
 			Meta: &mesh_proto.KumaResource_Meta{
-				Name:             r.GetMeta().GetName(),
-				Mesh:             r.GetMeta().GetMesh(),
-				CreationTime:     util_proto.MustTimestampProto(r.GetMeta().GetCreationTime()),
-				ModificationTime: util_proto.MustTimestampProto(r.GetMeta().GetModificationTime()),
-				Version:          r.GetMeta().GetVersion(),
+				Name: r.GetMeta().GetName(),
+				Mesh: r.GetMeta().GetMesh(),
+				// KDS ResourceMeta only contains name and mesh.
+				// The rest is managed by the receiver of resources anyways. See ResourceSyncer#Sync
 			},
 			Spec: pbany,
 		})

--- a/pkg/kds/util/resource.go
+++ b/pkg/kds/util/resource.go
@@ -3,6 +3,7 @@ package util
 import (
 	"fmt"
 	"strings"
+	"time"
 
 	envoy_sd "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
 	envoy_types "github.com/envoyproxy/go-control-plane/pkg/cache/types"
@@ -39,6 +40,12 @@ func ToEnvoyResources(rlist model.ResourceList) ([]envoy_types.Resource, error) 
 				Mesh: r.GetMeta().GetMesh(),
 				// KDS ResourceMeta only contains name and mesh.
 				// The rest is managed by the receiver of resources anyways. See ResourceSyncer#Sync
+				//
+				// backwards compatibility
+				// Right now we send creation and modification time because the old versions of Kuma CP expects them to be present.
+				CreationTime:     util_proto.MustTimestampProto(time.Unix(0, 0)),
+				ModificationTime: util_proto.MustTimestampProto(time.Unix(0, 0)),
+				Version:          "",
 			},
 			Spec: pbany,
 		})


### PR DESCRIPTION
### Summary

The receiver of KDS resources replaces version, creation and modification time.
Right now, if any of them has changed, we were sending the resource over KDS. But the resource itself might not have changed (for example, resource mapper cleared generation in insights).

There is no point in sending those parts of resource meta over KDS

### Issues resolved

Fix #3840

### Documentation

No docs

### Testing

- [ ] Unit tests
- [ ] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes

### Backwards compatibility

~- [ ] Update [`UPGRADE.md`](/UPGRADE.md) with any steps users will need to take when upgrading.~
- [X] Add `backport-to-stable` label if the code follows our [backporting policy](/CONTRIBUTING.md#backporting)
