### PR TITLE
chore(kuma-cp): better logging on signing key creation

### DIFF
--- a/pkg/defaults/components.go
+++ b/pkg/defaults/components.go
@@ -27,12 +27,18 @@ func Setup(runtime runtime.Runtime) error {
 	defaultsComponent := NewDefaultsComponent(runtime.Config().Defaults, runtime.Config().Mode, runtime.Config().Environment, runtime.ResourceManager(), runtime.ResourceStore())
 
 	zoneIngressSigningKeyManager := tokens.NewSigningKeyManager(runtime.ResourceManager(), zoneingress.ZoneIngressSigningKeyPrefix)
-	if err := runtime.Add(tokens.NewDefaultSigningKeyComponent(zoneIngressSigningKeyManager, log)); err != nil {
+	if err := runtime.Add(tokens.NewDefaultSigningKeyComponent(
+		zoneIngressSigningKeyManager,
+		log.WithValues("secretPrefix", zoneingress.ZoneIngressSigningKeyPrefix,
+	))); err != nil {
 		return err
 	}
 
 	zoneSigningKeyManager := tokens.NewSigningKeyManager(runtime.ResourceManager(), zone.SigningKeyPrefix)
-	if err := runtime.Add(tokens.NewDefaultSigningKeyComponent(zoneSigningKeyManager, log)); err != nil {
+	if err := runtime.Add(tokens.NewDefaultSigningKeyComponent(
+		zoneSigningKeyManager,
+		log.WithValues("secretPrefix", zoneingress.ZoneIngressSigningKeyPrefix),
+	)); err != nil {
 		return err
 	}
 

--- a/pkg/defaults/components.go
+++ b/pkg/defaults/components.go
@@ -29,8 +29,7 @@ func Setup(runtime runtime.Runtime) error {
 	zoneIngressSigningKeyManager := tokens.NewSigningKeyManager(runtime.ResourceManager(), zoneingress.ZoneIngressSigningKeyPrefix)
 	if err := runtime.Add(tokens.NewDefaultSigningKeyComponent(
 		zoneIngressSigningKeyManager,
-		log.WithValues("secretPrefix", zoneingress.ZoneIngressSigningKeyPrefix,
-	))); err != nil {
+		log.WithValues("secretPrefix", zoneingress.ZoneIngressSigningKeyPrefix))); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
### Summary

The logs say

```
2022-02-21T13:29:34.894Z	INFO	defaults	default signing key created
```

This PR add context to those messages 

### Issues resolved

No issues reported

### Documentation

No docs

### Testing

- [ ] Unit tests
- [ ] E2E tests
- [X] Manual testing on Universal
- [ ] Manual testing on Kubernetes

### Backwards compatibility

~- [ ] Update [`UPGRADE.md`](/UPGRADE.md) with any steps users will need to take when upgrading.~
~- [ ] Add `backport-to-stable` label if the code follows our [backporting policy](/CONTRIBUTING.md#backporting)~
