### PR TITLE
fix(kuma-cp): ignore non-provided KDS resources

### DIFF
--- a/pkg/kds/store/sync.go
+++ b/pkg/kds/store/sync.go
@@ -69,7 +69,6 @@ func (s *syncResourceStore) Sync(upstream model.ResourceList, fs ...SyncOptionFu
 	opts := NewSyncOptions(fs...)
 	ctx := context.Background()
 	log := s.log.WithValues("type", upstream.GetItemType())
-	log.V(1).Info("sync", "upstream", upstream)
 	downstream, err := registry.Global().NewList(upstream.GetItemType())
 	if err != nil {
 		return err
@@ -77,7 +76,7 @@ func (s *syncResourceStore) Sync(upstream model.ResourceList, fs ...SyncOptionFu
 	if err := s.resourceStore.List(ctx, downstream); err != nil {
 		return err
 	}
-	log.V(1).Info("before filtering", "downstream", downstream)
+	log.V(1).Info("before filtering", "downstream", downstream, "upstream", upstream)
 
 	if opts.Predicate != nil {
 		if filtered, err := filter(downstream, opts.Predicate); err != nil {
@@ -85,8 +84,13 @@ func (s *syncResourceStore) Sync(upstream model.ResourceList, fs ...SyncOptionFu
 		} else {
 			downstream = filtered
 		}
+		if filtered, err := filter(upstream, opts.Predicate); err != nil {
+			return err
+		} else {
+			upstream = filtered
+		}
 	}
-	log.V(1).Info("after filtering", "downstream", downstream)
+	log.V(1).Info("after filtering", "downstream", downstream, "upstream", upstream)
 
 	indexedUpstream := newIndexed(upstream)
 	indexedDownstream := newIndexed(downstream)

--- a/pkg/kds/store/sync_test.go
+++ b/pkg/kds/store/sync_test.go
@@ -109,4 +109,21 @@ var _ = Describe("SyncResourceStore", func() {
 			Expect(item.Spec).To(MatchProto(upstream.Items[i].Spec))
 		}
 	})
+
+	It("should ignore resources from upstream that it does not support", func() {
+		// given
+		upstream := &mesh.MeshResourceList{}
+		Expect(upstream.AddItem(meshBuilder(1))).To(Succeed())
+
+		// when
+		err := syncer.Sync(upstream, sync_store.PrefilterBy(func(r model.Resource) bool {
+			return r.GetMeta().GetName() != "mesh-1"
+		}))
+
+		// then
+		Expect(err).ToNot(HaveOccurred())
+		actual := &mesh.MeshResourceList{}
+		Expect(resourceStore.List(context.Background(), actual)).To(Succeed())
+		Expect(actual.GetItems()).To(BeEmpty())
+	})
 })


### PR DESCRIPTION
### Summary

Before the fix, if you introduce a new Secret provided by Global CP, the old version of Zone CP would try to create it on every KDS reconnection because it was filtered out from the downstream list.
Zone CP should only accept resources that it knows are managed by Global CP (and the other way around).

### Issues resolved

Fix #3854

### Documentation

No docs

### Testing

- [X] Unit tests
- [ ] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes

### Backwards compatibility

~- [ ] Update [`UPGRADE.md`](/UPGRADE.md) with any steps users will need to take when upgrading.~
~- [ ] Add `backport-to-stable` label if the code follows our [backporting policy](/CONTRIBUTING.md#backporting)~
