### PR TITLE
test(*): increase timeouts on flaky test

### DIFF
--- a/test/e2e/matching/matching_universal.go
+++ b/test/e2e/matching/matching_universal.go
@@ -87,7 +87,7 @@ conf:
 				return false
 			}
 			return strings.Contains(stdout, "HTTP/1.1 401 Unauthorized")
-		}, "10s", "100ms").Should(BeTrue())
+		}, "60s", "1s").Should(BeTrue())
 
 		Eventually(func() bool {
 			stdout, _, err := universal.Exec("", "", "demo-client-2", "curl", "-v", "test-server.mesh")
@@ -95,6 +95,6 @@ conf:
 				return false
 			}
 			return strings.Contains(stdout, "HTTP/1.1 402 Payment Required")
-		}, "10s", "100ms").Should(BeTrue())
+		}, "60s", "1s").Should(BeTrue())
 	})
 }


### PR DESCRIPTION
### Summary

After running this test in a loop with 10s timeout I managed to reproduce a problem after ~10 mins.
Because we don't wait for data plane proxies to be ready, 10s may not be enough. When the test failed for me, I saw that bootstrap configuration generation was ~2s after we started sending requests which indicate that 10s may not be enough with a low number of cores. Especially that we are running this with 100ms interval which also "steals" some CPU time to run the mesh.

After increasing the timeout to 60s, I run the test in a loop for 40min and it did not fail.

### Issues resolved

No reported issue.

### Documentation

No docs.

### Testing

- [ ] Unit tests
- [X] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes

### Backwards compatibility

~- [ ] Update [`UPGRADE.md`](/UPGRADE.md) with any steps users will need to take when upgrading.~
~- [ ] Add `backport-to-stable` label if the code follows our [backporting policy](/CONTRIBUTING.md#backporting)~
