### PR TITLE
ci(helm): add helm release action 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -883,29 +883,6 @@ jobs:
         command: |
           ./tools/releases/docker.sh --push
 
-  helm-release:
-    executor: golang
-    steps:
-    - checkout
-    - run:
-        name: "Install Helm Chart Releaser"
-        command: |
-          VER="1.1.1"
-          curl -L -o /tmp/cr-$VER.tgz https://github.com/helm/chart-releaser/releases/download/v$VER/chart-releaser_${VER}_linux_amd64.tar.gz
-          mkdir -p /tmp/cr
-          tar -xz -C /tmp/cr -f /tmp/cr-$VER.tgz
-          mv /tmp/cr/cr /usr/bin
-    - run:
-        name: "Package Helm Charts"
-        command: |
-          ./tools/releases/helm.sh --package
-    - run:
-        name: "Release Helm Charts"
-        command: |
-          ./tools/releases/helm.sh --release
-
-
-#
 # Below, the tag filter needs to be in all jobs
 # transitively required by the push job; otherwise,
 # the build isn't triggered.
@@ -1027,12 +1004,3 @@ workflows:
             - test/e2e-ipv4
             - test/e2e-ipv6
             - test/e2e-ipv4-oldk8s
-      - helm-release:
-          # Ideally we should be able to do CD on helm as well so this would be work_branch_workflow_filter
-          filters:
-            branches:
-              ignore: /.*/
-            tags:
-              only: /^v?(\d+)\.(\d+)\.(\d+)$/
-          requires:
-          - release

--- a/.github/workflows/helm-release.yaml
+++ b/.github/workflows/helm-release.yaml
@@ -1,0 +1,93 @@
+name: "Helm Charts"
+
+# This workflow provides two things:
+# On explicit dispatch, it packages, uploads and releases the chart to the
+# charts repo.
+#   It uses the appVersion and version as present in Chart.yaml.
+# On push to master, it packages and uploads a helm chart for the pushed commit.
+#   It updates both appVersion and version to be specific to this commit.
+#   See tools/release/helm.sh#dev_version
+# This workflow can be tested by any owner with a fork of kumahq/kuma and kumahq/charts
+on:
+  push:
+    branches:
+      - master
+      - release-*
+  workflow_dispatch:
+    inputs:
+      release:
+        description: Release charts
+        required: false
+        default: false
+        type: boolean
+
+env:
+  CR_VERSION: 1.3.0
+
+  GH_USER: "github-actions[bot]"
+  GH_EMAIL: "<41898282+github-actions[bot]@users.noreply.github.com>"
+  GH_OWNER: ${{ github.repository_owner }}
+
+jobs:
+  package:
+    name: Package
+    runs-on: ubuntu-latest
+    outputs:
+      filename: ${{ steps.package.outputs.filename }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Install chart-releaser
+        run:
+          curl -L "https://github.com/helm/chart-releaser/releases/download/v${CR_VERSION}/chart-releaser_${CR_VERSION}_linux_amd64.tar.gz"
+          | sudo tar xvz --directory /usr/bin cr
+      - name: Update chart versions on push
+        if: github.event_name == 'push'
+        run: |
+          git config user.name "${GH_USER}"
+          git config user.email "${GH_EMAIL}"
+
+          ./tools/releases/helm.sh --dev-version
+
+          git add -u deployments/charts
+          git commit -m "ci(helm): update versions for dev version"
+      - name: Package chart
+        id: package
+        run: |
+          ./tools/releases/helm.sh --package
+
+          PKG_FILENAME=$(find .cr-release-packages -type f -printf "%f\n")
+          echo "::set-output name=filename::${PKG_FILENAME}"
+      - name: Upload packaged chart
+        uses: actions/upload-artifact@v2
+        with:
+          name: ${{ steps.package.outputs.filename }}
+          path: .cr-release-packages/${{ steps.package.outputs.filename }}
+
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    needs: package
+    environment: charts
+    # https://github.com/actions/runner/issues/1483
+    if: github.event.inputs.release == 'true'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Install chart-releaser
+        run:
+          curl -L "https://github.com/helm/chart-releaser/releases/download/v${CR_VERSION}/chart-releaser_${CR_VERSION}_linux_amd64.tar.gz"
+          | sudo tar xvz --directory /usr/bin cr
+      - name: Download packaged chart
+        uses: actions/download-artifact@v2
+        with:
+          name: ${{ needs.package.outputs.filename }}
+          path: .cr-release-packages
+      - name: Release chart
+        env:
+          GH_TOKEN: ${{ secrets.CHARTS_GITHUB_TOKEN }}
+        run: ./tools/releases/helm.sh --release

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -35,6 +35,7 @@ To release a new version of Kuma follow these steps:
 - [ ] Push the Git tag. This will trigger the release job on CI.
 - [ ] Make sure the new binaries are available in [Bintray](https://bintray.com/kong/kuma).
 - [ ] Download the new Kuma version and double-check that it works with the demo app. Check that is works both in `universal` and `kubernetes` modes.
+- [ ] Run the [Helm Release workflow](https://github.com/kumahq/kuma/actions/workflows/helm-release.yaml) on the new tag with the "Release charts" check box checked
 - [ ] Merge PR to website repository.
 - [ ] Create a new [Github release](https://github.com/kumahq/kuma/releases) and create a link to both the changelog and to the assets download.
 - [ ] Make sure the `kumactl` formula is updated at [Homebrew](https://github.com/Homebrew/homebrew-core/blob/master/Formula/kumactl.rb)

--- a/tools/releases/helm.sh
+++ b/tools/releases/helm.sh
@@ -140,6 +140,10 @@ function main {
       package
       ;;
     dev-version)
+      if ! command -v yq >/dev/null || ! [[ $(command yq --version) =~ "mikefarah" ]]; then
+        msg_err "mikefarah/yq not installed"
+      fi
+
       dev_version
       ;;
     release)

--- a/tools/releases/helm.sh
+++ b/tools/releases/helm.sh
@@ -2,7 +2,8 @@
 
 set -e
 
-source "$(dirname -- "${BASH_SOURCE[0]}")/../common.sh"
+SCRIPT_DIR="$(dirname -- "${BASH_SOURCE[0]}")"
+source "${SCRIPT_DIR}/../common.sh"
 
 [ -z "$GH_OWNER" ] && GH_OWNER="kumahq"
 [ -z "$GH_REPO" ] && GH_REPO="charts"
@@ -11,7 +12,39 @@ CHARTS_DIR="./deployments/charts"
 CHARTS_PACKAGE_PATH=".cr-release-packages"
 CHARTS_INDEX_FILE="index.yaml"
 GH_PAGES_BRANCH="gh-pages"
-[ -z "$GH_REPO_URL" ] && GH_REPO_URL="git@github.com:${GH_OWNER}/${GH_REPO}.git"
+
+# dev_version updates Chart.yaml with:
+#  appVersion equal to the kuma version
+#  version:
+#    with the git commit suffix, if the kuma version has a git commit suffix
+#    otherwise it leaves version alone, assuming it's been chosen intentionally
+function dev_version {
+  for dir in "${CHARTS_DIR}"/*; do
+    if [ ! -d "${dir}" ]; then
+      continue
+    fi
+
+    # Fail if there are uncommitted changes
+    git diff --exit-code HEAD -- "${dir}"
+
+    kuma_version=$("${SCRIPT_DIR}/version.sh")
+    yq -i ".appVersion = \"${kuma_version}\"" "${dir}/Chart.yaml"
+
+    IFS=- read -r _version_core version_extra <<< "${kuma_version}"
+
+    chart_version=$(yq '.version' "${dir}/Chart.yaml")
+
+    # helm is semver-friendly, so we tweak the version.sh output a bit
+    short_hash=$(git rev-parse --short HEAD)
+
+    chart_version_extra=""
+    if [[ "${short_hash}" == "${version_extra}" ]]; then
+        chart_version_extra="+${version_extra}"
+    fi
+
+    yq -i ".version = \"${chart_version}${chart_version_extra}\"" "${dir}/Chart.yaml"
+  done
+}
 
 function package {
   # First package all the charts
@@ -39,6 +72,8 @@ function package {
 }
 
 function release {
+  [ -z "$GH_REPO_URL" ] && GH_REPO_URL="https://${GH_TOKEN}@github.com/${GH_OWNER}/${GH_REPO}.git"
+
   # First upload the packaged charts to the release
   cr upload \
     --owner "${GH_OWNER}" \
@@ -46,9 +81,8 @@ function release {
     --token "${GH_TOKEN}" \
     --package-path "${CHARTS_PACKAGE_PATH}"
 
-
   # Then build and upload the index file to github pages
-  git clone --single-branch --branch "${GH_PAGES_BRANCH}" $GH_REPO_URL
+  git clone --single-branch --branch "${GH_PAGES_BRANCH}" "$GH_REPO_URL"
 
   cr index \
     --owner "${GH_OWNER}" \
@@ -58,12 +92,14 @@ function release {
     --index-path "${GH_REPO}/${CHARTS_INDEX_FILE}"
 
   pushd ${GH_REPO}
-  # tell git who we are before adding the index file
-  git config user.email "helm@kuma.io"
-  git config user.name "Helm Releaser"
+
+  git config user.name "${GH_USER}"
+  git config user.email "${GH_EMAIL}"
+
   git add "${CHARTS_INDEX_FILE}"
-  git commit -m "ci(helm) publish charts"
+  git commit -m "ci(helm): publish charts"
   git push
+
   popd
   rm -rf ${GH_REPO}
 }
@@ -88,6 +124,9 @@ function main {
       --release)
         op="release"
         ;;
+      --dev-version)
+        op="dev-version"
+        ;;
       *)
         usage
         break
@@ -100,8 +139,13 @@ function main {
     package)
       package
       ;;
+    dev-version)
+      dev_version
+      ;;
     release)
-      [ -z "${GH_TOKEN}" ] && msg_err "GH_TOKEN required"
+      if [ -z "${GH_TOKEN}" ] || [ -z "${GH_USER}" ] || [ -z "${GH_EMAIL}" ]; then
+        msg_err "GH_TOKEN, GH_USER and GH_EMAIL required"
+      fi
 
       release
       ;;

--- a/tools/releases/version.sh
+++ b/tools/releases/version.sh
@@ -10,6 +10,8 @@ lastGitTag=$(git describe --abbrev=0 --tags)
 shortHash=$(git rev-parse --short HEAD)
 currentBranch=$(git rev-parse --abbrev-ref HEAD)
 
+# Note: this format must be changed carefully, other scripts depend on it
+
 if git describe --exact-match --tags > /dev/null 2>&1; then # if we are on tag
   echo "$lastGitTag"
 else


### PR DESCRIPTION
### Summary

- Add a GH workflow to manage Helm charts separately from `kuma` releases
- Package the helm chart for every commit on `master` and `release-*`
  - Tweak `appVersion` and `version` depending on commit
    - [ ] verify docker images work with `master` charts after merging
  - Each chart is available as a `.tar.gz` artifact that can be installed with `helm install`
  - We could optionally update the index of a chart repo with these commits as well
- A full chart release can be manually triggered from any commit
  - Uses [Github environments](https://docs.github.com/en/actions/deployment/about-deployments/deploying-with-github-actions#using-environments) for history and to restrict secret use (optional, just trying it out)
  - Option to add a required approval (probably most useful if we do something like auto release charts)
- The entire workflow can be end-to-end tested by simply forking `kumahq/kuma` and `kumahq/charts`
- Remove Helm release management from circleci

The main difference from the current release process is that a Helm release must now be triggered separately.

Part of #1105 