### PR TITLE
fix(kuma-cp): set inbound route timeout to zero instead of nil

### DIFF
--- a/pkg/xds/envoy/listeners/v3/http_inbound_routes_configurer_test.go
+++ b/pkg/xds/envoy/listeners/v3/http_inbound_routes_configurer_test.go
@@ -112,6 +112,7 @@ var _ = Describe("HttpInboundRouteConfigurer", func() {
                           prefix: /
                         route:
                           cluster: localhost:8080
+                          timeout: 0s
                   statPrefix: localhost_8080
 `,
 		}),
@@ -172,6 +173,7 @@ var _ = Describe("HttpInboundRouteConfigurer", func() {
                           prefix: /
                         route:
                           cluster: localhost:8080
+                          timeout: 0s
                         typedPerFilterConfig:
                           envoy.filters.http.local_ratelimit:
                             '@type': type.googleapis.com/envoy.extensions.filters.http.local_ratelimit.v3.LocalRateLimit
@@ -267,6 +269,7 @@ var _ = Describe("HttpInboundRouteConfigurer", func() {
                           prefix: /
                         route:
                           cluster: localhost:8080
+                          timeout: 0s
                         typedPerFilterConfig:
                           envoy.filters.http.local_ratelimit:
                             '@type': type.googleapis.com/envoy.extensions.filters.http.local_ratelimit.v3.LocalRateLimit

--- a/pkg/xds/envoy/listeners/v3/http_outbound_route_configurer_test.go
+++ b/pkg/xds/envoy/listeners/v3/http_outbound_route_configurer_test.go
@@ -98,6 +98,7 @@ var _ = Describe("HttpOutboundRouteConfigurer", func() {
                       - match:
                           prefix: /
                         route:
+                          timeout: 0s
                           weightedClusters:
                             clusters:
                             - name: backend-0
@@ -256,6 +257,7 @@ var _ = Describe("HttpOutboundRouteConfigurer", func() {
                           cluster: backend-0
                           hostRewriteLiteral: test
                           prefixRewrite: /another
+                          timeout: 0s
                   statPrefix: "127_0_0_1_18080"
             name: outbound:127.0.0.1:18080
             trafficDirection: OUTBOUND`,

--- a/pkg/xds/envoy/listeners/v3/retry_configurer_test.go
+++ b/pkg/xds/envoy/listeners/v3/retry_configurer_test.go
@@ -119,6 +119,7 @@ var _ = Describe("RetryConfigurer", func() {
                           prefix: /
                         route:
                           cluster: backend
+                          timeout: 0s
                   statPrefix: "127_0_0_1_17777"
             name: outbound:127.0.0.1:17777
             trafficDirection: OUTBOUND`,
@@ -197,6 +198,7 @@ var _ = Describe("RetryConfigurer", func() {
                           prefix: /
                         route:
                           cluster: backend
+                          timeout: 0s
                   statPrefix: "127_0_0_1_18080"
             name: outbound:127.0.0.1:18080
             trafficDirection: OUTBOUND`,
@@ -262,6 +264,7 @@ var _ = Describe("RetryConfigurer", func() {
                           prefix: /
                         route:
                           cluster: backend
+                          timeout: 0s
                   statPrefix: "127_0_0_1_17777"
             name: outbound:127.0.0.1:17777
             trafficDirection: OUTBOUND`,
@@ -340,6 +343,7 @@ var _ = Describe("RetryConfigurer", func() {
                           prefix: /
                         route:
                           cluster: backend
+                          timeout: 0s
                   statPrefix: "127_0_0_1_18080"
             name: outbound:127.0.0.1:18080
             trafficDirection: OUTBOUND`,

--- a/pkg/xds/envoy/routes/v3/routes_configurer.go
+++ b/pkg/xds/envoy/routes/v3/routes_configurer.go
@@ -7,10 +7,10 @@ import (
 	envoy_route "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
 	envoy_type_matcher "github.com/envoyproxy/go-control-plane/envoy/type/matcher/v3"
 	"github.com/golang/protobuf/ptypes/any"
-
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	util_proto "github.com/kumahq/kuma/pkg/util/proto"
 	envoy_common "github.com/kumahq/kuma/pkg/xds/envoy"
+	"google.golang.org/protobuf/types/known/durationpb"
 )
 
 type RoutesConfigurer struct {
@@ -160,6 +160,8 @@ func (c RoutesConfigurer) routeAction(clusters []envoy_common.Cluster, modify *m
 	if len(clusters) != 0 {
 		if timeout := clusters[0].Timeout(); timeout != nil {
 			routeAction.Timeout = timeout.Spec.GetConf().GetHttp().GetRequestTimeout()
+		} else {
+			routeAction.Timeout = durationpb.New(0)
 		}
 	}
 	if len(clusters) == 1 {

--- a/pkg/xds/envoy/routes/v3/routes_configurer.go
+++ b/pkg/xds/envoy/routes/v3/routes_configurer.go
@@ -7,10 +7,11 @@ import (
 	envoy_route "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
 	envoy_type_matcher "github.com/envoyproxy/go-control-plane/envoy/type/matcher/v3"
 	"github.com/golang/protobuf/ptypes/any"
+	"google.golang.org/protobuf/types/known/durationpb"
+
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	util_proto "github.com/kumahq/kuma/pkg/util/proto"
 	envoy_common "github.com/kumahq/kuma/pkg/xds/envoy"
-	"google.golang.org/protobuf/types/known/durationpb"
 )
 
 type RoutesConfigurer struct {

--- a/pkg/xds/envoy/routes/v3/routes_configurer_test.go
+++ b/pkg/xds/envoy/routes/v3/routes_configurer_test.go
@@ -2,11 +2,12 @@ package v3_test
 
 import (
 	envoy_config_route_v3 "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
 	util_proto "github.com/kumahq/kuma/pkg/util/proto"
 	envoy_common "github.com/kumahq/kuma/pkg/xds/envoy"
 	envoy_routes "github.com/kumahq/kuma/pkg/xds/envoy/routes/v3"
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
 )
 
 var _ = Describe("RoutesConfigurer", func() {

--- a/pkg/xds/envoy/routes/v3/routes_configurer_test.go
+++ b/pkg/xds/envoy/routes/v3/routes_configurer_test.go
@@ -1,0 +1,47 @@
+package v3_test
+
+import (
+	envoy_config_route_v3 "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
+	util_proto "github.com/kumahq/kuma/pkg/util/proto"
+	envoy_common "github.com/kumahq/kuma/pkg/xds/envoy"
+	envoy_routes "github.com/kumahq/kuma/pkg/xds/envoy/routes/v3"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("RoutesConfigurer", func() {
+
+	type testCase struct {
+		routes   envoy_common.Routes
+		expected string
+	}
+
+	DescribeTable("should generate proper Envoy config",
+		func(given testCase) {
+			// when
+			virtualHost := &envoy_config_route_v3.VirtualHost{}
+			err := envoy_routes.RoutesConfigurer{Routes: given.routes}.
+				Configure(virtualHost)
+			Expect(err).ToNot(HaveOccurred())
+
+			// when
+			actual, err := util_proto.ToYAML(virtualHost)
+			// then
+			Expect(err).ToNot(HaveOccurred())
+			// and
+			Expect(actual).To(MatchYAML(given.expected))
+		},
+		Entry("routes without timeouts", testCase{
+			routes: []envoy_common.Route{
+				envoy_common.NewRouteFromCluster(envoy_common.NewCluster(envoy_common.WithName("backend"))),
+			},
+			expected: `
+routes:
+  - match:
+      prefix: "/"
+    route:
+      timeout: "0s"
+      cluster: backend`,
+		}),
+	)
+})

--- a/pkg/xds/generator/egress/testdata/01.externalservice-only.golden.yaml
+++ b/pkg/xds/generator/egress/testdata/01.externalservice-only.golden.yaml
@@ -71,6 +71,7 @@ resources:
                   prefix: /
                 route:
                   cluster: mesh-1:externalservice-1
+                  timeout: 0s
           statPrefix: externalservice-1
       transportSocket:
         name: envoy.transport_sockets.tls

--- a/pkg/xds/generator/egress/testdata/03.mixed-services.golden.yaml
+++ b/pkg/xds/generator/egress/testdata/03.mixed-services.golden.yaml
@@ -223,6 +223,7 @@ resources:
                   prefix: /
                 route:
                   cluster: mesh-1:externalservice-1
+                  timeout: 0s
           statPrefix: externalservice-1
       transportSocket:
         name: envoy.transport_sockets.tls
@@ -277,6 +278,7 @@ resources:
                   prefix: /
                 route:
                   cluster: mesh-1:externalservice-2
+                  timeout: 0s
           statPrefix: externalservice-2
       transportSocket:
         name: envoy.transport_sockets.tls

--- a/pkg/xds/generator/egress/testdata/04.mixed-services-custom-trafficroute.golden.yaml
+++ b/pkg/xds/generator/egress/testdata/04.mixed-services-custom-trafficroute.golden.yaml
@@ -183,6 +183,7 @@ resources:
                   prefix: /
                 route:
                   cluster: mesh-1:externalservice-2
+                  timeout: 0s
           statPrefix: externalservice-2
       transportSocket:
         name: envoy.transport_sockets.tls

--- a/pkg/xds/generator/egress/testdata/05.mixed-services-with-custom-trafficpermissions.golden.yaml
+++ b/pkg/xds/generator/egress/testdata/05.mixed-services-with-custom-trafficpermissions.golden.yaml
@@ -225,6 +225,7 @@ resources:
                   prefix: /
                 route:
                   cluster: mesh-1:externalservice-1
+                  timeout: 0s
           statPrefix: externalservice-1
       transportSocket:
         name: envoy.transport_sockets.tls
@@ -273,6 +274,7 @@ resources:
                   prefix: /
                 route:
                   cluster: mesh-1:externalservice-2
+                  timeout: 0s
           statPrefix: externalservice-2
       transportSocket:
         name: envoy.transport_sockets.tls

--- a/pkg/xds/generator/testdata/inbound-proxy/3-envoy-config.golden.yaml
+++ b/pkg/xds/generator/testdata/inbound-proxy/3-envoy-config.golden.yaml
@@ -140,6 +140,7 @@ resources:
                   prefix: /
                 route:
                   cluster: localhost:8080
+                  timeout: 0s
                 typedPerFilterConfig:
                   envoy.filters.http.local_ratelimit:
                     '@type': type.googleapis.com/envoy.extensions.filters.http.local_ratelimit.v3.LocalRateLimit
@@ -165,6 +166,7 @@ resources:
                   prefix: /
                 route:
                   cluster: localhost:8080
+                  timeout: 0s
                 typedPerFilterConfig:
                   envoy.filters.http.local_ratelimit:
                     '@type': type.googleapis.com/envoy.extensions.filters.http.local_ratelimit.v3.LocalRateLimit
@@ -192,6 +194,7 @@ resources:
                   prefix: /
                 route:
                   cluster: localhost:8080
+                  timeout: 0s
           setCurrentClientCertDetails:
             uri: true
           statPrefix: localhost_8080
@@ -292,6 +295,7 @@ resources:
                   prefix: /
                 route:
                   cluster: localhost:8080
+                  timeout: 0s
           setCurrentClientCertDetails:
             uri: true
           statPrefix: localhost_8080

--- a/pkg/xds/generator/testdata/inbound-proxy/4-envoy-config.golden.yaml
+++ b/pkg/xds/generator/testdata/inbound-proxy/4-envoy-config.golden.yaml
@@ -142,6 +142,7 @@ resources:
                   prefix: /
                 route:
                   cluster: localhost:8080
+                  timeout: 0s
                 typedPerFilterConfig:
                   envoy.filters.http.local_ratelimit:
                     '@type': type.googleapis.com/envoy.extensions.filters.http.local_ratelimit.v3.LocalRateLimit
@@ -167,6 +168,7 @@ resources:
                   prefix: /
                 route:
                   cluster: localhost:8080
+                  timeout: 0s
                 typedPerFilterConfig:
                   envoy.filters.http.local_ratelimit:
                     '@type': type.googleapis.com/envoy.extensions.filters.http.local_ratelimit.v3.LocalRateLimit
@@ -194,6 +196,7 @@ resources:
                   prefix: /
                 route:
                   cluster: localhost:8080
+                  timeout: 0s
           setCurrentClientCertDetails:
             uri: true
           statPrefix: localhost_8080
@@ -296,6 +299,7 @@ resources:
                   prefix: /
                 route:
                   cluster: localhost:8080
+                  timeout: 0s
           setCurrentClientCertDetails:
             uri: true
           statPrefix: localhost_8080

--- a/pkg/xds/generator/testdata/inbound-proxy/5-envoy-config.golden.yaml
+++ b/pkg/xds/generator/testdata/inbound-proxy/5-envoy-config.golden.yaml
@@ -176,6 +176,7 @@ resources:
                   prefix: /
                 route:
                   cluster: localhost:8080
+                  timeout: 0s
                 typedPerFilterConfig:
                   envoy.filters.http.local_ratelimit:
                     '@type': type.googleapis.com/envoy.extensions.filters.http.local_ratelimit.v3.LocalRateLimit
@@ -201,6 +202,7 @@ resources:
                   prefix: /
                 route:
                   cluster: localhost:8080
+                  timeout: 0s
                 typedPerFilterConfig:
                   envoy.filters.http.local_ratelimit:
                     '@type': type.googleapis.com/envoy.extensions.filters.http.local_ratelimit.v3.LocalRateLimit
@@ -228,6 +230,7 @@ resources:
                   prefix: /
                 route:
                   cluster: localhost:8080
+                  timeout: 0s
           setCurrentClientCertDetails:
             uri: true
           statPrefix: localhost_8080
@@ -293,6 +296,7 @@ resources:
                   prefix: /
                 route:
                   cluster: localhost:8080
+                  timeout: 0s
                 typedPerFilterConfig:
                   envoy.filters.http.local_ratelimit:
                     '@type': type.googleapis.com/envoy.extensions.filters.http.local_ratelimit.v3.LocalRateLimit
@@ -318,6 +322,7 @@ resources:
                   prefix: /
                 route:
                   cluster: localhost:8080
+                  timeout: 0s
                 typedPerFilterConfig:
                   envoy.filters.http.local_ratelimit:
                     '@type': type.googleapis.com/envoy.extensions.filters.http.local_ratelimit.v3.LocalRateLimit
@@ -345,6 +350,7 @@ resources:
                   prefix: /
                 route:
                   cluster: localhost:8080
+                  timeout: 0s
           setCurrentClientCertDetails:
             uri: true
           statPrefix: localhost_8080
@@ -412,6 +418,7 @@ resources:
                   prefix: /
                 route:
                   cluster: localhost:8080
+                  timeout: 0s
                 typedPerFilterConfig:
                   envoy.filters.http.local_ratelimit:
                     '@type': type.googleapis.com/envoy.extensions.filters.http.local_ratelimit.v3.LocalRateLimit
@@ -437,6 +444,7 @@ resources:
                   prefix: /
                 route:
                   cluster: localhost:8080
+                  timeout: 0s
                 typedPerFilterConfig:
                   envoy.filters.http.local_ratelimit:
                     '@type': type.googleapis.com/envoy.extensions.filters.http.local_ratelimit.v3.LocalRateLimit
@@ -464,6 +472,7 @@ resources:
                   prefix: /
                 route:
                   cluster: localhost:8080
+                  timeout: 0s
           setCurrentClientCertDetails:
             uri: true
           statPrefix: localhost_8080
@@ -604,6 +613,7 @@ resources:
                   prefix: /
                 route:
                   cluster: localhost:8080
+                  timeout: 0s
           setCurrentClientCertDetails:
             uri: true
           statPrefix: localhost_8080
@@ -635,6 +645,7 @@ resources:
                   prefix: /
                 route:
                   cluster: localhost:8080
+                  timeout: 0s
           setCurrentClientCertDetails:
             uri: true
           statPrefix: localhost_8080
@@ -668,6 +679,7 @@ resources:
                   prefix: /
                 route:
                   cluster: localhost:8080
+                  timeout: 0s
           setCurrentClientCertDetails:
             uri: true
           statPrefix: localhost_8080

--- a/pkg/xds/generator/testdata/inbound-proxy/6-envoy-config.golden.yaml
+++ b/pkg/xds/generator/testdata/inbound-proxy/6-envoy-config.golden.yaml
@@ -178,6 +178,7 @@ resources:
                   prefix: /
                 route:
                   cluster: localhost:8080
+                  timeout: 0s
                 typedPerFilterConfig:
                   envoy.filters.http.local_ratelimit:
                     '@type': type.googleapis.com/envoy.extensions.filters.http.local_ratelimit.v3.LocalRateLimit
@@ -203,6 +204,7 @@ resources:
                   prefix: /
                 route:
                   cluster: localhost:8080
+                  timeout: 0s
                 typedPerFilterConfig:
                   envoy.filters.http.local_ratelimit:
                     '@type': type.googleapis.com/envoy.extensions.filters.http.local_ratelimit.v3.LocalRateLimit
@@ -230,6 +232,7 @@ resources:
                   prefix: /
                 route:
                   cluster: localhost:8080
+                  timeout: 0s
           setCurrentClientCertDetails:
             uri: true
           statPrefix: localhost_8080
@@ -295,6 +298,7 @@ resources:
                   prefix: /
                 route:
                   cluster: localhost:8080
+                  timeout: 0s
                 typedPerFilterConfig:
                   envoy.filters.http.local_ratelimit:
                     '@type': type.googleapis.com/envoy.extensions.filters.http.local_ratelimit.v3.LocalRateLimit
@@ -320,6 +324,7 @@ resources:
                   prefix: /
                 route:
                   cluster: localhost:8080
+                  timeout: 0s
                 typedPerFilterConfig:
                   envoy.filters.http.local_ratelimit:
                     '@type': type.googleapis.com/envoy.extensions.filters.http.local_ratelimit.v3.LocalRateLimit
@@ -347,6 +352,7 @@ resources:
                   prefix: /
                 route:
                   cluster: localhost:8080
+                  timeout: 0s
           setCurrentClientCertDetails:
             uri: true
           statPrefix: localhost_8080
@@ -414,6 +420,7 @@ resources:
                   prefix: /
                 route:
                   cluster: localhost:8080
+                  timeout: 0s
                 typedPerFilterConfig:
                   envoy.filters.http.local_ratelimit:
                     '@type': type.googleapis.com/envoy.extensions.filters.http.local_ratelimit.v3.LocalRateLimit
@@ -439,6 +446,7 @@ resources:
                   prefix: /
                 route:
                   cluster: localhost:8080
+                  timeout: 0s
                 typedPerFilterConfig:
                   envoy.filters.http.local_ratelimit:
                     '@type': type.googleapis.com/envoy.extensions.filters.http.local_ratelimit.v3.LocalRateLimit
@@ -466,6 +474,7 @@ resources:
                   prefix: /
                 route:
                   cluster: localhost:8080
+                  timeout: 0s
           setCurrentClientCertDetails:
             uri: true
           statPrefix: localhost_8080
@@ -608,6 +617,7 @@ resources:
                   prefix: /
                 route:
                   cluster: localhost:8080
+                  timeout: 0s
           setCurrentClientCertDetails:
             uri: true
           statPrefix: localhost_8080
@@ -639,6 +649,7 @@ resources:
                   prefix: /
                 route:
                   cluster: localhost:8080
+                  timeout: 0s
           setCurrentClientCertDetails:
             uri: true
           statPrefix: localhost_8080
@@ -672,6 +683,7 @@ resources:
                   prefix: /
                 route:
                   cluster: localhost:8080
+                  timeout: 0s
           setCurrentClientCertDetails:
             uri: true
           statPrefix: localhost_8080

--- a/pkg/xds/generator/testdata/outbound-proxy/03.envoy.golden.yaml
+++ b/pkg/xds/generator/testdata/outbound-proxy/03.envoy.golden.yaml
@@ -341,6 +341,7 @@ resources:
                   prefix: /
                 route:
                   cluster: api-http
+                  timeout: 0s
           statPrefix: api-http
     name: outbound:127.0.0.1:40001
     trafficDirection: OUTBOUND
@@ -401,6 +402,7 @@ resources:
                   prefix: /
                 route:
                   cluster: api-http2
+                  timeout: 0s
           statPrefix: api-http2
     name: outbound:127.0.0.1:40003
     trafficDirection: OUTBOUND
@@ -439,6 +441,7 @@ resources:
                   prefix: /
                 route:
                   cluster: api-grpc
+                  timeout: 0s
           statPrefix: api-grpc
     name: outbound:127.0.0.1:40004
     trafficDirection: OUTBOUND

--- a/pkg/xds/generator/testdata/outbound-proxy/04.envoy.golden.yaml
+++ b/pkg/xds/generator/testdata/outbound-proxy/04.envoy.golden.yaml
@@ -379,6 +379,7 @@ resources:
                   prefix: /
                 route:
                   cluster: api-http
+                  timeout: 0s
           statPrefix: api-http
     name: outbound:127.0.0.1:40001
     trafficDirection: OUTBOUND

--- a/pkg/xds/generator/testdata/outbound-proxy/05.envoy.golden.yaml
+++ b/pkg/xds/generator/testdata/outbound-proxy/05.envoy.golden.yaml
@@ -60,6 +60,7 @@ resources:
                 route:
                   autoHostRewrite: true
                   cluster: es-_0_
+                  timeout: 0s
           statPrefix: es
     name: outbound:127.0.0.1:18081
     trafficDirection: OUTBOUND

--- a/pkg/xds/generator/testdata/outbound-proxy/06.envoy.golden.yaml
+++ b/pkg/xds/generator/testdata/outbound-proxy/06.envoy.golden.yaml
@@ -60,6 +60,7 @@ resources:
                 route:
                   autoHostRewrite: true
                   cluster: es2-_0_
+                  timeout: 0s
           statPrefix: es2
     name: outbound:127.0.0.1:18082
     trafficDirection: OUTBOUND

--- a/pkg/xds/generator/testdata/profile-source/3-envoy-config.golden.yaml
+++ b/pkg/xds/generator/testdata/profile-source/3-envoy-config.golden.yaml
@@ -190,6 +190,7 @@ resources:
                   prefix: /
                 route:
                   cluster: localhost:8080
+                  timeout: 0s
           setCurrentClientCertDetails:
             uri: true
           statPrefix: localhost_8080

--- a/pkg/xds/generator/testdata/profile-source/4-envoy-config.golden.yaml
+++ b/pkg/xds/generator/testdata/profile-source/4-envoy-config.golden.yaml
@@ -211,6 +211,7 @@ resources:
                   prefix: /
                 route:
                   cluster: localhost:8080
+                  timeout: 0s
           setCurrentClientCertDetails:
             uri: true
           statPrefix: localhost_8080


### PR DESCRIPTION
### Summary

If we don't have Timeout for Cluster then it should be set to zero rather than nil.

### Full changelog

* set timeout to 0

### Issues resolved

Fix https://github.com/kumahq/kuma/issues/3934

### Documentation

- [ ] Link to the website [documentation PR](https://github.com/kumahq/kuma-website/pull/XXX)

### Testing

- [X] Unit tests
- [ ] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes

### Backwards compatibility

~- [ ] Update [`UPGRADE.md`](/UPGRADE.md) with any steps users will need to take when upgrading.~
~- [ ] Add `backport-to-stable` label if the code follows our [backporting policy](/CONTRIBUTING.md#backporting)~
