### PR TITLE
fix(ingress/egress): use kubernetes http probes

### DIFF
--- a/app/kumactl/cmd/install/testdata/install-control-plane.with-egress.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.with-egress.golden.yaml
@@ -1676,22 +1676,18 @@ spec:
           ports:
             - containerPort: 10002
           livenessProbe:
-            exec:
-              command:
-                - wget
-                - -qO-
-                - http://127.0.0.1:9901
+            httpGet:
+              path: "/ready"
+              port: 9901
             failureThreshold: 12
             initialDelaySeconds: 60
             periodSeconds: 5
             successThreshold: 1
             timeoutSeconds: 3
           readinessProbe:
-            exec:
-              command:
-                - wget
-                - -qO-
-                - http://127.0.0.1:9901
+            httpGet:
+              path: "/ready"
+              port: 9901
             failureThreshold: 12
             initialDelaySeconds: 1
             periodSeconds: 5

--- a/app/kumactl/cmd/install/testdata/install-control-plane.with-ingress.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.with-ingress.golden.yaml
@@ -1676,22 +1676,18 @@ spec:
           ports:
             - containerPort: 10001
           livenessProbe:
-            exec:
-              command:
-                - wget
-                - -qO-
-                - http://127.0.0.1:9901
+            httpGet:
+              path: "/ready"
+              port: 9901
             failureThreshold: 12
             initialDelaySeconds: 60
             periodSeconds: 5
             successThreshold: 1
             timeoutSeconds: 3
           readinessProbe:
-            exec:
-              command:
-                - wget
-                - -qO-
-                - http://127.0.0.1:9901
+            httpGet:
+              path: "/ready"
+              port: 9901
             failureThreshold: 12
             initialDelaySeconds: 1
             periodSeconds: 5

--- a/deployments/charts/kuma/templates/egress-deployment.yaml
+++ b/deployments/charts/kuma/templates/egress-deployment.yaml
@@ -83,22 +83,18 @@ spec:
           ports:
             - containerPort: 10002
           livenessProbe:
-            exec:
-              command:
-                - wget
-                - -qO-
-                - http://127.0.0.1:9901
+            httpGet:
+              path: "/ready"
+              port: 9901
             failureThreshold: 12
             initialDelaySeconds: 60
             periodSeconds: 5
             successThreshold: 1
             timeoutSeconds: 3
           readinessProbe:
-            exec:
-              command:
-                - wget
-                - -qO-
-                - http://127.0.0.1:9901
+            httpGet:
+              path: "/ready"
+              port: 9901
             failureThreshold: 12
             initialDelaySeconds: 1
             periodSeconds: 5

--- a/deployments/charts/kuma/templates/ingress-deployment.yaml
+++ b/deployments/charts/kuma/templates/ingress-deployment.yaml
@@ -83,22 +83,18 @@ spec:
           ports:
             - containerPort: 10001
           livenessProbe:
-            exec:
-              command:
-                - wget
-                - -qO-
-                - http://127.0.0.1:9901
+            httpGet:
+              path: "/ready"
+              port: 9901
             failureThreshold: 12
             initialDelaySeconds: 60
             periodSeconds: 5
             successThreshold: 1
             timeoutSeconds: 3
           readinessProbe:
-            exec:
-              command:
-                - wget
-                - -qO-
-                - http://127.0.0.1:9901
+            httpGet:
+              path: "/ready"
+              port: 9901
             failureThreshold: 12
             initialDelaySeconds: 1
             periodSeconds: 5


### PR DESCRIPTION
### Summary

We were using wget when kubernetes has builtin support for these

Fix #3298

### Documentation

- ~~[ ] Link to the website [documentation PR](https://github.com/kumahq/kuma-website/pull/XXX)~~

### Testing

- [x] Unit tests
- [x] E2E tests
- ~~[ ] Manual testing on Universal~~
- ~~[ ] Manual testing on Kubernetes~~

### Backwards compatibility

N/A