### PR TITLE
fix(kuma-cp): reserve VIPs from all meshes before allocating a new one

### DIFF
--- a/pkg/dns/vips_allocator.go
+++ b/pkg/dns/vips_allocator.go
@@ -95,12 +95,9 @@ func (d *VIPsAllocator) createOrUpdateVIPConfigs(meshes ...string) (errs error) 
 	if err != nil {
 		return err
 	}
-	for _, mesh := range meshes {
-		if _, ok := byMesh[mesh]; !ok {
-			byMesh[mesh] = vips.NewEmptyVirtualOutboundView()
-		}
-		for _, hostEntry := range byMesh[mesh].HostnameEntries() {
-			vo := byMesh[mesh].Get(hostEntry)
+	for _, meshView := range byMesh {
+		for _, hostEntry := range meshView.HostnameEntries() {
+			vo := meshView.Get(hostEntry)
 			err := gv.Reserve(hostEntry, vo.Address)
 			if err != nil {
 				return err
@@ -129,7 +126,11 @@ func (d *VIPsAllocator) createOrUpdateVIPConfigs(meshes ...string) (errs error) 
 	}
 
 	for _, mesh := range meshes {
-		if err := forEachMesh(mesh, byMesh[mesh]); err != nil {
+		meshView, ok := byMesh[mesh]
+		if !ok {
+			meshView = vips.NewEmptyVirtualOutboundView()
+		}
+		if err := forEachMesh(mesh, meshView); err != nil {
 			errs = multierr.Append(errs, err)
 		}
 	}


### PR DESCRIPTION
### Summary

`createOrUpdateVIPConfigs` executed with single mesh only reserved existing addresses based on this one mesh instead of all meshes.
When allocating a new address, we were allocating an IP that was already issued for a service in a different mesh. I think that technically it's not a problem, `frontend.mesh` from `mesh-1` can receive `240.0.0.1` and `backend.mesh` from `mesh-2` can resolve to `240.0.0.1` as well and it will work because there is no cross mesh communication. I'd argue that it's better to try to keep separate VIPs because
* It's consistent with Universal. Notice how Universal calls `CreateOrUpdateVIPConfigs()` and then `createOrUpdateVIPConfigs(mesh)` with all the meshes. They never overlap in that scenario
* It's easier to troubleshoot
* It get rid of potential blocker to implement direct multizone communication 
* reverse lookup might be confusing

Review commit by commit.

### Issues resolved

No issues reported.

### Documentation

No docs.

### Testing

- [X] Unit tests
- [ ] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes

### Backwards compatibility

~- [ ] Update [`UPGRADE.md`](/UPGRADE.md) with any steps users will need to take when upgrading.~
~- [ ] Add `backport-to-stable` label if the code follows our [backporting policy](/CONTRIBUTING.md#backporting)~
