### PR TITLE
fix(kuma-dp): reduce max unix socket length to 104

### DIFF
--- a/pkg/xds/envoy/sockets.go
+++ b/pkg/xds/envoy/sockets.go
@@ -7,20 +7,20 @@ import (
 	"github.com/kumahq/kuma/pkg/core"
 )
 
-// AccessLogSocketName generates a socket path that will fit the Unix socket path limitation of 108 chars
+// AccessLogSocketName generates a socket path that will fit the Unix socket path limitation of 104 chars
 func AccessLogSocketName(name, mesh string) string {
 	return socketName(fmt.Sprintf("%s%skuma-al-%s-%s", core.TempDir(), string(os.PathSeparator), name, mesh))
 }
 
-// MetricsHijackerSocketName generates a socket path that will fit the Unix socket path limitation of 108 chars
+// MetricsHijackerSocketName generates a socket path that will fit the Unix socket path limitation of 104 chars
 func MetricsHijackerSocketName(name, mesh string) string {
 	return socketName(fmt.Sprintf("%s%skuma-mh-%s-%s", core.TempDir(), string(os.PathSeparator), name, mesh))
 }
 
 func socketName(s string) string {
 	trimLen := len(s)
-	if trimLen > 100 {
-		trimLen = 100
+	if trimLen > 98 {
+		trimLen = 98
 	}
 	return s[:trimLen] + ".sock"
 }


### PR DESCRIPTION
Linux limit is 108 but it looks like BSD and OS X are 104

Signed-off-by: Nicolas Chariglione <nicolas@koyeb.com>

### Summary

Fix https://github.com/kumahq/kuma/issues/3950

### Full changelog

### Issues resolved

Fix #3950

### Documentation

- [ ] Link to the website [documentation PR](https://github.com/kumahq/kuma-website/pull/XXX)

### Testing

Let me know if we need a test there

### Backwards compatibility

- [ ] Update [`UPGRADE.md`](/UPGRADE.md) with any steps users will need to take when upgrading.
- [ ] Add `backport-to-stable` label if the code follows our [backporting policy](/CONTRIBUTING.md#backporting)
