### PR TITLE
fix(kuma-dp): better error message when the token is invalid

### DIFF
--- a/app/kuma-dp/cmd/run.go
+++ b/app/kuma-dp/cmd/run.go
@@ -132,7 +132,7 @@ func newRunCmd(opts kuma_cmd.RunCmdOpts, rootCtx *RootContext) *cobra.Command {
 
 			if cfg.DataplaneRuntime.TokenPath != "" {
 				if err := kumadp_config.ValidateTokenPath(cfg.DataplaneRuntime.TokenPath); err != nil {
-					return err
+					return errors.Wrapf(err, "dataplane token is invalid, in Kubernetes you must mount a serviceAccount token, in universal you must start your proxy with a generated token.")
 				}
 			}
 


### PR DESCRIPTION
### Summary

Users often get confused when they end up starting with an invalid token
We improve the error message with some extra info to help user get on the right track.

### Issues resolved

Fix #3943

### Documentation

- ~~[ ] Link to the website [documentation PR](https://github.com/kumahq/kuma-website/pull/XXX)~~

### Testing

- ~~[ ] Unit tests~~
- ~~[ ] E2E tests~~
- ~~[ ] Manual testing on Universal~~
- ~~[ ] Manual testing on Kubernetes~~

### Backwards compatibility

N/A
