### PR TITLE
ci(*): do not require DOCKER_REGISTRY env

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -754,7 +754,6 @@ jobs:
     parallelism: 8
     environment:
       GOPATH: /home/circleci/.go-kuma-go
-      DOCKER_REGISTRY: kumahq
     steps:
       - install_build_tools
       - checkout
@@ -826,8 +825,6 @@ jobs:
 
   build:
     executor: golang
-    environment:
-      DOCKER_REGISTRY: kumahq
     steps:
     - checkout
     - restore_cache:

--- a/mk/docker.mk
+++ b/mk/docker.mk
@@ -1,7 +1,7 @@
 BUILD_DOCKER_IMAGES_DIR ?= $(BUILD_DIR)/docker-images
 KUMA_VERSION ?= master
 
-DOCKER_REGISTRY ?= docker.io/kumahq
+DOCKER_REGISTRY ?= kumahq
 DOCKER_USERNAME ?=
 DOCKER_API_KEY ?=
 


### PR DESCRIPTION
### Summary

Always use `kumahq` docker registry by default.
When we rebuild and push images, we use other env var anyways.

### Issues resolved

No issues reported

### Documentation

No docs

### Testing

- [ ] Unit tests
- [X] E2E tests
- [ ] Manual testing on Universal
- [X] Manual testing on Kubernetes

### Backwards compatibility

~- [ ] Update [`UPGRADE.md`](/UPGRADE.md) with any steps users will need to take when upgrading.~
~- [ ] Add `backport-to-stable` label if the code follows our [backporting policy](/CONTRIBUTING.md#backporting)~
