### PR TITLE
feat(inspect): add gateways to policy inspect

### DIFF
--- a/app/kumactl/cmd/inspect/inspect_dataplane_test.go
+++ b/app/kumactl/cmd/inspect/inspect_dataplane_test.go
@@ -41,50 +41,54 @@ var _ = Describe("kumactl inspect dataplane", func() {
 	var rootCmd *cobra.Command
 	var buf *bytes.Buffer
 
-	BeforeEach(func() {
-		rawResponse, err := os.ReadFile(path.Join("testdata", "inspect-dataplane.server-response.json"))
-		Expect(err).ToNot(HaveOccurred())
-
-		list := api_server_types.DataplaneInspectEntryList{}
-		Expect(json.Unmarshal(rawResponse, &list)).To(Succeed())
-
-		testClient := &testDataplaneInspectClient{
-			response: &list,
-		}
-
-		rootCtx, err := test_kumactl.MakeRootContext(time.Now(), nil)
-		Expect(err).ToNot(HaveOccurred())
-
-		rootCtx.Runtime.NewDataplaneInspectClient = func(client util_http.Client) resources.DataplaneInspectClient {
-			return testClient
-		}
-
-		rootCmd = cmd.NewRootCmd(rootCtx)
-		buf = &bytes.Buffer{}
-		rootCmd.SetOut(buf)
-	})
-
 	type testCase struct {
-		goldenFile string
-		matcher    func(path ...string) gomega_types.GomegaMatcher
+		serverOutput string
+		goldenFile   string
+		matcher      func(path ...string) gomega_types.GomegaMatcher
 	}
 	DescribeTable("kumactl inspect dataplane",
 		func(given testCase) {
+			rawResponse, err := os.ReadFile(path.Join("testdata", given.serverOutput))
+			Expect(err).ToNot(HaveOccurred())
+
+			list := api_server_types.DataplaneInspectEntryList{}
+			Expect(json.Unmarshal(rawResponse, &list)).To(Succeed())
+
+			testClient := &testDataplaneInspectClient{
+				response: &list,
+			}
+
+			rootCtx, err := test_kumactl.MakeRootContext(time.Now(), nil)
+			Expect(err).ToNot(HaveOccurred())
+
+			rootCtx.Runtime.NewDataplaneInspectClient = func(client util_http.Client) resources.DataplaneInspectClient {
+				return testClient
+			}
+
+			rootCmd = cmd.NewRootCmd(rootCtx)
+			buf = &bytes.Buffer{}
+			rootCmd.SetOut(buf)
 			// given
 			rootCmd.SetArgs([]string{
 				"--config-file", filepath.Join("..", "testdata", "sample-kumactl.config.yaml"),
 				"inspect", "dataplane", "backend-1"})
 
 			// when
-			err := rootCmd.Execute()
+			err = rootCmd.Execute()
 
 			// then
 			Expect(err).ToNot(HaveOccurred())
 			Expect(buf.String()).To(given.matcher("testdata", given.goldenFile))
 		},
 		Entry("default output", testCase{
-			goldenFile: "inspect-dataplane.golden.txt",
-			matcher:    matchers.MatchGoldenEqual,
+			serverOutput: "inspect-dataplane.server-response.json",
+			goldenFile:   "inspect-dataplane.golden.txt",
+			matcher:      matchers.MatchGoldenEqual,
+		}),
+		Entry("builtin gateway dataplane", testCase{
+			serverOutput: "inspect-gateway-dataplane.server-response.json",
+			goldenFile:   "inspect-gateway-dataplane.golden.txt",
+			matcher:      matchers.MatchGoldenEqual,
 		}),
 	)
 })

--- a/app/kumactl/cmd/inspect/inspect_dataplane_test.go
+++ b/app/kumactl/cmd/inspect/inspect_dataplane_test.go
@@ -85,6 +85,11 @@ var _ = Describe("kumactl inspect dataplane", func() {
 			goldenFile:   "inspect-dataplane.golden.txt",
 			matcher:      matchers.MatchGoldenEqual,
 		}),
+		Entry("default output (no kind in response)", testCase{
+			serverOutput: "inspect-dataplane-1.5.server-response.json",
+			goldenFile:   "inspect-dataplane.golden.txt",
+			matcher:      matchers.MatchGoldenEqual,
+		}),
 		Entry("builtin gateway dataplane", testCase{
 			serverOutput: "inspect-gateway-dataplane.server-response.json",
 			goldenFile:   "inspect-gateway-dataplane.golden.txt",

--- a/app/kumactl/cmd/inspect/inspect_policy.go
+++ b/app/kumactl/cmd/inspect/inspect_policy.go
@@ -16,6 +16,7 @@ import (
 
 var policyInspectTemplate = "Affected data plane proxies:\n\n" +
 	"{{ range .Items }}" +
+	"{{ with IsSidecar . }}" +
 	"  {{ .DataplaneKey.Name }}" +
 	"{{ if . | PrintAttachments }}" +
 	":\n" +
@@ -24,16 +25,25 @@ var policyInspectTemplate = "Affected data plane proxies:\n\n" +
 	"{{ end }}" +
 	"{{ end }}" +
 	"\n" +
+	"{{ end }}" +
 	"{{ end }}"
 
 func newInspectPolicyCmd(policyDesc core_model.ResourceTypeDescriptor, pctx *cmd.RootContext) *cobra.Command {
 	tmpl, err := template.New("policy_inspect").Funcs(template.FuncMap{
-		"FormatAttachment": attachmentToStr(false),
-		"PrintAttachments": func(e api_server_types.PolicyInspectEntry) bool {
-			sidecarEntry, ok := e.PolicyInspectEntryKind.(*api_server_types.PolicyInspectSidecarEntry)
-			if !ok {
-				return true
+		"IsSidecar": func(e api_server_types.PolicyInspectEntry) *api_server_types.PolicyInspectSidecarEntry {
+			if concrete, ok := e.PolicyInspectEntryKind.(*api_server_types.PolicyInspectSidecarEntry); ok {
+				return concrete
 			}
+			return nil
+		},
+		"IsGateway": func(e api_server_types.PolicyInspectEntry) *api_server_types.PolicyInspectGatewayEntry {
+			if concrete, ok := e.PolicyInspectEntryKind.(*api_server_types.PolicyInspectGatewayEntry); ok {
+				return concrete
+			}
+			return nil
+		},
+		"FormatAttachment": attachmentToStr(false),
+		"PrintAttachments": func(sidecarEntry *api_server_types.PolicyInspectSidecarEntry) bool {
 			if len(sidecarEntry.Attachments) == 1 && sidecarEntry.Attachments[0].Type == "dataplane" {
 				return false
 			}

--- a/app/kumactl/cmd/inspect/inspect_policy.go
+++ b/app/kumactl/cmd/inspect/inspect_policy.go
@@ -30,7 +30,7 @@ func newInspectPolicyCmd(policyDesc core_model.ResourceTypeDescriptor, pctx *cmd
 	tmpl, err := template.New("policy_inspect").Funcs(template.FuncMap{
 		"FormatAttachment": attachmentToStr(false),
 		"PrintAttachments": func(e api_server_types.PolicyInspectEntry) bool {
-			sidecarEntry, ok := e.(*api_server_types.PolicyInspectSidecarEntry)
+			sidecarEntry, ok := e.PolicyInspectEntryKind.(*api_server_types.PolicyInspectSidecarEntry)
 			if !ok {
 				return true
 			}

--- a/app/kumactl/cmd/inspect/inspect_policy.go
+++ b/app/kumactl/cmd/inspect/inspect_policy.go
@@ -30,7 +30,11 @@ func newInspectPolicyCmd(policyDesc core_model.ResourceTypeDescriptor, pctx *cmd
 	tmpl, err := template.New("policy_inspect").Funcs(template.FuncMap{
 		"FormatAttachment": attachmentToStr(false),
 		"PrintAttachments": func(e api_server_types.PolicyInspectEntry) bool {
-			if len(e.Attachments) == 1 && e.Attachments[0].Type == "dataplane" {
+			sidecarEntry, ok := e.(*api_server_types.PolicyInspectSidecarEntry)
+			if !ok {
+				return true
+			}
+			if len(sidecarEntry.Attachments) == 1 && sidecarEntry.Attachments[0].Type == "dataplane" {
 				return false
 			}
 			return true

--- a/app/kumactl/cmd/inspect/inspect_policy_test.go
+++ b/app/kumactl/cmd/inspect/inspect_policy_test.go
@@ -85,6 +85,11 @@ var _ = Describe("kumactl inspect POLICY", func() {
 			serverResponseFile: "inspect-health-check.server-response.json",
 			cmdArgs:            []string{"inspect", "healthcheck", "hc1"},
 		}),
+		Entry("service policy (no kind in response)", testCase{
+			goldenFile:         "inspect-health-check.golden.txt",
+			serverResponseFile: "inspect-health-check-1.5.server-response.json",
+			cmdArgs:            []string{"inspect", "healthcheck", "hc1"},
+		}),
 		Entry("dataplane policy", testCase{
 			goldenFile:         "inspect-traffic-trace.golden.txt",
 			serverResponseFile: "inspect-traffic-trace.server-response.json",

--- a/app/kumactl/cmd/inspect/testdata/inspect-dataplane-1.5.server-response.json
+++ b/app/kumactl/cmd/inspect/testdata/inspect-dataplane-1.5.server-response.json
@@ -1,0 +1,256 @@
+{
+  "total": 4,
+  "items": [
+    {
+      "type": "dataplane",
+      "name": "",
+      "service": "",
+      "matchedPolicies": {
+        "TrafficTrace": [
+          {
+            "type": "TrafficTrace",
+            "mesh": "default",
+            "name": "backends-eu",
+            "creationTime": "2022-02-06T15:31:26.424855+01:00",
+            "modificationTime": "2022-02-06T15:31:26.424855+01:00",
+            "selectors": [
+              {
+                "match": {
+                  "kuma.io/service": "backend"
+                }
+              }
+            ],
+            "conf": {
+              "backend": "zipkin-eu"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "type": "inbound",
+      "name": "127.0.0.1:10010:10011",
+      "service": "backend",
+      "matchedPolicies": {
+        "TrafficPermission": [
+          {
+            "type": "TrafficPermission",
+            "mesh": "default",
+            "name": "allow-all-default",
+            "creationTime": "2022-02-04T17:55:46.426279+01:00",
+            "modificationTime": "2022-02-04T17:55:46.426279+01:00",
+            "sources": [
+              {
+                "match": {
+                  "kuma.io/service": "*"
+                }
+              }
+            ],
+            "destinations": [
+              {
+                "match": {
+                  "kuma.io/service": "*"
+                }
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "type": "outbound",
+      "name": "127.0.0.1:10006",
+      "service": "gateway",
+      "matchedPolicies": {
+        "Timeout": [
+          {
+            "type": "Timeout",
+            "mesh": "default",
+            "name": "timeout-all-default",
+            "creationTime": "2022-02-04T17:55:46.426752+01:00",
+            "modificationTime": "2022-02-04T17:55:46.426752+01:00",
+            "sources": [
+              {
+                "match": {
+                  "kuma.io/service": "*"
+                }
+              }
+            ],
+            "destinations": [
+              {
+                "match": {
+                  "kuma.io/service": "*"
+                }
+              }
+            ],
+            "conf": {
+              "connectTimeout": "5s",
+              "tcp": {
+                "idleTimeout": "3600s"
+              },
+              "http": {
+                "requestTimeout": "15s",
+                "idleTimeout": "3600s"
+              },
+              "grpc": {
+                "streamIdleTimeout": "300s"
+              }
+            }
+          }
+        ],
+        "TrafficRoute": [
+          {
+            "type": "TrafficRoute",
+            "mesh": "default",
+            "name": "route-all-default",
+            "creationTime": "2022-02-04T17:55:46.426489+01:00",
+            "modificationTime": "2022-02-04T17:55:46.426489+01:00",
+            "sources": [
+              {
+                "match": {
+                  "kuma.io/service": "*"
+                }
+              }
+            ],
+            "destinations": [
+              {
+                "match": {
+                  "kuma.io/service": "*"
+                }
+              }
+            ],
+            "conf": {
+              "loadBalancer": {
+                "roundRobin": {}
+              },
+              "destination": {
+                "kuma.io/service": "gateway"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "type": "service",
+      "name": "gateway",
+      "service": "gateway",
+      "matchedPolicies": {
+        "CircuitBreaker": [
+          {
+            "type": "CircuitBreaker",
+            "mesh": "default",
+            "name": "circuit-breaker-all-default",
+            "creationTime": "2022-02-04T17:55:46.426951+01:00",
+            "modificationTime": "2022-02-04T17:55:46.426951+01:00",
+            "sources": [
+              {
+                "match": {
+                  "kuma.io/service": "*"
+                }
+              }
+            ],
+            "destinations": [
+              {
+                "match": {
+                  "kuma.io/service": "*"
+                }
+              }
+            ],
+            "conf": {
+              "thresholds": {
+                "maxConnections": 1024,
+                "maxPendingRequests": 1024,
+                "maxRetries": 3,
+                "maxRequests": 1024
+              }
+            }
+          }
+        ],
+        "HealthCheck": [
+          {
+            "type": "HealthCheck",
+            "mesh": "default",
+            "name": "gateway-to-backend",
+            "creationTime": "2022-02-06T15:31:21.499862+01:00",
+            "modificationTime": "2022-02-06T15:31:21.499862+01:00",
+            "sources": [
+              {
+                "match": {
+                  "kuma.io/service": "backend"
+                }
+              }
+            ],
+            "destinations": [
+              {
+                "match": {
+                  "kuma.io/service": "gateway"
+                }
+              }
+            ],
+            "conf": {
+              "interval": "10s",
+              "timeout": "2s",
+              "unhealthyThreshold": 3,
+              "healthyThreshold": 1,
+              "healthyPanicThreshold": 0,
+              "failTrafficOnPanic": true,
+              "eventLogPath": "/Users/lobkovilya/Documents/kuma/trafficroutes/logs2",
+              "alwaysLogHealthCheckFailures": true,
+              "noTrafficInterval": "1s",
+              "tcp": {
+                "send": "Zm9v",
+                "receive": ["YmFy"]
+              },
+              "reuseConnection": true
+            }
+          }
+        ],
+        "Retry": [
+          {
+            "type": "Retry",
+            "mesh": "default",
+            "name": "retry-all-default",
+            "creationTime": "2022-02-04T17:55:46.427127+01:00",
+            "modificationTime": "2022-02-04T17:55:46.427127+01:00",
+            "sources": [
+              {
+                "match": {
+                  "kuma.io/service": "*"
+                }
+              }
+            ],
+            "destinations": [
+              {
+                "match": {
+                  "kuma.io/service": "*"
+                }
+              }
+            ],
+            "conf": {
+              "http": {
+                "numRetries": 5,
+                "perTryTimeout": "16s",
+                "backOff": {
+                  "baseInterval": "0.025s",
+                  "maxInterval": "0.250s"
+                }
+              },
+              "tcp": {
+                "maxConnectAttempts": 5
+              },
+              "grpc": {
+                "numRetries": 5,
+                "perTryTimeout": "16s",
+                "backOff": {
+                  "baseInterval": "0.025s",
+                  "maxInterval": "0.250s"
+                }
+              }
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/app/kumactl/cmd/inspect/testdata/inspect-dataplane.server-response.json
+++ b/app/kumactl/cmd/inspect/testdata/inspect-dataplane.server-response.json
@@ -1,4 +1,5 @@
 {
+  "kind": "SidecarDataplane",
   "total": 4,
   "items": [
     {

--- a/app/kumactl/cmd/inspect/testdata/inspect-gateway-dataplane.server-response.json
+++ b/app/kumactl/cmd/inspect/testdata/inspect-gateway-dataplane.server-response.json
@@ -1,0 +1,101 @@
+{
+ "kind": "GatewayDataplane",
+ "gateway": {
+  "mesh": "default",
+  "name": "gateway"
+ },
+ "listeners": [
+  {
+   "port": 80,
+   "protocol": "HTTP",
+   "hosts": [
+    {
+     "hostName": "*",
+     "routes": [
+      {
+       "route": "route-1",
+       "destinations": [
+        {
+         "tags": {
+          "kuma.io/service": "backend"
+         },
+         "policies": {
+          "HealthCheck": {
+           "type": "HealthCheck",
+           "mesh": "default",
+           "name": "hc-1",
+           "creationTime": "0001-01-01T00:00:00Z",
+           "modificationTime": "0001-01-01T00:00:00Z",
+           "sources": [
+            {
+             "match": {
+              "kuma.io/service": "gateway"
+             }
+            }
+           ],
+           "destinations": [
+            {
+             "match": {
+              "kuma.io/service": "backend"
+             }
+            }
+           ],
+           "conf": {
+            "interval": "5s",
+            "timeout": "7s",
+            "unhealthyThreshold": 11,
+            "healthyThreshold": 9
+           }
+          }
+         }
+        },
+        {
+         "tags": {
+          "kuma.io/service": "redis"
+         },
+         "policies": {
+          "Timeout": {
+           "type": "Timeout",
+           "mesh": "default",
+           "name": "t-1",
+           "creationTime": "0001-01-01T00:00:00Z",
+           "modificationTime": "0001-01-01T00:00:00Z",
+           "sources": [
+            {
+             "match": {
+              "kuma.io/service": "*"
+             }
+            }
+           ],
+           "destinations": [
+            {
+             "match": {
+              "kuma.io/service": "redis"
+             }
+            }
+           ],
+           "conf": {
+            "connectTimeout": "5s",
+            "tcp": {
+             "idleTimeout": "5s"
+            },
+            "http": {
+             "requestTimeout": "5s",
+             "idleTimeout": "5s"
+            },
+            "grpc": {
+             "streamIdleTimeout": "5s",
+             "maxStreamDuration": "5s"
+            }
+           }
+          }
+         }
+        }
+       ]
+      }
+     ]
+    }
+   ]
+  }
+ ]
+}

--- a/app/kumactl/cmd/inspect/testdata/inspect-health-check-1.5.server-response.json
+++ b/app/kumactl/cmd/inspect/testdata/inspect-health-check-1.5.server-response.json
@@ -1,0 +1,54 @@
+{
+  "total": 1,
+  "items": [
+    {
+      "dataplane": {
+        "mesh": "default",
+        "name": "backend-1"
+      },
+      "attachments": [
+        {
+          "type": "service",
+          "name": "gateway",
+          "service": "gateway"
+        },
+        {
+          "type": "service",
+          "name": "web",
+          "service": "web"
+        }
+      ]
+    },
+    {
+      "dataplane": {
+        "mesh": "default",
+        "name": "web-1"
+      },
+      "attachments": [
+        {
+          "type": "service",
+          "name": "gateway",
+          "service": "gateway"
+        }
+      ]
+    },
+    {
+      "dataplane": {
+        "mesh": "default",
+        "name": "redis-1"
+      },
+      "attachments": [
+        {
+          "type": "service",
+          "name": "gateway",
+          "service": "gateway"
+        },
+        {
+          "type": "service",
+          "name": "web",
+          "service": "web"
+        }
+      ]
+    }
+  ]
+}

--- a/app/kumactl/cmd/inspect/testdata/inspect-health-check.server-response.json
+++ b/app/kumactl/cmd/inspect/testdata/inspect-health-check.server-response.json
@@ -2,7 +2,39 @@
   "total": 1,
   "items": [
     {
-	  "kind": "SidecarDataplane",
+      "kind": "GatewayDataplane",
+      "dataplane": {
+        "mesh": "mesh-1",
+        "name": "meshgateway-1"
+      },
+      "gateway": {
+        "mesh": "mesh-1",
+        "name": "gateway"
+      },
+      "listeners": [
+        {
+          "port": 80,
+          "protocol": "HTTP",
+          "hosts": [
+            {
+              "hostName": "*",
+              "routes": [
+                {
+                  "route": "route-1",
+                  "destinations": [
+                    {
+                      "kuma.io/service": "redis"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "kind": "SidecarDataplane",
       "dataplane": {
         "mesh": "default",
         "name": "backend-1"
@@ -21,7 +53,7 @@
       ]
     },
     {
-	  "kind": "SidecarDataplane",
+      "kind": "SidecarDataplane",
       "dataplane": {
         "mesh": "default",
         "name": "web-1"
@@ -35,7 +67,7 @@
       ]
     },
     {
-	  "kind": "SidecarDataplane",
+      "kind": "SidecarDataplane",
       "dataplane": {
         "mesh": "default",
         "name": "redis-1"

--- a/app/kumactl/cmd/inspect/testdata/inspect-health-check.server-response.json
+++ b/app/kumactl/cmd/inspect/testdata/inspect-health-check.server-response.json
@@ -2,6 +2,7 @@
   "total": 1,
   "items": [
     {
+	  "kind": "SidecarDataplane",
       "dataplane": {
         "mesh": "default",
         "name": "backend-1"
@@ -20,6 +21,7 @@
       ]
     },
     {
+	  "kind": "SidecarDataplane",
       "dataplane": {
         "mesh": "default",
         "name": "web-1"
@@ -33,6 +35,7 @@
       ]
     },
     {
+	  "kind": "SidecarDataplane",
       "dataplane": {
         "mesh": "default",
         "name": "redis-1"

--- a/app/kumactl/cmd/inspect/testdata/inspect-timeout.server-response.json
+++ b/app/kumactl/cmd/inspect/testdata/inspect-timeout.server-response.json
@@ -2,6 +2,7 @@
   "total": 1,
   "items": [
     {
+      "kind": "SidecarDataplane",
       "dataplane": {
         "mesh": "default",
         "name": "backend-1"
@@ -25,6 +26,7 @@
       ]
     },
     {
+      "kind": "SidecarDataplane",
       "dataplane": {
         "mesh": "default",
         "name": "redis-1"

--- a/app/kumactl/cmd/inspect/testdata/inspect-traffic-permission.server-response.json
+++ b/app/kumactl/cmd/inspect/testdata/inspect-traffic-permission.server-response.json
@@ -2,6 +2,7 @@
   "total": 2,
   "items": [
     {
+      "kind": "SidecarDataplane",
       "dataplane": {
         "mesh": "default",
         "name": "backend-1"
@@ -25,6 +26,7 @@
       ]
     },
     {
+      "kind": "SidecarDataplane",
       "dataplane": {
         "mesh": "default",
         "name": "web-1"

--- a/app/kumactl/cmd/inspect/testdata/inspect-traffic-trace.server-response.json
+++ b/app/kumactl/cmd/inspect/testdata/inspect-traffic-trace.server-response.json
@@ -2,6 +2,7 @@
   "total": 1,
   "items": [
     {
+      "kind": "SidecarDataplane",
       "dataplane": {
         "mesh": "default",
         "name": "backend-1"
@@ -15,6 +16,7 @@
       ]
     },
     {
+      "kind": "SidecarDataplane",
       "dataplane": {
         "mesh": "default",
         "name": "web-1"
@@ -28,6 +30,7 @@
       ]
     },
     {
+      "kind": "SidecarDataplane",
       "dataplane": {
         "mesh": "default",
         "name": "redis-1"

--- a/pkg/api-server/inspect_endpoints.go
+++ b/pkg/api-server/inspect_endpoints.go
@@ -34,6 +34,8 @@ import (
 
 var CustomizeProxy func(meshContext xds_context.MeshContext, proxy *core_xds.Proxy) error
 
+// getMatchedPolicies returns information about either sidecar dataplanes or
+// builtin gateway dataplanes as well as the proxy and a potential error.
 func getMatchedPolicies(
 	cfg *kuma_cp.Config, meshContext xds_context.MeshContext, dataplaneKey core_model.ResourceKey,
 ) (
@@ -184,28 +186,36 @@ func inspectPolicies(
 
 		for _, dp := range meshContext.Resources.Dataplanes().Items {
 			dpKey := core_model.MetaToResourceKey(dp.GetMeta())
-			matchedPolicies, _, _, err := getMatchedPolicies(cfg, meshContext, dpKey)
+			resourceKey := api_server_types.ResourceKeyEntry{
+				Mesh: dpKey.Mesh,
+				Name: dpKey.Name,
+			}
+			matchedPolicies, gatewayEntries, proxy, err := getMatchedPolicies(cfg, meshContext, dpKey)
 			if err != nil {
 				rest_errors.HandleError(response, err, fmt.Sprintf("Could not get MatchedPolicies for %v", dpKey))
 				return
 			}
-			for policy, attachments := range core_xds.GroupByPolicy(matchedPolicies, dp.Spec.Networking) {
-				if policy.Type == resType && policy.Key.Name == policyName && policy.Key.Mesh == meshName {
-					attachmentList := []api_server_types.AttachmentEntry{}
-					for _, attachment := range attachments {
-						attachmentList = append(attachmentList, api_server_types.AttachmentEntry{
-							Type:    attachment.Type.String(),
-							Name:    attachment.Name,
-							Service: attachment.Service,
-						})
+			if matchedPolicies != nil {
+				for policy, attachments := range core_xds.GroupByPolicy(matchedPolicies, dp.Spec.Networking) {
+					if policy.Type == resType && policy.Key.Name == policyName && policy.Key.Mesh == meshName {
+						attachmentList := []api_server_types.AttachmentEntry{}
+						for _, attachment := range attachments {
+							attachmentList = append(attachmentList, api_server_types.AttachmentEntry{
+								Type:    attachment.Type.String(),
+								Name:    attachment.Name,
+								Service: attachment.Service,
+							})
+						}
+						entry := api_server_types.NewPolicyInspectSidecarEntry(resourceKey)
+						entry.Attachments = attachmentList
+						result.Items = append(result.Items, &entry)
 					}
-					result.Items = append(result.Items, &api_server_types.PolicyInspectEntry{
-						DataplaneKey: api_server_types.ResourceKeyEntry{
-							Mesh: dpKey.Mesh,
-							Name: dpKey.Name,
-						},
-						Attachments: attachmentList,
-					})
+				}
+			} else {
+				for policy, attachments := range gatewayEntriesByPolicy(proxy, gatewayEntries) {
+					if policy.Type == resType && policy.Key.Name == policyName && policy.Key.Mesh == meshName {
+						result.Items = append(result.Items, attachments...)
+					}
 				}
 			}
 		}
@@ -343,6 +353,38 @@ func routeDestinationToAPIDestination(des route.Destination) api_server_types.De
 	}
 }
 
+func newDataplaneInspectResponse(matchedPolicies *core_xds.MatchedPolicies, dp *core_mesh.DataplaneResource) []*api_server_types.DataplaneInspectEntry {
+	attachmentMap := core_xds.GroupByAttachment(matchedPolicies, dp.Spec.Networking)
+
+	entries := make([]*api_server_types.DataplaneInspectEntry, 0, len(attachmentMap))
+	attachments := []core_xds.Attachment{}
+	for attachment := range attachmentMap {
+		attachments = append(attachments, attachment)
+	}
+
+	sort.Stable(core_xds.AttachmentList(attachments))
+
+	for _, attachment := range attachments {
+		entry := &api_server_types.DataplaneInspectEntry{
+			AttachmentEntry: api_server_types.AttachmentEntry{
+				Type:    attachment.Type.String(),
+				Name:    attachment.Name,
+				Service: attachment.Service,
+			},
+			MatchedPolicies: map[core_model.ResourceType][]*rest.Resource{},
+		}
+		for typ, resList := range attachmentMap[attachment] {
+			for _, res := range resList {
+				entry.MatchedPolicies[typ] = append(entry.MatchedPolicies[typ], rest.From.Resource(res))
+			}
+		}
+
+		entries = append(entries, entry)
+	}
+
+	return entries
+}
+
 func newGatewayDataplaneInspectResponse(
 	proxy core_xds.Proxy,
 	listenerInfos []gateway.GatewayListenerInfo,
@@ -423,34 +465,122 @@ func newGatewayDataplaneInspectResponse(
 	return result
 }
 
-func newDataplaneInspectResponse(matchedPolicies *core_xds.MatchedPolicies, dp *core_mesh.DataplaneResource) []*api_server_types.DataplaneInspectEntry {
-	attachmentMap := core_xds.GroupByAttachment(matchedPolicies, dp.Spec.Networking)
+func routeToPolicyInspect(
+	policyMap map[core_xds.PolicyKey][]envoy.Tags,
+	des route.Destination,
+) map[core_xds.PolicyKey][]envoy.Tags {
+	for kind, p := range des.Policies {
+		policyKey := core_xds.PolicyKey{
+			Type: kind,
+			Key:  core_model.MetaToResourceKey(p.GetMeta()),
+		}
 
-	entries := make([]*api_server_types.DataplaneInspectEntry, 0, len(attachmentMap))
-	attachments := []core_xds.Attachment{}
-	for attachment := range attachmentMap {
-		attachments = append(attachments, attachment)
+		policies := policyMap[policyKey]
+		policies = append(policies, des.Destination)
+		policyMap[policyKey] = policies
 	}
 
-	sort.Stable(core_xds.AttachmentList(attachments))
+	return policyMap
+}
 
-	for _, attachment := range attachments {
-		entry := &api_server_types.DataplaneInspectEntry{
-			AttachmentEntry: api_server_types.AttachmentEntry{
-				Type:    attachment.Type.String(),
-				Name:    attachment.Name,
-				Service: attachment.Service,
-			},
-			MatchedPolicies: map[core_model.ResourceType][]*rest.Resource{},
-		}
-		for typ, resList := range attachmentMap[attachment] {
-			for _, res := range resList {
-				entry.MatchedPolicies[typ] = append(entry.MatchedPolicies[typ], rest.From.Resource(res))
+func gatewayEntriesByPolicy(
+	proxy core_xds.Proxy,
+	listenerInfos []gateway.GatewayListenerInfo,
+) map[core_xds.PolicyKey][]api_server_types.PolicyInspectEntry {
+	policyMap := map[core_xds.PolicyKey][]api_server_types.PolicyInspectEntry{}
+
+	dpKey := core_model.MetaToResourceKey(proxy.Dataplane.GetMeta())
+	resourceKey := api_server_types.ResourceKeyEntry{
+		Mesh: dpKey.Mesh,
+		Name: dpKey.Name,
+	}
+
+	listenersMap := map[core_xds.PolicyKey][]api_server_types.PolicyInspectGatewayListenerEntry{}
+	for _, info := range listenerInfos {
+		hostMap := map[core_xds.PolicyKey][]api_server_types.PolicyInspectGatewayHostEntry{}
+		for _, info := range info.HostInfos {
+			routeMap := map[core_xds.PolicyKey][]api_server_types.PolicyInspectGatewayRouteEntry{}
+			for _, entry := range info.Entries {
+				entryMap := map[core_xds.PolicyKey][]envoy.Tags{}
+				if entry.Mirror != nil {
+					entryMap = routeToPolicyInspect(entryMap, entry.Mirror.Forward)
+				}
+
+				for _, forward := range entry.Action.Forward {
+					entryMap = routeToPolicyInspect(entryMap, forward)
+				}
+
+				for policy, destinations := range entryMap {
+					routeMap[policy] = append(
+						routeMap[policy],
+						api_server_types.PolicyInspectGatewayRouteEntry{
+							Route:        entry.Route,
+							Destinations: destinations,
+						})
+				}
+			}
+
+			for policy, routes := range routeMap {
+				hostMap[policy] = append(
+					hostMap[policy],
+					api_server_types.PolicyInspectGatewayHostEntry{
+						HostName: info.Host.Hostname,
+						Routes:   routes,
+					})
 			}
 		}
 
-		entries = append(entries, entry)
+		for policy, hosts := range hostMap {
+			listenersMap[policy] = append(
+				listenersMap[policy],
+				api_server_types.PolicyInspectGatewayListenerEntry{
+					Port:     info.Listener.Port,
+					Protocol: info.Listener.Protocol.String(),
+					Hosts:    hosts,
+				},
+			)
+		}
 	}
 
-	return entries
+	var gatewayKey api_server_types.ResourceKeyEntry
+	if len(listenerInfos) > 0 {
+		gatewayKey = api_server_types.ResourceKeyEntryFromModelKey(core_model.MetaToResourceKey(listenerInfos[0].Gateway.GetMeta()))
+	}
+	for policy, listeners := range listenersMap {
+		result := api_server_types.NewPolicyInspectGatewayEntry(resourceKey, gatewayKey)
+
+		result.Listeners = listeners
+
+		result.Gateway = gatewayKey
+
+		policyMap[policy] = append(
+			policyMap[policy],
+			&result,
+		)
+	}
+
+	if logging, ok := proxy.Policies.TrafficLogs[core_mesh.PassThroughService]; ok {
+		wholeGateway := api_server_types.NewPolicyInspectGatewayEntry(resourceKey, gatewayKey)
+		policyKey := core_xds.PolicyKey{
+			Type: core_mesh.TrafficLogType,
+			Key:  core_model.MetaToResourceKey(logging.GetMeta()),
+		}
+		policyMap[policyKey] = append(
+			policyMap[policyKey],
+			&wholeGateway,
+		)
+	}
+	if trace := proxy.Policies.TrafficTrace; trace != nil {
+		wholeGateway := api_server_types.NewPolicyInspectGatewayEntry(resourceKey, gatewayKey)
+		policyKey := core_xds.PolicyKey{
+			Type: core_mesh.TrafficTraceType,
+			Key:  core_model.MetaToResourceKey(trace.GetMeta()),
+		}
+		policyMap[policyKey] = append(
+			policyMap[policyKey],
+			&wholeGateway,
+		)
+	}
+
+	return policyMap
 }

--- a/pkg/api-server/inspect_endpoints_test.go
+++ b/pkg/api-server/inspect_endpoints_test.go
@@ -676,6 +676,68 @@ var _ = Describe("Inspect WS", func() {
 			goldenFile: "inspect_retry.json",
 			resources: []core_model.Resource{
 				newMesh("mesh-1"),
+				&core_mesh.MeshGatewayResource{
+					Meta: &test_model.ResourceMeta{Name: "gateway", Mesh: "mesh-1"},
+					Spec: &mesh_proto.MeshGateway{
+						Selectors: selectors{
+							serviceSelector("meshgateway", ""),
+						},
+						Conf: &mesh_proto.MeshGateway_Conf{
+							Listeners: []*mesh_proto.MeshGateway_Listener{
+								{
+									Protocol: mesh_proto.MeshGateway_Listener_HTTP,
+									Port:     80,
+								},
+							},
+						},
+					},
+				},
+				&core_mesh.MeshGatewayRouteResource{
+					Meta: &test_model.ResourceMeta{Name: "route-1", Mesh: "mesh-1"},
+					Spec: &mesh_proto.MeshGatewayRoute{
+						Selectors: selectors{
+							serviceSelector("meshgateway", ""),
+						},
+						Conf: &mesh_proto.MeshGatewayRoute_Conf{
+							Route: &mesh_proto.MeshGatewayRoute_Conf_Http{
+								Http: &mesh_proto.MeshGatewayRoute_HttpRoute{
+									Rules: []*mesh_proto.MeshGatewayRoute_HttpRoute_Rule{
+										{
+											Matches: []*mesh_proto.MeshGatewayRoute_HttpRoute_Match{
+												{
+													Path: &mesh_proto.MeshGatewayRoute_HttpRoute_Match_Path{
+														Match: mesh_proto.MeshGatewayRoute_HttpRoute_Match_Path_EXACT,
+														Value: "/redis",
+													},
+												},
+											},
+											Backends: []*mesh_proto.MeshGatewayRoute_Backend{
+												{
+													Destination: serviceSelector("redis", "").Match,
+												},
+											},
+										},
+										{
+											Matches: []*mesh_proto.MeshGatewayRoute_HttpRoute_Match{
+												{
+													Path: &mesh_proto.MeshGatewayRoute_HttpRoute_Match_Path{
+														Match: mesh_proto.MeshGatewayRoute_HttpRoute_Match_Path_EXACT,
+														Value: "/backend",
+													},
+												},
+											},
+											Backends: []*mesh_proto.MeshGatewayRoute_Backend{
+												{
+													Destination: serviceSelector("backend", "").Match,
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
 				&core_mesh.RetryResource{
 					Meta: &test_model.ResourceMeta{Name: "r-1", Mesh: "mesh-1"},
 					Spec: &mesh_proto.Retry{
@@ -687,6 +749,10 @@ var _ = Describe("Inspect WS", func() {
 						Conf: samples.Retry.Conf,
 					},
 				},
+				newDataplane().
+					meta("meshgateway-1", "mesh-1").
+					builtin("meshgateway").
+					build(),
 				newDataplane().
 					meta("backend-1", "mesh-1").
 					inbound80to81("backend", "192.168.0.1").
@@ -772,6 +838,57 @@ var _ = Describe("Inspect WS", func() {
 						Conf:      samples.TrafficTrace.Conf,
 					},
 				},
+				&core_mesh.MeshGatewayResource{
+					Meta: &test_model.ResourceMeta{Name: "meshgateway", Mesh: "mesh-1"},
+					Spec: &mesh_proto.MeshGateway{
+						Selectors: selectors{
+							serviceSelector("meshgateway", ""),
+						},
+						Conf: &mesh_proto.MeshGateway_Conf{
+							Listeners: []*mesh_proto.MeshGateway_Listener{
+								{
+									Protocol: mesh_proto.MeshGateway_Listener_HTTP,
+									Port:     80,
+								},
+							},
+						},
+					},
+				},
+				&core_mesh.MeshGatewayRouteResource{
+					Meta: &test_model.ResourceMeta{Name: "route-1", Mesh: "mesh-1"},
+					Spec: &mesh_proto.MeshGatewayRoute{
+						Selectors: selectors{
+							serviceSelector("meshgateway", ""),
+						},
+						Conf: &mesh_proto.MeshGatewayRoute_Conf{
+							Route: &mesh_proto.MeshGatewayRoute_Conf_Http{
+								Http: &mesh_proto.MeshGatewayRoute_HttpRoute{
+									Rules: []*mesh_proto.MeshGatewayRoute_HttpRoute_Rule{
+										{
+											Matches: []*mesh_proto.MeshGatewayRoute_HttpRoute_Match{
+												{
+													Path: &mesh_proto.MeshGatewayRoute_HttpRoute_Match_Path{
+														Match: mesh_proto.MeshGatewayRoute_HttpRoute_Match_Path_EXACT,
+														Value: "/redis",
+													},
+												},
+											},
+											Backends: []*mesh_proto.MeshGatewayRoute_Backend{
+												{
+													Destination: serviceSelector("redis", "").Match,
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				newDataplane().
+					meta("meshgateway-1", "mesh-1").
+					builtin("meshgateway").
+					build(),
 				newDataplane().
 					meta("backend-1", "mesh-1").
 					inbound80to81("backend", "192.168.0.1").

--- a/pkg/api-server/testdata/inspect_changed_state_after.json
+++ b/pkg/api-server/testdata/inspect_changed_state_after.json
@@ -6,6 +6,7 @@
     "mesh": "default",
     "name": "redis-1"
    },
+   "kind": "SidecarDataplane",
    "attachments": [
     {
      "type": "inbound",

--- a/pkg/api-server/testdata/inspect_changed_state_after.json
+++ b/pkg/api-server/testdata/inspect_changed_state_after.json
@@ -2,11 +2,11 @@
  "total": 1,
  "items": [
   {
+   "kind": "SidecarDataplane",
    "dataplane": {
     "mesh": "default",
     "name": "redis-1"
    },
-   "kind": "SidecarDataplane",
    "attachments": [
     {
      "type": "inbound",

--- a/pkg/api-server/testdata/inspect_changed_state_before.json
+++ b/pkg/api-server/testdata/inspect_changed_state_before.json
@@ -2,11 +2,11 @@
  "total": 2,
  "items": [
   {
+   "kind": "SidecarDataplane",
    "dataplane": {
     "mesh": "default",
     "name": "backend-1"
    },
-   "kind": "SidecarDataplane",
    "attachments": [
     {
      "type": "inbound",
@@ -16,11 +16,11 @@
    ]
   },
   {
+   "kind": "SidecarDataplane",
    "dataplane": {
     "mesh": "default",
     "name": "redis-1"
    },
-   "kind": "SidecarDataplane",
    "attachments": [
     {
      "type": "inbound",

--- a/pkg/api-server/testdata/inspect_changed_state_before.json
+++ b/pkg/api-server/testdata/inspect_changed_state_before.json
@@ -6,6 +6,7 @@
     "mesh": "default",
     "name": "backend-1"
    },
+   "kind": "SidecarDataplane",
    "attachments": [
     {
      "type": "inbound",
@@ -19,6 +20,7 @@
     "mesh": "default",
     "name": "redis-1"
    },
+   "kind": "SidecarDataplane",
    "attachments": [
     {
      "type": "inbound",

--- a/pkg/api-server/testdata/inspect_circuit-breaker.json
+++ b/pkg/api-server/testdata/inspect_circuit-breaker.json
@@ -6,6 +6,7 @@
     "mesh": "mesh-1",
     "name": "backend-1"
    },
+   "kind": "SidecarDataplane",
    "attachments": [
     {
      "type": "service",
@@ -24,6 +25,7 @@
     "mesh": "mesh-1",
     "name": "redis-1"
    },
+   "kind": "SidecarDataplane",
    "attachments": [
     {
      "type": "service",

--- a/pkg/api-server/testdata/inspect_circuit-breaker.json
+++ b/pkg/api-server/testdata/inspect_circuit-breaker.json
@@ -2,11 +2,11 @@
  "total": 2,
  "items": [
   {
+   "kind": "SidecarDataplane",
    "dataplane": {
     "mesh": "mesh-1",
     "name": "backend-1"
    },
-   "kind": "SidecarDataplane",
    "attachments": [
     {
      "type": "service",
@@ -21,11 +21,11 @@
    ]
   },
   {
+   "kind": "SidecarDataplane",
    "dataplane": {
     "mesh": "mesh-1",
     "name": "redis-1"
    },
-   "kind": "SidecarDataplane",
    "attachments": [
     {
      "type": "service",

--- a/pkg/api-server/testdata/inspect_dataplane.json
+++ b/pkg/api-server/testdata/inspect_dataplane.json
@@ -1,6 +1,6 @@
 {
- "total": 6,
  "kind": "SidecarDataplane",
+ "total": 6,
  "items": [
   {
    "type": "inbound",

--- a/pkg/api-server/testdata/inspect_dataplane_empty-response.json
+++ b/pkg/api-server/testdata/inspect_dataplane_empty-response.json
@@ -1,5 +1,5 @@
 {
- "total": 0,
  "kind": "SidecarDataplane",
+ "total": 0,
  "items": []
 }

--- a/pkg/api-server/testdata/inspect_fault-injection.json
+++ b/pkg/api-server/testdata/inspect_fault-injection.json
@@ -6,6 +6,7 @@
     "mesh": "mesh-1",
     "name": "backend-redis-1"
    },
+   "kind": "SidecarDataplane",
    "attachments": [
     {
      "type": "inbound",
@@ -24,6 +25,7 @@
     "mesh": "mesh-1",
     "name": "gateway-1"
    },
+   "kind": "SidecarDataplane",
    "attachments": [
     {
      "type": "inbound",

--- a/pkg/api-server/testdata/inspect_fault-injection.json
+++ b/pkg/api-server/testdata/inspect_fault-injection.json
@@ -2,11 +2,11 @@
  "total": 2,
  "items": [
   {
+   "kind": "SidecarDataplane",
    "dataplane": {
     "mesh": "mesh-1",
     "name": "backend-redis-1"
    },
-   "kind": "SidecarDataplane",
    "attachments": [
     {
      "type": "inbound",
@@ -21,11 +21,11 @@
    ]
   },
   {
+   "kind": "SidecarDataplane",
    "dataplane": {
     "mesh": "mesh-1",
     "name": "gateway-1"
    },
-   "kind": "SidecarDataplane",
    "attachments": [
     {
      "type": "inbound",

--- a/pkg/api-server/testdata/inspect_health-check.json
+++ b/pkg/api-server/testdata/inspect_health-check.json
@@ -6,6 +6,7 @@
     "mesh": "mesh-1",
     "name": "backend-1"
    },
+   "kind": "SidecarDataplane",
    "attachments": [
     {
      "type": "service",
@@ -24,6 +25,7 @@
     "mesh": "mesh-1",
     "name": "redis-1"
    },
+   "kind": "SidecarDataplane",
    "attachments": [
     {
      "type": "service",

--- a/pkg/api-server/testdata/inspect_health-check.json
+++ b/pkg/api-server/testdata/inspect_health-check.json
@@ -2,11 +2,11 @@
  "total": 2,
  "items": [
   {
+   "kind": "SidecarDataplane",
    "dataplane": {
     "mesh": "mesh-1",
     "name": "backend-1"
    },
-   "kind": "SidecarDataplane",
    "attachments": [
     {
      "type": "service",
@@ -21,11 +21,11 @@
    ]
   },
   {
+   "kind": "SidecarDataplane",
    "dataplane": {
     "mesh": "mesh-1",
     "name": "redis-1"
    },
-   "kind": "SidecarDataplane",
    "attachments": [
     {
      "type": "service",

--- a/pkg/api-server/testdata/inspect_proxytemplate.json
+++ b/pkg/api-server/testdata/inspect_proxytemplate.json
@@ -2,11 +2,11 @@
  "total": 3,
  "items": [
   {
+   "kind": "SidecarDataplane",
    "dataplane": {
     "mesh": "mesh-1",
     "name": "backend-1"
    },
-   "kind": "SidecarDataplane",
    "attachments": [
     {
      "type": "dataplane",
@@ -16,11 +16,11 @@
    ]
   },
   {
+   "kind": "SidecarDataplane",
    "dataplane": {
     "mesh": "mesh-1",
     "name": "redis-1"
    },
-   "kind": "SidecarDataplane",
    "attachments": [
     {
      "type": "dataplane",
@@ -30,11 +30,11 @@
    ]
   },
   {
+   "kind": "SidecarDataplane",
    "dataplane": {
     "mesh": "mesh-1",
     "name": "web-1"
    },
-   "kind": "SidecarDataplane",
    "attachments": [
     {
      "type": "dataplane",

--- a/pkg/api-server/testdata/inspect_proxytemplate.json
+++ b/pkg/api-server/testdata/inspect_proxytemplate.json
@@ -6,6 +6,7 @@
     "mesh": "mesh-1",
     "name": "backend-1"
    },
+   "kind": "SidecarDataplane",
    "attachments": [
     {
      "type": "dataplane",
@@ -19,6 +20,7 @@
     "mesh": "mesh-1",
     "name": "redis-1"
    },
+   "kind": "SidecarDataplane",
    "attachments": [
     {
      "type": "dataplane",
@@ -32,6 +34,7 @@
     "mesh": "mesh-1",
     "name": "web-1"
    },
+   "kind": "SidecarDataplane",
    "attachments": [
     {
      "type": "dataplane",

--- a/pkg/api-server/testdata/inspect_rate-limit.json
+++ b/pkg/api-server/testdata/inspect_rate-limit.json
@@ -2,11 +2,11 @@
  "total": 1,
  "items": [
   {
+   "kind": "SidecarDataplane",
    "dataplane": {
     "mesh": "mesh-1",
     "name": "gateway-1"
    },
-   "kind": "SidecarDataplane",
    "attachments": [
     {
      "type": "inbound",

--- a/pkg/api-server/testdata/inspect_rate-limit.json
+++ b/pkg/api-server/testdata/inspect_rate-limit.json
@@ -6,6 +6,7 @@
     "mesh": "mesh-1",
     "name": "gateway-1"
    },
+   "kind": "SidecarDataplane",
    "attachments": [
     {
      "type": "inbound",

--- a/pkg/api-server/testdata/inspect_retry.json
+++ b/pkg/api-server/testdata/inspect_retry.json
@@ -6,6 +6,7 @@
     "mesh": "mesh-1",
     "name": "backend-1"
    },
+   "kind": "SidecarDataplane",
    "attachments": [
     {
      "type": "service",
@@ -24,6 +25,7 @@
     "mesh": "mesh-1",
     "name": "redis-1"
    },
+   "kind": "SidecarDataplane",
    "attachments": [
     {
      "type": "service",

--- a/pkg/api-server/testdata/inspect_retry.json
+++ b/pkg/api-server/testdata/inspect_retry.json
@@ -2,6 +2,7 @@
  "total": 3,
  "items": [
   {
+   "kind": "GatewayDataplane",
    "dataplane": {
     "mesh": "mesh-1",
     "name": "meshgateway-1"
@@ -30,15 +31,14 @@
       }
      ]
     }
-   ],
-   "kind": "GatewayDataplane"
+   ]
   },
   {
+   "kind": "SidecarDataplane",
    "dataplane": {
     "mesh": "mesh-1",
     "name": "backend-1"
    },
-   "kind": "SidecarDataplane",
    "attachments": [
     {
      "type": "service",
@@ -53,11 +53,11 @@
    ]
   },
   {
+   "kind": "SidecarDataplane",
    "dataplane": {
     "mesh": "mesh-1",
     "name": "redis-1"
    },
-   "kind": "SidecarDataplane",
    "attachments": [
     {
      "type": "service",

--- a/pkg/api-server/testdata/inspect_retry.json
+++ b/pkg/api-server/testdata/inspect_retry.json
@@ -1,6 +1,38 @@
 {
- "total": 2,
+ "total": 3,
  "items": [
+  {
+   "dataplane": {
+    "mesh": "mesh-1",
+    "name": "meshgateway-1"
+   },
+   "gateway": {
+    "mesh": "mesh-1",
+    "name": "gateway"
+   },
+   "listeners": [
+    {
+     "port": 80,
+     "protocol": "HTTP",
+     "hosts": [
+      {
+       "hostName": "*",
+       "routes": [
+        {
+         "route": "route-1",
+         "destinations": [
+          {
+           "kuma.io/service": "redis"
+          }
+         ]
+        }
+       ]
+      }
+     ]
+    }
+   ],
+   "kind": "GatewayDataplane"
+  },
   {
    "dataplane": {
     "mesh": "mesh-1",

--- a/pkg/api-server/testdata/inspect_timeout.json
+++ b/pkg/api-server/testdata/inspect_timeout.json
@@ -2,11 +2,11 @@
  "total": 2,
  "items": [
   {
+   "kind": "SidecarDataplane",
    "dataplane": {
     "mesh": "mesh-1",
     "name": "backend-1"
    },
-   "kind": "SidecarDataplane",
    "attachments": [
     {
      "type": "outbound",
@@ -21,11 +21,11 @@
    ]
   },
   {
+   "kind": "SidecarDataplane",
    "dataplane": {
     "mesh": "mesh-1",
     "name": "redis-1"
    },
-   "kind": "SidecarDataplane",
    "attachments": [
     {
      "type": "outbound",

--- a/pkg/api-server/testdata/inspect_timeout.json
+++ b/pkg/api-server/testdata/inspect_timeout.json
@@ -6,6 +6,7 @@
     "mesh": "mesh-1",
     "name": "backend-1"
    },
+   "kind": "SidecarDataplane",
    "attachments": [
     {
      "type": "outbound",
@@ -24,6 +25,7 @@
     "mesh": "mesh-1",
     "name": "redis-1"
    },
+   "kind": "SidecarDataplane",
    "attachments": [
     {
      "type": "outbound",

--- a/pkg/api-server/testdata/inspect_traffic-log.json
+++ b/pkg/api-server/testdata/inspect_traffic-log.json
@@ -6,6 +6,7 @@
     "mesh": "mesh-1",
     "name": "backend-1"
    },
+   "kind": "SidecarDataplane",
    "attachments": [
     {
      "type": "service",
@@ -24,6 +25,7 @@
     "mesh": "mesh-1",
     "name": "redis-1"
    },
+   "kind": "SidecarDataplane",
    "attachments": [
     {
      "type": "service",

--- a/pkg/api-server/testdata/inspect_traffic-log.json
+++ b/pkg/api-server/testdata/inspect_traffic-log.json
@@ -2,11 +2,11 @@
  "total": 2,
  "items": [
   {
+   "kind": "SidecarDataplane",
    "dataplane": {
     "mesh": "mesh-1",
     "name": "backend-1"
    },
-   "kind": "SidecarDataplane",
    "attachments": [
     {
      "type": "service",
@@ -21,11 +21,11 @@
    ]
   },
   {
+   "kind": "SidecarDataplane",
    "dataplane": {
     "mesh": "mesh-1",
     "name": "redis-1"
    },
-   "kind": "SidecarDataplane",
    "attachments": [
     {
      "type": "service",

--- a/pkg/api-server/testdata/inspect_traffic-permission.json
+++ b/pkg/api-server/testdata/inspect_traffic-permission.json
@@ -6,6 +6,7 @@
     "mesh": "default",
     "name": "backend-1"
    },
+   "kind": "SidecarDataplane",
    "attachments": [
     {
      "type": "inbound",
@@ -19,6 +20,7 @@
     "mesh": "default",
     "name": "redis-1"
    },
+   "kind": "SidecarDataplane",
    "attachments": [
     {
      "type": "inbound",
@@ -32,6 +34,7 @@
     "mesh": "default",
     "name": "gateway-1"
    },
+   "kind": "SidecarDataplane",
    "attachments": [
     {
      "type": "inbound",

--- a/pkg/api-server/testdata/inspect_traffic-permission.json
+++ b/pkg/api-server/testdata/inspect_traffic-permission.json
@@ -2,11 +2,11 @@
  "total": 3,
  "items": [
   {
+   "kind": "SidecarDataplane",
    "dataplane": {
     "mesh": "default",
     "name": "backend-1"
    },
-   "kind": "SidecarDataplane",
    "attachments": [
     {
      "type": "inbound",
@@ -16,11 +16,11 @@
    ]
   },
   {
+   "kind": "SidecarDataplane",
    "dataplane": {
     "mesh": "default",
     "name": "redis-1"
    },
-   "kind": "SidecarDataplane",
    "attachments": [
     {
      "type": "inbound",
@@ -30,11 +30,11 @@
    ]
   },
   {
+   "kind": "SidecarDataplane",
    "dataplane": {
     "mesh": "default",
     "name": "gateway-1"
    },
-   "kind": "SidecarDataplane",
    "attachments": [
     {
      "type": "inbound",

--- a/pkg/api-server/testdata/inspect_traffic-route.json
+++ b/pkg/api-server/testdata/inspect_traffic-route.json
@@ -2,11 +2,11 @@
  "total": 2,
  "items": [
   {
+   "kind": "SidecarDataplane",
    "dataplane": {
     "mesh": "mesh-1",
     "name": "backend-1"
    },
-   "kind": "SidecarDataplane",
    "attachments": [
     {
      "type": "outbound",
@@ -21,11 +21,11 @@
    ]
   },
   {
+   "kind": "SidecarDataplane",
    "dataplane": {
     "mesh": "mesh-1",
     "name": "redis-1"
    },
-   "kind": "SidecarDataplane",
    "attachments": [
     {
      "type": "outbound",

--- a/pkg/api-server/testdata/inspect_traffic-route.json
+++ b/pkg/api-server/testdata/inspect_traffic-route.json
@@ -6,6 +6,7 @@
     "mesh": "mesh-1",
     "name": "backend-1"
    },
+   "kind": "SidecarDataplane",
    "attachments": [
     {
      "type": "outbound",
@@ -24,6 +25,7 @@
     "mesh": "mesh-1",
     "name": "redis-1"
    },
+   "kind": "SidecarDataplane",
    "attachments": [
     {
      "type": "outbound",

--- a/pkg/api-server/testdata/inspect_traffic-trace.json
+++ b/pkg/api-server/testdata/inspect_traffic-trace.json
@@ -1,6 +1,17 @@
 {
- "total": 3,
+ "total": 4,
  "items": [
+  {
+   "dataplane": {
+    "mesh": "mesh-1",
+    "name": "meshgateway-1"
+   },
+   "gateway": {
+    "mesh": "mesh-1",
+    "name": "meshgateway"
+   },
+   "kind": "GatewayDataplane"
+  },
   {
    "dataplane": {
     "mesh": "mesh-1",

--- a/pkg/api-server/testdata/inspect_traffic-trace.json
+++ b/pkg/api-server/testdata/inspect_traffic-trace.json
@@ -2,6 +2,7 @@
  "total": 4,
  "items": [
   {
+   "kind": "GatewayDataplane",
    "dataplane": {
     "mesh": "mesh-1",
     "name": "meshgateway-1"
@@ -9,15 +10,14 @@
    "gateway": {
     "mesh": "mesh-1",
     "name": "meshgateway"
-   },
-   "kind": "GatewayDataplane"
+   }
   },
   {
+   "kind": "SidecarDataplane",
    "dataplane": {
     "mesh": "mesh-1",
     "name": "backend-1"
    },
-   "kind": "SidecarDataplane",
    "attachments": [
     {
      "type": "dataplane",
@@ -27,11 +27,11 @@
    ]
   },
   {
+   "kind": "SidecarDataplane",
    "dataplane": {
     "mesh": "mesh-1",
     "name": "redis-1"
    },
-   "kind": "SidecarDataplane",
    "attachments": [
     {
      "type": "dataplane",
@@ -41,11 +41,11 @@
    ]
   },
   {
+   "kind": "SidecarDataplane",
    "dataplane": {
     "mesh": "mesh-1",
     "name": "web-1"
    },
-   "kind": "SidecarDataplane",
    "attachments": [
     {
      "type": "dataplane",

--- a/pkg/api-server/testdata/inspect_traffic-trace.json
+++ b/pkg/api-server/testdata/inspect_traffic-trace.json
@@ -6,6 +6,7 @@
     "mesh": "mesh-1",
     "name": "backend-1"
    },
+   "kind": "SidecarDataplane",
    "attachments": [
     {
      "type": "dataplane",
@@ -19,6 +20,7 @@
     "mesh": "mesh-1",
     "name": "redis-1"
    },
+   "kind": "SidecarDataplane",
    "attachments": [
     {
      "type": "dataplane",
@@ -32,6 +34,7 @@
     "mesh": "mesh-1",
     "name": "web-1"
    },
+   "kind": "SidecarDataplane",
    "attachments": [
     {
      "type": "dataplane",

--- a/pkg/api-server/types/gateway.go
+++ b/pkg/api-server/types/gateway.go
@@ -42,3 +42,37 @@ func NewGatewayDataplaneInspectResult() GatewayDataplaneInspectResult {
 		Listeners: []GatewayListenerInspectEntry{},
 	}
 }
+
+type PolicyInspectGatewayRouteEntry struct {
+	Route        string       `json:"route"`
+	Destinations []envoy.Tags `json:"destinations"`
+}
+
+type PolicyInspectGatewayHostEntry struct {
+	HostName string                           `json:"hostName"`
+	Routes   []PolicyInspectGatewayRouteEntry `json:"routes"`
+}
+
+type PolicyInspectGatewayListenerEntry struct {
+	Port     uint32                          `json:"port"`
+	Protocol string                          `json:"protocol"`
+	Hosts    []PolicyInspectGatewayHostEntry `json:"hosts"`
+}
+
+type PolicyInspectGatewayEntry struct {
+	DataplaneKey ResourceKeyEntry                    `json:"dataplane"`
+	Gateway      ResourceKeyEntry                    `json:"gateway,omitempty"`
+	Listeners    []PolicyInspectGatewayListenerEntry `json:"listeners,omitempty"`
+	Kind         string                              `json:"kind"`
+}
+
+func (*PolicyInspectGatewayEntry) policyInspectEntry() {
+}
+
+func NewPolicyInspectGatewayEntry(key ResourceKeyEntry, gateway ResourceKeyEntry) PolicyInspectGatewayEntry {
+	return PolicyInspectGatewayEntry{
+		DataplaneKey: key,
+		Gateway:      gateway,
+		Kind:         "GatewayDataplane",
+	}
+}

--- a/pkg/api-server/types/gateway.go
+++ b/pkg/api-server/types/gateway.go
@@ -30,15 +30,16 @@ type GatewayListenerInspectEntry struct {
 }
 
 type GatewayDataplaneInspectResult struct {
-	Kind      string                        `json:"kind"`
 	Gateway   ResourceKeyEntry              `json:"gateway"`
 	Listeners []GatewayListenerInspectEntry `json:"listeners"`
 	Policies  PolicyMap                     `json:"policies,omitempty"`
 }
 
+func (*GatewayDataplaneInspectResult) dataplaneInspectEntry() {
+}
+
 func NewGatewayDataplaneInspectResult() GatewayDataplaneInspectResult {
 	return GatewayDataplaneInspectResult{
-		Kind:      "GatewayDataplane",
 		Listeners: []GatewayListenerInspectEntry{},
 	}
 }
@@ -63,7 +64,6 @@ type PolicyInspectGatewayEntry struct {
 	DataplaneKey ResourceKeyEntry                    `json:"dataplane"`
 	Gateway      ResourceKeyEntry                    `json:"gateway,omitempty"`
 	Listeners    []PolicyInspectGatewayListenerEntry `json:"listeners,omitempty"`
-	Kind         string                              `json:"kind"`
 }
 
 func (*PolicyInspectGatewayEntry) policyInspectEntry() {
@@ -73,6 +73,5 @@ func NewPolicyInspectGatewayEntry(key ResourceKeyEntry, gateway ResourceKeyEntry
 	return PolicyInspectGatewayEntry{
 		DataplaneKey: key,
 		Gateway:      gateway,
-		Kind:         "GatewayDataplane",
 	}
 }

--- a/pkg/api-server/types/inspect.go
+++ b/pkg/api-server/types/inspect.go
@@ -46,7 +46,9 @@ func (w *PolicyInspectEntry) UnmarshalJSON(data []byte) error {
 	}
 	var entry PolicyInspectEntryKind
 	switch i.Kind {
-	case SidecarDataplane:
+	// We treat a non-kinded entry as a SidecarDataplane for backwards
+	// compatibility
+	case SidecarDataplane, "":
 		entry = &PolicyInspectSidecarEntry{}
 	case GatewayDataplane:
 		entry = &PolicyInspectGatewayEntry{}

--- a/pkg/api-server/types/inspect.go
+++ b/pkg/api-server/types/inspect.go
@@ -16,20 +16,42 @@ type ResourceKeyEntry struct {
 	Name string `json:"name"`
 }
 
-type PolicyInspectEntry struct {
+func ResourceKeyEntryFromModelKey(key core_model.ResourceKey) ResourceKeyEntry {
+	return ResourceKeyEntry{
+		Mesh: key.Mesh,
+		Name: key.Name,
+	}
+}
+
+type PolicyInspectEntry interface {
+	policyInspectEntry()
+}
+
+type PolicyInspectSidecarEntry struct {
 	DataplaneKey ResourceKeyEntry  `json:"dataplane"`
+	Kind         string            `json:"kind"`
 	Attachments  []AttachmentEntry `json:"attachments"`
 }
 
+func (*PolicyInspectSidecarEntry) policyInspectEntry() {
+}
+
+func NewPolicyInspectSidecarEntry(key ResourceKeyEntry) PolicyInspectSidecarEntry {
+	return PolicyInspectSidecarEntry{
+		DataplaneKey: key,
+		Kind:         "SidecarDataplane",
+	}
+}
+
 type PolicyInspectEntryList struct {
-	Total uint32                `json:"total"`
-	Items []*PolicyInspectEntry `json:"items"`
+	Total uint32               `json:"total"`
+	Items []PolicyInspectEntry `json:"items"`
 }
 
 func NewPolicyInspectEntryList() *PolicyInspectEntryList {
 	return &PolicyInspectEntryList{
 		Total: 0,
-		Items: []*PolicyInspectEntry{},
+		Items: []PolicyInspectEntry{},
 	}
 }
 

--- a/pkg/test/matchers/golden.go
+++ b/pkg/test/matchers/golden.go
@@ -56,7 +56,7 @@ func (g *GoldenYAMLMatcher) Match(actual interface{}) (success bool, err error) 
 		return false, err
 	}
 	if golden.UpdateGoldenFiles() {
-		if actualContent[len(actualContent)-1] != '\n' {
+		if len(actualContent) > 0 && actualContent[len(actualContent)-1] != '\n' {
 			actualContent += "\n"
 		}
 		err := os.WriteFile(g.GoldenFilePath, []byte(actualContent), 0644)


### PR DESCRIPTION
### Summary

This does not add `kumactl` support yet, just adds builtin gateway `Dataplanes` to `<policy-type>/<policy>/dataplanes` and adds some tests for the current behavior (`kumactl` ignoring gateway dataplanes)

Note:
For the "applies to entire Gateway Dataplane" policies (`TrafficLog`, `TrafficTrace`) we could either return _all_ the listeners and routes or just omit the `listeners` field (how this PR does it)...

~Blocked by #3916~

Part of https://github.com/kumahq/kuma/issues/3720