### PR TITLE
ci(*): disable IPV6 and old K8S test for PR

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -974,6 +974,8 @@ workflows:
             - build
             - check
       - e2e:
+          # Avoids running expensive workflow on PRs
+          <<: *work_branch_workflow_filter
           name: test/e2e-ipv6
           requires:
             - build
@@ -981,6 +983,8 @@ workflows:
           # custom parameters
           ipv6: true
       - e2e:
+          # Avoids running expensive workflow on PRs
+          <<: *work_branch_workflow_filter
           name: test/e2e-ipv4-oldk8s
           k3sVersion: v1.19.16-k3s1
           requires:


### PR DESCRIPTION
### Summary

To save some CI credits we will skip IPV6 and old K8S tests for PRs

### Issues resolved

No issues reported.

### Documentation

No docs.

### Testing

- [ ] Unit tests
- [ ] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes

### Backwards compatibility

~- [ ] Update [`UPGRADE.md`](/UPGRADE.md) with any steps users will need to take when upgrading.~
~- [ ] Add `backport-to-stable` label if the code follows our [backporting policy](/CONTRIBUTING.md#backporting)~
