### PR TITLE
fix(kuma-cp): guard the nil version in metadata

### DIFF
--- a/pkg/core/xds/metadata_test.go
+++ b/pkg/core/xds/metadata_test.go
@@ -55,6 +55,28 @@ var _ = Describe("DataplaneMetadataFromXdsMetadata", func() {
 				EmptyDNSPort: 8001,
 			},
 		}),
+		Entry("should ignore dependencies version provided through metadata if version is not set at all", testCase{
+			node: &structpb.Struct{
+				Fields: map[string]*structpb.Value{
+					"dynamicMetadata": {
+						Kind: &structpb.Value_StructValue{
+							StructValue: &structpb.Struct{
+								Fields: map[string]*structpb.Value{
+									"version.dependencies.coredns": {
+										Kind: &structpb.Value_StringValue{
+											StringValue: "8000",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: xds.DataplaneMetadata{
+				DynamicMetadata: map[string]string{},
+			},
+		}),
 	)
 
 	It("should parse version", func() { // this has to be separate test because Equal does not work on proto


### PR DESCRIPTION
### Summary

Guard the nil version.dependencies.

I went through code a couple of times and it seems that the only place where we can get a nil panic.

### Issues resolved

Fix #3968

### Documentation

No docs.

### Testing

- [ ] Unit tests
- [ ] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes

### Backwards compatibility

~- [ ] Update [`UPGRADE.md`](/UPGRADE.md) with any steps users will need to take when upgrading.~
- [X] Add `backport-to-stable` label if the code follows our [backporting policy](/CONTRIBUTING.md#backporting)
