### PR TITLE
refactor(core/resources/model): use global registry to unmarshal rest.Resource

### DIFF
--- a/app/kumactl/cmd/inspect/inspect_dataplane_test.go
+++ b/app/kumactl/cmd/inspect/inspect_dataplane_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/kumahq/kuma/app/kumactl/cmd"
 	"github.com/kumahq/kuma/app/kumactl/pkg/resources"
 	api_server_types "github.com/kumahq/kuma/pkg/api-server/types"
-	"github.com/kumahq/kuma/pkg/core/resources/registry"
 	test_kumactl "github.com/kumahq/kuma/pkg/test/kumactl"
 	"github.com/kumahq/kuma/pkg/test/matchers"
 	util_http "github.com/kumahq/kuma/pkg/util/http"
@@ -46,13 +45,11 @@ var _ = Describe("kumactl inspect dataplane", func() {
 		rawResponse, err := os.ReadFile(path.Join("testdata", "inspect-dataplane.server-response.json"))
 		Expect(err).ToNot(HaveOccurred())
 
-		receiver := &api_server_types.DataplaneInspectEntryListReceiver{
-			NewResource: registry.Global().NewObject,
-		}
-		Expect(json.Unmarshal(rawResponse, receiver)).To(Succeed())
+		list := api_server_types.DataplaneInspectEntryList{}
+		Expect(json.Unmarshal(rawResponse, &list)).To(Succeed())
 
 		testClient := &testDataplaneInspectClient{
-			response: &receiver.DataplaneInspectEntryList,
+			response: &list,
 		}
 
 		rootCtx, err := test_kumactl.MakeRootContext(time.Now(), nil)

--- a/app/kumactl/pkg/resources/dataplane_inspect_client.go
+++ b/app/kumactl/pkg/resources/dataplane_inspect_client.go
@@ -10,7 +10,6 @@ import (
 	"github.com/pkg/errors"
 
 	api_server_types "github.com/kumahq/kuma/pkg/api-server/types"
-	"github.com/kumahq/kuma/pkg/core/resources/registry"
 	util_http "github.com/kumahq/kuma/pkg/util/http"
 )
 
@@ -46,11 +45,9 @@ func (h *httpDataplaneInspectClient) InspectPolicies(ctx context.Context, mesh, 
 	if statusCode != 200 {
 		return nil, errors.Errorf("(%d): %s", statusCode, string(b))
 	}
-	receiver := &api_server_types.DataplaneInspectEntryListReceiver{
-		NewResource: registry.Global().NewObject,
-	}
+	receiver := &api_server_types.DataplaneInspectEntryList{}
 	if err := json.Unmarshal(b, receiver); err != nil {
 		return nil, err
 	}
-	return &receiver.DataplaneInspectEntryList, nil
+	return receiver, nil
 }

--- a/pkg/api-server/types/inspect.go
+++ b/pkg/api-server/types/inspect.go
@@ -1,10 +1,6 @@
 package types
 
 import (
-	"encoding/json"
-
-	"github.com/pkg/errors"
-
 	core_model "github.com/kumahq/kuma/pkg/core/resources/model"
 	"github.com/kumahq/kuma/pkg/core/resources/model/rest"
 )
@@ -56,87 +52,4 @@ func NewDataplaneInspectEntryList() *DataplaneInspectEntryList {
 		Kind:  "SidecarDataplane",
 		Items: []*DataplaneInspectEntry{},
 	}
-}
-
-type DataplaneInspectEntryReceiver struct {
-	DataplaneInspectEntry
-	NewResource func(resourceType core_model.ResourceType) (core_model.Resource, error)
-}
-
-var _ json.Unmarshaler = &DataplaneInspectEntryReceiver{}
-
-func (rec *DataplaneInspectEntryReceiver) UnmarshalJSON(bytes []byte) error {
-	if rec.NewResource == nil {
-		return errors.Errorf("NewResource must not be nil")
-	}
-
-	type intermediate struct {
-		Type            string                                        `json:"type"`
-		Name            string                                        `json:"name"`
-		Service         string                                        `json:"service"`
-		MatchedPolicies map[core_model.ResourceType][]json.RawMessage `json:"matchedPolicies"`
-	}
-	inter := &intermediate{}
-
-	if err := json.Unmarshal(bytes, inter); err != nil {
-		return err
-	}
-	rec.Type = inter.Type
-	rec.Name = inter.Name
-	rec.Service = inter.Service
-	rec.MatchedPolicies = map[core_model.ResourceType][]*rest.Resource{}
-
-	for typ, rawList := range inter.MatchedPolicies {
-		for _, rawItem := range rawList {
-			res, err := rec.NewResource(typ)
-			if err != nil {
-				return err
-			}
-			restRes := &rest.Resource{
-				Spec: res.GetSpec(),
-			}
-			if err := json.Unmarshal(rawItem, restRes); err != nil {
-				return err
-			}
-			rec.MatchedPolicies[typ] = append(rec.MatchedPolicies[typ], restRes)
-		}
-	}
-
-	return nil
-}
-
-type DataplaneInspectEntryListReceiver struct {
-	DataplaneInspectEntryList
-	NewResource func(resourceType core_model.ResourceType) (core_model.Resource, error)
-}
-
-var _ json.Unmarshaler = &DataplaneInspectEntryListReceiver{}
-
-func (rec *DataplaneInspectEntryListReceiver) UnmarshalJSON(bytes []byte) error {
-	if rec.NewResource == nil {
-		return errors.Errorf("NewResource must not be nil")
-	}
-
-	type intermediate struct {
-		Total uint32            `json:"total"`
-		Items []json.RawMessage `json:"items"`
-	}
-
-	inter := &intermediate{}
-	if err := json.Unmarshal(bytes, inter); err != nil {
-		return err
-	}
-
-	rec.Total = inter.Total
-	for _, rawItem := range inter.Items {
-		entryReceiver := &DataplaneInspectEntryReceiver{
-			NewResource: rec.NewResource,
-		}
-		if err := json.Unmarshal(rawItem, entryReceiver); err != nil {
-			return err
-		}
-		rec.Items = append(rec.Items, &entryReceiver.DataplaneInspectEntry)
-	}
-
-	return nil
 }

--- a/pkg/api-server/types/inspect_test.go
+++ b/pkg/api-server/types/inspect_test.go
@@ -13,7 +13,6 @@ import (
 	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	"github.com/kumahq/kuma/pkg/core/resources/model"
 	"github.com/kumahq/kuma/pkg/core/resources/model/rest"
-	"github.com/kumahq/kuma/pkg/core/resources/registry"
 	"github.com/kumahq/kuma/pkg/test/kds/samples"
 	. "github.com/kumahq/kuma/pkg/test/matchers"
 	test_model "github.com/kumahq/kuma/pkg/test/resources/model"
@@ -72,18 +71,14 @@ var _ = Describe("Unmarshal DataplaneInspectEntry", func() {
 			bytes, err := ioutil.ReadAll(inputFile)
 			Expect(err).ToNot(HaveOccurred())
 
-			receiver := &types.DataplaneInspectEntryReceiver{
-				NewResource: registry.Global().NewObject,
-			}
-			err = json.Unmarshal(bytes, receiver)
+			entry := &types.DataplaneInspectEntry{}
+			err = json.Unmarshal(bytes, entry)
 			Expect(err).ToNot(HaveOccurred())
 
-			unmarshaledInspectEntry := receiver.DataplaneInspectEntry
-
-			Expect(unmarshaledInspectEntry.Name).To(Equal(given.output.Name))
-			Expect(unmarshaledInspectEntry.Type).To(Equal(given.output.Type))
-			Expect(unmarshaledInspectEntry.MatchedPolicies).To(HaveLen(len(given.output.MatchedPolicies)))
-			for resType, mp := range unmarshaledInspectEntry.MatchedPolicies {
+			Expect(entry.Name).To(Equal(given.output.Name))
+			Expect(entry.Type).To(Equal(given.output.Type))
+			Expect(entry.MatchedPolicies).To(HaveLen(len(given.output.MatchedPolicies)))
+			for resType, mp := range entry.MatchedPolicies {
 				Expect(given.output.MatchedPolicies[resType]).ToNot(BeNil())
 				Expect(mp).To(HaveLen(len(given.output.MatchedPolicies[resType])))
 				for i, item := range mp {
@@ -131,11 +126,8 @@ var _ = Describe("Unmarshal DataplaneInspectEntry", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		// when
-		receiver := &types.DataplaneInspectEntryListReceiver{
-			NewResource: registry.Global().NewObject,
-		}
-		Expect(json.Unmarshal(input, receiver)).To(Succeed())
-		entryList := receiver.DataplaneInspectEntryList
+		entryList := &types.DataplaneInspectEntryList{}
+		Expect(json.Unmarshal(input, entryList)).To(Succeed())
 
 		// then
 		Expect(entryList.Total).To(Equal(uint32(3)))
@@ -149,10 +141,8 @@ var _ = Describe("Unmarshal DataplaneInspectEntry", func() {
 			bytes, err := ioutil.ReadAll(inputFile)
 			Expect(err).ToNot(HaveOccurred())
 
-			receiver := &types.DataplaneInspectEntryReceiver{
-				NewResource: registry.Global().NewObject,
-			}
-			err = json.Unmarshal(bytes, receiver)
+			entry := &types.DataplaneInspectEntry{}
+			err = json.Unmarshal(bytes, entry)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(Equal(given.errMsg))
 		},

--- a/pkg/core/resources/model/rest/resource.go
+++ b/pkg/core/resources/model/rest/resource.go
@@ -9,6 +9,7 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/kumahq/kuma/pkg/core/resources/model"
+	"github.com/kumahq/kuma/pkg/core/resources/registry"
 )
 
 type ResourceMeta struct {
@@ -106,7 +107,11 @@ func (r *Resource) UnmarshalJSON(data []byte) error {
 		return err
 	}
 	if r.Spec == nil {
-		return nil
+		newR, err := registry.Global().NewObject(model.ResourceType(r.Meta.Type))
+		if err != nil {
+			return err
+		}
+		r.Spec = newR.GetSpec()
 	}
 	if err := (&jsonpb.Unmarshaler{AllowUnknownFields: true}).Unmarshal(bytes.NewReader(data), r.Spec); err != nil {
 		return err


### PR DESCRIPTION
### Summary

Not being able to know what `Spec` we want makes decoding JSON very painful (see the deleted helper `struct`s).

This is blocking `kumactl` support for [`dataplanes/<gateway>/policies`](#3916) (#3720)