### PR TITLE
feat(kumactl): add gateway support to inspect dataplane and policy

### DIFF
--- a/app/kumactl/cmd/inspect/inspect_dataplane.go
+++ b/app/kumactl/cmd/inspect/inspect_dataplane.go
@@ -13,14 +13,11 @@ import (
 	core_model "github.com/kumahq/kuma/pkg/core/resources/model"
 )
 
-var dataplaneInspectTemplate = "{{ range .Items }}" +
-	"{{ .AttachmentEntry | FormatAttachment }}:\n" +
-	"{{ range $typ, $policies := .MatchedPolicies }}" +
-	"  {{ $typ }}\n" +
-	"    {{ range $policies }}{{ .Meta.Name }}\n{{ end }}" +
-	"{{ end }}" +
-	"\n" +
-	"{{ end }}"
+var dataplaneInspectTemplate = `{{ range $num, $item := .Items }}{{ .AttachmentEntry | FormatAttachment }}:
+{{ range $typ, $policies := .MatchedPolicies }}  {{ $typ }}
+    {{ range $policies }}{{ .Meta.Name }}
+{{ end }}{{ end }}
+{{ end }}`
 
 func newInspectDataplaneCmd(pctx *cmd.RootContext) *cobra.Command {
 	tmpl, err := template.New("dataplane_inspect").Funcs(template.FuncMap{

--- a/app/kumactl/cmd/inspect/inspect_dataplane_test.go
+++ b/app/kumactl/cmd/inspect/inspect_dataplane_test.go
@@ -23,10 +23,10 @@ import (
 )
 
 type testDataplaneInspectClient struct {
-	response *api_server_types.DataplaneInspectEntryList
+	response api_server_types.DataplaneInspectResponse
 }
 
-func (t *testDataplaneInspectClient) InspectPolicies(ctx context.Context, mesh, name string) (*api_server_types.DataplaneInspectEntryList, error) {
+func (t *testDataplaneInspectClient) InspectPolicies(ctx context.Context, mesh, name string) (api_server_types.DataplaneInspectResponse, error) {
 	return t.response, nil
 }
 
@@ -51,11 +51,11 @@ var _ = Describe("kumactl inspect dataplane", func() {
 			rawResponse, err := os.ReadFile(path.Join("testdata", given.serverOutput))
 			Expect(err).ToNot(HaveOccurred())
 
-			list := api_server_types.DataplaneInspectEntryList{}
-			Expect(json.Unmarshal(rawResponse, &list)).To(Succeed())
+			response := api_server_types.DataplaneInspectResponse{}
+			Expect(json.Unmarshal(rawResponse, &response)).To(Succeed())
 
 			testClient := &testDataplaneInspectClient{
-				response: &list,
+				response: response,
 			}
 
 			rootCtx, err := test_kumactl.MakeRootContext(time.Now(), nil)

--- a/app/kumactl/cmd/inspect/inspect_policy.go
+++ b/app/kumactl/cmd/inspect/inspect_policy.go
@@ -15,19 +15,12 @@ import (
 	core_model "github.com/kumahq/kuma/pkg/core/resources/model"
 )
 
-var policyInspectTemplate = "Affected data plane proxies:\n\n" +
-	"{{ range .Items }}" +
-	"{{ with IsSidecar . }}" +
-	"  {{ .DataplaneKey.Name }}" +
-	"{{ if . | PrintAttachments }}" +
-	":\n" +
-	"{{ range .Attachments }}" +
-	"    {{ . | FormatAttachment }}\n" +
-	"{{ end }}" +
-	"{{ end }}" +
-	"\n" +
-	"{{ end }}" +
-	"{{ end }}"
+var policyInspectTemplate = `Affected data plane proxies:
+
+{{ range .Items }}{{ with IsSidecar . }}  {{ .DataplaneKey.Name }}{{ if . | PrintAttachments }}:
+{{ range .Attachments }}    {{ . | FormatAttachment }}
+{{ end }}{{ end }}
+{{ end }}{{ end }}`
 
 func newInspectPolicyCmd(policyDesc core_model.ResourceTypeDescriptor, pctx *cmd.RootContext) *cobra.Command {
 	tmpl, err := template.New("policy_inspect").Funcs(template.FuncMap{

--- a/app/kumactl/cmd/inspect/inspect_policy.go
+++ b/app/kumactl/cmd/inspect/inspect_policy.go
@@ -9,6 +9,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
+	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	"github.com/kumahq/kuma/app/kumactl/pkg/cmd"
 	api_server_types "github.com/kumahq/kuma/pkg/api-server/types"
 	core_model "github.com/kumahq/kuma/pkg/core/resources/model"
@@ -91,5 +92,17 @@ func attachmentToStr(upperCase bool) func(api_server_types.AttachmentEntry) stri
 		default:
 			return fmt.Sprintf("%s %s(%s)", typeToStr(a.Type), a.Name, a.Service)
 		}
+	}
+}
+
+func tagsToStr(upperCase bool) func(map[string]string) string {
+	return func(destinationTags map[string]string) string {
+		service := destinationTags[mesh_proto.ServiceTag]
+
+		label := "service"
+		if upperCase {
+			label = strings.ToUpper(label)
+		}
+		return fmt.Sprintf("%s %s", label, service)
 	}
 }

--- a/app/kumactl/cmd/inspect/inspect_policy.go
+++ b/app/kumactl/cmd/inspect/inspect_policy.go
@@ -20,6 +20,12 @@ var policyInspectTemplate = `Affected data plane proxies:
 {{ range .Items }}{{ with IsSidecar . }}  {{ .DataplaneKey.Name }}{{ if . | PrintAttachments }}:
 {{ range .Attachments }}    {{ . | FormatAttachment }}
 {{ end }}{{ end }}
+{{ end }}{{ with IsGateway . }}  {{ .Gateway.Name }}:
+{{ range .Listeners }}    listener ({{ .Protocol }}:{{ .Port }}):
+{{ range .Hosts }}      {{ .HostName }}:
+{{ range .Routes }}        {{ .Route }}:
+{{ range .Destinations }}          {{ FormatTags . }}
+{{ end }}{{ end }}{{ end }}{{ end }}
 {{ end }}{{ end }}`
 
 func newInspectPolicyCmd(policyDesc core_model.ResourceTypeDescriptor, pctx *cmd.RootContext) *cobra.Command {
@@ -43,6 +49,7 @@ func newInspectPolicyCmd(policyDesc core_model.ResourceTypeDescriptor, pctx *cmd
 			}
 			return true
 		},
+		"FormatTags": tagsToStr(false),
 	}).Parse(policyInspectTemplate)
 	if err != nil {
 		panic("unable to parse template")

--- a/app/kumactl/cmd/inspect/inspect_policy_test.go
+++ b/app/kumactl/cmd/inspect/inspect_policy_test.go
@@ -86,7 +86,7 @@ var _ = Describe("kumactl inspect POLICY", func() {
 			cmdArgs:            []string{"inspect", "healthcheck", "hc1"},
 		}),
 		Entry("service policy (no kind in response)", testCase{
-			goldenFile:         "inspect-health-check.golden.txt",
+			goldenFile:         "inspect-health-check-1.5.golden.txt",
 			serverResponseFile: "inspect-health-check-1.5.server-response.json",
 			cmdArgs:            []string{"inspect", "healthcheck", "hc1"},
 		}),

--- a/app/kumactl/cmd/inspect/testdata/inspect-gateway-dataplane.golden.txt
+++ b/app/kumactl/cmd/inspect/testdata/inspect-gateway-dataplane.golden.txt
@@ -1,0 +1,17 @@
+GATEWAY:
+  TrafficLog
+    all-traffic
+  TrafficTrace
+    all-traffic
+
+LISTENER (HTTP:80):
+  *:
+    route-1:
+      SERVICE backend:
+        HealthCheck
+          hc-1
+
+      SERVICE redis:
+        Timeout
+          t-1
+

--- a/app/kumactl/cmd/inspect/testdata/inspect-gateway-dataplane.server-response.json
+++ b/app/kumactl/cmd/inspect/testdata/inspect-gateway-dataplane.server-response.json
@@ -97,5 +97,45 @@
     }
    ]
   }
- ]
+ ],
+ "policies": {
+  "TrafficLog": {
+   "type": "TrafficLog",
+   "mesh": "default",
+   "name": "all-traffic",
+   "creationTime": "2022-03-03T22:24:14Z",
+   "modificationTime": "2022-03-03T22:24:14Z",
+   "sources": [
+    {
+     "match": {
+      "kuma.io/service": "*"
+     }
+    }
+   ],
+   "destinations": [
+    {
+     "match": {
+      "kuma.io/service": "*"
+     }
+    }
+   ]
+  },
+  "TrafficTrace": {
+   "type": "TrafficTrace",
+   "mesh": "default",
+   "name": "all-traffic",
+   "creationTime": "2022-03-03T22:25:34Z",
+   "modificationTime": "2022-03-03T22:25:34Z",
+   "selectors": [
+    {
+     "match": {
+      "kuma.io/service": "*"
+     }
+    }
+   ],
+   "conf": {
+    "backend": "go"
+   }
+  }
+ }
 }

--- a/app/kumactl/cmd/inspect/testdata/inspect-health-check-1.5.golden.txt
+++ b/app/kumactl/cmd/inspect/testdata/inspect-health-check-1.5.golden.txt
@@ -1,11 +1,5 @@
 Affected data plane proxies:
 
-  meshgateway:
-    listener (HTTP:80):
-      *:
-        route-1:
-          service redis
-
   web-1:
     service backend
 

--- a/app/kumactl/cmd/inspect/testdata/inspect-health-check-1.5.server-response.json
+++ b/app/kumactl/cmd/inspect/testdata/inspect-health-check-1.5.server-response.json
@@ -2,24 +2,7 @@
   "total": 1,
   "items": [
     {
-      "dataplane": {
-        "mesh": "default",
-        "name": "backend-1"
-      },
-      "attachments": [
-        {
-          "type": "service",
-          "name": "gateway",
-          "service": "gateway"
-        },
-        {
-          "type": "service",
-          "name": "web",
-          "service": "web"
-        }
-      ]
-    },
-    {
+      "kind": "SidecarDataplane",
       "dataplane": {
         "mesh": "default",
         "name": "web-1"
@@ -27,26 +10,27 @@
       "attachments": [
         {
           "type": "service",
-          "name": "gateway",
-          "service": "gateway"
+          "name": "backend",
+          "service": "backend"
         }
       ]
     },
     {
+      "kind": "SidecarDataplane",
       "dataplane": {
         "mesh": "default",
-        "name": "redis-1"
+        "name": "backend-1"
       },
       "attachments": [
         {
           "type": "service",
-          "name": "gateway",
-          "service": "gateway"
+          "name": "redis",
+          "service": "redis"
         },
         {
           "type": "service",
-          "name": "web",
-          "service": "web"
+          "name": "external",
+          "service": "external"
         }
       ]
     }

--- a/app/kumactl/cmd/inspect/testdata/inspect-health-check.server-response.json
+++ b/app/kumactl/cmd/inspect/testdata/inspect-health-check.server-response.json
@@ -9,7 +9,7 @@
       },
       "gateway": {
         "mesh": "mesh-1",
-        "name": "gateway"
+        "name": "meshgateway"
       },
       "listeners": [
         {
@@ -37,32 +37,13 @@
       "kind": "SidecarDataplane",
       "dataplane": {
         "mesh": "default",
-        "name": "backend-1"
-      },
-      "attachments": [
-        {
-          "type": "service",
-          "name": "gateway",
-          "service": "gateway"
-        },
-        {
-          "type": "service",
-          "name": "web",
-          "service": "web"
-        }
-      ]
-    },
-    {
-      "kind": "SidecarDataplane",
-      "dataplane": {
-        "mesh": "default",
         "name": "web-1"
       },
       "attachments": [
         {
           "type": "service",
-          "name": "gateway",
-          "service": "gateway"
+          "name": "backend",
+          "service": "backend"
         }
       ]
     },
@@ -70,18 +51,18 @@
       "kind": "SidecarDataplane",
       "dataplane": {
         "mesh": "default",
-        "name": "redis-1"
+        "name": "backend-1"
       },
       "attachments": [
         {
           "type": "service",
-          "name": "gateway",
-          "service": "gateway"
+          "name": "redis",
+          "service": "redis"
         },
         {
           "type": "service",
-          "name": "web",
-          "service": "web"
+          "name": "external",
+          "service": "external"
         }
       ]
     }

--- a/app/kumactl/pkg/resources/dataplane_inspect_client.go
+++ b/app/kumactl/pkg/resources/dataplane_inspect_client.go
@@ -14,7 +14,7 @@ import (
 )
 
 type DataplaneInspectClient interface {
-	InspectPolicies(ctx context.Context, mesh, name string) (*api_server_types.DataplaneInspectEntryList, error)
+	InspectPolicies(ctx context.Context, mesh, name string) (api_server_types.DataplaneInspectResponse, error)
 }
 
 func NewDataplaneInspectClient(client util_http.Client) DataplaneInspectClient {
@@ -29,25 +29,25 @@ type httpDataplaneInspectClient struct {
 
 var _ DataplaneInspectClient = &httpDataplaneInspectClient{}
 
-func (h *httpDataplaneInspectClient) InspectPolicies(ctx context.Context, mesh, name string) (*api_server_types.DataplaneInspectEntryList, error) {
+func (h *httpDataplaneInspectClient) InspectPolicies(ctx context.Context, mesh, name string) (api_server_types.DataplaneInspectResponse, error) {
 	resUrl, err := url.Parse(fmt.Sprintf("/meshes/%s/dataplanes/%s/policies", mesh, name))
 	if err != nil {
-		return nil, errors.Wrap(err, "could not construct the url")
+		return api_server_types.DataplaneInspectResponse{}, errors.Wrap(err, "could not construct the url")
 	}
 	req, err := http.NewRequest("GET", resUrl.String(), nil)
 	if err != nil {
-		return nil, err
+		return api_server_types.DataplaneInspectResponse{}, err
 	}
 	statusCode, b, err := doRequest(h.Client, ctx, req)
 	if err != nil {
-		return nil, err
+		return api_server_types.DataplaneInspectResponse{}, err
 	}
 	if statusCode != 200 {
-		return nil, errors.Errorf("(%d): %s", statusCode, string(b))
+		return api_server_types.DataplaneInspectResponse{}, errors.Errorf("(%d): %s", statusCode, string(b))
 	}
-	receiver := &api_server_types.DataplaneInspectEntryList{}
-	if err := json.Unmarshal(b, receiver); err != nil {
-		return nil, err
+	response := &api_server_types.DataplaneInspectResponse{}
+	if err := json.Unmarshal(b, &response); err != nil {
+		return api_server_types.DataplaneInspectResponse{}, err
 	}
-	return receiver, nil
+	return *response, nil
 }

--- a/pkg/api-server/types/inspect.go
+++ b/pkg/api-server/types/inspect.go
@@ -155,6 +155,27 @@ func (e DataplaneInspectResponse) MarshalJSON() ([]byte, error) {
 	panic("internal error")
 }
 
+func (w *DataplaneInspectResponse) UnmarshalJSON(data []byte) error {
+	i := KindTag{}
+	if err := json.Unmarshal(data, &i); err != nil {
+		return errors.Wrap(err, `unable to find "kind"`)
+	}
+	var entry DataplaneInspectResponseKind
+	switch i.Kind {
+	case SidecarDataplane, "":
+		entry = &DataplaneInspectEntryList{}
+	case GatewayDataplane:
+		entry = &GatewayDataplaneInspectResult{}
+	default:
+		return errors.Errorf("invalid DataplaneInspectResponse kind %q", i.Kind)
+	}
+	if err := json.Unmarshal(data, entry); err != nil {
+		return errors.Wrapf(err, "unable to parse DataplaneInspectResponse of kind %q", i.Kind)
+	}
+	w.DataplaneInspectResponseKind = entry
+	return nil
+}
+
 type DataplaneInspectEntry struct {
 	AttachmentEntry
 	MatchedPolicies MatchedPolicies `json:"matchedPolicies"`


### PR DESCRIPTION
### Summary

Add builtin gateway `Dataplanes` support to `kumactl inspect <policy>` and `kumactl inspect dataplane`

Ready ~but blocked by #3971 and #3966~

Part of #3720 