### PR TITLE
feat(kuma-cp): provide better message when running with an in-memory database

### DIFF
--- a/pkg/core/tokens/compatibility_test.go
+++ b/pkg/core/tokens/compatibility_test.go
@@ -10,6 +10,7 @@ import (
 	. "github.com/onsi/gomega"
 	"google.golang.org/protobuf/types/known/wrapperspb"
 
+	store_config "github.com/kumahq/kuma/pkg/config/core/resources/store"
 	"github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	"github.com/kumahq/kuma/pkg/core/resources/apis/system"
 	"github.com/kumahq/kuma/pkg/core/resources/manager"
@@ -38,6 +39,7 @@ var _ = Describe("Compatibility with old ASN.1 format", func() {
 		validator = tokens.NewValidator(
 			tokens.NewMeshedSigningKeyAccessor(resManager, TestTokenSigningKeyPrefix, model.DefaultMesh),
 			tokens.NewRevocations(resManager, TokenRevocationsGlobalSecretKey),
+			store_config.MemoryStore,
 		)
 
 		Expect(resManager.Create(ctx, mesh.NewMeshResource(), core_store.CreateByKey(model.DefaultMesh, model.NoMesh))).To(Succeed())

--- a/pkg/core/tokens/issuer_test.go
+++ b/pkg/core/tokens/issuer_test.go
@@ -10,6 +10,7 @@ import (
 	"google.golang.org/protobuf/types/known/wrapperspb"
 
 	system_proto "github.com/kumahq/kuma/api/system/v1alpha1"
+	store_config "github.com/kumahq/kuma/pkg/config/core/resources/store"
 	"github.com/kumahq/kuma/pkg/core"
 	"github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	"github.com/kumahq/kuma/pkg/core/resources/apis/system"
@@ -89,6 +90,7 @@ var _ = Describe("Token issuer", func() {
 			validator = tokens.NewValidator(
 				tokens.NewSigningKeyAccessor(secretManager, TestTokenSigningKeyPrefix),
 				tokens.NewRevocations(secretManager, TokenRevocationsGlobalSecretKey),
+				store_config.MemoryStore,
 			)
 
 			Expect(signingKeyManager.CreateDefaultSigningKey(ctx)).To(Succeed())
@@ -186,6 +188,7 @@ var _ = Describe("Token issuer", func() {
 			validator = tokens.NewValidator(
 				tokens.NewMeshedSigningKeyAccessor(secretManager, TestTokenSigningKeyPrefix, core_model.DefaultMesh),
 				tokens.NewRevocations(secretManager, TokenRevocationsSecretKey(core_model.DefaultMesh)),
+				store_config.MemoryStore,
 			)
 
 			Expect(secretManager.Create(ctx, mesh.NewMeshResource(), core_store.CreateByKey(core_model.DefaultMesh, core_model.NoMesh))).To(Succeed())

--- a/pkg/plugins/authn/api-server/tokens/admin_token_bootstrap_test.go
+++ b/pkg/plugins/authn/api-server/tokens/admin_token_bootstrap_test.go
@@ -7,6 +7,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	kuma_cp "github.com/kumahq/kuma/pkg/config/app/kuma-cp"
+	store_config "github.com/kumahq/kuma/pkg/config/core/resources/store"
 	"github.com/kumahq/kuma/pkg/core/resources/apis/system"
 	"github.com/kumahq/kuma/pkg/core/resources/manager"
 	core_store "github.com/kumahq/kuma/pkg/core/resources/store"
@@ -27,6 +28,7 @@ var _ = Describe("Admin Token Bootstrap", func() {
 			core_tokens.NewValidator(
 				core_tokens.NewSigningKeyAccessor(resManager, issuer.UserTokenSigningKeyPrefix),
 				core_tokens.NewRevocations(resManager, issuer.UserTokenRevocationsGlobalSecretKey),
+				store_config.MemoryStore,
 			),
 		)
 

--- a/pkg/plugins/authn/api-server/tokens/plugin.go
+++ b/pkg/plugins/authn/api-server/tokens/plugin.go
@@ -36,6 +36,7 @@ func (c plugin) NewAuthenticator(context plugins.PluginContext) (authn.Authentic
 		core_tokens.NewValidator(
 			core_tokens.NewSigningKeyAccessor(context.ResourceManager(), issuer.UserTokenSigningKeyPrefix),
 			core_tokens.NewRevocations(context.ResourceManager(), issuer.UserTokenRevocationsGlobalSecretKey),
+			context.Config().Store.Type,
 		),
 	)
 	return UserTokenAuthenticator(validator), nil

--- a/pkg/plugins/authn/api-server/tokens/ws/ws_test.go
+++ b/pkg/plugins/authn/api-server/tokens/ws/ws_test.go
@@ -11,6 +11,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	store_config "github.com/kumahq/kuma/pkg/config/core/resources/store"
 	"github.com/kumahq/kuma/pkg/core/resources/manager"
 	error_types "github.com/kumahq/kuma/pkg/core/rest/errors/types"
 	core_tokens "github.com/kumahq/kuma/pkg/core/tokens"
@@ -42,6 +43,7 @@ var _ = Describe("Auth Tokens WS", func() {
 			core_tokens.NewValidator(
 				core_tokens.NewSigningKeyAccessor(resManager, issuer.UserTokenSigningKeyPrefix),
 				core_tokens.NewRevocations(resManager, issuer.UserTokenRevocationsGlobalSecretKey),
+				store_config.MemoryStore,
 			),
 		)
 

--- a/pkg/plugins/resources/memory/plugin.go
+++ b/pkg/plugins/resources/memory/plugin.go
@@ -3,11 +3,13 @@ package memory
 import (
 	"github.com/pkg/errors"
 
+	"github.com/kumahq/kuma/pkg/core"
 	core_plugins "github.com/kumahq/kuma/pkg/core/plugins"
 	core_store "github.com/kumahq/kuma/pkg/core/resources/store"
 	"github.com/kumahq/kuma/pkg/events"
 )
 
+var log = core.Log.WithName("plugins")
 var _ core_plugins.ResourceStorePlugin = &plugin{}
 
 type plugin struct{}
@@ -17,6 +19,7 @@ func init() {
 }
 
 func (p *plugin) NewResourceStore(pc core_plugins.PluginContext, _ core_plugins.PluginConfig) (core_store.ResourceStore, error) {
+	log.Info("kuma-cp runs with an in-memory database and its state isn't preserved between restarts. Keep in mind that an in-memory database cannot be used with multiple instances of the control plane.")
 	return NewStore(), nil
 }
 

--- a/pkg/tokens/builtin/components.go
+++ b/pkg/tokens/builtin/components.go
@@ -2,6 +2,7 @@ package builtin
 
 import (
 	"github.com/kumahq/kuma/pkg/config/core"
+	store_config "github.com/kumahq/kuma/pkg/config/core/resources/store"
 	"github.com/kumahq/kuma/pkg/core/resources/manager"
 	"github.com/kumahq/kuma/pkg/core/tokens"
 	"github.com/kumahq/kuma/pkg/tokens/builtin/issuer"
@@ -33,25 +34,27 @@ func NewZoneTokenIssuer(resManager manager.ResourceManager) zone.TokenIssuer {
 	)
 }
 
-func NewDataplaneTokenValidator(resManager manager.ResourceManager) issuer.Validator {
+func NewDataplaneTokenValidator(resManager manager.ResourceManager, storeType store_config.StoreType) issuer.Validator {
 	return issuer.NewValidator(func(meshName string) tokens.Validator {
 		return tokens.NewValidator(
 			tokens.NewMeshedSigningKeyAccessor(resManager, issuer.DataplaneTokenSigningKeyPrefix(meshName), meshName),
 			tokens.NewRevocations(resManager, issuer.DataplaneTokenRevocationsSecretKey(meshName)),
+			storeType,
 		)
 	})
 }
 
-func NewZoneIngressTokenValidator(resManager manager.ResourceManager) zoneingress.Validator {
+func NewZoneIngressTokenValidator(resManager manager.ResourceManager, storeType store_config.StoreType) zoneingress.Validator {
 	return zoneingress.NewValidator(
 		tokens.NewValidator(
 			tokens.NewSigningKeyAccessor(resManager, zoneingress.ZoneIngressSigningKeyPrefix),
 			tokens.NewRevocations(resManager, zoneingress.ZoneIngressTokenRevocationsGlobalSecretKey),
+			storeType,
 		),
 	)
 }
 
-func NewZoneTokenValidator(resManager manager.ResourceManager, mode core.CpMode) zone.Validator {
+func NewZoneTokenValidator(resManager manager.ResourceManager, mode core.CpMode, storeType store_config.StoreType) zone.Validator {
 	var signingKeyAccessor tokens.SigningKeyAccessor
 
 	if mode == core.Zone {
@@ -64,6 +67,7 @@ func NewZoneTokenValidator(resManager manager.ResourceManager, mode core.CpMode)
 		tokens.NewValidator(
 			signingKeyAccessor,
 			tokens.NewRevocations(resManager, zone.TokenRevocationsGlobalSecretKey),
+			storeType,
 		),
 	)
 }

--- a/pkg/xds/auth/components/components.go
+++ b/pkg/xds/auth/components/components.go
@@ -23,9 +23,9 @@ func NewKubeAuthenticator(rt core_runtime.Runtime) (auth.Authenticator, error) {
 func NewUniversalAuthenticator(rt core_runtime.Runtime) (auth.Authenticator, error) {
 	config := rt.Config()
 
-	dataplaneValidator := builtin.NewDataplaneTokenValidator(rt.ResourceManager())
-	zoneIngressValidator := builtin.NewZoneIngressTokenValidator(rt.ResourceManager())
-	zoneTokenValidator := builtin.NewZoneTokenValidator(rt.ResourceManager(), config.Mode)
+	dataplaneValidator := builtin.NewDataplaneTokenValidator(rt.ResourceManager(), config.Store.Type)
+	zoneIngressValidator := builtin.NewZoneIngressTokenValidator(rt.ResourceManager(), config.Store.Type)
+	zoneTokenValidator := builtin.NewZoneTokenValidator(rt.ResourceManager(), config.Mode, config.Store.Type)
 
 	return universal_auth.NewAuthenticator(dataplaneValidator, zoneIngressValidator, zoneTokenValidator, config.Multizone.Zone.Name), nil
 }

--- a/pkg/xds/auth/universal/auth_test.go
+++ b/pkg/xds/auth/universal/auth_test.go
@@ -9,7 +9,9 @@ import (
 
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	config_core "github.com/kumahq/kuma/pkg/config/core"
+	store_config "github.com/kumahq/kuma/pkg/config/core/resources/store"
 	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
+	"github.com/kumahq/kuma/pkg/core/resources/apis/system"
 	"github.com/kumahq/kuma/pkg/core/resources/manager"
 	"github.com/kumahq/kuma/pkg/core/resources/model"
 	core_store "github.com/kumahq/kuma/pkg/core/resources/store"
@@ -26,6 +28,7 @@ var _ = Describe("Authentication flow", func() {
 	var issuer builtin_issuer.DataplaneTokenIssuer
 	var authenticator auth.Authenticator
 	var resStore core_store.ResourceStore
+	var resManager manager.ResourceManager
 	var ctx context.Context
 
 	dpRes := core_mesh.DataplaneResource{
@@ -61,15 +64,15 @@ var _ = Describe("Authentication flow", func() {
 	BeforeEach(func() {
 		ctx = context.Background()
 		resStore = memory.NewStore()
-		resManager := manager.NewResourceManager(resStore)
+		resManager = manager.NewResourceManager(resStore)
 
 		Expect(resManager.Create(context.Background(), core_mesh.NewMeshResource(), core_store.CreateByKey("default", model.NoMesh))).To(Succeed())
 		Expect(resManager.Create(context.Background(), core_mesh.NewMeshResource(), core_store.CreateByKey("demo", model.NoMesh))).To(Succeed())
 		Expect(resManager.Create(context.Background(), core_mesh.NewMeshResource(), core_store.CreateByKey("demo-2", model.NoMesh))).To(Succeed())
 
-		dataplaneValidator := builtin.NewDataplaneTokenValidator(resManager)
-		zoneIngressValidator := builtin.NewZoneIngressTokenValidator(resManager)
-		zoneTokenValidator := builtin.NewZoneTokenValidator(resManager, config_core.Global)
+		dataplaneValidator := builtin.NewDataplaneTokenValidator(resManager, store_config.MemoryStore)
+		zoneIngressValidator := builtin.NewZoneIngressTokenValidator(resManager, store_config.MemoryStore)
+		zoneTokenValidator := builtin.NewZoneTokenValidator(resManager, config_core.Global, store_config.MemoryStore)
 		issuer = builtin.NewDataplaneTokenIssuer(resManager)
 		authenticator = universal.NewAuthenticator(dataplaneValidator, zoneIngressValidator, zoneTokenValidator, "zone-1")
 
@@ -157,7 +160,7 @@ var _ = Describe("Authentication flow", func() {
 				Name: "dp-1",
 			},
 			dpRes: &dpRes,
-			err:   "could not parse token: crypto/rsa: verification error",
+			err:   "could not parse token. kuma-cp runs with an in-memory database and its state isn't preserved between restarts. Keep in mind that an in-memory database cannot be used with multiple instances of the control plane: crypto/rsa: verification error",
 		}),
 		Entry("on token with different tags", testCase{
 			id: builtin_issuer.DataplaneIdentity{
@@ -203,7 +206,44 @@ var _ = Describe("Authentication flow", func() {
 		err := authenticator.Authenticate(context.Background(), &dpRes, "this-is-not-valid-jwt-token")
 
 		// then
-		Expect(err).To(MatchError("could not parse token: token contains an invalid number of segments"))
+		Expect(err.Error()).To(ContainSubstring("could not parse token. kuma-cp runs with an in-memory database and its state isn't preserved between restarts." +
+			" Keep in mind that an in-memory database cannot be used with multiple instances of the control plane: token contains an invalid number of segments"))
+	})
+
+	It("should throw an error when signing key used for validation is different than for generation", func() {
+		// when
+		credential, err := issuer.Generate(ctx, builtin_issuer.DataplaneIdentity{
+			Name: "dp-1",
+			Mesh: "default",
+		}, 24*time.Hour)
+
+		// then
+		Expect(err).ToNot(HaveOccurred())
+
+		// when
+		err = authenticator.Authenticate(context.Background(), &dpRes, credential)
+
+		// then
+		Expect(err).ToNot(HaveOccurred())
+
+		// when
+		err = resManager.DeleteAll(context.Background(), &system.SecretResourceList{})
+
+		// then
+		Expect(err).ToNot(HaveOccurred())
+
+		// when
+		signingKeyManager := tokens.NewMeshedSigningKeyManager(resManager, builtin_issuer.DataplaneTokenSigningKeyPrefix("default"), "default")
+
+		// then
+		Expect(signingKeyManager.CreateDefaultSigningKey(ctx)).To(Succeed())
+
+		// when
+		err = authenticator.Authenticate(context.Background(), &dpRes, credential)
+
+		// then
+		Expect(err.Error()).To(ContainSubstring("could not parse token. kuma-cp runs with an in-memory database and its state isn't preserved between restarts." +
+			" Keep in mind that an in-memory database cannot be used with multiple instances of the control plane: crypto/rsa: verification error"))
 	})
 
 	It("should throw an error when signing key is not found", func() {


### PR DESCRIPTION
### Summary

When kuma-cp runs with an in-memory database and an instance gets restarted, dataplanes
cannot be authorized because the private key used to sign dataplane token has changed.
Added log to kuma-cp that during the start with in-memory database inform that state is
not preserved. Also, kuma-cp returns in XDS response information that when running
in-memory database doesn't keep state between restarts.

### Full changelog

* log at the startup message when running with an in-memory database
* return in XDS response that server runs an in-memory database and state is not preserved between restarts

### Issues resolved

Fix #3774 

### Documentation

- 

### Testing

- [X] Unit tests
- [ ] E2E tests
- [X] Manual testing on Universal
- [X] Manual testing on Kubernetes

### Backwards compatibility

- [ ] Update [`UPGRADE.md`](/UPGRADE.md) with any steps users will need to take when upgrading.
- [ ] Add `backport-to-stable` label if the code follows our [backporting policy](/CONTRIBUTING.md#backporting)
