### PR TITLE
chore: pass ARCH for docker release

### DIFF
--- a/tools/releases/docker.sh
+++ b/tools/releases/docker.sh
@@ -13,7 +13,7 @@ ENVOY_VERSION="${ENVOY_VERSION:-1.21.1}"
 function build() {
   for component in ${KUMA_COMPONENTS}; do
     msg "Building $component..."
-    docker build --build-arg KUMA_ROOT="$(pwd)" --build-arg ENVOY_VERSION="${ENVOY_VERSION}" -t "${KUMA_DOCKER_REPO_ORG}/${component}:${KUMA_VERSION}" \
+    docker build --build-arg KUMA_ROOT="$(pwd)" --build-arg ARCH="amd64" --build-arg ENVOY_VERSION="${ENVOY_VERSION}" -t "${KUMA_DOCKER_REPO_ORG}/${component}:${KUMA_VERSION}" \
       -f tools/releases/dockerfiles/Dockerfile."${component}" .
     docker tag "${KUMA_DOCKER_REPO_ORG}/${component}:${KUMA_VERSION}" "${KUMA_DOCKER_REPO_ORG}/${component}:latest"
     msg_green "... done!"


### PR DESCRIPTION
Signed-off-by: Ilya Lobkov <ilya.lobkov@konghq.com>

### Summary

Pass ARCH explicitly for docker release scripts.

### Full changelog

* [Implement ...]
* [Fix ...]

### Issues resolved

Fix #XXX

### Documentation

- [ ] Link to the website [documentation PR](https://github.com/kumahq/kuma-website/pull/XXX)

### Testing

- [ ] Unit tests
- [ ] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes

### Backwards compatibility

- [ ] Update [`UPGRADE.md`](/UPGRADE.md) with any steps users will need to take when upgrading.
- [ ] Add `backport-to-stable` label if the code follows our [backporting policy](/CONTRIBUTING.md#backporting)
