### PR TITLE
perf(kuma-cp): move outbounds from Dataplane to Config

### DIFF
--- a/api/mesh/v1alpha1/dataplane_helpers.go
+++ b/api/mesh/v1alpha1/dataplane_helpers.go
@@ -128,15 +128,15 @@ func (n *Dataplane_Networking) GetInboundInterface(service string) (*InboundInte
 	return nil, errors.Errorf("Dataplane has no Inbound Interface for service %q", service)
 }
 
-func (n *Dataplane_Networking) GetInboundInterfaces() ([]InboundInterface, error) {
+func (n *Dataplane_Networking) GetInboundInterfaces() []InboundInterface {
 	if n == nil {
-		return nil, nil
+		return nil
 	}
 	ifaces := make([]InboundInterface, len(n.Inbound))
 	for i, inbound := range n.Inbound {
 		ifaces[i] = n.ToInboundInterface(inbound)
 	}
-	return ifaces, nil
+	return ifaces
 }
 
 func (n *Dataplane_Networking) ToInboundInterface(inbound *Dataplane_Networking_Inbound) InboundInterface {

--- a/api/mesh/v1alpha1/dataplane_helpers_test.go
+++ b/api/mesh/v1alpha1/dataplane_helpers_test.go
@@ -105,10 +105,8 @@ var _ = Describe("Dataplane_Networking", func() {
 			DescribeTable("should parse valid input values",
 				func(given testCase) {
 					// when
-					ifaces, err := given.input.GetInboundInterfaces()
+					ifaces := given.input.GetInboundInterfaces()
 					// then
-					Expect(err).ToNot(HaveOccurred())
-					// and
 					Expect(ifaces).To(ConsistOf(given.expected))
 				},
 				Entry("nil", testCase{

--- a/pkg/api-server/config_ws_test.go
+++ b/pkg/api-server/config_ws_test.go
@@ -344,7 +344,8 @@ var _ = Describe("Config WS", func() {
             }
           },
           "experimental": {
-            "meshGateway": false
+            "meshGateway": false,
+            "kubeOutboundsAsVIPs": false
           }
         }
 		`, port, cfg.HTTPS.Port)

--- a/pkg/config/app/kuma-cp/config.go
+++ b/pkg/config/app/kuma-cp/config.go
@@ -199,7 +199,8 @@ var DefaultConfig = func() Config {
 		DpServer:    dp_server.DefaultDpServerConfig(),
 		Access:      access.DefaultAccessConfig(),
 		Experimental: ExperimentalConfig{
-			MeshGateway: false,
+			MeshGateway:         false,
+			KubeOutboundsAsVIPs: false,
 		},
 	}
 }
@@ -315,4 +316,7 @@ func DefaultGeneralConfig() *GeneralConfig {
 type ExperimentalConfig struct {
 	// If true, experimental built-in gateway is enabled.
 	MeshGateway bool `yaml:"meshGateway" envconfig:"KUMA_EXPERIMENTAL_MESHGATEWAY"`
+	// If true, instead of embedding kubernetes outbounds into Dataplane object, they are persisted next to VIPs in ConfigMap
+	// This can improve performance, but it should be enabled only after all instances are migrated to version that supports this config
+	KubeOutboundsAsVIPs bool `yaml:"kubeOutboundsAsVIPs" envconfig:"KUMA_EXPERIMENTAL_KUBE_OUTBOUNDS_AS_VIPS"`
 }

--- a/pkg/config/app/kuma-cp/kuma-cp.defaults.yaml
+++ b/pkg/config/app/kuma-cp/kuma-cp.defaults.yaml
@@ -433,3 +433,6 @@ access:
 experimental:
   # If true, experimental built-in gateway is enabled
   meshGateway: false # ENV: KUMA_EXPERIMENTAL_MESHGATEWAY
+  # If true, instead of embedding kubernetes outbounds into Dataplane object, they are persisted next to VIPs in ConfigMap
+  # This can improve performance, but it should be enabled only after all instances are migrated to version that supports this config
+  kubeOutboundsAsVIPs: false # ENV: KUMA_EXPERIMENTAL_KUBE_OUTBOUNDS_AS_VIPS

--- a/pkg/config/loader_test.go
+++ b/pkg/config/loader_test.go
@@ -250,6 +250,7 @@ var _ = Describe("Config loader", func() {
 			Expect(cfg.Access.Static.ViewConfigDump.Groups).To(Equal([]string{"zt-group1", "zt-group2"}))
 
 			Expect(cfg.Experimental.MeshGateway).To(BeTrue())
+			Expect(cfg.Experimental.KubeOutboundsAsVIPs).To(BeTrue())
 		},
 		Entry("from config file", testCase{
 			envVars: map[string]string{},
@@ -465,6 +466,7 @@ access:
       groups: ["zt-group1", "zt-group2"]
 experimental:
   meshGateway: true
+  kubeOutboundsAsVIPs: true
 `,
 		}),
 		Entry("from env variables", testCase{
@@ -612,6 +614,7 @@ experimental:
 				"KUMA_ACCESS_STATIC_GET_CONFIG_DUMP_USERS":                                                 "zt-admin1,zt-admin2",
 				"KUMA_ACCESS_STATIC_GET_CONFIG_DUMP_GROUPS":                                                "zt-group1,zt-group2",
 				"KUMA_EXPERIMENTAL_MESHGATEWAY":                                                            "true",
+				"KUMA_EXPERIMENTAL_KUBE_OUTBOUNDS_AS_VIPS":                                                 "true",
 			},
 			yamlFileConfig: "",
 		}),

--- a/pkg/core/resources/apis/mesh/dataplane_helpers.go
+++ b/pkg/core/resources/apis/mesh/dataplane_helpers.go
@@ -74,11 +74,7 @@ func (d *DataplaneResource) UsesInboundInterface(address net.IP, port uint32) bo
 	if d == nil {
 		return false
 	}
-	ifaces, err := d.Spec.Networking.GetInboundInterfaces()
-	if err != nil {
-		return false
-	}
-	for _, iface := range ifaces {
+	for _, iface := range d.Spec.Networking.GetInboundInterfaces() {
 		// compare against port and IP address of the dataplane
 		if port == iface.DataplanePort && overlap(address, net.ParseIP(iface.DataplaneIP)) {
 			return true

--- a/pkg/dns/vips/interfaces.go
+++ b/pkg/dns/vips/interfaces.go
@@ -9,6 +9,7 @@ type EntryType int
 const (
 	Service EntryType = iota
 	Host
+	KubeHost
 	FullyQualifiedDomain
 )
 
@@ -20,6 +21,8 @@ func (t EntryType) String() string {
 		return "host"
 	case FullyQualifiedDomain:
 		return "fqdn"
+	case KubeHost:
+		return "kubeHost"
 	default:
 		return "undefined"
 	}
@@ -54,6 +57,10 @@ func (e *HostnameEntry) Less(o *HostnameEntry) bool {
 
 func NewHostEntry(host string) HostnameEntry {
 	return HostnameEntry{Host, host}
+}
+
+func NewKubeHostEntry(host string) HostnameEntry {
+	return HostnameEntry{KubeHost, host}
 }
 
 func NewServiceEntry(name string) HostnameEntry {

--- a/pkg/dns/vips/interfaces.go
+++ b/pkg/dns/vips/interfaces.go
@@ -9,7 +9,6 @@ type EntryType int
 const (
 	Service EntryType = iota
 	Host
-	KubeHost
 	FullyQualifiedDomain
 )
 
@@ -21,8 +20,6 @@ func (t EntryType) String() string {
 		return "host"
 	case FullyQualifiedDomain:
 		return "fqdn"
-	case KubeHost:
-		return "kubeHost"
 	default:
 		return "undefined"
 	}
@@ -57,10 +54,6 @@ func (e *HostnameEntry) Less(o *HostnameEntry) bool {
 
 func NewHostEntry(host string) HostnameEntry {
 	return HostnameEntry{Host, host}
-}
-
-func NewKubeHostEntry(host string) HostnameEntry {
-	return HostnameEntry{KubeHost, host}
 }
 
 func NewServiceEntry(name string) HostnameEntry {

--- a/pkg/dns/vips/virtual_outbound.go
+++ b/pkg/dns/vips/virtual_outbound.go
@@ -28,6 +28,7 @@ func (vo *VirtualOutbound) Equal(other *VirtualOutbound) bool {
 const (
 	OriginHost    = "host"
 	OriginService = "service"
+	OriginKube    = "kubernetes"
 )
 
 var OriginVirtualOutbound = func(name string) string { return "virtual-outbound:" + name }

--- a/pkg/dns/vips/virtual_outbound_view.go
+++ b/pkg/dns/vips/virtual_outbound_view.go
@@ -108,7 +108,7 @@ func (vo *VirtualOutboundMeshView) Update(new *VirtualOutboundMeshView) (changes
 }
 
 func (vo *VirtualOutboundMeshView) ReplaceByOrigin(origin string, new *VirtualOutboundMeshView) {
-	for entry, _ := range vo.byHostname {
+	for entry := range vo.byHostname {
 		if len(vo.byHostname[entry].Outbounds) > 0 && vo.byHostname[entry].Outbounds[0].Origin == origin {
 			delete(vo.byHostname, entry)
 		}

--- a/pkg/dns/vips/virtual_outbound_view.go
+++ b/pkg/dns/vips/virtual_outbound_view.go
@@ -2,6 +2,7 @@ package vips
 
 import (
 	"fmt"
+	"net"
 	"sort"
 )
 
@@ -34,7 +35,7 @@ func (vo *VirtualOutboundMeshView) Get(entry HostnameEntry) *VirtualOutbound {
 func (vo *VirtualOutboundMeshView) Add(entry HostnameEntry, outbound OutboundEntry) error {
 	if vo.byHostname[entry] == nil {
 		vo.byHostname[entry] = &VirtualOutbound{Outbounds: []OutboundEntry{outbound}}
-		if entry.Type == KubeHost {
+		if entry.Type == Host && net.ParseIP(entry.Name) != nil {
 			vo.byHostname[entry].Address = entry.Name
 		}
 		return nil
@@ -106,9 +107,9 @@ func (vo *VirtualOutboundMeshView) Update(new *VirtualOutboundMeshView) (changes
 	return
 }
 
-func (vo *VirtualOutboundMeshView) ReplaceByType(entryType EntryType, new *VirtualOutboundMeshView) {
+func (vo *VirtualOutboundMeshView) ReplaceByOrigin(origin string, new *VirtualOutboundMeshView) {
 	for entry, _ := range vo.byHostname {
-		if entry.Type == entryType {
+		if len(vo.byHostname[entry].Outbounds) > 0 && vo.byHostname[entry].Outbounds[0].Origin == origin {
 			delete(vo.byHostname, entry)
 		}
 	}

--- a/pkg/dns/vips/virtual_outbound_view.go
+++ b/pkg/dns/vips/virtual_outbound_view.go
@@ -36,6 +36,7 @@ func (vo *VirtualOutboundMeshView) Add(entry HostnameEntry, outbound OutboundEnt
 	if vo.byHostname[entry] == nil {
 		vo.byHostname[entry] = &VirtualOutbound{Outbounds: []OutboundEntry{outbound}}
 		if entry.Type == Host && net.ParseIP(entry.Name) != nil {
+			// Entry name can be IP in case of providing IP in ExternalService or building VIPs based on ClusterIP/PodIP on Kubernetes
 			vo.byHostname[entry].Address = entry.Name
 		}
 		return nil
@@ -107,14 +108,11 @@ func (vo *VirtualOutboundMeshView) Update(new *VirtualOutboundMeshView) (changes
 	return
 }
 
-func (vo *VirtualOutboundMeshView) ReplaceByOrigin(origin string, new *VirtualOutboundMeshView) {
+func (vo *VirtualOutboundMeshView) DeleteByOrigin(origin string) {
 	for entry := range vo.byHostname {
 		if len(vo.byHostname[entry].Outbounds) > 0 && vo.byHostname[entry].Outbounds[0].Origin == origin {
 			delete(vo.byHostname, entry)
 		}
-	}
-	for entry, outbound := range new.byHostname {
-		vo.byHostname[entry] = outbound
 	}
 }
 

--- a/pkg/dns/vips/virtual_outbound_view.go
+++ b/pkg/dns/vips/virtual_outbound_view.go
@@ -34,6 +34,9 @@ func (vo *VirtualOutboundMeshView) Get(entry HostnameEntry) *VirtualOutbound {
 func (vo *VirtualOutboundMeshView) Add(entry HostnameEntry, outbound OutboundEntry) error {
 	if vo.byHostname[entry] == nil {
 		vo.byHostname[entry] = &VirtualOutbound{Outbounds: []OutboundEntry{outbound}}
+		if entry.Type == KubeHost {
+			vo.byHostname[entry].Address = entry.Name
+		}
 		return nil
 	}
 	for _, existingOutbound := range vo.byHostname[entry].Outbounds {
@@ -101,6 +104,17 @@ func (vo *VirtualOutboundMeshView) Update(new *VirtualOutboundMeshView) (changes
 		return changes[i].Entry.String() < changes[j].Entry.String()
 	})
 	return
+}
+
+func (vo *VirtualOutboundMeshView) ReplaceByType(entryType EntryType, new *VirtualOutboundMeshView) {
+	for entry, _ := range vo.byHostname {
+		if entry.Type == entryType {
+			delete(vo.byHostname, entry)
+		}
+	}
+	for entry, outbound := range new.byHostname {
+		vo.byHostname[entry] = outbound
+	}
 }
 
 type ChangeType string

--- a/pkg/dns/vips_allocator.go
+++ b/pkg/dns/vips_allocator.go
@@ -82,7 +82,7 @@ func (d *VIPsAllocator) CreateOrUpdateVIPConfigs() error {
 	return d.createOrUpdateVIPConfigs(meshes...)
 }
 
-func (d *VIPsAllocator) CreateOrUpdateVIPConfig(mesh string, viewModificator func(*vips.VirtualOutboundMeshView)) error {
+func (d *VIPsAllocator) CreateOrUpdateVIPConfig(mesh string, viewModificator func(*vips.VirtualOutboundMeshView) error) error {
 	meshViews, globalView, err := d.fetchViews()
 	if err != nil {
 		return err
@@ -97,7 +97,9 @@ func (d *VIPsAllocator) CreateOrUpdateVIPConfig(mesh string, viewModificator fun
 	if err != nil {
 		return err
 	}
-	viewModificator(newView)
+	if err := viewModificator(newView); err != nil {
+		return err
+	}
 
 	if err := d.createOrUpdateMeshVIPConfig(mesh, oldView, newView, globalView); err != nil {
 		return err

--- a/pkg/dns/vips_allocator_test.go
+++ b/pkg/dns/vips_allocator_test.go
@@ -59,7 +59,9 @@ var _ = Describe("VIP Allocator", func() {
 	var allocator *dns.VIPsAllocator
 	var r resolver.DNSResolver
 
-	NoModifications := func(view *vips.VirtualOutboundMeshView) {}
+	NoModifications := func(view *vips.VirtualOutboundMeshView) error {
+		return nil
+	}
 
 	BeforeEach(func() {
 		s := memory.NewStore()

--- a/pkg/dns/vips_allocator_test.go
+++ b/pkg/dns/vips_allocator_test.go
@@ -59,6 +59,8 @@ var _ = Describe("VIP Allocator", func() {
 	var allocator *dns.VIPsAllocator
 	var r resolver.DNSResolver
 
+	NoModifications := func(view *vips.VirtualOutboundMeshView) {}
+
 	BeforeEach(func() {
 		s := memory.NewStore()
 		rm = manager.NewResourceManager(s)
@@ -125,7 +127,7 @@ var _ = Describe("VIP Allocator", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		// when
-		err = allocator.CreateOrUpdateVIPConfig("mesh-1")
+		err = allocator.CreateOrUpdateVIPConfig("mesh-1", NoModifications)
 		Expect(err).ToNot(HaveOccurred())
 
 		vipList, err := persistence.GetByMesh("mesh-1")
@@ -148,13 +150,13 @@ var _ = Describe("VIP Allocator", func() {
 		errAllocator, err := dns.NewVIPsAllocator(rm, errConfigManager, true, "240.0.0.0/24", r)
 		Expect(err).ToNot(HaveOccurred())
 
-		err = errAllocator.CreateOrUpdateVIPConfig("mesh-1")
+		err = errAllocator.CreateOrUpdateVIPConfig("mesh-1", NoModifications)
 		Expect(err).ToNot(HaveOccurred())
 
 		err = rm.Create(context.Background(), &mesh.DataplaneResource{Spec: dp("database")}, store.CreateByKey("dp-3", "mesh-1"))
 		Expect(err).ToNot(HaveOccurred())
 
-		err = errAllocator.CreateOrUpdateVIPConfig("mesh-1")
+		err = errAllocator.CreateOrUpdateVIPConfig("mesh-1", NoModifications)
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(Equal("error during update, mesh = mesh-1"))
 	})
@@ -180,11 +182,11 @@ var _ = Describe("VIP Allocator", func() {
 
 	It("should not allocate the same VIPs for different services in multiple meshes", func() {
 		// given VIPs in mesh-1
-		err := allocator.CreateOrUpdateVIPConfig("mesh-1")
+		err := allocator.CreateOrUpdateVIPConfig("mesh-1", NoModifications)
 		Expect(err).ToNot(HaveOccurred())
 
 		// when VIPs from other meshes are created
-		err = allocator.CreateOrUpdateVIPConfig("mesh-2")
+		err = allocator.CreateOrUpdateVIPConfig("mesh-2", NoModifications)
 
 		// then the addresses should not overlap
 		Expect(err).ToNot(HaveOccurred())

--- a/pkg/plugins/runtime/k8s/controllers/configmap_controller.go
+++ b/pkg/plugins/runtime/k8s/controllers/configmap_controller.go
@@ -47,7 +47,12 @@ func (r *ConfigMapReconciler) Reconcile(ctx context.Context, req kube_ctrl.Reque
 
 	r.Log.V(1).Info("updating VIPs", "mesh", mesh)
 
-	if err := r.VIPsAllocator.CreateOrUpdateVIPConfig(mesh); err != nil {
+	kubeHostsView, err := KubeHosts(ctx, r.Client, r.ResourceManager, mesh)
+	if err != nil {
+		return kube_ctrl.Result{}, err
+	}
+
+	if err := r.VIPsAllocator.CreateOrUpdateVIPConfig(mesh, kubeHostsView); err != nil {
 		if store.IsResourceConflict(err) {
 			r.Log.V(1).Info("VIPs were updated in the other place. Retrying")
 			return kube_ctrl.Result{Requeue: true}, nil

--- a/pkg/plugins/runtime/k8s/controllers/kube_hosts_converter.go
+++ b/pkg/plugins/runtime/k8s/controllers/kube_hosts_converter.go
@@ -1,0 +1,72 @@
+package controllers
+
+import (
+	"context"
+
+	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
+	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
+	resources_manager "github.com/kumahq/kuma/pkg/core/resources/manager"
+	core_store "github.com/kumahq/kuma/pkg/core/resources/store"
+	"github.com/kumahq/kuma/pkg/dns/vips"
+	kube_client "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func KubeHosts(
+	ctx context.Context,
+	client kube_client.Client,
+	manager resources_manager.ReadOnlyResourceManager,
+	mesh string,
+) (*vips.VirtualOutboundMeshView, error) {
+	dpps := &core_mesh.DataplaneResourceList{}
+	if err := manager.List(ctx, dpps, core_store.ListByMesh(mesh)); err != nil {
+		return nil, err
+	}
+
+	view := vips.NewEmptyVirtualOutboundView()
+
+	endpoints := endpointsByService(dpps.Items)
+	for _, serviceTag := range endpoints.Services() {
+		service, port, err := k8sService(ctx, serviceTag, client)
+		if err != nil {
+			converterLog.Error(err, "could not get K8S Service for service tag")
+			continue // one invalid Dataplane definition should not break the entire mesh
+		}
+
+		// Do not generate outbounds for service-less
+		if isServiceLess(port) {
+			continue
+		}
+
+		if isHeadlessService(service) {
+			// Generate outbound listeners for every endpoint of services.
+			for _, endpoint := range endpoints[serviceTag] {
+				hostnameEntry := vips.NewKubeHostEntry(endpoint.Address)
+				err := view.Add(hostnameEntry, vips.OutboundEntry{
+					Port:   endpoint.Port,
+					TagSet: map[string]string{
+						mesh_proto.ServiceTag:  serviceTag,
+						mesh_proto.InstanceTag: endpoint.Instance,
+					},
+					Origin: vips.OriginKube,
+				})
+				if err != nil {
+					return nil, err
+				}
+			}
+		} else {
+			// generate outbound based on ClusterIP. Transparent Proxy will work only if DNS name that resolves to ClusterIP is used
+			hostnameEntry := vips.NewKubeHostEntry(service.Spec.ClusterIP)
+			err := view.Add(hostnameEntry, vips.OutboundEntry{
+				Port:   port,
+				TagSet: map[string]string{
+					mesh_proto.ServiceTag:  serviceTag,
+				},
+				Origin: vips.OriginKube,
+			})
+			if err != nil {
+				return nil, err
+			}
+		}
+	}
+	return view, nil
+}

--- a/pkg/plugins/runtime/k8s/controllers/kube_hosts_converter.go
+++ b/pkg/plugins/runtime/k8s/controllers/kube_hosts_converter.go
@@ -40,7 +40,7 @@ func KubeHosts(
 		if isHeadlessService(service) {
 			// Generate outbound listeners for every endpoint of services.
 			for _, endpoint := range endpoints[serviceTag] {
-				hostnameEntry := vips.NewKubeHostEntry(endpoint.Address)
+				hostnameEntry := vips.NewHostEntry(endpoint.Address)
 				err := view.Add(hostnameEntry, vips.OutboundEntry{
 					Port:   endpoint.Port,
 					TagSet: map[string]string{
@@ -55,7 +55,7 @@ func KubeHosts(
 			}
 		} else {
 			// generate outbound based on ClusterIP. Transparent Proxy will work only if DNS name that resolves to ClusterIP is used
-			hostnameEntry := vips.NewKubeHostEntry(service.Spec.ClusterIP)
+			hostnameEntry := vips.NewHostEntry(service.Spec.ClusterIP)
 			err := view.Add(hostnameEntry, vips.OutboundEntry{
 				Port:   port,
 				TagSet: map[string]string{

--- a/pkg/plugins/runtime/k8s/controllers/kube_hosts_converter.go
+++ b/pkg/plugins/runtime/k8s/controllers/kube_hosts_converter.go
@@ -3,12 +3,13 @@ package controllers
 import (
 	"context"
 
+	kube_client "sigs.k8s.io/controller-runtime/pkg/client"
+
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	resources_manager "github.com/kumahq/kuma/pkg/core/resources/manager"
 	core_store "github.com/kumahq/kuma/pkg/core/resources/store"
 	"github.com/kumahq/kuma/pkg/dns/vips"
-	kube_client "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 func KubeHosts(
@@ -42,7 +43,7 @@ func KubeHosts(
 			for _, endpoint := range endpoints[serviceTag] {
 				hostnameEntry := vips.NewHostEntry(endpoint.Address)
 				err := view.Add(hostnameEntry, vips.OutboundEntry{
-					Port:   endpoint.Port,
+					Port: endpoint.Port,
 					TagSet: map[string]string{
 						mesh_proto.ServiceTag:  serviceTag,
 						mesh_proto.InstanceTag: endpoint.Instance,
@@ -57,9 +58,9 @@ func KubeHosts(
 			// generate outbound based on ClusterIP. Transparent Proxy will work only if DNS name that resolves to ClusterIP is used
 			hostnameEntry := vips.NewHostEntry(service.Spec.ClusterIP)
 			err := view.Add(hostnameEntry, vips.OutboundEntry{
-				Port:   port,
+				Port: port,
 				TagSet: map[string]string{
-					mesh_proto.ServiceTag:  serviceTag,
+					mesh_proto.ServiceTag: serviceTag,
 				},
 				Origin: vips.OriginKube,
 			})

--- a/pkg/plugins/runtime/k8s/controllers/outbound_converter.go
+++ b/pkg/plugins/runtime/k8s/controllers/outbound_converter.go
@@ -5,12 +5,13 @@ import (
 	"strconv"
 	"strings"
 
-	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
-	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
-	mesh_k8s "github.com/kumahq/kuma/pkg/plugins/resources/k8s/native/api/v1alpha1"
 	"github.com/pkg/errors"
 	kube_core "k8s.io/api/core/v1"
 	kube_client "sigs.k8s.io/controller-runtime/pkg/client"
+
+	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
+	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
+	mesh_k8s "github.com/kumahq/kuma/pkg/plugins/resources/k8s/native/api/v1alpha1"
 )
 
 func (p *PodConverter) OutboundInterfacesFor(

--- a/pkg/plugins/runtime/k8s/plugin.go
+++ b/pkg/plugins/runtime/k8s/plugin.go
@@ -151,10 +151,11 @@ func addPodReconciler(mgr kube_ctrl.Manager, rt core_runtime.Runtime, converter 
 		Scheme:        mgr.GetScheme(),
 		Log:           core.Log.WithName("controllers").WithName("Pod"),
 		PodConverter: k8s_controllers.PodConverter{
-			ServiceGetter:     mgr.GetClient(),
-			NodeGetter:        mgr.GetClient(),
-			Zone:              rt.Config().Multizone.Zone.Name,
-			ResourceConverter: converter,
+			ServiceGetter:       mgr.GetClient(),
+			NodeGetter:          mgr.GetClient(),
+			Zone:                rt.Config().Multizone.Zone.Name,
+			ResourceConverter:   converter,
+			KubeOutboundsAsVIPs: rt.Config().Experimental.KubeOutboundsAsVIPs,
 		},
 		ResourceConverter: converter,
 		Persistence:       vips.NewPersistence(rt.ResourceManager(), rt.ConfigManager()),
@@ -190,14 +191,15 @@ func addDNS(mgr kube_ctrl.Manager, rt core_runtime.Runtime, converter k8s_common
 		return err
 	}
 	reconciler := &k8s_controllers.ConfigMapReconciler{
-		Client:            mgr.GetClient(),
-		EventRecorder:     mgr.GetEventRecorderFor("k8s.kuma.io/vips-generator"),
-		Scheme:            mgr.GetScheme(),
-		Log:               core.Log.WithName("controllers").WithName("ConfigMap"),
-		ResourceManager:   rt.ResourceManager(),
-		VIPsAllocator:     vipsAllocator,
-		SystemNamespace:   rt.Config().Store.Kubernetes.SystemNamespace,
-		ResourceConverter: converter,
+		Client:              mgr.GetClient(),
+		EventRecorder:       mgr.GetEventRecorderFor("k8s.kuma.io/vips-generator"),
+		Scheme:              mgr.GetScheme(),
+		Log:                 core.Log.WithName("controllers").WithName("ConfigMap"),
+		ResourceManager:     rt.ResourceManager(),
+		VIPsAllocator:       vipsAllocator,
+		SystemNamespace:     rt.Config().Store.Kubernetes.SystemNamespace,
+		ResourceConverter:   converter,
+		KubeOutboundsAsVIPs: rt.Config().Experimental.KubeOutboundsAsVIPs,
 	}
 	if err := reconciler.SetupWithManager(mgr); err != nil {
 		return err

--- a/pkg/xds/generator/inbound_proxy_generator.go
+++ b/pkg/xds/generator/inbound_proxy_generator.go
@@ -24,12 +24,8 @@ type InboundProxyGenerator struct {
 }
 
 func (g InboundProxyGenerator) Generate(ctx xds_context.Context, proxy *core_xds.Proxy) (*core_xds.ResourceSet, error) {
-	endpoints, err := proxy.Dataplane.Spec.Networking.GetInboundInterfaces()
-	if err != nil {
-		return nil, err
-	}
 	resources := core_xds.NewResourceSet()
-	for i, endpoint := range endpoints {
+	for i, endpoint := range proxy.Dataplane.Spec.Networking.GetInboundInterfaces() {
 		// we do not create inbounds for serviceless
 		if endpoint.IsServiceLess() {
 			continue

--- a/pkg/xds/sync/dataplane_proxy_builder.go
+++ b/pkg/xds/sync/dataplane_proxy_builder.go
@@ -1,6 +1,8 @@
 package sync
 
 import (
+	"net"
+
 	"github.com/pkg/errors"
 
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
@@ -107,9 +109,15 @@ func (p *DataplaneProxyBuilder) resolveVIPOutbounds(meshContext xds_context.Mesh
 	var outbounds []*mesh_proto.Dataplane_Networking_Outbound
 	for _, outbound := range meshContext.VIPOutbounds {
 		service := outbound.GetTagsIncludingLegacy()[mesh_proto.ServiceTag]
-		if len(reachableServices) == 0 || reachableServices[service] { // ignore VIP outbound if reachableServices is defined and not specified
-			outbounds = append(outbounds, outbound)
+		if len(reachableServices) != 0 && !reachableServices[service] {
+			continue // ignore VIP outbound if reachableServices is defined and not specified
 		}
+		if dataplane.UsesInboundInterface(net.ParseIP(outbound.Address), outbound.Port) {
+			// Skip overlapping outbound interface with inbound.
+			// This may happen for example with Headless service on Kubernetes (outbound is a PodIP not ClusterIP, so it's the same as inbound).
+			continue
+		}
+		outbounds = append(outbounds, outbound)
 	}
 	for _, outbound := range dataplane.Spec.Networking.GetOutbound() {
 		if generatedVips[outbound.Address] { // Useful while we still have resources with computed vip outbounds

--- a/pkg/xds/topology/dns.go
+++ b/pkg/xds/topology/dns.go
@@ -26,12 +26,12 @@ func VIPOutbounds(
 		domain := xds.VIPDomains{Address: voutbound.Address}
 		switch key.Type {
 		case vips.Host, vips.FullyQualifiedDomain:
+			if govalidator.IsDNSName(key.Name) {
+				domain.Domains = []string{key.Name}
+				vipDomains = append(vipDomains, domain)
+			}
 			seenGlobalVip := false
 			for _, ob := range voutbound.Outbounds {
-				if !govalidator.IsDNSName(key.Name) {
-					continue
-				}
-				domain.Domains = []string{key.Name}
 				seenGlobalVip = seenGlobalVip || ob.Port == VIPListenPort
 				if ob.Port != 0 {
 					outbounds = append(outbounds, &mesh_proto.Dataplane_Networking_Outbound{
@@ -42,14 +42,13 @@ func VIPOutbounds(
 				}
 			}
 			// TODO remove the `vips.Host` on the next major version it's there for backward compatibility
-			if key.Type == vips.Host && !seenGlobalVip && len(voutbound.Outbounds) > 0 {
+			if key.Type == vips.Host && !seenGlobalVip && len(voutbound.Outbounds) > 0 && len(domain.Domains) > 0 {
 				outbounds = append(outbounds, &mesh_proto.Dataplane_Networking_Outbound{
 					Address: voutbound.Address,
 					Port:    VIPListenPort,
 					Tags:    voutbound.Outbounds[0].TagSet,
 				})
 			}
-			vipDomains = append(vipDomains, domain)
 		case vips.Service:
 			ob := voutbound.Outbounds[0]
 			service := ob.TagSet[mesh_proto.ServiceTag]
@@ -74,14 +73,14 @@ func VIPOutbounds(
 				})
 			}
 			vipDomains = append(vipDomains, domain)
-		case vips.KubeHost:
-			for _, ob := range voutbound.Outbounds {
-				outbounds = append(outbounds, &mesh_proto.Dataplane_Networking_Outbound{
-					Address: voutbound.Address,
-					Port:    ob.Port,
-					Tags:    ob.TagSet,
-				})
-			}
+		//case vips.KubeHost:
+		//	for _, ob := range voutbound.Outbounds {
+		//		outbounds = append(outbounds, &mesh_proto.Dataplane_Networking_Outbound{
+		//			Address: voutbound.Address,
+		//			Port:    ob.Port,
+		//			Tags:    ob.TagSet,
+		//		})
+		//	}
 		}
 	}
 	return vipDomains, outbounds

--- a/pkg/xds/topology/dns.go
+++ b/pkg/xds/topology/dns.go
@@ -49,6 +49,7 @@ func VIPOutbounds(
 					Tags:    voutbound.Outbounds[0].TagSet,
 				})
 			}
+			vipDomains = append(vipDomains, domain)
 		case vips.Service:
 			ob := voutbound.Outbounds[0]
 			service := ob.TagSet[mesh_proto.ServiceTag]
@@ -72,8 +73,16 @@ func VIPOutbounds(
 					Tags:    ob.TagSet,
 				})
 			}
+			vipDomains = append(vipDomains, domain)
+		case vips.KubeHost:
+			for _, ob := range voutbound.Outbounds {
+				outbounds = append(outbounds, &mesh_proto.Dataplane_Networking_Outbound{
+					Address: voutbound.Address,
+					Port:    ob.Port,
+					Tags:    ob.TagSet,
+				})
+			}
 		}
-		vipDomains = append(vipDomains, domain)
 	}
 	return vipDomains, outbounds
 }

--- a/pkg/xds/topology/dns.go
+++ b/pkg/xds/topology/dns.go
@@ -73,14 +73,6 @@ func VIPOutbounds(
 				})
 			}
 			vipDomains = append(vipDomains, domain)
-		//case vips.KubeHost:
-		//	for _, ob := range voutbound.Outbounds {
-		//		outbounds = append(outbounds, &mesh_proto.Dataplane_Networking_Outbound{
-		//			Address: voutbound.Address,
-		//			Port:    ob.Port,
-		//			Tags:    ob.TagSet,
-		//		})
-		//	}
 		}
 	}
 	return vipDomains, outbounds

--- a/test/e2e/reachableservices/reachableservices_k8s.go
+++ b/test/e2e/reachableservices/reachableservices_k8s.go
@@ -20,7 +20,7 @@ func ReachableServicesOnK8s() {
 		cluster = NewK8sCluster(NewTestingT(), Kuma1, Silent)
 
 		err := NewClusterSetup().
-			Install(Kuma(config_core.Standalone)).
+			Install(Kuma(config_core.Standalone, WithEnv("KUMA_EXPERIMENTAL_KUBE_OUTBOUNDS_AS_VIPS", "true"))).
 			Install(YamlK8s(`
 apiVersion: kuma.io/v1alpha1
 kind: Mesh

--- a/test/e2e/trafficpermission/kubernetes/traffic_permission_k8s.go
+++ b/test/e2e/trafficpermission/kubernetes/traffic_permission_k8s.go
@@ -20,7 +20,7 @@ var _ = E2EBeforeSuite(func() {
 
 	k8sCluster = k8sClusters.GetCluster(Kuma1)
 
-	Expect(Kuma(config_core.Standalone)(k8sCluster)).To(Succeed())
+	Expect(Kuma(config_core.Standalone, WithEnv("KUMA_EXPERIMENTAL_KUBE_OUTBOUNDS_AS_VIPS", "true"))(k8sCluster)).To(Succeed())
 
 	E2EDeferCleanup(func() {
 		Expect(k8sCluster.DeleteKuma()).To(Succeed())


### PR DESCRIPTION
### Summary

This PR changes the way how we persist outbound for Kubernetes.
So far, we were persisting them in the `outbound` section in the `Dataplane` object.
With large deployments, this results in big `Dataplane` objects with the information that is common for the whole mesh.

The change is to use ConfigMap which we already use for storing Kuma VIPs. This way the `outbound` section is empty and we can reuse any logic for VIPs.

The feature is opt-in because we cannot switch it in a stable, backward-compatible way. It will be default in the next+1 minor version of Kuma.

In my testing, I haven't seen a radical improvement in performance. However, my cluster contained 100 services.
With 1000+ services we probably would see it a bit more.

Also, as a result, Pod Controller in the future can just watch Pods, not Pods, Services, Dataplanes and ConfigMaps.

Implicit virtual outbound is also consistent with our own VIPs

### Issues resolved

Fix #3787

### Documentation

In progress...

### Testing

- [ ] Unit tests
- [X] E2E tests
- [ ] Manual testing on Universal
- [X] Manual testing on Kubernetes

### Backwards compatibility

~- [ ] Update [`UPGRADE.md`](/UPGRADE.md) with any steps users will need to take when upgrading.~
~- [ ] Add `backport-to-stable` label if the code follows our [backporting policy](/CONTRIBUTING.md#backporting)~
