### PR TITLE
feat(kuma-cp): Add validation for pods with kuma.io scoped labels and annotations

### DIFF
--- a/pkg/plugins/runtime/k8s/metadata/annotations.go
+++ b/pkg/plugins/runtime/k8s/metadata/annotations.go
@@ -80,6 +80,28 @@ const (
 	KumaSidecarTokenVolumeAnnotation = "kuma.io/service-account-token-volume"
 )
 
+var ValidEndUserAnnotations = map[string]bool{
+	KumaMeshAnnotation:                 true,
+	KumaSidecarInjectionAnnotation:     true,
+	KumaGatewayAnnotation:              true,
+	KumaIngressAnnotation:              true,
+	KumaEgressAnnotation:               true,
+	KumaTagsAnnotation:                 true,
+	KumaIngressPublicAddressAnnotation: true,
+	KumaIngressPublicPortAnnotation:    true,
+	KumaDirectAccess:                   true,
+	KumaVirtualProbesAnnotation:        true,
+	KumaVirtualProbesPortAnnotation:    true,
+	KumaSidecarEnvVarsAnnotation:       true,
+	KumaSidecarConcurrencyAnnotation:   true,
+	KumaMetricsPrometheusPort:          true,
+	KumaMetricsPrometheusPath:          true,
+	KumaBuiltinDNS:                     true,
+	KumaBuiltinDNSPort:                 true,
+	KumaTrafficExcludeInboundPorts:     true,
+	KumaTrafficExcludeOutboundPorts:    true,
+}
+
 // Annotations that are being automatically set by the Kuma Sidecar Injector.
 const (
 	KumaSidecarInjectedAnnotation                      = "kuma.io/sidecar-injected"

--- a/pkg/plugins/runtime/k8s/metadata/annotations.go
+++ b/pkg/plugins/runtime/k8s/metadata/annotations.go
@@ -133,6 +133,7 @@ var ValidKumaAnnotations = map[string]bool{
 	KumaBuiltinDNSPort:                                 true,
 	KumaTrafficExcludeInboundPorts:                     true,
 	KumaTrafficExcludeOutboundPorts:                    true,
+	KumaSidecarTokenVolumeAnnotation:                   true,
 	KumaSidecarInjectedAnnotation:                      true,
 	KumaIgnoreAnnotation:                               true,
 	KumaSidecarUID:                                     true,

--- a/pkg/plugins/runtime/k8s/metadata/annotations.go
+++ b/pkg/plugins/runtime/k8s/metadata/annotations.go
@@ -80,28 +80,6 @@ const (
 	KumaSidecarTokenVolumeAnnotation = "kuma.io/service-account-token-volume"
 )
 
-var ValidEndUserAnnotations = map[string]bool{
-	KumaMeshAnnotation:                 true,
-	KumaSidecarInjectionAnnotation:     true,
-	KumaGatewayAnnotation:              true,
-	KumaIngressAnnotation:              true,
-	KumaEgressAnnotation:               true,
-	KumaTagsAnnotation:                 true,
-	KumaIngressPublicAddressAnnotation: true,
-	KumaIngressPublicPortAnnotation:    true,
-	KumaDirectAccess:                   true,
-	KumaVirtualProbesAnnotation:        true,
-	KumaVirtualProbesPortAnnotation:    true,
-	KumaSidecarEnvVarsAnnotation:       true,
-	KumaSidecarConcurrencyAnnotation:   true,
-	KumaMetricsPrometheusPort:          true,
-	KumaMetricsPrometheusPath:          true,
-	KumaBuiltinDNS:                     true,
-	KumaBuiltinDNSPort:                 true,
-	KumaTrafficExcludeInboundPorts:     true,
-	KumaTrafficExcludeOutboundPorts:    true,
-}
-
 // Annotations that are being automatically set by the Kuma Sidecar Injector.
 const (
 	KumaSidecarInjectedAnnotation                      = "kuma.io/sidecar-injected"
@@ -134,6 +112,37 @@ const (
 	AnnotationTrue     = "true"
 	AnnotationFalse    = "false"
 )
+
+var ValidKumaAnnotations = map[string]bool{
+	KumaMeshAnnotation:                                 true,
+	KumaSidecarInjectionAnnotation:                     true,
+	KumaGatewayAnnotation:                              true,
+	KumaIngressAnnotation:                              true,
+	KumaEgressAnnotation:                               true,
+	KumaTagsAnnotation:                                 true,
+	KumaIngressPublicAddressAnnotation:                 true,
+	KumaIngressPublicPortAnnotation:                    true,
+	KumaDirectAccess:                                   true,
+	KumaVirtualProbesAnnotation:                        true,
+	KumaVirtualProbesPortAnnotation:                    true,
+	KumaSidecarEnvVarsAnnotation:                       true,
+	KumaSidecarConcurrencyAnnotation:                   true,
+	KumaMetricsPrometheusPort:                          true,
+	KumaMetricsPrometheusPath:                          true,
+	KumaBuiltinDNS:                                     true,
+	KumaBuiltinDNSPort:                                 true,
+	KumaTrafficExcludeInboundPorts:                     true,
+	KumaTrafficExcludeOutboundPorts:                    true,
+	KumaSidecarInjectedAnnotation:                      true,
+	KumaIgnoreAnnotation:                               true,
+	KumaSidecarUID:                                     true,
+	KumaEnvoyAdminPort:                                 true,
+	KumaTransparentProxyingAnnotation:                  true,
+	KumaTransparentProxyingInboundPortAnnotation:       true,
+	KumaTransparentProxyingInboundPortAnnotationV6:     true,
+	KumaTransparentProxyingOutboundPortAnnotation:      true,
+	KumaTransparentProxyingReachableServicesAnnotation: true,
+}
 
 type Annotations map[string]string
 

--- a/pkg/plugins/runtime/k8s/webhooks/injector/injector.go
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/injector.go
@@ -75,7 +75,7 @@ func (i *KumaInjector) InjectKuma(pod *kube_core.Pod) error {
 	r := regexp.MustCompile(`.*\.?kuma.io\/`)
 	for a := range pod.Annotations {
 		if r.MatchString(a) {
-			ok := metadata.ValidEndUserAnnotations[a]
+			ok := metadata.ValidKumaAnnotations[a]
 			if !ok {
 				log.V(1).Info("pod has an invalid annotation", "annotation", a)
 				return errors.New("pod has an invalid annotation " + a)
@@ -84,7 +84,7 @@ func (i *KumaInjector) InjectKuma(pod *kube_core.Pod) error {
 	}
 	for l := range pod.Labels {
 		if r.MatchString(l) {
-			ok := metadata.ValidEndUserAnnotations[l]
+			ok := metadata.ValidKumaAnnotations[l]
 			if !ok {
 				log.V(1).Info("pod has an invalid label", "label", l)
 				return errors.New("pod has an invalid label " + l)

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.29.input.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.29.input.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: busybox
+  labels:
+    run: busybox
+  annotations:
+    kuma.io/gatway: enabled
+spec:
+  volumes:
+  - name: default-token-w7dxf
+    secret:
+      secretName: default-token-w7dxf
+  containers:
+  - name: busybox
+    image: busybox
+    resources: {}
+    volumeMounts:
+    - name: default-token-w7dxf
+      readOnly: true
+      mountPath: "/var/run/secrets/kubernetes.io/serviceaccount"

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.30.input.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.30.input.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: busybox
+  labels:
+    run: busybox
+  annotations:
+    kuma.io/gateway: enabled
+    kuma.io/buitindns: enabled
+spec:
+  volumes:
+  - name: default-token-w7dxf
+    secret:
+      secretName: default-token-w7dxf
+  containers:
+  - name: busybox
+    image: busybox
+    resources: {}
+    volumeMounts:
+    - name: default-token-w7dxf
+      readOnly: true
+      mountPath: "/var/run/secrets/kubernetes.io/serviceaccount"

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.31.input.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.31.input.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: busybox
+  labels:
+    run: busybox
+    kuma.io/gatway: enabled
+spec:
+  volumes:
+  - name: default-token-w7dxf
+    secret:
+      secretName: default-token-w7dxf
+  containers:
+  - name: busybox
+    image: busybox
+    resources: {}
+    volumeMounts:
+    - name: default-token-w7dxf
+      readOnly: true
+      mountPath: "/var/run/secrets/kubernetes.io/serviceaccount"

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.32.input.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.32.input.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: busybox
+  labels:
+    run: busybox
+    kuma.io/gateway: enabled
+    kuma.io/buitindns: enabled
+  annotations:
+spec:
+  volumes:
+  - name: default-token-w7dxf
+    secret:
+      secretName: default-token-w7dxf
+  containers:
+  - name: busybox
+    image: busybox
+    resources: {}
+    volumeMounts:
+    - name: default-token-w7dxf
+      readOnly: true
+      mountPath: "/var/run/secrets/kubernetes.io/serviceaccount"


### PR DESCRIPTION
### Summary

This PR adds a validating webhook to validate the kuma.io scoped labels and annotations. A lot of the boilerplate was inspired from #611.

### Full changelog

* Add a map in `metadata.annotations` to check for valid annotations/labels.
* Add webhook configuration in the relevant yaml manifests.
* Add `pod_validator.go` and `pod_validator_test.go` which contain the code for the webhook's `Handle` and `validate` methods.

### Issues resolved

Fix #2331

### Testing

- [x] Unit tests