### PR TITLE
chore(*): improve K3D dev workflow

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -91,3 +91,14 @@ Like `make test`, you can append the app name to the target to build a specific 
 make build/kumactl
 ```
 This could help expedite your development process if you only made changes to the `kumactl` files.
+
+## Running
+
+### Kubernetes
+
+Execute
+```bash
+make -j k3d/restart
+```
+
+To stop any existing Kuma K3D cluster, start a new K3D cluster, load images, deploy Kuma and Kuma counter demo. 

--- a/mk/k3d.mk
+++ b/mk/k3d.mk
@@ -89,16 +89,9 @@ k3d/load: images k3d/load/images
 
 .PHONY: k3d/deploy/kuma
 k3d/deploy/kuma: build/kumactl k3d/load
-	@KUBECONFIG=$(KIND_KUBECONFIG) $(BUILD_ARTIFACTS_DIR)/kumactl/kumactl install --mode $(KUMA_MODE) control-plane $(KUMACTL_INSTALL_CONTROL_PLANE_IMAGES) | KUBECONFIG=$(KIND_KUBECONFIG)  kubectl apply -f -
+	@KUBECONFIG=$(KIND_KUBECONFIG) $(BUILD_ARTIFACTS_DIR)/kumactl/kumactl install --mode $(KUMA_MODE) control-plane $(KUMACTL_INSTALL_CONTROL_PLANE_IMAGES) --experimental-meshgateway | KUBECONFIG=$(KIND_KUBECONFIG)  kubectl apply -f -
 	@KUBECONFIG=$(KIND_KUBECONFIG) kubectl wait --timeout=60s --for=condition=Available -n $(KUMA_NAMESPACE) deployment/kuma-control-plane
 	@KUBECONFIG=$(KIND_KUBECONFIG) kubectl wait --timeout=60s --for=condition=Ready -n $(KUMA_NAMESPACE) pods -l app=kuma-control-plane
-	@KUBECONFIG=$(KIND_KUBECONFIG) kumactl install dns | kubectl apply -f -
-	@KUBECONFIG=$(KIND_KUBECONFIG) kubectl delete -n $(EXAMPLE_NAMESPACE) pod -l app=example-app
-	@until \
-	KUBECONFIG=$(KIND_KUBECONFIG) kubectl wait -n kube-system --timeout=5s --for condition=Ready --all pods ; \
-    do \
-    	echo "Waiting for the cluster to come up" && sleep 1; \
-    done
 
 .PHONY: k3d/deploy/helm
 k3d/deploy/helm: k3d/load
@@ -116,9 +109,14 @@ k3d/deploy/helm: k3d/load
 	@KUBECONFIG=$(KIND_KUBECONFIG) kubectl wait --timeout=60s --for=condition=Available -n $(KUMA_NAMESPACE) deployment/kuma-control-plane
 	@KUBECONFIG=$(KIND_KUBECONFIG) kubectl wait --timeout=60s --for=condition=Ready -n $(KUMA_NAMESPACE) pods -l app=kuma-control-plane
 
-.PHONY: k3d/deploy/example-app
-k3d/deploy/example-app:
-	@KUBECONFIG=$(KIND_KUBECONFIG) kubectl create namespace $(EXAMPLE_NAMESPACE) || true
-	@KUBECONFIG=$(KIND_KUBECONFIG) kubectl annotate namespace $(EXAMPLE_NAMESPACE) kuma.io/sidecar-injection=enabled --overwrite
-	@KUBECONFIG=$(KIND_KUBECONFIG) kubectl apply -n $(EXAMPLE_NAMESPACE) -f dev/examples/k8s/example-app/example-app.yaml
-	@KUBECONFIG=$(KIND_KUBECONFIG) kubectl wait --timeout=60s --for=condition=Available -n $(EXAMPLE_NAMESPACE) pods -l app=example-app
+.PHONY: k3d/deploy/demo
+k3d/deploy/demo: build/kumactl
+	@$(BUILD_ARTIFACTS_DIR)/kumactl/kumactl install demo | KUBECONFIG=$(KIND_KUBECONFIG)  kubectl apply -f -
+	@KUBECONFIG=$(KIND_KUBECONFIG) kubectl wait --timeout=60s --for=condition=Ready -n kuma-demo --all pods
+
+.PHONY: k3d/restart
+k3d/restart:
+	$(MAKE) k3d/stop
+	$(MAKE) k3d/start
+	$(MAKE) k3d/deploy/kuma
+	$(MAKE) k3d/deploy/demo


### PR DESCRIPTION
### Summary

`make k3d/deploy/kuma` was failing because of `kuma install dns`.
I also replaced example app with counter demo. Let me know if you want keep this example app.
I introduced one command to clean K3D cluster, create a new one, deploy kuma and counter demo. I noticed that I was executing `make k3d/stop/all && make k3d/start && make -j k3d/deploy/kuma` and then manually demo app all the time.

### Issues resolved

No issues reported.

### Documentation

~- [ ] Link to the website [documentation PR](https://github.com/kumahq/kuma-website/pull/XXX)~

### Testing

- [ ] Unit tests
- [ ] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes

### Backwards compatibility

~- [ ] Update [`UPGRADE.md`](/UPGRADE.md) with any steps users will need to take when upgrading.~
~- [ ] Add `backport-to-stable` label if the code follows our [backporting policy](/CONTRIBUTING.md#backporting)~
