### PR TITLE
fix(kuma-cp): skip creating MeshGateways without proper attachmenet

### DIFF
--- a/pkg/plugins/runtime/k8s/controllers/gatewayapi/http_route_controller.go
+++ b/pkg/plugins/runtime/k8s/controllers/gatewayapi/http_route_controller.go
@@ -159,7 +159,8 @@ func (r *HTTPRouteReconciler) gapiToKumaRoutes(
 
 	var kumaRoute *mesh_proto.MeshGatewayRoute
 
-	if routeConf != nil {
+	if routeConf != nil && len(selectors) > 0 {
+		// We can only build MeshGatewayRoute if any attachment has matched, and we've got selectors
 		kumaRoute = &mesh_proto.MeshGatewayRoute{
 			Conf:      routeConf,
 			Selectors: selectors,


### PR DESCRIPTION
### Summary

In http route controller we convert API Gateway's HTTPRoute to Kuma's MeshGatewayRoute.

HTTP route looks like this
```
apiVersion: gateway.networking.k8s.io/v1alpha2
kind: HTTPRoute
metadata:
  name: echo
  namespace: kuma-demo
spec:
  parentRefs:
  - group: gateway.networking.k8s.io
    kind: Gateway
    name: kuma
  rules:
  - backendRefs:
    - group: ""
      kind: Service
      name: demo-app
      port: 5000
      weight: 1
    matches:
    - path:
        type: PathPrefix
        value: /
```

We can only consider HTTPRoute valid if it has a valid `parentsRef`. See `case attachment.Allowed:` in this file.

The problem was that I used this HTTPRoute with this Gateway
```
apiVersion: gateway.networking.k8s.io/v1alpha2
kind: Gateway
metadata:
  name: kuma
  namespace: default
spec:
  gatewayClassName: kuma
  listeners:
  - name: proxy
    port: 8080
    protocol: HTTP
```

HTTPRoute cannot be attached to this Gateway because it's in different namespace. The attachment was computed correctly `case attachment.NotPermitted:`. However, we successfully converted MeshGatewayRoute anyways, but without selectors. Then, we were trying to create it which resulted in error because we have static validators on empty selectors in MeshGatewayRoute.

Solution?
Only convert when there is an attachment - an extra if I added

_Bonus notes:_
To reference HTTPRoute cross namespace I had to add this
```
apiVersion: gateway.networking.k8s.io/v1alpha2
kind: Gateway
metadata:
  name: kuma
  namespace: default
spec:
  gatewayClassName: kuma
  listeners:
  - name: proxy
    port: 8080
    protocol: HTTP
    allowedRoutes: # <- this
      namespaces:
        from: All
```

### Issues resolved

No issues reported. I noticed this when I was testing Gateway API.

### Documentation

No docs.

### Testing

No tests yet as this is bigger story for Gateway API :(

- [ ] Unit tests
- [ ] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes

### Backwards compatibility

~- [ ] Update [`UPGRADE.md`](/UPGRADE.md) with any steps users will need to take when upgrading.~
~- [ ] Add `backport-to-stable` label if the code follows our [backporting policy](/CONTRIBUTING.md#backporting)~
