### PR TITLE
feat(kuma-cp): Gateway API behind experimental flag

### DIFF
--- a/pkg/api-server/config_ws_test.go
+++ b/pkg/api-server/config_ws_test.go
@@ -345,6 +345,7 @@ var _ = Describe("Config WS", func() {
           },
           "experimental": {
             "meshGateway": false,
+            "gatewayAPI": false,
             "kubeOutboundsAsVIPs": false
           }
         }

--- a/pkg/config/app/kuma-cp/config.go
+++ b/pkg/config/app/kuma-cp/config.go
@@ -200,6 +200,7 @@ var DefaultConfig = func() Config {
 		Access:      access.DefaultAccessConfig(),
 		Experimental: ExperimentalConfig{
 			MeshGateway:         false,
+			GatewayAPI:          false,
 			KubeOutboundsAsVIPs: false,
 		},
 	}
@@ -277,6 +278,9 @@ func (c *Config) Validate() error {
 	if err := c.Diagnostics.Validate(); err != nil {
 		return errors.Wrap(err, "Diagnostics validation failed")
 	}
+	if err := c.Experimental.Validate(); err != nil {
+		return errors.Wrap(err, "Experimental validation failed")
+	}
 	return nil
 }
 
@@ -316,7 +320,16 @@ func DefaultGeneralConfig() *GeneralConfig {
 type ExperimentalConfig struct {
 	// If true, experimental built-in gateway is enabled.
 	MeshGateway bool `yaml:"meshGateway" envconfig:"KUMA_EXPERIMENTAL_MESHGATEWAY"`
+	// If true, experimental Gateway API is enabled
+	GatewayAPI bool `yaml:"gatewayAPI" envconfig:"KUMA_EXPERIMENTAL_GATEWAY_API"`
 	// If true, instead of embedding kubernetes outbounds into Dataplane object, they are persisted next to VIPs in ConfigMap
 	// This can improve performance, but it should be enabled only after all instances are migrated to version that supports this config
 	KubeOutboundsAsVIPs bool `yaml:"kubeOutboundsAsVIPs" envconfig:"KUMA_EXPERIMENTAL_KUBE_OUTBOUNDS_AS_VIPS"`
+}
+
+func (e ExperimentalConfig) Validate() error {
+	if e.GatewayAPI && !e.MeshGateway {
+		return errors.New("GatewayAPI cannot be enabled without MeshGateway")
+	}
+	return nil
 }

--- a/pkg/config/app/kuma-cp/kuma-cp.defaults.yaml
+++ b/pkg/config/app/kuma-cp/kuma-cp.defaults.yaml
@@ -433,6 +433,8 @@ access:
 experimental:
   # If true, experimental built-in gateway is enabled
   meshGateway: false # ENV: KUMA_EXPERIMENTAL_MESHGATEWAY
+  # If true, experimental Gateway API is enabled
+  gatewayAPI: false # ENV: KUMA_EXPERIMENTAL_GATEWAY_API
   # If true, instead of embedding kubernetes outbounds into Dataplane object, they are persisted next to VIPs in ConfigMap
   # This can improve performance, but it should be enabled only after all instances are migrated to version that supports this config
   kubeOutboundsAsVIPs: false # ENV: KUMA_EXPERIMENTAL_KUBE_OUTBOUNDS_AS_VIPS

--- a/pkg/config/loader_test.go
+++ b/pkg/config/loader_test.go
@@ -250,6 +250,7 @@ var _ = Describe("Config loader", func() {
 			Expect(cfg.Access.Static.ViewConfigDump.Groups).To(Equal([]string{"zt-group1", "zt-group2"}))
 
 			Expect(cfg.Experimental.MeshGateway).To(BeTrue())
+			Expect(cfg.Experimental.GatewayAPI).To(BeTrue())
 			Expect(cfg.Experimental.KubeOutboundsAsVIPs).To(BeTrue())
 		},
 		Entry("from config file", testCase{
@@ -466,6 +467,7 @@ access:
       groups: ["zt-group1", "zt-group2"]
 experimental:
   meshGateway: true
+  gatewayAPI: true
   kubeOutboundsAsVIPs: true
 `,
 		}),
@@ -614,6 +616,7 @@ experimental:
 				"KUMA_ACCESS_STATIC_GET_CONFIG_DUMP_USERS":                                                 "zt-admin1,zt-admin2",
 				"KUMA_ACCESS_STATIC_GET_CONFIG_DUMP_GROUPS":                                                "zt-group1,zt-group2",
 				"KUMA_EXPERIMENTAL_MESHGATEWAY":                                                            "true",
+				"KUMA_EXPERIMENTAL_GATEWAY_API":                                                            "true",
 				"KUMA_EXPERIMENTAL_KUBE_OUTBOUNDS_AS_VIPS":                                                 "true",
 			},
 			yamlFileConfig: "",


### PR DESCRIPTION
### Summary

Gateway API behind a config flag.

### Issues resolved

xref #3702

### Documentation

Docs are in progress for the whole feature.

### Testing

- [ ] Unit tests
- [ ] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes

### Backwards compatibility

~- [ ] Update [`UPGRADE.md`](/UPGRADE.md) with any steps users will need to take when upgrading.~
~- [ ] Add `backport-to-stable` label if the code follows our [backporting policy](/CONTRIBUTING.md#backporting)~
