### PR TITLE
chore(kuma-cp): use appProtocol by default

### DIFF
--- a/app/kumactl/cmd/install/testdata/install-demo.defaults.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-demo.defaults.golden.yaml
@@ -24,13 +24,12 @@ kind: Service
 metadata:
   name: demo-app
   namespace: kuma-demo
-  annotations:
-    5000.service.kuma.io/protocol: http
 spec:
   selector:
     app: demo-app
   ports:
   - protocol: TCP
+    appProtocol: http
     port: 5000
 ---
 apiVersion: apps/v1

--- a/app/kumactl/cmd/install/testdata/install-demo.overrides.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-demo.overrides.golden.yaml
@@ -24,13 +24,12 @@ kind: Service
 metadata:
   name: demo-app
   namespace: not-kuma-demo
-  annotations:
-    5000.service.kuma.io/protocol: http
 spec:
   selector:
     app: demo-app
   ports:
   - protocol: TCP
+    appProtocol: http
     port: 5000
 ---
 apiVersion: apps/v1

--- a/app/kumactl/data/install/k8s/demo/demo.yaml
+++ b/app/kumactl/data/install/k8s/demo/demo.yaml
@@ -79,11 +79,10 @@ kind: Service
 metadata:
   name: demo-app
   namespace: {{ .Namespace }}
-  annotations:
-    5000.service.kuma.io/protocol: http
 spec:
   selector:
     app: demo-app
   ports:
   - protocol: TCP
+    appProtocol: http
     port: 5000

--- a/dev/examples/k8s/example-app/example-app.yaml
+++ b/dev/examples/k8s/example-app/example-app.yaml
@@ -3,12 +3,11 @@ apiVersion: v1
 kind: Service
 metadata:
   name: example-server
-  annotations:
-    80.service.kuma.io/protocol: http
 spec:
   ports:
   - port: 80
     name: http
+    appProtocol: http
   selector:
     app: example-app
     service: example-server

--- a/examples/kafka/manifest.yaml
+++ b/examples/kafka/manifest.yaml
@@ -32,8 +32,6 @@ kind: Service
 metadata:
   name: kafka-service
   namespace: kuma-kafka
-  annotations:
-    9092.service.kuma.io/protocol: kafka
   labels:
     name: kafka
 spec:
@@ -41,6 +39,7 @@ spec:
     - port: 9092
       name: kafka-port
       protocol: TCP
+      appProtocol: kafka
   selector:
     app: kafka
     id: "0"

--- a/test/e2e/externalservices/testdata/externalservice-http-server.yaml
+++ b/test/e2e/externalservices/testdata/externalservice-http-server.yaml
@@ -10,12 +10,11 @@ kind: Service
 metadata:
   name: externalservice-http-server
   namespace: externalservice-namespace
-  annotations:
-    10080.service.kuma.io/protocol: http
 spec:
   ports:
     - port: 10080
       name: http
+      appProtocol: http
       targetPort: 80
   selector:
     app: externalservice-http-server

--- a/test/e2e/externalservices/testdata/externalservice-https-server.yaml
+++ b/test/e2e/externalservices/testdata/externalservice-https-server.yaml
@@ -10,13 +10,12 @@ kind: Service
 metadata:
   name: externalservice-https-server
   namespace: externalservice-namespace
-  annotations:
-    10080.service.kuma.io/protocol: http
 spec:
   ports:
     - port: 10080
       name: https
       targetPort: 443
+      appProtocol: http
   selector:
     app: externalservice-https-server
 

--- a/test/framework/deployments/testserver/kubernetes.go
+++ b/test/framework/deployments/testserver/kubernetes.go
@@ -21,6 +21,7 @@ func (k *k8SDeployment) Name() string {
 }
 
 func (k *k8SDeployment) service() *corev1.Service {
+	appProtocol := "http"
 	return &corev1.Service{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Service",
@@ -29,13 +30,14 @@ func (k *k8SDeployment) service() *corev1.Service {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      k.Name(),
 			Namespace: k.opts.Namespace,
-			Annotations: map[string]string{
-				"80.service.kuma.io/protocol": "http",
-			},
 		},
 		Spec: corev1.ServiceSpec{
 			Ports: []corev1.ServicePort{
-				{Name: "http", Port: 80},
+				{
+					Name:        "http",
+					Port:        80,
+					AppProtocol: &appProtocol,
+				},
 			},
 			Selector: map[string]string{
 				"app": k.Name(),


### PR DESCRIPTION
### Summary

See https://github.com/kumahq/kuma-website/pull/731

### Issues resolved

No issues reported

### Documentation

https://github.com/kumahq/kuma-website/pull/731

### Testing

- [X] Unit tests
- [X] E2E tests
- [ ] Manual testing on Universal
- [X] Manual testing on Kubernetes

### Backwards compatibility

~- [ ] Update [`UPGRADE.md`](/UPGRADE.md) with any steps users will need to take when upgrading.~
~- [ ] Add `backport-to-stable` label if the code follows our [backporting policy](/CONTRIBUTING.md#backporting)~
