### PR TITLE
fix(ci): retry k3d image load

### DIFF
--- a/mk/k3d.mk
+++ b/mk/k3d.mk
@@ -83,6 +83,8 @@ k3d/stop/all:
 .PHONY: k3d/load/images
 k3d/load/images:
 	@k3d image import $(KUMA_IMAGES) --cluster=$(KIND_CLUSTER_NAME) --verbose
+	# https://github.com/k3d-io/k3d/issues/900 can cause failures that simple retry will fix
+	if [[ $? -ne 0 ]]; then k3d image import $(KUMA_IMAGES) --cluster=$(KIND_CLUSTER_NAME) --verbose; fi
 
 .PHONY: k3d/load
 k3d/load: images k3d/load/images


### PR DESCRIPTION
Because of https://github.com/k3d-io/k3d/issues/900
we're getting failures in `k3d import images` until it's fixed
we'll retry on failures

Signed-off-by: Charly Molter <charly.molter@konghq.com>