### PR TITLE
fix(ci): improve some failing bits of CI

### DIFF
--- a/app/kumactl/cmd/config/config_control_planes_add_test.go
+++ b/app/kumactl/cmd/config/config_control_planes_add_test.go
@@ -118,7 +118,7 @@ var _ = Describe("kumactl config control-planes add", func() {
 		It("should fail when CP timeouts", func() {
 			// setup
 			server, port := setupCpServer(func(writer http.ResponseWriter, req *http.Request) {
-				time.Sleep(time.Millisecond * 200)
+				time.Sleep(time.Millisecond * 500)
 			})
 			defer server.Close()
 

--- a/mk/k3d.mk
+++ b/mk/k3d.mk
@@ -82,9 +82,8 @@ k3d/stop/all:
 
 .PHONY: k3d/load/images
 k3d/load/images:
-	@k3d image import $(KUMA_IMAGES) --cluster=$(KIND_CLUSTER_NAME) --verbose
 	# https://github.com/k3d-io/k3d/issues/900 can cause failures that simple retry will fix
-	if [[ $? -ne 0 ]]; then k3d image import $(KUMA_IMAGES) --cluster=$(KIND_CLUSTER_NAME) --verbose; fi
+	@k3d image import $(KUMA_IMAGES) --cluster=$(KIND_CLUSTER_NAME) --verbose; if [[ ${?} -ne 0 ]]; then k3d image import $(KUMA_IMAGES) --cluster=$(KIND_CLUSTER_NAME) --verbose; fi
 
 .PHONY: k3d/load
 k3d/load: images k3d/load/images


### PR DESCRIPTION
- Fix k3d/load/images retries
- Increase timeout on config_control_planes_add (causing mac_test to fail)

Signed-off-by: Charly Molter <charly.molter@konghq.com>