### PR TITLE
feat(kuma-cp): validate GatewayAPI with multizone

### DIFF
--- a/app/kumactl/cmd/install/testdata/install-control-plane.cni-enabled.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.cni-enabled.golden.yaml
@@ -1630,7 +1630,7 @@ spec:
     metadata:
       annotations:
         checksum/config: f509d41973f6ed84a86f16e996b13068bffb3a90d10d7886a37e1c5fc225f760
-        checksum/tls-secrets: 78e5236addc11d7549493c1756f9ace9c6dc65d04880293bfd22b97f8173476b
+        checksum/tls-secrets: 1962ebe5f21decca98ad3ce41df62b9e3adbcb22c20273f2904dc4b0c6bf39a7
       labels:
         app.kubernetes.io/name: kuma
         app.kubernetes.io/instance: kuma
@@ -1966,4 +1966,23 @@ webhooks:
           - DELETE
         resources:
           - secrets
+    sideEffects: None
+  - name: gateway.validator.kuma-admission.kuma.io
+    admissionReviewVersions: ["v1"]
+    failurePolicy: Ignore
+    clientConfig:
+      caBundle: XYZ
+      service:
+        namespace: kuma-system
+        name: kuma-control-plane
+        path: /validate-v1alpha2-gateway
+    rules:
+      - apiGroups:
+          - "gateway.networking.k8s.io"
+        apiVersions:
+          - v1alpha2
+        operations:
+          - CREATE
+        resources:
+          - gatewayclasses
     sideEffects: None

--- a/app/kumactl/cmd/install/testdata/install-control-plane.defaults.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.defaults.golden.yaml
@@ -1455,7 +1455,7 @@ spec:
     metadata:
       annotations:
         checksum/config: f509d41973f6ed84a86f16e996b13068bffb3a90d10d7886a37e1c5fc225f760
-        checksum/tls-secrets: 78e5236addc11d7549493c1756f9ace9c6dc65d04880293bfd22b97f8173476b
+        checksum/tls-secrets: 1962ebe5f21decca98ad3ce41df62b9e3adbcb22c20273f2904dc4b0c6bf39a7
       labels:
         app.kubernetes.io/name: kuma
         app.kubernetes.io/instance: kuma
@@ -1791,4 +1791,23 @@ webhooks:
           - DELETE
         resources:
           - secrets
+    sideEffects: None
+  - name: gateway.validator.kuma-admission.kuma.io
+    admissionReviewVersions: ["v1"]
+    failurePolicy: Ignore
+    clientConfig:
+      caBundle: XYZ
+      service:
+        namespace: kuma-system
+        name: kuma-control-plane
+        path: /validate-v1alpha2-gateway
+    rules:
+      - apiGroups:
+          - "gateway.networking.k8s.io"
+        apiVersions:
+          - v1alpha2
+        operations:
+          - CREATE
+        resources:
+          - gatewayclasses
     sideEffects: None

--- a/app/kumactl/cmd/install/testdata/install-control-plane.global.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.global.golden.yaml
@@ -1465,7 +1465,7 @@ spec:
     metadata:
       annotations:
         checksum/config: f509d41973f6ed84a86f16e996b13068bffb3a90d10d7886a37e1c5fc225f760
-        checksum/tls-secrets: 78e5236addc11d7549493c1756f9ace9c6dc65d04880293bfd22b97f8173476b
+        checksum/tls-secrets: 1962ebe5f21decca98ad3ce41df62b9e3adbcb22c20273f2904dc4b0c6bf39a7
       labels:
         app.kubernetes.io/name: kuma
         app.kubernetes.io/instance: kuma
@@ -1798,4 +1798,23 @@ webhooks:
           - DELETE
         resources:
           - secrets
+    sideEffects: None
+  - name: gateway.validator.kuma-admission.kuma.io
+    admissionReviewVersions: ["v1"]
+    failurePolicy: Ignore
+    clientConfig:
+      caBundle: XYZ
+      service:
+        namespace: kuma-system
+        name: kuma-control-plane
+        path: /validate-v1alpha2-gateway
+    rules:
+      - apiGroups:
+          - "gateway.networking.k8s.io"
+        apiVersions:
+          - v1alpha2
+        operations:
+          - CREATE
+        resources:
+          - gatewayclasses
     sideEffects: None

--- a/app/kumactl/cmd/install/testdata/install-control-plane.override-env-vars.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.override-env-vars.golden.yaml
@@ -1455,7 +1455,7 @@ spec:
     metadata:
       annotations:
         checksum/config: f509d41973f6ed84a86f16e996b13068bffb3a90d10d7886a37e1c5fc225f760
-        checksum/tls-secrets: 78e5236addc11d7549493c1756f9ace9c6dc65d04880293bfd22b97f8173476b
+        checksum/tls-secrets: 1962ebe5f21decca98ad3ce41df62b9e3adbcb22c20273f2904dc4b0c6bf39a7
       labels:
         app.kubernetes.io/name: kuma
         app.kubernetes.io/instance: kuma
@@ -1791,4 +1791,23 @@ webhooks:
           - DELETE
         resources:
           - secrets
+    sideEffects: None
+  - name: gateway.validator.kuma-admission.kuma.io
+    admissionReviewVersions: ["v1"]
+    failurePolicy: Ignore
+    clientConfig:
+      caBundle: XYZ
+      service:
+        namespace: kuma-system
+        name: kuma-control-plane
+        path: /validate-v1alpha2-gateway
+    rules:
+      - apiGroups:
+          - "gateway.networking.k8s.io"
+        apiVersions:
+          - v1alpha2
+        operations:
+          - CREATE
+        resources:
+          - gatewayclasses
     sideEffects: None

--- a/app/kumactl/cmd/install/testdata/install-control-plane.overrides.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.overrides.golden.yaml
@@ -1857,7 +1857,7 @@ spec:
     metadata:
       annotations:
         checksum/config: 8c443d9f48d469a050e9e994d3d839c09b7f22f3c16bbe096c5a7d30f4207d99
-        checksum/tls-secrets: e478434cf09212624ee5588731cf8bb726cc008ddd0170817bebc681fa3a88d7
+        checksum/tls-secrets: 4cdc5ea0136d2fc1d500b2140e93abc2f3f4356a8d80324439bb9dd985f9d582
       labels:
         app.kubernetes.io/name: kuma
         app.kubernetes.io/instance: kuma
@@ -2238,4 +2238,23 @@ webhooks:
           - DELETE
         resources:
           - secrets
+    sideEffects: None
+  - name: gateway.validator.kuma-admission.kuma.io
+    admissionReviewVersions: ["v1"]
+    failurePolicy: Ignore
+    clientConfig:
+      caBundle: XYZ
+      service:
+        namespace: kuma
+        name: kuma-ctrl-plane
+        path: /validate-v1alpha2-gateway
+    rules:
+      - apiGroups:
+          - "gateway.networking.k8s.io"
+        apiVersions:
+          - v1alpha2
+        operations:
+          - CREATE
+        resources:
+          - gatewayclasses
     sideEffects: None

--- a/app/kumactl/cmd/install/testdata/install-control-plane.with-egress.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.with-egress.golden.yaml
@@ -1484,7 +1484,7 @@ spec:
     metadata:
       annotations:
         checksum/config: f509d41973f6ed84a86f16e996b13068bffb3a90d10d7886a37e1c5fc225f760
-        checksum/tls-secrets: 78e5236addc11d7549493c1756f9ace9c6dc65d04880293bfd22b97f8173476b
+        checksum/tls-secrets: 1962ebe5f21decca98ad3ce41df62b9e3adbcb22c20273f2904dc4b0c6bf39a7
       labels:
         app.kubernetes.io/name: kuma
         app.kubernetes.io/instance: kuma
@@ -1930,4 +1930,23 @@ webhooks:
           - DELETE
         resources:
           - secrets
+    sideEffects: None
+  - name: gateway.validator.kuma-admission.kuma.io
+    admissionReviewVersions: ["v1"]
+    failurePolicy: Ignore
+    clientConfig:
+      caBundle: XYZ
+      service:
+        namespace: kuma-system
+        name: kuma-control-plane
+        path: /validate-v1alpha2-gateway
+    rules:
+      - apiGroups:
+          - "gateway.networking.k8s.io"
+        apiVersions:
+          - v1alpha2
+        operations:
+          - CREATE
+        resources:
+          - gatewayclasses
     sideEffects: None

--- a/app/kumactl/cmd/install/testdata/install-control-plane.with-ingress.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.with-ingress.golden.yaml
@@ -1484,7 +1484,7 @@ spec:
     metadata:
       annotations:
         checksum/config: f509d41973f6ed84a86f16e996b13068bffb3a90d10d7886a37e1c5fc225f760
-        checksum/tls-secrets: 78e5236addc11d7549493c1756f9ace9c6dc65d04880293bfd22b97f8173476b
+        checksum/tls-secrets: 1962ebe5f21decca98ad3ce41df62b9e3adbcb22c20273f2904dc4b0c6bf39a7
       labels:
         app.kubernetes.io/name: kuma
         app.kubernetes.io/instance: kuma
@@ -1930,4 +1930,23 @@ webhooks:
           - DELETE
         resources:
           - secrets
+    sideEffects: None
+  - name: gateway.validator.kuma-admission.kuma.io
+    admissionReviewVersions: ["v1"]
+    failurePolicy: Ignore
+    clientConfig:
+      caBundle: XYZ
+      service:
+        namespace: kuma-system
+        name: kuma-control-plane
+        path: /validate-v1alpha2-gateway
+    rules:
+      - apiGroups:
+          - "gateway.networking.k8s.io"
+        apiVersions:
+          - v1alpha2
+        operations:
+          - CREATE
+        resources:
+          - gatewayclasses
     sideEffects: None

--- a/app/kumactl/cmd/install/testdata/install-control-plane.zone.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.zone.golden.yaml
@@ -1459,7 +1459,7 @@ spec:
     metadata:
       annotations:
         checksum/config: f509d41973f6ed84a86f16e996b13068bffb3a90d10d7886a37e1c5fc225f760
-        checksum/tls-secrets: 78e5236addc11d7549493c1756f9ace9c6dc65d04880293bfd22b97f8173476b
+        checksum/tls-secrets: 1962ebe5f21decca98ad3ce41df62b9e3adbcb22c20273f2904dc4b0c6bf39a7
       labels:
         app.kubernetes.io/name: kuma
         app.kubernetes.io/instance: kuma
@@ -1799,4 +1799,23 @@ webhooks:
           - DELETE
         resources:
           - secrets
+    sideEffects: None
+  - name: gateway.validator.kuma-admission.kuma.io
+    admissionReviewVersions: ["v1"]
+    failurePolicy: Ignore
+    clientConfig:
+      caBundle: XYZ
+      service:
+        namespace: kuma-system
+        name: kuma-control-plane
+        path: /validate-v1alpha2-gateway
+    rules:
+      - apiGroups:
+          - "gateway.networking.k8s.io"
+        apiVersions:
+          - v1alpha2
+        operations:
+          - CREATE
+        resources:
+          - gatewayclasses
     sideEffects: None

--- a/deployments/charts/kuma/templates/cp-webhooks-and-secrets.yaml
+++ b/deployments/charts/kuma/templates/cp-webhooks-and-secrets.yaml
@@ -261,3 +261,22 @@ webhooks:
         resources:
           - secrets
     sideEffects: None
+  - name: gateway.validator.kuma-admission.kuma.io
+    admissionReviewVersions: ["v1"]
+    failurePolicy: Ignore
+    clientConfig:
+      caBundle: {{ $caBundle }}
+      service:
+        namespace: {{ .Release.Namespace }}
+        name: {{ include "kuma.controlPlane.serviceName" .  }}
+        path: /validate-v1alpha2-gateway
+    rules:
+      - apiGroups:
+          - "gateway.networking.k8s.io"
+        apiVersions:
+          - v1alpha2
+        operations:
+          - CREATE
+        resources:
+          - gatewayclasses
+    sideEffects: None

--- a/pkg/plugins/runtime/k8s/plugin.go
+++ b/pkg/plugins/runtime/k8s/plugin.go
@@ -267,12 +267,8 @@ func addValidators(mgr kube_ctrl.Manager, rt core_runtime.Runtime, converter k8s
 		composite.AddValidator(validator)
 	}
 
-	path := "/validate-kuma-io-v1alpha1"
-	mgr.GetWebhookServer().Register(path, composite.WebHook())
-	log.Info("Registering a validation composite webhook", "path", path)
-
+	mgr.GetWebhookServer().Register("/validate-kuma-io-v1alpha1", composite.WebHook())
 	mgr.GetWebhookServer().Register("/validate-v1-service", &kube_webhook.Admission{Handler: &k8s_webhooks.ServiceValidator{}})
-	log.Info("Registering a validation webhook for v1/Service", "path", "/validate-v1-service")
 
 	client, ok := k8s_extensions.FromSecretClientContext(rt.Extensions())
 	if !ok {
@@ -283,7 +279,11 @@ func addValidators(mgr kube_ctrl.Manager, rt core_runtime.Runtime, converter k8s
 		Validator: manager.NewSecretValidator(rt.CaManagers(), rt.ResourceStore()),
 	}
 	mgr.GetWebhookServer().Register("/validate-v1-secret", &kube_webhook.Admission{Handler: secretValidator})
-	log.Info("Registering a validation webhook for v1/Secret", "path", "/validate-v1-secret")
+
+	if gatewayAPICRDsPresent(mgr) {
+		gatewayValidator := k8s_webhooks.NewGatewayAPIMultizoneValidator(rt.Config().Mode)
+		mgr.GetWebhookServer().Register("/validate-v1alpha2-gateway", gatewayValidator)
+	}
 
 	return nil
 }

--- a/pkg/plugins/runtime/k8s/webhooks/gatewayapi_multizone_validator.go
+++ b/pkg/plugins/runtime/k8s/webhooks/gatewayapi_multizone_validator.go
@@ -1,0 +1,50 @@
+package webhooks
+
+import (
+	"context"
+	"errors"
+	"net/http"
+
+	admission "k8s.io/api/admission/v1"
+	kube_webhook "sigs.k8s.io/controller-runtime/pkg/webhook"
+	kube_admission "sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+	gatewayapi "sigs.k8s.io/gateway-api/apis/v1alpha2"
+
+	config_core "github.com/kumahq/kuma/pkg/config/core"
+	"github.com/kumahq/kuma/pkg/plugins/runtime/k8s/controllers/gatewayapi/common"
+)
+
+func NewGatewayAPIMultizoneValidator(cpMode config_core.CpMode) *kube_admission.Webhook {
+	return &kube_admission.Webhook{
+		Handler: &GatewayAPIMultizoneValidator{
+			CpMode: cpMode,
+		},
+	}
+}
+
+var GatewayAPINotSupportedErr = errors.New("GatewayAPI of Kuma is only supported in Standalone deployments")
+
+type GatewayAPIMultizoneValidator struct {
+	CpMode  config_core.CpMode
+	Decoder *kube_admission.Decoder
+}
+
+var _ kube_webhook.AdmissionHandler = &GatewayAPIMultizoneValidator{}
+
+func (g *GatewayAPIMultizoneValidator) InjectDecoder(d *kube_admission.Decoder) error {
+	g.Decoder = d
+	return nil
+}
+
+func (g *GatewayAPIMultizoneValidator) Handle(_ context.Context, req kube_admission.Request) kube_admission.Response {
+	if req.Operation == admission.Create {
+		gatewayClass := &gatewayapi.GatewayClass{}
+		if err := g.Decoder.Decode(req, gatewayClass); err != nil {
+			return kube_admission.Errored(http.StatusBadRequest, err)
+		}
+		if g.CpMode != config_core.Standalone && gatewayClass.Spec.ControllerName == common.ControllerName {
+			return kube_admission.Errored(http.StatusBadRequest, GatewayAPINotSupportedErr)
+		}
+	}
+	return kube_admission.Allowed("")
+}

--- a/pkg/plugins/runtime/k8s/webhooks/gatewayapi_multizone_validator_test.go
+++ b/pkg/plugins/runtime/k8s/webhooks/gatewayapi_multizone_validator_test.go
@@ -1,0 +1,92 @@
+package webhooks_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	admission "k8s.io/api/admission/v1"
+	kube_meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kube_runtime "k8s.io/apimachinery/pkg/runtime"
+	kube_admission "sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+	gatewayapi "sigs.k8s.io/gateway-api/apis/v1alpha2"
+
+	config_core "github.com/kumahq/kuma/pkg/config/core"
+	"github.com/kumahq/kuma/pkg/plugins/runtime/k8s/controllers/gatewayapi/common"
+	"github.com/kumahq/kuma/pkg/plugins/runtime/k8s/webhooks"
+)
+
+var _ = Describe("Gateway API mutlizone validation webhook", func() {
+
+	type testCase struct {
+		cpMode       config_core.CpMode
+		gatewayClass gatewayapi.GatewayClass
+		response     kube_admission.Response
+	}
+
+	KumaGatewayClass := gatewayapi.GatewayClass{
+		Spec: gatewayapi.GatewayClassSpec{
+			ControllerName: common.ControllerName,
+		},
+	}
+
+	DescribeTable("should validate",
+		func(given testCase) {
+			// given
+			validator := webhooks.GatewayAPIMultizoneValidator{
+				CpMode:  given.cpMode,
+				Decoder: decoder,
+			}
+
+			bytes, err := json.Marshal(&given.gatewayClass)
+			Expect(err).ToNot(HaveOccurred())
+
+			req := kube_admission.Request{
+				AdmissionRequest: admission.AdmissionRequest{
+					Operation: admission.Create,
+					UID:       "12345",
+					Object: kube_runtime.RawExtension{
+						Raw: bytes,
+					},
+					Kind: kube_meta.GroupVersionKind{
+						Group:   given.gatewayClass.GetObjectKind().GroupVersionKind().Group,
+						Version: given.gatewayClass.GetObjectKind().GroupVersionKind().Version,
+						Kind:    given.gatewayClass.GetObjectKind().GroupVersionKind().Kind,
+					},
+				},
+			}
+
+			// when
+			resp := validator.Handle(context.Background(), req)
+
+			// then
+			Expect(resp).To(Equal(given.response))
+		},
+		Entry("pass on standalone with Kuma gateway", testCase{
+			cpMode:       config_core.Standalone,
+			gatewayClass: KumaGatewayClass,
+			response:     kube_admission.Allowed(""),
+		}),
+		Entry("do not pass on Zone with Kuma gateway", testCase{
+			cpMode:       config_core.Zone,
+			gatewayClass: KumaGatewayClass,
+			response:     kube_admission.Errored(http.StatusBadRequest, webhooks.GatewayAPINotSupportedErr),
+		}),
+		Entry("do not pass on Global with Kuma gateway", testCase{
+			cpMode:       config_core.Global,
+			gatewayClass: KumaGatewayClass,
+			response:     kube_admission.Errored(http.StatusBadRequest, webhooks.GatewayAPINotSupportedErr),
+		}),
+		Entry("pass unknown gateway on Global", testCase{
+			cpMode: config_core.Global,
+			gatewayClass: gatewayapi.GatewayClass{
+				Spec: gatewayapi.GatewayClassSpec{
+					ControllerName: "some-other-controller",
+				},
+			},
+			response: kube_admission.Allowed(""),
+		}),
+	)
+})


### PR DESCRIPTION
### Summary

Provide validation that Gateway API cannot be used with Zone and Global CP.
I validate only GatewayClass, otherwise, it's kind of hard to figure out if Gateway or GatewayRoute is used only with Kuma or not. GatewayClass is the required resource for Kuma Gateway to work anyways.

### Issues resolved

Fix #3905

### Documentation

There is already docs that you cannot use GatewayAPI with mutlizone

### Testing

- [X] Unit tests
- [ ] E2E tests
- [ ] Manual testing on Universal
- [X] Manual testing on Kubernetes

### Backwards compatibility

~- [ ] Update [`UPGRADE.md`](/UPGRADE.md) with any steps users will need to take when upgrading.~
~- [ ] Add `backport-to-stable` label if the code follows our [backporting policy](/CONTRIBUTING.md#backporting)~
