### PR TITLE
test(*): skip gatewayapi tests for IPV6

### DIFF
--- a/test/e2e/gateway/gatewayapi/gateway_api.go
+++ b/test/e2e/gateway/gatewayapi/gateway_api.go
@@ -38,6 +38,10 @@ spec:
 var cluster *K8sCluster
 
 var _ = E2EBeforeSuite(func() {
+	if Config.IPV6 {
+		return // KIND which is used for IPV6 tests does not support load balancer that is used in this test.
+	}
+
 	cluster = NewK8sCluster(NewTestingT(), Kuma1, Silent)
 
 	err := NewClusterSetup().
@@ -69,6 +73,9 @@ var _ = E2EBeforeSuite(func() {
 })
 
 func GatewayAPI() {
+	if Config.IPV6 {
+		return // KIND which is used for IPV6 tests does not support load balancer that is used in this test.
+	}
 	Context("HTTP Gateway", func() {
 		gateway := `
 apiVersion: gateway.networking.k8s.io/v1alpha2
@@ -94,7 +101,7 @@ spec:
 				g.Expect(err).ToNot(HaveOccurred())
 				g.Expect(out).ToNot(BeEmpty())
 				ip = out
-			}, "30s", "1s").Should(Succeed(), "could not get a LoadBalancer IP of the Gateway")
+			}, "60s", "1s").Should(Succeed(), "could not get a LoadBalancer IP of the Gateway")
 			return net.JoinHostPort(ip, "8080")
 		}
 

--- a/test/framework/client/collect.go
+++ b/test/framework/client/collect.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path"
 	"sync"
+	"time"
 
 	"github.com/gruntwork-io/terratest/modules/k8s"
 	"github.com/pkg/errors"
@@ -234,7 +235,10 @@ func CollectResponseDirectly(
 		req.Host = host
 	}
 
-	resp, err := http.DefaultClient.Do(req)
+	client := &http.Client{
+		Timeout: 5 * time.Second,
+	}
+	resp, err := client.Do(req)
 	if err != nil {
 		return types.EchoResponse{}, err
 	}


### PR DESCRIPTION
### Summary

Skip Gateway API tests for IPV6 and increase timeout for loadbalancer since I noticed it timeout out once.

### Issues resolved

No issues reported - flaky test.

### Documentation

~- [ ] Link to the website [documentation PR](https://github.com/kumahq/kuma-website/pull/XXX)~

### Testing

- [ ] Unit tests
- [X] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes

### Backwards compatibility

~- [ ] Update [`UPGRADE.md`](/UPGRADE.md) with any steps users will need to take when upgrading.~
~- [ ] Add `backport-to-stable` label if the code follows our [backporting policy](/CONTRIBUTING.md#backporting)~
