### PR TITLE
fix(kuma-cp): gateway reconciliation loops forever

### DIFF
--- a/pkg/plugins/runtime/k8s/controllers/gatewayapi/gateway_controller.go
+++ b/pkg/plugins/runtime/k8s/controllers/gatewayapi/gateway_controller.go
@@ -43,6 +43,7 @@ type GatewayReconciler struct {
 // Reconcile handles transforming a gateway-api MeshGateway into a Kuma MeshGateway and
 // managing the status of the gateway-api objects.
 func (r *GatewayReconciler) Reconcile(ctx context.Context, req kube_ctrl.Request) (kube_ctrl.Result, error) {
+	r.Log.V(1).Info("reconcile", "req", req)
 	gateway := &gatewayapi.Gateway{}
 	if err := r.Get(ctx, req.NamespacedName, gateway); err != nil {
 		if kube_apierrs.IsNotFound(err) {
@@ -88,7 +89,7 @@ func (r *GatewayReconciler) Reconcile(ctx context.Context, req kube_ctrl.Request
 		}
 	}
 
-	if err := r.updateStatus(ctx, gateway, gatewayInstance, listenerConditions); err != nil {
+	if err := r.updateStatus(ctx, r.Log, gateway, gatewayInstance, listenerConditions); err != nil {
 		return kube_ctrl.Result{}, errors.Wrap(err, "unable to update MeshGateway status")
 	}
 

--- a/pkg/plugins/runtime/k8s/controllers/gatewayapi/gateway_status.go
+++ b/pkg/plugins/runtime/k8s/controllers/gatewayapi/gateway_status.go
@@ -6,7 +6,9 @@ import (
 	"reflect"
 	"strings"
 
+	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
+	"k8s.io/apimachinery/pkg/api/equality"
 	kube_apierrs "k8s.io/apimachinery/pkg/api/errors"
 	kube_apimeta "k8s.io/apimachinery/pkg/api/meta"
 	kube_meta "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -19,6 +21,7 @@ import (
 
 func (r *GatewayReconciler) updateStatus(
 	ctx context.Context,
+	log logr.Logger,
 	gateway *gatewayapi.Gateway,
 	gatewayInstance *mesh_k8s.MeshGatewayInstance,
 	listenerConditions ListenerConditions,
@@ -32,6 +35,11 @@ func (r *GatewayReconciler) updateStatus(
 
 	mergeGatewayStatus(updated, gatewayInstance, listenerConditions, attachedListeners)
 
+	if equality.Semantic.DeepEqual(gateway.Status, updated.Status) {
+		return nil
+	}
+
+	log.Info("updating Gateway status")
 	if err := r.Client.Status().Patch(ctx, updated, kube_client.MergeFrom(gateway)); err != nil {
 		if kube_apierrs.IsNotFound(err) {
 			return nil


### PR DESCRIPTION
### Summary

Gateway API reconciliation was stuck in a loop (reconciling forever) because GatewayInstance was constantly updated.
We should only update Status of objects if there is any change to the status.

### Issues resolved

No issues reported

### Documentation

~- [ ] Link to the website [documentation PR](https://github.com/kumahq/kuma-website/pull/XXX)~

### Testing

- [ ] Unit tests
- [ ] E2E tests
- [ ] Manual testing on Universal
- [X] Manual testing on Kubernetes

### Backwards compatibility

~- [ ] Update [`UPGRADE.md`](/UPGRADE.md) with any steps users will need to take when upgrading.~
~- [ ] Add `backport-to-stable` label if the code follows our [backporting policy](/CONTRIBUTING.md#backporting)~
