### PR TITLE
feat(helm): Expose kuma-cp's metric port so it can be scraped by self-deployed prometheus.

### DIFF
--- a/app/kumactl/cmd/install/testdata/install-control-plane.cni-enabled.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.cni-enabled.golden.yaml
@@ -1501,6 +1501,8 @@ metadata:
 spec:
   type: ClusterIP
   ports:
+    - port: 5680
+      name: metrics
     - port: 5681
       name: http-api-server
     - port: 5682
@@ -1703,6 +1705,9 @@ spec:
             - --log-level=info
             - --config-file=/etc/kuma.io/kuma-control-plane/config.yaml
           ports:
+            - containerPort: 5680
+              name: metrics
+              protocol: TCP
             - containerPort: 5681
             - containerPort: 5682
             - containerPort: 5443

--- a/app/kumactl/cmd/install/testdata/install-control-plane.cni-enabled.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.cni-enabled.golden.yaml
@@ -1502,7 +1502,7 @@ spec:
   type: ClusterIP
   ports:
     - port: 5680
-      name: metrics
+      name: diagnostics
     - port: 5681
       name: http-api-server
     - port: 5682
@@ -1706,7 +1706,7 @@ spec:
             - --config-file=/etc/kuma.io/kuma-control-plane/config.yaml
           ports:
             - containerPort: 5680
-              name: metrics
+              name: diagnostics
               protocol: TCP
             - containerPort: 5681
             - containerPort: 5682

--- a/app/kumactl/cmd/install/testdata/install-control-plane.defaults.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.defaults.golden.yaml
@@ -1412,6 +1412,8 @@ metadata:
 spec:
   type: ClusterIP
   ports:
+    - port: 5680
+      name: metrics
     - port: 5681
       name: http-api-server
     - port: 5682
@@ -1528,6 +1530,9 @@ spec:
             - --log-level=info
             - --config-file=/etc/kuma.io/kuma-control-plane/config.yaml
           ports:
+            - containerPort: 5680
+              name: metrics
+              protocol: TCP
             - containerPort: 5681
             - containerPort: 5682
             - containerPort: 5443

--- a/app/kumactl/cmd/install/testdata/install-control-plane.defaults.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.defaults.golden.yaml
@@ -1413,7 +1413,7 @@ spec:
   type: ClusterIP
   ports:
     - port: 5680
-      name: metrics
+      name: diagnostics
     - port: 5681
       name: http-api-server
     - port: 5682
@@ -1531,7 +1531,7 @@ spec:
             - --config-file=/etc/kuma.io/kuma-control-plane/config.yaml
           ports:
             - containerPort: 5680
-              name: metrics
+              name: diagnostics
               protocol: TCP
             - containerPort: 5681
             - containerPort: 5682

--- a/app/kumactl/cmd/install/testdata/install-control-plane.global.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.global.golden.yaml
@@ -1430,7 +1430,7 @@ spec:
   type: ClusterIP
   ports:
     - port: 5680
-      name: metrics
+      name: diagnostics
     - port: 5681
       name: http-api-server
     - port: 5682
@@ -1541,7 +1541,7 @@ spec:
             - --config-file=/etc/kuma.io/kuma-control-plane/config.yaml
           ports:
             - containerPort: 5680
-              name: metrics
+              name: diagnostics
               protocol: TCP
             - containerPort: 5681
             - containerPort: 5682

--- a/app/kumactl/cmd/install/testdata/install-control-plane.global.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.global.golden.yaml
@@ -1429,6 +1429,8 @@ metadata:
 spec:
   type: ClusterIP
   ports:
+    - port: 5680
+      name: metrics
     - port: 5681
       name: http-api-server
     - port: 5682
@@ -1538,6 +1540,9 @@ spec:
             - --log-level=info
             - --config-file=/etc/kuma.io/kuma-control-plane/config.yaml
           ports:
+            - containerPort: 5680
+              name: metrics
+              protocol: TCP
             - containerPort: 5681
             - containerPort: 5682
             - containerPort: 5443

--- a/app/kumactl/cmd/install/testdata/install-control-plane.override-env-vars.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.override-env-vars.golden.yaml
@@ -1412,6 +1412,8 @@ metadata:
 spec:
   type: ClusterIP
   ports:
+    - port: 5680
+      name: metrics
     - port: 5681
       name: http-api-server
     - port: 5682
@@ -1528,6 +1530,9 @@ spec:
             - --log-level=info
             - --config-file=/etc/kuma.io/kuma-control-plane/config.yaml
           ports:
+            - containerPort: 5680
+              name: metrics
+              protocol: TCP
             - containerPort: 5681
             - containerPort: 5682
             - containerPort: 5443

--- a/app/kumactl/cmd/install/testdata/install-control-plane.override-env-vars.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.override-env-vars.golden.yaml
@@ -1413,7 +1413,7 @@ spec:
   type: ClusterIP
   ports:
     - port: 5680
-      name: metrics
+      name: diagnostics
     - port: 5681
       name: http-api-server
     - port: 5682
@@ -1531,7 +1531,7 @@ spec:
             - --config-file=/etc/kuma.io/kuma-control-plane/config.yaml
           ports:
             - containerPort: 5680
-              name: metrics
+              name: diagnostics
               protocol: TCP
             - containerPort: 5681
             - containerPort: 5682

--- a/app/kumactl/cmd/install/testdata/install-control-plane.overrides.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.overrides.golden.yaml
@@ -1815,7 +1815,7 @@ spec:
   type: ClusterIP
   ports:
     - port: 5680
-      name: metrics
+      name: diagnostics
     - port: 5681
       name: http-api-server
     - port: 5682
@@ -1951,7 +1951,7 @@ spec:
             - --config-file=/etc/kuma.io/kuma-control-plane/config.yaml
           ports:
             - containerPort: 5680
-              name: metrics
+              name: diagnostics
               protocol: TCP
             - containerPort: 5681
             - containerPort: 5682

--- a/app/kumactl/cmd/install/testdata/install-control-plane.overrides.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.overrides.golden.yaml
@@ -1814,6 +1814,8 @@ metadata:
 spec:
   type: ClusterIP
   ports:
+    - port: 5680
+      name: metrics
     - port: 5681
       name: http-api-server
     - port: 5682
@@ -1948,6 +1950,9 @@ spec:
             - --log-level=info
             - --config-file=/etc/kuma.io/kuma-control-plane/config.yaml
           ports:
+            - containerPort: 5680
+              name: metrics
+              protocol: TCP
             - containerPort: 5681
             - containerPort: 5682
             - containerPort: 5443

--- a/app/kumactl/cmd/install/testdata/install-control-plane.with-egress.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.with-egress.golden.yaml
@@ -1421,6 +1421,8 @@ metadata:
 spec:
   type: ClusterIP
   ports:
+    - port: 5680
+      name: metrics
     - port: 5681
       name: http-api-server
     - port: 5682
@@ -1557,6 +1559,9 @@ spec:
             - --log-level=info
             - --config-file=/etc/kuma.io/kuma-control-plane/config.yaml
           ports:
+            - containerPort: 5680
+              name: metrics
+              protocol: TCP
             - containerPort: 5681
             - containerPort: 5682
             - containerPort: 5443

--- a/app/kumactl/cmd/install/testdata/install-control-plane.with-egress.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.with-egress.golden.yaml
@@ -1422,7 +1422,7 @@ spec:
   type: ClusterIP
   ports:
     - port: 5680
-      name: metrics
+      name: diagnostics
     - port: 5681
       name: http-api-server
     - port: 5682
@@ -1560,7 +1560,7 @@ spec:
             - --config-file=/etc/kuma.io/kuma-control-plane/config.yaml
           ports:
             - containerPort: 5680
-              name: metrics
+              name: diagnostics
               protocol: TCP
             - containerPort: 5681
             - containerPort: 5682

--- a/app/kumactl/cmd/install/testdata/install-control-plane.with-ingress.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.with-ingress.golden.yaml
@@ -1421,6 +1421,8 @@ metadata:
 spec:
   type: ClusterIP
   ports:
+    - port: 5680
+      name: metrics
     - port: 5681
       name: http-api-server
     - port: 5682
@@ -1557,6 +1559,9 @@ spec:
             - --log-level=info
             - --config-file=/etc/kuma.io/kuma-control-plane/config.yaml
           ports:
+            - containerPort: 5680
+              name: metrics
+              protocol: TCP
             - containerPort: 5681
             - containerPort: 5682
             - containerPort: 5443

--- a/app/kumactl/cmd/install/testdata/install-control-plane.with-ingress.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.with-ingress.golden.yaml
@@ -1422,7 +1422,7 @@ spec:
   type: ClusterIP
   ports:
     - port: 5680
-      name: metrics
+      name: diagnostics
     - port: 5681
       name: http-api-server
     - port: 5682
@@ -1560,7 +1560,7 @@ spec:
             - --config-file=/etc/kuma.io/kuma-control-plane/config.yaml
           ports:
             - containerPort: 5680
-              name: metrics
+              name: diagnostics
               protocol: TCP
             - containerPort: 5681
             - containerPort: 5682

--- a/app/kumactl/cmd/install/testdata/install-control-plane.zone.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.zone.golden.yaml
@@ -1416,6 +1416,8 @@ metadata:
 spec:
   type: ClusterIP
   ports:
+    - port: 5680
+      name: metrics
     - port: 5681
       name: http-api-server
     - port: 5682
@@ -1536,6 +1538,9 @@ spec:
             - --log-level=info
             - --config-file=/etc/kuma.io/kuma-control-plane/config.yaml
           ports:
+            - containerPort: 5680
+              name: metrics
+              protocol: TCP
             - containerPort: 5681
             - containerPort: 5682
             - containerPort: 5443

--- a/app/kumactl/cmd/install/testdata/install-control-plane.zone.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.zone.golden.yaml
@@ -1417,7 +1417,7 @@ spec:
   type: ClusterIP
   ports:
     - port: 5680
-      name: metrics
+      name: diagnostics
     - port: 5681
       name: http-api-server
     - port: 5682
@@ -1539,7 +1539,7 @@ spec:
             - --config-file=/etc/kuma.io/kuma-control-plane/config.yaml
           ports:
             - containerPort: 5680
-              name: metrics
+              name: diagnostics
               protocol: TCP
             - containerPort: 5681
             - containerPort: 5682

--- a/deployments/charts/kuma/templates/cp-deployment.yaml
+++ b/deployments/charts/kuma/templates/cp-deployment.yaml
@@ -81,7 +81,7 @@ spec:
             - --config-file=/etc/kuma.io/kuma-control-plane/config.yaml
           ports:
             - containerPort: 5680
-              name: metrics
+              name: diagnostics
               protocol: TCP
             - containerPort: 5681
             - containerPort: 5682

--- a/deployments/charts/kuma/templates/cp-deployment.yaml
+++ b/deployments/charts/kuma/templates/cp-deployment.yaml
@@ -80,6 +80,9 @@ spec:
             - --log-level={{ .Values.controlPlane.logLevel }}
             - --config-file=/etc/kuma.io/kuma-control-plane/config.yaml
           ports:
+            - containerPort: 5680
+              name: metrics
+              protocol: TCP
             - containerPort: 5681
             - containerPort: 5682
             - containerPort: 5443

--- a/deployments/charts/kuma/templates/cp-service.yaml
+++ b/deployments/charts/kuma/templates/cp-service.yaml
@@ -14,6 +14,8 @@ metadata:
 spec:
   type: {{ .Values.controlPlane.service.type }}
   ports:
+    - port: 5680
+      name: metrics
     - port: 5681
       name: http-api-server
     - port: 5682

--- a/deployments/charts/kuma/templates/cp-service.yaml
+++ b/deployments/charts/kuma/templates/cp-service.yaml
@@ -15,7 +15,7 @@ spec:
   type: {{ .Values.controlPlane.service.type }}
   ports:
     - port: 5680
-      name: metrics
+      name: diagnostics
     - port: 5681
       name: http-api-server
     - port: 5682


### PR DESCRIPTION
### Summary

This PR updates both the kuma-cp deployment, and service template by exposing the metrics port (TCP/5680) so that metrics can easily be scraped by self-deployed Prometheus.  This configuration supports both Prometheus Operator configured PodMonitors, and ServiceMonitors configuration options.

### Full changelog

* Helm - Exposed kuma-cp's metric port via deployment and service configurations

### Documentation

N/A

### Testing

- [ ] Unit tests
- [ ] E2E tests
- [ ] Manual testing on Universal
- [ x ] Manual testing on Kubernetes

### Backwards compatibility

- Does not effect backwards compatibility.
