### PR TITLE
fix(gateway): fix status updating in MeshGatewayInstance reconciliation

### DIFF
--- a/pkg/plugins/runtime/k8s/controllers/gateway_instance_controller.go
+++ b/pkg/plugins/runtime/k8s/controllers/gateway_instance_controller.go
@@ -12,6 +12,7 @@ import (
 	kube_apps "k8s.io/api/apps/v1"
 	kube_core "k8s.io/api/core/v1"
 	kube_apierrs "k8s.io/apimachinery/pkg/api/errors"
+	kube_apimeta "k8s.io/apimachinery/pkg/api/meta"
 	kube_meta "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kube_runtime "k8s.io/apimachinery/pkg/runtime"
 	kube_schema "k8s.io/apimachinery/pkg/runtime/schema"
@@ -290,12 +291,17 @@ func updateStatus(gatewayInstance *mesh_k8s.MeshGatewayInstance, svc *kube_core.
 	}
 
 	readiness := kube_meta.Condition{
-		Type: mesh_k8s.GatewayInstanceReady, Status: status, Reason: reason, Message: message, LastTransitionTime: kube_meta.Now(), ObservedGeneration: gatewayInstance.GetGeneration(),
+		Type:               mesh_k8s.GatewayInstanceReady,
+		Status:             status,
+		Reason:             reason,
+		Message:            message,
+		ObservedGeneration: gatewayInstance.GetGeneration(),
 	}
 
-	gatewayInstance.Status.Conditions = []kube_meta.Condition{
+	kube_apimeta.SetStatusCondition(
+		&gatewayInstance.Status.Conditions,
 		readiness,
-	}
+	)
 }
 
 const serviceKey string = ".metadata.service"

--- a/pkg/plugins/runtime/k8s/controllers/gateway_instance_controller.go
+++ b/pkg/plugins/runtime/k8s/controllers/gateway_instance_controller.go
@@ -49,6 +49,7 @@ type GatewayInstanceReconciler struct {
 // Reconcile handles ensuring both a Service and a Deployment exist for an
 // instance as well as setting the status.
 func (r *GatewayInstanceReconciler) Reconcile(ctx context.Context, req kube_ctrl.Request) (kube_ctrl.Result, error) {
+	r.Log.V(1).Info("reconcile", "req", req)
 	gatewayInstance := &mesh_k8s.MeshGatewayInstance{}
 	if err := r.Get(ctx, req.NamespacedName, gatewayInstance); err != nil {
 		if kube_apierrs.IsNotFound(err) {

--- a/pkg/plugins/runtime/k8s/controllers/gateway_instance_controller.go
+++ b/pkg/plugins/runtime/k8s/controllers/gateway_instance_controller.go
@@ -11,7 +11,6 @@ import (
 	"github.com/pkg/errors"
 	kube_apps "k8s.io/api/apps/v1"
 	kube_core "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/equality"
 	kube_apierrs "k8s.io/apimachinery/pkg/api/errors"
 	kube_meta "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kube_runtime "k8s.io/apimachinery/pkg/runtime"
@@ -49,7 +48,6 @@ type GatewayInstanceReconciler struct {
 // Reconcile handles ensuring both a Service and a Deployment exist for an
 // instance as well as setting the status.
 func (r *GatewayInstanceReconciler) Reconcile(ctx context.Context, req kube_ctrl.Request) (kube_ctrl.Result, error) {
-	r.Log.V(1).Info("reconcile", "req", req)
 	gatewayInstance := &mesh_k8s.MeshGatewayInstance{}
 	if err := r.Get(ctx, req.NamespacedName, gatewayInstance); err != nil {
 		if kube_apierrs.IsNotFound(err) {
@@ -75,14 +73,11 @@ func (r *GatewayInstanceReconciler) Reconcile(ctx context.Context, req kube_ctrl
 
 	updateStatus(gatewayInstance, svc, deployment)
 
-	if !equality.Semantic.DeepEqual(gatewayInstance.Status, orig.(*mesh_k8s.MeshGatewayInstance).Status) {
-		r.Log.Info("updating MeshGatewayInstance status")
-		if err := r.Client.Status().Patch(ctx, gatewayInstance, kube_client.MergeFrom(orig)); err != nil {
-			if kube_apierrs.IsNotFound(err) {
-				return kube_ctrl.Result{}, nil
-			}
-			return kube_ctrl.Result{}, errors.Wrap(err, "unable to patch MeshGatewayInstance status")
+	if err := r.Client.Status().Patch(ctx, gatewayInstance, kube_client.MergeFrom(orig)); err != nil {
+		if kube_apierrs.IsNotFound(err) {
+			return kube_ctrl.Result{}, nil
 		}
+		return kube_ctrl.Result{}, errors.Wrap(err, "unable to patch MeshGatewayInstance status")
 	}
 
 	return kube_ctrl.Result{}, nil
@@ -295,24 +290,9 @@ func updateStatus(gatewayInstance *mesh_k8s.MeshGatewayInstance, svc *kube_core.
 	}
 
 	readiness := kube_meta.Condition{
-		Type:    mesh_k8s.GatewayInstanceReady,
-		Status:  status,
-		Reason:  reason,
-		Message: message,
+		Type: mesh_k8s.GatewayInstanceReady, Status: status, Reason: reason, Message: message, LastTransitionTime: kube_meta.Now(), ObservedGeneration: gatewayInstance.GetGeneration(),
 	}
 
-	if len(gatewayInstance.Status.Conditions) > 0 {
-		oldReadiness := gatewayInstance.Status.Conditions[0]
-		oldReadiness.LastTransitionTime = kube_meta.Time{}
-		oldReadiness.ObservedGeneration = 0
-
-		if equality.Semantic.DeepEqual(readiness, oldReadiness) {
-			return
-		}
-	}
-
-	readiness.LastTransitionTime = kube_meta.Now()
-	readiness.ObservedGeneration = gatewayInstance.GetGeneration()
 	gatewayInstance.Status.Conditions = []kube_meta.Condition{
 		readiness,
 	}

--- a/pkg/plugins/runtime/k8s/controllers/gatewayapi/gateway_controller.go
+++ b/pkg/plugins/runtime/k8s/controllers/gatewayapi/gateway_controller.go
@@ -43,7 +43,6 @@ type GatewayReconciler struct {
 // Reconcile handles transforming a gateway-api MeshGateway into a Kuma MeshGateway and
 // managing the status of the gateway-api objects.
 func (r *GatewayReconciler) Reconcile(ctx context.Context, req kube_ctrl.Request) (kube_ctrl.Result, error) {
-	r.Log.V(1).Info("reconcile", "req", req)
 	gateway := &gatewayapi.Gateway{}
 	if err := r.Get(ctx, req.NamespacedName, gateway); err != nil {
 		if kube_apierrs.IsNotFound(err) {
@@ -89,7 +88,7 @@ func (r *GatewayReconciler) Reconcile(ctx context.Context, req kube_ctrl.Request
 		}
 	}
 
-	if err := r.updateStatus(ctx, r.Log, gateway, gatewayInstance, listenerConditions); err != nil {
+	if err := r.updateStatus(ctx, gateway, gatewayInstance, listenerConditions); err != nil {
 		return kube_ctrl.Result{}, errors.Wrap(err, "unable to update MeshGateway status")
 	}
 

--- a/pkg/plugins/runtime/k8s/controllers/gatewayapi/gateway_controller.go
+++ b/pkg/plugins/runtime/k8s/controllers/gatewayapi/gateway_controller.go
@@ -43,6 +43,7 @@ type GatewayReconciler struct {
 // Reconcile handles transforming a gateway-api MeshGateway into a Kuma MeshGateway and
 // managing the status of the gateway-api objects.
 func (r *GatewayReconciler) Reconcile(ctx context.Context, req kube_ctrl.Request) (kube_ctrl.Result, error) {
+	r.Log.V(1).Info("reconcile", "req", req)
 	gateway := &gatewayapi.Gateway{}
 	if err := r.Get(ctx, req.NamespacedName, gateway); err != nil {
 		if kube_apierrs.IsNotFound(err) {

--- a/pkg/plugins/runtime/k8s/controllers/gatewayapi/gateway_status.go
+++ b/pkg/plugins/runtime/k8s/controllers/gatewayapi/gateway_status.go
@@ -6,9 +6,7 @@ import (
 	"reflect"
 	"strings"
 
-	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
-	"k8s.io/apimachinery/pkg/api/equality"
 	kube_apierrs "k8s.io/apimachinery/pkg/api/errors"
 	kube_apimeta "k8s.io/apimachinery/pkg/api/meta"
 	kube_meta "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -21,7 +19,6 @@ import (
 
 func (r *GatewayReconciler) updateStatus(
 	ctx context.Context,
-	log logr.Logger,
 	gateway *gatewayapi.Gateway,
 	gatewayInstance *mesh_k8s.MeshGatewayInstance,
 	listenerConditions ListenerConditions,
@@ -35,11 +32,6 @@ func (r *GatewayReconciler) updateStatus(
 
 	mergeGatewayStatus(updated, gatewayInstance, listenerConditions, attachedListeners)
 
-	if equality.Semantic.DeepEqual(gateway.Status, updated.Status) {
-		return nil
-	}
-
-	log.Info("updating Gateway status")
 	if err := r.Client.Status().Patch(ctx, updated, kube_client.MergeFrom(gateway)); err != nil {
 		if kube_apierrs.IsNotFound(err) {
 			return nil

--- a/pkg/plugins/runtime/k8s/controllers/gatewayapi/http_route_controller.go
+++ b/pkg/plugins/runtime/k8s/controllers/gatewayapi/http_route_controller.go
@@ -47,6 +47,7 @@ const (
 // Reconcile handles transforming a gateway-api HTTPRoute into a Kuma
 // GatewayRoute and managing the status of the gateway-api objects.
 func (r *HTTPRouteReconciler) Reconcile(ctx context.Context, req kube_ctrl.Request) (kube_ctrl.Result, error) {
+	r.Log.V(1).Info("reconcile", "req", req)
 	httpRoute := &gatewayapi.HTTPRoute{}
 	if err := r.Get(ctx, req.NamespacedName, httpRoute); err != nil {
 		if kube_apierrs.IsNotFound(err) {


### PR DESCRIPTION
### Summary

Revert #4034 and use `SetStatusCondition`

The problem fixed by #4034 appears to be that `LastTransitionTime` was always updated with the current time. `SetStatusCondition` handles this and it's already in use for the Gateway API objects, `GatewayInstanceReconciler` hadn't been updated.