### PR TITLE
fix(kuma-cp): execute hooks before proxy template modifications

### DIFF
--- a/pkg/xds/generator/proxy_template.go
+++ b/pkg/xds/generator/proxy_template.go
@@ -3,15 +3,12 @@ package generator
 import (
 	"fmt"
 
-	"github.com/pkg/errors"
-
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	model "github.com/kumahq/kuma/pkg/core/xds"
 	util_envoy "github.com/kumahq/kuma/pkg/util/envoy"
 	xds_context "github.com/kumahq/kuma/pkg/xds/context"
 	"github.com/kumahq/kuma/pkg/xds/generator/egress"
-	"github.com/kumahq/kuma/pkg/xds/generator/modifications"
 	"github.com/kumahq/kuma/pkg/xds/template"
 )
 
@@ -34,9 +31,6 @@ func (g *ProxyTemplateGenerator) Generate(ctx xds_context.Context, proxy *model.
 		return nil, fmt.Errorf("resources: %s", err)
 	} else {
 		resources.AddSet(rs)
-	}
-	if err := modifications.Apply(resources, g.ProxyTemplate.GetConf().GetModifications(), proxy.APIVersion); err != nil {
-		return nil, errors.Wrap(err, "could not apply modifications")
 	}
 	return resources, nil
 }

--- a/pkg/xds/generator/proxy_template_test.go
+++ b/pkg/xds/generator/proxy_template_test.go
@@ -17,6 +17,7 @@ import (
 	xds_context "github.com/kumahq/kuma/pkg/xds/context"
 	envoy_common "github.com/kumahq/kuma/pkg/xds/envoy"
 	"github.com/kumahq/kuma/pkg/xds/generator"
+	modifications "github.com/kumahq/kuma/pkg/xds/generator/modifications/v3"
 )
 
 var _ = Describe("ProxyTemplateGenerator", func() {
@@ -161,17 +162,14 @@ var _ = Describe("ProxyTemplateGenerator", func() {
 
 				// when
 				rs, err := gen.Generate(ctx, proxy)
-
-				// then
+				Expect(err).ToNot(HaveOccurred())
+				err = modifications.Apply(rs, proxyTemplate.GetConf().GetModifications())
 				Expect(err).ToNot(HaveOccurred())
 
-				// when
+				// then
 				resp, err := rs.List().ToDeltaDiscoveryResponse()
-				// then
 				Expect(err).ToNot(HaveOccurred())
-				// when
 				actual, err := util_proto.ToYAML(resp)
-				// then
 				Expect(err).ToNot(HaveOccurred())
 
 				// and output matches golden files

--- a/pkg/xds/server/v3/reconcile.go
+++ b/pkg/xds/server/v3/reconcile.go
@@ -15,6 +15,7 @@ import (
 	util_xds "github.com/kumahq/kuma/pkg/util/xds"
 	xds_context "github.com/kumahq/kuma/pkg/xds/context"
 	"github.com/kumahq/kuma/pkg/xds/generator"
+	"github.com/kumahq/kuma/pkg/xds/generator/modifications"
 	xds_hooks "github.com/kumahq/kuma/pkg/xds/hooks"
 	xds_sync "github.com/kumahq/kuma/pkg/xds/sync"
 	xds_template "github.com/kumahq/kuma/pkg/xds/template"
@@ -169,6 +170,9 @@ func (s *templateSnapshotGenerator) GenerateSnapshot(ctx xds_context.Context, pr
 		if err := hook.Modify(rs, ctx, proxy); err != nil {
 			return envoy_cache.Snapshot{}, errors.Wrapf(err, "could not apply hook %T", hook)
 		}
+	}
+	if err := modifications.Apply(rs, template.GetConf().GetModifications(), proxy.APIVersion); err != nil {
+		return envoy_cache.Snapshot{}, errors.Wrap(err, "could not apply modifications")
 	}
 
 	version := "" // empty value is a sign to other components to generate the version automatically


### PR DESCRIPTION
### Summary

Hooks should be executed before Proxy Template modifications.

### Issues resolved

Fix #3929

### Documentation

No docs.

### Testing

- [X] Unit tests
- [ ] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes

### Backwards compatibility

~- [ ] Update [`UPGRADE.md`](/UPGRADE.md) with any steps users will need to take when upgrading.~
- [X] Add `backport-to-stable` label if the code follows our [backporting policy](/CONTRIBUTING.md#backporting)
