### PR TITLE
feat(api-server): add inspect MeshGateway policies endpoint

### DIFF
--- a/pkg/api-server/testdata/inspect_gateway.json
+++ b/pkg/api-server/testdata/inspect_gateway.json
@@ -1,0 +1,123 @@
+{
+ "selectors": [
+  {
+   "listeners": [
+    {
+     "port": 80,
+     "protocol": "HTTP",
+     "hosts": [
+      {
+       "hostName": "*",
+       "routes": [
+        {
+         "route": "route-1",
+         "destinations": [
+          {
+           "tags": {
+            "kuma.io/service": "backend"
+           },
+           "policies": {
+            "HealthCheck": {
+             "type": "HealthCheck",
+             "mesh": "default",
+             "name": "hc-1",
+             "creationTime": "0001-01-01T00:00:00Z",
+             "modificationTime": "0001-01-01T00:00:00Z",
+             "sources": [
+              {
+               "match": {
+                "kuma.io/service": "gateway"
+               }
+              }
+             ],
+             "destinations": [
+              {
+               "match": {
+                "kuma.io/service": "backend"
+               }
+              }
+             ],
+             "conf": {
+              "interval": "5s",
+              "timeout": "7s",
+              "unhealthyThreshold": 11,
+              "healthyThreshold": 9
+             }
+            }
+           }
+          },
+          {
+           "tags": {
+            "kuma.io/service": "redis"
+           },
+           "policies": {
+            "Timeout": {
+             "type": "Timeout",
+             "mesh": "default",
+             "name": "t-1",
+             "creationTime": "0001-01-01T00:00:00Z",
+             "modificationTime": "0001-01-01T00:00:00Z",
+             "sources": [
+              {
+               "match": {
+                "kuma.io/service": "*"
+               }
+              }
+             ],
+             "destinations": [
+              {
+               "match": {
+                "kuma.io/service": "redis"
+               }
+              }
+             ],
+             "conf": {
+              "connectTimeout": "5s",
+              "tcp": {
+               "idleTimeout": "5s"
+              },
+              "http": {
+               "requestTimeout": "5s",
+               "idleTimeout": "5s"
+              },
+              "grpc": {
+               "streamIdleTimeout": "5s",
+               "maxStreamDuration": "5s"
+              }
+             }
+            }
+           }
+          }
+         ]
+        }
+       ]
+      }
+     ]
+    }
+   ],
+   "policies": {
+    "TrafficLog": {
+     "type": "TrafficLog",
+     "mesh": "default",
+     "name": "tl-1",
+     "creationTime": "0001-01-01T00:00:00Z",
+     "modificationTime": "0001-01-01T00:00:00Z",
+     "sources": [
+      {
+       "match": {
+        "kuma.io/service": "*"
+       }
+      }
+     ],
+     "destinations": [
+      {
+       "match": {
+        "kuma.io/service": "*"
+       }
+      }
+     ]
+    }
+   }
+  }
+ ]
+}

--- a/pkg/api-server/testdata/inspect_gateway_notfound.json
+++ b/pkg/api-server/testdata/inspect_gateway_notfound.json
@@ -1,0 +1,4 @@
+{
+ "title": "Could not find MeshGateway",
+ "details": "Not found"
+}

--- a/pkg/api-server/types/gateway.go
+++ b/pkg/api-server/types/gateway.go
@@ -75,3 +75,12 @@ func NewPolicyInspectGatewayEntry(key ResourceKeyEntry, gateway ResourceKeyEntry
 		Gateway:      gateway,
 	}
 }
+
+type GatewayInspectEntry struct {
+	Listeners []GatewayListenerInspectEntry `json:"listeners"`
+	Policies  PolicyMap                     `json:"policies,omitempty"`
+}
+
+type GatewayInspectResult struct {
+	Selectors []GatewayInspectEntry `json:"selectors"`
+}

--- a/pkg/plugins/runtime/gateway/suite_test.go
+++ b/pkg/plugins/runtime/gateway/suite_test.go
@@ -136,7 +136,7 @@ func MakeGeneratorContext(rt runtime.Runtime, key core_model.ResourceKey) (*xds_
 		Mesh:         meshCtx,
 	}
 
-	proxy, err := b.Build(key, meshCtx)
+	proxy, err := b.Build(key.Name, meshCtx)
 	Expect(err).To(Succeed())
 
 	return &ctx, proxy

--- a/pkg/xds/sync/dataplane_watchdog.go
+++ b/pkg/xds/sync/dataplane_watchdog.go
@@ -108,7 +108,7 @@ func (d *DataplaneWatchdog) syncDataplane() error {
 		ControlPlane: d.envoyCpCtx,
 		Mesh:         meshCtx,
 	}
-	proxy, err := d.dataplaneProxyBuilder.Build(d.key, meshCtx)
+	proxy, err := d.dataplaneProxyBuilder.Build(d.key.Name, meshCtx)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
### Summary

Add new API server inspect policies endpoint. See [discussion for behavior around `Selectors`](https://github.com/kumahq/kuma/issues/3720#issuecomment-1080818092).

Part of #3720 