### PR TITLE
chore(kumactl): use MESHGATEWAY instead of GATEWAY in inspect output

### DIFF
--- a/app/kumactl/cmd/inspect/inspect_dataplane.go
+++ b/app/kumactl/cmd/inspect/inspect_dataplane.go
@@ -18,7 +18,7 @@ var dataplaneInspectTemplate = `{{ with IsSidecar . }}{{ range $num, $item := .I
 {{ range $typ, $policies := .MatchedPolicies }}  {{ $typ }}
     {{ range $policies }}{{ .Meta.Name }}
 {{ end }}{{ end }}
-{{ end }}{{ end }}{{ with IsGateway . }}GATEWAY:
+{{ end }}{{ end }}{{ with IsGateway . }}MESHGATEWAY:
 {{ range $typ, $policy := .Policies }}  {{ $typ }}
     {{ .Meta.Name }}
 {{ end }}

--- a/app/kumactl/cmd/inspect/testdata/inspect-gateway-dataplane.golden.txt
+++ b/app/kumactl/cmd/inspect/testdata/inspect-gateway-dataplane.golden.txt
@@ -1,4 +1,4 @@
-GATEWAY:
+MESHGATEWAY:
   TrafficLog
     all-traffic
   TrafficTrace


### PR DESCRIPTION
### Summary

More consistent

> Changelog: feat(inspect): add gateways to policy inspect