### PR TITLE
chore(api-server): use MeshGatewayDataplane instead of GatewayDataplane in inspect endpoint output

### DIFF
--- a/app/kumactl/cmd/inspect/testdata/inspect-gateway-dataplane.server-response.json
+++ b/app/kumactl/cmd/inspect/testdata/inspect-gateway-dataplane.server-response.json
@@ -1,5 +1,5 @@
 {
- "kind": "GatewayDataplane",
+ "kind": "MeshGatewayDataplane",
  "gateway": {
   "mesh": "default",
   "name": "gateway"

--- a/app/kumactl/cmd/inspect/testdata/inspect-health-check.server-response.json
+++ b/app/kumactl/cmd/inspect/testdata/inspect-health-check.server-response.json
@@ -2,7 +2,7 @@
   "total": 1,
   "items": [
     {
-      "kind": "GatewayDataplane",
+      "kind": "MeshGatewayDataplane",
       "dataplane": {
         "mesh": "mesh-1",
         "name": "meshgateway-1"

--- a/pkg/api-server/testdata/inspect_gateway_dataplane.json
+++ b/pkg/api-server/testdata/inspect_gateway_dataplane.json
@@ -1,5 +1,5 @@
 {
- "kind": "GatewayDataplane",
+ "kind": "MeshGatewayDataplane",
  "gateway": {
   "mesh": "default",
   "name": "gateway"

--- a/pkg/api-server/testdata/inspect_retry.json
+++ b/pkg/api-server/testdata/inspect_retry.json
@@ -2,7 +2,7 @@
  "total": 3,
  "items": [
   {
-   "kind": "GatewayDataplane",
+   "kind": "MeshGatewayDataplane",
    "dataplane": {
     "mesh": "mesh-1",
     "name": "meshgateway-1"

--- a/pkg/api-server/testdata/inspect_traffic-trace.json
+++ b/pkg/api-server/testdata/inspect_traffic-trace.json
@@ -2,7 +2,7 @@
  "total": 4,
  "items": [
   {
-   "kind": "GatewayDataplane",
+   "kind": "MeshGatewayDataplane",
    "dataplane": {
     "mesh": "mesh-1",
     "name": "meshgateway-1"

--- a/pkg/api-server/types/inspect.go
+++ b/pkg/api-server/types/inspect.go
@@ -68,7 +68,7 @@ type PolicyInspectSidecarEntry struct {
 }
 
 const SidecarDataplane = "SidecarDataplane"
-const GatewayDataplane = "GatewayDataplane"
+const GatewayDataplane = "MeshGatewayDataplane"
 
 type KindTag struct {
 	Kind string `json:"kind"`


### PR DESCRIPTION
### Summary

More consistent