### PR TITLE
fix(gateway): ignore non TCP protocol for provided gateway

### DIFF
--- a/pkg/plugins/runtime/k8s/controllers/pod_converter_test.go
+++ b/pkg/plugins/runtime/k8s/controllers/pod_converter_test.go
@@ -245,6 +245,11 @@ var _ = Describe("PodToDataplane(..)", func() {
 			otherServices:   "17.other-services.yaml",
 			dataplane:       "17.dataplane.yaml",
 		}),
+		Entry("18. Gateway with non tcp appProtocol", testCase{
+			pod:            "18.pod.yaml",
+			servicesForPod: "18.services-for-pod.yaml",
+			dataplane:      "18.dataplane.yaml",
+		}),
 	)
 
 	DescribeTable("should convert Ingress Pod into an Ingress Dataplane YAML version",

--- a/pkg/plugins/runtime/k8s/controllers/testdata/01.services-for-pod.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/01.services-for-pod.yaml
@@ -9,7 +9,7 @@ spec:
       appProtocol: http
       port: 80
       targetPort: 8080
-    - kuma.io/protocol: TCP
+    - protocol: TCP
       port: 443
       targetPort: 8443
 ---
@@ -19,10 +19,10 @@ metadata:
 spec:
   clusterIP: 192.168.0.1
   ports:
-    - kuma.io/protocol: TCP
+    - protocol: TCP
       appProtocol: MONGO
       port: 7071
       targetPort: 7070
-    - kuma.io/protocol: TCP
+    - protocol: TCP
       port: 6061
       targetPort: metrics

--- a/pkg/plugins/runtime/k8s/controllers/testdata/02.other-services.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/02.other-services.yaml
@@ -9,11 +9,11 @@ spec:
   ports:
     - name: http
       port: 80
-      kuma.io/protocol: TCP
+      protocol: TCP
       targetPort: 80
     - name: https
       port: 443
-      kuma.io/protocol: TCP
+      protocol: TCP
       targetPort: 80
   selector:
     app: test-app

--- a/pkg/plugins/runtime/k8s/controllers/testdata/04.other-services.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/04.other-services.yaml
@@ -9,11 +9,11 @@ spec:
   ports:
     - name: http
       port: 80
-      kuma.io/protocol: TCP
+      protocol: TCP
       targetPort: 80
     - name: https
       port: 443
-      kuma.io/protocol: TCP
+      protocol: TCP
       targetPort: 80
   selector:
     app: test-app
@@ -32,7 +32,7 @@ spec:
   ports:
     - name: http
       port: 80
-      kuma.io/protocol: TCP
+      protocol: TCP
       targetPort: 80
   selector:
     app: second-test-app

--- a/pkg/plugins/runtime/k8s/controllers/testdata/05.other-services.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/05.other-services.yaml
@@ -9,11 +9,11 @@ spec:
   ports:
     - name: http
       port: 80
-      kuma.io/protocol: TCP
+      protocol: TCP
       targetPort: 80
     - name: https
       port: 443
-      kuma.io/protocol: TCP
+      protocol: TCP
       targetPort: 80
   selector:
     app: test-app
@@ -32,7 +32,7 @@ spec:
   ports:
     - name: http
       port: 80
-      kuma.io/protocol: TCP
+      protocol: TCP
       targetPort: 80
   selector:
     app: second-test-app

--- a/pkg/plugins/runtime/k8s/controllers/testdata/06.other-services.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/06.other-services.yaml
@@ -8,7 +8,7 @@ spec:
   ports:
     - name: http
       port: 80
-      kuma.io/protocol: TCP
+      protocol: TCP
       targetPort: 80
   selector:
     app: test-app

--- a/pkg/plugins/runtime/k8s/controllers/testdata/06.services-for-pod.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/06.services-for-pod.yaml
@@ -7,6 +7,6 @@ spec:
     - # protocol defaults to TCP
       port: 80
       targetPort: 8080
-    - kuma.io/protocol: TCP
+    - protocol: TCP
       port: 443
       targetPort: 8443

--- a/pkg/plugins/runtime/k8s/controllers/testdata/07.services-for-pod.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/07.services-for-pod.yaml
@@ -5,6 +5,6 @@ metadata:
 spec:
   clusterIP: 192.168.0.1
   ports:
-    - kuma.io/protocol: TCP
+    - protocol: TCP
       port: 7071
       targetPort: 7070

--- a/pkg/plugins/runtime/k8s/controllers/testdata/10.services-for-pod.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/10.services-for-pod.yaml
@@ -9,7 +9,7 @@ spec:
       appProtocol: http
       port: 80
       targetPort: 8080
-    - kuma.io/protocol: TCP
+    - protocol: TCP
       port: 443
       targetPort: 8443
 ---
@@ -19,10 +19,10 @@ metadata:
 spec:
   clusterIP: 192.168.0.1
   ports:
-    - kuma.io/protocol: TCP
+    - protocol: TCP
       appProtocol: MONGO
       port: 7071
       targetPort: 7070
-    - kuma.io/protocol: TCP
+    - protocol: TCP
       port: 6061
       targetPort: metrics

--- a/pkg/plugins/runtime/k8s/controllers/testdata/11.services-for-pod.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/11.services-for-pod.yaml
@@ -9,7 +9,7 @@ spec:
       appProtocol: http
       port: 80
       targetPort: 8080
-    - kuma.io/protocol: TCP
+    - protocol: TCP
       port: 443
       targetPort: 8443
 ---
@@ -19,10 +19,10 @@ metadata:
 spec:
   clusterIP: 192.168.0.1
   ports:
-    - kuma.io/protocol: TCP
+    - protocol: TCP
       appProtocol: MONGO
       port: 7071
       targetPort: 7070
-    - kuma.io/protocol: TCP
+    - protocol: TCP
       port: 6061
       targetPort: metrics

--- a/pkg/plugins/runtime/k8s/controllers/testdata/12.services-for-pod.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/12.services-for-pod.yaml
@@ -9,7 +9,7 @@ spec:
       port: 80
       appProtocol: http
       targetPort: 8080
-    - kuma.io/protocol: TCP
+    - protocol: TCP
       port: 443
       targetPort: 8443
 ---
@@ -21,9 +21,9 @@ metadata:
 spec:
   clusterIP: 192.168.0.1
   ports:
-    - kuma.io/protocol: TCP
+    - protocol: TCP
       port: 7071
       targetPort: 7070
-    - kuma.io/protocol: TCP
+    - protocol: TCP
       port: 6061
       targetPort: metrics

--- a/pkg/plugins/runtime/k8s/controllers/testdata/17.other-services.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/17.other-services.yaml
@@ -9,15 +9,15 @@ spec:
   ports:
     - name: http
       port: 80
-      kuma.io/protocol: TCP
+      protocol: TCP
       targetPort: 80
     - name: https
       port: 443
-      kuma.io/protocol: TCP
+      protocol: TCP
       targetPort: 80
     - name: https-second
       port: 444
-      kuma.io/protocol: TCP
+      protocol: TCP
       targetPort: 80
   selector:
     app: test-app

--- a/pkg/plugins/runtime/k8s/controllers/testdata/18.dataplane.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/18.dataplane.yaml
@@ -1,0 +1,15 @@
+mesh: default
+metadata:
+  creationTimestamp: null
+spec:
+  networking:
+    address: 192.168.0.1
+    gateway:
+      tags:
+        app: example
+        k8s.kuma.io/namespace: demo
+        k8s.kuma.io/service-name: example
+        k8s.kuma.io/service-port: "443"
+        kuma.io/service: example_demo_svc_443
+        kuma.io/zone: zone-1
+        version: "0.1"

--- a/pkg/plugins/runtime/k8s/controllers/testdata/18.pod.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/18.pod.yaml
@@ -1,0 +1,16 @@
+metadata:
+  namespace: demo
+  name: example
+  labels:
+    app: example
+    version: "0.1"
+  annotations:
+    kuma.io/gateway: enabled
+spec:
+  containers:
+    - ports:
+        - containerPort: 7070
+        - containerPort: 6060
+          name: metrics
+status:
+  podIP: 192.168.0.1

--- a/pkg/plugins/runtime/k8s/controllers/testdata/18.services-for-pod.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/18.services-for-pod.yaml
@@ -4,9 +4,7 @@ metadata:
 spec:
   clusterIP: 192.168.0.1
   ports:
-    - # protocol defaults to TCP
-      port: 80
-      targetPort: 8080
     - protocol: TCP
+      appProtocol: http
       port: 443
       targetPort: 8443


### PR DESCRIPTION
This has always been a tricky bit for the provided gateway with often
the dataplane generation failing with:

```
controllers.Pod	unable to create/update Dataplane	{"pod": "kong-mesh-system/kong-gateway-kong-9k8zc", "operationResult": "unchanged", "error": "admission webhook \"validator.kuma-admission.kuma.io\" denied the request: spec.networking.gateway.tags[\"kuma.io/protocol\"]: other values than TCP are not allowed"}
```

We now simply drop and log whenever a protocol is set on a gateway that is not tcp

### Documentation

- [ ] Link to the website [documentation PR](https://github.com/kumahq/kuma-website/pull/XXX)

### Testing

- [x] Unit tests
- [ ] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes

### Backwards compatibility

- [ ] Update [`UPGRADE.md`](/UPGRADE.md) with any steps users will need to take when upgrading.
- [ ] Add `backport-to-stable` label if the code follows our [backporting policy](/CONTRIBUTING.md#backporting)
