### PR TITLE
fix(helmcharts): Allow customization of image tags in Helm chart

### DIFF
--- a/deployments/charts/kuma/README.md
+++ b/deployments/charts/kuma/README.md
@@ -48,6 +48,7 @@ A Helm chart for the Kuma Control Plane
 | controlPlane.tls.kdsZoneClient.secretName | string | `""` | Secret that contains ca.crt which was used to sign KDS Global server. Used for CP verification |
 | controlPlane.image.pullPolicy | string | `"IfNotPresent"` | Kuma CP ImagePullPolicy |
 | controlPlane.image.repository | string | `"kuma-cp"` | Kuma CP image repository |
+| controlPlane.image.tag | string | `nil` | Kuma CP Image tag. When not specified, the value is copied from global.tag |
 | controlPlane.secrets | list of { Env: string, Secret: string, Key: string } | `nil` | Secrets to add as environment variables, where `Env` is the name of the env variable, `Secret` is the name of the Secret, and `Key` is the key of the Secret value to use |
 | controlPlane.envVars | object | `{}` | Additional environment variables that will be passed to the control plane |
 | controlPlane.extraConfigMaps | list | `[]` | Additional config maps to mount into the control plane, with optional inline values |
@@ -66,7 +67,9 @@ A Helm chart for the Kuma Control Plane
 | cni.image.tag | string | `"0.0.9"` | CNI image tag |
 | dataPlane.image.repository | string | `"kuma-dp"` | The Kuma DP image repository |
 | dataPlane.image.pullPolicy | string | `"IfNotPresent"` | Kuma DP ImagePullPolicy |
+| dataPlane.image.tag | string | `nil` | Kuma DP Image Tag. When not specified, the value is copied from global.tag |
 | dataPlane.initImage.repository | string | `"kuma-init"` | The Kuma DP init image repository |
+| dataPlane.initImage.tag | string | `nil` | Kuma DP init image tag When not specified, the value is copied from global.tag |
 | ingress.enabled | bool | `false` | If true, it deploys Ingress for cross cluster communication |
 | ingress.drainTime | string | `"30s"` | Time for which old listener will still be active as draining |
 | ingress.replicas | int | `1` | Number of replicas of the Ingress |
@@ -90,6 +93,7 @@ A Helm chart for the Kuma Control Plane
 | egress.nodeSelector | object | `{"kubernetes.io/arch":"amd64","kubernetes.io/os":"linux"}` | Node Selector for the Egress pods |
 | egress.affinity | object | `{}` | Affinity placement rule for the Kuma Ingress pods |
 | kumactl.image.repository | string | `"kumactl"` | The kumactl image repository |
+| kumactl.image.tag | string | `nil` | The kumactl image tag. When not specified, the value is copied from global.tag |
 | kubectl.image.registry | string | `"bitnami"` | The kubectl image registry |
 | kubectl.image.repository | string | `"kubectl"` | The kubectl image repository |
 | kubectl.image.tag | string | `"1.20"` | The kubectl image tag |

--- a/deployments/charts/kuma/values.yaml
+++ b/deployments/charts/kuma/values.yaml
@@ -127,7 +127,8 @@ controlPlane:
     pullPolicy: IfNotPresent
     # -- Kuma CP image repository
     repository: "kuma-cp"
-
+    # -- Kuma CP Image tag. When not specified, the value is copied from global.tag
+    tag:
   # -- (list of { Env: string, Secret: string, Key: string }) Secrets to add as environment variables,
   # where `Env` is the name of the env variable,
   # `Secret` is the name of the Secret,
@@ -192,10 +193,14 @@ dataPlane:
     repository: "kuma-dp"
     # -- Kuma DP ImagePullPolicy
     pullPolicy: IfNotPresent
+    # -- Kuma DP Image Tag. When not specified, the value is copied from global.tag
+    tag:
 
   initImage:
     # -- The Kuma DP init image repository
     repository: "kuma-init"
+    # -- Kuma DP init image tag When not specified, the value is copied from global.tag
+    tag:
 
 ingress:
   # -- If true, it deploys Ingress for cross cluster communication
@@ -257,6 +262,8 @@ kumactl:
   image:
     # -- The kumactl image repository
     repository: kumactl
+    # -- The kumactl image tag. When not specified, the value is copied from global.tag
+    tag:
 
 kubectl:
   # bitnami maintains an image for all k8s versions */ } }


### PR DESCRIPTION
### Summary

Currently, there is no place to specify the image tag for the
following components: kuma dp initContainer,kuma dp container,
kuma-cp and kumactl. Right now the image tag is pulled from
app version in the Chart file and applied to all components.
This fix provides the option to specify different tags for
kuma dp initContainer,kuma dp container,kuma-cp and kumactl

### Full changelog
* adds tag to following components: kuma dp initContainer,
kuma dp container,kuma-cp and kumactl in Helm charts

* Fixed
Fix #3988 (https://github.com/kumahq/kuma/issues/3988)

### Issues resolved

Fix https://github.com/kumahq/kuma/issues/3988

### Testing

- [ ] Unit tests
- [ ] E2E tests
- [ ] Manual testing on Universal
- [X] Manual testing on Kubernetes

### Backwards compatibility

Does not effect backwards compatibility.

* Signed-off-by: Gaurav Dasson <gaurav.dasson@gmail.com>