### PR TITLE
chore(*): replace cni registry

### DIFF
--- a/app/kumactl/cmd/install/context/install_control_plane_context.go
+++ b/app/kumactl/cmd/install/context/install_control_plane_context.go
@@ -94,7 +94,7 @@ func DefaultInstallCpContext() InstallCpContext {
 			Cni_net_dir:                             "/etc/cni/multus/net.d",
 			Cni_bin_dir:                             "/var/lib/cni/bin",
 			Cni_conf_name:                           "kuma-cni.conf",
-			Cni_image_registry:                      "docker.io/lobkovilya",
+			Cni_image_registry:                      "docker.io/kumahq",
 			Cni_image_repository:                    "install-cni",
 			Cni_image_tag:                           "0.0.9",
 			ControlPlane_mode:                       core.Standalone,

--- a/app/kumactl/cmd/install/testdata/install-control-plane.cni-enabled.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.cni-enabled.golden.yaml
@@ -1574,7 +1574,7 @@ spec:
       terminationGracePeriodSeconds: 5
       containers:
         - name: install-cni
-          image: "docker.io/lobkovilya/install-cni:0.0.9"
+          image: "docker.io/kumahq/install-cni:0.0.9"
           imagePullPolicy: Always
           command: ["/install-cni.sh"]
           env:

--- a/deployments/charts/kuma/README.md
+++ b/deployments/charts/kuma/README.md
@@ -62,7 +62,7 @@ A Helm chart for the Kuma Control Plane
 | cni.logLevel | string | `"info"` | CNI log level: one of off,info,debug |
 | cni.nodeSelector | object | `{"kubernetes.io/arch":"amd64","kubernetes.io/os":"linux"}` | Node Selector for the CNI pods |
 | cni.image.registry | string | `"docker.io"` | CNI image registry |
-| cni.image.repository | string | `"lobkovilya/install-cni"` | CNI image repository |
+| cni.image.repository | string | `"kumahq/install-cni"` | CNI image repository |
 | cni.image.tag | string | `"0.0.9"` | CNI image tag |
 | dataPlane.image.repository | string | `"kuma-dp"` | The Kuma DP image repository |
 | dataPlane.image.pullPolicy | string | `"IfNotPresent"` | Kuma DP ImagePullPolicy |

--- a/deployments/charts/kuma/values.yaml
+++ b/deployments/charts/kuma/values.yaml
@@ -182,7 +182,7 @@ cni:
     # -- CNI image registry
     registry: "docker.io"
     # -- CNI image repository
-    repository: "lobkovilya/install-cni"
+    repository: "kumahq/install-cni"
     # -- CNI image tag
     tag: "0.0.9"
 

--- a/docs/generated/cmd/kumactl/kumactl_install_control-plane.md
+++ b/docs/generated/cmd/kumactl/kumactl_install_control-plane.md
@@ -20,7 +20,7 @@ kumactl install control-plane [flags]
       --cni-enabled                                  install Kuma with CNI instead of proxy init container
       --cni-net-dir string                           set the CNI install directory (default "/etc/cni/multus/net.d")
       --cni-node-selector stringToString             node selector for CNI deployment (default [])
-      --cni-registry string                          registry for the image of the Kuma CNI component (default "docker.io/lobkovilya")
+      --cni-registry string                          registry for the image of the Kuma CNI component (default "docker.io/kumahq")
       --cni-repository string                        repository for the image of the Kuma CNI component (default "install-cni")
       --cni-version string                           version of the image of the Kuma CNI component (default "0.0.9")
       --control-plane-node-selector stringToString   node selector for Kuma Control Plane (default [])


### PR DESCRIPTION
### Summary

Replace registry for `install-cni` image

### Full changelog

* [Implement ...]
* [Fix ...]

### Issues resolved

Fix #XXX

### Documentation

- [ ] Link to the website [documentation PR](https://github.com/kumahq/kuma-website/pull/XXX)

### Testing

- [ ] Unit tests
- [ ] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes

### Backwards compatibility

- [ ] Update [`UPGRADE.md`](/UPGRADE.md) with any steps users will need to take when upgrading.
- [X] Add `backport-to-stable` label if the code follows our [backporting policy](/CONTRIBUTING.md#backporting)
