### PR TITLE
fix(kuma-cp): mesh gateway instance service target port

### DIFF
--- a/pkg/plugins/runtime/k8s/controllers/gateway_instance_controller.go
+++ b/pkg/plugins/runtime/k8s/controllers/gateway_instance_controller.go
@@ -17,6 +17,7 @@ import (
 	kube_runtime "k8s.io/apimachinery/pkg/runtime"
 	kube_schema "k8s.io/apimachinery/pkg/runtime/schema"
 	kube_types "k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	kube_ctrl "sigs.k8s.io/controller-runtime"
 	kube_client "sigs.k8s.io/controller-runtime/pkg/client"
 	kube_handler "sigs.k8s.io/controller-runtime/pkg/handler"
@@ -146,6 +147,7 @@ func (r *GatewayInstanceReconciler) createOrUpdateService(
 				servicePort.Name = strconv.Itoa(int(listener.Port))
 				servicePort.Protocol = kube_core.ProtocolTCP
 				servicePort.Port = int32(listener.Port)
+				servicePort.TargetPort = intstr.FromInt(int(servicePort.Port))
 				if gatewayInstance.Spec.ServiceType == kube_core.ServiceTypeNodePort {
 					servicePort.NodePort = int32(listener.Port)
 				}


### PR DESCRIPTION
### Summary

If the service of a mesh gateway instance had TargetPort set, we need to override it again.

### Issues resolved

No issues reported.
Fixed flakiness of Gateway E2E test.

### Documentation

~- [ ] Link to the website [documentation PR](https://github.com/kumahq/kuma-website/pull/XXX)~

### Testing

- [ ] Unit tests
- [X] E2E tests
- [ ] Manual testing on Universal
- [X] Manual testing on Kubernetes

### Backwards compatibility

~- [ ] Update [`UPGRADE.md`](/UPGRADE.md) with any steps users will need to take when upgrading.~
~- [ ] Add `backport-to-stable` label if the code follows our [backporting policy](/CONTRIBUTING.md#backporting)~
