### PR TITLE
feat(kuma-cp): upstream validation of Gateway API

### DIFF
--- a/app/kumactl/cmd/install/testdata/install-control-plane.cni-enabled.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.cni-enabled.golden.yaml
@@ -1632,7 +1632,7 @@ spec:
     metadata:
       annotations:
         checksum/config: f509d41973f6ed84a86f16e996b13068bffb3a90d10d7886a37e1c5fc225f760
-        checksum/tls-secrets: 1962ebe5f21decca98ad3ce41df62b9e3adbcb22c20273f2904dc4b0c6bf39a7
+        checksum/tls-secrets: 592096ac96f1bd1570fdf154d9d17b61be0b78b1dc35eb85cce636d33bdde56d
       labels:
         app.kubernetes.io/name: kuma
         app.kubernetes.io/instance: kuma
@@ -1990,4 +1990,27 @@ webhooks:
           - CREATE
         resources:
           - gatewayclasses
+    sideEffects: None
+  - name: validate.gateway.networking.k8s.io
+    admissionReviewVersions: ["v1"]
+    failurePolicy: Fail
+    matchPolicy: Equivalent
+    clientConfig:
+      caBundle: XYZ
+      service:
+        namespace: kuma-system
+        name: kuma-control-plane
+        path: /validate-v1alpha2-gateway-upstream
+    rules:
+      - apiGroups:
+          - "gateway.networking.k8s.io"
+        apiVersions:
+          - v1alpha2
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - gateways
+          - gatewayclasses
+          - httproutes
     sideEffects: None

--- a/app/kumactl/cmd/install/testdata/install-control-plane.defaults.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.defaults.golden.yaml
@@ -1457,7 +1457,7 @@ spec:
     metadata:
       annotations:
         checksum/config: f509d41973f6ed84a86f16e996b13068bffb3a90d10d7886a37e1c5fc225f760
-        checksum/tls-secrets: 1962ebe5f21decca98ad3ce41df62b9e3adbcb22c20273f2904dc4b0c6bf39a7
+        checksum/tls-secrets: 592096ac96f1bd1570fdf154d9d17b61be0b78b1dc35eb85cce636d33bdde56d
       labels:
         app.kubernetes.io/name: kuma
         app.kubernetes.io/instance: kuma
@@ -1815,4 +1815,27 @@ webhooks:
           - CREATE
         resources:
           - gatewayclasses
+    sideEffects: None
+  - name: validate.gateway.networking.k8s.io
+    admissionReviewVersions: ["v1"]
+    failurePolicy: Fail
+    matchPolicy: Equivalent
+    clientConfig:
+      caBundle: XYZ
+      service:
+        namespace: kuma-system
+        name: kuma-control-plane
+        path: /validate-v1alpha2-gateway-upstream
+    rules:
+      - apiGroups:
+          - "gateway.networking.k8s.io"
+        apiVersions:
+          - v1alpha2
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - gateways
+          - gatewayclasses
+          - httproutes
     sideEffects: None

--- a/app/kumactl/cmd/install/testdata/install-control-plane.global.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.global.golden.yaml
@@ -1467,7 +1467,7 @@ spec:
     metadata:
       annotations:
         checksum/config: f509d41973f6ed84a86f16e996b13068bffb3a90d10d7886a37e1c5fc225f760
-        checksum/tls-secrets: 1962ebe5f21decca98ad3ce41df62b9e3adbcb22c20273f2904dc4b0c6bf39a7
+        checksum/tls-secrets: 592096ac96f1bd1570fdf154d9d17b61be0b78b1dc35eb85cce636d33bdde56d
       labels:
         app.kubernetes.io/name: kuma
         app.kubernetes.io/instance: kuma
@@ -1822,4 +1822,27 @@ webhooks:
           - CREATE
         resources:
           - gatewayclasses
+    sideEffects: None
+  - name: validate.gateway.networking.k8s.io
+    admissionReviewVersions: ["v1"]
+    failurePolicy: Fail
+    matchPolicy: Equivalent
+    clientConfig:
+      caBundle: XYZ
+      service:
+        namespace: kuma-system
+        name: kuma-control-plane
+        path: /validate-v1alpha2-gateway-upstream
+    rules:
+      - apiGroups:
+          - "gateway.networking.k8s.io"
+        apiVersions:
+          - v1alpha2
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - gateways
+          - gatewayclasses
+          - httproutes
     sideEffects: None

--- a/app/kumactl/cmd/install/testdata/install-control-plane.override-env-vars.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.override-env-vars.golden.yaml
@@ -1457,7 +1457,7 @@ spec:
     metadata:
       annotations:
         checksum/config: f509d41973f6ed84a86f16e996b13068bffb3a90d10d7886a37e1c5fc225f760
-        checksum/tls-secrets: 1962ebe5f21decca98ad3ce41df62b9e3adbcb22c20273f2904dc4b0c6bf39a7
+        checksum/tls-secrets: 592096ac96f1bd1570fdf154d9d17b61be0b78b1dc35eb85cce636d33bdde56d
       labels:
         app.kubernetes.io/name: kuma
         app.kubernetes.io/instance: kuma
@@ -1815,4 +1815,27 @@ webhooks:
           - CREATE
         resources:
           - gatewayclasses
+    sideEffects: None
+  - name: validate.gateway.networking.k8s.io
+    admissionReviewVersions: ["v1"]
+    failurePolicy: Fail
+    matchPolicy: Equivalent
+    clientConfig:
+      caBundle: XYZ
+      service:
+        namespace: kuma-system
+        name: kuma-control-plane
+        path: /validate-v1alpha2-gateway-upstream
+    rules:
+      - apiGroups:
+          - "gateway.networking.k8s.io"
+        apiVersions:
+          - v1alpha2
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - gateways
+          - gatewayclasses
+          - httproutes
     sideEffects: None

--- a/app/kumactl/cmd/install/testdata/install-control-plane.overrides.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.overrides.golden.yaml
@@ -1860,7 +1860,7 @@ spec:
     metadata:
       annotations:
         checksum/config: 8c443d9f48d469a050e9e994d3d839c09b7f22f3c16bbe096c5a7d30f4207d99
-        checksum/tls-secrets: 4cdc5ea0136d2fc1d500b2140e93abc2f3f4356a8d80324439bb9dd985f9d582
+        checksum/tls-secrets: dd1eaf570ec3013fc8590bfd60f252c6807912c5232e14a69a2b585e87a533fd
       labels:
         app.kubernetes.io/name: kuma
         app.kubernetes.io/instance: kuma
@@ -2265,4 +2265,27 @@ webhooks:
           - CREATE
         resources:
           - gatewayclasses
+    sideEffects: None
+  - name: validate.gateway.networking.k8s.io
+    admissionReviewVersions: ["v1"]
+    failurePolicy: Fail
+    matchPolicy: Equivalent
+    clientConfig:
+      caBundle: XYZ
+      service:
+        namespace: kuma
+        name: kuma-ctrl-plane
+        path: /validate-v1alpha2-gateway-upstream
+    rules:
+      - apiGroups:
+          - "gateway.networking.k8s.io"
+        apiVersions:
+          - v1alpha2
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - gateways
+          - gatewayclasses
+          - httproutes
     sideEffects: None

--- a/app/kumactl/cmd/install/testdata/install-control-plane.with-egress.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.with-egress.golden.yaml
@@ -1486,7 +1486,7 @@ spec:
     metadata:
       annotations:
         checksum/config: f509d41973f6ed84a86f16e996b13068bffb3a90d10d7886a37e1c5fc225f760
-        checksum/tls-secrets: 1962ebe5f21decca98ad3ce41df62b9e3adbcb22c20273f2904dc4b0c6bf39a7
+        checksum/tls-secrets: 592096ac96f1bd1570fdf154d9d17b61be0b78b1dc35eb85cce636d33bdde56d
       labels:
         app.kubernetes.io/name: kuma
         app.kubernetes.io/instance: kuma
@@ -1954,4 +1954,27 @@ webhooks:
           - CREATE
         resources:
           - gatewayclasses
+    sideEffects: None
+  - name: validate.gateway.networking.k8s.io
+    admissionReviewVersions: ["v1"]
+    failurePolicy: Fail
+    matchPolicy: Equivalent
+    clientConfig:
+      caBundle: XYZ
+      service:
+        namespace: kuma-system
+        name: kuma-control-plane
+        path: /validate-v1alpha2-gateway-upstream
+    rules:
+      - apiGroups:
+          - "gateway.networking.k8s.io"
+        apiVersions:
+          - v1alpha2
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - gateways
+          - gatewayclasses
+          - httproutes
     sideEffects: None

--- a/app/kumactl/cmd/install/testdata/install-control-plane.with-ingress.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.with-ingress.golden.yaml
@@ -1486,7 +1486,7 @@ spec:
     metadata:
       annotations:
         checksum/config: f509d41973f6ed84a86f16e996b13068bffb3a90d10d7886a37e1c5fc225f760
-        checksum/tls-secrets: 1962ebe5f21decca98ad3ce41df62b9e3adbcb22c20273f2904dc4b0c6bf39a7
+        checksum/tls-secrets: 592096ac96f1bd1570fdf154d9d17b61be0b78b1dc35eb85cce636d33bdde56d
       labels:
         app.kubernetes.io/name: kuma
         app.kubernetes.io/instance: kuma
@@ -1954,4 +1954,27 @@ webhooks:
           - CREATE
         resources:
           - gatewayclasses
+    sideEffects: None
+  - name: validate.gateway.networking.k8s.io
+    admissionReviewVersions: ["v1"]
+    failurePolicy: Fail
+    matchPolicy: Equivalent
+    clientConfig:
+      caBundle: XYZ
+      service:
+        namespace: kuma-system
+        name: kuma-control-plane
+        path: /validate-v1alpha2-gateway-upstream
+    rules:
+      - apiGroups:
+          - "gateway.networking.k8s.io"
+        apiVersions:
+          - v1alpha2
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - gateways
+          - gatewayclasses
+          - httproutes
     sideEffects: None

--- a/app/kumactl/cmd/install/testdata/install-control-plane.zone.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.zone.golden.yaml
@@ -1461,7 +1461,7 @@ spec:
     metadata:
       annotations:
         checksum/config: f509d41973f6ed84a86f16e996b13068bffb3a90d10d7886a37e1c5fc225f760
-        checksum/tls-secrets: 1962ebe5f21decca98ad3ce41df62b9e3adbcb22c20273f2904dc4b0c6bf39a7
+        checksum/tls-secrets: 592096ac96f1bd1570fdf154d9d17b61be0b78b1dc35eb85cce636d33bdde56d
       labels:
         app.kubernetes.io/name: kuma
         app.kubernetes.io/instance: kuma
@@ -1823,4 +1823,27 @@ webhooks:
           - CREATE
         resources:
           - gatewayclasses
+    sideEffects: None
+  - name: validate.gateway.networking.k8s.io
+    admissionReviewVersions: ["v1"]
+    failurePolicy: Fail
+    matchPolicy: Equivalent
+    clientConfig:
+      caBundle: XYZ
+      service:
+        namespace: kuma-system
+        name: kuma-control-plane
+        path: /validate-v1alpha2-gateway-upstream
+    rules:
+      - apiGroups:
+          - "gateway.networking.k8s.io"
+        apiVersions:
+          - v1alpha2
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - gateways
+          - gatewayclasses
+          - httproutes
     sideEffects: None

--- a/deployments/charts/kuma/templates/cp-webhooks-and-secrets.yaml
+++ b/deployments/charts/kuma/templates/cp-webhooks-and-secrets.yaml
@@ -280,3 +280,26 @@ webhooks:
         resources:
           - gatewayclasses
     sideEffects: None
+  - name: validate.gateway.networking.k8s.io
+    admissionReviewVersions: ["v1"]
+    failurePolicy: Fail
+    matchPolicy: Equivalent
+    clientConfig:
+      caBundle: {{ $caBundle }}
+      service:
+        namespace: {{ .Release.Namespace }}
+        name: {{ include "kuma.controlPlane.serviceName" .  }}
+        path: /validate-v1alpha2-gateway-upstream
+    rules:
+      - apiGroups:
+          - "gateway.networking.k8s.io"
+        apiVersions:
+          - v1alpha2
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - gateways
+          - gatewayclasses
+          - httproutes
+    sideEffects: None

--- a/go.sum
+++ b/go.sum
@@ -1043,6 +1043,7 @@ github.com/lib/pq v1.10.4 h1:SO9z7FRPzA03QhHKJrH5BXA6HU1rS4V2nIVrrNC1iYk=
 github.com/lib/pq v1.10.4/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
 github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de/go.mod h1:zAbeS9B/r2mtpb6U+EI2rYA5OAXxsYw6wTamcNW+zcE=
 github.com/linuxkit/virtsock v0.0.0-20201010232012-f8cee7dfc7a3/go.mod h1:3r6x7q95whyfWQpmGZTu3gk3v2YkMi05HEzl7Tf7YEo=
+github.com/lithammer/dedent v1.1.0 h1:VNzHMVCBNG1j0fh3OrsFRkVUwStdDArbgBWoPAffktY=
 github.com/lithammer/dedent v1.1.0/go.mod h1:jrXYCQtgg0nJiN+StA2KgR7w6CiQNv9Fd/Z9BP0jIOc=
 github.com/lyft/protoc-gen-star v0.5.2/go.mod h1:9toiA3cC7z5uVbODF7kEQ91Xn7XNFkVUl+SrEe+ZORU=
 github.com/lyft/protoc-gen-star v0.5.3/go.mod h1:V0xaHgaf5oCCqmcxYcWiDfTiKsZsRc87/1qhoTACD8w=

--- a/pkg/plugins/runtime/k8s/plugin.go
+++ b/pkg/plugins/runtime/k8s/plugin.go
@@ -2,12 +2,14 @@ package k8s
 
 import (
 	"fmt"
+	"net/http"
 	"strings"
 
 	"github.com/pkg/errors"
 	kube_schema "k8s.io/apimachinery/pkg/runtime/schema"
 	kube_ctrl "sigs.k8s.io/controller-runtime"
 	kube_webhook "sigs.k8s.io/controller-runtime/pkg/webhook"
+	gapi_admission "sigs.k8s.io/gateway-api/pkg/admission"
 
 	config_core "github.com/kumahq/kuma/pkg/config/core"
 	"github.com/kumahq/kuma/pkg/core"
@@ -283,9 +285,17 @@ func addValidators(mgr kube_ctrl.Manager, rt core_runtime.Runtime, converter k8s
 	if gatewayAPICRDsPresent(mgr) {
 		gatewayValidator := k8s_webhooks.NewGatewayAPIMultizoneValidator(rt.Config().Mode)
 		mgr.GetWebhookServer().Register("/validate-v1alpha2-gateway", gatewayValidator)
+		mgr.GetWebhookServer().Register("/validate-v1alpha2-gateway-upstream", &upstreamValidatorHandler{})
 	}
 
 	return nil
+}
+
+type upstreamValidatorHandler struct {
+}
+
+func (g *upstreamValidatorHandler) ServeHTTP(writer http.ResponseWriter, request *http.Request) {
+	gapi_admission.ServeHTTP(writer, request)
 }
 
 func addMutators(mgr kube_ctrl.Manager, rt core_runtime.Runtime, converter k8s_common.Converter) error {

--- a/test/e2e/gateway/gatewayapi/gateway_api.go
+++ b/test/e2e/gateway/gatewayapi/gateway_api.go
@@ -331,4 +331,24 @@ data:
 			}, "30s", "1s").Should(Succeed())
 		})
 	})
+
+	Context("Upstream validation", func() {
+		It("should validate Gateway", func() {
+			gateway := `
+apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: Gateway
+metadata:
+  name: kuma
+  namespace: kuma-test
+spec:
+  gatewayClassName: kuma
+  listeners:
+  - name: proxy
+    port: 8080
+    protocol: TCP
+    hostname: xyz.io`
+			err := k8s.KubectlApplyFromStringE(cluster.GetTesting(), cluster.GetKubectlOptions(), gateway)
+			Expect(err).To(HaveOccurred())
+		})
+	})
 }


### PR DESCRIPTION
### Summary

Add upstream validation of Gateway API

### Issues resolved

Fix #3416

### Documentation

~- [ ] Link to the website [documentation PR](https://github.com/kumahq/kuma-website/pull/XXX)~

### Testing

- [ ] Unit tests
- [X] E2E tests
- [ ] Manual testing on Universal
- [X] Manual testing on Kubernetes

### Backwards compatibility

~- [ ] Update [`UPGRADE.md`](/UPGRADE.md) with any steps users will need to take when upgrading.~
~- [ ] Add `backport-to-stable` label if the code follows our [backporting policy](/CONTRIBUTING.md#backporting)~
