### PR TITLE
fix(kuma-cp): default policy creation

### DIFF
--- a/pkg/defaults/mesh/circuit_breaker.go
+++ b/pkg/defaults/mesh/circuit_breaker.go
@@ -3,24 +3,27 @@ package mesh
 import (
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
+	"github.com/kumahq/kuma/pkg/core/resources/model"
 	util_proto "github.com/kumahq/kuma/pkg/util/proto"
 )
 
-var defaultCircuitBreakerResource = &core_mesh.CircuitBreakerResource{
-	Spec: &mesh_proto.CircuitBreaker{
-		Sources: []*mesh_proto.Selector{{
-			Match: mesh_proto.MatchAnyService(),
-		}},
-		Destinations: []*mesh_proto.Selector{{
-			Match: mesh_proto.MatchAnyService(),
-		}},
-		Conf: &mesh_proto.CircuitBreaker_Conf{
-			Thresholds: &mesh_proto.CircuitBreaker_Conf_Thresholds{
-				MaxConnections:     util_proto.UInt32(1024),
-				MaxPendingRequests: util_proto.UInt32(1024),
-				MaxRequests:        util_proto.UInt32(1024),
-				MaxRetries:         util_proto.UInt32(3),
+var defaultCircuitBreakerResource = func() model.Resource {
+	return &core_mesh.CircuitBreakerResource{
+		Spec: &mesh_proto.CircuitBreaker{
+			Sources: []*mesh_proto.Selector{{
+				Match: mesh_proto.MatchAnyService(),
+			}},
+			Destinations: []*mesh_proto.Selector{{
+				Match: mesh_proto.MatchAnyService(),
+			}},
+			Conf: &mesh_proto.CircuitBreaker_Conf{
+				Thresholds: &mesh_proto.CircuitBreaker_Conf_Thresholds{
+					MaxConnections:     util_proto.UInt32(1024),
+					MaxPendingRequests: util_proto.UInt32(1024),
+					MaxRequests:        util_proto.UInt32(1024),
+					MaxRetries:         util_proto.UInt32(3),
+				},
 			},
 		},
-	},
+	}
 }

--- a/pkg/defaults/mesh/mesh.go
+++ b/pkg/defaults/mesh/mesh.go
@@ -30,7 +30,7 @@ func EnsureDefaultMeshResources(ctx context.Context, resManager manager.Resource
 
 	log.Info("ensuring default resources for Mesh exist", "mesh", meshName)
 
-	defaultResources := map[string]model.Resource{
+	defaultResourceBuilders := map[string]func() model.Resource{
 		"allow-all":           defaultTrafficPermissionResource,
 		"route-all":           defaultTrafficRouteResource,
 		"timeout-all":         defaultTimeoutResource,
@@ -38,12 +38,12 @@ func EnsureDefaultMeshResources(ctx context.Context, resManager manager.Resource
 		"retry-all":           defaultRetryResource,
 	}
 
-	for prefix, resource := range defaultResources {
+	for prefix, resourceBuilder := range defaultResourceBuilders {
 		key := model.ResourceKey{
 			Mesh: meshName,
 			Name: fmt.Sprintf("%s-%s", prefix, meshName),
 		}
-
+		resource := resourceBuilder()
 		err, created := ensureDefaultResource(ctx, resManager, resource, key)
 		if err != nil {
 			return errors.Wrapf(err, "could not create default %s %q", resource.Descriptor().Name, key.Name)

--- a/pkg/defaults/mesh/retry.go
+++ b/pkg/defaults/mesh/retry.go
@@ -1,6 +1,7 @@
 package mesh
 
 import (
+	"github.com/kumahq/kuma/pkg/core/resources/model"
 	"time"
 
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
@@ -8,42 +9,44 @@ import (
 	util_proto "github.com/kumahq/kuma/pkg/util/proto"
 )
 
-var defaultRetryResource = &core_mesh.RetryResource{
-	Spec: &mesh_proto.Retry{
-		Sources: []*mesh_proto.Selector{
-			{
-				Match: map[string]string{
-					mesh_proto.ServiceTag: "*",
+var defaultRetryResource = func() model.Resource {
+	return &core_mesh.RetryResource{
+		Spec: &mesh_proto.Retry{
+			Sources: []*mesh_proto.Selector{
+				{
+					Match: map[string]string{
+						mesh_proto.ServiceTag: "*",
+					},
+				},
+			},
+			Destinations: []*mesh_proto.Selector{
+				{
+					Match: map[string]string{
+						mesh_proto.ServiceTag: "*",
+					},
+				},
+			},
+			Conf: &mesh_proto.Retry_Conf{
+				Http: &mesh_proto.Retry_Conf_Http{
+					NumRetries:    util_proto.UInt32(5),
+					PerTryTimeout: util_proto.Duration(16 * time.Second),
+					BackOff: &mesh_proto.Retry_Conf_BackOff{
+						BaseInterval: util_proto.Duration(25 * time.Millisecond),
+						MaxInterval:  util_proto.Duration(250 * time.Millisecond),
+					},
+				},
+				Tcp: &mesh_proto.Retry_Conf_Tcp{
+					MaxConnectAttempts: 5,
+				},
+				Grpc: &mesh_proto.Retry_Conf_Grpc{
+					NumRetries:    util_proto.UInt32(5),
+					PerTryTimeout: util_proto.Duration(16 * time.Second),
+					BackOff: &mesh_proto.Retry_Conf_BackOff{
+						BaseInterval: util_proto.Duration(25 * time.Millisecond),
+						MaxInterval:  util_proto.Duration(250 * time.Millisecond),
+					},
 				},
 			},
 		},
-		Destinations: []*mesh_proto.Selector{
-			{
-				Match: map[string]string{
-					mesh_proto.ServiceTag: "*",
-				},
-			},
-		},
-		Conf: &mesh_proto.Retry_Conf{
-			Http: &mesh_proto.Retry_Conf_Http{
-				NumRetries:    util_proto.UInt32(5),
-				PerTryTimeout: util_proto.Duration(16 * time.Second),
-				BackOff: &mesh_proto.Retry_Conf_BackOff{
-					BaseInterval: util_proto.Duration(25 * time.Millisecond),
-					MaxInterval:  util_proto.Duration(250 * time.Millisecond),
-				},
-			},
-			Tcp: &mesh_proto.Retry_Conf_Tcp{
-				MaxConnectAttempts: 5,
-			},
-			Grpc: &mesh_proto.Retry_Conf_Grpc{
-				NumRetries:    util_proto.UInt32(5),
-				PerTryTimeout: util_proto.Duration(16 * time.Second),
-				BackOff: &mesh_proto.Retry_Conf_BackOff{
-					BaseInterval: util_proto.Duration(25 * time.Millisecond),
-					MaxInterval:  util_proto.Duration(250 * time.Millisecond),
-				},
-			},
-		},
-	},
+	}
 }

--- a/pkg/defaults/mesh/retry.go
+++ b/pkg/defaults/mesh/retry.go
@@ -1,11 +1,11 @@
 package mesh
 
 import (
-	"github.com/kumahq/kuma/pkg/core/resources/model"
 	"time"
 
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
+	"github.com/kumahq/kuma/pkg/core/resources/model"
 	util_proto "github.com/kumahq/kuma/pkg/util/proto"
 )
 

--- a/pkg/defaults/mesh/timeout.go
+++ b/pkg/defaults/mesh/timeout.go
@@ -1,6 +1,7 @@
 package mesh
 
 import (
+	"github.com/kumahq/kuma/pkg/core/resources/model"
 	"time"
 
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
@@ -8,26 +9,28 @@ import (
 	util_proto "github.com/kumahq/kuma/pkg/util/proto"
 )
 
-var defaultTimeoutResource = &core_mesh.TimeoutResource{
-	Spec: &mesh_proto.Timeout{
-		Sources: []*mesh_proto.Selector{{
-			Match: mesh_proto.MatchAnyService(),
-		}},
-		Destinations: []*mesh_proto.Selector{{
-			Match: mesh_proto.MatchAnyService(),
-		}},
-		Conf: &mesh_proto.Timeout_Conf{
-			ConnectTimeout: util_proto.Duration(5 * time.Second),
-			Tcp: &mesh_proto.Timeout_Conf_Tcp{
-				IdleTimeout: util_proto.Duration(1 * time.Hour),
-			},
-			Http: &mesh_proto.Timeout_Conf_Http{
-				IdleTimeout:    util_proto.Duration(1 * time.Hour),
-				RequestTimeout: util_proto.Duration(15 * time.Second),
-			},
-			Grpc: &mesh_proto.Timeout_Conf_Grpc{
-				StreamIdleTimeout: util_proto.Duration(5 * time.Minute),
+var defaultTimeoutResource = func() model.Resource {
+	return &core_mesh.TimeoutResource{
+		Spec: &mesh_proto.Timeout{
+			Sources: []*mesh_proto.Selector{{
+				Match: mesh_proto.MatchAnyService(),
+			}},
+			Destinations: []*mesh_proto.Selector{{
+				Match: mesh_proto.MatchAnyService(),
+			}},
+			Conf: &mesh_proto.Timeout_Conf{
+				ConnectTimeout: util_proto.Duration(5 * time.Second),
+				Tcp: &mesh_proto.Timeout_Conf_Tcp{
+					IdleTimeout: util_proto.Duration(1 * time.Hour),
+				},
+				Http: &mesh_proto.Timeout_Conf_Http{
+					IdleTimeout:    util_proto.Duration(1 * time.Hour),
+					RequestTimeout: util_proto.Duration(15 * time.Second),
+				},
+				Grpc: &mesh_proto.Timeout_Conf_Grpc{
+					StreamIdleTimeout: util_proto.Duration(5 * time.Minute),
+				},
 			},
 		},
-	},
+	}
 }

--- a/pkg/defaults/mesh/timeout.go
+++ b/pkg/defaults/mesh/timeout.go
@@ -1,11 +1,11 @@
 package mesh
 
 import (
-	"github.com/kumahq/kuma/pkg/core/resources/model"
 	"time"
 
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
+	"github.com/kumahq/kuma/pkg/core/resources/model"
 	util_proto "github.com/kumahq/kuma/pkg/util/proto"
 )
 

--- a/pkg/defaults/mesh/traffic_permission.go
+++ b/pkg/defaults/mesh/traffic_permission.go
@@ -3,23 +3,26 @@ package mesh
 import (
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
+	"github.com/kumahq/kuma/pkg/core/resources/model"
 )
 
-var defaultTrafficPermissionResource = &core_mesh.TrafficPermissionResource{
-	Spec: &mesh_proto.TrafficPermission{
-		Sources: []*mesh_proto.Selector{
-			{
-				Match: map[string]string{
-					mesh_proto.ServiceTag: "*",
+var defaultTrafficPermissionResource = func() model.Resource {
+	return &core_mesh.TrafficPermissionResource{
+		Spec: &mesh_proto.TrafficPermission{
+			Sources: []*mesh_proto.Selector{
+				{
+					Match: map[string]string{
+						mesh_proto.ServiceTag: "*",
+					},
+				},
+			},
+			Destinations: []*mesh_proto.Selector{
+				{
+					Match: map[string]string{
+						mesh_proto.ServiceTag: "*",
+					},
 				},
 			},
 		},
-		Destinations: []*mesh_proto.Selector{
-			{
-				Match: map[string]string{
-					mesh_proto.ServiceTag: "*",
-				},
-			},
-		},
-	},
+	}
 }

--- a/pkg/defaults/mesh/traffic_route.go
+++ b/pkg/defaults/mesh/traffic_route.go
@@ -3,21 +3,25 @@ package mesh
 import (
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
+	"github.com/kumahq/kuma/pkg/core/resources/model"
 )
 
-var defaultTrafficRouteResource = &core_mesh.TrafficRouteResource{
-	Spec: &mesh_proto.TrafficRoute{
-		Sources: []*mesh_proto.Selector{{
-			Match: mesh_proto.MatchAnyService(),
-		}},
-		Destinations: []*mesh_proto.Selector{{
-			Match: mesh_proto.MatchAnyService(),
-		}},
-		Conf: &mesh_proto.TrafficRoute_Conf{
-			Destination: mesh_proto.MatchAnyService(),
-			LoadBalancer: &mesh_proto.TrafficRoute_LoadBalancer{
-				LbType: &mesh_proto.TrafficRoute_LoadBalancer_RoundRobin_{},
+var defaultTrafficRouteResource = func() model.Resource {
+	return &core_mesh.TrafficRouteResource{
+		Spec: &mesh_proto.TrafficRoute{
+			Sources: []*mesh_proto.Selector{{
+				Match: mesh_proto.MatchAnyService(),
+			}},
+			Destinations: []*mesh_proto.Selector{{
+				Match: mesh_proto.MatchAnyService(),
+			}},
+			Conf: &mesh_proto.TrafficRoute_Conf{
+				Destination: mesh_proto.MatchAnyService(),
+				LoadBalancer: &mesh_proto.TrafficRoute_LoadBalancer{
+					LbType: &mesh_proto.TrafficRoute_LoadBalancer_RoundRobin_{},
+				},
 			},
 		},
-	},
+	}
+
 }

--- a/test/e2e/deploy/e2e_suite_test.go
+++ b/test/e2e/deploy/e2e_suite_test.go
@@ -16,3 +16,4 @@ func TestE2E(t *testing.T) {
 var _ = Describe("Test Zone and Global", deploy.ZoneAndGlobal)
 var _ = Describe("Test Universal deployment", deploy.UniversalDeployment)
 var _ = Describe("Test Universal Transparent Proxy deployment", deploy.UniversalTransparentProxyDeployment)
+var _ = Describe("Test Kubernetes deployment", deploy.KubernetesDeployment)

--- a/test/e2e/deploy/kuma_deploy_kubernetes.go
+++ b/test/e2e/deploy/kuma_deploy_kubernetes.go
@@ -1,16 +1,17 @@
 package deploy
 
 import (
+	"strings"
+
 	"github.com/gruntwork-io/terratest/modules/k8s"
-	config_core "github.com/kumahq/kuma/pkg/config/core"
-	. "github.com/kumahq/kuma/test/framework"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"strings"
+
+	config_core "github.com/kumahq/kuma/pkg/config/core"
+	. "github.com/kumahq/kuma/test/framework"
 )
 
 func KubernetesDeployment() {
-
 	var k8sCluster Cluster
 	BeforeEach(func() {
 		k8sClusters, err := NewK8sClusters([]string{Kuma1}, Silent)

--- a/test/e2e/deploy/kuma_deploy_kubernetes.go
+++ b/test/e2e/deploy/kuma_deploy_kubernetes.go
@@ -1,0 +1,59 @@
+package deploy
+
+import (
+	"github.com/gruntwork-io/terratest/modules/k8s"
+	config_core "github.com/kumahq/kuma/pkg/config/core"
+	. "github.com/kumahq/kuma/test/framework"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"strings"
+)
+
+func KubernetesDeployment() {
+
+	var k8sCluster Cluster
+	BeforeEach(func() {
+		k8sClusters, err := NewK8sClusters([]string{Kuma1}, Silent)
+		Expect(err).ToNot(HaveOccurred())
+
+		k8sCluster = k8sClusters.GetCluster(Kuma1)
+		Expect(Kuma(config_core.Standalone)(k8sCluster)).To(Succeed())
+	})
+
+	E2EAfterEach(func() {
+		Expect(k8sCluster.DeleteKuma()).To(Succeed())
+		Expect(k8sCluster.DismissCluster()).To(Succeed())
+	})
+
+	policyCreated := func(typ, name string) func() bool {
+		return func() bool {
+			output, err := k8s.RunKubectlAndGetOutputE(k8sCluster.GetTesting(), k8sCluster.GetKubectlOptions("default"), "get", typ)
+			if err != nil {
+				return false
+			}
+			return strings.Contains(output, name)
+		}
+	}
+
+	It("should create default policies for default mesh", func() {
+		Eventually(policyCreated("trafficpermission", "allow-all-default"), "5s", "500ms").Should(BeTrue())
+		Eventually(policyCreated("trafficroute", "route-all-default"), "5s", "500ms").Should(BeTrue())
+		Eventually(policyCreated("timeout", "timeout-all-default"), "5s", "500ms").Should(BeTrue())
+		Eventually(policyCreated("circuitbreaker", "circuit-breaker-all-default"), "5s", "500ms").Should(BeTrue())
+		Eventually(policyCreated("retry", "retry-all-default"), "5s", "500ms").Should(BeTrue())
+	})
+
+	It("should create default policies for non-default mesh", func() {
+		Expect(YamlK8s(`
+apiVersion: kuma.io/v1alpha1
+kind: Mesh
+metadata:
+  name: non-default`)(k8sCluster)).To(Succeed())
+
+		Eventually(policyCreated("trafficpermission", "allow-all-non-default"), "5s", "500ms").Should(BeTrue())
+		Eventually(policyCreated("trafficroute", "route-all-non-default"), "5s", "500ms").Should(BeTrue())
+		Eventually(policyCreated("timeout", "timeout-all-non-default"), "5s", "500ms").Should(BeTrue())
+		Eventually(policyCreated("circuitbreaker", "circuit-breaker-all-non-default"), "5s", "500ms").Should(BeTrue())
+		Eventually(policyCreated("retry", "retry-all-non-default"), "5s", "500ms").Should(BeTrue())
+	})
+}


### PR DESCRIPTION
### Summary

Store operation `Create` writes Meta to the global variables like `defaultCircuitBreakerResource`. That's why it failed to create default resources for the new mesh with the error `resourceVersion should not be set on objects to be created`

### Full changelog

* wrap global resources into builder functions
* add e2e tests

### Issues resolved

N/A

### Documentation

~- [ ] Link to the website [documentation PR](https://github.com/kumahq/kuma-website/pull/XXX)~

### Testing

- [ ] Unit tests
- [X] E2E tests
- [ ] Manual testing on Universal
- [X] Manual testing on Kubernetes

### Backwards compatibility

~- [ ] Update [`UPGRADE.md`](/UPGRADE.md) with any steps users will need to take when upgrading.~
~- [ ] Add `backport-to-stable` label if the code follows our [backporting policy](/CONTRIBUTING.md#backporting)~
