### PR TITLE
chore(kumactl): prefix MeshGatewayRoutes with ROUTE in inspect dataplane output

### DIFF
--- a/app/kumactl/cmd/inspect/inspect_dataplane.go
+++ b/app/kumactl/cmd/inspect/inspect_dataplane.go
@@ -24,7 +24,7 @@ var dataplaneInspectTemplate = `{{ with IsSidecar . }}{{ range $num, $item := .I
 {{ end }}
 {{ range .Listeners }}LISTENER ({{ .Protocol }}:{{ .Port }}):
 {{ range .Hosts }}  {{ .HostName }}:
-{{ range .Routes }}    {{ .Route }}:
+{{ range .Routes }}    ROUTE {{ .Route }}:
 {{ range .Destinations }}      {{ FormatTags .Tags }}:
 {{ range $typ, $policy := .Policies }}        {{ $typ }}
           {{ .Meta.Name }}

--- a/app/kumactl/cmd/inspect/testdata/inspect-gateway-dataplane.golden.txt
+++ b/app/kumactl/cmd/inspect/testdata/inspect-gateway-dataplane.golden.txt
@@ -6,7 +6,7 @@ MESHGATEWAY:
 
 LISTENER (HTTP:80):
   *:
-    route-1:
+    ROUTE route-1:
       SERVICE backend:
         HealthCheck
           hc-1


### PR DESCRIPTION
### Summary

The output is otherwise confusing if the route's name doesn't make it clear it's a route.