### PR TITLE
feat(kuma-cp): shutdown kuma-dp container for any owner kind

### DIFF
--- a/pkg/plugins/runtime/k8s/controllers/pod_status_controller.go
+++ b/pkg/plugins/runtime/k8s/controllers/pod_status_controller.go
@@ -106,6 +106,9 @@ var onlySidecarContainerRunning = predicate.NewPredicateFuncs(
 	func(obj kube_client.Object) bool {
 		pod := obj.(*kube_core.Pod)
 		sidecarContainerRunning := false
+		if pod.Spec.RestartPolicy == kube_core.RestartPolicyAlways {
+			return false
+		}
 
 		for _, cs := range pod.Status.ContainerStatuses {
 			if cs.Name == util_k8s.KumaSidecarContainerName {


### PR DESCRIPTION
### Summary

When `kuma-dp` is deployed with a different type than `Job` and containers are stopped, `kuma-sidecar` is still running. Changed behavior that does not check only `Job` type.

### Full changelog

* Implement `kuma-sidecar` shutdown for other types than `Job`

### Issues resolved

Fix #2848 

### Documentation

- [ ] Link to the website [documentation PR](https://github.com/kumahq/kuma-website/pull/XXX)

### Testing

- [ ] Unit tests
- [ ] E2E tests
- [ ] Manual testing on Universal
- [X] Manual testing on Kubernetes

### Backwards compatibility

- [ ] Update [`UPGRADE.md`](/UPGRADE.md) with any steps users will need to take when upgrading.
- [ ] Add `backport-to-stable` label if the code follows our [backporting policy](/CONTRIBUTING.md#backporting)
