### PR TITLE
chore(*): reenable gateway e2e tls test

### DIFF
--- a/test/e2e/gateway/gatewayapi/gateway_api.go
+++ b/test/e2e/gateway/gatewayapi/gateway_api.go
@@ -92,7 +92,7 @@ func GatewayAPI() {
 		return ip
 	}
 
-	Context("HTTP Gateway", func() {
+	Context("HTTP Gateway", Ordered, func() {
 		gateway := `
 apiVersion: gateway.networking.k8s.io/v1alpha2
 kind: Gateway
@@ -108,9 +108,10 @@ spec:
 
 		var address string
 
-		BeforeEach(func() {
-			err := k8s.RunKubectlE(cluster.GetTesting(), cluster.GetKubectlOptions(), "delete", "gateway", "--all")
-			Expect(err).ToNot(HaveOccurred())
+		BeforeAll(func() {
+			E2EDeferCleanup(func() error {
+				return k8s.RunKubectlE(cluster.GetTesting(), cluster.GetKubectlOptions(TestNamespace), "delete", "gateway", "kuma")
+			})
 			Expect(YamlK8s(gateway)(cluster)).To(Succeed())
 			address = net.JoinHostPort(GatewayIP(), "8080")
 		})
@@ -215,7 +216,7 @@ spec:
 		})
 	})
 
-	PContext("HTTPS Gateway", func() {
+	Context("HTTPS Gateway", Ordered, func() {
 		secret := `
 apiVersion: v1
 kind: Secret
@@ -246,9 +247,10 @@ spec:
 
 		var address string
 
-		BeforeEach(func() {
-			err := k8s.RunKubectlE(cluster.GetTesting(), cluster.GetKubectlOptions(), "delete", "gateway", "--all")
-			Expect(err).ToNot(HaveOccurred())
+		BeforeAll(func() {
+			E2EDeferCleanup(func() error {
+				return k8s.RunKubectlE(cluster.GetTesting(), cluster.GetKubectlOptions(TestNamespace), "delete", "gateway", "kuma")
+			})
 			Expect(YamlK8s(secret)(cluster)).To(Succeed())
 			Expect(YamlK8s(gateway)(cluster)).To(Succeed())
 			address = net.JoinHostPort(GatewayIP(), "8090")


### PR DESCRIPTION
I did not catch that Gateway TLS test was disabled here https://github.com/kumahq/kuma/pull/4066 but it was fixed here https://github.com/kumahq/kuma/pull/4071

Also changed BeforeEach to BeforeAll since that's the thing now in Ginkgo 2.

### Issues resolved

No issues reported

### Documentation

~- [ ] Link to the website [documentation PR](https://github.com/kumahq/kuma-website/pull/XXX)~

### Testing

- [ ] Unit tests
- [X] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes

### Backwards compatibility

~- [ ] Update [`UPGRADE.md`](/UPGRADE.md) with any steps users will need to take when upgrading.~
~- [ ] Add `backport-to-stable` label if the code follows our [backporting policy](/CONTRIBUTING.md#backporting)~
