### PR TITLE
feat(helm): fail if global.image.tag and appVersion incompatible

### DIFF
--- a/deployments/charts/kuma/templates/_helpers.tpl
+++ b/deployments/charts/kuma/templates/_helpers.tpl
@@ -96,6 +96,14 @@ returns: formatted image string
 {{- $root := .root }}
 {{- $registry := ($img.registry | default $root.Values.global.image.registry) -}}
 {{- $repo := ($img.repository | required "Must specify image repository") -}}
+{{- if
+  and
+    $root.Values.global.image.tag
+    (ne $root.Values.global.image.tag $root.Chart.AppVersion)
+    (eq $root.Values.global.image.registry "docker.io/kumahq")
+-}}
+{{- fail (printf "This chart only supports Kuma version %q but global.image.tag is set to %q. Set global.image.tag to %q or skip this check by setting *.image.tag for each individual component." $root.Chart.AppVersion $root.Values.global.image.tag $root.Chart.AppVersion) -}}
+{{- end -}}
 {{- $defaultTag := ($root.Values.global.image.tag | default $root.Chart.AppVersion) -}}
 {{- $tag := ($img.tag | default $defaultTag) -}}
 {{- printf "%s/%s:%s" $registry $repo $tag -}}


### PR DESCRIPTION
### Summary

Explicitly setting `global.image.tag` (and thus causing its value to not be upgraded without `--reset-values`):

```
$ helm install kuma kuma/kuma --version 0.9.0 --set-string global.image.tag=1.5.0
...
You can access the control-plane via either the GUI, kubectl, the HTTP API, or the kumactl CLI.
$ helm upgrade kuma deployments/charts/kuma
Error: UPGRADE FAILED: execution error at (kuma/templates/pre-upgrade-install-missing-crds-job.yaml:131:20):
  This chart only supports Kuma version "1.6.0" but global.image.tag is set to "1.5.0". Set global.image.tag to "1.6.0" or skip this check by setting *.image.tag for each individual component.
```

Leaving `global.image.tag` unset:

```
$ helm install kuma kuma/kuma --version 0.9.0
...
You can access the control-plane via either the GUI, kubectl, the HTTP API, or the kumactl CLI.
$ helm upgrade kuma deployments/charts/kuma
...
You can access the control-plane via either the GUI, kubectl, the HTTP API, or the kumactl CLI.
```

Setting `global.image.registry != "docker.io/kumahq"` or setting `global.image.tagOverride` skips the check.