### PR TITLE
feat(k8s): support startupProbes

### DIFF
--- a/pkg/plugins/runtime/k8s/controllers/probes.go
+++ b/pkg/plugins/runtime/k8s/controllers/probes.go
@@ -35,14 +35,21 @@ func ProbesFor(pod *kube_core.Pod) (*mesh_proto.Dataplane_Probes, error) {
 			continue
 		}
 		if c.LivenessProbe != nil && c.LivenessProbe.HTTPGet != nil {
-			if endpoint, err := ProbeFor(c.LivenessProbe, port); err != nil {
+			if endpoint, err := probeFor(c.LivenessProbe, port); err != nil {
 				return nil, err
 			} else {
 				dpProbes.Endpoints = append(dpProbes.Endpoints, endpoint)
 			}
 		}
 		if c.ReadinessProbe != nil && c.ReadinessProbe.HTTPGet != nil {
-			if endpoint, err := ProbeFor(c.ReadinessProbe, port); err != nil {
+			if endpoint, err := probeFor(c.ReadinessProbe, port); err != nil {
+				return nil, err
+			} else {
+				dpProbes.Endpoints = append(dpProbes.Endpoints, endpoint)
+			}
+		}
+		if c.StartupProbe != nil && c.StartupProbe.HTTPGet != nil {
+			if endpoint, err := probeFor(c.StartupProbe, port); err != nil {
 				return nil, err
 			} else {
 				dpProbes.Endpoints = append(dpProbes.Endpoints, endpoint)
@@ -52,7 +59,7 @@ func ProbesFor(pod *kube_core.Pod) (*mesh_proto.Dataplane_Probes, error) {
 	return dpProbes, nil
 }
 
-func ProbeFor(podProbe *kube_core.Probe, port uint32) (*mesh_proto.Dataplane_Probes_Endpoint, error) {
+func probeFor(podProbe *kube_core.Probe, port uint32) (*mesh_proto.Dataplane_Probes_Endpoint, error) {
 	inbound, err := probes.KumaProbe(*podProbe).ToReal(port)
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to convert virtual probe to real")

--- a/pkg/plugins/runtime/k8s/controllers/testdata/10.dataplane.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/10.dataplane.yaml
@@ -43,4 +43,7 @@ spec:
     - inboundPath: /metrics
       inboundPort: 3001
       path: /3001/metrics
+    - inboundPath: /metrics
+      inboundPort: 8081
+      path: /8081/metrics
     port: 19000

--- a/pkg/plugins/runtime/k8s/controllers/testdata/10.pod.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/10.pod.yaml
@@ -21,6 +21,12 @@ spec:
           port: 19000
         initialDelaySeconds: 3
         periodSeconds: 3
+      startupProbe:
+        httpGet:
+          path: /8081/metrics
+          port: 19000
+        initialDelaySeconds: 3
+        periodSeconds: 3
 
 status:
   podIP: 192.168.0.1

--- a/pkg/plugins/runtime/k8s/webhooks/injector/probes.go
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/probes.go
@@ -48,6 +48,13 @@ func (i *KumaInjector) overrideHTTPProbes(pod *kube_core.Pod) error {
 				return err
 			}
 		}
+		if c.StartupProbe != nil && c.StartupProbe.HTTPGet != nil {
+			log.V(1).Info("overriding startup probe", "container", c.Name)
+			resolveNamedPort(c, c.StartupProbe)
+			if err := overrideHTTPProbe(c.StartupProbe, port); err != nil {
+				return err
+			}
+		}
 	}
 	return nil
 }

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.21.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.21.golden.yaml
@@ -33,6 +33,12 @@ spec:
       initialDelaySeconds: 3
       periodSeconds: 3
     resources: {}
+    startupProbe:
+      httpGet:
+        path: /ready
+        port: 8080
+      initialDelaySeconds: 3
+      periodSeconds: 3
     volumeMounts:
     - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
       name: default-token-w7dxf

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.21.input.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.21.input.yaml
@@ -25,6 +25,12 @@ spec:
           port: 8080
         initialDelaySeconds: 3
         periodSeconds: 3
+      startupProbe:
+        httpGet:
+          path: /ready
+          port: 8080
+        initialDelaySeconds: 3
+        periodSeconds: 3
       volumeMounts:
         - name: default-token-w7dxf
           readOnly: true

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.22.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.22.golden.yaml
@@ -33,6 +33,12 @@ spec:
       initialDelaySeconds: 3
       periodSeconds: 3
     resources: {}
+    startupProbe:
+      httpGet:
+        path: /8081/metrics
+        port: 9000
+      initialDelaySeconds: 3
+      periodSeconds: 3
     volumeMounts:
     - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
       name: default-token-w7dxf

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.22.input.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.22.input.yaml
@@ -27,6 +27,12 @@ spec:
           port: 8080
         initialDelaySeconds: 3
         periodSeconds: 3
+      startupProbe:
+        httpGet:
+          path: /metrics
+          port: 8081
+        initialDelaySeconds: 3
+        periodSeconds: 3
       volumeMounts:
         - name: default-token-w7dxf
           readOnly: true

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.23.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.23.golden.yaml
@@ -31,6 +31,8 @@ spec:
       name: readiness-port
     - containerPort: 8080
       name: liveness-port
+    - containerPort: 8081
+      name: startup-port
     readinessProbe:
       httpGet:
         path: /3001/metrics
@@ -38,6 +40,12 @@ spec:
       initialDelaySeconds: 3
       periodSeconds: 3
     resources: {}
+    startupProbe:
+      httpGet:
+        path: /8081/startup
+        port: 9000
+      initialDelaySeconds: 3
+      periodSeconds: 3
     volumeMounts:
     - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
       name: default-token-w7dxf

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.23.input.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.23.input.yaml
@@ -18,6 +18,8 @@ spec:
           containerPort: 3001
         - name: liveness-port
           containerPort: 8080
+        - name: startup-port
+          containerPort: 8081
       readinessProbe:
         httpGet:
           path: /metrics
@@ -28,6 +30,12 @@ spec:
         httpGet:
           path: /metrics
           port: liveness-port
+        initialDelaySeconds: 3
+        periodSeconds: 3
+      startupProbe:
+        httpGet:
+          path: /startup
+          port: startup-port
         initialDelaySeconds: 3
         periodSeconds: 3
       volumeMounts:

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.28.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.28.golden.yaml
@@ -2,9 +2,9 @@ apiVersion: v1
 kind: Pod
 metadata:
   annotations:
-    kuma.io/service-account-token-volume: token
     kuma.io/envoy-admin-port: "9901"
     kuma.io/mesh: default
+    kuma.io/service-account-token-volume: token
     kuma.io/sidecar-injected: "true"
     kuma.io/sidecar-uid: "5678"
     kuma.io/transparent-proxying: enabled
@@ -151,11 +151,11 @@ spec:
       runAsGroup: 0
       runAsUser: 0
   volumes:
-    - name: token
-      projected:
-        sources:
-          - serviceAccountToken:
-              path: token
-              expirationSeconds: 7200
-              audience: "https://kubernetes.default.svc.cluster.local"
+  - name: token
+    projected:
+      sources:
+      - serviceAccountToken:
+          audience: https://kubernetes.default.svc.cluster.local
+          expirationSeconds: 7200
+          path: token
 status: {}


### PR DESCRIPTION
### Summary

Support startProbes like we support livenessProbes and readinessProbes

### Issues resolved

Fix #4020

### Documentation

- [ ] Link to the website [documentation PR](https://github.com/kumahq/kuma-website/pull/750)

### Testing

- [x] Unit tests
- [ ] E2E tests
- ~~[ ] Manual testing on Universal~~
- [x] Manual testing on Kubernetes

### Backwards compatibility

- [ ] Update [`UPGRADE.md`](/UPGRADE.md) with any steps users will need to take when upgrading.
- [ ] Add `backport-to-stable` label if the code follows our [backporting policy](/CONTRIBUTING.md#backporting)
