### PR TITLE
fix(kuma-cp): gateway tls listeners without hostnames

### DIFF
--- a/pkg/plugins/runtime/gateway/listener_generator_test.go
+++ b/pkg/plugins/runtime/gateway/listener_generator_test.go
@@ -192,6 +192,14 @@ conf:
       - secret: server-certificate
     tags:
       name: foo.example.com
+  - port: 443
+    protocol: HTTPS
+    tls:
+      mode: TERMINATE
+      certificates:
+      - secret: server-certificate
+    tags:
+      name: any-hostname
 `),
 	)
 

--- a/pkg/plugins/runtime/gateway/testdata/05-gateway-listener.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/05-gateway-listener.yaml
@@ -191,6 +191,66 @@ Resources:
             tlsParams:
               tlsMinimumProtocolVersion: TLSv1_2
           requireClientCertificate: false
+    - filterChainMatch:
+        applicationProtocols:
+        - h2
+        - http/1.1
+        transportProtocol: tls
+      filters:
+      - name: envoy.filters.network.http_connection_manager
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+          commonHttpProtocolOptions:
+            headersWithUnderscoresAction: REJECT_REQUEST
+            idleTimeout: 300s
+          http2ProtocolOptions:
+            allowConnect: true
+            initialConnectionWindowSize: 1048576
+            initialStreamWindowSize: 65536
+            maxConcurrentStreams: 100
+          httpFilters:
+          - name: envoy.filters.http.local_ratelimit
+            typedConfig:
+              '@type': type.googleapis.com/envoy.extensions.filters.http.local_ratelimit.v3.LocalRateLimit
+              statPrefix: rate_limit
+          - name: gzip-compress
+            typedConfig:
+              '@type': type.googleapis.com/envoy.extensions.filters.http.compressor.v3.Compressor
+              compressorLibrary:
+                name: gzip
+                typedConfig:
+                  '@type': type.googleapis.com/envoy.extensions.compression.gzip.compressor.v3.Gzip
+              responseDirectionConfig:
+                disableOnEtagHeader: true
+          - name: envoy.filters.http.router
+          mergeSlashes: true
+          normalizePath: true
+          rds:
+            configSource:
+              ads: {}
+              resourceApiVersion: V3
+            routeConfigName: default-gateway:HTTPS:443
+          requestHeadersTimeout: 0.500s
+          serverName: Kuma Gateway
+          statPrefix: gateway-default
+          streamIdleTimeout: 5s
+          stripAnyHostPort: true
+      transportSocket:
+        name: envoy.transport_sockets.tls
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext
+          commonTlsContext:
+            alpnProtocols:
+            - h2
+            - http/1.1
+            tlsCertificateSdsSecretConfigs:
+            - name: cert.rsa:secret:server-certificate
+              sdsConfig:
+                ads: {}
+                resourceApiVersion: V3
+            tlsParams:
+              tlsMinimumProtocolVersion: TLSv1_2
+          requireClientCertificate: false
     listenerFilters:
     - name: envoy.filters.listener.tls_inspector
       typedConfig:

--- a/pkg/xds/envoy/listeners/filter_chain_match_configurers.go
+++ b/pkg/xds/envoy/listeners/filter_chain_match_configurers.go
@@ -31,8 +31,12 @@ func MatchServerNames(names ...string) FilterChainBuilderOpt {
 				chain.FilterChainMatch = &envoy_listener.FilterChainMatch{}
 			}
 
-			chain.FilterChainMatch.ServerNames =
-				append(chain.FilterChainMatch.ServerNames, names...)
+			for _, name := range names {
+				// "" or "*" means match all, but Envoy supports only supports *.domain or more specific
+				if name != "" && name != "*" {
+					chain.FilterChainMatch.ServerNames = append(chain.FilterChainMatch.ServerNames, name)
+				}
+			}
 		}),
 	)
 }

--- a/test/e2e/gateway/gateway_universal.go
+++ b/test/e2e/gateway/gateway_universal.go
@@ -229,6 +229,12 @@ conf:
       - secret: example-kuma-io-certificate
     tags:
       hostname: example.kuma.io
+  - port: 8081
+    protocol: HTTPS
+    tls:
+      mode: TERMINATE
+      certificates:
+      - secret: example-kuma-io-certificate
 `),
 			).To(Succeed())
 
@@ -253,9 +259,18 @@ data: %s
 		})
 
 		It("should proxy simple HTTPS requests", func() {
-			ProxySecureRequests(cluster, "universal",
+			ProxySecureRequests(
+				cluster,
+				"universal",
 				net.JoinHostPort("example.kuma.io", GatewayPort),
-				client.Resolve("example.kuma.io", 8080, GatewayAddress("gateway-proxy")))
+				client.Resolve("example.kuma.io", 8080, GatewayAddress("gateway-proxy")),
+			)
+
+			ProxySecureRequests(
+				cluster,
+				"universal",
+				net.JoinHostPort(GatewayAddress("gateway-proxy"), "8081"),
+			)
 		})
 	})
 


### PR DESCRIPTION
### Summary

In case of "match all" tls listeners, server names in Envoy config should be empty.
I fixed this on the configurer level since I think it's nice UX to allow `*` for users anyways.

### Issues resolved

Fix #4091

### Documentation

~- [ ] Link to the website [documentation PR](https://github.com/kumahq/kuma-website/pull/XXX)~

### Testing

- [X] Unit tests
- [X] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes

### Backwards compatibility

~- [ ] Update [`UPGRADE.md`](/UPGRADE.md) with any steps users will need to take when upgrading.~
~- [ ] Add `backport-to-stable` label if the code follows our [backporting policy](/CONTRIBUTING.md#backporting)~


> Changelog: fix(gateway): gateway tls listeners without hostnames