### PR TITLE
feat(kuma-cp): expose kuma-cp gui through ingress

### DIFF
--- a/deployments/charts/kuma/README.md
+++ b/deployments/charts/kuma/README.md
@@ -32,7 +32,12 @@ A Helm chart for the Kuma Control Plane
 | controlPlane.service.name | string | `nil` | Optionally override of the Kuma Control Plane Service's name |
 | controlPlane.service.type | string | `"ClusterIP"` | Service type of the Kuma Control Plane |
 | controlPlane.service.annotations | object | `{}` | Additional annotations to put on the Kuma Control Plane |
-| controlPlane.ingress.enabled | bool | `false` | Install Kuma Control Plane with K8s Ingress resource |
+| controlPlane.ingress.enabled | bool | `false` | Install K8s Ingress resource that exposes GUI and API |
+| controlPlane.ingress.ingressClassName | string | `nil` | IngressClass defines which controller will implement the resource |
+| controlPlane.ingress.hostname | string | `nil` | Ingress hostname |
+| controlPlane.ingress.annotations | object | `{}` | Map of ingress annotations. |
+| controlPlane.ingress.path | string | `"/"` | Ingress path. |
+| controlPlane.ingress.pathType | string | `"ImplementationSpecific"` | Each path in an Ingress is required to have a corresponding path type. (ImplementationSpecific/Exact/Prefix) |
 | controlPlane.globalZoneSyncService | object | `{"annotations":{},"loadBalancerIP":null,"port":5685,"type":"LoadBalancer"}` | URL of Global Kuma CP |
 | controlPlane.globalZoneSyncService.type | string | `"LoadBalancer"` | Service type of the Global-zone sync |
 | controlPlane.globalZoneSyncService.loadBalancerIP | string | `nil` | Optionally specify IP to be used by cloud provider when configuring load balancer |

--- a/deployments/charts/kuma/README.md
+++ b/deployments/charts/kuma/README.md
@@ -32,6 +32,7 @@ A Helm chart for the Kuma Control Plane
 | controlPlane.service.name | string | `nil` | Optionally override of the Kuma Control Plane Service's name |
 | controlPlane.service.type | string | `"ClusterIP"` | Service type of the Kuma Control Plane |
 | controlPlane.service.annotations | object | `{}` | Additional annotations to put on the Kuma Control Plane |
+| controlPlane.ingress.enabled | bool | `false` | Install Kuma Control Plane with K8s Ingress resource |
 | controlPlane.globalZoneSyncService | object | `{"annotations":{},"loadBalancerIP":null,"port":5685,"type":"LoadBalancer"}` | URL of Global Kuma CP |
 | controlPlane.globalZoneSyncService.type | string | `"LoadBalancer"` | Service type of the Global-zone sync |
 | controlPlane.globalZoneSyncService.loadBalancerIP | string | `nil` | Optionally specify IP to be used by cloud provider when configuring load balancer |

--- a/deployments/charts/kuma/templates/cp-ingress.yaml
+++ b/deployments/charts/kuma/templates/cp-ingress.yaml
@@ -4,13 +4,18 @@ kind: Ingress
 metadata:
   name: {{ include "kuma.name" . }}-control-plane
   namespace: {{ .Release.Namespace }}
+  {{- with .Values.controlPlane.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
-  ingressClassName: {{ include "kuma.name" . }}-control-plane
+  ingressClassName: {{ .Values.controlPlane.ingress.ingressClassName }}
   rules:
-  - http:
+  - host: {{ .Values.controlPlane.ingress.hostname }}
+    http:
       paths:
-      - path: /
-        pathType: Prefix
+      - path: {{ .Values.controlPlane.ingress.path }}
+        pathType: {{ .Values.controlPlane.ingress.pathType }}
         backend:
           service:
             name: {{ include "kuma.name" . }}-control-plane

--- a/deployments/charts/kuma/templates/cp-ingress.yaml
+++ b/deployments/charts/kuma/templates/cp-ingress.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.controlPlane.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "kuma.name" . }}-control-plane
+  namespace: {{ .Release.Namespace }}
+spec:
+  ingressClassName: {{ include "kuma.name" . }}-control-plane
+  rules:
+  - http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: {{ include "kuma.name" . }}-control-plane
+            port:
+              number: 5681
+{{- end }}

--- a/deployments/charts/kuma/templates/cp-ingress.yaml
+++ b/deployments/charts/kuma/templates/cp-ingress.yaml
@@ -2,7 +2,7 @@
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: {{ include "kuma.name" . }}-control-plane
+  name: {{ include "kuma.controlPlane.serviceName" . }}
   namespace: {{ .Release.Namespace }}
   {{- with .Values.controlPlane.ingress.annotations }}
   annotations:
@@ -18,7 +18,7 @@ spec:
         pathType: {{ .Values.controlPlane.ingress.pathType }}
         backend:
           service:
-            name: {{ include "kuma.name" . }}-control-plane
+            name: {{ include "kuma.controlPlane.serviceName" . }}
             port:
               number: 5681
 {{- end }}

--- a/deployments/charts/kuma/values.yaml
+++ b/deployments/charts/kuma/values.yaml
@@ -75,11 +75,11 @@ controlPlane:
     # -- Additional annotations to put on the Kuma Control Plane
     annotations: { }
 
-  # Kuma admin ingress settings. Useful if you want to expose the
+  # Kuma API and GUI ingress settings. Useful if you want to expose the
   # API and GUI of Kuma outside the k8s cluster.
   ingress:
     # -- Install K8s Ingress resource that exposes GUI and API
-    enabled: false
+    enabled: true
     # -- IngressClass defines which controller will implement the resource
     ingressClassName:
     # -- Ingress hostname

--- a/deployments/charts/kuma/values.yaml
+++ b/deployments/charts/kuma/values.yaml
@@ -75,9 +75,21 @@ controlPlane:
     # -- Additional annotations to put on the Kuma Control Plane
     annotations: { }
 
+  # Kuma admin ingress settings. Useful if you want to expose the
+  # API and GUI of Kuma outside the k8s cluster.
   ingress:
-    # -- Install Kuma Control Plane with K8s Ingress resource
+    # -- Install K8s Ingress resource that exposes GUI and API
     enabled: false
+    # -- IngressClass defines which controller will implement the resource
+    ingressClassName:
+    # -- Ingress hostname
+    hostname:
+    # -- Map of ingress annotations.
+    annotations: {}
+    # -- Ingress path.
+    path: /
+    # -- Each path in an Ingress is required to have a corresponding path type. (ImplementationSpecific/Exact/Prefix)
+    pathType: ImplementationSpecific
 
   # -- URL of Global Kuma CP
   globalZoneSyncService:

--- a/deployments/charts/kuma/values.yaml
+++ b/deployments/charts/kuma/values.yaml
@@ -79,7 +79,7 @@ controlPlane:
   # API and GUI of Kuma outside the k8s cluster.
   ingress:
     # -- Install K8s Ingress resource that exposes GUI and API
-    enabled: true
+    enabled: false
     # -- IngressClass defines which controller will implement the resource
     ingressClassName:
     # -- Ingress hostname

--- a/deployments/charts/kuma/values.yaml
+++ b/deployments/charts/kuma/values.yaml
@@ -75,6 +75,10 @@ controlPlane:
     # -- Additional annotations to put on the Kuma Control Plane
     annotations: { }
 
+  ingress:
+    # -- Install Kuma Control Plane with K8s Ingress resource
+    enabled: false
+
   # -- URL of Global Kuma CP
   globalZoneSyncService:
     # -- Service type of the Global-zone sync


### PR DESCRIPTION
### Summary

expose kuma-cp gui/api through ingress

### Full changelog

* [Implement helm ingress definition]

### Issues resolved

Fix #1117 

### Documentation

- [ ] Link to the website [documentation PR](https://github.com/kumahq/kuma-website/pull/XXX)

### Testing

- [ ] Unit tests
- [ ] E2E tests
- [ ] Manual testing on Universal
- [X] Manual testing on Kubernetes

### Backwards compatibility

- [ ] Update [`UPGRADE.md`](/UPGRADE.md) with any steps users will need to take when upgrading.
- [ ] Add `backport-to-stable` label if the code follows our [backporting policy](/CONTRIBUTING.md#backporting)
