### PR TITLE
tests(e2e): embed token when deploying service

### DIFF
--- a/test/e2e/auth/auth_universal.go
+++ b/test/e2e/auth/auth_universal.go
@@ -20,10 +20,7 @@ func AuthUniversal() {
 		Expect(err).ToNot(HaveOccurred())
 	})
 
-	AfterEach(func() {
-		if ShouldSkipCleanup() {
-			return
-		}
+	E2EAfterEach(func() {
 		Expect(cluster.DeleteKuma()).To(Succeed())
 		Expect(cluster.DismissCluster()).To(Succeed())
 	})

--- a/test/e2e/auth/dp/dp_auth_universal.go
+++ b/test/e2e/auth/dp/dp_auth_universal.go
@@ -37,9 +37,7 @@ networking:
 		Expect(YamlUniversal(dp)(cluster)).To(Succeed())
 
 		// when trying to spin up dataplane with same name but token bound to a different service
-		dpToken, err := cluster.GetKuma().GenerateDpToken("default", "test-server")
-		Expect(err).ToNot(HaveOccurred())
-		err = TestServerUniversal("dp-01", "default", dpToken, WithServiceName("test-server"))(cluster)
+		err := TestServerUniversal("dp-01", "default", WithServiceName("test-server"))(cluster)
 		Expect(err).ToNot(HaveOccurred())
 
 		// then
@@ -64,9 +62,7 @@ networking:
 		Expect(YamlUniversal(dp)(cluster)).To(Succeed())
 
 		// when
-		dpToken, err := cluster.GetKuma().GenerateDpToken("default", "test-server")
-		Expect(err).ToNot(HaveOccurred())
-		err = TestServerUniversal("dp-02", "default", dpToken, WithServiceName("test-server"))(cluster)
+		err := TestServerUniversal("dp-02", "default", WithServiceName("test-server"))(cluster)
 		Expect(err).ToNot(HaveOccurred())
 
 		// then

--- a/test/e2e/compatibility/dp_compatibility_universal.go
+++ b/test/e2e/compatibility/dp_compatibility_universal.go
@@ -17,27 +17,18 @@ func UniversalCompatibility() {
 
 		err := NewClusterSetup().
 			Install(Kuma(core.Standalone)).
+			Install(TestServerUniversal("test-server", "default",
+				WithArgs([]string{"echo", "--instance", "universal1"}),
+				WithDPVersion("1.1.6"))).
+			Install(DemoClientUniversal(AppModeDemoClient, "default",
+				WithDPVersion("1.1.6"),
+				WithTransparentProxy(true)),
+			).
 			Setup(cluster)
-		Expect(err).ToNot(HaveOccurred())
-
-		testServerToken, err := cluster.GetKuma().GenerateDpToken("default", "test-server")
-		Expect(err).ToNot(HaveOccurred())
-		demoClientToken, err := cluster.GetKuma().GenerateDpToken("default", "demo-client")
-		Expect(err).ToNot(HaveOccurred())
-
-		err = TestServerUniversal("test-server", "default", testServerToken,
-			WithArgs([]string{"echo", "--instance", "universal1"}),
-			WithDPVersion("1.1.6"))(cluster)
-		Expect(err).ToNot(HaveOccurred())
-		err = DemoClientUniversal(AppModeDemoClient, "default", demoClientToken, WithDPVersion("1.1.6"), WithTransparentProxy(true))(cluster)
 		Expect(err).ToNot(HaveOccurred())
 	})
 
-	AfterEach(func() {
-		if ShouldSkipCleanup() {
-			return
-		}
-		Expect(cluster.DeleteKuma()).To(Succeed())
+	E2EAfterEach(func() {
 		Expect(cluster.DismissCluster()).To(Succeed())
 	})
 

--- a/test/e2e/deploy/kuma_deploy_global_zone.go
+++ b/test/e2e/deploy/kuma_deploy_global_zone.go
@@ -89,11 +89,7 @@ spec:
 		Expect(logs2).To(ContainSubstring("\"mode\":\"zone\""))
 	})
 
-	AfterEach(func() {
-		if ShouldSkipCleanup() {
-			return
-		}
-
+	E2EAfterEach(func() {
 		defer func() {
 			// restore the original namespace
 			Config.KumaNamespace = originalKumaNamespace

--- a/test/e2e/externalservices/externalservices_hostheader.go
+++ b/test/e2e/externalservices/externalservices_hostheader.go
@@ -31,20 +31,12 @@ networking:
 		err := NewClusterSetup().
 			Install(Kuma(core.Standalone)).
 			Install(YamlUniversal(externalService)).
+			Install(DemoClientUniversal("dp-demo-client", "default", WithTransparentProxy(true))).
 			Setup(cluster)
-		Expect(err).ToNot(HaveOccurred())
-
-		demoClientToken, err := cluster.GetKuma().GenerateDpToken("default", "dp-demo-client")
-		Expect(err).ToNot(HaveOccurred())
-
-		err = DemoClientUniversal("dp-demo-client", "default", demoClientToken, WithTransparentProxy(true))(cluster)
 		Expect(err).ToNot(HaveOccurred())
 	})
 
-	AfterEach(func() {
-		if ShouldSkipCleanup() {
-			return
-		}
+	E2EAfterEach(func() {
 		Expect(cluster.DeleteKuma()).To(Succeed())
 		Expect(cluster.DismissCluster()).To(Succeed())
 	})

--- a/test/e2e/externalservices/externalservices_kubernetes.go
+++ b/test/e2e/externalservices/externalservices_kubernetes.go
@@ -106,11 +106,7 @@ spec:
 		clientPod = &pods[0]
 	})
 
-	AfterEach(func() {
-		if ShouldSkipCleanup() {
-			return
-		}
-
+	E2EAfterEach(func() {
 		err := cluster.DeleteNamespace(TestNamespace)
 		Expect(err).ToNot(HaveOccurred())
 

--- a/test/e2e/externalservices/externalservices_kubernetes_without_egress.go
+++ b/test/e2e/externalservices/externalservices_kubernetes_without_egress.go
@@ -87,11 +87,7 @@ spec:
 		clientPod = &pods[0]
 	})
 
-	AfterEach(func() {
-		if ShouldSkipCleanup() {
-			return
-		}
-
+	E2EAfterEach(func() {
 		err := cluster.DeleteNamespace(TestNamespace)
 		Expect(err).ToNot(HaveOccurred())
 

--- a/test/e2e/externalservices/externalservices_multizone_universal.go
+++ b/test/e2e/externalservices/externalservices_multizone_universal.go
@@ -81,9 +81,6 @@ networking:
 
 		globalCP := global.GetKuma()
 
-		demoClientToken, err := globalCP.GenerateDpToken(defaultMesh, "demo-client")
-		Expect(err).ToNot(HaveOccurred())
-
 		// Cluster 1
 		zone1 = clusters.GetCluster(Kuma4)
 
@@ -92,7 +89,7 @@ networking:
 				WithGlobalAddress(globalCP.GetKDSServerAddress()),
 				WithHDS(false),
 			)).
-			Install(DemoClientUniversal(AppModeDemoClient, defaultMesh, demoClientToken, WithTransparentProxy(true))).
+			Install(DemoClientUniversal(AppModeDemoClient, defaultMesh, WithTransparentProxy(true))).
 			Setup(zone1)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -104,21 +101,15 @@ networking:
 				WithGlobalAddress(globalCP.GetKDSServerAddress()),
 				WithHDS(false),
 			)).
-			Install(DemoClientUniversal(AppModeDemoClient, defaultMesh, demoClientToken, WithTransparentProxy(true))).
+			Install(DemoClientUniversal(AppModeDemoClient, defaultMesh, WithTransparentProxy(true))).
 			Setup(zone2)
 		Expect(err).ToNot(HaveOccurred())
 	})
 
 	E2EAfterEach(func() {
 		Expect(external.DismissCluster()).To(Succeed())
-
-		Expect(zone1.DeleteKuma()).To(Succeed())
 		Expect(zone1.DismissCluster()).To(Succeed())
-
-		Expect(zone2.DeleteKuma()).To(Succeed())
 		Expect(zone2.DismissCluster()).To(Succeed())
-
-		Expect(global.DeleteKuma()).To(Succeed())
 		Expect(global.DismissCluster()).To(Succeed())
 	})
 

--- a/test/e2e/externalservices/localityawarelb_multizone/locality_multizone_hybrid.go
+++ b/test/e2e/externalservices/localityawarelb_multizone/locality_multizone_hybrid.go
@@ -119,23 +119,16 @@ var _ = E2EBeforeSuite(func() {
 	// Universal Cluster 4
 	zone4 = universalClusters.GetCluster(Kuma4).(*UniversalCluster)
 	Expect(err).ToNot(HaveOccurred())
-	egressTokenZone4, err := globalCP.GenerateZoneEgressToken(Kuma4)
-	Expect(err).ToNot(HaveOccurred())
-	ingressTokenZone4, err := globalCP.GenerateZoneIngressToken(Kuma4)
-	Expect(err).ToNot(HaveOccurred())
-	demoClientTokenZone4, err := globalCP.GenerateDpToken(defaultMesh, "zone4-demo-client")
-	Expect(err).ToNot(HaveOccurred())
 
 	Expect(NewClusterSetup().
 		Install(Kuma(config_core.Zone, WithGlobalAddress(globalCP.GetKDSServerAddress()))).
 		Install(DemoClientUniversal(
 			"zone4-demo-client",
 			defaultMesh,
-			demoClientTokenZone4,
 			WithTransparentProxy(true),
 		)).
-		Install(IngressUniversal(ingressTokenZone4)).
-		Install(EgressUniversal(egressTokenZone4)).
+		Install(IngressUniversal(globalCP.GenerateZoneIngressToken)).
+		Install(EgressUniversal(globalCP.GenerateZoneEgressToken)).
 		Install(InstallExternalService("external-service-in-zone4")).
 		Install(InstallExternalService("external-service-in-zone1")).
 		Install(InstallExternalService("external-service-in-both-zones")).
@@ -265,12 +258,9 @@ func ExternalServicesOnMultizoneHybridWithLocalityAwareLb() {
 			Setup(global)
 		Expect(err).ToNot(HaveOccurred())
 
-		demoClientTokenZone4, err := zone4.GetKuma().GenerateDpToken(mesh, "zone4-demo-client-2")
-		Expect(err).ToNot(HaveOccurred())
 		Expect(DemoClientUniversal(
 			"zone4-demo-client-2",
 			mesh,
-			demoClientTokenZone4,
 			WithTransparentProxy(true),
 		)(zone4)).To(Succeed())
 

--- a/test/e2e/gateway/hybrid/gateway_hybrid.go
+++ b/test/e2e/gateway/hybrid/gateway_hybrid.go
@@ -62,9 +62,6 @@ var _ = E2EBeforeSuite(func() {
 
 	E2EDeferCleanup(zone1.DismissCluster)
 
-	zoneIngressToken, err := global.GetKuma().GenerateZoneIngressToken(Kuma3)
-	Expect(err).ToNot(HaveOccurred())
-
 	zone2 = NewUniversalCluster(NewTestingT(), Kuma3, Silent)
 
 	Expect(NewClusterSetup().
@@ -73,7 +70,7 @@ var _ = E2EBeforeSuite(func() {
 			WithEnv("KUMA_EXPERIMENTAL_MESHGATEWAY", "true"),
 		)).
 		Install(gateway.EchoServerApp("echo-server", serviceName, Kuma3)).
-		Install(IngressUniversal(zoneIngressToken)).
+		Install(IngressUniversal(global.GetKuma().GenerateZoneIngressToken)).
 		Setup(zone2)).To(Succeed())
 	E2EDeferCleanup(zone2.DismissCluster)
 })

--- a/test/e2e/gateway/utils.go
+++ b/test/e2e/gateway/utils.go
@@ -160,15 +160,9 @@ networking:
 
 func EchoServerApp(name string, service string, instance string) framework.InstallFunc {
 	return func(cluster framework.Cluster) error {
-		token, err := cluster.GetKuma().GenerateDpToken("default", service)
-		if err != nil {
-			return err
-		}
-
 		return framework.TestServerUniversal(
 			name,
 			"default",
-			token,
 			framework.WithArgs([]string{"echo", "--instance", instance}),
 			framework.WithServiceName(service),
 		)(cluster)

--- a/test/e2e/healthcheck/universal/panic.go
+++ b/test/e2e/healthcheck/universal/panic.go
@@ -57,15 +57,10 @@ networking:
 			Setup(universalCluster)
 		Expect(err).ToNot(HaveOccurred())
 
-		testServerToken, err := universalCluster.GetKuma().GenerateDpToken("default", "test-server")
-		Expect(err).ToNot(HaveOccurred())
-		demoClientToken, err := universalCluster.GetKuma().GenerateDpToken("default", "demo-client")
-		Expect(err).ToNot(HaveOccurred())
-
 		for i := 1; i <= 6; i++ {
 			dpName := fmt.Sprintf("dp-echo-%d", i)
 			response := fmt.Sprintf("universal-%d", i)
-			err = TestServerUniversal(dpName, "default", testServerToken, WithArgs([]string{"echo", "--instance", response}))(universalCluster)
+			err = TestServerUniversal(dpName, "default", WithArgs([]string{"echo", "--instance", response}))(universalCluster)
 			Expect(err).ToNot(HaveOccurred())
 		}
 		for i := 7; i <= 10; i++ {
@@ -73,15 +68,11 @@ networking:
 			Expect(err).ToNot(HaveOccurred())
 		}
 
-		err = DemoClientUniversal(AppModeDemoClient, "default", demoClientToken, WithTransparentProxy(true))(universalCluster)
+		err = DemoClientUniversal(AppModeDemoClient, "default", WithTransparentProxy(true))(universalCluster)
 		Expect(err).ToNot(HaveOccurred())
 	})
 
-	AfterEach(func() {
-		if ShouldSkipCleanup() {
-			return
-		}
-		Expect(universalCluster.DeleteKuma()).To(Succeed())
+	E2EAfterEach(func() {
 		Expect(universalCluster.DismissCluster()).To(Succeed())
 	})
 

--- a/test/e2e/healthcheck/universal/policy_http.go
+++ b/test/e2e/healthcheck/universal/policy_http.go
@@ -46,26 +46,15 @@ conf:
 		err := NewClusterSetup().
 			Install(Kuma(config_core.Standalone)).
 			Install(YamlUniversal(healthCheck("health", "200"))).
+			Install(DemoClientUniversal("dp-demo-client", "default",
+				WithTransparentProxy(true)),
+			).
+			Install(TestServerUniversal("test-server", "default", WithArgs([]string{"health-check", "http"}))).
 			Setup(cluster)
-		Expect(err).ToNot(HaveOccurred())
-
-		demoClientToken, err := cluster.GetKuma().GenerateDpToken("default", "dp-demo-client")
-		Expect(err).ToNot(HaveOccurred())
-		testServerToken, err := cluster.GetKuma().GenerateDpToken("default", "test-server")
-		Expect(err).ToNot(HaveOccurred())
-
-		err = DemoClientUniversal("dp-demo-client", "default", demoClientToken,
-			WithTransparentProxy(true))(cluster)
-		Expect(err).ToNot(HaveOccurred())
-		err = TestServerUniversal("test-server", "default", testServerToken, WithArgs([]string{"health-check", "http"}))(cluster)
 		Expect(err).ToNot(HaveOccurred())
 	})
 
-	AfterEach(func() {
-		if ShouldSkipCleanup() {
-			return
-		}
-		Expect(cluster.DeleteKuma()).To(Succeed())
+	E2EAfterEach(func() {
 		Expect(cluster.DismissCluster()).To(Succeed())
 	})
 

--- a/test/e2e/healthcheck/universal/policy_tcp.go
+++ b/test/e2e/healthcheck/universal/policy_tcp.go
@@ -50,28 +50,18 @@ conf:
 		err := NewClusterSetup().
 			Install(Kuma(config_core.Standalone)).
 			Install(YamlUniversal(healthCheck("foo", "bar"))).
+			Install(DemoClientUniversal("dp-demo-client", "default",
+				WithTransparentProxy(true)),
+			).
+			Install(TestServerUniversal("test-server", "default",
+				WithArgs([]string{"health-check", "tcp"}),
+				WithProtocol("tcp")),
+			).
 			Setup(cluster)
-		Expect(err).ToNot(HaveOccurred())
-
-		demoClientToken, err := cluster.GetKuma().GenerateDpToken("default", "dp-demo-client")
-		Expect(err).ToNot(HaveOccurred())
-		testServerToken, err := cluster.GetKuma().GenerateDpToken("default", "test-server")
-		Expect(err).ToNot(HaveOccurred())
-
-		err = DemoClientUniversal("dp-demo-client", "default", demoClientToken,
-			WithTransparentProxy(true))(cluster)
-		Expect(err).ToNot(HaveOccurred())
-		err = TestServerUniversal("test-server", "default", testServerToken,
-			WithArgs([]string{"health-check", "tcp"}),
-			WithProtocol("tcp"))(cluster)
 		Expect(err).ToNot(HaveOccurred())
 	})
 
-	AfterEach(func() {
-		if ShouldSkipCleanup() {
-			return
-		}
-		Expect(cluster.DeleteKuma()).To(Succeed())
+	E2EAfterEach(func() {
 		Expect(cluster.DismissCluster()).To(Succeed())
 	})
 

--- a/test/e2e/helm/kuma_helm_deploy_autoscaling.go
+++ b/test/e2e/helm/kuma_helm_deploy_autoscaling.go
@@ -40,13 +40,8 @@ func ControlPlaneAutoscalingWithHelmChart() {
 		Expect(err).ToNot(HaveOccurred())
 	})
 
-	AfterEach(func() {
-		if ShouldSkipCleanup() {
-			return
-		}
-		// tear down Kuma
+	E2EAfterEach(func() {
 		Expect(cluster.DeleteKuma()).To(Succeed())
-		// tear down cluster
 		Expect(cluster.DismissCluster()).To(Succeed())
 	})
 

--- a/test/e2e/helm/kuma_helm_deploy_global_zone.go
+++ b/test/e2e/helm/kuma_helm_deploy_global_zone.go
@@ -79,16 +79,10 @@ func ZoneAndGlobalWithHelmChart() {
 		Expect(logs2).To(ContainSubstring("\"mode\":\"zone\""))
 	})
 
-	AfterEach(func() {
-		if ShouldSkipCleanup() {
-			return
-		}
-		// tear down apps
+	E2EAfterEach(func() {
 		Expect(c2.DeleteNamespace(TestNamespace)).To(Succeed())
-		// tear down Kuma
 		Expect(c1.DeleteKuma()).To(Succeed())
 		Expect(c2.DeleteKuma()).To(Succeed())
-		// tear down clusters
 		Expect(clusters.DismissCluster()).To(Succeed())
 	})
 

--- a/test/e2e/helm/kuma_helm_deploy_multi_apps.go
+++ b/test/e2e/helm/kuma_helm_deploy_multi_apps.go
@@ -56,15 +56,9 @@ metadata:
 		Expect(err).ToNot(HaveOccurred())
 	})
 
-	AfterEach(func() {
-		if ShouldSkipCleanup() {
-			return
-		}
-		// tear down apps
+	E2EAfterEach(func() {
 		Expect(cluster.DeleteNamespace(TestNamespace)).To(Succeed())
-		// tear down Kuma
 		Expect(cluster.DeleteKuma()).To(Succeed())
-		// tear down cluster
 		Expect(cluster.DismissCluster()).To(Succeed())
 	})
 

--- a/test/e2e/helm/kuma_helm_upgrade.go
+++ b/test/e2e/helm/kuma_helm_upgrade.go
@@ -16,11 +16,7 @@ import (
 func UpgradingWithHelmChart() {
 	var cluster Cluster
 
-	AfterEach(func() {
-		if ShouldSkipCleanup() {
-			return
-		}
-
+	E2EAfterEach(func() {
 		Expect(cluster.DeleteKuma()).To(Succeed())
 		Expect(cluster.DismissCluster()).To(Succeed())
 	})

--- a/test/e2e/hybrid/globaluniversal/kuma_hybrid.go
+++ b/test/e2e/hybrid/globaluniversal/kuma_hybrid.go
@@ -56,11 +56,6 @@ var _ = E2EBeforeSuite(func() {
 
 	globalCP := global.GetKuma()
 
-	echoServerToken, err := globalCP.GenerateDpToken(nonDefaultMesh, "test-server")
-	Expect(err).ToNot(HaveOccurred())
-	demoClientToken, err := globalCP.GenerateDpToken(nonDefaultMesh, "demo-client")
-	Expect(err).ToNot(HaveOccurred())
-
 	// K8s Cluster 1
 	zone1 = k8sClusters.GetCluster(Kuma1)
 	Expect(NewClusterSetup().
@@ -104,30 +99,24 @@ var _ = E2EBeforeSuite(func() {
 
 	// Universal Cluster 3
 	zone3 = universalClusters.GetCluster(Kuma3)
-	ingressTokenKuma3, err := globalCP.GenerateZoneIngressToken(Kuma3)
-	Expect(err).ToNot(HaveOccurred())
-
 	Expect(NewClusterSetup().
 		Install(Kuma(core.Zone, WithGlobalAddress(globalCP.GetKDSServerAddress()))).
-		Install(TestServerUniversal("dp-echo", nonDefaultMesh, echoServerToken,
+		Install(TestServerUniversal("dp-echo", nonDefaultMesh,
 			WithArgs([]string{"echo", "--instance", "echo-v1"}),
 			WithServiceName("test-server"),
 		)).
-		Install(DemoClientUniversal(AppModeDemoClient, nonDefaultMesh, demoClientToken, WithTransparentProxy(true), WithBuiltinDNS(false))).
-		Install(IngressUniversal(ingressTokenKuma3)).
+		Install(DemoClientUniversal(AppModeDemoClient, nonDefaultMesh, WithTransparentProxy(true), WithBuiltinDNS(false))).
+		Install(IngressUniversal(globalCP.GenerateZoneIngressToken)).
 		Setup(zone3)).To(Succeed())
 
 	E2EDeferCleanup(zone3.DismissCluster)
 
 	// Universal Cluster 4
 	zone4 = universalClusters.GetCluster(Kuma4)
-	ingressTokenKuma4, err := globalCP.GenerateZoneIngressToken(Kuma4)
-	Expect(err).ToNot(HaveOccurred())
-
 	Expect(NewClusterSetup().
 		Install(Kuma(core.Zone, WithGlobalAddress(globalCP.GetKDSServerAddress()))).
-		Install(DemoClientUniversal(AppModeDemoClient, nonDefaultMesh, demoClientToken, WithTransparentProxy(true))).
-		Install(IngressUniversal(ingressTokenKuma4)).
+		Install(DemoClientUniversal(AppModeDemoClient, nonDefaultMesh, WithTransparentProxy(true))).
+		Install(IngressUniversal(globalCP.GenerateZoneIngressToken)).
 		Setup(zone4)).To(Succeed())
 
 	E2EDeferCleanup(zone4.DismissCluster)

--- a/test/e2e/inspect/inspect_universal.go
+++ b/test/e2e/inspect/inspect_universal.go
@@ -14,13 +14,10 @@ func Universal() {
 	BeforeEach(func() {
 		cluster = NewUniversalCluster(NewTestingT(), Kuma1, Silent)
 
-		Expect(Kuma(config_core.Standalone, WithVerbose())(cluster)).To(Succeed())
-		Expect(cluster.VerifyKuma()).To(Succeed())
-
-		demoClientToken, err := cluster.GetKuma().GenerateDpToken("default", "demo-client")
-		Expect(err).ToNot(HaveOccurred())
-
-		err = DemoClientUniversal(AppModeDemoClient, "default", demoClientToken)(cluster)
+		err := NewClusterSetup().
+			Install(Kuma(config_core.Standalone, WithVerbose())).
+			Install(DemoClientUniversal(AppModeDemoClient, "default")).
+			Setup(cluster)
 		Expect(err).ToNot(HaveOccurred())
 	})
 

--- a/test/e2e/matching/matching_universal.go
+++ b/test/e2e/matching/matching_universal.go
@@ -21,30 +21,16 @@ func Universal() {
 
 		err = NewClusterSetup().
 			Install(Kuma(core.Standalone)).
+			Install(DemoClientUniversal("demo-client-1", "default", WithTransparentProxy(true))).
+			Install(DemoClientUniversal("demo-client-2", "default", WithTransparentProxy(true))).
+			Install(TestServerUniversal("test-server", "default",
+				WithArgs([]string{"echo", "--instance", "echo-v1"})),
+			).
 			Setup(universal)
 		Expect(err).ToNot(HaveOccurred())
-
-		demoClientToken1, err := universal.GetKuma().GenerateDpToken("default", "demo-client-1")
-		Expect(err).ToNot(HaveOccurred())
-		Expect(
-			DemoClientUniversal("demo-client-1", "default", demoClientToken1, WithTransparentProxy(true))(universal),
-		).To(Succeed())
-		demoClientToken2, err := universal.GetKuma().GenerateDpToken("default", "demo-client-2")
-		Expect(err).ToNot(HaveOccurred())
-		Expect(
-			DemoClientUniversal("demo-client-2", "default", demoClientToken2, WithTransparentProxy(true))(universal),
-		).To(Succeed())
-
-		testServerToken, err := universal.GetKuma().GenerateDpToken("default", "test-server")
-		Expect(err).ToNot(HaveOccurred())
-		Expect(
-			TestServerUniversal("test-server", "default", testServerToken,
-				WithArgs([]string{"echo", "--instance", "echo-v1"}))(universal),
-		).To(Succeed())
 	})
 
 	E2EAfterEach(func() {
-		Expect(universal.DeleteKuma()).To(Succeed())
 		Expect(universal.DismissCluster()).To(Succeed())
 	})
 

--- a/test/e2e/membership/universal/membership_universal.go
+++ b/test/e2e/membership/universal/membership_universal.go
@@ -37,9 +37,7 @@ constraints:
 		Expect(YamlUniversal(mesh)(cluster)).To(Succeed())
 
 		// when demo client is trying to connect
-		demoClientToken, err := cluster.GetKuma().GenerateDpToken("default", "demo-client")
-		Expect(err).ToNot(HaveOccurred())
-		err = DemoClientUniversal(AppModeDemoClient, "default", demoClientToken)(cluster)
+		err := DemoClientUniversal(AppModeDemoClient, "default")(cluster)
 		Expect(err).ToNot(HaveOccurred())
 
 		// then it's allowed
@@ -48,9 +46,7 @@ constraints:
 		}, "30s", "1s").ShouldNot(ContainSubstring("demo-client"))
 
 		// when test server is trying to connect
-		testServerToken, err := cluster.GetKuma().GenerateDpToken("default", "test-server")
-		Expect(err).ToNot(HaveOccurred())
-		err = TestServerUniversal("test-server", "default", testServerToken, WithArgs([]string{"echo", "--instance", "echo-v1"}))(cluster)
+		err = TestServerUniversal("test-server", "default", WithArgs([]string{"echo", "--instance", "echo-v1"}))(cluster)
 		Expect(err).ToNot(HaveOccurred())
 
 		// then it's not allowed

--- a/test/e2e/mtls/permissive/permissive_mode.go
+++ b/test/e2e/mtls/permissive/permissive_mode.go
@@ -43,22 +43,17 @@ mtls:
 	}
 
 	runDemoClient := func(mesh string) {
-		demoClientToken, err := universal.GetKuma().GenerateDpToken(mesh, "demo-client")
-		Expect(err).ToNot(HaveOccurred())
 		Expect(
-			DemoClientUniversal(AppModeDemoClient, mesh, demoClientToken, WithTransparentProxy(true))(universal),
+			DemoClientUniversal(AppModeDemoClient, mesh, WithTransparentProxy(true))(universal),
 		).To(Succeed())
 	}
 
 	runTestServer := func(mesh string, tls bool) {
-		echoServerToken, err := universal.GetKuma().GenerateDpToken(mesh, "test-server")
-		Expect(err).ToNot(HaveOccurred())
-
 		args := []string{"echo", "--instance", "universal-1"}
 		if tls {
 			args = append(args, "--tls", "--crt=/kuma/server.crt", "--key=/kuma/server.key")
 		}
-		Expect(TestServerUniversal("test-server", mesh, echoServerToken, WithArgs(args), WithProtocol("tcp"))(universal)).To(Succeed())
+		Expect(TestServerUniversal("test-server", mesh, WithArgs(args), WithProtocol("tcp"))(universal)).To(Succeed())
 	}
 
 	curlAddr := func(addr string, opts ...string) func() error {

--- a/test/e2e/mtls/universal/mtls_backends.go
+++ b/test/e2e/mtls/universal/mtls_backends.go
@@ -15,16 +15,9 @@ var _ = E2EBeforeSuite(func() {
 
 	Expect(NewClusterSetup().
 		Install(Kuma(config_core.Standalone)).
+		Install(TestServerUniversal("test-server", "default", WithArgs([]string{"echo", "--instance", "echo-v1"}))).
+		Install(DemoClientUniversal(AppModeDemoClient, "default", WithTransparentProxy(true))).
 		Setup(universalCluster)).To(Succeed())
-
-	testServerToken, err := universalCluster.GetKuma().GenerateDpToken("default", "test-server")
-	Expect(err).ToNot(HaveOccurred())
-	demoClientToken, err := universalCluster.GetKuma().GenerateDpToken("default", "demo-client")
-	Expect(err).ToNot(HaveOccurred())
-
-	Expect(TestServerUniversal("test-server", "default", testServerToken, WithArgs([]string{"echo", "--instance", "echo-v1"}))(universalCluster)).To(Succeed())
-	Expect(DemoClientUniversal(AppModeDemoClient, "default", demoClientToken, WithTransparentProxy(true))(universalCluster)).To(Succeed())
-
 	E2EDeferCleanup(universalCluster.DismissCluster)
 })
 

--- a/test/e2e/ownership/multizone_universal.go
+++ b/test/e2e/ownership/multizone_universal.go
@@ -36,21 +36,15 @@ func MultizoneUniversal() {
 	})
 
 	installZoneIngress := func() {
-		ingressToken, err := global.GetKuma().GenerateZoneIngressToken(Kuma2)
-		Expect(err).ToNot(HaveOccurred())
-		Expect(IngressUniversal(ingressToken)(zoneUniversal)).To(Succeed())
+		Expect(IngressUniversal(global.GetKuma().GenerateZoneIngressToken)(zoneUniversal)).To(Succeed())
 	}
 
 	installZoneEgress := func() {
-		egressToken, err := global.GetKuma().GenerateZoneEgressToken(Kuma2)
-		Expect(err).ToNot(HaveOccurred())
-		Expect(EgressUniversal(egressToken)(zoneUniversal)).To(Succeed())
+		Expect(EgressUniversal(global.GetKuma().GenerateZoneEgressToken)(zoneUniversal)).To(Succeed())
 	}
 
 	installDataplane := func() {
-		token, err := global.GetKuma().GenerateDpToken("default", AppModeDemoClient)
-		Expect(err).ToNot(HaveOccurred())
-		Expect(DemoClientUniversal(AppModeDemoClient, "default", token)(zoneUniversal)).To(Succeed())
+		Expect(DemoClientUniversal(AppModeDemoClient, "default")(zoneUniversal)).To(Succeed())
 	}
 
 	has := func(resourceURI string) func() bool {

--- a/test/e2e/proxytemplate/proxy_template_universal.go
+++ b/test/e2e/proxytemplate/proxy_template_universal.go
@@ -16,22 +16,13 @@ var _ = E2EBeforeSuite(func() {
 
 	err := NewClusterSetup().
 		Install(Kuma(config_core.Standalone)).
+		Install(TestServerUniversal("test-server", "default", WithArgs([]string{"echo", "--instance", "echo-v1"}))).
+		Install(DemoClientUniversal(AppModeDemoClient, "default", WithTransparentProxy(true))).
 		Setup(universalCluster)
-	Expect(err).ToNot(HaveOccurred())
-
-	testServerToken, err := universalCluster.GetKuma().GenerateDpToken("default", "test-server")
-	Expect(err).ToNot(HaveOccurred())
-	demoClientToken, err := universalCluster.GetKuma().GenerateDpToken("default", "demo-client")
-	Expect(err).ToNot(HaveOccurred())
-
-	err = TestServerUniversal("test-server", "default", testServerToken, WithArgs([]string{"echo", "--instance", "echo-v1"}))(universalCluster)
-	Expect(err).ToNot(HaveOccurred())
-	err = DemoClientUniversal(AppModeDemoClient, "default", demoClientToken, WithTransparentProxy(true))(universalCluster)
 	Expect(err).ToNot(HaveOccurred())
 })
 
 var _ = E2EAfterSuite(func() {
-	Expect(universalCluster.DeleteKuma()).To(Succeed())
 	Expect(universalCluster.DismissCluster()).To(Succeed())
 })
 

--- a/test/e2e/ratelimit/ratelimit_universal.go
+++ b/test/e2e/ratelimit/ratelimit_universal.go
@@ -41,31 +41,16 @@ var _ = E2EBeforeSuite(func() {
 		Silent)
 	Expect(err).ToNot(HaveOccurred())
 
-	// Global
 	cluster = clusters.GetCluster(kumaClusterId)
 
 	Expect(NewClusterSetup().
 		Install(Kuma(core.Standalone)).
-		Setup(cluster)).To(Succeed())
-
-	demoClientToken, err := cluster.GetKuma().GenerateDpToken("default", "demo-client")
-	Expect(err).ToNot(HaveOccurred())
-
-	testServerToken, err := cluster.GetKuma().GenerateDpToken("default", "test-server")
-	Expect(err).ToNot(HaveOccurred())
-
-	webToken, err := cluster.GetKuma().GenerateDpToken("default", "web")
-	Expect(err).ToNot(HaveOccurred())
-
-	Expect(YamlUniversal(rateLimitPolicy)(cluster)).To(Succeed())
-
-	Expect(NewClusterSetup().
-		Install(TestServerUniversal("test-server", "default", testServerToken, WithArgs([]string{"echo", "--instance", "universal-1"}))).
-		Install(DemoClientUniversal(AppModeDemoClient, "default", demoClientToken, WithTransparentProxy(true))).
-		Install(DemoClientUniversal("web", "default", webToken, WithTransparentProxy(true))).
+		Install(YamlUniversal(rateLimitPolicy)).
+		Install(TestServerUniversal("test-server", "default", WithArgs([]string{"echo", "--instance", "universal-1"}))).
+		Install(DemoClientUniversal(AppModeDemoClient, "default", WithTransparentProxy(true))).
+		Install(DemoClientUniversal("web", "default", WithTransparentProxy(true))).
 		Install(externalservice.Install(externalservice.HttpServer, externalservice.UniversalAppEchoServer81)).
 		Setup(cluster)).To(Succeed())
-
 	E2EDeferCleanup(cluster.DismissCluster)
 })
 

--- a/test/e2e/reachableservices/reachableservices_universal.go
+++ b/test/e2e/reachableservices/reachableservices_universal.go
@@ -16,26 +16,14 @@ func ReachableServicesOnUniversal() {
 
 		err := NewClusterSetup().
 			Install(Kuma(config_core.Standalone)).
-			Setup(cluster)
-		Expect(err).ToNot(HaveOccurred())
-
-		firstTestServerToken, err := cluster.GetKuma().GenerateDpToken("default", "first-test-server")
-		Expect(err).ToNot(HaveOccurred())
-		secondTestServerToken, err := cluster.GetKuma().GenerateDpToken("default", "second-test-server")
-		Expect(err).ToNot(HaveOccurred())
-		demoClientToken, err := cluster.GetKuma().GenerateDpToken("default", "demo-client")
-		Expect(err).ToNot(HaveOccurred())
-
-		err = NewClusterSetup().
-			Install(TestServerUniversal("first-test-server", "default", firstTestServerToken, WithArgs([]string{"echo"}), WithServiceName("first-test-server"))).
-			Install(TestServerUniversal("second-test-server", "default", secondTestServerToken, WithArgs([]string{"echo"}), WithServiceName("second-test-server"))).
-			Install(DemoClientUniversal(AppModeDemoClient, "default", demoClientToken, WithTransparentProxy(true), WithReachableServices("first-test-server"))).
+			Install(TestServerUniversal("first-test-server", "default", WithArgs([]string{"echo"}), WithServiceName("first-test-server"))).
+			Install(TestServerUniversal("second-test-server", "default", WithArgs([]string{"echo"}), WithServiceName("second-test-server"))).
+			Install(DemoClientUniversal(AppModeDemoClient, "default", WithTransparentProxy(true), WithReachableServices("first-test-server"))).
 			Setup(cluster)
 		Expect(err).ToNot(HaveOccurred())
 	})
 
 	E2EAfterEach(func() {
-		Expect(cluster.DeleteKuma()).To(Succeed())
 		Expect(cluster.DismissCluster()).To(Succeed())
 	})
 

--- a/test/e2e/resilience/resilience_multizone_universal_postgres.go
+++ b/test/e2e/resilience/resilience_multizone_universal_postgres.go
@@ -134,9 +134,7 @@ func ResilienceMultizoneUniversalPostgres() {
 
 	It("should mark zone ingress as offline after it is killed forcefully when zone control-plane is down", func() {
 		// deploy zone-ingress and wait while it's started
-		ingressToken, err := global.GetKuma().GenerateZoneIngressToken(Kuma2)
-		Expect(err).ToNot(HaveOccurred())
-		Expect(IngressUniversal(ingressToken)(zoneUniversal)).To(Succeed())
+		Expect(IngressUniversal(global.GetKuma().GenerateZoneIngressToken)(zoneUniversal)).To(Succeed())
 		Eventually(func() (string, error) {
 			return global.GetKumactlOptions().RunKumactlAndGetOutput("inspect", "zone-ingresses")
 		}, "30s", "1s").Should(ContainSubstring("Online"))
@@ -148,7 +146,7 @@ func ResilienceMultizoneUniversalPostgres() {
 		Expect(kumaCP).ToNot(BeNil())
 
 		// when Zone CP is killed
-		_, _, err = zoneUniversal.Exec("", "", AppModeCP, "pkill", "-9", "kuma-cp")
+		_, _, err := zoneUniversal.Exec("", "", AppModeCP, "pkill", "-9", "kuma-cp")
 		Expect(err).ToNot(HaveOccurred())
 
 		// and zone-ingress is killed while Zone CP is down

--- a/test/e2e/resilience/resilience_standalone_universal.go
+++ b/test/e2e/resilience/resilience_standalone_universal.go
@@ -18,25 +18,16 @@ func ResilienceStandaloneUniversal() {
 
 		universal = clusters.GetCluster(Kuma1)
 
-		err = NewClusterSetup().
-			Install(postgres.Install(Kuma1)).
-			Setup(universal)
-		Expect(err).ToNot(HaveOccurred())
+		Expect(postgres.Install(Kuma1)(universal)).To(Succeed())
 
 		err = NewClusterSetup().
 			Install(Kuma(core.Standalone,
 				WithPostgres(postgres.From(universal, Kuma1).GetEnvVars()),
 				WithEnv("KUMA_METRICS_DATAPLANE_IDLE_TIMEOUT", "10s"),
 			)).
+			Install(DemoClientUniversal(AppModeDemoClient, "default", WithKumactlFlow())).
 			Setup(universal)
 		Expect(err).ToNot(HaveOccurred())
-
-		demoClientToken, err := universal.GetKuma().GenerateDpToken("default", "demo-client")
-		Expect(err).ToNot(HaveOccurred())
-
-		Expect(
-			DemoClientUniversal(AppModeDemoClient, "default", demoClientToken, WithKumactlFlow())(universal),
-		).To(Succeed())
 	})
 
 	E2EAfterEach(func() {

--- a/test/e2e/retry/retry_universal.go
+++ b/test/e2e/retry/retry_universal.go
@@ -22,7 +22,6 @@ func RetryOnUniversal() {
 			Silent)
 		Expect(err).ToNot(HaveOccurred())
 
-		// Global
 		cluster = clusters.GetCluster(Kuma3)
 
 		err = NewClusterSetup().
@@ -30,31 +29,18 @@ func RetryOnUniversal() {
 			Setup(cluster)
 		Expect(err).ToNot(HaveOccurred())
 
-		demoClientToken, err := cluster.GetKuma().GenerateDpToken("default", "demo-client")
-		Expect(err).ToNot(HaveOccurred())
-
-		echoServerToken, err := cluster.GetKuma().GenerateDpToken("default", "test-server")
-		Expect(err).ToNot(HaveOccurred())
-
 		err = cluster.GetKumactlOptions().RunKumactl("delete", "retry", "retry-all-default")
 		Expect(err).ToNot(HaveOccurred())
 
 		err = NewClusterSetup().
-			Install(DemoClientUniversal(AppModeDemoClient, "default", demoClientToken, WithTransparentProxy(true))).
-			Install(TestServerUniversal("test-server", "default", echoServerToken, WithArgs([]string{"echo", "--instance", "universal"}))).
+			Install(DemoClientUniversal(AppModeDemoClient, "default", WithTransparentProxy(true))).
+			Install(TestServerUniversal("test-server", "default", WithArgs([]string{"echo", "--instance", "universal"}))).
 			Setup(cluster)
 		Expect(err).ToNot(HaveOccurred())
 	})
 
-	AfterEach(func() {
-		if ShouldSkipCleanup() {
-			return
-		}
-		err := cluster.DeleteKuma()
-		Expect(err).ToNot(HaveOccurred())
-
-		err = cluster.DismissCluster()
-		Expect(err).ToNot(HaveOccurred())
+	E2EAfterEach(func() {
+		Expect(cluster.DismissCluster()).To(Succeed())
 	})
 
 	It("should retry on TCP connection failure", func() {

--- a/test/e2e/timeout/timeout_universal.go
+++ b/test/e2e/timeout/timeout_universal.go
@@ -53,26 +53,13 @@ conf:
 		err := NewClusterSetup().
 			Install(Kuma(core.Standalone)).
 			Install(YamlUniversal(faultInjection)).
+			Install(TestServerUniversal("test-server", "default", WithArgs([]string{"echo", "--instance", "universal-1"}))).
+			Install(DemoClientUniversal(AppModeDemoClient, "default", WithTransparentProxy(true))).
 			Setup(universalCluster)
-		Expect(err).ToNot(HaveOccurred())
-
-		echoServerToken, err := universalCluster.GetKuma().GenerateDpToken("default", "test-server")
-		Expect(err).ToNot(HaveOccurred())
-		demoClientToken, err := universalCluster.GetKuma().GenerateDpToken("default", "demo-client")
-		Expect(err).ToNot(HaveOccurred())
-
-		err = TestServerUniversal("test-server", "default", echoServerToken, WithArgs([]string{"echo", "--instance", "universal-1"}))(universalCluster)
-		Expect(err).ToNot(HaveOccurred())
-
-		err = DemoClientUniversal(AppModeDemoClient, "default", demoClientToken, WithTransparentProxy(true))(universalCluster)
 		Expect(err).ToNot(HaveOccurred())
 	})
 
-	AfterEach(func() {
-		if ShouldSkipCleanup() {
-			return
-		}
-		Expect(universalCluster.DeleteKuma()).To(Succeed())
+	E2EAfterEach(func() {
 		Expect(universalCluster.DismissCluster()).To(Succeed())
 	})
 

--- a/test/e2e/tracing/tracing_universal.go
+++ b/test/e2e/tracing/tracing_universal.go
@@ -46,24 +46,13 @@ selectors:
 		err := NewClusterSetup().
 			Install(Kuma(core.Standalone)).
 			Install(tracing.Install()).
+			Install(TestServerUniversal("test-server", "default", WithArgs([]string{"echo", "--instance", "universal1"}))).
+			Install(DemoClientUniversal(AppModeDemoClient, "default", WithTransparentProxy(true))).
 			Setup(cluster)
-		Expect(err).ToNot(HaveOccurred())
-
-		testServerToken, err := cluster.GetKuma().GenerateDpToken("default", "test-server")
-		Expect(err).ToNot(HaveOccurred())
-		demoClientToken, err := cluster.GetKuma().GenerateDpToken("default", "demo-client")
-		Expect(err).ToNot(HaveOccurred())
-
-		err = TestServerUniversal("test-server", "default", testServerToken, WithArgs([]string{"echo", "--instance", "universal1"}))(cluster)
-		Expect(err).ToNot(HaveOccurred())
-		err = DemoClientUniversal(AppModeDemoClient, "default", demoClientToken, WithTransparentProxy(true))(cluster)
 		Expect(err).ToNot(HaveOccurred())
 	})
 
-	AfterEach(func() {
-		if ShouldSkipCleanup() {
-			return
-		}
+	E2EAfterEach(func() {
 		Expect(cluster.DeleteKuma()).To(Succeed())
 		Expect(cluster.DismissCluster()).To(Succeed())
 	})

--- a/test/e2e/trafficpermission/hybrid/traffic_permission_hybrid.go
+++ b/test/e2e/trafficpermission/hybrid/traffic_permission_hybrid.go
@@ -56,20 +56,14 @@ var _ = E2EBeforeSuite(func() {
 
 	globalCP := globalCluster.GetKuma()
 
-	testServerToken, err := globalCP.GenerateDpToken("default", "test-server")
-	Expect(err).ToNot(HaveOccurred())
-
 	// Zone universal
 	zoneUniversal = universalClusters.GetCluster(Kuma3)
-	ingressTokenKuma3, err := globalCP.GenerateZoneIngressToken(Kuma3)
-	Expect(err).ToNot(HaveOccurred())
-
 	Expect(NewClusterSetup().
 		Install(Kuma(config_core.Zone,
 			WithGlobalAddress(globalCP.GetKDSServerAddress()),
 		)).
-		Install(TestServerUniversal("test-server", "default", testServerToken, WithArgs([]string{"echo", "--instance", "echo-v1"}))).
-		Install(IngressUniversal(ingressTokenKuma3)).
+		Install(TestServerUniversal("test-server", "default", WithArgs([]string{"echo", "--instance", "echo-v1"}))).
+		Install(IngressUniversal(globalCP.GenerateZoneIngressToken)).
 		Setup(zoneUniversal)).To(Succeed())
 
 	E2EDeferCleanup(zoneUniversal.DismissCluster)

--- a/test/e2e/trafficpermission/universal/traffic_permission_universal.go
+++ b/test/e2e/trafficpermission/universal/traffic_permission_universal.go
@@ -26,16 +26,9 @@ var _ = E2EBeforeSuite(func() {
 	Expect(NewClusterSetup().
 		Install(Kuma(config_core.Standalone)).
 		Install(YamlUniversal(meshDefaultMtlsOn)).
+		Install(TestServerUniversal("test-server", "default", WithArgs([]string{"echo", "--instance", "echo-v1"}))).
+		Install(DemoClientUniversal(AppModeDemoClient, "default", WithTransparentProxy(true))).
 		Setup(universalCluster)).To(Succeed())
-
-	testServerToken, err := universalCluster.GetKuma().GenerateDpToken("default", "test-server")
-	Expect(err).ToNot(HaveOccurred())
-	demoClientToken, err := universalCluster.GetKuma().GenerateDpToken("default", "demo-client")
-	Expect(err).ToNot(HaveOccurred())
-
-	Expect(TestServerUniversal("test-server", "default", testServerToken, WithArgs([]string{"echo", "--instance", "echo-v1"}))(universalCluster)).To(Succeed())
-	Expect(DemoClientUniversal(AppModeDemoClient, "default", demoClientToken, WithTransparentProxy(true))(universalCluster)).To(Succeed())
-
 	E2EDeferCleanup(universalCluster.DismissCluster)
 })
 

--- a/test/e2e/trafficroute/universal_standalone/traffic_route.go
+++ b/test/e2e/trafficroute/universal_standalone/traffic_route.go
@@ -25,37 +25,27 @@ var _ = E2EBeforeSuite(func() {
 
 	Expect(NewClusterSetup().
 		Install(Kuma(core.Standalone)).
-		Setup(universal)).To(Succeed())
-
-	testServerToken, err := universal.GetKuma().GenerateDpToken(defaultMesh, "test-server")
-	Expect(err).ToNot(HaveOccurred())
-	anotherTestServerToken, err := universal.GetKuma().GenerateDpToken(defaultMesh, "another-test-server")
-	Expect(err).ToNot(HaveOccurred())
-	demoClientToken, err := universal.GetKuma().GenerateDpToken(defaultMesh, "demo-client")
-	Expect(err).ToNot(HaveOccurred())
-
-	Expect(NewClusterSetup().
-		Install(TestServerUniversal("dp-echo-1", defaultMesh, testServerToken,
+		Install(TestServerUniversal("dp-echo-1", defaultMesh,
 			WithArgs([]string{"echo", "--instance", "echo-v1"}),
 			WithServiceVersion("v1"),
 		)).
-		Install(TestServerUniversal("dp-echo-2", defaultMesh, testServerToken,
+		Install(TestServerUniversal("dp-echo-2", defaultMesh,
 			WithArgs([]string{"echo", "--instance", "echo-v2"}),
 			WithServiceVersion("v2"),
 		)).
-		Install(TestServerUniversal("dp-echo-3", defaultMesh, testServerToken,
+		Install(TestServerUniversal("dp-echo-3", defaultMesh,
 			WithArgs([]string{"echo", "--instance", "echo-v3"}),
 			WithServiceVersion("v3"),
 		)).
-		Install(TestServerUniversal("dp-echo-4", defaultMesh, testServerToken,
+		Install(TestServerUniversal("dp-echo-4", defaultMesh,
 			WithArgs([]string{"echo", "--instance", "echo-v4"}),
 			WithServiceVersion("v4"),
 		)).
-		Install(TestServerUniversal("dp-another-test", defaultMesh, anotherTestServerToken,
+		Install(TestServerUniversal("dp-another-test", defaultMesh,
 			WithArgs([]string{"echo", "--instance", "another-test-server"}),
 			WithServiceName("another-test-server"),
 		)).
-		Install(DemoClientUniversal(AppModeDemoClient, defaultMesh, demoClientToken, WithTransparentProxy(true))).
+		Install(DemoClientUniversal(AppModeDemoClient, defaultMesh, WithTransparentProxy(true))).
 		Setup(universal)).To(Succeed())
 
 	E2EDeferCleanup(universal.DismissCluster)

--- a/test/e2e/virtualoutbound/virtualoutbound_universal.go
+++ b/test/e2e/virtualoutbound/virtualoutbound_universal.go
@@ -19,7 +19,6 @@ func VirtualOutboundOnUniversal() {
 			Silent)
 		Expect(err).ToNot(HaveOccurred())
 
-		// Global
 		cluster = clusters.GetCluster(Kuma3)
 
 		err = NewClusterSetup().
@@ -30,29 +29,16 @@ func VirtualOutboundOnUniversal() {
 		_ = cluster.GetKumactlOptions().RunKumactl("delete", "virtual-outbound", "instances")
 		_ = cluster.GetKumactlOptions().RunKumactl("delete", "virtual-outbound", "all")
 
-		demoClientToken, err := cluster.GetKuma().GenerateDpToken("default", "demo-client")
-		Expect(err).ToNot(HaveOccurred())
-
-		echoServerToken, err := cluster.GetKuma().GenerateDpToken("default", "test-server")
-		Expect(err).ToNot(HaveOccurred())
-
 		err = NewClusterSetup().
-			Install(DemoClientUniversal(AppModeDemoClient, "default", demoClientToken, WithTransparentProxy(true))).
-			Install(TestServerUniversal("test-server1", "default", echoServerToken, WithArgs([]string{"echo", "--instance", "srv-1"}), WithServiceInstance("1"))).
-			Install(TestServerUniversal("test-server2", "default", echoServerToken, WithArgs([]string{"echo", "--instance", "srv-2"}), WithServiceInstance("2"))).
+			Install(DemoClientUniversal(AppModeDemoClient, "default", WithTransparentProxy(true))).
+			Install(TestServerUniversal("test-server1", "default", WithArgs([]string{"echo", "--instance", "srv-1"}), WithServiceInstance("1"))).
+			Install(TestServerUniversal("test-server2", "default", WithArgs([]string{"echo", "--instance", "srv-2"}), WithServiceInstance("2"))).
 			Setup(cluster)
 		Expect(err).ToNot(HaveOccurred())
 	})
 
-	AfterEach(func() {
-		if ShouldSkipCleanup() {
-			return
-		}
-		err := cluster.DeleteKuma()
-		Expect(err).ToNot(HaveOccurred())
-
-		err = cluster.DismissCluster()
-		Expect(err).ToNot(HaveOccurred())
+	E2EAfterEach(func() {
+		Expect(cluster.DismissCluster()).To(Succeed())
 	})
 
 	It("should add hostnames for individual instances", func() {

--- a/test/e2e/zoneegress/externalservices/zoneegress_externalservices_hybrid.go
+++ b/test/e2e/zoneegress/externalservices/zoneegress_externalservices_hybrid.go
@@ -110,20 +110,15 @@ networking:
 		// Universal Cluster 4
 		zone4 = universalClusters.GetCluster(Kuma4).(*UniversalCluster)
 		Expect(err).ToNot(HaveOccurred())
-		egressTokenZone4, err := globalCP.GenerateZoneEgressToken(Kuma4)
-		Expect(err).ToNot(HaveOccurred())
-		demoClientTokenZone4, err := globalCP.GenerateDpToken(nonDefaultMesh, "zone4-demo-client")
-		Expect(err).ToNot(HaveOccurred())
 
 		Expect(NewClusterSetup().
 			Install(Kuma(config_core.Zone, WithGlobalAddress(globalCP.GetKDSServerAddress()))).
 			Install(DemoClientUniversal(
 				"zone4-demo-client",
 				nonDefaultMesh,
-				demoClientTokenZone4,
 				WithTransparentProxy(true),
 			)).
-			Install(EgressUniversal(egressTokenZone4)).
+			Install(EgressUniversal(globalCP.GenerateZoneEgressToken)).
 			Install(
 				func(cluster Cluster) error {
 					return cluster.DeployApp(

--- a/test/e2e/zoneegress/externalservices/zoneegress_externalservices_universal.go
+++ b/test/e2e/zoneegress/externalservices/zoneegress_externalservices_universal.go
@@ -62,9 +62,7 @@ networking:
 			Install(YamlUniversal(meshDefaulMtlsOn)).
 			Install(externalservice.Install(externalservice.HttpServer, externalservice.UniversalAppEchoServer)).
 			Install(DemoClientUniversal(AppModeDemoClient, "default", WithTransparentProxy(true))).
-			Install(EgressUniversal(func(zone string) (string, error) {
-				return cluster.GetKuma().GenerateZoneEgressToken("")
-			})).
+			Install(EgressUniversal(cluster.GetKuma().GenerateZoneEgressToken)).
 			Setup(cluster)
 		Expect(err).ToNot(HaveOccurred())
 	})

--- a/test/e2e/zoneegress/externalservices/zoneegress_externalservices_universal.go
+++ b/test/e2e/zoneegress/externalservices/zoneegress_externalservices_universal.go
@@ -62,7 +62,9 @@ networking:
 			Install(YamlUniversal(meshDefaulMtlsOn)).
 			Install(externalservice.Install(externalservice.HttpServer, externalservice.UniversalAppEchoServer)).
 			Install(DemoClientUniversal(AppModeDemoClient, "default", WithTransparentProxy(true))).
-			Install(EgressUniversal(cluster.GetKuma().GenerateZoneEgressToken)).
+			Install(EgressUniversal(func(zone string) (string, error) {
+				return cluster.GetKuma().GenerateZoneEgressToken("")
+			})).
 			Setup(cluster)
 		Expect(err).ToNot(HaveOccurred())
 	})

--- a/test/e2e/zoneegress/faultinjection/standalone_universal.go
+++ b/test/e2e/zoneegress/faultinjection/standalone_universal.go
@@ -83,16 +83,10 @@ var _ = E2EBeforeSuite(func() {
 		Setup(cluster)
 	Expect(err).ToNot(HaveOccurred())
 
-	demoClientToken, err := cluster.GetKuma().GenerateDpToken("default", "demo-client")
-	Expect(err).ToNot(HaveOccurred())
-
-	egressToken, err := cluster.GetKuma().GenerateZoneEgressToken("")
-	Expect(err).ToNot(HaveOccurred())
-
 	err = NewClusterSetup().
 		Install(externalservice.Install(externalservice.HttpServer, externalservice.UniversalAppEchoServer)).
-		Install(DemoClientUniversal(AppModeDemoClient, "default", demoClientToken, WithTransparentProxy(true))).
-		Install(EgressUniversal(egressToken)).
+		Install(DemoClientUniversal(AppModeDemoClient, "default", WithTransparentProxy(true))).
+		Install(EgressUniversal(cluster.GetKuma().GenerateZoneEgressToken)).
 		Install(YamlUniversal(meshMTLSOn("default"))).
 		Install(ExternalServerUniversal("es-test-server-v1")).
 		Install(ExternalServerUniversal("es-test-server-v2")).

--- a/test/e2e/zoneegress/faultinjection/standalone_universal.go
+++ b/test/e2e/zoneegress/faultinjection/standalone_universal.go
@@ -86,7 +86,9 @@ var _ = E2EBeforeSuite(func() {
 	err = NewClusterSetup().
 		Install(externalservice.Install(externalservice.HttpServer, externalservice.UniversalAppEchoServer)).
 		Install(DemoClientUniversal(AppModeDemoClient, "default", WithTransparentProxy(true))).
-		Install(EgressUniversal(cluster.GetKuma().GenerateZoneEgressToken)).
+		Install(EgressUniversal(func(zone string) (string, error) {
+			return cluster.GetKuma().GenerateZoneEgressToken("")
+		})).
 		Install(YamlUniversal(meshMTLSOn("default"))).
 		Install(ExternalServerUniversal("es-test-server-v1")).
 		Install(ExternalServerUniversal("es-test-server-v2")).

--- a/test/e2e/zoneegress/internalservices/zoneegress_internalservices_hybrid.go
+++ b/test/e2e/zoneegress/internalservices/zoneegress_internalservices_hybrid.go
@@ -112,7 +112,7 @@ var _ = E2EBeforeSuite(func() {
 			WithTransparentProxy(true),
 		)).
 		Install(IngressUniversal(globalCP.GenerateZoneIngressToken)).
-		Install(EgressUniversal(globalCP.GenerateZoneIngressToken)).
+		Install(EgressUniversal(globalCP.GenerateZoneEgressToken)).
 		Setup(zone3)).To(Succeed())
 
 	E2EDeferCleanup(zone3.DismissCluster)

--- a/test/e2e/zoneegress/internalservices/zoneegress_internalservices_hybrid.go
+++ b/test/e2e/zoneegress/internalservices/zoneegress_internalservices_hybrid.go
@@ -100,47 +100,32 @@ var _ = E2EBeforeSuite(func() {
 
 	// Universal Cluster 3
 	zone3 = universalClusters.GetCluster(Kuma3)
-	ingressTokenKuma3, err := globalCP.GenerateZoneIngressToken(Kuma3)
-	Expect(err).ToNot(HaveOccurred())
-	egressTokenKuma3, err := globalCP.GenerateZoneEgressToken(Kuma3)
-	Expect(err).ToNot(HaveOccurred())
-	zone3TestServerToken, err := globalCP.GenerateDpToken(nonDefaultMesh, "zone3-test-server")
-	Expect(err).ToNot(HaveOccurred())
-	demoClientTokenZone3, err := globalCP.GenerateDpToken(nonDefaultMesh, "zone3-demo-client")
-	Expect(err).ToNot(HaveOccurred())
-
 	Expect(NewClusterSetup().
 		Install(Kuma(config_core.Zone, WithGlobalAddress(globalCP.GetKDSServerAddress()), WithVerbose())).
-		Install(TestServerUniversal("zone3-dp-echo", nonDefaultMesh, zone3TestServerToken,
+		Install(TestServerUniversal("zone3-dp-echo", nonDefaultMesh,
 			WithArgs([]string{"echo", "--instance", "echo-v1"}),
 			WithServiceName("zone3-test-server"),
 		)).
 		Install(DemoClientUniversal(
 			"zone3-demo-client",
 			nonDefaultMesh,
-			demoClientTokenZone3,
 			WithTransparentProxy(true),
 		)).
-		Install(IngressUniversal(ingressTokenKuma3)).
-		Install(EgressUniversal(egressTokenKuma3)).
+		Install(IngressUniversal(globalCP.GenerateZoneIngressToken)).
+		Install(EgressUniversal(globalCP.GenerateZoneIngressToken)).
 		Setup(zone3)).To(Succeed())
 
 	E2EDeferCleanup(zone3.DismissCluster)
 
 	// Universal Cluster 4
 	zone4 = universalClusters.GetCluster(Kuma4)
-	ingressTokenKuma4, err := globalCP.GenerateZoneIngressToken(Kuma4)
-	Expect(err).ToNot(HaveOccurred())
-	zone4TestServerToken, err := globalCP.GenerateDpToken(nonDefaultMesh, "zone4-test-server")
-	Expect(err).ToNot(HaveOccurred())
-
 	Expect(NewClusterSetup().
 		Install(Kuma(config_core.Zone, WithGlobalAddress(globalCP.GetKDSServerAddress()), WithVerbose())).
-		Install(TestServerUniversal("zone4-dp-echo", nonDefaultMesh, zone4TestServerToken,
+		Install(TestServerUniversal("zone4-dp-echo", nonDefaultMesh,
 			WithArgs([]string{"echo", "--instance", "echo-v1"}),
 			WithServiceName("zone4-test-server"),
 		)).
-		Install(IngressUniversal(ingressTokenKuma4)).
+		Install(IngressUniversal(globalCP.GenerateZoneIngressToken)).
 		Setup(zone4)).To(Succeed())
 
 	E2EDeferCleanup(zone4.DismissCluster)

--- a/test/e2e/zoneegress/ratelimit/standalone_universal.go
+++ b/test/e2e/zoneegress/ratelimit/standalone_universal.go
@@ -82,7 +82,9 @@ var _ = E2EBeforeSuite(func() {
 		Install(Kuma(config_core.Standalone)).
 		Install(externalservice.Install(externalservice.HttpServer, externalservice.UniversalAppEchoServer)).
 		Install(DemoClientUniversal(AppModeDemoClient, "default", WithTransparentProxy(true))).
-		Install(EgressUniversal(cluster.GetKuma().GenerateZoneEgressToken)).
+		Install(EgressUniversal(func(zone string) (string, error) {
+			return cluster.GetKuma().GenerateZoneEgressToken("")
+		})).
 		Install(YamlUniversal(meshMTLSOn("default"))).
 		Install(ExternalServerUniversal("es-test-server-v1")).
 		Install(ExternalServerUniversal("es-test-server-v2")).

--- a/test/e2e/zoneegress/ratelimit/standalone_universal.go
+++ b/test/e2e/zoneegress/ratelimit/standalone_universal.go
@@ -80,19 +80,9 @@ var _ = E2EBeforeSuite(func() {
 
 	err = NewClusterSetup().
 		Install(Kuma(config_core.Standalone)).
-		Setup(cluster)
-	Expect(err).ToNot(HaveOccurred())
-
-	demoClientToken, err := cluster.GetKuma().GenerateDpToken("default", "demo-client")
-	Expect(err).ToNot(HaveOccurred())
-
-	egressToken, err := cluster.GetKuma().GenerateZoneEgressToken("")
-	Expect(err).ToNot(HaveOccurred())
-
-	err = NewClusterSetup().
 		Install(externalservice.Install(externalservice.HttpServer, externalservice.UniversalAppEchoServer)).
-		Install(DemoClientUniversal(AppModeDemoClient, "default", demoClientToken, WithTransparentProxy(true))).
-		Install(EgressUniversal(egressToken)).
+		Install(DemoClientUniversal(AppModeDemoClient, "default", WithTransparentProxy(true))).
+		Install(EgressUniversal(cluster.GetKuma().GenerateZoneEgressToken)).
 		Install(YamlUniversal(meshMTLSOn("default"))).
 		Install(ExternalServerUniversal("es-test-server-v1")).
 		Install(ExternalServerUniversal("es-test-server-v2")).

--- a/test/framework/setup.go
+++ b/test/framework/setup.go
@@ -194,7 +194,11 @@ func zoneRelatedResource(
 		publicAddress := app.ip
 		dpYAML := resourceManifestFunc(publicAddress, kdsPort, kdsPort)
 
-		token, err := tokenProvider(uniCluster.name)
+		zone := uniCluster.name
+		if uniCluster.controlplane.mode == core.Standalone {
+			zone = ""
+		}
+		token, err := tokenProvider(zone)
 		if err != nil {
 			return err
 		}

--- a/test/framework/setup.go
+++ b/test/framework/setup.go
@@ -161,7 +161,7 @@ func WaitUntilJobSucceed(namespace, app string) InstallFunc {
 }
 
 func zoneRelatedResource(
-	token string,
+	tokenProvider func(zone string) (string, error),
 	appType AppMode,
 	resourceManifestFunc func(address string, port, advertisedPort int) string,
 ) func(cluster Cluster) error {
@@ -194,6 +194,11 @@ func zoneRelatedResource(
 		publicAddress := app.ip
 		dpYAML := resourceManifestFunc(publicAddress, kdsPort, kdsPort)
 
+		token, err := tokenProvider(uniCluster.name)
+		if err != nil {
+			return err
+		}
+
 		switch appType {
 		case AppIngress:
 			return uniCluster.CreateZoneIngress(app, dpName, publicAddress, dpYAML, token, false)
@@ -205,20 +210,20 @@ func zoneRelatedResource(
 	}
 }
 
-func IngressUniversal(token string) InstallFunc {
+func IngressUniversal(tokenProvider func(zone string) (string, error)) InstallFunc {
 	manifestFunc := func(address string, port, advertisedPort int) string {
 		return fmt.Sprintf(ZoneIngress, address, port, advertisedPort)
 	}
 
-	return zoneRelatedResource(token, AppIngress, manifestFunc)
+	return zoneRelatedResource(tokenProvider, AppIngress, manifestFunc)
 }
 
-func EgressUniversal(token string) InstallFunc {
+func EgressUniversal(tokenProvider func(zone string) (string, error)) InstallFunc {
 	manifestFunc := func(_ string, port, _ int) string {
 		return fmt.Sprintf(ZoneEgress, port)
 	}
 
-	return zoneRelatedResource(token, AppEgress, manifestFunc)
+	return zoneRelatedResource(tokenProvider, AppEgress, manifestFunc)
 }
 
 func DemoClientK8s(mesh string) InstallFunc {
@@ -334,7 +339,7 @@ func DemoClientJobK8s(namespace, mesh, destination string) InstallFunc {
 	)
 }
 
-func DemoClientUniversal(name, mesh, token string, opt ...AppDeploymentOption) InstallFunc {
+func DemoClientUniversal(name string, mesh string, opt ...AppDeploymentOption) InstallFunc {
 	return func(cluster Cluster) error {
 		var opts appDeploymentOptions
 		opts.apply(opt...)
@@ -350,6 +355,15 @@ func DemoClientUniversal(name, mesh, token string, opt ...AppDeploymentOption) I
 			}
 		}
 
+		token := opts.token
+		var err error
+		if token == "" {
+			token, err = cluster.GetKuma().GenerateDpToken(mesh, name)
+			if err != nil {
+				return err
+			}
+		}
+
 		opt = append(opt,
 			WithName(name),
 			WithMesh(mesh),
@@ -362,7 +376,7 @@ func DemoClientUniversal(name, mesh, token string, opt ...AppDeploymentOption) I
 	}
 }
 
-func TestServerUniversal(name, mesh, token string, opt ...AppDeploymentOption) InstallFunc {
+func TestServerUniversal(name string, mesh string, opt ...AppDeploymentOption) InstallFunc {
 	return func(cluster Cluster) error {
 		var opts appDeploymentOptions
 		opts.apply(opt...)
@@ -381,6 +395,14 @@ func TestServerUniversal(name, mesh, token string, opt ...AppDeploymentOption) I
 		}
 		if opts.serviceInstance == "" {
 			opts.serviceInstance = "1"
+		}
+		token := opts.token
+		var err error
+		if token == "" {
+			token, err = cluster.GetKuma().GenerateDpToken(mesh, opts.serviceName)
+			if err != nil {
+				return err
+			}
 		}
 
 		serviceProbe := ""


### PR DESCRIPTION
### Summary

### Full changelog

* Generate token when deploying test server
* Generate token when deploying client
* Pass func to Ingress/Egress for token generation
* Simplify AfterEachs by using E2EAfterEach
* On Universal Dismiss Cluster is enough so I removed DeleteKuma invocations

### Issues resolved

No issues reported.

### Documentation

~- [ ] Link to the website [documentation PR](https://github.com/kumahq/kuma-website/pull/XXX)~

### Testing

- [ ] Unit tests
- [X] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes

### Backwards compatibility

~- [ ] Update [`UPGRADE.md`](/UPGRADE.md) with any steps users will need to take when upgrading.~
~- [ ] Add `backport-to-stable` label if the code follows our [backporting policy](/CONTRIBUTING.md#backporting)~
