### PR TITLE
ci(e2e): use Config.Zone{In,E}gress app instead of strings

### DIFF
--- a/test/e2e/inspect/inspect_k8s_multizone.go
+++ b/test/e2e/inspect/inspect_k8s_multizone.go
@@ -83,7 +83,7 @@ spec:
 			g.Expect(dataplanes).Should(ContainElement(ContainSubstring("demo-client")))
 		}, "60s", "1s").Should(Succeed())
 
-		zoneIngress = GetPod(Config.KumaNamespace, "kuma-ingress")
+		zoneIngress = GetPod(Config.KumaNamespace, Config.ZoneIngressApp)
 	})
 
 	E2EAfterEach(func() {

--- a/test/framework/k8s_cluster.go
+++ b/test/framework/k8s_cluster.go
@@ -474,13 +474,13 @@ func (c *K8sCluster) DeployKuma(mode core.CpMode, opt ...KumaDeploymentOption) e
 	}
 
 	if c.opts.zoneIngress {
-		if err := c.WaitApp("kuma-ingress", Config.KumaNamespace, 1); err != nil {
+		if err := c.WaitApp(Config.ZoneIngressApp, Config.KumaNamespace, 1); err != nil {
 			return err
 		}
 	}
 
 	if c.opts.zoneEgress {
-		if err := c.WaitApp("kuma-egress", Config.KumaNamespace, 1); err != nil {
+		if err := c.WaitApp(Config.ZoneEgressApp, Config.KumaNamespace, 1); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
This is useful for places where we reuse these e2e tests

Signed-off-by: Charly Molter <charly.molter@konghq.com>