### PR TITLE
fix(helm): add prefix to `app` label in ingress/egress deployment

### DIFF
--- a/app/kumactl/cmd/install/testdata/install-control-plane.dump-values.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.dump-values.yaml
@@ -93,9 +93,12 @@ controlPlane:
   # -- Optionally override the resource spec
   # @default -- the resources will be chosen based on the mode
   resources:
-  #  requests:
+    requests:
   #    cpu: 100m
   #    memory: 256Mi
+    limits:
+  #    cpu: 250m
+  #    memory: 512Mi
 
   # TLS for various servers
   tls:

--- a/app/kumactl/cmd/install/testdata/install-control-plane.with-helm-set.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.with-helm-set.yaml
@@ -1518,8 +1518,8 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: f509d41973f6ed84a86f16e996b13068bffb3a90d10d7886a37e1c5fc225f760
-        checksum/tls-secrets: 592096ac96f1bd1570fdf154d9d17b61be0b78b1dc35eb85cce636d33bdde56d
+        checksum/config: 47f8e00f6916a54e5c2c5c1f0369b8107436c15171abc1167b1fa35bd9afad5f
+        checksum/tls-secrets: cf73e8628484dfed58bd012abd61502d41e6c343ec4b248e3928db75d0166373
       labels:
         app.kubernetes.io/name: kuma
         app.kubernetes.io/instance: kuma

--- a/app/kumactl/cmd/install/testdata/install-control-plane.with-helm-values.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.with-helm-values.yaml
@@ -1456,8 +1456,8 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: f509d41973f6ed84a86f16e996b13068bffb3a90d10d7886a37e1c5fc225f760
-        checksum/tls-secrets: 592096ac96f1bd1570fdf154d9d17b61be0b78b1dc35eb85cce636d33bdde56d
+        checksum/config: 47f8e00f6916a54e5c2c5c1f0369b8107436c15171abc1167b1fa35bd9afad5f
+        checksum/tls-secrets: cf73e8628484dfed58bd012abd61502d41e6c343ec4b248e3928db75d0166373
       labels:
         app.kubernetes.io/name: kuma
         app.kubernetes.io/instance: kuma

--- a/deployments/charts/kuma/templates/egress-deployment.yaml
+++ b/deployments/charts/kuma/templates/egress-deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "kuma.labels" . | nindent 4 }}
-    app: kuma-egress
+    app: {{ include "kuma.name" . }}-egress
 spec:
   strategy:
     rollingUpdate:

--- a/deployments/charts/kuma/templates/ingress-deployment.yaml
+++ b/deployments/charts/kuma/templates/ingress-deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "kuma.labels" . | nindent 4 }}
-    app: kuma-ingress
+    app: {{ include "kuma.name" . }}-ingress
 spec:
   strategy:
     rollingUpdate:

--- a/test/e2e/externalservices/localityawarelb_multizone/locality_multizone_hybrid.go
+++ b/test/e2e/externalservices/localityawarelb_multizone/locality_multizone_hybrid.go
@@ -2,6 +2,7 @@ package localityawarelb_multizone
 
 import (
 	"fmt"
+	"net"
 
 	"github.com/gruntwork-io/terratest/modules/k8s"
 	. "github.com/onsi/ginkgo/v2"
@@ -39,8 +40,8 @@ tags:
   kuma.io/service: external-service-in-both-zones
   kuma.io/protocol: http
 networking:
-  address: %s:8080
-`, mesh, ip)
+  address: %s
+`, mesh, net.JoinHostPort(ip, "8080"))
 }
 
 func zoneExternalService(mesh string, ip string, name string, zone string) string {
@@ -53,8 +54,8 @@ tags:
   kuma.io/protocol: http
   kuma.io/zone: %s
 networking:
-  address: %s:8080
-`, mesh, name, name, zone, ip)
+  address: %s
+`, mesh, name, name, zone, net.JoinHostPort(ip, "8080"))
 }
 
 const defaultMesh = "default"


### PR DESCRIPTION
This was missing when using a `kuma.name` in the template

Signed-off-by: Charly Molter <charly.molter@konghq.com>