### PR TITLE
build(dockerfiles): remove always empty build arg KUMA_ROOT

### DIFF
--- a/test/dockerfiles/Dockerfile.universal
+++ b/test/dockerfiles/Dockerfile.universal
@@ -33,14 +33,14 @@ RUN ssh-keygen -A \
 ARG ARCH
 ARG ENVOY_VERSION
 
-ADD $KUMA_ROOT/build/artifacts-linux-$ARCH/kuma-cp/kuma-cp /usr/bin
-ADD $KUMA_ROOT/build/artifacts-linux-$ARCH/kuma-dp/kuma-dp /usr/bin
-ADD $KUMA_ROOT/build/artifacts-linux-$ARCH/envoy/envoy-$ENVOY_VERSION-alpine /usr/bin/envoy
-ADD $KUMA_ROOT/build/artifacts-linux-$ARCH/coredns/coredns /usr/bin
-ADD $KUMA_ROOT/build/artifacts-linux-$ARCH/kumactl/kumactl /usr/bin
-ADD $KUMA_ROOT/build/artifacts-linux-$ARCH/test-server/test-server /usr/bin
-ADD $KUMA_ROOT/test/server/certs/server.crt /kuma
-ADD $KUMA_ROOT/test/server/certs/server.key /kuma
+ADD /build/artifacts-linux-$ARCH/kuma-cp/kuma-cp /usr/bin
+ADD /build/artifacts-linux-$ARCH/kuma-dp/kuma-dp /usr/bin
+ADD /build/artifacts-linux-$ARCH/envoy/envoy-$ENVOY_VERSION-alpine /usr/bin/envoy
+ADD /build/artifacts-linux-$ARCH/coredns/coredns /usr/bin
+ADD /build/artifacts-linux-$ARCH/kumactl/kumactl /usr/bin
+ADD /build/artifacts-linux-$ARCH/test-server/test-server /usr/bin
+ADD /test/server/certs/server.crt /kuma
+ADD /test/server/certs/server.key /kuma
 
 # do not detach (-D), log to stderr (-e)
 CMD ["/usr/sbin/sshd", "-D", "-e"]

--- a/tools/releases/docker.sh
+++ b/tools/releases/docker.sh
@@ -13,7 +13,7 @@ ENVOY_VERSION="${ENVOY_VERSION:-1.21.1}"
 function build() {
   for component in ${KUMA_COMPONENTS}; do
     msg "Building $component..."
-    docker build --build-arg KUMA_ROOT="$(pwd)" --build-arg ARCH="amd64" --build-arg ENVOY_VERSION="${ENVOY_VERSION}" -t "${KUMA_DOCKER_REPO_ORG}/${component}:${KUMA_VERSION}" \
+    docker build --build-arg ARCH="amd64" --build-arg ENVOY_VERSION="${ENVOY_VERSION}" -t "${KUMA_DOCKER_REPO_ORG}/${component}:${KUMA_VERSION}" \
       -f tools/releases/dockerfiles/Dockerfile."${component}" .
     docker tag "${KUMA_DOCKER_REPO_ORG}/${component}:${KUMA_VERSION}" "${KUMA_DOCKER_REPO_ORG}/${component}:latest"
     msg_green "... done!"

--- a/tools/releases/dockerfiles/Dockerfile.kuma-cp
+++ b/tools/releases/dockerfiles/Dockerfile.kuma-cp
@@ -2,16 +2,16 @@ FROM alpine:3.15.2
 
 ARG ARCH
 
-ADD $KUMA_ROOT/build/artifacts-linux-$ARCH/kuma-cp/kuma-cp /usr/bin
+ADD /build/artifacts-linux-$ARCH/kuma-cp/kuma-cp /usr/bin
 
 RUN mkdir -p /etc/kuma
-ADD $KUMA_ROOT/pkg/config/app/kuma-cp/kuma-cp.defaults.yaml /etc/kuma
+ADD /pkg/config/app/kuma-cp/kuma-cp.defaults.yaml /etc/kuma
 
-COPY $KUMA_ROOT/tools/releases/templates/LICENSE \
-    $KUMA_ROOT/tools/releases/templates/README \
+COPY /tools/releases/templates/LICENSE \
+    /tools/releases/templates/README \
     /kuma/
 
-COPY $KUMA_ROOT/tools/releases/templates/NOTICE /kuma/
+COPY /tools/releases/templates/NOTICE /kuma/
 
 RUN addgroup -S -g 6789 kuma-cp \
  && adduser -S -D -G kuma-cp -u 6789 kuma-cp

--- a/tools/releases/dockerfiles/Dockerfile.kuma-dp
+++ b/tools/releases/dockerfiles/Dockerfile.kuma-dp
@@ -3,15 +3,15 @@ FROM gcr.io/distroless/base-debian11:debug-nonroot
 ARG ENVOY_VERSION
 ARG ARCH
 
-ADD $KUMA_ROOT/build/artifacts-linux-$ARCH/kuma-dp/kuma-dp /usr/bin
-ADD $KUMA_ROOT/build/artifacts-linux-$ARCH/envoy/envoy-$ENVOY_VERSION-alpine /usr/bin/envoy
-ADD $KUMA_ROOT/build/artifacts-linux-$ARCH/coredns/coredns /usr/bin
+ADD /build/artifacts-linux-$ARCH/kuma-dp/kuma-dp /usr/bin
+ADD /build/artifacts-linux-$ARCH/envoy/envoy-$ENVOY_VERSION-alpine /usr/bin/envoy
+ADD /build/artifacts-linux-$ARCH/coredns/coredns /usr/bin
 
-COPY $KUMA_ROOT/tools/releases/templates/LICENSE \
-    $KUMA_ROOT/tools/releases/templates/README \
+COPY /tools/releases/templates/LICENSE \
+    /tools/releases/templates/README \
     /kuma/
 
-COPY $KUMA_ROOT/tools/releases/templates/NOTICE /kuma/
+COPY /tools/releases/templates/NOTICE /kuma/
 
 USER nobody:nobody
 

--- a/tools/releases/dockerfiles/Dockerfile.kuma-init
+++ b/tools/releases/dockerfiles/Dockerfile.kuma-init
@@ -6,13 +6,13 @@ RUN apt-get update && \
     apt-get -y install iptables iproute2 && \
     rm -rf /var/lib/apt/lists/*
 
-ADD $KUMA_ROOT/build/artifacts-linux-$ARCH/kumactl/kumactl /usr/bin
+ADD /build/artifacts-linux-$ARCH/kumactl/kumactl /usr/bin
 
-COPY $KUMA_ROOT/tools/releases/templates/LICENSE \
-    $KUMA_ROOT/tools/releases/templates/README \
+COPY /tools/releases/templates/LICENSE \
+    /tools/releases/templates/README \
     /kuma/
 
-COPY $KUMA_ROOT/tools/releases/templates/NOTICE-kumactl /kuma/NOTICE
+COPY /tools/releases/templates/NOTICE-kumactl /kuma/NOTICE
 
 RUN adduser --system --disabled-password --group kumactl --uid 5678
 

--- a/tools/releases/dockerfiles/Dockerfile.kuma-prometheus-sd
+++ b/tools/releases/dockerfiles/Dockerfile.kuma-prometheus-sd
@@ -2,13 +2,13 @@ FROM alpine:3.15.2
 
 ARG ARCH
 
-ADD $KUMA_ROOT/build/artifacts-linux-$ARCH/kuma-prometheus-sd/kuma-prometheus-sd /usr/bin
+ADD /build/artifacts-linux-$ARCH/kuma-prometheus-sd/kuma-prometheus-sd /usr/bin
 
-COPY $KUMA_ROOT/tools/releases/templates/LICENSE \
-    $KUMA_ROOT/tools/releases/templates/README \
+COPY /tools/releases/templates/LICENSE \
+    /tools/releases/templates/README \
     /kuma/
 
-COPY $KUMA_ROOT/tools/releases/templates/NOTICE /kuma/
+COPY /tools/releases/templates/NOTICE /kuma/
 
 USER nobody:nobody
 

--- a/tools/releases/dockerfiles/Dockerfile.kumactl
+++ b/tools/releases/dockerfiles/Dockerfile.kumactl
@@ -4,13 +4,13 @@ ARG ARCH
 
 RUN apk add --no-cache curl
 
-ADD $KUMA_ROOT/build/artifacts-linux-$ARCH/kumactl/kumactl /usr/bin
+ADD /build/artifacts-linux-$ARCH/kumactl/kumactl /usr/bin
 
-COPY $KUMA_ROOT/tools/releases/templates/LICENSE \
-    $KUMA_ROOT/tools/releases/templates/README \
+COPY /tools/releases/templates/LICENSE \
+    /tools/releases/templates/README \
     /kuma/
 
-COPY $KUMA_ROOT/tools/releases/templates/NOTICE-kumactl /kuma/NOTICE
+COPY /tools/releases/templates/NOTICE-kumactl /kuma/NOTICE
 
 RUN addgroup -S -g 6789 kumactl \
  && adduser -S -D -G kumactl -u 6789 kumactl


### PR DESCRIPTION
### Summary

I may be missing something but it's not declared via the `ARG` instruction in any `Dockerfile` and is thus always empty, no matter whether we set it via `--build-arg`.

Docker spits out warnings like:

```
[Warning] One or more build-args [KUMA_ROOT] were not consumed
```