### PR TITLE
feat(kuma-cp): unsafe delete

### DIFF
--- a/pkg/api-server/config_ws_test.go
+++ b/pkg/api-server/config_ws_test.go
@@ -307,7 +307,8 @@ var _ = Describe("Config WS", func() {
               "conflictRetryBaseBackoff": "100ms",
               "conflictRetryMaxTimes": 5
             },
-            "type": "memory"
+            "type": "memory",
+            "unsafeDelete": false
           },
           "xdsServer": {
             "dataplaneConfigurationRefreshInterval": "1s",

--- a/pkg/config/app/kuma-cp/kuma-cp.defaults.yaml
+++ b/pkg/config/app/kuma-cp/kuma-cp.defaults.yaml
@@ -66,6 +66,10 @@ store:
     # Max retries on upsert (get and update) operation when retry is enabled
     conflictRetryMaxTimes: 5 # ENV: KUMA_STORE_UPSERT_CONFLICT_RETRY_MAX_TIMES
 
+  # If true, skips validation of resource delete.
+  # For example you don't have to delete all Dataplane objects before you delete a Mesh
+  unsafeDelete: false # ENV: KUMA_STORE_UNSAFE_DELETE
+
 # Configuration of Bootstrap Server, which provides bootstrap config to Dataplanes
 bootstrapServer:
   # The version of Envoy API (available: "v3")

--- a/pkg/config/core/resources/store/config.go
+++ b/pkg/config/core/resources/store/config.go
@@ -32,6 +32,9 @@ type StoreConfig struct {
 	Cache CacheStoreConfig `yaml:"cache"`
 	// Upsert configuration
 	Upsert UpsertConfig `yaml:"upsert"`
+	// UnsafeDelete skips validation of resource delete.
+	// For example you don't have to delete all Dataplane objects before you delete a Mesh
+	UnsafeDelete bool `yaml:"unsafeDelete" envconfig:"kuma_store_unsafe_delete"`
 }
 
 func DefaultStoreConfig() *StoreConfig {

--- a/pkg/config/loader_test.go
+++ b/pkg/config/loader_test.go
@@ -90,6 +90,7 @@ var _ = Describe("Config loader", func() {
 			Expect(cfg.Environment).To(Equal(config_core.KubernetesEnvironment))
 
 			Expect(cfg.Store.Type).To(Equal(store.PostgresStore))
+			Expect(cfg.Store.UnsafeDelete).To(BeTrue())
 			Expect(cfg.Store.Postgres.Host).To(Equal("postgres.host"))
 			Expect(cfg.Store.Postgres.Port).To(Equal(5432))
 			Expect(cfg.Store.Postgres.User).To(Equal("kuma"))
@@ -259,6 +260,7 @@ var _ = Describe("Config loader", func() {
 environment: kubernetes
 store:
   type: postgres
+  unsafeDelete: true
   postgres:
     host: postgres.host
     port: 5432
@@ -481,6 +483,7 @@ experimental:
 				"KUMA_BOOTSTRAP_SERVER_PARAMS_ADMIN_ADDRESS":                                               "1.1.1.1",
 				"KUMA_ENVIRONMENT":                                                                         "kubernetes",
 				"KUMA_STORE_TYPE":                                                                          "postgres",
+				"KUMA_STORE_UNSAFE_DELETE":                                                                 "true",
 				"KUMA_STORE_POSTGRES_HOST":                                                                 "postgres.host",
 				"KUMA_STORE_POSTGRES_PORT":                                                                 "5432",
 				"KUMA_STORE_POSTGRES_USER":                                                                 "kuma",

--- a/pkg/core/bootstrap/bootstrap.go
+++ b/pkg/core/bootstrap/bootstrap.go
@@ -348,7 +348,14 @@ func initializeResourceManager(cfg kuma_cp.Config, builder *core_runtime.Builder
 
 	customizableManager.Customize(
 		mesh.MeshType,
-		mesh_managers.NewMeshManager(builder.ResourceStore(), customizableManager, builder.CaManagers(), registry.Global(), builder.ResourceValidators().Mesh),
+		mesh_managers.NewMeshManager(
+			builder.ResourceStore(),
+			customizableManager,
+			builder.CaManagers(),
+			registry.Global(),
+			builder.ResourceValidators().Mesh,
+			cfg.Store.UnsafeDelete,
+		),
 	)
 
 	rateLimitValidator := ratelimit_managers.RateLimitValidator{
@@ -379,7 +386,7 @@ func initializeResourceManager(cfg kuma_cp.Config, builder *core_runtime.Builder
 
 	customizableManager.Customize(
 		system.ZoneType,
-		zone.NewZoneManager(builder.ResourceStore(), zone.Validator{Store: builder.ResourceStore()}),
+		zone.NewZoneManager(builder.ResourceStore(), zone.Validator{Store: builder.ResourceStore()}, builder.Config().Store.UnsafeDelete),
 	)
 
 	customizableManager.Customize(
@@ -416,7 +423,7 @@ func initializeResourceManager(cfg kuma_cp.Config, builder *core_runtime.Builder
 
 	customizableManager.Customize(
 		system.SecretType,
-		secret_manager.NewSecretManager(builder.SecretStore(), cipher, secretValidator),
+		secret_manager.NewSecretManager(builder.SecretStore(), cipher, secretValidator, cfg.Store.UnsafeDelete),
 	)
 
 	customizableManager.Customize(

--- a/pkg/core/datasource/dynamic_test.go
+++ b/pkg/core/datasource/dynamic_test.go
@@ -25,7 +25,7 @@ var _ = Describe("DataSource Loader", func() {
 	var dataSourceLoader datasource.Loader
 
 	BeforeEach(func() {
-		secretManager = secret_manager.NewSecretManager(secret_store.NewSecretStore(memory.NewStore()), cipher.None(), nil)
+		secretManager = secret_manager.NewSecretManager(secret_store.NewSecretStore(memory.NewStore()), cipher.None(), nil, false)
 		dataSourceLoader = datasource.NewDataSourceLoader(secretManager)
 	})
 

--- a/pkg/core/managers/apis/mesh/mesh_manager_test.go
+++ b/pkg/core/managers/apis/mesh/mesh_manager_test.go
@@ -262,7 +262,7 @@ var _ = Describe("Mesh Manager", func() {
 			Expect(err.Error()).To(Equal("mesh: unable to delete mesh, there are still some dataplanes attached"))
 		})
 
-		It("should delete Mesh if there are Dataplanes attached when unsafe delete is enalbed", func() {
+		It("should delete Mesh if there are Dataplanes attached when unsafe delete is enabled", func() {
 			// given mesh and dataplane
 			err := resManager.Create(context.Background(), core_mesh.NewMeshResource(), store.CreateByKey("mesh-1", model.NoMesh))
 			Expect(err).ToNot(HaveOccurred())

--- a/pkg/core/managers/apis/mesh/mesh_manager_test.go
+++ b/pkg/core/managers/apis/mesh/mesh_manager_test.go
@@ -284,7 +284,7 @@ var _ = Describe("Mesh Manager", func() {
 			}, store.CreateByKey("dp-1", "mesh-1"))
 			Expect(err).ToNot(HaveOccurred())
 
-			// when mesh-1 is delete
+			// when mesh-1 is deleted
 			err = unsafeDeleteResManager.Delete(context.Background(), core_mesh.NewMeshResource(), store.DeleteByKey("mesh-1", model.NoMesh))
 
 			// then

--- a/pkg/core/managers/apis/zone/zone_manager_test.go
+++ b/pkg/core/managers/apis/zone/zone_manager_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/kumahq/kuma/api/system/v1alpha1"
 	"github.com/kumahq/kuma/pkg/core/managers/apis/zone"
 	"github.com/kumahq/kuma/pkg/core/resources/apis/system"
-	"github.com/kumahq/kuma/pkg/core/resources/manager"
 	"github.com/kumahq/kuma/pkg/core/resources/model"
 	"github.com/kumahq/kuma/pkg/core/resources/store"
 	"github.com/kumahq/kuma/pkg/plugins/resources/memory"
@@ -19,14 +18,12 @@ import (
 
 var _ = Describe("Zone Manager", func() {
 
-	var zoneManager manager.ResourceManager
+	var validator zone.Validator
 	var resStore store.ResourceStore
 
 	BeforeEach(func() {
 		resStore = memory.NewStore()
-
-		validator := zone.Validator{Store: resStore}
-		zoneManager = zone.NewZoneManager(resStore, validator)
+		validator = zone.Validator{Store: resStore}
 	})
 
 	It("should not delete zone if it's online", func() {
@@ -44,13 +41,45 @@ var _ = Describe("Zone Manager", func() {
 			},
 		}, store.CreateByKey("zone-1", model.NoMesh))
 		Expect(err).ToNot(HaveOccurred())
+		zoneManager := zone.NewZoneManager(resStore, validator, false)
 
 		zone := system.NewZoneResource()
 		err = resStore.Get(context.Background(), zone, store.GetByKey("zone-1", model.NoMesh))
 		Expect(err).ToNot(HaveOccurred())
 
+		// when
 		err = zoneManager.Delete(context.Background(), zone, store.DeleteByKey("zone-1", model.NoMesh))
+
+		// then
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(ContainSubstring("zone: unable to delete Zone, Zone CP is still connected, please shut it down first"))
+	})
+
+	It("should delete if zone is online when unsafe delete is enabled", func() {
+		// given zone and zoneInsight
+		err := resStore.Create(context.Background(), system.NewZoneResource(), store.CreateByKey("zone-1", model.NoMesh))
+		Expect(err).ToNot(HaveOccurred())
+
+		err = resStore.Create(context.Background(), &system.ZoneInsightResource{
+			Spec: &v1alpha1.ZoneInsight{
+				Subscriptions: []*v1alpha1.KDSSubscription{
+					{
+						ConnectTime: proto.MustTimestampProto(time.Now()),
+					},
+				},
+			},
+		}, store.CreateByKey("zone-1", model.NoMesh))
+		Expect(err).ToNot(HaveOccurred())
+		zoneManager := zone.NewZoneManager(resStore, validator, true)
+
+		zone := system.NewZoneResource()
+		err = resStore.Get(context.Background(), zone, store.GetByKey("zone-1", model.NoMesh))
+		Expect(err).ToNot(HaveOccurred())
+
+		// when
+		err = zoneManager.Delete(context.Background(), zone, store.DeleteByKey("zone-1", model.NoMesh))
+
+		// then
+		Expect(err).ToNot(HaveOccurred())
 	})
 })

--- a/pkg/core/secrets/manager/validator_test.go
+++ b/pkg/core/secrets/manager/validator_test.go
@@ -38,7 +38,7 @@ var _ = Describe("Secret Validator", func() {
 		caManagers = core_ca.Managers{}
 		secrets_manager.NewSecretValidator(caManagers, memoryStore)
 		validator = secrets_manager.NewSecretValidator(caManagers, memoryStore)
-		secManager := secrets_manager.NewSecretManager(secrets_store.NewSecretStore(memoryStore), cipher.None(), validator)
+		secManager := secrets_manager.NewSecretManager(secrets_store.NewSecretStore(memoryStore), cipher.None(), validator, false)
 
 		caManagers["builtin"] = ca_builtin.NewBuiltinCaManager(secManager)
 		caManagers["provided"] = ca_provided.NewProvidedCaManager(core_datasource.NewDataSourceLoader(secManager))

--- a/pkg/plugins/ca/builtin/manager_test.go
+++ b/pkg/plugins/ca/builtin/manager_test.go
@@ -35,7 +35,7 @@ var _ = Describe("Builtin CA Manager", func() {
 		core.Now = func() time.Time {
 			return now
 		}
-		secretManager = secret_manager.NewSecretManager(store.NewSecretStore(memory.NewStore()), cipher.None(), nil)
+		secretManager = secret_manager.NewSecretManager(store.NewSecretStore(memory.NewStore()), cipher.None(), nil, false)
 		caManager = builtin.NewBuiltinCaManager(secretManager)
 	})
 

--- a/pkg/plugins/runtime/k8s/controllers/mesh_defaults_controller_test.go
+++ b/pkg/plugins/runtime/k8s/controllers/mesh_defaults_controller_test.go
@@ -43,7 +43,9 @@ var _ = Describe("MeshDefaultsReconciler", func() {
 			secret_manager.NewSecretManager(
 				secretStore,
 				secret_cipher.None(),
-				secret_manager.ValidateDelete(func(ctx context.Context, secretName string, secretMesh string) error { return nil })),
+				secret_manager.ValidateDelete(func(ctx context.Context, secretName string, secretMesh string) error { return nil }),
+				false,
+			),
 		)
 
 		reconciler = &controllers.MeshDefaultsReconciler{

--- a/pkg/plugins/runtime/k8s/webhooks/zone_validator.go
+++ b/pkg/plugins/runtime/k8s/webhooks/zone_validator.go
@@ -12,14 +12,16 @@ import (
 	mesh_k8s "github.com/kumahq/kuma/pkg/plugins/resources/k8s/native/api/v1alpha1"
 )
 
-func NewZoneValidatorWebhook(validator zone.Validator) k8s_common.AdmissionValidator {
+func NewZoneValidatorWebhook(validator zone.Validator, unsafeDelete bool) k8s_common.AdmissionValidator {
 	return &ZoneValidator{
-		validator: validator,
+		validator:    validator,
+		unsafeDelete: unsafeDelete,
 	}
 }
 
 type ZoneValidator struct {
-	validator zone.Validator
+	validator    zone.Validator
+	unsafeDelete bool
 }
 
 func (z *ZoneValidator) InjectDecoder(_ *admission.Decoder) error {
@@ -35,8 +37,10 @@ func (z *ZoneValidator) Handle(ctx context.Context, req admission.Request) admis
 }
 
 func (z *ZoneValidator) ValidateDelete(ctx context.Context, req admission.Request) admission.Response {
-	if err := z.validator.ValidateDelete(ctx, req.Name); err != nil {
-		return admission.Errored(http.StatusBadRequest, err)
+	if !z.unsafeDelete {
+		if err := z.validator.ValidateDelete(ctx, req.Name); err != nil {
+			return admission.Errored(http.StatusBadRequest, err)
+		}
 	}
 	return admission.Allowed("")
 }

--- a/pkg/test/runtime/runtime.go
+++ b/pkg/test/runtime/runtime.go
@@ -124,10 +124,17 @@ func newResourceManager(builder *core_runtime.Builder) core_manager.Customizable
 	defaultManager := core_manager.NewResourceManager(builder.ResourceStore())
 	customManagers := map[core_model.ResourceType]core_manager.ResourceManager{}
 	customizableManager := core_manager.NewCustomizableResourceManager(defaultManager, customManagers)
-	meshManager := mesh_managers.NewMeshManager(builder.ResourceStore(), customizableManager, builder.CaManagers(), registry.Global(), builder.ResourceValidators().Mesh)
+	meshManager := mesh_managers.NewMeshManager(
+		builder.ResourceStore(),
+		customizableManager,
+		builder.CaManagers(),
+		registry.Global(),
+		builder.ResourceValidators().Mesh,
+		builder.Config().Store.UnsafeDelete,
+	)
 	customManagers[core_mesh.MeshType] = meshManager
 
-	secretManager := secret_manager.NewSecretManager(builder.SecretStore(), secret_cipher.None(), nil)
+	secretManager := secret_manager.NewSecretManager(builder.SecretStore(), secret_cipher.None(), nil, builder.Config().Store.UnsafeDelete)
 	customManagers[system.SecretType] = secretManager
 	return customizableManager
 }

--- a/pkg/xds/secrets/secrets_test.go
+++ b/pkg/xds/secrets/secrets_test.go
@@ -102,7 +102,7 @@ var _ = Describe("Secrets", func() {
 
 	BeforeEach(func() {
 		resStore := memory.NewStore()
-		secretManager := secrets_manager.NewSecretManager(secrets_store.NewSecretStore(resStore), cipher.None(), nil)
+		secretManager := secrets_manager.NewSecretManager(secrets_store.NewSecretStore(resStore), cipher.None(), nil, false)
 		builtinCaManager := ca_builtin.NewBuiltinCaManager(secretManager)
 		caManagers := core_ca.Managers{
 			"builtin": builtinCaManager,

--- a/pkg/xds/topology/outbound_test.go
+++ b/pkg/xds/topology/outbound_test.go
@@ -79,7 +79,7 @@ var _ = Describe("TrafficRoute", func() {
 	var dataSourceLoader datasource.Loader
 
 	BeforeEach(func() {
-		secretManager := secret_manager.NewSecretManager(secret_store.NewSecretStore(memory.NewStore()), cipher.None(), nil)
+		secretManager := secret_manager.NewSecretManager(secret_store.NewSecretStore(memory.NewStore()), cipher.None(), nil, false)
 		dataSourceLoader = datasource.NewDataSourceLoader(secretManager)
 	})
 	Describe("GetOutboundTargets()", func() {


### PR DESCRIPTION
### Summary

Add ability to delete resources unsafe way. Why?
* With tests we don't want to wait for all Dataplane object to be deleted, we just want to delete Mesh and forget about the rest
* On prod, we may get into an undefined state in which you may want to bypass validators. On Kubernetes you can always remove the webhook temporarily, on universal there is no such thing.

I was considering supporting this on Validator level, but I believe this is the responsibility of manager/webhook rather than validator. You should be able to swap a validator without worrying about this flag.

### Documentation

~- [ ] Link to the website [documentation PR](https://github.com/kumahq/kuma-website/pull/XXX)~

### Testing

- [X] Unit tests
- [ ] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes

### Backwards compatibility

~- [ ] Update [`UPGRADE.md`](/UPGRADE.md) with any steps users will need to take when upgrading.~
~- [ ] Add `backport-to-stable` label if the code follows our [backporting policy](/CONTRIBUTING.md#backporting)~
