### PR TITLE
fix(kuma-cp): update helm charts for 1.5.1

### DIFF
--- a/app/kumactl/cmd/install/testdata/install-control-plane.cni-enabled.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.cni-enabled.golden.yaml
@@ -1551,7 +1551,7 @@ spec:
         # priority scheduling and that its resources are reserved
         # if it ever gets evicted.
         scheduler.alpha.kubernetes.io/critical-pod: ''
-        checksum/config: dcb8e2a9ea14d68140d14e02cb7462584b13392cae9828c3dcb7254618860a76
+        checksum/config: 28304fca07074ec0e2c9382e1c6d2bfba8302f33652ed7dd006fec39e18fbfee
     spec:
       nodeSelector:
       
@@ -1629,8 +1629,8 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: f509d41973f6ed84a86f16e996b13068bffb3a90d10d7886a37e1c5fc225f760
-        checksum/tls-secrets: 78e5236addc11d7549493c1756f9ace9c6dc65d04880293bfd22b97f8173476b
+        checksum/config: 5a1774c2a3e29ca9135bef1f9622c70948207d37439b249073fc73bbf8f59b83
+        checksum/tls-secrets: a90a63ab418278361825d1ab320d8f20c1a69d328e346e16314f72c6122742f6
       labels:
         app.kubernetes.io/name: kuma
         app.kubernetes.io/instance: kuma

--- a/app/kumactl/cmd/install/testdata/install-control-plane.defaults.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.defaults.golden.yaml
@@ -1454,8 +1454,8 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: f509d41973f6ed84a86f16e996b13068bffb3a90d10d7886a37e1c5fc225f760
-        checksum/tls-secrets: 78e5236addc11d7549493c1756f9ace9c6dc65d04880293bfd22b97f8173476b
+        checksum/config: 5a1774c2a3e29ca9135bef1f9622c70948207d37439b249073fc73bbf8f59b83
+        checksum/tls-secrets: a90a63ab418278361825d1ab320d8f20c1a69d328e346e16314f72c6122742f6
       labels:
         app.kubernetes.io/name: kuma
         app.kubernetes.io/instance: kuma

--- a/app/kumactl/cmd/install/testdata/install-control-plane.global.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.global.golden.yaml
@@ -1464,8 +1464,8 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: f509d41973f6ed84a86f16e996b13068bffb3a90d10d7886a37e1c5fc225f760
-        checksum/tls-secrets: 78e5236addc11d7549493c1756f9ace9c6dc65d04880293bfd22b97f8173476b
+        checksum/config: 5a1774c2a3e29ca9135bef1f9622c70948207d37439b249073fc73bbf8f59b83
+        checksum/tls-secrets: a90a63ab418278361825d1ab320d8f20c1a69d328e346e16314f72c6122742f6
       labels:
         app.kubernetes.io/name: kuma
         app.kubernetes.io/instance: kuma

--- a/app/kumactl/cmd/install/testdata/install-control-plane.override-env-vars.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.override-env-vars.golden.yaml
@@ -1454,8 +1454,8 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: f509d41973f6ed84a86f16e996b13068bffb3a90d10d7886a37e1c5fc225f760
-        checksum/tls-secrets: 78e5236addc11d7549493c1756f9ace9c6dc65d04880293bfd22b97f8173476b
+        checksum/config: 5a1774c2a3e29ca9135bef1f9622c70948207d37439b249073fc73bbf8f59b83
+        checksum/tls-secrets: a90a63ab418278361825d1ab320d8f20c1a69d328e346e16314f72c6122742f6
       labels:
         app.kubernetes.io/name: kuma
         app.kubernetes.io/instance: kuma

--- a/app/kumactl/cmd/install/testdata/install-control-plane.overrides.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.overrides.golden.yaml
@@ -1856,8 +1856,8 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 8c443d9f48d469a050e9e994d3d839c09b7f22f3c16bbe096c5a7d30f4207d99
-        checksum/tls-secrets: e478434cf09212624ee5588731cf8bb726cc008ddd0170817bebc681fa3a88d7
+        checksum/config: 0eb30ec257dab9b5e430870392c890813e253c6fc9f55ec6b6a8d4aec66d6191
+        checksum/tls-secrets: 1988f3788e7e985462687daa534884e4d671660057fb105addcebead8849ec77
       labels:
         app.kubernetes.io/name: kuma
         app.kubernetes.io/instance: kuma
@@ -1877,7 +1877,7 @@ spec:
               topologyKey: kubernetes.io/hostname
       serviceAccountName: kuma-control-plane
       nodeSelector:
-
+        
         kubernetes.io/arch: amd64
         kubernetes.io/os: linux
       containers:
@@ -2023,7 +2023,7 @@ metadata:
   name: kuma-admission-mutating-webhook-configuration
   namespace: kuma
   labels:
-
+  
     app.kubernetes.io/name: kuma
     app.kubernetes.io/instance: kuma
 webhooks:
@@ -2078,8 +2078,8 @@ webhooks:
           - trafficroutes
           - traffictraces
           - virtualoutbounds
-
-
+    
+      
     sideEffects: None
   - name: namespace-kuma-injector.kuma.io
     admissionReviewVersions: ["v1"]
@@ -2127,7 +2127,7 @@ webhooks:
     sideEffects: None
   - name: kuma-injector.kuma.io
     admissionReviewVersions: ["v1"]
-    failurePolicy: Ignore
+    failurePolicy: Ignore 
     clientConfig:
       caBundle: XYZ
       service:
@@ -2151,7 +2151,7 @@ metadata:
   name: kuma-validating-webhook-configuration
   namespace: kuma
   labels:
-
+  
     app.kubernetes.io/name: kuma
     app.kubernetes.io/instance: kuma
 webhooks:
@@ -2192,8 +2192,8 @@ webhooks:
           - traffictraces
           - virtualoutbounds
           - zones
-
-
+    
+      
     sideEffects: None
   - name: service.validator.kuma-admission.kuma.io
     admissionReviewVersions: ["v1"]

--- a/app/kumactl/cmd/install/testdata/install-control-plane.with-egress.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.with-egress.golden.yaml
@@ -1483,8 +1483,8 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: f509d41973f6ed84a86f16e996b13068bffb3a90d10d7886a37e1c5fc225f760
-        checksum/tls-secrets: 78e5236addc11d7549493c1756f9ace9c6dc65d04880293bfd22b97f8173476b
+        checksum/config: 5a1774c2a3e29ca9135bef1f9622c70948207d37439b249073fc73bbf8f59b83
+        checksum/tls-secrets: a90a63ab418278361825d1ab320d8f20c1a69d328e346e16314f72c6122742f6
       labels:
         app.kubernetes.io/name: kuma
         app.kubernetes.io/instance: kuma

--- a/app/kumactl/cmd/install/testdata/install-control-plane.with-ingress.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.with-ingress.golden.yaml
@@ -1483,8 +1483,8 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: f509d41973f6ed84a86f16e996b13068bffb3a90d10d7886a37e1c5fc225f760
-        checksum/tls-secrets: 78e5236addc11d7549493c1756f9ace9c6dc65d04880293bfd22b97f8173476b
+        checksum/config: 5a1774c2a3e29ca9135bef1f9622c70948207d37439b249073fc73bbf8f59b83
+        checksum/tls-secrets: a90a63ab418278361825d1ab320d8f20c1a69d328e346e16314f72c6122742f6
       labels:
         app.kubernetes.io/name: kuma
         app.kubernetes.io/instance: kuma

--- a/app/kumactl/cmd/install/testdata/install-control-plane.zone.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.zone.golden.yaml
@@ -1458,8 +1458,8 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: f509d41973f6ed84a86f16e996b13068bffb3a90d10d7886a37e1c5fc225f760
-        checksum/tls-secrets: 78e5236addc11d7549493c1756f9ace9c6dc65d04880293bfd22b97f8173476b
+        checksum/config: 5a1774c2a3e29ca9135bef1f9622c70948207d37439b249073fc73bbf8f59b83
+        checksum/tls-secrets: a90a63ab418278361825d1ab320d8f20c1a69d328e346e16314f72c6122742f6
       labels:
         app.kubernetes.io/name: kuma
         app.kubernetes.io/instance: kuma

--- a/deployments/charts/kuma/Chart.yaml
+++ b/deployments/charts/kuma/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: kuma
 description: A Helm chart for the Kuma Control Plane
 type: application
-version: 0.9.0
-appVersion: 1.5.0
+version: 0.9.1
+appVersion: 1.5.1
 home: https://github.com/kumahq/kuma
 maintainers:
   - name: austince

--- a/deployments/charts/kuma/README.md
+++ b/deployments/charts/kuma/README.md
@@ -2,7 +2,7 @@
 
 A Helm chart for the Kuma Control Plane
 
-![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![Version: 0.9.0](https://img.shields.io/badge/Version-0.9.0-informational?style=flat-square) ![AppVersion: 1.5.0](https://img.shields.io/badge/AppVersion-1.5.0-informational?style=flat-square)
+![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![Version: 0.9.1](https://img.shields.io/badge/Version-0.9.1-informational?style=flat-square) ![AppVersion: 1.5.1](https://img.shields.io/badge/AppVersion-1.5.1-informational?style=flat-square)
 
 **Homepage:** <https://github.com/kumahq/kuma>
 
@@ -38,7 +38,7 @@ A Helm chart for the Kuma Control Plane
 | controlPlane.globalZoneSyncService.annotations | object | `{}` | Additional annotations to put on the Global Zone Sync Service |
 | controlPlane.globalZoneSyncService.port | int | `5685` | Port on which Global Zone Sync Service is exposed |
 | controlPlane.defaults.skipMeshCreation | bool | `false` | Whether to skip creating the default Mesh |
-| controlPlane.resources | string | the resources will be chosen based on the mode | Optionally override the resource spec |
+| controlPlane.resources | string | `nil` | Optionally override the resource spec |
 | controlPlane.tls.general.secretName | string | `""` | Secret that contains tls.crt, tls.key [and ca.crt when no controlPlane.tls.general.caSecretName specified] for protecting Kuma in-cluster communication |
 | controlPlane.tls.general.caSecretName | string | `""` | Secret that contains ca.crt that was used to sign cert for protecting Kuma in-cluster communication (ca.crt present in this secret have precedence over the one provided in the controlPlane.tls.general.secretName) |
 | controlPlane.tls.general.caBundle | string | `""` | Base64 encoded CA certificate (the same as in controlPlane.tls.general.secret#ca.crt) |

--- a/deployments/charts/kuma/README.md
+++ b/deployments/charts/kuma/README.md
@@ -38,7 +38,7 @@ A Helm chart for the Kuma Control Plane
 | controlPlane.globalZoneSyncService.annotations | object | `{}` | Additional annotations to put on the Global Zone Sync Service |
 | controlPlane.globalZoneSyncService.port | int | `5685` | Port on which Global Zone Sync Service is exposed |
 | controlPlane.defaults.skipMeshCreation | bool | `false` | Whether to skip creating the default Mesh |
-| controlPlane.resources | string | `nil` | Optionally override the resource spec |
+| controlPlane.resources | string | the resources will be chosen based on the mode | Optionally override the resource spec |
 | controlPlane.tls.general.secretName | string | `""` | Secret that contains tls.crt, tls.key [and ca.crt when no controlPlane.tls.general.caSecretName specified] for protecting Kuma in-cluster communication |
 | controlPlane.tls.general.caSecretName | string | `""` | Secret that contains ca.crt that was used to sign cert for protecting Kuma in-cluster communication (ca.crt present in this secret have precedence over the one provided in the controlPlane.tls.general.secretName) |
 | controlPlane.tls.general.caBundle | string | `""` | Base64 encoded CA certificate (the same as in controlPlane.tls.general.secret#ca.crt) |


### PR DESCRIPTION
### Summary

Update helm charts in Kuma

### Full changelog

* [Implement ...]
* [Fix ...]

### Issues resolved

Fix #XXX

### Documentation

- [ ] Link to the website [documentation PR](https://github.com/kumahq/kuma-website/pull/XXX)

### Testing

- [ ] Unit tests
- [ ] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes

### Backwards compatibility

- [ ] Update [`UPGRADE.md`](/UPGRADE.md) with any steps users will need to take when upgrading.
- [ ] Add `backport-to-stable` label if the code follows our [backporting policy](/CONTRIBUTING.md#backporting)
