### PR TITLE
feat(kuma-cp): added tests for proxy builder

### DIFF
--- a/pkg/core/config/manager/manager.go
+++ b/pkg/core/config/manager/manager.go
@@ -2,8 +2,8 @@ package manager
 
 import (
 	"context"
-	"time"
 
+	"github.com/kumahq/kuma/pkg/core"
 	config_model "github.com/kumahq/kuma/pkg/core/resources/apis/system"
 	"github.com/kumahq/kuma/pkg/core/resources/model"
 	core_store "github.com/kumahq/kuma/pkg/core/resources/store"
@@ -41,11 +41,11 @@ func (s *configManager) List(ctx context.Context, configs *config_model.ConfigRe
 }
 
 func (s *configManager) Create(ctx context.Context, config *config_model.ConfigResource, fs ...core_store.CreateOptionsFunc) error {
-	return s.configStore.Create(ctx, config, append(fs, core_store.CreatedAt(time.Now()))...)
+	return s.configStore.Create(ctx, config, append(fs, core_store.CreatedAt(core.Now()))...)
 }
 
 func (s *configManager) Update(ctx context.Context, config *config_model.ConfigResource, fs ...core_store.UpdateOptionsFunc) error {
-	return s.configStore.Update(ctx, config, append(fs, core_store.ModifiedAt(time.Now()))...)
+	return s.configStore.Update(ctx, config, append(fs, core_store.ModifiedAt(core.Now()))...)
 }
 
 func (s *configManager) Delete(ctx context.Context, config *config_model.ConfigResource, fs ...core_store.DeleteOptionsFunc) error {

--- a/pkg/core/managers/apis/external_service/external_service_manager.go
+++ b/pkg/core/managers/apis/external_service/external_service_manager.go
@@ -2,10 +2,10 @@ package externalservice
 
 import (
 	"context"
-	"time"
 
 	"github.com/pkg/errors"
 
+	"github.com/kumahq/kuma/pkg/core"
 	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	core_manager "github.com/kumahq/kuma/pkg/core/resources/manager"
 	core_model "github.com/kumahq/kuma/pkg/core/resources/model"
@@ -56,7 +56,7 @@ func (m *externalServiceManager) Create(ctx context.Context, resource core_model
 		return err
 	}
 
-	if err := m.store.Create(ctx, externalService, append(fs, core_store.CreatedAt(time.Now()))...); err != nil {
+	if err := m.store.Create(ctx, externalService, append(fs, core_store.CreatedAt(core.Now()))...); err != nil {
 		return err
 	}
 	return nil
@@ -102,7 +102,7 @@ func (m *externalServiceManager) Update(ctx context.Context, resource core_model
 		return err
 	}
 
-	return m.store.Update(ctx, externalService, append(fs, core_store.ModifiedAt(time.Now()))...)
+	return m.store.Update(ctx, externalService, append(fs, core_store.ModifiedAt(core.Now()))...)
 }
 
 func (m *externalServiceManager) externalService(resource core_model.Resource) (*core_mesh.ExternalServiceResource, error) {

--- a/pkg/core/managers/apis/mesh/mesh_manager.go
+++ b/pkg/core/managers/apis/mesh/mesh_manager.go
@@ -2,10 +2,10 @@ package mesh
 
 import (
 	"context"
-	"time"
 
 	"github.com/pkg/errors"
 
+	"github.com/kumahq/kuma/pkg/core"
 	core_ca "github.com/kumahq/kuma/pkg/core/ca"
 	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	"github.com/kumahq/kuma/pkg/core/resources/apis/system"
@@ -76,7 +76,7 @@ func (m *meshManager) Create(ctx context.Context, resource core_model.Resource, 
 	}
 
 	// persist Mesh
-	if err := m.store.Create(ctx, mesh, append(fs, core_store.CreatedAt(time.Now()))...); err != nil {
+	if err := m.store.Create(ctx, mesh, append(fs, core_store.CreatedAt(core.Now()))...); err != nil {
 		return err
 	}
 	if err := defaults_mesh.EnsureDefaultMeshResources(ctx, m.otherManagers, opts.Name); err != nil {
@@ -141,7 +141,7 @@ func (m *meshManager) Update(ctx context.Context, resource core_model.Resource, 
 	if err := EnsureCAs(ctx, m.caManagers, mesh, mesh.Meta.GetName()); err != nil {
 		return err
 	}
-	return m.store.Update(ctx, mesh, append(fs, core_store.ModifiedAt(time.Now()))...)
+	return m.store.Update(ctx, mesh, append(fs, core_store.ModifiedAt(core.Now()))...)
 }
 
 func (m *meshManager) mesh(resource core_model.Resource) (*core_mesh.MeshResource, error) {

--- a/pkg/core/managers/apis/ratelimit/ratelimit_manager.go
+++ b/pkg/core/managers/apis/ratelimit/ratelimit_manager.go
@@ -2,10 +2,10 @@ package ratelimit
 
 import (
 	"context"
-	"time"
 
 	"github.com/pkg/errors"
 
+	"github.com/kumahq/kuma/pkg/core"
 	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	core_manager "github.com/kumahq/kuma/pkg/core/resources/manager"
 	core_model "github.com/kumahq/kuma/pkg/core/resources/model"
@@ -56,7 +56,7 @@ func (m *rateLimitManager) Create(ctx context.Context, resource core_model.Resou
 		return err
 	}
 
-	if err := m.store.Create(ctx, rateLimit, append(fs, core_store.CreatedAt(time.Now()))...); err != nil {
+	if err := m.store.Create(ctx, rateLimit, append(fs, core_store.CreatedAt(core.Now()))...); err != nil {
 		return err
 	}
 	return nil
@@ -102,7 +102,7 @@ func (m *rateLimitManager) Update(ctx context.Context, resource core_model.Resou
 		return err
 	}
 
-	return m.store.Update(ctx, rateLimit, append(fs, core_store.ModifiedAt(time.Now()))...)
+	return m.store.Update(ctx, rateLimit, append(fs, core_store.ModifiedAt(core.Now()))...)
 }
 
 func (m *rateLimitManager) rateLimit(resource core_model.Resource) (*core_mesh.RateLimitResource, error) {

--- a/pkg/core/resources/manager/manager.go
+++ b/pkg/core/resources/manager/manager.go
@@ -94,7 +94,7 @@ func (r *resourcesManager) Update(ctx context.Context, resource model.Resource, 
 	if err := resource.Validate(); err != nil {
 		return err
 	}
-	return r.Store.Update(ctx, resource, append(fs, store.ModifiedAt(time.Now()))...)
+	return r.Store.Update(ctx, resource, append(fs, store.ModifiedAt(core.Now()))...)
 }
 
 type ConflictRetry struct {

--- a/pkg/core/secrets/manager/manager.go
+++ b/pkg/core/secrets/manager/manager.go
@@ -2,10 +2,10 @@ package manager
 
 import (
 	"context"
-	"time"
 
 	"github.com/pkg/errors"
 
+	"github.com/kumahq/kuma/pkg/core"
 	secret_model "github.com/kumahq/kuma/pkg/core/resources/apis/system"
 	"github.com/kumahq/kuma/pkg/core/resources/manager"
 	"github.com/kumahq/kuma/pkg/core/resources/model"
@@ -65,7 +65,7 @@ func (s *secretManager) Create(ctx context.Context, resource model.Resource, fs 
 	if err := s.encrypt(secret); err != nil {
 		return err
 	}
-	if err := s.secretStore.Create(ctx, secret, append(fs, core_store.CreatedAt(time.Now()))...); err != nil {
+	if err := s.secretStore.Create(ctx, secret, append(fs, core_store.CreatedAt(core.Now()))...); err != nil {
 		return err
 	}
 	return s.decrypt(secret)
@@ -79,7 +79,7 @@ func (s *secretManager) Update(ctx context.Context, resource model.Resource, fs 
 	if err := s.encrypt(secret); err != nil {
 		return err
 	}
-	if err := s.secretStore.Update(ctx, secret, append(fs, core_store.ModifiedAt(time.Now()))...); err != nil {
+	if err := s.secretStore.Update(ctx, secret, append(fs, core_store.ModifiedAt(core.Now()))...); err != nil {
 		return err
 	}
 	return s.decrypt(secret)

--- a/pkg/xds/sync/components.go
+++ b/pkg/xds/sync/components.go
@@ -28,7 +28,7 @@ func DefaultDataplaneProxyBuilder(
 	}
 }
 
-func defaultIngressProxyBuilder(
+func DefaultIngressProxyBuilder(
 	rt core_runtime.Runtime,
 	metadataTracker DataplaneMetadataTracker,
 	apiVersion envoy.APIVersion,
@@ -45,7 +45,7 @@ func defaultIngressProxyBuilder(
 	}
 }
 
-func defaultEgressProxyBuilder(
+func DefaultEgressProxyBuilder(
 	ctx context.Context,
 	rt core_runtime.Runtime,
 	metadataTracker DataplaneMetadataTracker,
@@ -84,14 +84,14 @@ func DefaultDataplaneWatchdogFactory(
 		apiVersion,
 	)
 
-	ingressProxyBuilder := defaultIngressProxyBuilder(
+	ingressProxyBuilder := DefaultIngressProxyBuilder(
 		rt,
 		metadataTracker,
 		apiVersion,
 		meshSnapshotCache,
 	)
 
-	egressProxyBuilder := defaultEgressProxyBuilder(
+	egressProxyBuilder := DefaultEgressProxyBuilder(
 		ctx,
 		rt,
 		metadataTracker,

--- a/pkg/xds/sync/dataplane_watchdog.go
+++ b/pkg/xds/sync/dataplane_watchdog.go
@@ -128,7 +128,7 @@ func (d *DataplaneWatchdog) syncIngress() error {
 		ControlPlane: d.envoyCpCtx,
 		Mesh:         xds_context.MeshContext{}, // ZoneIngress does not need MeshContext
 	}
-	proxy, err := d.ingressProxyBuilder.build(d.key)
+	proxy, err := d.ingressProxyBuilder.Build(d.key)
 	if err != nil {
 		return err
 	}

--- a/pkg/xds/sync/ingress_proxy_builder.go
+++ b/pkg/xds/sync/ingress_proxy_builder.go
@@ -29,7 +29,7 @@ type IngressProxyBuilder struct {
 	zone       string
 }
 
-func (p *IngressProxyBuilder) build(key core_model.ResourceKey) (*xds.Proxy, error) {
+func (p *IngressProxyBuilder) Build(key core_model.ResourceKey) (*xds.Proxy, error) {
 	ctx := context.Background()
 
 	zoneIngress, err := p.getZoneIngress(ctx, key)

--- a/pkg/xds/sync/proxy_builder_test.go
+++ b/pkg/xds/sync/proxy_builder_test.go
@@ -1,0 +1,158 @@
+package sync_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/ghodss/yaml"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	kuma_cp "github.com/kumahq/kuma/pkg/config/app/kuma-cp"
+	"github.com/kumahq/kuma/pkg/core"
+	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
+	core_manager "github.com/kumahq/kuma/pkg/core/resources/manager"
+	core_model "github.com/kumahq/kuma/pkg/core/resources/model"
+	rest_types "github.com/kumahq/kuma/pkg/core/resources/model/rest"
+	"github.com/kumahq/kuma/pkg/core/resources/store"
+	core_xds "github.com/kumahq/kuma/pkg/core/xds"
+	"github.com/kumahq/kuma/pkg/dns/vips"
+	core_metrics "github.com/kumahq/kuma/pkg/metrics"
+	"github.com/kumahq/kuma/pkg/test/matchers"
+	test_runtime "github.com/kumahq/kuma/pkg/test/runtime"
+	"github.com/kumahq/kuma/pkg/xds/cache/mesh"
+	xds_context "github.com/kumahq/kuma/pkg/xds/context"
+	envoy_common "github.com/kumahq/kuma/pkg/xds/envoy"
+	"github.com/kumahq/kuma/pkg/xds/server"
+	"github.com/kumahq/kuma/pkg/xds/sync"
+)
+
+type mockMetadataTracker struct{}
+
+func (m mockMetadataTracker) Metadata(dpKey core_model.ResourceKey) *core_xds.DataplaneMetadata {
+	return nil
+}
+
+func ToYAML(proxy *core_xds.Proxy) ([]byte, error) {
+	out, err := yaml.Marshal(proxy)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func initializeStore(ctx context.Context, resourceManager core_manager.ResourceManager, fileWithResourcesName string) {
+	resourcePath := filepath.Join(
+		"testdata", "input", fileWithResourcesName,
+	)
+
+	resourceBytes, err := os.ReadFile(resourcePath)
+	Expect(err).ToNot(HaveOccurred())
+
+	rawResources := strings.Split(string(resourceBytes), "---")
+	for _, rawResource := range rawResources {
+		bytes := []byte(rawResource)
+
+		res, err := rest_types.UnmarshallToCore(bytes)
+		Expect(err).To(BeNil())
+
+		switch res.Descriptor().Name {
+		case core_mesh.ZoneEgressType:
+			zoneEgress := res.(*core_mesh.ZoneEgressResource)
+			Expect(resourceManager.Create(ctx, zoneEgress, store.CreateBy(core_model.MetaToResourceKey(zoneEgress.GetMeta())))).To(Succeed())
+		case core_mesh.ZoneIngressType:
+			zoneIngress := res.(*core_mesh.ZoneIngressResource)
+			Expect(resourceManager.Create(ctx, zoneIngress, store.CreateBy(core_model.MetaToResourceKey(zoneIngress.GetMeta())))).To(Succeed())
+		case core_mesh.DataplaneType:
+			dataplane := res.(*core_mesh.DataplaneResource)
+			Expect(resourceManager.Create(ctx, dataplane, store.CreateBy(core_model.MetaToResourceKey(dataplane.GetMeta())))).To(Succeed())
+		case core_mesh.MeshType:
+			meshResource := res.(*core_mesh.MeshResource)
+			Expect(resourceManager.Create(ctx, meshResource, store.CreateBy(core_model.MetaToResourceKey(meshResource.GetMeta())))).To(Succeed())
+		case core_mesh.ExternalServiceType:
+			externalService := res.(*core_mesh.ExternalServiceResource)
+			Expect(resourceManager.Create(ctx, externalService, store.CreateBy(core_model.MetaToResourceKey(externalService.GetMeta())))).To(Succeed())
+		}
+	}
+}
+
+var _ = Describe("Proxy Builder", func() {
+	core.Now = func() time.Time {
+		now, _ := time.Parse(time.RFC3339, "2018-07-17T16:05:36.995+00:00")
+		return now
+	}
+	tracker := mockMetadataTracker{}
+	localZone := "zone-1"
+
+	ctx := context.Background()
+	config := kuma_cp.DefaultConfig()
+	config.Multizone.Zone.Name = localZone
+	builder, err := test_runtime.BuilderFor(ctx, config)
+	Expect(err).ToNot(HaveOccurred())
+	rt, err := builder.Build()
+	Expect(err).ToNot(HaveOccurred())
+
+	meshCtxBuilder := xds_context.NewMeshContextBuilder(
+		rt.ReadOnlyResourceManager(),
+		server.MeshResourceTypes(server.HashMeshExcludedResources),
+		rt.LookupIP(),
+		rt.Config().Multizone.Zone.Name,
+		vips.NewPersistence(rt.ReadOnlyResourceManager(), rt.ConfigManager()),
+		rt.Config().DNSServer.Domain,
+	)
+	metrics, err := core_metrics.NewMetrics("cache")
+	Expect(err).ToNot(HaveOccurred())
+	meshCache, err := mesh.NewCache(rt.Config().Store.Cache.ExpirationTime, meshCtxBuilder, metrics)
+	Expect(err).ToNot(HaveOccurred())
+	initializeStore(ctx, rt.ResourceManager(), "default_resources.yaml")
+
+	Describe("Build() zone egress", func() {
+		egressProxyBuilder := sync.DefaultEgressProxyBuilder(
+			ctx,
+			rt,
+			tracker,
+			meshCache,
+			envoy_common.APIV3,
+		)
+
+		It("should build proxy object for egress", func() {
+			// given
+			rk := core_model.ResourceKey{Name: "zone-egress-1"}
+
+			// when
+			proxy, err := egressProxyBuilder.Build(rk)
+			Expect(err).ToNot(HaveOccurred())
+			proxyYaml, err := ToYAML(proxy)
+			Expect(err).ToNot(HaveOccurred())
+
+			// then
+			Expect(proxyYaml).To(matchers.MatchGoldenYAML(filepath.Join("testdata", "01.zone-egress-proxy.golden.yaml")))
+		})
+	})
+
+	Describe("Build() zone ingress", func() {
+		ingressProxyBuilder := sync.DefaultIngressProxyBuilder(
+			rt,
+			tracker,
+			envoy_common.APIV3,
+			meshCache,
+		)
+
+		It("should build proxy object for ingress", func() {
+			// given
+			rk := core_model.ResourceKey{Name: "zone-ingress-zone-1"}
+
+			// when
+			proxy, err := ingressProxyBuilder.Build(rk)
+			Expect(err).ToNot(HaveOccurred())
+			proxyYaml, err := ToYAML(proxy)
+			Expect(err).ToNot(HaveOccurred())
+
+			// then
+			Expect(proxyYaml).To(matchers.MatchGoldenYAML(filepath.Join("testdata", "02.zone-ingress-proxy.golden.yaml")))
+		})
+	})
+})

--- a/pkg/xds/sync/testdata/01.zone-egress-proxy.golden.yaml
+++ b/pkg/xds/sync/testdata/01.zone-egress-proxy.golden.yaml
@@ -1,0 +1,223 @@
+APIVersion: v3
+Dataplane: null
+Id: {}
+Metadata: null
+Policies:
+  CircuitBreakers: null
+  CustomInboundPolicies: null
+  FaultInjections: null
+  HealthChecks: null
+  ProxyTemplate: null
+  RateLimitsInbound: null
+  RateLimitsOutbound: null
+  Retries: null
+  Timeouts: null
+  TrafficLogs: null
+  TrafficPermissions: null
+  TrafficRoutes: null
+  TrafficTrace: null
+Routing:
+  OutboundTargets: null
+  TrafficRoutes: null
+ZoneEgressProxy:
+  MeshResourcesList:
+  - EndpointMap:
+      external-service-1:
+      - ExternalService:
+          AllowRenegotiation: false
+          CaCert: null
+          ClientCert: null
+          ClientKey: null
+          ServerName: ""
+          TLSEnabled: false
+        Locality: null
+        Port: 90
+        Tags:
+          kuma.io/protocol: http
+          kuma.io/service: external-service-1
+          mesh: default
+        Target: host.com
+        UnixDomainPath: ""
+        Weight: 1
+      external-service-in-zone-2:
+      - ExternalService:
+          AllowRenegotiation: false
+          CaCert: null
+          ClientCert: null
+          ClientKey: null
+          ServerName: ""
+          TLSEnabled: false
+        Locality:
+          Priority: 0
+          Zone: zone-2
+        Port: 20003
+        Tags:
+          kuma.io/service: external-service-in-zone-2
+          kuma.io/zone: zone-2
+          mesh: default
+        Target: 7.7.7.7
+        UnixDomainPath: ""
+        Weight: 1
+      external-service-zone-1:
+      - ExternalService:
+          AllowRenegotiation: false
+          CaCert: null
+          ClientCert: null
+          ClientKey: null
+          ServerName: ""
+          TLSEnabled: false
+        Locality:
+          Priority: 0
+          Zone: zone-1
+        Port: 443
+        Tags:
+          kuma.io/service: external-service-zone-1
+          kuma.io/zone: zone-1
+          mesh: default
+        Target: example.com
+        UnixDomainPath: ""
+        Weight: 1
+      service-in-zone-2:
+      - ExternalService: null
+        Locality: null
+        Port: 20003
+        Tags:
+          kuma.io/service: service-in-zone-2
+          mesh: default
+        Target: 7.7.7.7
+        UnixDomainPath: ""
+        Weight: 1
+    ExternalServiceFaultInjections: {}
+    ExternalServicePermissionMap:
+      external-service-1:
+        Meta:
+          CreationTime: "2018-07-17T16:05:36.995Z"
+          Mesh: default
+          ModificationTime: "2018-07-17T16:05:36.995Z"
+          Name: allow-all-default
+          Version: 1
+        Spec:
+          destinations:
+          - match:
+              kuma.io/service: '*'
+          sources:
+          - match:
+              kuma.io/service: '*'
+      external-service-zone-1:
+        Meta:
+          CreationTime: "2018-07-17T16:05:36.995Z"
+          Mesh: default
+          ModificationTime: "2018-07-17T16:05:36.995Z"
+          Name: allow-all-default
+          Version: 1
+        Spec:
+          destinations:
+          - match:
+              kuma.io/service: '*'
+          sources:
+          - match:
+              kuma.io/service: '*'
+    ExternalServiceRateLimits: {}
+    ExternalServices:
+    - Meta:
+        CreationTime: "2018-07-17T16:05:36.995Z"
+        Mesh: default
+        ModificationTime: "2018-07-17T16:05:36.995Z"
+        Name: external-service-1
+        Version: 1
+      Spec:
+        networking:
+          address: host.com:90
+        tags:
+          kuma.io/protocol: http
+          kuma.io/service: external-service-1
+          mesh: default
+    - Meta:
+        CreationTime: "2018-07-17T16:05:36.995Z"
+        Mesh: default
+        ModificationTime: "2018-07-17T16:05:36.995Z"
+        Name: external-service-zone-1
+        Version: 1
+      Spec:
+        networking:
+          address: example.com:443
+        tags:
+          kuma.io/service: external-service-zone-1
+          kuma.io/zone: zone-1
+          mesh: default
+    Mesh:
+      Meta:
+        CreationTime: "2018-07-17T16:05:36.995Z"
+        Mesh: ""
+        ModificationTime: "2018-07-17T16:05:36.995Z"
+        Name: default
+        Version: 1
+      Spec:
+        mtls:
+          backends:
+          - name: builtin
+            type: builtin
+          enabledBackend: builtin
+        routing:
+          zoneEgress: true
+    TrafficRoutes:
+    - Meta:
+        CreationTime: "2018-07-17T16:05:36.995Z"
+        Mesh: default
+        ModificationTime: "2018-07-17T16:05:36.995Z"
+        Name: route-all-default
+        Version: 1
+      Spec:
+        conf:
+          destination:
+            kuma.io/service: '*'
+          load_balancer:
+            LbType:
+              RoundRobin: {}
+        destinations:
+        - match:
+            kuma.io/service: '*'
+        sources:
+        - match:
+            kuma.io/service: '*'
+  ZoneEgressResource:
+    Meta:
+      CreationTime: "2018-07-17T16:05:36.995Z"
+      Mesh: ""
+      ModificationTime: "2018-07-17T16:05:36.995Z"
+      Name: zone-egress-1
+      Version: 1
+    Spec:
+      networking:
+        address: 1.1.1.1
+        port: 10002
+      zone: zone-1
+  ZoneIngresses:
+  - Meta:
+      CreationTime: "2018-07-17T16:05:36.995Z"
+      Mesh: ""
+      ModificationTime: "2018-07-17T16:05:36.995Z"
+      Name: zone-ingress-zone-2
+      Version: 1
+    Spec:
+      availableServices:
+      - instances: 1
+        mesh: default
+        tags:
+          kuma.io/service: service-in-zone-2
+          mesh: default
+      - externalService: true
+        instances: 1
+        mesh: default
+        tags:
+          kuma.io/service: external-service-in-zone-2
+          kuma.io/zone: zone-2
+          mesh: default
+      networking:
+        address: 6.6.6.6
+        advertisedAddress: 7.7.7.7
+        advertisedPort: 20003
+        port: 20002
+      zone: zone-2
+ZoneIngress: null
+ZoneIngressProxy: null

--- a/pkg/xds/sync/testdata/02.zone-ingress-proxy.golden.yaml
+++ b/pkg/xds/sync/testdata/02.zone-ingress-proxy.golden.yaml
@@ -1,0 +1,139 @@
+APIVersion: v3
+Dataplane: null
+Id: {}
+Metadata: null
+Policies:
+  CircuitBreakers: null
+  CustomInboundPolicies: null
+  FaultInjections: null
+  HealthChecks: null
+  ProxyTemplate: null
+  RateLimitsInbound: null
+  RateLimitsOutbound: null
+  Retries: null
+  Timeouts: null
+  TrafficLogs: null
+  TrafficPermissions: null
+  TrafficRoutes: null
+  TrafficTrace: null
+Routing:
+  OutboundTargets:
+    backend:
+    - ExternalService: null
+      Locality: null
+      Port: 8080
+      Tags:
+        kuma.io/service: backend
+        mesh: default
+        version: v1
+      Target: 192.168.0.2
+      UnixDomainPath: ""
+      Weight: 1
+    external-service-zone-1:
+    - ExternalService:
+        AllowRenegotiation: false
+        CaCert: null
+        ClientCert: null
+        ClientKey: null
+        ServerName: ""
+        TLSEnabled: false
+      Locality: null
+      Port: 10002
+      Tags:
+        kuma.io/service: external-service-zone-1
+        kuma.io/zone: zone-1
+        mesh: default
+      Target: 1.1.1.1
+      UnixDomainPath: ""
+      Weight: 1
+    - ExternalService:
+        AllowRenegotiation: false
+        CaCert: null
+        ClientCert: null
+        ClientKey: null
+        ServerName: ""
+        TLSEnabled: false
+      Locality: null
+      Port: 10002
+      Tags:
+        kuma.io/service: external-service-zone-1
+        kuma.io/zone: zone-1
+        mesh: default
+      Target: 1.1.1.2
+      UnixDomainPath: ""
+      Weight: 1
+    frontend:
+    - ExternalService: null
+      Locality: null
+      Port: 8080
+      Tags:
+        kuma.io/service: frontend
+        mesh: default
+        version: v1
+      Target: 192.168.0.1
+      UnixDomainPath: ""
+      Weight: 1
+  TrafficRoutes: null
+ZoneEgressProxy: null
+ZoneIngress:
+  Meta:
+    CreationTime: "2018-07-17T16:05:36.995Z"
+    Mesh: ""
+    ModificationTime: "2018-07-17T16:05:36.995Z"
+    Name: zone-ingress-zone-1
+    Version: 2
+  Spec:
+    availableServices:
+    - instances: 1
+      mesh: default
+      tags:
+        kuma.io/service: backend
+        version: v1
+    - instances: 1
+      mesh: default
+      tags:
+        kuma.io/service: frontend
+        version: v1
+    - externalService: true
+      instances: 1
+      mesh: default
+      tags:
+        kuma.io/service: external-service-zone-1
+        kuma.io/zone: zone-1
+        mesh: default
+    networking:
+      address: 3.3.3.3
+      advertisedAddress: 4.4.4.4
+      advertisedPort: 30004
+      port: 30003
+    zone: zone-1
+ZoneIngressProxy:
+  GatewayRoutes:
+    Items: null
+    Pagination:
+      NextOffset: ""
+      Total: 0
+  TrafficRouteList:
+    Items:
+    - Meta:
+        CreationTime: "2018-07-17T16:05:36.995Z"
+        Mesh: default
+        ModificationTime: "2018-07-17T16:05:36.995Z"
+        Name: route-all-default
+        Version: 1
+      Spec:
+        conf:
+          destination:
+            kuma.io/service: '*'
+          load_balancer:
+            LbType:
+              RoundRobin: {}
+        destinations:
+        - match:
+            kuma.io/service: '*'
+        sources:
+        - match:
+            kuma.io/service: '*'
+    Pagination:
+      NextOffset: ""
+      Total: 1

--- a/pkg/xds/sync/testdata/input/default_resources.yaml
+++ b/pkg/xds/sync/testdata/input/default_resources.yaml
@@ -1,0 +1,104 @@
+type: Mesh
+name: default
+mtls:
+  enabledBackend: builtin
+  backends:
+    - name: builtin
+      type: builtin
+routing:
+  zoneEgress: true
+---
+type: Dataplane
+mesh: default
+name: service-1
+networking:
+  address: 192.168.0.1
+  inbound:
+  - port: 8080
+    servicePort: 80
+    tags:
+      kuma.io/service: frontend
+      version: "v1"
+  outbound:
+  - port: 80
+    address: 1.1.1.1
+    tags:
+      kuma.io/service: backend
+---
+type: Dataplane
+mesh: default
+name: service-2
+networking:
+  address: 192.168.0.2
+  inbound:
+  - port: 8080
+    servicePort: 80
+    tags:
+      kuma.io/service: backend
+      version: "v1"
+---
+type: ZoneIngress
+name: zone-ingress-zone-1
+zone: zone-1
+networking:
+  address: 3.3.3.3
+  advertisedAddress: 4.4.4.4
+  port: 30003
+  advertisedPort: 30004
+availableServices:
+- tags:
+    kuma.io/service: service-in-zone-1
+  instances: 1
+  mesh: default
+---
+type: ZoneIngress
+name: zone-ingress-zone-2
+zone: zone-2
+networking:
+  address: 6.6.6.6
+  advertisedAddress: 7.7.7.7
+  port: 20002
+  advertisedPort: 20003
+availableServices:
+- tags:
+    kuma.io/service: service-in-zone-2
+  instances: 1
+  mesh: default
+- tags:
+    kuma.io/service: external-service-in-zone-2
+    kuma.io/zone: "zone-2"
+  instances: 1
+  mesh: default
+  externalService: true
+---
+type: ZoneEgress
+name: zone-egress-1
+zone: zone-1
+networking:
+  address: 1.1.1.1
+  port: 10002
+---
+type: ZoneEgress
+name: zone-egress-2
+zone: zone-1
+networking:
+  address: 1.1.1.2
+  port: 10002
+---
+type: ExternalService
+name: external-service-1
+mesh: default
+tags:
+  kuma.io/service: external-service-1
+  kuma.io/protocol: http
+networking:
+  address: host.com:90
+---
+type: ExternalService
+name: external-service-zone-1
+mesh: default
+tags:
+  kuma.io/service: external-service-zone-1
+  kuma.io/zone: zone-1
+networking:
+  address: example.com:443


### PR DESCRIPTION
### Summary

Added test for Proxy builder. Changed `time.Now()` to `core.Now()` for better testing so if we want this test it's better to merge it after release

### Full changelog

* [Implement test for proxy builder for zone egress and zone ingress]
* [Changed `time.Now` to `core.Now` where necessary]

### Issues resolved

Fix #XXX

### Documentation

- [ ] Link to the website [documentation PR](https://github.com/kumahq/kuma-website/pull/XXX)

### Testing

- [X] Unit tests
- [ ] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes

### Backwards compatibility

- [ ] Update [`UPGRADE.md`](/UPGRADE.md) with any steps users will need to take when upgrading.
- [ ] Add `backport-to-stable` label if the code follows our [backporting policy](/CONTRIBUTING.md#backporting)
