### PR TITLE
feat(helm): allow specifying security context

### DIFF
--- a/app/kuma-cp/cmd/root.go
+++ b/app/kuma-cp/cmd/root.go
@@ -11,6 +11,7 @@ import (
 	"github.com/kumahq/kuma/pkg/cmd/version"
 	"github.com/kumahq/kuma/pkg/core"
 	kuma_log "github.com/kumahq/kuma/pkg/log"
+
 	// import Envoy protobuf definitions so (un)marshaling Envoy protobuf works
 	_ "github.com/kumahq/kuma/pkg/xds/envoy"
 )

--- a/app/kumactl/cmd/install/testdata/install-control-plane.cni-enabled.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.cni-enabled.golden.yaml
@@ -1592,11 +1592,13 @@ spec:
       # Minimize downtime during a rolling upgrade or deletion; tell Kubernetes to do a "force
       # deletion": https://kubernetes.io/docs/concepts/workloads/pods/pod/#termination-of-pods.
       terminationGracePeriodSeconds: 5
+        
       containers:
         - name: install-cni
           image: "docker.io/kumahq/install-cni:0.0.9"
           imagePullPolicy: Always
           command: ["/install-cni.sh"]
+          
           env:
             # Name of the CNI config file to create.
             - name: CNI_CONF_NAME
@@ -1668,6 +1670,7 @@ spec:
                   values:
                   - kuma-control-plane
               topologyKey: kubernetes.io/hostname
+      
       serviceAccountName: kuma-control-plane
       nodeSelector:
         
@@ -1677,6 +1680,7 @@ spec:
         - name: control-plane
           image: "docker.io/kumahq/kuma-cp:0.0.1"
           imagePullPolicy: IfNotPresent
+          
           env:
             - name: KUMA_API_SERVER_AUTHN_LOCALHOST_IS_ADMIN
               value: "false"

--- a/app/kumactl/cmd/install/testdata/install-control-plane.defaults.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.defaults.golden.yaml
@@ -1493,6 +1493,7 @@ spec:
                   values:
                   - kuma-control-plane
               topologyKey: kubernetes.io/hostname
+      
       serviceAccountName: kuma-control-plane
       nodeSelector:
         
@@ -1502,6 +1503,7 @@ spec:
         - name: control-plane
           image: "docker.io/kumahq/kuma-cp:0.0.1"
           imagePullPolicy: IfNotPresent
+          
           env:
             - name: KUMA_API_SERVER_AUTHN_LOCALHOST_IS_ADMIN
               value: "false"

--- a/app/kumactl/cmd/install/testdata/install-control-plane.dump-values.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.dump-values.yaml
@@ -241,7 +241,7 @@ cni:
     # -- CNI image tag
     tag: "0.0.9"
 
-  # -- Security context at the pod level for control plane.
+  # -- Security context at the pod level for cni
   podSecurityContext:
     #The values below are examples. More values can be added as needed, since the field resolves as free form.
     #runAsNonRoot: true
@@ -251,7 +251,7 @@ cni:
     #fsGroupChangePolicy:
     #to support additional pod level securityContext parameters, please check:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#podsecuritycontext-v1-core 
   
-  # -- Security context at the container level for control plane.
+  # -- Security context at the container level for cni
   containerSecurityContext: #for overlapping securityContext between pod and container, the container's value take precedence
     #The values below are examples. More values can be added as needed, since the field resolves as free form.
     #allowPrivilegeEscalation: false
@@ -308,7 +308,7 @@ ingress:
   # -- Affinity placement rule for the Kuma Ingress pods
   affinity: {}
 
-  # -- Security context at the pod level for control plane.
+  # -- Security context at the pod level for ingress
   podSecurityContext:
     #The values below are examples. More values can be added as needed, since the field resolves as free form.
     #runAsNonRoot: true
@@ -318,7 +318,7 @@ ingress:
     #fsGroupChangePolicy:
     #to support additional pod level securityContext parameters, please check:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#podsecuritycontext-v1-core 
   
-  # -- Security context at the container level for control plane.
+  # -- Security context at the container level for ingress
   containerSecurityContext: #for overlapping securityContext between pod and container, the container's value take precedence
     #The values below are examples. More values can be added as needed, since the field resolves as free form.
     #allowPrivilegeEscalation: false
@@ -360,7 +360,7 @@ egress:
   # -- Affinity placement rule for the Kuma Ingress pods
   affinity: {}
 
-  # -- Security context at the pod level for control plane.
+  # -- Security context at the pod level for egress
   podSecurityContext:
     #The values below are examples. More values can be added as needed, since the field resolves as free form.
     #runAsNonRoot: true
@@ -370,7 +370,7 @@ egress:
     #fsGroupChangePolicy:
     #to support additional pod level securityContext parameters, please check:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#podsecuritycontext-v1-core 
   
-  # -- Security context at the container level for control plane.
+  # -- Security context at the container level for egress
   containerSecurityContext: #for overlapping securityContext between pod and container, the container's value take precedence
     #The values below are examples. More values can be added as needed, since the field resolves as free form.
     #allowPrivilegeEscalation: false
@@ -407,8 +407,7 @@ hooks:
     kubernetes.io/os: linux
     kubernetes.io/arch: amd64
 
-  #The below context is used in 3 places:Jobs (crd/webhook/ns)
-  # -- Security context at the pod level for control plane.
+  # -- Security context at the pod level for crd/webhook/ns
   podSecurityContext:
     #The values below are examples. More values can be added as needed, since the field resolves as free form.
     #runAsNonRoot: true
@@ -418,7 +417,7 @@ hooks:
     #fsGroupChangePolicy:
     #to support additional pod level securityContext parameters, please check:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#podsecuritycontext-v1-core 
   
-  # -- Security context at the container level for control plane.
+  # -- Security context at the container level for crd/webhook/ns
   containerSecurityContext: #for overlapping securityContext between pod and container, the container's value take precedence
     #The values below are examples. More values can be added as needed, since the field resolves as free form.
     #allowPrivilegeEscalation: false

--- a/app/kumactl/cmd/install/testdata/install-control-plane.dump-values.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.dump-values.yaml
@@ -180,6 +180,41 @@ controlPlane:
       # -- Additional rules to apply on Kuma owner reference webhook. Useful when building custom policy on top of Kuma.
       additionalRules: ""
 
+  # -- Security context at the pod level for control plane. 
+  podSecurityContext:
+    #The values below are examples. More values can be added as needed, since the field resolves as free form.
+    # -- Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does.
+    #runAsNonRoot: true
+    # -- The UID to run the entrypoint of the container process.
+    #runAsUser: 1000
+    # -- The GID to run the entrypoint of the container process. 
+    #runAsGroup: 3000
+    # -- A special supplemental group that applies to all containers in a pod
+    #fsGroup: 2000
+    #fsGroupChangePolicy:
+    #to support additional pod level securityContext parameters, please check:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#podsecuritycontext-v1-core 
+  
+  # -- Security context at the container level for control plane.
+  containerSecurityContext: #for overlapping securityContext between pod and container, the container's value take precedence
+    #The values below are examples. More values can be added as needed, since the field resolves as free form.
+    # -- Controls whether a process can gain more privileges than its parent process. 
+    #allowPrivilegeEscalation: false
+    # -- The capabilities to add/drop when running containers
+    #capabilities:
+    #  drop:
+    #    - all
+    # -- Whether this container has a read-only root filesystem.   
+    #readOnlyRootFilesystem: true
+    # -- Run container in privileged mode. Processes in privileged containers are essentially equivalent to root on the host.
+    #privileged: false
+    # -- Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does.
+    #runAsNonRoot: true
+    # -- The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext.
+    #runAsUser: 1000
+    # -- The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in PodSecurityContext.
+    #runAsGroup: 3000
+    #to support additional container level securityContext parameters, please check:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#securitycontext-v1-core
+
 cni:
   # -- Install Kuma with CNI instead of proxy init container
   enabled: false
@@ -205,6 +240,30 @@ cni:
     repository: "kumahq/install-cni"
     # -- CNI image tag
     tag: "0.0.9"
+
+  # -- Security context at the pod level for control plane.
+  podSecurityContext:
+    #The values below are examples. More values can be added as needed, since the field resolves as free form.
+    #runAsNonRoot: true
+    #runAsUser: 1000
+    #runAsGroup: 3000
+    #fsGroup: 2000
+    #fsGroupChangePolicy:
+    #to support additional pod level securityContext parameters, please check:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#podsecuritycontext-v1-core 
+  
+  # -- Security context at the container level for control plane.
+  containerSecurityContext: #for overlapping securityContext between pod and container, the container's value take precedence
+    #The values below are examples. More values can be added as needed, since the field resolves as free form.
+    #allowPrivilegeEscalation: false
+    #capabilities:
+    #  drop:
+    #    - all 
+    #readOnlyRootFilesystem: true
+    #privileged: false
+    #runAsNonRoot: true
+    #runAsUser: 1000
+    #runAsGroup: 3000
+    #to support additional container level securityContext parameters, please check:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#securitycontext-v1-core
 
 dataPlane:
   image:
@@ -249,6 +308,30 @@ ingress:
   # -- Affinity placement rule for the Kuma Ingress pods
   affinity: {}
 
+  # -- Security context at the pod level for control plane.
+  podSecurityContext:
+    #The values below are examples. More values can be added as needed, since the field resolves as free form.
+    #runAsNonRoot: true
+    #runAsUser: 1000
+    #runAsGroup: 3000
+    #fsGroup: 2000
+    #fsGroupChangePolicy:
+    #to support additional pod level securityContext parameters, please check:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#podsecuritycontext-v1-core 
+  
+  # -- Security context at the container level for control plane.
+  containerSecurityContext: #for overlapping securityContext between pod and container, the container's value take precedence
+    #The values below are examples. More values can be added as needed, since the field resolves as free form.
+    #allowPrivilegeEscalation: false
+    #capabilities:
+    #  drop:
+    #    - all 
+    #readOnlyRootFilesystem: true
+    #privileged: false
+    #runAsNonRoot: true
+    #runAsUser: 1000
+    #runAsGroup: 3000
+    #to support additional container level securityContext parameters, please check:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#securitycontext-v1-core
+
 egress:
   # -- If true, it deploys Egress for cross cluster communication
   enabled: false
@@ -277,6 +360,30 @@ egress:
   # -- Affinity placement rule for the Kuma Ingress pods
   affinity: {}
 
+  # -- Security context at the pod level for control plane.
+  podSecurityContext:
+    #The values below are examples. More values can be added as needed, since the field resolves as free form.
+    #runAsNonRoot: true
+    #runAsUser: 1000
+    #runAsGroup: 3000
+    #fsGroup: 2000
+    #fsGroupChangePolicy:
+    #to support additional pod level securityContext parameters, please check:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#podsecuritycontext-v1-core 
+  
+  # -- Security context at the container level for control plane.
+  containerSecurityContext: #for overlapping securityContext between pod and container, the container's value take precedence
+    #The values below are examples. More values can be added as needed, since the field resolves as free form.
+    #allowPrivilegeEscalation: false
+    #capabilities:
+    #  drop:
+    #    - all 
+    #readOnlyRootFilesystem: true
+    #privileged: false
+    #runAsNonRoot: true
+    #runAsUser: 1000
+    #runAsGroup: 3000
+    #to support additional container level securityContext parameters, please check:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#securitycontext-v1-core
+
 kumactl:
   image:
     # -- The kumactl image repository
@@ -299,6 +406,31 @@ hooks:
   nodeSelector:
     kubernetes.io/os: linux
     kubernetes.io/arch: amd64
+
+  #The below context is used in 3 places:Jobs (crd/webhook/ns)
+  # -- Security context at the pod level for control plane.
+  podSecurityContext:
+    #The values below are examples. More values can be added as needed, since the field resolves as free form.
+    #runAsNonRoot: true
+    #runAsUser: 1000
+    #runAsGroup: 3000
+    #fsGroup: 2000
+    #fsGroupChangePolicy:
+    #to support additional pod level securityContext parameters, please check:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#podsecuritycontext-v1-core 
+  
+  # -- Security context at the container level for control plane.
+  containerSecurityContext: #for overlapping securityContext between pod and container, the container's value take precedence
+    #The values below are examples. More values can be added as needed, since the field resolves as free form.
+    #allowPrivilegeEscalation: false
+    #capabilities:
+    #  drop:
+    #    - all 
+    #readOnlyRootFilesystem: true
+    #privileged: false
+    #runAsNonRoot: true
+    #runAsUser: 1000
+    #runAsGroup: 3000
+    #to support additional container level securityContext parameters, please check:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#securitycontext-v1-core
 
 experimental:
   # -- If true, it installs experimental built-in Gateway support

--- a/app/kumactl/cmd/install/testdata/install-control-plane.global.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.global.golden.yaml
@@ -1503,6 +1503,7 @@ spec:
                   values:
                   - kuma-control-plane
               topologyKey: kubernetes.io/hostname
+      
       serviceAccountName: kuma-control-plane
       nodeSelector:
         
@@ -1512,6 +1513,7 @@ spec:
         - name: control-plane
           image: "docker.io/kumahq/kuma-cp:0.0.1"
           imagePullPolicy: IfNotPresent
+          
           env:
             - name: KUMA_API_SERVER_AUTHN_LOCALHOST_IS_ADMIN
               value: "false"

--- a/app/kumactl/cmd/install/testdata/install-control-plane.override-env-vars.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.override-env-vars.golden.yaml
@@ -1493,6 +1493,7 @@ spec:
                   values:
                   - kuma-control-plane
               topologyKey: kubernetes.io/hostname
+      
       serviceAccountName: kuma-control-plane
       nodeSelector:
         
@@ -1502,6 +1503,7 @@ spec:
         - name: control-plane
           image: "docker.io/kumahq/kuma-cp:0.0.1"
           imagePullPolicy: IfNotPresent
+          
           env:
             - name: KUMA_API_SERVER_AUTHN_LOCALHOST_IS_ADMIN
               value: "false"

--- a/app/kumactl/cmd/install/testdata/install-control-plane.overrides.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.overrides.golden.yaml
@@ -1896,6 +1896,7 @@ spec:
                   values:
                   - kuma-control-plane
               topologyKey: kubernetes.io/hostname
+      
       serviceAccountName: kuma-control-plane
       nodeSelector:
         
@@ -1905,6 +1906,7 @@ spec:
         - name: control-plane
           image: "kuma-ci/kuma-cp:greatest"
           imagePullPolicy: Never
+          
           env:
             - name: KUMA_API_SERVER_AUTHN_LOCALHOST_IS_ADMIN
               value: "false"

--- a/app/kumactl/cmd/install/testdata/install-control-plane.with-egress.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.with-egress.golden.yaml
@@ -1522,6 +1522,7 @@ spec:
                   values:
                   - kuma-control-plane
               topologyKey: kubernetes.io/hostname
+      
       serviceAccountName: kuma-control-plane
       nodeSelector:
         
@@ -1531,6 +1532,7 @@ spec:
         - name: control-plane
           image: "docker.io/kumahq/kuma-cp:0.0.1"
           imagePullPolicy: IfNotPresent
+          
           env:
             - name: KUMA_API_SERVER_AUTHN_LOCALHOST_IS_ADMIN
               value: "false"
@@ -1663,6 +1665,7 @@ spec:
                   values:
                   - kuma-egress
               topologyKey: kubernetes.io/hostname
+      
       serviceAccountName: kuma-egress
       nodeSelector:
       
@@ -1672,6 +1675,7 @@ spec:
         - name: egress
           image: "docker.io/kumahq/kuma-dp:0.0.1"
           imagePullPolicy: IfNotPresent
+          
           env:
             - name: POD_NAME
               valueFrom:

--- a/app/kumactl/cmd/install/testdata/install-control-plane.with-helm-set.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.with-helm-set.yaml
@@ -1555,6 +1555,7 @@ spec:
                   values:
                   - kuma-control-plane
               topologyKey: kubernetes.io/hostname
+      
       serviceAccountName: kuma-control-plane
       nodeSelector:
         
@@ -1564,6 +1565,7 @@ spec:
         - name: control-plane
           image: "docker.io/kumahq/kuma-cp:0.0.1"
           imagePullPolicy: IfNotPresent
+          
           env:
             - name: KUMA_API_SERVER_AUTHN_LOCALHOST_IS_ADMIN
               value: "false"
@@ -1700,6 +1702,7 @@ spec:
                   values:
                   - kuma-egress
               topologyKey: kubernetes.io/hostname
+      
       serviceAccountName: kuma-egress
       nodeSelector:
       
@@ -1709,6 +1712,7 @@ spec:
         - name: egress
           image: "docker.io/kumahq/kuma-dp:0.0.1"
           imagePullPolicy: IfNotPresent
+          
           env:
             - name: POD_NAME
               valueFrom:
@@ -1810,6 +1814,7 @@ spec:
                   values:
                   - kuma-ingress
               topologyKey: kubernetes.io/hostname
+      
       serviceAccountName: kuma-ingress
       nodeSelector:
       
@@ -1819,6 +1824,7 @@ spec:
         - name: ingress
           image: "docker.io/kumahq/kuma-dp:0.0.1"
           imagePullPolicy: IfNotPresent
+          
           env:
             - name: POD_NAME
               valueFrom:

--- a/app/kumactl/cmd/install/testdata/install-control-plane.with-helm-values.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.with-helm-values.yaml
@@ -1493,6 +1493,7 @@ spec:
                   values:
                   - kuma-control-plane
               topologyKey: kubernetes.io/hostname
+      
       serviceAccountName: kuma-control-plane
       nodeSelector:
         
@@ -1502,6 +1503,7 @@ spec:
         - name: control-plane
           image: "docker.io/kumahq/kuma-cp:0.0.1"
           imagePullPolicy: IfNotPresent
+          
           env:
             - name: KUMA_API_SERVER_AUTHN_LOCALHOST_IS_ADMIN
               value: "false"

--- a/app/kumactl/cmd/install/testdata/install-control-plane.with-ingress.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.with-ingress.golden.yaml
@@ -1526,6 +1526,7 @@ spec:
                   values:
                   - kuma-control-plane
               topologyKey: kubernetes.io/hostname
+      
       serviceAccountName: kuma-control-plane
       nodeSelector:
         
@@ -1535,6 +1536,7 @@ spec:
         - name: control-plane
           image: "docker.io/kumahq/kuma-cp:0.0.1"
           imagePullPolicy: IfNotPresent
+          
           env:
             - name: KUMA_API_SERVER_AUTHN_LOCALHOST_IS_ADMIN
               value: "false"
@@ -1671,6 +1673,7 @@ spec:
                   values:
                   - kuma-ingress
               topologyKey: kubernetes.io/hostname
+      
       serviceAccountName: kuma-ingress
       nodeSelector:
       
@@ -1680,6 +1683,7 @@ spec:
         - name: ingress
           image: "docker.io/kumahq/kuma-dp:0.0.1"
           imagePullPolicy: IfNotPresent
+          
           env:
             - name: POD_NAME
               valueFrom:

--- a/app/kumactl/cmd/install/testdata/install-control-plane.zone.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.zone.golden.yaml
@@ -1497,6 +1497,7 @@ spec:
                   values:
                   - kuma-control-plane
               topologyKey: kubernetes.io/hostname
+      
       serviceAccountName: kuma-control-plane
       nodeSelector:
         
@@ -1506,6 +1507,7 @@ spec:
         - name: control-plane
           image: "docker.io/kumahq/kuma-cp:0.0.1"
           imagePullPolicy: IfNotPresent
+          
           env:
             - name: KUMA_API_SERVER_AUTHN_LOCALHOST_IS_ADMIN
               value: "false"

--- a/app/kumactl/cmd/root.go
+++ b/app/kumactl/cmd/root.go
@@ -22,8 +22,10 @@ import (
 	kuma_cmd "github.com/kumahq/kuma/pkg/cmd"
 	"github.com/kumahq/kuma/pkg/core"
 	kuma_log "github.com/kumahq/kuma/pkg/log"
+
 	// Register gateway resources.
 	_ "github.com/kumahq/kuma/pkg/plugins/runtime/gateway/register"
+
 	// import Envoy protobuf definitions so (un)marshaling Envoy protobuf works
 	_ "github.com/kumahq/kuma/pkg/xds/envoy"
 )

--- a/deployments/charts/kuma/templates/cni-daemonset.yaml
+++ b/deployments/charts/kuma/templates/cni-daemonset.yaml
@@ -45,11 +45,19 @@ spec:
       # Minimize downtime during a rolling upgrade or deletion; tell Kubernetes to do a "force
       # deletion": https://kubernetes.io/docs/concepts/workloads/pods/pod/#termination-of-pods.
       terminationGracePeriodSeconds: 5
+      {{ if .Values.cni.podSecurityContext }}
+      securityContext:
+      {{ toYaml .Values.cni.podSecurityContext | trim | nindent 8 }}
+      {{- end }}  
       containers:
         - name: install-cni
           image: {{ include "kuma.formatImage" (dict "image" .Values.cni.image "root" $) | quote }}
           imagePullPolicy: Always
           command: ["/install-cni.sh"]
+          {{ if .Values.cni.containerSecurityContext }}
+          securityContext:
+          {{ toYaml .Values.cni.containerSecurityContext | trim | nindent 12 }}
+          {{- end }}
           env:
             # Name of the CNI config file to create.
             - name: CNI_CONF_NAME

--- a/deployments/charts/kuma/templates/cp-deployment.yaml
+++ b/deployments/charts/kuma/templates/cp-deployment.yaml
@@ -42,6 +42,10 @@ spec:
                   - {{ include "kuma.name" . }}-control-plane
               topologyKey: kubernetes.io/hostname
       {{- end }}
+      {{ if .Values.controlPlane.podSecurityContext }}
+      securityContext:
+      {{ toYaml .Values.controlPlane.podSecurityContext | trim | nindent 8 }}
+      {{- end }}
       serviceAccountName: {{ include "kuma.name" . }}-control-plane
       {{- with .Values.controlPlane.nodeSelector }}
       nodeSelector:
@@ -51,6 +55,10 @@ spec:
         - name: control-plane
           image: {{ include "kuma.formatImage" (dict "image" .Values.controlPlane.image "root" $) | quote }}
           imagePullPolicy: {{ .Values.controlPlane.image.pullPolicy }}
+          {{ if .Values.controlPlane.containerSecurityContext }}
+          securityContext:
+          {{ toYaml .Values.controlPlane.containerSecurityContext | trim | nindent 12 }}
+          {{- end }}
           env:
           {{-  $defaultEnv := include "kuma.defaultEnv" . | fromYaml | pluck "env" | first }}
           {{- $defaultEnvDict := dict }}

--- a/deployments/charts/kuma/templates/egress-deployment.yaml
+++ b/deployments/charts/kuma/templates/egress-deployment.yaml
@@ -47,6 +47,10 @@ spec:
                   - {{ include "kuma.name" . }}-egress
               topologyKey: kubernetes.io/hostname
       {{- end }}
+      {{ if .Values.egress.podSecurityContext }}
+      securityContext:
+      {{ toYaml .Values.egress.podSecurityContext | trim | nindent 8 }}
+      {{- end }}
       serviceAccountName: {{ include "kuma.name" . }}-egress
       {{- with .Values.egress.nodeSelector }}
       nodeSelector:
@@ -56,6 +60,10 @@ spec:
         - name: egress
           image: {{ include "kuma.formatImage" (dict "image" .Values.dataPlane.image "root" $) | quote }}
           imagePullPolicy: {{ .Values.dataPlane.image.pullPolicy }}
+          {{ if .Values.egress.containerSecurityContext }}
+          securityContext:
+          {{ toYaml .Values.egress.containerSecurityContext | trim | nindent 12 }}
+          {{- end }}
           env:
             - name: POD_NAME
               valueFrom:

--- a/deployments/charts/kuma/templates/ingress-deployment.yaml
+++ b/deployments/charts/kuma/templates/ingress-deployment.yaml
@@ -47,6 +47,10 @@ spec:
                   - {{ include "kuma.name" . }}-ingress
               topologyKey: kubernetes.io/hostname
       {{- end }}
+      {{ if .Values.ingress.podSecurityContext }}
+      securityContext:
+      {{ toYaml .Values.ingress.podSecurityContext | trim | nindent 8 }}
+      {{- end }}
       serviceAccountName: {{ include "kuma.name" . }}-ingress
       {{- with .Values.ingress.nodeSelector }}
       nodeSelector:
@@ -56,6 +60,10 @@ spec:
         - name: ingress
           image: {{ include "kuma.formatImage" (dict "image" .Values.dataPlane.image "root" $) | quote }}
           imagePullPolicy: {{ .Values.dataPlane.image.pullPolicy }}
+          {{ if .Values.ingress.containerSecurityContext }}
+          securityContext:
+          {{ toYaml .Values.ingress.containerSecurityContext | trim | nindent 12 }}
+          {{- end }}
           env:
             - name: POD_NAME
               valueFrom:

--- a/deployments/charts/kuma/templates/pre-delete-webhooks.yaml
+++ b/deployments/charts/kuma/templates/pre-delete-webhooks.yaml
@@ -81,6 +81,10 @@ spec:
       {{ toYaml . | nindent 8 }}
       {{- end }}
       restartPolicy: OnFailure
+      {{ if .Values.hooks.podSecurityContext }}
+      securityContext:
+      {{ toYaml .Values.hooks.podSecurityContext | trim | nindent 8 }}
+      {{- end }}   
       containers:
         - name: pre-delete-job
           image: {{ include "kubectl.formatImage" (dict "image" .Values.kubectl.image "root" $) | quote }}
@@ -89,3 +93,7 @@ spec:
             - 'delete'
             - 'ValidatingWebhookConfiguration'
             - {{ include "kuma.name" . }}-validating-webhook-configuration
+          {{ if .Values.hooks.containerSecurityContext }}
+          securityContext:
+          {{ toYaml .Values.hooks.containerSecurityContext | trim | nindent 12 }}
+          {{- end }}

--- a/deployments/charts/kuma/templates/pre-install-patch-namespace-job.yaml
+++ b/deployments/charts/kuma/templates/pre-install-patch-namespace-job.yaml
@@ -82,9 +82,17 @@ spec:
       {{ toYaml . | nindent 8 }}
       {{- end }}
       restartPolicy: OnFailure
+      {{ if .Values.hooks.podSecurityContext }}
+      securityContext:
+      {{ toYaml .Values.hooks.podSecurityContext | trim | nindent 8 }}
+      {{- end }}  
       containers:
         - name: pre-install-job
           image: {{ include "kubectl.formatImage" (dict "image" .Values.kubectl.image "root" $) | quote }}
+          {{ if .Values.hooks.containerSecurityContext }}
+          securityContext:
+          {{ toYaml .Values.hooks.containerSecurityContext | trim | nindent 12 }}
+          {{- end }}   
           command:
             - 'kubectl'
             - 'patch'

--- a/deployments/charts/kuma/templates/pre-upgrade-install-missing-crds-job.yaml
+++ b/deployments/charts/kuma/templates/pre-upgrade-install-missing-crds-job.yaml
@@ -114,9 +114,17 @@ spec:
       {{ toYaml . | nindent 8 }}
       {{- end }}
       restartPolicy: OnFailure
+      {{ if .Values.hooks.podSecurityContext }}
+      securityContext:
+      {{ toYaml .Values.hooks.podSecurityContext | trim | nindent 8 }}
+      {{- end }}  
       containers:
         - name: pre-upgrade-job
           image: {{ include "kubectl.formatImage" (dict "image" .Values.kubectl.image "root" $) | quote }}
+          {{ if .Values.hooks.containerSecurityContext }}
+          securityContext:
+          {{ toYaml .Values.hooks.containerSecurityContext | trim | nindent 12 }}
+          {{- end }}  
           command:
             - '/kuma/scripts/install_missing_crds.sh'
           volumeMounts:
@@ -129,6 +137,10 @@ spec:
       initContainers:
         - name: pre-upgrade-job-init
           image: {{ include "kuma.formatImage" (dict "image" .Values.kumactl.image "root" $) | quote }}
+          {{ if .Values.hooks.containerSecurityContext }}
+          securityContext:
+          {{ toYaml .Values.hooks.containerSecurityContext | trim | nindent 12 }}
+          {{- end }}  
           volumeMounts:
           - mountPath: /kuma/missing
             name: missing-crds

--- a/deployments/charts/kuma/values.yaml
+++ b/deployments/charts/kuma/values.yaml
@@ -241,7 +241,7 @@ cni:
     # -- CNI image tag
     tag: "0.0.9"
 
-  # -- Security context at the pod level for control plane.
+  # -- Security context at the pod level for cni
   podSecurityContext:
     #The values below are examples. More values can be added as needed, since the field resolves as free form.
     #runAsNonRoot: true
@@ -251,7 +251,7 @@ cni:
     #fsGroupChangePolicy:
     #to support additional pod level securityContext parameters, please check:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#podsecuritycontext-v1-core 
   
-  # -- Security context at the container level for control plane.
+  # -- Security context at the container level for cni
   containerSecurityContext: #for overlapping securityContext between pod and container, the container's value take precedence
     #The values below are examples. More values can be added as needed, since the field resolves as free form.
     #allowPrivilegeEscalation: false
@@ -308,7 +308,7 @@ ingress:
   # -- Affinity placement rule for the Kuma Ingress pods
   affinity: {}
 
-  # -- Security context at the pod level for control plane.
+  # -- Security context at the pod level for ingress
   podSecurityContext:
     #The values below are examples. More values can be added as needed, since the field resolves as free form.
     #runAsNonRoot: true
@@ -318,7 +318,7 @@ ingress:
     #fsGroupChangePolicy:
     #to support additional pod level securityContext parameters, please check:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#podsecuritycontext-v1-core 
   
-  # -- Security context at the container level for control plane.
+  # -- Security context at the container level for ingress
   containerSecurityContext: #for overlapping securityContext between pod and container, the container's value take precedence
     #The values below are examples. More values can be added as needed, since the field resolves as free form.
     #allowPrivilegeEscalation: false
@@ -360,7 +360,7 @@ egress:
   # -- Affinity placement rule for the Kuma Ingress pods
   affinity: {}
 
-  # -- Security context at the pod level for control plane.
+  # -- Security context at the pod level for egress
   podSecurityContext:
     #The values below are examples. More values can be added as needed, since the field resolves as free form.
     #runAsNonRoot: true
@@ -370,7 +370,7 @@ egress:
     #fsGroupChangePolicy:
     #to support additional pod level securityContext parameters, please check:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#podsecuritycontext-v1-core 
   
-  # -- Security context at the container level for control plane.
+  # -- Security context at the container level for egress
   containerSecurityContext: #for overlapping securityContext between pod and container, the container's value take precedence
     #The values below are examples. More values can be added as needed, since the field resolves as free form.
     #allowPrivilegeEscalation: false
@@ -408,7 +408,7 @@ hooks:
     kubernetes.io/arch: amd64
 
   #The below context is used in 3 places:Jobs (crd/webhook/ns)
-  # -- Security context at the pod level for control plane.
+  # -- Security context at the pod level for crd/webhook/ns
   podSecurityContext:
     #The values below are examples. More values can be added as needed, since the field resolves as free form.
     #runAsNonRoot: true
@@ -418,7 +418,7 @@ hooks:
     #fsGroupChangePolicy:
     #to support additional pod level securityContext parameters, please check:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#podsecuritycontext-v1-core 
   
-  # -- Security context at the container level for control plane.
+  # -- Security context at the container level for crd/webhook/ns
   containerSecurityContext: #for overlapping securityContext between pod and container, the container's value take precedence
     #The values below are examples. More values can be added as needed, since the field resolves as free form.
     #allowPrivilegeEscalation: false

--- a/deployments/charts/kuma/values.yaml
+++ b/deployments/charts/kuma/values.yaml
@@ -180,6 +180,41 @@ controlPlane:
       # -- Additional rules to apply on Kuma owner reference webhook. Useful when building custom policy on top of Kuma.
       additionalRules: ""
 
+  # -- Security context at the pod level for control plane. 
+  podSecurityContext:
+    #The values below are examples. More values can be added as needed, since the field resolves as free form.
+    # -- Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does.
+    #runAsNonRoot: true
+    # -- The UID to run the entrypoint of the container process.
+    #runAsUser: 1000
+    # -- The GID to run the entrypoint of the container process. 
+    #runAsGroup: 3000
+    # -- A special supplemental group that applies to all containers in a pod
+    #fsGroup: 2000
+    #fsGroupChangePolicy:
+    #to support additional pod level securityContext parameters, please check:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#podsecuritycontext-v1-core 
+  
+  # -- Security context at the container level for control plane.
+  containerSecurityContext: #for overlapping securityContext between pod and container, the container's value take precedence
+    #The values below are examples. More values can be added as needed, since the field resolves as free form.
+    # -- Controls whether a process can gain more privileges than its parent process. 
+    #allowPrivilegeEscalation: false
+    # -- The capabilities to add/drop when running containers
+    #capabilities:
+    #  drop:
+    #    - all
+    # -- Whether this container has a read-only root filesystem.   
+    #readOnlyRootFilesystem: true
+    # -- Run container in privileged mode. Processes in privileged containers are essentially equivalent to root on the host.
+    #privileged: false
+    # -- Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does.
+    #runAsNonRoot: true
+    # -- The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext.
+    #runAsUser: 1000
+    # -- The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in PodSecurityContext.
+    #runAsGroup: 3000
+    #to support additional container level securityContext parameters, please check:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#securitycontext-v1-core
+
 cni:
   # -- Install Kuma with CNI instead of proxy init container
   enabled: false
@@ -205,6 +240,30 @@ cni:
     repository: "kumahq/install-cni"
     # -- CNI image tag
     tag: "0.0.9"
+
+  # -- Security context at the pod level for control plane.
+  podSecurityContext:
+    #The values below are examples. More values can be added as needed, since the field resolves as free form.
+    #runAsNonRoot: true
+    #runAsUser: 1000
+    #runAsGroup: 3000
+    #fsGroup: 2000
+    #fsGroupChangePolicy:
+    #to support additional pod level securityContext parameters, please check:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#podsecuritycontext-v1-core 
+  
+  # -- Security context at the container level for control plane.
+  containerSecurityContext: #for overlapping securityContext between pod and container, the container's value take precedence
+    #The values below are examples. More values can be added as needed, since the field resolves as free form.
+    #allowPrivilegeEscalation: false
+    #capabilities:
+    #  drop:
+    #    - all 
+    #readOnlyRootFilesystem: true
+    #privileged: false
+    #runAsNonRoot: true
+    #runAsUser: 1000
+    #runAsGroup: 3000
+    #to support additional container level securityContext parameters, please check:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#securitycontext-v1-core
 
 dataPlane:
   image:
@@ -249,6 +308,30 @@ ingress:
   # -- Affinity placement rule for the Kuma Ingress pods
   affinity: {}
 
+  # -- Security context at the pod level for control plane.
+  podSecurityContext:
+    #The values below are examples. More values can be added as needed, since the field resolves as free form.
+    #runAsNonRoot: true
+    #runAsUser: 1000
+    #runAsGroup: 3000
+    #fsGroup: 2000
+    #fsGroupChangePolicy:
+    #to support additional pod level securityContext parameters, please check:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#podsecuritycontext-v1-core 
+  
+  # -- Security context at the container level for control plane.
+  containerSecurityContext: #for overlapping securityContext between pod and container, the container's value take precedence
+    #The values below are examples. More values can be added as needed, since the field resolves as free form.
+    #allowPrivilegeEscalation: false
+    #capabilities:
+    #  drop:
+    #    - all 
+    #readOnlyRootFilesystem: true
+    #privileged: false
+    #runAsNonRoot: true
+    #runAsUser: 1000
+    #runAsGroup: 3000
+    #to support additional container level securityContext parameters, please check:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#securitycontext-v1-core
+
 egress:
   # -- If true, it deploys Egress for cross cluster communication
   enabled: false
@@ -277,6 +360,30 @@ egress:
   # -- Affinity placement rule for the Kuma Ingress pods
   affinity: {}
 
+  # -- Security context at the pod level for control plane.
+  podSecurityContext:
+    #The values below are examples. More values can be added as needed, since the field resolves as free form.
+    #runAsNonRoot: true
+    #runAsUser: 1000
+    #runAsGroup: 3000
+    #fsGroup: 2000
+    #fsGroupChangePolicy:
+    #to support additional pod level securityContext parameters, please check:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#podsecuritycontext-v1-core 
+  
+  # -- Security context at the container level for control plane.
+  containerSecurityContext: #for overlapping securityContext between pod and container, the container's value take precedence
+    #The values below are examples. More values can be added as needed, since the field resolves as free form.
+    #allowPrivilegeEscalation: false
+    #capabilities:
+    #  drop:
+    #    - all 
+    #readOnlyRootFilesystem: true
+    #privileged: false
+    #runAsNonRoot: true
+    #runAsUser: 1000
+    #runAsGroup: 3000
+    #to support additional container level securityContext parameters, please check:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#securitycontext-v1-core
+
 kumactl:
   image:
     # -- The kumactl image repository
@@ -299,6 +406,31 @@ hooks:
   nodeSelector:
     kubernetes.io/os: linux
     kubernetes.io/arch: amd64
+
+  #The below context is used in 3 places:Jobs (crd/webhook/ns)
+  # -- Security context at the pod level for control plane.
+  podSecurityContext:
+    #The values below are examples. More values can be added as needed, since the field resolves as free form.
+    #runAsNonRoot: true
+    #runAsUser: 1000
+    #runAsGroup: 3000
+    #fsGroup: 2000
+    #fsGroupChangePolicy:
+    #to support additional pod level securityContext parameters, please check:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#podsecuritycontext-v1-core 
+  
+  # -- Security context at the container level for control plane.
+  containerSecurityContext: #for overlapping securityContext between pod and container, the container's value take precedence
+    #The values below are examples. More values can be added as needed, since the field resolves as free form.
+    #allowPrivilegeEscalation: false
+    #capabilities:
+    #  drop:
+    #    - all 
+    #readOnlyRootFilesystem: true
+    #privileged: false
+    #runAsNonRoot: true
+    #runAsUser: 1000
+    #runAsGroup: 3000
+    #to support additional container level securityContext parameters, please check:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#securitycontext-v1-core
 
 experimental:
   # -- If true, it installs experimental built-in Gateway support

--- a/deployments/charts/kuma/values.yaml
+++ b/deployments/charts/kuma/values.yaml
@@ -407,7 +407,6 @@ hooks:
     kubernetes.io/os: linux
     kubernetes.io/arch: amd64
 
-  #The below context is used in 3 places:Jobs (crd/webhook/ns)
   # -- Security context at the pod level for crd/webhook/ns
   podSecurityContext:
     #The values below are examples. More values can be added as needed, since the field resolves as free form.

--- a/docs/generated/resources/circuit-breaker.md
+++ b/docs/generated/resources/circuit-breaker.md
@@ -1,0 +1,122 @@
+## CircuitBreaker
+
+- `sources` (required, repeated)
+
+    List of selectors to match dataplanes that are sources of traffic.
+
+- `destinations` (required, repeated)
+
+    List of selectors to match services that are destinations of traffic.
+
+- `conf` (required)
+
+    Child properties:    
+    
+    - `interval` (optional)
+    
+        Time interval between ejection analysis sweeps    
+    
+    - `baseejectiontime` (optional)
+    
+        The base time that a host is ejected for. The real time is equal to the
+        base time multiplied by the number of times the host has been ejected    
+    
+    - `maxejectionpercent` (optional)
+    
+        The maximum percent of an upstream cluster that can be ejected due to
+        outlier detection, has to be in [0 - 100] range    
+    
+    - `splitexternalandlocalerrors` (optional)
+    
+        Enables Split Mode in which local and external errors are distinguished    
+    
+    - `detectors` (optional)
+    
+        Child properties:    
+        
+        - `totalerrors` (optional)
+        
+            Errors with status code 5xx and locally originated errors, in Split
+            Mode - just errors with status code 5xx
+        
+            Child properties:    
+            
+            - `consecutive` (optional)    
+        
+        - `gatewayerrors` (optional)
+        
+            Subset of 'total' related to gateway errors (502, 503 or 504 status
+            code)
+        
+            Child properties:    
+            
+            - `consecutive` (optional)    
+        
+        - `localerrors` (optional)
+        
+            Takes into account only in Split Mode, number of locally originated
+            errors
+        
+            Child properties:    
+            
+            - `consecutive` (optional)    
+        
+        - `standarddeviation` (optional)
+        
+            Child properties:    
+            
+            - `requestvolume` (optional)
+            
+                Ignore hosts with less number of requests than 'requestVolume'    
+            
+            - `minimumhosts` (optional)
+            
+                Won't count success rate for cluster if number of hosts with required
+                'requestVolume' is less than 'minimumHosts'    
+            
+            - `factor` (optional)
+            
+                Resulting threshold = mean - (stdev * factor)    
+        
+        - `failure` (optional)
+        
+            Child properties:    
+            
+            - `requestvolume` (optional)
+            
+                Ignore hosts with less number of requests than 'requestVolume'    
+            
+            - `minimumhosts` (optional)
+            
+                Won't count success rate for cluster if number of hosts with required
+                'requestVolume' is less than 'minimumHosts'    
+            
+            - `threshold` (optional)
+            
+                Eject host if failure percentage of a given host is greater than or
+                equal to this value, has to be in [0 - 100] range    
+    
+    - `thresholds` (optional)
+    
+        Child properties:    
+        
+        - `maxconnections` (optional)
+        
+            The maximum number of connections that Envoy will make to the upstream
+            cluster. If not specified, the default is 1024.    
+        
+        - `maxpendingrequests` (optional)
+        
+            The maximum number of pending requests that Envoy will allow to the
+            upstream cluster. If not specified, the default is 1024.    
+        
+        - `maxretries` (optional)
+        
+            The maximum number of parallel retries that Envoy will allow to the
+            upstream cluster. If not specified, the default is 3.    
+        
+        - `maxrequests` (optional)
+        
+            The maximum number of parallel requests that Envoy will make to the
+            upstream cluster. If not specified, the default is 1024.
+

--- a/docs/generated/resources/external-service.md
+++ b/docs/generated/resources/external-service.md
@@ -1,0 +1,47 @@
+## ExternalService
+
+- `networking` (required)
+
+    Child properties:    
+    
+    - `address` (required)
+    
+        Address of the external service    
+    
+    - `tls` (optional)
+    
+        Child properties:    
+        
+        - `enabled` (optional)
+        
+            denotes that the external service uses TLS    
+        
+        - `caCert` (optional)
+        
+            Data source for the certificate of CA    
+        
+        - `clientCert` (optional)
+        
+            Data source for the authentication    
+        
+        - `clientKey` (optional)
+        
+            Data source for the authentication    
+        
+        - `allowrenegotiation` (optional)
+        
+            If true then TLS session will allow renegotiation.
+            It's not recommended to set this to true because of security reasons.
+            However, some servers requires this setting, especially when using
+            mTLS.    
+        
+        - `serverName` (optional)
+        
+            ServerName overrides the default Server Name Indicator set by Kuma.
+            The default value is set to "address" specified in "networking".
+
+- `tags` (required)
+
+    Tags associated with the external service,
+    e.g. kuma.io/service=web, kuma.io/protocol, version=1.0.
+

--- a/docs/generated/resources/fault-injection.md
+++ b/docs/generated/resources/fault-injection.md
@@ -1,0 +1,63 @@
+## FaultInjection
+
+- `sources` (required, repeated)
+
+    List of selectors to match dataplanes that are sources of traffic.
+
+- `destinations` (required, repeated)
+
+    List of selectors to match services that are destinations of traffic.
+
+- `conf` (required)
+
+    Configuration of FaultInjection
+
+    Child properties:    
+    
+    - `delay` (optional)
+    
+        Delay if specified then response from the destination will be delivered
+        with a delay
+    
+        Child properties:    
+        
+        - `percentage` (required)
+        
+            Percentage of requests on which delay will be injected, has to be in
+            [0.0 - 100.0] range    
+        
+        - `value` (required)
+        
+            The duration during which the response will be delayed    
+    
+    - `abort` (optional)
+    
+        Abort if specified makes source side to receive specified httpStatus code
+    
+        Child properties:    
+        
+        - `percentage` (required)
+        
+            Percentage of requests on which abort will be injected, has to be in
+            [0.0 - 100.0] range    
+        
+        - `httpstatus` (required)
+        
+            HTTP status code which will be returned to source side    
+    
+    - `responseBandwidth` (optional)
+    
+        ResponseBandwidth if specified limits the speed of sending response body
+    
+        Child properties:    
+        
+        - `percentage` (required)
+        
+            Percentage of requests on which response bandwidth limit will be
+            injected, has to be in [0.0 - 100.0] range    
+        
+        - `limit` (required)
+        
+            Limit is represented by value measure in gbps, mbps, kbps or bps, e.g.
+            10kbps
+

--- a/docs/generated/resources/health-check.md
+++ b/docs/generated/resources/health-check.md
@@ -1,0 +1,125 @@
+## HealthCheck
+
+- `sources` (required, repeated)
+
+    List of selectors to match dataplanes that should be configured to do
+    health checks.
+
+- `destinations` (required, repeated)
+
+    List of selectors to match services that need to be health checked.
+
+- `conf` (required)
+
+    Configuration for various types of health checking.
+
+    Child properties:    
+    
+    - `interval` (required)
+    
+        Interval between consecutive health checks.    
+    
+    - `timeout` (required)
+    
+        Maximum time to wait for a health check response.    
+    
+    - `unhealthyThreshold` (required)
+    
+        Number of consecutive unhealthy checks before considering a host
+        unhealthy.    
+    
+    - `healthyThreshold` (required)
+    
+        Number of consecutive healthy checks before considering a host healthy.    
+    
+    - `initialJitter` (optional)
+    
+        If specified, Envoy will start health checking after for a random time in
+        ms between 0 and initial_jitter. This only applies to the first health
+        check.    
+    
+    - `intervalJitter` (optional)
+    
+        If specified, during every interval Envoy will add interval_jitter to the
+        wait time.    
+    
+    - `intervalJitterPercent` (optional)
+    
+        If specified, during every interval Envoy will add interval_ms *
+        interval_jitter_percent / 100 to the wait time. If interval_jitter_ms and
+        interval_jitter_percent are both set, both of them will be used to
+        increase the wait time.    
+    
+    - `healthyPanicThreshold` (optional)
+    
+        Allows to configure panic threshold for Envoy cluster. If not specified,
+        the default is 50%. To disable panic mode, set to 0%.    
+    
+    - `failTrafficOnPanic` (optional)
+    
+        If set to true, Envoy will not consider any hosts when the cluster is in
+        'panic mode'. Instead, the cluster will fail all requests as if all hosts
+        are unhealthy. This can help avoid potentially overwhelming a failing
+        service.    
+    
+    - `eventLogPath` (optional)
+    
+        Specifies the path to the file where Envoy can log health check events.
+        If empty, no event log will be written.    
+    
+    - `alwaysLogHealthCheckFailures` (optional)
+    
+        If set to true, health check failure events will always be logged. If set
+        to false, only the initial health check failure event will be logged. The
+        default value is false.    
+    
+    - `noTrafficInterval` (optional)
+    
+        The "no traffic interval" is a special health check interval that is used
+        when a cluster has never had traffic routed to it. This lower interval
+        allows cluster information to be kept up to date, without sending a
+        potentially large amount of active health checking traffic for no reason.
+        Once a cluster has been used for traffic routing, Envoy will shift back
+        to using the standard health check interval that is defined. Note that
+        this interval takes precedence over any other. The default value for "no
+        traffic interval" is 60 seconds.    
+    
+    - `tcp` (optional)
+    
+        Child properties:    
+        
+        - `send` (optional)
+        
+            Bytes which will be send during the health check to the target    
+        
+        - `receive` (optional, repeated)
+        
+            Bytes blocks expected as a response. When checking the response,
+            “fuzzy” matching is performed such that each block must be found, and
+            in the order specified, but not necessarily contiguous.    
+    
+    - `http` (optional)
+    
+        Child properties:    
+        
+        - `path` (required)
+        
+            The HTTP path which will be requested during the health check
+            (ie. /health)
+            +required    
+        
+        - `requestHeadersToAdd` (optional, repeated)
+        
+            The list of HTTP headers which should be added to each health check
+            request
+            +optional    
+        
+        - `expectedStatuses` (optional, repeated)
+        
+            List of HTTP response statuses which are considered healthy
+            +optional    
+    
+    - `reuseConnection` (optional)
+    
+        Reuse health check connection between health checks. Default is true.
+

--- a/docs/generated/resources/meshgatewayroute.md
+++ b/docs/generated/resources/meshgatewayroute.md
@@ -1,0 +1,51 @@
+## MeshGatewayRoute
+
+- `selectors` (required, repeated)
+
+    Selectors is used to match this resource to MeshGateway listener.
+
+- `conf` (required)
+
+    Conf specifies the route configuration.
+
+    Child properties:    
+    
+    - `udp` (optional)
+    
+        Child properties:    
+        
+        - `rules` (required, repeated)    
+    
+    - `tcp` (optional)
+    
+        Child properties:    
+        
+        - `rules` (required, repeated)    
+    
+    - `tls` (optional)
+    
+        Child properties:    
+        
+        - `hostnames` (optional, repeated)
+        
+            Hostnames lists the server names for which this route is valid. The
+            hostnames are matched against the TLS Server Name Indication extension
+            send by the client.    
+        
+        - `rules` (required, repeated)    
+    
+    - `http` (optional)
+    
+        Child properties:    
+        
+        - `hostnames` (optional, repeated)
+        
+            Hostnames lists the server names for which this route is valid. The
+            hostnames are matched against the TLS Server Name Indication extension
+            if this is a TLS session. They are also matched against the HTTP host
+            (authority) header in the client's HTTP request.    
+        
+        - `rules` (required, repeated)
+        
+            Rules specifies how the gateway should match and process HTTP requests.
+

--- a/docs/generated/resources/proxy-template.md
+++ b/docs/generated/resources/proxy-template.md
@@ -1,0 +1,91 @@
+## ProxyTemplate
+
+- `selectors` (required, repeated)
+
+    List of Dataplane selectors.
+
+- `conf` (required)
+
+    Configuration for ProxyTemplate
+
+    Child properties:    
+    
+    - `imports` (optional, repeated)
+    
+        List of imported profiles.
+        +optional    
+    
+    - `resources` (optional, repeated)
+    
+        List of raw xDS resources.
+        +optional    
+    
+    - `modifications` (optional, repeated)
+    
+        List of config modifications
+## ProxyTemplateSource
+
+- `name` (optional)
+
+    Name of a configuration source.
+    +optional
+
+- `profile` (optional)
+
+    Profile, e.g. `default-proxy`.
+    +optional
+
+    Child properties:    
+    
+    - `name` (optional)
+    
+        Profile name.    
+    
+    - `params` (optional)
+    
+        Profile params if any.
+        +optional
+
+- `raw` (optional)
+
+    Raw xDS resources.
+    +optional
+
+    Child properties:    
+    
+    - `resources` (optional, repeated)
+    
+        List of raw xDS resources.
+        +optional
+## ProxyTemplateProfileSource
+
+- `name` (optional)
+
+    Profile name.
+
+- `params` (optional)
+
+    Profile params if any.
+    +optional
+## ProxyTemplateRawSource
+
+- `resources` (optional, repeated)
+
+    List of raw xDS resources.
+    +optional
+## ProxyTemplateRawResource
+
+- `name` (required)
+
+    The resource's name, to distinguish it from others of the same type of
+    resource.
+
+- `version` (required)
+
+    The resource level version. It allows xDS to track the state of individual
+    resources.
+
+- `resource` (required)
+
+    xDS resource.
+

--- a/docs/generated/resources/rate-limit.md
+++ b/docs/generated/resources/rate-limit.md
@@ -1,0 +1,51 @@
+## RateLimit
+
+- `sources` (required, repeated)
+
+    List of selectors to match dataplanes that rate limit will be applied for
+
+- `destinations` (required, repeated)
+
+    List of selectors to match services that need to be rate limited.
+
+- `conf` (required)
+
+    Configuration for RateLimit
+    +required
+
+    Child properties:    
+    
+    - `http` (optional)
+    
+        The HTTP RateLimit configuration
+        +optional
+    
+        Child properties:    
+        
+        - `requests` (required)
+        
+            The number of HTTP requests this RateLimiter allows
+            +required    
+        
+        - `interval` (required)
+        
+            The the interval for which `requests` will be accounted.
+            +required    
+        
+        - `onratelimit` (optional)
+        
+            Describes the actions to take on RatelLimiter event
+            +optional
+        
+            Child properties:    
+            
+            - `status` (optional)
+            
+                The HTTP status code to be set on a RateLimit event
+                +optional    
+            
+            - `headers` (optional, repeated)
+            
+                The Headers to be added to the HTTP response on a RateLimit event
+                +optional
+

--- a/docs/generated/resources/retry.md
+++ b/docs/generated/resources/retry.md
@@ -1,0 +1,123 @@
+## Retry
+
+- `sources` (required, repeated)
+
+    List of selectors to match dataplanes that retry policy should be
+    configured for
+
+- `destinations` (required, repeated)
+
+    List of selectors to match services that need to be health checked.
+
+- `conf` (required)
+
+    +required
+
+    Child properties:    
+    
+    - `http` (optional)
+    
+        Child properties:    
+        
+        - `numRetries` (optional)
+        
+            +optional    
+        
+        - `perTryTimeout` (optional)
+        
+            +optional    
+        
+        - `backOff` (optional)
+        
+            +optional
+        
+            Child properties:    
+            
+            - `baseInterval` (required)
+            
+                +required    
+            
+            - `maxInterval` (optional)
+            
+                +optional    
+        
+        - `retriableStatusCodes` (optional, repeated)
+        
+            +optional    
+        
+        - `retriableMethods` (optional, repeated)
+        
+            +optional
+        
+            Supported values:
+        
+            - `NONE`
+        
+            - `CONNECT`
+        
+            - `DELETE`
+        
+            - `GET`
+        
+            - `HEAD`
+        
+            - `OPTIONS`
+        
+            - `PATCH`
+        
+            - `POST`
+        
+            - `PUT`
+        
+            - `TRACE`    
+    
+    - `tcp` (optional)
+    
+        Child properties:    
+        
+        - `maxConnectAttempts` (optional)
+        
+            +optional    
+    
+    - `grpc` (optional)
+    
+        Child properties:    
+        
+        - `retryOn` (optional, repeated)
+        
+            +optional
+        
+            Supported values:
+        
+            - `cancelled`
+        
+            - `deadline_exceeded`
+        
+            - `internal`
+        
+            - `resource_exhausted`
+        
+            - `unavailable`    
+        
+        - `numRetries` (optional)
+        
+            +optional    
+        
+        - `perTryTimeout` (optional)
+        
+            +optional    
+        
+        - `backOff` (optional)
+        
+            +optional
+        
+            Child properties:    
+            
+            - `baseInterval` (required)
+            
+                +required    
+            
+            - `maxInterval` (optional)
+            
+                +optional
+

--- a/docs/generated/resources/timeout.md
+++ b/docs/generated/resources/timeout.md
@@ -1,0 +1,56 @@
+## Timeout
+
+- `sources` (required, repeated)
+
+    List of selectors to match dataplanes that are sources of traffic.
+
+- `destinations` (required, repeated)
+
+    List of selectors to match services that are destinations of traffic.
+
+- `conf` (required)
+
+    Child properties:    
+    
+    - `connectTimeout` (optional)
+    
+        ConnectTimeout defines time to establish connection    
+    
+    - `tcp` (optional)
+    
+        Child properties:    
+        
+        - `idleTimeout` (required)
+        
+            IdleTimeout is defined as the period in which there are no bytes sent
+            or received on either the upstream or downstream connection    
+    
+    - `http` (optional)
+    
+        Child properties:    
+        
+        - `requestTimeout` (optional)
+        
+            RequestTimeout is a span between the point at which the entire
+            downstream request (i.e. end-of-stream) has been processed and when the
+            upstream response has been completely processed    
+        
+        - `idleTimeout` (optional)
+        
+            IdleTimeout is the time at which a downstream or upstream connection
+            will be terminated if there are no active streams    
+    
+    - `grpc` (optional)
+    
+        Child properties:    
+        
+        - `streamIdleTimeout` (optional)
+        
+            StreamIdleTimeout is the amount of time that the connection manager
+            will allow a stream to exist with no upstream or downstream activity    
+        
+        - `maxStreamDuration` (optional)
+        
+            MaxStreamDuration is the maximum time that a stream’s lifetime will
+            span
+

--- a/docs/generated/resources/traffic-log.md
+++ b/docs/generated/resources/traffic-log.md
@@ -1,0 +1,20 @@
+## TrafficLog
+
+- `sources` (required, repeated)
+
+    List of selectors to match dataplanes that are sources of traffic.
+
+- `destinations` (required, repeated)
+
+    List of selectors to match services that are destinations of traffic.
+
+- `conf` (optional)
+
+    Configuration of the logging.
+
+    Child properties:    
+    
+    - `backend` (optional)
+    
+        Backend defined in the Mesh entity.
+

--- a/docs/generated/resources/traffic-permissions.md
+++ b/docs/generated/resources/traffic-permissions.md
@@ -1,0 +1,10 @@
+## TrafficPermission
+
+- `sources` (required, repeated)
+
+    List of selectors to match dataplanes that are sources of traffic.
+
+- `destinations` (required, repeated)
+
+    List of selectors to match services that are destinations of traffic.
+

--- a/docs/generated/resources/traffic-route.md
+++ b/docs/generated/resources/traffic-route.md
@@ -1,0 +1,82 @@
+## TrafficRoute
+
+- `sources` (required, repeated)
+
+    List of selectors to match data plane proxies that are sources of traffic.
+
+- `destinations` (required, repeated)
+
+    List of selectors to match services that are destinations of traffic.
+    
+    Notice the difference between sources and destinations.
+    While the source of traffic is always a data plane proxy within a mesh,
+    the destination is a service that could be either within or outside
+    of a mesh.
+
+- `conf` (required)
+
+    Configuration for the route.
+
+    Child properties:    
+    
+    - `split` (optional, repeated)
+    
+        List of destinations with weights assigned to them.
+        When used, "destination" is not allowed.    
+    
+    - `loadBalancer` (optional)
+    
+        Load balancer configuration for given "split" or "destination"
+    
+        Child properties:    
+        
+        - `roundRobin` (optional)
+        
+            Child properties:    
+        
+        - `leastRequest` (optional)
+        
+            Child properties:    
+            
+            - `choiceCount` (optional)
+            
+                The number of random healthy hosts from which the host with the fewest
+                active requests will be chosen. Defaults to 2 so that we perform
+                two-choice selection if the field is not set.    
+        
+        - `ringHash` (optional)
+        
+            Child properties:    
+            
+            - `hashFunction` (optional)
+            
+                The hash function used to hash hosts onto the ketama ring. The value
+                defaults to 'XX_HASH'.    
+            
+            - `minRingSize` (optional)
+            
+                Minimum hash ring size.    
+            
+            - `maxRingSize` (optional)
+            
+                Maximum hash ring size.    
+        
+        - `random` (optional)
+        
+            Child properties:    
+        
+        - `maglev` (optional)
+        
+            Child properties:    
+    
+    - `destination` (optional)
+    
+        One destination that the traffic will be redirected to.
+        When used, "split" is not allowed.    
+    
+    - `http` (optional, repeated)
+    
+        Configuration of HTTP traffic. Traffic is matched one by one with the
+        order defined in the list. If the request does not match any criteria
+        then "split" or "destination" outside of "http" section is executed.
+

--- a/docs/generated/resources/traffic-trace.md
+++ b/docs/generated/resources/traffic-trace.md
@@ -1,0 +1,16 @@
+## TrafficTrace
+
+- `selectors` (required, repeated)
+
+    List of selectors to match dataplanes.
+
+- `conf` (optional)
+
+    Configuration of the tracing.
+
+    Child properties:    
+    
+    - `backend` (optional)
+    
+        Backend defined in the Mesh entity.
+

--- a/docs/generated/resources/virtual-outbound.md
+++ b/docs/generated/resources/virtual-outbound.md
@@ -1,0 +1,23 @@
+## VirtualOutbound
+
+- `selectors` (required, repeated)
+
+    List of selectors to match dataplanes that this policy applies to
+
+- `conf` (required)
+
+    Child properties:    
+    
+    - `host` (required)
+    
+        Host the gotemplate to generate the hostname from the Parameters map    
+    
+    - `port` (required)
+    
+        Port the gotemplate to generate the port from the Parameters map    
+    
+    - `parameters` (required, repeated)
+    
+        Parameters a mapping between tag keys and template parameter key. This
+        must always contain at least `kuma.io/service`
+

--- a/pkg/core/bootstrap/plugins.go
+++ b/pkg/core/bootstrap/plugins.go
@@ -1,6 +1,7 @@
 package bootstrap
 
 import (
+
 	// force plugins to get initialized and registered
 	_ "github.com/kumahq/kuma/pkg/plugins/authn/api-server/certs"
 	_ "github.com/kumahq/kuma/pkg/plugins/authn/api-server/tokens"

--- a/pkg/plugins/resources/k8s/k8s_suite_test.go
+++ b/pkg/plugins/resources/k8s/k8s_suite_test.go
@@ -32,6 +32,7 @@ import (
 
 	"github.com/kumahq/kuma/pkg/plugins/bootstrap/k8s"
 	k8s_registry "github.com/kumahq/kuma/pkg/plugins/resources/k8s/native/pkg/registry"
+
 	// +kubebuilder:scaffold:imports
 	sample_v1alpha1 "github.com/kumahq/kuma/pkg/plugins/resources/k8s/native/test/api/sample/v1alpha1"
 	"github.com/kumahq/kuma/pkg/test"

--- a/pkg/test/resources/registry.go
+++ b/pkg/test/resources/registry.go
@@ -1,9 +1,11 @@
 package resources
 
 import (
+
 	// import to register all types
 	_ "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	"github.com/kumahq/kuma/pkg/core/resources/registry"
+
 	// import to register all types
 	_ "github.com/kumahq/kuma/pkg/test/resources/apis/sample"
 )

--- a/pkg/xds/bootstrap/generator.go
+++ b/pkg/xds/bootstrap/generator.go
@@ -22,6 +22,7 @@ import (
 	"github.com/kumahq/kuma/pkg/core/validators"
 	core_xds "github.com/kumahq/kuma/pkg/core/xds"
 	"github.com/kumahq/kuma/pkg/xds/bootstrap/types"
+
 	// import Envoy protobuf definitions so (un)marshaling Envoy protobuf works in tests (normally it is imported in root.go)
 	envoy_common "github.com/kumahq/kuma/pkg/xds/envoy"
 )


### PR DESCRIPTION
### Summary

Currently, there is no place to specify/customize
the securityContext for following components:
kuma-cp/ Jobs (crd/webhook/ns)/ Ingress / Egress / CNI
This PR provides the option to specify securityContext
for all of the above components.


### Full changelog
* Added option to specify securityContext for :
kuma-cp/ Jobs (crd/webhook/ns)/ Ingress / Egress / CNI
* Fix(partially) #https://github.com/kumahq/kuma/issues/3989
* Refer https://github.com/kumahq/kuma/pull/4111

### Issues resolved

* Fix(partially) #https://github.com/kumahq/kuma/issues/3989

### Testing

- [ ] Unit tests
- [ ] E2E tests
- [ ] Manual testing on Universal
- [X] Manual testing on Kubernetes

### Backwards compatibility
Does not affect backward compatibility