### PR TITLE
feat(helm): allow specifying security context

### DIFF
--- a/app/kumactl/cmd/install/testdata/install-control-plane.dump-values.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.dump-values.yaml
@@ -180,6 +180,41 @@ controlPlane:
       # -- Additional rules to apply on Kuma owner reference webhook. Useful when building custom policy on top of Kuma.
       additionalRules: ""
 
+  # -- Security context at the pod level for control plane.
+  podSecurityContext:
+#    # The values below are examples. More values can be added as needed, since the field resolves as free form.
+#    # -- Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does.
+#    runAsNonRoot: true
+#    # -- The UID to run the entrypoint of the container process.
+#    runAsUser: 1000
+#    # -- The GID to run the entrypoint of the container process.
+#    runAsGroup: 3000
+#    # -- A special supplemental group that applies to all containers in a pod
+#    fsGroup: 2000
+#    fsGroupChangePolicy:
+#    # to support additional pod level securityContext parameters, please check:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#podsecuritycontext-v1-core
+
+  # -- Security context at the container level for control plane.
+  containerSecurityContext: #for overlapping securityContext between pod and container, the container's value take precedence
+#    # The values below are examples. More values can be added as needed, since the field resolves as free form.
+#    # -- Controls whether a process can gain more privileges than its parent process.
+#    allowPrivilegeEscalation: false
+#    # -- The capabilities to add/drop when running containers
+#    capabilities:
+#      drop:
+#        - all
+#    # -- Whether this container has a read-only root filesystem.
+#    readOnlyRootFilesystem: true
+#    # -- Run container in privileged mode. Processes in privileged containers are essentially equivalent to root on the host.
+#    privileged: false
+#    # -- Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does.
+#    runAsNonRoot: true
+#    # -- The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext.
+#    runAsUser: 1000
+#    # -- The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in PodSecurityContext.
+#    runAsGroup: 3000
+#    #to support additional container level securityContext parameters, please check:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#securitycontext-v1-core
+
 cni:
   # -- Install Kuma with CNI instead of proxy init container
   enabled: false
@@ -205,6 +240,30 @@ cni:
     repository: "kumahq/install-cni"
     # -- CNI image tag
     tag: "0.0.9"
+
+  # -- Security context at the pod level for cni
+  podSecurityContext:
+#    # The values below are examples. More values can be added as needed, since the field resolves as free form.
+#    runAsNonRoot: true
+#    runAsUser: 1000
+#    runAsGroup: 3000
+#    fsGroup: 2000
+#    fsGroupChangePolicy:
+#    # to support additional pod level securityContext parameters, please check:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#podsecuritycontext-v1-core
+
+  # -- Security context at the container level for cni
+  containerSecurityContext: # for overlapping securityContext between pod and container, the container's value take precedence
+#    # The values below are examples. More values can be added as needed, since the field resolves as free form.
+#    allowPrivilegeEscalation: false
+#    capabilities:
+#      drop:
+#        - all
+#    readOnlyRootFilesystem: true
+#    privileged: false
+#    runAsNonRoot: true
+#    runAsUser: 1000
+#    runAsGroup: 3000
+#    # to support additional container level securityContext parameters, please check:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#securitycontext-v1-core
 
 dataPlane:
   image:
@@ -249,6 +308,30 @@ ingress:
   # -- Affinity placement rule for the Kuma Ingress pods
   affinity: {}
 
+  # -- Security context at the pod level for ingress
+  podSecurityContext:
+#    # The values below are examples. More values can be added as needed, since the field resolves as free form.
+#    runAsNonRoot: true
+#    runAsUser: 1000
+#    runAsGroup: 3000
+#    fsGroup: 2000
+#    fsGroupChangePolicy:
+#    # to support additional pod level securityContext parameters, please check:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#podsecuritycontext-v1-core
+
+  # -- Security context at the container level for ingress
+  containerSecurityContext: # for overlapping securityContext between pod and container, the container's value take precedence
+#    # The values below are examples. More values can be added as needed, since the field resolves as free form.
+#    allowPrivilegeEscalation: false
+#    capabilities:
+#      drop:
+#        - all
+#    readOnlyRootFilesystem: true
+#    privileged: false
+#    runAsNonRoot: true
+#    runAsUser: 1000
+#    runAsGroup: 3000
+#    # to support additional container level securityContext parameters, please check:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#securitycontext-v1-core
+
 egress:
   # -- If true, it deploys Egress for cross cluster communication
   enabled: false
@@ -277,6 +360,30 @@ egress:
   # -- Affinity placement rule for the Kuma Ingress pods
   affinity: {}
 
+  # -- Security context at the pod level for egress
+  podSecurityContext:
+#    # The values below are examples. More values can be added as needed, since the field resolves as free form.
+#    runAsNonRoot: true
+#    runAsUser: 1000
+#    runAsGroup: 3000
+#    fsGroup: 2000
+#    fsGroupChangePolicy:
+#    # to support additional pod level securityContext parameters, please check:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#podsecuritycontext-v1-core
+
+  # -- Security context at the container level for egress
+  containerSecurityContext: # for overlapping securityContext between pod and container, the container's value take precedence
+#    # The values below are examples. More values can be added as needed, since the field resolves as free form.
+#    allowPrivilegeEscalation: false
+#    capabilities:
+#      drop:
+#        - all
+#    readOnlyRootFilesystem: true
+#    privileged: false
+#    runAsNonRoot: true
+#    runAsUser: 1000
+#    runAsGroup: 3000
+#    # to support additional container level securityContext parameters, please check:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#securitycontext-v1-core
+
 kumactl:
   image:
     # -- The kumactl image repository
@@ -299,6 +406,30 @@ hooks:
   nodeSelector:
     kubernetes.io/os: linux
     kubernetes.io/arch: amd64
+
+  # -- Security context at the pod level for crd/webhook/ns
+  podSecurityContext:
+#    # The values below are examples. More values can be added as needed, since the field resolves as free form.
+#    runAsNonRoot: true
+#    runAsUser: 1000
+#    runAsGroup: 3000
+#    fsGroup: 2000
+#    fsGroupChangePolicy:
+#    # to support additional pod level securityContext parameters, please check:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#podsecuritycontext-v1-core
+
+  # -- Security context at the container level for crd/webhook/ns
+  containerSecurityContext: # for overlapping securityContext between pod and container, the container's value take precedence
+#    # The values below are examples. More values can be added as needed, since the field resolves as free form.
+#    allowPrivilegeEscalation: false
+#    capabilities:
+#      drop:
+#        - all
+#    readOnlyRootFilesystem: true
+#    privileged: false
+#    runAsNonRoot: true
+#    runAsUser: 1000
+#    runAsGroup: 3000
+#    # to support additional container level securityContext parameters, please check:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#securitycontext-v1-core
 
 experimental:
   # -- If true, it installs experimental built-in Gateway support

--- a/app/kumactl/cmd/install/testdata/install-control-plane.dump-values.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.dump-values.yaml
@@ -181,7 +181,7 @@ controlPlane:
       additionalRules: ""
 
   # -- Security context at the pod level for control plane.
-  podSecurityContext:
+  podSecurityContext: {}
 #    # The values below are examples. More values can be added as needed, since the field resolves as free form.
 #    # -- Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does.
 #    runAsNonRoot: true
@@ -195,7 +195,7 @@ controlPlane:
 #    # to support additional pod level securityContext parameters, please check:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#podsecuritycontext-v1-core
 
   # -- Security context at the container level for control plane.
-  containerSecurityContext: #for overlapping securityContext between pod and container, the container's value take precedence
+  containerSecurityContext: {} #for overlapping securityContext between pod and container, the container's value take precedence
 #    # The values below are examples. More values can be added as needed, since the field resolves as free form.
 #    # -- Controls whether a process can gain more privileges than its parent process.
 #    allowPrivilegeEscalation: false
@@ -242,7 +242,7 @@ cni:
     tag: "0.0.9"
 
   # -- Security context at the pod level for cni
-  podSecurityContext:
+  podSecurityContext: {}
 #    # The values below are examples. More values can be added as needed, since the field resolves as free form.
 #    runAsNonRoot: true
 #    runAsUser: 1000
@@ -252,7 +252,7 @@ cni:
 #    # to support additional pod level securityContext parameters, please check:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#podsecuritycontext-v1-core
 
   # -- Security context at the container level for cni
-  containerSecurityContext: # for overlapping securityContext between pod and container, the container's value take precedence
+  containerSecurityContext: {} # for overlapping securityContext between pod and container, the container's value take precedence
 #    # The values below are examples. More values can be added as needed, since the field resolves as free form.
 #    allowPrivilegeEscalation: false
 #    capabilities:
@@ -309,7 +309,7 @@ ingress:
   affinity: {}
 
   # -- Security context at the pod level for ingress
-  podSecurityContext:
+  podSecurityContext: {}
 #    # The values below are examples. More values can be added as needed, since the field resolves as free form.
 #    runAsNonRoot: true
 #    runAsUser: 1000
@@ -319,7 +319,7 @@ ingress:
 #    # to support additional pod level securityContext parameters, please check:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#podsecuritycontext-v1-core
 
   # -- Security context at the container level for ingress
-  containerSecurityContext: # for overlapping securityContext between pod and container, the container's value take precedence
+  containerSecurityContext: {} # for overlapping securityContext between pod and container, the container's value take precedence
 #    # The values below are examples. More values can be added as needed, since the field resolves as free form.
 #    allowPrivilegeEscalation: false
 #    capabilities:
@@ -361,7 +361,7 @@ egress:
   affinity: {}
 
   # -- Security context at the pod level for egress
-  podSecurityContext:
+  podSecurityContext: {}
 #    # The values below are examples. More values can be added as needed, since the field resolves as free form.
 #    runAsNonRoot: true
 #    runAsUser: 1000
@@ -371,7 +371,7 @@ egress:
 #    # to support additional pod level securityContext parameters, please check:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#podsecuritycontext-v1-core
 
   # -- Security context at the container level for egress
-  containerSecurityContext: # for overlapping securityContext between pod and container, the container's value take precedence
+  containerSecurityContext: {} # for overlapping securityContext between pod and container, the container's value take precedence
 #    # The values below are examples. More values can be added as needed, since the field resolves as free form.
 #    allowPrivilegeEscalation: false
 #    capabilities:
@@ -408,7 +408,7 @@ hooks:
     kubernetes.io/arch: amd64
 
   # -- Security context at the pod level for crd/webhook/ns
-  podSecurityContext:
+  podSecurityContext: {}
 #    # The values below are examples. More values can be added as needed, since the field resolves as free form.
 #    runAsNonRoot: true
 #    runAsUser: 1000
@@ -418,7 +418,7 @@ hooks:
 #    # to support additional pod level securityContext parameters, please check:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#podsecuritycontext-v1-core
 
   # -- Security context at the container level for crd/webhook/ns
-  containerSecurityContext: # for overlapping securityContext between pod and container, the container's value take precedence
+  containerSecurityContext: {} # for overlapping securityContext between pod and container, the container's value take precedence
 #    # The values below are examples. More values can be added as needed, since the field resolves as free form.
 #    allowPrivilegeEscalation: false
 #    capabilities:

--- a/deployments/charts/kuma/README.md
+++ b/deployments/charts/kuma/README.md
@@ -61,8 +61,8 @@ A Helm chart for the Kuma Control Plane
 | controlPlane.extraSecrets | list | `[]` | Additional secrets to mount into the control plane |
 | controlPlane.webhooks.validator.additionalRules | string | `""` | Additional rules to apply on Kuma validator webhook. Useful when building custom policy on top of Kuma. |
 | controlPlane.webhooks.ownerReference.additionalRules | string | `""` | Additional rules to apply on Kuma owner reference webhook. Useful when building custom policy on top of Kuma. |
-| controlPlane.podSecurityContext | string | `nil` | Security context at the pod level for control plane. |
-| controlPlane.containerSecurityContext | string | `nil` | Security context at the container level for control plane. |
+| controlPlane.podSecurityContext | object | `{}` | Security context at the pod level for control plane. |
+| controlPlane.containerSecurityContext | object | `{}` | Security context at the container level for control plane. |
 | cni.enabled | bool | `false` | Install Kuma with CNI instead of proxy init container |
 | cni.chained | bool | `false` | Install CNI in chained mode |
 | cni.netDir | string | `"/etc/cni/multus/net.d"` | Set the CNI install directory |
@@ -73,8 +73,8 @@ A Helm chart for the Kuma Control Plane
 | cni.image.registry | string | `"docker.io"` | CNI image registry |
 | cni.image.repository | string | `"kumahq/install-cni"` | CNI image repository |
 | cni.image.tag | string | `"0.0.9"` | CNI image tag |
-| cni.podSecurityContext | string | `nil` | Security context at the pod level for cni |
-| cni.containerSecurityContext | string | `nil` | Security context at the container level for cni |
+| cni.podSecurityContext | object | `{}` | Security context at the pod level for cni |
+| cni.containerSecurityContext | object | `{}` | Security context at the container level for cni |
 | dataPlane.image.repository | string | `"kuma-dp"` | The Kuma DP image repository |
 | dataPlane.image.pullPolicy | string | `"IfNotPresent"` | Kuma DP ImagePullPolicy |
 | dataPlane.image.tag | string | `nil` | Kuma DP Image Tag. When not specified, the value is copied from global.tag |
@@ -91,8 +91,8 @@ A Helm chart for the Kuma Control Plane
 | ingress.annotations | object | `{}` | Additional deployment annotation |
 | ingress.nodeSelector | object | `{"kubernetes.io/arch":"amd64","kubernetes.io/os":"linux"}` | Node Selector for the Ingress pods |
 | ingress.affinity | object | `{}` | Affinity placement rule for the Kuma Ingress pods |
-| ingress.podSecurityContext | string | `nil` | Security context at the pod level for ingress |
-| ingress.containerSecurityContext | string | `nil` | Security context at the container level for ingress |
+| ingress.podSecurityContext | object | `{}` | Security context at the pod level for ingress |
+| ingress.containerSecurityContext | object | `{}` | Security context at the container level for ingress |
 | egress.enabled | bool | `false` | If true, it deploys Egress for cross cluster communication |
 | egress.drainTime | string | `"30s"` | Time for which old listener will still be active as draining |
 | egress.replicas | int | `1` | Number of replicas of the Egress |
@@ -104,16 +104,16 @@ A Helm chart for the Kuma Control Plane
 | egress.annotations | object | `{}` | Additional deployment annotation |
 | egress.nodeSelector | object | `{"kubernetes.io/arch":"amd64","kubernetes.io/os":"linux"}` | Node Selector for the Egress pods |
 | egress.affinity | object | `{}` | Affinity placement rule for the Kuma Ingress pods |
-| egress.podSecurityContext | string | `nil` | Security context at the pod level for egress |
-| egress.containerSecurityContext | string | `nil` | Security context at the container level for egress |
+| egress.podSecurityContext | object | `{}` | Security context at the pod level for egress |
+| egress.containerSecurityContext | object | `{}` | Security context at the container level for egress |
 | kumactl.image.repository | string | `"kumactl"` | The kumactl image repository |
 | kumactl.image.tag | string | `nil` | The kumactl image tag. When not specified, the value is copied from global.tag |
 | kubectl.image.registry | string | `"bitnami"` | The kubectl image registry |
 | kubectl.image.repository | string | `"kubectl"` | The kubectl image repository |
 | kubectl.image.tag | string | `"1.20"` | The kubectl image tag |
 | hooks.nodeSelector | object | `{"kubernetes.io/arch":"amd64","kubernetes.io/os":"linux"}` | Node selector for the HELM hooks |
-| hooks.podSecurityContext | string | `nil` | Security context at the pod level for crd/webhook/ns |
-| hooks.containerSecurityContext | string | `nil` | Security context at the container level for crd/webhook/ns |
+| hooks.podSecurityContext | object | `{}` | Security context at the pod level for crd/webhook/ns |
+| hooks.containerSecurityContext | object | `{}` | Security context at the container level for crd/webhook/ns |
 | experimental.meshGateway | bool | `false` | If true, it installs experimental built-in Gateway support |
 | experimental.gatewayAPI | bool | `false` | If true, it installs experimental Gateway API support |
 

--- a/deployments/charts/kuma/README.md
+++ b/deployments/charts/kuma/README.md
@@ -61,6 +61,8 @@ A Helm chart for the Kuma Control Plane
 | controlPlane.extraSecrets | list | `[]` | Additional secrets to mount into the control plane |
 | controlPlane.webhooks.validator.additionalRules | string | `""` | Additional rules to apply on Kuma validator webhook. Useful when building custom policy on top of Kuma. |
 | controlPlane.webhooks.ownerReference.additionalRules | string | `""` | Additional rules to apply on Kuma owner reference webhook. Useful when building custom policy on top of Kuma. |
+| controlPlane.podSecurityContext | string | `nil` | Security context at the pod level for control plane. |
+| controlPlane.containerSecurityContext | string | `nil` | Security context at the container level for control plane. |
 | cni.enabled | bool | `false` | Install Kuma with CNI instead of proxy init container |
 | cni.chained | bool | `false` | Install CNI in chained mode |
 | cni.netDir | string | `"/etc/cni/multus/net.d"` | Set the CNI install directory |
@@ -71,6 +73,8 @@ A Helm chart for the Kuma Control Plane
 | cni.image.registry | string | `"docker.io"` | CNI image registry |
 | cni.image.repository | string | `"kumahq/install-cni"` | CNI image repository |
 | cni.image.tag | string | `"0.0.9"` | CNI image tag |
+| cni.podSecurityContext | string | `nil` | Security context at the pod level for cni |
+| cni.containerSecurityContext | string | `nil` | Security context at the container level for cni |
 | dataPlane.image.repository | string | `"kuma-dp"` | The Kuma DP image repository |
 | dataPlane.image.pullPolicy | string | `"IfNotPresent"` | Kuma DP ImagePullPolicy |
 | dataPlane.image.tag | string | `nil` | Kuma DP Image Tag. When not specified, the value is copied from global.tag |
@@ -87,6 +91,8 @@ A Helm chart for the Kuma Control Plane
 | ingress.annotations | object | `{}` | Additional deployment annotation |
 | ingress.nodeSelector | object | `{"kubernetes.io/arch":"amd64","kubernetes.io/os":"linux"}` | Node Selector for the Ingress pods |
 | ingress.affinity | object | `{}` | Affinity placement rule for the Kuma Ingress pods |
+| ingress.podSecurityContext | string | `nil` | Security context at the pod level for ingress |
+| ingress.containerSecurityContext | string | `nil` | Security context at the container level for ingress |
 | egress.enabled | bool | `false` | If true, it deploys Egress for cross cluster communication |
 | egress.drainTime | string | `"30s"` | Time for which old listener will still be active as draining |
 | egress.replicas | int | `1` | Number of replicas of the Egress |
@@ -98,12 +104,16 @@ A Helm chart for the Kuma Control Plane
 | egress.annotations | object | `{}` | Additional deployment annotation |
 | egress.nodeSelector | object | `{"kubernetes.io/arch":"amd64","kubernetes.io/os":"linux"}` | Node Selector for the Egress pods |
 | egress.affinity | object | `{}` | Affinity placement rule for the Kuma Ingress pods |
+| egress.podSecurityContext | string | `nil` | Security context at the pod level for egress |
+| egress.containerSecurityContext | string | `nil` | Security context at the container level for egress |
 | kumactl.image.repository | string | `"kumactl"` | The kumactl image repository |
 | kumactl.image.tag | string | `nil` | The kumactl image tag. When not specified, the value is copied from global.tag |
 | kubectl.image.registry | string | `"bitnami"` | The kubectl image registry |
 | kubectl.image.repository | string | `"kubectl"` | The kubectl image repository |
 | kubectl.image.tag | string | `"1.20"` | The kubectl image tag |
 | hooks.nodeSelector | object | `{"kubernetes.io/arch":"amd64","kubernetes.io/os":"linux"}` | Node selector for the HELM hooks |
+| hooks.podSecurityContext | string | `nil` | Security context at the pod level for crd/webhook/ns |
+| hooks.containerSecurityContext | string | `nil` | Security context at the container level for crd/webhook/ns |
 | experimental.meshGateway | bool | `false` | If true, it installs experimental built-in Gateway support |
 | experimental.gatewayAPI | bool | `false` | If true, it installs experimental Gateway API support |
 

--- a/deployments/charts/kuma/templates/cni-daemonset.yaml
+++ b/deployments/charts/kuma/templates/cni-daemonset.yaml
@@ -45,6 +45,10 @@ spec:
       # Minimize downtime during a rolling upgrade or deletion; tell Kubernetes to do a "force
       # deletion": https://kubernetes.io/docs/concepts/workloads/pods/pod/#termination-of-pods.
       terminationGracePeriodSeconds: 5
+      {{- if .Values.cni.podSecurityContext }}
+      securityContext:
+      {{ toYaml .Values.cni.podSecurityContext | trim | nindent 8 }}
+      {{- end }}
       containers:
         - name: install-cni
           image: {{ include "kuma.formatImage" (dict "image" .Values.cni.image "root" $) | quote }}

--- a/deployments/charts/kuma/templates/cp-deployment.yaml
+++ b/deployments/charts/kuma/templates/cp-deployment.yaml
@@ -42,6 +42,10 @@ spec:
                   - {{ include "kuma.name" . }}-control-plane
               topologyKey: kubernetes.io/hostname
       {{- end }}
+      {{- if .Values.controlPlane.podSecurityContext }}
+      securityContext:
+      {{ toYaml .Values.controlPlane.podSecurityContext | trim | nindent 8 }}
+      {{- end }}
       serviceAccountName: {{ include "kuma.name" . }}-control-plane
       {{- with .Values.controlPlane.nodeSelector }}
       nodeSelector:
@@ -51,6 +55,10 @@ spec:
         - name: control-plane
           image: {{ include "kuma.formatImage" (dict "image" .Values.controlPlane.image "root" $) | quote }}
           imagePullPolicy: {{ .Values.controlPlane.image.pullPolicy }}
+          {{- if .Values.controlPlane.containerSecurityContext }}
+          securityContext:
+          {{ toYaml .Values.controlPlane.containerSecurityContext | trim | nindent 12 }}
+          {{- end }}
           env:
           {{-  $defaultEnv := include "kuma.defaultEnv" . | fromYaml | pluck "env" | first }}
           {{- $defaultEnvDict := dict }}

--- a/deployments/charts/kuma/templates/egress-deployment.yaml
+++ b/deployments/charts/kuma/templates/egress-deployment.yaml
@@ -47,6 +47,10 @@ spec:
                   - {{ include "kuma.name" . }}-egress
               topologyKey: kubernetes.io/hostname
       {{- end }}
+      {{- if .Values.egress.podSecurityContext }}
+      securityContext:
+      {{ toYaml .Values.egress.podSecurityContext | trim | nindent 8 }}
+      {{- end }}
       serviceAccountName: {{ include "kuma.name" . }}-egress
       {{- with .Values.egress.nodeSelector }}
       nodeSelector:
@@ -56,6 +60,10 @@ spec:
         - name: egress
           image: {{ include "kuma.formatImage" (dict "image" .Values.dataPlane.image "root" $) | quote }}
           imagePullPolicy: {{ .Values.dataPlane.image.pullPolicy }}
+          {{- if .Values.egress.containerSecurityContext }}
+          securityContext:
+          {{ toYaml .Values.egress.containerSecurityContext | trim | nindent 12 }}
+          {{- end }}
           env:
             - name: POD_NAME
               valueFrom:

--- a/deployments/charts/kuma/templates/ingress-deployment.yaml
+++ b/deployments/charts/kuma/templates/ingress-deployment.yaml
@@ -47,6 +47,10 @@ spec:
                   - {{ include "kuma.name" . }}-ingress
               topologyKey: kubernetes.io/hostname
       {{- end }}
+      {{- if .Values.ingress.podSecurityContext }}
+      securityContext:
+      {{ toYaml .Values.ingress.podSecurityContext | trim | nindent 8 }}
+      {{- end }}
       serviceAccountName: {{ include "kuma.name" . }}-ingress
       {{- with .Values.ingress.nodeSelector }}
       nodeSelector:
@@ -56,6 +60,10 @@ spec:
         - name: ingress
           image: {{ include "kuma.formatImage" (dict "image" .Values.dataPlane.image "root" $) | quote }}
           imagePullPolicy: {{ .Values.dataPlane.image.pullPolicy }}
+          {{- if .Values.ingress.containerSecurityContext }}
+          securityContext:
+          {{ toYaml .Values.ingress.containerSecurityContext | trim | nindent 12 }}
+          {{- end }}
           env:
             - name: POD_NAME
               valueFrom:

--- a/deployments/charts/kuma/templates/pre-delete-webhooks.yaml
+++ b/deployments/charts/kuma/templates/pre-delete-webhooks.yaml
@@ -81,6 +81,10 @@ spec:
       {{ toYaml . | nindent 8 }}
       {{- end }}
       restartPolicy: OnFailure
+      {{- if .Values.hooks.podSecurityContext }}
+      securityContext:
+      {{ toYaml .Values.hooks.podSecurityContext | trim | nindent 8 }}
+      {{- end }}
       containers:
         - name: pre-delete-job
           image: {{ include "kubectl.formatImage" (dict "image" .Values.kubectl.image "root" $) | quote }}
@@ -89,3 +93,7 @@ spec:
             - 'delete'
             - 'ValidatingWebhookConfiguration'
             - {{ include "kuma.name" . }}-validating-webhook-configuration
+          {{- if .Values.hooks.containerSecurityContext }}
+          securityContext:
+          {{ toYaml .Values.hooks.containerSecurityContext | trim | nindent 12 }}
+          {{- end }}

--- a/deployments/charts/kuma/templates/pre-install-patch-namespace-job.yaml
+++ b/deployments/charts/kuma/templates/pre-install-patch-namespace-job.yaml
@@ -82,9 +82,17 @@ spec:
       {{ toYaml . | nindent 8 }}
       {{- end }}
       restartPolicy: OnFailure
+      {{- if .Values.hooks.podSecurityContext }}
+      securityContext:
+      {{ toYaml .Values.hooks.podSecurityContext | trim | nindent 8 }}
+      {{- end }}
       containers:
         - name: pre-install-job
           image: {{ include "kubectl.formatImage" (dict "image" .Values.kubectl.image "root" $) | quote }}
+          {{- if .Values.hooks.containerSecurityContext }}
+          securityContext:
+          {{ toYaml .Values.hooks.containerSecurityContext | trim | nindent 12 }}
+          {{- end }}
           command:
             - 'kubectl'
             - 'patch'

--- a/deployments/charts/kuma/templates/pre-upgrade-install-missing-crds-job.yaml
+++ b/deployments/charts/kuma/templates/pre-upgrade-install-missing-crds-job.yaml
@@ -114,9 +114,17 @@ spec:
       {{ toYaml . | nindent 8 }}
       {{- end }}
       restartPolicy: OnFailure
+      {{- if .Values.hooks.podSecurityContext }}
+      securityContext:
+      {{ toYaml .Values.hooks.podSecurityContext | trim | nindent 8 }}
+      {{- end }}
       containers:
         - name: pre-upgrade-job
           image: {{ include "kubectl.formatImage" (dict "image" .Values.kubectl.image "root" $) | quote }}
+          {{- if .Values.hooks.containerSecurityContext }}
+          securityContext:
+          {{ toYaml .Values.hooks.containerSecurityContext | trim | nindent 12 }}
+          {{- end }}
           command:
             - '/kuma/scripts/install_missing_crds.sh'
           volumeMounts:
@@ -129,6 +137,10 @@ spec:
       initContainers:
         - name: pre-upgrade-job-init
           image: {{ include "kuma.formatImage" (dict "image" .Values.kumactl.image "root" $) | quote }}
+          {{- if .Values.hooks.containerSecurityContext }}
+          securityContext:
+          {{ toYaml .Values.hooks.containerSecurityContext | trim | nindent 12 }}
+          {{- end }}
           volumeMounts:
           - mountPath: /kuma/missing
             name: missing-crds

--- a/deployments/charts/kuma/values.yaml
+++ b/deployments/charts/kuma/values.yaml
@@ -180,6 +180,41 @@ controlPlane:
       # -- Additional rules to apply on Kuma owner reference webhook. Useful when building custom policy on top of Kuma.
       additionalRules: ""
 
+  # -- Security context at the pod level for control plane.
+  podSecurityContext:
+#    # The values below are examples. More values can be added as needed, since the field resolves as free form.
+#    # -- Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does.
+#    runAsNonRoot: true
+#    # -- The UID to run the entrypoint of the container process.
+#    runAsUser: 1000
+#    # -- The GID to run the entrypoint of the container process.
+#    runAsGroup: 3000
+#    # -- A special supplemental group that applies to all containers in a pod
+#    fsGroup: 2000
+#    fsGroupChangePolicy:
+#    # to support additional pod level securityContext parameters, please check:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#podsecuritycontext-v1-core
+
+  # -- Security context at the container level for control plane.
+  containerSecurityContext: #for overlapping securityContext between pod and container, the container's value take precedence
+#    # The values below are examples. More values can be added as needed, since the field resolves as free form.
+#    # -- Controls whether a process can gain more privileges than its parent process.
+#    allowPrivilegeEscalation: false
+#    # -- The capabilities to add/drop when running containers
+#    capabilities:
+#      drop:
+#        - all
+#    # -- Whether this container has a read-only root filesystem.
+#    readOnlyRootFilesystem: true
+#    # -- Run container in privileged mode. Processes in privileged containers are essentially equivalent to root on the host.
+#    privileged: false
+#    # -- Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does.
+#    runAsNonRoot: true
+#    # -- The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext.
+#    runAsUser: 1000
+#    # -- The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in PodSecurityContext.
+#    runAsGroup: 3000
+#    #to support additional container level securityContext parameters, please check:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#securitycontext-v1-core
+
 cni:
   # -- Install Kuma with CNI instead of proxy init container
   enabled: false
@@ -205,6 +240,30 @@ cni:
     repository: "kumahq/install-cni"
     # -- CNI image tag
     tag: "0.0.9"
+
+  # -- Security context at the pod level for cni
+  podSecurityContext:
+#    # The values below are examples. More values can be added as needed, since the field resolves as free form.
+#    runAsNonRoot: true
+#    runAsUser: 1000
+#    runAsGroup: 3000
+#    fsGroup: 2000
+#    fsGroupChangePolicy:
+#    # to support additional pod level securityContext parameters, please check:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#podsecuritycontext-v1-core
+
+  # -- Security context at the container level for cni
+  containerSecurityContext: # for overlapping securityContext between pod and container, the container's value take precedence
+#    # The values below are examples. More values can be added as needed, since the field resolves as free form.
+#    allowPrivilegeEscalation: false
+#    capabilities:
+#      drop:
+#        - all
+#    readOnlyRootFilesystem: true
+#    privileged: false
+#    runAsNonRoot: true
+#    runAsUser: 1000
+#    runAsGroup: 3000
+#    # to support additional container level securityContext parameters, please check:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#securitycontext-v1-core
 
 dataPlane:
   image:
@@ -249,6 +308,30 @@ ingress:
   # -- Affinity placement rule for the Kuma Ingress pods
   affinity: {}
 
+  # -- Security context at the pod level for ingress
+  podSecurityContext:
+#    # The values below are examples. More values can be added as needed, since the field resolves as free form.
+#    runAsNonRoot: true
+#    runAsUser: 1000
+#    runAsGroup: 3000
+#    fsGroup: 2000
+#    fsGroupChangePolicy:
+#    # to support additional pod level securityContext parameters, please check:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#podsecuritycontext-v1-core
+
+  # -- Security context at the container level for ingress
+  containerSecurityContext: # for overlapping securityContext between pod and container, the container's value take precedence
+#    # The values below are examples. More values can be added as needed, since the field resolves as free form.
+#    allowPrivilegeEscalation: false
+#    capabilities:
+#      drop:
+#        - all
+#    readOnlyRootFilesystem: true
+#    privileged: false
+#    runAsNonRoot: true
+#    runAsUser: 1000
+#    runAsGroup: 3000
+#    # to support additional container level securityContext parameters, please check:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#securitycontext-v1-core
+
 egress:
   # -- If true, it deploys Egress for cross cluster communication
   enabled: false
@@ -277,6 +360,30 @@ egress:
   # -- Affinity placement rule for the Kuma Ingress pods
   affinity: {}
 
+  # -- Security context at the pod level for egress
+  podSecurityContext:
+#    # The values below are examples. More values can be added as needed, since the field resolves as free form.
+#    runAsNonRoot: true
+#    runAsUser: 1000
+#    runAsGroup: 3000
+#    fsGroup: 2000
+#    fsGroupChangePolicy:
+#    # to support additional pod level securityContext parameters, please check:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#podsecuritycontext-v1-core
+
+  # -- Security context at the container level for egress
+  containerSecurityContext: # for overlapping securityContext between pod and container, the container's value take precedence
+#    # The values below are examples. More values can be added as needed, since the field resolves as free form.
+#    allowPrivilegeEscalation: false
+#    capabilities:
+#      drop:
+#        - all
+#    readOnlyRootFilesystem: true
+#    privileged: false
+#    runAsNonRoot: true
+#    runAsUser: 1000
+#    runAsGroup: 3000
+#    # to support additional container level securityContext parameters, please check:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#securitycontext-v1-core
+
 kumactl:
   image:
     # -- The kumactl image repository
@@ -299,6 +406,30 @@ hooks:
   nodeSelector:
     kubernetes.io/os: linux
     kubernetes.io/arch: amd64
+
+  # -- Security context at the pod level for crd/webhook/ns
+  podSecurityContext:
+#    # The values below are examples. More values can be added as needed, since the field resolves as free form.
+#    runAsNonRoot: true
+#    runAsUser: 1000
+#    runAsGroup: 3000
+#    fsGroup: 2000
+#    fsGroupChangePolicy:
+#    # to support additional pod level securityContext parameters, please check:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#podsecuritycontext-v1-core
+
+  # -- Security context at the container level for crd/webhook/ns
+  containerSecurityContext: # for overlapping securityContext between pod and container, the container's value take precedence
+#    # The values below are examples. More values can be added as needed, since the field resolves as free form.
+#    allowPrivilegeEscalation: false
+#    capabilities:
+#      drop:
+#        - all
+#    readOnlyRootFilesystem: true
+#    privileged: false
+#    runAsNonRoot: true
+#    runAsUser: 1000
+#    runAsGroup: 3000
+#    # to support additional container level securityContext parameters, please check:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#securitycontext-v1-core
 
 experimental:
   # -- If true, it installs experimental built-in Gateway support

--- a/deployments/charts/kuma/values.yaml
+++ b/deployments/charts/kuma/values.yaml
@@ -181,7 +181,7 @@ controlPlane:
       additionalRules: ""
 
   # -- Security context at the pod level for control plane.
-  podSecurityContext:
+  podSecurityContext: {}
 #    # The values below are examples. More values can be added as needed, since the field resolves as free form.
 #    # -- Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does.
 #    runAsNonRoot: true
@@ -195,7 +195,7 @@ controlPlane:
 #    # to support additional pod level securityContext parameters, please check:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#podsecuritycontext-v1-core
 
   # -- Security context at the container level for control plane.
-  containerSecurityContext: #for overlapping securityContext between pod and container, the container's value take precedence
+  containerSecurityContext: {} #for overlapping securityContext between pod and container, the container's value take precedence
 #    # The values below are examples. More values can be added as needed, since the field resolves as free form.
 #    # -- Controls whether a process can gain more privileges than its parent process.
 #    allowPrivilegeEscalation: false
@@ -242,7 +242,7 @@ cni:
     tag: "0.0.9"
 
   # -- Security context at the pod level for cni
-  podSecurityContext:
+  podSecurityContext: {}
 #    # The values below are examples. More values can be added as needed, since the field resolves as free form.
 #    runAsNonRoot: true
 #    runAsUser: 1000
@@ -252,7 +252,7 @@ cni:
 #    # to support additional pod level securityContext parameters, please check:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#podsecuritycontext-v1-core
 
   # -- Security context at the container level for cni
-  containerSecurityContext: # for overlapping securityContext between pod and container, the container's value take precedence
+  containerSecurityContext: {} # for overlapping securityContext between pod and container, the container's value take precedence
 #    # The values below are examples. More values can be added as needed, since the field resolves as free form.
 #    allowPrivilegeEscalation: false
 #    capabilities:
@@ -309,7 +309,7 @@ ingress:
   affinity: {}
 
   # -- Security context at the pod level for ingress
-  podSecurityContext:
+  podSecurityContext: {}
 #    # The values below are examples. More values can be added as needed, since the field resolves as free form.
 #    runAsNonRoot: true
 #    runAsUser: 1000
@@ -319,7 +319,7 @@ ingress:
 #    # to support additional pod level securityContext parameters, please check:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#podsecuritycontext-v1-core
 
   # -- Security context at the container level for ingress
-  containerSecurityContext: # for overlapping securityContext between pod and container, the container's value take precedence
+  containerSecurityContext: {} # for overlapping securityContext between pod and container, the container's value take precedence
 #    # The values below are examples. More values can be added as needed, since the field resolves as free form.
 #    allowPrivilegeEscalation: false
 #    capabilities:
@@ -361,7 +361,7 @@ egress:
   affinity: {}
 
   # -- Security context at the pod level for egress
-  podSecurityContext:
+  podSecurityContext: {}
 #    # The values below are examples. More values can be added as needed, since the field resolves as free form.
 #    runAsNonRoot: true
 #    runAsUser: 1000
@@ -371,7 +371,7 @@ egress:
 #    # to support additional pod level securityContext parameters, please check:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#podsecuritycontext-v1-core
 
   # -- Security context at the container level for egress
-  containerSecurityContext: # for overlapping securityContext between pod and container, the container's value take precedence
+  containerSecurityContext: {} # for overlapping securityContext between pod and container, the container's value take precedence
 #    # The values below are examples. More values can be added as needed, since the field resolves as free form.
 #    allowPrivilegeEscalation: false
 #    capabilities:
@@ -408,7 +408,7 @@ hooks:
     kubernetes.io/arch: amd64
 
   # -- Security context at the pod level for crd/webhook/ns
-  podSecurityContext:
+  podSecurityContext: {}
 #    # The values below are examples. More values can be added as needed, since the field resolves as free form.
 #    runAsNonRoot: true
 #    runAsUser: 1000
@@ -418,7 +418,7 @@ hooks:
 #    # to support additional pod level securityContext parameters, please check:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#podsecuritycontext-v1-core
 
   # -- Security context at the container level for crd/webhook/ns
-  containerSecurityContext: # for overlapping securityContext between pod and container, the container's value take precedence
+  containerSecurityContext: {} # for overlapping securityContext between pod and container, the container's value take precedence
 #    # The values below are examples. More values can be added as needed, since the field resolves as free form.
 #    allowPrivilegeEscalation: false
 #    capabilities:


### PR DESCRIPTION
### Summary

Currently, there is no place to specify/customize
the securityContext for following components:
kuma-cp/ Jobs (crd/webhook/ns)/ Ingress / Egress / CNI
This PR provides the option to specify securityContext
for all of the above components.

cc. @gdasson @johnharris85 

### Full changelog
* Added option to specify securityContext for :
kuma-cp/ Jobs (crd/webhook/ns)/ Ingress / Egress / CNI
* Fix(partially) #https://github.com/kumahq/kuma/issues/3989
* Refer https://github.com/kumahq/kuma/pull/4111

### Issues resolved

* Fix(partially) #https://github.com/kumahq/kuma/issues/3989

### Testing

- [ ] Unit tests
- [ ] E2E tests
- [ ] Manual testing on Universal
- [X] Manual testing on Kubernetes

### Backwards compatibility
Does not affect backward compatibility