### PR TITLE
[WIP] feat(transparent-proxy): skip conntrack zones

### DIFF
--- a/pkg/plugins/runtime/k8s/metadata/annotations.go
+++ b/pkg/plugins/runtime/k8s/metadata/annotations.go
@@ -78,6 +78,9 @@ const (
 
 	// KumaSidecarTokenVolumeAnnotation allows to specify which volume contains the service account token
 	KumaSidecarTokenVolumeAnnotation = "kuma.io/service-account-token-volume"
+
+	// KumaInitSkipDNSConntrackZoneSplit whether to skip using conntrack zone splitting in iptables
+	KumaInitSkipDNSConntrackZoneSplit = "kuma.io/init-skip-dns-conntrack-zone-split"
 )
 
 // Annotations that are being automatically set by the Kuma Sidecar Injector.


### PR DESCRIPTION
### Summary

Add annotation to allow users to skip the use of
conntrack zone splitting when using iptables
transparent proxy.

Signed-off-by: John Harris <john@johnharris.io>

### Documentation

- [ ] Link to the website [documentation PR](https://github.com/kumahq/kuma-website/pull/XXX)

### Testing

- [ ] Unit tests
- [ ] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes

### Backwards compatibility

- [ ] Update [`UPGRADE.md`](/UPGRADE.md) with any steps users will need to take when upgrading.
- [ ] Add `backport-to-stable` label if the code follows our [backporting policy](/CONTRIBUTING.md#backporting)
