### PR TITLE
build: package and release static kumactl binary

### DIFF
--- a/tools/releases/distros.sh
+++ b/tools/releases/distros.sh
@@ -138,7 +138,7 @@ function archive_path() {
   if [[ -n $distro ]]; then
     echo "$(artifact_dir "$arch" "$system")/$RELEASE_NAME-$KUMA_VERSION-$distro-$arch.tar.gz"
   else
-    echo "$(artifact_dir "$arch" "$system")/$RELEASE_NAME-$KUMA_VERSION-$arch.tar.gz"
+    echo "$(artifact_dir "$arch" "$system")/$RELEASE_NAME-$KUMA_VERSION-$system-$arch.tar.gz"
   fi
 }
 


### PR DESCRIPTION
### Summary

There's a refactor in here around not having a `$distro` set. The difference is a new archive `kuma-$version-$system-$arch.tar.gz`, i.e. without a `$distro`, containing only `kumactl`:

```
$ tar tvf build/artifacts-linux-amd64/kuma-dev-7557228b6-linux-amd64.tar.gz | awk '{print $6}'
./
./kuma-dev-7557228b6/
./kuma-dev-7557228b6/bin/
./kuma-dev-7557228b6/bin/kumactl
./kuma-dev-7557228b6/LICENSE
./kuma-dev-7557228b6/NOTICE-kumactl
```

Part of #3814 