### PR TITLE
refactor(kuma-cp): remove deprecated envoy listened ReusePort field

### DIFF
--- a/pkg/plugins/runtime/gateway/testdata/01-gateway-listener.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/01-gateway-listener.yaml
@@ -50,5 +50,5 @@ Resources:
         '@type': type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
     name: edge-gateway:HTTP:8080
     perConnectionBufferLimitBytes: 32768
-    reusePort: true
+    enableReusePort: true
     trafficDirection: INBOUND

--- a/pkg/plugins/runtime/gateway/testdata/01-gateway-listener.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/01-gateway-listener.yaml
@@ -4,6 +4,7 @@ Resources:
       socketAddress:
         address: 192.168.1.1
         portValue: 8080
+    enableReusePort: true
     filterChains:
     - filters:
       - name: envoy.filters.network.http_connection_manager
@@ -50,5 +51,4 @@ Resources:
         '@type': type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
     name: edge-gateway:HTTP:8080
     perConnectionBufferLimitBytes: 32768
-    enableReusePort: true
     trafficDirection: INBOUND

--- a/pkg/plugins/runtime/gateway/testdata/02-gateway-listener.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/02-gateway-listener.yaml
@@ -50,7 +50,7 @@ Resources:
         '@type': type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
     name: edge-gateway:HTTP:8080
     perConnectionBufferLimitBytes: 32768
-    reusePort: true
+    enableReusePort: true
     trafficDirection: INBOUND
   edge-gateway:HTTP:9090:
     address:
@@ -103,5 +103,5 @@ Resources:
         '@type': type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
     name: edge-gateway:HTTP:9090
     perConnectionBufferLimitBytes: 32768
-    reusePort: true
+    enableReusePort: true
     trafficDirection: INBOUND

--- a/pkg/plugins/runtime/gateway/testdata/02-gateway-listener.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/02-gateway-listener.yaml
@@ -4,6 +4,7 @@ Resources:
       socketAddress:
         address: 192.168.1.1
         portValue: 8080
+    enableReusePort: true
     filterChains:
     - filters:
       - name: envoy.filters.network.http_connection_manager
@@ -50,13 +51,13 @@ Resources:
         '@type': type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
     name: edge-gateway:HTTP:8080
     perConnectionBufferLimitBytes: 32768
-    enableReusePort: true
     trafficDirection: INBOUND
   edge-gateway:HTTP:9090:
     address:
       socketAddress:
         address: 192.168.1.1
         portValue: 9090
+    enableReusePort: true
     filterChains:
     - filters:
       - name: envoy.filters.network.http_connection_manager
@@ -103,5 +104,4 @@ Resources:
         '@type': type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
     name: edge-gateway:HTTP:9090
     perConnectionBufferLimitBytes: 32768
-    enableReusePort: true
     trafficDirection: INBOUND

--- a/pkg/plugins/runtime/gateway/testdata/03-gateway-listener.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/03-gateway-listener.yaml
@@ -61,5 +61,5 @@ Resources:
         '@type': type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
     name: tracing-gateway:HTTP:8080
     perConnectionBufferLimitBytes: 32768
-    reusePort: true
+    enableReusePort: true
     trafficDirection: INBOUND

--- a/pkg/plugins/runtime/gateway/testdata/03-gateway-listener.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/03-gateway-listener.yaml
@@ -4,6 +4,7 @@ Resources:
       socketAddress:
         address: 192.168.1.1
         portValue: 8080
+    enableReusePort: true
     filterChains:
     - filters:
       - name: envoy.filters.network.http_connection_manager
@@ -61,5 +62,4 @@ Resources:
         '@type': type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
     name: tracing-gateway:HTTP:8080
     perConnectionBufferLimitBytes: 32768
-    enableReusePort: true
     trafficDirection: INBOUND

--- a/pkg/plugins/runtime/gateway/testdata/04-gateway-listener.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/04-gateway-listener.yaml
@@ -59,5 +59,5 @@ Resources:
         '@type': type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
     name: logging-gateway:HTTP:8080
     perConnectionBufferLimitBytes: 32768
-    reusePort: true
+    enableReusePort: true
     trafficDirection: INBOUND

--- a/pkg/plugins/runtime/gateway/testdata/04-gateway-listener.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/04-gateway-listener.yaml
@@ -4,6 +4,7 @@ Resources:
       socketAddress:
         address: 192.168.1.1
         portValue: 8080
+    enableReusePort: true
     filterChains:
     - filters:
       - name: envoy.filters.network.http_connection_manager
@@ -59,5 +60,4 @@ Resources:
         '@type': type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
     name: logging-gateway:HTTP:8080
     perConnectionBufferLimitBytes: 32768
-    enableReusePort: true
     trafficDirection: INBOUND

--- a/pkg/plugins/runtime/gateway/testdata/05-gateway-listener.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/05-gateway-listener.yaml
@@ -4,6 +4,7 @@ Resources:
       socketAddress:
         address: 192.168.1.1
         portValue: 443
+    enableReusePort: true
     filterChains:
     - filterChainMatch:
         applicationProtocols:
@@ -257,5 +258,4 @@ Resources:
         '@type': type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
     name: default-gateway:HTTPS:443
     perConnectionBufferLimitBytes: 32768
-    enableReusePort: true
     trafficDirection: INBOUND

--- a/pkg/plugins/runtime/gateway/testdata/05-gateway-listener.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/05-gateway-listener.yaml
@@ -257,5 +257,5 @@ Resources:
         '@type': type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
     name: default-gateway:HTTPS:443
     perConnectionBufferLimitBytes: 32768
-    reusePort: true
+    enableReusePort: true
     trafficDirection: INBOUND

--- a/pkg/plugins/runtime/gateway/testdata/http/01-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/01-gateway-route.yaml
@@ -52,6 +52,7 @@ Listeners:
         socketAddress:
           address: 192.168.1.1
           portValue: 8080
+      enableReusePort: true
       filterChains:
       - filters:
         - name: envoy.filters.network.http_connection_manager
@@ -98,7 +99,6 @@ Listeners:
           '@type': type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
       name: edge-gateway:HTTP:8080
       perConnectionBufferLimitBytes: 32768
-      enableReusePort: true
       trafficDirection: INBOUND
 Routes:
   Resources:

--- a/pkg/plugins/runtime/gateway/testdata/http/01-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/01-gateway-route.yaml
@@ -98,7 +98,7 @@ Listeners:
           '@type': type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
       name: edge-gateway:HTTP:8080
       perConnectionBufferLimitBytes: 32768
-      reusePort: true
+      enableReusePort: true
       trafficDirection: INBOUND
 Routes:
   Resources:

--- a/pkg/plugins/runtime/gateway/testdata/http/02-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/02-gateway-route.yaml
@@ -52,6 +52,7 @@ Listeners:
         socketAddress:
           address: 192.168.1.1
           portValue: 8080
+      enableReusePort: true
       filterChains:
       - filters:
         - name: envoy.filters.network.http_connection_manager
@@ -98,7 +99,6 @@ Listeners:
           '@type': type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
       name: edge-gateway:HTTP:8080
       perConnectionBufferLimitBytes: 32768
-      enableReusePort: true
       trafficDirection: INBOUND
 Routes:
   Resources:

--- a/pkg/plugins/runtime/gateway/testdata/http/02-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/02-gateway-route.yaml
@@ -98,7 +98,7 @@ Listeners:
           '@type': type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
       name: edge-gateway:HTTP:8080
       perConnectionBufferLimitBytes: 32768
-      reusePort: true
+      enableReusePort: true
       trafficDirection: INBOUND
 Routes:
   Resources:

--- a/pkg/plugins/runtime/gateway/testdata/http/03-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/03-gateway-route.yaml
@@ -52,6 +52,7 @@ Listeners:
         socketAddress:
           address: 192.168.1.1
           portValue: 8080
+      enableReusePort: true
       filterChains:
       - filters:
         - name: envoy.filters.network.http_connection_manager
@@ -98,7 +99,6 @@ Listeners:
           '@type': type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
       name: edge-gateway:HTTP:8080
       perConnectionBufferLimitBytes: 32768
-      enableReusePort: true
       trafficDirection: INBOUND
 Routes:
   Resources:

--- a/pkg/plugins/runtime/gateway/testdata/http/03-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/03-gateway-route.yaml
@@ -98,7 +98,7 @@ Listeners:
           '@type': type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
       name: edge-gateway:HTTP:8080
       perConnectionBufferLimitBytes: 32768
-      reusePort: true
+      enableReusePort: true
       trafficDirection: INBOUND
 Routes:
   Resources:

--- a/pkg/plugins/runtime/gateway/testdata/http/04-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/04-gateway-route.yaml
@@ -127,7 +127,7 @@ Listeners:
           '@type': type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
       name: edge-gateway:HTTP:8080
       perConnectionBufferLimitBytes: 32768
-      reusePort: true
+      enableReusePort: true
       trafficDirection: INBOUND
 Routes:
   Resources:

--- a/pkg/plugins/runtime/gateway/testdata/http/04-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/04-gateway-route.yaml
@@ -81,6 +81,7 @@ Listeners:
         socketAddress:
           address: 192.168.1.1
           portValue: 8080
+      enableReusePort: true
       filterChains:
       - filters:
         - name: envoy.filters.network.http_connection_manager
@@ -127,7 +128,6 @@ Listeners:
           '@type': type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
       name: edge-gateway:HTTP:8080
       perConnectionBufferLimitBytes: 32768
-      enableReusePort: true
       trafficDirection: INBOUND
 Routes:
   Resources:

--- a/pkg/plugins/runtime/gateway/testdata/http/05-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/05-gateway-route.yaml
@@ -55,7 +55,7 @@ Listeners:
           '@type': type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
       name: edge-gateway:HTTP:8080
       perConnectionBufferLimitBytes: 32768
-      reusePort: true
+      enableReusePort: true
       trafficDirection: INBOUND
 Routes:
   Resources:

--- a/pkg/plugins/runtime/gateway/testdata/http/05-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/05-gateway-route.yaml
@@ -9,6 +9,7 @@ Listeners:
         socketAddress:
           address: 192.168.1.1
           portValue: 8080
+      enableReusePort: true
       filterChains:
       - filters:
         - name: envoy.filters.network.http_connection_manager
@@ -55,7 +56,6 @@ Listeners:
           '@type': type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
       name: edge-gateway:HTTP:8080
       perConnectionBufferLimitBytes: 32768
-      enableReusePort: true
       trafficDirection: INBOUND
 Routes:
   Resources:

--- a/pkg/plugins/runtime/gateway/testdata/http/06-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/06-gateway-route.yaml
@@ -127,7 +127,7 @@ Listeners:
           '@type': type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
       name: edge-gateway:HTTP:8080
       perConnectionBufferLimitBytes: 32768
-      reusePort: true
+      enableReusePort: true
       trafficDirection: INBOUND
 Routes:
   Resources:

--- a/pkg/plugins/runtime/gateway/testdata/http/06-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/06-gateway-route.yaml
@@ -81,6 +81,7 @@ Listeners:
         socketAddress:
           address: 192.168.1.1
           portValue: 8080
+      enableReusePort: true
       filterChains:
       - filters:
         - name: envoy.filters.network.http_connection_manager
@@ -127,7 +128,6 @@ Listeners:
           '@type': type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
       name: edge-gateway:HTTP:8080
       perConnectionBufferLimitBytes: 32768
-      enableReusePort: true
       trafficDirection: INBOUND
 Routes:
   Resources:

--- a/pkg/plugins/runtime/gateway/testdata/http/07-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/07-gateway-route.yaml
@@ -52,6 +52,7 @@ Listeners:
         socketAddress:
           address: 192.168.1.1
           portValue: 8080
+      enableReusePort: true
       filterChains:
       - filters:
         - name: envoy.filters.network.http_connection_manager
@@ -98,7 +99,6 @@ Listeners:
           '@type': type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
       name: edge-gateway:HTTP:8080
       perConnectionBufferLimitBytes: 32768
-      enableReusePort: true
       trafficDirection: INBOUND
 Routes:
   Resources:

--- a/pkg/plugins/runtime/gateway/testdata/http/07-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/07-gateway-route.yaml
@@ -98,7 +98,7 @@ Listeners:
           '@type': type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
       name: edge-gateway:HTTP:8080
       perConnectionBufferLimitBytes: 32768
-      reusePort: true
+      enableReusePort: true
       trafficDirection: INBOUND
 Routes:
   Resources:

--- a/pkg/plugins/runtime/gateway/testdata/http/08-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/08-gateway-route.yaml
@@ -95,6 +95,7 @@ Listeners:
         socketAddress:
           address: 192.168.1.1
           portValue: 8080
+      enableReusePort: true
       filterChains:
       - filters:
         - name: envoy.filters.network.http_connection_manager
@@ -141,7 +142,6 @@ Listeners:
           '@type': type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
       name: edge-gateway:HTTP:8080
       perConnectionBufferLimitBytes: 32768
-      enableReusePort: true
       trafficDirection: INBOUND
 Routes:
   Resources:

--- a/pkg/plugins/runtime/gateway/testdata/http/08-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/08-gateway-route.yaml
@@ -141,7 +141,7 @@ Listeners:
           '@type': type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
       name: edge-gateway:HTTP:8080
       perConnectionBufferLimitBytes: 32768
-      reusePort: true
+      enableReusePort: true
       trafficDirection: INBOUND
 Routes:
   Resources:

--- a/pkg/plugins/runtime/gateway/testdata/http/09-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/09-gateway-route.yaml
@@ -52,6 +52,7 @@ Listeners:
         socketAddress:
           address: 192.168.1.1
           portValue: 8080
+      enableReusePort: true
       filterChains:
       - filters:
         - name: envoy.filters.network.http_connection_manager
@@ -98,7 +99,6 @@ Listeners:
           '@type': type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
       name: edge-gateway:HTTP:8080
       perConnectionBufferLimitBytes: 32768
-      enableReusePort: true
       trafficDirection: INBOUND
 Routes:
   Resources:

--- a/pkg/plugins/runtime/gateway/testdata/http/09-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/09-gateway-route.yaml
@@ -98,7 +98,7 @@ Listeners:
           '@type': type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
       name: edge-gateway:HTTP:8080
       perConnectionBufferLimitBytes: 32768
-      reusePort: true
+      enableReusePort: true
       trafficDirection: INBOUND
 Routes:
   Resources:

--- a/pkg/plugins/runtime/gateway/testdata/http/10-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/10-gateway-route.yaml
@@ -95,6 +95,7 @@ Listeners:
         socketAddress:
           address: 192.168.1.1
           portValue: 8080
+      enableReusePort: true
       filterChains:
       - filters:
         - name: envoy.filters.network.http_connection_manager
@@ -141,7 +142,6 @@ Listeners:
           '@type': type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
       name: edge-gateway:HTTP:8080
       perConnectionBufferLimitBytes: 32768
-      enableReusePort: true
       trafficDirection: INBOUND
 Routes:
   Resources:

--- a/pkg/plugins/runtime/gateway/testdata/http/10-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/10-gateway-route.yaml
@@ -141,7 +141,7 @@ Listeners:
           '@type': type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
       name: edge-gateway:HTTP:8080
       perConnectionBufferLimitBytes: 32768
-      reusePort: true
+      enableReusePort: true
       trafficDirection: INBOUND
 Routes:
   Resources:

--- a/pkg/plugins/runtime/gateway/testdata/http/11-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/11-gateway-route.yaml
@@ -95,6 +95,7 @@ Listeners:
         socketAddress:
           address: 192.168.1.1
           portValue: 8080
+      enableReusePort: true
       filterChains:
       - filters:
         - name: envoy.filters.network.http_connection_manager
@@ -141,7 +142,6 @@ Listeners:
           '@type': type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
       name: edge-gateway:HTTP:8080
       perConnectionBufferLimitBytes: 32768
-      enableReusePort: true
       trafficDirection: INBOUND
 Routes:
   Resources:

--- a/pkg/plugins/runtime/gateway/testdata/http/11-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/11-gateway-route.yaml
@@ -141,7 +141,7 @@ Listeners:
           '@type': type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
       name: edge-gateway:HTTP:8080
       perConnectionBufferLimitBytes: 32768
-      reusePort: true
+      enableReusePort: true
       trafficDirection: INBOUND
 Routes:
   Resources:

--- a/pkg/plugins/runtime/gateway/testdata/http/12-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/12-gateway-route.yaml
@@ -52,6 +52,7 @@ Listeners:
         socketAddress:
           address: 192.168.1.1
           portValue: 8080
+      enableReusePort: true
       filterChains:
       - filters:
         - name: envoy.filters.network.http_connection_manager
@@ -98,7 +99,6 @@ Listeners:
           '@type': type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
       name: edge-gateway:HTTP:8080
       perConnectionBufferLimitBytes: 32768
-      enableReusePort: true
       trafficDirection: INBOUND
 Routes:
   Resources:

--- a/pkg/plugins/runtime/gateway/testdata/http/12-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/12-gateway-route.yaml
@@ -98,7 +98,7 @@ Listeners:
           '@type': type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
       name: edge-gateway:HTTP:8080
       perConnectionBufferLimitBytes: 32768
-      reusePort: true
+      enableReusePort: true
       trafficDirection: INBOUND
 Routes:
   Resources:

--- a/pkg/plugins/runtime/gateway/testdata/http/13-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/13-gateway-route.yaml
@@ -184,7 +184,7 @@ Listeners:
           '@type': type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
       name: edge-gateway:HTTP:8080
       perConnectionBufferLimitBytes: 32768
-      reusePort: true
+      enableReusePort: true
       trafficDirection: INBOUND
 Routes:
   Resources:

--- a/pkg/plugins/runtime/gateway/testdata/http/13-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/13-gateway-route.yaml
@@ -138,6 +138,7 @@ Listeners:
         socketAddress:
           address: 192.168.1.1
           portValue: 8080
+      enableReusePort: true
       filterChains:
       - filters:
         - name: envoy.filters.network.http_connection_manager
@@ -184,7 +185,6 @@ Listeners:
           '@type': type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
       name: edge-gateway:HTTP:8080
       perConnectionBufferLimitBytes: 32768
-      enableReusePort: true
       trafficDirection: INBOUND
 Routes:
   Resources:

--- a/pkg/plugins/runtime/gateway/testdata/http/14-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/14-gateway-route.yaml
@@ -52,6 +52,7 @@ Listeners:
         socketAddress:
           address: 192.168.1.1
           portValue: 8080
+      enableReusePort: true
       filterChains:
       - filters:
         - name: envoy.filters.network.http_connection_manager
@@ -98,7 +99,6 @@ Listeners:
           '@type': type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
       name: edge-gateway:HTTP:8080
       perConnectionBufferLimitBytes: 32768
-      enableReusePort: true
       trafficDirection: INBOUND
 Routes:
   Resources:

--- a/pkg/plugins/runtime/gateway/testdata/http/14-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/14-gateway-route.yaml
@@ -98,7 +98,7 @@ Listeners:
           '@type': type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
       name: edge-gateway:HTTP:8080
       perConnectionBufferLimitBytes: 32768
-      reusePort: true
+      enableReusePort: true
       trafficDirection: INBOUND
 Routes:
   Resources:

--- a/pkg/plugins/runtime/gateway/testdata/http/15-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/15-gateway-route.yaml
@@ -184,7 +184,7 @@ Listeners:
           '@type': type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
       name: edge-gateway:HTTP:8080
       perConnectionBufferLimitBytes: 32768
-      reusePort: true
+      enableReusePort: true
       trafficDirection: INBOUND
 Routes:
   Resources:

--- a/pkg/plugins/runtime/gateway/testdata/http/15-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/15-gateway-route.yaml
@@ -138,6 +138,7 @@ Listeners:
         socketAddress:
           address: 192.168.1.1
           portValue: 8080
+      enableReusePort: true
       filterChains:
       - filters:
         - name: envoy.filters.network.http_connection_manager
@@ -184,7 +185,6 @@ Listeners:
           '@type': type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
       name: edge-gateway:HTTP:8080
       perConnectionBufferLimitBytes: 32768
-      enableReusePort: true
       trafficDirection: INBOUND
 Routes:
   Resources:

--- a/pkg/plugins/runtime/gateway/testdata/http/16-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/16-gateway-route.yaml
@@ -135,6 +135,7 @@ Listeners:
         socketAddress:
           address: 192.168.1.1
           portValue: 8080
+      enableReusePort: true
       filterChains:
       - filters:
         - name: envoy.filters.network.http_connection_manager
@@ -181,7 +182,6 @@ Listeners:
           '@type': type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
       name: edge-gateway:HTTP:8080
       perConnectionBufferLimitBytes: 32768
-      enableReusePort: true
       trafficDirection: INBOUND
 Routes:
   Resources:

--- a/pkg/plugins/runtime/gateway/testdata/http/16-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/16-gateway-route.yaml
@@ -181,7 +181,7 @@ Listeners:
           '@type': type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
       name: edge-gateway:HTTP:8080
       perConnectionBufferLimitBytes: 32768
-      reusePort: true
+      enableReusePort: true
       trafficDirection: INBOUND
 Routes:
   Resources:

--- a/pkg/plugins/runtime/gateway/testdata/http/17-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/17-gateway-route.yaml
@@ -156,6 +156,7 @@ Listeners:
         socketAddress:
           address: 192.168.1.1
           portValue: 8080
+      enableReusePort: true
       filterChains:
       - filters:
         - name: envoy.filters.network.http_connection_manager
@@ -202,7 +203,6 @@ Listeners:
           '@type': type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
       name: edge-gateway:HTTP:8080
       perConnectionBufferLimitBytes: 32768
-      enableReusePort: true
       trafficDirection: INBOUND
 Routes:
   Resources:

--- a/pkg/plugins/runtime/gateway/testdata/http/17-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/17-gateway-route.yaml
@@ -202,7 +202,7 @@ Listeners:
           '@type': type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
       name: edge-gateway:HTTP:8080
       perConnectionBufferLimitBytes: 32768
-      reusePort: true
+      enableReusePort: true
       trafficDirection: INBOUND
 Routes:
   Resources:

--- a/pkg/plugins/runtime/gateway/testdata/http/18-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/18-gateway-route.yaml
@@ -49,6 +49,7 @@ Listeners:
         socketAddress:
           address: 192.168.1.1
           portValue: 8080
+      enableReusePort: true
       filterChains:
       - filters:
         - name: envoy.filters.network.http_connection_manager
@@ -95,7 +96,6 @@ Listeners:
           '@type': type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
       name: edge-gateway:HTTP:8080
       perConnectionBufferLimitBytes: 32768
-      enableReusePort: true
       trafficDirection: INBOUND
 Routes:
   Resources:

--- a/pkg/plugins/runtime/gateway/testdata/http/18-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/18-gateway-route.yaml
@@ -95,7 +95,7 @@ Listeners:
           '@type': type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
       name: edge-gateway:HTTP:8080
       perConnectionBufferLimitBytes: 32768
-      reusePort: true
+      enableReusePort: true
       trafficDirection: INBOUND
 Routes:
   Resources:

--- a/pkg/plugins/runtime/gateway/testdata/http/19-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/19-gateway-route.yaml
@@ -107,7 +107,7 @@ Listeners:
           '@type': type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
       name: edge-gateway:HTTP:8080
       perConnectionBufferLimitBytes: 32768
-      reusePort: true
+      enableReusePort: true
       trafficDirection: INBOUND
 Routes:
   Resources:

--- a/pkg/plugins/runtime/gateway/testdata/http/19-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/19-gateway-route.yaml
@@ -61,6 +61,7 @@ Listeners:
         socketAddress:
           address: 192.168.1.1
           portValue: 8080
+      enableReusePort: true
       filterChains:
       - filters:
         - name: envoy.filters.network.http_connection_manager
@@ -107,7 +108,6 @@ Listeners:
           '@type': type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
       name: edge-gateway:HTTP:8080
       perConnectionBufferLimitBytes: 32768
-      enableReusePort: true
       trafficDirection: INBOUND
 Routes:
   Resources:

--- a/pkg/plugins/runtime/gateway/testdata/http/20-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/20-gateway-route.yaml
@@ -138,6 +138,7 @@ Listeners:
         socketAddress:
           address: 192.168.1.1
           portValue: 9080
+      enableReusePort: true
       filterChains:
       - filters:
         - name: envoy.filters.network.http_connection_manager
@@ -184,7 +185,6 @@ Listeners:
           '@type': type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
       name: gateway-multihost:HTTP:9080
       perConnectionBufferLimitBytes: 32768
-      enableReusePort: true
       trafficDirection: INBOUND
 Routes:
   Resources:

--- a/pkg/plugins/runtime/gateway/testdata/http/20-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/20-gateway-route.yaml
@@ -184,7 +184,7 @@ Listeners:
           '@type': type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
       name: gateway-multihost:HTTP:9080
       perConnectionBufferLimitBytes: 32768
-      reusePort: true
+      enableReusePort: true
       trafficDirection: INBOUND
 Routes:
   Resources:

--- a/pkg/plugins/runtime/gateway/testdata/http/21-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/21-gateway-route.yaml
@@ -184,7 +184,7 @@ Listeners:
           '@type': type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
       name: edge-gateway:HTTP:8080
       perConnectionBufferLimitBytes: 32768
-      reusePort: true
+      enableReusePort: true
       trafficDirection: INBOUND
 Routes:
   Resources:

--- a/pkg/plugins/runtime/gateway/testdata/http/21-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/21-gateway-route.yaml
@@ -138,6 +138,7 @@ Listeners:
         socketAddress:
           address: 192.168.1.1
           portValue: 8080
+      enableReusePort: true
       filterChains:
       - filters:
         - name: envoy.filters.network.http_connection_manager
@@ -184,7 +185,6 @@ Listeners:
           '@type': type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
       name: edge-gateway:HTTP:8080
       perConnectionBufferLimitBytes: 32768
-      enableReusePort: true
       trafficDirection: INBOUND
 Routes:
   Resources:

--- a/pkg/plugins/runtime/gateway/testdata/http/22-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/22-gateway-route.yaml
@@ -95,6 +95,7 @@ Listeners:
         socketAddress:
           address: 192.168.1.1
           portValue: 8080
+      enableReusePort: true
       filterChains:
       - filters:
         - name: envoy.filters.network.http_connection_manager
@@ -141,7 +142,6 @@ Listeners:
           '@type': type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
       name: edge-gateway:HTTP:8080
       perConnectionBufferLimitBytes: 32768
-      enableReusePort: true
       trafficDirection: INBOUND
 Routes:
   Resources:

--- a/pkg/plugins/runtime/gateway/testdata/http/22-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/22-gateway-route.yaml
@@ -141,7 +141,7 @@ Listeners:
           '@type': type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
       name: edge-gateway:HTTP:8080
       perConnectionBufferLimitBytes: 32768
-      reusePort: true
+      enableReusePort: true
       trafficDirection: INBOUND
 Routes:
   Resources:

--- a/pkg/plugins/runtime/gateway/testdata/http/23-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/23-gateway-route.yaml
@@ -95,6 +95,7 @@ Listeners:
         socketAddress:
           address: 192.168.1.1
           portValue: 8080
+      enableReusePort: true
       filterChains:
       - filters:
         - name: envoy.filters.network.http_connection_manager
@@ -141,7 +142,6 @@ Listeners:
           '@type': type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
       name: edge-gateway:HTTP:8080
       perConnectionBufferLimitBytes: 32768
-      enableReusePort: true
       trafficDirection: INBOUND
 Routes:
   Resources:

--- a/pkg/plugins/runtime/gateway/testdata/http/23-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/23-gateway-route.yaml
@@ -141,7 +141,7 @@ Listeners:
           '@type': type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
       name: edge-gateway:HTTP:8080
       perConnectionBufferLimitBytes: 32768
-      reusePort: true
+      enableReusePort: true
       trafficDirection: INBOUND
 Routes:
   Resources:

--- a/pkg/plugins/runtime/gateway/testdata/http/24-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/24-gateway-route.yaml
@@ -95,6 +95,7 @@ Listeners:
         socketAddress:
           address: 192.168.1.1
           portValue: 8080
+      enableReusePort: true
       filterChains:
       - filters:
         - name: envoy.filters.network.http_connection_manager
@@ -141,7 +142,6 @@ Listeners:
           '@type': type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
       name: edge-gateway:HTTP:8080
       perConnectionBufferLimitBytes: 32768
-      enableReusePort: true
       trafficDirection: INBOUND
 Routes:
   Resources:

--- a/pkg/plugins/runtime/gateway/testdata/http/24-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/24-gateway-route.yaml
@@ -141,7 +141,7 @@ Listeners:
           '@type': type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
       name: edge-gateway:HTTP:8080
       perConnectionBufferLimitBytes: 32768
-      reusePort: true
+      enableReusePort: true
       trafficDirection: INBOUND
 Routes:
   Resources:

--- a/pkg/plugins/runtime/gateway/testdata/http/25-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/25-gateway-route.yaml
@@ -120,7 +120,7 @@ Listeners:
           '@type': type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
       name: edge-gateway:HTTP:8080
       perConnectionBufferLimitBytes: 32768
-      reusePort: true
+      enableReusePort: true
       trafficDirection: INBOUND
 Routes:
   Resources:

--- a/pkg/plugins/runtime/gateway/testdata/http/25-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/25-gateway-route.yaml
@@ -74,6 +74,7 @@ Listeners:
         socketAddress:
           address: 192.168.1.1
           portValue: 8080
+      enableReusePort: true
       filterChains:
       - filters:
         - name: envoy.filters.network.http_connection_manager
@@ -120,7 +121,6 @@ Listeners:
           '@type': type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
       name: edge-gateway:HTTP:8080
       perConnectionBufferLimitBytes: 32768
-      enableReusePort: true
       trafficDirection: INBOUND
 Routes:
   Resources:

--- a/pkg/plugins/runtime/gateway/testdata/http/26-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/26-gateway-route.yaml
@@ -106,7 +106,7 @@ Listeners:
           '@type': type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
       name: edge-gateway:HTTP:8080
       perConnectionBufferLimitBytes: 32768
-      reusePort: true
+      enableReusePort: true
       trafficDirection: INBOUND
 Routes:
   Resources:

--- a/pkg/plugins/runtime/gateway/testdata/http/26-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/26-gateway-route.yaml
@@ -60,6 +60,7 @@ Listeners:
         socketAddress:
           address: 192.168.1.1
           portValue: 8080
+      enableReusePort: true
       filterChains:
       - filters:
         - name: envoy.filters.network.http_connection_manager
@@ -106,7 +107,6 @@ Listeners:
           '@type': type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
       name: edge-gateway:HTTP:8080
       perConnectionBufferLimitBytes: 32768
-      enableReusePort: true
       trafficDirection: INBOUND
 Routes:
   Resources:

--- a/pkg/plugins/runtime/gateway/testdata/https/01-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/01-gateway-route.yaml
@@ -52,6 +52,7 @@ Listeners:
         socketAddress:
           address: 192.168.1.1
           portValue: 8080
+      enableReusePort: true
       filterChains:
       - filters:
         - name: envoy.filters.network.http_connection_manager
@@ -98,7 +99,6 @@ Listeners:
           '@type': type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
       name: edge-gateway:HTTP:8080
       perConnectionBufferLimitBytes: 32768
-      enableReusePort: true
       trafficDirection: INBOUND
 Routes:
   Resources:

--- a/pkg/plugins/runtime/gateway/testdata/https/01-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/01-gateway-route.yaml
@@ -98,7 +98,7 @@ Listeners:
           '@type': type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
       name: edge-gateway:HTTP:8080
       perConnectionBufferLimitBytes: 32768
-      reusePort: true
+      enableReusePort: true
       trafficDirection: INBOUND
 Routes:
   Resources:

--- a/pkg/plugins/runtime/gateway/testdata/https/02-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/02-gateway-route.yaml
@@ -52,6 +52,7 @@ Listeners:
         socketAddress:
           address: 192.168.1.1
           portValue: 8080
+      enableReusePort: true
       filterChains:
       - filters:
         - name: envoy.filters.network.http_connection_manager
@@ -98,7 +99,6 @@ Listeners:
           '@type': type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
       name: edge-gateway:HTTP:8080
       perConnectionBufferLimitBytes: 32768
-      enableReusePort: true
       trafficDirection: INBOUND
 Routes:
   Resources:

--- a/pkg/plugins/runtime/gateway/testdata/https/02-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/02-gateway-route.yaml
@@ -98,7 +98,7 @@ Listeners:
           '@type': type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
       name: edge-gateway:HTTP:8080
       perConnectionBufferLimitBytes: 32768
-      reusePort: true
+      enableReusePort: true
       trafficDirection: INBOUND
 Routes:
   Resources:

--- a/pkg/plugins/runtime/gateway/testdata/https/03-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/03-gateway-route.yaml
@@ -121,7 +121,7 @@ Listeners:
           '@type': type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
       name: edge-gateway:HTTPS:8080
       perConnectionBufferLimitBytes: 32768
-      reusePort: true
+      enableReusePort: true
       trafficDirection: INBOUND
 Routes:
   Resources:

--- a/pkg/plugins/runtime/gateway/testdata/https/03-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/03-gateway-route.yaml
@@ -52,6 +52,7 @@ Listeners:
         socketAddress:
           address: 192.168.1.1
           portValue: 8080
+      enableReusePort: true
       filterChains:
       - filterChainMatch:
           applicationProtocols:
@@ -121,7 +122,6 @@ Listeners:
           '@type': type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
       name: edge-gateway:HTTPS:8080
       perConnectionBufferLimitBytes: 32768
-      enableReusePort: true
       trafficDirection: INBOUND
 Routes:
   Resources:

--- a/pkg/plugins/runtime/gateway/testdata/https/04-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/04-gateway-route.yaml
@@ -81,6 +81,7 @@ Listeners:
         socketAddress:
           address: 192.168.1.1
           portValue: 8080
+      enableReusePort: true
       filterChains:
       - filterChainMatch:
           applicationProtocols:
@@ -150,7 +151,6 @@ Listeners:
           '@type': type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
       name: edge-gateway:HTTPS:8080
       perConnectionBufferLimitBytes: 32768
-      enableReusePort: true
       trafficDirection: INBOUND
 Routes:
   Resources:

--- a/pkg/plugins/runtime/gateway/testdata/https/04-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/04-gateway-route.yaml
@@ -150,7 +150,7 @@ Listeners:
           '@type': type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
       name: edge-gateway:HTTPS:8080
       perConnectionBufferLimitBytes: 32768
-      reusePort: true
+      enableReusePort: true
       trafficDirection: INBOUND
 Routes:
   Resources:

--- a/pkg/plugins/runtime/gateway/testdata/https/05-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/05-gateway-route.yaml
@@ -78,7 +78,7 @@ Listeners:
           '@type': type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
       name: edge-gateway:HTTPS:8080
       perConnectionBufferLimitBytes: 32768
-      reusePort: true
+      enableReusePort: true
       trafficDirection: INBOUND
 Routes:
   Resources:

--- a/pkg/plugins/runtime/gateway/testdata/https/05-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/05-gateway-route.yaml
@@ -9,6 +9,7 @@ Listeners:
         socketAddress:
           address: 192.168.1.1
           portValue: 8080
+      enableReusePort: true
       filterChains:
       - filterChainMatch:
           applicationProtocols:
@@ -78,7 +79,6 @@ Listeners:
           '@type': type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
       name: edge-gateway:HTTPS:8080
       perConnectionBufferLimitBytes: 32768
-      enableReusePort: true
       trafficDirection: INBOUND
 Routes:
   Resources:

--- a/pkg/plugins/runtime/gateway/testdata/https/06-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/06-gateway-route.yaml
@@ -81,6 +81,7 @@ Listeners:
         socketAddress:
           address: 192.168.1.1
           portValue: 8080
+      enableReusePort: true
       filterChains:
       - filterChainMatch:
           applicationProtocols:
@@ -150,7 +151,6 @@ Listeners:
           '@type': type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
       name: edge-gateway:HTTPS:8080
       perConnectionBufferLimitBytes: 32768
-      enableReusePort: true
       trafficDirection: INBOUND
 Routes:
   Resources:

--- a/pkg/plugins/runtime/gateway/testdata/https/06-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/06-gateway-route.yaml
@@ -150,7 +150,7 @@ Listeners:
           '@type': type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
       name: edge-gateway:HTTPS:8080
       perConnectionBufferLimitBytes: 32768
-      reusePort: true
+      enableReusePort: true
       trafficDirection: INBOUND
 Routes:
   Resources:

--- a/pkg/plugins/runtime/gateway/testdata/https/07-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/07-gateway-route.yaml
@@ -121,7 +121,7 @@ Listeners:
           '@type': type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
       name: edge-gateway:HTTPS:8080
       perConnectionBufferLimitBytes: 32768
-      reusePort: true
+      enableReusePort: true
       trafficDirection: INBOUND
 Routes:
   Resources:

--- a/pkg/plugins/runtime/gateway/testdata/https/07-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/07-gateway-route.yaml
@@ -52,6 +52,7 @@ Listeners:
         socketAddress:
           address: 192.168.1.1
           portValue: 8080
+      enableReusePort: true
       filterChains:
       - filterChainMatch:
           applicationProtocols:
@@ -121,7 +122,6 @@ Listeners:
           '@type': type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
       name: edge-gateway:HTTPS:8080
       perConnectionBufferLimitBytes: 32768
-      enableReusePort: true
       trafficDirection: INBOUND
 Routes:
   Resources:

--- a/pkg/plugins/runtime/gateway/testdata/https/08-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/08-gateway-route.yaml
@@ -95,6 +95,7 @@ Listeners:
         socketAddress:
           address: 192.168.1.1
           portValue: 8080
+      enableReusePort: true
       filterChains:
       - filterChainMatch:
           applicationProtocols:
@@ -164,7 +165,6 @@ Listeners:
           '@type': type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
       name: edge-gateway:HTTPS:8080
       perConnectionBufferLimitBytes: 32768
-      enableReusePort: true
       trafficDirection: INBOUND
 Routes:
   Resources:

--- a/pkg/plugins/runtime/gateway/testdata/https/08-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/08-gateway-route.yaml
@@ -164,7 +164,7 @@ Listeners:
           '@type': type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
       name: edge-gateway:HTTPS:8080
       perConnectionBufferLimitBytes: 32768
-      reusePort: true
+      enableReusePort: true
       trafficDirection: INBOUND
 Routes:
   Resources:

--- a/pkg/plugins/runtime/gateway/testdata/https/09-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/09-gateway-route.yaml
@@ -121,7 +121,7 @@ Listeners:
           '@type': type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
       name: edge-gateway:HTTPS:8080
       perConnectionBufferLimitBytes: 32768
-      reusePort: true
+      enableReusePort: true
       trafficDirection: INBOUND
 Routes:
   Resources:

--- a/pkg/plugins/runtime/gateway/testdata/https/09-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/09-gateway-route.yaml
@@ -52,6 +52,7 @@ Listeners:
         socketAddress:
           address: 192.168.1.1
           portValue: 8080
+      enableReusePort: true
       filterChains:
       - filterChainMatch:
           applicationProtocols:
@@ -121,7 +122,6 @@ Listeners:
           '@type': type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
       name: edge-gateway:HTTPS:8080
       perConnectionBufferLimitBytes: 32768
-      enableReusePort: true
       trafficDirection: INBOUND
 Routes:
   Resources:

--- a/pkg/plugins/runtime/gateway/testdata/https/10-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/10-gateway-route.yaml
@@ -95,6 +95,7 @@ Listeners:
         socketAddress:
           address: 192.168.1.1
           portValue: 8080
+      enableReusePort: true
       filterChains:
       - filterChainMatch:
           applicationProtocols:
@@ -164,7 +165,6 @@ Listeners:
           '@type': type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
       name: edge-gateway:HTTPS:8080
       perConnectionBufferLimitBytes: 32768
-      enableReusePort: true
       trafficDirection: INBOUND
 Routes:
   Resources:

--- a/pkg/plugins/runtime/gateway/testdata/https/10-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/10-gateway-route.yaml
@@ -164,7 +164,7 @@ Listeners:
           '@type': type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
       name: edge-gateway:HTTPS:8080
       perConnectionBufferLimitBytes: 32768
-      reusePort: true
+      enableReusePort: true
       trafficDirection: INBOUND
 Routes:
   Resources:

--- a/pkg/plugins/runtime/gateway/testdata/https/11-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/11-gateway-route.yaml
@@ -95,6 +95,7 @@ Listeners:
         socketAddress:
           address: 192.168.1.1
           portValue: 8080
+      enableReusePort: true
       filterChains:
       - filterChainMatch:
           applicationProtocols:
@@ -164,7 +165,6 @@ Listeners:
           '@type': type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
       name: edge-gateway:HTTPS:8080
       perConnectionBufferLimitBytes: 32768
-      enableReusePort: true
       trafficDirection: INBOUND
 Routes:
   Resources:

--- a/pkg/plugins/runtime/gateway/testdata/https/11-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/11-gateway-route.yaml
@@ -164,7 +164,7 @@ Listeners:
           '@type': type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
       name: edge-gateway:HTTPS:8080
       perConnectionBufferLimitBytes: 32768
-      reusePort: true
+      enableReusePort: true
       trafficDirection: INBOUND
 Routes:
   Resources:

--- a/pkg/plugins/runtime/gateway/testdata/https/12-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/12-gateway-route.yaml
@@ -121,7 +121,7 @@ Listeners:
           '@type': type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
       name: edge-gateway:HTTPS:8080
       perConnectionBufferLimitBytes: 32768
-      reusePort: true
+      enableReusePort: true
       trafficDirection: INBOUND
 Routes:
   Resources:

--- a/pkg/plugins/runtime/gateway/testdata/https/12-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/12-gateway-route.yaml
@@ -52,6 +52,7 @@ Listeners:
         socketAddress:
           address: 192.168.1.1
           portValue: 8080
+      enableReusePort: true
       filterChains:
       - filterChainMatch:
           applicationProtocols:
@@ -121,7 +122,6 @@ Listeners:
           '@type': type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
       name: edge-gateway:HTTPS:8080
       perConnectionBufferLimitBytes: 32768
-      enableReusePort: true
       trafficDirection: INBOUND
 Routes:
   Resources:

--- a/pkg/plugins/runtime/gateway/testdata/https/13-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/13-gateway-route.yaml
@@ -138,6 +138,7 @@ Listeners:
         socketAddress:
           address: 192.168.1.1
           portValue: 8080
+      enableReusePort: true
       filterChains:
       - filterChainMatch:
           applicationProtocols:
@@ -207,7 +208,6 @@ Listeners:
           '@type': type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
       name: edge-gateway:HTTPS:8080
       perConnectionBufferLimitBytes: 32768
-      enableReusePort: true
       trafficDirection: INBOUND
 Routes:
   Resources:

--- a/pkg/plugins/runtime/gateway/testdata/https/13-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/13-gateway-route.yaml
@@ -207,7 +207,7 @@ Listeners:
           '@type': type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
       name: edge-gateway:HTTPS:8080
       perConnectionBufferLimitBytes: 32768
-      reusePort: true
+      enableReusePort: true
       trafficDirection: INBOUND
 Routes:
   Resources:

--- a/pkg/plugins/runtime/gateway/testdata/https/14-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/14-gateway-route.yaml
@@ -121,7 +121,7 @@ Listeners:
           '@type': type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
       name: edge-gateway:HTTPS:8080
       perConnectionBufferLimitBytes: 32768
-      reusePort: true
+      enableReusePort: true
       trafficDirection: INBOUND
 Routes:
   Resources:

--- a/pkg/plugins/runtime/gateway/testdata/https/14-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/14-gateway-route.yaml
@@ -52,6 +52,7 @@ Listeners:
         socketAddress:
           address: 192.168.1.1
           portValue: 8080
+      enableReusePort: true
       filterChains:
       - filterChainMatch:
           applicationProtocols:
@@ -121,7 +122,6 @@ Listeners:
           '@type': type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
       name: edge-gateway:HTTPS:8080
       perConnectionBufferLimitBytes: 32768
-      enableReusePort: true
       trafficDirection: INBOUND
 Routes:
   Resources:

--- a/pkg/plugins/runtime/gateway/testdata/https/15-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/15-gateway-route.yaml
@@ -138,6 +138,7 @@ Listeners:
         socketAddress:
           address: 192.168.1.1
           portValue: 8080
+      enableReusePort: true
       filterChains:
       - filterChainMatch:
           applicationProtocols:
@@ -207,7 +208,6 @@ Listeners:
           '@type': type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
       name: edge-gateway:HTTPS:8080
       perConnectionBufferLimitBytes: 32768
-      enableReusePort: true
       trafficDirection: INBOUND
 Routes:
   Resources:

--- a/pkg/plugins/runtime/gateway/testdata/https/15-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/15-gateway-route.yaml
@@ -207,7 +207,7 @@ Listeners:
           '@type': type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
       name: edge-gateway:HTTPS:8080
       perConnectionBufferLimitBytes: 32768
-      reusePort: true
+      enableReusePort: true
       trafficDirection: INBOUND
 Routes:
   Resources:

--- a/pkg/plugins/runtime/gateway/testdata/https/16-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/16-gateway-route.yaml
@@ -204,7 +204,7 @@ Listeners:
           '@type': type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
       name: edge-gateway:HTTPS:8080
       perConnectionBufferLimitBytes: 32768
-      reusePort: true
+      enableReusePort: true
       trafficDirection: INBOUND
 Routes:
   Resources:

--- a/pkg/plugins/runtime/gateway/testdata/https/16-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/16-gateway-route.yaml
@@ -135,6 +135,7 @@ Listeners:
         socketAddress:
           address: 192.168.1.1
           portValue: 8080
+      enableReusePort: true
       filterChains:
       - filterChainMatch:
           applicationProtocols:
@@ -204,7 +205,6 @@ Listeners:
           '@type': type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
       name: edge-gateway:HTTPS:8080
       perConnectionBufferLimitBytes: 32768
-      enableReusePort: true
       trafficDirection: INBOUND
 Routes:
   Resources:

--- a/pkg/plugins/runtime/gateway/testdata/https/17-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/17-gateway-route.yaml
@@ -156,6 +156,7 @@ Listeners:
         socketAddress:
           address: 192.168.1.1
           portValue: 8080
+      enableReusePort: true
       filterChains:
       - filterChainMatch:
           applicationProtocols:
@@ -225,7 +226,6 @@ Listeners:
           '@type': type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
       name: edge-gateway:HTTPS:8080
       perConnectionBufferLimitBytes: 32768
-      enableReusePort: true
       trafficDirection: INBOUND
 Routes:
   Resources:

--- a/pkg/plugins/runtime/gateway/testdata/https/17-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/17-gateway-route.yaml
@@ -225,7 +225,7 @@ Listeners:
           '@type': type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
       name: edge-gateway:HTTPS:8080
       perConnectionBufferLimitBytes: 32768
-      reusePort: true
+      enableReusePort: true
       trafficDirection: INBOUND
 Routes:
   Resources:

--- a/pkg/plugins/runtime/gateway/testdata/https/18-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/18-gateway-route.yaml
@@ -118,7 +118,7 @@ Listeners:
           '@type': type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
       name: edge-gateway:HTTPS:8080
       perConnectionBufferLimitBytes: 32768
-      reusePort: true
+      enableReusePort: true
       trafficDirection: INBOUND
 Routes:
   Resources:

--- a/pkg/plugins/runtime/gateway/testdata/https/18-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/18-gateway-route.yaml
@@ -49,6 +49,7 @@ Listeners:
         socketAddress:
           address: 192.168.1.1
           portValue: 8080
+      enableReusePort: true
       filterChains:
       - filterChainMatch:
           applicationProtocols:
@@ -118,7 +119,6 @@ Listeners:
           '@type': type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
       name: edge-gateway:HTTPS:8080
       perConnectionBufferLimitBytes: 32768
-      enableReusePort: true
       trafficDirection: INBOUND
 Routes:
   Resources:

--- a/pkg/plugins/runtime/gateway/testdata/https/19-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/19-gateway-route.yaml
@@ -130,7 +130,7 @@ Listeners:
           '@type': type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
       name: edge-gateway:HTTPS:8080
       perConnectionBufferLimitBytes: 32768
-      reusePort: true
+      enableReusePort: true
       trafficDirection: INBOUND
 Routes:
   Resources:

--- a/pkg/plugins/runtime/gateway/testdata/https/19-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/19-gateway-route.yaml
@@ -61,6 +61,7 @@ Listeners:
         socketAddress:
           address: 192.168.1.1
           portValue: 8080
+      enableReusePort: true
       filterChains:
       - filterChainMatch:
           applicationProtocols:
@@ -130,7 +131,6 @@ Listeners:
           '@type': type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
       name: edge-gateway:HTTPS:8080
       perConnectionBufferLimitBytes: 32768
-      enableReusePort: true
       trafficDirection: INBOUND
 Routes:
   Resources:

--- a/pkg/plugins/runtime/gateway/testdata/https/20-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/20-gateway-route.yaml
@@ -331,7 +331,7 @@ Listeners:
           '@type': type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
       name: gateway-multihost:HTTPS:9443
       perConnectionBufferLimitBytes: 32768
-      reusePort: true
+      enableReusePort: true
       trafficDirection: INBOUND
 Routes:
   Resources:

--- a/pkg/plugins/runtime/gateway/testdata/https/20-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/20-gateway-route.yaml
@@ -138,6 +138,7 @@ Listeners:
         socketAddress:
           address: 192.168.1.1
           portValue: 9443
+      enableReusePort: true
       filterChains:
       - filterChainMatch:
           applicationProtocols:
@@ -331,7 +332,6 @@ Listeners:
           '@type': type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
       name: gateway-multihost:HTTPS:9443
       perConnectionBufferLimitBytes: 32768
-      enableReusePort: true
       trafficDirection: INBOUND
 Routes:
   Resources:

--- a/pkg/plugins/runtime/gateway/testdata/https/21-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/21-gateway-route.yaml
@@ -138,6 +138,7 @@ Listeners:
         socketAddress:
           address: 192.168.1.1
           portValue: 8080
+      enableReusePort: true
       filterChains:
       - filterChainMatch:
           applicationProtocols:
@@ -207,7 +208,6 @@ Listeners:
           '@type': type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
       name: edge-gateway:HTTPS:8080
       perConnectionBufferLimitBytes: 32768
-      enableReusePort: true
       trafficDirection: INBOUND
 Routes:
   Resources:

--- a/pkg/plugins/runtime/gateway/testdata/https/21-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/21-gateway-route.yaml
@@ -207,7 +207,7 @@ Listeners:
           '@type': type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
       name: edge-gateway:HTTPS:8080
       perConnectionBufferLimitBytes: 32768
-      reusePort: true
+      enableReusePort: true
       trafficDirection: INBOUND
 Routes:
   Resources:

--- a/pkg/plugins/runtime/gateway/testdata/https/22-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/22-gateway-route.yaml
@@ -95,6 +95,7 @@ Listeners:
         socketAddress:
           address: 192.168.1.1
           portValue: 8080
+      enableReusePort: true
       filterChains:
       - filters:
         - name: envoy.filters.network.http_connection_manager
@@ -141,7 +142,6 @@ Listeners:
           '@type': type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
       name: edge-gateway:HTTP:8080
       perConnectionBufferLimitBytes: 32768
-      enableReusePort: true
       trafficDirection: INBOUND
 Routes:
   Resources:

--- a/pkg/plugins/runtime/gateway/testdata/https/22-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/22-gateway-route.yaml
@@ -141,7 +141,7 @@ Listeners:
           '@type': type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
       name: edge-gateway:HTTP:8080
       perConnectionBufferLimitBytes: 32768
-      reusePort: true
+      enableReusePort: true
       trafficDirection: INBOUND
 Routes:
   Resources:

--- a/pkg/plugins/runtime/gateway/testdata/https/23-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/23-gateway-route.yaml
@@ -95,6 +95,7 @@ Listeners:
         socketAddress:
           address: 192.168.1.1
           portValue: 8080
+      enableReusePort: true
       filterChains:
       - filters:
         - name: envoy.filters.network.http_connection_manager
@@ -141,7 +142,6 @@ Listeners:
           '@type': type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
       name: edge-gateway:HTTP:8080
       perConnectionBufferLimitBytes: 32768
-      enableReusePort: true
       trafficDirection: INBOUND
 Routes:
   Resources:

--- a/pkg/plugins/runtime/gateway/testdata/https/23-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/23-gateway-route.yaml
@@ -141,7 +141,7 @@ Listeners:
           '@type': type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
       name: edge-gateway:HTTP:8080
       perConnectionBufferLimitBytes: 32768
-      reusePort: true
+      enableReusePort: true
       trafficDirection: INBOUND
 Routes:
   Resources:

--- a/pkg/plugins/runtime/gateway/testdata/https/24-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/24-gateway-route.yaml
@@ -95,6 +95,7 @@ Listeners:
         socketAddress:
           address: 192.168.1.1
           portValue: 8080
+      enableReusePort: true
       filterChains:
       - filters:
         - name: envoy.filters.network.http_connection_manager
@@ -141,7 +142,6 @@ Listeners:
           '@type': type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
       name: edge-gateway:HTTP:8080
       perConnectionBufferLimitBytes: 32768
-      enableReusePort: true
       trafficDirection: INBOUND
 Routes:
   Resources:

--- a/pkg/plugins/runtime/gateway/testdata/https/24-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/24-gateway-route.yaml
@@ -141,7 +141,7 @@ Listeners:
           '@type': type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
       name: edge-gateway:HTTP:8080
       perConnectionBufferLimitBytes: 32768
-      reusePort: true
+      enableReusePort: true
       trafficDirection: INBOUND
 Routes:
   Resources:

--- a/pkg/plugins/runtime/gateway/testdata/https/25-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/25-gateway-route.yaml
@@ -74,6 +74,7 @@ Listeners:
         socketAddress:
           address: 192.168.1.1
           portValue: 8080
+      enableReusePort: true
       filterChains:
       - filterChainMatch:
           applicationProtocols:
@@ -143,7 +144,6 @@ Listeners:
           '@type': type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
       name: edge-gateway:HTTPS:8080
       perConnectionBufferLimitBytes: 32768
-      enableReusePort: true
       trafficDirection: INBOUND
 Routes:
   Resources:

--- a/pkg/plugins/runtime/gateway/testdata/https/25-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/25-gateway-route.yaml
@@ -143,7 +143,7 @@ Listeners:
           '@type': type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
       name: edge-gateway:HTTPS:8080
       perConnectionBufferLimitBytes: 32768
-      reusePort: true
+      enableReusePort: true
       trafficDirection: INBOUND
 Routes:
   Resources:

--- a/pkg/plugins/runtime/gateway/testdata/https/26-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/26-gateway-route.yaml
@@ -60,6 +60,7 @@ Listeners:
         socketAddress:
           address: 192.168.1.1
           portValue: 8080
+      enableReusePort: true
       filterChains:
       - filterChainMatch:
           applicationProtocols:
@@ -129,7 +130,6 @@ Listeners:
           '@type': type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
       name: edge-gateway:HTTPS:8080
       perConnectionBufferLimitBytes: 32768
-      enableReusePort: true
       trafficDirection: INBOUND
 Routes:
   Resources:

--- a/pkg/plugins/runtime/gateway/testdata/https/26-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/26-gateway-route.yaml
@@ -129,7 +129,7 @@ Listeners:
           '@type': type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
       name: edge-gateway:HTTPS:8080
       perConnectionBufferLimitBytes: 32768
-      reusePort: true
+      enableReusePort: true
       trafficDirection: INBOUND
 Routes:
   Resources:

--- a/pkg/xds/envoy/listeners/filter_chain_configurer_test.go
+++ b/pkg/xds/envoy/listeners/filter_chain_configurer_test.go
@@ -50,6 +50,7 @@ var _ = Describe("ListenerFilterChainConfigurer", func() {
               socketAddress:
                 address: 192.168.0.1
                 portValue: 8080
+            enableReusePort: false
             filterChains:
             - {}
 `,

--- a/pkg/xds/envoy/listeners/listener_configurers.go
+++ b/pkg/xds/envoy/listeners/listener_configurers.go
@@ -79,8 +79,7 @@ func ConnectionBufferLimit(bytes uint32) ListenerBuilderOpt {
 func EnableReusePort(enable bool) ListenerBuilderOpt {
 	return AddListenerConfigurer(
 		v3.ListenerMustConfigureFunc(func(l *envoy_listener.Listener) {
-			// TODO(jpeach) in Envoy 1.20, this field is deprecated in favor of EnableReusePort.
-			l.ReusePort = enable
+			l.EnableReusePort = wrapperspb.Bool(enable)
 		}))
 }
 

--- a/pkg/xds/envoy/listeners/listener_configurers.go
+++ b/pkg/xds/envoy/listeners/listener_configurers.go
@@ -79,7 +79,7 @@ func ConnectionBufferLimit(bytes uint32) ListenerBuilderOpt {
 func EnableReusePort(enable bool) ListenerBuilderOpt {
 	return AddListenerConfigurer(
 		v3.ListenerMustConfigureFunc(func(l *envoy_listener.Listener) {
-			l.EnableReusePort = wrapperspb.Bool(enable)
+			l.EnableReusePort = &wrapperspb.BoolValue{Value: enable}
 		}))
 }
 

--- a/pkg/xds/envoy/listeners/v3/dns_configurer_test.go
+++ b/pkg/xds/envoy/listeners/v3/dns_configurer_test.go
@@ -51,6 +51,7 @@ var _ = Describe("DNSConfigurer", func() {
                 address: 192.168.0.1
                 portValue: 1234
                 protocol: UDP
+            enableReusePort: true
             listenerFilters:
             - name: envoy.filters.udp.dns_filter
               typedConfig:
@@ -90,7 +91,6 @@ var _ = Describe("DNSConfigurer", func() {
                       name: something.mesh
                 statPrefix: kuma_dns
             name: kuma:dns
-            enableReusePort: true
             trafficDirection: INBOUND
 `,
 		}),
@@ -108,6 +108,7 @@ var _ = Describe("DNSConfigurer", func() {
                 address: 192.168.0.1
                 portValue: 1234
                 protocol: UDP
+            enableReusePort: true
             listenerFilters:
             - name: envoy.filters.udp.dns_filter
               typedConfig:
@@ -146,7 +147,6 @@ var _ = Describe("DNSConfigurer", func() {
                       name: something.mesh
                 statPrefix: kuma_dns
             name: kuma:dns
-            reusePort: true
             trafficDirection: INBOUND
 `,
 		}),

--- a/pkg/xds/envoy/listeners/v3/dns_configurer_test.go
+++ b/pkg/xds/envoy/listeners/v3/dns_configurer_test.go
@@ -90,7 +90,7 @@ var _ = Describe("DNSConfigurer", func() {
                       name: something.mesh
                 statPrefix: kuma_dns
             name: kuma:dns
-            reusePort: true
+            enableReusePort: true
             trafficDirection: INBOUND
 `,
 		}),

--- a/pkg/xds/envoy/listeners/v3/http_connection_manager_configurer_test.go
+++ b/pkg/xds/envoy/listeners/v3/http_connection_manager_configurer_test.go
@@ -50,6 +50,7 @@ var _ = Describe("HttpConnectionManagerConfigurer", func() {
               socketAddress:
                 address: 192.168.0.1
                 portValue: 8080
+            enableReusePort: false
             filterChains:
             - filters:
               - name: envoy.filters.network.http_connection_manager

--- a/pkg/xds/envoy/listeners/v3/http_inbound_routes_configurer_test.go
+++ b/pkg/xds/envoy/listeners/v3/http_inbound_routes_configurer_test.go
@@ -88,6 +88,7 @@ var _ = Describe("HttpInboundRouteConfigurer", func() {
               socketAddress:
                 address: 192.168.0.1
                 portValue: 8080
+            enableReusePort: false
             filterChains:
             - filters:
               - name: envoy.filters.network.http_connection_manager
@@ -149,6 +150,7 @@ var _ = Describe("HttpInboundRouteConfigurer", func() {
               socketAddress:
                 address: 192.168.0.1
                 portValue: 8080
+            enableReusePort: false
             filterChains:
             - filters:
               - name: envoy.filters.network.http_connection_manager
@@ -240,6 +242,7 @@ var _ = Describe("HttpInboundRouteConfigurer", func() {
               socketAddress:
                 address: 192.168.0.1
                 portValue: 8080
+            enableReusePort: false
             filterChains:
             - filters:
               - name: envoy.filters.network.http_connection_manager

--- a/pkg/xds/envoy/listeners/v3/http_route_configurer_test.go
+++ b/pkg/xds/envoy/listeners/v3/http_route_configurer_test.go
@@ -30,6 +30,7 @@ var _ = Describe("HttpDynamicRouteConfigurer", func() {
         socketAddress:
           address: 127.0.0.1
           portValue: 99
+      enableReusePort: false
       filterChains:
       - filters:
         - name: envoy.filters.network.http_connection_manager

--- a/pkg/xds/envoy/listeners/v3/inbound_listener_configurer.go
+++ b/pkg/xds/envoy/listeners/v3/inbound_listener_configurer.go
@@ -3,6 +3,7 @@ package v3
 import (
 	envoy_core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	envoy_listener "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
+	"google.golang.org/protobuf/types/known/wrapperspb"
 
 	core_xds "github.com/kumahq/kuma/pkg/core/xds"
 )
@@ -16,7 +17,7 @@ type InboundListenerConfigurer struct {
 
 func (c *InboundListenerConfigurer) Configure(l *envoy_listener.Listener) error {
 	l.Name = c.ListenerName
-	l.ReusePort = c.Protocol == core_xds.SocketAddressProtocolUDP
+	l.EnableReusePort = wrapperspb.Bool(c.Protocol == core_xds.SocketAddressProtocolUDP)
 	l.TrafficDirection = envoy_core.TrafficDirection_INBOUND
 	l.Address = &envoy_core.Address{
 		Address: &envoy_core.Address_SocketAddress{

--- a/pkg/xds/envoy/listeners/v3/inbound_listener_configurer.go
+++ b/pkg/xds/envoy/listeners/v3/inbound_listener_configurer.go
@@ -3,9 +3,9 @@ package v3
 import (
 	envoy_core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	envoy_listener "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
-	"google.golang.org/protobuf/types/known/wrapperspb"
 
 	core_xds "github.com/kumahq/kuma/pkg/core/xds"
+	util_proto "github.com/kumahq/kuma/pkg/util/proto"
 )
 
 type InboundListenerConfigurer struct {
@@ -17,7 +17,7 @@ type InboundListenerConfigurer struct {
 
 func (c *InboundListenerConfigurer) Configure(l *envoy_listener.Listener) error {
 	l.Name = c.ListenerName
-	l.EnableReusePort = wrapperspb.Bool(c.Protocol == core_xds.SocketAddressProtocolUDP)
+	l.EnableReusePort = util_proto.Bool(c.Protocol == core_xds.SocketAddressProtocolUDP)
 	l.TrafficDirection = envoy_core.TrafficDirection_INBOUND
 	l.Address = &envoy_core.Address{
 		Address: &envoy_core.Address_SocketAddress{

--- a/pkg/xds/envoy/listeners/v3/inbound_listener_configurer_test.go
+++ b/pkg/xds/envoy/listeners/v3/inbound_listener_configurer_test.go
@@ -57,7 +57,7 @@ var _ = Describe("InboundListenerConfigurer", func() {
 			expected: `
             name: inbound:192.168.0.1:8080
             trafficDirection: INBOUND
-            reusePort: true
+            enableReusePort: true
             address:
               socketAddress:
                 address: 192.168.0.1

--- a/pkg/xds/envoy/listeners/v3/inbound_listener_configurer_test.go
+++ b/pkg/xds/envoy/listeners/v3/inbound_listener_configurer_test.go
@@ -47,6 +47,7 @@ var _ = Describe("InboundListenerConfigurer", func() {
               socketAddress:
                 address: 192.168.0.1
                 portValue: 8080
+            enableReusePort: false
 `,
 		}),
 		Entry("basic UDP listener", testCase{
@@ -57,12 +58,12 @@ var _ = Describe("InboundListenerConfigurer", func() {
 			expected: `
             name: inbound:192.168.0.1:8080
             trafficDirection: INBOUND
-            enableReusePort: true
             address:
               socketAddress:
                 address: 192.168.0.1
                 portValue: 8080
                 protocol: UDP
+            enableReusePort: true
 `,
 		}),
 	)

--- a/pkg/xds/envoy/listeners/v3/kafka_configurer_test.go
+++ b/pkg/xds/envoy/listeners/v3/kafka_configurer_test.go
@@ -57,6 +57,7 @@ var _ = Describe("TcpProxyConfigurer", func() {
           socketAddress:
             address: 192.168.0.1
             portValue: 8080
+        enableReusePort: false
         filterChains:
         - filters:
           - name: envoy.filters.network.tcp_proxy
@@ -88,6 +89,7 @@ var _ = Describe("TcpProxyConfigurer", func() {
               socketAddress:
                 address: 127.0.0.1
                 portValue: 5432
+            enableReusePort: false
             filterChains:
             - filters:
               - name: envoy.filters.network.tcp_proxy

--- a/pkg/xds/envoy/listeners/v3/listener_configurer_test.go
+++ b/pkg/xds/envoy/listeners/v3/listener_configurer_test.go
@@ -52,7 +52,7 @@ var _ = Describe("Miscellaneous Listener configurers", func() {
 		}),
 		Entry("enable reuse port disabled", testCase{
 			opt:      EnableReusePort(false),
-			expected: "{}",
+			expected: "enableReusePort: false",
 		}),
 		Entry("enable freebind", testCase{
 			opt:      EnableFreebind(true),

--- a/pkg/xds/envoy/listeners/v3/listener_configurer_test.go
+++ b/pkg/xds/envoy/listeners/v3/listener_configurer_test.go
@@ -46,11 +46,11 @@ var _ = Describe("Miscellaneous Listener configurers", func() {
 			opt:      ConnectionBufferLimit(123),
 			expected: "perConnectionBufferLimitBytes: 123",
 		}),
-		Entry("reuse port enabled", testCase{
+		Entry("enable reuse port enabled", testCase{
 			opt:      EnableReusePort(true),
-			expected: "reusePort: true",
+			expected: "enableReusePort: true",
 		}),
-		Entry("reuse port disabled", testCase{
+		Entry("enable reuse port disabled", testCase{
 			opt:      EnableReusePort(false),
 			expected: "{}",
 		}),

--- a/pkg/xds/envoy/listeners/v3/network_rbac_configurer_test.go
+++ b/pkg/xds/envoy/listeners/v3/network_rbac_configurer_test.go
@@ -84,6 +84,7 @@ var _ = Describe("NetworkRbacConfigurer", func() {
               socketAddress:
                 address: 192.168.0.1
                 portValue: 8080
+            enableReusePort: false
             filterChains:
             - filters:
               - name: envoy.filters.network.rbac
@@ -154,6 +155,7 @@ var _ = Describe("NetworkRbacConfigurer", func() {
               socketAddress:
                 address: 192.168.0.1
                 portValue: 8080
+            enableReusePort: false
             filterChains:
             - filters:
               - name: envoy.filters.network.tcp_proxy

--- a/pkg/xds/envoy/listeners/v3/server_mtls__with_cp_configurer_test.go
+++ b/pkg/xds/envoy/listeners/v3/server_mtls__with_cp_configurer_test.go
@@ -81,6 +81,7 @@ var _ = Describe("ServerMtlsConfigurer", func() {
               socketAddress:
                 address: 192.168.0.1
                 portValue: 8080
+            enableReusePort: false
             filterChains:
             - filters:
               - name: envoy.filters.network.tcp_proxy
@@ -134,6 +135,7 @@ var _ = Describe("ServerMtlsConfigurer", func() {
               socketAddress:
                 address: 192.168.0.1
                 portValue: 8080
+            enableReusePort: false
             filterChains:
             - filters:
               - name: envoy.filters.network.tcp_proxy

--- a/pkg/xds/envoy/listeners/v3/server_mtls_configurer_test.go
+++ b/pkg/xds/envoy/listeners/v3/server_mtls_configurer_test.go
@@ -74,6 +74,7 @@ var _ = Describe("ServerMtlsConfigurer", func() {
               socketAddress:
                 address: 192.168.0.1
                 portValue: 8080
+            enableReusePort: false
             filterChains:
             - filters:
               - name: envoy.filters.network.tcp_proxy
@@ -135,6 +136,7 @@ var _ = Describe("ServerMtlsConfigurer", func() {
               socketAddress:
                 address: 192.168.0.1
                 portValue: 8080
+            enableReusePort: false
             filterChains:
             - filters:
               - name: envoy.filters.network.tcp_proxy

--- a/pkg/xds/envoy/listeners/v3/static_endpoints_configurer_test.go
+++ b/pkg/xds/envoy/listeners/v3/static_endpoints_configurer_test.go
@@ -59,6 +59,7 @@ var _ = Describe("StaticEndpointsConfigurer", func() {
               socketAddress:
                 address: 192.168.0.1
                 portValue: 8080
+            enableReusePort: false
             filterChains:
             - filters:
               - name: envoy.filters.network.http_connection_manager

--- a/pkg/xds/envoy/listeners/v3/tags_metadata_configurer_test.go
+++ b/pkg/xds/envoy/listeners/v3/tags_metadata_configurer_test.go
@@ -49,6 +49,7 @@ var _ = Describe("TagsMetadataConfigurer", func() {
               socketAddress:
                 address: 192.168.0.1
                 portValue: 8080
+            enableReusePort: false
             metadata:
               filterMetadata:
                 io.kuma.tags:

--- a/pkg/xds/envoy/listeners/v3/tcp_proxy_configurer_test.go
+++ b/pkg/xds/envoy/listeners/v3/tcp_proxy_configurer_test.go
@@ -56,6 +56,7 @@ var _ = Describe("TcpProxyConfigurer", func() {
           socketAddress:
             address: 192.168.0.1
             portValue: 8080
+        enableReusePort: false
         filterChains:
         - filters:
           - name: envoy.filters.network.tcp_proxy
@@ -91,6 +92,7 @@ var _ = Describe("TcpProxyConfigurer", func() {
               socketAddress:
                 address: 127.0.0.1
                 portValue: 5432
+            enableReusePort: false
             filterChains:
             - filters:
               - name: envoy.filters.network.tcp_proxy
@@ -152,6 +154,7 @@ var _ = Describe("TcpProxyConfigurer", func() {
           socketAddress:
             address: 192.168.0.1
             portValue: 8080
+        enableReusePort: false
         filterChains:
         - filters:
           - name: envoy.filters.network.tcp_proxy
@@ -180,6 +183,7 @@ var _ = Describe("TcpProxyConfigurer", func() {
               socketAddress:
                 address: 127.0.0.1
                 portValue: 5432
+            enableReusePort: false
             filterChains:
             - filters:
               - name: envoy.filters.network.tcp_proxy

--- a/pkg/xds/envoy/listeners/v3/tracing_configurer_test.go
+++ b/pkg/xds/envoy/listeners/v3/tracing_configurer_test.go
@@ -50,6 +50,7 @@ var _ = Describe("TracingConfigurer", func() {
               socketAddress:
                 address: 192.168.0.1
                 portValue: 8080
+            enableReusePort: false
             filterChains:
             - filters:
               - name: envoy.filters.network.http_connection_manager
@@ -85,6 +86,7 @@ var _ = Describe("TracingConfigurer", func() {
               socketAddress:
                 address: 192.168.0.1
                 portValue: 8080
+            enableReusePort: false
             filterChains:
             - filters:
               - name: envoy.filters.network.http_connection_manager
@@ -119,6 +121,7 @@ var _ = Describe("TracingConfigurer", func() {
           socketAddress:
             address: 192.168.0.1
             portValue: 8080
+        enableReusePort: false
         filterChains:
         - filters:
           - name: envoy.filters.network.http_connection_manager
@@ -147,6 +150,7 @@ var _ = Describe("TracingConfigurer", func() {
               socketAddress:
                 address: 192.168.0.1
                 portValue: 8080
+            enableReusePort: false
             filterChains:
             - filters:
               - name: envoy.filters.network.http_connection_manager

--- a/pkg/xds/envoy/listeners/v3/transparent_proxying_configurer_test.go
+++ b/pkg/xds/envoy/listeners/v3/transparent_proxying_configurer_test.go
@@ -54,6 +54,7 @@ var _ = Describe("TransparentProxyingConfigurer", func() {
               socketAddress:
                 address: 192.168.0.1
                 portValue: 8080
+            enableReusePort: false
             bindToPort: false
 `,
 		}),
@@ -69,6 +70,7 @@ var _ = Describe("TransparentProxyingConfigurer", func() {
               socketAddress:
                 address: 192.168.0.1
                 portValue: 8080
+            enableReusePort: false
 `,
 		}),
 	)

--- a/pkg/xds/generator/egress/testdata/01.externalservice-only.golden.yaml
+++ b/pkg/xds/generator/egress/testdata/01.externalservice-only.golden.yaml
@@ -37,6 +37,7 @@ resources:
       socketAddress:
         address: 192.168.0.1
         portValue: 10002
+    enableReusePort: false
     filterChains:
     - filterChainMatch:
         serverNames:

--- a/pkg/xds/generator/egress/testdata/02.internalservice-only.golden.yaml
+++ b/pkg/xds/generator/egress/testdata/02.internalservice-only.golden.yaml
@@ -43,6 +43,7 @@ resources:
       socketAddress:
         address: 192.168.0.1
         portValue: 10002
+    enableReusePort: false
     filterChains:
     - filterChainMatch:
         serverNames:

--- a/pkg/xds/generator/egress/testdata/03.mixed-services.golden.yaml
+++ b/pkg/xds/generator/egress/testdata/03.mixed-services.golden.yaml
@@ -161,6 +161,7 @@ resources:
       socketAddress:
         address: 192.168.0.1
         portValue: 10002
+    enableReusePort: false
     filterChains:
     - filterChainMatch:
         serverNames:

--- a/pkg/xds/generator/egress/testdata/04.mixed-services-custom-trafficroute.golden.yaml
+++ b/pkg/xds/generator/egress/testdata/04.mixed-services-custom-trafficroute.golden.yaml
@@ -149,6 +149,7 @@ resources:
       socketAddress:
         address: 192.168.0.1
         portValue: 10002
+    enableReusePort: false
     filterChains:
     - filterChainMatch:
         serverNames:

--- a/pkg/xds/generator/egress/testdata/05.mixed-services-with-custom-trafficpermissions.golden.yaml
+++ b/pkg/xds/generator/egress/testdata/05.mixed-services-with-custom-trafficpermissions.golden.yaml
@@ -161,6 +161,7 @@ resources:
       socketAddress:
         address: 192.168.0.1
         portValue: 10002
+    enableReusePort: false
     filterChains:
     - filterChainMatch:
         serverNames:

--- a/pkg/xds/generator/egress/testdata/06.mixed-services-with-external-in-other-zone.golden.yaml
+++ b/pkg/xds/generator/egress/testdata/06.mixed-services-with-external-in-other-zone.golden.yaml
@@ -152,6 +152,7 @@ resources:
       socketAddress:
         address: 192.168.0.1
         portValue: 10002
+    enableReusePort: false
     filterChains:
     - filterChainMatch:
         serverNames:

--- a/pkg/xds/generator/testdata/admin/01.envoy-config.golden.yaml
+++ b/pkg/xds/generator/testdata/admin/01.envoy-config.golden.yaml
@@ -22,6 +22,7 @@ resources:
       socketAddress:
         address: 192.168.0.1
         portValue: 9901
+    enableReusePort: false
     filterChains:
     - filters:
       - name: envoy.filters.network.http_connection_manager

--- a/pkg/xds/generator/testdata/dns/1-envoy-config.golden.yaml
+++ b/pkg/xds/generator/testdata/dns/1-envoy-config.golden.yaml
@@ -48,5 +48,5 @@ resources:
               name: httpbin.mesh
         statPrefix: kuma_dns
     name: kuma:dns
-    reusePort: true
+    enableReusePort: true
     trafficDirection: INBOUND

--- a/pkg/xds/generator/testdata/dns/1-envoy-config.golden.yaml
+++ b/pkg/xds/generator/testdata/dns/1-envoy-config.golden.yaml
@@ -7,6 +7,7 @@ resources:
         address: 127.0.0.1
         portValue: 53001
         protocol: UDP
+    enableReusePort: true
     listenerFilters:
     - name: envoy.filters.udp.dns_filter
       typedConfig:
@@ -48,5 +49,4 @@ resources:
               name: httpbin.mesh
         statPrefix: kuma_dns
     name: kuma:dns
-    enableReusePort: true
     trafficDirection: INBOUND

--- a/pkg/xds/generator/testdata/dns/3-envoy-config.golden.yaml
+++ b/pkg/xds/generator/testdata/dns/3-envoy-config.golden.yaml
@@ -45,5 +45,5 @@ resources:
               name: httpbin.mesh
         statPrefix: kuma_dns
     name: kuma:dns
-    reusePort: true
+    enableReusePort: true
     trafficDirection: INBOUND

--- a/pkg/xds/generator/testdata/dns/3-envoy-config.golden.yaml
+++ b/pkg/xds/generator/testdata/dns/3-envoy-config.golden.yaml
@@ -7,6 +7,7 @@ resources:
         address: 127.0.0.1
         portValue: 53001
         protocol: UDP
+    enableReusePort: true
     listenerFilters:
     - name: envoy.filters.udp.dns_filter
       typedConfig:
@@ -45,5 +46,4 @@ resources:
               name: httpbin.mesh
         statPrefix: kuma_dns
     name: kuma:dns
-    enableReusePort: true
     trafficDirection: INBOUND

--- a/pkg/xds/generator/testdata/inbound-proxy/3-envoy-config.golden.yaml
+++ b/pkg/xds/generator/testdata/inbound-proxy/3-envoy-config.golden.yaml
@@ -38,6 +38,7 @@ resources:
       socketAddress:
         address: 192.168.0.1
         portValue: 443
+    enableReusePort: false
     filterChains:
     - filters:
       - name: envoy.filters.network.rbac
@@ -83,6 +84,7 @@ resources:
       socketAddress:
         address: 192.168.0.1
         portValue: 80
+    enableReusePort: false
     filterChains:
     - filters:
       - name: envoy.filters.network.rbac
@@ -236,6 +238,7 @@ resources:
       socketAddress:
         address: 192.168.0.2
         portValue: 443
+    enableReusePort: false
     filterChains:
     - filters:
       - name: envoy.filters.network.rbac
@@ -281,6 +284,7 @@ resources:
       socketAddress:
         address: 192.168.0.2
         portValue: 80
+    enableReusePort: false
     filterChains:
     - filters:
       - name: envoy.filters.network.rbac

--- a/pkg/xds/generator/testdata/inbound-proxy/4-envoy-config.golden.yaml
+++ b/pkg/xds/generator/testdata/inbound-proxy/4-envoy-config.golden.yaml
@@ -39,6 +39,7 @@ resources:
         address: 192.168.0.1
         portValue: 443
     bindToPort: false
+    enableReusePort: false
     filterChains:
     - filters:
       - name: envoy.filters.network.rbac
@@ -85,6 +86,7 @@ resources:
         address: 192.168.0.1
         portValue: 80
     bindToPort: false
+    enableReusePort: false
     filterChains:
     - filters:
       - name: envoy.filters.network.rbac
@@ -239,6 +241,7 @@ resources:
         address: 192.168.0.2
         portValue: 443
     bindToPort: false
+    enableReusePort: false
     filterChains:
     - filters:
       - name: envoy.filters.network.rbac
@@ -285,6 +288,7 @@ resources:
         address: 192.168.0.2
         portValue: 80
     bindToPort: false
+    enableReusePort: false
     filterChains:
     - filters:
       - name: envoy.filters.network.rbac

--- a/pkg/xds/generator/testdata/inbound-proxy/5-envoy-config.golden.yaml
+++ b/pkg/xds/generator/testdata/inbound-proxy/5-envoy-config.golden.yaml
@@ -38,6 +38,7 @@ resources:
       socketAddress:
         address: 192.168.0.1
         portValue: 443
+    enableReusePort: false
     filterChains:
     - filterChainMatch:
         transportProtocol: raw_buffer
@@ -117,6 +118,7 @@ resources:
       socketAddress:
         address: 192.168.0.1
         portValue: 80
+    enableReusePort: false
     filterChains:
     - filterChainMatch:
         transportProtocol: raw_buffer
@@ -518,6 +520,7 @@ resources:
       socketAddress:
         address: 192.168.0.2
         portValue: 443
+    enableReusePort: false
     filterChains:
     - filterChainMatch:
         transportProtocol: raw_buffer
@@ -597,6 +600,7 @@ resources:
       socketAddress:
         address: 192.168.0.2
         portValue: 80
+    enableReusePort: false
     filterChains:
     - filterChainMatch:
         transportProtocol: raw_buffer

--- a/pkg/xds/generator/testdata/inbound-proxy/6-envoy-config.golden.yaml
+++ b/pkg/xds/generator/testdata/inbound-proxy/6-envoy-config.golden.yaml
@@ -39,6 +39,7 @@ resources:
         address: 192.168.0.1
         portValue: 443
     bindToPort: false
+    enableReusePort: false
     filterChains:
     - filterChainMatch:
         transportProtocol: raw_buffer
@@ -119,6 +120,7 @@ resources:
         address: 192.168.0.1
         portValue: 80
     bindToPort: false
+    enableReusePort: false
     filterChains:
     - filterChainMatch:
         transportProtocol: raw_buffer
@@ -521,6 +523,7 @@ resources:
         address: 192.168.0.2
         portValue: 443
     bindToPort: false
+    enableReusePort: false
     filterChains:
     - filterChainMatch:
         transportProtocol: raw_buffer
@@ -601,6 +604,7 @@ resources:
         address: 192.168.0.2
         portValue: 80
     bindToPort: false
+    enableReusePort: false
     filterChains:
     - filterChainMatch:
         transportProtocol: raw_buffer

--- a/pkg/xds/generator/testdata/ingress/01.envoy.golden.yaml
+++ b/pkg/xds/generator/testdata/ingress/01.envoy.golden.yaml
@@ -60,6 +60,7 @@ resources:
       socketAddress:
         address: 10.0.0.1
         portValue: 10001
+    enableReusePort: false
     filterChains:
     - filterChainMatch:
         serverNames:

--- a/pkg/xds/generator/testdata/ingress/02.envoy.golden.yaml
+++ b/pkg/xds/generator/testdata/ingress/02.envoy.golden.yaml
@@ -6,6 +6,7 @@ resources:
       socketAddress:
         address: 10.0.0.1
         portValue: 10001
+    enableReusePort: false
     filterChains:
     - {}
     listenerFilters:

--- a/pkg/xds/generator/testdata/ingress/03.envoy.golden.yaml
+++ b/pkg/xds/generator/testdata/ingress/03.envoy.golden.yaml
@@ -68,6 +68,7 @@ resources:
       socketAddress:
         address: 10.0.0.1
         portValue: 10001
+    enableReusePort: false
     filterChains:
     - filterChainMatch:
         serverNames:

--- a/pkg/xds/generator/testdata/ingress/04.envoy.golden.yaml
+++ b/pkg/xds/generator/testdata/ingress/04.envoy.golden.yaml
@@ -128,6 +128,7 @@ resources:
       socketAddress:
         address: 10.0.0.1
         portValue: 10001
+    enableReusePort: false
     filterChains:
     - filterChainMatch:
         serverNames:

--- a/pkg/xds/generator/testdata/ingress/05.envoy.golden.yaml
+++ b/pkg/xds/generator/testdata/ingress/05.envoy.golden.yaml
@@ -26,6 +26,7 @@ resources:
       socketAddress:
         address: 10.0.0.1
         portValue: 10001
+    enableReusePort: false
     filterChains:
     - filterChainMatch:
         serverNames:

--- a/pkg/xds/generator/testdata/probe/01.envoy.golden.yaml
+++ b/pkg/xds/generator/testdata/probe/01.envoy.golden.yaml
@@ -5,6 +5,7 @@ resources:
     address:
       socketAddress:
         portValue: 9000
+    enableReusePort: false
     filterChains:
     - filters:
       - name: envoy.filters.network.http_connection_manager

--- a/pkg/xds/generator/testdata/probe/03.envoy.golden.yaml
+++ b/pkg/xds/generator/testdata/probe/03.envoy.golden.yaml
@@ -5,6 +5,7 @@ resources:
     address:
       socketAddress:
         portValue: 9000
+    enableReusePort: false
     filterChains:
     - filters:
       - name: envoy.filters.network.http_connection_manager

--- a/pkg/xds/generator/testdata/probe/04.envoy.golden.yaml
+++ b/pkg/xds/generator/testdata/probe/04.envoy.golden.yaml
@@ -5,6 +5,7 @@ resources:
     address:
       socketAddress:
         portValue: 9000
+    enableReusePort: false
     filterChains:
     - filters:
       - name: envoy.filters.network.http_connection_manager

--- a/pkg/xds/generator/testdata/profile-source/1-envoy-config.golden.yaml
+++ b/pkg/xds/generator/testdata/profile-source/1-envoy-config.golden.yaml
@@ -148,6 +148,7 @@ resources:
       socketAddress:
         address: 192.168.0.1
         portValue: 80
+    enableReusePort: false
     filterChains:
     - filters:
       - name: envoy.filters.network.rbac
@@ -193,6 +194,7 @@ resources:
       socketAddress:
         address: 192.168.0.1
         portValue: 9902
+    enableReusePort: false
     filterChains:
     - filters:
       - name: envoy.filters.network.http_connection_manager

--- a/pkg/xds/generator/testdata/profile-source/2-envoy-config.golden.yaml
+++ b/pkg/xds/generator/testdata/profile-source/2-envoy-config.golden.yaml
@@ -169,6 +169,7 @@ resources:
         address: 192.168.0.1
         portValue: 80
     bindToPort: false
+    enableReusePort: false
     filterChains:
     - filters:
       - name: envoy.filters.network.rbac
@@ -214,6 +215,7 @@ resources:
       socketAddress:
         address: 0.0.0.0
         portValue: 15006
+    enableReusePort: false
     filterChains:
     - filters:
       - name: envoy.filters.network.tcp_proxy
@@ -231,6 +233,7 @@ resources:
       socketAddress:
         address: 192.168.0.1
         portValue: 9902
+    enableReusePort: false
     filterChains:
     - filters:
       - name: envoy.filters.network.http_connection_manager

--- a/pkg/xds/generator/testdata/profile-source/3-envoy-config.golden.yaml
+++ b/pkg/xds/generator/testdata/profile-source/3-envoy-config.golden.yaml
@@ -163,6 +163,7 @@ resources:
       socketAddress:
         address: 192.168.0.1
         portValue: 80
+    enableReusePort: false
     filterChains:
     - filters:
       - name: envoy.filters.network.rbac
@@ -228,6 +229,7 @@ resources:
       socketAddress:
         address: 192.168.0.1
         portValue: 9902
+    enableReusePort: false
     filterChains:
     - filters:
       - name: envoy.filters.network.http_connection_manager
@@ -300,6 +302,7 @@ resources:
       socketAddress:
         address: 192.168.0.1
         portValue: 1234
+    enableReusePort: false
     filterChains:
     - filterChainMatch:
         sourcePrefixRanges:

--- a/pkg/xds/generator/testdata/profile-source/4-envoy-config.golden.yaml
+++ b/pkg/xds/generator/testdata/profile-source/4-envoy-config.golden.yaml
@@ -184,6 +184,7 @@ resources:
         address: 192.168.0.1
         portValue: 80
     bindToPort: false
+    enableReusePort: false
     filterChains:
     - filters:
       - name: envoy.filters.network.rbac
@@ -249,6 +250,7 @@ resources:
       socketAddress:
         address: 0.0.0.0
         portValue: 15006
+    enableReusePort: false
     filterChains:
     - filters:
       - name: envoy.filters.network.tcp_proxy
@@ -266,6 +268,7 @@ resources:
       socketAddress:
         address: 192.168.0.1
         portValue: 9902
+    enableReusePort: false
     filterChains:
     - filters:
       - name: envoy.filters.network.http_connection_manager
@@ -338,6 +341,7 @@ resources:
       socketAddress:
         address: 192.168.0.1
         portValue: 1234
+    enableReusePort: false
     filterChains:
     - filterChainMatch:
         sourcePrefixRanges:

--- a/pkg/xds/generator/testdata/prometheus-endpoint/custom.envoy-config.golden.yaml
+++ b/pkg/xds/generator/testdata/prometheus-endpoint/custom.envoy-config.golden.yaml
@@ -21,6 +21,7 @@ resources:
       socketAddress:
         address: 192.168.0.1
         portValue: 8765
+    enableReusePort: false
     filterChains:
     - filters:
       - name: envoy.filters.network.http_connection_manager

--- a/pkg/xds/generator/testdata/prometheus-endpoint/default-mtls.envoy-config.golden.yaml
+++ b/pkg/xds/generator/testdata/prometheus-endpoint/default-mtls.envoy-config.golden.yaml
@@ -21,6 +21,7 @@ resources:
       socketAddress:
         address: 192.168.0.1
         portValue: 1234
+    enableReusePort: false
     filterChains:
     - filterChainMatch:
         sourcePrefixRanges:

--- a/pkg/xds/generator/testdata/prometheus-endpoint/default-without-hijacker.envoy-config.golden.yaml
+++ b/pkg/xds/generator/testdata/prometheus-endpoint/default-without-hijacker.envoy-config.golden.yaml
@@ -21,6 +21,7 @@ resources:
       socketAddress:
         address: 192.168.0.1
         portValue: 1234
+    enableReusePort: false
     filterChains:
     - filters:
       - name: envoy.filters.network.http_connection_manager

--- a/pkg/xds/generator/testdata/prometheus-endpoint/default.envoy-config.golden.yaml
+++ b/pkg/xds/generator/testdata/prometheus-endpoint/default.envoy-config.golden.yaml
@@ -21,6 +21,7 @@ resources:
       socketAddress:
         address: 192.168.0.1
         portValue: 1234
+    enableReusePort: false
     filterChains:
     - filters:
       - name: envoy.filters.network.http_connection_manager

--- a/pkg/xds/generator/testdata/template-proxy/1-envoy-config.golden.yaml
+++ b/pkg/xds/generator/testdata/template-proxy/1-envoy-config.golden.yaml
@@ -59,6 +59,7 @@ resources:
         address: 192.168.0.1
         portValue: 80
     bindToPort: false
+    enableReusePort: false
     filterChains:
     - filters:
       - name: envoy.filters.network.rbac
@@ -104,6 +105,7 @@ resources:
       socketAddress:
         address: 0.0.0.0
         portValue: 15006
+    enableReusePort: false
     filterChains:
     - filters:
       - name: envoy.filters.network.tcp_proxy

--- a/pkg/xds/generator/testdata/template-proxy/2-envoy-config.golden.yaml
+++ b/pkg/xds/generator/testdata/template-proxy/2-envoy-config.golden.yaml
@@ -43,6 +43,7 @@ resources:
         address: 192.168.0.1
         portValue: 80
     bindToPort: false
+    enableReusePort: false
     filterChains:
     - filters:
       - name: envoy.filters.network.rbac
@@ -88,6 +89,7 @@ resources:
       socketAddress:
         address: 0.0.0.0
         portValue: 15006
+    enableReusePort: false
     filterChains:
     - filters:
       - name: envoy.filters.network.tcp_proxy

--- a/pkg/xds/generator/testdata/transparent-proxy/02.envoy.golden.yaml
+++ b/pkg/xds/generator/testdata/transparent-proxy/02.envoy.golden.yaml
@@ -26,6 +26,7 @@ resources:
       socketAddress:
         address: 0.0.0.0
         portValue: 15006
+    enableReusePort: false
     filterChains:
     - filters:
       - name: envoy.filters.network.tcp_proxy

--- a/pkg/xds/generator/testdata/transparent-proxy/03.envoy.golden.yaml
+++ b/pkg/xds/generator/testdata/transparent-proxy/03.envoy.golden.yaml
@@ -26,6 +26,7 @@ resources:
       socketAddress:
         address: 0.0.0.0
         portValue: 15006
+    enableReusePort: false
     filterChains:
     - filters:
       - name: envoy.filters.network.tcp_proxy

--- a/pkg/xds/generator/testdata/transparent-proxy/04.envoy.golden.yaml
+++ b/pkg/xds/generator/testdata/transparent-proxy/04.envoy.golden.yaml
@@ -46,6 +46,7 @@ resources:
       socketAddress:
         address: 0.0.0.0
         portValue: 15006
+    enableReusePort: false
     filterChains:
     - filters:
       - name: envoy.filters.network.tcp_proxy
@@ -63,6 +64,7 @@ resources:
       socketAddress:
         address: '::'
         portValue: 15010
+    enableReusePort: false
     filterChains:
     - filters:
       - name: envoy.filters.network.tcp_proxy

--- a/pkg/xds/server/v3/testdata/envoy-config.golden.yaml
+++ b/pkg/xds/server/v3/testdata/envoy-config.golden.yaml
@@ -59,6 +59,7 @@ resources:
         address: 192.168.0.1
         portValue: 443
     bindToPort: false
+    enableReusePort: false
     filterChains:
     - filters:
       - name: envoy.filters.network.rbac
@@ -105,6 +106,7 @@ resources:
         address: 192.168.0.1
         portValue: 80
     bindToPort: false
+    enableReusePort: false
     filterChains:
     - filters:
       - name: envoy.filters.network.rbac
@@ -164,6 +166,7 @@ resources:
         address: 192.168.0.2
         portValue: 443
     bindToPort: false
+    enableReusePort: false
     filterChains:
     - filters:
       - name: envoy.filters.network.rbac
@@ -210,6 +213,7 @@ resources:
         address: 192.168.0.2
         portValue: 80
     bindToPort: false
+    enableReusePort: false
     filterChains:
     - filters:
       - name: envoy.filters.network.rbac
@@ -255,6 +259,7 @@ resources:
       socketAddress:
         address: 0.0.0.0
         portValue: 15006
+    enableReusePort: false
     filterChains:
     - filters:
       - name: envoy.filters.network.tcp_proxy

--- a/test/e2e/compatibility/dp_compatibility_universal.go
+++ b/test/e2e/compatibility/dp_compatibility_universal.go
@@ -19,9 +19,9 @@ func UniversalCompatibility() {
 			Install(Kuma(core.Standalone)).
 			Install(TestServerUniversal("test-server", "default",
 				WithArgs([]string{"echo", "--instance", "universal1"}),
-				WithDPVersion("1.1.6"))).
+				WithDPVersion("1.5.0"))).
 			Install(DemoClientUniversal(AppModeDemoClient, "default",
-				WithDPVersion("1.1.6"),
+				WithDPVersion("1.5.0"),
 				WithTransparentProxy(true)),
 			).
 			Setup(cluster)


### PR DESCRIPTION
## Summary

remove the deprecated `reusePort` field and replace it with `enableReuesePort` available in **Envoy 1.20**.

### Full changelog

* replace `reusePort` with the newer option, `enableReuesePort`

Closes: https://github.com/kumahq/kuma/issues/2709

Signed-off-by: Pouriya Jamshidi <pouriya.jamshidi@gmail.com>

