### PR TITLE
test(e2e): fix compatibility test cleanup

### DIFF
--- a/test/e2e/compatibility/cp_compatibility_kubernetes_multizone.go
+++ b/test/e2e/compatibility/cp_compatibility_kubernetes_multizone.go
@@ -65,6 +65,7 @@ func CpCompatibilityMultizoneKubernetes() {
 		)
 
 		E2EDeferCleanup(func() {
+			Expect(zoneCluster.DeleteNamespace(TestNamespace)).To(Succeed())
 			Expect(zoneCluster.DeleteKuma()).To(Succeed())
 			Expect(zoneCluster.DismissCluster()).To(Succeed())
 		})


### PR DESCRIPTION
### Summary

Demo client was not cleaned up which caused other test to fail.

### Issues resolved

No issue reported.

### Documentation

~- [ ] Link to the website [documentation PR](https://github.com/kumahq/kuma-website/pull/XXX)~

### Testing

- [ ] Unit tests
- [X] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes

### Backwards compatibility

~- [ ] Update [`UPGRADE.md`](/UPGRADE.md) with any steps users will need to take when upgrading.~
~- [ ] Add `backport-to-stable` label if the code follows our [backporting policy](/CONTRIBUTING.md#backporting)~
