### PR TITLE
test(e2e): migrate external service host header test

### DIFF
--- a/test/e2e/externalservices/e2e_suite_test.go
+++ b/test/e2e/externalservices/e2e_suite_test.go
@@ -13,7 +13,6 @@ func TestE2E(t *testing.T) {
 	test.RunSpecs(t, "E2E External Services Suite")
 }
 
-var _ = Describe("ExternalService host header", externalservices.ExternalServiceHostHeader)
 var _ = Describe("Test ExternalServices on Kubernetes", externalservices.ExternalServicesOnKubernetes)
 var _ = Describe("Test ExternalServices on Kubernetes without Egress", externalservices.ExternalServicesOnKubernetesWithoutEgress)
 var _ = Describe("Test ExternalServices on Multizone Universal", externalservices.ExternalServicesOnMultizoneUniversal)

--- a/test/e2e_env/universal/universal_suite_test.go
+++ b/test/e2e_env/universal/universal_suite_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/kumahq/kuma/pkg/test"
 	"github.com/kumahq/kuma/test/e2e_env/universal/auth"
 	"github.com/kumahq/kuma/test/e2e_env/universal/env"
+	"github.com/kumahq/kuma/test/e2e_env/universal/externalservices"
 	"github.com/kumahq/kuma/test/e2e_env/universal/healthcheck"
 	. "github.com/kumahq/kuma/test/framework"
 )
@@ -52,3 +53,4 @@ var _ = SynchronizedBeforeSuite(
 var _ = Describe("User Auth", auth.UserAuth)
 var _ = Describe("DP Auth", auth.DpAuth, Ordered)
 var _ = Describe("HealthCheck panic threshold", healthcheck.HealthCheckPanicThreshold, Ordered)
+var _ = Describe("External Services", externalservices.ExternalServiceHostHeader, Ordered)


### PR DESCRIPTION
### Summary

Migrate external service test to Universal environment.

### Issues resolved

No issues reported

### Documentation

~- [ ] Link to the website [documentation PR](https://github.com/kumahq/kuma-website/pull/XXX)~

### Testing

- [ ] Unit tests
- [X] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes

### Backwards compatibility

~- [ ] Update [`UPGRADE.md`](/UPGRADE.md) with any steps users will need to take when upgrading.~
~- [ ] Add `backport-to-stable` label if the code follows our [backporting policy](/CONTRIBUTING.md#backporting)~
