### PR TITLE
fix(kuma-cp): memory store cannot delete a parent

### DIFF
--- a/pkg/plugins/resources/memory/store.go
+++ b/pkg/plugins/resources/memory/store.go
@@ -214,7 +214,7 @@ func (c *memoryStore) delete(r model.Resource, fs ...store.DeleteOptionsFunc) er
 	for _, child := range record.Children {
 		_, childRecord := c.findRecord(child.ResourceType, child.Name, child.Mesh)
 		if childRecord == nil {
-			return store.ErrorResourceNotFound(model.ResourceType(child.ResourceType), child.Name, child.Mesh)
+			continue // resource was already deleted
 		}
 		obj, err := registry.Global().NewObject(model.ResourceType(child.ResourceType))
 		if err != nil {

--- a/pkg/test/store/owner_test_template.go
+++ b/pkg/test/store/owner_test_template.go
@@ -128,4 +128,35 @@ func ExecuteOwnerTests(
 		Expect(err).ToNot(HaveOccurred())
 		Expect(actual.Items).To(BeEmpty())
 	})
+
+	It("should delete a parent after children is deleted", func() {
+		// given
+		meshRes := core_mesh.NewMeshResource()
+		err := s.Create(context.Background(), meshRes, store.CreateByKey(mesh, model.NoMesh))
+		Expect(err).ToNot(HaveOccurred())
+
+		name := "resource-1"
+		trRes := &sample_model.TrafficRouteResource{
+			Spec: &sample_proto.TrafficRoute{
+				Path: "demo",
+			},
+		}
+		err = s.Create(context.Background(), trRes,
+			store.CreateByKey(name, mesh),
+			store.CreatedAt(time.Now()),
+			store.CreateWithOwner(meshRes))
+		Expect(err).ToNot(HaveOccurred())
+
+		// when children is deleted
+		err = s.Delete(context.Background(), sample_model.NewTrafficRouteResource(), store.DeleteByKey(name, mesh))
+
+		// then
+		Expect(err).ToNot(HaveOccurred())
+
+		// when parent is deleted
+		err = s.Delete(context.Background(), core_mesh.NewMeshResource(), store.DeleteByKey(mesh, model.NoMesh))
+
+		// then
+		Expect(err).ToNot(HaveOccurred())
+	})
 }


### PR DESCRIPTION
### Summary

Memory store has a problem with deleting a resource in the following scenario:
* Create a parent with a child
* Delete the child
* Delete the parent

### Issues resolved

No issues reported. I noticed this while writing a multizone test.

### Documentation

~- [ ] Link to the website [documentation PR](https://github.com/kumahq/kuma-website/pull/XXX)~

### Testing

- [X] Unit tests
- [ ] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes

### Backwards compatibility

~- [ ] Update [`UPGRADE.md`](/UPGRADE.md) with any steps users will need to take when upgrading.~
~- [ ] Add `backport-to-stable` label if the code follows our [backporting policy](/CONTRIBUTING.md#backporting)~
