### PR TITLE
feat(*): support protoc download for darwin arm

### DIFF
--- a/mk/dev.mk
+++ b/mk/dev.mk
@@ -57,6 +57,9 @@ HELM_DOCS_ARCH := $(shell uname -m)
 ifeq ($(UNAME_ARCH), aarch64)
 	PROTOC_ARCH=aarch_64
 	HELM_DOCS_ARCH=arm64
+else ifeq ($(UNAME_ARCH), arm64)
+	PROTOC_ARCH=aarch_64
+	HELM_DOCS_ARCH=arm64
 endif
 
 CURL_PATH ?= curl


### PR DESCRIPTION
### Summary

`uname -m` for darwin return `arm64` while for linux `aarch64`. Added if condition to set proper version for `protoc` and `helm-docs`

### Full changelog

* [added condition to support darwin]

### Issues resolved

Part of #237 

### Documentation

- [ ] Link to the website [documentation PR](https://github.com/kumahq/kuma-website/pull/XXX)

### Testing

- [X] Unit tests
- [ ] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes

### Backwards compatibility

- [ ] Update [`UPGRADE.md`](/UPGRADE.md) with any steps users will need to take when upgrading.
- [ ] Add `backport-to-stable` label if the code follows our [backporting policy](/CONTRIBUTING.md#backporting)
