### PR TITLE
build: rename kumactl archive prefix from kuma- to kuma-kumactl-

### DIFF
--- a/tools/releases/distros.sh
+++ b/tools/releases/distros.sh
@@ -18,6 +18,7 @@ PULP_DIST_NAME="alpine"
 [ -z "$RELEASE_NAME" ] && RELEASE_NAME="kuma"
 ENVOY_VERSION=1.21.1
 [ -z "$KUMA_CONFIG_PATH" ] && KUMA_CONFIG_PATH=pkg/config/app/kuma-cp/kuma-cp.defaults.yaml
+CTL_NAME="kumactl"
 
 function get_envoy() {
   local distro=$1
@@ -138,7 +139,7 @@ function archive_path() {
   if [[ -n $distro ]]; then
     echo "$(artifact_dir "$arch" "$system")/$RELEASE_NAME-$KUMA_VERSION-$distro-$arch.tar.gz"
   else
-    echo "$(artifact_dir "$arch" "$system")/$RELEASE_NAME-$KUMA_VERSION-$system-$arch.tar.gz"
+    echo "$(artifact_dir "$arch" "$system")/$RELEASE_NAME-$CTL_NAME-$KUMA_VERSION-$system-$arch.tar.gz"
   fi
 }
 


### PR DESCRIPTION
### Summary

It's clearer this way and it uses both `$RELEASE_NAME` and "kumactl"