### PR TITLE
test(gateway): skip conformance tests on IPv6

### DIFF
--- a/test/e2e/gateway/gatewayapi/conformance_test.go
+++ b/test/e2e/gateway/gatewayapi/conformance_test.go
@@ -23,6 +23,10 @@ var maxNodePort = 30089
 // TestConformance runs as a `testing` test and not Ginkgo so we have to use an
 // explicit `g` to use Gomega.
 func TestConformance(t *testing.T) {
+	if Config.IPV6 {
+		t.Skip("On IPv6 we run on kind which doesn't support load balancers")
+	}
+
 	g := NewWithT(t)
 
 	cluster := NewK8sCluster(t, clusterName, Silent)


### PR DESCRIPTION
### Summary

No load balancers with Kind.