### PR TITLE
fix(*): fix the owner for dev_ubuntu build

### DIFF
--- a/mk/dev.mk
+++ b/mk/dev.mk
@@ -186,7 +186,7 @@ dev/install/etcd: # Kubebuilder's package doesn't have etcd for all the distribu
 		&& unzip -j /tmp/etcd-$(ETCD_VERSION)-$(GOOS)-$(ETCD_ARCH).zip etcd-$(ETCD_VERSION)-$(GOOS)-$(ETCD_ARCH)/etcd -d etcd-$(ETCD_VERSION)-$(GOOS)-$(ETCD_ARCH)/ \
 		&& rm /tmp/etcd-$(ETCD_VERSION)-$(GOOS)-$(ETCD_ARCH).zip; \
 	else $(CURL_DOWNLOAD) -o /tmp/etcd-$(ETCD_VERSION)-$(GOOS)-$(ETCD_ARCH).tar.gz https://github.com/etcd-io/etcd/releases/download/$(ETCD_VERSION)/etcd-$(ETCD_VERSION)-$(GOOS)-$(ETCD_ARCH).tar.gz \
-		&& tar -xf /tmp/etcd-$(ETCD_VERSION)-$(GOOS)-$(ETCD_ARCH).tar.gz etcd-$(ETCD_VERSION)-$(GOOS)-$(ETCD_ARCH)/etcd \
+		&& tar -xf /tmp/etcd-$(ETCD_VERSION)-$(GOOS)-$(ETCD_ARCH).tar.gz etcd-$(ETCD_VERSION)-$(GOOS)-$(ETCD_ARCH)/etcd --no-same-owner \
 		&& rm /tmp/etcd-$(ETCD_VERSION)-$(GOOS)-$(ETCD_ARCH).tar.gz; fi
 	mkdir -p $(CI_TOOLS_DIR) \
 	&& chmod +x etcd-$(ETCD_VERSION)-$(GOOS)-$(ETCD_ARCH)/etcd \


### PR DESCRIPTION
### Summary

Previous changes caused that build for `dev_ubuntu` starts to fail. It seems that it is caused by https://discuss.circleci.com/t/tar-cannot-change-ownership/28766. 

### Full changelog

* [Added flag for getting tar]

### Issues resolved

### Documentation

- [ ] Link to the website [documentation PR](https://github.com/kumahq/kuma-website/pull/XXX)

### Testing

- [ ] Unit tests
- [ ] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes

### Backwards compatibility

- [ ] Update [`UPGRADE.md`](/UPGRADE.md) with any steps users will need to take when upgrading.
- [ ] Add `backport-to-stable` label if the code follows our [backporting policy](/CONTRIBUTING.md#backporting)
