### PR TITLE
fix(zone-egress): resolve zone-ingress advertized address

### DIFF
--- a/pkg/test/runtime/runtime.go
+++ b/pkg/test/runtime/runtime.go
@@ -6,6 +6,8 @@ import (
 	"net"
 	"time"
 
+	"github.com/pkg/errors"
+
 	"github.com/kumahq/kuma/pkg/api-server/customization"
 	kuma_cp "github.com/kumahq/kuma/pkg/config/app/kuma-cp"
 	config_manager "github.com/kumahq/kuma/pkg/core/config/manager"
@@ -87,7 +89,9 @@ func BuilderFor(appCtx context.Context, cfg kuma_cp.Config) (*core_runtime.Build
 	builder.WithDataSourceLoader(datasource.NewDataSourceLoader(builder.ResourceManager()))
 	builder.WithCaManager("builtin", builtin.NewBuiltinCaManager(builder.ResourceManager()))
 	builder.WithLeaderInfo(&component.LeaderInfoComponent{})
-	builder.WithLookupIP(net.LookupIP)
+	builder.WithLookupIP(func(s string) ([]net.IP, error) {
+		return nil, errors.New("LookupIP not set, set one in your test to resolve things")
+	})
 	builder.WithEnvoyAdminClient(&DummyEnvoyAdminClient{})
 	builder.WithEventReaderFactory(events.NewEventBus())
 	builder.WithAPIManager(customization.NewAPIList())

--- a/pkg/xds/sync/egress_proxy_builder.go
+++ b/pkg/xds/sync/egress_proxy_builder.go
@@ -71,6 +71,9 @@ func (p *EgressProxyBuilder) Build(
 		}
 	}
 
+	// Resolve hostnames to ips in zoneIngresses.
+	zoneIngresses = xds_topology.ResolveZoneIngressAddresses(xdsServerLog, p.LookupIP, zoneIngresses)
+
 	// It's done for achieving stable xds config
 	sort.Slice(zoneIngresses, func(a, b int) bool {
 		return zoneIngresses[a].GetMeta().GetName() < zoneIngresses[b].GetMeta().GetName()

--- a/pkg/xds/sync/testdata/input/default_resources.yaml
+++ b/pkg/xds/sync/testdata/input/default_resources.yaml
@@ -52,7 +52,7 @@ availableServices:
   mesh: default
 ---
 type: ZoneIngress
-name: zone-ingress-zone-2
+name: zone-ingress-1-zone-2
 zone: zone-2
 networking:
   address: 6.6.6.6
@@ -70,6 +70,26 @@ availableServices:
   instances: 1
   mesh: default
   externalService: true
+---
+type: ZoneIngress
+name: zone-ingress-2-zone-2
+zone: zone-2
+networking:
+  address: 6.6.6.7
+  advertisedAddress: one.one.one.one
+  port: 20002
+  advertisedPort: 20003
+availableServices:
+  - tags:
+      kuma.io/service: service-in-zone-2
+    instances: 1
+    mesh: default
+  - tags:
+      kuma.io/service: external-service-in-zone-2
+      kuma.io/zone: "zone-2"
+    instances: 1
+    mesh: default
+    externalService: true
 ---
 type: ZoneEgress
 name: zone-egress-1

--- a/pkg/xds/topology/dataplanes.go
+++ b/pkg/xds/topology/dataplanes.go
@@ -45,13 +45,13 @@ func ResolveAddress(lookupIPFunc lookup.LookupIPFunc, dataplane *core_mesh.Datap
 }
 
 func ResolveZoneIngressPublicAddress(lookupIPFunc lookup.LookupIPFunc, zoneIngress *core_mesh.ZoneIngressResource) (*core_mesh.ZoneIngressResource, error) {
-	res, err := lookupFirstIp(lookupIPFunc, zoneIngress.Spec.GetNetworking().GetAdvertisedAddress())
+	ip, err := lookupFirstIp(lookupIPFunc, zoneIngress.Spec.GetNetworking().GetAdvertisedAddress())
 	if err != nil {
 		return nil, err
 	}
-	if res != "" { // only if we resolve any address, in most cases this is IP not a hostname
+	if ip != "" { // only if we resolve any address, in most cases this is IP not a hostname
 		ziSpec := proto.Clone(zoneIngress.Spec).(*mesh_proto.ZoneIngress)
-		ziSpec.Networking.AdvertisedAddress = res
+		ziSpec.Networking.AdvertisedAddress = ip
 		return &core_mesh.ZoneIngressResource{
 			Meta: zoneIngress.Meta,
 			Spec: ziSpec,

--- a/pkg/xds/topology/dataplanes.go
+++ b/pkg/xds/topology/dataplanes.go
@@ -1,7 +1,6 @@
 package topology
 
 import (
-	"context"
 	"net"
 
 	"github.com/go-logr/logr"
@@ -11,54 +10,31 @@ import (
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	"github.com/kumahq/kuma/pkg/core/dns/lookup"
 	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
-	"github.com/kumahq/kuma/pkg/core/resources/manager"
 )
-
-func GetZoneIngresses(log logr.Logger, ctx context.Context, rm manager.ReadOnlyResourceManager, lookupIPFunc lookup.LookupIPFunc) (*core_mesh.ZoneIngressResourceList, error) {
-	zoneIngresses := &core_mesh.ZoneIngressResourceList{}
-	if err := rm.List(ctx, zoneIngresses); err != nil {
-		return nil, err
-	}
-	zoneIngresses.Items = ResolveZoneIngressAddresses(log, lookupIPFunc, zoneIngresses.Items)
-	return zoneIngresses, nil
-}
 
 // ResolveAddress resolves 'dataplane.networking.address' if it has DNS name in it. This is a crucial feature for
 // some environments specifically AWS ECS. Dataplane resource has to be created before running Kuma DP, but IP address
 // will be assigned only after container's start. Envoy EDS doesn't support DNS names, that's why Kuma CP resolves
 // addresses before sending resources to the proxy.
 func ResolveAddress(lookupIPFunc lookup.LookupIPFunc, dataplane *core_mesh.DataplaneResource) (*core_mesh.DataplaneResource, error) {
-	var ips, aips []net.IP
-	var err error
-	var update_ip, update_aip bool = false, false
-	if ips, err = lookupIPFunc(dataplane.Spec.Networking.Address); err != nil {
+	if dataplane.Spec.Networking.Address == "" {
+		return nil, errors.New("Dataplane address must always be set")
+	}
+	ip, err := lookupFirstIp(lookupIPFunc, dataplane.Spec.Networking.Address)
+	if err != nil {
 		return nil, err
 	}
-	if len(ips) == 0 {
-		return nil, errors.Errorf("can't resolve address %v", dataplane.Spec.Networking.Address)
+	aip, err := lookupFirstIp(lookupIPFunc, dataplane.Spec.Networking.AdvertisedAddress)
+	if err != nil {
+		return nil, err
 	}
-	if dataplane.Spec.Networking.Address != ips[0].String() {
-		update_ip = true
-	}
-	if dataplane.Spec.Networking.AdvertisedAddress != "" {
-		if aips, err = lookupIPFunc(dataplane.Spec.Networking.AdvertisedAddress); err != nil {
-			return nil, err
-		}
-		if len(aips) == 0 {
-			return nil, errors.Errorf("can't resolve address %v", dataplane.Spec.Networking.AdvertisedAddress)
-		}
-		if dataplane.Spec.Networking.AdvertisedAddress != aips[0].String() {
-			update_aip = true
-		}
-	}
-
-	if update_ip || update_aip { // only if we resolve any address, in most cases this is IP not a hostname
+	if ip != "" || aip != "" { // only if we resolve any address, in most cases this is IP not a hostname
 		dpSpec := proto.Clone(dataplane.Spec).(*mesh_proto.Dataplane)
-		if update_ip {
-			dpSpec.Networking.Address = ips[0].String()
+		if ip != "" {
+			dpSpec.Networking.Address = ip
 		}
-		if update_aip {
-			dpSpec.Networking.AdvertisedAddress = aips[0].String()
+		if aip != "" {
+			dpSpec.Networking.AdvertisedAddress = aip
 		}
 		return &core_mesh.DataplaneResource{
 			Meta: dataplane.Meta,
@@ -69,19 +45,13 @@ func ResolveAddress(lookupIPFunc lookup.LookupIPFunc, dataplane *core_mesh.Datap
 }
 
 func ResolveZoneIngressPublicAddress(lookupIPFunc lookup.LookupIPFunc, zoneIngress *core_mesh.ZoneIngressResource) (*core_mesh.ZoneIngressResource, error) {
-	if zoneIngress.Spec.GetNetworking().GetAdvertisedAddress() == "" { // Ingress may not have public address yet.
-		return zoneIngress, nil
-	}
-	ips, err := lookupIPFunc(zoneIngress.Spec.GetNetworking().GetAdvertisedAddress())
+	res, err := lookupFirstIp(lookupIPFunc, zoneIngress.Spec.GetNetworking().GetAdvertisedAddress())
 	if err != nil {
 		return nil, err
 	}
-	if len(ips) == 0 {
-		return nil, errors.Errorf("can't resolve address %v", zoneIngress.Spec.GetNetworking().GetAdvertisedAddress())
-	}
-	if zoneIngress.Spec.GetNetworking().GetAdvertisedAddress() != ips[0].String() { // only if we resolve any address, in most cases this is IP not a hostname
+	if res != "" { // only if we resolve any address, in most cases this is IP not a hostname
 		ziSpec := proto.Clone(zoneIngress.Spec).(*mesh_proto.ZoneIngress)
-		ziSpec.Networking.AdvertisedAddress = ips[0].String()
+		ziSpec.Networking.AdvertisedAddress = res
 		return &core_mesh.ZoneIngressResource{
 			Meta: zoneIngress.Meta,
 			Spec: ziSpec,
@@ -114,4 +84,27 @@ func ResolveZoneIngressAddresses(log logr.Logger, lookupIPFunc lookup.LookupIPFu
 		rv = append(rv, resolvedZi)
 	}
 	return rv
+}
+
+func lookupFirstIp(lookupIPFunc lookup.LookupIPFunc, address string) (string, error) {
+	if address == "" || net.ParseIP(address) != nil { // There's either no address or it's already an ip so nothing to do
+		return "", nil
+	}
+	// Resolve it!
+	ips, err := lookupIPFunc(address)
+	if err != nil {
+		return "", err
+	}
+	if len(ips) == 0 {
+		return "", errors.Errorf("can't resolve address %v", address)
+	}
+	// Pick the first lexicographic order ip (to make resolution deterministic
+	minIp := ""
+	for i := range ips {
+		s := ips[i].String()
+		if minIp == "" || s < minIp {
+			minIp = s
+		}
+	}
+	return minIp, nil
 }

--- a/pkg/xds/topology/dataplanes_test.go
+++ b/pkg/xds/topology/dataplanes_test.go
@@ -33,7 +33,7 @@ var _ = Describe("Resolve Dataplane address", func() {
 		if s == "advertise-2.example.com" {
 			return []net.IP{net.ParseIP("192.0.2.2")}, nil
 		}
-		return nil, errors.New("can't resolve host name")
+		return nil, errors.New("can't resolve host name:" + s)
 	}
 
 	Context("ResolveAddress", func() {

--- a/pkg/xds/topology/dataplanes_test.go
+++ b/pkg/xds/topology/dataplanes_test.go
@@ -33,7 +33,7 @@ var _ = Describe("Resolve Dataplane address", func() {
 		if s == "advertise-2.example.com" {
 			return []net.IP{net.ParseIP("192.0.2.2")}, nil
 		}
-		return nil, errors.New("can't resolve host name:" + s)
+		return nil, errors.Errorf("can't resolve hostname: %s", s)
 	}
 
 	Context("ResolveAddress", func() {


### PR DESCRIPTION
### Summary

We were not resolving the address which was causing to send an invalid envoy config
as EDS can't accept hostnames.

Also refactor the topology/dataplanes to avoid redundant code and remove unecessary calls
when the ip already resolved

### Issues resolved

Fix #4218

### Testing

- [x] Unit tests
- [ ] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes

### Backwards compatibility

- ~~[ ] Update [`UPGRADE.md`](/UPGRADE.md) with any steps users will need to take when upgrading.~~
- ~~[ ] Add `backport-to-stable` label if the code follows our [backporting policy](/CONTRIBUTING.md#backporting)~~
