### PR TITLE
feat(helm): helm chart improvements

### DIFF
--- a/deployments/charts/kuma/README.md
+++ b/deployments/charts/kuma/README.md
@@ -16,6 +16,7 @@ A Helm chart for the Kuma Control Plane
 | patchSystemNamespace | bool | `true` | Whether to patch the target namespace with the system label |
 | installCrdsOnUpgrade.enabled | bool | `true` | Whether install new CRDs before upgrade (if any were introduced with the new version of Kuma) |
 | installCrdsOnUpgrade.imagePullSecrets | list | `[]` | The `imagePullSecrets` to attach to the Service Account running CRD installation. This field will be deprecated in a future release, please use .global.imagePullSecrets |
+| controlPlane.extraLabels | object | `{}` | Labels to add to resources in addition to default labels |
 | controlPlane.logLevel | string | `"info"` | Kuma CP log level: one of off,info,debug |
 | controlPlane.mode | string | `"standalone"` | Kuma CP modes: one of standalone,zone,global |
 | controlPlane.zone | string | `nil` | Kuma CP zone, if running multizone |
@@ -27,8 +28,12 @@ A Helm chart for the Kuma Control Plane
 | controlPlane.autoscaling.targetCPUUtilizationPercentage | int | `80` | For clusters that don't support autoscaling/v2beta, autoscaling/v1 is used |
 | controlPlane.autoscaling.metrics | list | `[{"resource":{"name":"cpu","target":{"averageUtilization":80,"type":"Utilization"}},"type":"Resource"}]` | For clusters that do support autoscaling/v2beta, use metrics |
 | controlPlane.nodeSelector | object | `{"kubernetes.io/arch":"amd64","kubernetes.io/os":"linux"}` | Node selector for the Kuma Control Plane pods |
-| controlPlane.affinity | object | `{}` | Affinity placement rule for the Kuma Control Plane pods |
+| controlPlane.podDisruptionBudget.enabled | bool | `false` | Whether or not to create a pod disruption budget |
+| controlPlane.podDisruptionBudget.maxUnavailable | int | `1` | The maximum number of unavailable pods allowed by the budget |
+| controlPlane.affinity | object | `{"podAntiAffinity":{"preferredDuringSchedulingIgnoredDuringExecution":[{"podAffinityTerm":{"labelSelector":{"matchExpressions":[{"key":"app.kubernetes.io/name","operator":"In","values":["{{ include \"kuma.name\" . }}"]},{"key":"app.kubernetes.io/instance","operator":"In","values":["{{ .Release.Name }}"]},{"key":"app","operator":"In","values":["{{ include \"kuma.name\" . }}-control-plane"]}]},"topologyKey":"kubernetes.io/hostname"},"weight":100}]}}` | Affinity placement rule for the Kuma Control Plane pods. This is rendered as a template, so you can reference other helm variables or includes. |
+| controlPlane.topologySpreadConstraints | string | `nil` | Topology spread constraints rule for the Kuma Control Plane pods. This is rendered as a template so you can use variables to generate match labels. |
 | controlPlane.injectorFailurePolicy | string | `"Fail"` | Failure policy of the mutating webhook implemented by the Kuma Injector component |
+| controlPlane.service.enabled | bool | `true` | Whether or not to create a service resource. |
 | controlPlane.service.name | string | `nil` | Optionally override of the Kuma Control Plane Service's name |
 | controlPlane.service.type | string | `"ClusterIP"` | Service type of the Kuma Control Plane |
 | controlPlane.service.annotations | object | `{}` | Additional annotations to put on the Kuma Control Plane |
@@ -38,23 +43,32 @@ A Helm chart for the Kuma Control Plane
 | controlPlane.ingress.annotations | object | `{}` | Map of ingress annotations. |
 | controlPlane.ingress.path | string | `"/"` | Ingress path. |
 | controlPlane.ingress.pathType | string | `"ImplementationSpecific"` | Each path in an Ingress is required to have a corresponding path type. (ImplementationSpecific/Exact/Prefix) |
-| controlPlane.globalZoneSyncService | object | `{"annotations":{},"loadBalancerIP":null,"port":5685,"type":"LoadBalancer"}` | URL of Global Kuma CP |
+| controlPlane.globalZoneSyncService | object | `{"annotations":{},"enabled":true,"loadBalancerIP":null,"port":5685,"type":"LoadBalancer"}` | URL of Global Kuma CP |
+| controlPlane.globalZoneSyncService.enabled | bool | `true` | Whether or not to create a k8s service for the global zone sync service. It will only be created when enabled and deploying the global control plane. |
 | controlPlane.globalZoneSyncService.type | string | `"LoadBalancer"` | Service type of the Global-zone sync |
 | controlPlane.globalZoneSyncService.loadBalancerIP | string | `nil` | Optionally specify IP to be used by cloud provider when configuring load balancer |
 | controlPlane.globalZoneSyncService.annotations | object | `{}` | Additional annotations to put on the Global Zone Sync Service |
 | controlPlane.globalZoneSyncService.port | int | `5685` | Port on which Global Zone Sync Service is exposed |
 | controlPlane.defaults.skipMeshCreation | bool | `false` | Whether to skip creating the default Mesh |
 | controlPlane.resources | object | the resources will be chosen based on the mode | Optionally override the resource spec |
+| controlPlane.lifecycle | object | `{}` | Pod lifecycle settings (useful for adding a preStop hook, when using AWS ALB or NLB) |
+| controlPlane.terminationGracePeriodSeconds | int | `30` | Number of seconds to wait before force killing the pod. Make sure to update this if you add a preStop hook. |
 | controlPlane.tls.general.secretName | string | `""` | Secret that contains tls.crt, tls.key [and ca.crt when no controlPlane.tls.general.caSecretName specified] for protecting Kuma in-cluster communication |
 | controlPlane.tls.general.caSecretName | string | `""` | Secret that contains ca.crt that was used to sign cert for protecting Kuma in-cluster communication (ca.crt present in this secret have precedence over the one provided in the controlPlane.tls.general.secretName) |
 | controlPlane.tls.general.caBundle | string | `""` | Base64 encoded CA certificate (the same as in controlPlane.tls.general.secret#ca.crt) |
 | controlPlane.tls.apiServer.secretName | string | `""` | Secret that contains tls.crt, tls.key for protecting Kuma API on HTTPS |
 | controlPlane.tls.apiServer.clientCertsSecretName | string | `""` | Secret that contains list of .pem certificates that can access admin endpoints of Kuma API on HTTPS |
-| controlPlane.tls.kdsGlobalServer.secretName | string | `""` | Secret that contains tls.crt, tls.key for protecting cross cluster communication |
-| controlPlane.tls.kdsZoneClient.secretName | string | `""` | Secret that contains ca.crt which was used to sign KDS Global server. Used for CP verification |
+| controlPlane.tls.kdsGlobalServer.secretName | string | `""` | Name of the K8s TLS Secret resource. If you set this and don't set create=true, you have to create the secret manually. |
+| controlPlane.tls.kdsGlobalServer.create | bool | `false` | Whether or not to create the TLS secret in helm. |
+| controlPlane.tls.kdsGlobalServer.cert | string | `""` | The TLS certificate to offer. |
+| controlPlane.tls.kdsGlobalServer.key | string | `""` | The TLS key to use. |
+| controlPlane.tls.kdsZoneClient.secretName | string | `""` | Name of the K8s TLS Secret resource. If you set this and don't set create=true, you have to create the secret manually. |
+| controlPlane.tls.kdsZoneClient.create | bool | `false` | Whether or not to create the TLS secret in helm. |
+| controlPlane.tls.kdsZoneClient.cert | string | `""` | The TLS certificate to expect. |
 | controlPlane.image.pullPolicy | string | `"IfNotPresent"` | Kuma CP ImagePullPolicy |
 | controlPlane.image.repository | string | `"kuma-cp"` | Kuma CP image repository |
 | controlPlane.image.tag | string | `nil` | Kuma CP Image tag. When not specified, the value is copied from global.tag |
+| controlPlane.additionalK8sSecrets | list | `[]` | list of additional secret resources to create; for each specify the name and stringData name is rendered as a template using (tpl $) |
 | controlPlane.secrets | list of { Env: string, Secret: string, Key: string } | `nil` | Secrets to add as environment variables, where `Env` is the name of the env variable, `Secret` is the name of the Secret, and `Key` is the key of the Secret value to use |
 | controlPlane.envVars | object | `{}` | Additional environment variables that will be passed to the control plane |
 | controlPlane.extraConfigMaps | list | `[]` | Additional config maps to mount into the control plane, with optional inline values |
@@ -82,8 +96,18 @@ A Helm chart for the Kuma Control Plane
 | dataPlane.initImage.repository | string | `"kuma-init"` | The Kuma DP init image repository |
 | dataPlane.initImage.tag | string | `nil` | Kuma DP init image tag When not specified, the value is copied from global.tag |
 | ingress.enabled | bool | `false` | If true, it deploys Ingress for cross cluster communication |
+| ingress.extraLabels | object | `{}` | Labels to add to resources, in addition to default labels |
 | ingress.drainTime | string | `"30s"` | Time for which old listener will still be active as draining |
-| ingress.replicas | int | `1` | Number of replicas of the Ingress |
+| ingress.replicas | int | `1` | Number of replicas of the Ingress. Ignored when autoscaling is enabled. |
+| ingress.resources | object | `{"limits":{"cpu":"1000m","memory":"512Mi"},"requests":{"cpu":"50m","memory":"64Mi"}}` | Define the resources to allocate to mesh ingress |
+| ingress.lifecycle | object | `{}` | Pod lifecycle settings (useful for adding a preStop hook, when using AWS ALB or NLB) |
+| ingress.terminationGracePeriodSeconds | int | `30` | Number of seconds to wait before force killing the pod. Make sure to update this if you add a preStop hook. |
+| ingress.autoscaling.enabled | bool | `false` | Whether to enable Horizontal Pod Autoscaling, which requires the [Metrics Server](https://github.com/kubernetes-sigs/metrics-server) in the cluster |
+| ingress.autoscaling.minReplicas | int | `2` | The minimum CP pods to allow |
+| ingress.autoscaling.maxReplicas | int | `5` | The max CP pods to scale to |
+| ingress.autoscaling.targetCPUUtilizationPercentage | int | `80` | For clusters that don't support autoscaling/v2beta, autoscaling/v1 is used |
+| ingress.autoscaling.metrics | list | `[{"resource":{"name":"cpu","target":{"averageUtilization":80,"type":"Utilization"}},"type":"Resource"}]` | For clusters that do support autoscaling/v2beta, use metrics |
+| ingress.service.enabled | bool | `true` | Whether or not to create a Service resource. |
 | ingress.service.type | string | `"LoadBalancer"` | Service type of the Ingress |
 | ingress.service.loadBalancerIP | string | `nil` | Optionally specify IP to be used by cloud provider when configuring load balancer |
 | ingress.service.annotations | object | `{}` | Additional annotations to put on the Ingress service |
@@ -91,12 +115,22 @@ A Helm chart for the Kuma Control Plane
 | ingress.service.nodePort | string | `nil` | Port on which service is exposed on Node for service of type NodePort |
 | ingress.annotations | object | `{}` | Additional deployment annotation |
 | ingress.nodeSelector | object | `{"kubernetes.io/arch":"amd64","kubernetes.io/os":"linux"}` | Node Selector for the Ingress pods |
-| ingress.affinity | object | `{}` | Affinity placement rule for the Kuma Ingress pods |
+| ingress.podDisruptionBudget.enabled | bool | `false` | Whether or not to create a pod disruption budget |
+| ingress.podDisruptionBudget.maxUnavailable | int | `1` | The maximum number of unavailable pods allowed by the budget |
+| ingress.affinity | object | `{"podAntiAffinity":{"preferredDuringSchedulingIgnoredDuringExecution":[{"podAffinityTerm":{"labelSelector":{"matchExpressions":[{"key":"app.kubernetes.io/name","operator":"In","values":["{{ include \"kuma.name\" . }}"]},{"key":"app.kubernetes.io/instance","operator":"In","values":["{{ .Release.Name }}"]},{"key":"app","operator":"In","values":["kuma-ingress"]}]},"topologyKey":"kubernetes.io/hostname"},"weight":100}]}}` | Affinity placement rule for the Kuma Ingress pods This is rendered as a template, so you can reference other helm variables or includes. |
+| ingress.topologySpreadConstraints | string | `nil` | Topology spread constraints rule for the Kuma Mesh Ingress pods. This is rendered as a template so you can use variables to generate match labels. |
 | ingress.podSecurityContext | object | `{}` | Security context at the pod level for ingress |
 | ingress.containerSecurityContext | object | `{}` | Security context at the container level for ingress |
 | egress.enabled | bool | `false` | If true, it deploys Egress for cross cluster communication |
+| egress.extraLabels | object | `{}` | Labels to add to resources, in addition to the default labels. |
 | egress.drainTime | string | `"30s"` | Time for which old listener will still be active as draining |
-| egress.replicas | int | `1` | Number of replicas of the Egress |
+| egress.replicas | int | `1` | Number of replicas of the Egress. Ignored when autoscaling is enabled. |
+| egress.autoscaling.enabled | bool | `false` | Whether to enable Horizontal Pod Autoscaling, which requires the [Metrics Server](https://github.com/kubernetes-sigs/metrics-server) in the cluster |
+| egress.autoscaling.minReplicas | int | `2` | The minimum CP pods to allow |
+| egress.autoscaling.maxReplicas | int | `5` | The max CP pods to scale to |
+| egress.autoscaling.targetCPUUtilizationPercentage | int | `80` | For clusters that don't support autoscaling/v2beta, autoscaling/v1 is used |
+| egress.autoscaling.metrics | list | `[{"resource":{"name":"cpu","target":{"averageUtilization":80,"type":"Utilization"}},"type":"Resource"}]` | For clusters that do support autoscaling/v2beta, use metrics |
+| egress.service.enabled | bool | `true` | Whether or not to create the service object |
 | egress.service.type | string | `"ClusterIP"` | Service type of the Egress |
 | egress.service.loadBalancerIP | string | `nil` | Optionally specify IP to be used by cloud provider when configuring load balancer |
 | egress.service.annotations | object | `{}` | Additional annotations to put on the Egress service |
@@ -104,7 +138,10 @@ A Helm chart for the Kuma Control Plane
 | egress.service.nodePort | string | `nil` | Port on which service is exposed on Node for service of type NodePort |
 | egress.annotations | object | `{}` | Additional deployment annotation |
 | egress.nodeSelector | object | `{"kubernetes.io/arch":"amd64","kubernetes.io/os":"linux"}` | Node Selector for the Egress pods |
-| egress.affinity | object | `{}` | Affinity placement rule for the Kuma Ingress pods |
+| egress.podDisruptionBudget.enabled | bool | `false` | Whether or not to create a pod disruption budget |
+| egress.podDisruptionBudget.maxUnavailable | int | `1` | The maximum number of unavailable pods allowed by the budget |
+| egress.affinity | object | `{"podAntiAffinity":{"preferredDuringSchedulingIgnoredDuringExecution":[{"podAffinityTerm":{"labelSelector":{"matchExpressions":[{"key":"app.kubernetes.io/name","operator":"In","values":["{{ include \"kuma.name\" . }}"]},{"key":"app.kubernetes.io/instance","operator":"In","values":["{{ .Release.Name }}"]},{"key":"app","operator":"In","values":["kuma-egress"]}]},"topologyKey":"kubernetes.io/hostname"},"weight":100}]}}` | Affinity placement rule for the Kuma Egress pods. This is rendered as a template, so you can reference other helm variables or includes. |
+| egress.topologySpreadConstraints | string | `nil` | Topology spread constraints rule for the Kuma Egress pods. This is rendered as a template so you can use variables to generate match labels. |
 | egress.podSecurityContext | object | `{}` | Security context at the pod level for egress |
 | egress.containerSecurityContext | object | `{}` | Security context at the container level for egress |
 | kumactl.image.repository | string | `"kumactl"` | The kumactl image repository |

--- a/deployments/charts/kuma/templates/_helpers.tpl
+++ b/deployments/charts/kuma/templates/_helpers.tpl
@@ -213,13 +213,13 @@ env:
 - name: KUMA_API_SERVER_AUTH_CLIENT_CERTS_DIR
   value: /var/run/secrets/kuma.io/api-server-client-certs/
 {{- end }}
-{{- if .Values.controlPlane.tls.kdsGlobalServer.secretName }}
+{{- if or .Values.controlPlane.tls.kdsGlobalServer.secretName .Values.controlPlane.kdsGlobalServerTLSSecret.enabled }}
 - name: KUMA_MULTIZONE_GLOBAL_KDS_TLS_CERT_FILE
   value: /var/run/secrets/kuma.io/kds-server-tls-cert/tls.crt
 - name: KUMA_MULTIZONE_GLOBAL_KDS_TLS_KEY_FILE
   value: /var/run/secrets/kuma.io/kds-server-tls-cert/tls.key
 {{- end }}
-{{- if .Values.controlPlane.tls.kdsZoneClient.secretName }}
+{{- if or .Values.controlPlane.tls.kdsZoneClient.secretName .Values.controlPlane.kdsZoneClientTLSSecret.enabled }}
 - name: KUMA_MULTIZONE_ZONE_KDS_ROOT_CA_FILE
   value: /var/run/secrets/kuma.io/kds-client-tls-cert/ca.crt
 {{- end }}

--- a/deployments/charts/kuma/templates/_helpers.tpl
+++ b/deployments/charts/kuma/templates/_helpers.tpl
@@ -246,13 +246,13 @@ env:
 - name: KUMA_API_SERVER_AUTH_CLIENT_CERTS_DIR
   value: /var/run/secrets/kuma.io/api-server-client-certs/
 {{- end }}
-{{- if or .Values.controlPlane.tls.kdsGlobalServer.secretName .Values.controlPlane.kdsGlobalServerTLSSecret.enabled }}
+{{- if and (eq .Values.controlPlane.mode "global") (or .Values.controlPlane.tls.kdsGlobalServer.secretName .Values.controlPlane.tls.kdsGlobalServer.create) }}
 - name: KUMA_MULTIZONE_GLOBAL_KDS_TLS_CERT_FILE
   value: /var/run/secrets/kuma.io/kds-server-tls-cert/tls.crt
 - name: KUMA_MULTIZONE_GLOBAL_KDS_TLS_KEY_FILE
   value: /var/run/secrets/kuma.io/kds-server-tls-cert/tls.key
 {{- end }}
-{{- if or .Values.controlPlane.tls.kdsZoneClient.secretName .Values.controlPlane.kdsZoneClientTLSSecret.enabled }}
+{{- if and (eq .Values.controlPlane.mode "zone") (or .Values.controlPlane.tls.kdsZoneClient.secretName .Values.controlPlane.tls.kdsZoneClient.create) }}
 - name: KUMA_MULTIZONE_ZONE_KDS_ROOT_CA_FILE
   value: /var/run/secrets/kuma.io/kds-client-tls-cert/ca.crt
 {{- end }}

--- a/deployments/charts/kuma/templates/_helpers.tpl
+++ b/deployments/charts/kuma/templates/_helpers.tpl
@@ -101,6 +101,39 @@ app: {{ include "kuma.name" . }}-cni
 {{- end }}
 
 {{/*
+control plane labels
+*/}}
+{{- define "kuma.cpLabels" -}}
+app: {{ include "kuma.name" . }}-control-plane
+{{ range $key, $value := $.Values.controlPlane.extraLabels }}
+{{ $key | quote }}: {{ $value | quote }}
+{{ end }}
+{{- include "kuma.labels" . }}
+{{- end }}
+
+{{/*
+ingress labels
+*/}}
+{{- define "kuma.ingressLabels" -}}
+app: {{ include "kuma.name" . }}-ingress
+{{ range $key, $value := .Values.ingress.extraLabels }}
+{{ $key | quote }}: {{ $value | quote }}
+{{ end }}
+{{- include "kuma.labels" . }}
+{{- end }}
+
+{{/*
+egress labels
+*/}}
+{{- define "kuma.egressLabels" -}}
+app: {{ include "kuma.name" . }}-egress
+{{ range $key, $value := .Values.egress.extraLabels }}
+{{ $key | quote }}: {{ $value | quote }}
+{{ end }}
+{{- include "kuma.labels" . }}
+{{- end }}
+
+{{/*
 CNI selector labels
 */}}
 {{- define "kuma.cniSelectorLabels" -}}

--- a/deployments/charts/kuma/templates/cni-configmap.yaml
+++ b/deployments/charts/kuma/templates/cni-configmap.yaml
@@ -4,8 +4,7 @@ apiVersion: v1
 metadata:
   name: {{ include "kuma.name" . }}-cni-config
   namespace: kube-system
-  labels:
-  {{ include "kuma.cniLabels" . | nindent 4 }}
+  labels: {{ include "kuma.cniLabels" . | nindent 4 }}
 data:
   # The CNI network configuration to add to the plugin chain on each node.
   cni_network_config: |-

--- a/deployments/charts/kuma/templates/cni-daemonset.yaml
+++ b/deployments/charts/kuma/templates/cni-daemonset.yaml
@@ -4,8 +4,7 @@ apiVersion: apps/v1
 metadata:
   name: {{ include "kuma.name" . }}-cni-node
   namespace: kube-system
-  labels:
-  {{- include "kuma.cniLabels" . | nindent 4 }}
+  labels: {{- include "kuma.cniLabels" . | nindent 4 }}
 spec:
   selector:
     matchLabels:

--- a/deployments/charts/kuma/templates/cni-rbac.yaml
+++ b/deployments/charts/kuma/templates/cni-rbac.yaml
@@ -4,8 +4,7 @@ kind: ServiceAccount
 metadata:
   name: {{ include "kuma.name" . }}-cni
   namespace: kube-system
-  labels:
-  {{ include "kuma.cniLabels" . | nindent 4 }}
+  labels: {{ include "kuma.cniLabels" . | nindent 4 }}
 {{- with .Values.global.imagePullSecrets }}
 imagePullSecrets:
   {{- range . }}

--- a/deployments/charts/kuma/templates/cp-additional-k8s-secrets.yaml
+++ b/deployments/charts/kuma/templates/cp-additional-k8s-secrets.yaml
@@ -1,0 +1,17 @@
+{{ range $secret := $.Values.controlPlane.additionalK8sSecrets }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ tpl $secret.name $ | quote }}
+  labels:
+    {{- include "kuma.labels" $ | nindent 4 }}
+    app: {{ include "kuma.name" $ }}-control-plane
+    {{ range $key, $value := $.Values.controlPlane.extraLabels }}
+    {{ $key | quote }}: {{ $value | quote }}
+    {{ end }}
+stringData:
+  {{ range $key, $value := $secret.stringData }}
+  {{ $key | quote }}: {{ $value | quote }}
+  {{ end }}
+{{ end }}

--- a/deployments/charts/kuma/templates/cp-additional-k8s-secrets.yaml
+++ b/deployments/charts/kuma/templates/cp-additional-k8s-secrets.yaml
@@ -4,12 +4,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ tpl $secret.name $ | quote }}
-  labels:
-    {{- include "kuma.labels" $ | nindent 4 }}
-    app: {{ include "kuma.name" $ }}-control-plane
-    {{ range $key, $value := $.Values.controlPlane.extraLabels }}
-    {{ $key | quote }}: {{ $value | quote }}
-    {{ end }}
+  labels: {{ include "kuma.cpLabels" $ | nindent 4 }}
 stringData:
   {{ range $key, $value := $secret.stringData }}
   {{ $key | quote }}: {{ $value | quote }}

--- a/deployments/charts/kuma/templates/cp-configmap.yaml
+++ b/deployments/charts/kuma/templates/cp-configmap.yaml
@@ -5,6 +5,9 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
   {{- include "kuma.labels" . | nindent 4 }}
+    {{ range $key, $value := .Values.controlPlane.extraLabels }}
+    {{ $key | quote }}: {{ $value | quote }}
+    {{ end }}
 data:
   config.yaml: |
     # use this file to override default configuration of `kuma-cp`
@@ -26,6 +29,9 @@ metadata:
   namespace: {{ $releaseNamespace }}
   labels:
   {{- $kumaLabels | nindent 4 }}
+    {{ range $key, $value := .Values.controlPlane.extraLabels }}
+    {{ $key | quote }}: {{ $value | quote }}
+    {{ end }}
 data:
   {{- range $fileName, $fileContents := $extraConfigMap.values }}
   {{- $fileName | nindent 2 }}: |

--- a/deployments/charts/kuma/templates/cp-configmap.yaml
+++ b/deployments/charts/kuma/templates/cp-configmap.yaml
@@ -3,11 +3,7 @@ kind: ConfigMap
 metadata:
   name: {{ include "kuma.name" . }}-control-plane-config
   namespace: {{ .Release.Namespace }}
-  labels:
-  {{- include "kuma.labels" . | nindent 4 }}
-    {{ range $key, $value := .Values.controlPlane.extraLabels }}
-    {{ $key | quote }}: {{ $value | quote }}
-    {{ end }}
+  labels: {{ include "kuma.cpLabels" . | nindent 4 }}
 data:
   config.yaml: |
     # use this file to override default configuration of `kuma-cp`

--- a/deployments/charts/kuma/templates/cp-deployment.yaml
+++ b/deployments/charts/kuma/templates/cp-deployment.yaml
@@ -26,21 +26,10 @@ spec:
         app: {{ include "kuma.name" . }}-control-plane
     spec:
       {{- with .Values.controlPlane.affinity }}
-      affinity:
-        {{ toYaml . | nindent 8 }}
-      {{- else }}
-      affinity:
-        podAntiAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-          - weight: 100
-            podAffinityTerm:
-              labelSelector:
-                matchExpressions:
-                - key: app
-                  operator: In
-                  values:
-                  - {{ include "kuma.name" . }}-control-plane
-              topologyKey: kubernetes.io/hostname
+      affinity: {{ tpl (toYaml . | nindent 8) $ }}
+      {{- end }}
+      {{- with .Values.controlPlane.topologySpreadConstraints }}
+      topologySpreadConstraints: {{ tpl (toYaml . | nindent 8) $ }}
       {{- end }}
       {{- if .Values.controlPlane.podSecurityContext }}
       securityContext:

--- a/deployments/charts/kuma/templates/cp-deployment.yaml
+++ b/deployments/charts/kuma/templates/cp-deployment.yaml
@@ -6,6 +6,9 @@ metadata:
   labels:
     {{- include "kuma.labels" . | nindent 4 }}
     app: {{ include "kuma.name" . }}-control-plane
+    {{ range $key, $value := .Values.controlPlane.extraLabels }}
+    {{ $key | quote }}: {{ $value | quote }}
+    {{ end }}
 spec:
   replicas: {{ .Values.controlPlane.replicas }}
   strategy:
@@ -24,6 +27,9 @@ spec:
       labels:
         {{- include "kuma.selectorLabels" . | nindent 8 }}
         app: {{ include "kuma.name" . }}-control-plane
+        {{ range $key, $value := .Values.controlPlane.extraLabels }}
+        {{ $key | quote }}: {{ $value | quote }}
+        {{ end }}
     spec:
       {{- with .Values.controlPlane.affinity }}
       affinity: {{ tpl (toYaml . | nindent 8) $ }}

--- a/deployments/charts/kuma/templates/cp-deployment.yaml
+++ b/deployments/charts/kuma/templates/cp-deployment.yaml
@@ -1,11 +1,19 @@
-{{ $kdsGlobalServerTLSSecretName := .Values.controlPlane.tls.kdsGlobalServer.secretName }}
-{{ if and .Values.controlPlane.kdsGlobalServerTLSSecret.enabled (eq $kdsGlobalServerTLSSecretName "") }}
-{{ $kdsGlobalServerTLSSecretName = print (include "kuma.name" .) "-kds-global-server-tls" }}
+{{ $kdsGlobalServerTLSSecretName := "" }}
+{{ if eq .Values.controlPlane.mode "global" }}
+  {{ $kdsGlobalServerTLSSecretName = .Values.controlPlane.tls.kdsGlobalServer.secretName }}
+  {{ if and .Values.controlPlane.tls.kdsGlobalServer.create (not $kdsGlobalServerTLSSecretName) }}
+    {{ $kdsGlobalServerTLSSecretName = print (include "kuma.name" .) "-kds-global-server-tls" }}
+  {{ end }}
 {{ end }}
-{{ $kdsZoneClientTLSSecretName := .Values.controlPlane.tls.kdsZoneClient.secretName }}
-{{ if and .Values.controlPlane.kdsZoneClientTLSSecret.enabled (eq $kdsZoneClientTLSSecretName "") }}
-{{ $kdsZoneClientTLSSecretName = print (include "kuma.name" .) "-kds-zone-client-tls" }}
+
+{{ $kdsZoneClientTLSSecretName := "" }}
+{{ if eq .Values.controlPlane.mode "zone" }}
+  {{ $kdsZoneClientTLSSecretName = .Values.controlPlane.tls.kdsZoneClient.secretName }}
+  {{ if and .Values.controlPlane.tls.kdsZoneClient.create (not $kdsZoneClientTLSSecretName) }}
+    {{ $kdsZoneClientTLSSecretName = print (include "kuma.name" .) "-kds-zone-client-tls" }}
+  {{ end }}
 {{ end }}
+
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/deployments/charts/kuma/templates/cp-deployment.yaml
+++ b/deployments/charts/kuma/templates/cp-deployment.yaml
@@ -55,6 +55,7 @@ spec:
         {{ toYaml . | nindent 8 }}
       {{- end }}
       hostNetwork: {{ .Values.controlPlane.hostNetwork }}
+      terminationGracePeriodSeconds: {{ .Values.controlPlane.terminationGracePeriodSeconds }}
       containers:
         - name: control-plane
           image: {{ include "kuma.formatImage" (dict "image" .Values.controlPlane.image "root" $) | quote }}
@@ -126,6 +127,9 @@ spec:
             limits:
             {{ .Values.controlPlane.resources.limits | toYaml | nindent 14 }}
             {{- end }}
+          {{ with .Values.controlPlane.lifecycle }}
+          lifecycle: {{ . | toYaml | nindent 14 }}
+          {{ end }}
           volumeMounts:
             - name: general-tls-cert
               mountPath: /var/run/secrets/kuma.io/tls-cert/tls.crt

--- a/deployments/charts/kuma/templates/cp-deployment.yaml
+++ b/deployments/charts/kuma/templates/cp-deployment.yaml
@@ -1,3 +1,11 @@
+{{ $kdsGlobalServerTLSSecretName := .Values.controlPlane.tls.kdsGlobalServer.secretName }}
+{{ if and .Values.controlPlane.kdsGlobalServerTLSSecret.enabled (eq $kdsGlobalServerTLSSecretName "") }}
+{{ $kdsGlobalServerTLSSecretName = print (include "kuma.name" .) "-kds-global-server-tls" }}
+{{ end }}
+{{ $kdsZoneClientTLSSecretName := .Values.controlPlane.tls.kdsZoneClient.secretName }}
+{{ if and .Values.controlPlane.kdsZoneClientTLSSecret.enabled (eq $kdsZoneClientTLSSecretName "") }}
+{{ $kdsZoneClientTLSSecretName = print (include "kuma.name" .) "-kds-zone-client-tls" }}
+{{ end }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -148,12 +156,12 @@ spec:
               mountPath: /var/run/secrets/kuma.io/api-server-client-certs
               readOnly: true
           {{- end }}
-          {{- if .Values.controlPlane.tls.kdsGlobalServer.secretName }}
+          {{- if $kdsGlobalServerTLSSecretName }}
             - name: kds-server-tls-cert
               mountPath: /var/run/secrets/kuma.io/kds-server-tls-cert
               readOnly: true
           {{- end }}
-          {{- if .Values.controlPlane.tls.kdsZoneClient.secretName }}
+          {{- if $kdsZoneClientTLSSecretName }}
             - name: kds-client-tls-cert
               mountPath: /var/run/secrets/kuma.io/kds-client-tls-cert
               readOnly: true
@@ -193,15 +201,15 @@ spec:
           secret:
             secretName: {{ .Values.controlPlane.tls.apiServer.clientCertsSecretName }}
         {{- end }}
-        {{- if .Values.controlPlane.tls.kdsGlobalServer.secretName }}
+        {{- if $kdsGlobalServerTLSSecretName }}
         - name: kds-server-tls-cert
           secret:
-            secretName: {{ .Values.controlPlane.tls.kdsGlobalServer.secretName }}
+            secretName: {{ $kdsGlobalServerTLSSecretName }}
         {{- end }}
-        {{- if .Values.controlPlane.tls.kdsZoneClient.secretName }}
+        {{- if $kdsZoneClientTLSSecretName }}
         - name: kds-client-tls-cert
           secret:
-            secretName: {{ .Values.controlPlane.tls.kdsZoneClient.secretName }}
+            secretName: {{ $kdsZoneClientTLSSecretName }}
         {{- end }}
         - name: {{ include "kuma.name" . }}-control-plane-config
           configMap:

--- a/deployments/charts/kuma/templates/cp-deployment.yaml
+++ b/deployments/charts/kuma/templates/cp-deployment.yaml
@@ -11,12 +11,7 @@ kind: Deployment
 metadata:
   name: {{ include "kuma.name" . }}-control-plane
   namespace: {{ .Release.Namespace }}
-  labels:
-    {{- include "kuma.labels" . | nindent 4 }}
-    app: {{ include "kuma.name" . }}-control-plane
-    {{ range $key, $value := .Values.controlPlane.extraLabels }}
-    {{ $key | quote }}: {{ $value | quote }}
-    {{ end }}
+  labels: {{ include "kuma.cpLabels" . | nindent 4 }}
 spec:
   replicas: {{ .Values.controlPlane.replicas }}
   strategy:
@@ -32,12 +27,8 @@ spec:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/cp-configmap.yaml") . | sha256sum }}
         checksum/tls-secrets: {{ include (print $.Template.BasePath "/cp-webhooks-and-secrets.yaml") . | sha256sum }}
-      labels:
+      labels: {{ include "kuma.cpLabels" . | nindent 8 }}
         {{- include "kuma.selectorLabels" . | nindent 8 }}
-        app: {{ include "kuma.name" . }}-control-plane
-        {{ range $key, $value := .Values.controlPlane.extraLabels }}
-        {{ $key | quote }}: {{ $value | quote }}
-        {{ end }}
     spec:
       {{- with .Values.controlPlane.affinity }}
       affinity: {{ tpl (toYaml . | nindent 8) $ }}

--- a/deployments/charts/kuma/templates/cp-global-sync-service.yaml
+++ b/deployments/charts/kuma/templates/cp-global-sync-service.yaml
@@ -1,4 +1,4 @@
-{{- if eq .Values.controlPlane.mode "global" }}
+{{- if or (and (eq .Values.controlPlane.mode "global") (eq .Values.controlPlane.globalZoneSyncService.enabled nil)) .Values.controlPlane.globalZoneSyncService.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -22,4 +22,4 @@ spec:
   selector:
     app: {{ include "kuma.name" . }}-control-plane
   {{ include "kuma.selectorLabels" . | nindent 4 }}
-  {{- end }}
+{{- end }}

--- a/deployments/charts/kuma/templates/cp-global-sync-service.yaml
+++ b/deployments/charts/kuma/templates/cp-global-sync-service.yaml
@@ -8,6 +8,10 @@ metadata:
     {{- range $key, $value := .Values.controlPlane.globalZoneSyncService.annotations }}
       {{ $key }}: {{ $value | quote }}
     {{- end }}
+  labels:
+    {{ range $key, $value := .Values.controlPlane.extraLabels }}
+    {{ $key | quote }}: {{ $value | quote }}
+    {{ end }}
 spec:
   type: {{ .Values.controlPlane.globalZoneSyncService.type }}
   {{- if .Values.controlPlane.globalZoneSyncService.loadBalancerIP }}

--- a/deployments/charts/kuma/templates/cp-global-sync-service.yaml
+++ b/deployments/charts/kuma/templates/cp-global-sync-service.yaml
@@ -1,4 +1,4 @@
-{{- if or (and (eq .Values.controlPlane.mode "global") (eq .Values.controlPlane.globalZoneSyncService.enabled nil)) .Values.controlPlane.globalZoneSyncService.enabled }}
+{{- if and (eq .Values.controlPlane.mode "global") .Values.controlPlane.globalZoneSyncService.enabled }}
 apiVersion: v1
 kind: Service
 metadata:

--- a/deployments/charts/kuma/templates/cp-global-sync-service.yaml
+++ b/deployments/charts/kuma/templates/cp-global-sync-service.yaml
@@ -8,10 +8,7 @@ metadata:
     {{- range $key, $value := .Values.controlPlane.globalZoneSyncService.annotations }}
       {{ $key }}: {{ $value | quote }}
     {{- end }}
-  labels:
-    {{ range $key, $value := .Values.controlPlane.extraLabels }}
-    {{ $key | quote }}: {{ $value | quote }}
-    {{ end }}
+  labels: {{ include "kuma.cpLabels" . | nindent 4 }}
 spec:
   type: {{ .Values.controlPlane.globalZoneSyncService.type }}
   {{- if .Values.controlPlane.globalZoneSyncService.loadBalancerIP }}

--- a/deployments/charts/kuma/templates/cp-hpa.yaml
+++ b/deployments/charts/kuma/templates/cp-hpa.yaml
@@ -1,12 +1,16 @@
 {{- if .Values.controlPlane.autoscaling.enabled }}
-{{- $supportsV2Beta2 := .Capabilities.APIVersions.Has "autoscaling/v2beta2" }}
-apiVersion: {{ $supportsV2Beta2 | ternary "autoscaling/v2beta2" "autoscaling/v1" }}
+{{ if .Capabilities.APIVersions.Has "autoscaling/v2beta2" }}
+apiVersion: "autoscaling/v2beta2"
+{{ else }}
+apiVersion: "autoscaling/v1"
+{{ end }}
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "kuma.name" . }}-control-plane
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "kuma.labels" . | nindent 4 }}
+    app: {{ include "kuma.name" . }}-control-plane
 spec:
   scaleTargetRef:
     apiVersion: apps/v1
@@ -14,10 +18,9 @@ spec:
     name: {{ include "kuma.name" . }}-control-plane
   minReplicas: {{ .Values.controlPlane.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.controlPlane.autoscaling.maxReplicas }}
-  {{- if not $supportsV2Beta2 }}
+  {{ if .Capabilities.APIVersions.Has "autoscaling/v2beta2" }}
+  metrics: {{- toYaml .Values.controlPlane.autoscaling.metrics | nindent 4 }}
+  {{ else }}
   targetCPUUtilizationPercentage: {{ .Values.controlPlane.autoscaling.targetCPUUtilizationPercentage }}
-  {{- else }}
-  metrics:
-  {{- toYaml .Values.controlPlane.autoscaling.metrics | nindent 4 }}
   {{- end }}
 {{- end }}

--- a/deployments/charts/kuma/templates/cp-hpa.yaml
+++ b/deployments/charts/kuma/templates/cp-hpa.yaml
@@ -11,6 +11,9 @@ metadata:
   labels:
     {{- include "kuma.labels" . | nindent 4 }}
     app: {{ include "kuma.name" . }}-control-plane
+    {{ range $key, $value := .Values.controlPlane.extraLabels }}
+    {{ $key | quote }}: {{ $value | quote }}
+    {{ end }}
 spec:
   scaleTargetRef:
     apiVersion: apps/v1

--- a/deployments/charts/kuma/templates/cp-hpa.yaml
+++ b/deployments/charts/kuma/templates/cp-hpa.yaml
@@ -8,12 +8,7 @@ kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "kuma.name" . }}-control-plane
   namespace: {{ .Release.Namespace }}
-  labels:
-    {{- include "kuma.labels" . | nindent 4 }}
-    app: {{ include "kuma.name" . }}-control-plane
-    {{ range $key, $value := .Values.controlPlane.extraLabels }}
-    {{ $key | quote }}: {{ $value | quote }}
-    {{ end }}
+  labels: {{ include "kuma.cpLabels" . | nindent 4 }}
 spec:
   scaleTargetRef:
     apiVersion: apps/v1

--- a/deployments/charts/kuma/templates/cp-ingress.yaml
+++ b/deployments/charts/kuma/templates/cp-ingress.yaml
@@ -7,6 +7,7 @@ metadata:
   {{- with .Values.controlPlane.ingress.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
+  labels: {{ include "kuma.cpLabels" . | nindent 4 }}
   {{- end }}
 spec:
   ingressClassName: {{ .Values.controlPlane.ingress.ingressClassName }}

--- a/deployments/charts/kuma/templates/cp-kds-global-server-secret.yaml
+++ b/deployments/charts/kuma/templates/cp-kds-global-server-secret.yaml
@@ -1,0 +1,16 @@
+{{ if .Values.controlPlane.kdsGlobalServerTLSSecret.enabled }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "kuma.name" . }}-kds-global-server-tls
+  labels:
+    {{- include "kuma.labels" . | nindent 4 }}
+    app: {{ include "kuma.name" . }}-control-plane
+    {{ range $key, $value := .Values.controlPlane.extraLabels }}
+    {{ $key | quote }}: {{ $value | quote }}
+    {{ end }}
+type: kubernetes.io/tls
+stringData:
+  tls.crt: {{ .Values.controlPlane.kdsGlobalServerTLSSecret.cert | quote }}
+  tls.key: {{ .Values.controlPlane.kdsGlobalServerTLSSecret.key | quote }}
+{{ end }}

--- a/deployments/charts/kuma/templates/cp-kds-global-server-secret.yaml
+++ b/deployments/charts/kuma/templates/cp-kds-global-server-secret.yaml
@@ -3,12 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ include "kuma.name" . }}-kds-global-server-tls
-  labels:
-    {{- include "kuma.labels" . | nindent 4 }}
-    app: {{ include "kuma.name" . }}-control-plane
-    {{ range $key, $value := .Values.controlPlane.extraLabels }}
-    {{ $key | quote }}: {{ $value | quote }}
-    {{ end }}
+  labels: {{ include "kuma.cpLabels" . | nindent 4 }}
 type: kubernetes.io/tls
 stringData:
   tls.crt: {{ .Values.controlPlane.kdsGlobalServerTLSSecret.cert | quote }}

--- a/deployments/charts/kuma/templates/cp-kds-global-server-secret.yaml
+++ b/deployments/charts/kuma/templates/cp-kds-global-server-secret.yaml
@@ -1,11 +1,15 @@
-{{ if .Values.controlPlane.kdsGlobalServerTLSSecret.enabled }}
+{{ if and (eq .Values.controlPlane.mode "global") .Values.controlPlane.tls.kdsGlobalServer.create }}
 apiVersion: v1
 kind: Secret
 metadata:
+{{ with .Values.controlPlane.tls.kdsGlobalServer.secretName }}
+  name: {{ . }}
+{{ else }}
   name: {{ include "kuma.name" . }}-kds-global-server-tls
+{{ end }}
   labels: {{ include "kuma.cpLabels" . | nindent 4 }}
 type: kubernetes.io/tls
 stringData:
-  tls.crt: {{ .Values.controlPlane.kdsGlobalServerTLSSecret.cert | quote }}
-  tls.key: {{ .Values.controlPlane.kdsGlobalServerTLSSecret.key | quote }}
+  tls.crt: {{ required "you must provide a kds tls cert" .Values.controlPlane.tls.kdsGlobalServer.cert | quote }}
+  tls.key: {{ required "you must provide a kds tls key" .Values.controlPlane.tls.kdsGlobalServer.key | quote }}
 {{ end }}

--- a/deployments/charts/kuma/templates/cp-kds-zone-client-tls-secret.yaml
+++ b/deployments/charts/kuma/templates/cp-kds-zone-client-tls-secret.yaml
@@ -1,0 +1,14 @@
+{{ if .Values.controlPlane.kdsZoneClientTLSSecret.enabled }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "kuma.name" . }}-kds-zone-client-tls
+  labels:
+    {{- include "kuma.labels" . | nindent 4 }}
+    app: {{ include "kuma.name" . }}-control-plane
+    {{ range $key, $value := .Values.controlPlane.extraLabels }}
+    {{ $key | quote }}: {{ $value | quote }}
+    {{ end }}
+stringData:
+  ca.crt: {{ .Values.controlPlane.kdsZoneClientTLSSecret.cert | quote }}
+{{ end }}

--- a/deployments/charts/kuma/templates/cp-kds-zone-client-tls-secret.yaml
+++ b/deployments/charts/kuma/templates/cp-kds-zone-client-tls-secret.yaml
@@ -1,9 +1,13 @@
-{{ if .Values.controlPlane.kdsZoneClientTLSSecret.enabled }}
+{{ if and (eq .Values.controlPlane.mode "zone") .Values.controlPlane.tls.kdsZoneClient.create }}
 apiVersion: v1
 kind: Secret
 metadata:
+{{ with .Values.controlPlane.tls.kdsZoneClient.secretName }}
+  name: {{ . }}
+{{ else }}
   name: {{ include "kuma.name" . }}-kds-zone-client-tls
+{{ end }}
   labels: {{ include "kuma.cpLabels" . | nindent 4 }}
 stringData:
-  ca.crt: {{ .Values.controlPlane.kdsZoneClientTLSSecret.cert | quote }}
+  ca.crt: {{ required "you must provide a kds cert" .Values.controlPlane.tls.kdsZoneClient.cert | quote }}
 {{ end }}

--- a/deployments/charts/kuma/templates/cp-kds-zone-client-tls-secret.yaml
+++ b/deployments/charts/kuma/templates/cp-kds-zone-client-tls-secret.yaml
@@ -3,12 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ include "kuma.name" . }}-kds-zone-client-tls
-  labels:
-    {{- include "kuma.labels" . | nindent 4 }}
-    app: {{ include "kuma.name" . }}-control-plane
-    {{ range $key, $value := .Values.controlPlane.extraLabels }}
-    {{ $key | quote }}: {{ $value | quote }}
-    {{ end }}
+  labels: {{ include "kuma.cpLabels" . | nindent 4 }}
 stringData:
   ca.crt: {{ .Values.controlPlane.kdsZoneClientTLSSecret.cert | quote }}
 {{ end }}

--- a/deployments/charts/kuma/templates/cp-pdb.yaml
+++ b/deployments/charts/kuma/templates/cp-pdb.yaml
@@ -1,0 +1,22 @@
+{{ if $.Values.controlPlane.podDisruptionBudget.enabled }}
+{{ if .Capabilities.APIVersions.Has "policy/v1" }}
+apiVersion: policy/v1
+{{ else if .Capabilities.APIVersions.Has "policy/v1beta1" }}
+apiVersion: policy/v1beta1
+{{ else }}
+{{ fail "pod disruption budgets are not supported by this version of kubernetes" }}
+{{ end }}
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "kuma.name" . }}-control-plane
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "kuma.labels" . | nindent 4 }}
+    app: {{ include "kuma.name" . }}-control-plane
+spec:
+  maxUnavailable: {{ .Values.controlPlane.podDisruptionBudget.maxUnavailable }}
+  selector:
+    matchLabels:
+      {{- include "kuma.selectorLabels" . | nindent 6 }}
+      app: {{ include "kuma.name" . }}-control-plane
+{{ end }}

--- a/deployments/charts/kuma/templates/cp-pdb.yaml
+++ b/deployments/charts/kuma/templates/cp-pdb.yaml
@@ -13,6 +13,9 @@ metadata:
   labels:
     {{- include "kuma.labels" . | nindent 4 }}
     app: {{ include "kuma.name" . }}-control-plane
+    {{ range $key, $value := .Values.controlPlane.extraLabels }}
+    {{ $key | quote }}: {{ $value | quote }}
+    {{ end }}
 spec:
   maxUnavailable: {{ .Values.controlPlane.podDisruptionBudget.maxUnavailable }}
   selector:

--- a/deployments/charts/kuma/templates/cp-pdb.yaml
+++ b/deployments/charts/kuma/templates/cp-pdb.yaml
@@ -10,12 +10,7 @@ kind: PodDisruptionBudget
 metadata:
   name: {{ include "kuma.name" . }}-control-plane
   namespace: {{ .Release.Namespace }}
-  labels:
-    {{- include "kuma.labels" . | nindent 4 }}
-    app: {{ include "kuma.name" . }}-control-plane
-    {{ range $key, $value := .Values.controlPlane.extraLabels }}
-    {{ $key | quote }}: {{ $value | quote }}
-    {{ end }}
+  labels: {{ include "kuma.cpLabels" . | nindent 4 }}
 spec:
   maxUnavailable: {{ .Values.controlPlane.podDisruptionBudget.maxUnavailable }}
   selector:

--- a/deployments/charts/kuma/templates/cp-rbac.yaml
+++ b/deployments/charts/kuma/templates/cp-rbac.yaml
@@ -3,11 +3,7 @@ kind: ServiceAccount
 metadata:
   name: {{ include "kuma.name" . }}-control-plane
   namespace: {{ .Release.Namespace }}
-  labels:
-  {{- include "kuma.labels" . | nindent 4 }}
-    {{ range $key, $value := .Values.controlPlane.extraLabels }}
-    {{ $key | quote }}: {{ $value | quote }}
-    {{ end }}
+  labels: {{ include "kuma.cpLabels" . | nindent 4 }}
 {{- with .Values.global.imagePullSecrets }}
 imagePullSecrets:
   {{- range . }}
@@ -19,11 +15,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: {{ include "kuma.name" . }}-control-plane
-  labels:
-  {{- include "kuma.labels" . | nindent 4 }}
-    {{ range $key, $value := .Values.controlPlane.extraLabels }}
-    {{ $key | quote }}: {{ $value | quote }}
-    {{ end }}
+  labels: {{ include "kuma.cpLabels" . | nindent 4 }}
 rules:
   - apiGroups:
       - ""
@@ -268,11 +260,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: {{ include "kuma.name" . }}-control-plane
-  labels:
-  {{- include "kuma.labels" . | nindent 4 }}
-    {{ range $key, $value := .Values.controlPlane.extraLabels }}
-    {{ $key | quote }}: {{ $value | quote }}
-    {{ end }}
+  labels: {{ include "kuma.cpLabels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -287,11 +275,7 @@ kind: Role
 metadata:
   name: {{ include "kuma.name" . }}-control-plane
   namespace: {{ .Release.Namespace }}
-  labels:
-  {{- include "kuma.labels" . | nindent 4 }}
-    {{ range $key, $value := .Values.controlPlane.extraLabels }}
-    {{ $key | quote }}: {{ $value | quote }}
-    {{ end }}
+  labels: {{ include "kuma.cpLabels" . | nindent 4 }}
 rules:
   - apiGroups:
       - ""
@@ -323,10 +307,7 @@ kind: RoleBinding
 metadata:
   name: {{ include "kuma.name" . }}-control-plane
   namespace: {{ .Release.Namespace }}
-  labels:
-    {{ range $key, $value := .Values.controlPlane.extraLabels }}
-    {{ $key | quote }}: {{ $value | quote }}
-    {{ end }}
+  labels: {{ include "kuma.cpLabels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/deployments/charts/kuma/templates/cp-rbac.yaml
+++ b/deployments/charts/kuma/templates/cp-rbac.yaml
@@ -5,6 +5,9 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
   {{- include "kuma.labels" . | nindent 4 }}
+    {{ range $key, $value := .Values.controlPlane.extraLabels }}
+    {{ $key | quote }}: {{ $value | quote }}
+    {{ end }}
 {{- with .Values.global.imagePullSecrets }}
 imagePullSecrets:
   {{- range . }}
@@ -18,6 +21,9 @@ metadata:
   name: {{ include "kuma.name" . }}-control-plane
   labels:
   {{- include "kuma.labels" . | nindent 4 }}
+    {{ range $key, $value := .Values.controlPlane.extraLabels }}
+    {{ $key | quote }}: {{ $value | quote }}
+    {{ end }}
 rules:
   - apiGroups:
       - ""
@@ -264,6 +270,9 @@ metadata:
   name: {{ include "kuma.name" . }}-control-plane
   labels:
   {{- include "kuma.labels" . | nindent 4 }}
+    {{ range $key, $value := .Values.controlPlane.extraLabels }}
+    {{ $key | quote }}: {{ $value | quote }}
+    {{ end }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -280,6 +289,9 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
   {{- include "kuma.labels" . | nindent 4 }}
+    {{ range $key, $value := .Values.controlPlane.extraLabels }}
+    {{ $key | quote }}: {{ $value | quote }}
+    {{ end }}
 rules:
   - apiGroups:
       - ""
@@ -311,6 +323,10 @@ kind: RoleBinding
 metadata:
   name: {{ include "kuma.name" . }}-control-plane
   namespace: {{ .Release.Namespace }}
+  labels:
+    {{ range $key, $value := .Values.controlPlane.extraLabels }}
+    {{ $key | quote }}: {{ $value | quote }}
+    {{ end }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/deployments/charts/kuma/templates/cp-service.yaml
+++ b/deployments/charts/kuma/templates/cp-service.yaml
@@ -1,3 +1,4 @@
+{{ if .Values.controlPlane.service.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -35,3 +36,4 @@ spec:
   selector:
     app: {{ include "kuma.name" . }}-control-plane
   {{- include "kuma.selectorLabels" . | nindent 4 }}
+{{ end }}

--- a/deployments/charts/kuma/templates/cp-service.yaml
+++ b/deployments/charts/kuma/templates/cp-service.yaml
@@ -6,6 +6,9 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
   {{- include "kuma.labels" . | nindent 4 }}
+    {{ range $key, $value := .Values.controlPlane.extraLabels }}
+    {{ $key | quote }}: {{ $value | quote }}
+    {{ end }}
   annotations:
     prometheus.io/scrape: "true"
     prometheus.io/port: "5680"

--- a/deployments/charts/kuma/templates/cp-service.yaml
+++ b/deployments/charts/kuma/templates/cp-service.yaml
@@ -4,11 +4,7 @@ kind: Service
 metadata:
   name: {{ include "kuma.controlPlane.serviceName" . }}
   namespace: {{ .Release.Namespace }}
-  labels:
-  {{- include "kuma.labels" . | nindent 4 }}
-    {{ range $key, $value := .Values.controlPlane.extraLabels }}
-    {{ $key | quote }}: {{ $value | quote }}
-    {{ end }}
+  labels: {{ include "kuma.cpLabels" . | nindent 4 }}
   annotations:
     prometheus.io/scrape: "true"
     prometheus.io/port: "5680"

--- a/deployments/charts/kuma/templates/cp-webhooks-and-secrets.yaml
+++ b/deployments/charts/kuma/templates/cp-webhooks-and-secrets.yaml
@@ -42,6 +42,9 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
   {{- include "kuma.labels" . | nindent 4 }}
+    {{ range $key, $value := .Values.controlPlane.extraLabels }}
+    {{ $key | quote }}: {{ $value | quote }}
+    {{ end }}
 data:
   tls.crt: {{ $cert }}
   tls.key: {{ $key }}
@@ -55,6 +58,9 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
   {{ include "kuma.labels" . | nindent 4 }}
+    {{ range $key, $value := .Values.controlPlane.extraLabels }}
+    {{ $key | quote }}: {{ $value | quote }}
+    {{ end }}
 webhooks:
   - name: mesh.defaulter.kuma-admission.kuma.io
     admissionReviewVersions: ["v1"]
@@ -180,6 +186,9 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
   {{ include "kuma.labels" . | nindent 4 }}
+    {{ range $key, $value := .Values.controlPlane.extraLabels }}
+    {{ $key | quote }}: {{ $value | quote }}
+    {{ end }}
 webhooks:
   - name: validator.kuma-admission.kuma.io
     admissionReviewVersions: ["v1"]

--- a/deployments/charts/kuma/templates/cp-webhooks-and-secrets.yaml
+++ b/deployments/charts/kuma/templates/cp-webhooks-and-secrets.yaml
@@ -40,11 +40,7 @@ type: kubernetes.io/tls
 metadata:
   name: {{ $secretName }}
   namespace: {{ .Release.Namespace }}
-  labels:
-  {{- include "kuma.labels" . | nindent 4 }}
-    {{ range $key, $value := .Values.controlPlane.extraLabels }}
-    {{ $key | quote }}: {{ $value | quote }}
-    {{ end }}
+  labels: {{ include "kuma.cpLabels" . | nindent 4 }}
 data:
   tls.crt: {{ $cert }}
   tls.key: {{ $key }}
@@ -56,11 +52,7 @@ kind: MutatingWebhookConfiguration
 metadata:
   name: {{ include "kuma.name" . }}-admission-mutating-webhook-configuration
   namespace: {{ .Release.Namespace }}
-  labels:
-  {{ include "kuma.labels" . | nindent 4 }}
-    {{ range $key, $value := .Values.controlPlane.extraLabels }}
-    {{ $key | quote }}: {{ $value | quote }}
-    {{ end }}
+  labels: {{ include "kuma.cpLabels" . | nindent 4 }}
 webhooks:
   - name: mesh.defaulter.kuma-admission.kuma.io
     admissionReviewVersions: ["v1"]
@@ -184,11 +176,7 @@ kind: ValidatingWebhookConfiguration
 metadata:
   name: {{ include "kuma.name" . }}-validating-webhook-configuration
   namespace: {{ .Release.Namespace }}
-  labels:
-  {{ include "kuma.labels" . | nindent 4 }}
-    {{ range $key, $value := .Values.controlPlane.extraLabels }}
-    {{ $key | quote }}: {{ $value | quote }}
-    {{ end }}
+  labels: {{ include "kuma.cpLabels" . | nindent 4 }}
 webhooks:
   - name: validator.kuma-admission.kuma.io
     admissionReviewVersions: ["v1"]

--- a/deployments/charts/kuma/templates/egress-deployment.yaml
+++ b/deployments/charts/kuma/templates/egress-deployment.yaml
@@ -31,21 +31,10 @@ spec:
         app: {{ include "kuma.name" . }}-egress
     spec:
       {{- with .Values.egress.affinity }}
-      affinity:
-        {{ toYaml . | nindent 8 }}
-      {{- else }}
-      affinity:
-        podAntiAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-          - weight: 100
-            podAffinityTerm:
-              labelSelector:
-                matchExpressions:
-                - key: app
-                  operator: In
-                  values:
-                  - {{ include "kuma.name" . }}-egress
-              topologyKey: kubernetes.io/hostname
+      affinity: {{ tpl (toYaml . | nindent 8) $ }}
+      {{- end }}
+      {{- with .Values.egress.topologySpreadConstraints }}
+      topologySpreadConstraints: {{ tpl (toYaml . | nindent 8) $ }}
       {{- end }}
       {{- if .Values.egress.podSecurityContext }}
       securityContext:

--- a/deployments/charts/kuma/templates/egress-deployment.yaml
+++ b/deployments/charts/kuma/templates/egress-deployment.yaml
@@ -7,6 +7,9 @@ metadata:
   labels:
     {{- include "kuma.labels" . | nindent 4 }}
     app: {{ include "kuma.name" . }}-egress
+    {{ range $key, $value := .Values.egress.extraLabels }}
+    {{ $key | quote }}: {{ $value | quote }}
+    {{ end }}
 spec:
   strategy:
     rollingUpdate:
@@ -29,6 +32,9 @@ spec:
       labels:
         {{- include "kuma.selectorLabels" . | nindent 8 }}
         app: {{ include "kuma.name" . }}-egress
+        {{ range $key, $value := .Values.egress.extraLabels }}
+        {{ $key | quote }}: {{ $value | quote }}
+        {{ end }}
     spec:
       {{- with .Values.egress.affinity }}
       affinity: {{ tpl (toYaml . | nindent 8) $ }}

--- a/deployments/charts/kuma/templates/egress-deployment.yaml
+++ b/deployments/charts/kuma/templates/egress-deployment.yaml
@@ -4,12 +4,7 @@ kind: Deployment
 metadata:
   name: {{ include "kuma.name" . }}-egress
   namespace: {{ .Release.Namespace }}
-  labels:
-    {{- include "kuma.labels" . | nindent 4 }}
-    app: {{ include "kuma.name" . }}-egress
-    {{ range $key, $value := .Values.egress.extraLabels }}
-    {{ $key | quote }}: {{ $value | quote }}
-    {{ end }}
+  labels: {{ include "kuma.egressLabels" . | nindent 4 }}
 spec:
   strategy:
     rollingUpdate:
@@ -29,12 +24,8 @@ spec:
         {{ $key }}: {{ $value | quote }}
         {{- end }}
         {{- end }}
-      labels:
+      labels: {{ include "kuma.egressLabels" . | nindent 8 }}
         {{- include "kuma.selectorLabels" . | nindent 8 }}
-        app: {{ include "kuma.name" . }}-egress
-        {{ range $key, $value := .Values.egress.extraLabels }}
-        {{ $key | quote }}: {{ $value | quote }}
-        {{ end }}
     spec:
       {{- with .Values.egress.affinity }}
       affinity: {{ tpl (toYaml . | nindent 8) $ }}

--- a/deployments/charts/kuma/templates/egress-hpa.yaml
+++ b/deployments/charts/kuma/templates/egress-hpa.yaml
@@ -1,0 +1,26 @@
+{{- if .Values.egress.autoscaling.enabled }}
+{{ if .Capabilities.APIVersions.Has "autoscaling/v2beta2" }}
+apiVersion: "autoscaling/v2beta2"
+{{ else }}
+apiVersion: "autoscaling/v1"
+{{ end }}
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "kuma.name" . }}-egress
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "kuma.labels" . | nindent 4 }}
+    app: kuma-egress
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "kuma.name" . }}-egress
+  minReplicas: {{ .Values.egress.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.egress.autoscaling.maxReplicas }}
+  {{ if .Capabilities.APIVersions.Has "autoscaling/v2beta2" }}
+  metrics: {{- toYaml .Values.egress.autoscaling.metrics | nindent 4 }}
+  {{ else }}
+  targetCPUUtilizationPercentage: {{ .Values.egress.autoscaling.targetCPUUtilizationPercentage }}
+  {{- end }}
+{{- end }}

--- a/deployments/charts/kuma/templates/egress-hpa.yaml
+++ b/deployments/charts/kuma/templates/egress-hpa.yaml
@@ -11,6 +11,9 @@ metadata:
   labels:
     {{- include "kuma.labels" . | nindent 4 }}
     app: kuma-egress
+    {{ range $key, $value := .Values.egress.extraLabels }}
+    {{ $key | quote }}: {{ $value | quote }}
+    {{ end }}
 spec:
   scaleTargetRef:
     apiVersion: apps/v1

--- a/deployments/charts/kuma/templates/egress-hpa.yaml
+++ b/deployments/charts/kuma/templates/egress-hpa.yaml
@@ -8,12 +8,7 @@ kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "kuma.name" . }}-egress
   namespace: {{ .Release.Namespace }}
-  labels:
-    {{- include "kuma.labels" . | nindent 4 }}
-    app: kuma-egress
-    {{ range $key, $value := .Values.egress.extraLabels }}
-    {{ $key | quote }}: {{ $value | quote }}
-    {{ end }}
+  labels: {{ include "kuma.egressLabels" . | nindent 4 }}
 spec:
   scaleTargetRef:
     apiVersion: apps/v1

--- a/deployments/charts/kuma/templates/egress-pdb.yaml
+++ b/deployments/charts/kuma/templates/egress-pdb.yaml
@@ -1,0 +1,22 @@
+{{ if $.Values.egress.podDisruptionBudget.enabled }}
+{{ if .Capabilities.APIVersions.Has "policy/v1" }}
+apiVersion: policy/v1
+{{ else if .Capabilities.APIVersions.Has "policy/v1beta1" }}
+apiVersion: policy/v1beta1
+{{ else }}
+{{ fail "pod disruption budgets are not supported by this version of kubernetes" }}
+{{ end }}
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "kuma.name" . }}-egress
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "kuma.labels" . | nindent 4 }}
+    app: kuma-egress
+spec:
+  maxUnavailable: {{ .Values.egress.podDisruptionBudget.maxUnavailable }}
+  selector:
+    matchLabels:
+      {{- include "kuma.selectorLabels" . | nindent 6 }}
+      app: kuma-egress
+{{ end }}

--- a/deployments/charts/kuma/templates/egress-pdb.yaml
+++ b/deployments/charts/kuma/templates/egress-pdb.yaml
@@ -13,6 +13,9 @@ metadata:
   labels:
     {{- include "kuma.labels" . | nindent 4 }}
     app: kuma-egress
+    {{ range $key, $value := .Values.egress.extraLabels }}
+    {{ $key | quote }}: {{ $value | quote }}
+    {{ end }}
 spec:
   maxUnavailable: {{ .Values.egress.podDisruptionBudget.maxUnavailable }}
   selector:

--- a/deployments/charts/kuma/templates/egress-pdb.yaml
+++ b/deployments/charts/kuma/templates/egress-pdb.yaml
@@ -10,12 +10,7 @@ kind: PodDisruptionBudget
 metadata:
   name: {{ include "kuma.name" . }}-egress
   namespace: {{ .Release.Namespace }}
-  labels:
-    {{- include "kuma.labels" . | nindent 4 }}
-    app: kuma-egress
-    {{ range $key, $value := .Values.egress.extraLabels }}
-    {{ $key | quote }}: {{ $value | quote }}
-    {{ end }}
+  labels: {{ include "kuma.egressLabels" . | nindent 4 }}
 spec:
   maxUnavailable: {{ .Values.egress.podDisruptionBudget.maxUnavailable }}
   selector:

--- a/deployments/charts/kuma/templates/egress-rbac.yaml
+++ b/deployments/charts/kuma/templates/egress-rbac.yaml
@@ -6,4 +6,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
   {{- include "kuma.labels" . | nindent 4 }}
+    {{ range $key, $value := .Values.egress.extraLabels }}
+    {{ $key | quote }}: {{ $value | quote }}
+    {{ end }}
 {{- end }}

--- a/deployments/charts/kuma/templates/egress-rbac.yaml
+++ b/deployments/charts/kuma/templates/egress-rbac.yaml
@@ -4,9 +4,5 @@ kind: ServiceAccount
 metadata:
   name: {{ include "kuma.name" . }}-egress
   namespace: {{ .Release.Namespace }}
-  labels:
-  {{- include "kuma.labels" . | nindent 4 }}
-    {{ range $key, $value := .Values.egress.extraLabels }}
-    {{ $key | quote }}: {{ $value | quote }}
-    {{ end }}
+  labels: {{ include "kuma.egressLabels" . | nindent 4 }}
 {{- end }}

--- a/deployments/charts/kuma/templates/egress-service.yaml
+++ b/deployments/charts/kuma/templates/egress-service.yaml
@@ -11,6 +11,9 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
   {{- include "kuma.labels" . | nindent 4 }}
+    {{ range $key, $value := .Values.egress.extraLabels }}
+    {{ $key | quote }}: {{ $value | quote }}
+    {{ end }}
   annotations:
     {{- range $key, $value := .Values.egress.service.annotations }}
       {{ $key }}: {{ $value | quote }}

--- a/deployments/charts/kuma/templates/egress-service.yaml
+++ b/deployments/charts/kuma/templates/egress-service.yaml
@@ -9,11 +9,7 @@ kind: Service
 metadata:
   name: {{ include "kuma.egress.serviceName" . }}
   namespace: {{ .Release.Namespace }}
-  labels:
-  {{- include "kuma.labels" . | nindent 4 }}
-    {{ range $key, $value := .Values.egress.extraLabels }}
-    {{ $key | quote }}: {{ $value | quote }}
-    {{ end }}
+  labels: {{ include "kuma.egressLabels" . | nindent 4 }}
   annotations:
     {{- range $key, $value := .Values.egress.service.annotations }}
       {{ $key }}: {{ $value | quote }}

--- a/deployments/charts/kuma/templates/egress-service.yaml
+++ b/deployments/charts/kuma/templates/egress-service.yaml
@@ -2,6 +2,8 @@
 {{- if eq .Values.controlPlane.mode "global" }}
 {{ fail "You shouldn't run zoneEgress when running the CP in global" }}
 {{- end }}
+{{- end }}
+{{- if and .Values.egress.enabled .Values.egress.service.enabled }}
 apiVersion: v1
 kind: Service
 metadata:

--- a/deployments/charts/kuma/templates/ingress-deployment.yaml
+++ b/deployments/charts/kuma/templates/ingress-deployment.yaml
@@ -103,13 +103,7 @@ spec:
             periodSeconds: 5
             successThreshold: 1
             timeoutSeconds: 3
-          resources:
-            requests:
-              cpu: 50m
-              memory: 64Mi
-            limits:
-              cpu: 1000m
-              memory: 512Mi
+          resources: {{ toYaml .Values.ingress.resources | nindent 12 }}
           volumeMounts:
             - name: {{ include "kuma.name" . }}-tls-cert
               mountPath: /var/run/secrets/kuma.io/tls-cert

--- a/deployments/charts/kuma/templates/ingress-deployment.yaml
+++ b/deployments/charts/kuma/templates/ingress-deployment.yaml
@@ -7,6 +7,9 @@ metadata:
   labels:
     {{- include "kuma.labels" . | nindent 4 }}
     app: {{ include "kuma.name" . }}-ingress
+    {{ range $key, $value := .Values.ingress.extraLabels }}
+    {{ $key | quote }}: {{ $value | quote }}
+    {{ end }}
 spec:
   strategy:
     rollingUpdate:
@@ -29,6 +32,9 @@ spec:
       labels:
         {{- include "kuma.selectorLabels" . | nindent 8 }}
         app: {{ include "kuma.name" . }}-ingress
+        {{ range $key, $value := .Values.ingress.extraLabels }}
+        {{ $key | quote }}: {{ $value | quote }}
+        {{ end }}
     spec:
       {{- with .Values.ingress.affinity }}
       affinity: {{ tpl (toYaml . | nindent 8) $ }}

--- a/deployments/charts/kuma/templates/ingress-deployment.yaml
+++ b/deployments/charts/kuma/templates/ingress-deployment.yaml
@@ -31,21 +31,10 @@ spec:
         app: {{ include "kuma.name" . }}-ingress
     spec:
       {{- with .Values.ingress.affinity }}
-      affinity:
-        {{ toYaml . | nindent 8 }}
-      {{- else }}
-      affinity:
-        podAntiAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-          - weight: 100
-            podAffinityTerm:
-              labelSelector:
-                matchExpressions:
-                - key: app
-                  operator: In
-                  values:
-                  - {{ include "kuma.name" . }}-ingress
-              topologyKey: kubernetes.io/hostname
+      affinity: {{ tpl (toYaml . | nindent 8) $ }}
+      {{- end }}
+      {{- with .Values.ingress.topologySpreadConstraints }}
+      topologySpreadConstraints: {{ tpl (toYaml . | nindent 8) $ }}
       {{- end }}
       {{- if .Values.ingress.podSecurityContext }}
       securityContext:

--- a/deployments/charts/kuma/templates/ingress-deployment.yaml
+++ b/deployments/charts/kuma/templates/ingress-deployment.yaml
@@ -4,12 +4,7 @@ kind: Deployment
 metadata:
   name: {{ include "kuma.name" . }}-ingress
   namespace: {{ .Release.Namespace }}
-  labels:
-    {{- include "kuma.labels" . | nindent 4 }}
-    app: {{ include "kuma.name" . }}-ingress
-    {{ range $key, $value := .Values.ingress.extraLabels }}
-    {{ $key | quote }}: {{ $value | quote }}
-    {{ end }}
+  labels: {{ include "kuma.ingressLabels" . | nindent 4 }}
 spec:
   strategy:
     rollingUpdate:
@@ -29,12 +24,8 @@ spec:
         {{ $key }}: {{ $value | quote }}
         {{- end }}
         {{- end }}
-      labels:
+      labels: {{ include "kuma.ingressLabels" . | nindent 8 }}
         {{- include "kuma.selectorLabels" . | nindent 8 }}
-        app: {{ include "kuma.name" . }}-ingress
-        {{ range $key, $value := .Values.ingress.extraLabels }}
-        {{ $key | quote }}: {{ $value | quote }}
-        {{ end }}
     spec:
       {{- with .Values.ingress.affinity }}
       affinity: {{ tpl (toYaml . | nindent 8) $ }}

--- a/deployments/charts/kuma/templates/ingress-deployment.yaml
+++ b/deployments/charts/kuma/templates/ingress-deployment.yaml
@@ -51,6 +51,7 @@ spec:
       nodeSelector:
       {{ toYaml . | nindent 8 }}
       {{- end }}
+      terminationGracePeriodSeconds: {{ .Values.ingress.terminationGracePeriodSeconds }}
       containers:
         - name: ingress
           image: {{ include "kuma.formatImage" (dict "image" .Values.dataPlane.image "root" $) | quote }}
@@ -104,6 +105,9 @@ spec:
             successThreshold: 1
             timeoutSeconds: 3
           resources: {{ toYaml .Values.ingress.resources | nindent 12 }}
+          {{ with .Values.ingress.lifecycle}}
+          lifecycle: {{ . | toYaml | nindent 12 }}
+          {{ end }}
           volumeMounts:
             - name: {{ include "kuma.name" . }}-tls-cert
               mountPath: /var/run/secrets/kuma.io/tls-cert

--- a/deployments/charts/kuma/templates/ingress-hpa.yaml
+++ b/deployments/charts/kuma/templates/ingress-hpa.yaml
@@ -11,6 +11,9 @@ metadata:
   labels:
     {{- include "kuma.labels" . | nindent 4 }}
     app: kuma-ingress
+    {{ range $key, $value := .Values.ingress.extraLabels }}
+    {{ $key | quote }}: {{ $value | quote }}
+    {{ end }}
 spec:
   scaleTargetRef:
     apiVersion: apps/v1

--- a/deployments/charts/kuma/templates/ingress-hpa.yaml
+++ b/deployments/charts/kuma/templates/ingress-hpa.yaml
@@ -1,0 +1,26 @@
+{{- if .Values.ingress.autoscaling.enabled }}
+{{ if .Capabilities.APIVersions.Has "autoscaling/v2beta2" }}
+apiVersion: "autoscaling/v2beta2"
+{{ else }}
+apiVersion: "autoscaling/v1"
+{{ end }}
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "kuma.name" . }}-ingress
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "kuma.labels" . | nindent 4 }}
+    app: kuma-ingress
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "kuma.name" . }}-ingress
+  minReplicas: {{ .Values.ingress.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.ingress.autoscaling.maxReplicas }}
+  {{ if .Capabilities.APIVersions.Has "autoscaling/v2beta2" }}
+  metrics: {{- toYaml .Values.ingress.autoscaling.metrics | nindent 4 }}
+  {{ else }}
+  targetCPUUtilizationPercentage: {{ .Values.ingress.autoscaling.targetCPUUtilizationPercentage }}
+  {{- end }}
+{{- end }}

--- a/deployments/charts/kuma/templates/ingress-hpa.yaml
+++ b/deployments/charts/kuma/templates/ingress-hpa.yaml
@@ -8,12 +8,7 @@ kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "kuma.name" . }}-ingress
   namespace: {{ .Release.Namespace }}
-  labels:
-    {{- include "kuma.labels" . | nindent 4 }}
-    app: kuma-ingress
-    {{ range $key, $value := .Values.ingress.extraLabels }}
-    {{ $key | quote }}: {{ $value | quote }}
-    {{ end }}
+  labels: {{ include "kuma.ingressLabels" . | nindent 4 }}
 spec:
   scaleTargetRef:
     apiVersion: apps/v1

--- a/deployments/charts/kuma/templates/ingress-pdb.yaml
+++ b/deployments/charts/kuma/templates/ingress-pdb.yaml
@@ -13,6 +13,9 @@ metadata:
   labels:
     {{- include "kuma.labels" . | nindent 4 }}
     app: kuma-ingress
+    {{ range $key, $value := .Values.ingress.extraLabels }}
+    {{ $key | quote }}: {{ $value | quote }}
+    {{ end }}
 spec:
   maxUnavailable: {{ .Values.ingress.podDisruptionBudget.maxUnavailable }}
   selector:

--- a/deployments/charts/kuma/templates/ingress-pdb.yaml
+++ b/deployments/charts/kuma/templates/ingress-pdb.yaml
@@ -1,0 +1,22 @@
+{{ if $.Values.ingress.podDisruptionBudget.enabled }}
+{{ if .Capabilities.APIVersions.Has "policy/v1" }}
+apiVersion: policy/v1
+{{ else if .Capabilities.APIVersions.Has "policy/v1beta1" }}
+apiVersion: policy/v1beta1
+{{ else }}
+{{ fail "pod disruption budgets are not supported by this version of kubernetes" }}
+{{ end }}
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "kuma.name" . }}-ingress
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "kuma.labels" . | nindent 4 }}
+    app: kuma-ingress
+spec:
+  maxUnavailable: {{ .Values.ingress.podDisruptionBudget.maxUnavailable }}
+  selector:
+    matchLabels:
+      {{- include "kuma.selectorLabels" . | nindent 6 }}
+      app: kuma-ingress
+{{ end }}

--- a/deployments/charts/kuma/templates/ingress-pdb.yaml
+++ b/deployments/charts/kuma/templates/ingress-pdb.yaml
@@ -10,12 +10,7 @@ kind: PodDisruptionBudget
 metadata:
   name: {{ include "kuma.name" . }}-ingress
   namespace: {{ .Release.Namespace }}
-  labels:
-    {{- include "kuma.labels" . | nindent 4 }}
-    app: kuma-ingress
-    {{ range $key, $value := .Values.ingress.extraLabels }}
-    {{ $key | quote }}: {{ $value | quote }}
-    {{ end }}
+  labels: {{ include "kuma.ingressLabels" . | nindent 4 }}
 spec:
   maxUnavailable: {{ .Values.ingress.podDisruptionBudget.maxUnavailable }}
   selector:

--- a/deployments/charts/kuma/templates/ingress-rbac.yaml
+++ b/deployments/charts/kuma/templates/ingress-rbac.yaml
@@ -6,6 +6,9 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
   {{- include "kuma.labels" . | nindent 4 }}
+    {{ range $key, $value := .Values.ingress.extraLabels }}
+    {{ $key | quote }}: {{ $value | quote }}
+    {{ end }}
 {{- with .Values.global.imagePullSecrets }}
 imagePullSecrets:
   {{- range . }}

--- a/deployments/charts/kuma/templates/ingress-rbac.yaml
+++ b/deployments/charts/kuma/templates/ingress-rbac.yaml
@@ -4,11 +4,7 @@ kind: ServiceAccount
 metadata:
   name: {{ include "kuma.name" . }}-ingress
   namespace: {{ .Release.Namespace }}
-  labels:
-  {{- include "kuma.labels" . | nindent 4 }}
-    {{ range $key, $value := .Values.ingress.extraLabels }}
-    {{ $key | quote }}: {{ $value | quote }}
-    {{ end }}
+  labels: {{ include "kuma.ingressLabels" . | nindent 4 }}
 {{- with .Values.global.imagePullSecrets }}
 imagePullSecrets:
   {{- range . }}

--- a/deployments/charts/kuma/templates/ingress-service.yaml
+++ b/deployments/charts/kuma/templates/ingress-service.yaml
@@ -9,11 +9,7 @@ kind: Service
 metadata:
   name: {{ include "kuma.ingress.serviceName" . }}
   namespace: {{ .Release.Namespace }}
-  labels:
-  {{- include "kuma.labels" . | nindent 4 }}
-    {{ range $key, $value := .Values.ingress.extraLabels }}
-    {{ $key | quote }}: {{ $value | quote }}
-    {{ end }}
+  labels: {{ include "kuma.ingressLabels" . | nindent 4 }}
   annotations:
     {{- range $key, $value := .Values.ingress.service.annotations }}
       {{ $key }}: {{ $value | quote }}

--- a/deployments/charts/kuma/templates/ingress-service.yaml
+++ b/deployments/charts/kuma/templates/ingress-service.yaml
@@ -11,6 +11,9 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
   {{- include "kuma.labels" . | nindent 4 }}
+    {{ range $key, $value := .Values.ingress.extraLabels }}
+    {{ $key | quote }}: {{ $value | quote }}
+    {{ end }}
   annotations:
     {{- range $key, $value := .Values.ingress.service.annotations }}
       {{ $key }}: {{ $value | quote }}

--- a/deployments/charts/kuma/templates/ingress-service.yaml
+++ b/deployments/charts/kuma/templates/ingress-service.yaml
@@ -2,6 +2,8 @@
 {{- if or (eq .Values.controlPlane.mode "global") (eq .Values.controlPlane.mode "standalone") }}
 {{ fail "You shouldn't run zoneIngress when running the CP in global or standalone" }}
 {{- end }}
+{{- end }}
+{{- if and .Values.ingress.enabled .Values.ingress.service.enabled }}
 apiVersion: v1
 kind: Service
 metadata:

--- a/deployments/charts/kuma/values.yaml
+++ b/deployments/charts/kuma/values.yaml
@@ -207,6 +207,16 @@ controlPlane:
     repository: "kuma-cp"
     # -- Kuma CP Image tag. When not specified, the value is copied from global.tag
     tag:
+
+  # -- list of additional secret resources to create; for each specify the name and stringData
+  # name is rendered as a template using (tpl $)
+  additionalK8sSecrets:
+    # example
+    # - name: {{ include "kuma.name" . }}-extra-secret
+    #   stringData:
+    #     myKey: myValue
+    #     mySecondKey: mySecondValue
+
   # -- (list of { Env: string, Secret: string, Key: string }) Secrets to add as environment variables,
   # where `Env` is the name of the env variable,
   # `Secret` is the name of the Secret,

--- a/deployments/charts/kuma/values.yaml
+++ b/deployments/charts/kuma/values.yaml
@@ -18,6 +18,9 @@ installCrdsOnUpgrade:
   imagePullSecrets: []
 
 controlPlane:
+  # -- Labels to add to resources in addition to default labels
+  extraLabels: {}
+
   # -- Kuma CP log level: one of off,info,debug
   logLevel: "info"
 
@@ -323,6 +326,10 @@ dataPlane:
 ingress:
   # -- If true, it deploys Ingress for cross cluster communication
   enabled: false
+
+  # -- Labels to add to resources, in addition to default labels
+  extraLabels: {}
+
   # -- Time for which old listener will still be active as draining
   drainTime: 30s
 
@@ -432,6 +439,8 @@ ingress:
 egress:
   # -- If true, it deploys Egress for cross cluster communication
   enabled: false
+  # -- Labels to add to resources, in addition to the default labels.
+  extraLabels: {}
   # -- Time for which old listener will still be active as draining
   drainTime: 30s
   # -- Number of replicas of the Egress. Ignored when autoscaling is enabled.

--- a/deployments/charts/kuma/values.yaml
+++ b/deployments/charts/kuma/values.yaml
@@ -59,6 +59,12 @@ controlPlane:
     kubernetes.io/os: linux
     kubernetes.io/arch: amd64
 
+  podDisruptionBudget:
+    # -- Whether or not to create a pod disruption budget
+    enabled: false
+    # -- The maximum number of unavailable pods allowed by the budget
+    maxUnavailable: 1
+
   # -- Affinity placement rule for the Kuma Control Plane pods.
   # This is rendered as a template, so you can reference other helm variables or includes.
   affinity:
@@ -333,6 +339,12 @@ ingress:
     kubernetes.io/os: linux
     kubernetes.io/arch: amd64
 
+  podDisruptionBudget:
+    # -- Whether or not to create a pod disruption budget
+    enabled: false
+    # -- The maximum number of unavailable pods allowed by the budget
+    maxUnavailable: 1
+
   # -- Affinity placement rule for the Kuma Ingress pods
   # This is rendered as a template, so you can reference other helm variables
   # or includes.
@@ -410,6 +422,12 @@ egress:
   nodeSelector:
     kubernetes.io/os: linux
     kubernetes.io/arch: amd64
+
+  podDisruptionBudget:
+    # -- Whether or not to create a pod disruption budget
+    enabled: false
+    # -- The maximum number of unavailable pods allowed by the budget
+    maxUnavailable: 1
 
   # -- Affinity placement rule for the Kuma Egress pods.
   # This is rendered as a template, so you can reference other helm variables or includes.

--- a/deployments/charts/kuma/values.yaml
+++ b/deployments/charts/kuma/values.yaml
@@ -59,8 +59,33 @@ controlPlane:
     kubernetes.io/os: linux
     kubernetes.io/arch: amd64
 
-  # -- Affinity placement rule for the Kuma Control Plane pods
-  affinity: {}
+  # -- Affinity placement rule for the Kuma Control Plane pods.
+  # This is rendered as a template, so you can reference other helm variables or includes.
+  affinity:
+    podAntiAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+      - weight: 100
+        podAffinityTerm:
+          labelSelector:
+            # These match the selector labels used on the deployment.
+            matchExpressions:
+              - key: app.kubernetes.io/name
+                operator: In
+                values:
+                  - '{{ include "kuma.name" . }}'
+              - key: app.kubernetes.io/instance
+                operator: In
+                values:
+                  - '{{ .Release.Name }}'
+              - key: app
+                operator: In
+                values:
+                  - '{{ include "kuma.name" . }}-control-plane'
+          topologyKey: kubernetes.io/hostname
+
+  # -- Topology spread constraints rule for the Kuma Control Plane pods
+  # Don't set this and affinity at the same time
+  topologySpreadConstraints:
 
   # -- Failure policy of the mutating webhook implemented by the Kuma Injector component
   injectorFailurePolicy: Fail
@@ -309,7 +334,33 @@ ingress:
     kubernetes.io/arch: amd64
 
   # -- Affinity placement rule for the Kuma Ingress pods
-  affinity: {}
+  # This is rendered as a template, so you can reference other helm variables
+  # or includes.
+  affinity:
+    podAntiAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+      - weight: 100
+        podAffinityTerm:
+          labelSelector:
+            # These match the selector labels used on the deployment.
+            matchExpressions:
+              - key: app.kubernetes.io/name
+                operator: In
+                values:
+                  - '{{ include "kuma.name" . }}'
+              - key: app.kubernetes.io/instance
+                operator: In
+                values:
+                  - '{{ .Release.Name }}'
+              - key: app
+                operator: In
+                values:
+                  - kuma-ingress
+          topologyKey: kubernetes.io/hostname
+
+  # -- Topology spread constraints rule for the Kuma Mesh Ingress pods
+  # Don't set this and affinity at the same time
+  topologySpreadConstraints:
 
   # -- Security context at the pod level for ingress
   podSecurityContext: {}
@@ -360,8 +411,33 @@ egress:
     kubernetes.io/os: linux
     kubernetes.io/arch: amd64
 
-  # -- Affinity placement rule for the Kuma Ingress pods
-  affinity: {}
+  # -- Affinity placement rule for the Kuma Egress pods.
+  # This is rendered as a template, so you can reference other helm variables or includes.
+  affinity:
+    podAntiAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+      - weight: 100
+        podAffinityTerm:
+          labelSelector:
+            # These match the selector labels used on the deployment.
+            matchExpressions:
+              - key: app.kubernetes.io/name
+                operator: In
+                values:
+                  - '{{ include "kuma.name" . }}'
+              - key: app.kubernetes.io/instance
+                operator: In
+                values:
+                  - '{{ .Release.Name }}'
+              - key: app
+                operator: In
+                values:
+                  - kuma-egress
+          topologyKey: kubernetes.io/hostname
+
+  # -- Topology spread constraints rule for the Kuma Egress pods
+  # Don't set this and affinity at the same time
+  topologySpreadConstraints:
 
   # -- Security context at the pod level for egress
   podSecurityContext: {}

--- a/deployments/charts/kuma/values.yaml
+++ b/deployments/charts/kuma/values.yaml
@@ -156,6 +156,14 @@ controlPlane:
   #    cpu: 250m
   #    memory: 512Mi
 
+  # -- Pod lifecycle settings (useful for adding a preStop hook, when
+  # using AWS ALB or NLB)
+  lifecycle: {}
+
+  # -- Number of seconds to wait before force killing the pod. Make sure to
+  # update this if you add a preStop hook.
+  terminationGracePeriodSeconds: 30
+
   # TLS for various servers
   tls:
     general:
@@ -372,6 +380,14 @@ ingress:
     limits:
       cpu: 1000m
       memory: 512Mi
+
+  # -- Pod lifecycle settings (useful for adding a preStop hook, when
+  # using AWS ALB or NLB)
+  lifecycle: {}
+
+  # -- Number of seconds to wait before force killing the pod. Make sure to
+  # update this if you add a preStop hook.
+  terminationGracePeriodSeconds: 30
 
   # Horizontal Pod Autoscaling configuration
   autoscaling:

--- a/deployments/charts/kuma/values.yaml
+++ b/deployments/charts/kuma/values.yaml
@@ -93,7 +93,6 @@ controlPlane:
           topologyKey: kubernetes.io/hostname
 
   # -- Topology spread constraints rule for the Kuma Control Plane pods
-  # Don't set this and affinity at the same time
   # This is rendered as a template so you can use variables to generate match labels.
   topologySpreadConstraints:
 
@@ -447,7 +446,6 @@ ingress:
           topologyKey: kubernetes.io/hostname
 
   # -- Topology spread constraints rule for the Kuma Mesh Ingress pods
-  # Don't set this and affinity at the same time
   # This is rendered as a template so you can use variables to generate match labels.
   topologySpreadConstraints:
 
@@ -557,7 +555,6 @@ egress:
           topologyKey: kubernetes.io/hostname
 
   # -- Topology spread constraints rule for the Kuma Egress pods
-  # Don't set this and affinity at the same time
   # This is rendered as a template so you can use variables to generate match labels.
   topologySpreadConstraints:
 

--- a/deployments/charts/kuma/values.yaml
+++ b/deployments/charts/kuma/values.yaml
@@ -131,8 +131,9 @@ controlPlane:
   # -- URL of Global Kuma CP
   globalZoneSyncService:
     # -- Whether or not to create a k8s service for the global zone sync
-    # service. If null, it will be created only if mode is set to global.
-    enabled: null
+    # service. It will only be created when enabled and deploying the global
+    # control plane.
+    enabled: true
     # -- Service type of the Global-zone sync
     type: LoadBalancer
     # -- (string) Optionally specify IP to be used by cloud provider when configuring load balancer

--- a/deployments/charts/kuma/values.yaml
+++ b/deployments/charts/kuma/values.yaml
@@ -365,6 +365,15 @@ ingress:
   # -- Number of replicas of the Ingress. Ignored when autoscaling is enabled.
   replicas: 1
 
+  # -- Define the resources to allocate to mesh ingress
+  resources:
+    requests:
+      cpu: 50m
+      memory: 64Mi
+    limits:
+      cpu: 1000m
+      memory: 512Mi
+
   # Horizontal Pod Autoscaling configuration
   autoscaling:
     # -- Whether to enable Horizontal Pod Autoscaling, which requires the [Metrics Server](https://github.com/kubernetes-sigs/metrics-server) in the cluster

--- a/deployments/charts/kuma/values.yaml
+++ b/deployments/charts/kuma/values.yaml
@@ -319,8 +319,31 @@ ingress:
   enabled: false
   # -- Time for which old listener will still be active as draining
   drainTime: 30s
-  # -- Number of replicas of the Ingress
+
+  # -- Number of replicas of the Ingress. Ignored when autoscaling is enabled.
   replicas: 1
+
+  # Horizontal Pod Autoscaling configuration
+  autoscaling:
+    # -- Whether to enable Horizontal Pod Autoscaling, which requires the [Metrics Server](https://github.com/kubernetes-sigs/metrics-server) in the cluster
+    enabled: false
+
+    # -- The minimum CP pods to allow
+    minReplicas: 2
+    # -- The max CP pods to scale to
+    maxReplicas: 5
+
+    # -- For clusters that don't support autoscaling/v2beta, autoscaling/v1 is used
+    targetCPUUtilizationPercentage: 80
+    # -- For clusters that do support autoscaling/v2beta, use metrics
+    metrics:
+      - type: Resource
+        resource:
+          name: cpu
+          target:
+            type: Utilization
+            averageUtilization: 80
+
   service:
     # -- Service type of the Ingress
     type: LoadBalancer
@@ -403,8 +426,30 @@ egress:
   enabled: false
   # -- Time for which old listener will still be active as draining
   drainTime: 30s
-  # -- Number of replicas of the Egress
+  # -- Number of replicas of the Egress. Ignored when autoscaling is enabled.
   replicas: 1
+
+  # Horizontal Pod Autoscaling configuration
+  autoscaling:
+    # -- Whether to enable Horizontal Pod Autoscaling, which requires the [Metrics Server](https://github.com/kubernetes-sigs/metrics-server) in the cluster
+    enabled: false
+
+    # -- The minimum CP pods to allow
+    minReplicas: 2
+    # -- The max CP pods to scale to
+    maxReplicas: 5
+
+    # -- For clusters that don't support autoscaling/v2beta, autoscaling/v1 is used
+    targetCPUUtilizationPercentage: 80
+    # -- For clusters that do support autoscaling/v2beta, use metrics
+    metrics:
+      - type: Resource
+        resource:
+          name: cpu
+          target:
+            type: Utilization
+            averageUtilization: 80
+
   service:
     # -- Service type of the Egress
     type: ClusterIP

--- a/deployments/charts/kuma/values.yaml
+++ b/deployments/charts/kuma/values.yaml
@@ -94,6 +94,7 @@ controlPlane:
 
   # -- Topology spread constraints rule for the Kuma Control Plane pods
   # Don't set this and affinity at the same time
+  # This is rendered as a template so you can use variables to generate match labels.
   topologySpreadConstraints:
 
   # -- Failure policy of the mutating webhook implemented by the Kuma Injector component
@@ -176,10 +177,28 @@ controlPlane:
       clientCertsSecretName: ""
     kdsGlobalServer:
       # -- Secret that contains tls.crt, tls.key for protecting cross cluster communication
+      # If kdsGlobalServerTLSSecret is enabled, the generated secret's name
+      # will be used by default, and this would override it.
       secretName: ""
     kdsZoneClient:
       # -- Secret that contains ca.crt which was used to sign KDS Global server. Used for CP verification
+      # If kdsZoneClientTLSSecret is enabled, the generated secret's name will
+      # be used by default, and this would override it.
       secretName: ""
+
+  kdsGlobalServerTLSSecret:
+    # -- Whether or not to create the global server secret. Leave set to false if you created the secret manually.
+    enabled: false
+    # -- The TLS certificate to offer
+    cert: ""
+    # -- The TLS key to use
+    key: ""
+
+  kdsZoneClientTLSSecret:
+    # -- Whether or not to create the zone client secret. Leave set to false if you created the secret manually.
+    enabled: false
+    # -- The TLS certificate to expect
+    cert: ""
 
   image:
     # -- Kuma CP ImagePullPolicy
@@ -410,6 +429,7 @@ ingress:
 
   # -- Topology spread constraints rule for the Kuma Mesh Ingress pods
   # Don't set this and affinity at the same time
+  # This is rendered as a template so you can use variables to generate match labels.
   topologySpreadConstraints:
 
   # -- Security context at the pod level for ingress
@@ -519,6 +539,7 @@ egress:
 
   # -- Topology spread constraints rule for the Kuma Egress pods
   # Don't set this and affinity at the same time
+  # This is rendered as a template so you can use variables to generate match labels.
   topologySpreadConstraints:
 
   # -- Security context at the pod level for egress

--- a/deployments/charts/kuma/values.yaml
+++ b/deployments/charts/kuma/values.yaml
@@ -92,7 +92,7 @@ controlPlane:
                   - '{{ include "kuma.name" . }}-control-plane'
           topologyKey: kubernetes.io/hostname
 
-  # -- Topology spread constraints rule for the Kuma Control Plane pods
+  # -- Topology spread constraints rule for the Kuma Control Plane pods.
   # This is rendered as a template so you can use variables to generate match labels.
   topologySpreadConstraints:
 
@@ -189,7 +189,8 @@ controlPlane:
     # - if secretName is empty and create is true, then create a secret with a default name and use it
     # - if secretName is non-empty and create is true, then create the secret using the provided name
     kdsGlobalServer:
-      # -- Name of the K8s TLS Secret resource.
+      # -- Name of the K8s TLS Secret resource. If you set this and don't set
+      # create=true, you have to create the secret manually.
       secretName: ""
       # -- Whether or not to create the TLS secret in helm.
       create: false
@@ -203,7 +204,8 @@ controlPlane:
     # - if secretName is empty and create is true, then create a secret with a default name and use it
     # - if secretName is non-empty and create is true, then create the secret using the provided name
     kdsZoneClient:
-      # -- Name of the K8s TLS Secret resource.
+      # -- Name of the K8s TLS Secret resource. If you set this and don't set
+      # create=true, you have to create the secret manually.
       secretName: ""
       # -- Whether or not to create the TLS secret in helm.
       create: false
@@ -220,7 +222,7 @@ controlPlane:
 
   # -- list of additional secret resources to create; for each specify the name and stringData
   # name is rendered as a template using (tpl $)
-  additionalK8sSecrets:
+  additionalK8sSecrets: []
     # example
     # - name: {{ include "kuma.name" . }}-extra-secret
     #   stringData:
@@ -464,7 +466,7 @@ ingress:
                   - kuma-ingress
           topologyKey: kubernetes.io/hostname
 
-  # -- Topology spread constraints rule for the Kuma Mesh Ingress pods
+  # -- Topology spread constraints rule for the Kuma Mesh Ingress pods.
   # This is rendered as a template so you can use variables to generate match labels.
   topologySpreadConstraints:
 
@@ -573,7 +575,7 @@ egress:
                   - kuma-egress
           topologyKey: kubernetes.io/hostname
 
-  # -- Topology spread constraints rule for the Kuma Egress pods
+  # -- Topology spread constraints rule for the Kuma Egress pods.
   # This is rendered as a template so you can use variables to generate match labels.
   topologySpreadConstraints:
 

--- a/deployments/charts/kuma/values.yaml
+++ b/deployments/charts/kuma/values.yaml
@@ -183,30 +183,32 @@ controlPlane:
       secretName: ""
       # -- Secret that contains list of .pem certificates that can access admin endpoints of Kuma API on HTTPS
       clientCertsSecretName: ""
+    # - if not creating the global control plane, then do nothing
+    # - if secretName is empty and create is false, then do nothing
+    # - if secretName is non-empty and create is false, then use the secret made outside of helm with the name secretName
+    # - if secretName is empty and create is true, then create a secret with a default name and use it
+    # - if secretName is non-empty and create is true, then create the secret using the provided name
     kdsGlobalServer:
-      # -- Secret that contains tls.crt, tls.key for protecting cross cluster communication
-      # If kdsGlobalServerTLSSecret is enabled, the generated secret's name
-      # will be used by default, and this would override it.
+      # -- Name of the K8s TLS Secret resource.
       secretName: ""
+      # -- Whether or not to create the TLS secret in helm.
+      create: false
+      # -- The TLS certificate to offer.
+      cert: ""
+      # -- The TLS key to use.
+      key: ""
+    # - if not creating the zonal control plane, then do nothing
+    # - if secretName is empty and create is false, then do nothing
+    # - if secretName is non-empty and create is false, then use the secret made outside of helm with the name secretName
+    # - if secretName is empty and create is true, then create a secret with a default name and use it
+    # - if secretName is non-empty and create is true, then create the secret using the provided name
     kdsZoneClient:
-      # -- Secret that contains ca.crt which was used to sign KDS Global server. Used for CP verification
-      # If kdsZoneClientTLSSecret is enabled, the generated secret's name will
-      # be used by default, and this would override it.
+      # -- Name of the K8s TLS Secret resource.
       secretName: ""
-
-  kdsGlobalServerTLSSecret:
-    # -- Whether or not to create the global server secret. Leave set to false if you created the secret manually.
-    enabled: false
-    # -- The TLS certificate to offer
-    cert: ""
-    # -- The TLS key to use
-    key: ""
-
-  kdsZoneClientTLSSecret:
-    # -- Whether or not to create the zone client secret. Leave set to false if you created the secret manually.
-    enabled: false
-    # -- The TLS certificate to expect
-    cert: ""
+      # -- Whether or not to create the TLS secret in helm.
+      create: false
+      # -- The TLS certificate to expect.
+      cert: ""
 
   image:
     # -- Kuma CP ImagePullPolicy

--- a/deployments/charts/kuma/values.yaml
+++ b/deployments/charts/kuma/values.yaml
@@ -97,6 +97,9 @@ controlPlane:
   injectorFailurePolicy: Fail
 
   service:
+    # -- Whether or not to create a service resource.
+    enabled: true
+
     # -- (string) Optionally override of the Kuma Control Plane Service's name
     name:
 
@@ -124,6 +127,9 @@ controlPlane:
 
   # -- URL of Global Kuma CP
   globalZoneSyncService:
+    # -- Whether or not to create a k8s service for the global zone sync
+    # service. If null, it will be created only if mode is set to global.
+    enabled: null
     # -- Service type of the Global-zone sync
     type: LoadBalancer
     # -- (string) Optionally specify IP to be used by cloud provider when configuring load balancer
@@ -345,6 +351,8 @@ ingress:
             averageUtilization: 80
 
   service:
+    # -- Whether or not to create a Service resource.
+    enabled: true
     # -- Service type of the Ingress
     type: LoadBalancer
     # -- (string) Optionally specify IP to be used by cloud provider when configuring load balancer
@@ -451,6 +459,8 @@ egress:
             averageUtilization: 80
 
   service:
+    # -- Whether or not to create the service object
+    enabled: true
     # -- Service type of the Egress
     type: ClusterIP
     # -- (string) Optionally specify IP to be used by cloud provider when configuring load balancer


### PR DESCRIPTION
### Summary

When using the Kuma helm chart at GoodRx, we had to make some tweaks to improve availability and integrate with our deployment and monitoring systems. These changes should all be backwards compatible and useful for the community at large. I realize we didn't discuss any of this with the maintainers beforehand. If you choose not to accept, we will maintain these changes in our own fork.


### Full changelog

- allow setting topology spread constraints
- allow defining pod disruption budgets
- allow defining autoscaling on ingress and egress
- make service creation optional (because we make them ourselves using terraform)
- allow adding optional extra labels (to assist our monitoring system)
- allow creating kds tls secrets in helm, and any other k8s secrets (so we don't have to add an extra step to our pipeline)
- allow specifying the resource requirements for ingress
- allow setting pod lifecycle and termination grace period (necessary to avoid outages when using AWS)
- standardize labels for all cp, egress, and ingress resources; some of them will get additional labels as a result. The selector labels are unaffected.

### Issues resolved


### Documentation


### Testing

- [ ] Unit tests
- [ ] E2E tests
- [ ] Manual testing on Universal
- [x] Manual testing on Kubernetes

I've tested these changes manually but I doubt I have tested every possible configuration.

### Backwards compatibility

It should be backwards compatible, but others should verify, because this is very difficult to test. :)
