### PR TITLE
ci(.github): add pr comment actions for golden files and format

### DIFF
--- a/.github/workflows/pr-comments.yaml
+++ b/.github/workflows/pr-comments.yaml
@@ -28,7 +28,7 @@ jobs:
         env:
           REPO: ${{ github.repository }}
           PR_NO: ${{ github.event.issue.number }}
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0

--- a/.github/workflows/pr-comments.yaml
+++ b/.github/workflows/pr-comments.yaml
@@ -1,0 +1,57 @@
+name: pull request comment
+on:
+  issue_comment:
+    types: [created, edited, deleted]
+env:
+  GH_USER: "github-actions[bot]"
+  GH_EMAIL: "<41898282+github-actions[bot]@users.noreply.github.com>"
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+jobs:
+  pr_comments:
+    if: github.event.issue.pull_request != '' && (contains(github.event.comment.body, '/format') || contains(github.event.comment.body, '/golden_files'))
+    runs-on: ubuntu-latest
+    steps:
+      - run: gh api --method POST -f content='+1' ${{ github.event.comment.url }}/reactions
+      - id: get-branch
+        run: echo ::set-output name=branch::$(gh pr view $PR_NO --repo $REPO --json headRefName --jq '.headRefName')
+        env:
+          REPO: ${{ github.repository }}
+          PR_NO: ${{ github.event.issue.number }}
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          ref: ${{ steps.get-branch.outputs.branch }}
+      - uses: actions/setup-go@v3
+        with:
+          go-version: 1.18
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+      - run: |
+          make dev/tools
+          git checkout go.mod go.sum # This is because of some weirdness in `make dev/tools`
+      - name: format
+        if: contains(github.event.comment.body, '/format')   # check the comment if it contains the keywords
+        run: |
+          make format
+      - name: run golden_files
+        if: contains(github.event.comment.body, '/golden_files')  # check the comment if it contains the keywords
+        run: |
+          make test UPDATE_GOLDEN_FILES=true
+      - name: commit and push fixes
+        run: |
+          if git diff --exit-code --stat; then
+            echo "No change detected, skipping git push"
+          else
+            git config user.name "${GH_USER}"
+            git config user.email "${GH_EMAIL}"
+            git commit -s -m "fix(ci): format files" .
+            git push
+          fi
+      - run: gh api --method POST -f content='hooray' ${{ github.event.comment.url }}/reactions

--- a/.github/workflows/pr-comments.yaml
+++ b/.github/workflows/pr-comments.yaml
@@ -1,7 +1,7 @@
 name: pull request comment
 on:
   issue_comment:
-    types: [created, edited, deleted]
+    types: [created]
 env:
   GH_USER: "github-actions[bot]"
   GH_EMAIL: "<41898282+github-actions[bot]@users.noreply.github.com>"
@@ -11,21 +11,30 @@ jobs:
     if: github.event.issue.pull_request != '' && (contains(github.event.comment.body, '/format') || contains(github.event.comment.body, '/golden_files'))
     runs-on: ubuntu-latest
     steps:
-      - run: gh api --method POST -f content='+1' ${{ github.event.comment.url }}/reactions
+      - name: check-maintainer
+        run:  |
+          # Ensure the commenter is a maintainer
+          USER=`gh api ${{ github.event.comment.url }} --jq .user.login`
+          if [[ `gh api  /repos/kumahq/kuma/collaborators --jq '.[] | select (.permissions.maintain == true) | .login' | grep $USER` ]]; then
+            gh api --method POST -f content='+1' ${{ github.event.comment.url }}/reactions
+          else
+            gh api --method POST -f content='-1' ${{ github.event.comment.url }}/reactions
+            exit 1
+          fi
         env:
-	  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - id: get-branch
         run: echo ::set-output name=branch::$(gh pr view $PR_NO --repo $REPO --json headRefName --jq '.headRefName')
         env:
           REPO: ${{ github.repository }}
           PR_NO: ${{ github.event.issue.number }}
-	  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
           ref: ${{ steps.get-branch.outputs.branch }}
         env:
-	  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - uses: actions/setup-go@v3
         with:
           go-version: 1.18
@@ -50,7 +59,7 @@ jobs:
           make test UPDATE_GOLDEN_FILES=true
       - name: commit and push fixes
         env:
-	  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           if git diff --exit-code --stat; then
             echo "No change detected, skipping git push"
@@ -62,4 +71,4 @@ jobs:
           fi
       - run: gh api --method POST -f content='hooray' ${{ github.event.comment.url }}/reactions
         env:
-	  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr-comments.yaml
+++ b/.github/workflows/pr-comments.yaml
@@ -5,7 +5,6 @@ on:
 env:
   GH_USER: "github-actions[bot]"
   GH_EMAIL: "<41898282+github-actions[bot]@users.noreply.github.com>"
-  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 jobs:
   pr_comments:
@@ -13,15 +12,20 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - run: gh api --method POST -f content='+1' ${{ github.event.comment.url }}/reactions
+        env:
+	  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - id: get-branch
         run: echo ::set-output name=branch::$(gh pr view $PR_NO --repo $REPO --json headRefName --jq '.headRefName')
         env:
           REPO: ${{ github.repository }}
           PR_NO: ${{ github.event.issue.number }}
+	  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
           ref: ${{ steps.get-branch.outputs.branch }}
+        env:
+	  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - uses: actions/setup-go@v3
         with:
           go-version: 1.18
@@ -45,6 +49,8 @@ jobs:
         run: |
           make test UPDATE_GOLDEN_FILES=true
       - name: commit and push fixes
+        env:
+	  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           if git diff --exit-code --stat; then
             echo "No change detected, skipping git push"
@@ -55,3 +61,5 @@ jobs:
             git push
           fi
       - run: gh api --method POST -f content='hooray' ${{ github.event.comment.url }}/reactions
+        env:
+	  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -91,9 +91,15 @@ to verify a few things:
 - Rebase your work on top of the base branch (seek help online on how to use
   `git rebase`; this is important to ensure your commit history is clean and
   linear)
-- The tests are passing: run `make test`, `make test/kuma-cp`,
+- The code formatting and the files are generated is good: `make check` will help.
+- The tests are passing: `make test`, `make test/kuma-cp`,
   `make test/kuma-dp`, or whichever make target under `test/` is appropriate
   for your change
+- If your PR are open and some tests are failing due to outdated golden files
+  or formatted and generated files are incorrect you can fix it by adding a
+  comment `/format` or `/golden_files`.
+- If you are introducing a change which requires specific attention when
+  upgrading update UPGRADE.md
 - Do not update CHANGELOG.md yourself. Your change will be included there in
   due time if it is accepted, no worries!
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -96,7 +96,7 @@ to verify a few things:
   `make test/kuma-dp`, or whichever make target under `test/` is appropriate
   for your change
 - If your PR are open and some tests are failing due to outdated golden files
-  or formatted and generated files are incorrect you can fix it by adding a
+  or formatted and generated files are incorrect a maintainer can fix it by adding a
   comment `/format` or `/golden_files`.
 - If you are introducing a change which requires specific attention when
   upgrading update UPGRADE.md

--- a/mk/check.mk
+++ b/mk/check.mk
@@ -30,18 +30,17 @@ golangci-lint: ## Dev: Runs golangci-lint linter
 helm-lint:
 	for c in ./deployments/charts/*; do \
   		if [ -d $$c ]; then \
-			helm lint $$c; \
+			helm lint --strict $$c; \
 		fi \
 	done
-
-.PHONY: helm-docs
-helm-docs: ## Dev: Runs helm-docs generator
-	$(HELM_DOCS_PATH) -s="file" --chart-search-root=./deployments/charts
 
 .PHONY: ginkgo/unfocus
 ginkgo/unfocus:
 	$(GOPATH_BIN_DIR)/ginkgo unfocus
 
+.PHONY: format
+format: fmt generate docs tidy ginkgo/unfocus
+
 .PHONY: check
-check: generate fmt docs helm-lint golangci-lint shellcheck tidy helm-docs ginkgo/unfocus ## Dev: Run code checks (go fmt, go vet, ...)
+check: format helm-lint golangci-lint shellcheck ## Dev: Run code checks (go fmt, go vet, ...)
 	git diff --quiet || test $$(git diff --name-only | grep -v -e 'go.mod$$' -e 'go.sum$$' | wc -l) -eq 0 || ( echo "The following changes (result of code generators and code checks) have been detected:" && git --no-pager diff && false ) # fail if Git working tree is dirty

--- a/mk/docs.mk
+++ b/mk/docs.mk
@@ -1,9 +1,12 @@
 .PHONY: docs
-docs: DESTDIR ?= docs/generated
-docs: ## Dev: Generate local documentation
+docs: helm-docs ## Dev: Generate local documentation
 	rm -rf $(DESTDIR)
 	@$(MAKE) docs/install/markdown DESTDIR=$(DESTDIR)/cmd
 	@$(MAKE) docs/install/resources DESTDIR=$(DESTDIR)/resources
+
+.PHONY: helm-docs
+helm-docs: ## Dev: Runs helm-docs generator
+	$(HELM_DOCS_PATH) -s="file" --chart-search-root=./deployments/charts
 
 .PHONY: docs/install/markdown
 docs/install/markdown: DESTDIR ?= docs/markdown

--- a/mk/docs.mk
+++ b/mk/docs.mk
@@ -1,4 +1,5 @@
 .PHONY: docs
+docs: DESTDIR ?= docs/generated
 docs: helm-docs ## Dev: Generate local documentation
 	rm -rf $(DESTDIR)
 	@$(MAKE) docs/install/markdown DESTDIR=$(DESTDIR)/cmd

--- a/tools/releases/version.sh
+++ b/tools/releases/version.sh
@@ -6,9 +6,9 @@
 #    At the same time, if $lastGitTag is not final tag (for example 1.4.0-rc1 or 1.4.0-preview1), the version is "dev-$shortHash"
 # 3) If the branch does not start with "release", then the version is "dev-$shortHash" (for example: dev-450174242)
 
-lastGitTag=$(git describe --abbrev=0 --tags)
-shortHash=$(git rev-parse --short HEAD)
-currentBranch=$(git rev-parse --abbrev-ref HEAD)
+lastGitTag=$(git describe --abbrev=0 --tags 2> /dev/null)
+shortHash=$(git rev-parse --short HEAD 2> /dev/null)
+currentBranch=$(git rev-parse --abbrev-ref HEAD 2> /dev/null)
 
 # Note: this format must be changed carefully, other scripts depend on it
 


### PR DESCRIPTION
### Summary

You can now comment on a pr with `/format` or `/golden_files` and it will run
the generation and formating or the tests with `UPDATE_GOLDEN_FILES=true` and
add a commit to the PR
This aims to make it easier for contributors to quickly fix their PRs when code gen
or equivalent changes things

Signed-off-by: Charly Molter <charly.molter@konghq.com>

### Testing

- ~~[ ] Unit tests~~
- ~~[ ] E2E tests~~
- ~~[ ] Manual testing on Universal~~
- ~~[ ] Manual testing on Kubernetes~~

### Backwards compatibility

- ~~[ ] Update [`UPGRADE.md`](/UPGRADE.md) with any steps users will need to take when upgrading.~~
- ~~[ ] Add `backport-to-stable` label if the code follows our [backporting policy](/CONTRIBUTING.md#backporting)~~
