### PR TITLE
fix(*): envoy build scripts

### DIFF
--- a/mk/envoy.mk
+++ b/mk/envoy.mk
@@ -9,7 +9,12 @@ ENVOY_VERSION = $(shell ${KUMA_DIR}/tools/envoy/version.sh ${ENVOY_TAG})
 ifeq ($(GOOS),linux)
 	ENVOY_DISTRO ?= alpine
 endif
-ENVOY_DISTRO ?= ${GOOS}
+ENVOY_DISTRO ?= $(GOOS)
+
+ifeq ($(ENVOY_DISTRO),centos)
+	BUILD_ENVOY_SCRIPT = $(KUMA_DIR)/tools/envoy/build_centos.sh
+endif
+BUILD_ENVOY_SCRIPT ?= $(KUMA_DIR)/tools/envoy/build_$(GOOS).sh
 
 SOURCE_DIR ?= ${TMPDIR}envoy-sources
 ifndef TMPDIR
@@ -43,7 +48,7 @@ ifeq ($(BUILD_ENVOY_FROM_SOURCES),true)
 	SOURCE_DIR=${SOURCE_DIR} \
 	KUMA_DIR=${KUMA_DIR} \
 	BAZEL_BUILD_EXTRA_OPTIONS=${BAZEL_BUILD_EXTRA_OPTIONS} \
-	BINARY_PATH=$@ ${KUMA_DIR}/tools/envoy/build_${ENVOY_DISTRO}.sh
+	BINARY_PATH=$@ $(BUILD_ENVOY_SCRIPT)
 else
 	ENVOY_VERSION=${ENVOY_VERSION} \
 	ENVOY_DISTRO=${ENVOY_DISTRO} \

--- a/tools/envoy/build_darwin.sh
+++ b/tools/envoy/build_darwin.sh
@@ -19,7 +19,7 @@ BAZEL_BUILD_OPTIONS=(
     --show_task_finish
     --verbose_failures
     --//contrib/vcl/source:enabled=false
-    "--action_env=PATH=/usr/local/bin:/opt/local/bin:/usr/bin:/bin"
+    "--action_env=PATH=/usr/local/bin:/opt/local/bin:/usr/bin:/bin:/opt/homebrew/bin"
     "--define" "wasm=disabled"
     "${BAZEL_BUILD_EXTRA_OPTIONS[@]+"${BAZEL_BUILD_EXTRA_OPTIONS[@]}"}")
 bazel build "${BAZEL_BUILD_OPTIONS[@]}" -c opt //contrib/exe:envoy-static


### PR DESCRIPTION
### Summary

Fix envoy build scripts

### Full changelog

* `ENVOY_DISTRO` env was used to call `build_${ENVOY_DISTRO}.sh` script, which is correct only if `ENVOY_DISTRO` is `centos`. In other cases it should be `build_${GOOS}.sh`
* Add `/opt/homebrew/bin` to bazel PATH when building envoy for darwin-arm64

### Issues resolved

N/A

### Documentation

~- [ ] Link to the website [documentation PR](https://github.com/kumahq/kuma-website/pull/XXX)~

### Testing

- [ ] Unit tests
- [ ] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes

### Backwards compatibility

~- [ ] Update [`UPGRADE.md`](/UPGRADE.md) with any steps users will need to take when upgrading.~
~- [ ] Add `backport-to-stable` label if the code follows our [backporting policy](/CONTRIBUTING.md#backporting)~
