### PR TITLE
fix(docs): add unzip to the list of CLI tools

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -12,7 +12,8 @@ for any tools/libraries that you may be missing.
 ### Command line tool
 
 - [`curl`](https://curl.haxx.se/)  
-- [`git`](https://git-scm.com/) 
+- [`git`](https://git-scm.com/)
+- [`unzip`](http://infozip.sourceforge.net/UnZip.html)
 - [`make`](https://www.gnu.org/software/make/)
 - [`go`](https://golang.org/)
 - [`clang-format`](https://clang.llvm.org/docs/ClangFormat.html) # normally included in


### PR DESCRIPTION
### Summary

add unzip to the `command line tool` section

### Full changelog

* add unzip to the `command line tool` section of `DEVELOPER.md` to prevent `make dev/tools` command failure if the system does not have `unzip` installed

Signed-off-by: Pouriya <pouriya.jamshidi@gmail.com>