### PR TITLE
fix: add missing auth plugin to relevant test cases

### DIFF
--- a/app/kumactl/cmd/apply/apply_test.go
+++ b/app/kumactl/cmd/apply/apply_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/kumahq/kuma/api/mesh/v1alpha1"
 	"github.com/kumahq/kuma/app/kumactl/cmd"
 	kumactl_cmd "github.com/kumahq/kuma/app/kumactl/pkg/cmd"
+	"github.com/kumahq/kuma/app/kumactl/pkg/plugins"
 	config_proto "github.com/kumahq/kuma/pkg/config/app/kumactl/v1alpha1"
 	"github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	"github.com/kumahq/kuma/pkg/core/resources/apis/system"
@@ -26,6 +27,7 @@ import (
 	"github.com/kumahq/kuma/pkg/core/resources/registry"
 	core_store "github.com/kumahq/kuma/pkg/core/resources/store"
 	"github.com/kumahq/kuma/pkg/core/rest/errors/types"
+	"github.com/kumahq/kuma/pkg/plugins/authn/api-server/tokens/cli"
 	memory_resources "github.com/kumahq/kuma/pkg/plugins/resources/memory"
 	"github.com/kumahq/kuma/pkg/test/resources/model"
 	test_store "github.com/kumahq/kuma/pkg/test/store"
@@ -41,6 +43,9 @@ var _ = Describe("kumactl apply", func() {
 	BeforeEach(func() {
 		rootCtx = &kumactl_cmd.RootContext{
 			Runtime: kumactl_cmd.RootRuntime{
+				AuthnPlugins: map[string]plugins.AuthnPlugin{
+					cli.AuthType: &cli.TokenAuthnPlugin{},
+				},
 				Registry: registry.Global(),
 				NewBaseAPIServerClient: func(server *config_proto.ControlPlaneCoordinates_ApiServer, _ time.Duration) (util_http.Client, error) {
 					return nil, nil

--- a/app/kumactl/cmd/generate/generate_dataplane_token_test.go
+++ b/app/kumactl/cmd/generate/generate_dataplane_token_test.go
@@ -13,9 +13,11 @@ import (
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	"github.com/kumahq/kuma/app/kumactl/cmd"
 	kumactl_cmd "github.com/kumahq/kuma/app/kumactl/pkg/cmd"
+	"github.com/kumahq/kuma/app/kumactl/pkg/plugins"
 	"github.com/kumahq/kuma/app/kumactl/pkg/tokens"
 	config_proto "github.com/kumahq/kuma/pkg/config/app/kumactl/v1alpha1"
 	"github.com/kumahq/kuma/pkg/core/resources/registry"
+	"github.com/kumahq/kuma/pkg/plugins/authn/api-server/tokens/cli"
 	util_http "github.com/kumahq/kuma/pkg/util/http"
 	"github.com/kumahq/kuma/pkg/util/test"
 )
@@ -43,6 +45,9 @@ var _ = Describe("kumactl generate dataplane-token", func() {
 		generator = &staticDataplaneTokenGenerator{}
 		ctx = &kumactl_cmd.RootContext{
 			Runtime: kumactl_cmd.RootRuntime{
+				AuthnPlugins: map[string]plugins.AuthnPlugin{
+					cli.AuthType: &cli.TokenAuthnPlugin{},
+				},
 				Registry: registry.NewTypeRegistry(),
 				NewBaseAPIServerClient: func(server *config_proto.ControlPlaneCoordinates_ApiServer, _ time.Duration) (util_http.Client, error) {
 					return nil, nil

--- a/app/kumactl/cmd/generate/generate_zone_token_test.go
+++ b/app/kumactl/cmd/generate/generate_zone_token_test.go
@@ -12,9 +12,11 @@ import (
 
 	"github.com/kumahq/kuma/app/kumactl/cmd"
 	kumactl_cmd "github.com/kumahq/kuma/app/kumactl/pkg/cmd"
+	"github.com/kumahq/kuma/app/kumactl/pkg/plugins"
 	"github.com/kumahq/kuma/app/kumactl/pkg/tokens"
 	config_proto "github.com/kumahq/kuma/pkg/config/app/kumactl/v1alpha1"
 	"github.com/kumahq/kuma/pkg/core/resources/registry"
+	"github.com/kumahq/kuma/pkg/plugins/authn/api-server/tokens/cli"
 	util_http "github.com/kumahq/kuma/pkg/util/http"
 	"github.com/kumahq/kuma/pkg/util/test"
 )
@@ -48,6 +50,9 @@ var _ = Describe("kumactl generate zone-token", func() {
 		generator = &staticZoneTokenGenerator{}
 		ctx = &kumactl_cmd.RootContext{
 			Runtime: kumactl_cmd.RootRuntime{
+				AuthnPlugins: map[string]plugins.AuthnPlugin{
+					cli.AuthType: &cli.TokenAuthnPlugin{},
+				},
 				Registry: registry.NewTypeRegistry(),
 				NewBaseAPIServerClient: func(server *config_proto.ControlPlaneCoordinates_ApiServer, _ time.Duration) (util_http.Client, error) {
 					return nil, nil

--- a/app/kumactl/cmd/generate/generate_zoneingress_token_test.go
+++ b/app/kumactl/cmd/generate/generate_zoneingress_token_test.go
@@ -12,9 +12,11 @@ import (
 
 	"github.com/kumahq/kuma/app/kumactl/cmd"
 	kumactl_cmd "github.com/kumahq/kuma/app/kumactl/pkg/cmd"
+	"github.com/kumahq/kuma/app/kumactl/pkg/plugins"
 	"github.com/kumahq/kuma/app/kumactl/pkg/tokens"
 	config_proto "github.com/kumahq/kuma/pkg/config/app/kumactl/v1alpha1"
 	"github.com/kumahq/kuma/pkg/core/resources/registry"
+	"github.com/kumahq/kuma/pkg/plugins/authn/api-server/tokens/cli"
 	util_http "github.com/kumahq/kuma/pkg/util/http"
 	"github.com/kumahq/kuma/pkg/util/test"
 )
@@ -43,6 +45,9 @@ var _ = Describe("kumactl generate zone-ingress-token", func() {
 		generator = &staticZoneIngressTokenGenerator{}
 		ctx = &kumactl_cmd.RootContext{
 			Runtime: kumactl_cmd.RootRuntime{
+				AuthnPlugins: map[string]plugins.AuthnPlugin{
+					cli.AuthType: &cli.TokenAuthnPlugin{},
+				},
 				Registry: registry.NewTypeRegistry(),
 				NewBaseAPIServerClient: func(server *config_proto.ControlPlaneCoordinates_ApiServer, _ time.Duration) (util_http.Client, error) {
 					return nil, nil

--- a/app/kumactl/cmd/get/get_single_resource_test.go
+++ b/app/kumactl/cmd/get/get_single_resource_test.go
@@ -13,11 +13,13 @@ import (
 
 	"github.com/kumahq/kuma/app/kumactl/cmd"
 	kumactl_cmd "github.com/kumahq/kuma/app/kumactl/pkg/cmd"
+	"github.com/kumahq/kuma/app/kumactl/pkg/plugins"
 	"github.com/kumahq/kuma/app/kumactl/pkg/resources"
 	"github.com/kumahq/kuma/pkg/api-server/types"
 	config_proto "github.com/kumahq/kuma/pkg/config/app/kumactl/v1alpha1"
 	"github.com/kumahq/kuma/pkg/core/resources/registry"
 	core_store "github.com/kumahq/kuma/pkg/core/resources/store"
+	"github.com/kumahq/kuma/pkg/plugins/authn/api-server/tokens/cli"
 	memory_resources "github.com/kumahq/kuma/pkg/plugins/resources/memory"
 	. "github.com/kumahq/kuma/pkg/test/matchers"
 	util_http "github.com/kumahq/kuma/pkg/util/http"
@@ -44,6 +46,9 @@ var _ = Describe("kumactl get [resource] NAME", func() {
 	BeforeEach(func() {
 		rootCtx := &kumactl_cmd.RootContext{
 			Runtime: kumactl_cmd.RootRuntime{
+				AuthnPlugins: map[string]plugins.AuthnPlugin{
+					cli.AuthType: &cli.TokenAuthnPlugin{},
+				},
 				Registry: registry.Global(),
 				Now:      func() time.Time { return rootTime },
 				NewBaseAPIServerClient: func(server *config_proto.ControlPlaneCoordinates_ApiServer, _ time.Duration) (util_http.Client, error) {

--- a/app/kumactl/cmd/root_test.go
+++ b/app/kumactl/cmd/root_test.go
@@ -10,8 +10,10 @@ import (
 	"github.com/kumahq/kuma/app/kumactl/cmd"
 	kumactl_cmd "github.com/kumahq/kuma/app/kumactl/pkg/cmd"
 	"github.com/kumahq/kuma/app/kumactl/pkg/config"
+	"github.com/kumahq/kuma/app/kumactl/pkg/plugins"
 	config_proto "github.com/kumahq/kuma/pkg/config/app/kumactl/v1alpha1"
 	"github.com/kumahq/kuma/pkg/core/resources/registry"
+	"github.com/kumahq/kuma/pkg/plugins/authn/api-server/tokens/cli"
 	util_http "github.com/kumahq/kuma/pkg/util/http"
 	"github.com/kumahq/kuma/pkg/util/test"
 )
@@ -37,6 +39,9 @@ var _ = Describe("kumactl root cmd", func() {
 		// given
 		rootCtx := &kumactl_cmd.RootContext{
 			Runtime: kumactl_cmd.RootRuntime{
+				AuthnPlugins: map[string]plugins.AuthnPlugin{
+					cli.AuthType: &cli.TokenAuthnPlugin{},
+				},
 				NewBaseAPIServerClient: func(server *config_proto.ControlPlaneCoordinates_ApiServer, _ time.Duration) (util_http.Client, error) {
 					return nil, nil
 				},
@@ -74,6 +79,9 @@ currentContext: local
 		// given
 		rootCtx := &kumactl_cmd.RootContext{
 			Runtime: kumactl_cmd.RootRuntime{
+				AuthnPlugins: map[string]plugins.AuthnPlugin{
+					cli.AuthType: &cli.TokenAuthnPlugin{},
+				},
 				NewBaseAPIServerClient: func(server *config_proto.ControlPlaneCoordinates_ApiServer, _ time.Duration) (util_http.Client, error) {
 					return nil, nil
 				},


### PR DESCRIPTION
Signed-off-by: slonka <slonka@users.noreply.github.com>

### Summary

Some tests were failing on my local machine due to auth plugin not being configured.
This caused the buffer to contain a warning that kumactl version could not be verified and caused [this assertion](https://github.com/kumahq/kuma/blob/84fa94694732d5a980719e5b7b773b922f1de695/app/kumactl/cmd/apply/apply_test.go#L417) to fail. I added the missing plugin in failing tests. It's a bit of a shotgun approach, it would be best to create a default `RootContext` and then add a builder to customise each field, I'll gladly do it if you think it's worth it. On a more general note: I'm a bit concerned that this went unnoticed for a long time (the check was added in [8 months ago](https://github.com/kumahq/kuma/blame/869e8d697914b7981921cfaa6794abe613535522/app/kumactl/pkg/cmd/root_context.go#L324)) - so either something that was supposed to inject that plugin does not work on my machine or we have some test caching issue on CI. 

Example failure below:
```
[38;5;243m/kuma/app/kumactl/cmd/apply/apply_test.go:36[0m
  [38;5;9m[1m[It] should apply a new Dataplane resource from URL[0m
  [38;5;243m/kuma/app/kumactl/cmd/apply/apply_test.go:217[0m

  [38;5;243mBegin Captured GinkgoWriter Output >>[0m
    1.6520916436663349e+09	ERROR	kumactl	Unable to get index client	{"error": "authentication plugin of type \"tokens\" not found", "errorVerbose": "authentication plugin of type \"tokens\" not found\ngithub.com/kumahq/kuma/app/kumactl/pkg/cmd.(*RootContext).BaseAPIServerClient\n\t/kuma/app/kumactl/pkg/cmd/root_context.go:179\ngithub.com/kumahq/kuma/app/kumactl/pkg/cmd.(*RootContext).CurrentApiClient\n\t/kuma/app/kumactl/pkg/cmd/root_context.go:302\ngithub.com/kumahq/kuma/app/kumactl/pkg/cmd.(*RootContext).CheckServerVersionCompatibility\n\t/kuma/app/kumactl/pkg/cmd/root_context.go:314\ngithub.com/kumahq/kuma/app/kumactl/cmd/apply.NewApplyCmd.func1\n\t/kuma/app/kumactl/cmd/apply/apply.go:66\ngithub.com/kumahq/kuma/app/kumactl/pkg/errors.FormatErrorWrapper.func1\n\t/kuma/app/kumactl/pkg/errors/formatter.go:14\ngithub.com/spf13/cobra.(*Command).execute\n\tgo/pkg/mod/github.com/spf13/cobra@v1.4.0/command.go:856\ngithub.com/spf13/cobra.(*Command).ExecuteC\n\tgo/pkg/mod/github.com/spf13/cobra@v1.4.0/command.go:974\ngithub.com/spf13/cobra.(*Command).Execute\n\tgo/pkg/mod/github.com/spf13/cobra@v1.4.0/command.go:902\ngithub.com/kumahq/kuma/app/kumactl/cmd/apply_test.glob..func1.9\n\t/kuma/app/kumactl/cmd/apply/apply_test.go:249\ngithub.com/onsi/ginkgo/v2/internal.(*Suite).runNode.func2\n\tgo/pkg/mod/github.com/onsi/ginkgo/v2@v2.1.4/internal/suite.go:596\nruntime.goexit\n\t/usr/local/go/src/runtime/asm_arm64.s:1259"}
    github.com/kumahq/kuma/app/kumactl/cmd/apply.NewApplyCmd.func1
    	/kuma/app/kumactl/cmd/apply/apply.go:66
    github.com/kumahq/kuma/app/kumactl/pkg/errors.FormatErrorWrapper.func1
    	/kuma/app/kumactl/pkg/errors/formatter.go:14
    github.com/spf13/cobra.(*Command).execute
    	go/pkg/mod/github.com/spf13/cobra@v1.4.0/command.go:856
    github.com/spf13/cobra.(*Command).ExecuteC
    	go/pkg/mod/github.com/spf13/cobra@v1.4.0/command.go:974
    github.com/spf13/cobra.(*Command).Execute
    	go/pkg/mod/github.com/spf13/cobra@v1.4.0/command.go:902
    github.com/kumahq/kuma/app/kumactl/cmd/apply_test.glob..func1.9
    	/kuma/app/kumactl/cmd/apply/apply_test.go:249
    github.com/onsi/ginkgo/v2/internal.(*Suite).runNode.func2
    	go/pkg/mod/github.com/onsi/ginkgo/v2@v2.1.4/internal/suite.go:596
  [38;5;243m<< End Captured GinkgoWriter Output[0m

  [38;5;9mUnexpected error:
      <*errors.fundamental | 0xc000f047c8>: {
          msg: "authentication plugin of type \"tokens\" not found",
          stack: [0x10159c538, 0x10159c680, 0x1015a62ec, 0x1024aa12c, 0x1008ac4e0, 0x1008acdb8, 0x10265ee50, 0x10265ee3d, 0x101603d14, 0x1003ff6b4],
      }
      authentication plugin of type "tokens" not found
  occurred[0m
  [38;5;9mIn [1m[It][0m[38;5;9m at: [1m/kuma/app/kumactl/cmd/apply/apply_test.go:252[0m
[38;5;243m------------------------------[0m
[38;5;10m•[0m[38;5;10m•[0m[38;5;10m•[0m[38;5;10m•[0m
[38;5;243m------------------------------[0m
[38;5;9m• [FAILED] [0.013 seconds][0m
```

### Full changelog

* Fix failing tests by adding missing auth token to relevant test cases

### Issues resolved

Fix #XXX

### Documentation

- [ ] Link to the website [documentation PR](https://github.com/kumahq/kuma-website/pull/XXX)

### Testing

- [x] Unit tests
- [ ] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes

### Backwards compatibility

- [ ] Update [`UPGRADE.md`](/UPGRADE.md) with any steps users will need to take when upgrading.
- [ ] Add `backport-to-stable` label if the code follows our [backporting policy](/CONTRIBUTING.md#backporting)
