### PR TITLE
fix: add in-memory config to tests

### DIFF
--- a/app/kumactl/cmd/apply/apply_test.go
+++ b/app/kumactl/cmd/apply/apply_test.go
@@ -40,6 +40,9 @@ var _ = Describe("kumactl apply", func() {
 	var store core_store.ResourceStore
 	BeforeEach(func() {
 		rootCtx = &kumactl_cmd.RootContext{
+			Args: kumactl_cmd.RootArgs{
+				ConfigType: kumactl_cmd.InMemory,
+			},
 			Runtime: kumactl_cmd.RootRuntime{
 				Registry: registry.Global(),
 				NewBaseAPIServerClient: func(server *config_proto.ControlPlaneCoordinates_ApiServer, _ time.Duration) (util_http.Client, error) {

--- a/app/kumactl/cmd/apply/apply_test.go
+++ b/app/kumactl/cmd/apply/apply_test.go
@@ -10,7 +10,6 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
-	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -19,7 +18,6 @@ import (
 	"github.com/kumahq/kuma/api/mesh/v1alpha1"
 	"github.com/kumahq/kuma/app/kumactl/cmd"
 	kumactl_cmd "github.com/kumahq/kuma/app/kumactl/pkg/cmd"
-	config_proto "github.com/kumahq/kuma/pkg/config/app/kumactl/v1alpha1"
 	"github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	"github.com/kumahq/kuma/pkg/core/resources/apis/system"
 	core_model "github.com/kumahq/kuma/pkg/core/resources/model"
@@ -27,10 +25,10 @@ import (
 	core_store "github.com/kumahq/kuma/pkg/core/resources/store"
 	"github.com/kumahq/kuma/pkg/core/rest/errors/types"
 	memory_resources "github.com/kumahq/kuma/pkg/plugins/resources/memory"
+	test_kumactl "github.com/kumahq/kuma/pkg/test/kumactl"
 	"github.com/kumahq/kuma/pkg/test/resources/model"
 	test_store "github.com/kumahq/kuma/pkg/test/store"
 	util_http "github.com/kumahq/kuma/pkg/util/http"
-	"github.com/kumahq/kuma/pkg/util/test"
 )
 
 var _ = Describe("kumactl apply", func() {
@@ -39,20 +37,10 @@ var _ = Describe("kumactl apply", func() {
 	var rootCmd *cobra.Command
 	var store core_store.ResourceStore
 	BeforeEach(func() {
-		rootCtx = &kumactl_cmd.RootContext{
-			Args: kumactl_cmd.RootArgs{
-				ConfigType: kumactl_cmd.InMemory,
-			},
-			Runtime: kumactl_cmd.RootRuntime{
-				Registry: registry.Global(),
-				NewBaseAPIServerClient: func(server *config_proto.ControlPlaneCoordinates_ApiServer, _ time.Duration) (util_http.Client, error) {
-					return nil, nil
-				},
-				NewResourceStore: func(util_http.Client) core_store.ResourceStore {
-					return store
-				},
-				NewAPIServerClient: test.GetMockNewAPIServerClient(),
-			},
+		rootCtx = test_kumactl.MakeMinimalRootContext()
+		rootCtx.Runtime.Registry = registry.Global()
+		rootCtx.Runtime.NewResourceStore = func(util_http.Client) core_store.ResourceStore {
+			return store
 		}
 		store = core_store.NewPaginationStore(memory_resources.NewStore())
 		rootCmd = cmd.NewRootCmd(rootCtx)

--- a/app/kumactl/cmd/generate/generate_dataplane_token_test.go
+++ b/app/kumactl/cmd/generate/generate_dataplane_token_test.go
@@ -14,10 +14,8 @@ import (
 	"github.com/kumahq/kuma/app/kumactl/cmd"
 	kumactl_cmd "github.com/kumahq/kuma/app/kumactl/pkg/cmd"
 	"github.com/kumahq/kuma/app/kumactl/pkg/tokens"
-	config_proto "github.com/kumahq/kuma/pkg/config/app/kumactl/v1alpha1"
-	"github.com/kumahq/kuma/pkg/core/resources/registry"
+	test_kumactl "github.com/kumahq/kuma/pkg/test/kumactl"
 	util_http "github.com/kumahq/kuma/pkg/util/http"
-	"github.com/kumahq/kuma/pkg/util/test"
 )
 
 type staticDataplaneTokenGenerator struct {
@@ -41,20 +39,9 @@ var _ = Describe("kumactl generate dataplane-token", func() {
 
 	BeforeEach(func() {
 		generator = &staticDataplaneTokenGenerator{}
-		ctx = &kumactl_cmd.RootContext{
-			Args: kumactl_cmd.RootArgs{
-				ConfigType: kumactl_cmd.InMemory,
-			},
-			Runtime: kumactl_cmd.RootRuntime{
-				Registry: registry.NewTypeRegistry(),
-				NewBaseAPIServerClient: func(server *config_proto.ControlPlaneCoordinates_ApiServer, _ time.Duration) (util_http.Client, error) {
-					return nil, nil
-				},
-				NewDataplaneTokenClient: func(util_http.Client) tokens.DataplaneTokenClient {
-					return generator
-				},
-				NewAPIServerClient: test.GetMockNewAPIServerClient(),
-			},
+		ctx = test_kumactl.MakeMinimalRootContext()
+		ctx.Runtime.NewDataplaneTokenClient = func(util_http.Client) tokens.DataplaneTokenClient {
+			return generator
 		}
 
 		rootCmd = cmd.NewRootCmd(ctx)

--- a/app/kumactl/cmd/generate/generate_dataplane_token_test.go
+++ b/app/kumactl/cmd/generate/generate_dataplane_token_test.go
@@ -42,6 +42,9 @@ var _ = Describe("kumactl generate dataplane-token", func() {
 	BeforeEach(func() {
 		generator = &staticDataplaneTokenGenerator{}
 		ctx = &kumactl_cmd.RootContext{
+			Args: kumactl_cmd.RootArgs{
+				ConfigType: kumactl_cmd.InMemory,
+			},
 			Runtime: kumactl_cmd.RootRuntime{
 				Registry: registry.NewTypeRegistry(),
 				NewBaseAPIServerClient: func(server *config_proto.ControlPlaneCoordinates_ApiServer, _ time.Duration) (util_http.Client, error) {

--- a/app/kumactl/cmd/generate/generate_zone_token_test.go
+++ b/app/kumactl/cmd/generate/generate_zone_token_test.go
@@ -47,6 +47,9 @@ var _ = Describe("kumactl generate zone-token", func() {
 	BeforeEach(func() {
 		generator = &staticZoneTokenGenerator{}
 		ctx = &kumactl_cmd.RootContext{
+			Args: kumactl_cmd.RootArgs{
+				ConfigType: kumactl_cmd.InMemory,
+			},
 			Runtime: kumactl_cmd.RootRuntime{
 				Registry: registry.NewTypeRegistry(),
 				NewBaseAPIServerClient: func(server *config_proto.ControlPlaneCoordinates_ApiServer, _ time.Duration) (util_http.Client, error) {

--- a/app/kumactl/cmd/generate/generate_zone_token_test.go
+++ b/app/kumactl/cmd/generate/generate_zone_token_test.go
@@ -13,10 +13,8 @@ import (
 	"github.com/kumahq/kuma/app/kumactl/cmd"
 	kumactl_cmd "github.com/kumahq/kuma/app/kumactl/pkg/cmd"
 	"github.com/kumahq/kuma/app/kumactl/pkg/tokens"
-	config_proto "github.com/kumahq/kuma/pkg/config/app/kumactl/v1alpha1"
-	"github.com/kumahq/kuma/pkg/core/resources/registry"
+	test_kumactl "github.com/kumahq/kuma/pkg/test/kumactl"
 	util_http "github.com/kumahq/kuma/pkg/util/http"
-	"github.com/kumahq/kuma/pkg/util/test"
 )
 
 type staticZoneTokenGenerator struct {
@@ -46,20 +44,9 @@ var _ = Describe("kumactl generate zone-token", func() {
 
 	BeforeEach(func() {
 		generator = &staticZoneTokenGenerator{}
-		ctx = &kumactl_cmd.RootContext{
-			Args: kumactl_cmd.RootArgs{
-				ConfigType: kumactl_cmd.InMemory,
-			},
-			Runtime: kumactl_cmd.RootRuntime{
-				Registry: registry.NewTypeRegistry(),
-				NewBaseAPIServerClient: func(server *config_proto.ControlPlaneCoordinates_ApiServer, _ time.Duration) (util_http.Client, error) {
-					return nil, nil
-				},
-				NewZoneTokenClient: func(util_http.Client) tokens.ZoneTokenClient {
-					return generator
-				},
-				NewAPIServerClient: test.GetMockNewAPIServerClient(),
-			},
+		ctx = test_kumactl.MakeMinimalRootContext()
+		ctx.Runtime.NewZoneTokenClient = func(util_http.Client) tokens.ZoneTokenClient {
+			return generator
 		}
 
 		rootCmd = cmd.NewRootCmd(ctx)

--- a/app/kumactl/cmd/generate/generate_zoneingress_token_test.go
+++ b/app/kumactl/cmd/generate/generate_zoneingress_token_test.go
@@ -42,6 +42,9 @@ var _ = Describe("kumactl generate zone-ingress-token", func() {
 	BeforeEach(func() {
 		generator = &staticZoneIngressTokenGenerator{}
 		ctx = &kumactl_cmd.RootContext{
+			Args: kumactl_cmd.RootArgs{
+				ConfigType: kumactl_cmd.InMemory,
+			},
 			Runtime: kumactl_cmd.RootRuntime{
 				Registry: registry.NewTypeRegistry(),
 				NewBaseAPIServerClient: func(server *config_proto.ControlPlaneCoordinates_ApiServer, _ time.Duration) (util_http.Client, error) {

--- a/app/kumactl/cmd/generate/generate_zoneingress_token_test.go
+++ b/app/kumactl/cmd/generate/generate_zoneingress_token_test.go
@@ -13,10 +13,8 @@ import (
 	"github.com/kumahq/kuma/app/kumactl/cmd"
 	kumactl_cmd "github.com/kumahq/kuma/app/kumactl/pkg/cmd"
 	"github.com/kumahq/kuma/app/kumactl/pkg/tokens"
-	config_proto "github.com/kumahq/kuma/pkg/config/app/kumactl/v1alpha1"
-	"github.com/kumahq/kuma/pkg/core/resources/registry"
+	"github.com/kumahq/kuma/pkg/test/kumactl"
 	util_http "github.com/kumahq/kuma/pkg/util/http"
-	"github.com/kumahq/kuma/pkg/util/test"
 )
 
 type staticZoneIngressTokenGenerator struct {
@@ -41,20 +39,9 @@ var _ = Describe("kumactl generate zone-ingress-token", func() {
 
 	BeforeEach(func() {
 		generator = &staticZoneIngressTokenGenerator{}
-		ctx = &kumactl_cmd.RootContext{
-			Args: kumactl_cmd.RootArgs{
-				ConfigType: kumactl_cmd.InMemory,
-			},
-			Runtime: kumactl_cmd.RootRuntime{
-				Registry: registry.NewTypeRegistry(),
-				NewBaseAPIServerClient: func(server *config_proto.ControlPlaneCoordinates_ApiServer, _ time.Duration) (util_http.Client, error) {
-					return nil, nil
-				},
-				NewZoneIngressTokenClient: func(util_http.Client) tokens.ZoneIngressTokenClient {
-					return generator
-				},
-				NewAPIServerClient: test.GetMockNewAPIServerClient(),
-			},
+		ctx = kumactl.MakeMinimalRootContext()
+		ctx.Runtime.NewZoneIngressTokenClient = func(util_http.Client) tokens.ZoneIngressTokenClient {
+			return generator
 		}
 
 		rootCmd = cmd.NewRootCmd(ctx)

--- a/app/kumactl/cmd/get/get_single_resource_test.go
+++ b/app/kumactl/cmd/get/get_single_resource_test.go
@@ -12,15 +12,13 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/kumahq/kuma/app/kumactl/cmd"
-	kumactl_cmd "github.com/kumahq/kuma/app/kumactl/pkg/cmd"
 	"github.com/kumahq/kuma/app/kumactl/pkg/resources"
 	"github.com/kumahq/kuma/pkg/api-server/types"
-	config_proto "github.com/kumahq/kuma/pkg/config/app/kumactl/v1alpha1"
 	"github.com/kumahq/kuma/pkg/core/resources/registry"
 	core_store "github.com/kumahq/kuma/pkg/core/resources/store"
 	memory_resources "github.com/kumahq/kuma/pkg/plugins/resources/memory"
+	test_kumactl "github.com/kumahq/kuma/pkg/test/kumactl"
 	. "github.com/kumahq/kuma/pkg/test/matchers"
-	util_http "github.com/kumahq/kuma/pkg/util/http"
 	kuma_version "github.com/kumahq/kuma/pkg/version"
 )
 
@@ -38,29 +36,11 @@ var _ = Describe("kumactl get [resource] NAME", func() {
 	var rootCmd *cobra.Command
 	var outbuf *bytes.Buffer
 	var store core_store.ResourceStore
-	var testClient *testApiServerClient
 	rootTime, _ := time.Parse(time.RFC3339, "2008-04-01T16:05:36.995Z")
 	var _ resources.ApiServerClient = &testApiServerClient{}
 	BeforeEach(func() {
-		rootCtx := &kumactl_cmd.RootContext{
-			Args: kumactl_cmd.RootArgs{
-				ConfigType: kumactl_cmd.InMemory,
-			},
-			Runtime: kumactl_cmd.RootRuntime{
-				Registry: registry.Global(),
-				Now:      func() time.Time { return rootTime },
-				NewBaseAPIServerClient: func(server *config_proto.ControlPlaneCoordinates_ApiServer, _ time.Duration) (util_http.Client, error) {
-					return nil, nil
-				},
-				NewResourceStore: func(util_http.Client) core_store.ResourceStore {
-					return store
-				},
-				NewAPIServerClient: func(util_http.Client) resources.ApiServerClient {
-					return testClient
-				},
-			},
-		}
-
+		rootCtx, _ := test_kumactl.MakeRootContext(rootTime, store)
+		rootCtx.Runtime.Registry = registry.Global()
 		store = core_store.NewPaginationStore(memory_resources.NewStore())
 		rootCmd = cmd.NewRootCmd(rootCtx)
 

--- a/app/kumactl/cmd/get/get_single_resource_test.go
+++ b/app/kumactl/cmd/get/get_single_resource_test.go
@@ -43,6 +43,9 @@ var _ = Describe("kumactl get [resource] NAME", func() {
 	var _ resources.ApiServerClient = &testApiServerClient{}
 	BeforeEach(func() {
 		rootCtx := &kumactl_cmd.RootContext{
+			Args: kumactl_cmd.RootArgs{
+				ConfigType: kumactl_cmd.InMemory,
+			},
 			Runtime: kumactl_cmd.RootRuntime{
 				Registry: registry.Global(),
 				Now:      func() time.Time { return rootTime },

--- a/app/kumactl/cmd/root.go
+++ b/app/kumactl/cmd/root.go
@@ -62,8 +62,12 @@ func NewRootCmd(root *kumactl_cmd.RootContext) *cobra.Command {
 				}
 			}
 
-			if err := root.LoadConfig(); err != nil {
-				return err
+			if root.Args.ConfigType == kumactl_cmd.InMemory {
+				root.LoadInMemoryConfig()
+			} else {
+				if err := root.LoadConfig(); err != nil {
+					return err
+				}
 			}
 
 			return nil

--- a/app/kumactl/cmd/root.go
+++ b/app/kumactl/cmd/root.go
@@ -64,13 +64,9 @@ func NewRootCmd(root *kumactl_cmd.RootContext) *cobra.Command {
 
 			if root.Args.ConfigType == kumactl_cmd.InMemory {
 				root.LoadInMemoryConfig()
-			} else {
-				if err := root.LoadConfig(); err != nil {
-					return err
-				}
 			}
 
-			return nil
+			return root.LoadConfig()
 		},
 	}
 

--- a/app/kumactl/cmd/root_test.go
+++ b/app/kumactl/cmd/root_test.go
@@ -36,6 +36,9 @@ var _ = Describe("kumactl root cmd", func() {
 	It("should create default config at startup", func() {
 		// given
 		rootCtx := &kumactl_cmd.RootContext{
+			Args: kumactl_cmd.RootArgs{
+				ConfigType: kumactl_cmd.InMemory,
+			},
 			Runtime: kumactl_cmd.RootRuntime{
 				NewBaseAPIServerClient: func(server *config_proto.ControlPlaneCoordinates_ApiServer, _ time.Duration) (util_http.Client, error) {
 					return nil, nil
@@ -73,6 +76,9 @@ currentContext: local
 	It("shouldn't create config file when --no-config flag is set", func() {
 		// given
 		rootCtx := &kumactl_cmd.RootContext{
+			Args: kumactl_cmd.RootArgs{
+				ConfigType: kumactl_cmd.InMemory,
+			},
 			Runtime: kumactl_cmd.RootRuntime{
 				NewBaseAPIServerClient: func(server *config_proto.ControlPlaneCoordinates_ApiServer, _ time.Duration) (util_http.Client, error) {
 					return nil, nil

--- a/app/kumactl/cmd/root_test.go
+++ b/app/kumactl/cmd/root_test.go
@@ -2,18 +2,13 @@ package cmd_test
 
 import (
 	"os"
-	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
 	"github.com/kumahq/kuma/app/kumactl/cmd"
-	kumactl_cmd "github.com/kumahq/kuma/app/kumactl/pkg/cmd"
 	"github.com/kumahq/kuma/app/kumactl/pkg/config"
-	config_proto "github.com/kumahq/kuma/pkg/config/app/kumactl/v1alpha1"
-	"github.com/kumahq/kuma/pkg/core/resources/registry"
-	util_http "github.com/kumahq/kuma/pkg/util/http"
-	"github.com/kumahq/kuma/pkg/util/test"
+	test_kumactl "github.com/kumahq/kuma/pkg/test/kumactl"
 )
 
 var _ = Describe("kumactl root cmd", func() {
@@ -35,18 +30,7 @@ var _ = Describe("kumactl root cmd", func() {
 
 	It("should create default config at startup", func() {
 		// given
-		rootCtx := &kumactl_cmd.RootContext{
-			Args: kumactl_cmd.RootArgs{
-				ConfigType: kumactl_cmd.InMemory,
-			},
-			Runtime: kumactl_cmd.RootRuntime{
-				NewBaseAPIServerClient: func(server *config_proto.ControlPlaneCoordinates_ApiServer, _ time.Duration) (util_http.Client, error) {
-					return nil, nil
-				},
-				Registry:           registry.NewTypeRegistry(),
-				NewAPIServerClient: test.GetMockNewAPIServerClient(),
-			},
-		}
+		rootCtx := test_kumactl.MakeMinimalRootContext()
 		rootCmd := cmd.NewRootCmd(rootCtx)
 
 		// when
@@ -75,18 +59,7 @@ currentContext: local
 
 	It("shouldn't create config file when --no-config flag is set", func() {
 		// given
-		rootCtx := &kumactl_cmd.RootContext{
-			Args: kumactl_cmd.RootArgs{
-				ConfigType: kumactl_cmd.InMemory,
-			},
-			Runtime: kumactl_cmd.RootRuntime{
-				NewBaseAPIServerClient: func(server *config_proto.ControlPlaneCoordinates_ApiServer, _ time.Duration) (util_http.Client, error) {
-					return nil, nil
-				},
-				Registry:           registry.NewTypeRegistry(),
-				NewAPIServerClient: test.GetMockNewAPIServerClient(),
-			},
-		}
+		rootCtx := test_kumactl.MakeMinimalRootContext()
 		rootCmd := cmd.NewRootCmd(rootCtx)
 
 		// when

--- a/app/kumactl/pkg/cmd/root_context.go
+++ b/app/kumactl/pkg/cmd/root_context.go
@@ -27,8 +27,16 @@ import (
 	kuma_version "github.com/kumahq/kuma/pkg/version"
 )
 
+type ConfigType int
+
+const (
+	FileConfig ConfigType = iota
+	InMemory
+)
+
 type RootArgs struct {
 	ConfigFile string
+	ConfigType ConfigType
 	Mesh       string
 	ApiTimeout time.Duration
 }
@@ -127,6 +135,10 @@ func (rc *RootContext) SaveConfig() error {
 
 func (rc *RootContext) Config() *config_proto.Configuration {
 	return &rc.Runtime.Config
+}
+
+func (rc *RootContext) LoadInMemoryConfig() {
+	rc.Runtime.Config = config.DefaultConfiguration()
 }
 
 func (rc *RootContext) CurrentContext() (*config_proto.Context, error) {

--- a/app/kumactl/pkg/cmd/root_context.go
+++ b/app/kumactl/pkg/cmd/root_context.go
@@ -64,6 +64,7 @@ type RootRuntime struct {
 }
 
 // RootContext contains variables, functions and components that can be overridden when extending kumactl or running the test.
+// To create one for tests use helper functions in pkg/test/kumactl/context.go
 // Example:
 //
 // rootCtx := kumactl_cmd.DefaultRootContext()

--- a/pkg/test/kumactl/context.go
+++ b/pkg/test/kumactl/context.go
@@ -12,6 +12,27 @@ import (
 	util_test "github.com/kumahq/kuma/pkg/util/test"
 )
 
+var defaultArgs = kumactl_cmd.RootArgs{
+	ConfigType: kumactl_cmd.InMemory,
+}
+
+var defaultNewAPIServerClient = util_test.GetMockNewAPIServerClient()
+
+var defaultNewBaseAPIServerClient = func(server *config_proto.ControlPlaneCoordinates_ApiServer, _ time.Duration) (util_http.Client, error) {
+	return nil, nil
+}
+
+func MakeMinimalRootContext() *kumactl_cmd.RootContext {
+	return &kumactl_cmd.RootContext{
+		Args: defaultArgs,
+		Runtime: kumactl_cmd.RootRuntime{
+			Registry:               registry.NewTypeRegistry(),
+			NewAPIServerClient:     defaultNewAPIServerClient,
+			NewBaseAPIServerClient: defaultNewBaseAPIServerClient,
+		},
+	}
+}
+
 func MakeRootContext(now time.Time, resourceStore store.ResourceStore, res ...model.ResourceTypeDescriptor) (*kumactl_cmd.RootContext, error) {
 	reg := registry.NewTypeRegistry()
 	for _, r := range res {
@@ -20,18 +41,17 @@ func MakeRootContext(now time.Time, resourceStore store.ResourceStore, res ...mo
 		}
 	}
 	return &kumactl_cmd.RootContext{
+		Args: defaultArgs,
 		// should I add the in-memory here as well? or should I make other tests use this function?
 		// why aren't other tests using this?
 		Runtime: kumactl_cmd.RootRuntime{
-			Registry: reg,
-			Now:      func() time.Time { return now },
-			NewBaseAPIServerClient: func(server *config_proto.ControlPlaneCoordinates_ApiServer, _ time.Duration) (util_http.Client, error) {
-				return nil, nil
-			},
+			Registry:               reg,
+			Now:                    func() time.Time { return now },
+			NewBaseAPIServerClient: defaultNewBaseAPIServerClient,
 			NewResourceStore: func(util_http.Client) store.ResourceStore {
 				return resourceStore
 			},
-			NewAPIServerClient: util_test.GetMockNewAPIServerClient(),
+			NewAPIServerClient: defaultNewAPIServerClient,
 		},
 	}, nil
 }

--- a/pkg/test/kumactl/context.go
+++ b/pkg/test/kumactl/context.go
@@ -20,6 +20,8 @@ func MakeRootContext(now time.Time, resourceStore store.ResourceStore, res ...mo
 		}
 	}
 	return &kumactl_cmd.RootContext{
+		// should I add the in-memory here as well? or should I make other tests use this function?
+		// why aren't other tests using this?
 		Runtime: kumactl_cmd.RootRuntime{
 			Registry: reg,
 			Now:      func() time.Time { return now },


### PR DESCRIPTION
Signed-off-by: slonka <slonka@users.noreply.github.com>

### Summary

This is an improved version of #4257 - instead of adding the auth plugin we make the tests independent of the contents of `~/.kuma/config` which is a better approach.

### Full changelog

* Fix tests failing on user machine by adding in-memory config to test so that they are independent of what resides on disk

### Issues resolved

Fix #XXX

### Documentation

- [ ] Link to the website [documentation PR](https://github.com/kumahq/kuma-website/pull/XXX)

### Testing

- [X] Unit tests
- [ ] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes

### Backwards compatibility

- [ ] Update [`UPGRADE.md`](/UPGRADE.md) with any steps users will need to take when upgrading.
- [ ] Add `backport-to-stable` label if the code follows our [backporting policy](/CONTRIBUTING.md#backporting)
