### PR TITLE
fix(*): added docker remote setup for release pipeline

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -420,14 +420,13 @@ jobs:
         - artifacts-linux-<<parameters.go_arch>>
 
   release:
-    executor: golang
+    executor: vm
     steps:
+    - install_build_tools
     - checkout
     - run:
         name: "Download Go modules"
         command: go mod download
-    - setup_remote_docker:
-        version: *docker_version
     - run:
         name: Build Packages
         command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,6 +4,7 @@ reusable:
 
   constants:
     - &go_version "1.18"
+    - &docker_version "20.10.7"
 
   docker_images:
     - &golang_image "cimg/go:1.18.0"
@@ -402,7 +403,7 @@ jobs:
         name: Build all Kuma binaries (such as, kumactl, kuma-cp, kuma-dp, kuma-prometheus-sd)
         command: make build
     - setup_remote_docker:
-        version: 20.10.7
+        version: *docker_version
     - run:
         name: Build Docker images
         command: |
@@ -421,11 +422,12 @@ jobs:
   release:
     executor: golang
     steps:
-    - install_build_tools
     - checkout
     - run:
         name: "Download Go modules"
         command: go mod download
+    - setup_remote_docker:
+        version: *docker_version
     - run:
         name: Build Packages
         command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -444,7 +444,7 @@ jobs:
         command: |
           ./tools/releases/docker.sh --push
     - run:
-        name: Create and Push multiarch manifest for Docker images
+        name: Create and Push multi arch manifest for Docker images
         command: |
           ./tools/releases/docker.sh --manifest
 

--- a/mk/dev.mk
+++ b/mk/dev.mk
@@ -12,6 +12,7 @@ DATAPLANE_API_LATEST_VERSION := main
 SHELLCHECK_VERSION := v0.8.0
 YQ_VERSION := v4.24.2
 ETCD_VERSION := v3.5.3
+HELM_VERSION := v3.8.2
 
 CI_KUBEBUILDER_VERSION ?= 2.3.2
 CI_KUBECTL_VERSION ?= v1.23.5
@@ -292,7 +293,7 @@ dev/install/yq:
 .PHONY: dev/install/helm3
 dev/install/helm3: ## Bootstrap: Install Helm 3
 	$(CURL_DOWNLOAD) https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 | \
-		env HELM_INSTALL_DIR=$(CI_TOOLS_DIR) USE_SUDO=false bash
+		env HELM_INSTALL_DIR=$(CI_TOOLS_DIR) DESIRED_VERSION=$(HELM_VERSION) USE_SUDO=false bash
 
 .PHONY: dev/install/helm-docs
 dev/install/helm-docs: ## Bootstrap: Install helm-docs


### PR DESCRIPTION
### Summary

Because executor changed to golang for release job we need to setup remote docker.

### Full changelog

* [Added setup of docker remote]

### Issues resolved

Fix #XXX

### Documentation

- [ ] Link to the website [documentation PR](https://github.com/kumahq/kuma-website/pull/XXX)

### Testing

- [ ] Unit tests
- [ ] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes

### Backwards compatibility

- [ ] Update [`UPGRADE.md`](/UPGRADE.md) with any steps users will need to take when upgrading.
- [ ] Add `backport-to-stable` label if the code follows our [backporting policy](/CONTRIBUTING.md#backporting)
