### PR TITLE
fix(*): do not exclude arm64 files from docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -8,6 +8,7 @@ api
 app
 build/*
 !build/artifacts-linux-amd64
+!build/artifacts-linux-arm64
 dev
 docs
 examples


### PR DESCRIPTION
### Summary

Do not exclude arm64 from docker.

### Full changelog

* [added arm64 packages to docker]

### Issues resolved

Fix #XXX

### Documentation

- [ ] Link to the website [documentation PR](https://github.com/kumahq/kuma-website/pull/XXX)

### Testing

- [ ] Unit tests
- [ ] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes

### Backwards compatibility

- [ ] Update [`UPGRADE.md`](/UPGRADE.md) with any steps users will need to take when upgrading.
- [ ] Add `backport-to-stable` label if the code follows our [backporting policy](/CONTRIBUTING.md#backporting)
