### PR TITLE
chore(e2e): increase timeout from 45m to 60m

### DIFF
--- a/mk/e2e.new.mk
+++ b/mk/e2e.new.mk
@@ -94,7 +94,7 @@ test/e2e/k8s/stop: $(K8SCLUSTERS_STOP_TARGETS)
 .PHONY: test/e2e/test
 test/e2e/test:
 	for t in $(E2E_PKG_LIST); do \
-		$(E2E_ENV_VARS) $(GO_TEST_E2E) -v -timeout=45m $$t || exit; \
+		$(E2E_ENV_VARS) $(GO_TEST_E2E) -v -timeout=60m $$t || exit; \
 	done
 
 # test/e2e/debug is used for quicker feedback of E2E tests (ex. debugging flaky tests)


### PR DESCRIPTION
Signed-off-by: Ilya Lobkov <ilya.lobkov@konghq.com>

### Summary

Increase timeout while https://github.com/kumahq/kuma/issues/4259 is not done

### Full changelog

* [Implement ...]
* [Fix ...]

### Issues resolved

Fix #XXX

### Documentation

- [ ] Link to the website [documentation PR](https://github.com/kumahq/kuma-website/pull/XXX)

### Testing

- [ ] Unit tests
- [ ] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes

### Backwards compatibility

- [ ] Update [`UPGRADE.md`](/UPGRADE.md) with any steps users will need to take when upgrading.
- [ ] Add `backport-to-stable` label if the code follows our [backporting policy](/CONTRIBUTING.md#backporting)
