### PR TITLE
feat(kuma-cp): intercept signal for different platforms

### DIFF
--- a/app/kuma-dp/pkg/dataplane/command/build_command.go
+++ b/app/kuma-dp/pkg/dataplane/command/build_command.go
@@ -1,5 +1,4 @@
-//go:build !linux
-// +build !linux
+//go:build !linux && !windows
 
 package command
 

--- a/app/kuma-dp/pkg/dataplane/command/build_command_windows.go
+++ b/app/kuma-dp/pkg/dataplane/command/build_command_windows.go
@@ -1,4 +1,4 @@
-//go:build linux
+//go:build windows
 
 package command
 
@@ -6,7 +6,6 @@ import (
 	"context"
 	"io"
 	"os/exec"
-	"syscall"
 )
 
 func BuildCommand(
@@ -19,12 +18,7 @@ func BuildCommand(
 	command := exec.CommandContext(ctx, name, args...)
 	command.Stdout = stdout
 	command.Stderr = stderr
-	command.SysProcAttr = &syscall.SysProcAttr{
-		Pdeathsig: syscall.SIGKILL,
-		// Set those attributes so the new process won't receive the signals from a parent automatically.
-		Setpgid: true,
-		Pgid:    0,
-	}
+	// todo(jakubdyszkiewicz): do not propagate SIGTERM
 
 	return command
 }


### PR DESCRIPTION
### Summary

@lukidzi noticed that compilation fails on Windows, because of a lack of arguments.
At the same time, I noticed that I missed the args on Linux.

I'm not sure how to implement this on Windows this time. I'd rather create an issue and figure it out later.

### Issues resolved

No issues reported

### Documentation

No docs

### Testing

- [ ] Unit tests
- [ ] E2E tests
- [X] Manual testing on Universal
- [ ] Manual testing on Kubernetes

### Backwards compatibility

~- [ ] Update [`UPGRADE.md`](/UPGRADE.md) with any steps users will need to take when upgrading.~
~- [ ] Add `backport-to-stable` label if the code follows our [backporting policy](/CONTRIBUTING.md#backporting)~
