### PR TITLE
test(gateway): reduce logger output in Gateway API conformance test

### DIFF
--- a/test/e2e/gateway/gatewayapi/gateway_api.go
+++ b/test/e2e/gateway/gatewayapi/gateway_api.go
@@ -14,16 +14,10 @@ import (
 )
 
 func GatewayAPICRDs(cluster Cluster) error {
-	out, err := k8s.RunKubectlAndGetOutputE(
+	return k8s.RunKubectlE(
 		cluster.GetTesting(),
 		cluster.GetKubectlOptions(),
-		"kustomize", "github.com/kubernetes-sigs/gateway-api/config/crd?ref=v0.4.0",
-	)
-	if err != nil {
-		return err
-	}
-
-	return k8s.KubectlApplyFromStringE(cluster.GetTesting(), cluster.GetKubectlOptions(), out)
+		"apply", "-k", "github.com/kubernetes-sigs/gateway-api/config/crd?ref=v0.4.3")
 }
 
 const GatewayClass = `


### PR DESCRIPTION
### Summary

The first command's output (all resources) is logged and `kubectl` has the `-k` switch now.