### PR TITLE
feature: support kube-linter tools to analyzes Kubernetes YAML files

### DIFF
--- a/.kube-linter.yaml
+++ b/.kube-linter.yaml
@@ -1,0 +1,6 @@
+checks:
+  doNotAutoAddDefaults: true
+  include:
+    - "privileged-container"
+
+customChecks:

--- a/mk/check.mk
+++ b/mk/check.mk
@@ -41,10 +41,10 @@ ginkgo/unfocus:
 .PHONY: format
 format: fmt generate docs tidy ginkgo/unfocus
 
+.PHONY: kube-lint
+kube-lint:
+	$(GOPATH_BIN_DIR)/kube-linter lint .
+
 .PHONY: check
 check: format helm-lint golangci-lint shellcheck kube-lint ## Dev: Run code checks (go fmt, go vet, ...)
 	git diff --quiet || test $$(git diff --name-only | grep -v -e 'go.mod$$' -e 'go.sum$$' | wc -l) -eq 0 || ( echo "The following changes (result of code generators and code checks) have been detected:" && git --no-pager diff && false ) # fail if Git working tree is dirty
-
-.PHONY: kube-lint
-kube-lint:
-	kube-linter lint .

--- a/mk/check.mk
+++ b/mk/check.mk
@@ -42,5 +42,9 @@ ginkgo/unfocus:
 format: fmt generate docs tidy ginkgo/unfocus
 
 .PHONY: check
-check: format helm-lint golangci-lint shellcheck ## Dev: Run code checks (go fmt, go vet, ...)
+check: format helm-lint golangci-lint shellcheck kube-lint ## Dev: Run code checks (go fmt, go vet, ...)
 	git diff --quiet || test $$(git diff --name-only | grep -v -e 'go.mod$$' -e 'go.sum$$' | wc -l) -eq 0 || ( echo "The following changes (result of code generators and code checks) have been detected:" && git --no-pager diff && false ) # fail if Git working tree is dirty
+
+.PHONY: kube-lint
+kube-lint:
+	kube-linter lint .

--- a/mk/dev.mk
+++ b/mk/dev.mk
@@ -13,6 +13,7 @@ SHELLCHECK_VERSION := v0.8.0
 YQ_VERSION := v4.24.2
 ETCD_VERSION := v3.5.3
 HELM_VERSION := v3.8.2
+KUBE_LINTER_VERSION := v0.0.0-20220513142942-846f273ed465
 
 CI_KUBEBUILDER_VERSION ?= 2.3.2
 CI_KUBECTL_VERSION ?= v1.23.5
@@ -101,7 +102,8 @@ dev/tools/all: dev/install/protoc dev/install/protobuf-wellknown-types \
 	dev/install/helm-docs \
 	dev/install/data-plane-api \
 	dev/install/shellcheck \
-	dev/install/yq
+	dev/install/yq \
+	dev/install/kube-lint
 
 .PHONY: dev/install/protoc-gen-kumadoc
 dev/install/protoc-gen-kumadoc:
@@ -309,6 +311,10 @@ dev/install/helm-docs: ## Bootstrap: Install helm-docs
 		&& mv helm-docs $(HELM_DOCS_PATH) \
 		&& set +x \
 		&& echo "helm-docs $(HELM_DOCS_VERSION) has been installed at $(HELM_DOCS_PATH)" ; fi
+
+.PHONY: dev/install/kube-lint
+dev/install/kube-lint:
+	go install golang.stackrox.io/kube-linter/cmd/kube-linter@$(KUBE_LINTER_VERSION)
 
 $(KUBECONFIG_DIR):
 	@mkdir -p $(KUBECONFIG_DIR)


### PR DESCRIPTION
Signed-off-by: mango <xu.weiKyrie@foxmail.com>

### Summary

Support kube-linter tools to analyzes Kubernetes YAML files and Helm charts and checks them against various best practices.

### Full changelog

* [Implement ...]
* [Fix ...]

### Issues resolved

Fix #4266

### Documentation

- [ ] Link to the website [documentation PR](https://github.com/kumahq/kuma-website/pull/XXX)

### Testing

- [ ] Unit tests
- [ ] E2E tests
- [x] Manual testing on Universal
- [ ] Manual testing on Kubernetes

### Backwards compatibility

- [ ] Update [`UPGRADE.md`](/UPGRADE.md) with any steps users will need to take when upgrading.
- [ ] Add `backport-to-stable` label if the code follows our [backporting policy](/CONTRIBUTING.md#backporting)
