### PR TITLE
fix(kuma-cp): graceful start of many ZoneIngresses

### DIFF
--- a/pkg/xds/topology/outbound.go
+++ b/pkg/xds/topology/outbound.go
@@ -204,7 +204,15 @@ func fillIngressOutbounds(
 			continue
 		}
 
-		ziInstances[ziCoordinates] = struct{}{}
+		if len(zi.Spec.GetAvailableServices()) > 0 {
+			// Consider squashing instances only if available services are reconciled.
+			// This is necessary to perform graceful join of new instances of ZoneIngress.
+			// When a new instance of ZoneIngress is up, it's immediately synced to all zones.
+			// Only after a short period of time (first XDS reconciliation) it will be updated with AvailableServices.
+			// If we just take any instance, we may choose an instance without AvailableServices as a representation
+			// of all ZoneIngress instances behind one load balancer.
+			ziInstances[ziCoordinates] = struct{}{}
+		}
 
 		for _, service := range zi.Spec.GetAvailableServices() {
 			if service.Mesh != mesh.GetMeta().GetName() {

--- a/pkg/xds/topology/outbound_test.go
+++ b/pkg/xds/topology/outbound_test.go
@@ -338,18 +338,10 @@ var _ = Describe("TrafficRoute", func() {
 								AdvertisedAddress: "192.168.0.100",
 								AdvertisedPort:    12345,
 							},
-							AvailableServices: []*mesh_proto.ZoneIngress_AvailableService{
-								{
-									Instances: 2,
-									Mesh:      defaultMeshName,
-									Tags:      map[string]string{mesh_proto.ServiceTag: "redis", "version": "v2", mesh_proto.ZoneTag: "eu"},
-								},
-								{
-									Instances: 3,
-									Mesh:      defaultMeshName,
-									Tags:      map[string]string{mesh_proto.ServiceTag: "redis", "version": "v3"},
-								},
-							},
+							// when AvailableServices are not computed for the instance of the ingress behind the same
+							// load balancer (advertised address + port), available services from an instance that has them
+							// is preferred.
+							AvailableServices: []*mesh_proto.ZoneIngress_AvailableService{},
 						},
 					},
 					{


### PR DESCRIPTION
### Summary

I noticed that sometimes on scaling zone ingress from 1 to 5 instances for a short period of time (~2s) we can see a problem with the traffic.

### Issues resolved

Fix #4251

### Documentation

No extra docs.

### Testing

- [X] Unit tests
- [ ] E2E tests
- [ ] Manual testing on Universal
- [X] Manual testing on Kubernetes

### Backwards compatibility

~- [ ] Update [`UPGRADE.md`](/UPGRADE.md) with any steps users will need to take when upgrading.~
~- [ ] Add `backport-to-stable` label if the code follows our [backporting policy](/CONTRIBUTING.md#backporting)~
