### PR TITLE
test(e2e): fix broken port-forward

### DIFF
--- a/test/e2e_env/kubernetes/graceful/graceful.go
+++ b/test/e2e_env/kubernetes/graceful/graceful.go
@@ -4,6 +4,7 @@ import (
 	"io"
 	"io/ioutil"
 	"net/http"
+	"time"
 
 	"github.com/gruntwork-io/terratest/modules/k8s"
 	. "github.com/onsi/ginkgo/v2"
@@ -84,6 +85,10 @@ spec:
 
 	var gatewayIP string
 
+	httpClient := http.Client{
+		Timeout: 5 * time.Second,
+	}
+
 	BeforeAll(func() {
 		E2EDeferCleanup(func() {
 			Expect(env.Cluster.TriggerDeleteNamespace(namespace)).To(Succeed())
@@ -115,7 +120,7 @@ spec:
 	})
 
 	requestThroughGateway := func() error {
-		resp, err := http.Get("http://" + gatewayIP + ":8080")
+		resp, err := httpClient.Get("http://" + gatewayIP + ":8080")
 		if err != nil {
 			return err
 		}

--- a/test/e2e_env/kubernetes/kubernetes_suite_test.go
+++ b/test/e2e_env/kubernetes/kubernetes_suite_test.go
@@ -61,6 +61,10 @@ var _ = SynchronizedBeforeSuite(
 	},
 )
 
+// SynchronizedAfterSuite keeps the main process alive until all other processes finish.
+// Otherwise, we would close port-forward to the CP and remaining tests executed in different processes may fail.
+var _ = SynchronizedAfterSuite(func() {}, func() {})
+
 var _ = Describe("Virtual Probes", healthcheck.VirtualProbes, Ordered)
 var _ = Describe("Graceful", graceful.Graceful, Ordered)
 var _ = Describe("Jobs", jobs.Jobs)


### PR DESCRIPTION
### Summary

In K8S tests, the main process can finish first and break port-forward.
I also saw one problem with the graceful test that it was stuck on the request. We should have an explicit timeout (it's infinite by default)

The SynchronizedAfterSuite is not needed in Multizone and Universal env, because it has DeferCleanup which acts like SynchronizedAfterSuite

### Issues resolved

No issues reported.

### Documentation

No docs.

### Testing

- [ ] Unit tests
- [X] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes

### Backwards compatibility

~- [ ] Update [`UPGRADE.md`](/UPGRADE.md) with any steps users will need to take when upgrading.~
~- [ ] Add `backport-to-stable` label if the code follows our [backporting policy](/CONTRIBUTING.md#backporting)~
