### PR TITLE
chore(kuma-cni): upgrade to 0.0.10

### DIFF
--- a/app/kumactl/cmd/install/context/install_control_plane_context.go
+++ b/app/kumactl/cmd/install/context/install_control_plane_context.go
@@ -101,7 +101,7 @@ func DefaultInstallCpContext() InstallCpContext {
 			Cni_conf_name:                           "kuma-cni.conf",
 			Cni_image_registry:                      "docker.io/kumahq",
 			Cni_image_repository:                    "install-cni",
-			Cni_image_tag:                           "0.0.9",
+			Cni_image_tag:                           "0.0.10",
 			ControlPlane_mode:                       core.Standalone,
 			ControlPlane_zone:                       "",
 			ControlPlane_globalZoneSyncService_type: "LoadBalancer",

--- a/app/kumactl/cmd/install/testdata/install-control-plane.cni-enabled.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.cni-enabled.golden.yaml
@@ -1704,7 +1704,7 @@ spec:
       terminationGracePeriodSeconds: 5
       containers:
         - name: install-cni
-          image: "docker.io/kumahq/install-cni:0.0.9"
+          image: "docker.io/kumahq/install-cni:0.0.10"
           imagePullPolicy: Always
           command: ["/install-cni.sh"]
           env:

--- a/app/kumactl/cmd/install/testdata/install-control-plane.dump-values.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.dump-values.yaml
@@ -242,7 +242,7 @@ cni:
     # -- CNI image repository
     repository: "kumahq/install-cni"
     # -- CNI image tag
-    tag: "0.0.9"
+    tag: "0.0.10"
 
   # -- Security context at the pod level for cni
   podSecurityContext: {}
@@ -395,8 +395,8 @@ kumactl:
     tag:
 
 kubectl:
-  # rancher maintains an image for all k8s versions */ } }
-  # see: https://hub.docker.com/r/rancher/kubectl */ } }
+  # kuma image that support v1.20.15 image */ } }
+  # see: https://hub.docker.com/r/kumahq/kubectl */ } }
   image:
     # -- The kubectl image registry
     registry: kumahq

--- a/deployments/charts/kuma/README.md
+++ b/deployments/charts/kuma/README.md
@@ -73,7 +73,7 @@ A Helm chart for the Kuma Control Plane
 | cni.nodeSelector | object | `{"kubernetes.io/arch":"amd64","kubernetes.io/os":"linux"}` | Node Selector for the CNI pods |
 | cni.image.registry | string | `"docker.io"` | CNI image registry |
 | cni.image.repository | string | `"kumahq/install-cni"` | CNI image repository |
-| cni.image.tag | string | `"0.0.9"` | CNI image tag |
+| cni.image.tag | string | `"0.0.10"` | CNI image tag |
 | cni.podSecurityContext | object | `{}` | Security context at the pod level for cni |
 | cni.containerSecurityContext | object | `{}` | Security context at the container level for cni |
 | dataPlane.image.repository | string | `"kuma-dp"` | The Kuma DP image repository |

--- a/deployments/charts/kuma/values.yaml
+++ b/deployments/charts/kuma/values.yaml
@@ -242,7 +242,7 @@ cni:
     # -- CNI image repository
     repository: "kumahq/install-cni"
     # -- CNI image tag
-    tag: "0.0.9"
+    tag: "0.0.10"
 
   # -- Security context at the pod level for cni
   podSecurityContext: {}

--- a/docs/generated/cmd/kumactl/kumactl_install_control-plane.md
+++ b/docs/generated/cmd/kumactl/kumactl_install_control-plane.md
@@ -22,7 +22,7 @@ kumactl install control-plane [flags]
       --cni-node-selector stringToString             node selector for CNI deployment (default [])
       --cni-registry string                          registry for the image of the Kuma CNI component (default "docker.io/kumahq")
       --cni-repository string                        repository for the image of the Kuma CNI component (default "install-cni")
-      --cni-version string                           version of the image of the Kuma CNI component (default "0.0.9")
+      --cni-version string                           version of the image of the Kuma CNI component (default "0.0.10")
       --control-plane-node-selector stringToString   node selector for Kuma Control Plane (default [])
       --control-plane-registry string                registry for the image of the Kuma Control Plane component (default "docker.io/kumahq")
       --control-plane-repository string              repository for the image of the Kuma Control Plane component (default "kuma-cp")


### PR DESCRIPTION
### Summary

Upgrade Kuma CNI to 0.0.10

### Full changelog

* [Implement ...]
* [Fix ...]

### Issues resolved

Fix https://github.com/kumahq/kuma/issues/4303

### Documentation

- [ ] Link to the website [documentation PR](https://github.com/kumahq/kuma-website/pull/XXX)

### Testing

- [ ] Unit tests
- [ ] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes

### Backwards compatibility

- [ ] Update [`UPGRADE.md`](/UPGRADE.md) with any steps users will need to take when upgrading.
- [ ] Add `backport-to-stable` label if the code follows our [backporting policy](/CONTRIBUTING.md#backporting)
