### PR TITLE
fix(*): release should download arch specific envoy binary

### DIFF
--- a/tools/releases/distros.sh
+++ b/tools/releases/distros.sh
@@ -23,11 +23,12 @@ CTL_NAME="kumactl"
 function get_envoy() {
   local distro=$1
   local envoy_distro=$2
+  local arch=$3
 
   local status
   status=$(curl -L -o build/envoy-"$distro" \
     --write-out '%{http_code}' --silent --output /dev/null \
-    "https://download.konghq.com/mesh-alpine/envoy-$ENVOY_VERSION-$envoy_distro")
+    "https://download.konghq.com/mesh-alpine/envoy-$ENVOY_VERSION-$envoy_distro-$arch")
 
   if [ "$status" -ne "200" ]; then msg_err "Error: failed downloading Envoy"; fi
 }
@@ -81,7 +82,7 @@ function create_tarball() {
   mkdir "$kuma_dir/bin"
   mkdir "$kuma_dir/conf"
 
-  get_envoy "$distro" "$envoy_distro"
+  get_envoy "$distro" "$envoy_distro" "$arch"
   chmod 755 build/envoy-"$distro"
 
   artifact_dir=$(artifact_dir "$arch" "$system")


### PR DESCRIPTION
### Summary

Download arch-specific envoy version

### Full changelog

* [add arch to envoy binary url]

### Issues resolved

Fix #XXX

### Documentation

- [ ] Link to the website [documentation PR](https://github.com/kumahq/kuma-website/pull/XXX)

### Testing

- [ ] Unit tests
- [ ] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes

### Backwards compatibility

- [ ] Update [`UPGRADE.md`](/UPGRADE.md) with any steps users will need to take when upgrading.
- [ ] Add `backport-to-stable` label if the code follows our [backporting policy](/CONTRIBUTING.md#backporting)
