### PR TITLE
fix(kumactl): refactors delete `kumactl` cmd to align with get cmd

### DIFF
--- a/app/kumactl/cmd/delete/delete.go
+++ b/app/kumactl/cmd/delete/delete.go
@@ -17,6 +17,10 @@ import (
 func NewDeleteCmd(pctx *kumactl_cmd.RootContext) *cobra.Command {
 	register.RegisterGatewayTypes() // allow applying experimental Gateway types
 
+	var (
+		resourceTypeArg string
+		name            string
+	)
 	byName := map[string]model.ResourceTypeDescriptor{}
 	allNames := []string{}
 	for _, desc := range pctx.Runtime.Registry.ObjectDescriptors(model.HasKumactlEnabled()) {
@@ -28,14 +32,18 @@ func NewDeleteCmd(pctx *kumactl_cmd.RootContext) *cobra.Command {
 		Use:   "delete TYPE NAME",
 		Short: "Delete Kuma resources",
 		Long:  `Delete Kuma resources.`,
-		Args:  cobra.ExactArgs(2),
+		// Args:  cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := pctx.CheckServerVersionCompatibility(); err != nil {
 				cmd.PrintErrln(err)
 			}
 
-			resourceTypeArg := args[0]
-			name := args[1]
+			if len(args) > 1 {
+				resourceTypeArg = args[0]
+				name = args[1]
+			} else {
+				return cmd.Help()
+			}
 
 			desc, ok := byName[resourceTypeArg]
 			if !ok {


### PR DESCRIPTION
Signed-off-by: afzal442 <afzal442@gmail.com>

### Summary

This PR allows you to show usage of `kumactl` delete cmd when you type `kumactl delete` and hit enter

### Full changelog

```
➜  build/artifacts-linux-amd64/kumactl/kumactl delete
WARNING: Unable to confirm the server supports this kumactl version
Delete Kuma resources.

Usage:
  kumactl delete TYPE NAME [flags]

Flags:
  -h, --help          help for delete
  -m, --mesh string   mesh to use (default "default")

Global Flags:
      --api-timeout duration   the timeout for api calls. It includes connection time, any redirects, and reading the response body. A timeout of zero means no timeout (default 1m0s)
      --config-file string     path to the configuration file to use
      --log-level string       log level: one of off|info|debug (default "off")
      --no-config              if set no config file and config directory will be created
```

### Issues resolved

Fix #2976

### Documentation

- [ ] Link to the website [documentation PR](https://github.com/kumahq/kuma-website/pull/XXX)

### Testing

- [ ] Unit tests
- [ ] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes

### Backwards compatibility

- [ ] Update [`UPGRADE.md`](/UPGRADE.md) with any steps users will need to take when upgrading.
- [ ] Add `backport-to-stable` label if the code follows our [backporting policy](/CONTRIBUTING.md#backporting)
