### PR TITLE
fix(*): added join host port to support ipv6

### DIFF
--- a/test/e2e_env/kubernetes/metrics/applications_metrics.go
+++ b/test/e2e_env/kubernetes/metrics/applications_metrics.go
@@ -2,6 +2,7 @@ package metrics
 
 import (
 	"fmt"
+	"net"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -116,7 +117,7 @@ func ApplicationsMetrics() {
 
 		// when
 		stdout, _, err := env.Cluster.Exec(namespace, podName, "test-server",
-			"curl", "-v", "-m", "3", "--fail", "http://"+podIp+":1234/metrics?filter=concurrency")
+			"curl", "-v", "-m", "3", "--fail", "http://"+net.JoinHostPort(podIp, "1234")+"/metrics?filter=concurrency")
 
 		// then
 		Expect(err).ToNot(HaveOccurred())
@@ -138,7 +139,7 @@ func ApplicationsMetrics() {
 
 		// when
 		stdout, _, err := env.Cluster.Exec(namespace, podName, "test-server-override-mesh",
-			"curl", "-v", "-m", "3", "--fail", "http://"+podIp+":1234/metrics?filter=concurrency")
+			"curl", "-v", "-m", "3", "--fail", "http://"+net.JoinHostPort(podIp, "1234")+"/metrics?filter=concurrency")
 
 		// then
 		Expect(err).ToNot(HaveOccurred())
@@ -170,7 +171,7 @@ func ApplicationsMetrics() {
 
 		// when
 		stdout, _, err := env.Cluster.Exec(namespace, podName, "test-server-dp-metrics",
-			"curl", "-v", "-m", "3", "--fail", "http://"+podIp+":1234/metrics?filter=concurrency")
+			"curl", "-v", "-m", "3", "--fail", "http://"+net.JoinHostPort(podIp, "1234")+"/metrics?filter=concurrency")
 
 		// then
 		Expect(err).ToNot(HaveOccurred())

--- a/test/e2e_env/universal/metrics/applications_metrics.go
+++ b/test/e2e_env/universal/metrics/applications_metrics.go
@@ -2,6 +2,7 @@ package metrics
 
 import (
 	"fmt"
+	"net"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -123,7 +124,7 @@ metrics:
 
 		// when
 		stdout, _, err := env.Cluster.ExecWithRetries("", "", "test-server",
-			"curl", "-v", "-m", "3", "--fail", "http://"+ip+":1234/metrics?filter=concurrency")
+			"curl", "-v", "-m", "3", "--fail", "http://"+net.JoinHostPort(ip, "1234")+"/metrics?filter=concurrency")
 
 		// then
 		Expect(err).ToNot(HaveOccurred())
@@ -142,7 +143,7 @@ metrics:
 
 		// when
 		stdout, _, err := env.Cluster.ExecWithRetries("", "", "test-server-override-mesh",
-			"curl", "-v", "-m", "3", "--fail", "http://"+ip+":1234/metrics/overridden?filter=concurrency")
+			"curl", "-v", "-m", "3", "--fail", "http://"+net.JoinHostPort(ip, "1234")+"/metrics/overridden?filter=concurrency")
 
 		// then
 		Expect(err).ToNot(HaveOccurred())
@@ -171,7 +172,7 @@ metrics:
 
 		// when
 		stdout, _, err := env.Cluster.ExecWithRetries("", "", "test-server-dp-metrics",
-			"curl", "-v", "-m", "3", "--fail", "http://"+ip+":5555/stats?filter=concurrency")
+			"curl", "-v", "-m", "3", "--fail", "http://"+net.JoinHostPort(ip, "5555")+"/stats?filter=concurrency")
 
 		// then
 		Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
### Summary
Changed way how create `host:port` to support ipv6.

### Full changelog

* [Implement ...]
* [changed string concatenation to `JontHostPort`]

### Issues resolved

Fix #XXX

### Documentation

- [ ] Link to the website [documentation PR](https://github.com/kumahq/kuma-website/pull/XXX)

### Testing

- [ ] Unit tests
- [ ] E2E tests
- [ ] Manual testing on Universal
- [X] Manual testing on Kubernetes

### Backwards compatibility

- [ ] Update [`UPGRADE.md`](/UPGRADE.md) with any steps users will need to take when upgrading.
- [ ] Add `backport-to-stable` label if the code follows our [backporting policy](/CONTRIBUTING.md#backporting)
