### PR TITLE
test(e2e): lower resources limits for test servers

### DIFF
--- a/test/framework/deployments/testserver/kubernetes.go
+++ b/test/framework/deployments/testserver/kubernetes.go
@@ -140,8 +140,8 @@ func (k *k8SDeployment) podSpec() corev1.PodTemplateSpec {
 					Args:    append([]string{"echo", "--port", "80", "--probes"}, k.opts.Args...),
 					Resources: corev1.ResourceRequirements{
 						Limits: corev1.ResourceList{
-							"cpu":    resource.MustParse("500m"),
-							"memory": resource.MustParse("128Mi"),
+							"cpu":    resource.MustParse("50m"),
+							"memory": resource.MustParse("64Mi"),
 						},
 					},
 					Lifecycle: &corev1.Lifecycle{

--- a/test/framework/setup.go
+++ b/test/framework/setup.go
@@ -310,7 +310,7 @@ spec:
           resources:
             limits:
               cpu: 50m
-              memory: 128Mi
+              memory: 64Mi
 `
 	return Combine(
 		YamlK8s(fmt.Sprintf(deployment, namespace, mesh, Config.GetUniversalImage())),


### PR DESCRIPTION
### Summary

Half of the vCPU for the test server is too much if we are running many of them in parallel. Removing a namespace with pods takes time, I suspect we are running into resources limits.

https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
> Note: If you specify a limit for a resource, but do not specify any request, and no admission-time mechanism has applied a default request for that resource, then Kubernetes copies the limit you specified and uses it as the requested value for the resource.

### Issues resolved

No issues reported, flaky test on master.

### Documentation

~- [ ] Link to the website [documentation PR](https://github.com/kumahq/kuma-website/pull/XXX)~

### Testing

- [ ] Unit tests
- [X] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes

### Backwards compatibility

~- [ ] Update [`UPGRADE.md`](/UPGRADE.md) with any steps users will need to take when upgrading.~
~- [ ] Add `backport-to-stable` label if the code follows our [backporting policy](/CONTRIBUTING.md#backporting)~
