### PR TITLE
chore(*): delete 'kubernetes.io/arch' node selector

### DIFF
--- a/app/kumactl/cmd/install/install_control_plane.go
+++ b/app/kumactl/cmd/install/install_control_plane.go
@@ -9,6 +9,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"helm.sh/helm/v3/pkg/strvals"
+	_ "k8s.io/client-go/plugin/pkg/client/auth"
 	"k8s.io/client-go/rest"
 
 	install_context "github.com/kumahq/kuma/app/kumactl/cmd/install/context"
@@ -18,8 +19,6 @@ import (
 	"github.com/kumahq/kuma/pkg/config/core"
 	mesh_k8s "github.com/kumahq/kuma/pkg/plugins/resources/k8s/native/api/v1alpha1"
 	"github.com/kumahq/kuma/pkg/plugins/runtime/gateway/register"
-
-	_ "k8s.io/client-go/plugin/pkg/client/auth"
 )
 
 type componentVersion struct {

--- a/app/kumactl/cmd/install/install_control_plane.go
+++ b/app/kumactl/cmd/install/install_control_plane.go
@@ -18,6 +18,8 @@ import (
 	"github.com/kumahq/kuma/pkg/config/core"
 	mesh_k8s "github.com/kumahq/kuma/pkg/plugins/resources/k8s/native/api/v1alpha1"
 	"github.com/kumahq/kuma/pkg/plugins/runtime/gateway/register"
+
+	_ "k8s.io/client-go/plugin/pkg/client/auth"
 )
 
 type componentVersion struct {

--- a/app/kumactl/cmd/install/testdata/install-control-plane.cni-enabled.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.cni-enabled.golden.yaml
@@ -2095,7 +2095,6 @@ spec:
     spec:
       nodeSelector:
       
-        kubernetes.io/arch: amd64
         kubernetes.io/os: linux
       hostNetwork: true
       tolerations:
@@ -2192,7 +2191,6 @@ spec:
       automountServiceAccountToken: true
       nodeSelector:
         
-        kubernetes.io/arch: amd64
         kubernetes.io/os: linux
       hostNetwork: false
       containers:

--- a/app/kumactl/cmd/install/testdata/install-control-plane.defaults.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.defaults.golden.yaml
@@ -2017,7 +2017,6 @@ spec:
       automountServiceAccountToken: true
       nodeSelector:
         
-        kubernetes.io/arch: amd64
         kubernetes.io/os: linux
       hostNetwork: false
       containers:

--- a/app/kumactl/cmd/install/testdata/install-control-plane.dump-values.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.dump-values.yaml
@@ -57,7 +57,6 @@ controlPlane:
   # -- Node selector for the Kuma Control Plane pods
   nodeSelector:
     kubernetes.io/os: linux
-    kubernetes.io/arch: amd64
 
   # -- Affinity placement rule for the Kuma Control Plane pods
   affinity: {}
@@ -237,7 +236,6 @@ cni:
   # -- Node Selector for the CNI pods
   nodeSelector:
     kubernetes.io/os: linux
-    kubernetes.io/arch: amd64
 
   image:
     # -- CNI image registry
@@ -309,7 +307,6 @@ ingress:
   # -- Node Selector for the Ingress pods
   nodeSelector:
     kubernetes.io/os: linux
-    kubernetes.io/arch: amd64
 
   # -- Affinity placement rule for the Kuma Ingress pods
   affinity: {}
@@ -361,7 +358,6 @@ egress:
   # -- Node Selector for the Egress pods
   nodeSelector:
     kubernetes.io/os: linux
-    kubernetes.io/arch: amd64
 
   # -- Affinity placement rule for the Kuma Ingress pods
   affinity: {}
@@ -411,7 +407,6 @@ hooks:
   # -- Node selector for the HELM hooks
   nodeSelector:
     kubernetes.io/os: linux
-    kubernetes.io/arch: amd64
 
   # -- Security context at the pod level for crd/webhook/ns
   podSecurityContext: {}

--- a/app/kumactl/cmd/install/testdata/install-control-plane.global.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.global.golden.yaml
@@ -2027,7 +2027,6 @@ spec:
       automountServiceAccountToken: true
       nodeSelector:
         
-        kubernetes.io/arch: amd64
         kubernetes.io/os: linux
       hostNetwork: false
       containers:

--- a/app/kumactl/cmd/install/testdata/install-control-plane.override-env-vars.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.override-env-vars.golden.yaml
@@ -2017,7 +2017,6 @@ spec:
       automountServiceAccountToken: true
       nodeSelector:
         
-        kubernetes.io/arch: amd64
         kubernetes.io/os: linux
       hostNetwork: false
       containers:

--- a/app/kumactl/cmd/install/testdata/install-control-plane.overrides.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.overrides.golden.yaml
@@ -2133,7 +2133,6 @@ spec:
       automountServiceAccountToken: true
       nodeSelector:
         
-        kubernetes.io/arch: amd64
         kubernetes.io/os: linux
       hostNetwork: false
       containers:

--- a/app/kumactl/cmd/install/testdata/install-control-plane.with-egress.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.with-egress.golden.yaml
@@ -2046,7 +2046,6 @@ spec:
       automountServiceAccountToken: true
       nodeSelector:
         
-        kubernetes.io/arch: amd64
         kubernetes.io/os: linux
       hostNetwork: false
       containers:
@@ -2186,7 +2185,6 @@ spec:
       serviceAccountName: kuma-egress
       nodeSelector:
       
-        kubernetes.io/arch: amd64
         kubernetes.io/os: linux
       containers:
         - name: egress

--- a/app/kumactl/cmd/install/testdata/install-control-plane.with-helm-set.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.with-helm-set.yaml
@@ -2079,7 +2079,6 @@ spec:
       automountServiceAccountToken: true
       nodeSelector:
         
-        kubernetes.io/arch: amd64
         kubernetes.io/os: linux
       hostNetwork: false
       containers:
@@ -2223,7 +2222,6 @@ spec:
       serviceAccountName: kuma-egress
       nodeSelector:
       
-        kubernetes.io/arch: amd64
         kubernetes.io/os: linux
       containers:
         - name: egress
@@ -2333,7 +2331,6 @@ spec:
       serviceAccountName: kuma-ingress
       nodeSelector:
       
-        kubernetes.io/arch: amd64
         kubernetes.io/os: linux
       containers:
         - name: ingress

--- a/app/kumactl/cmd/install/testdata/install-control-plane.with-helm-values.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.with-helm-values.yaml
@@ -2017,7 +2017,6 @@ spec:
       automountServiceAccountToken: true
       nodeSelector:
         
-        kubernetes.io/arch: amd64
         kubernetes.io/os: linux
       hostNetwork: false
       containers:

--- a/app/kumactl/cmd/install/testdata/install-control-plane.with-ingress.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.with-ingress.golden.yaml
@@ -2050,7 +2050,6 @@ spec:
       automountServiceAccountToken: true
       nodeSelector:
         
-        kubernetes.io/arch: amd64
         kubernetes.io/os: linux
       hostNetwork: false
       containers:
@@ -2194,7 +2193,6 @@ spec:
       serviceAccountName: kuma-ingress
       nodeSelector:
       
-        kubernetes.io/arch: amd64
         kubernetes.io/os: linux
       containers:
         - name: ingress

--- a/app/kumactl/cmd/install/testdata/install-control-plane.zone.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.zone.golden.yaml
@@ -2021,7 +2021,6 @@ spec:
       automountServiceAccountToken: true
       nodeSelector:
         
-        kubernetes.io/arch: amd64
         kubernetes.io/os: linux
       hostNetwork: false
       containers:

--- a/deployments/charts/kuma/README.md
+++ b/deployments/charts/kuma/README.md
@@ -26,7 +26,7 @@ A Helm chart for the Kuma Control Plane
 | controlPlane.autoscaling.maxReplicas | int | `5` | The max CP pods to scale to |
 | controlPlane.autoscaling.targetCPUUtilizationPercentage | int | `80` | For clusters that don't support autoscaling/v2beta, autoscaling/v1 is used |
 | controlPlane.autoscaling.metrics | list | `[{"resource":{"name":"cpu","target":{"averageUtilization":80,"type":"Utilization"}},"type":"Resource"}]` | For clusters that do support autoscaling/v2beta, use metrics |
-| controlPlane.nodeSelector | object | `{"kubernetes.io/arch":"amd64","kubernetes.io/os":"linux"}` | Node selector for the Kuma Control Plane pods |
+| controlPlane.nodeSelector | object | `{"kubernetes.io/os":"linux"}` | Node selector for the Kuma Control Plane pods |
 | controlPlane.affinity | object | `{}` | Affinity placement rule for the Kuma Control Plane pods |
 | controlPlane.injectorFailurePolicy | string | `"Fail"` | Failure policy of the mutating webhook implemented by the Kuma Injector component |
 | controlPlane.service.name | string | `nil` | Optionally override of the Kuma Control Plane Service's name |
@@ -71,7 +71,7 @@ A Helm chart for the Kuma Control Plane
 | cni.binDir | string | `"/var/lib/cni/bin"` | Set the CNI bin directory |
 | cni.confName | string | `"kuma-cni.conf"` | Set the CNI configuration name |
 | cni.logLevel | string | `"info"` | CNI log level: one of off,info,debug |
-| cni.nodeSelector | object | `{"kubernetes.io/arch":"amd64","kubernetes.io/os":"linux"}` | Node Selector for the CNI pods |
+| cni.nodeSelector | object | `{"kubernetes.io/os":"linux"}` | Node Selector for the CNI pods |
 | cni.image.registry | string | `"docker.io"` | CNI image registry |
 | cni.image.repository | string | `"kumahq/install-cni"` | CNI image repository |
 | cni.image.tag | string | `"0.0.10"` | CNI image tag |
@@ -91,7 +91,7 @@ A Helm chart for the Kuma Control Plane
 | ingress.service.port | int | `10001` | Port on which Ingress is exposed |
 | ingress.service.nodePort | string | `nil` | Port on which service is exposed on Node for service of type NodePort |
 | ingress.annotations | object | `{}` | Additional deployment annotation |
-| ingress.nodeSelector | object | `{"kubernetes.io/arch":"amd64","kubernetes.io/os":"linux"}` | Node Selector for the Ingress pods |
+| ingress.nodeSelector | object | `{"kubernetes.io/os":"linux"}` | Node Selector for the Ingress pods |
 | ingress.affinity | object | `{}` | Affinity placement rule for the Kuma Ingress pods |
 | ingress.podSecurityContext | object | `{}` | Security context at the pod level for ingress |
 | ingress.containerSecurityContext | object | `{}` | Security context at the container level for ingress |
@@ -104,7 +104,7 @@ A Helm chart for the Kuma Control Plane
 | egress.service.port | int | `10002` | Port on which Egress is exposed |
 | egress.service.nodePort | string | `nil` | Port on which service is exposed on Node for service of type NodePort |
 | egress.annotations | object | `{}` | Additional deployment annotation |
-| egress.nodeSelector | object | `{"kubernetes.io/arch":"amd64","kubernetes.io/os":"linux"}` | Node Selector for the Egress pods |
+| egress.nodeSelector | object | `{"kubernetes.io/os":"linux"}` | Node Selector for the Egress pods |
 | egress.affinity | object | `{}` | Affinity placement rule for the Kuma Ingress pods |
 | egress.podSecurityContext | object | `{}` | Security context at the pod level for egress |
 | egress.containerSecurityContext | object | `{}` | Security context at the container level for egress |
@@ -113,7 +113,7 @@ A Helm chart for the Kuma Control Plane
 | kubectl.image.registry | string | `"kumahq"` | The kubectl image registry |
 | kubectl.image.repository | string | `"kubectl"` | The kubectl image repository |
 | kubectl.image.tag | string | `"v1.20.15"` | The kubectl image tag |
-| hooks.nodeSelector | object | `{"kubernetes.io/arch":"amd64","kubernetes.io/os":"linux"}` | Node selector for the HELM hooks |
+| hooks.nodeSelector | object | `{"kubernetes.io/os":"linux"}` | Node selector for the HELM hooks |
 | hooks.podSecurityContext | object | `{}` | Security context at the pod level for crd/webhook/ns |
 | hooks.containerSecurityContext | object | `{}` | Security context at the container level for crd/webhook/ns |
 | experimental.gatewayAPI | bool | `false` | If true, it installs experimental Gateway API support |

--- a/deployments/charts/kuma/values.yaml
+++ b/deployments/charts/kuma/values.yaml
@@ -57,7 +57,6 @@ controlPlane:
   # -- Node selector for the Kuma Control Plane pods
   nodeSelector:
     kubernetes.io/os: linux
-    kubernetes.io/arch: amd64
 
   # -- Affinity placement rule for the Kuma Control Plane pods
   affinity: {}
@@ -237,7 +236,6 @@ cni:
   # -- Node Selector for the CNI pods
   nodeSelector:
     kubernetes.io/os: linux
-    kubernetes.io/arch: amd64
 
   image:
     # -- CNI image registry
@@ -309,7 +307,6 @@ ingress:
   # -- Node Selector for the Ingress pods
   nodeSelector:
     kubernetes.io/os: linux
-    kubernetes.io/arch: amd64
 
   # -- Affinity placement rule for the Kuma Ingress pods
   affinity: {}
@@ -361,7 +358,6 @@ egress:
   # -- Node Selector for the Egress pods
   nodeSelector:
     kubernetes.io/os: linux
-    kubernetes.io/arch: amd64
 
   # -- Affinity placement rule for the Kuma Ingress pods
   affinity: {}
@@ -411,7 +407,6 @@ hooks:
   # -- Node selector for the HELM hooks
   nodeSelector:
     kubernetes.io/os: linux
-    kubernetes.io/arch: amd64
 
   # -- Security context at the pod level for crd/webhook/ns
   podSecurityContext: {}

--- a/go.mod
+++ b/go.mod
@@ -71,7 +71,12 @@ require (
 require (
 	cloud.google.com/go/compute v1.5.0 // indirect
 	github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1 // indirect
+	github.com/Azure/go-autorest v14.2.0+incompatible // indirect
 	github.com/Azure/go-autorest/autorest v0.11.21 // indirect
+	github.com/Azure/go-autorest/autorest/adal v0.9.16 // indirect
+	github.com/Azure/go-autorest/autorest/date v0.3.0 // indirect
+	github.com/Azure/go-autorest/logger v0.2.1 // indirect
+	github.com/Azure/go-autorest/tracing v0.6.0 // indirect
 	github.com/BurntSushi/toml v0.4.1 // indirect
 	github.com/Masterminds/goutils v1.1.1 // indirect
 	github.com/Masterminds/semver v1.5.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -88,6 +88,7 @@ github.com/Azure/go-autorest/autorest/adal v0.9.16/go.mod h1:tGMin8I49Yij6AQ+rvV
 github.com/Azure/go-autorest/autorest/date v0.3.0 h1:7gUk1U5M/CQbp9WoqinNzJar+8KY+LPI6wiWrP/myHw=
 github.com/Azure/go-autorest/autorest/date v0.3.0/go.mod h1:BI0uouVdmngYNUzGWeSYnokU+TrmwEsOqdt8Y6sso74=
 github.com/Azure/go-autorest/autorest/mocks v0.4.0/go.mod h1:LTp+uSrOhSkaKrUy935gNZuuIPPVsHlr9DSOxSayd+k=
+github.com/Azure/go-autorest/autorest/mocks v0.4.1 h1:K0laFcLE6VLTOwNgSxaGbUcLPuGXlNkbVvq4cW4nIHk=
 github.com/Azure/go-autorest/autorest/mocks v0.4.1/go.mod h1:LTp+uSrOhSkaKrUy935gNZuuIPPVsHlr9DSOxSayd+k=
 github.com/Azure/go-autorest/autorest/to v0.4.0/go.mod h1:fE8iZBn7LQR7zH/9XU2NcPR4o9jEImooCeWJcYV/zLE=
 github.com/Azure/go-autorest/logger v0.2.0/go.mod h1:T9E3cAhj2VqvPOtCYAvby9aBXkZmbF5NWuPV8+WeEW8=


### PR DESCRIPTION
### Summary

Since we support both `arm64` and `amd64` it makes sense to remove arch node selector from the list of default node selectors.

### Full changelog

* delete `kubernetes.io/arch` node selector
* add `_ "k8s.io/client-go/plugin/pkg/client/auth"` 

### Issues resolved

Fix https://github.com/kumahq/kuma/issues/4326

### Documentation

- [ ] Link to the website [documentation PR](https://github.com/kumahq/kuma-website/pull/XXX)

### Testing

- [X] Unit tests
- [ ] E2E tests
- [ ] Manual testing on Universal
- [X] Manual testing on Kubernetes

### Backwards compatibility

- [ ] Update [`UPGRADE.md`](/UPGRADE.md) with any steps users will need to take when upgrading.
- [ ] Add `backport-to-stable` label if the code follows our [backporting policy](/CONTRIBUTING.md#backporting)
