### PR TITLE
chore(*): delete dns-server 5653 port

### DIFF
--- a/app/kumactl/cmd/install/testdata/install-control-plane.cni-enabled.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.cni-enabled.golden.yaml
@@ -2052,9 +2052,6 @@ spec:
       name: mads-server
     - port: 5678
       name: dp-server
-    - port: 5653
-      name: dns-server
-      protocol: UDP
   selector:
     app: kuma-control-plane
     app.kubernetes.io/name: kuma

--- a/app/kumactl/cmd/install/testdata/install-control-plane.defaults.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.defaults.golden.yaml
@@ -1963,9 +1963,6 @@ spec:
       name: mads-server
     - port: 5678
       name: dp-server
-    - port: 5653
-      name: dns-server
-      protocol: UDP
   selector:
     app: kuma-control-plane
     app.kubernetes.io/name: kuma

--- a/app/kumactl/cmd/install/testdata/install-control-plane.override-env-vars.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.override-env-vars.golden.yaml
@@ -1963,9 +1963,6 @@ spec:
       name: mads-server
     - port: 5678
       name: dp-server
-    - port: 5653
-      name: dns-server
-      protocol: UDP
   selector:
     app: kuma-control-plane
     app.kubernetes.io/name: kuma

--- a/app/kumactl/cmd/install/testdata/install-control-plane.overrides.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.overrides.golden.yaml
@@ -2079,9 +2079,6 @@ spec:
       name: mads-server
     - port: 5678
       name: dp-server
-    - port: 5653
-      name: dns-server
-      protocol: UDP
   selector:
     app: kuma-control-plane
     app.kubernetes.io/name: kuma

--- a/app/kumactl/cmd/install/testdata/install-control-plane.with-egress.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.with-egress.golden.yaml
@@ -1972,9 +1972,6 @@ spec:
       name: mads-server
     - port: 5678
       name: dp-server
-    - port: 5653
-      name: dns-server
-      protocol: UDP
   selector:
     app: kuma-control-plane
     app.kubernetes.io/name: kuma

--- a/app/kumactl/cmd/install/testdata/install-control-plane.with-helm-set.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.with-helm-set.yaml
@@ -1985,9 +1985,6 @@ spec:
       name: mads-server
     - port: 5678
       name: dp-server
-    - port: 5653
-      name: dns-server
-      protocol: UDP
   selector:
     app: kuma-control-plane
     app.kubernetes.io/name: kuma

--- a/app/kumactl/cmd/install/testdata/install-control-plane.with-helm-values.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.with-helm-values.yaml
@@ -1963,9 +1963,6 @@ spec:
       name: mads-server
     - port: 5678
       name: dp-server
-    - port: 5653
-      name: dns-server
-      protocol: UDP
   selector:
     app: kuma-control-plane
     app.kubernetes.io/name: kuma

--- a/app/kumactl/cmd/install/testdata/install-control-plane.with-ingress.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.with-ingress.golden.yaml
@@ -1976,9 +1976,6 @@ spec:
       name: mads-server
     - port: 5678
       name: dp-server
-    - port: 5653
-      name: dns-server
-      protocol: UDP
   selector:
     app: kuma-control-plane
     app.kubernetes.io/name: kuma

--- a/app/kumactl/cmd/install/testdata/install-control-plane.zone.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.zone.golden.yaml
@@ -1967,9 +1967,6 @@ spec:
       name: mads-server
     - port: 5678
       name: dp-server
-    - port: 5653
-      name: dns-server
-      protocol: UDP
   selector:
     app: kuma-control-plane
     app.kubernetes.io/name: kuma

--- a/deployments/charts/kuma/templates/cp-service.yaml
+++ b/deployments/charts/kuma/templates/cp-service.yaml
@@ -28,9 +28,6 @@ spec:
       name: mads-server
     - port: 5678
       name: dp-server
-    - port: 5653
-      name: dns-server
-      protocol: UDP
     {{- end }}
   selector:
     app: {{ include "kuma.name" . }}-control-plane

--- a/pkg/config/app/kuma-cp/kuma-cp.defaults.yaml
+++ b/pkg/config/app/kuma-cp/kuma-cp.defaults.yaml
@@ -318,8 +318,6 @@ guiServer:
 dnsServer:
   # The domain that the server will resolve the services for
   domain: "mesh" # ENV: KUMA_DNS_SERVER_DOMAIN
-  # Port on which the server is exposed
-  port: 5653 # ENV: KUMA_DNS_SERVER_PORT
   # The CIDR range used to allocate
   CIDR: "240.0.0.0/4" # ENV: KUMA_DNS_SERVER_CIDR
   # Will create a service "<kuma.io/service>.mesh" dns entry for every service.


### PR DESCRIPTION
### Summary

PR https://github.com/kumahq/kuma/pull/4192 deleted port from config, but `kuma-cp.defaults.yaml` and k8s.Service still have this port

### Full changelog

* delete 5653 port from `kuma-cp.defaults.yaml` and deployment

### Issues resolved

N/A

### Documentation

- [ ] Link to the website [documentation PR](https://github.com/kumahq/kuma-website/pull/XXX)

### Testing

- [ ] Unit tests
- [ ] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes

### Backwards compatibility

- [ ] Update [`UPGRADE.md`](/UPGRADE.md) with any steps users will need to take when upgrading.
- [ ] Add `backport-to-stable` label if the code follows our [backporting policy](/CONTRIBUTING.md#backporting)
