### PR TITLE
chore(*): pull image because of no image change detected

### DIFF
--- a/tools/releases/docker.sh
+++ b/tools/releases/docker.sh
@@ -24,7 +24,7 @@ function build() {
       if [ "$arch" == "arm64" ]; then
         read -ra additional_args <<< "${ARM64_BUILD_ARGS[@]}"
       fi
-      docker build "${build_args[@]}" "${additional_args[@]}" -t "${KUMA_DOCKER_REPO_ORG}/${component}:${KUMA_VERSION}-${arch}" \
+      docker build --pull "${build_args[@]}" "${additional_args[@]}" -t "${KUMA_DOCKER_REPO_ORG}/${component}:${KUMA_VERSION}-${arch}" \
         -f tools/releases/dockerfiles/Dockerfile."${component}" .
       docker tag "${KUMA_DOCKER_REPO_ORG}/${component}:${KUMA_VERSION}-${arch}" "${KUMA_DOCKER_REPO_ORG}/${component}:latest-${arch}"
       msg_green "... done!"


### PR DESCRIPTION
### Summary

While building docker image for multiarch, once downloaded image for `amd64` is used for `arm64` that causes issue. We need to pull image before steps

### Full changelog

* [download images before build]

### Issues resolved

Fix #XXX

### Documentation

- [ ] Link to the website [documentation PR](https://github.com/kumahq/kuma-website/pull/XXX)

### Testing

- [ ] Unit tests
- [ ] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes

### Backwards compatibility

- [ ] Update [`UPGRADE.md`](/UPGRADE.md) with any steps users will need to take when upgrading.
- [ ] Add `backport-to-stable` label if the code follows our [backporting policy](/CONTRIBUTING.md#backporting)
