### PR TITLE
fix(tests): don't check version comp. in dp status

### DIFF
--- a/pkg/core/xds/metadata_test.go
+++ b/pkg/core/xds/metadata_test.go
@@ -83,14 +83,14 @@ var _ = Describe("DataplaneMetadataFromXdsMetadata", func() {
 		// given
 		version := &mesh_proto.Version{
 			KumaDp: &mesh_proto.KumaDpVersion{
-				Version:          "0.0.1",
-				GitTag:           "v0.0.1",
-				GitCommit:        "91ce236824a9d875601679aa80c63783fb0e8725",
-				BuildDate:        "2019-08-07T11:26:06Z",
+				Version:   "0.0.1",
+				GitTag:    "v0.0.1",
+				GitCommit: "91ce236824a9d875601679aa80c63783fb0e8725",
+				BuildDate: "2019-08-07T11:26:06Z",
 			},
 			Envoy: &mesh_proto.EnvoyVersion{
-				Version:          "1.15.0",
-				Build:            "hash/1.15.0/RELEASE",
+				Version: "1.15.0",
+				Build:   "hash/1.15.0/RELEASE",
 			},
 		}
 

--- a/pkg/core/xds/metadata_test.go
+++ b/pkg/core/xds/metadata_test.go
@@ -87,12 +87,10 @@ var _ = Describe("DataplaneMetadataFromXdsMetadata", func() {
 				GitTag:           "v0.0.1",
 				GitCommit:        "91ce236824a9d875601679aa80c63783fb0e8725",
 				BuildDate:        "2019-08-07T11:26:06Z",
-				KumaCpCompatible: true,
 			},
 			Envoy: &mesh_proto.EnvoyVersion{
 				Version:          "1.15.0",
 				Build:            "hash/1.15.0/RELEASE",
-				KumaDpCompatible: true,
 			},
 		}
 
@@ -110,6 +108,18 @@ var _ = Describe("DataplaneMetadataFromXdsMetadata", func() {
 		metadata := xds.DataplaneMetadataFromXdsMetadata(node)
 
 		// then
-		Expect(metadata.Version).To(matchers.MatchProto(version))
+		// We don't want to validate KumaDpVersion.KumaCpCompatible
+		// as compatibility checks are currently checked in insights
+		// ref: https://github.com/kumahq/kuma/issues/4203
+		Expect(metadata.GetVersion().GetEnvoy()).
+			To(matchers.MatchProto(version.GetEnvoy()))
+		Expect(metadata.GetVersion().GetKumaDp().GetVersion()).
+			To(Equal(version.GetKumaDp().GetVersion()))
+		Expect(metadata.GetVersion().GetKumaDp().GetBuildDate()).
+			To(Equal(version.GetKumaDp().GetBuildDate()))
+		Expect(metadata.GetVersion().GetKumaDp().GetGitCommit()).
+			To(Equal(version.GetKumaDp().GetGitCommit()))
+		Expect(metadata.GetVersion().GetKumaDp().GetGitTag()).
+			To(Equal(version.GetKumaDp().GetGitTag()))
 	})
 })

--- a/pkg/xds/server/callbacks/dataplane_status_tracker_test.go
+++ b/pkg/xds/server/callbacks/dataplane_status_tracker_test.go
@@ -123,10 +123,10 @@ var _ = Describe("DataplaneStatusTracker", func() {
 			streamID := int64(1)
 			version := mesh_proto.Version{
 				KumaDp: &mesh_proto.KumaDpVersion{
-					Version:          "0.0.1",
-					GitTag:           "v0.0.1",
-					GitCommit:        "91ce236824a9d875601679aa80c63783fb0e8725",
-					BuildDate:        "2019-08-07T11:26:06Z",
+					Version:   "0.0.1",
+					GitTag:    "v0.0.1",
+					GitCommit: "91ce236824a9d875601679aa80c63783fb0e8725",
+					BuildDate: "2019-08-07T11:26:06Z",
 				},
 				Envoy: &mesh_proto.EnvoyVersion{
 					Version: "1.15.0",


### PR DESCRIPTION
### Summary

We don't want to validate KumaDpVersion.KumaCpCompatible
as compatibility checks are currently checked in insights

### Full changelog

n/a

### Issues resolved

n/a

### Documentation

- [ ] ~~Link to the website [documentation PR](https://github.com/kumahq/kuma-website/pull/XXX)~~

### Testing

- [x] Unit tests
- [ ] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes

### Backwards compatibility

- [ ] ~~Update [`UPGRADE.md`](/UPGRADE.md) with any steps users will need to take when upgrading.~~
- [x] Add `backport-to-stable` label if the code follows our [backporting policy](/CONTRIBUTING.md#backporting)
