### PR TITLE
fix(gateway): use MeshGatewayInstance mesh annotation when matching

### DIFF
--- a/pkg/plugins/runtime/k8s/controllers/gateway_instance_controller.go
+++ b/pkg/plugins/runtime/k8s/controllers/gateway_instance_controller.go
@@ -26,6 +26,7 @@ import (
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	"github.com/kumahq/kuma/pkg/core/resources/manager"
+	"github.com/kumahq/kuma/pkg/core/resources/store"
 	k8s_common "github.com/kumahq/kuma/pkg/plugins/common/k8s"
 	mesh_k8s "github.com/kumahq/kuma/pkg/plugins/resources/k8s/native/api/v1alpha1"
 	"github.com/kumahq/kuma/pkg/plugins/runtime/gateway/match"
@@ -97,8 +98,13 @@ func (r *GatewayInstanceReconciler) createOrUpdateService(
 ) (*kube_core.Service, error) {
 	gatewayList := &core_mesh.MeshGatewayResourceList{}
 
-	// XXX BUG: Needs to refer to specific mesh
-	if err := r.ResourceManager.List(ctx, gatewayList); err != nil {
+	ns := kube_core.Namespace{}
+	if err := r.Client.Get(ctx, kube_types.NamespacedName{Name: gatewayInstance.Namespace}, &ns); err != nil {
+		return nil, errors.Wrap(err, "unable to get Namespace of MeshGatewayInstance")
+	}
+
+	mesh := k8s_util.MeshOf(gatewayInstance, &ns)
+	if err := r.ResourceManager.List(ctx, gatewayList, store.ListByMesh(mesh)); err != nil {
 		return nil, err
 	}
 	gateway := match.Gateway(gatewayList, func(selector mesh_proto.TagSelector) bool {


### PR DESCRIPTION
### Summary

Or should `MeshGatewayInstance` have a `.mesh` field like `MeshGateway`/`MeshGatewayRoute`? 
Since it's namespaced though, it will need to respect the Namespace annotation either way.