### PR TITLE
fix(kuma-cp): '/config_dump' request if Global CP is on Kubernetes

### DIFF
--- a/pkg/core/bootstrap/bootstrap.go
+++ b/pkg/core/bootstrap/bootstrap.go
@@ -113,7 +113,9 @@ func buildRuntime(appCtx context.Context, cfg kuma_cp.Config) (core_runtime.Runt
 	builder.WithKDSContext(kds_context.DefaultContext(builder.ResourceManager(), cfg.Multizone.Zone.Name))
 
 	if cfg.Mode == config_core.Global {
-		builder.WithEnvoyAdminClient(admin.NewKDSEnvoyAdminClient(builder.KDSContext().XdsConfigStreams))
+		builder.WithEnvoyAdminClient(admin.NewKDSEnvoyAdminClient(
+			builder.KDSContext().XdsConfigStreams,
+			cfg.Store.Type == store.KubernetesStore))
 	} else {
 		envoyAdminClient, err := admin.NewEnvoyAdminClient(
 			builder.ResourceManager(),


### PR DESCRIPTION
### Summary

Trim namespace suffix before making a `/config_dump` request if Global CP is on Kubernetes

### Full changelog

* trim namespace suffix

### Issues resolved

Fix https://github.com/kumahq/kuma/issues/4357

### Documentation

- [ ] Link to the website [documentation PR](https://github.com/kumahq/kuma-website/pull/XXX)

### Testing

- [X] Unit tests
- [ ] E2E tests
- [ ] Manual testing on Universal
- [X] Manual testing on Kubernetes

### Backwards compatibility

- [ ] Update [`UPGRADE.md`](/UPGRADE.md) with any steps users will need to take when upgrading.
- [X] Add `backport-to-stable` label if the code follows our [backporting policy](/CONTRIBUTING.md#backporting)
