### PR TITLE
feat(k8s): add 'kuma' to CRD categories

### DIFF
--- a/app/kumactl/cmd/install/testdata/install-control-plane.cni-enabled.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.cni-enabled.golden.yaml
@@ -76,6 +76,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: CircuitBreaker
     listKind: CircuitBreakerList
     plural: circuitbreakers
@@ -119,6 +121,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: ContainerPatch
     listKind: ContainerPatchList
     plural: containerpatches
@@ -227,6 +231,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: MeshGateway
     listKind: MeshGatewayList
     plural: meshgateways
@@ -270,6 +276,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: MeshInsight
     listKind: MeshInsightList
     plural: meshinsights
@@ -313,6 +321,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: ProxyTemplate
     listKind: ProxyTemplateList
     plural: proxytemplates
@@ -356,6 +366,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: RateLimit
     listKind: RateLimitList
     plural: ratelimits
@@ -399,6 +411,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: Retry
     listKind: RetryList
     plural: retries
@@ -442,6 +456,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: ServiceInsight
     listKind: ServiceInsightList
     plural: serviceinsights
@@ -485,6 +501,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: Timeout
     listKind: TimeoutList
     plural: timeouts
@@ -528,6 +546,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: TrafficLog
     listKind: TrafficLogList
     plural: trafficlogs
@@ -571,6 +591,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: TrafficPermission
     listKind: TrafficPermissionList
     plural: trafficpermissions
@@ -614,6 +636,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: TrafficRoute
     listKind: TrafficRouteList
     plural: trafficroutes
@@ -657,6 +681,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: DataplaneInsight
     listKind: DataplaneInsightList
     plural: dataplaneinsights
@@ -700,6 +726,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: TrafficTrace
     listKind: TrafficTraceList
     plural: traffictraces
@@ -743,6 +771,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: VirtualOutbound
     listKind: VirtualOutboundList
     plural: virtualoutbounds
@@ -786,6 +816,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: ZoneEgress
     listKind: ZoneEgressList
     plural: zoneegresses
@@ -829,6 +861,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: ZoneEgressInsight
     listKind: ZoneEgressInsightList
     plural: zoneegressinsights
@@ -872,6 +906,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: ZoneIngress
     listKind: ZoneIngressList
     plural: zoneingresses
@@ -915,6 +951,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: ZoneIngressInsight
     listKind: ZoneIngressInsightList
     plural: zoneingressinsights
@@ -959,6 +997,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: ZoneInsight
     listKind: ZoneInsightList
     plural: zoneinsights
@@ -1002,6 +1042,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: Zone
     listKind: ZoneList
     plural: zones
@@ -1045,6 +1087,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: Dataplane
     listKind: DataplaneList
     plural: dataplanes
@@ -1088,6 +1132,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: ExternalService
     listKind: ExternalServiceList
     plural: externalservices
@@ -1131,6 +1177,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: FaultInjection
     listKind: FaultInjectionList
     plural: faultinjections
@@ -1174,6 +1222,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: HealthCheck
     listKind: HealthCheckList
     plural: healthchecks
@@ -1217,6 +1267,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: Mesh
     listKind: MeshList
     plural: meshes
@@ -1260,6 +1312,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: MeshGatewayInstance
     listKind: MeshGatewayInstanceList
     plural: meshgatewayinstances
@@ -1510,6 +1564,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: MeshGatewayRoute
     listKind: MeshGatewayRouteList
     plural: meshgatewayroutes

--- a/app/kumactl/cmd/install/testdata/install-control-plane.defaults.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.defaults.golden.yaml
@@ -42,6 +42,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: CircuitBreaker
     listKind: CircuitBreakerList
     plural: circuitbreakers
@@ -85,6 +87,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: ContainerPatch
     listKind: ContainerPatchList
     plural: containerpatches
@@ -193,6 +197,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: MeshGateway
     listKind: MeshGatewayList
     plural: meshgateways
@@ -236,6 +242,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: MeshInsight
     listKind: MeshInsightList
     plural: meshinsights
@@ -279,6 +287,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: ProxyTemplate
     listKind: ProxyTemplateList
     plural: proxytemplates
@@ -322,6 +332,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: RateLimit
     listKind: RateLimitList
     plural: ratelimits
@@ -365,6 +377,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: Retry
     listKind: RetryList
     plural: retries
@@ -408,6 +422,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: ServiceInsight
     listKind: ServiceInsightList
     plural: serviceinsights
@@ -451,6 +467,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: Timeout
     listKind: TimeoutList
     plural: timeouts
@@ -494,6 +512,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: TrafficLog
     listKind: TrafficLogList
     plural: trafficlogs
@@ -537,6 +557,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: TrafficPermission
     listKind: TrafficPermissionList
     plural: trafficpermissions
@@ -580,6 +602,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: TrafficRoute
     listKind: TrafficRouteList
     plural: trafficroutes
@@ -623,6 +647,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: DataplaneInsight
     listKind: DataplaneInsightList
     plural: dataplaneinsights
@@ -666,6 +692,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: TrafficTrace
     listKind: TrafficTraceList
     plural: traffictraces
@@ -709,6 +737,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: VirtualOutbound
     listKind: VirtualOutboundList
     plural: virtualoutbounds
@@ -752,6 +782,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: ZoneEgress
     listKind: ZoneEgressList
     plural: zoneegresses
@@ -795,6 +827,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: ZoneEgressInsight
     listKind: ZoneEgressInsightList
     plural: zoneegressinsights
@@ -838,6 +872,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: ZoneIngress
     listKind: ZoneIngressList
     plural: zoneingresses
@@ -881,6 +917,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: ZoneIngressInsight
     listKind: ZoneIngressInsightList
     plural: zoneingressinsights
@@ -925,6 +963,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: ZoneInsight
     listKind: ZoneInsightList
     plural: zoneinsights
@@ -968,6 +1008,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: Zone
     listKind: ZoneList
     plural: zones
@@ -1011,6 +1053,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: Dataplane
     listKind: DataplaneList
     plural: dataplanes
@@ -1054,6 +1098,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: ExternalService
     listKind: ExternalServiceList
     plural: externalservices
@@ -1097,6 +1143,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: FaultInjection
     listKind: FaultInjectionList
     plural: faultinjections
@@ -1140,6 +1188,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: HealthCheck
     listKind: HealthCheckList
     plural: healthchecks
@@ -1183,6 +1233,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: Mesh
     listKind: MeshList
     plural: meshes
@@ -1226,6 +1278,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: MeshGatewayInstance
     listKind: MeshGatewayInstanceList
     plural: meshgatewayinstances
@@ -1476,6 +1530,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: MeshGatewayRoute
     listKind: MeshGatewayRouteList
     plural: meshgatewayroutes

--- a/app/kumactl/cmd/install/testdata/install-control-plane.global.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.global.golden.yaml
@@ -42,6 +42,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: CircuitBreaker
     listKind: CircuitBreakerList
     plural: circuitbreakers
@@ -85,6 +87,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: ContainerPatch
     listKind: ContainerPatchList
     plural: containerpatches
@@ -193,6 +197,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: MeshGateway
     listKind: MeshGatewayList
     plural: meshgateways
@@ -236,6 +242,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: MeshInsight
     listKind: MeshInsightList
     plural: meshinsights
@@ -279,6 +287,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: ProxyTemplate
     listKind: ProxyTemplateList
     plural: proxytemplates
@@ -322,6 +332,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: RateLimit
     listKind: RateLimitList
     plural: ratelimits
@@ -365,6 +377,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: Retry
     listKind: RetryList
     plural: retries
@@ -408,6 +422,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: ServiceInsight
     listKind: ServiceInsightList
     plural: serviceinsights
@@ -451,6 +467,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: Timeout
     listKind: TimeoutList
     plural: timeouts
@@ -494,6 +512,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: TrafficLog
     listKind: TrafficLogList
     plural: trafficlogs
@@ -537,6 +557,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: TrafficPermission
     listKind: TrafficPermissionList
     plural: trafficpermissions
@@ -580,6 +602,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: TrafficRoute
     listKind: TrafficRouteList
     plural: trafficroutes
@@ -623,6 +647,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: DataplaneInsight
     listKind: DataplaneInsightList
     plural: dataplaneinsights
@@ -666,6 +692,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: TrafficTrace
     listKind: TrafficTraceList
     plural: traffictraces
@@ -709,6 +737,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: VirtualOutbound
     listKind: VirtualOutboundList
     plural: virtualoutbounds
@@ -752,6 +782,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: ZoneEgress
     listKind: ZoneEgressList
     plural: zoneegresses
@@ -795,6 +827,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: ZoneEgressInsight
     listKind: ZoneEgressInsightList
     plural: zoneegressinsights
@@ -838,6 +872,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: ZoneIngress
     listKind: ZoneIngressList
     plural: zoneingresses
@@ -881,6 +917,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: ZoneIngressInsight
     listKind: ZoneIngressInsightList
     plural: zoneingressinsights
@@ -925,6 +963,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: ZoneInsight
     listKind: ZoneInsightList
     plural: zoneinsights
@@ -968,6 +1008,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: Zone
     listKind: ZoneList
     plural: zones
@@ -1011,6 +1053,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: Dataplane
     listKind: DataplaneList
     plural: dataplanes
@@ -1054,6 +1098,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: ExternalService
     listKind: ExternalServiceList
     plural: externalservices
@@ -1097,6 +1143,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: FaultInjection
     listKind: FaultInjectionList
     plural: faultinjections
@@ -1140,6 +1188,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: HealthCheck
     listKind: HealthCheckList
     plural: healthchecks
@@ -1183,6 +1233,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: Mesh
     listKind: MeshList
     plural: meshes
@@ -1226,6 +1278,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: MeshGatewayInstance
     listKind: MeshGatewayInstanceList
     plural: meshgatewayinstances
@@ -1476,6 +1530,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: MeshGatewayRoute
     listKind: MeshGatewayRouteList
     plural: meshgatewayroutes

--- a/app/kumactl/cmd/install/testdata/install-control-plane.override-env-vars.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.override-env-vars.golden.yaml
@@ -42,6 +42,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: CircuitBreaker
     listKind: CircuitBreakerList
     plural: circuitbreakers
@@ -85,6 +87,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: ContainerPatch
     listKind: ContainerPatchList
     plural: containerpatches
@@ -193,6 +197,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: MeshGateway
     listKind: MeshGatewayList
     plural: meshgateways
@@ -236,6 +242,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: MeshInsight
     listKind: MeshInsightList
     plural: meshinsights
@@ -279,6 +287,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: ProxyTemplate
     listKind: ProxyTemplateList
     plural: proxytemplates
@@ -322,6 +332,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: RateLimit
     listKind: RateLimitList
     plural: ratelimits
@@ -365,6 +377,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: Retry
     listKind: RetryList
     plural: retries
@@ -408,6 +422,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: ServiceInsight
     listKind: ServiceInsightList
     plural: serviceinsights
@@ -451,6 +467,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: Timeout
     listKind: TimeoutList
     plural: timeouts
@@ -494,6 +512,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: TrafficLog
     listKind: TrafficLogList
     plural: trafficlogs
@@ -537,6 +557,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: TrafficPermission
     listKind: TrafficPermissionList
     plural: trafficpermissions
@@ -580,6 +602,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: TrafficRoute
     listKind: TrafficRouteList
     plural: trafficroutes
@@ -623,6 +647,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: DataplaneInsight
     listKind: DataplaneInsightList
     plural: dataplaneinsights
@@ -666,6 +692,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: TrafficTrace
     listKind: TrafficTraceList
     plural: traffictraces
@@ -709,6 +737,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: VirtualOutbound
     listKind: VirtualOutboundList
     plural: virtualoutbounds
@@ -752,6 +782,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: ZoneEgress
     listKind: ZoneEgressList
     plural: zoneegresses
@@ -795,6 +827,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: ZoneEgressInsight
     listKind: ZoneEgressInsightList
     plural: zoneegressinsights
@@ -838,6 +872,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: ZoneIngress
     listKind: ZoneIngressList
     plural: zoneingresses
@@ -881,6 +917,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: ZoneIngressInsight
     listKind: ZoneIngressInsightList
     plural: zoneingressinsights
@@ -925,6 +963,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: ZoneInsight
     listKind: ZoneInsightList
     plural: zoneinsights
@@ -968,6 +1008,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: Zone
     listKind: ZoneList
     plural: zones
@@ -1011,6 +1053,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: Dataplane
     listKind: DataplaneList
     plural: dataplanes
@@ -1054,6 +1098,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: ExternalService
     listKind: ExternalServiceList
     plural: externalservices
@@ -1097,6 +1143,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: FaultInjection
     listKind: FaultInjectionList
     plural: faultinjections
@@ -1140,6 +1188,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: HealthCheck
     listKind: HealthCheckList
     plural: healthchecks
@@ -1183,6 +1233,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: Mesh
     listKind: MeshList
     plural: meshes
@@ -1226,6 +1278,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: MeshGatewayInstance
     listKind: MeshGatewayInstanceList
     plural: meshgatewayinstances
@@ -1476,6 +1530,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: MeshGatewayRoute
     listKind: MeshGatewayRouteList
     plural: meshgatewayroutes

--- a/app/kumactl/cmd/install/testdata/install-control-plane.overrides.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.overrides.golden.yaml
@@ -42,6 +42,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: CircuitBreaker
     listKind: CircuitBreakerList
     plural: circuitbreakers
@@ -85,6 +87,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: ContainerPatch
     listKind: ContainerPatchList
     plural: containerpatches
@@ -193,6 +197,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: MeshGatewayRoute
     listKind: MeshGatewayRouteList
     plural: meshgatewayroutes
@@ -236,6 +242,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: MeshGateway
     listKind: MeshGatewayList
     plural: meshgateways
@@ -279,6 +287,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: MeshInsight
     listKind: MeshInsightList
     plural: meshinsights
@@ -322,6 +332,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: ProxyTemplate
     listKind: ProxyTemplateList
     plural: proxytemplates
@@ -365,6 +377,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: RateLimit
     listKind: RateLimitList
     plural: ratelimits
@@ -408,6 +422,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: Retry
     listKind: RetryList
     plural: retries
@@ -451,6 +467,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: ServiceInsight
     listKind: ServiceInsightList
     plural: serviceinsights
@@ -494,6 +512,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: Timeout
     listKind: TimeoutList
     plural: timeouts
@@ -537,6 +557,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: TrafficLog
     listKind: TrafficLogList
     plural: trafficlogs
@@ -580,6 +602,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: TrafficPermission
     listKind: TrafficPermissionList
     plural: trafficpermissions
@@ -623,6 +647,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: DataplaneInsight
     listKind: DataplaneInsightList
     plural: dataplaneinsights
@@ -666,6 +692,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: TrafficRoute
     listKind: TrafficRouteList
     plural: trafficroutes
@@ -709,6 +737,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: TrafficTrace
     listKind: TrafficTraceList
     plural: traffictraces
@@ -752,6 +782,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: VirtualOutbound
     listKind: VirtualOutboundList
     plural: virtualoutbounds
@@ -795,6 +827,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: ZoneEgress
     listKind: ZoneEgressList
     plural: zoneegresses
@@ -838,6 +872,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: ZoneEgressInsight
     listKind: ZoneEgressInsightList
     plural: zoneegressinsights
@@ -881,6 +917,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: ZoneIngress
     listKind: ZoneIngressList
     plural: zoneingresses
@@ -924,6 +962,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: ZoneIngressInsight
     listKind: ZoneIngressInsightList
     plural: zoneingressinsights
@@ -968,6 +1008,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: ZoneInsight
     listKind: ZoneInsightList
     plural: zoneinsights
@@ -1011,6 +1053,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: Zone
     listKind: ZoneList
     plural: zones
@@ -1054,6 +1098,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: Dataplane
     listKind: DataplaneList
     plural: dataplanes
@@ -1097,6 +1143,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: ExternalService
     listKind: ExternalServiceList
     plural: externalservices
@@ -1140,6 +1188,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: FaultInjection
     listKind: FaultInjectionList
     plural: faultinjections
@@ -1183,6 +1233,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: HealthCheck
     listKind: HealthCheckList
     plural: healthchecks
@@ -1226,6 +1278,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: Mesh
     listKind: MeshList
     plural: meshes
@@ -1269,6 +1323,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: MeshGatewayConfig
     listKind: MeshGatewayConfigList
     plural: meshgatewayconfigs
@@ -1388,6 +1444,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: MeshGatewayInstance
     listKind: MeshGatewayInstanceList
     plural: meshgatewayinstances

--- a/app/kumactl/cmd/install/testdata/install-control-plane.with-egress.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.with-egress.golden.yaml
@@ -52,6 +52,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: CircuitBreaker
     listKind: CircuitBreakerList
     plural: circuitbreakers
@@ -95,6 +97,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: ContainerPatch
     listKind: ContainerPatchList
     plural: containerpatches
@@ -203,6 +207,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: MeshGateway
     listKind: MeshGatewayList
     plural: meshgateways
@@ -246,6 +252,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: MeshInsight
     listKind: MeshInsightList
     plural: meshinsights
@@ -289,6 +297,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: ProxyTemplate
     listKind: ProxyTemplateList
     plural: proxytemplates
@@ -332,6 +342,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: RateLimit
     listKind: RateLimitList
     plural: ratelimits
@@ -375,6 +387,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: Retry
     listKind: RetryList
     plural: retries
@@ -418,6 +432,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: ServiceInsight
     listKind: ServiceInsightList
     plural: serviceinsights
@@ -461,6 +477,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: Timeout
     listKind: TimeoutList
     plural: timeouts
@@ -504,6 +522,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: TrafficLog
     listKind: TrafficLogList
     plural: trafficlogs
@@ -547,6 +567,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: TrafficPermission
     listKind: TrafficPermissionList
     plural: trafficpermissions
@@ -590,6 +612,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: TrafficRoute
     listKind: TrafficRouteList
     plural: trafficroutes
@@ -633,6 +657,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: DataplaneInsight
     listKind: DataplaneInsightList
     plural: dataplaneinsights
@@ -676,6 +702,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: TrafficTrace
     listKind: TrafficTraceList
     plural: traffictraces
@@ -719,6 +747,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: VirtualOutbound
     listKind: VirtualOutboundList
     plural: virtualoutbounds
@@ -762,6 +792,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: ZoneEgress
     listKind: ZoneEgressList
     plural: zoneegresses
@@ -805,6 +837,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: ZoneEgressInsight
     listKind: ZoneEgressInsightList
     plural: zoneegressinsights
@@ -848,6 +882,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: ZoneIngress
     listKind: ZoneIngressList
     plural: zoneingresses
@@ -891,6 +927,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: ZoneIngressInsight
     listKind: ZoneIngressInsightList
     plural: zoneingressinsights
@@ -935,6 +973,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: ZoneInsight
     listKind: ZoneInsightList
     plural: zoneinsights
@@ -978,6 +1018,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: Zone
     listKind: ZoneList
     plural: zones
@@ -1021,6 +1063,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: Dataplane
     listKind: DataplaneList
     plural: dataplanes
@@ -1064,6 +1108,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: ExternalService
     listKind: ExternalServiceList
     plural: externalservices
@@ -1107,6 +1153,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: FaultInjection
     listKind: FaultInjectionList
     plural: faultinjections
@@ -1150,6 +1198,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: HealthCheck
     listKind: HealthCheckList
     plural: healthchecks
@@ -1193,6 +1243,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: Mesh
     listKind: MeshList
     plural: meshes
@@ -1236,6 +1288,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: MeshGatewayInstance
     listKind: MeshGatewayInstanceList
     plural: meshgatewayinstances
@@ -1486,6 +1540,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: MeshGatewayRoute
     listKind: MeshGatewayRouteList
     plural: meshgatewayroutes

--- a/app/kumactl/cmd/install/testdata/install-control-plane.with-helm-set.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.with-helm-set.yaml
@@ -62,6 +62,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: CircuitBreaker
     listKind: CircuitBreakerList
     plural: circuitbreakers
@@ -105,6 +107,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: ContainerPatch
     listKind: ContainerPatchList
     plural: containerpatches
@@ -213,6 +217,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: MeshGateway
     listKind: MeshGatewayList
     plural: meshgateways
@@ -256,6 +262,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: MeshInsight
     listKind: MeshInsightList
     plural: meshinsights
@@ -299,6 +307,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: ProxyTemplate
     listKind: ProxyTemplateList
     plural: proxytemplates
@@ -342,6 +352,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: RateLimit
     listKind: RateLimitList
     plural: ratelimits
@@ -385,6 +397,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: Retry
     listKind: RetryList
     plural: retries
@@ -428,6 +442,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: ServiceInsight
     listKind: ServiceInsightList
     plural: serviceinsights
@@ -471,6 +487,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: Timeout
     listKind: TimeoutList
     plural: timeouts
@@ -514,6 +532,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: TrafficLog
     listKind: TrafficLogList
     plural: trafficlogs
@@ -557,6 +577,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: TrafficPermission
     listKind: TrafficPermissionList
     plural: trafficpermissions
@@ -600,6 +622,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: TrafficRoute
     listKind: TrafficRouteList
     plural: trafficroutes
@@ -643,6 +667,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: DataplaneInsight
     listKind: DataplaneInsightList
     plural: dataplaneinsights
@@ -686,6 +712,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: TrafficTrace
     listKind: TrafficTraceList
     plural: traffictraces
@@ -729,6 +757,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: VirtualOutbound
     listKind: VirtualOutboundList
     plural: virtualoutbounds
@@ -772,6 +802,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: ZoneEgress
     listKind: ZoneEgressList
     plural: zoneegresses
@@ -815,6 +847,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: ZoneEgressInsight
     listKind: ZoneEgressInsightList
     plural: zoneegressinsights
@@ -858,6 +892,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: ZoneIngress
     listKind: ZoneIngressList
     plural: zoneingresses
@@ -901,6 +937,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: ZoneIngressInsight
     listKind: ZoneIngressInsightList
     plural: zoneingressinsights
@@ -945,6 +983,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: ZoneInsight
     listKind: ZoneInsightList
     plural: zoneinsights
@@ -988,6 +1028,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: Zone
     listKind: ZoneList
     plural: zones
@@ -1031,6 +1073,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: Dataplane
     listKind: DataplaneList
     plural: dataplanes
@@ -1074,6 +1118,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: ExternalService
     listKind: ExternalServiceList
     plural: externalservices
@@ -1117,6 +1163,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: FaultInjection
     listKind: FaultInjectionList
     plural: faultinjections
@@ -1160,6 +1208,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: HealthCheck
     listKind: HealthCheckList
     plural: healthchecks
@@ -1203,6 +1253,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: Mesh
     listKind: MeshList
     plural: meshes
@@ -1246,6 +1298,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: MeshGatewayInstance
     listKind: MeshGatewayInstanceList
     plural: meshgatewayinstances
@@ -1496,6 +1550,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: MeshGatewayRoute
     listKind: MeshGatewayRouteList
     plural: meshgatewayroutes

--- a/app/kumactl/cmd/install/testdata/install-control-plane.with-helm-values.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.with-helm-values.yaml
@@ -42,6 +42,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: CircuitBreaker
     listKind: CircuitBreakerList
     plural: circuitbreakers
@@ -85,6 +87,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: ContainerPatch
     listKind: ContainerPatchList
     plural: containerpatches
@@ -193,6 +197,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: MeshGateway
     listKind: MeshGatewayList
     plural: meshgateways
@@ -236,6 +242,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: MeshInsight
     listKind: MeshInsightList
     plural: meshinsights
@@ -279,6 +287,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: ProxyTemplate
     listKind: ProxyTemplateList
     plural: proxytemplates
@@ -322,6 +332,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: RateLimit
     listKind: RateLimitList
     plural: ratelimits
@@ -365,6 +377,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: Retry
     listKind: RetryList
     plural: retries
@@ -408,6 +422,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: ServiceInsight
     listKind: ServiceInsightList
     plural: serviceinsights
@@ -451,6 +467,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: Timeout
     listKind: TimeoutList
     plural: timeouts
@@ -494,6 +512,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: TrafficLog
     listKind: TrafficLogList
     plural: trafficlogs
@@ -537,6 +557,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: TrafficPermission
     listKind: TrafficPermissionList
     plural: trafficpermissions
@@ -580,6 +602,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: TrafficRoute
     listKind: TrafficRouteList
     plural: trafficroutes
@@ -623,6 +647,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: DataplaneInsight
     listKind: DataplaneInsightList
     plural: dataplaneinsights
@@ -666,6 +692,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: TrafficTrace
     listKind: TrafficTraceList
     plural: traffictraces
@@ -709,6 +737,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: VirtualOutbound
     listKind: VirtualOutboundList
     plural: virtualoutbounds
@@ -752,6 +782,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: ZoneEgress
     listKind: ZoneEgressList
     plural: zoneegresses
@@ -795,6 +827,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: ZoneEgressInsight
     listKind: ZoneEgressInsightList
     plural: zoneegressinsights
@@ -838,6 +872,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: ZoneIngress
     listKind: ZoneIngressList
     plural: zoneingresses
@@ -881,6 +917,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: ZoneIngressInsight
     listKind: ZoneIngressInsightList
     plural: zoneingressinsights
@@ -925,6 +963,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: ZoneInsight
     listKind: ZoneInsightList
     plural: zoneinsights
@@ -968,6 +1008,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: Zone
     listKind: ZoneList
     plural: zones
@@ -1011,6 +1053,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: Dataplane
     listKind: DataplaneList
     plural: dataplanes
@@ -1054,6 +1098,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: ExternalService
     listKind: ExternalServiceList
     plural: externalservices
@@ -1097,6 +1143,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: FaultInjection
     listKind: FaultInjectionList
     plural: faultinjections
@@ -1140,6 +1188,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: HealthCheck
     listKind: HealthCheckList
     plural: healthchecks
@@ -1183,6 +1233,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: Mesh
     listKind: MeshList
     plural: meshes
@@ -1226,6 +1278,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: MeshGatewayInstance
     listKind: MeshGatewayInstanceList
     plural: meshgatewayinstances
@@ -1476,6 +1530,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: MeshGatewayRoute
     listKind: MeshGatewayRouteList
     plural: meshgatewayroutes

--- a/app/kumactl/cmd/install/testdata/install-control-plane.with-ingress.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.with-ingress.golden.yaml
@@ -52,6 +52,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: CircuitBreaker
     listKind: CircuitBreakerList
     plural: circuitbreakers
@@ -95,6 +97,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: ContainerPatch
     listKind: ContainerPatchList
     plural: containerpatches
@@ -203,6 +207,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: MeshGateway
     listKind: MeshGatewayList
     plural: meshgateways
@@ -246,6 +252,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: MeshInsight
     listKind: MeshInsightList
     plural: meshinsights
@@ -289,6 +297,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: ProxyTemplate
     listKind: ProxyTemplateList
     plural: proxytemplates
@@ -332,6 +342,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: RateLimit
     listKind: RateLimitList
     plural: ratelimits
@@ -375,6 +387,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: Retry
     listKind: RetryList
     plural: retries
@@ -418,6 +432,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: ServiceInsight
     listKind: ServiceInsightList
     plural: serviceinsights
@@ -461,6 +477,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: Timeout
     listKind: TimeoutList
     plural: timeouts
@@ -504,6 +522,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: TrafficLog
     listKind: TrafficLogList
     plural: trafficlogs
@@ -547,6 +567,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: TrafficPermission
     listKind: TrafficPermissionList
     plural: trafficpermissions
@@ -590,6 +612,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: TrafficRoute
     listKind: TrafficRouteList
     plural: trafficroutes
@@ -633,6 +657,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: DataplaneInsight
     listKind: DataplaneInsightList
     plural: dataplaneinsights
@@ -676,6 +702,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: TrafficTrace
     listKind: TrafficTraceList
     plural: traffictraces
@@ -719,6 +747,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: VirtualOutbound
     listKind: VirtualOutboundList
     plural: virtualoutbounds
@@ -762,6 +792,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: ZoneEgress
     listKind: ZoneEgressList
     plural: zoneegresses
@@ -805,6 +837,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: ZoneEgressInsight
     listKind: ZoneEgressInsightList
     plural: zoneegressinsights
@@ -848,6 +882,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: ZoneIngress
     listKind: ZoneIngressList
     plural: zoneingresses
@@ -891,6 +927,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: ZoneIngressInsight
     listKind: ZoneIngressInsightList
     plural: zoneingressinsights
@@ -935,6 +973,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: ZoneInsight
     listKind: ZoneInsightList
     plural: zoneinsights
@@ -978,6 +1018,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: Zone
     listKind: ZoneList
     plural: zones
@@ -1021,6 +1063,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: Dataplane
     listKind: DataplaneList
     plural: dataplanes
@@ -1064,6 +1108,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: ExternalService
     listKind: ExternalServiceList
     plural: externalservices
@@ -1107,6 +1153,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: FaultInjection
     listKind: FaultInjectionList
     plural: faultinjections
@@ -1150,6 +1198,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: HealthCheck
     listKind: HealthCheckList
     plural: healthchecks
@@ -1193,6 +1243,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: Mesh
     listKind: MeshList
     plural: meshes
@@ -1236,6 +1288,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: MeshGatewayInstance
     listKind: MeshGatewayInstanceList
     plural: meshgatewayinstances
@@ -1486,6 +1540,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: MeshGatewayRoute
     listKind: MeshGatewayRouteList
     plural: meshgatewayroutes

--- a/app/kumactl/cmd/install/testdata/install-control-plane.zone.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.zone.golden.yaml
@@ -42,6 +42,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: CircuitBreaker
     listKind: CircuitBreakerList
     plural: circuitbreakers
@@ -85,6 +87,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: ContainerPatch
     listKind: ContainerPatchList
     plural: containerpatches
@@ -193,6 +197,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: MeshGateway
     listKind: MeshGatewayList
     plural: meshgateways
@@ -236,6 +242,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: MeshInsight
     listKind: MeshInsightList
     plural: meshinsights
@@ -279,6 +287,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: ProxyTemplate
     listKind: ProxyTemplateList
     plural: proxytemplates
@@ -322,6 +332,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: RateLimit
     listKind: RateLimitList
     plural: ratelimits
@@ -365,6 +377,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: Retry
     listKind: RetryList
     plural: retries
@@ -408,6 +422,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: ServiceInsight
     listKind: ServiceInsightList
     plural: serviceinsights
@@ -451,6 +467,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: Timeout
     listKind: TimeoutList
     plural: timeouts
@@ -494,6 +512,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: TrafficLog
     listKind: TrafficLogList
     plural: trafficlogs
@@ -537,6 +557,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: TrafficPermission
     listKind: TrafficPermissionList
     plural: trafficpermissions
@@ -580,6 +602,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: TrafficRoute
     listKind: TrafficRouteList
     plural: trafficroutes
@@ -623,6 +647,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: DataplaneInsight
     listKind: DataplaneInsightList
     plural: dataplaneinsights
@@ -666,6 +692,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: TrafficTrace
     listKind: TrafficTraceList
     plural: traffictraces
@@ -709,6 +737,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: VirtualOutbound
     listKind: VirtualOutboundList
     plural: virtualoutbounds
@@ -752,6 +782,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: ZoneEgress
     listKind: ZoneEgressList
     plural: zoneegresses
@@ -795,6 +827,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: ZoneEgressInsight
     listKind: ZoneEgressInsightList
     plural: zoneegressinsights
@@ -838,6 +872,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: ZoneIngress
     listKind: ZoneIngressList
     plural: zoneingresses
@@ -881,6 +917,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: ZoneIngressInsight
     listKind: ZoneIngressInsightList
     plural: zoneingressinsights
@@ -925,6 +963,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: ZoneInsight
     listKind: ZoneInsightList
     plural: zoneinsights
@@ -968,6 +1008,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: Zone
     listKind: ZoneList
     plural: zones
@@ -1011,6 +1053,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: Dataplane
     listKind: DataplaneList
     plural: dataplanes
@@ -1054,6 +1098,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: ExternalService
     listKind: ExternalServiceList
     plural: externalservices
@@ -1097,6 +1143,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: FaultInjection
     listKind: FaultInjectionList
     plural: faultinjections
@@ -1140,6 +1188,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: HealthCheck
     listKind: HealthCheckList
     plural: healthchecks
@@ -1183,6 +1233,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: Mesh
     listKind: MeshList
     plural: meshes
@@ -1226,6 +1278,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: MeshGatewayInstance
     listKind: MeshGatewayInstanceList
     plural: meshgatewayinstances
@@ -1476,6 +1530,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: MeshGatewayRoute
     listKind: MeshGatewayRouteList
     plural: meshgatewayroutes

--- a/app/kumactl/cmd/install/testdata/install-crds.all.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-crds.all.golden.yaml
@@ -10,6 +10,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: CircuitBreaker
     listKind: CircuitBreakerList
     plural: circuitbreakers
@@ -53,6 +55,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: ContainerPatch
     listKind: ContainerPatchList
     plural: containerpatches
@@ -161,6 +165,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: DataplaneInsight
     listKind: DataplaneInsightList
     plural: dataplaneinsights
@@ -204,6 +210,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: Dataplane
     listKind: DataplaneList
     plural: dataplanes
@@ -247,6 +255,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: ExternalService
     listKind: ExternalServiceList
     plural: externalservices
@@ -290,6 +300,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: FaultInjection
     listKind: FaultInjectionList
     plural: faultinjections
@@ -333,6 +345,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: HealthCheck
     listKind: HealthCheckList
     plural: healthchecks
@@ -376,6 +390,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: Mesh
     listKind: MeshList
     plural: meshes
@@ -419,6 +435,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: MeshGatewayInstance
     listKind: MeshGatewayInstanceList
     plural: meshgatewayinstances
@@ -669,6 +687,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: MeshGatewayRoute
     listKind: MeshGatewayRouteList
     plural: meshgatewayroutes
@@ -712,6 +732,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: MeshGateway
     listKind: MeshGatewayList
     plural: meshgateways
@@ -755,6 +777,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: MeshInsight
     listKind: MeshInsightList
     plural: meshinsights
@@ -798,6 +822,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: ProxyTemplate
     listKind: ProxyTemplateList
     plural: proxytemplates
@@ -841,6 +867,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: RateLimit
     listKind: RateLimitList
     plural: ratelimits
@@ -884,6 +912,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: Retry
     listKind: RetryList
     plural: retries
@@ -927,6 +957,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: ServiceInsight
     listKind: ServiceInsightList
     plural: serviceinsights
@@ -970,6 +1002,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: Timeout
     listKind: TimeoutList
     plural: timeouts
@@ -1013,6 +1047,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: TrafficLog
     listKind: TrafficLogList
     plural: trafficlogs
@@ -1056,6 +1092,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: TrafficPermission
     listKind: TrafficPermissionList
     plural: trafficpermissions
@@ -1099,6 +1137,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: TrafficRoute
     listKind: TrafficRouteList
     plural: trafficroutes
@@ -1142,6 +1182,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: TrafficTrace
     listKind: TrafficTraceList
     plural: traffictraces
@@ -1185,6 +1227,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: VirtualOutbound
     listKind: VirtualOutboundList
     plural: virtualoutbounds
@@ -1228,6 +1272,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: ZoneEgress
     listKind: ZoneEgressList
     plural: zoneegresses
@@ -1271,6 +1317,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: ZoneEgressInsight
     listKind: ZoneEgressInsightList
     plural: zoneegressinsights
@@ -1314,6 +1362,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: ZoneIngress
     listKind: ZoneIngressList
     plural: zoneingresses
@@ -1357,6 +1407,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: ZoneIngressInsight
     listKind: ZoneIngressInsightList
     plural: zoneingressinsights
@@ -1401,6 +1453,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: ZoneInsight
     listKind: ZoneInsightList
     plural: zoneinsights
@@ -1444,6 +1498,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: Zone
     listKind: ZoneList
     plural: zones

--- a/app/kumactl/cmd/install/testdata/install-crds.experimental-gatewayapi.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-crds.experimental-gatewayapi.golden.yaml
@@ -10,6 +10,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: CircuitBreaker
     listKind: CircuitBreakerList
     plural: circuitbreakers
@@ -53,6 +55,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: ContainerPatch
     listKind: ContainerPatchList
     plural: containerpatches
@@ -161,6 +165,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: DataplaneInsight
     listKind: DataplaneInsightList
     plural: dataplaneinsights
@@ -204,6 +210,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: Dataplane
     listKind: DataplaneList
     plural: dataplanes
@@ -247,6 +255,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: ExternalService
     listKind: ExternalServiceList
     plural: externalservices
@@ -290,6 +300,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: FaultInjection
     listKind: FaultInjectionList
     plural: faultinjections
@@ -333,6 +345,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: HealthCheck
     listKind: HealthCheckList
     plural: healthchecks
@@ -376,6 +390,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: Mesh
     listKind: MeshList
     plural: meshes
@@ -419,6 +435,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: MeshGatewayConfig
     listKind: MeshGatewayConfigList
     plural: meshgatewayconfigs
@@ -538,6 +556,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: MeshGatewayInstance
     listKind: MeshGatewayInstanceList
     plural: meshgatewayinstances
@@ -788,6 +808,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: MeshGatewayRoute
     listKind: MeshGatewayRouteList
     plural: meshgatewayroutes
@@ -831,6 +853,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: MeshGateway
     listKind: MeshGatewayList
     plural: meshgateways
@@ -874,6 +898,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: MeshInsight
     listKind: MeshInsightList
     plural: meshinsights
@@ -917,6 +943,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: ProxyTemplate
     listKind: ProxyTemplateList
     plural: proxytemplates
@@ -960,6 +988,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: RateLimit
     listKind: RateLimitList
     plural: ratelimits
@@ -1003,6 +1033,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: Retry
     listKind: RetryList
     plural: retries
@@ -1046,6 +1078,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: ServiceInsight
     listKind: ServiceInsightList
     plural: serviceinsights
@@ -1089,6 +1123,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: Timeout
     listKind: TimeoutList
     plural: timeouts
@@ -1132,6 +1168,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: TrafficLog
     listKind: TrafficLogList
     plural: trafficlogs
@@ -1175,6 +1213,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: TrafficPermission
     listKind: TrafficPermissionList
     plural: trafficpermissions
@@ -1218,6 +1258,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: TrafficRoute
     listKind: TrafficRouteList
     plural: trafficroutes
@@ -1261,6 +1303,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: TrafficTrace
     listKind: TrafficTraceList
     plural: traffictraces
@@ -1304,6 +1348,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: VirtualOutbound
     listKind: VirtualOutboundList
     plural: virtualoutbounds
@@ -1347,6 +1393,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: ZoneEgress
     listKind: ZoneEgressList
     plural: zoneegresses
@@ -1390,6 +1438,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: ZoneEgressInsight
     listKind: ZoneEgressInsightList
     plural: zoneegressinsights
@@ -1433,6 +1483,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: ZoneIngress
     listKind: ZoneIngressList
     plural: zoneingresses
@@ -1476,6 +1528,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: ZoneIngressInsight
     listKind: ZoneIngressInsightList
     plural: zoneingressinsights
@@ -1520,6 +1574,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: ZoneInsight
     listKind: ZoneInsightList
     plural: zoneinsights
@@ -1563,6 +1619,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: Zone
     listKind: ZoneList
     plural: zones

--- a/deployments/charts/kuma/crds/kuma.io_circuitbreakers.yaml
+++ b/deployments/charts/kuma/crds/kuma.io_circuitbreakers.yaml
@@ -9,6 +9,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: CircuitBreaker
     listKind: CircuitBreakerList
     plural: circuitbreakers

--- a/deployments/charts/kuma/crds/kuma.io_containerpatches.yaml
+++ b/deployments/charts/kuma/crds/kuma.io_containerpatches.yaml
@@ -9,6 +9,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: ContainerPatch
     listKind: ContainerPatchList
     plural: containerpatches

--- a/deployments/charts/kuma/crds/kuma.io_dataplaneinsights.yaml
+++ b/deployments/charts/kuma/crds/kuma.io_dataplaneinsights.yaml
@@ -9,6 +9,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: DataplaneInsight
     listKind: DataplaneInsightList
     plural: dataplaneinsights

--- a/deployments/charts/kuma/crds/kuma.io_dataplanes.yaml
+++ b/deployments/charts/kuma/crds/kuma.io_dataplanes.yaml
@@ -9,6 +9,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: Dataplane
     listKind: DataplaneList
     plural: dataplanes

--- a/deployments/charts/kuma/crds/kuma.io_externalservices.yaml
+++ b/deployments/charts/kuma/crds/kuma.io_externalservices.yaml
@@ -9,6 +9,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: ExternalService
     listKind: ExternalServiceList
     plural: externalservices

--- a/deployments/charts/kuma/crds/kuma.io_faultinjections.yaml
+++ b/deployments/charts/kuma/crds/kuma.io_faultinjections.yaml
@@ -9,6 +9,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: FaultInjection
     listKind: FaultInjectionList
     plural: faultinjections

--- a/deployments/charts/kuma/crds/kuma.io_healthchecks.yaml
+++ b/deployments/charts/kuma/crds/kuma.io_healthchecks.yaml
@@ -9,6 +9,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: HealthCheck
     listKind: HealthCheckList
     plural: healthchecks

--- a/deployments/charts/kuma/crds/kuma.io_meshes.yaml
+++ b/deployments/charts/kuma/crds/kuma.io_meshes.yaml
@@ -9,6 +9,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: Mesh
     listKind: MeshList
     plural: meshes

--- a/deployments/charts/kuma/crds/kuma.io_meshgatewayconfigs.yaml
+++ b/deployments/charts/kuma/crds/kuma.io_meshgatewayconfigs.yaml
@@ -9,6 +9,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: MeshGatewayConfig
     listKind: MeshGatewayConfigList
     plural: meshgatewayconfigs

--- a/deployments/charts/kuma/crds/kuma.io_meshgatewayinstances.yaml
+++ b/deployments/charts/kuma/crds/kuma.io_meshgatewayinstances.yaml
@@ -9,6 +9,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: MeshGatewayInstance
     listKind: MeshGatewayInstanceList
     plural: meshgatewayinstances

--- a/deployments/charts/kuma/crds/kuma.io_meshgatewayroutes.yaml
+++ b/deployments/charts/kuma/crds/kuma.io_meshgatewayroutes.yaml
@@ -9,6 +9,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: MeshGatewayRoute
     listKind: MeshGatewayRouteList
     plural: meshgatewayroutes

--- a/deployments/charts/kuma/crds/kuma.io_meshgateways.yaml
+++ b/deployments/charts/kuma/crds/kuma.io_meshgateways.yaml
@@ -9,6 +9,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: MeshGateway
     listKind: MeshGatewayList
     plural: meshgateways

--- a/deployments/charts/kuma/crds/kuma.io_meshinsights.yaml
+++ b/deployments/charts/kuma/crds/kuma.io_meshinsights.yaml
@@ -9,6 +9,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: MeshInsight
     listKind: MeshInsightList
     plural: meshinsights

--- a/deployments/charts/kuma/crds/kuma.io_proxytemplates.yaml
+++ b/deployments/charts/kuma/crds/kuma.io_proxytemplates.yaml
@@ -9,6 +9,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: ProxyTemplate
     listKind: ProxyTemplateList
     plural: proxytemplates

--- a/deployments/charts/kuma/crds/kuma.io_ratelimits.yaml
+++ b/deployments/charts/kuma/crds/kuma.io_ratelimits.yaml
@@ -9,6 +9,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: RateLimit
     listKind: RateLimitList
     plural: ratelimits

--- a/deployments/charts/kuma/crds/kuma.io_retries.yaml
+++ b/deployments/charts/kuma/crds/kuma.io_retries.yaml
@@ -9,6 +9,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: Retry
     listKind: RetryList
     plural: retries

--- a/deployments/charts/kuma/crds/kuma.io_serviceinsights.yaml
+++ b/deployments/charts/kuma/crds/kuma.io_serviceinsights.yaml
@@ -9,6 +9,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: ServiceInsight
     listKind: ServiceInsightList
     plural: serviceinsights

--- a/deployments/charts/kuma/crds/kuma.io_timeouts.yaml
+++ b/deployments/charts/kuma/crds/kuma.io_timeouts.yaml
@@ -9,6 +9,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: Timeout
     listKind: TimeoutList
     plural: timeouts

--- a/deployments/charts/kuma/crds/kuma.io_trafficlogs.yaml
+++ b/deployments/charts/kuma/crds/kuma.io_trafficlogs.yaml
@@ -9,6 +9,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: TrafficLog
     listKind: TrafficLogList
     plural: trafficlogs

--- a/deployments/charts/kuma/crds/kuma.io_trafficpermissions.yaml
+++ b/deployments/charts/kuma/crds/kuma.io_trafficpermissions.yaml
@@ -9,6 +9,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: TrafficPermission
     listKind: TrafficPermissionList
     plural: trafficpermissions

--- a/deployments/charts/kuma/crds/kuma.io_trafficroutes.yaml
+++ b/deployments/charts/kuma/crds/kuma.io_trafficroutes.yaml
@@ -9,6 +9,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: TrafficRoute
     listKind: TrafficRouteList
     plural: trafficroutes

--- a/deployments/charts/kuma/crds/kuma.io_traffictraces.yaml
+++ b/deployments/charts/kuma/crds/kuma.io_traffictraces.yaml
@@ -9,6 +9,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: TrafficTrace
     listKind: TrafficTraceList
     plural: traffictraces

--- a/deployments/charts/kuma/crds/kuma.io_virtualoutbounds.yaml
+++ b/deployments/charts/kuma/crds/kuma.io_virtualoutbounds.yaml
@@ -9,6 +9,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: VirtualOutbound
     listKind: VirtualOutboundList
     plural: virtualoutbounds

--- a/deployments/charts/kuma/crds/kuma.io_zoneegresses.yaml
+++ b/deployments/charts/kuma/crds/kuma.io_zoneegresses.yaml
@@ -9,6 +9,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: ZoneEgress
     listKind: ZoneEgressList
     plural: zoneegresses

--- a/deployments/charts/kuma/crds/kuma.io_zoneegressinsights.yaml
+++ b/deployments/charts/kuma/crds/kuma.io_zoneegressinsights.yaml
@@ -9,6 +9,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: ZoneEgressInsight
     listKind: ZoneEgressInsightList
     plural: zoneegressinsights

--- a/deployments/charts/kuma/crds/kuma.io_zoneingresses.yaml
+++ b/deployments/charts/kuma/crds/kuma.io_zoneingresses.yaml
@@ -9,6 +9,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: ZoneIngress
     listKind: ZoneIngressList
     plural: zoneingresses

--- a/deployments/charts/kuma/crds/kuma.io_zoneingressinsights.yaml
+++ b/deployments/charts/kuma/crds/kuma.io_zoneingressinsights.yaml
@@ -9,6 +9,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: ZoneIngressInsight
     listKind: ZoneIngressInsightList
     plural: zoneingressinsights

--- a/deployments/charts/kuma/crds/kuma.io_zoneinsights.yaml
+++ b/deployments/charts/kuma/crds/kuma.io_zoneinsights.yaml
@@ -9,6 +9,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: ZoneInsight
     listKind: ZoneInsightList
     plural: zoneinsights

--- a/deployments/charts/kuma/crds/kuma.io_zones.yaml
+++ b/deployments/charts/kuma/crds/kuma.io_zones.yaml
@@ -9,6 +9,8 @@ metadata:
 spec:
   group: kuma.io
   names:
+    categories:
+    - kuma
     kind: Zone
     listKind: ZoneList
     plural: zones

--- a/pkg/plugins/resources/k8s/native/api/v1alpha1/container_patch.go
+++ b/pkg/plugins/resources/k8s/native/api/v1alpha1/container_patch.go
@@ -12,7 +12,7 @@ import (
 //
 // +k8s:deepcopy-gen=true
 // +kubebuilder:object:root=true
-// +kubebuilder:resource:scope=Namespaced
+// +kubebuilder:resource:categories=kuma,scope=Namespaced
 type ContainerPatch struct {
 	kube_meta.TypeMeta   `json:",inline"`
 	kube_meta.ObjectMeta `json:"metadata,omitempty"`

--- a/pkg/plugins/resources/k8s/native/api/v1alpha1/mesh_gateway_config.go
+++ b/pkg/plugins/resources/k8s/native/api/v1alpha1/mesh_gateway_config.go
@@ -7,7 +7,7 @@ import (
 
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
-// +kubebuilder:resource:scope=Cluster
+// +kubebuilder:resource:categories=kuma,scope=Cluster
 
 // MeshGatewayConfig holds the configuration of a MeshGateway. A
 // GatewayClass can refer to a MeshGatewayConfig via parametersRef.

--- a/pkg/plugins/resources/k8s/native/api/v1alpha1/mesh_gateway_instance.go
+++ b/pkg/plugins/resources/k8s/native/api/v1alpha1/mesh_gateway_instance.go
@@ -7,6 +7,7 @@ import (
 
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
+// +kubebuilder:resource:categories=kuma,scope=Namespaced
 
 // MeshGatewayInstance represents a managed instance of a dataplane proxy for a Kuma
 // Gateway.

--- a/pkg/plugins/resources/k8s/native/api/v1alpha1/zz_generated.mesh.go
+++ b/pkg/plugins/resources/k8s/native/api/v1alpha1/zz_generated.mesh.go
@@ -18,7 +18,7 @@ import (
 )
 
 // +kubebuilder:object:root=true
-// +kubebuilder:resource:scope=Cluster
+// +kubebuilder:resource:categories=kuma,scope=Cluster
 type CircuitBreaker struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -113,7 +113,7 @@ func init() {
 }
 
 // +kubebuilder:object:root=true
-// +kubebuilder:resource:scope=Namespaced
+// +kubebuilder:resource:categories=kuma,scope=Namespaced
 type Dataplane struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -208,7 +208,7 @@ func init() {
 }
 
 // +kubebuilder:object:root=true
-// +kubebuilder:resource:scope=Namespaced
+// +kubebuilder:resource:categories=kuma,scope=Namespaced
 type DataplaneInsight struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -305,7 +305,7 @@ func init() {
 }
 
 // +kubebuilder:object:root=true
-// +kubebuilder:resource:scope=Cluster
+// +kubebuilder:resource:categories=kuma,scope=Cluster
 type ExternalService struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -400,7 +400,7 @@ func init() {
 }
 
 // +kubebuilder:object:root=true
-// +kubebuilder:resource:scope=Cluster
+// +kubebuilder:resource:categories=kuma,scope=Cluster
 type FaultInjection struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -495,7 +495,7 @@ func init() {
 }
 
 // +kubebuilder:object:root=true
-// +kubebuilder:resource:scope=Cluster
+// +kubebuilder:resource:categories=kuma,scope=Cluster
 type HealthCheck struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -590,7 +590,7 @@ func init() {
 }
 
 // +kubebuilder:object:root=true
-// +kubebuilder:resource:scope=Cluster
+// +kubebuilder:resource:categories=kuma,scope=Cluster
 type Mesh struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -685,7 +685,7 @@ func init() {
 }
 
 // +kubebuilder:object:root=true
-// +kubebuilder:resource:scope=Cluster
+// +kubebuilder:resource:categories=kuma,scope=Cluster
 type MeshGateway struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -780,7 +780,7 @@ func init() {
 }
 
 // +kubebuilder:object:root=true
-// +kubebuilder:resource:scope=Cluster
+// +kubebuilder:resource:categories=kuma,scope=Cluster
 type MeshGatewayRoute struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -875,7 +875,7 @@ func init() {
 }
 
 // +kubebuilder:object:root=true
-// +kubebuilder:resource:scope=Cluster
+// +kubebuilder:resource:categories=kuma,scope=Cluster
 type MeshInsight struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -970,7 +970,7 @@ func init() {
 }
 
 // +kubebuilder:object:root=true
-// +kubebuilder:resource:scope=Cluster
+// +kubebuilder:resource:categories=kuma,scope=Cluster
 type ProxyTemplate struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -1065,7 +1065,7 @@ func init() {
 }
 
 // +kubebuilder:object:root=true
-// +kubebuilder:resource:scope=Cluster
+// +kubebuilder:resource:categories=kuma,scope=Cluster
 type RateLimit struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -1160,7 +1160,7 @@ func init() {
 }
 
 // +kubebuilder:object:root=true
-// +kubebuilder:resource:scope=Cluster
+// +kubebuilder:resource:categories=kuma,scope=Cluster
 type Retry struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -1255,7 +1255,7 @@ func init() {
 }
 
 // +kubebuilder:object:root=true
-// +kubebuilder:resource:scope=Cluster
+// +kubebuilder:resource:categories=kuma,scope=Cluster
 type ServiceInsight struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -1350,7 +1350,7 @@ func init() {
 }
 
 // +kubebuilder:object:root=true
-// +kubebuilder:resource:scope=Cluster
+// +kubebuilder:resource:categories=kuma,scope=Cluster
 type Timeout struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -1445,7 +1445,7 @@ func init() {
 }
 
 // +kubebuilder:object:root=true
-// +kubebuilder:resource:scope=Cluster
+// +kubebuilder:resource:categories=kuma,scope=Cluster
 type TrafficLog struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -1540,7 +1540,7 @@ func init() {
 }
 
 // +kubebuilder:object:root=true
-// +kubebuilder:resource:scope=Cluster
+// +kubebuilder:resource:categories=kuma,scope=Cluster
 type TrafficPermission struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -1635,7 +1635,7 @@ func init() {
 }
 
 // +kubebuilder:object:root=true
-// +kubebuilder:resource:scope=Cluster
+// +kubebuilder:resource:categories=kuma,scope=Cluster
 type TrafficRoute struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -1730,7 +1730,7 @@ func init() {
 }
 
 // +kubebuilder:object:root=true
-// +kubebuilder:resource:scope=Cluster
+// +kubebuilder:resource:categories=kuma,scope=Cluster
 type TrafficTrace struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -1825,7 +1825,7 @@ func init() {
 }
 
 // +kubebuilder:object:root=true
-// +kubebuilder:resource:scope=Cluster
+// +kubebuilder:resource:categories=kuma,scope=Cluster
 type VirtualOutbound struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -1920,7 +1920,7 @@ func init() {
 }
 
 // +kubebuilder:object:root=true
-// +kubebuilder:resource:scope=Namespaced
+// +kubebuilder:resource:categories=kuma,scope=Namespaced
 type ZoneEgress struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -2015,7 +2015,7 @@ func init() {
 }
 
 // +kubebuilder:object:root=true
-// +kubebuilder:resource:scope=Namespaced
+// +kubebuilder:resource:categories=kuma,scope=Namespaced
 type ZoneEgressInsight struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -2110,7 +2110,7 @@ func init() {
 }
 
 // +kubebuilder:object:root=true
-// +kubebuilder:resource:scope=Namespaced
+// +kubebuilder:resource:categories=kuma,scope=Namespaced
 type ZoneIngress struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -2205,7 +2205,7 @@ func init() {
 }
 
 // +kubebuilder:object:root=true
-// +kubebuilder:resource:scope=Namespaced
+// +kubebuilder:resource:categories=kuma,scope=Namespaced
 type ZoneIngressInsight struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/pkg/plugins/resources/k8s/native/api/v1alpha1/zz_generated.system.go
+++ b/pkg/plugins/resources/k8s/native/api/v1alpha1/zz_generated.system.go
@@ -18,7 +18,7 @@ import (
 )
 
 // +kubebuilder:object:root=true
-// +kubebuilder:resource:scope=Cluster
+// +kubebuilder:resource:categories=kuma,scope=Cluster
 type Zone struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -113,7 +113,7 @@ func init() {
 }
 
 // +kubebuilder:object:root=true
-// +kubebuilder:resource:scope=Cluster
+// +kubebuilder:resource:categories=kuma,scope=Cluster
 type ZoneInsight struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/tools/policy-gen/protoc-gen-kumapolicy/crd.go
+++ b/tools/policy-gen/protoc-gen-kumapolicy/crd.go
@@ -38,9 +38,9 @@ import (
 
 // +kubebuilder:object:root=true
 {{- if .ScopeNamespace }}
-// +kubebuilder:resource:scope=Namespaced
+// +kubebuilder:resource:categories=kuma,scope=Namespaced
 {{- else }}
-// +kubebuilder:resource:scope=Cluster
+// +kubebuilder:resource:categories=kuma,scope=Cluster
 {{- end}}
 {{- if .StorageVersion }}
 // +kubebuilder:storageversion

--- a/tools/resource-gen/main.go
+++ b/tools/resource-gen/main.go
@@ -45,9 +45,9 @@ import (
 
 // +kubebuilder:object:root=true
 {{- if .ScopeNamespace }}
-// +kubebuilder:resource:scope=Namespaced
+// +kubebuilder:resource:categories=kuma,scope=Namespaced
 {{- else }}
-// +kubebuilder:resource:scope=Cluster
+// +kubebuilder:resource:categories=kuma,scope=Cluster
 {{- end}}
 type {{.ResourceType}} struct {
 	metav1.TypeMeta   {{ $tk }}json:",inline"{{ $tk }}


### PR DESCRIPTION
### Summary

Just an idea. Useful? Not useful?

```
$ kubectl get kuma
NAME                                                 AGE
circuitbreaker.kuma.io/circuit-breaker-all-default   106s

NAME                                          AGE
trafficpermission.kuma.io/allow-all-default   106s

NAME                              AGE
retry.kuma.io/retry-all-default   106s

NAME                                          AGE
serviceinsight.kuma.io/all-services-default   96s

NAME                                  AGE
timeout.kuma.io/timeout-all-default   106s

NAME                          AGE
meshinsight.kuma.io/default   96s

NAME                   AGE
mesh.kuma.io/default   106s

NAME                                     AGE
trafficroute.kuma.io/route-all-default   106s
```