### PR TITLE
chore(kuma-cp): change config map reconciler log level

### DIFF
--- a/pkg/dns/vips_allocator.go
+++ b/pkg/dns/vips_allocator.go
@@ -129,7 +129,7 @@ func (d *VIPsAllocator) createOrUpdateMeshVIPConfig(
 	if len(changes) == 0 {
 		return nil
 	}
-	Log.Info("mesh vip changes", "mesh", mesh, "changes", changes)
+	Log.Info("mesh VIPs changed", "mesh", mesh, "changes", changes)
 	return d.persistence.Set(ctx, mesh, out)
 }
 

--- a/pkg/plugins/runtime/k8s/controllers/configmap_controller.go
+++ b/pkg/plugins/runtime/k8s/controllers/configmap_controller.go
@@ -47,7 +47,7 @@ func (r *ConfigMapReconciler) Reconcile(ctx context.Context, req kube_ctrl.Reque
 	}
 
 	l := r.Log.WithValues("mesh", mesh)
-	l.Info("updating VIPs")
+	l.V(1).Info("reconcile VIPs")
 
 	viewModificator := func(view *vips.VirtualOutboundMeshView) error {
 		return nil
@@ -79,7 +79,7 @@ func (r *ConfigMapReconciler) Reconcile(ctx context.Context, req kube_ctrl.Reque
 		return kube_ctrl.Result{}, err
 	}
 
-	l.Info("VIPs updated")
+	l.V(1).Info("VIPs reconciled")
 
 	return kube_ctrl.Result{}, nil
 }


### PR DESCRIPTION
### Summary

These logs are confusing in my opinion.

Log says `updating VIPs`, but we are really reconciling VIPs, it does not mean that we are making any change.
`VIPs updated` suggest that VIPs were updated, but that might not be the case if nothing has changed.

Processes like watchdogs, reconcilers etc. are executed periodically or on some action, but very often they don't change the state of the system. IMHO we should log the activity on V1 to reduce the noise and we should log the actual action on V0.

Change of state action is already logged in `vips_allocator`.

### Issues resolved

No issues reported.

### Documentation

~- [ ] Link to the website [documentation PR](https://github.com/kumahq/kuma-website/pull/XXX)~

### Testing

- [ ] Unit tests
- [ ] E2E tests
- [X] Manual testing on Universal
- [X] Manual testing on Kubernetes

### Backwards compatibility

- [ ] Update [`UPGRADE.md`](/UPGRADE.md) with any steps users will need to take when upgrading.
- [ ] Add `backport-to-stable` label if the code follows our [backporting policy](/CONTRIBUTING.md#backporting)
