### PR TITLE
feat(kuma-cp): customize envoy log level

### DIFF
--- a/app/kuma-dp/cmd/run.go
+++ b/app/kuma-dp/cmd/run.go
@@ -75,6 +75,10 @@ func newRunCmd(opts kuma_cmd.RunCmdOpts, rootCtx *RootContext) *cobra.Command {
 				return errors.Errorf("invalid proxy type %q", cfg.Dataplane.ProxyType)
 			}
 
+			if cfg.DataplaneRuntime.EnvoyLogLevel == "" {
+				cfg.DataplaneRuntime.EnvoyLogLevel = rootCtx.LogLevel.String()
+			}
+
 			proxyResource, err = readResource(cmd, &cfg.DataplaneRuntime)
 			if err != nil {
 				runLog.Error(err, "failed to read policy", "proxyType", cfg.Dataplane.ProxyType)
@@ -169,7 +173,6 @@ func newRunCmd(opts kuma_cmd.RunCmdOpts, rootCtx *RootContext) *cobra.Command {
 				Stdout:    cmd.OutOrStdout(),
 				Stderr:    cmd.OutOrStderr(),
 				Quit:      shouldQuit,
-				LogLevel:  rootCtx.LogLevel,
 			}
 
 			if cfg.DNS.Enabled &&
@@ -289,6 +292,7 @@ func newRunCmd(opts kuma_cmd.RunCmdOpts, rootCtx *RootContext) *cobra.Command {
 	cmd.PersistentFlags().StringVar(&cfg.DataplaneRuntime.Resource, "dataplane", "", "Dataplane template to apply (YAML or JSON)")
 	cmd.PersistentFlags().StringVarP(&cfg.DataplaneRuntime.ResourcePath, "dataplane-file", "d", "", "Path to Dataplane template to apply (YAML or JSON)")
 	cmd.PersistentFlags().StringToStringVarP(&cfg.DataplaneRuntime.ResourceVars, "dataplane-var", "v", map[string]string{}, "Variables to replace Dataplane template")
+	cmd.PersistentFlags().StringVar(&cfg.DataplaneRuntime.EnvoyLogLevel, "envoy-log-level", "", "Envoy log level. Available values are: [trace][debug][info][warning|warn][error][critical][off]. By default it inherits Kuma DP logging level.")
 	cmd.PersistentFlags().BoolVar(&cfg.DNS.Enabled, "dns-enabled", cfg.DNS.Enabled, "If true then builtin DNS functionality is enabled and CoreDNS server is started")
 	cmd.PersistentFlags().Uint32Var(&cfg.DNS.EnvoyDNSPort, "dns-envoy-port", cfg.DNS.EnvoyDNSPort, "A port that handles Virtual IP resolving by Envoy. CoreDNS should be configured that it first tries to use this DNS resolver and then the real one")
 	cmd.PersistentFlags().Uint32Var(&cfg.DNS.CoreDNSPort, "dns-coredns-port", cfg.DNS.CoreDNSPort, "A port that handles DNS requests. When transparent proxy is enabled then iptables will redirect DNS traffic to this port.")

--- a/app/kuma-dp/pkg/dataplane/envoy/envoy.go
+++ b/app/kuma-dp/pkg/dataplane/envoy/envoy.go
@@ -21,7 +21,6 @@ import (
 	"github.com/kumahq/kuma/pkg/core"
 	"github.com/kumahq/kuma/pkg/core/resources/model/rest"
 	"github.com/kumahq/kuma/pkg/core/runtime/component"
-	pkg_log "github.com/kumahq/kuma/pkg/log"
 	"github.com/kumahq/kuma/pkg/util/files"
 	"github.com/kumahq/kuma/pkg/xds/bootstrap/types"
 )
@@ -48,7 +47,6 @@ type Opts struct {
 	Stdout          io.Writer
 	Stderr          io.Writer
 	Quit            chan struct{}
-	LogLevel        pkg_log.LogLevel
 }
 
 func New(opts Opts) (*Envoy, error) {
@@ -116,7 +114,7 @@ func (e *Envoy) Start(stop <-chan struct{}) error {
 		// and we don't expect users to do "hot restart" manually.
 		// so, let's turn it off to simplify getting started experience.
 		"--disable-hot-restart",
-		"--log-level", e.opts.LogLevel.String(),
+		"--log-level", e.opts.Config.DataplaneRuntime.EnvoyLogLevel,
 	}
 
 	// If the concurrency is explicit, use that. On Linux, users

--- a/app/kuma-dp/pkg/dataplane/envoy/envoy_test.go
+++ b/app/kuma-dp/pkg/dataplane/envoy/envoy_test.go
@@ -86,8 +86,9 @@ var _ = Describe("Envoy", func() {
 					DrainTime: 15 * time.Second,
 				},
 				DataplaneRuntime: kuma_dp.DataplaneRuntime{
-					BinaryPath: filepath.Join("testdata", "envoy-mock.exit-0.sh"),
-					ConfigDir:  configDir,
+					BinaryPath:    filepath.Join("testdata", "envoy-mock.exit-0.sh"),
+					ConfigDir:     configDir,
+					EnvoyLogLevel: "off",
 				},
 			}
 			expectedConfigFile := filepath.Join(configDir, "bootstrap.yaml")
@@ -145,9 +146,10 @@ var _ = Describe("Envoy", func() {
 					DrainTime: 15 * time.Second,
 				},
 				DataplaneRuntime: kuma_dp.DataplaneRuntime{
-					BinaryPath:  filepath.Join("testdata", "envoy-mock.exit-0.sh"),
-					ConfigDir:   configDir,
-					Concurrency: 9,
+					BinaryPath:    filepath.Join("testdata", "envoy-mock.exit-0.sh"),
+					ConfigDir:     configDir,
+					Concurrency:   9,
+					EnvoyLogLevel: "off",
 				},
 			}
 

--- a/docs/generated/cmd/kuma-dp/kuma-dp_run.md
+++ b/docs/generated/cmd/kuma-dp/kuma-dp_run.md
@@ -32,6 +32,7 @@ kuma-dp run [flags]
       --dns-prometheus-port uint32                A port for exposing Prometheus stats (default 19153)
       --dns-server-config-dir string              Directory in which DNS Server config will be generated
       --drain-time duration                       drain time for Envoy connections on Kuma DP shutdown (default 30s)
+      --envoy-log-level string                    Envoy log level. Available values are: [trace][debug][info][warning|warn][error][critical][off]. By default it inherits Kuma DP logging level.
   -h, --help                                      help for run
       --mesh string                               Mesh that Dataplane belongs to
       --name string                               Name of the Dataplane

--- a/pkg/config/app/kuma-dp/config.go
+++ b/pkg/config/app/kuma-dp/config.go
@@ -139,6 +139,10 @@ type DataplaneRuntime struct {
 	ResourcePath string `yaml:"resourcePath,omitempty" envconfig:"kuma_dataplane_runtime_resource_path"`
 	// ResourceVars are the StringToString values that can fill the Resource template
 	ResourceVars map[string]string `yaml:"resourceVars,omitempty"`
+	// EnvoyLogLevel is a level on which Envoy will log.
+	// Available values are: [trace][debug][info][warning|warn][error][critical][off]
+	// By default it inherits Kuma DP logging level.
+	EnvoyLogLevel string `yaml:"envoyLogLevel,omitempty" envconfig:"kuma_dataplane_runtime_envoy_log_level"`
 }
 
 var _ config.Config = &Config{}

--- a/pkg/config/app/kuma-dp/config_test.go
+++ b/pkg/config/app/kuma-dp/config_test.go
@@ -64,6 +64,7 @@ var _ = Describe("Config", func() {
 				"KUMA_DATAPLANE_RUNTIME_BINARY_PATH":                     "envoy.sh",
 				"KUMA_DATAPLANE_RUNTIME_CONFIG_DIR":                      "/var/run/envoy",
 				"KUMA_DATAPLANE_RUNTIME_TOKEN_PATH":                      "/tmp/token",
+				"KUMA_DATAPLANE_RUNTIME_ENVOY_LOG_LEVEL":                 "trace",
 				"KUMA_DNS_ENABLED":                                       "true",
 				"KUMA_DNS_CORE_DNS_PORT":                                 "5300",
 				"KUMA_DNS_CORE_DNS_EMPTY_PORT":                           "5301",
@@ -97,6 +98,7 @@ var _ = Describe("Config", func() {
 			Expect(cfg.DataplaneRuntime.BinaryPath).To(Equal("envoy.sh"))
 			Expect(cfg.DataplaneRuntime.ConfigDir).To(Equal("/var/run/envoy"))
 			Expect(cfg.DataplaneRuntime.TokenPath).To(Equal("/tmp/token"))
+			Expect(cfg.DataplaneRuntime.EnvoyLogLevel).To(Equal("trace"))
 			Expect(cfg.DNS.Enabled).To(BeTrue())
 			Expect(cfg.DNS.CoreDNSPort).To(Equal(uint32(5300)))
 			Expect(cfg.DNS.CoreDNSEmptyPort).To(Equal(uint32(5301)))

--- a/pkg/config/app/kuma-dp/testdata/valid-config.input.yaml
+++ b/pkg/config/app/kuma-dp/testdata/valid-config.input.yaml
@@ -12,3 +12,4 @@ dataplane:
 dataplaneRuntime:
   binaryPath: envoy.sh
   configDir: /var/run/envoy
+  envoyLogLevel: trace

--- a/pkg/plugins/runtime/k8s/containers/factory.go
+++ b/pkg/plugins/runtime/k8s/containers/factory.go
@@ -234,6 +234,12 @@ func (i *DataplaneProxyFactory) sidecarEnvVars(mesh string, podAnnotations map[s
 			Value: "false",
 		}
 	}
+	if logLevel, exist := metadata.Annotations(podAnnotations).GetString(metadata.KumaEnvoyLogLevel); exist {
+		envVars["KUMA_DATAPLANE_RUNTIME_ENVOY_LOG_LEVEL"] = kube_core.EnvVar{
+			Name:  "KUMA_DATAPLANE_RUNTIME_ENVOY_LOG_LEVEL",
+			Value: logLevel,
+		}
+	}
 
 	// override defaults with cfg env vars
 	for envName, envVal := range i.ContainerConfig.EnvVars {

--- a/pkg/plugins/runtime/k8s/metadata/annotations.go
+++ b/pkg/plugins/runtime/k8s/metadata/annotations.go
@@ -88,6 +88,10 @@ const (
 	// KumaContainerPatches is a comma-separated list of ContainerPatch names to be applied to injected containers on a given workload
 	KumaContainerPatches = "kuma.io/container-patches"
 
+	// KumaEnvoyLogLevel allows to control Envoy log level.
+	// Available values are: [trace][debug][info][warning|warn][error][critical][off]
+	KumaEnvoyLogLevel = "kuma.io/envoy-log-level"
+
 	// KumaMetricsPrometheusAggregatePath allows to specify which path for specific app should request for metrics
 	KumaMetricsPrometheusAggregatePath = "prometheus.metrics.kuma.io/aggregate-%s-path"
 	// KumaMetricsPrometheusAggregatePort allows to specify which port for specific app should request for metrics

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.30.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.30.golden.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     kuma.io/container-patches: container-patch-1
     kuma.io/envoy-admin-port: "9901"
+    kuma.io/envoy-log-level: trace
     kuma.io/mesh: default
     kuma.io/sidecar-drain-time: 10s
     kuma.io/sidecar-injected: "true"
@@ -73,6 +74,8 @@ spec:
       value: default
     - name: KUMA_DATAPLANE_NAME
       value: $(POD_NAME).$(POD_NAMESPACE)
+    - name: KUMA_DATAPLANE_RUNTIME_ENVOY_LOG_LEVEL
+      value: trace
     - name: KUMA_DATAPLANE_RUNTIME_TOKEN_PATH
       value: /var/run/secrets/kubernetes.io/serviceaccount/token
     - name: KUMA_DNS_ENABLED

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.30.input.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.30.input.yaml
@@ -6,6 +6,7 @@ metadata:
     run: busybox
   annotations:
     kuma.io/sidecar-drain-time: "10s"
+    kuma.io/envoy-log-level: "trace"
     kuma.io/container-patches: container-patch-1
 spec:
   containers:


### PR DESCRIPTION
### Summary

Expose Envoy log level. I did not want to introduce meaningless log levels to kuma-dp itself, so it's a separate flag.
On Kubernetes, you can customize it with annotation `kuma.io/envoy-log-level`.
If you want to customize it on all envoys, you can either use `KUMA_RUNTIME_KUBERNETES_INJECTOR_SIDECAR_CONTAINER_ENV_VARS` or ContainerPatch.

### Issues resolved

Fix #1820

### Documentation

- [ ] In progress

### Testing

- [X] Unit tests
- [ ] E2E tests
- [X] Manual testing on Universal
- [X] Manual testing on Kubernetes

### Backwards compatibility

~- [ ] Update [`UPGRADE.md`](/UPGRADE.md) with any steps users will need to take when upgrading.~
~- [ ] Add `backport-to-stable` label if the code follows our [backporting policy](/CONTRIBUTING.md#backporting)~
