### PR TITLE
fix(chart): remove replica from cp-deployment.yaml when autoscaling enabled

### DIFF
--- a/deployments/charts/kuma/templates/cp-deployment.yaml
+++ b/deployments/charts/kuma/templates/cp-deployment.yaml
@@ -21,7 +21,9 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels: {{ include "kuma.cpLabels" . | nindent 4 }}
 spec:
+  {{- if not .Values.controlPlane.autoscaling.enabled }}
   replicas: {{ .Values.controlPlane.replicas }}
+  {{- end }}
   strategy:
     rollingUpdate:
       maxSurge: 1

--- a/deployments/charts/kuma/templates/egress-deployment.yaml
+++ b/deployments/charts/kuma/templates/egress-deployment.yaml
@@ -10,7 +10,9 @@ spec:
     rollingUpdate:
       maxSurge: 1
       maxUnavailable: 0
+  {{- if not .Values.egress.autoscaling.enabled }}
   replicas: {{ .Values.egress.replicas }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "kuma.selectorLabels" . | nindent 6 }}

--- a/deployments/charts/kuma/templates/ingress-deployment.yaml
+++ b/deployments/charts/kuma/templates/ingress-deployment.yaml
@@ -10,7 +10,9 @@ spec:
     rollingUpdate:
       maxSurge: 1
       maxUnavailable: 0
+  {{- if not .Values.ingress.autoscaling.enabled }}
   replicas: {{ .Values.ingress.replicas }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "kuma.selectorLabels" . | nindent 6 }}


### PR DESCRIPTION
### Summary

This PR fixes cp-deployment.yaml replica count when `controlPlane.autoscaling.enabled == true`.

### Full changelog

* Added conditional replica count in `cp-deployment.yaml` when `controlPlane.autoscaling.enabled`
* Added conditional replica count in `egress-deployment.yaml` when `egress.autoscaling.enabled`
* Added conditional replica count in `ingress-deployment.yaml` when `ingress.autoscaling.enabled`