### PR TITLE
fix(kuma-cp): don't panic in webhook if k8s object can't convert to core resource

### DIFF
--- a/pkg/plugins/policies/donothingpolicy/k8s/v1alpha1/zz_generated.types.go
+++ b/pkg/plugins/policies/donothingpolicy/k8s/v1alpha1/zz_generated.types.go
@@ -54,8 +54,8 @@ func (cb *DoNothingPolicy) SetMesh(mesh string) {
 	cb.Mesh = mesh
 }
 
-func (cb *DoNothingPolicy) GetSpec() proto.Message {
-	return cb.Spec
+func (cb *DoNothingPolicy) GetSpec() (proto.Message, error) {
+	return cb.Spec, nil
 }
 
 func (cb *DoNothingPolicy) SetSpec(spec proto.Message) {

--- a/pkg/plugins/resources/k8s/caching_converter.go
+++ b/pkg/plugins/resources/k8s/caching_converter.go
@@ -43,14 +43,22 @@ func (c *cachingConverter) ToCoreResource(obj k8s_model.KubernetesObject, out co
 	if obj.GetResourceVersion() == "" {
 		// an absent of the ResourceVersion means we decode 'obj' from webhook request,
 		// all webhooks use SimpleConverter, so this is not supposed to happen
-		if err := out.SetSpec(obj.GetSpec()); err != nil {
+		spec, err := obj.GetSpec()
+		if err != nil {
+			return err
+		}
+		if err := out.SetSpec(spec); err != nil {
 			return err
 		}
 	}
 	if v, ok := c.cache.Get(key); ok {
 		return out.SetSpec(v.(core_model.ResourceSpec))
 	}
-	if err := out.SetSpec(obj.GetSpec()); err != nil {
+	spec, err := obj.GetSpec()
+	if err != nil {
+		return err
+	}
+	if err := out.SetSpec(spec); err != nil {
 		return err
 	}
 	c.cache.SetDefault(key, out.GetSpec())

--- a/pkg/plugins/resources/k8s/converter.go
+++ b/pkg/plugins/resources/k8s/converter.go
@@ -50,8 +50,11 @@ func (c *SimpleConverter) ToKubernetesList(rl core_model.ResourceList) (k8s_mode
 
 func (c *SimpleConverter) ToCoreResource(obj k8s_model.KubernetesObject, out core_model.Resource) error {
 	out.SetMeta(&KubernetesMetaAdapter{ObjectMeta: *obj.GetObjectMeta(), Mesh: obj.GetMesh()})
-	err := out.SetSpec(obj.GetSpec())
-	return err
+	spec, err := obj.GetSpec()
+	if err != nil {
+		return err
+	}
+	return out.SetSpec(spec)
 }
 
 func (c *SimpleConverter) ToCoreList(in k8s_model.KubernetesList, out core_model.ResourceList, predicate k8s_common.ConverterPredicate) error {

--- a/pkg/plugins/resources/k8s/native/api/v1alpha1/zz_generated.mesh.go
+++ b/pkg/plugins/resources/k8s/native/api/v1alpha1/zz_generated.mesh.go
@@ -61,15 +61,16 @@ func (cb *CircuitBreaker) SetMesh(mesh string) {
 	cb.Mesh = mesh
 }
 
-func (cb *CircuitBreaker) GetSpec() proto.Message {
+func (cb *CircuitBreaker) GetSpec() (proto.Message, error) {
 	spec := cb.Spec
 	m := mesh_proto.CircuitBreaker{}
 
 	if spec == nil || len(spec.Raw) == 0 {
-		return &m
+		return &m, nil
 	}
 
-	return util_proto.MustUnmarshalJSON(spec.Raw, &m)
+	err := util_proto.FromJSON(spec.Raw, &m)
+	return &m, err
 }
 
 func (cb *CircuitBreaker) SetSpec(spec proto.Message) {
@@ -156,15 +157,16 @@ func (cb *Dataplane) SetMesh(mesh string) {
 	cb.Mesh = mesh
 }
 
-func (cb *Dataplane) GetSpec() proto.Message {
+func (cb *Dataplane) GetSpec() (proto.Message, error) {
 	spec := cb.Spec
 	m := mesh_proto.Dataplane{}
 
 	if spec == nil || len(spec.Raw) == 0 {
-		return &m
+		return &m, nil
 	}
 
-	return util_proto.MustUnmarshalJSON(spec.Raw, &m)
+	err := util_proto.FromJSON(spec.Raw, &m)
+	return &m, err
 }
 
 func (cb *Dataplane) SetSpec(spec proto.Message) {
@@ -251,15 +253,16 @@ func (cb *DataplaneInsight) SetMesh(mesh string) {
 	cb.Mesh = mesh
 }
 
-func (cb *DataplaneInsight) GetSpec() proto.Message {
+func (cb *DataplaneInsight) GetSpec() (proto.Message, error) {
 	spec := cb.Status
 	m := mesh_proto.DataplaneInsight{}
 
 	if spec == nil || len(spec.Raw) == 0 {
-		return &m
+		return &m, nil
 	}
 
-	return util_proto.MustUnmarshalJSON(spec.Raw, &m)
+	err := util_proto.FromJSON(spec.Raw, &m)
+	return &m, err
 }
 
 func (cb *DataplaneInsight) SetSpec(spec proto.Message) {
@@ -348,15 +351,16 @@ func (cb *ExternalService) SetMesh(mesh string) {
 	cb.Mesh = mesh
 }
 
-func (cb *ExternalService) GetSpec() proto.Message {
+func (cb *ExternalService) GetSpec() (proto.Message, error) {
 	spec := cb.Spec
 	m := mesh_proto.ExternalService{}
 
 	if spec == nil || len(spec.Raw) == 0 {
-		return &m
+		return &m, nil
 	}
 
-	return util_proto.MustUnmarshalJSON(spec.Raw, &m)
+	err := util_proto.FromJSON(spec.Raw, &m)
+	return &m, err
 }
 
 func (cb *ExternalService) SetSpec(spec proto.Message) {
@@ -443,15 +447,16 @@ func (cb *FaultInjection) SetMesh(mesh string) {
 	cb.Mesh = mesh
 }
 
-func (cb *FaultInjection) GetSpec() proto.Message {
+func (cb *FaultInjection) GetSpec() (proto.Message, error) {
 	spec := cb.Spec
 	m := mesh_proto.FaultInjection{}
 
 	if spec == nil || len(spec.Raw) == 0 {
-		return &m
+		return &m, nil
 	}
 
-	return util_proto.MustUnmarshalJSON(spec.Raw, &m)
+	err := util_proto.FromJSON(spec.Raw, &m)
+	return &m, err
 }
 
 func (cb *FaultInjection) SetSpec(spec proto.Message) {
@@ -538,15 +543,16 @@ func (cb *HealthCheck) SetMesh(mesh string) {
 	cb.Mesh = mesh
 }
 
-func (cb *HealthCheck) GetSpec() proto.Message {
+func (cb *HealthCheck) GetSpec() (proto.Message, error) {
 	spec := cb.Spec
 	m := mesh_proto.HealthCheck{}
 
 	if spec == nil || len(spec.Raw) == 0 {
-		return &m
+		return &m, nil
 	}
 
-	return util_proto.MustUnmarshalJSON(spec.Raw, &m)
+	err := util_proto.FromJSON(spec.Raw, &m)
+	return &m, err
 }
 
 func (cb *HealthCheck) SetSpec(spec proto.Message) {
@@ -633,15 +639,16 @@ func (cb *Mesh) SetMesh(mesh string) {
 	cb.Mesh = mesh
 }
 
-func (cb *Mesh) GetSpec() proto.Message {
+func (cb *Mesh) GetSpec() (proto.Message, error) {
 	spec := cb.Spec
 	m := mesh_proto.Mesh{}
 
 	if spec == nil || len(spec.Raw) == 0 {
-		return &m
+		return &m, nil
 	}
 
-	return util_proto.MustUnmarshalJSON(spec.Raw, &m)
+	err := util_proto.FromJSON(spec.Raw, &m)
+	return &m, err
 }
 
 func (cb *Mesh) SetSpec(spec proto.Message) {
@@ -728,15 +735,16 @@ func (cb *MeshGateway) SetMesh(mesh string) {
 	cb.Mesh = mesh
 }
 
-func (cb *MeshGateway) GetSpec() proto.Message {
+func (cb *MeshGateway) GetSpec() (proto.Message, error) {
 	spec := cb.Spec
 	m := mesh_proto.MeshGateway{}
 
 	if spec == nil || len(spec.Raw) == 0 {
-		return &m
+		return &m, nil
 	}
 
-	return util_proto.MustUnmarshalJSON(spec.Raw, &m)
+	err := util_proto.FromJSON(spec.Raw, &m)
+	return &m, err
 }
 
 func (cb *MeshGateway) SetSpec(spec proto.Message) {
@@ -823,15 +831,16 @@ func (cb *MeshGatewayRoute) SetMesh(mesh string) {
 	cb.Mesh = mesh
 }
 
-func (cb *MeshGatewayRoute) GetSpec() proto.Message {
+func (cb *MeshGatewayRoute) GetSpec() (proto.Message, error) {
 	spec := cb.Spec
 	m := mesh_proto.MeshGatewayRoute{}
 
 	if spec == nil || len(spec.Raw) == 0 {
-		return &m
+		return &m, nil
 	}
 
-	return util_proto.MustUnmarshalJSON(spec.Raw, &m)
+	err := util_proto.FromJSON(spec.Raw, &m)
+	return &m, err
 }
 
 func (cb *MeshGatewayRoute) SetSpec(spec proto.Message) {
@@ -918,15 +927,16 @@ func (cb *MeshInsight) SetMesh(mesh string) {
 	cb.Mesh = mesh
 }
 
-func (cb *MeshInsight) GetSpec() proto.Message {
+func (cb *MeshInsight) GetSpec() (proto.Message, error) {
 	spec := cb.Spec
 	m := mesh_proto.MeshInsight{}
 
 	if spec == nil || len(spec.Raw) == 0 {
-		return &m
+		return &m, nil
 	}
 
-	return util_proto.MustUnmarshalJSON(spec.Raw, &m)
+	err := util_proto.FromJSON(spec.Raw, &m)
+	return &m, err
 }
 
 func (cb *MeshInsight) SetSpec(spec proto.Message) {
@@ -1013,15 +1023,16 @@ func (cb *ProxyTemplate) SetMesh(mesh string) {
 	cb.Mesh = mesh
 }
 
-func (cb *ProxyTemplate) GetSpec() proto.Message {
+func (cb *ProxyTemplate) GetSpec() (proto.Message, error) {
 	spec := cb.Spec
 	m := mesh_proto.ProxyTemplate{}
 
 	if spec == nil || len(spec.Raw) == 0 {
-		return &m
+		return &m, nil
 	}
 
-	return util_proto.MustUnmarshalJSON(spec.Raw, &m)
+	err := util_proto.FromJSON(spec.Raw, &m)
+	return &m, err
 }
 
 func (cb *ProxyTemplate) SetSpec(spec proto.Message) {
@@ -1108,15 +1119,16 @@ func (cb *RateLimit) SetMesh(mesh string) {
 	cb.Mesh = mesh
 }
 
-func (cb *RateLimit) GetSpec() proto.Message {
+func (cb *RateLimit) GetSpec() (proto.Message, error) {
 	spec := cb.Spec
 	m := mesh_proto.RateLimit{}
 
 	if spec == nil || len(spec.Raw) == 0 {
-		return &m
+		return &m, nil
 	}
 
-	return util_proto.MustUnmarshalJSON(spec.Raw, &m)
+	err := util_proto.FromJSON(spec.Raw, &m)
+	return &m, err
 }
 
 func (cb *RateLimit) SetSpec(spec proto.Message) {
@@ -1203,15 +1215,16 @@ func (cb *Retry) SetMesh(mesh string) {
 	cb.Mesh = mesh
 }
 
-func (cb *Retry) GetSpec() proto.Message {
+func (cb *Retry) GetSpec() (proto.Message, error) {
 	spec := cb.Spec
 	m := mesh_proto.Retry{}
 
 	if spec == nil || len(spec.Raw) == 0 {
-		return &m
+		return &m, nil
 	}
 
-	return util_proto.MustUnmarshalJSON(spec.Raw, &m)
+	err := util_proto.FromJSON(spec.Raw, &m)
+	return &m, err
 }
 
 func (cb *Retry) SetSpec(spec proto.Message) {
@@ -1298,15 +1311,16 @@ func (cb *ServiceInsight) SetMesh(mesh string) {
 	cb.Mesh = mesh
 }
 
-func (cb *ServiceInsight) GetSpec() proto.Message {
+func (cb *ServiceInsight) GetSpec() (proto.Message, error) {
 	spec := cb.Spec
 	m := mesh_proto.ServiceInsight{}
 
 	if spec == nil || len(spec.Raw) == 0 {
-		return &m
+		return &m, nil
 	}
 
-	return util_proto.MustUnmarshalJSON(spec.Raw, &m)
+	err := util_proto.FromJSON(spec.Raw, &m)
+	return &m, err
 }
 
 func (cb *ServiceInsight) SetSpec(spec proto.Message) {
@@ -1393,15 +1407,16 @@ func (cb *Timeout) SetMesh(mesh string) {
 	cb.Mesh = mesh
 }
 
-func (cb *Timeout) GetSpec() proto.Message {
+func (cb *Timeout) GetSpec() (proto.Message, error) {
 	spec := cb.Spec
 	m := mesh_proto.Timeout{}
 
 	if spec == nil || len(spec.Raw) == 0 {
-		return &m
+		return &m, nil
 	}
 
-	return util_proto.MustUnmarshalJSON(spec.Raw, &m)
+	err := util_proto.FromJSON(spec.Raw, &m)
+	return &m, err
 }
 
 func (cb *Timeout) SetSpec(spec proto.Message) {
@@ -1488,15 +1503,16 @@ func (cb *TrafficLog) SetMesh(mesh string) {
 	cb.Mesh = mesh
 }
 
-func (cb *TrafficLog) GetSpec() proto.Message {
+func (cb *TrafficLog) GetSpec() (proto.Message, error) {
 	spec := cb.Spec
 	m := mesh_proto.TrafficLog{}
 
 	if spec == nil || len(spec.Raw) == 0 {
-		return &m
+		return &m, nil
 	}
 
-	return util_proto.MustUnmarshalJSON(spec.Raw, &m)
+	err := util_proto.FromJSON(spec.Raw, &m)
+	return &m, err
 }
 
 func (cb *TrafficLog) SetSpec(spec proto.Message) {
@@ -1583,15 +1599,16 @@ func (cb *TrafficPermission) SetMesh(mesh string) {
 	cb.Mesh = mesh
 }
 
-func (cb *TrafficPermission) GetSpec() proto.Message {
+func (cb *TrafficPermission) GetSpec() (proto.Message, error) {
 	spec := cb.Spec
 	m := mesh_proto.TrafficPermission{}
 
 	if spec == nil || len(spec.Raw) == 0 {
-		return &m
+		return &m, nil
 	}
 
-	return util_proto.MustUnmarshalJSON(spec.Raw, &m)
+	err := util_proto.FromJSON(spec.Raw, &m)
+	return &m, err
 }
 
 func (cb *TrafficPermission) SetSpec(spec proto.Message) {
@@ -1678,15 +1695,16 @@ func (cb *TrafficRoute) SetMesh(mesh string) {
 	cb.Mesh = mesh
 }
 
-func (cb *TrafficRoute) GetSpec() proto.Message {
+func (cb *TrafficRoute) GetSpec() (proto.Message, error) {
 	spec := cb.Spec
 	m := mesh_proto.TrafficRoute{}
 
 	if spec == nil || len(spec.Raw) == 0 {
-		return &m
+		return &m, nil
 	}
 
-	return util_proto.MustUnmarshalJSON(spec.Raw, &m)
+	err := util_proto.FromJSON(spec.Raw, &m)
+	return &m, err
 }
 
 func (cb *TrafficRoute) SetSpec(spec proto.Message) {
@@ -1773,15 +1791,16 @@ func (cb *TrafficTrace) SetMesh(mesh string) {
 	cb.Mesh = mesh
 }
 
-func (cb *TrafficTrace) GetSpec() proto.Message {
+func (cb *TrafficTrace) GetSpec() (proto.Message, error) {
 	spec := cb.Spec
 	m := mesh_proto.TrafficTrace{}
 
 	if spec == nil || len(spec.Raw) == 0 {
-		return &m
+		return &m, nil
 	}
 
-	return util_proto.MustUnmarshalJSON(spec.Raw, &m)
+	err := util_proto.FromJSON(spec.Raw, &m)
+	return &m, err
 }
 
 func (cb *TrafficTrace) SetSpec(spec proto.Message) {
@@ -1868,15 +1887,16 @@ func (cb *VirtualOutbound) SetMesh(mesh string) {
 	cb.Mesh = mesh
 }
 
-func (cb *VirtualOutbound) GetSpec() proto.Message {
+func (cb *VirtualOutbound) GetSpec() (proto.Message, error) {
 	spec := cb.Spec
 	m := mesh_proto.VirtualOutbound{}
 
 	if spec == nil || len(spec.Raw) == 0 {
-		return &m
+		return &m, nil
 	}
 
-	return util_proto.MustUnmarshalJSON(spec.Raw, &m)
+	err := util_proto.FromJSON(spec.Raw, &m)
+	return &m, err
 }
 
 func (cb *VirtualOutbound) SetSpec(spec proto.Message) {
@@ -1963,15 +1983,16 @@ func (cb *ZoneEgress) SetMesh(mesh string) {
 	cb.Mesh = mesh
 }
 
-func (cb *ZoneEgress) GetSpec() proto.Message {
+func (cb *ZoneEgress) GetSpec() (proto.Message, error) {
 	spec := cb.Spec
 	m := mesh_proto.ZoneEgress{}
 
 	if spec == nil || len(spec.Raw) == 0 {
-		return &m
+		return &m, nil
 	}
 
-	return util_proto.MustUnmarshalJSON(spec.Raw, &m)
+	err := util_proto.FromJSON(spec.Raw, &m)
+	return &m, err
 }
 
 func (cb *ZoneEgress) SetSpec(spec proto.Message) {
@@ -2058,15 +2079,16 @@ func (cb *ZoneEgressInsight) SetMesh(mesh string) {
 	cb.Mesh = mesh
 }
 
-func (cb *ZoneEgressInsight) GetSpec() proto.Message {
+func (cb *ZoneEgressInsight) GetSpec() (proto.Message, error) {
 	spec := cb.Spec
 	m := mesh_proto.ZoneEgressInsight{}
 
 	if spec == nil || len(spec.Raw) == 0 {
-		return &m
+		return &m, nil
 	}
 
-	return util_proto.MustUnmarshalJSON(spec.Raw, &m)
+	err := util_proto.FromJSON(spec.Raw, &m)
+	return &m, err
 }
 
 func (cb *ZoneEgressInsight) SetSpec(spec proto.Message) {
@@ -2153,15 +2175,16 @@ func (cb *ZoneIngress) SetMesh(mesh string) {
 	cb.Mesh = mesh
 }
 
-func (cb *ZoneIngress) GetSpec() proto.Message {
+func (cb *ZoneIngress) GetSpec() (proto.Message, error) {
 	spec := cb.Spec
 	m := mesh_proto.ZoneIngress{}
 
 	if spec == nil || len(spec.Raw) == 0 {
-		return &m
+		return &m, nil
 	}
 
-	return util_proto.MustUnmarshalJSON(spec.Raw, &m)
+	err := util_proto.FromJSON(spec.Raw, &m)
+	return &m, err
 }
 
 func (cb *ZoneIngress) SetSpec(spec proto.Message) {
@@ -2248,15 +2271,16 @@ func (cb *ZoneIngressInsight) SetMesh(mesh string) {
 	cb.Mesh = mesh
 }
 
-func (cb *ZoneIngressInsight) GetSpec() proto.Message {
+func (cb *ZoneIngressInsight) GetSpec() (proto.Message, error) {
 	spec := cb.Spec
 	m := mesh_proto.ZoneIngressInsight{}
 
 	if spec == nil || len(spec.Raw) == 0 {
-		return &m
+		return &m, nil
 	}
 
-	return util_proto.MustUnmarshalJSON(spec.Raw, &m)
+	err := util_proto.FromJSON(spec.Raw, &m)
+	return &m, err
 }
 
 func (cb *ZoneIngressInsight) SetSpec(spec proto.Message) {

--- a/pkg/plugins/resources/k8s/native/api/v1alpha1/zz_generated.system.go
+++ b/pkg/plugins/resources/k8s/native/api/v1alpha1/zz_generated.system.go
@@ -61,15 +61,16 @@ func (cb *Zone) SetMesh(mesh string) {
 	cb.Mesh = mesh
 }
 
-func (cb *Zone) GetSpec() proto.Message {
+func (cb *Zone) GetSpec() (proto.Message, error) {
 	spec := cb.Spec
 	m := system_proto.Zone{}
 
 	if spec == nil || len(spec.Raw) == 0 {
-		return &m
+		return &m, nil
 	}
 
-	return util_proto.MustUnmarshalJSON(spec.Raw, &m)
+	err := util_proto.FromJSON(spec.Raw, &m)
+	return &m, err
 }
 
 func (cb *Zone) SetSpec(spec proto.Message) {
@@ -156,15 +157,16 @@ func (cb *ZoneInsight) SetMesh(mesh string) {
 	cb.Mesh = mesh
 }
 
-func (cb *ZoneInsight) GetSpec() proto.Message {
+func (cb *ZoneInsight) GetSpec() (proto.Message, error) {
 	spec := cb.Spec
 	m := system_proto.ZoneInsight{}
 
 	if spec == nil || len(spec.Raw) == 0 {
-		return &m
+		return &m, nil
 	}
 
-	return util_proto.MustUnmarshalJSON(spec.Raw, &m)
+	err := util_proto.FromJSON(spec.Raw, &m)
+	return &m, err
 }
 
 func (cb *ZoneInsight) SetSpec(spec proto.Message) {

--- a/pkg/plugins/resources/k8s/native/pkg/model/resources.go
+++ b/pkg/plugins/resources/k8s/native/pkg/model/resources.go
@@ -21,7 +21,7 @@ type KubernetesObject interface {
 	SetObjectMeta(*metav1.ObjectMeta)
 	GetMesh() string
 	SetMesh(string)
-	GetSpec() proto.Message
+	GetSpec() (proto.Message, error)
 	SetSpec(proto.Message)
 	Scope() Scope
 }

--- a/pkg/plugins/resources/k8s/native/test/api/sample/v1alpha1/sample_types_helpers.go
+++ b/pkg/plugins/resources/k8s/native/test/api/sample/v1alpha1/sample_types_helpers.go
@@ -28,15 +28,16 @@ func (pt *SampleTrafficRoute) SetMesh(mesh string) {
 	pt.Mesh = mesh
 }
 
-func (pt *SampleTrafficRoute) GetSpec() proto.Message {
+func (pt *SampleTrafficRoute) GetSpec() (proto.Message, error) {
 	spec := pt.Spec
 	m := sample_proto.TrafficRoute{}
 
 	if spec == nil || len(spec.Raw) == 0 {
-		return &m
+		return &m, nil
 	}
 
-	return util_proto.MustUnmarshalJSON(spec.Raw, &m)
+	err := util_proto.FromJSON(spec.Raw, &m)
+	return &m, err
 }
 
 func (pt *SampleTrafficRoute) SetSpec(spec proto.Message) {

--- a/pkg/plugins/runtime/k8s/controllers/gateway_instance_controller.go
+++ b/pkg/plugins/runtime/k8s/controllers/gateway_instance_controller.go
@@ -326,10 +326,11 @@ func GatewayToInstanceMapper(l logr.Logger, client kube_client.Client) kube_hand
 
 	return func(obj kube_client.Object) []kube_reconcile.Request {
 		gateway := obj.(*mesh_k8s.MeshGateway)
+		l = l.WithValues("gateway", obj.GetName(), "mesh", gateway.Mesh)
 
 		spec, err := gateway.GetSpec()
 		if err != nil {
-			l.WithValues("gateway", obj.GetName()).Error(err, "failed to get core resource from MeshGateway")
+			l.Error(err, "failed to get core resource from MeshGateway")
 		}
 
 		var serviceNames []string
@@ -345,7 +346,7 @@ func GatewayToInstanceMapper(l logr.Logger, client kube_client.Client) kube_hand
 			if err := client.List(
 				context.Background(), instances, kube_client.MatchingFields{serviceKey: serviceName},
 			); err != nil {
-				l.WithValues("gateway", obj.GetName()).Error(err, "failed to fetch GatewayInstances")
+				l.Error(err, "failed to fetch GatewayInstances")
 			}
 
 			for _, instance := range instances.Items {

--- a/pkg/plugins/runtime/k8s/controllers/gateway_instance_controller.go
+++ b/pkg/plugins/runtime/k8s/controllers/gateway_instance_controller.go
@@ -327,9 +327,13 @@ func GatewayToInstanceMapper(l logr.Logger, client kube_client.Client) kube_hand
 	return func(obj kube_client.Object) []kube_reconcile.Request {
 		gateway := obj.(*mesh_k8s.MeshGateway)
 
+		spec, err := gateway.GetSpec()
+		if err != nil {
+			l.WithValues("gateway", obj.GetName()).Error(err, "failed to get core resource from MeshGateway")
+		}
+
 		var serviceNames []string
-		spec := gateway.GetSpec().(*mesh_proto.MeshGateway)
-		for _, selector := range spec.GetSelectors() {
+		for _, selector := range spec.(*mesh_proto.MeshGateway).GetSelectors() {
 			if tagValue, ok := selector.Match[mesh_proto.ServiceTag]; ok {
 				serviceNames = append(serviceNames, tagValue)
 			}

--- a/tools/policy-gen/protoc-gen-kumapolicy/crd.go
+++ b/tools/policy-gen/protoc-gen-kumapolicy/crd.go
@@ -102,11 +102,11 @@ func (cb *{{.ResourceType}}) SetMesh(mesh string) {
 	cb.Mesh = mesh
 }
 
-func (cb *{{.ResourceType}}) GetSpec() proto.Message {
+func (cb *{{.ResourceType}}) GetSpec() (proto.Message, error) {
 {{- if eq .ResourceType "DataplaneInsight" }}
-	return cb.Status
+	return cb.Status, nil
 {{- else}}
-	return  cb.Spec
+	return cb.Spec, nil
 {{- end}}
 }
 

--- a/tools/resource-gen/main.go
+++ b/tools/resource-gen/main.go
@@ -104,19 +104,20 @@ func (cb *{{.ResourceType}}) SetMesh(mesh string) {
 	cb.Mesh = mesh
 }
 
-func (cb *{{.ResourceType}}) GetSpec() proto.Message {
+func (cb *{{.ResourceType}}) GetSpec() (proto.Message, error) {
 {{- if eq .ResourceType "DataplaneInsight" }}
 	spec := cb.Status
 {{- else}}
-	spec :=  cb.Spec
+	spec := cb.Spec
 {{- end}}
 	m := {{$pkg}}.{{.ProtoType}}{}
 
     if spec == nil || len(spec.Raw) == 0 {
-		return &m
+		return &m, nil
 	}
 
-	return util_proto.MustUnmarshalJSON(spec.Raw, &m)
+	err := util_proto.FromJSON(spec.Raw, &m)
+	return &m, err
 }
 
 func (cb *{{.ResourceType}}) SetSpec(spec proto.Message) {


### PR DESCRIPTION
### Summary

Trying to set, for example, a negative weight on a `TrafficRoute` split results in a confusing error for users:

```
error: trafficroutes.kuma.io "route-all-default" could not be patched: Internal error occurred: failed calling webhook "validator.kuma-admission.kuma.io": failed to call webhook: Post "https://kuma-control-plane.kuma-system.svc:443/validate-kuma-io-v1alpha1?timeout=10s": EOF
```

and a panic in the webhook goroutine in `kuma-cp`:

```
2022/06/10 06:42:31 http: panic serving 172.17.0.1:8216: failed to unmarshal *v1alpha1.TrafficRoute: json: cannot unmarshal number -1 into Go value of type uint32
goroutine 1247 [running]:
net/http.(*conn).serve.func1()
	/usr/lib/go/src/net/http/server.go:1825 +0xbf
panic({0x1e1dde0, 0xc0013482b0})
	/usr/lib/go/src/runtime/panic.go:844 +0x258
github.com/kumahq/kuma/pkg/util/proto.MustUnmarshalJSON({0xc0006ca833?, 0xc001c9e1e8?, 0x40d987?}, {0x3031080?, 0xc00163f560?})
	/home/mike/projects/kuma/pkg/util/proto/proto.go:67 +0xc7
github.com/kumahq/kuma/pkg/plugins/resources/k8s/native/api/v1alpha1.(*TrafficRoute).GetSpec(0xc0006ca480?)
	/home/mike/projects/kuma/pkg/plugins/resources/k8s/native/api/v1alpha1/zz_generated.mesh.go:1689 +0x58
github.com/kumahq/kuma/pkg/plugins/resources/k8s.(*SimpleConverter).ToCoreResource(0xc001421530?, {0x3057300, 0xc001644b40}, {0x3042890, 0xc000651d40})
	/home/mike/projects/kuma/pkg/plugins/resources/k8s/converter.go:53 +0x112
github.com/kumahq/kuma/pkg/plugins/runtime/k8s/webhooks.(*validatingHandler).decode(_, {{{0xc001421530, 0x24}, {{0xc000ce2930, 0x7}, {0xc000ce2938, 0x8}, {0xc000ce2940, 0xc}}, {{0xc000ce2950, ...}, ...}, ...}})
	/home/mike/projects/kuma/pkg/plugins/runtime/k8s/webhooks/validation.go:105 +0x16a
```

Here we can't assume that `GetSpec` succeeds.


Now the user gets:

```
error: trafficroutes.kuma.io "route-all-default" could not be patched: admission webhook "validator.kuma-admission.kuma.io" denied the request: json: cannot unmarshal number -2 into Go value of type uint32
```