### PR TITLE
chore: upgrade helm chart to v1.6.1

### DIFF
--- a/app/kumactl/cmd/install/testdata/install-control-plane.cni-enabled.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.cni-enabled.golden.yaml
@@ -1571,7 +1571,7 @@ spec:
         # priority scheduling and that its resources are reserved
         # if it ever gets evicted.
         scheduler.alpha.kubernetes.io/critical-pod: ''
-        checksum/config: caf52130abbfc69c2f5696ff0bdf6c5da872aace86379e196492aa45c25e5940
+        checksum/config: 8875bf0cfa24f435cbba3229db1d72d83c40c3bafcf1c974d3444a5ae31b7ef1
     spec:
       nodeSelector:
       
@@ -1649,8 +1649,8 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 47f8e00f6916a54e5c2c5c1f0369b8107436c15171abc1167b1fa35bd9afad5f
-        checksum/tls-secrets: cf73e8628484dfed58bd012abd61502d41e6c343ec4b248e3928db75d0166373
+        checksum/config: c65bd7f70f21551f5c996f2e8c344d97e0d067441be69f27987b34dc688df0bf
+        checksum/tls-secrets: 7c0868d5ffc022c2d62669aaff5f7283e06b8eabb93431de4d5ce50303b2fef1
       labels:
         app.kubernetes.io/name: kuma
         app.kubernetes.io/instance: kuma

--- a/app/kumactl/cmd/install/testdata/install-control-plane.defaults.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.defaults.golden.yaml
@@ -1474,8 +1474,8 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 47f8e00f6916a54e5c2c5c1f0369b8107436c15171abc1167b1fa35bd9afad5f
-        checksum/tls-secrets: cf73e8628484dfed58bd012abd61502d41e6c343ec4b248e3928db75d0166373
+        checksum/config: c65bd7f70f21551f5c996f2e8c344d97e0d067441be69f27987b34dc688df0bf
+        checksum/tls-secrets: 7c0868d5ffc022c2d62669aaff5f7283e06b8eabb93431de4d5ce50303b2fef1
       labels:
         app.kubernetes.io/name: kuma
         app.kubernetes.io/instance: kuma

--- a/app/kumactl/cmd/install/testdata/install-control-plane.global.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.global.golden.yaml
@@ -1484,8 +1484,8 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 47f8e00f6916a54e5c2c5c1f0369b8107436c15171abc1167b1fa35bd9afad5f
-        checksum/tls-secrets: cf73e8628484dfed58bd012abd61502d41e6c343ec4b248e3928db75d0166373
+        checksum/config: c65bd7f70f21551f5c996f2e8c344d97e0d067441be69f27987b34dc688df0bf
+        checksum/tls-secrets: 7c0868d5ffc022c2d62669aaff5f7283e06b8eabb93431de4d5ce50303b2fef1
       labels:
         app.kubernetes.io/name: kuma
         app.kubernetes.io/instance: kuma

--- a/app/kumactl/cmd/install/testdata/install-control-plane.override-env-vars.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.override-env-vars.golden.yaml
@@ -1474,8 +1474,8 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 47f8e00f6916a54e5c2c5c1f0369b8107436c15171abc1167b1fa35bd9afad5f
-        checksum/tls-secrets: cf73e8628484dfed58bd012abd61502d41e6c343ec4b248e3928db75d0166373
+        checksum/config: c65bd7f70f21551f5c996f2e8c344d97e0d067441be69f27987b34dc688df0bf
+        checksum/tls-secrets: 7c0868d5ffc022c2d62669aaff5f7283e06b8eabb93431de4d5ce50303b2fef1
       labels:
         app.kubernetes.io/name: kuma
         app.kubernetes.io/instance: kuma

--- a/app/kumactl/cmd/install/testdata/install-control-plane.overrides.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.overrides.golden.yaml
@@ -1877,8 +1877,8 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 652c0fee8359addb5b565f00943a4c64a5511bb208b041d6cdcca177d2772e61
-        checksum/tls-secrets: b8deca59ac509c99819cfab78ff0fe69ca375602f1eae5273153cff35ef8c2bc
+        checksum/config: 8a9148c86bdd3685318b0db0c510aec55261a3b680a8dd39ec7d52777cf199db
+        checksum/tls-secrets: d320aedaf0557602aecb56b374733a7e171cb04df86d21af918593461c2b8706
       labels:
         app.kubernetes.io/name: kuma
         app.kubernetes.io/instance: kuma

--- a/app/kumactl/cmd/install/testdata/install-control-plane.with-egress.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.with-egress.golden.yaml
@@ -1503,8 +1503,8 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 47f8e00f6916a54e5c2c5c1f0369b8107436c15171abc1167b1fa35bd9afad5f
-        checksum/tls-secrets: cf73e8628484dfed58bd012abd61502d41e6c343ec4b248e3928db75d0166373
+        checksum/config: c65bd7f70f21551f5c996f2e8c344d97e0d067441be69f27987b34dc688df0bf
+        checksum/tls-secrets: 7c0868d5ffc022c2d62669aaff5f7283e06b8eabb93431de4d5ce50303b2fef1
       labels:
         app.kubernetes.io/name: kuma
         app.kubernetes.io/instance: kuma

--- a/app/kumactl/cmd/install/testdata/install-control-plane.with-helm-set.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.with-helm-set.yaml
@@ -1536,8 +1536,8 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 47f8e00f6916a54e5c2c5c1f0369b8107436c15171abc1167b1fa35bd9afad5f
-        checksum/tls-secrets: cf73e8628484dfed58bd012abd61502d41e6c343ec4b248e3928db75d0166373
+        checksum/config: c65bd7f70f21551f5c996f2e8c344d97e0d067441be69f27987b34dc688df0bf
+        checksum/tls-secrets: 7c0868d5ffc022c2d62669aaff5f7283e06b8eabb93431de4d5ce50303b2fef1
       labels:
         app.kubernetes.io/name: kuma
         app.kubernetes.io/instance: kuma

--- a/app/kumactl/cmd/install/testdata/install-control-plane.with-helm-values.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.with-helm-values.yaml
@@ -1474,8 +1474,8 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 47f8e00f6916a54e5c2c5c1f0369b8107436c15171abc1167b1fa35bd9afad5f
-        checksum/tls-secrets: cf73e8628484dfed58bd012abd61502d41e6c343ec4b248e3928db75d0166373
+        checksum/config: c65bd7f70f21551f5c996f2e8c344d97e0d067441be69f27987b34dc688df0bf
+        checksum/tls-secrets: 7c0868d5ffc022c2d62669aaff5f7283e06b8eabb93431de4d5ce50303b2fef1
       labels:
         app.kubernetes.io/name: kuma
         app.kubernetes.io/instance: kuma

--- a/app/kumactl/cmd/install/testdata/install-control-plane.with-ingress.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.with-ingress.golden.yaml
@@ -1507,8 +1507,8 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 47f8e00f6916a54e5c2c5c1f0369b8107436c15171abc1167b1fa35bd9afad5f
-        checksum/tls-secrets: cf73e8628484dfed58bd012abd61502d41e6c343ec4b248e3928db75d0166373
+        checksum/config: c65bd7f70f21551f5c996f2e8c344d97e0d067441be69f27987b34dc688df0bf
+        checksum/tls-secrets: 7c0868d5ffc022c2d62669aaff5f7283e06b8eabb93431de4d5ce50303b2fef1
       labels:
         app.kubernetes.io/name: kuma
         app.kubernetes.io/instance: kuma

--- a/app/kumactl/cmd/install/testdata/install-control-plane.zone.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.zone.golden.yaml
@@ -1478,8 +1478,8 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 47f8e00f6916a54e5c2c5c1f0369b8107436c15171abc1167b1fa35bd9afad5f
-        checksum/tls-secrets: cf73e8628484dfed58bd012abd61502d41e6c343ec4b248e3928db75d0166373
+        checksum/config: c65bd7f70f21551f5c996f2e8c344d97e0d067441be69f27987b34dc688df0bf
+        checksum/tls-secrets: 7c0868d5ffc022c2d62669aaff5f7283e06b8eabb93431de4d5ce50303b2fef1
       labels:
         app.kubernetes.io/name: kuma
         app.kubernetes.io/instance: kuma

--- a/deployments/charts/kuma/Chart.yaml
+++ b/deployments/charts/kuma/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: kuma
 description: A Helm chart for the Kuma Control Plane
 type: application
-version: 1.6.0
-appVersion: 1.6.0
+version: 1.6.1
+appVersion: 1.6.1
 home: https://github.com/kumahq/kuma
 maintainers:
   - name: austince

--- a/deployments/charts/kuma/README.md
+++ b/deployments/charts/kuma/README.md
@@ -2,7 +2,7 @@
 
 A Helm chart for the Kuma Control Plane
 
-![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![Version: 1.6.0](https://img.shields.io/badge/Version-1.6.0-informational?style=flat-square) ![AppVersion: 1.6.0](https://img.shields.io/badge/AppVersion-1.6.0-informational?style=flat-square)
+![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![Version: 1.6.1](https://img.shields.io/badge/Version-1.6.1-informational?style=flat-square) ![AppVersion: 1.6.1](https://img.shields.io/badge/AppVersion-1.6.1-informational?style=flat-square)
 
 **Homepage:** <https://github.com/kumahq/kuma>
 


### PR DESCRIPTION
### Summary

Upgrade Helm to 1.6.1

### Full changelog

n/a

### Issues resolved

n/a

### Documentation

- [ ] Link to the website [documentation PR](https://github.com/kumahq/kuma-website/pull/XXX)

### Testing

- [ ] Unit tests
- [ ] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes

### Backwards compatibility

- [ ] Update [`UPGRADE.md`](/UPGRADE.md) with any steps users will need to take when upgrading.
- [ ] Add `backport-to-stable` label if the code follows our [backporting policy](/CONTRIBUTING.md#backporting)
