### PR TITLE
chore: upgrade helm chart to v1.5.2/0.9.2

### DIFF
--- a/app/kumactl/cmd/install/testdata/install-control-plane.cni-enabled.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.cni-enabled.golden.yaml
@@ -1551,7 +1551,7 @@ spec:
         # priority scheduling and that its resources are reserved
         # if it ever gets evicted.
         scheduler.alpha.kubernetes.io/critical-pod: ''
-        checksum/config: 28304fca07074ec0e2c9382e1c6d2bfba8302f33652ed7dd006fec39e18fbfee
+        checksum/config: 597264e73753ab9f2ccf8233dedaf19e4144be4a76cb641a55d6c4d1bb96b097
     spec:
       nodeSelector:
       
@@ -1629,8 +1629,8 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 5a1774c2a3e29ca9135bef1f9622c70948207d37439b249073fc73bbf8f59b83
-        checksum/tls-secrets: a90a63ab418278361825d1ab320d8f20c1a69d328e346e16314f72c6122742f6
+        checksum/config: f37ee9f6dea2ad75293a8076863b6d404fcba82ab5e4ea862bcf480d1e8110dc
+        checksum/tls-secrets: 3fe6a25683489e633287475a9b9c535ffa342252b5abea7a49ee79e0fd91c421
       labels:
         app.kubernetes.io/name: kuma
         app.kubernetes.io/instance: kuma

--- a/app/kumactl/cmd/install/testdata/install-control-plane.defaults.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.defaults.golden.yaml
@@ -1454,8 +1454,8 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 5a1774c2a3e29ca9135bef1f9622c70948207d37439b249073fc73bbf8f59b83
-        checksum/tls-secrets: a90a63ab418278361825d1ab320d8f20c1a69d328e346e16314f72c6122742f6
+        checksum/config: f37ee9f6dea2ad75293a8076863b6d404fcba82ab5e4ea862bcf480d1e8110dc
+        checksum/tls-secrets: 3fe6a25683489e633287475a9b9c535ffa342252b5abea7a49ee79e0fd91c421
       labels:
         app.kubernetes.io/name: kuma
         app.kubernetes.io/instance: kuma

--- a/app/kumactl/cmd/install/testdata/install-control-plane.global.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.global.golden.yaml
@@ -1464,8 +1464,8 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 5a1774c2a3e29ca9135bef1f9622c70948207d37439b249073fc73bbf8f59b83
-        checksum/tls-secrets: a90a63ab418278361825d1ab320d8f20c1a69d328e346e16314f72c6122742f6
+        checksum/config: f37ee9f6dea2ad75293a8076863b6d404fcba82ab5e4ea862bcf480d1e8110dc
+        checksum/tls-secrets: 3fe6a25683489e633287475a9b9c535ffa342252b5abea7a49ee79e0fd91c421
       labels:
         app.kubernetes.io/name: kuma
         app.kubernetes.io/instance: kuma

--- a/app/kumactl/cmd/install/testdata/install-control-plane.override-env-vars.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.override-env-vars.golden.yaml
@@ -1454,8 +1454,8 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 5a1774c2a3e29ca9135bef1f9622c70948207d37439b249073fc73bbf8f59b83
-        checksum/tls-secrets: a90a63ab418278361825d1ab320d8f20c1a69d328e346e16314f72c6122742f6
+        checksum/config: f37ee9f6dea2ad75293a8076863b6d404fcba82ab5e4ea862bcf480d1e8110dc
+        checksum/tls-secrets: 3fe6a25683489e633287475a9b9c535ffa342252b5abea7a49ee79e0fd91c421
       labels:
         app.kubernetes.io/name: kuma
         app.kubernetes.io/instance: kuma

--- a/app/kumactl/cmd/install/testdata/install-control-plane.overrides.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.overrides.golden.yaml
@@ -1856,8 +1856,8 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 0eb30ec257dab9b5e430870392c890813e253c6fc9f55ec6b6a8d4aec66d6191
-        checksum/tls-secrets: 1988f3788e7e985462687daa534884e4d671660057fb105addcebead8849ec77
+        checksum/config: 9845231104d72952c6bb2ff89e06f001804066eef10fd8788c184db3db9bfacf
+        checksum/tls-secrets: c3c6d88e73d7f88b3afa748648e01ea845e212a647a1d3d850520e0197376472
       labels:
         app.kubernetes.io/name: kuma
         app.kubernetes.io/instance: kuma

--- a/app/kumactl/cmd/install/testdata/install-control-plane.with-egress.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.with-egress.golden.yaml
@@ -1483,8 +1483,8 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 5a1774c2a3e29ca9135bef1f9622c70948207d37439b249073fc73bbf8f59b83
-        checksum/tls-secrets: a90a63ab418278361825d1ab320d8f20c1a69d328e346e16314f72c6122742f6
+        checksum/config: f37ee9f6dea2ad75293a8076863b6d404fcba82ab5e4ea862bcf480d1e8110dc
+        checksum/tls-secrets: 3fe6a25683489e633287475a9b9c535ffa342252b5abea7a49ee79e0fd91c421
       labels:
         app.kubernetes.io/name: kuma
         app.kubernetes.io/instance: kuma

--- a/app/kumactl/cmd/install/testdata/install-control-plane.with-ingress.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.with-ingress.golden.yaml
@@ -1483,8 +1483,8 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 5a1774c2a3e29ca9135bef1f9622c70948207d37439b249073fc73bbf8f59b83
-        checksum/tls-secrets: a90a63ab418278361825d1ab320d8f20c1a69d328e346e16314f72c6122742f6
+        checksum/config: f37ee9f6dea2ad75293a8076863b6d404fcba82ab5e4ea862bcf480d1e8110dc
+        checksum/tls-secrets: 3fe6a25683489e633287475a9b9c535ffa342252b5abea7a49ee79e0fd91c421
       labels:
         app.kubernetes.io/name: kuma
         app.kubernetes.io/instance: kuma

--- a/app/kumactl/cmd/install/testdata/install-control-plane.zone.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.zone.golden.yaml
@@ -1458,8 +1458,8 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 5a1774c2a3e29ca9135bef1f9622c70948207d37439b249073fc73bbf8f59b83
-        checksum/tls-secrets: a90a63ab418278361825d1ab320d8f20c1a69d328e346e16314f72c6122742f6
+        checksum/config: f37ee9f6dea2ad75293a8076863b6d404fcba82ab5e4ea862bcf480d1e8110dc
+        checksum/tls-secrets: 3fe6a25683489e633287475a9b9c535ffa342252b5abea7a49ee79e0fd91c421
       labels:
         app.kubernetes.io/name: kuma
         app.kubernetes.io/instance: kuma

--- a/deployments/charts/kuma/Chart.yaml
+++ b/deployments/charts/kuma/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: kuma
 description: A Helm chart for the Kuma Control Plane
 type: application
-version: 0.9.1
-appVersion: 1.5.1
+version: 0.9.2
+appVersion: 1.5.2
 home: https://github.com/kumahq/kuma
 maintainers:
   - name: austince

--- a/deployments/charts/kuma/README.md
+++ b/deployments/charts/kuma/README.md
@@ -2,7 +2,7 @@
 
 A Helm chart for the Kuma Control Plane
 
-![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![Version: 0.9.1](https://img.shields.io/badge/Version-0.9.1-informational?style=flat-square) ![AppVersion: 1.5.1](https://img.shields.io/badge/AppVersion-1.5.1-informational?style=flat-square)
+![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![Version: 0.9.2](https://img.shields.io/badge/Version-0.9.2-informational?style=flat-square) ![AppVersion: 1.5.2](https://img.shields.io/badge/AppVersion-1.5.2-informational?style=flat-square)
 
 **Homepage:** <https://github.com/kumahq/kuma>
 


### PR DESCRIPTION
### Summary

Upgrade help chart to v1.52/0.9.2

### Full changelog

n/a

### Issues resolved

n/a

### Documentation

- [ ] Link to the website [documentation PR](https://github.com/kumahq/kuma-website/pull/XXX)

### Testing

- [ ] Unit tests
- [ ] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes

### Backwards compatibility

- [ ] Update [`UPGRADE.md`](/UPGRADE.md) with any steps users will need to take when upgrading.
- [ ] Add `backport-to-stable` label if the code follows our [backporting policy](/CONTRIBUTING.md#backporting)
