### PR TITLE
chore(*): upgrade Envoy to 1.22.1

### DIFF
--- a/mk/envoy.mk
+++ b/mk/envoy.mk
@@ -2,7 +2,7 @@ KUMA_DIR ?= .
 
 BUILD_ENVOY_FROM_SOURCES ?= false
 
-ENVOY_TAG ?= v1.22.0 # commit hash or git tag
+ENVOY_TAG ?= v1.22.1 # commit hash or git tag
 # Remember to update pkg/version/compatibility.go
 ENVOY_VERSION = $(shell ${KUMA_DIR}/tools/envoy/version.sh ${ENVOY_TAG})
 

--- a/tools/releases/distros.sh
+++ b/tools/releases/distros.sh
@@ -25,7 +25,7 @@ PULP_HOST="https://api.pulp.konnect-prod.konghq.com"
 PULP_PACKAGE_TYPE="mesh"
 PULP_DIST_NAME="alpine"
 [ -z "$RELEASE_NAME" ] && RELEASE_NAME="kuma"
-ENVOY_VERSION=1.22.0
+ENVOY_VERSION=1.22.1
 [ -z "$KUMA_CONFIG_PATH" ] && KUMA_CONFIG_PATH=pkg/config/app/kuma-cp/kuma-cp.defaults.yaml
 CTL_NAME="kumactl"
 

--- a/tools/releases/docker.sh
+++ b/tools/releases/docker.sh
@@ -8,7 +8,7 @@ source "${SCRIPT_DIR}/../common.sh"
 KUMA_DOCKER_REPO="${KUMA_DOCKER_REPO:-docker.io}"
 KUMA_DOCKER_REPO_ORG="${KUMA_DOCKER_REPO_ORG:-${KUMA_DOCKER_REPO}/kumahq}"
 KUMA_COMPONENTS="${KUMA_COMPONENTS:-kuma-cp kuma-dp kumactl kuma-init kuma-prometheus-sd}"
-ENVOY_VERSION="${ENVOY_VERSION:-1.22.0}"
+ENVOY_VERSION="${ENVOY_VERSION:-1.22.1}"
 BUILD_ARCH="${BUILD_ARCH:-amd64 arm64}"
 
 function build() {


### PR DESCRIPTION
### Summary

Upgrade Envoy to 1.22.1

### Full changelog

* [Implement ...]
* [Fix ...]

### Issues resolved

Fix #XXX

### Documentation

- [ ] Link to the website [documentation PR](https://github.com/kumahq/kuma-website/pull/XXX)

### Testing

- [ ] Unit tests
- [ ] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes

### Backwards compatibility

- [ ] Update [`UPGRADE.md`](/UPGRADE.md) with any steps users will need to take when upgrading.
- [ ] Add `backport-to-stable` label if the code follows our [backporting policy](/CONTRIBUTING.md#backporting)
