### PR TITLE
ci(circleci): fix bad tags glob on dev jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,24 +12,6 @@ reusable:
   vm_images:
     - &ubuntu_vm_image "ubuntu-2004:202111-01"
 
-  snippets:
-    # on branches master or release-*
-    work_branch_workflow_filter: &work_branch_workflow_filter
-      filters:
-        branches:
-          only:
-            - master
-            - /^release-.*/
-        tags:
-          ignore: /.*/
-    # on tags
-    tags_workflow_filter: &tags_workflow_filter
-      filters:
-        branches:
-          ignore: /.*/
-        tags:
-          only: /.*/
-
 # See https://circleci.com/docs/2.0/configuration-reference/#commands-requires-version-21.
 commands:
   install_build_tools:
@@ -440,7 +422,13 @@ workflows:
     jobs:
       - dev:
           # Avoids running expensive workflow on PRs
-          <<: *work_branch_workflow_filter
+          filters: &expensive_workflow_filter # only run on tags, master and release-* branches
+            branches:
+              only:
+                - master
+                - /^release-.*/
+            tags:
+              only: /.*/
           name: dev-<< matrix.executor >>
           matrix:
             alias: dev
@@ -490,9 +478,19 @@ workflows:
           requires: [ build-<< matrix.arch >>, check ]
       - release:
           # publish artifacts speculatively for normal commits
-          <<: *work_branch_workflow_filter
+          filters: # only on master and release-* branches (never on PRs and tags)
+            branches:
+              only:
+                - master
+                - /^release-.*/
+            tags:
+              ignore: /.*/
           requires: [ build ]
       - release:
           # only publish tagged artifacts if everything passes
-          <<: *tags_workflow_filter
+          filters: # only on tags
+            branches:
+              ignore: /.*/
+            tags:
+              only: /.*/
           requires: [ dev, test, test/e2e, test/e2e-legacy ]


### PR DESCRIPTION
These were required for `release` so we needed to add a circleci filter

Signed-off-by: Charly Molter <charly.molter@konghq.com>