### PR TITLE
feat(gateway): propagate x-kuma-tags from MeshGateways

### DIFF
--- a/pkg/plugins/runtime/gateway/cluster_generator.go
+++ b/pkg/plugins/runtime/gateway/cluster_generator.go
@@ -39,10 +39,7 @@ func (c *ClusterGenerator) GenerateClusters(ctx xds_context.Context, info Gatewa
 		matched := match.ExternalService(info.ExternalServices.Items, mesh_proto.TagSelector(dest.Destination))
 		service := dest.Destination[mesh_proto.ServiceTag]
 
-		var firstEndpointExternalService bool
-		if endpoints := info.OutboundEndpoints[service]; len(endpoints) > 0 {
-			firstEndpointExternalService = endpoints[0].IsExternalService()
-		}
+		firstEndpointExternalService := route.HasExternalServiceEndpoint(ctx.Mesh.Resource, info.OutboundEndpoints, *dest)
 
 		// If there is Mesh property ZoneEgress enabled we want always to
 		// direct the traffic through them. The condition is, the mesh must

--- a/pkg/plugins/runtime/gateway/route_table_generator.go
+++ b/pkg/plugins/runtime/gateway/route_table_generator.go
@@ -53,7 +53,7 @@ func GenerateVirtualHost(
 			route.RouteMatchExactHeader(":method", e.Match.Method),
 
 			route.RouteActionRedirect(e.Action.Redirect),
-			route.RouteActionForward(e.Action.Forward),
+			route.RouteActionForward(ctx.Mesh.Resource, info.OutboundEndpoints, info.Proxy.Dataplane.Spec.TagSet(), e.Action.Forward),
 		)
 
 		// Generate a retry policy for this route, if there is one.

--- a/pkg/plugins/runtime/gateway/testdata/http/01-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/01-gateway-route.yaml
@@ -128,6 +128,10 @@ Routes:
             weightedClusters:
               clusters:
               - name: echo-service-5a416c39037aa8f6
+                requestHeadersToAdd:
+                - header:
+                    key: x-kuma-tags
+                    value: '&kuma.io/service=gateway-default&'
                 weight: 1
               totalWeight: 1
       - domains:
@@ -148,6 +152,10 @@ Routes:
             weightedClusters:
               clusters:
               - name: echo-service-5a416c39037aa8f6
+                requestHeadersToAdd:
+                - header:
+                    key: x-kuma-tags
+                    value: '&kuma.io/service=gateway-default&'
                 weight: 1
               totalWeight: 1
       - domains:
@@ -168,6 +176,10 @@ Routes:
             weightedClusters:
               clusters:
               - name: echo-service-5a416c39037aa8f6
+                requestHeadersToAdd:
+                - header:
+                    key: x-kuma-tags
+                    value: '&kuma.io/service=gateway-default&'
                 weight: 1
               totalWeight: 1
       - domains:

--- a/pkg/plugins/runtime/gateway/testdata/http/02-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/02-gateway-route.yaml
@@ -128,6 +128,10 @@ Routes:
             weightedClusters:
               clusters:
               - name: echo-service-5a416c39037aa8f6
+                requestHeadersToAdd:
+                - header:
+                    key: x-kuma-tags
+                    value: '&kuma.io/service=gateway-default&'
                 weight: 1
               totalWeight: 1
       - domains:
@@ -148,6 +152,10 @@ Routes:
             weightedClusters:
               clusters:
               - name: echo-service-5a416c39037aa8f6
+                requestHeadersToAdd:
+                - header:
+                    key: x-kuma-tags
+                    value: '&kuma.io/service=gateway-default&'
                 weight: 1
               totalWeight: 1
 Runtimes:

--- a/pkg/plugins/runtime/gateway/testdata/http/03-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/03-gateway-route.yaml
@@ -128,6 +128,10 @@ Routes:
             weightedClusters:
               clusters:
               - name: echo-service-5a416c39037aa8f6
+                requestHeadersToAdd:
+                - header:
+                    key: x-kuma-tags
+                    value: '&kuma.io/service=gateway-default&'
                 weight: 1
               totalWeight: 1
 Runtimes:

--- a/pkg/plugins/runtime/gateway/testdata/http/04-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/04-gateway-route.yaml
@@ -163,6 +163,10 @@ Routes:
             weightedClusters:
               clusters:
               - name: echo-service-5a416c39037aa8f6
+                requestHeadersToAdd:
+                - header:
+                    key: x-kuma-tags
+                    value: '&kuma.io/service=gateway-default&'
                 weight: 1
               totalWeight: 1
 Runtimes:

--- a/pkg/plugins/runtime/gateway/testdata/http/06-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/06-gateway-route.yaml
@@ -182,6 +182,10 @@ Routes:
             weightedClusters:
               clusters:
               - name: echo-service-5a416c39037aa8f6
+                requestHeadersToAdd:
+                - header:
+                    key: x-kuma-tags
+                    value: '&kuma.io/service=gateway-default&'
                 weight: 1
               totalWeight: 1
 Runtimes:

--- a/pkg/plugins/runtime/gateway/testdata/http/07-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/07-gateway-route.yaml
@@ -128,6 +128,10 @@ Routes:
             weightedClusters:
               clusters:
               - name: echo-service-5a416c39037aa8f6
+                requestHeadersToAdd:
+                - header:
+                    key: x-kuma-tags
+                    value: '&kuma.io/service=gateway-default&'
                 weight: 1
               totalWeight: 1
         - match:
@@ -144,6 +148,10 @@ Routes:
             weightedClusters:
               clusters:
               - name: echo-service-5a416c39037aa8f6
+                requestHeadersToAdd:
+                - header:
+                    key: x-kuma-tags
+                    value: '&kuma.io/service=gateway-default&'
                 weight: 1
               totalWeight: 1
 Runtimes:

--- a/pkg/plugins/runtime/gateway/testdata/http/08-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/08-gateway-route.yaml
@@ -171,6 +171,10 @@ Routes:
             weightedClusters:
               clusters:
               - name: exact-service-09493d2d54b2a972
+                requestHeadersToAdd:
+                - header:
+                    key: x-kuma-tags
+                    value: '&kuma.io/service=gateway-default&'
                 weight: 1
               totalWeight: 1
         - match:
@@ -187,6 +191,10 @@ Routes:
             weightedClusters:
               clusters:
               - name: prefix-service-5061ee504b81a555
+                requestHeadersToAdd:
+                - header:
+                    key: x-kuma-tags
+                    value: '&kuma.io/service=gateway-default&'
                 weight: 1
               totalWeight: 1
 Runtimes:

--- a/pkg/plugins/runtime/gateway/testdata/http/09-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/09-gateway-route.yaml
@@ -130,6 +130,10 @@ Routes:
             weightedClusters:
               clusters:
               - name: echo-service-5a416c39037aa8f6
+                requestHeadersToAdd:
+                - header:
+                    key: x-kuma-tags
+                    value: '&kuma.io/service=gateway-default&'
                 weight: 1
               totalWeight: 1
 Runtimes:

--- a/pkg/plugins/runtime/gateway/testdata/http/10-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/10-gateway-route.yaml
@@ -180,6 +180,10 @@ Routes:
             weightedClusters:
               clusters:
               - name: regex-header-match-ad0dd92f37b8a38d
+                requestHeadersToAdd:
+                - header:
+                    key: x-kuma-tags
+                    value: '&kuma.io/service=gateway-default&'
                 weight: 1
               totalWeight: 1
         - match:
@@ -199,6 +203,10 @@ Routes:
             weightedClusters:
               clusters:
               - name: exact-header-match-f6b57a6b55557c81
+                requestHeadersToAdd:
+                - header:
+                    key: x-kuma-tags
+                    value: '&kuma.io/service=gateway-default&'
                 weight: 1
               totalWeight: 1
         - match:
@@ -218,6 +226,10 @@ Routes:
             weightedClusters:
               clusters:
               - name: exact-header-match-f6b57a6b55557c81
+                requestHeadersToAdd:
+                - header:
+                    key: x-kuma-tags
+                    value: '&kuma.io/service=gateway-default&'
                 weight: 1
               totalWeight: 1
 Runtimes:

--- a/pkg/plugins/runtime/gateway/testdata/http/11-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/11-gateway-route.yaml
@@ -182,6 +182,10 @@ Routes:
             weightedClusters:
               clusters:
               - name: regex-query-match-3804d7b8516d7323
+                requestHeadersToAdd:
+                - header:
+                    key: x-kuma-tags
+                    value: '&kuma.io/service=gateway-default&'
                 weight: 1
               totalWeight: 1
         - match:
@@ -202,6 +206,10 @@ Routes:
             weightedClusters:
               clusters:
               - name: exact-query-match-cc1370f58a3b5330
+                requestHeadersToAdd:
+                - header:
+                    key: x-kuma-tags
+                    value: '&kuma.io/service=gateway-default&'
                 weight: 1
               totalWeight: 1
         - match:
@@ -222,6 +230,10 @@ Routes:
             weightedClusters:
               clusters:
               - name: exact-query-match-cc1370f58a3b5330
+                requestHeadersToAdd:
+                - header:
+                    key: x-kuma-tags
+                    value: '&kuma.io/service=gateway-default&'
                 weight: 1
               totalWeight: 1
 Runtimes:

--- a/pkg/plugins/runtime/gateway/testdata/http/12-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/12-gateway-route.yaml
@@ -133,6 +133,10 @@ Routes:
             weightedClusters:
               clusters:
               - name: echo-service-5a416c39037aa8f6
+                requestHeadersToAdd:
+                - header:
+                    key: x-kuma-tags
+                    value: '&kuma.io/service=gateway-default&'
                 weight: 1
               totalWeight: 1
         - match:
@@ -154,6 +158,10 @@ Routes:
             weightedClusters:
               clusters:
               - name: echo-service-5a416c39037aa8f6
+                requestHeadersToAdd:
+                - header:
+                    key: x-kuma-tags
+                    value: '&kuma.io/service=gateway-default&'
                 weight: 1
               totalWeight: 1
         - match:
@@ -175,6 +183,10 @@ Routes:
             weightedClusters:
               clusters:
               - name: echo-service-5a416c39037aa8f6
+                requestHeadersToAdd:
+                - header:
+                    key: x-kuma-tags
+                    value: '&kuma.io/service=gateway-default&'
                 weight: 1
               totalWeight: 1
 Runtimes:

--- a/pkg/plugins/runtime/gateway/testdata/http/13-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/13-gateway-route.yaml
@@ -214,6 +214,10 @@ Routes:
             weightedClusters:
               clusters:
               - name: echo-exact-ad4e3a31db1bf217
+                requestHeadersToAdd:
+                - header:
+                    key: x-kuma-tags
+                    value: '&kuma.io/service=gateway-default&'
                 weight: 1
               totalWeight: 1
         - match:
@@ -230,6 +234,10 @@ Routes:
             weightedClusters:
               clusters:
               - name: echo-prefix-d0e5ba63b0c9b9f0
+                requestHeadersToAdd:
+                - header:
+                    key: x-kuma-tags
+                    value: '&kuma.io/service=gateway-default&'
                 weight: 1
               totalWeight: 1
         - match:
@@ -246,6 +254,10 @@ Routes:
             weightedClusters:
               clusters:
               - name: echo-prefix-d0e5ba63b0c9b9f0
+                requestHeadersToAdd:
+                - header:
+                    key: x-kuma-tags
+                    value: '&kuma.io/service=gateway-default&'
                 weight: 1
               totalWeight: 1
         - match:
@@ -264,6 +276,10 @@ Routes:
             weightedClusters:
               clusters:
               - name: echo-regex-627905e7b1c2eb33
+                requestHeadersToAdd:
+                - header:
+                    key: x-kuma-tags
+                    value: '&kuma.io/service=gateway-default&'
                 weight: 1
               totalWeight: 1
 Runtimes:

--- a/pkg/plugins/runtime/gateway/testdata/http/14-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/14-gateway-route.yaml
@@ -132,6 +132,10 @@ Routes:
             weightedClusters:
               clusters:
               - name: echo-service-5a416c39037aa8f6
+                requestHeadersToAdd:
+                - header:
+                    key: x-kuma-tags
+                    value: '&kuma.io/service=gateway-default&'
                 weight: 1
               totalWeight: 1
 Runtimes:

--- a/pkg/plugins/runtime/gateway/testdata/http/15-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/15-gateway-route.yaml
@@ -214,6 +214,10 @@ Routes:
             weightedClusters:
               clusters:
               - name: api-service-6b688a06cd66f5c9
+                requestHeadersToAdd:
+                - header:
+                    key: x-kuma-tags
+                    value: '&kuma.io/service=gateway-default&'
                 weight: 1
               totalWeight: 1
         - match:
@@ -230,6 +234,10 @@ Routes:
             weightedClusters:
               clusters:
               - name: api-service-6b688a06cd66f5c9
+                requestHeadersToAdd:
+                - header:
+                    key: x-kuma-tags
+                    value: '&kuma.io/service=gateway-default&'
                 weight: 1
               totalWeight: 1
         - match:
@@ -251,6 +259,10 @@ Routes:
             weightedClusters:
               clusters:
               - name: echo-service-b5c2b60cba392c4e
+                requestHeadersToAdd:
+                - header:
+                    key: x-kuma-tags
+                    value: '&kuma.io/service=gateway-default&'
                 weight: 1
               totalWeight: 1
 Runtimes:

--- a/pkg/plugins/runtime/gateway/testdata/http/16-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/16-gateway-route.yaml
@@ -211,6 +211,10 @@ Routes:
             weightedClusters:
               clusters:
               - name: api-service-49c6d22609eca2d2
+                requestHeadersToAdd:
+                - header:
+                    key: x-kuma-tags
+                    value: '&kuma.io/service=gateway-default&'
                 weight: 1
               totalWeight: 1
         - match:
@@ -227,6 +231,10 @@ Routes:
             weightedClusters:
               clusters:
               - name: api-service-49c6d22609eca2d2
+                requestHeadersToAdd:
+                - header:
+                    key: x-kuma-tags
+                    value: '&kuma.io/service=gateway-default&'
                 weight: 1
               totalWeight: 1
         - match:
@@ -248,6 +256,10 @@ Routes:
             weightedClusters:
               clusters:
               - name: echo-service-48cd7f2dbb98df84
+                requestHeadersToAdd:
+                - header:
+                    key: x-kuma-tags
+                    value: '&kuma.io/service=gateway-default&'
                 weight: 1
               totalWeight: 1
 Runtimes:

--- a/pkg/plugins/runtime/gateway/testdata/http/17-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/17-gateway-route.yaml
@@ -232,6 +232,10 @@ Routes:
             weightedClusters:
               clusters:
               - name: api-service-19fcb7995aa98119
+                requestHeadersToAdd:
+                - header:
+                    key: x-kuma-tags
+                    value: '&kuma.io/service=gateway-default&'
                 weight: 1
               totalWeight: 1
         - match:
@@ -248,6 +252,10 @@ Routes:
             weightedClusters:
               clusters:
               - name: api-service-19fcb7995aa98119
+                requestHeadersToAdd:
+                - header:
+                    key: x-kuma-tags
+                    value: '&kuma.io/service=gateway-default&'
                 weight: 1
               totalWeight: 1
         - match:
@@ -269,6 +277,10 @@ Routes:
             weightedClusters:
               clusters:
               - name: echo-service-eb4ea372d99abf73
+                requestHeadersToAdd:
+                - header:
+                    key: x-kuma-tags
+                    value: '&kuma.io/service=gateway-default&'
                 weight: 1
               totalWeight: 1
 Runtimes:

--- a/pkg/plugins/runtime/gateway/testdata/http/20-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/20-gateway-route.yaml
@@ -214,6 +214,10 @@ Routes:
             weightedClusters:
               clusters:
               - name: echo-service-dbfe9218dfa3ba0c
+                requestHeadersToAdd:
+                - header:
+                    key: x-kuma-tags
+                    value: '&kuma.io/service=gateway-multihost&'
                 weight: 1
               totalWeight: 1
       - domains:
@@ -234,6 +238,10 @@ Routes:
             weightedClusters:
               clusters:
               - name: echo-service-cff7b41a9764f367
+                requestHeadersToAdd:
+                - header:
+                    key: x-kuma-tags
+                    value: '&kuma.io/service=gateway-multihost&'
                 weight: 1
               totalWeight: 1
       - domains:
@@ -254,6 +262,10 @@ Routes:
             weightedClusters:
               clusters:
               - name: echo-service-b5c2b60cba392c4e
+                requestHeadersToAdd:
+                - header:
+                    key: x-kuma-tags
+                    value: '&kuma.io/service=gateway-multihost&'
                 weight: 1
               totalWeight: 1
 Runtimes:

--- a/pkg/plugins/runtime/gateway/testdata/http/21-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/21-gateway-route.yaml
@@ -214,6 +214,10 @@ Routes:
             weightedClusters:
               clusters:
               - name: api-service-f8ae3d759cc477a6
+                requestHeadersToAdd:
+                - header:
+                    key: x-kuma-tags
+                    value: '&kuma.io/service=gateway-default&'
                 weight: 1
               totalWeight: 1
           typedPerFilterConfig:
@@ -246,6 +250,10 @@ Routes:
             weightedClusters:
               clusters:
               - name: api-service-f8ae3d759cc477a6
+                requestHeadersToAdd:
+                - header:
+                    key: x-kuma-tags
+                    value: '&kuma.io/service=gateway-default&'
                 weight: 1
               totalWeight: 1
           typedPerFilterConfig:
@@ -283,6 +291,10 @@ Routes:
             weightedClusters:
               clusters:
               - name: echo-service-5a416c39037aa8f6
+                requestHeadersToAdd:
+                - header:
+                    key: x-kuma-tags
+                    value: '&kuma.io/service=gateway-default&'
                 weight: 1
               totalWeight: 1
           typedPerFilterConfig:

--- a/pkg/plugins/runtime/gateway/testdata/http/22-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/22-gateway-route.yaml
@@ -171,6 +171,10 @@ Routes:
             weightedClusters:
               clusters:
               - name: api-service-f8ae3d759cc477a6
+                requestHeadersToAdd:
+                - header:
+                    key: x-kuma-tags
+                    value: '&kuma.io/service=gateway-default&'
                 weight: 1
               totalWeight: 1
         - match:
@@ -187,6 +191,10 @@ Routes:
             weightedClusters:
               clusters:
               - name: echo-service-5a416c39037aa8f6
+                requestHeadersToAdd:
+                - header:
+                    key: x-kuma-tags
+                    value: '&kuma.io/service=gateway-default&'
                 weight: 1
               totalWeight: 1
       - domains:

--- a/pkg/plugins/runtime/gateway/testdata/http/23-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/23-gateway-route.yaml
@@ -171,6 +171,10 @@ Routes:
             weightedClusters:
               clusters:
               - name: api-service-f8ae3d759cc477a6
+                requestHeadersToAdd:
+                - header:
+                    key: x-kuma-tags
+                    value: '&kuma.io/service=gateway-default&'
                 weight: 1
               totalWeight: 1
         - match:
@@ -187,6 +191,10 @@ Routes:
             weightedClusters:
               clusters:
               - name: echo-service-5a416c39037aa8f6
+                requestHeadersToAdd:
+                - header:
+                    key: x-kuma-tags
+                    value: '&kuma.io/service=gateway-default&'
                 weight: 1
               totalWeight: 1
       - domains:
@@ -207,6 +215,10 @@ Routes:
             weightedClusters:
               clusters:
               - name: echo-service-5a416c39037aa8f6
+                requestHeadersToAdd:
+                - header:
+                    key: x-kuma-tags
+                    value: '&kuma.io/service=gateway-default&'
                 weight: 1
               totalWeight: 1
       - domains:

--- a/pkg/plugins/runtime/gateway/testdata/http/24-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/24-gateway-route.yaml
@@ -171,6 +171,10 @@ Routes:
             weightedClusters:
               clusters:
               - name: api-service-f8ae3d759cc477a6
+                requestHeadersToAdd:
+                - header:
+                    key: x-kuma-tags
+                    value: '&kuma.io/service=gateway-default&'
                 weight: 1
               totalWeight: 1
         - match:
@@ -187,6 +191,10 @@ Routes:
             weightedClusters:
               clusters:
               - name: echo-service-5a416c39037aa8f6
+                requestHeadersToAdd:
+                - header:
+                    key: x-kuma-tags
+                    value: '&kuma.io/service=gateway-default&'
                 weight: 1
               totalWeight: 1
       - domains:
@@ -207,6 +215,10 @@ Routes:
             weightedClusters:
               clusters:
               - name: echo-service-5a416c39037aa8f6
+                requestHeadersToAdd:
+                - header:
+                    key: x-kuma-tags
+                    value: '&kuma.io/service=gateway-default&'
                 weight: 1
               totalWeight: 1
       - domains:

--- a/pkg/plugins/runtime/gateway/testdata/http/25-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/25-gateway-route.yaml
@@ -150,6 +150,10 @@ Routes:
             weightedClusters:
               clusters:
               - name: external-httpbin-622a08eefce6a721
+                requestHeadersToAdd:
+                - header:
+                    key: x-kuma-tags
+                    value: '&kuma.io/service=gateway-default&'
                 weight: 1
               totalWeight: 1
 Runtimes:

--- a/pkg/plugins/runtime/gateway/testdata/http/26-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/26-gateway-route.yaml
@@ -136,6 +136,10 @@ Routes:
             weightedClusters:
               clusters:
               - name: external-httpbin-61ba7d91cd9211a5
+                requestHeadersToAdd:
+                - header:
+                    key: x-kuma-tags
+                    value: '&kuma.io/service=gateway-default&'
                 weight: 1
               totalWeight: 1
 Runtimes:

--- a/pkg/plugins/runtime/gateway/testdata/https/01-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/01-gateway-route.yaml
@@ -128,6 +128,10 @@ Routes:
             weightedClusters:
               clusters:
               - name: echo-service-5a416c39037aa8f6
+                requestHeadersToAdd:
+                - header:
+                    key: x-kuma-tags
+                    value: '&kuma.io/service=gateway-default&'
                 weight: 1
               totalWeight: 1
       - domains:
@@ -148,6 +152,10 @@ Routes:
             weightedClusters:
               clusters:
               - name: echo-service-5a416c39037aa8f6
+                requestHeadersToAdd:
+                - header:
+                    key: x-kuma-tags
+                    value: '&kuma.io/service=gateway-default&'
                 weight: 1
               totalWeight: 1
       - domains:
@@ -168,6 +176,10 @@ Routes:
             weightedClusters:
               clusters:
               - name: echo-service-5a416c39037aa8f6
+                requestHeadersToAdd:
+                - header:
+                    key: x-kuma-tags
+                    value: '&kuma.io/service=gateway-default&'
                 weight: 1
               totalWeight: 1
       - domains:

--- a/pkg/plugins/runtime/gateway/testdata/https/02-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/02-gateway-route.yaml
@@ -128,6 +128,10 @@ Routes:
             weightedClusters:
               clusters:
               - name: echo-service-5a416c39037aa8f6
+                requestHeadersToAdd:
+                - header:
+                    key: x-kuma-tags
+                    value: '&kuma.io/service=gateway-default&'
                 weight: 1
               totalWeight: 1
       - domains:
@@ -148,6 +152,10 @@ Routes:
             weightedClusters:
               clusters:
               - name: echo-service-5a416c39037aa8f6
+                requestHeadersToAdd:
+                - header:
+                    key: x-kuma-tags
+                    value: '&kuma.io/service=gateway-default&'
                 weight: 1
               totalWeight: 1
 Runtimes:

--- a/pkg/plugins/runtime/gateway/testdata/https/03-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/03-gateway-route.yaml
@@ -154,6 +154,10 @@ Routes:
             weightedClusters:
               clusters:
               - name: echo-service-5a416c39037aa8f6
+                requestHeadersToAdd:
+                - header:
+                    key: x-kuma-tags
+                    value: '&kuma.io/service=gateway-default&'
                 weight: 1
               totalWeight: 1
 Runtimes:

--- a/pkg/plugins/runtime/gateway/testdata/https/04-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/04-gateway-route.yaml
@@ -189,6 +189,10 @@ Routes:
             weightedClusters:
               clusters:
               - name: echo-service-5a416c39037aa8f6
+                requestHeadersToAdd:
+                - header:
+                    key: x-kuma-tags
+                    value: '&kuma.io/service=gateway-default&'
                 weight: 1
               totalWeight: 1
 Runtimes:

--- a/pkg/plugins/runtime/gateway/testdata/https/06-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/06-gateway-route.yaml
@@ -208,6 +208,10 @@ Routes:
             weightedClusters:
               clusters:
               - name: echo-service-5a416c39037aa8f6
+                requestHeadersToAdd:
+                - header:
+                    key: x-kuma-tags
+                    value: '&kuma.io/service=gateway-default&'
                 weight: 1
               totalWeight: 1
 Runtimes:

--- a/pkg/plugins/runtime/gateway/testdata/https/07-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/07-gateway-route.yaml
@@ -154,6 +154,10 @@ Routes:
             weightedClusters:
               clusters:
               - name: echo-service-5a416c39037aa8f6
+                requestHeadersToAdd:
+                - header:
+                    key: x-kuma-tags
+                    value: '&kuma.io/service=gateway-default&'
                 weight: 1
               totalWeight: 1
         - match:
@@ -170,6 +174,10 @@ Routes:
             weightedClusters:
               clusters:
               - name: echo-service-5a416c39037aa8f6
+                requestHeadersToAdd:
+                - header:
+                    key: x-kuma-tags
+                    value: '&kuma.io/service=gateway-default&'
                 weight: 1
               totalWeight: 1
 Runtimes:

--- a/pkg/plugins/runtime/gateway/testdata/https/08-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/08-gateway-route.yaml
@@ -197,6 +197,10 @@ Routes:
             weightedClusters:
               clusters:
               - name: exact-service-09493d2d54b2a972
+                requestHeadersToAdd:
+                - header:
+                    key: x-kuma-tags
+                    value: '&kuma.io/service=gateway-default&'
                 weight: 1
               totalWeight: 1
         - match:
@@ -213,6 +217,10 @@ Routes:
             weightedClusters:
               clusters:
               - name: prefix-service-5061ee504b81a555
+                requestHeadersToAdd:
+                - header:
+                    key: x-kuma-tags
+                    value: '&kuma.io/service=gateway-default&'
                 weight: 1
               totalWeight: 1
 Runtimes:

--- a/pkg/plugins/runtime/gateway/testdata/https/09-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/09-gateway-route.yaml
@@ -156,6 +156,10 @@ Routes:
             weightedClusters:
               clusters:
               - name: echo-service-5a416c39037aa8f6
+                requestHeadersToAdd:
+                - header:
+                    key: x-kuma-tags
+                    value: '&kuma.io/service=gateway-default&'
                 weight: 1
               totalWeight: 1
 Runtimes:

--- a/pkg/plugins/runtime/gateway/testdata/https/10-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/10-gateway-route.yaml
@@ -206,6 +206,10 @@ Routes:
             weightedClusters:
               clusters:
               - name: regex-header-match-ad0dd92f37b8a38d
+                requestHeadersToAdd:
+                - header:
+                    key: x-kuma-tags
+                    value: '&kuma.io/service=gateway-default&'
                 weight: 1
               totalWeight: 1
         - match:
@@ -225,6 +229,10 @@ Routes:
             weightedClusters:
               clusters:
               - name: exact-header-match-f6b57a6b55557c81
+                requestHeadersToAdd:
+                - header:
+                    key: x-kuma-tags
+                    value: '&kuma.io/service=gateway-default&'
                 weight: 1
               totalWeight: 1
         - match:
@@ -244,6 +252,10 @@ Routes:
             weightedClusters:
               clusters:
               - name: exact-header-match-f6b57a6b55557c81
+                requestHeadersToAdd:
+                - header:
+                    key: x-kuma-tags
+                    value: '&kuma.io/service=gateway-default&'
                 weight: 1
               totalWeight: 1
 Runtimes:

--- a/pkg/plugins/runtime/gateway/testdata/https/11-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/11-gateway-route.yaml
@@ -208,6 +208,10 @@ Routes:
             weightedClusters:
               clusters:
               - name: regex-query-match-3804d7b8516d7323
+                requestHeadersToAdd:
+                - header:
+                    key: x-kuma-tags
+                    value: '&kuma.io/service=gateway-default&'
                 weight: 1
               totalWeight: 1
         - match:
@@ -228,6 +232,10 @@ Routes:
             weightedClusters:
               clusters:
               - name: exact-query-match-cc1370f58a3b5330
+                requestHeadersToAdd:
+                - header:
+                    key: x-kuma-tags
+                    value: '&kuma.io/service=gateway-default&'
                 weight: 1
               totalWeight: 1
         - match:
@@ -248,6 +256,10 @@ Routes:
             weightedClusters:
               clusters:
               - name: exact-query-match-cc1370f58a3b5330
+                requestHeadersToAdd:
+                - header:
+                    key: x-kuma-tags
+                    value: '&kuma.io/service=gateway-default&'
                 weight: 1
               totalWeight: 1
 Runtimes:

--- a/pkg/plugins/runtime/gateway/testdata/https/12-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/12-gateway-route.yaml
@@ -159,6 +159,10 @@ Routes:
             weightedClusters:
               clusters:
               - name: echo-service-5a416c39037aa8f6
+                requestHeadersToAdd:
+                - header:
+                    key: x-kuma-tags
+                    value: '&kuma.io/service=gateway-default&'
                 weight: 1
               totalWeight: 1
         - match:
@@ -180,6 +184,10 @@ Routes:
             weightedClusters:
               clusters:
               - name: echo-service-5a416c39037aa8f6
+                requestHeadersToAdd:
+                - header:
+                    key: x-kuma-tags
+                    value: '&kuma.io/service=gateway-default&'
                 weight: 1
               totalWeight: 1
         - match:
@@ -201,6 +209,10 @@ Routes:
             weightedClusters:
               clusters:
               - name: echo-service-5a416c39037aa8f6
+                requestHeadersToAdd:
+                - header:
+                    key: x-kuma-tags
+                    value: '&kuma.io/service=gateway-default&'
                 weight: 1
               totalWeight: 1
 Runtimes:

--- a/pkg/plugins/runtime/gateway/testdata/https/13-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/13-gateway-route.yaml
@@ -240,6 +240,10 @@ Routes:
             weightedClusters:
               clusters:
               - name: echo-exact-ad4e3a31db1bf217
+                requestHeadersToAdd:
+                - header:
+                    key: x-kuma-tags
+                    value: '&kuma.io/service=gateway-default&'
                 weight: 1
               totalWeight: 1
         - match:
@@ -256,6 +260,10 @@ Routes:
             weightedClusters:
               clusters:
               - name: echo-prefix-d0e5ba63b0c9b9f0
+                requestHeadersToAdd:
+                - header:
+                    key: x-kuma-tags
+                    value: '&kuma.io/service=gateway-default&'
                 weight: 1
               totalWeight: 1
         - match:
@@ -272,6 +280,10 @@ Routes:
             weightedClusters:
               clusters:
               - name: echo-prefix-d0e5ba63b0c9b9f0
+                requestHeadersToAdd:
+                - header:
+                    key: x-kuma-tags
+                    value: '&kuma.io/service=gateway-default&'
                 weight: 1
               totalWeight: 1
         - match:
@@ -290,6 +302,10 @@ Routes:
             weightedClusters:
               clusters:
               - name: echo-regex-627905e7b1c2eb33
+                requestHeadersToAdd:
+                - header:
+                    key: x-kuma-tags
+                    value: '&kuma.io/service=gateway-default&'
                 weight: 1
               totalWeight: 1
 Runtimes:

--- a/pkg/plugins/runtime/gateway/testdata/https/14-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/14-gateway-route.yaml
@@ -158,6 +158,10 @@ Routes:
             weightedClusters:
               clusters:
               - name: echo-service-5a416c39037aa8f6
+                requestHeadersToAdd:
+                - header:
+                    key: x-kuma-tags
+                    value: '&kuma.io/service=gateway-default&'
                 weight: 1
               totalWeight: 1
 Runtimes:

--- a/pkg/plugins/runtime/gateway/testdata/https/15-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/15-gateway-route.yaml
@@ -240,6 +240,10 @@ Routes:
             weightedClusters:
               clusters:
               - name: api-service-6b688a06cd66f5c9
+                requestHeadersToAdd:
+                - header:
+                    key: x-kuma-tags
+                    value: '&kuma.io/service=gateway-default&'
                 weight: 1
               totalWeight: 1
         - match:
@@ -256,6 +260,10 @@ Routes:
             weightedClusters:
               clusters:
               - name: api-service-6b688a06cd66f5c9
+                requestHeadersToAdd:
+                - header:
+                    key: x-kuma-tags
+                    value: '&kuma.io/service=gateway-default&'
                 weight: 1
               totalWeight: 1
         - match:
@@ -277,6 +285,10 @@ Routes:
             weightedClusters:
               clusters:
               - name: echo-service-b5c2b60cba392c4e
+                requestHeadersToAdd:
+                - header:
+                    key: x-kuma-tags
+                    value: '&kuma.io/service=gateway-default&'
                 weight: 1
               totalWeight: 1
 Runtimes:

--- a/pkg/plugins/runtime/gateway/testdata/https/16-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/16-gateway-route.yaml
@@ -237,6 +237,10 @@ Routes:
             weightedClusters:
               clusters:
               - name: api-service-49c6d22609eca2d2
+                requestHeadersToAdd:
+                - header:
+                    key: x-kuma-tags
+                    value: '&kuma.io/service=gateway-default&'
                 weight: 1
               totalWeight: 1
         - match:
@@ -253,6 +257,10 @@ Routes:
             weightedClusters:
               clusters:
               - name: api-service-49c6d22609eca2d2
+                requestHeadersToAdd:
+                - header:
+                    key: x-kuma-tags
+                    value: '&kuma.io/service=gateway-default&'
                 weight: 1
               totalWeight: 1
         - match:
@@ -274,6 +282,10 @@ Routes:
             weightedClusters:
               clusters:
               - name: echo-service-48cd7f2dbb98df84
+                requestHeadersToAdd:
+                - header:
+                    key: x-kuma-tags
+                    value: '&kuma.io/service=gateway-default&'
                 weight: 1
               totalWeight: 1
 Runtimes:

--- a/pkg/plugins/runtime/gateway/testdata/https/17-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/17-gateway-route.yaml
@@ -258,6 +258,10 @@ Routes:
             weightedClusters:
               clusters:
               - name: api-service-19fcb7995aa98119
+                requestHeadersToAdd:
+                - header:
+                    key: x-kuma-tags
+                    value: '&kuma.io/service=gateway-default&'
                 weight: 1
               totalWeight: 1
         - match:
@@ -274,6 +278,10 @@ Routes:
             weightedClusters:
               clusters:
               - name: api-service-19fcb7995aa98119
+                requestHeadersToAdd:
+                - header:
+                    key: x-kuma-tags
+                    value: '&kuma.io/service=gateway-default&'
                 weight: 1
               totalWeight: 1
         - match:
@@ -295,6 +303,10 @@ Routes:
             weightedClusters:
               clusters:
               - name: echo-service-eb4ea372d99abf73
+                requestHeadersToAdd:
+                - header:
+                    key: x-kuma-tags
+                    value: '&kuma.io/service=gateway-default&'
                 weight: 1
               totalWeight: 1
 Runtimes:

--- a/pkg/plugins/runtime/gateway/testdata/https/20-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/20-gateway-route.yaml
@@ -362,6 +362,10 @@ Routes:
             weightedClusters:
               clusters:
               - name: echo-service-dbfe9218dfa3ba0c
+                requestHeadersToAdd:
+                - header:
+                    key: x-kuma-tags
+                    value: '&kuma.io/service=gateway-multihost&'
                 weight: 1
               totalWeight: 1
       - domains:
@@ -388,6 +392,10 @@ Routes:
             weightedClusters:
               clusters:
               - name: echo-service-cff7b41a9764f367
+                requestHeadersToAdd:
+                - header:
+                    key: x-kuma-tags
+                    value: '&kuma.io/service=gateway-multihost&'
                 weight: 1
               totalWeight: 1
       - domains:
@@ -414,6 +422,10 @@ Routes:
             weightedClusters:
               clusters:
               - name: echo-service-b5c2b60cba392c4e
+                requestHeadersToAdd:
+                - header:
+                    key: x-kuma-tags
+                    value: '&kuma.io/service=gateway-multihost&'
                 weight: 1
               totalWeight: 1
 Runtimes:

--- a/pkg/plugins/runtime/gateway/testdata/https/21-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/21-gateway-route.yaml
@@ -240,6 +240,10 @@ Routes:
             weightedClusters:
               clusters:
               - name: api-service-f8ae3d759cc477a6
+                requestHeadersToAdd:
+                - header:
+                    key: x-kuma-tags
+                    value: '&kuma.io/service=gateway-default&'
                 weight: 1
               totalWeight: 1
           typedPerFilterConfig:
@@ -272,6 +276,10 @@ Routes:
             weightedClusters:
               clusters:
               - name: api-service-f8ae3d759cc477a6
+                requestHeadersToAdd:
+                - header:
+                    key: x-kuma-tags
+                    value: '&kuma.io/service=gateway-default&'
                 weight: 1
               totalWeight: 1
           typedPerFilterConfig:
@@ -309,6 +317,10 @@ Routes:
             weightedClusters:
               clusters:
               - name: echo-service-5a416c39037aa8f6
+                requestHeadersToAdd:
+                - header:
+                    key: x-kuma-tags
+                    value: '&kuma.io/service=gateway-default&'
                 weight: 1
               totalWeight: 1
           typedPerFilterConfig:

--- a/pkg/plugins/runtime/gateway/testdata/https/22-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/22-gateway-route.yaml
@@ -171,6 +171,10 @@ Routes:
             weightedClusters:
               clusters:
               - name: api-service-f8ae3d759cc477a6
+                requestHeadersToAdd:
+                - header:
+                    key: x-kuma-tags
+                    value: '&kuma.io/service=gateway-default&'
                 weight: 1
               totalWeight: 1
         - match:
@@ -187,6 +191,10 @@ Routes:
             weightedClusters:
               clusters:
               - name: echo-service-5a416c39037aa8f6
+                requestHeadersToAdd:
+                - header:
+                    key: x-kuma-tags
+                    value: '&kuma.io/service=gateway-default&'
                 weight: 1
               totalWeight: 1
       - domains:

--- a/pkg/plugins/runtime/gateway/testdata/https/23-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/23-gateway-route.yaml
@@ -171,6 +171,10 @@ Routes:
             weightedClusters:
               clusters:
               - name: api-service-f8ae3d759cc477a6
+                requestHeadersToAdd:
+                - header:
+                    key: x-kuma-tags
+                    value: '&kuma.io/service=gateway-default&'
                 weight: 1
               totalWeight: 1
         - match:
@@ -187,6 +191,10 @@ Routes:
             weightedClusters:
               clusters:
               - name: echo-service-5a416c39037aa8f6
+                requestHeadersToAdd:
+                - header:
+                    key: x-kuma-tags
+                    value: '&kuma.io/service=gateway-default&'
                 weight: 1
               totalWeight: 1
       - domains:
@@ -207,6 +215,10 @@ Routes:
             weightedClusters:
               clusters:
               - name: echo-service-5a416c39037aa8f6
+                requestHeadersToAdd:
+                - header:
+                    key: x-kuma-tags
+                    value: '&kuma.io/service=gateway-default&'
                 weight: 1
               totalWeight: 1
       - domains:

--- a/pkg/plugins/runtime/gateway/testdata/https/24-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/24-gateway-route.yaml
@@ -171,6 +171,10 @@ Routes:
             weightedClusters:
               clusters:
               - name: api-service-f8ae3d759cc477a6
+                requestHeadersToAdd:
+                - header:
+                    key: x-kuma-tags
+                    value: '&kuma.io/service=gateway-default&'
                 weight: 1
               totalWeight: 1
         - match:
@@ -187,6 +191,10 @@ Routes:
             weightedClusters:
               clusters:
               - name: echo-service-5a416c39037aa8f6
+                requestHeadersToAdd:
+                - header:
+                    key: x-kuma-tags
+                    value: '&kuma.io/service=gateway-default&'
                 weight: 1
               totalWeight: 1
       - domains:
@@ -207,6 +215,10 @@ Routes:
             weightedClusters:
               clusters:
               - name: echo-service-5a416c39037aa8f6
+                requestHeadersToAdd:
+                - header:
+                    key: x-kuma-tags
+                    value: '&kuma.io/service=gateway-default&'
                 weight: 1
               totalWeight: 1
       - domains:

--- a/pkg/plugins/runtime/gateway/testdata/https/25-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/25-gateway-route.yaml
@@ -176,6 +176,10 @@ Routes:
             weightedClusters:
               clusters:
               - name: external-httpbin-622a08eefce6a721
+                requestHeadersToAdd:
+                - header:
+                    key: x-kuma-tags
+                    value: '&kuma.io/service=gateway-default&'
                 weight: 1
               totalWeight: 1
 Runtimes:

--- a/pkg/plugins/runtime/gateway/testdata/https/26-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/26-gateway-route.yaml
@@ -162,6 +162,10 @@ Routes:
             weightedClusters:
               clusters:
               - name: external-httpbin-61ba7d91cd9211a5
+                requestHeadersToAdd:
+                - header:
+                    key: x-kuma-tags
+                    value: '&kuma.io/service=gateway-default&'
                 weight: 1
               totalWeight: 1
 Runtimes:


### PR DESCRIPTION
### Summary

Closes https://github.com/kumahq/kuma/issues/3313

This PR adds `requestHeadersToAdd` to the weighted clusters depending on if the request is staying in the mesh.

The issue assumes we have to do this in RouteConfiguration but it seems like we can add this to each WeightedCluster. Is this (i.e. the configs in the test) the correct behavior?