### PR TITLE
fix(kuma-cp): support GC service account

### DIFF
--- a/pkg/plugins/runtime/k8s/webhooks/validation.go
+++ b/pkg/plugins/runtime/k8s/webhooks/validation.go
@@ -110,8 +110,10 @@ func (h *validatingHandler) decode(req admission.Request) (core_model.Resource, 
 
 // Note that this func does not validate ConfigMap and Secret since this webhook does not support those
 func (h *validatingHandler) isOperationAllowed(resType core_model.ResourceType, userInfo authenticationv1.UserInfo) admission.Response {
-	if userInfo.Username == h.cpServiceAccountName {
-		// Assume this means sync from another zone. Not security; protecting user from self.
+	if userInfo.Username == h.cpServiceAccountName ||
+		userInfo.Username == "system:serviceaccount:kube-system:generic-garbage-collector" {
+		// Assume this means sync from another zone or GC cleanup resources due to OwnerRef.
+		// Not security; protecting user from self.
 		return admission.Allowed("")
 	}
 

--- a/pkg/plugins/runtime/k8s/webhooks/validation_test.go
+++ b/pkg/plugins/runtime/k8s/webhooks/validation_test.go
@@ -656,5 +656,20 @@ var _ = Describe("Validation", func() {
 			},
 			operation: admissionv1.Delete,
 		}),
+		Entry("should pass validation on DELETE in Global CP by GC", testCase{
+			mode:        core.Global,
+			objTemplate: &mesh_proto.Dataplane{},
+			username:    "system:serviceaccount:kube-system:generic-garbage-collector",
+			resp: kube_admission.Response{
+				AdmissionResponse: admissionv1.AdmissionResponse{
+					UID:     "12345",
+					Allowed: true,
+					Result: &kube_meta.Status{
+						Code: 200,
+					},
+				},
+			},
+			operation: admissionv1.Delete,
+		}),
 	)
 })


### PR DESCRIPTION
### Summary

Special treatment for GC service account when checking if an operation on resources is allowed

### Full changelog

* [Implement ...]
* [Fix ...]

### Issues resolved

Fix https://github.com/kumahq/kuma/issues/4434

### Documentation

- [ ] Link to the website [documentation PR](https://github.com/kumahq/kuma-website/pull/XXX)

### Testing

- [X] Unit tests
- [ ] E2E tests
- [ ] Manual testing on Universal
- [X] Manual testing on Kubernetes

### Backwards compatibility

- [ ] Update [`UPGRADE.md`](/UPGRADE.md) with any steps users will need to take when upgrading.
- [ ] Add `backport-to-stable` label if the code follows our [backporting policy](/CONTRIBUTING.md#backporting)
