### PR TITLE
deps(*) move from github.com/pkg/errors to 'errors' and 'fmt'

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -56,7 +56,12 @@ linters-settings:
       modules:
       - github.com/go-errors/errors:
           recommendations:
-          - github.com/pkg/errors
+          - fmt
+          - errors
+      - github.com/pkg/errors:
+          recommendations:
+          - fmt
+          - errors
   misspell:
     locale: US
     ignore-words:

--- a/api/mesh/v1alpha1/dataplane_helpers.go
+++ b/api/mesh/v1alpha1/dataplane_helpers.go
@@ -8,8 +8,6 @@ import (
 	"sort"
 	"strconv"
 	"strings"
-
-	"github.com/pkg/errors"
 )
 
 const (
@@ -49,7 +47,7 @@ func (t ProxyType) IsValid() error {
 	case DataplaneProxyType, IngressProxyType, EgressProxyType:
 		return nil
 	}
-	return errors.Errorf("%s is not a valid proxy type", t)
+	return fmt.Errorf("%s is not a valid proxy type", t)
 }
 
 type InboundInterface struct {
@@ -125,7 +123,7 @@ func (n *Dataplane_Networking) GetInboundInterface(service string) (*InboundInte
 		iface := n.ToInboundInterface(inbound)
 		return &iface, nil
 	}
-	return nil, errors.Errorf("Dataplane has no Inbound Interface for service %q", service)
+	return nil, fmt.Errorf("Dataplane has no Inbound Interface for service %q", service)
 }
 
 func (n *Dataplane_Networking) GetInboundInterfaces() []InboundInterface {

--- a/api/mesh/v1alpha1/dataplane_insight_helpers.go
+++ b/api/mesh/v1alpha1/dataplane_insight_helpers.go
@@ -1,10 +1,9 @@
 package v1alpha1
 
 import (
+	"fmt"
 	"strings"
 	"time"
-
-	"github.com/pkg/errors"
 
 	"github.com/kumahq/kuma/api/generic"
 	util_proto "github.com/kumahq/kuma/pkg/util/proto"
@@ -91,7 +90,7 @@ func (x *DataplaneInsight) UpdateSubscription(s generic.Subscription) error {
 	}
 	discoverySubscription, ok := s.(*DiscoverySubscription)
 	if !ok {
-		return errors.Errorf("invalid type %T for DataplaneInsight", s)
+		return fmt.Errorf("invalid type %T for DataplaneInsight", s)
 	}
 	i, old := x.GetSubscription(discoverySubscription.Id)
 	if old != nil {

--- a/api/mesh/v1alpha1/zone_ingress_insight_helpers.go
+++ b/api/mesh/v1alpha1/zone_ingress_insight_helpers.go
@@ -1,7 +1,7 @@
 package v1alpha1
 
 import (
-	"github.com/pkg/errors"
+	"fmt"
 
 	"github.com/kumahq/kuma/api/generic"
 	util_proto "github.com/kumahq/kuma/pkg/util/proto"
@@ -24,7 +24,7 @@ func (x *ZoneIngressInsight) UpdateSubscription(s generic.Subscription) error {
 	}
 	discoverySubscription, ok := s.(*DiscoverySubscription)
 	if !ok {
-		return errors.Errorf("invalid type %T for ZoneIngressInsight", s)
+		return fmt.Errorf("invalid type %T for ZoneIngressInsight", s)
 	}
 	i, old := x.GetSubscription(discoverySubscription.Id)
 	if old != nil {

--- a/api/mesh/v1alpha1/zoneegressinsight_helpers.go
+++ b/api/mesh/v1alpha1/zoneegressinsight_helpers.go
@@ -1,7 +1,7 @@
 package v1alpha1
 
 import (
-	"github.com/pkg/errors"
+	"fmt"
 
 	"github.com/kumahq/kuma/api/generic"
 	util_proto "github.com/kumahq/kuma/pkg/util/proto"
@@ -24,7 +24,7 @@ func (x *ZoneEgressInsight) UpdateSubscription(s generic.Subscription) error {
 	}
 	discoverySubscription, ok := s.(*DiscoverySubscription)
 	if !ok {
-		return errors.Errorf("invalid type %T for ZoneEgressInsight", s)
+		return fmt.Errorf("invalid type %T for ZoneEgressInsight", s)
 	}
 	i, old := x.GetSubscription(discoverySubscription.Id)
 	if old != nil {

--- a/api/system/v1alpha1/zone_insight_helpers.go
+++ b/api/system/v1alpha1/zone_insight_helpers.go
@@ -1,9 +1,9 @@
 package v1alpha1
 
 import (
+	"fmt"
 	"time"
 
-	"github.com/pkg/errors"
 	timestamppb "google.golang.org/protobuf/types/known/timestamppb"
 
 	"github.com/kumahq/kuma/api/generic"
@@ -62,7 +62,7 @@ func (x *ZoneInsight) UpdateSubscription(s generic.Subscription) error {
 	}
 	kdsSubscription, ok := s.(*KDSSubscription)
 	if !ok {
-		return errors.Errorf("invalid type %T for ZoneInsight", s)
+		return fmt.Errorf("invalid type %T for ZoneInsight", s)
 	}
 	i, old := x.GetSubscription(kdsSubscription.Id)
 	if old != nil {

--- a/app/kuma-cp/cmd/migrate.go
+++ b/app/kuma-cp/cmd/migrate.go
@@ -1,7 +1,9 @@
 package cmd
 
 import (
-	"github.com/pkg/errors"
+	"errors"
+	"fmt"
+
 	"github.com/spf13/cobra"
 
 	"github.com/kumahq/kuma/pkg/config"
@@ -40,7 +42,7 @@ func newMigrateUpCmd() *cobra.Command {
 			}
 
 			if err := migrate(cfg); err != nil {
-				if err == core_plugins.AlreadyMigrated {
+				if errors.Is(err, core_plugins.AlreadyMigrated) {
 					cmd.Printf("DB has already been migrated for Kuma %s\n", version.Build.Version)
 				} else {
 					return err
@@ -70,11 +72,11 @@ func migrate(cfg kuma_cp.Config) error {
 		pluginName = core_plugins.Postgres
 		pluginConfig = cfg.Store.Postgres
 	default:
-		return errors.Errorf("unknown store type %s", cfg.Store.Type)
+		return fmt.Errorf("unknown store type %s", cfg.Store.Type)
 	}
 	plugin, err := core_plugins.Plugins().ResourceStore(pluginName)
 	if err != nil {
-		return errors.Wrapf(err, "could not retrieve store %s plugin", pluginName)
+		return fmt.Errorf("could not retrieve store %s plugin: %w", pluginName, err)
 	}
 	_, err = plugin.Migrate(nil, pluginConfig)
 	return err

--- a/app/kuma-dp/cmd/dataplane.go
+++ b/app/kuma-dp/cmd/dataplane.go
@@ -1,10 +1,10 @@
 package cmd
 
 import (
+	"fmt"
 	"io"
 	"os"
 
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
 	kuma_dp "github.com/kumahq/kuma/pkg/config/app/kuma-dp"
@@ -30,7 +30,7 @@ func readResource(cmd *cobra.Command, r *kuma_dp.DataplaneRuntime) (model.Resour
 		}
 	default:
 		if b, err = os.ReadFile(r.ResourcePath); err != nil {
-			return nil, errors.Wrap(err, "error while reading provided file")
+			return nil, fmt.Errorf("error while reading provided file: %w", err)
 		}
 	}
 

--- a/app/kuma-dp/pkg/config/validate.go
+++ b/app/kuma-dp/pkg/config/validate.go
@@ -1,11 +1,12 @@
 package config
 
 import (
+	"errors"
+	"fmt"
 	"os"
 	"unicode"
 
 	"github.com/golang-jwt/jwt/v4"
-	"github.com/pkg/errors"
 
 	util_files "github.com/kumahq/kuma/pkg/util/files"
 )
@@ -16,20 +17,20 @@ func ValidateTokenPath(path string) error {
 	}
 	empty, err := util_files.FileEmpty(path)
 	if err != nil {
-		return errors.Wrapf(err, "could not read file %s", path)
+		return fmt.Errorf("could not read file %s: %w", path, err)
 	}
 	if empty {
-		return errors.Errorf("token under file %s is empty", path)
+		return fmt.Errorf("token under file %s is empty", path)
 	}
 
 	rawToken, err := os.ReadFile(path)
 	if err != nil {
-		return errors.Wrapf(err, "could not read the token in the file %s", path)
+		return fmt.Errorf("could not read the token in the file %s: %w", path, err)
 	}
 
 	token, parts, err := new(jwt.Parser).ParseUnverified(string(rawToken), &jwt.MapClaims{})
 	if err != nil {
-		return errors.Wrap(err, "not valid JWT token. Can't parse it.")
+		return fmt.Errorf("not valid JWT token. Can't parse it.: %w", err)
 	}
 
 	if token.Method.Alg() == "" {

--- a/app/kuma-dp/pkg/dataplane/accesslogs/server.go
+++ b/app/kuma-dp/pkg/dataplane/accesslogs/server.go
@@ -5,7 +5,6 @@ import (
 	"net"
 	"os"
 
-	"github.com/pkg/errors"
 	"google.golang.org/grpc"
 
 	v3 "github.com/kumahq/kuma/app/kuma-dp/pkg/dataplane/accesslogs/v3"
@@ -45,11 +44,11 @@ func (s *accessLogServer) Start(stop <-chan struct{}) error {
 		newName := s.address + ".bak"
 		err := os.Rename(s.address, newName)
 		if err != nil {
-			return errors.Errorf("file %s exists and probably opened by another kuma-dp instance", s.address)
+			return fmt.Errorf("file %s exists and probably opened by another kuma-dp instance", s.address)
 		}
 		err = os.Remove(newName)
 		if err != nil {
-			return errors.Errorf("not able the delete the backup file %s", newName)
+			return fmt.Errorf("not able the delete the backup file %s", newName)
 		}
 	}
 

--- a/app/kuma-dp/pkg/dataplane/accesslogs/v3/factories.go
+++ b/app/kuma-dp/pkg/dataplane/accesslogs/v3/factories.go
@@ -1,11 +1,11 @@
 package v3
 
 import (
+	"fmt"
 	"strings"
 
 	envoy_accesslog "github.com/envoyproxy/go-control-plane/envoy/service/accesslog/v3"
 	"github.com/go-logr/logr"
-	"github.com/pkg/errors"
 
 	accesslog "github.com/kumahq/kuma/pkg/envoy/accesslog/v3"
 )
@@ -13,7 +13,7 @@ import (
 func defaultHandler(log logr.Logger, msg *envoy_accesslog.StreamAccessLogsMessage) (logHandler, error) {
 	parts := strings.SplitN(msg.GetIdentifier().GetLogName(), ";", 2)
 	if len(parts) != 2 {
-		return nil, errors.Errorf("log name %q has invalid format: expected %d components separated by ';', got %d", msg.GetIdentifier().GetLogName(), 2, len(parts))
+		return nil, fmt.Errorf("log name %q has invalid format: expected %d components separated by ';', got %d", msg.GetIdentifier().GetLogName(), 2, len(parts))
 	}
 	address, formatString := parts[0], parts[1]
 

--- a/app/kuma-dp/pkg/dataplane/accesslogs/v3/sender.go
+++ b/app/kuma-dp/pkg/dataplane/accesslogs/v3/sender.go
@@ -1,11 +1,11 @@
 package v3
 
 import (
+	"fmt"
 	"net"
 	"time"
 
 	"github.com/go-logr/logr"
-	"github.com/pkg/errors"
 )
 
 const (
@@ -21,7 +21,7 @@ type sender struct {
 func (s *sender) Connect() error {
 	conn, err := net.DialTimeout("tcp", s.address, defaultConnectTimeout)
 	if err != nil {
-		return errors.Wrapf(err, "failed to connect to a TCP logging backend: %s", s.address)
+		return fmt.Errorf("failed to connect to a TCP logging backend: %s: %w", s.address, err)
 	}
 	s.log.Info("connected to TCP logging backend", "address", s.address)
 	s.conn = conn
@@ -30,7 +30,7 @@ func (s *sender) Connect() error {
 
 func (s *sender) Send(record string) error {
 	_, err := s.conn.Write([]byte(record))
-	return errors.Wrapf(err, "failed to send a log entry to a TCP logging backend: %s", s.address)
+	return fmt.Errorf("failed to send a log entry to a TCP logging backend: %s: %w", s.address, err)
 }
 
 func (s *sender) Close() error {

--- a/app/kuma-dp/pkg/dataplane/accesslogs/v3/server.go
+++ b/app/kuma-dp/pkg/dataplane/accesslogs/v3/server.go
@@ -1,11 +1,12 @@
 package v3
 
 import (
+	"errors"
+	"fmt"
 	"io"
 	"sync/atomic"
 
 	envoy_accesslog "github.com/envoyproxy/go-control-plane/envoy/service/accesslog/v3"
-	"github.com/pkg/errors"
 	"google.golang.org/grpc"
 
 	"github.com/kumahq/kuma/pkg/core"
@@ -49,7 +50,7 @@ func (s *accessLogServer) StreamAccessLogs(stream envoy_accesslog.AccessLogServi
 	for {
 		msg, err := stream.Recv()
 		if err != nil {
-			if err == io.EOF {
+			if errors.Is(err, io.EOF) {
 				return nil
 			}
 			return err
@@ -62,7 +63,7 @@ func (s *accessLogServer) StreamAccessLogs(stream envoy_accesslog.AccessLogServi
 
 			handler, err = s.newHandler(log, msg)
 			if err != nil {
-				return errors.Wrap(err, "failed to initialize Access Logs stream")
+				return fmt.Errorf("failed to initialize Access Logs stream: %w", err)
 			}
 			defer handler.Close()
 		}

--- a/app/kuma-dp/pkg/dataplane/dnsserver/config_file.go
+++ b/app/kuma-dp/pkg/dataplane/dnsserver/config_file.go
@@ -1,24 +1,23 @@
 package dnsserver
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
-
-	"github.com/pkg/errors"
 
 	kuma_dp "github.com/kumahq/kuma/pkg/config/app/kuma-dp"
 )
 
 func GenerateConfigFile(cfg kuma_dp.DNS, config []byte) (string, error) {
 	configFile := filepath.Join(cfg.ConfigDir, "Corefile")
-	if err := writeFile(configFile, config, 0600); err != nil {
-		return "", errors.Wrap(err, "failed to persist Envoy bootstrap config on disk")
+	if err := writeFile(configFile, config, 0o600); err != nil {
+		return "", fmt.Errorf("failed to persist Envoy bootstrap config on disk: %w", err)
 	}
 	return configFile, nil
 }
 
 func writeFile(filename string, data []byte, perm os.FileMode) error {
-	if err := os.MkdirAll(filepath.Dir(filename), 0755); err != nil {
+	if err := os.MkdirAll(filepath.Dir(filename), 0o755); err != nil {
 		return err
 	}
 	return os.WriteFile(filename, data, perm)

--- a/app/kuma-dp/pkg/dataplane/dnsserver/dnsserver.go
+++ b/app/kuma-dp/pkg/dataplane/dnsserver/dnsserver.go
@@ -3,13 +3,12 @@ package dnsserver
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"io"
 	"os/exec"
 	"regexp"
 	"sync"
 	"text/template"
-
-	"github.com/pkg/errors"
 
 	command_utils "github.com/kumahq/kuma/app/kuma-dp/pkg/dataplane/command"
 	kuma_dp "github.com/kumahq/kuma/pkg/config/app/kuma-dp"
@@ -18,9 +17,7 @@ import (
 	"github.com/kumahq/kuma/pkg/util/files"
 )
 
-var (
-	runLog = core.Log.WithName("kuma-dp").WithName("run").WithName("dns-server")
-)
+var runLog = core.Log.WithName("kuma-dp").WithName("run").WithName("dns-server")
 
 type DNSServer struct {
 	opts *Opts
@@ -82,7 +79,7 @@ func (s *DNSServer) GetVersion() (string, error) {
 
 	match := regexp.MustCompile(`CoreDNS-(.*)`).FindSubmatch(output)
 	if len(match) < 2 {
-		return "", errors.Errorf("unexpected version output format: %s", output)
+		return "", fmt.Errorf("unexpected version output format: %s", output)
 	}
 
 	return string(match[1]), nil

--- a/app/kuma-dp/pkg/dataplane/dnsserver/dnsserver_test.go
+++ b/app/kuma-dp/pkg/dataplane/dnsserver/dnsserver_test.go
@@ -5,6 +5,7 @@ package dnsserver
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -167,7 +168,8 @@ var _ = Describe("DNS Server", func() {
 			Expect(err).To(BeAssignableToTypeOf(&exec.ExitError{}))
 
 			// when
-			exitError := err.(*exec.ExitError)
+			var exitError *exec.ExitError
+			errors.As(err, &exitError)
 			// then
 			Expect(exitError.ProcessState.ExitCode()).To(Equal(1))
 		}))

--- a/app/kuma-dp/pkg/dataplane/envoy/bootstrap_file.go
+++ b/app/kuma-dp/pkg/dataplane/envoy/bootstrap_file.go
@@ -1,24 +1,23 @@
 package envoy
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
-
-	"github.com/pkg/errors"
 
 	kuma_dp "github.com/kumahq/kuma/pkg/config/app/kuma-dp"
 )
 
 func GenerateBootstrapFile(cfg kuma_dp.DataplaneRuntime, config []byte) (string, error) {
 	configFile := filepath.Join(cfg.ConfigDir, "bootstrap.yaml")
-	if err := writeFile(configFile, config, 0600); err != nil {
-		return "", errors.Wrap(err, "failed to persist Envoy bootstrap config on disk")
+	if err := writeFile(configFile, config, 0o600); err != nil {
+		return "", fmt.Errorf("failed to persist Envoy bootstrap config on disk: %w", err)
 	}
 	return configFile, nil
 }
 
 func writeFile(filename string, data []byte, perm os.FileMode) error {
-	if err := os.MkdirAll(filepath.Dir(filename), 0755); err != nil {
+	if err := os.MkdirAll(filepath.Dir(filename), 0o755); err != nil {
 		return err
 	}
 	return os.WriteFile(filename, data, perm)

--- a/app/kuma-dp/pkg/dataplane/envoy/compatibility.go
+++ b/app/kuma-dp/pkg/dataplane/envoy/compatibility.go
@@ -1,8 +1,9 @@
 package envoy
 
 import (
+	"fmt"
+
 	"github.com/Masterminds/semver/v3"
-	"github.com/pkg/errors"
 )
 
 // EnvoyCompatibility is the description of envoy versions
@@ -15,13 +16,13 @@ var EnvoyCompatibility = "~1.21.1"
 func EnvoyVersionCompatible(envoyVersion string) (bool, error) {
 	ver, err := semver.NewVersion(envoyVersion)
 	if err != nil {
-		return false, errors.Wrapf(err, "unable to parse envoy version %s", envoyVersion)
+		return false, fmt.Errorf("unable to parse envoy version %s: %w", envoyVersion, err)
 	}
 
 	constraint, err := semver.NewConstraint(EnvoyCompatibility)
 	if err != nil {
 		// Programmer error
-		panic(errors.Wrapf(err, "Invalid envoy compatibility constraint %s", EnvoyCompatibility))
+		panic(fmt.Errorf("Invalid envoy compatibility constraint %s: %w", EnvoyCompatibility, err))
 	}
 
 	return constraint.Check(ver), nil

--- a/app/kuma-dp/pkg/dataplane/envoy/envoy.go
+++ b/app/kuma-dp/pkg/dataplane/envoy/envoy.go
@@ -14,7 +14,6 @@ import (
 	"time"
 
 	envoy_bootstrap_v3 "github.com/envoyproxy/go-control-plane/envoy/config/bootstrap/v3"
-	"github.com/pkg/errors"
 
 	command_utils "github.com/kumahq/kuma/app/kuma-dp/pkg/dataplane/command"
 	kuma_dp "github.com/kumahq/kuma/pkg/config/app/kuma-dp"
@@ -25,9 +24,7 @@ import (
 	"github.com/kumahq/kuma/pkg/xds/bootstrap/types"
 )
 
-var (
-	runLog = core.Log.WithName("kuma-dp").WithName("run").WithName("envoy")
-)
+var runLog = core.Log.WithName("kuma-dp").WithName("run").WithName("envoy")
 
 type BootstrapParams struct {
 	Dataplane       *rest.Resource
@@ -176,7 +173,7 @@ func (e *Envoy) DrainConnections() error {
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != 200 {
-		return errors.Errorf("expected 200 status code, got %d", resp.StatusCode)
+		return fmt.Errorf("expected 200 status code, got %d", resp.StatusCode)
 	}
 	return nil
 }
@@ -190,7 +187,7 @@ func GetEnvoyVersion(binaryPath string) (*EnvoyVersion, error) {
 	command := exec.Command(resolvedPath, arg)
 	output, err := command.Output()
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to execute %s with arguments %q", resolvedPath, arg)
+		return nil, fmt.Errorf("failed to execute %s with arguments %q: %w", resolvedPath, arg, err)
 	}
 	build := strings.ReplaceAll(string(output), "\r\n", "\n")
 	build = strings.Trim(build, "\n")
@@ -200,7 +197,7 @@ func GetEnvoyVersion(binaryPath string) (*EnvoyVersion, error) {
 
 	parts := strings.Split(build, "/")
 	if len(parts) != 5 { // revision/build_version_number/revision_status/build_type/ssl_version
-		return nil, errors.Errorf("wrong Envoy build format: %s", build)
+		return nil, fmt.Errorf("wrong Envoy build format: %s", build)
 	}
 	return &EnvoyVersion{
 		Build:   build,

--- a/app/kuma-dp/pkg/dataplane/envoy/envoy_test.go
+++ b/app/kuma-dp/pkg/dataplane/envoy/envoy_test.go
@@ -5,6 +5,7 @@ package envoy_test
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -22,7 +23,6 @@ import (
 )
 
 var _ = Describe("Envoy", func() {
-
 	var configDir string
 
 	BeforeEach(func() {
@@ -214,7 +214,8 @@ var _ = Describe("Envoy", func() {
 			Expect(err).To(BeAssignableToTypeOf(&exec.ExitError{}))
 
 			// when
-			exitError := err.(*exec.ExitError)
+			var exitError *exec.ExitError
+			errors.As(err, &exitError)
 			// then
 			Expect(exitError.ProcessState.ExitCode()).To(Equal(1))
 		}))

--- a/app/kuma-dp/pkg/dataplane/metrics/merge.go
+++ b/app/kuma-dp/pkg/dataplane/metrics/merge.go
@@ -1,13 +1,13 @@
 package metrics
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"regexp"
 	"sort"
 	"strings"
 
-	"github.com/pkg/errors"
 	io_prometheus_client "github.com/prometheus/client_model/go"
 	"github.com/prometheus/common/expfmt"
 )

--- a/app/kuma-dp/pkg/dataplane/metrics/server.go
+++ b/app/kuma-dp/pkg/dataplane/metrics/server.go
@@ -12,8 +12,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/pkg/errors"
-
 	kumadp "github.com/kumahq/kuma/pkg/config/app/kuma-dp"
 	"github.com/kumahq/kuma/pkg/core"
 	"github.com/kumahq/kuma/pkg/core/runtime/component"
@@ -54,11 +52,11 @@ func (s *Hijacker) Start(stop <-chan struct{}) error {
 		newName := s.socketPath + ".bak"
 		err := os.Rename(s.socketPath, newName)
 		if err != nil {
-			return errors.Errorf("file %s exists and probably opened by another kuma-dp instance", s.socketPath)
+			return fmt.Errorf("file %s exists and probably opened by another kuma-dp instance", s.socketPath)
 		}
 		err = os.Remove(newName)
 		if err != nil {
-			return errors.Errorf("not able the delete the backup file %s", newName)
+			return fmt.Errorf("not able the delete the backup file %s", newName)
 		}
 	}
 

--- a/app/kuma-prometheus-sd/cmd/run.go
+++ b/app/kuma-prometheus-sd/cmd/run.go
@@ -1,9 +1,9 @@
 package cmd
 
 import (
+	"fmt"
 	"path/filepath"
 
-	"github.com/pkg/errors"
 	"github.com/prometheus/prometheus/documentation/examples/custom-sd/adapter"
 	"github.com/spf13/cobra"
 
@@ -16,9 +16,7 @@ import (
 	util_os "github.com/kumahq/kuma/pkg/util/os"
 )
 
-var (
-	runLog = prometheusSdLog.WithName("run")
-)
+var runLog = prometheusSdLog.WithName("run")
 
 func newRunCmdWithOpts(opts kuma_cmd.RunCmdOpts) *cobra.Command {
 	cfg := kuma_promsd.DefaultConfig()
@@ -41,7 +39,7 @@ func newRunCmdWithOpts(opts kuma_cmd.RunCmdOpts) *cobra.Command {
 
 			outputDir, _ := filepath.Split(cfg.Prometheus.OutputFile)
 			if err := util_os.TryWriteToDir(outputDir); err != nil {
-				return errors.Wrapf(err, "unable to write to directory %q", outputDir)
+				return fmt.Errorf("unable to write to directory %q: %w", outputDir, err)
 			}
 
 			ctx, _ := opts.SetupSignalHandler()

--- a/app/kuma-prometheus-sd/pkg/discovery/xds/xds.go
+++ b/app/kuma-prometheus-sd/pkg/discovery/xds/xds.go
@@ -2,9 +2,9 @@ package xds
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/go-logr/logr"
-	"github.com/pkg/errors"
 	"github.com/prometheus/prometheus/discovery"
 	"github.com/prometheus/prometheus/discovery/targetgroup"
 
@@ -24,7 +24,7 @@ func NewDiscoverer(config common.DiscoveryConfig, log logr.Logger) (discovery.Di
 	case common.V1:
 		factory = v1.NewFactory()
 	default:
-		return nil, errors.Errorf("invalid MADS apiVersion %s", config.ApiVersion)
+		return nil, fmt.Errorf("invalid MADS apiVersion %s", config.ApiVersion)
 	}
 
 	return &discoverer{
@@ -49,7 +49,7 @@ func (d *discoverer) Run(ctx context.Context, ch chan<- []*targetgroup.Group) {
 					if err, ok := e.(error); ok {
 						errCh <- err
 					} else {
-						errCh <- errors.Errorf("%v", e)
+						errCh <- fmt.Errorf("%v", e)
 					}
 				}
 			}()

--- a/app/kumactl/cmd/apply/apply.go
+++ b/app/kumactl/cmd/apply/apply.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
 	kumactl_cmd "github.com/kumahq/kuma/app/kumactl/pkg/cmd"
@@ -80,24 +79,24 @@ $ kumactl apply -f https://example.com/resource.yaml
 					}
 					req, err := http.NewRequest("GET", ctx.args.file, nil)
 					if err != nil {
-						return errors.Wrap(err, "error creating new http request")
+						return fmt.Errorf("error creating new http request: %w", err)
 					}
 					resp, err := client.Do(req)
 					if err != nil {
-						return errors.Wrap(err, "error with GET http request")
+						return fmt.Errorf("error with GET http request: %w", err)
 					}
 					if resp.StatusCode != http.StatusOK {
-						return errors.Wrap(err, "error while retrieving URL")
+						return fmt.Errorf("error while retrieving URL: %w", err)
 					}
 					defer resp.Body.Close()
 					b, err = io.ReadAll(resp.Body)
 					if err != nil {
-						return errors.Wrap(err, "error while reading provided file")
+						return fmt.Errorf("error while reading provided file: %w", err)
 					}
 				} else {
 					b, err = os.ReadFile(ctx.args.file)
 					if err != nil {
-						return errors.Wrap(err, "error while reading provided file")
+						return fmt.Errorf("error while reading provided file: %w", err)
 					}
 				}
 			}
@@ -116,7 +115,7 @@ $ kumactl apply -f https://example.com/resource.yaml
 				}
 				res, err := rest_types.UnmarshallToCore(bytes)
 				if err != nil {
-					return errors.Wrap(err, "YAML contains invalid resource")
+					return fmt.Errorf("YAML contains invalid resource: %w", err)
 				}
 				if err := mesh.ValidateMeta(res.GetMeta().GetName(), res.GetMeta().GetMesh(), res.Descriptor().Scope); err.HasViolations() {
 					return err.OrNil()

--- a/app/kumactl/cmd/config/config_control_planes_remove.go
+++ b/app/kumactl/cmd/config/config_control_planes_remove.go
@@ -1,7 +1,8 @@
 package config
 
 import (
-	"github.com/pkg/errors"
+	"fmt"
+
 	"github.com/spf13/cobra"
 
 	kumactl_cmd "github.com/kumahq/kuma/app/kumactl/pkg/cmd"
@@ -19,7 +20,7 @@ func newConfigControlPlanesRemoveCmd(pctx *kumactl_cmd.RootContext) *cobra.Comma
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			cfg := pctx.Config()
 			if !cfg.RemoveControlPlane(args.name) {
-				return errors.Errorf("there is no Control Plane with name %q", args.name)
+				return fmt.Errorf("there is no Control Plane with name %q", args.name)
 			}
 			if err := pctx.SaveConfig(); err != nil {
 				return err

--- a/app/kumactl/cmd/config/config_control_planes_switch.go
+++ b/app/kumactl/cmd/config/config_control_planes_switch.go
@@ -1,7 +1,8 @@
 package config
 
 import (
-	"github.com/pkg/errors"
+	"fmt"
+
 	"github.com/spf13/cobra"
 
 	kumactl_cmd "github.com/kumahq/kuma/app/kumactl/pkg/cmd"
@@ -19,7 +20,7 @@ func newConfigControlPlanesSwitchCmd(pctx *kumactl_cmd.RootContext) *cobra.Comma
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			cfg := pctx.Config()
 			if !cfg.SwitchContext(args.name) {
-				return errors.Errorf("there is no Control Plane with name %q", args.name)
+				return fmt.Errorf("there is no Control Plane with name %q", args.name)
 			}
 			if err := pctx.SaveConfig(); err != nil {
 				return err

--- a/app/kumactl/cmd/config/config_view.go
+++ b/app/kumactl/cmd/config/config_view.go
@@ -1,7 +1,8 @@
 package config
 
 import (
-	"github.com/pkg/errors"
+	"fmt"
+
 	"github.com/spf13/cobra"
 
 	kumactl_cmd "github.com/kumahq/kuma/app/kumactl/pkg/cmd"
@@ -18,7 +19,7 @@ func newConfigViewCmd(pctx *kumactl_cmd.RootContext) *cobra.Command {
 			cfg := pctx.Config()
 			contents, err := util_proto.ToYAML(cfg)
 			if err != nil {
-				return errors.Wrapf(err, "Cannot format configuration: %#v", cfg)
+				return fmt.Errorf("Cannot format configuration: %#v: %w", cfg, err)
 			}
 			cmd.Println(string(contents))
 			return nil

--- a/app/kumactl/cmd/delete/delete.go
+++ b/app/kumactl/cmd/delete/delete.go
@@ -2,10 +2,10 @@ package delete
 
 import (
 	"context"
+	"fmt"
 	"sort"
 	"strings"
 
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
 	kumactl_cmd "github.com/kumahq/kuma/app/kumactl/pkg/cmd"
@@ -36,10 +36,10 @@ func NewDeleteCmd(pctx *kumactl_cmd.RootContext) *cobra.Command {
 
 			desc, ok := byName[resourceTypeArg]
 			if !ok {
-				return errors.Errorf("unknown TYPE: %s. Allowed values: %s", resourceTypeArg, strings.Join(allNames, ", "))
+				return fmt.Errorf("unknown TYPE: %s. Allowed values: %s", resourceTypeArg, strings.Join(allNames, ", "))
 			}
 			if desc.ReadOnly {
-				return errors.Errorf("TYPE: %s is readOnly, can't use it for write action", resourceTypeArg)
+				return fmt.Errorf("TYPE: %s is readOnly, can't use it for write action", resourceTypeArg)
 			}
 
 			rs, err := pctx.CurrentResourceStore()
@@ -69,9 +69,9 @@ func deleteResource(name string, mesh string, desc model.ResourceTypeDescriptor,
 	deleteOptions := store.DeleteBy(model.ResourceKey{Mesh: mesh, Name: name})
 	if err := rs.Delete(context.Background(), resource, deleteOptions); err != nil {
 		if store.IsResourceNotFound(err) {
-			return errors.Errorf("there is no %s with name %q", desc.Name, name)
+			return fmt.Errorf("there is no %s with name %q", desc.Name, name)
 		}
-		return errors.Wrapf(err, "failed to delete %s with the name %q", desc.Name, name)
+		return fmt.Errorf("failed to delete %s with the name %q: %w", desc.Name, name, err)
 	}
 
 	return nil

--- a/app/kumactl/cmd/generate/generate_dataplane_token.go
+++ b/app/kumactl/cmd/generate/generate_dataplane_token.go
@@ -1,10 +1,10 @@
 package generate
 
 import (
+	"fmt"
 	"strings"
 	"time"
 
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
 	kumactl_cmd "github.com/kumahq/kuma/app/kumactl/pkg/cmd"
@@ -44,7 +44,7 @@ $ kumactl generate dataplane-token --mesh demo --tag kuma.io/service=web,web-api
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			client, err := pctx.CurrentDataplaneTokenClient()
 			if err != nil {
-				return errors.Wrap(err, "failed to create dataplane token client")
+				return fmt.Errorf("failed to create dataplane token client: %w", err)
 			}
 
 			tags := map[string][]string{}
@@ -54,7 +54,7 @@ $ kumactl generate dataplane-token --mesh demo --tag kuma.io/service=web,web-api
 			name := ctx.args.name
 			token, err := client.Generate(name, pctx.CurrentMesh(), tags, ctx.args.proxyType, ctx.args.validFor)
 			if err != nil {
-				return errors.Wrap(err, "failed to generate a dataplane token")
+				return fmt.Errorf("failed to generate a dataplane token: %w", err)
 			}
 			_, err = cmd.OutOrStdout().Write([]byte(token))
 			return err

--- a/app/kumactl/cmd/generate/generate_signing_key.go
+++ b/app/kumactl/cmd/generate/generate_signing_key.go
@@ -2,8 +2,8 @@ package generate
 
 import (
 	"encoding/base64"
+	"fmt"
 
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
 	"github.com/kumahq/kuma/app/kumactl/pkg/cmd"
@@ -38,7 +38,7 @@ type: system.kuma.io/global-secret
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			key, err := ctx.GenerateContext.NewSigningKey()
 			if err != nil {
-				return errors.Wrap(err, "could not generate signing key")
+				return fmt.Errorf("could not generate signing key: %w", err)
 			}
 			_, err = cmd.OutOrStdout().Write([]byte(base64.StdEncoding.EncodeToString(key)))
 			return err

--- a/app/kumactl/cmd/generate/generate_zone_token.go
+++ b/app/kumactl/cmd/generate/generate_zone_token.go
@@ -1,9 +1,9 @@
 package generate
 
 import (
+	"fmt"
 	"time"
 
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
 	kumactl_cmd "github.com/kumahq/kuma/app/kumactl/pkg/cmd"
@@ -43,12 +43,12 @@ $ kumactl generate zone-token --zone zone-1 --valid-for 24h --scope egress`,
 
 			client, err := pctx.CurrentZoneTokenClient()
 			if err != nil {
-				return errors.Wrap(err, "failed to create zone token client")
+				return fmt.Errorf("failed to create zone token client: %w", err)
 			}
 
 			token, err := client.Generate(ctx.args.zone, ctx.args.scope, ctx.args.validFor)
 			if err != nil {
-				return errors.Wrap(err, "failed to generate a zone token")
+				return fmt.Errorf("failed to generate a zone token: %w", err)
 			}
 
 			_, err = cmd.OutOrStdout().Write([]byte(token))
@@ -78,7 +78,7 @@ func validateArgs(args *generateZoneTokenContextArgs) error {
 	}
 
 	if len(unsupportedScopes) > 0 {
-		return errors.Errorf(
+		return fmt.Errorf(
 			"invalid --scope values: %+v (supported scopes: %+v)",
 			unsupportedScopes,
 			zone.FullScope,

--- a/app/kumactl/cmd/generate/generate_zoneingress_token.go
+++ b/app/kumactl/cmd/generate/generate_zoneingress_token.go
@@ -1,9 +1,9 @@
 package generate
 
 import (
+	"fmt"
 	"time"
 
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
 	kumactl_cmd "github.com/kumahq/kuma/app/kumactl/pkg/cmd"
@@ -32,12 +32,12 @@ $ kumactl generate zone-ingress-token --zone zone-1 --valid-for 30d
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			client, err := pctx.CurrentZoneIngressTokenClient()
 			if err != nil {
-				return errors.Wrap(err, "failed to create zone ingress token client")
+				return fmt.Errorf("failed to create zone ingress token client: %w", err)
 			}
 
 			token, err := client.Generate(ctx.args.zone, ctx.args.validFor)
 			if err != nil {
-				return errors.Wrap(err, "failed to generate a zone ingress token")
+				return fmt.Errorf("failed to generate a zone ingress token: %w", err)
 			}
 			_, err = cmd.OutOrStdout().Write([]byte(token))
 			return err

--- a/app/kumactl/cmd/get/get_resource.go
+++ b/app/kumactl/cmd/get/get_resource.go
@@ -2,9 +2,9 @@ package get
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
 	kumactl_cmd "github.com/kumahq/kuma/app/kumactl/pkg/cmd"
@@ -35,15 +35,15 @@ func NewGetResourceCmd(pctx *kumactl_cmd.RootContext, desc core_model.ResourceTy
 					if store.IsResourceNotFound(err) {
 						return errors.New("No resources found")
 					}
-					return errors.Wrapf(err, "failed to get %s", name)
+					return fmt.Errorf("failed to get %s: %w", name, err)
 				}
 			case core_model.ScopeMesh:
 				currentMesh := pctx.CurrentMesh()
 				if err := rs.Get(context.Background(), resource, store.GetByKey(name, currentMesh)); err != nil {
 					if store.IsResourceNotFound(err) {
-						return errors.Errorf("No resources found in %s mesh", currentMesh)
+						return fmt.Errorf("No resources found in %s mesh", currentMesh)
 					}
-					return errors.Wrapf(err, "failed to get %s in mesh %s", name, currentMesh)
+					return fmt.Errorf("failed to get %s in mesh %s: %w", name, currentMesh, err)
 				}
 			default:
 				return fmt.Errorf("Scope %s is unsupported", desc.Scope)

--- a/app/kumactl/cmd/get/get_resources.go
+++ b/app/kumactl/cmd/get/get_resources.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
 	kumactl_cmd "github.com/kumahq/kuma/app/kumactl/pkg/cmd"
@@ -34,7 +33,7 @@ func NewGetResourcesCmd(pctx *kumactl_cmd.RootContext, desc model.ResourceTypeDe
 				currentMesh = ""
 			}
 			if err := rs.List(context.Background(), resources, core_store.ListByMesh(currentMesh), core_store.ListByPage(pctx.ListContext.Args.Size, pctx.ListContext.Args.Offset)); err != nil {
-				return errors.Wrapf(err, "failed to list "+string(desc.Name))
+				return fmt.Errorf("failed to list %s: %w", string(desc.Name), err)
 			}
 
 			switch format := output.Format(pctx.GetContext.Args.OutputFormat); format {

--- a/app/kumactl/cmd/inspect/inspect_dataplane.go
+++ b/app/kumactl/cmd/inspect/inspect_dataplane.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"text/template"
 
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
 	"github.com/kumahq/kuma/app/kumactl/pkg/cmd"
@@ -62,7 +61,7 @@ func newInspectDataplaneCmd(pctx *cmd.RootContext) *cobra.Command {
 			if configDump {
 				client, err := pctx.CurrentInspectEnvoyProxyClient(mesh.DataplaneResourceTypeDescriptor)
 				if err != nil {
-					return errors.Wrap(err, "failed to create a dataplane inspect client")
+					return fmt.Errorf("failed to create a dataplane inspect client: %w", err)
 				}
 				bytes, err := client.ConfigDump(context.Background(), core_model.ResourceKey{Name: name, Mesh: pctx.CurrentMesh()})
 				if err != nil {
@@ -73,7 +72,7 @@ func newInspectDataplaneCmd(pctx *cmd.RootContext) *cobra.Command {
 			} else {
 				client, err := pctx.CurrentDataplaneInspectClient()
 				if err != nil {
-					return errors.Wrap(err, "failed to create a dataplane inspect client")
+					return fmt.Errorf("failed to create a dataplane inspect client: %w", err)
 				}
 				entryList, err := client.InspectPolicies(context.Background(), pctx.CurrentMesh(), name)
 				if err != nil {

--- a/app/kumactl/cmd/inspect/inspect_dataplanes.go
+++ b/app/kumactl/cmd/inspect/inspect_dataplanes.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
@@ -38,7 +37,7 @@ func newInspectDataplanesCmd(pctx *cmd.RootContext) *cobra.Command {
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			client, err := pctx.CurrentDataplaneOverviewClient()
 			if err != nil {
-				return errors.Wrap(err, "failed to create a dataplane client")
+				return fmt.Errorf("failed to create a dataplane client: %w", err)
 			}
 			overviews, err := client.List(context.Background(), pctx.CurrentMesh(), ctx.args.tags, ctx.args.gateway, ctx.args.ingress)
 			if err != nil {

--- a/app/kumactl/cmd/inspect/inspect_meshgateway.go
+++ b/app/kumactl/cmd/inspect/inspect_meshgateway.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"text/template"
 
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
 	"github.com/kumahq/kuma/app/kumactl/pkg/cmd"
@@ -30,7 +29,7 @@ func newInspectMeshGatewayCmd(pctx *cmd.RootContext) *cobra.Command {
 			name := args[0]
 			client, err := pctx.CurrentMeshGatewayInspectClient()
 			if err != nil {
-				return errors.Wrap(err, "failed to create a dataplane inspect client")
+				return fmt.Errorf("failed to create a dataplane inspect client: %w", err)
 			}
 			dataplanes, err := client.InspectDataplanes(context.Background(), pctx.CurrentMesh(), name)
 			if err != nil {

--- a/app/kumactl/cmd/inspect/inspect_policy.go
+++ b/app/kumactl/cmd/inspect/inspect_policy.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 	"text/template"
 
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
@@ -63,7 +62,7 @@ func newInspectPolicyCmd(policyDesc core_model.ResourceTypeDescriptor, pctx *cmd
 		RunE: func(cmd *cobra.Command, args []string) error {
 			client, err := pctx.CurrentPolicyInspectClient()
 			if err != nil {
-				return errors.Wrap(err, "failed to create a policy inspect client")
+				return fmt.Errorf("failed to create a policy inspect client: %w", err)
 			}
 			name := args[0]
 			entryList, err := client.Inspect(context.Background(), policyDesc, pctx.CurrentMesh(), name)

--- a/app/kumactl/cmd/inspect/inspect_zoneegress.go
+++ b/app/kumactl/cmd/inspect/inspect_zoneegress.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
 	"github.com/kumahq/kuma/app/kumactl/pkg/cmd"
@@ -29,7 +28,7 @@ func newInspectZoneEgressCmd(pctx *cmd.RootContext) *cobra.Command {
 			}
 			client, err := pctx.CurrentInspectEnvoyProxyClient(mesh.ZoneEgressResourceTypeDescriptor)
 			if err != nil {
-				return errors.Wrap(err, "failed to create a zoneegress inspect client")
+				return fmt.Errorf("failed to create a zoneegress inspect client: %w", err)
 			}
 			name := args[0]
 			bytes, err := client.ConfigDump(context.Background(), core_model.ResourceKey{Name: name, Mesh: core_model.NoMesh})

--- a/app/kumactl/cmd/inspect/inspect_zoneegresses.go
+++ b/app/kumactl/cmd/inspect/inspect_zoneegresses.go
@@ -2,10 +2,10 @@ package inspect
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"time"
 
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
@@ -26,7 +26,7 @@ func newInspectZoneEgressesCmd(ctx *cmd.RootContext) *cobra.Command {
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			client, err := ctx.CurrentZoneEgressOverviewClient()
 			if err != nil {
-				return errors.Wrap(err, "failed to create a zone egress client")
+				return fmt.Errorf("failed to create a zone egress client: %w", err)
 			}
 			overviews, err := client.List(context.Background())
 			if err != nil {

--- a/app/kumactl/cmd/inspect/inspect_zoneingress.go
+++ b/app/kumactl/cmd/inspect/inspect_zoneingress.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
 	"github.com/kumahq/kuma/app/kumactl/pkg/cmd"
@@ -30,7 +29,7 @@ func newInspectZoneIngressCmd(pctx *cmd.RootContext) *cobra.Command {
 
 			client, err := pctx.CurrentInspectEnvoyProxyClient(mesh.ZoneIngressResourceTypeDescriptor)
 			if err != nil {
-				return errors.Wrap(err, "failed to create a zoneingress inspect client")
+				return fmt.Errorf("failed to create a zoneingress inspect client: %w", err)
 			}
 			name := args[0]
 			bytes, err := client.ConfigDump(context.Background(), core_model.ResourceKey{Name: name, Mesh: core_model.NoMesh})

--- a/app/kumactl/cmd/inspect/inspect_zoneingresses.go
+++ b/app/kumactl/cmd/inspect/inspect_zoneingresses.go
@@ -2,10 +2,10 @@ package inspect
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"time"
 
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
@@ -26,7 +26,7 @@ func newInspectZoneIngressesCmd(ctx *cmd.RootContext) *cobra.Command {
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			client, err := ctx.CurrentZoneIngressOverviewClient()
 			if err != nil {
-				return errors.Wrap(err, "failed to create a zone ingress client")
+				return fmt.Errorf("failed to create a zone ingress client: %w", err)
 			}
 			overviews, err := client.List(context.Background())
 			if err != nil {

--- a/app/kumactl/cmd/inspect/inspect_zones.go
+++ b/app/kumactl/cmd/inspect/inspect_zones.go
@@ -3,10 +3,10 @@ package inspect
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"time"
 
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
 	system_proto "github.com/kumahq/kuma/api/system/v1alpha1"
@@ -27,7 +27,7 @@ func newInspectZonesCmd(ctx *cmd.RootContext) *cobra.Command {
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			client, err := ctx.CurrentZoneOverviewClient()
 			if err != nil {
-				return errors.Wrap(err, "failed to create a zone client")
+				return fmt.Errorf("failed to create a zone client: %w", err)
 			}
 			overviews, err := client.List(context.Background())
 			if err != nil {
@@ -94,7 +94,7 @@ func printZoneOverviews(now time.Time, zoneOverviews *system.ZoneOverviewResourc
 						} `json:"store"`
 					}{}
 					if err := json.Unmarshal([]byte(lastSubscription.GetConfig()), &cfg); err != nil {
-						unmarshallErr = errors.Wrap(err, "could not unmarshal CP config")
+						unmarshallErr = fmt.Errorf("could not unmarshal CP config: %w", err)
 					} else {
 						backend = cfg.Store.Type
 					}

--- a/app/kumactl/cmd/install/install_demo.go
+++ b/app/kumactl/cmd/install/install_demo.go
@@ -1,7 +1,8 @@
 package install
 
 import (
-	"github.com/pkg/errors"
+	"fmt"
+
 	"github.com/spf13/cobra"
 
 	install_context "github.com/kumahq/kuma/app/kumactl/cmd/install/context"
@@ -33,24 +34,23 @@ func newInstallDemoCmd(ctx *install_context.InstallDemoContext) *cobra.Command {
 
 			templateFiles, err := data.ReadFiles(kumactl_data.InstallDemoFS())
 			if err != nil {
-				return errors.Wrap(err, "Failed to read template files")
+				return fmt.Errorf("Failed to read template files: %w", err)
 			}
 
 			renderedFiles, err := renderFiles(templateFiles, templateArgs, simpleTemplateRenderer)
-
 			if err != nil {
-				return errors.Wrap(err, "Failed to render template files")
+				return fmt.Errorf("Failed to render template files: %w", err)
 			}
 
 			sortedResources, err := k8s.SortResourcesByKind(renderedFiles)
 			if err != nil {
-				return errors.Wrap(err, "Failed to sort resources by kind")
+				return fmt.Errorf("Failed to sort resources by kind: %w", err)
 			}
 
 			singleFile := data.JoinYAML(sortedResources)
 
 			if _, err := cmd.OutOrStdout().Write(singleFile.Data); err != nil {
-				return errors.Wrap(err, "Failed to output rendered resources")
+				return fmt.Errorf("Failed to output rendered resources: %w", err)
 			}
 			return nil
 		},

--- a/app/kumactl/cmd/install/install_gateway_kong.go
+++ b/app/kumactl/cmd/install/install_gateway_kong.go
@@ -1,7 +1,8 @@
 package install
 
 import (
-	"github.com/pkg/errors"
+	"fmt"
+
 	"github.com/spf13/cobra"
 
 	install_context "github.com/kumahq/kuma/app/kumactl/cmd/install/context"
@@ -19,24 +20,23 @@ func newInstallGatewayKongCmd(ctx *install_context.InstallGatewayKongContext) *c
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			templateFiles, err := data.ReadFiles(kumactl_data.InstallGatewayKongFS())
 			if err != nil {
-				return errors.Wrap(err, "Failed to read template files")
+				return fmt.Errorf("Failed to read template files: %w", err)
 			}
 
 			renderedFiles, err := renderFiles(templateFiles, args, simpleTemplateRenderer)
-
 			if err != nil {
-				return errors.Wrap(err, "Failed to render template files")
+				return fmt.Errorf("Failed to render template files: %w", err)
 			}
 
 			sortedResources, err := k8s.SortResourcesByKind(renderedFiles)
 			if err != nil {
-				return errors.Wrap(err, "Failed to sort resources by kind")
+				return fmt.Errorf("Failed to sort resources by kind: %w", err)
 			}
 
 			singleFile := data.JoinYAML(sortedResources)
 
 			if _, err := cmd.OutOrStdout().Write(singleFile.Data); err != nil {
-				return errors.Wrap(err, "Failed to output rendered resources")
+				return fmt.Errorf("Failed to output rendered resources: %w", err)
 			}
 			return nil
 		},

--- a/app/kumactl/cmd/install/install_gateway_kong_enterprise.go
+++ b/app/kumactl/cmd/install/install_gateway_kong_enterprise.go
@@ -1,9 +1,9 @@
 package install
 
 import (
+	"fmt"
 	"os"
 
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
 	install_context "github.com/kumahq/kuma/app/kumactl/cmd/install/context"
@@ -26,12 +26,12 @@ func newInstallGatewayKongEnterpriseCmd(ctx *install_context.InstallGatewayKongE
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			templateFiles, err := data.ReadFiles(kumactl_data.InstallGatewayKongEnterpriseFS())
 			if err != nil {
-				return errors.Wrap(err, "Failed to read template files")
+				return fmt.Errorf("Failed to read template files: %w", err)
 			}
 
 			licenseBytes, err := os.ReadFile(args.LicensePath)
 			if err != nil {
-				return errors.Wrap(err, "Failed to read license file")
+				return fmt.Errorf("Failed to read license file: %w", err)
 			}
 
 			templateArgs := templateArgs{
@@ -40,20 +40,19 @@ func newInstallGatewayKongEnterpriseCmd(ctx *install_context.InstallGatewayKongE
 			}
 
 			renderedFiles, err := renderFiles(templateFiles, templateArgs, simpleTemplateRenderer)
-
 			if err != nil {
-				return errors.Wrap(err, "Failed to render template files")
+				return fmt.Errorf("Failed to render template files: %w", err)
 			}
 
 			sortedResources, err := k8s.SortResourcesByKind(renderedFiles)
 			if err != nil {
-				return errors.Wrap(err, "Failed to sort resources by kind")
+				return fmt.Errorf("Failed to sort resources by kind: %w", err)
 			}
 
 			singleFile := data.JoinYAML(sortedResources)
 
 			if _, err := cmd.OutOrStdout().Write(singleFile.Data); err != nil {
-				return errors.Wrap(err, "Failed to output rendered resources")
+				return fmt.Errorf("Failed to output rendered resources: %w", err)
 			}
 
 			return nil

--- a/app/kumactl/cmd/install/install_logging.go
+++ b/app/kumactl/cmd/install/install_logging.go
@@ -3,7 +3,8 @@
 package install
 
 import (
-	"github.com/pkg/errors"
+	"fmt"
+
 	"github.com/spf13/cobra"
 
 	kumactl_data "github.com/kumahq/kuma/app/kumactl/data"
@@ -30,23 +31,23 @@ func newInstallLogging(pctx *kumactl_cmd.RootContext) *cobra.Command {
 
 			templateFiles, err := data.ReadFiles(kumactl_data.InstallDeprecatedLoggingFS())
 			if err != nil {
-				return errors.Wrap(err, "Failed to read template files")
+				return fmt.Errorf("Failed to read template files: %w", err)
 			}
 
 			renderedFiles, err := renderFiles(templateFiles, templateArgs, simpleTemplateRenderer)
 			if err != nil {
-				return errors.Wrap(err, "Failed to render template files")
+				return fmt.Errorf("Failed to render template files: %w", err)
 			}
 
 			sortedResources, err := k8s.SortResourcesByKind(renderedFiles)
 			if err != nil {
-				return errors.Wrap(err, "Failed to sort resources by kind")
+				return fmt.Errorf("Failed to sort resources by kind: %w", err)
 			}
 
 			singleFile := data.JoinYAML(sortedResources)
 
 			if _, err := cmd.OutOrStdout().Write(singleFile.Data); err != nil {
-				return errors.Wrap(err, "Failed to output rendered resources")
+				return fmt.Errorf("Failed to output rendered resources: %w", err)
 			}
 			return nil
 		},

--- a/app/kumactl/cmd/install/install_metrics.go
+++ b/app/kumactl/cmd/install/install_metrics.go
@@ -3,9 +3,9 @@
 package install
 
 import (
+	"fmt"
 	"strings"
 
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
 	"github.com/kumahq/kuma/app/kumactl/cmd/install/context"
@@ -27,7 +27,7 @@ func newInstallMetrics(pctx *kumactl_cmd.RootContext) *cobra.Command {
 			installMetricsFS := kumactl_data.InstallDeprecatedMetricsFS()
 			templateFiles, err := data.ReadFiles(installMetricsFS)
 			if err != nil {
-				return errors.Wrap(err, "Failed to read template files")
+				return fmt.Errorf("Failed to read template files: %w", err)
 			}
 			yamlTemplateFiles := templateFiles.Filter(func(file data.File) bool {
 				return strings.HasSuffix(file.Name, ".yaml")
@@ -82,18 +82,18 @@ func newInstallMetrics(pctx *kumactl_cmd.RootContext) *cobra.Command {
 
 			renderedFiles, err := renderFilesWithFilter(yamlTemplateFiles, args, simpleTemplateRenderer, filter)
 			if err != nil {
-				return errors.Wrap(err, "Failed to render template files")
+				return fmt.Errorf("Failed to render template files: %w", err)
 			}
 
 			sortedResources, err := k8s.SortResourcesByKind(renderedFiles)
 			if err != nil {
-				return errors.Wrap(err, "Failed to sort resources by kind")
+				return fmt.Errorf("Failed to sort resources by kind: %w", err)
 			}
 
 			singleFile := data.JoinYAML(sortedResources)
 
 			if _, err := cmd.OutOrStdout().Write(singleFile.Data); err != nil {
-				return errors.Wrap(err, "Failed to output rendered resources")
+				return fmt.Errorf("Failed to output rendered resources: %w", err)
 			}
 			return nil
 		},

--- a/app/kumactl/cmd/install/install_observability.go
+++ b/app/kumactl/cmd/install/install_observability.go
@@ -1,9 +1,9 @@
 package install
 
 import (
+	"fmt"
 	"strings"
 
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
 	"github.com/kumahq/kuma/app/kumactl/cmd/install/context"
@@ -47,7 +47,7 @@ func newInstallObservability(pctx *kumactl_cmd.RootContext) *cobra.Command {
 			singleFile := data.JoinYAML(combinedResources)
 
 			if _, err := cmd.OutOrStdout().Write(singleFile.Data); err != nil {
-				return errors.Wrap(err, "Failed to output rendered resources")
+				return fmt.Errorf("Failed to output rendered resources: %w", err)
 			}
 			return nil
 		},
@@ -66,7 +66,7 @@ func getMetrics(args *context.ObservabilityTemplateArgs) ([]data.File, error) {
 	installMetricsFS := kumactl_data.InstallMetricsFS()
 	templateFiles, err := data.ReadFiles(installMetricsFS)
 	if err != nil {
-		return nil, errors.Wrap(err, "Failed to read template files")
+		return nil, fmt.Errorf("Failed to read template files: %w", err)
 	}
 	yamlTemplateFiles := templateFiles.Filter(func(file data.File) bool {
 		return strings.HasSuffix(file.Name, ".yaml")
@@ -120,12 +120,12 @@ func getMetrics(args *context.ObservabilityTemplateArgs) ([]data.File, error) {
 	filter := getExcludePrefixesFilter(args)
 	renderedFiles, err := renderFilesWithFilter(yamlTemplateFiles, args, simpleTemplateRenderer, filter)
 	if err != nil {
-		return nil, errors.Wrap(err, "Failed to render template files")
+		return nil, fmt.Errorf("Failed to render template files: %w", err)
 	}
 
 	sortedResources, err := k8s.SortResourcesByKind(renderedFiles)
 	if err != nil {
-		return nil, errors.Wrap(err, "Failed to sort resources by kind")
+		return nil, fmt.Errorf("Failed to sort resources by kind: %w", err)
 	}
 	return sortedResources, nil
 }
@@ -133,18 +133,18 @@ func getMetrics(args *context.ObservabilityTemplateArgs) ([]data.File, error) {
 func getLogging(args *context.ObservabilityTemplateArgs) ([]data.File, error) {
 	templateFiles, err := data.ReadFiles(kumactl_data.InstallLoggingFS())
 	if err != nil {
-		return nil, errors.Wrap(err, "Failed to read template files")
+		return nil, fmt.Errorf("Failed to read template files: %w", err)
 	}
 
 	filter := getExcludePrefixesFilter(args)
 	renderedFiles, err := renderFilesWithFilter(templateFiles, args, simpleTemplateRenderer, filter)
 	if err != nil {
-		return nil, errors.Wrap(err, "Failed to render template files")
+		return nil, fmt.Errorf("Failed to render template files: %w", err)
 	}
 
 	sortedResources, err := k8s.SortResourcesByKind(renderedFiles)
 	if err != nil {
-		return nil, errors.Wrap(err, "Failed to sort resources by kind")
+		return nil, fmt.Errorf("Failed to sort resources by kind: %w", err)
 	}
 	return sortedResources, nil
 }
@@ -152,18 +152,18 @@ func getLogging(args *context.ObservabilityTemplateArgs) ([]data.File, error) {
 func getTracing(args *context.ObservabilityTemplateArgs) ([]data.File, error) {
 	templateFiles, err := data.ReadFiles(kumactl_data.InstallTracingFS())
 	if err != nil {
-		return nil, errors.Wrap(err, "Failed to read template files")
+		return nil, fmt.Errorf("Failed to read template files: %w", err)
 	}
 
 	filter := getExcludePrefixesFilter(args)
 	renderedFiles, err := renderFilesWithFilter(templateFiles, args, simpleTemplateRenderer, filter)
 	if err != nil {
-		return nil, errors.Wrap(err, "Failed to render template files")
+		return nil, fmt.Errorf("Failed to render template files: %w", err)
 	}
 
 	sortedResources, err := k8s.SortResourcesByKind(renderedFiles)
 	if err != nil {
-		return nil, errors.Wrap(err, "Failed to sort resources by kind")
+		return nil, fmt.Errorf("Failed to sort resources by kind: %w", err)
 	}
 	return sortedResources, nil
 }

--- a/app/kumactl/cmd/install/install_tracing.go
+++ b/app/kumactl/cmd/install/install_tracing.go
@@ -3,7 +3,8 @@
 package install
 
 import (
-	"github.com/pkg/errors"
+	"fmt"
+
 	"github.com/spf13/cobra"
 
 	kumactl_data "github.com/kumahq/kuma/app/kumactl/data"
@@ -30,23 +31,23 @@ func newInstallTracing(pctx *kumactl_cmd.RootContext) *cobra.Command {
 
 			templateFiles, err := data.ReadFiles(kumactl_data.InstallDeprecatedTracingFS())
 			if err != nil {
-				return errors.Wrap(err, "Failed to read template files")
+				return fmt.Errorf("Failed to read template files: %w", err)
 			}
 
 			renderedFiles, err := renderFiles(templateFiles, templateArgs, simpleTemplateRenderer)
 			if err != nil {
-				return errors.Wrap(err, "Failed to render template files")
+				return fmt.Errorf("Failed to render template files: %w", err)
 			}
 
 			sortedResources, err := k8s.SortResourcesByKind(renderedFiles)
 			if err != nil {
-				return errors.Wrap(err, "Failed to sort resources by kind")
+				return fmt.Errorf("Failed to sort resources by kind: %w", err)
 			}
 
 			singleFile := data.JoinYAML(sortedResources)
 
 			if _, err := cmd.OutOrStdout().Write(singleFile.Data); err != nil {
-				return errors.Wrap(err, "Failed to output rendered resources")
+				return fmt.Errorf("Failed to output rendered resources: %w", err)
 			}
 			return nil
 		},

--- a/app/kumactl/cmd/install/install_transparent_proxy_windows.go
+++ b/app/kumactl/cmd/install/install_transparent_proxy_windows.go
@@ -1,7 +1,8 @@
 package install
 
 import (
-	"github.com/pkg/errors"
+	"errors"
+
 	"github.com/spf13/cobra"
 )
 

--- a/app/kumactl/cmd/install/render_files.go
+++ b/app/kumactl/cmd/install/render_files.go
@@ -2,11 +2,11 @@ package install
 
 import (
 	"bytes"
+	"fmt"
 	"io"
 	"text/template"
 
 	"github.com/Masterminds/sprig"
-	"github.com/pkg/errors"
 
 	"github.com/kumahq/kuma/app/kumactl/pkg/install/data"
 )
@@ -46,7 +46,7 @@ type templateRenderer interface {
 func simpleTemplateRenderer(text data.File) (templateRenderer, error) {
 	tmpl, err := template.New("").Funcs(sprig.TxtFuncMap()).Parse(string(text.Data))
 	if err != nil {
-		return nil, errors.Wrap(err, "Failed to parse k8s resource template")
+		return nil, fmt.Errorf("Failed to parse k8s resource template: %w", err)
 	}
 	return tmpl, nil
 }
@@ -66,8 +66,7 @@ func (f ExcludePrefixesFilter) Filter(name string) bool {
 	return true
 }
 
-type NoneFilter struct {
-}
+type NoneFilter struct{}
 
 func (f NoneFilter) Filter(name string) bool {
 	return true

--- a/app/kumactl/cmd/install/render_helm_files.go
+++ b/app/kumactl/cmd/install/render_helm_files.go
@@ -7,7 +7,6 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/pkg/errors"
 	"helm.sh/helm/v3/pkg/chart"
 	"helm.sh/helm/v3/pkg/chart/loader"
 	"helm.sh/helm/v3/pkg/chartutil"
@@ -46,18 +45,18 @@ func renderHelmFiles(
 ) ([]data.File, error) {
 	kumaChart, err := loadCharts(templates)
 	if err != nil {
-		return nil, errors.Errorf("Failed to load charts: %s", err)
+		return nil, fmt.Errorf("Failed to load charts: %s", err)
 	}
 
 	if err := chartutil.ProcessDependencies(kumaChart, overrideValues); err != nil {
-		return nil, errors.Errorf("Failed to process dependencies: %s", err)
+		return nil, fmt.Errorf("Failed to process dependencies: %s", err)
 	}
 
 	options := generateReleaseOptions(kumaChart.Metadata.Name, namespace)
 
 	valuesToRender, err := chartutil.ToRenderValues(kumaChart, overrideValues, options, nil)
 	if err != nil {
-		return nil, errors.Errorf("Failed to render values: %s", err)
+		return nil, fmt.Errorf("Failed to render values: %s", err)
 	}
 
 	var files map[string]string
@@ -67,7 +66,7 @@ func renderHelmFiles(
 		files, err = engine.RenderWithClient(kumaChart, valuesToRender, kubeClientConfig)
 	}
 	if err != nil {
-		return nil, errors.Errorf("Failed to render templates: %s", err)
+		return nil, fmt.Errorf("Failed to render templates: %s", err)
 	}
 	files["namespace.yaml"] = kumaSystemNamespace(namespace)
 

--- a/app/kumactl/cmd/uninstall/uninstall_transparent_proxy.go
+++ b/app/kumactl/cmd/uninstall/uninstall_transparent_proxy.go
@@ -4,10 +4,10 @@
 package uninstall
 
 import (
+	"fmt"
 	"os"
 	"runtime"
 
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
 	"github.com/kumahq/kuma/pkg/transparentproxy"
@@ -29,14 +29,14 @@ func newUninstallTransparentProxy() *cobra.Command {
 		Long:  `Uninstall Transparent Proxy by restoring the hosts iptables and /etc/resolv.conf`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			if !args.DryRun && runtime.GOOS != "linux" {
-				return errors.Errorf("transparent proxy will work only on Linux OSes")
+				return fmt.Errorf("transparent proxy will work only on Linux OSes")
 			}
 
 			tp := transparentproxy.DefaultTransparentProxy()
 
 			output, err := tp.Cleanup(args.DryRun, args.Verbose)
 			if err != nil {
-				return errors.Wrap(err, "Failed to cleanup transparent proxy")
+				return fmt.Errorf("Failed to cleanup transparent proxy: %w", err)
 			}
 
 			if args.DryRun {
@@ -47,13 +47,13 @@ func newUninstallTransparentProxy() *cobra.Command {
 			if _, err := os.Stat("/etc/resolv.conf.kuma-backup"); !os.IsNotExist(err) {
 				content, err := os.ReadFile("/etc/resolv.conf.kuma-backup")
 				if err != nil {
-					return errors.Wrap(err, "unable to open /etc/resolv.conf.kuma-backup")
+					return fmt.Errorf("unable to open /etc/resolv.conf.kuma-backup: %w", err)
 				}
 
 				if !args.DryRun {
 					err = os.WriteFile("/etc/resolv.conf", content, 0644)
 					if err != nil {
-						return errors.Wrap(err, "unable to write /etc/resolv.conf")
+						return fmt.Errorf("unable to write /etc/resolv.conf: %w", err)
 					}
 				}
 

--- a/app/kumactl/cmd/uninstall/uninstall_transparent_proxy_windows.go
+++ b/app/kumactl/cmd/uninstall/uninstall_transparent_proxy_windows.go
@@ -1,7 +1,8 @@
 package uninstall
 
 import (
-	"github.com/pkg/errors"
+	"errors"
+
 	"github.com/spf13/cobra"
 )
 

--- a/app/kumactl/pkg/client/api_server_client.go
+++ b/app/kumactl/pkg/client/api_server_client.go
@@ -1,11 +1,10 @@
 package client
 
 import (
+	"fmt"
 	"net/http"
 	"net/url"
 	"time"
-
-	"github.com/pkg/errors"
 
 	config_proto "github.com/kumahq/kuma/pkg/config/app/kumactl/v1alpha1"
 	util_http "github.com/kumahq/kuma/pkg/util/http"
@@ -15,13 +14,13 @@ func ApiServerClient(coordinates *config_proto.ControlPlaneCoordinates_ApiServer
 	headers := make(map[string]string)
 	baseURL, err := url.Parse(coordinates.Url)
 	if err != nil {
-		return nil, errors.Wrapf(err, "Failed to parse API Server URL")
+		return nil, fmt.Errorf("Failed to parse API Server URL: %w", err)
 	}
 	client := &http.Client{
 		Timeout: timeout,
 	}
 	if err := util_http.ConfigureMTLS(client, coordinates.CaCertFile, coordinates.ClientCertFile, coordinates.ClientKeyFile); err != nil {
-		return nil, errors.Wrap(err, "could not configure HTTP client with TLS")
+		return nil, fmt.Errorf("could not configure HTTP client with TLS: %w", err)
 	}
 	for _, h := range coordinates.Headers {
 		headers[h.Key] = h.Value

--- a/app/kumactl/pkg/errors/formatter.go
+++ b/app/kumactl/pkg/errors/formatter.go
@@ -1,9 +1,9 @@
 package errors
 
 import (
+	"errors"
 	"fmt"
 
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
 	"github.com/kumahq/kuma/pkg/core/rest/errors/types"
@@ -12,13 +12,11 @@ import (
 func FormatErrorWrapper(fn func(*cobra.Command, []string) error) func(*cobra.Command, []string) error {
 	return func(cmd *cobra.Command, args []string) error {
 		if err := fn(cmd, args); err != nil {
-			cause := errors.Cause(err)
-			switch typedErr := cause.(type) {
-			case *types.Error:
+			var typedErr *types.Error
+			if errors.As(err, &typedErr) {
 				return formatApiServerError(typedErr)
-			default:
-				return err
 			}
+			return err
 		}
 		return nil
 	}

--- a/app/kumactl/pkg/errors/formatter_test.go
+++ b/app/kumactl/pkg/errors/formatter_test.go
@@ -1,9 +1,11 @@
 package errors_test
 
 import (
+	"errors"
+	"fmt"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
 	kumactl_errors "github.com/kumahq/kuma/app/kumactl/pkg/errors"
@@ -11,7 +13,6 @@ import (
 )
 
 var _ = Describe("Formatter test", func() {
-
 	type testCase struct {
 		err error
 		msg string
@@ -51,10 +52,10 @@ var _ = Describe("Formatter test", func() {
 * mesh: cannot be empty`,
 		}),
 		Entry("kuma api error even when it is wrapped", testCase{
-			err: errors.Wrap(&types.Error{
+			err: fmt.Errorf("failed: %w", &types.Error{
 				Title:   "Could not get the resource",
 				Details: "Internal Server Error",
-			}, "failed"),
+			}),
 			msg: `Could not get the resource (Internal Server Error)`,
 		}),
 		Entry("unknown error", testCase{
@@ -75,5 +76,4 @@ var _ = Describe("Formatter test", func() {
 		// then
 		Expect(err).ToNot(HaveOccurred())
 	})
-
 })

--- a/app/kumactl/pkg/install/data/files.go
+++ b/app/kumactl/pkg/install/data/files.go
@@ -1,10 +1,9 @@
 package data
 
 import (
+	"fmt"
 	"io"
 	"io/fs"
-
-	"github.com/pkg/errors"
 )
 
 type FileList []File
@@ -29,7 +28,7 @@ func ReadFiles(fileSys fs.FS) (FileList, error) {
 		if !dir.IsDir() {
 			data, err := fs.ReadFile(fileSys, path)
 			if err != nil {
-				return errors.Wrapf(err, "Failed to read file: %s", path)
+				return fmt.Errorf("Failed to read file: %s: %w", path, err)
 			}
 			file := File{
 				Data:     data,

--- a/app/kumactl/pkg/output/printers/printers.go
+++ b/app/kumactl/pkg/output/printers/printers.go
@@ -1,7 +1,7 @@
 package printers
 
 import (
-	"github.com/pkg/errors"
+	"fmt"
 
 	"github.com/kumahq/kuma/app/kumactl/pkg/output"
 	"github.com/kumahq/kuma/app/kumactl/pkg/output/json"
@@ -11,9 +11,7 @@ import (
 
 type Table = table.Table
 
-var (
-	NewTablePrinter = table.NewPrinter
-)
+var NewTablePrinter = table.NewPrinter
 
 func NewGenericPrinter(format output.Format) (output.Printer, error) {
 	switch format {
@@ -22,6 +20,6 @@ func NewGenericPrinter(format output.Format) (output.Printer, error) {
 	case output.YAMLFormat:
 		return yaml.NewPrinter(), nil
 	default:
-		return nil, errors.Errorf("unknown output format %q", format)
+		return nil, fmt.Errorf("unknown output format %q", format)
 	}
 }

--- a/app/kumactl/pkg/resources/apiserver_client.go
+++ b/app/kumactl/pkg/resources/apiserver_client.go
@@ -3,9 +3,8 @@ package resources
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
-
-	"github.com/pkg/errors"
 
 	"github.com/kumahq/kuma/pkg/api-server/types"
 	util_http "github.com/kumahq/kuma/pkg/util/http"
@@ -35,7 +34,7 @@ func (d *httpApiServerClient) GetVersion(ctx context.Context) (*types.IndexRespo
 		return nil, err
 	}
 	if statusCode != 200 {
-		return nil, errors.Errorf("(%d): %s", statusCode, string(b))
+		return nil, fmt.Errorf("(%d): %s", statusCode, string(b))
 	}
 	version := types.IndexResponse{}
 	if err := json.Unmarshal(b, &version); err != nil {

--- a/app/kumactl/pkg/resources/dataplane_inspect_client.go
+++ b/app/kumactl/pkg/resources/dataplane_inspect_client.go
@@ -7,8 +7,6 @@ import (
 	"net/http"
 	"net/url"
 
-	"github.com/pkg/errors"
-
 	api_server_types "github.com/kumahq/kuma/pkg/api-server/types"
 	util_http "github.com/kumahq/kuma/pkg/util/http"
 )
@@ -32,7 +30,7 @@ var _ DataplaneInspectClient = &httpDataplaneInspectClient{}
 func (h *httpDataplaneInspectClient) InspectPolicies(ctx context.Context, mesh, name string) (api_server_types.DataplaneInspectResponse, error) {
 	resUrl, err := url.Parse(fmt.Sprintf("/meshes/%s/dataplanes/%s/policies", mesh, name))
 	if err != nil {
-		return api_server_types.DataplaneInspectResponse{}, errors.Wrap(err, "could not construct the url")
+		return api_server_types.DataplaneInspectResponse{}, fmt.Errorf("could not construct the url: %w", err)
 	}
 	req, err := http.NewRequest("GET", resUrl.String(), nil)
 	if err != nil {
@@ -43,7 +41,7 @@ func (h *httpDataplaneInspectClient) InspectPolicies(ctx context.Context, mesh, 
 		return api_server_types.DataplaneInspectResponse{}, err
 	}
 	if statusCode != 200 {
-		return api_server_types.DataplaneInspectResponse{}, errors.Errorf("(%d): %s", statusCode, string(b))
+		return api_server_types.DataplaneInspectResponse{}, fmt.Errorf("(%d): %s", statusCode, string(b))
 	}
 	response := &api_server_types.DataplaneInspectResponse{}
 	if err := json.Unmarshal(b, &response); err != nil {

--- a/app/kumactl/pkg/resources/dataplane_overview_client.go
+++ b/app/kumactl/pkg/resources/dataplane_overview_client.go
@@ -6,8 +6,6 @@ import (
 	"net/http"
 	"net/url"
 
-	"github.com/pkg/errors"
-
 	"github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	"github.com/kumahq/kuma/pkg/plugins/resources/remote"
 	util_http "github.com/kumahq/kuma/pkg/util/http"
@@ -30,7 +28,7 @@ type httpDataplaneOverviewClient struct {
 func (d *httpDataplaneOverviewClient) List(ctx context.Context, meshName string, tags map[string]string, gateway bool, ingress bool) (*mesh.DataplaneOverviewResourceList, error) {
 	resUrl, err := constructUrl(meshName, tags, gateway, ingress)
 	if err != nil {
-		return nil, errors.Wrap(err, "could not construct the url")
+		return nil, fmt.Errorf("could not construct the url: %w", err)
 	}
 	req, err := http.NewRequest("GET", resUrl.String(), nil)
 	if err != nil {
@@ -41,7 +39,7 @@ func (d *httpDataplaneOverviewClient) List(ctx context.Context, meshName string,
 		return nil, err
 	}
 	if statusCode != 200 {
-		return nil, errors.Errorf("(%d): %s", statusCode, string(b))
+		return nil, fmt.Errorf("(%d): %s", statusCode, string(b))
 	}
 	overviews := mesh.DataplaneOverviewResourceList{}
 	if err := remote.UnmarshalList(b, &overviews); err != nil {

--- a/app/kumactl/pkg/resources/inspect_envoy_proxy_client.go
+++ b/app/kumactl/pkg/resources/inspect_envoy_proxy_client.go
@@ -6,8 +6,6 @@ import (
 	"net/http"
 	"net/url"
 
-	"github.com/pkg/errors"
-
 	"github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	core_model "github.com/kumahq/kuma/pkg/core/resources/model"
 	util_http "github.com/kumahq/kuma/pkg/util/http"
@@ -34,7 +32,7 @@ var _ InspectEnvoyProxyClient = &httpInspectEnvoyProxyClient{}
 func (h *httpInspectEnvoyProxyClient) ConfigDump(ctx context.Context, rk core_model.ResourceKey) ([]byte, error) {
 	resUrl, err := h.buildURL(rk)
 	if err != nil {
-		return nil, errors.Wrap(err, "could not construct the url")
+		return nil, fmt.Errorf("could not construct the url: %w", err)
 	}
 	req, err := http.NewRequest("GET", resUrl.String(), nil)
 	if err != nil {
@@ -45,7 +43,7 @@ func (h *httpInspectEnvoyProxyClient) ConfigDump(ctx context.Context, rk core_mo
 		return nil, err
 	}
 	if statusCode != 200 {
-		return nil, errors.Errorf("(%d): %s", statusCode, string(b))
+		return nil, fmt.Errorf("(%d): %s", statusCode, string(b))
 	}
 	return b, nil
 }

--- a/app/kumactl/pkg/resources/meshgateway_inspect_client.go
+++ b/app/kumactl/pkg/resources/meshgateway_inspect_client.go
@@ -7,8 +7,6 @@ import (
 	"net/http"
 	"net/url"
 
-	"github.com/pkg/errors"
-
 	api_server_types "github.com/kumahq/kuma/pkg/api-server/types"
 	util_http "github.com/kumahq/kuma/pkg/util/http"
 )
@@ -32,7 +30,7 @@ var _ MeshGatewayInspectClient = &httpMeshGatewayInspectClient{}
 func (h *httpMeshGatewayInspectClient) InspectDataplanes(ctx context.Context, mesh, name string) (api_server_types.GatewayDataplanesInspectEntryList, error) {
 	resUrl, err := url.Parse(fmt.Sprintf("/meshes/%s/meshgateways/%s/dataplanes", mesh, name))
 	if err != nil {
-		return api_server_types.GatewayDataplanesInspectEntryList{}, errors.Wrap(err, "could not construct the url")
+		return api_server_types.GatewayDataplanesInspectEntryList{}, fmt.Errorf("could not construct the url: %w", err)
 	}
 	req, err := http.NewRequest("GET", resUrl.String(), nil)
 	if err != nil {
@@ -43,7 +41,7 @@ func (h *httpMeshGatewayInspectClient) InspectDataplanes(ctx context.Context, me
 		return api_server_types.GatewayDataplanesInspectEntryList{}, err
 	}
 	if statusCode != 200 {
-		return api_server_types.GatewayDataplanesInspectEntryList{}, errors.Errorf("(%d): %s", statusCode, string(b))
+		return api_server_types.GatewayDataplanesInspectEntryList{}, fmt.Errorf("(%d): %s", statusCode, string(b))
 	}
 	response := &api_server_types.GatewayDataplanesInspectEntryList{}
 	if err := json.Unmarshal(b, &response); err != nil {

--- a/app/kumactl/pkg/resources/policy_inspect_client.go
+++ b/app/kumactl/pkg/resources/policy_inspect_client.go
@@ -7,8 +7,6 @@ import (
 	"net/http"
 	"net/url"
 
-	"github.com/pkg/errors"
-
 	api_server_types "github.com/kumahq/kuma/pkg/api-server/types"
 	core_model "github.com/kumahq/kuma/pkg/core/resources/model"
 	util_http "github.com/kumahq/kuma/pkg/util/http"
@@ -33,7 +31,7 @@ type httpPolicyInspectClient struct {
 func (h *httpPolicyInspectClient) Inspect(ctx context.Context, policyDesc core_model.ResourceTypeDescriptor, mesh, name string) (*api_server_types.PolicyInspectEntryList, error) {
 	resUrl, err := url.Parse(fmt.Sprintf("/meshes/%s/%s/%s/dataplanes", mesh, policyDesc.WsPath, name))
 	if err != nil {
-		return nil, errors.Wrap(err, "could not construct the url")
+		return nil, fmt.Errorf("could not construct the url: %w", err)
 	}
 	req, err := http.NewRequest("GET", resUrl.String(), nil)
 	if err != nil {
@@ -44,7 +42,7 @@ func (h *httpPolicyInspectClient) Inspect(ctx context.Context, policyDesc core_m
 		return nil, err
 	}
 	if statusCode != 200 {
-		return nil, errors.Errorf("(%d): %s", statusCode, string(b))
+		return nil, fmt.Errorf("(%d): %s", statusCode, string(b))
 	}
 	entryList := &api_server_types.PolicyInspectEntryList{}
 	if err := json.Unmarshal(b, entryList); err != nil {

--- a/app/kumactl/pkg/resources/service_overview_client.go
+++ b/app/kumactl/pkg/resources/service_overview_client.go
@@ -5,8 +5,6 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/pkg/errors"
-
 	"github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	"github.com/kumahq/kuma/pkg/plugins/resources/remote"
 	util_http "github.com/kumahq/kuma/pkg/util/http"
@@ -36,7 +34,7 @@ func (d *httpServiceOverviewClient) List(ctx context.Context, meshName string) (
 		return nil, err
 	}
 	if statusCode != 200 {
-		return nil, errors.Errorf("(%d): %s", statusCode, string(b))
+		return nil, fmt.Errorf("(%d): %s", statusCode, string(b))
 	}
 	overviews := &mesh.ServiceOverviewResourceList{}
 	if err := remote.UnmarshalList(b, overviews); err != nil {

--- a/app/kumactl/pkg/resources/zone_overview_client.go
+++ b/app/kumactl/pkg/resources/zone_overview_client.go
@@ -2,9 +2,8 @@ package resources
 
 import (
 	"context"
+	"fmt"
 	"net/http"
-
-	"github.com/pkg/errors"
 
 	"github.com/kumahq/kuma/pkg/core/resources/apis/system"
 	"github.com/kumahq/kuma/pkg/plugins/resources/remote"
@@ -35,7 +34,7 @@ func (d *httpZoneOverviewClient) List(ctx context.Context) (*system.ZoneOverview
 		return nil, err
 	}
 	if statusCode != 200 {
-		return nil, errors.Errorf("(%d): %s", statusCode, string(b))
+		return nil, fmt.Errorf("(%d): %s", statusCode, string(b))
 	}
 	overviews := system.ZoneOverviewResourceList{}
 	if err := remote.UnmarshalList(b, &overviews); err != nil {

--- a/app/kumactl/pkg/resources/zoneegressoverview_client.go
+++ b/app/kumactl/pkg/resources/zoneegressoverview_client.go
@@ -2,9 +2,8 @@ package resources
 
 import (
 	"context"
+	"fmt"
 	"net/http"
-
-	"github.com/pkg/errors"
 
 	"github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	"github.com/kumahq/kuma/pkg/plugins/resources/remote"
@@ -35,7 +34,7 @@ func (d *httpZoneEgressOverviewClient) List(ctx context.Context) (*mesh.ZoneEgre
 		return nil, err
 	}
 	if statusCode != 200 {
-		return nil, errors.Errorf("(%d): %s", statusCode, string(b))
+		return nil, fmt.Errorf("(%d): %s", statusCode, string(b))
 	}
 	overviews := mesh.ZoneEgressOverviewResourceList{}
 	if err := remote.UnmarshalList(b, &overviews); err != nil {

--- a/app/kumactl/pkg/resources/zoneingress_overview_client.go
+++ b/app/kumactl/pkg/resources/zoneingress_overview_client.go
@@ -2,9 +2,8 @@ package resources
 
 import (
 	"context"
+	"fmt"
 	"net/http"
-
-	"github.com/pkg/errors"
 
 	"github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	"github.com/kumahq/kuma/pkg/plugins/resources/remote"
@@ -35,7 +34,7 @@ func (d *httpZoneIngressOverviewClient) List(ctx context.Context) (*mesh.ZoneIng
 		return nil, err
 	}
 	if statusCode != 200 {
-		return nil, errors.Errorf("(%d): %s", statusCode, string(b))
+		return nil, fmt.Errorf("(%d): %s", statusCode, string(b))
 	}
 	overviews := mesh.ZoneIngressOverviewResourceList{}
 	if err := remote.UnmarshalList(b, &overviews); err != nil {

--- a/app/kumactl/pkg/tokens/client.go
+++ b/app/kumactl/pkg/tokens/client.go
@@ -3,11 +3,10 @@ package tokens
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"time"
-
-	"github.com/pkg/errors"
 
 	error_types "github.com/kumahq/kuma/pkg/core/rest/errors/types"
 	"github.com/kumahq/kuma/pkg/tokens/builtin/server/types"
@@ -40,21 +39,21 @@ func (h *httpDataplaneTokenClient) Generate(name string, mesh string, tags map[s
 	}
 	reqBytes, err := json.Marshal(tokenReq)
 	if err != nil {
-		return "", errors.Wrap(err, "could not marshal token request to json")
+		return "", fmt.Errorf("could not marshal token request to json: %w", err)
 	}
 	req, err := http.NewRequest("POST", "/tokens/dataplane", bytes.NewReader(reqBytes))
 	if err != nil {
-		return "", errors.Wrap(err, "could not construct the request")
+		return "", fmt.Errorf("could not construct the request: %w", err)
 	}
 	req.Header.Set("content-type", "application/json")
 	resp, err := h.client.Do(req)
 	if err != nil {
-		return "", errors.Wrap(err, "could not execute the request")
+		return "", fmt.Errorf("could not execute the request: %w", err)
 	}
 	defer resp.Body.Close()
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return "", errors.Wrap(err, "could not read a body of the request")
+		return "", fmt.Errorf("could not read a body of the request: %w", err)
 	}
 	if resp.StatusCode != 200 {
 		kumaErr := error_types.Error{}
@@ -63,7 +62,7 @@ func (h *httpDataplaneTokenClient) Generate(name string, mesh string, tags map[s
 				return "", &kumaErr
 			}
 		}
-		return "", errors.Errorf("(%d): %s", resp.StatusCode, body)
+		return "", fmt.Errorf("(%d): %s", resp.StatusCode, body)
 	}
 	return string(body), nil
 }

--- a/app/kumactl/pkg/tokens/zone_client.go
+++ b/app/kumactl/pkg/tokens/zone_client.go
@@ -3,11 +3,10 @@ package tokens
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"time"
-
-	"github.com/pkg/errors"
 
 	error_types "github.com/kumahq/kuma/pkg/core/rest/errors/types"
 	"github.com/kumahq/kuma/pkg/tokens/builtin/server/types"
@@ -39,25 +38,25 @@ func (h *httpZoneTokenClient) Generate(zone string, scope []string, validFor tim
 
 	reqBytes, err := json.Marshal(tokenReq)
 	if err != nil {
-		return "", errors.Wrap(err, "could not marshal token request to json")
+		return "", fmt.Errorf("could not marshal token request to json: %w", err)
 	}
 
 	req, err := http.NewRequest(http.MethodPost, "/tokens/zone", bytes.NewReader(reqBytes))
 	if err != nil {
-		return "", errors.Wrap(err, "could not construct the request")
+		return "", fmt.Errorf("could not construct the request: %w", err)
 	}
 
 	req.Header.Set("content-type", "application/json")
 
 	resp, err := h.client.Do(req)
 	if err != nil {
-		return "", errors.Wrap(err, "could not execute the request")
+		return "", fmt.Errorf("could not execute the request: %w", err)
 	}
 	defer resp.Body.Close()
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return "", errors.Wrap(err, "could not read a body of the request")
+		return "", fmt.Errorf("could not read a body of the request: %w", err)
 	}
 
 	if resp.StatusCode != http.StatusOK {
@@ -67,7 +66,7 @@ func (h *httpZoneTokenClient) Generate(zone string, scope []string, validFor tim
 				return "", &kumaErr
 			}
 		}
-		return "", errors.Errorf("(%d): %s", resp.StatusCode, body)
+		return "", fmt.Errorf("(%d): %s", resp.StatusCode, body)
 	}
 
 	return string(body), nil

--- a/app/kumactl/pkg/tokens/zoneingress_client.go
+++ b/app/kumactl/pkg/tokens/zoneingress_client.go
@@ -3,11 +3,10 @@ package tokens
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"time"
-
-	"github.com/pkg/errors"
 
 	error_types "github.com/kumahq/kuma/pkg/core/rest/errors/types"
 	"github.com/kumahq/kuma/pkg/tokens/builtin/server/types"
@@ -37,21 +36,21 @@ func (h *httpZoneIngressTokenClient) Generate(zone string, validFor time.Duratio
 	}
 	reqBytes, err := json.Marshal(tokenReq)
 	if err != nil {
-		return "", errors.Wrap(err, "could not marshal token request to json")
+		return "", fmt.Errorf("could not marshal token request to json: %w", err)
 	}
 	req, err := http.NewRequest("POST", "/tokens/zone-ingress", bytes.NewReader(reqBytes))
 	if err != nil {
-		return "", errors.Wrap(err, "could not construct the request")
+		return "", fmt.Errorf("could not construct the request: %w", err)
 	}
 	req.Header.Set("content-type", "application/json")
 	resp, err := h.client.Do(req)
 	if err != nil {
-		return "", errors.Wrap(err, "could not execute the request")
+		return "", fmt.Errorf("could not execute the request: %w", err)
 	}
 	defer resp.Body.Close()
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return "", errors.Wrap(err, "could not read a body of the request")
+		return "", fmt.Errorf("could not read a body of the request: %w", err)
 	}
 	if resp.StatusCode != 200 {
 		kumaErr := error_types.Error{}
@@ -60,7 +59,7 @@ func (h *httpZoneIngressTokenClient) Generate(zone string, validFor time.Duratio
 				return "", &kumaErr
 			}
 		}
-		return "", errors.Errorf("(%d): %s", resp.StatusCode, body)
+		return "", fmt.Errorf("(%d): %s", resp.StatusCode, body)
 	}
 	return string(body), nil
 }

--- a/go.mod
+++ b/go.mod
@@ -32,7 +32,6 @@ require (
 	github.com/onsi/gomega v1.19.0
 	github.com/operator-framework/operator-lib v0.11.0
 	github.com/patrickmn/go-cache v2.1.0+incompatible
-	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.12.2
 	github.com/prometheus/client_model v0.2.0
 	github.com/prometheus/common v0.34.0
@@ -47,7 +46,7 @@ require (
 	go.uber.org/multierr v1.8.0
 	go.uber.org/zap v1.21.0
 	golang.org/x/net v0.0.0-20220520000938-2e3eb7b945c2
-	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
+	golang.org/x/sync v0.0.0-20220513210516-0976fa681c29
 	golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a
 	golang.org/x/time v0.0.0-20220224211638-0e9765cccd65
 	google.golang.org/genproto v0.0.0-20220519153652-3a47de7e79bd
@@ -152,6 +151,7 @@ require (
 	github.com/opencontainers/runc v1.1.2 // indirect
 	github.com/pelletier/go-toml v1.9.5 // indirect
 	github.com/pelletier/go-toml/v2 v2.0.1 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/pquerna/otp v1.2.0 // indirect
 	github.com/prometheus/procfs v0.7.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1775,8 +1775,9 @@ golang.org/x/sync v0.0.0-20200317015054-43a5402ce75a/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201207232520-09787c993a3a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
-golang.org/x/sync v0.0.0-20210220032951-036812b2e83c h1:5KslGYwFpkhGh+Q16bwMP3cOontH8FOep7tGV86Y7SQ=
 golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20220513210516-0976fa681c29 h1:w8s32wxx3sY+OjLlv9qltkLU5yvJzxjjgiHWLjdIcw4=
+golang.org/x/sync v0.0.0-20220513210516-0976fa681c29/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180117170059-2c42eef0765b/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180224232135-f6cff0780e54/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180823144017-11551d06cbcc/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/pkg/api-server/types/errors.go
+++ b/pkg/api-server/types/errors.go
@@ -1,13 +1,13 @@
 package types
 
 import (
+	"errors"
+	"fmt"
 	"strings"
-
-	"github.com/pkg/errors"
 )
 
 func NewMaxPageSizeExceeded(pageSize, limit int) error {
-	return errors.Errorf("Invalid page size of %d. Maximum page size is %d", pageSize, limit)
+	return fmt.Errorf("Invalid page size of %d. Maximum page size is %d", pageSize, limit)
 }
 
 func IsMaxPageSizeExceeded(err error) bool {

--- a/pkg/api-server/types/inspect.go
+++ b/pkg/api-server/types/inspect.go
@@ -2,8 +2,7 @@ package types
 
 import (
 	"encoding/json"
-
-	"github.com/pkg/errors"
+	"fmt"
 
 	core_model "github.com/kumahq/kuma/pkg/core/resources/model"
 	"github.com/kumahq/kuma/pkg/core/resources/model/rest"
@@ -42,7 +41,7 @@ func NewPolicyInspectEntry(k PolicyInspectEntryKind) PolicyInspectEntry {
 func (w *PolicyInspectEntry) UnmarshalJSON(data []byte) error {
 	i := KindTag{}
 	if err := json.Unmarshal(data, &i); err != nil {
-		return errors.Wrap(err, `unable to find "kind"`)
+		return fmt.Errorf(`unable to find "kind": %w`, err)
 	}
 	var entry PolicyInspectEntryKind
 	switch i.Kind {
@@ -53,10 +52,10 @@ func (w *PolicyInspectEntry) UnmarshalJSON(data []byte) error {
 	case GatewayDataplane:
 		entry = &PolicyInspectGatewayEntry{}
 	default:
-		return errors.Errorf("invalid PolicyInspectEntry kind %q", i.Kind)
+		return fmt.Errorf("invalid PolicyInspectEntry kind %q", i.Kind)
 	}
 	if err := json.Unmarshal(data, entry); err != nil {
-		return errors.Wrapf(err, "unable to parse PolicyInspectEntry of kind %q", i.Kind)
+		return fmt.Errorf("unable to parse PolicyInspectEntry of kind %q: %w", i.Kind, err)
 	}
 	w.PolicyInspectEntryKind = entry
 	return nil
@@ -67,8 +66,10 @@ type PolicyInspectSidecarEntry struct {
 	Attachments  []AttachmentEntry `json:"attachments"`
 }
 
-const SidecarDataplane = "SidecarDataplane"
-const GatewayDataplane = "MeshGatewayDataplane"
+const (
+	SidecarDataplane = "SidecarDataplane"
+	GatewayDataplane = "MeshGatewayDataplane"
+)
 
 type KindTag struct {
 	Kind string `json:"kind"`
@@ -174,7 +175,7 @@ func (e DataplaneInspectResponse) MarshalJSON() ([]byte, error) {
 func (w *DataplaneInspectResponse) UnmarshalJSON(data []byte) error {
 	i := KindTag{}
 	if err := json.Unmarshal(data, &i); err != nil {
-		return errors.Wrap(err, `unable to find "kind"`)
+		return fmt.Errorf(`unable to find "kind": %w`, err)
 	}
 	var entry DataplaneInspectResponseKind
 	switch i.Kind {
@@ -183,10 +184,10 @@ func (w *DataplaneInspectResponse) UnmarshalJSON(data []byte) error {
 	case GatewayDataplane:
 		entry = &GatewayDataplaneInspectResult{}
 	default:
-		return errors.Errorf("invalid DataplaneInspectResponse kind %q", i.Kind)
+		return fmt.Errorf("invalid DataplaneInspectResponse kind %q", i.Kind)
 	}
 	if err := json.Unmarshal(data, entry); err != nil {
-		return errors.Wrapf(err, "unable to parse DataplaneInspectResponse of kind %q", i.Kind)
+		return fmt.Errorf("unable to parse DataplaneInspectResponse of kind %q: %w", i.Kind, err)
 	}
 	w.DataplaneInspectResponseKind = entry
 	return nil

--- a/pkg/clusterid/components.go
+++ b/pkg/clusterid/components.go
@@ -1,7 +1,7 @@
 package clusterid
 
 import (
-	"github.com/pkg/errors"
+	"fmt"
 
 	config_core "github.com/kumahq/kuma/pkg/config/core"
 	core_runtime "github.com/kumahq/kuma/pkg/core/runtime"
@@ -22,6 +22,6 @@ func Setup(rt core_runtime.Runtime) error {
 		}
 		return nil
 	default:
-		return errors.Errorf("unknown mode of the CP %s", rt.Config().Mode)
+		return fmt.Errorf("unknown mode of the CP %s", rt.Config().Mode)
 	}
 }

--- a/pkg/clusterid/creator.go
+++ b/pkg/clusterid/creator.go
@@ -2,8 +2,7 @@ package clusterid
 
 import (
 	"context"
-
-	"github.com/pkg/errors"
+	"fmt"
 
 	"github.com/kumahq/kuma/pkg/core"
 	config_manager "github.com/kumahq/kuma/pkg/core/config/manager"
@@ -34,7 +33,7 @@ func (c *clusterIDCreator) create() error {
 		resource.Spec.Config = core.NewUUID()
 		log.Info("creating cluster ID", "clusterID", resource.Spec.Config)
 		if err := c.configManager.Create(context.Background(), resource, store.CreateByKey(config_manager.ClusterIdConfigKey, core_model.NoMesh)); err != nil {
-			return errors.Wrap(err, "could not create config")
+			return fmt.Errorf("could not create config: %w", err)
 		}
 	}
 

--- a/pkg/config/access/config.go
+++ b/pkg/config/access/config.go
@@ -1,7 +1,7 @@
 package access
 
 import (
-	"github.com/pkg/errors"
+	"errors"
 
 	"github.com/kumahq/kuma/pkg/config"
 )

--- a/pkg/config/api-server/config.go
+++ b/pkg/config/api-server/config.go
@@ -1,7 +1,8 @@
 package api_server
 
 import (
-	"github.com/pkg/errors"
+	"errors"
+	"fmt"
 
 	"github.com/kumahq/kuma/pkg/config"
 )
@@ -97,10 +98,10 @@ func (a *ApiServerConfig) Sanitize() {
 
 func (a *ApiServerConfig) Validate() error {
 	if err := a.HTTP.Validate(); err != nil {
-		return errors.Wrap(err, ".HTTP not valid")
+		return fmt.Errorf(".HTTP not valid: %w", err)
 	}
 	if err := a.HTTPS.Validate(); err != nil {
-		return errors.Wrap(err, ".HTTP not valid")
+		return fmt.Errorf(".HTTP not valid: %w", err)
 	}
 	return nil
 }

--- a/pkg/config/app/kuma-cp/config.go
+++ b/pkg/config/app/kuma-cp/config.go
@@ -1,9 +1,9 @@
 package kuma_cp
 
 import (
+	"errors"
+	"fmt"
 	"time"
-
-	"github.com/pkg/errors"
 
 	"github.com/kumahq/kuma/pkg/config"
 	"github.com/kumahq/kuma/pkg/config/access"
@@ -47,7 +47,7 @@ func (m *Metrics) Sanitize() {
 
 func (m *Metrics) Validate() error {
 	if err := m.Dataplane.Validate(); err != nil {
-		return errors.Wrap(err, "Dataplane validation failed")
+		return fmt.Errorf("Dataplane validation failed: %w", err)
 	}
 	return nil
 }
@@ -207,78 +207,78 @@ var DefaultConfig = func() Config {
 
 func (c *Config) Validate() error {
 	if err := core.ValidateCpMode(c.Mode); err != nil {
-		return errors.Wrap(err, "Mode validation failed")
+		return fmt.Errorf("Mode validation failed: %w", err)
 	}
 	switch c.Mode {
 	case core.Global:
 		if err := c.GuiServer.Validate(); err != nil {
-			return errors.Wrap(err, "GuiServer validation failed")
+			return fmt.Errorf("GuiServer validation failed: %w", err)
 		}
 		if err := c.Multizone.Global.Validate(); err != nil {
-			return errors.Wrap(err, "Multizone Global validation failed")
+			return fmt.Errorf("Multizone Global validation failed: %w", err)
 		}
 	case core.Standalone:
 		if err := c.GuiServer.Validate(); err != nil {
-			return errors.Wrap(err, "GuiServer validation failed")
+			return fmt.Errorf("GuiServer validation failed: %w", err)
 		}
 		if err := c.XdsServer.Validate(); err != nil {
-			return errors.Wrap(err, "Xds Server validation failed")
+			return fmt.Errorf("Xds Server validation failed: %w", err)
 		}
 		if err := c.BootstrapServer.Validate(); err != nil {
-			return errors.Wrap(err, "Bootstrap Server validation failed")
+			return fmt.Errorf("Bootstrap Server validation failed: %w", err)
 		}
 		if err := c.MonitoringAssignmentServer.Validate(); err != nil {
-			return errors.Wrap(err, "Monitoring Assignment Server validation failed")
+			return fmt.Errorf("Monitoring Assignment Server validation failed: %w", err)
 		}
 		if c.Environment != core.KubernetesEnvironment && c.Environment != core.UniversalEnvironment {
-			return errors.Errorf("Environment should be either %s or %s", core.KubernetesEnvironment, core.UniversalEnvironment)
+			return fmt.Errorf("Environment should be either %s or %s", core.KubernetesEnvironment, core.UniversalEnvironment)
 		}
 		if err := c.Runtime.Validate(c.Environment); err != nil {
-			return errors.Wrap(err, "Runtime validation failed")
+			return fmt.Errorf("Runtime validation failed: %w", err)
 		}
 		if err := c.Metrics.Validate(); err != nil {
-			return errors.Wrap(err, "Metrics validation failed")
+			return fmt.Errorf("Metrics validation failed: %w", err)
 		}
 	case core.Zone:
 		if err := c.Multizone.Zone.Validate(); err != nil {
-			return errors.Wrap(err, "Multizone Zone validation failed")
+			return fmt.Errorf("Multizone Zone validation failed: %w", err)
 		}
 		if err := c.XdsServer.Validate(); err != nil {
-			return errors.Wrap(err, "Xds Server validation failed")
+			return fmt.Errorf("Xds Server validation failed: %w", err)
 		}
 		if err := c.BootstrapServer.Validate(); err != nil {
-			return errors.Wrap(err, "Bootstrap Server validation failed")
+			return fmt.Errorf("Bootstrap Server validation failed: %w", err)
 		}
 		if err := c.MonitoringAssignmentServer.Validate(); err != nil {
-			return errors.Wrap(err, "Monitoring Assignment Server validation failed")
+			return fmt.Errorf("Monitoring Assignment Server validation failed: %w", err)
 		}
 		if c.Environment != core.KubernetesEnvironment && c.Environment != core.UniversalEnvironment {
-			return errors.Errorf("Environment should be either %s or %s", core.KubernetesEnvironment, core.UniversalEnvironment)
+			return fmt.Errorf("Environment should be either %s or %s", core.KubernetesEnvironment, core.UniversalEnvironment)
 		}
 		if err := c.Runtime.Validate(c.Environment); err != nil {
-			return errors.Wrap(err, "Runtime validation failed")
+			return fmt.Errorf("Runtime validation failed: %w", err)
 		}
 		if err := c.Metrics.Validate(); err != nil {
-			return errors.Wrap(err, "Metrics validation failed")
+			return fmt.Errorf("Metrics validation failed: %w", err)
 		}
 	}
 	if err := c.Store.Validate(); err != nil {
-		return errors.Wrap(err, "Store validation failed")
+		return fmt.Errorf("Store validation failed: %w", err)
 	}
 	if err := c.ApiServer.Validate(); err != nil {
-		return errors.Wrap(err, "ApiServer validation failed")
+		return fmt.Errorf("ApiServer validation failed: %w", err)
 	}
 	if err := c.Defaults.Validate(); err != nil {
-		return errors.Wrap(err, "Defaults validation failed")
+		return fmt.Errorf("Defaults validation failed: %w", err)
 	}
 	if err := c.DNSServer.Validate(); err != nil {
-		return errors.Wrap(err, "DNSServer validation failed")
+		return fmt.Errorf("DNSServer validation failed: %w", err)
 	}
 	if err := c.Diagnostics.Validate(); err != nil {
-		return errors.Wrap(err, "Diagnostics validation failed")
+		return fmt.Errorf("Diagnostics validation failed: %w", err)
 	}
 	if err := c.Experimental.Validate(); err != nil {
-		return errors.Wrap(err, "Experimental validation failed")
+		return fmt.Errorf("Experimental validation failed: %w", err)
 	}
 	return nil
 }

--- a/pkg/config/app/kuma-prometheus-sd/config.go
+++ b/pkg/config/app/kuma-prometheus-sd/config.go
@@ -1,9 +1,9 @@
 package kuma_prometheus_sd
 
 import (
+	"fmt"
 	"net/url"
 
-	"github.com/pkg/errors"
 	"go.uber.org/multierr"
 
 	"github.com/kumahq/kuma/pkg/config"
@@ -42,10 +42,10 @@ func (c *Config) Sanitize() {
 
 func (c *Config) Validate() (errs error) {
 	if err := c.MonitoringAssignment.Validate(); err != nil {
-		errs = multierr.Append(errs, errors.Wrapf(err, ".MonitoringAssignment is not valid"))
+		errs = multierr.Append(errs, fmt.Errorf(".MonitoringAssignment is not valid: %w", err))
 	}
 	if err := c.Prometheus.Validate(); err != nil {
-		errs = multierr.Append(errs, errors.Wrapf(err, ".Prometheus is not valid"))
+		errs = multierr.Append(errs, fmt.Errorf(".Prometheus is not valid: %w", err))
 	}
 	return
 }
@@ -74,7 +74,7 @@ func (c *MonitoringAssignmentConfig) Sanitize() {
 
 func (c *MonitoringAssignmentConfig) Validate() (errs error) {
 	if err := c.Client.Validate(); err != nil {
-		errs = multierr.Append(errs, errors.Wrapf(err, ".Client is not valid"))
+		errs = multierr.Append(errs, fmt.Errorf(".Client is not valid: %w", err))
 	}
 	return
 }
@@ -86,27 +86,27 @@ func (c *MonitoringAssignmentClientConfig) Sanitize() {
 
 func (c *MonitoringAssignmentClientConfig) Validate() (errs error) {
 	if c.Name == "" {
-		errs = multierr.Append(errs, errors.Errorf(".Name must be non-empty"))
+		errs = multierr.Append(errs, fmt.Errorf(".Name must be non-empty"))
 	}
 	if c.URL == "" {
-		errs = multierr.Append(errs, errors.Errorf(".URL must be non-empty"))
+		errs = multierr.Append(errs, fmt.Errorf(".URL must be non-empty"))
 	}
 	url, err := url.Parse(c.URL)
 	if err != nil {
-		errs = multierr.Append(errs, errors.Wrapf(err, ".URL must be a valid absolute URI"))
+		errs = multierr.Append(errs, fmt.Errorf(".URL must be a valid absolute URI: %w", err))
 	} else {
 		if !url.IsAbs() {
-			errs = multierr.Append(errs, errors.Errorf(".URL must be a valid absolute URI"))
+			errs = multierr.Append(errs, fmt.Errorf(".URL must be a valid absolute URI"))
 		}
 		if url.Scheme != "grpc" && url.Scheme != "grpcs" {
-			errs = multierr.Append(errs, errors.Errorf(".URL must start with grpc:// or grpcs://"))
+			errs = multierr.Append(errs, fmt.Errorf(".URL must start with grpc:// or grpcs://"))
 		}
 	}
 
 	if c.ApiVersion == "" {
-		errs = multierr.Append(errs, errors.Errorf(".ApiVersion must be non-empty"))
+		errs = multierr.Append(errs, fmt.Errorf(".ApiVersion must be non-empty"))
 	} else if c.ApiVersion != mads.API_V1 {
-		errs = multierr.Append(errs, errors.Errorf(".ApiVersion must be v1, got: %s", c.ApiVersion))
+		errs = multierr.Append(errs, fmt.Errorf(".ApiVersion must be v1, got: %s", c.ApiVersion))
 	}
 
 	return
@@ -130,7 +130,7 @@ func (c *PrometheusConfig) Sanitize() {
 
 func (c *PrometheusConfig) Validate() (errs error) {
 	if c.OutputFile == "" {
-		errs = multierr.Append(errs, errors.Errorf(".OutputFile must be non-empty"))
+		errs = multierr.Append(errs, fmt.Errorf(".OutputFile must be non-empty"))
 	}
 	return
 }

--- a/pkg/config/core/config.go
+++ b/pkg/config/core/config.go
@@ -1,6 +1,6 @@
 package core
 
-import "github.com/pkg/errors"
+import "fmt"
 
 type EnvironmentType = string
 
@@ -22,7 +22,7 @@ const (
 // ValidateCpMode to check modes of kuma-cp
 func ValidateCpMode(mode CpMode) error {
 	if mode != Standalone && mode != Zone && mode != Global {
-		return errors.Errorf("invalid mode. Available modes: %s, %s, %s", Standalone, Zone, Global)
+		return fmt.Errorf("invalid mode. Available modes: %s, %s, %s", Standalone, Zone, Global)
 	}
 	return nil
 }

--- a/pkg/config/core/resources/store/config.go
+++ b/pkg/config/core/resources/store/config.go
@@ -1,9 +1,9 @@
 package store
 
 import (
+	"errors"
+	"fmt"
 	"time"
-
-	"github.com/pkg/errors"
 
 	"github.com/kumahq/kuma/pkg/config"
 	"github.com/kumahq/kuma/pkg/config/plugins/resources/k8s"
@@ -57,20 +57,20 @@ func (s *StoreConfig) Validate() error {
 	switch s.Type {
 	case PostgresStore:
 		if err := s.Postgres.Validate(); err != nil {
-			return errors.Wrap(err, "Postgres validation failed")
+			return fmt.Errorf("Postgres validation failed: %w", err)
 		}
 	case KubernetesStore:
 		if err := s.Kubernetes.Validate(); err != nil {
-			return errors.Wrap(err, "Kubernetes validation failed")
+			return fmt.Errorf("Kubernetes validation failed: %w", err)
 		}
 		return nil
 	case MemoryStore:
 		return nil
 	default:
-		return errors.Errorf("Type should be either %s, %s or %s", PostgresStore, KubernetesStore, MemoryStore)
+		return fmt.Errorf("Type should be either %s, %s or %s", PostgresStore, KubernetesStore, MemoryStore)
 	}
 	if err := s.Cache.Validate(); err != nil {
-		return errors.Wrap(err, "Cache validation failed")
+		return fmt.Errorf("Cache validation failed: %w", err)
 	}
 	return nil
 }

--- a/pkg/config/dp-server/config.go
+++ b/pkg/config/dp-server/config.go
@@ -1,9 +1,9 @@
 package dp_server
 
 import (
+	"errors"
+	"fmt"
 	"time"
-
-	"github.com/pkg/errors"
 
 	"github.com/kumahq/kuma/pkg/config"
 )
@@ -41,7 +41,7 @@ type DpServerAuthConfig struct {
 
 func (a *DpServerAuthConfig) Validate() error {
 	if a.Type != "" && a.Type != DpServerAuthNone && a.Type != DpServerAuthDpToken && a.Type != DpServerAuthServiceAccountToken {
-		return errors.Errorf("Type is invalid. Available values are: %q, %q, %q", DpServerAuthDpToken, DpServerAuthServiceAccountToken, DpServerAuthNone)
+		return fmt.Errorf("Type is invalid. Available values are: %q, %q, %q", DpServerAuthDpToken, DpServerAuthServiceAccountToken, DpServerAuthNone)
 	}
 	return nil
 }
@@ -54,7 +54,7 @@ func (a *DpServerConfig) Validate() error {
 		return errors.New("Port cannot be negative")
 	}
 	if err := a.Auth.Validate(); err != nil {
-		return errors.Wrap(err, "Auth is invalid")
+		return fmt.Errorf("Auth is invalid: %w", err)
 	}
 	return nil
 }
@@ -104,7 +104,7 @@ func (h *HdsConfig) Validate() error {
 		return errors.New("Interval must be greater than 0s")
 	}
 	if err := h.CheckDefaults.Validate(); err != nil {
-		return errors.Wrap(err, "Check is invalid")
+		return fmt.Errorf("Check is invalid: %w", err)
 	}
 	return nil
 }

--- a/pkg/config/loader.go
+++ b/pkg/config/loader.go
@@ -1,10 +1,10 @@
 package config
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/kelseyhightower/envconfig"
-	"github.com/pkg/errors"
 	"gopkg.in/yaml.v2"
 
 	"github.com/kumahq/kuma/pkg/core"
@@ -22,19 +22,19 @@ func Load(file string, cfg Config) error {
 	}
 
 	if err := cfg.Validate(); err != nil {
-		return errors.Wrapf(err, "Invalid configuration")
+		return fmt.Errorf("Invalid configuration: %w", err)
 	}
 	return nil
 }
 
 func loadFromFile(file string, cfg Config) error {
 	if !fileExists(file) {
-		return errors.Errorf("Failed to access configuration file %q", file)
+		return fmt.Errorf("Failed to access configuration file %q", file)
 	}
 	if contents, err := os.ReadFile(file); err != nil {
-		return errors.Wrapf(err, "Failed to read configuration from file %q", file)
+		return fmt.Errorf("Failed to read configuration from file %q: %w", file, err)
 	} else if err := yaml.Unmarshal(contents, cfg); err != nil {
-		return errors.Wrapf(err, "Failed to parse configuration from file %q", file)
+		return fmt.Errorf("Failed to parse configuration from file %q: %w", file, err)
 	}
 	return nil
 }

--- a/pkg/config/mads/config.go
+++ b/pkg/config/mads/config.go
@@ -1,9 +1,10 @@
 package mads
 
 import (
+	"errors"
+	"fmt"
 	"time"
 
-	"github.com/pkg/errors"
 	"go.uber.org/multierr"
 
 	"github.com/kumahq/kuma/pkg/config"
@@ -53,16 +54,16 @@ func (c *MonitoringAssignmentServerConfig) Validate() (errs error) {
 	}
 
 	if 65535 < c.Port {
-		errs = multierr.Append(errs, errors.Errorf(".Port must be in the range [0, 65535]"))
+		errs = multierr.Append(errs, fmt.Errorf(".Port must be in the range [0, 65535]"))
 	}
 
 	if len(c.ApiVersions) == 0 {
-		errs = multierr.Append(errs, errors.Errorf(".ApiVersions must contain at least one version"))
+		errs = multierr.Append(errs, fmt.Errorf(".ApiVersions must contain at least one version"))
 	}
 
 	for _, apiVersion := range c.ApiVersions {
 		if apiVersion != mads.API_V1 {
-			errs = multierr.Append(errs, errors.Errorf(".ApiVersions contains invalid version %s", apiVersion))
+			errs = multierr.Append(errs, fmt.Errorf(".ApiVersions contains invalid version %s", apiVersion))
 		}
 	}
 

--- a/pkg/config/multizone/kds.go
+++ b/pkg/config/multizone/kds.go
@@ -1,9 +1,10 @@
 package multizone
 
 import (
+	"errors"
+	"fmt"
 	"time"
 
-	"github.com/pkg/errors"
 	"go.uber.org/multierr"
 
 	"github.com/kumahq/kuma/pkg/config"
@@ -32,7 +33,7 @@ func (c *KdsServerConfig) Sanitize() {
 
 func (c *KdsServerConfig) Validate() (errs error) {
 	if c.GrpcPort > 65535 {
-		errs = multierr.Append(errs, errors.Errorf(".GrpcPort must be in the range [0, 65535]"))
+		errs = multierr.Append(errs, fmt.Errorf(".GrpcPort must be in the range [0, 65535]"))
 	}
 	if c.RefreshInterval <= 0 {
 		return errors.New(".RefreshInterval must be positive")

--- a/pkg/config/plugins/resources/k8s/config.go
+++ b/pkg/config/plugins/resources/k8s/config.go
@@ -1,7 +1,7 @@
 package k8s
 
 import (
-	"github.com/pkg/errors"
+	"errors"
 
 	"github.com/kumahq/kuma/pkg/config"
 )

--- a/pkg/config/plugins/resources/postgres/config.go
+++ b/pkg/config/plugins/resources/postgres/config.go
@@ -1,11 +1,10 @@
 package postgres
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 	"time"
-
-	"github.com/pkg/errors"
 
 	"github.com/kumahq/kuma/pkg/config"
 )
@@ -81,7 +80,7 @@ func (mode TLSMode) postgresMode() (string, error) {
 	case VerifyFull:
 		return "verify-full", nil
 	default:
-		return "", errors.Errorf("could not translate mode %q to postgres mode", mode)
+		return "", fmt.Errorf("could not translate mode %q to postgres mode", mode)
 	}
 }
 
@@ -110,7 +109,7 @@ func (s TLSPostgresStoreConfig) Validate() error {
 	case VerifyNone:
 	case Disable:
 	default:
-		return errors.Errorf("invalid mode: %s", s.Mode)
+		return fmt.Errorf("invalid mode: %s", s.Mode)
 	}
 	if s.KeyPath == "" && s.CertPath != "" {
 		return errors.New("KeyPath cannot be empty when CertPath is provided")
@@ -142,7 +141,7 @@ func (p *PostgresStoreConfig) Validate() error {
 		return errors.New("DbName should not be empty")
 	}
 	if err := p.TLS.Validate(); err != nil {
-		return errors.Wrap(err, "TLS validation failed")
+		return fmt.Errorf("TLS validation failed: %w", err)
 	}
 	if p.MinReconnectInterval >= p.MaxReconnectInterval {
 		return errors.New("MinReconnectInterval should be less than MaxReconnectInterval")

--- a/pkg/config/plugins/runtime/config.go
+++ b/pkg/config/plugins/runtime/config.go
@@ -1,7 +1,7 @@
 package runtime
 
 import (
-	"github.com/pkg/errors"
+	"fmt"
 
 	"github.com/kumahq/kuma/pkg/config/core"
 	"github.com/kumahq/kuma/pkg/config/plugins/runtime/k8s"
@@ -31,11 +31,11 @@ func (c *RuntimeConfig) Validate(env core.EnvironmentType) error {
 	switch env {
 	case core.KubernetesEnvironment:
 		if err := c.Kubernetes.Validate(); err != nil {
-			return errors.Wrap(err, "Kubernetes validation failed")
+			return fmt.Errorf("Kubernetes validation failed: %w", err)
 		}
 	case core.UniversalEnvironment:
 	default:
-		return errors.Errorf("unknown environment type %q", env)
+		return fmt.Errorf("unknown environment type %q", env)
 	}
 	return nil
 }

--- a/pkg/config/plugins/runtime/k8s/config.go
+++ b/pkg/config/plugins/runtime/k8s/config.go
@@ -1,9 +1,9 @@
 package k8s
 
 import (
+	"fmt"
 	"time"
 
-	"github.com/pkg/errors"
 	"go.uber.org/multierr"
 	kube_api "k8s.io/apimachinery/pkg/api/resource"
 
@@ -252,13 +252,13 @@ func (c *KubernetesRuntimeConfig) Sanitize() {
 
 func (c *KubernetesRuntimeConfig) Validate() (errs error) {
 	if err := c.AdmissionServer.Validate(); err != nil {
-		errs = multierr.Append(errs, errors.Wrapf(err, ".AdmissionServer is not valid"))
+		errs = multierr.Append(errs, fmt.Errorf(".AdmissionServer is not valid: %w", err))
 	}
 	if err := c.Injector.Validate(); err != nil {
-		errs = multierr.Append(errs, errors.Wrapf(err, ".Injector is not valid"))
+		errs = multierr.Append(errs, fmt.Errorf(".Injector is not valid: %w", err))
 	}
 	if c.MarshalingCacheExpirationTime < 0 {
-		errs = multierr.Append(errs, errors.Errorf(".MarshalingCacheExpirationTime must be positive or equal to 0"))
+		errs = multierr.Append(errs, fmt.Errorf(".MarshalingCacheExpirationTime must be positive or equal to 0"))
 	}
 	return
 }
@@ -270,10 +270,10 @@ func (c *AdmissionServerConfig) Sanitize() {
 
 func (c *AdmissionServerConfig) Validate() (errs error) {
 	if 65535 < c.Port {
-		errs = multierr.Append(errs, errors.Errorf(".Port must be in the range [0, 65535]"))
+		errs = multierr.Append(errs, fmt.Errorf(".Port must be in the range [0, 65535]"))
 	}
 	if c.CertDir == "" {
-		errs = multierr.Append(errs, errors.Errorf(".CertDir should not be empty"))
+		errs = multierr.Append(errs, fmt.Errorf(".CertDir should not be empty"))
 	}
 	return
 }
@@ -287,10 +287,10 @@ func (i *Injector) Sanitize() {
 
 func (i *Injector) Validate() (errs error) {
 	if err := i.SidecarContainer.Validate(); err != nil {
-		errs = multierr.Append(errs, errors.Wrapf(err, ".SidecarContainer is not valid"))
+		errs = multierr.Append(errs, fmt.Errorf(".SidecarContainer is not valid: %w", err))
 	}
 	if err := i.InitContainer.Validate(); err != nil {
-		errs = multierr.Append(errs, errors.Wrapf(err, ".InitContainer is not valid"))
+		errs = multierr.Append(errs, fmt.Errorf(".InitContainer is not valid: %w", err))
 	}
 	return
 }
@@ -305,31 +305,31 @@ func (c *SidecarContainer) Sanitize() {
 
 func (c *SidecarContainer) Validate() (errs error) {
 	if c.Image == "" {
-		errs = multierr.Append(errs, errors.Errorf(".Image must be non-empty"))
+		errs = multierr.Append(errs, fmt.Errorf(".Image must be non-empty"))
 	}
 	if 65535 < c.RedirectPortInbound {
-		errs = multierr.Append(errs, errors.Errorf(".RedirectPortInbound must be in the range [0, 65535]"))
+		errs = multierr.Append(errs, fmt.Errorf(".RedirectPortInbound must be in the range [0, 65535]"))
 	}
 	if 0 != c.RedirectPortInboundV6 && 65535 < c.RedirectPortInboundV6 {
-		errs = multierr.Append(errs, errors.Errorf(".RedirectPortInboundV6 must be in the range [0, 65535]"))
+		errs = multierr.Append(errs, fmt.Errorf(".RedirectPortInboundV6 must be in the range [0, 65535]"))
 	}
 	if 65535 < c.RedirectPortOutbound {
-		errs = multierr.Append(errs, errors.Errorf(".RedirectPortOutbound must be in the range [0, 65535]"))
+		errs = multierr.Append(errs, fmt.Errorf(".RedirectPortOutbound must be in the range [0, 65535]"))
 	}
 	if 65535 < c.AdminPort {
-		errs = multierr.Append(errs, errors.Errorf(".AdminPort must be in the range [0, 65535]"))
+		errs = multierr.Append(errs, fmt.Errorf(".AdminPort must be in the range [0, 65535]"))
 	}
 	if c.DrainTime <= 0 {
-		errs = multierr.Append(errs, errors.Errorf(".DrainTime must be positive"))
+		errs = multierr.Append(errs, fmt.Errorf(".DrainTime must be positive"))
 	}
 	if err := c.ReadinessProbe.Validate(); err != nil {
-		errs = multierr.Append(errs, errors.Wrapf(err, ".ReadinessProbe is not valid"))
+		errs = multierr.Append(errs, fmt.Errorf(".ReadinessProbe is not valid: %w", err))
 	}
 	if err := c.LivenessProbe.Validate(); err != nil {
-		errs = multierr.Append(errs, errors.Wrapf(err, ".LivenessProbe is not valid"))
+		errs = multierr.Append(errs, fmt.Errorf(".LivenessProbe is not valid: %w", err))
 	}
 	if err := c.Resources.Validate(); err != nil {
-		errs = multierr.Append(errs, errors.Wrapf(err, ".Resources is not valid"))
+		errs = multierr.Append(errs, fmt.Errorf(".Resources is not valid: %w", err))
 	}
 	return
 }
@@ -341,7 +341,7 @@ func (c *InitContainer) Sanitize() {
 
 func (c *InitContainer) Validate() (errs error) {
 	if c.Image == "" {
-		errs = multierr.Append(errs, errors.Errorf(".Image must be non-empty"))
+		errs = multierr.Append(errs, fmt.Errorf(".Image must be non-empty"))
 	}
 	return
 }
@@ -353,19 +353,19 @@ func (c *SidecarReadinessProbe) Sanitize() {
 
 func (c *SidecarReadinessProbe) Validate() (errs error) {
 	if c.InitialDelaySeconds < 1 {
-		errs = multierr.Append(errs, errors.Errorf(".InitialDelaySeconds must be >= 1"))
+		errs = multierr.Append(errs, fmt.Errorf(".InitialDelaySeconds must be >= 1"))
 	}
 	if c.TimeoutSeconds < 1 {
-		errs = multierr.Append(errs, errors.Errorf(".TimeoutSeconds must be >= 1"))
+		errs = multierr.Append(errs, fmt.Errorf(".TimeoutSeconds must be >= 1"))
 	}
 	if c.PeriodSeconds < 1 {
-		errs = multierr.Append(errs, errors.Errorf(".PeriodSeconds must be >= 1"))
+		errs = multierr.Append(errs, fmt.Errorf(".PeriodSeconds must be >= 1"))
 	}
 	if c.SuccessThreshold < 1 {
-		errs = multierr.Append(errs, errors.Errorf(".SuccessThreshold must be >= 1"))
+		errs = multierr.Append(errs, fmt.Errorf(".SuccessThreshold must be >= 1"))
 	}
 	if c.FailureThreshold < 1 {
-		errs = multierr.Append(errs, errors.Errorf(".FailureThreshold must be >= 1"))
+		errs = multierr.Append(errs, fmt.Errorf(".FailureThreshold must be >= 1"))
 	}
 	return
 }
@@ -377,16 +377,16 @@ func (c *SidecarLivenessProbe) Sanitize() {
 
 func (c *SidecarLivenessProbe) Validate() (errs error) {
 	if c.InitialDelaySeconds < 1 {
-		errs = multierr.Append(errs, errors.Errorf(".InitialDelaySeconds must be >= 1"))
+		errs = multierr.Append(errs, fmt.Errorf(".InitialDelaySeconds must be >= 1"))
 	}
 	if c.TimeoutSeconds < 1 {
-		errs = multierr.Append(errs, errors.Errorf(".TimeoutSeconds must be >= 1"))
+		errs = multierr.Append(errs, fmt.Errorf(".TimeoutSeconds must be >= 1"))
 	}
 	if c.PeriodSeconds < 1 {
-		errs = multierr.Append(errs, errors.Errorf(".PeriodSeconds must be >= 1"))
+		errs = multierr.Append(errs, fmt.Errorf(".PeriodSeconds must be >= 1"))
 	}
 	if c.FailureThreshold < 1 {
-		errs = multierr.Append(errs, errors.Errorf(".FailureThreshold must be >= 1"))
+		errs = multierr.Append(errs, fmt.Errorf(".FailureThreshold must be >= 1"))
 	}
 	return
 }
@@ -403,10 +403,10 @@ func (c *SidecarResourceRequests) Sanitize() {
 
 func (c *SidecarResources) Validate() (errs error) {
 	if err := c.Requests.Validate(); err != nil {
-		errs = multierr.Append(errs, errors.Wrapf(err, ".Requests is not valid"))
+		errs = multierr.Append(errs, fmt.Errorf(".Requests is not valid: %w", err))
 	}
 	if err := c.Limits.Validate(); err != nil {
-		errs = multierr.Append(errs, errors.Wrapf(err, ".Limits is not valid"))
+		errs = multierr.Append(errs, fmt.Errorf(".Limits is not valid: %w", err))
 	}
 	return
 }
@@ -415,10 +415,10 @@ var _ config.Config = &SidecarResourceRequests{}
 
 func (c *SidecarResourceRequests) Validate() (errs error) {
 	if _, err := kube_api.ParseQuantity(c.CPU); err != nil {
-		errs = multierr.Append(errs, errors.Wrapf(err, ".CPU is not valid"))
+		errs = multierr.Append(errs, fmt.Errorf(".CPU is not valid: %w", err))
 	}
 	if _, err := kube_api.ParseQuantity(c.Memory); err != nil {
-		errs = multierr.Append(errs, errors.Wrapf(err, ".Memory is not valid"))
+		errs = multierr.Append(errs, fmt.Errorf(".Memory is not valid: %w", err))
 	}
 	return
 }
@@ -430,10 +430,10 @@ func (c *SidecarResourceLimits) Sanitize() {
 
 func (c *SidecarResourceLimits) Validate() (errs error) {
 	if _, err := kube_api.ParseQuantity(c.CPU); err != nil {
-		errs = multierr.Append(errs, errors.Wrapf(err, ".CPU is not valid"))
+		errs = multierr.Append(errs, fmt.Errorf(".CPU is not valid: %w", err))
 	}
 	if _, err := kube_api.ParseQuantity(c.Memory); err != nil {
-		errs = multierr.Append(errs, errors.Wrapf(err, ".Memory is not valid"))
+		errs = multierr.Append(errs, fmt.Errorf(".Memory is not valid: %w", err))
 	}
 	return
 }
@@ -445,7 +445,7 @@ func (c *BuiltinDNS) Sanitize() {
 
 func (c *BuiltinDNS) Validate() (errs error) {
 	if 65535 < c.Port {
-		errs = multierr.Append(errs, errors.Errorf(".port must be in the range [0, 65535]"))
+		errs = multierr.Append(errs, fmt.Errorf(".port must be in the range [0, 65535]"))
 	}
 	return
 }

--- a/pkg/config/plugins/runtime/universal/config.go
+++ b/pkg/config/plugins/runtime/universal/config.go
@@ -1,9 +1,9 @@
 package universal
 
 import (
+	"fmt"
 	"time"
 
-	"github.com/pkg/errors"
 	"go.uber.org/multierr"
 )
 
@@ -24,7 +24,7 @@ func (u *UniversalRuntimeConfig) Sanitize() {
 
 func (u *UniversalRuntimeConfig) Validate() (errs error) {
 	if u.DataplaneCleanupAge <= 0 {
-		errs = multierr.Append(errs, errors.Errorf(".DataplaneCleanupAge must be positive"))
+		errs = multierr.Append(errs, fmt.Errorf(".DataplaneCleanupAge must be positive"))
 	}
 	return
 }

--- a/pkg/config/types/portrange.go
+++ b/pkg/config/types/portrange.go
@@ -1,11 +1,10 @@
 package types
 
 import (
+	"errors"
 	"fmt"
 	"strconv"
 	"strings"
-
-	"github.com/pkg/errors"
 )
 
 const (
@@ -130,11 +129,11 @@ func ParsePortRange(text string) (*PortRange, error) {
 	var err error
 	lowest, err = parsePortOrDefault(left, MinPort)
 	if err != nil {
-		return nil, errors.Wrapf(err, invalidPortRange(text))
+		return nil, fmt.Errorf("%s: %w", invalidPortRange(text), err)
 	}
 	highest, err = parsePortOrDefault(right, MaxPort)
 	if err != nil {
-		return nil, errors.Wrapf(err, invalidPortRange(text))
+		return nil, fmt.Errorf("%s: %w", invalidPortRange(text), err)
 	}
 	// convert into a range
 	r, err := NewPortRange(lowest, highest)

--- a/pkg/config/xds/bootstrap/config.go
+++ b/pkg/config/xds/bootstrap/config.go
@@ -1,11 +1,11 @@
 package bootstrap
 
 import (
+	"errors"
+	"fmt"
 	"net"
 	"os"
 	"time"
-
-	"github.com/pkg/errors"
 
 	"github.com/kumahq/kuma/pkg/config"
 )
@@ -23,7 +23,7 @@ func (b *BootstrapServerConfig) Sanitize() {
 
 func (b *BootstrapServerConfig) Validate() error {
 	if err := b.Params.Validate(); err != nil {
-		return errors.Wrap(err, "Params validation failed")
+		return fmt.Errorf("Params validation failed: %w", err)
 	}
 	return nil
 }

--- a/pkg/config/xds/config.go
+++ b/pkg/config/xds/config.go
@@ -1,9 +1,8 @@
 package xds
 
 import (
+	"errors"
 	"time"
-
-	"github.com/pkg/errors"
 
 	"github.com/kumahq/kuma/pkg/config"
 )

--- a/pkg/core/datasource/dynamic.go
+++ b/pkg/core/datasource/dynamic.go
@@ -2,9 +2,9 @@ package datasource
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"os"
-
-	"github.com/pkg/errors"
 
 	system_proto "github.com/kumahq/kuma/api/system/v1alpha1"
 	"github.com/kumahq/kuma/pkg/core/resources/apis/system"
@@ -40,7 +40,7 @@ func (l *dynamicLoader) Load(ctx context.Context, mesh string, source *system_pr
 		return nil, errors.New("unsupported type of the DataSource")
 	}
 	if err != nil {
-		return nil, errors.Wrap(err, "could not load data")
+		return nil, fmt.Errorf("could not load data: %w", err)
 	}
 	return data, nil
 }

--- a/pkg/core/datasource/static.go
+++ b/pkg/core/datasource/static.go
@@ -2,8 +2,8 @@ package datasource
 
 import (
 	"context"
-
-	"github.com/pkg/errors"
+	"errors"
+	"fmt"
 
 	system_proto "github.com/kumahq/kuma/api/system/v1alpha1"
 	"github.com/kumahq/kuma/pkg/core/resources/apis/system"
@@ -46,7 +46,7 @@ func (s *staticLoader) Load(_ context.Context, mesh string, source *system_proto
 		return nil, errors.New("unsupported type of the DataSource")
 	}
 	if err != nil {
-		return nil, errors.Wrap(err, "could not load data")
+		return nil, fmt.Errorf("could not load data: %w", err)
 	}
 	return data, nil
 }

--- a/pkg/core/faultinjections/matcher.go
+++ b/pkg/core/faultinjections/matcher.go
@@ -2,8 +2,7 @@ package faultinjections
 
 import (
 	"context"
-
-	"github.com/pkg/errors"
+	"fmt"
 
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	manager_dataplane "github.com/kumahq/kuma/pkg/core/managers/apis/dataplane"
@@ -22,11 +21,11 @@ type FaultInjectionMatcher struct {
 func (f *FaultInjectionMatcher) Match(ctx context.Context, dataplane *core_mesh.DataplaneResource, mesh *core_mesh.MeshResource) (core_xds.FaultInjectionMap, error) {
 	faultInjections := &core_mesh.FaultInjectionResourceList{}
 	if err := f.ResourceManager.List(ctx, faultInjections, store.ListByMesh(dataplane.GetMeta().GetMesh())); err != nil {
-		return nil, errors.Wrap(err, "could not retrieve fault injections")
+		return nil, fmt.Errorf("could not retrieve fault injections: %w", err)
 	}
 	additionalInbounds, err := manager_dataplane.AdditionalInbounds(dataplane, mesh)
 	if err != nil {
-		return nil, errors.Wrap(err, "could not fetch additional inbounds")
+		return nil, fmt.Errorf("could not fetch additional inbounds: %w", err)
 	}
 	inbounds := append(dataplane.Spec.GetNetworking().GetInbound(), additionalInbounds...)
 	return BuildFaultInjectionMap(dataplane, inbounds, faultInjections.Items), nil

--- a/pkg/core/logs/matcher.go
+++ b/pkg/core/logs/matcher.go
@@ -2,8 +2,7 @@ package logs
 
 import (
 	"context"
-
-	"github.com/pkg/errors"
+	"fmt"
 
 	"github.com/kumahq/kuma/pkg/core/policy"
 	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
@@ -27,7 +26,7 @@ type TrafficLogsMatcher struct {
 func (m *TrafficLogsMatcher) Match(ctx context.Context, dataplane *core_mesh.DataplaneResource) (core_xds.TrafficLogMap, error) {
 	logs := &core_mesh.TrafficLogResourceList{}
 	if err := m.ResourceManager.List(ctx, logs, store.ListByMesh(dataplane.GetMeta().GetMesh())); err != nil {
-		return nil, errors.Wrap(err, "could not retrieve traffic logs")
+		return nil, fmt.Errorf("could not retrieve traffic logs: %w", err)
 	}
 	return BuildTrafficLogMap(dataplane, logs.Items), nil
 }

--- a/pkg/core/managers/apis/dataplane/additional_networking.go
+++ b/pkg/core/managers/apis/dataplane/additional_networking.go
@@ -1,7 +1,7 @@
 package dataplane
 
 import (
-	"github.com/pkg/errors"
+	"fmt"
 
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
@@ -22,7 +22,7 @@ func AdditionalInbounds(dataplane *core_mesh.DataplaneResource, mesh *core_mesh.
 func PrometheusInbound(dataplane *core_mesh.DataplaneResource, mesh *core_mesh.MeshResource) (*mesh_proto.Dataplane_Networking_Inbound, error) {
 	cfg, err := dataplane.GetPrometheusConfig(mesh)
 	if err != nil {
-		return nil, errors.Wrap(err, "could not parse prometheus config")
+		return nil, fmt.Errorf("could not parse prometheus config: %w", err)
 	} else if cfg != nil { // metrics are on
 		inbound := &mesh_proto.Dataplane_Networking_Inbound{
 			Address:     dataplane.Spec.GetNetworking().GetAddress(),

--- a/pkg/core/managers/apis/dataplane/dataplane_manager.go
+++ b/pkg/core/managers/apis/dataplane/dataplane_manager.go
@@ -2,8 +2,7 @@ package dataplane
 
 import (
 	"context"
-
-	"github.com/pkg/errors"
+	"fmt"
 
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	"github.com/kumahq/kuma/pkg/core"
@@ -82,7 +81,7 @@ func (m *dataplaneManager) Update(ctx context.Context, resource core_model.Resou
 func (m *dataplaneManager) dataplane(resource core_model.Resource) (*core_mesh.DataplaneResource, error) {
 	dp, ok := resource.(*core_mesh.DataplaneResource)
 	if !ok {
-		return nil, errors.Errorf("invalid resource type: expected=%T, got=%T", (*core_mesh.DataplaneResource)(nil), resource)
+		return nil, fmt.Errorf("invalid resource type: expected=%T, got=%T", (*core_mesh.DataplaneResource)(nil), resource)
 	}
 	return dp, nil
 }

--- a/pkg/core/managers/apis/external_service/external_service_manager.go
+++ b/pkg/core/managers/apis/external_service/external_service_manager.go
@@ -2,9 +2,8 @@ package externalservice
 
 import (
 	"context"
+	"fmt"
 	"time"
-
-	"github.com/pkg/errors"
 
 	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	core_manager "github.com/kumahq/kuma/pkg/core/resources/manager"
@@ -108,7 +107,7 @@ func (m *externalServiceManager) Update(ctx context.Context, resource core_model
 func (m *externalServiceManager) externalService(resource core_model.Resource) (*core_mesh.ExternalServiceResource, error) {
 	externalService, ok := resource.(*core_mesh.ExternalServiceResource)
 	if !ok {
-		return nil, errors.Errorf("invalid resource type: expected=%T, got=%T", (*core_mesh.ExternalServiceResource)(nil), resource)
+		return nil, fmt.Errorf("invalid resource type: expected=%T, got=%T", (*core_mesh.ExternalServiceResource)(nil), resource)
 	}
 	return externalService, nil
 }
@@ -116,7 +115,7 @@ func (m *externalServiceManager) externalService(resource core_model.Resource) (
 func (m *externalServiceManager) externalServices(list core_model.ResourceList) (*core_mesh.ExternalServiceResourceList, error) {
 	externalServices, ok := list.(*core_mesh.ExternalServiceResourceList)
 	if !ok {
-		return nil, errors.Errorf("invalid resource type: expected=%T, got=%T", (*core_mesh.ExternalServiceResourceList)(nil), list)
+		return nil, fmt.Errorf("invalid resource type: expected=%T, got=%T", (*core_mesh.ExternalServiceResourceList)(nil), list)
 	}
 	return externalServices, nil
 }

--- a/pkg/core/managers/apis/mesh/mesh_helpers.go
+++ b/pkg/core/managers/apis/mesh/mesh_helpers.go
@@ -2,8 +2,7 @@ package mesh
 
 import (
 	"context"
-
-	"github.com/pkg/errors"
+	"fmt"
 
 	"github.com/kumahq/kuma/api/mesh/v1alpha1"
 	core_ca "github.com/kumahq/kuma/pkg/core/ca"
@@ -18,10 +17,10 @@ func EnsureCAs(ctx context.Context, caManagers core_ca.Managers, mesh *core_mesh
 	for typ, backends := range backendsForType {
 		caManager, exist := caManagers[typ]
 		if !exist { // this should be caught by validator earlier
-			return errors.Errorf("CA manager for type %s does not exist", typ)
+			return fmt.Errorf("CA manager for type %s does not exist", typ)
 		}
 		if err := caManager.EnsureBackends(ctx, meshName, backends); err != nil {
-			return errors.Wrapf(err, "could not ensure CA backends of type %s", typ)
+			return fmt.Errorf("could not ensure CA backends of type %s: %w", typ, err)
 		}
 	}
 	return nil

--- a/pkg/core/managers/apis/mesh/mesh_manager.go
+++ b/pkg/core/managers/apis/mesh/mesh_manager.go
@@ -2,9 +2,8 @@ package mesh
 
 import (
 	"context"
+	"fmt"
 	"time"
-
-	"github.com/pkg/errors"
 
 	core_ca "github.com/kumahq/kuma/pkg/core/ca"
 	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
@@ -112,7 +111,7 @@ func (m *meshManager) Delete(ctx context.Context, resource core_model.Resource, 
 	}
 	// delete all secrets
 	if err := m.otherManagers.DeleteAll(ctx, &system.SecretResourceList{}, core_store.DeleteAllByMesh(opts.Name)); err != nil {
-		return errors.Wrap(err, "could not delete associated secrets")
+		return fmt.Errorf("could not delete associated secrets: %w", err)
 	}
 	return notFoundErr
 }
@@ -152,7 +151,7 @@ func (m *meshManager) Update(ctx context.Context, resource core_model.Resource, 
 func (m *meshManager) mesh(resource core_model.Resource) (*core_mesh.MeshResource, error) {
 	mesh, ok := resource.(*core_mesh.MeshResource)
 	if !ok {
-		return nil, errors.Errorf("invalid resource type: expected=%T, got=%T", (*core_mesh.MeshResource)(nil), resource)
+		return nil, fmt.Errorf("invalid resource type: expected=%T, got=%T", (*core_mesh.MeshResource)(nil), resource)
 	}
 	return mesh, nil
 }
@@ -160,7 +159,7 @@ func (m *meshManager) mesh(resource core_model.Resource) (*core_mesh.MeshResourc
 func (m *meshManager) meshes(list core_model.ResourceList) (*core_mesh.MeshResourceList, error) {
 	meshes, ok := list.(*core_mesh.MeshResourceList)
 	if !ok {
-		return nil, errors.Errorf("invalid resource type: expected=%T, got=%T", (*core_mesh.MeshResourceList)(nil), list)
+		return nil, fmt.Errorf("invalid resource type: expected=%T, got=%T", (*core_mesh.MeshResourceList)(nil), list)
 	}
 	return meshes, nil
 }

--- a/pkg/core/managers/apis/ratelimit/ratelimit_manager.go
+++ b/pkg/core/managers/apis/ratelimit/ratelimit_manager.go
@@ -2,9 +2,8 @@ package ratelimit
 
 import (
 	"context"
+	"fmt"
 	"time"
-
-	"github.com/pkg/errors"
 
 	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	core_manager "github.com/kumahq/kuma/pkg/core/resources/manager"
@@ -108,7 +107,7 @@ func (m *rateLimitManager) Update(ctx context.Context, resource core_model.Resou
 func (m *rateLimitManager) rateLimit(resource core_model.Resource) (*core_mesh.RateLimitResource, error) {
 	rateLimit, ok := resource.(*core_mesh.RateLimitResource)
 	if !ok {
-		return nil, errors.Errorf("invalid resource type: expected=%T, got=%T", (*core_mesh.RateLimitResource)(nil), resource)
+		return nil, fmt.Errorf("invalid resource type: expected=%T, got=%T", (*core_mesh.RateLimitResource)(nil), resource)
 	}
 	return rateLimit, nil
 }
@@ -116,7 +115,7 @@ func (m *rateLimitManager) rateLimit(resource core_model.Resource) (*core_mesh.R
 func (m *rateLimitManager) rateLimits(list core_model.ResourceList) (*core_mesh.RateLimitResourceList, error) {
 	rateLimits, ok := list.(*core_mesh.RateLimitResourceList)
 	if !ok {
-		return nil, errors.Errorf("invalid resource type: expected=%T, got=%T", (*core_mesh.RateLimitResourceList)(nil), list)
+		return nil, fmt.Errorf("invalid resource type: expected=%T, got=%T", (*core_mesh.RateLimitResourceList)(nil), list)
 	}
 	return rateLimits, nil
 }

--- a/pkg/core/managers/apis/zone/zone_validator.go
+++ b/pkg/core/managers/apis/zone/zone_validator.go
@@ -2,8 +2,7 @@ package zone
 
 import (
 	"context"
-
-	"github.com/pkg/errors"
+	"fmt"
 
 	"github.com/kumahq/kuma/pkg/core/resources/apis/system"
 	"github.com/kumahq/kuma/pkg/core/resources/model"
@@ -24,7 +23,7 @@ func (v *Validator) ValidateDelete(ctx context.Context, name string) error {
 			// there is no information about Online/Offline status
 			return nil
 		}
-		return errors.Wrap(err, "unable to get ZoneInsight")
+		return fmt.Errorf("unable to get ZoneInsight: %w", err)
 	}
 	if zi.Spec.IsOnline() {
 		validationErr.AddViolation("zone", "unable to delete Zone, Zone CP is still connected, please shut it down first")

--- a/pkg/core/permissions/matcher.go
+++ b/pkg/core/permissions/matcher.go
@@ -2,8 +2,7 @@ package permissions
 
 import (
 	"context"
-
-	"github.com/pkg/errors"
+	"fmt"
 
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	manager_dataplane "github.com/kumahq/kuma/pkg/core/managers/apis/dataplane"
@@ -21,12 +20,12 @@ type TrafficPermissionsMatcher struct {
 func (m *TrafficPermissionsMatcher) Match(ctx context.Context, dataplane *core_mesh.DataplaneResource, mesh *core_mesh.MeshResource) (core_xds.TrafficPermissionMap, error) {
 	permissions := &core_mesh.TrafficPermissionResourceList{}
 	if err := m.ResourceManager.List(ctx, permissions, store.ListByMesh(dataplane.GetMeta().GetMesh())); err != nil {
-		return nil, errors.Wrap(err, "could not retrieve traffic permissions")
+		return nil, fmt.Errorf("could not retrieve traffic permissions: %w", err)
 	}
 
 	additionalInbounds, err := manager_dataplane.AdditionalInbounds(dataplane, mesh)
 	if err != nil {
-		return nil, errors.Wrap(err, "could not fetch additional inbounds")
+		return nil, fmt.Errorf("could not fetch additional inbounds: %w", err)
 	}
 	inbounds := append(dataplane.Spec.GetNetworking().GetInbound(), additionalInbounds...)
 	return BuildTrafficPermissionMap(dataplane, inbounds, permissions.Items), nil

--- a/pkg/core/plugins/interfaces.go
+++ b/pkg/core/plugins/interfaces.go
@@ -1,7 +1,7 @@
 package plugins
 
 import (
-	"github.com/pkg/errors"
+	"errors"
 
 	"github.com/kumahq/kuma/pkg/api-server/authn"
 	core_ca "github.com/kumahq/kuma/pkg/core/ca"
@@ -41,6 +41,7 @@ type BootstrapPlugin interface {
 
 // ResourceStorePlugin is responsible for instantiating a particular ResourceStore.
 type DbVersion = uint
+
 type ResourceStorePlugin interface {
 	Plugin
 	NewResourceStore(PluginContext, PluginConfig) (core_store.ResourceStore, error)

--- a/pkg/core/plugins/registry.go
+++ b/pkg/core/plugins/registry.go
@@ -1,9 +1,8 @@
 package plugins
 
 import (
+	"fmt"
 	"sort"
-
-	"github.com/pkg/errors"
 )
 
 type pluginType string
@@ -176,10 +175,10 @@ func (r *registry) Register(name PluginName, plugin Plugin) error {
 }
 
 func noSuchPluginError(typ pluginType, name PluginName) error {
-	return errors.Errorf("there is no plugin registered with type=%q and name=%s", typ, name)
+	return fmt.Errorf("there is no plugin registered with type=%q and name=%s", typ, name)
 }
 
 func pluginAlreadyRegisteredError(typ pluginType, name PluginName, old, new Plugin) error {
-	return errors.Errorf("plugin with type=%q and name=%s has already been registered: old=%#v new=%#v",
+	return fmt.Errorf("plugin with type=%q and name=%s has already been registered: old=%#v new=%#v",
 		typ, name, old, new)
 }

--- a/pkg/core/ratelimits/matcher.go
+++ b/pkg/core/ratelimits/matcher.go
@@ -2,8 +2,8 @@ package ratelimits
 
 import (
 	"context"
+	"fmt"
 
-	"github.com/pkg/errors"
 	"google.golang.org/protobuf/proto"
 
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
@@ -23,12 +23,12 @@ type RateLimitMatcher struct {
 func (m *RateLimitMatcher) Match(ctx context.Context, dataplane *core_mesh.DataplaneResource, mesh *core_mesh.MeshResource) (core_xds.RateLimitsMap, error) {
 	ratelimits := &core_mesh.RateLimitResourceList{}
 	if err := m.ResourceManager.List(ctx, ratelimits, store.ListByMesh(dataplane.GetMeta().GetMesh())); err != nil {
-		return core_xds.RateLimitsMap{}, errors.Wrap(err, "could not retrieve ratelimits")
+		return core_xds.RateLimitsMap{}, fmt.Errorf("could not retrieve ratelimits: %w", err)
 	}
 
 	additionalInbounds, err := manager_dataplane.AdditionalInbounds(dataplane, mesh)
 	if err != nil {
-		return core_xds.RateLimitsMap{}, errors.Wrap(err, "could not fetch additional inbounds")
+		return core_xds.RateLimitsMap{}, fmt.Errorf("could not fetch additional inbounds: %w", err)
 	}
 	inbounds := append(dataplane.Spec.GetNetworking().GetInbound(), additionalInbounds...)
 	return BuildRateLimitMap(dataplane, inbounds, splitPoliciesBySourceMatch(ratelimits.Items)), nil

--- a/pkg/core/resources/apis/mesh/mesh_defaulter.go
+++ b/pkg/core/resources/apis/mesh/mesh_defaulter.go
@@ -1,7 +1,7 @@
 package mesh
 
 import (
-	"github.com/pkg/errors"
+	"fmt"
 
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	"github.com/kumahq/kuma/pkg/util/proto"
@@ -13,7 +13,7 @@ func (mesh *MeshResource) Default() error {
 		if backend.GetType() == mesh_proto.MetricsPrometheusType {
 			cfg := mesh_proto.PrometheusMetricsBackendConfig{}
 			if err := proto.ToTyped(backend.GetConf(), &cfg); err != nil {
-				return errors.Wrap(err, "could not convert the backend")
+				return fmt.Errorf("could not convert the backend: %w", err)
 			}
 
 			if cfg.Port == 0 {
@@ -30,7 +30,7 @@ func (mesh *MeshResource) Default() error {
 
 			str, err := proto.ToStruct(&cfg)
 			if err != nil {
-				return errors.Wrap(err, "could not convert the backend")
+				return fmt.Errorf("could not convert the backend: %w", err)
 			}
 			mesh.Spec.Metrics.Backends[idx].Conf = str
 		}

--- a/pkg/core/resources/apis/system/location_validator.go
+++ b/pkg/core/resources/apis/system/location_validator.go
@@ -1,9 +1,8 @@
 package system
 
 import (
+	"fmt"
 	"strings"
-
-	"github.com/pkg/errors"
 
 	"github.com/kumahq/kuma/pkg/config/core"
 	"github.com/kumahq/kuma/pkg/core/resources/model"
@@ -23,7 +22,7 @@ func ValidateLocation(resourceType model.ResourceType, mode core.CpMode) error {
 }
 
 func InvalidLocationErr(resourceType model.ResourceType, supportedLocations ...core.CpMode) error {
-	return errors.Errorf("%s resource can only be applied on CP with mode: %v", resourceType, supportedLocations)
+	return fmt.Errorf("%s resource can only be applied on CP with mode: %v", resourceType, supportedLocations)
 }
 
 func IsInvalidLocationErr(err error) bool {

--- a/pkg/core/resources/manager/manager.go
+++ b/pkg/core/resources/manager/manager.go
@@ -2,6 +2,7 @@ package manager
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -173,6 +174,6 @@ func MeshNotFound(meshName string) error {
 }
 
 func IsMeshNotFound(err error) bool {
-	_, ok := err.(*MeshNotFoundError)
-	return ok
+	var meshNotFoundError *MeshNotFoundError
+	return errors.As(err, &meshNotFoundError)
 }

--- a/pkg/core/resources/model/resource.go
+++ b/pkg/core/resources/model/resource.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"github.com/golang/protobuf/proto"
-	"github.com/pkg/errors"
 )
 
 const (
@@ -16,11 +15,9 @@ const (
 	NoMesh = ""
 )
 
-var (
-	// ResourceNameExtensionsUnsupported is a convenience constant
-	// that is meant to make source code more readable.
-	ResourceNameExtensionsUnsupported = ResourceNameExtensions(nil)
-)
+// ResourceNameExtensionsUnsupported is a convenience constant
+// that is meant to make source code more readable.
+var ResourceNameExtensionsUnsupported = ResourceNameExtensions(nil)
 
 func WithMesh(mesh string, name string) ResourceKey {
 	return ResourceKey{Mesh: mesh, Name: name}
@@ -97,7 +94,7 @@ func (d ResourceTypeDescriptor) NewObject() Resource {
 	resType := reflect.TypeOf(d.Resource).Elem()
 	resource := reflect.New(resType).Interface().(Resource)
 	if err := resource.SetSpec(newSpec); err != nil {
-		panic(errors.Wrap(err, "could not set spec on the new resource"))
+		panic(fmt.Errorf("could not set spec on the new resource: %w", err))
 	}
 	return resource
 }

--- a/pkg/core/resources/model/rest/api.go
+++ b/pkg/core/resources/model/rest/api.go
@@ -3,8 +3,6 @@ package rest
 import (
 	"fmt"
 
-	"github.com/pkg/errors"
-
 	"github.com/kumahq/kuma/pkg/core/resources/model"
 )
 
@@ -61,7 +59,7 @@ type ApiDescriptor struct {
 func (m *ApiDescriptor) GetResourceApi(typ model.ResourceType) (ResourceApi, error) {
 	mapping, ok := m.Resources[typ]
 	if !ok {
-		return nil, errors.Errorf("unknown resource type: %q", typ)
+		return nil, fmt.Errorf("unknown resource type: %q", typ)
 	}
 	return mapping, nil
 }

--- a/pkg/core/resources/model/rest/resource.go
+++ b/pkg/core/resources/model/rest/resource.go
@@ -3,10 +3,10 @@ package rest
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"time"
 
 	"github.com/golang/protobuf/jsonpb"
-	"github.com/pkg/errors"
 
 	"github.com/kumahq/kuma/pkg/core/resources/model"
 	"github.com/kumahq/kuma/pkg/core/resources/registry"
@@ -76,8 +76,10 @@ type ResourceList struct {
 	Next  *string     `json:"next"`
 }
 
-var _ json.Marshaler = &Resource{}
-var _ json.Unmarshaler = &Resource{}
+var (
+	_ json.Marshaler   = &Resource{}
+	_ json.Unmarshaler = &Resource{}
+)
 
 func (r *Resource) MarshalJSON() ([]byte, error) {
 	var specBytes []byte
@@ -128,7 +130,7 @@ var _ json.Unmarshaler = &ResourceListReceiver{}
 
 func (rec *ResourceListReceiver) UnmarshalJSON(data []byte) error {
 	if rec.NewResource == nil {
-		return errors.Errorf("NewResource must not be nil")
+		return fmt.Errorf("NewResource must not be nil")
 	}
 	type List struct {
 		Total uint32             `json:"total"`

--- a/pkg/core/resources/model/rest/unmarshaller.go
+++ b/pkg/core/resources/model/rest/unmarshaller.go
@@ -1,8 +1,9 @@
 package rest
 
 import (
+	"fmt"
+
 	"github.com/ghodss/yaml"
-	"github.com/pkg/errors"
 
 	"github.com/kumahq/kuma/pkg/core/resources/model"
 	"github.com/kumahq/kuma/pkg/core/resources/registry"
@@ -20,7 +21,7 @@ func UnmarshallToCore(bytes []byte) (model.Resource, error) {
 func Unmarshall(bytes []byte) (*Resource, error) {
 	meta := ResourceMeta{}
 	if err := yaml.Unmarshal(bytes, &meta); err != nil {
-		return nil, errors.Wrap(err, "invalid meta type")
+		return nil, fmt.Errorf("invalid meta type: %w", err)
 	}
 	resource, err := registry.Global().NewObject(model.ResourceType(meta.Type))
 	if err != nil {
@@ -31,7 +32,7 @@ func Unmarshall(bytes []byte) (*Resource, error) {
 		Spec: resource.GetSpec(),
 	}
 	if err := proto.FromYAML(bytes, res.Spec); err != nil {
-		return nil, errors.Wrapf(err, "invalid %s object %q", meta.Type, meta.Name)
+		return nil, fmt.Errorf("invalid %s object %q: %w", meta.Type, meta.Name, err)
 	}
 	return res, nil
 }

--- a/pkg/core/resources/registry/registry.go
+++ b/pkg/core/resources/registry/registry.go
@@ -1,9 +1,9 @@
 package registry
 
 import (
+	"errors"
+	"fmt"
 	"reflect"
-
-	"github.com/pkg/errors"
 
 	"github.com/kumahq/kuma/pkg/core/resources/model"
 )
@@ -32,7 +32,7 @@ type typeRegistry struct {
 func (t *typeRegistry) DescriptorFor(resType model.ResourceType) (model.ResourceTypeDescriptor, error) {
 	typDesc, ok := t.descriptors[resType]
 	if !ok {
-		return model.ResourceTypeDescriptor{}, errors.Errorf("invalid resource type %q", resType)
+		return model.ResourceTypeDescriptor{}, fmt.Errorf("invalid resource type %q", resType)
 	}
 	return typDesc, nil
 }
@@ -70,7 +70,7 @@ func (t *typeRegistry) RegisterType(res model.ResourceTypeDescriptor) error {
 		return errors.New("spec in the object cannot be nil")
 	}
 	if previous, ok := t.descriptors[res.Name]; ok {
-		return errors.Errorf("duplicate registration of ResourceType under name %q: previous=%#v new=%#v", res.Name, previous, reflect.TypeOf(res.Resource).Elem().String())
+		return fmt.Errorf("duplicate registration of ResourceType under name %q: previous=%#v new=%#v", res.Name, previous, reflect.TypeOf(res.Resource).Elem().String())
 	}
 	t.descriptors[res.Name] = res
 	return nil
@@ -79,7 +79,7 @@ func (t *typeRegistry) RegisterType(res model.ResourceTypeDescriptor) error {
 func (t *typeRegistry) NewObject(resType model.ResourceType) (model.Resource, error) {
 	typDesc, ok := t.descriptors[resType]
 	if !ok {
-		return nil, errors.Errorf("invalid resource type %q", resType)
+		return nil, fmt.Errorf("invalid resource type %q", resType)
 	}
 	return typDesc.NewObject(), nil
 }
@@ -87,7 +87,7 @@ func (t *typeRegistry) NewObject(resType model.ResourceType) (model.Resource, er
 func (t *typeRegistry) NewList(resType model.ResourceType) (model.ResourceList, error) {
 	typDesc, ok := t.descriptors[resType]
 	if !ok {
-		return nil, errors.Errorf("invalid resource type %q", resType)
+		return nil, fmt.Errorf("invalid resource type %q", resType)
 	}
 	return typDesc.NewList(), nil
 }

--- a/pkg/core/resources/store/store.go
+++ b/pkg/core/resources/store/store.go
@@ -2,11 +2,10 @@ package store
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"strings"
-
-	"github.com/pkg/errors"
 
 	"github.com/kumahq/kuma/pkg/core/resources/model"
 )

--- a/pkg/core/rest/errors/errors.go
+++ b/pkg/core/rest/errors/errors.go
@@ -1,8 +1,7 @@
 package errors
 
-type Unauthenticated struct {
-}
+import (
+	"errors"
+)
 
-func (u *Unauthenticated) Error() string {
-	return "Unauthenticated"
-}
+var Unauthenticated = errors.New("Unauthenticated")

--- a/pkg/core/runtime/builder.go
+++ b/pkg/core/runtime/builder.go
@@ -6,8 +6,6 @@ import (
 	"os"
 	"time"
 
-	"github.com/pkg/errors"
-
 	"github.com/kumahq/kuma/pkg/api-server/authn"
 	api_server "github.com/kumahq/kuma/pkg/api-server/customization"
 	kuma_cp "github.com/kumahq/kuma/pkg/config/app/kuma-cp"
@@ -89,7 +87,7 @@ type Builder struct {
 func BuilderFor(appCtx context.Context, cfg kuma_cp.Config) (*Builder, error) {
 	hostname, err := os.Hostname()
 	if err != nil {
-		return nil, errors.Wrap(err, "could not get hostname")
+		return nil, fmt.Errorf("could not get hostname: %w", err)
 	}
 	suffix := core.NewUUID()[0:4]
 	return &Builder{
@@ -236,61 +234,61 @@ func (b *Builder) WithExtraReportsFn(fn ExtraReportsFn) *Builder {
 
 func (b *Builder) Build() (Runtime, error) {
 	if b.cm == nil {
-		return nil, errors.Errorf("ComponentManager has not been configured")
+		return nil, fmt.Errorf("ComponentManager has not been configured")
 	}
 	if b.rs == nil {
-		return nil, errors.Errorf("ResourceStore has not been configured")
+		return nil, fmt.Errorf("ResourceStore has not been configured")
 	}
 	if b.rm == nil {
-		return nil, errors.Errorf("ResourceManager has not been configured")
+		return nil, fmt.Errorf("ResourceManager has not been configured")
 	}
 	if b.rom == nil {
-		return nil, errors.Errorf("ReadOnlyResourceManager has not been configured")
+		return nil, fmt.Errorf("ReadOnlyResourceManager has not been configured")
 	}
 	if b.dsl == nil {
-		return nil, errors.Errorf("DataSourceLoader has not been configured")
+		return nil, fmt.Errorf("DataSourceLoader has not been configured")
 	}
 	if b.ext == nil {
-		return nil, errors.Errorf("Extensions have been misconfigured")
+		return nil, fmt.Errorf("Extensions have been misconfigured")
 	}
 	if b.leadInfo == nil {
-		return nil, errors.Errorf("LeaderInfo has not been configured")
+		return nil, fmt.Errorf("LeaderInfo has not been configured")
 	}
 	if b.lif == nil {
-		return nil, errors.Errorf("LookupIP func has not been configured")
+		return nil, fmt.Errorf("LookupIP func has not been configured")
 	}
 	if b.eac == nil {
-		return nil, errors.Errorf("EnvoyAdminClient has not been configured")
+		return nil, fmt.Errorf("EnvoyAdminClient has not been configured")
 	}
 	if b.metrics == nil {
-		return nil, errors.Errorf("Metrics has not been configured")
+		return nil, fmt.Errorf("Metrics has not been configured")
 	}
 	if b.erf == nil {
-		return nil, errors.Errorf("EventReaderFactory has not been configured")
+		return nil, fmt.Errorf("EventReaderFactory has not been configured")
 	}
 	if b.apim == nil {
-		return nil, errors.Errorf("APIManager has not been configured")
+		return nil, fmt.Errorf("APIManager has not been configured")
 	}
 	if b.xdsh == nil {
-		return nil, errors.Errorf("XDSHooks has not been configured")
+		return nil, fmt.Errorf("XDSHooks has not been configured")
 	}
 	if b.cap == nil {
-		return nil, errors.Errorf("CAProvider has not been configured")
+		return nil, fmt.Errorf("CAProvider has not been configured")
 	}
 	if b.dps == nil {
-		return nil, errors.Errorf("DpServer has not been configured")
+		return nil, fmt.Errorf("DpServer has not been configured")
 	}
 	if b.kdsctx == nil {
-		return nil, errors.Errorf("KDSContext has not been configured")
+		return nil, fmt.Errorf("KDSContext has not been configured")
 	}
 	if b.rv == (ResourceValidators{}) {
-		return nil, errors.Errorf("ResourceValidators have not been configured")
+		return nil, fmt.Errorf("ResourceValidators have not been configured")
 	}
 	if b.au == nil {
-		return nil, errors.Errorf("API Server Authenticator has not been configured")
+		return nil, fmt.Errorf("API Server Authenticator has not been configured")
 	}
 	if b.acc == (Access{}) {
-		return nil, errors.Errorf("Access has not been configured")
+		return nil, fmt.Errorf("Access has not been configured")
 	}
 	return &runtime{
 		RuntimeInfo: b.runtimeInfo,
@@ -327,75 +325,99 @@ func (b *Builder) Build() (Runtime, error) {
 func (b *Builder) ComponentManager() component.Manager {
 	return b.cm
 }
+
 func (b *Builder) ResourceStore() core_store.ResourceStore {
 	return b.rs
 }
+
 func (b *Builder) SecretStore() store.SecretStore {
 	return b.ss
 }
+
 func (b *Builder) ConfigStore() core_store.ResourceStore {
 	return b.cs
 }
+
 func (b *Builder) ResourceManager() core_manager.CustomizableResourceManager {
 	return b.rm
 }
+
 func (b *Builder) ReadOnlyResourceManager() core_manager.ReadOnlyResourceManager {
 	return b.rom
 }
+
 func (b *Builder) CaManagers() core_ca.Managers {
 	return b.cam
 }
+
 func (b *Builder) Config() kuma_cp.Config {
 	return b.cfg
 }
+
 func (b *Builder) DataSourceLoader() datasource.Loader {
 	return b.dsl
 }
+
 func (b *Builder) Extensions() context.Context {
 	return b.ext
 }
+
 func (b *Builder) ConfigManager() config_manager.ConfigManager {
 	return b.configm
 }
+
 func (b *Builder) LeaderInfo() component.LeaderInfo {
 	return b.leadInfo
 }
+
 func (b *Builder) LookupIP() lookup.LookupIPFunc {
 	return b.lif
 }
+
 func (b *Builder) Metrics() metrics.Metrics {
 	return b.metrics
 }
+
 func (b *Builder) EventReaderFactory() events.ListenerFactory {
 	return b.erf
 }
+
 func (b *Builder) APIManager() api_server.APIManager {
 	return b.apim
 }
+
 func (b *Builder) XDSHooks() *xds_hooks.Hooks {
 	return b.xdsh
 }
+
 func (b *Builder) CAProvider() secrets.CaProvider {
 	return b.cap
 }
+
 func (b *Builder) DpServer() *dp_server.DpServer {
 	return b.dps
 }
+
 func (b *Builder) KDSContext() *kds_context.Context {
 	return b.kdsctx
 }
+
 func (b *Builder) ResourceValidators() ResourceValidators {
 	return b.rv
 }
+
 func (b *Builder) APIServerAuthenticator() authn.Authenticator {
 	return b.au
 }
+
 func (b *Builder) Access() Access {
 	return b.acc
 }
+
 func (b *Builder) AppCtx() context.Context {
 	return b.appCtx
 }
+
 func (b *Builder) ExtraReportsFn() ExtraReportsFn {
 	return b.extraReportsFn
 }

--- a/pkg/core/runtime/component/resilient.go
+++ b/pkg/core/runtime/component/resilient.go
@@ -1,10 +1,10 @@
 package component
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/go-logr/logr"
-	"github.com/pkg/errors"
 )
 
 const (
@@ -35,7 +35,7 @@ func (r *resilientComponent) Start(stop <-chan struct{}) error {
 					if err, ok := e.(error); ok {
 						errCh <- err
 					} else {
-						errCh <- errors.Errorf("%v", e)
+						errCh <- fmt.Errorf("%v", e)
 					}
 				}
 			}()

--- a/pkg/core/runtime/reports/reports.go
+++ b/pkg/core/runtime/reports/reports.go
@@ -11,8 +11,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/pkg/errors"
-
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	kuma_cp "github.com/kumahq/kuma/pkg/config/app/kuma-cp"
 	config_core "github.com/kumahq/kuma/pkg/config/core"
@@ -30,9 +28,7 @@ const (
 	pingPort     = 61832
 )
 
-var (
-	log = core.Log.WithName("core").WithName("reports")
-)
+var log = core.Log.WithName("core").WithName("reports")
 
 /*
   - buffer initialized upon Init call
@@ -48,7 +44,7 @@ type reportsBuffer struct {
 func fetchDataplanes(rt core_runtime.Runtime) (*mesh.DataplaneResourceList, error) {
 	dataplanes := mesh.DataplaneResourceList{}
 	if err := rt.ReadOnlyResourceManager().List(context.Background(), &dataplanes); err != nil {
-		return nil, errors.Wrap(err, "could not fetch dataplanes")
+		return nil, fmt.Errorf("could not fetch dataplanes: %w", err)
 	}
 
 	return &dataplanes, nil
@@ -57,7 +53,7 @@ func fetchDataplanes(rt core_runtime.Runtime) (*mesh.DataplaneResourceList, erro
 func fetchMeshes(rt core_runtime.Runtime) (*mesh.MeshResourceList, error) {
 	meshes := mesh.MeshResourceList{}
 	if err := rt.ReadOnlyResourceManager().List(context.Background(), &meshes); err != nil {
-		return nil, errors.Wrap(err, "could not fetch meshes")
+		return nil, fmt.Errorf("could not fetch meshes: %w", err)
 	}
 
 	return &meshes, nil
@@ -66,7 +62,7 @@ func fetchMeshes(rt core_runtime.Runtime) (*mesh.MeshResourceList, error) {
 func fetchZones(rt core_runtime.Runtime) (*system.ZoneResourceList, error) {
 	zones := system.ZoneResourceList{}
 	if err := rt.ReadOnlyResourceManager().List(context.Background(), &zones); err != nil {
-		return nil, errors.Wrap(err, "could not fetch zones")
+		return nil, fmt.Errorf("could not fetch zones: %w", err)
 	}
 	return &zones, nil
 }
@@ -78,7 +74,7 @@ func fetchNumPolicies(rt core_runtime.Runtime) (map[string]string, error) {
 		typedList := descr.NewList()
 		k := "n_" + strings.ToLower(string(descr.Name))
 		if err := rt.ReadOnlyResourceManager().List(context.Background(), typedList); err != nil {
-			return nil, errors.Wrap(err, fmt.Sprintf("could not fetch %s", k))
+			return nil, fmt.Errorf("could not fetch %s: %w", k, err)
 		}
 		policyCounts[k] = strconv.Itoa(len(typedList.GetItems()))
 	}
@@ -88,7 +84,7 @@ func fetchNumPolicies(rt core_runtime.Runtime) (map[string]string, error) {
 func fetchNumOfServices(rt core_runtime.Runtime) (int, int, error) {
 	insights := mesh.ServiceInsightResourceList{}
 	if err := rt.ReadOnlyResourceManager().List(context.Background(), &insights); err != nil {
-		return 0, 0, errors.Wrap(err, "could not fetch service insights")
+		return 0, 0, fmt.Errorf("could not fetch service insights: %w", err)
 	}
 	internalServices := 0
 	for _, insight := range insights.Items {
@@ -97,7 +93,7 @@ func fetchNumOfServices(rt core_runtime.Runtime) (int, int, error) {
 
 	externalServicesList := mesh.ExternalServiceResourceList{}
 	if err := rt.ReadOnlyResourceManager().List(context.Background(), &externalServicesList); err != nil {
-		return 0, 0, errors.Wrap(err, "could not fetch external services")
+		return 0, 0, fmt.Errorf("could not fetch external services: %w", err)
 	}
 	return internalServices, len(externalServicesList.Items), nil
 }

--- a/pkg/core/secrets/manager/manager.go
+++ b/pkg/core/secrets/manager/manager.go
@@ -2,9 +2,8 @@ package manager
 
 import (
 	"context"
+	"errors"
 	"time"
-
-	"github.com/pkg/errors"
 
 	secret_model "github.com/kumahq/kuma/pkg/core/resources/apis/system"
 	"github.com/kumahq/kuma/pkg/core/resources/manager"

--- a/pkg/core/secrets/manager/validator.go
+++ b/pkg/core/secrets/manager/validator.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/pkg/errors"
-
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	"github.com/kumahq/kuma/pkg/core"
 	"github.com/kumahq/kuma/pkg/core/ca"
@@ -65,11 +63,11 @@ func (s *secretValidator) ValidateDelete(ctx context.Context, name string, mesh 
 func (s *secretValidator) secretUsedByMTLSBackend(name string, mesh string, backend *mesh_proto.CertificateAuthorityBackend) (bool, error) {
 	caManager := s.caManagers[backend.Type]
 	if caManager == nil { // this should be caught earlier by validator
-		return false, errors.Errorf("manager of type %q does not exist", backend.Type)
+		return false, fmt.Errorf("manager of type %q does not exist", backend.Type)
 	}
 	secrets, err := caManager.UsedSecrets(mesh, backend)
 	if err != nil {
-		return false, errors.Wrapf(err, "could not retrieve secrets in use by backend %q", backend.Name)
+		return false, fmt.Errorf("could not retrieve secrets in use by backend %q: %w", backend.Name, err)
 	}
 	for _, secret := range secrets {
 		if secret == name {

--- a/pkg/core/tokens/issuer.go
+++ b/pkg/core/tokens/issuer.go
@@ -2,11 +2,11 @@ package tokens
 
 import (
 	"context"
+	"fmt"
 	"strconv"
 	"time"
 
 	"github.com/golang-jwt/jwt/v4"
-	"github.com/pkg/errors"
 
 	"github.com/kumahq/kuma/pkg/core"
 )
@@ -50,7 +50,7 @@ func (j *jwtTokenIssuer) Generate(ctx context.Context, claims Claims, validFor t
 	token.Header[KeyIDHeader] = strconv.Itoa(serialNumber)
 	tokenString, err := token.SignedString(signingKey)
 	if err != nil {
-		return "", errors.Wrap(err, "could not sign a token")
+		return "", fmt.Errorf("could not sign a token: %w", err)
 	}
 	return tokenString, nil
 }

--- a/pkg/core/tokens/meshed_signing_key_accessor.go
+++ b/pkg/core/tokens/meshed_signing_key_accessor.go
@@ -3,8 +3,7 @@ package tokens
 import (
 	"context"
 	"crypto/rsa"
-
-	"github.com/pkg/errors"
+	"fmt"
 
 	"github.com/kumahq/kuma/pkg/core/resources/apis/system"
 	"github.com/kumahq/kuma/pkg/core/resources/manager"
@@ -52,7 +51,7 @@ func (s *meshedSigningKeyAccessor) getKeyBytes(ctx context.Context, serialNumber
 				Mesh:         s.mesh,
 			}
 		}
-		return nil, errors.Wrap(err, "could not retrieve signing key")
+		return nil, fmt.Errorf("could not retrieve signing key: %w", err)
 	}
 	return resource.Spec.GetData().GetValue(), nil
 }

--- a/pkg/core/tokens/meshed_signing_key_manager.go
+++ b/pkg/core/tokens/meshed_signing_key_manager.go
@@ -3,9 +3,9 @@ package tokens
 import (
 	"context"
 	"crypto/rsa"
+	"fmt"
 
 	"github.com/golang/protobuf/ptypes/wrappers"
-	"github.com/pkg/errors"
 
 	system_proto "github.com/kumahq/kuma/api/system/v1alpha1"
 	"github.com/kumahq/kuma/pkg/core/resources/apis/system"
@@ -35,7 +35,7 @@ var _ SigningKeyManager = &meshedSigningKeyManager{}
 func (s *meshedSigningKeyManager) GetLatestSigningKey(ctx context.Context) (*rsa.PrivateKey, int, error) {
 	resources := system.SecretResourceList{}
 	if err := s.manager.List(ctx, &resources, store.ListByMesh(s.mesh)); err != nil {
-		return nil, 0, errors.Wrap(err, "could not retrieve signing key from secret manager")
+		return nil, 0, fmt.Errorf("could not retrieve signing key from secret manager: %w", err)
 	}
 	return latestSigningKey(&resources, s.signingKeyPrefix, s.mesh)
 }

--- a/pkg/core/tokens/public_key_secret_signing_key_accessor.go
+++ b/pkg/core/tokens/public_key_secret_signing_key_accessor.go
@@ -3,8 +3,7 @@ package tokens
 import (
 	"context"
 	"crypto/rsa"
-
-	"github.com/pkg/errors"
+	"errors"
 
 	"github.com/kumahq/kuma/pkg/core/resources/manager"
 )

--- a/pkg/core/tokens/signing_key.go
+++ b/pkg/core/tokens/signing_key.go
@@ -4,11 +4,10 @@ import (
 	"context"
 	"crypto/rsa"
 	"crypto/x509"
+	"errors"
 	"fmt"
 	"strconv"
 	"strings"
-
-	"github.com/pkg/errors"
 
 	"github.com/kumahq/kuma/pkg/core/resources/apis/system"
 	"github.com/kumahq/kuma/pkg/core/resources/manager"
@@ -20,7 +19,7 @@ import (
 func NewSigningKey() ([]byte, error) {
 	key, err := util_rsa.GenerateKey(util_rsa.DefaultKeySize)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to generate RSA key")
+		return nil, fmt.Errorf("failed to generate RSA key: %w", err)
 	}
 	return util_rsa.FromPrivateKeyToPEMBytes(key)
 }
@@ -114,7 +113,7 @@ func getKeyBytes(
 			}
 		}
 
-		return nil, errors.Wrap(err, "could not retrieve signing key")
+		return nil, fmt.Errorf("could not retrieve signing key: %w", err)
 	}
 
 	return resource.Spec.GetData().GetValue(), nil

--- a/pkg/core/tokens/signing_key_manager.go
+++ b/pkg/core/tokens/signing_key_manager.go
@@ -3,10 +3,10 @@ package tokens
 import (
 	"context"
 	"crypto/rsa"
+	"fmt"
 	"strings"
 
 	"github.com/golang/protobuf/ptypes/wrappers"
-	"github.com/pkg/errors"
 
 	system_proto "github.com/kumahq/kuma/api/system/v1alpha1"
 	"github.com/kumahq/kuma/pkg/core/resources/apis/system"
@@ -47,7 +47,7 @@ var _ SigningKeyManager = &signingKeyManager{}
 func (s *signingKeyManager) GetLatestSigningKey(ctx context.Context) (*rsa.PrivateKey, int, error) {
 	resources := system.GlobalSecretResourceList{}
 	if err := s.manager.List(ctx, &resources); err != nil {
-		return nil, 0, errors.Wrap(err, "could not retrieve signing key from secret manager")
+		return nil, 0, fmt.Errorf("could not retrieve signing key from secret manager: %w", err)
 	}
 	return latestSigningKey(&resources, s.signingKeyPrefix, model.NoMesh)
 }

--- a/pkg/core/validators/types.go
+++ b/pkg/core/validators/types.go
@@ -1,6 +1,7 @@
 package validators
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 )
@@ -114,8 +115,8 @@ func MakeRequiredFieldErr(path PathBuilder) ValidationError {
 }
 
 func IsValidationError(err error) bool {
-	_, ok := err.(*ValidationError)
-	return ok
+	var validationError *ValidationError
+	return errors.As(err, &validationError)
 }
 
 type PathBuilder []string

--- a/pkg/core/xds/types.go
+++ b/pkg/core/xds/types.go
@@ -2,11 +2,11 @@ package xds
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 
 	"github.com/golang/protobuf/proto"
-	"github.com/pkg/errors"
 
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
@@ -244,12 +244,15 @@ func (st *secretsTracker) RequestAllInOneCa() CaRequest {
 		meshNames: st.allMeshes,
 	}
 }
+
 func (st *secretsTracker) UsedIdentity() bool {
 	return st.identity
 }
+
 func (st *secretsTracker) UsedCas() map[string]struct{} {
 	return st.meshes
 }
+
 func (st *secretsTracker) UsedAllInOne() bool {
 	return st.allInOne
 }
@@ -363,7 +366,7 @@ func BuildProxyId(mesh, name string) *ProxyId {
 
 func ParseProxyIdFromString(id string) (*ProxyId, error) {
 	if id == "" {
-		return nil, errors.Errorf("Envoy ID must not be nil")
+		return nil, fmt.Errorf("Envoy ID must not be nil")
 	}
 	parts := strings.SplitN(id, ".", 2)
 	mesh := parts[0]

--- a/pkg/defaults/components.go
+++ b/pkg/defaults/components.go
@@ -2,10 +2,10 @@ package defaults
 
 import (
 	"context"
+	"fmt"
 	"sync"
 	"time"
 
-	"github.com/pkg/errors"
 	"github.com/sethvargo/go-retry"
 	"go.uber.org/multierr"
 
@@ -92,7 +92,7 @@ func (d *defaultsComponent) Start(stop <-chan struct{}) error {
 			if err != nil {
 				// Retry this operation since on Kubernetes Mesh needs to be validated and set default values.
 				// This code can execute before the control plane is ready therefore hooks can fail.
-				errChan <- errors.Wrap(err, "could not create the default Mesh")
+				errChan <- fmt.Errorf("could not create the default Mesh: %w", err)
 			}
 		}()
 	}

--- a/pkg/defaults/mesh/mesh.go
+++ b/pkg/defaults/mesh/mesh.go
@@ -5,8 +5,6 @@ import (
 	"fmt"
 	"sync"
 
-	"github.com/pkg/errors"
-
 	"github.com/kumahq/kuma/pkg/core"
 	"github.com/kumahq/kuma/pkg/core/resources/manager"
 	"github.com/kumahq/kuma/pkg/core/resources/model"
@@ -46,7 +44,7 @@ func EnsureDefaultMeshResources(ctx context.Context, resManager manager.Resource
 		resource := resourceBuilder()
 		err, created := ensureDefaultResource(ctx, resManager, resource, key)
 		if err != nil {
-			return errors.Wrapf(err, "could not create default %s %q", resource.Descriptor().Name, key.Name)
+			return fmt.Errorf("could not create default %s %q: %w", resource.Descriptor().Name, key.Name, err)
 		}
 
 		msg := fmt.Sprintf("default %s already exists", resource.Descriptor().Name)
@@ -59,7 +57,7 @@ func EnsureDefaultMeshResources(ctx context.Context, resManager manager.Resource
 
 	created, err := ensureDataplaneTokenSigningKey(ctx, resManager, meshName)
 	if err != nil {
-		return errors.Wrap(err, "could not create default Dataplane Token Signing Key")
+		return fmt.Errorf("could not create default Dataplane Token Signing Key: %w", err)
 	}
 	if created {
 		resKey := tokens.SigningKeyResourceKey(issuer.DataplaneTokenSigningKeyPrefix(meshName), tokens.DefaultSerialNumber, meshName)
@@ -76,10 +74,10 @@ func ensureDefaultResource(ctx context.Context, resManager manager.ResourceManag
 		return nil, false
 	}
 	if !store.IsResourceNotFound(err) {
-		return errors.Wrap(err, "could not retrieve a resource"), false
+		return fmt.Errorf("could not retrieve a resource: %w", err), false
 	}
 	if err := resManager.Create(ctx, res, store.CreateBy(resourceKey)); err != nil {
-		return errors.Wrap(err, "could not create a resource"), false
+		return fmt.Errorf("could not create a resource: %w", err), false
 	}
 	return nil, true
 }

--- a/pkg/dns/vips/persistence.go
+++ b/pkg/dns/vips/persistence.go
@@ -6,8 +6,6 @@ import (
 	"fmt"
 	"regexp"
 
-	"github.com/pkg/errors"
-
 	config_manager "github.com/kumahq/kuma/pkg/core/config/manager"
 	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	config_model "github.com/kumahq/kuma/pkg/core/resources/apis/system"
@@ -80,7 +78,7 @@ func (m *Persistence) Set(ctx context.Context, mesh string, vips *VirtualOutboun
 
 	jsonBytes, err := json.Marshal(vips.byHostname)
 	if err != nil {
-		return errors.Wrap(err, "unable to marshall VIP list")
+		return fmt.Errorf("unable to marshall VIP list: %w", err)
 	}
 	resource.Spec.Config = string(jsonBytes)
 

--- a/pkg/dns/vips_allocator_test.go
+++ b/pkg/dns/vips_allocator_test.go
@@ -2,10 +2,10 @@ package dns_test
 
 import (
 	"context"
+	"fmt"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/pkg/errors"
 
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	dns_server "github.com/kumahq/kuma/pkg/config/dns-server"
@@ -50,7 +50,7 @@ type errConfigManager struct {
 
 func (e *errConfigManager) Update(ctx context.Context, r *config_model.ConfigResource, opts ...store.UpdateOptionsFunc) error {
 	meshName, _ := vips.MeshFromConfigKey(r.GetMeta().GetName())
-	return errors.Errorf("error during update, mesh = %s", meshName)
+	return fmt.Errorf("error during update, mesh = %s", meshName)
 }
 
 var testConfig = dns_server.Config{

--- a/pkg/envoy/accesslog/v3/format_parser.go
+++ b/pkg/envoy/accesslog/v3/format_parser.go
@@ -1,11 +1,10 @@
 package v3
 
 import (
+	"fmt"
 	"regexp"
 	"strconv"
 	"strings"
-
-	"github.com/pkg/errors"
 )
 
 var (
@@ -43,11 +42,11 @@ type formatParser struct{}
 func (p formatParser) Parse(format string) (_ *AccessLogFormat, err error) {
 	defer func() {
 		if err != nil {
-			err = errors.Wrap(err, "format string is not valid")
+			err = fmt.Errorf("format string is not valid: %w", err)
 		}
 	}()
 
-	var textLiteralStart = -1
+	textLiteralStart := -1
 	var fragments []AccessLogFragment
 
 	for pos := 0; pos < len(format); pos++ {
@@ -60,7 +59,7 @@ func (p formatParser) Parse(format string) (_ *AccessLogFormat, err error) {
 			tail := format[pos:]
 			match := commandWithArgsRE.FindStringSubmatch(tail)
 			if match == nil {
-				return nil, errors.Errorf("expected a command operator to start at position %d, instead got: %q", pos+1, tail)
+				return nil, fmt.Errorf("expected a command operator to start at position %d, instead got: %q", pos+1, tail)
 			}
 			token, command, args, limit, err := p.splitMatch(match)
 			if err != nil {
@@ -86,7 +85,7 @@ func (p formatParser) Parse(format string) (_ *AccessLogFormat, err error) {
 
 func (p formatParser) splitMatch(match []string) (token string, command string, args string, limit string, err error) {
 	if len(match) != 4 {
-		return "", "", "", "", errors.Errorf("expected a command operator that consists of a command, args and limit, got %q", match)
+		return "", "", "", "", fmt.Errorf("expected a command operator that consists of a command, args and limit, got %q", match)
 	}
 	return match[0], match[1], match[2], match[3], nil
 }
@@ -143,21 +142,21 @@ func (p formatParser) parseCommandOperator(token, command, args, limit string) (
 
 func (p formatParser) parseHeaderOperator(token, command, args, limit string) (header string, altHeader string, maxLen int, err error) {
 	if p.hasNoArguments(token, command, args, limit) {
-		return "", "", 0, errors.Errorf(`command %q requires a header and optional alternative header names as its arguments, instead got %q`, CommandOperatorDescriptor(command), token)
+		return "", "", 0, fmt.Errorf(`command %q requires a header and optional alternative header names as its arguments, instead got %q`, CommandOperatorDescriptor(command), token)
 	}
 	header, altHeaders, maxLen, err := p.parseOperator(token, args, limit, "?")
 	if err != nil {
 		return "", "", 0, err
 	}
 	if len(altHeaders) > 1 {
-		return "", "", 0, errors.Errorf("more than 1 alternative header specified in %q", token)
+		return "", "", 0, fmt.Errorf("more than 1 alternative header specified in %q", token)
 	}
 	if len(altHeaders) > 0 {
 		altHeader = altHeaders[0]
 	}
 	// The main and alternative header should not contain invalid characters {NUL, LR, CF}.
 	if newlineRE.MatchString(header) || newlineRE.MatchString(altHeader) {
-		return "", "", 0, errors.Errorf("header name contains a newline in %q", token)
+		return "", "", 0, fmt.Errorf("header name contains a newline in %q", token)
 	}
 	// apparently, Envoy allows both `Header` and `AltHeader` to be empty
 	return strings.ToLower(header), strings.ToLower(altHeader), maxLen, nil // Envoy emits log entries with all headers in lower case
@@ -169,7 +168,7 @@ func (p formatParser) parseDynamicMetadataOperator(token, command, args, limit s
 		return "", nil, 0, err
 	}
 	if p.hasNoArguments(token, command, args, limit) {
-		return "", nil, 0, errors.Errorf(`command %q requires a filter namespace and optional path as its arguments, instead got %q`, CommandOperatorDescriptor(command), token)
+		return "", nil, 0, fmt.Errorf(`command %q requires a filter namespace and optional path as its arguments, instead got %q`, CommandOperatorDescriptor(command), token)
 	}
 	return namespace, path, maxLen, err
 }
@@ -180,7 +179,7 @@ func (p formatParser) parseFilterStateOperator(token, command, args, limit strin
 		return "", 0, err
 	}
 	if p.hasNoArguments(token, command, args, limit) || key == "" {
-		return "", 0, errors.Errorf(`command %q requires a key as its argument, instead got %q`, CommandOperatorDescriptor(command), token)
+		return "", 0, fmt.Errorf(`command %q requires a key as its argument, instead got %q`, CommandOperatorDescriptor(command), token)
 	}
 	return key, maxLen, nil
 }
@@ -189,14 +188,14 @@ func (p formatParser) parseStartTimeOperator(token, args string) (format string,
 	// Validate the input specifier here. The formatted string may be destined for a header, and
 	// should not contain invalid characters {NUL, LR, CF}.
 	if startTimeNewlineRE.MatchString(args) {
-		return "", errors.Errorf("start time format string contains a newline in %q", token)
+		return "", fmt.Errorf("start time format string contains a newline in %q", token)
 	}
 	return args, nil
 }
 
 func (p formatParser) parseFieldOperator(token, command string) (field string, err error) {
 	if token[1:len(token)-1] != command {
-		return "", errors.Errorf(`command %q doesn't support arguments or max length constraint, instead got %q`, CommandOperatorDescriptor(command), token)
+		return "", fmt.Errorf(`command %q doesn't support arguments or max length constraint, instead got %q`, CommandOperatorDescriptor(command), token)
 	}
 	return command, nil
 }
@@ -205,7 +204,7 @@ func (p formatParser) parseOperator(token, args, limit string, separator string)
 	if limit != "" {
 		maxLen, err = strconv.Atoi(limit)
 		if err != nil {
-			return "", nil, 0, errors.Errorf("length must be an integer, instead got %q in %q", limit, token)
+			return "", nil, 0, fmt.Errorf("length must be an integer, instead got %q in %q", limit, token)
 		}
 	}
 	if separator != "" {

--- a/pkg/events/eventbus.go
+++ b/pkg/events/eventbus.go
@@ -1,9 +1,8 @@
 package events
 
 import (
+	"errors"
 	"sync"
-
-	"github.com/pkg/errors"
 )
 
 func NewEventBus() *EventBus {

--- a/pkg/events/interfaces.go
+++ b/pkg/events/interfaces.go
@@ -1,7 +1,7 @@
 package events
 
 import (
-	"github.com/pkg/errors"
+	"errors"
 
 	"github.com/kumahq/kuma/pkg/core/resources/model"
 )

--- a/pkg/gc/components.go
+++ b/pkg/gc/components.go
@@ -1,9 +1,8 @@
 package gc
 
 import (
+	"fmt"
 	"time"
-
-	"github.com/pkg/errors"
 
 	config_core "github.com/kumahq/kuma/pkg/config/core"
 	"github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
@@ -62,7 +61,7 @@ func setupFinalizer(rt runtime.Runtime) error {
 			system.ZoneInsightType,
 		}
 	default:
-		return errors.Errorf("unknown Kuma CP mode %s", rt.Config().Mode)
+		return fmt.Errorf("unknown Kuma CP mode %s", rt.Config().Mode)
 	}
 
 	finalizer, err := NewSubscriptionFinalizer(rt.ResourceManager(), newTicker, resourceTypes...)

--- a/pkg/gc/finalizer.go
+++ b/pkg/gc/finalizer.go
@@ -2,9 +2,8 @@ package gc
 
 import (
 	"context"
+	"fmt"
 	"time"
-
-	"github.com/pkg/errors"
 
 	"github.com/kumahq/kuma/api/generic"
 	"github.com/kumahq/kuma/pkg/core"
@@ -14,9 +13,7 @@ import (
 	"github.com/kumahq/kuma/pkg/core/runtime/component"
 )
 
-var (
-	finalizerLog = core.Log.WithName("finalizer")
-)
+var finalizerLog = core.Log.WithName("finalizer")
 
 // Every Insight has a statusSink that periodically increments the 'generation' counter while Kuma CP <-> DPP
 // connection is active. This updates happens every <KumaCP.Config>.Metrics.Dataplane.IdleTimeout / 2.
@@ -52,7 +49,7 @@ func NewSubscriptionFinalizer(rm manager.ResourceManager, newTicker func() *time
 	insights := insightsByType{}
 	for _, typ := range types {
 		if !isInsightType(typ) {
-			return nil, errors.Errorf("%q type is not an Insight", typ)
+			return nil, fmt.Errorf("%q type is not an Insight", typ)
 		}
 		insights[typ] = map[core_model.ResourceKey]*descriptor{}
 	}

--- a/pkg/hds/authn/callbacks_test.go
+++ b/pkg/hds/authn/callbacks_test.go
@@ -2,12 +2,13 @@ package authn_test
 
 import (
 	"context"
+	"errors"
+	"fmt"
 
 	envoy_config_core_v3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	envoy_service_health_v3 "github.com/envoyproxy/go-control-plane/envoy/service/health/v3"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/pkg/errors"
 	"google.golang.org/grpc/metadata"
 
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
@@ -36,7 +37,7 @@ func (t *testAuthenticator) Authenticate(_ context.Context, resource model.Resou
 			return nil
 		}
 	default:
-		return errors.Errorf("no matching authenticator for %s resource", resource.Descriptor().Name)
+		return fmt.Errorf("no matching authenticator for %s resource", resource.Descriptor().Name)
 	}
 
 	return errors.New("invalid credential")

--- a/pkg/hds/cache/snapshot.go
+++ b/pkg/hds/cache/snapshot.go
@@ -1,10 +1,11 @@
 package cache
 
 import (
+	"errors"
+
 	envoy_service_health_v3 "github.com/envoyproxy/go-control-plane/envoy/service/health/v3"
 	envoy_types "github.com/envoyproxy/go-control-plane/pkg/cache/types"
 	"github.com/envoyproxy/go-control-plane/pkg/cache/v3"
-	"github.com/pkg/errors"
 
 	util_xds_v3 "github.com/kumahq/kuma/pkg/util/xds/v3"
 )

--- a/pkg/hds/server/server.go
+++ b/pkg/hds/server/server.go
@@ -2,12 +2,12 @@ package server
 
 import (
 	"context"
+	"errors"
 	"sync/atomic"
 
 	envoy_core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	envoy_service_health "github.com/envoyproxy/go-control-plane/envoy/service/health/v3"
 	"github.com/envoyproxy/go-control-plane/pkg/cache/v3"
-	"github.com/pkg/errors"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -114,7 +114,7 @@ func (s *server) process(stream Stream, reqOrRespCh chan *envoy_service_health.H
 	}
 
 	responseChan := make(chan cache.Response, 1)
-	var node = &envoy_core.Node{}
+	node := &envoy_core.Node{}
 	for {
 		select {
 		case <-s.ctx.Done():

--- a/pkg/hds/tracker/callbacks.go
+++ b/pkg/hds/tracker/callbacks.go
@@ -2,13 +2,13 @@ package tracker
 
 import (
 	"context"
+	"fmt"
 	"sync"
 	"time"
 
 	envoy_core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	envoy_service_health "github.com/envoyproxy/go-control-plane/envoy/service/health/v3"
 	"github.com/go-logr/logr"
-	"github.com/pkg/errors"
 
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	dp_server "github.com/kumahq/kuma/pkg/config/dp-server"
@@ -189,7 +189,7 @@ func (t *tracker) updateDataplane(streamID xds.StreamID, healthMap map[uint32]bo
 	defer t.RUnlock()
 	dataplaneKey, hasAssociation := t.streamsAssociation[streamID]
 	if !hasAssociation {
-		return errors.Errorf("no proxy for streamID = %d", streamID)
+		return fmt.Errorf("no proxy for streamID = %d", streamID)
 	}
 
 	dp := mesh.NewDataplaneResource()

--- a/pkg/insights/resyncer.go
+++ b/pkg/insights/resyncer.go
@@ -2,6 +2,7 @@ package insights
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 	"time"
@@ -123,7 +124,7 @@ func (r *resyncer) Start(stop <-chan struct{}) error {
 	eventReader := r.eventFactory.New()
 	for {
 		event, err := eventReader.Recv(stop)
-		if err == events.ListenerStoppedErr {
+		if errors.Is(err, events.ListenerStoppedErr) {
 			return nil
 		}
 		if err != nil {

--- a/pkg/kds/cache/snapshot.go
+++ b/pkg/kds/cache/snapshot.go
@@ -1,11 +1,11 @@
 package cache
 
 import (
+	"errors"
 	"fmt"
 
 	envoy_types "github.com/envoyproxy/go-control-plane/pkg/cache/types"
 	envoy_cache "github.com/envoyproxy/go-control-plane/pkg/cache/v3"
-	"github.com/pkg/errors"
 
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	"github.com/kumahq/kuma/pkg/core/resources/model"
@@ -13,8 +13,7 @@ import (
 	util_xds_v3 "github.com/kumahq/kuma/pkg/util/xds/v3"
 )
 
-type ResourceBuilder interface {
-}
+type ResourceBuilder interface{}
 
 type SnapshotBuilder interface {
 	With(typ string, resources []envoy_types.Resource) SnapshotBuilder

--- a/pkg/kds/context/context.go
+++ b/pkg/kds/context/context.go
@@ -2,10 +2,10 @@ package context
 
 import (
 	"context"
+	"fmt"
 	"reflect"
 	"strings"
 
-	"github.com/pkg/errors"
 	"google.golang.org/protobuf/proto"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	"google.golang.org/protobuf/types/known/wrapperspb"
@@ -100,7 +100,7 @@ func MapInsightResourcesZeroGeneration(r model.Resource) (model.Resource, error)
 		newR := reflect.New(resType).Interface().(model.Resource)
 		newR.SetMeta(meta)
 		if err := newR.SetSpec(spec.(model.ResourceSpec)); err != nil {
-			panic(any(errors.Wrap(err, "error setting spec on resource")))
+			panic(any(fmt.Errorf("error setting spec on resource: %w", err)))
 		}
 
 		return newR, nil

--- a/pkg/kds/global/components.go
+++ b/pkg/kds/global/components.go
@@ -2,10 +2,9 @@ package global
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
-
-	"github.com/pkg/errors"
 
 	system_proto "github.com/kumahq/kuma/api/system/v1alpha1"
 	config_core "github.com/kumahq/kuma/pkg/config/core"
@@ -29,9 +28,7 @@ import (
 	util_proto "github.com/kumahq/kuma/pkg/util/proto"
 )
 
-var (
-	kdsGlobalLog = core.Log.WithName("kds-global")
-)
+var kdsGlobalLog = core.Log.WithName("kds-global")
 
 func Setup(rt runtime.Runtime) (err error) {
 	if rt.Config().Mode != config_core.Global {
@@ -108,7 +105,7 @@ func Callbacks(s sync_store.ResourceSyncer, k8sStore bool, kubeFactory resources
 				// KubernetesStore parses Name and considers substring after the last dot as a Namespace's Name.
 				kubeObject, err := kubeFactory.NewObject(rs.NewItem())
 				if err != nil {
-					return errors.Wrap(err, "could not convert object")
+					return fmt.Errorf("could not convert object: %w", err)
 				}
 				if kubeObject.Scope() == k8s_model.ScopeNamespace {
 					util.AddSuffixToNames(rs.GetItems(), "default")

--- a/pkg/kds/mux/server.go
+++ b/pkg/kds/mux/server.go
@@ -5,7 +5,6 @@ import (
 	"net"
 	"time"
 
-	"github.com/pkg/errors"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/keepalive"
@@ -24,9 +23,7 @@ const (
 	grpcKeepAliveTime        = 15 * time.Second
 )
 
-var (
-	muxServerLog = core.Log.WithName("kds-mux-server")
-)
+var muxServerLog = core.Log.WithName("kds-mux-server")
 
 type Filter interface {
 	InterceptSession(session Session) error
@@ -49,9 +46,7 @@ type server struct {
 	serviceServer *service.GlobalKDSServiceServer
 }
 
-var (
-	_ component.Component = &server{}
-)
+var _ component.Component = &server{}
 
 func NewServer(
 	callbacks Callbacks,
@@ -88,7 +83,7 @@ func (s *server) Start(stop <-chan struct{}) error {
 	if useTLS {
 		creds, err := credentials.NewServerTLSFromFile(s.config.TlsCertFile, s.config.TlsKeyFile)
 		if err != nil {
-			return errors.Wrap(err, "failed to load TLS certificate")
+			return fmt.Errorf("failed to load TLS certificate: %w", err)
 		}
 		grpcOptions = append(grpcOptions, grpc.Creds(creds))
 	}

--- a/pkg/kds/mux/session_test.go
+++ b/pkg/kds/mux/session_test.go
@@ -3,6 +3,7 @@ package mux_test
 import (
 	"bytes"
 	"context"
+	"errors"
 	"io"
 	"runtime"
 	"strconv"
@@ -13,7 +14,6 @@ import (
 	envoy_sd "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/pkg/errors"
 	"google.golang.org/grpc/metadata"
 
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
@@ -89,7 +89,6 @@ func (t *testMultiplexStream) CheckInvariants() error {
 }
 
 var _ = Describe("Multiplex Session", func() {
-
 	Context("basic Send/Recv operations", func() {
 		var clientSession mux.Session
 		var serverSession mux.Session
@@ -172,7 +171,6 @@ var _ = Describe("Multiplex Session", func() {
 	}))
 
 	Context("concurrent operations", func() {
-
 		Context("Recv", func() {
 			var clientSession mux.Session
 			var serverSession mux.Session

--- a/pkg/kds/mux/version.go
+++ b/pkg/kds/mux/version.go
@@ -2,12 +2,12 @@ package mux
 
 import (
 	"context"
+	"fmt"
 
 	envoy_api_v2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	envoy_core_v2 "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
 	envoy_core_v3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	envoy_sd_v3 "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
-	"github.com/pkg/errors"
 	"google.golang.org/grpc/metadata"
 )
 
@@ -38,7 +38,7 @@ func KDSVersion(ctx context.Context) string {
 }
 
 func UnsupportedKDSVersion(version string) error {
-	return errors.Errorf("invalid KDS version %s. Supported versions %s %s", version, KDSVersionV2, KDSVersionV3)
+	return fmt.Errorf("invalid KDS version %s. Supported versions %s %s", version, KDSVersionV2, KDSVersionV3)
 }
 
 func DiscoveryRequestV2(request *envoy_sd_v3.DiscoveryRequest) *envoy_api_v2.DiscoveryRequest {

--- a/pkg/kds/service/xds_config_processor.go
+++ b/pkg/kds/service/xds_config_processor.go
@@ -2,9 +2,8 @@ package service
 
 import (
 	"context"
+	"fmt"
 	"time"
-
-	"github.com/pkg/errors"
 
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	core_manager "github.com/kumahq/kuma/pkg/core/resources/manager"
@@ -84,7 +83,7 @@ func (s *xdsConfigDumpProcessor) executeConfigDump(ctx context.Context, req *mes
 
 	resWithAddr, ok := res.(core_model.ResourceWithAddress)
 	if !ok {
-		return nil, errors.Errorf("invalid type %T", resWithAddr)
+		return nil, fmt.Errorf("invalid type %T", resWithAddr)
 	}
 
 	return s.configDumpFn(ctx, resWithAddr)

--- a/pkg/kds/service/xds_config_streams.go
+++ b/pkg/kds/service/xds_config_streams.go
@@ -1,9 +1,8 @@
 package service
 
 import (
+	"fmt"
 	"sync"
-
-	"github.com/pkg/errors"
 
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 )
@@ -32,7 +31,7 @@ func (x *xdsConfigStreams) ResponseReceived(zone string, resp *mesh_proto.XDSCon
 	ch, ok := stream.watchForRequestId[resp.RequestId]
 	stream.Unlock()
 	if !ok {
-		return errors.Errorf("callback for request Id %s not found", resp.RequestId)
+		return fmt.Errorf("callback for request Id %s not found", resp.RequestId)
 	}
 	ch <- resp
 	return nil
@@ -58,7 +57,7 @@ func (x *xdsConfigStreams) zoneStream(zone string) (*xdsConfigStream, error) {
 	defer x.Unlock()
 	stream, ok := x.streamForZone[zone]
 	if !ok {
-		return nil, errors.Errorf("zone %s is not connected", zone)
+		return nil, fmt.Errorf("zone %s is not connected", zone)
 	}
 	return stream, nil
 }

--- a/pkg/kds/util/client_id.go
+++ b/pkg/kds/util/client_id.go
@@ -2,8 +2,8 @@ package util
 
 import (
 	"context"
+	"errors"
 
-	"github.com/pkg/errors"
 	"google.golang.org/grpc/metadata"
 )
 

--- a/pkg/kds/zone/components.go
+++ b/pkg/kds/zone/components.go
@@ -1,7 +1,7 @@
 package zone
 
 import (
-	"github.com/pkg/errors"
+	"fmt"
 
 	"github.com/kumahq/kuma/pkg/config"
 	config_core "github.com/kumahq/kuma/pkg/config/core"
@@ -25,9 +25,7 @@ import (
 	"github.com/kumahq/kuma/pkg/tokens/builtin/zoneingress"
 )
 
-var (
-	kdsZoneLog = core.Log.WithName("kds-zone")
-)
+var kdsZoneLog = core.Log.WithName("kds-zone")
 
 func Setup(rt core_runtime.Runtime) error {
 	if rt.Config().Mode != config_core.Zone {
@@ -48,11 +46,11 @@ func Setup(rt core_runtime.Runtime) error {
 	cfg := rt.Config()
 	cfgForDisplay, err := config.ConfigForDisplay(&cfg)
 	if err != nil {
-		return errors.Wrap(err, "could not construct config for display")
+		return fmt.Errorf("could not construct config for display: %w", err)
 	}
 	cfgJson, err := config.ToJson(cfgForDisplay)
 	if err != nil {
-		return errors.Wrap(err, "could not marshall config to json")
+		return fmt.Errorf("could not marshall config to json: %w", err)
 	}
 	onSessionStarted := mux.OnSessionStartedFunc(func(session mux.Session) error {
 		log := kdsZoneLog.WithValues("peer-id", session.PeerID())
@@ -93,7 +91,7 @@ func Callbacks(configToSync map[string]bool, syncer sync_store.ResourceSyncer, k
 				// System resources are not in the kubeFactory therefore we need explicit ifs for them
 				kubeObject, err := kubeFactory.NewObject(rs.NewItem())
 				if err != nil {
-					return errors.Wrap(err, "could not convert object")
+					return fmt.Errorf("could not convert object: %w", err)
 				}
 				if kubeObject.Scope() == k8s_model.ScopeNamespace {
 					util.AddSuffixToNames(rs.GetItems(), "default")

--- a/pkg/log/logger.go
+++ b/pkg/log/logger.go
@@ -1,12 +1,12 @@
 package log
 
 import (
+	"fmt"
 	"io"
 	"os"
 
 	"github.com/go-logr/logr"
 	"github.com/go-logr/zapr"
-	"github.com/pkg/errors"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 	"gopkg.in/natefinch/lumberjack.v2"
@@ -43,7 +43,7 @@ func ParseLogLevel(text string) (LogLevel, error) {
 	case "debug":
 		return DebugLevel, nil
 	default:
-		return OffLevel, errors.Errorf("unknown log level %q", text)
+		return OffLevel, fmt.Errorf("unknown log level %q", text)
 	}
 }
 
@@ -56,7 +56,8 @@ func NewLoggerWithRotation(level LogLevel, outputPath string, maxSize int, maxBa
 		Filename:   outputPath,
 		MaxSize:    maxSize,
 		MaxBackups: maxBackups,
-		MaxAge:     maxAge}, level)
+		MaxAge:     maxAge,
+	}, level)
 }
 
 func NewLoggerTo(destWriter io.Writer, level LogLevel) logr.Logger {

--- a/pkg/mads/v1/cache/snapshot.go
+++ b/pkg/mads/v1/cache/snapshot.go
@@ -1,9 +1,10 @@
 package cache
 
 import (
+	"errors"
+
 	envoy_types "github.com/envoyproxy/go-control-plane/pkg/cache/types"
 	envoy_cache "github.com/envoyproxy/go-control-plane/pkg/cache/v3"
-	"github.com/pkg/errors"
 
 	v1 "github.com/kumahq/kuma/pkg/mads/v1"
 	util_xds_v3 "github.com/kumahq/kuma/pkg/util/xds/v3"

--- a/pkg/mads/v1/client/client.go
+++ b/pkg/mads/v1/client/client.go
@@ -8,7 +8,6 @@ import (
 
 	envoy_core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	envoy_sd "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
-	"github.com/pkg/errors"
 	"google.golang.org/genproto/googleapis/rpc/status"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
@@ -45,7 +44,7 @@ func New(serverURL string) (*Client, error) {
 			InsecureSkipVerify: true, // it's acceptable since we don't pass any secrets to the server
 		})))
 	default:
-		return nil, errors.Errorf("unsupported scheme %q. Use one of %s", url.Scheme, []string{"grpc", "grpcs"})
+		return nil, fmt.Errorf("unsupported scheme %q. Use one of %s", url.Scheme, []string{"grpc", "grpcs"})
 	}
 	conn, err := grpc.Dial(url.Host, dialOpts...)
 	if err != nil {
@@ -126,7 +125,7 @@ func (s *Stream) WaitForAssignments() ([]*observability_v1.MonitoringAssignment,
 	for i := range resp.Resources {
 		assignment := &observability_v1.MonitoringAssignment{}
 		if err := util_proto.UnmarshalAnyTo(resp.Resources[i], assignment); err != nil {
-			return nil, errors.Wrapf(err, "failed to unmarshal MADS response: %v", resp)
+			return nil, fmt.Errorf("failed to unmarshal MADS response: %v: %w", resp, err)
 		}
 		assignments[i] = assignment
 	}

--- a/pkg/mads/v1/service/components.go
+++ b/pkg/mads/v1/service/components.go
@@ -2,13 +2,13 @@ package service
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	envoy_core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	envoy_cache "github.com/envoyproxy/go-control-plane/pkg/cache/v3"
 	envoy_xds "github.com/envoyproxy/go-control-plane/pkg/server/v3"
 	"github.com/go-logr/logr"
-	"github.com/pkg/errors"
 
 	"github.com/kumahq/kuma/pkg/core"
 	core_manager "github.com/kumahq/kuma/pkg/core/resources/manager"
@@ -28,7 +28,8 @@ func NewVersioner() util_xds_v3.SnapshotVersioner {
 }
 
 func NewReconciler(hasher envoy_cache.NodeHash, cache util_xds_v3.SnapshotCache,
-	generator util_xds_v3.SnapshotGenerator, versioner util_xds_v3.SnapshotVersioner) mads_reconcile.Reconciler {
+	generator util_xds_v3.SnapshotGenerator, versioner util_xds_v3.SnapshotVersioner,
+) mads_reconcile.Reconciler {
 	return mads_reconcile.NewReconciler(hasher, cache, generator, versioner)
 }
 
@@ -41,7 +42,7 @@ func (r *restReconcilerCallbacks) OnFetchRequest(ctx context.Context, request ut
 
 	node, ok := nodei.(*envoy_core.Node)
 	if !ok {
-		return errors.Errorf("expecting a v3 Node, got: %v", nodei)
+		return fmt.Errorf("expecting a v3 Node, got: %v", nodei)
 	}
 
 	// only reconcile if there is not a valid response present
@@ -83,8 +84,7 @@ func NewXdsContext(log logr.Logger) (envoy_cache.NodeHash, util_xds_v3.SnapshotC
 	return hasher, util_xds_v3.NewSnapshotCache(false, hasher, logger)
 }
 
-type hasher struct {
-}
+type hasher struct{}
 
 func (_ hasher) ID(node *envoy_core.Node) string {
 	// in the very first implementation, we don't differentiate clients

--- a/pkg/mads/v1/service/http.go
+++ b/pkg/mads/v1/service/http.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"errors"
 	"io"
 	"net/http"
 	"time"
@@ -74,7 +75,8 @@ func (s *service) handleDiscovery(req *restful.Request, res *restful.Response) {
 
 	discoveryRes, err := s.server.FetchMonitoringAssignments(ctx, discoveryReq)
 	if err != nil {
-		if _, ok := err.(*cache_types.SkipFetchError); ok {
+		var skipFetchError *cache_types.SkipFetchError
+		if errors.As(err, &skipFetchError) {
 			// No update necessary, send 304 Not Modified
 			s.log.V(1).Info("no update needed")
 			res.WriteHeader(http.StatusNotModified)

--- a/pkg/plugins/authn/api-server/tokens/admin_token_bootstrap.go
+++ b/pkg/plugins/authn/api-server/tokens/admin_token_bootstrap.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/pkg/errors"
 	"github.com/sethvargo/go-retry"
 	"google.golang.org/protobuf/types/known/wrapperspb"
 
@@ -68,13 +67,13 @@ func (a *adminTokenBootstrap) generateTokenIfNotExist(ctx context.Context) error
 		return nil // already exists
 	}
 	if !core_store.IsResourceNotFound(err) {
-		return errors.Wrap(err, "could not check if token exist")
+		return fmt.Errorf("could not check if token exist: %w", err)
 	}
 
 	log.Info("Admin User Token not found. Generating.")
 	token, err := a.generateAdminToken(ctx)
 	if err != nil {
-		return errors.Wrap(err, "could not generate admin token")
+		return fmt.Errorf("could not generate admin token: %w", err)
 	}
 
 	log.Info("saving generated Admin User Token", "globalSecretName", AdminTokenKey.Name)

--- a/pkg/plugins/authn/api-server/tokens/authenticator.go
+++ b/pkg/plugins/authn/api-server/tokens/authenticator.go
@@ -25,7 +25,7 @@ func UserTokenAuthenticator(validator issuer.UserTokenValidator) authn.Authentic
 			token := strings.TrimPrefix(authnHeader, bearerPrefix)
 			u, err := validator.Validate(request.Request.Context(), token)
 			if err != nil {
-				rest_errors.HandleError(response, &rest_errors.Unauthenticated{}, "Invalid authentication data")
+				rest_errors.HandleError(response, rest_errors.Unauthenticated, "Invalid authentication data")
 				log.Info("authentication rejected", "reason", err.Error())
 				return
 			}

--- a/pkg/plugins/authn/api-server/tokens/cli/generate/generate_user_token.go
+++ b/pkg/plugins/authn/api-server/tokens/cli/generate/generate_user_token.go
@@ -1,9 +1,9 @@
 package generate
 
 import (
+	"fmt"
 	"time"
 
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
 	kumactl_cmd "github.com/kumahq/kuma/app/kumactl/pkg/cmd"
@@ -37,7 +37,7 @@ $ kumactl generate user-token --name john.doe@example.com --group users --valid-
 			tokenClient := NewHTTPUserTokenClient(client)
 			token, err := tokenClient.Generate(args.name, args.groups, args.validFor)
 			if err != nil {
-				return errors.Wrap(err, "failed to generate a user token")
+				return fmt.Errorf("failed to generate a user token: %w", err)
 			}
 			_, err = cmd.OutOrStdout().Write([]byte(token))
 			return err

--- a/pkg/plugins/authn/api-server/tokens/cli/plugin.go
+++ b/pkg/plugins/authn/api-server/tokens/cli/plugin.go
@@ -1,9 +1,8 @@
 package cli
 
 import (
+	"errors"
 	"net/http"
-
-	"github.com/pkg/errors"
 
 	"github.com/kumahq/kuma/app/kumactl/pkg/plugins"
 	util_http "github.com/kumahq/kuma/pkg/util/http"
@@ -14,8 +13,7 @@ const (
 	TokenKey = "token"
 )
 
-type TokenAuthnPlugin struct {
-}
+type TokenAuthnPlugin struct{}
 
 var _ plugins.AuthnPlugin = &TokenAuthnPlugin{}
 

--- a/pkg/plugins/authn/api-server/tokens/plugin.go
+++ b/pkg/plugins/authn/api-server/tokens/plugin.go
@@ -1,7 +1,7 @@
 package tokens
 
 import (
-	"github.com/pkg/errors"
+	"fmt"
 
 	"github.com/kumahq/kuma/pkg/api-server/authn"
 	config_access "github.com/kumahq/kuma/pkg/config/access"
@@ -14,11 +14,12 @@ import (
 
 const PluginName = "tokens"
 
-type plugin struct {
-}
+type plugin struct{}
 
-var _ plugins.AuthnAPIServerPlugin = plugin{}
-var _ plugins.BootstrapPlugin = plugin{}
+var (
+	_ plugins.AuthnAPIServerPlugin = plugin{}
+	_ plugins.BootstrapPlugin      = plugin{}
+)
 
 // We declare AccessStrategies and not into Runtime because it's a plugin.
 var AccessStrategies = map[string]func(*plugins.MutablePluginContext) access.GenerateUserTokenAccess{
@@ -54,7 +55,7 @@ func (c plugin) AfterBootstrap(context *plugins.MutablePluginContext, config plu
 	}
 	accessFn, ok := AccessStrategies[context.Config().Access.Type]
 	if !ok {
-		return errors.Errorf("no Access strategy for type %q", context.Config().Access.Type)
+		return fmt.Errorf("no Access strategy for type %q", context.Config().Access.Type)
 	}
 	tokenIssuer := issuer.NewUserTokenIssuer(core_tokens.NewTokenIssuer(signingKeyManager))
 	if context.Config().ApiServer.Authn.Tokens.BootstrapAdminToken {

--- a/pkg/plugins/authn/api-server/tokens/ws/client/client.go
+++ b/pkg/plugins/authn/api-server/tokens/ws/client/client.go
@@ -3,11 +3,10 @@ package client
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"time"
-
-	"github.com/pkg/errors"
 
 	error_types "github.com/kumahq/kuma/pkg/core/rest/errors/types"
 	"github.com/kumahq/kuma/pkg/plugins/authn/api-server/tokens/ws"
@@ -38,21 +37,21 @@ func (h *httpUserTokenClient) Generate(name string, groups []string, validFor ti
 	}
 	reqBytes, err := json.Marshal(tokenReq)
 	if err != nil {
-		return "", errors.Wrap(err, "could not marshal token request to json")
+		return "", fmt.Errorf("could not marshal token request to json: %w", err)
 	}
 	req, err := http.NewRequest("POST", "/tokens/user", bytes.NewReader(reqBytes))
 	if err != nil {
-		return "", errors.Wrap(err, "could not construct the request")
+		return "", fmt.Errorf("could not construct the request: %w", err)
 	}
 	req.Header.Set("content-type", "application/json")
 	resp, err := h.client.Do(req)
 	if err != nil {
-		return "", errors.Wrap(err, "could not execute the request")
+		return "", fmt.Errorf("could not execute the request: %w", err)
 	}
 	defer resp.Body.Close()
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return "", errors.Wrap(err, "could not read a body of the request")
+		return "", fmt.Errorf("could not read a body of the request: %w", err)
 	}
 	if resp.StatusCode != 200 {
 		var kumaErr error_types.Error
@@ -61,7 +60,7 @@ func (h *httpUserTokenClient) Generate(name string, groups []string, validFor ti
 				return "", &kumaErr
 			}
 		}
-		return "", errors.Errorf("(%d): %s", resp.StatusCode, body)
+		return "", fmt.Errorf("(%d): %s", resp.StatusCode, body)
 	}
 	return string(body), nil
 }

--- a/pkg/plugins/bootstrap/k8s/scheme.go
+++ b/pkg/plugins/bootstrap/k8s/scheme.go
@@ -1,7 +1,8 @@
 package k8s
 
 import (
-	"github.com/pkg/errors"
+	"fmt"
+
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	kube_runtime "k8s.io/apimachinery/pkg/runtime"
 	kube_client_scheme "k8s.io/client-go/kubernetes/scheme"
@@ -16,19 +17,19 @@ import (
 func NewScheme() (*kube_runtime.Scheme, error) {
 	s := kube_runtime.NewScheme()
 	if err := kube_client_scheme.AddToScheme(s); err != nil {
-		return nil, errors.Wrapf(err, "could not add client resources to scheme")
+		return nil, fmt.Errorf("could not add client resources to scheme: %w", err)
 	}
 	if err := mesh_k8s.AddToScheme(s); err != nil {
-		return nil, errors.Wrapf(err, "could not add %q to scheme", mesh_k8s.GroupVersion)
+		return nil, fmt.Errorf("could not add %q to scheme: %w", mesh_k8s.GroupVersion, err)
 	}
 	if err := k8scnicncfio.AddToScheme(s); err != nil {
-		return nil, errors.Wrapf(err, "could not add %q to scheme", k8scnicncfio.GroupVersion)
+		return nil, fmt.Errorf("could not add %q to scheme: %w", k8scnicncfio.GroupVersion, err)
 	}
 	if err := apiextensionsv1.AddToScheme(s); err != nil {
-		return nil, errors.Wrapf(err, "could not add %q to scheme", apiextensionsv1.SchemeGroupVersion)
+		return nil, fmt.Errorf("could not add %q to scheme: %w", apiextensionsv1.SchemeGroupVersion, err)
 	}
 	if err := gatewayapi.Install(s); err != nil {
-		return nil, errors.Wrapf(err, "could not add %q to scheme", gatewayapi.SchemeGroupVersion)
+		return nil, fmt.Errorf("could not add %q to scheme: %w", gatewayapi.SchemeGroupVersion, err)
 	}
 	if err := policies.AddToScheme(s); err != nil {
 		return nil, err

--- a/pkg/plugins/bootstrap/k8s/xds/hooks/api_server_bypass.go
+++ b/pkg/plugins/bootstrap/k8s/xds/hooks/api_server_bypass.go
@@ -1,7 +1,7 @@
 package hooks
 
 import (
-	"github.com/pkg/errors"
+	"fmt"
 
 	core_xds "github.com/kumahq/kuma/pkg/core/xds"
 	xds_context "github.com/kumahq/kuma/pkg/xds/context"
@@ -46,14 +46,14 @@ func (h ApiServerBypass) Modify(resources *core_xds.ResourceSet, ctx xds_context
 		Configure(envoy_listeners.OriginalDstForwarder()).
 		Build()
 	if err != nil {
-		return errors.Wrapf(err, "could not generate listener: %s", apiServerBypassHookResourcesName)
+		return fmt.Errorf("could not generate listener: %s: %w", apiServerBypassHookResourcesName, err)
 	}
 
 	cluster, err := envoy_clusters.NewClusterBuilder(proxy.APIVersion).
 		Configure(envoy_clusters.PassThroughCluster(apiServerBypassHookResourcesName)).
 		Build()
 	if err != nil {
-		return errors.Wrapf(err, "could not generate cluster: %s", apiServerBypassHookResourcesName)
+		return fmt.Errorf("could not generate cluster: %s: %w", apiServerBypassHookResourcesName, err)
 	}
 
 	resources.Add(&core_xds.Resource{

--- a/pkg/plugins/ca/builtin/ca.go
+++ b/pkg/plugins/ca/builtin/ca.go
@@ -5,11 +5,11 @@ import (
 	"crypto/rand"
 	"crypto/x509"
 	"crypto/x509/pkix"
+	"fmt"
 	"math/big"
 	"net/url"
 	"time"
 
-	"github.com/pkg/errors"
 	"github.com/spiffe/go-spiffe/spiffe"
 
 	"github.com/kumahq/kuma/pkg/core"
@@ -38,11 +38,11 @@ func newRootCa(mesh string, rsaBits int, certOpts ...certOptsFn) (*core_ca.KeyPa
 	}
 	key, err := util_rsa.GenerateKey(rsaBits)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to generate a private key")
+		return nil, fmt.Errorf("failed to generate a private key: %w", err)
 	}
 	cert, err := newCACert(key, mesh, certOpts...)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to generate X509 certificate")
+		return nil, fmt.Errorf("failed to generate X509 certificate: %w", err)
 	}
 	return util_tls.ToKeyPair(key, cert)
 }

--- a/pkg/plugins/ca/provided/ca_cert_validator_test.go
+++ b/pkg/plugins/ca/provided/ca_cert_validator_test.go
@@ -4,6 +4,7 @@ import (
 	"crypto/rand"
 	"crypto/rsa"
 	"crypto/x509"
+	"fmt"
 	"math/big"
 	"os"
 	"path/filepath"
@@ -11,14 +12,12 @@ import (
 	"github.com/ghodss/yaml"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/pkg/errors"
 
 	. "github.com/kumahq/kuma/pkg/plugins/ca/provided"
 	util_tls "github.com/kumahq/kuma/pkg/tls"
 )
 
 var _ = Describe("ValidateCaCert()", func() {
-
 	It("should accept proper CA certificates", func() {
 		// when
 		cert, err := os.ReadFile(filepath.Join("testdata", "ca.pem"))
@@ -42,13 +41,13 @@ var _ = Describe("ValidateCaCert()", func() {
 	NewSelfSignedCert := func(newTemplate func() *x509.Certificate) (*util_tls.KeyPair, error) {
 		key, err := rsa.GenerateKey(rand.Reader, 2048)
 		if err != nil {
-			return nil, errors.Wrap(err, "failed to generate a private key")
+			return nil, fmt.Errorf("failed to generate a private key: %w", err)
 		}
 		template := newTemplate()
 		template.PublicKey = key.Public()
 		cert, err := x509.CreateCertificate(rand.Reader, template, template, key.Public(), key)
 		if err != nil {
-			return nil, errors.Wrap(err, "failed to sign X509 certificate")
+			return nil, fmt.Errorf("failed to sign X509 certificate: %w", err)
 		}
 		return util_tls.ToKeyPair(key, cert)
 	}

--- a/pkg/plugins/common/postgres/connection.go
+++ b/pkg/plugins/common/postgres/connection.go
@@ -2,8 +2,7 @@ package postgres
 
 import (
 	"database/sql"
-
-	"github.com/pkg/errors"
+	"fmt"
 
 	config "github.com/kumahq/kuma/pkg/config/plugins/resources/postgres"
 )
@@ -15,7 +14,7 @@ func ConnectToDb(cfg config.PostgresStoreConfig) (*sql.DB, error) {
 	}
 	db, err := sql.Open("postgres", connStr)
 	if err != nil {
-		return nil, errors.Wrap(err, "cannot create connection to DB")
+		return nil, fmt.Errorf("cannot create connection to DB: %w", err)
 	}
 
 	db.SetMaxOpenConns(cfg.MaxOpenConnections)
@@ -23,7 +22,7 @@ func ConnectToDb(cfg config.PostgresStoreConfig) (*sql.DB, error) {
 
 	// check connection to DB, Open() does not check it.
 	if err := db.Ping(); err != nil {
-		return nil, errors.Wrap(err, "cannot connect to DB")
+		return nil, fmt.Errorf("cannot connect to DB: %w", err)
 	}
 
 	return db, nil

--- a/pkg/plugins/config/k8s/plugin.go
+++ b/pkg/plugins/config/k8s/plugin.go
@@ -1,7 +1,7 @@
 package k8s
 
 import (
-	"github.com/pkg/errors"
+	"fmt"
 
 	core_plugins "github.com/kumahq/kuma/pkg/core/plugins"
 	core_store "github.com/kumahq/kuma/pkg/core/resources/store"
@@ -19,11 +19,11 @@ func init() {
 func (p *plugin) NewConfigStore(pc core_plugins.PluginContext, _ core_plugins.PluginConfig) (core_store.ResourceStore, error) {
 	mgr, ok := k8s_extensions.FromManagerContext(pc.Extensions())
 	if !ok {
-		return nil, errors.Errorf("k8s controller runtime Manager hasn't been configured")
+		return nil, fmt.Errorf("k8s controller runtime Manager hasn't been configured")
 	}
 	converter, ok := k8s_extensions.FromResourceConverterContext(pc.Extensions())
 	if !ok {
-		return nil, errors.Errorf("k8s resource converter hasn't been configured")
+		return nil, fmt.Errorf("k8s resource converter hasn't been configured")
 	}
 	return NewStore(mgr.GetClient(), pc.Config().Store.Kubernetes.SystemNamespace, mgr.GetScheme(), converter)
 }

--- a/pkg/plugins/resources/k8s/events/listener.go
+++ b/pkg/plugins/resources/k8s/events/listener.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -127,7 +126,7 @@ func (k *listener) NeedLeaderElection() bool {
 func (k *listener) addTypeInformationToObject(obj runtime.Object) error {
 	gvks, _, err := k.mgr.GetScheme().ObjectKinds(obj)
 	if err != nil {
-		return errors.Wrap(err, "missing apiVersion or kind and cannot assign it")
+		return fmt.Errorf("missing apiVersion or kind and cannot assign it: %w", err)
 	}
 
 	for _, gvk := range gvks {

--- a/pkg/plugins/resources/k8s/native/pkg/registry/registry.go
+++ b/pkg/plugins/resources/k8s/native/pkg/registry/registry.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 
 	"github.com/golang/protobuf/proto"
-	"github.com/pkg/errors"
 
 	"github.com/kumahq/kuma/pkg/plugins/resources/k8s/native/pkg/model"
 )
@@ -40,7 +39,7 @@ type typeRegistry struct {
 func (r *typeRegistry) RegisterObjectType(typ ResourceType, obj model.KubernetesObject) error {
 	name := proto.MessageName(typ)
 	if previous, ok := r.objectTypes[name]; ok {
-		return errors.Errorf("duplicate registration of KubernetesObject type under name %q: previous=%#v new=%#v", name, previous, obj)
+		return fmt.Errorf("duplicate registration of KubernetesObject type under name %q: previous=%#v new=%#v", name, previous, obj)
 	}
 	r.objectTypes[name] = obj
 	return nil
@@ -57,7 +56,7 @@ func (r *typeRegistry) RegisterObjectTypeIfAbsent(typ ResourceType, obj model.Ku
 func (r *typeRegistry) RegisterListType(typ ResourceType, obj model.KubernetesList) error {
 	name := proto.MessageName(typ)
 	if previous, ok := r.objectListTypes[name]; ok {
-		return errors.Errorf("duplicate registration of KubernetesList type under name %q: previous=%#v new=%#v", name, previous, obj)
+		return fmt.Errorf("duplicate registration of KubernetesList type under name %q: previous=%#v new=%#v", name, previous, obj)
 	}
 	r.objectListTypes[name] = obj
 	return nil

--- a/pkg/plugins/resources/k8s/plugin.go
+++ b/pkg/plugins/resources/k8s/plugin.go
@@ -1,7 +1,8 @@
 package k8s
 
 import (
-	"github.com/pkg/errors"
+	"errors"
+	"fmt"
 
 	core_plugins "github.com/kumahq/kuma/pkg/core/plugins"
 	core_store "github.com/kumahq/kuma/pkg/core/resources/store"
@@ -21,11 +22,11 @@ func init() {
 func (p *plugin) NewResourceStore(pc core_plugins.PluginContext, _ core_plugins.PluginConfig) (core_store.ResourceStore, error) {
 	mgr, ok := k8s_runtime.FromManagerContext(pc.Extensions())
 	if !ok {
-		return nil, errors.Errorf("k8s controller runtime Manager hasn't been configured")
+		return nil, fmt.Errorf("k8s controller runtime Manager hasn't been configured")
 	}
 	converter, ok := k8s_runtime.FromResourceConverterContext(pc.Extensions())
 	if !ok {
-		return nil, errors.Errorf("k8s resource converter hasn't been configured")
+		return nil, fmt.Errorf("k8s resource converter hasn't been configured")
 	}
 	return NewStore(mgr.GetClient(), mgr.GetScheme(), converter)
 }
@@ -37,7 +38,7 @@ func (p *plugin) Migrate(pc core_plugins.PluginContext, config core_plugins.Plug
 func (p *plugin) EventListener(pc core_plugins.PluginContext, writer events.Emitter) error {
 	mgr, ok := k8s_runtime.FromManagerContext(pc.Extensions())
 	if !ok {
-		return errors.Errorf("k8s controller runtime Manager hasn't been configured")
+		return fmt.Errorf("k8s controller runtime Manager hasn't been configured")
 	}
 	if err := pc.ComponentManager().Add(k8s_events.NewListener(mgr, writer)); err != nil {
 		return err

--- a/pkg/plugins/resources/memory/plugin.go
+++ b/pkg/plugins/resources/memory/plugin.go
@@ -1,7 +1,7 @@
 package memory
 
 import (
-	"github.com/pkg/errors"
+	"errors"
 
 	"github.com/kumahq/kuma/pkg/core"
 	core_plugins "github.com/kumahq/kuma/pkg/core/plugins"
@@ -9,8 +9,10 @@ import (
 	"github.com/kumahq/kuma/pkg/events"
 )
 
-var log = core.Log.WithName("plugins").WithName("resources").WithName("memory")
-var _ core_plugins.ResourceStorePlugin = &plugin{}
+var (
+	log                                  = core.Log.WithName("plugins").WithName("resources").WithName("memory")
+	_   core_plugins.ResourceStorePlugin = &plugin{}
+)
 
 type plugin struct{}
 

--- a/pkg/plugins/resources/postgres/events/listener.go
+++ b/pkg/plugins/resources/postgres/events/listener.go
@@ -2,8 +2,7 @@ package events
 
 import (
 	"encoding/json"
-
-	"github.com/pkg/errors"
+	"errors"
 
 	"github.com/kumahq/kuma/pkg/config/plugins/resources/postgres"
 	"github.com/kumahq/kuma/pkg/core"

--- a/pkg/plugins/resources/remote/unmarshalling.go
+++ b/pkg/plugins/resources/remote/unmarshalling.go
@@ -2,10 +2,9 @@ package remote
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/url"
 	"time"
-
-	"github.com/pkg/errors"
 
 	"github.com/kumahq/kuma/pkg/core/resources/model"
 	"github.com/kumahq/kuma/pkg/core/resources/model/rest"
@@ -84,7 +83,7 @@ func UnmarshalList(b []byte, rs model.ResourceList) error {
 	if rsr.Next != nil {
 		uri, err := url.ParseRequestURI(*rsr.Next)
 		if err != nil {
-			return errors.Wrap(err, "invalid next URL from the server")
+			return fmt.Errorf("invalid next URL from the server: %w", err)
 		}
 		offset := uri.Query().Get("offset")
 		// we do not preserve here the size of the page, but since it is used in kumactl

--- a/pkg/plugins/runtime/gateway/builder.go
+++ b/pkg/plugins/runtime/gateway/builder.go
@@ -1,8 +1,9 @@
 package gateway
 
 import (
+	"fmt"
+
 	"github.com/golang/protobuf/proto"
-	"github.com/pkg/errors"
 
 	"github.com/kumahq/kuma/pkg/core/xds"
 	"github.com/kumahq/kuma/pkg/xds/envoy"
@@ -24,7 +25,7 @@ func BuildResourceSet(b ResourceBuilder) (*xds.ResourceSet, error) {
 	}
 
 	if resource.GetName() == "" {
-		return nil, errors.Errorf("anonymous resource %T", resource)
+		return nil, fmt.Errorf("anonymous resource %T", resource)
 	}
 
 	set := xds.NewResourceSet()

--- a/pkg/plugins/runtime/gateway/cluster_generator.go
+++ b/pkg/plugins/runtime/gateway/cluster_generator.go
@@ -2,9 +2,9 @@ package gateway
 
 import (
 	"context"
+	"fmt"
 
 	envoy_cluster_v3 "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
-	"github.com/pkg/errors"
 
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
@@ -104,7 +104,7 @@ func (c *ClusterGenerator) GenerateClusters(ctx xds_context.Context, info Gatewa
 			ctx.Mesh.EndpointMap,
 		)
 		if err != nil {
-			return nil, errors.Wrapf(err, "failed to build LoadAssignment for cluster %q", dest.Name)
+			return nil, fmt.Errorf("failed to build LoadAssignment for cluster %q: %w", dest.Name, err)
 		}
 
 		resources.Add(NewResource(dest.Name, loadAssignment))

--- a/pkg/plugins/runtime/gateway/route/builders.go
+++ b/pkg/plugins/runtime/gateway/route/builders.go
@@ -7,7 +7,6 @@ import (
 
 	envoy_cluster_v3 "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
 	envoy_config_route "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
-	"github.com/pkg/errors"
 
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	util_proto "github.com/kumahq/kuma/pkg/util/proto"
@@ -66,7 +65,7 @@ func (f RouteMustConfigureFunc) Configure(r *envoy_config_route.Route) error {
 func DestinationClusterName(d *Destination, c *envoy_cluster_v3.Cluster) (string, error) {
 	serviceName := d.Destination[mesh_proto.ServiceTag]
 	if serviceName == "" {
-		return "", errors.Errorf("missing %s tag", mesh_proto.ServiceTag)
+		return "", fmt.Errorf("missing %s tag", mesh_proto.ServiceTag)
 	}
 
 	// If cluster is splitting the target service with selector tags,

--- a/pkg/plugins/runtime/gateway/route/configurers.go
+++ b/pkg/plugins/runtime/gateway/route/configurers.go
@@ -1,6 +1,8 @@
 package route
 
 import (
+	"errors"
+	"fmt"
 	"net/http"
 	"strings"
 	"time"
@@ -9,7 +11,6 @@ import (
 	envoy_config_route "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
 	envoy_type_matcher "github.com/envoyproxy/go-control-plane/envoy/type/matcher/v3"
 	"github.com/golang/protobuf/ptypes/any"
-	"github.com/pkg/errors"
 
 	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	util_proto "github.com/kumahq/kuma/pkg/util/proto"
@@ -273,7 +274,7 @@ func RoutePerFilterConfig(filterName string, filterConfig *any.Any) RouteConfigu
 		m := r.GetTypedPerFilterConfig()
 
 		if _, ok := m[filterName]; ok {
-			return errors.Errorf("duplicate %q per-filter config for %s",
+			return fmt.Errorf("duplicate %q per-filter config for %s",
 				filterConfig.GetTypeUrl(), filterName)
 		}
 
@@ -313,7 +314,7 @@ func RouteActionRedirect(redirect *Redirection) RouteConfigurer {
 		case 308:
 			r.GetRedirect().ResponseCode = envoy_config_route.RedirectAction_PERMANENT_REDIRECT
 		default:
-			return errors.Errorf("redirect status code %d is not supported", redirect.Status)
+			return fmt.Errorf("redirect status code %d is not supported", redirect.Status)
 		}
 
 		return nil
@@ -358,7 +359,8 @@ func RouteActionForward(destinations []Destination) RouteConfigurer {
 					WeightedClusters: &envoy_config_route.WeightedCluster{
 						Clusters:    weights,
 						TotalWeight: util_proto.UInt32(total),
-					}},
+					},
+				},
 			},
 		}
 
@@ -539,7 +541,7 @@ func VirtualHostRoute(route *RouteBuilder) envoy_routes.VirtualHostBuilderOpt {
 
 			routeProto, ok := resource.(*envoy_config_route.Route)
 			if !ok {
-				return errors.Errorf("attempt to attach %T as type %q",
+				return fmt.Errorf("attempt to attach %T as type %q",
 					resource, "envoy_config_route.Route")
 			}
 

--- a/pkg/plugins/runtime/k8s/controllers/configmap_controller.go
+++ b/pkg/plugins/runtime/k8s/controllers/configmap_controller.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	"github.com/go-logr/logr"
-	"github.com/pkg/errors"
 	kube_core "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	kube_runtime "k8s.io/apimachinery/pkg/runtime"
@@ -102,7 +101,7 @@ func ServiceToConfigMapsMapper(client kube_client.Reader, l logr.Logger, systemN
 	return func(obj kube_client.Object) []kube_reconile.Request {
 		cause, ok := obj.(*kube_core.Service)
 		if !ok {
-			l.WithValues("dataplane", obj.GetName()).Error(errors.Errorf("wrong argument type: expected %T, got %T", cause, obj), "wrong argument type")
+			l.WithValues("dataplane", obj.GetName()).Error(fmt.Errorf("wrong argument type: expected %T, got %T", cause, obj), "wrong argument type")
 			return nil
 		}
 
@@ -140,7 +139,7 @@ func DataplaneToMeshMapper(l logr.Logger, ns string, resourceConverter k8s_commo
 	return func(obj kube_client.Object) []kube_reconile.Request {
 		cause, ok := obj.(*mesh_k8s.Dataplane)
 		if !ok {
-			l.WithValues("dataplane", obj.GetName()).Error(errors.Errorf("wrong argument type: expected %T, got %T", cause, obj), "wrong argument type")
+			l.WithValues("dataplane", obj.GetName()).Error(fmt.Errorf("wrong argument type: expected %T, got %T", cause, obj), "wrong argument type")
 			return nil
 		}
 
@@ -163,7 +162,7 @@ func MeshGatewayToMeshMapper(client kube_client.Reader, l logr.Logger, ns string
 
 		cause, ok := obj.(*mesh_k8s.MeshGateway)
 		if !ok {
-			l.WithValues("meshgateway", obj.GetName()).Error(errors.Errorf("wrong argument type: expected %T, got %T", cause, obj), "wrong argument type")
+			l.WithValues("meshgateway", obj.GetName()).Error(fmt.Errorf("wrong argument type: expected %T, got %T", cause, obj), "wrong argument type")
 			return nil
 		}
 
@@ -193,7 +192,7 @@ func MeshGatewayRouteToMeshMapper(client kube_client.Reader, l logr.Logger, ns s
 
 		cause, ok := obj.(*mesh_k8s.MeshGatewayRoute)
 		if !ok {
-			l.WithValues("meshgatewayroute", obj.GetName()).Error(errors.Errorf("wrong argument type: expected %T, got %T", cause, obj), "wrong argument type")
+			l.WithValues("meshgatewayroute", obj.GetName()).Error(fmt.Errorf("wrong argument type: expected %T, got %T", cause, obj), "wrong argument type")
 			return nil
 		}
 
@@ -221,7 +220,7 @@ func ZoneIngressToMeshMapper(l logr.Logger, ns string, resourceConverter k8s_com
 	return func(obj kube_client.Object) []kube_reconile.Request {
 		cause, ok := obj.(*mesh_k8s.ZoneIngress)
 		if !ok {
-			l.WithValues("zoneIngress", obj.GetName()).Error(errors.Errorf("wrong argument type: expected %T, got %T", cause, obj), "wrong argument type")
+			l.WithValues("zoneIngress", obj.GetName()).Error(fmt.Errorf("wrong argument type: expected %T, got %T", cause, obj), "wrong argument type")
 			return nil
 		}
 		zoneIngress := core_mesh.NewZoneIngressResource()
@@ -250,7 +249,7 @@ func ExternalServiceToConfigMapsMapper(l logr.Logger, ns string) kube_handler.Ma
 	return func(obj kube_client.Object) []kube_reconile.Request {
 		cause, ok := obj.(*mesh_k8s.ExternalService)
 		if !ok {
-			l.WithValues("externalService", obj.GetName()).Error(errors.Errorf("wrong argument type: expected %T, got %T", cause, obj), "wrong argument type")
+			l.WithValues("externalService", obj.GetName()).Error(fmt.Errorf("wrong argument type: expected %T, got %T", cause, obj), "wrong argument type")
 			return nil
 		}
 
@@ -265,7 +264,7 @@ func VirtualOutboundToConfigMapsMapper(l logr.Logger, ns string) kube_handler.Ma
 	return func(obj kube_client.Object) []kube_reconile.Request {
 		cause, ok := obj.(*mesh_k8s.VirtualOutbound)
 		if !ok {
-			l.WithValues("virtualOutbound", obj.GetName()).Error(errors.Errorf("wrong argument type: expected %T, got %T", cause, obj), "wrong argument type")
+			l.WithValues("virtualOutbound", obj.GetName()).Error(fmt.Errorf("wrong argument type: expected %T, got %T", cause, obj), "wrong argument type")
 			return nil
 		}
 

--- a/pkg/plugins/runtime/k8s/controllers/egress_converter.go
+++ b/pkg/plugins/runtime/k8s/controllers/egress_converter.go
@@ -1,7 +1,8 @@
 package controllers
 
 import (
-	"github.com/pkg/errors"
+	"fmt"
+
 	kube_core "k8s.io/api/core/v1"
 
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
@@ -14,14 +15,14 @@ func (p *PodConverter) EgressFor(
 	services []*kube_core.Service,
 ) error {
 	if len(services) != 1 {
-		return errors.Errorf("egress should be matched by exactly one service. Matched %d services", len(services))
+		return fmt.Errorf("egress should be matched by exactly one service. Matched %d services", len(services))
 	}
 	ifaces, err := InboundInterfacesFor(p.Zone, pod, services)
 	if err != nil {
-		return errors.Wrap(err, "could not generate inbound interfaces")
+		return fmt.Errorf("could not generate inbound interfaces: %w", err)
 	}
 	if len(ifaces) != 1 {
-		return errors.Errorf("generated %d inbound interfaces, expected 1. Interfaces: %v", len(ifaces), ifaces)
+		return fmt.Errorf("generated %d inbound interfaces, expected 1. Interfaces: %v", len(ifaces), ifaces)
 	}
 
 	if zoneEgress.Networking == nil {

--- a/pkg/plugins/runtime/k8s/controllers/gatewayapi/attachment/attachment.go
+++ b/pkg/plugins/runtime/k8s/controllers/gatewayapi/attachment/attachment.go
@@ -2,8 +2,8 @@ package attachment
 
 import (
 	"context"
+	"fmt"
 
-	"github.com/pkg/errors"
 	kube_core "k8s.io/api/core/v1"
 	kube_apierrs "k8s.io/apimachinery/pkg/api/errors"
 	kube_meta "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -53,7 +53,7 @@ func findRouteListenerAttachment(
 			// error
 			selector, err := kube_meta.LabelSelectorAsSelector(ns.Selector)
 			if err != nil {
-				return Unknown, errors.Wrap(err, "internal error: couldn't convert to selector")
+				return Unknown, fmt.Errorf("internal error: couldn't convert to selector: %w", err)
 			}
 
 			if !selector.Matches(kube_labels.Set(routeNs.GetLabels())) {
@@ -154,7 +154,7 @@ func EvaluateParentRefAttachment(
 ) (Attachment, error) {
 	gateway, err := getParentRefGateway(ctx, client, routeNs.GetName(), ref)
 	if err != nil {
-		return Unknown, errors.Wrap(err, "couldn't find Gateway referrent")
+		return Unknown, fmt.Errorf("couldn't find Gateway referrent: %w", err)
 	}
 	if gateway == nil {
 		return Unknown, nil

--- a/pkg/plugins/runtime/k8s/controllers/gatewayapi/common/common.go
+++ b/pkg/plugins/runtime/k8s/controllers/gatewayapi/common/common.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/pkg/errors"
 	kube_apierrs "k8s.io/apimachinery/pkg/api/errors"
 	kube_types "k8s.io/apimachinery/pkg/types"
 	kube_client "sigs.k8s.io/controller-runtime/pkg/client"
@@ -23,6 +22,7 @@ func ServiceTagForGateway(name kube_types.NamespacedName) map[string]string {
 		mesh_proto.ServiceTag: fmt.Sprintf("%s_%s_gateway", name.Name, name.Namespace),
 	}
 }
+
 func GetGatewayClass(ctx context.Context, client kube_client.Client, name gatewayapi.ObjectName) (*gatewayapi.GatewayClass, error) {
 	class := &gatewayapi.GatewayClass{}
 	classObjectKey := kube_types.NamespacedName{Name: string(name)}
@@ -32,7 +32,7 @@ func GetGatewayClass(ctx context.Context, client kube_client.Client, name gatewa
 			return nil, nil
 		}
 
-		return nil, errors.Wrapf(err, "failed to get GatewayClass %s", classObjectKey)
+		return nil, fmt.Errorf("failed to get GatewayClass %s: %w", classObjectKey, err)
 	}
 
 	return class, nil

--- a/pkg/plugins/runtime/k8s/controllers/gatewayapi/common/reconcile.go
+++ b/pkg/plugins/runtime/k8s/controllers/gatewayapi/common/reconcile.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	"github.com/golang/protobuf/proto"
-	"github.com/pkg/errors"
 	kube_apierrs "k8s.io/apimachinery/pkg/api/errors"
 	kube_meta "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kube_types "k8s.io/apimachinery/pkg/types"
@@ -41,7 +40,7 @@ func ReconcileLabelledObject(
 
 	ownedList, err := registry.NewList(ownedType)
 	if err != nil {
-		return errors.Wrapf(err, "could not create list of owned %T", ownedType)
+		return fmt.Errorf("could not create list of owned %T: %w", ownedType, err)
 	}
 
 	if err := client.List(ctx, ownedList, labels); err != nil {
@@ -75,14 +74,14 @@ func ReconcileLabelledObject(
 		existing.SetSpec(ownedSpec)
 
 		if err := client.Update(ctx, existing); err != nil {
-			return errors.Wrapf(err, "could not update owned %T", ownedType)
+			return fmt.Errorf("could not update owned %T: %w", ownedType, err)
 		}
 		return nil
 	}
 
 	owned, err := registry.NewObject(ownedType)
 	if err != nil {
-		return errors.Wrapf(err, "could not get new %T from registry", ownedType)
+		return fmt.Errorf("could not get new %T from registry: %w", ownedType, err)
 	}
 
 	owned.SetMesh(ownerMesh)
@@ -98,7 +97,7 @@ func ReconcileLabelledObject(
 	owned.SetSpec(ownedSpec)
 
 	if err := client.Create(ctx, owned); err != nil {
-		return errors.Wrapf(err, "could not create owned %T", ownedType)
+		return fmt.Errorf("could not create owned %T: %w", ownedType, err)
 	}
 
 	return nil

--- a/pkg/plugins/runtime/k8s/controllers/gatewayapi/gateway_status.go
+++ b/pkg/plugins/runtime/k8s/controllers/gatewayapi/gateway_status.go
@@ -6,7 +6,6 @@ import (
 	"reflect"
 	"strings"
 
-	"github.com/pkg/errors"
 	kube_apierrs "k8s.io/apimachinery/pkg/api/errors"
 	kube_apimeta "k8s.io/apimachinery/pkg/api/meta"
 	kube_meta "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -36,7 +35,7 @@ func (r *GatewayReconciler) updateStatus(
 		if kube_apierrs.IsNotFound(err) {
 			return nil
 		}
-		return errors.Wrap(err, "unable to patch status subresource")
+		return fmt.Errorf("unable to patch status subresource: %w", err)
 	}
 
 	return nil
@@ -96,7 +95,7 @@ func attachedRoutesForListeners(
 	if err := client.List(ctx, &routes, kube_client.MatchingFields{
 		gatewayIndexField: kube_client.ObjectKeyFromObject(gateway).String(),
 	}); err != nil {
-		return nil, errors.Wrap(err, "unexpected error listing HTTPRoutes")
+		return nil, fmt.Errorf("unexpected error listing HTTPRoutes: %w", err)
 	}
 
 	attachedRoutes := AttachedRoutesForListeners{}

--- a/pkg/plugins/runtime/k8s/controllers/gatewayapi/http_route_conversion.go
+++ b/pkg/plugins/runtime/k8s/controllers/gatewayapi/http_route_conversion.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/pkg/errors"
 	kube_core "k8s.io/api/core/v1"
 	kube_apierrs "k8s.io/apimachinery/pkg/api/errors"
 	kube_meta "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -44,7 +43,7 @@ func (r *HTTPRouteReconciler) gapiToKumaRule(
 	for _, match := range rule.Matches {
 		kumaMatch, err := gapiToKumaMatch(match)
 		if err != nil {
-			return mesh_proto.MeshGatewayRoute_HttpRoute_Rule{}, nil, errors.Wrap(err, "couldn't convert match")
+			return mesh_proto.MeshGatewayRoute_HttpRoute_Rule{}, nil, fmt.Errorf("couldn't convert match: %w", err)
 		}
 
 		matches = append(matches, kumaMatch)
@@ -87,7 +86,7 @@ func (r *HTTPRouteReconciler) gapiToKumaRouteConf(
 	for _, rule := range route.Spec.Rules {
 		kumaRule, condition, err := r.gapiToKumaRule(ctx, mesh, route, rule)
 		if err != nil {
-			return nil, nil, errors.Wrap(err, "couldn't convert HTTPRoute to Kuma GatewayRoute")
+			return nil, nil, fmt.Errorf("couldn't convert HTTPRoute to Kuma GatewayRoute: %w", err)
 		}
 		if condition != nil {
 			return nil, []kube_meta.Condition{*condition}, nil
@@ -142,7 +141,7 @@ func (r *HTTPRouteReconciler) gapiToKumaRef(
 	namespacedName := policyRef.NamespacedNameReferredTo()
 
 	if permitted, err := policy.IsReferencePermitted(ctx, r.Client, policyRef); err != nil {
-		return nil, nil, errors.Wrap(err, "couldn't determine if backend reference is permitted")
+		return nil, nil, fmt.Errorf("couldn't determine if backend reference is permitted: %w", err)
 	} else if !permitted {
 		return nil,
 			&kube_meta.Condition{

--- a/pkg/plugins/runtime/k8s/controllers/gatewayapi/http_route_status.go
+++ b/pkg/plugins/runtime/k8s/controllers/gatewayapi/http_route_status.go
@@ -2,9 +2,9 @@ package gatewayapi
 
 import (
 	"context"
+	"fmt"
 	"reflect"
 
-	"github.com/pkg/errors"
 	kube_apierrs "k8s.io/apimachinery/pkg/api/errors"
 	kube_apimeta "k8s.io/apimachinery/pkg/api/meta"
 	kube_client "sigs.k8s.io/controller-runtime/pkg/client"
@@ -21,7 +21,7 @@ func (r *HTTPRouteReconciler) updateStatus(ctx context.Context, route *gatewayap
 		if kube_apierrs.IsNotFound(err) {
 			return nil
 		}
-		return errors.Wrap(err, "unable to update status subresource")
+		return fmt.Errorf("unable to update status subresource: %w", err)
 	}
 
 	return nil

--- a/pkg/plugins/runtime/k8s/controllers/gatewayapi/policy/policy.go
+++ b/pkg/plugins/runtime/k8s/controllers/gatewayapi/policy/policy.go
@@ -2,9 +2,9 @@ package policy
 
 import (
 	"context"
+	"fmt"
 	"reflect"
 
-	"github.com/pkg/errors"
 	kube_schema "k8s.io/apimachinery/pkg/runtime/schema"
 	kube_types "k8s.io/apimachinery/pkg/types"
 	kube_client "sigs.k8s.io/controller-runtime/pkg/client"
@@ -87,7 +87,7 @@ func IsReferencePermitted(
 
 	policies := &gatewayapi.ReferencePolicyList{}
 	if err := client.List(ctx, policies, kube_client.InNamespace(reference.toNamespace)); err != nil {
-		return false, errors.Wrap(err, "failed to list ReferencePolicies")
+		return false, fmt.Errorf("failed to list ReferencePolicies: %w", err)
 	}
 
 	for _, policy := range policies.Items {

--- a/pkg/plugins/runtime/k8s/controllers/gatewayapi/secret_controller.go
+++ b/pkg/plugins/runtime/k8s/controllers/gatewayapi/secret_controller.go
@@ -2,10 +2,10 @@ package gatewayapi
 
 import (
 	"context"
+	"fmt"
 	"reflect"
 
 	"github.com/go-logr/logr"
-	"github.com/pkg/errors"
 	kube_core "k8s.io/api/core/v1"
 	kube_apierrs "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
@@ -38,7 +38,7 @@ func (r *SecretController) Reconcile(ctx context.Context, req kube_ctrl.Request)
 			}
 			return kube_ctrl.Result{}, nil
 		}
-		return kube_ctrl.Result{}, errors.Wrapf(err, "unable to fetch Secret %s", req.NamespacedName.String())
+		return kube_ctrl.Result{}, fmt.Errorf("unable to fetch Secret %s: %w", req.NamespacedName.String(), err)
 	}
 
 	if secret.Type != kube_core.SecretTypeTLS {
@@ -61,7 +61,7 @@ func (r *SecretController) updateCopiedSecret(ctx context.Context, key types.Nam
 			r.Log.V(1).Info("secret was not copied, nothing to update", "key", key.String())
 			return nil
 		}
-		return errors.Wrapf(err, "unable to fetch Secret %s", key.String())
+		return fmt.Errorf("unable to fetch Secret %s: %w", key.String(), err)
 	}
 
 	bytes, err := convertSecret(originalSecret)

--- a/pkg/plugins/runtime/k8s/controllers/gatewayapi/secret_convertion.go
+++ b/pkg/plugins/runtime/k8s/controllers/gatewayapi/secret_convertion.go
@@ -5,7 +5,6 @@ import (
 	"encoding/pem"
 	"fmt"
 
-	"github.com/pkg/errors"
 	"google.golang.org/protobuf/types/known/wrapperspb"
 	kube_core "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -66,7 +65,7 @@ func (r *GatewayReconciler) createSecretIfMissing(
 
 func convertSecret(secret *kube_core.Secret) ([]byte, error) {
 	if secret.Type != kube_core.SecretTypeTLS {
-		return nil, errors.Errorf("only secrets of type %q are supported", secret.Type)
+		return nil, fmt.Errorf("only secrets of type %q are supported", secret.Type)
 	}
 
 	privatePEM := pem.EncodeToMemory(&pem.Block{

--- a/pkg/plugins/runtime/k8s/controllers/inbound_converter.go
+++ b/pkg/plugins/runtime/k8s/controllers/inbound_converter.go
@@ -5,7 +5,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/pkg/errors"
 	kube_core "k8s.io/api/core/v1"
 
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
@@ -127,7 +126,7 @@ func InboundInterfacesFor(zone string, pod *kube_core.Pod, services []*kube_core
 
 	if len(ifaces) == 0 {
 		if len(services) > 0 {
-			return nil, errors.Errorf("A service that selects pod %s was found, but it doesn't match any container ports.", pod.GetName())
+			return nil, fmt.Errorf("A service that selects pod %s was found, but it doesn't match any container ports.", pod.GetName())
 		}
 
 		ifaces = append(ifaces, inboundForServiceless(zone, pod)...)

--- a/pkg/plugins/runtime/k8s/controllers/pod_converter.go
+++ b/pkg/plugins/runtime/k8s/controllers/pod_converter.go
@@ -2,11 +2,11 @@ package controllers
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"regexp"
 	"strings"
 
-	"github.com/pkg/errors"
 	kube_core "k8s.io/api/core/v1"
 	kube_client "sigs.k8s.io/controller-runtime/pkg/client"
 

--- a/pkg/plugins/runtime/k8s/controllers/pod_converter_test.go
+++ b/pkg/plugins/runtime/k8s/controllers/pod_converter_test.go
@@ -2,6 +2,7 @@ package controllers_test
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -9,7 +10,6 @@ import (
 	"github.com/ghodss/yaml"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/pkg/errors"
 	kube_core "k8s.io/api/core/v1"
 	kube_meta "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kube_intstr "k8s.io/apimachinery/pkg/util/intstr"
@@ -26,7 +26,6 @@ import (
 )
 
 var _ = Describe("PodToDataplane(..)", func() {
-
 	pod := `
     metadata:
       namespace: demo
@@ -460,7 +459,6 @@ var _ = Describe("PodToDataplane(..)", func() {
 })
 
 var _ = Describe("InboundTagsForService(..)", func() {
-
 	type testCase struct {
 		isGateway      bool
 		zone           string
@@ -643,7 +641,6 @@ var _ = Describe("InboundTagsForService(..)", func() {
 })
 
 var _ = Describe("MetricsAggregateFor(..)", func() {
-
 	type testCase struct {
 		annotations map[string]string
 		expected    []*mesh_proto.PrometheusAggregateMetricsConfig
@@ -729,7 +726,6 @@ var _ = Describe("MetricsAggregateFor(..)", func() {
 })
 
 var _ = Describe("MetricsAggregateFor(..)", func() {
-
 	type testCase struct {
 		annotations map[string]string
 		expected    string
@@ -767,7 +763,6 @@ var _ = Describe("MetricsAggregateFor(..)", func() {
 })
 
 var _ = Describe("ProtocolTagFor(..)", func() {
-
 	type testCase struct {
 		appProtocol *string
 		annotations map[string]string

--- a/pkg/plugins/runtime/k8s/controllers/pod_status_controller.go
+++ b/pkg/plugins/runtime/k8s/controllers/pod_status_controller.go
@@ -2,9 +2,9 @@ package controllers
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/go-logr/logr"
-	"github.com/pkg/errors"
 	"go.uber.org/multierr"
 	kube_core "k8s.io/api/core/v1"
 	kube_apierrs "k8s.io/apimachinery/pkg/api/errors"
@@ -67,12 +67,12 @@ func (r *PodStatusReconciler) Reconcile(ctx context.Context, req kube_ctrl.Reque
 	var errs error
 	err := r.EnvoyAdminClient.PostQuit(ctx, dp)
 	if err != nil {
-		errs = multierr.Append(errs, errors.Wrapf(err, "envoy admin client failed. Most probably the pod is already going down."))
+		errs = multierr.Append(errs, fmt.Errorf("envoy admin client failed. Most probably the pod is already going down.: %w", err))
 	}
 
 	err = r.Client.Delete(ctx, dataplane)
 	if err != nil {
-		errs = multierr.Append(errs, errors.Wrapf(err, "unable to delete the job's dataplane"))
+		errs = multierr.Append(errs, fmt.Errorf("unable to delete the job's dataplane: %w", err))
 	}
 
 	return kube_ctrl.Result{}, errs

--- a/pkg/plugins/runtime/k8s/controllers/probes.go
+++ b/pkg/plugins/runtime/k8s/controllers/probes.go
@@ -1,7 +1,8 @@
 package controllers
 
 import (
-	"github.com/pkg/errors"
+	"fmt"
+
 	kube_core "k8s.io/api/core/v1"
 
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
@@ -24,7 +25,7 @@ func ProbesFor(pod *kube_core.Pod) (*mesh_proto.Dataplane_Probes, error) {
 		return nil, err
 	}
 	if !exist {
-		return nil, errors.Errorf("%s annotation doesn't exist", metadata.KumaVirtualProbesPortAnnotation)
+		return nil, fmt.Errorf("%s annotation doesn't exist", metadata.KumaVirtualProbesPortAnnotation)
 	}
 
 	dpProbes := &mesh_proto.Dataplane_Probes{
@@ -62,7 +63,7 @@ func ProbesFor(pod *kube_core.Pod) (*mesh_proto.Dataplane_Probes, error) {
 func probeFor(podProbe *kube_core.Probe, port uint32) (*mesh_proto.Dataplane_Probes_Endpoint, error) {
 	inbound, err := probes.KumaProbe(*podProbe).ToReal(port)
 	if err != nil {
-		return nil, errors.Wrap(err, "unable to convert virtual probe to real")
+		return nil, fmt.Errorf("unable to convert virtual probe to real: %w", err)
 	}
 	return &mesh_proto.Dataplane_Probes_Endpoint{
 		InboundPort: inbound.Port(),

--- a/pkg/plugins/runtime/k8s/metadata/annotations.go
+++ b/pkg/plugins/runtime/k8s/metadata/annotations.go
@@ -1,10 +1,9 @@
 package metadata
 
 import (
+	"fmt"
 	"strconv"
 	"strings"
-
-	"github.com/pkg/errors"
 )
 
 // Annotations that can be used by the end users.
@@ -148,7 +147,7 @@ func (a Annotations) GetEnabled(key string) (bool, bool, error) {
 	case AnnotationDisabled, AnnotationFalse:
 		return false, true, nil
 	default:
-		return false, true, errors.Errorf("annotation \"%s\" has wrong value \"%s\"", key, value)
+		return false, true, fmt.Errorf("annotation \"%s\" has wrong value \"%s\"", key, value)
 	}
 }
 
@@ -159,7 +158,7 @@ func (a Annotations) GetUint32(key string) (uint32, bool, error) {
 	}
 	u, err := strconv.ParseUint(value, 10, 32)
 	if err != nil {
-		return 0, true, errors.Errorf("failed to parse annotation %q: %s", key, err.Error())
+		return 0, true, fmt.Errorf("failed to parse annotation %q: %s", key, err.Error())
 	}
 	return uint32(u), true, nil
 }
@@ -184,7 +183,7 @@ func (a Annotations) GetMap(key string) (map[string]string, error) {
 	for _, pair := range pairs {
 		kvSplit := strings.Split(pair, "=")
 		if len(kvSplit) != 2 {
-			return nil, errors.Errorf("invalid format. Map in %q has to be provided in the following format: key1=value1;key2=value2", key)
+			return nil, fmt.Errorf("invalid format. Map in %q has to be provided in the following format: key1=value1;key2=value2", key)
 		}
 		result[kvSplit[0]] = kvSplit[1]
 	}

--- a/pkg/plugins/runtime/k8s/plugin_gateway.go
+++ b/pkg/plugins/runtime/k8s/plugin_gateway.go
@@ -1,10 +1,10 @@
 package k8s
 
 import (
+	"errors"
 	"fmt"
 	"os"
 
-	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	kube_ctrl "sigs.k8s.io/controller-runtime"
 	gatewayapi "sigs.k8s.io/gateway-api/apis/v1alpha2"
@@ -57,7 +57,7 @@ func addGatewayReconcilers(mgr kube_ctrl.Manager, rt core_runtime.Runtime, conve
 	if cfg.CaCertFile != "" {
 		bytes, err := os.ReadFile(cfg.CaCertFile)
 		if err != nil {
-			return errors.Wrapf(err, "could not read provided CA cert file %s", cfg.CaCertFile)
+			return fmt.Errorf("could not read provided CA cert file %s: %w", cfg.CaCertFile, err)
 		}
 		caCert = string(bytes)
 	}
@@ -74,7 +74,7 @@ func addGatewayReconcilers(mgr kube_ctrl.Manager, rt core_runtime.Runtime, conve
 		ResourceManager: rt.ResourceManager(),
 	}
 	if err := gatewayInstanceReconciler.SetupWithManager(mgr); err != nil {
-		return errors.Wrap(err, "could not setup MeshGatewayInstance reconciler")
+		return fmt.Errorf("could not setup MeshGatewayInstance reconciler: %w", err)
 	}
 
 	if rt.Config().Experimental.GatewayAPI {
@@ -97,7 +97,7 @@ func addGatewayAPIReconcillers(mgr kube_ctrl.Manager, rt core_runtime.Runtime, p
 		Log:    core.Log.WithName("controllers").WithName("gatewayapi").WithName("GatewayClass"),
 	}
 	if err := gatewayAPIGatewayClassReconciler.SetupWithManager(mgr); err != nil {
-		return errors.Wrap(err, "could not setup Gateway API GatewayClass reconciler")
+		return fmt.Errorf("could not setup Gateway API GatewayClass reconciler: %w", err)
 	}
 
 	gatewayAPIGatewayReconciler := &gatewayapi_controllers.GatewayReconciler{
@@ -110,7 +110,7 @@ func addGatewayAPIReconcillers(mgr kube_ctrl.Manager, rt core_runtime.Runtime, p
 		ResourceManager: rt.ResourceManager(),
 	}
 	if err := gatewayAPIGatewayReconciler.SetupWithManager(mgr); err != nil {
-		return errors.Wrap(err, "could not setup Gateway API Gateway reconciler")
+		return fmt.Errorf("could not setup Gateway API Gateway reconciler: %w", err)
 	}
 
 	gatewayAPIHTTPRouteReconciler := &gatewayapi_controllers.HTTPRouteReconciler{
@@ -122,7 +122,7 @@ func addGatewayAPIReconcillers(mgr kube_ctrl.Manager, rt core_runtime.Runtime, p
 		ResourceManager: rt.ResourceManager(),
 	}
 	if err := gatewayAPIHTTPRouteReconciler.SetupWithManager(mgr); err != nil {
-		return errors.Wrap(err, "could not setup Gateway API HTTPRoute reconciler")
+		return fmt.Errorf("could not setup Gateway API HTTPRoute reconciler: %w", err)
 	}
 
 	secretController := &gatewayapi_controllers.SecretController{
@@ -131,7 +131,7 @@ func addGatewayAPIReconcillers(mgr kube_ctrl.Manager, rt core_runtime.Runtime, p
 		SystemNamespace: rt.Config().Store.Kubernetes.SystemNamespace,
 	}
 	if err := secretController.SetupWithManager(mgr); err != nil {
-		return errors.Wrap(err, "could not setup Secret reconciler")
+		return fmt.Errorf("could not setup Secret reconciler: %w", err)
 	}
 
 	return nil

--- a/pkg/plugins/runtime/k8s/probes/probe.go
+++ b/pkg/plugins/runtime/k8s/probes/probe.go
@@ -1,11 +1,11 @@
 package probes
 
 import (
+	"errors"
 	"fmt"
 	"strconv"
 	"strings"
 
-	"github.com/pkg/errors"
 	kube_core "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
@@ -25,7 +25,7 @@ type KumaProbe kube_core.Probe
 // then method returns an error
 func (p KumaProbe) ToReal(virtualPort uint32) (KumaProbe, error) {
 	if p.Port() != virtualPort {
-		return KumaProbe{}, errors.Errorf("probe's port %d should be equal to virtual port %d", p.Port(), virtualPort)
+		return KumaProbe{}, fmt.Errorf("probe's port %d should be equal to virtual port %d", p.Port(), virtualPort)
 	}
 	segments := strings.Split(p.Path(), "/")
 	if len(segments) < 2 || segments[0] != "" {
@@ -33,7 +33,7 @@ func (p KumaProbe) ToReal(virtualPort uint32) (KumaProbe, error) {
 	}
 	vport, err := strconv.ParseInt(segments[1], 10, 32)
 	if err != nil {
-		return KumaProbe{}, errors.Errorf("invalid port value %s", segments[1])
+		return KumaProbe{}, fmt.Errorf("invalid port value %s", segments[1])
 	}
 	return KumaProbe{
 		ProbeHandler: kube_core.ProbeHandler{
@@ -47,7 +47,7 @@ func (p KumaProbe) ToReal(virtualPort uint32) (KumaProbe, error) {
 
 func (p KumaProbe) ToVirtual(virtualPort uint32) (KumaProbe, error) {
 	if p.Port() == virtualPort {
-		return KumaProbe{}, errors.Errorf("cannot override Pod's probes. Port for probe cannot "+
+		return KumaProbe{}, fmt.Errorf("cannot override Pod's probes. Port for probe cannot "+
 			"be set to %d. It is reserved for the dataplane that will serve pods without mTLS.", virtualPort)
 	}
 	probePath := p.Path()

--- a/pkg/plugins/runtime/k8s/webhooks/dataplane_validator.go
+++ b/pkg/plugins/runtime/k8s/webhooks/dataplane_validator.go
@@ -2,9 +2,10 @@ package webhooks
 
 import (
 	"context"
+	"errors"
 	"net/http"
 
-	"k8s.io/api/admission/v1"
+	v1 "k8s.io/api/admission/v1"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	"github.com/kumahq/kuma/pkg/core/managers/apis/dataplane"
@@ -63,7 +64,8 @@ func (h *DataplaneValidator) ValidateCreate(ctx context.Context, req admission.R
 	}
 
 	if err := h.validator.ValidateCreate(ctx, core_model.MetaToResourceKey(coreRes.GetMeta()), coreRes, mesh); err != nil {
-		if kumaErr, ok := err.(*validators.ValidationError); ok {
+		var kumaErr *validators.ValidationError
+		if errors.As(err, &kumaErr) {
 			return convertSpecValidationError(kumaErr, k8sRes)
 		}
 		return admission.Denied(err.Error())
@@ -96,7 +98,8 @@ func (h *DataplaneValidator) ValidateUpdate(ctx context.Context, req admission.R
 	}
 
 	if err := h.validator.ValidateUpdate(ctx, coreRes, mesh); err != nil {
-		if kumaErr, ok := err.(*validators.ValidationError); ok {
+		var kumaErr *validators.ValidationError
+		if errors.As(err, &kumaErr) {
 			return convertSpecValidationError(kumaErr, k8sRes)
 		}
 		return admission.Denied(err.Error())

--- a/pkg/plugins/runtime/k8s/webhooks/externalservice_validator.go
+++ b/pkg/plugins/runtime/k8s/webhooks/externalservice_validator.go
@@ -2,9 +2,10 @@ package webhooks
 
 import (
 	"context"
+	"errors"
 	"net/http"
 
-	"k8s.io/api/admission/v1"
+	v1 "k8s.io/api/admission/v1"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	externalservice_managers "github.com/kumahq/kuma/pkg/core/managers/apis/external_service"
@@ -61,7 +62,8 @@ func (h *ExternalServiceValidator) ValidateCreate(ctx context.Context, req admis
 		return admission.Errored(http.StatusInternalServerError, err)
 	}
 	if err := h.validator.ValidateCreate(ctx, k8sRes.Mesh, coreRes); err != nil {
-		if kumaErr, ok := err.(*validators.ValidationError); ok {
+		var kumaErr *validators.ValidationError
+		if errors.As(err, &kumaErr) {
 			return convertSpecValidationError(kumaErr, k8sRes)
 		}
 		return admission.Denied(err.Error())
@@ -89,7 +91,8 @@ func (h *ExternalServiceValidator) ValidateUpdate(ctx context.Context, req admis
 	}
 
 	if err := h.validator.ValidateUpdate(ctx, oldCoreRes, coreRes); err != nil {
-		if kumaErr, ok := err.(*validators.ValidationError); ok {
+		var kumaErr *validators.ValidationError
+		if errors.As(err, &kumaErr) {
 			return convertSpecValidationError(kumaErr, k8sRes)
 		}
 		return admission.Denied(err.Error())

--- a/pkg/plugins/runtime/k8s/webhooks/injector/probes.go
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/probes.go
@@ -1,9 +1,9 @@
 package injector
 
 import (
+	"errors"
 	"fmt"
 
-	"github.com/pkg/errors"
 	kube_core "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 

--- a/pkg/plugins/runtime/k8s/webhooks/mesh_validator.go
+++ b/pkg/plugins/runtime/k8s/webhooks/mesh_validator.go
@@ -2,9 +2,10 @@ package webhooks
 
 import (
 	"context"
+	"errors"
 	"net/http"
 
-	"k8s.io/api/admission/v1"
+	v1 "k8s.io/api/admission/v1"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	managers_mesh "github.com/kumahq/kuma/pkg/core/managers/apis/mesh"
@@ -69,7 +70,8 @@ func (h *MeshValidator) ValidateCreate(ctx context.Context, req admission.Reques
 		return admission.Errored(http.StatusInternalServerError, err)
 	}
 	if err := h.validator.ValidateCreate(ctx, req.Name, coreRes); err != nil {
-		if kumaErr, ok := err.(*validators.ValidationError); ok {
+		var kumaErr *validators.ValidationError
+		if errors.As(err, &kumaErr) {
 			return convertSpecValidationError(kumaErr, k8sRes)
 		}
 		return admission.Denied(err.Error())
@@ -97,7 +99,8 @@ func (h *MeshValidator) ValidateUpdate(ctx context.Context, req admission.Reques
 	}
 
 	if err := h.validator.ValidateUpdate(ctx, oldCoreRes, coreRes); err != nil {
-		if kumaErr, ok := err.(*validators.ValidationError); ok {
+		var kumaErr *validators.ValidationError
+		if errors.As(err, &kumaErr) {
 			return convertSpecValidationError(kumaErr, k8sRes)
 		}
 		return admission.Denied(err.Error())

--- a/pkg/plugins/runtime/k8s/webhooks/ratelimit_validator.go
+++ b/pkg/plugins/runtime/k8s/webhooks/ratelimit_validator.go
@@ -2,9 +2,10 @@ package webhooks
 
 import (
 	"context"
+	"errors"
 	"net/http"
 
-	"k8s.io/api/admission/v1"
+	v1 "k8s.io/api/admission/v1"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	ratelimit_managers "github.com/kumahq/kuma/pkg/core/managers/apis/ratelimit"
@@ -61,7 +62,8 @@ func (h *RateLimitValidator) ValidateCreate(ctx context.Context, req admission.R
 		return admission.Errored(http.StatusInternalServerError, err)
 	}
 	if err := h.validator.ValidateCreate(ctx, k8sRes.Mesh, coreRes); err != nil {
-		if kumaErr, ok := err.(*validators.ValidationError); ok {
+		var kumaErr *validators.ValidationError
+		if errors.As(err, &kumaErr) {
 			return convertSpecValidationError(kumaErr, k8sRes)
 		}
 		return admission.Denied(err.Error())
@@ -89,7 +91,8 @@ func (h *RateLimitValidator) ValidateUpdate(ctx context.Context, req admission.R
 	}
 
 	if err := h.validator.ValidateUpdate(ctx, oldCoreRes, coreRes); err != nil {
-		if kumaErr, ok := err.(*validators.ValidationError); ok {
+		var kumaErr *validators.ValidationError
+		if errors.As(err, &kumaErr) {
 			return convertSpecValidationError(kumaErr, k8sRes)
 		}
 		return admission.Denied(err.Error())

--- a/pkg/plugins/runtime/k8s/webhooks/service_validator.go
+++ b/pkg/plugins/runtime/k8s/webhooks/service_validator.go
@@ -2,6 +2,7 @@ package webhooks
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 
@@ -27,7 +28,8 @@ func (v *ServiceValidator) Handle(ctx context.Context, req admission.Request) ad
 	}
 
 	if err := v.validate(svc); err != nil {
-		if verr, ok := err.(*validators.ValidationError); ok {
+		var verr *validators.ValidationError
+		if errors.As(err, &verr) {
 			return convertValidationErrorOf(*verr, svc, svc)
 		}
 		return admission.Denied(err.Error())

--- a/pkg/plugins/runtime/k8s/webhooks/validation.go
+++ b/pkg/plugins/runtime/k8s/webhooks/validation.go
@@ -2,6 +2,7 @@ package webhooks
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"strings"
@@ -79,7 +80,8 @@ func (h *validatingHandler) Handle(ctx context.Context, req admission.Request) a
 		}
 
 		if err := coreRes.Validate(); err != nil {
-			if kumaErr, ok := err.(*validators.ValidationError); ok {
+			var kumaErr *validators.ValidationError
+			if errors.As(err, &kumaErr) {
 				// we assume that coreRes.Validate() returns validation errors of the spec
 				return convertSpecValidationError(kumaErr, k8sObj)
 			}

--- a/pkg/plugins/secrets/k8s/plugin.go
+++ b/pkg/plugins/secrets/k8s/plugin.go
@@ -1,7 +1,7 @@
 package k8s
 
 import (
-	"github.com/pkg/errors"
+	"fmt"
 
 	core_plugins "github.com/kumahq/kuma/pkg/core/plugins"
 	secret_store "github.com/kumahq/kuma/pkg/core/secrets/store"
@@ -19,7 +19,7 @@ func init() {
 func (p *plugin) NewSecretStore(pc core_plugins.PluginContext, _ core_plugins.PluginConfig) (secret_store.SecretStore, error) {
 	client, ok := k8s_extensions.FromSecretClientContext(pc.Extensions())
 	if !ok {
-		return nil, errors.Errorf("secret client hasn't been configured")
+		return nil, fmt.Errorf("secret client hasn't been configured")
 	}
 	return NewStore(client, client, pc.Config().Store.Kubernetes.SystemNamespace)
 }

--- a/pkg/test/matchers/golden.go
+++ b/pkg/test/matchers/golden.go
@@ -1,12 +1,12 @@
 package matchers
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 
 	"github.com/onsi/gomega"
 	"github.com/onsi/gomega/types"
-	"github.com/pkg/errors"
 
 	"github.com/kumahq/kuma/pkg/test/golden"
 )
@@ -59,14 +59,14 @@ func (g *GoldenYAMLMatcher) Match(actual interface{}) (success bool, err error) 
 		if len(actualContent) > 0 && actualContent[len(actualContent)-1] != '\n' {
 			actualContent += "\n"
 		}
-		err := os.WriteFile(g.GoldenFilePath, []byte(actualContent), 0644)
+		err := os.WriteFile(g.GoldenFilePath, []byte(actualContent), 0o644)
 		if err != nil {
-			return false, errors.Wrap(err, "could not update golden file")
+			return false, fmt.Errorf("could not update golden file: %w", err)
 		}
 	}
 	expected, err := os.ReadFile(g.GoldenFilePath)
 	if err != nil {
-		return false, errors.Wrap(err, "could not read golden file")
+		return false, fmt.Errorf("could not read golden file: %w", err)
 	}
 
 	// Generate a new instance of the matcher for this match. Since
@@ -100,6 +100,6 @@ func (g *GoldenYAMLMatcher) actualString(actual interface{}) (string, error) {
 	case string:
 		return actual, nil
 	default:
-		return "", errors.Errorf("not supported type %T for MatchGolden", actual)
+		return "", fmt.Errorf("not supported type %T for MatchGolden", actual)
 	}
 }

--- a/pkg/test/matchers/proto.go
+++ b/pkg/test/matchers/proto.go
@@ -1,10 +1,12 @@
 package matchers
 
 import (
+	"errors"
+	"fmt"
+
 	"github.com/golang/protobuf/proto"
 	"github.com/onsi/gomega/format"
 	"github.com/onsi/gomega/types"
-	"github.com/pkg/errors"
 
 	util_proto "github.com/kumahq/kuma/pkg/util/proto"
 )
@@ -55,13 +57,13 @@ func (p *ProtoMatcher) yamls(actual interface{}) (string, string, error) {
 	actualProto := actual.(proto.Message)
 	actualYAML, err := util_proto.ToYAML(actualProto)
 	if err != nil {
-		return "", "", errors.Errorf("Proto are not equal (could not convert to YAML: %s)", err)
+		return "", "", fmt.Errorf("Proto are not equal (could not convert to YAML: %s)", err)
 	}
 
 	expectedProto := p.Expected.(proto.Message)
 	expectedYAML, err := util_proto.ToYAML(expectedProto)
 	if err != nil {
-		return "", "", errors.Errorf("Proto are not equal (could not convert to YAML: %s)", err)
+		return "", "", fmt.Errorf("Proto are not equal (could not convert to YAML: %s)", err)
 	}
 	return string(actualYAML), string(expectedYAML), nil
 }

--- a/pkg/test/resources/apis/sample/sample_types.go
+++ b/pkg/test/resources/apis/sample/sample_types.go
@@ -1,7 +1,7 @@
 package sample
 
 import (
-	"github.com/pkg/errors"
+	"errors"
 
 	"github.com/kumahq/kuma/pkg/core/resources/model"
 	"github.com/kumahq/kuma/pkg/core/resources/registry"

--- a/pkg/test/runtime/runtime.go
+++ b/pkg/test/runtime/runtime.go
@@ -2,11 +2,10 @@ package runtime
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"time"
-
-	"github.com/pkg/errors"
 
 	"github.com/kumahq/kuma/pkg/api-server/customization"
 	kuma_cp "github.com/kumahq/kuma/pkg/config/app/kuma-cp"

--- a/pkg/test/xds/client/stream/client.go
+++ b/pkg/test/xds/client/stream/client.go
@@ -10,7 +10,6 @@ import (
 	envoy "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	envoy_core "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
 	envoy_discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v2"
-	"github.com/pkg/errors"
 	"google.golang.org/genproto/googleapis/rpc/status"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
@@ -46,7 +45,7 @@ func New(serverURL string) (*Client, error) {
 			InsecureSkipVerify: true, // it's acceptable since we don't pass any secrets to the server
 		})))
 	default:
-		return nil, errors.Errorf("unsupported scheme %q. Use one of %s", url.Scheme, []string{"grpc", "grpcs"})
+		return nil, fmt.Errorf("unsupported scheme %q. Use one of %s", url.Scheme, []string{"grpc", "grpcs"})
 	}
 	conn, err := grpc.Dial(url.Host, dialOpts...)
 	if err != nil {

--- a/pkg/tls/keypair.go
+++ b/pkg/tls/keypair.go
@@ -7,8 +7,7 @@ import (
 	"crypto/rsa"
 	"crypto/x509"
 	"encoding/pem"
-
-	"github.com/pkg/errors"
+	"fmt"
 )
 
 type KeyPair struct {
@@ -19,11 +18,11 @@ type KeyPair struct {
 func ToKeyPair(key crypto.PrivateKey, cert []byte) (*KeyPair, error) {
 	keyPem, err := pemEncodeKey(key)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to PEM encode a private key")
+		return nil, fmt.Errorf("failed to PEM encode a private key: %w", err)
 	}
 	certPem, err := pemEncodeCert(cert)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to PEM encode a certificate")
+		return nil, fmt.Errorf("failed to PEM encode a certificate: %w", err)
 	}
 	return &KeyPair{
 		CertPEM: certPem,
@@ -43,7 +42,7 @@ func pemEncodeKey(priv crypto.PrivateKey) ([]byte, error) {
 	case *rsa.PrivateKey:
 		block = &pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(k)}
 	default:
-		return nil, errors.Errorf("unsupported private key type %T", priv)
+		return nil, fmt.Errorf("unsupported private key type %T", priv)
 	}
 	var keyBuf bytes.Buffer
 	if err := pem.Encode(&keyBuf, block); err != nil {

--- a/pkg/tls/verify_only_ca.go
+++ b/pkg/tls/verify_only_ca.go
@@ -2,9 +2,8 @@ package tls
 
 import (
 	"crypto/x509"
+	"fmt"
 	"time"
-
-	"github.com/pkg/errors"
 )
 
 func VerifyOnlyCA(caPool *x509.CertPool) func([][]byte, [][]*x509.Certificate) error {
@@ -19,7 +18,7 @@ func VerifyOnlyCA(caPool *x509.CertPool) func([][]byte, [][]*x509.Certificate) e
 		for i, asn1Data := range rawCerts {
 			cert, err := x509.ParseCertificate(asn1Data)
 			if err != nil {
-				return errors.Wrap(err, "tls: failed to parse certificate from server")
+				return fmt.Errorf("tls: failed to parse certificate from server: %w", err)
 			}
 			certs[i] = cert
 		}

--- a/pkg/tokens/builtin/zone/token.go
+++ b/pkg/tokens/builtin/zone/token.go
@@ -1,15 +1,18 @@
 package zone
 
 import (
+	"errors"
+
 	"github.com/golang-jwt/jwt/v4"
-	"github.com/pkg/errors"
 
 	core_model "github.com/kumahq/kuma/pkg/core/resources/model"
 	core_tokens "github.com/kumahq/kuma/pkg/core/tokens"
 )
 
-const SigningKeyPrefix = "zone-token-signing-key"
-const SigningPublicKeyPrefix = "zone-token-signing-public-key"
+const (
+	SigningKeyPrefix       = "zone-token-signing-key"
+	SigningPublicKeyPrefix = "zone-token-signing-public-key"
+)
 
 var TokenRevocationsGlobalSecretKey = core_model.ResourceKey{
 	Name: "zone-token-revocations",

--- a/pkg/transparentproxy/istio/istio.go
+++ b/pkg/transparentproxy/istio/istio.go
@@ -1,9 +1,9 @@
 package istio
 
 import (
+	"fmt"
 	"os"
 
-	"github.com/pkg/errors"
 	"github.com/spf13/viper"
 
 	"github.com/kumahq/kuma/pkg/transparentproxy/istio/config"
@@ -59,7 +59,7 @@ func (tp *IstioTransparentProxy) Setup(cfg *config.TransparentProxyConfig) (stri
 	}()
 
 	if err := install.GetCommand().Execute(); err != nil {
-		return tp.getStdOutStdErr(), errors.Wrapf(err, "setting istio")
+		return tp.getStdOutStdErr(), fmt.Errorf("setting istio: %w", err)
 	}
 
 	return tp.getStdOutStdErr(), nil
@@ -83,7 +83,7 @@ func (tp *IstioTransparentProxy) Cleanup(dryRun, verbose bool) (string, error) {
 	}()
 
 	if err := uninstall.GetCommand().Execute(); err != nil {
-		return tp.getStdOutStdErr(), errors.Wrapf(err, "setting istio")
+		return tp.getStdOutStdErr(), fmt.Errorf("setting istio: %w", err)
 	}
 
 	return tp.getStdOutStdErr(), nil
@@ -91,7 +91,6 @@ func (tp *IstioTransparentProxy) Cleanup(dryRun, verbose bool) (string, error) {
 
 func (tp *IstioTransparentProxy) redirectStdOutStdErr() {
 	reader, writer, err := os.Pipe()
-
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/util/files/lookup_binary.go
+++ b/pkg/util/files/lookup_binary.go
@@ -1,11 +1,10 @@
 package files
 
 import (
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
-
-	"github.com/pkg/errors"
 )
 
 type LookupPathFn = func() (string, error)
@@ -56,5 +55,5 @@ func LookupBinaryPath(pathFns ...LookupPathFn) (string, error) {
 		}
 	}
 
-	return "", errors.Errorf("could not find binary in any of the following paths: %v", candidatePaths)
+	return "", fmt.Errorf("could not find binary in any of the following paths: %v", candidatePaths)
 }

--- a/pkg/util/http/tls.go
+++ b/pkg/util/http/tls.go
@@ -3,10 +3,10 @@ package http
 import (
 	"crypto/tls"
 	"crypto/x509"
+	"errors"
+	"fmt"
 	"net/http"
 	"os"
-
-	"github.com/pkg/errors"
 )
 
 func ConfigureMTLS(httpClient *http.Client, caCert string, clientCert string, clientKey string) error {
@@ -19,7 +19,7 @@ func ConfigureMTLS(httpClient *http.Client, caCert string, clientCert string, cl
 	} else {
 		certBytes, err := os.ReadFile(caCert)
 		if err != nil {
-			return errors.Wrap(err, "could not read CA cert")
+			return fmt.Errorf("could not read CA cert: %w", err)
 		}
 		certPool := x509.NewCertPool()
 		if ok := certPool.AppendCertsFromPEM(certBytes); !ok {
@@ -31,7 +31,7 @@ func ConfigureMTLS(httpClient *http.Client, caCert string, clientCert string, cl
 	if clientKey != "" && clientCert != "" {
 		cert, err := tls.LoadX509KeyPair(clientCert, clientKey)
 		if err != nil {
-			return errors.Wrap(err, "could not create key pair from client cert and client key")
+			return fmt.Errorf("could not create key pair from client cert and client key: %w", err)
 		}
 		transport.TLSClientConfig.Certificates = []tls.Certificate{cert}
 	}

--- a/pkg/util/k8s/name_converter.go
+++ b/pkg/util/k8s/name_converter.go
@@ -1,16 +1,15 @@
 package k8s
 
 import (
+	"errors"
 	"fmt"
 	"strings"
-
-	"github.com/pkg/errors"
 )
 
 func CoreNameToK8sName(coreName string) (string, string, error) {
 	idx := strings.LastIndex(coreName, ".")
 	if idx == -1 {
-		return "", "", errors.Errorf(`name %q must include namespace after the dot, ex. "name.namespace"`, coreName)
+		return "", "", fmt.Errorf(`name %q must include namespace after the dot, ex. "name.namespace"`, coreName)
 	}
 	// namespace cannot contain "." therefore it's always the last part
 	namespace := coreName[idx+1:]

--- a/pkg/util/net/ips.go
+++ b/pkg/util/net/ips.go
@@ -4,15 +4,13 @@ import (
 	"fmt"
 	"net"
 	"sort"
-
-	"github.com/pkg/errors"
 )
 
 // GetAllIPs returns all IPs (IPv4 and IPv6) from the all network interfaces on the machine
 func GetAllIPs() ([]string, error) {
 	addrs, err := net.InterfaceAddrs()
 	if err != nil {
-		return nil, errors.Wrap(err, "could not list network interfaces")
+		return nil, fmt.Errorf("could not list network interfaces: %w", err)
 	}
 	var result []string
 	for _, address := range addrs {

--- a/pkg/util/os/fs.go
+++ b/pkg/util/os/fs.go
@@ -1,26 +1,25 @@
 package os
 
 import (
+	"fmt"
 	"os"
-
-	"github.com/pkg/errors"
 )
 
 func TryWriteToDir(dir string) error {
 	file, err := os.CreateTemp(dir, "write-access-check")
 	if err != nil {
 		if os.IsNotExist(err) {
-			if err := os.MkdirAll(dir, os.ModeDir|0755); err != nil {
-				return errors.Wrapf(err, "unable to create a directory %q", dir)
+			if err := os.MkdirAll(dir, os.ModeDir|0o755); err != nil {
+				return fmt.Errorf("unable to create a directory %q: %w", dir, err)
 			}
 			file, err = os.CreateTemp(dir, "write-access-check")
 		}
 		if err != nil {
-			return errors.Wrapf(err, "unable to create temporary files in directory %q", dir)
+			return fmt.Errorf("unable to create temporary files in directory %q: %w", dir, err)
 		}
 	}
 	if err := os.Remove(file.Name()); err != nil {
-		return errors.Wrapf(err, "unable to remove temporary files in directory %q", dir)
+		return fmt.Errorf("unable to remove temporary files in directory %q: %w", dir, err)
 	}
 	return nil
 }

--- a/pkg/util/proto/any.go
+++ b/pkg/util/proto/any.go
@@ -1,12 +1,12 @@
 package proto
 
 import (
+	"fmt"
 	"reflect"
 	"strings"
 
 	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/ptypes/any"
-	"github.com/pkg/errors"
 	proto2 "google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/anypb"
 )
@@ -53,7 +53,7 @@ func MergeAnys(dst *any.Any, src *any.Any) (*any.Any, error) {
 		return src, nil
 	}
 	if src.TypeUrl != dst.TypeUrl {
-		return nil, errors.Errorf("type URL of dst %q is different than src %q", dst.TypeUrl, src.TypeUrl)
+		return nil, fmt.Errorf("type URL of dst %q is different than src %q", dst.TypeUrl, src.TypeUrl)
 	}
 
 	msgTypeName := strings.ReplaceAll(dst.TypeUrl, googleApis, "") // TypeURL in Any contains type.googleapis.com/ prefix, but in Proto registry it does not have this prefix.

--- a/pkg/util/rsa/pem.go
+++ b/pkg/util/rsa/pem.go
@@ -5,12 +5,13 @@ import (
 	"crypto/rsa"
 	"crypto/x509"
 	"encoding/pem"
-
-	"github.com/pkg/errors"
+	"fmt"
 )
 
-const rsaPrivateBlockType = "RSA PRIVATE KEY"
-const rsaPublicBlockType = "RSA PUBLIC KEY"
+const (
+	rsaPrivateBlockType = "RSA PRIVATE KEY"
+	rsaPublicBlockType  = "RSA PUBLIC KEY"
+)
 
 func FromPrivateKeyToPEMBytes(key *rsa.PrivateKey) ([]byte, error) {
 	block := pem.Block{
@@ -48,7 +49,7 @@ func FromPrivateKeyPEMBytesToPublicKeyPEMBytes(b []byte) ([]byte, error) {
 func FromPEMBytesToPrivateKey(b []byte) (*rsa.PrivateKey, error) {
 	block, _ := pem.Decode(b)
 	if block.Type != rsaPrivateBlockType {
-		return nil, errors.Errorf("invalid key encoding %q", block.Type)
+		return nil, fmt.Errorf("invalid key encoding %q", block.Type)
 	}
 	return x509.ParsePKCS1PrivateKey(block.Bytes)
 }
@@ -56,7 +57,7 @@ func FromPEMBytesToPrivateKey(b []byte) (*rsa.PrivateKey, error) {
 func FromPEMBytesToPublicKey(b []byte) (*rsa.PublicKey, error) {
 	block, _ := pem.Decode(b)
 	if block.Type != rsaPublicBlockType {
-		return nil, errors.Errorf("invalid key encoding %q", block.Type)
+		return nil, fmt.Errorf("invalid key encoding %q", block.Type)
 	}
 	return x509.ParsePKCS1PublicKey(block.Bytes)
 }

--- a/pkg/xds/auth/callbacks_test.go
+++ b/pkg/xds/auth/callbacks_test.go
@@ -2,13 +2,14 @@ package auth_test
 
 import (
 	"context"
+	"errors"
+	"fmt"
 
 	envoy_core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	envoy_sd "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
 	envoy_server "github.com/envoyproxy/go-control-plane/pkg/server/v3"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/pkg/errors"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/protobuf/types/known/structpb"
 
@@ -49,14 +50,13 @@ func (t *testAuthenticator) Authenticate(_ context.Context, resource core_model.
 			return nil
 		}
 	default:
-		return errors.Errorf("no matching authenticator for %s resource", resource.Descriptor().Name)
+		return fmt.Errorf("no matching authenticator for %s resource", resource.Descriptor().Name)
 	}
 
 	return errors.New("invalid credential")
 }
 
 var _ = Describe("Auth Callbacks", func() {
-
 	var testAuth *testAuthenticator
 	var resManager core_manager.ResourceManager
 	var callbacks envoy_server.Callbacks

--- a/pkg/xds/auth/components/components.go
+++ b/pkg/xds/auth/components/components.go
@@ -1,7 +1,7 @@
 package components
 
 import (
-	"github.com/pkg/errors"
+	"fmt"
 
 	dp_server "github.com/kumahq/kuma/pkg/config/dp-server"
 	core_runtime "github.com/kumahq/kuma/pkg/core/runtime"
@@ -15,7 +15,7 @@ import (
 func NewKubeAuthenticator(rt core_runtime.Runtime) (auth.Authenticator, error) {
 	mgr, ok := k8s_extensions.FromManagerContext(rt.Extensions())
 	if !ok {
-		return nil, errors.Errorf("k8s controller runtime Manager hasn't been configured")
+		return nil, fmt.Errorf("k8s controller runtime Manager hasn't been configured")
 	}
 	return k8s_auth.New(mgr.GetClient()), nil
 }
@@ -39,6 +39,6 @@ func DefaultAuthenticator(rt core_runtime.Runtime) (auth.Authenticator, error) {
 	case dp_server.DpServerAuthNone:
 		return universal_auth.NewNoopAuthenticator(), nil
 	default:
-		return nil, errors.Errorf("unable to choose authenticator of %q", rt.Config().DpServer.Auth.Type)
+		return nil, fmt.Errorf("unable to choose authenticator of %q", rt.Config().DpServer.Auth.Type)
 	}
 }

--- a/pkg/xds/auth/universal/authenticator.go
+++ b/pkg/xds/auth/universal/authenticator.go
@@ -2,8 +2,7 @@ package universal
 
 import (
 	"context"
-
-	"github.com/pkg/errors"
+	"fmt"
 
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
@@ -50,7 +49,7 @@ func (u *universalAuthenticator) Authenticate(ctx context.Context, resource mode
 	case *core_mesh.ZoneEgressResource:
 		return u.authZoneEgress(ctx, credential)
 	default:
-		return errors.Errorf("no matching authenticator for %s resource", resource.Descriptor().Name)
+		return fmt.Errorf("no matching authenticator for %s resource", resource.Descriptor().Name)
 	}
 }
 
@@ -61,10 +60,10 @@ func (u *universalAuthenticator) authDataplane(ctx context.Context, dataplane *c
 	}
 
 	if dpIdentity.Name != "" && dataplane.Meta.GetName() != dpIdentity.Name {
-		return errors.Errorf("proxy name from requestor: %s is different than in token: %s", dataplane.Meta.GetName(), dpIdentity.Name)
+		return fmt.Errorf("proxy name from requestor: %s is different than in token: %s", dataplane.Meta.GetName(), dpIdentity.Name)
 	}
 	if dpIdentity.Mesh != "" && dataplane.Meta.GetMesh() != dpIdentity.Mesh {
-		return errors.Errorf("proxy mesh from requestor: %s is different than in token: %s", dataplane.Meta.GetMesh(), dpIdentity.Mesh)
+		return fmt.Errorf("proxy mesh from requestor: %s is different than in token: %s", dataplane.Meta.GetMesh(), dpIdentity.Mesh)
 	}
 	if err := validateTags(dpIdentity.Tags, dataplane.Spec.TagSet()); err != nil {
 		return err
@@ -78,7 +77,7 @@ func (u *universalAuthenticator) authZoneIngress(ctx context.Context, credential
 		return err
 	}
 	if u.zone != identity.Zone {
-		return errors.Errorf("zone ingress zone from requestor: %s is different than in token: %s", u.zone, identity.Zone)
+		return fmt.Errorf("zone ingress zone from requestor: %s is different than in token: %s", u.zone, identity.Zone)
 	}
 
 	return nil
@@ -94,7 +93,7 @@ func (u *universalAuthenticator) authZoneEgress(
 	}
 
 	if !zone.InScope(identity.Scope, zone.EgressScope) {
-		return errors.Errorf(
+		return fmt.Errorf(
 			"token cannot be used to authenticate zone egresses (%s is out of token's scope: %+v)",
 			zone.EgressScope,
 			identity.Scope,
@@ -102,7 +101,7 @@ func (u *universalAuthenticator) authZoneEgress(
 	}
 
 	if identity.Zone != "" && u.zone != identity.Zone {
-		return errors.Errorf("zone egress zone from requestor: %s is different than in token: %s", u.zone, identity.Zone)
+		return fmt.Errorf("zone egress zone from requestor: %s is different than in token: %s", u.zone, identity.Zone)
 	}
 
 	return nil
@@ -112,11 +111,11 @@ func validateTags(tokenTags mesh_proto.MultiValueTagSet, dpTags mesh_proto.Multi
 	for tagName, allowedValues := range tokenTags {
 		dpValues, exist := dpTags[tagName]
 		if !exist {
-			return errors.Errorf("dataplane has no tag %q required by the token", tagName)
+			return fmt.Errorf("dataplane has no tag %q required by the token", tagName)
 		}
 		for value := range dpValues {
 			if !allowedValues[value] {
-				return errors.Errorf("dataplane contains tag %q with value %q which is not allowed with this token. Allowed values in token are %q", tagName, value, tokenTags.Values(tagName))
+				return fmt.Errorf("dataplane contains tag %q with value %q which is not allowed with this token. Allowed values in token are %q", tagName, value, tokenTags.Values(tagName))
 			}
 		}
 	}

--- a/pkg/xds/auth/universal/noop_authenticator.go
+++ b/pkg/xds/auth/universal/noop_authenticator.go
@@ -2,8 +2,7 @@ package universal
 
 import (
 	"context"
-
-	"github.com/pkg/errors"
+	"fmt"
 
 	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	"github.com/kumahq/kuma/pkg/core/resources/model"
@@ -14,8 +13,7 @@ func NewNoopAuthenticator() auth.Authenticator {
 	return &noopAuthenticator{}
 }
 
-type noopAuthenticator struct {
-}
+type noopAuthenticator struct{}
 
 var _ auth.Authenticator = &noopAuthenticator{}
 
@@ -28,6 +26,6 @@ func (u *noopAuthenticator) Authenticate(ctx context.Context, resource model.Res
 	case *core_mesh.ZoneEgressResource:
 		return nil
 	default:
-		return errors.Errorf("no matching authenticator for %s resource", resource.Descriptor().Name)
+		return fmt.Errorf("no matching authenticator for %s resource", resource.Descriptor().Name)
 	}
 }

--- a/pkg/xds/bootstrap/handler.go
+++ b/pkg/xds/bootstrap/handler.go
@@ -2,6 +2,7 @@ package bootstrap
 
 import (
 	"encoding/json"
+	"errors"
 	"io"
 	"net"
 	"net/http"
@@ -87,7 +88,7 @@ func (b *BootstrapHandler) Handle(resp http.ResponseWriter, req *http.Request) {
 }
 
 func handleError(resp http.ResponseWriter, err error, logger logr.Logger) {
-	if err == DpTokenRequired || store.IsResourcePreconditionFailed(err) || validators.IsValidationError(err) {
+	if errors.Is(err, DpTokenRequired) || store.IsResourcePreconditionFailed(err) || validators.IsValidationError(err) {
 		resp.WriteHeader(http.StatusUnprocessableEntity)
 		_, err = resp.Write([]byte(err.Error()))
 		if err != nil {
@@ -95,7 +96,7 @@ func handleError(resp http.ResponseWriter, err error, logger logr.Logger) {
 		}
 		return
 	}
-	if ISSANMismatchErr(err) || err == NotCA {
+	if ISSANMismatchErr(err) || errors.Is(err, NotCA) {
 		resp.WriteHeader(http.StatusBadRequest)
 		if _, err := resp.Write([]byte(err.Error())); err != nil {
 			logger.Error(err, "Error while writing the response")

--- a/pkg/xds/components.go
+++ b/pkg/xds/components.go
@@ -1,7 +1,7 @@
 package xds
 
 import (
-	"github.com/pkg/errors"
+	"fmt"
 
 	config_core "github.com/kumahq/kuma/pkg/config/core"
 	core_runtime "github.com/kumahq/kuma/pkg/core/runtime"
@@ -14,10 +14,10 @@ func Setup(rt core_runtime.Runtime) error {
 		return nil
 	}
 	if err := server.RegisterXDS(rt); err != nil {
-		return errors.Wrap(err, "could not register XDS")
+		return fmt.Errorf("could not register XDS: %w", err)
 	}
 	if err := bootstrap.RegisterBootstrap(rt); err != nil {
-		return errors.Wrap(err, "could not register Bootstrap")
+		return fmt.Errorf("could not register Bootstrap: %w", err)
 	}
 	return nil
 }

--- a/pkg/xds/envoy/clusters/v3/endpoint_cluster_configurer.go
+++ b/pkg/xds/envoy/clusters/v3/endpoint_cluster_configurer.go
@@ -1,10 +1,10 @@
 package clusters
 
 import (
+	"errors"
 	"net"
 
 	envoy_cluster "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
-	"github.com/pkg/errors"
 
 	"github.com/kumahq/kuma/pkg/core/xds"
 	envoy_endpoints "github.com/kumahq/kuma/pkg/xds/envoy/endpoints/v3"

--- a/pkg/xds/envoy/clusters/v3/health_check_configurer.go
+++ b/pkg/xds/envoy/clusters/v3/health_check_configurer.go
@@ -2,11 +2,11 @@ package clusters
 
 import (
 	"encoding/hex"
+	"errors"
 
 	envoy_cluster "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
 	envoy_core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	envoy_type "github.com/envoyproxy/go-control-plane/envoy/type/v3"
-	"github.com/pkg/errors"
 	"google.golang.org/protobuf/types/known/wrapperspb"
 
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"

--- a/pkg/xds/envoy/clusters/v3/lb_configurer.go
+++ b/pkg/xds/envoy/clusters/v3/lb_configurer.go
@@ -1,10 +1,10 @@
 package clusters
 
 import (
+	"errors"
 	"fmt"
 
 	envoy_cluster "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
-	"github.com/pkg/errors"
 
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	util_proto "github.com/kumahq/kuma/pkg/util/proto"

--- a/pkg/xds/envoy/listeners/filter_chain_builder.go
+++ b/pkg/xds/envoy/listeners/filter_chain_builder.go
@@ -1,10 +1,11 @@
 package listeners
 
 import (
+	"errors"
+
 	envoy_listener_v3 "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
 	envoy_hcm "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
 	envoy_types "github.com/envoyproxy/go-control-plane/pkg/cache/types"
-	"github.com/pkg/errors"
 	"google.golang.org/protobuf/types/known/anypb"
 
 	"github.com/kumahq/kuma/pkg/xds/envoy"

--- a/pkg/xds/envoy/listeners/listener_builder.go
+++ b/pkg/xds/envoy/listeners/listener_builder.go
@@ -1,8 +1,9 @@
 package listeners
 
 import (
+	"errors"
+
 	envoy_listener_v3 "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
-	"github.com/pkg/errors"
 
 	"github.com/kumahq/kuma/pkg/xds/envoy"
 	v3 "github.com/kumahq/kuma/pkg/xds/envoy/listeners/v3"

--- a/pkg/xds/envoy/listeners/v3/http_route_configurer.go
+++ b/pkg/xds/envoy/listeners/v3/http_route_configurer.go
@@ -1,11 +1,12 @@
 package v3
 
 import (
+	"errors"
+
 	envoy_core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	envoy_listener "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
 	envoy_route "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
 	envoy_hcm "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
-	"github.com/pkg/errors"
 
 	envoy_routes "github.com/kumahq/kuma/pkg/xds/envoy/routes"
 )
@@ -62,8 +63,7 @@ func (c *HttpDynamicRouteConfigurer) Configure(filterChain *envoy_listener.Filte
 
 // HttpScopedRouteConfigurer configures a set of scoped routes into the
 // HttpConnectionManager in the filter chain.
-type HttpScopedRouteConfigurer struct {
-}
+type HttpScopedRouteConfigurer struct{}
 
 var _ FilterChainConfigurer = &HttpScopedRouteConfigurer{}
 

--- a/pkg/xds/envoy/listeners/v3/timeout_configurer.go
+++ b/pkg/xds/envoy/listeners/v3/timeout_configurer.go
@@ -1,11 +1,12 @@
 package v3
 
 import (
+	"fmt"
+
 	envoy_config_core_v3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	envoy_listener "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
 	envoy_hcm "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
 	envoy_tcp "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/tcp_proxy/v3"
-	"github.com/pkg/errors"
 
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
@@ -31,7 +32,7 @@ func (c *TimeoutConfigurer) Configure(filterChain *envoy_listener.FilterChain) e
 			return nil
 		})
 	default:
-		return errors.Errorf("unsupported protocol %s", c.Protocol)
+		return fmt.Errorf("unsupported protocol %s", c.Protocol)
 	}
 }
 

--- a/pkg/xds/envoy/listeners/v3/tracing_configurer.go
+++ b/pkg/xds/envoy/listeners/v3/tracing_configurer.go
@@ -1,13 +1,13 @@
 package v3
 
 import (
+	"fmt"
 	net_url "net/url"
 
 	envoy_listener "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
 	envoy_trace "github.com/envoyproxy/go-control-plane/envoy/config/trace/v3"
 	envoy_hcm "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
 	envoy_type "github.com/envoyproxy/go-control-plane/envoy/type/v3"
-	"github.com/pkg/errors"
 	"google.golang.org/protobuf/types/known/structpb"
 
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
@@ -58,7 +58,7 @@ func (c *TracingConfigurer) Configure(filterChain *envoy_listener.FilterChain) e
 func datadogConfig(cfgStr *structpb.Struct, backendName string, serviceName string) (*envoy_trace.Tracing_Http, error) {
 	cfg := mesh_proto.DatadogTracingBackendConfig{}
 	if err := proto.ToTyped(cfgStr, &cfg); err != nil {
-		return nil, errors.Wrap(err, "could not convert backend")
+		return nil, fmt.Errorf("could not convert backend: %w", err)
 	}
 
 	datadogConfig := envoy_trace.DatadogConfig{
@@ -81,11 +81,11 @@ func datadogConfig(cfgStr *structpb.Struct, backendName string, serviceName stri
 func zipkinConfig(cfgStr *structpb.Struct, backendName string) (*envoy_trace.Tracing_Http, error) {
 	cfg := mesh_proto.ZipkinTracingBackendConfig{}
 	if err := proto.ToTyped(cfgStr, &cfg); err != nil {
-		return nil, errors.Wrap(err, "could not convert backend")
+		return nil, fmt.Errorf("could not convert backend: %w", err)
 	}
 	url, err := net_url.ParseRequestURI(cfg.Url)
 	if err != nil {
-		return nil, errors.Wrap(err, "invalid URL of Zipkin")
+		return nil, fmt.Errorf("invalid URL of Zipkin: %w", err)
 	}
 
 	zipkinConfig := envoy_trace.ZipkinConfig{

--- a/pkg/xds/envoy/listeners/v3/util.go
+++ b/pkg/xds/envoy/listeners/v3/util.go
@@ -1,6 +1,8 @@
 package v3
 
 import (
+	"errors"
+	"fmt"
 	"math"
 	"regexp"
 	"strconv"
@@ -9,7 +11,6 @@ import (
 	envoy_hcm "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
 	envoy_tcp "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/tcp_proxy/v3"
 	envoy_type "github.com/envoyproxy/go-control-plane/envoy/type/v3"
-	"github.com/pkg/errors"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/anypb"
 	"google.golang.org/protobuf/types/known/wrapperspb"
@@ -39,7 +40,7 @@ func UpdateFilterConfig(filterChain *envoy_listener.FilterChain, filterName stri
 	for i, filter := range filterChain.Filters {
 		if filter.Name == filterName {
 			if filter.GetTypedConfig() == nil {
-				return errors.Errorf("filters[%d]: config cannot be 'nil'", i)
+				return fmt.Errorf("filters[%d]: config cannot be 'nil'", i)
 			}
 
 			msg, err := filter.GetTypedConfig().UnmarshalNew()
@@ -64,7 +65,7 @@ func UpdateFilterConfig(filterChain *envoy_listener.FilterChain, filterName stri
 }
 
 func NewUnexpectedFilterConfigTypeError(actual, expected proto.Message) error {
-	return errors.Errorf("filter config has unexpected type: expected %T, got %T", expected, actual)
+	return fmt.Errorf("filter config has unexpected type: expected %T, got %T", expected, actual)
 }
 
 func ConvertPercentage(percentage *wrapperspb.DoubleValue) *envoy_type.FractionalPercent {

--- a/pkg/xds/envoy/names/resource_names.go
+++ b/pkg/xds/envoy/names/resource_names.go
@@ -5,8 +5,6 @@ import (
 	"net"
 	"strconv"
 	"strings"
-
-	"github.com/pkg/errors"
 )
 
 // Separator is the separator used in resource names.
@@ -32,7 +30,7 @@ func GetSplitClusterName(service string, idx int) string {
 func GetPortForLocalClusterName(cluster string) (uint32, error) {
 	parts := strings.Split(cluster, Separator)
 	if len(parts) != 2 {
-		return 0, errors.Errorf("failed to  parse local cluster name: %s", cluster)
+		return 0, fmt.Errorf("failed to  parse local cluster name: %s", cluster)
 	}
 	port, err := strconv.ParseUint(parts[1], 10, 32)
 	if err != nil {

--- a/pkg/xds/envoy/routes/route_configuration_builder.go
+++ b/pkg/xds/envoy/routes/route_configuration_builder.go
@@ -1,8 +1,9 @@
 package routes
 
 import (
+	"errors"
+
 	envoy_route_v3 "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
-	"github.com/pkg/errors"
 
 	"github.com/kumahq/kuma/pkg/xds/envoy"
 	v3 "github.com/kumahq/kuma/pkg/xds/envoy/routes/v3"

--- a/pkg/xds/envoy/routes/virtual_host_builder.go
+++ b/pkg/xds/envoy/routes/virtual_host_builder.go
@@ -1,8 +1,9 @@
 package routes
 
 import (
+	"errors"
+
 	envoy_route_v3 "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
-	"github.com/pkg/errors"
 
 	"github.com/kumahq/kuma/pkg/xds/envoy"
 	v3 "github.com/kumahq/kuma/pkg/xds/envoy/routes/v3"

--- a/pkg/xds/envoy/types.go
+++ b/pkg/xds/envoy/types.go
@@ -1,12 +1,12 @@
 package envoy
 
 import (
+	"errors"
 	"fmt"
 	"sort"
 	"strings"
 
 	envoy_types "github.com/envoyproxy/go-control-plane/pkg/cache/types"
-	"github.com/pkg/errors"
 
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 )
@@ -119,10 +119,12 @@ func WithExternalService(isExternalService bool) NewClusterOpt {
 	})
 }
 
-type Tags map[string]string
-type TagsSlice []Tags
-type TagKeys []string
-type TagKeysSlice []TagKeys
+type (
+	Tags         map[string]string
+	TagsSlice    []Tags
+	TagKeys      []string
+	TagKeysSlice []TagKeys
+)
 
 func (t TagsSlice) ToTagKeysSlice() TagKeysSlice {
 	out := []TagKeys{}

--- a/pkg/xds/generator/core/resource_generator.go
+++ b/pkg/xds/generator/core/resource_generator.go
@@ -1,7 +1,7 @@
 package core
 
 import (
-	"github.com/pkg/errors"
+	"fmt"
 
 	model "github.com/kumahq/kuma/pkg/core/xds"
 	xds_context "github.com/kumahq/kuma/pkg/xds/context"
@@ -18,7 +18,7 @@ func (c CompositeResourceGenerator) Generate(ctx xds_context.Context, proxy *mod
 	for _, gen := range c {
 		rs, err := gen.Generate(ctx, proxy)
 		if err != nil {
-			return nil, errors.Wrapf(err, "%T failed", gen)
+			return nil, fmt.Errorf("%T failed: %w", gen, err)
 		}
 		resources.AddSet(rs)
 	}

--- a/pkg/xds/generator/direct_access_proxy_generator.go
+++ b/pkg/xds/generator/direct_access_proxy_generator.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 	"sort"
 
-	"github.com/pkg/errors"
-
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	manager_dataplane "github.com/kumahq/kuma/pkg/core/managers/apis/dataplane"
 	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
@@ -26,8 +24,7 @@ const OriginDirectAccess = "direct-access"
 //
 // Second approach to consider was to use FilterChainMatch on catch_all listener with list of all direct access endpoints
 // instead of generating outbound listener, but it seemed to not work with Listener#UseOriginalDst
-type DirectAccessProxyGenerator struct {
-}
+type DirectAccessProxyGenerator struct{}
 
 func (_ DirectAccessProxyGenerator) Generate(ctx xds_context.Context, proxy *core_xds.Proxy) (*core_xds.ResourceSet, error) {
 	tproxy := proxy.Dataplane.Spec.Networking.GetTransparentProxying()
@@ -75,7 +72,7 @@ func (_ DirectAccessProxyGenerator) Generate(ctx xds_context.Context, proxy *cor
 		Configure(envoy_clusters.UnknownDestinationClientSideMTLS(proxy.SecretsTracker, ctx.Mesh.Resource)).
 		Build()
 	if err != nil {
-		return nil, errors.Wrapf(err, "could not generate cluster: direct_access")
+		return nil, fmt.Errorf("could not generate cluster: direct_access: %w", err)
 	}
 	resources.Add(&core_xds.Resource{
 		Name:     directAccessCluster.GetName(),

--- a/pkg/xds/generator/egress/generator.go
+++ b/pkg/xds/generator/egress/generator.go
@@ -1,7 +1,7 @@
 package egress
 
 import (
-	"github.com/pkg/errors"
+	"fmt"
 
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	"github.com/kumahq/kuma/pkg/core"
@@ -22,9 +22,7 @@ const (
 	OriginEgress = "egress"
 )
 
-var (
-	log = core.Log.WithName("xds").WithName("generator").WithName("egress")
-)
+var log = core.Log.WithName("xds").WithName("generator").WithName("egress")
 
 // ZoneEgressGenerator is responsible for generating xDS resources for
 // a single ZoneEgress.
@@ -81,12 +79,9 @@ func (g Generator) Generate(
 		for _, generator := range g.ZoneEgressGenerators {
 			rs, err := generator.Generate(ctx, proxy, listenerBuilder, meshResources)
 			if err != nil {
-				err := errors.Wrapf(
-					err,
-					"%T failed to generate resources for zone egress %q",
+				err := fmt.Errorf("%T failed to generate resources for zone egress %q: %w",
 					generator,
-					proxy.Id,
-				)
+					proxy.Id, err)
 				return nil, err
 			}
 
@@ -112,12 +107,9 @@ func (g Generator) Generate(
 			ctx, proxy.Id, proxy.ZoneEgressProxy.ZoneEgressResource, secretsTracker, meshResources.Mesh,
 		)
 		if err != nil {
-			err := errors.Wrapf(
-				err,
-				"%T failed to generate resources for zone egress %q",
+			err := fmt.Errorf("%T failed to generate resources for zone egress %q: %w",
 				g.SecretGenerator,
-				proxy.Id,
-			)
+				proxy.Id, err)
 			return nil, err
 		}
 

--- a/pkg/xds/generator/inbound_proxy_generator.go
+++ b/pkg/xds/generator/inbound_proxy_generator.go
@@ -1,7 +1,8 @@
 package generator
 
 import (
-	"github.com/pkg/errors"
+	"errors"
+	"fmt"
 
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
@@ -21,8 +22,7 @@ import (
 // OriginInbound is a marker to indicate by which ProxyGenerator resources were generated.
 const OriginInbound = "inbound"
 
-type InboundProxyGenerator struct {
-}
+type InboundProxyGenerator struct{}
 
 func (g InboundProxyGenerator) Generate(ctx xds_context.Context, proxy *core_xds.Proxy) (*core_xds.ResourceSet, error) {
 	resources := core_xds.NewResourceSet()
@@ -49,7 +49,7 @@ func (g InboundProxyGenerator) Generate(ctx xds_context.Context, proxy *core_xds
 		}
 		envoyCluster, err := clusterBuilder.Build()
 		if err != nil {
-			return nil, errors.Wrapf(err, "%s: could not generate cluster %s", validators.RootedAt("dataplane").Field("networking").Field("inbound").Index(i), localClusterName)
+			return nil, fmt.Errorf("%s: could not generate cluster %s: %w", validators.RootedAt("dataplane").Field("networking").Field("inbound").Index(i), localClusterName, err)
 		}
 		resources.Add(&core_xds.Resource{
 			Name:     localClusterName,
@@ -151,7 +151,7 @@ func (g InboundProxyGenerator) Generate(ctx xds_context.Context, proxy *core_xds
 
 		inboundListener, err := listenerBuilder.Build()
 		if err != nil {
-			return nil, errors.Wrapf(err, "%s: could not generate listener %s", validators.RootedAt("dataplane").Field("networking").Field("inbound").Index(i), inboundListenerName)
+			return nil, fmt.Errorf("%s: could not generate listener %s: %w", validators.RootedAt("dataplane").Field("networking").Field("inbound").Index(i), inboundListenerName, err)
 		}
 		resources.Add(&core_xds.Resource{
 			Name:     inboundListenerName,

--- a/pkg/xds/generator/modifications/modifications.go
+++ b/pkg/xds/generator/modifications/modifications.go
@@ -1,7 +1,7 @@
 package modifications
 
 import (
-	"github.com/pkg/errors"
+	"fmt"
 
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	core_xds "github.com/kumahq/kuma/pkg/core/xds"
@@ -14,6 +14,6 @@ func Apply(resources *core_xds.ResourceSet, modifications []*mesh_proto.ProxyTem
 	case envoy_common.APIV3:
 		return modifications_v3.Apply(resources, modifications)
 	default:
-		return errors.Errorf("unknown API version %s", apiVersion)
+		return fmt.Errorf("unknown API version %s", apiVersion)
 	}
 }

--- a/pkg/xds/generator/modifications/v3/cluster.go
+++ b/pkg/xds/generator/modifications/v3/cluster.go
@@ -1,9 +1,10 @@
 package v3
 
 import (
+	"fmt"
+
 	envoy_cluster "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
 	envoy_resource "github.com/envoyproxy/go-control-plane/pkg/resource/v3"
-	"github.com/pkg/errors"
 
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	core_xds "github.com/kumahq/kuma/pkg/core/xds"
@@ -25,7 +26,7 @@ func (c *clusterModificator) apply(resources *core_xds.ResourceSet) error {
 	case mesh_proto.OpPatch:
 		c.patch(resources, clusterMod)
 	default:
-		return errors.Errorf("invalid operation: %s", c.Operation)
+		return fmt.Errorf("invalid operation: %s", c.Operation)
 	}
 	return nil
 }

--- a/pkg/xds/generator/modifications/v3/http_filter.go
+++ b/pkg/xds/generator/modifications/v3/http_filter.go
@@ -1,10 +1,11 @@
 package v3
 
 import (
+	"fmt"
+
 	envoy_listener "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
 	envoy_hcm "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
 	envoy_resource "github.com/envoyproxy/go-control-plane/pkg/resource/v3"
-	"github.com/pkg/errors"
 
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	core_xds "github.com/kumahq/kuma/pkg/core/xds"
@@ -60,10 +61,10 @@ func (h *httpFilterModificator) applyHCMModification(hcm *envoy_hcm.HttpConnecti
 		h.remove(hcm)
 	case mesh_proto.OpPatch:
 		if err := h.patch(hcm, filter); err != nil {
-			return errors.Wrap(err, "could not patch the resource")
+			return fmt.Errorf("could not patch the resource: %w", err)
 		}
 	default:
-		return errors.Errorf("invalid operation: %s", h.Operation)
+		return fmt.Errorf("invalid operation: %s", h.Operation)
 	}
 	return nil
 }

--- a/pkg/xds/generator/modifications/v3/listener.go
+++ b/pkg/xds/generator/modifications/v3/listener.go
@@ -1,9 +1,10 @@
 package v3
 
 import (
+	"fmt"
+
 	envoy_listener "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
 	envoy_resource "github.com/envoyproxy/go-control-plane/pkg/resource/v3"
-	"github.com/pkg/errors"
 
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	core_xds "github.com/kumahq/kuma/pkg/core/xds"
@@ -26,7 +27,7 @@ func (l *listenerModificator) apply(resources *core_xds.ResourceSet) error {
 	case mesh_proto.OpPatch:
 		l.patch(resources, listener)
 	default:
-		return errors.Errorf("invalid operation: %s", l.Operation)
+		return fmt.Errorf("invalid operation: %s", l.Operation)
 	}
 	return nil
 }

--- a/pkg/xds/generator/modifications/v3/modifications.go
+++ b/pkg/xds/generator/modifications/v3/modifications.go
@@ -1,7 +1,7 @@
 package v3
 
 import (
-	"github.com/pkg/errors"
+	"fmt"
 
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	core_xds "github.com/kumahq/kuma/pkg/core/xds"
@@ -34,10 +34,10 @@ func Apply(resources *core_xds.ResourceSet, modifications []*mesh_proto.ProxyTem
 			mod := virtualHostModificator(*modification.GetVirtualHost())
 			modificator = &mod
 		default:
-			return errors.Errorf("invalid modification type %T", modification.Type)
+			return fmt.Errorf("invalid modification type %T", modification.Type)
 		}
 		if err := modificator.apply(resources); err != nil {
-			return errors.Wrapf(err, "could not apply %d modification", i)
+			return fmt.Errorf("could not apply %d modification: %w", i, err)
 		}
 	}
 	return nil

--- a/pkg/xds/generator/modifications/v3/network_filter.go
+++ b/pkg/xds/generator/modifications/v3/network_filter.go
@@ -1,9 +1,10 @@
 package v3
 
 import (
+	"fmt"
+
 	envoy_listener "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
 	envoy_resource "github.com/envoyproxy/go-control-plane/pkg/resource/v3"
-	"github.com/pkg/errors"
 
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	core_xds "github.com/kumahq/kuma/pkg/core/xds"
@@ -35,10 +36,10 @@ func (n *networkFilterModificator) apply(resources *core_xds.ResourceSet) error 
 					n.remove(chain)
 				case mesh_proto.OpPatch:
 					if err := n.patch(chain, filter); err != nil {
-						return errors.Wrap(err, "could not patch the resource")
+						return fmt.Errorf("could not patch the resource: %w", err)
 					}
 				default:
-					return errors.Errorf("invalid operation: %s", n.Operation)
+					return fmt.Errorf("invalid operation: %s", n.Operation)
 				}
 			}
 		}

--- a/pkg/xds/generator/modifications/v3/virtual_host.go
+++ b/pkg/xds/generator/modifications/v3/virtual_host.go
@@ -1,11 +1,12 @@
 package v3
 
 import (
+	"fmt"
+
 	envoy_listener "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
 	envoy_route "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
 	envoy_hcm "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
 	envoy_resource "github.com/envoyproxy/go-control-plane/pkg/resource/v3"
-	"github.com/pkg/errors"
 
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	core_xds "github.com/kumahq/kuma/pkg/core/xds"
@@ -66,7 +67,7 @@ func (c *virtualHostModificator) applyHCMModification(hcm *envoy_hcm.HttpConnect
 	case mesh_proto.OpPatch:
 		c.patch(routeCfg, virtualHost)
 	default:
-		return errors.Errorf("invalid operation: %s", c.Operation)
+		return fmt.Errorf("invalid operation: %s", c.Operation)
 	}
 	return nil
 }

--- a/pkg/xds/generator/probe_generator.go
+++ b/pkg/xds/generator/probe_generator.go
@@ -1,9 +1,8 @@
 package generator
 
 import (
+	"fmt"
 	"net/url"
-
-	"github.com/pkg/errors"
 
 	model "github.com/kumahq/kuma/pkg/core/xds"
 	xds_context "github.com/kumahq/kuma/pkg/xds/context"
@@ -18,8 +17,7 @@ const (
 	listenerName = "probe:listener"
 )
 
-type ProbeProxyGenerator struct {
-}
+type ProbeProxyGenerator struct{}
 
 func (g ProbeProxyGenerator) Generate(ctx xds_context.Context, proxy *model.Proxy) (*model.ResourceSet, error) {
 	probes := proxy.Dataplane.Spec.Probes
@@ -65,7 +63,7 @@ func (g ProbeProxyGenerator) Generate(ctx xds_context.Context, proxy *model.Prox
 		Configure(envoy_listeners.TransparentProxying(proxy.Dataplane.Spec.Networking.GetTransparentProxying())).
 		Build()
 	if err != nil {
-		return nil, errors.Wrapf(err, "could not generate listener %s", listenerName)
+		return nil, fmt.Errorf("could not generate listener %s: %w", listenerName, err)
 	}
 
 	resources := model.NewResourceSet()

--- a/pkg/xds/generator/prometheus_endpoint_generator.go
+++ b/pkg/xds/generator/prometheus_endpoint_generator.go
@@ -1,9 +1,8 @@
 package generator
 
 import (
+	"fmt"
 	"net"
-
-	"github.com/pkg/errors"
 
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	manager_dataplane "github.com/kumahq/kuma/pkg/core/managers/apis/dataplane"
@@ -27,13 +26,12 @@ const OriginPrometheus = "prometheus"
 // a port that is already in use by the application or other Envoy listeners.
 // In the latter case we prefer not generate Prometheus endpoint at all
 // rather than introduce undeterministic behavior.
-type PrometheusEndpointGenerator struct {
-}
+type PrometheusEndpointGenerator struct{}
 
 func (g PrometheusEndpointGenerator) Generate(ctx xds_context.Context, proxy *core_xds.Proxy) (*core_xds.ResourceSet, error) {
 	prometheusEndpoint, err := proxy.Dataplane.GetPrometheusConfig(ctx.Mesh.Resource)
 	if err != nil {
-		return nil, errors.Wrap(err, "could not get prometheus endpoint")
+		return nil, fmt.Errorf("could not get prometheus endpoint: %w", err)
 	}
 	if prometheusEndpoint == nil {
 		// Prometheus metrics must be enabled Mesh-wide for Prometheus endpoint to be generated.
@@ -83,7 +81,7 @@ func (g PrometheusEndpointGenerator) Generate(ctx xds_context.Context, proxy *co
 
 	inbound, err := manager_dataplane.PrometheusInbound(proxy.Dataplane, ctx.Mesh.Resource)
 	if err != nil {
-		return nil, errors.Wrap(err, "could not get prometheus inbound interface")
+		return nil, fmt.Errorf("could not get prometheus inbound interface: %w", err)
 	}
 
 	iface := proxy.Dataplane.Spec.GetNetworking().ToInboundInterface(inbound)

--- a/pkg/xds/secrets/ca_provider.go
+++ b/pkg/xds/secrets/ca_provider.go
@@ -2,9 +2,10 @@ package secrets
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"time"
 
-	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 
 	core_ca "github.com/kumahq/kuma/pkg/core/ca"
@@ -53,7 +54,7 @@ func (s *meshCaProvider) Get(ctx context.Context, mesh *core_mesh.MeshResource) 
 
 	caManager, exist := s.caManagers[backend.Type]
 	if !exist {
-		return nil, nil, errors.Errorf("CA manager of type %s not exist", backend.Type)
+		return nil, nil, fmt.Errorf("CA manager of type %s not exist", backend.Type)
 	}
 
 	var certs [][]byte
@@ -66,7 +67,7 @@ func (s *meshCaProvider) Get(ctx context.Context, mesh *core_mesh.MeshResource) 
 		certs, err = caManager.GetRootCert(ctx, mesh.GetMeta().GetName(), backend)
 	}()
 	if err != nil {
-		return nil, nil, errors.Wrap(err, "could not get root certs")
+		return nil, nil, fmt.Errorf("could not get root certs: %w", err)
 	}
 
 	return &core_xds.CaSecret{

--- a/pkg/xds/secrets/identity_provider.go
+++ b/pkg/xds/secrets/identity_provider.go
@@ -2,9 +2,9 @@ package secrets
 
 import (
 	"context"
+	"fmt"
 	"time"
 
-	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
@@ -48,7 +48,7 @@ type identityCertProvider struct {
 func (s *identityCertProvider) Get(ctx context.Context, requestor Identity, mesh *core_mesh.MeshResource) (*core_xds.IdentitySecret, string, error) {
 	backend := mesh.GetEnabledCertificateAuthorityBackend()
 	if backend == nil {
-		return nil, "", errors.Errorf("CA default backend in mesh %q has to be defined", mesh.GetMeta().GetName())
+		return nil, "", fmt.Errorf("CA default backend in mesh %q has to be defined", mesh.GetMeta().GetName())
 	}
 
 	timeout := backend.GetDpCert().GetRequestTimeout()
@@ -60,7 +60,7 @@ func (s *identityCertProvider) Get(ctx context.Context, requestor Identity, mesh
 
 	caManager, exist := s.caManagers[backend.Type]
 	if !exist {
-		return nil, "", errors.Errorf("CA manager of type %s not exist", backend.Type)
+		return nil, "", fmt.Errorf("CA manager of type %s not exist", backend.Type)
 	}
 
 	var pair core_ca.KeyPair
@@ -74,7 +74,7 @@ func (s *identityCertProvider) Get(ctx context.Context, requestor Identity, mesh
 	}()
 
 	if err != nil {
-		return nil, "", errors.Wrapf(err, "could not generate dataplane cert for mesh: %q backend: %q services: %q", mesh.GetMeta().GetName(), backend.Name, requestor.Services)
+		return nil, "", fmt.Errorf("could not generate dataplane cert for mesh: %q backend: %q services: %q: %w", mesh.GetMeta().GetName(), backend.Name, requestor.Services, err)
 	}
 
 	return &core_xds.IdentitySecret{

--- a/pkg/xds/server/callbacks/dataplane_callbacks.go
+++ b/pkg/xds/server/callbacks/dataplane_callbacks.go
@@ -2,9 +2,9 @@ package callbacks
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"sync"
-
-	"github.com/pkg/errors"
 
 	core_model "github.com/kumahq/kuma/pkg/core/resources/model"
 	core_xds "github.com/kumahq/kuma/pkg/core/xds"
@@ -87,7 +87,7 @@ func (d *xdsCallbacks) OnStreamRequest(streamID core_xds.StreamID, request util_
 
 	proxyId, err := core_xds.ParseProxyIdFromString(request.NodeId())
 	if err != nil {
-		return errors.Wrap(err, "invalid node ID")
+		return fmt.Errorf("invalid node ID: %w", err)
 	}
 	dpKey := proxyId.ToResourceKey()
 	metadata := core_xds.DataplaneMetadataFromXdsMetadata(request.Metadata())
@@ -135,8 +135,7 @@ func (d *xdsCallbacks) OnStreamOpen(ctx context.Context, streamID core_xds.Strea
 }
 
 // NoopDataplaneCallbacks are empty callbacks that helps to implement DataplaneCallbacks without need to implement every function.
-type NoopDataplaneCallbacks struct {
-}
+type NoopDataplaneCallbacks struct{}
 
 func (n *NoopDataplaneCallbacks) OnProxyReconnected(core_xds.StreamID, core_model.ResourceKey, context.Context, core_xds.DataplaneMetadata) error {
 	return nil

--- a/pkg/xds/server/callbacks/dataplane_lifecycle.go
+++ b/pkg/xds/server/callbacks/dataplane_lifecycle.go
@@ -2,9 +2,8 @@ package callbacks
 
 import (
 	"context"
+	"fmt"
 	"sync"
-
-	"github.com/pkg/errors"
 
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	"github.com/kumahq/kuma/pkg/core"
@@ -53,7 +52,7 @@ func (d *DataplaneLifecycle) register(ctx context.Context, streamID core_xds.Str
 		log.Info("registering dataplane")
 		if err := d.registerDataplane(ctx, dp); err != nil {
 			log.Info("cannot register dataplane", "reason", err.Error())
-			return errors.Wrap(err, "could not register dataplane passed in kuma-dp run")
+			return fmt.Errorf("could not register dataplane passed in kuma-dp run: %w", err)
 		}
 	case md.GetProxyType() == mesh_proto.IngressProxyType && md.GetZoneIngressResource() != nil:
 		zi := md.GetZoneIngressResource()
@@ -61,7 +60,7 @@ func (d *DataplaneLifecycle) register(ctx context.Context, streamID core_xds.Str
 		log.Info("registering zone ingress")
 		if err := d.registerZoneIngress(ctx, zi); err != nil {
 			log.Info("cannot register zone ingress", "reason", err.Error())
-			return errors.Wrap(err, "could not register zone ingress passed in kuma-dp run")
+			return fmt.Errorf("could not register zone ingress passed in kuma-dp run: %w", err)
 		}
 	case md.GetProxyType() == mesh_proto.EgressProxyType && md.GetZoneEgressResource() != nil:
 		zi := md.GetZoneEgressResource()
@@ -69,7 +68,7 @@ func (d *DataplaneLifecycle) register(ctx context.Context, streamID core_xds.Str
 		log.Info("registering zone egress")
 		if err := d.registerZoneEgress(ctx, zi); err != nil {
 			log.Info("cannot register zone egress", "reason", err.Error())
-			return errors.Wrap(err, "could not register zone egress passed in kuma-dp run")
+			return fmt.Errorf("could not register zone egress passed in kuma-dp run: %w", err)
 		}
 	default:
 		return nil
@@ -140,7 +139,7 @@ func (d *DataplaneLifecycle) registerDataplane(ctx context.Context, dp *core_mes
 	existing := core_mesh.NewDataplaneResource()
 	return manager.Upsert(d.resManager, key, existing, func(resource model.Resource) error {
 		if err := d.validateUpsert(ctx, existing); err != nil {
-			return errors.Wrap(err, "you are trying to override existing dataplane to which you don't have an access.")
+			return fmt.Errorf("you are trying to override existing dataplane to which you don't have an access.: %w", err)
 		}
 		return existing.SetSpec(dp.GetSpec())
 	})
@@ -171,7 +170,7 @@ func (d *DataplaneLifecycle) registerZoneIngress(ctx context.Context, zi *core_m
 	existing := core_mesh.NewZoneIngressResource()
 	return manager.Upsert(d.resManager, key, existing, func(resource model.Resource) error {
 		if err := d.validateUpsert(ctx, existing); err != nil {
-			return errors.Wrap(err, "you are trying to override existing zone ingress to which you don't have an access.")
+			return fmt.Errorf("you are trying to override existing zone ingress to which you don't have an access.: %w", err)
 		}
 		return existing.SetSpec(zi.GetSpec())
 	})
@@ -182,7 +181,7 @@ func (d *DataplaneLifecycle) registerZoneEgress(ctx context.Context, ze *core_me
 	existing := core_mesh.NewZoneEgressResource()
 	return manager.Upsert(d.resManager, key, existing, func(resource model.Resource) error {
 		if err := d.validateUpsert(ctx, existing); err != nil {
-			return errors.Wrap(err, "you are trying to override existing zone egress to which you don't have an access.")
+			return fmt.Errorf("you are trying to override existing zone egress to which you don't have an access.: %w", err)
 		}
 		return existing.SetSpec(ze.GetSpec())
 	})

--- a/pkg/xds/server/callbacks/dataplane_lifecycle_test.go
+++ b/pkg/xds/server/callbacks/dataplane_lifecycle_test.go
@@ -2,6 +2,7 @@ package callbacks_test
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 
@@ -10,7 +11,6 @@ import (
 	envoy_server "github.com/envoyproxy/go-control-plane/pkg/server/v3"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/pkg/errors"
 	"google.golang.org/protobuf/types/known/structpb"
 
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
@@ -36,7 +36,6 @@ func (s *staticAuthenticator) Authenticate(ctx context.Context, resource core_mo
 var _ xds_auth.Authenticator = &staticAuthenticator{}
 
 var _ = Describe("Dataplane Lifecycle", func() {
-
 	var authenticator *staticAuthenticator
 	var resManager core_manager.ResourceManager
 	var callbacks envoy_server.Callbacks
@@ -339,6 +338,5 @@ var _ = Describe("Dataplane Lifecycle", func() {
 		}
 
 		wg.Wait()
-
 	})
 })

--- a/pkg/xds/server/components.go
+++ b/pkg/xds/server/components.go
@@ -1,7 +1,7 @@
 package server
 
 import (
-	"github.com/pkg/errors"
+	"fmt"
 
 	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	core_system "github.com/kumahq/kuma/pkg/core/resources/apis/system"
@@ -98,7 +98,7 @@ func RegisterXDS(rt core_runtime.Runtime) error {
 	}
 
 	if err := v3.RegisterXDS(statsCallbacks, xdsMetrics, meshSnapshotCache, envoyCpCtx, rt); err != nil {
-		return errors.Wrap(err, "could not register V3 XDS")
+		return fmt.Errorf("could not register V3 XDS: %w", err)
 	}
 	return nil
 }

--- a/pkg/xds/server/v3/resource_warming_forcer.go
+++ b/pkg/xds/server/v3/resource_warming_forcer.go
@@ -2,6 +2,7 @@ package v3
 
 import (
 	"context"
+	"fmt"
 	"sync"
 
 	envoy_sd "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
@@ -9,7 +10,6 @@ import (
 	envoy_cache "github.com/envoyproxy/go-control-plane/pkg/cache/v3"
 	envoy_resource "github.com/envoyproxy/go-control-plane/pkg/resource/v3"
 	envoy_xds "github.com/envoyproxy/go-control-plane/pkg/server/v3"
-	"github.com/pkg/errors"
 
 	"github.com/kumahq/kuma/pkg/core"
 	"github.com/kumahq/kuma/pkg/core/xds"
@@ -120,7 +120,7 @@ func (r *resourceWarmingForcer) forceNewEndpointsVersion(nodeID string) error {
 	endpoints.Version = core.NewUUID()
 	snapshot.Resources[types.Endpoint] = endpoints
 	if err := r.cache.SetSnapshot(context.TODO(), nodeID, snapshot); err != nil {
-		return errors.Wrap(err, "could not set snapshot")
+		return fmt.Errorf("could not set snapshot: %w", err)
 	}
 	return nil
 }

--- a/pkg/xds/sync/dataplane_proxy_builder.go
+++ b/pkg/xds/sync/dataplane_proxy_builder.go
@@ -1,9 +1,8 @@
 package sync
 
 import (
+	"fmt"
 	"net"
-
-	"github.com/pkg/errors"
 
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	"github.com/kumahq/kuma/pkg/core"
@@ -141,7 +140,7 @@ func (p *DataplaneProxyBuilder) resolveVIPOutbounds(meshContext xds_context.Mesh
 func (p *DataplaneProxyBuilder) matchPolicies(meshContext xds_context.MeshContext, dataplane *core_mesh.DataplaneResource, outboundSelectors core_xds.DestinationMap) (*core_xds.MatchedPolicies, error) {
 	additionalInbounds, err := manager_dataplane.AdditionalInbounds(dataplane, meshContext.Resource)
 	if err != nil {
-		return nil, errors.Wrap(err, "could not fetch additional inbounds")
+		return nil, fmt.Errorf("could not fetch additional inbounds: %w", err)
 	}
 	inbounds := append(dataplane.Spec.GetNetworking().GetInbound(), additionalInbounds...)
 

--- a/pkg/xds/sync/dataplane_watchdog.go
+++ b/pkg/xds/sync/dataplane_watchdog.go
@@ -2,9 +2,9 @@ package sync
 
 import (
 	"context"
+	"errors"
 
 	"github.com/go-logr/logr"
-	"github.com/pkg/errors"
 
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	"github.com/kumahq/kuma/pkg/core"

--- a/pkg/xds/sync/proxy_builder_test.go
+++ b/pkg/xds/sync/proxy_builder_test.go
@@ -2,6 +2,7 @@ package sync_test
 
 import (
 	"context"
+	"errors"
 	"net"
 	"os"
 	"path/filepath"
@@ -9,7 +10,6 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/pkg/errors"
 
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	kuma_cp "github.com/kumahq/kuma/pkg/config/app/kuma-cp"

--- a/pkg/xds/topology/dataplanes.go
+++ b/pkg/xds/topology/dataplanes.go
@@ -1,11 +1,12 @@
 package topology
 
 import (
+	"errors"
+	"fmt"
 	"net"
 
 	"github.com/go-logr/logr"
 	"github.com/golang/protobuf/proto"
-	"github.com/pkg/errors"
 
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	"github.com/kumahq/kuma/pkg/core/dns/lookup"
@@ -96,7 +97,7 @@ func lookupFirstIp(lookupIPFunc lookup.LookupIPFunc, address string) (string, er
 		return "", err
 	}
 	if len(ips) == 0 {
-		return "", errors.Errorf("can't resolve address %v", address)
+		return "", fmt.Errorf("can't resolve address %v", address)
 	}
 	// Pick the first lexicographic order ip (to make resolution deterministic
 	minIp := ""

--- a/pkg/xds/topology/dataplanes_test.go
+++ b/pkg/xds/topology/dataplanes_test.go
@@ -1,11 +1,11 @@
 package topology_test
 
 import (
+	"fmt"
 	"net"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/pkg/errors"
 
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	"github.com/kumahq/kuma/pkg/core"
@@ -33,14 +33,16 @@ var _ = Describe("Resolve Dataplane address", func() {
 		if s == "advertise-2.example.com" {
 			return []net.IP{net.ParseIP("192.0.2.2")}, nil
 		}
-		return nil, errors.Errorf("can't resolve hostname: %s", s)
+		return nil, fmt.Errorf("can't resolve hostname: %s", s)
 	}
 
 	Context("ResolveAddress", func() {
 		It("should resolve if networking.address is domain name", func() {
 			// given
-			dp := &mesh.DataplaneResource{Spec: &mesh_proto.Dataplane{
-				Networking: &mesh_proto.Dataplane_Networking{Address: "example.com", AdvertisedAddress: "advertise.example.com"}},
+			dp := &mesh.DataplaneResource{
+				Spec: &mesh_proto.Dataplane{
+					Networking: &mesh_proto.Dataplane_Networking{Address: "example.com", AdvertisedAddress: "advertise.example.com"},
+				},
 			}
 
 			// when

--- a/test/e2e/deploy/kuma_deploy_universal.go
+++ b/test/e2e/deploy/kuma_deploy_universal.go
@@ -7,7 +7,6 @@ import (
 	"github.com/gruntwork-io/terratest/modules/retry"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/pkg/errors"
 
 	"github.com/kumahq/kuma/pkg/config/core"
 	. "github.com/kumahq/kuma/test/framework"
@@ -107,7 +106,7 @@ name: %s
 				if strings.Contains(stdout, "HTTP/1.1 200 OK") {
 					return "Accessing service successful", nil
 				}
-				return "should retry", errors.Errorf("should retry")
+				return "should retry", fmt.Errorf("should retry")
 			})
 
 		retry.DoWithRetry(zone2.GetTesting(), "curl remote service",
@@ -121,7 +120,7 @@ name: %s
 				if strings.Contains(stdout, "HTTP/1.1 200 OK") {
 					return "Accessing service successful", nil
 				}
-				return "should retry", errors.Errorf("should retry")
+				return "should retry", fmt.Errorf("should retry")
 			})
 	})
 

--- a/test/e2e/deploy/kuma_deploy_universal_transparent_proxy.go
+++ b/test/e2e/deploy/kuma_deploy_universal_transparent_proxy.go
@@ -1,12 +1,12 @@
 package deploy
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/gruntwork-io/terratest/modules/retry"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/pkg/errors"
 
 	"github.com/kumahq/kuma/pkg/config/core"
 	. "github.com/kumahq/kuma/test/framework"
@@ -46,7 +46,7 @@ func UniversalTransparentProxyDeployment() {
 				if strings.Contains(stdout, "HTTP/1.1 200 OK") {
 					return "Accessing service successful", nil
 				}
-				return "should retry", errors.Errorf("should retry")
+				return "should retry", fmt.Errorf("should retry")
 			})
 		retry.DoWithRetry(cluster.GetTesting(), "curl service with dots",
 			DefaultRetries, DefaultTimeout,
@@ -59,7 +59,7 @@ func UniversalTransparentProxyDeployment() {
 				if strings.Contains(stdout, "HTTP/1.1 200 OK") {
 					return "Accessing service successful", nil
 				}
-				return "should retry", errors.Errorf("should retry")
+				return "should retry", fmt.Errorf("should retry")
 			})
 	})
 
@@ -75,7 +75,7 @@ func UniversalTransparentProxyDeployment() {
 				if strings.Contains(stdout, "HTTP/1.1 200 OK") {
 					return "Accessing service successful", nil
 				}
-				return "should retry", errors.Errorf("should retry")
+				return "should retry", fmt.Errorf("should retry")
 			})
 
 		stdout, _, err := cluster.ExecWithRetries("", "", "demo-client",
@@ -95,7 +95,7 @@ func UniversalTransparentProxyDeployment() {
 				if strings.Contains(stdout, "HTTP/1.1 200 OK") {
 					return "Accessing service successful", nil
 				}
-				return "should retry", errors.Errorf("should retry")
+				return "should retry", fmt.Errorf("should retry")
 			})
 	})
 }

--- a/test/e2e/helm/kuma_helm_deploy_global_zone.go
+++ b/test/e2e/helm/kuma_helm_deploy_global_zone.go
@@ -12,7 +12,6 @@ import (
 	"github.com/gruntwork-io/terratest/modules/random"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/pkg/errors"
 
 	api_server "github.com/kumahq/kuma/pkg/api-server"
 	"github.com/kumahq/kuma/pkg/config/core"
@@ -81,11 +80,11 @@ func ZoneAndGlobalWithHelmChart() {
 		Eventually(func() (bool, error) {
 			status, response := http_helper.HttpGet(c1.GetTesting(), global.GetGlobalStatusAPI(), nil)
 			if status != http.StatusOK {
-				return false, errors.Errorf("unable to contact server %s with status %d", global.GetGlobalStatusAPI(), status)
+				return false, fmt.Errorf("unable to contact server %s with status %d", global.GetGlobalStatusAPI(), status)
 			}
 			err := json.Unmarshal([]byte(response), &clustersStatus)
 			if err != nil {
-				return false, errors.Errorf("unable to parse response [%s] with error: %v", response, err)
+				return false, fmt.Errorf("unable to parse response [%s] with error: %v", response, err)
 			}
 			if len(clustersStatus) != 1 {
 				return false, nil

--- a/test/e2e/hybrid/globaluniversal/kuma_hybrid.go
+++ b/test/e2e/hybrid/globaluniversal/kuma_hybrid.go
@@ -1,13 +1,13 @@
 package globaluniversal
 
 import (
+	"errors"
 	"fmt"
 	"regexp"
 
 	"github.com/gruntwork-io/terratest/modules/k8s"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/kumahq/kuma/pkg/config/core"
@@ -29,8 +29,10 @@ mtls:
 
 var global, zone1, zone2, zone3 Cluster
 
-const nonDefaultMesh = "non-default"
-const defaultMesh = "default"
+const (
+	nonDefaultMesh = "non-default"
+	defaultMesh    = "default"
+)
 
 var _ = E2EBeforeSuite(func() {
 	k8sClusters, err := NewK8sClusters(

--- a/test/e2e/retry/retry_universal.go
+++ b/test/e2e/retry/retry_universal.go
@@ -1,13 +1,13 @@
 package retry
 
 import (
+	"fmt"
 	"strings"
 	"time"
 
 	"github.com/gruntwork-io/terratest/modules/retry"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/pkg/errors"
 
 	"github.com/kumahq/kuma/pkg/config/core"
 	. "github.com/kumahq/kuma/test/framework"
@@ -83,7 +83,7 @@ conf:
 				if strings.Contains(stdout, "HTTP/1.1 200 OK") {
 					return "Accessing service successful", nil
 				}
-				return "should retry", errors.Errorf("should retry")
+				return "should retry", fmt.Errorf("should retry")
 			})
 
 		for i := 0; i < 10; i++ {
@@ -103,7 +103,6 @@ conf:
 
 		for i := 0; i < 10; i++ {
 			_, _, err := cluster.Exec("", "", "demo-client", "curl", "-v", "-m", "8", "--fail", "test-server.mesh")
-
 			if err != nil {
 				errs = append(errs, err)
 			}

--- a/test/e2e/trafficroute/universal_standalone/traffic_route.go
+++ b/test/e2e/trafficroute/universal_standalone/traffic_route.go
@@ -1,12 +1,12 @@
 package universal_standalone
 
 import (
+	"errors"
 	"fmt"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/types"
-	"github.com/pkg/errors"
 
 	"github.com/kumahq/kuma/pkg/config/core"
 	. "github.com/kumahq/kuma/test/framework"
@@ -459,7 +459,7 @@ conf:
 					return err
 				}
 				if resp.Received.Path != "/new-rewrite-prefix" {
-					return errors.Errorf("expected %s, got %s", "/new-rewrite-prefix", resp.Received.Path)
+					return fmt.Errorf("expected %s, got %s", "/new-rewrite-prefix", resp.Received.Path)
 				}
 				return nil
 			}, "30s", "500ms").Should(Succeed())
@@ -470,7 +470,7 @@ conf:
 					return err
 				}
 				if resp.Received.Path != "/regex-test" {
-					return errors.Errorf("expected %s, got %s", "/regex-test", resp.Received.Path)
+					return fmt.Errorf("expected %s, got %s", "/regex-test", resp.Received.Path)
 				}
 				return nil
 			}, "30s", "500ms").Should(Succeed())
@@ -523,7 +523,7 @@ conf:
 				}
 				host := resp.Received.Headers["Host"]
 				if len(host) < 1 || host[0] != "modified-host" {
-					return errors.Errorf("expected %s, got %s", "modified-host", host)
+					return fmt.Errorf("expected %s, got %s", "modified-host", host)
 				}
 				return nil
 			}, "30s", "500ms").Should(Succeed())
@@ -535,7 +535,7 @@ conf:
 				}
 				host := resp.Received.Headers["Host"]
 				if len(host) < 1 || host[0] != "path" {
-					return errors.Errorf("expected %s, got %s", "path", host)
+					return fmt.Errorf("expected %s, got %s", "path", host)
 				}
 				return nil
 			}, "30s", "500ms").Should(Succeed())
@@ -586,14 +586,14 @@ conf:
 				}
 				header := resp.Received.Headers["X-Custom-Header"]
 				if len(header) < 1 || header[0] != "xyz" {
-					return errors.Errorf("expected %s, got %s", "xyz", header)
+					return fmt.Errorf("expected %s, got %s", "xyz", header)
 				}
 				if len(resp.Received.Headers["Header-To-Remove"]) > 0 {
 					return errors.New("expected 'Header-To-Remove' to not be present")
 				}
 				header = resp.Received.Headers["X-Multiple-Values"]
 				if len(header) < 2 || header[0] != "abc" || header[1] != "xyz" {
-					return errors.Errorf("expected %s, got %s", "abc,xyz", header)
+					return fmt.Errorf("expected %s, got %s", "abc,xyz", header)
 				}
 				return nil
 			}, "30s", "500ms").Should(Succeed())
@@ -606,7 +606,7 @@ conf:
 				}
 				header := resp.Received.Headers["X-Custom-Header"]
 				if len(header) < 1 || header[0] != "xyz" {
-					return errors.Errorf("expected %s, got %s", "xyz", header)
+					return fmt.Errorf("expected %s, got %s", "xyz", header)
 				}
 				return nil
 			}, "30s", "500ms").Should(Succeed())

--- a/test/e2e_env/kubernetes/graceful/graceful.go
+++ b/test/e2e_env/kubernetes/graceful/graceful.go
@@ -11,7 +11,6 @@ import (
 	"github.com/gruntwork-io/terratest/modules/k8s"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/pkg/errors"
 
 	"github.com/kumahq/kuma/pkg/util/channels"
 	"github.com/kumahq/kuma/test/e2e_env/kubernetes/env"
@@ -142,7 +141,7 @@ spec:
 		}
 		defer resp.Body.Close()
 		if resp.StatusCode != 200 {
-			return errors.Errorf("status code: %d", resp.StatusCode)
+			return fmt.Errorf("status code: %d", resp.StatusCode)
 		}
 		_, err = io.Copy(ioutil.Discard, resp.Body)
 		return err

--- a/test/e2e_env/multizone/healthcheck/healthcheck.go
+++ b/test/e2e_env/multizone/healthcheck/healthcheck.go
@@ -8,7 +8,6 @@ import (
 	"github.com/gruntwork-io/terratest/modules/retry"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/pkg/errors"
 
 	"github.com/kumahq/kuma/test/e2e_env/multizone/env"
 	. "github.com/kumahq/kuma/test/framework"
@@ -71,7 +70,7 @@ func ApplicationOnUniversalClientOnK8s() {
 					}
 				}
 				if len(instanceSet) != len(instances) {
-					return "", errors.Errorf("checked %d/%d instances", len(instanceSet), len(instances))
+					return "", fmt.Errorf("checked %d/%d instances", len(instanceSet), len(instances))
 				}
 				return "", nil
 			},

--- a/test/framework/client/collect.go
+++ b/test/framework/client/collect.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/tls"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"net"
@@ -17,7 +18,6 @@ import (
 	"time"
 
 	"github.com/gruntwork-io/terratest/modules/k8s"
-	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8s_exec "k8s.io/client-go/util/exec"
 
@@ -203,7 +203,7 @@ func CollectResponse(
 			},
 		)
 		if err != nil {
-			return types.EchoResponse{}, errors.Wrap(err, "failed to list pods")
+			return types.EchoResponse{}, fmt.Errorf("failed to list pods: %w", err)
 		}
 
 		pod = pods[0].Name
@@ -216,7 +216,7 @@ func CollectResponse(
 
 	response := &types.EchoResponse{}
 	if err := json.Unmarshal([]byte(stdout), response); err != nil {
-		return types.EchoResponse{}, errors.Wrapf(err, "failed to unmarshal response: %q", stdout)
+		return types.EchoResponse{}, fmt.Errorf("failed to unmarshal response: %q: %w", stdout, err)
 	}
 
 	return *response, nil
@@ -278,7 +278,7 @@ func CollectResponseDirectly(
 
 	response := types.EchoResponse{}
 	if err := json.Unmarshal(body, &response); err != nil {
-		return types.EchoResponse{}, errors.Wrapf(err, "failed to unmarshal response: %q", string(body))
+		return types.EchoResponse{}, fmt.Errorf("failed to unmarshal response: %q: %w", string(body), err)
 	}
 	return response, nil
 }
@@ -324,7 +324,7 @@ func CollectFailure(cluster framework.Cluster, container, destination string, fn
 			},
 		)
 		if err != nil {
-			return FailureResponse{}, errors.Wrap(err, "failed to list pods")
+			return FailureResponse{}, fmt.Errorf("failed to list pods: %w", err)
 		}
 
 		pod = pods[0].Name
@@ -350,7 +350,7 @@ func CollectFailure(cluster framework.Cluster, container, destination string, fn
 			return response, err
 		}
 
-		return response, errors.Errorf("empty JSON response from curl: %q", stdout)
+		return response, fmt.Errorf("empty JSON response from curl: %q", stdout)
 	}
 
 	// for k8s

--- a/test/framework/config.go
+++ b/test/framework/config.go
@@ -6,8 +6,6 @@ import (
 	"runtime"
 	"time"
 
-	"github.com/pkg/errors"
-
 	core_config "github.com/kumahq/kuma/pkg/config"
 	kuma_version "github.com/kumahq/kuma/pkg/version"
 )
@@ -72,7 +70,7 @@ func (c E2eConfig) Validate() error {
 	if Config.KumactlBin != "" {
 		_, err := os.Stat(Config.KumactlBin)
 		if os.IsNotExist(err) {
-			return errors.Wrapf(err, "unable to find kumactl at:%s", Config.KumactlBin)
+			return fmt.Errorf("unable to find kumactl at:%s: %w", Config.KumactlBin, err)
 		}
 	}
 	return nil

--- a/test/framework/deployments/docker.go
+++ b/test/framework/deployments/docker.go
@@ -1,6 +1,7 @@
 package deployments
 
 import (
+	"fmt"
 	"strconv"
 	"time"
 
@@ -9,7 +10,6 @@ import (
 	"github.com/gruntwork-io/terratest/modules/retry"
 	"github.com/gruntwork-io/terratest/modules/shell"
 	"github.com/gruntwork-io/terratest/modules/testing"
-	"github.com/pkg/errors"
 
 	"github.com/kumahq/kuma/test/framework"
 )
@@ -40,7 +40,7 @@ func NewDockerContainer(fs ...DockerContainerOptFn) (*DockerContainer, error) {
 
 	for _, f := range fs {
 		if err := f(d); err != nil {
-			return nil, errors.Errorf("couldn't create docker containter: %s", err)
+			return nil, fmt.Errorf("couldn't create docker containter: %s", err)
 		}
 	}
 

--- a/test/framework/deployments/externalservice/deployment.go
+++ b/test/framework/deployments/externalservice/deployment.go
@@ -1,7 +1,7 @@
 package externalservice
 
 import (
-	"github.com/pkg/errors"
+	"errors"
 
 	"github.com/kumahq/kuma/test/framework"
 )

--- a/test/framework/deployments/kic/deployment.go
+++ b/test/framework/deployments/kic/deployment.go
@@ -1,9 +1,8 @@
 package kic
 
 import (
+	"errors"
 	"fmt"
-
-	"github.com/pkg/errors"
 
 	"github.com/kumahq/kuma/test/framework"
 )

--- a/test/framework/deployments/kic/kubernetes.go
+++ b/test/framework/deployments/kic/kubernetes.go
@@ -6,7 +6,6 @@ import (
 	"strconv"
 
 	"github.com/gruntwork-io/terratest/modules/k8s"
-	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/kumahq/kuma/test/framework"
@@ -16,8 +15,10 @@ type k8sDeployment struct {
 	ingressNamespace string
 }
 
-var DefaultNodePortHTTP = 30080
-var DefaultNodePortHTTPS = 30443
+var (
+	DefaultNodePortHTTP  = 30080
+	DefaultNodePortHTTPS = 30443
+)
 
 var _ Deployment = &k8sDeployment{}
 
@@ -94,7 +95,7 @@ func (t *k8sDeployment) Deploy(cluster framework.Cluster) error {
 		},
 	)
 	if len(pods) != 1 {
-		return errors.Errorf("counting KIC pods. Got: %d. Expected: 1", len(pods))
+		return fmt.Errorf("counting KIC pods. Got: %d. Expected: 1", len(pods))
 	}
 
 	k8s.WaitUntilPodAvailable(cluster.GetTesting(),

--- a/test/framework/deployments/observability/deployment.go
+++ b/test/framework/deployments/observability/deployment.go
@@ -1,7 +1,7 @@
 package observability
 
 import (
-	"github.com/pkg/errors"
+	"errors"
 
 	"github.com/kumahq/kuma/test/framework"
 )

--- a/test/framework/deployments/observability/kubernetes.go
+++ b/test/framework/deployments/observability/kubernetes.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 
 	"github.com/gruntwork-io/terratest/modules/k8s"
-	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/kumahq/kuma/test/framework"
@@ -60,7 +59,7 @@ func (t *k8SDeployment) Deploy(cluster framework.Cluster) error {
 		},
 	)
 	if len(pods) != 1 {
-		return errors.Errorf("counting Jaeger pods. Got: %d. Expected: 1", len(pods))
+		return fmt.Errorf("counting Jaeger pods. Got: %d. Expected: 1", len(pods))
 	}
 
 	k8s.WaitUntilPodAvailable(cluster.GetTesting(),

--- a/test/framework/deployments/observability/universal.go
+++ b/test/framework/deployments/observability/universal.go
@@ -10,7 +10,6 @@ import (
 	"github.com/gruntwork-io/terratest/modules/retry"
 	"github.com/gruntwork-io/terratest/modules/shell"
 	"github.com/gruntwork-io/terratest/modules/testing"
-	"github.com/pkg/errors"
 
 	"github.com/kumahq/kuma/test/framework"
 )
@@ -95,7 +94,7 @@ func (u *universalDeployment) Delete(cluster framework.Cluster) error {
 		func() (string, error) {
 			_, err := docker.StopE(cluster.GetTesting(), []string{u.container}, &docker.StopOptions{Time: 1})
 			if err == nil {
-				return "Container still running", errors.Errorf("Container still running")
+				return "Container still running", fmt.Errorf("Container still running")
 			}
 			return "Container stopped", nil
 		})

--- a/test/framework/deployments/testserver/deployment.go
+++ b/test/framework/deployments/testserver/deployment.go
@@ -1,7 +1,7 @@
 package testserver
 
 import (
-	"github.com/pkg/errors"
+	"errors"
 
 	"github.com/kumahq/kuma/test/framework"
 )
@@ -93,8 +93,7 @@ func WithPodAnnotations(annotations map[string]string) DeploymentOptsFn {
 	}
 }
 
-type TestServer interface {
-}
+type TestServer interface{}
 
 type Deployment interface {
 	framework.Deployment

--- a/test/framework/docker.go
+++ b/test/framework/docker.go
@@ -1,13 +1,13 @@
 package framework
 
 import (
+	"fmt"
 	"net"
 	"strconv"
 	"strings"
 
 	"github.com/gruntwork-io/terratest/modules/shell"
 	"github.com/gruntwork-io/terratest/modules/testing"
-	"github.com/pkg/errors"
 )
 
 func GetPublishedDockerPorts(
@@ -27,7 +27,7 @@ func GetPublishedDockerPorts(
 		}
 		addresses := strings.Split(out, "\n")
 		if len(addresses) < 1 {
-			return nil, errors.Errorf("there are no addresses for port %d", port)
+			return nil, fmt.Errorf("there are no addresses for port %d", port)
 		}
 		_, pubPortStr, err := net.SplitHostPort(addresses[0])
 		if err != nil {

--- a/test/framework/envoy_admin/tunnel/k8s.go
+++ b/test/framework/envoy_admin/tunnel/k8s.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/gruntwork-io/terratest/modules/k8s"
 	"github.com/gruntwork-io/terratest/modules/testing"
-	"github.com/pkg/errors"
 
 	"github.com/kumahq/kuma/test/framework/envoy_admin"
 	"github.com/kumahq/kuma/test/framework/envoy_admin/stats"
@@ -32,13 +31,13 @@ func NewK8sEnvoyAdminTunnel(
 
 	localPort, err := utils.GetFreePort()
 	if err != nil {
-		return nil, errors.Wrapf(err, "getting free port for the new tunnel failed")
+		return nil, fmt.Errorf("getting free port for the new tunnel failed: %w", err)
 	}
 
 	tunnel := k8s.NewTunnel(kubectlOptions, resourceType, resourceName, localPort, port)
 
 	if err := tunnel.ForwardPortE(t); err != nil {
-		return nil, errors.Wrapf(err, "port forwarding for %d:%d failed", localPort, port)
+		return nil, fmt.Errorf("port forwarding for %d:%d failed: %w", localPort, port, err)
 	}
 
 	return &K8sTunnel{
@@ -57,7 +56,7 @@ func (t *K8sTunnel) GetStats(name string) (*stats.Stats, error) {
 	defer response.Body.Close()
 
 	if response.StatusCode != http.StatusOK {
-		return nil, errors.Errorf(
+		return nil, fmt.Errorf(
 			"got response with unexpected status code: %+q, Expected: %+q",
 			response.Status,
 			http.StatusText(http.StatusOK),
@@ -82,7 +81,7 @@ func (t *K8sTunnel) ResetCounters() error {
 	defer response.Body.Close()
 
 	if response.StatusCode != http.StatusOK {
-		return errors.Errorf(
+		return fmt.Errorf(
 			"got response with unexpected status code: %+q, Expected: %+q",
 			response.Status,
 			http.StatusText(http.StatusOK),

--- a/test/framework/envoy_admin/tunnel/universal.go
+++ b/test/framework/envoy_admin/tunnel/universal.go
@@ -2,10 +2,10 @@ package tunnel
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 
 	"github.com/gruntwork-io/terratest/modules/testing"
-	"github.com/pkg/errors"
 
 	"github.com/kumahq/kuma/test/framework/envoy_admin"
 	"github.com/kumahq/kuma/test/framework/envoy_admin/stats"

--- a/test/framework/k8s.go
+++ b/test/framework/k8s.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 
 	"github.com/gruntwork-io/terratest/modules/k8s"
-	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -20,7 +19,7 @@ func PodNameOfApp(cluster Cluster, name string, namespace string) (string, error
 		return "", err
 	}
 	if len(pods) != 1 {
-		return "", errors.Errorf("expected %d pods, got %d", 1, len(pods))
+		return "", fmt.Errorf("expected %d pods, got %d", 1, len(pods))
 	}
 	return pods[0].Name, nil
 }
@@ -37,7 +36,7 @@ func PodIPOfApp(cluster Cluster, name string, namespace string) (string, error) 
 		return "", err
 	}
 	if len(pods) != 1 {
-		return "", errors.Errorf("expected %d pods, got %d", 1, len(pods))
+		return "", fmt.Errorf("expected %d pods, got %d", 1, len(pods))
 	}
 	return pods[0].Status.PodIP, nil
 }

--- a/test/framework/k8s_cluster.go
+++ b/test/framework/k8s_cluster.go
@@ -3,6 +3,7 @@ package framework
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -17,7 +18,6 @@ import (
 	"github.com/gruntwork-io/terratest/modules/random"
 	"github.com/gruntwork-io/terratest/modules/retry"
 	"github.com/gruntwork-io/terratest/modules/testing"
-	"github.com/pkg/errors"
 	"go.uber.org/multierr"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -74,7 +74,6 @@ func (c *K8sCluster) addEgressEnvoyTunnel() error {
 		k8s.ResourceTypeService,
 		Config.ZoneEgressApp,
 	)
-
 	if err != nil {
 		return err
 	}
@@ -91,7 +90,6 @@ func (c *K8sCluster) addIngressEnvoyTunnel() error {
 		k8s.ResourceTypeService,
 		Config.ZoneIngressApp,
 	)
-
 	if err != nil {
 		return err
 	}
@@ -104,7 +102,7 @@ func (c *K8sCluster) addIngressEnvoyTunnel() error {
 func (c *K8sCluster) GetZoneEgressEnvoyTunnel() envoy_admin.Tunnel {
 	t, ok := c.envoyTunnels[Config.ZoneEgressApp]
 	if !ok {
-		c.t.Fatal(errors.Errorf("no tunnel with name %+q", Config.ZoneEgressApp))
+		c.t.Fatal(fmt.Errorf("no tunnel with name %+q", Config.ZoneEgressApp))
 	}
 	return t
 }
@@ -112,7 +110,7 @@ func (c *K8sCluster) GetZoneEgressEnvoyTunnel() envoy_admin.Tunnel {
 func (c *K8sCluster) GetZoneIngressEnvoyTunnel() envoy_admin.Tunnel {
 	t, ok := c.envoyTunnels[Config.ZoneIngressApp]
 	if !ok {
-		c.t.Fatal(errors.Errorf("no tunnel with name %+q", Config.ZoneIngressApp))
+		c.t.Fatal(fmt.Errorf("no tunnel with name %+q", Config.ZoneIngressApp))
 	}
 	return t
 }
@@ -153,6 +151,7 @@ func (c *K8sCluster) ApplyAndWaitServiceOnK8sCluster(namespace string, service s
 
 	return nil
 }
+
 func (c *K8sCluster) WaitNamespaceCreate(namespace string) {
 	retry.DoWithRetry(c.t,
 		"Wait the Kuma Namespace to terminate.",
@@ -191,14 +190,14 @@ func (c *K8sCluster) GetPodLogs(pod v1.Pod) (string, error) {
 	// creates the clientset
 	clientset, err := k8s.GetKubernetesClientFromOptionsE(c.t, c.GetKubectlOptions())
 	if err != nil {
-		return "", errors.Wrapf(err, "error in getting access to K8S")
+		return "", fmt.Errorf("error in getting access to K8S: %w", err)
 	}
 
 	req := clientset.CoreV1().Pods(pod.Namespace).GetLogs(pod.Name, &podLogOpts)
 
 	podLogs, err := req.Stream(context.Background())
 	if err != nil {
-		return "", errors.Wrapf(err, "error in opening stream")
+		return "", fmt.Errorf("error in opening stream: %w", err)
 	}
 	defer podLogs.Close()
 
@@ -206,7 +205,7 @@ func (c *K8sCluster) GetPodLogs(pod v1.Pod) (string, error) {
 
 	_, err = io.Copy(buf, podLogs)
 	if err != nil {
-		return "", errors.Wrap(err, "error in copy information from podLogs to buf")
+		return "", fmt.Errorf("error in copy information from podLogs to buf: %w", err)
 	}
 
 	str := buf.String()
@@ -438,7 +437,7 @@ func (c *K8sCluster) DeployKuma(mode core.CpMode, opt ...KumaDeploymentOption) e
 	switch mode {
 	case core.Zone:
 		if c.opts.globalAddress == "" {
-			return errors.Errorf("GlobalAddress expected for zone")
+			return fmt.Errorf("GlobalAddress expected for zone")
 		}
 	}
 
@@ -454,7 +453,7 @@ func (c *K8sCluster) DeployKuma(mode core.CpMode, opt ...KumaDeploymentOption) e
 		}
 		err = c.deployKumaViaHelm(mode)
 	default:
-		return errors.Errorf("invalid installation mode: %s", c.opts.installationMode)
+		return fmt.Errorf("invalid installation mode: %s", c.opts.installationMode)
 	}
 
 	if err != nil {
@@ -574,7 +573,7 @@ func (c *K8sCluster) UpgradeKuma(mode string, opt ...KumaDeploymentOption) error
 	switch mode {
 	case core.Zone:
 		if c.opts.globalAddress == "" {
-			return errors.Errorf("GlobalAddress expected for zone")
+			return fmt.Errorf("GlobalAddress expected for zone")
 		}
 	}
 
@@ -741,7 +740,7 @@ func (c *K8sCluster) GetKumaCPLogs() (string, error) {
 
 	pods := c.GetKuma().(*K8sControlPlane).GetKumaCPPods()
 	if len(pods) < 1 {
-		return "", errors.Errorf("no kuma-cp pods found for logs")
+		return "", fmt.Errorf("no kuma-cp pods found for logs")
 	}
 
 	for _, p := range pods {
@@ -983,7 +982,7 @@ func (c *K8sCluster) Deploy(deployment Deployment) error {
 func (c *K8sCluster) DeleteDeployment(name string) error {
 	deployment, ok := c.deployments[name]
 	if !ok {
-		return errors.Errorf("deployment %s not found", name)
+		return fmt.Errorf("deployment %s not found", name)
 	}
 	if err := deployment.Delete(c); err != nil {
 		return err
@@ -1009,7 +1008,7 @@ func (c *K8sCluster) WaitApp(name, namespace string, replicas int) error {
 		},
 	)
 	if len(pods) < replicas {
-		return errors.Errorf("%s pods: %d. expected %d", name, len(pods), replicas)
+		return fmt.Errorf("%s pods: %d. expected %d", name, len(pods), replicas)
 	}
 
 	for i := 0; i < replicas; i++ {

--- a/test/framework/k8s_clusters.go
+++ b/test/framework/k8s_clusters.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/gruntwork-io/terratest/modules/k8s"
 	"github.com/gruntwork-io/terratest/modules/testing"
-	"github.com/pkg/errors"
 
 	"github.com/kumahq/kuma/pkg/config/core"
 	"github.com/kumahq/kuma/test/framework/envoy_admin"
@@ -22,7 +21,7 @@ var _ Clusters = &K8sClusters{}
 
 func NewK8sClusters(clusterNames []string, verbose bool) (Clusters, error) {
 	if len(clusterNames) < 1 || len(clusterNames) > maxClusters {
-		return nil, errors.Errorf("Invalid cluster number. Should be in the range [1,3], but it is %d", len(clusterNames))
+		return nil, fmt.Errorf("Invalid cluster number. Should be in the range [1,3], but it is %d", len(clusterNames))
 	}
 
 	t := NewTestingT()
@@ -71,7 +70,7 @@ func (cs *K8sClusters) GetKumaCPLogs() (string, error) {
 func (cs *K8sClusters) DismissCluster() error {
 	for name, c := range cs.clusters {
 		if err := c.DismissCluster(); err != nil {
-			return errors.Wrapf(err, "Deploy Kuma on %s failed: %v", name, err)
+			return fmt.Errorf("Deploy Kuma on %s failed: %w", name, err)
 		}
 	}
 
@@ -98,7 +97,7 @@ func (cs *K8sClusters) GetCluster(name string) Cluster {
 func (cs *K8sClusters) DeployKuma(mode core.CpMode, opt ...KumaDeploymentOption) error {
 	for name, c := range cs.clusters {
 		if err := c.DeployKuma(mode, opt...); err != nil {
-			return errors.Wrapf(err, "Deploy Kuma on %s failed: %v", name, err)
+			return fmt.Errorf("Deploy Kuma on %s failed: %w", name, err)
 		}
 	}
 
@@ -108,7 +107,7 @@ func (cs *K8sClusters) DeployKuma(mode core.CpMode, opt ...KumaDeploymentOption)
 func (cs *K8sClusters) UpgradeKuma(mode string, opt ...KumaDeploymentOption) error {
 	for name, c := range cs.clusters {
 		if err := c.UpgradeKuma(mode, opt...); err != nil {
-			return errors.Wrapf(err, "Upgrade Kuma on %s failed: %v", name, err)
+			return fmt.Errorf("Upgrade Kuma on %s failed: %w", name, err)
 		}
 	}
 
@@ -122,7 +121,7 @@ func (cs *K8sClusters) GetKuma() ControlPlane {
 func (cs *K8sClusters) VerifyKuma() error {
 	for name, c := range cs.clusters {
 		if err := c.VerifyKuma(); err != nil {
-			return errors.Wrapf(err, "Verify Kuma on %s failed: %v", name, err)
+			return fmt.Errorf("Verify Kuma on %s failed: %w", name, err)
 		}
 	}
 
@@ -140,7 +139,7 @@ func (cs *K8sClusters) DeleteKuma() error {
 	}
 
 	if len(failed) > 0 {
-		return errors.Errorf("Clusters failed to delete %v", failed)
+		return fmt.Errorf("Clusters failed to delete %v", failed)
 	}
 
 	return nil
@@ -153,7 +152,7 @@ func (cs *K8sClusters) GetKubectlOptions(namespace ...string) *k8s.KubectlOption
 func (cs *K8sClusters) CreateNamespace(namespace string) error {
 	for name, c := range cs.clusters {
 		if err := c.CreateNamespace(namespace); err != nil {
-			return errors.Wrapf(err, "Creating Namespace %s on %s failed: %v", namespace, name, err)
+			return fmt.Errorf("Creating Namespace %s on %s failed: %w", namespace, name, err)
 		}
 	}
 
@@ -163,7 +162,7 @@ func (cs *K8sClusters) CreateNamespace(namespace string) error {
 func (cs *K8sClusters) DeleteNamespace(namespace string) error {
 	for name, c := range cs.clusters {
 		if err := c.DeleteNamespace(namespace); err != nil {
-			return errors.Wrapf(err, "Delete Namespace %s on %s failed: %v", namespace, name, err)
+			return fmt.Errorf("Delete Namespace %s on %s failed: %w", namespace, name, err)
 		}
 	}
 
@@ -178,7 +177,7 @@ func (cs *K8sClusters) GetKumactlOptions() *KumactlOptions {
 func (cs *K8sClusters) DeployApp(opt ...AppDeploymentOption) error {
 	for name, c := range cs.clusters {
 		if err := c.DeployApp(opt...); err != nil {
-			return errors.Wrapf(err, "unable to deploy on %s", name)
+			return fmt.Errorf("unable to deploy on %s: %w", name, err)
 		}
 	}
 
@@ -188,7 +187,7 @@ func (cs *K8sClusters) DeployApp(opt ...AppDeploymentOption) error {
 func (cs *K8sClusters) DeleteApp(namespace, appname string) error {
 	for name, c := range cs.clusters {
 		if err := c.DeleteApp(namespace, appname); err != nil {
-			return errors.Wrapf(err, "Labeling Namespace %s on %s failed: %v", namespace, name, err)
+			return fmt.Errorf("Labeling Namespace %s on %s failed: %w", namespace, name, err)
 		}
 	}
 
@@ -206,7 +205,7 @@ func (cs *K8sClusters) Deployment(name string) Deployment {
 func (cs *K8sClusters) Deploy(deployment Deployment) error {
 	for name, c := range cs.clusters {
 		if err := c.Deploy(deployment); err != nil {
-			return errors.Wrapf(err, "deployment %s failed on %s cluster", deployment.Name(), name)
+			return fmt.Errorf("deployment %s failed on %s cluster: %w", deployment.Name(), name, err)
 		}
 	}
 	return nil
@@ -215,7 +214,7 @@ func (cs *K8sClusters) Deploy(deployment Deployment) error {
 func (cs *K8sClusters) DeleteDeployment(deploymentName string) error {
 	for name, c := range cs.clusters {
 		if err := c.DeleteDeployment(deploymentName); err != nil {
-			return errors.Wrapf(err, "delete deployment %s failed on %s cluster", deploymentName, name)
+			return fmt.Errorf("delete deployment %s failed on %s cluster: %w", deploymentName, name, err)
 		}
 	}
 	return nil

--- a/test/framework/k8s_controlplane.go
+++ b/test/framework/k8s_controlplane.go
@@ -13,7 +13,6 @@ import (
 	"github.com/gruntwork-io/terratest/modules/k8s"
 	"github.com/gruntwork-io/terratest/modules/retry"
 	"github.com/gruntwork-io/terratest/modules/testing"
-	"github.com/pkg/errors"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -120,7 +119,7 @@ func (c *K8sControlPlane) GetKumaCPSvcs() []v1.Service {
 
 func (c *K8sControlPlane) VerifyKumaCtl() error {
 	if c.portFwd.ApiServerEndpoint == "" {
-		return errors.Errorf("API port not forwarded")
+		return fmt.Errorf("API port not forwarded")
 	}
 
 	output, err := c.kumactl.RunKumactlAndGetOutputV(c.verbose, "get", "dataplanes")
@@ -302,7 +301,7 @@ func (c *K8sControlPlane) UpdateObject(
 	codecs := serializer.NewCodecFactory(scheme)
 	info, ok := runtime.SerializerInfoForMediaType(codecs.SupportedMediaTypes(), runtime.ContentTypeYAML)
 	if !ok {
-		return errors.Errorf("no serializer for %q", runtime.ContentTypeYAML)
+		return fmt.Errorf("no serializer for %q", runtime.ContentTypeYAML)
 	}
 
 	_, err = retry.DoWithRetryableErrorsE(c.t, "update object", map[string]string{"Error from server \\(Conflict\\)": "object conflict"}, 5, time.Second, func() (string, error) {
@@ -342,7 +341,7 @@ func (c *K8sControlPlane) UpdateObject(
 	})
 
 	if err != nil {
-		return errors.Wrapf(err, "failed to update %s object %q", typeName, objectName)
+		return fmt.Errorf("failed to update %s object %q: %w", typeName, objectName, err)
 	}
 	return nil
 }

--- a/test/framework/setup.go
+++ b/test/framework/setup.go
@@ -9,7 +9,6 @@ import (
 	"github.com/ghodss/yaml"
 	"github.com/gruntwork-io/terratest/modules/k8s"
 	"github.com/gruntwork-io/terratest/modules/retry"
-	"github.com/pkg/errors"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -250,7 +249,7 @@ func zoneRelatedResource(
 		case AppEgress:
 			return uniCluster.CreateZoneEgress(app, dpName, publicAddress, dpYAML, token, false)
 		default:
-			return errors.Errorf("unsupported appType: %s", appType)
+			return fmt.Errorf("unsupported appType: %s", appType)
 		}
 	}
 }
@@ -458,8 +457,7 @@ func TestServerUniversal(name string, mesh string, opt ...AppDeploymentOption) I
 
 		serviceProbe := ""
 		if opts.serviceProbe {
-			serviceProbe =
-				`    serviceProbe:
+			serviceProbe = `    serviceProbe:
       tcp: {}`
 		}
 

--- a/test/framework/universal_cluster.go
+++ b/test/framework/universal_cluster.go
@@ -1,6 +1,7 @@
 package framework
 
 import (
+	"errors"
 	"fmt"
 	"net"
 	"strings"
@@ -9,7 +10,6 @@ import (
 	"github.com/gruntwork-io/terratest/modules/k8s"
 	"github.com/gruntwork-io/terratest/modules/retry"
 	"github.com/gruntwork-io/terratest/modules/testing"
-	"github.com/pkg/errors"
 	"go.uber.org/multierr"
 
 	"github.com/kumahq/kuma/pkg/config/core"
@@ -94,7 +94,7 @@ func (c *UniversalCluster) DeployKuma(mode core.CpMode, opt ...KumaDeploymentOpt
 	}
 	c.opts.apply(opt...)
 	if c.opts.installationMode != KumactlInstallationMode {
-		return errors.Errorf("universal clusters only support the '%s' installation mode but got '%s'", KumactlInstallationMode, c.opts.installationMode)
+		return fmt.Errorf("universal clusters only support the '%s' installation mode but got '%s'", KumactlInstallationMode, c.opts.installationMode)
 	}
 
 	env := map[string]string{"KUMA_MODE": mode, "KUMA_DNS_SERVER_PORT": "53"}
@@ -335,7 +335,7 @@ func runPostgresMigration(kumaCP *UniversalApp, envVars map[string]string) error
 
 	app := ssh.NewApp(kumaCP.verbose, sshPort, envVars, args)
 	if err := app.Run(); err != nil {
-		return errors.Errorf("db migration err: %s\nstderr :%s\nstdout %s", err.Error(), app.Err(), app.Out())
+		return fmt.Errorf("db migration err: %s\nstderr :%s\nstdout %s", err.Error(), app.Err(), app.Out())
 	}
 
 	return nil
@@ -348,7 +348,7 @@ func (c *UniversalCluster) GetApp(appName string) *UniversalApp {
 func (c *UniversalCluster) DeleteApp(appname string) error {
 	app, ok := c.apps[appname]
 	if !ok {
-		return errors.Errorf("App %s not found for deletion", appname)
+		return fmt.Errorf("App %s not found for deletion", appname)
 	}
 	if err := app.Stop(); err != nil {
 		return err
@@ -375,7 +375,7 @@ func (c *UniversalCluster) DeleteMeshApps(mesh string) error {
 func (c *UniversalCluster) Exec(namespace, podName, appname string, cmd ...string) (string, string, error) {
 	app, ok := c.apps[appname]
 	if !ok {
-		return "", "", errors.Errorf("App %s not found", appname)
+		return "", "", fmt.Errorf("App %s not found", appname)
 	}
 	sshApp := ssh.NewApp(c.verbose, app.ports[sshPort], nil, cmd)
 	err := sshApp.Run()
@@ -393,7 +393,7 @@ func (c *UniversalCluster) ExecWithRetries(namespace, podName, appname string, c
 		func() (string, error) {
 			app, ok := c.apps[appname]
 			if !ok {
-				return "", errors.Errorf("App %s not found", appname)
+				return "", fmt.Errorf("App %s not found", appname)
 			}
 			sshApp := ssh.NewApp(c.verbose, app.ports[sshPort], nil, cmd)
 			err := sshApp.Run()
@@ -423,7 +423,7 @@ func (c *UniversalCluster) Deploy(deployment Deployment) error {
 func (c *UniversalCluster) DeleteDeployment(name string) error {
 	deployment, ok := c.deployments[name]
 	if !ok {
-		return errors.Errorf("deployment %s not found", name)
+		return fmt.Errorf("deployment %s not found", name)
 	}
 	if err := deployment.Delete(c); err != nil {
 		return err
@@ -479,7 +479,7 @@ func (c *UniversalCluster) GetZoneIngressEnvoyTunnel() envoy_admin.Tunnel {
 func (c *UniversalCluster) GetZoneEgressEnvoyTunnelE() (envoy_admin.Tunnel, error) {
 	t, ok := c.envoyTunnels[Config.ZoneEgressApp]
 	if !ok {
-		return nil, errors.Errorf("no tunnel with name %+q", Config.ZoneEgressApp)
+		return nil, fmt.Errorf("no tunnel with name %+q", Config.ZoneEgressApp)
 	}
 
 	return t, nil
@@ -488,7 +488,7 @@ func (c *UniversalCluster) GetZoneEgressEnvoyTunnelE() (envoy_admin.Tunnel, erro
 func (c *UniversalCluster) GetZoneIngressEnvoyTunnelE() (envoy_admin.Tunnel, error) {
 	t, ok := c.envoyTunnels[Config.ZoneIngressApp]
 	if !ok {
-		return nil, errors.Errorf("no tunnel with name %+q", Config.ZoneIngressApp)
+		return nil, fmt.Errorf("no tunnel with name %+q", Config.ZoneIngressApp)
 	}
 
 	return t, nil

--- a/test/framework/universal_clusters.go
+++ b/test/framework/universal_clusters.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/gruntwork-io/terratest/modules/k8s"
 	"github.com/gruntwork-io/terratest/modules/testing"
-	"github.com/pkg/errors"
 
 	"github.com/kumahq/kuma/pkg/config/core"
 	"github.com/kumahq/kuma/test/framework/envoy_admin"
@@ -22,7 +21,7 @@ var _ Clusters = &UniversalClusters{}
 
 func NewUniversalClusters(clusterNames []string, verbose bool) (Clusters, error) {
 	if len(clusterNames) < 1 || len(clusterNames) > maxClusters {
-		return nil, errors.Errorf("Invalid cluster number. Should be in the range [1,3], but it is %d", len(clusterNames))
+		return nil, fmt.Errorf("Invalid cluster number. Should be in the range [1,3], but it is %d", len(clusterNames))
 	}
 
 	t := NewTestingT()
@@ -71,7 +70,7 @@ func (cs *UniversalClusters) Name() string {
 func (cs *UniversalClusters) DismissCluster() error {
 	for name, c := range cs.clusters {
 		if err := c.DismissCluster(); err != nil {
-			return errors.Wrapf(err, "Dismiss cluster %s failed: %v", name, err)
+			return fmt.Errorf("Dismiss cluster %s failed: %w", name, err)
 		}
 	}
 
@@ -90,7 +89,7 @@ func (cs *UniversalClusters) GetCluster(name string) Cluster {
 func (cs *UniversalClusters) DeployKuma(mode core.CpMode, opt ...KumaDeploymentOption) error {
 	for name, c := range cs.clusters {
 		if err := c.DeployKuma(mode, opt...); err != nil {
-			return errors.Wrapf(err, "Deploy Kuma on %s failed: %v", name, err)
+			return fmt.Errorf("Deploy Kuma on %s failed: %w", name, err)
 		}
 	}
 
@@ -104,7 +103,7 @@ func (cs *UniversalClusters) GetKuma() ControlPlane {
 func (cs *UniversalClusters) VerifyKuma() error {
 	for name, c := range cs.clusters {
 		if err := c.VerifyKuma(); err != nil {
-			return errors.Wrapf(err, "Verify Kuma on %s failed: %v", name, err)
+			return fmt.Errorf("Verify Kuma on %s failed: %w", name, err)
 		}
 	}
 
@@ -122,7 +121,7 @@ func (cs *UniversalClusters) DeleteKuma() error {
 	}
 
 	if len(failed) > 0 {
-		return errors.Errorf("Clusters failed to delete %v", failed)
+		return fmt.Errorf("Clusters failed to delete %v", failed)
 	}
 
 	return nil
@@ -135,7 +134,7 @@ func (cs *UniversalClusters) GetKubectlOptions(namespace ...string) *k8s.Kubectl
 func (cs *UniversalClusters) CreateNamespace(namespace string) error {
 	for name, c := range cs.clusters {
 		if err := c.CreateNamespace(namespace); err != nil {
-			return errors.Wrapf(err, "Creating Namespace %s on %s failed: %v", namespace, name, err)
+			return fmt.Errorf("Creating Namespace %s on %s failed: %w", namespace, name, err)
 		}
 	}
 
@@ -145,7 +144,7 @@ func (cs *UniversalClusters) CreateNamespace(namespace string) error {
 func (cs *UniversalClusters) DeleteNamespace(namespace string) error {
 	for name, c := range cs.clusters {
 		if err := c.DeleteNamespace(namespace); err != nil {
-			return errors.Wrapf(err, "Delete Namespace %s on %s failed: %v", namespace, name, err)
+			return fmt.Errorf("Delete Namespace %s on %s failed: %w", namespace, name, err)
 		}
 	}
 
@@ -161,7 +160,7 @@ func (cs *UniversalClusters) GetKumactlOptions() *KumactlOptions {
 func (cs *UniversalClusters) DeployApp(opt ...AppDeploymentOption) error {
 	for name, c := range cs.clusters {
 		if err := c.DeployApp(opt...); err != nil {
-			return errors.Wrapf(err, "unable to deploy on %s", name)
+			return fmt.Errorf("unable to deploy on %s: %w", name, err)
 		}
 	}
 
@@ -171,7 +170,7 @@ func (cs *UniversalClusters) DeployApp(opt ...AppDeploymentOption) error {
 func (cs *UniversalClusters) DeleteApp(appname string) error {
 	for name, c := range cs.clusters {
 		if err := c.DeleteApp(appname); err != nil {
-			return errors.Wrapf(err, "delete app %s failed", name)
+			return fmt.Errorf("delete app %s failed: %w", name, err)
 		}
 	}
 
@@ -197,7 +196,7 @@ func (cs *UniversalClusters) Deployment(string) Deployment {
 func (cs *UniversalClusters) Deploy(deployment Deployment) error {
 	for name, c := range cs.clusters {
 		if err := c.Deploy(deployment); err != nil {
-			return errors.Wrapf(err, "deployment %s failed on %s cluster", deployment.Name(), name)
+			return fmt.Errorf("deployment %s failed on %s cluster: %w", deployment.Name(), name, err)
 		}
 	}
 	return nil
@@ -206,7 +205,7 @@ func (cs *UniversalClusters) Deploy(deployment Deployment) error {
 func (cs *UniversalClusters) DeleteDeployment(deploymentName string) error {
 	for name, c := range cs.clusters {
 		if err := c.DeleteDeployment(deploymentName); err != nil {
-			return errors.Wrapf(err, "delete deployment %s failed on %s cluster", deploymentName, name)
+			return fmt.Errorf("delete deployment %s failed on %s cluster: %w", deploymentName, name, err)
 		}
 	}
 	return nil

--- a/test/framework/universal_controlplane.go
+++ b/test/framework/universal_controlplane.go
@@ -3,12 +3,12 @@ package framework
 import (
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net"
 
 	"github.com/gruntwork-io/terratest/modules/retry"
 	"github.com/gruntwork-io/terratest/modules/testing"
-	"github.com/pkg/errors"
 
 	"github.com/kumahq/kuma/pkg/config/core"
 	core_model "github.com/kumahq/kuma/pkg/core/resources/model"
@@ -78,9 +78,11 @@ func (c *UniversalControlPlane) GetAPIServerAddress() string {
 
 func (c *UniversalControlPlane) GetMetrics() (string, error) {
 	return retry.DoWithRetryE(c.t, "fetching CP metrics", DefaultRetries, DefaultTimeout, func() (string, error) {
-		sshApp := ssh.NewApp(c.verbose, c.cpNetworking.SshPort, nil, []string{"curl",
+		sshApp := ssh.NewApp(c.verbose, c.cpNetworking.SshPort, nil, []string{
+			"curl",
 			"--fail", "--show-error",
-			"http://localhost:5680/metrics"})
+			"http://localhost:5680/metrics",
+		})
 		if err := sshApp.Run(); err != nil {
 			return "", err
 		}
@@ -107,11 +109,13 @@ func (c *UniversalControlPlane) generateToken(
 				c.verbose,
 				c.cpNetworking.SshPort,
 				nil,
-				[]string{"curl",
+				[]string{
+					"curl",
 					"--fail", "--show-error",
 					"-H", "\"Content-Type: application/json\"",
 					"--data", data,
-					"http://localhost:5681/tokens" + tokenPath},
+					"http://localhost:5681/tokens" + tokenPath,
+				},
 			)
 
 			if err := sshApp.Run(); err != nil {

--- a/test/testenvconfig/envconfig.go
+++ b/test/testenvconfig/envconfig.go
@@ -24,13 +24,12 @@ package testenvconfig
 
 import (
 	"encoding"
+	"errors"
 	"fmt"
 	"reflect"
 	"regexp"
 	"strconv"
 	"strings"
-
-	"github.com/pkg/errors"
 )
 
 // varInfo maintains information about the configuration variable
@@ -93,8 +92,10 @@ func binaryUnmarshaler(field reflect.Value) (b encoding.BinaryUnmarshaler) {
 	return b
 }
 
-var gatherRegexp = regexp.MustCompile("([^A-Z]+|[A-Z]+[^A-Z]+|[A-Z]+)")
-var acronymRegexp = regexp.MustCompile("([A-Z]+)([A-Z][^A-Z]+)")
+var (
+	gatherRegexp  = regexp.MustCompile("([^A-Z]+|[A-Z]+[^A-Z]+|[A-Z]+)")
+	acronymRegexp = regexp.MustCompile("([A-Z]+)([A-Z][^A-Z]+)")
+)
 
 // GatherInfo gathers information about the specified struct
 func GatherInfo(prefix string, spec interface{}) ([]varInfo, error) {

--- a/tools/policy-gen/protoc-gen-kumapolicy/crd.go
+++ b/tools/policy-gen/protoc-gen-kumapolicy/crd.go
@@ -6,7 +6,6 @@ import (
 	"go/format"
 	"html/template"
 
-	"github.com/pkg/errors"
 	"google.golang.org/protobuf/compiler/protogen"
 
 	"github.com/kumahq/kuma/tools/resource-gen/genutils"
@@ -198,7 +197,7 @@ func generateCRD(
 	}
 
 	if len(infos) > 1 {
-		return errors.Errorf("only one Kuma resource per proto file is allowed")
+		return fmt.Errorf("only one Kuma resource per proto file is allowed")
 	}
 
 	info := infos[0]

--- a/tools/policy-gen/protoc-gen-kumapolicy/main.go
+++ b/tools/policy-gen/protoc-gen-kumapolicy/main.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"html/template"
 
-	"github.com/pkg/errors"
 	"google.golang.org/protobuf/compiler/protogen"
 
 	"github.com/kumahq/kuma/tools/resource-gen/genutils"
@@ -61,7 +60,7 @@ func generateEndpoints(
 	}
 
 	if len(infos) > 1 {
-		return errors.Errorf("only one Kuma resource per proto file is allowed")
+		return fmt.Errorf("only one Kuma resource per proto file is allowed")
 	}
 
 	info := infos[0]

--- a/tools/policy-gen/protoc-gen-kumapolicy/plugin.go
+++ b/tools/policy-gen/protoc-gen-kumapolicy/plugin.go
@@ -2,10 +2,10 @@ package main
 
 import (
 	"bytes"
+	"fmt"
 	"go/format"
 	"html/template"
 
-	"github.com/pkg/errors"
 	"google.golang.org/protobuf/compiler/protogen"
 
 	"github.com/kumahq/kuma/tools/resource-gen/genutils"
@@ -52,7 +52,7 @@ func generatePluginFile(
 	}
 
 	if len(infos) > 1 {
-		return errors.Errorf("only one Kuma resource per proto file is allowed")
+		return fmt.Errorf("only one Kuma resource per proto file is allowed")
 	}
 
 	info := infos[0]

--- a/tools/policy-gen/protoc-gen-kumapolicy/resource.go
+++ b/tools/policy-gen/protoc-gen-kumapolicy/resource.go
@@ -6,7 +6,6 @@ import (
 	"go/format"
 	"html/template"
 
-	"github.com/pkg/errors"
 	"google.golang.org/protobuf/compiler/protogen"
 
 	"github.com/kumahq/kuma/tools/resource-gen/genutils"
@@ -161,7 +160,7 @@ func generateResource(
 	}
 
 	if len(infos) > 1 {
-		return errors.Errorf("only one Kuma resource per proto file is allowed")
+		return fmt.Errorf("only one Kuma resource per proto file is allowed")
 	}
 
 	outBuf := bytes.Buffer{}


### PR DESCRIPTION
### Summary

The package https://github.com/pkg/errors is not maintained anymore.
This PR replaces https://github.com/pkg/errors with official errors and fmt golang packages

### Testing

- [ ] Unit tests
- [ ] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes

### Backwards compatibility

- [ ] Update [`UPGRADE.md`](/UPGRADE.md) with any steps users will need to take when upgrading.
- [ ] Add `backport-to-stable` label if the code follows our [backporting policy](/CONTRIBUTING.md#backporting)

Signed-off-by: Matthieu MOREL <mmorel-35@users.noreply.github.com>