### PR TITLE
fix(kuma-dp) access log path on windows when cp is on linux

### DIFF
--- a/app/kuma-dp/cmd/context.go
+++ b/app/kuma-dp/cmd/context.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"crypto/tls"
 	"net/http"
+	"runtime"
 	"time"
 
 	"github.com/kumahq/kuma/app/kuma-dp/pkg/dataplane/envoy"
@@ -28,7 +29,7 @@ func DefaultRootContext() *RootContext {
 		BootstrapGenerator: envoy.NewRemoteBootstrapGenerator(&http.Client{
 			Timeout:   10 * time.Second,
 			Transport: &http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: true}},
-		}),
+		}, runtime.GOOS),
 		Config:                   &config,
 		BootstrapDynamicMetadata: map[string]string{},
 	}

--- a/app/kuma-dp/pkg/dataplane/envoy/remote_bootstrap.go
+++ b/app/kuma-dp/pkg/dataplane/envoy/remote_bootstrap.go
@@ -24,11 +24,15 @@ import (
 )
 
 type remoteBootstrap struct {
-	client *http.Client
+	client          *http.Client
+	operatingSystem string
 }
 
-func NewRemoteBootstrapGenerator(client *http.Client) BootstrapConfigFactoryFunc {
-	rb := remoteBootstrap{client: client}
+func NewRemoteBootstrapGenerator(client *http.Client, operatingSystem string) BootstrapConfigFactoryFunc {
+	rb := remoteBootstrap{
+		client:          client,
+		operatingSystem: operatingSystem,
+	}
 	return rb.Generate
 }
 
@@ -151,6 +155,7 @@ func (b *remoteBootstrap) requestForBootstrap(ctx context.Context, url *net_url.
 		DynamicMetadata: params.DynamicMetadata,
 		DNSPort:         params.DNSPort,
 		EmptyDNSPort:    params.EmptyDNSPort,
+		OperatingSystem: b.operatingSystem,
 	}
 	jsonBytes, err := json.Marshal(request)
 	if err != nil {

--- a/app/kuma-dp/pkg/dataplane/envoy/remote_bootstrap_test.go
+++ b/app/kuma-dp/pkg/dataplane/envoy/remote_bootstrap_test.go
@@ -67,7 +67,7 @@ var _ = Describe("Remote Bootstrap", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		// and
-		generator := NewRemoteBootstrapGenerator(http.DefaultClient)
+		generator := NewRemoteBootstrapGenerator(http.DefaultClient, "linux")
 
 		// when
 		params := BootstrapParams{
@@ -130,7 +130,8 @@ var _ = Describe("Remote Bootstrap", func() {
 					  "caCert": "",
 					  "dynamicMetadata": {
 					    "test": "value"
-					  }
+					  },
+					  "operatingSystem": "linux"
 					}`,
 				}
 			}()),
@@ -176,7 +177,8 @@ var _ = Describe("Remote Bootstrap", func() {
                         }
                       },
                       "caCert": "",
-                      "dynamicMetadata": null
+                      "dynamicMetadata": null,
+                      "operatingSystem": "linux"
                     }`,
 				}
 			}()),
@@ -221,7 +223,8 @@ var _ = Describe("Remote Bootstrap", func() {
                         }
                       },
                       "caCert": "",
-                      "dynamicMetadata": null
+                      "dynamicMetadata": null,
+                      "operatingSystem": "linux"
                     }`,
 				}
 			}()),
@@ -264,7 +267,8 @@ var _ = Describe("Remote Bootstrap", func() {
                         }
                       },
                       "caCert": "",
-					  "dynamicMetadata": null
+					  "dynamicMetadata": null,
+					  "operatingSystem": "linux"
                     }`,
 				}
 			}()),
@@ -309,7 +313,7 @@ var _ = Describe("Remote Bootstrap", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		// and
-		generator := NewRemoteBootstrapGenerator(http.DefaultClient)
+		generator := NewRemoteBootstrapGenerator(http.DefaultClient, "linux")
 
 		// when
 		cfg := kuma_dp.DefaultConfig()
@@ -368,7 +372,7 @@ var _ = Describe("Remote Bootstrap", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		// and
-		generator := NewRemoteBootstrapGenerator(http.DefaultClient)
+		generator := NewRemoteBootstrapGenerator(http.DefaultClient, "linux")
 
 		// when
 		cfg := kuma_dp.DefaultConfig()
@@ -402,7 +406,7 @@ var _ = Describe("Remote Bootstrap", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		// and
-		generator := NewRemoteBootstrapGenerator(http.DefaultClient)
+		generator := NewRemoteBootstrapGenerator(http.DefaultClient, "linux")
 
 		// when
 		config := kuma_dp.DefaultConfig()

--- a/pkg/xds/bootstrap/generator.go
+++ b/pkg/xds/bootstrap/generator.go
@@ -371,6 +371,9 @@ func (b *bootstrapGenerator) xdsHost(request types.BootstrapRequest) string {
 }
 
 func (b *bootstrapGenerator) adminAccessLogPath(operatingSystem string) string {
+	if operatingSystem == "" { // backwards compatibility
+		return b.config.Params.AdminAccessLogPath
+	}
 	if b.config.Params.AdminAccessLogPath == os.DevNull && operatingSystem == "windows" {
 		// when AdminAccessLogPath was not explicitly set and DPP OS is Windows we need to set window specific DevNull.
 		// otherwise when CP is on Linux, we would set /dev/null which is not corrent on Windows.

--- a/pkg/xds/bootstrap/generator.go
+++ b/pkg/xds/bootstrap/generator.go
@@ -79,7 +79,7 @@ func (b *bootstrapGenerator) Generate(ctx context.Context, request types.Bootstr
 	params := configParameters{
 		Id:                    proxyId.String(),
 		AdminAddress:          b.config.Params.AdminAddress,
-		AdminAccessLogPath:    b.config.Params.AdminAccessLogPath,
+		AdminAccessLogPath:    b.adminAccessLogPath(request.OperatingSystem),
 		XdsHost:               b.xdsHost(request),
 		XdsPort:               b.config.Params.XdsPort,
 		XdsConnectTimeout:     b.config.Params.XdsConnectTimeout,
@@ -368,6 +368,15 @@ func (b *bootstrapGenerator) xdsHost(request types.BootstrapRequest) string {
 	} else {
 		return request.Host
 	}
+}
+
+func (b *bootstrapGenerator) adminAccessLogPath(operatingSystem string) string {
+	if b.config.Params.AdminAccessLogPath == os.DevNull && operatingSystem == "windows" {
+		// when AdminAccessLogPath was not explicitly set and DPP OS is Windows we need to set window specific DevNull.
+		// otherwise when CP is on Linux, we would set /dev/null which is not corrent on Windows.
+		return "NUL"
+	}
+	return b.config.Params.AdminAccessLogPath
 }
 
 type SANSet map[string]bool

--- a/pkg/xds/bootstrap/generator_test.go
+++ b/pkg/xds/bootstrap/generator_test.go
@@ -3,6 +3,7 @@ package bootstrap_test
 import (
 	"context"
 	"fmt"
+	"os"
 	"path/filepath"
 	"time"
 
@@ -194,7 +195,7 @@ var _ = Describe("bootstrapGenerator", func() {
 					Params: &bootstrap_config.BootstrapParamsConfig{
 						AdminAddress:       "192.168.0.1", // by default, Envoy Admin interface should listen on loopback address
 						AdminPort:          9902,          // by default, turn off Admin interface of Envoy
-						AdminAccessLogPath: "/var/log",
+						AdminAccessLogPath: os.DevNull,
 						XdsHost:            "localhost",
 						XdsPort:            15678,
 						XdsConnectTimeout:  2 * time.Second,
@@ -203,9 +204,10 @@ var _ = Describe("bootstrapGenerator", func() {
 			},
 			dataplane: defaultDataplane,
 			request: types.BootstrapRequest{
-				Mesh:           "mesh",
-				Name:           "name.namespace",
-				DataplaneToken: "token",
+				Mesh:            "mesh",
+				Name:            "name.namespace",
+				DataplaneToken:  "token",
+				OperatingSystem: "windows",
 				DynamicMetadata: map[string]string{
 					"test": "value",
 				},

--- a/pkg/xds/bootstrap/testdata/generator.custom-config.golden.yaml
+++ b/pkg/xds/bootstrap/testdata/generator.custom-config.golden.yaml
@@ -1,5 +1,5 @@
 admin:
-  accessLogPath: /var/log
+  accessLogPath: NUL
   address:
     socketAddress:
       address: 192.168.0.1

--- a/pkg/xds/bootstrap/types/bootstrap_request.go
+++ b/pkg/xds/bootstrap/types/bootstrap_request.go
@@ -15,6 +15,7 @@ type BootstrapRequest struct {
 	DynamicMetadata map[string]string `json:"dynamicMetadata"`
 	DNSPort         uint32            `json:"dnsPort,omitempty"`
 	EmptyDNSPort    uint32            `json:"emptyDnsPort,omitempty"`
+	OperatingSystem string            `json:"operatingSystem"`
 }
 
 type Version struct {


### PR DESCRIPTION
### Summary

When CP is deployed on linux VM and DP is on windows VM, there we set `/dev/null` to access log path which crashes Envoy.

### Issues resolved

No issues reported.

### Documentation

~- [ ] Link to the website [documentation PR](https://github.com/kumahq/kuma-website/pull/XXX)~

### Testing

- [X] Unit tests
- [ ] E2E tests
- [X] Manual testing on Universal
- [ ] Manual testing on Kubernetes

### Backwards compatibility

~- [ ] Update [`UPGRADE.md`](/UPGRADE.md) with any steps users will need to take when upgrading.~
- [X] Add `backport-to-stable` label if the code follows our [backporting policy](/CONTRIBUTING.md#backporting)
