### PR TITLE
test(e2e): use PodNameOfApp helper in tests

### DIFF
--- a/test/e2e/externalservices/externalservices_kubernetes_without_egress.go
+++ b/test/e2e/externalservices/externalservices_kubernetes_without_egress.go
@@ -3,11 +3,8 @@ package externalservices
 import (
 	"fmt"
 
-	"github.com/gruntwork-io/terratest/modules/k8s"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	v1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/kumahq/kuma/pkg/config/core"
 	. "github.com/kumahq/kuma/test/framework"
@@ -53,7 +50,7 @@ spec:
 	es2 := "2"
 
 	var cluster Cluster
-	var clientPod *v1.Pod
+	var clientPodName string
 
 	BeforeEach(func() {
 		clusters, err := NewK8sClusters(
@@ -74,17 +71,8 @@ spec:
 		err = YamlK8s(fmt.Sprintf(meshDefaulMtlsOn, "false", "false"))(cluster)
 		Expect(err).ToNot(HaveOccurred())
 
-		pods, err := k8s.ListPodsE(
-			cluster.GetTesting(),
-			cluster.GetKubectlOptions(TestNamespace),
-			metav1.ListOptions{
-				LabelSelector: fmt.Sprintf("app=%s", "demo-client"),
-			},
-		)
+		clientPodName, err = PodNameOfApp(cluster, "demo-client", TestNamespace)
 		Expect(err).ToNot(HaveOccurred())
-		Expect(pods).To(HaveLen(1))
-
-		clientPod = &pods[0]
 	})
 
 	E2EAfterEach(func() {
@@ -99,7 +87,7 @@ spec:
 	})
 
 	trafficBlocked := func() error {
-		_, _, err := cluster.Exec(TestNamespace, clientPod.GetName(), "demo-client",
+		_, _, err := cluster.Exec(TestNamespace, clientPodName, "demo-client",
 			"curl", "-v", "-m", "3", "--fail", "http://externalservice-http-server.externalservice-namespace:10080")
 		return err
 	}
@@ -110,7 +98,7 @@ spec:
 		Expect(err).ToNot(HaveOccurred())
 
 		// then communication outside of the Mesh works
-		_, stderr, err := cluster.ExecWithRetries(TestNamespace, clientPod.GetName(), "demo-client",
+		_, stderr, err := cluster.ExecWithRetries(TestNamespace, clientPodName, "demo-client",
 			"curl", "-v", "-m", "3", "--fail", "http://externalservice-http-server.externalservice-namespace:10080")
 		Expect(err).ToNot(HaveOccurred())
 		Expect(stderr).To(ContainSubstring("HTTP/1.1 200 OK"))
@@ -120,7 +108,7 @@ spec:
 		Expect(err).ToNot(HaveOccurred())
 
 		// then communication outside of the Mesh works
-		_, stderr, err = cluster.ExecWithRetries(TestNamespace, clientPod.GetName(), "demo-client",
+		_, stderr, err = cluster.ExecWithRetries(TestNamespace, clientPodName, "demo-client",
 			"curl", "-v", "-m", "3", "--fail", "http://externalservice-http-server.externalservice-namespace:10080")
 		Expect(err).ToNot(HaveOccurred())
 		Expect(stderr).To(ContainSubstring("HTTP/1.1 200 OK"))
@@ -152,7 +140,7 @@ spec:
 			"true"))(cluster)
 		Expect(err).ToNot(HaveOccurred())
 
-		_, _, err = cluster.ExecWithRetries(TestNamespace, clientPod.GetName(), "demo-client",
+		_, _, err = cluster.ExecWithRetries(TestNamespace, clientPodName, "demo-client",
 			"curl", "-v", "-m", "3", "--fail", "http://external-service.mesh:10080")
 		Expect(err).To(HaveOccurred())
 	})

--- a/test/e2e/zoneegress/externalservices/zoneegress_externalservices_hybrid.go
+++ b/test/e2e/zoneegress/externalservices/zoneegress_externalservices_hybrid.go
@@ -4,10 +4,8 @@ import (
 	"fmt"
 	"net"
 
-	"github.com/gruntwork-io/terratest/modules/k8s"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	config_core "github.com/kumahq/kuma/pkg/config/core"
 	. "github.com/kumahq/kuma/test/framework"
@@ -145,17 +143,8 @@ networking:
 			"external-service-1",
 		)
 
-		pods, err := k8s.ListPodsE(
-			zone1.GetTesting(),
-			zone1.GetKubectlOptions(TestNamespace),
-			metav1.ListOptions{
-				LabelSelector: fmt.Sprintf("app=%s", "demo-client"),
-			},
-		)
+		clientPodName, err := PodNameOfApp(zone1, "demo-client", TestNamespace)
 		Expect(err).ToNot(HaveOccurred())
-		Expect(pods).To(HaveLen(1))
-
-		clientPod := pods[0]
 
 		Eventually(func(g Gomega) {
 			stat, err := zone1.GetZoneEgressEnvoyTunnel().GetStats(filter)
@@ -163,7 +152,7 @@ networking:
 			g.Expect(stat).To(stats.BeEqualZero())
 		}, "30s", "1s").Should(Succeed())
 
-		_, stderr, err := zone1.ExecWithRetries(TestNamespace, clientPod.GetName(), "demo-client",
+		_, stderr, err := zone1.ExecWithRetries(TestNamespace, clientPodName, "demo-client",
 			"curl", "--verbose", "--max-time", "3", "--fail", "external-service-1.mesh")
 		Expect(err).ToNot(HaveOccurred())
 		Expect(stderr).To(ContainSubstring("HTTP/1.1 200 OK"))
@@ -204,19 +193,11 @@ networking:
 		// given k8s cluster
 		k8sCluster := zone1.(*K8sCluster)
 
-		pods, err := k8s.ListPodsE(
-			zone1.GetTesting(),
-			zone1.GetKubectlOptions(TestNamespace),
-			metav1.ListOptions{
-				LabelSelector: fmt.Sprintf("app=%s", "demo-client"),
-			},
-		)
+		clientPodName, err := PodNameOfApp(zone1, "demo-client", TestNamespace)
 		Expect(err).ToNot(HaveOccurred())
-		Expect(pods).To(HaveLen(1))
 
-		clientPod := pods[0]
 		serviceUnreachable := func() error {
-			_, _, err := k8sCluster.ExecWithRetries(TestNamespace, clientPod.GetName(), "demo-client",
+			_, _, err := k8sCluster.ExecWithRetries(TestNamespace, clientPodName, "demo-client",
 				"curl", "--verbose", "--max-time", "3", "--fail", "external-service-1.mesh")
 			return err
 		}

--- a/test/e2e_env/multizone/trafficpermission/trafficpermission.go
+++ b/test/e2e_env/multizone/trafficpermission/trafficpermission.go
@@ -1,12 +1,9 @@
 package trafficpermission
 
 import (
-	"fmt"
-
 	"github.com/gruntwork-io/terratest/modules/k8s"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	"github.com/kumahq/kuma/test/e2e_env/multizone/env"
@@ -47,15 +44,8 @@ func TrafficPermission() {
 			Setup(env.KubeZone1)
 		Expect(err).ToNot(HaveOccurred())
 
-		pods, err := k8s.ListPodsE(
-			env.KubeZone1.GetTesting(),
-			env.KubeZone1.GetKubectlOptions(namespace),
-			metav1.ListOptions{
-				LabelSelector: fmt.Sprintf("app=%s", "demo-client"),
-			},
-		)
+		clientPodName, err = PodNameOfApp(env.KubeZone1, "demo-client", namespace)
 		Expect(err).ToNot(HaveOccurred())
-		clientPodName = pods[0].Name
 	})
 
 	BeforeEach(func() {


### PR DESCRIPTION
### Summary

I noticed that recently quite often bring this on reviews. Because it's not used in every single test, it's easy to copy the full code.

### Issues resolved

No issues reported

### Documentation

~- [ ] Link to the website [documentation PR](https://github.com/kumahq/kuma-website/pull/XXX)~

### Testing

- [ ] Unit tests
- [X] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes

### Backwards compatibility

~- [ ] Update [`UPGRADE.md`](/UPGRADE.md) with any steps users will need to take when upgrading.~
~- [ ] Add `backport-to-stable` label if the code follows our [backporting policy](/CONTRIBUTING.md#backporting)~
