### PR TITLE
feat(kuma-cp): use remote address for Gateway

### DIFF
--- a/pkg/plugins/runtime/gateway/filter_chain_generator.go
+++ b/pkg/plugins/runtime/gateway/filter_chain_generator.go
@@ -274,6 +274,8 @@ func newFilterChain(ctx xds_context.MeshContext, info GatewayListenerInfo) *envo
 		envoy_listeners.StripHostPort(),
 		envoy_listeners.AddFilterChainConfigurer(
 			envoy_listeners_v3.HttpConnectionManagerMustConfigureFunc(func(hcm *envoy_hcm.HttpConnectionManager) {
+				hcm.UseRemoteAddress = util_proto.Bool(true)
+
 				hcm.RequestHeadersTimeout = util_proto.Duration(DefaultRequestHeadersTimeout)
 				hcm.StreamIdleTimeout = util_proto.Duration(DefaultStreamIdleTimeout)
 

--- a/pkg/plugins/runtime/gateway/testdata/01-gateway-listener.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/01-gateway-listener.yaml
@@ -47,6 +47,7 @@ Resources:
           statPrefix: gateway-default
           streamIdleTimeout: 5s
           stripAnyHostPort: true
+          useRemoteAddress: true
     listenerFilters:
     - name: envoy.filters.listener.tls_inspector
       typedConfig:

--- a/pkg/plugins/runtime/gateway/testdata/02-gateway-listener.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/02-gateway-listener.yaml
@@ -47,6 +47,7 @@ Resources:
           statPrefix: gateway-default
           streamIdleTimeout: 5s
           stripAnyHostPort: true
+          useRemoteAddress: true
     listenerFilters:
     - name: envoy.filters.listener.tls_inspector
       typedConfig:
@@ -102,6 +103,7 @@ Resources:
           statPrefix: gateway-default
           streamIdleTimeout: 5s
           stripAnyHostPort: true
+          useRemoteAddress: true
     listenerFilters:
     - name: envoy.filters.listener.tls_inspector
       typedConfig:

--- a/pkg/plugins/runtime/gateway/testdata/03-gateway-listener.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/03-gateway-listener.yaml
@@ -58,6 +58,7 @@ Resources:
                 collectorEndpoint: /api/v2/spans
                 collectorEndpointVersion: HTTP_JSON
                 collectorHostname: jaeger-collector.kuma-tracing:9411
+          useRemoteAddress: true
     listenerFilters:
     - name: envoy.filters.listener.tls_inspector
       typedConfig:

--- a/pkg/plugins/runtime/gateway/testdata/04-gateway-listener.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/04-gateway-listener.yaml
@@ -56,6 +56,7 @@ Resources:
           statPrefix: gateway-default
           streamIdleTimeout: 5s
           stripAnyHostPort: true
+          useRemoteAddress: true
     listenerFilters:
     - name: envoy.filters.listener.tls_inspector
       typedConfig:

--- a/pkg/plugins/runtime/gateway/testdata/05-gateway-listener.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/05-gateway-listener.yaml
@@ -51,6 +51,7 @@ Resources:
           statPrefix: gateway-default
           streamIdleTimeout: 5s
           stripAnyHostPort: true
+          useRemoteAddress: true
       transportSocket:
         name: envoy.transport_sockets.tls
         typedConfig:
@@ -112,6 +113,7 @@ Resources:
           statPrefix: gateway-default
           streamIdleTimeout: 5s
           stripAnyHostPort: true
+          useRemoteAddress: true
       transportSocket:
         name: envoy.transport_sockets.tls
         typedConfig:
@@ -173,6 +175,7 @@ Resources:
           statPrefix: gateway-default
           streamIdleTimeout: 5s
           stripAnyHostPort: true
+          useRemoteAddress: true
       transportSocket:
         name: envoy.transport_sockets.tls
         typedConfig:
@@ -232,6 +235,7 @@ Resources:
           statPrefix: gateway-default
           streamIdleTimeout: 5s
           stripAnyHostPort: true
+          useRemoteAddress: true
       transportSocket:
         name: envoy.transport_sockets.tls
         typedConfig:

--- a/pkg/plugins/runtime/gateway/testdata/http/01-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/01-gateway-route.yaml
@@ -95,6 +95,7 @@ Listeners:
             statPrefix: gateway-default
             streamIdleTimeout: 5s
             stripAnyHostPort: true
+            useRemoteAddress: true
       listenerFilters:
       - name: envoy.filters.listener.tls_inspector
         typedConfig:

--- a/pkg/plugins/runtime/gateway/testdata/http/02-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/02-gateway-route.yaml
@@ -95,6 +95,7 @@ Listeners:
             statPrefix: gateway-default
             streamIdleTimeout: 5s
             stripAnyHostPort: true
+            useRemoteAddress: true
       listenerFilters:
       - name: envoy.filters.listener.tls_inspector
         typedConfig:

--- a/pkg/plugins/runtime/gateway/testdata/http/03-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/03-gateway-route.yaml
@@ -95,6 +95,7 @@ Listeners:
             statPrefix: gateway-default
             streamIdleTimeout: 5s
             stripAnyHostPort: true
+            useRemoteAddress: true
       listenerFilters:
       - name: envoy.filters.listener.tls_inspector
         typedConfig:

--- a/pkg/plugins/runtime/gateway/testdata/http/04-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/04-gateway-route.yaml
@@ -124,6 +124,7 @@ Listeners:
             statPrefix: gateway-default
             streamIdleTimeout: 5s
             stripAnyHostPort: true
+            useRemoteAddress: true
       listenerFilters:
       - name: envoy.filters.listener.tls_inspector
         typedConfig:

--- a/pkg/plugins/runtime/gateway/testdata/http/05-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/05-gateway-route.yaml
@@ -52,6 +52,7 @@ Listeners:
             statPrefix: gateway-default
             streamIdleTimeout: 5s
             stripAnyHostPort: true
+            useRemoteAddress: true
       listenerFilters:
       - name: envoy.filters.listener.tls_inspector
         typedConfig:

--- a/pkg/plugins/runtime/gateway/testdata/http/06-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/06-gateway-route.yaml
@@ -124,6 +124,7 @@ Listeners:
             statPrefix: gateway-default
             streamIdleTimeout: 5s
             stripAnyHostPort: true
+            useRemoteAddress: true
       listenerFilters:
       - name: envoy.filters.listener.tls_inspector
         typedConfig:

--- a/pkg/plugins/runtime/gateway/testdata/http/07-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/07-gateway-route.yaml
@@ -95,6 +95,7 @@ Listeners:
             statPrefix: gateway-default
             streamIdleTimeout: 5s
             stripAnyHostPort: true
+            useRemoteAddress: true
       listenerFilters:
       - name: envoy.filters.listener.tls_inspector
         typedConfig:

--- a/pkg/plugins/runtime/gateway/testdata/http/08-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/08-gateway-route.yaml
@@ -138,6 +138,7 @@ Listeners:
             statPrefix: gateway-default
             streamIdleTimeout: 5s
             stripAnyHostPort: true
+            useRemoteAddress: true
       listenerFilters:
       - name: envoy.filters.listener.tls_inspector
         typedConfig:

--- a/pkg/plugins/runtime/gateway/testdata/http/09-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/09-gateway-route.yaml
@@ -95,6 +95,7 @@ Listeners:
             statPrefix: gateway-default
             streamIdleTimeout: 5s
             stripAnyHostPort: true
+            useRemoteAddress: true
       listenerFilters:
       - name: envoy.filters.listener.tls_inspector
         typedConfig:

--- a/pkg/plugins/runtime/gateway/testdata/http/10-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/10-gateway-route.yaml
@@ -138,6 +138,7 @@ Listeners:
             statPrefix: gateway-default
             streamIdleTimeout: 5s
             stripAnyHostPort: true
+            useRemoteAddress: true
       listenerFilters:
       - name: envoy.filters.listener.tls_inspector
         typedConfig:

--- a/pkg/plugins/runtime/gateway/testdata/http/11-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/11-gateway-route.yaml
@@ -138,6 +138,7 @@ Listeners:
             statPrefix: gateway-default
             streamIdleTimeout: 5s
             stripAnyHostPort: true
+            useRemoteAddress: true
       listenerFilters:
       - name: envoy.filters.listener.tls_inspector
         typedConfig:

--- a/pkg/plugins/runtime/gateway/testdata/http/12-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/12-gateway-route.yaml
@@ -95,6 +95,7 @@ Listeners:
             statPrefix: gateway-default
             streamIdleTimeout: 5s
             stripAnyHostPort: true
+            useRemoteAddress: true
       listenerFilters:
       - name: envoy.filters.listener.tls_inspector
         typedConfig:

--- a/pkg/plugins/runtime/gateway/testdata/http/13-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/13-gateway-route.yaml
@@ -181,6 +181,7 @@ Listeners:
             statPrefix: gateway-default
             streamIdleTimeout: 5s
             stripAnyHostPort: true
+            useRemoteAddress: true
       listenerFilters:
       - name: envoy.filters.listener.tls_inspector
         typedConfig:

--- a/pkg/plugins/runtime/gateway/testdata/http/14-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/14-gateway-route.yaml
@@ -95,6 +95,7 @@ Listeners:
             statPrefix: gateway-default
             streamIdleTimeout: 5s
             stripAnyHostPort: true
+            useRemoteAddress: true
       listenerFilters:
       - name: envoy.filters.listener.tls_inspector
         typedConfig:

--- a/pkg/plugins/runtime/gateway/testdata/http/15-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/15-gateway-route.yaml
@@ -181,6 +181,7 @@ Listeners:
             statPrefix: gateway-default
             streamIdleTimeout: 5s
             stripAnyHostPort: true
+            useRemoteAddress: true
       listenerFilters:
       - name: envoy.filters.listener.tls_inspector
         typedConfig:

--- a/pkg/plugins/runtime/gateway/testdata/http/16-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/16-gateway-route.yaml
@@ -178,6 +178,7 @@ Listeners:
             statPrefix: gateway-default
             streamIdleTimeout: 5s
             stripAnyHostPort: true
+            useRemoteAddress: true
       listenerFilters:
       - name: envoy.filters.listener.tls_inspector
         typedConfig:

--- a/pkg/plugins/runtime/gateway/testdata/http/17-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/17-gateway-route.yaml
@@ -199,6 +199,7 @@ Listeners:
             statPrefix: gateway-default
             streamIdleTimeout: 5s
             stripAnyHostPort: true
+            useRemoteAddress: true
       listenerFilters:
       - name: envoy.filters.listener.tls_inspector
         typedConfig:

--- a/pkg/plugins/runtime/gateway/testdata/http/18-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/18-gateway-route.yaml
@@ -92,6 +92,7 @@ Listeners:
             statPrefix: gateway-default
             streamIdleTimeout: 5s
             stripAnyHostPort: true
+            useRemoteAddress: true
       listenerFilters:
       - name: envoy.filters.listener.tls_inspector
         typedConfig:

--- a/pkg/plugins/runtime/gateway/testdata/http/19-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/19-gateway-route.yaml
@@ -104,6 +104,7 @@ Listeners:
             statPrefix: gateway-default
             streamIdleTimeout: 5s
             stripAnyHostPort: true
+            useRemoteAddress: true
       listenerFilters:
       - name: envoy.filters.listener.tls_inspector
         typedConfig:

--- a/pkg/plugins/runtime/gateway/testdata/http/20-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/20-gateway-route.yaml
@@ -181,6 +181,7 @@ Listeners:
             statPrefix: gateway-multihost
             streamIdleTimeout: 5s
             stripAnyHostPort: true
+            useRemoteAddress: true
       listenerFilters:
       - name: envoy.filters.listener.tls_inspector
         typedConfig:

--- a/pkg/plugins/runtime/gateway/testdata/http/21-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/21-gateway-route.yaml
@@ -181,6 +181,7 @@ Listeners:
             statPrefix: gateway-default
             streamIdleTimeout: 5s
             stripAnyHostPort: true
+            useRemoteAddress: true
       listenerFilters:
       - name: envoy.filters.listener.tls_inspector
         typedConfig:

--- a/pkg/plugins/runtime/gateway/testdata/http/22-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/22-gateway-route.yaml
@@ -138,6 +138,7 @@ Listeners:
             statPrefix: gateway-default
             streamIdleTimeout: 5s
             stripAnyHostPort: true
+            useRemoteAddress: true
       listenerFilters:
       - name: envoy.filters.listener.tls_inspector
         typedConfig:

--- a/pkg/plugins/runtime/gateway/testdata/http/23-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/23-gateway-route.yaml
@@ -138,6 +138,7 @@ Listeners:
             statPrefix: gateway-default
             streamIdleTimeout: 5s
             stripAnyHostPort: true
+            useRemoteAddress: true
       listenerFilters:
       - name: envoy.filters.listener.tls_inspector
         typedConfig:

--- a/pkg/plugins/runtime/gateway/testdata/http/24-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/24-gateway-route.yaml
@@ -138,6 +138,7 @@ Listeners:
             statPrefix: gateway-default
             streamIdleTimeout: 5s
             stripAnyHostPort: true
+            useRemoteAddress: true
       listenerFilters:
       - name: envoy.filters.listener.tls_inspector
         typedConfig:

--- a/pkg/plugins/runtime/gateway/testdata/http/25-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/25-gateway-route.yaml
@@ -117,6 +117,7 @@ Listeners:
             statPrefix: gateway-default
             streamIdleTimeout: 5s
             stripAnyHostPort: true
+            useRemoteAddress: true
       listenerFilters:
       - name: envoy.filters.listener.tls_inspector
         typedConfig:

--- a/pkg/plugins/runtime/gateway/testdata/http/26-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/26-gateway-route.yaml
@@ -103,6 +103,7 @@ Listeners:
             statPrefix: gateway-default
             streamIdleTimeout: 5s
             stripAnyHostPort: true
+            useRemoteAddress: true
       listenerFilters:
       - name: envoy.filters.listener.tls_inspector
         typedConfig:

--- a/pkg/plugins/runtime/gateway/testdata/http/cross-mesh-gateway.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/cross-mesh-gateway.yaml
@@ -173,6 +173,7 @@ Listeners:
             statPrefix: gateway-default
             streamIdleTimeout: 5s
             stripAnyHostPort: true
+            useRemoteAddress: true
         transportSocket:
           name: envoy.transport_sockets.tls
           typedConfig:

--- a/pkg/plugins/runtime/gateway/testdata/https/01-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/01-gateway-route.yaml
@@ -95,6 +95,7 @@ Listeners:
             statPrefix: gateway-default
             streamIdleTimeout: 5s
             stripAnyHostPort: true
+            useRemoteAddress: true
       listenerFilters:
       - name: envoy.filters.listener.tls_inspector
         typedConfig:

--- a/pkg/plugins/runtime/gateway/testdata/https/02-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/02-gateway-route.yaml
@@ -95,6 +95,7 @@ Listeners:
             statPrefix: gateway-default
             streamIdleTimeout: 5s
             stripAnyHostPort: true
+            useRemoteAddress: true
       listenerFilters:
       - name: envoy.filters.listener.tls_inspector
         typedConfig:

--- a/pkg/plugins/runtime/gateway/testdata/https/03-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/03-gateway-route.yaml
@@ -99,6 +99,7 @@ Listeners:
             statPrefix: gateway-default
             streamIdleTimeout: 5s
             stripAnyHostPort: true
+            useRemoteAddress: true
         transportSocket:
           name: envoy.transport_sockets.tls
           typedConfig:

--- a/pkg/plugins/runtime/gateway/testdata/https/04-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/04-gateway-route.yaml
@@ -128,6 +128,7 @@ Listeners:
             statPrefix: gateway-default
             streamIdleTimeout: 5s
             stripAnyHostPort: true
+            useRemoteAddress: true
         transportSocket:
           name: envoy.transport_sockets.tls
           typedConfig:

--- a/pkg/plugins/runtime/gateway/testdata/https/05-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/05-gateway-route.yaml
@@ -56,6 +56,7 @@ Listeners:
             statPrefix: gateway-default
             streamIdleTimeout: 5s
             stripAnyHostPort: true
+            useRemoteAddress: true
         transportSocket:
           name: envoy.transport_sockets.tls
           typedConfig:

--- a/pkg/plugins/runtime/gateway/testdata/https/06-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/06-gateway-route.yaml
@@ -128,6 +128,7 @@ Listeners:
             statPrefix: gateway-default
             streamIdleTimeout: 5s
             stripAnyHostPort: true
+            useRemoteAddress: true
         transportSocket:
           name: envoy.transport_sockets.tls
           typedConfig:

--- a/pkg/plugins/runtime/gateway/testdata/https/07-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/07-gateway-route.yaml
@@ -99,6 +99,7 @@ Listeners:
             statPrefix: gateway-default
             streamIdleTimeout: 5s
             stripAnyHostPort: true
+            useRemoteAddress: true
         transportSocket:
           name: envoy.transport_sockets.tls
           typedConfig:

--- a/pkg/plugins/runtime/gateway/testdata/https/08-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/08-gateway-route.yaml
@@ -142,6 +142,7 @@ Listeners:
             statPrefix: gateway-default
             streamIdleTimeout: 5s
             stripAnyHostPort: true
+            useRemoteAddress: true
         transportSocket:
           name: envoy.transport_sockets.tls
           typedConfig:

--- a/pkg/plugins/runtime/gateway/testdata/https/09-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/09-gateway-route.yaml
@@ -99,6 +99,7 @@ Listeners:
             statPrefix: gateway-default
             streamIdleTimeout: 5s
             stripAnyHostPort: true
+            useRemoteAddress: true
         transportSocket:
           name: envoy.transport_sockets.tls
           typedConfig:

--- a/pkg/plugins/runtime/gateway/testdata/https/10-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/10-gateway-route.yaml
@@ -142,6 +142,7 @@ Listeners:
             statPrefix: gateway-default
             streamIdleTimeout: 5s
             stripAnyHostPort: true
+            useRemoteAddress: true
         transportSocket:
           name: envoy.transport_sockets.tls
           typedConfig:

--- a/pkg/plugins/runtime/gateway/testdata/https/11-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/11-gateway-route.yaml
@@ -142,6 +142,7 @@ Listeners:
             statPrefix: gateway-default
             streamIdleTimeout: 5s
             stripAnyHostPort: true
+            useRemoteAddress: true
         transportSocket:
           name: envoy.transport_sockets.tls
           typedConfig:

--- a/pkg/plugins/runtime/gateway/testdata/https/12-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/12-gateway-route.yaml
@@ -99,6 +99,7 @@ Listeners:
             statPrefix: gateway-default
             streamIdleTimeout: 5s
             stripAnyHostPort: true
+            useRemoteAddress: true
         transportSocket:
           name: envoy.transport_sockets.tls
           typedConfig:

--- a/pkg/plugins/runtime/gateway/testdata/https/13-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/13-gateway-route.yaml
@@ -185,6 +185,7 @@ Listeners:
             statPrefix: gateway-default
             streamIdleTimeout: 5s
             stripAnyHostPort: true
+            useRemoteAddress: true
         transportSocket:
           name: envoy.transport_sockets.tls
           typedConfig:

--- a/pkg/plugins/runtime/gateway/testdata/https/14-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/14-gateway-route.yaml
@@ -99,6 +99,7 @@ Listeners:
             statPrefix: gateway-default
             streamIdleTimeout: 5s
             stripAnyHostPort: true
+            useRemoteAddress: true
         transportSocket:
           name: envoy.transport_sockets.tls
           typedConfig:

--- a/pkg/plugins/runtime/gateway/testdata/https/15-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/15-gateway-route.yaml
@@ -185,6 +185,7 @@ Listeners:
             statPrefix: gateway-default
             streamIdleTimeout: 5s
             stripAnyHostPort: true
+            useRemoteAddress: true
         transportSocket:
           name: envoy.transport_sockets.tls
           typedConfig:

--- a/pkg/plugins/runtime/gateway/testdata/https/16-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/16-gateway-route.yaml
@@ -182,6 +182,7 @@ Listeners:
             statPrefix: gateway-default
             streamIdleTimeout: 5s
             stripAnyHostPort: true
+            useRemoteAddress: true
         transportSocket:
           name: envoy.transport_sockets.tls
           typedConfig:

--- a/pkg/plugins/runtime/gateway/testdata/https/17-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/17-gateway-route.yaml
@@ -203,6 +203,7 @@ Listeners:
             statPrefix: gateway-default
             streamIdleTimeout: 5s
             stripAnyHostPort: true
+            useRemoteAddress: true
         transportSocket:
           name: envoy.transport_sockets.tls
           typedConfig:

--- a/pkg/plugins/runtime/gateway/testdata/https/18-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/18-gateway-route.yaml
@@ -96,6 +96,7 @@ Listeners:
             statPrefix: gateway-default
             streamIdleTimeout: 5s
             stripAnyHostPort: true
+            useRemoteAddress: true
         transportSocket:
           name: envoy.transport_sockets.tls
           typedConfig:

--- a/pkg/plugins/runtime/gateway/testdata/https/19-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/19-gateway-route.yaml
@@ -108,6 +108,7 @@ Listeners:
             statPrefix: gateway-default
             streamIdleTimeout: 5s
             stripAnyHostPort: true
+            useRemoteAddress: true
         transportSocket:
           name: envoy.transport_sockets.tls
           typedConfig:

--- a/pkg/plugins/runtime/gateway/testdata/https/20-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/20-gateway-route.yaml
@@ -185,6 +185,7 @@ Listeners:
             statPrefix: gateway-multihost
             streamIdleTimeout: 5s
             stripAnyHostPort: true
+            useRemoteAddress: true
         transportSocket:
           name: envoy.transport_sockets.tls
           typedConfig:
@@ -246,6 +247,7 @@ Listeners:
             statPrefix: gateway-multihost
             streamIdleTimeout: 5s
             stripAnyHostPort: true
+            useRemoteAddress: true
         transportSocket:
           name: envoy.transport_sockets.tls
           typedConfig:
@@ -307,6 +309,7 @@ Listeners:
             statPrefix: gateway-multihost
             streamIdleTimeout: 5s
             stripAnyHostPort: true
+            useRemoteAddress: true
         transportSocket:
           name: envoy.transport_sockets.tls
           typedConfig:

--- a/pkg/plugins/runtime/gateway/testdata/https/21-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/21-gateway-route.yaml
@@ -185,6 +185,7 @@ Listeners:
             statPrefix: gateway-default
             streamIdleTimeout: 5s
             stripAnyHostPort: true
+            useRemoteAddress: true
         transportSocket:
           name: envoy.transport_sockets.tls
           typedConfig:

--- a/pkg/plugins/runtime/gateway/testdata/https/22-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/22-gateway-route.yaml
@@ -138,6 +138,7 @@ Listeners:
             statPrefix: gateway-default
             streamIdleTimeout: 5s
             stripAnyHostPort: true
+            useRemoteAddress: true
       listenerFilters:
       - name: envoy.filters.listener.tls_inspector
         typedConfig:

--- a/pkg/plugins/runtime/gateway/testdata/https/23-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/23-gateway-route.yaml
@@ -138,6 +138,7 @@ Listeners:
             statPrefix: gateway-default
             streamIdleTimeout: 5s
             stripAnyHostPort: true
+            useRemoteAddress: true
       listenerFilters:
       - name: envoy.filters.listener.tls_inspector
         typedConfig:

--- a/pkg/plugins/runtime/gateway/testdata/https/24-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/24-gateway-route.yaml
@@ -138,6 +138,7 @@ Listeners:
             statPrefix: gateway-default
             streamIdleTimeout: 5s
             stripAnyHostPort: true
+            useRemoteAddress: true
       listenerFilters:
       - name: envoy.filters.listener.tls_inspector
         typedConfig:

--- a/pkg/plugins/runtime/gateway/testdata/https/25-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/25-gateway-route.yaml
@@ -121,6 +121,7 @@ Listeners:
             statPrefix: gateway-default
             streamIdleTimeout: 5s
             stripAnyHostPort: true
+            useRemoteAddress: true
         transportSocket:
           name: envoy.transport_sockets.tls
           typedConfig:

--- a/pkg/plugins/runtime/gateway/testdata/https/26-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/26-gateway-route.yaml
@@ -107,6 +107,7 @@ Listeners:
             statPrefix: gateway-default
             streamIdleTimeout: 5s
             stripAnyHostPort: true
+            useRemoteAddress: true
         transportSocket:
           name: envoy.transport_sockets.tls
           typedConfig:

--- a/pkg/plugins/runtime/gateway/testdata/https/cross-mesh-gateway.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/cross-mesh-gateway.yaml
@@ -173,6 +173,7 @@ Listeners:
             statPrefix: gateway-default
             streamIdleTimeout: 5s
             stripAnyHostPort: true
+            useRemoteAddress: true
         transportSocket:
           name: envoy.transport_sockets.tls
           typedConfig:


### PR DESCRIPTION
Signed-off-by: Jakub Dyszkiewicz <jakub.dyszkiewicz@gmail.com>

### Summary

SUMMARY_GOES_HERE

### Full changelog

* [Implement ...]
* [Fix ...]

### Issues resolved

Fix #XXX

### Documentation

- [ ] Link to the website [documentation PR](https://github.com/kumahq/kuma-website/pull/XXX)

### Testing

- [ ] Unit tests
- [ ] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes

### Backwards compatibility

- [ ] Update [`UPGRADE.md`](/UPGRADE.md) with any steps users will need to take when upgrading.
- [ ] Add `backport-to-stable` label if the code follows our [backporting policy](/CONTRIBUTING.md#backporting)
