### PR TITLE
feat(gateway): allow MeshGateway Dataplane Pods to bind privileged ports

### DIFF
--- a/pkg/plugins/runtime/k8s/controllers/gateway_instance_controller.go
+++ b/pkg/plugins/runtime/k8s/controllers/gateway_instance_controller.go
@@ -251,6 +251,12 @@ func (r *GatewayInstanceReconciler) createOrUpdateDeployment(
 						Value: "0",
 					}},
 				}
+			} else {
+				secContext := container.SecurityContext
+				if secContext.Capabilities == nil {
+					secContext.Capabilities = &kube_core.Capabilities{}
+				}
+				secContext.Capabilities.Add = append(secContext.Capabilities.Add, "NET_BIND_SERVICE")
 			}
 
 			podSpec := kube_core.PodSpec{

--- a/pkg/plugins/runtime/k8s/controllers/gateway_instance_controller.go
+++ b/pkg/plugins/runtime/k8s/controllers/gateway_instance_controller.go
@@ -17,6 +17,7 @@ import (
 	kube_schema "k8s.io/apimachinery/pkg/runtime/schema"
 	kube_types "k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	kube_version "k8s.io/apimachinery/pkg/version"
 	kube_ctrl "sigs.k8s.io/controller-runtime"
 	kube_client "sigs.k8s.io/controller-runtime/pkg/client"
 	kube_handler "sigs.k8s.io/controller-runtime/pkg/handler"
@@ -38,6 +39,7 @@ import (
 
 // GatewayInstanceReconciler reconciles a MeshGatewayInstance object.
 type GatewayInstanceReconciler struct {
+	K8sVersion *kube_version.Info
 	kube_client.Client
 	Log logr.Logger
 
@@ -180,6 +182,27 @@ func (r *GatewayInstanceReconciler) createOrUpdateService(
 	return obj.(*kube_core.Service), nil
 }
 
+func isUnprivilegedPortStartSysctlSupported(v kube_version.Info) (bool, error) {
+	major, err := strconv.Atoi(v.Major)
+	if err != nil {
+		return false, err
+	}
+
+	minor, err := strconv.Atoi(v.Minor)
+	if err != nil {
+		return false, err
+	}
+
+	switch {
+	case major > 1:
+		return true, nil
+	case major == 1:
+		return minor >= 22, nil
+	default:
+		return false, nil
+	}
+}
+
 // createOrUpdateDeployment can either return an error, a created Deployment or
 // neither if reconciliation shouldn't continue.
 func (r *GatewayInstanceReconciler) createOrUpdateDeployment(
@@ -215,8 +238,24 @@ func (r *GatewayInstanceReconciler) createOrUpdateDeployment(
 
 			container.Name = k8s_util.KumaGatewayContainerName
 
+			unprivilegedPortStartSupported, err := isUnprivilegedPortStartSysctlSupported(*r.K8sVersion)
+			if err != nil {
+				r.Log.Info("couldn't determine Sysctl `net.ipv4.ip_unprivileged_port_start` support", "error", err)
+			}
+
+			var securityContext *kube_core.PodSecurityContext
+			if unprivilegedPortStartSupported {
+				securityContext = &kube_core.PodSecurityContext{
+					Sysctls: []kube_core.Sysctl{{
+						Name:  "net.ipv4.ip_unprivileged_port_start",
+						Value: "0",
+					}},
+				}
+			}
+
 			podSpec := kube_core.PodSpec{
-				Containers: []kube_core.Container{container},
+				SecurityContext: securityContext,
+				Containers:      []kube_core.Container{container},
 			}
 
 			jsonTags, err := json.Marshal(gatewayInstance.Spec.Tags)

--- a/tools/releases/dockerfiles/Dockerfile.kuma-dp
+++ b/tools/releases/dockerfiles/Dockerfile.kuma-dp
@@ -1,11 +1,20 @@
 ARG BASE_IMAGE_ARCH=amd64
-FROM --platform=linux/$BASE_IMAGE_ARCH gcr.io/distroless/base-debian11:debug-nonroot
 
+FROM debian:11 as envoy
 ARG ENVOY_VERSION
 ARG ARCH
 
+ADD /build/artifacts-linux-$ARCH/envoy/envoy-$ENVOY_VERSION-alpine /envoy
+
+RUN apt-get update && \
+    apt-get install -y libcap2-bin
+RUN setcap cap_net_bind_service+ep /envoy
+
+FROM --platform=linux/$BASE_IMAGE_ARCH gcr.io/distroless/base-debian11:debug-nonroot
+ARG ARCH
+
 ADD /build/artifacts-linux-$ARCH/kuma-dp/kuma-dp /usr/bin
-ADD /build/artifacts-linux-$ARCH/envoy/envoy-$ENVOY_VERSION-alpine /usr/bin/envoy
+COPY --from=envoy /envoy /usr/bin/envoy
 ADD /build/artifacts-linux-$ARCH/coredns/coredns /usr/bin
 
 COPY /tools/releases/templates/LICENSE \


### PR DESCRIPTION
### Summary

Closes #4084. 

* [\>= v1.22 set `net.ipv4.ip_unprivileged_port_start` to `0`](https://github.com/kubernetes/kubernetes/pull/103326) so that all ports are unprivileged
* < v1.22
  * build `kuma-dp` using `setcap` to add `cap_net_bind_service` to `envoy`
  * add `NET_BIND_SERVICE` capability to gateway container

I've tested as working on GKE.