### PR TITLE
fix(gateway): check hostname intersection between HTTPRoute and Gateway listener

### DIFF
--- a/pkg/plugins/runtime/k8s/controllers/gatewayapi/attachment/attachment_suite_test.go
+++ b/pkg/plugins/runtime/k8s/controllers/gatewayapi/attachment/attachment_suite_test.go
@@ -6,6 +6,6 @@ import (
 	"github.com/kumahq/kuma/pkg/test"
 )
 
-func TestAllowedRoutes(t *testing.T) {
-	test.RunSpecs(t, "Gateway API AllowedRoutes support")
+func TestRouteAttachment(t *testing.T) {
+	test.RunSpecs(t, "Gateway API route attachment support")
 }

--- a/pkg/plugins/runtime/k8s/controllers/gatewayapi/http_route_controller.go
+++ b/pkg/plugins/runtime/k8s/controllers/gatewayapi/http_route_controller.go
@@ -120,7 +120,7 @@ func (r *HTTPRouteReconciler) gapiToKumaRoutes(
 
 	// Convert GAPI parent refs into selectors
 	for i, ref := range route.Spec.ParentRefs {
-		refAttachment, err := attachment.EvaluateParentRefAttachment(ctx, r.Client, &routeNs, ref)
+		refAttachment, err := attachment.EvaluateParentRefAttachment(ctx, r.Client, route.Spec.Hostnames, &routeNs, ref)
 		if err != nil {
 			return nil, nil, errors.Wrapf(err, "unable to check parent ref %d", i)
 		}


### PR DESCRIPTION
### Summary

The [HTTPRoute docs specify this behavior](https://gateway-api.sigs.k8s.io/v1alpha2/references/spec/#gateway.networking.k8s.io/v1alpha2.HTTPRoute). It's one part of the remaining failing test from #4523 