### PR TITLE
fix(mk): run test/e2e/debug-fast serialized

### DIFF
--- a/mk/e2e.new.mk
+++ b/mk/e2e.new.mk
@@ -106,7 +106,7 @@ test/e2e/debug-fast:
 	$(MAKE) $(K8SCLUSTERS_WAIT_TARGETS) # there is no easy way of waiting for processes in the background so just wait for K8S clusters
 	$(E2E_ENV_VARS) \
 	GINKGO_EDITOR_INTEGRATION=true \
-		$(GINKGO_TEST_E2E) --keep-going=false --fail-fast $(E2E_PKG_LIST)
+		$(GINKGO_TEST_E2E) --procs 1 --keep-going=false --fail-fast $(E2E_PKG_LIST)
 	$(MAKE) test/e2e/k8s/stop
 
 # test/e2e/debug-universal is the same target as 'test/e2e/debug' but builds only 'kuma-universal' image


### PR DESCRIPTION
### Summary

@lahabana Do we need this for all `make/e2e-*` targets?