### PR TITLE
fix(gateway): hostname intersections, use new RouteReasons

### DIFF
--- a/pkg/plugins/runtime/k8s/controllers/gatewayapi/attachment/attachment.go
+++ b/pkg/plugins/runtime/k8s/controllers/gatewayapi/attachment/attachment.go
@@ -26,6 +26,7 @@ const (
 	// Invalid means the route points to a nonexistent parent
 	// or is otherwise invalid
 	Invalid
+	NoHostnameIntersection
 	// Allowed means we could successfully attach
 	Allowed
 )
@@ -160,8 +161,9 @@ func hostnamesIntersect(routeHostnames []gatewayapi.Hostname, listenerHostnames 
 			}
 			// If the gateway hostname is a wildcard and the route hostname
 			// matches the wildcard
-			if suffix := strings.TrimPrefix(string(listenerHostname), "*."); len(suffix) != len(listenerHostname) {
-				return strings.HasSuffix(string(routeHostname), suffix)
+			suffix := strings.TrimPrefix(string(listenerHostname), "*.")
+			if len(suffix) != len(listenerHostname) && strings.HasSuffix(string(routeHostname), suffix) && suffix != string(routeHostname) {
+				return true
 			}
 		}
 	}
@@ -198,7 +200,7 @@ func EvaluateParentRefAttachment(
 	}
 
 	if !hostnamesIntersect(routeHostnames, listenerHostnames) {
-		return Invalid, nil
+		return NoHostnameIntersection, nil
 	}
 
 	return findRouteListenerAttachment(gateway, routeNs, ref.SectionName)

--- a/pkg/plugins/runtime/k8s/controllers/gatewayapi/attachment/attachment.go
+++ b/pkg/plugins/runtime/k8s/controllers/gatewayapi/attachment/attachment.go
@@ -146,6 +146,15 @@ func getParentRefGateway(
 	return gateway, nil
 }
 
+func nameMatchesWildcardName(name, pat gatewayapi.Hostname) bool {
+	suffix := strings.TrimPrefix(string(pat), "*.")
+	if len(suffix) == len(pat) {
+		return false
+	}
+
+	return strings.HasSuffix(string(name), suffix) && suffix != string(name)
+}
+
 func hostnamesIntersect(routeHostnames []gatewayapi.Hostname, listenerHostnames []gatewayapi.Hostname) bool {
 	if len(routeHostnames) == 0 {
 		return true
@@ -159,10 +168,8 @@ func hostnamesIntersect(routeHostnames []gatewayapi.Hostname, listenerHostnames 
 			if routeHostname == listenerHostname {
 				return true
 			}
-			// If the gateway hostname is a wildcard and the route hostname
-			// matches the wildcard
-			suffix := strings.TrimPrefix(string(listenerHostname), "*.")
-			if len(suffix) != len(listenerHostname) && strings.HasSuffix(string(routeHostname), suffix) && suffix != string(routeHostname) {
+			// If one hostname is a wildcard and the other hostname matches the wildcard
+			if nameMatchesWildcardName(routeHostname, listenerHostname) || nameMatchesWildcardName(listenerHostname, routeHostname) {
 				return true
 			}
 		}

--- a/pkg/plugins/runtime/k8s/controllers/gatewayapi/attachment/attachment_test.go
+++ b/pkg/plugins/runtime/k8s/controllers/gatewayapi/attachment/attachment_test.go
@@ -87,6 +87,7 @@ var _ = Describe("Hostname intersection support", func() {
 		DescribeTable("matches", checkAttachment(attachment.Allowed),
 			Entry("on exact match", []gatewayapi.Hostname{"simple.local"}),
 			Entry("if one matches", []gatewayapi.Hostname{"other.local", "simple.local"}),
+			Entry("if route wildcard matches", []gatewayapi.Hostname{"*.local"}),
 		)
 
 		DescribeTable("doesn't match", checkAttachment(attachment.NoHostnameIntersection),

--- a/pkg/plugins/runtime/k8s/controllers/gatewayapi/http_route_controller.go
+++ b/pkg/plugins/runtime/k8s/controllers/gatewayapi/http_route_controller.go
@@ -126,24 +126,6 @@ func (r *HTTPRouteReconciler) gapiToKumaRoutes(
 		}
 
 		switch refAttachment {
-		case attachment.NotPermitted, attachment.Invalid:
-			var message string
-			switch refAttachment {
-			case attachment.NotPermitted:
-				message = "attachment to parent not permitted by AllowedRoutes"
-			case attachment.Invalid:
-				// TODO missing a specific Reason for this?
-				message = "listener not found, reference to parent is invalid"
-			}
-
-			conditions[ref] = []kube_meta.Condition{
-				{
-					Type:    string(gatewayapi.RouteConditionAccepted),
-					Status:  kube_meta.ConditionFalse,
-					Reason:  "Refused", // kubernetes-sigs/gateway-api#972
-					Message: message,
-				},
-			}
 		case attachment.Unknown:
 			// We don't care about this ref
 		case attachment.Allowed:
@@ -155,6 +137,25 @@ func (r *HTTPRouteReconciler) gapiToKumaRoutes(
 			)
 
 			conditions[ref] = routeConditions
+		default:
+			var message string
+			switch refAttachment {
+			case attachment.NotPermitted:
+				message = "attachment to parent not permitted by AllowedRoutes"
+			case attachment.Invalid:
+				message = "listener not found, reference to parent is invalid"
+			case attachment.NoHostnameIntersection:
+				message = "hostnames do not intersect with parent listeners"
+			}
+
+			conditions[ref] = []kube_meta.Condition{
+				{
+					Type:    string(gatewayapi.RouteConditionAccepted),
+					Status:  kube_meta.ConditionFalse,
+					Reason:  "Refused", // kubernetes-sigs/gateway-api#972
+					Message: message,
+				},
+			}
 		}
 	}
 

--- a/pkg/plugins/runtime/k8s/controllers/gatewayapi/http_route_controller.go
+++ b/pkg/plugins/runtime/k8s/controllers/gatewayapi/http_route_controller.go
@@ -138,21 +138,25 @@ func (r *HTTPRouteReconciler) gapiToKumaRoutes(
 
 			conditions[ref] = routeConditions
 		default:
-			var message string
+			var reason, message string
 			switch refAttachment {
 			case attachment.NotPermitted:
-				message = "attachment to parent not permitted by AllowedRoutes"
+				reason = string(gatewayapi.RouteReasonNotAllowedByListeners)
+				message = ""
 			case attachment.Invalid:
+				// TODO how to handle this case?
+				reason = "Refused"
 				message = "listener not found, reference to parent is invalid"
 			case attachment.NoHostnameIntersection:
-				message = "hostnames do not intersect with parent listeners"
+				reason = string(gatewayapi.RouteReasonNoMatchingListenerHostname)
+				message = ""
 			}
 
 			conditions[ref] = []kube_meta.Condition{
 				{
 					Type:    string(gatewayapi.RouteConditionAccepted),
 					Status:  kube_meta.ConditionFalse,
-					Reason:  "Refused", // kubernetes-sigs/gateway-api#972
+					Reason:  reason,
 					Message: message,
 				},
 			}

--- a/pkg/plugins/runtime/k8s/controllers/gatewayapi/http_route_conversion.go
+++ b/pkg/plugins/runtime/k8s/controllers/gatewayapi/http_route_conversion.go
@@ -109,14 +109,14 @@ func (r *HTTPRouteReconciler) gapiToKumaRouteConf(
 		{
 			Type:   string(gatewayapi.RouteConditionResolvedRefs),
 			Status: kube_meta.ConditionTrue,
-			Reason: string(gatewayapi.RouteConditionResolvedRefs),
+			Reason: string(gatewayapi.RouteReasonResolvedRefs),
 		},
 		// TODO: reflect the true state from the actual gateway of this
 		// route
 		{
 			Type:   string(gatewayapi.RouteConditionAccepted),
 			Status: kube_meta.ConditionTrue,
-			Reason: string(gatewayapi.RouteConditionAccepted),
+			Reason: string(gatewayapi.RouteReasonAccepted),
 		},
 	}
 


### PR DESCRIPTION
### Summary

Fixed matching logic and use new upstream status `Reason`s.

Part of #4532