### PR TITLE
fix(gateway): workaround label value max length with hash

### DIFF
--- a/pkg/plugins/runtime/k8s/controllers/gatewayapi/common/reconcile.go
+++ b/pkg/plugins/runtime/k8s/controllers/gatewayapi/common/reconcile.go
@@ -23,7 +23,7 @@ func hashNamespacedName(name kube_types.NamespacedName) string {
 	hash.Write([]byte(name.Namespace))
 	hash.Write([]byte(name.Name))
 	// our hash is 8 characters and our label can be 63
-	return fmt.Sprintf("%.54s-%x", name.String(), hash.Sum(nil))
+	return fmt.Sprintf("%.54s-%x", fmt.Sprintf("%s_%s", name.Namespace, name.Name), hash.Sum(nil))
 }
 
 // ReconcileLabelledObject manages a set of owned kuma objects based on

--- a/pkg/plugins/runtime/k8s/controllers/gatewayapi/common/reconcile.go
+++ b/pkg/plugins/runtime/k8s/controllers/gatewayapi/common/reconcile.go
@@ -19,10 +19,11 @@ import (
 const ownerLabel = "gateways.kuma.io/gateway.networking.k8s.io-owner"
 
 func hashNamespacedName(name kube_types.NamespacedName) string {
-	hash := fnv.New128()
+	hash := fnv.New32()
 	hash.Write([]byte(name.Namespace))
 	hash.Write([]byte(name.Name))
-	return fmt.Sprintf("%x", hash.Sum(nil))
+	// our hash is 8 characters and our label can be 63
+	return fmt.Sprintf("%.54s-%x", name.String(), hash.Sum(nil))
 }
 
 // ReconcileLabelledObject manages a set of owned kuma objects based on


### PR DESCRIPTION
### Summary

We can't use namespace/name as a label value because the character limits are different.

One downside here is that we can no longer look at the label value and
check whether the owner exists without checking all potential owners.
This logic isn't implemented yet, however.