### PR TITLE
test(gateway): enable Gateway API conformance test HTTPRouteHostnameIntersection

### DIFF
--- a/test/e2e/gateway/gatewayapi/conformance_test.go
+++ b/test/e2e/gateway/gatewayapi/conformance_test.go
@@ -85,8 +85,7 @@ func TestConformance(t *testing.T) {
 	var passingTests []suite.ConformanceTest
 	for _, test := range tests.ConformanceTests {
 		switch test.ShortName {
-		case tests.HTTPRouteDisallowedKind.ShortName, // TODO: we only support HTTPRoute so it's not yet possible to test this
-			tests.HTTPRouteHostnameIntersection.ShortName: // TODO parents aren't correct/routes aren't accepted
+		case tests.HTTPRouteDisallowedKind.ShortName: // TODO: we only support HTTPRoute so it's not yet possible to test this
 			continue
 		}
 		passingTests = append(passingTests, test)


### PR DESCRIPTION
### Summary

Closes #4532 

Blocked on #4544 and #4545