### PR TITLE
cleanup(bootstrap): replace deprecated admin_access_log_path

### DIFF
--- a/pkg/xds/bootstrap/generator.go
+++ b/pkg/xds/bootstrap/generator.go
@@ -376,7 +376,7 @@ func (b *bootstrapGenerator) adminAccessLogPath(operatingSystem string) string {
 	}
 	if b.config.Params.AdminAccessLogPath == os.DevNull && operatingSystem == "windows" {
 		// when AdminAccessLogPath was not explicitly set and DPP OS is Windows we need to set window specific DevNull.
-		// otherwise when CP is on Linux, we would set /dev/null which is not corrent on Windows.
+		// otherwise when CP is on Linux, we would set /dev/null which is not valid on Windows.
 		return "NUL"
 	}
 	return b.config.Params.AdminAccessLogPath

--- a/pkg/xds/bootstrap/testdata/bootstrap.overridden.golden.yaml
+++ b/pkg/xds/bootstrap/testdata/bootstrap.overridden.golden.yaml
@@ -1,5 +1,9 @@
 admin:
-  accessLogPath: /dev/null
+  accessLog:
+  - name: envoy.access_loggers.file
+    typedConfig:
+      '@type': type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog
+      path: /dev/null
   address:
     socketAddress:
       address: 127.0.0.1

--- a/pkg/xds/bootstrap/testdata/generator.custom-config-minimal-request.golden.yaml
+++ b/pkg/xds/bootstrap/testdata/generator.custom-config-minimal-request.golden.yaml
@@ -1,5 +1,9 @@
 admin:
-  accessLogPath: /var/log
+  accessLog:
+  - name: envoy.access_loggers.file
+    typedConfig:
+      '@type': type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog
+      path: /var/log
   address:
     socketAddress:
       address: 192.168.0.1

--- a/pkg/xds/bootstrap/testdata/generator.custom-config.golden.yaml
+++ b/pkg/xds/bootstrap/testdata/generator.custom-config.golden.yaml
@@ -1,5 +1,9 @@
 admin:
-  accessLogPath: NUL
+  accessLog:
+  - name: envoy.access_loggers.file
+    typedConfig:
+      '@type': type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog
+      path: NUL
   address:
     socketAddress:
       address: 192.168.0.1

--- a/pkg/xds/bootstrap/testdata/generator.default-config-token-path.golden.yaml
+++ b/pkg/xds/bootstrap/testdata/generator.default-config-token-path.golden.yaml
@@ -1,5 +1,9 @@
 admin:
-  accessLogPath: /dev/null
+  accessLog:
+  - name: envoy.access_loggers.file
+    typedConfig:
+      '@type': type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog
+      path: /dev/null
   address:
     socketAddress:
       address: 127.0.0.1

--- a/pkg/xds/bootstrap/testdata/generator.default-config.golden.yaml
+++ b/pkg/xds/bootstrap/testdata/generator.default-config.golden.yaml
@@ -1,5 +1,9 @@
 admin:
-  accessLogPath: /dev/null
+  accessLog:
+  - name: envoy.access_loggers.file
+    typedConfig:
+      '@type': type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog
+      path: /dev/null
   address:
     socketAddress:
       address: 127.0.0.1

--- a/pkg/xds/bootstrap/testdata/generator.default-config.kubernetes.golden.yaml
+++ b/pkg/xds/bootstrap/testdata/generator.default-config.kubernetes.golden.yaml
@@ -1,5 +1,9 @@
 admin:
-  accessLogPath: /dev/null
+  accessLog:
+  - name: envoy.access_loggers.file
+    typedConfig:
+      '@type': type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog
+      path: /dev/null
   address:
     socketAddress:
       address: 127.0.0.1

--- a/pkg/xds/bootstrap/testdata/generator.default-config.kubernetes.ipv6.golden.yaml
+++ b/pkg/xds/bootstrap/testdata/generator.default-config.kubernetes.ipv6.golden.yaml
@@ -1,5 +1,9 @@
 admin:
-  accessLogPath: /dev/null
+  accessLog:
+  - name: envoy.access_loggers.file
+    typedConfig:
+      '@type': type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog
+      path: /dev/null
   address:
     socketAddress:
       address: 127.0.0.1

--- a/pkg/xds/bootstrap/testdata/generator.metrics-config.kubernetes.golden.yaml
+++ b/pkg/xds/bootstrap/testdata/generator.metrics-config.kubernetes.golden.yaml
@@ -1,5 +1,9 @@
 admin:
-  accessLogPath: /dev/null
+  accessLog:
+  - name: envoy.access_loggers.file
+    typedConfig:
+      '@type': type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog
+      path: /dev/null
   address:
     socketAddress:
       address: 127.0.0.1


### PR DESCRIPTION
Use correct access logging instead using access_log

Fix #2114

Signed-off-by: Charly Molter <charly.molter@konghq.com>