### PR TITLE
fix(kuma-dp): have envoy version check always work

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,6 @@ help: ## Display this help screen
 
 include mk/dev.mk
 
-include mk/envoy.mk
 include mk/api.mk
 include mk/build.mk
 include mk/check.mk
@@ -27,3 +26,4 @@ include mk/kind.mk
 include mk/k3d.mk
 include mk/e2e.new.mk
 include mk/docs.mk
+include mk/envoy.mk

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,7 @@ help: ## Display this help screen
 
 include mk/dev.mk
 
+include mk/envoy.mk
 include mk/api.mk
 include mk/build.mk
 include mk/check.mk
@@ -26,4 +27,3 @@ include mk/kind.mk
 include mk/k3d.mk
 include mk/e2e.new.mk
 include mk/docs.mk
-include mk/envoy.mk

--- a/app/kuma-dp/cmd/run.go
+++ b/app/kuma-dp/cmd/run.go
@@ -205,10 +205,10 @@ func newRunCmd(opts kuma_cmd.RunCmdOpts, rootCtx *RootContext) *cobra.Command {
 				return errors.Wrap(err, "failed to get Envoy version")
 			}
 
-			if envoyVersion.KumaDpCompatible, err = envoy.EnvoyVersionCompatible(envoyVersion.Version); err != nil {
+			if envoyVersion.KumaDpCompatible, err = envoy.VersionCompatible("~"+kuma_version.Envoy, envoyVersion.Version); err != nil {
 				runLog.Error(err, "cannot determine envoy version compatibility")
 			} else if !envoyVersion.KumaDpCompatible {
-				runLog.Info("Envoy version incompatible", "expected", envoy.EnvoyCompatibility, "current", envoyVersion.Version)
+				runLog.Info("Envoy version incompatible", "expected", kuma_version.Envoy, "current", envoyVersion.Version)
 			}
 
 			runLog.Info("fetched Envoy version", "version", envoyVersion)

--- a/app/kuma-dp/pkg/dataplane/envoy/bootstrap_file_test.go
+++ b/app/kuma-dp/pkg/dataplane/envoy/bootstrap_file_test.go
@@ -1,4 +1,4 @@
-package envoy
+package envoy_test
 
 import (
 	"os"
@@ -7,6 +7,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	"github.com/kumahq/kuma/app/kuma-dp/pkg/dataplane/envoy"
 	kuma_dp "github.com/kumahq/kuma/pkg/config/app/kuma-dp"
 )
 
@@ -40,7 +41,7 @@ var _ = Describe("Bootstrap File", func() {
 			}
 
 			// when
-			filename, err := GenerateBootstrapFile(runtime, []byte(config))
+			filename, err := envoy.GenerateBootstrapFile(runtime, []byte(config))
 			// then
 			Expect(err).ToNot(HaveOccurred())
 			// and

--- a/app/kuma-dp/pkg/dataplane/envoy/compatibility.go
+++ b/app/kuma-dp/pkg/dataplane/envoy/compatibility.go
@@ -5,23 +5,18 @@ import (
 	"github.com/pkg/errors"
 )
 
-// EnvoyCompatibility is the description of envoy versions
-// which are currently compatible with this data plane,
-// in Masterminds/semver/v3 format.
-var EnvoyCompatibility = "~1.21.1"
-
-// EnvoyVersionCompatible returns true if the given version of
-// envoy is compatible with this DP, false otherwise.
-func EnvoyVersionCompatible(envoyVersion string) (bool, error) {
+// VersionCompatible returns true if the given version of
+// envoy is compatible with this DP, false otherwise, expectedVersion is in Masterminds/semver/v3 format.
+func VersionCompatible(expectedVersion string, envoyVersion string) (bool, error) {
 	ver, err := semver.NewVersion(envoyVersion)
 	if err != nil {
 		return false, errors.Wrapf(err, "unable to parse envoy version %s", envoyVersion)
 	}
 
-	constraint, err := semver.NewConstraint(EnvoyCompatibility)
+	constraint, err := semver.NewConstraint(expectedVersion)
 	if err != nil {
 		// Programmer error
-		panic(errors.Wrapf(err, "Invalid envoy compatibility constraint %s", EnvoyCompatibility))
+		panic(errors.Wrapf(err, "Invalid envoy compatibility constraint %s", expectedVersion))
 	}
 
 	return constraint.Check(ver), nil

--- a/app/kuma-dp/pkg/dataplane/envoy/compatibility_test.go
+++ b/app/kuma-dp/pkg/dataplane/envoy/compatibility_test.go
@@ -1,0 +1,58 @@
+package envoy_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/kumahq/kuma/app/kuma-dp/pkg/dataplane/envoy"
+	"github.com/kumahq/kuma/pkg/test"
+	"github.com/kumahq/kuma/pkg/version"
+)
+
+var _ = Describe("Compatibility", func() {
+	It("Should be ok by default", func() {
+		r, err := envoy.VersionCompatible("~1.21.1", "1.21.1")
+		Expect(err).ToNot(HaveOccurred())
+		Expect(r).To(BeTrue())
+	})
+	It("Should fail with old version", func() {
+		r, err := envoy.VersionCompatible("~1.21.1", "1.17.1")
+		Expect(err).ToNot(HaveOccurred())
+		Expect(r).To(BeFalse())
+	})
+	It("Should fail with too recent", func() {
+		r, err := envoy.VersionCompatible("~1.21.1", "10.17.1") // Let's guess envoy 10 will never happen
+		Expect(err).ToNot(HaveOccurred())
+		Expect(r).To(BeFalse())
+	})
+	It("Should be ok with higher patch", func() {
+		r, err := envoy.VersionCompatible("~1.21.1", "1.21.2")
+		Expect(err).ToNot(HaveOccurred())
+		Expect(r).To(BeTrue())
+	})
+	It("Should fail with lower patch", func() {
+		r, err := envoy.VersionCompatible("~1.21.1", "1.21.0")
+		Expect(err).ToNot(HaveOccurred())
+		Expect(r).To(BeFalse())
+	})
+	It("Should fail with higher minor", func() {
+		r, err := envoy.VersionCompatible("~1.21.1", "1.22.1")
+		Expect(err).ToNot(HaveOccurred())
+		Expect(r).To(BeFalse())
+	})
+	It("Should fail with lower minor", func() {
+		r, err := envoy.VersionCompatible("~1.21.1", "1.20.1")
+		Expect(err).ToNot(HaveOccurred())
+		Expect(r).To(BeFalse())
+	})
+	It("Should err with bad version", func() {
+		r, err := envoy.VersionCompatible("~1.21.1", "funky")
+		Expect(err).To(HaveOccurred())
+		Expect(r).To(BeFalse())
+	})
+	It("Works with actual build version", func() {
+		r, err := envoy.VersionCompatible("~"+version.Envoy, version.Envoy)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(r).To(BeTrue())
+	}, test.LabelBuildCheck)
+})

--- a/app/kuma-dp/pkg/dataplane/envoy/envoy_suite_test.go
+++ b/app/kuma-dp/pkg/dataplane/envoy/envoy_suite_test.go
@@ -1,4 +1,4 @@
-package envoy
+package envoy_test
 
 import (
 	"testing"

--- a/app/kuma-dp/pkg/dataplane/envoy/remote_bootstrap_test.go
+++ b/app/kuma-dp/pkg/dataplane/envoy/remote_bootstrap_test.go
@@ -1,4 +1,4 @@
-package envoy
+package envoy_test
 
 import (
 	"context"
@@ -16,6 +16,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	. "github.com/kumahq/kuma/app/kuma-dp/pkg/dataplane/envoy"
 	kuma_dp "github.com/kumahq/kuma/pkg/config/app/kuma-dp"
 	config_types "github.com/kumahq/kuma/pkg/config/types"
 	"github.com/kumahq/kuma/pkg/core/resources/model/rest"

--- a/mk/build.mk
+++ b/mk/build.mk
@@ -2,12 +2,14 @@ BUILD_INFO_GIT_TAG ?= $(shell git describe --tags 2>/dev/null || echo unknown)
 BUILD_INFO_GIT_COMMIT ?= $(shell git rev-parse HEAD 2>/dev/null || echo unknown)
 BUILD_INFO_BUILD_DATE ?= $(shell date -u +"%Y-%m-%dT%H:%M:%SZ" || echo unknown)
 BUILD_INFO_VERSION ?= $(shell $(TOOLS_DIR)/releases/version.sh)
+BUILD_INFO_ENVOY_VERSION ?= $(ENVOY_VERSION)
 
 build_info_fields := \
 	version=$(BUILD_INFO_VERSION) \
 	gitTag=$(BUILD_INFO_GIT_TAG) \
 	gitCommit=$(BUILD_INFO_GIT_COMMIT) \
-	buildDate=$(BUILD_INFO_BUILD_DATE)
+	buildDate=$(BUILD_INFO_BUILD_DATE) \
+	Envoy=$(BUILD_INFO_ENVOY_VERSION)
 build_info_ld_flags := $(foreach entry,$(build_info_fields), -X github.com/kumahq/kuma/pkg/version.$(entry))
 
 LD_FLAGS := -ldflags="-s -w $(build_info_ld_flags) $(EXTRA_LD_FLAGS)"

--- a/mk/dev.mk
+++ b/mk/dev.mk
@@ -1,3 +1,5 @@
+KUMA_DIR ?= .
+ENVOY_VERSION = $(shell ${KUMA_DIR}/tools/envoy/version.sh)
 GINKGO_VERSION := v2.1.3
 GOLANGCI_LINT_VERSION := v1.45.2
 GOLANG_PROTOBUF_VERSION := v1.5.2

--- a/mk/envoy.mk
+++ b/mk/envoy.mk
@@ -1,8 +1,4 @@
-KUMA_DIR ?= .
-
 BUILD_ENVOY_FROM_SOURCES ?= false
-
-ENVOY_VERSION = $(shell ${KUMA_DIR}/tools/envoy/version.sh)
 
 ifeq ($(GOOS),linux)
 	ENVOY_DISTRO ?= alpine

--- a/mk/envoy.mk
+++ b/mk/envoy.mk
@@ -2,9 +2,7 @@ KUMA_DIR ?= .
 
 BUILD_ENVOY_FROM_SOURCES ?= false
 
-ENVOY_TAG ?= v1.22.1 # commit hash or git tag
-# Remember to update pkg/version/compatibility.go
-ENVOY_VERSION = $(shell ${KUMA_DIR}/tools/envoy/version.sh ${ENVOY_TAG})
+ENVOY_VERSION = $(shell ${KUMA_DIR}/tools/envoy/version.sh)
 
 ifeq ($(GOOS),linux)
 	ENVOY_DISTRO ?= alpine
@@ -44,7 +42,7 @@ build/artifacts-linux-arm64/envoy/envoy:
 
 build/artifacts-${GOOS}-${GOARCH}/envoy/envoy-${ENVOY_VERSION}-${ENVOY_DISTRO}:
 ifeq ($(BUILD_ENVOY_FROM_SOURCES),true)
-	ENVOY_TAG=${ENVOY_TAG} \
+	ENVOY_TAG=$(ENVOY_TAG) \
 	SOURCE_DIR=${SOURCE_DIR} \
 	KUMA_DIR=${KUMA_DIR} \
 	BAZEL_BUILD_EXTRA_OPTIONS=${BAZEL_BUILD_EXTRA_OPTIONS} \

--- a/pkg/test/const.go
+++ b/pkg/test/const.go
@@ -1,7 +1,14 @@
 package test
 
-import "path/filepath"
+import (
+	"path/filepath"
+
+	"github.com/onsi/ginkgo/v2"
+)
 
 // CustomResourceDir is the path from the top of the Kuma repository to
 // the directory containing the Kuma CRD YAML files.
 var CustomResourceDir = filepath.Join("deployments", "charts", "kuma", "crds")
+
+// LabelBuildCheck this is for tests that check that the build is correct (some tests rely on build flags to be set)
+var LabelBuildCheck = ginkgo.Label("build_check")

--- a/pkg/version/compatibility_test.go
+++ b/pkg/version/compatibility_test.go
@@ -1,8 +1,10 @@
-package version
+package version_test
 
 import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
+	. "github.com/kumahq/kuma/pkg/version"
 )
 
 var _ = Describe("Version Compatibility", func() {

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -11,6 +11,7 @@ var (
 	gitTag    = "unknown"
 	gitCommit = "unknown"
 	buildDate = "unknown"
+	Envoy     = "unknown"
 )
 
 type BuildInfo struct {

--- a/pkg/version/version_test.go
+++ b/pkg/version/version_test.go
@@ -1,0 +1,34 @@
+package version_test
+
+import (
+	"time"
+
+	"github.com/Masterminds/semver/v3"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/kumahq/kuma/pkg/test"
+	"github.com/kumahq/kuma/pkg/version"
+)
+
+var _ = Describe("Verify build flags are set", func() {
+	It("Should have build info has semver version", func() {
+		_, err := semver.NewVersion(version.Build.Version)
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	It("Should have a valid builddate", func() {
+		_, err := time.Parse(time.RFC3339, version.Build.BuildDate)
+		Expect(err).ToNot(HaveOccurred())
+	})
+	It("Should have a valid gittag", func() {
+		Expect(version.Build.GitTag).To(MatchRegexp("[a-f0-9]+"))
+	})
+	It("Should have a valid git commit", func() {
+		Expect(version.Build.GitCommit).ToNot(And(BeEmpty(), Equal("unknown")))
+	})
+	It("Should set envoy version", func() {
+		Expect(version.Envoy).ToNot(And(BeEmpty(), Equal("unknown")))
+	})
+
+}, test.LabelBuildCheck)

--- a/tools/envoy/README.md
+++ b/tools/envoy/README.md
@@ -9,6 +9,10 @@ source code.
 
 ### Usage
 
+Changing default envoy version:
+
+Update the ENVOY_TAG in version.sh
+
 Download the latest supported Envoy binary for your host OS: 
 ```shell
 $ make build/envoy

--- a/tools/envoy/version.sh
+++ b/tools/envoy/version.sh
@@ -8,7 +8,7 @@ set -o nounset
 # - if ENVOY_TAG is a real git tag like 'v1.20.0' then the version is equal to '1.20.0' (without the first letter 'v').
 # - if ENVOY_TAG is a commit hash then the version will look like '1.20.1-dev-b16d390f'
 
-ENVOY_TAG=$1
+ENVOY_TAG=${ENVOY_TAG:-"v1.22.1"}
 ENVOY_VERSION=$(curl --silent --location "https://raw.githubusercontent.com/envoyproxy/envoy/${ENVOY_TAG}/VERSION.txt")
 
 # for envoy versions older than v1.22.0 file 'VERSION.txt' used to be called 'VERSION'

--- a/tools/releases/distros.sh
+++ b/tools/releases/distros.sh
@@ -25,7 +25,7 @@ PULP_HOST="https://api.pulp.konnect-prod.konghq.com"
 PULP_PACKAGE_TYPE="mesh"
 PULP_DIST_NAME="alpine"
 [ -z "$RELEASE_NAME" ] && RELEASE_NAME="kuma"
-ENVOY_VERSION=1.22.1
+ENVOY_VERSION=$("${SCRIPT_DIR}/../envoy/version.sh")
 [ -z "$KUMA_CONFIG_PATH" ] && KUMA_CONFIG_PATH=pkg/config/app/kuma-cp/kuma-cp.defaults.yaml
 CTL_NAME="kumactl"
 

--- a/tools/releases/docker.sh
+++ b/tools/releases/docker.sh
@@ -8,7 +8,7 @@ source "${SCRIPT_DIR}/../common.sh"
 KUMA_DOCKER_REPO="${KUMA_DOCKER_REPO:-docker.io}"
 KUMA_DOCKER_REPO_ORG="${KUMA_DOCKER_REPO_ORG:-${KUMA_DOCKER_REPO}/kumahq}"
 KUMA_COMPONENTS="${KUMA_COMPONENTS:-kuma-cp kuma-dp kumactl kuma-init kuma-prometheus-sd}"
-ENVOY_VERSION="${ENVOY_VERSION:-1.22.1}"
+ENVOY_VERSION=$("${SCRIPT_DIR}/../envoy/version.sh")
 BUILD_ARCH="${BUILD_ARCH:-amd64 arm64}"
 
 function build() {


### PR DESCRIPTION
- Stop having to update envoy version in many places
- Add test to check that the dp compatibility check works
- Add tests to check that build arguments are set correctly

Signed-off-by: Charly Molter <charly.molter@konghq.com>
