### PR TITLE
chore(dependabot): add dependabot for github actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,9 +6,17 @@ updates:
       interval: "weekly"
     labels:
       - "dependencies"
+      
   - package-ecosystem: "docker"
     directory: "/tools/releases/dockerfiles"
     schedule:
       interval: "weekly"
     labels:
       - "dependencies"
+      
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"      

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -1,8 +1,0 @@
-version: 2
-updates:
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-    labels:
-      - "dependencies"

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -1,4 +1,3 @@
-
 version: 2
 updates:
   - package-ecosystem: "github-actions"

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -1,0 +1,9 @@
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"


### PR DESCRIPTION
### Summary

This will add dependabot for github actions in .github. This can help with keeping the versions up to date, and providing changelogs for the versions before you merge a PR.

### Full changelog

*Adds dependabot for github actions in the .github directory.

### Documentation

- [x] Link to the website [documentation PR](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file)

### Testing
N/A (No testing, just made these changes on the GitHub website)
- [ ] Unit tests
- [ ] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes
