### PR TITLE
fix(kuma-cp): grant delete Pods in kuma-system namespace to control plane

### DIFF
--- a/deployments/charts/kuma/templates/cp-rbac.yaml
+++ b/deployments/charts/kuma/templates/cp-rbac.yaml
@@ -298,6 +298,13 @@ rules:
       - update
       - patch
       - delete
+  # leader-for-life election deletes Pods in some circumstances
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - delete
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding


### PR DESCRIPTION
### Summary

Under [certain circumstances `operator-framework/operator-lib` tries to delete other CP Pods](https://github.com/operator-framework/operator-lib/blob/v0.11.0/leader/leader.go#L165-L193).