### PR TITLE
fix(core): validate both old and new objects on Update

### DIFF
--- a/pkg/api-server/resource_endpoints.go
+++ b/pkg/api-server/resource_endpoints.go
@@ -172,17 +172,18 @@ func (r *resourceEndpoints) createResource(ctx context.Context, name string, mes
 }
 
 func (r *resourceEndpoints) updateResource(ctx context.Context, res model.Resource, restRes rest.Resource, response *restful.Response) {
-	_ = res.SetSpec(restRes.Spec)
-
 	if err := r.resourceAccess.ValidateUpdate(
 		model.ResourceKey{Mesh: res.GetMeta().GetMesh(), Name: res.GetMeta().GetName()},
 		res.GetSpec(),
+		restRes.Spec,
 		r.descriptor,
 		user.FromCtx(ctx),
 	); err != nil {
 		rest_errors.HandleError(response, err, "Access Denied")
 		return
 	}
+
+	_ = res.SetSpec(restRes.Spec)
 
 	if err := r.resManager.Update(ctx, res); err != nil {
 		rest_errors.HandleError(response, err, "Could not update a resource")

--- a/pkg/core/resources/access/admin_resource_access.go
+++ b/pkg/core/resources/access/admin_resource_access.go
@@ -30,15 +30,15 @@ func NewAdminResourceAccess(cfg config_access.AdminResourcesStaticAccessConfig) 
 
 var _ ResourceAccess = &adminResourceAccess{}
 
-func (a *adminResourceAccess) ValidateCreate(key model.ResourceKey, spec model.ResourceSpec, descriptor model.ResourceTypeDescriptor, user user.User) error {
+func (a *adminResourceAccess) ValidateCreate(_ model.ResourceKey, _ model.ResourceSpec, descriptor model.ResourceTypeDescriptor, user user.User) error {
 	return a.validateAdminAccess(user, descriptor)
 }
 
-func (a *adminResourceAccess) ValidateUpdate(key model.ResourceKey, spec model.ResourceSpec, descriptor model.ResourceTypeDescriptor, user user.User) error {
+func (a *adminResourceAccess) ValidateUpdate(_ model.ResourceKey, _ model.ResourceSpec, _ model.ResourceSpec, descriptor model.ResourceTypeDescriptor, user user.User) error {
 	return a.validateAdminAccess(user, descriptor)
 }
 
-func (a *adminResourceAccess) ValidateDelete(key model.ResourceKey, spec model.ResourceSpec, descriptor model.ResourceTypeDescriptor, user user.User) error {
+func (a *adminResourceAccess) ValidateDelete(_ model.ResourceKey, _ model.ResourceSpec, descriptor model.ResourceTypeDescriptor, user user.User) error {
 	return a.validateAdminAccess(user, descriptor)
 }
 
@@ -46,7 +46,7 @@ func (a *adminResourceAccess) ValidateList(descriptor model.ResourceTypeDescript
 	return a.validateAdminAccess(user, descriptor)
 }
 
-func (a *adminResourceAccess) ValidateGet(key model.ResourceKey, descriptor model.ResourceTypeDescriptor, user user.User) error {
+func (a *adminResourceAccess) ValidateGet(_ model.ResourceKey, descriptor model.ResourceTypeDescriptor, user user.User) error {
 	return a.validateAdminAccess(user, descriptor)
 }
 

--- a/pkg/core/resources/access/admin_resource_access_test.go
+++ b/pkg/core/resources/access/admin_resource_access_test.go
@@ -75,6 +75,7 @@ var _ = Describe("Admin Resource Access", func() {
 		err := resourceAccess.ValidateUpdate(
 			model.ResourceKey{Name: "xyz"},
 			&system_proto.Secret{},
+			&system_proto.Secret{},
 			system.NewSecretResource().Descriptor(),
 			user.Admin,
 		)
@@ -87,6 +88,7 @@ var _ = Describe("Admin Resource Access", func() {
 		// when
 		err := resourceAccess.ValidateUpdate(
 			model.ResourceKey{Name: "xyz"},
+			&system_proto.Secret{},
 			&system_proto.Secret{},
 			system.NewSecretResource().Descriptor(),
 			user.User{Name: "john doe", Groups: []string{"users"}},

--- a/pkg/core/resources/access/resource_access.go
+++ b/pkg/core/resources/access/resource_access.go
@@ -7,7 +7,7 @@ import (
 
 type ResourceAccess interface {
 	ValidateCreate(key model.ResourceKey, spec model.ResourceSpec, desc model.ResourceTypeDescriptor, user user.User) error
-	ValidateUpdate(key model.ResourceKey, spec model.ResourceSpec, desc model.ResourceTypeDescriptor, user user.User) error
+	ValidateUpdate(key model.ResourceKey, currentSpec model.ResourceSpec, newSpec model.ResourceSpec, desc model.ResourceTypeDescriptor, user user.User) error
 	ValidateDelete(key model.ResourceKey, spec model.ResourceSpec, desc model.ResourceTypeDescriptor, user user.User) error
 	ValidateList(desc model.ResourceTypeDescriptor, user user.User) error
 	ValidateGet(key model.ResourceKey, desc model.ResourceTypeDescriptor, user user.User) error


### PR DESCRIPTION
### Summary

This enables validators to check both specs.