### PR TITLE
fix(kuma-cp): do not modify external service tags

### DIFF
--- a/pkg/xds/sync/proxy_builder_test.go
+++ b/pkg/xds/sync/proxy_builder_test.go
@@ -265,7 +265,6 @@ var _ = Describe("Proxy Builder", func() {
 						Tags: map[string]string{
 							mesh_proto.ServiceTag: "external-service-zone-1",
 							mesh_proto.ZoneTag:    "zone-1",
-							"mesh":                "default",
 						},
 						Instances:       1,
 						Mesh:            "default",

--- a/pkg/xds/topology/outbound.go
+++ b/pkg/xds/topology/outbound.go
@@ -425,7 +425,10 @@ func fillExternalServicesOutboundsThroughEgress(
 	mesh *core_mesh.MeshResource,
 ) {
 	for _, externalService := range externalServices {
-		serviceTags := externalService.Spec.GetTags()
+		serviceTags := map[string]string{}
+		for tag, value := range externalService.Spec.GetTags() { // deep copy map to not modify tags in ExternalService.
+			serviceTags[tag] = value
+		}
 		serviceName := serviceTags[mesh_proto.ServiceTag]
 		locality := localityFromTags(mesh, priorityRemote, serviceTags)
 
@@ -460,7 +463,10 @@ func NewExternalServiceEndpoint(
 	spec := externalService.Spec
 	tls := spec.GetNetworking().GetTls()
 	meshName := mesh.GetMeta().GetName()
-	tags := spec.GetTags()
+	tags := map[string]string{}
+	for tag, value := range spec.GetTags() { // deep copy map to not modify tags in ExternalService.
+		tags[tag] = value
+	}
 
 	es := &core_xds.ExternalService{
 		TLSEnabled:         tls.GetEnabled(),


### PR DESCRIPTION
### Summary

We were plugging in the map of tags from `ExternalService` object to `core_xds.Endpoint` object. Then we enriched `core_xds.Endpoint` with `mesh` tag for internal purposes. Since this map was shared, the end result was that AvailableServices in ZoneIngress were getting `mesh` tags.

I don't believe this can cause any problem in production. However, it caused instability in tests.

### Issues resolved

No issues were reported.

### Documentation

~- [ ] Link to the website [documentation PR](https://github.com/kumahq/kuma-website/pull/XXX)~

### Testing

- [X] Unit tests
- [ ] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes

### Backwards compatibility

~- [ ] Update [`UPGRADE.md`](/UPGRADE.md) with any steps users will need to take when upgrading.~
~- [ ] Add `backport-to-stable` label if the code follows our [backporting policy](/CONTRIBUTING.md#backporting)~
