### PR TITLE
fix(*): extended timeout for curl to beat default 5 sec timeout for Retry E2E test

### DIFF
--- a/test/e2e_env/universal/retry/retry.go
+++ b/test/e2e_env/universal/retry/retry.go
@@ -103,8 +103,9 @@ conf:
 
 		By("Eventually all requests succeed consistently")
 		Eventually(func() error {
+			// -m 8 to wait for 8 seconds to beat the default 5s connect timeout
 			stdout, _, err := env.Cluster.Exec("", "", "demo-client",
-				"curl", "-v", "-m", "3", "--fail", "test-server.mesh")
+				"curl", "-v", "-m", "8", "--fail", "test-server.mesh")
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
### Summary

Noticed that `e2e_env/universal/retry/retry.go` is failing because of default connection timeout. Curl was using `3 sec` while the default is `5 sec`. Changed to higher value to beat default.

### Full changelog

* [Increased curl timeout for retry E2E test]

### Issues resolved

Fix #XXX

### Documentation

- [ ] Link to the website [documentation PR](https://github.com/kumahq/kuma-website/pull/XXX)

### Testing

- [ ] Unit tests
- [X] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes

### Backwards compatibility

- [ ] Update [`UPGRADE.md`](/UPGRADE.md) with any steps users will need to take when upgrading.
- [ ] Add `backport-to-stable` label if the code follows our [backporting policy](/CONTRIBUTING.md#backporting)
