### PR TITLE
fix(e2e): improve external service to bring stability on universal

### DIFF
--- a/test/e2e_env/universal/auth/dp_auth.go
+++ b/test/e2e_env/universal/auth/dp_auth.go
@@ -14,11 +14,11 @@ func DpAuth() {
 	const meshName = "dp-auth"
 
 	BeforeAll(func() {
-		E2EDeferCleanup(func() {
-			Expect(env.Cluster.DeleteMeshApps(meshName)).To(Succeed())
-			Expect(env.Cluster.DeleteMesh(meshName)).To(Succeed())
-		})
 		Expect(env.Cluster.Install(MeshUniversal(meshName))).To(Succeed())
+	})
+	E2EAfterAll(func() {
+		Expect(env.Cluster.DeleteMeshApps(meshName)).To(Succeed())
+		Expect(env.Cluster.DeleteMesh(meshName)).To(Succeed())
 	})
 
 	It("should not be able to override someone else Dataplane", func() {

--- a/test/e2e_env/universal/healthcheck/panic.go
+++ b/test/e2e_env/universal/healthcheck/panic.go
@@ -49,11 +49,6 @@ networking:
 	}
 
 	BeforeAll(func() {
-		E2EDeferCleanup(func() {
-			Expect(env.Cluster.DeleteMeshApps(meshName)).To(Succeed())
-			Expect(env.Cluster.DeleteMesh(meshName)).To(Succeed())
-		})
-
 		err := NewClusterSetup().
 			Install(MeshUniversal(meshName)).
 			Install(YamlUniversal(healthCheck)).
@@ -73,6 +68,11 @@ networking:
 
 		err = DemoClientUniversal(AppModeDemoClient, meshName, WithTransparentProxy(true))(env.Cluster)
 		Expect(err).ToNot(HaveOccurred())
+	})
+
+	E2EAfterAll(func() {
+		Expect(env.Cluster.DeleteMeshApps(meshName)).To(Succeed())
+		Expect(env.Cluster.DeleteMesh(meshName)).To(Succeed())
 	})
 
 	It("should switch to panic mode and dismiss all requests", func() {

--- a/test/e2e_env/universal/inspect/inspect.go
+++ b/test/e2e_env/universal/inspect/inspect.go
@@ -12,16 +12,15 @@ func Inspect() {
 	meshName := "inspect"
 
 	BeforeAll(func() {
-		E2EDeferCleanup(func() {
-			Expect(env.Cluster.DeleteMeshApps(meshName)).To(Succeed())
-			Expect(env.Cluster.DeleteMesh(meshName)).To(Succeed())
-		})
-
 		err := NewClusterSetup().
 			Install(MeshUniversal(meshName)).
 			Install(DemoClientUniversal(AppModeDemoClient, meshName)).
 			Setup(env.Cluster)
 		Expect(err).To(BeNil())
+	})
+	E2EAfterAll(func() {
+		Expect(env.Cluster.DeleteMeshApps(meshName)).To(Succeed())
+		Expect(env.Cluster.DeleteMesh(meshName)).To(Succeed())
 	})
 
 	It("should return envoy config_dump", func() {

--- a/test/e2e_env/universal/ratelimit/ratelimit.go
+++ b/test/e2e_env/universal/ratelimit/ratelimit.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/kumahq/kuma/test/e2e_env/universal/env"
 	. "github.com/kumahq/kuma/test/framework"
-	"github.com/kumahq/kuma/test/framework/deployments/externalservice"
 )
 
 func Policy() {
@@ -40,7 +39,7 @@ conf:
 			Install(TestServerUniversal("test-server", meshName, WithArgs([]string{"echo", "--instance", "universal-1"}))).
 			Install(DemoClientUniversal("demo-client", meshName, WithTransparentProxy(true))).
 			Install(DemoClientUniversal("web", meshName, WithTransparentProxy(true))).
-			Install(externalservice.Install("rate-limit", externalservice.UniversalEchoServer(88, false))).
+			Install(TestServerExternalServiceUniversal("rate-limit", meshName, 80, false)).
 			Setup(env.Cluster)).To(Succeed())
 	})
 	E2EAfterAll(func() {

--- a/test/framework/deployments/externalservice/universal.go
+++ b/test/framework/deployments/externalservice/universal.go
@@ -27,18 +27,6 @@ type universalDeployment struct {
 }
 
 var _ Deployment = &universalDeployment{}
-
-var UniversalEchoServer = func(port int, tls bool) Command {
-	args := []string{
-		"test-server", "echo",
-		"--instance", fmt.Sprintf("echo-%d", port),
-		"--port", fmt.Sprintf("%d", port),
-	}
-	if tls {
-		args = append(args, "--crt", "/server-cert.pem", "--key", "/server-key.pem", "--tls")
-	}
-	return args
-}
 var UniversalAppEchoServer = ExternalServiceCommand(80, "Echo 80")
 var UniversalAppHttpsEchoServer = Command([]string{"ncat",
 	"-lk", "-p", "443",

--- a/test/framework/interface.go
+++ b/test/framework/interface.go
@@ -107,6 +107,9 @@ type appDeploymentOptions struct {
 	serviceProbe          bool
 	reachableServices     []string
 	appendDataplaneConfig string
+
+	dockerVolumes       []string
+	dockerContainerName string
 }
 
 func (d *appDeploymentOptions) apply(opts ...AppDeploymentOption) {
@@ -450,6 +453,18 @@ func WithConcurrency(concurrency int) AppDeploymentOption {
 func WithReachableServices(services ...string) AppDeploymentOption {
 	return AppOptionFunc(func(o *appDeploymentOptions) {
 		o.reachableServices = services
+	})
+}
+
+func WithDockerVolumes(volumes ...string) AppDeploymentOption {
+	return AppOptionFunc(func(o *appDeploymentOptions) {
+		o.dockerVolumes = append(o.dockerVolumes, volumes...)
+	})
+}
+
+func WithDockerContainerName(name string) AppDeploymentOption {
+	return AppOptionFunc(func(o *appDeploymentOptions) {
+		o.dockerContainerName = name
 	})
 }
 

--- a/test/framework/universal_cluster.go
+++ b/test/framework/universal_cluster.go
@@ -143,7 +143,7 @@ func (c *UniversalCluster) DeployKuma(mode core.CpMode, opt ...KumaDeploymentOpt
 		cmd = append(cmd, "--config-file", "/kuma/kuma-cp.conf")
 	}
 
-	app, err := NewUniversalApp(c.t, c.name, AppModeCP, "", AppModeCP, c.opts.isipv6, true, []string{})
+	app, err := NewUniversalApp(c.t, c.name, AppModeCP, "", AppModeCP, c.opts.isipv6, true, []string{}, nil, "")
 	if err != nil {
 		return err
 	}
@@ -276,7 +276,7 @@ func (c *UniversalCluster) DeployApp(opt ...AppDeploymentOption) error {
 
 	Logf("IPV6 is %v", opts.isipv6)
 
-	app, err := NewUniversalApp(c.t, c.name, opts.name, opts.mesh, AppMode(appname), opts.isipv6, *opts.verbose, caps)
+	app, err := NewUniversalApp(c.t, c.name, opts.name, opts.mesh, AppMode(appname), opts.isipv6, *opts.verbose, caps, opts.dockerVolumes, opts.dockerContainerName)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
- Retry wait on postgres container startup
- Add simpler api for universal e2e external services
- Ensure we destroy all apps after tests
- Fix timeouts on mtls tests

Signed-off-by: Charly Molter <charly.molter@konghq.com>