### PR TITLE
fix(*): generate cluster name hash based on tags not config

### DIFF
--- a/app/kuma-dp/pkg/dataplane/metrics/merge_test.go
+++ b/app/kuma-dp/pkg/dataplane/metrics/merge_test.go
@@ -98,6 +98,7 @@ var _ = Describe("Detect mergable clusters", func() {
 				},
 			},
 			&envoy_cluster_v3.Cluster{},
+			map[string]string{},
 		)
 		Expect(err).To(Succeed())
 		Expect(clusterName).ToNot(BeEmpty())

--- a/app/kuma-dp/pkg/dataplane/metrics/merge_test.go
+++ b/app/kuma-dp/pkg/dataplane/metrics/merge_test.go
@@ -6,7 +6,6 @@ import (
 	"io"
 	"os"
 
-	envoy_cluster_v3 "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
@@ -97,8 +96,9 @@ var _ = Describe("Detect mergable clusters", func() {
 					mesh_proto.ZoneTag:    "foo-zone",
 				},
 			},
-			&envoy_cluster_v3.Cluster{},
-			map[string]string{},
+			map[string]string{
+				"custom": "tag",
+			},
 		)
 		Expect(err).To(Succeed())
 		Expect(clusterName).ToNot(BeEmpty())

--- a/pkg/plugins/runtime/gateway/cluster_generator.go
+++ b/pkg/plugins/runtime/gateway/cluster_generator.go
@@ -201,7 +201,7 @@ func newClusterBuilder(
 // qualified name for the cluster. Because the connection policies applied
 // to a cluster can be different depending on the listener and the hostname,
 // we can't just build a cluster using the service name and tags, we have to
-// take the full configuration into account.
+// take listener tags into account.
 func buildClusterResource(
 	dest *route.Destination,
 	c *clusters.ClusterBuilder,

--- a/pkg/plugins/runtime/gateway/cluster_generator.go
+++ b/pkg/plugins/runtime/gateway/cluster_generator.go
@@ -216,7 +216,6 @@ func buildClusterResource(
 
 	name, err := route.DestinationClusterName(
 		dest,
-		cluster,
 		identifyingTags,
 	)
 	if err != nil {

--- a/pkg/plugins/runtime/gateway/cluster_name_test.go
+++ b/pkg/plugins/runtime/gateway/cluster_name_test.go
@@ -23,7 +23,7 @@ var _ = Describe("Cluster name", func() {
 		}
 
 		c := envoy_cluster_v3.Cluster{}
-		name, err := route.DestinationClusterName(&d, &c)
+		name, err := route.DestinationClusterName(&d, &c, map[string]string{})
 		Expect(err).To(Succeed())
 
 		return name
@@ -38,6 +38,7 @@ var _ = Describe("Cluster name", func() {
 				},
 			},
 			&envoy_cluster_v3.Cluster{},
+			map[string]string{},
 		)
 
 		Expect(err).To(Not(Succeed()))
@@ -90,6 +91,10 @@ var _ = Describe("Cluster name", func() {
 				},
 			},
 			&envoy_cluster_v3.Cluster{RespectDnsTtl: true},
+			map[string]string{
+				"tag1": "value1",
+				"tag2": "value2",
+			},
 		)
 		Expect(err).To(Succeed())
 
@@ -100,6 +105,10 @@ var _ = Describe("Cluster name", func() {
 				},
 			},
 			&envoy_cluster_v3.Cluster{},
+			map[string]string{
+				"tag1": "value3",
+				"abc":  "value2",
+			},
 		)
 		Expect(err).To(Succeed())
 

--- a/pkg/plugins/runtime/gateway/cluster_name_test.go
+++ b/pkg/plugins/runtime/gateway/cluster_name_test.go
@@ -1,7 +1,6 @@
 package gateway_test
 
 import (
-	envoy_cluster_v3 "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
@@ -22,8 +21,7 @@ var _ = Describe("Cluster name", func() {
 			d.Destination[tags[i]] = tags[i+1]
 		}
 
-		c := envoy_cluster_v3.Cluster{}
-		name, err := route.DestinationClusterName(&d, &c, map[string]string{})
+		name, err := route.DestinationClusterName(&d, map[string]string{})
 		Expect(err).To(Succeed())
 
 		return name
@@ -37,7 +35,6 @@ var _ = Describe("Cluster name", func() {
 					"kuma.io/zone": "one",
 				},
 			},
-			&envoy_cluster_v3.Cluster{},
 			map[string]string{},
 		)
 
@@ -83,14 +80,13 @@ var _ = Describe("Cluster name", func() {
 		))))
 	})
 
-	It("should generate different names for different config", func() {
+	It("should generate different names for different tags", func() {
 		n1, err := route.DestinationClusterName(
 			&route.Destination{
 				Destination: map[string]string{
 					"kuma.io/service": "one",
 				},
 			},
-			&envoy_cluster_v3.Cluster{RespectDnsTtl: true},
 			map[string]string{
 				"tag1": "value1",
 				"tag2": "value2",
@@ -104,7 +100,6 @@ var _ = Describe("Cluster name", func() {
 					"kuma.io/service": "one",
 				},
 			},
-			&envoy_cluster_v3.Cluster{},
 			map[string]string{
 				"tag1": "value3",
 				"abc":  "value2",

--- a/pkg/plugins/runtime/gateway/generator.go
+++ b/pkg/plugins/runtime/gateway/generator.go
@@ -51,7 +51,8 @@ type GatewayHost struct {
 	Routes   []model.Resource
 	Policies map[model.ResourceType][]match.RankedPolicy
 	TLS      *mesh_proto.MeshGateway_TLS_Conf
-	Tags     mesh_proto.TagSelector
+	// Contains MeshGateway, Listener and Dataplane object tags
+	Tags mesh_proto.TagSelector
 }
 
 type GatewayListener struct {

--- a/pkg/plugins/runtime/gateway/generator.go
+++ b/pkg/plugins/runtime/gateway/generator.go
@@ -51,6 +51,7 @@ type GatewayHost struct {
 	Routes   []model.Resource
 	Policies map[model.ResourceType][]match.RankedPolicy
 	TLS      *mesh_proto.MeshGateway_TLS_Conf
+	Tags     mesh_proto.TagSelector
 }
 
 type GatewayListener struct {
@@ -273,7 +274,7 @@ func (g Generator) generateCDS(ctx xds_context.Context, info GatewayListenerInfo
 	resources := core_xds.NewResourceSet()
 
 	for _, hostInfo := range hostInfos {
-		clusterRes, err := g.ClusterGenerator.GenerateClusters(ctx, info, hostInfo.Entries)
+		clusterRes, err := g.ClusterGenerator.GenerateClusters(ctx, info, hostInfo)
 		if err != nil {
 			return nil, errors.Wrapf(err, "failed to generate clusters for dataplane %q", info.Proxy.Id)
 		}
@@ -352,6 +353,7 @@ func MakeGatewayListener(
 			Hostname: hostname,
 			Policies: map[model.ResourceType][]match.RankedPolicy{},
 			TLS:      l.GetTls(),
+			Tags:     l.Tags,
 		}
 
 		switch listener.Protocol {

--- a/pkg/plugins/runtime/gateway/route/builders.go
+++ b/pkg/plugins/runtime/gateway/route/builders.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"sort"
 
-	envoy_cluster_v3 "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
 	envoy_config_route "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
 	"github.com/pkg/errors"
 
@@ -64,7 +63,6 @@ func (f RouteMustConfigureFunc) Configure(r *envoy_config_route.Route) error {
 // destination. The destination must contain at least a service tag.
 func DestinationClusterName(
 	d *Destination,
-	c *envoy_cluster_v3.Cluster,
 	identifyingTags map[string]string,
 ) (string, error) {
 	serviceName := d.Destination[mesh_proto.ServiceTag]

--- a/pkg/plugins/runtime/gateway/route/builders.go
+++ b/pkg/plugins/runtime/gateway/route/builders.go
@@ -10,7 +10,6 @@ import (
 	"github.com/pkg/errors"
 
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
-	util_proto "github.com/kumahq/kuma/pkg/util/proto"
 	"github.com/kumahq/kuma/pkg/xds/envoy"
 )
 
@@ -63,7 +62,11 @@ func (f RouteMustConfigureFunc) Configure(r *envoy_config_route.Route) error {
 
 // DestinationClusterName generates a unique cluster name for the
 // destination. The destination must contain at least a service tag.
-func DestinationClusterName(d *Destination, c *envoy_cluster_v3.Cluster) (string, error) {
+func DestinationClusterName(
+	d *Destination,
+	c *envoy_cluster_v3.Cluster,
+	identifyingTags map[string]string,
+) (string, error) {
 	serviceName := d.Destination[mesh_proto.ServiceTag]
 	if serviceName == "" {
 		return "", errors.Errorf("missing %s tag", mesh_proto.ServiceTag)
@@ -80,18 +83,21 @@ func DestinationClusterName(d *Destination, c *envoy_cluster_v3.Cluster) (string
 
 	h := sha256.New()
 
+	// destination tags from route
 	for _, k := range keys {
 		h.Write([]byte(k))
 		h.Write([]byte(d.Destination[k]))
 	}
 
-	any, err := util_proto.MarshalAnyDeterministic(c)
-	if err != nil {
-		return "", err
+	keys = []string{}
+	for k := range identifyingTags {
+		keys = append(keys, k)
 	}
-
-	h.Write([]byte(any.GetTypeUrl()))
-	h.Write(any.GetValue())
+	// identifyingTags contains listener, meshGateway and Dataplane tags
+	for _, k := range keys {
+		h.Write([]byte(k))
+		h.Write([]byte(identifyingTags[k]))
+	}
 
 	// The qualifier is 16 hex digits. Unscientifically balancing the length
 	// of the hex against the likelihood of collisions.

--- a/pkg/plugins/runtime/gateway/route/builders.go
+++ b/pkg/plugins/runtime/gateway/route/builders.go
@@ -93,6 +93,8 @@ func DestinationClusterName(
 	for k := range identifyingTags {
 		keys = append(keys, k)
 	}
+	sort.Strings(keys)
+
 	// identifyingTags contains listener, meshGateway and Dataplane tags
 	for _, k := range keys {
 		h.Write([]byte(k))

--- a/pkg/plugins/runtime/gateway/testdata/http/01-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/01-gateway-route.yaml
@@ -1,6 +1,6 @@
 Clusters:
   Resources:
-    echo-service-5a416c39037aa8f6:
+    echo-service-9f149ed9e14091ca:
       circuitBreakers:
         thresholds:
         - maxConnections: 1024
@@ -12,7 +12,7 @@ Clusters:
         edsConfig:
           ads: {}
           resourceApiVersion: V3
-      name: echo-service-5a416c39037aa8f6
+      name: echo-service-9f149ed9e14091ca
       outlierDetection:
         enforcingConsecutive5xx: 0
         enforcingConsecutiveGatewayFailure: 0
@@ -29,8 +29,8 @@ Clusters:
             httpProtocolOptions: {}
 Endpoints:
   Resources:
-    echo-service-5a416c39037aa8f6:
-      clusterName: echo-service-5a416c39037aa8f6
+    echo-service-9f149ed9e14091ca:
+      clusterName: echo-service-9f149ed9e14091ca
       endpoints:
       - lbEndpoints:
         - endpoint:
@@ -128,7 +128,7 @@ Routes:
             timeout: 15s
             weightedClusters:
               clusters:
-              - name: echo-service-5a416c39037aa8f6
+              - name: echo-service-9f149ed9e14091ca
                 requestHeadersToAdd:
                 - header:
                     key: x-kuma-tags
@@ -152,7 +152,7 @@ Routes:
             timeout: 15s
             weightedClusters:
               clusters:
-              - name: echo-service-5a416c39037aa8f6
+              - name: echo-service-9f149ed9e14091ca
                 requestHeadersToAdd:
                 - header:
                     key: x-kuma-tags
@@ -176,7 +176,7 @@ Routes:
             timeout: 15s
             weightedClusters:
               clusters:
-              - name: echo-service-5a416c39037aa8f6
+              - name: echo-service-9f149ed9e14091ca
                 requestHeadersToAdd:
                 - header:
                     key: x-kuma-tags

--- a/pkg/plugins/runtime/gateway/testdata/http/02-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/02-gateway-route.yaml
@@ -1,32 +1,5 @@
 Clusters:
   Resources:
-    echo-service-6ab423c47cdb0767:
-      circuitBreakers:
-        thresholds:
-        - maxConnections: 1024
-          maxPendingRequests: 1024
-          maxRequests: 1024
-          maxRetries: 3
-      connectTimeout: 5s
-      edsClusterConfig:
-        edsConfig:
-          ads: {}
-          resourceApiVersion: V3
-      name: echo-service-6ab423c47cdb0767
-      outlierDetection:
-        enforcingConsecutive5xx: 0
-        enforcingConsecutiveGatewayFailure: 0
-        enforcingConsecutiveLocalOriginFailure: 0
-        enforcingFailurePercentage: 0
-        enforcingSuccessRate: 0
-      type: EDS
-      typedExtensionProtocolOptions:
-        envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
-          '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
-          commonHttpProtocolOptions:
-            idleTimeout: 3600s
-          explicitHttpConfig:
-            httpProtocolOptions: {}
     echo-service-9f149ed9e14091ca:
       circuitBreakers:
         thresholds:
@@ -56,22 +29,6 @@ Clusters:
             httpProtocolOptions: {}
 Endpoints:
   Resources:
-    echo-service-6ab423c47cdb0767:
-      clusterName: echo-service-6ab423c47cdb0767
-      endpoints:
-      - lbEndpoints:
-        - endpoint:
-            address:
-              socketAddress:
-                address: 192.168.1.6
-                portValue: 20006
-          loadBalancingWeight: 1
-          metadata:
-            filterMetadata:
-              envoy.lb:
-                kuma.io/protocol: http
-              envoy.transport_socket_match:
-                kuma.io/protocol: http
     echo-service-9f149ed9e14091ca:
       clusterName: echo-service-9f149ed9e14091ca
       endpoints:
@@ -195,7 +152,7 @@ Routes:
             timeout: 15s
             weightedClusters:
               clusters:
-              - name: echo-service-6ab423c47cdb0767
+              - name: echo-service-9f149ed9e14091ca
                 requestHeadersToAdd:
                 - header:
                     key: x-kuma-tags

--- a/pkg/plugins/runtime/gateway/testdata/http/02-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/02-gateway-route.yaml
@@ -1,6 +1,6 @@
 Clusters:
   Resources:
-    echo-service-5a416c39037aa8f6:
+    echo-service-6ab423c47cdb0767:
       circuitBreakers:
         thresholds:
         - maxConnections: 1024
@@ -12,7 +12,34 @@ Clusters:
         edsConfig:
           ads: {}
           resourceApiVersion: V3
-      name: echo-service-5a416c39037aa8f6
+      name: echo-service-6ab423c47cdb0767
+      outlierDetection:
+        enforcingConsecutive5xx: 0
+        enforcingConsecutiveGatewayFailure: 0
+        enforcingConsecutiveLocalOriginFailure: 0
+        enforcingFailurePercentage: 0
+        enforcingSuccessRate: 0
+      type: EDS
+      typedExtensionProtocolOptions:
+        envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+          '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+          commonHttpProtocolOptions:
+            idleTimeout: 3600s
+          explicitHttpConfig:
+            httpProtocolOptions: {}
+    echo-service-9f149ed9e14091ca:
+      circuitBreakers:
+        thresholds:
+        - maxConnections: 1024
+          maxPendingRequests: 1024
+          maxRequests: 1024
+          maxRetries: 3
+      connectTimeout: 5s
+      edsClusterConfig:
+        edsConfig:
+          ads: {}
+          resourceApiVersion: V3
+      name: echo-service-9f149ed9e14091ca
       outlierDetection:
         enforcingConsecutive5xx: 0
         enforcingConsecutiveGatewayFailure: 0
@@ -29,8 +56,24 @@ Clusters:
             httpProtocolOptions: {}
 Endpoints:
   Resources:
-    echo-service-5a416c39037aa8f6:
-      clusterName: echo-service-5a416c39037aa8f6
+    echo-service-6ab423c47cdb0767:
+      clusterName: echo-service-6ab423c47cdb0767
+      endpoints:
+      - lbEndpoints:
+        - endpoint:
+            address:
+              socketAddress:
+                address: 192.168.1.6
+                portValue: 20006
+          loadBalancingWeight: 1
+          metadata:
+            filterMetadata:
+              envoy.lb:
+                kuma.io/protocol: http
+              envoy.transport_socket_match:
+                kuma.io/protocol: http
+    echo-service-9f149ed9e14091ca:
+      clusterName: echo-service-9f149ed9e14091ca
       endpoints:
       - lbEndpoints:
         - endpoint:
@@ -128,7 +171,7 @@ Routes:
             timeout: 15s
             weightedClusters:
               clusters:
-              - name: echo-service-5a416c39037aa8f6
+              - name: echo-service-9f149ed9e14091ca
                 requestHeadersToAdd:
                 - header:
                     key: x-kuma-tags
@@ -152,7 +195,7 @@ Routes:
             timeout: 15s
             weightedClusters:
               clusters:
-              - name: echo-service-5a416c39037aa8f6
+              - name: echo-service-6ab423c47cdb0767
                 requestHeadersToAdd:
                 - header:
                     key: x-kuma-tags

--- a/pkg/plugins/runtime/gateway/testdata/http/03-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/03-gateway-route.yaml
@@ -1,6 +1,6 @@
 Clusters:
   Resources:
-    echo-service-5a416c39037aa8f6:
+    echo-service-9f149ed9e14091ca:
       circuitBreakers:
         thresholds:
         - maxConnections: 1024
@@ -12,7 +12,7 @@ Clusters:
         edsConfig:
           ads: {}
           resourceApiVersion: V3
-      name: echo-service-5a416c39037aa8f6
+      name: echo-service-9f149ed9e14091ca
       outlierDetection:
         enforcingConsecutive5xx: 0
         enforcingConsecutiveGatewayFailure: 0
@@ -29,8 +29,8 @@ Clusters:
             httpProtocolOptions: {}
 Endpoints:
   Resources:
-    echo-service-5a416c39037aa8f6:
-      clusterName: echo-service-5a416c39037aa8f6
+    echo-service-9f149ed9e14091ca:
+      clusterName: echo-service-9f149ed9e14091ca
       endpoints:
       - lbEndpoints:
         - endpoint:
@@ -128,7 +128,7 @@ Routes:
             timeout: 15s
             weightedClusters:
               clusters:
-              - name: echo-service-5a416c39037aa8f6
+              - name: echo-service-9f149ed9e14091ca
                 requestHeadersToAdd:
                 - header:
                     key: x-kuma-tags

--- a/pkg/plugins/runtime/gateway/testdata/http/04-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/04-gateway-route.yaml
@@ -1,6 +1,6 @@
 Clusters:
   Resources:
-    echo-mirror-eb192462fe75ad40:
+    echo-mirror-90205ae37cc0294e:
       circuitBreakers:
         thresholds:
         - maxConnections: 1024
@@ -12,7 +12,7 @@ Clusters:
         edsConfig:
           ads: {}
           resourceApiVersion: V3
-      name: echo-mirror-eb192462fe75ad40
+      name: echo-mirror-90205ae37cc0294e
       outlierDetection:
         enforcingConsecutive5xx: 0
         enforcingConsecutiveGatewayFailure: 0
@@ -27,7 +27,7 @@ Clusters:
             idleTimeout: 3600s
           explicitHttpConfig:
             httpProtocolOptions: {}
-    echo-service-5a416c39037aa8f6:
+    echo-service-9f149ed9e14091ca:
       circuitBreakers:
         thresholds:
         - maxConnections: 1024
@@ -39,7 +39,7 @@ Clusters:
         edsConfig:
           ads: {}
           resourceApiVersion: V3
-      name: echo-service-5a416c39037aa8f6
+      name: echo-service-9f149ed9e14091ca
       outlierDetection:
         enforcingConsecutive5xx: 0
         enforcingConsecutiveGatewayFailure: 0
@@ -56,10 +56,10 @@ Clusters:
             httpProtocolOptions: {}
 Endpoints:
   Resources:
-    echo-mirror-eb192462fe75ad40:
-      clusterName: echo-mirror-eb192462fe75ad40
-    echo-service-5a416c39037aa8f6:
-      clusterName: echo-service-5a416c39037aa8f6
+    echo-mirror-90205ae37cc0294e:
+      clusterName: echo-mirror-90205ae37cc0294e
+    echo-service-9f149ed9e14091ca:
+      clusterName: echo-service-9f149ed9e14091ca
       endpoints:
       - lbEndpoints:
         - endpoint:
@@ -148,7 +148,7 @@ Routes:
             path: /
           route:
             requestMirrorPolicies:
-            - cluster: echo-mirror-eb192462fe75ad40
+            - cluster: echo-mirror-90205ae37cc0294e
               runtimeFraction:
                 defaultValue:
                   denominator: TEN_THOUSAND
@@ -163,7 +163,7 @@ Routes:
             timeout: 15s
             weightedClusters:
               clusters:
-              - name: echo-service-5a416c39037aa8f6
+              - name: echo-service-9f149ed9e14091ca
                 requestHeadersToAdd:
                 - header:
                     key: x-kuma-tags

--- a/pkg/plugins/runtime/gateway/testdata/http/06-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/06-gateway-route.yaml
@@ -1,6 +1,6 @@
 Clusters:
   Resources:
-    echo-mirror-eb192462fe75ad40:
+    echo-mirror-90205ae37cc0294e:
       circuitBreakers:
         thresholds:
         - maxConnections: 1024
@@ -12,7 +12,7 @@ Clusters:
         edsConfig:
           ads: {}
           resourceApiVersion: V3
-      name: echo-mirror-eb192462fe75ad40
+      name: echo-mirror-90205ae37cc0294e
       outlierDetection:
         enforcingConsecutive5xx: 0
         enforcingConsecutiveGatewayFailure: 0
@@ -27,7 +27,7 @@ Clusters:
             idleTimeout: 3600s
           explicitHttpConfig:
             httpProtocolOptions: {}
-    echo-service-5a416c39037aa8f6:
+    echo-service-9f149ed9e14091ca:
       circuitBreakers:
         thresholds:
         - maxConnections: 1024
@@ -39,7 +39,7 @@ Clusters:
         edsConfig:
           ads: {}
           resourceApiVersion: V3
-      name: echo-service-5a416c39037aa8f6
+      name: echo-service-9f149ed9e14091ca
       outlierDetection:
         enforcingConsecutive5xx: 0
         enforcingConsecutiveGatewayFailure: 0
@@ -56,10 +56,10 @@ Clusters:
             httpProtocolOptions: {}
 Endpoints:
   Resources:
-    echo-mirror-eb192462fe75ad40:
-      clusterName: echo-mirror-eb192462fe75ad40
-    echo-service-5a416c39037aa8f6:
-      clusterName: echo-service-5a416c39037aa8f6
+    echo-mirror-90205ae37cc0294e:
+      clusterName: echo-mirror-90205ae37cc0294e
+    echo-service-9f149ed9e14091ca:
+      clusterName: echo-service-9f149ed9e14091ca
       endpoints:
       - lbEndpoints:
         - endpoint:
@@ -167,7 +167,7 @@ Routes:
           - delete-another
           route:
             requestMirrorPolicies:
-            - cluster: echo-mirror-eb192462fe75ad40
+            - cluster: echo-mirror-90205ae37cc0294e
               runtimeFraction:
                 defaultValue:
                   denominator: TEN_THOUSAND
@@ -182,7 +182,7 @@ Routes:
             timeout: 15s
             weightedClusters:
               clusters:
-              - name: echo-service-5a416c39037aa8f6
+              - name: echo-service-9f149ed9e14091ca
                 requestHeadersToAdd:
                 - header:
                     key: x-kuma-tags

--- a/pkg/plugins/runtime/gateway/testdata/http/07-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/07-gateway-route.yaml
@@ -1,6 +1,6 @@
 Clusters:
   Resources:
-    echo-service-5a416c39037aa8f6:
+    echo-service-9f149ed9e14091ca:
       circuitBreakers:
         thresholds:
         - maxConnections: 1024
@@ -12,7 +12,7 @@ Clusters:
         edsConfig:
           ads: {}
           resourceApiVersion: V3
-      name: echo-service-5a416c39037aa8f6
+      name: echo-service-9f149ed9e14091ca
       outlierDetection:
         enforcingConsecutive5xx: 0
         enforcingConsecutiveGatewayFailure: 0
@@ -29,8 +29,8 @@ Clusters:
             httpProtocolOptions: {}
 Endpoints:
   Resources:
-    echo-service-5a416c39037aa8f6:
-      clusterName: echo-service-5a416c39037aa8f6
+    echo-service-9f149ed9e14091ca:
+      clusterName: echo-service-9f149ed9e14091ca
       endpoints:
       - lbEndpoints:
         - endpoint:
@@ -128,7 +128,7 @@ Routes:
             timeout: 15s
             weightedClusters:
               clusters:
-              - name: echo-service-5a416c39037aa8f6
+              - name: echo-service-9f149ed9e14091ca
                 requestHeadersToAdd:
                 - header:
                     key: x-kuma-tags
@@ -148,7 +148,7 @@ Routes:
             timeout: 15s
             weightedClusters:
               clusters:
-              - name: echo-service-5a416c39037aa8f6
+              - name: echo-service-9f149ed9e14091ca
                 requestHeadersToAdd:
                 - header:
                     key: x-kuma-tags

--- a/pkg/plugins/runtime/gateway/testdata/http/08-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/08-gateway-route.yaml
@@ -1,6 +1,6 @@
 Clusters:
   Resources:
-    exact-service-09493d2d54b2a972:
+    exact-service-6c25eaca226749f3:
       circuitBreakers:
         thresholds:
         - maxConnections: 1024
@@ -12,7 +12,7 @@ Clusters:
         edsConfig:
           ads: {}
           resourceApiVersion: V3
-      name: exact-service-09493d2d54b2a972
+      name: exact-service-6c25eaca226749f3
       outlierDetection:
         enforcingConsecutive5xx: 0
         enforcingConsecutiveGatewayFailure: 0
@@ -27,7 +27,7 @@ Clusters:
             idleTimeout: 3600s
           explicitHttpConfig:
             httpProtocolOptions: {}
-    prefix-service-5061ee504b81a555:
+    prefix-service-bfa07e23a84b267b:
       circuitBreakers:
         thresholds:
         - maxConnections: 1024
@@ -39,7 +39,7 @@ Clusters:
         edsConfig:
           ads: {}
           resourceApiVersion: V3
-      name: prefix-service-5061ee504b81a555
+      name: prefix-service-bfa07e23a84b267b
       outlierDetection:
         enforcingConsecutive5xx: 0
         enforcingConsecutiveGatewayFailure: 0
@@ -56,8 +56,8 @@ Clusters:
             httpProtocolOptions: {}
 Endpoints:
   Resources:
-    exact-service-09493d2d54b2a972:
-      clusterName: exact-service-09493d2d54b2a972
+    exact-service-6c25eaca226749f3:
+      clusterName: exact-service-6c25eaca226749f3
       endpoints:
       - lbEndpoints:
         - endpoint:
@@ -72,8 +72,8 @@ Endpoints:
                 kuma.io/protocol: http
               envoy.transport_socket_match:
                 kuma.io/protocol: http
-    prefix-service-5061ee504b81a555:
-      clusterName: prefix-service-5061ee504b81a555
+    prefix-service-bfa07e23a84b267b:
+      clusterName: prefix-service-bfa07e23a84b267b
       endpoints:
       - lbEndpoints:
         - endpoint:
@@ -171,7 +171,7 @@ Routes:
             timeout: 15s
             weightedClusters:
               clusters:
-              - name: exact-service-09493d2d54b2a972
+              - name: exact-service-6c25eaca226749f3
                 requestHeadersToAdd:
                 - header:
                     key: x-kuma-tags
@@ -191,7 +191,7 @@ Routes:
             timeout: 15s
             weightedClusters:
               clusters:
-              - name: prefix-service-5061ee504b81a555
+              - name: prefix-service-bfa07e23a84b267b
                 requestHeadersToAdd:
                 - header:
                     key: x-kuma-tags

--- a/pkg/plugins/runtime/gateway/testdata/http/09-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/09-gateway-route.yaml
@@ -1,6 +1,6 @@
 Clusters:
   Resources:
-    echo-service-5a416c39037aa8f6:
+    echo-service-9f149ed9e14091ca:
       circuitBreakers:
         thresholds:
         - maxConnections: 1024
@@ -12,7 +12,7 @@ Clusters:
         edsConfig:
           ads: {}
           resourceApiVersion: V3
-      name: echo-service-5a416c39037aa8f6
+      name: echo-service-9f149ed9e14091ca
       outlierDetection:
         enforcingConsecutive5xx: 0
         enforcingConsecutiveGatewayFailure: 0
@@ -29,8 +29,8 @@ Clusters:
             httpProtocolOptions: {}
 Endpoints:
   Resources:
-    echo-service-5a416c39037aa8f6:
-      clusterName: echo-service-5a416c39037aa8f6
+    echo-service-9f149ed9e14091ca:
+      clusterName: echo-service-9f149ed9e14091ca
       endpoints:
       - lbEndpoints:
         - endpoint:
@@ -130,7 +130,7 @@ Routes:
             timeout: 15s
             weightedClusters:
               clusters:
-              - name: echo-service-5a416c39037aa8f6
+              - name: echo-service-9f149ed9e14091ca
                 requestHeadersToAdd:
                 - header:
                     key: x-kuma-tags

--- a/pkg/plugins/runtime/gateway/testdata/http/10-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/10-gateway-route.yaml
@@ -1,6 +1,6 @@
 Clusters:
   Resources:
-    exact-header-match-f6b57a6b55557c81:
+    exact-header-match-d7c910a2e5559eda:
       circuitBreakers:
         thresholds:
         - maxConnections: 1024
@@ -12,7 +12,7 @@ Clusters:
         edsConfig:
           ads: {}
           resourceApiVersion: V3
-      name: exact-header-match-f6b57a6b55557c81
+      name: exact-header-match-d7c910a2e5559eda
       outlierDetection:
         enforcingConsecutive5xx: 0
         enforcingConsecutiveGatewayFailure: 0
@@ -27,7 +27,7 @@ Clusters:
             idleTimeout: 3600s
           explicitHttpConfig:
             httpProtocolOptions: {}
-    regex-header-match-ad0dd92f37b8a38d:
+    regex-header-match-70561bb2da83c870:
       circuitBreakers:
         thresholds:
         - maxConnections: 1024
@@ -39,7 +39,7 @@ Clusters:
         edsConfig:
           ads: {}
           resourceApiVersion: V3
-      name: regex-header-match-ad0dd92f37b8a38d
+      name: regex-header-match-70561bb2da83c870
       outlierDetection:
         enforcingConsecutive5xx: 0
         enforcingConsecutiveGatewayFailure: 0
@@ -56,8 +56,8 @@ Clusters:
             httpProtocolOptions: {}
 Endpoints:
   Resources:
-    exact-header-match-f6b57a6b55557c81:
-      clusterName: exact-header-match-f6b57a6b55557c81
+    exact-header-match-d7c910a2e5559eda:
+      clusterName: exact-header-match-d7c910a2e5559eda
       endpoints:
       - lbEndpoints:
         - endpoint:
@@ -72,8 +72,8 @@ Endpoints:
                 kuma.io/protocol: http
               envoy.transport_socket_match:
                 kuma.io/protocol: http
-    regex-header-match-ad0dd92f37b8a38d:
-      clusterName: regex-header-match-ad0dd92f37b8a38d
+    regex-header-match-70561bb2da83c870:
+      clusterName: regex-header-match-70561bb2da83c870
       endpoints:
       - lbEndpoints:
         - endpoint:
@@ -180,7 +180,7 @@ Routes:
             timeout: 15s
             weightedClusters:
               clusters:
-              - name: regex-header-match-ad0dd92f37b8a38d
+              - name: regex-header-match-70561bb2da83c870
                 requestHeadersToAdd:
                 - header:
                     key: x-kuma-tags
@@ -203,7 +203,7 @@ Routes:
             timeout: 15s
             weightedClusters:
               clusters:
-              - name: exact-header-match-f6b57a6b55557c81
+              - name: exact-header-match-d7c910a2e5559eda
                 requestHeadersToAdd:
                 - header:
                     key: x-kuma-tags
@@ -226,7 +226,7 @@ Routes:
             timeout: 15s
             weightedClusters:
               clusters:
-              - name: exact-header-match-f6b57a6b55557c81
+              - name: exact-header-match-d7c910a2e5559eda
                 requestHeadersToAdd:
                 - header:
                     key: x-kuma-tags

--- a/pkg/plugins/runtime/gateway/testdata/http/11-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/11-gateway-route.yaml
@@ -27,7 +27,7 @@ Clusters:
             idleTimeout: 3600s
           explicitHttpConfig:
             httpProtocolOptions: {}
-    regex-query-match-1c308de0249548d3:
+    regex-query-match-2c070f45017d23a5:
       circuitBreakers:
         thresholds:
         - maxConnections: 1024
@@ -39,7 +39,7 @@ Clusters:
         edsConfig:
           ads: {}
           resourceApiVersion: V3
-      name: regex-query-match-1c308de0249548d3
+      name: regex-query-match-2c070f45017d23a5
       outlierDetection:
         enforcingConsecutive5xx: 0
         enforcingConsecutiveGatewayFailure: 0
@@ -72,8 +72,8 @@ Endpoints:
                 kuma.io/protocol: http
               envoy.transport_socket_match:
                 kuma.io/protocol: http
-    regex-query-match-1c308de0249548d3:
-      clusterName: regex-query-match-1c308de0249548d3
+    regex-query-match-2c070f45017d23a5:
+      clusterName: regex-query-match-2c070f45017d23a5
       endpoints:
       - lbEndpoints:
         - endpoint:
@@ -182,7 +182,7 @@ Routes:
             timeout: 15s
             weightedClusters:
               clusters:
-              - name: regex-query-match-1c308de0249548d3
+              - name: regex-query-match-2c070f45017d23a5
                 requestHeadersToAdd:
                 - header:
                     key: x-kuma-tags

--- a/pkg/plugins/runtime/gateway/testdata/http/11-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/11-gateway-route.yaml
@@ -1,6 +1,6 @@
 Clusters:
   Resources:
-    exact-query-match-cc1370f58a3b5330:
+    exact-query-match-36212e4e8ec491f1:
       circuitBreakers:
         thresholds:
         - maxConnections: 1024
@@ -12,7 +12,7 @@ Clusters:
         edsConfig:
           ads: {}
           resourceApiVersion: V3
-      name: exact-query-match-cc1370f58a3b5330
+      name: exact-query-match-36212e4e8ec491f1
       outlierDetection:
         enforcingConsecutive5xx: 0
         enforcingConsecutiveGatewayFailure: 0
@@ -27,7 +27,7 @@ Clusters:
             idleTimeout: 3600s
           explicitHttpConfig:
             httpProtocolOptions: {}
-    regex-query-match-3804d7b8516d7323:
+    regex-query-match-1c308de0249548d3:
       circuitBreakers:
         thresholds:
         - maxConnections: 1024
@@ -39,7 +39,7 @@ Clusters:
         edsConfig:
           ads: {}
           resourceApiVersion: V3
-      name: regex-query-match-3804d7b8516d7323
+      name: regex-query-match-1c308de0249548d3
       outlierDetection:
         enforcingConsecutive5xx: 0
         enforcingConsecutiveGatewayFailure: 0
@@ -56,8 +56,8 @@ Clusters:
             httpProtocolOptions: {}
 Endpoints:
   Resources:
-    exact-query-match-cc1370f58a3b5330:
-      clusterName: exact-query-match-cc1370f58a3b5330
+    exact-query-match-36212e4e8ec491f1:
+      clusterName: exact-query-match-36212e4e8ec491f1
       endpoints:
       - lbEndpoints:
         - endpoint:
@@ -72,8 +72,8 @@ Endpoints:
                 kuma.io/protocol: http
               envoy.transport_socket_match:
                 kuma.io/protocol: http
-    regex-query-match-3804d7b8516d7323:
-      clusterName: regex-query-match-3804d7b8516d7323
+    regex-query-match-1c308de0249548d3:
+      clusterName: regex-query-match-1c308de0249548d3
       endpoints:
       - lbEndpoints:
         - endpoint:
@@ -182,7 +182,7 @@ Routes:
             timeout: 15s
             weightedClusters:
               clusters:
-              - name: regex-query-match-3804d7b8516d7323
+              - name: regex-query-match-1c308de0249548d3
                 requestHeadersToAdd:
                 - header:
                     key: x-kuma-tags
@@ -206,7 +206,7 @@ Routes:
             timeout: 15s
             weightedClusters:
               clusters:
-              - name: exact-query-match-cc1370f58a3b5330
+              - name: exact-query-match-36212e4e8ec491f1
                 requestHeadersToAdd:
                 - header:
                     key: x-kuma-tags
@@ -230,7 +230,7 @@ Routes:
             timeout: 15s
             weightedClusters:
               clusters:
-              - name: exact-query-match-cc1370f58a3b5330
+              - name: exact-query-match-36212e4e8ec491f1
                 requestHeadersToAdd:
                 - header:
                     key: x-kuma-tags

--- a/pkg/plugins/runtime/gateway/testdata/http/12-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/12-gateway-route.yaml
@@ -1,6 +1,6 @@
 Clusters:
   Resources:
-    echo-service-5a416c39037aa8f6:
+    echo-service-9f149ed9e14091ca:
       circuitBreakers:
         thresholds:
         - maxConnections: 1024
@@ -12,7 +12,7 @@ Clusters:
         edsConfig:
           ads: {}
           resourceApiVersion: V3
-      name: echo-service-5a416c39037aa8f6
+      name: echo-service-9f149ed9e14091ca
       outlierDetection:
         enforcingConsecutive5xx: 0
         enforcingConsecutiveGatewayFailure: 0
@@ -29,8 +29,8 @@ Clusters:
             httpProtocolOptions: {}
 Endpoints:
   Resources:
-    echo-service-5a416c39037aa8f6:
-      clusterName: echo-service-5a416c39037aa8f6
+    echo-service-9f149ed9e14091ca:
+      clusterName: echo-service-9f149ed9e14091ca
       endpoints:
       - lbEndpoints:
         - endpoint:
@@ -133,7 +133,7 @@ Routes:
             timeout: 15s
             weightedClusters:
               clusters:
-              - name: echo-service-5a416c39037aa8f6
+              - name: echo-service-9f149ed9e14091ca
                 requestHeadersToAdd:
                 - header:
                     key: x-kuma-tags
@@ -158,7 +158,7 @@ Routes:
             timeout: 15s
             weightedClusters:
               clusters:
-              - name: echo-service-5a416c39037aa8f6
+              - name: echo-service-9f149ed9e14091ca
                 requestHeadersToAdd:
                 - header:
                     key: x-kuma-tags
@@ -183,7 +183,7 @@ Routes:
             timeout: 15s
             weightedClusters:
               clusters:
-              - name: echo-service-5a416c39037aa8f6
+              - name: echo-service-9f149ed9e14091ca
                 requestHeadersToAdd:
                 - header:
                     key: x-kuma-tags

--- a/pkg/plugins/runtime/gateway/testdata/http/13-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/13-gateway-route.yaml
@@ -1,6 +1,6 @@
 Clusters:
   Resources:
-    echo-exact-ad4e3a31db1bf217:
+    echo-exact-0c6c646106bd51f3:
       circuitBreakers:
         thresholds:
         - maxConnections: 1024
@@ -12,7 +12,7 @@ Clusters:
         edsConfig:
           ads: {}
           resourceApiVersion: V3
-      name: echo-exact-ad4e3a31db1bf217
+      name: echo-exact-0c6c646106bd51f3
       outlierDetection:
         enforcingConsecutive5xx: 0
         enforcingConsecutiveGatewayFailure: 0
@@ -27,7 +27,7 @@ Clusters:
             idleTimeout: 3600s
           explicitHttpConfig:
             httpProtocolOptions: {}
-    echo-prefix-d0e5ba63b0c9b9f0:
+    echo-prefix-1d3cd70bb04bf6e2:
       circuitBreakers:
         thresholds:
         - maxConnections: 1024
@@ -39,7 +39,7 @@ Clusters:
         edsConfig:
           ads: {}
           resourceApiVersion: V3
-      name: echo-prefix-d0e5ba63b0c9b9f0
+      name: echo-prefix-1d3cd70bb04bf6e2
       outlierDetection:
         enforcingConsecutive5xx: 0
         enforcingConsecutiveGatewayFailure: 0
@@ -54,7 +54,7 @@ Clusters:
             idleTimeout: 3600s
           explicitHttpConfig:
             httpProtocolOptions: {}
-    echo-regex-627905e7b1c2eb33:
+    echo-prefix-fb233dfa49dbd8d9:
       circuitBreakers:
         thresholds:
         - maxConnections: 1024
@@ -66,7 +66,34 @@ Clusters:
         edsConfig:
           ads: {}
           resourceApiVersion: V3
-      name: echo-regex-627905e7b1c2eb33
+      name: echo-prefix-fb233dfa49dbd8d9
+      outlierDetection:
+        enforcingConsecutive5xx: 0
+        enforcingConsecutiveGatewayFailure: 0
+        enforcingConsecutiveLocalOriginFailure: 0
+        enforcingFailurePercentage: 0
+        enforcingSuccessRate: 0
+      type: EDS
+      typedExtensionProtocolOptions:
+        envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+          '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+          commonHttpProtocolOptions:
+            idleTimeout: 3600s
+          explicitHttpConfig:
+            httpProtocolOptions: {}
+    echo-regex-197ed2f99640f307:
+      circuitBreakers:
+        thresholds:
+        - maxConnections: 1024
+          maxPendingRequests: 1024
+          maxRequests: 1024
+          maxRetries: 3
+      connectTimeout: 5s
+      edsClusterConfig:
+        edsConfig:
+          ads: {}
+          resourceApiVersion: V3
+      name: echo-regex-197ed2f99640f307
       outlierDetection:
         enforcingConsecutive5xx: 0
         enforcingConsecutiveGatewayFailure: 0
@@ -83,8 +110,8 @@ Clusters:
             httpProtocolOptions: {}
 Endpoints:
   Resources:
-    echo-exact-ad4e3a31db1bf217:
-      clusterName: echo-exact-ad4e3a31db1bf217
+    echo-exact-0c6c646106bd51f3:
+      clusterName: echo-exact-0c6c646106bd51f3
       endpoints:
       - lbEndpoints:
         - endpoint:
@@ -99,8 +126,8 @@ Endpoints:
                 kuma.io/protocol: http
               envoy.transport_socket_match:
                 kuma.io/protocol: http
-    echo-prefix-d0e5ba63b0c9b9f0:
-      clusterName: echo-prefix-d0e5ba63b0c9b9f0
+    echo-prefix-1d3cd70bb04bf6e2:
+      clusterName: echo-prefix-1d3cd70bb04bf6e2
       endpoints:
       - lbEndpoints:
         - endpoint:
@@ -115,8 +142,24 @@ Endpoints:
                 kuma.io/protocol: http
               envoy.transport_socket_match:
                 kuma.io/protocol: http
-    echo-regex-627905e7b1c2eb33:
-      clusterName: echo-regex-627905e7b1c2eb33
+    echo-prefix-fb233dfa49dbd8d9:
+      clusterName: echo-prefix-fb233dfa49dbd8d9
+      endpoints:
+      - lbEndpoints:
+        - endpoint:
+            address:
+              socketAddress:
+                address: 192.168.1.4
+                portValue: 20004
+          loadBalancingWeight: 1
+          metadata:
+            filterMetadata:
+              envoy.lb:
+                kuma.io/protocol: http
+              envoy.transport_socket_match:
+                kuma.io/protocol: http
+    echo-regex-197ed2f99640f307:
+      clusterName: echo-regex-197ed2f99640f307
       endpoints:
       - lbEndpoints:
         - endpoint:
@@ -214,7 +257,7 @@ Routes:
             timeout: 15s
             weightedClusters:
               clusters:
-              - name: echo-exact-ad4e3a31db1bf217
+              - name: echo-exact-0c6c646106bd51f3
                 requestHeadersToAdd:
                 - header:
                     key: x-kuma-tags
@@ -234,7 +277,7 @@ Routes:
             timeout: 15s
             weightedClusters:
               clusters:
-              - name: echo-prefix-d0e5ba63b0c9b9f0
+              - name: echo-prefix-1d3cd70bb04bf6e2
                 requestHeadersToAdd:
                 - header:
                     key: x-kuma-tags
@@ -254,7 +297,7 @@ Routes:
             timeout: 15s
             weightedClusters:
               clusters:
-              - name: echo-prefix-d0e5ba63b0c9b9f0
+              - name: echo-prefix-1d3cd70bb04bf6e2
                 requestHeadersToAdd:
                 - header:
                     key: x-kuma-tags
@@ -276,7 +319,7 @@ Routes:
             timeout: 15s
             weightedClusters:
               clusters:
-              - name: echo-regex-627905e7b1c2eb33
+              - name: echo-regex-197ed2f99640f307
                 requestHeadersToAdd:
                 - header:
                     key: x-kuma-tags

--- a/pkg/plugins/runtime/gateway/testdata/http/13-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/13-gateway-route.yaml
@@ -54,33 +54,6 @@ Clusters:
             idleTimeout: 3600s
           explicitHttpConfig:
             httpProtocolOptions: {}
-    echo-prefix-fb233dfa49dbd8d9:
-      circuitBreakers:
-        thresholds:
-        - maxConnections: 1024
-          maxPendingRequests: 1024
-          maxRequests: 1024
-          maxRetries: 3
-      connectTimeout: 5s
-      edsClusterConfig:
-        edsConfig:
-          ads: {}
-          resourceApiVersion: V3
-      name: echo-prefix-fb233dfa49dbd8d9
-      outlierDetection:
-        enforcingConsecutive5xx: 0
-        enforcingConsecutiveGatewayFailure: 0
-        enforcingConsecutiveLocalOriginFailure: 0
-        enforcingFailurePercentage: 0
-        enforcingSuccessRate: 0
-      type: EDS
-      typedExtensionProtocolOptions:
-        envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
-          '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
-          commonHttpProtocolOptions:
-            idleTimeout: 3600s
-          explicitHttpConfig:
-            httpProtocolOptions: {}
     echo-regex-197ed2f99640f307:
       circuitBreakers:
         thresholds:
@@ -128,22 +101,6 @@ Endpoints:
                 kuma.io/protocol: http
     echo-prefix-1d3cd70bb04bf6e2:
       clusterName: echo-prefix-1d3cd70bb04bf6e2
-      endpoints:
-      - lbEndpoints:
-        - endpoint:
-            address:
-              socketAddress:
-                address: 192.168.1.4
-                portValue: 20004
-          loadBalancingWeight: 1
-          metadata:
-            filterMetadata:
-              envoy.lb:
-                kuma.io/protocol: http
-              envoy.transport_socket_match:
-                kuma.io/protocol: http
-    echo-prefix-fb233dfa49dbd8d9:
-      clusterName: echo-prefix-fb233dfa49dbd8d9
       endpoints:
       - lbEndpoints:
         - endpoint:

--- a/pkg/plugins/runtime/gateway/testdata/http/14-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/14-gateway-route.yaml
@@ -1,6 +1,6 @@
 Clusters:
   Resources:
-    echo-service-5a416c39037aa8f6:
+    echo-service-9f149ed9e14091ca:
       circuitBreakers:
         thresholds:
         - maxConnections: 1024
@@ -12,7 +12,7 @@ Clusters:
         edsConfig:
           ads: {}
           resourceApiVersion: V3
-      name: echo-service-5a416c39037aa8f6
+      name: echo-service-9f149ed9e14091ca
       outlierDetection:
         enforcingConsecutive5xx: 0
         enforcingConsecutiveGatewayFailure: 0
@@ -29,8 +29,8 @@ Clusters:
             httpProtocolOptions: {}
 Endpoints:
   Resources:
-    echo-service-5a416c39037aa8f6:
-      clusterName: echo-service-5a416c39037aa8f6
+    echo-service-9f149ed9e14091ca:
+      clusterName: echo-service-9f149ed9e14091ca
       endpoints:
       - lbEndpoints:
         - endpoint:
@@ -132,7 +132,7 @@ Routes:
             timeout: 15s
             weightedClusters:
               clusters:
-              - name: echo-service-5a416c39037aa8f6
+              - name: echo-service-9f149ed9e14091ca
                 requestHeadersToAdd:
                 - header:
                     key: x-kuma-tags

--- a/pkg/plugins/runtime/gateway/testdata/http/15-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/15-gateway-route.yaml
@@ -1,6 +1,6 @@
 Clusters:
   Resources:
-    api-service-6b688a06cd66f5c9:
+    api-service-4508437668c35ed8:
       circuitBreakers:
         thresholds:
         - maxConnections: 1024
@@ -12,7 +12,7 @@ Clusters:
         edsConfig:
           ads: {}
           resourceApiVersion: V3
-      name: api-service-6b688a06cd66f5c9
+      name: api-service-4508437668c35ed8
       outlierDetection:
         enforcingConsecutive5xx: 0
         enforcingConsecutiveGatewayFailure: 0
@@ -27,7 +27,7 @@ Clusters:
             idleTimeout: 20s
           explicitHttpConfig:
             httpProtocolOptions: {}
-    echo-mirror-5c286df2bcbe50d6:
+    echo-mirror-3dd740a2de879d4c:
       circuitBreakers:
         thresholds:
         - maxConnections: 1024
@@ -39,7 +39,7 @@ Clusters:
         edsConfig:
           ads: {}
           resourceApiVersion: V3
-      name: echo-mirror-5c286df2bcbe50d6
+      name: echo-mirror-3dd740a2de879d4c
       outlierDetection:
         enforcingConsecutive5xx: 0
         enforcingConsecutiveGatewayFailure: 0
@@ -54,7 +54,7 @@ Clusters:
             idleTimeout: 30s
           explicitHttpConfig:
             httpProtocolOptions: {}
-    echo-service-b5c2b60cba392c4e:
+    echo-service-6ab423c47cdb0767:
       circuitBreakers:
         thresholds:
         - maxConnections: 1024
@@ -66,7 +66,7 @@ Clusters:
         edsConfig:
           ads: {}
           resourceApiVersion: V3
-      name: echo-service-b5c2b60cba392c4e
+      name: echo-service-6ab423c47cdb0767
       outlierDetection:
         enforcingConsecutive5xx: 0
         enforcingConsecutiveGatewayFailure: 0
@@ -83,8 +83,8 @@ Clusters:
             httpProtocolOptions: {}
 Endpoints:
   Resources:
-    api-service-6b688a06cd66f5c9:
-      clusterName: api-service-6b688a06cd66f5c9
+    api-service-4508437668c35ed8:
+      clusterName: api-service-4508437668c35ed8
       endpoints:
       - lbEndpoints:
         - endpoint:
@@ -99,8 +99,8 @@ Endpoints:
                 kuma.io/protocol: http
               envoy.transport_socket_match:
                 kuma.io/protocol: http
-    echo-mirror-5c286df2bcbe50d6:
-      clusterName: echo-mirror-5c286df2bcbe50d6
+    echo-mirror-3dd740a2de879d4c:
+      clusterName: echo-mirror-3dd740a2de879d4c
       endpoints:
       - lbEndpoints:
         - endpoint:
@@ -115,8 +115,8 @@ Endpoints:
                 kuma.io/protocol: http
               envoy.transport_socket_match:
                 kuma.io/protocol: http
-    echo-service-b5c2b60cba392c4e:
-      clusterName: echo-service-b5c2b60cba392c4e
+    echo-service-6ab423c47cdb0767:
+      clusterName: echo-service-6ab423c47cdb0767
       endpoints:
       - lbEndpoints:
         - endpoint:
@@ -214,7 +214,7 @@ Routes:
             timeout: 20s
             weightedClusters:
               clusters:
-              - name: api-service-6b688a06cd66f5c9
+              - name: api-service-4508437668c35ed8
                 requestHeadersToAdd:
                 - header:
                     key: x-kuma-tags
@@ -234,7 +234,7 @@ Routes:
             timeout: 20s
             weightedClusters:
               clusters:
-              - name: api-service-6b688a06cd66f5c9
+              - name: api-service-4508437668c35ed8
                 requestHeadersToAdd:
                 - header:
                     key: x-kuma-tags
@@ -245,7 +245,7 @@ Routes:
             prefix: /
           route:
             requestMirrorPolicies:
-            - cluster: echo-mirror-5c286df2bcbe50d6
+            - cluster: echo-mirror-3dd740a2de879d4c
               runtimeFraction:
                 defaultValue:
                   numerator: 1
@@ -259,7 +259,7 @@ Routes:
             timeout: 10s
             weightedClusters:
               clusters:
-              - name: echo-service-b5c2b60cba392c4e
+              - name: echo-service-6ab423c47cdb0767
                 requestHeadersToAdd:
                 - header:
                     key: x-kuma-tags

--- a/pkg/plugins/runtime/gateway/testdata/http/15-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/15-gateway-route.yaml
@@ -54,7 +54,7 @@ Clusters:
             idleTimeout: 30s
           explicitHttpConfig:
             httpProtocolOptions: {}
-    echo-service-6ab423c47cdb0767:
+    echo-service-9f149ed9e14091ca:
       circuitBreakers:
         thresholds:
         - maxConnections: 1024
@@ -66,7 +66,7 @@ Clusters:
         edsConfig:
           ads: {}
           resourceApiVersion: V3
-      name: echo-service-6ab423c47cdb0767
+      name: echo-service-9f149ed9e14091ca
       outlierDetection:
         enforcingConsecutive5xx: 0
         enforcingConsecutiveGatewayFailure: 0
@@ -115,8 +115,8 @@ Endpoints:
                 kuma.io/protocol: http
               envoy.transport_socket_match:
                 kuma.io/protocol: http
-    echo-service-6ab423c47cdb0767:
-      clusterName: echo-service-6ab423c47cdb0767
+    echo-service-9f149ed9e14091ca:
+      clusterName: echo-service-9f149ed9e14091ca
       endpoints:
       - lbEndpoints:
         - endpoint:
@@ -259,7 +259,7 @@ Routes:
             timeout: 10s
             weightedClusters:
               clusters:
-              - name: echo-service-6ab423c47cdb0767
+              - name: echo-service-9f149ed9e14091ca
                 requestHeadersToAdd:
                 - header:
                     key: x-kuma-tags

--- a/pkg/plugins/runtime/gateway/testdata/http/16-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/16-gateway-route.yaml
@@ -1,6 +1,6 @@
 Clusters:
   Resources:
-    api-service-49c6d22609eca2d2:
+    api-service-4508437668c35ed8:
       circuitBreakers:
         thresholds:
         - maxRetries: 20
@@ -9,7 +9,7 @@ Clusters:
         edsConfig:
           ads: {}
           resourceApiVersion: V3
-      name: api-service-49c6d22609eca2d2
+      name: api-service-4508437668c35ed8
       outlierDetection:
         baseEjectionTime: 20s
         consecutiveLocalOriginFailure: 20
@@ -26,7 +26,7 @@ Clusters:
             idleTimeout: 3600s
           explicitHttpConfig:
             httpProtocolOptions: {}
-    echo-mirror-f534124491f4385f:
+    echo-mirror-3dd740a2de879d4c:
       circuitBreakers:
         thresholds:
         - maxRetries: 20
@@ -35,7 +35,7 @@ Clusters:
         edsConfig:
           ads: {}
           resourceApiVersion: V3
-      name: echo-mirror-f534124491f4385f
+      name: echo-mirror-3dd740a2de879d4c
       outlierDetection:
         baseEjectionTime: 30s
         consecutiveLocalOriginFailure: 30
@@ -52,7 +52,7 @@ Clusters:
             idleTimeout: 3600s
           explicitHttpConfig:
             httpProtocolOptions: {}
-    echo-service-48cd7f2dbb98df84:
+    echo-service-6ab423c47cdb0767:
       circuitBreakers:
         thresholds:
         - maxRetries: 10
@@ -61,7 +61,7 @@ Clusters:
         edsConfig:
           ads: {}
           resourceApiVersion: V3
-      name: echo-service-48cd7f2dbb98df84
+      name: echo-service-6ab423c47cdb0767
       outlierDetection:
         baseEjectionTime: 10s
         consecutiveLocalOriginFailure: 10
@@ -80,8 +80,8 @@ Clusters:
             httpProtocolOptions: {}
 Endpoints:
   Resources:
-    api-service-49c6d22609eca2d2:
-      clusterName: api-service-49c6d22609eca2d2
+    api-service-4508437668c35ed8:
+      clusterName: api-service-4508437668c35ed8
       endpoints:
       - lbEndpoints:
         - endpoint:
@@ -96,8 +96,8 @@ Endpoints:
                 kuma.io/protocol: http
               envoy.transport_socket_match:
                 kuma.io/protocol: http
-    echo-mirror-f534124491f4385f:
-      clusterName: echo-mirror-f534124491f4385f
+    echo-mirror-3dd740a2de879d4c:
+      clusterName: echo-mirror-3dd740a2de879d4c
       endpoints:
       - lbEndpoints:
         - endpoint:
@@ -112,8 +112,8 @@ Endpoints:
                 kuma.io/protocol: http
               envoy.transport_socket_match:
                 kuma.io/protocol: http
-    echo-service-48cd7f2dbb98df84:
-      clusterName: echo-service-48cd7f2dbb98df84
+    echo-service-6ab423c47cdb0767:
+      clusterName: echo-service-6ab423c47cdb0767
       endpoints:
       - lbEndpoints:
         - endpoint:
@@ -211,7 +211,7 @@ Routes:
             timeout: 15s
             weightedClusters:
               clusters:
-              - name: api-service-49c6d22609eca2d2
+              - name: api-service-4508437668c35ed8
                 requestHeadersToAdd:
                 - header:
                     key: x-kuma-tags
@@ -231,7 +231,7 @@ Routes:
             timeout: 15s
             weightedClusters:
               clusters:
-              - name: api-service-49c6d22609eca2d2
+              - name: api-service-4508437668c35ed8
                 requestHeadersToAdd:
                 - header:
                     key: x-kuma-tags
@@ -242,7 +242,7 @@ Routes:
             prefix: /
           route:
             requestMirrorPolicies:
-            - cluster: echo-mirror-f534124491f4385f
+            - cluster: echo-mirror-3dd740a2de879d4c
               runtimeFraction:
                 defaultValue:
                   numerator: 1
@@ -256,7 +256,7 @@ Routes:
             timeout: 15s
             weightedClusters:
               clusters:
-              - name: echo-service-48cd7f2dbb98df84
+              - name: echo-service-6ab423c47cdb0767
                 requestHeadersToAdd:
                 - header:
                     key: x-kuma-tags

--- a/pkg/plugins/runtime/gateway/testdata/http/16-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/16-gateway-route.yaml
@@ -52,7 +52,7 @@ Clusters:
             idleTimeout: 3600s
           explicitHttpConfig:
             httpProtocolOptions: {}
-    echo-service-6ab423c47cdb0767:
+    echo-service-9f149ed9e14091ca:
       circuitBreakers:
         thresholds:
         - maxRetries: 10
@@ -61,7 +61,7 @@ Clusters:
         edsConfig:
           ads: {}
           resourceApiVersion: V3
-      name: echo-service-6ab423c47cdb0767
+      name: echo-service-9f149ed9e14091ca
       outlierDetection:
         baseEjectionTime: 10s
         consecutiveLocalOriginFailure: 10
@@ -112,8 +112,8 @@ Endpoints:
                 kuma.io/protocol: http
               envoy.transport_socket_match:
                 kuma.io/protocol: http
-    echo-service-6ab423c47cdb0767:
-      clusterName: echo-service-6ab423c47cdb0767
+    echo-service-9f149ed9e14091ca:
+      clusterName: echo-service-9f149ed9e14091ca
       endpoints:
       - lbEndpoints:
         - endpoint:
@@ -256,7 +256,7 @@ Routes:
             timeout: 15s
             weightedClusters:
               clusters:
-              - name: echo-service-6ab423c47cdb0767
+              - name: echo-service-9f149ed9e14091ca
                 requestHeadersToAdd:
                 - header:
                     key: x-kuma-tags

--- a/pkg/plugins/runtime/gateway/testdata/http/17-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/17-gateway-route.yaml
@@ -1,6 +1,6 @@
 Clusters:
   Resources:
-    api-service-19fcb7995aa98119:
+    api-service-4508437668c35ed8:
       circuitBreakers:
         thresholds:
         - maxConnections: 1024
@@ -18,7 +18,7 @@ Clusters:
         tcpHealthCheck: {}
         timeout: 20s
         unhealthyThreshold: 2
-      name: api-service-19fcb7995aa98119
+      name: api-service-4508437668c35ed8
       outlierDetection:
         enforcingConsecutive5xx: 0
         enforcingConsecutiveGatewayFailure: 0
@@ -33,7 +33,7 @@ Clusters:
             idleTimeout: 3600s
           explicitHttpConfig:
             httpProtocolOptions: {}
-    echo-mirror-2e2ba113e4d991ba:
+    echo-mirror-3dd740a2de879d4c:
       circuitBreakers:
         thresholds:
         - maxConnections: 1024
@@ -51,7 +51,7 @@ Clusters:
         tcpHealthCheck: {}
         timeout: 30s
         unhealthyThreshold: 3
-      name: echo-mirror-2e2ba113e4d991ba
+      name: echo-mirror-3dd740a2de879d4c
       outlierDetection:
         enforcingConsecutive5xx: 0
         enforcingConsecutiveGatewayFailure: 0
@@ -66,7 +66,7 @@ Clusters:
             idleTimeout: 3600s
           explicitHttpConfig:
             httpProtocolOptions: {}
-    echo-service-eb4ea372d99abf73:
+    echo-service-6ab423c47cdb0767:
       circuitBreakers:
         thresholds:
         - maxConnections: 1024
@@ -84,7 +84,7 @@ Clusters:
         tcpHealthCheck: {}
         timeout: 10s
         unhealthyThreshold: 1
-      name: echo-service-eb4ea372d99abf73
+      name: echo-service-6ab423c47cdb0767
       outlierDetection:
         enforcingConsecutive5xx: 0
         enforcingConsecutiveGatewayFailure: 0
@@ -101,8 +101,8 @@ Clusters:
             httpProtocolOptions: {}
 Endpoints:
   Resources:
-    api-service-19fcb7995aa98119:
-      clusterName: api-service-19fcb7995aa98119
+    api-service-4508437668c35ed8:
+      clusterName: api-service-4508437668c35ed8
       endpoints:
       - lbEndpoints:
         - endpoint:
@@ -117,8 +117,8 @@ Endpoints:
                 kuma.io/protocol: http
               envoy.transport_socket_match:
                 kuma.io/protocol: http
-    echo-mirror-2e2ba113e4d991ba:
-      clusterName: echo-mirror-2e2ba113e4d991ba
+    echo-mirror-3dd740a2de879d4c:
+      clusterName: echo-mirror-3dd740a2de879d4c
       endpoints:
       - lbEndpoints:
         - endpoint:
@@ -133,8 +133,8 @@ Endpoints:
                 kuma.io/protocol: http
               envoy.transport_socket_match:
                 kuma.io/protocol: http
-    echo-service-eb4ea372d99abf73:
-      clusterName: echo-service-eb4ea372d99abf73
+    echo-service-6ab423c47cdb0767:
+      clusterName: echo-service-6ab423c47cdb0767
       endpoints:
       - lbEndpoints:
         - endpoint:
@@ -232,7 +232,7 @@ Routes:
             timeout: 15s
             weightedClusters:
               clusters:
-              - name: api-service-19fcb7995aa98119
+              - name: api-service-4508437668c35ed8
                 requestHeadersToAdd:
                 - header:
                     key: x-kuma-tags
@@ -252,7 +252,7 @@ Routes:
             timeout: 15s
             weightedClusters:
               clusters:
-              - name: api-service-19fcb7995aa98119
+              - name: api-service-4508437668c35ed8
                 requestHeadersToAdd:
                 - header:
                     key: x-kuma-tags
@@ -263,7 +263,7 @@ Routes:
             prefix: /
           route:
             requestMirrorPolicies:
-            - cluster: echo-mirror-2e2ba113e4d991ba
+            - cluster: echo-mirror-3dd740a2de879d4c
               runtimeFraction:
                 defaultValue:
                   numerator: 1
@@ -277,7 +277,7 @@ Routes:
             timeout: 15s
             weightedClusters:
               clusters:
-              - name: echo-service-eb4ea372d99abf73
+              - name: echo-service-6ab423c47cdb0767
                 requestHeadersToAdd:
                 - header:
                     key: x-kuma-tags

--- a/pkg/plugins/runtime/gateway/testdata/http/17-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/17-gateway-route.yaml
@@ -66,7 +66,7 @@ Clusters:
             idleTimeout: 3600s
           explicitHttpConfig:
             httpProtocolOptions: {}
-    echo-service-6ab423c47cdb0767:
+    echo-service-9f149ed9e14091ca:
       circuitBreakers:
         thresholds:
         - maxConnections: 1024
@@ -84,7 +84,7 @@ Clusters:
         tcpHealthCheck: {}
         timeout: 10s
         unhealthyThreshold: 1
-      name: echo-service-6ab423c47cdb0767
+      name: echo-service-9f149ed9e14091ca
       outlierDetection:
         enforcingConsecutive5xx: 0
         enforcingConsecutiveGatewayFailure: 0
@@ -133,8 +133,8 @@ Endpoints:
                 kuma.io/protocol: http
               envoy.transport_socket_match:
                 kuma.io/protocol: http
-    echo-service-6ab423c47cdb0767:
-      clusterName: echo-service-6ab423c47cdb0767
+    echo-service-9f149ed9e14091ca:
+      clusterName: echo-service-9f149ed9e14091ca
       endpoints:
       - lbEndpoints:
         - endpoint:
@@ -277,7 +277,7 @@ Routes:
             timeout: 15s
             weightedClusters:
               clusters:
-              - name: echo-service-6ab423c47cdb0767
+              - name: echo-service-9f149ed9e14091ca
                 requestHeadersToAdd:
                 - header:
                     key: x-kuma-tags

--- a/pkg/plugins/runtime/gateway/testdata/http/18-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/18-gateway-route.yaml
@@ -1,6 +1,6 @@
 Clusters:
   Resources:
-    external-httpbin-4a2cc28cd5e983f1:
+    external-httpbin-8490df2e58a77ae0:
       circuitBreakers:
         thresholds:
         - maxConnections: 1024
@@ -25,7 +25,7 @@ Clusters:
                   kuma.io/protocol: http
                 envoy.transport_socket_match:
                   kuma.io/protocol: http
-      name: external-httpbin-4a2cc28cd5e983f1
+      name: external-httpbin-8490df2e58a77ae0
       outlierDetection:
         enforcingConsecutive5xx: 0
         enforcingConsecutiveGatewayFailure: 0
@@ -125,7 +125,7 @@ Routes:
             timeout: 15s
             weightedClusters:
               clusters:
-              - name: external-httpbin-4a2cc28cd5e983f1
+              - name: external-httpbin-8490df2e58a77ae0
                 weight: 1
               totalWeight: 1
 Runtimes:

--- a/pkg/plugins/runtime/gateway/testdata/http/19-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/19-gateway-route.yaml
@@ -1,6 +1,6 @@
 Clusters:
   Resources:
-    external-httpbin-e70841077c6e3aa5:
+    external-httpbin-8490df2e58a77ae0:
       circuitBreakers:
         thresholds:
         - maxConnections: 1024
@@ -27,7 +27,7 @@ Clusters:
                 envoy.transport_socket_match:
                   kuma.io/external-service-name: external-httpbin
                   kuma.io/protocol: http2
-      name: external-httpbin-e70841077c6e3aa5
+      name: external-httpbin-8490df2e58a77ae0
       outlierDetection:
         enforcingConsecutive5xx: 0
         enforcingConsecutiveGatewayFailure: 0
@@ -137,7 +137,7 @@ Routes:
             timeout: 15s
             weightedClusters:
               clusters:
-              - name: external-httpbin-e70841077c6e3aa5
+              - name: external-httpbin-8490df2e58a77ae0
                 weight: 1
               totalWeight: 1
 Runtimes:

--- a/pkg/plugins/runtime/gateway/testdata/http/20-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/20-gateway-route.yaml
@@ -27,33 +27,6 @@ Clusters:
             idleTimeout: 10s
           explicitHttpConfig:
             httpProtocolOptions: {}
-    echo-service-09d7c1c6ad2a108d:
-      circuitBreakers:
-        thresholds:
-        - maxConnections: 1024
-          maxPendingRequests: 1024
-          maxRequests: 1024
-          maxRetries: 3
-      connectTimeout: 20s
-      edsClusterConfig:
-        edsConfig:
-          ads: {}
-          resourceApiVersion: V3
-      name: echo-service-09d7c1c6ad2a108d
-      outlierDetection:
-        enforcingConsecutive5xx: 0
-        enforcingConsecutiveGatewayFailure: 0
-        enforcingConsecutiveLocalOriginFailure: 0
-        enforcingFailurePercentage: 0
-        enforcingSuccessRate: 0
-      type: EDS
-      typedExtensionProtocolOptions:
-        envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
-          '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
-          commonHttpProtocolOptions:
-            idleTimeout: 20s
-          explicitHttpConfig:
-            httpProtocolOptions: {}
     echo-service-11405a82852416ac:
       circuitBreakers:
         thresholds:
@@ -81,6 +54,33 @@ Clusters:
             idleTimeout: 30s
           explicitHttpConfig:
             httpProtocolOptions: {}
+    echo-service-ff1f8bb571f3bfa4:
+      circuitBreakers:
+        thresholds:
+        - maxConnections: 1024
+          maxPendingRequests: 1024
+          maxRequests: 1024
+          maxRetries: 3
+      connectTimeout: 20s
+      edsClusterConfig:
+        edsConfig:
+          ads: {}
+          resourceApiVersion: V3
+      name: echo-service-ff1f8bb571f3bfa4
+      outlierDetection:
+        enforcingConsecutive5xx: 0
+        enforcingConsecutiveGatewayFailure: 0
+        enforcingConsecutiveLocalOriginFailure: 0
+        enforcingFailurePercentage: 0
+        enforcingSuccessRate: 0
+      type: EDS
+      typedExtensionProtocolOptions:
+        envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+          '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+          commonHttpProtocolOptions:
+            idleTimeout: 20s
+          explicitHttpConfig:
+            httpProtocolOptions: {}
 Endpoints:
   Resources:
     echo-service-4d89cd662308223d:
@@ -99,8 +99,8 @@ Endpoints:
                 kuma.io/protocol: http
               envoy.transport_socket_match:
                 kuma.io/protocol: http
-    echo-service-09d7c1c6ad2a108d:
-      clusterName: echo-service-09d7c1c6ad2a108d
+    echo-service-11405a82852416ac:
+      clusterName: echo-service-11405a82852416ac
       endpoints:
       - lbEndpoints:
         - endpoint:
@@ -115,8 +115,8 @@ Endpoints:
                 kuma.io/protocol: http
               envoy.transport_socket_match:
                 kuma.io/protocol: http
-    echo-service-11405a82852416ac:
-      clusterName: echo-service-11405a82852416ac
+    echo-service-ff1f8bb571f3bfa4:
+      clusterName: echo-service-ff1f8bb571f3bfa4
       endpoints:
       - lbEndpoints:
         - endpoint:
@@ -214,7 +214,7 @@ Routes:
             timeout: 20s
             weightedClusters:
               clusters:
-              - name: echo-service-09d7c1c6ad2a108d
+              - name: echo-service-ff1f8bb571f3bfa4
                 requestHeadersToAdd:
                 - header:
                     key: x-kuma-tags

--- a/pkg/plugins/runtime/gateway/testdata/http/20-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/20-gateway-route.yaml
@@ -1,6 +1,6 @@
 Clusters:
   Resources:
-    echo-service-b5c2b60cba392c4e:
+    echo-service-4d89cd662308223d:
       circuitBreakers:
         thresholds:
         - maxConnections: 1024
@@ -12,7 +12,7 @@ Clusters:
         edsConfig:
           ads: {}
           resourceApiVersion: V3
-      name: echo-service-b5c2b60cba392c4e
+      name: echo-service-4d89cd662308223d
       outlierDetection:
         enforcingConsecutive5xx: 0
         enforcingConsecutiveGatewayFailure: 0
@@ -27,34 +27,7 @@ Clusters:
             idleTimeout: 10s
           explicitHttpConfig:
             httpProtocolOptions: {}
-    echo-service-cff7b41a9764f367:
-      circuitBreakers:
-        thresholds:
-        - maxConnections: 1024
-          maxPendingRequests: 1024
-          maxRequests: 1024
-          maxRetries: 3
-      connectTimeout: 300s
-      edsClusterConfig:
-        edsConfig:
-          ads: {}
-          resourceApiVersion: V3
-      name: echo-service-cff7b41a9764f367
-      outlierDetection:
-        enforcingConsecutive5xx: 0
-        enforcingConsecutiveGatewayFailure: 0
-        enforcingConsecutiveLocalOriginFailure: 0
-        enforcingFailurePercentage: 0
-        enforcingSuccessRate: 0
-      type: EDS
-      typedExtensionProtocolOptions:
-        envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
-          '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
-          commonHttpProtocolOptions:
-            idleTimeout: 30s
-          explicitHttpConfig:
-            httpProtocolOptions: {}
-    echo-service-dbfe9218dfa3ba0c:
+    echo-service-09d7c1c6ad2a108d:
       circuitBreakers:
         thresholds:
         - maxConnections: 1024
@@ -66,7 +39,7 @@ Clusters:
         edsConfig:
           ads: {}
           resourceApiVersion: V3
-      name: echo-service-dbfe9218dfa3ba0c
+      name: echo-service-09d7c1c6ad2a108d
       outlierDetection:
         enforcingConsecutive5xx: 0
         enforcingConsecutiveGatewayFailure: 0
@@ -81,10 +54,37 @@ Clusters:
             idleTimeout: 20s
           explicitHttpConfig:
             httpProtocolOptions: {}
+    echo-service-11405a82852416ac:
+      circuitBreakers:
+        thresholds:
+        - maxConnections: 1024
+          maxPendingRequests: 1024
+          maxRequests: 1024
+          maxRetries: 3
+      connectTimeout: 300s
+      edsClusterConfig:
+        edsConfig:
+          ads: {}
+          resourceApiVersion: V3
+      name: echo-service-11405a82852416ac
+      outlierDetection:
+        enforcingConsecutive5xx: 0
+        enforcingConsecutiveGatewayFailure: 0
+        enforcingConsecutiveLocalOriginFailure: 0
+        enforcingFailurePercentage: 0
+        enforcingSuccessRate: 0
+      type: EDS
+      typedExtensionProtocolOptions:
+        envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+          '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+          commonHttpProtocolOptions:
+            idleTimeout: 30s
+          explicitHttpConfig:
+            httpProtocolOptions: {}
 Endpoints:
   Resources:
-    echo-service-b5c2b60cba392c4e:
-      clusterName: echo-service-b5c2b60cba392c4e
+    echo-service-4d89cd662308223d:
+      clusterName: echo-service-4d89cd662308223d
       endpoints:
       - lbEndpoints:
         - endpoint:
@@ -99,8 +99,8 @@ Endpoints:
                 kuma.io/protocol: http
               envoy.transport_socket_match:
                 kuma.io/protocol: http
-    echo-service-cff7b41a9764f367:
-      clusterName: echo-service-cff7b41a9764f367
+    echo-service-09d7c1c6ad2a108d:
+      clusterName: echo-service-09d7c1c6ad2a108d
       endpoints:
       - lbEndpoints:
         - endpoint:
@@ -115,8 +115,8 @@ Endpoints:
                 kuma.io/protocol: http
               envoy.transport_socket_match:
                 kuma.io/protocol: http
-    echo-service-dbfe9218dfa3ba0c:
-      clusterName: echo-service-dbfe9218dfa3ba0c
+    echo-service-11405a82852416ac:
+      clusterName: echo-service-11405a82852416ac
       endpoints:
       - lbEndpoints:
         - endpoint:
@@ -214,7 +214,7 @@ Routes:
             timeout: 20s
             weightedClusters:
               clusters:
-              - name: echo-service-dbfe9218dfa3ba0c
+              - name: echo-service-09d7c1c6ad2a108d
                 requestHeadersToAdd:
                 - header:
                     key: x-kuma-tags
@@ -238,7 +238,7 @@ Routes:
             timeout: 30s
             weightedClusters:
               clusters:
-              - name: echo-service-cff7b41a9764f367
+              - name: echo-service-11405a82852416ac
                 requestHeadersToAdd:
                 - header:
                     key: x-kuma-tags
@@ -262,7 +262,7 @@ Routes:
             timeout: 10s
             weightedClusters:
               clusters:
-              - name: echo-service-b5c2b60cba392c4e
+              - name: echo-service-4d89cd662308223d
                 requestHeadersToAdd:
                 - header:
                     key: x-kuma-tags

--- a/pkg/plugins/runtime/gateway/testdata/http/21-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/21-gateway-route.yaml
@@ -27,33 +27,6 @@ Clusters:
             idleTimeout: 3600s
           explicitHttpConfig:
             httpProtocolOptions: {}
-    api-service-bb145fed7e9ae110:
-      circuitBreakers:
-        thresholds:
-        - maxConnections: 1024
-          maxPendingRequests: 1024
-          maxRequests: 1024
-          maxRetries: 3
-      connectTimeout: 5s
-      edsClusterConfig:
-        edsConfig:
-          ads: {}
-          resourceApiVersion: V3
-      name: api-service-bb145fed7e9ae110
-      outlierDetection:
-        enforcingConsecutive5xx: 0
-        enforcingConsecutiveGatewayFailure: 0
-        enforcingConsecutiveLocalOriginFailure: 0
-        enforcingFailurePercentage: 0
-        enforcingSuccessRate: 0
-      type: EDS
-      typedExtensionProtocolOptions:
-        envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
-          '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
-          commonHttpProtocolOptions:
-            idleTimeout: 3600s
-          explicitHttpConfig:
-            httpProtocolOptions: {}
     echo-mirror-3dd740a2de879d4c:
       circuitBreakers:
         thresholds:
@@ -81,7 +54,7 @@ Clusters:
             idleTimeout: 3600s
           explicitHttpConfig:
             httpProtocolOptions: {}
-    echo-service-6ab423c47cdb0767:
+    echo-service-9f149ed9e14091ca:
       circuitBreakers:
         thresholds:
         - maxConnections: 1024
@@ -93,7 +66,7 @@ Clusters:
         edsConfig:
           ads: {}
           resourceApiVersion: V3
-      name: echo-service-6ab423c47cdb0767
+      name: echo-service-9f149ed9e14091ca
       outlierDetection:
         enforcingConsecutive5xx: 0
         enforcingConsecutiveGatewayFailure: 0
@@ -126,22 +99,6 @@ Endpoints:
                 kuma.io/protocol: http
               envoy.transport_socket_match:
                 kuma.io/protocol: http
-    api-service-bb145fed7e9ae110:
-      clusterName: api-service-bb145fed7e9ae110
-      endpoints:
-      - lbEndpoints:
-        - endpoint:
-            address:
-              socketAddress:
-                address: 192.168.1.1
-                portValue: 20001
-          loadBalancingWeight: 1
-          metadata:
-            filterMetadata:
-              envoy.lb:
-                kuma.io/protocol: http
-              envoy.transport_socket_match:
-                kuma.io/protocol: http
     echo-mirror-3dd740a2de879d4c:
       clusterName: echo-mirror-3dd740a2de879d4c
       endpoints:
@@ -158,8 +115,8 @@ Endpoints:
                 kuma.io/protocol: http
               envoy.transport_socket_match:
                 kuma.io/protocol: http
-    echo-service-6ab423c47cdb0767:
-      clusterName: echo-service-6ab423c47cdb0767
+    echo-service-9f149ed9e14091ca:
+      clusterName: echo-service-9f149ed9e14091ca
       endpoints:
       - lbEndpoints:
         - endpoint:
@@ -257,7 +214,7 @@ Routes:
             timeout: 15s
             weightedClusters:
               clusters:
-              - name: api-service-bb145fed7e9ae110
+              - name: api-service-4508437668c35ed8
                 requestHeadersToAdd:
                 - header:
                     key: x-kuma-tags
@@ -293,7 +250,7 @@ Routes:
             timeout: 15s
             weightedClusters:
               clusters:
-              - name: api-service-bb145fed7e9ae110
+              - name: api-service-4508437668c35ed8
                 requestHeadersToAdd:
                 - header:
                     key: x-kuma-tags
@@ -334,7 +291,7 @@ Routes:
             timeout: 15s
             weightedClusters:
               clusters:
-              - name: echo-service-6ab423c47cdb0767
+              - name: echo-service-9f149ed9e14091ca
                 requestHeadersToAdd:
                 - header:
                     key: x-kuma-tags

--- a/pkg/plugins/runtime/gateway/testdata/http/21-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/21-gateway-route.yaml
@@ -1,6 +1,6 @@
 Clusters:
   Resources:
-    api-service-f8ae3d759cc477a6:
+    api-service-4508437668c35ed8:
       circuitBreakers:
         thresholds:
         - maxConnections: 1024
@@ -12,7 +12,7 @@ Clusters:
         edsConfig:
           ads: {}
           resourceApiVersion: V3
-      name: api-service-f8ae3d759cc477a6
+      name: api-service-4508437668c35ed8
       outlierDetection:
         enforcingConsecutive5xx: 0
         enforcingConsecutiveGatewayFailure: 0
@@ -27,7 +27,7 @@ Clusters:
             idleTimeout: 3600s
           explicitHttpConfig:
             httpProtocolOptions: {}
-    echo-mirror-712ce3acc3cececc:
+    api-service-bb145fed7e9ae110:
       circuitBreakers:
         thresholds:
         - maxConnections: 1024
@@ -39,7 +39,7 @@ Clusters:
         edsConfig:
           ads: {}
           resourceApiVersion: V3
-      name: echo-mirror-712ce3acc3cececc
+      name: api-service-bb145fed7e9ae110
       outlierDetection:
         enforcingConsecutive5xx: 0
         enforcingConsecutiveGatewayFailure: 0
@@ -54,7 +54,7 @@ Clusters:
             idleTimeout: 3600s
           explicitHttpConfig:
             httpProtocolOptions: {}
-    echo-service-5a416c39037aa8f6:
+    echo-mirror-3dd740a2de879d4c:
       circuitBreakers:
         thresholds:
         - maxConnections: 1024
@@ -66,7 +66,34 @@ Clusters:
         edsConfig:
           ads: {}
           resourceApiVersion: V3
-      name: echo-service-5a416c39037aa8f6
+      name: echo-mirror-3dd740a2de879d4c
+      outlierDetection:
+        enforcingConsecutive5xx: 0
+        enforcingConsecutiveGatewayFailure: 0
+        enforcingConsecutiveLocalOriginFailure: 0
+        enforcingFailurePercentage: 0
+        enforcingSuccessRate: 0
+      type: EDS
+      typedExtensionProtocolOptions:
+        envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+          '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+          commonHttpProtocolOptions:
+            idleTimeout: 3600s
+          explicitHttpConfig:
+            httpProtocolOptions: {}
+    echo-service-6ab423c47cdb0767:
+      circuitBreakers:
+        thresholds:
+        - maxConnections: 1024
+          maxPendingRequests: 1024
+          maxRequests: 1024
+          maxRetries: 3
+      connectTimeout: 5s
+      edsClusterConfig:
+        edsConfig:
+          ads: {}
+          resourceApiVersion: V3
+      name: echo-service-6ab423c47cdb0767
       outlierDetection:
         enforcingConsecutive5xx: 0
         enforcingConsecutiveGatewayFailure: 0
@@ -83,8 +110,8 @@ Clusters:
             httpProtocolOptions: {}
 Endpoints:
   Resources:
-    api-service-f8ae3d759cc477a6:
-      clusterName: api-service-f8ae3d759cc477a6
+    api-service-4508437668c35ed8:
+      clusterName: api-service-4508437668c35ed8
       endpoints:
       - lbEndpoints:
         - endpoint:
@@ -99,8 +126,24 @@ Endpoints:
                 kuma.io/protocol: http
               envoy.transport_socket_match:
                 kuma.io/protocol: http
-    echo-mirror-712ce3acc3cececc:
-      clusterName: echo-mirror-712ce3acc3cececc
+    api-service-bb145fed7e9ae110:
+      clusterName: api-service-bb145fed7e9ae110
+      endpoints:
+      - lbEndpoints:
+        - endpoint:
+            address:
+              socketAddress:
+                address: 192.168.1.1
+                portValue: 20001
+          loadBalancingWeight: 1
+          metadata:
+            filterMetadata:
+              envoy.lb:
+                kuma.io/protocol: http
+              envoy.transport_socket_match:
+                kuma.io/protocol: http
+    echo-mirror-3dd740a2de879d4c:
+      clusterName: echo-mirror-3dd740a2de879d4c
       endpoints:
       - lbEndpoints:
         - endpoint:
@@ -115,8 +158,8 @@ Endpoints:
                 kuma.io/protocol: http
               envoy.transport_socket_match:
                 kuma.io/protocol: http
-    echo-service-5a416c39037aa8f6:
-      clusterName: echo-service-5a416c39037aa8f6
+    echo-service-6ab423c47cdb0767:
+      clusterName: echo-service-6ab423c47cdb0767
       endpoints:
       - lbEndpoints:
         - endpoint:
@@ -214,7 +257,7 @@ Routes:
             timeout: 15s
             weightedClusters:
               clusters:
-              - name: api-service-f8ae3d759cc477a6
+              - name: api-service-bb145fed7e9ae110
                 requestHeadersToAdd:
                 - header:
                     key: x-kuma-tags
@@ -250,7 +293,7 @@ Routes:
             timeout: 15s
             weightedClusters:
               clusters:
-              - name: api-service-f8ae3d759cc477a6
+              - name: api-service-bb145fed7e9ae110
                 requestHeadersToAdd:
                 - header:
                     key: x-kuma-tags
@@ -277,7 +320,7 @@ Routes:
             prefix: /
           route:
             requestMirrorPolicies:
-            - cluster: echo-mirror-712ce3acc3cececc
+            - cluster: echo-mirror-3dd740a2de879d4c
               runtimeFraction:
                 defaultValue:
                   numerator: 1
@@ -291,7 +334,7 @@ Routes:
             timeout: 15s
             weightedClusters:
               clusters:
-              - name: echo-service-5a416c39037aa8f6
+              - name: echo-service-6ab423c47cdb0767
                 requestHeadersToAdd:
                 - header:
                     key: x-kuma-tags

--- a/pkg/plugins/runtime/gateway/testdata/http/22-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/22-gateway-route.yaml
@@ -1,6 +1,6 @@
 Clusters:
   Resources:
-    api-service-54505e76023cc1cc:
+    api-service-ebbb1519109a5d70:
       circuitBreakers:
         thresholds:
         - maxConnections: 1024
@@ -12,7 +12,7 @@ Clusters:
         edsConfig:
           ads: {}
           resourceApiVersion: V3
-      name: api-service-54505e76023cc1cc
+      name: api-service-ebbb1519109a5d70
       outlierDetection:
         enforcingConsecutive5xx: 0
         enforcingConsecutiveGatewayFailure: 0
@@ -27,7 +27,7 @@ Clusters:
             idleTimeout: 3600s
           explicitHttpConfig:
             httpProtocolOptions: {}
-    echo-service-c641ec6d56895d4f:
+    echo-service-b70526a3f546ce4f:
       circuitBreakers:
         thresholds:
         - maxConnections: 1024
@@ -39,7 +39,7 @@ Clusters:
         edsConfig:
           ads: {}
           resourceApiVersion: V3
-      name: echo-service-c641ec6d56895d4f
+      name: echo-service-b70526a3f546ce4f
       outlierDetection:
         enforcingConsecutive5xx: 0
         enforcingConsecutiveGatewayFailure: 0
@@ -56,8 +56,8 @@ Clusters:
             httpProtocolOptions: {}
 Endpoints:
   Resources:
-    api-service-54505e76023cc1cc:
-      clusterName: api-service-54505e76023cc1cc
+    api-service-ebbb1519109a5d70:
+      clusterName: api-service-ebbb1519109a5d70
       endpoints:
       - lbEndpoints:
         - endpoint:
@@ -72,8 +72,8 @@ Endpoints:
                 kuma.io/protocol: http
               envoy.transport_socket_match:
                 kuma.io/protocol: http
-    echo-service-c641ec6d56895d4f:
-      clusterName: echo-service-c641ec6d56895d4f
+    echo-service-b70526a3f546ce4f:
+      clusterName: echo-service-b70526a3f546ce4f
       endpoints:
       - lbEndpoints:
         - endpoint:
@@ -171,7 +171,7 @@ Routes:
             timeout: 15s
             weightedClusters:
               clusters:
-              - name: api-service-54505e76023cc1cc
+              - name: api-service-ebbb1519109a5d70
                 requestHeadersToAdd:
                 - header:
                     key: x-kuma-tags
@@ -191,7 +191,7 @@ Routes:
             timeout: 15s
             weightedClusters:
               clusters:
-              - name: echo-service-c641ec6d56895d4f
+              - name: echo-service-b70526a3f546ce4f
                 requestHeadersToAdd:
                 - header:
                     key: x-kuma-tags

--- a/pkg/plugins/runtime/gateway/testdata/http/22-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/22-gateway-route.yaml
@@ -1,6 +1,6 @@
 Clusters:
   Resources:
-    api-service-f8ae3d759cc477a6:
+    api-service-54505e76023cc1cc:
       circuitBreakers:
         thresholds:
         - maxConnections: 1024
@@ -12,7 +12,7 @@ Clusters:
         edsConfig:
           ads: {}
           resourceApiVersion: V3
-      name: api-service-f8ae3d759cc477a6
+      name: api-service-54505e76023cc1cc
       outlierDetection:
         enforcingConsecutive5xx: 0
         enforcingConsecutiveGatewayFailure: 0
@@ -27,7 +27,7 @@ Clusters:
             idleTimeout: 3600s
           explicitHttpConfig:
             httpProtocolOptions: {}
-    echo-service-5a416c39037aa8f6:
+    echo-service-c641ec6d56895d4f:
       circuitBreakers:
         thresholds:
         - maxConnections: 1024
@@ -39,7 +39,7 @@ Clusters:
         edsConfig:
           ads: {}
           resourceApiVersion: V3
-      name: echo-service-5a416c39037aa8f6
+      name: echo-service-c641ec6d56895d4f
       outlierDetection:
         enforcingConsecutive5xx: 0
         enforcingConsecutiveGatewayFailure: 0
@@ -56,8 +56,8 @@ Clusters:
             httpProtocolOptions: {}
 Endpoints:
   Resources:
-    api-service-f8ae3d759cc477a6:
-      clusterName: api-service-f8ae3d759cc477a6
+    api-service-54505e76023cc1cc:
+      clusterName: api-service-54505e76023cc1cc
       endpoints:
       - lbEndpoints:
         - endpoint:
@@ -72,8 +72,8 @@ Endpoints:
                 kuma.io/protocol: http
               envoy.transport_socket_match:
                 kuma.io/protocol: http
-    echo-service-5a416c39037aa8f6:
-      clusterName: echo-service-5a416c39037aa8f6
+    echo-service-c641ec6d56895d4f:
+      clusterName: echo-service-c641ec6d56895d4f
       endpoints:
       - lbEndpoints:
         - endpoint:
@@ -171,7 +171,7 @@ Routes:
             timeout: 15s
             weightedClusters:
               clusters:
-              - name: api-service-f8ae3d759cc477a6
+              - name: api-service-54505e76023cc1cc
                 requestHeadersToAdd:
                 - header:
                     key: x-kuma-tags
@@ -191,7 +191,7 @@ Routes:
             timeout: 15s
             weightedClusters:
               clusters:
-              - name: echo-service-5a416c39037aa8f6
+              - name: echo-service-c641ec6d56895d4f
                 requestHeadersToAdd:
                 - header:
                     key: x-kuma-tags

--- a/pkg/plugins/runtime/gateway/testdata/http/23-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/23-gateway-route.yaml
@@ -1,6 +1,6 @@
 Clusters:
   Resources:
-    api-service-f8ae3d759cc477a6:
+    api-service-ebbb1519109a5d70:
       circuitBreakers:
         thresholds:
         - maxConnections: 1024
@@ -12,7 +12,7 @@ Clusters:
         edsConfig:
           ads: {}
           resourceApiVersion: V3
-      name: api-service-f8ae3d759cc477a6
+      name: api-service-ebbb1519109a5d70
       outlierDetection:
         enforcingConsecutive5xx: 0
         enforcingConsecutiveGatewayFailure: 0
@@ -27,7 +27,7 @@ Clusters:
             idleTimeout: 3600s
           explicitHttpConfig:
             httpProtocolOptions: {}
-    echo-service-5a416c39037aa8f6:
+    echo-service-90fd1f9189c63c08:
       circuitBreakers:
         thresholds:
         - maxConnections: 1024
@@ -39,7 +39,34 @@ Clusters:
         edsConfig:
           ads: {}
           resourceApiVersion: V3
-      name: echo-service-5a416c39037aa8f6
+      name: echo-service-90fd1f9189c63c08
+      outlierDetection:
+        enforcingConsecutive5xx: 0
+        enforcingConsecutiveGatewayFailure: 0
+        enforcingConsecutiveLocalOriginFailure: 0
+        enforcingFailurePercentage: 0
+        enforcingSuccessRate: 0
+      type: EDS
+      typedExtensionProtocolOptions:
+        envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+          '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+          commonHttpProtocolOptions:
+            idleTimeout: 3600s
+          explicitHttpConfig:
+            httpProtocolOptions: {}
+    echo-service-93307c48e3f89873:
+      circuitBreakers:
+        thresholds:
+        - maxConnections: 1024
+          maxPendingRequests: 1024
+          maxRequests: 1024
+          maxRetries: 3
+      connectTimeout: 5s
+      edsClusterConfig:
+        edsConfig:
+          ads: {}
+          resourceApiVersion: V3
+      name: echo-service-93307c48e3f89873
       outlierDetection:
         enforcingConsecutive5xx: 0
         enforcingConsecutiveGatewayFailure: 0
@@ -56,8 +83,8 @@ Clusters:
             httpProtocolOptions: {}
 Endpoints:
   Resources:
-    api-service-f8ae3d759cc477a6:
-      clusterName: api-service-f8ae3d759cc477a6
+    api-service-ebbb1519109a5d70:
+      clusterName: api-service-ebbb1519109a5d70
       endpoints:
       - lbEndpoints:
         - endpoint:
@@ -72,8 +99,24 @@ Endpoints:
                 kuma.io/protocol: http
               envoy.transport_socket_match:
                 kuma.io/protocol: http
-    echo-service-5a416c39037aa8f6:
-      clusterName: echo-service-5a416c39037aa8f6
+    echo-service-90fd1f9189c63c08:
+      clusterName: echo-service-90fd1f9189c63c08
+      endpoints:
+      - lbEndpoints:
+        - endpoint:
+            address:
+              socketAddress:
+                address: 192.168.1.6
+                portValue: 20006
+          loadBalancingWeight: 1
+          metadata:
+            filterMetadata:
+              envoy.lb:
+                kuma.io/protocol: http
+              envoy.transport_socket_match:
+                kuma.io/protocol: http
+    echo-service-93307c48e3f89873:
+      clusterName: echo-service-93307c48e3f89873
       endpoints:
       - lbEndpoints:
         - endpoint:
@@ -171,7 +214,7 @@ Routes:
             timeout: 15s
             weightedClusters:
               clusters:
-              - name: api-service-f8ae3d759cc477a6
+              - name: api-service-ebbb1519109a5d70
                 requestHeadersToAdd:
                 - header:
                     key: x-kuma-tags
@@ -191,7 +234,7 @@ Routes:
             timeout: 15s
             weightedClusters:
               clusters:
-              - name: echo-service-5a416c39037aa8f6
+              - name: echo-service-93307c48e3f89873
                 requestHeadersToAdd:
                 - header:
                     key: x-kuma-tags
@@ -215,7 +258,7 @@ Routes:
             timeout: 15s
             weightedClusters:
               clusters:
-              - name: echo-service-5a416c39037aa8f6
+              - name: echo-service-90fd1f9189c63c08
                 requestHeadersToAdd:
                 - header:
                     key: x-kuma-tags

--- a/pkg/plugins/runtime/gateway/testdata/http/23-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/23-gateway-route.yaml
@@ -27,7 +27,7 @@ Clusters:
             idleTimeout: 3600s
           explicitHttpConfig:
             httpProtocolOptions: {}
-    echo-service-90fd1f9189c63c08:
+    echo-service-86192ff3ecc578b7:
       circuitBreakers:
         thresholds:
         - maxConnections: 1024
@@ -39,7 +39,7 @@ Clusters:
         edsConfig:
           ads: {}
           resourceApiVersion: V3
-      name: echo-service-90fd1f9189c63c08
+      name: echo-service-86192ff3ecc578b7
       outlierDetection:
         enforcingConsecutive5xx: 0
         enforcingConsecutiveGatewayFailure: 0
@@ -54,7 +54,7 @@ Clusters:
             idleTimeout: 3600s
           explicitHttpConfig:
             httpProtocolOptions: {}
-    echo-service-93307c48e3f89873:
+    echo-service-b70526a3f546ce4f:
       circuitBreakers:
         thresholds:
         - maxConnections: 1024
@@ -66,7 +66,7 @@ Clusters:
         edsConfig:
           ads: {}
           resourceApiVersion: V3
-      name: echo-service-93307c48e3f89873
+      name: echo-service-b70526a3f546ce4f
       outlierDetection:
         enforcingConsecutive5xx: 0
         enforcingConsecutiveGatewayFailure: 0
@@ -99,8 +99,8 @@ Endpoints:
                 kuma.io/protocol: http
               envoy.transport_socket_match:
                 kuma.io/protocol: http
-    echo-service-90fd1f9189c63c08:
-      clusterName: echo-service-90fd1f9189c63c08
+    echo-service-86192ff3ecc578b7:
+      clusterName: echo-service-86192ff3ecc578b7
       endpoints:
       - lbEndpoints:
         - endpoint:
@@ -115,8 +115,8 @@ Endpoints:
                 kuma.io/protocol: http
               envoy.transport_socket_match:
                 kuma.io/protocol: http
-    echo-service-93307c48e3f89873:
-      clusterName: echo-service-93307c48e3f89873
+    echo-service-b70526a3f546ce4f:
+      clusterName: echo-service-b70526a3f546ce4f
       endpoints:
       - lbEndpoints:
         - endpoint:
@@ -234,7 +234,7 @@ Routes:
             timeout: 15s
             weightedClusters:
               clusters:
-              - name: echo-service-93307c48e3f89873
+              - name: echo-service-b70526a3f546ce4f
                 requestHeadersToAdd:
                 - header:
                     key: x-kuma-tags
@@ -258,7 +258,7 @@ Routes:
             timeout: 15s
             weightedClusters:
               clusters:
-              - name: echo-service-90fd1f9189c63c08
+              - name: echo-service-86192ff3ecc578b7
                 requestHeadersToAdd:
                 - header:
                     key: x-kuma-tags

--- a/pkg/plugins/runtime/gateway/testdata/http/24-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/24-gateway-route.yaml
@@ -1,6 +1,6 @@
 Clusters:
   Resources:
-    api-service-f8ae3d759cc477a6:
+    api-service-4508437668c35ed8:
       circuitBreakers:
         thresholds:
         - maxConnections: 1024
@@ -12,7 +12,7 @@ Clusters:
         edsConfig:
           ads: {}
           resourceApiVersion: V3
-      name: api-service-f8ae3d759cc477a6
+      name: api-service-4508437668c35ed8
       outlierDetection:
         enforcingConsecutive5xx: 0
         enforcingConsecutiveGatewayFailure: 0
@@ -27,7 +27,7 @@ Clusters:
             idleTimeout: 3600s
           explicitHttpConfig:
             httpProtocolOptions: {}
-    echo-service-5a416c39037aa8f6:
+    echo-service-9f149ed9e14091ca:
       circuitBreakers:
         thresholds:
         - maxConnections: 1024
@@ -39,7 +39,7 @@ Clusters:
         edsConfig:
           ads: {}
           resourceApiVersion: V3
-      name: echo-service-5a416c39037aa8f6
+      name: echo-service-9f149ed9e14091ca
       outlierDetection:
         enforcingConsecutive5xx: 0
         enforcingConsecutiveGatewayFailure: 0
@@ -56,8 +56,8 @@ Clusters:
             httpProtocolOptions: {}
 Endpoints:
   Resources:
-    api-service-f8ae3d759cc477a6:
-      clusterName: api-service-f8ae3d759cc477a6
+    api-service-4508437668c35ed8:
+      clusterName: api-service-4508437668c35ed8
       endpoints:
       - lbEndpoints:
         - endpoint:
@@ -72,8 +72,8 @@ Endpoints:
                 kuma.io/protocol: http
               envoy.transport_socket_match:
                 kuma.io/protocol: http
-    echo-service-5a416c39037aa8f6:
-      clusterName: echo-service-5a416c39037aa8f6
+    echo-service-9f149ed9e14091ca:
+      clusterName: echo-service-9f149ed9e14091ca
       endpoints:
       - lbEndpoints:
         - endpoint:
@@ -171,7 +171,7 @@ Routes:
             timeout: 15s
             weightedClusters:
               clusters:
-              - name: api-service-f8ae3d759cc477a6
+              - name: api-service-4508437668c35ed8
                 requestHeadersToAdd:
                 - header:
                     key: x-kuma-tags
@@ -191,7 +191,7 @@ Routes:
             timeout: 15s
             weightedClusters:
               clusters:
-              - name: echo-service-5a416c39037aa8f6
+              - name: echo-service-9f149ed9e14091ca
                 requestHeadersToAdd:
                 - header:
                     key: x-kuma-tags
@@ -215,7 +215,7 @@ Routes:
             timeout: 15s
             weightedClusters:
               clusters:
-              - name: echo-service-5a416c39037aa8f6
+              - name: echo-service-9f149ed9e14091ca
                 requestHeadersToAdd:
                 - header:
                     key: x-kuma-tags

--- a/pkg/plugins/runtime/gateway/testdata/http/25-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/25-gateway-route.yaml
@@ -1,6 +1,6 @@
 Clusters:
   Resources:
-    external-httpbin-622a08eefce6a721:
+    external-httpbin-8490df2e58a77ae0:
       circuitBreakers:
         thresholds:
         - maxConnections: 1024
@@ -12,7 +12,7 @@ Clusters:
         edsConfig:
           ads: {}
           resourceApiVersion: V3
-      name: external-httpbin-622a08eefce6a721
+      name: external-httpbin-8490df2e58a77ae0
       outlierDetection:
         enforcingConsecutive5xx: 0
         enforcingConsecutiveGatewayFailure: 0
@@ -51,8 +51,8 @@ Clusters:
             httpProtocolOptions: {}
 Endpoints:
   Resources:
-    external-httpbin-622a08eefce6a721:
-      clusterName: external-httpbin-622a08eefce6a721
+    external-httpbin-8490df2e58a77ae0:
+      clusterName: external-httpbin-8490df2e58a77ae0
       endpoints:
       - lbEndpoints:
         - endpoint:
@@ -150,7 +150,7 @@ Routes:
             timeout: 15s
             weightedClusters:
               clusters:
-              - name: external-httpbin-622a08eefce6a721
+              - name: external-httpbin-8490df2e58a77ae0
                 requestHeadersToAdd:
                 - header:
                     key: x-kuma-tags

--- a/pkg/plugins/runtime/gateway/testdata/http/26-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/26-gateway-route.yaml
@@ -1,6 +1,6 @@
 Clusters:
   Resources:
-    external-httpbin-61ba7d91cd9211a5:
+    external-httpbin-8490df2e58a77ae0:
       circuitBreakers:
         thresholds:
         - maxConnections: 1024
@@ -12,7 +12,7 @@ Clusters:
         edsConfig:
           ads: {}
           resourceApiVersion: V3
-      name: external-httpbin-61ba7d91cd9211a5
+      name: external-httpbin-8490df2e58a77ae0
       outlierDetection:
         enforcingConsecutive5xx: 0
         enforcingConsecutiveGatewayFailure: 0
@@ -51,8 +51,8 @@ Clusters:
             httpProtocolOptions: {}
 Endpoints:
   Resources:
-    external-httpbin-61ba7d91cd9211a5:
-      clusterName: external-httpbin-61ba7d91cd9211a5
+    external-httpbin-8490df2e58a77ae0:
+      clusterName: external-httpbin-8490df2e58a77ae0
 Listeners:
   Resources:
     edge-gateway:HTTP:8080:
@@ -136,7 +136,7 @@ Routes:
             timeout: 15s
             weightedClusters:
               clusters:
-              - name: external-httpbin-61ba7d91cd9211a5
+              - name: external-httpbin-8490df2e58a77ae0
                 requestHeadersToAdd:
                 - header:
                     key: x-kuma-tags

--- a/pkg/plugins/runtime/gateway/testdata/http/cross-mesh-gateway.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/cross-mesh-gateway.yaml
@@ -1,6 +1,6 @@
 Clusters:
   Resources:
-    echo-service-b1e19f953add857b:
+    echo-service-bfae5b64a0fe8b74:
       circuitBreakers:
         thresholds:
         - maxConnections: 1024
@@ -12,7 +12,7 @@ Clusters:
         edsConfig:
           ads: {}
           resourceApiVersion: V3
-      name: echo-service-b1e19f953add857b
+      name: echo-service-bfae5b64a0fe8b74
       outlierDetection:
         enforcingConsecutive5xx: 0
         enforcingConsecutiveGatewayFailure: 0
@@ -49,7 +49,7 @@ Clusters:
             idleTimeout: 3600s
           explicitHttpConfig:
             httpProtocolOptions: {}
-    external-httpbin-e70841077c6e3aa5:
+    external-httpbin-823fa8131cdd67fa:
       circuitBreakers:
         thresholds:
         - maxConnections: 1024
@@ -76,7 +76,7 @@ Clusters:
                 envoy.transport_socket_match:
                   kuma.io/external-service-name: external-httpbin
                   kuma.io/protocol: http2
-      name: external-httpbin-e70841077c6e3aa5
+      name: external-httpbin-823fa8131cdd67fa
       outlierDetection:
         enforcingConsecutive5xx: 0
         enforcingConsecutiveGatewayFailure: 0
@@ -103,8 +103,8 @@ Clusters:
             http2ProtocolOptions: {}
 Endpoints:
   Resources:
-    echo-service-b1e19f953add857b:
-      clusterName: echo-service-b1e19f953add857b
+    echo-service-bfae5b64a0fe8b74:
+      clusterName: echo-service-bfae5b64a0fe8b74
       endpoints:
       - lbEndpoints:
         - endpoint:
@@ -230,7 +230,7 @@ Routes:
             timeout: 15s
             weightedClusters:
               clusters:
-              - name: echo-service-b1e19f953add857b
+              - name: echo-service-bfae5b64a0fe8b74
                 requestHeadersToAdd:
                 - header:
                     key: x-kuma-tags
@@ -250,7 +250,7 @@ Routes:
             timeout: 15s
             weightedClusters:
               clusters:
-              - name: external-httpbin-e70841077c6e3aa5
+              - name: external-httpbin-823fa8131cdd67fa
                 weight: 1
               totalWeight: 1
         - match:
@@ -266,7 +266,7 @@ Routes:
             timeout: 15s
             weightedClusters:
               clusters:
-              - name: echo-service-b1e19f953add857b
+              - name: echo-service-bfae5b64a0fe8b74
                 requestHeadersToAdd:
                 - header:
                     key: x-kuma-tags
@@ -286,7 +286,7 @@ Routes:
             timeout: 15s
             weightedClusters:
               clusters:
-              - name: external-httpbin-e70841077c6e3aa5
+              - name: external-httpbin-823fa8131cdd67fa
                 weight: 1
               totalWeight: 1
 Runtimes:

--- a/pkg/plugins/runtime/gateway/testdata/http/external-service-with-timeout-no-egress.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/external-service-with-timeout-no-egress.yaml
@@ -1,6 +1,6 @@
 Clusters:
   Resources:
-    external-httpbin-f452fc958912174e:
+    external-httpbin-823fa8131cdd67fa:
       circuitBreakers:
         thresholds:
         - maxConnections: 1024
@@ -27,7 +27,7 @@ Clusters:
                 envoy.transport_socket_match:
                   kuma.io/external-service-name: external-httpbin
                   kuma.io/protocol: http2
-      name: external-httpbin-f452fc958912174e
+      name: external-httpbin-823fa8131cdd67fa
       outlierDetection:
         enforcingConsecutive5xx: 0
         enforcingConsecutiveGatewayFailure: 0
@@ -138,7 +138,7 @@ Routes:
             timeout: 114s
             weightedClusters:
               clusters:
-              - name: external-httpbin-f452fc958912174e
+              - name: external-httpbin-823fa8131cdd67fa
                 weight: 1
               totalWeight: 1
         - match:
@@ -154,7 +154,7 @@ Routes:
             timeout: 114s
             weightedClusters:
               clusters:
-              - name: external-httpbin-f452fc958912174e
+              - name: external-httpbin-823fa8131cdd67fa
                 weight: 1
               totalWeight: 1
 Runtimes:

--- a/pkg/plugins/runtime/gateway/testdata/http/no-timeout.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/no-timeout.yaml
@@ -1,6 +1,6 @@
 Clusters:
   Resources:
-    echo-service-fedb984f12d264d6:
+    echo-service-9f149ed9e14091ca:
       circuitBreakers:
         thresholds:
         - maxConnections: 1024
@@ -12,7 +12,7 @@ Clusters:
         edsConfig:
           ads: {}
           resourceApiVersion: V3
-      name: echo-service-fedb984f12d264d6
+      name: echo-service-9f149ed9e14091ca
       outlierDetection:
         enforcingConsecutive5xx: 0
         enforcingConsecutiveGatewayFailure: 0
@@ -29,8 +29,8 @@ Clusters:
             httpProtocolOptions: {}
 Endpoints:
   Resources:
-    echo-service-fedb984f12d264d6:
-      clusterName: echo-service-fedb984f12d264d6
+    echo-service-9f149ed9e14091ca:
+      clusterName: echo-service-9f149ed9e14091ca
       endpoints:
       - lbEndpoints:
         - endpoint:
@@ -127,7 +127,7 @@ Routes:
               retryOn: gateway-error,connect-failure,refused-stream
             weightedClusters:
               clusters:
-              - name: echo-service-fedb984f12d264d6
+              - name: echo-service-9f149ed9e14091ca
                 requestHeadersToAdd:
                 - header:
                     key: x-kuma-tags

--- a/pkg/plugins/runtime/gateway/testdata/https/01-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/01-gateway-route.yaml
@@ -1,32 +1,5 @@
 Clusters:
   Resources:
-    echo-service-6ab423c47cdb0767:
-      circuitBreakers:
-        thresholds:
-        - maxConnections: 1024
-          maxPendingRequests: 1024
-          maxRequests: 1024
-          maxRetries: 3
-      connectTimeout: 5s
-      edsClusterConfig:
-        edsConfig:
-          ads: {}
-          resourceApiVersion: V3
-      name: echo-service-6ab423c47cdb0767
-      outlierDetection:
-        enforcingConsecutive5xx: 0
-        enforcingConsecutiveGatewayFailure: 0
-        enforcingConsecutiveLocalOriginFailure: 0
-        enforcingFailurePercentage: 0
-        enforcingSuccessRate: 0
-      type: EDS
-      typedExtensionProtocolOptions:
-        envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
-          '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
-          commonHttpProtocolOptions:
-            idleTimeout: 3600s
-          explicitHttpConfig:
-            httpProtocolOptions: {}
     echo-service-9f149ed9e14091ca:
       circuitBreakers:
         thresholds:
@@ -56,22 +29,6 @@ Clusters:
             httpProtocolOptions: {}
 Endpoints:
   Resources:
-    echo-service-6ab423c47cdb0767:
-      clusterName: echo-service-6ab423c47cdb0767
-      endpoints:
-      - lbEndpoints:
-        - endpoint:
-            address:
-              socketAddress:
-                address: 192.168.1.6
-                portValue: 20006
-          loadBalancingWeight: 1
-          metadata:
-            filterMetadata:
-              envoy.lb:
-                kuma.io/protocol: http
-              envoy.transport_socket_match:
-                kuma.io/protocol: http
     echo-service-9f149ed9e14091ca:
       clusterName: echo-service-9f149ed9e14091ca
       endpoints:
@@ -195,7 +152,7 @@ Routes:
             timeout: 15s
             weightedClusters:
               clusters:
-              - name: echo-service-6ab423c47cdb0767
+              - name: echo-service-9f149ed9e14091ca
                 requestHeadersToAdd:
                 - header:
                     key: x-kuma-tags

--- a/pkg/plugins/runtime/gateway/testdata/https/01-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/01-gateway-route.yaml
@@ -1,6 +1,6 @@
 Clusters:
   Resources:
-    echo-service-5a416c39037aa8f6:
+    echo-service-6ab423c47cdb0767:
       circuitBreakers:
         thresholds:
         - maxConnections: 1024
@@ -12,7 +12,34 @@ Clusters:
         edsConfig:
           ads: {}
           resourceApiVersion: V3
-      name: echo-service-5a416c39037aa8f6
+      name: echo-service-6ab423c47cdb0767
+      outlierDetection:
+        enforcingConsecutive5xx: 0
+        enforcingConsecutiveGatewayFailure: 0
+        enforcingConsecutiveLocalOriginFailure: 0
+        enforcingFailurePercentage: 0
+        enforcingSuccessRate: 0
+      type: EDS
+      typedExtensionProtocolOptions:
+        envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+          '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+          commonHttpProtocolOptions:
+            idleTimeout: 3600s
+          explicitHttpConfig:
+            httpProtocolOptions: {}
+    echo-service-9f149ed9e14091ca:
+      circuitBreakers:
+        thresholds:
+        - maxConnections: 1024
+          maxPendingRequests: 1024
+          maxRequests: 1024
+          maxRetries: 3
+      connectTimeout: 5s
+      edsClusterConfig:
+        edsConfig:
+          ads: {}
+          resourceApiVersion: V3
+      name: echo-service-9f149ed9e14091ca
       outlierDetection:
         enforcingConsecutive5xx: 0
         enforcingConsecutiveGatewayFailure: 0
@@ -29,8 +56,24 @@ Clusters:
             httpProtocolOptions: {}
 Endpoints:
   Resources:
-    echo-service-5a416c39037aa8f6:
-      clusterName: echo-service-5a416c39037aa8f6
+    echo-service-6ab423c47cdb0767:
+      clusterName: echo-service-6ab423c47cdb0767
+      endpoints:
+      - lbEndpoints:
+        - endpoint:
+            address:
+              socketAddress:
+                address: 192.168.1.6
+                portValue: 20006
+          loadBalancingWeight: 1
+          metadata:
+            filterMetadata:
+              envoy.lb:
+                kuma.io/protocol: http
+              envoy.transport_socket_match:
+                kuma.io/protocol: http
+    echo-service-9f149ed9e14091ca:
+      clusterName: echo-service-9f149ed9e14091ca
       endpoints:
       - lbEndpoints:
         - endpoint:
@@ -128,7 +171,7 @@ Routes:
             timeout: 15s
             weightedClusters:
               clusters:
-              - name: echo-service-5a416c39037aa8f6
+              - name: echo-service-9f149ed9e14091ca
                 requestHeadersToAdd:
                 - header:
                     key: x-kuma-tags
@@ -152,7 +195,7 @@ Routes:
             timeout: 15s
             weightedClusters:
               clusters:
-              - name: echo-service-5a416c39037aa8f6
+              - name: echo-service-6ab423c47cdb0767
                 requestHeadersToAdd:
                 - header:
                     key: x-kuma-tags
@@ -176,7 +219,7 @@ Routes:
             timeout: 15s
             weightedClusters:
               clusters:
-              - name: echo-service-5a416c39037aa8f6
+              - name: echo-service-9f149ed9e14091ca
                 requestHeadersToAdd:
                 - header:
                     key: x-kuma-tags

--- a/pkg/plugins/runtime/gateway/testdata/https/02-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/02-gateway-route.yaml
@@ -1,32 +1,5 @@
 Clusters:
   Resources:
-    echo-service-6ab423c47cdb0767:
-      circuitBreakers:
-        thresholds:
-        - maxConnections: 1024
-          maxPendingRequests: 1024
-          maxRequests: 1024
-          maxRetries: 3
-      connectTimeout: 5s
-      edsClusterConfig:
-        edsConfig:
-          ads: {}
-          resourceApiVersion: V3
-      name: echo-service-6ab423c47cdb0767
-      outlierDetection:
-        enforcingConsecutive5xx: 0
-        enforcingConsecutiveGatewayFailure: 0
-        enforcingConsecutiveLocalOriginFailure: 0
-        enforcingFailurePercentage: 0
-        enforcingSuccessRate: 0
-      type: EDS
-      typedExtensionProtocolOptions:
-        envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
-          '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
-          commonHttpProtocolOptions:
-            idleTimeout: 3600s
-          explicitHttpConfig:
-            httpProtocolOptions: {}
     echo-service-9f149ed9e14091ca:
       circuitBreakers:
         thresholds:
@@ -56,22 +29,6 @@ Clusters:
             httpProtocolOptions: {}
 Endpoints:
   Resources:
-    echo-service-6ab423c47cdb0767:
-      clusterName: echo-service-6ab423c47cdb0767
-      endpoints:
-      - lbEndpoints:
-        - endpoint:
-            address:
-              socketAddress:
-                address: 192.168.1.6
-                portValue: 20006
-          loadBalancingWeight: 1
-          metadata:
-            filterMetadata:
-              envoy.lb:
-                kuma.io/protocol: http
-              envoy.transport_socket_match:
-                kuma.io/protocol: http
     echo-service-9f149ed9e14091ca:
       clusterName: echo-service-9f149ed9e14091ca
       endpoints:
@@ -171,7 +128,7 @@ Routes:
             timeout: 15s
             weightedClusters:
               clusters:
-              - name: echo-service-6ab423c47cdb0767
+              - name: echo-service-9f149ed9e14091ca
                 requestHeadersToAdd:
                 - header:
                     key: x-kuma-tags

--- a/pkg/plugins/runtime/gateway/testdata/https/02-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/02-gateway-route.yaml
@@ -1,6 +1,6 @@
 Clusters:
   Resources:
-    echo-service-5a416c39037aa8f6:
+    echo-service-6ab423c47cdb0767:
       circuitBreakers:
         thresholds:
         - maxConnections: 1024
@@ -12,7 +12,34 @@ Clusters:
         edsConfig:
           ads: {}
           resourceApiVersion: V3
-      name: echo-service-5a416c39037aa8f6
+      name: echo-service-6ab423c47cdb0767
+      outlierDetection:
+        enforcingConsecutive5xx: 0
+        enforcingConsecutiveGatewayFailure: 0
+        enforcingConsecutiveLocalOriginFailure: 0
+        enforcingFailurePercentage: 0
+        enforcingSuccessRate: 0
+      type: EDS
+      typedExtensionProtocolOptions:
+        envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+          '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+          commonHttpProtocolOptions:
+            idleTimeout: 3600s
+          explicitHttpConfig:
+            httpProtocolOptions: {}
+    echo-service-9f149ed9e14091ca:
+      circuitBreakers:
+        thresholds:
+        - maxConnections: 1024
+          maxPendingRequests: 1024
+          maxRequests: 1024
+          maxRetries: 3
+      connectTimeout: 5s
+      edsClusterConfig:
+        edsConfig:
+          ads: {}
+          resourceApiVersion: V3
+      name: echo-service-9f149ed9e14091ca
       outlierDetection:
         enforcingConsecutive5xx: 0
         enforcingConsecutiveGatewayFailure: 0
@@ -29,8 +56,24 @@ Clusters:
             httpProtocolOptions: {}
 Endpoints:
   Resources:
-    echo-service-5a416c39037aa8f6:
-      clusterName: echo-service-5a416c39037aa8f6
+    echo-service-6ab423c47cdb0767:
+      clusterName: echo-service-6ab423c47cdb0767
+      endpoints:
+      - lbEndpoints:
+        - endpoint:
+            address:
+              socketAddress:
+                address: 192.168.1.6
+                portValue: 20006
+          loadBalancingWeight: 1
+          metadata:
+            filterMetadata:
+              envoy.lb:
+                kuma.io/protocol: http
+              envoy.transport_socket_match:
+                kuma.io/protocol: http
+    echo-service-9f149ed9e14091ca:
+      clusterName: echo-service-9f149ed9e14091ca
       endpoints:
       - lbEndpoints:
         - endpoint:
@@ -128,7 +171,7 @@ Routes:
             timeout: 15s
             weightedClusters:
               clusters:
-              - name: echo-service-5a416c39037aa8f6
+              - name: echo-service-6ab423c47cdb0767
                 requestHeadersToAdd:
                 - header:
                     key: x-kuma-tags
@@ -152,7 +195,7 @@ Routes:
             timeout: 15s
             weightedClusters:
               clusters:
-              - name: echo-service-5a416c39037aa8f6
+              - name: echo-service-9f149ed9e14091ca
                 requestHeadersToAdd:
                 - header:
                     key: x-kuma-tags

--- a/pkg/plugins/runtime/gateway/testdata/https/03-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/03-gateway-route.yaml
@@ -1,6 +1,6 @@
 Clusters:
   Resources:
-    echo-service-5a416c39037aa8f6:
+    echo-service-9f149ed9e14091ca:
       circuitBreakers:
         thresholds:
         - maxConnections: 1024
@@ -12,7 +12,7 @@ Clusters:
         edsConfig:
           ads: {}
           resourceApiVersion: V3
-      name: echo-service-5a416c39037aa8f6
+      name: echo-service-9f149ed9e14091ca
       outlierDetection:
         enforcingConsecutive5xx: 0
         enforcingConsecutiveGatewayFailure: 0
@@ -29,8 +29,8 @@ Clusters:
             httpProtocolOptions: {}
 Endpoints:
   Resources:
-    echo-service-5a416c39037aa8f6:
-      clusterName: echo-service-5a416c39037aa8f6
+    echo-service-9f149ed9e14091ca:
+      clusterName: echo-service-9f149ed9e14091ca
       endpoints:
       - lbEndpoints:
         - endpoint:
@@ -154,7 +154,7 @@ Routes:
             timeout: 15s
             weightedClusters:
               clusters:
-              - name: echo-service-5a416c39037aa8f6
+              - name: echo-service-9f149ed9e14091ca
                 requestHeadersToAdd:
                 - header:
                     key: x-kuma-tags

--- a/pkg/plugins/runtime/gateway/testdata/https/04-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/04-gateway-route.yaml
@@ -1,6 +1,6 @@
 Clusters:
   Resources:
-    echo-mirror-eb192462fe75ad40:
+    echo-mirror-90205ae37cc0294e:
       circuitBreakers:
         thresholds:
         - maxConnections: 1024
@@ -12,7 +12,7 @@ Clusters:
         edsConfig:
           ads: {}
           resourceApiVersion: V3
-      name: echo-mirror-eb192462fe75ad40
+      name: echo-mirror-90205ae37cc0294e
       outlierDetection:
         enforcingConsecutive5xx: 0
         enforcingConsecutiveGatewayFailure: 0
@@ -27,7 +27,7 @@ Clusters:
             idleTimeout: 3600s
           explicitHttpConfig:
             httpProtocolOptions: {}
-    echo-service-5a416c39037aa8f6:
+    echo-service-9f149ed9e14091ca:
       circuitBreakers:
         thresholds:
         - maxConnections: 1024
@@ -39,7 +39,7 @@ Clusters:
         edsConfig:
           ads: {}
           resourceApiVersion: V3
-      name: echo-service-5a416c39037aa8f6
+      name: echo-service-9f149ed9e14091ca
       outlierDetection:
         enforcingConsecutive5xx: 0
         enforcingConsecutiveGatewayFailure: 0
@@ -56,10 +56,10 @@ Clusters:
             httpProtocolOptions: {}
 Endpoints:
   Resources:
-    echo-mirror-eb192462fe75ad40:
-      clusterName: echo-mirror-eb192462fe75ad40
-    echo-service-5a416c39037aa8f6:
-      clusterName: echo-service-5a416c39037aa8f6
+    echo-mirror-90205ae37cc0294e:
+      clusterName: echo-mirror-90205ae37cc0294e
+    echo-service-9f149ed9e14091ca:
+      clusterName: echo-service-9f149ed9e14091ca
       endpoints:
       - lbEndpoints:
         - endpoint:
@@ -174,7 +174,7 @@ Routes:
             path: /
           route:
             requestMirrorPolicies:
-            - cluster: echo-mirror-eb192462fe75ad40
+            - cluster: echo-mirror-90205ae37cc0294e
               runtimeFraction:
                 defaultValue:
                   denominator: TEN_THOUSAND
@@ -189,7 +189,7 @@ Routes:
             timeout: 15s
             weightedClusters:
               clusters:
-              - name: echo-service-5a416c39037aa8f6
+              - name: echo-service-9f149ed9e14091ca
                 requestHeadersToAdd:
                 - header:
                     key: x-kuma-tags

--- a/pkg/plugins/runtime/gateway/testdata/https/06-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/06-gateway-route.yaml
@@ -1,6 +1,6 @@
 Clusters:
   Resources:
-    echo-mirror-eb192462fe75ad40:
+    echo-mirror-90205ae37cc0294e:
       circuitBreakers:
         thresholds:
         - maxConnections: 1024
@@ -12,7 +12,7 @@ Clusters:
         edsConfig:
           ads: {}
           resourceApiVersion: V3
-      name: echo-mirror-eb192462fe75ad40
+      name: echo-mirror-90205ae37cc0294e
       outlierDetection:
         enforcingConsecutive5xx: 0
         enforcingConsecutiveGatewayFailure: 0
@@ -27,7 +27,7 @@ Clusters:
             idleTimeout: 3600s
           explicitHttpConfig:
             httpProtocolOptions: {}
-    echo-service-5a416c39037aa8f6:
+    echo-service-9f149ed9e14091ca:
       circuitBreakers:
         thresholds:
         - maxConnections: 1024
@@ -39,7 +39,7 @@ Clusters:
         edsConfig:
           ads: {}
           resourceApiVersion: V3
-      name: echo-service-5a416c39037aa8f6
+      name: echo-service-9f149ed9e14091ca
       outlierDetection:
         enforcingConsecutive5xx: 0
         enforcingConsecutiveGatewayFailure: 0
@@ -56,10 +56,10 @@ Clusters:
             httpProtocolOptions: {}
 Endpoints:
   Resources:
-    echo-mirror-eb192462fe75ad40:
-      clusterName: echo-mirror-eb192462fe75ad40
-    echo-service-5a416c39037aa8f6:
-      clusterName: echo-service-5a416c39037aa8f6
+    echo-mirror-90205ae37cc0294e:
+      clusterName: echo-mirror-90205ae37cc0294e
+    echo-service-9f149ed9e14091ca:
+      clusterName: echo-service-9f149ed9e14091ca
       endpoints:
       - lbEndpoints:
         - endpoint:
@@ -193,7 +193,7 @@ Routes:
           - delete-another
           route:
             requestMirrorPolicies:
-            - cluster: echo-mirror-eb192462fe75ad40
+            - cluster: echo-mirror-90205ae37cc0294e
               runtimeFraction:
                 defaultValue:
                   denominator: TEN_THOUSAND
@@ -208,7 +208,7 @@ Routes:
             timeout: 15s
             weightedClusters:
               clusters:
-              - name: echo-service-5a416c39037aa8f6
+              - name: echo-service-9f149ed9e14091ca
                 requestHeadersToAdd:
                 - header:
                     key: x-kuma-tags

--- a/pkg/plugins/runtime/gateway/testdata/https/07-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/07-gateway-route.yaml
@@ -1,6 +1,6 @@
 Clusters:
   Resources:
-    echo-service-5a416c39037aa8f6:
+    echo-service-9f149ed9e14091ca:
       circuitBreakers:
         thresholds:
         - maxConnections: 1024
@@ -12,7 +12,7 @@ Clusters:
         edsConfig:
           ads: {}
           resourceApiVersion: V3
-      name: echo-service-5a416c39037aa8f6
+      name: echo-service-9f149ed9e14091ca
       outlierDetection:
         enforcingConsecutive5xx: 0
         enforcingConsecutiveGatewayFailure: 0
@@ -29,8 +29,8 @@ Clusters:
             httpProtocolOptions: {}
 Endpoints:
   Resources:
-    echo-service-5a416c39037aa8f6:
-      clusterName: echo-service-5a416c39037aa8f6
+    echo-service-9f149ed9e14091ca:
+      clusterName: echo-service-9f149ed9e14091ca
       endpoints:
       - lbEndpoints:
         - endpoint:
@@ -154,7 +154,7 @@ Routes:
             timeout: 15s
             weightedClusters:
               clusters:
-              - name: echo-service-5a416c39037aa8f6
+              - name: echo-service-9f149ed9e14091ca
                 requestHeadersToAdd:
                 - header:
                     key: x-kuma-tags
@@ -174,7 +174,7 @@ Routes:
             timeout: 15s
             weightedClusters:
               clusters:
-              - name: echo-service-5a416c39037aa8f6
+              - name: echo-service-9f149ed9e14091ca
                 requestHeadersToAdd:
                 - header:
                     key: x-kuma-tags

--- a/pkg/plugins/runtime/gateway/testdata/https/08-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/08-gateway-route.yaml
@@ -1,6 +1,6 @@
 Clusters:
   Resources:
-    exact-service-09493d2d54b2a972:
+    exact-service-6c25eaca226749f3:
       circuitBreakers:
         thresholds:
         - maxConnections: 1024
@@ -12,7 +12,7 @@ Clusters:
         edsConfig:
           ads: {}
           resourceApiVersion: V3
-      name: exact-service-09493d2d54b2a972
+      name: exact-service-6c25eaca226749f3
       outlierDetection:
         enforcingConsecutive5xx: 0
         enforcingConsecutiveGatewayFailure: 0
@@ -27,7 +27,7 @@ Clusters:
             idleTimeout: 3600s
           explicitHttpConfig:
             httpProtocolOptions: {}
-    prefix-service-5061ee504b81a555:
+    prefix-service-bfa07e23a84b267b:
       circuitBreakers:
         thresholds:
         - maxConnections: 1024
@@ -39,7 +39,7 @@ Clusters:
         edsConfig:
           ads: {}
           resourceApiVersion: V3
-      name: prefix-service-5061ee504b81a555
+      name: prefix-service-bfa07e23a84b267b
       outlierDetection:
         enforcingConsecutive5xx: 0
         enforcingConsecutiveGatewayFailure: 0
@@ -56,8 +56,8 @@ Clusters:
             httpProtocolOptions: {}
 Endpoints:
   Resources:
-    exact-service-09493d2d54b2a972:
-      clusterName: exact-service-09493d2d54b2a972
+    exact-service-6c25eaca226749f3:
+      clusterName: exact-service-6c25eaca226749f3
       endpoints:
       - lbEndpoints:
         - endpoint:
@@ -72,8 +72,8 @@ Endpoints:
                 kuma.io/protocol: http
               envoy.transport_socket_match:
                 kuma.io/protocol: http
-    prefix-service-5061ee504b81a555:
-      clusterName: prefix-service-5061ee504b81a555
+    prefix-service-bfa07e23a84b267b:
+      clusterName: prefix-service-bfa07e23a84b267b
       endpoints:
       - lbEndpoints:
         - endpoint:
@@ -197,7 +197,7 @@ Routes:
             timeout: 15s
             weightedClusters:
               clusters:
-              - name: exact-service-09493d2d54b2a972
+              - name: exact-service-6c25eaca226749f3
                 requestHeadersToAdd:
                 - header:
                     key: x-kuma-tags
@@ -217,7 +217,7 @@ Routes:
             timeout: 15s
             weightedClusters:
               clusters:
-              - name: prefix-service-5061ee504b81a555
+              - name: prefix-service-bfa07e23a84b267b
                 requestHeadersToAdd:
                 - header:
                     key: x-kuma-tags

--- a/pkg/plugins/runtime/gateway/testdata/https/09-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/09-gateway-route.yaml
@@ -1,6 +1,6 @@
 Clusters:
   Resources:
-    echo-service-5a416c39037aa8f6:
+    echo-service-9f149ed9e14091ca:
       circuitBreakers:
         thresholds:
         - maxConnections: 1024
@@ -12,7 +12,7 @@ Clusters:
         edsConfig:
           ads: {}
           resourceApiVersion: V3
-      name: echo-service-5a416c39037aa8f6
+      name: echo-service-9f149ed9e14091ca
       outlierDetection:
         enforcingConsecutive5xx: 0
         enforcingConsecutiveGatewayFailure: 0
@@ -29,8 +29,8 @@ Clusters:
             httpProtocolOptions: {}
 Endpoints:
   Resources:
-    echo-service-5a416c39037aa8f6:
-      clusterName: echo-service-5a416c39037aa8f6
+    echo-service-9f149ed9e14091ca:
+      clusterName: echo-service-9f149ed9e14091ca
       endpoints:
       - lbEndpoints:
         - endpoint:
@@ -156,7 +156,7 @@ Routes:
             timeout: 15s
             weightedClusters:
               clusters:
-              - name: echo-service-5a416c39037aa8f6
+              - name: echo-service-9f149ed9e14091ca
                 requestHeadersToAdd:
                 - header:
                     key: x-kuma-tags

--- a/pkg/plugins/runtime/gateway/testdata/https/10-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/10-gateway-route.yaml
@@ -1,6 +1,6 @@
 Clusters:
   Resources:
-    exact-header-match-f6b57a6b55557c81:
+    exact-header-match-9f720dd4e289b673:
       circuitBreakers:
         thresholds:
         - maxConnections: 1024
@@ -12,7 +12,7 @@ Clusters:
         edsConfig:
           ads: {}
           resourceApiVersion: V3
-      name: exact-header-match-f6b57a6b55557c81
+      name: exact-header-match-9f720dd4e289b673
       outlierDetection:
         enforcingConsecutive5xx: 0
         enforcingConsecutiveGatewayFailure: 0
@@ -27,7 +27,7 @@ Clusters:
             idleTimeout: 3600s
           explicitHttpConfig:
             httpProtocolOptions: {}
-    regex-header-match-ad0dd92f37b8a38d:
+    exact-header-match-d7c910a2e5559eda:
       circuitBreakers:
         thresholds:
         - maxConnections: 1024
@@ -39,7 +39,34 @@ Clusters:
         edsConfig:
           ads: {}
           resourceApiVersion: V3
-      name: regex-header-match-ad0dd92f37b8a38d
+      name: exact-header-match-d7c910a2e5559eda
+      outlierDetection:
+        enforcingConsecutive5xx: 0
+        enforcingConsecutiveGatewayFailure: 0
+        enforcingConsecutiveLocalOriginFailure: 0
+        enforcingFailurePercentage: 0
+        enforcingSuccessRate: 0
+      type: EDS
+      typedExtensionProtocolOptions:
+        envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+          '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+          commonHttpProtocolOptions:
+            idleTimeout: 3600s
+          explicitHttpConfig:
+            httpProtocolOptions: {}
+    regex-header-match-70561bb2da83c870:
+      circuitBreakers:
+        thresholds:
+        - maxConnections: 1024
+          maxPendingRequests: 1024
+          maxRequests: 1024
+          maxRetries: 3
+      connectTimeout: 5s
+      edsClusterConfig:
+        edsConfig:
+          ads: {}
+          resourceApiVersion: V3
+      name: regex-header-match-70561bb2da83c870
       outlierDetection:
         enforcingConsecutive5xx: 0
         enforcingConsecutiveGatewayFailure: 0
@@ -56,8 +83,8 @@ Clusters:
             httpProtocolOptions: {}
 Endpoints:
   Resources:
-    exact-header-match-f6b57a6b55557c81:
-      clusterName: exact-header-match-f6b57a6b55557c81
+    exact-header-match-9f720dd4e289b673:
+      clusterName: exact-header-match-9f720dd4e289b673
       endpoints:
       - lbEndpoints:
         - endpoint:
@@ -72,8 +99,24 @@ Endpoints:
                 kuma.io/protocol: http
               envoy.transport_socket_match:
                 kuma.io/protocol: http
-    regex-header-match-ad0dd92f37b8a38d:
-      clusterName: regex-header-match-ad0dd92f37b8a38d
+    exact-header-match-d7c910a2e5559eda:
+      clusterName: exact-header-match-d7c910a2e5559eda
+      endpoints:
+      - lbEndpoints:
+        - endpoint:
+            address:
+              socketAddress:
+                address: 192.168.1.7
+                portValue: 20007
+          loadBalancingWeight: 1
+          metadata:
+            filterMetadata:
+              envoy.lb:
+                kuma.io/protocol: http
+              envoy.transport_socket_match:
+                kuma.io/protocol: http
+    regex-header-match-70561bb2da83c870:
+      clusterName: regex-header-match-70561bb2da83c870
       endpoints:
       - lbEndpoints:
         - endpoint:
@@ -206,7 +249,7 @@ Routes:
             timeout: 15s
             weightedClusters:
               clusters:
-              - name: regex-header-match-ad0dd92f37b8a38d
+              - name: regex-header-match-70561bb2da83c870
                 requestHeadersToAdd:
                 - header:
                     key: x-kuma-tags
@@ -229,7 +272,7 @@ Routes:
             timeout: 15s
             weightedClusters:
               clusters:
-              - name: exact-header-match-f6b57a6b55557c81
+              - name: exact-header-match-9f720dd4e289b673
                 requestHeadersToAdd:
                 - header:
                     key: x-kuma-tags
@@ -252,7 +295,7 @@ Routes:
             timeout: 15s
             weightedClusters:
               clusters:
-              - name: exact-header-match-f6b57a6b55557c81
+              - name: exact-header-match-9f720dd4e289b673
                 requestHeadersToAdd:
                 - header:
                     key: x-kuma-tags

--- a/pkg/plugins/runtime/gateway/testdata/https/10-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/10-gateway-route.yaml
@@ -1,32 +1,5 @@
 Clusters:
   Resources:
-    exact-header-match-9f720dd4e289b673:
-      circuitBreakers:
-        thresholds:
-        - maxConnections: 1024
-          maxPendingRequests: 1024
-          maxRequests: 1024
-          maxRetries: 3
-      connectTimeout: 5s
-      edsClusterConfig:
-        edsConfig:
-          ads: {}
-          resourceApiVersion: V3
-      name: exact-header-match-9f720dd4e289b673
-      outlierDetection:
-        enforcingConsecutive5xx: 0
-        enforcingConsecutiveGatewayFailure: 0
-        enforcingConsecutiveLocalOriginFailure: 0
-        enforcingFailurePercentage: 0
-        enforcingSuccessRate: 0
-      type: EDS
-      typedExtensionProtocolOptions:
-        envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
-          '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
-          commonHttpProtocolOptions:
-            idleTimeout: 3600s
-          explicitHttpConfig:
-            httpProtocolOptions: {}
     exact-header-match-d7c910a2e5559eda:
       circuitBreakers:
         thresholds:
@@ -83,22 +56,6 @@ Clusters:
             httpProtocolOptions: {}
 Endpoints:
   Resources:
-    exact-header-match-9f720dd4e289b673:
-      clusterName: exact-header-match-9f720dd4e289b673
-      endpoints:
-      - lbEndpoints:
-        - endpoint:
-            address:
-              socketAddress:
-                address: 192.168.1.7
-                portValue: 20007
-          loadBalancingWeight: 1
-          metadata:
-            filterMetadata:
-              envoy.lb:
-                kuma.io/protocol: http
-              envoy.transport_socket_match:
-                kuma.io/protocol: http
     exact-header-match-d7c910a2e5559eda:
       clusterName: exact-header-match-d7c910a2e5559eda
       endpoints:
@@ -272,7 +229,7 @@ Routes:
             timeout: 15s
             weightedClusters:
               clusters:
-              - name: exact-header-match-9f720dd4e289b673
+              - name: exact-header-match-d7c910a2e5559eda
                 requestHeadersToAdd:
                 - header:
                     key: x-kuma-tags
@@ -295,7 +252,7 @@ Routes:
             timeout: 15s
             weightedClusters:
               clusters:
-              - name: exact-header-match-9f720dd4e289b673
+              - name: exact-header-match-d7c910a2e5559eda
                 requestHeadersToAdd:
                 - header:
                     key: x-kuma-tags

--- a/pkg/plugins/runtime/gateway/testdata/https/11-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/11-gateway-route.yaml
@@ -1,6 +1,6 @@
 Clusters:
   Resources:
-    exact-query-match-cc1370f58a3b5330:
+    exact-query-match-36212e4e8ec491f1:
       circuitBreakers:
         thresholds:
         - maxConnections: 1024
@@ -12,7 +12,7 @@ Clusters:
         edsConfig:
           ads: {}
           resourceApiVersion: V3
-      name: exact-query-match-cc1370f58a3b5330
+      name: exact-query-match-36212e4e8ec491f1
       outlierDetection:
         enforcingConsecutive5xx: 0
         enforcingConsecutiveGatewayFailure: 0
@@ -27,7 +27,7 @@ Clusters:
             idleTimeout: 3600s
           explicitHttpConfig:
             httpProtocolOptions: {}
-    regex-query-match-3804d7b8516d7323:
+    regex-query-match-2c070f45017d23a5:
       circuitBreakers:
         thresholds:
         - maxConnections: 1024
@@ -39,7 +39,7 @@ Clusters:
         edsConfig:
           ads: {}
           resourceApiVersion: V3
-      name: regex-query-match-3804d7b8516d7323
+      name: regex-query-match-2c070f45017d23a5
       outlierDetection:
         enforcingConsecutive5xx: 0
         enforcingConsecutiveGatewayFailure: 0
@@ -56,8 +56,8 @@ Clusters:
             httpProtocolOptions: {}
 Endpoints:
   Resources:
-    exact-query-match-cc1370f58a3b5330:
-      clusterName: exact-query-match-cc1370f58a3b5330
+    exact-query-match-36212e4e8ec491f1:
+      clusterName: exact-query-match-36212e4e8ec491f1
       endpoints:
       - lbEndpoints:
         - endpoint:
@@ -72,8 +72,8 @@ Endpoints:
                 kuma.io/protocol: http
               envoy.transport_socket_match:
                 kuma.io/protocol: http
-    regex-query-match-3804d7b8516d7323:
-      clusterName: regex-query-match-3804d7b8516d7323
+    regex-query-match-2c070f45017d23a5:
+      clusterName: regex-query-match-2c070f45017d23a5
       endpoints:
       - lbEndpoints:
         - endpoint:
@@ -208,7 +208,7 @@ Routes:
             timeout: 15s
             weightedClusters:
               clusters:
-              - name: regex-query-match-3804d7b8516d7323
+              - name: regex-query-match-2c070f45017d23a5
                 requestHeadersToAdd:
                 - header:
                     key: x-kuma-tags
@@ -232,7 +232,7 @@ Routes:
             timeout: 15s
             weightedClusters:
               clusters:
-              - name: exact-query-match-cc1370f58a3b5330
+              - name: exact-query-match-36212e4e8ec491f1
                 requestHeadersToAdd:
                 - header:
                     key: x-kuma-tags
@@ -256,7 +256,7 @@ Routes:
             timeout: 15s
             weightedClusters:
               clusters:
-              - name: exact-query-match-cc1370f58a3b5330
+              - name: exact-query-match-36212e4e8ec491f1
                 requestHeadersToAdd:
                 - header:
                     key: x-kuma-tags

--- a/pkg/plugins/runtime/gateway/testdata/https/12-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/12-gateway-route.yaml
@@ -1,6 +1,6 @@
 Clusters:
   Resources:
-    echo-service-5a416c39037aa8f6:
+    echo-service-9f149ed9e14091ca:
       circuitBreakers:
         thresholds:
         - maxConnections: 1024
@@ -12,7 +12,7 @@ Clusters:
         edsConfig:
           ads: {}
           resourceApiVersion: V3
-      name: echo-service-5a416c39037aa8f6
+      name: echo-service-9f149ed9e14091ca
       outlierDetection:
         enforcingConsecutive5xx: 0
         enforcingConsecutiveGatewayFailure: 0
@@ -29,8 +29,8 @@ Clusters:
             httpProtocolOptions: {}
 Endpoints:
   Resources:
-    echo-service-5a416c39037aa8f6:
-      clusterName: echo-service-5a416c39037aa8f6
+    echo-service-9f149ed9e14091ca:
+      clusterName: echo-service-9f149ed9e14091ca
       endpoints:
       - lbEndpoints:
         - endpoint:
@@ -159,7 +159,7 @@ Routes:
             timeout: 15s
             weightedClusters:
               clusters:
-              - name: echo-service-5a416c39037aa8f6
+              - name: echo-service-9f149ed9e14091ca
                 requestHeadersToAdd:
                 - header:
                     key: x-kuma-tags
@@ -184,7 +184,7 @@ Routes:
             timeout: 15s
             weightedClusters:
               clusters:
-              - name: echo-service-5a416c39037aa8f6
+              - name: echo-service-9f149ed9e14091ca
                 requestHeadersToAdd:
                 - header:
                     key: x-kuma-tags
@@ -209,7 +209,7 @@ Routes:
             timeout: 15s
             weightedClusters:
               clusters:
-              - name: echo-service-5a416c39037aa8f6
+              - name: echo-service-9f149ed9e14091ca
                 requestHeadersToAdd:
                 - header:
                     key: x-kuma-tags

--- a/pkg/plugins/runtime/gateway/testdata/https/13-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/13-gateway-route.yaml
@@ -1,6 +1,6 @@
 Clusters:
   Resources:
-    echo-exact-ad4e3a31db1bf217:
+    echo-exact-0c6c646106bd51f3:
       circuitBreakers:
         thresholds:
         - maxConnections: 1024
@@ -12,7 +12,7 @@ Clusters:
         edsConfig:
           ads: {}
           resourceApiVersion: V3
-      name: echo-exact-ad4e3a31db1bf217
+      name: echo-exact-0c6c646106bd51f3
       outlierDetection:
         enforcingConsecutive5xx: 0
         enforcingConsecutiveGatewayFailure: 0
@@ -27,7 +27,7 @@ Clusters:
             idleTimeout: 3600s
           explicitHttpConfig:
             httpProtocolOptions: {}
-    echo-prefix-d0e5ba63b0c9b9f0:
+    echo-prefix-1d3cd70bb04bf6e2:
       circuitBreakers:
         thresholds:
         - maxConnections: 1024
@@ -39,7 +39,7 @@ Clusters:
         edsConfig:
           ads: {}
           resourceApiVersion: V3
-      name: echo-prefix-d0e5ba63b0c9b9f0
+      name: echo-prefix-1d3cd70bb04bf6e2
       outlierDetection:
         enforcingConsecutive5xx: 0
         enforcingConsecutiveGatewayFailure: 0
@@ -54,7 +54,7 @@ Clusters:
             idleTimeout: 3600s
           explicitHttpConfig:
             httpProtocolOptions: {}
-    echo-regex-627905e7b1c2eb33:
+    echo-regex-197ed2f99640f307:
       circuitBreakers:
         thresholds:
         - maxConnections: 1024
@@ -66,7 +66,7 @@ Clusters:
         edsConfig:
           ads: {}
           resourceApiVersion: V3
-      name: echo-regex-627905e7b1c2eb33
+      name: echo-regex-197ed2f99640f307
       outlierDetection:
         enforcingConsecutive5xx: 0
         enforcingConsecutiveGatewayFailure: 0
@@ -83,8 +83,8 @@ Clusters:
             httpProtocolOptions: {}
 Endpoints:
   Resources:
-    echo-exact-ad4e3a31db1bf217:
-      clusterName: echo-exact-ad4e3a31db1bf217
+    echo-exact-0c6c646106bd51f3:
+      clusterName: echo-exact-0c6c646106bd51f3
       endpoints:
       - lbEndpoints:
         - endpoint:
@@ -99,8 +99,8 @@ Endpoints:
                 kuma.io/protocol: http
               envoy.transport_socket_match:
                 kuma.io/protocol: http
-    echo-prefix-d0e5ba63b0c9b9f0:
-      clusterName: echo-prefix-d0e5ba63b0c9b9f0
+    echo-prefix-1d3cd70bb04bf6e2:
+      clusterName: echo-prefix-1d3cd70bb04bf6e2
       endpoints:
       - lbEndpoints:
         - endpoint:
@@ -115,8 +115,8 @@ Endpoints:
                 kuma.io/protocol: http
               envoy.transport_socket_match:
                 kuma.io/protocol: http
-    echo-regex-627905e7b1c2eb33:
-      clusterName: echo-regex-627905e7b1c2eb33
+    echo-regex-197ed2f99640f307:
+      clusterName: echo-regex-197ed2f99640f307
       endpoints:
       - lbEndpoints:
         - endpoint:
@@ -240,7 +240,7 @@ Routes:
             timeout: 15s
             weightedClusters:
               clusters:
-              - name: echo-exact-ad4e3a31db1bf217
+              - name: echo-exact-0c6c646106bd51f3
                 requestHeadersToAdd:
                 - header:
                     key: x-kuma-tags
@@ -260,7 +260,7 @@ Routes:
             timeout: 15s
             weightedClusters:
               clusters:
-              - name: echo-prefix-d0e5ba63b0c9b9f0
+              - name: echo-prefix-1d3cd70bb04bf6e2
                 requestHeadersToAdd:
                 - header:
                     key: x-kuma-tags
@@ -280,7 +280,7 @@ Routes:
             timeout: 15s
             weightedClusters:
               clusters:
-              - name: echo-prefix-d0e5ba63b0c9b9f0
+              - name: echo-prefix-1d3cd70bb04bf6e2
                 requestHeadersToAdd:
                 - header:
                     key: x-kuma-tags
@@ -302,7 +302,7 @@ Routes:
             timeout: 15s
             weightedClusters:
               clusters:
-              - name: echo-regex-627905e7b1c2eb33
+              - name: echo-regex-197ed2f99640f307
                 requestHeadersToAdd:
                 - header:
                     key: x-kuma-tags

--- a/pkg/plugins/runtime/gateway/testdata/https/14-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/14-gateway-route.yaml
@@ -1,6 +1,6 @@
 Clusters:
   Resources:
-    echo-service-5a416c39037aa8f6:
+    echo-service-6ab423c47cdb0767:
       circuitBreakers:
         thresholds:
         - maxConnections: 1024
@@ -12,7 +12,7 @@ Clusters:
         edsConfig:
           ads: {}
           resourceApiVersion: V3
-      name: echo-service-5a416c39037aa8f6
+      name: echo-service-6ab423c47cdb0767
       outlierDetection:
         enforcingConsecutive5xx: 0
         enforcingConsecutiveGatewayFailure: 0
@@ -29,8 +29,8 @@ Clusters:
             httpProtocolOptions: {}
 Endpoints:
   Resources:
-    echo-service-5a416c39037aa8f6:
-      clusterName: echo-service-5a416c39037aa8f6
+    echo-service-6ab423c47cdb0767:
+      clusterName: echo-service-6ab423c47cdb0767
       endpoints:
       - lbEndpoints:
         - endpoint:
@@ -158,7 +158,7 @@ Routes:
             timeout: 15s
             weightedClusters:
               clusters:
-              - name: echo-service-5a416c39037aa8f6
+              - name: echo-service-6ab423c47cdb0767
                 requestHeadersToAdd:
                 - header:
                     key: x-kuma-tags

--- a/pkg/plugins/runtime/gateway/testdata/https/14-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/14-gateway-route.yaml
@@ -1,6 +1,6 @@
 Clusters:
   Resources:
-    echo-service-6ab423c47cdb0767:
+    echo-service-9f149ed9e14091ca:
       circuitBreakers:
         thresholds:
         - maxConnections: 1024
@@ -12,7 +12,7 @@ Clusters:
         edsConfig:
           ads: {}
           resourceApiVersion: V3
-      name: echo-service-6ab423c47cdb0767
+      name: echo-service-9f149ed9e14091ca
       outlierDetection:
         enforcingConsecutive5xx: 0
         enforcingConsecutiveGatewayFailure: 0
@@ -29,8 +29,8 @@ Clusters:
             httpProtocolOptions: {}
 Endpoints:
   Resources:
-    echo-service-6ab423c47cdb0767:
-      clusterName: echo-service-6ab423c47cdb0767
+    echo-service-9f149ed9e14091ca:
+      clusterName: echo-service-9f149ed9e14091ca
       endpoints:
       - lbEndpoints:
         - endpoint:
@@ -158,7 +158,7 @@ Routes:
             timeout: 15s
             weightedClusters:
               clusters:
-              - name: echo-service-6ab423c47cdb0767
+              - name: echo-service-9f149ed9e14091ca
                 requestHeadersToAdd:
                 - header:
                     key: x-kuma-tags

--- a/pkg/plugins/runtime/gateway/testdata/https/15-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/15-gateway-route.yaml
@@ -1,6 +1,6 @@
 Clusters:
   Resources:
-    api-service-6b688a06cd66f5c9:
+    api-service-4508437668c35ed8:
       circuitBreakers:
         thresholds:
         - maxConnections: 1024
@@ -12,7 +12,7 @@ Clusters:
         edsConfig:
           ads: {}
           resourceApiVersion: V3
-      name: api-service-6b688a06cd66f5c9
+      name: api-service-4508437668c35ed8
       outlierDetection:
         enforcingConsecutive5xx: 0
         enforcingConsecutiveGatewayFailure: 0
@@ -27,7 +27,7 @@ Clusters:
             idleTimeout: 20s
           explicitHttpConfig:
             httpProtocolOptions: {}
-    echo-mirror-5c286df2bcbe50d6:
+    echo-mirror-3dd740a2de879d4c:
       circuitBreakers:
         thresholds:
         - maxConnections: 1024
@@ -39,7 +39,7 @@ Clusters:
         edsConfig:
           ads: {}
           resourceApiVersion: V3
-      name: echo-mirror-5c286df2bcbe50d6
+      name: echo-mirror-3dd740a2de879d4c
       outlierDetection:
         enforcingConsecutive5xx: 0
         enforcingConsecutiveGatewayFailure: 0
@@ -54,7 +54,7 @@ Clusters:
             idleTimeout: 30s
           explicitHttpConfig:
             httpProtocolOptions: {}
-    echo-service-b5c2b60cba392c4e:
+    echo-service-9f149ed9e14091ca:
       circuitBreakers:
         thresholds:
         - maxConnections: 1024
@@ -66,7 +66,7 @@ Clusters:
         edsConfig:
           ads: {}
           resourceApiVersion: V3
-      name: echo-service-b5c2b60cba392c4e
+      name: echo-service-9f149ed9e14091ca
       outlierDetection:
         enforcingConsecutive5xx: 0
         enforcingConsecutiveGatewayFailure: 0
@@ -83,8 +83,8 @@ Clusters:
             httpProtocolOptions: {}
 Endpoints:
   Resources:
-    api-service-6b688a06cd66f5c9:
-      clusterName: api-service-6b688a06cd66f5c9
+    api-service-4508437668c35ed8:
+      clusterName: api-service-4508437668c35ed8
       endpoints:
       - lbEndpoints:
         - endpoint:
@@ -99,8 +99,8 @@ Endpoints:
                 kuma.io/protocol: http
               envoy.transport_socket_match:
                 kuma.io/protocol: http
-    echo-mirror-5c286df2bcbe50d6:
-      clusterName: echo-mirror-5c286df2bcbe50d6
+    echo-mirror-3dd740a2de879d4c:
+      clusterName: echo-mirror-3dd740a2de879d4c
       endpoints:
       - lbEndpoints:
         - endpoint:
@@ -115,8 +115,8 @@ Endpoints:
                 kuma.io/protocol: http
               envoy.transport_socket_match:
                 kuma.io/protocol: http
-    echo-service-b5c2b60cba392c4e:
-      clusterName: echo-service-b5c2b60cba392c4e
+    echo-service-9f149ed9e14091ca:
+      clusterName: echo-service-9f149ed9e14091ca
       endpoints:
       - lbEndpoints:
         - endpoint:
@@ -240,7 +240,7 @@ Routes:
             timeout: 20s
             weightedClusters:
               clusters:
-              - name: api-service-6b688a06cd66f5c9
+              - name: api-service-4508437668c35ed8
                 requestHeadersToAdd:
                 - header:
                     key: x-kuma-tags
@@ -260,7 +260,7 @@ Routes:
             timeout: 20s
             weightedClusters:
               clusters:
-              - name: api-service-6b688a06cd66f5c9
+              - name: api-service-4508437668c35ed8
                 requestHeadersToAdd:
                 - header:
                     key: x-kuma-tags
@@ -271,7 +271,7 @@ Routes:
             prefix: /
           route:
             requestMirrorPolicies:
-            - cluster: echo-mirror-5c286df2bcbe50d6
+            - cluster: echo-mirror-3dd740a2de879d4c
               runtimeFraction:
                 defaultValue:
                   numerator: 1
@@ -285,7 +285,7 @@ Routes:
             timeout: 10s
             weightedClusters:
               clusters:
-              - name: echo-service-b5c2b60cba392c4e
+              - name: echo-service-9f149ed9e14091ca
                 requestHeadersToAdd:
                 - header:
                     key: x-kuma-tags

--- a/pkg/plugins/runtime/gateway/testdata/https/16-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/16-gateway-route.yaml
@@ -1,6 +1,6 @@
 Clusters:
   Resources:
-    api-service-49c6d22609eca2d2:
+    api-service-4508437668c35ed8:
       circuitBreakers:
         thresholds:
         - maxRetries: 20
@@ -9,7 +9,7 @@ Clusters:
         edsConfig:
           ads: {}
           resourceApiVersion: V3
-      name: api-service-49c6d22609eca2d2
+      name: api-service-4508437668c35ed8
       outlierDetection:
         baseEjectionTime: 20s
         consecutiveLocalOriginFailure: 20
@@ -26,7 +26,7 @@ Clusters:
             idleTimeout: 3600s
           explicitHttpConfig:
             httpProtocolOptions: {}
-    echo-mirror-f534124491f4385f:
+    echo-mirror-3dd740a2de879d4c:
       circuitBreakers:
         thresholds:
         - maxRetries: 20
@@ -35,7 +35,7 @@ Clusters:
         edsConfig:
           ads: {}
           resourceApiVersion: V3
-      name: echo-mirror-f534124491f4385f
+      name: echo-mirror-3dd740a2de879d4c
       outlierDetection:
         baseEjectionTime: 30s
         consecutiveLocalOriginFailure: 30
@@ -52,7 +52,7 @@ Clusters:
             idleTimeout: 3600s
           explicitHttpConfig:
             httpProtocolOptions: {}
-    echo-service-48cd7f2dbb98df84:
+    echo-service-6ab423c47cdb0767:
       circuitBreakers:
         thresholds:
         - maxRetries: 10
@@ -61,7 +61,7 @@ Clusters:
         edsConfig:
           ads: {}
           resourceApiVersion: V3
-      name: echo-service-48cd7f2dbb98df84
+      name: echo-service-6ab423c47cdb0767
       outlierDetection:
         baseEjectionTime: 10s
         consecutiveLocalOriginFailure: 10
@@ -80,8 +80,8 @@ Clusters:
             httpProtocolOptions: {}
 Endpoints:
   Resources:
-    api-service-49c6d22609eca2d2:
-      clusterName: api-service-49c6d22609eca2d2
+    api-service-4508437668c35ed8:
+      clusterName: api-service-4508437668c35ed8
       endpoints:
       - lbEndpoints:
         - endpoint:
@@ -96,8 +96,8 @@ Endpoints:
                 kuma.io/protocol: http
               envoy.transport_socket_match:
                 kuma.io/protocol: http
-    echo-mirror-f534124491f4385f:
-      clusterName: echo-mirror-f534124491f4385f
+    echo-mirror-3dd740a2de879d4c:
+      clusterName: echo-mirror-3dd740a2de879d4c
       endpoints:
       - lbEndpoints:
         - endpoint:
@@ -112,8 +112,8 @@ Endpoints:
                 kuma.io/protocol: http
               envoy.transport_socket_match:
                 kuma.io/protocol: http
-    echo-service-48cd7f2dbb98df84:
-      clusterName: echo-service-48cd7f2dbb98df84
+    echo-service-6ab423c47cdb0767:
+      clusterName: echo-service-6ab423c47cdb0767
       endpoints:
       - lbEndpoints:
         - endpoint:
@@ -237,7 +237,7 @@ Routes:
             timeout: 15s
             weightedClusters:
               clusters:
-              - name: api-service-49c6d22609eca2d2
+              - name: api-service-4508437668c35ed8
                 requestHeadersToAdd:
                 - header:
                     key: x-kuma-tags
@@ -257,7 +257,7 @@ Routes:
             timeout: 15s
             weightedClusters:
               clusters:
-              - name: api-service-49c6d22609eca2d2
+              - name: api-service-4508437668c35ed8
                 requestHeadersToAdd:
                 - header:
                     key: x-kuma-tags
@@ -268,7 +268,7 @@ Routes:
             prefix: /
           route:
             requestMirrorPolicies:
-            - cluster: echo-mirror-f534124491f4385f
+            - cluster: echo-mirror-3dd740a2de879d4c
               runtimeFraction:
                 defaultValue:
                   numerator: 1
@@ -282,7 +282,7 @@ Routes:
             timeout: 15s
             weightedClusters:
               clusters:
-              - name: echo-service-48cd7f2dbb98df84
+              - name: echo-service-6ab423c47cdb0767
                 requestHeadersToAdd:
                 - header:
                     key: x-kuma-tags

--- a/pkg/plugins/runtime/gateway/testdata/https/16-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/16-gateway-route.yaml
@@ -52,7 +52,7 @@ Clusters:
             idleTimeout: 3600s
           explicitHttpConfig:
             httpProtocolOptions: {}
-    echo-service-6ab423c47cdb0767:
+    echo-service-9f149ed9e14091ca:
       circuitBreakers:
         thresholds:
         - maxRetries: 10
@@ -61,7 +61,7 @@ Clusters:
         edsConfig:
           ads: {}
           resourceApiVersion: V3
-      name: echo-service-6ab423c47cdb0767
+      name: echo-service-9f149ed9e14091ca
       outlierDetection:
         baseEjectionTime: 10s
         consecutiveLocalOriginFailure: 10
@@ -112,8 +112,8 @@ Endpoints:
                 kuma.io/protocol: http
               envoy.transport_socket_match:
                 kuma.io/protocol: http
-    echo-service-6ab423c47cdb0767:
-      clusterName: echo-service-6ab423c47cdb0767
+    echo-service-9f149ed9e14091ca:
+      clusterName: echo-service-9f149ed9e14091ca
       endpoints:
       - lbEndpoints:
         - endpoint:
@@ -282,7 +282,7 @@ Routes:
             timeout: 15s
             weightedClusters:
               clusters:
-              - name: echo-service-6ab423c47cdb0767
+              - name: echo-service-9f149ed9e14091ca
                 requestHeadersToAdd:
                 - header:
                     key: x-kuma-tags

--- a/pkg/plugins/runtime/gateway/testdata/https/17-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/17-gateway-route.yaml
@@ -33,39 +33,6 @@ Clusters:
             idleTimeout: 3600s
           explicitHttpConfig:
             httpProtocolOptions: {}
-    api-service-bb145fed7e9ae110:
-      circuitBreakers:
-        thresholds:
-        - maxConnections: 1024
-          maxPendingRequests: 1024
-          maxRequests: 1024
-          maxRetries: 3
-      connectTimeout: 5s
-      edsClusterConfig:
-        edsConfig:
-          ads: {}
-          resourceApiVersion: V3
-      healthChecks:
-      - healthyThreshold: 2
-        interval: 20s
-        tcpHealthCheck: {}
-        timeout: 20s
-        unhealthyThreshold: 2
-      name: api-service-bb145fed7e9ae110
-      outlierDetection:
-        enforcingConsecutive5xx: 0
-        enforcingConsecutiveGatewayFailure: 0
-        enforcingConsecutiveLocalOriginFailure: 0
-        enforcingFailurePercentage: 0
-        enforcingSuccessRate: 0
-      type: EDS
-      typedExtensionProtocolOptions:
-        envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
-          '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
-          commonHttpProtocolOptions:
-            idleTimeout: 3600s
-          explicitHttpConfig:
-            httpProtocolOptions: {}
     echo-mirror-3dd740a2de879d4c:
       circuitBreakers:
         thresholds:
@@ -136,22 +103,6 @@ Endpoints:
   Resources:
     api-service-4508437668c35ed8:
       clusterName: api-service-4508437668c35ed8
-      endpoints:
-      - lbEndpoints:
-        - endpoint:
-            address:
-              socketAddress:
-                address: 192.168.1.1
-                portValue: 20001
-          loadBalancingWeight: 1
-          metadata:
-            filterMetadata:
-              envoy.lb:
-                kuma.io/protocol: http
-              envoy.transport_socket_match:
-                kuma.io/protocol: http
-    api-service-bb145fed7e9ae110:
-      clusterName: api-service-bb145fed7e9ae110
       endpoints:
       - lbEndpoints:
         - endpoint:
@@ -307,7 +258,7 @@ Routes:
             timeout: 15s
             weightedClusters:
               clusters:
-              - name: api-service-bb145fed7e9ae110
+              - name: api-service-4508437668c35ed8
                 requestHeadersToAdd:
                 - header:
                     key: x-kuma-tags
@@ -327,7 +278,7 @@ Routes:
             timeout: 15s
             weightedClusters:
               clusters:
-              - name: api-service-bb145fed7e9ae110
+              - name: api-service-4508437668c35ed8
                 requestHeadersToAdd:
                 - header:
                     key: x-kuma-tags

--- a/pkg/plugins/runtime/gateway/testdata/https/17-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/17-gateway-route.yaml
@@ -1,6 +1,6 @@
 Clusters:
   Resources:
-    api-service-19fcb7995aa98119:
+    api-service-4508437668c35ed8:
       circuitBreakers:
         thresholds:
         - maxConnections: 1024
@@ -18,7 +18,7 @@ Clusters:
         tcpHealthCheck: {}
         timeout: 20s
         unhealthyThreshold: 2
-      name: api-service-19fcb7995aa98119
+      name: api-service-4508437668c35ed8
       outlierDetection:
         enforcingConsecutive5xx: 0
         enforcingConsecutiveGatewayFailure: 0
@@ -33,7 +33,40 @@ Clusters:
             idleTimeout: 3600s
           explicitHttpConfig:
             httpProtocolOptions: {}
-    echo-mirror-2e2ba113e4d991ba:
+    api-service-bb145fed7e9ae110:
+      circuitBreakers:
+        thresholds:
+        - maxConnections: 1024
+          maxPendingRequests: 1024
+          maxRequests: 1024
+          maxRetries: 3
+      connectTimeout: 5s
+      edsClusterConfig:
+        edsConfig:
+          ads: {}
+          resourceApiVersion: V3
+      healthChecks:
+      - healthyThreshold: 2
+        interval: 20s
+        tcpHealthCheck: {}
+        timeout: 20s
+        unhealthyThreshold: 2
+      name: api-service-bb145fed7e9ae110
+      outlierDetection:
+        enforcingConsecutive5xx: 0
+        enforcingConsecutiveGatewayFailure: 0
+        enforcingConsecutiveLocalOriginFailure: 0
+        enforcingFailurePercentage: 0
+        enforcingSuccessRate: 0
+      type: EDS
+      typedExtensionProtocolOptions:
+        envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+          '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+          commonHttpProtocolOptions:
+            idleTimeout: 3600s
+          explicitHttpConfig:
+            httpProtocolOptions: {}
+    echo-mirror-3dd740a2de879d4c:
       circuitBreakers:
         thresholds:
         - maxConnections: 1024
@@ -51,7 +84,7 @@ Clusters:
         tcpHealthCheck: {}
         timeout: 30s
         unhealthyThreshold: 3
-      name: echo-mirror-2e2ba113e4d991ba
+      name: echo-mirror-3dd740a2de879d4c
       outlierDetection:
         enforcingConsecutive5xx: 0
         enforcingConsecutiveGatewayFailure: 0
@@ -66,7 +99,7 @@ Clusters:
             idleTimeout: 3600s
           explicitHttpConfig:
             httpProtocolOptions: {}
-    echo-service-eb4ea372d99abf73:
+    echo-service-9f149ed9e14091ca:
       circuitBreakers:
         thresholds:
         - maxConnections: 1024
@@ -84,7 +117,7 @@ Clusters:
         tcpHealthCheck: {}
         timeout: 10s
         unhealthyThreshold: 1
-      name: echo-service-eb4ea372d99abf73
+      name: echo-service-9f149ed9e14091ca
       outlierDetection:
         enforcingConsecutive5xx: 0
         enforcingConsecutiveGatewayFailure: 0
@@ -101,8 +134,8 @@ Clusters:
             httpProtocolOptions: {}
 Endpoints:
   Resources:
-    api-service-19fcb7995aa98119:
-      clusterName: api-service-19fcb7995aa98119
+    api-service-4508437668c35ed8:
+      clusterName: api-service-4508437668c35ed8
       endpoints:
       - lbEndpoints:
         - endpoint:
@@ -117,8 +150,24 @@ Endpoints:
                 kuma.io/protocol: http
               envoy.transport_socket_match:
                 kuma.io/protocol: http
-    echo-mirror-2e2ba113e4d991ba:
-      clusterName: echo-mirror-2e2ba113e4d991ba
+    api-service-bb145fed7e9ae110:
+      clusterName: api-service-bb145fed7e9ae110
+      endpoints:
+      - lbEndpoints:
+        - endpoint:
+            address:
+              socketAddress:
+                address: 192.168.1.1
+                portValue: 20001
+          loadBalancingWeight: 1
+          metadata:
+            filterMetadata:
+              envoy.lb:
+                kuma.io/protocol: http
+              envoy.transport_socket_match:
+                kuma.io/protocol: http
+    echo-mirror-3dd740a2de879d4c:
+      clusterName: echo-mirror-3dd740a2de879d4c
       endpoints:
       - lbEndpoints:
         - endpoint:
@@ -133,8 +182,8 @@ Endpoints:
                 kuma.io/protocol: http
               envoy.transport_socket_match:
                 kuma.io/protocol: http
-    echo-service-eb4ea372d99abf73:
-      clusterName: echo-service-eb4ea372d99abf73
+    echo-service-9f149ed9e14091ca:
+      clusterName: echo-service-9f149ed9e14091ca
       endpoints:
       - lbEndpoints:
         - endpoint:
@@ -258,7 +307,7 @@ Routes:
             timeout: 15s
             weightedClusters:
               clusters:
-              - name: api-service-19fcb7995aa98119
+              - name: api-service-bb145fed7e9ae110
                 requestHeadersToAdd:
                 - header:
                     key: x-kuma-tags
@@ -278,7 +327,7 @@ Routes:
             timeout: 15s
             weightedClusters:
               clusters:
-              - name: api-service-19fcb7995aa98119
+              - name: api-service-bb145fed7e9ae110
                 requestHeadersToAdd:
                 - header:
                     key: x-kuma-tags
@@ -289,7 +338,7 @@ Routes:
             prefix: /
           route:
             requestMirrorPolicies:
-            - cluster: echo-mirror-2e2ba113e4d991ba
+            - cluster: echo-mirror-3dd740a2de879d4c
               runtimeFraction:
                 defaultValue:
                   numerator: 1
@@ -303,7 +352,7 @@ Routes:
             timeout: 15s
             weightedClusters:
               clusters:
-              - name: echo-service-eb4ea372d99abf73
+              - name: echo-service-9f149ed9e14091ca
                 requestHeadersToAdd:
                 - header:
                     key: x-kuma-tags

--- a/pkg/plugins/runtime/gateway/testdata/https/18-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/18-gateway-route.yaml
@@ -1,6 +1,6 @@
 Clusters:
   Resources:
-    external-httpbin-4a2cc28cd5e983f1:
+    external-httpbin-8490df2e58a77ae0:
       circuitBreakers:
         thresholds:
         - maxConnections: 1024
@@ -25,7 +25,7 @@ Clusters:
                   kuma.io/protocol: http
                 envoy.transport_socket_match:
                   kuma.io/protocol: http
-      name: external-httpbin-4a2cc28cd5e983f1
+      name: external-httpbin-8490df2e58a77ae0
       outlierDetection:
         enforcingConsecutive5xx: 0
         enforcingConsecutiveGatewayFailure: 0
@@ -151,7 +151,7 @@ Routes:
             timeout: 15s
             weightedClusters:
               clusters:
-              - name: external-httpbin-4a2cc28cd5e983f1
+              - name: external-httpbin-8490df2e58a77ae0
                 weight: 1
               totalWeight: 1
 Runtimes:

--- a/pkg/plugins/runtime/gateway/testdata/https/19-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/19-gateway-route.yaml
@@ -1,6 +1,6 @@
 Clusters:
   Resources:
-    external-httpbin-e70841077c6e3aa5:
+    external-httpbin-8490df2e58a77ae0:
       circuitBreakers:
         thresholds:
         - maxConnections: 1024
@@ -27,7 +27,7 @@ Clusters:
                 envoy.transport_socket_match:
                   kuma.io/external-service-name: external-httpbin
                   kuma.io/protocol: http2
-      name: external-httpbin-e70841077c6e3aa5
+      name: external-httpbin-8490df2e58a77ae0
       outlierDetection:
         enforcingConsecutive5xx: 0
         enforcingConsecutiveGatewayFailure: 0
@@ -163,7 +163,7 @@ Routes:
             timeout: 15s
             weightedClusters:
               clusters:
-              - name: external-httpbin-e70841077c6e3aa5
+              - name: external-httpbin-8490df2e58a77ae0
                 weight: 1
               totalWeight: 1
 Runtimes:

--- a/pkg/plugins/runtime/gateway/testdata/https/20-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/20-gateway-route.yaml
@@ -27,7 +27,7 @@ Clusters:
             idleTimeout: 10s
           explicitHttpConfig:
             httpProtocolOptions: {}
-    echo-service-4e9f279944b992f7:
+    echo-service-11405a82852416ac:
       circuitBreakers:
         thresholds:
         - maxConnections: 1024
@@ -39,7 +39,7 @@ Clusters:
         edsConfig:
           ads: {}
           resourceApiVersion: V3
-      name: echo-service-4e9f279944b992f7
+      name: echo-service-11405a82852416ac
       outlierDetection:
         enforcingConsecutive5xx: 0
         enforcingConsecutiveGatewayFailure: 0
@@ -99,8 +99,8 @@ Endpoints:
                 kuma.io/protocol: http
               envoy.transport_socket_match:
                 kuma.io/protocol: http
-    echo-service-4e9f279944b992f7:
-      clusterName: echo-service-4e9f279944b992f7
+    echo-service-11405a82852416ac:
+      clusterName: echo-service-11405a82852416ac
       endpoints:
       - lbEndpoints:
         - endpoint:
@@ -394,7 +394,7 @@ Routes:
             timeout: 30s
             weightedClusters:
               clusters:
-              - name: echo-service-4e9f279944b992f7
+              - name: echo-service-11405a82852416ac
                 requestHeadersToAdd:
                 - header:
                     key: x-kuma-tags

--- a/pkg/plugins/runtime/gateway/testdata/https/20-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/20-gateway-route.yaml
@@ -1,6 +1,6 @@
 Clusters:
   Resources:
-    echo-service-b5c2b60cba392c4e:
+    echo-service-4d89cd662308223d:
       circuitBreakers:
         thresholds:
         - maxConnections: 1024
@@ -12,7 +12,7 @@ Clusters:
         edsConfig:
           ads: {}
           resourceApiVersion: V3
-      name: echo-service-b5c2b60cba392c4e
+      name: echo-service-4d89cd662308223d
       outlierDetection:
         enforcingConsecutive5xx: 0
         enforcingConsecutiveGatewayFailure: 0
@@ -27,7 +27,7 @@ Clusters:
             idleTimeout: 10s
           explicitHttpConfig:
             httpProtocolOptions: {}
-    echo-service-cff7b41a9764f367:
+    echo-service-4e9f279944b992f7:
       circuitBreakers:
         thresholds:
         - maxConnections: 1024
@@ -39,7 +39,7 @@ Clusters:
         edsConfig:
           ads: {}
           resourceApiVersion: V3
-      name: echo-service-cff7b41a9764f367
+      name: echo-service-4e9f279944b992f7
       outlierDetection:
         enforcingConsecutive5xx: 0
         enforcingConsecutiveGatewayFailure: 0
@@ -54,7 +54,7 @@ Clusters:
             idleTimeout: 30s
           explicitHttpConfig:
             httpProtocolOptions: {}
-    echo-service-dbfe9218dfa3ba0c:
+    echo-service-ff1f8bb571f3bfa4:
       circuitBreakers:
         thresholds:
         - maxConnections: 1024
@@ -66,7 +66,7 @@ Clusters:
         edsConfig:
           ads: {}
           resourceApiVersion: V3
-      name: echo-service-dbfe9218dfa3ba0c
+      name: echo-service-ff1f8bb571f3bfa4
       outlierDetection:
         enforcingConsecutive5xx: 0
         enforcingConsecutiveGatewayFailure: 0
@@ -83,8 +83,8 @@ Clusters:
             httpProtocolOptions: {}
 Endpoints:
   Resources:
-    echo-service-b5c2b60cba392c4e:
-      clusterName: echo-service-b5c2b60cba392c4e
+    echo-service-4d89cd662308223d:
+      clusterName: echo-service-4d89cd662308223d
       endpoints:
       - lbEndpoints:
         - endpoint:
@@ -99,8 +99,8 @@ Endpoints:
                 kuma.io/protocol: http
               envoy.transport_socket_match:
                 kuma.io/protocol: http
-    echo-service-cff7b41a9764f367:
-      clusterName: echo-service-cff7b41a9764f367
+    echo-service-4e9f279944b992f7:
+      clusterName: echo-service-4e9f279944b992f7
       endpoints:
       - lbEndpoints:
         - endpoint:
@@ -115,8 +115,8 @@ Endpoints:
                 kuma.io/protocol: http
               envoy.transport_socket_match:
                 kuma.io/protocol: http
-    echo-service-dbfe9218dfa3ba0c:
-      clusterName: echo-service-dbfe9218dfa3ba0c
+    echo-service-ff1f8bb571f3bfa4:
+      clusterName: echo-service-ff1f8bb571f3bfa4
       endpoints:
       - lbEndpoints:
         - endpoint:
@@ -364,7 +364,7 @@ Routes:
             timeout: 20s
             weightedClusters:
               clusters:
-              - name: echo-service-dbfe9218dfa3ba0c
+              - name: echo-service-ff1f8bb571f3bfa4
                 requestHeadersToAdd:
                 - header:
                     key: x-kuma-tags
@@ -394,7 +394,7 @@ Routes:
             timeout: 30s
             weightedClusters:
               clusters:
-              - name: echo-service-cff7b41a9764f367
+              - name: echo-service-4e9f279944b992f7
                 requestHeadersToAdd:
                 - header:
                     key: x-kuma-tags
@@ -424,7 +424,7 @@ Routes:
             timeout: 10s
             weightedClusters:
               clusters:
-              - name: echo-service-b5c2b60cba392c4e
+              - name: echo-service-4d89cd662308223d
                 requestHeadersToAdd:
                 - header:
                     key: x-kuma-tags

--- a/pkg/plugins/runtime/gateway/testdata/https/21-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/21-gateway-route.yaml
@@ -1,6 +1,6 @@
 Clusters:
   Resources:
-    api-service-f8ae3d759cc477a6:
+    api-service-4508437668c35ed8:
       circuitBreakers:
         thresholds:
         - maxConnections: 1024
@@ -12,7 +12,7 @@ Clusters:
         edsConfig:
           ads: {}
           resourceApiVersion: V3
-      name: api-service-f8ae3d759cc477a6
+      name: api-service-4508437668c35ed8
       outlierDetection:
         enforcingConsecutive5xx: 0
         enforcingConsecutiveGatewayFailure: 0
@@ -27,7 +27,7 @@ Clusters:
             idleTimeout: 3600s
           explicitHttpConfig:
             httpProtocolOptions: {}
-    echo-mirror-712ce3acc3cececc:
+    echo-mirror-3dd740a2de879d4c:
       circuitBreakers:
         thresholds:
         - maxConnections: 1024
@@ -39,7 +39,7 @@ Clusters:
         edsConfig:
           ads: {}
           resourceApiVersion: V3
-      name: echo-mirror-712ce3acc3cececc
+      name: echo-mirror-3dd740a2de879d4c
       outlierDetection:
         enforcingConsecutive5xx: 0
         enforcingConsecutiveGatewayFailure: 0
@@ -54,7 +54,7 @@ Clusters:
             idleTimeout: 3600s
           explicitHttpConfig:
             httpProtocolOptions: {}
-    echo-service-5a416c39037aa8f6:
+    echo-service-9f149ed9e14091ca:
       circuitBreakers:
         thresholds:
         - maxConnections: 1024
@@ -66,7 +66,7 @@ Clusters:
         edsConfig:
           ads: {}
           resourceApiVersion: V3
-      name: echo-service-5a416c39037aa8f6
+      name: echo-service-9f149ed9e14091ca
       outlierDetection:
         enforcingConsecutive5xx: 0
         enforcingConsecutiveGatewayFailure: 0
@@ -83,8 +83,8 @@ Clusters:
             httpProtocolOptions: {}
 Endpoints:
   Resources:
-    api-service-f8ae3d759cc477a6:
-      clusterName: api-service-f8ae3d759cc477a6
+    api-service-4508437668c35ed8:
+      clusterName: api-service-4508437668c35ed8
       endpoints:
       - lbEndpoints:
         - endpoint:
@@ -99,8 +99,8 @@ Endpoints:
                 kuma.io/protocol: http
               envoy.transport_socket_match:
                 kuma.io/protocol: http
-    echo-mirror-712ce3acc3cececc:
-      clusterName: echo-mirror-712ce3acc3cececc
+    echo-mirror-3dd740a2de879d4c:
+      clusterName: echo-mirror-3dd740a2de879d4c
       endpoints:
       - lbEndpoints:
         - endpoint:
@@ -115,8 +115,8 @@ Endpoints:
                 kuma.io/protocol: http
               envoy.transport_socket_match:
                 kuma.io/protocol: http
-    echo-service-5a416c39037aa8f6:
-      clusterName: echo-service-5a416c39037aa8f6
+    echo-service-9f149ed9e14091ca:
+      clusterName: echo-service-9f149ed9e14091ca
       endpoints:
       - lbEndpoints:
         - endpoint:
@@ -240,7 +240,7 @@ Routes:
             timeout: 15s
             weightedClusters:
               clusters:
-              - name: api-service-f8ae3d759cc477a6
+              - name: api-service-4508437668c35ed8
                 requestHeadersToAdd:
                 - header:
                     key: x-kuma-tags
@@ -276,7 +276,7 @@ Routes:
             timeout: 15s
             weightedClusters:
               clusters:
-              - name: api-service-f8ae3d759cc477a6
+              - name: api-service-4508437668c35ed8
                 requestHeadersToAdd:
                 - header:
                     key: x-kuma-tags
@@ -303,7 +303,7 @@ Routes:
             prefix: /
           route:
             requestMirrorPolicies:
-            - cluster: echo-mirror-712ce3acc3cececc
+            - cluster: echo-mirror-3dd740a2de879d4c
               runtimeFraction:
                 defaultValue:
                   numerator: 1
@@ -317,7 +317,7 @@ Routes:
             timeout: 15s
             weightedClusters:
               clusters:
-              - name: echo-service-5a416c39037aa8f6
+              - name: echo-service-9f149ed9e14091ca
                 requestHeadersToAdd:
                 - header:
                     key: x-kuma-tags

--- a/pkg/plugins/runtime/gateway/testdata/https/22-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/22-gateway-route.yaml
@@ -1,6 +1,6 @@
 Clusters:
   Resources:
-    api-service-f8ae3d759cc477a6:
+    api-service-d9dbfff8ad1fc589:
       circuitBreakers:
         thresholds:
         - maxConnections: 1024
@@ -12,7 +12,7 @@ Clusters:
         edsConfig:
           ads: {}
           resourceApiVersion: V3
-      name: api-service-f8ae3d759cc477a6
+      name: api-service-d9dbfff8ad1fc589
       outlierDetection:
         enforcingConsecutive5xx: 0
         enforcingConsecutiveGatewayFailure: 0
@@ -27,7 +27,7 @@ Clusters:
             idleTimeout: 3600s
           explicitHttpConfig:
             httpProtocolOptions: {}
-    echo-service-5a416c39037aa8f6:
+    echo-service-2987454ef247f8b4:
       circuitBreakers:
         thresholds:
         - maxConnections: 1024
@@ -39,7 +39,7 @@ Clusters:
         edsConfig:
           ads: {}
           resourceApiVersion: V3
-      name: echo-service-5a416c39037aa8f6
+      name: echo-service-2987454ef247f8b4
       outlierDetection:
         enforcingConsecutive5xx: 0
         enforcingConsecutiveGatewayFailure: 0
@@ -56,8 +56,8 @@ Clusters:
             httpProtocolOptions: {}
 Endpoints:
   Resources:
-    api-service-f8ae3d759cc477a6:
-      clusterName: api-service-f8ae3d759cc477a6
+    api-service-d9dbfff8ad1fc589:
+      clusterName: api-service-d9dbfff8ad1fc589
       endpoints:
       - lbEndpoints:
         - endpoint:
@@ -72,8 +72,8 @@ Endpoints:
                 kuma.io/protocol: http
               envoy.transport_socket_match:
                 kuma.io/protocol: http
-    echo-service-5a416c39037aa8f6:
-      clusterName: echo-service-5a416c39037aa8f6
+    echo-service-2987454ef247f8b4:
+      clusterName: echo-service-2987454ef247f8b4
       endpoints:
       - lbEndpoints:
         - endpoint:
@@ -171,7 +171,7 @@ Routes:
             timeout: 15s
             weightedClusters:
               clusters:
-              - name: api-service-f8ae3d759cc477a6
+              - name: api-service-d9dbfff8ad1fc589
                 requestHeadersToAdd:
                 - header:
                     key: x-kuma-tags
@@ -191,7 +191,7 @@ Routes:
             timeout: 15s
             weightedClusters:
               clusters:
-              - name: echo-service-5a416c39037aa8f6
+              - name: echo-service-2987454ef247f8b4
                 requestHeadersToAdd:
                 - header:
                     key: x-kuma-tags

--- a/pkg/plugins/runtime/gateway/testdata/https/22-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/22-gateway-route.yaml
@@ -1,6 +1,6 @@
 Clusters:
   Resources:
-    api-service-d9dbfff8ad1fc589:
+    api-service-ebbb1519109a5d70:
       circuitBreakers:
         thresholds:
         - maxConnections: 1024
@@ -12,7 +12,7 @@ Clusters:
         edsConfig:
           ads: {}
           resourceApiVersion: V3
-      name: api-service-d9dbfff8ad1fc589
+      name: api-service-ebbb1519109a5d70
       outlierDetection:
         enforcingConsecutive5xx: 0
         enforcingConsecutiveGatewayFailure: 0
@@ -27,7 +27,7 @@ Clusters:
             idleTimeout: 3600s
           explicitHttpConfig:
             httpProtocolOptions: {}
-    echo-service-2987454ef247f8b4:
+    echo-service-b70526a3f546ce4f:
       circuitBreakers:
         thresholds:
         - maxConnections: 1024
@@ -39,7 +39,7 @@ Clusters:
         edsConfig:
           ads: {}
           resourceApiVersion: V3
-      name: echo-service-2987454ef247f8b4
+      name: echo-service-b70526a3f546ce4f
       outlierDetection:
         enforcingConsecutive5xx: 0
         enforcingConsecutiveGatewayFailure: 0
@@ -56,8 +56,8 @@ Clusters:
             httpProtocolOptions: {}
 Endpoints:
   Resources:
-    api-service-d9dbfff8ad1fc589:
-      clusterName: api-service-d9dbfff8ad1fc589
+    api-service-ebbb1519109a5d70:
+      clusterName: api-service-ebbb1519109a5d70
       endpoints:
       - lbEndpoints:
         - endpoint:
@@ -72,8 +72,8 @@ Endpoints:
                 kuma.io/protocol: http
               envoy.transport_socket_match:
                 kuma.io/protocol: http
-    echo-service-2987454ef247f8b4:
-      clusterName: echo-service-2987454ef247f8b4
+    echo-service-b70526a3f546ce4f:
+      clusterName: echo-service-b70526a3f546ce4f
       endpoints:
       - lbEndpoints:
         - endpoint:
@@ -171,7 +171,7 @@ Routes:
             timeout: 15s
             weightedClusters:
               clusters:
-              - name: api-service-d9dbfff8ad1fc589
+              - name: api-service-ebbb1519109a5d70
                 requestHeadersToAdd:
                 - header:
                     key: x-kuma-tags
@@ -191,7 +191,7 @@ Routes:
             timeout: 15s
             weightedClusters:
               clusters:
-              - name: echo-service-2987454ef247f8b4
+              - name: echo-service-b70526a3f546ce4f
                 requestHeadersToAdd:
                 - header:
                     key: x-kuma-tags

--- a/pkg/plugins/runtime/gateway/testdata/https/23-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/23-gateway-route.yaml
@@ -1,6 +1,6 @@
 Clusters:
   Resources:
-    api-service-f8ae3d759cc477a6:
+    api-service-54505e76023cc1cc:
       circuitBreakers:
         thresholds:
         - maxConnections: 1024
@@ -12,7 +12,7 @@ Clusters:
         edsConfig:
           ads: {}
           resourceApiVersion: V3
-      name: api-service-f8ae3d759cc477a6
+      name: api-service-54505e76023cc1cc
       outlierDetection:
         enforcingConsecutive5xx: 0
         enforcingConsecutiveGatewayFailure: 0
@@ -27,7 +27,7 @@ Clusters:
             idleTimeout: 3600s
           explicitHttpConfig:
             httpProtocolOptions: {}
-    echo-service-5a416c39037aa8f6:
+    echo-service-90fd1f9189c63c08:
       circuitBreakers:
         thresholds:
         - maxConnections: 1024
@@ -39,7 +39,34 @@ Clusters:
         edsConfig:
           ads: {}
           resourceApiVersion: V3
-      name: echo-service-5a416c39037aa8f6
+      name: echo-service-90fd1f9189c63c08
+      outlierDetection:
+        enforcingConsecutive5xx: 0
+        enforcingConsecutiveGatewayFailure: 0
+        enforcingConsecutiveLocalOriginFailure: 0
+        enforcingFailurePercentage: 0
+        enforcingSuccessRate: 0
+      type: EDS
+      typedExtensionProtocolOptions:
+        envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+          '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+          commonHttpProtocolOptions:
+            idleTimeout: 3600s
+          explicitHttpConfig:
+            httpProtocolOptions: {}
+    echo-service-c641ec6d56895d4f:
+      circuitBreakers:
+        thresholds:
+        - maxConnections: 1024
+          maxPendingRequests: 1024
+          maxRequests: 1024
+          maxRetries: 3
+      connectTimeout: 5s
+      edsClusterConfig:
+        edsConfig:
+          ads: {}
+          resourceApiVersion: V3
+      name: echo-service-c641ec6d56895d4f
       outlierDetection:
         enforcingConsecutive5xx: 0
         enforcingConsecutiveGatewayFailure: 0
@@ -56,8 +83,8 @@ Clusters:
             httpProtocolOptions: {}
 Endpoints:
   Resources:
-    api-service-f8ae3d759cc477a6:
-      clusterName: api-service-f8ae3d759cc477a6
+    api-service-54505e76023cc1cc:
+      clusterName: api-service-54505e76023cc1cc
       endpoints:
       - lbEndpoints:
         - endpoint:
@@ -72,8 +99,24 @@ Endpoints:
                 kuma.io/protocol: http
               envoy.transport_socket_match:
                 kuma.io/protocol: http
-    echo-service-5a416c39037aa8f6:
-      clusterName: echo-service-5a416c39037aa8f6
+    echo-service-90fd1f9189c63c08:
+      clusterName: echo-service-90fd1f9189c63c08
+      endpoints:
+      - lbEndpoints:
+        - endpoint:
+            address:
+              socketAddress:
+                address: 192.168.1.6
+                portValue: 20006
+          loadBalancingWeight: 1
+          metadata:
+            filterMetadata:
+              envoy.lb:
+                kuma.io/protocol: http
+              envoy.transport_socket_match:
+                kuma.io/protocol: http
+    echo-service-c641ec6d56895d4f:
+      clusterName: echo-service-c641ec6d56895d4f
       endpoints:
       - lbEndpoints:
         - endpoint:
@@ -171,7 +214,7 @@ Routes:
             timeout: 15s
             weightedClusters:
               clusters:
-              - name: api-service-f8ae3d759cc477a6
+              - name: api-service-54505e76023cc1cc
                 requestHeadersToAdd:
                 - header:
                     key: x-kuma-tags
@@ -191,7 +234,7 @@ Routes:
             timeout: 15s
             weightedClusters:
               clusters:
-              - name: echo-service-5a416c39037aa8f6
+              - name: echo-service-c641ec6d56895d4f
                 requestHeadersToAdd:
                 - header:
                     key: x-kuma-tags
@@ -215,7 +258,7 @@ Routes:
             timeout: 15s
             weightedClusters:
               clusters:
-              - name: echo-service-5a416c39037aa8f6
+              - name: echo-service-90fd1f9189c63c08
                 requestHeadersToAdd:
                 - header:
                     key: x-kuma-tags

--- a/pkg/plugins/runtime/gateway/testdata/https/23-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/23-gateway-route.yaml
@@ -1,6 +1,6 @@
 Clusters:
   Resources:
-    api-service-54505e76023cc1cc:
+    api-service-ebbb1519109a5d70:
       circuitBreakers:
         thresholds:
         - maxConnections: 1024
@@ -12,7 +12,7 @@ Clusters:
         edsConfig:
           ads: {}
           resourceApiVersion: V3
-      name: api-service-54505e76023cc1cc
+      name: api-service-ebbb1519109a5d70
       outlierDetection:
         enforcingConsecutive5xx: 0
         enforcingConsecutiveGatewayFailure: 0
@@ -27,7 +27,7 @@ Clusters:
             idleTimeout: 3600s
           explicitHttpConfig:
             httpProtocolOptions: {}
-    echo-service-90fd1f9189c63c08:
+    echo-service-86192ff3ecc578b7:
       circuitBreakers:
         thresholds:
         - maxConnections: 1024
@@ -39,7 +39,7 @@ Clusters:
         edsConfig:
           ads: {}
           resourceApiVersion: V3
-      name: echo-service-90fd1f9189c63c08
+      name: echo-service-86192ff3ecc578b7
       outlierDetection:
         enforcingConsecutive5xx: 0
         enforcingConsecutiveGatewayFailure: 0
@@ -54,7 +54,7 @@ Clusters:
             idleTimeout: 3600s
           explicitHttpConfig:
             httpProtocolOptions: {}
-    echo-service-c641ec6d56895d4f:
+    echo-service-b70526a3f546ce4f:
       circuitBreakers:
         thresholds:
         - maxConnections: 1024
@@ -66,7 +66,7 @@ Clusters:
         edsConfig:
           ads: {}
           resourceApiVersion: V3
-      name: echo-service-c641ec6d56895d4f
+      name: echo-service-b70526a3f546ce4f
       outlierDetection:
         enforcingConsecutive5xx: 0
         enforcingConsecutiveGatewayFailure: 0
@@ -83,8 +83,8 @@ Clusters:
             httpProtocolOptions: {}
 Endpoints:
   Resources:
-    api-service-54505e76023cc1cc:
-      clusterName: api-service-54505e76023cc1cc
+    api-service-ebbb1519109a5d70:
+      clusterName: api-service-ebbb1519109a5d70
       endpoints:
       - lbEndpoints:
         - endpoint:
@@ -99,8 +99,8 @@ Endpoints:
                 kuma.io/protocol: http
               envoy.transport_socket_match:
                 kuma.io/protocol: http
-    echo-service-90fd1f9189c63c08:
-      clusterName: echo-service-90fd1f9189c63c08
+    echo-service-86192ff3ecc578b7:
+      clusterName: echo-service-86192ff3ecc578b7
       endpoints:
       - lbEndpoints:
         - endpoint:
@@ -115,8 +115,8 @@ Endpoints:
                 kuma.io/protocol: http
               envoy.transport_socket_match:
                 kuma.io/protocol: http
-    echo-service-c641ec6d56895d4f:
-      clusterName: echo-service-c641ec6d56895d4f
+    echo-service-b70526a3f546ce4f:
+      clusterName: echo-service-b70526a3f546ce4f
       endpoints:
       - lbEndpoints:
         - endpoint:
@@ -214,7 +214,7 @@ Routes:
             timeout: 15s
             weightedClusters:
               clusters:
-              - name: api-service-54505e76023cc1cc
+              - name: api-service-ebbb1519109a5d70
                 requestHeadersToAdd:
                 - header:
                     key: x-kuma-tags
@@ -234,7 +234,7 @@ Routes:
             timeout: 15s
             weightedClusters:
               clusters:
-              - name: echo-service-c641ec6d56895d4f
+              - name: echo-service-b70526a3f546ce4f
                 requestHeadersToAdd:
                 - header:
                     key: x-kuma-tags
@@ -258,7 +258,7 @@ Routes:
             timeout: 15s
             weightedClusters:
               clusters:
-              - name: echo-service-90fd1f9189c63c08
+              - name: echo-service-86192ff3ecc578b7
                 requestHeadersToAdd:
                 - header:
                     key: x-kuma-tags

--- a/pkg/plugins/runtime/gateway/testdata/https/24-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/24-gateway-route.yaml
@@ -1,6 +1,6 @@
 Clusters:
   Resources:
-    api-service-f8ae3d759cc477a6:
+    api-service-4508437668c35ed8:
       circuitBreakers:
         thresholds:
         - maxConnections: 1024
@@ -12,7 +12,7 @@ Clusters:
         edsConfig:
           ads: {}
           resourceApiVersion: V3
-      name: api-service-f8ae3d759cc477a6
+      name: api-service-4508437668c35ed8
       outlierDetection:
         enforcingConsecutive5xx: 0
         enforcingConsecutiveGatewayFailure: 0
@@ -27,7 +27,7 @@ Clusters:
             idleTimeout: 3600s
           explicitHttpConfig:
             httpProtocolOptions: {}
-    echo-service-5a416c39037aa8f6:
+    echo-service-9f149ed9e14091ca:
       circuitBreakers:
         thresholds:
         - maxConnections: 1024
@@ -39,7 +39,7 @@ Clusters:
         edsConfig:
           ads: {}
           resourceApiVersion: V3
-      name: echo-service-5a416c39037aa8f6
+      name: echo-service-9f149ed9e14091ca
       outlierDetection:
         enforcingConsecutive5xx: 0
         enforcingConsecutiveGatewayFailure: 0
@@ -56,8 +56,8 @@ Clusters:
             httpProtocolOptions: {}
 Endpoints:
   Resources:
-    api-service-f8ae3d759cc477a6:
-      clusterName: api-service-f8ae3d759cc477a6
+    api-service-4508437668c35ed8:
+      clusterName: api-service-4508437668c35ed8
       endpoints:
       - lbEndpoints:
         - endpoint:
@@ -72,8 +72,8 @@ Endpoints:
                 kuma.io/protocol: http
               envoy.transport_socket_match:
                 kuma.io/protocol: http
-    echo-service-5a416c39037aa8f6:
-      clusterName: echo-service-5a416c39037aa8f6
+    echo-service-9f149ed9e14091ca:
+      clusterName: echo-service-9f149ed9e14091ca
       endpoints:
       - lbEndpoints:
         - endpoint:
@@ -171,7 +171,7 @@ Routes:
             timeout: 15s
             weightedClusters:
               clusters:
-              - name: api-service-f8ae3d759cc477a6
+              - name: api-service-4508437668c35ed8
                 requestHeadersToAdd:
                 - header:
                     key: x-kuma-tags
@@ -191,7 +191,7 @@ Routes:
             timeout: 15s
             weightedClusters:
               clusters:
-              - name: echo-service-5a416c39037aa8f6
+              - name: echo-service-9f149ed9e14091ca
                 requestHeadersToAdd:
                 - header:
                     key: x-kuma-tags
@@ -215,7 +215,7 @@ Routes:
             timeout: 15s
             weightedClusters:
               clusters:
-              - name: echo-service-5a416c39037aa8f6
+              - name: echo-service-9f149ed9e14091ca
                 requestHeadersToAdd:
                 - header:
                     key: x-kuma-tags

--- a/pkg/plugins/runtime/gateway/testdata/https/25-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/25-gateway-route.yaml
@@ -1,6 +1,6 @@
 Clusters:
   Resources:
-    external-httpbin-622a08eefce6a721:
+    external-httpbin-8490df2e58a77ae0:
       circuitBreakers:
         thresholds:
         - maxConnections: 1024
@@ -12,7 +12,7 @@ Clusters:
         edsConfig:
           ads: {}
           resourceApiVersion: V3
-      name: external-httpbin-622a08eefce6a721
+      name: external-httpbin-8490df2e58a77ae0
       outlierDetection:
         enforcingConsecutive5xx: 0
         enforcingConsecutiveGatewayFailure: 0
@@ -51,8 +51,8 @@ Clusters:
             httpProtocolOptions: {}
 Endpoints:
   Resources:
-    external-httpbin-622a08eefce6a721:
-      clusterName: external-httpbin-622a08eefce6a721
+    external-httpbin-8490df2e58a77ae0:
+      clusterName: external-httpbin-8490df2e58a77ae0
       endpoints:
       - lbEndpoints:
         - endpoint:
@@ -176,7 +176,7 @@ Routes:
             timeout: 15s
             weightedClusters:
               clusters:
-              - name: external-httpbin-622a08eefce6a721
+              - name: external-httpbin-8490df2e58a77ae0
                 requestHeadersToAdd:
                 - header:
                     key: x-kuma-tags

--- a/pkg/plugins/runtime/gateway/testdata/https/26-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/26-gateway-route.yaml
@@ -1,6 +1,6 @@
 Clusters:
   Resources:
-    external-httpbin-61ba7d91cd9211a5:
+    external-httpbin-8490df2e58a77ae0:
       circuitBreakers:
         thresholds:
         - maxConnections: 1024
@@ -12,7 +12,7 @@ Clusters:
         edsConfig:
           ads: {}
           resourceApiVersion: V3
-      name: external-httpbin-61ba7d91cd9211a5
+      name: external-httpbin-8490df2e58a77ae0
       outlierDetection:
         enforcingConsecutive5xx: 0
         enforcingConsecutiveGatewayFailure: 0
@@ -51,8 +51,8 @@ Clusters:
             httpProtocolOptions: {}
 Endpoints:
   Resources:
-    external-httpbin-61ba7d91cd9211a5:
-      clusterName: external-httpbin-61ba7d91cd9211a5
+    external-httpbin-8490df2e58a77ae0:
+      clusterName: external-httpbin-8490df2e58a77ae0
 Listeners:
   Resources:
     edge-gateway:HTTPS:8080:
@@ -162,7 +162,7 @@ Routes:
             timeout: 15s
             weightedClusters:
               clusters:
-              - name: external-httpbin-61ba7d91cd9211a5
+              - name: external-httpbin-8490df2e58a77ae0
                 requestHeadersToAdd:
                 - header:
                     key: x-kuma-tags

--- a/pkg/plugins/runtime/gateway/testdata/https/cross-mesh-gateway.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/cross-mesh-gateway.yaml
@@ -1,6 +1,6 @@
 Clusters:
   Resources:
-    echo-service-b1e19f953add857b:
+    echo-service-bfae5b64a0fe8b74:
       circuitBreakers:
         thresholds:
         - maxConnections: 1024
@@ -12,7 +12,7 @@ Clusters:
         edsConfig:
           ads: {}
           resourceApiVersion: V3
-      name: echo-service-b1e19f953add857b
+      name: echo-service-bfae5b64a0fe8b74
       outlierDetection:
         enforcingConsecutive5xx: 0
         enforcingConsecutiveGatewayFailure: 0
@@ -49,7 +49,7 @@ Clusters:
             idleTimeout: 3600s
           explicitHttpConfig:
             httpProtocolOptions: {}
-    external-httpbin-e70841077c6e3aa5:
+    external-httpbin-823fa8131cdd67fa:
       circuitBreakers:
         thresholds:
         - maxConnections: 1024
@@ -76,7 +76,7 @@ Clusters:
                 envoy.transport_socket_match:
                   kuma.io/external-service-name: external-httpbin
                   kuma.io/protocol: http2
-      name: external-httpbin-e70841077c6e3aa5
+      name: external-httpbin-823fa8131cdd67fa
       outlierDetection:
         enforcingConsecutive5xx: 0
         enforcingConsecutiveGatewayFailure: 0
@@ -103,8 +103,8 @@ Clusters:
             http2ProtocolOptions: {}
 Endpoints:
   Resources:
-    echo-service-b1e19f953add857b:
-      clusterName: echo-service-b1e19f953add857b
+    echo-service-bfae5b64a0fe8b74:
+      clusterName: echo-service-bfae5b64a0fe8b74
       endpoints:
       - lbEndpoints:
         - endpoint:
@@ -230,7 +230,7 @@ Routes:
             timeout: 15s
             weightedClusters:
               clusters:
-              - name: echo-service-b1e19f953add857b
+              - name: echo-service-bfae5b64a0fe8b74
                 requestHeadersToAdd:
                 - header:
                     key: x-kuma-tags
@@ -250,7 +250,7 @@ Routes:
             timeout: 15s
             weightedClusters:
               clusters:
-              - name: external-httpbin-e70841077c6e3aa5
+              - name: external-httpbin-823fa8131cdd67fa
                 weight: 1
               totalWeight: 1
         - match:
@@ -266,7 +266,7 @@ Routes:
             timeout: 15s
             weightedClusters:
               clusters:
-              - name: echo-service-b1e19f953add857b
+              - name: echo-service-bfae5b64a0fe8b74
                 requestHeadersToAdd:
                 - header:
                     key: x-kuma-tags
@@ -286,7 +286,7 @@ Routes:
             timeout: 15s
             weightedClusters:
               clusters:
-              - name: external-httpbin-e70841077c6e3aa5
+              - name: external-httpbin-823fa8131cdd67fa
                 weight: 1
               totalWeight: 1
 Runtimes:

--- a/pkg/plugins/runtime/gateway/testdata/https/external-service-with-timeout-no-egress.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/external-service-with-timeout-no-egress.yaml
@@ -1,6 +1,6 @@
 Clusters:
   Resources:
-    external-httpbin-f452fc958912174e:
+    external-httpbin-823fa8131cdd67fa:
       circuitBreakers:
         thresholds:
         - maxConnections: 1024
@@ -27,7 +27,7 @@ Clusters:
                 envoy.transport_socket_match:
                   kuma.io/external-service-name: external-httpbin
                   kuma.io/protocol: http2
-      name: external-httpbin-f452fc958912174e
+      name: external-httpbin-823fa8131cdd67fa
       outlierDetection:
         enforcingConsecutive5xx: 0
         enforcingConsecutiveGatewayFailure: 0
@@ -138,7 +138,7 @@ Routes:
             timeout: 114s
             weightedClusters:
               clusters:
-              - name: external-httpbin-f452fc958912174e
+              - name: external-httpbin-823fa8131cdd67fa
                 weight: 1
               totalWeight: 1
         - match:
@@ -154,7 +154,7 @@ Routes:
             timeout: 114s
             weightedClusters:
               clusters:
-              - name: external-httpbin-f452fc958912174e
+              - name: external-httpbin-823fa8131cdd67fa
                 weight: 1
               totalWeight: 1
 Runtimes:

--- a/pkg/plugins/runtime/gateway/testdata/https/no-timeout.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/no-timeout.yaml
@@ -1,6 +1,6 @@
 Clusters:
   Resources:
-    echo-service-fedb984f12d264d6:
+    echo-service-9f149ed9e14091ca:
       circuitBreakers:
         thresholds:
         - maxConnections: 1024
@@ -12,7 +12,7 @@ Clusters:
         edsConfig:
           ads: {}
           resourceApiVersion: V3
-      name: echo-service-fedb984f12d264d6
+      name: echo-service-9f149ed9e14091ca
       outlierDetection:
         enforcingConsecutive5xx: 0
         enforcingConsecutiveGatewayFailure: 0
@@ -29,8 +29,8 @@ Clusters:
             httpProtocolOptions: {}
 Endpoints:
   Resources:
-    echo-service-fedb984f12d264d6:
-      clusterName: echo-service-fedb984f12d264d6
+    echo-service-9f149ed9e14091ca:
+      clusterName: echo-service-9f149ed9e14091ca
       endpoints:
       - lbEndpoints:
         - endpoint:
@@ -153,7 +153,7 @@ Routes:
               retryOn: gateway-error,connect-failure,refused-stream
             weightedClusters:
               clusters:
-              - name: echo-service-fedb984f12d264d6
+              - name: echo-service-9f149ed9e14091ca
                 requestHeadersToAdd:
                 - header:
                     key: x-kuma-tags

--- a/pkg/plugins/runtime/gateway/testdata/tcp/tcp-route-no-egress.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/tcp/tcp-route-no-egress.yaml
@@ -1,6 +1,6 @@
 Clusters:
   Resources:
-    external-httpbin-8bd356c79796cec2:
+    external-httpbin-8490df2e58a77ae0:
       circuitBreakers:
         thresholds:
         - maxConnections: 1024
@@ -25,7 +25,7 @@ Clusters:
                   kuma.io/external-service-name: external-httpbin
                 envoy.transport_socket_match:
                   kuma.io/external-service-name: external-httpbin
-      name: external-httpbin-8bd356c79796cec2
+      name: external-httpbin-8490df2e58a77ae0
       outlierDetection:
         enforcingConsecutive5xx: 0
         enforcingConsecutiveGatewayFailure: 0
@@ -57,7 +57,7 @@ Listeners:
         - name: envoy.filters.network.tcp_proxy
           typedConfig:
             '@type': type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
-            cluster: external-httpbin-8bd356c79796cec2
+            cluster: external-httpbin-8490df2e58a77ae0
             maxConnectAttempts: 5
             statPrefix: gateway-default
       listenerFilters:

--- a/pkg/plugins/runtime/gateway/testdata/tcp/tcp-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/tcp/tcp-route.yaml
@@ -1,6 +1,6 @@
 Clusters:
   Resources:
-    api-service-6deccbd18c30bed3:
+    api-service-4508437668c35ed8:
       circuitBreakers:
         thresholds:
         - maxConnections: 1024
@@ -12,7 +12,7 @@ Clusters:
         edsConfig:
           ads: {}
           resourceApiVersion: V3
-      name: api-service-6deccbd18c30bed3
+      name: api-service-4508437668c35ed8
       outlierDetection:
         enforcingConsecutive5xx: 0
         enforcingConsecutiveGatewayFailure: 0
@@ -42,7 +42,7 @@ Clusters:
                 resourceApiVersion: V3
           sni: api-service{mesh=default}
       type: EDS
-    echo-service-7ac4685ceb7ca5fc:
+    echo-service-9f149ed9e14091ca:
       circuitBreakers:
         thresholds:
         - maxConnections: 1024
@@ -54,7 +54,7 @@ Clusters:
         edsConfig:
           ads: {}
           resourceApiVersion: V3
-      name: echo-service-7ac4685ceb7ca5fc
+      name: echo-service-9f149ed9e14091ca
       outlierDetection:
         enforcingConsecutive5xx: 0
         enforcingConsecutiveGatewayFailure: 0
@@ -84,7 +84,7 @@ Clusters:
                 resourceApiVersion: V3
           sni: echo-service{mesh=default}
       type: EDS
-    external-httpbin-c7ae16fc6e6c5a95:
+    external-httpbin-8490df2e58a77ae0:
       circuitBreakers:
         thresholds:
         - maxConnections: 1024
@@ -96,7 +96,7 @@ Clusters:
         edsConfig:
           ads: {}
           resourceApiVersion: V3
-      name: external-httpbin-c7ae16fc6e6c5a95
+      name: external-httpbin-8490df2e58a77ae0
       outlierDetection:
         enforcingConsecutive5xx: 0
         enforcingConsecutiveGatewayFailure: 0
@@ -128,8 +128,8 @@ Clusters:
       type: EDS
 Endpoints:
   Resources:
-    api-service-6deccbd18c30bed3:
-      clusterName: api-service-6deccbd18c30bed3
+    api-service-4508437668c35ed8:
+      clusterName: api-service-4508437668c35ed8
       endpoints:
       - lbEndpoints:
         - endpoint:
@@ -144,8 +144,8 @@ Endpoints:
                 kuma.io/protocol: http
               envoy.transport_socket_match:
                 kuma.io/protocol: http
-    echo-service-7ac4685ceb7ca5fc:
-      clusterName: echo-service-7ac4685ceb7ca5fc
+    echo-service-9f149ed9e14091ca:
+      clusterName: echo-service-9f149ed9e14091ca
       endpoints:
       - lbEndpoints:
         - endpoint:
@@ -160,8 +160,8 @@ Endpoints:
                 kuma.io/protocol: http
               envoy.transport_socket_match:
                 kuma.io/protocol: http
-    external-httpbin-c7ae16fc6e6c5a95:
-      clusterName: external-httpbin-c7ae16fc6e6c5a95
+    external-httpbin-8490df2e58a77ae0:
+      clusterName: external-httpbin-8490df2e58a77ae0
 Listeners:
   Resources:
     edge-gateway:TCP:8080:
@@ -179,9 +179,9 @@ Listeners:
             statPrefix: gateway-default
             weightedClusters:
               clusters:
-              - name: api-service-6deccbd18c30bed3
-              - name: echo-service-7ac4685ceb7ca5fc
-              - name: external-httpbin-c7ae16fc6e6c5a95
+              - name: api-service-4508437668c35ed8
+              - name: echo-service-9f149ed9e14091ca
+              - name: external-httpbin-8490df2e58a77ae0
       listenerFilters:
       - name: envoy.filters.listener.tls_inspector
         typedConfig:


### PR DESCRIPTION
### Summary

Depending on the configuration, a gateway might have different routes that redirect to the same service but with different configurations (timeout, retry .. ). We used to generate a name based on `kuma.io/service` and hash of (route tags and cluster configuration). That causes some problems. Whenever we change the configuration of the cluster, the new name is generated which causes CP to send new routes/clusters back to Envoy. While there is traffic it might happen that for a really short period you can observe `cluster_not_found`. In this PR we are changing that behavior and now instead of using configuration for a hash generation we are using: Listener, MeshGateway, and Dataplane tags combined. Each cluster's configuration change won't cause name generation now. The only downside is that for a different set of tags we are generating different clusters.

### Full changelog

* [Fix cluster name generation to use combination of Listener, Dataplane, MeshGateway tags]

### Issues resolved

Fix #4556 

### Documentation

- [ ] Link to the website [documentation PR](https://github.com/kumahq/kuma-website/pull/XXX)

### Testing

- [X] Unit tests
- [X] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes

### Backwards compatibility

- [ ] Update [`UPGRADE.md`](/UPGRADE.md) with any steps users will need to take when upgrading.
- [ ] Add `backport-to-stable` label if the code follows our [backporting policy](/CONTRIBUTING.md#backporting)
