### PR TITLE
fix(cni): add cni binaries to release binaries list

### DIFF
--- a/mk/build.mk
+++ b/mk/build.mk
@@ -33,7 +33,7 @@ COREDNS_TMP_DIRECTORY ?= $(BUILD_DIR)/coredns
 COREDNS_PLUGIN_CFG_PATH ?= $(TOP)/tools/builds/coredns/templates/plugin.cfg
 
 # List of binaries that we have release build rules for.
-BUILD_RELEASE_BINARIES := kuma-cp kuma-dp kumactl kuma-prometheus-sd coredns envoy
+BUILD_RELEASE_BINARIES := kuma-cp kuma-dp kumactl kuma-prometheus-sd coredns envoy kuma-cni install-cni
 
 # List of binaries that we have test build roles for.
 BUILD_TEST_BINARIES := test-server


### PR DESCRIPTION
Signed-off-by: slonka <slonka@users.noreply.github.com>

### Summary

Release script is failing

### Full changelog

* add cni binaries to release binaries list to fix release script

### Issues resolved

Reported on slack.

### Documentation

~~- [ ] Link to the website [documentation PR](https://github.com/kumahq/kuma-website/pull/XXX)~~

### Testing

~~- [ ] Unit tests~~
~~- [ ] E2E tests~~
- [x] Manual testing on Universal
~~- [ ] Manual testing on Kubernetes~~

### Backwards compatibility

~~- [ ] Update [`UPGRADE.md`](/UPGRADE.md) with any steps users will need to take when upgrading.~~
~~- [ ] Add `backport-to-stable` label if the code follows our [backporting policy](/CONTRIBUTING.md#backporting)~~
