### PR TITLE
fix(helm): use image.global.registry for imageExperimental

### DIFF
--- a/app/kumactl/cmd/install/testdata/install-control-plane.cni-experimental-enabled.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.cni-experimental-enabled.golden.yaml
@@ -2035,7 +2035,7 @@ spec:
       terminationGracePeriodSeconds: 5
       containers:
         - name: install-cni
-          image: "kumahq/kuma-cni:1.7.0"
+          image: "docker.io/kumahq/kuma-cni:1.7.0"
           imagePullPolicy: IfNotPresent
           command: ["/install-cni"]
           env:

--- a/app/kumactl/cmd/install/testdata/install-control-plane.dump-values.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.dump-values.yaml
@@ -150,7 +150,7 @@ controlPlane:
 
   # -- Whether to automountServiceAccountToken for cp. Optionally set to false
   automountServiceAccountToken: true
-  
+
   # -- Optionally override the resource spec
   # @default -- the resources will be chosen based on the mode
   resources:
@@ -322,8 +322,6 @@ cni:
 
   # -- use new CNI image (experimental)
   imageExperimental:
-    # -- CNI experimental image registry
-    registry: "kumahq"
     # -- CNI experimental image repository
     repository: "kuma-cni"
     # -- CNI experimental image tag - defaults to .Chart.AppVersion

--- a/deployments/charts/kuma/README.md
+++ b/deployments/charts/kuma/README.md
@@ -88,8 +88,7 @@ A Helm chart for the Kuma Control Plane
 | cni.image.registry | string | `"docker.io/kumahq"` | CNI image registry |
 | cni.image.repository | string | `"install-cni"` | CNI image repository |
 | cni.image.tag | string | `"0.0.10"` | CNI image tag |
-| cni.imageExperimental | object | `{"registry":"kumahq","repository":"kuma-cni","tag":null}` | use new CNI image (experimental) |
-| cni.imageExperimental.registry | string | `"kumahq"` | CNI experimental image registry |
+| cni.imageExperimental | object | `{"repository":"kuma-cni","tag":null}` | use new CNI image (experimental) |
 | cni.imageExperimental.repository | string | `"kuma-cni"` | CNI experimental image repository |
 | cni.imageExperimental.tag | string | `nil` | CNI experimental image tag - defaults to .Chart.AppVersion |
 | cni.podSecurityContext | object | `{}` | Security context at the pod level for cni |

--- a/deployments/charts/kuma/values.yaml
+++ b/deployments/charts/kuma/values.yaml
@@ -150,7 +150,7 @@ controlPlane:
 
   # -- Whether to automountServiceAccountToken for cp. Optionally set to false
   automountServiceAccountToken: true
-  
+
   # -- Optionally override the resource spec
   # @default -- the resources will be chosen based on the mode
   resources:
@@ -322,8 +322,6 @@ cni:
 
   # -- use new CNI image (experimental)
   imageExperimental:
-    # -- CNI experimental image registry
-    registry: "kumahq"
     # -- CNI experimental image repository
     repository: "kuma-cni"
     # -- CNI experimental image tag - defaults to .Chart.AppVersion


### PR DESCRIPTION
### Summary

Instead of hardcoding registry, we leave it empty so we can infer this from image.global.registry

### Issues resolved

No issues reported.

### Documentation

~- [ ] Link to the website [documentation PR](https://github.com/kumahq/kuma-website/pull/XXX)~

### Testing

- [ ] Unit tests
- [ ] E2E tests
- [ ] Manual testing on Universal
- [X] Manual testing on Kubernetes

### Backwards compatibility

~- [ ] Update [`UPGRADE.md`](/UPGRADE.md) with any steps users will need to take when upgrading.~
~- [ ] Add `backport-to-stable` label if the code follows our [backporting policy](/CONTRIBUTING.md#backporting)~
