### PR TITLE
fix(cni): check to enable ipv6 flag on transparent proxy engine

### DIFF
--- a/app/cni/pkg/cni/injector_linux.go
+++ b/app/cni/pkg/cni/injector_linux.go
@@ -11,6 +11,8 @@ import (
 
 	"github.com/kumahq/kuma-net/iptables/builder"
 	"github.com/kumahq/kuma-net/iptables/config"
+
+	"github.com/kumahq/kuma/pkg/transparentproxy"
 )
 
 func convertToUint16(field string, value string) (uint16, error) {
@@ -93,6 +95,12 @@ func mapToConfig(intermediateConfig *IntermediateConfig) (*config.Config, error)
 		if err != nil {
 			return nil, err
 		}
+		enableIpV6, err := transparentproxy.ShouldEnableIPv6()
+		if err != nil {
+			return nil, err
+		}
+		cfg.IPv6 = enableIpV6
+
 		inboundPortV6, err := convertToUint16("inbound port ipv6", intermediateConfig.inboundPortV6)
 		if err != nil {
 			return nil, err

--- a/pkg/transparentproxy/transparentproxy_experimental.go
+++ b/pkg/transparentproxy/transparentproxy_experimental.go
@@ -51,7 +51,7 @@ func hasLocalIPv6() (bool, error) {
 	return false, nil
 }
 
-func shouldEnableIPv6() (bool, error) {
+func ShouldEnableIPv6() (bool, error) {
 	hasIPv6Address, err := hasLocalIPv6()
 	if !hasIPv6Address || err != nil {
 		return false, err
@@ -124,7 +124,7 @@ func (tp *ExperimentalTransparentProxy) Setup(tpConfig *config.TransparentProxyC
 		}
 	}
 
-	ipv6, err := shouldEnableIPv6()
+	ipv6, err := ShouldEnableIPv6()
 	if err != nil {
 		return "", errors.Wrap(err, "cannot verify if IPv6 should be enabled")
 	}


### PR DESCRIPTION
Signed-off-by: slonka <slonka@users.noreply.github.com>

### Summary

Check if ipv6 can be enabled and pass the value to the config

### Full changelog

* [Fix failing ipv6 build https://app.circleci.com/pipelines/github/kumahq/kuma/15351/workflows/cb3322ce-4881-40a7-b8f4-1cd7cef2b07f/jobs/185366/parallel-runs/4

### Issues resolved

No issue created, build failing.

### Documentation

~~- [ ] Link to the website [documentation PR](https://github.com/kumahq/kuma-website/pull/XXX)~~

### Testing

~~- [ ] Unit tests~~
~~- [ ] E2E tests~~
~~- [ ] Manual testing on Universal~~
- [x] Manual testing on Kubernetes

### Backwards compatibility

~~- [ ] Update [`UPGRADE.md`](/UPGRADE.md) with any steps users will need to take when upgrading.~~
~~- [ ] Add `backport-to-stable` label if the code follows our [backporting policy](/CONTRIBUTING.md#backporting)~~
