### PR TITLE
fix: registering dp on reconnect

### DIFF
--- a/pkg/api-server/config_ws_test.go
+++ b/pkg/api-server/config_ws_test.go
@@ -297,6 +297,7 @@ var _ = Describe("Config WS", func() {
           "xdsServer": {
             "dataplaneConfigurationRefreshInterval": "1s",
             "dataplaneStatusFlushInterval": "10s",
+            "dataplaneDeregistrationDelay": "10s",
             "nackBackoff": "5s"
           },
           "diagnostics": {

--- a/pkg/config/app/kuma-cp/kuma-cp.defaults.yaml
+++ b/pkg/config/app/kuma-cp/kuma-cp.defaults.yaml
@@ -111,6 +111,8 @@ xdsServer:
   nackBackoff: 5s # ENV: KUMA_XDS_SERVER_NACK_BACKOFF
   # A delay between proxy terminating a connection and the CP trying to deregister the proxy.
   # It is used only in universal mode when you use direct lifecycle.
+  # Disabling this may cause race conditions that one instance of CP removes proxy object
+  # while proxy is connected to another instance of the CP.
   dataplaneDeregistrationDelay: 10s # ENV: KUMA_XDS_DATAPLANE_DEREGISTRATION_DELAY
 
 # API Server configuration

--- a/pkg/config/app/kuma-cp/kuma-cp.defaults.yaml
+++ b/pkg/config/app/kuma-cp/kuma-cp.defaults.yaml
@@ -111,6 +111,7 @@ xdsServer:
   nackBackoff: 5s # ENV: KUMA_XDS_SERVER_NACK_BACKOFF
   # A delay between proxy terminating a connection and the CP trying to deregister the proxy.
   # It is used only in universal mode when you use direct lifecycle.
+  # Setting this setting to 0s disables the delay.
   # Disabling this may cause race conditions that one instance of CP removes proxy object
   # while proxy is connected to another instance of the CP.
   dataplaneDeregistrationDelay: 10s # ENV: KUMA_XDS_DATAPLANE_DEREGISTRATION_DELAY

--- a/pkg/config/app/kuma-cp/kuma-cp.defaults.yaml
+++ b/pkg/config/app/kuma-cp/kuma-cp.defaults.yaml
@@ -109,6 +109,9 @@ xdsServer:
   dataplaneStatusFlushInterval: 10s # ENV: KUMA_XDS_SERVER_DATAPLANE_STATUS_FLUSH_INTERVAL
   # Backoff that is executed when Control Plane is sending the response that was previously rejected by Dataplane
   nackBackoff: 5s # ENV: KUMA_XDS_SERVER_NACK_BACKOFF
+  # A delay between proxy terminating a connection and the CP trying to deregister the proxy.
+  # It is used only in universal mode when you use direct lifecycle.
+  dataplaneDeregistrationDelay: 10s # ENV: KUMA_XDS_DATAPLANE_DEREGISTRATION_DELAY
 
 # API Server configuration
 apiServer:

--- a/pkg/config/loader_test.go
+++ b/pkg/config/loader_test.go
@@ -216,6 +216,7 @@ var _ = Describe("Config loader", func() {
 
 			Expect(cfg.XdsServer.DataplaneStatusFlushInterval).To(Equal(7 * time.Second))
 			Expect(cfg.XdsServer.DataplaneConfigurationRefreshInterval).To(Equal(21 * time.Second))
+			Expect(cfg.XdsServer.DataplaneDeregistrationDelay).To(Equal(11 * time.Second))
 			Expect(cfg.XdsServer.NACKBackoff).To(Equal(10 * time.Second))
 
 			Expect(cfg.Metrics.Zone.SubscriptionLimit).To(Equal(23))
@@ -425,6 +426,7 @@ diagnostics:
 xdsServer:
   dataplaneConfigurationRefreshInterval: 21s
   dataplaneStatusFlushInterval: 7s
+  dataplaneDeregistrationDelay: 11s
   nackBackoff: 10s
 metrics:
   zone:
@@ -596,6 +598,7 @@ experimental:
 				"KUMA_DIAGNOSTICS_DEBUG_ENDPOINTS":                                                         "true",
 				"KUMA_XDS_SERVER_DATAPLANE_STATUS_FLUSH_INTERVAL":                                          "7s",
 				"KUMA_XDS_SERVER_DATAPLANE_CONFIGURATION_REFRESH_INTERVAL":                                 "21s",
+				"KUMA_XDS_DATAPLANE_DEREGISTRATION_DELAY":                                                  "11s",
 				"KUMA_XDS_SERVER_NACK_BACKOFF":                                                             "10s",
 				"KUMA_METRICS_ZONE_SUBSCRIPTION_LIMIT":                                                     "23",
 				"KUMA_METRICS_ZONE_IDLE_TIMEOUT":                                                           "2m",

--- a/pkg/config/xds/config.go
+++ b/pkg/config/xds/config.go
@@ -16,6 +16,9 @@ type XdsServerConfig struct {
 	DataplaneConfigurationRefreshInterval time.Duration `yaml:"dataplaneConfigurationRefreshInterval" envconfig:"kuma_xds_server_dataplane_configuration_refresh_interval"`
 	// Interval for flushing status of Dataplanes connected to the Control Plane
 	DataplaneStatusFlushInterval time.Duration `yaml:"dataplaneStatusFlushInterval" envconfig:"kuma_xds_server_dataplane_status_flush_interval"`
+	// DataplaneDeregistrationDelay is a delay between proxy terminating a connection and the CP trying to deregister the proxy.
+	// It is used only in universal mode when you use direct lifecycle.
+	DataplaneDeregistrationDelay time.Duration `yaml:"dataplaneDeregistrationDelay" envconfig:"kuma_xds_dataplane_deregistration_delay"`
 	// Backoff that is executed when Control Plane is sending the response that was previously rejected by Dataplane
 	NACKBackoff time.Duration `yaml:"nackBackoff" envconfig:"kuma_xds_server_nack_backoff"`
 }
@@ -37,6 +40,7 @@ func DefaultXdsServerConfig() *XdsServerConfig {
 	return &XdsServerConfig{
 		DataplaneConfigurationRefreshInterval: 1 * time.Second,
 		DataplaneStatusFlushInterval:          10 * time.Second,
+		DataplaneDeregistrationDelay:          10 * time.Second,
 		NACKBackoff:                           5 * time.Second,
 	}
 }

--- a/pkg/config/xds/config.go
+++ b/pkg/config/xds/config.go
@@ -18,6 +18,7 @@ type XdsServerConfig struct {
 	DataplaneStatusFlushInterval time.Duration `yaml:"dataplaneStatusFlushInterval" envconfig:"kuma_xds_server_dataplane_status_flush_interval"`
 	// DataplaneDeregistrationDelay is a delay between proxy terminating a connection and the CP trying to deregister the proxy.
 	// It is used only in universal mode when you use direct lifecycle.
+	// Setting this setting to 0s disables the delay.
 	// Disabling this may cause race conditions that one instance of CP removes proxy object
 	// while proxy is connected to another instance of the CP.
 	DataplaneDeregistrationDelay time.Duration `yaml:"dataplaneDeregistrationDelay" envconfig:"kuma_xds_dataplane_deregistration_delay"`

--- a/pkg/config/xds/config.go
+++ b/pkg/config/xds/config.go
@@ -18,6 +18,8 @@ type XdsServerConfig struct {
 	DataplaneStatusFlushInterval time.Duration `yaml:"dataplaneStatusFlushInterval" envconfig:"kuma_xds_server_dataplane_status_flush_interval"`
 	// DataplaneDeregistrationDelay is a delay between proxy terminating a connection and the CP trying to deregister the proxy.
 	// It is used only in universal mode when you use direct lifecycle.
+	// Disabling this may cause race conditions that one instance of CP removes proxy object
+	// while proxy is connected to another instance of the CP.
 	DataplaneDeregistrationDelay time.Duration `yaml:"dataplaneDeregistrationDelay" envconfig:"kuma_xds_dataplane_deregistration_delay"`
 	// Backoff that is executed when Control Plane is sending the response that was previously rejected by Dataplane
 	NACKBackoff time.Duration `yaml:"nackBackoff" envconfig:"kuma_xds_server_nack_backoff"`

--- a/pkg/config/xds/testdata/default-config.golden.yaml
+++ b/pkg/config/xds/testdata/default-config.golden.yaml
@@ -1,3 +1,4 @@
 dataplaneConfigurationRefreshInterval: 1s
 dataplaneStatusFlushInterval: 10s
+dataplaneDeregistrationDelay: 10s
 nackBackoff: 5s

--- a/pkg/xds/server/callbacks/dataplane_callbacks.go
+++ b/pkg/xds/server/callbacks/dataplane_callbacks.go
@@ -26,7 +26,7 @@ type DataplaneCallbacks interface {
 	// This can happen when there is a delay with closing the old connection from the proxy to the control plane.
 	OnProxyReconnected(streamID core_xds.StreamID, dpKey core_model.ResourceKey, ctx context.Context, metadata core_xds.DataplaneMetadata) error
 	// OnProxyDisconnected is executed only when the last stream of the proxy disconnects.
-	OnProxyDisconnected(streamID core_xds.StreamID, dpKey core_model.ResourceKey)
+	OnProxyDisconnected(ctx context.Context, streamID core_xds.StreamID, dpKey core_model.ResourceKey)
 }
 
 type xdsCallbacks struct {
@@ -68,7 +68,7 @@ func (d *xdsCallbacks) OnStreamClosed(streamID core_xds.StreamID) {
 	d.Unlock()
 	if lastStreamDpKey != nil {
 		// execute callback after lock is freed, so heavy callback implementation won't block every callback for every DPP.
-		d.callbacks.OnProxyDisconnected(streamID, *lastStreamDpKey)
+		d.callbacks.OnProxyDisconnected(dpStream.ctx, streamID, *lastStreamDpKey)
 	}
 }
 
@@ -151,7 +151,7 @@ func (n *NoopDataplaneCallbacks) OnProxyConnected(core_xds.StreamID, core_model.
 	return nil
 }
 
-func (n *NoopDataplaneCallbacks) OnProxyDisconnected(core_xds.StreamID, core_model.ResourceKey) {
+func (n *NoopDataplaneCallbacks) OnProxyDisconnected(context.Context, core_xds.StreamID, core_model.ResourceKey) {
 }
 
 var _ DataplaneCallbacks = &NoopDataplaneCallbacks{}

--- a/pkg/xds/server/callbacks/dataplane_callbacks_test.go
+++ b/pkg/xds/server/callbacks/dataplane_callbacks_test.go
@@ -31,7 +31,7 @@ func (c *countingDpCallbacks) OnProxyReconnected(streamID core_xds.StreamID, dpK
 	return nil
 }
 
-func (c *countingDpCallbacks) OnProxyDisconnected(streamID core_xds.StreamID, dpKey core_model.ResourceKey) {
+func (c *countingDpCallbacks) OnProxyDisconnected(ctx context.Context, streamID core_xds.StreamID, dpKey core_model.ResourceKey) {
 	c.OnProxyDisconnectedCounter++
 }
 

--- a/pkg/xds/server/callbacks/dataplane_lifecycle.go
+++ b/pkg/xds/server/callbacks/dataplane_lifecycle.go
@@ -231,6 +231,9 @@ func (d *DataplaneLifecycle) deregisterProxy(
 			log.Info("no need to deregister proxy. It has already connected to another instance", "newCpInstanceID", sub.ControlPlaneInstanceId)
 			return nil
 		}
+	} else {
+		// If insight is missing it most likely means that it was not yet created, so DP just connected and now leaving the mesh.
+		log.V(1).Info("insight is missing. Safe to deregister the proxy")
 	}
 	log.Info("deregister proxy")
 	return d.resManager.Delete(context.Background(), obj, store.DeleteBy(key))

--- a/pkg/xds/server/callbacks/dataplane_lifecycle.go
+++ b/pkg/xds/server/callbacks/dataplane_lifecycle.go
@@ -210,11 +210,7 @@ func (d *DataplaneLifecycle) deregisterProxy(
 	log logr.Logger,
 ) error {
 	log.Info("waiting for deregister proxy", "waitFor", d.deregistrationDelay)
-	select {
-	case <-ctx.Done():
-		return ctx.Err()
-	case <-time.After(d.deregistrationDelay):
-	}
+	time.After(d.deregistrationDelay)
 	err := d.resManager.Get(ctx, insight, store.GetBy(key))
 	switch {
 	case store.IsResourceNotFound(err):

--- a/pkg/xds/server/callbacks/dataplane_lifecycle_test.go
+++ b/pkg/xds/server/callbacks/dataplane_lifecycle_test.go
@@ -95,6 +95,7 @@ var _ = Describe("Dataplane Lifecycle", func() {
 			},
 		}
 		const streamId = 123
+		Expect(callbacks.OnStreamOpen(context.Background(), streamId, "")).To(Succeed())
 
 		// when
 		err := callbacks.OnStreamRequest(streamId, &req)
@@ -322,6 +323,7 @@ var _ = Describe("Dataplane Lifecycle", func() {
 						},
 					},
 				}
+				Expect(callbacks.OnStreamOpen(context.Background(), streamID, "")).To(Succeed())
 
 				// when
 				err := callbacks.OnStreamRequest(streamID, &req)
@@ -388,6 +390,7 @@ var _ = Describe("Dataplane Lifecycle", func() {
 		}
 
 		const streamId = 123
+		Expect(callbacks.OnStreamOpen(context.Background(), streamId, "")).To(Succeed())
 		err := callbacks.OnStreamRequest(streamId, &req)
 		Expect(err).ToNot(HaveOccurred())
 

--- a/pkg/xds/server/callbacks/dataplane_metadata_tracker.go
+++ b/pkg/xds/server/callbacks/dataplane_metadata_tracker.go
@@ -43,7 +43,7 @@ func (d *DataplaneMetadataTracker) storeMetadata(dpKey core_model.ResourceKey, m
 	d.metadataForDp[dpKey] = &metadata
 }
 
-func (d *DataplaneMetadataTracker) OnProxyDisconnected(_ core_xds.StreamID, dpKey core_model.ResourceKey) {
+func (d *DataplaneMetadataTracker) OnProxyDisconnected(_ context.Context, _ core_xds.StreamID, dpKey core_model.ResourceKey) {
 	d.Lock()
 	defer d.Unlock()
 	delete(d.metadataForDp, dpKey)

--- a/pkg/xds/server/callbacks/dataplane_status_sink.go
+++ b/pkg/xds/server/callbacks/dataplane_status_sink.go
@@ -116,6 +116,11 @@ func (s *dataplaneInsightSink) Start(stop <-chan struct{}) {
 		}
 	}
 
+	// flush the first insight as quickly as possible so
+	// 1) user sees that DP is online in kumactl/GUI (even without any XDS updates)
+	// 2) we can have lower deregistrationDelay, see pkg/xds/server/callbacks/dataplane_lifecycle.go#deregisterProxy
+	flush(false)
+
 	for {
 		select {
 		case <-flushTicker.C:

--- a/pkg/xds/server/callbacks/dataplane_status_sink_test.go
+++ b/pkg/xds/server/callbacks/dataplane_status_sink_test.go
@@ -73,20 +73,15 @@ var _ = Describe("DataplaneInsightSink", func() {
 				1*time.Millisecond,
 				store,
 			)
-			go sink.Start(stop)
 
 			// when
-			ticks <- t0.Add(1 * time.Second)
+			go sink.Start(stop)
+
 			// then
-			Eventually(func() bool {
-				select {
-				case create, ok := <-recorder.Creates:
-					latestOperation = &create
-					return ok
-				default:
-					return false
-				}
-			}, "100s", "1ms").Should(BeTrue())
+			create, ok := <-recorder.Creates
+			Expect(ok).To(BeTrue())
+			latestOperation = &create
+
 			// and
 			Expect(util_proto.ToYAML(latestOperation.DiscoverySubscription)).To(MatchYAML(`
             connectTime: "2019-07-01T00:00:00Z"

--- a/pkg/xds/server/callbacks/dataplane_sync_tracker.go
+++ b/pkg/xds/server/callbacks/dataplane_sync_tracker.go
@@ -56,7 +56,7 @@ func (t *dataplaneSyncTracker) OnProxyConnected(streamID core_xds.StreamID, dpKe
 	return nil
 }
 
-func (t *dataplaneSyncTracker) OnProxyDisconnected(_ core_xds.StreamID, dpKey core_model.ResourceKey) {
+func (t *dataplaneSyncTracker) OnProxyDisconnected(_ context.Context, _ core_xds.StreamID, dpKey core_model.ResourceKey) {
 	t.Lock()
 	defer t.Unlock()
 	if cancelFn := t.watchdogs[dpKey]; cancelFn != nil {

--- a/pkg/xds/server/v3/components.go
+++ b/pkg/xds/server/v3/components.go
@@ -59,7 +59,9 @@ func RegisterXDS(
 		util_xds_v3.AdaptCallbacks(authCallbacks),
 		util_xds_v3.AdaptCallbacks(xds_callbacks.DataplaneCallbacksToXdsCallbacks(xds_callbacks.NewDataplaneSyncTracker(watchdogFactory.New))),
 		util_xds_v3.AdaptCallbacks(xds_callbacks.DataplaneCallbacksToXdsCallbacks(metadataTracker)),
-		util_xds_v3.AdaptCallbacks(xds_callbacks.DataplaneCallbacksToXdsCallbacks(xds_callbacks.NewDataplaneLifecycle(rt.AppContext(), rt.ResourceManager(), authenticator))),
+		util_xds_v3.AdaptCallbacks(xds_callbacks.DataplaneCallbacksToXdsCallbacks(
+			xds_callbacks.NewDataplaneLifecycle(rt.AppContext(), rt.ResourceManager(), authenticator, rt.Config().XdsServer.DataplaneDeregistrationDelay, rt.GetInstanceId())),
+		),
 		util_xds_v3.AdaptCallbacks(DefaultDataplaneStatusTracker(rt, envoyCpCtx.Secrets)),
 		util_xds_v3.AdaptCallbacks(xds_callbacks.NewNackBackoff(rt.Config().XdsServer.NACKBackoff)),
 		newResourceWarmingForcer(xdsContext.Cache(), xdsContext.Hasher()),


### PR DESCRIPTION
### Summary

* Changed the status sink to flush when it's started so we can get an info that DP is connected to the CP without status flush interval delay.
* Introduced configuration of deregistration delay with 10s by default.

### Issues resolved

Fix #4616

### Documentation

~- [ ] Link to the website [documentation PR](https://github.com/kumahq/kuma-website/pull/XXX)~

### Testing

- [X] Unit tests
- ~[ ] E2E tests~ (no idea how to try to write test with this race)
- [X] Manual testing on Universal
- ~[ ] Manual testing on Kubernetes~

### Backwards compatibility

~- [ ] Update [`UPGRADE.md`](/UPGRADE.md) with any steps users will need to take when upgrading.~
~- [ ] Add `backport-to-stable` label if the code follows our [backporting policy](/CONTRIBUTING.md#backporting)~
