### PR TITLE
chore(kumactl): add a limit to the prom TSDB size

### DIFF
--- a/app/kumactl/cmd/install/testdata/install-observability.defaults.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-observability.defaults.golden.yaml
@@ -12417,6 +12417,7 @@ spec:
             - --web.console.libraries=/etc/prometheus/console_libraries
             - --web.console.templates=/etc/prometheus/consoles
             - --web.enable-lifecycle
+            - --storage.tsdb.retention.size=7GB
           ports:
             - containerPort: 9090
           resources:

--- a/app/kumactl/cmd/install/testdata/install-observability.no-grafana.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-observability.no-grafana.golden.yaml
@@ -618,6 +618,7 @@ spec:
             - --web.console.libraries=/etc/prometheus/console_libraries
             - --web.console.templates=/etc/prometheus/consoles
             - --web.enable-lifecycle
+            - --storage.tsdb.retention.size=7GB
           ports:
             - containerPort: 9090
           resources:

--- a/app/kumactl/cmd/install/testdata/install-observability.no-jaeger.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-observability.no-jaeger.golden.yaml
@@ -12417,6 +12417,7 @@ spec:
             - --web.console.libraries=/etc/prometheus/console_libraries
             - --web.console.templates=/etc/prometheus/consoles
             - --web.enable-lifecycle
+            - --storage.tsdb.retention.size=7GB
           ports:
             - containerPort: 9090
           resources:

--- a/app/kumactl/cmd/install/testdata/install-observability.no-loki.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-observability.no-loki.golden.yaml
@@ -12417,6 +12417,7 @@ spec:
             - --web.console.libraries=/etc/prometheus/console_libraries
             - --web.console.templates=/etc/prometheus/consoles
             - --web.enable-lifecycle
+            - --storage.tsdb.retention.size=7GB
           ports:
             - containerPort: 9090
           resources:

--- a/app/kumactl/cmd/install/testdata/install-observability.overrides.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-observability.overrides.golden.yaml
@@ -12417,6 +12417,7 @@ spec:
             - --web.console.libraries=/etc/prometheus/console_libraries
             - --web.console.templates=/etc/prometheus/consoles
             - --web.enable-lifecycle
+            - --storage.tsdb.retention.size=7GB
           ports:
             - containerPort: 9090
           resources:

--- a/app/kumactl/data/install/k8s/metrics/prometheus/server.yaml
+++ b/app/kumactl/data/install/k8s/metrics/prometheus/server.yaml
@@ -456,6 +456,7 @@ spec:
             - --web.console.libraries=/etc/prometheus/console_libraries
             - --web.console.templates=/etc/prometheus/consoles
             - --web.enable-lifecycle
+            - --storage.tsdb.retention.size=7GB
           ports:
             - containerPort: 9090
           resources:


### PR DESCRIPTION
We have a PVC of 8GB on prom and the data would grow without limit.
This would eventualy cause prometheus to run out of disk space and crash

This limits the data size using a prometheus commandline flag

Signed-off-by: Charly Molter <charly.molter@konghq.com>