### PR TITLE
fix(kuma-cp): external service datasource validation

### DIFF
--- a/pkg/core/resources/apis/mesh/external_service_validator.go
+++ b/pkg/core/resources/apis/mesh/external_service_validator.go
@@ -8,6 +8,7 @@ import (
 	"github.com/asaskevich/govalidator"
 
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
+	"github.com/kumahq/kuma/pkg/core/resources/apis/system"
 	"github.com/kumahq/kuma/pkg/core/validators"
 )
 
@@ -44,6 +45,9 @@ func validateExternalServiceNetworking(networking *mesh_proto.ExternalService_Ne
 	if networking.GetTls().GetServerName() != nil && networking.GetTls().GetServerName().GetValue() == "" {
 		err.AddViolationAt(path.Field("tls").Field("serverName"), "cannot be empty")
 	}
+	err.Add(system.ValidateDataSource(path.Field("tls").Field("caCert"), networking.GetTls().GetCaCert()))
+	err.Add(system.ValidateDataSource(path.Field("tls").Field("clientCert"), networking.GetTls().GetClientCert()))
+	err.Add(system.ValidateDataSource(path.Field("tls").Field("clientKey"), networking.GetTls().GetClientKey()))
 	return err
 }
 

--- a/pkg/core/resources/apis/mesh/external_service_validator_test.go
+++ b/pkg/core/resources/apis/mesh/external_service_validator_test.go
@@ -304,6 +304,32 @@ var _ = Describe("ExternalService", func() {
                 - field: tags["invalidTagValue"]
                   message: tag value must consist of alphanumeric characters, dots, dashes and underscores`,
 		}),
+		Entry("tls: empty inline cert", testCase{
+			dataplane: `
+                type: ExternalService
+                name: es-1
+                mesh: default
+                tags:
+                  kuma.io/service: backend
+                networking:
+                  address: 192.168.0.1:8080
+                  tls:
+                    enabled: true
+                    caCert:
+                      inline: ""
+                    clientCert:
+                      inlineString: ""
+                    clientKey:
+                      secret: ""`,
+			expected: `
+                violations:
+                - field: networking.tls.caCert
+                  message: data source cannot be empty
+                - field: networking.tls.clientCert
+                  message: data source cannot be empty
+                - field: networking.tls.clientKey
+                  message: data source cannot be empty`,
+		}),
 	)
 
 })

--- a/pkg/core/resources/apis/system/validators.go
+++ b/pkg/core/resources/apis/system/validators.go
@@ -1,0 +1,17 @@
+package system
+
+import (
+	system_proto "github.com/kumahq/kuma/api/system/v1alpha1"
+	"github.com/kumahq/kuma/pkg/core/validators"
+)
+
+func ValidateDataSource(path validators.PathBuilder, ds *system_proto.DataSource) validators.ValidationError {
+	verr := validators.ValidationError{}
+	if ds == nil {
+		return verr
+	}
+	if len(ds.GetInline().GetValue()) == 0 && ds.GetInlineString() == "" && ds.GetSecret() == "" && ds.GetFile() == "" {
+		verr.AddViolationAt(path, "data source cannot be empty")
+	}
+	return verr
+}

--- a/pkg/xds/topology/outbound.go
+++ b/pkg/xds/topology/outbound.go
@@ -5,6 +5,8 @@ import (
 	"net"
 	"strconv"
 
+	"github.com/pkg/errors"
+
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	"github.com/kumahq/kuma/api/system/v1alpha1"
 	"github.com/kumahq/kuma/pkg/core"
@@ -468,11 +470,24 @@ func NewExternalServiceEndpoint(
 		tags[tag] = value
 	}
 
+	caCert, err := loadBytes(tls.GetCaCert(), meshName, loader)
+	if err != nil {
+		return nil, errors.Wrap(err, "could not load caCert")
+	}
+	clientCert, err := loadBytes(tls.GetClientCert(), meshName, loader)
+	if err != nil {
+		return nil, errors.Wrap(err, "could not load clientCert")
+	}
+	clientKey, err := loadBytes(tls.GetClientKey(), meshName, loader)
+	if err != nil {
+		return nil, errors.Wrap(err, "could not load clientKey")
+	}
+
 	es := &core_xds.ExternalService{
 		TLSEnabled:         tls.GetEnabled(),
-		CaCert:             convertToEnvoy(tls.GetCaCert(), meshName, loader),
-		ClientCert:         convertToEnvoy(tls.GetClientCert(), meshName, loader),
-		ClientKey:          convertToEnvoy(tls.GetClientKey(), meshName, loader),
+		CaCert:             caCert,
+		ClientCert:         clientCert,
+		ClientKey:          clientKey,
 		AllowRenegotiation: tls.GetAllowRenegotiation().GetValue(),
 		ServerName:         tls.GetServerName().GetValue(),
 	}
@@ -499,18 +514,11 @@ func NewExternalServiceEndpoint(
 	}, nil
 }
 
-func convertToEnvoy(ds *v1alpha1.DataSource, mesh string, loader datasource.Loader) []byte {
+func loadBytes(ds *v1alpha1.DataSource, mesh string, loader datasource.Loader) ([]byte, error) {
 	if ds == nil {
-		return nil
+		return nil, nil
 	}
-
-	data, err := loader.Load(context.Background(), mesh, ds)
-	if err != nil {
-		core.Log.Error(err, "failed to resolve ingress's public name, skipping dataplane")
-		return nil
-	}
-
-	return data
+	return loader.Load(context.Background(), mesh, ds)
 }
 
 func localityFromTags(mesh *core_mesh.MeshResource, priority uint32, tags map[string]string) *core_xds.Locality {

--- a/test/e2e/externalservices/externalservices_multizone_universal.go
+++ b/test/e2e/externalservices/externalservices_multizone_universal.go
@@ -136,7 +136,6 @@ routing:
 	})
 
 	It("should route to external-service", func() {
-
 		err := ResourceUniversal(externalServiceRes(es1, "kuma-3_externalservice-http-server:80", false, nil))(global)
 		Expect(err).ToNot(HaveOccurred())
 

--- a/test/e2e/externalservices/externalservices_multizone_universal.go
+++ b/test/e2e/externalservices/externalservices_multizone_universal.go
@@ -6,8 +6,13 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"google.golang.org/protobuf/types/known/wrapperspb"
 
+	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
+	system_proto "github.com/kumahq/kuma/api/system/v1alpha1"
 	"github.com/kumahq/kuma/pkg/config/core"
+	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
+	test_model "github.com/kumahq/kuma/pkg/test/resources/model"
 	. "github.com/kumahq/kuma/test/framework"
 	. "github.com/kumahq/kuma/test/framework/client"
 	"github.com/kumahq/kuma/test/framework/deployments/externalservice"
@@ -29,22 +34,39 @@ routing:
   localityAwareLoadBalancing: %s
 `
 
-	externalService := `
-type: ExternalService
-mesh: default
-name: external-service-%s
-tags:
-  kuma.io/service: external-service-%s
-  kuma.io/protocol: http
-networking:
-  address: %s
-  tls:
-    enabled: %s
-    caCert:
-      inline: "%s"
-`
-	es1 := "1"
-	es2 := "2"
+	externalServiceRes := func(service, address string, tls bool, caCert []byte) *core_mesh.ExternalServiceResource {
+		res := &core_mesh.ExternalServiceResource{
+			Meta: &test_model.ResourceMeta{
+				Mesh: "default",
+				Name: service,
+			},
+			Spec: &mesh_proto.ExternalService{
+				Tags: map[string]string{
+					mesh_proto.ServiceTag:  service,
+					mesh_proto.ProtocolTag: core_mesh.ProtocolHTTP,
+				},
+				Networking: &mesh_proto.ExternalService_Networking{
+					Address: address,
+					Tls: &mesh_proto.ExternalService_Networking_TLS{
+						Enabled: tls,
+					},
+				},
+			},
+		}
+		if tls {
+			res.Spec.Networking.Tls.CaCert = &system_proto.DataSource{
+				Type: &system_proto.DataSource_Inline{
+					Inline: &wrapperspb.BytesValue{
+						Value: caCert,
+					},
+				},
+			}
+		}
+		return res
+	}
+
+	es1 := "external-service-1"
+	es2 := "external-service-2"
 
 	const defaultMesh = "default"
 
@@ -114,10 +136,8 @@ networking:
 	})
 
 	It("should route to external-service", func() {
-		err := YamlUniversal(fmt.Sprintf(externalService,
-			es1, es1,
-			"kuma-3_externalservice-http-server:80",
-			"false", ""))(global)
+
+		err := ResourceUniversal(externalServiceRes(es1, "kuma-3_externalservice-http-server:80", false, nil))(global)
 		Expect(err).ToNot(HaveOccurred())
 
 		stdout, _, err := zone1.ExecWithRetries("", "", "demo-client",
@@ -148,11 +168,8 @@ networking:
 	It("should route to external-service over tls", func() {
 		// when set invalid certificate
 		otherCert := "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURMRENDQWhTZ0F3SUJBZ0lRSGRQaHhPZlhnV3VOeG9GbFYvRXdxVEFOQmdrcWhraUc5dzBCQVFzRkFEQVAKTVEwd0N3WURWUVFERXdScmRXMWhNQjRYRFRJd01Ea3hOakV5TWpnME5Gb1hEVE13TURreE5ERXlNamcwTkZvdwpEekVOTUFzR0ExVUVBeE1FYTNWdFlUQ0NBU0l3RFFZSktvWklodmNOQVFFQkJRQURnZ0VQQURDQ0FRb0NnZ0VCCkFPWkdiV2hTbFFTUnhGTnQ1cC8yV0NLRnlIWjNDdXdOZ3lMRVA3blM0Wlh5a3hzRmJZU3VWM2JJZ0Y3YlQvdXEKYTVRaXJlK0M2MGd1aEZicExjUGgyWjZVZmdJZDY5R2xRekhNVlljbUxHalZRdXlBdDRGTU1rVGZWRWw1STRPYQorMml0M0J2aWhWa0toVXo4eTVSUjVLYnFKZkdwNFoyMEZoNmZ0dG9DRmJlT0RtdkJzWUpGbVVRUytpZm95TVkvClAzUjAzU3U3ZzVpSXZuejd0bWt5ZG9OQzhuR1JEemRENUM4Zkp2clZJMVVYNkpSR3lMS3Q0NW9RWHQxbXhLMTAKNUthTjJ6TlYyV3RIc2FKcDlid3JQSCtKaVpHZVp5dnVoNVV3ckxkSENtcUs3c205VG9kR3p0VVpZMFZ6QWM0cQprWVZpWFk4Z1VqZk5tK2NRclBPMWtOOENBd0VBQWFPQmd6Q0JnREFPQmdOVkhROEJBZjhFQkFNQ0FxUXdIUVlEClZSMGxCQll3RkFZSUt3WUJCUVVIQXdFR0NDc0dBUVVGQndNQk1BOEdBMVVkRXdFQi93UUZNQU1CQWY4d0hRWUQKVlIwT0JCWUVGR01EQlBQaUJGSjNtdjJvQTlDVHFqZW1GVFYyTUI4R0ExVWRFUVFZTUJhQ0NXeHZZMkZzYUc5egpkSUlKYkc5allXeG9iM04wTUEwR0NTcUdTSWIzRFFFQkN3VUFBNElCQVFDLzE3UXdlT3BHZGIxTUVCSjhYUEc3CjNzSy91dG9XTFgxdGpmOFN1MURnYTZDRFQvZVRXSFpyV1JmODFLT1ZZMDdkbGU1U1JJREsxUWhmYkdHdEZQK1QKdlprcm9vdXNJOVVTMmFDV2xrZUNaV0dUbnF2TG1Eb091anFhZ0RvS1JSdWs0bVFkdE5Ob254aUwvd1p0VEZLaQorMWlOalVWYkxXaURYZEJMeG9SSVZkTE96cWIvTU54d0VsVXlhVERBa29wUXlPV2FURGtZUHJHbWFXamNzZlBHCmFPS293MHplK3pIVkZxVEhiam5DcUVWM2huc1V5UlV3c0JsbjkrakRKWGd3Wk0vdE1sVkpyWkNoMFNsZTlZNVoKTU9CMGZDZjZzVE1OUlRHZzVMcGw2dUlZTS81SU5wbUhWTW8zbjdNQlNucEVEQVVTMmJmL3VvNWdJaXE2WENkcAotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg=="
-		err := YamlUniversal(fmt.Sprintf(externalService,
-			es2, es2,
-			"kuma-3_externalservice-https-server:443",
-			"true",
-			otherCert))(global)
+		cert, _ := base64.StdEncoding.DecodeString(otherCert)
+		err := ResourceUniversal(externalServiceRes(es2, "kuma-3_externalservice-https-server:443", true, cert))(global)
 		Expect(err).ToNot(HaveOccurred())
 
 		// then accessing the secured external service fails
@@ -164,11 +181,7 @@ networking:
 		externalServiceCaCert := externalservice.From(external, externalservice.HttpsServer).GetCert()
 		Expect(externalServiceCaCert).ToNot(BeEmpty())
 
-		err = YamlUniversal(fmt.Sprintf(externalService,
-			es2, es2,
-			"kuma-3_externalservice-https-server:443",
-			"true",
-			base64.StdEncoding.EncodeToString([]byte(externalServiceCaCert))))(global)
+		err = ResourceUniversal(externalServiceRes(es2, "kuma-3_externalservice-https-server:443", true, []byte(externalServiceCaCert)))(global)
 		Expect(err).ToNot(HaveOccurred())
 
 		// then accessing the secured external service succeeds

--- a/test/e2e/zoneegress/externalservices/zoneegress_externalservices_universal.go
+++ b/test/e2e/zoneegress/externalservices/zoneegress_externalservices_universal.go
@@ -31,16 +31,12 @@ routing:
 	externalService := `
 type: ExternalService
 mesh: default
-name: external-service-%s
+name: external-service-1
 tags:
-  kuma.io/service: external-service-%s
+  kuma.io/service: external-service-1
   kuma.io/protocol: http
 networking:
-  address: %s
-  tls:
-    enabled: %s
-    caCert:
-      inline: "%s"
+  address: "kuma-3_externalservice-http-server:80"
 `
 
 	var cluster Cluster
@@ -86,10 +82,7 @@ networking:
 			"external-service-1",
 		)
 
-		err := YamlUniversal(fmt.Sprintf(externalService,
-			"1", "1",
-			"kuma-3_externalservice-http-server:80",
-			"false", ""))(cluster)
+		err := YamlUniversal(externalService)(cluster)
 		Expect(err).ToNot(HaveOccurred())
 
 		Eventually(func(g Gomega) {
@@ -123,10 +116,7 @@ networking:
 		)
 
 		// when external service configuration is provided
-		err := YamlUniversal(fmt.Sprintf(externalService,
-			"1", "1",
-			"kuma-3_externalservice-http-server:80",
-			"false", ""))(cluster)
+		err := YamlUniversal(externalService)(cluster)
 		Expect(err).ToNot(HaveOccurred())
 
 		// then should reach external service

--- a/test/framework/setup.go
+++ b/test/framework/setup.go
@@ -20,6 +20,8 @@ import (
 	k8sjson "k8s.io/apimachinery/pkg/runtime/serializer/json"
 
 	"github.com/kumahq/kuma/pkg/config/core"
+	"github.com/kumahq/kuma/pkg/core/resources/model"
+	core_rest "github.com/kumahq/kuma/pkg/core/resources/model/rest"
 	bootstrap_k8s "github.com/kumahq/kuma/pkg/plugins/bootstrap/k8s"
 	"github.com/kumahq/kuma/pkg/tls"
 )
@@ -141,6 +143,26 @@ func YamlUniversal(yaml string) InstallFunc {
 			func() (s string, err error) {
 				kumactl := cluster.GetKumactlOptions()
 				return "", kumactl.KumactlApplyFromString(yaml)
+			})
+		return err
+	}
+}
+
+func ResourceUniversal(resource model.Resource) InstallFunc {
+	return func(cluster Cluster) error {
+		_, err := retry.DoWithRetryE(cluster.GetTesting(), "install resource", DefaultRetries, DefaultTimeout,
+			func() (s string, err error) {
+				kumactl := cluster.GetKumactlOptions()
+
+				json, err := core_rest.From.Resource(resource).MarshalJSON()
+				if err != nil {
+					return "", err
+				}
+				yaml, err := yaml.JSONToYAML(json)
+				if err != nil {
+					return "", err
+				}
+				return "", kumactl.KumactlApplyFromString(string(yaml))
 			})
 		return err
 	}


### PR DESCRIPTION
### Summary

### Full changelog

* Remove misleading log and return an error
* Validate external service better to eliminate the case when we can fall into this error
* Fix E2E test to not set invalid external service (empty caCert.inline)

### Issues resolved

Noticed while debugging other things.

### Documentation

~- [ ] Link to the website [documentation PR](https://github.com/kumahq/kuma-website/pull/XXX)~

### Testing

- [X] Unit tests
- [X] E2E tests
- ~[ ] Manual testing on Universal~
- ~[ ] Manual testing on Kubernetes~

### Backwards compatibility

~- [ ] Update [`UPGRADE.md`](/UPGRADE.md) with any steps users will need to take when upgrading.~
~- [ ] Add `backport-to-stable` label if the code follows our [backporting policy](/CONTRIBUTING.md#backporting)~
