### PR TITLE
fix(kuma-cp): don't tar up ./

### DIFF
--- a/tools/releases/distros.sh
+++ b/tools/releases/distros.sh
@@ -53,7 +53,8 @@ function create_kumactl_tarball() {
   make GOOS="$system" GOARCH="$arch" build/kumactl
 
   local dest_dir=build/$RELEASE_NAME-$arch
-  local kuma_dir=$dest_dir/$RELEASE_NAME-$KUMA_VERSION
+  local kuma_subdir="$RELEASE_NAME-$KUMA_VERSION"
+  local kuma_dir=$dest_dir/$kuma_subdir
 
   rm -rf "$dest_dir"
   mkdir "$dest_dir"
@@ -68,7 +69,7 @@ function create_kumactl_tarball() {
 
   archive_path=$(archive_path "$arch" "$system")
 
-  tar -czf "${archive_path}" -C "$dest_dir" .
+  tar -czf "${archive_path}" -C "$dest_dir" "$kuma_subdir"
 }
 
 function create_tarball() {
@@ -83,7 +84,8 @@ function create_tarball() {
   make GOOS="$system" GOARCH="$arch" build
 
   local dest_dir=build/$RELEASE_NAME-$distro-$arch
-  local kuma_dir=$dest_dir/$RELEASE_NAME-$KUMA_VERSION
+  local kuma_subdir="$RELEASE_NAME-$KUMA_VERSION"
+  local kuma_dir=$dest_dir/$kuma_subdir
 
   rm -rf "$dest_dir"
   mkdir "$dest_dir"
@@ -107,7 +109,7 @@ function create_tarball() {
 
   archive_path=$(archive_path "$arch" "$system" "$distro")
 
-  tar -czf "${archive_path}" -C "$dest_dir" .
+  tar -czf "${archive_path}" -C "$dest_dir" "$kuma_subdir"
 }
 
 function package() {


### PR DESCRIPTION
Signed-off-by: Paul Parkanzky <paul.parkanzky@konghq.com>

### Summary

We were including the `./` dir in the distro tgz files, which was causing problems. This tars up the appropriate dirs now.

Results like this:

```
% tar -tzf .//build/artifacts-darwin-amd64/kuma-0.0.0-preview.2e025c981-darwin-amd64.tar.gz
kuma-0.0.0-preview.2e025c981/
kuma-0.0.0-preview.2e025c981/LICENSE
kuma-0.0.0-preview.2e025c981/bin/
kuma-0.0.0-preview.2e025c981/README
kuma-0.0.0-preview.2e025c981/NOTICE
kuma-0.0.0-preview.2e025c981/NOTICE-kumactl
kuma-0.0.0-preview.2e025c981/conf/
kuma-0.0.0-preview.2e025c981/conf/kuma-cp.conf.yml
kuma-0.0.0-preview.2e025c981/bin/kuma-cp
kuma-0.0.0-preview.2e025c981/bin/kumactl
kuma-0.0.0-preview.2e025c981/bin/kuma-prometheus-sd
kuma-0.0.0-preview.2e025c981/bin/envoy
kuma-0.0.0-preview.2e025c981/bin/kuma-dp
kuma-0.0.0-preview.2e025c981/bin/coredns
```


### Testing

- [ ] Unit tests
- [ ] E2E tests
- [x] Manual testing on Universal
- [ ] Manual testing on Kubernetes

### Backwards compatibility

- [ ] Update [`UPGRADE.md`](/UPGRADE.md) with any steps users will need to take when upgrading.
- [ ] Add `backport-to-stable` label if the code follows our [backporting policy](/CONTRIBUTING.md#backporting)
