### PR TITLE
chore: update kuma universal image to ubuntu 22.04

### DIFF
--- a/test/dockerfiles/Dockerfile.universal
+++ b/test/dockerfiles/Dockerfile.universal
@@ -1,5 +1,5 @@
 ARG BASE_IMAGE_ARCH
-FROM --platform=linux/${BASE_IMAGE_ARCH} ubuntu:21.04
+FROM --platform=linux/${BASE_IMAGE_ARCH} ubuntu:22.04
 
 RUN mkdir /kuma
 RUN echo "# use this file to override default configuration of \`kuma-cp\`" > /kuma/kuma-cp.conf \


### PR DESCRIPTION
Signed-off-by: slonka <slonka@users.noreply.github.com>

### Summary

Ubuntu 21.04 is no longer maintained (see: https://ubuntu.com/about/release-cycle) and the build is failing with:

```
E: The repository 'http://security.ubuntu.com/ubuntu hirsute-security Release' does not have a Release file.
N: Updating from such a repository can't be done securely, and is therefore disabled by default.
```

I'm updating it to 22.04 which is LTS release supported until 2032.

### Full changelog

* Fix kuma-universal image building 

### Issues resolved

Not reported yet.

### Documentation

~~- [ ] Link to the website [documentation PR](https://github.com/kumahq/kuma-website/pull/XXX)~~

### Testing

~~- [ ] Unit tests~~
~~- [ ] E2E tests~~
~~- [ ] Manual testing on Universal~~
~~- [ ] Manual testing on Kubernetes~~

### Backwards compatibility

~~- [ ] Update [`UPGRADE.md`](/UPGRADE.md) with any steps users will need to take when upgrading.~~
~~- [ ] Add `backport-to-stable` label if the code follows our [backporting policy](/CONTRIBUTING.md#backporting)~~
