### PR TITLE
chore(deps): use github.com/emicklei/go-restful/v3

### DIFF
--- a/app/kumactl/pkg/tokens/client_test.go
+++ b/app/kumactl/pkg/tokens/client_test.go
@@ -7,7 +7,7 @@ import (
 	"net/http/httptest"
 	"time"
 
-	"github.com/emicklei/go-restful"
+	"github.com/emicklei/go-restful/v3"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 

--- a/app/kumactl/pkg/tokens/zone_client_test.go
+++ b/app/kumactl/pkg/tokens/zone_client_test.go
@@ -7,7 +7,7 @@ import (
 	"net/http/httptest"
 	"time"
 
-	"github.com/emicklei/go-restful"
+	"github.com/emicklei/go-restful/v3"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 

--- a/app/kumactl/pkg/tokens/zoneingress_client_test.go
+++ b/app/kumactl/pkg/tokens/zoneingress_client_test.go
@@ -7,7 +7,7 @@ import (
 	"net/http/httptest"
 	"time"
 
-	"github.com/emicklei/go-restful"
+	"github.com/emicklei/go-restful/v3"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/cncf/xds/go v0.0.0-20211130200136-a8f946100490
 	github.com/containernetworking/cni v0.8.1
 	github.com/containernetworking/plugins v0.9.1
-	github.com/emicklei/go-restful v2.15.0+incompatible
+	github.com/emicklei/go-restful/v3 v3.9.0
 	github.com/envoyproxy/go-control-plane v0.10.2-0.20220325020618-49ff273808a1
 	github.com/envoyproxy/protoc-gen-validate v0.6.7
 	github.com/evanphx/json-patch/v5 v5.6.0
@@ -103,6 +103,7 @@ require (
 	github.com/docker/docker v20.10.13+incompatible // indirect
 	github.com/docker/go-connections v0.4.0 // indirect
 	github.com/docker/go-units v0.4.0 // indirect
+	github.com/emicklei/go-restful v2.15.0+incompatible // indirect
 	github.com/evanphx/json-patch v4.12.0+incompatible // indirect
 	github.com/fatih/color v1.13.0 // indirect
 	github.com/fsnotify/fsnotify v1.5.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -479,6 +479,8 @@ github.com/emicklei/go-restful v0.0.0-20170410110728-ff4f55a20633/go.mod h1:otzb
 github.com/emicklei/go-restful v2.9.5+incompatible/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
 github.com/emicklei/go-restful v2.15.0+incompatible h1:8KpYO/Xl/ZudZs5RNOEhWMBY4hmzlZhhRd9cu+jrZP4=
 github.com/emicklei/go-restful v2.15.0+incompatible/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
+github.com/emicklei/go-restful/v3 v3.9.0 h1:XwGDlfxEnQZzuopoqxwSEllNcCOM9DhhFyhFIIGKwxE=
+github.com/emicklei/go-restful/v3 v3.9.0/go.mod h1:6n3XBCmQQb25CM2LCACGz8ukIrRry+4bhvbpWn3mrbc=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/envoyproxy/protoc-gen-validate v0.6.2/go.mod h1:2t7qjJNvHPx8IjnBOzl9E9/baC+qXE/TeeyBRzgJDws=
 github.com/envoyproxy/protoc-gen-validate v0.6.7 h1:qcZcULcd/abmQg6dwigimCNEyi4gg31M/xaciQlDml8=

--- a/pkg/api-server/authn/authenticator.go
+++ b/pkg/api-server/authn/authenticator.go
@@ -1,7 +1,7 @@
 package authn
 
 import (
-	"github.com/emicklei/go-restful"
+	"github.com/emicklei/go-restful/v3"
 )
 
 type Authenticator = restful.FilterFunction

--- a/pkg/api-server/authn/localhost.go
+++ b/pkg/api-server/authn/localhost.go
@@ -3,7 +3,7 @@ package authn
 import (
 	"net"
 
-	"github.com/emicklei/go-restful"
+	"github.com/emicklei/go-restful/v3"
 
 	"github.com/kumahq/kuma/pkg/core"
 	rest_errors "github.com/kumahq/kuma/pkg/core/rest/errors"

--- a/pkg/api-server/config_ws.go
+++ b/pkg/api-server/config_ws.go
@@ -1,7 +1,7 @@
 package api_server
 
 import (
-	"github.com/emicklei/go-restful"
+	"github.com/emicklei/go-restful/v3"
 
 	"github.com/kumahq/kuma/pkg/config"
 )

--- a/pkg/api-server/customization/api_manager.go
+++ b/pkg/api-server/customization/api_manager.go
@@ -1,7 +1,7 @@
 package customization
 
 import (
-	"github.com/emicklei/go-restful"
+	"github.com/emicklei/go-restful/v3"
 )
 
 type APIInstaller interface {

--- a/pkg/api-server/customization/api_manager_test.go
+++ b/pkg/api-server/customization/api_manager_test.go
@@ -6,7 +6,7 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/emicklei/go-restful"
+	"github.com/emicklei/go-restful/v3"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 

--- a/pkg/api-server/dataplane_overview_endpoints.go
+++ b/pkg/api-server/dataplane_overview_endpoints.go
@@ -5,7 +5,7 @@ import (
 	"reflect"
 	"strings"
 
-	"github.com/emicklei/go-restful"
+	"github.com/emicklei/go-restful/v3"
 
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	"github.com/kumahq/kuma/pkg/core/resources/access"

--- a/pkg/api-server/global_insights_endpoints.go
+++ b/pkg/api-server/global_insights_endpoints.go
@@ -4,7 +4,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/emicklei/go-restful"
+	"github.com/emicklei/go-restful/v3"
 
 	"github.com/kumahq/kuma/pkg/core"
 	"github.com/kumahq/kuma/pkg/core/resources/access"

--- a/pkg/api-server/index_endpoints.go
+++ b/pkg/api-server/index_endpoints.go
@@ -3,7 +3,7 @@ package api_server
 import (
 	"os"
 
-	"github.com/emicklei/go-restful"
+	"github.com/emicklei/go-restful/v3"
 
 	"github.com/kumahq/kuma/pkg/api-server/types"
 	kuma_version "github.com/kumahq/kuma/pkg/version"

--- a/pkg/api-server/inspect_endpoints.go
+++ b/pkg/api-server/inspect_endpoints.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"sort"
 
-	"github.com/emicklei/go-restful"
+	"github.com/emicklei/go-restful/v3"
 
 	api_server_types "github.com/kumahq/kuma/pkg/api-server/types"
 	kuma_cp "github.com/kumahq/kuma/pkg/config/app/kuma-cp"

--- a/pkg/api-server/inspect_envoy_admin_endpoints.go
+++ b/pkg/api-server/inspect_envoy_admin_endpoints.go
@@ -3,7 +3,7 @@ package api_server
 import (
 	"context"
 
-	"github.com/emicklei/go-restful"
+	"github.com/emicklei/go-restful/v3"
 
 	kuma_cp "github.com/kumahq/kuma/pkg/config/app/kuma-cp"
 	"github.com/kumahq/kuma/pkg/config/core"

--- a/pkg/api-server/pagination.go
+++ b/pkg/api-server/pagination.go
@@ -4,7 +4,7 @@ import (
 	"net/url"
 	"strconv"
 
-	"github.com/emicklei/go-restful"
+	"github.com/emicklei/go-restful/v3"
 
 	"github.com/kumahq/kuma/pkg/api-server/types"
 )

--- a/pkg/api-server/resource_endpoints.go
+++ b/pkg/api-server/resource_endpoints.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/emicklei/go-restful"
+	"github.com/emicklei/go-restful/v3"
 
 	config_core "github.com/kumahq/kuma/pkg/config/core"
 	"github.com/kumahq/kuma/pkg/core"

--- a/pkg/api-server/resource_endpoints_test.go
+++ b/pkg/api-server/resource_endpoints_test.go
@@ -6,7 +6,7 @@ import (
 	"io"
 	"net/http"
 
-	"github.com/emicklei/go-restful"
+	"github.com/emicklei/go-restful/v3"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 

--- a/pkg/api-server/server.go
+++ b/pkg/api-server/server.go
@@ -14,7 +14,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/emicklei/go-restful"
+	"github.com/emicklei/go-restful/v3"
 	"github.com/pkg/errors"
 	http_prometheus "github.com/slok/go-http-metrics/metrics/prometheus"
 	"github.com/slok/go-http-metrics/middleware"

--- a/pkg/api-server/service_insight_endpoints.go
+++ b/pkg/api-server/service_insight_endpoints.go
@@ -5,7 +5,7 @@ import (
 	"sort"
 	"strconv"
 
-	"github.com/emicklei/go-restful"
+	"github.com/emicklei/go-restful/v3"
 
 	"github.com/kumahq/kuma/api/mesh/v1alpha1"
 	"github.com/kumahq/kuma/pkg/core"

--- a/pkg/api-server/zone_overview_endpoints.go
+++ b/pkg/api-server/zone_overview_endpoints.go
@@ -3,7 +3,7 @@ package api_server
 import (
 	"context"
 
-	"github.com/emicklei/go-restful"
+	"github.com/emicklei/go-restful/v3"
 
 	system_proto "github.com/kumahq/kuma/api/system/v1alpha1"
 	"github.com/kumahq/kuma/pkg/core/resources/access"

--- a/pkg/api-server/zoneegressoverview_endpoints.go
+++ b/pkg/api-server/zoneegressoverview_endpoints.go
@@ -3,7 +3,7 @@ package api_server
 import (
 	"context"
 
-	"github.com/emicklei/go-restful"
+	"github.com/emicklei/go-restful/v3"
 
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	"github.com/kumahq/kuma/pkg/core/resources/access"

--- a/pkg/api-server/zoneingress_overview_endpoints.go
+++ b/pkg/api-server/zoneingress_overview_endpoints.go
@@ -3,7 +3,7 @@ package api_server
 import (
 	"context"
 
-	"github.com/emicklei/go-restful"
+	"github.com/emicklei/go-restful/v3"
 
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	"github.com/kumahq/kuma/pkg/core/resources/access"

--- a/pkg/api-server/zones_ws.go
+++ b/pkg/api-server/zones_ws.go
@@ -3,7 +3,7 @@ package api_server
 import (
 	"context"
 
-	"github.com/emicklei/go-restful"
+	"github.com/emicklei/go-restful/v3"
 
 	"github.com/kumahq/kuma/pkg/core/resources/apis/system"
 	"github.com/kumahq/kuma/pkg/core/resources/manager"

--- a/pkg/core/rest/errors/error_handler.go
+++ b/pkg/core/rest/errors/error_handler.go
@@ -3,7 +3,7 @@ package errors
 import (
 	"fmt"
 
-	"github.com/emicklei/go-restful"
+	"github.com/emicklei/go-restful/v3"
 	"github.com/pkg/errors"
 
 	api_server_types "github.com/kumahq/kuma/pkg/api-server/types"

--- a/pkg/mads/server/server.go
+++ b/pkg/mads/server/server.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/emicklei/go-restful"
+	"github.com/emicklei/go-restful/v3"
 	http_prometheus "github.com/slok/go-http-metrics/metrics/prometheus"
 	"github.com/slok/go-http-metrics/middleware"
 	"github.com/soheilhy/cmux"

--- a/pkg/mads/v1/service/http.go
+++ b/pkg/mads/v1/service/http.go
@@ -6,7 +6,7 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/emicklei/go-restful"
+	"github.com/emicklei/go-restful/v3"
 	v3 "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
 	cache_types "github.com/envoyproxy/go-control-plane/pkg/cache/types"
 	"github.com/golang/protobuf/jsonpb"

--- a/pkg/mads/v1/service_test.go
+++ b/pkg/mads/v1/service_test.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/emicklei/go-restful"
+	"github.com/emicklei/go-restful/v3"
 	envoy_core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	envoy_v3 "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
 	"github.com/go-logr/logr"

--- a/pkg/plugins/authn/api-server/certs/authenticator.go
+++ b/pkg/plugins/authn/api-server/certs/authenticator.go
@@ -1,7 +1,7 @@
 package certs
 
 import (
-	"github.com/emicklei/go-restful"
+	"github.com/emicklei/go-restful/v3"
 
 	"github.com/kumahq/kuma/pkg/core/user"
 )

--- a/pkg/plugins/authn/api-server/tokens/authenticator.go
+++ b/pkg/plugins/authn/api-server/tokens/authenticator.go
@@ -3,7 +3,7 @@ package tokens
 import (
 	"strings"
 
-	"github.com/emicklei/go-restful"
+	"github.com/emicklei/go-restful/v3"
 
 	"github.com/kumahq/kuma/pkg/api-server/authn"
 	"github.com/kumahq/kuma/pkg/core"

--- a/pkg/plugins/authn/api-server/tokens/ws/server/webservice.go
+++ b/pkg/plugins/authn/api-server/tokens/ws/server/webservice.go
@@ -4,7 +4,7 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/emicklei/go-restful"
+	"github.com/emicklei/go-restful/v3"
 
 	"github.com/kumahq/kuma/pkg/core"
 	"github.com/kumahq/kuma/pkg/core/rest/errors"

--- a/pkg/plugins/authn/api-server/tokens/ws/ws_test.go
+++ b/pkg/plugins/authn/api-server/tokens/ws/ws_test.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/emicklei/go-restful"
+	"github.com/emicklei/go-restful/v3"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 

--- a/pkg/tokens/builtin/server/webservice.go
+++ b/pkg/tokens/builtin/server/webservice.go
@@ -4,7 +4,7 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/emicklei/go-restful"
+	"github.com/emicklei/go-restful/v3"
 
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	"github.com/kumahq/kuma/pkg/core"

--- a/pkg/tokens/builtin/server/webservice_test.go
+++ b/pkg/tokens/builtin/server/webservice_test.go
@@ -11,7 +11,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/emicklei/go-restful"
+	"github.com/emicklei/go-restful/v3"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
@@ -35,8 +35,7 @@ func (s *staticTokenIssuer) Generate(context.Context, issuer.DataplaneIdentity, 
 	return s.resp, nil
 }
 
-type zoneIngressStaticTokenIssuer struct {
-}
+type zoneIngressStaticTokenIssuer struct{}
 
 var _ zoneingress.TokenIssuer = &zoneIngressStaticTokenIssuer{}
 
@@ -44,8 +43,7 @@ func (z *zoneIngressStaticTokenIssuer) Generate(ctx context.Context, identity zo
 	return fmt.Sprintf("token-for-%s", identity.Zone), nil
 }
 
-type zoneStaticTokenIssuer struct {
-}
+type zoneStaticTokenIssuer struct{}
 
 var _ zone.TokenIssuer = &zoneStaticTokenIssuer{}
 
@@ -54,7 +52,6 @@ func (z *zoneStaticTokenIssuer) Generate(ctx context.Context, identity zone.Iden
 }
 
 var _ = Describe("Dataplane Token Webservice", func() {
-
 	const credentials = "test"
 	var url string
 

--- a/pkg/util/prometheus/gorestful_middleware.go
+++ b/pkg/util/prometheus/gorestful_middleware.go
@@ -3,7 +3,7 @@ package prometheus
 import (
 	"context"
 
-	gorestful "github.com/emicklei/go-restful"
+	gorestful "github.com/emicklei/go-restful/v3"
 	"github.com/slok/go-http-metrics/middleware"
 )
 


### PR DESCRIPTION
### Summary

Use module version of github.com/emicklei/go-restful

### Testing

- [ ] Unit tests
- [ ] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes

### Backwards compatibility

- [ ] Update [`UPGRADE.md`](/UPGRADE.md) with any steps users will need to take when upgrading.
- [ ] Add `backport-to-stable` label if the code follows our [backporting policy](/CONTRIBUTING.md#backporting)


Signed-off-by: Matthieu MOREL <mmorel-35@users.noreply.github.com>