### PR TITLE
ci(test): fix flaky unit tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -454,112 +454,41 @@ workflows:
             parameters:
               arch: [ amd64, arm64 ]
           requires: [ check ]
-      # Run multiple runs of tests to see if they always succeed
-      - test:
-          name: test-<< matrix.arch >>
+      - e2e:
+          name: test/e2e-legacy-k8s:<< matrix.arch >>-<< matrix.k8sVersion >>
           matrix:
-            alias: test
+            alias: test/e2e-legacy
             parameters:
+              k8sVersion: [ v1.19.16-k3s1, v1.21.7-k3s1, kind, kindIpv6 ]
               arch: [ amd64, arm64 ]
-          requires: [ check ]
-      - test:
-          name: test-<< matrix.arch >>
+          parallelism: 8
+          target: test/e2e
+          requires: [ build-<< matrix.arch >>, check ]
+      - e2e:
+          name: << matrix.target >>:<< matrix.arch >>-<< matrix.k8sVersion >>
           matrix:
-            alias: test
+            alias: test/e2e
             parameters:
+              k8sVersion: [ v1.19.16-k3s1, v1.21.7-k3s1, kind, kindIpv6 ]
+              target: [ test/e2e-kubernetes, test/e2e-universal, test/e2e-multizone ]
               arch: [ amd64, arm64 ]
-          requires: [ check ]
-      - test:
-          name: test-<< matrix.arch >>
-          matrix:
-            alias: test
-            parameters:
-              arch: [ amd64, arm64 ]
-          requires: [ check ]
-      - test:
-          name: test-<< matrix.arch >>
-          matrix:
-            alias: test
-            parameters:
-              arch: [ amd64, arm64 ]
-          requires: [ check ]
-      - test:
-          name: test-<< matrix.arch >>
-          matrix:
-            alias: test
-            parameters:
-              arch: [ amd64, arm64 ]
-          requires: [ check ]
-      - test:
-          name: test-<< matrix.arch >>
-          matrix:
-            alias: test
-            parameters:
-              arch: [ amd64, arm64 ]
-          requires: [ check ]
-      - test:
-          name: test-<< matrix.arch >>
-          matrix:
-            alias: test
-            parameters:
-              arch: [ amd64, arm64 ]
-          requires: [ check ]
-      - test:
-          name: test-<< matrix.arch >>
-          matrix:
-            alias: test
-            parameters:
-              arch: [ amd64, arm64 ]
-          requires: [ check ]
-      - test:
-          name: test-<< matrix.arch >>
-          matrix:
-            alias: test
-            parameters:
-              arch: [ amd64, arm64 ]
-          requires: [ check ]
-      - test:
-          name: test-<< matrix.arch >>
-          matrix:
-            alias: test
-            parameters:
-              arch: [ amd64, arm64 ]
-          requires: [ check ]
-#      - e2e:
-#          name: test/e2e-legacy-k8s:<< matrix.arch >>-<< matrix.k8sVersion >>
-#          matrix:
-#            alias: test/e2e-legacy
-#            parameters:
-#              k8sVersion: [ v1.19.16-k3s1, v1.21.7-k3s1, kind, kindIpv6 ]
-#              arch: [ amd64, arm64 ]
-#          parallelism: 8
-#          target: test/e2e
-#          requires: [ build-<< matrix.arch >>, check ]
-#      - e2e:
-#          name: << matrix.target >>:<< matrix.arch >>-<< matrix.k8sVersion >>
-#          matrix:
-#            alias: test/e2e
-#            parameters:
-#              k8sVersion: [ v1.19.16-k3s1, v1.21.7-k3s1, kind, kindIpv6 ]
-#              target: [ test/e2e-kubernetes, test/e2e-universal, test/e2e-multizone ]
-#              arch: [ amd64, arm64 ]
-#          parallelism: 1
-#          requires: [ build-<< matrix.arch >>, check ]
-#      - release:
-#          # publish artifacts speculatively for normal commits
-#          filters: # only on master and release-* branches (never on PRs and tags)
-#            branches:
-#              only:
-#                - master
-#                - /^release-.*/
-#            tags:
-#              ignore: /.*/
-#          requires: [ build ]
-#      - release:
-#          # only publish tagged artifacts if everything passes
-#          filters: # only on tags
-#            branches:
-#              ignore: /.*/
-#            tags:
-#              only: /.*/
-#          requires: [ dev, test, test/e2e, test/e2e-legacy ]
+          parallelism: 1
+          requires: [ build-<< matrix.arch >>, check ]
+      - release:
+          # publish artifacts speculatively for normal commits
+          filters: # only on master and release-* branches (never on PRs and tags)
+            branches:
+              only:
+                - master
+                - /^release-.*/
+            tags:
+              ignore: /.*/
+          requires: [ build ]
+      - release:
+          # only publish tagged artifacts if everything passes
+          filters: # only on tags
+            branches:
+              ignore: /.*/
+            tags:
+              only: /.*/
+          requires: [ dev, test, test/e2e, test/e2e-legacy ]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -476,6 +476,55 @@ workflows:
             parameters:
               arch: [ amd64, arm64 ]
           requires: [ check ]
+      - test:
+          name: test-<< matrix.arch >>
+          matrix:
+            alias: test
+            parameters:
+              arch: [ amd64, arm64 ]
+          requires: [ check ]
+      - test:
+          name: test-<< matrix.arch >>
+          matrix:
+            alias: test
+            parameters:
+              arch: [ amd64, arm64 ]
+          requires: [ check ]
+      - test:
+          name: test-<< matrix.arch >>
+          matrix:
+            alias: test
+            parameters:
+              arch: [ amd64, arm64 ]
+          requires: [ check ]
+      - test:
+          name: test-<< matrix.arch >>
+          matrix:
+            alias: test
+            parameters:
+              arch: [ amd64, arm64 ]
+          requires: [ check ]
+      - test:
+          name: test-<< matrix.arch >>
+          matrix:
+            alias: test
+            parameters:
+              arch: [ amd64, arm64 ]
+          requires: [ check ]
+      - test:
+          name: test-<< matrix.arch >>
+          matrix:
+            alias: test
+            parameters:
+              arch: [ amd64, arm64 ]
+          requires: [ check ]
+      - test:
+          name: test-<< matrix.arch >>
+          matrix:
+            alias: test
+            parameters:
+              arch: [ amd64, arm64 ]
+          requires: [ check ]
 #      - e2e:
 #          name: test/e2e-legacy-k8s:<< matrix.arch >>-<< matrix.k8sVersion >>
 #          matrix:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -454,41 +454,63 @@ workflows:
             parameters:
               arch: [ amd64, arm64 ]
           requires: [ check ]
-      - e2e:
-          name: test/e2e-legacy-k8s:<< matrix.arch >>-<< matrix.k8sVersion >>
+      # Run multiple runs of tests to see if they always succeed
+      - test:
+          name: test-<< matrix.arch >>
           matrix:
-            alias: test/e2e-legacy
+            alias: test
             parameters:
-              k8sVersion: [ v1.19.16-k3s1, v1.21.7-k3s1, kind, kindIpv6 ]
               arch: [ amd64, arm64 ]
-          parallelism: 8
-          target: test/e2e
-          requires: [ build-<< matrix.arch >>, check ]
-      - e2e:
-          name: << matrix.target >>:<< matrix.arch >>-<< matrix.k8sVersion >>
+          requires: [ check ]
+      - test:
+          name: test-<< matrix.arch >>
           matrix:
-            alias: test/e2e
+            alias: test
             parameters:
-              k8sVersion: [ v1.19.16-k3s1, v1.21.7-k3s1, kind, kindIpv6 ]
-              target: [ test/e2e-kubernetes, test/e2e-universal, test/e2e-multizone ]
               arch: [ amd64, arm64 ]
-          parallelism: 1
-          requires: [ build-<< matrix.arch >>, check ]
-      - release:
-          # publish artifacts speculatively for normal commits
-          filters: # only on master and release-* branches (never on PRs and tags)
-            branches:
-              only:
-                - master
-                - /^release-.*/
-            tags:
-              ignore: /.*/
-          requires: [ build ]
-      - release:
-          # only publish tagged artifacts if everything passes
-          filters: # only on tags
-            branches:
-              ignore: /.*/
-            tags:
-              only: /.*/
-          requires: [ dev, test, test/e2e, test/e2e-legacy ]
+          requires: [ check ]
+      - test:
+          name: test-<< matrix.arch >>
+          matrix:
+            alias: test
+            parameters:
+              arch: [ amd64, arm64 ]
+          requires: [ check ]
+#      - e2e:
+#          name: test/e2e-legacy-k8s:<< matrix.arch >>-<< matrix.k8sVersion >>
+#          matrix:
+#            alias: test/e2e-legacy
+#            parameters:
+#              k8sVersion: [ v1.19.16-k3s1, v1.21.7-k3s1, kind, kindIpv6 ]
+#              arch: [ amd64, arm64 ]
+#          parallelism: 8
+#          target: test/e2e
+#          requires: [ build-<< matrix.arch >>, check ]
+#      - e2e:
+#          name: << matrix.target >>:<< matrix.arch >>-<< matrix.k8sVersion >>
+#          matrix:
+#            alias: test/e2e
+#            parameters:
+#              k8sVersion: [ v1.19.16-k3s1, v1.21.7-k3s1, kind, kindIpv6 ]
+#              target: [ test/e2e-kubernetes, test/e2e-universal, test/e2e-multizone ]
+#              arch: [ amd64, arm64 ]
+#          parallelism: 1
+#          requires: [ build-<< matrix.arch >>, check ]
+#      - release:
+#          # publish artifacts speculatively for normal commits
+#          filters: # only on master and release-* branches (never on PRs and tags)
+#            branches:
+#              only:
+#                - master
+#                - /^release-.*/
+#            tags:
+#              ignore: /.*/
+#          requires: [ build ]
+#      - release:
+#          # only publish tagged artifacts if everything passes
+#          filters: # only on tags
+#            branches:
+#              ignore: /.*/
+#            tags:
+#              only: /.*/
+#          requires: [ dev, test, test/e2e, test/e2e-legacy ]

--- a/pkg/api-server/api_server_suite_test.go
+++ b/pkg/api-server/api_server_suite_test.go
@@ -113,18 +113,20 @@ type testApiServerConfigurer struct {
 	store     store.ResourceStore
 	enableGui bool
 	config    *config_api_server.ApiServerConfig
-	metrics   core_metrics.Metrics
+	metrics   func() core_metrics.Metrics
 	zone      string
 	global    bool
 }
 
 func NewTestApiServerConfigurer() *testApiServerConfigurer {
-	m, _ := core_metrics.NewMetrics("Standalone")
 	return &testApiServerConfigurer{
 		enableGui: false,
-		metrics:   m,
-		config:    config_api_server.DefaultApiServerConfig(),
-		store:     memory.NewStore(),
+		metrics: func() core_metrics.Metrics {
+			m, _ := core_metrics.NewMetrics("Standalone")
+			return m
+		},
+		config: config_api_server.DefaultApiServerConfig(),
+		store:  memory.NewStore(),
 	}
 }
 
@@ -156,8 +158,9 @@ func (t *testApiServerConfigurer) WithStore(resourceStore store.ResourceStore) *
 	return t
 }
 
-func (t *testApiServerConfigurer) WithMetrics(metrics core_metrics.Metrics) *testApiServerConfigurer {
-	t.metrics = metrics
+// WithMetrics a function that creates metrics (needs to be a function as these can't be reused in case of failed startups)
+func (t *testApiServerConfigurer) WithMetrics(metricsFn func() core_metrics.Metrics) *testApiServerConfigurer {
+	t.metrics = metricsFn
 	return t
 }
 
@@ -222,7 +225,7 @@ func tryStartApiServer(t *testApiServerConfigurer) (*api_server.ApiServer, func(
 		append(registry.Global().ObjectDescriptors(model.HasWsEnabled()), sample_model.TrafficRouteResourceTypeDescriptor),
 		&cfg,
 		t.enableGui,
-		t.metrics,
+		t.metrics(),
 		func() string { return "instance-id" },
 		func() string { return "cluster-id" },
 		certs.ClientCertAuthenticator,

--- a/pkg/api-server/resource_endpoints_test.go
+++ b/pkg/api-server/resource_endpoints_test.go
@@ -33,10 +33,11 @@ var _ = Describe("Resource Endpoints", func() {
 
 	BeforeEach(func() {
 		resourceStore = store.NewPaginationStore(memory.NewStore())
-		m, err := core_metrics.NewMetrics("Standalone")
-		Expect(err).ToNot(HaveOccurred())
-		metrics = m
-		apiServer, stop = StartApiServer(NewTestApiServerConfigurer().WithStore(resourceStore).WithMetrics(m))
+		apiServer, stop = StartApiServer(NewTestApiServerConfigurer().WithStore(resourceStore).WithMetrics(func() core_metrics.Metrics {
+			m, _ := core_metrics.NewMetrics("Standalone")
+			metrics = m
+			return m
+		}))
 		client = resourceApiClient{
 			address: apiServer.Address(),
 			path:    "/meshes/" + mesh + "/sample-traffic-routes",

--- a/pkg/test/store/postgres/test_container.go
+++ b/pkg/test/store/postgres/test_container.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"math/rand"
 	"os"
 	"path"
+	"strconv"
 	"strings"
 
 	. "github.com/onsi/gomega"
@@ -43,7 +45,12 @@ func (v *PostgresContainer) Start() error {
 	if v.WithTLS {
 		mode = "tls"
 	}
+	uniqueId := strconv.Itoa(rand.Int())
 	buildArgs["MODE"] = &mode
+	// Add a uniqueId to make each image different, this was causing flakiness as test-container
+	// deletes the image that it builds unconditionally during teardown and fails if the image doesn't exist.
+	// In the case of parallel tests it's possible that the same image was used in multiple tests and the second teardown would fail.
+	buildArgs["UNIQUEID"] = &uniqueId
 	req := testcontainers.ContainerRequest{
 		FromDockerfile: testcontainers.FromDockerfile{
 			Context:   resourceDir(),

--- a/tools/postgres/Dockerfile
+++ b/tools/postgres/Dockerfile
@@ -1,4 +1,7 @@
 ARG MODE
+# With test-containers building the same image many times have race conditions when deleting the images
+# We therefore add a unique ID just to make images different
+ARG UNIQUEID
 FROM postgres:latest AS pg-tls
 COPY pg_hba.conf /var/lib/postgresql/pg_hba.conf
 COPY certs/rootCA.crt /var/lib/postgresql/rootCA.crt
@@ -10,3 +13,4 @@ CMD ["-c", "ssl=on", "-c", "ssl_cert_file=/var/lib/postgresql/postgres.server.cr
 FROM postgres:latest AS pg-standard
 
 FROM pg-${MODE}
+RUN echo ${UNIQUEID} /tmp/uniqueID


### PR DESCRIPTION
## Avoid duplicate metrics registration on server start failure

This was because if the server fails to bind we try it again with a different port.
Except that when we do this the metrics are already initialized which causes this issue

Example: https://app.circleci.com/pipelines/gh/kumahq/kuma/15380/workflows/fb9e1ebf-1388-4df1-a034-255a86800d25/jobs/186308
Error was: Sometimes tests would fail with: "duplicate metrics collector registration attempted"

## Avoid flaky postgres teardown:

Add a uniqueId to make each image different, this was causing flakiness as test-container
deletes the image that it builds unconditionally during teardown and fails if the image doesn't exist.
In the case of parallel tests it's possible that the same image was used in multiple tests and the second teardown would fail.

Example: https://app.circleci.com/pipelines/github/kumahq/kuma/15434/workflows/07c6c425-d6df-4b17-acbd-76bff91b1cb0/jobs/187787/tests#failed-test-0
Error was: "Error response from daemon: unrecognized image ID sha256:5bfef573fbb586e368b5a44f0733ed5f23376c2d34a5e399afcb4c5ad43f014b"

Signed-off-by: Charly Molter <charly.molter@konghq.com>
