### PR TITLE
fix(kuma-cp): don't deploy Pod/Service webhooks in global

### DIFF
--- a/app/kumactl/cmd/install/testdata/install-control-plane.global.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.global.golden.yaml
@@ -1936,7 +1936,7 @@ spec:
     metadata:
       annotations:
         checksum/config: 3a05a95096ec7248d5e43d50e181064206f451b7714554d2b64c8f5a37118bed
-        checksum/tls-secrets: eff536347c7cffd5ca2b354dcf6d4dc42efafc01d898d289a3663534fb5e61f9
+        checksum/tls-secrets: 9e47d42327f33bc8c2e67b10fea71cd7b73525e7bb4d11298ef25b5978695dc6
         
       labels: 
         app: kuma-control-plane
@@ -2127,69 +2127,6 @@ webhooks:
     
       
     sideEffects: None
-  - name: namespace-kuma-injector.kuma.io
-    admissionReviewVersions: ["v1"]
-    failurePolicy: Fail
-    namespaceSelector:
-      matchLabels:
-        kuma.io/sidecar-injection: enabled
-    clientConfig:
-      caBundle: XYZ
-      service:
-        namespace: kuma-system
-        name: kuma-control-plane
-        path: /inject-sidecar
-    rules:
-      - apiGroups:
-          - ""
-        apiVersions:
-          - v1
-        operations:
-          - CREATE
-        resources:
-          - pods
-    sideEffects: None
-  - name: pods-kuma-injector.kuma.io
-    admissionReviewVersions: ["v1"]
-    failurePolicy: Fail
-    objectSelector:
-      matchLabels:
-        kuma.io/sidecar-injection: enabled
-    clientConfig:
-      caBundle: XYZ
-      service:
-        namespace: kuma-system
-        name: kuma-control-plane
-        path: /inject-sidecar
-    rules:
-      - apiGroups:
-          - ""
-        apiVersions:
-          - v1
-        operations:
-          - CREATE
-        resources:
-          - pods
-    sideEffects: None
-  - name: kuma-injector.kuma.io
-    admissionReviewVersions: ["v1"]
-    failurePolicy: Ignore 
-    clientConfig:
-      caBundle: XYZ
-      service:
-        namespace: kuma-system
-        name: kuma-control-plane
-        path: /inject-sidecar
-    rules:
-      - apiGroups:
-          - ""
-        apiVersions:
-          - v1
-        operations:
-          - CREATE
-        resources:
-          - pods
-    sideEffects: None
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
@@ -2241,26 +2178,6 @@ webhooks:
           - containerpatches
     
       
-    sideEffects: None
-  - name: service.validator.kuma-admission.kuma.io
-    admissionReviewVersions: ["v1"]
-    failurePolicy: Ignore
-    clientConfig:
-      caBundle: XYZ
-      service:
-        namespace: kuma-system
-        name: kuma-control-plane
-        path: /validate-v1-service
-    rules:
-      - apiGroups:
-          - ""
-        apiVersions:
-          - v1
-        operations:
-          - CREATE
-          - UPDATE
-        resources:
-          - services
     sideEffects: None
   - name: secret.validator.kuma-admission.kuma.io
     admissionReviewVersions: ["v1"]

--- a/deployments/charts/kuma/templates/cp-webhooks-and-secrets.yaml
+++ b/deployments/charts/kuma/templates/cp-webhooks-and-secrets.yaml
@@ -107,6 +107,7 @@ webhooks:
           - virtualoutbounds
     {{ .Values.controlPlane.webhooks.ownerReference.additionalRules | nindent 6 }}
     sideEffects: None
+  {{- if ne .Values.controlPlane.mode "global" }}
   - name: namespace-kuma-injector.kuma.io
     admissionReviewVersions: ["v1"]
     failurePolicy: {{ .Values.controlPlane.injectorFailurePolicy }}
@@ -170,6 +171,7 @@ webhooks:
         resources:
           - pods
     sideEffects: None
+  {{- end }}
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
@@ -218,6 +220,7 @@ webhooks:
           - containerpatches
     {{ .Values.controlPlane.webhooks.validator.additionalRules | nindent 6 }}
     sideEffects: None
+  {{- if ne .Values.controlPlane.mode "global" }}
   - name: service.validator.kuma-admission.kuma.io
     admissionReviewVersions: ["v1"]
     failurePolicy: Ignore
@@ -238,6 +241,7 @@ webhooks:
         resources:
           - services
     sideEffects: None
+  {{- end }}
   - name: secret.validator.kuma-admission.kuma.io
     admissionReviewVersions: ["v1"]
     namespaceSelector:


### PR DESCRIPTION
### Summary

Is there a reason to keep them?