### PR TITLE
fix(helm): add containersecuritycontext to CNI daemonset

### DIFF
--- a/deployments/charts/kuma/templates/cni-daemonset.yaml
+++ b/deployments/charts/kuma/templates/cni-daemonset.yaml
@@ -59,6 +59,10 @@ spec:
           imagePullPolicy: Always
           command: ["/install-cni.sh"]
           {{- end }}
+          {{- if .Values.cni.containerSecurityContext }}
+          securityContext:
+          {{- toYaml .Values.cni.containerSecurityContext | trim | nindent 12 }}
+          {{- end }}
           env:
             # Name of the CNI config file to create.
             - name: CNI_CONF_NAME


### PR DESCRIPTION
### Checklist prior to review

- [X] Link to docs PR or issue -- no docs, value already in Values.yaml
- [X] Link to UI issue or PR -- no relation to UI
- [X] Is the [issue worked on linked][1]? -- https://github.com/kumahq/kuma/issues/4636
- [X] Unit Tests -- we don't unit test every single value
- [X] E2E Tests -- we don't test security context in e2e tests
- [X] Manual Universal Tests -- no needed
- [X] Manual Kubernetes Tests -- tested with helm template
- [X] Do you need to update [`UPGRADE.md`](/UPGRADE.md)? -- nothing to upgrade
- [X] Does it need to be backported according to the [backporting policy](/CONTRIBUTING.md#backporting)? -- we could but it does not qualify.

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
