### PR TITLE
chore(helm): remove duplicate keys in resources

### DIFF
--- a/app/kumactl/cmd/install/testdata/install-control-plane.with-egress.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.with-egress.golden.yaml
@@ -2102,10 +2102,8 @@ spec:
     metadata:
       annotations:
         kuma.io/egress: enabled
-      labels: 
+      labels:
         app: kuma-egress
-        app.kubernetes.io/name: kuma
-        app.kubernetes.io/instance: kuma
         app.kubernetes.io/name: kuma
         app.kubernetes.io/instance: kuma
     spec:

--- a/app/kumactl/cmd/install/testdata/install-control-plane.with-helm-set.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.with-helm-set.yaml
@@ -2141,10 +2141,8 @@ spec:
     metadata:
       annotations:
         kuma.io/egress: enabled
-      labels: 
+      labels:
         app: kuma-egress
-        app.kubernetes.io/name: kuma
-        app.kubernetes.io/instance: kuma
         app.kubernetes.io/name: kuma
         app.kubernetes.io/instance: kuma
     spec:
@@ -2260,10 +2258,8 @@ spec:
     metadata:
       annotations:
         kuma.io/ingress: enabled
-      labels: 
+      labels:
         app: kuma-ingress
-        app.kubernetes.io/name: kuma
-        app.kubernetes.io/instance: kuma
         app.kubernetes.io/name: kuma
         app.kubernetes.io/instance: kuma
     spec:

--- a/app/kumactl/cmd/install/testdata/install-control-plane.with-ingress.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.with-ingress.golden.yaml
@@ -2110,10 +2110,8 @@ spec:
     metadata:
       annotations:
         kuma.io/ingress: enabled
-      labels: 
+      labels:
         app: kuma-ingress
-        app.kubernetes.io/name: kuma
-        app.kubernetes.io/instance: kuma
         app.kubernetes.io/name: kuma
         app.kubernetes.io/instance: kuma
     spec:

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/fix4496.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/fix4496.golden.yaml
@@ -2122,11 +2122,9 @@ spec:
     metadata:
       annotations:
         kuma.io/ingress: enabled
-      labels: 
+      labels:
         app: kuma-ingress
         "foo": "bar"
-        app.kubernetes.io/name: kuma
-        app.kubernetes.io/instance: kuma
         app.kubernetes.io/name: kuma
         app.kubernetes.io/instance: kuma
     spec:

--- a/app/kumactl/cmd/install/testdata/install-observability.defaults.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-observability.defaults.golden.yaml
@@ -13236,9 +13236,6 @@ items:
         app.kubernetes.io/name: jaeger
         app.kubernetes.io/component: query
     spec:
-      selector:
-        matchLabels:
-          app: jaeger-query
       ports:
         - name: query-http
           port: 80
@@ -13258,9 +13255,6 @@ items:
         app.kubernetes.io/name: jaeger
         app.kubernetes.io/component: collector
     spec:
-      selector:
-        matchLabels:
-          app: jaeger-collector
       ports:
         - name: jaeger-collector-tchannel
           port: 14267
@@ -13288,9 +13282,6 @@ items:
         app.kubernetes.io/name: jaeger
         app.kubernetes.io/component: agent
     spec:
-      selector:
-        matchLabels:
-          app: jaeger-agent
       ports:
         - name: agent-zipkin-thrift
           port: 5775
@@ -13322,9 +13313,6 @@ items:
         app.kubernetes.io/name: jaeger
         app.kubernetes.io/component: zipkin
     spec:
-      selector:
-        matchLabels:
-          app: zipkin
       ports:
         - name: jaeger-collector-zipkin
           port: 9411

--- a/app/kumactl/cmd/install/testdata/install-observability.no-grafana.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-observability.no-grafana.golden.yaml
@@ -1472,9 +1472,6 @@ items:
         app.kubernetes.io/name: jaeger
         app.kubernetes.io/component: query
     spec:
-      selector:
-        matchLabels:
-          app: jaeger-query
       ports:
         - name: query-http
           port: 80
@@ -1494,9 +1491,6 @@ items:
         app.kubernetes.io/name: jaeger
         app.kubernetes.io/component: collector
     spec:
-      selector:
-        matchLabels:
-          app: jaeger-collector
       ports:
         - name: jaeger-collector-tchannel
           port: 14267
@@ -1524,9 +1518,6 @@ items:
         app.kubernetes.io/name: jaeger
         app.kubernetes.io/component: agent
     spec:
-      selector:
-        matchLabels:
-          app: jaeger-agent
       ports:
         - name: agent-zipkin-thrift
           port: 5775
@@ -1558,9 +1549,6 @@ items:
         app.kubernetes.io/name: jaeger
         app.kubernetes.io/component: zipkin
     spec:
-      selector:
-        matchLabels:
-          app: zipkin
       ports:
         - name: jaeger-collector-zipkin
           port: 9411

--- a/app/kumactl/cmd/install/testdata/install-observability.no-loki.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-observability.no-loki.golden.yaml
@@ -12520,9 +12520,6 @@ items:
         app.kubernetes.io/name: jaeger
         app.kubernetes.io/component: query
     spec:
-      selector:
-        matchLabels:
-          app: jaeger-query
       ports:
         - name: query-http
           port: 80
@@ -12542,9 +12539,6 @@ items:
         app.kubernetes.io/name: jaeger
         app.kubernetes.io/component: collector
     spec:
-      selector:
-        matchLabels:
-          app: jaeger-collector
       ports:
         - name: jaeger-collector-tchannel
           port: 14267
@@ -12572,9 +12566,6 @@ items:
         app.kubernetes.io/name: jaeger
         app.kubernetes.io/component: agent
     spec:
-      selector:
-        matchLabels:
-          app: jaeger-agent
       ports:
         - name: agent-zipkin-thrift
           port: 5775
@@ -12606,9 +12597,6 @@ items:
         app.kubernetes.io/name: jaeger
         app.kubernetes.io/component: zipkin
     spec:
-      selector:
-        matchLabels:
-          app: zipkin
       ports:
         - name: jaeger-collector-zipkin
           port: 9411

--- a/app/kumactl/cmd/install/testdata/install-observability.no-prometheus.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-observability.no-prometheus.golden.yaml
@@ -12568,9 +12568,6 @@ items:
         app.kubernetes.io/name: jaeger
         app.kubernetes.io/component: query
     spec:
-      selector:
-        matchLabels:
-          app: jaeger-query
       ports:
         - name: query-http
           port: 80
@@ -12590,9 +12587,6 @@ items:
         app.kubernetes.io/name: jaeger
         app.kubernetes.io/component: collector
     spec:
-      selector:
-        matchLabels:
-          app: jaeger-collector
       ports:
         - name: jaeger-collector-tchannel
           port: 14267
@@ -12620,9 +12614,6 @@ items:
         app.kubernetes.io/name: jaeger
         app.kubernetes.io/component: agent
     spec:
-      selector:
-        matchLabels:
-          app: jaeger-agent
       ports:
         - name: agent-zipkin-thrift
           port: 5775
@@ -12654,9 +12645,6 @@ items:
         app.kubernetes.io/name: jaeger
         app.kubernetes.io/component: zipkin
     spec:
-      selector:
-        matchLabels:
-          app: zipkin
       ports:
         - name: jaeger-collector-zipkin
           port: 9411

--- a/app/kumactl/cmd/install/testdata/install-observability.overrides.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-observability.overrides.golden.yaml
@@ -13236,9 +13236,6 @@ items:
         app.kubernetes.io/name: jaeger
         app.kubernetes.io/component: query
     spec:
-      selector:
-        matchLabels:
-          app: jaeger-query
       ports:
         - name: query-http
           port: 80
@@ -13258,9 +13255,6 @@ items:
         app.kubernetes.io/name: jaeger
         app.kubernetes.io/component: collector
     spec:
-      selector:
-        matchLabels:
-          app: jaeger-collector
       ports:
         - name: jaeger-collector-tchannel
           port: 14267
@@ -13288,9 +13282,6 @@ items:
         app.kubernetes.io/name: jaeger
         app.kubernetes.io/component: agent
     spec:
-      selector:
-        matchLabels:
-          app: jaeger-agent
       ports:
         - name: agent-zipkin-thrift
           port: 5775
@@ -13322,9 +13313,6 @@ items:
         app.kubernetes.io/name: jaeger
         app.kubernetes.io/component: zipkin
     spec:
-      selector:
-        matchLabels:
-          app: zipkin
       ports:
         - name: jaeger-collector-zipkin
           port: 9411

--- a/app/kumactl/cmd/install/testdata/install-tracing.defaults.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-tracing.defaults.golden.yaml
@@ -84,9 +84,6 @@ items:
         app.kubernetes.io/name: jaeger
         app.kubernetes.io/component: query
     spec:
-      selector:
-        matchLabels:
-          app: jaeger-query
       ports:
         - name: query-http
           port: 80
@@ -106,9 +103,6 @@ items:
         app.kubernetes.io/name: jaeger
         app.kubernetes.io/component: collector
     spec:
-      selector:
-        matchLabels:
-          app: jaeger-collector
       ports:
         - name: jaeger-collector-tchannel
           port: 14267
@@ -136,9 +130,6 @@ items:
         app.kubernetes.io/name: jaeger
         app.kubernetes.io/component: agent
     spec:
-      selector:
-        matchLabels:
-          app: jaeger-agent
       ports:
         - name: agent-zipkin-thrift
           port: 5775
@@ -170,9 +161,6 @@ items:
         app.kubernetes.io/name: jaeger
         app.kubernetes.io/component: zipkin
     spec:
-      selector:
-        matchLabels:
-          app: zipkin
       ports:
         - name: jaeger-collector-zipkin
           port: 9411

--- a/app/kumactl/cmd/install/testdata/install-tracing.overrides.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-tracing.overrides.golden.yaml
@@ -84,9 +84,6 @@ items:
         app.kubernetes.io/name: jaeger
         app.kubernetes.io/component: query
     spec:
-      selector:
-        matchLabels:
-          app: jaeger-query
       ports:
         - name: query-http
           port: 80
@@ -106,9 +103,6 @@ items:
         app.kubernetes.io/name: jaeger
         app.kubernetes.io/component: collector
     spec:
-      selector:
-        matchLabels:
-          app: jaeger-collector
       ports:
         - name: jaeger-collector-tchannel
           port: 14267
@@ -136,9 +130,6 @@ items:
         app.kubernetes.io/name: jaeger
         app.kubernetes.io/component: agent
     spec:
-      selector:
-        matchLabels:
-          app: jaeger-agent
       ports:
         - name: agent-zipkin-thrift
           port: 5775
@@ -170,9 +161,6 @@ items:
         app.kubernetes.io/name: jaeger
         app.kubernetes.io/component: zipkin
     spec:
-      selector:
-        matchLabels:
-          app: zipkin
       ports:
         - name: jaeger-collector-zipkin
           port: 9411

--- a/app/kumactl/data/install/k8s-deprecated/tracing/jaeger/all-in-one-template.yaml
+++ b/app/kumactl/data/install/k8s-deprecated/tracing/jaeger/all-in-one-template.yaml
@@ -77,9 +77,6 @@ items:
         app.kubernetes.io/name: jaeger
         app.kubernetes.io/component: query
     spec:
-      selector:
-        matchLabels:
-          app: jaeger-query
       ports:
         - name: query-http
           port: 80
@@ -99,9 +96,6 @@ items:
         app.kubernetes.io/name: jaeger
         app.kubernetes.io/component: collector
     spec:
-      selector:
-        matchLabels:
-          app: jaeger-collector
       ports:
         - name: jaeger-collector-tchannel
           port: 14267
@@ -129,9 +123,6 @@ items:
         app.kubernetes.io/name: jaeger
         app.kubernetes.io/component: agent
     spec:
-      selector:
-        matchLabels:
-          app: jaeger-agent
       ports:
         - name: agent-zipkin-thrift
           port: 5775
@@ -163,9 +154,6 @@ items:
         app.kubernetes.io/name: jaeger
         app.kubernetes.io/component: zipkin
     spec:
-      selector:
-        matchLabels:
-          app: zipkin
       ports:
         - name: jaeger-collector-zipkin
           port: 9411

--- a/app/kumactl/data/install/k8s/tracing/jaeger/all-in-one-template.yaml
+++ b/app/kumactl/data/install/k8s/tracing/jaeger/all-in-one-template.yaml
@@ -77,9 +77,6 @@ items:
         app.kubernetes.io/name: jaeger
         app.kubernetes.io/component: query
     spec:
-      selector:
-        matchLabels:
-          app: jaeger-query
       ports:
         - name: query-http
           port: 80
@@ -99,9 +96,6 @@ items:
         app.kubernetes.io/name: jaeger
         app.kubernetes.io/component: collector
     spec:
-      selector:
-        matchLabels:
-          app: jaeger-collector
       ports:
         - name: jaeger-collector-tchannel
           port: 14267
@@ -129,9 +123,6 @@ items:
         app.kubernetes.io/name: jaeger
         app.kubernetes.io/component: agent
     spec:
-      selector:
-        matchLabels:
-          app: jaeger-agent
       ports:
         - name: agent-zipkin-thrift
           port: 5775
@@ -163,9 +154,6 @@ items:
         app.kubernetes.io/name: jaeger
         app.kubernetes.io/component: zipkin
     spec:
-      selector:
-        matchLabels:
-          app: zipkin
       ports:
         - name: jaeger-collector-zipkin
           port: 9411

--- a/deployments/charts/kuma/templates/egress-deployment.yaml
+++ b/deployments/charts/kuma/templates/egress-deployment.yaml
@@ -26,8 +26,8 @@ spec:
         {{ $key }}: {{ $value | quote }}
         {{- end }}
         {{- end }}
-      labels: {{ include "kuma.egressLabels" . | nindent 8 }}
-        {{- include "kuma.selectorLabels" . | nindent 8 }}
+      labels:
+        {{- include "kuma.egressLabels" . | nindent 8 }}
     spec:
       {{- with .Values.egress.affinity }}
       affinity: {{ tpl (toYaml . | nindent 8) $ }}

--- a/deployments/charts/kuma/templates/ingress-deployment.yaml
+++ b/deployments/charts/kuma/templates/ingress-deployment.yaml
@@ -26,8 +26,8 @@ spec:
         {{ $key }}: {{ $value | quote }}
         {{- end }}
         {{- end }}
-      labels: {{ include "kuma.ingressLabels" . | nindent 8 }}
-        {{- include "kuma.selectorLabels" . | nindent 8 }}
+      labels:
+        {{- include "kuma.ingressLabels" . | nindent 8 }}
     spec:
       {{- with .Values.ingress.affinity }}
       affinity: {{ tpl (toYaml . | nindent 8) $ }}


### PR DESCRIPTION
### Summary

`kuma.egressLabels` and `kuma.ingressLabels` already include
`kuma.selectorLabels`. The first `Service` `selector` was being
overwritten anyway.

Blocking https://github.com/kumahq/kuma/pull/4671 but I think this should be an explicit PR.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] Link to docs PR or issue --
- [x] Link to UI issue or PR --
- [x] Is the [issue worked on linked][1]? --
- [x] Unit Tests --
- [x] E2E Tests --
- [x] Manual Universal Tests --
- [x] Manual Kubernetes Tests --
- [x] Do you need to update [`UPGRADE.md`](/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](/CONTRIBUTING.md#backporting)? --

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
