### PR TITLE
feat(kuma-cp): authenticate DP every time

### DIFF
--- a/pkg/core/tokens/meshed_signing_key_accessor.go
+++ b/pkg/core/tokens/meshed_signing_key_accessor.go
@@ -12,7 +12,7 @@ import (
 )
 
 type meshedSigningKeyAccessor struct {
-	resManager       manager.ResourceManager
+	resManager       manager.ReadOnlyResourceManager
 	signingKeyPrefix string
 	mesh             string
 }
@@ -22,7 +22,7 @@ var _ SigningKeyAccessor = &meshedSigningKeyAccessor{}
 // NewMeshedSigningKeyAccessor builds SigningKeyAccessor that is bound to a Mesh.
 // Some tokens like Dataplane Token are bound to a mesh.
 // In this case, the singing key is also stored as a Secret in the Mesh, not as GlobalSecret.
-func NewMeshedSigningKeyAccessor(resManager manager.ResourceManager, signingKeyPrefix string, mesh string) SigningKeyAccessor {
+func NewMeshedSigningKeyAccessor(resManager manager.ReadOnlyResourceManager, signingKeyPrefix string, mesh string) SigningKeyAccessor {
 	return &meshedSigningKeyAccessor{
 		resManager:       resManager,
 		signingKeyPrefix: signingKeyPrefix,

--- a/pkg/core/tokens/public_key_secret_signing_key_accessor.go
+++ b/pkg/core/tokens/public_key_secret_signing_key_accessor.go
@@ -14,13 +14,13 @@ import (
 // in zone token, where only global contains private key, and zones only
 // public ones to validate tokens
 type signingKeyFromPublicKeyAccessor struct {
-	resManager       manager.ResourceManager
+	resManager       manager.ReadOnlyResourceManager
 	signingKeyPrefix string
 }
 
 var _ SigningKeyAccessor = &signingKeyFromPublicKeyAccessor{}
 
-func NewSigningKeyFromPublicKeyAccessor(resManager manager.ResourceManager, signingKeyPrefix string) SigningKeyAccessor {
+func NewSigningKeyFromPublicKeyAccessor(resManager manager.ReadOnlyResourceManager, signingKeyPrefix string) SigningKeyAccessor {
 	return &signingKeyFromPublicKeyAccessor{
 		resManager:       resManager,
 		signingKeyPrefix: signingKeyPrefix,

--- a/pkg/core/tokens/revocations.go
+++ b/pkg/core/tokens/revocations.go
@@ -52,8 +52,8 @@ func (s *secretRevocations) IsRevoked(ctx context.Context, id string) (bool, err
 func (s *secretRevocations) getSecretData(ctx context.Context) ([]byte, error) {
 	// Do a list operation instead of get because of the cache in ReadOnlyResourceManager
 	// For the majority of cases, users do not set revocation secret.
-	// We don't cache not found result of get operation, so with many execution to IsRevoked() we would say a lot of requests to a DB.
-	// We could do get requests and preserve separate cache here (taking into acoutn resource not found),
+	// We don't cache not found result of get operation, so with many execution to IsRevoked() we would send a lot of requests to a DB.
+	// We could do get requests and preserve separate cache here (taking into account resource not found),
 	// but there is a high chance that SecretResourceList is already in the cache, because of XDS reconciliation, so we can avoid I/O at all.
 	var resources core_model.ResourceList
 	if s.revocationKey.Mesh == "" {

--- a/pkg/core/tokens/revocations.go
+++ b/pkg/core/tokens/revocations.go
@@ -50,17 +50,25 @@ func (s *secretRevocations) IsRevoked(ctx context.Context, id string) (bool, err
 }
 
 func (s *secretRevocations) getSecretData(ctx context.Context) ([]byte, error) {
-	var resource core_model.Resource
+	// Do a list operation instead of get because of the cache in ReadOnlyResourceManager
+	// For the majority of cases, users do not set revocation secret.
+	// We don't cache not found result of get operation, so with many execution to IsRevoked() we would say a lot of requests to a DB.
+	// We could do get requests and preserve separate cache here (taking into acoutn resource not found),
+	// but there is a high chance that SecretResourceList is already in the cache, because of XDS reconciliation, so we can avoid I/O at all.
+	var resources core_model.ResourceList
 	if s.revocationKey.Mesh == "" {
-		resource = system.NewGlobalSecretResource()
+		resources = &system.GlobalSecretResourceList{}
 	} else {
-		resource = system.NewSecretResource()
+		resources = &system.SecretResourceList{}
 	}
-	if err := s.manager.Get(ctx, resource, core_store.GetBy(s.revocationKey)); err != nil {
-		if core_store.IsResourceNotFound(err) {
-			return nil, nil
-		}
+
+	if err := s.manager.List(ctx, resources, core_store.ListByMesh(s.revocationKey.Mesh)); err != nil {
 		return nil, err
 	}
-	return resource.GetSpec().(*system_proto.Secret).GetData().GetValue(), nil
+	for _, res := range resources.GetItems() {
+		if res.GetMeta().GetName() == s.revocationKey.Name {
+			return res.GetSpec().(*system_proto.Secret).GetData().GetValue(), nil
+		}
+	}
+	return nil, nil
 }

--- a/pkg/core/tokens/signing_key.go
+++ b/pkg/core/tokens/signing_key.go
@@ -101,7 +101,7 @@ func signingKeySerialNumber(secretName string, signingKeyPrefix string) (int, er
 
 func getKeyBytes(
 	ctx context.Context,
-	resManager manager.ResourceManager,
+	resManager manager.ReadOnlyResourceManager,
 	signingKeyPrefix string,
 	serialNumber int,
 ) ([]byte, error) {

--- a/pkg/core/tokens/signing_key_accessor.go
+++ b/pkg/core/tokens/signing_key_accessor.go
@@ -19,13 +19,13 @@ type SigningKeyAccessor interface {
 }
 
 type signingKeyAccessor struct {
-	resManager       manager.ResourceManager
+	resManager       manager.ReadOnlyResourceManager
 	signingKeyPrefix string
 }
 
 var _ SigningKeyAccessor = &signingKeyAccessor{}
 
-func NewSigningKeyAccessor(resManager manager.ResourceManager, signingKeyPrefix string) SigningKeyAccessor {
+func NewSigningKeyAccessor(resManager manager.ReadOnlyResourceManager, signingKeyPrefix string) SigningKeyAccessor {
 	return &signingKeyAccessor{
 		resManager:       resManager,
 		signingKeyPrefix: signingKeyPrefix,

--- a/pkg/tokens/builtin/components.go
+++ b/pkg/tokens/builtin/components.go
@@ -34,7 +34,7 @@ func NewZoneTokenIssuer(resManager manager.ResourceManager) zone.TokenIssuer {
 	)
 }
 
-func NewDataplaneTokenValidator(resManager manager.ResourceManager, storeType store_config.StoreType) issuer.Validator {
+func NewDataplaneTokenValidator(resManager manager.ReadOnlyResourceManager, storeType store_config.StoreType) issuer.Validator {
 	return issuer.NewValidator(func(meshName string) tokens.Validator {
 		return tokens.NewValidator(
 			tokens.NewMeshedSigningKeyAccessor(resManager, issuer.DataplaneTokenSigningKeyPrefix(meshName), meshName),
@@ -44,7 +44,7 @@ func NewDataplaneTokenValidator(resManager manager.ResourceManager, storeType st
 	})
 }
 
-func NewZoneIngressTokenValidator(resManager manager.ResourceManager, storeType store_config.StoreType) zoneingress.Validator {
+func NewZoneIngressTokenValidator(resManager manager.ReadOnlyResourceManager, storeType store_config.StoreType) zoneingress.Validator {
 	return zoneingress.NewValidator(
 		tokens.NewValidator(
 			tokens.NewSigningKeyAccessor(resManager, zoneingress.ZoneIngressSigningKeyPrefix),
@@ -54,7 +54,7 @@ func NewZoneIngressTokenValidator(resManager manager.ResourceManager, storeType 
 	)
 }
 
-func NewZoneTokenValidator(resManager manager.ResourceManager, mode core.CpMode, storeType store_config.StoreType) zone.Validator {
+func NewZoneTokenValidator(resManager manager.ReadOnlyResourceManager, mode core.CpMode, storeType store_config.StoreType) zone.Validator {
 	var signingKeyAccessor tokens.SigningKeyAccessor
 
 	if mode == core.Zone {

--- a/pkg/xds/auth/callbacks.go
+++ b/pkg/xds/auth/callbacks.go
@@ -48,14 +48,17 @@ type authCallbacks struct {
 	authenticator   Authenticator
 	dpNotFoundRetry DPNotFoundRetry
 
-	sync.RWMutex // protects contexts and authenticated
+	sync.RWMutex // protects streams
 	streams      map[core_xds.StreamID]stream
 }
 
 type stream struct {
-	ctx      context.Context
+	// context of the stream that contains a credential
+	ctx context.Context
+	// Dataplane / ZoneIngress / ZoneEgress associated with this XDS stream.
 	resource model.Resource
-	nodeID   string
+	// nodeID of the stream. Has to be the same for the whole life of a stream.
+	nodeID string
 }
 
 var _ util_xds.Callbacks = &authCallbacks{}

--- a/pkg/xds/auth/callbacks_test.go
+++ b/pkg/xds/auth/callbacks_test.go
@@ -125,7 +125,7 @@ var _ = Describe("Auth Callbacks", func() {
 		Expect(err).ToNot(HaveOccurred())
 	})
 
-	It("should authenticate only first request on the stream", func() {
+	It("should successfully authenticate", func() {
 		// given
 		ctx := metadata.NewIncomingContext(context.Background(), metadata.New(map[string]string{"authorization": "pass"}))
 		streamID := int64(1)
@@ -144,13 +144,6 @@ var _ = Describe("Auth Callbacks", func() {
 		})
 
 		// then
-		Expect(err).ToNot(HaveOccurred())
-		Expect(testAuth.callCounter).To(Equal(1))
-
-		// when send second request that is already authenticated
-		err = callbacks.OnStreamRequest(streamID, &envoy_sd.DiscoveryRequest{})
-
-		// then auth is called only once
 		Expect(err).ToNot(HaveOccurred())
 		Expect(testAuth.callCounter).To(Equal(1))
 	})
@@ -296,13 +289,6 @@ var _ = Describe("Auth Callbacks", func() {
 		// then
 		Expect(err).ToNot(HaveOccurred())
 		Expect(testAuth.zoneCallCounter).To(Equal(1))
-
-		// when send second request that is already authenticated
-		err = callbacks.OnStreamRequest(streamID, &envoy_sd.DiscoveryRequest{})
-
-		// then auth is called only once
-		Expect(err).ToNot(HaveOccurred())
-		Expect(testAuth.zoneCallCounter).To(Equal(1))
 	})
 
 	It("should authenticate egress", func() {
@@ -333,13 +319,6 @@ var _ = Describe("Auth Callbacks", func() {
 		})
 
 		// then
-		Expect(err).ToNot(HaveOccurred())
-		Expect(testAuth.zoneCallCounter).To(Equal(1))
-
-		// when send second request that is already authenticated
-		err = callbacks.OnStreamRequest(streamID, &envoy_sd.DiscoveryRequest{})
-
-		// then auth is called only once
 		Expect(err).ToNot(HaveOccurred())
 		Expect(testAuth.zoneCallCounter).To(Equal(1))
 	})

--- a/pkg/xds/auth/components/components.go
+++ b/pkg/xds/auth/components/components.go
@@ -23,9 +23,9 @@ func NewKubeAuthenticator(rt core_runtime.Runtime) (auth.Authenticator, error) {
 func NewUniversalAuthenticator(rt core_runtime.Runtime) (auth.Authenticator, error) {
 	config := rt.Config()
 
-	dataplaneValidator := builtin.NewDataplaneTokenValidator(rt.ResourceManager(), config.Store.Type)
-	zoneIngressValidator := builtin.NewZoneIngressTokenValidator(rt.ResourceManager(), config.Store.Type)
-	zoneTokenValidator := builtin.NewZoneTokenValidator(rt.ResourceManager(), config.Mode, config.Store.Type)
+	dataplaneValidator := builtin.NewDataplaneTokenValidator(rt.ReadOnlyResourceManager(), config.Store.Type)
+	zoneIngressValidator := builtin.NewZoneIngressTokenValidator(rt.ReadOnlyResourceManager(), config.Store.Type)
+	zoneTokenValidator := builtin.NewZoneTokenValidator(rt.ReadOnlyResourceManager(), config.Mode, config.Store.Type)
 
 	return universal_auth.NewAuthenticator(dataplaneValidator, zoneIngressValidator, zoneTokenValidator, config.Multizone.Zone.Name), nil
 }

--- a/pkg/xds/auth/k8s/authenticator.go
+++ b/pkg/xds/auth/k8s/authenticator.go
@@ -3,6 +3,7 @@ package k8s
 import (
 	"context"
 	"strings"
+	"sync"
 
 	"github.com/pkg/errors"
 	kube_auth "k8s.io/api/authentication/v1"
@@ -18,27 +19,49 @@ import (
 
 func New(client kube_client.Client) auth.Authenticator {
 	return &kubeAuthenticator{
-		client: client,
+		client:        client,
+		authenticated: map[auth.Credential]struct{}{},
 	}
 }
 
 type kubeAuthenticator struct {
 	client kube_client.Client
+
+	// todo cleanup of the map. number of elements? cache with expiration time?
+	authenticated map[auth.Credential]struct{}
+	mutex         sync.RWMutex
 }
 
 var _ auth.Authenticator = &kubeAuthenticator{}
 
 func (k *kubeAuthenticator) Authenticate(ctx context.Context, resource model.Resource, credential auth.Credential) error {
+	k.mutex.RLock()
+	_, authenticated := k.authenticated[credential]
+	k.mutex.RUnlock()
+	if authenticated {
+		return nil
+	}
+
+	var err error
 	switch resource := resource.(type) {
 	case *core_mesh.DataplaneResource:
-		return k.authDataplane(ctx, resource, credential)
+		err = k.authDataplane(ctx, resource, credential)
 	case *core_mesh.ZoneIngressResource:
-		return k.authZoneIngress(ctx, resource, credential)
+		err = k.authZoneIngress(ctx, resource, credential)
 	case *core_mesh.ZoneEgressResource:
-		return k.authZoneEgress(ctx, resource, credential)
+		err = k.authZoneEgress(ctx, resource, credential)
 	default:
-		return errors.Errorf("no matching authenticator for %s resource", resource.Descriptor().Name)
+		err = errors.Errorf("no matching authenticator for %s resource", resource.Descriptor().Name)
 	}
+
+	if err != nil {
+		return err
+	}
+
+	k.mutex.Lock()
+	k.authenticated[credential] = struct{}{}
+	k.mutex.Unlock()
+	return nil
 }
 
 func (k *kubeAuthenticator) authDataplane(ctx context.Context, dataplane *core_mesh.DataplaneResource, credential auth.Credential) error {

--- a/test/e2e_env/universal/auth/dp_auth.go
+++ b/test/e2e_env/universal/auth/dp_auth.go
@@ -1,8 +1,11 @@
 package auth
 
 import (
+	"encoding/base64"
 	"fmt"
+	"math/rand"
 
+	"github.com/golang-jwt/jwt/v4"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
@@ -70,5 +73,59 @@ networking:
 		Eventually(func() (string, error) {
 			return env.Cluster.GetKumactlOptions().RunKumactlAndGetOutput("get", "dataplanes", "-oyaml")
 		}, "30s", "1s").ShouldNot(ContainSubstring("192.168.0.2"))
+	})
+
+	It("should revoke token and kick out dataplane proxy out of the mesh", func() {
+		// given
+		serviceName := "test-server-to-be-revoked"
+		token, err := env.Cluster.GetKuma().GenerateDpToken(meshName, serviceName)
+		Expect(err).ToNot(HaveOccurred())
+
+		err = env.Cluster.Install(TestServerUniversal(serviceName, meshName, WithServiceName(serviceName), WithToken(token)))
+		Expect(err).ToNot(HaveOccurred())
+
+		Eventually(func(g Gomega) {
+			online, found, err := IsDataplaneOnline(env.Cluster, meshName, serviceName)
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(found).To(BeTrue())
+			g.Expect(online).To(BeTrue())
+		}).Should(Succeed())
+
+		// when token ID is added to revocation list
+		claims := &jwt.RegisteredClaims{}
+		_, _, err = jwt.NewParser().ParseUnverified(token, claims)
+		Expect(err).ToNot(HaveOccurred())
+
+		yaml := fmt.Sprintf(`
+type: Secret
+mesh: dp-auth
+name: dataplane-token-revocations-dp-auth
+data: %s`, base64.StdEncoding.EncodeToString([]byte(claims.ID)))
+		Expect(env.Cluster.Install(YamlUniversal(yaml))).To(Succeed())
+
+		// then DPP is disconnected
+		Eventually(func(g Gomega) {
+			// we need to trigger XDS config change for this DP to disconnect it
+			// this limitation may be lifted in the future
+			yaml = fmt.Sprintf(`
+type: Retry
+name: retry-policy
+mesh: dp-auth
+sources:
+- match:
+    kuma.io/service: test-server-to-be-revoked
+destinations:
+- match:
+    kuma.io/service: test-server-to-be-revoked
+conf:
+  http:
+    numRetries: %d
+`, rand.Int()%100)
+			g.Expect(env.Cluster.Install(YamlUniversal(yaml))).To(Succeed())
+
+			online, _, err := IsDataplaneOnline(env.Cluster, meshName, serviceName)
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(online).To(BeFalse()) // either online or not found
+		}).Should(Succeed())
 	})
 }

--- a/test/framework/dataplane.go
+++ b/test/framework/dataplane.go
@@ -1,0 +1,18 @@
+package framework
+
+import (
+	"strings"
+)
+
+func IsDataplaneOnline(cluster Cluster, mesh, name string) (bool, bool, error) {
+	out, err := cluster.GetKumactlOptions().RunKumactlAndGetOutput("inspect", "dataplanes", "--mesh", mesh)
+	if err != nil {
+		return false, false, err
+	}
+	for _, line := range strings.Split(out, "\n") {
+		if strings.Contains(line, name) {
+			return strings.Contains(line, "Online"), true, nil
+		}
+	}
+	return false, false, nil
+}


### PR DESCRIPTION
Authenticate DP on every DiscoveryRequest.
It is done so we can throw out of mesh DPPs with an expired or revoked token.

On Kubernetes, we don't have expiration or revocation and auth is expensive, therefore we need to have a cache for SATs.

## Perf implications

Kubernetes - not affected.

Universal - worst-case scenario (multiple DiscoveryRequests / s):
* GET request for revocation list
* GET request for signing key
* parsing token - should be lightweight

Both requests are cached with ReadOnlyResourceManager so the max overhead is an extra 2 req/s.

DPP with an expired or revoked tokens will be disconnected on the next DiscoveryRequest which means that if there are no changes in the config, the DPP can stay in the mesh for some time.
If we want to be reactive about this, we need some other mechanism to trigger DPP to send DiscoveryRequest. Out of scope for this PR.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [ ] Link to docs PR or issue --
- [X] Link to UI issue or PR -- not relevant
- [X] Is the [issue worked on linked][1]? -- xref #3379
- [X] Unit Tests --
- [X] E2E Tests --
- [X] Manual Universal Tests --
- [X] Manual Kubernetes Tests -- not relevant
- [X] Do you need to update [`UPGRADE.md`](/UPGRADE.md)? -- no
- [X] Does it need to be backported according to the [backporting policy](/CONTRIBUTING.md#backporting)? -- no

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
