### PR TITLE
test(e2e): universal logs

### DIFF
--- a/test/framework/deployments/externalservice/universal.go
+++ b/test/framework/deployments/externalservice/universal.go
@@ -96,19 +96,19 @@ func (u *UniversalDeployment) Deploy(cluster framework.Cluster) error {
 		return err
 	}
 
-	err = ssh.NewApp(u.verbose, port, nil, []string{"printf ", "--", "\"" + cert + "\"", ">", "/server-cert.pem"}).Run()
+	err = ssh.NewApp(u.name, u.verbose, port, nil, []string{"printf ", "--", "\"" + cert + "\"", ">", "/server-cert.pem"}).Run()
 	if err != nil {
 		panic(err)
 	}
 
-	err = ssh.NewApp(u.verbose, port, nil, []string{"printf ", "--", "\"" + key + "\"", ">", "/server-key.pem"}).Run()
+	err = ssh.NewApp(u.name, u.verbose, port, nil, []string{"printf ", "--", "\"" + key + "\"", ">", "/server-key.pem"}).Run()
 	if err != nil {
 		panic(err)
 	}
 
 	u.cert = cert
 	for _, arg := range u.commands {
-		u.app = ssh.NewApp(u.verbose, port, nil, arg)
+		u.app = ssh.NewApp(u.name, u.verbose, port, nil, arg)
 		err = u.app.Start()
 		if err != nil {
 			return err
@@ -120,7 +120,7 @@ func (u *UniversalDeployment) Deploy(cluster framework.Cluster) error {
 
 func (u *UniversalDeployment) Exec(cmd ...string) (string, string, error) {
 	port := strconv.Itoa(int(u.ports[22]))
-	sshApp := ssh.NewApp(u.verbose, port, nil, cmd)
+	sshApp := ssh.NewApp(u.name, u.verbose, port, nil, cmd)
 	err := sshApp.Run()
 	return sshApp.Out(), sshApp.Err(), err
 }

--- a/test/framework/envoy_admin/tunnel/universal.go
+++ b/test/framework/envoy_admin/tunnel/universal.go
@@ -37,7 +37,7 @@ func (t *UniversalTunnel) GetStats(name string) (*stats.Stats, error) {
 		"curl", "--silent", "--max-time", "3", "--fail", url,
 	}
 
-	app := ssh.NewApp(t.verbose, t.port, nil, sshArgs)
+	app := ssh.NewApp("tunnel", t.verbose, t.port, nil, sshArgs)
 
 	if err := app.Run(); err != nil {
 		return nil, err
@@ -61,7 +61,7 @@ func (t *UniversalTunnel) ResetCounters() error {
 		"'http://localhost:9901/reset_counters'",
 	}
 
-	app := ssh.NewApp(t.verbose, t.port, nil, sshArgs)
+	app := ssh.NewApp("tunnel", t.verbose, t.port, nil, sshArgs)
 
 	if err := app.Run(); err != nil {
 		return err

--- a/test/framework/universal_app.go
+++ b/test/framework/universal_app.go
@@ -351,12 +351,12 @@ func (s *UniversalApp) ReStart() error {
 func (s *UniversalApp) CreateMainApp(env map[string]string, args []string) {
 	s.mainAppEnv = env
 	s.mainAppArgs = args
-	s.mainApp = ssh.NewApp(s.verbose, s.ports[sshPort], env, args)
+	s.mainApp = ssh.NewApp(s.containerName, s.verbose, s.ports[sshPort], env, args)
 }
 
 func (s *UniversalApp) OverrideDpVersion(version string) error {
 	// It is important to store installation package in /tmp/kuma/, not /tmp/ otherwise root was taking over /tmp/ and Kuma DP could not store /tmp files
-	err := ssh.NewApp(s.verbose, s.ports[sshPort], nil, []string{
+	err := ssh.NewApp(s.containerName, s.verbose, s.ports[sshPort], nil, []string{
 		"wget",
 		fmt.Sprintf("https://download.konghq.com/mesh-alpine/kuma-%s-ubuntu-amd64.tar.gz", version),
 		"-O",
@@ -366,7 +366,7 @@ func (s *UniversalApp) OverrideDpVersion(version string) error {
 		return err
 	}
 
-	err = ssh.NewApp(s.verbose, s.ports[sshPort], nil, []string{
+	err = ssh.NewApp(s.containerName, s.verbose, s.ports[sshPort], nil, []string{
 		"mkdir",
 		"-p",
 		"/tmp/kuma/",
@@ -375,7 +375,7 @@ func (s *UniversalApp) OverrideDpVersion(version string) error {
 		return err
 	}
 
-	err = ssh.NewApp(s.verbose, s.ports[sshPort], nil, []string{
+	err = ssh.NewApp(s.containerName, s.verbose, s.ports[sshPort], nil, []string{
 		"tar",
 		"xvzf",
 		fmt.Sprintf("/tmp/kuma-%s-ubuntu-amd64.tar.gz", version),
@@ -386,7 +386,7 @@ func (s *UniversalApp) OverrideDpVersion(version string) error {
 		return err
 	}
 
-	err = ssh.NewApp(s.verbose, s.ports[sshPort], nil, []string{
+	err = ssh.NewApp(s.containerName, s.verbose, s.ports[sshPort], nil, []string{
 		"cp",
 		fmt.Sprintf("/tmp/kuma/kuma-%s/bin/kuma-dp", version),
 		"/usr/bin/kuma-dp",
@@ -395,7 +395,7 @@ func (s *UniversalApp) OverrideDpVersion(version string) error {
 		return err
 	}
 
-	err = ssh.NewApp(s.verbose, s.ports[sshPort], nil, []string{
+	err = ssh.NewApp(s.containerName, s.verbose, s.ports[sshPort], nil, []string{
 		"cp",
 		fmt.Sprintf("/tmp/kuma/kuma-%s/bin/envoy", version),
 		"/usr/local/bin/envoy",
@@ -414,7 +414,7 @@ func (s *UniversalApp) CreateDP(
 	concurrency int,
 ) {
 	// create the token file on the app container
-	err := ssh.NewApp(s.verbose, s.ports[sshPort], nil, []string{"printf ", "\"" + token + "\"", ">", "/kuma/token-" + name}).Run()
+	err := ssh.NewApp(s.containerName, s.verbose, s.ports[sshPort], nil, []string{"printf ", "\"" + token + "\"", ">", "/kuma/token-" + name}).Run()
 	if err != nil {
 		panic(err)
 	}
@@ -429,7 +429,7 @@ func (s *UniversalApp) CreateDP(
 	}
 
 	if dpyaml != "" {
-		err = ssh.NewApp(s.verbose, s.ports[sshPort], nil, []string{"printf ", "\"" + dpyaml + "\"", ">", "/kuma/dpyaml-" + name}).Run()
+		err = ssh.NewApp(s.containerName, s.verbose, s.ports[sshPort], nil, []string{"printf ", "\"" + dpyaml + "\"", ">", "/kuma/dpyaml-" + name}).Run()
 		if err != nil {
 			panic(err)
 		}
@@ -455,7 +455,7 @@ func (s *UniversalApp) CreateDP(
 		args = append(args, "--proxy-type", proxyType)
 	}
 
-	s.dpApp = ssh.NewApp(s.verbose, s.ports[sshPort], nil, args)
+	s.dpApp = ssh.NewApp(s.containerName, s.verbose, s.ports[sshPort], nil, args)
 }
 
 // iptablesChainExists tests whether iptables believes the given chainName
@@ -464,7 +464,7 @@ func (s *UniversalApp) CreateDP(
 // compatibility) though subsequent commands that depend on it may
 // still fail.
 func (s *UniversalApp) iptablesChainExists(tableName string, chainName string) bool {
-	app := ssh.NewApp(s.verbose, s.ports[sshPort], nil, []string{
+	app := ssh.NewApp(s.containerName, s.verbose, s.ports[sshPort], nil, []string{
 		"iptables", "-t", tableName, "-L", chainName,
 	})
 
@@ -487,7 +487,7 @@ func (s *UniversalApp) setupTransparent(cpIp string, builtindns bool) {
 		)
 	}
 
-	app := ssh.NewApp(s.verbose, s.ports[sshPort], nil, args)
+	app := ssh.NewApp(s.containerName, s.verbose, s.ports[sshPort], nil, args)
 	err := app.Run()
 	if err != nil {
 		panic(fmt.Sprintf("err: %s\nstderr :%s\nstdout %s", err.Error(), app.Err(), app.Out()))
@@ -495,7 +495,7 @@ func (s *UniversalApp) setupTransparent(cpIp string, builtindns bool) {
 }
 
 func (s *UniversalApp) getIP(isipv6 bool) (string, error) {
-	cmd := ssh.NewApp(s.verbose, s.ports[sshPort], nil, []string{"getent", "ahosts", s.container[:12]})
+	cmd := ssh.NewApp(s.containerName, s.verbose, s.ports[sshPort], nil, []string{"getent", "ahosts", s.container[:12]})
 	err := cmd.Run()
 	if err != nil {
 		return "invalid", errors.Wrapf(err, "getent failed with %s", cmd.Err())

--- a/test/framework/universal_cluster.go
+++ b/test/framework/universal_cluster.go
@@ -351,7 +351,7 @@ func runPostgresMigration(kumaCP *UniversalApp, envVars map[string]string) error
 		return errors.New("missing public port: 22")
 	}
 
-	app := ssh.NewApp(kumaCP.verbose, sshPort, envVars, args)
+	app := ssh.NewApp(kumaCP.containerName, kumaCP.verbose, sshPort, envVars, args)
 	if err := app.Run(); err != nil {
 		return errors.Errorf("db migration err: %s\nstderr :%s\nstdout %s", err.Error(), app.Err(), app.Out())
 	}
@@ -395,7 +395,7 @@ func (c *UniversalCluster) Exec(namespace, podName, appname string, cmd ...strin
 	if !ok {
 		return "", "", errors.Errorf("App %s not found", appname)
 	}
-	sshApp := ssh.NewApp(c.verbose, app.ports[sshPort], nil, cmd)
+	sshApp := ssh.NewApp(app.containerName, c.verbose, app.ports[sshPort], nil, cmd)
 	err := sshApp.Run()
 	return sshApp.Out(), sshApp.Err(), err
 }
@@ -417,7 +417,7 @@ func (c *UniversalCluster) ExecWithCustomRetries(namespace, podName, appname str
 			if !ok {
 				return "", errors.Errorf("App %s not found", appname)
 			}
-			sshApp := ssh.NewApp(c.verbose, app.ports[sshPort], nil, cmd)
+			sshApp := ssh.NewApp(app.containerName, c.verbose, app.ports[sshPort], nil, cmd)
 			err := sshApp.Run()
 			stdout = sshApp.Out()
 			stderr = sshApp.Err()

--- a/test/framework/universal_controlplane.go
+++ b/test/framework/universal_controlplane.go
@@ -68,7 +68,7 @@ func (c *UniversalControlPlane) GetAPIServerAddress() string {
 
 func (c *UniversalControlPlane) GetMetrics() (string, error) {
 	return retry.DoWithRetryE(c.t, "fetching CP metrics", DefaultRetries, DefaultTimeout, func() (string, error) {
-		sshApp := ssh.NewApp(c.verbose, c.cpNetworking.SshPort, nil, []string{"curl",
+		sshApp := ssh.NewApp(c.name, c.verbose, c.cpNetworking.SshPort, nil, []string{"curl",
 			"--fail", "--show-error",
 			"http://localhost:5680/metrics"})
 		if err := sshApp.Run(); err != nil {
@@ -94,6 +94,7 @@ func (c *UniversalControlPlane) generateToken(
 		DefaultTimeout,
 		func() (string, error) {
 			sshApp := ssh.NewApp(
+				c.name,
 				c.verbose,
 				c.cpNetworking.SshPort,
 				nil,
@@ -124,6 +125,7 @@ func (c *UniversalControlPlane) retrieveAdminToken() (string, error) {
 		DefaultTimeout,
 		func() (string, error) {
 			sshApp := ssh.NewApp(
+				c.name,
 				c.verbose, c.cpNetworking.SshPort, nil, []string{
 					"curl", "--fail", "--show-error",
 					"http://localhost:5681/global-secrets/admin-user-token",


### PR DESCRIPTION
Right now, all the logs from universal containers are logged on stdout. This makes debugging tests very hard, because you cannot see logs from one container. Parallelization only makes this problem more difficult.

This PR introduces better logging for universal containers.

## Considered options

1) Redirecting to stdout/stderr of containers
So we could use `docker logs kuma-cp_hash` and see logs of kuma cp.
I haven't found a way to implement this, since it's not a main process in the container

2) Logging to a file in the container
I tried to use `tee` to have logs both visible in tests as well as in the file in the container.
`tee` messes up with stderr+stdout. If think it redirects stderr to stdout by default. Bunch of tests were failing because of that.
Also, when container is gone, logs are also gone.

3) Logging to a file in the host
Simple to implement.
This has the advantage that if docker containers are stopped, you still have the logs.
The disadvantage is that logs are piling up, but it's easy to delete them. If this will bother us, we can create a cleanup mechanism.

This PR implements option 3.

### Checklist prior to review

- [X] Link to docs PR or issue -- not relevant
- [X] Link to UI issue or PR -- not relevant
- [X] Is the [issue worked on linked][1]? -- #4187
- [X] Unit Tests -- not relevant
- [X] E2E Tests --
- [X] Manual Universal Tests -- not relevant
- [X] Manual Kubernetes Tests -- not relevant 
- [X] Do you need to update [`UPGRADE.md`](/UPGRADE.md)? -- not relevant
- [X] Does it need to be backported according to the [backporting policy](/CONTRIBUTING.md#backporting)? -- no

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
