### PR TITLE
test(e2e): don't panic if an `Install` fails before `Kuma` is called

### DIFF
--- a/test/framework/k8s_cluster.go
+++ b/test/framework/k8s_cluster.go
@@ -912,6 +912,10 @@ func (c *K8sCluster) deleteKumaViaKumactl() error {
 }
 
 func (c *K8sCluster) DeleteKuma() error {
+	if c.controlplane == nil {
+		return nil
+	}
+
 	c.controlplane.ClosePortForwards()
 	var err error
 	switch c.opts.installationMode {


### PR DESCRIPTION
See [this CircleCI run](https://app.circleci.com/pipelines/github/kumahq/kuma/15528/workflows/4cd8a03f-f04a-4a52-836c-e88f272a5c19/jobs/190865)

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [ ] Link to docs PR or issue --
- [ ] Link to UI issue or PR --
- [ ] Is the [issue worked on linked][1]? --
- [ ] Unit Tests --
- [ ] E2E Tests --
- [ ] Manual Universal Tests --
- [ ] Manual Kubernetes Tests --
- [ ] Do you need to update [`UPGRADE.md`](/UPGRADE.md)? --
- [ ] Does it need to be backported according to the [backporting policy](/CONTRIBUTING.md#backporting)? --

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
