### PR TITLE
feat(gateway): configure overload_manager based on max memory

### DIFF
--- a/app/kuma-dp/pkg/dataplane/envoy/remote_bootstrap.go
+++ b/app/kuma-dp/pkg/dataplane/envoy/remote_bootstrap.go
@@ -137,29 +137,29 @@ func maybeReadAsBytes(path string) *UIntOrString {
 }
 
 func (b *remoteBootstrap) resourceMetadata(cfg kuma_dp.DataplaneResources) (types.ProxyResources, error) {
-	var maxHeap uint64
+	var maxMemory uint64
 
 	if cfg.MaxMemoryBytes == 0 {
 		switch cgroups.Mode() {
 		case cgroups.Legacy:
 			res := maybeReadAsBytes("/sys/fs/cgroup/memory.limit_in_bytes")
 			if res != nil && res.Type == "int" {
-				maxHeap = res.UInt
+				maxMemory = res.UInt
 			}
 		case cgroups.Hybrid, cgroups.Unified:
 			res := maybeReadAsBytes("/sys/fs/cgroup/memory.max")
 			if res != nil && res.Type == "int" {
-				maxHeap = res.UInt
+				maxMemory = res.UInt
 			}
 		}
 	} else {
-		maxHeap = cfg.MaxMemoryBytes
+		maxMemory = cfg.MaxMemoryBytes
 	}
 
 	res := types.ProxyResources{}
 
-	if maxHeap != 0 {
-		res.MaxHeapSizeBytes = uint64(0.90 * float64(maxHeap))
+	if maxMemory != 0 {
+		res.MaxHeapSizeBytes = maxMemory
 	}
 
 	return res, nil

--- a/app/kuma-dp/pkg/dataplane/envoy/remote_bootstrap_test.go
+++ b/app/kuma-dp/pkg/dataplane/envoy/remote_bootstrap_test.go
@@ -130,7 +130,10 @@ var _ = Describe("Remote Bootstrap", func() {
 					    "test": "value"
 					  },
 					  "operatingSystem": "linux",
-					  "features": []
+					  "features": [],
+					  "resources": {
+					    "maxHeapSizeBytes": 0
+				      }
 					}`,
 				}
 			}()),
@@ -176,7 +179,10 @@ var _ = Describe("Remote Bootstrap", func() {
                       "caCert": "",
                       "dynamicMetadata": null,
                       "operatingSystem": "linux",
-                      "features": []
+                      "features": [],
+					  "resources": {
+					    "maxHeapSizeBytes": 0
+				      }
                     }`,
 				}
 			}()),
@@ -221,7 +227,10 @@ var _ = Describe("Remote Bootstrap", func() {
                       "caCert": "",
                       "dynamicMetadata": null,
                       "operatingSystem": "linux",
-                      "features": []
+                      "features": [],
+					  "resources": {
+					    "maxHeapSizeBytes": 0
+				      }
                     }`,
 				}
 			}()),
@@ -265,7 +274,10 @@ var _ = Describe("Remote Bootstrap", func() {
                       "caCert": "",
 					  "dynamicMetadata": null,
 					  "operatingSystem": "linux",
-					  "features": []
+					  "features": [],
+					  "resources": {
+					    "maxHeapSizeBytes": 0
+				      }
                     }`,
 				}
 			}()),

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/Nordix/simple-ipam v1.0.0
 	github.com/asaskevich/govalidator v0.0.0-20210307081110-f21760c49a8d
 	github.com/cncf/xds/go v0.0.0-20211130200136-a8f946100490
+	github.com/containerd/cgroups v1.0.3
 	github.com/containernetworking/cni v1.1.1
 	github.com/containernetworking/plugins v1.1.1
 	github.com/emicklei/go-restful/v3 v3.9.0
@@ -95,8 +96,8 @@ require (
 	github.com/census-instrumentation/opencensus-proto v0.3.0 // indirect
 	github.com/cespare/xxhash/v2 v2.1.2 // indirect
 	github.com/cilium/ebpf v0.9.1 // indirect
-	github.com/containerd/cgroups v1.0.3 // indirect
 	github.com/containerd/containerd v1.6.6 // indirect
+	github.com/coreos/go-systemd/v22 v22.3.2 // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.2 // indirect
 	github.com/cyphar/filepath-securejoin v0.2.3 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
@@ -117,6 +118,7 @@ require (
 	github.com/go-sql-driver/mysql v1.6.0 // indirect
 	github.com/gobuffalo/flect v0.2.5 // indirect
 	github.com/gobwas/glob v0.2.3 // indirect
+	github.com/godbus/dbus/v5 v5.0.6 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/google/gnostic v0.5.7-v3refs // indirect
@@ -156,6 +158,7 @@ require (
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.0.3-0.20211202183452-c5a74bcca799 // indirect
 	github.com/opencontainers/runc v1.1.2 // indirect
+	github.com/opencontainers/runtime-spec v1.0.3-0.20210326190908-1c3f411f0417 // indirect
 	github.com/pelletier/go-toml v1.9.5 // indirect
 	github.com/pelletier/go-toml/v2 v2.0.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -425,6 +425,7 @@ github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e/go.mod h1:F5haX7
 github.com/coreos/go-systemd v0.0.0-20190719114852-fd7a80b32e1f/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/coreos/go-systemd/v22 v22.0.0/go.mod h1:xO0FLkIi5MaZafQlIrOotqXZ90ih+1atmu1JpKERPPk=
 github.com/coreos/go-systemd/v22 v22.1.0/go.mod h1:xO0FLkIi5MaZafQlIrOotqXZ90ih+1atmu1JpKERPPk=
+github.com/coreos/go-systemd/v22 v22.3.2 h1:D9/bQk5vlXQFZ6Kwuu6zaiXJ9oTPe68++AzAJc1DzSI=
 github.com/coreos/go-systemd/v22 v22.3.2/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
 github.com/coreos/pkg v0.0.0-20160727233714-3ac0863d7acf/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
 github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
@@ -647,6 +648,7 @@ github.com/godbus/dbus v0.0.0-20180201030542-885f9cc04c9c/go.mod h1:/YcGZj5zSblf
 github.com/godbus/dbus v0.0.0-20190422162347-ade71ed3457e/go.mod h1:bBOAhwG1umN6/6ZUMtDFBMQR8jRg9O75tm9K00oMsK4=
 github.com/godbus/dbus/v5 v5.0.3/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
+github.com/godbus/dbus/v5 v5.0.6 h1:mkgN1ofwASrYnJ5W6U/BxG15eXXXjirgZc7CLqkcaro=
 github.com/godbus/dbus/v5 v5.0.6/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/godror/godror v0.24.2/go.mod h1:wZv/9vPiUib6tkoDl+AZ/QLf5YZgMravZ7jxH2eQWAE=
 github.com/gofrs/flock v0.8.1/go.mod h1:F1TvTiK9OcQqauNUHlbJvyl9Qa1QvF/gOUDKA14jxHU=
@@ -1243,6 +1245,7 @@ github.com/opencontainers/runtime-spec v1.0.1/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/
 github.com/opencontainers/runtime-spec v1.0.2-0.20190207185410-29686dbc5559/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
 github.com/opencontainers/runtime-spec v1.0.2/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
 github.com/opencontainers/runtime-spec v1.0.3-0.20200929063507-e6143ca7d51d/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
+github.com/opencontainers/runtime-spec v1.0.3-0.20210326190908-1c3f411f0417 h1:3snG66yBm59tKhhSPQrQ/0bCrv1LQbKt40LnUPiUxdc=
 github.com/opencontainers/runtime-spec v1.0.3-0.20210326190908-1c3f411f0417/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
 github.com/opencontainers/runtime-tools v0.0.0-20181011054405-1d69bd0f9c39/go.mod h1:r3f7wjNzSs2extwzU3Y+6pKfobzPh+kKFJ3ofN+3nfs=
 github.com/opencontainers/selinux v1.6.0/go.mod h1:VVGKuOLlE7v4PJyT6h7mNWvq1rzqiriPsEqVhc+svHE=

--- a/pkg/config/app/kuma-dp/config.go
+++ b/pkg/config/app/kuma-dp/config.go
@@ -137,6 +137,13 @@ type DataplaneRuntime struct {
 	// Available values are: [trace][debug][info][warning|warn][error][critical][off]
 	// By default it inherits Kuma DP logging level.
 	EnvoyLogLevel string `yaml:"envoyLogLevel,omitempty" envconfig:"kuma_dataplane_runtime_envoy_log_level"`
+	// Resources defines the resources for this proxy.
+	Resources DataplaneResources `yaml:"resources,omitempty"`
+}
+
+// DataplaneResources defines the resources available to a dataplane proxy.
+type DataplaneResources struct {
+	MaxHeapSizeBytes uint64 `yaml:"maxHeapSizeBytes,omitempty" envconfig:"kuma_dataplane_resources_max_heap_size_bytes"`
 }
 
 var _ config.Config = &Config{}

--- a/pkg/config/app/kuma-dp/config.go
+++ b/pkg/config/app/kuma-dp/config.go
@@ -143,7 +143,7 @@ type DataplaneRuntime struct {
 
 // DataplaneResources defines the resources available to a dataplane proxy.
 type DataplaneResources struct {
-	MaxHeapSizeBytes uint64 `yaml:"maxHeapSizeBytes,omitempty" envconfig:"kuma_dataplane_resources_max_heap_size_bytes"`
+	MaxMemoryBytes uint64 `yaml:"maxMemoryBytes,omitempty" envconfig:"kuma_dataplane_resources_max_memory_bytes"`
 }
 
 var _ config.Config = &Config{}

--- a/pkg/plugins/runtime/k8s/controllers/gateway_instance_controller.go
+++ b/pkg/plugins/runtime/k8s/controllers/gateway_instance_controller.go
@@ -238,6 +238,17 @@ func (r *GatewayInstanceReconciler) createOrUpdateDeployment(
 			}
 
 			container.Name = k8s_util.KumaGatewayContainerName
+			container.Env = append(container.Env,
+				kube_core.EnvVar{
+					Name: "KUMA_DATAPLANE_RESOURCES_MAX_HEAP_SIZE_BYTES",
+					ValueFrom: &kube_core.EnvVarSource{
+						ResourceFieldRef: &kube_core.ResourceFieldSelector{
+							ContainerName: container.Name,
+							Resource:      "limits.memory",
+						},
+					},
+				},
+			)
 
 			unprivilegedPortStartSupported, err := isUnprivilegedPortStartSysctlSupported(*r.K8sVersion)
 			if err != nil {

--- a/pkg/plugins/runtime/k8s/controllers/gateway_instance_controller.go
+++ b/pkg/plugins/runtime/k8s/controllers/gateway_instance_controller.go
@@ -240,7 +240,7 @@ func (r *GatewayInstanceReconciler) createOrUpdateDeployment(
 			container.Name = k8s_util.KumaGatewayContainerName
 			container.Env = append(container.Env,
 				kube_core.EnvVar{
-					Name: "KUMA_DATAPLANE_RESOURCES_MAX_HEAP_SIZE_BYTES",
+					Name: "KUMA_DATAPLANE_RESOURCES_MAX_MEMORY_BYTES",
 					ValueFrom: &kube_core.EnvVarSource{
 						ResourceFieldRef: &kube_core.ResourceFieldSelector{
 							ContainerName: container.Name,

--- a/pkg/xds/bootstrap/generator.go
+++ b/pkg/xds/bootstrap/generator.go
@@ -134,6 +134,10 @@ func (b *bootstrapGenerator) Generate(ctx context.Context, request types.Bootstr
 			return nil, kumaDpBootstrap, err
 		}
 
+		if dataplane.Spec.IsBuiltinGateway() {
+			params.IsGatewayDataplane = true
+		}
+
 		params.Service = dataplane.Spec.GetIdentifyingService()
 		setAdminPort(dataplane.Spec.GetNetworking().GetAdmin().GetPort())
 

--- a/pkg/xds/bootstrap/generator.go
+++ b/pkg/xds/bootstrap/generator.go
@@ -98,6 +98,7 @@ func (b *bootstrapGenerator) Generate(ctx context.Context, request types.Bootstr
 		EmptyDNSPort:          request.EmptyDNSPort,
 		ProxyType:             request.ProxyType,
 		Features:              request.Features,
+		Resources:             request.Resources,
 	}
 	if params.ProxyType == "" {
 		params.ProxyType = string(mesh_proto.DataplaneProxyType)

--- a/pkg/xds/bootstrap/parameters.go
+++ b/pkg/xds/bootstrap/parameters.go
@@ -2,6 +2,8 @@ package bootstrap
 
 import (
 	"time"
+
+	"github.com/kumahq/kuma/pkg/xds/bootstrap/types"
 )
 
 type KumaDpBootstrap struct {
@@ -42,4 +44,5 @@ type configParameters struct {
 	ProxyType             string
 	Features              []string
 	IsGatewayDataplane    bool
+	Resources             types.ProxyResources
 }

--- a/pkg/xds/bootstrap/parameters.go
+++ b/pkg/xds/bootstrap/parameters.go
@@ -1,6 +1,8 @@
 package bootstrap
 
-import "time"
+import (
+	"time"
+)
 
 type KumaDpBootstrap struct {
 	AggregateMetricsConfig []AggregateMetricsConfig
@@ -39,4 +41,5 @@ type configParameters struct {
 	EmptyDNSPort          uint32
 	ProxyType             string
 	Features              []string
+	IsGatewayDataplane    bool
 }

--- a/pkg/xds/bootstrap/server_test.go
+++ b/pkg/xds/bootstrap/server_test.go
@@ -135,6 +135,23 @@ var _ = Describe("Bootstrap Server", func() {
 		}
 	}
 
+	gatewayDataplane := func() *mesh.DataplaneResource {
+		return &mesh.DataplaneResource{
+			Spec: &mesh_proto.Dataplane{
+				Networking: &mesh_proto.Dataplane_Networking{
+					Address: "8.8.8.8",
+					Gateway: &mesh_proto.Dataplane_Networking_Gateway{
+						Type: mesh_proto.Dataplane_Networking_Gateway_BUILTIN,
+						Tags: map[string]string{
+							mesh_proto.ServiceTag: "gateway",
+						},
+					},
+					Admin: &mesh_proto.EnvoyAdmin{},
+				},
+			},
+		}
+	}
+
 	type testCase struct {
 		dataplaneName      string
 		dataplane          func() *mesh.DataplaneResource
@@ -186,6 +203,12 @@ var _ = Describe("Bootstrap Server", func() {
 			dataplane:          defaultDataplane,
 			body:               fmt.Sprintf(`{ "mesh": "default", "name": "dp-1.default", "dataplaneToken": "token", %s }`, version),
 			expectedConfigFile: "bootstrap.k8s.golden.yaml",
+		}),
+		Entry("with max heap size", testCase{
+			dataplaneName:      "gateway-1.default",
+			dataplane:          gatewayDataplane,
+			body:               fmt.Sprintf(`{ "mesh": "default", "name": "gateway-1.default", "dataplaneToken": "token", "resources": { "maxHeapSizeBytes": 2000000 }, %s }`, version),
+			expectedConfigFile: "bootstrap.gateway.golden.yaml",
 		}),
 		Entry("full data provided", testCase{
 			dataplaneName: "dp-1.default",

--- a/pkg/xds/bootstrap/template_v3.go
+++ b/pkg/xds/bootstrap/template_v3.go
@@ -190,12 +190,7 @@ func genConfig(parameters configParameters, useTokenPath bool) (*envoy_bootstrap
 	}
 
 	if parameters.IsGatewayDataplane {
-		if maxBytesRaw, ok := parameters.DynamicMetadata["max_heap_size_bytes"]; ok {
-			maxBytes, err := strconv.ParseUint(maxBytesRaw, 10, 64)
-			if err != nil {
-				return nil, err
-			}
-
+		if maxBytes := parameters.Resources.MaxHeapSizeBytes; maxBytes > 0 {
 			config := &resource_monitors_fixed_heap.FixedHeapConfig{
 				MaxHeapSizeBytes: maxBytes,
 			}

--- a/pkg/xds/bootstrap/testdata/bootstrap.gateway.golden.yaml
+++ b/pkg/xds/bootstrap/testdata/bootstrap.gateway.golden.yaml
@@ -1,0 +1,145 @@
+dynamicResources:
+  adsConfig:
+    apiType: GRPC
+    grpcServices:
+    - envoyGrpc:
+        clusterName: ads_cluster
+      initialMetadata:
+      - key: authorization
+        value: token
+    setNodeOnFirstMessageOnly: true
+    transportApiVersion: V3
+  cdsConfig:
+    ads: {}
+    resourceApiVersion: V3
+  ldsConfig:
+    ads: {}
+    resourceApiVersion: V3
+hdsConfig:
+  apiType: GRPC
+  grpcServices:
+  - envoyGrpc:
+      clusterName: ads_cluster
+    initialMetadata:
+    - key: authorization
+      value: token
+  setNodeOnFirstMessageOnly: true
+  transportApiVersion: V3
+layeredRuntime:
+  layers:
+  - name: kuma
+    staticLayer:
+      envoy.restart_features.use_apple_api_for_dns_lookups: false
+      re2.max_program_size.error_level: 4294967295
+      re2.max_program_size.warn_level: 1000
+node:
+  cluster: gateway
+  id: default.gateway-1.default
+  metadata:
+    dataplane.proxyType: dataplane
+    features: []
+    version:
+      dependencies: {}
+      envoy:
+        build: hash/1.15.0/RELEASE
+        kumaDpCompatible: false
+        version: 1.15.0
+      kumaDp:
+        buildDate: "2019-08-07T11:26:06Z"
+        gitCommit: 91ce236824a9d875601679aa80c63783fb0e8725
+        gitTag: v0.0.1
+        version: 0.0.1
+overloadManager:
+  actions:
+  - name: envoy.overload_actions.shrink_heap
+    triggers:
+    - name: envoy.resource_monitors.fixed_heap
+      threshold:
+        value: 0.95
+  - name: envoy.overload_actions.stop_accepting_requests
+    triggers:
+    - name: envoy.resource_monitors.fixed_heap
+      threshold:
+        value: 0.98
+  refreshInterval: 0.250s
+  resourceMonitors:
+  - name: envoy.resource_monitors.fixed_heap
+    typedConfig:
+      '@type': type.googleapis.com/envoy.extensions.resource_monitors.fixed_heap.v3.FixedHeapConfig
+      maxHeapSizeBytes: "2000000"
+staticResources:
+  clusters:
+  - connectTimeout: 1s
+    loadAssignment:
+      clusterName: access_log_sink
+      endpoints:
+      - lbEndpoints:
+        - endpoint:
+            address:
+              pipe:
+                path: /tmp/kuma-al-gateway-1.default-default.sock
+    name: access_log_sink
+    type: STATIC
+    typedExtensionProtocolOptions:
+      envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+        '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+        explicitHttpConfig:
+          http2ProtocolOptions: {}
+    upstreamConnectionOptions:
+      tcpKeepalive:
+        keepaliveInterval: 10
+        keepaliveProbes: 3
+        keepaliveTime: 10
+  - connectTimeout: 1s
+    loadAssignment:
+      clusterName: ads_cluster
+      endpoints:
+      - lbEndpoints:
+        - endpoint:
+            address:
+              socketAddress:
+                address: localhost
+                portValue: 5678
+    name: ads_cluster
+    transportSocket:
+      name: envoy.transport_sockets.tls
+      typedConfig:
+        '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
+        commonTlsContext:
+          tlsParams:
+            tlsMinimumProtocolVersion: TLSv1_2
+          validationContextSdsSecretConfig:
+            name: cp_validation_ctx
+        sni: localhost
+    type: STRICT_DNS
+    typedExtensionProtocolOptions:
+      envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+        '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+        explicitHttpConfig:
+          http2ProtocolOptions: {}
+    upstreamConnectionOptions:
+      tcpKeepalive:
+        keepaliveInterval: 10
+        keepaliveProbes: 3
+        keepaliveTime: 10
+  secrets:
+  - name: cp_validation_ctx
+    validationContext:
+      matchSubjectAltNames:
+      - exact: localhost
+      trustedCa:
+        inlineBytes: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURNekNDQWh1Z0F3SUJBZ0lRRGhsSW5mc1hZSGFtS04rMjlxblF2ekFOQmdrcWhraUc5dzBCQVFzRkFEQVAKTVEwd0N3WURWUVFERXdScmRXMWhNQjRYRFRJeE1EUXdNakV3TWpJeU5sb1hEVE14TURNek1URXdNakl5TmxvdwpEekVOTUFzR0ExVUVBeE1FYTNWdFlUQ0NBU0l3RFFZSktvWklodmNOQVFFQkJRQURnZ0VQQURDQ0FRb0NnZ0VCCkFMNEdHZytlMk83ZUExMkYwRjZ2MnJyOGoyaVZTRktlcG5adEwxNWxyQ2RzNmxxSzUwc1hXT3c4UEtacDJpaEEKWEpWVFNaekthc3lMRFRBUjlWWVFqVHBFNTI2RXp2dGR0aFNhZ2YzMlFXVyt3WTZMTXBFZGV4S09PQ3gyc2U1NQpSZDk3TDMzeVlQZmdYMTVPWWxpSFBEMDU2ampob3RITGROMmxweTcrU1REdlF5Um5YQXU3M1lrWTM3RWQ0aEk0CnQvVjZzb0h5RUdOY0RobTlwNWZCR3F6MG5qQmJRa3AybFRZNS9rajQycUI3UTZyQ00ydGJQc0VNb29lQUF3NW0KaHlZNHhqMHRQOXVjcWxVejhnYys2bzhIRE5zdDhOZUpYWmt0V24rQ095dGpyL056R2dTMjJrdlNEcGhpc0pvdApvMEZ5b0lPZEF0eEMxcXhYWFIrWHVVVUNBd0VBQWFPQmlqQ0JoekFPQmdOVkhROEJBZjhFQkFNQ0FxUXdIUVlEClZSMGxCQll3RkFZSUt3WUJCUVVIQXdFR0NDc0dBUVVGQndNQk1BOEdBMVVkRXdFQi93UUZNQU1CQWY4d0hRWUQKVlIwT0JCWUVGS1JMa2dJelgvT2pLdzlpZGVwdVEvUk10VCtBTUNZR0ExVWRFUVFmTUIyQ0NXeHZZMkZzYUc5egpkSWNRL1FDaEl3QUFBQUFBQUFBQUFBQUFBVEFOQmdrcWhraUc5dzBCQVFzRkFBT0NBUUVBUHM1eUpaaG9ZbEdXCkNwQThkU0lTaXZNOC84aUJOUTNmVndQNjNmdDBFSkxNVkd1MlJGWjQvVUFKL3JVUFNHTjh4aFhTazUrMWQ1NmEKL2thSDlyWDBIYVJJSEhseEE3aVBVS3hBajQ0eDlMS21xUEhUb0wzWGxXWTFBWHp2aWNXOWQrR00yRmFRZWUrSQpsZWFxTGJ6MEFadmxudTI3MVoxQ2VhQUN1VTlHbGp1anZ5aVRURTluYUhVRXF2SGdTcFB0aWxKYWx5SjUveklsClo5RjArVVd0M1RPWU1zNWcrU0N0ME13SFROYmlzYm1ld3BjRkZKemp0Mmt2dHJjOXQ5ZGtGODF4aGNTMTl3N3EKaDFBZVAzUlJsTGw3YnY5RUFWWEVtSWF2aWgvMjlQQTNaU3krcGJZTlc3ak5KSGpNUTRoUTBFK3hjQ2F6VS9PNAp5cFdHYWFudlBnPT0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=
+statsConfig:
+  statsTags:
+  - regex: ^grpc\.((.+)\.)
+    tagName: name
+  - regex: ^grpc.*streams_closed(_([0-9]+))
+    tagName: status
+  - regex: ^kafka(\.(\S*[0-9]))\.
+    tagName: kafka_name
+  - regex: ^kafka\..*\.(.*)
+    tagName: kafka_type
+  - regex: (worker_([0-9]+)\.)
+    tagName: worker
+  - regex: ((.+?)\.)rbac\.
+    tagName: listener

--- a/pkg/xds/bootstrap/types/bootstrap_request.go
+++ b/pkg/xds/bootstrap/types/bootstrap_request.go
@@ -16,6 +16,7 @@ type BootstrapRequest struct {
 	EmptyDNSPort    uint32            `json:"emptyDnsPort,omitempty"`
 	OperatingSystem string            `json:"operatingSystem"`
 	Features        []string          `json:"features"`
+	Resources       ProxyResources    `json:"resources"`
 }
 
 type Version struct {
@@ -34,4 +35,10 @@ type EnvoyVersion struct {
 	Version          string `json:"version"`
 	Build            string `json:"build"`
 	KumaDpCompatible bool   `json:"kumaDpCompatible"`
+}
+
+// ProxyResources contains information about what resources this proxy has
+// available
+type ProxyResources struct {
+	MaxHeapSizeBytes uint64 `json:"maxHeapSizeBytes"`
 }


### PR DESCRIPTION
### Summary

As suggested by [the Envoy docs](https://www.envoyproxy.io/docs/envoy/latest/configuration/best_practices/edge)

This PR checks both Kubernetes limits (via Downward API) directly as well as `cgroup` limits if they're available.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] Link to docs PR or issue -- https://github.com/kumahq/kuma-website/issues/931
- [x] Link to UI issue or PR -- Closes https://github.com/kumahq/kuma/issues/3305
- [x] Is the [issue worked on linked][1]? -- #3305 #3304 
- [x] Unit Tests --
- [x] E2E Tests -- none
- [x] Manual Universal Tests --
- [x] Manual Kubernetes Tests --
- [x] Do you need to update [`UPGRADE.md`](/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](/CONTRIBUTING.md#backporting)? -- no

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
