### PR TITLE
fix: update kuma-net to fix failing cni test

### DIFF
--- a/app/cni/pkg/cni/injector_linux.go
+++ b/app/cni/pkg/cni/injector_linux.go
@@ -128,8 +128,10 @@ func mapToConfig(intermediateConfig *IntermediateConfig) (*kumanet_config.Config
 			return nil, err
 		}
 		cfg.Redirect.DNS = kumanet_config.DNS{
-			Enabled: true,
-			Port:    builtinDnsPort,
+			Enabled:            true,
+			Port:               builtinDnsPort,
+			CaptureAll:         true,
+			ConntrackZoneSplit: true,
 		}
 	}
 	return &cfg, nil

--- a/app/cni/pkg/cni/injector_linux.go
+++ b/app/cni/pkg/cni/injector_linux.go
@@ -79,6 +79,7 @@ func mapToConfig(intermediateConfig *IntermediateConfig) (*kumanet_config.Config
 		},
 		Redirect: kumanet_config.Redirect{
 			Outbound: kumanet_config.TrafficFlow{
+				Enabled:      true,
 				Port:         port,
 				ExcludePorts: excludePorts,
 			},
@@ -110,6 +111,7 @@ func mapToConfig(intermediateConfig *IntermediateConfig) (*kumanet_config.Config
 			return nil, err
 		}
 		cfg.Redirect.Inbound = kumanet_config.TrafficFlow{
+			Enabled:      true,
 			Port:         inboundPort,
 			PortIPv6:     inboundPortV6,
 			ExcludePorts: excludedPorts,

--- a/app/cni/pkg/cni/injector_linux.go
+++ b/app/cni/pkg/cni/injector_linux.go
@@ -9,8 +9,8 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
 
-	"github.com/kumahq/kuma-net/iptables/builder"
-	"github.com/kumahq/kuma-net/transparent-proxy/config"
+	kumanet_tproxy "github.com/kumahq/kuma-net/transparent-proxy"
+	kumanet_config "github.com/kumahq/kuma-net/transparent-proxy/config"
 
 	"github.com/kumahq/kuma/pkg/transparentproxy"
 )
@@ -51,7 +51,7 @@ func Inject(netns string, logger logr.Logger, intermediateConfig *IntermediateCo
 	defer namespace.Close()
 
 	err = namespace.Do(func(_ ns.NetNS) error {
-		rules, err := builder.RestoreIPTables(*cfg)
+		rules, err := kumanet_tproxy.Setup(*cfg)
 		if err != nil {
 			return err
 		}
@@ -63,7 +63,7 @@ func Inject(netns string, logger logr.Logger, intermediateConfig *IntermediateCo
 	return err
 }
 
-func mapToConfig(intermediateConfig *IntermediateConfig) (*config.Config, error) {
+func mapToConfig(intermediateConfig *IntermediateConfig) (*kumanet_config.Config, error) {
 	port, err := convertToUint16("inbound port", intermediateConfig.targetPort)
 	if err != nil {
 		return nil, err
@@ -72,13 +72,13 @@ func mapToConfig(intermediateConfig *IntermediateConfig) (*config.Config, error)
 	if err != nil {
 		return nil, err
 	}
-	cfg := config.Config{
+	cfg := kumanet_config.Config{
 		RuntimeStdout: ioutil.Discard,
-		Owner: config.Owner{
+		Owner: kumanet_config.Owner{
 			UID: intermediateConfig.noRedirectUID,
 		},
-		Redirect: config.Redirect{
-			Outbound: config.TrafficFlow{
+		Redirect: kumanet_config.Redirect{
+			Outbound: kumanet_config.TrafficFlow{
 				Port:         port,
 				ExcludePorts: excludePorts,
 			},
@@ -109,7 +109,7 @@ func mapToConfig(intermediateConfig *IntermediateConfig) (*config.Config, error)
 		if err != nil {
 			return nil, err
 		}
-		cfg.Redirect.Inbound = config.TrafficFlow{
+		cfg.Redirect.Inbound = kumanet_config.TrafficFlow{
 			Port:         inboundPort,
 			PortIPv6:     inboundPortV6,
 			ExcludePorts: excludedPorts,
@@ -125,7 +125,7 @@ func mapToConfig(intermediateConfig *IntermediateConfig) (*config.Config, error)
 		if err != nil {
 			return nil, err
 		}
-		cfg.Redirect.DNS = config.DNS{
+		cfg.Redirect.DNS = kumanet_config.DNS{
 			Enabled: true,
 			Port:    builtinDnsPort,
 		}

--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/gruntwork-io/terratest v0.40.18
 	github.com/hoisie/mustache v0.0.0-20160804235033-6375acf62c69
 	github.com/kelseyhightower/envconfig v1.4.0
-	github.com/kumahq/kuma-net v0.4.1
+	github.com/kumahq/kuma-net v0.4.2
 	github.com/kumahq/protoc-gen-kumadoc v0.3.0
 	github.com/lib/pq v1.10.6
 	github.com/miekg/dns v1.1.50

--- a/go.sum
+++ b/go.sum
@@ -1015,8 +1015,8 @@ github.com/kumahq/gateway-api v0.0.0-20220714082056-fbb05ce01577 h1:YPnAD+6Sier4
 github.com/kumahq/gateway-api v0.0.0-20220714082056-fbb05ce01577/go.mod h1:x0AP6gugkFV8fC/oTlnOMU0pnmuzIR8LfIPRVUjxSqA=
 github.com/kumahq/go-control-plane v0.9.10-0.20211022075049-d35edcf0813a h1:RtOjGzZDv0JDtpWthWmxDHXhZRnJBaeIoIHcQrigWdE=
 github.com/kumahq/go-control-plane v0.9.10-0.20211022075049-d35edcf0813a/go.mod h1:utjuSZ1DPHuYf0cTZ8WEsaQf5bwmT1TZiWaQjpJtBF0=
-github.com/kumahq/kuma-net v0.4.1 h1:AS76xSikIYKmNV2ii8BEO+2a8M+cr4HrWq0N2s/j+HA=
-github.com/kumahq/kuma-net v0.4.1/go.mod h1:f6FAs2ULvGoJ4NeOoOD5F58oERXQpxZiKUww+iRQPZc=
+github.com/kumahq/kuma-net v0.4.2 h1:eNiExbfcs1Oc9veE39MXif5YrXK+TbYX6GULVoo7Oxo=
+github.com/kumahq/kuma-net v0.4.2/go.mod h1:f6FAs2ULvGoJ4NeOoOD5F58oERXQpxZiKUww+iRQPZc=
 github.com/kumahq/protoc-gen-kumadoc v0.3.0 h1:EXCZZd2TUxWrnCcdQa9lV8/00uKgvaa4U2yTgnZ0H1w=
 github.com/kumahq/protoc-gen-kumadoc v0.3.0/go.mod h1:F+c9RjgKlv1Q3UEoPJCtMJw8Fd+X5PfG5jlkTSfZOMA=
 github.com/lann/builder v0.0.0-20180802200727-47ae307949d0/go.mod h1:dXGbAdH5GtBTC4WfIxhKZfyBF/HBFgRZSWwZ9g/He9o=

--- a/pkg/transparentproxy/transparentproxy_experimental.go
+++ b/pkg/transparentproxy/transparentproxy_experimental.go
@@ -135,11 +135,13 @@ func (tp *ExperimentalTransparentProxy) Setup(tpConfig *config.TransparentProxyC
 		Redirect: kumanet_config.Redirect{
 			NamePrefix: "KUMA_",
 			Inbound: kumanet_config.TrafficFlow{
+				Enabled:      tpConfig.RedirectInBound,
 				Port:         redirectInboundPort,
 				PortIPv6:     redirectInboundPortIPv6,
 				ExcludePorts: excludeInboundPorts,
 			},
 			Outbound: kumanet_config.TrafficFlow{
+				Enabled:      true,
 				Port:         redirectOutboundPort,
 				ExcludePorts: excludeOutboundPorts,
 			},


### PR DESCRIPTION
Update kuma-net to 0.4.2 to fix failing test with experimental CNI

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] Link to docs PR or issue -- it's a fix for failing e2e test on CI
- [x] Link to UI issue or PR -- it's a fix for failing e2e test on CI
- [x] Is the [issue worked on linked][1]? -- it's a fix for failing e2e test on CI
- [x] Unit Tests -- it's a fix for failing e2e test on CI
- [x] E2E Tests -- it's a fix for failing e2e test on CI
- [x] Manual Universal Tests -- it's a fix for failing e2e test on CI
- [x] Manual Kubernetes Tests -- it's a fix for failing e2e test on CI
- [x] Do you need to update [`UPGRADE.md`](/UPGRADE.md)? -- it's a fix for failing e2e test on CI
- [x] Does it need to be backported according to the [backporting policy](/CONTRIBUTING.md#backporting)? -- it's a fix for failing e2e test on CI and the issue was introduced in the master and not released earlier

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
