### PR TITLE
feat(stats): implement rule evaluation stats tracer and generator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,3 +27,6 @@ include mk/k3d.mk
 include mk/e2e.new.mk
 include mk/docs.mk
 include mk/envoy.mk
+ifdef KUMA_BUILD_GENERATE_STATS
+include mk/stats.mk
+endif

--- a/mk/stats.mk
+++ b/mk/stats.mk
@@ -1,0 +1,2 @@
+OLD_SHELL := $(SHELL)
+SHELL = /bin/bash ${KUMA_DIR}/tools/stats/tracer.sh $(OLD_SHELL) $@ ${KUMA_DIR}

--- a/tools/stats/tracer.sh
+++ b/tools/stats/tracer.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+OLD_SHELL="$1"
+TARGET="$2"
+KUMA_DIR="$3"
+shift
+shift
+shift
+
+# time in ms
+START=$(gdate +%s%3N)
+"$OLD_SHELL" "$@"
+STOP=$(gdate +%s%3N)
+TOTAL=$((STOP-START))
+
+if (( TOTAL > 0 )); then
+    echo "{\"$TARGET\": $TOTAL}" >> "$KUMA_DIR"/build/build-times
+fi


### PR DESCRIPTION
This PR implements a simple tracer that writes rule execution times to `build/build-times` in a json format:

```
{"build/linux-arm64": 7733}
{"image/kuma-universal": 6}
```

I plan to gather this data on my local machine so I know which parts take the longest and which could be improved to speed up the developer feedback loop. The tracer is only enabled if an env var called `KUMA_BUILD_GENERATE_STATS` is defined, for now it only works on OSX.

Signed-off-by: slonka <slonka@users.noreply.github.com>

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] Link to docs PR or issue -- experimental feature, no docs
- [X] Link to UI issue or PR -- not an UI issue
- [X] Is the [issue worked on linked][1]? -- no issue reported yet, PR is small enough
- [X] Unit Tests -- not a kuma code change
- [X] E2E Tests -- not a kuma code change
- [X] Manual Universal Tests -- manually tested the build process
- [X] Manual Kubernetes Tests -- not a k8s feature
- [X] Do you need to update [`UPGRADE.md`](/UPGRADE.md)? -- no
- [X] Does it need to be backported according to the [backporting policy](/CONTRIBUTING.md#backporting)? -- no need

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
