### PR TITLE
fix(kuma-dp): set prometheus content-type when returning metrics

### DIFF
--- a/app/kuma-dp/pkg/dataplane/metrics/server.go
+++ b/app/kuma-dp/pkg/dataplane/metrics/server.go
@@ -20,13 +20,7 @@ import (
 	"github.com/kumahq/kuma/pkg/xds/envoy"
 )
 
-const (
-	acceptHeader            = "accept"
-	acceptEncodingHeader    = "accept-encoding"
-	userAgentHeader         = "user-agent"
-	prometheusTimeoutHeader = "x-prometheus-scrape-timeout-seconds"
-)
-
+var prometheusRequestHeaders = []string{"accept", "accept-encoding", "user-agent", "x-prometheus-scrape-timeout-seconds"}
 var logger = core.Log.WithName("metrics-hijacker")
 
 var _ component.Component = &Hijacker{}
@@ -198,7 +192,7 @@ func (s *Hijacker) getStats(ctx context.Context, initReq *http.Request, app Appl
 func (s *Hijacker) passRequestHeaders(into http.Header, from http.Header) {
 	// pass request headers
 	// https://github.com/prometheus/prometheus/blob/main/scrape/scrape.go#L772
-	for _, header := range []string{acceptEncodingHeader, acceptHeader, prometheusTimeoutHeader, userAgentHeader} {
+	for _, header := range prometheusRequestHeaders {
 		val := from.Get(header)
 		if val != "" {
 			into.Set(header, val)

--- a/test/e2e_env/universal/observability/applications_metrics.go
+++ b/test/e2e_env/universal/observability/applications_metrics.go
@@ -6,6 +6,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/prometheus/common/expfmt"
 
 	"github.com/kumahq/kuma/test/e2e_env/universal/env"
 	. "github.com/kumahq/kuma/test/framework"
@@ -177,6 +178,7 @@ metrics:
 		// then
 		Expect(err).ToNot(HaveOccurred())
 		Expect(stdout).ToNot(BeNil())
+		Expect(stdout).To(ContainSubstring(string(expfmt.FmtText)))
 
 		// response doesn't exist because was disabled
 		Expect(stdout).ToNot(ContainSubstring("path-stats"))


### PR DESCRIPTION
## Summary 
`kuma-dp` scrapes metrics from the applications, aggregates them, and returns. Unfortunately we were not setting correct `content-type` and some applications could file while scraping. Added setting of content type based on https://github.com/prometheus/docs/blob/main/content/docs/instrumenting/exposition_formats.md#basic-info. Also, added passing of prometheus requests header to the application. based on the code (https://github.com/prometheus/prometheus/blob/main/scrape/scrape.go#L772)
### Checklist prior to review
~- [ ] Link to docs PR or issue~ --
~- [ ] Link to UI issue or PR~ --
- [X] Is the [issue worked on linked][1]? -- Fix #4607 
~- [ ] Unit Tests~ --
- [X] E2E Tests --
- [X] Manual Universal Tests --
- [X] Manual Kubernetes Tests --
~- [ ] Do you need to update [`UPGRADE.md`](/UPGRADE.md)?~ --
~- [ ] Does it need to be backported according to the [backporting policy](/CONTRIBUTING.md#backporting)?~ -- 
