### PR TITLE
feat(kuma-dp): detect memory limit only on linux

### DIFF
--- a/app/kuma-dp/pkg/dataplane/envoy/memory_limit_darwin.go
+++ b/app/kuma-dp/pkg/dataplane/envoy/memory_limit_darwin.go
@@ -1,0 +1,5 @@
+package envoy
+
+func DetectMaxMemory() uint64 {
+	return 0
+}

--- a/app/kuma-dp/pkg/dataplane/envoy/memory_limit_linux.go
+++ b/app/kuma-dp/pkg/dataplane/envoy/memory_limit_linux.go
@@ -1,0 +1,50 @@
+package envoy
+
+import (
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/containerd/cgroups"
+)
+
+type UIntOrString struct {
+	Type   string
+	UInt   uint64
+	String string
+}
+
+func DetectMaxMemory() uint64 {
+	switch cgroups.Mode() {
+	case cgroups.Legacy:
+		res := maybeReadAsBytes("/sys/fs/cgroup/memory.limit_in_bytes")
+		if res != nil && res.Type == "int" {
+			return res.UInt
+		}
+	case cgroups.Hybrid, cgroups.Unified:
+		res := maybeReadAsBytes("/sys/fs/cgroup/memory.max")
+		if res != nil && res.Type == "int" {
+			return res.UInt
+		}
+	}
+	return 0
+}
+
+func maybeReadAsBytes(path string) *UIntOrString {
+	byteContents, err := os.ReadFile(path)
+	if err == nil {
+		contents := strings.TrimSpace(string(byteContents))
+		bytes, err := strconv.ParseUint(contents, 10, 64)
+		if err != nil {
+			return &UIntOrString{
+				Type:   "string",
+				String: contents,
+			}
+		}
+		return &UIntOrString{
+			Type: "int",
+			UInt: bytes,
+		}
+	}
+	return nil
+}

--- a/app/kuma-dp/pkg/dataplane/envoy/memory_limit_windows.go
+++ b/app/kuma-dp/pkg/dataplane/envoy/memory_limit_windows.go
@@ -1,0 +1,5 @@
+package envoy
+
+func DetectMaxMemory() uint64 {
+	return 0
+}


### PR DESCRIPTION
cgroups does not work on MacOS (and Windows).

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [X] Link to docs PR or issue --
- [X] Link to UI issue or PR --
- [X] Is the [issue worked on linked][1]? --
- [X] Unit Tests --
- [X] E2E Tests --
- [X] Manual Universal Tests --
- [X] Manual Kubernetes Tests --
- [X] Do you need to update [`UPGRADE.md`](/UPGRADE.md)? --
- [X] Does it need to be backported according to the [backporting policy](/CONTRIBUTING.md#backporting)? --

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
