### PR TITLE
feat(gateway): set global_downstream_max_connections to 50000

### DIFF
--- a/pkg/config/app/kuma-cp/config.go
+++ b/pkg/config/app/kuma-cp/config.go
@@ -143,6 +143,8 @@ type Config struct {
 	Access access.AccessConfig `yaml:"access"`
 	// Configuration of experimental features
 	Experimental ExperimentalConfig `yaml:"experimental"`
+	// ProxyConfiguration holds configuration for proxies
+	ProxyConfiguration xds.ProxyConfig `yaml:"proxyConfig"`
 }
 
 func (c *Config) Sanitize() {
@@ -202,6 +204,7 @@ var DefaultConfig = func() Config {
 			GatewayAPI:          false,
 			KubeOutboundsAsVIPs: false,
 		},
+		ProxyConfiguration: xds.DefaultProxyConfig(),
 	}
 }
 

--- a/pkg/config/app/kuma-cp/config.go
+++ b/pkg/config/app/kuma-cp/config.go
@@ -143,8 +143,8 @@ type Config struct {
 	Access access.AccessConfig `yaml:"access"`
 	// Configuration of experimental features
 	Experimental ExperimentalConfig `yaml:"experimental"`
-	// ProxyConfiguration holds configuration for proxies
-	ProxyConfiguration xds.ProxyConfig `yaml:"proxyConfig"`
+	// Proxy holds configuration for proxies
+	Proxy xds.Proxy `yaml:"proxy"`
 }
 
 func (c *Config) Sanitize() {
@@ -204,7 +204,7 @@ var DefaultConfig = func() Config {
 			GatewayAPI:          false,
 			KubeOutboundsAsVIPs: false,
 		},
-		ProxyConfiguration: xds.DefaultProxyConfig(),
+		Proxy: xds.DefaultProxyConfig(),
 	}
 }
 

--- a/pkg/config/app/kuma-cp/kuma-cp.defaults.yaml
+++ b/pkg/config/app/kuma-cp/kuma-cp.defaults.yaml
@@ -468,3 +468,7 @@ experimental:
   # If true, instead of embedding kubernetes outbounds into Dataplane object, they are persisted next to VIPs in ConfigMap
   # This can improve performance, but it should be enabled only after all instances are migrated to version that supports this config
   kubeOutboundsAsVIPs: false # ENV: KUMA_EXPERIMENTAL_KUBE_OUTBOUNDS_AS_VIPS
+
+proxyConfig:
+  gateway:
+    globalDownstreamMaxConnections: 50000

--- a/pkg/config/app/kuma-cp/kuma-cp.defaults.yaml
+++ b/pkg/config/app/kuma-cp/kuma-cp.defaults.yaml
@@ -469,6 +469,8 @@ experimental:
   # This can improve performance, but it should be enabled only after all instances are migrated to version that supports this config
   kubeOutboundsAsVIPs: false # ENV: KUMA_EXPERIMENTAL_KUBE_OUTBOUNDS_AS_VIPS
 
-proxyConfig:
+proxy:
   gateway:
-    globalDownstreamMaxConnections: 50000
+    # Sets the envoy runtime value to limit maximum number of incoming
+    # connections to a builtin gateway data plane proxy
+    globalDownstreamMaxConnections: 50000 # ENV: KUMA_PROXY_GATEWAY_GLOBAL_DOWNSTREAM_MAX_CONNECTIONS

--- a/pkg/config/xds/config.go
+++ b/pkg/config/xds/config.go
@@ -47,3 +47,20 @@ func DefaultXdsServerConfig() *XdsServerConfig {
 		NACKBackoff:                           5 * time.Second,
 	}
 }
+
+type ProxyConfig struct {
+	// Gateway holds data plane wide configuration for MeshGateway proxies
+	Gateway GatewayConfig `yaml:"gateway"`
+}
+
+type GatewayConfig struct {
+	GlobalDownstreamMaxConnections uint64 `yaml:"globalDownstreamMaxConnections"`
+}
+
+func DefaultProxyConfig() ProxyConfig {
+	return ProxyConfig{
+		Gateway: GatewayConfig{
+			GlobalDownstreamMaxConnections: 50000,
+		},
+	}
+}

--- a/pkg/config/xds/config.go
+++ b/pkg/config/xds/config.go
@@ -48,18 +48,18 @@ func DefaultXdsServerConfig() *XdsServerConfig {
 	}
 }
 
-type ProxyConfig struct {
+type Proxy struct {
 	// Gateway holds data plane wide configuration for MeshGateway proxies
-	Gateway GatewayConfig `yaml:"gateway"`
+	Gateway Gateway `yaml:"gateway"`
 }
 
-type GatewayConfig struct {
-	GlobalDownstreamMaxConnections uint64 `yaml:"globalDownstreamMaxConnections"`
+type Gateway struct {
+	GlobalDownstreamMaxConnections uint64 `yaml:"globalDownstreamMaxConnections" envconfig:"kuma_proxy_gateway_global_downstream_max_connections"`
 }
 
-func DefaultProxyConfig() ProxyConfig {
-	return ProxyConfig{
-		Gateway: GatewayConfig{
+func DefaultProxyConfig() Proxy {
+	return Proxy{
+		Gateway: Gateway{
 			GlobalDownstreamMaxConnections: 50000,
 		},
 	}

--- a/pkg/xds/bootstrap/components.go
+++ b/pkg/xds/bootstrap/components.go
@@ -9,7 +9,7 @@ func RegisterBootstrap(rt core_runtime.Runtime) error {
 	generator, err := NewDefaultBootstrapGenerator(
 		rt.ResourceManager(),
 		rt.Config().BootstrapServer,
-		rt.Config().ProxyConfiguration,
+		rt.Config().Proxy,
 		rt.Config().DpServer.TlsCertFile,
 		rt.Config().DpServer.Auth.Type != dp_server.DpServerAuthNone,
 		rt.Config().DpServer.Auth.UseTokenPath,

--- a/pkg/xds/bootstrap/components.go
+++ b/pkg/xds/bootstrap/components.go
@@ -9,6 +9,7 @@ func RegisterBootstrap(rt core_runtime.Runtime) error {
 	generator, err := NewDefaultBootstrapGenerator(
 		rt.ResourceManager(),
 		rt.Config().BootstrapServer,
+		rt.Config().ProxyConfiguration,
 		rt.Config().DpServer.TlsCertFile,
 		rt.Config().DpServer.Auth.Type != dp_server.DpServerAuthNone,
 		rt.Config().DpServer.Auth.UseTokenPath,

--- a/pkg/xds/bootstrap/generator.go
+++ b/pkg/xds/bootstrap/generator.go
@@ -33,7 +33,7 @@ type BootstrapGenerator interface {
 func NewDefaultBootstrapGenerator(
 	resManager core_manager.ResourceManager,
 	serverConfig *bootstrap_config.BootstrapServerConfig,
-	proxyConfig xds_config.ProxyConfig,
+	proxyConfig xds_config.Proxy,
 	dpServerCertFile string,
 	dpAuthEnabled bool,
 	dpUseTokenPath bool,
@@ -63,7 +63,7 @@ func NewDefaultBootstrapGenerator(
 type bootstrapGenerator struct {
 	resManager       core_manager.ResourceManager
 	config           *bootstrap_config.BootstrapServerConfig
-	proxyConfig      xds_config.ProxyConfig
+	proxyConfig      xds_config.Proxy
 	dpAuthEnabled    bool
 	dpUseTokenPath   bool
 	xdsCertFile      string

--- a/pkg/xds/bootstrap/generator.go
+++ b/pkg/xds/bootstrap/generator.go
@@ -13,6 +13,7 @@ import (
 	"github.com/pkg/errors"
 
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
+	xds_config "github.com/kumahq/kuma/pkg/config/xds"
 	bootstrap_config "github.com/kumahq/kuma/pkg/config/xds/bootstrap"
 	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	core_manager "github.com/kumahq/kuma/pkg/core/resources/manager"
@@ -31,7 +32,8 @@ type BootstrapGenerator interface {
 
 func NewDefaultBootstrapGenerator(
 	resManager core_manager.ResourceManager,
-	config *bootstrap_config.BootstrapServerConfig,
+	serverConfig *bootstrap_config.BootstrapServerConfig,
+	proxyConfig xds_config.ProxyConfig,
 	dpServerCertFile string,
 	dpAuthEnabled bool,
 	dpUseTokenPath bool,
@@ -42,12 +44,13 @@ func NewDefaultBootstrapGenerator(
 	if err != nil {
 		return nil, err
 	}
-	if config.Params.XdsHost != "" && !hostsAndIps[config.Params.XdsHost] {
-		return nil, errors.Errorf("hostname: %s set by KUMA_BOOTSTRAP_SERVER_PARAMS_XDS_HOST is not available in the DP Server certificate. Available hostnames: %q. Change the hostname or generate certificate with proper hostname.", config.Params.XdsHost, hostsAndIps.slice())
+	if serverConfig.Params.XdsHost != "" && !hostsAndIps[serverConfig.Params.XdsHost] {
+		return nil, errors.Errorf("hostname: %s set by KUMA_BOOTSTRAP_SERVER_PARAMS_XDS_HOST is not available in the DP Server certificate. Available hostnames: %q. Change the hostname or generate certificate with proper hostname.", serverConfig.Params.XdsHost, hostsAndIps.slice())
 	}
 	return &bootstrapGenerator{
 		resManager:       resManager,
-		config:           config,
+		config:           serverConfig,
+		proxyConfig:      proxyConfig,
 		xdsCertFile:      dpServerCertFile,
 		dpAuthEnabled:    dpAuthEnabled,
 		dpUseTokenPath:   dpUseTokenPath,
@@ -60,6 +63,7 @@ func NewDefaultBootstrapGenerator(
 type bootstrapGenerator struct {
 	resManager       core_manager.ResourceManager
 	config           *bootstrap_config.BootstrapServerConfig
+	proxyConfig      xds_config.ProxyConfig
 	dpAuthEnabled    bool
 	dpUseTokenPath   bool
 	xdsCertFile      string
@@ -155,7 +159,7 @@ func (b *bootstrapGenerator) Generate(ctx context.Context, request types.Bootstr
 		return nil, kumaDpBootstrap, err
 	}
 
-	config, err := genConfig(params, b.dpUseTokenPath)
+	config, err := genConfig(params, b.proxyConfig, b.dpUseTokenPath)
 	if err != nil {
 		return nil, kumaDpBootstrap, errors.Wrap(err, "failed creating bootstrap conf")
 	}

--- a/pkg/xds/bootstrap/generator_test.go
+++ b/pkg/xds/bootstrap/generator_test.go
@@ -95,7 +95,7 @@ var _ = Describe("bootstrapGenerator", func() {
 
 	type testCase struct {
 		serverConfig       *bootstrap_config.BootstrapServerConfig
-		proxyConfig        *xds_config.ProxyConfig
+		proxyConfig        *xds_config.Proxy
 		dataplane          func() *core_mesh.DataplaneResource
 		dpAuthEnabled      bool
 		useTokenPath       bool
@@ -383,7 +383,7 @@ var _ = Describe("bootstrapGenerator", func() {
 				cfg.Params.XdsPort = 5678
 				return cfg
 			}(),
-			proxyConfig: func() *xds_config.ProxyConfig {
+			proxyConfig: func() *xds_config.Proxy {
 				cfg := xds_config.DefaultProxyConfig()
 				cfg.Gateway.GlobalDownstreamMaxConnections = 35678
 				return &cfg

--- a/pkg/xds/bootstrap/server_test.go
+++ b/pkg/xds/bootstrap/server_test.go
@@ -16,6 +16,7 @@ import (
 
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	dp_server_cfg "github.com/kumahq/kuma/pkg/config/dp-server"
+	xds_config "github.com/kumahq/kuma/pkg/config/xds"
 	bootstrap_config "github.com/kumahq/kuma/pkg/config/xds/bootstrap"
 	"github.com/kumahq/kuma/pkg/core"
 	"github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
@@ -79,7 +80,9 @@ var _ = Describe("Bootstrap Server", func() {
 		}
 		dpServer := server.NewDpServer(dpServerCfg, metrics)
 
-		generator, err := bootstrap.NewDefaultBootstrapGenerator(resManager, config, filepath.Join("..", "..", "..", "test", "certs", "server-cert.pem"), true, false, true, 0)
+		proxyConfig := xds_config.DefaultProxyConfig()
+
+		generator, err := bootstrap.NewDefaultBootstrapGenerator(resManager, config, proxyConfig, filepath.Join("..", "..", "..", "test", "certs", "server-cert.pem"), true, false, true, 0)
 		Expect(err).ToNot(HaveOccurred())
 		bootstrapHandler := bootstrap.BootstrapHandler{
 			Generator: generator,

--- a/pkg/xds/bootstrap/template_v3.go
+++ b/pkg/xds/bootstrap/template_v3.go
@@ -36,7 +36,7 @@ func RegisterBootstrapCluster(c string) string {
 var adsClusterName = RegisterBootstrapCluster("ads_cluster")
 var accessLogSinkClusterName = RegisterBootstrapCluster("access_log_sink")
 
-func genConfig(parameters configParameters, proxyConfig xds.ProxyConfig, useTokenPath bool) (*envoy_bootstrap_v3.Bootstrap, error) {
+func genConfig(parameters configParameters, proxyConfig xds.Proxy, useTokenPath bool) (*envoy_bootstrap_v3.Bootstrap, error) {
 	staticClusters, err := buildStaticClusters(parameters, useTokenPath)
 	if err != nil {
 		return nil, err

--- a/pkg/xds/bootstrap/template_v3.go
+++ b/pkg/xds/bootstrap/template_v3.go
@@ -58,18 +58,27 @@ func genConfig(parameters configParameters, useTokenPath bool) (*envoy_bootstrap
 	}}
 
 	if parameters.IsGatewayDataplane {
-		runtimeLayers = append(runtimeLayers, &envoy_bootstrap_v3.RuntimeLayer{
-			Name: "gateway.listeners",
-			LayerSpecifier: &envoy_bootstrap_v3.RuntimeLayer_RtdsLayer_{
-				RtdsLayer: &envoy_bootstrap_v3.RuntimeLayer_RtdsLayer{
-					Name: "gateway.listeners",
-					RtdsConfig: &envoy_core_v3.ConfigSource{
-						ResourceApiVersion:    envoy_core_v3.ApiVersion_V3,
-						ConfigSourceSpecifier: &envoy_core_v3.ConfigSource_Ads{},
-					},
+		runtimeLayers = append(runtimeLayers,
+			&envoy_bootstrap_v3.RuntimeLayer{
+				Name: "gateway",
+				LayerSpecifier: &envoy_bootstrap_v3.RuntimeLayer_StaticLayer{
+					StaticLayer: util_proto.MustStruct(map[string]interface{}{
+						"overload.global_downstream_max_connections": 50000,
+					}),
 				},
 			},
-		})
+			&envoy_bootstrap_v3.RuntimeLayer{
+				Name: "gateway.listeners",
+				LayerSpecifier: &envoy_bootstrap_v3.RuntimeLayer_RtdsLayer_{
+					RtdsLayer: &envoy_bootstrap_v3.RuntimeLayer_RtdsLayer{
+						Name: "gateway.listeners",
+						RtdsConfig: &envoy_core_v3.ConfigSource{
+							ResourceApiVersion:    envoy_core_v3.ApiVersion_V3,
+							ConfigSourceSpecifier: &envoy_core_v3.ConfigSource_Ads{},
+						},
+					},
+				},
+			})
 	}
 
 	res := &envoy_bootstrap_v3.Bootstrap{

--- a/pkg/xds/bootstrap/template_v3.go
+++ b/pkg/xds/bootstrap/template_v3.go
@@ -20,6 +20,7 @@ import (
 	envoy_type_matcher_v3 "github.com/envoyproxy/go-control-plane/envoy/type/matcher/v3"
 	"github.com/pkg/errors"
 
+	"github.com/kumahq/kuma/pkg/config/xds"
 	util_proto "github.com/kumahq/kuma/pkg/util/proto"
 	clusters_v3 "github.com/kumahq/kuma/pkg/xds/envoy/clusters/v3"
 	"github.com/kumahq/kuma/pkg/xds/envoy/tls"
@@ -35,7 +36,7 @@ func RegisterBootstrapCluster(c string) string {
 var adsClusterName = RegisterBootstrapCluster("ads_cluster")
 var accessLogSinkClusterName = RegisterBootstrapCluster("access_log_sink")
 
-func genConfig(parameters configParameters, useTokenPath bool) (*envoy_bootstrap_v3.Bootstrap, error) {
+func genConfig(parameters configParameters, proxyConfig xds.ProxyConfig, useTokenPath bool) (*envoy_bootstrap_v3.Bootstrap, error) {
 	staticClusters, err := buildStaticClusters(parameters, useTokenPath)
 	if err != nil {
 		return nil, err
@@ -58,12 +59,17 @@ func genConfig(parameters configParameters, useTokenPath bool) (*envoy_bootstrap
 	}}
 
 	if parameters.IsGatewayDataplane {
+		connections := proxyConfig.Gateway.GlobalDownstreamMaxConnections
+		if connections == 0 {
+			connections = 50000
+		}
+
 		runtimeLayers = append(runtimeLayers,
 			&envoy_bootstrap_v3.RuntimeLayer{
 				Name: "gateway",
 				LayerSpecifier: &envoy_bootstrap_v3.RuntimeLayer_StaticLayer{
 					StaticLayer: util_proto.MustStruct(map[string]interface{}{
-						"overload.global_downstream_max_connections": 50000,
+						"overload.global_downstream_max_connections": connections,
 					}),
 				},
 			},

--- a/pkg/xds/bootstrap/template_v3_test.go
+++ b/pkg/xds/bootstrap/template_v3_test.go
@@ -108,7 +108,7 @@ var _ = Describe("genConfig", func() {
 		}
 
 		// when
-		result, err := genConfig(params, xds_config.ProxyConfig{}, true)
+		result, err := genConfig(params, xds_config.Proxy{}, true)
 
 		// then
 		Expect(err).ToNot(HaveOccurred())
@@ -161,7 +161,7 @@ var _ = Describe("genConfig", func() {
 		}
 
 		// when
-		result, err := genConfig(params, xds_config.ProxyConfig{}, false)
+		result, err := genConfig(params, xds_config.Proxy{}, false)
 
 		// then
 		Expect(err).ToNot(HaveOccurred())
@@ -196,7 +196,7 @@ var _ = Describe("genConfig", func() {
 		}
 
 		// when
-		result, err := genConfig(params, xds_config.ProxyConfig{}, true)
+		result, err := genConfig(params, xds_config.Proxy{}, true)
 
 		// then
 		Expect(err).ToNot(HaveOccurred())

--- a/pkg/xds/bootstrap/template_v3_test.go
+++ b/pkg/xds/bootstrap/template_v3_test.go
@@ -10,6 +10,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	xds_config "github.com/kumahq/kuma/pkg/config/xds"
 	util_proto "github.com/kumahq/kuma/pkg/util/proto"
 )
 
@@ -107,7 +108,7 @@ var _ = Describe("genConfig", func() {
 		}
 
 		// when
-		result, err := genConfig(params, true)
+		result, err := genConfig(params, xds_config.ProxyConfig{}, true)
 
 		// then
 		Expect(err).ToNot(HaveOccurred())
@@ -160,7 +161,7 @@ var _ = Describe("genConfig", func() {
 		}
 
 		// when
-		result, err := genConfig(params, false)
+		result, err := genConfig(params, xds_config.ProxyConfig{}, false)
 
 		// then
 		Expect(err).ToNot(HaveOccurred())
@@ -195,7 +196,7 @@ var _ = Describe("genConfig", func() {
 		}
 
 		// when
-		result, err := genConfig(params, true)
+		result, err := genConfig(params, xds_config.ProxyConfig{}, true)
 
 		// then
 		Expect(err).ToNot(HaveOccurred())

--- a/pkg/xds/bootstrap/testdata/bootstrap.gateway.golden.yaml
+++ b/pkg/xds/bootstrap/testdata/bootstrap.gateway.golden.yaml
@@ -32,6 +32,9 @@ layeredRuntime:
       envoy.restart_features.use_apple_api_for_dns_lookups: false
       re2.max_program_size.error_level: 4294967295
       re2.max_program_size.warn_level: 1000
+  - name: gateway
+    staticLayer:
+      overload.global_downstream_max_connections: 50000
   - name: gateway.listeners
     rtdsLayer:
       name: gateway.listeners

--- a/pkg/xds/bootstrap/testdata/generator.gateway.golden.yaml
+++ b/pkg/xds/bootstrap/testdata/generator.gateway.golden.yaml
@@ -1,0 +1,126 @@
+dynamicResources:
+  adsConfig:
+    apiType: GRPC
+    grpcServices:
+    - googleGrpc:
+        callCredentials:
+        - fromPlugin:
+            name: envoy.grpc_credentials.file_based_metadata
+            typedConfig:
+              '@type': type.googleapis.com/envoy.config.grpc_credential.v3.FileBasedMetadataConfig
+              secretData:
+                filename: /path/to/file
+        channelCredentials:
+          sslCredentials:
+            rootCerts:
+              inlineBytes: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURNekNDQWh1Z0F3SUJBZ0lRRGhsSW5mc1hZSGFtS04rMjlxblF2ekFOQmdrcWhraUc5dzBCQVFzRkFEQVAKTVEwd0N3WURWUVFERXdScmRXMWhNQjRYRFRJeE1EUXdNakV3TWpJeU5sb1hEVE14TURNek1URXdNakl5TmxvdwpEekVOTUFzR0ExVUVBeE1FYTNWdFlUQ0NBU0l3RFFZSktvWklodmNOQVFFQkJRQURnZ0VQQURDQ0FRb0NnZ0VCCkFMNEdHZytlMk83ZUExMkYwRjZ2MnJyOGoyaVZTRktlcG5adEwxNWxyQ2RzNmxxSzUwc1hXT3c4UEtacDJpaEEKWEpWVFNaekthc3lMRFRBUjlWWVFqVHBFNTI2RXp2dGR0aFNhZ2YzMlFXVyt3WTZMTXBFZGV4S09PQ3gyc2U1NQpSZDk3TDMzeVlQZmdYMTVPWWxpSFBEMDU2ampob3RITGROMmxweTcrU1REdlF5Um5YQXU3M1lrWTM3RWQ0aEk0CnQvVjZzb0h5RUdOY0RobTlwNWZCR3F6MG5qQmJRa3AybFRZNS9rajQycUI3UTZyQ00ydGJQc0VNb29lQUF3NW0KaHlZNHhqMHRQOXVjcWxVejhnYys2bzhIRE5zdDhOZUpYWmt0V24rQ095dGpyL056R2dTMjJrdlNEcGhpc0pvdApvMEZ5b0lPZEF0eEMxcXhYWFIrWHVVVUNBd0VBQWFPQmlqQ0JoekFPQmdOVkhROEJBZjhFQkFNQ0FxUXdIUVlEClZSMGxCQll3RkFZSUt3WUJCUVVIQXdFR0NDc0dBUVVGQndNQk1BOEdBMVVkRXdFQi93UUZNQU1CQWY4d0hRWUQKVlIwT0JCWUVGS1JMa2dJelgvT2pLdzlpZGVwdVEvUk10VCtBTUNZR0ExVWRFUVFmTUIyQ0NXeHZZMkZzYUc5egpkSWNRL1FDaEl3QUFBQUFBQUFBQUFBQUFBVEFOQmdrcWhraUc5dzBCQVFzRkFBT0NBUUVBUHM1eUpaaG9ZbEdXCkNwQThkU0lTaXZNOC84aUJOUTNmVndQNjNmdDBFSkxNVkd1MlJGWjQvVUFKL3JVUFNHTjh4aFhTazUrMWQ1NmEKL2thSDlyWDBIYVJJSEhseEE3aVBVS3hBajQ0eDlMS21xUEhUb0wzWGxXWTFBWHp2aWNXOWQrR00yRmFRZWUrSQpsZWFxTGJ6MEFadmxudTI3MVoxQ2VhQUN1VTlHbGp1anZ5aVRURTluYUhVRXF2SGdTcFB0aWxKYWx5SjUveklsClo5RjArVVd0M1RPWU1zNWcrU0N0ME13SFROYmlzYm1ld3BjRkZKemp0Mmt2dHJjOXQ5ZGtGODF4aGNTMTl3N3EKaDFBZVAzUlJsTGw3YnY5RUFWWEVtSWF2aWgvMjlQQTNaU3krcGJZTlc3ak5KSGpNUTRoUTBFK3hjQ2F6VS9PNAp5cFdHYWFudlBnPT0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=
+        credentialsFactoryName: envoy.grpc_credentials.file_based_metadata
+        statPrefix: ads
+        targetUri: localhost:5678
+    setNodeOnFirstMessageOnly: true
+    transportApiVersion: V3
+  cdsConfig:
+    ads: {}
+    resourceApiVersion: V3
+  ldsConfig:
+    ads: {}
+    resourceApiVersion: V3
+hdsConfig:
+  apiType: GRPC
+  grpcServices:
+  - googleGrpc:
+      callCredentials:
+      - fromPlugin:
+          name: envoy.grpc_credentials.file_based_metadata
+          typedConfig:
+            '@type': type.googleapis.com/envoy.config.grpc_credential.v3.FileBasedMetadataConfig
+            secretData:
+              filename: /path/to/file
+      channelCredentials:
+        sslCredentials:
+          rootCerts:
+            inlineBytes: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURNekNDQWh1Z0F3SUJBZ0lRRGhsSW5mc1hZSGFtS04rMjlxblF2ekFOQmdrcWhraUc5dzBCQVFzRkFEQVAKTVEwd0N3WURWUVFERXdScmRXMWhNQjRYRFRJeE1EUXdNakV3TWpJeU5sb1hEVE14TURNek1URXdNakl5TmxvdwpEekVOTUFzR0ExVUVBeE1FYTNWdFlUQ0NBU0l3RFFZSktvWklodmNOQVFFQkJRQURnZ0VQQURDQ0FRb0NnZ0VCCkFMNEdHZytlMk83ZUExMkYwRjZ2MnJyOGoyaVZTRktlcG5adEwxNWxyQ2RzNmxxSzUwc1hXT3c4UEtacDJpaEEKWEpWVFNaekthc3lMRFRBUjlWWVFqVHBFNTI2RXp2dGR0aFNhZ2YzMlFXVyt3WTZMTXBFZGV4S09PQ3gyc2U1NQpSZDk3TDMzeVlQZmdYMTVPWWxpSFBEMDU2ampob3RITGROMmxweTcrU1REdlF5Um5YQXU3M1lrWTM3RWQ0aEk0CnQvVjZzb0h5RUdOY0RobTlwNWZCR3F6MG5qQmJRa3AybFRZNS9rajQycUI3UTZyQ00ydGJQc0VNb29lQUF3NW0KaHlZNHhqMHRQOXVjcWxVejhnYys2bzhIRE5zdDhOZUpYWmt0V24rQ095dGpyL056R2dTMjJrdlNEcGhpc0pvdApvMEZ5b0lPZEF0eEMxcXhYWFIrWHVVVUNBd0VBQWFPQmlqQ0JoekFPQmdOVkhROEJBZjhFQkFNQ0FxUXdIUVlEClZSMGxCQll3RkFZSUt3WUJCUVVIQXdFR0NDc0dBUVVGQndNQk1BOEdBMVVkRXdFQi93UUZNQU1CQWY4d0hRWUQKVlIwT0JCWUVGS1JMa2dJelgvT2pLdzlpZGVwdVEvUk10VCtBTUNZR0ExVWRFUVFmTUIyQ0NXeHZZMkZzYUc5egpkSWNRL1FDaEl3QUFBQUFBQUFBQUFBQUFBVEFOQmdrcWhraUc5dzBCQVFzRkFBT0NBUUVBUHM1eUpaaG9ZbEdXCkNwQThkU0lTaXZNOC84aUJOUTNmVndQNjNmdDBFSkxNVkd1MlJGWjQvVUFKL3JVUFNHTjh4aFhTazUrMWQ1NmEKL2thSDlyWDBIYVJJSEhseEE3aVBVS3hBajQ0eDlMS21xUEhUb0wzWGxXWTFBWHp2aWNXOWQrR00yRmFRZWUrSQpsZWFxTGJ6MEFadmxudTI3MVoxQ2VhQUN1VTlHbGp1anZ5aVRURTluYUhVRXF2SGdTcFB0aWxKYWx5SjUveklsClo5RjArVVd0M1RPWU1zNWcrU0N0ME13SFROYmlzYm1ld3BjRkZKemp0Mmt2dHJjOXQ5ZGtGODF4aGNTMTl3N3EKaDFBZVAzUlJsTGw3YnY5RUFWWEVtSWF2aWgvMjlQQTNaU3krcGJZTlc3ak5KSGpNUTRoUTBFK3hjQ2F6VS9PNAp5cFdHYWFudlBnPT0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=
+      credentialsFactoryName: envoy.grpc_credentials.file_based_metadata
+      statPrefix: ads
+      targetUri: localhost:5678
+  setNodeOnFirstMessageOnly: true
+  transportApiVersion: V3
+layeredRuntime:
+  layers:
+  - name: kuma
+    staticLayer:
+      envoy.restart_features.use_apple_api_for_dns_lookups: false
+      re2.max_program_size.error_level: 4294967295
+      re2.max_program_size.warn_level: 1000
+  - name: gateway
+    staticLayer:
+      overload.global_downstream_max_connections: 35678
+  - name: gateway.listeners
+    rtdsLayer:
+      name: gateway.listeners
+      rtdsConfig:
+        ads: {}
+        resourceApiVersion: V3
+node:
+  cluster: gateway
+  id: mesh.name.namespace
+  metadata:
+    dataplane.dns.empty.port: "53002"
+    dataplane.dns.port: "53001"
+    dataplane.proxyType: dataplane
+    features: []
+    version:
+      dependencies: {}
+      envoy:
+        build: hash/1.15.0/RELEASE
+        kumaDpCompatible: false
+        version: 1.15.0
+      kumaDp:
+        buildDate: "2019-08-07T11:26:06Z"
+        gitCommit: 91ce236824a9d875601679aa80c63783fb0e8725
+        gitTag: v0.0.1
+        version: 0.0.1
+staticResources:
+  clusters:
+  - connectTimeout: 1s
+    loadAssignment:
+      clusterName: access_log_sink
+      endpoints:
+      - lbEndpoints:
+        - endpoint:
+            address:
+              pipe:
+                path: /tmp/kuma-al-name.namespace-mesh.sock
+    name: access_log_sink
+    type: STATIC
+    typedExtensionProtocolOptions:
+      envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+        '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+        explicitHttpConfig:
+          http2ProtocolOptions: {}
+    upstreamConnectionOptions:
+      tcpKeepalive:
+        keepaliveInterval: 10
+        keepaliveProbes: 3
+        keepaliveTime: 10
+  secrets:
+  - name: cp_validation_ctx
+    validationContext:
+      matchSubjectAltNames:
+      - exact: localhost
+      trustedCa:
+        inlineBytes: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURNekNDQWh1Z0F3SUJBZ0lRRGhsSW5mc1hZSGFtS04rMjlxblF2ekFOQmdrcWhraUc5dzBCQVFzRkFEQVAKTVEwd0N3WURWUVFERXdScmRXMWhNQjRYRFRJeE1EUXdNakV3TWpJeU5sb1hEVE14TURNek1URXdNakl5TmxvdwpEekVOTUFzR0ExVUVBeE1FYTNWdFlUQ0NBU0l3RFFZSktvWklodmNOQVFFQkJRQURnZ0VQQURDQ0FRb0NnZ0VCCkFMNEdHZytlMk83ZUExMkYwRjZ2MnJyOGoyaVZTRktlcG5adEwxNWxyQ2RzNmxxSzUwc1hXT3c4UEtacDJpaEEKWEpWVFNaekthc3lMRFRBUjlWWVFqVHBFNTI2RXp2dGR0aFNhZ2YzMlFXVyt3WTZMTXBFZGV4S09PQ3gyc2U1NQpSZDk3TDMzeVlQZmdYMTVPWWxpSFBEMDU2ampob3RITGROMmxweTcrU1REdlF5Um5YQXU3M1lrWTM3RWQ0aEk0CnQvVjZzb0h5RUdOY0RobTlwNWZCR3F6MG5qQmJRa3AybFRZNS9rajQycUI3UTZyQ00ydGJQc0VNb29lQUF3NW0KaHlZNHhqMHRQOXVjcWxVejhnYys2bzhIRE5zdDhOZUpYWmt0V24rQ095dGpyL056R2dTMjJrdlNEcGhpc0pvdApvMEZ5b0lPZEF0eEMxcXhYWFIrWHVVVUNBd0VBQWFPQmlqQ0JoekFPQmdOVkhROEJBZjhFQkFNQ0FxUXdIUVlEClZSMGxCQll3RkFZSUt3WUJCUVVIQXdFR0NDc0dBUVVGQndNQk1BOEdBMVVkRXdFQi93UUZNQU1CQWY4d0hRWUQKVlIwT0JCWUVGS1JMa2dJelgvT2pLdzlpZGVwdVEvUk10VCtBTUNZR0ExVWRFUVFmTUIyQ0NXeHZZMkZzYUc5egpkSWNRL1FDaEl3QUFBQUFBQUFBQUFBQUFBVEFOQmdrcWhraUc5dzBCQVFzRkFBT0NBUUVBUHM1eUpaaG9ZbEdXCkNwQThkU0lTaXZNOC84aUJOUTNmVndQNjNmdDBFSkxNVkd1MlJGWjQvVUFKL3JVUFNHTjh4aFhTazUrMWQ1NmEKL2thSDlyWDBIYVJJSEhseEE3aVBVS3hBajQ0eDlMS21xUEhUb0wzWGxXWTFBWHp2aWNXOWQrR00yRmFRZWUrSQpsZWFxTGJ6MEFadmxudTI3MVoxQ2VhQUN1VTlHbGp1anZ5aVRURTluYUhVRXF2SGdTcFB0aWxKYWx5SjUveklsClo5RjArVVd0M1RPWU1zNWcrU0N0ME13SFROYmlzYm1ld3BjRkZKemp0Mmt2dHJjOXQ5ZGtGODF4aGNTMTl3N3EKaDFBZVAzUlJsTGw3YnY5RUFWWEVtSWF2aWgvMjlQQTNaU3krcGJZTlc3ak5KSGpNUTRoUTBFK3hjQ2F6VS9PNAp5cFdHYWFudlBnPT0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=
+statsConfig:
+  statsTags:
+  - regex: ^grpc\.((.+)\.)
+    tagName: name
+  - regex: ^grpc.*streams_closed(_([0-9]+))
+    tagName: status
+  - regex: ^kafka(\.(\S*[0-9]))\.
+    tagName: kafka_name
+  - regex: ^kafka\..*\.(.*)
+    tagName: kafka_type
+  - regex: (worker_([0-9]+)\.)
+    tagName: worker
+  - regex: ((.+?)\.)rbac\.
+    tagName: listener


### PR DESCRIPTION
### Checklist prior to review

Blocked on https://github.com/kumahq/kuma/pull/4755

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

From the example in [best practices](https://www.envoyproxy.io/docs/envoy/latest/configuration/best_practices/edge).

We also have:

> The connection limit is recommended to be less than half of the system’s file descriptor limit, to account for upstream connections, files, and other usage of file descriptors.

so we could theoretically try to get this limit and derive a connection limit but the value in `/proc/sys/fs/file-max` seems unreliably high, at least on my machine/`minikube`.

Or otherwise make it customizable now rather than later.

- [x] Link to docs PR or issue -- none
- [x] Link to UI issue or PR -- none
- [x] Is the [issue worked on linked][1]? -- https://github.com/kumahq/kuma/issues/4692
- [x] Unit Tests --
- [x] E2E Tests -- none
- [x] Manual Universal Tests -- nothing to test
- [x] Manual Kubernetes Tests -- nothing to test
- [x] Do you need to update [`UPGRADE.md`](/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](/CONTRIBUTING.md#backporting)? --

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
