### PR TITLE
fix(kumactl): fixes to dashboards

### DIFF
--- a/app/kumactl/cmd/install/testdata/install-observability.defaults.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-observability.defaults.golden.yaml
@@ -357,15 +357,6 @@ data:
         target_label: kubernetes_node
       scrape_interval: 5m
       scrape_timeout: 30s
-    - honor_labels: true
-      job_name: prometheus-pushgateway
-      kubernetes_sd_configs:
-      - role: service
-      relabel_configs:
-      - action: keep
-        regex: pushgateway
-        source_labels:
-        - __meta_kubernetes_service_annotation_prometheus_io_probe
     - job_name: kubernetes-services
       kubernetes_sd_configs:
       - role: service
@@ -460,14 +451,6 @@ data:
       scrape_interval: "5s"
       relabel_configs:
       - source_labels:
-        - k8s_kuma_io_name
-        regex: "(.*)"
-        target_label: pod
-      - source_labels:
-        - k8s_kuma_io_namespace
-        regex: "(.*)"
-        target_label: namespace
-      - source_labels:
         - __meta_kuma_mesh
         regex: "(.*)"
         target_label: mesh
@@ -481,6 +464,14 @@ data:
         target_label: service
       - action: labelmap
         regex: __meta_kuma_label_(.+)
+      - source_labels:
+        - k8s_kuma_io_name
+        regex: "(.*)"
+        target_label: pod
+      - source_labels:
+        - k8s_kuma_io_namespace
+        regex: "(.*)"
+        target_label: namespace
       kuma_sd_configs:
       - server: http://kuma-control-plane.kuma-system:5676
     alerting:
@@ -1025,7 +1016,7 @@ data:
           }
         },
         {
-          "collapsed": true,
+          "collapsed": false,
           "datasource": "Prometheus",
           "gridPos": {
             "h": 1,
@@ -1768,7 +1759,7 @@ data:
           "type": "row"
         },
         {
-          "collapsed": true,
+          "collapsed": false,
           "datasource": "Prometheus",
           "gridPos": {
             "h": 1,
@@ -2807,7 +2798,7 @@ data:
           }
         },
         {
-          "collapsed": true,
+          "collapsed": false,
           "datasource": "Prometheus",
           "gridPos": {
             "h": 1,
@@ -3022,7 +3013,7 @@ data:
           "type": "row"
         },
         {
-          "collapsed": true,
+          "collapsed": false,
           "datasource": null,
           "gridPos": {
             "h": 1,
@@ -4664,7 +4655,7 @@ data:
       "links": [],
       "panels": [
         {
-          "collapsed": true,
+          "collapsed": false,
           "datasource": "Prometheus",
           "gridPos": {
             "h": 1,
@@ -5532,7 +5523,7 @@ data:
           }
         },
         {
-          "collapsed": true,
+          "collapsed": false,
           "datasource": "Prometheus",
           "gridPos": {
             "h": 1,
@@ -5942,7 +5933,7 @@ data:
               "value": "backend_kuma-demo_svc_3001"
             },
             "datasource": "Prometheus",
-            "definition": "label_values(envoy_server_live{mesh=\"$mesh\"}, kuma_io_service)",
+            "definition": "label_values(envoy_server_live{mesh=\"$mesh\",kuma_io_mesh_gateway=\"\"}, kuma_io_service)",
             "description": null,
             "error": null,
             "hide": 0,
@@ -5952,7 +5943,7 @@ data:
             "name": "source_service",
             "options": [],
             "query": {
-              "query": "label_values(envoy_server_live{mesh=\"$mesh\"}, kuma_io_service)",
+              "query": "label_values(envoy_server_live{mesh=\"$mesh\",kuma_io_mesh_gateway=\"\"}, kuma_io_service)",
               "refId": "Prometheus-source_service-Variable-Query"
             },
             "refresh": 1,
@@ -10407,10 +10398,10 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(rate(envoy_cluster_internal_upstream_rq_xx{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",kuma_io_mesh_gateway=~\".*$meshgateway.*\",kuma_io_mesh_gateway!=\"\",kuma_io_mesh_traffic=\"true\"}[1m])) by (envoy_response_code_class)",
+              "expr": "sum(rate(envoy_cluster_internal_upstream_rq_xx{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",kuma_io_mesh_gateway=~\".*$meshgateway.*\",kuma_io_mesh_gateway!=\"\",kuma_io_mesh_traffic=\"true\"}[1m])) by (envoy_response_code_class,envoy_cluster_name)",
               "hide": false,
               "interval": "",
-              "legendFormat": "{{envoy_response_code_class}}xx",
+              "legendFormat": "{{envoy_cluster_name}}:{{envoy_response_code_class}}xx",
               "refId": "B"
             }
           ],
@@ -11887,7 +11878,7 @@ data:
               "value": "backend_kuma-demo_svc_3001"
             },
             "datasource": null,
-            "definition": "label_values(envoy_server_live{mesh=\"$mesh\",kuma_io_zone=~\"$zone\"}, kuma_io_service)",
+            "definition": "label_values(envoy_server_live{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",kuma_io_mesh_gateway=\"\"}, kuma_io_service)",
             "description": null,
             "error": null,
             "hide": 0,
@@ -11897,7 +11888,7 @@ data:
             "name": "service",
             "options": [],
             "query": {
-              "query": "label_values(envoy_server_live{mesh=\"$mesh\",kuma_io_zone=~\"$zone\"}, kuma_io_service)",
+              "query": "label_values(envoy_server_live{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",kuma_io_mesh_gateway=\"\"}, kuma_io_service)",
               "refId": "StandardVariableQuery"
             },
             "refresh": 1,

--- a/app/kumactl/cmd/install/testdata/install-observability.no-grafana.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-observability.no-grafana.golden.yaml
@@ -186,15 +186,6 @@ data:
         target_label: kubernetes_node
       scrape_interval: 5m
       scrape_timeout: 30s
-    - honor_labels: true
-      job_name: prometheus-pushgateway
-      kubernetes_sd_configs:
-      - role: service
-      relabel_configs:
-      - action: keep
-        regex: pushgateway
-        source_labels:
-        - __meta_kubernetes_service_annotation_prometheus_io_probe
     - job_name: kubernetes-services
       kubernetes_sd_configs:
       - role: service
@@ -289,14 +280,6 @@ data:
       scrape_interval: "5s"
       relabel_configs:
       - source_labels:
-        - k8s_kuma_io_name
-        regex: "(.*)"
-        target_label: pod
-      - source_labels:
-        - k8s_kuma_io_namespace
-        regex: "(.*)"
-        target_label: namespace
-      - source_labels:
         - __meta_kuma_mesh
         regex: "(.*)"
         target_label: mesh
@@ -310,6 +293,14 @@ data:
         target_label: service
       - action: labelmap
         regex: __meta_kuma_label_(.+)
+      - source_labels:
+        - k8s_kuma_io_name
+        regex: "(.*)"
+        target_label: pod
+      - source_labels:
+        - k8s_kuma_io_namespace
+        regex: "(.*)"
+        target_label: namespace
       kuma_sd_configs:
       - server: http://kuma-control-plane.kuma-system:5676
     alerting:

--- a/app/kumactl/cmd/install/testdata/install-observability.no-jaeger.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-observability.no-jaeger.golden.yaml
@@ -357,15 +357,6 @@ data:
         target_label: kubernetes_node
       scrape_interval: 5m
       scrape_timeout: 30s
-    - honor_labels: true
-      job_name: prometheus-pushgateway
-      kubernetes_sd_configs:
-      - role: service
-      relabel_configs:
-      - action: keep
-        regex: pushgateway
-        source_labels:
-        - __meta_kubernetes_service_annotation_prometheus_io_probe
     - job_name: kubernetes-services
       kubernetes_sd_configs:
       - role: service
@@ -460,14 +451,6 @@ data:
       scrape_interval: "5s"
       relabel_configs:
       - source_labels:
-        - k8s_kuma_io_name
-        regex: "(.*)"
-        target_label: pod
-      - source_labels:
-        - k8s_kuma_io_namespace
-        regex: "(.*)"
-        target_label: namespace
-      - source_labels:
         - __meta_kuma_mesh
         regex: "(.*)"
         target_label: mesh
@@ -481,6 +464,14 @@ data:
         target_label: service
       - action: labelmap
         regex: __meta_kuma_label_(.+)
+      - source_labels:
+        - k8s_kuma_io_name
+        regex: "(.*)"
+        target_label: pod
+      - source_labels:
+        - k8s_kuma_io_namespace
+        regex: "(.*)"
+        target_label: namespace
       kuma_sd_configs:
       - server: http://kuma-control-plane.kuma-system:5676
     alerting:
@@ -1025,7 +1016,7 @@ data:
           }
         },
         {
-          "collapsed": true,
+          "collapsed": false,
           "datasource": "Prometheus",
           "gridPos": {
             "h": 1,
@@ -1768,7 +1759,7 @@ data:
           "type": "row"
         },
         {
-          "collapsed": true,
+          "collapsed": false,
           "datasource": "Prometheus",
           "gridPos": {
             "h": 1,
@@ -2807,7 +2798,7 @@ data:
           }
         },
         {
-          "collapsed": true,
+          "collapsed": false,
           "datasource": "Prometheus",
           "gridPos": {
             "h": 1,
@@ -3022,7 +3013,7 @@ data:
           "type": "row"
         },
         {
-          "collapsed": true,
+          "collapsed": false,
           "datasource": null,
           "gridPos": {
             "h": 1,
@@ -4664,7 +4655,7 @@ data:
       "links": [],
       "panels": [
         {
-          "collapsed": true,
+          "collapsed": false,
           "datasource": "Prometheus",
           "gridPos": {
             "h": 1,
@@ -5532,7 +5523,7 @@ data:
           }
         },
         {
-          "collapsed": true,
+          "collapsed": false,
           "datasource": "Prometheus",
           "gridPos": {
             "h": 1,
@@ -5942,7 +5933,7 @@ data:
               "value": "backend_kuma-demo_svc_3001"
             },
             "datasource": "Prometheus",
-            "definition": "label_values(envoy_server_live{mesh=\"$mesh\"}, kuma_io_service)",
+            "definition": "label_values(envoy_server_live{mesh=\"$mesh\",kuma_io_mesh_gateway=\"\"}, kuma_io_service)",
             "description": null,
             "error": null,
             "hide": 0,
@@ -5952,7 +5943,7 @@ data:
             "name": "source_service",
             "options": [],
             "query": {
-              "query": "label_values(envoy_server_live{mesh=\"$mesh\"}, kuma_io_service)",
+              "query": "label_values(envoy_server_live{mesh=\"$mesh\",kuma_io_mesh_gateway=\"\"}, kuma_io_service)",
               "refId": "Prometheus-source_service-Variable-Query"
             },
             "refresh": 1,
@@ -10407,10 +10398,10 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(rate(envoy_cluster_internal_upstream_rq_xx{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",kuma_io_mesh_gateway=~\".*$meshgateway.*\",kuma_io_mesh_gateway!=\"\",kuma_io_mesh_traffic=\"true\"}[1m])) by (envoy_response_code_class)",
+              "expr": "sum(rate(envoy_cluster_internal_upstream_rq_xx{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",kuma_io_mesh_gateway=~\".*$meshgateway.*\",kuma_io_mesh_gateway!=\"\",kuma_io_mesh_traffic=\"true\"}[1m])) by (envoy_response_code_class,envoy_cluster_name)",
               "hide": false,
               "interval": "",
-              "legendFormat": "{{envoy_response_code_class}}xx",
+              "legendFormat": "{{envoy_cluster_name}}:{{envoy_response_code_class}}xx",
               "refId": "B"
             }
           ],
@@ -11887,7 +11878,7 @@ data:
               "value": "backend_kuma-demo_svc_3001"
             },
             "datasource": null,
-            "definition": "label_values(envoy_server_live{mesh=\"$mesh\",kuma_io_zone=~\"$zone\"}, kuma_io_service)",
+            "definition": "label_values(envoy_server_live{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",kuma_io_mesh_gateway=\"\"}, kuma_io_service)",
             "description": null,
             "error": null,
             "hide": 0,
@@ -11897,7 +11888,7 @@ data:
             "name": "service",
             "options": [],
             "query": {
-              "query": "label_values(envoy_server_live{mesh=\"$mesh\",kuma_io_zone=~\"$zone\"}, kuma_io_service)",
+              "query": "label_values(envoy_server_live{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",kuma_io_mesh_gateway=\"\"}, kuma_io_service)",
               "refId": "StandardVariableQuery"
             },
             "refresh": 1,

--- a/app/kumactl/cmd/install/testdata/install-observability.no-loki.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-observability.no-loki.golden.yaml
@@ -357,15 +357,6 @@ data:
         target_label: kubernetes_node
       scrape_interval: 5m
       scrape_timeout: 30s
-    - honor_labels: true
-      job_name: prometheus-pushgateway
-      kubernetes_sd_configs:
-      - role: service
-      relabel_configs:
-      - action: keep
-        regex: pushgateway
-        source_labels:
-        - __meta_kubernetes_service_annotation_prometheus_io_probe
     - job_name: kubernetes-services
       kubernetes_sd_configs:
       - role: service
@@ -460,14 +451,6 @@ data:
       scrape_interval: "5s"
       relabel_configs:
       - source_labels:
-        - k8s_kuma_io_name
-        regex: "(.*)"
-        target_label: pod
-      - source_labels:
-        - k8s_kuma_io_namespace
-        regex: "(.*)"
-        target_label: namespace
-      - source_labels:
         - __meta_kuma_mesh
         regex: "(.*)"
         target_label: mesh
@@ -481,6 +464,14 @@ data:
         target_label: service
       - action: labelmap
         regex: __meta_kuma_label_(.+)
+      - source_labels:
+        - k8s_kuma_io_name
+        regex: "(.*)"
+        target_label: pod
+      - source_labels:
+        - k8s_kuma_io_namespace
+        regex: "(.*)"
+        target_label: namespace
       kuma_sd_configs:
       - server: http://kuma-control-plane.kuma-system:5676
     alerting:
@@ -1025,7 +1016,7 @@ data:
           }
         },
         {
-          "collapsed": true,
+          "collapsed": false,
           "datasource": "Prometheus",
           "gridPos": {
             "h": 1,
@@ -1768,7 +1759,7 @@ data:
           "type": "row"
         },
         {
-          "collapsed": true,
+          "collapsed": false,
           "datasource": "Prometheus",
           "gridPos": {
             "h": 1,
@@ -2807,7 +2798,7 @@ data:
           }
         },
         {
-          "collapsed": true,
+          "collapsed": false,
           "datasource": "Prometheus",
           "gridPos": {
             "h": 1,
@@ -3022,7 +3013,7 @@ data:
           "type": "row"
         },
         {
-          "collapsed": true,
+          "collapsed": false,
           "datasource": null,
           "gridPos": {
             "h": 1,
@@ -4664,7 +4655,7 @@ data:
       "links": [],
       "panels": [
         {
-          "collapsed": true,
+          "collapsed": false,
           "datasource": "Prometheus",
           "gridPos": {
             "h": 1,
@@ -5532,7 +5523,7 @@ data:
           }
         },
         {
-          "collapsed": true,
+          "collapsed": false,
           "datasource": "Prometheus",
           "gridPos": {
             "h": 1,
@@ -5942,7 +5933,7 @@ data:
               "value": "backend_kuma-demo_svc_3001"
             },
             "datasource": "Prometheus",
-            "definition": "label_values(envoy_server_live{mesh=\"$mesh\"}, kuma_io_service)",
+            "definition": "label_values(envoy_server_live{mesh=\"$mesh\",kuma_io_mesh_gateway=\"\"}, kuma_io_service)",
             "description": null,
             "error": null,
             "hide": 0,
@@ -5952,7 +5943,7 @@ data:
             "name": "source_service",
             "options": [],
             "query": {
-              "query": "label_values(envoy_server_live{mesh=\"$mesh\"}, kuma_io_service)",
+              "query": "label_values(envoy_server_live{mesh=\"$mesh\",kuma_io_mesh_gateway=\"\"}, kuma_io_service)",
               "refId": "Prometheus-source_service-Variable-Query"
             },
             "refresh": 1,
@@ -10407,10 +10398,10 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(rate(envoy_cluster_internal_upstream_rq_xx{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",kuma_io_mesh_gateway=~\".*$meshgateway.*\",kuma_io_mesh_gateway!=\"\",kuma_io_mesh_traffic=\"true\"}[1m])) by (envoy_response_code_class)",
+              "expr": "sum(rate(envoy_cluster_internal_upstream_rq_xx{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",kuma_io_mesh_gateway=~\".*$meshgateway.*\",kuma_io_mesh_gateway!=\"\",kuma_io_mesh_traffic=\"true\"}[1m])) by (envoy_response_code_class,envoy_cluster_name)",
               "hide": false,
               "interval": "",
-              "legendFormat": "{{envoy_response_code_class}}xx",
+              "legendFormat": "{{envoy_cluster_name}}:{{envoy_response_code_class}}xx",
               "refId": "B"
             }
           ],
@@ -11887,7 +11878,7 @@ data:
               "value": "backend_kuma-demo_svc_3001"
             },
             "datasource": null,
-            "definition": "label_values(envoy_server_live{mesh=\"$mesh\",kuma_io_zone=~\"$zone\"}, kuma_io_service)",
+            "definition": "label_values(envoy_server_live{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",kuma_io_mesh_gateway=\"\"}, kuma_io_service)",
             "description": null,
             "error": null,
             "hide": 0,
@@ -11897,7 +11888,7 @@ data:
             "name": "service",
             "options": [],
             "query": {
-              "query": "label_values(envoy_server_live{mesh=\"$mesh\",kuma_io_zone=~\"$zone\"}, kuma_io_service)",
+              "query": "label_values(envoy_server_live{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",kuma_io_mesh_gateway=\"\"}, kuma_io_service)",
               "refId": "StandardVariableQuery"
             },
             "refresh": 1,

--- a/app/kumactl/cmd/install/testdata/install-observability.no-prometheus.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-observability.no-prometheus.golden.yaml
@@ -694,7 +694,7 @@ data:
           }
         },
         {
-          "collapsed": true,
+          "collapsed": false,
           "datasource": "Prometheus",
           "gridPos": {
             "h": 1,
@@ -1437,7 +1437,7 @@ data:
           "type": "row"
         },
         {
-          "collapsed": true,
+          "collapsed": false,
           "datasource": "Prometheus",
           "gridPos": {
             "h": 1,
@@ -2476,7 +2476,7 @@ data:
           }
         },
         {
-          "collapsed": true,
+          "collapsed": false,
           "datasource": "Prometheus",
           "gridPos": {
             "h": 1,
@@ -2691,7 +2691,7 @@ data:
           "type": "row"
         },
         {
-          "collapsed": true,
+          "collapsed": false,
           "datasource": null,
           "gridPos": {
             "h": 1,
@@ -4333,7 +4333,7 @@ data:
       "links": [],
       "panels": [
         {
-          "collapsed": true,
+          "collapsed": false,
           "datasource": "Prometheus",
           "gridPos": {
             "h": 1,
@@ -5201,7 +5201,7 @@ data:
           }
         },
         {
-          "collapsed": true,
+          "collapsed": false,
           "datasource": "Prometheus",
           "gridPos": {
             "h": 1,
@@ -5611,7 +5611,7 @@ data:
               "value": "backend_kuma-demo_svc_3001"
             },
             "datasource": "Prometheus",
-            "definition": "label_values(envoy_server_live{mesh=\"$mesh\"}, kuma_io_service)",
+            "definition": "label_values(envoy_server_live{mesh=\"$mesh\",kuma_io_mesh_gateway=\"\"}, kuma_io_service)",
             "description": null,
             "error": null,
             "hide": 0,
@@ -5621,7 +5621,7 @@ data:
             "name": "source_service",
             "options": [],
             "query": {
-              "query": "label_values(envoy_server_live{mesh=\"$mesh\"}, kuma_io_service)",
+              "query": "label_values(envoy_server_live{mesh=\"$mesh\",kuma_io_mesh_gateway=\"\"}, kuma_io_service)",
               "refId": "Prometheus-source_service-Variable-Query"
             },
             "refresh": 1,
@@ -10076,10 +10076,10 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(rate(envoy_cluster_internal_upstream_rq_xx{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",kuma_io_mesh_gateway=~\".*$meshgateway.*\",kuma_io_mesh_gateway!=\"\",kuma_io_mesh_traffic=\"true\"}[1m])) by (envoy_response_code_class)",
+              "expr": "sum(rate(envoy_cluster_internal_upstream_rq_xx{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",kuma_io_mesh_gateway=~\".*$meshgateway.*\",kuma_io_mesh_gateway!=\"\",kuma_io_mesh_traffic=\"true\"}[1m])) by (envoy_response_code_class,envoy_cluster_name)",
               "hide": false,
               "interval": "",
-              "legendFormat": "{{envoy_response_code_class}}xx",
+              "legendFormat": "{{envoy_cluster_name}}:{{envoy_response_code_class}}xx",
               "refId": "B"
             }
           ],
@@ -11556,7 +11556,7 @@ data:
               "value": "backend_kuma-demo_svc_3001"
             },
             "datasource": null,
-            "definition": "label_values(envoy_server_live{mesh=\"$mesh\",kuma_io_zone=~\"$zone\"}, kuma_io_service)",
+            "definition": "label_values(envoy_server_live{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",kuma_io_mesh_gateway=\"\"}, kuma_io_service)",
             "description": null,
             "error": null,
             "hide": 0,
@@ -11566,7 +11566,7 @@ data:
             "name": "service",
             "options": [],
             "query": {
-              "query": "label_values(envoy_server_live{mesh=\"$mesh\",kuma_io_zone=~\"$zone\"}, kuma_io_service)",
+              "query": "label_values(envoy_server_live{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",kuma_io_mesh_gateway=\"\"}, kuma_io_service)",
               "refId": "StandardVariableQuery"
             },
             "refresh": 1,

--- a/app/kumactl/cmd/install/testdata/install-observability.overrides.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-observability.overrides.golden.yaml
@@ -357,15 +357,6 @@ data:
         target_label: kubernetes_node
       scrape_interval: 5m
       scrape_timeout: 30s
-    - honor_labels: true
-      job_name: prometheus-pushgateway
-      kubernetes_sd_configs:
-      - role: service
-      relabel_configs:
-      - action: keep
-        regex: pushgateway
-        source_labels:
-        - __meta_kubernetes_service_annotation_prometheus_io_probe
     - job_name: kubernetes-services
       kubernetes_sd_configs:
       - role: service
@@ -460,14 +451,6 @@ data:
       scrape_interval: "5s"
       relabel_configs:
       - source_labels:
-        - k8s_kuma_io_name
-        regex: "(.*)"
-        target_label: pod
-      - source_labels:
-        - k8s_kuma_io_namespace
-        regex: "(.*)"
-        target_label: namespace
-      - source_labels:
         - __meta_kuma_mesh
         regex: "(.*)"
         target_label: mesh
@@ -481,6 +464,14 @@ data:
         target_label: service
       - action: labelmap
         regex: __meta_kuma_label_(.+)
+      - source_labels:
+        - k8s_kuma_io_name
+        regex: "(.*)"
+        target_label: pod
+      - source_labels:
+        - k8s_kuma_io_namespace
+        regex: "(.*)"
+        target_label: namespace
       kuma_sd_configs:
       - server: http://kuma.local:5681
     alerting:
@@ -1025,7 +1016,7 @@ data:
           }
         },
         {
-          "collapsed": true,
+          "collapsed": false,
           "datasource": "Prometheus",
           "gridPos": {
             "h": 1,
@@ -1768,7 +1759,7 @@ data:
           "type": "row"
         },
         {
-          "collapsed": true,
+          "collapsed": false,
           "datasource": "Prometheus",
           "gridPos": {
             "h": 1,
@@ -2807,7 +2798,7 @@ data:
           }
         },
         {
-          "collapsed": true,
+          "collapsed": false,
           "datasource": "Prometheus",
           "gridPos": {
             "h": 1,
@@ -3022,7 +3013,7 @@ data:
           "type": "row"
         },
         {
-          "collapsed": true,
+          "collapsed": false,
           "datasource": null,
           "gridPos": {
             "h": 1,
@@ -4664,7 +4655,7 @@ data:
       "links": [],
       "panels": [
         {
-          "collapsed": true,
+          "collapsed": false,
           "datasource": "Prometheus",
           "gridPos": {
             "h": 1,
@@ -5532,7 +5523,7 @@ data:
           }
         },
         {
-          "collapsed": true,
+          "collapsed": false,
           "datasource": "Prometheus",
           "gridPos": {
             "h": 1,
@@ -5942,7 +5933,7 @@ data:
               "value": "backend_kuma-demo_svc_3001"
             },
             "datasource": "Prometheus",
-            "definition": "label_values(envoy_server_live{mesh=\"$mesh\"}, kuma_io_service)",
+            "definition": "label_values(envoy_server_live{mesh=\"$mesh\",kuma_io_mesh_gateway=\"\"}, kuma_io_service)",
             "description": null,
             "error": null,
             "hide": 0,
@@ -5952,7 +5943,7 @@ data:
             "name": "source_service",
             "options": [],
             "query": {
-              "query": "label_values(envoy_server_live{mesh=\"$mesh\"}, kuma_io_service)",
+              "query": "label_values(envoy_server_live{mesh=\"$mesh\",kuma_io_mesh_gateway=\"\"}, kuma_io_service)",
               "refId": "Prometheus-source_service-Variable-Query"
             },
             "refresh": 1,
@@ -10407,10 +10398,10 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(rate(envoy_cluster_internal_upstream_rq_xx{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",kuma_io_mesh_gateway=~\".*$meshgateway.*\",kuma_io_mesh_gateway!=\"\",kuma_io_mesh_traffic=\"true\"}[1m])) by (envoy_response_code_class)",
+              "expr": "sum(rate(envoy_cluster_internal_upstream_rq_xx{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",kuma_io_mesh_gateway=~\".*$meshgateway.*\",kuma_io_mesh_gateway!=\"\",kuma_io_mesh_traffic=\"true\"}[1m])) by (envoy_response_code_class,envoy_cluster_name)",
               "hide": false,
               "interval": "",
-              "legendFormat": "{{envoy_response_code_class}}xx",
+              "legendFormat": "{{envoy_cluster_name}}:{{envoy_response_code_class}}xx",
               "refId": "B"
             }
           ],
@@ -11887,7 +11878,7 @@ data:
               "value": "backend_kuma-demo_svc_3001"
             },
             "datasource": null,
-            "definition": "label_values(envoy_server_live{mesh=\"$mesh\",kuma_io_zone=~\"$zone\"}, kuma_io_service)",
+            "definition": "label_values(envoy_server_live{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",kuma_io_mesh_gateway=\"\"}, kuma_io_service)",
             "description": null,
             "error": null,
             "hide": 0,
@@ -11897,7 +11888,7 @@ data:
             "name": "service",
             "options": [],
             "query": {
-              "query": "label_values(envoy_server_live{mesh=\"$mesh\",kuma_io_zone=~\"$zone\"}, kuma_io_service)",
+              "query": "label_values(envoy_server_live{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",kuma_io_mesh_gateway=\"\"}, kuma_io_service)",
               "refId": "StandardVariableQuery"
             },
             "refresh": 1,

--- a/app/kumactl/data/install/k8s/metrics/grafana/kuma-dataplane.json
+++ b/app/kumactl/data/install/k8s/metrics/grafana/kuma-dataplane.json
@@ -482,7 +482,7 @@
       }
     },
     {
-      "collapsed": true,
+      "collapsed": false,
       "datasource": "Prometheus",
       "gridPos": {
         "h": 1,
@@ -1225,7 +1225,7 @@
       "type": "row"
     },
     {
-      "collapsed": true,
+      "collapsed": false,
       "datasource": "Prometheus",
       "gridPos": {
         "h": 1,
@@ -2264,7 +2264,7 @@
       }
     },
     {
-      "collapsed": true,
+      "collapsed": false,
       "datasource": "Prometheus",
       "gridPos": {
         "h": 1,
@@ -2479,7 +2479,7 @@
       "type": "row"
     },
     {
-      "collapsed": true,
+      "collapsed": false,
       "datasource": null,
       "gridPos": {
         "h": 1,

--- a/app/kumactl/data/install/k8s/metrics/grafana/kuma-gateway.json
+++ b/app/kumactl/data/install/k8s/metrics/grafana/kuma-gateway.json
@@ -574,10 +574,10 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(envoy_cluster_internal_upstream_rq_xx{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",kuma_io_mesh_gateway=~\".*$meshgateway.*\",kuma_io_mesh_gateway!=\"\",kuma_io_mesh_traffic=\"true\"}[1m])) by (envoy_response_code_class)",
+          "expr": "sum(rate(envoy_cluster_internal_upstream_rq_xx{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",kuma_io_mesh_gateway=~\".*$meshgateway.*\",kuma_io_mesh_gateway!=\"\",kuma_io_mesh_traffic=\"true\"}[1m])) by (envoy_response_code_class,envoy_cluster_name)",
           "hide": false,
           "interval": "",
-          "legendFormat": "{{envoy_response_code_class}}xx",
+          "legendFormat": "{{envoy_cluster_name}}:{{envoy_response_code_class}}xx",
           "refId": "B"
         }
       ],

--- a/app/kumactl/data/install/k8s/metrics/grafana/kuma-service-to-service.json
+++ b/app/kumactl/data/install/k8s/metrics/grafana/kuma-service-to-service.json
@@ -21,7 +21,7 @@
   "links": [],
   "panels": [
     {
-      "collapsed": true,
+      "collapsed": false,
       "datasource": "Prometheus",
       "gridPos": {
         "h": 1,
@@ -889,7 +889,7 @@
       }
     },
     {
-      "collapsed": true,
+      "collapsed": false,
       "datasource": "Prometheus",
       "gridPos": {
         "h": 1,
@@ -1299,7 +1299,7 @@
           "value": "backend_kuma-demo_svc_3001"
         },
         "datasource": "Prometheus",
-        "definition": "label_values(envoy_server_live{mesh=\"$mesh\"}, kuma_io_service)",
+        "definition": "label_values(envoy_server_live{mesh=\"$mesh\",kuma_io_mesh_gateway=\"\"}, kuma_io_service)",
         "description": null,
         "error": null,
         "hide": 0,
@@ -1309,7 +1309,7 @@
         "name": "source_service",
         "options": [],
         "query": {
-          "query": "label_values(envoy_server_live{mesh=\"$mesh\"}, kuma_io_service)",
+          "query": "label_values(envoy_server_live{mesh=\"$mesh\",kuma_io_mesh_gateway=\"\"}, kuma_io_service)",
           "refId": "Prometheus-source_service-Variable-Query"
         },
         "refresh": 1,

--- a/app/kumactl/data/install/k8s/metrics/grafana/kuma-service.json
+++ b/app/kumactl/data/install/k8s/metrics/grafana/kuma-service.json
@@ -1008,7 +1008,7 @@
           "value": "backend_kuma-demo_svc_3001"
         },
         "datasource": null,
-        "definition": "label_values(envoy_server_live{mesh=\"$mesh\",kuma_io_zone=~\"$zone\"}, kuma_io_service)",
+        "definition": "label_values(envoy_server_live{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",kuma_io_mesh_gateway=\"\"}, kuma_io_service)",
         "description": null,
         "error": null,
         "hide": 0,
@@ -1018,7 +1018,7 @@
         "name": "service",
         "options": [],
         "query": {
-          "query": "label_values(envoy_server_live{mesh=\"$mesh\",kuma_io_zone=~\"$zone\"}, kuma_io_service)",
+          "query": "label_values(envoy_server_live{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",kuma_io_mesh_gateway=\"\"}, kuma_io_service)",
           "refId": "StandardVariableQuery"
         },
         "refresh": 1,

--- a/app/kumactl/data/install/k8s/metrics/prometheus/server.yaml
+++ b/app/kumactl/data/install/k8s/metrics/prometheus/server.yaml
@@ -158,15 +158,6 @@ data:
         target_label: kubernetes_node
       scrape_interval: 5m
       scrape_timeout: 30s
-    - honor_labels: true
-      job_name: prometheus-pushgateway
-      kubernetes_sd_configs:
-      - role: service
-      relabel_configs:
-      - action: keep
-        regex: pushgateway
-        source_labels:
-        - __meta_kubernetes_service_annotation_prometheus_io_probe
     - job_name: kubernetes-services
       kubernetes_sd_configs:
       - role: service
@@ -261,14 +252,6 @@ data:
       scrape_interval: "5s"
       relabel_configs:
       - source_labels:
-        - k8s_kuma_io_name
-        regex: "(.*)"
-        target_label: pod
-      - source_labels:
-        - k8s_kuma_io_namespace
-        regex: "(.*)"
-        target_label: namespace
-      - source_labels:
         - __meta_kuma_mesh
         regex: "(.*)"
         target_label: mesh
@@ -282,6 +265,14 @@ data:
         target_label: service
       - action: labelmap
         regex: __meta_kuma_label_(.+)
+      - source_labels:
+        - k8s_kuma_io_name
+        regex: "(.*)"
+        target_label: pod
+      - source_labels:
+        - k8s_kuma_io_namespace
+        regex: "(.*)"
+        target_label: namespace
       kuma_sd_configs:
       - server: {{ .KumaCpAddress }}
     alerting:


### PR DESCRIPTION
- Have no panels collapsed by default
- Fix scraping to get back `pod` and `namespace` label of Kuma scraping
- Don't list gateways in service dashboards
- Show envoy_cluster_name in gateway status code dashboards

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] Link to docs PR or issue -- NA
- [x] Link to UI issue or PR -- NA
- [x] Is the [issue worked on linked][1]? -- https://github.com/kumahq/kuma/issues/4658
- [x] Unit Tests -- Updated golden files
- [x] E2E Tests -- NA
- [x] Manual Universal Tests -- NA
- [x] Manual Kubernetes Tests -- Yes
- [x] Do you need to update [`UPGRADE.md`](/UPGRADE.md)? -- NA
- [x] Does it need to be backported according to the [backporting policy](/CONTRIBUTING.md#backporting)? -- NA

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
