### PR TITLE
fix(kuma-cp): check if kuma annotation or label is set but ignore value 

### DIFF
--- a/pkg/plugins/runtime/k8s/controllers/namespace_controller.go
+++ b/pkg/plugins/runtime/k8s/controllers/namespace_controller.go
@@ -60,19 +60,17 @@ func (r *NamespaceReconciler) Reconcile(ctx context.Context, req kube_ctrl.Reque
 		return kube_ctrl.Result{}, nil
 	}
 
-	injectedLabel, _, err := metadata.Annotations(ns.Labels).GetEnabled(metadata.KumaSidecarInjectionAnnotation)
+	_, labelExists, err := metadata.Annotations(ns.Labels).GetEnabled(metadata.KumaSidecarInjectionAnnotation)
 	if err != nil {
 		return kube_ctrl.Result{}, errors.Wrapf(err, "unable to check sidecar injection label on namespace %s", ns.Name)
 	}
 	// support annotations for backwards compatibility
 	// https://github.com/kumahq/kuma/issues/4005
-	injectedAnnotation := false
-	injectedAnnotation, _, err = metadata.Annotations(ns.Annotations).GetEnabled(metadata.KumaSidecarInjectionAnnotation)
+	_, annotationExists, err := metadata.Annotations(ns.Annotations).GetEnabled(metadata.KumaSidecarInjectionAnnotation)
 	if err != nil {
 		return kube_ctrl.Result{}, errors.Wrapf(err, "unable to check sidecar injection annotation on namespace %s", ns.Name)
 	}
-	injected := injectedLabel || injectedAnnotation
-	if injected {
+	if labelExists || annotationExists {
 		log.Info("creating NetworkAttachmentDefinition for CNI support")
 		err := r.createOrUpdateNetworkAttachmentDefinition(ctx, req.Name)
 		return kube_ctrl.Result{}, err


### PR DESCRIPTION
### Summery
Removed check if the value of annotation `kuma.io/sidecar-injection` is `enabled`, now we check if the annotation is present.

- [X] Link to docs PR or issue -- docs https://github.com/kumahq/kuma-website/pull/940 
- [X] Link to UI issue or PR -- none
- [X] Is the [issue worked on linked][1]? -- fix #4224
- [X] Unit Tests -- 
- [X] E2E Tests -- none
- [X] Manual Universal Tests -- none
- [X] Manual Kubernetes Tests -- none
- [X] Do you need to update [`UPGRADE.md`](/UPGRADE.md)? -- none
- [X] Does it need to be backported according to the [backporting policy](/CONTRIBUTING.md#backporting)? -- none
