### PR TITLE
chore: remove race on k3d/load with parallelization

### DIFF
--- a/mk/k3d.mk
+++ b/mk/k3d.mk
@@ -86,7 +86,9 @@ k3d/load/images:
 	@k3d image import $(KUMA_IMAGES) --cluster=$(KIND_CLUSTER_NAME) --verbose || k3d image import $(KUMA_IMAGES) --cluster=$(KIND_CLUSTER_NAME) --verbose
 
 .PHONY: k3d/load
-k3d/load: images k3d/load/images
+k3d/load:
+	$(MAKE) images
+	$(MAKE) k3d/load/images
 
 .PHONY: k3d/deploy/kuma
 k3d/deploy/kuma: build/kumactl k3d/load


### PR DESCRIPTION
`k3d/load` had a race when running with `-j`. If you run `images` and `k3d/load/images` in parallel, you may not have images built yet.

This PR forces order to build images first and then load them

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [X] Link to docs PR or issue --
- [X] Link to UI issue or PR --
- [X] Is the [issue worked on linked][1]? --
- [X] Unit Tests --
- [X] E2E Tests --
- [X] Manual Universal Tests --
- [X] Manual Kubernetes Tests --
- [X] Do you need to update [`UPGRADE.md`](/UPGRADE.md)? --
- [X] Does it need to be backported according to the [backporting policy](/CONTRIBUTING.md#backporting)? --

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
