### PR TITLE
chore: wait for default mesh in k3d/deploy/kuma

### DIFF
--- a/mk/k3d.mk
+++ b/mk/k3d.mk
@@ -93,6 +93,9 @@ k3d/deploy/kuma: build/kumactl k3d/load
 	@KUBECONFIG=$(KIND_KUBECONFIG) $(BUILD_ARTIFACTS_DIR)/kumactl/kumactl install --mode $(KUMA_MODE) control-plane $(KUMACTL_INSTALL_CONTROL_PLANE_IMAGES) | KUBECONFIG=$(KIND_KUBECONFIG)  kubectl apply -f -
 	@KUBECONFIG=$(KIND_KUBECONFIG) kubectl wait --timeout=60s --for=condition=Available -n $(KUMA_NAMESPACE) deployment/kuma-control-plane
 	@KUBECONFIG=$(KIND_KUBECONFIG) kubectl wait --timeout=60s --for=condition=Ready -n $(KUMA_NAMESPACE) pods -l app=kuma-control-plane
+	until \
+		 KUBECONFIG=$(KIND_KUBECONFIG) kubectl get mesh default ; \
+	do echo "Waiting for default mesh to be present" && sleep 1; done
 
 .PHONY: k3d/deploy/helm
 k3d/deploy/helm: k3d/load


### PR DESCRIPTION
We should wait for default mesh in k3d/deploy/kuma. Otherwise if we execute k3d/deploy/demo immediately we may fail, because there is no mesh in Kuma.

Ideally, this should be a check in `/ready` endpoint, but that's a bigger issue
https://github.com/kumahq/kuma/issues/1001

We cannot add this check currently to `/ready` because creating default mesh triggers the webhook to CP and if CP is not ready then the webhook will fail. Chicken and egg problem.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [X] Link to docs PR or issue --
- [X] Link to UI issue or PR --
- [X] Is the [issue worked on linked][1]? --
- [X] Unit Tests --
- [X] E2E Tests --
- [X] Manual Universal Tests --
- [X] Manual Kubernetes Tests --
- [X] Do you need to update [`UPGRADE.md`](/UPGRADE.md)? --
- [X] Does it need to be backported according to the [backporting policy](/CONTRIBUTING.md#backporting)? --

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
