### PR TITLE
ci(helm): use GitHub app to release charts

### DIFF
--- a/.github/workflows/helm-release.yaml
+++ b/.github/workflows/helm-release.yaml
@@ -92,7 +92,14 @@ jobs:
         with:
           name: ${{ needs.package.outputs.filename }}
           path: .cr-release-packages
+      - name: Generate GitHub app token
+        id: github-app-token
+        uses: tibdex/github-app-token@f717b5ecd4534d3c4df4ce9b5c1c2214f0f7cd06 # v1.6.0
+        with:
+          app_id: ${{ secrets.APP_ID }}
+          private_key: ${{ secrets.APP_PRIVATE_KEY }}
+          repository: ${{ env.GH_OWNER }}/charts
       - name: Release chart
         env:
-          GH_TOKEN: ${{ secrets.CHARTS_GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.github-app-token.outputs.token }}
         run: ./tools/releases/helm.sh --release


### PR DESCRIPTION
### Checklist prior to review

The app is installed on `kumahq/charts` and the secrets are available on this repo. This makes the workflow a little harder to test since you can't just fork `kumahq/kuma` and `kumahq/charts` and run it but creating an app is quite straightforward.

- [x] Link to docs PR or issue --
- [x] Link to UI issue or PR --
- [x] Is the [issue worked on linked][1]? --
- [x] Unit Tests --
- [x] E2E Tests --
- [x] Manual Universal Tests --
- [x] Manual Kubernetes Tests --
- [x] Do you need to update [`UPGRADE.md`](/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](/CONTRIBUTING.md#backporting)? --

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
