### PR TITLE
fix(kuma-dp): only call syscall.Mkfifo for accesslogs on unix-like systems

### DIFF
--- a/app/kuma-dp/pkg/dataplane/accesslogs/server_unix.go
+++ b/app/kuma-dp/pkg/dataplane/accesslogs/server_unix.go
@@ -1,0 +1,27 @@
+//go:build !windows
+
+package accesslogs
+
+import (
+	"os"
+	"syscall"
+
+	"github.com/pkg/errors"
+)
+
+func streamer(address string) (ReaderCloser, error) {
+	err := os.Remove(address)
+	if err != nil && !os.IsNotExist(err) {
+		return nil, errors.Wrapf(err, "error removing existing fifo %s", address)
+	}
+	err = syscall.Mkfifo(address, 0666)
+	if err != nil {
+		return nil, errors.Wrapf(err, "error creating fifo %s", address)
+	}
+	fd, err := os.OpenFile(address, os.O_CREATE, os.ModeNamedPipe)
+	if err != nil {
+		return nil, errors.Wrapf(err, "error opening fifo %s", address)
+	}
+
+	return fd, nil
+}

--- a/app/kuma-dp/pkg/dataplane/accesslogs/server_windows.go
+++ b/app/kuma-dp/pkg/dataplane/accesslogs/server_windows.go
@@ -1,0 +1,9 @@
+package accesslogs
+
+import (
+	"errors"
+)
+
+func streamer(address string) (ReaderCloser, error) {
+	return nil, errors.New("unsupported on Windows")
+}


### PR DESCRIPTION
### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] Link to docs PR or issue --
- [x] Link to UI issue or PR --
- [x] Is the [issue worked on linked][1]? --
- [x] Unit Tests --
- [x] E2E Tests --
- [x] Manual Universal Tests --
- [x] Manual Kubernetes Tests --
- [x] Do you need to update [`UPGRADE.md`](/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](/CONTRIBUTING.md#backporting)? --

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
