### PR TITLE
fix(kuma-dp): fix multi OS build of accesslogs

### DIFF
--- a/app/kuma-dp/pkg/dataplane/accesslogs/server.go
+++ b/app/kuma-dp/pkg/dataplane/accesslogs/server.go
@@ -1,3 +1,5 @@
+//go:build !windows
+
 package accesslogs
 
 import (

--- a/app/kuma-dp/pkg/dataplane/accesslogs/server_windows.go
+++ b/app/kuma-dp/pkg/dataplane/accesslogs/server_windows.go
@@ -1,0 +1,37 @@
+// go:build windows
+package accesslogs
+
+import (
+	kumadp "github.com/kumahq/kuma/pkg/config/app/kuma-dp"
+	"github.com/kumahq/kuma/pkg/core"
+	"github.com/kumahq/kuma/pkg/core/runtime/component"
+	"github.com/kumahq/kuma/pkg/xds/envoy"
+)
+
+var logger = core.Log.WithName("accesslogs-server")
+
+var _ component.Component = &accessLogServer{}
+
+type accessLogServer struct {
+	address string
+}
+
+func (s *accessLogServer) NeedLeaderElection() bool {
+	return false
+}
+
+func NewAccessLogServer(dataplane kumadp.Dataplane) *accessLogServer {
+	address := envoy.AccessLogSocketName(dataplane.Name, dataplane.Mesh)
+	return &accessLogServer{
+		address: address,
+	}
+}
+
+func (s *accessLogServer) Start(stop <-chan struct{}) error {
+	logger.Info("TCP AccessLog is not supported on windows")
+	select {
+	case <-stop:
+		logger.Info("stopping Access Log Server")
+		return nil
+	}
+}


### PR DESCRIPTION
Signed-off-by: Charly Molter <charly.molter@konghq.com>

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] Link to docs PR or issue --
- [x] Link to UI issue or PR --
- [x] Is the [issue worked on linked][1]? --
- [x] Unit Tests --
- [x] E2E Tests --
- [x] Manual Universal Tests --
- [x] Manual Kubernetes Tests --
- [x] Do you need to update [`UPGRADE.md`](/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](/CONTRIBUTING.md#backporting)? --

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
