### PR TITLE
feat(ci): add a special label to run full test matrix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -275,10 +275,13 @@ jobs:
               circleci-agent step halt
               exit 0
             }
-            function has_full_matrix_label() {
-              local labels=$(curl -s -H "Accept: application/vnd.github+json" -H "Authorization: token $GH_TOKEN" https://api.github.com/repos/kumahq/kuma/pulls/$CIRCLE_PR_NUMBER | jq '.labels[].name')
-              echo $labels | grep -q "ci/run-full-matrix"
-            }
+            PR_OUTPUT=$(curl -H "Accept: application/vnd.github+json" -H "Authorization: token $GH_TOKEN" https://api.github.com/repos/kumahq/kuma/pulls/$CIRCLE_PR_NUMBER)
+            echo $PR_OUTPUT
+            JQ_OUTPUT=$(echo $PR_OUTPUT | jq '.labels[].name')
+            echo $JQ_OUTPUT
+            echo $JQ_OUTPUT | grep -q "ci/run-full-matrix"
+            skip "no need to run further"
+            
             if [[ "<< parameters.k8sVersion >>" == "kind" && "<< parameters.target >>" != "test/e2e-universal" ]]; then
               skip "kind should only be used when testing ipv6 or with test/e2e-universal"
             fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,4 @@
 version: 2.1 # Adds support for executors, parameterized jobs, etc
-orbs:
-  github-cli: circleci/github-cli@2.1.0
 
 reusable:
 
@@ -278,7 +276,7 @@ jobs:
               exit 0
             }
             function has_full_matrix_label() {
-              local labels=$(gh --repo kumahq/kuma pr view $CIRCLE_PR_NUMBER --json labels | jq '.labels[].name')
+              local labels=$(curl -s -H "Accept: application/vnd.github+json" -H "Authorization: token $GH_TOKEN" https://api.github.com/repos/kumahq/kuma/pulls/$CIRCLE_PR_NUMBER | jq '.labels[].name')
               echo $labels | grep -q "ci/run-full-matrix"
             }
             if [[ "<< parameters.k8sVersion >>" == "kind" && "<< parameters.target >>" != "test/e2e-universal" ]]; then

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -277,7 +277,7 @@ jobs:
             }
             function has_full_matrix_label() {
               local labels=$(gh --repo kumahq/kuma pr view $CIRCLE_PR_NUMBER --json labels | jq '.labels[].name')
-              echo $LABELS | grep -q "ci/run-full-matrix"
+              echo $labels | grep -q "ci/run-full-matrix"
             }
             if [[ "<< parameters.k8sVersion >>" == "kind" && "<< parameters.target >>" != "test/e2e-universal" ]]; then
               skip "kind should only be used when testing ipv6 or with test/e2e-universal"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -275,15 +275,21 @@ jobs:
               circleci-agent step halt
               exit 0
             }
+            function has_full_matrix_label() {
+              local labels=$(gh --repo kumahq/kuma pr view $CIRCLE_PR_NUMBER --json labels | jq '.labels[].name')
+              echo $LABELS | grep -q "ci/run-full-matrix"
+            }
             if [[ "<< parameters.k8sVersion >>" == "kind" && "<< parameters.target >>" != "test/e2e-universal" ]]; then
               skip "kind should only be used when testing ipv6 or with test/e2e-universal"
             fi
             if [[ "<< parameters.k8sVersion >>" != kind* && "<< parameters.target >>" == "test/e2e-universal" ]]; then
               skip "universal only runs on kind"
             fi
-            if [[ "<< pipeline.git.branch >>" != "master" && "<< pipeline.git.branch >>" != "release-"* ]]; then
-              if [[ "<< parameters.k8sVersion >>" == "kindIpv6" || "<< parameters.k8sVersion >>" == "v1.19.16-k3s1" || "<< parameters.arch >>" == "arm64" ]]; then
-                skip "Not running tests on PRs with kindIpv6, oldK8s and arm64"
+            if ! has_full_matrix_label; then
+              if [[ "<< pipeline.git.branch >>" != "master" && "<< pipeline.git.branch >>" != "release-"* ]]; then
+                if [[ "<< parameters.k8sVersion >>" == "kindIpv6" || "<< parameters.k8sVersion >>" == "v1.19.16-k3s1" || "<< parameters.arch >>" == "arm64" ]]; then
+                  skip "Not running tests on PRs with kindIpv6, oldK8s and arm64"
+                fi
               fi
             fi
             echo "Continuing tests"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -275,20 +275,13 @@ jobs:
               circleci-agent step halt
               exit 0
             }
-            PR_OUTPUT=$(curl -H "Accept: application/vnd.github+json" -H "Authorization: token $GH_TOKEN" https://api.github.com/repos/kumahq/kuma/pulls/$CIRCLE_PR_NUMBER)
-            echo $PR_OUTPUT
-            JQ_OUTPUT=$(echo $PR_OUTPUT | jq '.labels[].name')
-            echo $JQ_OUTPUT
-            echo $JQ_OUTPUT | grep -q "ci/run-full-matrix"
-            skip "no need to run further"
-            
             if [[ "<< parameters.k8sVersion >>" == "kind" && "<< parameters.target >>" != "test/e2e-universal" ]]; then
               skip "kind should only be used when testing ipv6 or with test/e2e-universal"
             fi
             if [[ "<< parameters.k8sVersion >>" != kind* && "<< parameters.target >>" == "test/e2e-universal" ]]; then
               skip "universal only runs on kind"
             fi
-            if ! has_full_matrix_label; then
+            if [[ ! $(./tools/ci/has_label.sh ci/run-full-matrix) == "true" ]]; then
               if [[ "<< pipeline.git.branch >>" != "master" && "<< pipeline.git.branch >>" != "release-"* ]]; then
                 if [[ "<< parameters.k8sVersion >>" == "kindIpv6" || "<< parameters.k8sVersion >>" == "v1.19.16-k3s1" || "<< parameters.arch >>" == "arm64" ]]; then
                   skip "Not running tests on PRs with kindIpv6, oldK8s and arm64"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -259,6 +259,7 @@ jobs:
       name: vm-<< parameters.arch >>
     parallelism: << parameters.parallelism >>
     steps:
+      - checkout
       - run:
           # This works around circleci limitation by skipping tests for combinations that don't make sense
           # See: https://discuss.circleci.com/t/matrix-exclude-entire-subset/43879
@@ -291,7 +292,6 @@ jobs:
             echo "Continuing tests"
       - install_build_tools:
           go_arch: << parameters.arch >>
-      - checkout
       - restore_cache:
           keys:
             # prefer the exact match

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,6 @@
 version: 2.1 # Adds support for executors, parameterized jobs, etc
+orbs:
+  github-cli: circleci/github-cli@2.1.0
 
 reusable:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -98,6 +98,8 @@ to verify a few things:
 - If your PR are open and some tests are failing due to outdated golden files
   or formatted and generated files are incorrect a maintainer can fix it by adding a
   comment `/format` or `/golden_files`.
+- If you are introducing a change that might break on ipv6 or old k8s kubernetes (v1.19.16-k3s1)
+  consider creating PR with a label `ci/run-full-matrix` that will trigger the full test matrix
 - If you are introducing a change which requires specific attention when
   upgrading update UPGRADE.md
 - Do not update CHANGELOG.md yourself. Your change will be included there in

--- a/tools/ci/has_label.sh
+++ b/tools/ci/has_label.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+LABEL_TO_CHECK="$1"
+CURL_OUTPUT=$(curl -s --fail -H "Accept: application/vnd.github+json" https://api.github.com/repos/kumahq/kuma/pulls/"$CIRCLE_PR_NUMBER")
+
+if [[ $CURL_OUTPUT != "" ]]; then
+    LABELS=$(jq '.labels[].name' <<< "$CURL_OUTPUT")
+    if echo "$LABELS" | grep -q "$LABEL_TO_CHECK"; then
+        echo "true"
+    else
+        echo "false"
+    fi
+else
+    echo "curl call failed"
+fi


### PR DESCRIPTION
This PR gives the contributor an ability to run the whole matrix test suite by adding "ci/run-full-matrix" label to the PR.

The master branch is broken now because of https://github.com/kumahq/kuma/pull/4769 but you can see from the [history](https://app.circleci.com/pipelines/github/kumahq/kuma?branch=pull%2F4770) that all targets were triggered.

Signed-off-by: slonka <slonka@users.noreply.github.com>

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [X] Link to docs PR or issue -- CI improvement 
- [X] Link to UI issue or PR -- not a UI issue
- [X] Is the [issue worked on linked][1]? -- not reported as a bug
- [X] Unit Tests -- not a kuma feature
- [X] E2E Tests -- not a kuma feature 
- [X] Manual Universal Tests -- not a kuma feature, but tested manually on circleCI
- [X] Manual Kubernetes Tests -- not a kuma feature
- [X] Do you need to update [`UPGRADE.md`](/UPGRADE.md)? -- no
- [X] Does it need to be backported according to the [backporting policy](/CONTRIBUTING.md#backporting)? -- no

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
