### PR TITLE
test(e2e): trigger delete namespace in hc multizone

### DIFF
--- a/test/e2e_env/multizone/healthcheck/healthcheck.go
+++ b/test/e2e_env/multizone/healthcheck/healthcheck.go
@@ -45,7 +45,7 @@ func ApplicationOnUniversalClientOnK8s() {
 		Expect(err).ToNot(HaveOccurred())
 	})
 	E2EAfterAll(func() {
-		Expect(env.KubeZone1.DeleteNamespace(namespace)).To(Succeed())
+		Expect(env.KubeZone1.TriggerDeleteNamespace(namespace)).To(Succeed())
 		Expect(env.UniZone1.DeleteMeshApps(meshName)).To(Succeed())
 		Expect(env.Global.DeleteMesh(meshName)).To(Succeed())
 	})


### PR DESCRIPTION
We should use `TriggerDeleteNamespace` to not waste time waiting for the namespace to be deleted.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [X] Link to docs PR or issue --
- [X] Link to UI issue or PR --
- [X] Is the [issue worked on linked][1]? --
- [X] The PR does not hardcode values that might break projects that depend on kuma (e.g. "kumahq" as a image registry) --
- [X] The PR will work for both Linux and Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [X] Unit Tests --
- [X] E2E Tests --
- [X] Manual Universal Tests --
- [X] Manual Kubernetes Tests --
- [X] Do you need to update [`UPGRADE.md`](/UPGRADE.md)? --
- [X] Does it need to be backported according to the [backporting policy](/CONTRIBUTING.md#backporting)? --

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
