### PR TITLE
test(e2e): rewrite zoneegress hybrid tests

### DIFF
--- a/test/e2e/zoneegress/externalservices/e2e_suite_test.go
+++ b/test/e2e/zoneegress/externalservices/e2e_suite_test.go
@@ -13,5 +13,5 @@ func TestE2E(t *testing.T) {
 	test.RunSpecs(t, "E2E ZoneEgress for ExternalServices Suite")
 }
 
-var _ = Describe("Test ZoneEgress for External Services in Hybrid Multizone", externalservices.HybridUniversalGlobal)
+var _ = Describe("Test ZoneEgress for External Services in Hybrid Multizone", externalservices.HybridUniversalGlobal, Ordered)
 var _ = Describe("Test ZoneEgress for External Services in Universal Standalone", externalservices.UniversalStandalone)

--- a/test/e2e/zoneegress/externalservices/zoneegress_externalservices_hybrid.go
+++ b/test/e2e/zoneegress/externalservices/zoneegress_externalservices_hybrid.go
@@ -135,13 +135,13 @@ networking:
 			Expect(YamlUniversal(fmt.Sprintf(meshMTLSOn, nonDefaultMesh, "false", "false"))(global)).To(Succeed())
 		})
 
-		It("k8s should reach external service", func() {
+		It("should reach external service from k8s", func() {
 			_, _, err := zone1.ExecWithRetries(TestNamespace, clientPodName, "demo-client",
 				"curl", "--verbose", "--max-time", "3", "--fail", "external-service-1.mesh")
 			Expect(err).ToNot(HaveOccurred())
 		})
 
-		It("universal should reach external service", func() {
+		It("should reach external service from universal", func() {
 			_, _, err := zone4.ExecWithRetries("", "", "zone4-demo-client",
 				"curl", "-v", "-m", "3", "--fail", "external-service-2.mesh")
 			Expect(err).ToNot(HaveOccurred())
@@ -153,7 +153,7 @@ networking:
 			Expect(YamlUniversal(fmt.Sprintf(meshMTLSOn, nonDefaultMesh, "false", "true"))(global)).To(Succeed())
 		})
 
-		It("k8s should not reach external service when zone egress is down", func() {
+		It("should not reach external service from k8s when zone egress is down", func() {
 			Eventually(func() error {
 				_, _, err := zone1.Exec(TestNamespace, clientPodName, "demo-client",
 					"curl", "--verbose", "--max-time", "3", "--fail", "external-service-1.mesh")
@@ -161,7 +161,7 @@ networking:
 			}, "30s", "1s").Should(HaveOccurred())
 		})
 
-		It("universal should not reach external service when zone egress is down", func() {
+		It("should not reach external service from universal when zone egress is down", func() {
 			Eventually(func() error {
 				_, _, err := zone4.Exec("", "", "zone4-demo-client",
 					"curl", "-v", "-m", "3", "--fail", "external-service-2.mesh")

--- a/test/e2e/zoneegress/externalservices/zoneegress_externalservices_hybrid.go
+++ b/test/e2e/zoneegress/externalservices/zoneegress_externalservices_hybrid.go
@@ -10,10 +10,8 @@ import (
 	config_core "github.com/kumahq/kuma/pkg/config/core"
 	. "github.com/kumahq/kuma/test/framework"
 	"github.com/kumahq/kuma/test/framework/deployments/testserver"
-	"github.com/kumahq/kuma/test/framework/envoy_admin/stats"
 )
 
-const defaultMesh = "default"
 const nonDefaultMesh = "non-default"
 
 func HybridUniversalGlobal() {
@@ -56,8 +54,9 @@ networking:
 
 	var global, zone1 Cluster
 	var zone4 *UniversalCluster
+	var clientPodName string
 
-	BeforeEach(func() {
+	BeforeAll(func() {
 		k8sClusters, err := NewK8sClusters(
 			[]string{Kuma1},
 			Silent)
@@ -73,23 +72,16 @@ networking:
 
 		Expect(NewClusterSetup().
 			Install(Kuma(config_core.Global)).
-			Install(YamlUniversal(fmt.Sprintf(meshMTLSOn, defaultMesh, "true", "true"))).
 			Install(YamlUniversal(fmt.Sprintf(meshMTLSOn, nonDefaultMesh, "true", "true"))).
 			Install(YamlUniversal(fmt.Sprintf(externalService1, nonDefaultMesh))).
 			Setup(global)).To(Succeed())
-
-		E2EDeferCleanup(global.DismissCluster)
 
 		globalCP := global.GetKuma()
 
 		// K8s Cluster 1
 		zone1 = k8sClusters.GetCluster(Kuma1)
 		Expect(NewClusterSetup().
-			Install(Kuma(config_core.Zone,
-				WithEgress(),
-				WithEgressEnvoyAdminTunnel(),
-				WithGlobalAddress(globalCP.GetKDSServerAddress()),
-			)).
+			Install(Kuma(config_core.Zone, WithGlobalAddress(globalCP.GetKDSServerAddress()))). // do not deploy Egress
 			Install(NamespaceWithSidecarInjection(TestNamespace)).
 			Install(DemoClientK8s(nonDefaultMesh, TestNamespace)).
 			Install(testserver.Install(
@@ -99,24 +91,20 @@ networking:
 			)).
 			Setup(zone1)).To(Succeed())
 
-		E2EDeferCleanup(func() {
-			Expect(zone1.DeleteNamespace(TestNamespace)).To(Succeed())
-			Expect(zone1.DeleteKuma()).To(Succeed())
-			Expect(zone1.DismissCluster()).To(Succeed())
-		})
+		clientPodName, err = PodNameOfApp(zone1, "demo-client", TestNamespace)
+		Expect(err).ToNot(HaveOccurred())
 
 		// Universal Cluster 4
 		zone4 = universalClusters.GetCluster(Kuma4).(*UniversalCluster)
 		Expect(err).ToNot(HaveOccurred())
 
 		Expect(NewClusterSetup().
-			Install(Kuma(config_core.Zone, WithGlobalAddress(globalCP.GetKDSServerAddress()))).
+			Install(Kuma(config_core.Zone, WithGlobalAddress(globalCP.GetKDSServerAddress()))). // do not deploy Egress
 			Install(DemoClientUniversal(
 				"zone4-demo-client",
 				nonDefaultMesh,
 				WithTransparentProxy(true),
 			)).
-			Install(EgressUniversal(globalCP.GenerateZoneEgressToken)).
 			Install(
 				func(cluster Cluster) error {
 					return cluster.DeployApp(
@@ -128,124 +116,57 @@ networking:
 			Setup(zone4),
 		).To(Succeed())
 
-		E2EDeferCleanup(zone4.DismissCluster)
-
 		Expect(global.GetKumactlOptions().
 			KumactlApplyFromString(
 				fmt.Sprintf(externalService2, nonDefaultMesh, net.JoinHostPort(zone4.GetApp("es-test-server").GetIP(), "8080"))),
 		).To(Succeed())
 	})
 
-	It("k8s should access external service through zoneegress", func() {
-		filter := fmt.Sprintf(
-			"cluster.%s_%s.upstream_rq_total",
-			nonDefaultMesh,
-			"external-service-1",
-		)
-
-		clientPodName, err := PodNameOfApp(zone1, "demo-client", TestNamespace)
-		Expect(err).ToNot(HaveOccurred())
-
-		Eventually(func(g Gomega) {
-			stat, err := zone1.GetZoneEgressEnvoyTunnel().GetStats(filter)
-			g.Expect(err).ToNot(HaveOccurred())
-			g.Expect(stat).To(stats.BeEqualZero())
-		}, "30s", "1s").Should(Succeed())
-
-		_, stderr, err := zone1.ExecWithRetries(TestNamespace, clientPodName, "demo-client",
-			"curl", "--verbose", "--max-time", "3", "--fail", "external-service-1.mesh")
-		Expect(err).ToNot(HaveOccurred())
-		Expect(stderr).To(ContainSubstring("HTTP/1.1 200 OK"))
-
-		Eventually(func(g Gomega) {
-			stat, err := zone1.GetZoneEgressEnvoyTunnel().GetStats(filter)
-			g.Expect(err).ToNot(HaveOccurred())
-			g.Expect(stat).To(stats.BeGreaterThanZero())
-		}, "30s", "1s").Should(Succeed())
+	E2EAfterAll(func() {
+		Expect(zone1.DeleteNamespace(TestNamespace)).To(Succeed())
+		Expect(zone1.DeleteKuma()).To(Succeed())
+		Expect(zone1.DismissCluster()).To(Succeed())
+		Expect(zone4.DismissCluster()).To(Succeed())
+		Expect(global.DismissCluster()).To(Succeed())
 	})
 
-	It("universal should access external service through zoneegress", func() {
-		filter := fmt.Sprintf(
-			"cluster.%s_%s.upstream_rq_total",
-			nonDefaultMesh,
-			"external-service-2",
-		)
+	Context("passthrough false with zoneegress false", func() {
+		BeforeAll(func() {
+			Expect(YamlUniversal(fmt.Sprintf(meshMTLSOn, nonDefaultMesh, "false", "false"))(global)).To(Succeed())
+		})
 
-		Eventually(func(g Gomega) {
-			stat, err := zone4.GetZoneEgressEnvoyTunnel().GetStats(filter)
-			g.Expect(err).ToNot(HaveOccurred())
-			g.Expect(stat).To(stats.BeEqualZero())
-		}, "30s", "1s").Should(Succeed())
-
-		stdout, _, err := zone4.ExecWithRetries("", "", "zone4-demo-client",
-			"curl", "--verbose", "--max-time", "3", "--fail", "external-service-2.mesh")
-		Expect(err).ToNot(HaveOccurred())
-		Expect(stdout).To(ContainSubstring("HTTP/1.1 200 OK"))
-
-		Eventually(func(g Gomega) {
-			stat, err := zone4.GetZoneEgressEnvoyTunnel().GetStats(filter)
-			g.Expect(err).ToNot(HaveOccurred())
-			g.Expect(stat).To(stats.BeGreaterThanZero())
-		}, "30s", "1s").Should(Succeed())
-	})
-
-	It("k8s should not reach external service when zone egress is down", func() {
-		// given k8s cluster
-		k8sCluster := zone1.(*K8sCluster)
-
-		clientPodName, err := PodNameOfApp(zone1, "demo-client", TestNamespace)
-		Expect(err).ToNot(HaveOccurred())
-
-		serviceUnreachable := func() error {
-			_, _, err := k8sCluster.Exec(TestNamespace, clientPodName, "demo-client",
+		It("k8s should reach external service", func() {
+			_, _, err := zone1.ExecWithRetries(TestNamespace, clientPodName, "demo-client",
 				"curl", "--verbose", "--max-time", "3", "--fail", "external-service-1.mesh")
-			return err
-		}
+			Expect(err).ToNot(HaveOccurred())
+		})
 
-		// when zone egress is unreachable
-		Expect(k8sCluster.StopZoneEgress()).To(Succeed())
-
-		// then traffic shouldn't reach external service
-		Eventually(serviceUnreachable, "30s", "1s").Should(HaveOccurred())
+		It("universal should reach external service", func() {
+			_, _, err := zone4.ExecWithRetries("", "", "zone4-demo-client",
+				"curl", "-v", "-m", "3", "--fail", "external-service-2.mesh")
+			Expect(err).ToNot(HaveOccurred())
+		})
 	})
 
-	It("universal should not reach external service when zone egress is down", func() {
-		serviceUnreachable := func() error {
-			_, _, err := zone4.Exec("", "", "demo-client",
-				"curl", "-v", "-m", "3", "--fail", "external-service-1.mesh")
-			return err
-		}
+	Context("passthrough false with zoneegress true", func() {
+		BeforeAll(func() {
+			Expect(YamlUniversal(fmt.Sprintf(meshMTLSOn, nonDefaultMesh, "false", "true"))(global)).To(Succeed())
+		})
 
-		filter := fmt.Sprintf(
-			"cluster.%s_%s.upstream_rq_total",
-			nonDefaultMesh,
-			"external-service-2",
-		)
+		It("k8s should not reach external service when zone egress is down", func() {
+			Eventually(func() error {
+				_, _, err := zone1.Exec(TestNamespace, clientPodName, "demo-client",
+					"curl", "--verbose", "--max-time", "3", "--fail", "external-service-1.mesh")
+				return err
+			}, "30s", "1s").Should(HaveOccurred())
+		})
 
-		Eventually(func(g Gomega) {
-			stat, err := zone4.GetZoneEgressEnvoyTunnel().GetStats(filter)
-			g.Expect(err).ToNot(HaveOccurred())
-			g.Expect(stat).To(stats.BeEqualZero())
-		}, "30s", "1s").Should(Succeed())
-
-		// when request external service
-		stdout, _, err := zone4.ExecWithRetries("", "", "zone4-demo-client",
-			"curl", "--verbose", "--max-time", "3", "--fail", "external-service-2.mesh")
-		Expect(err).ToNot(HaveOccurred())
-		Expect(stdout).To(ContainSubstring("HTTP/1.1 200 OK"))
-
-		// then stats at zone egress increase
-		Eventually(func(g Gomega) {
-			stat, err := zone4.GetZoneEgressEnvoyTunnel().GetStats(filter)
-			g.Expect(err).ToNot(HaveOccurred())
-			g.Expect(stat).To(stats.BeGreaterThanZero())
-		}, "30s", "1s").Should(Succeed())
-
-		// when egress is down
-		_, _, err = zone4.Exec("", "", AppEgress, "pkill", "-9", "kuma-dp")
-		Expect(err).ToNot(HaveOccurred())
-
-		// then traffic shouldn't reach external service
-		Eventually(serviceUnreachable, "30s", "1s").Should(HaveOccurred())
+		It("universal should not reach external service when zone egress is down", func() {
+			Eventually(func() error {
+				_, _, err := zone4.Exec("", "", "zone4-demo-client",
+					"curl", "-v", "-m", "3", "--fail", "external-service-2.mesh")
+				return err
+			}, "30s", "1s").Should(HaveOccurred())
+		})
 	})
 }


### PR DESCRIPTION
Unfortunately, this one cannot be migrated to e2e_env because it relies on the absence of zone egress.
However, the current test is not optimal because of `BeforeEach`.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [ ] Link to docs PR or issue --
- [ ] Link to UI issue or PR --
- [ ] Is the [issue worked on linked][1]? --
- [ ] The PR does not hardcode values that might break projects that depend on kuma (e.g. "kumahq" as a image registry) --
- [ ] The PR will work for both Linux and Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [ ] Unit Tests --
- [ ] E2E Tests --
- [ ] Manual Universal Tests --
- [ ] Manual Kubernetes Tests --
- [ ] Do you need to update [`UPGRADE.md`](/UPGRADE.md)? --
- [ ] Does it need to be backported according to the [backporting policy](/CONTRIBUTING.md#backporting)? --

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
