### PR TITLE
test(e2e): reuse images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -346,7 +346,7 @@ jobs:
               export E2E_PKG_LIST=${E2E_PKG_LIST:-$(circleci tests glob ./test/e2e/* | circleci tests split | xargs printf "./%s/... ")}
             fi
             env
-            make ${MAKE_PARAMETERS} << parameters.target >>
+            make ${MAKE_PARAMETERS} CI=true << parameters.target >>
       - store_test_results:
           path: build/reports
 

--- a/mk/docker.mk
+++ b/mk/docker.mk
@@ -75,7 +75,7 @@ ${BUILD_DOCKER_IMAGES_DIR}:
 docker/save: $(DOCKER_SAVE_TARGETS)
 
 .PHONY: docker/save/release
-docker/save/release: docker/save/kuma-cp docker/save/kuma-dp docker/save/kumactl docker/save/kuma-init docker/save/kuma-prometheus-sd
+docker/save/release: docker/save/kuma-cp docker/save/kuma-dp docker/save/kumactl docker/save/kuma-init docker/save/kuma-prometheus-sd docker/save/kuma-cni
 
 .PHONY: docker/save/test
 docker/save/test: docker/save/kuma-universal
@@ -100,6 +100,10 @@ docker/save/kuma-init: ${BUILD_DOCKER_IMAGES_DIR}
 docker/save/kuma-prometheus-sd: ${BUILD_DOCKER_IMAGES_DIR}
 	docker save --output ${BUILD_DOCKER_IMAGES_DIR}/kuma-prometheus-sd.tar $(KUMA_PROMETHEUS_SD_DOCKER_IMAGE)
 
+.PHONY: docker/save/kuma-cni
+docker/save/kuma-cni: ${BUILD_DOCKER_IMAGES_DIR}
+	docker save --output ${BUILD_DOCKER_IMAGES_DIR}/kuma-cni.tar $(KUMA_CNI_DOCKER_IMAGE)
+
 .PHONY: docker/save/kuma-universal
 docker/save/kuma-universal: ${BUILD_DOCKER_IMAGES_DIR}
 	docker save --output ${BUILD_DOCKER_IMAGES_DIR}/kuma-universal.tar $(KUMA_UNIVERSAL_DOCKER_IMAGE)
@@ -108,7 +112,7 @@ docker/save/kuma-universal: ${BUILD_DOCKER_IMAGES_DIR}
 docker/load: $(DOCKER_LOAD_TARGETS)
 
 .PHONY: docker/load/release
-docker/load/release: docker/load/kuma-cp docker/load/kuma-dp docker/load/kumactl docker/load/kuma-init docker/load/kuma-prometheus-sd
+docker/load/release: docker/load/kuma-cp docker/load/kuma-dp docker/load/kumactl docker/load/kuma-init docker/load/kuma-prometheus-sd docker/load/kuma-cni
 
 .PHONY: docker/load/test
 docker/load/test: docker/load/kuma-universal
@@ -132,6 +136,10 @@ docker/load/kuma-init: ${BUILD_DOCKER_IMAGES_DIR}/kuma-init.tar
 .PHONY: docker/load/kuma-prometheus-sd
 docker/load/kuma-prometheus-sd: ${BUILD_DOCKER_IMAGES_DIR}/kuma-prometheus-sd.tar
 	docker load --input ${BUILD_DOCKER_IMAGES_DIR}/kuma-prometheus-sd.tar
+
+.PHONY: docker/load/kuma-cni
+docker/load/kuma-cni: ${BUILD_DOCKER_IMAGES_DIR}/kuma-cni.tar
+	docker load --input ${BUILD_DOCKER_IMAGES_DIR}/kuma-cni.tar
 
 .PHONY: docker/load/kuma-universal
 docker/load/kuma-universal: ${BUILD_DOCKER_IMAGES_DIR}/kuma-universal.tar

--- a/mk/e2e.new.mk
+++ b/mk/e2e.new.mk
@@ -12,7 +12,6 @@ E2E_ENV_VARS ?=
 
 ifdef CI
 # In circleCI all this was built from previous targets let's reuse them!
-E2E_DEPS_TARGETS+= docker/load
 else
 E2E_DEPS_TARGETS+= build/kumactl images
 endif
@@ -64,7 +63,7 @@ test/e2e/k8s/start/cluster/$1:
 
 .PHONY: test/e2e/k8s/load/images/$1
 test/e2e/k8s/load/images/$1:
-	KIND_CLUSTER_NAME=$1 $(MAKE) $(K8S_CLUSTER_TOOL)/load
+	KIND_CLUSTER_NAME=$1 $(MAKE) $(K8S_CLUSTER_TOOL)/load/images
 
 .PHONY: test/e2e/k8s/wait/$1
 test/e2e/k8s/wait/$1:

--- a/mk/e2e.new.mk
+++ b/mk/e2e.new.mk
@@ -12,6 +12,7 @@ E2E_ENV_VARS ?=
 
 ifdef CI
 # In circleCI all this was built from previous targets let's reuse them!
+E2E_DEPS_TARGETS+= docker/load
 else
 E2E_DEPS_TARGETS+= build/kumactl images
 endif


### PR DESCRIPTION
Save ~1m30s (on each E2E job) by reusing images that were built in the `build` step.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [X] Link to docs PR or issue --
- [X] Link to UI issue or PR --
- [X] Is the [issue worked on linked][1]? --
- [X] The PR does not hardcode values that might break projects that depend on kuma (e.g. "kumahq" as a image registry) --
- [X] The PR will work for both Linux and Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [X] Unit Tests --
- [X] E2E Tests --
- [X] Manual Universal Tests --
- [X] Manual Kubernetes Tests --
- [X] Do you need to update [`UPGRADE.md`](/UPGRADE.md)? --
- [X] Does it need to be backported according to the [backporting policy](/CONTRIBUTING.md#backporting)? --

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
