### PR TITLE
test(e2e): fix skip of gateway api for arm and ipv6

### DIFF
--- a/test/e2e_env/kubernetes/gateway/gatewayapi.go
+++ b/test/e2e_env/kubernetes/gateway/gatewayapi.go
@@ -27,10 +27,12 @@ spec:
 
 func GatewayAPI() {
 	if Config.IPV6 {
-		Skip("IPv6 tests use kind which doesn't support the LoadBalancer ServiceType")
+		fmt.Println("IPv6 tests use kind which doesn't support the LoadBalancer ServiceType")
+		return
 	}
 	if runtime.GOARCH == "arm64" {
-		Skip("The webhook doesn't provide an arm64 image")
+		fmt.Println("The webhook doesn't provide an arm64 image")
+		return
 	}
 
 	meshName := "gatewayapi"


### PR DESCRIPTION
Skip does not work in this place

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [ ] Link to docs PR or issue --
- [ ] Link to UI issue or PR --
- [ ] Is the [issue worked on linked][1]? --
- [ ] The PR does not hardcode values that might break projects that depend on kuma (e.g. "kumahq" as a image registry) --
- [ ] The PR will work for both Linux and Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [ ] Unit Tests --
- [ ] E2E Tests --
- [ ] Manual Universal Tests --
- [ ] Manual Kubernetes Tests --
- [ ] Do you need to update [`UPGRADE.md`](/UPGRADE.md)? --
- [ ] Does it need to be backported according to the [backporting policy](/CONTRIBUTING.md#backporting)? --

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
