### PR TITLE
fix(kuma-cp): protect sort from empty locality

### DIFF
--- a/pkg/xds/envoy/endpoints/v3/endpoints.go
+++ b/pkg/xds/envoy/endpoints/v3/endpoints.go
@@ -97,8 +97,12 @@ func (l LocalityLbEndpointsMap) asSlice() []*envoy_endpoint.LocalityLbEndpoints 
 	// sort the slice to ensure stable Envoy configuration
 	sort.Slice(slice, func(i, j int) bool {
 		left, right := slice[i], slice[j]
-		return (left.Locality.Region + left.Locality.Zone + left.Locality.SubZone) >
-			(right.Locality.Region + right.Locality.Zone + right.Locality.SubZone)
+		leftLocality := left.GetLocality().GetRegion() + left.GetLocality().GetZone() + left.GetLocality().GetSubZone()
+		rightLocality := right.GetLocality().GetRegion() + right.GetLocality().GetZone() + right.GetLocality().GetSubZone()
+		if leftLocality != "" || rightLocality != "" {
+			return leftLocality < rightLocality
+		}
+		return len(left.LbEndpoints) < len(right.LbEndpoints)
 	})
 
 	return slice

--- a/pkg/xds/envoy/endpoints/v3/endpoints_test.go
+++ b/pkg/xds/envoy/endpoints/v3/endpoints_test.go
@@ -188,6 +188,55 @@ var _ = Describe("Endpoints", func() {
                     loadBalancingWeight: 2
 `,
 			}),
+			Entry("mixed locality", testCase{
+				cluster: "127.0.0.1:8080",
+				endpoints: []core_xds.Endpoint{
+					{
+						Target: "192.168.0.1",
+						Port:   8081,
+						Weight: 2,
+						Locality: &core_xds.Locality{
+							Zone: "west",
+						},
+					},
+					{
+						Target: "192.168.0.2",
+						Port:   8082,
+						Weight: 1,
+					},
+					{
+						Target: "192.168.0.3",
+						Port:   8082,
+						Weight: 1,
+					},
+				},
+				expected: `
+clusterName: 127.0.0.1:8080
+endpoints:
+    - lbEndpoints:
+        - endpoint:
+            address:
+                socketAddress:
+                    address: 192.168.0.2
+                    portValue: 8082
+          loadBalancingWeight: 1
+        - endpoint:
+            address:
+                socketAddress:
+                    address: 192.168.0.3
+                    portValue: 8082
+          loadBalancingWeight: 1
+    - lbEndpoints:
+        - endpoint:
+            address:
+                socketAddress:
+                    address: 192.168.0.1
+                    portValue: 8081
+          loadBalancingWeight: 2
+      locality:
+        zone: west
+`,
+			}),
 		)
 	})
 })


### PR DESCRIPTION
I'm not sure how to get into this state by using Kuma. Locality in endpoints is always nil (standalone) or always present (multizone). Maybe some mix of external service with kuma.io/zone tag (missing/present)

Fix #4816

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [X] Link to docs PR or issue --
- [X] Link to UI issue or PR --
- [X] Is the [issue worked on linked][1]? -- https://github.com/kumahq/kuma/issues/4816
- [X] The PR does not hardcode values that might break projects that depend on kuma (e.g. "kumahq" as a image registry) --
- [X] The PR will work for both Linux and Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [X] Unit Tests --
- [X] E2E Tests -- no
- [X] Manual Universal Tests -- no
- [X] Manual Kubernetes Tests -- no
- [X] Do you need to update [`UPGRADE.md`](/UPGRADE.md)? -- no
- [X] Does it need to be backported according to the [backporting policy](/CONTRIBUTING.md#backporting)? -- yes

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
