### PR TITLE
test(e2e): retry tests with pulp

### DIFF
--- a/test/e2e/compatibility/e2e_suite_test.go
+++ b/test/e2e/compatibility/e2e_suite_test.go
@@ -14,4 +14,6 @@ func TestE2E(t *testing.T) {
 }
 
 var _ = Describe("Test Kubernetes Multizone Compatibility", Label("arm-not-supported"), compatibility.CpCompatibilityMultizoneKubernetes)
-var _ = Describe("Test Universal Compatibility", Label("arm-not-supported"), compatibility.UniversalCompatibility)
+
+// Set FlakeAttempts because sometimes there is a problem with fetching Kuma binaries from pulp.
+var _ = Describe("Test Universal Compatibility", Label("arm-not-supported"), FlakeAttempts(3), compatibility.UniversalCompatibility)


### PR DESCRIPTION
Pulp (our binary registry) is sometimes flaky.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [X] Link to docs PR or issue --
- [X] Link to UI issue or PR --
- [X] Is the [issue worked on linked][1]? --
- [X] The PR does not hardcode values that might break projects that depend on kuma (e.g. "kumahq" as a image registry) --
- [X] The PR will work for both Linux and Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [X] Unit Tests --
- [X] E2E Tests --
- [X] Manual Universal Tests --
- [X] Manual Kubernetes Tests --
- [X] Do you need to update [`UPGRADE.md`](/UPGRADE.md)? --
- [X] Does it need to be backported according to the [backporting policy](/CONTRIBUTING.md#backporting)? --

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
