### PR TITLE
test(e2e): skip legacy zone egress hybrid on arm

### DIFF
--- a/test/e2e/zoneegress/externalservices/e2e_suite_test.go
+++ b/test/e2e/zoneegress/externalservices/e2e_suite_test.go
@@ -13,5 +13,6 @@ func TestE2E(t *testing.T) {
 	test.RunSpecs(t, "E2E ZoneEgress for ExternalServices Suite")
 }
 
-var _ = Describe("Test ZoneEgress for External Services in Hybrid Multizone", externalservices.HybridUniversalGlobal, Ordered)
+// arm-not-supported because of https://github.com/kumahq/kuma/issues/4822
+var _ = Describe("Test ZoneEgress for External Services in Hybrid Multizone", Label("arm-not-supported"), externalservices.HybridUniversalGlobal, Ordered)
 var _ = Describe("Test ZoneEgress for External Services in Universal Standalone", externalservices.UniversalStandalone)


### PR DESCRIPTION
Created a separate issue to debug this since it's quite difficult. The flake only happens on arm (once every ~10 times)

https://github.com/kumahq/kuma/issues/4822

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [X] Link to docs PR or issue --
- [X] Link to UI issue or PR --
- [X] Is the [issue worked on linked][1]? --
- [X] The PR does not hardcode values that might break projects that depend on kuma (e.g. "kumahq" as a image registry) --
- [X] The PR will work for both Linux and Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [X] Unit Tests --
- [X] E2E Tests --
- [X] Manual Universal Tests --
- [X] Manual Kubernetes Tests --
- [X] Do you need to update [`UPGRADE.md`](/UPGRADE.md)? --
- [X] Does it need to be backported according to the [backporting policy](/CONTRIBUTING.md#backporting)? --

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
