### PR TITLE
chore: switch merbridge image registry to upstream

### DIFF
--- a/app/kumactl/cmd/install/testdata/install-control-plane.dump-values.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.dump-values.yaml
@@ -335,7 +335,7 @@ cni:
 
     imageEbpf:
       # -- CNI experimental eBPF image registry
-      registry: "docker.io/kumahq"
+      registry: "docker.io/merbridge"
       # -- CNI experimental eBPF image repository
       repository: "merbridge"
       # -- CNI experimental eBPF image tag

--- a/deployments/charts/kuma/README.md
+++ b/deployments/charts/kuma/README.md
@@ -90,10 +90,10 @@ A Helm chart for the Kuma Control Plane
 | cni.image.tag | string | `"0.0.10"` | CNI image tag |
 | cni.image.imagePullPolicy | string | `"IfNotPresent"` | CNI image pull policy |
 | cni.delayStartupSeconds | int | `0` | it's only useful in tests to trigger a possible race condition |
-| cni.experimental | object | `{"image":{"repository":"kuma-cni","tag":null},"imageEbpf":{"registry":"docker.io/kumahq","repository":"merbridge","tag":"0.7.1"}}` | use new CNI image (experimental) |
+| cni.experimental | object | `{"image":{"repository":"kuma-cni","tag":null},"imageEbpf":{"registry":"docker.io/merbridge","repository":"merbridge","tag":"0.7.1"}}` | use new CNI image (experimental) |
 | cni.experimental.image.repository | string | `"kuma-cni"` | CNI experimental image repository |
 | cni.experimental.image.tag | string | `nil` | CNI experimental image tag - defaults to .Chart.AppVersion |
-| cni.experimental.imageEbpf.registry | string | `"docker.io/kumahq"` | CNI experimental eBPF image registry |
+| cni.experimental.imageEbpf.registry | string | `"docker.io/merbridge"` | CNI experimental eBPF image registry |
 | cni.experimental.imageEbpf.repository | string | `"merbridge"` | CNI experimental eBPF image repository |
 | cni.experimental.imageEbpf.tag | string | `"0.7.1"` | CNI experimental eBPF image tag |
 | cni.podSecurityContext | object | `{}` | Security context at the pod level for cni |

--- a/deployments/charts/kuma/values.yaml
+++ b/deployments/charts/kuma/values.yaml
@@ -335,7 +335,7 @@ cni:
 
     imageEbpf:
       # -- CNI experimental eBPF image registry
-      registry: "docker.io/kumahq"
+      registry: "docker.io/merbridge"
       # -- CNI experimental eBPF image repository
       repository: "merbridge"
       # -- CNI experimental eBPF image tag


### PR DESCRIPTION
As merbridge was released with support of Kuma in its CNI plugin
we can switch to use upstream image instead our own

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] Link to docs PR or issue -- just replacing the image to the upstream one
- [x] Link to UI issue or PR -- just replacing the image to the upstream one
- [x] Is the [issue worked on linked][1]? -- just replacing the image to the upstream one
- [x] The PR does not hardcode values that might break projects that depend on kuma (e.g. "kumahq" as a image registry) -- just replacing the image to the upstream one
- [x] The PR will work for both Linux and Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS -- just replacing the image to the upstream one
- [x] Unit Tests -- just replacing the image to the upstream one
- [x] E2E Tests -- just replacing the image to the upstream one
- [x] Manual Universal Tests -- just replacing the image to the upstream one
- [x] Manual Kubernetes Tests -- just replacing the image to the upstream one
- [x] Do you need to update [`UPGRADE.md`](/UPGRADE.md)? -- just replacing the image to the upstream one
- [x] Does it need to be backported according to the [backporting policy](/CONTRIBUTING.md#backporting)? -- just replacing the image to the upstream one

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
