### PR TITLE
fix(cni): add empty registry to experimental cni

### DIFF
--- a/app/kumactl/cmd/install/context/install_control_plane_context.go
+++ b/app/kumactl/cmd/install/context/install_control_plane_context.go
@@ -41,6 +41,7 @@ type InstallControlPlaneArgs struct {
 	Cni_image_registry                           string            `helm:"cni.image.registry,omitempty"`
 	Cni_image_repository                         string            `helm:"cni.image.repository"`
 	Cni_image_tag                                string            `helm:"cni.image.tag"`
+	Cni_experimental_image_registry              string            `helm:"cni.experimental.image.registry"`
 	Cni_experimental_image_repository            string            `helm:"cni.experimental.image.repository"`
 	Cni_experimental_image_tag                   string            `helm:"cni.experimental.image.tag"`
 	Cni_nodeSelector                             map[string]string `helm:"cni.nodeSelector"`
@@ -106,6 +107,7 @@ func DefaultInstallCpContext() InstallCpContext {
 			Cni_image_registry:                      "",
 			Cni_image_repository:                    "install-cni",
 			Cni_image_tag:                           "0.0.10",
+			Cni_experimental_image_registry:         "",
 			Cni_experimental_image_repository:       "kuma-cni",
 			Cni_experimental_image_tag:              kuma_version.Build.Version,
 			ControlPlane_mode:                       core.Standalone,


### PR DESCRIPTION
Add empty registry so that it can be overwritten in depending projects

Signed-off-by: slonka <slonka@users.noreply.github.com>

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [X] Link to docs PR or issue -- issue in depending project
- [X] Link to UI issue or PR -- not a UI issue
- [X] Is the [issue worked on linked][1]? -- issue in depending project
- [X] The PR does not hardcode values that might break projects that depend on kuma (e.g. "kumahq" as a image registry) -- no
- [X] The PR will work for both Linux and Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS -- yes
- [X] Unit Tests -- no
- [X] E2E Tests -- no
- [X] Manual Universal Tests -- no
- [X] Manual Kubernetes Tests -- yes
- [X] Do you need to update [`UPGRADE.md`](/UPGRADE.md)? -- no
- [X] Does it need to be backported according to the [backporting policy](/CONTRIBUTING.md#backporting)? -- no

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword