### PR TITLE
refactor(cni): remove one requirement for ebpf

### DIFF
--- a/deployments/charts/kuma/templates/cni-configmap.yaml
+++ b/deployments/charts/kuma/templates/cni-configmap.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.cni.enabled (not (and .Values.experimental.cni .Values.experimental.ebpf.enabled)) }}
+{{- if and .Values.cni.enabled (not .Values.experimental.ebpf.enabled) }}
 kind: ConfigMap
 apiVersion: v1
 metadata:

--- a/deployments/charts/kuma/templates/cni-daemonset.yaml
+++ b/deployments/charts/kuma/templates/cni-daemonset.yaml
@@ -51,7 +51,17 @@ spec:
       containers:
         - name: install-cni
           {{- if .Values.experimental.cni }}
-          {{- if .Values.experimental.ebpf.enabled }}
+          image: {{ include "kuma.formatImage" (dict "image" .Values.cni.experimental.image "root" $) | quote }}
+          imagePullPolicy: {{ .Values.cni.image.imagePullPolicy }}
+          readinessProbe:
+            initialDelaySeconds: {{ .Values.cni.delayStartupSeconds }}
+            exec:
+              command:
+                - cat
+                - /tmp/ready
+          command: [ "/bin/sh", "-c", "--" ]
+          args: [ "sleep {{.Values.cni.delayStartupSeconds}} && exec /install-cni" ]
+          {{- else if .Values.experimental.ebpf.enabled }}
           {{- with .Values.cni.experimental.imageEbpf }}
           image: {{ printf "%s/%s:%s" .registry .repository .tag | quote }}
           {{- end }}
@@ -72,24 +82,12 @@ spec:
                 - --keep-going
                 - clean
           {{- else }}
-          image: {{ include "kuma.formatImage" (dict "image" .Values.cni.experimental.image "root" $) | quote }}
-          imagePullPolicy: {{ .Values.cni.image.imagePullPolicy }}
-          readinessProbe:
-            initialDelaySeconds: {{ .Values.cni.delayStartupSeconds }}
-            exec:
-              command:
-                - cat
-                - /tmp/ready
-          command: [ "/bin/sh", "-c", "--" ]
-          args: [ "sleep {{.Values.cni.delayStartupSeconds}} && exec /install-cni" ]
-          {{- end }}
-          {{- else }}
           image: {{ include "kuma.formatImage" (dict "image" .Values.cni.image "root" $) | quote }}
           imagePullPolicy: {{ .Values.cni.image.imagePullPolicy }}
           command: [ "/bin/sh", "-c", "--" ]
           args: [ "sleep {{.Values.cni.delayStartupSeconds}} && exec /install-cni.sh" ]
           {{- end }}
-          {{- if and .Values.experimental.cni .Values.experimental.ebpf.enabled }}
+          {{- if .Values.experimental.ebpf.enabled }}
           securityContext:
             privileged: true
           {{- else }}
@@ -120,7 +118,7 @@ spec:
               name: cni-bin-dir
             - mountPath: /host/etc/cni/net.d
               name: cni-net-dir
-            {{- if and .Values.experimental.cni .Values.experimental.ebpf.enabled }}
+            {{- if .Values.experimental.ebpf.enabled }}
             - mountPath: /sys/fs/cgroup
               name: sys-fs-cgroup
             - mountPath: /host/proc
@@ -137,7 +135,7 @@ spec:
         - name: cni-net-dir
           hostPath:
             path: {{ .Values.cni.netDir }}
-        {{- if and .Values.experimental.cni .Values.experimental.ebpf.enabled }}
+        {{- if .Values.experimental.ebpf.enabled }}
         - hostPath:
             path: /var/run
           name: host-var-run


### PR DESCRIPTION
After the discussion during the testing before the release there was
a suggestion to remove requirement of `experimental.cni=true` to enable
`ebpf` version of `cni`. So to run cni plubin with ebpf (merbridge)
instead of:

```sh
[...]
--set "cni.enabled=true" \
--set "experimental.cni=true" \
--set "experimental.ebpf.enabled=true"
```

you would have to do:

```sh
[...]
--set "cni.enabled=true" \
--set "experimental.ebpf.enabled=true"
```

so as a result:
To install default/old CNI plugin:

```sh
[...]
--set "cni.enabled=true"
```

To install new/experimental CNI:

```sh
[...]
--set "cni.enabled=true" \
--set "experimental.cni=true"
```

To install merbridge CNI with eBPF

```sh
[...]
--set "cni.enabled=true" \
--set "experimental.ebpf.enabled=true"
```

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] Link to docs PR or issue -- https://github.com/kumahq/kuma-website/pull/958
- [x] Link to UI issue or PR -- n/a
- [x] Is the [issue worked on linked][1]? -- n/a
- [x] The PR does not hardcode values that might break projects that depend on kuma (e.g. "kumahq" as a image registry) --
- [x] The PR will work for both Linux and Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS -- n/a
- [x] Unit Tests -- n/a
- [x] E2E Tests -- will followup in the next PR
- [x] Manual Universal Tests -- n/a
- [x] Manual Kubernetes Tests --
- [x] Do you need to update [`UPGRADE.md`](/UPGRADE.md)? -- no
- [x] Does it need to be backported according to the [backporting policy](/CONTRIBUTING.md#backporting)? --

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
