### PR TITLE
feat(kuma-cp): add flag to disable taint controller

### DIFF
--- a/pkg/config/app/kuma-cp/kuma-cp.defaults.yaml
+++ b/pkg/config/app/kuma-cp/kuma-cp.defaults.yaml
@@ -166,6 +166,8 @@ runtime:
     controlPlaneServiceName: kuma-control-plane # ENV: KUMA_RUNTIME_KUBERNETES_CONTROL_PLANE_SERVICE_NAME
     # Name of Service Account that is used to run the Control Plane
     serviceAccountName: "system:serviceaccount:kuma-system:kuma-control-plane" # ENV: KUMA_RUNTIME_KUBERNETES_SERVICE_ACCOUNT_NAME
+    # Enables taint controller that prevents applications from scheduling until experimental CNI is ready.
+    nodeTaintControllerEnabled: true
     # Admission WebHook Server configuration
     admissionServer:
       # Address the Admission WebHook Server should be listening on

--- a/pkg/config/loader_test.go
+++ b/pkg/config/loader_test.go
@@ -141,6 +141,7 @@ var _ = Describe("Config loader", func() {
 
 			Expect(cfg.Runtime.Kubernetes.ControlPlaneServiceName).To(Equal("custom-control-plane"))
 			Expect(cfg.Runtime.Kubernetes.ServiceAccountName).To(Equal("custom-sa"))
+			Expect(cfg.Runtime.Kubernetes.NodeTaintControllerEnabled).To(BeFalse())
 
 			Expect(cfg.Runtime.Kubernetes.AdmissionServer.Address).To(Equal("127.0.0.2"))
 			Expect(cfg.Runtime.Kubernetes.AdmissionServer.Port).To(Equal(uint32(9443)))
@@ -337,6 +338,7 @@ runtime:
   kubernetes:
     serviceAccountName: custom-sa
     controlPlaneServiceName: custom-control-plane
+    nodeTaintControllerEnabled: false
     admissionServer:
       address: 127.0.0.2
       port: 9443
@@ -546,6 +548,7 @@ proxy:
 				"KUMA_REPORTS_ENABLED":                                                                     "false",
 				"KUMA_RUNTIME_KUBERNETES_CONTROL_PLANE_SERVICE_NAME":                                       "custom-control-plane",
 				"KUMA_RUNTIME_KUBERNETES_SERVICE_ACCOUNT_NAME":                                             "custom-sa",
+				"KUMA_RUNTIME_KUBERNETES_NODE_TAINT_CONTROLLER_ENABLED":                                    "false",
 				"KUMA_RUNTIME_KUBERNETES_ADMISSION_SERVER_ADDRESS":                                         "127.0.0.2",
 				"KUMA_RUNTIME_KUBERNETES_ADMISSION_SERVER_PORT":                                            "9443",
 				"KUMA_RUNTIME_KUBERNETES_ADMISSION_SERVER_CERT_DIR":                                        "/var/run/secrets/kuma.io/kuma-admission-server/tls-cert",

--- a/pkg/config/plugins/runtime/k8s/config.go
+++ b/pkg/config/plugins/runtime/k8s/config.go
@@ -15,8 +15,9 @@ func DefaultKubernetesRuntimeConfig() *KubernetesRuntimeConfig {
 		AdmissionServer: AdmissionServerConfig{
 			Port: 5443,
 		},
-		ControlPlaneServiceName: "kuma-control-plane",
-		ServiceAccountName:      "system:serviceaccount:kuma-system:kuma-control-plane",
+		ControlPlaneServiceName:    "kuma-control-plane",
+		NodeTaintControllerEnabled: true,
+		ServiceAccountName:         "system:serviceaccount:kuma-system:kuma-control-plane",
 		Injector: Injector{
 			CNIEnabled:           false,
 			VirtualProbesEnabled: true,
@@ -95,6 +96,8 @@ type KubernetesRuntimeConfig struct {
 	ServiceAccountName string `yaml:"serviceAccountName,omitempty" envconfig:"kuma_runtime_kubernetes_service_account_name"`
 	// ControlPlaneServiceName defines service name of the Kuma control plane. It is used to point Kuma DP to proper URL.
 	ControlPlaneServiceName string `yaml:"controlPlaneServiceName,omitempty" envconfig:"kuma_runtime_kubernetes_control_plane_service_name"`
+	// NodeTaintControllerEnabled enables taint controller that prevents applications from scheduling until experimental CNI is ready.
+	NodeTaintControllerEnabled bool `yaml:"nodeTaintControllerEnabled" envconfig:"kuma_runtime_kubernetes_node_taint_controller_enabled"`
 }
 
 // Configuration of the Admission WebHook Server implemented by the Control Plane.

--- a/pkg/config/plugins/runtime/k8s/testdata/default-config.golden.yaml
+++ b/pkg/config/plugins/runtime/k8s/testdata/default-config.golden.yaml
@@ -50,3 +50,4 @@ injector:
 marshalingCacheExpirationTime: 5m0s
 serviceAccountName: system:serviceaccount:kuma-system:kuma-control-plane
 controlPlaneServiceName: kuma-control-plane
+nodeTaintControllerEnabled: true

--- a/pkg/plugins/runtime/k8s/plugin.go
+++ b/pkg/plugins/runtime/k8s/plugin.go
@@ -91,7 +91,7 @@ func addControllers(mgr kube_ctrl.Manager, rt core_runtime.Runtime, converter k8
 		return err
 	}
 
-	if rt.Config().Experimental.Cni {
+	if rt.Config().Experimental.Cni && rt.Config().Runtime.Kubernetes.NodeTaintControllerEnabled {
 		if err := addCniNodeTaintReconciler(mgr, rt.Config().Experimental.CniApp); err != nil {
 			return err
 		}


### PR DESCRIPTION
Fix #4843

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [X] Link to docs PR or issue --
- [X] Link to UI issue or PR --
- [X] Is the [issue worked on linked][1]? -- https://github.com/kumahq/kuma/issues/4843
- [X] The PR does not hardcode values that might break projects that depend on kuma (e.g. "kumahq" as a image registry) --
- [X] The PR will work for both Linux and Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [X] Unit Tests --
- [X] E2E Tests --
- [X] Manual Universal Tests --
- [X] Manual Kubernetes Tests --
- [X] Do you need to update [`UPGRADE.md`](/UPGRADE.md)? --
- [X] Does it need to be backported according to the [backporting policy](/CONTRIBUTING.md#backporting)? --

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
