### PR TITLE
fix: wrong version being pulled in tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -391,6 +391,11 @@ jobs:
         - artifacts-linux-<<parameters.arch>>
 
   release:
+    parameters:
+      build_context:
+        description: Context of the build script to determinate version
+        type: string
+        default: "branch"
     executor: vm-amd64
     steps:
     - install_build_tools
@@ -406,23 +411,23 @@ jobs:
     - run:
         name: Build Packages
         command: |
-          ./tools/releases/distros.sh --package
+          ./tools/releases/distros.sh --package --context <<parameters.build_context>>
     - run:
         name: Push Packages
         command: |
-          ./tools/releases/distros.sh --release
+          ./tools/releases/distros.sh --release --context <<parameters.build_context>>
     - run:
         name: Build Docker
         command: |
-          ./tools/releases/docker.sh --build
+          ./tools/releases/docker.sh --build --context <<parameters.build_context>>
     - run:
         name: Push Docker
         command: |
-          ./tools/releases/docker.sh --push
+          ./tools/releases/docker.sh --push --context <<parameters.build_context>>
     - run:
         name: Create and Push multiarch manifest for Docker images
         command: |
-          ./tools/releases/docker.sh --manifest
+          ./tools/releases/docker.sh --manifest --context <<parameters.build_context>>
 
 workflows:
   version: 2
@@ -513,4 +518,3 @@ workflows:
               ignore: /.*/
             tags:
               only: /.*/
-          requires: [ dev, test, test/e2e, test/e2e-legacy ]

--- a/mk/build.mk
+++ b/mk/build.mk
@@ -1,7 +1,8 @@
+BUILD_INFO_CONTEXT ?= "branch"
 BUILD_INFO_GIT_TAG ?= $(shell git describe --tags 2>/dev/null || echo unknown)
 BUILD_INFO_GIT_COMMIT ?= $(shell git rev-parse HEAD 2>/dev/null || echo unknown)
 BUILD_INFO_BUILD_DATE ?= $(shell date -u +"%Y-%m-%dT%H:%M:%SZ" || echo unknown)
-BUILD_INFO_VERSION ?= $(shell $(TOOLS_DIR)/releases/version.sh)
+BUILD_INFO_VERSION ?= $(shell $(TOOLS_DIR)/releases/version.sh $(BUILD_INFO_CONTEXT))
 BUILD_INFO_ENVOY_VERSION ?= $(ENVOY_VERSION)
 
 build_info_fields := \

--- a/tools/releases/distros.sh
+++ b/tools/releases/distros.sh
@@ -188,13 +188,15 @@ function usage() {
 }
 
 function main() {
-  KUMA_VERSION=$("${SCRIPT_DIR}/version.sh")
-
   while [[ $# -gt 0 ]]; do
     flag=$1
     case $flag in
     --help)
       usage
+      ;;
+    --context)
+      context="$2"
+      shift
       ;;
     --package)
       op="package"
@@ -210,6 +212,7 @@ function main() {
     shift
   done
 
+  KUMA_VERSION=$("${SCRIPT_DIR}/version.sh" "$context")
   case $op in
   package)
     package

--- a/tools/releases/docker.sh
+++ b/tools/releases/docker.sh
@@ -80,13 +80,16 @@ function usage() {
 }
 
 function main() {
-  KUMA_VERSION=$("${SCRIPT_DIR}/version.sh")
 
   while [[ $# -gt 0 ]]; do
     flag=$1
     case $flag in
     --help)
       usage
+      ;;
+    --context)
+      context="$2"
+      shift
       ;;
     --build)
       op="build"
@@ -105,6 +108,7 @@ function main() {
     shift
   done
 
+  KUMA_VERSION=$("${SCRIPT_DIR}/version.sh" "$context")
   [ -z "$DOCKER_USERNAME" ] && msg_err "\$DOCKER_USERNAME required"
   [ -z "$DOCKER_API_KEY" ] && msg_err "\$DOCKER_API_KEY required"
 

--- a/tools/releases/version.sh
+++ b/tools/releases/version.sh
@@ -1,30 +1,39 @@
 #!/usr/bin/env bash
 
-# Kuma version is built as follows:
-# 1) If a git tag is present on the current commit, then the version is a git tag (without a starting v)
-# 2) If the branch is "release-X.Y" look at the existing tags and use either X.Y.0-<shortHash> if there's none or
-#     the latest tag with a patch version increased by one (.e.g if latest tag is X.Y.1 the version will be `X.Y.2-<shortHash>`)
-# 3) In non release branch use `0.0.0-$shortHash`
+function get_version() {
+  local context; context=$1
 
-# Note: this format must be changed carefully, other scripts depend on it
-exactTag=$(git describe --exact-match --tags 2> /dev/null)
-# We only support tags of the format: "v?X.Y.Z(-<alphaNumericName>)?" all other tags will just be ignored and use the regular versioning scheme
-if [[ ${exactTag} =~ ^v?[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9]+)?$ ]]; then
-  echo "${exactTag/^v//}"
-  exit 0
-fi
+  # Kuma version is built as follows:
+  # 1) If a git tag is present on the current commit, then the version is a git tag (without a starting v)
+  # 2) If the branch is "release-X.Y" look at the existing tags and use either X.Y.0-<shortHash> if there's none or
+  #     the latest tag with a patch version increased by one (.e.g if latest tag is X.Y.1 the version will be `X.Y.2-<shortHash>`)
+  # 3) In non release branch use `0.0.0-$shortHash`
 
-shortHash=$(git rev-parse --short HEAD 2> /dev/null)
-currentBranch=$(git rev-parse --abbrev-ref HEAD 2> /dev/null)
-if [[ ${currentBranch} == release-* ]]; then
-    releasePrefix=${currentBranch//release-/}
-    lastGitTag=$(git tag -l | grep -E "^v?${releasePrefix}\.[0-9]+$" | sed 's/^v//'| sort -V | tail -1)
-    if [[ ${lastGitTag} ]]; then
-      IFS=. read -r major minor patch <<< "${lastGitTag}"
-      echo "${major}.${minor}.$((++patch))-preview.${shortHash}"
-    else
-      echo "${releasePrefix}.0-preview.${shortHash}"
+  # Note: this format must be changed carefully, other scripts depend on it
+  if [[ ${context} == "tag" ]]; then
+    exactTag=$(git describe --exact-match --tags 2> /dev/null)
+    # We only support tags of the format: "v?X.Y.Z(-<alphaNumericName>)?" all other tags will just be ignored and use the regular versioning scheme
+    if [[ ${exactTag} =~ ^v?[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9]+)?$ ]]; then
+      echo "${exactTag/^v//}"
+      exit 0
     fi
-else
-  echo "0.0.0-preview.${shortHash}"
-fi
+  fi
+
+  shortHash=$(git rev-parse --short HEAD 2> /dev/null)
+  currentBranch=$(git rev-parse --abbrev-ref HEAD 2> /dev/null)
+  if [[ ${currentBranch} == release-* ]]; then
+      releasePrefix=${currentBranch//release-/}
+      lastGitTag=$(git tag -l | grep -E "^v?${releasePrefix}\.[0-9]+$" | sed 's/^v//'| sort -V | tail -1)
+      if [[ ${lastGitTag} ]]; then
+        IFS=. read -r major minor patch <<< "${lastGitTag}"
+        echo "${major}.${minor}.$((++patch))-preview.${shortHash}"
+      else
+        echo "${releasePrefix}.0-preview.${shortHash}"
+      fi
+  else
+    echo "0.0.0-preview.${shortHash}"
+  fi
+}
+
+get_version "$1"
+


### PR DESCRIPTION
Signed-off-by: slonka <slonka@users.noreply.github.com>

[Tests are failing](https://app.circleci.com/pipelines/github/kumahq/kuma/16065/workflows/d2ca1a53-3ca5-49e4-b769-507da6ade7f5/jobs/210442?invite=true#step-110-261) because of `version.sh` using wrong version of Kuma in tests. This PR adds context to the version.sh script and removes dependency on other jobs (as discussed on slack) since some of them are not run even though they are defined in `requires` section:

![image](https://user-images.githubusercontent.com/2753650/186137062-8ef91675-a042-4a63-b394-1e62faff26e8.png)
 

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [X] Link to docs PR or issue -- CI change
- [X] Link to UI issue or PR -- CI change
- [X] Is the [issue worked on linked][1]? -- not reported
- [X] The PR does not hardcode values that might break projects that depend on kuma (e.g. "kumahq" as a image registry) -- no 
- [X] The PR will work for both Linux and Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS -- yes
- [X] Unit Tests -- manually tested invoking the edited bash scripts
- [X] E2E Tests --
- [X] Manual Universal Tests --
- [X] Manual Kubernetes Tests --
- [X] Do you need to update [`UPGRADE.md`](/UPGRADE.md)? -- no
- [X] Does it need to be backported according to the [backporting policy](/CONTRIBUTING.md#backporting)? -- no

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
