### PR TITLE
test(e2e): skip KIC tests on arm

### DIFF
--- a/test/e2e_env/kubernetes/kubernetes_suite_test.go
+++ b/test/e2e_env/kubernetes/kubernetes_suite_test.go
@@ -101,4 +101,4 @@ var _ = Describe("Reachable Services", reachableservices.ReachableServices, Orde
 var _ = Describe("Defaults", defaults.Defaults, Ordered)
 var _ = Describe("External Services", externalservices.ExternalServices, Ordered)
 var _ = Describe("Virtual Outbound", virtualoutbound.VirtualOutbound, Ordered)
-var _ = Describe("Kong Ingress Controller", kic.KICKubernetes, Ordered)
+var _ = Describe("Kong Ingress Controller", Label("arm-not-supported"), kic.KICKubernetes, Ordered)


### PR DESCRIPTION
KIC does not work on arm.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [ ] Link to docs PR or issue --
- [ ] Link to UI issue or PR --
- [ ] Is the [issue worked on linked][1]? --
- [ ] The PR does not hardcode values that might break projects that depend on kuma (e.g. "kumahq" as a image registry) --
- [ ] The PR will work for both Linux and Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [ ] Unit Tests --
- [ ] E2E Tests --
- [ ] Manual Universal Tests --
- [ ] Manual Kubernetes Tests --
- [ ] Do you need to update [`UPGRADE.md`](/UPGRADE.md)? --
- [ ] Does it need to be backported according to the [backporting policy](/CONTRIBUTING.md#backporting)? --

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
