### PR TITLE
ci(docs): add more info about `> Changelog:` marker

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -17,5 +17,6 @@ If something doesn't apply please check the box and add a justification after th
 - [ ] Manual Kubernetes Tests --
 - [ ] Do you need to update [`UPGRADE.md`](/UPGRADE.md)? --
 - [ ] Does it need to be backported according to the [backporting policy](/CONTRIBUTING.md#backporting)? --
+- [ ] Do you need to explicitly set a [`> Changelog:` entry here](/CONTRIBUTING.md#submitting-a-patch)?
 
 [1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -105,7 +105,7 @@ to verify a few things:
 - Do not update CHANGELOG.md yourself. Your change will be included there when we release, no worries!
   You can however help us maintain a good changelog and release notes by following this process:
     - By default, the changelog generation will use the PR title. If you want to specify something different as a Changelog entry add a line that starts with `> Changelog:` in the PR description e.g.:`> Changelog: feat: my new feature`. Reusing the same content across multiple PRs will rollup all the PRs in a single changelog entry (this is useful for features that span multiple PRs).
-    - By default, all commit messages that start with build, ci, test, refactor will be excluded from the Changelog. If you want still want a change to be included add a `> Changelog:` entry in the PR description.
+    - By default, all commit messages that start with build, ci, test, refactor will be excluded from the Changelog. If you still want a change to be included add a `> Changelog:` entry in the PR description.
     - If you want a change to not be included in the changelog you can add `> Changelog: skip` to explicitly ignore it.
   This is in the PR description because it enables you to add/modify it even after merging a PR. curious about the automation? You can find it in: [`tools/releases/changelog`](tools/releases/changelog).
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -102,8 +102,12 @@ to verify a few things:
   consider creating PR with a label `ci/run-full-matrix` that will trigger the full test matrix
 - If you are introducing a change which requires specific attention when
   upgrading update UPGRADE.md
-- Do not update CHANGELOG.md yourself. Your change will be included there in
-  due time if it is accepted, no worries!
+- Do not update CHANGELOG.md yourself. Your change will be included there when we release, no worries!
+  You can however help us maintain a good changelog and release notes by following this process:
+    - By default, the changelog generation will use the PR title. If you want to specify something different as a Changelog entry add a line that starts with `> Changelog:` in the PR description e.g.:`> Changelog: feat: my new feature`. Reusing the same content across multiple PRs will rollup all the PRs in a single changelog entry (this is useful for features that span multiple PRs).
+    - By default, all commit messages that start with build, ci, test, refactor will be excluded from the Changelog. If you want still want a change to be included add a `> Changelog:` entry in the PR description.
+    - If you want a change to not be included in the changelog you can add `> Changelog: skip` to explicitly ignore it.
+  This is in the PR description because it enables you to add/modify it even after merging a PR. curious about the automation? You can find it in: [`tools/releases/changelog`](tools/releases/changelog).
 
 If the above guidelines are respected, your Pull Request will be reviewed by
 a maintainer.

--- a/tools/releases/changelog/root.go
+++ b/tools/releases/changelog/root.go
@@ -201,16 +201,17 @@ func NewCommitInfo(commit GQLCommit) *CommitInfo {
 			changelog = strings.TrimSpace(strings.TrimPrefix(l, "> Changelog: "))
 		}
 	}
-	if changelog == "skip" {
+	switch changelog {
+	case "skip":
 		return nil
-	}
-	for _, v := range []string{"build:", "ci:", "ci(", "test(", "refactor(", "chore(ci)", "fix(ci)", "fix(test)", "tests(", "build(", "docs(madr)"} {
-		if strings.HasPrefix(commit.Message, v) {
-			return nil
+	case "":
+		// Ignore prs with usually ignored prefix
+		for _, v := range []string{"build:", "ci:", "ci(", "test(", "refactor(", "chore(ci)", "fix(ci)", "fix(test)", "tests(", "build(", "docs(madr)"} {
+			if strings.HasPrefix(commit.Message, v) {
+				return nil
+			}
 		}
-	}
-	// We do this after so that if we set `> Changelog:` with one of the ignored prefix we still can have this
-	if changelog == "" {
+		// Use the pr.Title as a changelog entry
 		changelog = pr.Title
 	}
 	return &CommitInfo{


### PR DESCRIPTION
This was not well explained and therefore not followed.
This change adds:

- An entry in the PR template to remind people and reviewer to maybe add this
- An explanation of how it works in the CONTRIBUTING.md docs
- Change the tool to still add to changelog if there's a `> Changelog:` marker on a by default ignored PR.

Signed-off-by: Charly Molter <charly.molter@konghq.com>

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] Link to docs PR or issue --
- [x] Link to UI issue or PR --
- [x] Is the [issue worked on linked][1]? --
- [x] The PR does not hardcode values that might break projects that depend on kuma (e.g. "kumahq" as a image registry) --
- [x] The PR will work for both Linux and Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Unit Tests --
- [x] E2E Tests --
- [x] Manual Universal Tests --
- [x] Manual Kubernetes Tests --
- [x] Do you need to update [`UPGRADE.md`](/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](/CONTRIBUTING.md#backporting)? --

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword

> Changelog: skip