### PR TITLE
feat(policy): add interfaces for policy plugins

### DIFF
--- a/pkg/core/plugins/interfaces.go
+++ b/pkg/core/plugins/interfaces.go
@@ -5,10 +5,13 @@ import (
 
 	"github.com/kumahq/kuma/pkg/api-server/authn"
 	core_ca "github.com/kumahq/kuma/pkg/core/ca"
+	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	core_store "github.com/kumahq/kuma/pkg/core/resources/store"
 	core_runtime "github.com/kumahq/kuma/pkg/core/runtime"
 	secret_store "github.com/kumahq/kuma/pkg/core/secrets/store"
+	core_xds "github.com/kumahq/kuma/pkg/core/xds"
 	"github.com/kumahq/kuma/pkg/events"
+	xds_context "github.com/kumahq/kuma/pkg/xds/context"
 )
 
 type Plugin interface{}
@@ -79,4 +82,14 @@ type CaPlugin interface {
 type AuthnAPIServerPlugin interface {
 	Plugin
 	NewAuthenticator(PluginContext) (authn.Authenticator, error)
+}
+
+// PolicyPlugin a plugin to add a Policy to Kuma
+type PolicyPlugin interface {
+	Plugin
+	// MatchedPolicies return all the policies of the plugins' type matching this dataplane. This is used in the inspect api and accessible in Apply through `proxy.Policies.Dynamic`
+	MatchedPolicies(dataplane *core_mesh.DataplaneResource, resources xds_context.Resources) (core_xds.TypedMatchingPolicies, error)
+	// Apply to `rs` using the `ctx` and `proxy` the mutation for all policies of the type this plugin implements.
+	// You can access matching policies by using `proxy.Policies.Dynamic`.
+	Apply(rs *core_xds.ResourceSet, ctx xds_context.Context, proxy *core_xds.Proxy) error
 }

--- a/pkg/core/plugins/registry.go
+++ b/pkg/core/plugins/registry.go
@@ -16,6 +16,7 @@ const (
 	runtimePlugin       pluginType = "runtime"
 	caPlugin            pluginType = "ca"
 	authnAPIServer      pluginType = "authn-api-server"
+	policyPlugin        pluginType = "policy"
 )
 
 type PluginName string
@@ -39,6 +40,7 @@ type Registry interface {
 	RuntimePlugins() map[PluginName]RuntimePlugin
 	CaPlugins() map[PluginName]CaPlugin
 	AuthnAPIServer() map[PluginName]AuthnAPIServerPlugin
+	PolicyPlugins() map[PluginName]PolicyPlugin
 }
 
 type RegistryMutator interface {
@@ -59,6 +61,7 @@ func NewRegistry() MutableRegistry {
 		runtime:        make(map[PluginName]RuntimePlugin),
 		ca:             make(map[PluginName]CaPlugin),
 		authnAPIServer: make(map[PluginName]AuthnAPIServerPlugin),
+		policy:         make(map[PluginName]PolicyPlugin),
 	}
 }
 
@@ -72,6 +75,7 @@ type registry struct {
 	runtime        map[PluginName]RuntimePlugin
 	ca             map[PluginName]CaPlugin
 	authnAPIServer map[PluginName]AuthnAPIServerPlugin
+	policy         map[PluginName]PolicyPlugin
 }
 
 func (r *registry) ResourceStore(name PluginName) (ResourceStorePlugin, error) {
@@ -104,6 +108,10 @@ func (r *registry) CaPlugins() map[PluginName]CaPlugin {
 
 func (r *registry) RuntimePlugins() map[PluginName]RuntimePlugin {
 	return r.runtime
+}
+
+func (r *registry) PolicyPlugins() map[PluginName]PolicyPlugin {
+	return r.policy
 }
 
 func (r *registry) BootstrapPlugins() []BootstrapPlugin {
@@ -171,6 +179,12 @@ func (r *registry) Register(name PluginName, plugin Plugin) error {
 			return pluginAlreadyRegisteredError(authnAPIServer, name, old, authn)
 		}
 		r.authnAPIServer[name] = authn
+	}
+	if policy, ok := plugin.(PolicyPlugin); ok {
+		if old, exists := r.policy[name]; exists {
+			return pluginAlreadyRegisteredError(policyPlugin, name, old, policy)
+		}
+		r.policy[name] = policy
 	}
 	return nil
 }

--- a/pkg/xds/server/v3/reconcile.go
+++ b/pkg/xds/server/v3/reconcile.go
@@ -11,6 +11,7 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/kumahq/kuma/pkg/core"
+	"github.com/kumahq/kuma/pkg/core/plugins"
 	model "github.com/kumahq/kuma/pkg/core/xds"
 	util_xds "github.com/kumahq/kuma/pkg/util/xds"
 	xds_context "github.com/kumahq/kuma/pkg/xds/context"
@@ -171,6 +172,11 @@ func (s *templateSnapshotGenerator) GenerateSnapshot(ctx xds_context.Context, pr
 	if err != nil {
 		reconcileLog.Error(err, "failed to generate a snapshot", "proxy", proxy, "template", template)
 		return envoy_cache.Snapshot{}, err
+	}
+	for name, p := range plugins.Plugins().PolicyPlugins() {
+		if err := p.Apply(rs, ctx, proxy); err != nil {
+			return envoy_cache.Snapshot{}, errors.Wrapf(err, "could not apply policy plugin %s", name)
+		}
 	}
 	for _, hook := range s.ResourceSetHooks {
 		if err := hook.Modify(rs, ctx, proxy); err != nil {


### PR DESCRIPTION
Rework the way policy plugins work to be able to handle policy matching in the plugin

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [ ] Link to docs PR or issue --
- [ ] Link to UI issue or PR --
- [ ] Is the [issue worked on linked][1]? --
- [ ] The PR does not hardcode values that might break projects that depend on kuma (e.g. "kumahq" as a image registry) --
- [ ] The PR will work for both Linux and Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [ ] Unit Tests --
- [ ] E2E Tests --
- [ ] Manual Universal Tests --
- [ ] Manual Kubernetes Tests --
- [ ] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [ ] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [ ] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch)?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
