### PR TITLE
feat(gatewayapi): add `gateways.kuma.io/cross-mesh` annotation for GatewayAPI `Gateways`

### DIFF
--- a/pkg/plugins/runtime/k8s/controllers/gatewayapi/gateway_controller.go
+++ b/pkg/plugins/runtime/k8s/controllers/gatewayapi/gateway_controller.go
@@ -109,15 +109,24 @@ func (r *GatewayReconciler) createOrUpdateInstance(ctx context.Context, client k
 		},
 	}
 
-	tags := common.ServiceTagForGateway(kube_client.ObjectKeyFromObject(gateway))
+	serviceType := kube_core.ServiceTypeLoadBalancer
+
+	if crossMesh, _, err := metadata.Annotations(gateway.Annotations).GetEnabled(CrossMeshAnnotation); err != nil {
+		return nil, err
+	} else if crossMesh {
+		serviceType = kube_core.ServiceTypeClusterIP
+	}
+
 	commonConfig := mesh_k8s.MeshGatewayCommonConfig{
-		ServiceType: kube_core.ServiceTypeLoadBalancer,
+		ServiceType: serviceType,
 	}
 
 	ref, _, err := getParametersRef(ctx, client, class.Spec.ParametersRef)
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to fetch parameters for GatewayClass")
 	}
+
+	tags := common.ServiceTagForGateway(kube_client.ObjectKeyFromObject(gateway))
 
 	if ref != nil {
 		tags = mesh_proto.Merge(


### PR DESCRIPTION
This proposes using the `gateways.kuma.io/cross-mesh` annotation to set all listeners to be cross-mesh for Gateway API `Gateways`. This presumably covers most use cases. Users wanting to mix cross-mesh/non cross-mesh listeners can fall back on `MeshGateway`.

Closes https://github.com/kumahq/kuma/issues/4397

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [ ] Link to docs PR or issue --
- [x] Link to UI issue or PR --
- [x] Is the [issue worked on linked][1]? --
- [x] The PR does not hardcode values that might break projects that depend on kuma (e.g. "kumahq" as a image registry) --
- [x] The PR will work for both Linux and Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Unit Tests --
- [ ] E2E Tests --
- [x] Manual Universal Tests -- none
- [x] Manual Kubernetes Tests --
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [x] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch)?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
