### PR TITLE
build(generate): set OpenAPI .type property in policy schemas

### DIFF
--- a/pkg/plugins/policies/donothingpolicy/api/v1alpha1/schema.yaml
+++ b/pkg/plugins/policies/donothingpolicy/api/v1alpha1/schema.yaml
@@ -2,6 +2,8 @@ properties:
   type:
     description: ''
     type: string
+    enum:
+      - DoNothingPolicy
   mesh:
     description: 'Mesh is the name of the Kuma mesh this resource belongs to. It may be omitted for cluster-scoped resources.'
     type: string

--- a/tools/policy-gen/crd-extract-openapi.sh
+++ b/tools/policy-gen/crd-extract-openapi.sh
@@ -47,3 +47,5 @@ CRD_FILE=$(find "${POLICIES_CRD_DIR}" -type f)
 yq e '.spec.versions[] | select (.name == "'"${VERSION}"'") | .schema.openAPIV3Schema.properties.spec | del(.type) | del(.description)' \
 "${CRD_FILE}" | yq eval-all -i '. as $item ireduce ({}; . * $item )' \
 "${POLICIES_API_DIR}"/schema.yaml -
+
+yq e -i ".properties.type.enum = [load(\"${CRD_FILE}\") | .spec.names.kind]" "${POLICIES_API_DIR}"/schema.yaml


### PR DESCRIPTION
This is the best you can do to express a constant with OpenAPI apparently.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] Link to docs PR or issue --
- [x] Link to UI issue or PR --
- [x] Is the [issue worked on linked][1]? --
- [x] The PR does not hardcode values that might break projects that depend on kuma (e.g. "kumahq" as a image registry) --
- [x] The PR will work for both Linux and Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Unit Tests --
- [x] E2E Tests --
- [x] Manual Universal Tests --
- [x] Manual Kubernetes Tests --
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [x] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch)?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
