### PR TITLE
ci: make postgres container ID non-deterministic

### DIFF
--- a/pkg/test/store/postgres/test_container.go
+++ b/pkg/test/store/postgres/test_container.go
@@ -53,7 +53,7 @@ func (v *PostgresContainer) Start() error {
 	// Add a uniqueId to make each image different, this was causing flakiness as test-container
 	// deletes the image that it builds unconditionally during teardown and fails if the image doesn't exist.
 	// In the case of parallel tests it's possible that the same image was used in multiple tests and the second teardown would fail.
-	r := rand.New(rand.NewSource(GinkgoRandomSeed()))
+	r := rand.New(rand.NewSource(int64(GinkgoParallelProcess())))
 	uniqueId := strconv.Itoa(r.Int())
 	buildArgs["UNIQUEID"] = &uniqueId
 

--- a/pkg/test/store/postgres/test_container.go
+++ b/pkg/test/store/postgres/test_container.go
@@ -9,6 +9,7 @@ import (
 	"path"
 	"strconv"
 	"strings"
+	"time"
 
 	. "github.com/onsi/gomega"
 	"github.com/testcontainers/testcontainers-go"
@@ -40,17 +41,22 @@ func resourceDir() string {
 
 func (v *PostgresContainer) Start() error {
 	ctx := context.Background()
+
 	buildArgs := map[string]*string{}
+
 	mode := "standard"
 	if v.WithTLS {
 		mode = "tls"
 	}
-	uniqueId := strconv.Itoa(rand.Int())
 	buildArgs["MODE"] = &mode
+
 	// Add a uniqueId to make each image different, this was causing flakiness as test-container
 	// deletes the image that it builds unconditionally during teardown and fails if the image doesn't exist.
 	// In the case of parallel tests it's possible that the same image was used in multiple tests and the second teardown would fail.
+	r := rand.New(rand.NewSource(time.Now().UnixNano()))
+	uniqueId := strconv.Itoa(r.Int())
 	buildArgs["UNIQUEID"] = &uniqueId
+
 	req := testcontainers.ContainerRequest{
 		FromDockerfile: testcontainers.FromDockerfile{
 			Context:   resourceDir(),

--- a/pkg/test/store/postgres/test_container.go
+++ b/pkg/test/store/postgres/test_container.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
-	"math/rand"
 	"os"
 	"path"
 	"strconv"
@@ -53,8 +52,7 @@ func (v *PostgresContainer) Start() error {
 	// Add a uniqueId to make each image different, this was causing flakiness as test-container
 	// deletes the image that it builds unconditionally during teardown and fails if the image doesn't exist.
 	// In the case of parallel tests it's possible that the same image was used in multiple tests and the second teardown would fail.
-	r := rand.New(rand.NewSource(int64(GinkgoParallelProcess())))
-	uniqueId := strconv.Itoa(r.Int())
+	uniqueId := strconv.Itoa(GinkgoParallelProcess())
 	buildArgs["UNIQUEID"] = &uniqueId
 
 	req := testcontainers.ContainerRequest{

--- a/pkg/test/store/postgres/test_container.go
+++ b/pkg/test/store/postgres/test_container.go
@@ -9,8 +9,8 @@ import (
 	"path"
 	"strconv"
 	"strings"
-	"time"
 
+	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/wait"
@@ -53,7 +53,7 @@ func (v *PostgresContainer) Start() error {
 	// Add a uniqueId to make each image different, this was causing flakiness as test-container
 	// deletes the image that it builds unconditionally during teardown and fails if the image doesn't exist.
 	// In the case of parallel tests it's possible that the same image was used in multiple tests and the second teardown would fail.
-	r := rand.New(rand.NewSource(time.Now().UnixNano()))
+	r := rand.New(rand.NewSource(GinkgoRandomSeed()))
 	uniqueId := strconv.Itoa(r.Int())
 	buildArgs["UNIQUEID"] = &uniqueId
 


### PR DESCRIPTION
Might [this be the reason](https://pkg.go.dev/math/rand#pkg-overview) we still see [flakiness in the postgres suite](https://app.circleci.com/pipelines/github/kumahq/kuma/16207/workflows/124126f7-9a65-4df6-8a49-f85b1ed7fdbc/jobs/215132/tests) after https://github.com/kumahq/kuma/pull/4668?

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] Link to docs PR or issue --
- [x] Link to UI issue or PR --
- [x] Is the [issue worked on linked][1]? --
- [x] The PR does not hardcode values that might break projects that depend on kuma (e.g. "kumahq" as a image registry) --
- [x] The PR will work for both Linux and Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Unit Tests --
- [x] E2E Tests --
- [x] Manual Universal Tests --
- [x] Manual Kubernetes Tests --
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [x] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch)?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
