### PR TITLE
refactor(gatewayapi): don't use GenerateName for generated Kuma resources

### DIFF
--- a/pkg/plugins/runtime/k8s/controllers/gatewayapi/common/reconcile.go
+++ b/pkg/plugins/runtime/k8s/controllers/gatewayapi/common/reconcile.go
@@ -98,7 +98,7 @@ func ReconcileLabelledObject(
 
 	owned.SetObjectMeta(
 		&kube_meta.ObjectMeta{
-			GenerateName: fmt.Sprintf("%s-%s-", owner.Namespace, owner.Name),
+			Name: fmt.Sprintf("%s.%s", owner.Name, owner.Namespace),
 			Labels: map[string]string{
 				ownerLabel: ownerLabelValue,
 			},


### PR DESCRIPTION
There's no reason these shouldn't be deterministic and predictable.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] Link to docs PR or issue --
- [x] Link to UI issue or PR --
- [x] Is the [issue worked on linked][1]? --
- [x] The PR does not hardcode values that might break projects that depend on kuma (e.g. "kumahq" as a image registry) --
- [x] The PR will work for both Linux and Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Unit Tests --
- [x] E2E Tests --
- [x] Manual Universal Tests -- none
- [x] Manual Kubernetes Tests --
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? -- no
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [x] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch)?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
