### PR TITLE
chore(pkg/gc): don't rely on core.Now var for time

### DIFF
--- a/pkg/gc/components.go
+++ b/pkg/gc/components.go
@@ -29,7 +29,7 @@ func setupCollector(rt runtime.Runtime) error {
 		return nil
 	}
 	return rt.Add(
-		NewCollector(rt.ResourceManager(), 1*time.Minute, rt.Config().Runtime.Universal.DataplaneCleanupAge),
+		NewCollector(rt.ResourceManager(), func() *time.Ticker { return time.NewTicker(1 * time.Minute) }, rt.Config().Runtime.Universal.DataplaneCleanupAge),
 	)
 }
 

--- a/pkg/gc/finalizer.go
+++ b/pkg/gc/finalizer.go
@@ -72,9 +72,9 @@ func (f *subscriptionFinalizer) Start(stop <-chan struct{}) error {
 	finalizerLog.Info("started")
 	for {
 		select {
-		case <-ticker.C:
+		case now := <-ticker.C:
 			for _, typ := range f.types {
-				if err := f.checkGeneration(typ); err != nil {
+				if err := f.checkGeneration(typ, now); err != nil {
 					finalizerLog.Error(err, "unable to check subscription's generation", "type", typ)
 				}
 			}
@@ -85,7 +85,7 @@ func (f *subscriptionFinalizer) Start(stop <-chan struct{}) error {
 	}
 }
 
-func (f *subscriptionFinalizer) checkGeneration(typ core_model.ResourceType) error {
+func (f *subscriptionFinalizer) checkGeneration(typ core_model.ResourceType, now time.Time) error {
 	// get all the insights for provided type
 	insights, _ := registry.Global().NewList(typ)
 	if err := f.rm.List(context.Background(), insights); err != nil {
@@ -117,7 +117,7 @@ func (f *subscriptionFinalizer) checkGeneration(typ core_model.ResourceType) err
 		}
 
 		log.V(1).Info("mark subscription as disconnected")
-		insight.GetLastSubscription().SetDisconnectTime(core.Now())
+		insight.GetLastSubscription().SetDisconnectTime(now)
 
 		upsertInsight, _ := registry.Global().NewObject(typ)
 		err := manager.Upsert(f.rm, key, upsertInsight, func(r core_model.Resource) error {

--- a/pkg/gc/finalizer_test.go
+++ b/pkg/gc/finalizer_test.go
@@ -13,7 +13,6 @@ import (
 	core_manager "github.com/kumahq/kuma/pkg/core/resources/manager"
 	core_model "github.com/kumahq/kuma/pkg/core/resources/model"
 	"github.com/kumahq/kuma/pkg/core/resources/store"
-	"github.com/kumahq/kuma/pkg/core/runtime/component"
 	"github.com/kumahq/kuma/pkg/gc"
 	"github.com/kumahq/kuma/pkg/plugins/resources/memory"
 	"github.com/kumahq/kuma/pkg/util/proto"
@@ -23,22 +22,18 @@ var _ = Describe("Subscription Finalizer", func() {
 	sampleTime, _ := time.Parse(time.RFC3339, "2019-07-01T00:00:00+00:00")
 
 	var rm *countingManager
-	var finalizer component.Component
 
 	BeforeEach(func() {
 		rm = &countingManager{ResourceManager: core_manager.NewResourceManager(memory.NewStore())}
 	})
 
 	startSubscriptionFinalizer := func(ticks chan time.Time, stop chan struct{}) {
-		var err error
-		finalizer, err = gc.NewSubscriptionFinalizer(rm, func() *time.Ticker {
+		finalizer, err := gc.NewSubscriptionFinalizer(rm, func() *time.Ticker {
 			return &time.Ticker{C: ticks}
 		}, system.ZoneInsightType)
 		Expect(err).ToNot(HaveOccurred())
 		go func() {
-			mtxNow.RLock()
 			_ = finalizer.Start(stop)
-			mtxNow.RUnlock()
 		}()
 	}
 


### PR DESCRIPTION
- Always provide ticker as a parameter to both finalizer and gc
- Use the time of the ticker instead of `core.Now()`
- Rewrite tests to create synthetic ticks
- Improve logging

Motivation:

- Tests would have to rely mutexes and some would expose a race because
of the shared global variable. .e.g: https://app.circleci.com/pipelines/gh/kumahq/kuma/16160/workflows/e5332335-a44e-451f-8942-51a8909156bf/jobs/213638
- We can write very precise tests as we trigger the ticks ourselves
- Not relying on global vars is always an improvement

Signed-off-by: Charly Molter <charly.molter@konghq.com>

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] Link to docs PR or issue --
- [x] Link to UI issue or PR --
- [x] Is the [issue worked on linked][1]? --
- [x] The PR does not hardcode values that might break projects that depend on kuma (e.g. "kumahq" as a image registry) --
- [x] The PR will work for both Linux and Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Unit Tests --
- [x] E2E Tests --
- [x] Manual Universal Tests --
- [x] Manual Kubernetes Tests --
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [x] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch)?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
