### PR TITLE
feat(helm): fix pod annotation indentation

### DIFF
--- a/deployments/charts/kuma/templates/_helpers.tpl
+++ b/deployments/charts/kuma/templates/_helpers.tpl
@@ -115,9 +115,9 @@ app: {{ include "kuma.name" . }}-control-plane
 control plane pod annotations
 */}}
 {{- define "kuma.cpPodAnnotations" -}}
-{{ range $key, $value := $.Values.controlPlane.podAnnotations }}
-{{- $key }}: {{ $value -}}
-{{ end }}
+{{- range $key, $value := $.Values.controlPlane.podAnnotations }}
+{{ $key }}: {{ $value }}
+{{- end }}
 {{- end }}
 
 {{/*


### PR DESCRIPTION
Fixes https://github.com/kumahq/kuma/issues/4935

The new line character remover seems to be messing up when multiple annotations was specified and argo's helm template command was throwing `mapping values are not allowed in this context` error during templating. if its a single annotation it just works

Manually tested since we dont have tests for helm charts yet.

```
## before

1. with a single pod annotation
helm template . --name-template mesh-remote-cp-dev-us-east-2 --namespace kong-mesh-remote-cp --set controlPlane.podAnnotations.prometheus\\.datadoghq\\.com/scrape=true 

...
  template:
    metadata:
      annotations:
        checksum/config: c09e37c4eeff86c7fe596b7d1a9862e1961268499b57c0ffdba7efd4c7ceca78
        checksum/tls-secrets: f0dce1aa97db0a7b3474166d0e4ccc2487e0830c26209374b30bff678ccf4fe7
        prometheus.datadoghq.com/scrape: true
      labels:
        app: kuma-control-plane
        helm.sh/chart: kuma-1.8.0
...

2. with multiple annotations
helm template kuma/kuma --name-template mesh-remote-cp-dev-us-east-2 --namespace kong-mesh-remote-cp --set controlPlane.podAnnotations.prometheus\\.io/port=5680 --set controlPlane.podAnnotations.prometheus\\.datadoghq\\.com/scrape=true
Error: YAML parse error on kuma/templates/cp-deployment.yaml: error converting YAML to JSON: yaml: line 29: mapping values are not allowed in this context

## after

1. with a single pod annotation
helm template . --name-template mesh-remote-cp-dev-us-east-2 --namespace kong-mesh-remote-cp --set controlPlane.podAnnotations.prometheus\\.datadoghq\\.com/scrape=true 

...
  template:
    metadata:
      annotations:
        checksum/config: c09e37c4eeff86c7fe596b7d1a9862e1961268499b57c0ffdba7efd4c7ceca78
        checksum/tls-secrets: 02b27bd9cf0486e07d07d37b6c5b5dd77529e7c7e89e5ec645f0bdffd2ac0d95

        prometheus.datadoghq.com/scrape: true
      labels:
        app: kuma-control-plane
        helm.sh/chart: kuma-1.8.0
...

2. with multiple annotations
helm template . --name-template mesh-remote-cp-dev-us-east-2 --namespace kong-mesh-remote-cp --set controlPlane.podAnnotations.prometheus\\.io/port=5680 --set controlPlane.podAnnotations.prometheus\\.datadoghq\\.com/scrape=true

  template:
    metadata:
      annotations:
        checksum/config: c09e37c4eeff86c7fe596b7d1a9862e1961268499b57c0ffdba7efd4c7ceca78
        checksum/tls-secrets: fa6bc58a6b4a5cb7322b8707842b10c6d551a34118342bf2816845f784dceec7

        prometheus.datadoghq.com/scrape: true
        prometheus.io/port: 5680
      labels:
        app: kuma-control-plane
        helm.sh/chart: kuma-1.8.0

```