### PR TITLE
test(e2e): use ClusterIP instead of NodePort for KIC tests

### DIFF
--- a/test/e2e_env/kubernetes/kic/kong_ingress.go
+++ b/test/e2e_env/kubernetes/kic/kong_ingress.go
@@ -72,6 +72,7 @@ func KICKubernetes() {
 
 	E2EAfterAll(func() {
 		Expect(env.Cluster.TriggerDeleteNamespace(namespace)).To(Succeed())
+		Expect(env.Cluster.TriggerDeleteNamespace(namespaceOutsideMesh)).To(Succeed())
 		Expect(env.Cluster.DeleteMesh(mesh)).To(Succeed())
 	})
 

--- a/test/e2e_env/kubernetes/kic/kong_ingress.go
+++ b/test/e2e_env/kubernetes/kic/kong_ingress.go
@@ -3,6 +3,7 @@ package kic
 import (
 	"fmt"
 
+	"github.com/gruntwork-io/terratest/modules/k8s"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
@@ -29,22 +30,44 @@ func KICKubernetes() {
 
 	namespace := "kic"
 	mesh := "kic"
+	namespaceOutsideMesh := "kic-external"
+
+	getKICIP := func() string {
+		var ip string
+		Eventually(func(g Gomega) {
+			out, err := k8s.RunKubectlAndGetOutputE(
+				env.Cluster.GetTesting(),
+				env.Cluster.GetKubectlOptions(namespace),
+				"get", "service", "gateway", "-ojsonpath={.spec.clusterIP}",
+			)
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(out).ToNot(BeEmpty())
+			ip = out
+		}, "60s", "1s").Should(Succeed(), "could not get the clusterIP of the Service")
+		return ip
+	}
+
+	var kicIP string
 
 	BeforeAll(func() {
 		Expect(NewClusterSetup().
 			Install(MTLSMeshKubernetes(mesh)).
 			Install(NamespaceWithSidecarInjection(namespace)).
+			Install(Namespace(namespaceOutsideMesh)).
+			Install(DemoClientK8s(mesh, namespaceOutsideMesh)). // this will not be in the mesh
 			Install(kic.KongIngressController(
 				kic.WithNamespace(namespace),
 				kic.WithMesh(mesh),
 			)).
-			Install(kic.KongIngressNodePort(kic.WithNamespace(namespace))).
+			Install(kic.KongIngressService(kic.WithNamespace(namespace))).
 			Install(testserver.Install(
 				testserver.WithNamespace(namespace),
 				testserver.WithMesh(mesh),
 				testserver.WithName("test-server"),
 			)).
 			Setup(env.Cluster)).To(Succeed())
+
+		kicIP = getKICIP()
 	})
 
 	E2EAfterAll(func() {
@@ -73,7 +96,10 @@ spec:
 		Expect(env.Cluster.Install(YamlK8s(ingress))).To(Succeed())
 
 		Eventually(func(g Gomega) {
-			_, err := client.CollectResponseDirectly(fmt.Sprintf("http://localhost:%d/test-server", kic.NodePortHTTP()))
+			_, err := client.CollectResponse(
+				env.Cluster, "demo-client", fmt.Sprintf("http://%s/test-server", kicIP),
+				client.FromKubernetesPod(namespaceOutsideMesh, "demo-client"),
+			)
 			g.Expect(err).ToNot(HaveOccurred())
 		}, "30s", "1s").Should(Succeed())
 	})
@@ -110,7 +136,10 @@ spec:
 		Expect(env.Cluster.Install(YamlK8s(ingressMeshDNS))).To(Succeed())
 
 		Eventually(func(g Gomega) {
-			_, err := client.CollectResponseDirectly(fmt.Sprintf("http://localhost:%d/dot-mesh", kic.NodePortHTTP()))
+			_, err := client.CollectResponse(
+				env.Cluster, "demo-client", fmt.Sprintf("http://%s/dot-mesh", kicIP),
+				client.FromKubernetesPod(namespaceOutsideMesh, "demo-client"),
+			)
 			g.Expect(err).ToNot(HaveOccurred())
 		}, "30s", "1s").Should(Succeed())
 	})

--- a/test/framework/deployments/kic/deployment.go
+++ b/test/framework/deployments/kic/deployment.go
@@ -69,32 +69,28 @@ func KongIngressController(fs ...deployOptionsFunc) framework.InstallFunc {
 	return Install(fs...)
 }
 
-func KongIngressNodePort(fs ...deployOptionsFunc) framework.InstallFunc {
-	proxy_port := NodePortHTTP()
-	proxy_ssl_port := NodePortHTTPS()
+func KongIngressService(fs ...deployOptionsFunc) framework.InstallFunc {
 	opts := newDeployOpt(fs...)
 	if opts.namespace == "" {
 		opts.namespace = framework.Config.DefaultGatewayNamespace
 	}
-	nodeport := `
+	svc := `
 apiVersion: v1
 kind: Service
 metadata:
-  name: gateway-nodeport
+  name: gateway
   namespace: %s
 spec:
-  type: NodePort
+  type: ClusterIP
   selector:
     app: ingress-kong
   ports:
     - name: proxy
       targetPort: 8000
-      nodePort: %d
-      port: %d
+      port: 80
     - name: proxy-ssl
       targetPort: 8443
-      nodePort: %d
-      port: %d
+      port: 443
 `
-	return framework.YamlK8s(fmt.Sprintf(nodeport, opts.namespace, proxy_port, proxy_port, proxy_ssl_port, proxy_ssl_port))
+	return framework.YamlK8s(fmt.Sprintf(svc, opts.namespace))
 }

--- a/test/framework/deployments/kic/kubernetes.go
+++ b/test/framework/deployments/kic/kubernetes.go
@@ -2,8 +2,6 @@ package kic
 
 import (
 	"fmt"
-	"os"
-	"strconv"
 
 	"github.com/gruntwork-io/terratest/modules/k8s"
 	"github.com/pkg/errors"
@@ -17,42 +15,9 @@ type k8sDeployment struct {
 	mesh             string
 }
 
-var DefaultNodePortHTTP = 30080
-var DefaultNodePortHTTPS = 30443
-
 var _ Deployment = &k8sDeployment{}
 
 var ingressApp = "ingress-kong"
-
-func NodePortHTTP() int {
-	var port int
-	var err error
-	portStr := os.Getenv("E2E_KONG_INGRESS_HTTP_PORT")
-	if portStr == "" {
-		port = DefaultNodePortHTTP
-	} else {
-		port, err = strconv.Atoi(portStr)
-		if err != nil {
-			panic(fmt.Sprintf("Invalid E2E_KONG_INGRESS_HTTP_PORT: %s", portStr))
-		}
-	}
-	return port
-}
-
-func NodePortHTTPS() int {
-	var port int
-	var err error
-	portStr := os.Getenv("E2E_KONG_INGRESS_HTTPS_PORT")
-	if portStr == "" {
-		port = DefaultNodePortHTTPS
-	} else {
-		port, err = strconv.Atoi(portStr)
-		if err != nil {
-			panic(fmt.Sprintf("Invalid E2E_KONG_INGRESS_HTTPS_PORT: %s", portStr))
-		}
-	}
-	return port
-}
 
 func (t *k8sDeployment) Name() string {
 	return DeploymentName


### PR DESCRIPTION
There's no need to test from outside the cluster here, just outside the mesh. This should fix [some flakes](https://app.circleci.com/pipelines/github/kumahq/kuma/16284/workflows/c617e3a3-61fd-46c5-87a5-0018ae512a63/jobs/217809/steps).

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] Link to docs PR or issue --
- [x] Link to UI issue or PR --
- [x] Is the [issue worked on linked][1]? --
- [x] The PR does not hardcode values that might break projects that depend on kuma (e.g. "kumahq" as a image registry) --
- [x] The PR will work for both Linux and Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Unit Tests --
- [x] E2E Tests --
- [x] Manual Universal Tests --
- [x] Manual Kubernetes Tests --
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [x] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch)?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
