### PR TITLE
chore(helm): remove unused `critical-pod` annotation

### DIFF
--- a/app/kumactl/cmd/install/testdata/install-control-plane.cni-enabled.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.cni-enabled.golden.yaml
@@ -1953,13 +1953,13 @@ spec:
         app.kubernetes.io/name: kuma
         app.kubernetes.io/instance: kuma
       annotations:
-        # This, along with the CriticalAddonsOnly toleration below,
-        # marks the pod as a critical add-on, ensuring it gets
-        # priority scheduling and that its resources are reserved
-        # if it ever gets evicted.
-        scheduler.alpha.kubernetes.io/critical-pod: ''
         checksum/config: 850246b56a69bba30d67145d2efc88941f6c91badd116beca4123d75c70a39ec
     spec:
+      # This, along with the CriticalAddonsOnly toleration below,
+      # marks the pod as a critical add-on, ensuring it gets
+      # priority scheduling and that its resources are reserved
+      # if it ever gets evicted.
+      priorityClassName: system-cluster-critical
       nodeSelector:
       
         kubernetes.io/os: linux
@@ -1973,7 +1973,6 @@ spec:
           operator: Exists
         - effect: NoExecute
           operator: Exists
-      priorityClassName: system-cluster-critical
       serviceAccountName: kuma-cni
       # Minimize downtime during a rolling upgrade or deletion; tell Kubernetes to do a "force
       # deletion": https://kubernetes.io/docs/concepts/workloads/pods/pod/#termination-of-pods.

--- a/app/kumactl/cmd/install/testdata/install-control-plane.cni-experimental-enabled.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.cni-experimental-enabled.golden.yaml
@@ -1965,13 +1965,13 @@ spec:
         app.kubernetes.io/name: kuma
         app.kubernetes.io/instance: kuma
       annotations:
-        # This, along with the CriticalAddonsOnly toleration below,
-        # marks the pod as a critical add-on, ensuring it gets
-        # priority scheduling and that its resources are reserved
-        # if it ever gets evicted.
-        scheduler.alpha.kubernetes.io/critical-pod: ''
         checksum/config: 850246b56a69bba30d67145d2efc88941f6c91badd116beca4123d75c70a39ec
     spec:
+      # This, along with the CriticalAddonsOnly toleration below,
+      # marks the pod as a critical add-on, ensuring it gets
+      # priority scheduling and that its resources are reserved
+      # if it ever gets evicted.
+      priorityClassName: system-cluster-critical
       nodeSelector:
       
         kubernetes.io/os: linux
@@ -1985,7 +1985,6 @@ spec:
           operator: Exists
         - effect: NoExecute
           operator: Exists
-      priorityClassName: system-cluster-critical
       serviceAccountName: kuma-cni
       # Minimize downtime during a rolling upgrade or deletion; tell Kubernetes to do a "force
       # deletion": https://kubernetes.io/docs/concepts/workloads/pods/pod/#termination-of-pods.

--- a/deployments/charts/kuma/templates/cni-daemonset.yaml
+++ b/deployments/charts/kuma/templates/cni-daemonset.yaml
@@ -18,13 +18,13 @@ spec:
       labels:
       {{- include "kuma.cniSelectorLabels" . | nindent 8 }}
       annotations:
-        # This, along with the CriticalAddonsOnly toleration below,
-        # marks the pod as a critical add-on, ensuring it gets
-        # priority scheduling and that its resources are reserved
-        # if it ever gets evicted.
-        scheduler.alpha.kubernetes.io/critical-pod: ''
         checksum/config: {{ include (print $.Template.BasePath "/cni-configmap.yaml") . | sha256sum }}
     spec:
+      # This, along with the CriticalAddonsOnly toleration below,
+      # marks the pod as a critical add-on, ensuring it gets
+      # priority scheduling and that its resources are reserved
+      # if it ever gets evicted.
+      priorityClassName: system-cluster-critical
       {{- with .Values.cni.nodeSelector }}
       nodeSelector:
       {{ toYaml . | nindent 8 }}
@@ -39,7 +39,6 @@ spec:
           operator: Exists
         - effect: NoExecute
           operator: Exists
-      priorityClassName: system-cluster-critical
       serviceAccountName: {{ include "kuma.name" . }}-cni
       # Minimize downtime during a rolling upgrade or deletion; tell Kubernetes to do a "force
       # deletion": https://kubernetes.io/docs/concepts/workloads/pods/pod/#termination-of-pods.


### PR DESCRIPTION
kubectl warns on apply with:

```
Warning: spec.template.metadata.annotations[scheduler.alpha.kubernetes.io/critical-pod]: non-functional in v1.16+; use the "priorityClassName" field instead
```

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] Link to docs PR or issue --
- [x] Link to UI issue or PR --
- [x] Is the [issue worked on linked][1]? --
- [x] The PR does not hardcode values that might break projects that depend on kuma (e.g. "kumahq" as a image registry) --
- [x] The PR will work for both Linux and Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Unit Tests -- none
- [x] E2E Tests -- none
- [x] Manual Universal Tests -- none
- [x] Manual Kubernetes Tests --
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [x] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch)?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
