### PR TITLE
chore: removes update/gui command

### DIFF
--- a/mk/generate.mk
+++ b/mk/generate.mk
@@ -100,20 +100,6 @@ crd/controller-gen:
 	$(CONTROLLER_GEN) "crd:crdVersions=v1" paths=$(IN_CRD) output:crd:artifacts:config=$(OUT_CRD)
 	$(CONTROLLER_GEN) object:headerFile=./tools/policy-gen/boilerplate.go.txt,year=$$(date +%Y) paths=$(IN_CRD)
 
-
-KUMA_GUI_GIT_URL=https://github.com/kumahq/kuma-gui.git
-KUMA_GUI_VERSION=master
-KUMA_GUI_FOLDER=app/kuma-ui/pkg/resources/data
-KUMA_GUI_WORK_FOLDER=app/kuma-ui/data/work
-
-.PHONY: upgrade/gui
-upgrade/gui:
-	rm -rf $(KUMA_GUI_WORK_FOLDER)
-	git clone --depth 1 -b $(KUMA_GUI_VERSION) $(KUMA_GUI_GIT_URL) $(KUMA_GUI_WORK_FOLDER)
-	cd $(KUMA_GUI_WORK_FOLDER) && yarn install && yarn build
-	rm -rf $(KUMA_GUI_FOLDER) && mv $(KUMA_GUI_WORK_FOLDER)/dist/ $(KUMA_GUI_FOLDER)
-	rm -rf $(KUMA_GUI_WORK_FOLDER)
-
 .PHONY: generate/envoy-imports
 generate/envoy-imports:
 	echo 'package envoy\n' > ${ENVOY_IMPORTS}


### PR DESCRIPTION
Removes the upgrade/gui command because we now have a GitHub Actions workflow that automatically create update PRs.

See https://github.com/kumahq/kuma-gui/issues/367.

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [ ] Link to docs PR or issue -- 
- [x] Link to UI issue or PR -- https://github.com/kumahq/kuma-gui/issues/367
- [x] Is the [issue worked on linked][1]? -- Yes
- [ ] The PR does not hardcode values that might break projects that depend on kuma (e.g. "kumahq" as a image registry) --
- [ ] The PR will work for both Linux and Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [ ] Unit Tests --
- [ ] E2E Tests --
- [ ] Manual Universal Tests --
- [ ] Manual Kubernetes Tests --
- [ ] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [ ] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? -- No.
- [ ] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch)? No.

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
