### PR TITLE
perf(kuma-cp): avoid rebuilding endpoint map

### DIFF
--- a/pkg/core/xds/types.go
+++ b/pkg/core/xds/types.go
@@ -291,6 +291,10 @@ type VIPDomains struct {
 type Routing struct {
 	TrafficRoutes   RouteMap
 	OutboundTargets EndpointMap
+	// ExternalServiceOutboundTargets contains endpoint map for direct access of external services (without egress)
+	// Since we take into account TrafficPermission to exclude external services from the map,
+	// it is specific for each data plane proxy.
+	ExternalServiceOutboundTargets EndpointMap
 }
 
 type CaSecret struct {

--- a/pkg/plugins/runtime/gateway/generator.go
+++ b/pkg/plugins/runtime/gateway/generator.go
@@ -153,16 +153,21 @@ func GatewayListenerInfoFromProxy(
 		return nil, errors.Wrap(err, "unable to find external services matched by traffic permissions")
 	}
 
-	outboundEndpoints := xds_topology.BuildEndpointMap(
+	outboundEndpoints := core_xds.EndpointMap{}
+	for k, v := range meshCtx.EndpointMap {
+		outboundEndpoints[k] = v
+	}
+
+	esEndpoints := xds_topology.BuildExternalServicesEndpointMap(
 		ctx,
 		meshCtx.Resource,
-		zone,
-		meshCtx.Resources.Dataplanes().Items,
-		meshCtx.Resources.ZoneIngresses().Items,
-		meshCtx.Resources.ZoneEgresses().Items,
 		matchedExternalServices,
 		meshCtx.DataSourceLoader,
+		zone,
 	)
+	for k, v := range esEndpoints {
+		outboundEndpoints[k] = v
+	}
 
 	// We already validate that listeners are collapsible
 	for _, listeners := range collapsed {

--- a/pkg/xds/generator/outbound_proxy_generator.go
+++ b/pkg/xds/generator/outbound_proxy_generator.go
@@ -216,7 +216,7 @@ func (g OutboundProxyGenerator) generateCDS(ctx xds_context.Context, services en
 							clusterTags,
 						))
 				} else {
-					endpoints := proxy.Routing.OutboundTargets[serviceName]
+					endpoints := proxy.Routing.ExternalServiceOutboundTargets[serviceName]
 					isIPv6 := proxy.Dataplane.IsIPv6()
 
 					edsClusterBuilder.
@@ -315,6 +315,8 @@ func (OutboundProxyGenerator) inferProtocol(proxy *model.Proxy, clusters []envoy
 		serviceName := cluster.Tags()[mesh_proto.ServiceTag]
 		endpoints := model.EndpointList(proxy.Routing.OutboundTargets[serviceName])
 		allEndpoints = append(allEndpoints, endpoints...)
+		endpoints = proxy.Routing.ExternalServiceOutboundTargets[serviceName]
+		allEndpoints = append(allEndpoints, endpoints...)
 	}
 	return InferServiceProtocol(allEndpoints)
 }
@@ -367,6 +369,9 @@ func (OutboundProxyGenerator) determineRoutes(
 			var isExternalService bool
 			if endpoints := proxy.Routing.OutboundTargets[service]; len(endpoints) > 0 {
 				isExternalService = endpoints[0].IsExternalService()
+			}
+			if endpoints := proxy.Routing.ExternalServiceOutboundTargets[service]; len(endpoints) > 0 {
+				isExternalService = true
 			}
 
 			cluster := envoy_common.NewCluster(

--- a/pkg/xds/generator/outbound_proxy_generator_test.go
+++ b/pkg/xds/generator/outbound_proxy_generator_test.go
@@ -279,6 +279,9 @@ var _ = Describe("OutboundProxyGenerator", func() {
 						Weight: 1,
 					},
 				},
+			}
+
+			esOutboundTargets := model.EndpointMap{
 				"es": []model.Endpoint{
 					{
 						Target:          "10.0.0.1",
@@ -505,7 +508,8 @@ var _ = Describe("OutboundProxyGenerator", func() {
 							},
 						},
 					},
-					OutboundTargets: outboundTargets,
+					OutboundTargets:                outboundTargets,
+					ExternalServiceOutboundTargets: esOutboundTargets,
 				},
 				Policies: model.MatchedPolicies{
 					TrafficLogs: model.TrafficLogMap{

--- a/pkg/xds/sync/dataplane_proxy_builder.go
+++ b/pkg/xds/sync/dataplane_proxy_builder.go
@@ -90,21 +90,17 @@ func (p *DataplaneProxyBuilder) resolveRouting(
 	// create a map of selectors to match other dataplanes reachable via given routes
 	destinations := xds_topology.BuildDestinationMap(dataplane, routes)
 
-	// resolve all endpoints that match given selectors
-	outbound := xds_topology.BuildEndpointMap(
+	endpointMap := xds_topology.BuildExternalServicesEndpointMap(
 		ctx,
 		meshContext.Resource,
-		p.Zone,
-		meshContext.Resources.Dataplanes().Items,
-		meshContext.Resources.ZoneIngresses().Items,
-		meshContext.Resources.ZoneEgresses().Items,
 		matchedExternalServices,
 		meshContext.DataSourceLoader,
+		p.Zone,
 	)
-
 	routing := &core_xds.Routing{
-		TrafficRoutes:   routes,
-		OutboundTargets: outbound,
+		TrafficRoutes:                  routes,
+		OutboundTargets:                meshContext.EndpointMap,
+		ExternalServiceOutboundTargets: endpointMap,
 	}
 	return routing, destinations, nil
 }

--- a/pkg/xds/topology/outbound.go
+++ b/pkg/xds/topology/outbound.go
@@ -24,23 +24,17 @@ const (
 	priorityRemote = 1
 )
 
-// BuildEndpointMap creates a map of all endpoints that match given selectors.
-func BuildEndpointMap(
+func BuildExternalServicesEndpointMap(
 	ctx context.Context,
 	mesh *core_mesh.MeshResource,
-	zone string,
-	dataplanes []*core_mesh.DataplaneResource,
-	zoneIngresses []*core_mesh.ZoneIngressResource,
-	zoneEgresses []*core_mesh.ZoneEgressResource,
 	externalServices []*core_mesh.ExternalServiceResource,
 	loader datasource.Loader,
+	zone string,
 ) core_xds.EndpointMap {
-	outbound := BuildEdsEndpointMap(mesh, zone, dataplanes, zoneIngresses, zoneEgresses, externalServices)
-
+	outbound := core_xds.EndpointMap{}
 	if !mesh.ZoneEgressEnabled() {
 		fillExternalServicesOutbounds(ctx, outbound, externalServices, mesh, loader, zone)
 	}
-
 	return outbound
 }
 

--- a/pkg/xds/topology/outbound_test.go
+++ b/pkg/xds/topology/outbound_test.go
@@ -193,8 +193,8 @@ var _ = Describe("TrafficRoute", func() {
 			externalServices := &core_mesh.ExternalServiceResourceList{}
 
 			// when
-			targets := BuildEndpointMap(
-				context.Background(), defaultMeshWithMTLS, "zone-1", dataplanes.Items, nil, nil, externalServices.Items, dataSourceLoader,
+			targets := BuildEdsEndpointMap(
+				defaultMeshWithMTLS, "zone-1", dataplanes.Items, nil, nil, externalServices.Items,
 			)
 
 			Expect(targets).To(HaveLen(4))
@@ -282,9 +282,15 @@ var _ = Describe("TrafficRoute", func() {
 		DescribeTable("should include only those dataplanes that match given selectors",
 			func(given testCase) {
 				// when
-				endpoints := BuildEndpointMap(
-					context.Background(), given.mesh, "zone-1", given.dataplanes, given.zoneIngresses, given.zoneEgresses, given.externalServices, dataSourceLoader,
+				endpoints := BuildEdsEndpointMap(
+					given.mesh, "zone-1", given.dataplanes, given.zoneIngresses, given.zoneEgresses, given.externalServices,
 				)
+				esEndpoints := BuildExternalServicesEndpointMap(
+					context.Background(), given.mesh, given.externalServices, dataSourceLoader, "zone-1",
+				)
+				for k, v := range esEndpoints {
+					endpoints[k] = v
+				}
 				// then
 				Expect(endpoints).To(Equal(given.expected))
 			},


### PR DESCRIPTION
This PR removes rebuilding endpoint map in `DataplaneProxyBuilder`.
We already compute endpoint map for all data plane proxy in the mesh and cache it in `MeshContext`.
However, we were rebuilding the map in `DataplaneProxyBuilder`, because if we had no zone egress we decided if we want to include external service endpoints based on traffic permission. I changed the logic to only compute external services endpoint for each data plane proxy and share the endpoint map for the rest of services.

This saves a significant amount of CPU (2-3x when benchmarking with in-memory storage and mock Envoys)

Before:
![master](https://user-images.githubusercontent.com/5459824/188815815-0a871377-3594-4f7b-833c-c49321324b24.jpg)
![image](https://user-images.githubusercontent.com/5459824/188815941-afd5e76b-f14c-45b8-84b0-c82bbd9a9094.png)


After:
![perf-fix](https://user-images.githubusercontent.com/5459824/188815838-c682088a-7948-4702-bd4d-0ce61c07fdaf.jpg)

![image](https://user-images.githubusercontent.com/5459824/188815976-98048694-4240-4e65-9909-c76df4902a96.png)

Fix #2989

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [X] Link to docs PR or issue -- no
- [X] Link to UI issue or PR -- no
- [X] Is the [issue worked on linked][1]? -- https://github.com/kumahq/kuma/issues/2989
- [X] The PR does not hardcode values that might break projects that depend on kuma (e.g. "kumahq" as a image registry) -- no
- [X] The PR will work for both Linux and Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS -- no
- [X] Unit Tests --
- [X] E2E Tests --
- [X] Manual Universal Tests --
- [X] Manual Kubernetes Tests --
- [X] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? -- no
- [X] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? -- no
- [X] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch)?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
