### PR TITLE
fix(helm): use `podAnnotations` everywhere possible

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -13,6 +13,10 @@ does not have any particular instructions.
 This component has been removed
 after [a long period of deprecation](https://github.com/kumahq/kuma/issues/2851).
 
+### Helm
+
+`ingress.annotations` and `egress.annotations` are deprecated in favour of `ingress.podAnnotations` and `egress.podAnnotations` which is a better name and aligne with the existing `controlPlane.podAnnoations`.
+
 ## Upgrade to `1.8.x`
 
 ### Kumactl

--- a/app/kumactl/cmd/install/testdata/install-control-plane.cni-enabled.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.cni-enabled.golden.yaml
@@ -2167,7 +2167,6 @@ spec:
       annotations:
         checksum/config: c52be51867deb8823a422dc1d188c7a2ab7fc5e501f620467d7fdd8fc4637d47
         checksum/tls-secrets: 0f778cb0c1f035e562a58b0fac0af5eb78fa2ed5d89f26c9e7968d50cea2a1dd
-        
       labels: 
         app: kuma-control-plane
         app.kubernetes.io/name: kuma

--- a/app/kumactl/cmd/install/testdata/install-control-plane.cni-experimental-enabled.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.cni-experimental-enabled.golden.yaml
@@ -2185,7 +2185,6 @@ spec:
       annotations:
         checksum/config: c52be51867deb8823a422dc1d188c7a2ab7fc5e501f620467d7fdd8fc4637d47
         checksum/tls-secrets: 0f778cb0c1f035e562a58b0fac0af5eb78fa2ed5d89f26c9e7968d50cea2a1dd
-        
       labels: 
         app: kuma-control-plane
         app.kubernetes.io/name: kuma

--- a/app/kumactl/cmd/install/testdata/install-control-plane.defaults.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.defaults.golden.yaml
@@ -1989,7 +1989,6 @@ spec:
       annotations:
         checksum/config: c52be51867deb8823a422dc1d188c7a2ab7fc5e501f620467d7fdd8fc4637d47
         checksum/tls-secrets: 0f778cb0c1f035e562a58b0fac0af5eb78fa2ed5d89f26c9e7968d50cea2a1dd
-        
       labels: 
         app: kuma-control-plane
         app.kubernetes.io/name: kuma

--- a/app/kumactl/cmd/install/testdata/install-control-plane.dump-values.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.dump-values.yaml
@@ -311,6 +311,8 @@ cni:
   # -- Node Selector for the CNI pods
   nodeSelector:
     kubernetes.io/os: linux
+  # -- Additional pod annotations
+  podAnnotations: { }
 
   image:
     # -- CNI image registry
@@ -444,8 +446,10 @@ ingress:
     port: 10001
     # -- Port on which service is exposed on Node for service of type NodePort
     nodePort:
-  # -- Additional deployment annotation
+  # -- Additional pod annotations (deprecated favor `podAnnotations`)
   annotations: { }
+  # -- Additional pod annotations
+  podAnnotations: { }
   # -- Node Selector for the Ingress pods
   nodeSelector:
     kubernetes.io/os: linux
@@ -553,8 +557,10 @@ egress:
     port: 10002
     # -- Port on which service is exposed on Node for service of type NodePort
     nodePort:
-  # -- Additional deployment annotation
+  # -- Additional pod annotations (deprecated favor `podAnnotations`)
   annotations: { }
+  # -- Additional pod annotations
+  podAnnotations: { }
   # -- Node Selector for the Egress pods
   nodeSelector:
     kubernetes.io/os: linux

--- a/app/kumactl/cmd/install/testdata/install-control-plane.global.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.global.golden.yaml
@@ -2006,7 +2006,6 @@ spec:
       annotations:
         checksum/config: c52be51867deb8823a422dc1d188c7a2ab7fc5e501f620467d7fdd8fc4637d47
         checksum/tls-secrets: fd5cb26395594662e1f976f50c10bee12480e1d1f27ab49903572bdc3bb43e7c
-        
       labels: 
         app: kuma-control-plane
         app.kubernetes.io/name: kuma

--- a/app/kumactl/cmd/install/testdata/install-control-plane.override-env-vars.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.override-env-vars.golden.yaml
@@ -1989,7 +1989,6 @@ spec:
       annotations:
         checksum/config: c52be51867deb8823a422dc1d188c7a2ab7fc5e501f620467d7fdd8fc4637d47
         checksum/tls-secrets: 0f778cb0c1f035e562a58b0fac0af5eb78fa2ed5d89f26c9e7968d50cea2a1dd
-        
       labels: 
         app: kuma-control-plane
         app.kubernetes.io/name: kuma

--- a/app/kumactl/cmd/install/testdata/install-control-plane.overrides.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.overrides.golden.yaml
@@ -2119,7 +2119,6 @@ spec:
       annotations:
         checksum/config: 1ddb2793e3c20c70cd0520f7a4fde01d98a29f277eb94d778097c8d1c992128f
         checksum/tls-secrets: 7f615c364a983efeb4034f3aa765835f7d5f11ca524e62608f396a8a92b824f6
-        
       labels: 
         app: kuma-control-plane
         app.kubernetes.io/name: kuma

--- a/app/kumactl/cmd/install/testdata/install-control-plane.registry.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.registry.golden.yaml
@@ -1989,7 +1989,6 @@ spec:
       annotations:
         checksum/config: c52be51867deb8823a422dc1d188c7a2ab7fc5e501f620467d7fdd8fc4637d47
         checksum/tls-secrets: 0f778cb0c1f035e562a58b0fac0af5eb78fa2ed5d89f26c9e7968d50cea2a1dd
-        
       labels: 
         app: kuma-control-plane
         app.kubernetes.io/name: kuma

--- a/app/kumactl/cmd/install/testdata/install-control-plane.tproxy-ebpf-experimental-enabled.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.tproxy-ebpf-experimental-enabled.golden.yaml
@@ -1989,7 +1989,6 @@ spec:
       annotations:
         checksum/config: c52be51867deb8823a422dc1d188c7a2ab7fc5e501f620467d7fdd8fc4637d47
         checksum/tls-secrets: 0f778cb0c1f035e562a58b0fac0af5eb78fa2ed5d89f26c9e7968d50cea2a1dd
-        
       labels: 
         app: kuma-control-plane
         app.kubernetes.io/name: kuma

--- a/app/kumactl/cmd/install/testdata/install-control-plane.with-egress.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.with-egress.golden.yaml
@@ -2020,7 +2020,6 @@ spec:
       annotations:
         checksum/config: c52be51867deb8823a422dc1d188c7a2ab7fc5e501f620467d7fdd8fc4637d47
         checksum/tls-secrets: 0f778cb0c1f035e562a58b0fac0af5eb78fa2ed5d89f26c9e7968d50cea2a1dd
-        
       labels: 
         app: kuma-control-plane
         app.kubernetes.io/name: kuma

--- a/app/kumactl/cmd/install/testdata/install-control-plane.with-helm-set.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.with-helm-set.yaml
@@ -2051,7 +2051,6 @@ spec:
       annotations:
         checksum/config: c52be51867deb8823a422dc1d188c7a2ab7fc5e501f620467d7fdd8fc4637d47
         checksum/tls-secrets: 0f778cb0c1f035e562a58b0fac0af5eb78fa2ed5d89f26c9e7968d50cea2a1dd
-        
       labels: 
         app: kuma-control-plane
         app.kubernetes.io/name: kuma

--- a/app/kumactl/cmd/install/testdata/install-control-plane.with-helm-values.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.with-helm-values.yaml
@@ -1989,7 +1989,6 @@ spec:
       annotations:
         checksum/config: c52be51867deb8823a422dc1d188c7a2ab7fc5e501f620467d7fdd8fc4637d47
         checksum/tls-secrets: 0f778cb0c1f035e562a58b0fac0af5eb78fa2ed5d89f26c9e7968d50cea2a1dd
-        
       labels: 
         app: kuma-control-plane
         app.kubernetes.io/name: kuma

--- a/app/kumactl/cmd/install/testdata/install-control-plane.with-ingress.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.with-ingress.golden.yaml
@@ -2020,7 +2020,6 @@ spec:
       annotations:
         checksum/config: c52be51867deb8823a422dc1d188c7a2ab7fc5e501f620467d7fdd8fc4637d47
         checksum/tls-secrets: 0f778cb0c1f035e562a58b0fac0af5eb78fa2ed5d89f26c9e7968d50cea2a1dd
-        
       labels: 
         app: kuma-control-plane
         app.kubernetes.io/name: kuma

--- a/app/kumactl/cmd/install/testdata/install-control-plane.zone.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.zone.golden.yaml
@@ -1989,7 +1989,6 @@ spec:
       annotations:
         checksum/config: c52be51867deb8823a422dc1d188c7a2ab7fc5e501f620467d7fdd8fc4637d47
         checksum/tls-secrets: 0f778cb0c1f035e562a58b0fac0af5eb78fa2ed5d89f26c9e7968d50cea2a1dd
-        
       labels: 
         app: kuma-control-plane
         app.kubernetes.io/name: kuma

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/empty.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/empty.golden.yaml
@@ -1989,7 +1989,6 @@ spec:
       annotations:
         checksum/config: c52be51867deb8823a422dc1d188c7a2ab7fc5e501f620467d7fdd8fc4637d47
         checksum/tls-secrets: 0f778cb0c1f035e562a58b0fac0af5eb78fa2ed5d89f26c9e7968d50cea2a1dd
-        
       labels: 
         app: kuma-control-plane
         app.kubernetes.io/name: kuma

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/fix4485.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/fix4485.golden.yaml
@@ -2011,7 +2011,6 @@ spec:
       annotations:
         checksum/config: a339f834847039f79aed19d73fd8903aeb736f152c512a641f4fb907dbad1429
         checksum/tls-secrets: 6c59f080c0827192e886efb995ae009149bee063ab26e28eac17b70cfd7ae974
-        
       labels: 
         app: kuma-control-plane
         "foo": "baz"

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/fix4935.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/fix4935.golden.yaml
@@ -10,11 +10,30 @@ metadata:
 apiVersion: v1
 kind: ServiceAccount
 metadata:
+  name: kuma-cni
+  namespace: kube-system
+  labels: 
+    app: kuma-cni
+    app.kubernetes.io/name: kuma
+    app.kubernetes.io/instance: kuma
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
   name: kuma-control-plane
   namespace: kuma-system
   labels: 
     app: kuma-control-plane
-    "foo": "bar"
+    app.kubernetes.io/name: kuma
+    app.kubernetes.io/instance: kuma
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kuma-egress
+  namespace: kuma-system
+  labels: 
+    app: kuma-egress
     app.kubernetes.io/name: kuma
     app.kubernetes.io/instance: kuma
 ---
@@ -25,9 +44,32 @@ metadata:
   namespace: kuma-system
   labels: 
     app: kuma-ingress
-    "foo": "bar"
     app.kubernetes.io/name: kuma
     app.kubernetes.io/instance: kuma
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: kuma-cni-config
+  namespace: kube-system
+  labels: 
+    app: kuma-cni
+    app.kubernetes.io/name: kuma
+    app.kubernetes.io/instance: kuma
+data:
+  # The CNI network configuration to add to the plugin chain on each node.
+  cni_network_config: |-
+    {
+      "cniVersion": "0.3.1",
+      "name": "kuma-cni",
+      "type": "kuma-cni",
+      "log_level": "info",
+      "kubernetes": {
+          "kubeconfig": "__KUBECONFIG_FILEPATH__",
+          "cni_bin_dir": "/var/lib/cni/bin",
+          "exclude_namespaces": [ "kube-system" ]
+      }
+    }
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -36,7 +78,6 @@ metadata:
   namespace: kuma-system
   labels: 
     app: kuma-control-plane
-    "foo": "bar"
     app.kubernetes.io/name: kuma
     app.kubernetes.io/instance: kuma
 data:
@@ -1715,10 +1756,30 @@ spec:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
+  name: kuma-cni
+  labels:
+  
+    app: kuma-cni
+    app.kubernetes.io/name: kuma
+    app.kubernetes.io/instance: kuma
+rules:
+  - apiGroups: [""]
+    resources:
+      - nodes
+    verbs:
+      - get
+  - apiGroups: [""]
+    resources:
+      - pods
+    verbs:
+      - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
   name: kuma-control-plane
   labels: 
     app: kuma-control-plane
-    "foo": "bar"
     app.kubernetes.io/name: kuma
     app.kubernetes.io/instance: kuma
 rules:
@@ -1860,6 +1921,24 @@ rules:
       - get
       - patch
       - update
+  - apiGroups:
+      - k8s.cni.cncf.io
+    resources:
+      - network-attachment-definitions
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - delete
+  - apiGroups:
+      - apiextensions.k8s.io
+    resources:
+      - customresourcedefinitions
+    verbs:
+      - get
+      - list
+      - watch
   # validate k8s token before issuing mTLS cert
   - apiGroups:
       - authentication.k8s.io
@@ -1871,10 +1950,27 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
+  name: kuma-cni
+  labels:
+  
+    app: kuma-cni
+    app.kubernetes.io/name: kuma
+    app.kubernetes.io/instance: kuma
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kuma-cni
+subjects:
+  - kind: ServiceAccount
+    name: kuma-cni
+    namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
   name: kuma-control-plane
   labels: 
     app: kuma-control-plane
-    "foo": "bar"
     app.kubernetes.io/name: kuma
     app.kubernetes.io/instance: kuma
 roleRef:
@@ -1893,7 +1989,6 @@ metadata:
   namespace: kuma-system
   labels: 
     app: kuma-control-plane
-    "foo": "bar"
     app.kubernetes.io/name: kuma
     app.kubernetes.io/instance: kuma
 rules:
@@ -1936,7 +2031,6 @@ metadata:
   namespace: kuma-system
   labels: 
     app: kuma-control-plane
-    "foo": "bar"
     app.kubernetes.io/name: kuma
     app.kubernetes.io/instance: kuma
 roleRef:
@@ -1955,12 +2049,13 @@ metadata:
   namespace: kuma-system
   labels: 
     app: kuma-control-plane
-    "foo": "bar"
     app.kubernetes.io/name: kuma
     app.kubernetes.io/instance: kuma
   annotations:
     prometheus.io/scrape: "true"
     prometheus.io/port: "5680"
+    foo: "{\"bar\": \"baz\"}"
+    service: "annotation"
 spec:
   type: ClusterIP
   ports:
@@ -1985,14 +2080,38 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
+  name: kuma-egress
+  namespace: kuma-system
+  labels: 
+    app: kuma-egress
+    app.kubernetes.io/name: kuma
+    app.kubernetes.io/instance: kuma
+  annotations:
+      foo: "{\"bar\": \"baz\"}"
+      service: "zone-egress"
+spec:
+  type: ClusterIP
+  ports:
+    - port: 10002
+      protocol: TCP
+      targetPort: 10002
+  selector:
+    app: kuma-egress
+    app.kubernetes.io/name: kuma
+    app.kubernetes.io/instance: kuma
+---
+apiVersion: v1
+kind: Service
+metadata:
   name: kuma-ingress
   namespace: kuma-system
   labels: 
     app: kuma-ingress
-    "foo": "bar"
     app.kubernetes.io/name: kuma
     app.kubernetes.io/instance: kuma
   annotations:
+      foo: "{\"bar\": \"baz\"}"
+      service: "zone-ingress"
 spec:
   type: LoadBalancer
   ports:
@@ -2004,6 +2123,95 @@ spec:
     app.kubernetes.io/name: kuma
     app.kubernetes.io/instance: kuma
 ---
+kind: DaemonSet
+apiVersion: apps/v1
+metadata:
+  name: kuma-cni-node
+  namespace: kube-system
+  labels:
+    app: kuma-cni
+    app.kubernetes.io/name: kuma
+    app.kubernetes.io/instance: kuma
+spec:
+  selector:
+    matchLabels:
+      app: kuma-cni
+      app.kubernetes.io/name: kuma
+      app.kubernetes.io/instance: kuma
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+  template:
+    metadata:
+      labels:
+        app: kuma-cni
+        app.kubernetes.io/name: kuma
+        app.kubernetes.io/instance: kuma
+      annotations:
+        checksum/config: 850246b56a69bba30d67145d2efc88941f6c91badd116beca4123d75c70a39ec
+        foo: "{\"bar\": \"baz\"}"
+        pod: "cni"
+    spec:
+      # This, along with the CriticalAddonsOnly toleration below,
+      # marks the pod as a critical add-on, ensuring it gets
+      # priority scheduling and that its resources are reserved
+      # if it ever gets evicted.
+      priorityClassName: system-cluster-critical
+      nodeSelector:
+      
+        kubernetes.io/os: linux
+      hostNetwork: true
+      tolerations:
+        # Make sure kuma-cni-node gets scheduled on all nodes.
+        - effect: NoSchedule
+          operator: Exists
+        # Mark the pod as a critical add-on for rescheduling.
+        - key: CriticalAddonsOnly
+          operator: Exists
+        - effect: NoExecute
+          operator: Exists
+      serviceAccountName: kuma-cni
+      # Minimize downtime during a rolling upgrade or deletion; tell Kubernetes to do a "force
+      # deletion": https://kubernetes.io/docs/concepts/workloads/pods/pod/#termination-of-pods.
+      terminationGracePeriodSeconds: 5
+      containers:
+        - name: install-cni
+          image: "docker.io/kumahq/install-cni:0.0.10"
+          imagePullPolicy: IfNotPresent
+          command: [ "/bin/sh", "-c", "--" ]
+          args: [ "sleep 0 && exec /install-cni.sh" ]
+          env:
+            # Name of the CNI config file to create.
+            - name: CNI_CONF_NAME
+              value: "kuma-cni.conf"
+            # The CNI network config to install on each node.
+            - name: CNI_NETWORK_CONFIG
+              valueFrom:
+                configMapKeyRef:
+                  name: kuma-cni-config
+                  key: cni_network_config
+            - name: CNI_NET_DIR
+              value: "/etc/cni/multus/net.d"
+            # If true, deploy as a chained CNI plugin, otherwise deploy as a standalone CNI
+            - name: CHAINED_CNI_PLUGIN
+              value: "false"
+            - name: CNI_LOG_LEVEL
+              value: "info"
+          volumeMounts:
+            - mountPath: /host/opt/cni/bin
+              name: cni-bin-dir
+            - mountPath: /host/etc/cni/net.d
+              name: cni-net-dir
+      volumes:
+        # Used to install CNI.
+        - name: cni-bin-dir
+          hostPath:
+            path: /var/lib/cni/bin
+        - name: cni-net-dir
+          hostPath:
+            path: /etc/cni/multus/net.d
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -2011,7 +2219,6 @@ metadata:
   namespace: kuma-system
   labels: 
     app: kuma-control-plane
-    "foo": "bar"
     app.kubernetes.io/name: kuma
     app.kubernetes.io/instance: kuma
 spec:
@@ -2028,11 +2235,12 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 8e3d9b7078c00005eae94f443d41866ae6d12b93b99888c865c01e843e16dd38
-        checksum/tls-secrets: 6a60bfebb565d14f3eb7deea8f96a8d4eb674254ab8a60c3e19e7ff761168e0b
+        checksum/config: c52be51867deb8823a422dc1d188c7a2ab7fc5e501f620467d7fdd8fc4637d47
+        checksum/tls-secrets: 0f778cb0c1f035e562a58b0fac0af5eb78fa2ed5d89f26c9e7968d50cea2a1dd
+        bim: "bam"
+        foo: "{\"bar\": \"baz\"}"
       labels: 
         app: kuma-control-plane
-        "foo": "bar"
         app.kubernetes.io/name: kuma
         app.kubernetes.io/instance: kuma
     spec:
@@ -2087,9 +2295,9 @@ spec:
             - name: KUMA_MODE
               value: "zone"
             - name: KUMA_MULTIZONE_ZONE_GLOBAL_ADDRESS
-              value: "grpcs://foo.com:3456"
+              value: "grpcs://localhost:5678"
             - name: KUMA_MULTIZONE_ZONE_NAME
-              value: "east"
+              value: "zone1"
             - name: KUMA_RUNTIME_KUBERNETES_ADMISSION_SERVER_CERT_DIR
               value: "/var/run/secrets/kuma.io/tls-cert"
             - name: KUMA_RUNTIME_KUBERNETES_ADMISSION_SERVER_PORT
@@ -2099,7 +2307,7 @@ spec:
             - name: KUMA_RUNTIME_KUBERNETES_INJECTOR_CA_CERT_FILE
               value: "/var/run/secrets/kuma.io/tls-cert/ca.crt"
             - name: KUMA_RUNTIME_KUBERNETES_INJECTOR_CNI_ENABLED
-              value: "false"
+              value: "true"
             - name: KUMA_RUNTIME_KUBERNETES_INJECTOR_SIDECAR_CONTAINER_IMAGE
               value: "docker.io/kumahq/kuma-dp:0.0.1"
             - name: KUMA_RUNTIME_KUBERNETES_SERVICE_ACCOUNT_NAME
@@ -2166,11 +2374,130 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
+  name: kuma-egress
+  namespace: kuma-system
+  labels: 
+    app: kuma-egress
+    app.kubernetes.io/name: kuma
+    app.kubernetes.io/instance: kuma
+spec:
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: kuma
+      app.kubernetes.io/instance: kuma
+      app: kuma-egress
+  template:
+    metadata:
+      annotations:
+        kuma.io/egress: enabled
+        foo: "{\"bar\": \"baz\"}"
+        pod: "zone-egress"
+        pod2: "zone-ingress"
+      labels:
+        app: kuma-egress
+        app.kubernetes.io/name: kuma
+        app.kubernetes.io/instance: kuma
+    spec:
+      affinity: 
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: app.kubernetes.io/name
+                  operator: In
+                  values:
+                  - 'kuma'
+                - key: app.kubernetes.io/instance
+                  operator: In
+                  values:
+                  - 'kuma'
+                - key: app
+                  operator: In
+                  values:
+                  - kuma-egress
+              topologyKey: kubernetes.io/hostname
+            weight: 100
+      serviceAccountName: kuma-egress
+      nodeSelector:
+      
+        kubernetes.io/os: linux
+      containers:
+        - name: egress
+          image: "docker.io/kumahq/kuma-dp:0.0.1"
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: KUMA_CONTROL_PLANE_URL
+              value: "https://kuma-control-plane.kuma-system:5678"
+            - name: KUMA_CONTROL_PLANE_CA_CERT_FILE
+              value: /var/run/secrets/kuma.io/tls-cert/ca.crt
+            - name: KUMA_DATAPLANE_NAME
+              value: $(POD_NAME).$(POD_NAMESPACE)
+            - name: KUMA_DATAPLANE_DRAIN_TIME
+              value: 30s
+            - name: KUMA_DATAPLANE_RUNTIME_TOKEN_PATH
+              value: /var/run/secrets/kubernetes.io/serviceaccount/token
+            - name: KUMA_DATAPLANE_PROXY_TYPE
+              value: "egress"
+          args:
+            - run
+            - --log-level=info
+          ports:
+            - containerPort: 10002
+          livenessProbe:
+            httpGet:
+              path: "/ready"
+              port: 9901
+            failureThreshold: 12
+            initialDelaySeconds: 60
+            periodSeconds: 5
+            successThreshold: 1
+            timeoutSeconds: 3
+          readinessProbe:
+            httpGet:
+              path: "/ready"
+              port: 9901
+            failureThreshold: 12
+            initialDelaySeconds: 1
+            periodSeconds: 5
+            successThreshold: 1
+            timeoutSeconds: 3
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 1000m
+              memory: 512Mi
+          volumeMounts:
+            - name: kuma-tls-cert
+              mountPath: /var/run/secrets/kuma.io/tls-cert
+              readOnly: true
+      volumes:
+        - name: kuma-tls-cert
+          secret:
+            secretName: kuma-tls-cert
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
   name: kuma-ingress
   namespace: kuma-system
   labels: 
     app: kuma-ingress
-    "foo": "bar"
     app.kubernetes.io/name: kuma
     app.kubernetes.io/instance: kuma
 spec:
@@ -2188,9 +2515,11 @@ spec:
     metadata:
       annotations:
         kuma.io/ingress: enabled
+        foo: "{\"bar\": \"baz\"}"
+        pod: "zone-ingress"
+        pod2: "zone-ingress"
       labels:
         app: kuma-ingress
-        "foo": "bar"
         app.kubernetes.io/name: kuma
         app.kubernetes.io/instance: kuma
     spec:
@@ -2289,9 +2618,11 @@ kind: Ingress
 metadata:
   name: kuma-control-plane
   namespace: kuma-system
+  annotations:
+    foo: '{"bar": "baz"}'
+    service: ingress
   labels: 
     app: kuma-control-plane
-    "foo": "bar"
     app.kubernetes.io/name: kuma
     app.kubernetes.io/instance: kuma
 spec:
@@ -2315,7 +2646,6 @@ metadata:
   namespace: kuma-system
   labels: 
     app: kuma-control-plane
-    "foo": "bar"
     app.kubernetes.io/name: kuma
     app.kubernetes.io/instance: kuma
 webhooks:
@@ -2447,7 +2777,6 @@ metadata:
   namespace: kuma-system
   labels: 
     app: kuma-control-plane
-    "foo": "bar"
     app.kubernetes.io/name: kuma
     app.kubernetes.io/instance: kuma
 webhooks:

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/fix4935.values.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/fix4935.values.yaml
@@ -1,0 +1,52 @@
+# Test all possible annotations in the chart
+controlPlane:
+  mode: zone
+  zone: zone1
+  kdsGlobalAddress: "grpcs://localhost:5678"
+  podAnnotations:
+    foo: '{"bar": "baz"}'
+    bim: "bam"
+  annotations:
+    zoom: zam
+  service:
+    annotations:
+      foo: '{"bar": "baz"}'
+      service: "annotation"
+  ingress:
+    enabled: true
+    annotations:
+      foo: '{"bar": "baz"}'
+      service: "ingress"
+  globalZoneSyncService:
+    annotations:
+      foo: '{"bar": "baz"}'
+      service: "globalSync"
+ingress:
+  enabled: true
+  annotations:
+    foo: '{"bar": "baz"}'
+    pod: "zone-ingress"
+  podAnnotations:
+    foo: '{"bar": "baz"}'
+    pod2: "zone-ingress"
+  service:
+    annotations:
+      foo: '{"bar": "baz"}'
+      service: "zone-ingress"
+egress:
+  enabled: true
+  annotations:
+    foo: '{"bar": "baz"}'
+    pod: "zone-egress"
+  podAnnotations:
+    foo: '{"bar": "baz"}'
+    pod2: "zone-ingress"
+  service:
+    annotations:
+      foo: '{"bar": "baz"}'
+      service: "zone-egress"
+cni:
+  enabled: true
+  podAnnotations:
+    foo: '{"bar": "baz"}'
+    pod: "cni"

--- a/deployments/charts/README.md
+++ b/deployments/charts/README.md
@@ -4,3 +4,9 @@ In addition to the `kumactl install` command, Kuma offers a set of Helm charts t
 Kuma on Kubernetes.
 
 These charts are compatible with Helm 3+.
+
+
+## Testing the helm chart
+
+You can add some input/output in `app/kumactl/cmd/install/testdata/install-cp-helm`.
+You create a `values` file and its matching output this ensures no regression will be introduced with future changes.

--- a/deployments/charts/kuma/README.md
+++ b/deployments/charts/kuma/README.md
@@ -85,6 +85,7 @@ A Helm chart for the Kuma Control Plane
 | cni.confName | string | `"kuma-cni.conf"` | Set the CNI configuration name |
 | cni.logLevel | string | `"info"` | CNI log level: one of off,info,debug |
 | cni.nodeSelector | object | `{"kubernetes.io/os":"linux"}` | Node Selector for the CNI pods |
+| cni.podAnnotations | object | `{}` | Additional pod annotations |
 | cni.image.registry | string | `"docker.io/kumahq"` | CNI image registry |
 | cni.image.repository | string | `"install-cni"` | CNI image repository |
 | cni.image.tag | string | `"0.0.10"` | CNI image tag |
@@ -121,7 +122,8 @@ A Helm chart for the Kuma Control Plane
 | ingress.service.annotations | object | `{}` | Additional annotations to put on the Ingress service |
 | ingress.service.port | int | `10001` | Port on which Ingress is exposed |
 | ingress.service.nodePort | string | `nil` | Port on which service is exposed on Node for service of type NodePort |
-| ingress.annotations | object | `{}` | Additional deployment annotation |
+| ingress.annotations | object | `{}` | Additional pod annotations (deprecated favor `podAnnotations`) |
+| ingress.podAnnotations | object | `{}` | Additional pod annotations |
 | ingress.nodeSelector | object | `{"kubernetes.io/os":"linux"}` | Node Selector for the Ingress pods |
 | ingress.podDisruptionBudget.enabled | bool | `false` | Whether to create a pod disruption budget |
 | ingress.podDisruptionBudget.maxUnavailable | int | `1` | The maximum number of unavailable pods allowed by the budget |
@@ -144,7 +146,8 @@ A Helm chart for the Kuma Control Plane
 | egress.service.annotations | object | `{}` | Additional annotations to put on the Egress service |
 | egress.service.port | int | `10002` | Port on which Egress is exposed |
 | egress.service.nodePort | string | `nil` | Port on which service is exposed on Node for service of type NodePort |
-| egress.annotations | object | `{}` | Additional deployment annotation |
+| egress.annotations | object | `{}` | Additional pod annotations (deprecated favor `podAnnotations`) |
+| egress.podAnnotations | object | `{}` | Additional pod annotations |
 | egress.nodeSelector | object | `{"kubernetes.io/os":"linux"}` | Node Selector for the Egress pods |
 | egress.podDisruptionBudget.enabled | bool | `false` | Whether to create a pod disruption budget |
 | egress.podDisruptionBudget.maxUnavailable | int | `1` | The maximum number of unavailable pods allowed by the budget |

--- a/deployments/charts/kuma/templates/_helpers.tpl
+++ b/deployments/charts/kuma/templates/_helpers.tpl
@@ -112,15 +112,6 @@ app: {{ include "kuma.name" . }}-control-plane
 {{- end }}
 
 {{/*
-control plane pod annotations
-*/}}
-{{- define "kuma.cpPodAnnotations" -}}
-{{ range $key, $value := $.Values.controlPlane.podAnnotations }}
-{{- $key }}: {{ $value -}}
-{{ end }}
-{{- end }}
-
-{{/*
 ingress labels
 */}}
 {{- define "kuma.ingressLabels" -}}

--- a/deployments/charts/kuma/templates/cni-daemonset.yaml
+++ b/deployments/charts/kuma/templates/cni-daemonset.yaml
@@ -19,6 +19,9 @@ spec:
       {{- include "kuma.cniSelectorLabels" . | nindent 8 }}
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/cni-configmap.yaml") . | sha256sum }}
+        {{- range $key, $value := .Values.cni.podAnnotations }}
+        {{ $key }}: {{ $value | quote }}
+        {{- end }}
     spec:
       # This, along with the CriticalAddonsOnly toleration below,
       # marks the pod as a critical add-on, ensuring it gets

--- a/deployments/charts/kuma/templates/cp-deployment.yaml
+++ b/deployments/charts/kuma/templates/cp-deployment.yaml
@@ -37,7 +37,9 @@ spec:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/cp-configmap.yaml") . | sha256sum }}
         checksum/tls-secrets: {{ include (print $.Template.BasePath "/cp-webhooks-and-secrets.yaml") . | sha256sum }}
-        {{- include "kuma.cpPodAnnotations" . | nindent 8 }}
+        {{- range $key, $value := $.Values.controlPlane.podAnnotations }}
+        {{ $key }}: {{ $value | quote }}
+        {{- end }}
       labels: {{ include "kuma.cpLabels" . | nindent 8 }}
     spec:
       {{- with .Values.controlPlane.affinity }}

--- a/deployments/charts/kuma/templates/egress-deployment.yaml
+++ b/deployments/charts/kuma/templates/egress-deployment.yaml
@@ -21,10 +21,8 @@ spec:
     metadata:
       annotations:
         kuma.io/egress: enabled
-        {{- if .Values.egress.annotations }}
-        {{- range $key, $value := .Values.egress.annotations }}
+        {{- range $key, $value := merge .Values.egress.podAnnotations .Values.egress.annotations }}
         {{ $key }}: {{ $value | quote }}
-        {{- end }}
         {{- end }}
       labels:
         {{- include "kuma.egressLabels" . | nindent 8 }}

--- a/deployments/charts/kuma/templates/ingress-deployment.yaml
+++ b/deployments/charts/kuma/templates/ingress-deployment.yaml
@@ -21,10 +21,8 @@ spec:
     metadata:
       annotations:
         kuma.io/ingress: enabled
-        {{- if .Values.ingress.annotations }}
-        {{- range $key, $value := .Values.ingress.annotations }}
+        {{- range $key, $value := merge .Values.ingress.podAnnotations .Values.ingress.annotations }}
         {{ $key }}: {{ $value | quote }}
-        {{- end }}
         {{- end }}
       labels:
         {{- include "kuma.ingressLabels" . | nindent 8 }}

--- a/deployments/charts/kuma/values.yaml
+++ b/deployments/charts/kuma/values.yaml
@@ -311,6 +311,8 @@ cni:
   # -- Node Selector for the CNI pods
   nodeSelector:
     kubernetes.io/os: linux
+  # -- Additional pod annotations
+  podAnnotations: { }
 
   image:
     # -- CNI image registry
@@ -444,8 +446,10 @@ ingress:
     port: 10001
     # -- Port on which service is exposed on Node for service of type NodePort
     nodePort:
-  # -- Additional deployment annotation
+  # -- Additional pod annotations (deprecated favor `podAnnotations`)
   annotations: { }
+  # -- Additional pod annotations
+  podAnnotations: { }
   # -- Node Selector for the Ingress pods
   nodeSelector:
     kubernetes.io/os: linux
@@ -553,8 +557,10 @@ egress:
     port: 10002
     # -- Port on which service is exposed on Node for service of type NodePort
     nodePort:
-  # -- Additional deployment annotation
+  # -- Additional pod annotations (deprecated favor `podAnnotations`)
   annotations: { }
+  # -- Additional pod annotations
+  podAnnotations: { }
   # -- Node Selector for the Egress pods
   nodeSelector:
     kubernetes.io/os: linux


### PR DESCRIPTION
- Deprecated `annotations` everywhere in favour of `podAnnotations`
- Add test to validate all `annotations` values
- Add `cni.podAnnotations`
- Add README for helm chart tests

Fix #4935

Co-authored-by: Deepak Mohandas <deepak.mohandas@konghq.com>
Signed-off-by: Charly Molter <charly.molter@konghq.com>

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] Link to docs PR or issue --
- [x] Link to UI issue or PR --
- [x] Is the [issue worked on linked][1]? --
- [x] The PR does not hardcode values that might break projects that depend on kuma (e.g. "kumahq" as a image registry) --
- [x] The PR will work for both Linux and Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Unit Tests --
- [x] E2E Tests --
- [x] Manual Universal Tests --
- [x] Manual Kubernetes Tests --
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [x] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch)?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
