### PR TITLE
test(e2e_env): enable experimental transparent proxy v2 on k8s

### DIFF
--- a/test/e2e_env/kubernetes/kubernetes_suite_test.go
+++ b/test/e2e_env/kubernetes/kubernetes_suite_test.go
@@ -42,7 +42,10 @@ var _ = SynchronizedBeforeSuite(
 		Expect(env.Cluster.Install(
 			Kuma(core.Standalone,
 				WithEnv("KUMA_STORE_UNSAFE_DELETE", "true"),
-				WithCtlOpts(map[string]string{"--experimental-gatewayapi": "true"}),
+				WithCtlOpts(map[string]string{
+					"--experimental-gatewayapi": "true",
+					"--set":                     "experimental.transparentProxy=true",
+				}),
 				WithEgress(),
 			)),
 		).To(Succeed())


### PR DESCRIPTION
### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] Link to docs PR or issue --
- [x] Link to UI issue or PR --
- [x] Is the [issue worked on linked][1]? -- #4442 
- [x] The PR does not hardcode values that might break projects that depend on kuma (e.g. "kumahq" as a image registry) --
- [x] The PR will work for both Linux and Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Unit Tests --
- [x] E2E Tests --
- [x] Manual Universal Tests -- none
- [x] Manual Kubernetes Tests -- definitely enables the proxy
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [x] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch)?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
