### PR TITLE
fix: add 'v' prefix to preview version format

### DIFF
--- a/tools/releases/version.sh
+++ b/tools/releases/version.sh
@@ -21,10 +21,10 @@ if [[ ${currentBranch} == release-* ]]; then
     lastGitTag=$(git tag -l | grep -E "^v?${releasePrefix}\.[0-9]+$" | sed 's/^v//'| sort -V | tail -1)
     if [[ ${lastGitTag} ]]; then
       IFS=. read -r major minor patch <<< "${lastGitTag}"
-      echo "${major}.${minor}.$((++patch))-preview.${shortHash}"
+      echo "${major}.${minor}.$((++patch))-preview.v${shortHash}"
     else
-      echo "${releasePrefix}.0-preview.${shortHash}"
+      echo "${releasePrefix}.0-preview.v${shortHash}"
     fi
 else
-  echo "0.0.0-preview.${shortHash}"
+  echo "0.0.0-preview.v${shortHash}"
 fi


### PR DESCRIPTION
This is necessary because a commit can begin with 0, which would otherwise result in a non-semver compliant string according to https://semver.org/#spec-item-9.

For example, the [helm package validation fails](https://github.com/kumahq/kuma/actions/runs/3052381378/jobs/4921705942).

I'll update `preview.sh` in `kuma-website` after.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [ ] Link to docs PR or issue --
- [ ] Link to UI issue or PR --
- [ ] Is the [issue worked on linked][1]? --
- [ ] The PR does not hardcode values that might break projects that depend on kuma (e.g. "kumahq" as a image registry) --
- [ ] The PR will work for both Linux and Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [ ] Unit Tests --
- [ ] E2E Tests --
- [ ] Manual Universal Tests --
- [ ] Manual Kubernetes Tests --
- [ ] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [ ] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [ ] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch)?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
