### PR TITLE
fix(gateway): route sorting

### DIFF
--- a/pkg/plugins/runtime/gateway/route/route_suite_test.go
+++ b/pkg/plugins/runtime/gateway/route/route_suite_test.go
@@ -1,0 +1,11 @@
+package route_test
+
+import (
+	"testing"
+
+	"github.com/kumahq/kuma/pkg/test"
+)
+
+func TestConfig(t *testing.T) {
+	test.RunSpecs(t, "Route package")
+}

--- a/pkg/plugins/runtime/gateway/route/sorter.go
+++ b/pkg/plugins/runtime/gateway/route/sorter.go
@@ -33,6 +33,8 @@ func isMoreSpecific(lhs *Match, rhs *Match) bool {
 		if len(lhs.ExactPath) < len(rhs.ExactPath) {
 			return false
 		}
+	case rhs.ExactPath != "":
+		return false
 	case lhs.PrefixPath != "":
 		// Prefix match is more specific than regex.
 		if rhs.PrefixPath == "" {
@@ -46,7 +48,9 @@ func isMoreSpecific(lhs *Match, rhs *Match) bool {
 		if len(lhs.PrefixPath) < len(rhs.PrefixPath) {
 			return false
 		}
-	case lhs.RegexPath != "":
+	case rhs.PrefixPath != "":
+		return false
+	default:
 		// Regex match is more specific than no path match.
 		if rhs.RegexPath == "" {
 			return true

--- a/pkg/plugins/runtime/gateway/route/sorter_test.go
+++ b/pkg/plugins/runtime/gateway/route/sorter_test.go
@@ -1,0 +1,40 @@
+package route_test
+
+import (
+	"sort"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/kumahq/kuma/pkg/plugins/runtime/gateway/route"
+)
+
+var _ = Describe("sorting", func() {
+	It("is consistent", func() {
+		routes := []route.Entry{{
+			Match: route.Match{
+				ExactPath: "/go",
+			},
+		}, {
+			Match: route.Match{
+				PrefixPath: "/go",
+			},
+		}}
+
+		sort.Sort(route.Sorter(routes))
+
+		swappedRoutes := []route.Entry{{
+			Match: route.Match{
+				PrefixPath: "/go",
+			},
+		}, {
+			Match: route.Match{
+				ExactPath: "/go",
+			},
+		}}
+
+		sort.Sort(route.Sorter(swappedRoutes))
+
+		Expect(routes).To(Equal(swappedRoutes))
+	})
+})


### PR DESCRIPTION
Sorting isn't totally solved but this at least makes it not completely broken.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] Link to docs PR or issue --
- [x] Link to UI issue or PR --
- [x] Is the [issue worked on linked][1]? --
- [x] The PR does not hardcode values that might break projects that depend on kuma (e.g. "kumahq" as a image registry) --
- [x] The PR will work for both Linux and Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Unit Tests --
- [x] E2E Tests --
- [x] Manual Universal Tests --
- [x] Manual Kubernetes Tests --
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [x] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch)?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
