### PR TITLE
test: set XDSAuthenticator in test runtime

### DIFF
--- a/pkg/test/runtime/runtime.go
+++ b/pkg/test/runtime/runtime.go
@@ -34,6 +34,7 @@ import (
 	leader_memory "github.com/kumahq/kuma/pkg/plugins/leader/memory"
 	resources_memory "github.com/kumahq/kuma/pkg/plugins/resources/memory"
 	tokens_access "github.com/kumahq/kuma/pkg/tokens/builtin/access"
+	xds_auth_components "github.com/kumahq/kuma/pkg/xds/auth/components"
 	xds_hooks "github.com/kumahq/kuma/pkg/xds/hooks"
 	"github.com/kumahq/kuma/pkg/xds/secrets"
 )
@@ -83,6 +84,13 @@ func BuilderFor(appCtx context.Context, cfg kuma_cp.Config) (*core_runtime.Build
 
 	metrics, _ := metrics.NewMetrics("Standalone")
 	builder.WithMetrics(metrics)
+
+	authenticator, err := xds_auth_components.DefaultAuthenticator(builder) //nolint:contextcheck
+	if err != nil {
+		return nil, err
+	}
+
+	builder.WithXDSAuthenticator(authenticator)
 
 	builder.WithDataSourceLoader(datasource.NewDataSourceLoader(builder.ResourceManager()))
 	builder.WithCaManager("builtin", builtin.NewBuiltinCaManager(builder.ResourceManager()))

--- a/pkg/test/runtime/runtime.go
+++ b/pkg/test/runtime/runtime.go
@@ -34,7 +34,7 @@ import (
 	leader_memory "github.com/kumahq/kuma/pkg/plugins/leader/memory"
 	resources_memory "github.com/kumahq/kuma/pkg/plugins/resources/memory"
 	tokens_access "github.com/kumahq/kuma/pkg/tokens/builtin/access"
-	xds_auth_components "github.com/kumahq/kuma/pkg/xds/auth/components"
+	universal_auth "github.com/kumahq/kuma/pkg/xds/auth/universal"
 	xds_hooks "github.com/kumahq/kuma/pkg/xds/hooks"
 	"github.com/kumahq/kuma/pkg/xds/secrets"
 )
@@ -85,12 +85,7 @@ func BuilderFor(appCtx context.Context, cfg kuma_cp.Config) (*core_runtime.Build
 	metrics, _ := metrics.NewMetrics("Standalone")
 	builder.WithMetrics(metrics)
 
-	authenticator, err := xds_auth_components.DefaultAuthenticator(builder) //nolint:contextcheck
-	if err != nil {
-		return nil, err
-	}
-
-	builder.WithXDSAuthenticator(authenticator)
+	builder.WithXDSAuthenticator(universal_auth.NewNoopAuthenticator())
 
 	builder.WithDataSourceLoader(datasource.NewDataSourceLoader(builder.ResourceManager()))
 	builder.WithCaManager("builtin", builtin.NewBuiltinCaManager(builder.ResourceManager()))


### PR DESCRIPTION
### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] Link to docs PR or issue --
- [x] Link to UI issue or PR --
- [x] Is the [issue worked on linked][1]? --
- [x] The PR does not hardcode values that might break projects that depend on kuma (e.g. "kumahq" as a image registry) --
- [x] The PR will work for both Linux and Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Unit Tests --
- [x] E2E Tests --
- [x] Manual Universal Tests --
- [x] Manual Kubernetes Tests --
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [x] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch)?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
