### PR TITLE
chore(kuma-init): use iptables-legacy in kuma-init

### DIFF
--- a/tools/releases/dockerfiles/Dockerfile.kuma-init
+++ b/tools/releases/dockerfiles/Dockerfile.kuma-init
@@ -22,6 +22,8 @@ COPY /tools/releases/templates/NOTICE-kumactl /kuma/NOTICE
 
 COPY --from=ebpf /mb_* /kuma/ebpf/
 
+RUN update-alternatives --set iptables /usr/sbin/iptables-legacy
+
 RUN adduser --system --disabled-password --group kumactl --uid 5678
 
 ENTRYPOINT ["/usr/bin/kumactl", "install", "transparent-proxy"]


### PR DESCRIPTION
Ubuntu 22.04 comes with iptables 1.8.7 which in default (non legacy) mode appears to sometimes crash (tested on GKE), so we manually set the legacy (non iptables->nftables translation) mode

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] Link to docs PR or issue --
- [x] Link to UI issue or PR --
- [x] Is the [issue worked on linked][1]? --
- [x] The PR does not hardcode values that might break projects that depend on kuma (e.g. "kumahq" as a image registry) --
- [x] The PR will work for both Linux and Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Unit Tests --
- [x] E2E Tests --
- [x] Manual Universal Tests --
- [x] Manual Kubernetes Tests --
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [x] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch)?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
