### PR TITLE
test(e2e): add possibility to pass YAML cp config

### DIFF
--- a/test/framework/interface.go
+++ b/test/framework/interface.go
@@ -50,6 +50,7 @@ type kumaDeploymentOptions struct {
 	cpReplicas                  int
 	hdsDisabled                 bool
 	runPostgresMigration        bool
+	yamlConfig                  string
 
 	// Functions to apply to each mesh after the control plane
 	// is provisioned.
@@ -262,6 +263,12 @@ func WithEnvs(entries map[string]string) KumaDeploymentOption {
 		for k, v := range entries {
 			o.env[k] = v
 		}
+	})
+}
+
+func WithYamlConfig(cfg string) KumaDeploymentOption {
+	return KumaOptionFunc(func(o *kumaDeploymentOptions) {
+		o.yamlConfig = cfg
 	})
 }
 

--- a/test/framework/k8s_cluster.go
+++ b/test/framework/k8s_cluster.go
@@ -374,6 +374,10 @@ func (c *K8sCluster) yamlForKumaViaKubectl(mode string) (string, error) {
 		args = append(args, "--env-var", fmt.Sprintf("%s=%s", k, v))
 	}
 
+	if c.opts.yamlConfig != "" {
+		args = append(args, "--set", fmt.Sprintf("%s%s=%s", Config.HelmSubChartPrefix, "controlPlane.config", c.opts.yamlConfig))
+	}
+
 	return c.controlplane.InstallCP(args...)
 }
 


### PR DESCRIPTION
objects in lists and maps in CP config cannot be configured via env. This Pr adds a possibility to add CP config with YAML file.

### Checklist prior to review

- [X] Link to docs PR or issue --
- [X] Link to UI issue or PR --
- [X] Is the [issue worked on linked][1]? --
- [X] The PR does not hardcode values that might break projects that depend on kuma (e.g. "kumahq" as a image registry) --
- [X] The PR will work for both Linux and Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [X] Unit Tests --
- [X] E2E Tests --
- [X] Manual Universal Tests --
- [X] Manual Kubernetes Tests --
- [X] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [X] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [X] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
