### PR TITLE
feat(kuma-cp): control plane user

### DIFF
--- a/pkg/core/tokens/default_signing_key.go
+++ b/pkg/core/tokens/default_signing_key.go
@@ -9,6 +9,7 @@ import (
 	"github.com/sethvargo/go-retry"
 
 	"github.com/kumahq/kuma/pkg/core/runtime/component"
+	"github.com/kumahq/kuma/pkg/core/user"
 )
 
 type defaultSigningKeyComponent struct {
@@ -26,7 +27,7 @@ func NewDefaultSigningKeyComponent(signingKeyManager SigningKeyManager, log logr
 }
 
 func (d *defaultSigningKeyComponent) Start(stop <-chan struct{}) error {
-	ctx, cancelFn := context.WithCancel(context.Background())
+	ctx, cancelFn := context.WithCancel(user.Ctx(context.Background(), user.ControlPlane))
 	defer cancelFn()
 	errChan := make(chan error)
 	go func() {

--- a/pkg/core/user/user.go
+++ b/pkg/core/user/user.go
@@ -29,3 +29,10 @@ var Anonymous = User{
 	Name:   "mesh-system:anonymous",
 	Groups: []string{"mesh-system:unauthenticated"},
 }
+
+// ControlPlane is a static user that is used whenever the control plane itself executes operations.
+// For example: update of DataplaneInsight, creation of default resources etc.
+var ControlPlane = User{
+	Name:   "mesh-system:control-plane",
+	Groups: []string{},
+}

--- a/pkg/defaults/components.go
+++ b/pkg/defaults/components.go
@@ -17,6 +17,7 @@ import (
 	"github.com/kumahq/kuma/pkg/core/runtime"
 	"github.com/kumahq/kuma/pkg/core/runtime/component"
 	"github.com/kumahq/kuma/pkg/core/tokens"
+	"github.com/kumahq/kuma/pkg/core/user"
 	"github.com/kumahq/kuma/pkg/tokens/builtin/zone"
 	"github.com/kumahq/kuma/pkg/tokens/builtin/zoneingress"
 )
@@ -81,7 +82,7 @@ func (d *defaultsComponent) NeedLeaderElection() bool {
 
 func (d *defaultsComponent) Start(stop <-chan struct{}) error {
 	// todo(jakubdyszkiewicz) once this https://github.com/kumahq/kuma/issues/1001 is done. Wait for all the components to be ready.
-	ctx, cancelFn := context.WithCancel(context.Background())
+	ctx, cancelFn := context.WithCancel(user.Ctx(context.Background(), user.ControlPlane))
 	defer cancelFn()
 	wg := &sync.WaitGroup{}
 	errChan := make(chan error)

--- a/pkg/defaults/envoy_admin_ca.go
+++ b/pkg/defaults/envoy_admin_ca.go
@@ -10,6 +10,7 @@ import (
 	"github.com/kumahq/kuma/pkg/core/resources/manager"
 	"github.com/kumahq/kuma/pkg/core/resources/store"
 	"github.com/kumahq/kuma/pkg/core/runtime/component"
+	"github.com/kumahq/kuma/pkg/core/user"
 	"github.com/kumahq/kuma/pkg/envoy/admin/tls"
 )
 
@@ -20,7 +21,7 @@ type EnvoyAdminCaDefaultComponent struct {
 var _ component.Component = &EnvoyAdminCaDefaultComponent{}
 
 func (e *EnvoyAdminCaDefaultComponent) Start(stop <-chan struct{}) error {
-	ctx, cancelFn := context.WithCancel(context.Background())
+	ctx, cancelFn := context.WithCancel(user.Ctx(context.Background(), user.ControlPlane))
 	go func() {
 		<-stop
 		cancelFn()

--- a/pkg/gc/collector.go
+++ b/pkg/gc/collector.go
@@ -12,6 +12,7 @@ import (
 	"github.com/kumahq/kuma/pkg/core/resources/model"
 	"github.com/kumahq/kuma/pkg/core/resources/store"
 	"github.com/kumahq/kuma/pkg/core/runtime/component"
+	"github.com/kumahq/kuma/pkg/core/user"
 )
 
 var (
@@ -36,7 +37,7 @@ func (d *collector) Start(stop <-chan struct{}) error {
 	ticker := d.newTicker()
 	defer ticker.Stop()
 	gcLog.Info("started")
-	ctx := context.Background()
+	ctx := user.Ctx(context.Background(), user.ControlPlane)
 	for {
 		select {
 		case now := <-ticker.C:

--- a/pkg/hds/components.go
+++ b/pkg/hds/components.go
@@ -10,6 +10,7 @@ import (
 	config_core "github.com/kumahq/kuma/pkg/config/core"
 	"github.com/kumahq/kuma/pkg/core"
 	core_runtime "github.com/kumahq/kuma/pkg/core/runtime"
+	"github.com/kumahq/kuma/pkg/core/user"
 	"github.com/kumahq/kuma/pkg/hds/authn"
 	hds_callbacks "github.com/kumahq/kuma/pkg/hds/callbacks"
 	hds_metrics "github.com/kumahq/kuma/pkg/hds/metrics"
@@ -38,7 +39,7 @@ func Setup(rt core_runtime.Runtime) error {
 		return err
 	}
 
-	srv := hds_server.New(context.Background(), snapshotCache, callbacks)
+	srv := hds_server.New(user.Ctx(context.Background(), user.ControlPlane), snapshotCache, callbacks)
 
 	hdsServerLog.Info("registering Health Discovery Service in Dataplane Server")
 	envoy_service_health.RegisterHealthDiscoveryServiceServer(rt.DpServer().GrpcServer(), srv)

--- a/pkg/hds/tracker/healthcheck_generator.go
+++ b/pkg/hds/tracker/healthcheck_generator.go
@@ -13,6 +13,7 @@ import (
 	"github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	"github.com/kumahq/kuma/pkg/core/resources/manager"
 	"github.com/kumahq/kuma/pkg/core/resources/store"
+	"github.com/kumahq/kuma/pkg/core/user"
 	"github.com/kumahq/kuma/pkg/core/xds"
 	"github.com/kumahq/kuma/pkg/hds/cache"
 	util_proto "github.com/kumahq/kuma/pkg/util/proto"
@@ -39,12 +40,13 @@ func NewSnapshotGenerator(
 }
 
 func (g *SnapshotGenerator) GenerateSnapshot(node *envoy_core.Node) (util_xds_v3.Snapshot, error) {
+	ctx := user.Ctx(context.TODO(), user.ControlPlane)
 	proxyId, err := xds.ParseProxyIdFromString(node.Id)
 	if err != nil {
 		return nil, err
 	}
 	dp := mesh.NewDataplaneResource()
-	if err := g.readOnlyResourceManager.Get(context.Background(), dp, store.GetBy(proxyId.ToResourceKey())); err != nil {
+	if err := g.readOnlyResourceManager.Get(ctx, dp, store.GetBy(proxyId.ToResourceKey())); err != nil {
 		return nil, err
 	}
 

--- a/pkg/kds/global/components.go
+++ b/pkg/kds/global/components.go
@@ -18,6 +18,7 @@ import (
 	"github.com/kumahq/kuma/pkg/core/resources/registry"
 	"github.com/kumahq/kuma/pkg/core/resources/store"
 	"github.com/kumahq/kuma/pkg/core/runtime"
+	"github.com/kumahq/kuma/pkg/core/user"
 	"github.com/kumahq/kuma/pkg/kds/client"
 	"github.com/kumahq/kuma/pkg/kds/mux"
 	kds_server "github.com/kumahq/kuma/pkg/kds/server"
@@ -82,7 +83,8 @@ func Setup(rt runtime.Runtime) (err error) {
 }
 
 func createZoneIfAbsent(name string, resManager manager.ResourceManager) error {
-	if err := resManager.Get(context.Background(), system.NewZoneResource(), store.GetByKey(name, model.NoMesh)); err != nil {
+	ctx := user.Ctx(context.Background(), user.ControlPlane)
+	if err := resManager.Get(ctx, system.NewZoneResource(), store.GetByKey(name, model.NoMesh)); err != nil {
 		if !store.IsResourceNotFound(err) {
 			return err
 		}
@@ -92,7 +94,7 @@ func createZoneIfAbsent(name string, resManager manager.ResourceManager) error {
 				Enabled: util_proto.Bool(true),
 			},
 		}
-		if err := resManager.Create(context.Background(), zone, store.CreateByKey(name, model.NoMesh)); err != nil {
+		if err := resManager.Create(ctx, zone, store.CreateByKey(name, model.NoMesh)); err != nil {
 			return err
 		}
 	}

--- a/pkg/kds/server/status_sink.go
+++ b/pkg/kds/server/status_sink.go
@@ -12,6 +12,7 @@ import (
 	"github.com/kumahq/kuma/pkg/core/resources/manager"
 	core_model "github.com/kumahq/kuma/pkg/core/resources/model"
 	"github.com/kumahq/kuma/pkg/core/resources/store"
+	"github.com/kumahq/kuma/pkg/core/user"
 )
 
 type ZoneInsightSink interface {
@@ -107,7 +108,7 @@ type zoneInsightStore struct {
 }
 
 func (s *zoneInsightStore) Upsert(zone string, subscription *system_proto.KDSSubscription) error {
-	ctx := context.TODO()
+	ctx := user.Ctx(context.TODO(), user.ControlPlane)
 
 	key := core_model.ResourceKey{
 		Name: zone,

--- a/pkg/kds/store/sync.go
+++ b/pkg/kds/store/sync.go
@@ -11,6 +11,7 @@ import (
 	"github.com/kumahq/kuma/pkg/core/resources/model"
 	"github.com/kumahq/kuma/pkg/core/resources/registry"
 	"github.com/kumahq/kuma/pkg/core/resources/store"
+	"github.com/kumahq/kuma/pkg/core/user"
 )
 
 // ResourceSyncer allows to synchronize resources in Store
@@ -67,7 +68,7 @@ func NewResourceSyncer(log logr.Logger, resourceStore store.ResourceStore) Resou
 
 func (s *syncResourceStore) Sync(upstream model.ResourceList, fs ...SyncOptionFunc) error {
 	opts := NewSyncOptions(fs...)
-	ctx := context.Background()
+	ctx := user.Ctx(context.TODO(), user.ControlPlane)
 	log := s.log.WithValues("type", upstream.GetItemType())
 	downstream, err := registry.Global().NewList(upstream.GetItemType())
 	if err != nil {

--- a/pkg/plugins/authn/api-server/tokens/admin_token_bootstrap.go
+++ b/pkg/plugins/authn/api-server/tokens/admin_token_bootstrap.go
@@ -39,7 +39,7 @@ func NewAdminTokenBootstrap(issuer issuer.UserTokenIssuer, resManager manager.Re
 }
 
 func (a *adminTokenBootstrap) Start(stop <-chan struct{}) error {
-	ctx, cancelFn := context.WithCancel(context.Background())
+	ctx, cancelFn := context.WithCancel(user.Ctx(context.Background(), user.ControlPlane))
 	go func() {
 		if err := a.generateTokenIfNotExist(ctx); err != nil {
 			// just log, do not exist control plane

--- a/pkg/plugins/runtime/gateway/filter_chain_generator.go
+++ b/pkg/plugins/runtime/gateway/filter_chain_generator.go
@@ -19,6 +19,7 @@ import (
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	system_proto "github.com/kumahq/kuma/api/system/v1alpha1"
 	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
+	"github.com/kumahq/kuma/pkg/core/user"
 	"github.com/kumahq/kuma/pkg/core/validators"
 	core_xds "github.com/kumahq/kuma/pkg/core/xds"
 	"github.com/kumahq/kuma/pkg/plugins/runtime/gateway/match"
@@ -200,7 +201,7 @@ func (g *HTTPSFilterChainGenerator) generateCertificateSecret(
 	host GatewayHost,
 	secret *system_proto.DataSource,
 ) (*envoy_extensions_transport_sockets_tls_v3.Secret, error) {
-	data, err := ctx.DataSourceLoader.Load(context.Background(), ctx.Resource.GetMeta().GetName(), secret)
+	data, err := ctx.DataSourceLoader.Load(user.Ctx(context.TODO(), user.ControlPlane), ctx.Resource.GetMeta().GetName(), secret)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/plugins/runtime/universal/plugin.go
+++ b/pkg/plugins/runtime/universal/plugin.go
@@ -8,6 +8,7 @@ import (
 	core_plugins "github.com/kumahq/kuma/pkg/core/plugins"
 	core_runtime "github.com/kumahq/kuma/pkg/core/runtime"
 	"github.com/kumahq/kuma/pkg/core/runtime/component"
+	"github.com/kumahq/kuma/pkg/core/user"
 	"github.com/kumahq/kuma/pkg/dns"
 )
 
@@ -53,7 +54,7 @@ func addDNS(rt core_runtime.Runtime) error {
 		defer ticker.Stop()
 
 		dns.Log.Info("starting the DNS VIPs allocator")
-		ctx := context.Background()
+		ctx := user.Ctx(context.Background(), user.ControlPlane)
 		for {
 			select {
 			case <-ticker.C:

--- a/pkg/xds/generator/outbound_proxy_generator.go
+++ b/pkg/xds/generator/outbound_proxy_generator.go
@@ -9,6 +9,7 @@ import (
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	"github.com/kumahq/kuma/pkg/core"
 	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
+	"github.com/kumahq/kuma/pkg/core/user"
 	model "github.com/kumahq/kuma/pkg/core/xds"
 	xds_context "github.com/kumahq/kuma/pkg/xds/context"
 	envoy_common "github.com/kumahq/kuma/pkg/xds/envoy"
@@ -292,7 +293,7 @@ func (OutboundProxyGenerator) generateEDS(
 					endpoints = ctx.Mesh.EndpointMap
 				}
 
-				loadAssignment, err := ctx.ControlPlane.CLACache.GetCLA(context.Background(), ctx.Mesh.Resource.Meta.GetName(), ctx.Mesh.Hash, cluster, apiVersion, endpoints)
+				loadAssignment, err := ctx.ControlPlane.CLACache.GetCLA(user.Ctx(context.TODO(), user.ControlPlane), ctx.Mesh.Resource.Meta.GetName(), ctx.Mesh.Hash, cluster, apiVersion, endpoints)
 				if err != nil {
 					return nil, errors.Wrapf(err, "could not get ClusterLoadAssignment for %s", serviceName)
 				}

--- a/pkg/xds/sync/components.go
+++ b/pkg/xds/sync/components.go
@@ -6,6 +6,7 @@ import (
 	kuma_cp "github.com/kumahq/kuma/pkg/config/app/kuma-cp"
 	"github.com/kumahq/kuma/pkg/core"
 	core_runtime "github.com/kumahq/kuma/pkg/core/runtime"
+	"github.com/kumahq/kuma/pkg/core/user"
 	"github.com/kumahq/kuma/pkg/xds/cache/mesh"
 	xds_context "github.com/kumahq/kuma/pkg/xds/context"
 	"github.com/kumahq/kuma/pkg/xds/envoy"
@@ -75,7 +76,7 @@ func DefaultDataplaneWatchdogFactory(
 	envoyCpCtx *xds_context.ControlPlaneContext,
 	apiVersion envoy.APIVersion,
 ) (DataplaneWatchdogFactory, error) {
-	ctx := context.Background()
+	ctx := user.Ctx(context.Background(), user.ControlPlane)
 	config := rt.Config()
 
 	dataplaneProxyBuilder := DefaultDataplaneProxyBuilder(

--- a/pkg/xds/sync/dataplane_watchdog_factory.go
+++ b/pkg/xds/sync/dataplane_watchdog_factory.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/kumahq/kuma/pkg/core"
 	"github.com/kumahq/kuma/pkg/core/resources/model"
+	"github.com/kumahq/kuma/pkg/core/user"
 	util_watchdog "github.com/kumahq/kuma/pkg/util/watchdog"
 	xds_metrics "github.com/kumahq/kuma/pkg/xds/metrics"
 )
@@ -32,7 +33,7 @@ func NewDataplaneWatchdogFactory(
 func (d *dataplaneWatchdogFactory) New(dpKey model.ResourceKey) util_watchdog.Watchdog {
 	log := xdsServerLog.WithName("dataplane-sync-watchdog").WithValues("dataplaneKey", dpKey)
 	dataplaneWatchdog := NewDataplaneWatchdog(d.deps, dpKey)
-	ctx, cancelFn := context.WithCancel(context.Background())
+	ctx, cancelFn := context.WithCancel(user.Ctx(context.Background(), user.ControlPlane))
 	return &util_watchdog.SimpleWatchdog{
 		NewTicker: func() *time.Ticker {
 			return time.NewTicker(d.refreshInterval)

--- a/pkg/xds/template/proxy_template_resolver.go
+++ b/pkg/xds/template/proxy_template_resolver.go
@@ -10,6 +10,7 @@ import (
 	"github.com/kumahq/kuma/pkg/core/resources/manager"
 	core_model "github.com/kumahq/kuma/pkg/core/resources/model"
 	core_store "github.com/kumahq/kuma/pkg/core/resources/store"
+	"github.com/kumahq/kuma/pkg/core/user"
 	model "github.com/kumahq/kuma/pkg/core/xds"
 )
 
@@ -27,7 +28,7 @@ type SimpleProxyTemplateResolver struct {
 
 func (r *SimpleProxyTemplateResolver) GetTemplate(proxy *model.Proxy) *mesh_proto.ProxyTemplate {
 	log := templateResolverLog.WithValues("dataplane", core_model.MetaToResourceKey(proxy.Dataplane.Meta))
-	ctx := context.Background()
+	ctx := user.Ctx(context.Background(), user.ControlPlane)
 	templateList := &core_mesh.ProxyTemplateResourceList{}
 	if err := r.ReadOnlyResourceManager.List(ctx, templateList, core_store.ListByMesh(proxy.Dataplane.Meta.GetMesh())); err != nil {
 		templateResolverLog.Error(err, "failed to list ProxyTemplates")


### PR DESCRIPTION
Add implicit Control Plane user to background contexts, so we can later retrieve this information in components.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [X] Link to docs PR or issue -- no docs change
- [X] Link to UI issue or PR -- no UI change
- [X] Is the [issue worked on linked][1]? -- no issue reported
- [X] The PR does not hardcode values that might break projects that depend on kuma (e.g. "kumahq" as a image registry) --
- [X] The PR will work for both Linux and Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [ ] Unit Tests --
- [ ] E2E Tests --
- [ ] Manual Universal Tests --
- [ ] Manual Kubernetes Tests --
- [X] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? -- no
- [X] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? -- no
- [X] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
