### PR TITLE
fix(kuma-cp): deep copy tags when gen. outbounds

### DIFF
--- a/pkg/xds/sync/proxy_builder_test.go
+++ b/pkg/xds/sync/proxy_builder_test.go
@@ -138,7 +138,6 @@ var _ = Describe("Proxy Builder", func() {
 						{
 							Tags: map[string]string{
 								mesh_proto.ServiceTag: "service-in-zone-2",
-								"mesh":                "default",
 							},
 							Instances: 1,
 							Mesh:      "default",
@@ -147,7 +146,6 @@ var _ = Describe("Proxy Builder", func() {
 							Tags: map[string]string{
 								mesh_proto.ServiceTag: "external-service-in-zone-2",
 								mesh_proto.ZoneTag:    "zone-2",
-								"mesh":                "default",
 							},
 							Instances:       1,
 							Mesh:            "default",
@@ -168,7 +166,6 @@ var _ = Describe("Proxy Builder", func() {
 						{
 							Tags: map[string]string{
 								mesh_proto.ServiceTag: "service-in-zone-2",
-								"mesh":                "default",
 							},
 							Instances: 1,
 							Mesh:      "default",
@@ -177,7 +174,6 @@ var _ = Describe("Proxy Builder", func() {
 							Tags: map[string]string{
 								mesh_proto.ServiceTag: "external-service-in-zone-2",
 								mesh_proto.ZoneTag:    "zone-2",
-								"mesh":                "default",
 							},
 							Instances:       1,
 							Mesh:            "default",

--- a/pkg/xds/topology/outbound.go
+++ b/pkg/xds/topology/outbound.go
@@ -134,7 +134,7 @@ func fillDataplaneOutbounds(
 		dpNetworking := dpSpec.GetNetworking()
 
 		for _, inbound := range dpNetworking.GetHealthyInbounds() {
-			inboundTags := inbound.GetTags()
+			inboundTags := cloneTags(inbound.GetTags())
 			serviceName := inboundTags[mesh_proto.ServiceTag]
 			inboundInterface := dpNetworking.ToInboundInterface(inbound)
 			inboundAddress := inboundInterface.DataplaneAdvertisedIP
@@ -321,7 +321,8 @@ func fillIngressOutbounds(
 				continue
 			}
 
-			serviceTags := service.GetTags()
+			// deep copy map to not modify tags in BuildRemoteEndpointMap
+			serviceTags := cloneTags(service.GetTags())
 			serviceName := serviceTags[mesh_proto.ServiceTag]
 			serviceInstances := service.GetInstances()
 			locality := localityFromTags(mesh, priorityRemote, serviceTags)
@@ -348,7 +349,7 @@ func fillIngressOutbounds(
 					}
 					// this is necessary for correct spiffe generation for dp when
 					// traffic is routed: egress -> ingress -> egress
-					if mesh.ZoneEgressEnabled() && service.ExternalService {
+					if service.ExternalService {
 						endpoint.ExternalService = &core_xds.ExternalService{}
 					}
 
@@ -426,10 +427,8 @@ func fillExternalServicesOutboundsThroughEgress(
 	mesh *core_mesh.MeshResource,
 ) {
 	for _, externalService := range externalServices {
-		serviceTags := map[string]string{}
-		for tag, value := range externalService.Spec.GetTags() { // deep copy map to not modify tags in ExternalService.
-			serviceTags[tag] = value
-		}
+		// deep copy map to not modify tags in ExternalService.
+		serviceTags := cloneTags(externalService.Spec.GetTags())
 		serviceName := serviceTags[mesh_proto.ServiceTag]
 		locality := localityFromTags(mesh, priorityRemote, serviceTags)
 
@@ -465,10 +464,8 @@ func NewExternalServiceEndpoint(
 	spec := externalService.Spec
 	tls := spec.GetNetworking().GetTls()
 	meshName := mesh.GetMeta().GetName()
-	tags := map[string]string{}
-	for tag, value := range spec.GetTags() { // deep copy map to not modify tags in ExternalService.
-		tags[tag] = value
-	}
+	// deep copy map to not modify tags in ExternalService.
+	tags := cloneTags(spec.GetTags())
 
 	caCert, err := loadBytes(ctx, tls.GetCaCert(), meshName, loader)
 	if err != nil {
@@ -512,6 +509,14 @@ func NewExternalServiceEndpoint(
 		ExternalService: es,
 		Locality:        localityFromTags(mesh, priority, tags),
 	}, nil
+}
+
+func cloneTags(tags map[string]string) map[string]string {
+	result := map[string]string{}
+	for tag, value := range tags {
+		result[tag] = value
+	}
+	return result
 }
 
 func loadBytes(ctx context.Context, ds *v1alpha1.DataSource, mesh string, loader datasource.Loader) ([]byte, error) {


### PR DESCRIPTION
It fixes potential data race (iterating and writing to tags map)

We are adding tag `mesh` during [building remote endpoint map](https://github.com/kumahq/kuma/blob/b9819c1c5b33b3ea64f854053bf8a476cf744d7a/pkg/xds/topology/outbound.go#L66) which is done after [building ingress outbounds](https://github.com/kumahq/kuma/blob/b9819c1c5b33b3ea64f854053bf8a476cf744d7a/pkg/xds/topology/outbound.go#L54), so the tests were valid only by having reference for map with tags inside ingress resources, which was also pointing to the same map inside endpoint map.

xref: https://github.com/kumahq/kuma/pull/4591

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] Link to docs PR or issue --
- [x] Link to UI issue or PR --
- [x] Is the [issue worked on linked][1]? --
- [x] The PR does not hardcode values that might break projects that depend on kuma (e.g. "kumahq" as a image registry) --
- [x] The PR will work for both Linux and Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Unit Tests --
- [x] E2E Tests --
- [x] Manual Universal Tests --
- [x] Manual Kubernetes Tests --
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [x] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
