### PR TITLE
feat(kuma-cp): extensible token issuers

### DIFF
--- a/pkg/core/bootstrap/bootstrap.go
+++ b/pkg/core/bootstrap/bootstrap.go
@@ -44,6 +44,7 @@ import (
 	kds_context "github.com/kumahq/kuma/pkg/kds/context"
 	"github.com/kumahq/kuma/pkg/metrics"
 	metrics_store "github.com/kumahq/kuma/pkg/metrics/store"
+	"github.com/kumahq/kuma/pkg/tokens/builtin"
 	tokens_access "github.com/kumahq/kuma/pkg/tokens/builtin/access"
 	zone_access "github.com/kumahq/kuma/pkg/tokens/builtin/zone/access"
 	xds_auth_components "github.com/kumahq/kuma/pkg/xds/auth/components"
@@ -155,6 +156,12 @@ func buildRuntime(appCtx context.Context, cfg kuma_cp.Config) (core_runtime.Runt
 	if err := initializeAPIServerAuthenticator(builder); err != nil {
 		return nil, err
 	}
+
+	builder.WithTokenIssuers(builtin.TokenIssuers{
+		DataplaneToken:   builtin.NewDataplaneTokenIssuer(builder.ResourceManager()),
+		ZoneIngressToken: builtin.NewZoneIngressTokenIssuer(builder.ResourceManager()),
+		ZoneToken:        builtin.NewZoneTokenIssuer(builder.ResourceManager()),
+	})
 
 	for _, plugin := range core_plugins.Plugins().BootstrapPlugins() {
 		if err := plugin.AfterBootstrap(builder, cfg); err != nil {

--- a/pkg/core/runtime/builder.go
+++ b/pkg/core/runtime/builder.go
@@ -25,6 +25,7 @@ import (
 	"github.com/kumahq/kuma/pkg/events"
 	kds_context "github.com/kumahq/kuma/pkg/kds/context"
 	"github.com/kumahq/kuma/pkg/metrics"
+	"github.com/kumahq/kuma/pkg/tokens/builtin"
 	util_xds "github.com/kumahq/kuma/pkg/util/xds"
 	xds_auth "github.com/kumahq/kuma/pkg/xds/auth"
 	xds_hooks "github.com/kumahq/kuma/pkg/xds/hooks"
@@ -53,6 +54,7 @@ type BuilderContext interface {
 	KDSContext() *kds_context.Context
 	APIServerAuthenticator() authn.Authenticator
 	Access() Access
+	TokenIssuers() builtin.TokenIssuers
 }
 
 var _ BuilderContext = &Builder{}
@@ -87,6 +89,7 @@ type Builder struct {
 	acc            Access
 	appCtx         context.Context
 	extraReportsFn ExtraReportsFn
+	tokenIssuers   builtin.TokenIssuers
 	*runtimeInfo
 }
 
@@ -248,6 +251,11 @@ func (b *Builder) WithExtraReportsFn(fn ExtraReportsFn) *Builder {
 	return b
 }
 
+func (b *Builder) WithTokenIssuers(tokenIssuers builtin.TokenIssuers) *Builder {
+	b.tokenIssuers = tokenIssuers
+	return b
+}
+
 func (b *Builder) Build() (Runtime, error) {
 	if b.cm == nil {
 		return nil, errors.Errorf("ComponentManager has not been configured")
@@ -306,6 +314,9 @@ func (b *Builder) Build() (Runtime, error) {
 	if b.acc == (Access{}) {
 		return nil, errors.Errorf("Access has not been configured")
 	}
+	if b.tokenIssuers == (builtin.TokenIssuers{}) {
+		return nil, errors.Errorf("TokenIssuers has not been configured")
+	}
 	return &runtime{
 		RuntimeInfo: b.runtimeInfo,
 		RuntimeContext: &runtimeContext{
@@ -335,6 +346,7 @@ func (b *Builder) Build() (Runtime, error) {
 			acc:            b.acc,
 			appCtx:         b.appCtx,
 			extraReportsFn: b.extraReportsFn,
+			tokenIssuers:   b.tokenIssuers,
 		},
 		Manager: b.cm,
 	}, nil
@@ -417,4 +429,7 @@ func (b *Builder) AppCtx() context.Context {
 }
 func (b *Builder) ExtraReportsFn() ExtraReportsFn {
 	return b.extraReportsFn
+}
+func (b *Builder) TokenIssuers() builtin.TokenIssuers {
+	return b.tokenIssuers
 }

--- a/pkg/core/runtime/builder.go
+++ b/pkg/core/runtime/builder.go
@@ -433,3 +433,6 @@ func (b *Builder) ExtraReportsFn() ExtraReportsFn {
 func (b *Builder) TokenIssuers() builtin.TokenIssuers {
 	return b.tokenIssuers
 }
+func (b *Builder) EnvoyAdminClient() admin.EnvoyAdminClient {
+	return b.eac
+}

--- a/pkg/core/runtime/runtime.go
+++ b/pkg/core/runtime/runtime.go
@@ -25,6 +25,7 @@ import (
 	"github.com/kumahq/kuma/pkg/events"
 	kds_context "github.com/kumahq/kuma/pkg/kds/context"
 	"github.com/kumahq/kuma/pkg/metrics"
+	"github.com/kumahq/kuma/pkg/tokens/builtin"
 	tokens_access "github.com/kumahq/kuma/pkg/tokens/builtin/access"
 	zone_access "github.com/kumahq/kuma/pkg/tokens/builtin/zone/access"
 	util_xds "github.com/kumahq/kuma/pkg/util/xds"
@@ -78,6 +79,7 @@ type RuntimeContext interface {
 	// AppContext returns a context.Context which tracks the lifetime of the apps, it gets cancelled when the app is starting to shutdown.
 	AppContext() context.Context
 	ExtraReportsFn() ExtraReportsFn
+	TokenIssuers() builtin.TokenIssuers
 }
 
 type Access struct {
@@ -162,6 +164,7 @@ type runtimeContext struct {
 	acc            Access
 	appCtx         context.Context
 	extraReportsFn ExtraReportsFn
+	tokenIssuers   builtin.TokenIssuers
 }
 
 func (rc *runtimeContext) Metrics() metrics.Metrics {
@@ -269,4 +272,8 @@ func (rc *runtimeContext) AppContext() context.Context {
 
 func (rc *runtimeContext) ExtraReportsFn() ExtraReportsFn {
 	return rc.extraReportsFn
+}
+
+func (rc *runtimeContext) TokenIssuers() builtin.TokenIssuers {
+	return rc.tokenIssuers
 }

--- a/pkg/plugins/authn/api-server/tokens/issuer/issuer.go
+++ b/pkg/plugins/authn/api-server/tokens/issuer/issuer.go
@@ -25,7 +25,7 @@ func NewUserTokenIssuer(issuer tokens.Issuer) UserTokenIssuer {
 var _ UserTokenIssuer = &jwtTokenIssuer{}
 
 func (j *jwtTokenIssuer) Generate(ctx context.Context, identity user.User, validFor time.Duration) (tokens.Token, error) {
-	c := userClaims{
+	c := UserClaims{
 		User: identity,
 	}
 	return j.issuer.Generate(ctx, &c, validFor)

--- a/pkg/plugins/authn/api-server/tokens/issuer/token.go
+++ b/pkg/plugins/authn/api-server/tokens/issuer/token.go
@@ -17,21 +17,21 @@ var UserTokenRevocationsGlobalSecretKey = core_model.ResourceKey{
 	Mesh: core_model.NoMesh,
 }
 
-type userClaims struct {
+type UserClaims struct {
 	user.User
 	jwt.RegisteredClaims
 }
 
-var _ tokens.Claims = &userClaims{}
+var _ tokens.Claims = &UserClaims{}
 
-func (c *userClaims) ID() string {
+func (c *UserClaims) ID() string {
 	return c.RegisteredClaims.ID
 }
 
-func (c *userClaims) KeyIDFallback() (int, error) {
+func (c *UserClaims) KeyIDFallback() (int, error) {
 	return 0, errors.New("kid is required") // kid was required when we introduced User Token
 }
 
-func (c *userClaims) SetRegisteredClaims(claims jwt.RegisteredClaims) {
+func (c *UserClaims) SetRegisteredClaims(claims jwt.RegisteredClaims) {
 	c.RegisteredClaims = claims
 }

--- a/pkg/plugins/authn/api-server/tokens/issuer/validator.go
+++ b/pkg/plugins/authn/api-server/tokens/issuer/validator.go
@@ -22,7 +22,7 @@ type jwtTokenValidator struct {
 }
 
 func (j *jwtTokenValidator) Validate(ctx context.Context, rawToken tokens.Token) (user.User, error) {
-	claims := &userClaims{}
+	claims := &UserClaims{}
 	if err := j.validator.ParseWithValidation(ctx, rawToken, claims); err != nil {
 		return user.User{}, err
 	}

--- a/pkg/plugins/authn/api-server/tokens/plugin.go
+++ b/pkg/plugins/authn/api-server/tokens/plugin.go
@@ -27,6 +27,10 @@ var AccessStrategies = map[string]func(*plugins.MutablePluginContext) access.Gen
 	},
 }
 
+var NewUserTokenIssuer = func(signingKeyManager core_tokens.SigningKeyManager) issuer.UserTokenIssuer {
+	return issuer.NewUserTokenIssuer(core_tokens.NewTokenIssuer(signingKeyManager))
+}
+
 func init() {
 	plugins.Register(PluginName, &plugin{})
 }
@@ -56,7 +60,7 @@ func (c plugin) AfterBootstrap(context *plugins.MutablePluginContext, config plu
 	if !ok {
 		return errors.Errorf("no Access strategy for type %q", context.Config().Access.Type)
 	}
-	tokenIssuer := issuer.NewUserTokenIssuer(core_tokens.NewTokenIssuer(signingKeyManager))
+	tokenIssuer := NewUserTokenIssuer(signingKeyManager)
 	if context.Config().ApiServer.Authn.Tokens.BootstrapAdminToken {
 		if err := context.ComponentManager().Add(NewAdminTokenBootstrap(tokenIssuer, context.ResourceManager(), context.Config())); err != nil {
 			return err
@@ -72,5 +76,5 @@ func (c plugin) Name() plugins.PluginName {
 }
 
 func (c plugin) Order() int {
-	return plugins.EnvironmentPreparedOrder
+	return plugins.EnvironmentPreparedOrder + 1
 }

--- a/pkg/test/runtime/runtime.go
+++ b/pkg/test/runtime/runtime.go
@@ -33,6 +33,7 @@ import (
 	"github.com/kumahq/kuma/pkg/plugins/ca/builtin"
 	leader_memory "github.com/kumahq/kuma/pkg/plugins/leader/memory"
 	resources_memory "github.com/kumahq/kuma/pkg/plugins/resources/memory"
+	tokens_builtin "github.com/kumahq/kuma/pkg/tokens/builtin"
 	tokens_access "github.com/kumahq/kuma/pkg/tokens/builtin/access"
 	xds_hooks "github.com/kumahq/kuma/pkg/xds/hooks"
 	"github.com/kumahq/kuma/pkg/xds/secrets"
@@ -105,6 +106,11 @@ func BuilderFor(appCtx context.Context, cfg kuma_cp.Config) (*core_runtime.Build
 	builder.WithAccess(core_runtime.Access{
 		ResourceAccess:       resources_access.NewAdminResourceAccess(builder.Config().Access.Static.AdminResources),
 		DataplaneTokenAccess: tokens_access.NewStaticGenerateDataplaneTokenAccess(builder.Config().Access.Static.GenerateDPToken),
+	})
+	builder.WithTokenIssuers(tokens_builtin.TokenIssuers{
+		DataplaneToken:   tokens_builtin.NewDataplaneTokenIssuer(builder.ResourceManager()),
+		ZoneIngressToken: tokens_builtin.NewZoneIngressTokenIssuer(builder.ResourceManager()),
+		ZoneToken:        tokens_builtin.NewZoneTokenIssuer(builder.ResourceManager()),
 	})
 
 	initializeConfigManager(builder)

--- a/pkg/tokens/builtin/issuers.go
+++ b/pkg/tokens/builtin/issuers.go
@@ -1,0 +1,13 @@
+package builtin
+
+import (
+	"github.com/kumahq/kuma/pkg/tokens/builtin/issuer"
+	"github.com/kumahq/kuma/pkg/tokens/builtin/zone"
+	"github.com/kumahq/kuma/pkg/tokens/builtin/zoneingress"
+)
+
+type TokenIssuers struct {
+	DataplaneToken   issuer.DataplaneTokenIssuer
+	ZoneIngressToken zoneingress.TokenIssuer
+	ZoneToken        zone.TokenIssuer
+}

--- a/pkg/tokens/builtin/zone/issuer.go
+++ b/pkg/tokens/builtin/zone/issuer.go
@@ -33,7 +33,7 @@ type jwtTokenIssuer struct {
 }
 
 func (j *jwtTokenIssuer) Generate(ctx context.Context, identity Identity, validFor time.Duration) (Token, error) {
-	claims := &zoneClaims{
+	claims := &ZoneClaims{
 		Zone:  identity.Zone,
 		Scope: identity.Scope,
 	}

--- a/pkg/tokens/builtin/zone/token.go
+++ b/pkg/tokens/builtin/zone/token.go
@@ -16,22 +16,22 @@ var TokenRevocationsGlobalSecretKey = core_model.ResourceKey{
 	Mesh: core_model.NoMesh,
 }
 
-type zoneClaims struct {
+type ZoneClaims struct {
 	Zone  string
 	Scope []string
 	jwt.RegisteredClaims
 }
 
-var _ core_tokens.Claims = &zoneClaims{}
+var _ core_tokens.Claims = &ZoneClaims{}
 
-func (c *zoneClaims) ID() string {
+func (c *ZoneClaims) ID() string {
 	return c.RegisteredClaims.ID
 }
 
-func (c *zoneClaims) KeyIDFallback() (int, error) {
+func (c *ZoneClaims) KeyIDFallback() (int, error) {
 	return 0, errors.New("missing Key ID")
 }
 
-func (c *zoneClaims) SetRegisteredClaims(claims jwt.RegisteredClaims) {
+func (c *ZoneClaims) SetRegisteredClaims(claims jwt.RegisteredClaims) {
 	c.RegisteredClaims = claims
 }

--- a/pkg/tokens/builtin/zone/validator.go
+++ b/pkg/tokens/builtin/zone/validator.go
@@ -23,7 +23,7 @@ func NewValidator(validator core_tokens.Validator) Validator {
 }
 
 func (j *jwtValidator) Validate(ctx context.Context, token Token) (Identity, error) {
-	claims := &zoneClaims{}
+	claims := &ZoneClaims{}
 
 	if err := j.validator.ParseWithValidation(ctx, token, claims); err != nil {
 		return Identity{}, err

--- a/pkg/tokens/builtin/zoneingress/issuer.go
+++ b/pkg/tokens/builtin/zoneingress/issuer.go
@@ -33,7 +33,7 @@ type jwtTokenIssuer struct {
 }
 
 func (j *jwtTokenIssuer) Generate(ctx context.Context, identity Identity, validFor time.Duration) (Token, error) {
-	claims := &zoneIngressClaims{
+	claims := &ZoneIngressClaims{
 		Zone: identity.Zone,
 	}
 	return j.issuer.Generate(ctx, claims, validFor)

--- a/pkg/tokens/builtin/zoneingress/token.go
+++ b/pkg/tokens/builtin/zoneingress/token.go
@@ -14,21 +14,21 @@ var ZoneIngressTokenRevocationsGlobalSecretKey = core_model.ResourceKey{
 	Mesh: core_model.NoMesh,
 }
 
-type zoneIngressClaims struct {
+type ZoneIngressClaims struct {
 	Zone string
 	jwt.RegisteredClaims
 }
 
-var _ core_tokens.Claims = &zoneIngressClaims{}
+var _ core_tokens.Claims = &ZoneIngressClaims{}
 
-func (c *zoneIngressClaims) ID() string {
+func (c *ZoneIngressClaims) ID() string {
 	return c.RegisteredClaims.ID
 }
 
-func (c *zoneIngressClaims) KeyIDFallback() (int, error) {
+func (c *ZoneIngressClaims) KeyIDFallback() (int, error) {
 	return 0, nil
 }
 
-func (c *zoneIngressClaims) SetRegisteredClaims(claims jwt.RegisteredClaims) {
+func (c *ZoneIngressClaims) SetRegisteredClaims(claims jwt.RegisteredClaims) {
 	c.RegisteredClaims = claims
 }

--- a/pkg/tokens/builtin/zoneingress/validator.go
+++ b/pkg/tokens/builtin/zoneingress/validator.go
@@ -23,7 +23,7 @@ func NewValidator(validator core_tokens.Validator) Validator {
 }
 
 func (j *jwtValidator) Validate(ctx context.Context, token Token) (Identity, error) {
-	claims := &zoneIngressClaims{}
+	claims := &ZoneIngressClaims{}
 	if err := j.validator.ParseWithValidation(ctx, token, claims); err != nil {
 		return Identity{}, err
 	}


### PR DESCRIPTION
Open Issuers to extensions so they can be overridden in projects that are based on Kuma.
Also, expose Claims of tokens.

### Checklist prior to review

- [X] Link to docs PR or issue --
- [X] Link to UI issue or PR --
- [X] Is the [issue worked on linked][1]? --
- [X] The PR does not hardcode values that might break projects that depend on kuma (e.g. "kumahq" as a image registry) --
- [X] The PR will work for both Linux and Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [X] Unit Tests --
- [X] E2E Tests --
- [X] Manual Universal Tests --
- [X] Manual Kubernetes Tests --
- [X] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [X] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [X] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
