### PR TITLE
feat: add MeshGateway support to MeshAccessLog

### DIFF
--- a/pkg/plugins/policies/meshaccesslog/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshaccesslog/plugin/v1alpha1/plugin_test.go
@@ -13,30 +13,40 @@ import (
 	core_xds "github.com/kumahq/kuma/pkg/core/xds"
 	api "github.com/kumahq/kuma/pkg/plugins/policies/meshaccesslog/api/v1alpha1"
 	plugin "github.com/kumahq/kuma/pkg/plugins/policies/meshaccesslog/plugin/v1alpha1"
+	"github.com/kumahq/kuma/pkg/plugins/runtime/gateway"
 	test_model "github.com/kumahq/kuma/pkg/test/resources/model"
 	util_proto "github.com/kumahq/kuma/pkg/util/proto"
 	xds_context "github.com/kumahq/kuma/pkg/xds/context"
 	envoy_common "github.com/kumahq/kuma/pkg/xds/envoy"
 	. "github.com/kumahq/kuma/pkg/xds/envoy/listeners"
+	envoy_names "github.com/kumahq/kuma/pkg/xds/envoy/names"
 	"github.com/kumahq/kuma/pkg/xds/generator"
 )
 
 var _ = Describe("MeshAccessLog", func() {
-	type testCase struct {
+	type sidecarTestCase struct {
 		resources         []core_xds.Resource
 		toRules           core_xds.ToRules
 		fromRules         core_xds.FromRules
 		expectedListeners []string
 	}
 	DescribeTable("should generate proper Envoy config",
-		func(given testCase) {
-			resources := core_xds.NewResourceSet()
+		func(given sidecarTestCase) {
+			resourceSet := core_xds.NewResourceSet()
 			for _, res := range given.resources {
 				r := res
-				resources.Add(&r)
+				resourceSet.Add(&r)
 			}
 
-			context := xds_context.Context{}
+			context := xds_context.Context{
+				Mesh: xds_context.MeshContext{
+					Resource: &core_mesh.MeshResource{
+						Meta: &test_model.ResourceMeta{
+							Name: "default",
+						},
+					},
+				},
+			}
 			proxy := xds.Proxy{
 				Dataplane: &core_mesh.DataplaneResource{
 					Meta: &test_model.ResourceMeta{
@@ -78,16 +88,16 @@ var _ = Describe("MeshAccessLog", func() {
 			}
 			plugin := plugin.NewPlugin().(core_plugins.PolicyPlugin)
 
-			Expect(plugin.Apply(resources, context, &proxy)).To(Succeed())
+			Expect(plugin.Apply(resourceSet, context, &proxy)).To(Succeed())
 
-			for i, r := range resources.ListOf(envoy_resource.ListenerType) {
+			for i, r := range resourceSet.ListOf(envoy_resource.ListenerType) {
 				actual, err := util_proto.ToYAML(r.Resource)
 				Expect(err).ToNot(HaveOccurred())
 
 				Expect(actual).To(MatchYAML(given.expectedListeners[i]))
 			}
 		},
-		Entry("basic outbound route", testCase{
+		Entry("basic outbound route", sidecarTestCase{
 			resources: []core_xds.Resource{{
 				Name:   "outbound",
 				Origin: generator.OriginOutbound,
@@ -116,7 +126,7 @@ var _ = Describe("MeshAccessLog", func() {
 			toRules: core_xds.ToRules{
 				Rules: []*core_xds.Rule{
 					{
-						Subset: []core_xds.Tag{},
+						Subset: core_xds.Subset{},
 						Conf: &api.MeshAccessLog_Conf{
 							Backends: []*api.MeshAccessLog_Backend{{
 								File: &api.MeshAccessLog_FileBackend{
@@ -173,7 +183,7 @@ var _ = Describe("MeshAccessLog", func() {
             name: outbound:127.0.0.1:27777
             trafficDirection: OUTBOUND`,
 			}}),
-		Entry("basic outbound tcp", testCase{
+		Entry("basic outbound tcp", sidecarTestCase{
 			resources: []core_xds.Resource{{
 				Name:   "outbound",
 				Origin: generator.OriginOutbound,
@@ -192,7 +202,7 @@ var _ = Describe("MeshAccessLog", func() {
 			toRules: core_xds.ToRules{
 				Rules: []*core_xds.Rule{
 					{
-						Subset: []core_xds.Tag{},
+						Subset: core_xds.Subset{},
 						Conf: &api.MeshAccessLog_Conf{
 							Backends: []*api.MeshAccessLog_Backend{{
 								File: &api.MeshAccessLog_FileBackend{
@@ -229,7 +239,7 @@ var _ = Describe("MeshAccessLog", func() {
             name: outbound:127.0.0.1:27777
             trafficDirection: OUTBOUND`,
 			}}),
-		Entry("basic outbound route without match", testCase{
+		Entry("basic outbound route without match", sidecarTestCase{
 			resources: []core_xds.Resource{{
 				Name:   "outbound",
 				Origin: generator.OriginOutbound,
@@ -260,7 +270,7 @@ var _ = Describe("MeshAccessLog", func() {
 			toRules: core_xds.ToRules{
 				Rules: []*core_xds.Rule{
 					{
-						Subset: []core_xds.Tag{{
+						Subset: core_xds.Subset{{
 							Key:   mesh_proto.ServiceTag,
 							Value: "other",
 						}},
@@ -311,7 +321,7 @@ var _ = Describe("MeshAccessLog", func() {
             name: outbound:127.0.0.1:27777
             trafficDirection: OUTBOUND`,
 			}}),
-		Entry("basic inbound route", testCase{
+		Entry("basic inbound route", sidecarTestCase{
 			resources: []core_xds.Resource{{
 				Name:   "inbound",
 				Origin: generator.OriginInbound,
@@ -337,7 +347,7 @@ var _ = Describe("MeshAccessLog", func() {
 			fromRules: core_xds.FromRules{
 				Rules: map[xds.InboundListener]xds.Rules{
 					{Address: "127.0.0.1", Port: 17777}: {{
-						Subset: []core_xds.Tag{},
+						Subset: core_xds.Subset{},
 						Conf: &api.MeshAccessLog_Conf{
 							Backends: []*api.MeshAccessLog_Backend{{
 								File: &api.MeshAccessLog_FileBackend{
@@ -391,6 +401,159 @@ var _ = Describe("MeshAccessLog", func() {
                           timeout: 0s
                   statPrefix: "127_0_0_1_17777"
             name: inbound:127.0.0.1:17777
+            trafficDirection: INBOUND`,
+			}}),
+	)
+	type gatewayTestCase struct {
+		resources         []core_xds.Resource
+		toRules           core_xds.ToRules
+		expectedListeners []string
+	}
+	DescribeTable("should generate proper Envoy config for MeshGateway Dataplanes",
+		func(given gatewayTestCase) {
+			resourceSet := core_xds.NewResourceSet()
+			for _, res := range given.resources {
+				r := res
+				resourceSet.Add(&r)
+			}
+
+			gateways := core_mesh.MeshGatewayResourceList{
+				Items: []*core_mesh.MeshGatewayResource{{
+					Meta: &test_model.ResourceMeta{Name: "gateway", Mesh: "default"},
+					Spec: &mesh_proto.MeshGateway{
+						Selectors: []*mesh_proto.Selector{{
+							Match: map[string]string{
+								mesh_proto.ServiceTag: "gateway",
+							}},
+						},
+						Conf: &mesh_proto.MeshGateway_Conf{
+							Listeners: []*mesh_proto.MeshGateway_Listener{
+								{
+									Protocol: mesh_proto.MeshGateway_Listener_HTTP,
+									Port:     8080,
+								},
+							},
+						},
+					},
+				}},
+			}
+			resources := xds_context.NewResources()
+			resources.MeshLocalResources[core_mesh.MeshGatewayType] = &gateways
+
+			context := xds_context.Context{
+				Mesh: xds_context.MeshContext{
+					Resource: &core_mesh.MeshResource{
+						Meta: &test_model.ResourceMeta{
+							Name: "default",
+						},
+					},
+					Resources: resources,
+				},
+			}
+			proxy := xds.Proxy{
+				Dataplane: &core_mesh.DataplaneResource{
+					Meta: &test_model.ResourceMeta{
+						Mesh: "default",
+						Name: "gateway",
+					},
+					Spec: &mesh_proto.Dataplane{
+						Networking: &mesh_proto.Dataplane_Networking{
+							Address: "127.0.0.1",
+							Gateway: &mesh_proto.Dataplane_Networking_Gateway{
+								Tags: map[string]string{
+									mesh_proto.ServiceTag: "gateway",
+								},
+								Type: mesh_proto.Dataplane_Networking_Gateway_BUILTIN,
+							},
+						},
+					},
+				},
+				Policies: xds.MatchedPolicies{
+					Dynamic: map[core_model.ResourceType]xds.TypedMatchingPolicies{
+						api.MeshAccessLogType: {
+							Type:    api.MeshAccessLogType,
+							ToRules: given.toRules,
+						},
+					},
+				},
+			}
+			plugin := plugin.NewPlugin().(core_plugins.PolicyPlugin)
+
+			Expect(plugin.Apply(resourceSet, context, &proxy)).To(Succeed())
+
+			for i, r := range resourceSet.ListOf(envoy_resource.ListenerType) {
+				actual, err := util_proto.ToYAML(r.Resource)
+				Expect(err).ToNot(HaveOccurred())
+
+				Expect(actual).To(MatchYAML(given.expectedListeners[i]))
+			}
+		},
+		Entry("basic gateway", gatewayTestCase{
+			resources: []core_xds.Resource{{
+				Name:   "gateway",
+				Origin: gateway.OriginGateway,
+				Resource: NewListenerBuilder(envoy_common.APIV3).
+					Configure(
+						InboundListener(
+							envoy_names.GetGatewayListenerName("gateway", "HTTP", 8080), "127.0.0.1", 8080, xds.SocketAddressProtocolTCP,
+						),
+						EnableReusePort(true),
+						TLSInspector(),
+						FilterChain(
+							NewFilterChainBuilder(envoy_common.APIV3).Configure(
+								HttpConnectionManager("gateway", false),
+								ServerHeader("Kuma Gateway"),
+							),
+						),
+					).MustBuild(),
+			}},
+			toRules: core_xds.ToRules{
+				Rules: []*core_xds.Rule{
+					{
+						Subset: core_xds.Subset{},
+						Conf: &api.MeshAccessLog_Conf{
+							Backends: []*api.MeshAccessLog_Backend{{
+								File: &api.MeshAccessLog_FileBackend{
+									Format: &api.MeshAccessLog_Format{
+										Plain: "",
+									},
+									Path: "/tmp/log",
+								},
+							}},
+						},
+					},
+				}},
+			expectedListeners: []string{`
+            address:
+              socketAddress:
+                address: 127.0.0.1
+                portValue: 8080
+            enableReusePort: true
+            filterChains:
+            - filters:
+              - name: envoy.filters.network.http_connection_manager
+                typedConfig:
+                  '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+                  httpFilters:
+                  - name: envoy.filters.http.router
+                    typedConfig:
+                      '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+                  serverName: Kuma Gateway
+                  statPrefix: gateway
+                  accessLog:
+                  - name: envoy.access_loggers.file
+                    typedConfig:
+                      '@type': type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog
+                      logFormat:
+                          textFormatSource:
+                              inlineString: |
+                                [%START_TIME%] default "%REQ(:method)% %REQ(x-envoy-original-path?:path)% %PROTOCOL%" %RESPONSE_CODE% %RESPONSE_FLAGS% %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(x-envoy-upstream-service-time)% "%REQ(x-forwarded-for)%" "%REQ(user-agent)%" "%REQ(x-b3-traceid?x-datadog-traceid)%" "%REQ(x-request-id)%" "%REQ(:authority)%" "gateway" "*" "127.0.0.1" "%UPSTREAM_HOST%"
+                      path: /tmp/log
+            listenerFilters:
+            - name: envoy.filters.listener.tls_inspector
+              typedConfig:
+                '@type': type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
+            name: gateway:HTTP:8080
             trafficDirection: INBOUND`,
 			}}),
 	)

--- a/test/e2e_env/universal/gateway/gateway.go
+++ b/test/e2e_env/universal/gateway/gateway.go
@@ -25,7 +25,7 @@ func Gateway() {
 	BeforeAll(func() {
 		setup := NewClusterSetup().
 			Install(MeshUniversal(mesh)).
-			Install(gatewayClientAppUniversal("gateway-client")).
+			Install(GatewayClientAppUniversal("gateway-client")).
 			Install(echoServerApp(mesh, "echo-server", "echo-service", "universal")).
 			Install(GatewayProxyUniversal(mesh, "gateway-proxy")).
 			Install(YamlUniversal(MkGateway("edge-gateway", mesh, false, "example.kuma.io", "echo-service", gatewayPort)))
@@ -49,7 +49,7 @@ func Gateway() {
 
 	Context("when mTLS is disabled", func() {
 		It("should proxy simple HTTP requests", func() {
-			proxySimpleRequests(env.Cluster, "universal",
+			ProxySimpleRequests(env.Cluster, "universal",
 				GatewayAddressPort("gateway-proxy", gatewayPort), "example.kuma.io")
 		})
 	})
@@ -58,7 +58,7 @@ func Gateway() {
 		It("should proxy simple HTTP requests", func() {
 			Expect(env.Cluster.Install(MTLSMeshUniversal(mesh))).To(Succeed())
 
-			proxySimpleRequests(env.Cluster, "universal",
+			ProxySimpleRequests(env.Cluster, "universal",
 				GatewayAddressPort("gateway-proxy", gatewayPort), "example.kuma.io")
 		})
 	})
@@ -109,7 +109,7 @@ networking:
 		})
 
 		It("should proxy simple HTTP requests", func() {
-			proxySimpleRequests(env.Cluster, "external-echo",
+			ProxySimpleRequests(env.Cluster, "external-echo",
 				GatewayAddressPort("gateway-proxy", gatewayPort), "example.kuma.io",
 				client.WithPathPrefix("/external"))
 		})

--- a/test/e2e_env/universal/gateway/utils.go
+++ b/test/e2e_env/universal/gateway/utils.go
@@ -148,9 +148,9 @@ networking:
 	}
 }
 
-// gatewayClientAppUniversal runs an empty container that will
+// GatewayClientAppUniversal runs an empty container that will
 // function as a client for a gateway.
-func gatewayClientAppUniversal(name string) InstallFunc {
+func GatewayClientAppUniversal(name string) InstallFunc {
 	return func(cluster Cluster) error {
 		return cluster.DeployApp(
 			WithName(name),
@@ -171,7 +171,7 @@ func echoServerApp(mesh, name, service, instance string) InstallFunc {
 	}
 }
 
-func proxySimpleRequests(cluster Cluster, instance, gateway, host string, opts ...client.CollectResponsesOptsFn) {
+func ProxySimpleRequests(cluster Cluster, instance, gateway, host string, opts ...client.CollectResponsesOptsFn) {
 	targetPath := path.Join("test", GinkgoT().Name())
 
 	Logf("expecting 200 response from %q", gateway)

--- a/test/e2e_env/universal/meshaccesslog/meshaccesslog.go
+++ b/test/e2e_env/universal/meshaccesslog/meshaccesslog.go
@@ -2,15 +2,16 @@ package meshaccesslog
 
 import (
 	"fmt"
+	"net"
 	"strconv"
 	"strings"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	gomega_types "github.com/onsi/gomega/types"
 
 	"github.com/kumahq/kuma/test/e2e_env/universal/env"
+	"github.com/kumahq/kuma/test/e2e_env/universal/gateway"
 	. "github.com/kumahq/kuma/test/framework"
 	"github.com/kumahq/kuma/test/framework/deployments/externalservice"
 )
@@ -21,6 +22,11 @@ func TestPlugin() {
 	externalServiceDeployment := "externalservice-" + externalServiceName
 	var externalServiceDockerName string
 
+	GatewayAddressPort := func(appName string, port int) string {
+		ip := env.Cluster.GetApp(appName).GetIP()
+		return net.JoinHostPort(ip, strconv.Itoa(port))
+	}
+
 	BeforeAll(func() {
 		externalServiceDockerName = fmt.Sprintf("%s_%s-%s", env.Cluster.Name(), meshName, "test-server")
 		Expect(NewClusterSetup().
@@ -29,6 +35,9 @@ func TestPlugin() {
 				"test-server", meshName, WithArgs([]string{"echo", "--instance", "echo-v1"}), WithDockerContainerName(externalServiceDockerName)),
 			).
 			Install(DemoClientUniversal(AppModeDemoClient, meshName, WithTransparentProxy(true))).
+			Install(GatewayProxyUniversal(meshName, "edge-gateway")).
+			Install(YamlUniversal(gateway.MkGateway("edge-gateway", meshName, false, "example.kuma.io", "test-server", 8080))).
+			Install(gateway.GatewayClientAppUniversal("gateway-client")).
 			Setup(env.Cluster)).To(Succeed())
 	})
 	E2EAfterAll(func() {
@@ -58,13 +67,11 @@ func TestPlugin() {
 	})
 
 	trafficLogFormat := "%START_TIME(%s)%,%KUMA_SOURCE_SERVICE%,%KUMA_DESTINATION_SERVICE%"
-	expectTrafficLogged := func(target string, curlErr gomega_types.GomegaMatcher) (src, dst string) {
+	expectTrafficLogged := func(makeRequest func(g Gomega)) (src, dst string) {
 		sinkDeployment := env.Cluster.Deployment(externalServiceDeployment).(*externalservice.UniversalDeployment)
 
 		Eventually(func(g Gomega) {
-			_, _, err := env.Cluster.Exec("", "", AppModeDemoClient,
-				"curl", "-v", "--fail", target)
-			g.Expect(err).To(curlErr)
+			makeRequest(g)
 
 			stdout, _, err := sinkDeployment.Exec("", "", "head", "-1", "/nc.out")
 			g.Expect(err).ToNot(HaveOccurred())
@@ -103,7 +110,12 @@ spec:
 `, trafficLogFormat, env.Cluster.Name(), externalServiceDeployment)
 		Expect(YamlUniversal(yaml)(env.Cluster)).To(Succeed())
 
-		src, dst := expectTrafficLogged("test-server.mesh", Succeed())
+		makeRequest := func(g Gomega) {
+			_, _, err := env.Cluster.Exec("", "", AppModeDemoClient,
+				"curl", "-v", "--fail", "test-server.mesh")
+			g.Expect(err).ToNot(HaveOccurred())
+		}
+		src, dst := expectTrafficLogged(makeRequest)
 
 		Expect(src).To(Equal(AppModeDemoClient))
 		Expect(dst).To(Equal("test-server"))
@@ -132,7 +144,12 @@ spec:
 		Expect(YamlUniversal(yaml)(env.Cluster)).To(Succeed())
 
 		// 52 is empty response but the TCP connection succeeded
-		src, dst := expectTrafficLogged(externalServiceDockerName, ContainSubstring("exit status 52"))
+		makeRequest := func(g Gomega) {
+			_, _, err := env.Cluster.Exec("", "", AppModeDemoClient,
+				"curl", "-v", "--fail", externalServiceDockerName)
+			g.Expect(err).To(ContainSubstring("exit status 52"))
+		}
+		src, dst := expectTrafficLogged(makeRequest)
 
 		Expect(src).To(Equal(AppModeDemoClient))
 		Expect(dst).To(Equal("external"))
@@ -160,9 +177,45 @@ spec:
 
 		Expect(YamlUniversal(yaml)(env.Cluster)).To(Succeed())
 
-		src, dst := expectTrafficLogged("test-server.mesh", Succeed())
+		makeRequest := func(g Gomega) {
+			_, _, err := env.Cluster.Exec("", "", AppModeDemoClient,
+				"curl", "-v", "--fail", "test-server.mesh")
+			g.Expect(err).ToNot(HaveOccurred())
+		}
+		src, dst := expectTrafficLogged(makeRequest)
 
 		Expect(src).To(Equal("unknown"))
 		Expect(dst).To(Equal("test-server"))
+	})
+
+	It("should log traffic from MeshGateway", func() {
+		yaml := fmt.Sprintf(`
+type: MeshAccessLog
+name: gateway-outgoing
+mesh: meshaccesslog
+spec:
+ targetRef:
+   kind: MeshService
+   name: edge-gateway
+ to:
+   - targetRef:
+       kind: Mesh
+     default:
+       backends:
+       - tcp:
+           format:
+             plain: '%s'
+           address: "%s_%s:9999"
+`, trafficLogFormat, env.Cluster.Name(), externalServiceDeployment)
+		Expect(YamlUniversal(yaml)(env.Cluster)).To(Succeed())
+
+		makeRequest := func(g Gomega) {
+			gateway.ProxySimpleRequests(env.Cluster, "echo-v1",
+				GatewayAddressPort("edge-gateway", 8080), "example.kuma.io")
+		}
+		src, dst := expectTrafficLogged(makeRequest)
+
+		Expect(src).To(Equal("edge-gateway"))
+		Expect(dst).To(Equal("*"))
 	})
 }


### PR DESCRIPTION
### Checklist prior to review

`> Changelog: skip`

- [x] Link to docs PR or issue --
- [x] Link to UI issue or PR --
- [x] Is the [issue worked on linked][1]? -- #4979 
- [x] The PR does not hardcode values that might break projects that depend on kuma (e.g. "kumahq" as a image registry) --
- [x] The PR will work for both Linux and Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Unit Tests --
- [x] E2E Tests --
- [x] Manual Universal Tests -- none
- [x] Manual Kubernetes Tests -- none
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [x] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
