### PR TITLE
feat(kuma-cp): use zone token to auth zone ingress

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -23,7 +23,7 @@ after [a long period of deprecation](https://github.com/kumahq/kuma/issues/2851)
 This is only relevant to Multizone deployment with Universal zones.
 Zone Token that was previously used for authenticating Zone Egress, can now be used to authenticate Zone Ingress.
 Please regenerate Zone Ingress token using `kumactl generate zone-token --scope=ingress`.
-For this time being you can still use the old Zone Ingress token and Zone Token with scope ingress.
+For the time being you can still use the old Zone Ingress token and Zone Token with scope ingress.
 However, Zone Ingress Token is now deprecated and will be removed in the future.
 
 ### Helm

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -18,6 +18,14 @@ Make sure your certificates contain a valid CN or SANs.
 This component has been removed
 after [a long period of deprecation](https://github.com/kumahq/kuma/issues/2851).
 
+### Zone Ingress Token migration
+
+This is only relevant to Multizone deployment with Universal zones.
+Zone Token that was previously used for authenticating Zone Egress, can now be used to authenticate Zone Ingress.
+Please regenerate Zone Ingress token using `kumactl generate zone-token --scope=ingress`.
+For this time being you can still use the old Zone Ingress token and Zone Token with scope ingress.
+However, Zone Ingress Token is now deprecated and will be removed in the future.
+
 ### Helm
 
 `ingress.annotations` and `egress.annotations` are deprecated in favour of `ingress.podAnnotations` and `egress.podAnnotations` which is a better name and aligne with the existing `controlPlane.podAnnoations`.

--- a/app/kumactl/cmd/generate/generate_zone_token.go
+++ b/app/kumactl/cmd/generate/generate_zone_token.go
@@ -30,7 +30,7 @@ func NewGenerateZoneTokenCmd(pctx *kumactl_cmd.RootContext) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "zone-token",
 		Short: "Generate Zone Token",
-		Long:  `Generate Zone Token that is used to prove identity of zone (Zone Ingress, Zone Egress).`,
+		Long:  `Generate Zone Token that is used to prove identity of zone components (Zone Ingress, Zone Egress).`,
 		Example: `Generate token bound by zone
 $ kumactl generate zone-token --zone zone-1 --valid-for 24h
 $ kumactl generate zone-token --zone zone-1 --valid-for 24h --scope egress

--- a/app/kumactl/cmd/generate/generate_zone_token.go
+++ b/app/kumactl/cmd/generate/generate_zone_token.go
@@ -1,6 +1,7 @@
 package generate
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/pkg/errors"
@@ -29,12 +30,12 @@ func NewGenerateZoneTokenCmd(pctx *kumactl_cmd.RootContext) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "zone-token",
 		Short: "Generate Zone Token",
-		// TODO (bartsmykla): update descriptions when this token will be able to
-		//  be used to prove identities of zone dataplanes and ingresses as well
-		Long: `Generate Zone Token that is used to prove identity of Zone egresses.`,
+		Long:  `Generate Zone Token that is used to prove identity of zone (Zone Ingress, Zone Egress).`,
 		Example: `Generate token bound by zone
 $ kumactl generate zone-token --zone zone-1 --valid-for 24h
-$ kumactl generate zone-token --zone zone-1 --valid-for 24h --scope egress`,
+$ kumactl generate zone-token --zone zone-1 --valid-for 24h --scope egress
+$ kumactl generate zone-token --zone zone-1 --valid-for 24h --scope ingress
+$ kumactl generate zone-token --zone zone-1 --valid-for 24h --scope ingress --scope egress`,
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			if err := validateArgs(ctx.args); err != nil {
@@ -58,8 +59,7 @@ $ kumactl generate zone-token --zone zone-1 --valid-for 24h --scope egress`,
 	}
 
 	cmd.Flags().StringVar(&ctx.args.zone, "zone", "", "name of the zone where resides")
-	// TODO (bartsmykla): update when Zone Token will be available for dataplanes and ingresses
-	cmd.Flags().StringSliceVar(&ctx.args.scope, "scope", zone.FullScope, "scope of resources which the token will be able to identify (can be 'egress')")
+	cmd.Flags().StringSliceVar(&ctx.args.scope, "scope", zone.FullScope, fmt.Sprintf("scope of resources which the token will be able to identify (can be: %v)", zone.FullScope))
 	cmd.Flags().DurationVar(&ctx.args.validFor, "valid-for", 0, `how long the token will be valid (for example "24h")`)
 
 	_ = cmd.MarkFlagRequired("valid-for")
@@ -71,8 +71,7 @@ func validateArgs(args *generateZoneTokenContextArgs) error {
 	var unsupportedScopes []string
 
 	for _, s := range args.scope {
-		// TODO (bartsmykla): update when Zone Token will be available for dataplanes and ingresses
-		if s != zone.EgressScope {
+		if !zone.InScope(zone.FullScope, s) {
 			unsupportedScopes = append(unsupportedScopes, s)
 		}
 	}

--- a/app/kumactl/cmd/generate/generate_zoneingress_token.go
+++ b/app/kumactl/cmd/generate/generate_zoneingress_token.go
@@ -23,7 +23,10 @@ func NewGenerateZoneIngressTokenCmd(pctx *kumactl_cmd.RootContext) *cobra.Comman
 	cmd := &cobra.Command{
 		Use:   "zone-ingress-token",
 		Short: "Generate Zone Ingress Token",
-		Long:  `Generate Zone Ingress Token that is used to prove Zone Ingress identity.`,
+		Long: `Generate Zone Ingress Token that is used to prove Zone Ingress identity.
+
+DEPRECATED: Use kumactl generate zone-token --scope=ingress instead.
+`,
 		Example: `
 Generate token bound by zone
 $ kumactl generate zone-ingress-token --zone zone-1 --valid-for 30d

--- a/docs/generated/cmd/kumactl/kumactl_generate_zone-ingress-token.md
+++ b/docs/generated/cmd/kumactl/kumactl_generate_zone-ingress-token.md
@@ -6,6 +6,9 @@ Generate Zone Ingress Token
 
 Generate Zone Ingress Token that is used to prove Zone Ingress identity.
 
+DEPRECATED: Use kumactl generate zone-token --scope=ingress instead.
+
+
 ```
 kumactl generate zone-ingress-token [flags]
 ```

--- a/docs/generated/cmd/kumactl/kumactl_generate_zone-token.md
+++ b/docs/generated/cmd/kumactl/kumactl_generate_zone-token.md
@@ -4,7 +4,7 @@ Generate Zone Token
 
 ### Synopsis
 
-Generate Zone Token that is used to prove identity of Zone egresses.
+Generate Zone Token that is used to prove identity of zone (Zone Ingress, Zone Egress).
 
 ```
 kumactl generate zone-token [flags]
@@ -16,13 +16,15 @@ kumactl generate zone-token [flags]
 Generate token bound by zone
 $ kumactl generate zone-token --zone zone-1 --valid-for 24h
 $ kumactl generate zone-token --zone zone-1 --valid-for 24h --scope egress
+$ kumactl generate zone-token --zone zone-1 --valid-for 24h --scope ingress
+$ kumactl generate zone-token --zone zone-1 --valid-for 24h --scope ingress --scope egress
 ```
 
 ### Options
 
 ```
   -h, --help                 help for zone-token
-      --scope strings        scope of resources which the token will be able to identify (can be 'egress') (default [egress])
+      --scope strings        scope of resources which the token will be able to identify (can be: [ingress egress]) (default [ingress,egress])
       --valid-for duration   how long the token will be valid (for example "24h")
       --zone string          name of the zone where resides
 ```

--- a/docs/generated/cmd/kumactl/kumactl_generate_zone-token.md
+++ b/docs/generated/cmd/kumactl/kumactl_generate_zone-token.md
@@ -4,7 +4,7 @@ Generate Zone Token
 
 ### Synopsis
 
-Generate Zone Token that is used to prove identity of zone (Zone Ingress, Zone Egress).
+Generate Zone Token that is used to prove identity of zone components (Zone Ingress, Zone Egress).
 
 ```
 kumactl generate zone-token [flags]

--- a/pkg/core/xds/rules.go
+++ b/pkg/core/xds/rules.go
@@ -227,10 +227,12 @@ func (c *SubsetIter) next() bool {
 }
 
 // simplified returns copy of c.current and deletes redundant tags, for example:
-//   * env: dev
-//   * env: !prod
+//   - env: dev
+//   - env: !prod
+//
 // could be simplified to:
-//   * env: dev
+//   - env: dev
+//
 // If tags are contradicted (same keys have different positive value) then the function
 // returns nil.
 func (c *SubsetIter) simplified() Subset {

--- a/pkg/tokens/builtin/zone/scope.go
+++ b/pkg/tokens/builtin/zone/scope.go
@@ -1,18 +1,12 @@
 package zone
 
 const (
-	// TODO (bartsmykla): uncomment when Zone Token will be available for dataplanes
-	// 	and ingresses
-	// DataplaneScope string = "dataplane
-	// IngressScope string = "ingress"
-	EgressScope string = "egress"
+	IngressScope string = "ingress"
+	EgressScope  string = "egress"
 )
 
 var FullScope = []string{
-	// TODO (bartsmykla): uncomment when Zone Token will be available for dataplanes
-	// 	and ingresses
-	// DataplaneScope,
-	// IngressScope,
+	IngressScope,
 	EgressScope,
 }
 

--- a/pkg/tokens/builtin/zoneingress/zone_validator_adapter.go
+++ b/pkg/tokens/builtin/zoneingress/zone_validator_adapter.go
@@ -1,0 +1,50 @@
+package zoneingress
+
+import (
+	"context"
+
+	"github.com/golang-jwt/jwt/v4"
+
+	"github.com/kumahq/kuma/pkg/tokens/builtin/zone"
+)
+
+type zoneValidatorAdapter struct {
+	zoneIngressValidator Validator
+	zoneValidator        zone.Validator
+}
+
+var _ zone.Validator = &zoneValidatorAdapter{}
+
+// NewZoneValidatorAdapter returns Zone Token Validator that has a fallback on Zone Ingress Validator
+// This is used for backwards compatibility to still support old ingress token.
+// This should be deleted if we delete zone ingress token.
+func NewZoneValidatorAdapter(zoneIngressValidator Validator, zoneValidator zone.Validator) zone.Validator {
+	return &zoneValidatorAdapter{
+		zoneIngressValidator: zoneIngressValidator,
+		zoneValidator:        zoneValidator,
+	}
+}
+
+func (z *zoneValidatorAdapter) Validate(ctx context.Context, token zone.Token) (zone.Identity, error) {
+	if isZoneToken(token) {
+		return z.zoneValidator.Validate(ctx, token)
+	}
+	id, err := z.zoneIngressValidator.Validate(ctx, token)
+	if err != nil {
+		return zone.Identity{}, err
+	}
+	return zone.Identity{
+		Zone:  id.Zone,
+		Scope: []string{zone.IngressScope},
+	}, nil
+}
+
+func isZoneToken(token zone.Token) bool {
+	parser := jwt.Parser{}
+	claims := zone.ZoneClaims{}
+	_, _, err := parser.ParseUnverified(token, &claims)
+	if err != nil {
+		return false
+	}
+	return len(claims.Scope) > 0 // zone token has to contain Scope
+}

--- a/pkg/xds/auth/components/components.go
+++ b/pkg/xds/auth/components/components.go
@@ -10,6 +10,7 @@ import (
 	core_manager "github.com/kumahq/kuma/pkg/core/resources/manager"
 	k8s_extensions "github.com/kumahq/kuma/pkg/plugins/extensions/k8s"
 	"github.com/kumahq/kuma/pkg/tokens/builtin"
+	"github.com/kumahq/kuma/pkg/tokens/builtin/zoneingress"
 	"github.com/kumahq/kuma/pkg/xds/auth"
 	k8s_auth "github.com/kumahq/kuma/pkg/xds/auth/k8s"
 	universal_auth "github.com/kumahq/kuma/pkg/xds/auth/universal"
@@ -35,8 +36,9 @@ func NewUniversalAuthenticator(rt Context) (auth.Authenticator, error) {
 	dataplaneValidator := builtin.NewDataplaneTokenValidator(rt.ReadOnlyResourceManager(), config.Store.Type)
 	zoneIngressValidator := builtin.NewZoneIngressTokenValidator(rt.ReadOnlyResourceManager(), config.Store.Type)
 	zoneTokenValidator := builtin.NewZoneTokenValidator(rt.ReadOnlyResourceManager(), config.Mode, config.Store.Type)
+	adaptedValidator := zoneingress.NewZoneValidatorAdapter(zoneIngressValidator, zoneTokenValidator)
 
-	return universal_auth.NewAuthenticator(dataplaneValidator, zoneIngressValidator, zoneTokenValidator, config.Multizone.Zone.Name), nil
+	return universal_auth.NewAuthenticator(dataplaneValidator, adaptedValidator, config.Multizone.Zone.Name), nil
 }
 
 func DefaultAuthenticator(rt Context) (auth.Authenticator, error) {

--- a/test/e2e_env/multizone/multizone_suite_test.go
+++ b/test/e2e_env/multizone/multizone_suite_test.go
@@ -89,7 +89,7 @@ var _ = SynchronizedBeforeSuite(
 					WithEgressEnvoyAdminTunnel(),
 					WithIngressEnvoyAdminTunnel(),
 				)).
-				Install(IngressUniversal(env.Global.GetKuma().GenerateZoneIngressToken)).
+				Install(IngressUniversal(env.Global.GetKuma().GenerateZoneIngressLegacyToken)).
 				Install(EgressUniversal(env.Global.GetKuma().GenerateZoneEgressToken)).
 				Setup(env.UniZone1)
 			Expect(err).ToNot(HaveOccurred())

--- a/test/framework/interface.go
+++ b/test/framework/interface.go
@@ -544,5 +544,6 @@ type ControlPlane interface {
 	GetAPIServerAddress() string
 	GenerateDpToken(mesh, serviceName string) (string, error)
 	GenerateZoneIngressToken(zone string) (string, error)
+	GenerateZoneIngressLegacyToken(zone string) (string, error)
 	GenerateZoneEgressToken(zone string) (string, error)
 }

--- a/test/framework/k8s_controlplane.go
+++ b/test/framework/k8s_controlplane.go
@@ -273,7 +273,13 @@ func (c *K8sControlPlane) GenerateDpToken(mesh, service string) (string, error) 
 }
 
 func (c *K8sControlPlane) GenerateZoneIngressToken(zone string) (string, error) {
-	data := fmt.Sprintf(`{"zone": "%s"}`, zone)
+	data := fmt.Sprintf(`'{"zone": "%s", "scope": ["ingress"]}'`, zone)
+
+	return c.generateToken("/zone", data)
+}
+
+func (c *K8sControlPlane) GenerateZoneIngressLegacyToken(zone string) (string, error) {
+	data := fmt.Sprintf(`'{"zone": "%s"}'`, zone)
 
 	return c.generateToken("/zone-ingress", data)
 }

--- a/test/framework/universal_controlplane.go
+++ b/test/framework/universal_controlplane.go
@@ -168,6 +168,12 @@ func (c *UniversalControlPlane) GenerateDpToken(mesh, service string) (string, e
 }
 
 func (c *UniversalControlPlane) GenerateZoneIngressToken(zone string) (string, error) {
+	data := fmt.Sprintf(`'{"zone": "%s", "scope": ["ingress"]}'`, zone)
+
+	return c.generateToken("/zone", data)
+}
+
+func (c *UniversalControlPlane) GenerateZoneIngressLegacyToken(zone string) (string, error) {
 	data := fmt.Sprintf(`'{"zone": "%s"}'`, zone)
 
 	return c.generateToken("/zone-ingress", data)


### PR DESCRIPTION
Give the capability to use a zone token to authenticate ingress. This will help us drop zone ingress in the future to simplify our security story.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [X] Link to docs PR or issue -- https://github.com/kumahq/kuma-website/pull/1025
- [X] Link to UI issue or PR -- no UI changes
- [X] Is the [issue worked on linked][1]? --
- [X] The PR does not hardcode values that might break projects that depend on kuma (e.g. "kumahq" as a image registry) --
- [X] The PR will work for both Linux and Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [X] Unit Tests --
- [X] E2E Tests --
- [ ] Manual Universal Tests --
- [ ] Manual Kubernetes Tests --
- [X] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [X] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? -- no
- [ ] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
