### PR TITLE
feat: match new policies to MeshGateways

### DIFF
--- a/pkg/plugins/policies/matchers/match.go
+++ b/pkg/plugins/policies/matchers/match.go
@@ -124,7 +124,7 @@ func inboundsSelectedByTargetRef(tr *common_proto.TargetRef, dpp *core_mesh.Data
 func inboundsSelectedByTags(tags map[string]string, dpp *core_mesh.DataplaneResource, gateway *core_mesh.MeshGatewayResource) []core_xds.InboundListener {
 	result := []core_xds.InboundListener{}
 	for _, inbound := range dpp.Spec.GetNetworking().GetInbound() {
-		if isInboundSelectedByTags(tags, inbound) {
+		if mesh_proto.TagSelector(tags).Matches(inbound.Tags) {
 			intf := dpp.Spec.GetNetworking().ToInboundInterface(inbound)
 			result = append(result, core_xds.InboundListener{
 				Address: intf.DataplaneIP,
@@ -148,15 +148,6 @@ func inboundsSelectedByTags(tags map[string]string, dpp *core_mesh.DataplaneReso
 		}
 	}
 	return result
-}
-
-func isInboundSelectedByTags(tags map[string]string, inbound *mesh_proto.Dataplane_Networking_Inbound) bool {
-	for k, v := range tags {
-		if inboundValue, ok := inbound.Tags[k]; !ok || inboundValue != v {
-			return false
-		}
-	}
-	return true
 }
 
 type ByTargetRef []core_model.Resource

--- a/pkg/plugins/policies/matchers/testdata/match/meshgateways/01.dataplane.yaml
+++ b/pkg/plugins/policies/matchers/testdata/match/meshgateways/01.dataplane.yaml
@@ -1,0 +1,9 @@
+type: Dataplane
+mesh: mesh-1
+name: gateway-1
+networking:
+ address: 127.0.0.1
+ gateway:
+  type: BUILTIN
+  tags:
+   kuma.io/service: edge-gateway

--- a/pkg/plugins/policies/matchers/testdata/match/meshgateways/01.golden.yaml
+++ b/pkg/plugins/policies/matchers/testdata/match/meshgateways/01.golden.yaml
@@ -1,0 +1,11 @@
+Rules:
+  127.0.0.1:8080:
+  - Conf:
+      action: DENY
+    Origin: null
+    Subset: []
+  127.0.0.1:8081:
+  - Conf:
+      action: ALLOW
+    Origin: null
+    Subset: []

--- a/pkg/plugins/policies/matchers/testdata/match/meshgateways/01.policies.yaml
+++ b/pkg/plugins/policies/matchers/testdata/match/meshgateways/01.policies.yaml
@@ -1,0 +1,44 @@
+---
+type: MeshTrafficPermission
+mesh: mesh-1
+name: mtp-1
+spec:
+ targetRef:
+  kind: Mesh
+ from:
+  - targetRef:
+     kind: Mesh
+    default:
+     action: DENY
+---
+type: MeshTrafficPermission
+mesh: mesh-1
+name: mtp-2
+spec:
+ targetRef:
+  kind: MeshServiceSubset
+  name: edge-gateway
+  tags:
+    listener: two
+ from:
+  - targetRef:
+     kind: Mesh
+    default:
+     action: ALLOW
+---
+type: MeshGateway
+mesh: mesh-1
+name: gateway-1
+selectors:
+ - match:
+    kuma.io/service: edge-gateway
+conf:
+ listeners:
+  - port: 8080
+    protocol: HTTP
+    tags:
+     listener: one
+  - port: 8081
+    protocol: HTTP
+    tags:
+     listener: two

--- a/pkg/plugins/policies/meshtrafficpermission/plugin/v1alpha1/plugin.go
+++ b/pkg/plugins/policies/meshtrafficpermission/plugin/v1alpha1/plugin.go
@@ -36,6 +36,10 @@ func (p plugin) Apply(rs *core_xds.ResourceSet, ctx xds_context.Context, proxy *
 		return nil
 	}
 
+	if proxy.Dataplane.Spec.IsBuiltinGateway() {
+		return nil
+	}
+
 	mtp, ok := proxy.Policies.Dynamic[api.MeshTrafficPermissionType]
 	if !ok {
 		return nil


### PR DESCRIPTION
Really a blocker for #5101 but is worth merging alone since this might break other policy plugins

Note that in particular in the case of `MeshGateway`s, policies match the union of `Dataplane` tags, `MeshGateway` tags and `MeshGateway` listener tags.

`> Changelog: skip`

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] Link to docs PR or issue --
- [x] Link to UI issue or PR --
- [x] Is the [issue worked on linked][1]? --
- [x] The PR does not hardcode values that might break projects that depend on kuma (e.g. "kumahq" as a image registry) --
- [x] The PR will work for both Linux and Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Unit Tests --
- [x] E2E Tests -- I think this is part of the e2e tests per policy
- [x] Manual Universal Tests -- none
- [x] Manual Kubernetes Tests -- none
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [x] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
