### PR TITLE
test(e2e): fix generate tokens on k8s

### DIFF
--- a/test/framework/k8s_controlplane.go
+++ b/test/framework/k8s_controlplane.go
@@ -273,19 +273,19 @@ func (c *K8sControlPlane) GenerateDpToken(mesh, service string) (string, error) 
 }
 
 func (c *K8sControlPlane) GenerateZoneIngressToken(zone string) (string, error) {
-	data := fmt.Sprintf(`'{"zone": "%s", "scope": ["ingress"]}'`, zone)
+	data := fmt.Sprintf(`{"zone": "%s", "scope": ["ingress"]}`, zone)
 
 	return c.generateToken("/zone", data)
 }
 
 func (c *K8sControlPlane) GenerateZoneIngressLegacyToken(zone string) (string, error) {
-	data := fmt.Sprintf(`'{"zone": "%s"}'`, zone)
+	data := fmt.Sprintf(`{"zone": "%s"}`, zone)
 
 	return c.generateToken("/zone-ingress", data)
 }
 
 func (c *K8sControlPlane) GenerateZoneEgressToken(zone string) (string, error) {
-	data := fmt.Sprintf(`'{"zone": "%s", "scope": ["egress"]}'`, zone)
+	data := fmt.Sprintf(`{"zone": "%s", "scope": ["egress"]}`, zone)
 
 	return c.generateToken("/zone", data)
 }


### PR DESCRIPTION
Fix token generation on k8s. We don't use it in tests in Kuma (we always generate tokens on global universal). That's why it passed CI.

the extra `'` makes this invalid JSON
### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [ ] Link to docs PR or issue --
- [ ] Link to UI issue or PR --
- [ ] Is the [issue worked on linked][1]? --
- [ ] The PR does not hardcode values that might break projects that depend on kuma (e.g. "kumahq" as a image registry) --
- [ ] The PR will work for both Linux and Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [ ] Unit Tests --
- [ ] E2E Tests --
- [ ] Manual Universal Tests --
- [ ] Manual Kubernetes Tests --
- [ ] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [ ] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [ ] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
