### PR TITLE
ci(.circleci): fix has_label to extract PR number correctly

### DIFF
--- a/tools/ci/has_label.sh
+++ b/tools/ci/has_label.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 
 LABEL_TO_CHECK="$1"
-CURL_OUTPUT=$(curl -s --fail -H "Accept: application/vnd.github+json" https://api.github.com/repos/kumahq/kuma/pulls/"$CIRCLE_PR_NUMBER")
+PR_NUMBER="${2:-$(basename "${CIRCLE_PULL_REQUEST}")}"
+CURL_OUTPUT=$(curl -s --fail -H "Accept: application/vnd.github+json" https://api.github.com/repos/kumahq/kuma/pulls/"$PR_NUMBER")
 
 if [[ $CURL_OUTPUT != "" ]]; then
     LABELS=$(jq '.labels[].name' <<< "$CURL_OUTPUT")


### PR DESCRIPTION
CIRCLE_PR_NUMBER wasn't working on PRs not coming from forks which happens for autogenerated PRs like GUI updates

Signed-off-by: Charly Molter <charly.molter@konghq.com>

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] Link to docs PR or issue --
- [x] Link to UI issue or PR --
- [x] Is the [issue worked on linked][1]? --
- [x] The PR does not hardcode values that might break projects that depend on kuma (e.g. "kumahq" as a image registry) --
- [x] The PR will work for both Linux and Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Unit Tests --
- [x] E2E Tests --
- [x] Manual Universal Tests --
- [x] Manual Kubernetes Tests --
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [x] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
