### PR TITLE
feat: support JSON with MeshAccessLog

### DIFF
--- a/app/kuma-dp/pkg/dataplane/accesslogs/streamer.go
+++ b/app/kuma-dp/pkg/dataplane/accesslogs/streamer.go
@@ -116,6 +116,7 @@ func (s *accessLogStreamer) streamAccessLogs(reader *bufio.Reader) (err error) {
 
 		var wrappedMsg wrappedMessage
 		if err := json.Unmarshal(msg, &wrappedMsg); err != nil {
+			// This is for compatibility if using TrafficLog
 			parts := bytes.SplitN(msg, []byte(";"), 2)
 			if len(parts) != 2 {
 				logger.Error(nil, "log format invalid: expected 2 components separated by ';' or a JSON object")


### PR DESCRIPTION
For TCP we now always embed log lines as JSON messages for the log streamer. It still supports old style log lines for now.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] Link to docs PR or issue --
- [x] Link to UI issue or PR --
- [x] Is the [issue worked on linked][1]? -- #4979 
- [x] The PR does not hardcode values that might break projects that depend on kuma (e.g. "kumahq" as a image registry) --
- [x] The PR will work for both Linux and Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Unit Tests -- no new ones
- [x] E2E Tests --
- [x] Manual Universal Tests -- none
- [x] Manual Kubernetes Tests --
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [x] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
