### PR TITLE
ci(test): improve reliability of postgres tests

### DIFF
--- a/pkg/plugins/resources/postgres/store_suite_test.go
+++ b/pkg/plugins/resources/postgres/store_suite_test.go
@@ -20,7 +20,11 @@ func TestPostgresStore(t *testing.T) {
 		Expect(c.Start()).To(Succeed())
 	})
 	AfterSuite(func() {
-		Expect(c.Stop()).To(Succeed())
+		err := c.Stop()
+		if err != nil {
+			// Exception around delete image bug: https://github.com/moby/moby/issues/44290
+			Expect(err).To(ContainSubstring(err.Error(), "unrecognized image"))
+		}
 	})
 	test.RunSpecs(t, "Postgres Resource Store Suite")
 }


### PR DESCRIPTION
### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] Link to docs PR or issue --
- [x] Link to UI issue or PR --
- [x] Is the [issue worked on linked][1]? --
- [x] The PR does not hardcode values that might break projects that depend on kuma (e.g. "kumahq" as a image registry) --
- [x] The PR will work for both Linux and Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Unit Tests --
- [x] E2E Tests --
- [x] Manual Universal Tests --
- [x] Manual Kubernetes Tests --
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [x] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
