### PR TITLE
fix(policies): improve targetRef validation

### DIFF
--- a/pkg/api-server/inspect_endpoints_test.go
+++ b/pkg/api-server/inspect_endpoints_test.go
@@ -339,6 +339,9 @@ var _ = Describe("Inspect WS", func() {
 						},
 						From: []*policies_api.MeshTrafficPermission_From{
 							{
+								TargetRef: &common_api.TargetRef{
+									Kind: "Mesh",
+								},
 								Default: &policies_api.MeshTrafficPermission_Conf{
 									Action: "ALLOW",
 								},
@@ -1105,6 +1108,9 @@ var _ = Describe("Inspect WS", func() {
 						},
 						From: []*policies_api.MeshTrafficPermission_From{
 							{
+								TargetRef: &common_api.TargetRef{
+									Kind: "Mesh",
+								},
 								Default: &policies_api.MeshTrafficPermission_Conf{
 									Action: "ALLOW",
 								},

--- a/pkg/api-server/testdata/inspect_dataplane.json
+++ b/pkg/api-server/testdata/inspect_dataplane.json
@@ -19,6 +19,9 @@
       },
       "from": [
        {
+        "targetRef": {
+         "kind": "Mesh"
+        },
         "default": {
          "action": "ALLOW"
         }

--- a/pkg/core/xds/rules.go
+++ b/pkg/core/xds/rules.go
@@ -218,10 +218,6 @@ func newConf(t reflect.Type) (proto.Message, error) {
 }
 
 func asSubset(tr *common_api.TargetRef) (Subset, error) {
-	if tr == nil {
-		// syntactic sugar, empty targetRef means targetRef{kind: Mesh}
-		return Subset{}, nil
-	}
 	switch tr.GetKindEnum() {
 	case common_api.TargetRef_Mesh:
 		return Subset{}, nil

--- a/pkg/core/xds/testdata/rules/06.policy.yaml
+++ b/pkg/core/xds/testdata/rules/06.policy.yaml
@@ -4,7 +4,6 @@ name: mt-1
 spec:
   targetRef:
     kind: Mesh
-    name: mesh-1
   default:
     tags:
       - name: team

--- a/pkg/core/xds/testdata/rules/07.policy.yaml
+++ b/pkg/core/xds/testdata/rules/07.policy.yaml
@@ -4,7 +4,6 @@ name: mt-1
 spec:
   targetRef:
     kind: Mesh
-    name: mesh-1
   default:
     tags:
       - name: team

--- a/pkg/plugins/policies/matchers/match.go
+++ b/pkg/plugins/policies/matchers/match.go
@@ -33,8 +33,7 @@ func MatchedPolicies(rType core_model.ResourceType, dpp *core_mesh.DataplaneReso
 			return core_xds.TypedMatchingPolicies{}, errors.Errorf("resource type %v doesn't support TargetRef matching", rType)
 		}
 
-		targetRef := spec.GetTargetRef()
-		selectedInbounds := inboundsSelectedByTargetRef(targetRef, dpp, gateway)
+		selectedInbounds := inboundsSelectedByTargetRef(spec.GetTargetRef(), dpp, gateway)
 		if len(selectedInbounds) == 0 {
 			// DPP is not matched by the policy
 			continue

--- a/pkg/plugins/policies/matchers/testdata/match/dataplanepolicies/01.golden.yaml
+++ b/pkg/plugins/policies/matchers/testdata/match/dataplanepolicies/01.golden.yaml
@@ -9,7 +9,6 @@ items:
         action: ALLOW
       targetRef:
         kind: Mesh
-        name: default
     targetRef:
       kind: Mesh
   type: MeshTrafficPermission
@@ -23,7 +22,6 @@ items:
         action: ALLOW
       targetRef:
         kind: Mesh
-        name: default
     targetRef:
       kind: MeshSubset
       tags:
@@ -39,7 +37,6 @@ items:
         action: ALLOW
       targetRef:
         kind: Mesh
-        name: default
     targetRef:
       kind: MeshService
       name: web
@@ -54,7 +51,6 @@ items:
         action: ALLOW
       targetRef:
         kind: Mesh
-        name: default
     targetRef:
       kind: MeshServiceSubset
       name: web

--- a/pkg/plugins/policies/matchers/testdata/match/dataplanepolicies/01.policies.yaml
+++ b/pkg/plugins/policies/matchers/testdata/match/dataplanepolicies/01.policies.yaml
@@ -11,7 +11,6 @@ spec:
   from:
     - targetRef:
         kind: Mesh
-        name: default
       default:
         action: ALLOW
 ---
@@ -24,7 +23,6 @@ spec:
   from:
     - targetRef:
         kind: Mesh
-        name: default
       default:
         action: ALLOW
 ---
@@ -38,7 +36,6 @@ spec:
   from:
     - targetRef:
         kind: Mesh
-        name: default
       default:
         action: ALLOW
 ---
@@ -53,7 +50,6 @@ spec:
   from:
     - targetRef:
         kind: Mesh
-        name: default
       default:
         action: ALLOW
 ---
@@ -67,7 +63,6 @@ spec:
   from:
     - targetRef:
         kind: Mesh
-        name: default
       default:
         action: ALLOW
 ---
@@ -83,7 +78,6 @@ spec:
   from:
     - targetRef:
         kind: Mesh
-        name: default
       default:
         action: ALLOW
 ---
@@ -99,6 +93,5 @@ spec:
   from:
     - targetRef:
         kind: Mesh
-        name: default
       default:
         action: ALLOW

--- a/pkg/plugins/policies/matchers/testdata/match/dataplanepolicies/02.golden.yaml
+++ b/pkg/plugins/policies/matchers/testdata/match/dataplanepolicies/02.golden.yaml
@@ -9,7 +9,6 @@ items:
         action: ALLOW
       targetRef:
         kind: Mesh
-        name: default
     targetRef:
       kind: Mesh
   type: MeshTrafficPermission
@@ -23,7 +22,6 @@ items:
         action: ALLOW
       targetRef:
         kind: Mesh
-        name: default
     targetRef:
       kind: Mesh
   type: MeshTrafficPermission
@@ -37,7 +35,6 @@ items:
         action: ALLOW
       targetRef:
         kind: Mesh
-        name: default
     targetRef:
       kind: MeshSubset
       tags:
@@ -53,7 +50,6 @@ items:
         action: ALLOW
       targetRef:
         kind: Mesh
-        name: default
     targetRef:
       kind: MeshSubset
       tags:
@@ -69,7 +65,6 @@ items:
         action: ALLOW
       targetRef:
         kind: Mesh
-        name: default
     targetRef:
       kind: MeshService
       name: web
@@ -84,7 +79,6 @@ items:
         action: ALLOW
       targetRef:
         kind: Mesh
-        name: default
     targetRef:
       kind: MeshService
       name: web
@@ -99,7 +93,6 @@ items:
         action: ALLOW
       targetRef:
         kind: Mesh
-        name: default
     targetRef:
       kind: MeshServiceSubset
       name: web
@@ -116,7 +109,6 @@ items:
         action: ALLOW
       targetRef:
         kind: Mesh
-        name: default
     targetRef:
       kind: MeshServiceSubset
       name: web

--- a/pkg/plugins/policies/matchers/testdata/match/dataplanepolicies/02.policies.yaml
+++ b/pkg/plugins/policies/matchers/testdata/match/dataplanepolicies/02.policies.yaml
@@ -11,7 +11,6 @@ spec:
   from:
     - targetRef:
         kind: Mesh
-        name: default
       default:
         action: ALLOW
 ---
@@ -27,7 +26,6 @@ spec:
   from:
     - targetRef:
         kind: Mesh
-        name: default
       default:
         action: ALLOW
 ---
@@ -40,7 +38,6 @@ spec:
   from:
     - targetRef:
         kind: Mesh
-        name: default
       default:
         action: ALLOW
 ---
@@ -53,7 +50,6 @@ spec:
   from:
     - targetRef:
         kind: Mesh
-        name: default
       default:
         action: ALLOW
 ---
@@ -67,7 +63,6 @@ spec:
   from:
     - targetRef:
         kind: Mesh
-        name: default
       default:
         action: ALLOW
 ---
@@ -81,7 +76,6 @@ spec:
   from:
     - targetRef:
         kind: Mesh
-        name: default
       default:
         action: ALLOW
 ---
@@ -96,7 +90,6 @@ spec:
   from:
     - targetRef:
         kind: Mesh
-        name: default
       default:
         action: ALLOW
 ---
@@ -111,6 +104,5 @@ spec:
   from:
     - targetRef:
         kind: Mesh
-        name: default
       default:
         action: ALLOW

--- a/pkg/plugins/policies/matchers/testdata/match/dataplanepolicies/03.policies.yaml
+++ b/pkg/plugins/policies/matchers/testdata/match/dataplanepolicies/03.policies.yaml
@@ -13,6 +13,5 @@ spec:
   from:
     - targetRef:
         kind: Mesh
-        name: default
       default:
         action: ALLOW

--- a/pkg/plugins/policies/matchers/testdata/match/dataplanepolicies/04.policies.yaml
+++ b/pkg/plugins/policies/matchers/testdata/match/dataplanepolicies/04.policies.yaml
@@ -13,6 +13,5 @@ spec:
   from:
     - targetRef:
         kind: Mesh
-        name: default
       default:
         action: ALLOW

--- a/pkg/plugins/policies/meshaccesslog/api/v1alpha1/validator_test.go
+++ b/pkg/plugins/policies/meshaccesslog/api/v1alpha1/validator_test.go
@@ -32,7 +32,6 @@ targetRef:
 from:
   - targetRef:
       kind: Mesh
-      name: default
     default:
       backends:
         - tcp:
@@ -59,7 +58,6 @@ targetRef:
 from:
   - targetRef:
       kind: Mesh
-      name: default
     default:
       backends:
         - file:
@@ -92,7 +90,6 @@ from:
 				inputYaml: `
 targetRef:
   kind: Mesh
-  name: default
 `,
 				expected: `
 violations:
@@ -107,7 +104,6 @@ targetRef:
 from:
   - targetRef:
       kind: Mesh
-      name: default
     default:
       backends:
         - file:
@@ -127,7 +123,6 @@ targetRef:
 from:
   - targetRef:
       kind: Mesh
-      name: default
     default:
       backends:
         - file:
@@ -148,7 +143,6 @@ targetRef:
 from:
   - targetRef:
       kind: Mesh
-      name: default
     default:
       backends:
         - file:
@@ -170,7 +164,6 @@ targetRef:
 from:
   - targetRef:
       kind: Mesh
-      name: default
     default:
       backends:
         - file:
@@ -192,7 +185,6 @@ targetRef:
 from:
   - targetRef:
       kind: Mesh
-      name: default
     default:
       backends:
         - file:
@@ -215,7 +207,6 @@ targetRef:
 from:
   - targetRef:
       kind: Mesh
-      name: default
     default:
       backends:
         - tcp:
@@ -239,7 +230,6 @@ targetRef:
 from:
   - targetRef:
       kind: Mesh
-      name: default
     default:
       backends:
         - tcp:
@@ -267,7 +257,6 @@ targetRef:
 to:
   - targetRef:
       kind: Mesh
-      name: default
     default:
       backends:
         - file:
@@ -288,7 +277,6 @@ targetRef:
 to:
   - targetRef:
       kind: Mesh
-      name: default
     default:
       backends:
         - file:
@@ -298,6 +286,8 @@ to:
 `,
 				expected: `
 violations:
+- field: spec.targetRef.kind
+  message: MeshHTTPRoute is not yet supported
 - field: spec.to
   message: 'cannot use "to" when "targetRef" is "MeshHTTPRoute" - "to" always goes to the application'`,
 			}),
@@ -305,11 +295,9 @@ violations:
 				inputYaml: `
 targetRef:
   kind: Mesh
-  name: default
 to:
   - targetRef:
       kind: Mesh
-      name: default
 `,
 				expected: `
 violations:
@@ -320,11 +308,9 @@ violations:
 				inputYaml: `
 targetRef:
   kind: Mesh
-  name: default
 from:
   - targetRef:
       kind: Mesh
-      name: default
 `,
 				expected: `
 violations:
@@ -339,7 +325,6 @@ targetRef:
 from:
   - targetRef:
       kind: Mesh
-      name: default
     default:
       backends:
         - tcp:

--- a/test/e2e_env/kubernetes/observability/meshtrace.go
+++ b/test/e2e_env/kubernetes/observability/meshtrace.go
@@ -24,7 +24,6 @@ metadata:
 spec:
   targetRef:
     kind: Mesh
-    name: %s
   default:
     tags:
       - name: team
@@ -32,7 +31,7 @@ spec:
     backends:
       - zipkin:
           url: %s
-`, meshName, meshName, url)
+`, meshName, url)
 }
 
 func PluginTest() {

--- a/test/e2e_env/universal/observability/meshtrace.go
+++ b/test/e2e_env/universal/observability/meshtrace.go
@@ -19,7 +19,6 @@ mesh: %s
 spec:
   targetRef:
     kind: Mesh
-    name: %s
   default:
     tags:
       - name: team
@@ -27,7 +26,7 @@ spec:
     backends:
       - zipkin:
           url: %s
-`, meshName, meshName, url)
+`, meshName, url)
 }
 
 func PluginTest() {


### PR DESCRIPTION
- disallow setting name with `kind: Mesh` as it's unclear what it will mean
- disallow setting mesh with all kinds as it's unclear what it will mean too
- disallow using `MeshHTTPRoute` the thing is not even defined
- rewrite validator for targetRef to use the same wording everywhere

Fix #5165

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] Link to docs PR or issue --
- [x] Link to UI issue or PR --
- [x] Is the [issue worked on linked][1]? --
- [x] The PR does not hardcode values that might break projects that depend on kuma (e.g. "kumahq" as a image registry) --
- [x] The PR will work for both Linux and Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Unit Tests --
- [x] E2E Tests --
- [x] Manual Universal Tests --
- [x] Manual Kubernetes Tests --
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [x] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
