### PR TITLE
test(e2e): remove flakiness in trace tests, add info in healthcheck

### DIFF
--- a/test/e2e_env/kubernetes/observability/meshtrace.go
+++ b/test/e2e_env/kubernetes/observability/meshtrace.go
@@ -36,10 +36,10 @@ spec:
 }
 
 func PluginTest() {
-	ns := "trace"
-	obsNs := "obs-trace"
+	ns := "meshtrace"
+	obsNs := "obs-meshtrace"
 	obsDeployment := "obs-trace-deployment"
-	mesh := "trace"
+	mesh := "meshtrace"
 
 	var obsClient obs.Observability
 	BeforeAll(func() {

--- a/test/e2e_env/universal/observability/meshtrace.go
+++ b/test/e2e_env/universal/observability/meshtrace.go
@@ -31,8 +31,8 @@ spec:
 }
 
 func PluginTest() {
-	mesh := "tracing"
-	obsDeployment := "obs-tracing"
+	mesh := "meshtrace"
+	obsDeployment := "obs-meshtrace"
 	var obsClient obs.Observability
 
 	BeforeAll(func() {


### PR DESCRIPTION
- meshtrace and trace tests were using the same namespace/mesh
- healthcheck test is flaky with curl exit code 52, it's not super clear what happens so rewrote the test in a way that may bubble error more clearly to figure out what's wrong

Signed-off-by: Charly Molter <charly.molter@konghq.com>

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] Link to docs PR or issue --
- [x] Link to UI issue or PR --
- [x] Is the [issue worked on linked][1]? --
- [x] The PR does not hardcode values that might break projects that depend on kuma (e.g. "kumahq" as a image registry) --
- [x] The PR will work for both Linux and Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Unit Tests --
- [x] E2E Tests --
- [x] Manual Universal Tests --
- [x] Manual Kubernetes Tests --
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [x] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
