### PR TITLE
fix(kumactl): get APIVersions from k8s server

### DIFF
--- a/app/kumactl/cmd/install/install_control_plane.go
+++ b/app/kumactl/cmd/install/install_control_plane.go
@@ -48,6 +48,7 @@ func (cv *componentVersion) Type() string {
 }
 
 // getVersionSet retrieves a set of available k8s API versions
+// This is inlined from https://github.com/helm/helm/blob/v3.8.1/pkg/action/action.go#L309
 func getVersionSet(client discovery.ServerResourcesInterface) (chartutil.VersionSet, error) {
 	groups, resources, err := client.ServerGroupsAndResources()
 	if err != nil && !discovery.IsGroupDiscoveryFailedError(err) {
@@ -91,6 +92,7 @@ func getVersionSet(client discovery.ServerResourcesInterface) (chartutil.Version
 }
 
 // getCapabilities builds a Capabilities from discovery information.
+// This is inlined from https://github.com/helm/helm/blob/v3.8.1/pkg/action/action.go#L239
 func getCapabilities(kubeConfig *rest.Config) (*chartutil.Capabilities, error) {
 	dc, err := discovery.NewDiscoveryClientForConfig(kubeConfig)
 	if err != nil {

--- a/app/kumactl/cmd/install/install_control_plane.go
+++ b/app/kumactl/cmd/install/install_control_plane.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path"
 	"strings"
 
 	"github.com/ghodss/yaml"
@@ -11,6 +12,7 @@ import (
 	"github.com/spf13/cobra"
 	"helm.sh/helm/v3/pkg/chartutil"
 	"helm.sh/helm/v3/pkg/strvals"
+	"k8s.io/client-go/discovery"
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 	"k8s.io/client-go/rest"
 
@@ -18,7 +20,7 @@ import (
 	"github.com/kumahq/kuma/app/kumactl/pkg/install/data"
 	"github.com/kumahq/kuma/app/kumactl/pkg/install/k8s"
 	kuma_cmd "github.com/kumahq/kuma/pkg/cmd"
-	"github.com/kumahq/kuma/pkg/config/core"
+	config_core "github.com/kumahq/kuma/pkg/config/core"
 	mesh_k8s "github.com/kumahq/kuma/pkg/plugins/resources/k8s/native/api/v1alpha1"
 )
 
@@ -43,6 +45,81 @@ func (cv *componentVersion) Set(v string) error {
 
 func (cv *componentVersion) Type() string {
 	return "string"
+}
+
+// getVersionSet retrieves a set of available k8s API versions
+func getVersionSet(client discovery.ServerResourcesInterface) (chartutil.VersionSet, error) {
+	groups, resources, err := client.ServerGroupsAndResources()
+	if err != nil && !discovery.IsGroupDiscoveryFailedError(err) {
+		return chartutil.DefaultVersionSet, errors.Wrap(err, "could not get apiVersions from Kubernetes")
+	}
+
+	if len(groups) == 0 && len(resources) == 0 {
+		return chartutil.DefaultVersionSet, nil
+	}
+
+	versionMap := make(map[string]interface{})
+	versions := []string{}
+
+	// Extract the groups
+	for _, g := range groups {
+		for _, gv := range g.Versions {
+			versionMap[gv.GroupVersion] = struct{}{}
+		}
+	}
+
+	// Extract the resources
+	var id string
+	var ok bool
+	for _, r := range resources {
+		for _, rl := range r.APIResources {
+			// A Kind at a GroupVersion can show up more than once. We only want
+			// it displayed once in the final output.
+			id = path.Join(r.GroupVersion, rl.Kind)
+			if _, ok = versionMap[id]; !ok {
+				versionMap[id] = struct{}{}
+			}
+		}
+	}
+
+	// Convert to a form that NewVersionSet can use
+	for k := range versionMap {
+		versions = append(versions, k)
+	}
+
+	return chartutil.VersionSet(versions), nil
+}
+
+// getCapabilities builds a Capabilities from discovery information.
+func getCapabilities(kubeConfig *rest.Config) (*chartutil.Capabilities, error) {
+	dc, err := discovery.NewDiscoveryClientForConfig(kubeConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	kubeVersion, err := dc.ServerVersion()
+	if err != nil {
+		return nil, errors.Wrap(err, "could not get server version from Kubernetes")
+	}
+
+	// Issue #6361:
+	// Client-Go emits an error when an API service is registered but unimplemented.
+	// We ignore that error here. But since the discovery client continues
+	// building the API object, it is correctly populated with all valid APIs.
+	// See https://github.com/kubernetes/kubernetes/issues/72051#issuecomment-521157642
+	apiVersions, err := getVersionSet(dc)
+	if err != nil && !discovery.IsGroupDiscoveryFailedError(err) {
+		return nil, errors.Wrap(err, "could not get apiVersions from Kubernetes")
+	}
+
+	return &chartutil.Capabilities{
+		APIVersions: apiVersions,
+		KubeVersion: chartutil.KubeVersion{
+			Version: kubeVersion.GitVersion,
+			Major:   kubeVersion.Major,
+			Minor:   kubeVersion.Minor,
+		},
+	}, nil
 }
 
 func newInstallControlPlaneCmd(ctx *install_context.InstallCpContext) *cobra.Command {
@@ -108,7 +185,7 @@ This command requires that the KUBECONFIG environment is set`,
 				return errors.Wrap(err, "Failed to evaluate helm values")
 			}
 
-			if args.UseNodePort && args.ControlPlane_mode == core.Global {
+			if args.UseNodePort && args.ControlPlane_mode == config_core.Global {
 				v := "controlPlane.globalZoneSyncService.type=NodePort"
 				if ctx.HELMValuesPrefix != "" {
 					v = fmt.Sprintf("%s.%s", ctx.HELMValuesPrefix, v)
@@ -137,12 +214,18 @@ This command requires that the KUBECONFIG environment is set`,
 				}
 			}
 
-			capabilities := *chartutil.DefaultCapabilities
+			capabilities := chartutil.DefaultCapabilities
+			if !args.WithoutKubernetesConnection {
+				capabilities, err = getCapabilities(kubeClientConfig)
+				if err != nil {
+					return errors.Wrap(err, "could not get Capabilities")
+				}
+			}
 			for _, version := range args.APIVersions {
 				capabilities.APIVersions = append(capabilities.APIVersions, version)
 			}
 
-			renderedFiles, err := renderHelmFiles(templateFiles, args.Namespace, vals, kubeClientConfig, capabilities)
+			renderedFiles, err := renderHelmFiles(templateFiles, args.Namespace, vals, kubeClientConfig, *capabilities)
 			if err != nil {
 				return errors.Wrap(err, "Failed to render helm template files")
 			}

--- a/app/kumactl/cmd/install/install_control_plane_test.go
+++ b/app/kumactl/cmd/install/install_control_plane_test.go
@@ -61,6 +61,7 @@ var _ = Describe("kumactl install control-plane", func() {
 				"--tls-general-secret", "general-tls-secret",
 				"--tls-general-ca-bundle", "XYZ",
 				"--skip-kinds", "CustomResourceDefinition",
+				"--without-kubernetes-connection",
 				"--values", inputFile,
 			},
 		)
@@ -109,6 +110,7 @@ var _ = Describe("kumactl install control-plane", func() {
 				"control-plane",
 				"--tls-general-secret", "general-tls-secret",
 				"--tls-general-ca-bundle", "XYZ",
+				"--without-kubernetes-connection",
 			}
 			if !given.includeCRDs {
 				args = append(args, "--skip-kinds", "CustomResourceDefinition")
@@ -139,16 +141,13 @@ var _ = Describe("kumactl install control-plane", func() {
 			ExpectMatchesGoldenFiles(actual, filepath.Join("testdata", given.goldenFile))
 		},
 		Entry("should generate Kubernetes resources with default settings", testCase{
-			extraArgs: []string{
-				"--without-kubernetes-connection",
-			},
+			extraArgs:   []string{},
 			includeCRDs: true,
 			goldenFile:  "install-control-plane.defaults.golden.yaml",
 		}),
 		Entry("should override default env-vars with values supplied", testCase{
 			extraArgs: []string{
 				"--env-var", "KUMA_DEFAULTS_SKIP_MESH_CREATION=true",
-				"--without-kubernetes-connection",
 			},
 			goldenFile: "install-control-plane.override-env-vars.golden.yaml",
 		}),
@@ -173,7 +172,6 @@ var _ = Describe("kumactl install control-plane", func() {
 				"--kds-global-address", "grpcs://192.168.0.1:5685",
 				"--zone", "zone-1",
 				"--use-node-port",
-				"--without-kubernetes-connection",
 				"--experimental-gatewayapi",
 			},
 			goldenFile: "install-control-plane.overrides.golden.yaml",
@@ -188,14 +186,12 @@ var _ = Describe("kumactl install control-plane", func() {
 		Entry("should generate Kubernetes resources with CNI plugin", testCase{
 			extraArgs: []string{
 				"--cni-enabled",
-				"--without-kubernetes-connection",
 			},
 			goldenFile: "install-control-plane.cni-enabled.golden.yaml",
 		}),
 		Entry("should generate Kubernetes resources with new CNI plugin (experimental)", testCase{
 			extraArgs: []string{
 				"--cni-enabled",
-				"--without-kubernetes-connection",
 				"--set",
 				"experimental.cni=true",
 			},
@@ -205,14 +201,12 @@ var _ = Describe("kumactl install control-plane", func() {
 			"using ebpf (experimental)", testCase{
 			extraArgs: []string{
 				"--set", "experimental.ebpf.enabled=true",
-				"--without-kubernetes-connection",
 			},
 			goldenFile: "install-control-plane.tproxy-ebpf-experimental-enabled.golden.yaml",
 		}),
 		Entry("should generate Kubernetes resources for Global", testCase{
 			extraArgs: []string{
 				"--mode", "global",
-				"--without-kubernetes-connection",
 			},
 			goldenFile: "install-control-plane.global.golden.yaml",
 		}),
@@ -221,7 +215,6 @@ var _ = Describe("kumactl install control-plane", func() {
 				"--mode", "zone",
 				"--zone", "zone-1",
 				"--kds-global-address", "grpcs://192.168.0.1:5685",
-				"--without-kubernetes-connection",
 			},
 			goldenFile: "install-control-plane.zone.golden.yaml",
 		}),
@@ -233,7 +226,6 @@ var _ = Describe("kumactl install control-plane", func() {
 				"--zone", "zone-1",
 				"--kds-global-address", "grpcs://192.168.0.1:5685",
 				"--ingress-use-node-port",
-				"--without-kubernetes-connection",
 			},
 			goldenFile: "install-control-plane.with-ingress.golden.yaml",
 		}),
@@ -241,7 +233,6 @@ var _ = Describe("kumactl install control-plane", func() {
 			extraArgs: []string{
 				"--egress-enabled",
 				"--egress-drain-time", "60s",
-				"--without-kubernetes-connection",
 			},
 			goldenFile: "install-control-plane.with-egress.golden.yaml",
 		}),
@@ -274,7 +265,6 @@ controlPlane:
 		}),
 		Entry("should add GatewayClass if CRDs are present and enabled", testCase{
 			extraArgs: []string{
-				"--without-kubernetes-connection",
 				"--api-versions", fmt.Sprintf("%s/%s", gatewayapi.GroupVersion.String(), "GatewayClass"),
 				"--experimental-gatewayapi",
 			},
@@ -283,7 +273,6 @@ controlPlane:
 		}),
 		Entry("should not add GatewayClass if experimental not enabled", testCase{
 			extraArgs: []string{
-				"--without-kubernetes-connection",
 				"--api-versions", fmt.Sprintf("%s/%s", gatewayapi.GroupVersion.String(), "GatewayClass"),
 			},
 			includeCRDs: true,

--- a/test/e2e/gateway/gatewayapi/conformance_test.go
+++ b/test/e2e/gateway/gatewayapi/conformance_test.go
@@ -40,10 +40,10 @@ func TestConformance(t *testing.T) {
 
 	cluster := NewK8sCluster(t, clusterName, Silent)
 
-	defer func() {
+	t.Cleanup(func() {
 		g.Expect(cluster.DeleteKuma()).To(Succeed())
 		g.Expect(cluster.DismissCluster()).To(Succeed())
-	}()
+	})
 
 	g.Expect(cluster.Install(gateway.GatewayAPICRDs)).To(Succeed())
 	g.Eventually(func() error {

--- a/test/e2e/gateway/gatewayapi/conformance_test.go
+++ b/test/e2e/gateway/gatewayapi/conformance_test.go
@@ -23,15 +23,6 @@ var clusterName = Kuma1
 var minNodePort = 30080
 var maxNodePort = 30089
 
-const gatewayClass = `
-apiVersion: gateway.networking.k8s.io/v1beta1
-kind: GatewayClass
-metadata:
-  name: kuma
-spec:
-  controllerName: gateways.kuma.io/controller
-`
-
 // TestConformance runs as a `testing` test and not Ginkgo so we have to use an
 // explicit `g` to use Gomega.
 func TestConformance(t *testing.T) {
@@ -59,7 +50,6 @@ func TestConformance(t *testing.T) {
 		Install(Kuma(config_core.Standalone,
 			WithCtlOpts(map[string]string{"--experimental-gatewayapi": "true"}),
 		)).
-		Install(YamlK8s(gatewayClass)).
 		Setup(cluster)
 	g.Expect(err).ToNot(HaveOccurred())
 

--- a/test/e2e/gateway/gatewayapi/conformance_test.go
+++ b/test/e2e/gateway/gatewayapi/conformance_test.go
@@ -45,13 +45,14 @@ func TestConformance(t *testing.T) {
 		g.Expect(cluster.DismissCluster()).To(Succeed())
 	}()
 
-	err := NewClusterSetup().
-		Install(gateway.GatewayAPICRDs).
-		Install(Kuma(config_core.Standalone,
-			WithCtlOpts(map[string]string{"--experimental-gatewayapi": "true"}),
-		)).
-		Setup(cluster)
-	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(cluster.Install(gateway.GatewayAPICRDs)).To(Succeed())
+	g.Eventually(func() error {
+		return NewClusterSetup().
+			Install(Kuma(config_core.Standalone,
+				WithCtlOpts(map[string]string{"--experimental-gatewayapi": "true"}),
+			)).
+			Setup(cluster)
+	}, "30s", "3s").Should(Succeed())
 
 	opts := cluster.GetKubectlOptions()
 


### PR DESCRIPTION
This wasn't being set correctly when using actual clusters so `.Capabilities.APIVersions` in templates wasn't working correctly with `kumactl`. Which meant that the `GatewayClass` in the templates wasn't ever created, even if Gateway API CRDs are in the cluster.

This code is more or less directly [inlined from helm](https://github.com/helm/helm/blob/5cb9af4b1b271d11d7a97a71df3ac337dd94ad37/pkg/action/action.go#L239) because these aren't public functions.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] Link to docs PR or issue --
- [x] Link to UI issue or PR --
- [x] Is the [issue worked on linked][1]? --
- [x] The PR does not hardcode values that might break projects that depend on kuma (e.g. "kumahq" as a image registry) --
- [x] The PR will work for both Linux and Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Unit Tests --
- [x] E2E Tests --
- [x] Manual Universal Tests --
- [x] Manual Kubernetes Tests --
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [x] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
