### PR TITLE
feat: add `crossMesh` to `MeshGatewayConfig`

### DIFF
--- a/app/kumactl/cmd/install/testdata/install-control-plane.gateway-api-present.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.gateway-api-present.yaml
@@ -2724,27 +2724,9 @@ spec:
 apiVersion: gateway.networking.k8s.io/v1beta1
 kind: GatewayClass
 metadata:
-  name: kuma
+ name: kuma
 spec:
-  controllerName: "gateways.kuma.io/controller"
----
-apiVersion: gateway.networking.k8s.io/v1beta1
-kind: GatewayClass
-metadata:
-  name: kuma-cross-mesh
-spec:
-  controllerName: "gateways.kuma.io/controller"
-  parametersRef:
-    group: kuma.io/v1alpha1
-    kind: MeshGatewayConfig
-    name: default-cross-mesh
----
-apiVersion: kuma.io/v1alpha1
-kind: MeshGatewayConfig
-metadata:
-  name: default-cross-mesh
-spec:
-  crossMesh: true
+ controllerName: "gateways.kuma.io/controller"
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration

--- a/app/kumactl/cmd/install/testdata/install-control-plane.gateway-api-present.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.gateway-api-present.yaml
@@ -2720,9 +2720,27 @@ spec:
 apiVersion: gateway.networking.k8s.io/v1beta1
 kind: GatewayClass
 metadata:
- name: kuma
+  name: kuma
 spec:
- controllerName: "gateways.kuma.io/controller"
+  controllerName: "gateways.kuma.io/controller"
+---
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: GatewayClass
+metadata:
+  name: kuma-cross-mesh
+spec:
+  controllerName: "gateways.kuma.io/controller"
+  parametersRef:
+    group: kuma.io/v1alpha1
+    kind: MeshGatewayConfig
+    name: default-cross-mesh
+---
+apiVersion: kuma.io/v1alpha1
+kind: MeshGatewayConfig
+metadata:
+  name: default-cross-mesh
+spec:
+  crossMesh: true
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration

--- a/app/kumactl/cmd/install/testdata/install-control-plane.gateway-api-present.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.gateway-api-present.yaml
@@ -2205,6 +2205,10 @@ spec:
             description: MeshGatewayConfigSpec specifies the options available for
               a Kuma MeshGateway.
             properties:
+              crossMesh:
+                description: CrossMesh specifies whether listeners configured by this
+                  gateway are cross mesh listeners.
+                type: boolean
               replicas:
                 default: 1
                 description: Replicas is the number of dataplane proxy replicas to

--- a/app/kumactl/cmd/install/testdata/install-crds.experimental-gatewayapi.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-crds.experimental-gatewayapi.golden.yaml
@@ -733,6 +733,10 @@ spec:
             description: MeshGatewayConfigSpec specifies the options available for
               a Kuma MeshGateway.
             properties:
+              crossMesh:
+                description: CrossMesh specifies whether listeners configured by this
+                  gateway are cross mesh listeners.
+                type: boolean
               replicas:
                 default: 1
                 description: Replicas is the number of dataplane proxy replicas to

--- a/deployments/charts/kuma/crds/kuma.io_meshgatewayconfigs.yaml
+++ b/deployments/charts/kuma/crds/kuma.io_meshgatewayconfigs.yaml
@@ -39,6 +39,10 @@ spec:
             description: MeshGatewayConfigSpec specifies the options available for
               a Kuma MeshGateway.
             properties:
+              crossMesh:
+                description: CrossMesh specifies whether listeners configured by this
+                  gateway are cross mesh listeners.
+                type: boolean
               replicas:
                 default: 1
                 description: Replicas is the number of dataplane proxy replicas to

--- a/deployments/charts/kuma/templates/gateway-class.yaml
+++ b/deployments/charts/kuma/templates/gateway-class.yaml
@@ -3,7 +3,25 @@
 apiVersion: gateway.networking.k8s.io/v1beta1
 kind: GatewayClass
 metadata:
- name: kuma
+  name: kuma
 spec:
- controllerName: "gateways.kuma.io/controller"
+  controllerName: "gateways.kuma.io/controller"
+---
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: GatewayClass
+metadata:
+  name: kuma-cross-mesh
+spec:
+  controllerName: "gateways.kuma.io/controller"
+  parametersRef:
+    group: kuma.io/v1alpha1
+    kind: MeshGatewayConfig
+    name: default-cross-mesh
+---
+apiVersion: kuma.io/v1alpha1
+kind: MeshGatewayConfig
+metadata:
+  name: default-cross-mesh
+spec:
+  crossMesh: true
 {{- end }}

--- a/deployments/charts/kuma/templates/gateway-class.yaml
+++ b/deployments/charts/kuma/templates/gateway-class.yaml
@@ -3,25 +3,7 @@
 apiVersion: gateway.networking.k8s.io/v1beta1
 kind: GatewayClass
 metadata:
-  name: kuma
+ name: kuma
 spec:
-  controllerName: "gateways.kuma.io/controller"
----
-apiVersion: gateway.networking.k8s.io/v1beta1
-kind: GatewayClass
-metadata:
-  name: kuma-cross-mesh
-spec:
-  controllerName: "gateways.kuma.io/controller"
-  parametersRef:
-    group: kuma.io/v1alpha1
-    kind: MeshGatewayConfig
-    name: default-cross-mesh
----
-apiVersion: kuma.io/v1alpha1
-kind: MeshGatewayConfig
-metadata:
-  name: default-cross-mesh
-spec:
-  crossMesh: true
+ controllerName: "gateways.kuma.io/controller"
 {{- end }}

--- a/pkg/plugins/resources/k8s/native/api/v1alpha1/mesh_gateway_config.go
+++ b/pkg/plugins/resources/k8s/native/api/v1alpha1/mesh_gateway_config.go
@@ -90,6 +90,10 @@ type MeshGatewayServiceSpec struct {
 type MeshGatewayConfigSpec struct {
 	MeshGatewayCommonConfig `json:",inline"`
 
+	// CrossMesh specifies whether listeners configured by this gateway are
+	// cross mesh listeners.
+	CrossMesh bool `json:"crossMesh,omitempty"`
+
 	// Tags specifies a set of Kuma tags that are included in the
 	// MeshGatewayInstance and thus propagated to every Dataplane generated to
 	// serve the MeshGateway.

--- a/pkg/plugins/runtime/k8s/controllers/gatewayapi/gateway_conversion_test.go
+++ b/pkg/plugins/runtime/k8s/controllers/gatewayapi/gateway_conversion_test.go
@@ -144,8 +144,8 @@ var _ = Describe("ValidateListeners", func() {
 
 		invalid := ContainElements(
 			MatchFields(IgnoreExtras, Fields{
-				"Type":   Equal(string(gatewayapi.ListenerConditionDetached)),
-				"Status": Equal(kube_meta.ConditionTrue),
+				"Type":   Equal(string(gatewayapi.ListenerConditionAccepted)),
+				"Status": Equal(kube_meta.ConditionFalse),
 				"Reason": Equal(string(gatewayapi.ListenerReasonUnsupportedProtocol)),
 			}),
 			MatchFields(IgnoreExtras, Fields{

--- a/test/framework/setup.go
+++ b/test/framework/setup.go
@@ -132,6 +132,16 @@ func YamlK8s(yaml string) InstallFunc {
 	}
 }
 
+func DeleteYamlK8s(yaml string) InstallFunc {
+	return func(cluster Cluster) error {
+		_, err := retry.DoWithRetryE(cluster.GetTesting(), "delete yaml resource", DefaultRetries, DefaultTimeout,
+			func() (s string, err error) {
+				return "", k8s.KubectlDeleteFromStringE(cluster.GetTesting(), cluster.GetKubectlOptions(), yaml)
+			})
+		return err
+	}
+}
+
 func MeshUniversal(name string) InstallFunc {
 	mesh := fmt.Sprintf(`
 type: Mesh


### PR DESCRIPTION
This is an alternative to #4911 for using cross mesh and Gateway API.

- ~[ ] Blocker: adding a `MeshGatewayConfig` to the `install control-plane` resources breaks `kumactl install control-plane | kubectl apply -f -` because `kubectl apply` does not ensure that CRDs are installed first, leading to a race condition with errors like `unknown resource MeshGatewayConfig, ensure CRDs exist`~
  I'll handle ensuring this `GatewayClass` exists in another PR

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] Link to docs PR or issue --
- [x] Link to UI issue or PR --
- [x] Is the [issue worked on linked][1]? -- Closes #4397 
- [x] The PR does not hardcode values that might break projects that depend on kuma (e.g. "kumahq" as a image registry) --
- [x] The PR will work for both Linux and Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Unit Tests --
- [x] E2E Tests --
- [x] Manual Universal Tests --
- [x] Manual Kubernetes Tests --
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [x] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
