### PR TITLE
feat(kuma-cp): policy origin in rules

### DIFF
--- a/pkg/core/xds/matched_policies.go
+++ b/pkg/core/xds/matched_policies.go
@@ -20,6 +20,11 @@ type PolicyItem interface {
 	GetDefaultAsProto() proto.Message
 }
 
+type PolicyItemWithMeta struct {
+	PolicyItem
+	core_model.ResourceMeta
+}
+
 type Policy interface {
 	core_model.ResourceSpec
 	GetTargetRef() *common_proto.TargetRef
@@ -43,6 +48,17 @@ type PolicyWithSingleItem interface {
 type InboundListener struct {
 	Address string
 	Port    uint32
+}
+
+func BuildPolicyItemsWithMeta(items []PolicyItem, meta core_model.ResourceMeta) []PolicyItemWithMeta {
+	var result []PolicyItemWithMeta
+	for _, item := range items {
+		result = append(result, PolicyItemWithMeta{
+			PolicyItem:   item,
+			ResourceMeta: meta,
+		})
+	}
+	return result
 }
 
 // We need to implement TextMarshaler because InboundListener is used

--- a/pkg/core/xds/rules.go
+++ b/pkg/core/xds/rules.go
@@ -83,7 +83,6 @@ func (ss Subset) IndexOfPositive() int {
 type Rule struct {
 	Subset Subset
 	Conf   proto.Message
-	// todo(lobkovilya): add support for Origin to implement Inspect API
 	Origin []core_model.ResourceMeta
 }
 
@@ -104,7 +103,7 @@ func (rs Rules) Compute(sub Subset) proto.Message {
 // Filtering out of negative rules could be useful for XDS generators that don't have a way to configure negations.
 //
 // See the detailed algorithm description in docs/madr/decisions/007-mesh-traffic-permission.md
-func BuildRules(list []PolicyItem) (Rules, error) {
+func BuildRules(list []PolicyItemWithMeta) (Rules, error) {
 	rules := Rules{}
 
 	// 1. Each targetRef should be represented as a list of tags
@@ -139,6 +138,7 @@ func BuildRules(list []PolicyItem) (Rules, error) {
 		}
 		// 3. For each combination determine a configuration
 		confs := []any{}
+		distinctOrigins := map[core_model.ResourceMeta]struct{}{}
 		for i := 0; i < len(list); i++ {
 			item := list[i]
 			itemSubset, err := asSubset(item.GetTargetRef())
@@ -147,6 +147,7 @@ func BuildRules(list []PolicyItem) (Rules, error) {
 			}
 			if itemSubset.IsSubset(ss) {
 				confs = append(confs, item.GetDefaultAsProto())
+				distinctOrigins[item.ResourceMeta] = struct{}{}
 			}
 		}
 		merged, err := merge(confs)
@@ -154,9 +155,17 @@ func BuildRules(list []PolicyItem) (Rules, error) {
 			return nil, err
 		}
 		if merged != nil {
+			var origins []core_model.ResourceMeta
+			for origin := range distinctOrigins {
+				origins = append(origins, origin)
+			}
+			sort.Slice(origins, func(i, j int) bool {
+				return origins[i].GetName() < origins[j].GetName()
+			})
 			rules = append(rules, &Rule{
 				Subset: ss,
 				Conf:   merged,
+				Origin: origins,
 			})
 		}
 	}

--- a/pkg/core/xds/rules_test.go
+++ b/pkg/core/xds/rules_test.go
@@ -162,7 +162,7 @@ var _ = Describe("Rules", func() {
 				Expect(ok).To(BeTrue())
 
 				// when
-				rules, err := xds.BuildRules(mtp.GetFromList())
+				rules, err := xds.BuildRules(xds.BuildPolicyItemsWithMeta(mtp.GetFromList(), policy.GetMeta()))
 				Expect(err).ToNot(HaveOccurred())
 
 				// then
@@ -200,13 +200,13 @@ var _ = Describe("Rules", func() {
 				Expect(err).ToNot(HaveOccurred())
 
 				yamls := util_yaml.SplitYAML(string(policyBytes))
-				policies := []xds.PolicyItem{}
+				policies := []xds.PolicyItemWithMeta{}
 				for _, yaml := range yamls {
 					policy, err := rest.YAML.UnmarshalCore([]byte(yaml))
 					Expect(err).ToNot(HaveOccurred())
 					mt, ok := policy.(*meshtrace_api.MeshTraceResource)
 					Expect(ok).To(BeTrue())
-					policies = append(policies, mt.Spec.GetPolicyItem())
+					policies = append(policies, xds.PolicyItemWithMeta{mt.Spec.GetPolicyItem(), policy.GetMeta()})
 				}
 
 				// when

--- a/pkg/core/xds/testdata/rules/01.golden.yaml
+++ b/pkg/core/xds/testdata/rules/01.golden.yaml
@@ -1,6 +1,11 @@
 - Conf:
     action: ALLOW
-  Origin: null
+  Origin:
+  - creationTime: "0001-01-01T00:00:00Z"
+    mesh: mesh-1
+    modificationTime: "0001-01-01T00:00:00Z"
+    name: mtp-1
+    type: MeshTrafficPermission
   Subset:
   - Key: env
     Not: false
@@ -10,7 +15,12 @@
     Value: us-east
 - Conf:
     action: ALLOW
-  Origin: null
+  Origin:
+  - creationTime: "0001-01-01T00:00:00Z"
+    mesh: mesh-1
+    modificationTime: "0001-01-01T00:00:00Z"
+    name: mtp-1
+    type: MeshTrafficPermission
   Subset:
   - Key: env
     Not: false
@@ -20,7 +30,12 @@
     Value: us-east
 - Conf:
     action: DENY
-  Origin: null
+  Origin:
+  - creationTime: "0001-01-01T00:00:00Z"
+    mesh: mesh-1
+    modificationTime: "0001-01-01T00:00:00Z"
+    name: mtp-1
+    type: MeshTrafficPermission
   Subset:
   - Key: env
     Not: true
@@ -33,7 +48,12 @@
     Value: us-east
 - Conf:
     action: ALLOW
-  Origin: null
+  Origin:
+  - creationTime: "0001-01-01T00:00:00Z"
+    mesh: mesh-1
+    modificationTime: "0001-01-01T00:00:00Z"
+    name: mtp-1
+    type: MeshTrafficPermission
   Subset:
   - Key: env
     Not: false
@@ -43,7 +63,12 @@
     Value: us-east
 - Conf:
     action: ALLOW
-  Origin: null
+  Origin:
+  - creationTime: "0001-01-01T00:00:00Z"
+    mesh: mesh-1
+    modificationTime: "0001-01-01T00:00:00Z"
+    name: mtp-1
+    type: MeshTrafficPermission
   Subset:
   - Key: env
     Not: false
@@ -53,7 +78,12 @@
     Value: us-east
 - Conf:
     action: ALLOW
-  Origin: null
+  Origin:
+  - creationTime: "0001-01-01T00:00:00Z"
+    mesh: mesh-1
+    modificationTime: "0001-01-01T00:00:00Z"
+    name: mtp-1
+    type: MeshTrafficPermission
   Subset:
   - Key: env
     Not: true

--- a/pkg/core/xds/testdata/rules/02.golden.yaml
+++ b/pkg/core/xds/testdata/rules/02.golden.yaml
@@ -1,6 +1,11 @@
 - Conf:
     action: ALLOW
-  Origin: null
+  Origin:
+  - creationTime: "0001-01-01T00:00:00Z"
+    mesh: mesh-1
+    modificationTime: "0001-01-01T00:00:00Z"
+    name: mtp-1
+    type: MeshTrafficPermission
   Subset:
   - Key: env
     Not: false
@@ -13,7 +18,12 @@
     Value: us-east
 - Conf:
     action: DENY
-  Origin: null
+  Origin:
+  - creationTime: "0001-01-01T00:00:00Z"
+    mesh: mesh-1
+    modificationTime: "0001-01-01T00:00:00Z"
+    name: mtp-1
+    type: MeshTrafficPermission
   Subset:
   - Key: env
     Not: true
@@ -26,7 +36,12 @@
     Value: us-east
 - Conf:
     action: ALLOW
-  Origin: null
+  Origin:
+  - creationTime: "0001-01-01T00:00:00Z"
+    mesh: mesh-1
+    modificationTime: "0001-01-01T00:00:00Z"
+    name: mtp-1
+    type: MeshTrafficPermission
   Subset:
   - Key: env
     Not: false
@@ -39,7 +54,12 @@
     Value: us-east
 - Conf:
     action: ALLOW
-  Origin: null
+  Origin:
+  - creationTime: "0001-01-01T00:00:00Z"
+    mesh: mesh-1
+    modificationTime: "0001-01-01T00:00:00Z"
+    name: mtp-1
+    type: MeshTrafficPermission
   Subset:
   - Key: env
     Not: false
@@ -52,7 +72,12 @@
     Value: us-east
 - Conf:
     action: DENY
-  Origin: null
+  Origin:
+  - creationTime: "0001-01-01T00:00:00Z"
+    mesh: mesh-1
+    modificationTime: "0001-01-01T00:00:00Z"
+    name: mtp-1
+    type: MeshTrafficPermission
   Subset:
   - Key: env
     Not: true
@@ -65,7 +90,12 @@
     Value: us-east
 - Conf:
     action: ALLOW
-  Origin: null
+  Origin:
+  - creationTime: "0001-01-01T00:00:00Z"
+    mesh: mesh-1
+    modificationTime: "0001-01-01T00:00:00Z"
+    name: mtp-1
+    type: MeshTrafficPermission
   Subset:
   - Key: env
     Not: true
@@ -78,7 +108,12 @@
     Value: us-east
 - Conf:
     action: ALLOW
-  Origin: null
+  Origin:
+  - creationTime: "0001-01-01T00:00:00Z"
+    mesh: mesh-1
+    modificationTime: "0001-01-01T00:00:00Z"
+    name: mtp-1
+    type: MeshTrafficPermission
   Subset:
   - Key: env
     Not: false

--- a/pkg/core/xds/testdata/rules/03.golden.yaml
+++ b/pkg/core/xds/testdata/rules/03.golden.yaml
@@ -1,27 +1,47 @@
 - Conf:
     action: DENY
-  Origin: null
+  Origin:
+  - creationTime: "0001-01-01T00:00:00Z"
+    mesh: mesh-1
+    modificationTime: "0001-01-01T00:00:00Z"
+    name: mtp-1
+    type: MeshTrafficPermission
   Subset:
   - Key: kuma.io/service
     Not: false
     Value: web
 - Conf:
     action: DENY_WITH_SHADOW_ALLOW
-  Origin: null
+  Origin:
+  - creationTime: "0001-01-01T00:00:00Z"
+    mesh: mesh-1
+    modificationTime: "0001-01-01T00:00:00Z"
+    name: mtp-1
+    type: MeshTrafficPermission
   Subset:
   - Key: kuma.io/service
     Not: false
     Value: orders
 - Conf:
     action: ALLOW
-  Origin: null
+  Origin:
+  - creationTime: "0001-01-01T00:00:00Z"
+    mesh: mesh-1
+    modificationTime: "0001-01-01T00:00:00Z"
+    name: mtp-1
+    type: MeshTrafficPermission
   Subset:
   - Key: kuma.io/service
     Not: false
     Value: backend
 - Conf:
     action: ALLOW_WITH_SHADOW_DENY
-  Origin: null
+  Origin:
+  - creationTime: "0001-01-01T00:00:00Z"
+    mesh: mesh-1
+    modificationTime: "0001-01-01T00:00:00Z"
+    name: mtp-1
+    type: MeshTrafficPermission
   Subset:
   - Key: kuma.io/service
     Not: false

--- a/pkg/core/xds/testdata/rules/04.golden.yaml
+++ b/pkg/core/xds/testdata/rules/04.golden.yaml
@@ -1,4 +1,9 @@
 - Conf:
     backends: []
-  Origin: null
+  Origin:
+  - creationTime: "0001-01-01T00:00:00Z"
+    mesh: mesh-1
+    modificationTime: "0001-01-01T00:00:00Z"
+    name: mal-1
+    type: MeshAccessLog
   Subset: []

--- a/pkg/core/xds/testdata/rules/05.golden.yaml
+++ b/pkg/core/xds/testdata/rules/05.golden.yaml
@@ -2,5 +2,10 @@
     backends:
     - tcp:
         address: logging:8080
-  Origin: null
+  Origin:
+  - creationTime: "0001-01-01T00:00:00Z"
+    mesh: mesh-1
+    modificationTime: "0001-01-01T00:00:00Z"
+    name: mal-1
+    type: MeshAccessLog
   Subset: []

--- a/pkg/core/xds/testdata/rules/06.golden.yaml
+++ b/pkg/core/xds/testdata/rules/06.golden.yaml
@@ -5,5 +5,10 @@
     tags:
     - literal: core
       name: team
-  Origin: null
+  Origin:
+  - creationTime: "0001-01-01T00:00:00Z"
+    mesh: mesh-1
+    modificationTime: "0001-01-01T00:00:00Z"
+    name: mt-1
+    type: MeshTrace
   Subset: []

--- a/pkg/core/xds/testdata/rules/07.golden.yaml
+++ b/pkg/core/xds/testdata/rules/07.golden.yaml
@@ -5,5 +5,15 @@
     tags:
     - literal: support
       name: team
-  Origin: null
+  Origin:
+  - creationTime: "0001-01-01T00:00:00Z"
+    mesh: mesh-1
+    modificationTime: "0001-01-01T00:00:00Z"
+    name: mt-1
+    type: MeshTrace
+  - creationTime: "0001-01-01T00:00:00Z"
+    mesh: mesh-1
+    modificationTime: "0001-01-01T00:00:00Z"
+    name: mt-2
+    type: MeshTrace
   Subset: []

--- a/pkg/plugins/policies/matchers/testdata/match/fromrules/01.golden.yaml
+++ b/pkg/plugins/policies/matchers/testdata/match/fromrules/01.golden.yaml
@@ -2,21 +2,46 @@ Rules:
   1.1.1.1:8080:
   - Conf:
       action: ALLOW_WITH_SHADOW_DENY
-    Origin: null
+    Origin:
+    - creationTime: "0001-01-01T00:00:00Z"
+      mesh: mesh-1
+      modificationTime: "0001-01-01T00:00:00Z"
+      name: mtp-1
+      type: MeshTrafficPermission
+    - creationTime: "0001-01-01T00:00:00Z"
+      mesh: mesh-1
+      modificationTime: "0001-01-01T00:00:00Z"
+      name: mtp-2
+      type: MeshTrafficPermission
     Subset:
     - Key: kuma.io/service
       Not: false
       Value: orders
   - Conf:
       action: ALLOW
-    Origin: null
+    Origin:
+    - creationTime: "0001-01-01T00:00:00Z"
+      mesh: mesh-1
+      modificationTime: "0001-01-01T00:00:00Z"
+      name: mtp-1
+      type: MeshTrafficPermission
+    - creationTime: "0001-01-01T00:00:00Z"
+      mesh: mesh-1
+      modificationTime: "0001-01-01T00:00:00Z"
+      name: mtp-2
+      type: MeshTrafficPermission
     Subset:
     - Key: kuma.io/service
       Not: false
       Value: backend
   - Conf:
       action: DENY
-    Origin: null
+    Origin:
+    - creationTime: "0001-01-01T00:00:00Z"
+      mesh: mesh-1
+      modificationTime: "0001-01-01T00:00:00Z"
+      name: mtp-2
+      type: MeshTrafficPermission
     Subset:
     - Key: kuma.io/service
       Not: true
@@ -27,5 +52,10 @@ Rules:
   1.1.1.1:8081:
   - Conf:
       action: DENY
-    Origin: null
+    Origin:
+    - creationTime: "0001-01-01T00:00:00Z"
+      mesh: mesh-1
+      modificationTime: "0001-01-01T00:00:00Z"
+      name: mtp-2
+      type: MeshTrafficPermission
     Subset: []

--- a/pkg/plugins/policies/matchers/testdata/match/fromrules/02.golden.yaml
+++ b/pkg/plugins/policies/matchers/testdata/match/fromrules/02.golden.yaml
@@ -2,7 +2,17 @@ Rules:
   1.1.1.1:8080:
   - Conf:
       action: ALLOW
-    Origin: null
+    Origin:
+    - creationTime: "0001-01-01T00:00:00Z"
+      mesh: mesh-1
+      modificationTime: "0001-01-01T00:00:00Z"
+      name: mtp-1
+      type: MeshTrafficPermission
+    - creationTime: "0001-01-01T00:00:00Z"
+      mesh: mesh-1
+      modificationTime: "0001-01-01T00:00:00Z"
+      name: mtp-2
+      type: MeshTrafficPermission
     Subset:
     - Key: kuma.io/service
       Not: false
@@ -15,7 +25,12 @@ Rules:
       Value: v2
   - Conf:
       action: DENY
-    Origin: null
+    Origin:
+    - creationTime: "0001-01-01T00:00:00Z"
+      mesh: mesh-1
+      modificationTime: "0001-01-01T00:00:00Z"
+      name: mtp-2
+      type: MeshTrafficPermission
     Subset:
     - Key: kuma.io/service
       Not: true
@@ -28,7 +43,12 @@ Rules:
       Value: v2
   - Conf:
       action: DENY
-    Origin: null
+    Origin:
+    - creationTime: "0001-01-01T00:00:00Z"
+      mesh: mesh-1
+      modificationTime: "0001-01-01T00:00:00Z"
+      name: mtp-2
+      type: MeshTrafficPermission
     Subset:
     - Key: kuma.io/service
       Not: false
@@ -41,7 +61,12 @@ Rules:
       Value: v2
   - Conf:
       action: DENY
-    Origin: null
+    Origin:
+    - creationTime: "0001-01-01T00:00:00Z"
+      mesh: mesh-1
+      modificationTime: "0001-01-01T00:00:00Z"
+      name: mtp-2
+      type: MeshTrafficPermission
     Subset:
     - Key: kuma.io/service
       Not: true
@@ -55,7 +80,12 @@ Rules:
   1.1.1.1:8081:
   - Conf:
       action: DENY
-    Origin: null
+    Origin:
+    - creationTime: "0001-01-01T00:00:00Z"
+      mesh: mesh-1
+      modificationTime: "0001-01-01T00:00:00Z"
+      name: mtp-2
+      type: MeshTrafficPermission
     Subset:
     - Key: kuma.io/zone
       Not: false

--- a/pkg/plugins/policies/matchers/testdata/match/meshgateways/01.golden.yaml
+++ b/pkg/plugins/policies/matchers/testdata/match/meshgateways/01.golden.yaml
@@ -2,10 +2,25 @@ Rules:
   127.0.0.1:8080:
   - Conf:
       action: DENY
-    Origin: null
+    Origin:
+    - creationTime: "0001-01-01T00:00:00Z"
+      mesh: mesh-1
+      modificationTime: "0001-01-01T00:00:00Z"
+      name: mtp-1
+      type: MeshTrafficPermission
     Subset: []
   127.0.0.1:8081:
   - Conf:
       action: ALLOW
-    Origin: null
+    Origin:
+    - creationTime: "0001-01-01T00:00:00Z"
+      mesh: mesh-1
+      modificationTime: "0001-01-01T00:00:00Z"
+      name: mtp-1
+      type: MeshTrafficPermission
+    - creationTime: "0001-01-01T00:00:00Z"
+      mesh: mesh-1
+      modificationTime: "0001-01-01T00:00:00Z"
+      name: mtp-2
+      type: MeshTrafficPermission
     Subset: []


### PR DESCRIPTION
Implement policy origin in rules so we can expose this in inspect API.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [X] Link to docs PR or issue -- no
- [X] Link to UI issue or PR -- no
- [X] Is the [issue worked on linked][1]? -- no
- [X] The PR does not hardcode values that might break projects that depend on kuma (e.g. "kumahq" as a image registry) --
- [X] The PR will work for both Linux and Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [X] Unit Tests --
- [ ] E2E Tests --
- [ ] Manual Universal Tests --
- [ ] Manual Kubernetes Tests --
- [X] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --no 
- [X] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? -- no
- [X] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests? no

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
