### PR TITLE
fix(gatewayapi): don't NPE if the `GatewayClass` ref doesn't exist

### DIFF
--- a/pkg/plugins/runtime/k8s/controllers/gatewayapi/gateway_controller.go
+++ b/pkg/plugins/runtime/k8s/controllers/gatewayapi/gateway_controller.go
@@ -64,7 +64,7 @@ func (r *GatewayReconciler) Reconcile(ctx context.Context, req kube_ctrl.Request
 		return kube_ctrl.Result{}, errors.Wrap(err, "unable to retrieve GatewayClass referenced by MeshGateway")
 	}
 
-	if class.Spec.ControllerName != common.ControllerName {
+	if class == nil || class.Spec.ControllerName != common.ControllerName {
 		return kube_ctrl.Result{}, nil
 	}
 


### PR DESCRIPTION
### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] Link to docs PR or issue --
- [x] Link to UI issue or PR --
- [x] Is the [issue worked on linked][1]? --
- [x] The PR does not hardcode values that might break projects that depend on kuma (e.g. "kumahq" as a image registry) --
- [x] The PR will work for both Linux and Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Unit Tests -- none
- [x] E2E Tests -- none
- [x] Manual Universal Tests --
- [x] Manual Kubernetes Tests --
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [x] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
