### PR TITLE
docs: rewrite dataplane proto docs

### DIFF
--- a/api/mesh/v1alpha1/dataplane.proto
+++ b/api/mesh/v1alpha1/dataplane.proto
@@ -18,7 +18,7 @@ option (doc.config) = {
   file_name : "dataplane"
 };
 
-// Dataplane defines configuration of a side-car proxy.
+// Dataplane defines a configuration of a side-car proxy.
 message Dataplane {
 
   option (kuma.mesh.resource).name = "DataplaneResource";
@@ -28,52 +28,75 @@ message Dataplane {
   option (kuma.mesh.resource).ws.name = "dataplane";
   option (kuma.mesh.resource).scope_namespace = true;
 
-  // Networking describes inbound and outbound interfaces of a dataplane.
+  // Networking describes inbound and outbound interfaces of a data plane proxy.
   message Networking {
 
-    // Public IP on which the dataplane is accessible in the network.
+    // IP on which the data plane proxy is accessible to the control plane and
+    // other data plane proxies in the same network. This can also be a
+    // hostname, in which case the control plane will periodically resolve it.
     string address = 5 [ (doc.required) = true ];
 
     reserved 6; // Formerly ingress mode message, see #3435
 
-    // In some situation, dataplane resides in a private network and not
-    // reachable via 'address'. advertisedAddress is configured with public
-    // routable address for such dataplane so that other dataplanes in the mesh
-    // can connect to it over advertisedAddress and not via address
-    // Note: Envoy binds to the address not advertisedAddress
+    // In some situations, a data plane proxy resides in a private network (e.g.
+    // Docker) and is not reachable via `address` to other data plane proxies.
+    // `advertisedAddress` is configured with a routable address for such data
+    // plane proxy so that other proxies in the mesh can connect to it over
+    // `advertisedAddress` and not via address.
+    //
+    // Envoy still binds to the `address`, not `advertisedAddress`.
     string advertisedAddress = 7;
 
-    // Inbound describes a service implemented by the dataplane.
+    // Inbound describes a service implemented by the data plane proxy.
+    // All incoming traffic to a data plane proxy are going through inbound
+    // listeners. For every defined Inbound there is a corresponding Envoy
+    // Listener.
     message Inbound {
       // Port of the inbound interface that will forward requests to the
       // service.
+      //
+      // When transparent proxying is used, it is a port on which the service is
+      // listening to. When transparent proxying is not used, Envoy will bind to
+      // this port.
       uint32 port = 3 [ (doc.required) = true ];
 
       // Port of the service that requests will be forwarded to.
+      // Defaults to the same value as `port`.
       uint32 servicePort = 4;
 
       // Address of the service that requests will be forwarded to.
-      // Empty value defaults to '127.0.0.1', since Kuma DP should be deployed
-      // next to service.
+      // Defaults to '127.0.0.1', since Kuma DP should be deployed next to the
+      // service.
       string serviceAddress = 6;
 
-      // Address on which inbound listener will be exposed. Defaults to
-      // networking.address.
+      // Address on which inbound listener will be exposed.
+      // Defaults to `networking.address`.
       string address = 5;
 
-      // Tags associated with an application this dataplane is deployed next to,
-      // e.g. kuma.io/service=web, version=1.0.
+      // Tags associated with an application this data plane proxy is deployed
+      // next to, e.g. `kuma.io/service=web`, `version=1.0`. You can then
+      // reference these tags in policies like MeshTrafficPermission.
       // `kuma.io/service` tag is mandatory.
       map<string, string> tags = 2
           [ (validate.rules).map.min_pairs = 1, (doc.required) = true ];
 
       // Health describes the status of an inbound
-      message Health { bool ready = 1; }
+      message Health {
+        // Ready indicates if the data plane proxy is ready to serve the
+        // traffic.
+        bool ready = 1;
+      }
 
-      // Health is an optional field filled automatically by Kuma Control Plane
-      // on Kubernetes if Pod has ReadinessProbe configured. If 'health' is
-      // equal to nil we consider dataplane as healthy. Unhealthy dataplanes
-      // will be excluded from Endpoints Discovery Service (EDS)
+      // Health describes the status of an inbound.
+      // If 'health' is nil we consider data plane proxy as healthy.
+      // Unhealthy data plane proxies are excluded from Endpoints Discovery
+      // Service (EDS). On Kubernetes, it is filled automatically by the control
+      // plane if Pod has readiness probe configured. On Universal, it can be
+      // set by the external health checking system, but the most common way is
+      // to use service probes.
+      //
+      // See https://kuma.io/docs/latest/documentation/health for more
+      // information.
       Health health = 7;
 
       // ServiceProbe defines parameters for probing service's port
@@ -97,48 +120,75 @@ message Dataplane {
         Tcp tcp = 5;
       }
 
-      // ServiceProbe defines parameters for probing service's port
+      // ServiceProbe defines parameters for probing the service next to
+      // sidecar. When service probe is defined, Envoy will periodically health
+      // check the application next to it and report the status to the control
+      // plane. On Kubernetes, Kuma deployments rely on Kubernetes probes so
+      // this is not used.
+      //
+      // See https://kuma.io/docs/latest/documentation/health for more
+      // information.
       ServiceProbe serviceProbe = 8;
     }
 
-    // Outbound describes a service consumed by the dataplane.
+    // Outbound describes a service consumed by the data plane proxy.
+    // For every defined Outbound there is a corresponding Envoy Listener.
     message Outbound {
-      // Address on which the service will be available to this dataplane.
-      // Defaults to 127.0.0.1
+      // IP on which the consumed service will be available to this data plane
+      // proxy. On Kubernetes, it's usually ClusterIP of a Service or PodIP of a
+      // Headless Service. Defaults to 127.0.0.1
       string address = 3;
 
-      // Port on which the service will be available to this dataplane.
+      // Port on which the consumed service will be available to this data plane
+      // proxy. When transparent proxying is not used, Envoy will bind to this
+      // port.
       uint32 port = 4 [ (doc.required) = true ];
 
-      // DEPRECATED: use networking.outbound[].tags
-      // Service name.
+      // DEPRECATED: use `networking.outbound[].tags['kuma.io/service']`
+      // Service name identified by the value of `kuma.io/service`.
       string service = 2
           [ (validate.rules).string.hostname = true, deprecated = true ];
 
-      // Tags
+      // Tags of consumed data plane proxies.
+      // `kuma.io/service` tag is required.
+      // These tags can then be referenced in `destinations` section of policies
+      // like TrafficRoute or in `to` section in policies like MeshAccessLog. It
+      // is recommended to only use `kuma.io/service`. If you need to consume
+      // specific data plane proxy of a service (for example: `version=v2`) the
+      // better practice is to use TrafficRoute.
       map<string, string> tags = 5;
     }
 
     // Gateway describes a service that ingress should not be proxied.
     message Gateway {
       enum GatewayType {
-        // A DELEGATED gateway is a independently deployed proxy that
+        // A `DELEGATED` gateway is an independently deployed proxy that
         // receives inbound traffic that is not proxied by Kuma, and
-        // sends outbound traffic into the Kuma dataplane proxy.
+        // it sends outbound traffic into the data plane proxy.
         DELEGATED = 0;
-        // The BUILTIN gateway type is experimental and unsupported.
+        // The `BUILTIN` gateway type configures data plane proxy itself as a
+        // gateway.
         BUILTIN = 1;
       }
 
-      // Tags associated with a gateway (e.g., Kong, Contour, etc) this
-      // dataplane is deployed next to, e.g. service=gateway, env=prod.
-      // `service` tag is mandatory.
+      // Tags associated with a gateway of this data plane to, e.g.
+      // `kuma.io/service=gateway`, `env=prod`. `kuma.io/service` tag is
+      // mandatory.
       map<string, string> tags = 1
           [ (validate.rules).map.min_pairs = 1, (doc.required) = true ];
 
-      // Type of gateway this dataplane manages. The default is a DELEGATED
-      // gateway, which is an external proxy. The BUILTIN gateway type causes
-      // the dataplane proxy itself to be configured as a gateway.
+      // Type of gateway this data plane proxy manages.
+      // There are two types: `DELEGATED` and `BUILTIN`. Defaults to
+      // `DELEGATED`.
+      //
+      // A `DELEGATED` gateway is an independently deployed proxy (e.g., Kong,
+      // Contour, etc) that receives inbound traffic that is not proxied by
+      // Kuma, and it sends outbound traffic into the data plane proxy.
+      //
+      // The `BUILTIN` gateway type causes the data plane proxy itself to be
+      // configured as a gateway.
+      //
+      // See https://kuma.io/docs/latest/explore/gateway/ for more information.
       GatewayType type = 2 [ (doc.required) = true ];
     }
 
@@ -153,7 +203,10 @@ message Dataplane {
       uint32 redirect_port_outbound = 2
           [ (validate.rules).uint32 = {lte : 65535} ];
 
-      // List of services that will be access directly via IP:PORT
+      // List of services that will be accessed directly via IP:PORT
+      // Use `*` to indicate direct access to every service in the Mesh.
+      // Using `*` to directly access every service is a resource-intensive
+      // operation, use it only if needed.
       repeated string direct_access_services = 3;
 
       // Port on which all IPv6 inbound traffic is being transparently
@@ -162,51 +215,79 @@ message Dataplane {
           [ (validate.rules).uint32 = {lte : 65535} ];
 
       // List of reachable services (represented by the value of
-      // kuma.io/service) via transparent proxying. Setting an explicit list can
-      // dramatically improve the performance of the mesh. If not specified, all
-      // services in the mesh are reachable.
+      // `kuma.io/service`) via transparent proxying. Setting an explicit list
+      // can dramatically improve the performance of the mesh. If not specified,
+      // all services in the mesh are reachable.
       repeated string reachable_services = 5;
     }
 
-    // Gateway describes configuration of gateway of the dataplane.
+    // Gateway describes a configuration of the gateway of the data plane proxy.
     Gateway gateway = 3;
 
-    // Inbound describes a list of inbound interfaces of the dataplane.
+    // Inbound describes a list of inbound interfaces of the data plane proxy.
+    //
+    // Inbound describes a service implemented by the data plane proxy.
+    // All incoming traffic to a data plane proxy is going through inbound
+    // listeners. For every defined Inbound there is a corresponding Envoy
+    // Listener.
     repeated Inbound inbound = 1;
 
-    // Outbound describes a list of outbound interfaces of the dataplane.
+    // Outbound describes a list of services consumed by the data plane proxy.
+    // For every defined Outbound, there is a corresponding Envoy Listener.
     repeated Outbound outbound = 2;
 
-    // TransparentProxying describes configuration for transparent proxying.
+    // TransparentProxying describes the configuration for transparent proxying.
+    // It is used by default on Kubernetes.
     TransparentProxying transparent_proxying = 4;
 
-    // Admin contains configuration related to Envoy Admin API
+    // Admin describes configuration related to Envoy Admin API.
+    // Due to security, all the Envoy Admin endpoints are exposed only on
+    // localhost. Additionally, Envoy will expose `/ready` endpoint on
+    // `networking.address` for health checking systems to be able to check the
+    // state of Envoy. The rest of the endpoints exposed on `networking.address`
+    // are always protected by mTLS and only meant to be consumed internally by
+    // the control plane.
     EnvoyAdmin admin = 8;
   }
 
-  // Networking describes inbound and outbound interfaces of the dataplane.
+  // Networking describes inbound and outbound interfaces of the data plane
+  // proxy.
   Networking networking = 1;
 
   // Configuration for metrics that should be collected and exposed by the
-  // dataplane.
+  // data plane proxy.
   //
   // Settings defined here will override their respective defaults
   // defined at a Mesh level.
   MetricsBackend metrics = 2;
 
   message Probes {
+    // Port on which the probe endpoints will be exposed. This cannot overlap
+    // with any other ports.
     uint32 port = 1 [ (doc.required) = true ];
 
     message Endpoint {
+      // Inbound port is a port of the application from which we expose the
+      // endpoint.
       uint32 inbound_port = 1 [ (doc.required) = true ];
+      // Inbound path is a path of the application from which we expose the
+      // endpoint. It is recommended to be as specific as possible.
       string inbound_path = 2 [ (doc.required) = true ];
+      // Path is a path on which we expose inbound path on the probes port.
       string path = 3 [ (doc.required) = true ];
     }
 
+    // List of endpoints to expose without mTLS.
     repeated Endpoint endpoints = 2 [ (doc.required) = true ];
   }
 
-  // Probes describes list of endpoints which will redirect traffic from
-  // insecure port to localhost path
+  // Probes describe a list of endpoints that will be exposed without mTLS.
+  // This is useful to expose the health endpoints of the application so the
+  // orchestration system (e.g. Kubernetes) can still health check the
+  // application.
+  //
+  // See
+  // https://kuma.io/docs/latest/policies/service-health-probes/#virtual-probes
+  // for more information.
   Probes probes = 3;
 }

--- a/docs/generated/resources/proxy_dataplane.md
+++ b/docs/generated/resources/proxy_dataplane.md
@@ -2,35 +2,49 @@
 
 - `networking` (optional)
 
-    Networking describes inbound and outbound interfaces of the dataplane.    
+    Networking describes inbound and outbound interfaces of the data plane
+    proxy.    
     
     - `address` (required)
     
-        Public IP on which the dataplane is accessible in the network.    
+        IP on which the data plane proxy is accessible to the control plane and
+        other data plane proxies in the same network. This can also be a
+        hostname, in which case the control plane will periodically resolve it.    
     
     - `advertisedAddress` (optional)
     
-        In some situation, dataplane resides in a private network and not
-        reachable via 'address'. advertisedAddress is configured with public
-        routable address for such dataplane so that other dataplanes in the mesh
-        can connect to it over advertisedAddress and not via address
-        Note: Envoy binds to the address not advertisedAddress    
+        In some situations, a data plane proxy resides in a private network (e.g.
+        Docker) and is not reachable via `address` to other data plane proxies.
+        `advertisedAddress` is configured with a routable address for such data
+        plane proxy so that other proxies in the mesh can connect to it over
+        `advertisedAddress` and not via address.
+        
+        Envoy still binds to the `address`, not `advertisedAddress`.    
     
     - `gateway` (optional)
     
-        Gateway describes configuration of gateway of the dataplane.    
+        Gateway describes a configuration of the gateway of the data plane proxy.    
         
         - `tags` (required)
         
-            Tags associated with a gateway (e.g., Kong, Contour, etc) this
-            dataplane is deployed next to, e.g. service=gateway, env=prod.
-            `service` tag is mandatory.    
+            Tags associated with a gateway of this data plane to, e.g.
+            `kuma.io/service=gateway`, `env=prod`. `kuma.io/service` tag is
+            mandatory.    
         
         - `type` (required, enum)
         
-            Type of gateway this dataplane manages. The default is a DELEGATED
-            gateway, which is an external proxy. The BUILTIN gateway type causes
-            the dataplane proxy itself to be configured as a gateway.
+            Type of gateway this data plane proxy manages.
+            There are two types: `DELEGATED` and `BUILTIN`. Defaults to
+            `DELEGATED`.
+            
+            A `DELEGATED` gateway is an independently deployed proxy (e.g., Kong,
+            Contour, etc) that receives inbound traffic that is not proxied by
+            Kuma, and it sends outbound traffic into the data plane proxy.
+            
+            The `BUILTIN` gateway type causes the data plane proxy itself to be
+            configured as a gateway.
+            
+            See https://kuma.io/docs/latest/explore/gateway/ for more information.
         
             - `DELEGATED`
         
@@ -38,46 +52,73 @@
     
     - `inbound` (optional, repeated)
     
-        Inbound describes a list of inbound interfaces of the dataplane.    
+        Inbound describes a list of inbound interfaces of the data plane proxy.
+        
+        Inbound describes a service implemented by the data plane proxy.
+        All incoming traffic to a data plane proxy is going through inbound
+        listeners. For every defined Inbound there is a corresponding Envoy
+        Listener.    
         
         - `port` (required)
         
             Port of the inbound interface that will forward requests to the
-            service.    
+            service.
+            
+            When transparent proxying is used, it is a port on which the service is
+            listening to. When transparent proxying is not used, Envoy will bind to
+            this port.    
         
         - `servicePort` (optional)
         
-            Port of the service that requests will be forwarded to.    
+            Port of the service that requests will be forwarded to.
+            Defaults to the same value as `port`.    
         
         - `serviceAddress` (optional)
         
             Address of the service that requests will be forwarded to.
-            Empty value defaults to '127.0.0.1', since Kuma DP should be deployed
-            next to service.    
+            Defaults to '127.0.0.1', since Kuma DP should be deployed next to the
+            service.    
         
         - `address` (optional)
         
-            Address on which inbound listener will be exposed. Defaults to
-            networking.address.    
+            Address on which inbound listener will be exposed.
+            Defaults to `networking.address`.    
         
         - `tags` (required)
         
-            Tags associated with an application this dataplane is deployed next to,
-            e.g. kuma.io/service=web, version=1.0.
+            Tags associated with an application this data plane proxy is deployed
+            next to, e.g. `kuma.io/service=web`, `version=1.0`. You can then
+            reference these tags in policies like MeshTrafficPermission.
             `kuma.io/service` tag is mandatory.    
         
         - `health` (optional)
         
-            Health is an optional field filled automatically by Kuma Control Plane
-            on Kubernetes if Pod has ReadinessProbe configured. If 'health' is
-            equal to nil we consider dataplane as healthy. Unhealthy dataplanes
-            will be excluded from Endpoints Discovery Service (EDS)    
+            Health describes the status of an inbound.
+            If 'health' is nil we consider data plane proxy as healthy.
+            Unhealthy data plane proxies are excluded from Endpoints Discovery
+            Service (EDS). On Kubernetes, it is filled automatically by the control
+            plane if Pod has readiness probe configured. On Universal, it can be
+            set by the external health checking system, but the most common way is
+            to use service probes.
             
-            - `ready` (optional)    
+            See https://kuma.io/docs/latest/documentation/health for more
+            information.    
+            
+            - `ready` (optional)
+            
+                Ready indicates if the data plane proxy is ready to serve the
+                traffic.    
         
         - `serviceProbe` (optional)
         
-            ServiceProbe defines parameters for probing service's port    
+            ServiceProbe defines parameters for probing the service next to
+            sidecar. When service probe is defined, Envoy will periodically health
+            check the application next to it and report the status to the control
+            plane. On Kubernetes, Kuma deployments rely on Kubernetes probes so
+            this is not used.
+            
+            See https://kuma.io/docs/latest/documentation/health for more
+            information.    
             
             - `interval` (optional)
             
@@ -103,29 +144,40 @@
     
     - `outbound` (optional, repeated)
     
-        Outbound describes a list of outbound interfaces of the dataplane.    
+        Outbound describes a list of services consumed by the data plane proxy.
+        For every defined Outbound, there is a corresponding Envoy Listener.    
         
         - `address` (optional)
         
-            Address on which the service will be available to this dataplane.
-            Defaults to 127.0.0.1    
+            IP on which the consumed service will be available to this data plane
+            proxy. On Kubernetes, it's usually ClusterIP of a Service or PodIP of a
+            Headless Service. Defaults to 127.0.0.1    
         
         - `port` (required)
         
-            Port on which the service will be available to this dataplane.    
+            Port on which the consumed service will be available to this data plane
+            proxy. When transparent proxying is not used, Envoy will bind to this
+            port.    
         
         - `service` (optional)
         
-            DEPRECATED: use networking.outbound[].tags
-            Service name.    
+            DEPRECATED: use `networking.outbound[].tags['kuma.io/service']`
+            Service name identified by the value of `kuma.io/service`.    
         
         - `tags` (optional)
         
-            Tags    
+            Tags of consumed data plane proxies.
+            `kuma.io/service` tag is required.
+            These tags can then be referenced in `destinations` section of policies
+            like TrafficRoute or in `to` section in policies like MeshAccessLog. It
+            is recommended to only use `kuma.io/service`. If you need to consume
+            specific data plane proxy of a service (for example: `version=v2`) the
+            better practice is to use TrafficRoute.    
     
     - `transparentProxying` (optional)
     
-        TransparentProxying describes configuration for transparent proxying.    
+        TransparentProxying describes the configuration for transparent proxying.
+        It is used by default on Kubernetes.    
         
         - `redirectPortInbound` (optional)
         
@@ -137,7 +189,10 @@
         
         - `directAccessServices` (optional, repeated)
         
-            List of services that will be access directly via IP:PORT    
+            List of services that will be accessed directly via IP:PORT
+            Use `*` to indicate direct access to every service in the Mesh.
+            Using `*` to directly access every service is a resource-intensive
+            operation, use it only if needed.    
         
         - `redirectPortInboundV6` (optional)
         
@@ -147,13 +202,19 @@
         - `reachableServices` (optional, repeated)
         
             List of reachable services (represented by the value of
-            kuma.io/service) via transparent proxying. Setting an explicit list can
-            dramatically improve the performance of the mesh. If not specified, all
-            services in the mesh are reachable.    
+            `kuma.io/service`) via transparent proxying. Setting an explicit list
+            can dramatically improve the performance of the mesh. If not specified,
+            all services in the mesh are reachable.    
     
     - `admin` (optional)
     
-        Admin contains configuration related to Envoy Admin API    
+        Admin describes configuration related to Envoy Admin API.
+        Due to security, all the Envoy Admin endpoints are exposed only on
+        localhost. Additionally, Envoy will expose `/ready` endpoint on
+        `networking.address` for health checking systems to be able to check the
+        state of Envoy. The rest of the endpoints exposed on `networking.address`
+        are always protected by mTLS and only meant to be consumed internally by
+        the control plane.    
         
         - `port` (optional)
         
@@ -162,7 +223,7 @@
 - `metrics` (optional)
 
     Configuration for metrics that should be collected and exposed by the
-    dataplane.
+    data plane proxy.
     
     Settings defined here will override their respective defaults
     defined at a Mesh level.    
@@ -181,16 +242,35 @@
 
 - `probes` (optional)
 
-    Probes describes list of endpoints which will redirect traffic from
-    insecure port to localhost path    
+    Probes describe a list of endpoints that will be exposed without mTLS.
+    This is useful to expose the health endpoints of the application so the
+    orchestration system (e.g. Kubernetes) can still health check the
+    application.
     
-    - `port` (required)    
+    See
+    https://kuma.io/docs/latest/policies/service-health-probes/#virtual-probes
+    for more information.    
     
-    - `endpoints` (required, repeated)    
+    - `port` (required)
+    
+        Port on which the probe endpoints will be exposed. This cannot overlap
+        with any other ports.    
+    
+    - `endpoints` (required, repeated)
+    
+        List of endpoints to expose without mTLS.    
         
-        - `inboundPort` (required)    
+        - `inboundPort` (required)
         
-        - `inboundPath` (required)    
+            Inbound port is a port of the application from which we expose the
+            endpoint.    
+        
+        - `inboundPath` (required)
+        
+            Inbound path is a path of the application from which we expose the
+            endpoint. It is recommended to be as specific as possible.    
         
         - `path` (required)
+        
+            Path is a path on which we expose inbound path on the probes port.
 


### PR DESCRIPTION
Rewrite the data plane proto docs.

One thing that we need to do for proto docs is to repeat Message docs with field docs. For example, `Gateway` message docs were descriptive, but the field `gateway` was not. The problem is that the Message doc is not appearing in the end docs, therefore we need to repeat it.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [X] Link to docs PR or issue --
- [X] Link to UI issue or PR --
- [X] Is the [issue worked on linked][1]? --
- [X] The PR does not hardcode values that might break projects that depend on kuma (e.g. "kumahq" as a image registry) --
- [X] The PR will work for both Linux and Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [X] Unit Tests --
- [X] E2E Tests --
- [X] Manual Universal Tests --
- [X] Manual Kubernetes Tests --
- [X] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [X] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [X] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
