### PR TITLE
fix(kuma-cp): correct namespace policy validation error message

### DIFF
--- a/pkg/plugins/runtime/k8s/webhooks/policy_namespace_validator.go
+++ b/pkg/plugins/runtime/k8s/webhooks/policy_namespace_validator.go
@@ -22,7 +22,7 @@ func (p *PolicyNamespaceValidator) InjectDecoder(decoder *admission.Decoder) err
 
 func (p *PolicyNamespaceValidator) Handle(ctx context.Context, request admission.Request) admission.Response {
 	if request.Namespace != p.SystemNamespace {
-		return admission.Denied(fmt.Sprintf("policies could be created only in %s", p.SystemNamespace))
+		return admission.Denied(fmt.Sprintf("policy can only be created in the system namespace:%s", p.SystemNamespace))
 	}
 	return admission.Allowed("")
 }

--- a/test/e2e_env/kubernetes/meshtrafficpermission/api.go
+++ b/test/e2e_env/kubernetes/meshtrafficpermission/api.go
@@ -105,6 +105,6 @@ spec:
 `)
 
 		Expect(err).To(HaveOccurred())
-		Expect(err.Error()).To(ContainSubstring(fmt.Sprintf("policies could be created only in %s", Config.KumaNamespace)))
+		Expect(err.Error()).To(ContainSubstring(fmt.Sprintf("policy can only be created in the system namespace:%s", Config.KumaNamespace)))
 	})
 }


### PR DESCRIPTION
Signed-off-by: Charly Molter <charly.molter@konghq.com>

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] Link to docs PR or issue --
- [x] Link to UI issue or PR --
- [x] Is the [issue worked on linked][1]? --
- [x] The PR does not hardcode values that might break projects that depend on kuma (e.g. "kumahq" as a image registry) --
- [x] The PR will work for both Linux and Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Unit Tests --
- [x] E2E Tests --
- [x] Manual Universal Tests --
- [x] Manual Kubernetes Tests --
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [x] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword

> Changelog: skip
