### PR TITLE
test(e2e): add E2E_DEPS_TARGETS to debug targets

### DIFF
--- a/mk/e2e.new.mk
+++ b/mk/e2e.new.mk
@@ -104,7 +104,7 @@ test/e2e/k8s/stop: $(K8SCLUSTERS_STOP_TARGETS)
 # GINKGO_EDITOR_INTEGRATION is required to work with focused test. Normally they exit with non 0 code which prevents clusters to be cleaned up.
 # We run ginkgo instead of "go test" to fail fast (builtin "go test" fail fast does not seem to work with individual ginkgo tests)
 .PHONY: test/e2e/debug
-test/e2e/debug: build/kumactl images test/e2e/k8s/start
+test/e2e/debug: $(E2E_DEPS_TARGETS) build/kumactl images test/e2e/k8s/start
 	$(E2E_ENV_VARS) \
 	GINKGO_EDITOR_INTEGRATION=true \
 		$(GINKGO_TEST_E2E) --keep-going=false --fail-fast $(E2E_PKG_LIST)
@@ -114,7 +114,7 @@ test/e2e/debug: build/kumactl images test/e2e/k8s/start
 # test/e2e/debug-fast is an equivalent of test/e2e/debug, but with the goal to minimize time for test to start running.
 # Run only with -j and K3D=true
 .PHONY: test/e2e/debug-fast
-test/e2e/debug-fast:
+test/e2e/debug-fast: $(E2E_DEPS_TARGETS)
 	$(MAKE) $(K8SCLUSTERS_START_TARGETS) & # start K8S clusters in the background since it takes the most time
 	$(MAKE) images
 	$(MAKE) build/kumactl
@@ -128,10 +128,10 @@ test/e2e/debug-fast:
 # test/e2e/debug-universal is the same target as 'test/e2e/debug' but builds only 'kuma-universal' image
 # and doesn't start Kind clusters
 .PHONY: test/e2e/debug-universal
-test/e2e/debug-universal: build/kumactl images/test k3d/network/create
+test/e2e/debug-universal: $(E2E_DEPS_TARGETS) build/kumactl images/test k3d/network/create
 	$(E2E_ENV_VARS) \
 	GINKGO_EDITOR_INTEGRATION=true \
-		$(GINKGO_TEST_E2E) --keep-going=false --fail-fast $(UNIVERSAL_E2E_PKG_LIST)
+		$(GINKGO_TEST_E2E) --keep-going=false --procs 1 --fail-fast $(UNIVERSAL_E2E_PKG_LIST)
 
 
 .PHONY: test/e2e


### PR DESCRIPTION
*  add `E2E_DEPS_TARGETS` to debug targets so you can plug extra dependency targets for debug e2e too
* set `--proc` to 1 for `debug-universal`. When you run this, there is high change you are debugging e2e test that is not from e2e env, so we can't run this with parallelization.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [X] Link to docs PR or issue --
- [X] Link to UI issue or PR --
- [X] Is the [issue worked on linked][1]? --
- [X] The PR does not hardcode values that might break projects that depend on kuma (e.g. "kumahq" as a image registry) --
- [X] The PR will work for both Linux and Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [X] Unit Tests --
- [X] E2E Tests --
- [X] Manual Universal Tests --
- [X] Manual Kubernetes Tests --
- [X] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [X] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [X] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
