### PR TITLE
fix(helm): now we provide value to repo of image

### DIFF
--- a/deployments/charts/kuma/templates/post-delete-cleanup-ebpf-job.yaml
+++ b/deployments/charts/kuma/templates/post-delete-cleanup-ebpf-job.yaml
@@ -118,5 +118,5 @@ spec:
             - '--cleanup-image-registry'
             - {{ .Values.global.image.registry }}
             - '--"cleanup-image-repository'
-            - {{ .Values.dataPlane.initImage.registry }}
+            - {{ .Values.dataPlane.initImage.repository }}
   {{- end }}

--- a/deployments/charts/kuma/templates/post-delete-cleanup-ebpf-job.yaml
+++ b/deployments/charts/kuma/templates/post-delete-cleanup-ebpf-job.yaml
@@ -115,4 +115,8 @@ spec:
             - 'kumactl'
             - 'uninstall'
             - 'ebpf'
+            - '--cleanup-image-registry'
+            - {{ .Values.global.image.registry }}
+            - '--"cleanup-image-repository'
+            - {{ .Values.dataPlane.initImage.registry }}
   {{- end }}

--- a/deployments/charts/kuma/templates/post-delete-cleanup-ebpf-job.yaml
+++ b/deployments/charts/kuma/templates/post-delete-cleanup-ebpf-job.yaml
@@ -117,6 +117,6 @@ spec:
             - 'ebpf'
             - '--cleanup-image-registry'
             - {{ .Values.global.image.registry }}
-            - '--"cleanup-image-repository'
+            - '--cleanup-image-repository'
             - {{ .Values.dataPlane.initImage.repository }}
   {{- end }}


### PR DESCRIPTION
Added passing of registry and repository to do not break other projects 
### Checklist prior to review
- [X] Link to docs PR or issue --
- [X] Link to UI issue or PR --
- [X] Is the [issue worked on linked][1]? --
- [X] The PR does not hardcode values that might break projects that depend on kuma (e.g. "kumahq" as a image registry) -- fixes dependency
- [X] The PR will work for both Linux and Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [X] Unit Tests --
- [X] E2E Tests --
- [X] Manual Universal Tests --
- [X ] Manual Kubernetes Tests --
- [X] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [X] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [X] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
