### PR TITLE
docs(proto): fixed default serviceAddress and upgrade docs 

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -61,10 +61,10 @@ changed to agree with the other `image` values.
 * The `/versions` endpoint was removed. This is not something that was reliable enough and version compatibility
 is checked inside the DP
 * We are deprecating `kuma.io/builtindns` and `kuma.io/builtindnsport` annotations in favour of the clearer `kuma.io/builtin-dns` and `kuma.io/builtin-dns-port`. The behavior of the new annotations is unchanged but you should migrate (a warning is present on the log if you are using the deprecated version).
-* Applications that are binding to `localhost` won't be reachable anymore. We are changing the default inbound cluster that was always pointing to `localhost` to `DataplaneIP`. Before upgrade check if your applications are listening on `localhost` and should be exposed:
-  * Universal: If you don't want to expose application change binding to `127.0.0.1` and define `dataplane.networking.inbound[].serviceAddress: "127.0.0.1"`.
-  * Kubernetes: In this case change address on which application listen to `0.0.0.0`.
-Another way is to disable the new behavior by setting `kuma-cp` configuration `KUMA_DEFAULTS_ENABLE_LOCALHOST_INBOUND_CLUSTERS` to `true` or `defaults.enableLocalhostInboundClusters` to `true`. The last option is going to be removed in further versions.
+* By default, applications binding to `localhost` are not reachable anymore. We are changing the default inbound cluster from `localhost` to `networking.address`. Before upgrade check if your applications are listening on `localhost` and should be exposed:
+  * Universal: If you don't want to expose application make sure your application binds  to `127.0.0.1` and set `dataplane.networking.inbound[].serviceAddress: "127.0.0.1"`.
+  * Kubernetes: Make sure your application binds to `0.0.0.0`.
+To ease migration you can temporarily disable this new behavior by setting `KUMA_DEFAULTS_ENABLE_LOCALHOST_INBOUND_CLUSTERS=true` on `kuma-cp`, this option will be removed in a future version.
 
 ## Upgrade to `1.7.x`
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -61,7 +61,7 @@ changed to agree with the other `image` values.
 * The `/versions` endpoint was removed. This is not something that was reliable enough and version compatibility
 is checked inside the DP
 * We are deprecating `kuma.io/builtindns` and `kuma.io/builtindnsport` annotations in favour of the clearer `kuma.io/builtin-dns` and `kuma.io/builtin-dns-port`. The behavior of the new annotations is unchanged but you should migrate (a warning is present on the log if you are using the deprecated version).
-* By default, applications binding to `localhost` are not reachable anymore. We are changing the default inbound cluster from `localhost` to `networking.address`. Before upgrade check if your applications are listening on `localhost` and should be exposed:
+* By default, applications binding to `localhost` are not reachable anymore. We are changing the default inbound cluster from `localhost` to `inbound.address`. Before upgrade check if your applications are listening on `localhost` and should be exposed:
   * Universal: If you don't want to expose application make sure your application binds  to `127.0.0.1` and set `dataplane.networking.inbound[].serviceAddress: "127.0.0.1"`.
   * Kubernetes: Make sure your application binds to `0.0.0.0`.
 To ease migration you can temporarily disable this new behavior by setting `KUMA_DEFAULTS_ENABLE_LOCALHOST_INBOUND_CLUSTERS=true` on `kuma-cp`, this option will be removed in a future version.

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -61,10 +61,12 @@ changed to agree with the other `image` values.
 * The `/versions` endpoint was removed. This is not something that was reliable enough and version compatibility
 is checked inside the DP
 * We are deprecating `kuma.io/builtindns` and `kuma.io/builtindnsport` annotations in favour of the clearer `kuma.io/builtin-dns` and `kuma.io/builtin-dns-port`. The behavior of the new annotations is unchanged but you should migrate (a warning is present on the log if you are using the deprecated version).
-* By default, applications binding to `localhost` are not reachable anymore. We are changing the default inbound cluster from `localhost` to `inbound.address`. Before upgrade check if your applications are listening on `localhost` and should be exposed:
-  * Universal: If you don't want to expose application make sure your application binds  to `127.0.0.1` and set `dataplane.networking.inbound[].serviceAddress: "127.0.0.1"`.
-  * Kubernetes: Make sure your application binds to `0.0.0.0`.
-To ease migration you can temporarily disable this new behavior by setting `KUMA_DEFAULTS_ENABLE_LOCALHOST_INBOUND_CLUSTERS=true` on `kuma-cp`, this option will be removed in a future version.
+* By default, applications binding to `localhost` are not reachable anymore. A `Dataplane` inbound's default `serviceAddress` is now the inbound's `address`. Before upgrade check if your applications are listening on `localhost` and:
+  * you run on K8s and you want it exposed - change binding of the application to `0.0.0.0`.
+  * you run on K8s and you don't want it exposed - changes are not needed.
+  * you run on Universal and you want it exposed - change it binding to `inbound.address` or set `dataplane.networking.inbound[].serviceAddress: "127.0.0.1"`.
+  * you run on Universal and you don't want it exposed - changes are not needed.
+To make migration easier you can temporarily disable this new behavior by setting `KUMA_DEFAULTS_ENABLE_LOCALHOST_INBOUND_CLUSTERS=true` on `kuma-cp`, this option will be removed in a future version.
 
 ## Upgrade to `1.7.x`
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -61,7 +61,10 @@ changed to agree with the other `image` values.
 * The `/versions` endpoint was removed. This is not something that was reliable enough and version compatibility
 is checked inside the DP
 * We are deprecating `kuma.io/builtindns` and `kuma.io/builtindnsport` annotations in favour of the clearer `kuma.io/builtin-dns` and `kuma.io/builtin-dns-port`. The behavior of the new annotations is unchanged but you should migrate (a warning is present on the log if you are using the deprecated version).
-* Applications that are binding to `localhost` won't be reachable anymore. We are changing the default inbound cluster that was always pointing to `localhost` to `DataplaneIP`. Before upgrade check if your applications are listening on `localhost` and should be exposed. In this case change address on which application listen to `0.0.0.0`. Other option is to define `dataplane.networking.inbound[].serviceAddress` to the address which service is binding. Another way is to disable the new behavior by setting `kuma-cp` configuration `KUMA_DEFAULTS_ENABLE_LOCALHOST_INBOUND_CLUSTERS` to `true` or `defaults.enableLocalhostInboundClusters` to `true`. The last option is going to be removed in further versions.
+* Applications that are binding to `localhost` won't be reachable anymore. We are changing the default inbound cluster that was always pointing to `localhost` to `DataplaneIP`. Before upgrade check if your applications are listening on `localhost` and should be exposed:
+  * Universal: If you don't want to expose application change binding to `127.0.0.1` and define `dataplane.networking.inbound[].serviceAddress: "127.0.0.1"`.
+  * Kubernetes: In this case change address on which application listen to `0.0.0.0`.
+Another way is to disable the new behavior by setting `kuma-cp` configuration `KUMA_DEFAULTS_ENABLE_LOCALHOST_INBOUND_CLUSTERS` to `true` or `defaults.enableLocalhostInboundClusters` to `true`. The last option is going to be removed in further versions.
 
 ## Upgrade to `1.7.x`
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -61,11 +61,9 @@ changed to agree with the other `image` values.
 * The `/versions` endpoint was removed. This is not something that was reliable enough and version compatibility
 is checked inside the DP
 * We are deprecating `kuma.io/builtindns` and `kuma.io/builtindnsport` annotations in favour of the clearer `kuma.io/builtin-dns` and `kuma.io/builtin-dns-port`. The behavior of the new annotations is unchanged but you should migrate (a warning is present on the log if you are using the deprecated version).
-* By default, applications binding to `localhost` are not reachable anymore. A `Dataplane` inbound's default `serviceAddress` is now the inbound's `address`. Before upgrade check if your applications are listening on `localhost` and:
-  * you run on K8s and you want it exposed - change binding of the application to `0.0.0.0`.
-  * you run on K8s and you don't want it exposed - changes are not needed.
-  * you run on Universal and you want it exposed - change it binding to `inbound.address` or set `dataplane.networking.inbound[].serviceAddress: "127.0.0.1"`.
-  * you run on Universal and you don't want it exposed - changes are not needed.
+* By default, applications binding to `localhost` are not reachable anymore. A `Dataplane` inbound's default `serviceAddress` is now the inbound's `address`. Before upgrade, if you have applications listening on `localhost` that you want to expose on:
+  * Kubernetes: listen on `0.0.0.0` instead
+  * Universal: listen on `inbound.address` instead or set `dataplane.networking.inbound[].serviceAddress: "127.0.0.1"`
 To make migration easier you can temporarily disable this new behavior by setting `KUMA_DEFAULTS_ENABLE_LOCALHOST_INBOUND_CLUSTERS=true` on `kuma-cp`, this option will be removed in a future version.
 
 ## Upgrade to `1.7.x`

--- a/api/mesh/v1alpha1/dataplane.pb.go
+++ b/api/mesh/v1alpha1/dataplane.pb.go
@@ -359,7 +359,7 @@ type Dataplane_Networking_Inbound struct {
 	// Address of the service that requests will be forwarded to.
 	// Defaults to 'inbound.address', since Kuma DP should be deployed next
 	// to the service. When `KUMA_DEFAULTS_ENABLE_LOCALHOST_INBOUND_CLUSTERS`
-	// is true defaults to `127.0.0.1`.
+	// is true, this defaults to `127.0.0.1`.
 	ServiceAddress string `protobuf:"bytes,6,opt,name=serviceAddress,proto3" json:"serviceAddress,omitempty"`
 	// Address on which inbound listener will be exposed.
 	// Defaults to `networking.address`.

--- a/api/mesh/v1alpha1/dataplane.pb.go
+++ b/api/mesh/v1alpha1/dataplane.pb.go
@@ -357,9 +357,9 @@ type Dataplane_Networking_Inbound struct {
 	// Defaults to the same value as `port`.
 	ServicePort uint32 `protobuf:"varint,4,opt,name=servicePort,proto3" json:"servicePort,omitempty"`
 	// Address of the service that requests will be forwarded to.
-	// Defaults to 'DataplaneIP', since Kuma DP should be deployed next to the
-	// service. When `KUMA_DEFAULTS_ENABLE_LOCALHOST_INBOUND_CLUSTERS` is true
-	// defaults to `127.0.0.1`.
+	// Defaults to 'networking.address', since Kuma DP should be deployed next
+	// to the service. When `KUMA_DEFAULTS_ENABLE_LOCALHOST_INBOUND_CLUSTERS`
+	// is true defaults to `127.0.0.1`.
 	ServiceAddress string `protobuf:"bytes,6,opt,name=serviceAddress,proto3" json:"serviceAddress,omitempty"`
 	// Address on which inbound listener will be exposed.
 	// Defaults to `networking.address`.

--- a/api/mesh/v1alpha1/dataplane.pb.go
+++ b/api/mesh/v1alpha1/dataplane.pb.go
@@ -357,7 +357,7 @@ type Dataplane_Networking_Inbound struct {
 	// Defaults to the same value as `port`.
 	ServicePort uint32 `protobuf:"varint,4,opt,name=servicePort,proto3" json:"servicePort,omitempty"`
 	// Address of the service that requests will be forwarded to.
-	// Defaults to 'networking.address', since Kuma DP should be deployed next
+	// Defaults to 'inbound.address', since Kuma DP should be deployed next
 	// to the service. When `KUMA_DEFAULTS_ENABLE_LOCALHOST_INBOUND_CLUSTERS`
 	// is true defaults to `127.0.0.1`.
 	ServiceAddress string `protobuf:"bytes,6,opt,name=serviceAddress,proto3" json:"serviceAddress,omitempty"`

--- a/api/mesh/v1alpha1/dataplane.pb.go
+++ b/api/mesh/v1alpha1/dataplane.pb.go
@@ -357,7 +357,7 @@ type Dataplane_Networking_Inbound struct {
 	// Defaults to the same value as `port`.
 	ServicePort uint32 `protobuf:"varint,4,opt,name=servicePort,proto3" json:"servicePort,omitempty"`
 	// Address of the service that requests will be forwarded to.
-	// Defaults to '127.0.0.1', since Kuma DP should be deployed next to the
+	// Defaults to 'DataplaneIP', since Kuma DP should be deployed next to the
 	// service.
 	ServiceAddress string `protobuf:"bytes,6,opt,name=serviceAddress,proto3" json:"serviceAddress,omitempty"`
 	// Address on which inbound listener will be exposed.

--- a/api/mesh/v1alpha1/dataplane.pb.go
+++ b/api/mesh/v1alpha1/dataplane.pb.go
@@ -358,7 +358,8 @@ type Dataplane_Networking_Inbound struct {
 	ServicePort uint32 `protobuf:"varint,4,opt,name=servicePort,proto3" json:"servicePort,omitempty"`
 	// Address of the service that requests will be forwarded to.
 	// Defaults to 'DataplaneIP', since Kuma DP should be deployed next to the
-	// service.
+	// service. When `KUMA_DEFAULTS_ENABLE_LOCALHOST_INBOUND_CLUSTERS` is true
+	// defaults to `127.0.0.1`.
 	ServiceAddress string `protobuf:"bytes,6,opt,name=serviceAddress,proto3" json:"serviceAddress,omitempty"`
 	// Address on which inbound listener will be exposed.
 	// Defaults to `networking.address`.

--- a/api/mesh/v1alpha1/dataplane.proto
+++ b/api/mesh/v1alpha1/dataplane.proto
@@ -65,7 +65,7 @@ message Dataplane {
       uint32 servicePort = 4;
 
       // Address of the service that requests will be forwarded to.
-      // Defaults to 'networking.address', since Kuma DP should be deployed next
+      // Defaults to 'inbound.address', since Kuma DP should be deployed next
       // to the service. When `KUMA_DEFAULTS_ENABLE_LOCALHOST_INBOUND_CLUSTERS`
       // is true defaults to `127.0.0.1`.
       string serviceAddress = 6;

--- a/api/mesh/v1alpha1/dataplane.proto
+++ b/api/mesh/v1alpha1/dataplane.proto
@@ -66,7 +66,8 @@ message Dataplane {
 
       // Address of the service that requests will be forwarded to.
       // Defaults to 'DataplaneIP', since Kuma DP should be deployed next to the
-      // service.
+      // service. When `KUMA_DEFAULTS_ENABLE_LOCALHOST_INBOUND_CLUSTERS` is true
+      // defaults to `127.0.0.1`.
       string serviceAddress = 6;
 
       // Address on which inbound listener will be exposed.

--- a/api/mesh/v1alpha1/dataplane.proto
+++ b/api/mesh/v1alpha1/dataplane.proto
@@ -67,7 +67,7 @@ message Dataplane {
       // Address of the service that requests will be forwarded to.
       // Defaults to 'inbound.address', since Kuma DP should be deployed next
       // to the service. When `KUMA_DEFAULTS_ENABLE_LOCALHOST_INBOUND_CLUSTERS`
-      // is true defaults to `127.0.0.1`.
+      // is true, this defaults to `127.0.0.1`.
       string serviceAddress = 6;
 
       // Address on which inbound listener will be exposed.

--- a/api/mesh/v1alpha1/dataplane.proto
+++ b/api/mesh/v1alpha1/dataplane.proto
@@ -65,7 +65,7 @@ message Dataplane {
       uint32 servicePort = 4;
 
       // Address of the service that requests will be forwarded to.
-      // Defaults to '127.0.0.1', since Kuma DP should be deployed next to the
+      // Defaults to 'DataplaneIP', since Kuma DP should be deployed next to the
       // service.
       string serviceAddress = 6;
 

--- a/api/mesh/v1alpha1/dataplane.proto
+++ b/api/mesh/v1alpha1/dataplane.proto
@@ -65,9 +65,9 @@ message Dataplane {
       uint32 servicePort = 4;
 
       // Address of the service that requests will be forwarded to.
-      // Defaults to 'DataplaneIP', since Kuma DP should be deployed next to the
-      // service. When `KUMA_DEFAULTS_ENABLE_LOCALHOST_INBOUND_CLUSTERS` is true
-      // defaults to `127.0.0.1`.
+      // Defaults to 'networking.address', since Kuma DP should be deployed next
+      // to the service. When `KUMA_DEFAULTS_ENABLE_LOCALHOST_INBOUND_CLUSTERS`
+      // is true defaults to `127.0.0.1`.
       string serviceAddress = 6;
 
       // Address on which inbound listener will be exposed.

--- a/docs/generated/resources/proxy_dataplane.md
+++ b/docs/generated/resources/proxy_dataplane.md
@@ -76,7 +76,7 @@
         - `serviceAddress` (optional)
         
             Address of the service that requests will be forwarded to.
-            Defaults to 'networking.address', since Kuma DP should be deployed next
+            Defaults to 'inbound.address', since Kuma DP should be deployed next
             to the service. When `KUMA_DEFAULTS_ENABLE_LOCALHOST_INBOUND_CLUSTERS`
             is true defaults to `127.0.0.1`.    
         

--- a/docs/generated/resources/proxy_dataplane.md
+++ b/docs/generated/resources/proxy_dataplane.md
@@ -76,9 +76,9 @@
         - `serviceAddress` (optional)
         
             Address of the service that requests will be forwarded to.
-            Defaults to 'DataplaneIP', since Kuma DP should be deployed next to the
-            service. When `KUMA_DEFAULTS_ENABLE_LOCALHOST_INBOUND_CLUSTERS` is true
-            defaults to `127.0.0.1`.    
+            Defaults to 'networking.address', since Kuma DP should be deployed next
+            to the service. When `KUMA_DEFAULTS_ENABLE_LOCALHOST_INBOUND_CLUSTERS`
+            is true defaults to `127.0.0.1`.    
         
         - `address` (optional)
         

--- a/docs/generated/resources/proxy_dataplane.md
+++ b/docs/generated/resources/proxy_dataplane.md
@@ -78,7 +78,7 @@
             Address of the service that requests will be forwarded to.
             Defaults to 'inbound.address', since Kuma DP should be deployed next
             to the service. When `KUMA_DEFAULTS_ENABLE_LOCALHOST_INBOUND_CLUSTERS`
-            is true defaults to `127.0.0.1`.    
+            is true, this defaults to `127.0.0.1`.    
         
         - `address` (optional)
         

--- a/docs/generated/resources/proxy_dataplane.md
+++ b/docs/generated/resources/proxy_dataplane.md
@@ -77,7 +77,8 @@
         
             Address of the service that requests will be forwarded to.
             Defaults to 'DataplaneIP', since Kuma DP should be deployed next to the
-            service.    
+            service. When `KUMA_DEFAULTS_ENABLE_LOCALHOST_INBOUND_CLUSTERS` is true
+            defaults to `127.0.0.1`.    
         
         - `address` (optional)
         

--- a/docs/generated/resources/proxy_dataplane.md
+++ b/docs/generated/resources/proxy_dataplane.md
@@ -76,7 +76,7 @@
         - `serviceAddress` (optional)
         
             Address of the service that requests will be forwarded to.
-            Defaults to '127.0.0.1', since Kuma DP should be deployed next to the
+            Defaults to 'DataplaneIP', since Kuma DP should be deployed next to the
             service.    
         
         - `address` (optional)


### PR DESCRIPTION
Split information about Universal and Kubernetes in UPGRADE docs, fixed default binding address in docs of Dataplane proto
- [X] Link to docs PR or issue --
- [X] Link to UI issue or PR --
- [X] Is the [issue worked on linked][1]? --
- [X] The PR does not hardcode values that might break projects that depend on kuma (e.g. "kumahq" as a image registry) --
- [X] The PR will work for both Linux and Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [X] Unit Tests --
- [X] E2E Tests --
- [X] Manual Universal Tests --
- [X] Manual Kubernetes Tests --
- [X] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [X] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [X] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
