### PR TITLE
test(e2e): add `ExternalService` with `MeshAccessLog`

### DIFF
--- a/test/e2e_env/universal/meshaccesslog/meshaccesslog.go
+++ b/test/e2e_env/universal/meshaccesslog/meshaccesslog.go
@@ -209,7 +209,7 @@ spec:
 		Expect(dst).To(Equal("external"))
 	})
 
-	It("supports logging traffic to an ExternalService using MeshService", func() {
+	It("supports logging traffic to an ExternalService using MeshService (without ZoneIngress)", func() {
 		externalService := fmt.Sprintf(`
 type: ExternalService
 name: external-service
@@ -253,6 +253,7 @@ spec:
 		Expect(src).To(Equal(AppModeDemoClient))
 		Expect(dst).To(Equal("ext-service"))
 	})
+
 	It("should log incoming traffic", func() {
 		yaml := fmt.Sprintf(`
 type: MeshAccessLog


### PR DESCRIPTION
### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] Link to docs PR or issue --
- [x] Link to UI issue or PR --
- [x] Is the [issue worked on linked][1]? -- Closes #5235 
- [x] The PR does not hardcode values that might break projects that depend on kuma (e.g. "kumahq" as a image registry) --
- [x] The PR will work for both Linux and Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Unit Tests --
- [x] E2E Tests --
- [x] Manual Universal Tests --
- [x] Manual Kubernetes Tests --
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [x] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
