### PR TITLE
fix(MeshGateway): cross-mesh gateways with same service

### DIFF
--- a/pkg/xds/generator/outbound_proxy_generator.go
+++ b/pkg/xds/generator/outbound_proxy_generator.go
@@ -375,6 +375,7 @@ func (OutboundProxyGenerator) determineRoutes(
 				isExternalService = true
 			}
 
+			allTags := envoy_common.Tags(destination.Destination)
 			cluster := envoy_common.NewCluster(
 				envoy_common.WithService(service),
 				envoy_common.WithName(name),
@@ -382,7 +383,7 @@ func (OutboundProxyGenerator) determineRoutes(
 				// The mesh tag is set here if this destination is generated
 				// from a MeshGateway virtual outbound and is not part of the
 				// service tags
-				envoy_common.WithTags(envoy_common.Tags(destination.Destination).WithoutTags(mesh_proto.MeshTag)),
+				envoy_common.WithTags(allTags.WithoutTags(mesh_proto.MeshTag)),
 				envoy_common.WithTimeout(timeoutConf),
 				envoy_common.WithLB(route.Spec.GetConf().GetLoadBalancer()),
 				envoy_common.WithExternalService(isExternalService),
@@ -392,10 +393,10 @@ func (OutboundProxyGenerator) determineRoutes(
 				cluster.SetMesh(mesh)
 			}
 
-			if name, ok := clusterCache[cluster.Tags().String()]; ok {
+			if name, ok := clusterCache[allTags.String()]; ok {
 				cluster.SetName(name)
 			} else {
-				clusterCache[cluster.Tags().String()] = cluster.Name()
+				clusterCache[allTags.String()] = cluster.Name()
 			}
 
 			if isExternalService {

--- a/test/e2e_env/kubernetes/gateway/cross-mesh.go
+++ b/test/e2e_env/kubernetes/gateway/cross-mesh.go
@@ -206,11 +206,11 @@ func CrossMeshGatewayOnKubernetes() {
 			Expect(setup.Setup(env.Cluster)).To(Succeed())
 
 			gatewayAddr := net.JoinHostPort(crossMeshHostname, strconv.Itoa(crossMeshGatewayPort))
-			Eventually(FailToProxyRequestToGateway(
+			Consistently(FailToProxyRequestToGateway(
 				env.Cluster,
 				gatewayAddr,
 				gatewayClientNamespaceOtherMesh,
-			), "30s", "1s").Should(Succeed())
+			), "30s", "1s").ShouldNot(Succeed())
 
 			setup = NewClusterSetup().
 				Install(DeleteYamlK8s(crossMeshGatewayYaml2)).

--- a/test/e2e_env/kubernetes/gateway/cross-mesh.go
+++ b/test/e2e_env/kubernetes/gateway/cross-mesh.go
@@ -123,6 +123,7 @@ func CrossMeshGatewayOnKubernetes() {
 		Expect(env.Cluster.TriggerDeleteNamespace(gatewayClientNamespaceSameMesh)).To(Succeed())
 		Expect(env.Cluster.TriggerDeleteNamespace(gatewayClientOutsideMesh)).To(Succeed())
 		Expect(env.Cluster.TriggerDeleteNamespace(gatewayTestNamespace)).To(Succeed())
+		Expect(env.Cluster.TriggerDeleteNamespace(gatewayTestNamespace2)).To(Succeed())
 		Expect(env.Cluster.DeleteMesh(gatewayMesh)).To(Succeed())
 		Expect(env.Cluster.DeleteMesh(gatewayOtherMesh)).To(Succeed())
 	})

--- a/test/e2e_env/kubernetes/gateway/utils.go
+++ b/test/e2e_env/kubernetes/gateway/utils.go
@@ -57,7 +57,7 @@ func FailToProxyRequestToGateway(cluster Cluster, gatewayAddr string, namespace 
 	}
 }
 
-func mkGateway(name, mesh string, crossMesh bool, hostname, backendService string, port int) string {
+func mkGateway(resourceName, serviceName, mesh string, crossMesh bool, hostname, backendService string, port int) string {
 	meshGateway := fmt.Sprintf(`
 apiVersion: kuma.io/v1alpha1
 kind: MeshGateway
@@ -74,7 +74,7 @@ spec:
       protocol: HTTP
       crossMesh: %t
       hostname: %s
-`, name, mesh, name, port, crossMesh, hostname)
+`, resourceName, mesh, serviceName, port, crossMesh, hostname)
 
 	route := fmt.Sprintf(`
 apiVersion: kuma.io/v1alpha1
@@ -96,7 +96,7 @@ spec:
         backends:
         - destination:
             kuma.io/service: %s # Matches the echo-server we deployed.
-`, name, mesh, name, backendService)
+`, resourceName, mesh, serviceName, backendService)
 	return strings.Join([]string{meshGateway, route}, "\n---\n")
 }
 


### PR DESCRIPTION
If two cross mesh gateways exist in different meshes with the same `kuma.io/service` tag, XDS was broken.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] Link to docs PR or issue --
- [x] Link to UI issue or PR --
- [x] Is the [issue worked on linked][1]? --
- [x] The PR does not hardcode values that might break projects that depend on kuma (e.g. "kumahq" as a image registry) --
- [x] The PR will work for both Linux and Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Unit Tests --
- [x] E2E Tests --
- [x] Manual Universal Tests --
- [x] Manual Kubernetes Tests --
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [x] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
