### PR TITLE
docs(release): created section 2.0 and upcoming release

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 [![][kuma-logo]][kuma-url]
 
 **Builds**
+[![CircleCI release-2.0](https://img.shields.io/circleci/build/github/kumahq/kuma/release-2.0?label=release-2.0)](https://circleci.com/gh/kumahq/kuma/tree/release-2.0)
 [![CircleCI release-1.8](https://img.shields.io/circleci/build/github/kumahq/kuma/release-1.8?label=release-1.8)](https://circleci.com/gh/kumahq/kuma/tree/release-1.8)
 [![CircleCI release-1.7](https://img.shields.io/circleci/build/github/kumahq/kuma/release-1.7?label=release-1.7)](https://circleci.com/gh/kumahq/kuma/tree/release-1.7)
 [![CircleCI release-1.6](https://img.shields.io/circleci/build/github/kumahq/kuma/release-1.6?label=release-1.6)](https://circleci.com/gh/kumahq/kuma/tree/release-1.6)

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,6 +8,8 @@ does not have any particular instructions.
 
 ## Upcoming release
 
+## Upgrade to `2.0.x`
+
 ### Universal
 
 A `lib/pq` change enables SNI by default when connecting to Postgres over TLS.


### PR DESCRIPTION
Added label to `README.md` and `2.x` section to `UPGRADE.md`.

- [X] Link to docs PR or issue --
- [X] Link to UI issue or PR --
- [X] Is the [issue worked on linked][1]? --
- [X] The PR does not hardcode values that might break projects that depend on kuma (e.g. "kumahq" as a image registry) --
- [X] The PR will work for both Linux and Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [X] Unit Tests --
- [X] E2E Tests --
- [X] Manual Universal Tests --
- [X] Manual Kubernetes Tests --
- [X] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [X] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [X] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
