### PR TITLE
feat(MeshGatewayInstance): respect `kuma.io/mesh` label

### DIFF
--- a/pkg/plugins/runtime/k8s/controllers/configmap_controller.go
+++ b/pkg/plugins/runtime/k8s/controllers/configmap_controller.go
@@ -122,7 +122,7 @@ func ServiceToConfigMapsMapper(client kube_client.Reader, l logr.Logger, systemN
 
 		meshSet := map[string]struct{}{}
 		for _, pod := range pods.Items {
-			meshSet[k8s_util.MeshOf(&pod, &ns)] = struct{}{}
+			meshSet[k8s_util.MeshOfByAnnotation(&pod, &ns)] = struct{}{}
 		}
 		var req []kube_reconile.Request
 		for mesh := range meshSet {

--- a/pkg/plugins/runtime/k8s/controllers/gateway_converter.go
+++ b/pkg/plugins/runtime/k8s/controllers/gateway_converter.go
@@ -24,7 +24,7 @@ func (r *PodReconciler) createorUpdateBuiltinGatewayDataplane(ctx context.Contex
 			Namespace: pod.Namespace,
 			Name:      pod.Name,
 		},
-		Mesh: k8s_util.MeshOf(pod, ns),
+		Mesh: k8s_util.MeshOfByAnnotation(pod, ns),
 	}
 
 	tagsAnnotation, ok := pod.Annotations[metadata.KumaTagsAnnotation]

--- a/pkg/plugins/runtime/k8s/controllers/gateway_instance_controller.go
+++ b/pkg/plugins/runtime/k8s/controllers/gateway_instance_controller.go
@@ -67,7 +67,8 @@ func (r *GatewayInstanceReconciler) Reconcile(ctx context.Context, req kube_ctrl
 	if err := r.Client.Get(ctx, kube_types.NamespacedName{Name: gatewayInstance.Namespace}, &ns); err != nil {
 		return kube_ctrl.Result{}, errors.Wrap(err, "unable to get Namespace of MeshGatewayInstance")
 	}
-	mesh := k8s_util.MeshOf(gatewayInstance, &ns)
+
+	mesh := k8s_util.MeshOfByLabelOrAnnotation(r.Log, gatewayInstance, &ns)
 
 	orig := gatewayInstance.DeepCopyObject().(kube_client.Object)
 	svc, err := r.createOrUpdateService(ctx, mesh, gatewayInstance)

--- a/pkg/plugins/runtime/k8s/controllers/gatewayapi/gateway_controller.go
+++ b/pkg/plugins/runtime/k8s/controllers/gatewayapi/gateway_controller.go
@@ -82,7 +82,7 @@ func (r *GatewayReconciler) Reconcile(ctx context.Context, req kube_ctrl.Request
 		return kube_ctrl.Result{}, errors.Wrap(err, "unable to get Namespace of MeshGateway")
 	}
 
-	mesh := k8s_util.MeshOf(gateway, &ns)
+	mesh := k8s_util.MeshOfByAnnotation(gateway, &ns)
 	gatewaySpec, listenerConditions, err := r.gapiToKumaGateway(ctx, mesh, gateway, config)
 	if err != nil {
 		return kube_ctrl.Result{}, errors.Wrap(err, "error generating MeshGateway.kuma.io")

--- a/pkg/plugins/runtime/k8s/controllers/gatewayapi/http_route_controller.go
+++ b/pkg/plugins/runtime/k8s/controllers/gatewayapi/http_route_controller.go
@@ -59,7 +59,7 @@ func (r *HTTPRouteReconciler) Reconcile(ctx context.Context, req kube_ctrl.Reque
 		return kube_ctrl.Result{}, errors.Wrap(err, "unable to get Namespace of HTTPRoute")
 	}
 
-	mesh := k8s_util.MeshOf(httpRoute, &ns)
+	mesh := k8s_util.MeshOfByAnnotation(httpRoute, &ns)
 
 	spec, conditions, err := r.gapiToKumaRoutes(ctx, mesh, httpRoute)
 	if err != nil {

--- a/pkg/plugins/runtime/k8s/controllers/pod_controller.go
+++ b/pkg/plugins/runtime/k8s/controllers/pod_controller.go
@@ -238,7 +238,7 @@ func (r *PodReconciler) findOtherDataplanes(ctx context.Context, pod *kube_core.
 	}
 
 	// only consider Dataplanes in the same Mesh as Pod
-	mesh := util_k8s.MeshOf(pod, ns)
+	mesh := util_k8s.MeshOfByAnnotation(pod, ns)
 	otherDataplanes := make([]*mesh_k8s.Dataplane, 0)
 	for i := range allDataplanes.Items {
 		dataplane := allDataplanes.Items[i]

--- a/pkg/plugins/runtime/k8s/controllers/pod_converter.go
+++ b/pkg/plugins/runtime/k8s/controllers/pod_converter.go
@@ -41,7 +41,7 @@ func (p *PodConverter) PodToDataplane(
 	services []*kube_core.Service,
 	others []*mesh_k8s.Dataplane,
 ) error {
-	dataplane.Mesh = util_k8s.MeshOf(pod, ns)
+	dataplane.Mesh = util_k8s.MeshOfByAnnotation(pod, ns)
 	dataplaneProto, err := p.dataplaneFor(ctx, pod, services, others)
 	if err != nil {
 		return err

--- a/pkg/plugins/runtime/k8s/util/util.go
+++ b/pkg/plugins/runtime/k8s/util/util.go
@@ -151,20 +151,17 @@ func MeshOfByAnnotation(obj kube_meta.Object, namespace *kube_core.Namespace) st
 }
 
 // MeshOfByLabelOrAnnotation returns the mesh of the given object according to its own
-// annotations or labels or those of its namespace. It treats the annotation
+// annotations or labels or the annotations of its namespace. It treats the annotation
 // directly on the object as deprecated.
 func MeshOfByLabelOrAnnotation(log logr.Logger, obj kube_client.Object, namespace *kube_core.Namespace) string {
 	if mesh, exists := metadata.Annotations(obj.GetLabels()).GetString(metadata.KumaMeshLabel); exists && mesh != "" {
 		return mesh
 	}
-	if mesh, exists := metadata.Annotations(namespace.GetLabels()).GetString(metadata.KumaMeshLabel); exists && mesh != "" {
-		return mesh
-	}
-
 	if mesh, exists := metadata.Annotations(obj.GetAnnotations()).GetString(metadata.KumaMeshAnnotation); exists && mesh != "" {
 		log.Info("WARNING: The kuma.io/mesh annotation is deprecated for this object kind", "name", obj.GetName(), "namespace", obj.GetNamespace(), "kind", obj.GetObjectKind().GroupVersionKind().Kind)
 		return mesh
 	}
+
 	if mesh, exists := metadata.Annotations(namespace.GetAnnotations()).GetString(metadata.KumaMeshAnnotation); exists && mesh != "" {
 		return mesh
 	}

--- a/pkg/plugins/runtime/k8s/util/util_test.go
+++ b/pkg/plugins/runtime/k8s/util/util_test.go
@@ -205,7 +205,7 @@ var _ = Describe("Util", func() {
 				}
 
 				// then
-				Expect(util.MeshOf(pod, ns)).To(Equal(given.expected))
+				Expect(util.MeshOfByAnnotation(pod, ns)).To(Equal(given.expected))
 			},
 			Entry("Pod without annotations", testCase{
 				podAnnotations: nil,

--- a/pkg/plugins/runtime/k8s/webhooks/injector/injector.go
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/injector.go
@@ -88,7 +88,7 @@ func (i *KumaInjector) InjectKuma(ctx context.Context, pod *kube_core.Pod) error
 		logger.V(1).Info("skip injecting Kuma")
 		return nil
 	}
-	meshName := k8s_util.MeshOf(pod, ns)
+	meshName := k8s_util.MeshOfByAnnotation(pod, ns)
 	logger = logger.WithValues("mesh", meshName)
 	// Check mesh exists
 	if err := i.client.Get(ctx, kube_types.NamespacedName{Name: meshName}, &mesh_k8s.Mesh{}); err != nil {


### PR DESCRIPTION
This is more in line with the plans for `targetRef` policies.

We need to decide on whether to move to labels everywhere (i.e. Pods/Namespaces)!

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] Link to docs PR or issue -- https://github.com/kumahq/kuma-website/issues/1160
- [x] Link to UI issue or PR --
- [x] Is the [issue worked on linked][1]? -- none
- [x] The PR does not hardcode values that might break projects that depend on kuma (e.g. "kumahq" as a image registry) --
- [x] The PR will work for both Linux and Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Unit Tests --
- [x] E2E Tests -- none
- [x] Manual Universal Tests -- none
- [x] Manual Kubernetes Tests -- none 
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [x] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
