### PR TITLE
fix(kumadp): use non ssl images - [WIP]

### DIFF
--- a/tools/releases/dockerfiles/Dockerfile.kuma-dp
+++ b/tools/releases/dockerfiles/Dockerfile.kuma-dp
@@ -10,6 +10,8 @@ RUN apt-get update && \
     apt-get install -y libcap2-bin
 RUN setcap cap_net_bind_service+ep /envoy
 
+# need to wait for gcr.io/distroless/base-nonssl-debian11:debug-nonroot
+# https://github.com/GoogleContainerTools/distroless/issues/1098
 FROM --platform=linux/$BASE_IMAGE_ARCH gcr.io/distroless/base-debian11:debug-nonroot
 ARG ARCH
 

--- a/tools/releases/dockerfiles/Dockerfile.kuma-init
+++ b/tools/releases/dockerfiles/Dockerfile.kuma-init
@@ -8,6 +8,7 @@ ARG ARCH
 
 RUN apt-get update && \
     apt-get -y install iptables iproute2 && \
+    apt-get -y remove openssl && \
     rm -rf /var/lib/apt/lists/*
 
 ADD /build/artifacts-linux-$ARCH/kumactl/kumactl /usr/bin


### PR DESCRIPTION
Signed-off-by: slonka <slonka@users.noreply.github.com>

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [ ] Link to docs PR or issue --
- [ ] Link to UI issue or PR --
- [ ] Is the [issue worked on linked][1]? --
- [ ] The PR does not hardcode values that might break projects that depend on kuma (e.g. "kumahq" as a image registry) --
- [ ] The PR will work for both Linux and Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [ ] Unit Tests --
- [ ] E2E Tests --
- [ ] Manual Universal Tests --
- [ ] Manual Kubernetes Tests --
- [ ] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [ ] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [ ] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
