### PR TITLE
ci(commitlint): restrict some scopes

### DIFF
--- a/.github/commitlint.config.js
+++ b/.github/commitlint.config.js
@@ -7,5 +7,9 @@ module.exports = {
     "footer-max-line-length": [0],
     "footer-leading-blank": [0],
     "header-max-length": [0],
+    // Disable some common mistyped scopes and some that should be used
+    "scope-enum": [2, "never", [
+      "kumacp", "kumadp", "kumacni", "kumainit", "*", "madr", "test", "ci", "perf"
+    ]]
   },
 };


### PR DESCRIPTION
This disallow some common misspell, * and some scopes that are actually types

Signed-off-by: Charly Molter <charly.molter@konghq.com>

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] Link to docs PR or issue --
- [x] Link to UI issue or PR --
- [x] Is the [issue worked on linked][1]? --
- [x] The PR does not hardcode values that might break projects that depend on kuma (e.g. "kumahq" as a image registry) --
- [x] The PR will work for both Linux and Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Unit Tests --
- [x] E2E Tests --
- [x] Manual Universal Tests --
- [x] Manual Kubernetes Tests --
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [x] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
