### PR TITLE
test(e2e): increase eventually timeouts in defaults tests

### DIFF
--- a/test/e2e_env/kubernetes/defaults/defaults.go
+++ b/test/e2e_env/kubernetes/defaults/defaults.go
@@ -33,18 +33,18 @@ func Defaults() {
 	}
 
 	It("should create default policies for default mesh", func() {
-		Eventually(policyCreated("trafficpermission", "allow-all-default"), "5s", "500ms").Should(BeTrue())
-		Eventually(policyCreated("trafficroute", "route-all-default"), "5s", "500ms").Should(BeTrue())
-		Eventually(policyCreated("timeout", "timeout-all-default"), "5s", "500ms").Should(BeTrue())
-		Eventually(policyCreated("circuitbreaker", "circuit-breaker-all-default"), "5s", "500ms").Should(BeTrue())
-		Eventually(policyCreated("retry", "retry-all-default"), "5s", "500ms").Should(BeTrue())
+		Eventually(policyCreated("trafficpermission", "allow-all-default"), "30s", "1s").Should(BeTrue())
+		Eventually(policyCreated("trafficroute", "route-all-default"), "30s", "1s").Should(BeTrue())
+		Eventually(policyCreated("timeout", "timeout-all-default"), "30s", "1s").Should(BeTrue())
+		Eventually(policyCreated("circuitbreaker", "circuit-breaker-all-default"), "30s", "1s").Should(BeTrue())
+		Eventually(policyCreated("retry", "retry-all-default"), "30s", "1s").Should(BeTrue())
 	})
 
 	It("should create default policies for non-default mesh", func() {
-		Eventually(policyCreated("trafficpermission", "allow-all-"+meshName), "5s", "500ms").Should(BeTrue())
-		Eventually(policyCreated("trafficroute", "route-all-"+meshName), "5s", "500ms").Should(BeTrue())
-		Eventually(policyCreated("timeout", "timeout-all-"+meshName), "5s", "500ms").Should(BeTrue())
-		Eventually(policyCreated("circuitbreaker", "circuit-breaker-all-"+meshName), "5s", "500ms").Should(BeTrue())
-		Eventually(policyCreated("retry", "retry-all-"+meshName), "5s", "500ms").Should(BeTrue())
+		Eventually(policyCreated("trafficpermission", "allow-all-"+meshName), "30s", "1s").Should(BeTrue())
+		Eventually(policyCreated("trafficroute", "route-all-"+meshName), "30s", "1s").Should(BeTrue())
+		Eventually(policyCreated("timeout", "timeout-all-"+meshName), "30s", "1s").Should(BeTrue())
+		Eventually(policyCreated("circuitbreaker", "circuit-breaker-all-"+meshName), "30s", "1s").Should(BeTrue())
+		Eventually(policyCreated("retry", "retry-all-"+meshName), "30s", "1s").Should(BeTrue())
 	})
 }


### PR DESCRIPTION
`defaults.go` test is flaky.
5s for creating resources may not be enough when many tests are run in parallel (Kube API Server can throttle Kuma)

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [ ] Link to docs PR or issue --
- [ ] Link to UI issue or PR --
- [ ] Is the [issue worked on linked][1]? --
- [ ] The PR does not hardcode values that might break projects that depend on kuma (e.g. "kumahq" as a image registry) --
- [ ] The PR will work for both Linux and Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [ ] Unit Tests --
- [ ] E2E Tests --
- [ ] Manual Universal Tests --
- [ ] Manual Kubernetes Tests --
- [ ] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [ ] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [ ] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
