### PR TITLE
feat(MeshAccessLog): add OmitEmptyValues to MeshAccessLog format

### DIFF
--- a/app/kumactl/cmd/install/testdata/install-control-plane.defaults.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.defaults.golden.yaml
@@ -1635,6 +1635,8 @@ spec:
                                               type: string
                                           type: object
                                         type: array
+                                      omitEmptyValues:
+                                        type: boolean
                                       plain:
                                         type: string
                                     type: object
@@ -1662,6 +1664,8 @@ spec:
                                               type: string
                                           type: object
                                         type: array
+                                      omitEmptyValues:
+                                        type: boolean
                                       plain:
                                         type: string
                                     type: object
@@ -1759,6 +1763,8 @@ spec:
                                               type: string
                                           type: object
                                         type: array
+                                      omitEmptyValues:
+                                        type: boolean
                                       plain:
                                         type: string
                                     type: object
@@ -1786,6 +1792,8 @@ spec:
                                               type: string
                                           type: object
                                         type: array
+                                      omitEmptyValues:
+                                        type: boolean
                                       plain:
                                         type: string
                                     type: object

--- a/app/kumactl/cmd/install/testdata/install-control-plane.gateway-api-present-not-enabled.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.gateway-api-present-not-enabled.yaml
@@ -1635,6 +1635,8 @@ spec:
                                               type: string
                                           type: object
                                         type: array
+                                      omitEmptyValues:
+                                        type: boolean
                                       plain:
                                         type: string
                                     type: object
@@ -1662,6 +1664,8 @@ spec:
                                               type: string
                                           type: object
                                         type: array
+                                      omitEmptyValues:
+                                        type: boolean
                                       plain:
                                         type: string
                                     type: object
@@ -1759,6 +1763,8 @@ spec:
                                               type: string
                                           type: object
                                         type: array
+                                      omitEmptyValues:
+                                        type: boolean
                                       plain:
                                         type: string
                                     type: object
@@ -1786,6 +1792,8 @@ spec:
                                               type: string
                                           type: object
                                         type: array
+                                      omitEmptyValues:
+                                        type: boolean
                                       plain:
                                         type: string
                                     type: object

--- a/app/kumactl/cmd/install/testdata/install-control-plane.gateway-api-present.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.gateway-api-present.yaml
@@ -1894,6 +1894,8 @@ spec:
                                               type: string
                                           type: object
                                         type: array
+                                      omitEmptyValues:
+                                        type: boolean
                                       plain:
                                         type: string
                                     type: object
@@ -1921,6 +1923,8 @@ spec:
                                               type: string
                                           type: object
                                         type: array
+                                      omitEmptyValues:
+                                        type: boolean
                                       plain:
                                         type: string
                                     type: object
@@ -2018,6 +2022,8 @@ spec:
                                               type: string
                                           type: object
                                         type: array
+                                      omitEmptyValues:
+                                        type: boolean
                                       plain:
                                         type: string
                                     type: object
@@ -2045,6 +2051,8 @@ spec:
                                               type: string
                                           type: object
                                         type: array
+                                      omitEmptyValues:
+                                        type: boolean
                                       plain:
                                         type: string
                                     type: object

--- a/app/kumactl/cmd/install/testdata/install-control-plane.with-helm-set.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.with-helm-set.yaml
@@ -1655,6 +1655,8 @@ spec:
                                               type: string
                                           type: object
                                         type: array
+                                      omitEmptyValues:
+                                        type: boolean
                                       plain:
                                         type: string
                                     type: object
@@ -1682,6 +1684,8 @@ spec:
                                               type: string
                                           type: object
                                         type: array
+                                      omitEmptyValues:
+                                        type: boolean
                                       plain:
                                         type: string
                                     type: object
@@ -1779,6 +1783,8 @@ spec:
                                               type: string
                                           type: object
                                         type: array
+                                      omitEmptyValues:
+                                        type: boolean
                                       plain:
                                         type: string
                                     type: object
@@ -1806,6 +1812,8 @@ spec:
                                               type: string
                                           type: object
                                         type: array
+                                      omitEmptyValues:
+                                        type: boolean
                                       plain:
                                         type: string
                                     type: object

--- a/app/kumactl/cmd/install/testdata/install-crds.all.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-crds.all.golden.yaml
@@ -446,6 +446,8 @@ spec:
                                               type: string
                                           type: object
                                         type: array
+                                      omitEmptyValues:
+                                        type: boolean
                                       plain:
                                         type: string
                                     type: object
@@ -473,6 +475,8 @@ spec:
                                               type: string
                                           type: object
                                         type: array
+                                      omitEmptyValues:
+                                        type: boolean
                                       plain:
                                         type: string
                                     type: object
@@ -570,6 +574,8 @@ spec:
                                               type: string
                                           type: object
                                         type: array
+                                      omitEmptyValues:
+                                        type: boolean
                                       plain:
                                         type: string
                                     type: object
@@ -597,6 +603,8 @@ spec:
                                               type: string
                                           type: object
                                         type: array
+                                      omitEmptyValues:
+                                        type: boolean
                                       plain:
                                         type: string
                                     type: object

--- a/app/kumactl/cmd/install/testdata/install-crds.experimental-gatewayapi.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-crds.experimental-gatewayapi.golden.yaml
@@ -446,6 +446,8 @@ spec:
                                               type: string
                                           type: object
                                         type: array
+                                      omitEmptyValues:
+                                        type: boolean
                                       plain:
                                         type: string
                                     type: object
@@ -473,6 +475,8 @@ spec:
                                               type: string
                                           type: object
                                         type: array
+                                      omitEmptyValues:
+                                        type: boolean
                                       plain:
                                         type: string
                                     type: object
@@ -570,6 +574,8 @@ spec:
                                               type: string
                                           type: object
                                         type: array
+                                      omitEmptyValues:
+                                        type: boolean
                                       plain:
                                         type: string
                                     type: object
@@ -597,6 +603,8 @@ spec:
                                               type: string
                                           type: object
                                         type: array
+                                      omitEmptyValues:
+                                        type: boolean
                                       plain:
                                         type: string
                                     type: object

--- a/deployments/charts/kuma/crds/kuma.io_meshaccesslogs.yaml
+++ b/deployments/charts/kuma/crds/kuma.io_meshaccesslogs.yaml
@@ -65,6 +65,8 @@ spec:
                                               type: string
                                           type: object
                                         type: array
+                                      omitEmptyValues:
+                                        type: boolean
                                       plain:
                                         type: string
                                     type: object
@@ -92,6 +94,8 @@ spec:
                                               type: string
                                           type: object
                                         type: array
+                                      omitEmptyValues:
+                                        type: boolean
                                       plain:
                                         type: string
                                     type: object
@@ -189,6 +193,8 @@ spec:
                                               type: string
                                           type: object
                                         type: array
+                                      omitEmptyValues:
+                                        type: boolean
                                       plain:
                                         type: string
                                     type: object
@@ -216,6 +222,8 @@ spec:
                                               type: string
                                           type: object
                                         type: array
+                                      omitEmptyValues:
+                                        type: boolean
                                       plain:
                                         type: string
                                     type: object

--- a/pkg/plugins/policies/meshaccesslog/api/v1alpha1/meshaccesslog.go
+++ b/pkg/plugins/policies/meshaccesslog/api/v1alpha1/meshaccesslog.go
@@ -66,8 +66,9 @@ type FileBackend struct {
 }
 
 type Format struct {
-	Plain string      `json:"plain,omitempty"`
-	Json  []JsonValue `json:"json,omitempty"`
+	Plain           string      `json:"plain,omitempty"`
+	Json            []JsonValue `json:"json,omitempty"`
+	OmitEmptyValues bool        `json:"omitEmptyValues,omitempty"`
 }
 
 type JsonValue struct {

--- a/pkg/plugins/policies/meshaccesslog/api/v1alpha1/schema.yaml
+++ b/pkg/plugins/policies/meshaccesslog/api/v1alpha1/schema.yaml
@@ -35,6 +35,8 @@ properties:
                                   type: string
                               type: object
                             type: array
+                          omitEmptyValues:
+                            type: boolean
                           plain:
                             type: string
                         type: object
@@ -60,6 +62,8 @@ properties:
                                   type: string
                               type: object
                             type: array
+                          omitEmptyValues:
+                            type: boolean
                           plain:
                             type: string
                         type: object
@@ -143,6 +147,8 @@ properties:
                                   type: string
                               type: object
                             type: array
+                          omitEmptyValues:
+                            type: boolean
                           plain:
                             type: string
                         type: object
@@ -168,6 +174,8 @@ properties:
                                   type: string
                               type: object
                             type: array
+                          omitEmptyValues:
+                            type: boolean
                           plain:
                             type: string
                         type: object

--- a/pkg/plugins/policies/meshaccesslog/k8s/crd/kuma.io_meshaccesslogs.yaml
+++ b/pkg/plugins/policies/meshaccesslog/k8s/crd/kuma.io_meshaccesslogs.yaml
@@ -65,6 +65,8 @@ spec:
                                               type: string
                                           type: object
                                         type: array
+                                      omitEmptyValues:
+                                        type: boolean
                                       plain:
                                         type: string
                                     type: object
@@ -92,6 +94,8 @@ spec:
                                               type: string
                                           type: object
                                         type: array
+                                      omitEmptyValues:
+                                        type: boolean
                                       plain:
                                         type: string
                                     type: object
@@ -189,6 +193,8 @@ spec:
                                               type: string
                                           type: object
                                         type: array
+                                      omitEmptyValues:
+                                        type: boolean
                                       plain:
                                         type: string
                                     type: object
@@ -216,6 +222,8 @@ spec:
                                               type: string
                                           type: object
                                         type: array
+                                      omitEmptyValues:
+                                        type: boolean
                                       plain:
                                         type: string
                                     type: object

--- a/pkg/plugins/policies/meshaccesslog/plugin/xds/configurer.go
+++ b/pkg/plugins/policies/meshaccesslog/plugin/xds/configurer.go
@@ -92,6 +92,7 @@ func (c *Configurer) envoyAccessLog(defaultFormat string) (*envoy_accesslog.Acce
 						},
 					},
 				},
+				OmitEmptyValues: format.OmitEmptyValues,
 			}
 		} else if tcp := c.Backend.Tcp; tcp != nil {
 			substitutionFormatString = envoy_core.SubstitutionFormatString{
@@ -103,6 +104,7 @@ func (c *Configurer) envoyAccessLog(defaultFormat string) (*envoy_accesslog.Acce
 						},
 					},
 				},
+				OmitEmptyValues: format.OmitEmptyValues,
 			}
 		}
 	} else {
@@ -135,6 +137,7 @@ func (c *Configurer) envoyAccessLog(defaultFormat string) (*envoy_accesslog.Acce
 			Format: &envoy_core.SubstitutionFormatString_JsonFormat{
 				JsonFormat: &jsonFormat,
 			},
+			OmitEmptyValues: format.OmitEmptyValues,
 		}
 	}
 


### PR DESCRIPTION
Fixes #5290

Signed-off-by: Matthieu MOREL <matthieu.morel35@gmail.com>

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [ ] Link to docs PR or issue --
- [ ] Link to UI issue or PR --
- [ ] Is the [issue worked on linked][1]? --
- [ ] The PR does not hardcode values that might break projects that depend on kuma (e.g. "kumahq" as a image registry) --
- [ ] The PR will work for both Linux and Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [ ] Unit Tests --
- [ ] E2E Tests --
- [ ] Manual Universal Tests --
- [ ] Manual Kubernetes Tests --
- [ ] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [ ] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [ ] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
