### PR TITLE
test(e2e): flaky "remove Dataplane of evicted Pod"

### DIFF
--- a/test/e2e_env/kubernetes/graceful/eviction.go
+++ b/test/e2e_env/kubernetes/graceful/eviction.go
@@ -53,19 +53,12 @@ spec:
 		// when faulty pod is applied
 		Expect(env.Cluster.Install(YamlK8s(evictionPod))).To(Succeed())
 
-		// then Dataplane should be created
-		Eventually(func(g Gomega) {
-			dataplanes, err := env.Cluster.GetKumactlOptions().KumactlList("dataplanes", meshName)
-			g.Expect(err).ToNot(HaveOccurred())
-			g.Expect(dataplanes).Should(ContainElement(ContainSubstring("to-be-evicted")))
-		}, "30s", "1s").Should(Succeed())
-
 		// when it's evicted
 		Eventually(func(g Gomega) {
 			out, err := k8s.RunKubectlAndGetOutputE(env.Cluster.GetTesting(), env.Cluster.GetKubectlOptions(nsName), "get", "pods")
 			g.Expect(err).ToNot(HaveOccurred())
 			g.Expect(out).To(ContainSubstring("Evicted"))
-		}, "30s", "1s").Should(Succeed())
+		}, "60s", "1s").Should(Succeed())
 
 		// then Dataplane is removed
 		Eventually(func(g Gomega) {


### PR DESCRIPTION
CI fails https://app.circleci.com/pipelines/github/kumahq/kuma/17304/workflows/2314dfbb-afc2-4ce6-8a06-2a52a3ab3a40/jobs/252269

The checks in the test are not really correct:
1. Create a "bad" Pod
2. Check the DPP is created
3. Check the Pod has an "Evicted" status
4. Check the DPP is removed

It may happen that Pod is evicted so quickly that "Step 2" fails. I think we should check only the final "stable" state of the system. That's why the current PR removes "Step 2".

Signed-off-by: Ilya Lobkov <ilya.lobkov@konghq.com>

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [X] Link to docs PR or issue --
- [X] Link to UI issue or PR --
- [X] Is the [issue worked on linked][1]? --
- [X] The PR does not hardcode values that might break projects that depend on kuma (e.g. "kumahq" as a image registry) --
- [X] The PR will work for both Linux and Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [X] Unit Tests --
- [X] E2E Tests --
- [X] Manual Universal Tests --
- [X] Manual Kubernetes Tests --
- [X] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [X] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [X] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
