### PR TITLE
fix(kuma-cp): add option to disable `sslsni` in universal

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -26,7 +26,11 @@ and existing resources with a trailing slash are not affected.
 ### Universal
 
 A `lib/pq` change enables SNI by default when connecting to Postgres over TLS.
-Make sure your certificates contain a valid CN or SANs.
+Either make sure your certificates contain a valid CN or SANs for the hostname
+you're using
+or update to `2.0.1` and disable `sslsni` by setting the
+`KUMA_STORE_POSTGRES_TLS_DISABLE_SSLSNI` environment variable or
+`store.postgres.tls.disableSSLSNI` in the config to `true`.
 
 ### `kuma-prometheus-sd`
 

--- a/pkg/config/loader_test.go
+++ b/pkg/config/loader_test.go
@@ -115,6 +115,7 @@ var _ = Describe("Config loader", func() {
 			Expect(cfg.Store.Postgres.TLS.CertPath).To(Equal("/path/to/cert"))
 			Expect(cfg.Store.Postgres.TLS.KeyPath).To(Equal("/path/to/key"))
 			Expect(cfg.Store.Postgres.TLS.CAPath).To(Equal("/path/to/rootCert"))
+			Expect(cfg.Store.Postgres.TLS.DisableSSLSNI).To(BeTrue())
 
 			Expect(cfg.ApiServer.ReadOnly).To(Equal(true))
 			Expect(cfg.ApiServer.HTTP.Enabled).To(Equal(false))
@@ -310,6 +311,7 @@ store:
       certPath: /path/to/cert
       keyPath: /path/to/key
       caPath: /path/to/rootCert
+      disableSSLSNI: true
   kubernetes:
     systemNamespace: test-namespace
   cache:
@@ -567,6 +569,7 @@ proxy:
 				"KUMA_STORE_POSTGRES_TLS_CERT_PATH":                                                        "/path/to/cert",
 				"KUMA_STORE_POSTGRES_TLS_KEY_PATH":                                                         "/path/to/key",
 				"KUMA_STORE_POSTGRES_TLS_CA_PATH":                                                          "/path/to/rootCert",
+				"KUMA_STORE_POSTGRES_TLS_DISABLE_SSLSNI":                                                   "true",
 				"KUMA_STORE_POSTGRES_MIN_RECONNECT_INTERVAL":                                               "44s",
 				"KUMA_STORE_POSTGRES_MAX_RECONNECT_INTERVAL":                                               "55s",
 				"KUMA_STORE_KUBERNETES_SYSTEM_NAMESPACE":                                                   "test-namespace",

--- a/pkg/config/plugins/resources/postgres/config.go
+++ b/pkg/config/plugins/resources/postgres/config.go
@@ -52,9 +52,16 @@ func (cfg PostgresStoreConfig) ConnectionString() (string, error) {
 		return "", err
 	}
 	escape := func(value string) string { return strings.ReplaceAll(strings.ReplaceAll(value, `\`, `\\`), `'`, `\'`) }
+	boolOption := func(value bool) string {
+		if value {
+			return "1"
+		} else {
+			return "0"
+		}
+	}
 	return fmt.Sprintf(
-		`host='%s' port=%d user='%s' password='%s' dbname='%s' connect_timeout=%d sslmode=%s sslcert='%s' sslkey='%s' sslrootcert='%s'`,
-		escape(cfg.Host), cfg.Port, escape(cfg.User), escape(cfg.Password), escape(cfg.DbName), cfg.ConnectionTimeout, mode, escape(cfg.TLS.CertPath), escape(cfg.TLS.KeyPath), escape(cfg.TLS.CAPath),
+		`host='%s' port=%d user='%s' password='%s' dbname='%s' connect_timeout=%d sslmode=%s sslcert='%s' sslkey='%s' sslrootcert='%s' sslsni=%s`,
+		escape(cfg.Host), cfg.Port, escape(cfg.User), escape(cfg.Password), escape(cfg.DbName), cfg.ConnectionTimeout, mode, escape(cfg.TLS.CertPath), escape(cfg.TLS.KeyPath), escape(cfg.TLS.CAPath), boolOption(!cfg.TLS.DisableSSLSNI),
 	), nil
 }
 
@@ -95,6 +102,8 @@ type TLSPostgresStoreConfig struct {
 	KeyPath string `json:"keyPath" envconfig:"kuma_store_postgres_tls_key_path"`
 	// Path to the root certificate. Used in verifyCa and verifyFull modes.
 	CAPath string `json:"caPath" envconfig:"kuma_store_postgres_tls_ca_path"`
+	// Whether to disable SNI the postgres `sslsni` option.
+	DisableSSLSNI bool `json:"disableSSLSNI" envconfig:"kuma_store_postgres_tls_disable_sslsni"`
 }
 
 func (s TLSPostgresStoreConfig) Sanitize() {

--- a/pkg/config/plugins/resources/postgres/config_test.go
+++ b/pkg/config/plugins/resources/postgres/config_test.go
@@ -82,6 +82,13 @@ var _ = Describe("TLSPostgresStoreConfig", func() {
 			KeyPath:  "/path",
 			CertPath: "/path",
 		}),
+		Entry("mode VerifyFull without sslsni", postgres.TLSPostgresStoreConfig{
+			Mode:          postgres.VerifyFull,
+			CAPath:        "/path",
+			KeyPath:       "/path",
+			CertPath:      "/path",
+			DisableSSLSNI: true,
+		}),
 	)
 })
 
@@ -114,24 +121,25 @@ var _ = Describe("PostgresStoreConfig", func() {
 				MinReconnectInterval: config_types.Duration{Duration: 10 * time.Second},
 				MaxReconnectInterval: config_types.Duration{Duration: 10 * time.Second},
 			},
-			expected: `host='localhost' port=0 user='postgres' password='postgres' dbname='kuma' connect_timeout=0 sslmode=verify-full sslcert='/path' sslkey='/path' sslrootcert='/path'`,
+			expected: `host='localhost' port=0 user='postgres' password='postgres' dbname='kuma' connect_timeout=0 sslmode=verify-full sslcert='/path' sslkey='/path' sslrootcert='/path' sslsni=1`,
 		}),
-		Entry("password needing escape", stringTestCase{
+		Entry("password needing escape without sslsni", stringTestCase{
 			given: postgres.PostgresStoreConfig{
 				Host:     "localhost",
 				User:     "postgres",
 				Password: `'\`,
 				DbName:   "kuma",
 				TLS: postgres.TLSPostgresStoreConfig{
-					Mode:     postgres.VerifyFull,
-					CAPath:   "/path",
-					KeyPath:  "/path",
-					CertPath: "/path",
+					Mode:          postgres.VerifyFull,
+					CAPath:        "/path",
+					KeyPath:       "/path",
+					CertPath:      "/path",
+					DisableSSLSNI: true,
 				},
 				MinReconnectInterval: config_types.Duration{Duration: 10 * time.Second},
 				MaxReconnectInterval: config_types.Duration{Duration: 10 * time.Second},
 			},
-			expected: `host='localhost' port=0 user='postgres' password='\'\\' dbname='kuma' connect_timeout=0 sslmode=verify-full sslcert='/path' sslkey='/path' sslrootcert='/path'`,
+			expected: `host='localhost' port=0 user='postgres' password='\'\\' dbname='kuma' connect_timeout=0 sslmode=verify-full sslcert='/path' sslkey='/path' sslrootcert='/path' sslsni=0`,
 		}),
 	)
 	type validateTestCase struct {


### PR DESCRIPTION
### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] Link to docs PR or issue --
- [x] Link to UI issue or PR --
- [x] Is the [issue worked on linked][1]? --
- [x] The PR does not hardcode values that might break projects that depend on kuma (e.g. "kumahq" as a image registry) --
- [x] The PR will work for both Linux and Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Unit Tests --
- [x] E2E Tests -- none
- [x] Manual Universal Tests --
- [x] Manual Kubernetes Tests -- none
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [x] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
