### PR TITLE
fix(kumactl): use the same client in `kumactl apply`

### DIFF
--- a/app/kumactl/cmd/apply/apply_test.go
+++ b/app/kumactl/cmd/apply/apply_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/kumahq/kuma/pkg/core/rest/errors/types"
 	memory_resources "github.com/kumahq/kuma/pkg/plugins/resources/memory"
 	test_kumactl "github.com/kumahq/kuma/pkg/test/kumactl"
+	"github.com/kumahq/kuma/pkg/test/matchers"
 	"github.com/kumahq/kuma/pkg/test/resources/model"
 	test_store "github.com/kumahq/kuma/pkg/test/store"
 	util_http "github.com/kumahq/kuma/pkg/util/http"
@@ -443,6 +444,24 @@ networking:
 		Expect(resource.Meta.GetName()).To(Equal("sample"))
 		Expect(resource.Meta.GetMesh()).To(Equal("default"))
 		Expect(resource.Spec.Networking.Address).To(Equal("2.2.2.2"))
+	})
+
+	It("dry-run outputs templated resources", func() {
+		// given
+		rootCmd.SetArgs([]string{
+			"apply", "-f", filepath.Join("testdata", "apply-many-dataplane-template.yaml"),
+			"-v", "address=2.2.2.2", "--dry-run",
+		})
+
+		// when
+		buf := &bytes.Buffer{}
+		rootCmd.SetOut(buf)
+		rootCmd.SetErr(buf)
+		err := rootCmd.Execute()
+
+		// then
+		Expect(err).ToNot(HaveOccurred())
+		Expect(buf.String()).To(matchers.MatchGoldenEqual(filepath.Join("testdata", "apply-many-dataplane-template.golden.yaml")))
 	})
 
 	type testCase struct {

--- a/app/kumactl/cmd/apply/testdata/apply-many-dataplane-template.golden.yaml
+++ b/app/kumactl/cmd/apply/testdata/apply-many-dataplane-template.golden.yaml
@@ -1,0 +1,35 @@
+creationTime: "0001-01-01T00:00:00Z"
+mesh: default
+modificationTime: "0001-01-01T00:00:00Z"
+name: sample
+type: Dataplane
+networking:
+  address: 2.2.2.2
+  inbound:
+  - port: 80
+    tags:
+      kuma.io/service: web
+---
+creationTime: "0001-01-01T00:00:00Z"
+mesh: default
+modificationTime: "0001-01-01T00:00:00Z"
+name: sample-2
+type: Dataplane
+networking:
+  address: 2.2.2.2
+  inbound:
+  - port: 80
+    tags:
+      kuma.io/service: web
+---
+creationTime: "0001-01-01T00:00:00Z"
+mesh: default
+modificationTime: "0001-01-01T00:00:00Z"
+name: sample-3
+type: Dataplane
+networking:
+  address: 2.2.2.2
+  inbound:
+  - port: 80
+    tags:
+      kuma.io/service: web

--- a/app/kumactl/cmd/apply/testdata/apply-many-dataplane-template.yaml
+++ b/app/kumactl/cmd/apply/testdata/apply-many-dataplane-template.yaml
@@ -1,0 +1,29 @@
+name: sample
+mesh: default
+type: Dataplane
+networking:
+  address: "{{ address }}"
+  inbound:
+    - port: 80
+      tags:
+        "kuma.io/service": "web"
+---
+name: sample-2
+mesh: default
+type: Dataplane
+networking:
+  address: "{{ address }}"
+  inbound:
+    - port: 80
+      tags:
+        "kuma.io/service": "web"
+---
+name: sample-3
+mesh: default
+type: Dataplane
+networking:
+  address: "{{ address }}"
+  inbound:
+    - port: 80
+      tags:
+        "kuma.io/service": "web"

--- a/app/kumactl/cmd/get/get_resource.go
+++ b/app/kumactl/cmd/get/get_resource.go
@@ -1,7 +1,6 @@
 package get
 
 import (
-	"context"
 	"fmt"
 
 	"github.com/pkg/errors"
@@ -31,7 +30,7 @@ func NewGetResourceCmd(pctx *kumactl_cmd.RootContext, desc core_model.ResourceTy
 			resource := desc.NewObject()
 			switch desc.Scope {
 			case core_model.ScopeGlobal:
-				if err := rs.Get(context.Background(), resource, store.GetByKey(name, "")); err != nil {
+				if err := rs.Get(cmd.Context(), resource, store.GetByKey(name, "")); err != nil {
 					if store.IsResourceNotFound(err) {
 						return errors.New("No resources found")
 					}
@@ -39,7 +38,7 @@ func NewGetResourceCmd(pctx *kumactl_cmd.RootContext, desc core_model.ResourceTy
 				}
 			case core_model.ScopeMesh:
 				currentMesh := pctx.CurrentMesh()
-				if err := rs.Get(context.Background(), resource, store.GetByKey(name, currentMesh)); err != nil {
+				if err := rs.Get(cmd.Context(), resource, store.GetByKey(name, currentMesh)); err != nil {
 					if store.IsResourceNotFound(err) {
 						return errors.Errorf("No resources found in %s mesh", currentMesh)
 					}

--- a/app/kumactl/cmd/get/get_single_resource_test.go
+++ b/app/kumactl/cmd/get/get_single_resource_test.go
@@ -39,9 +39,9 @@ var _ = Describe("kumactl get [resource] NAME", func() {
 	rootTime, _ := time.Parse(time.RFC3339, "2008-04-01T16:05:36.995Z")
 	var _ resources.ApiServerClient = &testApiServerClient{}
 	BeforeEach(func() {
+		store = core_store.NewPaginationStore(memory_resources.NewStore())
 		rootCtx, _ := test_kumactl.MakeRootContext(rootTime, store)
 		rootCtx.Runtime.Registry = registry.Global()
-		store = core_store.NewPaginationStore(memory_resources.NewStore())
 		rootCmd = cmd.NewRootCmd(rootCtx)
 
 		// Different versions of cobra might emit errors to stdout

--- a/app/kumactl/pkg/output/yaml/printer.go
+++ b/app/kumactl/pkg/output/yaml/printer.go
@@ -17,7 +17,10 @@ func NewPrinter() output.Printer {
 
 var _ output.Printer = &printer{}
 
-type printer struct{}
+type printer struct {
+	// hasPrinted is used to add yaml separators `---` when printing multiple objects with the same printer
+	hasPrinted bool
+}
 
 func print(obj interface{}, out io.Writer) error {
 	b, err := yaml.Marshal(obj)
@@ -33,6 +36,12 @@ func (p *printer) Print(obj interface{}, out io.Writer) error {
 	// case showing the meta and then the spec is more readable than
 	// showing fields in an arbitrary order. This partially addresses
 	// https://github.com/kumahq/kuma/issues/679.
+	if p.hasPrinted {
+		if _, err := out.Write([]byte("---\n")); err != nil {
+			return err
+		}
+	}
+	p.hasPrinted = true
 	switch obj := obj.(type) {
 	case rest.Resource:
 		if err := print(obj.GetMeta(), out); err != nil {


### PR DESCRIPTION
We were creating a new http client for each resource which was causing an out of fd error when applying a lot of entities at once.

This moves client creation outside of the loop and ensure context is passed in everywhere.

Also fix --dry-run to output a valid set of yaml with `---` separators

Signed-off-by: Charly Molter <charly.molter@konghq.com>

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] Link to docs PR or issue --
- [x] Link to UI issue or PR --
- [x] Is the [issue worked on linked][1]? --
- [x] The PR does not hardcode values that might break projects that depend on kuma (e.g. "kumahq" as a image registry) --
- [x] The PR will work for both Linux and Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Unit Tests --
- [x] E2E Tests --
- [x] Manual Universal Tests --
- [x] Manual Kubernetes Tests --
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [x] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
