### PR TITLE
test(e2e): run probes test on universal cluster 2

### DIFF
--- a/test/e2e_env/multizone/healthcheck/healthcheck.go
+++ b/test/e2e_env/multizone/healthcheck/healthcheck.go
@@ -1,15 +1,15 @@
 package healthcheck
 
 import (
-	"fmt"
-	"strings"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	"github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	"github.com/kumahq/kuma/test/e2e_env/multizone/env"
 	. "github.com/kumahq/kuma/test/framework"
+	"github.com/kumahq/kuma/test/framework/client"
 )
 
 func ApplicationOnUniversalClientOnK8s() {
@@ -20,12 +20,17 @@ func ApplicationOnUniversalClientOnK8s() {
 		err := env.Global.Install(MTLSMeshUniversal(meshName))
 		Expect(err).ToNot(HaveOccurred())
 
+		err = DeleteAllResourcesUniversal(*env.Global.GetKumactlOptions(), mesh.RetryResourceTypeDescriptor, meshName)
+		Expect(err).ToNot(HaveOccurred())
+
 		err = NewClusterSetup().
 			Install(NamespaceWithSidecarInjection(namespace)).
 			Install(DemoClientK8s(meshName, namespace)).
 			Setup(env.KubeZone1)
 		Expect(err).ToNot(HaveOccurred())
 
+		// This is deliberately deployed on UniZone2 where KUMA_DEFAULTS_ENABLE_LOCALHOST_INBOUND_CLUSTERS is set to false
+		// Change this to UniZone2 (or split to both zones) when https://github.com/kumahq/kuma/issues/5335 is fixed.
 		err = NewClusterSetup().
 			Install(TestServerUniversal("test-server-1", meshName,
 				WithArgs([]string{"echo", "--instance", "dp-universal-1"}),
@@ -39,58 +44,27 @@ func ApplicationOnUniversalClientOnK8s() {
 			Install(TestServerUniversal("test-server-3", meshName,
 				WithArgs([]string{"echo", "--instance", "dp-universal-3"}),
 				WithProtocol("tcp"))).
-			Setup(env.UniZone1)
+			Setup(env.UniZone2)
 		Expect(err).ToNot(HaveOccurred())
 	})
 	E2EAfterAll(func() {
 		Expect(env.KubeZone1.TriggerDeleteNamespace(namespace)).To(Succeed())
-		Expect(env.UniZone1.DeleteMeshApps(meshName)).To(Succeed())
+		Expect(env.UniZone2.DeleteMeshApps(meshName)).To(Succeed())
 		Expect(env.Global.DeleteMesh(meshName)).To(Succeed())
 	})
 
 	It("should not load balance requests to unhealthy instance", func() {
-		pod, err := PodNameOfApp(env.KubeZone1, "demo-client", namespace)
-		Expect(err).ToNot(HaveOccurred())
-
-		cmd := []string{"curl", "-v", "-m", "3", "--fail", "test-server.mesh"}
-
-		instanceSet := map[string]bool{}
-		Eventually(func(g Gomega) {
-			instances := []string{"dp-universal-1", "dp-universal-3"}
-			stdout, _, err := env.KubeZone1.Exec(namespace, pod, "demo-client", cmd...)
+		expectHealthyInstances := func(g Gomega) {
+			instances, err := client.CollectResponsesByInstance(env.KubeZone1, "demo-client", "test-server.mesh",
+				client.FromKubernetesPod(namespace, "demo-client"),
+				client.WithNumberOfRequests(10),
+			)
 			g.Expect(err).ToNot(HaveOccurred())
-			for _, instance := range instances {
-				if strings.Contains(stdout, instance) {
-					instanceSet[instance] = true
-				}
-			}
-			g.Expect(instanceSet).To(HaveLen(len(instances)), fmt.Sprintf("Received from set: %v with different len to %v", instanceSet, instances))
-		}).WithTimeout(30 * time.Second).WithPolling(time.Second / 2).Should(Succeed())
-
-		var counter1, counter2, counter3, numErrors int
-		const numOfRequest = 100
-
-		for i := 0; i < numOfRequest; i++ {
-			var stdout string
-
-			stdout, _, err = env.KubeZone1.Exec(namespace, pod, "demo-client", cmd...)
-			switch {
-			case err != nil:
-				numErrors++
-				Logf("Got error when executing curl '%v'", err)
-			case strings.Contains(stdout, "dp-universal-1"):
-				counter1++
-			case strings.Contains(stdout, "dp-universal-2"):
-				counter2++
-			case strings.Contains(stdout, "dp-universal-3"):
-				counter3++
-			}
+			g.Expect(instances).To(HaveLen(2))
+			g.Expect(instances).To(And(HaveKey("dp-universal-1"), HaveKey("dp-universal-3")))
 		}
 
-		Expect(counter2).To(Equal(0))
-		Expect(counter1 > 0).To(BeTrue())
-		Expect(counter3 > 0).To(BeTrue())
-		Expect(counter1 + counter3).To(Equal(numOfRequest))
-		Expect(numErrors).To(Equal(0))
+		Eventually(expectHealthyInstances).WithTimeout(30 * time.Second).WithPolling(time.Second / 2).Should(Succeed())
+		Consistently(expectHealthyInstances).WithTimeout(10 * time.Second).WithPolling(time.Second / 2).Should(Succeed())
 	})
 }


### PR DESCRIPTION
`should not load balance requests to unhealthy instance` was flaky sometimes.
It turned out that it is a regression that was hidden behind retries that were not removed.

It still works with `KUMA_DEFAULTS_ENABLE_LOCALHOST_INBOUND_CLUSTERS=false` which is not a default setting.
I considered just disabling the test for now, but it's probably still good to run this and see that it's not flaky under "right" setting.
I refactored the test to use `CollectResponsesByInstance` which was used exactly for the case of checking which instances we did hit.

xref #5335

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [X] Link to docs PR or issue --
- [X] Link to UI issue or PR --
- [X] Is the [issue worked on linked][1]? --
- [X] The PR does not hardcode values that might break projects that depend on kuma (e.g. "kumahq" as a image registry) --
- [X] The PR will work for both Linux and Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [X] Unit Tests --
- [X] E2E Tests --
- [X] Manual Universal Tests --
- [X] Manual Kubernetes Tests --
- [X] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [X] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [X] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
