### PR TITLE
fix(api-server): fix tags filter value with `:`

### DIFF
--- a/pkg/api-server/dataplane_overview_endpoints.go
+++ b/pkg/api-server/dataplane_overview_endpoints.go
@@ -147,7 +147,8 @@ func (r *dataplaneOverviewEndpoints) fetchOverviews(ctx context.Context, p page,
 func parseTags(queryParamValues []string) map[string]string {
 	tags := make(map[string]string)
 	for _, value := range queryParamValues {
-		tagKv := strings.Split(value, ":")
+		// ":" are valid in tag value so only stop at the first separator
+		tagKv := strings.SplitN(value, ":", 2)
 		if len(tagKv) != 2 {
 			// ignore invalid formatted tags
 			continue

--- a/pkg/api-server/dataplane_overview_endpoints_test.go
+++ b/pkg/api-server/dataplane_overview_endpoints_test.go
@@ -82,8 +82,9 @@ var _ = Describe("Dataplane Overview Endpoints", func() {
 					{
 						Port: 1234,
 						Tags: map[string]string{
-							"service": "backend",
-							"version": "v1",
+							"service":   "backend",
+							"version":   "v1",
+							"tagcolumn": "tag:v",
 						},
 					},
 				},
@@ -141,7 +142,8 @@ var _ = Describe("Dataplane Overview Endpoints", func() {
 					"port": 1234,
 					"tags": {
 						"service": "backend",
-						"version": "v1"
+						"version": "v1",
+						"tagcolumn": "tag:v"
 					}
 				}
 			]
@@ -206,6 +208,10 @@ var _ = Describe("Dataplane Overview Endpoints", func() {
 			}),
 			Entry("should list all with all matching tags", testCase{
 				url:          "/meshes/mesh1/dataplanes+insights?tag=service:backend&tag=version:v1",
+				expectedJson: fmt.Sprintf(`{"total": 1, "items": [%s], "next": null}`, dp2Json),
+			}),
+			Entry("should list all with all matching tags with value with a column", testCase{
+				url:          "/meshes/mesh1/dataplanes+insights?tag=tagcolumn:tag:v",
 				expectedJson: fmt.Sprintf(`{"total": 1, "items": [%s], "next": null}`, dp2Json),
 			}),
 			Entry("should not list when any tag is not matching", testCase{


### PR DESCRIPTION
DP overview endpoint can filter by tags but wasn't supporting `:` values

Signed-off-by: Charly Molter <charly.molter@konghq.com>

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] Link to docs PR or issue --
- [x] Link to UI issue or PR --
- [x] Is the [issue worked on linked][1]? --
- [x] The PR does not hardcode values that might break projects that depend on kuma (e.g. "kumahq" as a image registry) --
- [x] The PR will work for both Linux and Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Unit Tests --
- [x] E2E Tests --
- [x] Manual Universal Tests --
- [x] Manual Kubernetes Tests --
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [x] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
