### PR TITLE
fix(policies): fix schema.yaml to have correct metadata

### DIFF
--- a/pkg/plugins/policies/donothingpolicy/api/v1alpha1/schema.yaml
+++ b/pkg/plugins/policies/donothingpolicy/api/v1alpha1/schema.yaml
@@ -1,110 +1,115 @@
 properties:
   type:
-    description: ''
+    description: 'the type of the resource'
     type: string
     enum:
       - DoNothingPolicy
   mesh:
     description: 'Mesh is the name of the Kuma mesh this resource belongs to. It may be omitted for cluster-scoped resources.'
     type: string
+    default: default
   name:
     description: 'Name of the Kuma resource'
     type: string
-  from:
-    description: From list makes a match between clients and corresponding configurations
-    items:
-      properties:
-        default:
-          description: Default is a configuration specific to the group of clients referenced in 'targetRef'
-          properties:
-            enableDoNothing:
-              description: User defined fields Set true in case of doing nothing
-              type: boolean
-          type: object
-        targetRef:
-          description: TargetRef is a reference to the resource that represents a group of clients.
-          properties:
-            kind:
-              description: Kind of the referenced resource
-              enum:
-                - Mesh
-                - MeshSubset
-                - MeshService
-                - MeshServiceSubset
-                - MeshGatewayRoute
-              type: string
-            mesh:
-              description: Mesh is reserved for future use to identify cross mesh resources.
-              type: string
-            name:
-              description: 'Name of the referenced resource. Can only be used with kinds: `MeshService`, `MeshServiceSubset` and `MeshGatewayRoute`'
-              type: string
-            tags:
-              additionalProperties:
-                type: string
-              description: Tags used to select a subset of proxies by tags. Can only be used with kinds `MeshSubset` and `MeshServiceSubset`
-              type: object
-          type: object
-      type: object
-    type: array
-  targetRef:
-    description: TargetRef is a reference to the resource the policy takes an effect on. The resource could be either a real store object or virtual resource defined inplace.
+  spec:
+    description: Spec is the specification of the Kuma DoNothingPolicy resource.
     properties:
-      kind:
-        description: Kind of the referenced resource
-        enum:
-          - Mesh
-          - MeshSubset
-          - MeshService
-          - MeshServiceSubset
-          - MeshGatewayRoute
-        type: string
-      mesh:
-        description: Mesh is reserved for future use to identify cross mesh resources.
-        type: string
-      name:
-        description: 'Name of the referenced resource. Can only be used with kinds: `MeshService`, `MeshServiceSubset` and `MeshGatewayRoute`'
-        type: string
-      tags:
-        additionalProperties:
-          type: string
-        description: Tags used to select a subset of proxies by tags. Can only be used with kinds `MeshSubset` and `MeshServiceSubset`
-        type: object
-    type: object
-  to:
-    description: To list makes a match between the consumed services and corresponding configurations
-    items:
-      properties:
-        default:
-          description: Default is a configuration specific to the group of destinations referenced in 'targetRef'
+      from:
+        description: From list makes a match between clients and corresponding configurations
+        items:
           properties:
-            enableDoNothing:
-              description: User defined fields Set true in case of doing nothing
-              type: boolean
-          type: object
-        targetRef:
-          description: TargetRef is a reference to the resource that represents a group of destinations.
-          properties:
-            kind:
-              description: Kind of the referenced resource
-              enum:
-                - Mesh
-                - MeshSubset
-                - MeshService
-                - MeshServiceSubset
-                - MeshGatewayRoute
-              type: string
-            mesh:
-              description: Mesh is reserved for future use to identify cross mesh resources.
-              type: string
-            name:
-              description: 'Name of the referenced resource. Can only be used with kinds: `MeshService`, `MeshServiceSubset` and `MeshGatewayRoute`'
-              type: string
-            tags:
-              additionalProperties:
-                type: string
-              description: Tags used to select a subset of proxies by tags. Can only be used with kinds `MeshSubset` and `MeshServiceSubset`
+            default:
+              description: Default is a configuration specific to the group of clients referenced in 'targetRef'
+              properties:
+                enableDoNothing:
+                  description: User defined fields Set true in case of doing nothing
+                  type: boolean
+              type: object
+            targetRef:
+              description: TargetRef is a reference to the resource that represents a group of clients.
+              properties:
+                kind:
+                  description: Kind of the referenced resource
+                  enum:
+                    - Mesh
+                    - MeshSubset
+                    - MeshService
+                    - MeshServiceSubset
+                    - MeshGatewayRoute
+                  type: string
+                mesh:
+                  description: Mesh is reserved for future use to identify cross mesh resources.
+                  type: string
+                name:
+                  description: 'Name of the referenced resource. Can only be used with kinds: `MeshService`, `MeshServiceSubset` and `MeshGatewayRoute`'
+                  type: string
+                tags:
+                  additionalProperties:
+                    type: string
+                  description: Tags used to select a subset of proxies by tags. Can only be used with kinds `MeshSubset` and `MeshServiceSubset`
+                  type: object
               type: object
           type: object
-      type: object
-    type: array
+        type: array
+      targetRef:
+        description: TargetRef is a reference to the resource the policy takes an effect on. The resource could be either a real store object or virtual resource defined inplace.
+        properties:
+          kind:
+            description: Kind of the referenced resource
+            enum:
+              - Mesh
+              - MeshSubset
+              - MeshService
+              - MeshServiceSubset
+              - MeshGatewayRoute
+            type: string
+          mesh:
+            description: Mesh is reserved for future use to identify cross mesh resources.
+            type: string
+          name:
+            description: 'Name of the referenced resource. Can only be used with kinds: `MeshService`, `MeshServiceSubset` and `MeshGatewayRoute`'
+            type: string
+          tags:
+            additionalProperties:
+              type: string
+            description: Tags used to select a subset of proxies by tags. Can only be used with kinds `MeshSubset` and `MeshServiceSubset`
+            type: object
+        type: object
+      to:
+        description: To list makes a match between the consumed services and corresponding configurations
+        items:
+          properties:
+            default:
+              description: Default is a configuration specific to the group of destinations referenced in 'targetRef'
+              properties:
+                enableDoNothing:
+                  description: User defined fields Set true in case of doing nothing
+                  type: boolean
+              type: object
+            targetRef:
+              description: TargetRef is a reference to the resource that represents a group of destinations.
+              properties:
+                kind:
+                  description: Kind of the referenced resource
+                  enum:
+                    - Mesh
+                    - MeshSubset
+                    - MeshService
+                    - MeshServiceSubset
+                    - MeshGatewayRoute
+                  type: string
+                mesh:
+                  description: Mesh is reserved for future use to identify cross mesh resources.
+                  type: string
+                name:
+                  description: 'Name of the referenced resource. Can only be used with kinds: `MeshService`, `MeshServiceSubset` and `MeshGatewayRoute`'
+                  type: string
+                tags:
+                  additionalProperties:
+                    type: string
+                  description: Tags used to select a subset of proxies by tags. Can only be used with kinds `MeshSubset` and `MeshServiceSubset`
+                  type: object
+              type: object
+          type: object
+        type: array
+    type: object

--- a/pkg/plugins/policies/donothingpolicy/api/v1alpha1/zz_generated.resource.go
+++ b/pkg/plugins/policies/donothingpolicy/api/v1alpha1/zz_generated.resource.go
@@ -17,12 +17,13 @@ import (
 
 //go:embed schema.yaml
 var rawSchema []byte
-var schema = &spec.Schema{}
+var schema = spec.Schema{}
 
 func init() {
-	if err := yaml.Unmarshal(rawSchema, schema); err != nil {
+	if err := yaml.Unmarshal(rawSchema, &schema); err != nil {
 		panic(err)
 	}
+	schema = schema.Properties["spec"]
 }
 
 const (
@@ -73,7 +74,7 @@ func (t *DoNothingPolicyResource) Descriptor() model.ResourceTypeDescriptor {
 }
 
 func (t *DoNothingPolicyResource) Validate() error {
-	if err := validation.ValidateSchema(t.GetSpec(), schema); err != nil {
+	if err := validation.ValidateSchema(t.GetSpec(), &schema); err != nil {
 		return err
 	}
 

--- a/pkg/plugins/policies/meshaccesslog/api/v1alpha1/schema.yaml
+++ b/pkg/plugins/policies/meshaccesslog/api/v1alpha1/schema.yaml
@@ -1,212 +1,217 @@
 properties:
   type:
-    description: ''
+    description: 'the type of the resource'
     type: string
     enum:
       - MeshAccessLog
   mesh:
     description: 'Mesh is the name of the Kuma mesh this resource belongs to. It may be omitted for cluster-scoped resources.'
     type: string
+    default: default
   name:
     description: 'Name of the Kuma resource'
     type: string
-  from:
-    description: From list makes a match between clients and corresponding configurations
-    items:
-      properties:
-        default:
-          description: Default is a configuration specific to the group of clients referenced in 'targetRef'
-          properties:
-            backends:
-              items:
-                properties:
-                  file:
-                    description: FileBackend defines configuration for file based access logs
-                    properties:
-                      format:
-                        description: Format of access logs. Placeholders available on https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log
-                        properties:
-                          json:
-                            items:
-                              properties:
-                                key:
-                                  type: string
-                                value:
-                                  type: string
-                              type: object
-                            type: array
-                          omitEmptyValues:
-                            type: boolean
-                          plain:
-                            type: string
-                        type: object
-                      path:
-                        description: Path to a file that logs will be written to
-                        type: string
-                    type: object
-                  tcp:
-                    description: TCPBackend defines a TCP logging backend.
-                    properties:
-                      address:
-                        description: Address of the TCP logging backend
-                        type: string
-                      format:
-                        description: Format of access logs. Placeholders available on https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log
-                        properties:
-                          json:
-                            items:
-                              properties:
-                                key:
-                                  type: string
-                                value:
-                                  type: string
-                              type: object
-                            type: array
-                          omitEmptyValues:
-                            type: boolean
-                          plain:
-                            type: string
-                        type: object
-                    type: object
-                type: object
-              nullable: true
-              type: array
-          type: object
-        targetRef:
-          description: TargetRef is a reference to the resource that represents a group of clients.
-          properties:
-            kind:
-              description: Kind of the referenced resource
-              enum:
-                - Mesh
-                - MeshSubset
-                - MeshService
-                - MeshServiceSubset
-                - MeshGatewayRoute
-              type: string
-            mesh:
-              description: Mesh is reserved for future use to identify cross mesh resources.
-              type: string
-            name:
-              description: 'Name of the referenced resource. Can only be used with kinds: `MeshService`, `MeshServiceSubset` and `MeshGatewayRoute`'
-              type: string
-            tags:
-              additionalProperties:
-                type: string
-              description: Tags used to select a subset of proxies by tags. Can only be used with kinds `MeshSubset` and `MeshServiceSubset`
-              type: object
-          type: object
-      type: object
-    type: array
-  targetRef:
-    description: TargetRef is a reference to the resource the policy takes an effect on. The resource could be either a real store object or virtual resource defined inplace.
+  spec:
+    description: Spec is the specification of the Kuma MeshAccessLog resource.
     properties:
-      kind:
-        description: Kind of the referenced resource
-        enum:
-          - Mesh
-          - MeshSubset
-          - MeshService
-          - MeshServiceSubset
-          - MeshGatewayRoute
-        type: string
-      mesh:
-        description: Mesh is reserved for future use to identify cross mesh resources.
-        type: string
-      name:
-        description: 'Name of the referenced resource. Can only be used with kinds: `MeshService`, `MeshServiceSubset` and `MeshGatewayRoute`'
-        type: string
-      tags:
-        additionalProperties:
-          type: string
-        description: Tags used to select a subset of proxies by tags. Can only be used with kinds `MeshSubset` and `MeshServiceSubset`
-        type: object
-    type: object
-  to:
-    description: To list makes a match between the consumed services and corresponding configurations
-    items:
-      properties:
-        default:
-          description: Default is a configuration specific to the group of destinations referenced in 'targetRef'
+      from:
+        description: From list makes a match between clients and corresponding configurations
+        items:
           properties:
-            backends:
-              items:
-                properties:
-                  file:
-                    description: FileBackend defines configuration for file based access logs
+            default:
+              description: Default is a configuration specific to the group of clients referenced in 'targetRef'
+              properties:
+                backends:
+                  items:
                     properties:
-                      format:
-                        description: Format of access logs. Placeholders available on https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log
+                      file:
+                        description: FileBackend defines configuration for file based access logs
                         properties:
-                          json:
-                            items:
-                              properties:
-                                key:
-                                  type: string
-                                value:
-                                  type: string
-                              type: object
-                            type: array
-                          omitEmptyValues:
-                            type: boolean
-                          plain:
+                          format:
+                            description: Format of access logs. Placeholders available on https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log
+                            properties:
+                              json:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    value:
+                                      type: string
+                                  type: object
+                                type: array
+                              omitEmptyValues:
+                                type: boolean
+                              plain:
+                                type: string
+                            type: object
+                          path:
+                            description: Path to a file that logs will be written to
                             type: string
                         type: object
-                      path:
-                        description: Path to a file that logs will be written to
-                        type: string
-                    type: object
-                  tcp:
-                    description: TCPBackend defines a TCP logging backend.
-                    properties:
-                      address:
-                        description: Address of the TCP logging backend
-                        type: string
-                      format:
-                        description: Format of access logs. Placeholders available on https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log
+                      tcp:
+                        description: TCPBackend defines a TCP logging backend.
                         properties:
-                          json:
-                            items:
-                              properties:
-                                key:
-                                  type: string
-                                value:
-                                  type: string
-                              type: object
-                            type: array
-                          omitEmptyValues:
-                            type: boolean
-                          plain:
+                          address:
+                            description: Address of the TCP logging backend
                             type: string
+                          format:
+                            description: Format of access logs. Placeholders available on https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log
+                            properties:
+                              json:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    value:
+                                      type: string
+                                  type: object
+                                type: array
+                              omitEmptyValues:
+                                type: boolean
+                              plain:
+                                type: string
+                            type: object
                         type: object
                     type: object
-                type: object
-              nullable: true
-              type: array
-          type: object
-        targetRef:
-          description: TargetRef is a reference to the resource that represents a group of destinations.
-          properties:
-            kind:
-              description: Kind of the referenced resource
-              enum:
-                - Mesh
-                - MeshSubset
-                - MeshService
-                - MeshServiceSubset
-                - MeshGatewayRoute
-              type: string
-            mesh:
-              description: Mesh is reserved for future use to identify cross mesh resources.
-              type: string
-            name:
-              description: 'Name of the referenced resource. Can only be used with kinds: `MeshService`, `MeshServiceSubset` and `MeshGatewayRoute`'
-              type: string
-            tags:
-              additionalProperties:
-                type: string
-              description: Tags used to select a subset of proxies by tags. Can only be used with kinds `MeshSubset` and `MeshServiceSubset`
+                  nullable: true
+                  type: array
+              type: object
+            targetRef:
+              description: TargetRef is a reference to the resource that represents a group of clients.
+              properties:
+                kind:
+                  description: Kind of the referenced resource
+                  enum:
+                    - Mesh
+                    - MeshSubset
+                    - MeshService
+                    - MeshServiceSubset
+                    - MeshGatewayRoute
+                  type: string
+                mesh:
+                  description: Mesh is reserved for future use to identify cross mesh resources.
+                  type: string
+                name:
+                  description: 'Name of the referenced resource. Can only be used with kinds: `MeshService`, `MeshServiceSubset` and `MeshGatewayRoute`'
+                  type: string
+                tags:
+                  additionalProperties:
+                    type: string
+                  description: Tags used to select a subset of proxies by tags. Can only be used with kinds `MeshSubset` and `MeshServiceSubset`
+                  type: object
               type: object
           type: object
-      type: object
-    type: array
+        type: array
+      targetRef:
+        description: TargetRef is a reference to the resource the policy takes an effect on. The resource could be either a real store object or virtual resource defined inplace.
+        properties:
+          kind:
+            description: Kind of the referenced resource
+            enum:
+              - Mesh
+              - MeshSubset
+              - MeshService
+              - MeshServiceSubset
+              - MeshGatewayRoute
+            type: string
+          mesh:
+            description: Mesh is reserved for future use to identify cross mesh resources.
+            type: string
+          name:
+            description: 'Name of the referenced resource. Can only be used with kinds: `MeshService`, `MeshServiceSubset` and `MeshGatewayRoute`'
+            type: string
+          tags:
+            additionalProperties:
+              type: string
+            description: Tags used to select a subset of proxies by tags. Can only be used with kinds `MeshSubset` and `MeshServiceSubset`
+            type: object
+        type: object
+      to:
+        description: To list makes a match between the consumed services and corresponding configurations
+        items:
+          properties:
+            default:
+              description: Default is a configuration specific to the group of destinations referenced in 'targetRef'
+              properties:
+                backends:
+                  items:
+                    properties:
+                      file:
+                        description: FileBackend defines configuration for file based access logs
+                        properties:
+                          format:
+                            description: Format of access logs. Placeholders available on https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log
+                            properties:
+                              json:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    value:
+                                      type: string
+                                  type: object
+                                type: array
+                              omitEmptyValues:
+                                type: boolean
+                              plain:
+                                type: string
+                            type: object
+                          path:
+                            description: Path to a file that logs will be written to
+                            type: string
+                        type: object
+                      tcp:
+                        description: TCPBackend defines a TCP logging backend.
+                        properties:
+                          address:
+                            description: Address of the TCP logging backend
+                            type: string
+                          format:
+                            description: Format of access logs. Placeholders available on https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log
+                            properties:
+                              json:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    value:
+                                      type: string
+                                  type: object
+                                type: array
+                              omitEmptyValues:
+                                type: boolean
+                              plain:
+                                type: string
+                            type: object
+                        type: object
+                    type: object
+                  nullable: true
+                  type: array
+              type: object
+            targetRef:
+              description: TargetRef is a reference to the resource that represents a group of destinations.
+              properties:
+                kind:
+                  description: Kind of the referenced resource
+                  enum:
+                    - Mesh
+                    - MeshSubset
+                    - MeshService
+                    - MeshServiceSubset
+                    - MeshGatewayRoute
+                  type: string
+                mesh:
+                  description: Mesh is reserved for future use to identify cross mesh resources.
+                  type: string
+                name:
+                  description: 'Name of the referenced resource. Can only be used with kinds: `MeshService`, `MeshServiceSubset` and `MeshGatewayRoute`'
+                  type: string
+                tags:
+                  additionalProperties:
+                    type: string
+                  description: Tags used to select a subset of proxies by tags. Can only be used with kinds `MeshSubset` and `MeshServiceSubset`
+                  type: object
+              type: object
+          type: object
+        type: array
+    type: object

--- a/pkg/plugins/policies/meshaccesslog/api/v1alpha1/zz_generated.resource.go
+++ b/pkg/plugins/policies/meshaccesslog/api/v1alpha1/zz_generated.resource.go
@@ -17,12 +17,13 @@ import (
 
 //go:embed schema.yaml
 var rawSchema []byte
-var schema = &spec.Schema{}
+var schema = spec.Schema{}
 
 func init() {
-	if err := yaml.Unmarshal(rawSchema, schema); err != nil {
+	if err := yaml.Unmarshal(rawSchema, &schema); err != nil {
 		panic(err)
 	}
+	schema = schema.Properties["spec"]
 }
 
 const (
@@ -73,7 +74,7 @@ func (t *MeshAccessLogResource) Descriptor() model.ResourceTypeDescriptor {
 }
 
 func (t *MeshAccessLogResource) Validate() error {
-	if err := validation.ValidateSchema(t.GetSpec(), schema); err != nil {
+	if err := validation.ValidateSchema(t.GetSpec(), &schema); err != nil {
 		return err
 	}
 

--- a/pkg/plugins/policies/meshtrace/api/v1alpha1/schema.yaml
+++ b/pkg/plugins/policies/meshtrace/api/v1alpha1/schema.yaml
@@ -1,114 +1,119 @@
 properties:
   type:
-    description: ''
+    description: 'the type of the resource'
     type: string
     enum:
       - MeshTrace
   mesh:
     description: 'Mesh is the name of the Kuma mesh this resource belongs to. It may be omitted for cluster-scoped resources.'
     type: string
+    default: default
   name:
     description: 'Name of the Kuma resource'
     type: string
-  default:
-    description: MeshTrace configuration.
+  spec:
+    description: Spec is the specification of the Kuma MeshTrace resource.
     properties:
-      backends:
-        description: A one element array of backend definition. Envoy allows configuring only 1 backend, so the natural way of representing that would be just one object. Unfortunately due to the reasons explained in MADR 009-tracing-policy this has to be a one element array for now.
-        items:
-          description: Only one of zipkin or datadog can be used.
-          properties:
-            datadog:
-              description: Datadog backend configuration.
-              properties:
-                splitService:
-                  description: 'Determines if datadog service name should be split based on traffic direction and destination. For example, with `splitService: true` and a `backend` service that communicates with a couple of databases, you would get service names like `backend_INBOUND`, `backend_OUTBOUND_db1`, and `backend_OUTBOUND_db2` in Datadog. Default: false'
-                  type: boolean
-                url:
-                  description: Address of Datadog collector, only host and port are allowed (no paths, fragments etc.)
-                  type: string
-              type: object
-            zipkin:
-              description: Zipkin backend configuration.
-              properties:
-                apiVersion:
-                  description: 'Version of the API. values: httpJson, httpProto. Default: httpJson see https://github.com/envoyproxy/envoy/blob/v1.22.0/api/envoy/config/trace/v3/zipkin.proto#L66'
-                  type: string
-                sharedSpanContext:
-                  description: 'Determines whether client and server spans will share the same span context. Default: true. https://github.com/envoyproxy/envoy/blob/v1.22.0/api/envoy/config/trace/v3/zipkin.proto#L63'
-                  type: boolean
-                traceId128bit:
-                  description: 'Generate 128bit traces. Default: false'
-                  type: boolean
-                url:
-                  description: Address of Zipkin collector.
-                  type: string
-              type: object
-          type: object
-        nullable: true
-        type: array
-      sampling:
-        description: Sampling configuration. Sampling is the process by which a decision is made on whether to process/export a span or not.
+      default:
+        description: MeshTrace configuration.
         properties:
-          client:
-            description: 'Target percentage of requests that will be force traced if the ''x-client-trace-id'' header is set. Default: 100% Mirror of client_sampling in Envoy https://github.com/envoyproxy/envoy/blob/v1.22.0/api/envoy/config/filter/network/http_connection_manager/v2/http_connection_manager.proto#L127-L133'
-            format: int32
-            type: integer
-          overall:
-            description: 'Target percentage of requests will be traced after all other sampling checks have been applied (client, force tracing, random sampling). This field functions as an upper limit on the total configured sampling rate. For instance, setting client_sampling to 100% but overall_sampling to 1% will result in only 1% of client requests with the appropriate headers to be force traced. Default: 100% Mirror of overall_sampling in Envoy https://github.com/envoyproxy/envoy/blob/v1.22.0/api/envoy/config/filter/network/http_connection_manager/v2/http_connection_manager.proto#L142-L150'
-            format: int32
-            type: integer
-          random:
-            description: 'Target percentage of requests that will be randomly selected for trace generation, if not requested by the client or not forced. Default: 100% Mirror of random_sampling in Envoy https://github.com/envoyproxy/envoy/blob/v1.22.0/api/envoy/config/filter/network/http_connection_manager/v2/http_connection_manager.proto#L135-L140'
-            format: int32
-            type: integer
-        type: object
-      tags:
-        description: Custom tags configuration. You can add custom tags to traces based on headers or literal values.
-        items:
-          description: Custom tags configuration. Only one of literal or header can be used.
-          properties:
-            header:
-              description: Tag taken from a header.
+          backends:
+            description: A one element array of backend definition. Envoy allows configuring only 1 backend, so the natural way of representing that would be just one object. Unfortunately due to the reasons explained in MADR 009-tracing-policy this has to be a one element array for now.
+            items:
+              description: Only one of zipkin or datadog can be used.
               properties:
-                default:
-                  description: Default value to use if header is missing. If the default is missing and there is no value the tag will not be included.
+                datadog:
+                  description: Datadog backend configuration.
+                  properties:
+                    splitService:
+                      description: 'Determines if datadog service name should be split based on traffic direction and destination. For example, with `splitService: true` and a `backend` service that communicates with a couple of databases, you would get service names like `backend_INBOUND`, `backend_OUTBOUND_db1`, and `backend_OUTBOUND_db2` in Datadog. Default: false'
+                      type: boolean
+                    url:
+                      description: Address of Datadog collector, only host and port are allowed (no paths, fragments etc.)
+                      type: string
+                  type: object
+                zipkin:
+                  description: Zipkin backend configuration.
+                  properties:
+                    apiVersion:
+                      description: 'Version of the API. values: httpJson, httpProto. Default: httpJson see https://github.com/envoyproxy/envoy/blob/v1.22.0/api/envoy/config/trace/v3/zipkin.proto#L66'
+                      type: string
+                    sharedSpanContext:
+                      description: 'Determines whether client and server spans will share the same span context. Default: true. https://github.com/envoyproxy/envoy/blob/v1.22.0/api/envoy/config/trace/v3/zipkin.proto#L63'
+                      type: boolean
+                    traceId128bit:
+                      description: 'Generate 128bit traces. Default: false'
+                      type: boolean
+                    url:
+                      description: Address of Zipkin collector.
+                      type: string
+                  type: object
+              type: object
+            nullable: true
+            type: array
+          sampling:
+            description: Sampling configuration. Sampling is the process by which a decision is made on whether to process/export a span or not.
+            properties:
+              client:
+                description: 'Target percentage of requests that will be force traced if the ''x-client-trace-id'' header is set. Default: 100% Mirror of client_sampling in Envoy https://github.com/envoyproxy/envoy/blob/v1.22.0/api/envoy/config/filter/network/http_connection_manager/v2/http_connection_manager.proto#L127-L133'
+                format: int32
+                type: integer
+              overall:
+                description: 'Target percentage of requests will be traced after all other sampling checks have been applied (client, force tracing, random sampling). This field functions as an upper limit on the total configured sampling rate. For instance, setting client_sampling to 100% but overall_sampling to 1% will result in only 1% of client requests with the appropriate headers to be force traced. Default: 100% Mirror of overall_sampling in Envoy https://github.com/envoyproxy/envoy/blob/v1.22.0/api/envoy/config/filter/network/http_connection_manager/v2/http_connection_manager.proto#L142-L150'
+                format: int32
+                type: integer
+              random:
+                description: 'Target percentage of requests that will be randomly selected for trace generation, if not requested by the client or not forced. Default: 100% Mirror of random_sampling in Envoy https://github.com/envoyproxy/envoy/blob/v1.22.0/api/envoy/config/filter/network/http_connection_manager/v2/http_connection_manager.proto#L135-L140'
+                format: int32
+                type: integer
+            type: object
+          tags:
+            description: Custom tags configuration. You can add custom tags to traces based on headers or literal values.
+            items:
+              description: Custom tags configuration. Only one of literal or header can be used.
+              properties:
+                header:
+                  description: Tag taken from a header.
+                  properties:
+                    default:
+                      description: Default value to use if header is missing. If the default is missing and there is no value the tag will not be included.
+                      type: string
+                    name:
+                      description: Name of the header.
+                      type: string
+                  type: object
+                literal:
+                  description: Tag taken from literal value.
                   type: string
                 name:
-                  description: Name of the header.
+                  description: Name of the tag.
                   type: string
               type: object
-            literal:
-              description: Tag taken from literal value.
+            nullable: true
+            type: array
+        type: object
+      targetRef:
+        description: TargetRef is a reference to the resource the policy takes an effect on. The resource could be either a real store object or virtual resource defined inplace.
+        properties:
+          kind:
+            description: Kind of the referenced resource
+            enum:
+              - Mesh
+              - MeshSubset
+              - MeshService
+              - MeshServiceSubset
+              - MeshGatewayRoute
+            type: string
+          mesh:
+            description: Mesh is reserved for future use to identify cross mesh resources.
+            type: string
+          name:
+            description: 'Name of the referenced resource. Can only be used with kinds: `MeshService`, `MeshServiceSubset` and `MeshGatewayRoute`'
+            type: string
+          tags:
+            additionalProperties:
               type: string
-            name:
-              description: Name of the tag.
-              type: string
-          type: object
-        nullable: true
-        type: array
-    type: object
-  targetRef:
-    description: TargetRef is a reference to the resource the policy takes an effect on. The resource could be either a real store object or virtual resource defined inplace.
-    properties:
-      kind:
-        description: Kind of the referenced resource
-        enum:
-          - Mesh
-          - MeshSubset
-          - MeshService
-          - MeshServiceSubset
-          - MeshGatewayRoute
-        type: string
-      mesh:
-        description: Mesh is reserved for future use to identify cross mesh resources.
-        type: string
-      name:
-        description: 'Name of the referenced resource. Can only be used with kinds: `MeshService`, `MeshServiceSubset` and `MeshGatewayRoute`'
-        type: string
-      tags:
-        additionalProperties:
-          type: string
-        description: Tags used to select a subset of proxies by tags. Can only be used with kinds `MeshSubset` and `MeshServiceSubset`
+            description: Tags used to select a subset of proxies by tags. Can only be used with kinds `MeshSubset` and `MeshServiceSubset`
+            type: object
         type: object
     type: object

--- a/pkg/plugins/policies/meshtrace/api/v1alpha1/zz_generated.resource.go
+++ b/pkg/plugins/policies/meshtrace/api/v1alpha1/zz_generated.resource.go
@@ -17,12 +17,13 @@ import (
 
 //go:embed schema.yaml
 var rawSchema []byte
-var schema = &spec.Schema{}
+var schema = spec.Schema{}
 
 func init() {
-	if err := yaml.Unmarshal(rawSchema, schema); err != nil {
+	if err := yaml.Unmarshal(rawSchema, &schema); err != nil {
 		panic(err)
 	}
+	schema = schema.Properties["spec"]
 }
 
 const (
@@ -73,7 +74,7 @@ func (t *MeshTraceResource) Descriptor() model.ResourceTypeDescriptor {
 }
 
 func (t *MeshTraceResource) Validate() error {
-	if err := validation.ValidateSchema(t.GetSpec(), schema); err != nil {
+	if err := validation.ValidateSchema(t.GetSpec(), &schema); err != nil {
 		return err
 	}
 

--- a/pkg/plugins/policies/meshtrafficpermission/api/v1alpha1/schema.yaml
+++ b/pkg/plugins/policies/meshtrafficpermission/api/v1alpha1/schema.yaml
@@ -1,77 +1,82 @@
 properties:
   type:
-    description: ''
+    description: 'the type of the resource'
     type: string
     enum:
       - MeshTrafficPermission
   mesh:
     description: 'Mesh is the name of the Kuma mesh this resource belongs to. It may be omitted for cluster-scoped resources.'
     type: string
+    default: default
   name:
     description: 'Name of the Kuma resource'
     type: string
-  from:
-    description: From list makes a match between clients and corresponding configurations
-    items:
-      properties:
-        default:
-          description: Default is a configuration specific to the group of clients referenced in 'targetRef'
+  spec:
+    description: Spec is the specification of the Kuma MeshTrafficPermission resource.
+    properties:
+      from:
+        description: From list makes a match between clients and corresponding configurations
+        items:
           properties:
-            action:
-              description: 'Action defines a behavior for the specified group of clients:'
-              enum:
-                - ALLOW
-                - DENY
-                - ALLOW_WITH_SHADOW_DENY
-              type: string
-          type: object
-        targetRef:
-          description: TargetRef is a reference to the resource that represents a group of clients.
-          properties:
-            kind:
-              description: Kind of the referenced resource
-              enum:
-                - Mesh
-                - MeshSubset
-                - MeshService
-                - MeshServiceSubset
-                - MeshGatewayRoute
-              type: string
-            mesh:
-              description: Mesh is reserved for future use to identify cross mesh resources.
-              type: string
-            name:
-              description: 'Name of the referenced resource. Can only be used with kinds: `MeshService`, `MeshServiceSubset` and `MeshGatewayRoute`'
-              type: string
-            tags:
-              additionalProperties:
-                type: string
-              description: Tags used to select a subset of proxies by tags. Can only be used with kinds `MeshSubset` and `MeshServiceSubset`
+            default:
+              description: Default is a configuration specific to the group of clients referenced in 'targetRef'
+              properties:
+                action:
+                  description: 'Action defines a behavior for the specified group of clients:'
+                  enum:
+                    - ALLOW
+                    - DENY
+                    - ALLOW_WITH_SHADOW_DENY
+                  type: string
+              type: object
+            targetRef:
+              description: TargetRef is a reference to the resource that represents a group of clients.
+              properties:
+                kind:
+                  description: Kind of the referenced resource
+                  enum:
+                    - Mesh
+                    - MeshSubset
+                    - MeshService
+                    - MeshServiceSubset
+                    - MeshGatewayRoute
+                  type: string
+                mesh:
+                  description: Mesh is reserved for future use to identify cross mesh resources.
+                  type: string
+                name:
+                  description: 'Name of the referenced resource. Can only be used with kinds: `MeshService`, `MeshServiceSubset` and `MeshGatewayRoute`'
+                  type: string
+                tags:
+                  additionalProperties:
+                    type: string
+                  description: Tags used to select a subset of proxies by tags. Can only be used with kinds `MeshSubset` and `MeshServiceSubset`
+                  type: object
               type: object
           type: object
-      type: object
-    type: array
-  targetRef:
-    description: TargetRef is a reference to the resource the policy takes an effect on. The resource could be either a real store object or virtual resource defined inplace.
-    properties:
-      kind:
-        description: Kind of the referenced resource
-        enum:
-          - Mesh
-          - MeshSubset
-          - MeshService
-          - MeshServiceSubset
-          - MeshGatewayRoute
-        type: string
-      mesh:
-        description: Mesh is reserved for future use to identify cross mesh resources.
-        type: string
-      name:
-        description: 'Name of the referenced resource. Can only be used with kinds: `MeshService`, `MeshServiceSubset` and `MeshGatewayRoute`'
-        type: string
-      tags:
-        additionalProperties:
-          type: string
-        description: Tags used to select a subset of proxies by tags. Can only be used with kinds `MeshSubset` and `MeshServiceSubset`
+        type: array
+      targetRef:
+        description: TargetRef is a reference to the resource the policy takes an effect on. The resource could be either a real store object or virtual resource defined inplace.
+        properties:
+          kind:
+            description: Kind of the referenced resource
+            enum:
+              - Mesh
+              - MeshSubset
+              - MeshService
+              - MeshServiceSubset
+              - MeshGatewayRoute
+            type: string
+          mesh:
+            description: Mesh is reserved for future use to identify cross mesh resources.
+            type: string
+          name:
+            description: 'Name of the referenced resource. Can only be used with kinds: `MeshService`, `MeshServiceSubset` and `MeshGatewayRoute`'
+            type: string
+          tags:
+            additionalProperties:
+              type: string
+            description: Tags used to select a subset of proxies by tags. Can only be used with kinds `MeshSubset` and `MeshServiceSubset`
+            type: object
         type: object
     type: object

--- a/pkg/plugins/policies/meshtrafficpermission/api/v1alpha1/zz_generated.resource.go
+++ b/pkg/plugins/policies/meshtrafficpermission/api/v1alpha1/zz_generated.resource.go
@@ -17,12 +17,13 @@ import (
 
 //go:embed schema.yaml
 var rawSchema []byte
-var schema = &spec.Schema{}
+var schema = spec.Schema{}
 
 func init() {
-	if err := yaml.Unmarshal(rawSchema, schema); err != nil {
+	if err := yaml.Unmarshal(rawSchema, &schema); err != nil {
 		panic(err)
 	}
+	schema = schema.Properties["spec"]
 }
 
 const (
@@ -73,7 +74,7 @@ func (t *MeshTrafficPermissionResource) Descriptor() model.ResourceTypeDescripto
 }
 
 func (t *MeshTrafficPermissionResource) Validate() error {
-	if err := validation.ValidateSchema(t.GetSpec(), schema); err != nil {
+	if err := validation.ValidateSchema(t.GetSpec(), &schema); err != nil {
 		return err
 	}
 

--- a/tools/policy-gen/crd-extract-openapi.sh
+++ b/tools/policy-gen/crd-extract-openapi.sh
@@ -43,10 +43,5 @@ fi
 
 CRD_FILE=$(find "${POLICIES_CRD_DIR}" -type f)
 
-# we don't want expressions to be expanded with yq, that's why we're intentionally using single quotes
-# shellcheck disable=SC2016
-yq e '.spec.versions[] | select (.name == "'"${VERSION}"'") | .schema.openAPIV3Schema.properties.spec | del(.type) | del(.description)' \
-"${CRD_FILE}" | yq eval-all -i '. as $item ireduce ({}; . * $item )' \
-"${POLICIES_API_DIR}"/schema.yaml -
-
+yq e -i ".properties.spec += (load(\"${CRD_FILE}\") | .spec.versions[] | select (.name == \"${VERSION}\") | .schema.openAPIV3Schema.properties.spec)" "${POLICIES_API_DIR}"/schema.yaml
 yq e -i ".properties.type.enum = [load(\"${CRD_FILE}\") | .spec.names.kind]" "${POLICIES_API_DIR}"/schema.yaml

--- a/tools/policy-gen/generator/cmd/core_resource.go
+++ b/tools/policy-gen/generator/cmd/core_resource.go
@@ -57,12 +57,13 @@ import (
 
 //_DELETE_GO_EMBED_WORKAROUND_go:embed schema.yaml
 var rawSchema []byte
-var schema = &spec.Schema{}
+var schema = spec.Schema{}
 
 func init() {
-	if err := yaml.Unmarshal(rawSchema, schema); err != nil {
+	if err := yaml.Unmarshal(rawSchema, &schema); err != nil {
 		panic(err)
 	}
+	schema = schema.Properties["spec"]
 }
 
 const (
@@ -113,7 +114,7 @@ func (t *{{.Name}}Resource) Descriptor() model.ResourceTypeDescriptor {
 }
 
 func (t *{{.Name}}Resource) Validate() error {
-	if err := validation.ValidateSchema(t.GetSpec(), schema); err != nil {
+	if err := validation.ValidateSchema(t.GetSpec(), &schema); err != nil {
 		return err
 	}
 

--- a/tools/policy-gen/templates/schema.yaml
+++ b/tools/policy-gen/templates/schema.yaml
@@ -1,11 +1,13 @@
 properties:
   type:
-    description: ''
+    description: 'the type of the resource'
     type: string
   mesh:
     description: 'Mesh is the name of the Kuma mesh this resource belongs to.
       It may be omitted for cluster-scoped resources.'
     type: string
+    default: default
   name:
     description: 'Name of the Kuma resource'
     type: string
+  spec: {}


### PR DESCRIPTION
Before name, mesh and type where at the root and `spec` was missing. This created an invalid schema and the openapi spec was invalid too.

Fix #5213

Signed-off-by: Charly Molter <charly.molter@konghq.com>

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] Link to docs PR or issue --
- [x] Link to UI issue or PR --
- [x] Is the [issue worked on linked][1]? --
- [x] The PR does not hardcode values that might break projects that depend on kuma (e.g. "kumahq" as a image registry) --
- [x] The PR will work for both Linux and Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Unit Tests --
- [x] E2E Tests --
- [x] Manual Universal Tests --
- [x] Manual Kubernetes Tests --
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [x] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
