### PR TITLE
feat(gui): serve index from all paths without extension

### DIFF
--- a/app/kuma-ui/pkg/resources/data/index.html
+++ b/app/kuma-ui/pkg/resources/data/index.html
@@ -7,12 +7,12 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width,initial-scale=1" />
 
-    <link rel="icon" href="/{{.BaseGuiPath}}/favicon.png" />
+    <link rel="icon" href="/{{ .BaseGuiPath | trimPrefix "/" }}/favicon.png" />
     <title>Manager</title>
 
     
-    <script type="module" crossorigin src="/{{.BaseGuiPath}}/assets/index.c8163df9.js"></script>
-    <link rel="stylesheet" href="/{{.BaseGuiPath}}/assets/index.a46d24ef.css">
+    <script type="module" crossorigin src="/{{.BaseGuiPath | trimPrefix "/" }}/assets/index.c8163df9.js"></script>
+    <link rel="stylesheet" href="/{{.BaseGuiPath | trimPrefix "/" }}/assets/index.a46d24ef.css">
   </head>
   <body>
     <noscript>

--- a/pkg/api-server/gui_handler.go
+++ b/pkg/api-server/gui_handler.go
@@ -58,7 +58,6 @@ func NewGuiHandler(guiPath string, enabledGui bool, guiConfig GuiConfig) (http.H
 			writer.WriteHeader(http.StatusOK)
 			writer.Header().Set("Content-Type", "text/html")
 			_, _ = writer.Write(buf.Bytes())
-			return
 		})), nil
 	}
 	return http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {

--- a/pkg/api-server/gui_handler.go
+++ b/pkg/api-server/gui_handler.go
@@ -50,11 +50,9 @@ func NewGuiHandler(guiPath string, enabledGui bool, guiConfig GuiConfig) (http.H
 		return http.StripPrefix(guiPath, http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
 			_, err := guiFs.Open(request.URL.Path)
 			if err == nil {
-				log.Info("server", "path", request.URL.Path)
 				http.FileServer(http.FS(guiFs)).ServeHTTP(writer, request)
 				return
 			}
-			log.Info("server", "path", request.URL.Path)
 			writer.WriteHeader(http.StatusOK)
 			writer.Header().Set("Content-Type", "text/html")
 			_, _ = writer.Write(buf.Bytes())

--- a/pkg/api-server/gui_handler_test.go
+++ b/pkg/api-server/gui_handler_test.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"net/http"
 	"path/filepath"
+	"regexp"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -55,40 +56,50 @@ var _ = Describe("GUI Server", func() {
 			Expect(resp.Body.Close()).To(Succeed())
 			Expect(err).ToNot(HaveOccurred())
 
-			Expect(received).To(matchers.MatchGoldenEqual(given.expectedFile))
+			Expect(received).To(WithTransform(func(in []byte) []byte {
+				// Remove the part of the file name that changes always
+				r := regexp.MustCompile(`index\.[a-z0-9]+\.`).ReplaceAll(in, []byte("index."))
+				r = regexp.MustCompile(`"[0-9]+\.[0-9]+\.[0-9]+[^"]*"`).ReplaceAll(r, []byte(`"0.0.0"`))
+				return r
+			}, matchers.MatchGoldenEqual(given.expectedFile)))
 		},
 			Entry("should serve index.html without path", testCase{
 				urlPath:      "/gui",
-				expectedFile: filepath.Join("..", "..", "app", "kuma-ui", "pkg", "resources", "data", "index.html"),
+				expectedFile: filepath.Join("testdata", "index.html"),
+			}),
+			Entry("should serve on different path", testCase{
+				urlPath:      "/gui/meshes",
+				expectedFile: filepath.Join("testdata", "gui_other_files.html"),
 			}),
 			Entry("should serve index.html with / path", testCase{
 				urlPath:      "/gui/",
-				expectedFile: filepath.Join("..", "..", "app", "kuma-ui", "pkg", "resources", "data", "index.html"),
+				expectedFile: filepath.Join("testdata", "index.html"),
 			}),
-			Entry("should serve config.json", testCase{
-				urlPath:      "/gui/config.json",
-				expectedFile: filepath.Join("testdata", "gui_config.json"),
-			}),
-			Entry("should serve config.json on alternative path", testCase{
-				urlPath:      "/ui/config.json",
-				expectedFile: filepath.Join("testdata", "gui_config_with_base_path.json"),
+			Entry("should serve index.html on alternative path", testCase{
+				urlPath:      "/ui/foo",
+				expectedFile: filepath.Join("testdata", "gui_with_base_path.html"),
 				basePath:     "/ui",
 			}),
-			Entry("should serve config.json on alternative path with end /", testCase{
-				urlPath:      "/ui/config.json",
-				expectedFile: filepath.Join("testdata", "gui_config_with_base_path_with_slash.json"),
+			Entry("should serve index.html on alternative path with end /", testCase{
+				urlPath:      "/ui/",
+				expectedFile: filepath.Join("testdata", "gui_with_base_path_with_slash.html"),
 				basePath:     "/ui/",
 			}),
-			Entry("should serve config.json with path from rootUrl", testCase{
-				urlPath:      "/gui/config.json",
-				expectedFile: filepath.Join("testdata", "gui_config_with_root_url.json"),
+			Entry("should serve index.html with path from rootUrl", testCase{
+				urlPath:      "/gui/",
+				expectedFile: filepath.Join("testdata", "gui_with_root_url.html"),
 				guiRootUrl:   "https://foo.com/gui/foo",
 			}),
-			Entry("should serve config.json with path from rootUrl even with basePath set", testCase{
-				urlPath:      "/foo/config.json",
-				expectedFile: filepath.Join("testdata", "gui_config_with_root_url_and_base_path.json"),
+			Entry("should serve index.html with path from rootUrl even with basePath set", testCase{
+				urlPath:      "/foo/",
+				expectedFile: filepath.Join("testdata", "gui_with_root_url_and_base_path.html"),
 				basePath:     "/foo",
 				guiRootUrl:   "https://foo.com/gui/foo",
+			}),
+			Entry("should serve index.html on alternative path", testCase{
+				urlPath:      "/ui/foo",
+				expectedFile: filepath.Join("testdata", "gui_with_base_path.html"),
+				basePath:     "/ui",
 			}),
 		)
 	})

--- a/pkg/api-server/gui_handler_test.go
+++ b/pkg/api-server/gui_handler_test.go
@@ -15,11 +15,11 @@ import (
 	"github.com/kumahq/kuma/pkg/test/matchers"
 )
 
-var _ = Describe("GUI Server", func() {
+var _ = FDescribe("GUI Server", func() {
 
 	var baseUrl string
 
-	Describe("enabled", func() {
+	FDescribe("enabled", func() {
 
 		type testCase struct {
 			urlPath      string
@@ -66,6 +66,10 @@ var _ = Describe("GUI Server", func() {
 			Entry("should serve index.html without path", testCase{
 				urlPath:      "/gui",
 				expectedFile: filepath.Join("testdata", "index.html"),
+			}),
+			Entry("should serve robots.txt correctly", testCase{
+				urlPath:      "/gui/robots.txt",
+				expectedFile: filepath.Join("testdata", "robots.txt"),
 			}),
 			Entry("should serve on different path", testCase{
 				urlPath:      "/gui/meshes",

--- a/pkg/api-server/gui_handler_test.go
+++ b/pkg/api-server/gui_handler_test.go
@@ -15,11 +15,11 @@ import (
 	"github.com/kumahq/kuma/pkg/test/matchers"
 )
 
-var _ = FDescribe("GUI Server", func() {
+var _ = Describe("GUI Server", func() {
 
 	var baseUrl string
 
-	FDescribe("enabled", func() {
+	Describe("enabled", func() {
 
 		type testCase struct {
 			urlPath      string

--- a/pkg/api-server/server.go
+++ b/pkg/api-server/server.go
@@ -40,6 +40,7 @@ import (
 	"github.com/kumahq/kuma/pkg/tokens/builtin"
 	tokens_server "github.com/kumahq/kuma/pkg/tokens/builtin/server"
 	util_prometheus "github.com/kumahq/kuma/pkg/util/prometheus"
+	"github.com/kumahq/kuma/pkg/version"
 	xds_context "github.com/kumahq/kuma/pkg/xds/context"
 	"github.com/kumahq/kuma/pkg/xds/server"
 )
@@ -178,7 +179,11 @@ func NewApiServer(
 	if !strings.HasSuffix(basePath, "/") {
 		basePath += "/"
 	}
-	container.Handle(guiPath, guiHandler(guiPath, enableGUI, apiUrl, basePath))
+	guiHandler, err := NewGuiHandler(guiPath, enableGUI, GuiConfig{BaseGuiPath: strings.Trim(basePath, "/"), ApiUrl: apiUrl, Version: version.Build.Version})
+	if err != nil {
+		return nil, err
+	}
+	container.Handle(guiPath, guiHandler)
 
 	newApiServer := &ApiServer{
 		mux:    container.ServeMux,

--- a/pkg/api-server/server.go
+++ b/pkg/api-server/server.go
@@ -176,10 +176,8 @@ func NewApiServer(
 		}
 		basePath = u.Path
 	}
-	if !strings.HasSuffix(basePath, "/") {
-		basePath += "/"
-	}
-	guiHandler, err := NewGuiHandler(guiPath, enableGUI, GuiConfig{BaseGuiPath: strings.Trim(basePath, "/"), ApiUrl: apiUrl, Version: version.Build.Version})
+	basePath = strings.TrimSuffix(basePath, "/")
+	guiHandler, err := NewGuiHandler(guiPath, enableGUI, GuiConfig{BaseGuiPath: basePath, ApiUrl: apiUrl, Version: version.Build.Version})
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/api-server/testdata/gui_other_files.html
+++ b/pkg/api-server/testdata/gui_other_files.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <script id="kuma-config" type="application/json">
-      {"apiUrl":"https://foo.bar.com:8080/foo","baseGuiPath":"gui","version":"0.0.0"}
+      {"apiUrl":"https://foo.bar.com:8080/foo","baseGuiPath":"/gui","version":"0.0.0"}
     </script>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width,initial-scale=1" />

--- a/pkg/api-server/testdata/gui_other_files.html
+++ b/pkg/api-server/testdata/gui_other_files.html
@@ -2,17 +2,17 @@
 <html lang="en">
   <head>
     <script id="kuma-config" type="application/json">
-      {{.}}
+      {"apiUrl":"https://foo.bar.com:8080/foo","baseGuiPath":"gui","version":"0.0.0"}
     </script>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width,initial-scale=1" />
 
-    <link rel="icon" href="/{{.BaseGuiPath}}/favicon.png" />
+    <link rel="icon" href="/gui/favicon.png" />
     <title>Manager</title>
 
     
-    <script type="module" crossorigin src="/{{.BaseGuiPath}}/assets/index.c8163df9.js"></script>
-    <link rel="stylesheet" href="/{{.BaseGuiPath}}/assets/index.a46d24ef.css">
+    <script type="module" crossorigin src="/gui/assets/index.js"></script>
+    <link rel="stylesheet" href="/gui/assets/index.css">
   </head>
   <body>
     <noscript>

--- a/pkg/api-server/testdata/gui_with_base_path.html
+++ b/pkg/api-server/testdata/gui_with_base_path.html
@@ -2,17 +2,17 @@
 <html lang="en">
   <head>
     <script id="kuma-config" type="application/json">
-      {{.}}
+      {"apiUrl":"https://foo.bar.com:8080/foo","baseGuiPath":"ui","version":"0.0.0"}
     </script>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width,initial-scale=1" />
 
-    <link rel="icon" href="/{{.BaseGuiPath}}/favicon.png" />
+    <link rel="icon" href="/ui/favicon.png" />
     <title>Manager</title>
 
     
-    <script type="module" crossorigin src="/{{.BaseGuiPath}}/assets/index.c8163df9.js"></script>
-    <link rel="stylesheet" href="/{{.BaseGuiPath}}/assets/index.a46d24ef.css">
+    <script type="module" crossorigin src="/ui/assets/index.js"></script>
+    <link rel="stylesheet" href="/ui/assets/index.css">
   </head>
   <body>
     <noscript>

--- a/pkg/api-server/testdata/gui_with_base_path.html
+++ b/pkg/api-server/testdata/gui_with_base_path.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <script id="kuma-config" type="application/json">
-      {"apiUrl":"https://foo.bar.com:8080/foo","baseGuiPath":"ui","version":"0.0.0"}
+      {"apiUrl":"https://foo.bar.com:8080/foo","baseGuiPath":"/ui","version":"0.0.0"}
     </script>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width,initial-scale=1" />

--- a/pkg/api-server/testdata/gui_with_base_path_with_slash.html
+++ b/pkg/api-server/testdata/gui_with_base_path_with_slash.html
@@ -2,17 +2,17 @@
 <html lang="en">
   <head>
     <script id="kuma-config" type="application/json">
-      {{.}}
+      {"apiUrl":"https://foo.bar.com:8080/foo","baseGuiPath":"ui","version":"0.0.0"}
     </script>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width,initial-scale=1" />
 
-    <link rel="icon" href="/{{.BaseGuiPath}}/favicon.png" />
+    <link rel="icon" href="/ui/favicon.png" />
     <title>Manager</title>
 
     
-    <script type="module" crossorigin src="/{{.BaseGuiPath}}/assets/index.c8163df9.js"></script>
-    <link rel="stylesheet" href="/{{.BaseGuiPath}}/assets/index.a46d24ef.css">
+    <script type="module" crossorigin src="/ui/assets/index.js"></script>
+    <link rel="stylesheet" href="/ui/assets/index.css">
   </head>
   <body>
     <noscript>

--- a/pkg/api-server/testdata/gui_with_base_path_with_slash.html
+++ b/pkg/api-server/testdata/gui_with_base_path_with_slash.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <script id="kuma-config" type="application/json">
-      {"apiUrl":"https://foo.bar.com:8080/foo","baseGuiPath":"ui","version":"0.0.0"}
+      {"apiUrl":"https://foo.bar.com:8080/foo","baseGuiPath":"/ui","version":"0.0.0"}
     </script>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width,initial-scale=1" />

--- a/pkg/api-server/testdata/gui_with_root_url.html
+++ b/pkg/api-server/testdata/gui_with_root_url.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <script id="kuma-config" type="application/json">
-      {"apiUrl":"https://foo.bar.com:8080/foo","baseGuiPath":"gui/foo","version":"0.0.0"}
+      {"apiUrl":"https://foo.bar.com:8080/foo","baseGuiPath":"/gui/foo","version":"0.0.0"}
     </script>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width,initial-scale=1" />

--- a/pkg/api-server/testdata/gui_with_root_url.html
+++ b/pkg/api-server/testdata/gui_with_root_url.html
@@ -2,17 +2,17 @@
 <html lang="en">
   <head>
     <script id="kuma-config" type="application/json">
-      {{.}}
+      {"apiUrl":"https://foo.bar.com:8080/foo","baseGuiPath":"gui/foo","version":"0.0.0"}
     </script>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width,initial-scale=1" />
 
-    <link rel="icon" href="/{{.BaseGuiPath}}/favicon.png" />
+    <link rel="icon" href="/gui/foo/favicon.png" />
     <title>Manager</title>
 
     
-    <script type="module" crossorigin src="/{{.BaseGuiPath}}/assets/index.c8163df9.js"></script>
-    <link rel="stylesheet" href="/{{.BaseGuiPath}}/assets/index.a46d24ef.css">
+    <script type="module" crossorigin src="/gui/foo/assets/index.js"></script>
+    <link rel="stylesheet" href="/gui/foo/assets/index.css">
   </head>
   <body>
     <noscript>

--- a/pkg/api-server/testdata/gui_with_root_url_and_base_path.html
+++ b/pkg/api-server/testdata/gui_with_root_url_and_base_path.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <script id="kuma-config" type="application/json">
-      {"apiUrl":"https://foo.bar.com:8080/foo","baseGuiPath":"gui/foo","version":"0.0.0"}
+      {"apiUrl":"https://foo.bar.com:8080/foo","baseGuiPath":"/gui/foo","version":"0.0.0"}
     </script>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width,initial-scale=1" />

--- a/pkg/api-server/testdata/gui_with_root_url_and_base_path.html
+++ b/pkg/api-server/testdata/gui_with_root_url_and_base_path.html
@@ -2,17 +2,17 @@
 <html lang="en">
   <head>
     <script id="kuma-config" type="application/json">
-      {{.}}
+      {"apiUrl":"https://foo.bar.com:8080/foo","baseGuiPath":"gui/foo","version":"0.0.0"}
     </script>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width,initial-scale=1" />
 
-    <link rel="icon" href="/{{.BaseGuiPath}}/favicon.png" />
+    <link rel="icon" href="/gui/foo/favicon.png" />
     <title>Manager</title>
 
     
-    <script type="module" crossorigin src="/{{.BaseGuiPath}}/assets/index.c8163df9.js"></script>
-    <link rel="stylesheet" href="/{{.BaseGuiPath}}/assets/index.a46d24ef.css">
+    <script type="module" crossorigin src="/gui/foo/assets/index.js"></script>
+    <link rel="stylesheet" href="/gui/foo/assets/index.css">
   </head>
   <body>
     <noscript>

--- a/pkg/api-server/testdata/index.html
+++ b/pkg/api-server/testdata/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <script id="kuma-config" type="application/json">
-      {"apiUrl":"https://foo.bar.com:8080/foo","baseGuiPath":"gui","version":"0.0.0"}
+      {"apiUrl":"https://foo.bar.com:8080/foo","baseGuiPath":"/gui","version":"0.0.0"}
     </script>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width,initial-scale=1" />

--- a/pkg/api-server/testdata/index.html
+++ b/pkg/api-server/testdata/index.html
@@ -2,17 +2,17 @@
 <html lang="en">
   <head>
     <script id="kuma-config" type="application/json">
-      {{.}}
+      {"apiUrl":"https://foo.bar.com:8080/foo","baseGuiPath":"gui","version":"0.0.0"}
     </script>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width,initial-scale=1" />
 
-    <link rel="icon" href="/{{.BaseGuiPath}}/favicon.png" />
+    <link rel="icon" href="/gui/favicon.png" />
     <title>Manager</title>
 
     
-    <script type="module" crossorigin src="/{{.BaseGuiPath}}/assets/index.c8163df9.js"></script>
-    <link rel="stylesheet" href="/{{.BaseGuiPath}}/assets/index.a46d24ef.css">
+    <script type="module" crossorigin src="/gui/assets/index.js"></script>
+    <link rel="stylesheet" href="/gui/assets/index.css">
   </head>
   <body>
     <noscript>

--- a/pkg/api-server/testdata/robots.txt
+++ b/pkg/api-server/testdata/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow:


### PR DESCRIPTION
- remove config.json
- use a templated index.html to dynamically set base paths
- serve index.html whenever the path points to a file that doesn't exist

Fix #5306

Signed-off-by: Charly Molter <charly.molter@konghq.com>

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] Link to docs PR or issue --
- [x] Link to UI issue or PR --
- [x] Is the [issue worked on linked][1]? --
- [x] The PR does not hardcode values that might break projects that depend on kuma (e.g. "kumahq" as a image registry) --
- [x] The PR will work for both Linux and Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Unit Tests --
- [x] E2E Tests --
- [x] Manual Universal Tests --
- [x] Manual Kubernetes Tests --
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [x] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
