### PR TITLE
ci(changelog): fix changelog script for dependabot rollups

### DIFF
--- a/tools/releases/changelog/github.go
+++ b/tools/releases/changelog/github.go
@@ -127,27 +127,33 @@ It will then output a changelog with all PRs with the same changelog grouped tog
 		var out []Changelog
 		for changelog, commits := range byChangelog {
 			uniqueAuthors := map[string]interface{}{}
+			uniquePrs := map[int]interface{}{}
 			var authors []string
 			var prs []int
+			sort.Slice(commits, func(i, j int) bool {
+				return commits[i].PrNumber < commits[j].PrNumber
+			})
 			var minVersion, maxVersion string
 			for _, c := range commits {
-				if minVersion == "" || c.MinDependency < minVersion {
+				// Required because in the past we weren't squashing commits
+				if _, exists := uniquePrs[c.PrNumber]; exists {
+					continue
+				}
+				uniquePrs[c.PrNumber] = nil
+				prs = append(prs, c.PrNumber)
+				if minVersion == "" {
 					minVersion = c.MinDependency
 				}
-				if maxVersion == "" || c.MaxDependency > maxVersion {
-					maxVersion = c.MaxDependency
-				}
-				prs = append(prs, c.PrNumber)
+				maxVersion = c.MaxDependency
 				if _, exists := uniqueAuthors[c.Author]; !exists {
 					authors = append(authors, fmt.Sprintf("@%s", c.Author))
 					uniqueAuthors[c.Author] = nil
 				}
 			}
-			sort.Ints(prs)
-			sort.Strings(authors)
 			if minVersion != "" && maxVersion != "" {
 				changelog = fmt.Sprintf("%s from %s to %s", changelog, minVersion, maxVersion)
 			}
+			sort.Strings(authors)
 			out = append(out, Changelog{Desc: changelog, Authors: authors, PullRequests: prs})
 		}
 		sort.Slice(out, func(i, j int) bool {
@@ -204,7 +210,7 @@ type CommitInfo struct {
 }
 
 // titles look like: chore(deps): bump github.com/lib/pq from 1.10.6 to 1.10.7
-var dependabotPRTitleRegExp = regexp.MustCompile(`(chore\(deps\): bump [^ ]+) from ([^ ]+) to ([^ ]+)`)
+var dependabotPRTitleRegExp = regexp.MustCompile(`(chore\(deps\): bump [^ ]+) from ([^ ]+) to ([^ ]+).*`)
 
 func NewCommitInfo(commit GQLCommit) *CommitInfo {
 	if len(commit.AssociatedPullRequests.Nodes) == 0 {
@@ -233,18 +239,16 @@ func NewCommitInfo(commit GQLCommit) *CommitInfo {
 				return nil
 			}
 		}
-		matches := dependabotPRTitleRegExp.FindStringSubmatch(pr.Title)
-		// Rollup dependabot issues with the same dependency into just one so we can rebuild a single line with all update PRs.
-		if matches != nil {
-			res.Changelog = matches[1]
-			res.MinDependency = matches[2]
-			res.MaxDependency = matches[3]
-		} else {
-			// Use the pr.Title as a changelog entry
-			res.Changelog = pr.Title
-		}
+		// Use the pr.Title as a changelog entry
+		res.Changelog = pr.Title
 	default:
 		res.Changelog = changelog
+	}
+	if matches := dependabotPRTitleRegExp.FindStringSubmatch(res.Changelog); matches != nil {
+		// Rollup dependabot issues with the same dependency into just one so we can rebuild a single line with all update PRs.
+		res.Changelog = matches[1]
+		res.MinDependency = matches[2]
+		res.MaxDependency = matches[3]
 	}
 	return res
 }


### PR DESCRIPTION
Use a regexp instead of random splits as it's more robust Fix badly implemented min/max functions

Now the changelog look like: 

```
* chore(deps): bump github.com/onsi/gomega from 1.23.0 to 1.24.1 [#5275](https://github.com/kumahq/kuma/pull/5275) [#5313](https://github.com/kumahq/kuma/pull/5313) @dependabot
* chore(deps): bump github.com/prometheus/client_golang from 1.13.0 to 1.14.0 [#5274](https://github.com/kumahq/kuma/pull/5274) [#5323](https://github.com/kumahq/kuma/pull/5323) @dependabot
* chore(deps): bump github.com/prometheus/prometheus from 0.39.1 to 0.40.2 [#5320](https://github.com/kumahq/kuma/pull/5320) [#5353](https://github.com/kumahq/kuma/pull/5353) @dependabot
```

And changes like: `* chore(deps): update to emicklei/go-restful/v3 v3.10.1 and remove `/tokens` [#5324](https://github.com/kumahq/kuma/pull/5324) @dependabot` do not cause issues anymore


Signed-off-by: Charly Molter <charly.molter@konghq.com>

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] Link to docs PR or issue --
- [x] Link to UI issue or PR --
- [x] Is the [issue worked on linked][1]? --
- [x] The PR does not hardcode values that might break projects that depend on kuma (e.g. "kumahq" as a image registry) --
- [x] The PR will work for both Linux and Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Unit Tests --
- [x] E2E Tests --
- [x] Manual Universal Tests --
- [x] Manual Kubernetes Tests --
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [x] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
