### PR TITLE
fix(xds): don't read metadata in ProxyBuilders

### DIFF
--- a/pkg/api-server/inspect_endpoints.go
+++ b/pkg/api-server/inspect_endpoints.go
@@ -24,7 +24,6 @@ import (
 	xds_context "github.com/kumahq/kuma/pkg/xds/context"
 	"github.com/kumahq/kuma/pkg/xds/envoy"
 	"github.com/kumahq/kuma/pkg/xds/envoy/tags"
-	"github.com/kumahq/kuma/pkg/xds/server/callbacks"
 	"github.com/kumahq/kuma/pkg/xds/sync"
 )
 
@@ -35,10 +34,7 @@ func getMatchedPolicies(
 ) (
 	*core_xds.MatchedPolicies, []gateway.GatewayListenerInfo, core_xds.Proxy, error,
 ) {
-	proxyBuilder := sync.DefaultDataplaneProxyBuilder(
-		*cfg,
-		callbacks.NewDataplaneMetadataTracker(),
-		envoy.APIV3)
+	proxyBuilder := sync.DefaultDataplaneProxyBuilder(*cfg, envoy.APIV3)
 	if proxy, err := proxyBuilder.Build(ctx, dataplaneKey, meshContext); err != nil {
 		return nil, nil, core_xds.Proxy{}, err
 	} else {

--- a/pkg/plugins/runtime/gateway/suite_test.go
+++ b/pkg/plugins/runtime/gateway/suite_test.go
@@ -96,17 +96,10 @@ func MakeProtoSnapshot(snap cache_v3.ResourceSnapshot) ProtoSnapshot {
 	}
 }
 
-type mockMetadataTracker struct{}
-
-func (m mockMetadataTracker) Metadata(dpKey core_model.ResourceKey) *core_xds.DataplaneMetadata {
-	return nil
-}
-
 func MakeGeneratorContext(rt runtime.Runtime, key core_model.ResourceKey) (*xds_context.Context, *core_xds.Proxy) {
 	b := sync.DataplaneProxyBuilder{
-		MetadataTracker: mockMetadataTracker{},
-		Zone:            rt.Config().Multizone.Zone.Name,
-		APIVersion:      envoy.APIV3,
+		Zone:       rt.Config().Multizone.Zone.Name,
+		APIVersion: envoy.APIV3,
 	}
 
 	cache, err := cla.NewCache(rt.Config().Store.Cache.ExpirationTime.Duration, rt.Metrics())

--- a/pkg/xds/server/v3/snapshot_generator_test.go
+++ b/pkg/xds/server/v3/snapshot_generator_test.go
@@ -37,7 +37,6 @@ import (
 	"github.com/kumahq/kuma/pkg/xds/generator"
 	xds_hooks "github.com/kumahq/kuma/pkg/xds/hooks"
 	"github.com/kumahq/kuma/pkg/xds/server"
-	"github.com/kumahq/kuma/pkg/xds/server/callbacks"
 	v3 "github.com/kumahq/kuma/pkg/xds/server/v3"
 	"github.com/kumahq/kuma/pkg/xds/sync"
 	"github.com/kumahq/kuma/pkg/xds/template"
@@ -118,7 +117,7 @@ var _ = Describe("GenerateSnapshot", func() {
 			cfg.DNSServer.ServiceVipPort,
 		)
 
-		proxyBuilder = sync.DefaultDataplaneProxyBuilder(cfg, callbacks.NewDataplaneMetadataTracker(), envoy_common.APIV3)
+		proxyBuilder = sync.DefaultDataplaneProxyBuilder(cfg, envoy_common.APIV3)
 	})
 
 	create := func(r core_model.Resource) {

--- a/pkg/xds/sync/components.go
+++ b/pkg/xds/sync/components.go
@@ -18,26 +18,22 @@ var (
 
 func DefaultDataplaneProxyBuilder(
 	config kuma_cp.Config,
-	metadataTracker DataplaneMetadataTracker,
 	apiVersion core_xds.APIVersion,
 ) *DataplaneProxyBuilder {
 	return &DataplaneProxyBuilder{
-		MetadataTracker: metadataTracker,
-		Zone:            config.Multizone.Zone.Name,
-		APIVersion:      apiVersion,
+		Zone:       config.Multizone.Zone.Name,
+		APIVersion: apiVersion,
 	}
 }
 
 func DefaultIngressProxyBuilder(
 	rt core_runtime.Runtime,
-	metadataTracker DataplaneMetadataTracker,
 	apiVersion core_xds.APIVersion,
 ) *IngressProxyBuilder {
 	return &IngressProxyBuilder{
 		ResManager:         rt.ResourceManager(),
 		ReadOnlyResManager: rt.ReadOnlyResourceManager(),
 		LookupIP:           rt.LookupIP(),
-		MetadataTracker:    metadataTracker,
 		apiVersion:         apiVersion,
 		meshCache:          rt.MeshCache(),
 		zone:               rt.Config().Multizone.Zone.Name,
@@ -47,7 +43,6 @@ func DefaultIngressProxyBuilder(
 func DefaultEgressProxyBuilder(
 	ctx context.Context,
 	rt core_runtime.Runtime,
-	metadataTracker DataplaneMetadataTracker,
 	apiVersion core_xds.APIVersion,
 ) *EgressProxyBuilder {
 	return &EgressProxyBuilder{
@@ -55,7 +50,6 @@ func DefaultEgressProxyBuilder(
 		ResManager:         rt.ResourceManager(),
 		ReadOnlyResManager: rt.ReadOnlyResourceManager(),
 		LookupIP:           rt.LookupIP(),
-		MetadataTracker:    metadataTracker,
 		meshCache:          rt.MeshCache(),
 		apiVersion:         apiVersion,
 		zone:               rt.Config().Multizone.Zone.Name,
@@ -77,20 +71,17 @@ func DefaultDataplaneWatchdogFactory(
 
 	dataplaneProxyBuilder := DefaultDataplaneProxyBuilder(
 		config,
-		metadataTracker,
 		apiVersion,
 	)
 
 	ingressProxyBuilder := DefaultIngressProxyBuilder(
 		rt,
-		metadataTracker,
 		apiVersion,
 	)
 
 	egressProxyBuilder := DefaultEgressProxyBuilder(
 		ctx,
 		rt,
-		metadataTracker,
 		apiVersion,
 	)
 

--- a/pkg/xds/sync/dataplane_proxy_builder.go
+++ b/pkg/xds/sync/dataplane_proxy_builder.go
@@ -27,8 +27,6 @@ import (
 var syncLog = core.Log.WithName("sync")
 
 type DataplaneProxyBuilder struct {
-	MetadataTracker DataplaneMetadataTracker
-
 	Zone       string
 	APIVersion core_xds.APIVersion
 }
@@ -64,7 +62,6 @@ func (p *DataplaneProxyBuilder) Build(ctx context.Context, key core_model.Resour
 		Id:             core_xds.FromResourceKey(key),
 		APIVersion:     p.APIVersion,
 		Dataplane:      dp,
-		Metadata:       p.MetadataTracker.Metadata(key),
 		Routing:        *routing,
 		Policies:       *matchedPolicies,
 		SecretsTracker: secretsTracker,

--- a/pkg/xds/sync/dataplane_watchdog_test.go
+++ b/pkg/xds/sync/dataplane_watchdog_test.go
@@ -87,9 +87,8 @@ var _ = Describe("Dataplane Watchdog", func() {
 
 		deps = sync.DataplaneWatchdogDependencies{
 			DataplaneProxyBuilder: &sync.DataplaneProxyBuilder{
-				MetadataTracker: metadataTracker,
-				APIVersion:      envoy.APIV3,
-				Zone:            zone,
+				APIVersion: envoy.APIV3,
+				Zone:       zone,
 			},
 			DataplaneReconciler: snapshotReconciler,
 			EnvoyCpCtx: &xds_context.ControlPlaneContext{

--- a/pkg/xds/sync/egress_proxy_builder.go
+++ b/pkg/xds/sync/egress_proxy_builder.go
@@ -12,7 +12,7 @@ import (
 	"github.com/kumahq/kuma/pkg/core/resources/manager"
 	core_model "github.com/kumahq/kuma/pkg/core/resources/model"
 	core_store "github.com/kumahq/kuma/pkg/core/resources/store"
-	"github.com/kumahq/kuma/pkg/core/xds"
+	core_xds "github.com/kumahq/kuma/pkg/core/xds"
 	xds_cache "github.com/kumahq/kuma/pkg/xds/cache/mesh"
 	xds_topology "github.com/kumahq/kuma/pkg/xds/topology"
 )
@@ -23,17 +23,16 @@ type EgressProxyBuilder struct {
 	ResManager         manager.ResourceManager
 	ReadOnlyResManager manager.ReadOnlyResourceManager
 	LookupIP           lookup.LookupIPFunc
-	MetadataTracker    DataplaneMetadataTracker
 	meshCache          *xds_cache.Cache
 
 	zone       string
-	apiVersion xds.APIVersion
+	apiVersion core_xds.APIVersion
 }
 
 func (p *EgressProxyBuilder) Build(
 	ctx context.Context,
 	key core_model.ResourceKey,
-) (*xds.Proxy, error) {
+) (*core_xds.Proxy, error) {
 	zoneEgress := core_mesh.NewZoneEgressResource()
 
 	if err := p.ReadOnlyResManager.Get(
@@ -79,7 +78,7 @@ func (p *EgressProxyBuilder) Build(
 		return zoneIngresses[a].GetMeta().GetName() < zoneIngresses[b].GetMeta().GetName()
 	})
 
-	var meshResourcesList []*xds.MeshResources
+	var meshResourcesList []*core_xds.MeshResources
 
 	for _, mesh := range meshes {
 		meshName := mesh.GetMeta().GetName()
@@ -95,7 +94,7 @@ func (p *EgressProxyBuilder) Build(
 		faultInjections := meshCtx.Resources.FaultInjections().Items
 		rateLimits := meshCtx.Resources.RateLimits().Items
 
-		meshResources := &xds.MeshResources{
+		meshResources := &core_xds.MeshResources{
 			Mesh:             mesh,
 			TrafficRoutes:    trafficRoutes,
 			ExternalServices: externalServices,
@@ -124,15 +123,14 @@ func (p *EgressProxyBuilder) Build(
 		meshResourcesList = append(meshResourcesList, meshResources)
 	}
 
-	proxy := &xds.Proxy{
-		Id:         xds.FromResourceKey(key),
+	proxy := &core_xds.Proxy{
+		Id:         core_xds.FromResourceKey(key),
 		APIVersion: p.apiVersion,
-		ZoneEgressProxy: &xds.ZoneEgressProxy{
+		ZoneEgressProxy: &core_xds.ZoneEgressProxy{
 			ZoneEgressResource: zoneEgress,
 			ZoneIngresses:      zoneIngresses,
 			MeshResourcesList:  meshResourcesList,
 		},
-		Metadata: p.MetadataTracker.Metadata(key),
 	}
 
 	return proxy, nil

--- a/pkg/xds/sync/proxy_builder_test.go
+++ b/pkg/xds/sync/proxy_builder_test.go
@@ -30,12 +30,6 @@ import (
 	"github.com/kumahq/kuma/pkg/xds/sync"
 )
 
-type mockMetadataTracker struct{}
-
-func (m mockMetadataTracker) Metadata(dpKey core_model.ResourceKey) *core_xds.DataplaneMetadata {
-	return nil
-}
-
 func initializeStore(ctx context.Context, resourceManager core_manager.ResourceManager, fileWithResourcesName string) {
 	resourcePath := filepath.Join(
 		"testdata", "input", fileWithResourcesName,
@@ -75,7 +69,6 @@ func initializeStore(ctx context.Context, resourceManager core_manager.ResourceM
 }
 
 var _ = Describe("Proxy Builder", func() {
-	tracker := mockMetadataTracker{}
 	localZone := "zone-1"
 
 	ctx := context.Background()
@@ -112,7 +105,6 @@ var _ = Describe("Proxy Builder", func() {
 		egressProxyBuilder := sync.DefaultEgressProxyBuilder(
 			ctx,
 			rt,
-			tracker,
 			envoy_common.APIV3,
 		)
 
@@ -195,7 +187,6 @@ var _ = Describe("Proxy Builder", func() {
 	Describe("Build() zone ingress", func() {
 		ingressProxyBuilder := sync.DefaultIngressProxyBuilder(
 			rt,
-			tracker,
 			envoy_common.APIV3,
 		)
 


### PR DESCRIPTION
We were using a `DataplaneMetadataTracker` in all proxy builders. This was causing issues as the proxy may disconnect while reconciliation is in progress.

We now set the proxy metadata in the DataplaneWatchdog so that it's read once only and nil checked. We therefore protect ourselves against this race

Signed-off-by: Charly Molter <charly.molter@konghq.com>

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] Link to docs PR or issue --
- [x] Link to UI issue or PR --
- [x] Is the [issue worked on linked][1]? --
- [x] The PR does not hardcode values that might break projects that depend on kuma (e.g. "kumahq" as a image registry) --
- [x] The PR will work for both Linux and Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Unit Tests --
- [x] E2E Tests --
- [x] Manual Universal Tests --
- [x] Manual Kubernetes Tests --
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [x] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
