### PR TITLE
fix(universal): don't set sslsni option if not disabled

### DIFF
--- a/pkg/config/plugins/resources/postgres/config.go
+++ b/pkg/config/plugins/resources/postgres/config.go
@@ -51,16 +51,13 @@ func (cfg PostgresStoreConfig) ConnectionString() (string, error) {
 		return "", err
 	}
 	escape := func(value string) string { return strings.ReplaceAll(strings.ReplaceAll(value, `\`, `\\`), `'`, `\'`) }
-	boolOption := func(value bool) string {
-		if value {
-			return "1"
-		} else {
-			return "0"
-		}
+	sslsniOpt := ""
+	if cfg.TLS.DisableSSLSNI {
+		sslsniOpt = "sslsni=0"
 	}
 	return fmt.Sprintf(
-		`host='%s' port=%d user='%s' password='%s' dbname='%s' connect_timeout=%d sslmode=%s sslcert='%s' sslkey='%s' sslrootcert='%s' sslsni=%s`,
-		escape(cfg.Host), cfg.Port, escape(cfg.User), escape(cfg.Password), escape(cfg.DbName), cfg.ConnectionTimeout, mode, escape(cfg.TLS.CertPath), escape(cfg.TLS.KeyPath), escape(cfg.TLS.CAPath), boolOption(!cfg.TLS.DisableSSLSNI),
+		`host='%s' port=%d user='%s' password='%s' dbname='%s' connect_timeout=%d sslmode=%s sslcert='%s' sslkey='%s' sslrootcert='%s' %s`,
+		escape(cfg.Host), cfg.Port, escape(cfg.User), escape(cfg.Password), escape(cfg.DbName), cfg.ConnectionTimeout, mode, escape(cfg.TLS.CertPath), escape(cfg.TLS.KeyPath), escape(cfg.TLS.CAPath), sslsniOpt,
 	), nil
 }
 

--- a/pkg/config/plugins/resources/postgres/config.go
+++ b/pkg/config/plugins/resources/postgres/config.go
@@ -51,14 +51,31 @@ func (cfg PostgresStoreConfig) ConnectionString() (string, error) {
 		return "", err
 	}
 	escape := func(value string) string { return strings.ReplaceAll(strings.ReplaceAll(value, `\`, `\\`), `'`, `\'`) }
-	sslsniOpt := ""
-	if cfg.TLS.DisableSSLSNI {
-		sslsniOpt = "sslsni=0"
+	intVariable := func(name string, value int) string {
+		return fmt.Sprintf("%s=%d", name, value)
 	}
-	return fmt.Sprintf(
-		`host='%s' port=%d user='%s' password='%s' dbname='%s' connect_timeout=%d sslmode=%s sslcert='%s' sslkey='%s' sslrootcert='%s' %s`,
-		escape(cfg.Host), cfg.Port, escape(cfg.User), escape(cfg.Password), escape(cfg.DbName), cfg.ConnectionTimeout, mode, escape(cfg.TLS.CertPath), escape(cfg.TLS.KeyPath), escape(cfg.TLS.CAPath), sslsniOpt,
-	), nil
+	variable := func(name, value string) string {
+		return fmt.Sprintf("%s=%s", name, value)
+	}
+	quotedVariable := func(name, value string) string {
+		return fmt.Sprintf("%s='%s'", name, escape(value))
+	}
+	variables := []string{
+		quotedVariable("host", cfg.Host),
+		intVariable("port", cfg.Port),
+		quotedVariable("user", cfg.User),
+		quotedVariable("password", cfg.Password),
+		quotedVariable("dbname", cfg.DbName),
+		intVariable("connect_timeout", cfg.ConnectionTimeout),
+		variable("sslmode", mode),
+		quotedVariable("sslcert", cfg.TLS.CertPath),
+		quotedVariable("sslkey", cfg.TLS.KeyPath),
+		quotedVariable("sslrootcert", cfg.TLS.CAPath),
+	}
+	if cfg.TLS.DisableSSLSNI {
+		variables = append(variables, "sslsni=0")
+	}
+	return strings.Join(variables, " "), nil
 }
 
 // Modes available here https://godoc.org/github.com/lib/pq

--- a/pkg/config/plugins/resources/postgres/config_test.go
+++ b/pkg/config/plugins/resources/postgres/config_test.go
@@ -120,7 +120,7 @@ var _ = Describe("PostgresStoreConfig", func() {
 				MinReconnectInterval: 10 * time.Second,
 				MaxReconnectInterval: 10 * time.Second,
 			},
-			expected: `host='localhost' port=0 user='postgres' password='postgres' dbname='kuma' connect_timeout=0 sslmode=verify-full sslcert='/path' sslkey='/path' sslrootcert='/path' sslsni=1`,
+			expected: `host='localhost' port=0 user='postgres' password='postgres' dbname='kuma' connect_timeout=0 sslmode=verify-full sslcert='/path' sslkey='/path' sslrootcert='/path' `,
 		}),
 		Entry("password needing escape without sslsni", stringTestCase{
 			given: postgres.PostgresStoreConfig{

--- a/pkg/config/plugins/resources/postgres/config_test.go
+++ b/pkg/config/plugins/resources/postgres/config_test.go
@@ -120,7 +120,7 @@ var _ = Describe("PostgresStoreConfig", func() {
 				MinReconnectInterval: 10 * time.Second,
 				MaxReconnectInterval: 10 * time.Second,
 			},
-			expected: `host='localhost' port=0 user='postgres' password='postgres' dbname='kuma' connect_timeout=0 sslmode=verify-full sslcert='/path' sslkey='/path' sslrootcert='/path' `,
+			expected: `host='localhost' port=0 user='postgres' password='postgres' dbname='kuma' connect_timeout=0 sslmode=verify-full sslcert='/path' sslkey='/path' sslrootcert='/path'`,
 		}),
 		Entry("password needing escape without sslsni", stringTestCase{
 			given: postgres.PostgresStoreConfig{


### PR DESCRIPTION
This option is apparently relatively new, postgres 14, so we should skip including it unless it's explicitly disabled and let `libpg` handle the default.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] Link to docs PR or issue --
- [x] Link to UI issue or PR --
- [x] Is the [issue worked on linked][1]? --
- [x] The PR does not hardcode values that might break projects that depend on kuma (e.g. "kumahq" as a image registry) --
- [x] The PR will work for both Linux and Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Unit Tests --
- [x] E2E Tests --
- [x] Manual Universal Tests -- none
- [x] Manual Kubernetes Tests -- none
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [x] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
