### PR TITLE
feat(build): fix docker publish for ubi enterprise

### DIFF
--- a/tools/releases/docker.sh
+++ b/tools/releases/docker.sh
@@ -29,8 +29,15 @@ function build() {
       if [ "$arch" == "arm64" ]; then
         read -ra additional_args <<< "${ARM64_BUILD_ARGS[@]}"
       fi
+
+      if [[ -f "$SCRIPT_DIR"/dockerfiles/Dockerfile."${component}" ]]; then
+          dockerfile_path="$SCRIPT_DIR/dockerfiles/Dockerfile.${component}"
+      else
+          dockerfile_path="tools/releases/dockerfiles/Dockerfile.${component}"
+      fi
+
       docker build --label="do-not-remove=true" "${build_args[@]}" "${additional_args[@]}" -t "${KUMA_DOCKER_REPO_ORG}/${component}:${KUMA_VERSION}-${arch}" \
-        -f "$SCRIPT_DIR"/dockerfiles/Dockerfile."${component}" .
+        -f "${dockerfile_path}" .
       docker tag "${KUMA_DOCKER_REPO_ORG}/${component}:${KUMA_VERSION}-${arch}" "${KUMA_DOCKER_REPO_ORG}/${component}:latest-${arch}"
       msg_green "... done!"
     done


### PR DESCRIPTION
some dockerfiles are still separate (mirror) directory so I need to check for these

Signed-off-by: slonka <slonka@users.noreply.github.com>

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [ ] Link to docs PR or issue --
- [ ] Link to UI issue or PR --
- [ ] Is the [issue worked on linked][1]? --
- [ ] The PR does not hardcode values that might break projects that depend on kuma (e.g. "kumahq" as a image registry) --
- [ ] The PR will work for both Linux and Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [ ] Unit Tests --
- [ ] E2E Tests --
- [ ] Manual Universal Tests --
- [ ] Manual Kubernetes Tests --
- [ ] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [ ] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [ ] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
