### PR TITLE
test(e2e): lower delete namespace check interval

### DIFF
--- a/test/framework/k8s_cluster.go
+++ b/test/framework/k8s_cluster.go
@@ -224,7 +224,7 @@ func (c *K8sCluster) WaitNamespaceDelete(namespace string) {
 	retry.DoWithRetry(c.t,
 		fmt.Sprintf("Wait for %s Namespace to terminate.", namespace),
 		c.defaultRetries,
-		5*c.defaultTimeout,
+		c.defaultTimeout,
 		func() (string, error) {
 			_, err := k8s.GetNamespaceE(c.t,
 				c.GetKubectlOptions(),
@@ -240,7 +240,7 @@ func (c *K8sCluster) WaitNodeDelete(node string) (string, error) {
 	return retry.DoWithRetryE(c.t,
 		fmt.Sprintf("Wait for %s node to terminate.", node),
 		c.defaultRetries,
-		5*c.defaultTimeout,
+		c.defaultTimeout,
 		func() (string, error) {
 			nodes, err := k8s.GetNodesE(c.t, c.GetKubectlOptions())
 			if err != nil {


### PR DESCRIPTION
I noticed that for no real reason we are checking whether the namespace is deleted every 30s by default. That's quite a lot and can potentially introduce 30s latency on a single test suite.

It only affects non-shared-env E2E tests 

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [ ] Link to docs PR or issue --
- [ ] Link to UI issue or PR --
- [ ] Is the [issue worked on linked][1]? --
- [ ] The PR does not hardcode values that might break projects that depend on kuma (e.g. "kumahq" as a image registry) --
- [ ] The PR will work for both Linux and Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [ ] Unit Tests --
- [ ] E2E Tests --
- [ ] Manual Universal Tests --
- [ ] Manual Kubernetes Tests --
- [ ] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [ ] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [ ] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
