### PR TITLE
test(e2e): redistribute test jobs

### DIFF
--- a/test/e2e/ownership/e2e_suite_test.go
+++ b/test/e2e/ownership/e2e_suite_test.go
@@ -13,4 +13,4 @@ func TestE2E(t *testing.T) {
 	test.RunSpecs(t, "E2E Ownership tests")
 }
 
-var _ = Describe("Test Multizone Ownership for Universal", Label("job-2"), ownership.MultizoneUniversal)
+var _ = Describe("Test Multizone Ownership for Universal", Label("job-1"), ownership.MultizoneUniversal)

--- a/test/e2e/resilience/e2e_suite_test.go
+++ b/test/e2e/resilience/e2e_suite_test.go
@@ -14,7 +14,7 @@ func TestE2E(t *testing.T) {
 }
 
 var _ = Describe("Test Leader Election with Postgres", Label("job-1"), resilience.LeaderElectionPostgres)
-var _ = Describe("Test Multizone Resilience for Universal", Label("job-2"), resilience.ResilienceMultizoneUniversal)
+var _ = Describe("Test Multizone Resilience for Universal", Label("job-0"), resilience.ResilienceMultizoneUniversal)
 var _ = Describe("Test Multizone Resilience for K8s", Label("job-2"), resilience.ResilienceMultizoneK8s)
 var _ = Describe("Test Multizone Resilience for Universal with Postgres", Label("job-3"), resilience.ResilienceMultizoneUniversalPostgres)
 var _ = Describe("Test Standalone Resilience for Universal with Postgres", Label("job-4"), resilience.ResilienceStandaloneUniversal)

--- a/test/e2e/resilience/e2e_suite_test.go
+++ b/test/e2e/resilience/e2e_suite_test.go
@@ -14,7 +14,7 @@ func TestE2E(t *testing.T) {
 }
 
 var _ = Describe("Test Leader Election with Postgres", Label("job-1"), resilience.LeaderElectionPostgres)
-var _ = Describe("Test Multizone Resilience for Universal", Label("job-1"), resilience.ResilienceMultizoneUniversal)
+var _ = Describe("Test Multizone Resilience for Universal", Label("job-2"), resilience.ResilienceMultizoneUniversal)
 var _ = Describe("Test Multizone Resilience for K8s", Label("job-2"), resilience.ResilienceMultizoneK8s)
 var _ = Describe("Test Multizone Resilience for Universal with Postgres", Label("job-3"), resilience.ResilienceMultizoneUniversalPostgres)
 var _ = Describe("Test Standalone Resilience for Universal with Postgres", Label("job-4"), resilience.ResilienceStandaloneUniversal)

--- a/test/e2e/resilience/e2e_suite_test.go
+++ b/test/e2e/resilience/e2e_suite_test.go
@@ -14,7 +14,7 @@ func TestE2E(t *testing.T) {
 }
 
 var _ = Describe("Test Leader Election with Postgres", Label("job-1"), resilience.LeaderElectionPostgres)
-var _ = Describe("Test Multizone Resilience for Universal", Label("job-2"), resilience.ResilienceMultizoneUniversal)
+var _ = Describe("Test Multizone Resilience for Universal", Label("job-1"), resilience.ResilienceMultizoneUniversal)
 var _ = Describe("Test Multizone Resilience for K8s", Label("job-2"), resilience.ResilienceMultizoneK8s)
-var _ = Describe("Test Multizone Resilience for Universal with Postgres", Label("job-2"), resilience.ResilienceMultizoneUniversalPostgres)
-var _ = Describe("Test Standalone Resilience for Universal with Postgres", Label("job-2"), resilience.ResilienceStandaloneUniversal)
+var _ = Describe("Test Multizone Resilience for Universal with Postgres", Label("job-3"), resilience.ResilienceMultizoneUniversalPostgres)
+var _ = Describe("Test Standalone Resilience for Universal with Postgres", Label("job-4"), resilience.ResilienceStandaloneUniversal)

--- a/test/e2e/trafficpermission/kubernetes/e2e_suite_test.go
+++ b/test/e2e/trafficpermission/kubernetes/e2e_suite_test.go
@@ -13,4 +13,4 @@ func TestE2E(t *testing.T) {
 	test.RunSpecs(t, "E2E Traffic Permission Kubernetes Suite")
 }
 
-var _ = Describe("Traffic Permission on Kubernetes", Label("job-2"), kubernetes.TrafficPermission)
+var _ = Describe("Traffic Permission on Kubernetes", Label("job-4"), kubernetes.TrafficPermission)

--- a/test/e2e/zoneegress/externalservices/e2e_suite_test.go
+++ b/test/e2e/zoneegress/externalservices/e2e_suite_test.go
@@ -14,5 +14,5 @@ func TestE2E(t *testing.T) {
 }
 
 // arm-not-supported because of https://github.com/kumahq/kuma/issues/4822
-var _ = Describe("Test ZoneEgress for External Services in Hybrid Multizone", Label("job-2"), Label("arm-not-supported"), externalservices.HybridUniversalGlobal, Ordered)
+var _ = Describe("Test ZoneEgress for External Services in Hybrid Multizone", Label("job-1"), Label("arm-not-supported"), externalservices.HybridUniversalGlobal, Ordered)
 var _ = Describe("Test ZoneEgress for External Services in Universal Standalone", Label("job-4"), externalservices.UniversalStandalone)

--- a/test/e2e/zoneegress/externalservices/e2e_suite_test.go
+++ b/test/e2e/zoneegress/externalservices/e2e_suite_test.go
@@ -15,4 +15,4 @@ func TestE2E(t *testing.T) {
 
 // arm-not-supported because of https://github.com/kumahq/kuma/issues/4822
 var _ = Describe("Test ZoneEgress for External Services in Hybrid Multizone", Label("job-2"), Label("arm-not-supported"), externalservices.HybridUniversalGlobal, Ordered)
-var _ = Describe("Test ZoneEgress for External Services in Universal Standalone", Label("job-2"), externalservices.UniversalStandalone)
+var _ = Describe("Test ZoneEgress for External Services in Universal Standalone", Label("job-4"), externalservices.UniversalStandalone)


### PR DESCRIPTION
Ilya reenabled resilience test which caused a disproportion

![image](https://user-images.githubusercontent.com/5459824/206492272-d44b5e33-587d-4961-84fe-50133c8217fa.png)

This PR tries to fix it

![image](https://user-images.githubusercontent.com/5459824/206698821-a34871ec-d94d-4bf6-89ae-2551d0f4596f.png)

In some other PR I will try to optimise the resilience K8S test, because it's very long and I have an idea how to improve it.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [ ] Link to docs PR or issue --
- [ ] Link to UI issue or PR --
- [ ] Is the [issue worked on linked][1]? --
- [ ] The PR does not hardcode values that might break projects that depend on kuma (e.g. "kumahq" as a image registry) --
- [ ] The PR will work for both Linux and Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [ ] Unit Tests --
- [ ] E2E Tests --
- [ ] Manual Universal Tests --
- [ ] Manual Kubernetes Tests --
- [ ] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [ ] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [ ] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
