### PR TITLE
docs: create MADR for MeshRetry

### DIFF
--- a/docs/madr/decisions/015-retry-policy.md
+++ b/docs/madr/decisions/015-retry-policy.md
@@ -18,9 +18,8 @@ MeshRetry
 
 Even though it's possible to place a retry policy on the inbound routes, 
 it doesn't seem like there is a value in it.
-Retries create an additional load on the service,
-that's why it's not in the interest of service owners to place retries on the inbounds.
-Most of the time retrying of the request is a client's concern.
+We won't add inbound retries mostly because retries create additional load on the service.
+Most of the time retrying requests is a client's concern.
 
 #### Top level
 
@@ -28,7 +27,7 @@ Top-level targetRef can have the following kinds:
 
 ```yaml
 targetRef:
-  kind: Mesh|MeshSubset|MeshService|MeshServiceSubset|MeshGatewayRoute
+  kind: Mesh|MeshSubset|MeshService|MeshServiceSubset
   name: ...
 ```
 
@@ -38,7 +37,7 @@ To-level targetRef can have the following kinds:
 
 ```yaml
 targetRef:
-  kind: Mesh|MeshService|MeshHTTPRoute
+  kind: Mesh|MeshService
   name: ...
 ```
 
@@ -134,16 +133,16 @@ default:
 
 Changes:
 
-1. Rename "http.retryOn.all_5xx" to "http.retryOn.5xx". Apparently it was a limitation of proto enums.
-2. Rename "retriableStatusCodes" to "additionalRetriableStatusCodes" 
-because this field provides additional status codes to whatever already specified in "retryOn".
-Today there is a validation if you set "retriableStatusCodes" you must provide "retriable_status_codes" to the "retryOn" list. 
+1. Rename `http.retryOn.all_5xx` to `http.retryOn.5xx`. Apparently it was a limitation of proto enums.
+2. Rename `retriableStatusCodes` to `additionalRetriableStatusCodes` 
+because this field provides additional status codes to whatever already specified in `retryOn`.
+Today there is a validation if you set `retriableStatusCodes` you must provide `retriable_status_codes` to the `retryOn` list. 
 Due to a multi-level organisation of policies now it's impossible to validate.
-I think the best option is to add "retriable_status_codes" to "retryOn" automatically if "additionalRetriableStatusCodes" is specified. 
-3. New field "retriableHeaders" (or "retriableResponseHeaders"). Even though we have already had "retryOn.retriable_headers" 
+I think the best option is to add `retriable_status_codes` to `retryOn` automatically if `additionalRetriableStatusCodes` is specified. 
+3. New field `retriableHeaders` (or `retriableResponseHeaders`). Even though we have already had `retryOn.retriable_headers` 
 there was no way to provide a list of headers. 
-If this field is set we automatically add "retriable_headers" to "retryOn".
-4. New field "retriableRequestHeaders". Purely for the sake of symmetry, 
+If this field is set we automatically add `retriable_headers` to `retryOn`.
+4. New field `retriableRequestHeaders`. Purely for the sake of symmetry, 
 if we allow retrying on response headers why not allow that on request headers. 
 
 #### Other retry-related Envoy parameters
@@ -153,7 +152,7 @@ But there are few additional things we can potentially support.
 
 ##### per_try_idle_timeout
 
-Same as "idle_timeout" but enforced on each individual attempt.
+Same as `idle_timeout` but enforced on each individual attempt.
 
 ##### Host selection
 
@@ -178,21 +177,21 @@ hostSelection:
     updateFrequency: 2 # how often the priority load should be updated based on previously attempted priorities                                                                                             
 ```
 
-Having configurable "hostSelection" implies exposing the "host_selection_retry_max_attempts" parameter as well.
+Having configurable `hostSelection` implies exposing the `host_selection_retry_max_attempts` parameter as well.
 It allows configuring the maximum number of times host selection will be reattempted before giving up.
 
-##### Retry budged
+##### Retry budget
 
 This parameter allows specifying a limit on concurrent retries in relation to the number of active requests.
-The problem is that "retry budged" is set on Envoy cluster 
+The problem is that `retry budget` is set on Envoy cluster 
 while other parameters are set on a "per route" or "per virtual host" basis.
 Even though today Kuma generates an Envoy cluster "per route" it might not be the case in the future.
-So I don't think having "retry budged" in MeshRetry policy is a good idea.
+So I don't think having `retry budget` in MeshRetry policy is a good idea.
 
 ## Considered Options
 
 * Implement MeshRetry without additional parameters
-* Implement MeshRetry with "per_try_idle_timeout" and "host selection"
+* Implement MeshRetry with `per_try_idle_timeout` and `hostSelection`
 
 ### Implement MeshRetry without additional parameters
 
@@ -205,7 +204,7 @@ So I don't think having "retry budged" in MeshRetry policy is a good idea.
 
 * MeshRetry could be considered by some users as not flexible enough 
 
-### Implement MeshRetry with "per_try_idle_timeout" and "host selection"
+### Implement MeshRetry with `per_try_idle_timeout` and `hostSelection`
 
 #### Pros
 

--- a/docs/madr/decisions/015-retry-policy.md
+++ b/docs/madr/decisions/015-retry-policy.md
@@ -1,0 +1,223 @@
+# Retry policy
+
+* Status: accepted
+
+Technical Story: https://github.com/kumahq/kuma/issues/4738
+
+## Context and Problem Statement
+
+We want to create a new policy for retries that uses TargetRef [matching](https://github.com/kumahq/kuma/blob/22c157d4adac7f518b1b49939c7e9ea4d2a1876c/docs/madr/decisions/005-policy-matching.md).
+
+### Specification 
+
+#### Name
+
+MeshRetry
+
+#### From level
+
+Even though it's possible to place a retry policy on the inbound routes, 
+it doesn't seem like there is a value in it.
+Retries create an additional load on the service,
+that's why it's not in the interest of service owners to place retries on the inbounds.
+Most of the time retrying of the request is a client's concern.
+
+#### Top level
+
+Top-level targetRef can have the following kinds:
+
+```yaml
+targetRef:
+  kind: Mesh|MeshSubset|MeshService|MeshServiceSubset|MeshGatewayRoute
+  name: ...
+```
+
+#### To level
+
+To-level targetRef can have the following kinds:
+
+```yaml
+targetRef:
+  kind: Mesh|MeshService|MeshHTTPRoute
+  name: ...
+```
+
+#### Conf
+
+Existing Retry policy:
+
+```yaml
+conf:
+  http:
+    numRetries: 5
+    perTryTimeout: 200ms
+    backOff:
+      baseInterval: 20ms
+      maxInterval: 1s
+    retriableStatusCodes:
+      - 500
+      - 504
+    retriableMethods:
+      - GET
+    retryOn:
+      - all_5xx
+      - gateway_error
+      - reset
+      - connect_failure
+      - envoy_ratelimited
+      - retriable_4xx
+      - refused_stream
+      - retriable_status_codes
+      - retriable_headers
+      - http3_post_connect_failure
+  grpc:
+    numRetries: 5
+    perTryTimeout: 200ms
+    backOff:
+      baseInterval: 20ms
+      maxInterval: 1s
+    retryOn:
+      - cancelled
+      - deadline_exceeded
+      - internal
+      - resource_exhausted
+      - unavailable
+  tcp:
+    maxConnectAttempts: 3
+```
+
+We can slightly change the conf for better compatibility with merging:
+
+```yaml
+default:
+  http:
+    numRetries: 5
+    perTryTimeout: 200ms
+    backOff:
+      baseInterval: 20ms
+      maxInterval: 1s
+    retriableMethods:
+      - GET
+    retryOn:
+      - 5xx
+      - gateway_error
+      - reset
+      - connect_failure
+      - envoy_ratelimited
+      - retriable_4xx
+      - refused_stream
+      - http3_post_connect_failure
+    additionalRetriableStatusCodes:
+      - 500
+      - 504 
+    retriableHeaders:
+      - name: header-name
+        exact: value
+    retriableRequestHeaders:
+      - name: should-retry-this
+        exact: yes
+  grpc:
+    numRetries: 5
+    perTryTimeout: 200ms
+    backOff:
+      baseInterval: 20ms
+      maxInterval: 1s
+    retryOn:
+      - cancelled
+      - deadline_exceeded
+      - internal
+      - resource_exhausted
+      - unavailable
+  tcp:
+    maxConnectAttempts: 3
+```
+
+Changes:
+
+1. Rename "http.retryOn.all_5xx" to "http.retryOn.5xx". Apparently it was a limitation of proto enums.
+2. Rename "retriableStatusCodes" to "additionalRetriableStatusCodes" 
+because this field provides additional status codes to whatever already specified in "retryOn".
+Today there is a validation if you set "retriableStatusCodes" you must provide "retriable_status_codes" to the "retryOn" list. 
+Due to a multi-level organisation of policies now it's impossible to validate.
+I think the best option is to add "retriable_status_codes" to "retryOn" automatically if "additionalRetriableStatusCodes" is specified. 
+3. New field "retriableHeaders" (or "retriableResponseHeaders"). Even though we have already had "retryOn.retriable_headers" 
+there was no way to provide a list of headers. 
+If this field is set we automatically add "retriable_headers" to "retryOn".
+4. New field "retriableRequestHeaders". Purely for the sake of symmetry, 
+if we allow retrying on response headers why not allow that on request headers. 
+
+#### Other retry-related Envoy parameters
+
+So far we didn't get requests from users to extend the policy with other Envoy parameters.
+But there are few additional things we can potentially support.
+
+##### per_try_idle_timeout
+
+Same as "idle_timeout" but enforced on each individual attempt.
+
+##### Host selection
+
+Envoy has "host predicates" and "priority predicates" to enforce an additional logic 
+when selecting a host for the attempt:
+
+* don't retry on previously retried hosts
+* don't retry on canary hosts
+* don't retry on hosts with specified metadata key/value
+* don't retry on previous priorities
+
+These predicates can be combined:
+
+```yaml
+hostSelection:
+  - predicate: OMIT_PREVIOUS_HOSTS
+  - predicate: OMIT_CANARY_HOSTS
+  - predicate: OMIT_HOSTS_WITH_TAGS
+    tags:
+      env: dev
+  - predicate: OMIT_PREVIOUS_PRIORITIES
+    updateFrequency: 2 # how often the priority load should be updated based on previously attempted priorities                                                                                             
+```
+
+Having configurable "hostSelection" implies exposing the "host_selection_retry_max_attempts" parameter as well.
+It allows configuring the maximum number of times host selection will be reattempted before giving up.
+
+##### Retry budged
+
+This parameter allows specifying a limit on concurrent retries in relation to the number of active requests.
+The problem is that "retry budged" is set on Envoy cluster 
+while other parameters are set on a "per route" or "per virtual host" basis.
+Even though today Kuma generates an Envoy cluster "per route" it might not be the case in the future.
+So I don't think having "retry budged" in MeshRetry policy is a good idea.
+
+## Considered Options
+
+* Implement MeshRetry without additional parameters
+* Implement MeshRetry with "per_try_idle_timeout" and "host selection"
+
+### Implement MeshRetry without additional parameters
+
+#### Pros
+
+* easy to implement
+* policy is not overloaded with parameters
+
+#### Cons
+
+* MeshRetry could be considered by some users as not flexible enough 
+
+### Implement MeshRetry with "per_try_idle_timeout" and "host selection"
+
+#### Pros
+
+* users can configure complex host selection strategies for retries
+
+#### Cons
+
+* more difficult implementation
+* policy is overloaded with parameters
+
+## Decision Outcome
+
+Chosen option: "Implement MeshRetry without additional parameters". 
+Let's start simple. 
+We can always extend the policy in the future if we see interest in the community. 

--- a/docs/madr/decisions/015-retry-policy.md
+++ b/docs/madr/decisions/015-retry-policy.md
@@ -160,7 +160,7 @@ Envoy has "host predicates" and "priority predicates" to enforce an additional l
 when selecting a host for the attempt:
 
 * don't retry on previously retried hosts
-* don't retry on canary hosts
+* don't retry on canary hosts (the host should be preliminarily marked with `canary: true`)
 * don't retry on hosts with specified metadata key/value
 * don't retry on previous priorities
 

--- a/docs/madr/decisions/015-retry-policy.md
+++ b/docs/madr/decisions/015-retry-policy.md
@@ -109,7 +109,7 @@ default:
     additionalRetriableStatusCodes:
       - 500
       - 504 
-    retriableHeaders:
+    retriableResponseHeaders:
       - name: header-name
         exact: value
     retriableRequestHeaders:
@@ -139,7 +139,7 @@ because this field provides additional status codes to whatever already specifie
 Today there is a validation if you set `retriableStatusCodes` you must provide `retriable_status_codes` to the `retryOn` list. 
 Due to a multi-level organisation of policies now it's impossible to validate.
 I think the best option is to add `retriable_status_codes` to `retryOn` automatically if `additionalRetriableStatusCodes` is specified. 
-3. New field `retriableHeaders` (or `retriableResponseHeaders`). Even though we have already had `retryOn.retriable_headers` 
+3. New field `retriableResponseHeaders`. Even though we have already had `retryOn.retriable_headers` 
 there was no way to provide a list of headers. 
 If this field is set we automatically add `retriable_headers` to `retryOn`.
 4. New field `retriableRequestHeaders`. Purely for the sake of symmetry, 


### PR DESCRIPTION
[Formated version](https://github.com/lobkovilya/kuma/blob/5984660bb1e6c0d0de6f7f90550bbd9412d007fb/docs/madr/decisions/015-retry-policy.md)

Signed-off-by: Ilya Lobkov <ilya.lobkov@konghq.com>

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [X] Link to docs PR or issue --
- [X] Link to UI issue or PR --
- [X] Is the [issue worked on linked][1]? -- Fix https://github.com/kumahq/kuma/issues/4738
- [X] The PR does not hardcode values that might break projects that depend on kuma (e.g. "kumahq" as a image registry) --
- [X] The PR will work for both Linux and Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [X] Unit Tests --
- [X] E2E Tests --
- [X] Manual Universal Tests --
- [X] Manual Kubernetes Tests --
- [X] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [X] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [X] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
