### PR TITLE
test: fix data race in heatbeat component tests

### DIFF
--- a/pkg/intercp/catalog/heartbeat_component_test.go
+++ b/pkg/intercp/catalog/heartbeat_component_test.go
@@ -38,14 +38,15 @@ var _ = Describe("Heartbeats", func() {
 		pingClient = &staticPingClient{
 			leader: true,
 		}
+		pc := pingClient // copy pointer to get rid of data race
 
 		heartbeatComponent = catalog.NewHeartbeatComponent(
 			c,
 			currentInstance,
 			10*time.Millisecond,
 			func(serverURL string) (catalog.Client, error) {
-				pingClient.SetServerURL(serverURL)
-				return pingClient, nil
+				pc.SetServerURL(serverURL)
+				return pc, nil
 			},
 		)
 


### PR DESCRIPTION
Signed-off-by: Jakub Dyszkiewicz <jakub.dyszkiewicz@gmail.com>

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [ ] Link to docs PR or issue --
- [ ] Link to UI issue or PR --
- [ ] Is the [issue worked on linked][1]? --
- [ ] The PR does not hardcode values that might break projects that depend on kuma (e.g. "kumahq" as a image registry) --
- [ ] The PR will work for both Linux and Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [ ] Unit Tests --
- [ ] E2E Tests --
- [ ] Manual Universal Tests --
- [ ] Manual Kubernetes Tests --
- [ ] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [ ] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [ ] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
