### PR TITLE
test(e2e): speed up resilience multizone k8s test

### DIFF
--- a/test/e2e/resilience/e2e_suite_test.go
+++ b/test/e2e/resilience/e2e_suite_test.go
@@ -15,6 +15,6 @@ func TestE2E(t *testing.T) {
 
 var _ = Describe("Test Leader Election with Postgres", Label("job-1"), resilience.LeaderElectionPostgres)
 var _ = Describe("Test Multizone Resilience for Universal", Label("job-0"), resilience.ResilienceMultizoneUniversal)
-var _ = Describe("Test Multizone Resilience for K8s", Label("job-2"), resilience.ResilienceMultizoneK8s)
+var _ = Describe("Test Multizone Resilience for K8s", Label("job-2"), resilience.ResilienceMultizoneK8s, Ordered)
 var _ = Describe("Test Multizone Resilience for Universal with Postgres", Label("job-3"), resilience.ResilienceMultizoneUniversalPostgres)
 var _ = Describe("Test Standalone Resilience for Universal with Postgres", Label("job-4"), resilience.ResilienceStandaloneUniversal)


### PR DESCRIPTION
Signed-off-by: Jakub Dyszkiewicz <jakub.dyszkiewicz@gmail.com>

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [ ] Link to docs PR or issue --
- [ ] Link to UI issue or PR --
- [ ] Is the [issue worked on linked][1]? --
- [ ] The PR does not hardcode values that might break projects that depend on kuma (e.g. "kumahq" as a image registry) --
- [ ] The PR will work for both Linux and Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [ ] Unit Tests --
- [ ] E2E Tests --
- [ ] Manual Universal Tests --
- [ ] Manual Kubernetes Tests --
- [ ] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [ ] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [ ] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
