### PR TITLE
chore: graduate debug-fast target

### DIFF
--- a/mk/e2e.new.mk
+++ b/mk/e2e.new.mk
@@ -103,18 +103,9 @@ test/e2e/k8s/stop: $(K8SCLUSTERS_STOP_TARGETS)
 # Clusters are deleted only if all tests passes, otherwise clusters are live and running current test deployment
 # GINKGO_EDITOR_INTEGRATION is required to work with focused test. Normally they exit with non 0 code which prevents clusters to be cleaned up.
 # We run ginkgo instead of "go test" to fail fast (builtin "go test" fail fast does not seem to work with individual ginkgo tests)
+# Run only with -j and K8S_CLUSTER_TOOL=k3d (which is the default value)
 .PHONY: test/e2e/debug
-test/e2e/debug: $(E2E_DEPS_TARGETS) build/kumactl images test/e2e/k8s/start
-	$(E2E_ENV_VARS) \
-	GINKGO_EDITOR_INTEGRATION=true \
-		$(GINKGO_TEST_E2E) --keep-going=false --fail-fast $(E2E_PKG_LIST)
-	$(MAKE) test/e2e/k8s/stop
-
-# test/e2e/debug-fast is an experimental target tested with K8S_CLUSTER_TOOL=k3d.
-# test/e2e/debug-fast is an equivalent of test/e2e/debug, but with the goal to minimize time for test to start running.
-# Run only with -j and K8S_CLUSTER_TOOL=k3d
-.PHONY: test/e2e/debug-fast
-test/e2e/debug-fast: $(E2E_DEPS_TARGETS)
+test/e2e/debug: $(E2E_DEPS_TARGETS)
 	$(MAKE) $(K8SCLUSTERS_START_TARGETS) & # start K8S clusters in the background since it takes the most time
 	$(MAKE) images
 	$(MAKE) build/kumactl


### PR DESCRIPTION
`make test/e2e/debug-fast` started as an experiment to shorten the feedback loop when developing E2E tests.
The experiment was a success so we can replace the old `test/e2e/debug` with it.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [ ] Link to docs PR or issue --
- [ ] Link to UI issue or PR --
- [ ] Is the [issue worked on linked][1]? --
- [ ] The PR does not hardcode values that might break projects that depend on kuma (e.g. "kumahq" as a image registry) --
- [ ] The PR will work for both Linux and Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [ ] Unit Tests --
- [ ] E2E Tests --
- [ ] Manual Universal Tests --
- [ ] Manual Kubernetes Tests --
- [ ] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [ ] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [ ] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
