### PR TITLE
chore(e2e): cleanup gateway client which is not in mesh

### DIFF
--- a/test/e2e_env/universal/gateway/gateway.go
+++ b/test/e2e_env/universal/gateway/gateway.go
@@ -34,6 +34,7 @@ func Gateway() {
 	})
 
 	E2EAfterAll(func() {
+		Expect(env.Cluster.DeleteApp("gateway-client")).To(Succeed())
 		Expect(env.Cluster.DeleteMeshApps(mesh)).To(Succeed())
 		Expect(env.Cluster.DeleteMesh(mesh)).To(Succeed())
 	})

--- a/test/e2e_env/universal/meshaccesslog/meshaccesslog.go
+++ b/test/e2e_env/universal/meshaccesslog/meshaccesslog.go
@@ -41,6 +41,7 @@ func TestPlugin() {
 			Setup(env.Cluster)).To(Succeed())
 	})
 	E2EAfterAll(func() {
+		Expect(env.Cluster.DeleteApp("gateway-client")).To(Succeed())
 		Expect(env.Cluster.DeleteMeshApps(meshName)).To(Succeed())
 		Expect(env.Cluster.DeleteMesh(meshName)).To(Succeed())
 	})

--- a/test/e2e_env/universal/observability/meshtrace.go
+++ b/test/e2e_env/universal/observability/meshtrace.go
@@ -57,6 +57,7 @@ func PluginTest() {
 	})
 
 	E2EAfterAll(func() {
+		Expect(env.Cluster.DeleteApp("gateway-client")).To(Succeed())
 		Expect(env.Cluster.DeleteMeshApps(mesh)).To(Succeed())
 		Expect(env.Cluster.DeleteMesh(mesh)).To(Succeed())
 		Expect(env.Cluster.DeleteDeployment(obsDeployment)).To(Succeed())


### PR DESCRIPTION
`gateway-client` wasn't in a mesh so it is not removed at the end of the tests
- [X] Link to docs PR or issue --
- [X] Link to UI issue or PR --
- [X] Is the [issue worked on linked][1]? --
- [X] The PR does not hardcode values that might break projects that depend on kuma (e.g. "kumahq" as a image registry) --
- [X] The PR will work for both Linux and Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [X] Unit Tests --
- [X] E2E Tests --
- [X] Manual Universal Tests --
- [X] Manual Kubernetes Tests --
- [X] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [X] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [X] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
