### PR TITLE
fix(kuma-cp): filtering of name prefix on K8S

### DIFF
--- a/pkg/plugins/resources/k8s/store.go
+++ b/pkg/plugins/resources/k8s/store.go
@@ -180,11 +180,11 @@ func (s *KubernetesStore) List(ctx context.Context, rs core_model.ResourceList, 
 		return errors.Wrap(err, "failed to list k8s resources")
 	}
 	predicate := func(r core_model.Resource) bool {
-		if opts.Mesh != "" {
-			return r.GetMeta().GetMesh() == opts.Mesh
+		if opts.Mesh != "" && r.GetMeta().GetMesh() != opts.Mesh {
+			return false
 		}
-		if opts.NamePrefix != "" {
-			return strings.HasPrefix(r.GetMeta().GetName(), opts.NamePrefix)
+		if opts.NamePrefix != "" && !strings.HasPrefix(r.GetMeta().GetName(), opts.NamePrefix) {
+			return false
 		}
 		return true
 	}

--- a/pkg/test/store/store_test_template.go
+++ b/pkg/test/store/store_test_template.go
@@ -339,7 +339,7 @@ func ExecuteStoreTests(
 			Expect(list.Items).To(HaveLen(0))
 		})
 
-		It("should return a list of resources with prefix", func() {
+		It("should return a list of resources with prefix from all meshes", func() {
 			// given two resources
 			createResource("list-res-1.demo")
 			createResource("list-res-2.demo")
@@ -349,6 +349,31 @@ func ExecuteStoreTests(
 
 			// when
 			err := s.List(context.Background(), &list, store.ListByNamePrefix("list-res"))
+
+			// then
+			Expect(err).ToNot(HaveOccurred())
+			// and
+			Expect(list.Pagination.Total).To(Equal(uint32(2)))
+			// and
+			Expect(list.Items).To(WithTransform(func(itms []*core_mesh.TrafficRouteResource) []string {
+				var res []string
+				for _, v := range itms {
+					res = append(res, v.GetMeta().GetName())
+				}
+				return res
+			}, Equal([]string{"list-res-1.demo", "list-res-2.demo"})))
+		})
+
+		It("should return a list of resources with prefix from the specific mesh", func() {
+			// given two resources
+			createResource("list-res-1.demo")
+			createResource("list-res-2.demo")
+			createResource("list-mes-1.demo")
+
+			list := core_mesh.TrafficRouteResourceList{}
+
+			// when
+			err := s.List(context.Background(), &list, store.ListByNamePrefix("list-res"), store.ListByMesh(mesh))
 
 			// then
 			Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
Fix for filtering name prefix

fix #5512 

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [ ] Link to docs PR or issue --
- [ ] Link to UI issue or PR --
- [ ] Is the [issue worked on linked][1]? --
- [ ] The PR does not hardcode values that might break projects that depend on kuma (e.g. "kumahq" as a image registry) --
- [ ] The PR will work for both Linux and Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [ ] Unit Tests --
- [ ] E2E Tests --
- [ ] Manual Universal Tests --
- [ ] Manual Kubernetes Tests --
- [ ] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [ ] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [ ] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
