### PR TITLE
fix: warn when using deprecated token id

### DIFF
--- a/pkg/core/tokens/compatibility_test.go
+++ b/pkg/core/tokens/compatibility_test.go
@@ -11,6 +11,7 @@ import (
 	"google.golang.org/protobuf/types/known/wrapperspb"
 
 	store_config "github.com/kumahq/kuma/pkg/config/core/resources/store"
+	"github.com/kumahq/kuma/pkg/core"
 	"github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	"github.com/kumahq/kuma/pkg/core/resources/apis/system"
 	"github.com/kumahq/kuma/pkg/core/resources/manager"
@@ -37,6 +38,7 @@ var _ = Describe("Compatibility with old ASN.1 format", func() {
 		signingKeyManager = tokens.NewMeshedSigningKeyManager(resManager, TestTokenSigningKeyPrefix, model.DefaultMesh)
 		issuer = tokens.NewTokenIssuer(signingKeyManager)
 		validator = tokens.NewValidator(
+			core.Log.WithName("test"),
 			tokens.NewMeshedSigningKeyAccessor(resManager, TestTokenSigningKeyPrefix, model.DefaultMesh),
 			tokens.NewRevocations(resManager, TokenRevocationsGlobalSecretKey),
 			store_config.MemoryStore,

--- a/pkg/core/tokens/issuer_test.go
+++ b/pkg/core/tokens/issuer_test.go
@@ -32,8 +32,7 @@ func (t *TestClaims) ID() string {
 	return t.RegisteredClaims.ID
 }
 
-func (t *TestClaims) KeyIDFallback() (int, error) {
-	return 0, nil
+func (t *TestClaims) KeyIDFallback() {
 }
 
 func (t *TestClaims) SetRegisteredClaims(claims jwt.RegisteredClaims) {

--- a/pkg/core/tokens/issuer_test.go
+++ b/pkg/core/tokens/issuer_test.go
@@ -87,6 +87,7 @@ var _ = Describe("Token issuer", func() {
 			signingKeyManager = tokens.NewSigningKeyManager(secretManager, TestTokenSigningKeyPrefix)
 			issuer = tokens.NewTokenIssuer(signingKeyManager)
 			validator = tokens.NewValidator(
+				core.Log.WithName("test"),
 				tokens.NewSigningKeyAccessor(secretManager, TestTokenSigningKeyPrefix),
 				tokens.NewRevocations(secretManager, TokenRevocationsGlobalSecretKey),
 				store_config.MemoryStore,
@@ -185,6 +186,7 @@ var _ = Describe("Token issuer", func() {
 			signingKeyManager = tokens.NewMeshedSigningKeyManager(secretManager, TestTokenSigningKeyPrefix, core_model.DefaultMesh)
 			issuer = tokens.NewTokenIssuer(signingKeyManager)
 			validator = tokens.NewValidator(
+				core.Log.WithName("test"),
 				tokens.NewMeshedSigningKeyAccessor(secretManager, TestTokenSigningKeyPrefix, core_model.DefaultMesh),
 				tokens.NewRevocations(secretManager, TokenRevocationsSecretKey(core_model.DefaultMesh)),
 				store_config.MemoryStore,

--- a/pkg/core/tokens/token.go
+++ b/pkg/core/tokens/token.go
@@ -7,11 +7,13 @@ type Token = string
 type Claims interface {
 	jwt.Claims
 	ID() string
-	// KeyIDFallback returns KID when it is not provided as a header.
-	// It helps us to built backwards compatibility with a tokens that did not have KID in the past.
-	// https://github.com/kumahq/kuma/issues/4006
-	KeyIDFallback() (int, error)
 	SetRegisteredClaims(claims jwt.RegisteredClaims)
+}
+
+type KeyIDFallback interface {
+	// KeyIDFallback Marker function to indicate this can be used for tokens with v0
+	// This will be removed with https://github.com/kumahq/kuma/issues/5519
+	KeyIDFallback()
 }
 
 const KeyIDHeader = "kid" // standard JWT header that indicates which signing key we should use

--- a/pkg/plugins/authn/api-server/tokens/admin_token_bootstrap_test.go
+++ b/pkg/plugins/authn/api-server/tokens/admin_token_bootstrap_test.go
@@ -8,6 +8,7 @@ import (
 
 	kuma_cp "github.com/kumahq/kuma/pkg/config/app/kuma-cp"
 	store_config "github.com/kumahq/kuma/pkg/config/core/resources/store"
+	"github.com/kumahq/kuma/pkg/core"
 	"github.com/kumahq/kuma/pkg/core/resources/apis/system"
 	"github.com/kumahq/kuma/pkg/core/resources/manager"
 	core_store "github.com/kumahq/kuma/pkg/core/resources/store"
@@ -26,6 +27,7 @@ var _ = Describe("Admin Token Bootstrap", func() {
 		tokenIssuer := issuer.NewUserTokenIssuer(core_tokens.NewTokenIssuer(signingKeyManager))
 		tokenValidator := issuer.NewUserTokenValidator(
 			core_tokens.NewValidator(
+				core.Log.WithName("test"),
 				core_tokens.NewSigningKeyAccessor(resManager, issuer.UserTokenSigningKeyPrefix),
 				core_tokens.NewRevocations(resManager, issuer.UserTokenRevocationsGlobalSecretKey),
 				store_config.MemoryStore,

--- a/pkg/plugins/authn/api-server/tokens/issuer/token.go
+++ b/pkg/plugins/authn/api-server/tokens/issuer/token.go
@@ -1,8 +1,6 @@
 package issuer
 
 import (
-	"errors"
-
 	"github.com/golang-jwt/jwt/v4"
 
 	core_model "github.com/kumahq/kuma/pkg/core/resources/model"
@@ -26,10 +24,6 @@ var _ tokens.Claims = &UserClaims{}
 
 func (c *UserClaims) ID() string {
 	return c.RegisteredClaims.ID
-}
-
-func (c *UserClaims) KeyIDFallback() (int, error) {
-	return 0, errors.New("kid is required") // kid was required when we introduced User Token
 }
 
 func (c *UserClaims) SetRegisteredClaims(claims jwt.RegisteredClaims) {

--- a/pkg/plugins/authn/api-server/tokens/plugin.go
+++ b/pkg/plugins/authn/api-server/tokens/plugin.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/kumahq/kuma/pkg/api-server/authn"
 	config_access "github.com/kumahq/kuma/pkg/config/access"
+	"github.com/kumahq/kuma/pkg/core"
 	"github.com/kumahq/kuma/pkg/core/plugins"
 	core_tokens "github.com/kumahq/kuma/pkg/core/tokens"
 	"github.com/kumahq/kuma/pkg/plugins/authn/api-server/tokens/access"
@@ -38,6 +39,7 @@ func init() {
 func (c plugin) NewAuthenticator(context plugins.PluginContext) (authn.Authenticator, error) {
 	validator := issuer.NewUserTokenValidator(
 		core_tokens.NewValidator(
+			core.Log.WithName("test"),
 			core_tokens.NewSigningKeyAccessor(context.ResourceManager(), issuer.UserTokenSigningKeyPrefix),
 			core_tokens.NewRevocations(context.ResourceManager(), issuer.UserTokenRevocationsGlobalSecretKey),
 			context.Config().Store.Type,

--- a/pkg/plugins/authn/api-server/tokens/ws/ws_test.go
+++ b/pkg/plugins/authn/api-server/tokens/ws/ws_test.go
@@ -15,6 +15,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	store_config "github.com/kumahq/kuma/pkg/config/core/resources/store"
+	"github.com/kumahq/kuma/pkg/core"
 	"github.com/kumahq/kuma/pkg/core/resources/manager"
 	error_types "github.com/kumahq/kuma/pkg/core/rest/errors/types"
 	core_tokens "github.com/kumahq/kuma/pkg/core/tokens"
@@ -45,6 +46,7 @@ var _ = Describe("Auth Tokens WS", func() {
 		tokenIssuer := issuer.NewUserTokenIssuer(core_tokens.NewTokenIssuer(signingKeyManager))
 		userTokenValidator = issuer.NewUserTokenValidator(
 			core_tokens.NewValidator(
+				core.Log.WithName("test"),
 				core_tokens.NewSigningKeyAccessor(resManager, issuer.UserTokenSigningKeyPrefix),
 				core_tokens.NewRevocations(resManager, issuer.UserTokenRevocationsGlobalSecretKey),
 				store_config.MemoryStore,

--- a/pkg/tokens/builtin/issuer/token.go
+++ b/pkg/tokens/builtin/issuer/token.go
@@ -38,8 +38,7 @@ func (d *DataplaneClaims) ID() string {
 	return d.RegisteredClaims.ID
 }
 
-func (d *DataplaneClaims) KeyIDFallback() (int, error) {
-	return 0, nil
+func (d *DataplaneClaims) KeyIDFallback() {
 }
 
 func (d *DataplaneClaims) SetRegisteredClaims(claims jwt.RegisteredClaims) {

--- a/pkg/tokens/builtin/zone/token.go
+++ b/pkg/tokens/builtin/zone/token.go
@@ -2,7 +2,6 @@ package zone
 
 import (
 	"github.com/golang-jwt/jwt/v4"
-	"github.com/pkg/errors"
 
 	core_model "github.com/kumahq/kuma/pkg/core/resources/model"
 	core_tokens "github.com/kumahq/kuma/pkg/core/tokens"
@@ -26,10 +25,6 @@ var _ core_tokens.Claims = &ZoneClaims{}
 
 func (c *ZoneClaims) ID() string {
 	return c.RegisteredClaims.ID
-}
-
-func (c *ZoneClaims) KeyIDFallback() (int, error) {
-	return 0, errors.New("missing Key ID")
 }
 
 func (c *ZoneClaims) SetRegisteredClaims(claims jwt.RegisteredClaims) {

--- a/pkg/tokens/builtin/zoneingress/token.go
+++ b/pkg/tokens/builtin/zoneingress/token.go
@@ -25,8 +25,7 @@ func (c *ZoneIngressClaims) ID() string {
 	return c.RegisteredClaims.ID
 }
 
-func (c *ZoneIngressClaims) KeyIDFallback() (int, error) {
-	return 0, nil
+func (c *ZoneIngressClaims) KeyIDFallback() {
 }
 
 func (c *ZoneIngressClaims) SetRegisteredClaims(claims jwt.RegisteredClaims) {


### PR DESCRIPTION
Tracking removal with #5519

Fix #4006

Signed-off-by: Charly Molter <charly.molter@konghq.com>

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] Link to docs PR or issue --
- [x] Link to UI issue or PR --
- [x] Is the [issue worked on linked][1]? --
- [x] The PR does not hardcode values that might break projects that depend on kuma (e.g. "kumahq" as a image registry) --
- x ] The PR will work for both Linux and Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Unit Tests --
- [x] E2E Tests --
- [x] Manual Universal Tests --
- [x] Manual Kubernetes Tests --
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [x] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
