### PR TITLE
chore(kumactl): remove default `--valid-for` for tokens

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -17,6 +17,9 @@ Make sure you are using a recent `kumactl` or that you use the right path if usi
 
 The sidecar container is always injected first (since [#5436](https://github.com/kumahq/kuma/pull/5436)). This should only impact you when modifying the sidecar container with a container-patch. If you do so, upgrade Kuma and then change your container patch to modify the right container.
 
+### Kumactl
+
+`--valid-for` must be set for all token types, before it was defaulting to 10 years.
 
 ## Upgrade to `2.0.x`
 

--- a/app/kumactl/cmd/generate/generate_dataplane_token.go
+++ b/app/kumactl/cmd/generate/generate_dataplane_token.go
@@ -66,8 +66,6 @@ $ kumactl generate dataplane-token --mesh demo --tag kuma.io/service=web,web-api
 	_ = cmd.Flags().MarkDeprecated("type", "please use --proxy-type instead")
 	cmd.Flags().StringVar(&ctx.args.proxyType, "proxy-type", "", `type of the Dataplane ("dataplane", "ingress")`)
 	cmd.Flags().StringToStringVar(&ctx.args.tags, "tag", nil, "required tag values for dataplane (split values by comma to provide multiple values)")
-	// Backwards compatibility with 1.3.x. Right now we pick 10 years as default, but in the future this should be required argument without default.
-	// https://github.com/kumahq/kuma/issues/4001
-	cmd.Flags().DurationVar(&ctx.args.validFor, "valid-for", 24*time.Hour*365*10, `how long the token will be valid (for example "24h")`)
+	cmd.Flags().DurationVar(&ctx.args.validFor, "valid-for", 0, `how long the token will be valid (for example "24h")`)
 	return cmd
 }

--- a/app/kumactl/cmd/generate/generate_zoneingress_token.go
+++ b/app/kumactl/cmd/generate/generate_zoneingress_token.go
@@ -47,8 +47,6 @@ $ kumactl generate zone-ingress-token --zone zone-1 --valid-for 30d
 		},
 	}
 	cmd.Flags().StringVar(&ctx.args.zone, "zone", "", "name of the zone where ingress resides")
-	// Backwards compatibility with 1.3.x. Right now we pick 10 years as default, but in the future this should be required argument without default.
-	// https://github.com/kumahq/kuma/issues/4001
-	cmd.Flags().DurationVar(&ctx.args.validFor, "valid-for", 24*time.Hour*365*10, `how long the token will be valid (for example "24h")`)
+	cmd.Flags().DurationVar(&ctx.args.validFor, "valid-for", 0, `how long the token will be valid (for example "24h")`)
 	return cmd
 }

--- a/app/kumactl/pkg/tokens/client.go
+++ b/app/kumactl/pkg/tokens/client.go
@@ -31,6 +31,9 @@ type httpDataplaneTokenClient struct {
 var _ DataplaneTokenClient = &httpDataplaneTokenClient{}
 
 func (h *httpDataplaneTokenClient) Generate(name string, mesh string, tags map[string][]string, dpType string, validFor time.Duration) (string, error) {
+	if validFor == 0 {
+		return "", errors.Errorf("You must set a token validFor value")
+	}
 	tokenReq := &types.DataplaneTokenRequest{
 		Name:     name,
 		Mesh:     mesh,

--- a/docs/generated/cmd/kumactl/kumactl_generate_dataplane-token.md
+++ b/docs/generated/cmd/kumactl/kumactl_generate_dataplane-token.md
@@ -36,7 +36,7 @@ $ kumactl generate dataplane-token --mesh demo --tag kuma.io/service=web,web-api
       --name string          name of the Dataplane
       --proxy-type string    type of the Dataplane ("dataplane", "ingress")
       --tag stringToString   required tag values for dataplane (split values by comma to provide multiple values) (default [])
-      --valid-for duration   how long the token will be valid (for example "24h") (default 87600h0m0s)
+      --valid-for duration   how long the token will be valid (for example "24h")
 ```
 
 ### Options inherited from parent commands

--- a/docs/generated/cmd/kumactl/kumactl_generate_zone-ingress-token.md
+++ b/docs/generated/cmd/kumactl/kumactl_generate_zone-ingress-token.md
@@ -26,7 +26,7 @@ $ kumactl generate zone-ingress-token --zone zone-1 --valid-for 30d
 
 ```
   -h, --help                 help for zone-ingress-token
-      --valid-for duration   how long the token will be valid (for example "24h") (default 87600h0m0s)
+      --valid-for duration   how long the token will be valid (for example "24h")
       --zone string          name of the zone where ingress resides
 ```
 

--- a/pkg/plugins/authn/api-server/tokens/ws/server/webservice.go
+++ b/pkg/plugins/authn/api-server/tokens/ws/server/webservice.go
@@ -66,6 +66,9 @@ func (d *userTokenWebService) handleIdentityRequest(request *restful.Request, re
 			verr.AddViolation("validFor", "is invalid: "+err.Error())
 		}
 		validFor = dur
+		if validFor == 0 {
+			verr.AddViolation("validFor", "cannot be empty or nil")
+		}
 	}
 
 	if verr.HasViolations() {

--- a/pkg/plugins/authn/api-server/tokens/ws/ws_test.go
+++ b/pkg/plugins/authn/api-server/tokens/ws/ws_test.go
@@ -65,7 +65,7 @@ var _ = Describe("Auth Tokens WS", func() {
 
 		// wait for the server
 		Eventually(func() error {
-			_, err := userTokenClient.Generate("john.doe@example.com", []string{"team-a"}, 0)
+			_, err := userTokenClient.Generate("john.doe@example.com", []string{"team-a"}, time.Hour)
 			return err
 		}).ShouldNot(HaveOccurred())
 	})
@@ -82,7 +82,7 @@ var _ = Describe("Auth Tokens WS", func() {
 		Expect(u.Groups).To(Equal([]string{"team-a"}))
 	})
 
-	It("should throw an error when zone is not passed", func() {
+	It("should throw an error when name is not passed", func() {
 		// when
 		_, err := userTokenClient.Generate("", nil, 1*time.Hour)
 
@@ -99,7 +99,24 @@ var _ = Describe("Auth Tokens WS", func() {
 		}))
 	})
 
-	It("should throw an validFor is not present", func() {
+	It("should throw an error with 0 for validFor", func() {
+		// when
+		_, err := userTokenClient.Generate("foo@example.com", nil, 0)
+
+		// then
+		Expect(err).To(Equal(&error_types.Error{
+			Title:   "Invalid request",
+			Details: "Resource is not valid",
+			Causes: []error_types.Cause{
+				{
+					Field:   "validFor",
+					Message: "cannot be empty or nil",
+				},
+			},
+		}))
+	})
+
+	It("should throw an error if validFor is not present", func() {
 		// given invalid request (cannot be implemented using UserTokenClient)
 		req, err := http.NewRequest("POST", "/tokens/user", strings.NewReader(`{"name": "xyz"}`))
 		req.Header.Add("content-type", "application/json")


### PR DESCRIPTION
The goal is to have users think about tokens a little more

Fix #4001 

Signed-off-by: Charly Molter <charly.molter@konghq.com>

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] Link to docs PR or issue --
- [x] Link to UI issue or PR --
- [x] Is the [issue worked on linked][1]? --
- [x] The PR does not hardcode values that might break projects that depend on kuma (e.g. "kumahq" as a image registry) --
- [x] The PR will work for both Linux and Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Unit Tests --
- [x] E2E Tests --
- [x] Manual Universal Tests --
- [x] Manual Kubernetes Tests --
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [x] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
