### PR TITLE
chore: unify delete mesh resources

### DIFF
--- a/test/e2e_env/kubernetes/graceful/graceful.go
+++ b/test/e2e_env/kubernetes/graceful/graceful.go
@@ -12,6 +12,7 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/pkg/errors"
 
+	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	"github.com/kumahq/kuma/pkg/util/channels"
 	"github.com/kumahq/kuma/test/e2e_env/kubernetes/env"
 	. "github.com/kumahq/kuma/test/framework"
@@ -126,12 +127,7 @@ spec:
 		}, "60s", "1s").Should(Succeed(), "could not get a LoadBalancer IP of the Gateway")
 
 		// remove retries to avoid covering failed request
-		err = k8s.RunKubectlE(
-			env.Cluster.GetTesting(),
-			env.Cluster.GetKubectlOptions(),
-			"delete", "retry", "retry-all-graceful",
-		)
-		Expect(err).ToNot(HaveOccurred())
+		Expect(DeleteMeshResources(env.Cluster, mesh, core_mesh.RetryResourceTypeDescriptor)).To(Succeed())
 	})
 
 	requestThroughGateway := func() error {

--- a/test/e2e_env/kubernetes/meshcircuitbreaker/api.go
+++ b/test/e2e_env/kubernetes/meshcircuitbreaker/api.go
@@ -7,6 +7,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	"github.com/kumahq/kuma/pkg/plugins/policies/meshcircuitbreaker/api/v1alpha1"
 	"github.com/kumahq/kuma/test/e2e_env/kubernetes/env"
 	. "github.com/kumahq/kuma/test/framework"
 )
@@ -22,16 +23,7 @@ func API() {
 	})
 
 	E2EAfterEach(func() {
-		Expect(
-			k8s.RunKubectlE(
-				env.Cluster.GetTesting(),
-				env.Cluster.GetKubectlOptions(),
-				"delete",
-				"meshcircuitbreaker",
-				"-A",
-				"--all",
-			),
-		).To(Succeed())
+		Expect(DeleteMeshResources(env.Cluster, meshName, v1alpha1.MeshCircuitBreakerResourceTypeDescriptor)).To(Succeed())
 	})
 
 	E2EAfterAll(func() {

--- a/test/e2e_env/kubernetes/meshcircuitbreaker/meshcircuitbreaker.go
+++ b/test/e2e_env/kubernetes/meshcircuitbreaker/meshcircuitbreaker.go
@@ -27,7 +27,7 @@ func MeshCircuitBreaker() {
 			Setup(env.Cluster)
 		Expect(err).ToNot(HaveOccurred())
 
-		Expect(DeleteAllResourcesKubernetes(env.Cluster, mesh,
+		Expect(DeleteMeshResources(env.Cluster, mesh,
 			core_mesh.CircuitBreakerResourceTypeDescriptor,
 			core_mesh.RetryResourceTypeDescriptor,
 			v1alpha1.MeshCircuitBreakerResourceTypeDescriptor,
@@ -35,8 +35,7 @@ func MeshCircuitBreaker() {
 	})
 
 	E2EAfterEach(func() {
-		Expect(DeleteAllResourcesKubernetes(env.Cluster, mesh, v1alpha1.MeshCircuitBreakerResourceTypeDescriptor)).
-			To(Succeed())
+		Expect(DeleteMeshResources(env.Cluster, mesh, v1alpha1.MeshCircuitBreakerResourceTypeDescriptor)).To(Succeed())
 	})
 
 	E2EAfterAll(func() {

--- a/test/e2e_env/kubernetes/meshtimeout/meshtimeout.go
+++ b/test/e2e_env/kubernetes/meshtimeout/meshtimeout.go
@@ -4,10 +4,10 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/gruntwork-io/terratest/modules/k8s"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	"github.com/kumahq/kuma/pkg/plugins/policies/meshtimeout/api/v1alpha1"
 	"github.com/kumahq/kuma/test/e2e_env/kubernetes/env"
 	. "github.com/kumahq/kuma/test/framework"
 	"github.com/kumahq/kuma/test/framework/deployments/testserver"
@@ -32,9 +32,7 @@ func MeshTimeout() {
 	})
 
 	E2EAfterEach(func() {
-		Expect(
-			k8s.RunKubectlE(env.Cluster.GetTesting(), env.Cluster.GetKubectlOptions(), "delete", "meshtimeouts", "-A", "--all"),
-		).To(Succeed())
+		Expect(DeleteMeshResources(env.Cluster, mesh, v1alpha1.MeshTimeoutResourceTypeDescriptor)).To(Succeed())
 	})
 
 	E2EAfterAll(func() {

--- a/test/e2e_env/kubernetes/meshtrafficpermission/api.go
+++ b/test/e2e_env/kubernetes/meshtrafficpermission/api.go
@@ -7,6 +7,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	"github.com/kumahq/kuma/pkg/plugins/policies/meshtrafficpermission/api/v1alpha1"
 	"github.com/kumahq/kuma/test/e2e_env/kubernetes/env"
 	. "github.com/kumahq/kuma/test/framework"
 )
@@ -22,9 +23,7 @@ func API() {
 	})
 
 	E2EAfterEach(func() {
-		Expect(
-			k8s.RunKubectlE(env.Cluster.GetTesting(), env.Cluster.GetKubectlOptions(), "delete", "meshtrafficpermissions", "-A", "--all"),
-		).To(Succeed())
+		Expect(DeleteMeshResources(env.Cluster, meshName, v1alpha1.MeshTrafficPermissionResourceTypeDescriptor)).To(Succeed())
 	})
 
 	E2EAfterAll(func() {

--- a/test/e2e_env/kubernetes/virtualoutbound/virtualoutbound.go
+++ b/test/e2e_env/kubernetes/virtualoutbound/virtualoutbound.go
@@ -1,10 +1,10 @@
 package virtualoutbound
 
 import (
-	"github.com/gruntwork-io/terratest/modules/k8s"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	"github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	"github.com/kumahq/kuma/test/e2e_env/kubernetes/env"
 	. "github.com/kumahq/kuma/test/framework"
 	"github.com/kumahq/kuma/test/framework/deployments/testserver"
@@ -35,12 +35,7 @@ func VirtualOutbound() {
 	})
 
 	BeforeEach(func() {
-		err := k8s.RunKubectlE(
-			env.Cluster.GetTesting(),
-			env.Cluster.GetKubectlOptions(),
-			"delete", "virtualoutbounds", "--all",
-		)
-		Expect(err).ToNot(HaveOccurred())
+		Expect(DeleteMeshResources(env.Cluster, meshName, mesh.VirtualOutboundResourceTypeDescriptor)).To(Succeed())
 	})
 
 	It("simple virtual outbound", func() {

--- a/test/e2e_env/multizone/healthcheck/healthcheck.go
+++ b/test/e2e_env/multizone/healthcheck/healthcheck.go
@@ -20,8 +20,7 @@ func ApplicationOnUniversalClientOnK8s() {
 		err := env.Global.Install(MTLSMeshUniversal(meshName))
 		Expect(err).ToNot(HaveOccurred())
 
-		err = DeleteAllResourcesUniversal(*env.Global.GetKumactlOptions(), mesh.RetryResourceTypeDescriptor, meshName)
-		Expect(err).ToNot(HaveOccurred())
+		Expect(DeleteMeshResources(env.Global, meshName, mesh.RetryResourceTypeDescriptor)).To(Succeed())
 
 		err = NewClusterSetup().
 			Install(NamespaceWithSidecarInjection(namespace)).

--- a/test/e2e_env/multizone/meshtrafficpermission/meshtrafficpermission.go
+++ b/test/e2e_env/multizone/meshtrafficpermission/meshtrafficpermission.go
@@ -42,11 +42,7 @@ func MeshTrafficPermission() {
 	})
 
 	BeforeEach(func() {
-		Expect(DeleteAllResourcesUniversal(
-			*env.Global.GetKumactlOptions(),
-			policies_api.MeshTrafficPermissionResourceTypeDescriptor,
-			meshName),
-		).To(Succeed())
+		Expect(DeleteMeshResources(env.Global, meshName, policies_api.MeshTrafficPermissionResourceTypeDescriptor)).To(Succeed())
 	})
 
 	E2EAfterAll(func() {

--- a/test/e2e_env/multizone/trafficpermission/trafficpermission.go
+++ b/test/e2e_env/multizone/trafficpermission/trafficpermission.go
@@ -40,11 +40,7 @@ func TrafficPermission() {
 	})
 
 	BeforeEach(func() {
-		Expect(DeleteAllResourcesUniversal(
-			*env.Global.GetKumactlOptions(),
-			core_mesh.TrafficPermissionResourceTypeDescriptor,
-			meshName),
-		).To(Succeed())
+		Expect(DeleteMeshResources(env.Global, meshName, core_mesh.TrafficPermissionResourceTypeDescriptor)).To(Succeed())
 	})
 
 	E2EAfterAll(func() {

--- a/test/e2e_env/multizone/trafficroute/trafficroute.go
+++ b/test/e2e_env/multizone/trafficroute/trafficroute.go
@@ -80,11 +80,7 @@ func TrafficRoute() {
 	})
 
 	BeforeEach(func() {
-		Expect(DeleteAllResourcesUniversal(
-			*env.Global.GetKumactlOptions(),
-			mesh.TrafficRouteResourceTypeDescriptor,
-			meshName),
-		).To(Succeed())
+		Expect(DeleteMeshResources(env.Global, meshName, mesh.TrafficRouteResourceTypeDescriptor)).To(Succeed())
 	})
 
 	It("should access all instances of the service", func() {

--- a/test/e2e_env/universal/zoneegress/external_services.go
+++ b/test/e2e_env/universal/zoneegress/external_services.go
@@ -127,8 +127,7 @@ func ExternalServices() {
 
 	Context("Fault Injection", func() {
 		AfterEach(func() {
-			err := DeleteAllResourcesUniversal(*env.Cluster.GetKumactlOptions(), core_mesh.FaultInjectionResourceTypeDescriptor, meshName)
-			Expect(err).ToNot(HaveOccurred())
+			Expect(DeleteMeshResources(env.Cluster, meshName, core_mesh.FaultInjectionResourceTypeDescriptor)).To(Succeed())
 		})
 
 		It("should inject faults for external service", func() {
@@ -162,8 +161,7 @@ conf:
 
 	Context("Rate Limit", func() {
 		AfterEach(func() {
-			err := DeleteAllResourcesUniversal(*env.Cluster.GetKumactlOptions(), core_mesh.RateLimitResourceTypeDescriptor, meshName)
-			Expect(err).ToNot(HaveOccurred())
+			Expect(DeleteMeshResources(env.Cluster, meshName, core_mesh.RateLimitResourceTypeDescriptor)).To(Succeed())
 		})
 
 		It("should rate limit requests to external service", func() {


### PR DESCRIPTION
Unify method to delete all mesh resources for both universal and kubernetes clusters.
Additionally, I replaced usages like this
```
k8s.RunKubectlE(env.Cluster.GetTesting(), env.Cluster.GetKubectlOptions(), "delete", "meshtrafficpermissions", "-A", "--all"),
```
That could create flakiness in other tests because it does not take into account the mesh.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [X] Link to docs PR or issue --
- [X] Link to UI issue or PR --
- [X] Is the [issue worked on linked][1]? --
- [X] The PR does not hardcode values that might break projects that depend on kuma (e.g. "kumahq" as a image registry) --
- [X] The PR will work for both Linux and Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [X] Unit Tests --
- [X] E2E Tests --
- [X] Manual Universal Tests --
- [X] Manual Kubernetes Tests --
- [X] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [X] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [X] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
