### PR TITLE
ci(helm): checkout charts repo before doing anything

### DIFF
--- a/tools/releases/helm.sh
+++ b/tools/releases/helm.sh
@@ -81,6 +81,8 @@ function release {
     [ -z "$GH_REPO_URL" ] && GH_REPO_URL="https://${GH_TOKEN}@github.com/${GH_OWNER}/${GH_REPO}.git"
   fi
 
+  git clone --single-branch --branch "${GH_PAGES_BRANCH}" "$GH_REPO_URL"
+
   # First upload the packaged charts to the release
   cr upload \
     --owner "${GH_OWNER}" \
@@ -89,8 +91,6 @@ function release {
     --package-path "${CHARTS_PACKAGE_PATH}"
 
   # Then build and upload the index file to github pages
-  git clone --single-branch --branch "${GH_PAGES_BRANCH}" "$GH_REPO_URL"
-
   cr index \
     --owner "${GH_OWNER}" \
     --git-repo "${GH_REPO}" \


### PR DESCRIPTION
Less of a chance of getting stuck in an invalid state if the checkout fails.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [ ] Link to docs PR or issue --
- [ ] Link to UI issue or PR --
- [ ] Is the [issue worked on linked][1]? --
- [ ] The PR does not hardcode values that might break projects that depend on kuma (e.g. "kumahq" as a image registry) --
- [ ] The PR will work for both Linux and Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [ ] Unit Tests --
- [ ] E2E Tests --
- [ ] Manual Universal Tests --
- [ ] Manual Kubernetes Tests --
- [ ] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [ ] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [ ] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
