### PR TITLE
ci(e2e): get rid of ExecWithRetry

### DIFF
--- a/mk/e2e.new.mk
+++ b/mk/e2e.new.mk
@@ -32,7 +32,7 @@ UNIVERSAL_E2E_PKG_LIST ?= ./test/e2e_env/universal
 MULTIZONE_E2E_PKG_LIST ?= ./test/e2e_env/multizone
 GINKGO_E2E_TEST_FLAGS ?=
 GINKGO_E2E_LABEL_FILTERS ?=
-GINKGO_TEST_E2E=$(GINKGO_TEST) -v --slow-spec-threshold 30s $(GINKGO_E2E_TEST_FLAGS) --label-filter="$(GINKGO_E2E_LABEL_FILTERS)"
+GINKGO_TEST_E2E=$(GINKGO_TEST) -v $(GINKGO_E2E_TEST_FLAGS) --label-filter="$(GINKGO_E2E_LABEL_FILTERS)"
 
 define append_label_filter
 $(if $(GINKGO_E2E_LABEL_FILTERS),$(GINKGO_E2E_LABEL_FILTERS) && $(1),$(1))

--- a/pkg/test/ginkgo.go
+++ b/pkg/test/ginkgo.go
@@ -1,7 +1,9 @@
 package test
 
 import (
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/go-logr/logr"
 	"github.com/onsi/ginkgo/v2"
@@ -14,6 +16,21 @@ import (
 
 // RunSpecs wraps ginkgo+gomega test suite initialization.
 func RunSpecs(t *testing.T, description string) {
+	if strings.HasPrefix(description, "E2E") {
+		panic("Use RunE2ESpecs for e2e tests!")
+	}
+	runSpecs(t, description)
+}
+
+func RunE2ESpecs(t *testing.T, description string) {
+	gomega.SetDefaultConsistentlyDuration(time.Second * 5)
+	gomega.SetDefaultConsistentlyPollingInterval(time.Millisecond * 200)
+	gomega.SetDefaultEventuallyPollingInterval(time.Millisecond * 500)
+	gomega.SetDefaultEventuallyTimeout(time.Second * 30)
+	runSpecs(t, description)
+}
+
+func runSpecs(t *testing.T, description string) {
 	// Make resetting the core logger a no-op so that internal
 	// code doesn't interfere with testing.
 	core.SetLogger = func(l logr.Logger) {}

--- a/test/e2e/cni/e2e_suite_test.go
+++ b/test/e2e/cni/e2e_suite_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestE2E(t *testing.T) {
-	test.RunSpecs(t, "E2E CNI Suite")
+	test.RunE2ESpecs(t, "E2E CNI Suite")
 }
 
 var _ = Describe("Taint controller", Label("job-0"), Label("kind-not-supported"), Label("legacy-k3s-not-supported"), cni.AppDeploymentWithCniAndTaintController)

--- a/test/e2e/cni/taint_controller_race.go
+++ b/test/e2e/cni/taint_controller_race.go
@@ -88,19 +88,19 @@ metadata:
 			Expect(err).ToNot(HaveOccurred())
 
 			Eventually(func() (string, error) {
-				_, stderr, err := cluster.ExecWithRetries(TestNamespace, clientPodName, "demo-client",
+				_, stderr, err := cluster.Exec(TestNamespace, clientPodName, "demo-client",
 					"curl", "-v", "-m", "3", "--fail", "test-server")
 				return stderr, err
 			}, "10s", "1s").Should(ContainSubstring("HTTP/1.1 200 OK"))
 
 			Eventually(func() (string, error) {
-				_, stderr, err := cluster.ExecWithRetries(TestNamespace, clientPodName, "demo-client",
+				_, stderr, err := cluster.Exec(TestNamespace, clientPodName, "demo-client",
 					"curl", "-v", "-m", "3", "--fail", "test-server_kuma-test_svc_80.mesh")
 				return stderr, err
 			}, "10s", "1s").Should(ContainSubstring("HTTP/1.1 200 OK"))
 
 			Eventually(func() (string, error) { // should access a service with . instead of _
-				_, stderr, err := cluster.ExecWithRetries(TestNamespace, clientPodName, "demo-client",
+				_, stderr, err := cluster.Exec(TestNamespace, clientPodName, "demo-client",
 					"curl", "-v", "-m", "3", "--fail", "test-server.kuma-test.svc.80.mesh")
 				return stderr, err
 			}, "10s", "1s").Should(ContainSubstring("HTTP/1.1 200 OK"))

--- a/test/e2e/compatibility/dp_compatibility_universal.go
+++ b/test/e2e/compatibility/dp_compatibility_universal.go
@@ -1,12 +1,12 @@
 package compatibility
 
 import (
-	"github.com/gruntwork-io/terratest/modules/retry"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
 	"github.com/kumahq/kuma/pkg/config/core"
 	. "github.com/kumahq/kuma/test/framework"
+	. "github.com/kumahq/kuma/test/framework/client"
 )
 
 func UniversalCompatibility() {
@@ -33,9 +33,9 @@ func UniversalCompatibility() {
 	})
 
 	It("client should access server", func() {
-		retry.DoWithRetry(cluster.GetTesting(), "check communication between services", DefaultRetries, DefaultTimeout, func() (string, error) {
-			_, _, err := cluster.Exec("", "", "demo-client", "curl", "-v", "-m", "3", "--fail", "test-server.mesh")
-			return "", err
-		})
+		Eventually(func(g Gomega) {
+			_, err := CollectResponse(cluster, "demo-client", "test-server.mesh")
+			g.Expect(err).ToNot(HaveOccurred())
+		}, "20s", "250ms").Should(Succeed())
 	})
 }

--- a/test/e2e/compatibility/e2e_suite_test.go
+++ b/test/e2e/compatibility/e2e_suite_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestE2E(t *testing.T) {
-	test.RunSpecs(t, "E2E Compatibility Suite")
+	test.RunE2ESpecs(t, "E2E Compatibility Suite")
 }
 
 var _ = Describe("Test Kubernetes Multizone Compatibility", Label("job-1"), Label("arm-not-supported"), compatibility.CpCompatibilityMultizoneKubernetes)

--- a/test/e2e/deploy/e2e_suite_test.go
+++ b/test/e2e/deploy/e2e_suite_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestE2E(t *testing.T) {
-	test.RunSpecs(t, "E2E Deploy Suite")
+	test.RunE2ESpecs(t, "E2E Deploy Suite")
 }
 
 var _ = Describe("Test Universal deployment", Label("job-1"), deploy.UniversalDeployment)

--- a/test/e2e/ebpf/e2e_suite_test.go
+++ b/test/e2e/ebpf/e2e_suite_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestE2E(t *testing.T) {
-	test.RunSpecs(t, "E2E Ebpf Suite")
+	test.RunE2ESpecs(t, "E2E Ebpf Suite")
 }
 
 var _ = Describe("Test Cleanup eBPF", Label("job-0"), Label("arm-not-supported"), Label("legacy-k3s-not-supported"), ebpf.CleanupEbpfConfigFromNode, Ordered)

--- a/test/e2e/ebpf/ebpf_cleanup.go
+++ b/test/e2e/ebpf/ebpf_cleanup.go
@@ -24,19 +24,17 @@ func CleanupEbpfConfigFromNode() {
 	}
 
 	var cluster Cluster
-	var k8sCluster *K8sCluster
 	releaseName := fmt.Sprintf(
 		"kuma-%s",
 		strings.ToLower(random.UniqueId()),
 	)
 
 	BeforeAll(func() {
-		k8sCluster = NewK8sCluster(NewTestingT(), Kuma1, Silent)
-		cluster = k8sCluster.
+		cluster = NewK8sCluster(NewTestingT(), Kuma1, Silent).
 			WithTimeout(6 * time.Second).
 			WithRetries(60)
 
-		Expect(NewClusterSetup().
+		err := NewClusterSetup().
 			Install(Kuma(core.Standalone,
 				WithInstallationMode(HelmInstallationMode),
 				WithHelmReleaseName(releaseName),
@@ -50,8 +48,9 @@ func CleanupEbpfConfigFromNode() {
 			Install(ebpf_checker.Install(
 				ebpf_checker.WithNamespace(TestNamespace),
 				ebpf_checker.WithoutSidecar(),
-			)).
-			Setup(cluster)).ToNot(HaveOccurred())
+			)).Setup(cluster)
+
+		Expect(err).ToNot(HaveOccurred())
 	})
 
 	AfterAll(func() {

--- a/test/e2e/externalservices/e2e_suite_test.go
+++ b/test/e2e/externalservices/e2e_suite_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestE2E(t *testing.T) {
-	test.RunSpecs(t, "E2E External Services Suite")
+	test.RunE2ESpecs(t, "E2E External Services Suite")
 }
 
 var _ = Describe("Test ExternalServices on Kubernetes without Egress", Label("job-4"), externalservices.ExternalServicesOnKubernetesWithoutEgress)

--- a/test/e2e/externalservices/externalservices_kubernetes_without_egress.go
+++ b/test/e2e/externalservices/externalservices_kubernetes_without_egress.go
@@ -98,20 +98,24 @@ spec:
 		Expect(err).ToNot(HaveOccurred())
 
 		// then communication outside of the Mesh works
-		_, stderr, err := cluster.ExecWithRetries(TestNamespace, clientPodName, "demo-client",
-			"curl", "-v", "-m", "3", "--fail", "http://externalservice-http-server.externalservice-namespace:10080")
-		Expect(err).ToNot(HaveOccurred())
-		Expect(stderr).To(ContainSubstring("HTTP/1.1 200 OK"))
+		Eventually(func(g Gomega) {
+			_, stderr, err := cluster.Exec(TestNamespace, clientPodName, "demo-client",
+				"curl", "-v", "-m", "3", "--fail", "http://externalservice-http-server.externalservice-namespace:10080")
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(stderr).To(ContainSubstring("HTTP/1.1 200 OK"))
+		}, "1m", "3s").Should(Succeed())
 
 		// when passthrough is disabled on the Mesh and no egress
 		err = YamlK8s(fmt.Sprintf(meshDefaulMtlsOn, "false", "false"))(cluster)
 		Expect(err).ToNot(HaveOccurred())
 
 		// then communication outside of the Mesh works
-		_, stderr, err = cluster.ExecWithRetries(TestNamespace, clientPodName, "demo-client",
-			"curl", "-v", "-m", "3", "--fail", "http://externalservice-http-server.externalservice-namespace:10080")
-		Expect(err).ToNot(HaveOccurred())
-		Expect(stderr).To(ContainSubstring("HTTP/1.1 200 OK"))
+		Eventually(func(g Gomega) {
+			_, stderr, err := cluster.Exec(TestNamespace, clientPodName, "demo-client",
+				"curl", "-v", "-m", "3", "--fail", "http://externalservice-http-server.externalservice-namespace:10080")
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(stderr).To(ContainSubstring("HTTP/1.1 200 OK"))
+		}, "1m", "3s").Should(Succeed())
 
 		// when apply external service
 		err = YamlK8s(fmt.Sprintf(externalService,

--- a/test/e2e/externalservices/externalservices_multizone_universal.go
+++ b/test/e2e/externalservices/externalservices_multizone_universal.go
@@ -139,29 +139,37 @@ routing:
 		err := ResourceUniversal(externalServiceRes(es1, "kuma-3_externalservice-http-server:80", false, nil))(global)
 		Expect(err).ToNot(HaveOccurred())
 
-		stdout, _, err := zone1.ExecWithRetries("", "", "demo-client",
-			"curl", "-v", "-m", "3", "--fail", "external-service-1.mesh")
-		Expect(err).ToNot(HaveOccurred())
-		Expect(stdout).To(ContainSubstring("HTTP/1.1 200 OK"))
-		Expect(stdout).ToNot(ContainSubstring("HTTPS"))
+		Eventually(func(g Gomega) {
+			stdout, _, err := zone1.Exec("", "", "demo-client",
+				"curl", "-v", "-m", "3", "--fail", "external-service-1.mesh")
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(stdout).To(ContainSubstring("HTTP/1.1 200 OK"))
+			g.Expect(stdout).ToNot(ContainSubstring("HTTPS"))
+		}, "1m", "3s").Should(Succeed())
 
-		stdout, _, err = zone1.ExecWithRetries("", "", "demo-client",
-			"curl", "-v", "-m", "3", "--fail", "kuma-3_externalservice-http-server:80")
-		Expect(err).ToNot(HaveOccurred())
-		Expect(stdout).To(ContainSubstring("HTTP/1.1 200 OK"))
-		Expect(stdout).ToNot(ContainSubstring("HTTPS"))
+		Eventually(func(g Gomega) {
+			stdout, _, err := zone1.Exec("", "", "demo-client",
+				"curl", "-v", "-m", "3", "--fail", "kuma-3_externalservice-http-server:80")
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(stdout).To(ContainSubstring("HTTP/1.1 200 OK"))
+			g.Expect(stdout).ToNot(ContainSubstring("HTTPS"))
+		}, "1m", "3s").Should(Succeed())
 
-		stdout, _, err = zone2.ExecWithRetries("", "", "demo-client",
-			"curl", "-v", "-m", "3", "--fail", "external-service-1.mesh")
-		Expect(err).ToNot(HaveOccurred())
-		Expect(stdout).To(ContainSubstring("HTTP/1.1 200 OK"))
-		Expect(stdout).ToNot(ContainSubstring("HTTPS"))
+		Eventually(func(g Gomega) {
+			stdout, _, err := zone2.Exec("", "", "demo-client",
+				"curl", "-v", "-m", "3", "--fail", "external-service-1.mesh")
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(stdout).To(ContainSubstring("HTTP/1.1 200 OK"))
+			g.Expect(stdout).ToNot(ContainSubstring("HTTPS"))
+		}, "1m", "3s").Should(Succeed())
 
-		stdout, _, err = zone2.ExecWithRetries("", "", "demo-client",
-			"curl", "-v", "-m", "3", "--fail", "kuma-3_externalservice-http-server:80")
-		Expect(err).ToNot(HaveOccurred())
-		Expect(stdout).To(ContainSubstring("HTTP/1.1 200 OK"))
-		Expect(stdout).ToNot(ContainSubstring("HTTPS"))
+		Eventually(func(g Gomega) {
+			stdout, _, err := zone2.Exec("", "", "demo-client",
+				"curl", "-v", "-m", "3", "--fail", "kuma-3_externalservice-http-server:80")
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(stdout).To(ContainSubstring("HTTP/1.1 200 OK"))
+			g.Expect(stdout).ToNot(ContainSubstring("HTTPS"))
+		}, "1m", "3s").Should(Succeed())
 	})
 
 	It("should route to external-service over tls", func() {
@@ -172,9 +180,11 @@ routing:
 		Expect(err).ToNot(HaveOccurred())
 
 		// then accessing the secured external service fails
-		_, _, err = zone1.ExecWithRetries("", "", "demo-client",
-			"curl", "-v", "-m", "3", "--fail", "http://kuma-3_externalservice-https-server:443")
-		Expect(err).To(HaveOccurred())
+		Eventually(func(g Gomega) {
+			_, _, err = zone1.Exec("", "", "demo-client",
+				"curl", "-v", "-m", "3", "--fail", "http://kuma-3_externalservice-https-server:443")
+			g.Expect(err).To(HaveOccurred())
+		}, "1m", "3s").Should(Succeed())
 
 		// when set proper certificate
 		externalServiceCaCert := externalservice.From(external, externalservice.HttpsServer).GetCert()
@@ -184,17 +194,21 @@ routing:
 		Expect(err).ToNot(HaveOccurred())
 
 		// then accessing the secured external service succeeds
-		stdout, _, err := zone1.ExecWithRetries("", "", "demo-client",
-			"curl", "-v", "-m", "3", "--fail", "http://kuma-3_externalservice-https-server:443")
-		Expect(err).ToNot(HaveOccurred())
-		Expect(stdout).To(ContainSubstring("HTTP/1.1 200 OK"))
-		Expect(stdout).To(ContainSubstring("HTTPS"))
+		Eventually(func(g Gomega) {
+			stdout, _, err := zone1.Exec("", "", "demo-client",
+				"curl", "-v", "-m", "3", "--fail", "http://kuma-3_externalservice-https-server:443")
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(stdout).To(ContainSubstring("HTTP/1.1 200 OK"))
+			g.Expect(stdout).To(ContainSubstring("HTTPS"))
+		}, "1m", "3s").Should(Succeed())
 
-		stdout, _, err = zone2.ExecWithRetries("", "", "demo-client",
-			"curl", "-v", "-m", "3", "--fail", "http://kuma-3_externalservice-https-server:443")
-		Expect(err).ToNot(HaveOccurred())
-		Expect(stdout).To(ContainSubstring("HTTP/1.1 200 OK"))
-		Expect(stdout).To(ContainSubstring("HTTPS"))
+		Eventually(func(g Gomega) {
+			stdout, _, err := zone2.Exec("", "", "demo-client",
+				"curl", "-v", "-m", "3", "--fail", "http://kuma-3_externalservice-https-server:443")
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(stdout).To(ContainSubstring("HTTP/1.1 200 OK"))
+			g.Expect(stdout).To(ContainSubstring("HTTPS"))
+		}, "1m", "3s").Should(Succeed())
 	})
 
 	It("should respect external-service's zone tag in locality-aware lb mode", func() {

--- a/test/e2e/externalservices/localityawarelb_multizone/e2e_suite_test.go
+++ b/test/e2e/externalservices/localityawarelb_multizone/e2e_suite_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestE2E(t *testing.T) {
-	test.RunSpecs(t, "E2E External Services Locality Hybrid Suite")
+	test.RunE2ESpecs(t, "E2E External Services Locality Hybrid Suite")
 }
 
 var _ = Describe("Test ExternalServices on Multizone Hybrid with LocalityAwareLb", Label("job-2"), localityawarelb_multizone.ExternalServicesOnMultizoneHybridWithLocalityAwareLb, Ordered)

--- a/test/e2e/gateway/e2e_suite_test.go
+++ b/test/e2e/gateway/e2e_suite_test.go
@@ -7,5 +7,5 @@ import (
 )
 
 func TestE2E(t *testing.T) {
-	test.RunSpecs(t, "E2E Gateway Suite")
+	test.RunE2ESpecs(t, "E2E Gateway Suite")
 }

--- a/test/e2e/gateway/gatewayapi/gatewayapi_suite_test.go
+++ b/test/e2e/gateway/gatewayapi/gatewayapi_suite_test.go
@@ -7,5 +7,5 @@ import (
 )
 
 func TestE2E(t *testing.T) {
-	test.RunSpecs(t, "E2E Gateway API Suite")
+	test.RunE2ESpecs(t, "E2E Gateway API Suite")
 }

--- a/test/e2e/helm/e2e_suite_test.go
+++ b/test/e2e/helm/e2e_suite_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestE2E(t *testing.T) {
-	test.RunSpecs(t, "E2E Helm Suite")
+	test.RunE2ESpecs(t, "E2E Helm Suite")
 }
 
 var _ = Describe("Test Zone and Global with Helm chart", Label("job-3"), Label("arm-not-supported"), helm.ZoneAndGlobalWithHelmChart, Ordered)

--- a/test/e2e/helm/kuma_helm_deploy_global_zone.go
+++ b/test/e2e/helm/kuma_helm_deploy_global_zone.go
@@ -103,7 +103,7 @@ interCp:
 				return false, nil
 			}
 			return clustersStatus[0].Active, nil
-		}, time.Minute, DefaultTimeout).Should(BeTrue())
+		}, "1m", "1s").Should(BeTrue())
 
 		// then
 		active := true

--- a/test/e2e/helm/kuma_helm_deploy_multi_apps.go
+++ b/test/e2e/helm/kuma_helm_deploy_multi_apps.go
@@ -58,20 +58,26 @@ func AppDeploymentWithHelmChart() {
 			clientPodName, err := PodNameOfApp(cluster, "demo-client", TestNamespace)
 			Expect(err).ToNot(HaveOccurred())
 
-			_, stderr, err := cluster.ExecWithRetries(TestNamespace, clientPodName, "demo-client",
-				"curl", "-v", "-m", "3", "--fail", "test-server")
-			Expect(err).ToNot(HaveOccurred())
-			Expect(stderr).To(ContainSubstring("HTTP/1.1 200 OK"))
+			Eventually(func(g Gomega) {
+				_, stderr, err := cluster.Exec(TestNamespace, clientPodName, "demo-client",
+					"curl", "-v", "-m", "3", "--fail", "test-server")
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(stderr).To(ContainSubstring("HTTP/1.1 200 OK"))
+			}).Should(Succeed())
 
-			_, stderr, err = cluster.ExecWithRetries(TestNamespace, clientPodName, "demo-client",
-				"curl", "-v", "-m", "3", "--fail", "test-server_kuma-test_svc_80.mesh")
-			Expect(err).ToNot(HaveOccurred())
-			Expect(stderr).To(ContainSubstring("HTTP/1.1 200 OK"))
+			Eventually(func(g Gomega) {
+				_, stderr, err := cluster.Exec(TestNamespace, clientPodName, "demo-client",
+					"curl", "-v", "-m", "3", "--fail", "test-server_kuma-test_svc_80.mesh")
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(stderr).To(ContainSubstring("HTTP/1.1 200 OK"))
+			}).Should(Succeed())
 
-			_, stderr, err = cluster.ExecWithRetries(TestNamespace, clientPodName, "demo-client",
-				"curl", "-v", "-m", "3", "--fail", "test-server.kuma-test.svc.80.mesh")
-			Expect(err).ToNot(HaveOccurred())
-			Expect(stderr).To(ContainSubstring("HTTP/1.1 200 OK"))
+			Eventually(func(g Gomega) {
+				_, stderr, err := cluster.Exec(TestNamespace, clientPodName, "demo-client",
+					"curl", "-v", "-m", "3", "--fail", "test-server.kuma-test.svc.80.mesh")
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(stderr).To(ContainSubstring("HTTP/1.1 200 OK"))
+			}).Should(Succeed())
 		},
 		Entry("with default cni", WithCNI()),
 		Entry("with new cni (experimental)", WithExperimentalCNI()),

--- a/test/e2e/ownership/e2e_suite_test.go
+++ b/test/e2e/ownership/e2e_suite_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestE2E(t *testing.T) {
-	test.RunSpecs(t, "E2E Ownership tests")
+	test.RunE2ESpecs(t, "E2E Ownership tests")
 }
 
 var _ = Describe("Test Multizone Ownership for Universal", Label("job-1"), ownership.MultizoneUniversal)

--- a/test/e2e/ownership/multizone_universal.go
+++ b/test/e2e/ownership/multizone_universal.go
@@ -50,7 +50,7 @@ func MultizoneUniversal() {
 	has := func(resourceURI string) func() bool {
 		return func() bool {
 			cmd := []string{"curl", "-v", "-m", "3", "--fail", "localhost:5681/" + resourceURI}
-			stdout, _, err := global.ExecWithRetries("", "", AppModeCP, cmd...)
+			stdout, _, err := global.Exec("", "", AppModeCP, cmd...)
 			Expect(err).ToNot(HaveOccurred())
 			return strings.Contains(stdout, `"total": 1`)
 		}

--- a/test/e2e/projectedsatoken/e2e_suite_test.go
+++ b/test/e2e/projectedsatoken/e2e_suite_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestE2E(t *testing.T) {
-	test.RunSpecs(t, "E2E Projected SAT")
+	test.RunE2ESpecs(t, "E2E Projected SAT")
 }
 
 var _ = Describe("Test Projected Service Account Token on Universal", Label("job-0"), projectedsatoken.ProjectedServiceAccountToken)

--- a/test/e2e/resilience/e2e_suite_test.go
+++ b/test/e2e/resilience/e2e_suite_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestE2E(t *testing.T) {
-	test.RunSpecs(t, "E2E Resilience Suite")
+	test.RunE2ESpecs(t, "E2E Resilience Suite")
 }
 
 var _ = Describe("Test Leader Election with Postgres", Label("job-4"), resilience.LeaderElectionPostgres)

--- a/test/e2e/trafficpermission/kubernetes/e2e_suite_test.go
+++ b/test/e2e/trafficpermission/kubernetes/e2e_suite_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestE2E(t *testing.T) {
-	test.RunSpecs(t, "E2E Traffic Permission Kubernetes Suite")
+	test.RunE2ESpecs(t, "E2E Traffic Permission Kubernetes Suite")
 }
 
 var _ = Describe("Traffic Permission on Kubernetes", Label("job-2"), kubernetes.TrafficPermission)

--- a/test/e2e/virtualoutbound/e2e_suite_test.go
+++ b/test/e2e/virtualoutbound/e2e_suite_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestE2E(t *testing.T) {
-	test.RunSpecs(t, "E2E VirtualOutbound Suite")
+	test.RunE2ESpecs(t, "E2E VirtualOutbound Suite")
 }
 
 var _ = Describe("Test VirtualOutbound on K8s", Label("job-1"), virtualoutbound.VirtualOutboundOnK8s)

--- a/test/e2e/virtualoutbound/virtualoutbound_k8s.go
+++ b/test/e2e/virtualoutbound/virtualoutbound_k8s.go
@@ -6,6 +6,7 @@ import (
 
 	config_core "github.com/kumahq/kuma/pkg/config/core"
 	. "github.com/kumahq/kuma/test/framework"
+	. "github.com/kumahq/kuma/test/framework/client"
 	"github.com/kumahq/kuma/test/framework/deployments/testserver"
 )
 
@@ -52,20 +53,22 @@ spec:
 `
 		err := YamlK8s(virtualOutboundAll)(k8sCluster)
 		Expect(err).ToNot(HaveOccurred())
-		// when client sends requests to server
-		clientPodName, err := PodNameOfApp(k8sCluster, "demo-client", TestNamespace)
-		Expect(err).ToNot(HaveOccurred())
 
 		// Succeed with virtual-outbound
-		stdout, stderr, err := k8sCluster.ExecWithRetries(TestNamespace, clientPodName, "demo-client",
-			"curl", "-v", "-m", "3", "--fail", "test-server_kuma-test_svc_80.foo:8080")
-		Expect(err).ToNot(HaveOccurred())
-		Expect(stderr).To(ContainSubstring("HTTP/1.1 200 OK"))
-		Expect(stdout).To(ContainSubstring(`"instance":"test-server`))
+		Eventually(func(g Gomega) {
+			res, err := CollectResponse(k8sCluster, "demo-client", "test-server_kuma-test_svc_80.foo:8080",
+				FromKubernetesPod(TestNamespace, "demo-client"),
+			)
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(res.Instance).To(Or(Equal("test-server-1"), Equal("test-server-0")))
+		}, "30s", "1s").Should(Succeed())
 
 		// Fails with built in vip (it's disabled in conf)
-		_, _, err = k8sCluster.Exec(TestNamespace, clientPodName, "demo-client",
-			"curl", "-v", "-m", "3", "--fail", "test-server_kuma-test_svc_80.mesh:80")
-		Expect(err).To(HaveOccurred())
+		Consistently(func(g Gomega) {
+			_, err := CollectResponse(k8sCluster, "demo-client", "test-server_kuma-test_svc_80.mesh:80",
+				FromKubernetesPod(TestNamespace, "demo-client"),
+			)
+			g.Expect(err).To(HaveOccurred())
+		}, "2s", "250ms").Should(Succeed())
 	})
 }

--- a/test/e2e/zoneegress/externalservices/e2e_suite_test.go
+++ b/test/e2e/zoneegress/externalservices/e2e_suite_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestE2E(t *testing.T) {
-	test.RunSpecs(t, "E2E ZoneEgress for ExternalServices Suite")
+	test.RunE2ESpecs(t, "E2E ZoneEgress for ExternalServices Suite")
 }
 
 // arm-not-supported because of https://github.com/kumahq/kuma/issues/4822

--- a/test/e2e/zoneegress/externalservices/zoneegress_externalservices_universal.go
+++ b/test/e2e/zoneegress/externalservices/zoneegress_externalservices_universal.go
@@ -91,10 +91,12 @@ networking:
 		Expect(err).ToNot(HaveOccurred())
 
 		// then should reach external service
-		stdout, _, err := cluster.ExecWithRetries("", "", "demo-client",
-			"curl", "--verbose", "--max-time", "3", "--fail", "external-service-1.mesh")
-		Expect(err).ToNot(HaveOccurred())
-		Expect(stdout).To(ContainSubstring("HTTP/1.1 200 OK"))
+		Eventually(func(g Gomega) {
+			stdout, _, err := cluster.Exec("", "", "demo-client",
+				"curl", "--verbose", "--max-time", "3", "--fail", "external-service-1.mesh")
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(stdout).To(ContainSubstring("HTTP/1.1 200 OK"))
+		}, "30s", "1s").Should(Succeed())
 
 		// and increase stats at egress
 		Eventually(func(g Gomega) {

--- a/test/e2e_env/kubernetes/externalservices/externalservices.go
+++ b/test/e2e_env/kubernetes/externalservices/externalservices.go
@@ -106,10 +106,12 @@ spec:
 
 		It("should route to external-service", func() {
 			// given working communication outside of the mesh with passthrough enabled and no traffic permission
-			_, stderr, err := env.Cluster.ExecWithRetries(clientNamespace, clientPodName, "demo-client",
-				"curl", "-v", "-m", "3", "--fail", "http://external-service.external-services:80")
-			Expect(err).ToNot(HaveOccurred())
-			Expect(stderr).To(ContainSubstring("HTTP/1.1 200 OK"))
+			Eventually(func(g Gomega) {
+				_, stderr, err := env.Cluster.Exec(clientNamespace, clientPodName, "demo-client",
+					"curl", "-v", "-m", "3", "--fail", "http://external-service.external-services:80")
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(stderr).To(ContainSubstring("HTTP/1.1 200 OK"))
+			}).Should(Succeed())
 
 			// when passthrough is disabled on the Mesh
 			Expect(env.Cluster.Install(YamlK8s(meshPassthroughDisabled))).To(Succeed())
@@ -127,16 +129,20 @@ spec:
 			Expect(env.Cluster.Install(YamlK8s(trafficPermission))).To(Succeed())
 
 			// then you can access external service again
-			_, stderr, err = env.Cluster.ExecWithRetries(clientNamespace, clientPodName, "demo-client",
-				"curl", "-v", "-m", "3", "--fail", "http://external-service.external-services:80")
-			Expect(err).ToNot(HaveOccurred())
-			Expect(stderr).To(ContainSubstring("HTTP/1.1 200 OK"))
+			Eventually(func(g Gomega) {
+				_, stderr, err := env.Cluster.Exec(clientNamespace, clientPodName, "demo-client",
+					"curl", "-v", "-m", "3", "--fail", "http://external-service.external-services:80")
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(stderr).To(ContainSubstring("HTTP/1.1 200 OK"))
+			}).Should(Succeed())
 
 			// and you can also use .mesh on port of the provided host
-			_, stderr, err = env.Cluster.ExecWithRetries(clientNamespace, clientPodName, "demo-client",
-				"curl", "-v", "-m", "3", "--fail", "http://external-service.mesh:80")
-			Expect(err).ToNot(HaveOccurred())
-			Expect(stderr).To(ContainSubstring("HTTP/1.1 200 OK"))
+			Eventually(func(g Gomega) {
+				_, stderr, err := env.Cluster.Exec(clientNamespace, clientPodName, "demo-client",
+					"curl", "-v", "-m", "3", "--fail", "http://external-service.mesh:80")
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(stderr).To(ContainSubstring("HTTP/1.1 200 OK"))
+			}).Should(Succeed())
 		})
 	})
 
@@ -187,10 +193,12 @@ spec:
 		})
 
 		It("should access tls external service", func() {
-			_, stderr, err := env.Cluster.ExecWithRetries(clientNamespace, clientPodName, "demo-client",
-				"curl", "-v", "-m", "3", "--fail", "http://tls-external-service.mesh:80")
-			Expect(err).ToNot(HaveOccurred())
-			Expect(stderr).To(ContainSubstring("HTTP/1.1 200 OK"))
+			Eventually(func(g Gomega) {
+				_, stderr, err := env.Cluster.Exec(clientNamespace, clientPodName, "demo-client",
+					"curl", "-v", "-m", "3", "--fail", "http://tls-external-service.mesh:80")
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(stderr).To(ContainSubstring("HTTP/1.1 200 OK"))
+			}).Should(Succeed())
 		})
 	})
 }

--- a/test/e2e_env/kubernetes/gateway/cross-mesh.go
+++ b/test/e2e_env/kubernetes/gateway/cross-mesh.go
@@ -159,20 +159,20 @@ func CrossMeshGatewayOnKubernetes() {
 
 		It("should proxy HTTP requests from a different mesh", func() {
 			gatewayAddr := net.JoinHostPort(crossMeshHostname, strconv.Itoa(crossMeshGatewayPort))
-			SuccessfullyProxyRequestToGateway(
+			Eventually(SuccessfullyProxyRequestToGateway(
 				env.Cluster, gatewayMesh,
 				gatewayAddr,
 				gatewayClientNamespaceOtherMesh,
-			)
+			), "1m", "1s").Should(Succeed())
 		})
 
 		It("should proxy HTTP requests from the same mesh", func() {
 			gatewayAddr := net.JoinHostPort(crossMeshHostname, strconv.Itoa(crossMeshGatewayPort))
-			SuccessfullyProxyRequestToGateway(
+			Eventually(SuccessfullyProxyRequestToGateway(
 				env.Cluster, gatewayMesh,
 				gatewayAddr,
 				gatewayClientNamespaceSameMesh,
-			)
+			), "1m", "1s").Should(Succeed())
 		})
 
 		It("doesn't allow HTTP requests from outside the mesh", func() {
@@ -181,19 +181,19 @@ func CrossMeshGatewayOnKubernetes() {
 				env.Cluster,
 				gatewayAddr,
 				gatewayClientOutsideMesh,
-			), "10s", "1s").Should(Succeed())
+			), "1m", "1s").Should(Succeed())
 		})
 
-		Specify("HTTP requests to a non-crossMesh gateway should still be proxied", func() {
+		It("HTTP requests to a non-crossMesh gateway should still be proxied", func() {
 			gatewayAddr := gatewayAddress(edgeGatewayName, gatewayTestNamespace, edgeGatewayPort)
-			SuccessfullyProxyRequestToGateway(
+			Eventually(SuccessfullyProxyRequestToGateway(
 				env.Cluster, gatewayOtherMesh,
 				gatewayAddr,
 				gatewayClientNamespaceOtherMesh,
-			)
+			)).Should(Succeed())
 		})
 
-		Specify("doesn't break when two cross-mesh gateways exist with the same service value", func() {
+		It("doesn't break when two cross-mesh gateways exist with the same service value", func() {
 			const gatewayMesh2 = "cross-mesh-gateway2"
 			crossMeshGatewayYaml2 := mkGateway(
 				crossMeshGatewayName+"2", crossMeshGatewayName, gatewayMesh2, true, "gateway2.mesh", echoServerService(gatewayMesh2, gatewayTestNamespace), crossMeshGatewayPort,
@@ -294,11 +294,11 @@ spec:
 		})
 		It("should proxy HTTP requests from a different mesh", func() {
 			gatewayAddr := net.JoinHostPort(crossMeshHostname, strconv.Itoa(crossMeshGatewayPort))
-			SuccessfullyProxyRequestToGateway(
+			Eventually(SuccessfullyProxyRequestToGateway(
 				env.Cluster, gatewayMesh,
 				gatewayAddr,
 				gatewayClientNamespaceOtherMesh,
-			)
+			), "1m", "1s").Should(Succeed())
 		})
 	})
 }

--- a/test/e2e_env/kubernetes/gateway/gatewayapi.go
+++ b/test/e2e_env/kubernetes/gateway/gatewayapi.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"io"
 	"net"
-	"runtime"
 
 	"github.com/gruntwork-io/terratest/modules/k8s"
 	. "github.com/onsi/ginkgo/v2"
@@ -19,10 +18,6 @@ import (
 func GatewayAPI() {
 	if Config.IPV6 {
 		fmt.Println("IPv6 tests use kind which doesn't support the LoadBalancer ServiceType")
-		return
-	}
-	if runtime.GOARCH == "arm64" {
-		fmt.Println("The webhook doesn't provide an arm64 image")
 		return
 	}
 

--- a/test/e2e_env/kubernetes/gateway/resources.go
+++ b/test/e2e_env/kubernetes/gateway/resources.go
@@ -127,8 +127,6 @@ spec:
 			CaptureStdout:      true,
 			CaptureStderr:      true,
 			PreserveWhitespace: false,
-			Retries:            DefaultRetries,
-			Timeout:            DefaultTimeout,
 		})
 	}
 
@@ -149,6 +147,14 @@ spec:
 
 		go keepConnectionOpen()
 
+		Eventually(func(g Gomega) {
+			_, err := client.CollectResponse(
+				env.Cluster, "demo-client", target,
+				client.FromKubernetesPod(curlingClientNamespace, "demo-client"),
+			)
+
+			g.Expect(err).ToNot(HaveOccurred())
+		}).Should(Succeed())
 		Consistently(func(g Gomega) {
 			response, err := client.CollectResponse(
 				env.Cluster, "demo-client", target,

--- a/test/e2e_env/kubernetes/gateway/utils.go
+++ b/test/e2e_env/kubernetes/gateway/utils.go
@@ -25,19 +25,20 @@ func GatewayAPICRDs(cluster Cluster) error {
 		"apply", "-f", "https://github.com/kubernetes-sigs/gateway-api/releases/download/v0.5.1/experimental-install.yaml")
 }
 
-func SuccessfullyProxyRequestToGateway(cluster Cluster, instance string, gatewayAddr string, namespace string) {
-	Logf("expecting 200 response from %q", gatewayAddr)
-	target := fmt.Sprintf("http://%s/%s",
-		gatewayAddr, path.Join("test", url.PathEscape(GinkgoT().Name())),
-	)
+func SuccessfullyProxyRequestToGateway(cluster Cluster, instance string, gatewayAddr string, namespace string) func(Gomega) {
+	return func(g Gomega) {
+		target := fmt.Sprintf("http://%s/%s",
+			gatewayAddr, path.Join("test", url.PathEscape(GinkgoT().Name())),
+		)
 
-	response, err := client.CollectResponse(
-		cluster, "demo-client", target,
-		client.FromKubernetesPod(namespace, "demo-client"),
-	)
+		response, err := client.CollectResponse(
+			cluster, "demo-client", target,
+			client.FromKubernetesPod(namespace, "demo-client"),
+		)
 
-	Expect(err).ToNot(HaveOccurred())
-	Expect(response.Instance).To(Equal(instance))
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(response.Instance).To(Equal(instance))
+	}
 }
 
 func FailToProxyRequestToGateway(cluster Cluster, gatewayAddr string, namespace string) func(Gomega) {

--- a/test/e2e_env/kubernetes/graceful/graceful.go
+++ b/test/e2e_env/kubernetes/graceful/graceful.go
@@ -97,11 +97,6 @@ spec:
 	}
 
 	BeforeAll(func() {
-		E2EDeferCleanup(func() {
-			Expect(env.Cluster.TriggerDeleteNamespace(namespace)).To(Succeed())
-			Expect(env.Cluster.DeleteMesh(mesh))
-		})
-
 		err := NewClusterSetup().
 			Install(MeshKubernetes(mesh)).
 			Install(NamespaceWithSidecarInjection(namespace)).
@@ -128,6 +123,11 @@ spec:
 
 		// remove retries to avoid covering failed request
 		Expect(DeleteMeshResources(env.Cluster, mesh, core_mesh.RetryResourceTypeDescriptor)).To(Succeed())
+	})
+
+	E2EAfterAll(func() {
+		Expect(env.Cluster.TriggerDeleteNamespace(namespace)).To(Succeed())
+		Expect(env.Cluster.DeleteMesh(mesh))
 	})
 
 	requestThroughGateway := func() error {

--- a/test/e2e_env/kubernetes/healthcheck/virtual_probes.go
+++ b/test/e2e_env/kubernetes/healthcheck/virtual_probes.go
@@ -15,11 +15,6 @@ func VirtualProbes() {
 	const mesh = "virtual-probes"
 
 	BeforeAll(func() {
-		E2EDeferCleanup(func() {
-			Expect(env.Cluster.TriggerDeleteNamespace(namespace)).To(Succeed())
-			Expect(env.Cluster.DeleteMesh(mesh))
-		})
-
 		err := NewClusterSetup().
 			Install(MTLSMeshKubernetes(mesh)).
 			Install(NamespaceWithSidecarInjection(namespace)).
@@ -30,6 +25,10 @@ func VirtualProbes() {
 			)).
 			Setup(env.Cluster)
 		Expect(err).To(Succeed())
+	})
+	E2EAfterAll(func() {
+		Expect(env.Cluster.TriggerDeleteNamespace(namespace)).To(Succeed())
+		Expect(env.Cluster.DeleteMesh(mesh))
 	})
 
 	It("should deploy test-server with probes", func() {

--- a/test/e2e_env/kubernetes/k8s_api_bypass/k8s_api_bypass.go
+++ b/test/e2e_env/kubernetes/k8s_api_bypass/k8s_api_bypass.go
@@ -56,23 +56,24 @@ spec:
 		caCert := fmt.Sprintf("%s/ca.crt", serviceAccount)
 		header := fmt.Sprintf("Authorization: Bearer %s", token)
 		url := fmt.Sprintf("%s/api", apiServer)
-
 		cmd := fmt.Sprintf("curl -s --cacert %s --header %q -o /dev/null -w '%%{http_code}\\n' -m 3 --fail %s", caCert, header, url)
 
 		// given Mesh with passthrough enabled then communication with API Server works
-		stdout, _, err := env.Cluster.ExecWithRetries(namespace, clientPodName, "demo-client",
-			"bash", "-c", cmd)
-		Expect(err).ToNot(HaveOccurred())
-		Expect(stdout).To(Equal("200"))
+		Eventually(func(g Gomega) {
+			stdout, _, err := env.Cluster.Exec(namespace, clientPodName, "demo-client", "bash", "-c", cmd)
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(stdout).To(Equal("200"))
+		}).Should(Succeed())
 
 		// when passthrough is disabled on the Mesh
-		err = env.Cluster.Install(YamlK8s(fmt.Sprintf(meshDefaultMtlsOn, "false")))
+		err := env.Cluster.Install(YamlK8s(fmt.Sprintf(meshDefaultMtlsOn, "false")))
 		Expect(err).ToNot(HaveOccurred())
 
 		// then communication with API Server still works
-		stdout, _, err = env.Cluster.ExecWithRetries(namespace, clientPodName, "demo-client",
-			"bash", "-c", cmd)
-		Expect(err).ToNot(HaveOccurred())
-		Expect(stdout).To(Equal("200"))
+		Eventually(func(g Gomega) {
+			stdout, _, err := env.Cluster.Exec(namespace, clientPodName, "demo-client", "bash", "-c", cmd)
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(stdout).To(Equal("200"))
+		}).Should(Succeed())
 	})
 }

--- a/test/e2e_env/kubernetes/kubernetes_suite_test.go
+++ b/test/e2e_env/kubernetes/kubernetes_suite_test.go
@@ -35,7 +35,7 @@ import (
 )
 
 func TestE2E(t *testing.T) {
-	test.RunSpecs(t, "E2E Kubernetes Suite")
+	test.RunE2ESpecs(t, "E2E Kubernetes Suite")
 }
 
 var _ = SynchronizedBeforeSuite(
@@ -101,7 +101,7 @@ var _ = SynchronizedAfterSuite(func() {}, func() {})
 var _ = Describe("Virtual Probes", healthcheck.VirtualProbes, Ordered)
 var _ = Describe("Gateway", gateway.Gateway, Ordered)
 var _ = Describe("Gateway - Cross-mesh", gateway.CrossMeshGatewayOnKubernetes, Ordered)
-var _ = Describe("Gateway - Gateway API", gateway.GatewayAPI, Ordered)
+var _ = Describe("Gateway - Gateway API", Label("arm-not-supported"), gateway.GatewayAPI, Ordered)
 var _ = Describe("Gateway - mTLS", gateway.Mtls, Ordered)
 var _ = Describe("Gateway - Resources", gateway.Resources, Ordered)
 var _ = Describe("Graceful", graceful.Graceful, Ordered)

--- a/test/e2e_env/kubernetes/observability/meshtrace.go
+++ b/test/e2e_env/kubernetes/observability/meshtrace.go
@@ -67,18 +67,17 @@ func PluginTest() {
 		clientPod, err := PodNameOfApp(env.Cluster, "demo-client", ns)
 		Expect(err).ToNot(HaveOccurred())
 
-		Eventually(func() ([]string, error) {
-			_, _, err := env.Cluster.ExecWithRetries(ns, clientPod, "demo-client",
+		Eventually(func(g Gomega) {
+			_, _, err := env.Cluster.Exec(ns, clientPod, "demo-client",
 				"curl", "-v", "-m", "3", "--fail", "test-server")
-			if err != nil {
-				return nil, err
-			}
-			// then traces are published
-			return obsClient.TracedServices()
-		}, "30s", "1s").Should(Equal([]string{
-			fmt.Sprintf("demo-client_%s_svc", ns),
-			"jaeger-query",
-			fmt.Sprintf("test-server_%s_svc_80", ns),
-		}))
+			g.Expect(err).ToNot(HaveOccurred())
+			srvs, err := obsClient.TracedServices()
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(srvs).To(Equal([]string{
+				fmt.Sprintf("demo-client_%s_svc", ns),
+				"jaeger-query",
+				fmt.Sprintf("test-server_%s_svc_80", ns),
+			}))
+		}, "30s", "1s").Should(Succeed())
 	})
 }

--- a/test/e2e_env/kubernetes/trafficlog/tcp_logging.go
+++ b/test/e2e_env/kubernetes/trafficlog/tcp_logging.go
@@ -144,7 +144,7 @@ spec:
 			tcpSinkPodName, err := PodNameOfApp(env.Cluster, tcpSinkAppName, tcpSinkNamespace)
 			Expect(err).ToNot(HaveOccurred())
 			Eventually(func() error {
-				_, _, err = env.Cluster.ExecWithRetries(trafficNamespace, clientPodName,
+				_, _, err = env.Cluster.Exec(trafficNamespace, clientPodName,
 					AppModeDemoClient, "curl", "-v", "--fail", "test-server")
 				if err != nil {
 					return err
@@ -160,7 +160,7 @@ spec:
 				}
 				startTimeStr, src, dst = parts[0], parts[1], parts[2]
 				return nil
-			}, "30s", "1ms").ShouldNot(HaveOccurred())
+			}).ShouldNot(HaveOccurred())
 			startTimeInt, err := strconv.Atoi(startTimeStr)
 			Expect(err).ToNot(HaveOccurred())
 			startTime := time.Unix(int64(startTimeInt), 0)

--- a/test/e2e_env/kubernetes/virtualoutbound/virtualoutbound.go
+++ b/test/e2e_env/kubernetes/virtualoutbound/virtualoutbound.go
@@ -63,11 +63,13 @@ spec:
 		Expect(err).ToNot(HaveOccurred())
 
 		// Succeed with virtual-outbound
-		stdout, stderr, err := env.Cluster.ExecWithRetries(namespace, clientPodName, "demo-client",
-			"curl", "-v", "-m", "3", "--fail", "test-server_virtual-outbounds_svc_80.foo:8080")
-		Expect(err).ToNot(HaveOccurred())
-		Expect(stderr).To(ContainSubstring("HTTP/1.1 200 OK"))
-		Expect(stdout).To(ContainSubstring(`"instance":"test-server`))
+		Eventually(func(g Gomega) {
+			stdout, stderr, err := env.Cluster.Exec(namespace, clientPodName, "demo-client",
+				"curl", "-v", "-m", "3", "--fail", "test-server_virtual-outbounds_svc_80.foo:8080")
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(stderr).To(ContainSubstring("HTTP/1.1 200 OK"))
+			g.Expect(stdout).To(ContainSubstring(`"instance":"test-server`))
+		}).Should(Succeed())
 	})
 
 	It("virtual outbounds on statefulSet", func() {
@@ -97,16 +99,20 @@ spec:
 		clientPodName, err := PodNameOfApp(env.Cluster, "demo-client", namespace)
 		Expect(err).ToNot(HaveOccurred())
 
-		stdout, stderr, err := env.Cluster.ExecWithRetries(namespace, clientPodName, "demo-client",
-			"curl", "-v", "-m", "3", "--fail", "test-server_virtual-outbounds_svc_80.test-server-0:8080")
-		Expect(err).ToNot(HaveOccurred())
-		Expect(stderr).To(ContainSubstring("HTTP/1.1 200 OK"))
-		Expect(stdout).To(ContainSubstring(`"instance":"test-server-0"`))
+		Eventually(func(g Gomega) {
+			stdout, stderr, err := env.Cluster.Exec(namespace, clientPodName, "demo-client",
+				"curl", "-v", "-m", "3", "--fail", "test-server_virtual-outbounds_svc_80.test-server-0:8080")
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(stderr).To(ContainSubstring("HTTP/1.1 200 OK"))
+			g.Expect(stdout).To(ContainSubstring(`"instance":"test-server-0"`))
+		}, "30s", "1s").Should(Succeed())
 
-		stdout, stderr, err = env.Cluster.ExecWithRetries(namespace, clientPodName, "demo-client",
-			"curl", "-v", "-m", "3", "--fail", "test-server_virtual-outbounds_svc_80.test-server-1:8080")
-		Expect(err).ToNot(HaveOccurred())
-		Expect(stderr).To(ContainSubstring("HTTP/1.1 200 OK"))
-		Expect(stdout).To(ContainSubstring(`"instance":"test-server-1"`))
+		Eventually(func(g Gomega) {
+			stdout, stderr, err := env.Cluster.Exec(namespace, clientPodName, "demo-client",
+				"curl", "-v", "-m", "3", "--fail", "test-server_virtual-outbounds_svc_80.test-server-1:8080")
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(stderr).To(ContainSubstring("HTTP/1.1 200 OK"))
+			g.Expect(stdout).To(ContainSubstring(`"instance":"test-server-1"`))
+		}, "30s", "1s").Should(Succeed())
 	})
 }

--- a/test/e2e_env/multizone/gateway/cross-mesh.go
+++ b/test/e2e_env/multizone/gateway/cross-mesh.go
@@ -119,18 +119,18 @@ func CrossMeshGatewayOnMultizone() {
 		Context("Intrazone", func() {
 			zone := &env.KubeZone1
 			It("proxies HTTP requests from a different mesh", func() {
-				k8s_gateway.SuccessfullyProxyRequestToGateway(
+				Eventually(k8s_gateway.SuccessfullyProxyRequestToGateway(
 					*zone, gatewayMesh,
 					gatewayAddr,
 					gatewayClientNamespaceOtherMesh,
-				)
+				)).Should(Succeed())
 			})
 			It("proxies HTTP requests from the same mesh", func() {
-				k8s_gateway.SuccessfullyProxyRequestToGateway(
+				Eventually(k8s_gateway.SuccessfullyProxyRequestToGateway(
 					*zone, gatewayMesh,
 					gatewayAddr,
 					gatewayClientNamespaceSameMesh,
-				)
+				)).Should(Succeed())
 			})
 		})
 		Context("Crosszone", func() {
@@ -151,21 +151,21 @@ func CrossMeshGatewayOnMultizone() {
 			})
 
 			It("proxies HTTP requests from a different mesh", func() {
-				k8s_gateway.SuccessfullyProxyRequestToGateway(
+				Eventually(k8s_gateway.SuccessfullyProxyRequestToGateway(
 					*zone, gatewayMesh,
 					gatewayAddr,
 					gatewayClientNamespaceOtherMesh,
-				)
+				)).Should(Succeed())
 
 				egress := (*zone).GetZoneEgressEnvoyTunnel()
 				Expect(egress.GetStats(filter)).To(stats.BeGreaterThan(currentStat))
 			})
 			It("proxies HTTP requests from the same mesh", func() {
-				k8s_gateway.SuccessfullyProxyRequestToGateway(
+				Eventually(k8s_gateway.SuccessfullyProxyRequestToGateway(
 					*zone, gatewayMesh,
 					gatewayAddr,
 					gatewayClientNamespaceSameMesh,
-				)
+				)).Should(Succeed())
 
 				egress := (*zone).GetZoneEgressEnvoyTunnel()
 				Expect(egress.GetStats(filter)).To(stats.BeGreaterThan(currentStat))

--- a/test/e2e_env/multizone/inbound_communication/inbound_passthrough.go
+++ b/test/e2e_env/multizone/inbound_communication/inbound_passthrough.go
@@ -97,167 +97,73 @@ func InboundPassthrough() {
 		Expect(env.Global.DeleteMesh(mesh)).To(Succeed())
 	})
 
-	Describe("k8s to k8s communication", func() {
-		It("should succeed when application binds to wildcard", func() {
-			// when
-			response, err := client.CollectResponse(
-				env.KubeZone1, "demo-client", "k8s-test-server-wildcard.inbound-passthrough.svc.80.mesh",
-				client.FromKubernetesPod(namespace, "demo-client"),
-			)
+	Context("k8s communication", func() {
+		DescribeTable("should succeed when application",
+			func(url string, expectedInstance string) {
+				// when
+				Eventually(func(g Gomega) {
+					response, err := client.CollectResponse(
+						env.KubeZone1, "demo-client", url,
+						client.FromKubernetesPod(namespace, "demo-client"),
+					)
 
-			// then
-			Expect(err).ToNot(HaveOccurred())
-			Expect(response.Instance).To(Equal("k8s-bound-wildcard"))
-		})
-		It("should succeed when application binds to pod", func() {
-			// when
-			response, err := client.CollectResponse(
-				env.KubeZone1, "demo-client", "k8s-test-server-pod.inbound-passthrough.svc.80.mesh",
-				client.FromKubernetesPod(namespace, "demo-client"),
-			)
+					// then
+					g.Expect(err).ToNot(HaveOccurred())
+					g.Expect(response.Instance).To(Equal(expectedInstance))
+				}).Should(Succeed())
+			},
+			Entry("on k8s binds to wildcard", "k8s-test-server-wildcard.inbound-passthrough.svc.80.mesh", "k8s-bound-wildcard"),
+			Entry("on k8s binds to podip", "k8s-test-server-pod.inbound-passthrough.svc.80.mesh", "k8s-bound-pod"),
+			Entry("on universal binds to wildcard", "uni-test-server-wildcard.mesh", "uni-bound-wildcard"),
+			Entry("on universal binds to podip", "uni-test-server-containerip.mesh", "uni-bound-containerip"),
+			Entry("on universal is not using transparent-proxy", "uni-test-server-wildcard-no-tp.mesh", "uni-bound-wildcard-no-tp"),
+		)
+		DescribeTable("should fail when application",
+			func(url string) {
+				Consistently(func(g Gomega) {
+					_, err := client.CollectResponse(
+						env.KubeZone1, "demo-client", url,
+						client.FromKubernetesPod(namespace, "demo-client"),
+					)
 
-			// then
-			Expect(err).ToNot(HaveOccurred())
-			Expect(response.Instance).To(Equal("k8s-bound-pod"))
-		})
-		It("should fail when application binds to localhost", func() {
-			// given
-			podName, err := PodNameOfApp(env.KubeZone1, "demo-client", namespace)
-			Expect(err).ToNot(HaveOccurred())
-
-			// when
-			_, _, err = env.KubeZone1.Exec(namespace, podName, "demo-client",
-				"curl", "-v", "-m", "3", "--fail", "k8s-test-server-localhost.inbound-passthrough.svc.80.mesh")
-
-			// then
-			Expect(err).To(HaveOccurred())
-		})
+					// then
+					g.Expect(err).To(HaveOccurred())
+				}).Should(Succeed())
+			},
+			Entry("on k8s binds to localhost", "k8s-test-server-localhost.inbound-passthrough.svc.80.mesh"),
+			Entry("on universal binds to localhost", "uni-test-server-localhost.mesh"),
+		)
 	})
 
-	Describe("universal to universal communication", func() {
-		It("should succeed when application binds to wildcard", func() {
-			// when
-			response, err := client.CollectResponse(
-				env.UniZone1, "uni-demo-client", "uni-test-server-wildcard.mesh",
-			)
+	Context("universal communication", func() {
+		DescribeTable("should succeed when application",
+			func(url string, expectedInstance string) {
+				Eventually(func(g Gomega) {
+					// when
+					response, err := client.CollectResponse(env.UniZone1, "uni-demo-client", url)
 
-			// then
-			Expect(err).ToNot(HaveOccurred())
-			Expect(response.Instance).To(Equal("uni-bound-wildcard"))
-		})
-		It("should succeed when application binds to container ip", func() {
-			// when
-			response, err := client.CollectResponse(
-				env.UniZone1, "uni-demo-client", "uni-test-server-containerip.mesh",
-			)
-
-			// then
-			Expect(err).ToNot(HaveOccurred())
-			Expect(response.Instance).To(Equal("uni-bound-containerip"))
-		})
-		It("should succeed when container is not using transparent proxy", func() {
-			// when
-			_, _, err := env.UniZone1.Exec("", "", "uni-demo-client",
-				"curl", "-v", "-m", "3", "--fail", "uni-test-server-localhost.mesh")
-
-			// then
-			Expect(err).To(HaveOccurred())
-		})
-		It("should fail when application binds to localhost", func() {
-			// when
-			_, _, err := env.UniZone1.Exec("", "", "uni-demo-client",
-				"curl", "-v", "-m", "3", "--fail", "uni-test-server-localhost.mesh")
-
-			// then
-			Expect(err).To(HaveOccurred())
-		})
-	})
-
-	Describe("universal to k8s communication", func() {
-		It("should succeed when application binds to wildcard", func() {
-			// when
-			response, err := client.CollectResponse(
-				env.UniZone1, "uni-demo-client", "k8s-test-server-wildcard.inbound-passthrough.svc.80.mesh",
-			)
-
-			// then
-			Expect(err).ToNot(HaveOccurred())
-			Expect(response.Instance).To(Equal("k8s-bound-wildcard"))
-		})
-		It("should succeed when application binds to pod", func() {
-			// when
-			response, err := client.CollectResponse(
-				env.UniZone1, "uni-demo-client", "k8s-test-server-pod.inbound-passthrough.svc.80.mesh",
-			)
-
-			// then
-			Expect(err).ToNot(HaveOccurred())
-			Expect(response.Instance).To(Equal("k8s-bound-pod"))
-		})
-		It("should fail when application binds to localhost", func() {
-			// when
-			_, _, err := env.UniZone1.Exec("", "", "uni-demo-client",
-				"curl", "-v", "-m", "3", "--fail", "k8s-test-server-localhost.inbound-passthrough.svc.80.mesh")
-
-			// then
-			Expect(err).To(HaveOccurred())
-		})
-	})
-
-	Describe("k8s to universal communication", func() {
-		It("should succeed when application binds to wildcard", func() {
-			// when
-			response, err := client.CollectResponse(
-				env.KubeZone1, "demo-client", "uni-test-server-wildcard.mesh",
-				client.FromKubernetesPod(namespace, "demo-client"),
-			)
-
-			// then
-			Expect(err).ToNot(HaveOccurred())
-			Expect(response.Instance).To(Equal("uni-bound-wildcard"))
-		})
-		It("should succeed when application binds to container ip", func() {
-			// when
-			response, err := client.CollectResponse(
-				env.UniZone1, "uni-demo-client", "uni-test-server-containerip.mesh",
-			)
-
-			// then
-			Expect(err).ToNot(HaveOccurred())
-			Expect(response.Instance).To(Equal("uni-bound-containerip"))
-		})
-		It("should succeed when container is not using transparent proxy", func() {
-			// when
-			response, err := client.CollectResponse(
-				env.KubeZone1, "demo-client", "uni-test-server-wildcard-no-tp.mesh",
-				client.FromKubernetesPod(namespace, "demo-client"),
-			)
-
-			// then
-			Expect(err).ToNot(HaveOccurred())
-			Expect(response.Instance).To(Equal("uni-bound-wildcard-no-tp"))
-		})
-		It("should succeed when user expose localhost outside", func() {
-			// when
-			response, err := client.CollectResponse(
-				env.UniZone1, "uni-demo-client", "uni-test-server-localhost-exposed.mesh",
-			)
-
-			// then
-			Expect(err).ToNot(HaveOccurred())
-			Expect(response.Instance).To(Equal("uni-bound-localhost-exposed"))
-		})
-		It("should fail when application binds to localhost", func() {
-			// given
-			podName, err := PodNameOfApp(env.KubeZone1, "demo-client", namespace)
-			Expect(err).ToNot(HaveOccurred())
-
-			// when
-			_, _, err = env.KubeZone1.Exec(namespace, podName, "demo-client",
-				"curl", "-v", "-m", "3", "--fail", "uni-test-server-localhost.mesh")
-
-			// then
-			Expect(err).To(HaveOccurred())
-		})
+					// then
+					g.Expect(err).ToNot(HaveOccurred())
+					g.Expect(response.Instance).To(Equal(expectedInstance))
+				}).Should(Succeed())
+			},
+			Entry("on universal binds to wildcard", "uni-test-server-wildcard.mesh", "uni-bound-wildcard"),
+			Entry("on universal binds to container ip", "uni-test-server-containerip.mesh", "uni-bound-containerip"),
+			Entry("on universal is not using transparent-proxy", "uni-test-server-wildcard-no-tp.mesh", "uni-bound-wildcard-no-tp"),
+			Entry("on k8s binds to wildcard", "k8s-test-server-wildcard.inbound-passthrough.svc.80.mesh", "k8s-bound-wildcard"),
+			Entry("on k8s binds to podip", "k8s-test-server-pod.inbound-passthrough.svc.80.mesh", "k8s-bound-pod"),
+		)
+		DescribeTable("should fail when application",
+			func(url string) {
+				Consistently(func(g Gomega) {
+					// when
+					_, err := client.CollectResponse(env.UniZone1, "uni-demo-client", url)
+					// then
+					Expect(err).To(HaveOccurred())
+				}).Should(Succeed())
+			},
+			Entry("on universal binds to localhost", "uni-test-server-localhost.mesh"),
+			Entry("on k8s binds to localhost", "k8s-test-server-localhost.inbound-passthrough.svc.80.mesh"),
+		)
 	})
 }

--- a/test/e2e_env/multizone/meshtrafficpermission/meshtrafficpermission.go
+++ b/test/e2e_env/multizone/meshtrafficpermission/meshtrafficpermission.go
@@ -52,9 +52,11 @@ func MeshTrafficPermission() {
 	})
 
 	trafficAllowed := func() {
-		_, _, err := env.KubeZone1.ExecWithRetries(namespace, clientPodName, "demo-client",
-			"curl", "-v", "-m", "3", "--fail", "test-server.mesh")
-		Expect(err).ToNot(HaveOccurred())
+		Eventually(func(g Gomega) {
+			_, _, err := env.KubeZone1.Exec(namespace, clientPodName, "demo-client",
+				"curl", "-v", "-m", "3", "--fail", "test-server.mesh")
+			g.Expect(err).ToNot(HaveOccurred())
+		}).Should(Succeed())
 	}
 
 	trafficBlocked := func() {
@@ -62,7 +64,7 @@ func MeshTrafficPermission() {
 			_, _, err := env.KubeZone1.Exec(namespace, clientPodName, "demo-client",
 				"curl", "-v", "-m", "3", "--fail", "test-server.mesh")
 			return err
-		}, "30s", "1s").Should(HaveOccurred())
+		}).Should(HaveOccurred())
 	}
 
 	It("should allow the traffic with allow-all meshtrafficpermission", func() {

--- a/test/e2e_env/multizone/multizone_suite_test.go
+++ b/test/e2e_env/multizone/multizone_suite_test.go
@@ -26,7 +26,7 @@ import (
 )
 
 func TestE2E(t *testing.T) {
-	test.RunSpecs(t, "E2E Multizone Suite")
+	test.RunE2ESpecs(t, "E2E Multizone Suite")
 }
 
 type State struct {

--- a/test/e2e_env/multizone/trafficpermission/trafficpermission.go
+++ b/test/e2e_env/multizone/trafficpermission/trafficpermission.go
@@ -50,9 +50,11 @@ func TrafficPermission() {
 	})
 
 	trafficAllowed := func() {
-		_, _, err := env.KubeZone1.ExecWithRetries(namespace, clientPodName, "demo-client",
-			"curl", "-v", "-m", "3", "--fail", "test-server.mesh")
-		Expect(err).ToNot(HaveOccurred())
+		Eventually(func(g Gomega) {
+			_, _, err := env.KubeZone1.Exec(namespace, clientPodName, "demo-client",
+				"curl", "-v", "-m", "3", "--fail", "test-server.mesh")
+			g.Expect(err).ToNot(HaveOccurred())
+		}).Should(Succeed())
 	}
 
 	trafficBlocked := func() {
@@ -60,7 +62,7 @@ func TrafficPermission() {
 			_, _, err := env.KubeZone1.Exec(namespace, clientPodName, "demo-client",
 				"curl", "-v", "-m", "3", "--fail", "test-server.mesh")
 			return err
-		}, "30s", "1s").Should(HaveOccurred())
+		}).Should(HaveOccurred())
 	}
 
 	It("should allow the traffic with default traffic permission", func() {

--- a/test/e2e_env/multizone/zoneegress/internal_services.go
+++ b/test/e2e_env/multizone/zoneegress/internal_services.go
@@ -97,10 +97,12 @@ routing:
 				g.Expect(env.KubeZone1.GetZoneEgressEnvoyTunnel().GetStats(filter)).To(stats.BeEqualZero())
 			}, "30s", "1s").Should(Succeed())
 
-			_, stderr, err := env.KubeZone1.ExecWithRetries(namespace, zone1ClientPodName, "demo-client",
-				"curl", "--verbose", "--max-time", "3", "--fail", "test-server_ze-internal_svc_80.mesh")
-			Expect(err).ToNot(HaveOccurred())
-			Expect(stderr).To(ContainSubstring("HTTP/1.1 200 OK"))
+			Eventually(func(g Gomega) {
+				_, stderr, err := env.KubeZone1.Exec(namespace, zone1ClientPodName, "demo-client",
+					"curl", "--verbose", "--max-time", "3", "--fail", "test-server_ze-internal_svc_80.mesh")
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(stderr).To(ContainSubstring("HTTP/1.1 200 OK"))
+			}).Should(Succeed())
 
 			Eventually(func(g Gomega) {
 				g.Expect(env.KubeZone1.GetZoneEgressEnvoyTunnel().GetStats(filter)).
@@ -122,10 +124,12 @@ routing:
 					To(stats.BeEqualZero())
 			}, "30s", "1s").Should(Succeed())
 
-			stdout, _, err := env.UniZone1.ExecWithRetries("", "", "zone3-demo-client",
-				"curl", "--verbose", "--max-time", "3", "--fail", "zone4-test-server.mesh")
-			Expect(err).ToNot(HaveOccurred())
-			Expect(stdout).To(ContainSubstring("HTTP/1.1 200 OK"))
+			Eventually(func(g Gomega) {
+				stdout, _, err := env.UniZone1.Exec("", "", "zone3-demo-client",
+					"curl", "--verbose", "--max-time", "3", "--fail", "zone4-test-server.mesh")
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(stdout).To(ContainSubstring("HTTP/1.1 200 OK"))
+			}, "30s", "1s").Should(Succeed())
 
 			Eventually(func(g Gomega) {
 				g.Expect(env.UniZone1.GetZoneEgressEnvoyTunnel().GetStats(filter)).

--- a/test/e2e_env/universal/externalservices/externalservices.go
+++ b/test/e2e_env/universal/externalservices/externalservices.go
@@ -94,7 +94,7 @@ networking:
 			g.Expect(err).ToNot(HaveOccurred())
 			g.Expect(stdout).To(ContainSubstring("HTTP/1.1 200 OK"))
 			g.Expect(stdout).To(matcher)
-		}).WithOffset(1).Should(Succeed())
+		}, "30s", "500ms").WithOffset(1).Should(Succeed())
 	}
 
 	It("should route to external-service", func() {

--- a/test/e2e_env/universal/gateway/cross-mesh.go
+++ b/test/e2e_env/universal/gateway/cross-mesh.go
@@ -86,18 +86,16 @@ func CrossMeshGatewayOnUniversal() {
 	Context("when mTLS is enabled", func() {
 		It("should proxy HTTP requests from a different mesh", func() {
 			gatewayAddr := net.JoinHostPort(crossMeshHostname, strconv.Itoa(crossMeshGatewayPort))
-			successfullyProxyRequestToGateway(
-				env.Cluster, demoClientOtherMesh, gatewayMesh,
-				gatewayAddr,
-			)
+			Eventually(successfullyProxyRequestToGateway(
+				env.Cluster, demoClientOtherMesh, gatewayMesh, gatewayAddr,
+			), "30s", "1s").Should(Succeed())
 		})
 
 		It("should proxy HTTP requests from the same mesh", func() {
 			gatewayAddr := net.JoinHostPort(crossMeshHostname, strconv.Itoa(crossMeshGatewayPort))
-			successfullyProxyRequestToGateway(
-				env.Cluster, demoClientInMesh, gatewayMesh,
-				gatewayAddr,
-			)
+			Eventually(successfullyProxyRequestToGateway(
+				env.Cluster, demoClientInMesh, gatewayMesh, gatewayAddr,
+			)).Should(Succeed())
 		})
 
 		It("doesn't allow HTTP requests from outside the mesh", func() {
@@ -109,18 +107,17 @@ func CrossMeshGatewayOnUniversal() {
 
 		Specify("HTTP requests to a non-crossMesh gateway should still be proxied", func() {
 			gatewayAddr := net.JoinHostPort(env.Cluster.GetApp(edgeGatewayName).GetIP(), strconv.Itoa(edgeGatewayPort))
-			successfullyProxyRequestToGateway(
-				env.Cluster, demoClientOtherMesh, gatewayOtherMesh,
-				gatewayAddr,
-			)
+			Eventually(successfullyProxyRequestToGateway(
+				env.Cluster, demoClientOtherMesh, gatewayOtherMesh, gatewayAddr,
+			)).Should(Succeed())
 		})
 
 		It("should be reachable without transparent proxy", func() {
 			gatewayAddr := net.JoinHostPort(crossMeshHostname, strconv.Itoa(crossMeshGatewayPort))
-			successfullyProxyRequestToGateway(
+			Eventually(successfullyProxyRequestToGateway(
 				env.Cluster, demoClientNoTransparent, gatewayMesh,
 				gatewayAddr, client.Resolve(gatewayAddr, "127.0.0.1"),
-			)
+			)).Should(Succeed())
 		})
 	})
 }

--- a/test/e2e_env/universal/gateway/utils.go
+++ b/test/e2e_env/universal/gateway/utils.go
@@ -18,19 +18,21 @@ func demoClientName(mesh string) string {
 	return fmt.Sprintf("demo-client-%s", mesh)
 }
 
-func successfullyProxyRequestToGateway(cluster Cluster, clientName, instance, gatewayAddr string, opt ...client.CollectResponsesOptsFn) {
-	Logf("expecting 200 response from %q", gatewayAddr)
-	target := fmt.Sprintf("http://%s/%s",
-		gatewayAddr, path.Join("test", url.PathEscape(GinkgoT().Name())),
-	)
+func successfullyProxyRequestToGateway(cluster Cluster, clientName, instance, gatewayAddr string, opt ...client.CollectResponsesOptsFn) func(Gomega) {
+	return func(g Gomega) {
+		Logf("expecting 200 response from %q", gatewayAddr)
+		target := fmt.Sprintf("http://%s/%s",
+			gatewayAddr, path.Join("test", url.PathEscape(GinkgoT().Name())),
+		)
 
-	response, err := client.CollectResponse(
-		cluster, clientName, target,
-		opt...,
-	)
+		response, err := client.CollectResponse(
+			cluster, clientName, target,
+			opt...,
+		)
 
-	Expect(err).NotTo(HaveOccurred())
-	Expect(response.Instance).To(Equal(instance))
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(response.Instance).To(Equal(instance))
+	}
 }
 
 func failToProxyRequestToGateway(cluster Cluster, containerName, gatewayAddr, host string) func(Gomega) {

--- a/test/e2e_env/universal/healthcheck/panic.go
+++ b/test/e2e_env/universal/healthcheck/panic.go
@@ -2,7 +2,6 @@ package healthcheck
 
 import (
 	"fmt"
-	"strings"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -76,10 +75,10 @@ networking:
 	})
 
 	It("should switch to panic mode and dismiss all requests", func() {
-		Eventually(func() bool {
+		Eventually(func(g Gomega) {
 			stdout, _, _ := env.Cluster.Exec("", "", "demo-client",
 				"curl", "-v", "test-server.mesh")
-			return strings.Contains(stdout, "no healthy upstream")
-		}, "30s", "500ms").Should(BeTrue())
+			g.Expect(stdout).To(ContainSubstring("no healthy upstream"))
+		}, "30s", "500ms").Should(Succeed())
 	})
 }

--- a/test/e2e_env/universal/meshhealthcheck/panic.go
+++ b/test/e2e_env/universal/meshhealthcheck/panic.go
@@ -2,7 +2,6 @@ package meshhealthcheck
 
 import (
 	"fmt"
-	"strings"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -78,10 +77,10 @@ networking:
 	})
 
 	It("should switch to panic mode and dismiss all requests", func() {
-		Eventually(func() bool {
+		Eventually(func(g Gomega) {
 			stdout, _, _ := env.Cluster.Exec("", "", "demo-client",
 				"curl", "-v", "test-server.mesh")
-			return strings.Contains(stdout, "no healthy upstream")
-		}, "120m", "1m").Should(BeTrue())
+			g.Expect(stdout).To(ContainSubstring("no healthy upstream"))
+		}, "30s", "500ms").Should(Succeed())
 	})
 }

--- a/test/e2e_env/universal/meshtrafficpermission/meshtrafficpermission.go
+++ b/test/e2e_env/universal/meshtrafficpermission/meshtrafficpermission.go
@@ -39,10 +39,12 @@ func MeshTrafficPermissionUniversal() {
 	})
 
 	trafficAllowed := func() {
-		stdout, _, err := env.Cluster.ExecWithRetries("", "", "demo-client",
-			"curl", "-v", "--fail", "test-server.mesh")
-		Expect(err).ToNot(HaveOccurred())
-		Expect(stdout).To(ContainSubstring("HTTP/1.1 200 OK"))
+		Eventually(func(g Gomega) {
+			stdout, _, err := env.Cluster.Exec("", "", "demo-client",
+				"curl", "-v", "--fail", "test-server.mesh")
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(stdout).To(ContainSubstring("HTTP/1.1 200 OK"))
+		}).Should(Succeed())
 	}
 
 	trafficBlocked := func() {
@@ -50,7 +52,7 @@ func MeshTrafficPermissionUniversal() {
 			_, _, err := env.Cluster.Exec("", "", "demo-client",
 				"curl", "-v", "--fail", "test-server.mesh")
 			return err
-		}, "30s", "1s").Should(HaveOccurred())
+		}).Should(HaveOccurred())
 	}
 
 	It("should allow the traffic with meshtrafficpermission based on MeshService", func() {

--- a/test/e2e_env/universal/observability/applications_metrics.go
+++ b/test/e2e_env/universal/observability/applications_metrics.go
@@ -148,18 +148,20 @@ metrics:
 		ip := env.Cluster.GetApp("test-server").GetIP()
 
 		// when
-		stdout, _, err := env.Cluster.ExecWithRetries("", "", "test-server",
-			"curl", "-v", "-m", "3", "--fail", "http://"+net.JoinHostPort(ip, "1234")+"/metrics?filter=concurrency")
+		Eventually(func(g Gomega) {
+			stdout, _, err := env.Cluster.Exec("", "", "test-server",
+				"curl", "-v", "-m", "3", "--fail", "http://"+net.JoinHostPort(ip, "1234")+"/metrics?filter=concurrency")
 
-		// then
-		Expect(err).ToNot(HaveOccurred())
-		Expect(stdout).ToNot(BeNil())
-		// response returned by test-server
-		Expect(stdout).To(ContainSubstring("path-stats"))
-		// metric from envoy
-		Expect(stdout).To(ContainSubstring("envoy_server_concurrency"))
-		// response doesn't exist
-		Expect(stdout).ToNot(ContainSubstring("not-working-service"))
+			// then
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(stdout).ToNot(BeNil())
+			// response returned by test-server
+			g.Expect(stdout).To(ContainSubstring("path-stats"))
+			// metric from envoy
+			g.Expect(stdout).To(ContainSubstring("envoy_server_concurrency"))
+			// response doesn't exist
+			g.Expect(stdout).ToNot(ContainSubstring("not-working-service"))
+		}).Should(Succeed())
 	})
 
 	It("should override mesh configuration with dataplane configuration", func() {
@@ -167,28 +169,30 @@ metrics:
 		ip := env.Cluster.GetApp("test-server-override-mesh").GetIP()
 
 		// when
-		stdout, _, err := env.Cluster.ExecWithRetries("", "", "test-server-override-mesh",
-			"curl", "-v", "-m", "3", "--fail", "http://"+net.JoinHostPort(ip, "1234")+"/metrics/overridden?filter=concurrency")
+		Eventually(func(g Gomega) {
+			stdout, _, err := env.Cluster.Exec("", "", "test-server-override-mesh",
+				"curl", "-v", "-m", "3", "--fail", "http://"+net.JoinHostPort(ip, "1234")+"/metrics/overridden?filter=concurrency")
 
-		// then
-		Expect(err).ToNot(HaveOccurred())
-		Expect(stdout).ToNot(BeNil())
+			// then
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(stdout).ToNot(BeNil())
 
-		// response doesn't exist because was disabled
-		Expect(stdout).ToNot(ContainSubstring("path-stats"))
-		// path has been overridden
-		Expect(stdout).ToNot(ContainSubstring("service-to-override"))
-		// response doesn't exist
-		Expect(stdout).ToNot(ContainSubstring("not-working-service"))
+			// response doesn't exist because was disabled
+			g.Expect(stdout).ToNot(ContainSubstring("path-stats"))
+			// path has been overridden
+			g.Expect(stdout).ToNot(ContainSubstring("service-to-override"))
+			// response doesn't exist
+			g.Expect(stdout).ToNot(ContainSubstring("not-working-service"))
 
-		// overridden by pod
-		Expect(stdout).To(ContainSubstring("overridden"))
-		// overridden by pod
-		Expect(stdout).To(ContainSubstring("mesh-default"))
-		// added in pod
-		Expect(stdout).To(ContainSubstring("my-app"))
-		// metric from envoy
-		Expect(stdout).To(ContainSubstring("envoy_server_concurrency"))
+			// overridden by pod
+			g.Expect(stdout).To(ContainSubstring("overridden"))
+			// overridden by pod
+			g.Expect(stdout).To(ContainSubstring("mesh-default"))
+			// added in pod
+			g.Expect(stdout).To(ContainSubstring("my-app"))
+			// metric from envoy
+			g.Expect(stdout).To(ContainSubstring("envoy_server_concurrency"))
+		}).Should(Succeed())
 	})
 
 	It("should use only configuration from dataplane", func() {
@@ -196,25 +200,27 @@ metrics:
 		ip := env.Cluster.GetApp("test-server-dp-metrics").GetIP()
 
 		// when
-		stdout, _, err := env.Cluster.ExecWithRetries("", "", "test-server-dp-metrics",
-			"curl", "-v", "-m", "3", "--fail", "http://"+net.JoinHostPort(ip, "5555")+"/stats?filter=concurrency")
+		Eventually(func(g Gomega) {
+			stdout, _, err := env.Cluster.Exec("", "", "test-server-dp-metrics",
+				"curl", "-v", "-m", "3", "--fail", "http://"+net.JoinHostPort(ip, "5555")+"/stats?filter=concurrency")
 
-		// then
-		Expect(err).ToNot(HaveOccurred())
-		Expect(stdout).ToNot(BeNil())
-		Expect(stdout).To(ContainSubstring(string(expfmt.FmtText)))
+			// then
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(stdout).ToNot(BeNil())
+			g.Expect(stdout).To(ContainSubstring(string(expfmt.FmtText)))
 
-		// response doesn't exist because was disabled
-		Expect(stdout).ToNot(ContainSubstring("path-stats"))
-		// path has been overridden
-		Expect(stdout).ToNot(ContainSubstring("service-to-override"))
+			// response doesn't exist because was disabled
+			g.Expect(stdout).ToNot(ContainSubstring("path-stats"))
+			// path has been overridden
+			g.Expect(stdout).ToNot(ContainSubstring("service-to-override"))
 
-		// overridden by pod
-		Expect(stdout).To(ContainSubstring("my-app"))
-		// overridden by pod
-		Expect(stdout).To(ContainSubstring("other-app"))
-		// metric from envoy
-		Expect(stdout).To(ContainSubstring("envoy_server_concurrency"))
+			// overridden by pod
+			g.Expect(stdout).To(ContainSubstring("my-app"))
+			// overridden by pod
+			g.Expect(stdout).To(ContainSubstring("other-app"))
+			// metric from envoy
+			g.Expect(stdout).To(ContainSubstring("envoy_server_concurrency"))
+		}).Should(Succeed())
 	})
 
 	It("should allow to define and expose localhost bound server", func() {
@@ -222,20 +228,22 @@ metrics:
 		ip := env.Cluster.GetApp("test-server-dp-metrics-localhost").GetIP()
 
 		// when
-		stdout, _, err := env.Cluster.ExecWithRetries("", "", "test-server-dp-metrics-localhost",
-			"curl", "-v", "-m", "3", "--fail", "http://"+net.JoinHostPort(ip, "1234")+"/metrics?filter=concurrency")
+		Eventually(func(g Gomega) {
+			stdout, _, err := env.Cluster.Exec("", "", "test-server-dp-metrics-localhost",
+				"curl", "-v", "-m", "3", "--fail", "http://"+net.JoinHostPort(ip, "1234")+"/metrics?filter=concurrency")
 
-		// then
-		Expect(err).ToNot(HaveOccurred())
-		Expect(stdout).ToNot(BeNil())
-		Expect(stdout).To(ContainSubstring(string(expfmt.FmtText)))
+			// then
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(stdout).ToNot(BeNil())
+			g.Expect(stdout).To(ContainSubstring(string(expfmt.FmtText)))
 
-		// path doesn't have defined address
-		Expect(stdout).ToNot(ContainSubstring("localhost-bound-not-exposed"))
+			// path doesn't have defined address
+			g.Expect(stdout).ToNot(ContainSubstring("localhost-bound-not-exposed"))
 
-		// exposed localhost bound service
-		Expect(stdout).To(ContainSubstring("localhost-bound"))
-		// metric from envoy
-		Expect(stdout).To(ContainSubstring("envoy_server_concurrency"))
+			// exposed localhost bound service
+			g.Expect(stdout).To(ContainSubstring("localhost-bound"))
+			// metric from envoy
+			g.Expect(stdout).To(ContainSubstring("envoy_server_concurrency"))
+		}).Should(Succeed())
 	})
 }

--- a/test/e2e_env/universal/reachableservices/reachableservices.go
+++ b/test/e2e_env/universal/reachableservices/reachableservices.go
@@ -27,21 +27,25 @@ func ReachableServices() {
 	})
 
 	It("should be able to connect to reachable services", func() {
-		// when
-		stdout, _, err := env.Cluster.ExecWithRetries("", "", "demo-client",
-			"curl", "-v", "--fail", "first-test-server.mesh")
+		Eventually(func(g Gomega) {
+			// when
+			stdout, _, err := env.Cluster.Exec("", "", "demo-client",
+				"curl", "-v", "--fail", "first-test-server.mesh")
 
-		// then
-		Expect(err).ToNot(HaveOccurred())
-		Expect(stdout).To(ContainSubstring("HTTP/1.1 200 OK"))
+			// then
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(stdout).To(ContainSubstring("HTTP/1.1 200 OK"))
+		}).Should(Succeed())
 	})
 
 	It("should not be able to non reachable services", func() {
-		// when
-		_, _, err := env.Cluster.Exec("", "", "demo-client",
-			"curl", "-v", "--fail", "second-test-server.mesh")
+		Consistently(func(g Gomega) {
+			// when
+			_, _, err := env.Cluster.Exec("", "", "demo-client",
+				"curl", "-v", "--fail", "second-test-server.mesh")
 
-		// then
-		Expect(err).To(HaveOccurred())
+			// then
+			g.Expect(err).To(HaveOccurred())
+		}).Should(Succeed())
 	})
 }

--- a/test/e2e_env/universal/trafficlog/tcp_logging.go
+++ b/test/e2e_env/universal/trafficlog/tcp_logging.go
@@ -63,9 +63,11 @@ destinations:
 		It("should send a traffic log to TCP port", func() {
 			// given traffic between apps with invalid logging backend
 			Expect(env.Cluster.Install(YamlUniversal(invalidLoggingBackend))).To(Succeed())
-			_, _, err := env.Cluster.ExecWithRetries("", "", AppModeDemoClient,
-				"curl", "-v", "--fail", "test-server.mesh")
-			Expect(err).ToNot(HaveOccurred())
+			Eventually(func(g Gomega) {
+				_, _, err := env.Cluster.Exec("", "", AppModeDemoClient,
+					"curl", "-v", "--fail", "test-server.mesh")
+				g.Expect(err).ToNot(HaveOccurred())
+			}).Should(Succeed())
 
 			// when valid backend is present
 			Expect(env.Cluster.Install(YamlUniversal(validLoggingBackend))).To(Succeed())
@@ -74,7 +76,7 @@ destinations:
 			var startTimeStr, src, dst string
 			sinkDeployment := env.Cluster.Deployment("externalservice-tcp-sink").(*externalservice.UniversalDeployment)
 			Eventually(func(g Gomega) {
-				_, _, err := env.Cluster.ExecWithRetries("", "", AppModeDemoClient,
+				_, _, err := env.Cluster.Exec("", "", AppModeDemoClient,
 					"curl", "-v", "--fail", "test-server.mesh")
 				g.Expect(err).ToNot(HaveOccurred())
 

--- a/test/e2e_env/universal/trafficpermission/traffic_permission.go
+++ b/test/e2e_env/universal/trafficpermission/traffic_permission.go
@@ -56,10 +56,12 @@ destinations:
 	})
 
 	trafficAllowed := func() {
-		stdout, _, err := env.Cluster.ExecWithRetries("", "", "demo-client",
-			"curl", "-v", "--fail", "test-server.mesh")
-		Expect(err).ToNot(HaveOccurred())
-		Expect(stdout).To(ContainSubstring("HTTP/1.1 200 OK"))
+		Eventually(func(g Gomega) {
+			stdout, _, err := env.Cluster.Exec("", "", "demo-client",
+				"curl", "-v", "--fail", "test-server.mesh")
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(stdout).To(ContainSubstring("HTTP/1.1 200 OK"))
+		}).Should(Succeed())
 	}
 
 	trafficBlocked := func() {

--- a/test/e2e_env/universal/transparentproxy/transparent_proxy.go
+++ b/test/e2e_env/universal/transparentproxy/transparent_proxy.go
@@ -34,19 +34,21 @@ func TransparentProxy() {
 		Eventually(func(g Gomega) {
 			_, err := client.CollectResponses(env.Cluster, "tp-client", "test-server.mesh")
 			g.Expect(err).ToNot(HaveOccurred())
-		}, "30s", "1s").Should(Succeed())
+		}).Should(Succeed())
 
 		// when
-		stdout, _, err := env.Cluster.ExecWithRetries("", "", "tp-client",
-			"/usr/bin/kumactl", "install", "transparent-proxy",
-			"--kuma-dp-user", "kuma-dp", "--verbose")
-		Expect(stdout).To(ContainSubstring("Transparent proxy set up successfully"))
-		Expect(err).ToNot(HaveOccurred())
+		Eventually(func(g Gomega) {
+			stdout, _, err := env.Cluster.Exec("", "", "tp-client",
+				"/usr/bin/kumactl", "install", "transparent-proxy",
+				"--kuma-dp-user", "kuma-dp", "--verbose")
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(stdout).To(ContainSubstring("Transparent proxy set up successfully"))
+		}).Should(Succeed())
 
 		// then
 		Eventually(func(g Gomega) {
 			_, err := client.CollectResponses(env.Cluster, "tp-client", "test-server.mesh")
 			g.Expect(err).ToNot(HaveOccurred())
-		}, "30s", "1s").Should(Succeed())
+		}).Should(Succeed())
 	})
 }

--- a/test/e2e_env/universal/universal_suite_test.go
+++ b/test/e2e_env/universal/universal_suite_test.go
@@ -3,7 +3,6 @@ package auth_test
 import (
 	"encoding/json"
 	"testing"
-	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -41,11 +40,7 @@ import (
 )
 
 func TestE2E(t *testing.T) {
-	SetDefaultConsistentlyDuration(time.Second * 5)
-	SetDefaultConsistentlyPollingInterval(time.Millisecond * 200)
-	SetDefaultEventuallyPollingInterval(time.Millisecond * 500)
-	SetDefaultEventuallyTimeout(time.Second * 10)
-	test.RunSpecs(t, "E2E Universal Suite")
+	test.RunE2ESpecs(t, "E2E Universal Suite")
 }
 
 var _ = SynchronizedBeforeSuite(
@@ -95,7 +90,7 @@ var _ = Describe("Gateway - Cross-mesh", gateway.CrossMeshGatewayOnUniversal, Or
 var _ = Describe("HealthCheck panic threshold", healthcheck.HealthCheckPanicThreshold, Ordered)
 var _ = Describe("HealthCheck", healthcheck.Policy)
 var _ = Describe("MeshHealthCheck panic threshold", meshhealthcheck.MeshHealthCheckPanicThreshold, Ordered)
-var _ = Describe("HealthCheck", meshhealthcheck.MeshHealthCheck)
+var _ = Describe("MeshHealthCheck", meshhealthcheck.MeshHealthCheck)
 var _ = Describe("Service Probes", healthcheck.ServiceProbes, Ordered)
 var _ = Describe("External Services", externalservices.Policy, Ordered)
 var _ = Describe("Inspect", inspect.Inspect, Ordered)

--- a/test/e2e_env/universal/virtualoutbound/virtualoutbound_universal.go
+++ b/test/e2e_env/universal/virtualoutbound/virtualoutbound_universal.go
@@ -68,26 +68,32 @@ conf:
 		time.Sleep(5 * time.Second)
 
 		// Check we can reach the first instance
-		stdout, stderr, err := env.Cluster.ExecWithRetries("", "", "demo-client",
-			"curl", "-v", "-m", "3", "--fail", "test-server.1:8080")
-		Expect(err).ToNot(HaveOccurred())
-		Expect(stderr).To(BeEmpty())
-		Expect(stdout).To(ContainSubstring("HTTP/1.1 200 OK"))
-		Expect(stdout).To(ContainSubstring(`"instance":"srv-1"`))
+		Eventually(func(g Gomega) {
+			stdout, stderr, err := env.Cluster.Exec("", "", "demo-client",
+				"curl", "-v", "-m", "3", "--fail", "test-server.1:8080")
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(stderr).To(BeEmpty())
+			g.Expect(stdout).To(ContainSubstring("HTTP/1.1 200 OK"))
+			g.Expect(stdout).To(ContainSubstring(`"instance":"srv-1"`))
+		}).Should(Succeed())
 
 		// Check we can reach the second instance
-		stdout, stderr, err = env.Cluster.ExecWithRetries("", "", "demo-client",
-			"curl", "-v", "-m", "3", "--fail", "test-server.2:8080")
-		Expect(err).ToNot(HaveOccurred())
-		Expect(stderr).To(BeEmpty())
-		Expect(stdout).To(ContainSubstring("HTTP/1.1 200 OK"))
-		Expect(stdout).To(ContainSubstring(`"instance":"srv-2"`))
+		Eventually(func(g Gomega) {
+			stdout, stderr, err := env.Cluster.Exec("", "", "demo-client",
+				"curl", "-v", "-m", "3", "--fail", "test-server.2:8080")
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(stderr).To(BeEmpty())
+			g.Expect(stdout).To(ContainSubstring("HTTP/1.1 200 OK"))
+			g.Expect(stdout).To(ContainSubstring(`"instance":"srv-2"`))
+		}).Should(Succeed())
 
-		stdout, stderr, err = env.Cluster.ExecWithRetries("", "", "demo-client",
-			"curl", "-v", "-m", "3", "--fail", "test-server:8080")
-		Expect(err).ToNot(HaveOccurred())
-		Expect(stderr).To(BeEmpty())
-		Expect(stdout).To(ContainSubstring("HTTP/1.1 200 OK"))
-		Expect(stdout).To(Or(ContainSubstring(`"instance":"srv-2"`), ContainSubstring(`"instance":"srv-1"`)))
+		Eventually(func(g Gomega) {
+			stdout, stderr, err := env.Cluster.Exec("", "", "demo-client",
+				"curl", "-v", "-m", "3", "--fail", "test-server:8080")
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(stderr).To(BeEmpty())
+			g.Expect(stdout).To(ContainSubstring("HTTP/1.1 200 OK"))
+			g.Expect(stdout).To(Or(ContainSubstring(`"instance":"srv-2"`), ContainSubstring(`"instance":"srv-1"`)))
+		}).Should(Succeed())
 	})
 }

--- a/test/framework/interface.go
+++ b/test/framework/interface.go
@@ -540,7 +540,6 @@ type Cluster interface {
 	DeleteNamespace(namespace string) error
 	DeployApp(fs ...AppDeploymentOption) error
 	Exec(namespace, podName, containerName string, cmd ...string) (string, string, error)
-	ExecWithRetries(namespace, podName, containerName string, cmd ...string) (string, string, error)
 
 	// Testing
 	GetTesting() testing.TestingT

--- a/test/framework/k8s_clusters.go
+++ b/test/framework/k8s_clusters.go
@@ -83,10 +83,6 @@ func (cs *K8sClusters) Exec(namespace, podName, containerName string, cmd ...str
 	panic("not supported")
 }
 
-func (cs *K8sClusters) ExecWithRetries(namespace, podName, containerName string, cmd ...string) (string, string, error) {
-	panic("not supported")
-}
-
 func (cs *K8sClusters) GetCluster(name string) Cluster {
 	c, found := cs.clusters[name]
 	if !found {

--- a/test/framework/setup.go
+++ b/test/framework/setup.go
@@ -247,23 +247,25 @@ func WaitService(namespace, service string) InstallFunc {
 
 func WaitNumPods(namespace string, num int, app string) InstallFunc {
 	return func(c Cluster) error {
+		ck8s := c.(*K8sCluster)
 		k8s.WaitUntilNumPodsCreated(c.GetTesting(), c.GetKubectlOptions(namespace),
 			metav1.ListOptions{
 				LabelSelector: fmt.Sprintf("app=%s", app),
-			}, num, DefaultRetries, DefaultTimeout)
+			}, num, ck8s.defaultRetries, ck8s.defaultTimeout)
 		return nil
 	}
 }
 
 func WaitPodsAvailable(namespace, app string) InstallFunc {
 	return func(c Cluster) error {
+		ck8s := c.(*K8sCluster)
 		pods, err := k8s.ListPodsE(c.GetTesting(), c.GetKubectlOptions(namespace),
 			metav1.ListOptions{LabelSelector: fmt.Sprintf("app=%s", app)})
 		if err != nil {
 			return err
 		}
 		for _, p := range pods {
-			err := k8s.WaitUntilPodAvailableE(c.GetTesting(), c.GetKubectlOptions(namespace), p.GetName(), DefaultRetries, DefaultTimeout)
+			err := k8s.WaitUntilPodAvailableE(c.GetTesting(), c.GetKubectlOptions(namespace), p.GetName(), ck8s.defaultRetries, ck8s.defaultTimeout)
 			if err != nil {
 				return err
 			}
@@ -274,7 +276,8 @@ func WaitPodsAvailable(namespace, app string) InstallFunc {
 
 func WaitUntilJobSucceed(namespace, app string) InstallFunc {
 	return func(c Cluster) error {
-		return k8s.WaitUntilJobSucceedE(c.GetTesting(), c.GetKubectlOptions(namespace), app, DefaultRetries, DefaultTimeout)
+		ck8s := c.(*K8sCluster)
+		return k8s.WaitUntilJobSucceedE(c.GetTesting(), c.GetKubectlOptions(namespace), app, ck8s.defaultRetries, ck8s.defaultTimeout)
 	}
 }
 

--- a/test/framework/ssh/ssh.go
+++ b/test/framework/ssh/ssh.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"syscall"
 
 	"github.com/gruntwork-io/terratest/modules/logger"
 	"github.com/onsi/ginkgo/v2"
@@ -32,37 +33,29 @@ func NewApp(appName string, verbose bool, port string, envMap map[string]string,
 	app := &App{
 		port: port,
 	}
-	var env []string
-	for k, v := range envMap {
-		env = append(env, fmt.Sprintf("%s='%s'", k, utils.ShellEscape(v)))
+	sshArgs := []string{
+		"-q", "-tt",
+		"-o", "StrictHostKeyChecking=no",
+		"-o", "UserKnownHostsFile=/dev/null",
+		"root@localhost", "-p", port,
 	}
-	sshArgs := append(
-		[]string{
-			"-q", "-tt",
-			"-o", "StrictHostKeyChecking=no",
-			"-o", "UserKnownHostsFile=/dev/null",
-			"root@localhost", "-p", port,
-		}, env...,
-	)
+	for k, v := range envMap {
+		sshArgs = append(sshArgs, fmt.Sprintf("%s='%s'", k, utils.ShellEscape(v)))
+	}
 	sshArgs = append(sshArgs, args...)
 	app.cmd = exec.Command("ssh", sshArgs...)
-
-	inWriters := []io.Reader{&app.stdin}
-	outWriters := []io.Writer{&app.stdout}
-	errWriters := []io.Writer{&app.stderr}
-
 	logDirName := "/tmp/e2e"
 	err := os.MkdirAll(logDirName, os.ModePerm)
 	if err != nil {
 		panic(errors.Wrap(err, "could not create /tmp/e2e"))
 	}
 	logFileName := logDirName + "/" + appName
-	f, err := os.OpenFile(logFileName, os.O_RDWR|os.O_APPEND|os.O_CREATE, 0660)
+	app.logFile, err = os.OpenFile(logFileName, os.O_RDWR|os.O_APPEND|os.O_CREATE, 0660)
 	if err != nil {
 		panic(errors.Wrap(err, "could not create "+logFileName))
 	}
-	outWriters = append(outWriters, f)
-	errWriters = append(errWriters, f)
+	outWriters := []io.Writer{&app.stdout, app.logFile}
+	errWriters := []io.Writer{&app.stderr, app.logFile}
 
 	if verbose {
 		outWriters = append(outWriters, os.Stdout)
@@ -70,50 +63,37 @@ func NewApp(appName string, verbose bool, port string, envMap map[string]string,
 	}
 	app.cmd.Stdout = io.MultiWriter(outWriters...)
 	app.cmd.Stderr = io.MultiWriter(errWriters...)
-	app.cmd.Stdin = io.MultiReader(inWriters...)
+	app.cmd.Stdin = &app.stdin
 	return app
 }
 
+func (s *App) done() {
+	s.logFile.Close()
+}
+
 func (s *App) Run() error {
+	defer s.done()
 	Logf("Running %v", s.cmd)
 	return s.cmd.Run()
 }
 
-func (s *App) Kill() error {
-	Logf("Killing %v", s.cmd)
-	return s.cmd.Process.Kill()
-}
-
-func (s *App) ProcessWait() error {
-	Logf("Waiting %v", s.cmd)
-
-	_, err := s.cmd.Process.Wait()
-
-	return err
+func (s *App) Signal(signal syscall.Signal, wait bool) error {
+	defer s.done()
+	Logf("Signaling %s %v", signal, s.cmd)
+	if err := s.cmd.Process.Signal(signal); err != nil {
+		return err
+	}
+	if wait {
+		Logf("Waiting %v", s.cmd)
+		_, err := s.cmd.Process.Wait()
+		return err
+	}
+	return nil
 }
 
 func (s *App) Start() error {
 	Logf("Starting %v", s.cmd)
 	return s.cmd.Start()
-}
-
-func (s *App) Stop() error {
-	if err := s.cmd.Process.Kill(); err != nil {
-		return err
-	}
-	if _, err := s.cmd.Process.Wait(); err != nil {
-		return err
-	}
-	if s.logFile != nil {
-		if err := s.logFile.Close(); err != nil {
-			return errors.Wrapf(err, "could not close the file %s", s.logFile.Name())
-		}
-	}
-	return nil
-}
-
-func (s *App) Wait() error {
-	return s.cmd.Wait()
 }
 
 func (s *App) Out() string {

--- a/test/framework/universal_app.go
+++ b/test/framework/universal_app.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"syscall"
 
 	"github.com/asaskevich/govalidator"
 	"github.com/gruntwork-io/terratest/modules/docker"
@@ -345,13 +346,9 @@ func (s *UniversalApp) Stop() error {
 }
 
 func (s *UniversalApp) ReStart() error {
-	if err := s.mainApp.Kill(); err != nil {
+	if err := s.mainApp.Signal(syscall.SIGKILL, true); err != nil {
 		return err
 	}
-	if err := s.mainApp.ProcessWait(); err != nil {
-		return err
-	}
-
 	s.CreateMainApp(s.mainAppEnv, s.mainAppArgs)
 
 	if err := s.mainApp.Start(); err != nil {

--- a/test/framework/universal_clusters.go
+++ b/test/framework/universal_clusters.go
@@ -186,10 +186,6 @@ func (cs *UniversalClusters) Exec(string, string, string, ...string) (string, st
 	panic("not supported")
 }
 
-func (cs *UniversalClusters) ExecWithRetries(string, string, string, ...string) (string, string, error) {
-	panic("not supported")
-}
-
 func (cs *UniversalClusters) Deployment(string) Deployment {
 	panic("not supported")
 }


### PR DESCRIPTION
Use Eventually instead to make output easier to understand and tests more predictable

Signed-off-by: Charly Molter <charly.molter@konghq.com>

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] Link to docs PR or issue --
- [x] Link to UI issue or PR --
- [x] Is the [issue worked on linked][1]? --
- [x] The PR does not hardcode values that might break projects that depend on kuma (e.g. "kumahq" as a image registry) --
- [x] The PR will work for both Linux and Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Unit Tests --
- [x] E2E Tests --
- [x] Manual Universal Tests --
- [x] Manual Kubernetes Tests --
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [x] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
