### PR TITLE
test(e2e): fix name collision in mesh circuit breaker

### DIFF
--- a/test/e2e_env/kubernetes/meshcircuitbreaker/api.go
+++ b/test/e2e_env/kubernetes/meshcircuitbreaker/api.go
@@ -41,7 +41,7 @@ func API() {
 apiVersion: kuma.io/v1alpha1
 kind: MeshCircuitBreaker
 metadata:
-  name: mcb1
+  name: mcb-api-1
   namespace: %s
   labels:
     kuma.io/mesh: meshcircuitbreaker-api
@@ -91,7 +91,7 @@ spec:
 		mcb, err = env.Cluster.GetKumactlOptions().KumactlList("meshcircuitbreakers", meshName)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(mcb).To(HaveLen(1))
-		Expect(mcb[0]).To(Equal(fmt.Sprintf("mcb1.%s", Config.KumaNamespace)))
+		Expect(mcb[0]).To(Equal(fmt.Sprintf("mcb-api-1.%s", Config.KumaNamespace)))
 	})
 
 	It("should deny creating policy in the non-system namespace", func() {
@@ -107,7 +107,7 @@ spec:
 apiVersion: kuma.io/v1alpha1
 kind: MeshCircuitBreaker
 metadata:
-  name: mcb1
+  name: mcb-api-invalid
   namespace: default
   labels:
     kuma.io/mesh: meshcircuitbreaker-api

--- a/test/e2e_env/kubernetes/meshcircuitbreaker/meshcircuitbreaker.go
+++ b/test/e2e_env/kubernetes/meshcircuitbreaker/meshcircuitbreaker.go
@@ -87,7 +87,7 @@ func MeshCircuitBreaker() {
 apiVersion: kuma.io/v1alpha1
 kind: MeshCircuitBreaker
 metadata:
-  name: mcb1
+  name: mcb-outbound
   namespace: %s
   labels:
     kuma.io/mesh: %s
@@ -109,7 +109,7 @@ spec:
 apiVersion: kuma.io/v1alpha1
 kind: MeshCircuitBreaker
 metadata:
-  name: mcb1
+  name: mcb-inbound
   namespace: %s
   labels:
     kuma.io/mesh: %s


### PR DESCRIPTION
There was a name collision between two tests.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [ ] Link to docs PR or issue --
- [ ] Link to UI issue or PR --
- [ ] Is the [issue worked on linked][1]? --
- [ ] The PR does not hardcode values that might break projects that depend on kuma (e.g. "kumahq" as a image registry) --
- [ ] The PR will work for both Linux and Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [ ] Unit Tests --
- [ ] E2E Tests --
- [ ] Manual Universal Tests --
- [ ] Manual Kubernetes Tests --
- [ ] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [ ] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [ ] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
