### PR TITLE
fix(kuma-cp): allow to set policies order from others projects

### DIFF
--- a/pkg/plugins/policies/policies.go
+++ b/pkg/plugins/policies/policies.go
@@ -22,3 +22,7 @@ var policies = []plugins.PluginName{
 func Enabled() []plugins.PluginName {
 	return policies
 }
+
+func SetPolicies(newPolicies []plugins.PluginName){
+	policies = newPolicies
+}

--- a/pkg/plugins/policies/policies.go
+++ b/pkg/plugins/policies/policies.go
@@ -23,6 +23,6 @@ func Enabled() []plugins.PluginName {
 	return policies
 }
 
-func SetPolicies(newPolicies []plugins.PluginName){
+func SetPolicies(newPolicies []plugins.PluginName) {
 	policies = newPolicies
 }

--- a/pkg/plugins/policies/policies.go
+++ b/pkg/plugins/policies/policies.go
@@ -10,19 +10,11 @@ import (
 	meshtrafficpermission_api "github.com/kumahq/kuma/pkg/plugins/policies/meshtrafficpermission/api/v1alpha1"
 )
 
-var policies = []plugins.PluginName{
+var Policies = []plugins.PluginName{
 	plugins.PluginName(meshaccesslog_api.MeshAccessLogResourceTypeDescriptor.KumactlArg),
 	plugins.PluginName(meshtrace_api.MeshTraceResourceTypeDescriptor.KumactlArg),
 	plugins.PluginName(meshratelimit_api.MeshRateLimitResourceTypeDescriptor.KumactlArg),
 	plugins.PluginName(meshtimeout_api.MeshTimeoutResourceTypeDescriptor.KumactlArg),
 	plugins.PluginName(meshtrafficpermission_api.MeshTrafficPermissionResourceTypeDescriptor.KumactlArg),
 	plugins.PluginName(meshcircuitbreaker_api.MeshCircuitBreakerResourceTypeDescriptor.KumactlArg),
-}
-
-func Enabled() []plugins.PluginName {
-	return policies
-}
-
-func SetPolicies(newPolicies []plugins.PluginName) {
-	policies = newPolicies
 }

--- a/pkg/xds/server/v3/reconcile.go
+++ b/pkg/xds/server/v3/reconcile.go
@@ -175,7 +175,7 @@ func (s *TemplateSnapshotGenerator) GenerateSnapshot(ctx xds_context.Context, pr
 		return nil, err
 	}
 	allPolicies := plugins.Plugins().PolicyPlugins()
-	for _, policyName := range policies.Enabled() {
+	for _, policyName := range policies.Policies {
 		policy, exists := allPolicies[policyName]
 		if !exists {
 			reconcileLog.Error(errors.Errorf("policy doesn't exist"), "failed to apply policy's changes", "policyName", policyName)


### PR DESCRIPTION
If someone inherits Kuma and wants to create a new policy and set it in a specific order that wasn't possible. Added function that allows setting order of the policies.
- [X] Link to docs PR or issue --
- [X] Link to UI issue or PR --
- [X] Is the [issue worked on linked][1]? --
- [X] The PR does not hardcode values that might break projects that depend on kuma (e.g. "kumahq" as a image registry) -- fixes possibility to set from other project
- [X] The PR will work for both Linux and Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [X] Unit Tests --
- [X] E2E Tests --
- [X] Manual Universal Tests --
- [X] Manual Kubernetes Tests --
- [X] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [X] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [X] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
