### PR TITLE
test(e2e): adjust probes, add delay to graceful test

### DIFF
--- a/test/framework/deployments/testserver/kubernetes.go
+++ b/test/framework/deployments/testserver/kubernetes.go
@@ -137,7 +137,9 @@ func (k *k8SDeployment) podSpec() corev1.PodTemplateSpec {
 				},
 			},
 			InitialDelaySeconds: 3,
-			PeriodSeconds:       3,
+			PeriodSeconds:       5,
+			TimeoutSeconds:      3,
+			FailureThreshold:    60,
 		}
 		readiness = &corev1.Probe{
 			ProbeHandler: corev1.ProbeHandler{
@@ -147,7 +149,9 @@ func (k *k8SDeployment) podSpec() corev1.PodTemplateSpec {
 				},
 			},
 			InitialDelaySeconds: 3,
-			PeriodSeconds:       3,
+			PeriodSeconds:       5,
+			TimeoutSeconds:      3,
+			FailureThreshold:    12,
 		}
 	}
 	if !k.opts.EnableProbes {


### PR DESCRIPTION
I managed to reproduce this flake on my VM with 14 threads when I run the tests with "--procs 30".
Sometimes the app container is just marked as unhealthy (and killed) because of "quite aggressive" probes.
The test was flakier with time which would indicate that the more test we add - the more flaky the graceful test is.
Because we are running many test in parallel and we hammer the app with requests, it was quite likely that the app would respond on the probe longer than 1 second (default, it was not set) 3 times in a row.

I adjusted the probes to be the same as kuma-sidecar. This helped to pass the test on my machine every single time.
Additionally, I introduced slight delay with every request.
If we still experience fails with this test, I'd move it from `e2e_env` to `e2e` to have a separation of resources.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [ ] Link to docs PR or issue --
- [ ] Link to UI issue or PR --
- [ ] Is the [issue worked on linked][1]? --
- [ ] The PR does not hardcode values that might break projects that depend on kuma (e.g. "kumahq" as a image registry) --
- [ ] The PR will work for both Linux and Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [ ] Unit Tests --
- [ ] E2E Tests --
- [ ] Manual Universal Tests --
- [ ] Manual Kubernetes Tests --
- [ ] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [ ] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [ ] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
