### PR TITLE
build: add skipDefault to policy generation

### DIFF
--- a/tools/policy-gen/generator/cmd/helpers.go
+++ b/tools/policy-gen/generator/cmd/helpers.go
@@ -34,6 +34,7 @@ func newHelpers(rootArgs *args) *cobra.Command {
 				"version":               pconfig.Package,
 				"generateTo":            pconfig.HasTo,
 				"generateFrom":          pconfig.HasFrom,
+				"skipDefault":           pconfig.SkipDefault,
 				"generateGetPolicyItem": !pconfig.HasFrom && !pconfig.HasTo,
 			}, outPath)
 		},
@@ -64,10 +65,12 @@ func (x *{{.name}}) GetTargetRef() common_api.TargetRef {
 func (x *From) GetTargetRef() common_api.TargetRef {
 	return x.TargetRef
 }
+{{ if not .skipDefault }}
 
 func (x *From) GetDefault() interface{} {
 	return x.Default
 }
+{{- end }}
 
 func (x *{{.name}}) GetFromList() []core_xds.PolicyItem {
 	var result []core_xds.PolicyItem

--- a/tools/policy-gen/generator/cmd/helpers.go
+++ b/tools/policy-gen/generator/cmd/helpers.go
@@ -86,10 +86,12 @@ func (x *{{.name}}) GetFromList() []core_xds.PolicyItem {
 func (x *To) GetTargetRef() common_api.TargetRef {
 	return x.TargetRef
 }
+{{ if not .skipDefault }}
 
 func (x *To) GetDefault() interface{} {
 	return x.Default
 }
+{{- end }}
 
 func (x *{{.name}}) GetToList() []core_xds.PolicyItem {
 	var result []core_xds.PolicyItem
@@ -102,10 +104,12 @@ func (x *{{.name}}) GetToList() []core_xds.PolicyItem {
 {{- end }}
 
 {{ if .generateGetPolicyItem}}
+{{ if not .skipDefault }}
 
 func (x *{{.name}}) GetDefault() interface{} {
 	return x.Default
 }
+{{- end }}
 
 func (x *{{.name}}) GetPolicyItem() core_xds.PolicyItem {
 	return &policyItem{

--- a/tools/policy-gen/generator/cmd/helpers.go
+++ b/tools/policy-gen/generator/cmd/helpers.go
@@ -34,7 +34,7 @@ func newHelpers(rootArgs *args) *cobra.Command {
 				"version":               pconfig.Package,
 				"generateTo":            pconfig.HasTo,
 				"generateFrom":          pconfig.HasFrom,
-				"skipDefault":           pconfig.SkipDefault,
+				"skipGetDefault":        pconfig.SkipGetDefault,
 				"generateGetPolicyItem": !pconfig.HasFrom && !pconfig.HasTo,
 			}, outPath)
 		},
@@ -65,7 +65,7 @@ func (x *{{.name}}) GetTargetRef() common_api.TargetRef {
 func (x *From) GetTargetRef() common_api.TargetRef {
 	return x.TargetRef
 }
-{{ if not .skipDefault }}
+{{ if not .skipGetDefault }}
 
 func (x *From) GetDefault() interface{} {
 	return x.Default
@@ -86,7 +86,7 @@ func (x *{{.name}}) GetFromList() []core_xds.PolicyItem {
 func (x *To) GetTargetRef() common_api.TargetRef {
 	return x.TargetRef
 }
-{{ if not .skipDefault }}
+{{ if not .skipGetDefault }}
 
 func (x *To) GetDefault() interface{} {
 	return x.Default
@@ -104,7 +104,7 @@ func (x *{{.name}}) GetToList() []core_xds.PolicyItem {
 {{- end }}
 
 {{ if .generateGetPolicyItem}}
-{{ if not .skipDefault }}
+{{ if not .skipGetDefault }}
 
 func (x *{{.name}}) GetDefault() interface{} {
 	return x.Default

--- a/tools/policy-gen/generator/pkg/parse/policyconfig.go
+++ b/tools/policy-gen/generator/pkg/parse/policyconfig.go
@@ -19,7 +19,7 @@ type PolicyConfig struct {
 	NameLower           string
 	Plural              string
 	SkipRegistration    bool
-	SkipDefault         bool
+	SkipGetDefault      bool
 	SingularDisplayName string
 	PluralDisplayName   string
 	Path                string
@@ -128,8 +128,8 @@ func newPolicyConfig(pkg, name string, markers map[string]string, hasTo, hasFrom
 	if v, ok := parseBool(markers, "kuma:policy:skip_registration"); ok {
 		res.SkipRegistration = v
 	}
-	if v, ok := parseBool(markers, "kuma:policy:skip_default"); ok {
-		res.SkipDefault = v
+	if v, ok := parseBool(markers, "kuma:policy:skip_get_default"); ok {
+		res.SkipGetDefault = v
 	}
 
 	if v, ok := markers["kuma:policy:plural"]; ok {

--- a/tools/policy-gen/generator/pkg/parse/policyconfig.go
+++ b/tools/policy-gen/generator/pkg/parse/policyconfig.go
@@ -19,6 +19,7 @@ type PolicyConfig struct {
 	NameLower           string
 	Plural              string
 	SkipRegistration    bool
+	SkipDefault         bool
 	SingularDisplayName string
 	PluralDisplayName   string
 	Path                string
@@ -100,6 +101,18 @@ func parseMarkers(cg *ast.CommentGroup) (map[string]string, error) {
 	return result, nil
 }
 
+func parseBool(markers map[string]string, key string) (bool, bool) {
+	if v, ok := markers[key]; ok {
+		vbool, err := strconv.ParseBool(v)
+		if err != nil {
+			return false, false
+		}
+		return vbool, true
+	}
+
+	return false, false
+}
+
 func newPolicyConfig(pkg, name string, markers map[string]string, hasTo, hasFrom bool) (PolicyConfig, error) {
 	res := PolicyConfig{
 		Package:             pkg,
@@ -112,12 +125,11 @@ func newPolicyConfig(pkg, name string, markers map[string]string, hasTo, hasFrom
 		HasFrom:             hasFrom,
 	}
 
-	if v, ok := markers["kuma:policy:skip_registration"]; ok {
-		vbool, err := strconv.ParseBool(v)
-		if err != nil {
-			return PolicyConfig{}, err
-		}
-		res.SkipRegistration = vbool
+	if v, ok := parseBool(markers, "kuma:policy:skip_registration"); ok {
+		res.SkipRegistration = v
+	}
+	if v, ok := parseBool(markers, "kuma:policy:skip_default"); ok {
+		res.SkipDefault = v
 	}
 
 	if v, ok := markers["kuma:policy:plural"]; ok {


### PR DESCRIPTION
This allows for custom implementations of `GetDefault`, which allow for a more flexible schema that can still be merged using the generic policy code. See https://github.com/kumahq/kuma/blob/5aec8ae01195f02ead983e139d988877a87f6c28/pkg/plugins/policies/meshhttproute/api/v1alpha1/zz_generated.helpers.go#L20-L28

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] Link to docs PR or issue --
- [x] Link to UI issue or PR --
- [x] Is the [issue worked on linked][1]? --
- [x] The PR does not hardcode values that might break projects that depend on kuma (e.g. "kumahq" as a image registry) --
- [x] The PR will work for both Linux and Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Unit Tests --
- [x] E2E Tests --
- [x] Manual Universal Tests --
- [x] Manual Kubernetes Tests --
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [x] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
