### PR TITLE
feat: utils for pointers

### DIFF
--- a/pkg/core/resources/model/utils.go
+++ b/pkg/core/resources/model/utils.go
@@ -92,7 +92,3 @@ func IsEmpty(spec ResourceSpec) bool {
 		return reflect.ValueOf(spec).Elem().IsZero()
 	}
 }
-
-func PtrTo[T any](t T) *T {
-	return &t
-}

--- a/pkg/plugins/policies/meshtrace/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshtrace/plugin/v1alpha1/plugin_test.go
@@ -15,6 +15,7 @@ import (
 	plugin "github.com/kumahq/kuma/pkg/plugins/policies/meshtrace/plugin/v1alpha1"
 	policies_xds "github.com/kumahq/kuma/pkg/plugins/policies/xds"
 	test_model "github.com/kumahq/kuma/pkg/test/resources/model"
+	"github.com/kumahq/kuma/pkg/util/pointer"
 	xds_context "github.com/kumahq/kuma/pkg/xds/context"
 	envoy_common "github.com/kumahq/kuma/pkg/xds/envoy"
 	. "github.com/kumahq/kuma/pkg/xds/envoy/listeners"
@@ -109,12 +110,12 @@ var _ = Describe("MeshTrace", func() {
 						Subset: []core_xds.Tag{},
 						Conf: api.Conf{
 							Sampling: api.Sampling{
-								Random: core_model.PtrTo(uint32(50)),
+								Random: pointer.To(uint32(50)),
 							},
 							Backends: []api.Backend{{
 								Zipkin: &api.ZipkinBackend{
 									Url:               "http://jaeger-collector.mesh-observability:9411/api/v2/spans",
-									SharedSpanContext: core_model.PtrTo(true),
+									SharedSpanContext: pointer.To(true),
 									ApiVersion:        "httpProto",
 									TraceId128Bit:     true,
 								},
@@ -208,7 +209,7 @@ var _ = Describe("MeshTrace", func() {
 						Subset: []core_xds.Tag{},
 						Conf: api.Conf{
 							Sampling: api.Sampling{
-								Random: core_model.PtrTo(uint32(50)),
+								Random: pointer.To(uint32(50)),
 							},
 							Backends: []api.Backend{{
 								Datadog: &api.DatadogBackend{

--- a/pkg/util/pointer/pointer.go
+++ b/pkg/util/pointer/pointer.go
@@ -1,0 +1,15 @@
+package pointer
+
+// Deref returns the value the pointer points to. If ptr is nil the function returns zero value
+func Deref[T any](ptr *T) T {
+	if ptr == nil {
+		var zero T
+		return zero
+	}
+	return *ptr
+}
+
+// To returns pointer to the passed value
+func To[T any](t T) *T {
+	return &t
+}


### PR DESCRIPTION
Functions for access to policy pointer fields when we don't have to distinguish between zero and nil values.

Signed-off-by: Ilya Lobkov <ilya.lobkov@konghq.com>

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [X] Link to docs PR or issue --
- [X] Link to UI issue or PR --
- [X] Is the [issue worked on linked][1]? --
- [X] The PR does not hardcode values that might break projects that depend on kuma (e.g. "kumahq" as a image registry) --
- [X] The PR will work for both Linux and Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [X] Unit Tests --
- [X] E2E Tests --
- [X] Manual Universal Tests --
- [X] Manual Kubernetes Tests --
- [X] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [X] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [X] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
