### PR TITLE
fix: wrong assertion in test

### DIFF
--- a/pkg/plugins/resources/postgres/store_suite_test.go
+++ b/pkg/plugins/resources/postgres/store_suite_test.go
@@ -20,10 +20,9 @@ func TestPostgresStore(t *testing.T) {
 		Expect(c.Start()).To(Succeed())
 	})
 	AfterSuite(func() {
-		err := c.Stop()
-		if err != nil {
+		if err := c.Stop(); err != nil {
 			// Exception around delete image bug: https://github.com/moby/moby/issues/44290
-			Expect(err).To(ContainSubstring(err.Error(), "unrecognized image"))
+			Expect(err.Error()).To(ContainSubstring("unrecognized image"))
 		}
 	})
 	test.RunSpecs(t, "Postgres Resource Store Suite")


### PR DESCRIPTION
CI fail https://app.circleci.com/pipelines/github/kumahq/kuma/18318/workflows/275912cc-d897-486b-a21b-82c71436d81b/jobs/286531

Signed-off-by: Ilya Lobkov <ilya.lobkov@konghq.com>

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [X] Link to docs PR or issue --
- [X] Link to UI issue or PR --
- [X] Is the [issue worked on linked][1]? --
- [X] The PR does not hardcode values that might break projects that depend on kuma (e.g. "kumahq" as a image registry) --
- [X] The PR will work for both Linux and Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [X] Unit Tests --
- [X] E2E Tests --
- [X] Manual Universal Tests --
- [X] Manual Kubernetes Tests --
- [X] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [X] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [X] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
