### PR TITLE
fix(kuma-dp): tolerate endline in token file

### DIFF
--- a/app/kuma-dp/pkg/config/validate_test.go
+++ b/app/kuma-dp/pkg/config/validate_test.go
@@ -1,8 +1,8 @@
 package config_test
 
 import (
-	"fmt"
 	"os"
+	"strings"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -12,29 +12,9 @@ import (
 
 var _ = Describe("ValidateTokenPath", func() {
 
-	var tokenFile *os.File
-
-	BeforeEach(func() {
-		tf, err := os.CreateTemp("", "")
-		Expect(err).ToNot(HaveOccurred())
-		tokenFile = tf
-	})
-
 	It("should pass validation for empty path", func() {
 		// when
 		err := config.ValidateTokenPath("")
-
-		// then
-		Expect(err).ToNot(HaveOccurred())
-	})
-
-	It("should pass validation for empty path", func() {
-		// given
-		_, err := tokenFile.WriteString("sampletoken")
-		Expect(err).ToNot(HaveOccurred())
-
-		// when
-		err = config.ValidateTokenPath("")
 
 		// then
 		Expect(err).ToNot(HaveOccurred())
@@ -48,18 +28,10 @@ var _ = Describe("ValidateTokenPath", func() {
 		Expect(err).To(MatchError("could not read file nonexistingfile: stat nonexistingfile: no such file or directory"))
 	})
 
-	It("should fail for empty file", func() {
-		// when
-		err := config.ValidateTokenPath(tokenFile.Name())
-
-		// then
-		Expect(err).To(MatchError(fmt.Sprintf("token under file %s is empty", tokenFile.Name())))
-	})
-
-	Context("should valicate token", func() {
+	Context("should validate token", func() {
 		type testCase struct {
-			token    string
-			expected string
+			token         string
+			expectedError string
 		}
 		DescribeTable("should fail with invalid token",
 			func(given testCase) {
@@ -73,21 +45,35 @@ var _ = Describe("ValidateTokenPath", func() {
 				// when
 				err = config.ValidateTokenPath(invalidTokenFile.Name())
 
-				// then
-				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).To(Equal(given.expected))
+				if given.expectedError == "" {
+					Expect(err).ToNot(HaveOccurred())
+				} else {
+					// then
+					Expect(err).To(HaveOccurred())
+					Expect(err.Error()).To(Equal(strings.ReplaceAll(given.expectedError, "{}", invalidTokenFile.Name())))
+				}
 			},
+			Entry("empty file", testCase{
+				token:         "",
+				expectedError: "token under file {} is empty",
+			}),
 			Entry("can't parse token", testCase{
-				token:    "yJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJOYW1lIjoidGVzdCIsIk1lc2giOiJkZWZhdWx0IiwiVGFncyI6e30sIlR5cGUiOiIifQ.rdQ6l_6hzT93Kbk9kO-kZYY7BaexUH8QknvbdRy_f6s",
-				expected: "not valid JWT token. Can't parse it.: invalid character 'È' looking for beginning of value",
+				token:         "yJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJOYW1lIjoidGVzdCIsIk1lc2giOiJkZWZhdWx0IiwiVGFncyI6e30sIlR5cGUiOiIifQ.rdQ6l_6hzT93Kbk9kO-kZYY7BaexUH8QknvbdRy_f6s",
+				expectedError: "not valid JWT token. Can't parse it.: invalid character 'È' looking for beginning of value",
 			}),
 			Entry("need 3 segments", testCase{
-				token:    "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJOYW1lIjoidGVzdCIsIk1lc2giOiJkZWZhdWx0IiwiVGFncyI6e30sIlR5cGUiOiIifQ",
-				expected: "not valid JWT token. Can't parse it.: token contains an invalid number of segments",
+				token:         "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJOYW1lIjoidGVzdCIsIk1lc2giOiJkZWZhdWx0IiwiVGFncyI6e30sIlR5cGUiOiIifQ",
+				expectedError: "not valid JWT token. Can't parse it.: token contains an invalid number of segments",
 			}),
-			Entry("new line in the end ", testCase{
-				token:    "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJOYW1lIjoidGVzdCIsIk1lc2giOiJkZWZhdWx0IiwiVGFncyI6e30sIlR5cGUiOiIifQ.rdQ6l_6hzT93Kbk9kO-kZYY7BaexUH8QknvbdRy_f6s\n",
-				expected: "The file cannot have blank characters like empty lines. Example how to get rid of non-printable characters: sed -i '' '/^$/d' token.file",
+			Entry("new line in the end", testCase{
+				token: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJOYW1lIjoidGVzdCIsIk1lc2giOiJkZWZhdWx0IiwiVGFncyI6e30sIlR5cGUiOiIifQ.rdQ6l_6hzT93Kbk9kO-kZYY7BaexUH8QknvbdRy_f6s\n",
+			}),
+			Entry("new line at the start", testCase{
+				token: "\neyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJOYW1lIjoidGVzdCIsIk1lc2giOiJkZWZhdWx0IiwiVGFncyI6e30sIlR5cGUiOiIifQ.rdQ6l_6hzT93Kbk9kO-kZYY7BaexUH8QknvbdRy_f6s\n",
+			}),
+			Entry("new line in the middle", testCase{
+				token:         "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpX\nVCJ9.eyJOYW1lIjoidGVzdCIsIk1lc2giOiJkZWZhdWx0IiwiVGFncyI6e30sIlR5cGUiOiIifQ.rdQ6l_6hzT93Kbk9kO-kZYY7BaexUH8QknvbdRy_f6s\n",
+				expectedError: "Token shouldn't contain line breaks within the token, only at the start or end",
 			}),
 		)
 

--- a/app/kuma-dp/pkg/dataplane/envoy/remote_bootstrap.go
+++ b/app/kuma-dp/pkg/dataplane/envoy/remote_bootstrap.go
@@ -148,6 +148,8 @@ func (b *remoteBootstrap) requestForBootstrap(ctx context.Context, url *net_url.
 	if cfg.DataplaneRuntime.Token != "" {
 		token = cfg.DataplaneRuntime.Token
 	}
+	// Remove any trailing and starting spaces.
+	token = strings.TrimSpace(token)
 
 	resources := b.resourceMetadata(cfg.DataplaneRuntime.Resources)
 


### PR DESCRIPTION
This is overly strict validation is causing more problems than it is solving. We now simply trim the token data

Fix #4567

Signed-off-by: Charly Molter <charly.molter@konghq.com>

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] Link to docs PR or issue --
- [x] Link to UI issue or PR --
- [x] Is the [issue worked on linked][1]? --
- [x] The PR does not hardcode values that might break projects that depend on kuma (e.g. "kumahq" as a image registry) --
- [x] The PR will work for both Linux and Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Unit Tests --
- [x] E2E Tests --
- [x] Manual Universal Tests --
- [x] Manual Kubernetes Tests --
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [x] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
