### PR TITLE
fix: make targetRef required

### DIFF
--- a/app/kumactl/cmd/install/testdata/install-control-plane.defaults.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.defaults.golden.yaml
@@ -1407,6 +1407,8 @@ spec:
                             tags. Can only be used with kinds `MeshSubset` and `MeshServiceSubset`
                           type: object
                       type: object
+                  required:
+                  - targetRef
                   type: object
                 type: array
               targetRef:
@@ -2917,6 +2919,8 @@ spec:
                             tags. Can only be used with kinds `MeshSubset` and `MeshServiceSubset`
                           type: object
                       type: object
+                  required:
+                  - targetRef
                   type: object
                 type: array
               targetRef:
@@ -3379,6 +3383,8 @@ spec:
                             tags. Can only be used with kinds `MeshSubset` and `MeshServiceSubset`
                           type: object
                       type: object
+                  required:
+                  - targetRef
                   type: object
                 type: array
               targetRef:

--- a/app/kumactl/cmd/install/testdata/install-control-plane.defaults.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.defaults.golden.yaml
@@ -799,8 +799,12 @@ spec:
                             tags. Can only be used with kinds `MeshSubset` and `MeshServiceSubset`
                           type: object
                       type: object
+                  required:
+                  - targetRef
                   type: object
                 type: array
+            required:
+            - targetRef
             type: object
         type: object
     served: true
@@ -998,6 +1002,8 @@ spec:
                             tags. Can only be used with kinds `MeshSubset` and `MeshServiceSubset`
                           type: object
                       type: object
+                  required:
+                  - targetRef
                   type: object
                 type: array
               targetRef:
@@ -1029,6 +1035,8 @@ spec:
                       Can only be used with kinds `MeshSubset` and `MeshServiceSubset`
                     type: object
                 type: object
+            required:
+            - targetRef
             type: object
         type: object
     served: true
@@ -1270,8 +1278,12 @@ spec:
                             tags. Can only be used with kinds `MeshSubset` and `MeshServiceSubset`
                           type: object
                       type: object
+                  required:
+                  - targetRef
                   type: object
                 type: array
+            required:
+            - targetRef
             type: object
         type: object
     served: true
@@ -1507,8 +1519,12 @@ spec:
                             tags. Can only be used with kinds `MeshSubset` and `MeshServiceSubset`
                           type: object
                       type: object
+                  required:
+                  - targetRef
                   type: object
                 type: array
+            required:
+            - targetRef
             type: object
         type: object
     served: true
@@ -1689,6 +1705,8 @@ spec:
                       Can only be used with kinds `MeshSubset` and `MeshServiceSubset`
                     type: object
                 type: object
+            required:
+            - targetRef
             type: object
         type: object
     served: true
@@ -1779,6 +1797,8 @@ spec:
                             tags. Can only be used with kinds `MeshSubset` and `MeshServiceSubset`
                           type: object
                       type: object
+                  required:
+                  - targetRef
                   type: object
                 type: array
               targetRef:
@@ -1810,6 +1830,8 @@ spec:
                       Can only be used with kinds `MeshSubset` and `MeshServiceSubset`
                     type: object
                 type: object
+            required:
+            - targetRef
             type: object
         type: object
     served: true
@@ -3023,8 +3045,12 @@ spec:
                             tags. Can only be used with kinds `MeshSubset` and `MeshServiceSubset`
                           type: object
                       type: object
+                  required:
+                  - targetRef
                   type: object
                 type: array
+            required:
+            - targetRef
             type: object
         type: object
     served: true
@@ -3669,8 +3695,12 @@ spec:
                             tags. Can only be used with kinds `MeshSubset` and `MeshServiceSubset`
                           type: object
                       type: object
+                  required:
+                  - targetRef
                   type: object
                 type: array
+            required:
+            - targetRef
             type: object
         type: object
     served: true

--- a/app/kumactl/cmd/install/testdata/install-control-plane.gateway-api-present-not-enabled.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.gateway-api-present-not-enabled.yaml
@@ -1407,6 +1407,8 @@ spec:
                             tags. Can only be used with kinds `MeshSubset` and `MeshServiceSubset`
                           type: object
                       type: object
+                  required:
+                  - targetRef
                   type: object
                 type: array
               targetRef:
@@ -2917,6 +2919,8 @@ spec:
                             tags. Can only be used with kinds `MeshSubset` and `MeshServiceSubset`
                           type: object
                       type: object
+                  required:
+                  - targetRef
                   type: object
                 type: array
               targetRef:
@@ -3379,6 +3383,8 @@ spec:
                             tags. Can only be used with kinds `MeshSubset` and `MeshServiceSubset`
                           type: object
                       type: object
+                  required:
+                  - targetRef
                   type: object
                 type: array
               targetRef:

--- a/app/kumactl/cmd/install/testdata/install-control-plane.gateway-api-present-not-enabled.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.gateway-api-present-not-enabled.yaml
@@ -799,8 +799,12 @@ spec:
                             tags. Can only be used with kinds `MeshSubset` and `MeshServiceSubset`
                           type: object
                       type: object
+                  required:
+                  - targetRef
                   type: object
                 type: array
+            required:
+            - targetRef
             type: object
         type: object
     served: true
@@ -998,6 +1002,8 @@ spec:
                             tags. Can only be used with kinds `MeshSubset` and `MeshServiceSubset`
                           type: object
                       type: object
+                  required:
+                  - targetRef
                   type: object
                 type: array
               targetRef:
@@ -1029,6 +1035,8 @@ spec:
                       Can only be used with kinds `MeshSubset` and `MeshServiceSubset`
                     type: object
                 type: object
+            required:
+            - targetRef
             type: object
         type: object
     served: true
@@ -1270,8 +1278,12 @@ spec:
                             tags. Can only be used with kinds `MeshSubset` and `MeshServiceSubset`
                           type: object
                       type: object
+                  required:
+                  - targetRef
                   type: object
                 type: array
+            required:
+            - targetRef
             type: object
         type: object
     served: true
@@ -1507,8 +1519,12 @@ spec:
                             tags. Can only be used with kinds `MeshSubset` and `MeshServiceSubset`
                           type: object
                       type: object
+                  required:
+                  - targetRef
                   type: object
                 type: array
+            required:
+            - targetRef
             type: object
         type: object
     served: true
@@ -1689,6 +1705,8 @@ spec:
                       Can only be used with kinds `MeshSubset` and `MeshServiceSubset`
                     type: object
                 type: object
+            required:
+            - targetRef
             type: object
         type: object
     served: true
@@ -1779,6 +1797,8 @@ spec:
                             tags. Can only be used with kinds `MeshSubset` and `MeshServiceSubset`
                           type: object
                       type: object
+                  required:
+                  - targetRef
                   type: object
                 type: array
               targetRef:
@@ -1810,6 +1830,8 @@ spec:
                       Can only be used with kinds `MeshSubset` and `MeshServiceSubset`
                     type: object
                 type: object
+            required:
+            - targetRef
             type: object
         type: object
     served: true
@@ -3023,8 +3045,12 @@ spec:
                             tags. Can only be used with kinds `MeshSubset` and `MeshServiceSubset`
                           type: object
                       type: object
+                  required:
+                  - targetRef
                   type: object
                 type: array
+            required:
+            - targetRef
             type: object
         type: object
     served: true
@@ -3669,8 +3695,12 @@ spec:
                             tags. Can only be used with kinds `MeshSubset` and `MeshServiceSubset`
                           type: object
                       type: object
+                  required:
+                  - targetRef
                   type: object
                 type: array
+            required:
+            - targetRef
             type: object
         type: object
     served: true

--- a/app/kumactl/cmd/install/testdata/install-control-plane.gateway-api-present.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.gateway-api-present.yaml
@@ -1539,6 +1539,8 @@ spec:
                             tags. Can only be used with kinds `MeshSubset` and `MeshServiceSubset`
                           type: object
                       type: object
+                  required:
+                  - targetRef
                   type: object
                 type: array
               targetRef:
@@ -3049,6 +3051,8 @@ spec:
                             tags. Can only be used with kinds `MeshSubset` and `MeshServiceSubset`
                           type: object
                       type: object
+                  required:
+                  - targetRef
                   type: object
                 type: array
               targetRef:
@@ -3511,6 +3515,8 @@ spec:
                             tags. Can only be used with kinds `MeshSubset` and `MeshServiceSubset`
                           type: object
                       type: object
+                  required:
+                  - targetRef
                   type: object
                 type: array
               targetRef:

--- a/app/kumactl/cmd/install/testdata/install-control-plane.gateway-api-present.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.gateway-api-present.yaml
@@ -931,8 +931,12 @@ spec:
                             tags. Can only be used with kinds `MeshSubset` and `MeshServiceSubset`
                           type: object
                       type: object
+                  required:
+                  - targetRef
                   type: object
                 type: array
+            required:
+            - targetRef
             type: object
         type: object
     served: true
@@ -1130,6 +1134,8 @@ spec:
                             tags. Can only be used with kinds `MeshSubset` and `MeshServiceSubset`
                           type: object
                       type: object
+                  required:
+                  - targetRef
                   type: object
                 type: array
               targetRef:
@@ -1161,6 +1167,8 @@ spec:
                       Can only be used with kinds `MeshSubset` and `MeshServiceSubset`
                     type: object
                 type: object
+            required:
+            - targetRef
             type: object
         type: object
     served: true
@@ -1402,8 +1410,12 @@ spec:
                             tags. Can only be used with kinds `MeshSubset` and `MeshServiceSubset`
                           type: object
                       type: object
+                  required:
+                  - targetRef
                   type: object
                 type: array
+            required:
+            - targetRef
             type: object
         type: object
     served: true
@@ -1639,8 +1651,12 @@ spec:
                             tags. Can only be used with kinds `MeshSubset` and `MeshServiceSubset`
                           type: object
                       type: object
+                  required:
+                  - targetRef
                   type: object
                 type: array
+            required:
+            - targetRef
             type: object
         type: object
     served: true
@@ -1821,6 +1837,8 @@ spec:
                       Can only be used with kinds `MeshSubset` and `MeshServiceSubset`
                     type: object
                 type: object
+            required:
+            - targetRef
             type: object
         type: object
     served: true
@@ -1956,6 +1974,8 @@ spec:
                             tags. Can only be used with kinds `MeshSubset` and `MeshServiceSubset`
                           type: object
                       type: object
+                  required:
+                  - targetRef
                   type: object
                 type: array
               targetRef:
@@ -1987,6 +2007,8 @@ spec:
                       Can only be used with kinds `MeshSubset` and `MeshServiceSubset`
                     type: object
                 type: object
+            required:
+            - targetRef
             type: object
         type: object
     served: true
@@ -3155,8 +3177,12 @@ spec:
                             tags. Can only be used with kinds `MeshSubset` and `MeshServiceSubset`
                           type: object
                       type: object
+                  required:
+                  - targetRef
                   type: object
                 type: array
+            required:
+            - targetRef
             type: object
         type: object
     served: true
@@ -3801,8 +3827,12 @@ spec:
                             tags. Can only be used with kinds `MeshSubset` and `MeshServiceSubset`
                           type: object
                       type: object
+                  required:
+                  - targetRef
                   type: object
                 type: array
+            required:
+            - targetRef
             type: object
         type: object
     served: true

--- a/app/kumactl/cmd/install/testdata/install-control-plane.with-helm-set.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.with-helm-set.yaml
@@ -819,8 +819,12 @@ spec:
                             tags. Can only be used with kinds `MeshSubset` and `MeshServiceSubset`
                           type: object
                       type: object
+                  required:
+                  - targetRef
                   type: object
                 type: array
+            required:
+            - targetRef
             type: object
         type: object
     served: true
@@ -1018,6 +1022,8 @@ spec:
                             tags. Can only be used with kinds `MeshSubset` and `MeshServiceSubset`
                           type: object
                       type: object
+                  required:
+                  - targetRef
                   type: object
                 type: array
               targetRef:
@@ -1049,6 +1055,8 @@ spec:
                       Can only be used with kinds `MeshSubset` and `MeshServiceSubset`
                     type: object
                 type: object
+            required:
+            - targetRef
             type: object
         type: object
     served: true
@@ -1290,8 +1298,12 @@ spec:
                             tags. Can only be used with kinds `MeshSubset` and `MeshServiceSubset`
                           type: object
                       type: object
+                  required:
+                  - targetRef
                   type: object
                 type: array
+            required:
+            - targetRef
             type: object
         type: object
     served: true
@@ -1527,8 +1539,12 @@ spec:
                             tags. Can only be used with kinds `MeshSubset` and `MeshServiceSubset`
                           type: object
                       type: object
+                  required:
+                  - targetRef
                   type: object
                 type: array
+            required:
+            - targetRef
             type: object
         type: object
     served: true
@@ -1709,6 +1725,8 @@ spec:
                       Can only be used with kinds `MeshSubset` and `MeshServiceSubset`
                     type: object
                 type: object
+            required:
+            - targetRef
             type: object
         type: object
     served: true
@@ -1799,6 +1817,8 @@ spec:
                             tags. Can only be used with kinds `MeshSubset` and `MeshServiceSubset`
                           type: object
                       type: object
+                  required:
+                  - targetRef
                   type: object
                 type: array
               targetRef:
@@ -1830,6 +1850,8 @@ spec:
                       Can only be used with kinds `MeshSubset` and `MeshServiceSubset`
                     type: object
                 type: object
+            required:
+            - targetRef
             type: object
         type: object
     served: true
@@ -3043,8 +3065,12 @@ spec:
                             tags. Can only be used with kinds `MeshSubset` and `MeshServiceSubset`
                           type: object
                       type: object
+                  required:
+                  - targetRef
                   type: object
                 type: array
+            required:
+            - targetRef
             type: object
         type: object
     served: true
@@ -3689,8 +3715,12 @@ spec:
                             tags. Can only be used with kinds `MeshSubset` and `MeshServiceSubset`
                           type: object
                       type: object
+                  required:
+                  - targetRef
                   type: object
                 type: array
+            required:
+            - targetRef
             type: object
         type: object
     served: true

--- a/app/kumactl/cmd/install/testdata/install-control-plane.with-helm-set.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.with-helm-set.yaml
@@ -1427,6 +1427,8 @@ spec:
                             tags. Can only be used with kinds `MeshSubset` and `MeshServiceSubset`
                           type: object
                       type: object
+                  required:
+                  - targetRef
                   type: object
                 type: array
               targetRef:
@@ -2937,6 +2939,8 @@ spec:
                             tags. Can only be used with kinds `MeshSubset` and `MeshServiceSubset`
                           type: object
                       type: object
+                  required:
+                  - targetRef
                   type: object
                 type: array
               targetRef:
@@ -3399,6 +3403,8 @@ spec:
                             tags. Can only be used with kinds `MeshSubset` and `MeshServiceSubset`
                           type: object
                       type: object
+                  required:
+                  - targetRef
                   type: object
                 type: array
               targetRef:

--- a/app/kumactl/cmd/install/testdata/install-crds.all.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-crds.all.golden.yaml
@@ -642,8 +642,12 @@ spec:
                             tags. Can only be used with kinds `MeshSubset` and `MeshServiceSubset`
                           type: object
                       type: object
+                  required:
+                  - targetRef
                   type: object
                 type: array
+            required:
+            - targetRef
             type: object
         type: object
     served: true
@@ -1288,8 +1292,12 @@ spec:
                             tags. Can only be used with kinds `MeshSubset` and `MeshServiceSubset`
                           type: object
                       type: object
+                  required:
+                  - targetRef
                   type: object
                 type: array
+            required:
+            - targetRef
             type: object
         type: object
     served: true
@@ -1952,8 +1960,12 @@ spec:
                             tags. Can only be used with kinds `MeshSubset` and `MeshServiceSubset`
                           type: object
                       type: object
+                  required:
+                  - targetRef
                   type: object
                 type: array
+            required:
+            - targetRef
             type: object
         type: object
     served: true
@@ -2151,6 +2163,8 @@ spec:
                             tags. Can only be used with kinds `MeshSubset` and `MeshServiceSubset`
                           type: object
                       type: object
+                  required:
+                  - targetRef
                   type: object
                 type: array
               targetRef:
@@ -2182,6 +2196,8 @@ spec:
                       Can only be used with kinds `MeshSubset` and `MeshServiceSubset`
                     type: object
                 type: object
+            required:
+            - targetRef
             type: object
         type: object
     served: true
@@ -2423,8 +2439,12 @@ spec:
                             tags. Can only be used with kinds `MeshSubset` and `MeshServiceSubset`
                           type: object
                       type: object
+                  required:
+                  - targetRef
                   type: object
                 type: array
+            required:
+            - targetRef
             type: object
         type: object
     served: true
@@ -2660,8 +2680,12 @@ spec:
                             tags. Can only be used with kinds `MeshSubset` and `MeshServiceSubset`
                           type: object
                       type: object
+                  required:
+                  - targetRef
                   type: object
                 type: array
+            required:
+            - targetRef
             type: object
         type: object
     served: true
@@ -2842,6 +2866,8 @@ spec:
                       Can only be used with kinds `MeshSubset` and `MeshServiceSubset`
                     type: object
                 type: object
+            required:
+            - targetRef
             type: object
         type: object
     served: true
@@ -2932,6 +2958,8 @@ spec:
                             tags. Can only be used with kinds `MeshSubset` and `MeshServiceSubset`
                           type: object
                       type: object
+                  required:
+                  - targetRef
                   type: object
                 type: array
               targetRef:
@@ -2963,6 +2991,8 @@ spec:
                       Can only be used with kinds `MeshSubset` and `MeshServiceSubset`
                     type: object
                 type: object
+            required:
+            - targetRef
             type: object
         type: object
     served: true

--- a/app/kumactl/cmd/install/testdata/install-crds.all.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-crds.all.golden.yaml
@@ -514,6 +514,8 @@ spec:
                             tags. Can only be used with kinds `MeshSubset` and `MeshServiceSubset`
                           type: object
                       type: object
+                  required:
+                  - targetRef
                   type: object
                 type: array
               targetRef:
@@ -976,6 +978,8 @@ spec:
                             tags. Can only be used with kinds `MeshSubset` and `MeshServiceSubset`
                           type: object
                       type: object
+                  required:
+                  - targetRef
                   type: object
                 type: array
               targetRef:
@@ -2568,6 +2572,8 @@ spec:
                             tags. Can only be used with kinds `MeshSubset` and `MeshServiceSubset`
                           type: object
                       type: object
+                  required:
+                  - targetRef
                   type: object
                 type: array
               targetRef:

--- a/app/kumactl/cmd/install/testdata/install-crds.experimental-gatewayapi.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-crds.experimental-gatewayapi.golden.yaml
@@ -642,8 +642,12 @@ spec:
                             tags. Can only be used with kinds `MeshSubset` and `MeshServiceSubset`
                           type: object
                       type: object
+                  required:
+                  - targetRef
                   type: object
                 type: array
+            required:
+            - targetRef
             type: object
         type: object
     served: true
@@ -1288,8 +1292,12 @@ spec:
                             tags. Can only be used with kinds `MeshSubset` and `MeshServiceSubset`
                           type: object
                       type: object
+                  required:
+                  - targetRef
                   type: object
                 type: array
+            required:
+            - targetRef
             type: object
         type: object
     served: true
@@ -2084,8 +2092,12 @@ spec:
                             tags. Can only be used with kinds `MeshSubset` and `MeshServiceSubset`
                           type: object
                       type: object
+                  required:
+                  - targetRef
                   type: object
                 type: array
+            required:
+            - targetRef
             type: object
         type: object
     served: true
@@ -2283,6 +2295,8 @@ spec:
                             tags. Can only be used with kinds `MeshSubset` and `MeshServiceSubset`
                           type: object
                       type: object
+                  required:
+                  - targetRef
                   type: object
                 type: array
               targetRef:
@@ -2314,6 +2328,8 @@ spec:
                       Can only be used with kinds `MeshSubset` and `MeshServiceSubset`
                     type: object
                 type: object
+            required:
+            - targetRef
             type: object
         type: object
     served: true
@@ -2555,8 +2571,12 @@ spec:
                             tags. Can only be used with kinds `MeshSubset` and `MeshServiceSubset`
                           type: object
                       type: object
+                  required:
+                  - targetRef
                   type: object
                 type: array
+            required:
+            - targetRef
             type: object
         type: object
     served: true
@@ -2792,8 +2812,12 @@ spec:
                             tags. Can only be used with kinds `MeshSubset` and `MeshServiceSubset`
                           type: object
                       type: object
+                  required:
+                  - targetRef
                   type: object
                 type: array
+            required:
+            - targetRef
             type: object
         type: object
     served: true
@@ -2974,6 +2998,8 @@ spec:
                       Can only be used with kinds `MeshSubset` and `MeshServiceSubset`
                     type: object
                 type: object
+            required:
+            - targetRef
             type: object
         type: object
     served: true
@@ -3064,6 +3090,8 @@ spec:
                             tags. Can only be used with kinds `MeshSubset` and `MeshServiceSubset`
                           type: object
                       type: object
+                  required:
+                  - targetRef
                   type: object
                 type: array
               targetRef:
@@ -3095,6 +3123,8 @@ spec:
                       Can only be used with kinds `MeshSubset` and `MeshServiceSubset`
                     type: object
                 type: object
+            required:
+            - targetRef
             type: object
         type: object
     served: true

--- a/app/kumactl/cmd/install/testdata/install-crds.experimental-gatewayapi.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-crds.experimental-gatewayapi.golden.yaml
@@ -514,6 +514,8 @@ spec:
                             tags. Can only be used with kinds `MeshSubset` and `MeshServiceSubset`
                           type: object
                       type: object
+                  required:
+                  - targetRef
                   type: object
                 type: array
               targetRef:
@@ -976,6 +978,8 @@ spec:
                             tags. Can only be used with kinds `MeshSubset` and `MeshServiceSubset`
                           type: object
                       type: object
+                  required:
+                  - targetRef
                   type: object
                 type: array
               targetRef:
@@ -2700,6 +2704,8 @@ spec:
                             tags. Can only be used with kinds `MeshSubset` and `MeshServiceSubset`
                           type: object
                       type: object
+                  required:
+                  - targetRef
                   type: object
                 type: array
               targetRef:

--- a/deployments/charts/kuma/crds/kuma.io_meshaccesslogs.yaml
+++ b/deployments/charts/kuma/crds/kuma.io_meshaccesslogs.yaml
@@ -261,8 +261,12 @@ spec:
                             tags. Can only be used with kinds `MeshSubset` and `MeshServiceSubset`
                           type: object
                       type: object
+                  required:
+                  - targetRef
                   type: object
                 type: array
+            required:
+            - targetRef
             type: object
         type: object
     served: true

--- a/deployments/charts/kuma/crds/kuma.io_meshaccesslogs.yaml
+++ b/deployments/charts/kuma/crds/kuma.io_meshaccesslogs.yaml
@@ -133,6 +133,8 @@ spec:
                             tags. Can only be used with kinds `MeshSubset` and `MeshServiceSubset`
                           type: object
                       type: object
+                  required:
+                  - targetRef
                   type: object
                 type: array
               targetRef:

--- a/deployments/charts/kuma/crds/kuma.io_meshcircuitbreakers.yaml
+++ b/deployments/charts/kuma/crds/kuma.io_meshcircuitbreakers.yaml
@@ -322,6 +322,8 @@ spec:
                             tags. Can only be used with kinds `MeshSubset` and `MeshServiceSubset`
                           type: object
                       type: object
+                  required:
+                  - targetRef
                   type: object
                 type: array
               targetRef:

--- a/deployments/charts/kuma/crds/kuma.io_meshcircuitbreakers.yaml
+++ b/deployments/charts/kuma/crds/kuma.io_meshcircuitbreakers.yaml
@@ -638,8 +638,12 @@ spec:
                             tags. Can only be used with kinds `MeshSubset` and `MeshServiceSubset`
                           type: object
                       type: object
+                  required:
+                  - targetRef
                   type: object
                 type: array
+            required:
+            - targetRef
             type: object
         type: object
     served: true

--- a/deployments/charts/kuma/crds/kuma.io_meshhealthchecks.yaml
+++ b/deployments/charts/kuma/crds/kuma.io_meshhealthchecks.yaml
@@ -262,8 +262,12 @@ spec:
                             tags. Can only be used with kinds `MeshSubset` and `MeshServiceSubset`
                           type: object
                       type: object
+                  required:
+                  - targetRef
                   type: object
                 type: array
+            required:
+            - targetRef
             type: object
         type: object
     served: true

--- a/deployments/charts/kuma/crds/kuma.io_meshratelimits.yaml
+++ b/deployments/charts/kuma/crds/kuma.io_meshratelimits.yaml
@@ -146,6 +146,8 @@ spec:
                             tags. Can only be used with kinds `MeshSubset` and `MeshServiceSubset`
                           type: object
                       type: object
+                  required:
+                  - targetRef
                   type: object
                 type: array
               targetRef:
@@ -177,6 +179,8 @@ spec:
                       Can only be used with kinds `MeshSubset` and `MeshServiceSubset`
                     type: object
                 type: object
+            required:
+            - targetRef
             type: object
         type: object
     served: true

--- a/deployments/charts/kuma/crds/kuma.io_meshretries.yaml
+++ b/deployments/charts/kuma/crds/kuma.io_meshretries.yaml
@@ -235,8 +235,12 @@ spec:
                             tags. Can only be used with kinds `MeshSubset` and `MeshServiceSubset`
                           type: object
                       type: object
+                  required:
+                  - targetRef
                   type: object
                 type: array
+            required:
+            - targetRef
             type: object
         type: object
     served: true

--- a/deployments/charts/kuma/crds/kuma.io_meshtimeouts.yaml
+++ b/deployments/charts/kuma/crds/kuma.io_meshtimeouts.yaml
@@ -229,8 +229,12 @@ spec:
                             tags. Can only be used with kinds `MeshSubset` and `MeshServiceSubset`
                           type: object
                       type: object
+                  required:
+                  - targetRef
                   type: object
                 type: array
+            required:
+            - targetRef
             type: object
         type: object
     served: true

--- a/deployments/charts/kuma/crds/kuma.io_meshtimeouts.yaml
+++ b/deployments/charts/kuma/crds/kuma.io_meshtimeouts.yaml
@@ -117,6 +117,8 @@ spec:
                             tags. Can only be used with kinds `MeshSubset` and `MeshServiceSubset`
                           type: object
                       type: object
+                  required:
+                  - targetRef
                   type: object
                 type: array
               targetRef:

--- a/deployments/charts/kuma/crds/kuma.io_meshtraces.yaml
+++ b/deployments/charts/kuma/crds/kuma.io_meshtraces.yaml
@@ -174,6 +174,8 @@ spec:
                       Can only be used with kinds `MeshSubset` and `MeshServiceSubset`
                     type: object
                 type: object
+            required:
+            - targetRef
             type: object
         type: object
     served: true

--- a/deployments/charts/kuma/crds/kuma.io_meshtrafficpermissions.yaml
+++ b/deployments/charts/kuma/crds/kuma.io_meshtrafficpermissions.yaml
@@ -84,6 +84,8 @@ spec:
                             tags. Can only be used with kinds `MeshSubset` and `MeshServiceSubset`
                           type: object
                       type: object
+                  required:
+                  - targetRef
                   type: object
                 type: array
               targetRef:
@@ -115,6 +117,8 @@ spec:
                       Can only be used with kinds `MeshSubset` and `MeshServiceSubset`
                     type: object
                 type: object
+            required:
+            - targetRef
             type: object
         type: object
     served: true

--- a/pkg/plugins/policies/donothingpolicy/api/v1alpha1/donothingpolicy.go
+++ b/pkg/plugins/policies/donothingpolicy/api/v1alpha1/donothingpolicy.go
@@ -11,7 +11,7 @@ type DoNothingPolicy struct {
 	// TargetRef is a reference to the resource the policy takes an effect on.
 	// The resource could be either a real store object or virtual resource
 	// defined inplace.
-	TargetRef common_api.TargetRef `json:"targetRef,omitempty"`
+	TargetRef common_api.TargetRef `json:"targetRef"`
 	// To list makes a match between the consumed services and corresponding configurations
 	To []To `json:"to,omitempty"`
 	// From list makes a match between clients and corresponding configurations
@@ -21,7 +21,7 @@ type DoNothingPolicy struct {
 type To struct {
 	// TargetRef is a reference to the resource that represents a group of
 	// destinations.
-	TargetRef common_api.TargetRef `json:"targetRef,omitempty"`
+	TargetRef common_api.TargetRef `json:"targetRef"`
 	// Default is a configuration specific to the group of destinations referenced in
 	// 'targetRef'
 	Default Conf `json:"default,omitempty"`

--- a/pkg/plugins/policies/donothingpolicy/api/v1alpha1/donothingpolicy.go
+++ b/pkg/plugins/policies/donothingpolicy/api/v1alpha1/donothingpolicy.go
@@ -30,7 +30,7 @@ type To struct {
 type From struct {
 	// TargetRef is a reference to the resource that represents a group of
 	// clients.
-	TargetRef common_api.TargetRef `json:"targetRef,omitempty"`
+	TargetRef common_api.TargetRef `json:"targetRef"`
 	// Default is a configuration specific to the group of clients referenced in
 	// 'targetRef'
 	Default Conf `json:"default,omitempty"`

--- a/pkg/plugins/policies/donothingpolicy/api/v1alpha1/schema.yaml
+++ b/pkg/plugins/policies/donothingpolicy/api/v1alpha1/schema.yaml
@@ -110,6 +110,10 @@ properties:
                   description: Tags used to select a subset of proxies by tags. Can only be used with kinds `MeshSubset` and `MeshServiceSubset`
                   type: object
               type: object
+          required:
+            - targetRef
           type: object
         type: array
+    required:
+      - targetRef
     type: object

--- a/pkg/plugins/policies/donothingpolicy/api/v1alpha1/schema.yaml
+++ b/pkg/plugins/policies/donothingpolicy/api/v1alpha1/schema.yaml
@@ -49,6 +49,8 @@ properties:
                   description: Tags used to select a subset of proxies by tags. Can only be used with kinds `MeshSubset` and `MeshServiceSubset`
                   type: object
               type: object
+          required:
+            - targetRef
           type: object
         type: array
       targetRef:

--- a/pkg/plugins/policies/donothingpolicy/k8s/crd/kuma.io_donothingpolicies.yaml
+++ b/pkg/plugins/policies/donothingpolicy/k8s/crd/kuma.io_donothingpolicies.yaml
@@ -153,8 +153,12 @@ spec:
                             tags. Can only be used with kinds `MeshSubset` and `MeshServiceSubset`
                           type: object
                       type: object
+                  required:
+                  - targetRef
                   type: object
                 type: array
+            required:
+            - targetRef
             type: object
         type: object
     served: true

--- a/pkg/plugins/policies/donothingpolicy/k8s/crd/kuma.io_donothingpolicies.yaml
+++ b/pkg/plugins/policies/donothingpolicy/k8s/crd/kuma.io_donothingpolicies.yaml
@@ -79,6 +79,8 @@ spec:
                             tags. Can only be used with kinds `MeshSubset` and `MeshServiceSubset`
                           type: object
                       type: object
+                  required:
+                  - targetRef
                   type: object
                 type: array
               targetRef:

--- a/pkg/plugins/policies/meshaccesslog/api/v1alpha1/meshaccesslog.go
+++ b/pkg/plugins/policies/meshaccesslog/api/v1alpha1/meshaccesslog.go
@@ -30,7 +30,7 @@ type To struct {
 type From struct {
 	// TargetRef is a reference to the resource that represents a group of
 	// clients.
-	TargetRef common_api.TargetRef `json:"targetRef,omitempty"`
+	TargetRef common_api.TargetRef `json:"targetRef"`
 	// Default is a configuration specific to the group of clients referenced in
 	// 'targetRef'
 	Default Conf `json:"default,omitempty"`

--- a/pkg/plugins/policies/meshaccesslog/api/v1alpha1/meshaccesslog.go
+++ b/pkg/plugins/policies/meshaccesslog/api/v1alpha1/meshaccesslog.go
@@ -11,7 +11,7 @@ type MeshAccessLog struct {
 	// TargetRef is a reference to the resource the policy takes an effect on.
 	// The resource could be either a real store object or virtual resource
 	// defined inplace.
-	TargetRef common_api.TargetRef `json:"targetRef,omitempty"`
+	TargetRef common_api.TargetRef `json:"targetRef"`
 	// To list makes a match between the consumed services and corresponding configurations
 	To []To `json:"to,omitempty"`
 	// From list makes a match between clients and corresponding configurations
@@ -21,7 +21,7 @@ type MeshAccessLog struct {
 type To struct {
 	// TargetRef is a reference to the resource that represents a group of
 	// destinations.
-	TargetRef common_api.TargetRef `json:"targetRef,omitempty"`
+	TargetRef common_api.TargetRef `json:"targetRef"`
 	// Default is a configuration specific to the group of destinations referenced in
 	// 'targetRef'
 	Default Conf `json:"default,omitempty"`

--- a/pkg/plugins/policies/meshaccesslog/api/v1alpha1/schema.yaml
+++ b/pkg/plugins/policies/meshaccesslog/api/v1alpha1/schema.yaml
@@ -100,6 +100,8 @@ properties:
                   description: Tags used to select a subset of proxies by tags. Can only be used with kinds `MeshSubset` and `MeshServiceSubset`
                   type: object
               type: object
+          required:
+            - targetRef
           type: object
         type: array
       targetRef:

--- a/pkg/plugins/policies/meshaccesslog/api/v1alpha1/schema.yaml
+++ b/pkg/plugins/policies/meshaccesslog/api/v1alpha1/schema.yaml
@@ -212,6 +212,10 @@ properties:
                   description: Tags used to select a subset of proxies by tags. Can only be used with kinds `MeshSubset` and `MeshServiceSubset`
                   type: object
               type: object
+          required:
+            - targetRef
           type: object
         type: array
+    required:
+      - targetRef
     type: object

--- a/pkg/plugins/policies/meshaccesslog/k8s/crd/kuma.io_meshaccesslogs.yaml
+++ b/pkg/plugins/policies/meshaccesslog/k8s/crd/kuma.io_meshaccesslogs.yaml
@@ -261,8 +261,12 @@ spec:
                             tags. Can only be used with kinds `MeshSubset` and `MeshServiceSubset`
                           type: object
                       type: object
+                  required:
+                  - targetRef
                   type: object
                 type: array
+            required:
+            - targetRef
             type: object
         type: object
     served: true

--- a/pkg/plugins/policies/meshaccesslog/k8s/crd/kuma.io_meshaccesslogs.yaml
+++ b/pkg/plugins/policies/meshaccesslog/k8s/crd/kuma.io_meshaccesslogs.yaml
@@ -133,6 +133,8 @@ spec:
                             tags. Can only be used with kinds `MeshSubset` and `MeshServiceSubset`
                           type: object
                       type: object
+                  required:
+                  - targetRef
                   type: object
                 type: array
               targetRef:

--- a/pkg/plugins/policies/meshcircuitbreaker/api/v1alpha1/meshcircuitbreaker.go
+++ b/pkg/plugins/policies/meshcircuitbreaker/api/v1alpha1/meshcircuitbreaker.go
@@ -34,7 +34,7 @@ type To struct {
 type From struct {
 	// TargetRef is a reference to the resource that represents a group of
 	// destinations.
-	TargetRef common_api.TargetRef `json:"targetRef,omitempty"`
+	TargetRef common_api.TargetRef `json:"targetRef"`
 	// Default is a configuration specific to the group of destinations
 	// referenced in 'targetRef'
 	Default Conf `json:"default,omitempty"`

--- a/pkg/plugins/policies/meshcircuitbreaker/api/v1alpha1/meshcircuitbreaker.go
+++ b/pkg/plugins/policies/meshcircuitbreaker/api/v1alpha1/meshcircuitbreaker.go
@@ -12,7 +12,7 @@ type MeshCircuitBreaker struct {
 	// TargetRef is a reference to the resource the policy takes an effect on.
 	// The resource could be either a real store object or virtual resource
 	// defined in place.
-	TargetRef common_api.TargetRef `json:"targetRef,omitempty"`
+	TargetRef common_api.TargetRef `json:"targetRef"`
 
 	// To list makes a match between the consumed services and corresponding
 	// configurations
@@ -25,7 +25,7 @@ type MeshCircuitBreaker struct {
 type To struct {
 	// TargetRef is a reference to the resource that represents a group of
 	// destinations.
-	TargetRef common_api.TargetRef `json:"targetRef,omitempty"`
+	TargetRef common_api.TargetRef `json:"targetRef"`
 	// Default is a configuration specific to the group of destinations
 	// referenced in 'targetRef'
 	Default Conf `json:"default,omitempty"`

--- a/pkg/plugins/policies/meshcircuitbreaker/api/v1alpha1/schema.yaml
+++ b/pkg/plugins/policies/meshcircuitbreaker/api/v1alpha1/schema.yaml
@@ -150,6 +150,8 @@ properties:
                   description: Tags used to select a subset of proxies by tags. Can only be used with kinds `MeshSubset` and `MeshServiceSubset`
                   type: object
               type: object
+          required:
+            - targetRef
           type: object
         type: array
       targetRef:

--- a/pkg/plugins/policies/meshcircuitbreaker/api/v1alpha1/schema.yaml
+++ b/pkg/plugins/policies/meshcircuitbreaker/api/v1alpha1/schema.yaml
@@ -312,6 +312,10 @@ properties:
                   description: Tags used to select a subset of proxies by tags. Can only be used with kinds `MeshSubset` and `MeshServiceSubset`
                   type: object
               type: object
+          required:
+            - targetRef
           type: object
         type: array
+    required:
+      - targetRef
     type: object

--- a/pkg/plugins/policies/meshcircuitbreaker/k8s/crd/kuma.io_meshcircuitbreakers.yaml
+++ b/pkg/plugins/policies/meshcircuitbreaker/k8s/crd/kuma.io_meshcircuitbreakers.yaml
@@ -322,6 +322,8 @@ spec:
                             tags. Can only be used with kinds `MeshSubset` and `MeshServiceSubset`
                           type: object
                       type: object
+                  required:
+                  - targetRef
                   type: object
                 type: array
               targetRef:

--- a/pkg/plugins/policies/meshcircuitbreaker/k8s/crd/kuma.io_meshcircuitbreakers.yaml
+++ b/pkg/plugins/policies/meshcircuitbreaker/k8s/crd/kuma.io_meshcircuitbreakers.yaml
@@ -638,8 +638,12 @@ spec:
                             tags. Can only be used with kinds `MeshSubset` and `MeshServiceSubset`
                           type: object
                       type: object
+                  required:
+                  - targetRef
                   type: object
                 type: array
+            required:
+            - targetRef
             type: object
         type: object
     served: true

--- a/pkg/plugins/policies/meshhealthcheck/api/v1alpha1/meshhealthcheck.go
+++ b/pkg/plugins/policies/meshhealthcheck/api/v1alpha1/meshhealthcheck.go
@@ -13,7 +13,7 @@ type MeshHealthCheck struct {
 	// TargetRef is a reference to the resource the policy takes an effect on.
 	// The resource could be either a real store object or virtual resource
 	// defined inplace.
-	TargetRef common_api.TargetRef `json:"targetRef,omitempty"`
+	TargetRef common_api.TargetRef `json:"targetRef"`
 
 	// To list makes a match between the consumed services and corresponding configurations
 	To []To `json:"to,omitempty"`
@@ -22,7 +22,7 @@ type MeshHealthCheck struct {
 type To struct {
 	// TargetRef is a reference to the resource that represents a group of
 	// destinations.
-	TargetRef common_api.TargetRef `json:"targetRef,omitempty"`
+	TargetRef common_api.TargetRef `json:"targetRef"`
 	// Default is a configuration specific to the group of destinations referenced in
 	// 'targetRef'
 	Default Conf `json:"default,omitempty"`

--- a/pkg/plugins/policies/meshhealthcheck/api/v1alpha1/schema.yaml
+++ b/pkg/plugins/policies/meshhealthcheck/api/v1alpha1/schema.yaml
@@ -176,6 +176,10 @@ properties:
                   description: Tags used to select a subset of proxies by tags. Can only be used with kinds `MeshSubset` and `MeshServiceSubset`
                   type: object
               type: object
+          required:
+            - targetRef
           type: object
         type: array
+    required:
+      - targetRef
     type: object

--- a/pkg/plugins/policies/meshhealthcheck/k8s/crd/kuma.io_meshhealthchecks.yaml
+++ b/pkg/plugins/policies/meshhealthcheck/k8s/crd/kuma.io_meshhealthchecks.yaml
@@ -262,8 +262,12 @@ spec:
                             tags. Can only be used with kinds `MeshSubset` and `MeshServiceSubset`
                           type: object
                       type: object
+                  required:
+                  - targetRef
                   type: object
                 type: array
+            required:
+            - targetRef
             type: object
         type: object
     served: true

--- a/pkg/plugins/policies/meshratelimit/api/v1alpha1/meshratelimit.go
+++ b/pkg/plugins/policies/meshratelimit/api/v1alpha1/meshratelimit.go
@@ -12,7 +12,7 @@ type MeshRateLimit struct {
 	// TargetRef is a reference to the resource the policy takes an effect on.
 	// The resource could be either a real store object or virtual resource
 	// defined inplace.
-	TargetRef common_api.TargetRef `json:"targetRef,omitempty"`
+	TargetRef common_api.TargetRef `json:"targetRef"`
 	// From list makes a match between clients and corresponding configurations
 	From []From `json:"from,omitempty"`
 }
@@ -20,7 +20,7 @@ type MeshRateLimit struct {
 type From struct {
 	// TargetRef is a reference to the resource that represents a group of
 	// clients.
-	TargetRef common_api.TargetRef `json:"targetRef,omitempty"`
+	TargetRef common_api.TargetRef `json:"targetRef"`
 	// Default is a configuration specific to the group of clients referenced in
 	// 'targetRef'
 	Default Conf `json:"default,omitempty"`

--- a/pkg/plugins/policies/meshratelimit/api/v1alpha1/schema.yaml
+++ b/pkg/plugins/policies/meshratelimit/api/v1alpha1/schema.yaml
@@ -105,6 +105,8 @@ properties:
                   description: Tags used to select a subset of proxies by tags. Can only be used with kinds `MeshSubset` and `MeshServiceSubset`
                   type: object
               type: object
+          required:
+            - targetRef
           type: object
         type: array
       targetRef:
@@ -131,4 +133,6 @@ properties:
             description: Tags used to select a subset of proxies by tags. Can only be used with kinds `MeshSubset` and `MeshServiceSubset`
             type: object
         type: object
+    required:
+      - targetRef
     type: object

--- a/pkg/plugins/policies/meshratelimit/k8s/crd/kuma.io_meshratelimits.yaml
+++ b/pkg/plugins/policies/meshratelimit/k8s/crd/kuma.io_meshratelimits.yaml
@@ -146,6 +146,8 @@ spec:
                             tags. Can only be used with kinds `MeshSubset` and `MeshServiceSubset`
                           type: object
                       type: object
+                  required:
+                  - targetRef
                   type: object
                 type: array
               targetRef:
@@ -177,6 +179,8 @@ spec:
                       Can only be used with kinds `MeshSubset` and `MeshServiceSubset`
                     type: object
                 type: object
+            required:
+            - targetRef
             type: object
         type: object
     served: true

--- a/pkg/plugins/policies/meshretry/api/v1alpha1/meshretry.go
+++ b/pkg/plugins/policies/meshretry/api/v1alpha1/meshretry.go
@@ -12,7 +12,7 @@ type MeshRetry struct {
 	// TargetRef is a reference to the resource the policy takes an effect on.
 	// The resource could be either a real store object or virtual resource
 	// defined inplace.
-	TargetRef common_api.TargetRef `json:"targetRef,omitempty"`
+	TargetRef common_api.TargetRef `json:"targetRef"`
 	// To list makes a match between the consumed services and corresponding configurations
 	To []To `json:"to,omitempty"`
 }
@@ -20,7 +20,7 @@ type MeshRetry struct {
 type To struct {
 	// TargetRef is a reference to the resource that represents a group of
 	// destinations.
-	TargetRef common_api.TargetRef `json:"targetRef,omitempty"`
+	TargetRef common_api.TargetRef `json:"targetRef"`
 	// Default is a configuration specific to the group of destinations referenced in
 	// 'targetRef'
 	Default Conf `json:"default,omitempty"`

--- a/pkg/plugins/policies/meshretry/api/v1alpha1/schema.yaml
+++ b/pkg/plugins/policies/meshretry/api/v1alpha1/schema.yaml
@@ -162,6 +162,10 @@ properties:
                   description: Tags used to select a subset of proxies by tags. Can only be used with kinds `MeshSubset` and `MeshServiceSubset`
                   type: object
               type: object
+          required:
+            - targetRef
           type: object
         type: array
+    required:
+      - targetRef
     type: object

--- a/pkg/plugins/policies/meshretry/k8s/crd/kuma.io_meshretries.yaml
+++ b/pkg/plugins/policies/meshretry/k8s/crd/kuma.io_meshretries.yaml
@@ -235,8 +235,12 @@ spec:
                             tags. Can only be used with kinds `MeshSubset` and `MeshServiceSubset`
                           type: object
                       type: object
+                  required:
+                  - targetRef
                   type: object
                 type: array
+            required:
+            - targetRef
             type: object
         type: object
     served: true

--- a/pkg/plugins/policies/meshtimeout/api/v1alpha1/meshtimeout.go
+++ b/pkg/plugins/policies/meshtimeout/api/v1alpha1/meshtimeout.go
@@ -31,7 +31,7 @@ type To struct {
 type From struct {
 	// TargetRef is a reference to the resource that represents a group of
 	// clients.
-	TargetRef common_api.TargetRef `json:"targetRef,omitempty"`
+	TargetRef common_api.TargetRef `json:"targetRef"`
 	// Default is a configuration specific to the group of clients referenced in
 	// 'targetRef'
 	Default Conf `json:"default,omitempty"`

--- a/pkg/plugins/policies/meshtimeout/api/v1alpha1/meshtimeout.go
+++ b/pkg/plugins/policies/meshtimeout/api/v1alpha1/meshtimeout.go
@@ -12,7 +12,7 @@ type MeshTimeout struct {
 	// TargetRef is a reference to the resource the policy takes an effect on.
 	// The resource could be either a real store object or virtual resource
 	// defined inplace.
-	TargetRef common_api.TargetRef `json:"targetRef,omitempty"`
+	TargetRef common_api.TargetRef `json:"targetRef"`
 	// To list makes a match between the consumed services and corresponding configurations
 	To []To `json:"to,omitempty"`
 	// From list makes a match between clients and corresponding configurations
@@ -22,7 +22,7 @@ type MeshTimeout struct {
 type To struct {
 	// TargetRef is a reference to the resource that represents a group of
 	// destinations.
-	TargetRef common_api.TargetRef `json:"targetRef,omitempty"`
+	TargetRef common_api.TargetRef `json:"targetRef"`
 	// Default is a configuration specific to the group of destinations referenced in
 	// 'targetRef'
 	Default Conf `json:"default,omitempty"`

--- a/pkg/plugins/policies/meshtimeout/api/v1alpha1/schema.yaml
+++ b/pkg/plugins/policies/meshtimeout/api/v1alpha1/schema.yaml
@@ -148,6 +148,10 @@ properties:
                   description: Tags used to select a subset of proxies by tags. Can only be used with kinds `MeshSubset` and `MeshServiceSubset`
                   type: object
               type: object
+          required:
+            - targetRef
           type: object
         type: array
+    required:
+      - targetRef
     type: object

--- a/pkg/plugins/policies/meshtimeout/api/v1alpha1/schema.yaml
+++ b/pkg/plugins/policies/meshtimeout/api/v1alpha1/schema.yaml
@@ -68,6 +68,8 @@ properties:
                   description: Tags used to select a subset of proxies by tags. Can only be used with kinds `MeshSubset` and `MeshServiceSubset`
                   type: object
               type: object
+          required:
+            - targetRef
           type: object
         type: array
       targetRef:

--- a/pkg/plugins/policies/meshtimeout/k8s/crd/kuma.io_meshtimeouts.yaml
+++ b/pkg/plugins/policies/meshtimeout/k8s/crd/kuma.io_meshtimeouts.yaml
@@ -229,8 +229,12 @@ spec:
                             tags. Can only be used with kinds `MeshSubset` and `MeshServiceSubset`
                           type: object
                       type: object
+                  required:
+                  - targetRef
                   type: object
                 type: array
+            required:
+            - targetRef
             type: object
         type: object
     served: true

--- a/pkg/plugins/policies/meshtimeout/k8s/crd/kuma.io_meshtimeouts.yaml
+++ b/pkg/plugins/policies/meshtimeout/k8s/crd/kuma.io_meshtimeouts.yaml
@@ -117,6 +117,8 @@ spec:
                             tags. Can only be used with kinds `MeshSubset` and `MeshServiceSubset`
                           type: object
                       type: object
+                  required:
+                  - targetRef
                   type: object
                 type: array
               targetRef:

--- a/pkg/plugins/policies/meshtrace/api/v1alpha1/meshtrace.go
+++ b/pkg/plugins/policies/meshtrace/api/v1alpha1/meshtrace.go
@@ -11,7 +11,7 @@ type MeshTrace struct {
 	// TargetRef is a reference to the resource the policy takes an effect on.
 	// The resource could be either a real store object or virtual resource
 	// defined inplace.
-	TargetRef common_api.TargetRef `json:"targetRef,omitempty"`
+	TargetRef common_api.TargetRef `json:"targetRef"`
 	// MeshTrace configuration.
 	Default Conf `json:"default,omitempty"`
 }

--- a/pkg/plugins/policies/meshtrace/api/v1alpha1/schema.yaml
+++ b/pkg/plugins/policies/meshtrace/api/v1alpha1/schema.yaml
@@ -116,4 +116,6 @@ properties:
             description: Tags used to select a subset of proxies by tags. Can only be used with kinds `MeshSubset` and `MeshServiceSubset`
             type: object
         type: object
+    required:
+      - targetRef
     type: object

--- a/pkg/plugins/policies/meshtrace/k8s/crd/kuma.io_meshtraces.yaml
+++ b/pkg/plugins/policies/meshtrace/k8s/crd/kuma.io_meshtraces.yaml
@@ -174,6 +174,8 @@ spec:
                       Can only be used with kinds `MeshSubset` and `MeshServiceSubset`
                     type: object
                 type: object
+            required:
+            - targetRef
             type: object
         type: object
     served: true

--- a/pkg/plugins/policies/meshtrafficpermission/api/v1alpha1/meshtrafficpermission.go
+++ b/pkg/plugins/policies/meshtrafficpermission/api/v1alpha1/meshtrafficpermission.go
@@ -11,7 +11,7 @@ type MeshTrafficPermission struct {
 	// TargetRef is a reference to the resource the policy takes an effect on.
 	// The resource could be either a real store object or virtual resource
 	// defined inplace.
-	TargetRef common_api.TargetRef `json:"targetRef,omitempty"`
+	TargetRef common_api.TargetRef `json:"targetRef"`
 	// From list makes a match between clients and corresponding configurations
 	From []From `json:"from,omitempty"`
 }
@@ -19,7 +19,7 @@ type MeshTrafficPermission struct {
 type From struct {
 	// TargetRef is a reference to the resource that represents a group of
 	// clients.
-	TargetRef common_api.TargetRef `json:"targetRef,omitempty"`
+	TargetRef common_api.TargetRef `json:"targetRef"`
 	// Default is a configuration specific to the group of clients referenced in
 	// 'targetRef'
 	Default Conf `json:"default,omitempty"`
@@ -34,7 +34,7 @@ var ALLOW Action = "ALLOW"
 var DENY Action = "DENY"
 
 // ALLOW_WITH_SHADOW_DENY action lets the requests pass but emits logs as if
-//  requests are denied
+// requests are denied
 var ALLOW_WITH_SHADOW_DENY Action = "ALLOW_WITH_SHADOW_DENY"
 
 type Conf struct {

--- a/pkg/plugins/policies/meshtrafficpermission/api/v1alpha1/schema.yaml
+++ b/pkg/plugins/policies/meshtrafficpermission/api/v1alpha1/schema.yaml
@@ -53,6 +53,8 @@ properties:
                   description: Tags used to select a subset of proxies by tags. Can only be used with kinds `MeshSubset` and `MeshServiceSubset`
                   type: object
               type: object
+          required:
+            - targetRef
           type: object
         type: array
       targetRef:
@@ -79,4 +81,6 @@ properties:
             description: Tags used to select a subset of proxies by tags. Can only be used with kinds `MeshSubset` and `MeshServiceSubset`
             type: object
         type: object
+    required:
+      - targetRef
     type: object

--- a/pkg/plugins/policies/meshtrafficpermission/k8s/crd/kuma.io_meshtrafficpermissions.yaml
+++ b/pkg/plugins/policies/meshtrafficpermission/k8s/crd/kuma.io_meshtrafficpermissions.yaml
@@ -84,6 +84,8 @@ spec:
                             tags. Can only be used with kinds `MeshSubset` and `MeshServiceSubset`
                           type: object
                       type: object
+                  required:
+                  - targetRef
                   type: object
                 type: array
               targetRef:
@@ -115,6 +117,8 @@ spec:
                       Can only be used with kinds `MeshSubset` and `MeshServiceSubset`
                     type: object
                 type: object
+            required:
+            - targetRef
             type: object
         type: object
     served: true

--- a/tools/policy-gen/bootstrap/root.go
+++ b/tools/policy-gen/bootstrap/root.go
@@ -176,7 +176,7 @@ type {{ .name }} struct {
 	// TargetRef is a reference to the resource the policy takes an effect on.
 	// The resource could be either a real store object or virtual resource
 	// defined inplace.
-	TargetRef common_api.TargetRef` + " `json:\"targetRef,omitempty\"`" + `
+	TargetRef common_api.TargetRef` + " `json:\"targetRef\"`" + `
 	{{- end }}
 	{{- if .generateTo }}
 	// To list makes a match between the consumed services and corresponding configurations
@@ -192,7 +192,7 @@ type {{ .name }} struct {
 type To struct {
 	// TargetRef is a reference to the resource that represents a group of
 	// destinations.
-	TargetRef common_api.TargetRef` + " `json:\"targetRef,omitempty\"`" + `
+	TargetRef common_api.TargetRef` + " `json:\"targetRef\"`" + `
 	// Default is a configuration specific to the group of destinations referenced in
 	// 'targetRef'
 	Default Conf` + " `json:\"default,omitempty\"`" + `
@@ -204,7 +204,7 @@ type To struct {
 type From struct {
 	// TargetRef is a reference to the resource that represents a group of
 	// clients.
-	TargetRef common_api.TargetRef` + " `json:\"targetRef,omitempty\"`" + `
+	TargetRef common_api.TargetRef` + " `json:\"targetRef\"`" + `
 	// Default is a configuration specific to the group of clients referenced in
 	// 'targetRef'
 	Default Conf` + " `json:\"default,omitempty\"`" + `


### PR DESCRIPTION
Remove omitempty for all TargetRefs and regenerate the policies (Closes #5548)

Signed-off-by: AyushSenapati <a.p.senapati008@gmail.com>

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] Link to docs PR or issue -- https://github.com/kumahq/kuma/issues/5548
- [x] Link to UI issue or PR -- https://github.com/kumahq/kuma/issues/5548
- [x] Is the [issue worked on linked][1]? -- Yes
- [x] The PR does not hardcode values that might break projects that depend on kuma (e.g. "kumahq" as a image registry) -- No
- [x] The PR will work for both Linux and Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Unit Tests --
- [x] E2E Tests --
- [x] Manual Universal Tests --
- [x] Manual Kubernetes Tests --
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? -- No
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? -- No
- [x] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests? No

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
