### PR TITLE
build: add ability to set explicit name for policies

### DIFF
--- a/pkg/core/resources/model/display_name.go
+++ b/pkg/core/resources/model/display_name.go
@@ -28,7 +28,3 @@ func PluralType(resType string) string {
 		return resType + "s"
 	}
 }
-
-func PluralDisplayName(resType string) string {
-	return PluralType(DisplayName(resType))
-}

--- a/pkg/core/resources/model/display_name.go
+++ b/pkg/core/resources/model/display_name.go
@@ -30,5 +30,5 @@ func PluralType(resType string) string {
 }
 
 func PluralDisplayName(resType string) string {
-	return DisplayName(PluralType(resType))
+	return PluralType(DisplayName(resType))
 }

--- a/tools/policy-gen/generator/pkg/parse/policyconfig.go
+++ b/tools/policy-gen/generator/pkg/parse/policyconfig.go
@@ -119,7 +119,7 @@ func newPolicyConfig(pkg, name string, markers map[string]string, hasTo, hasFrom
 		Name:                name,
 		NameLower:           strings.ToLower(name),
 		SingularDisplayName: core_model.DisplayName(name),
-		PluralDisplayName:   core_model.PluralDisplayName(name),
+		PluralDisplayName:   core_model.PluralType(core_model.DisplayName(name)),
 		AlternativeNames:    []string{strings.ToLower(name)},
 		HasTo:               hasTo,
 		HasFrom:             hasFrom,
@@ -130,6 +130,11 @@ func newPolicyConfig(pkg, name string, markers map[string]string, hasTo, hasFrom
 	}
 	if v, ok := parseBool(markers, "kuma:policy:skip_get_default"); ok {
 		res.SkipGetDefault = v
+	}
+
+	if v, ok := markers["kuma:policy:singular_display_name"]; ok {
+		res.SingularDisplayName = v
+		res.PluralDisplayName = core_model.PluralType(v)
 	}
 
 	if v, ok := markers["kuma:policy:plural"]; ok {

--- a/tools/resource-gen/genutils/util.go
+++ b/tools/resource-gen/genutils/util.go
@@ -102,7 +102,7 @@ func ToResourceInfo(desc protoreflect.MessageDescriptor) ResourceInfo {
 		}
 	}
 	if out.PluralDisplayName == "" {
-		out.PluralDisplayName = core_model.PluralDisplayName(r.Type)
+		out.PluralDisplayName = core_model.PluralType(core_model.DisplayName(r.Type))
 	}
 	// Working around the fact we don't really differentiate policies from the rest of resources:
 	// Anything global can't be a policy as it need to be on a mesh. Anything with locked Ws config is something internal and therefore not a policy


### PR DESCRIPTION
Blocking #5530 

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] Link to docs PR or issue --
- [x] Link to UI issue or PR --
- [x] Is the [issue worked on linked][1]? --
- [x] The PR does not hardcode values that might break projects that depend on kuma (e.g. "kumahq" as a image registry) --
- [x] The PR will work for both Linux and Windows, system specific functions like `sycall.Mkfifo` have equivalent implementation on the other OS --
- [x] Unit Tests -- none
- [x] E2E Tests -- none
- [x] Manual Universal Tests --
- [x] Manual Kubernetes Tests --
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [x] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
