### PR TITLE
fix: always call 'CollectResponse' inside 'Eventually'

### DIFF
--- a/test/e2e_env/multizone/localityawarelb/locality_multizone_hybrid.go
+++ b/test/e2e_env/multizone/localityawarelb/locality_multizone_hybrid.go
@@ -146,9 +146,11 @@ func ExternalServicesWithLocalityAwareLb() {
 		Eventually(EgressStats(env.KubeZone1, filterEgress), "30s", "1s").Should(stats.BeEqualZero())
 
 		// when
-		response, err := client.CollectResponse(env.UniZone1, "uni-zone4-demo-client", "external-service-in-kube-zone1.mesh")
-		Expect(err).ToNot(HaveOccurred())
-		Expect(response.Instance).Should(Equal("external-service-in-kube-zone1"))
+		Eventually(func(g Gomega) {
+			response, err := client.CollectResponse(env.UniZone1, "uni-zone4-demo-client", "external-service-in-kube-zone1.mesh")
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(response.Instance).Should(Equal("external-service-in-kube-zone1"))
+		}, "30s", "1s").Should(Succeed())
 
 		// then should route:
 		// app -> zone egress (zone4) -> zone ingress (zone1) -> zone egress (zone1) -> external service
@@ -171,12 +173,14 @@ func ExternalServicesWithLocalityAwareLb() {
 		Eventually(EgressStats(env.UniZone1, filterEgress), "30s", "1s").Should(stats.BeEqualZero())
 
 		// when request to external service in zone 1
-		response, err := client.CollectResponse(
-			env.KubeZone1, "demo-client", "external-service-in-uni-zone4.mesh",
-			client.FromKubernetesPod(namespace, "demo-client"),
-		)
-		Expect(err).ToNot(HaveOccurred())
-		Expect(response.Instance).To(Equal("external-service-in-uni-zone4"))
+		Eventually(func(g Gomega) {
+			response, err := client.CollectResponse(
+				env.KubeZone1, "demo-client", "external-service-in-uni-zone4.mesh",
+				client.FromKubernetesPod(namespace, "demo-client"),
+			)
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(response.Instance).To(Equal("external-service-in-uni-zone4"))
+		}, "30s", "1s").Should(Succeed())
 
 		// then should route:
 		// app -> zone egress (zone1) -> zone ingress (zone4) -> zone egress (zone4) -> external service
@@ -201,9 +205,11 @@ func ExternalServicesWithLocalityAwareLb() {
 		}, "30s", "1s").Should(Succeed())
 
 		// when doing requests to external service with tag zone1
-		response, err := client.CollectResponse(env.UniZone1, "uni-zone4-demo-client-no-egress", "demo-es-in-uni-zone4.mesh")
-		Expect(err).ToNot(HaveOccurred())
-		Expect(response.Instance).Should(Equal("external-service-in-uni-zone4"))
+		Eventually(func(g Gomega) {
+			response, err := client.CollectResponse(env.UniZone1, "uni-zone4-demo-client-no-egress", "demo-es-in-uni-zone4.mesh")
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(response.Instance).Should(Equal("external-service-in-uni-zone4"))
+		}, "30s", "1s").Should(Succeed())
 
 		// then there is no stat because external service is not exposed through egress
 		Eventually(func(g Gomega) {

--- a/test/e2e_env/multizone/trafficroute/trafficroute.go
+++ b/test/e2e_env/multizone/trafficroute/trafficroute.go
@@ -167,8 +167,8 @@ conf:
 
 		Eventually(func(g Gomega) {
 			res, err := CollectResponsesByInstance(env.UniZone1, "demo-client", "test-server.mesh", WithNumberOfRequests(200))
-			Expect(err).ToNot(HaveOccurred())
-			Expect(res).To(And(
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(res).To(And(
 				HaveLen(2),
 				HaveKeyWithValue(MatchRegexp(`.*echo-v1.*`), BeNumerically("~", 2*v1Weight, 20)),
 				HaveKeyWithValue(MatchRegexp(`.*echo-v2.*`), BeNumerically("~", 2*v2Weight, 20)),


### PR DESCRIPTION
fail examples: 
* https://app.circleci.com/pipelines/github/kumahq/kuma/18347/workflows/64f6bd25-616a-429c-82f0-01ca12321dbc/jobs/287437/tests
* https://app.circleci.com/pipelines/github/kumahq/kuma/18353/workflows/2e25f459-3f0d-4416-937b-72ca0bb17143/jobs/287750

Signed-off-by: Ilya Lobkov <ilya.lobkov@konghq.com>

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [X] Link to docs PR or issue --
- [X] Link to UI issue or PR --
- [X] Is the [issue worked on linked][1]? --
- [X] The PR does not hardcode values that might break projects that depend on kuma (e.g. "kumahq" as a image registry) --
- [X] The PR will work for both Linux and Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [X] Unit Tests --
- [X] E2E Tests --
- [X] Manual Universal Tests --
- [X] Manual Kubernetes Tests --
- [X] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [X] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [X] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
