### PR TITLE
build: use circleci config in cache key

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -148,7 +148,7 @@ jobs:
               go_arch: arm64
     - checkout
     - restore_cache:
-        key: << parameters.executor >>_go.mod_{{ checksum "go.sum" }}_{{ checksum "mk/dependencies/deps.lock" }}
+        key: << parameters.executor >>_go.mod_{{ checksum "go.sum" }}_{{ checksum "mk/dependencies/deps.lock" }}_{{ checksum ".circleci/config.yml" }}
     - run:
         command: make dev/tools
     - run:
@@ -157,7 +157,7 @@ jobs:
           go mod download -x
     # since execution of go commands might change contents of "go.sum", we have to save cache immediately
     - save_cache:
-        key: << parameters.executor >>_go.mod_{{ checksum "go.sum" }}_{{ checksum "mk/dependencies/deps.lock" }}
+        key: << parameters.executor >>_go.mod_{{ checksum "go.sum" }}_{{ checksum "mk/dependencies/deps.lock" }}_{{ checksum ".circleci/config.yml" }}
         paths:
         - "/home/circleci/go/pkg/mod"
         - "/home/circleci/.kuma-dev"
@@ -169,7 +169,7 @@ jobs:
     - restore_cache:
         keys:
         # prefer the exact match
-        - golang_go.mod_{{ checksum "go.sum" }}_{{ checksum "mk/dependencies/deps.lock" }}
+        - golang_go.mod_{{ checksum "go.sum" }}_{{ checksum "mk/dependencies/deps.lock" }}_{{ checksum ".circleci/config.yml" }}
     - run:
         name: "Run code generators (go generate, protoc, ...) and code checks (go fmt, go vet, ...)"
         command: make check
@@ -203,7 +203,7 @@ jobs:
     - restore_cache:
         keys:
         # prefer the exact match
-        - vm-<< parameters.arch >>_go.mod_{{ checksum "go.sum" }}_{{ checksum "mk/dependencies/deps.lock" }}
+        - vm-<< parameters.arch >>_go.mod_{{ checksum "go.sum" }}_{{ checksum "mk/dependencies/deps.lock" }}_{{ checksum ".circleci/config.yml" }}
     - run:
         name: "Run tests"
         command: |
@@ -299,7 +299,7 @@ jobs:
       - restore_cache:
           keys:
             # prefer the exact match
-            - vm-<< parameters.arch >>_go.mod_{{ checksum "go.sum" }}_{{ checksum "mk/dependencies/deps.lock" }}
+            - vm-<< parameters.arch >>_go.mod_{{ checksum "go.sum" }}_{{ checksum "mk/dependencies/deps.lock" }}_{{ checksum ".circleci/config.yml" }}
       # Mount files from the upstream jobs
       - attach_workspace:
           at: build
@@ -373,7 +373,7 @@ jobs:
     - restore_cache:
         keys:
         # prefer the exact match
-        - golang_go.mod_{{ checksum "go.sum" }}_{{ checksum "mk/dependencies/deps.lock" }}
+        - golang_go.mod_{{ checksum "go.sum" }}_{{ checksum "mk/dependencies/deps.lock" }}_{{ checksum ".circleci/config.yml" }}
     - run:
         name: Build all Kuma binaries (such as, kumactl, kuma-cp, kuma-dp)
         command: make build


### PR DESCRIPTION
This makes sure if we change the go minor version, defined in `.circleci/config.yml`, the cache is refreshed because a different minor means we use a different image, which may not be compatible with the cache.

It seems to have worked here https://github.com/kumahq/kuma/compare/fix/generate_2.0:

- without: https://app.circleci.com/pipelines/github/kumahq/kuma/18480/workflows/9a2b5a02-8335-4542-a326-c1b4ec8ea5b1/jobs/290628
- with: https://app.circleci.com/pipelines/github/kumahq/kuma/18483/workflows/1b5738e0-4fb8-45ec-9537-a14e0ab5caa0/jobs/290689

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] Link to docs PR or issue --
- [x] Link to UI issue or PR --
- [x] Is the [issue worked on linked][1]? --
- [x] The PR does not hardcode values that might break projects that depend on kuma (e.g. "kumahq" as a image registry) --
- [x] The PR will work for both Linux and Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Unit Tests --
- [x] E2E Tests --
- [x] Manual Universal Tests --
- [x] Manual Kubernetes Tests --
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [x] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
