### PR TITLE
feat(tools): add possibility to generate policy with different gomodule

### DIFF
--- a/mk/generate.mk
+++ b/mk/generate.mk
@@ -5,6 +5,8 @@ CONTROLLER_GEN := go run -mod=mod sigs.k8s.io/controller-tools/cmd/controller-ge
 RESOURCE_GEN := go run -mod=mod $(TOOLS_DIR)/resource-gen/main.go
 POLICY_GEN := go run -mod=mod $(TOOLS_DIR)/policy-gen/generator/main.go
 
+GO_MODULE := github.com/kumahq/kuma
+
 .PHONY: clean/proto
 clean/proto: ## Dev: Remove auto-generated Protobuf files
 	find $(PROTO_DIRS) -name '*.pb.go' -delete
@@ -58,7 +60,7 @@ generate/policy/%: generate/schema/%
 
 generate/schema/%: generate/controller-gen/%
 	for version in $(foreach dir,$(wildcard $(POLICIES_DIR)/$*/api/*),$(notdir $(dir))); do \
-		PATH=$(CI_TOOLS_BIN_DIR):$$PATH $(TOOLS_DIR)/policy-gen/crd-extract-openapi.sh $* $$version ; \
+		PATH=$(CI_TOOLS_BIN_DIR):$$PATH $(TOOLS_DIR)/policy-gen/crd-extract-openapi.sh $* $$version $(TOOLS_DIR) ; \
 	done
 
 generate/policy-import:
@@ -75,11 +77,11 @@ generate/controller-gen/%: generate/kumapolicy-gen/%
 	done
 
 generate/kumapolicy-gen/%: generate/dirs/%
-	$(POLICY_GEN) core-resource --plugin-dir $(POLICIES_DIR)/$* && \
-	$(POLICY_GEN) k8s-resource --plugin-dir $(POLICIES_DIR)/$* && \
-	$(POLICY_GEN) openapi --plugin-dir $(POLICIES_DIR)/$* --openapi-template-path=$(TOOLS_DIR)/policy-gen/templates/endpoints.yaml && \
-	$(POLICY_GEN) plugin-file --plugin-dir $(POLICIES_DIR)/$* && \
-	$(POLICY_GEN) helpers --plugin-dir $(POLICIES_DIR)/$*
+	$(POLICY_GEN) core-resource --plugin-dir $(POLICIES_DIR)/$* --gomodule $(GO_MODULE) && \
+	$(POLICY_GEN) k8s-resource --plugin-dir $(POLICIES_DIR)/$* --gomodule $(GO_MODULE) && \
+	$(POLICY_GEN) openapi --plugin-dir $(POLICIES_DIR)/$* --openapi-template-path=$(TOOLS_DIR)/policy-gen/templates/endpoints.yaml --gomodule $(GO_MODULE) && \
+	$(POLICY_GEN) plugin-file --plugin-dir $(POLICIES_DIR)/$* --gomodule $(GO_MODULE) && \
+	$(POLICY_GEN) helpers --plugin-dir $(POLICIES_DIR)/$* --gomodule $(GO_MODULE)
 
 generate/dirs/%:
 	for version in $(foreach dir,$(wildcard $(POLICIES_DIR)/$*/api/*),$(notdir $(dir))); do \

--- a/mk/generate.mk
+++ b/mk/generate.mk
@@ -6,7 +6,7 @@ RESOURCE_GEN := go run -mod=mod $(TOOLS_DIR)/resource-gen/main.go
 POLICY_GEN := go run -mod=mod $(TOOLS_DIR)/policy-gen/generator/main.go
 
 GENERATE_TARGET ?= clean/proto generate/api protoc/pkg/config/app/kumactl/v1alpha1 protoc/plugins resources/type generate/policies
-GO_MODULE := github.com/kumahq/kuma
+GO_MODULE ?= github.com/kumahq/kuma
 
 .PHONY: clean/proto
 clean/proto: ## Dev: Remove auto-generated Protobuf files

--- a/mk/generate.mk
+++ b/mk/generate.mk
@@ -5,6 +5,7 @@ CONTROLLER_GEN := go run -mod=mod sigs.k8s.io/controller-tools/cmd/controller-ge
 RESOURCE_GEN := go run -mod=mod $(TOOLS_DIR)/resource-gen/main.go
 POLICY_GEN := go run -mod=mod $(TOOLS_DIR)/policy-gen/generator/main.go
 
+GENERATE_TARGET ?= clean/proto generate/api protoc/pkg/config/app/kumactl/v1alpha1 protoc/plugins resources/type generate/policies
 GO_MODULE := github.com/kumahq/kuma
 
 .PHONY: clean/proto
@@ -14,7 +15,7 @@ clean/proto: ## Dev: Remove auto-generated Protobuf files
 
 .PHONY: generate
 generate:  ## Dev: Run code generators
-generate: clean/proto generate/api protoc/pkg/config/app/kumactl/v1alpha1 protoc/plugins resources/type generate/policies
+generate: $(GENERATE_TARGET)
 
 .PHONY: resources/type
 resources/type:

--- a/tools/policy-gen/crd-extract-openapi.sh
+++ b/tools/policy-gen/crd-extract-openapi.sh
@@ -7,12 +7,13 @@ set -e
 
 POLICY=$1
 VERSION=${2:-"v1alpha1"}
+TOOLS_LOCATION=${3:-"."}
 
 POLICIES_DIR=pkg/plugins/policies
 POLICIES_API_DIR="${POLICIES_DIR}/${POLICY}/api/${VERSION}"
 POLICIES_CRD_DIR="${POLICIES_DIR}/${POLICY}/k8s/crd"
 
-SCHEMA_TEMPLATE=tools/policy-gen/templates/schema.yaml
+SCHEMA_TEMPLATE="${TOOLS_LOCATION}/tools/policy-gen/templates/schema.yaml"
 
 # 1. Copy file ${SCHEMA_TEMPLATE} to ${POLICIES_API_DIR}/schema.yaml. It contains
 #    information about fields that are equal for all resources 'type', 'mesh' and 'name'.

--- a/tools/policy-gen/crd-extract-openapi.sh
+++ b/tools/policy-gen/crd-extract-openapi.sh
@@ -6,7 +6,7 @@ set -o nounset
 set -e
 
 POLICY=$1
-VERSION=${2:-"v1alpha1"}
+VERSION=$2
 TOOLS_LOCATION=$3
 
 POLICIES_DIR=pkg/plugins/policies

--- a/tools/policy-gen/crd-extract-openapi.sh
+++ b/tools/policy-gen/crd-extract-openapi.sh
@@ -7,13 +7,13 @@ set -e
 
 POLICY=$1
 VERSION=${2:-"v1alpha1"}
-TOOLS_LOCATION=${3:-"."}
+TOOLS_LOCATION=$3
 
 POLICIES_DIR=pkg/plugins/policies
 POLICIES_API_DIR="${POLICIES_DIR}/${POLICY}/api/${VERSION}"
 POLICIES_CRD_DIR="${POLICIES_DIR}/${POLICY}/k8s/crd"
 
-SCHEMA_TEMPLATE="${TOOLS_LOCATION}/tools/policy-gen/templates/schema.yaml"
+SCHEMA_TEMPLATE="${TOOLS_LOCATION}/policy-gen/templates/schema.yaml"
 
 # 1. Copy file ${SCHEMA_TEMPLATE} to ${POLICIES_API_DIR}/schema.yaml. It contains
 #    information about fields that are equal for all resources 'type', 'mesh' and 'name'.

--- a/tools/policy-gen/generator/cmd/k8s_resource.go
+++ b/tools/policy-gen/generator/cmd/k8s_resource.go
@@ -28,6 +28,8 @@ func newK8sResource(rootArgs *args) *cobra.Command {
 				return err
 			}
 
+			pconfig.GoModule = rootArgs.goModule
+
 			k8sPath := filepath.Join(rootArgs.pluginDir, "k8s", rootArgs.version)
 			if err := os.MkdirAll(k8sPath, 0755); err != nil {
 				return err
@@ -66,7 +68,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	core_model "github.com/kumahq/kuma/pkg/core/resources/model"
-	policy "github.com/kumahq/kuma/pkg/plugins/policies/{{.NameLower}}/api/{{.Package}}"
+	policy "{{.GoModule}}/pkg/plugins/policies/{{.NameLower}}/api/{{.Package}}"
 	"github.com/kumahq/kuma/pkg/plugins/resources/k8s/native/pkg/model"
 	{{- if not .SkipRegistration }}
 	"github.com/kumahq/kuma/pkg/plugins/resources/k8s/native/pkg/registry"

--- a/tools/policy-gen/generator/cmd/root.go
+++ b/tools/policy-gen/generator/cmd/root.go
@@ -9,6 +9,7 @@ import (
 type args struct {
 	pluginDir string
 	version   string
+	goModule  string
 }
 
 func newRootCmd() *cobra.Command {
@@ -34,6 +35,7 @@ func newRootCmd() *cobra.Command {
 
 	cmd.PersistentFlags().StringVar(&rootArgs.pluginDir, "plugin-dir", "", "path to the policy plugin director")
 	cmd.PersistentFlags().StringVar(&rootArgs.version, "version", "v1alpha1", "policy version")
+	cmd.PersistentFlags().StringVar(&rootArgs.goModule, "gomodule", "github.com/kumahq/kuma", "Where to put the generated code")
 
 	return cmd
 }

--- a/tools/policy-gen/generator/pkg/parse/policyconfig.go
+++ b/tools/policy-gen/generator/pkg/parse/policyconfig.go
@@ -26,6 +26,7 @@ type PolicyConfig struct {
 	AlternativeNames    []string
 	HasTo               bool
 	HasFrom             bool
+	GoModule            string
 }
 
 func Policy(path string) (PolicyConfig, error) {


### PR DESCRIPTION
Signed-off-by: Marcin Skalski <marcin.skalski@konghq.com>

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] Link to docs PR or issue --
- [x] Link to UI issue or PR --
- [x] Is the [issue worked on linked][1]? --
- [x] The PR does not hardcode values that might break projects that depend on kuma (e.g. "kumahq" as a image registry) --
- [x] The PR will work for both Linux and Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Unit Tests --
- [x] E2E Tests --
- [x] Manual Universal Tests --
- [x] Manual Kubernetes Tests --
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [x] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
