### PR TITLE
test(e2e): better error when pod is not available

### DIFF
--- a/test/framework/k8s.go
+++ b/test/framework/k8s.go
@@ -2,8 +2,11 @@ package framework
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/gruntwork-io/terratest/modules/k8s"
+	"github.com/gruntwork-io/terratest/modules/retry"
+	"github.com/gruntwork-io/terratest/modules/testing"
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -40,4 +43,32 @@ func PodIPOfApp(cluster Cluster, name string, namespace string) (string, error) 
 		return "", errors.Errorf("expected %d pods, got %d", 1, len(pods))
 	}
 	return pods[0].Status.PodIP, nil
+}
+
+// WaitUntilPodAvailableE it's a "fork" of original WaitUntilPodAvailableE from terratest with more information why the pod failed
+// Remove when https://github.com/gruntwork-io/terratest/pull/1223 is merged.
+func WaitUntilPodAvailableE(t testing.TestingT, options *k8s.KubectlOptions, podName string, retries int, sleepBetweenRetries time.Duration) error {
+	statusMsg := fmt.Sprintf("Wait for pod %s to be provisioned.", podName)
+	message, err := retry.DoWithRetryE(
+		t,
+		statusMsg,
+		retries,
+		sleepBetweenRetries,
+		func() (string, error) {
+			pod, err := k8s.GetPodE(t, options, podName)
+			if err != nil {
+				return "", err
+			}
+			if !k8s.IsPodAvailable(pod) {
+				return "", errors.Errorf("Pod %s is not available, reason: %s, message: %s", pod.Name, pod.Status.Reason, pod.Status.Message)
+			}
+			return "Pod is now available", nil
+		},
+	)
+	if err != nil {
+		Logf("Timedout waiting for Pod to be provisioned: %s", err)
+		return err
+	}
+	Logf(message)
+	return nil
 }

--- a/test/framework/setup.go
+++ b/test/framework/setup.go
@@ -265,7 +265,7 @@ func WaitPodsAvailable(namespace, app string) InstallFunc {
 			return err
 		}
 		for _, p := range pods {
-			err := k8s.WaitUntilPodAvailableE(c.GetTesting(), c.GetKubectlOptions(namespace), p.GetName(), ck8s.defaultRetries, ck8s.defaultTimeout)
+			err := WaitUntilPodAvailableE(c.GetTesting(), c.GetKubectlOptions(namespace), p.GetName(), ck8s.defaultRetries, ck8s.defaultTimeout)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
Implement https://github.com/gruntwork-io/terratest/pull/1223 to get better error messages quicker.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [ ] Link to docs PR or issue --
- [ ] Link to UI issue or PR --
- [ ] Is the [issue worked on linked][1]? --
- [ ] The PR does not hardcode values that might break projects that depend on kuma (e.g. "kumahq" as a image registry) --
- [ ] The PR will work for both Linux and Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [ ] Unit Tests --
- [ ] E2E Tests --
- [ ] Manual Universal Tests --
- [ ] Manual Kubernetes Tests --
- [ ] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [ ] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [ ] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
