### PR TITLE
feat(policies): allow merging by a complex key

### DIFF
--- a/pkg/core/xds/merge.go
+++ b/pkg/core/xds/merge.go
@@ -68,7 +68,7 @@ type acc struct {
 
 const (
 	defaultFieldName = "Default"
-	xdsMergeTag      = "xdsMerge"
+	policyMergeTag   = "policyMerge"
 	mergeValuesByKey = "mergeValuesByKey"
 	mergeKey         = "mergeKey"
 )
@@ -77,7 +77,7 @@ func handleMergeByKeyFields(valueResult reflect.Value) error {
 	confType := valueResult.Elem().Type()
 	for i := 0; i < confType.NumField(); i++ {
 		field := confType.Field(i)
-		if !strings.Contains(field.Tag.Get(xdsMergeTag), mergeValuesByKey) {
+		if !strings.Contains(field.Tag.Get(policyMergeTag), mergeValuesByKey) {
 			continue
 		}
 		if field.Type.Kind() != reflect.Slice && field.Type.Elem().Kind() != reflect.Struct {
@@ -147,7 +147,7 @@ func findKeyAndSpec(typ reflect.Type) (reflect.StructField, bool) {
 	var key *reflect.StructField
 	for i := 0; i < typ.NumField(); i++ {
 		field := typ.Field(i)
-		if strings.Contains(field.Tag.Get(xdsMergeTag), mergeKey) {
+		if strings.Contains(field.Tag.Get(policyMergeTag), mergeKey) {
 			key = &field
 			break
 		}
@@ -178,7 +178,7 @@ func clearAppendSlices(val reflect.Value) {
 		field := strVal.Type().Field(i)
 		switch valField.Kind() {
 		case reflect.Slice:
-			mergeByKey := strings.Contains(field.Tag.Get(xdsMergeTag), mergeValuesByKey)
+			mergeByKey := strings.Contains(field.Tag.Get(policyMergeTag), mergeValuesByKey)
 			if strings.HasPrefix(field.Name, appendSlicesPrefix) || mergeByKey {
 				valField.Set(reflect.Zero(valField.Type()))
 			}
@@ -206,7 +206,7 @@ func appendSlices(dst reflect.Value, src reflect.Value) {
 		field := strDst.Type().Field(i)
 		switch dstField.Kind() {
 		case reflect.Slice:
-			mergeByKey := strings.Contains(field.Tag.Get(xdsMergeTag), mergeValuesByKey)
+			mergeByKey := strings.Contains(field.Tag.Get(policyMergeTag), mergeValuesByKey)
 			if strings.HasPrefix(field.Name, appendSlicesPrefix) || mergeByKey {
 				s := reflect.AppendSlice(dstField, srcField)
 				dstField.Set(s)

--- a/pkg/core/xds/merge_test.go
+++ b/pkg/core/xds/merge_test.go
@@ -209,7 +209,7 @@ var _ = Describe("MergeConfs", func() {
 		B *bool `json:"b,omitempty"`
 	}
 	type mergeEntry struct {
-		Key     mergeKey  `json:"key" xdsMerge:"mergeKey"`
+		Key     mergeKey  `json:"key" policyMerge:"mergeKey"`
 		Default mergeConf `json:"default"`
 	}
 	type nonMergeEntry struct {
@@ -217,7 +217,7 @@ var _ = Describe("MergeConfs", func() {
 		Default mergeConf `json:"default"`
 	}
 	type testPolicy struct {
-		MergeValues []mergeEntry     `xdsMerge:"mergeValuesByKey"`
+		MergeValues []mergeEntry     `policyMerge:"mergeValuesByKey"`
 		OtherValues *[]nonMergeEntry `json:"otherValues,omitempty"`
 	}
 


### PR DESCRIPTION
This allows us to move the logic from `MeshHTTPRoute` into `core_xds`

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] Link to docs PR or issue --
- [x] Link to UI issue or PR --
- [x] Is the [issue worked on linked][1]? --
- [x] The PR does not hardcode values that might break projects that depend on kuma (e.g. "kumahq" as a image registry) --
- [x] The PR will work for both Linux and Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Unit Tests --
- [x] E2E Tests --
- [x] Manual Universal Tests --
- [x] Manual Kubernetes Tests --
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [x] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
