### PR TITLE
chore: validation error path merging with index/keys

### DIFF
--- a/pkg/core/validators/types.go
+++ b/pkg/core/validators/types.go
@@ -54,32 +54,30 @@ func (v *ValidationError) AddViolation(field string, message string) {
 	v.Violations = append(v.Violations, violation)
 }
 
-func (v *ValidationError) Add(err ValidationError) {
-	v.AddError("", err)
-}
-
 func (v *ValidationError) AddErrorAt(path PathBuilder, validationErr ValidationError) {
-	v.AddError(path.String(), validationErr)
-}
-
-func (v *ValidationError) AddError(rootField string, validationErr ValidationError) {
 	for _, violation := range validationErr.Violations {
-		field := ""
-		if violation.Field == "" {
-			field = rootField
-		} else {
-			sep := ""
-			if rootField != "" && !strings.HasPrefix(violation.Field, "[") {
-				sep = "."
-			}
-			field = fmt.Sprintf("%s%s%s", rootField, sep, violation.Field)
+		field := Root()
+		if violation.Field != "" {
+			field = RootedAt(violation.Field)
 		}
 		newViolation := Violation{
-			Field:   field,
+			Field:   path.concat(field).String(),
 			Message: violation.Message,
 		}
 		v.Violations = append(v.Violations, newViolation)
 	}
+}
+
+func (v *ValidationError) Add(err ValidationError) {
+	v.AddErrorAt(Root(), err)
+}
+
+func (v *ValidationError) AddError(rootField string, validationErr ValidationError) {
+	root := Root()
+	if rootField != "" {
+		root = RootedAt(rootField)
+	}
+	v.AddErrorAt(root, validationErr)
 }
 
 // Transform returns a new ValidationError with every violation
@@ -124,6 +122,10 @@ func RootedAt(name string) PathBuilder {
 	return PathBuilder{name}
 }
 
+func Root() PathBuilder {
+	return PathBuilder{}
+}
+
 func (p PathBuilder) Field(name string) PathBuilder {
 	return append(p, fmt.Sprintf(".%s", name))
 }
@@ -138,4 +140,20 @@ func (p PathBuilder) Key(key string) PathBuilder {
 
 func (p PathBuilder) String() string {
 	return strings.Join(p, "")
+}
+
+func (p PathBuilder) concat(other PathBuilder) PathBuilder {
+	if len(other) == 0 {
+		return p
+	}
+	if len(p) == 0 {
+		return other
+	}
+
+	firstOther := other[0]
+	if !strings.HasPrefix(firstOther, "[") {
+		firstOther = "." + firstOther
+	}
+
+	return append(append(p, firstOther), other[1:]...)
 }

--- a/pkg/core/validators/types.go
+++ b/pkg/core/validators/types.go
@@ -63,16 +63,16 @@ func (v *ValidationError) AddErrorAt(path PathBuilder, validationErr ValidationE
 }
 
 func (v *ValidationError) AddError(rootField string, validationErr ValidationError) {
-	rootPrefix := ""
-	if rootField != "" {
-		rootPrefix += fmt.Sprintf("%s.", rootField)
-	}
 	for _, violation := range validationErr.Violations {
 		field := ""
 		if violation.Field == "" {
 			field = rootField
 		} else {
-			field = fmt.Sprintf("%s%s", rootPrefix, violation.Field)
+			sep := ""
+			if rootField != "" && !strings.HasPrefix(violation.Field, "[") {
+				sep = "."
+			}
+			field = fmt.Sprintf("%s%s%s", rootField, sep, violation.Field)
 		}
 		newViolation := Violation{
 			Field:   field,

--- a/pkg/core/validators/types_test.go
+++ b/pkg/core/validators/types_test.go
@@ -99,6 +99,25 @@ var _ = Describe("Validation Error", func() {
 		})
 	})
 
+	Describe("AddErrorAt()", func() {
+		It("does not properly concatenate paths with index/keys", func() {
+			// given
+			path := validators.RootedAt("spec").Field("fields")
+			err := validators.ValidationError{}
+			subErr := validators.ValidationError{}
+			subErr.AddViolationAt(validators.PathBuilder{}.Index(2), "something bad")
+
+			// when
+			err.AddErrorAt(path, subErr)
+			// then
+			Expect(err).To(Equal(validators.ValidationError{
+				Violations: []validators.Violation{
+					{Field: "spec.fields.[2]", Message: "something bad"},
+				},
+			}))
+		})
+	})
+
 	Describe("Transform()", func() {
 		type testCase struct {
 			input         *validators.ValidationError

--- a/pkg/core/validators/types_test.go
+++ b/pkg/core/validators/types_test.go
@@ -105,7 +105,7 @@ var _ = Describe("Validation Error", func() {
 			path := validators.RootedAt("spec").Field("fields")
 			err := validators.ValidationError{}
 			subErr := validators.ValidationError{}
-			subErr.AddViolationAt(validators.PathBuilder{}.Index(2), "something bad")
+			subErr.AddViolationAt(validators.Root().Index(2), "something bad")
 
 			// when
 			err.AddErrorAt(path, subErr)
@@ -193,7 +193,7 @@ var _ = Describe("Validation Error", func() {
 
 var _ = Describe("PathBuilder", func() {
 	It("should produce empty path by default", func() {
-		Expect(validators.PathBuilder{}.String()).To(Equal(""))
+		Expect(validators.Root().String()).To(Equal(""))
 	})
 
 	It("should produce valid root path", func() {

--- a/pkg/core/validators/types_test.go
+++ b/pkg/core/validators/types_test.go
@@ -100,7 +100,7 @@ var _ = Describe("Validation Error", func() {
 	})
 
 	Describe("AddErrorAt()", func() {
-		It("does not properly concatenate paths with index/keys", func() {
+		It("properly concatenates paths with index/keys", func() {
 			// given
 			path := validators.RootedAt("spec").Field("fields")
 			err := validators.ValidationError{}
@@ -112,7 +112,7 @@ var _ = Describe("Validation Error", func() {
 			// then
 			Expect(err).To(Equal(validators.ValidationError{
 				Violations: []validators.Violation{
-					{Field: "spec.fields.[2]", Message: "something bad"},
+					{Field: "spec.fields[2]", Message: "something bad"},
 				},
 			}))
 		})


### PR DESCRIPTION
See the test before and after, without this fix there is a spurious second `.` in `spec.fields.[2]`.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] Link to docs PR or issue --
- [x] Link to UI issue or PR --
- [x] Is the [issue worked on linked][1]? --
- [x] The PR does not hardcode values that might break projects that depend on kuma (e.g. "kumahq" as a image registry) --
- [x] The PR will work for both Linux and Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Unit Tests --
- [x] E2E Tests --
- [x] Manual Universal Tests --
- [x] Manual Kubernetes Tests --
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [x] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
