### PR TITLE
fix(MeshHealthCheck): only add health check at most once to cluster

### DIFF
--- a/pkg/plugins/policies/meshhealthcheck/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshhealthcheck/plugin/v1alpha1/plugin_test.go
@@ -89,6 +89,12 @@ var _ = Describe("MeshHealthCheck", func() {
 							mesh_proto.ProtocolTag: "grpc",
 						}),
 					).
+					AddOutbound(
+						builders.Outbound().WithAddress("240.0.0.1").WithPort(27779).WithTags(map[string]string{
+							mesh_proto.ServiceTag:  grpcServiceTag,
+							mesh_proto.ProtocolTag: "grpc",
+						}),
+					).
 					Build(),
 				Policies: xds.MatchedPolicies{
 					Dynamic: map[core_model.ResourceType]xds.TypedMatchingPolicies{
@@ -247,6 +253,13 @@ healthChecks:
 			expectedClusters: []string{`
 name: echo-grpc
 healthChecks:
+- healthyThreshold: 1
+  interval: 10s
+  timeout: 2s
+  unhealthyThreshold: 3
+  grpcHealthCheck:
+    authority: grpc-client.default.svc.cluster.local
+    serviceName: grpc-client
 - healthyThreshold: 1
   interval: 10s
   timeout: 2s

--- a/pkg/plugins/policies/meshhealthcheck/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshhealthcheck/plugin/v1alpha1/plugin_test.go
@@ -260,13 +260,6 @@ healthChecks:
   grpcHealthCheck:
     authority: grpc-client.default.svc.cluster.local
     serviceName: grpc-client
-- healthyThreshold: 1
-  interval: 10s
-  timeout: 2s
-  unhealthyThreshold: 3
-  grpcHealthCheck:
-    authority: grpc-client.default.svc.cluster.local
-    serviceName: grpc-client
 `},
 		}),
 	)


### PR DESCRIPTION
### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] Link to docs PR or issue --
- [x] Link to UI issue or PR --
- [x] Is the [issue worked on linked][1]? -- https://github.com/kumahq/kuma/issues/5643
- [x] The PR does not hardcode values that might break projects that depend on kuma (e.g. "kumahq" as a image registry) --
- [x] The PR will work for both Linux and Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Unit Tests --
- [x] E2E Tests --
- [x] Manual Universal Tests --
- [x] Manual Kubernetes Tests --
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [x] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
