### PR TITLE
test(e2e): rewrite external service without kubernetes

### DIFF
--- a/test/e2e/externalservices/externalservices_kubernetes_without_egress.go
+++ b/test/e2e/externalservices/externalservices_kubernetes_without_egress.go
@@ -8,11 +8,11 @@ import (
 
 	"github.com/kumahq/kuma/pkg/config/core"
 	. "github.com/kumahq/kuma/test/framework"
-	"github.com/kumahq/kuma/test/framework/deployments/externalservice"
+	"github.com/kumahq/kuma/test/framework/deployments/testserver"
 )
 
 func ExternalServicesOnKubernetesWithoutEgress() {
-	meshDefaulMtlsOn := `
+	const meshDefaulMtlsOn = `
 apiVersion: kuma.io/v1alpha1
 kind: Mesh
 metadata:
@@ -30,45 +30,37 @@ spec:
     zoneEgress: %s
 `
 
-	externalService := `
+	const externalService = `
 apiVersion: kuma.io/v1alpha1
 kind: ExternalService
 mesh: default
 metadata:
-  name: external-service-%s
+  name: external-service-1
 spec:
   tags:
     kuma.io/service: external-service
     kuma.io/protocol: http
-    id: "%s"
   networking:
-    address: %s:%d
-    tls:
-      enabled: %s
+    address: external-service.external-services.svc.cluster.local:80 # .svc.cluster.local is needed, otherwise Kubernetes will resolve this to the real IP
 `
-	es1 := "1"
-	es2 := "2"
+	const externalServicesNamespace = "external-services"
 
-	var cluster Cluster
+	var cluster *K8sCluster
 	var clientPodName string
 
 	BeforeEach(func() {
-		clusters, err := NewK8sClusters(
-			[]string{Kuma1},
-			Silent)
-		Expect(err).ToNot(HaveOccurred())
-
-		cluster = clusters.GetCluster(Kuma1)
-		err = NewClusterSetup().
+		cluster = NewK8sCluster(NewTestingT(), Kuma1, Silent)
+		err := NewClusterSetup().
 			Install(Kuma(core.Standalone)).
+			Install(YamlK8s(fmt.Sprintf(meshDefaulMtlsOn, "false", "false"))).
 			Install(NamespaceWithSidecarInjection(TestNamespace)).
 			Install(DemoClientK8s("default", TestNamespace)).
-			Install(externalservice.Install(externalservice.HttpServer, []string{})).
-			Install(externalservice.Install(externalservice.HttpsServer, []string{})).
+			Install(Namespace(externalServicesNamespace)).
+			Install(testserver.Install(
+				testserver.WithNamespace(externalServicesNamespace),
+				testserver.WithName("external-service"),
+			)).
 			Setup(cluster)
-		Expect(err).ToNot(HaveOccurred())
-
-		err = YamlK8s(fmt.Sprintf(meshDefaulMtlsOn, "false", "false"))(cluster)
 		Expect(err).ToNot(HaveOccurred())
 
 		clientPodName, err = PodNameOfApp(cluster, "demo-client", TestNamespace)
@@ -76,78 +68,51 @@ spec:
 	})
 
 	E2EAfterEach(func() {
-		err := cluster.DeleteNamespace(TestNamespace)
-		Expect(err).ToNot(HaveOccurred())
+		Expect(cluster.TriggerDeleteNamespace(externalServicesNamespace)).To(Succeed())
+		Expect(cluster.TriggerDeleteNamespace(TestNamespace)).To(Succeed())
+		cluster.WaitNamespaceDelete(externalServicesNamespace)
+		cluster.WaitNamespaceDelete(TestNamespace)
 
-		err = cluster.DeleteKuma()
-		Expect(err).ToNot(HaveOccurred())
-
-		err = cluster.DismissCluster()
-		Expect(err).ToNot(HaveOccurred())
+		Expect(cluster.DeleteKuma()).To(Succeed())
+		Expect(cluster.DismissCluster()).To(Succeed())
 	})
 
-	trafficBlocked := func() error {
+	trafficBlocked := func(g Gomega) {
 		_, _, err := cluster.Exec(TestNamespace, clientPodName, "demo-client",
-			"curl", "-v", "-m", "3", "--fail", "http://externalservice-http-server.externalservice-namespace:10080")
-		return err
+			"curl", "-v", "-m", "3", "--fail", "external-service.external-services.svc.cluster.local:80")
+		g.Expect(err).To(HaveOccurred())
+	}
+
+	trafficAllowed := func(g Gomega) {
+		_, stderr, err := cluster.Exec(TestNamespace, clientPodName, "demo-client",
+			"curl", "-v", "-m", "3", "--fail", "external-service.external-services.svc.cluster.local:80")
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(stderr).To(ContainSubstring("HTTP/1.1 200 OK"))
 	}
 
 	It("should route to external-service", func() {
-		// given Mesh with passthrough enabled and no egress
-		err := YamlK8s(fmt.Sprintf(meshDefaulMtlsOn, "true", "false"))(cluster)
-		Expect(err).ToNot(HaveOccurred())
+		// given the mesh with passthrough enabled and no egress disabled
+		Expect(cluster.Install(YamlK8s(fmt.Sprintf(meshDefaulMtlsOn, "true", "false")))).To(Succeed())
 
-		// then communication outside of the Mesh works
-		Eventually(func(g Gomega) {
-			_, stderr, err := cluster.Exec(TestNamespace, clientPodName, "demo-client",
-				"curl", "-v", "-m", "3", "--fail", "http://externalservice-http-server.externalservice-namespace:10080")
-			g.Expect(err).ToNot(HaveOccurred())
-			g.Expect(stderr).To(ContainSubstring("HTTP/1.1 200 OK"))
-		}, "1m", "3s").Should(Succeed())
+		// then communication outside of the Mesh works, because it goes through passthrough
+		Eventually(trafficAllowed, "30s", "1s").Should(Succeed())
 
-		// when passthrough is disabled on the Mesh and no egress
-		err = YamlK8s(fmt.Sprintf(meshDefaulMtlsOn, "false", "false"))(cluster)
-		Expect(err).ToNot(HaveOccurred())
-
-		// then communication outside of the Mesh works
-		Eventually(func(g Gomega) {
-			_, stderr, err := cluster.Exec(TestNamespace, clientPodName, "demo-client",
-				"curl", "-v", "-m", "3", "--fail", "http://externalservice-http-server.externalservice-namespace:10080")
-			g.Expect(err).ToNot(HaveOccurred())
-			g.Expect(stderr).To(ContainSubstring("HTTP/1.1 200 OK"))
-		}, "1m", "3s").Should(Succeed())
-
-		// when apply external service
-		err = YamlK8s(fmt.Sprintf(externalService,
-			es1, es1,
-			"externalservice-http-server.externalservice-namespace.svc.cluster.local", 10080, // .svc.cluster.local is needed, otherwise Kubernetes will resolve this to the real IP
-			"false"))(cluster)
-		Expect(err).ToNot(HaveOccurred())
-
-		// and passthrough is disabled on the Mesh and zone egress enabled
-		err = YamlK8s(fmt.Sprintf(meshDefaulMtlsOn, "false", "true"))(cluster)
-		Expect(err).ToNot(HaveOccurred())
+		// when passthrough is disabled
+		Expect(cluster.Install(YamlK8s(fmt.Sprintf(meshDefaulMtlsOn, "false", "false")))).To(Succeed())
 
 		// then accessing the external service is no longer possible
-		Eventually(trafficBlocked, "30s", "1s").Should(HaveOccurred())
-	})
-
-	It("should route to external-service over tls", func() {
-		// given Mesh with passthrough enabled and with zone egress
-		err := YamlK8s(fmt.Sprintf(meshDefaulMtlsOn, "true", "true"))(cluster)
-		Expect(err).ToNot(HaveOccurred())
+		Eventually(trafficBlocked, "30s", "1s").Should(Succeed())
 
 		// when apply external service
-		err = YamlK8s(fmt.Sprintf(externalService,
-			es2, es2,
-			"externalservice-https-server.externalservice-namespace.svc.cluster.local", 10080,
-			"true"))(cluster)
-		Expect(err).ToNot(HaveOccurred())
+		Expect(cluster.Install(YamlK8s(externalService))).To(Succeed())
 
-		Eventually(func() error {
-			_, _, err = cluster.Exec(TestNamespace, clientPodName, "demo-client",
-				"curl", "-v", "-m", "3", "--fail", "http://external-service.mesh:10080")
-			return err
-		}, "30s", "1s").Should(HaveOccurred())
+		// then communication outside of the Mesh works, because it goes directly from the client to a service
+		Eventually(trafficAllowed, "30s", "1s").Should(Succeed())
+
+		// when passthrough is disabled on the Mesh and zone egress enabled
+		Expect(cluster.Install(YamlK8s(fmt.Sprintf(meshDefaulMtlsOn, "false", "true")))).To(Succeed())
+
+		// then accessing the external service is no longer possible, because zone egress is not deployed
+		Eventually(trafficBlocked, "30s", "1s").Should(Succeed())
 	})
 }

--- a/test/e2e/externalservices/externalservices_kubernetes_without_egress.go
+++ b/test/e2e/externalservices/externalservices_kubernetes_without_egress.go
@@ -25,7 +25,7 @@ spec:
         type: builtin
   networking:
     outbound:
-      passthrough: %s
+      passthrough: false
   routing:
     zoneEgress: %s
 `
@@ -52,7 +52,7 @@ spec:
 		cluster = NewK8sCluster(NewTestingT(), Kuma1, Silent)
 		err := NewClusterSetup().
 			Install(Kuma(core.Standalone)).
-			Install(YamlK8s(fmt.Sprintf(meshDefaulMtlsOn, "false", "false"))).
+			Install(YamlK8s(fmt.Sprintf(meshDefaulMtlsOn, "false"))).
 			Install(NamespaceWithSidecarInjection(TestNamespace)).
 			Install(DemoClientK8s("default", TestNamespace)).
 			Install(Namespace(externalServicesNamespace)).
@@ -77,42 +77,26 @@ spec:
 		Expect(cluster.DismissCluster()).To(Succeed())
 	})
 
-	trafficBlocked := func(g Gomega) {
-		_, _, err := cluster.Exec(TestNamespace, clientPodName, "demo-client",
-			"curl", "-v", "-m", "3", "--fail", "external-service.external-services.svc.cluster.local:80")
-		g.Expect(err).To(HaveOccurred())
-	}
-
-	trafficAllowed := func(g Gomega) {
-		_, stderr, err := cluster.Exec(TestNamespace, clientPodName, "demo-client",
-			"curl", "-v", "-m", "3", "--fail", "external-service.external-services.svc.cluster.local:80")
-		g.Expect(err).ToNot(HaveOccurred())
-		g.Expect(stderr).To(ContainSubstring("HTTP/1.1 200 OK"))
-	}
-
-	It("should route to external-service", func() {
-		// given the mesh with passthrough enabled and no egress disabled
-		Expect(cluster.Install(YamlK8s(fmt.Sprintf(meshDefaulMtlsOn, "true", "false")))).To(Succeed())
-
-		// then communication outside of the Mesh works, because it goes through passthrough
-		Eventually(trafficAllowed, "30s", "1s").Should(Succeed())
-
-		// when passthrough is disabled
-		Expect(cluster.Install(YamlK8s(fmt.Sprintf(meshDefaulMtlsOn, "false", "false")))).To(Succeed())
-
-		// then accessing the external service is no longer possible
-		Eventually(trafficBlocked, "30s", "1s").Should(Succeed())
-
-		// when apply external service
+	It("should block the traffic when zone egress is not deployed", func() {
+		// when external service is defined without passthrough and zone routing
 		Expect(cluster.Install(YamlK8s(externalService))).To(Succeed())
 
 		// then communication outside of the Mesh works, because it goes directly from the client to a service
-		Eventually(trafficAllowed, "30s", "1s").Should(Succeed())
+		Eventually(func(g Gomega) {
+			_, stderr, err := cluster.Exec(TestNamespace, clientPodName, "demo-client",
+				"curl", "-v", "-m", "3", "--fail", "external-service.external-services.svc.cluster.local:80")
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(stderr).To(ContainSubstring("HTTP/1.1 200 OK"))
+		}, "30s", "1s").Should(Succeed())
 
 		// when passthrough is disabled on the Mesh and zone egress enabled
-		Expect(cluster.Install(YamlK8s(fmt.Sprintf(meshDefaulMtlsOn, "false", "true")))).To(Succeed())
+		Expect(cluster.Install(YamlK8s(fmt.Sprintf(meshDefaulMtlsOn, "true")))).To(Succeed())
 
 		// then accessing the external service is no longer possible, because zone egress is not deployed
-		Eventually(trafficBlocked, "30s", "1s").Should(Succeed())
+		Eventually(func(g Gomega) {
+			_, _, err := cluster.Exec(TestNamespace, clientPodName, "demo-client",
+				"curl", "-v", "-m", "3", "--fail", "external-service.external-services.svc.cluster.local:80")
+			g.Expect(err).To(HaveOccurred())
+		}, "30s", "1s").Should(Succeed())
 	})
 }

--- a/test/framework/interface.go
+++ b/test/framework/interface.go
@@ -533,6 +533,7 @@ type Cluster interface {
 	GetZoneEgressEnvoyTunnel() envoy_admin.Tunnel
 	GetZoneIngressEnvoyTunnel() envoy_admin.Tunnel
 	Verbose() bool
+	Install(fn InstallFunc) error
 
 	// K8s
 	GetKubectlOptions(namespace ...string) *k8s.KubectlOptions

--- a/test/framework/k8s_clusters.go
+++ b/test/framework/k8s_clusters.go
@@ -53,6 +53,10 @@ func (cs *K8sClusters) Verbose() bool {
 	return cs.verbose
 }
 
+func (c *K8sClusters) Install(fn InstallFunc) error {
+	panic("not implemented")
+}
+
 func (cs *K8sClusters) WithRetries(retries int) Cluster {
 	for _, c := range cs.clusters {
 		c.WithRetries(retries)

--- a/test/framework/universal_clusters.go
+++ b/test/framework/universal_clusters.go
@@ -68,6 +68,10 @@ func (cs *UniversalClusters) Name() string {
 	panic("not supported")
 }
 
+func (c *UniversalClusters) Install(fn InstallFunc) error {
+	panic("not implemented")
+}
+
 func (cs *UniversalClusters) DismissCluster() error {
 	for name, c := range cs.clusters {
 		if err := c.DismissCluster(); err != nil {


### PR DESCRIPTION
I rewrite the external service without kubernetes
* I removed TLS part, it's tested in `e2e_env` anyways
* I changed `deployments/externalservice` with test server for more robust server
* spotted bug here https://app.circleci.com/pipelines/github/kumahq/kuma/18557/workflows/b446f1d1-c4c1-4bc1-a519-42ca115bafca/jobs/292690 In 116 line the communication should not work, because we set passthrough=false and do not have external service. It worked for majority of time because of XDS reconciliation delay of 1s, whereas the assertion was executed immediately.

This test still needs to live here because we need to test the case where Mesh#egress is set to true, but we don't have egress deployed.

I want to get rid of `k8s_clusters.go` and `universal_clusters.go`, but I don't want to do it in this PR.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [X] Link to docs PR or issue --
- [X] Link to UI issue or PR --
- [X] Is the [issue worked on linked][1]? --
- [X] The PR does not hardcode values that might break projects that depend on kuma (e.g. "kumahq" as a image registry) --
- [X] The PR will work for both Linux and Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [X] Unit Tests --
- [X] E2E Tests --
- [X] Manual Universal Tests --
- [X] Manual Kubernetes Tests --
- [X] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [X] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [X] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
