### PR TITLE
refactor(MeshCircuitBreaker): only configure clusters at most once

### DIFF
--- a/pkg/plugins/policies/meshcircuitbreaker/plugin/v1alpha1/plugin.go
+++ b/pkg/plugins/policies/meshcircuitbreaker/plugin/v1alpha1/plugin.go
@@ -90,6 +90,7 @@ func applyToOutbounds(
 	outboundClusters map[string]*envoy_cluster.Cluster,
 	dataplane *core_mesh.DataplaneResource,
 ) error {
+	targetedClusters := map[*envoy_cluster.Cluster]string{}
 	for _, outbound := range dataplane.Spec.Networking.GetOutbound() {
 		serviceName := outbound.GetTagsIncludingLegacy()[mesh_proto.ServiceTag]
 		cluster, ok := outboundClusters[serviceName]
@@ -97,6 +98,10 @@ func applyToOutbounds(
 			continue
 		}
 
+		targetedClusters[cluster] = serviceName
+	}
+
+	for cluster, serviceName := range targetedClusters {
 		if err := configure(rules.Rules, core_xds.MeshService(serviceName), cluster); err != nil {
 			return err
 		}


### PR DESCRIPTION
This isn't actually a bug because configure only overwrites properties of the cluster but nevertheless.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] Link to docs PR or issue --
- [x] Link to UI issue or PR --
- [x] Is the [issue worked on linked][1]? -- #5643 
- [x] The PR does not hardcode values that might break projects that depend on kuma (e.g. "kumahq" as a image registry) --
- [x] The PR will work for both Linux and Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Unit Tests --
- [x] E2E Tests --
- [x] Manual Universal Tests --
- [x] Manual Kubernetes Tests --
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [x] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
