### PR TITLE
test(e2e): use wait for pod available everywhere

### DIFF
--- a/test/e2e_env/multizone/multizone_suite_test.go
+++ b/test/e2e_env/multizone/multizone_suite_test.go
@@ -51,6 +51,7 @@ var _ = SynchronizedBeforeSuite(
 		env.KubeZone1 = NewK8sCluster(NewTestingT(), Kuma1, Verbose)
 		go func() {
 			defer GinkgoRecover()
+			defer wg.Done()
 			Expect(env.KubeZone1.Install(Kuma(core.Zone,
 				WithEnv("KUMA_STORE_UNSAFE_DELETE", "true"),
 				WithIngress(),
@@ -59,12 +60,12 @@ var _ = SynchronizedBeforeSuite(
 				WithEgressEnvoyAdminTunnel(),
 				WithGlobalAddress(env.Global.GetKuma().GetKDSServerAddress()),
 			))).To(Succeed())
-			wg.Done()
 		}()
 
 		env.KubeZone2 = NewK8sCluster(NewTestingT(), Kuma2, Verbose)
 		go func() {
 			defer GinkgoRecover()
+			defer wg.Done()
 			Expect(env.KubeZone2.Install(Kuma(core.Zone,
 				WithEnv("KUMA_STORE_UNSAFE_DELETE", "true"),
 				WithEnv("KUMA_DEFAULTS_ENABLE_LOCALHOST_INBOUND_CLUSTERS", "true"),
@@ -75,13 +76,13 @@ var _ = SynchronizedBeforeSuite(
 				WithGlobalAddress(env.Global.GetKuma().GetKDSServerAddress()),
 				WithExperimentalCNI(),
 			))).To(Succeed())
-			wg.Done()
 		}()
 
 		env.UniZone1 = NewUniversalCluster(NewTestingT(), Kuma4, Silent)
 		E2EDeferCleanup(env.UniZone1.DismissCluster) // clean up any containers if needed
 		go func() {
 			defer GinkgoRecover()
+			defer wg.Done()
 			err := NewClusterSetup().
 				Install(Kuma(core.Zone,
 					WithGlobalAddress(env.Global.GetKuma().GetKDSServerAddress()),
@@ -93,13 +94,13 @@ var _ = SynchronizedBeforeSuite(
 				Install(EgressUniversal(env.Global.GetKuma().GenerateZoneEgressToken)).
 				Setup(env.UniZone1)
 			Expect(err).ToNot(HaveOccurred())
-			wg.Done()
 		}()
 
 		env.UniZone2 = NewUniversalCluster(NewTestingT(), Kuma5, Silent)
 		E2EDeferCleanup(env.UniZone2.DismissCluster) // clean up any containers if needed
 		go func() {
 			defer GinkgoRecover()
+			defer wg.Done()
 			err := NewClusterSetup().
 				Install(Kuma(core.Zone,
 					WithGlobalAddress(env.Global.GetKuma().GetKDSServerAddress()),
@@ -112,7 +113,6 @@ var _ = SynchronizedBeforeSuite(
 				Install(EgressUniversal(env.Global.GetKuma().GenerateZoneEgressToken)).
 				Setup(env.UniZone2)
 			Expect(err).ToNot(HaveOccurred())
-			wg.Done()
 		}()
 		wg.Wait()
 

--- a/test/framework/deployments/kic/kubernetes.go
+++ b/test/framework/deployments/kic/kubernetes.go
@@ -65,11 +65,14 @@ func (t *k8sDeployment) Deploy(cluster framework.Cluster) error {
 		return errors.Errorf("counting KIC pods. Got: %d. Expected: 1", len(pods))
 	}
 
-	k8s.WaitUntilPodAvailable(cluster.GetTesting(),
+	err = framework.WaitUntilPodAvailableE(cluster.GetTesting(),
 		cluster.GetKubectlOptions(t.ingressNamespace),
 		pods[0].Name,
 		framework.DefaultRetries,
 		framework.DefaultTimeout)
+	if err != nil {
+		return err
+	}
 
 	return nil
 }

--- a/test/framework/deployments/observability/kubernetes.go
+++ b/test/framework/deployments/observability/kubernetes.go
@@ -63,11 +63,14 @@ func (t *k8SDeployment) Deploy(cluster framework.Cluster) error {
 		return errors.Errorf("counting Jaeger pods. Got: %d. Expected: 1", len(pods))
 	}
 
-	k8s.WaitUntilPodAvailable(cluster.GetTesting(),
+	err = framework.WaitUntilPodAvailableE(cluster.GetTesting(),
 		cluster.GetKubectlOptions(t.namespace),
 		pods[0].Name,
 		framework.DefaultRetries,
 		framework.DefaultTimeout)
+	if err != nil {
+		return err
+	}
 
 	t.jaegerApiTunnel = k8s.NewTunnel(cluster.GetKubectlOptions(t.namespace), k8s.ResourceTypePod, pods[0].Name, 0, 16686)
 	t.jaegerApiTunnel.ForwardPort(cluster.GetTesting())

--- a/test/framework/k8s_cluster.go
+++ b/test/framework/k8s_cluster.go
@@ -1134,11 +1134,14 @@ func (c *K8sCluster) WaitApp(name, namespace string, replicas int) error {
 	}
 
 	for i := 0; i < replicas; i++ {
-		k8s.WaitUntilPodAvailable(c.t,
+		err := WaitUntilPodAvailableE(c.t,
 			c.GetKubectlOptions(namespace),
 			pods[i].Name,
 			c.defaultRetries,
 			c.defaultTimeout)
+		if err != nil {
+			return err
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
also changed `wg.Done` to `defer`. When it was after `Expect`, it would not be called in case of failure and the `BeforeSuite` was stuck forever.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [ ] Link to docs PR or issue --
- [ ] Link to UI issue or PR --
- [ ] Is the [issue worked on linked][1]? --
- [ ] The PR does not hardcode values that might break projects that depend on kuma (e.g. "kumahq" as a image registry) --
- [ ] The PR will work for both Linux and Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [ ] Unit Tests --
- [ ] E2E Tests --
- [ ] Manual Universal Tests --
- [ ] Manual Kubernetes Tests --
- [ ] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [ ] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [ ] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
