### PR TITLE
test(e2e): retry install kuma in compatibility tests

### DIFF
--- a/test/e2e/compatibility/cp_compatibility_kubernetes_multizone.go
+++ b/test/e2e/compatibility/cp_compatibility_kubernetes_multizone.go
@@ -79,7 +79,7 @@ func CpCompatibilityMultizoneKubernetes() {
 					WithInstallationMode(HelmInstallationMode),
 					WithHelmReleaseName(globalReleaseName))...,
 			)).
-			Setup(globalCluster)
+			SetupWithRetries(globalCluster, 3)
 		Expect(err).ToNot(HaveOccurred())
 
 		// Start a zone
@@ -92,7 +92,7 @@ func CpCompatibilityMultizoneKubernetes() {
 					WithHelmOpt("ingress.enabled", "true"))...,
 			)).
 			Install(NamespaceWithSidecarInjectionOnAnnotation(TestNamespace)).
-			Setup(zoneCluster)
+			SetupWithRetries(zoneCluster, 3)
 		Expect(err).ToNot(HaveOccurred())
 
 		// and new resource is created on Global

--- a/test/e2e/compatibility/dp_compatibility_universal.go
+++ b/test/e2e/compatibility/dp_compatibility_universal.go
@@ -24,7 +24,7 @@ func UniversalCompatibility() {
 				WithDPVersion("1.5.0"),
 				WithTransparentProxy(true)),
 			).
-			Setup(cluster)
+			SetupWithRetries(cluster, 3)
 		Expect(err).ToNot(HaveOccurred())
 	})
 

--- a/test/framework/deployments/kic/kubernetes.go
+++ b/test/framework/deployments/kic/kubernetes.go
@@ -65,16 +65,11 @@ func (t *k8sDeployment) Deploy(cluster framework.Cluster) error {
 		return errors.Errorf("counting KIC pods. Got: %d. Expected: 1", len(pods))
 	}
 
-	err = framework.WaitUntilPodAvailableE(cluster.GetTesting(),
+	return framework.WaitUntilPodAvailableE(cluster.GetTesting(),
 		cluster.GetKubectlOptions(t.ingressNamespace),
 		pods[0].Name,
 		framework.DefaultRetries,
 		framework.DefaultTimeout)
-	if err != nil {
-		return err
-	}
-
-	return nil
 }
 
 func (t *k8sDeployment) Delete(cluster framework.Cluster) error {

--- a/test/framework/setup.go
+++ b/test/framework/setup.go
@@ -608,6 +608,25 @@ func Combine(fs ...InstallFunc) InstallFunc {
 	}
 }
 
+func CombineWithRetries(maxRetries int, fs ...InstallFunc) InstallFunc {
+	return func(cluster Cluster) error {
+		for _, f := range fs {
+			_, err := retry.DoWithRetryE(
+				cluster.GetTesting(),
+				"installing component to cluster",
+				maxRetries,
+				0,
+				func() (string, error) {
+					return "", f(cluster)
+				})
+			if err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+}
+
 func Namespace(name string) InstallFunc {
 	return func(cluster Cluster) error {
 		return k8s.CreateNamespaceE(cluster.GetTesting(), cluster.GetKubectlOptions(), name)
@@ -629,6 +648,10 @@ func (cs *ClusterSetup) Install(fn InstallFunc) *ClusterSetup {
 
 func (cs *ClusterSetup) Setup(cluster Cluster) error {
 	return Combine(cs.installFuncs...)(cluster)
+}
+
+func (cs *ClusterSetup) SetupWithRetries(cluster Cluster, maxRetries int) error {
+	return CombineWithRetries(maxRetries, cs.installFuncs...)(cluster)
 }
 
 func CreateCertsFor(names ...string) (cert, key string, err error) {


### PR DESCRIPTION
Because compatibility tests are fetching Kuma from the internet, there might be a failure.

For example https://app.circleci.com/pipelines/github/kumahq/kuma/18663/workflows/bb4e95a1-4e22-4839-a3a4-22170672e5e5/jobs/295000

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [ ] Link to docs PR or issue --
- [ ] Link to UI issue or PR --
- [ ] Is the [issue worked on linked][1]? --
- [ ] The PR does not hardcode values that might break projects that depend on kuma (e.g. "kumahq" as a image registry) --
- [ ] The PR will work for both Linux and Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [ ] Unit Tests --
- [ ] E2E Tests --
- [ ] Manual Universal Tests --
- [ ] Manual Kubernetes Tests --
- [ ] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [ ] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [ ] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
