### PR TITLE
fix(MeshGateway): properly apply Service template annotations to existing Service

### DIFF
--- a/pkg/plugins/runtime/k8s/controllers/gateway_instance_controller.go
+++ b/pkg/plugins/runtime/k8s/controllers/gateway_instance_controller.go
@@ -130,14 +130,15 @@ func (r *GatewayInstanceReconciler) createOrUpdateService(
 
 			service := &kube_core.Service{
 				ObjectMeta: kube_meta.ObjectMeta{
-					Namespace:   gatewayInstance.Namespace,
-					Name:        gatewayInstance.Name,
-					Annotations: svcAnnotations,
+					Namespace: gatewayInstance.Namespace,
+					Name:      gatewayInstance.Name,
 				},
 			}
 			if obj != nil {
 				service = obj.(*kube_core.Service)
 			}
+
+			service.Annotations = svcAnnotations
 
 			var ports []kube_core.ServicePort
 			seenPorts := map[uint32]struct{}{}


### PR DESCRIPTION
They were being removed by the assignment of the existing object.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] Link to docs PR or issue --
- [x] Link to UI issue or PR --
- [x] Is the [issue worked on linked][1]? -- Closes https://github.com/kumahq/kuma/issues/5672
- [x] The PR does not hardcode values that might break projects that depend on kuma (e.g. "kumahq" as a image registry) --
- [x] The PR will work for both Linux and Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Unit Tests -- NONE
- [x] E2E Tests -- NONE
- [x] Manual Universal Tests --
- [x] Manual Kubernetes Tests -- YES
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [x] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
