### PR TITLE
chore(deps): bump github.com/gruntwork-io/terratest from 0.41.7 to 0.41.8

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/google/go-cmp v0.5.9
 	github.com/google/uuid v1.3.0
 	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0
-	github.com/gruntwork-io/terratest v0.41.7
+	github.com/gruntwork-io/terratest v0.41.8
 	github.com/hoisie/mustache v0.0.0-20160804235033-6375acf62c69
 	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/kumahq/kuma-net v0.8.10

--- a/go.sum
+++ b/go.sum
@@ -768,8 +768,8 @@ github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFb
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.7.0/go.mod h1:hgWBS7lorOAVIJEQMi4ZsPv9hVvWI6+ch50m39Pf2Ks=
 github.com/gruntwork-io/go-commons v0.8.0 h1:k/yypwrPqSeYHevLlEDmvmgQzcyTwrlZGRaxEM6G0ro=
 github.com/gruntwork-io/go-commons v0.8.0/go.mod h1:gtp0yTtIBExIZp7vyIV9I0XQkVwiQZze678hvDXof78=
-github.com/gruntwork-io/terratest v0.41.7 h1:Vc0hb7ajWHutGA++gu/a9FSkuf+IuQuGDRymiWdrA04=
-github.com/gruntwork-io/terratest v0.41.7/go.mod h1:qH1xkPTTGx30XkMHw8jAVIbzqheSjIa5IyiTwSV2vKI=
+github.com/gruntwork-io/terratest v0.41.8 h1:ZFVZIL2MnXLJ2g8s5lZ5pxI6ARiBAqse83oso1yPH58=
+github.com/gruntwork-io/terratest v0.41.8/go.mod h1:qH1xkPTTGx30XkMHw8jAVIbzqheSjIa5IyiTwSV2vKI=
 github.com/hailocab/go-hostpool v0.0.0-20160125115350-e80d13ce29ed/go.mod h1:tMWxXQ9wFIaZeTI9F+hmhFiGpFmhOHzyShyFUhRm0H4=
 github.com/hashicorp/consul/api v1.1.0/go.mod h1:VmuI/Lkw1nC05EYQWNKwWGbkg+FbDBtguAZLlVdkD9Q=
 github.com/hashicorp/consul/sdk v0.1.1/go.mod h1:VKf9jXwCTEY1QZP2MOLRhb5i/I/ssyNV1vwHyQBF0x8=

--- a/test/framework/deployments/kic/kubernetes.go
+++ b/test/framework/deployments/kic/kubernetes.go
@@ -65,7 +65,7 @@ func (t *k8sDeployment) Deploy(cluster framework.Cluster) error {
 		return errors.Errorf("counting KIC pods. Got: %d. Expected: 1", len(pods))
 	}
 
-	return framework.WaitUntilPodAvailableE(cluster.GetTesting(),
+	return k8s.WaitUntilPodAvailableE(cluster.GetTesting(),
 		cluster.GetKubectlOptions(t.ingressNamespace),
 		pods[0].Name,
 		framework.DefaultRetries,

--- a/test/framework/deployments/observability/kubernetes.go
+++ b/test/framework/deployments/observability/kubernetes.go
@@ -63,7 +63,7 @@ func (t *k8SDeployment) Deploy(cluster framework.Cluster) error {
 		return errors.Errorf("counting Jaeger pods. Got: %d. Expected: 1", len(pods))
 	}
 
-	err = framework.WaitUntilPodAvailableE(cluster.GetTesting(),
+	err = k8s.WaitUntilPodAvailableE(cluster.GetTesting(),
 		cluster.GetKubectlOptions(t.namespace),
 		pods[0].Name,
 		framework.DefaultRetries,

--- a/test/framework/k8s.go
+++ b/test/framework/k8s.go
@@ -2,11 +2,8 @@ package framework
 
 import (
 	"fmt"
-	"time"
 
 	"github.com/gruntwork-io/terratest/modules/k8s"
-	"github.com/gruntwork-io/terratest/modules/retry"
-	"github.com/gruntwork-io/terratest/modules/testing"
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -43,32 +40,4 @@ func PodIPOfApp(cluster Cluster, name string, namespace string) (string, error) 
 		return "", errors.Errorf("expected %d pods, got %d", 1, len(pods))
 	}
 	return pods[0].Status.PodIP, nil
-}
-
-// WaitUntilPodAvailableE it's a "fork" of original WaitUntilPodAvailableE from terratest with more information why the pod failed
-// Remove when https://github.com/gruntwork-io/terratest/pull/1223 is merged.
-func WaitUntilPodAvailableE(t testing.TestingT, options *k8s.KubectlOptions, podName string, retries int, sleepBetweenRetries time.Duration) error {
-	statusMsg := fmt.Sprintf("Wait for pod %s to be provisioned.", podName)
-	message, err := retry.DoWithRetryE(
-		t,
-		statusMsg,
-		retries,
-		sleepBetweenRetries,
-		func() (string, error) {
-			pod, err := k8s.GetPodE(t, options, podName)
-			if err != nil {
-				return "", err
-			}
-			if !k8s.IsPodAvailable(pod) {
-				return "", errors.Errorf("Pod %s is not available, reason: %s, message: %s", pod.Name, pod.Status.Reason, pod.Status.Message)
-			}
-			return "Pod is now available", nil
-		},
-	)
-	if err != nil {
-		Logf("Timedout waiting for Pod to be provisioned: %s", err)
-		return err
-	}
-	Logf(message)
-	return nil
 }

--- a/test/framework/k8s_cluster.go
+++ b/test/framework/k8s_cluster.go
@@ -1138,7 +1138,7 @@ func (c *K8sCluster) WaitApp(name, namespace string, replicas int) error {
 	}
 
 	for i := 0; i < replicas; i++ {
-		err := WaitUntilPodAvailableE(c.t,
+		err := k8s.WaitUntilPodAvailableE(c.t,
 			c.GetKubectlOptions(namespace),
 			pods[i].Name,
 			c.defaultRetries,

--- a/test/framework/setup.go
+++ b/test/framework/setup.go
@@ -265,7 +265,7 @@ func WaitPodsAvailable(namespace, app string) InstallFunc {
 			return err
 		}
 		for _, p := range pods {
-			err := WaitUntilPodAvailableE(c.GetTesting(), c.GetKubectlOptions(namespace), p.GetName(), ck8s.defaultRetries, ck8s.defaultTimeout)
+			err := k8s.WaitUntilPodAvailableE(c.GetTesting(), c.GetKubectlOptions(namespace), p.GetName(), ck8s.defaultRetries, ck8s.defaultTimeout)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
Reporting reason for failed container is now done in Terratest

Signed-off-by: Charly Molter <charly.molter@konghq.com>

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [ x Link to docs PR or issue --
- [x] Link to UI issue or PR --
- [x] Is the [issue worked on linked][1]? --
- [x] The PR does not hardcode values that might break projects that depend on kuma (e.g. "kumahq" as a image registry) --
- [x] The PR will work for both Linux and Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Unit Tests --
- [x] E2E Tests --
- [x] Manual Universal Tests --
- [x] Manual Kubernetes Tests --
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [x] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
