### PR TITLE
chore(MeshHTTPRoute): use correct return type of GetDefault

### DIFF
--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/plugin.go
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/plugin.go
@@ -53,7 +53,7 @@ func (p plugin) Apply(rs *core_xds.ResourceSet, ctx xds_context.Context, proxy *
 	for _, policy := range policies.ToRules.Rules {
 		toRules = append(toRules, ToRouteRule{
 			Subset: policy.Subset,
-			Rules:  policy.Conf.([]api.Rule),
+			Rules:  policy.Conf.(api.PolicyDefault).AppendRules,
 			Origin: policy.Origin,
 		})
 	}

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/plugin_test.go
@@ -347,31 +347,32 @@ var _ = Describe("MeshHTTPRoute", func() {
 							ToRules: core_xds.ToRules{
 								Rules: core_xds.Rules{{
 									Subset: core_xds.MeshService("backend"),
-									Conf: []api.Rule{{
-										Matches: []api.Match{{
-											Path: api.PathMatch{
-												Prefix: "/v1",
-											},
-										}},
-										Default: api.RuleConf{
-											BackendRefs: &[]api.BackendRef{{
-												TargetRef: builders.TargetRefService("backend"),
-												Weight:    100,
+									Conf: api.PolicyDefault{
+										AppendRules: []api.Rule{{
+											Matches: []api.Match{{
+												Path: api.PathMatch{
+													Prefix: "/v1",
+												},
 											}},
-										},
-									}, {
-										Matches: []api.Match{{
-											Path: api.PathMatch{
-												Prefix: "/v2",
+											Default: api.RuleConf{
+												BackendRefs: &[]api.BackendRef{{
+													TargetRef: builders.TargetRefService("backend"),
+													Weight:    100,
+												}},
 											},
-										}},
-										Default: api.RuleConf{
-											BackendRefs: &[]api.BackendRef{{
-												TargetRef: builders.TargetRefServiceSubset("backend", "region", "us"),
-												Weight:    100,
+										}, {
+											Matches: []api.Match{{
+												Path: api.PathMatch{
+													Prefix: "/v2",
+												},
 											}},
-										},
-									}},
+											Default: api.RuleConf{
+												BackendRefs: &[]api.BackendRef{{
+													TargetRef: builders.TargetRefServiceSubset("backend", "region", "us"),
+													Weight:    100,
+												}},
+											},
+										}}},
 								}},
 							},
 						},


### PR DESCRIPTION
`GetDefault` wraps the rules into a struct

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] Link to docs PR or issue --
- [x] Link to UI issue or PR --
- [x] Is the [issue worked on linked][1]? -- #5470 
- [x] The PR does not hardcode values that might break projects that depend on kuma (e.g. "kumahq" as a image registry) --
- [x] The PR will work for both Linux and Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Unit Tests --
- [x] E2E Tests --
- [x] Manual Universal Tests --
- [x] Manual Kubernetes Tests --
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [x] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
