### PR TITLE
fix(api-server): return 400 on invalid resource name

### DIFF
--- a/pkg/core/resources/store/store.go
+++ b/pkg/core/resources/store/store.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"reflect"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -144,4 +145,16 @@ func IsResourceNotFound(err error) bool {
 
 func IsResourcePreconditionFailed(err error) bool {
 	return err != nil && strings.HasPrefix(err.Error(), "Resource precondition failed")
+}
+
+type PreconditionError struct {
+	Reason string
+}
+
+func (a *PreconditionError) Error() string {
+	return "invalid format: " + a.Reason
+}
+
+func (a *PreconditionError) Is(err error) bool {
+	return reflect.TypeOf(a) == reflect.TypeOf(err)
 }

--- a/pkg/core/rest/errors/error_handler.go
+++ b/pkg/core/rest/errors/error_handler.go
@@ -22,6 +22,13 @@ func HandleError(response *restful.Response, err error, title string) {
 		handleNotFound(title, response)
 	case store.IsResourcePreconditionFailed(err):
 		handlePreconditionFailed(title, response)
+	case errors.Is(err, &store.PreconditionError{}):
+		var err2 *store.PreconditionError
+		errors.As(err, &err2)
+		WriteError(response, 400, types.Error{
+			Title:   "Bad Request",
+			Details: err2.Reason,
+		})
 	case err == store.ErrorInvalidOffset:
 		handleInvalidOffset(title, response)
 	case manager.IsMeshNotFound(err):

--- a/pkg/plugins/resources/k8s/store.go
+++ b/pkg/plugins/resources/k8s/store.go
@@ -205,11 +205,18 @@ func (s *KubernetesStore) List(ctx context.Context, rs core_model.ResourceList, 
 }
 
 func k8sNameNamespace(coreName string, scope k8s_model.Scope) (string, string, error) {
+	if coreName == "" {
+		return "", "", &store.PreconditionError{Reason: "name can't be empty"}
+	}
 	switch scope {
 	case k8s_model.ScopeCluster:
 		return coreName, "", nil
 	case k8s_model.ScopeNamespace:
-		return util_k8s.CoreNameToK8sName(coreName)
+		name, ns, err := util_k8s.CoreNameToK8sName(coreName)
+		if err != nil {
+			return "", "", &store.PreconditionError{Reason: err.Error()}
+		}
+		return name, ns, nil
 	default:
 		return "", "", errors.Errorf("unknown scope %s", scope)
 	}

--- a/test/e2e_env/kubernetes/inspect/inspect.go
+++ b/test/e2e_env/kubernetes/inspect/inspect.go
@@ -28,6 +28,12 @@ func Inspect() {
 		Expect(kubernetes.Cluster.DeleteMesh(meshName)).To(Succeed())
 	})
 
+	It("should return bad request on invalid name(#4985)", func() {
+		_, err := kubernetes.Cluster.GetKumactlOptions().RunKumactlAndGetOutput("inspect", "dataplane", "-m", meshName, "dummy-name", "--type=config-dump")
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring(`Bad Request (name "dummy-name" must include namespace after the dot, ex. "name.namespace")`))
+	})
+
 	It("should return envoy config_dump", func() {
 		// Synchronize on the dataplanes coming up.
 		Eventually(func(g Gomega) {


### PR DESCRIPTION
Before we were returning 500 when resource was not in the format `<name>.<namespace>`
We now return a typed error in the store and have the api-server map the error to a 400

Fix #5705
Fix #4985

Signed-off-by: Charly Molter <charly.molter@konghq.com>

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] Link to docs PR or issue --
- [x] Link to UI issue or PR --
- [x] Is the [issue worked on linked][1]? --
- [x] The PR does not hardcode values that might break projects that depend on kuma (e.g. "kumahq" as a image registry) --
- [x] The PR will work for both Linux and Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Unit Tests --
- [x] E2E Tests --
- [x] Manual Universal Tests --
- [x] Manual Kubernetes Tests --
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [x] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
