### PR TITLE
feat(meshhealthcheck): add x-kuma-tags to requests

### DIFF
--- a/pkg/plugins/policies/meshhealthcheck/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshhealthcheck/plugin/v1alpha1/plugin_test.go
@@ -184,6 +184,9 @@ healthChecks:
         start: "201"
     path: /health
     requestHeadersToAdd:
+      - header:
+          key: x-kuma-tags
+          value: '&kuma.io/service=backend&'
       - append: true
         header:
           key: x-some-header

--- a/pkg/plugins/runtime/gateway/route/configurers.go
+++ b/pkg/plugins/runtime/gateway/route/configurers.go
@@ -411,7 +411,7 @@ func RouteActionForward(mesh *core_mesh.MeshResource, endpoints core_xds.Endpoin
 
 			if isMeshCluster {
 				requestHeadersToAdd = []*envoy_config_core.HeaderValueOption{{
-					Header: &envoy_config_core.HeaderValue{Key: v3.TagsHeaderName, Value: tags.Serialize(proxyTags)},
+					Header: &envoy_config_core.HeaderValue{Key: tags.TagsHeaderName, Value: tags.Serialize(proxyTags)},
 				}}
 			}
 

--- a/pkg/xds/envoy/listeners/v3/fault_injection_configurer.go
+++ b/pkg/xds/envoy/listeners/v3/fault_injection_configurer.go
@@ -11,7 +11,6 @@ import (
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	"github.com/kumahq/kuma/pkg/util/proto"
-	envoy_routes "github.com/kumahq/kuma/pkg/xds/envoy/routes/v3"
 	"github.com/kumahq/kuma/pkg/xds/envoy/tags"
 )
 
@@ -70,7 +69,7 @@ func createHeaders(selectors []mesh_proto.SingleValueTagSet) *envoy_route.Header
 	regexOR := tags.RegexOR(selectorRegexs...)
 
 	return &envoy_route.HeaderMatcher{
-		Name: envoy_routes.TagsHeaderName,
+		Name: tags.TagsHeaderName,
 		HeaderMatchSpecifier: &envoy_route.HeaderMatcher_SafeRegexMatch{
 			SafeRegexMatch: &envoy_type_matcher.RegexMatcher{
 				EngineType: &envoy_type_matcher.RegexMatcher_GoogleRe2{

--- a/pkg/xds/envoy/listeners/v3/http_inbound_routes_configurer_test.go
+++ b/pkg/xds/envoy/listeners/v3/http_inbound_routes_configurer_test.go
@@ -11,7 +11,6 @@ import (
 	util_proto "github.com/kumahq/kuma/pkg/util/proto"
 	envoy_common "github.com/kumahq/kuma/pkg/xds/envoy"
 	. "github.com/kumahq/kuma/pkg/xds/envoy/listeners"
-	v3 "github.com/kumahq/kuma/pkg/xds/envoy/routes/v3"
 	"github.com/kumahq/kuma/pkg/xds/envoy/tags"
 )
 
@@ -35,7 +34,7 @@ var _ = Describe("HttpInboundRouteConfigurer", func() {
 			}
 			regexOR := tags.RegexOR(selectorRegexs...)
 
-			route.Match.Headers[v3.TagsHeaderName] = &v1alpha1.TrafficRoute_Http_Match_StringMatcher{
+			route.Match.Headers[tags.TagsHeaderName] = &v1alpha1.TrafficRoute_Http_Match_StringMatcher{
 				MatcherType: &v1alpha1.TrafficRoute_Http_Match_StringMatcher_Regex{
 					Regex: regexOR,
 				},

--- a/pkg/xds/envoy/routes/v3/reset_tags_header_configurer.go
+++ b/pkg/xds/envoy/routes/v3/reset_tags_header_configurer.go
@@ -1,11 +1,15 @@
 package v3
 
-import envoy_route "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
+import (
+	envoy_route "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
+
+	"github.com/kumahq/kuma/pkg/xds/envoy/tags"
+)
 
 type ResetTagsHeaderConfigurer struct {
 }
 
 func (r *ResetTagsHeaderConfigurer) Configure(rc *envoy_route.RouteConfiguration) error {
-	rc.RequestHeadersToRemove = append(rc.RequestHeadersToRemove, TagsHeaderName)
+	rc.RequestHeadersToRemove = append(rc.RequestHeadersToRemove, tags.TagsHeaderName)
 	return nil
 }

--- a/pkg/xds/envoy/routes/v3/tags_header_configurer.go
+++ b/pkg/xds/envoy/routes/v3/tags_header_configurer.go
@@ -8,8 +8,6 @@ import (
 	"github.com/kumahq/kuma/pkg/xds/envoy/tags"
 )
 
-const TagsHeaderName = "x-kuma-tags"
-
 type TagsHeaderConfigurer struct {
 	Tags mesh_proto.MultiValueTagSet
 }
@@ -19,7 +17,7 @@ func (t *TagsHeaderConfigurer) Configure(rc *envoy_route.RouteConfiguration) err
 		return nil
 	}
 	rc.RequestHeadersToAdd = append(rc.RequestHeadersToAdd, &envoy_core.HeaderValueOption{
-		Header: &envoy_core.HeaderValue{Key: TagsHeaderName, Value: tags.Serialize(t.Tags)},
+		Header: &envoy_core.HeaderValue{Key: tags.TagsHeaderName, Value: tags.Serialize(t.Tags)},
 	})
 	return nil
 }

--- a/pkg/xds/envoy/tags/match.go
+++ b/pkg/xds/envoy/tags/match.go
@@ -10,6 +10,8 @@ import (
 	core_policy "github.com/kumahq/kuma/pkg/core/policy"
 )
 
+const TagsHeaderName = "x-kuma-tags"
+
 type Tags map[string]string
 
 func (t Tags) WithoutTags(tags ...string) Tags {

--- a/pkg/xds/generator/egress/external_services_generator.go
+++ b/pkg/xds/generator/egress/external_services_generator.go
@@ -9,7 +9,6 @@ import (
 	envoy_clusters "github.com/kumahq/kuma/pkg/xds/envoy/clusters"
 	envoy_listeners "github.com/kumahq/kuma/pkg/xds/envoy/listeners"
 	envoy_names "github.com/kumahq/kuma/pkg/xds/envoy/names"
-	envoy_routes "github.com/kumahq/kuma/pkg/xds/envoy/routes/v3"
 	"github.com/kumahq/kuma/pkg/xds/envoy/tags"
 	"github.com/kumahq/kuma/pkg/xds/envoy/tls"
 )
@@ -199,7 +198,7 @@ func (g *ExternalServicesGenerator) addFilterChains(
 
 					routes = append(routes, envoy_common.NewRoute(
 						envoy_common.WithCluster(cluster),
-						envoy_common.WithMatchHeaderRegex(envoy_routes.TagsHeaderName, tags.MatchSourceRegex(rl)),
+						envoy_common.WithMatchHeaderRegex(tags.TagsHeaderName, tags.MatchSourceRegex(rl)),
 						envoy_common.WithRateLimit(rl.Spec),
 					))
 				}

--- a/pkg/xds/generator/inbound_proxy_generator.go
+++ b/pkg/xds/generator/inbound_proxy_generator.go
@@ -14,7 +14,6 @@ import (
 	envoy_clusters "github.com/kumahq/kuma/pkg/xds/envoy/clusters"
 	envoy_listeners "github.com/kumahq/kuma/pkg/xds/envoy/listeners"
 	envoy_names "github.com/kumahq/kuma/pkg/xds/envoy/names"
-	envoy_routes "github.com/kumahq/kuma/pkg/xds/envoy/routes/v3"
 	"github.com/kumahq/kuma/pkg/xds/envoy/tags"
 	xds_tls "github.com/kumahq/kuma/pkg/xds/envoy/tls"
 )
@@ -80,7 +79,7 @@ func (g InboundProxyGenerator) Generate(ctx xds_context.Context, proxy *core_xds
 
 			routes = append(routes, envoy_common.NewRoute(
 				envoy_common.WithCluster(cluster),
-				envoy_common.WithMatchHeaderRegex(envoy_routes.TagsHeaderName, tags.MatchSourceRegex(rl)),
+				envoy_common.WithMatchHeaderRegex(tags.TagsHeaderName, tags.MatchSourceRegex(rl)),
 				envoy_common.WithRateLimit(rl.Spec),
 			))
 		}


### PR DESCRIPTION
We add x-kuma-tags to all requests that way things like faultInjection can also apply to health checks

Fix #5718

Signed-off-by: Charly Molter <charly.molter@konghq.com>

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] Link to docs PR or issue --
- [x] Link to UI issue or PR --
- [x] Is the [issue worked on linked][1]? --
- [x] The PR does not hardcode values that might break projects that depend on kuma (e.g. "kumahq" as a image registry) --
- [x] The PR will work for both Linux and Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Unit Tests --
- [x] E2E Tests --
- [x] Manual Universal Tests --
- [x] Manual Kubernetes Tests --
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [x] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
