### PR TITLE
fix: replace 'test.PointerOf' with 'pointer.To'

### DIFF
--- a/pkg/plugins/policies/meshcircuitbreaker/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshcircuitbreaker/plugin/v1alpha1/plugin_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/kumahq/kuma/pkg/test/resources/builders"
 	test_model "github.com/kumahq/kuma/pkg/test/resources/model"
 	test_xds "github.com/kumahq/kuma/pkg/test/xds"
+	"github.com/kumahq/kuma/pkg/util/pointer"
 	util_proto "github.com/kumahq/kuma/pkg/util/proto"
 	xds_context "github.com/kumahq/kuma/pkg/xds/context"
 	envoy_names "github.com/kumahq/kuma/pkg/xds/envoy/names"
@@ -36,11 +37,11 @@ var _ = Describe("MeshCircuitBreaker", func() {
 
 	genConnectionLimits := func() *api.ConnectionLimits {
 		return &api.ConnectionLimits{
-			MaxConnectionPools: test.PointerOf(uint32(1111)),
-			MaxConnections:     test.PointerOf(uint32(2222)),
-			MaxPendingRequests: test.PointerOf(uint32(3333)),
-			MaxRequests:        test.PointerOf(uint32(4444)),
-			MaxRetries:         test.PointerOf(uint32(5555)),
+			MaxConnectionPools: pointer.To(uint32(1111)),
+			MaxConnections:     pointer.To(uint32(2222)),
+			MaxPendingRequests: pointer.To(uint32(3333)),
+			MaxRequests:        pointer.To(uint32(4444)),
+			MaxRetries:         pointer.To(uint32(5555)),
 		}
 	}
 
@@ -49,27 +50,27 @@ var _ = Describe("MeshCircuitBreaker", func() {
 			Disabled:                    &disabled,
 			Interval:                    test.ParseDuration("10s"),
 			BaseEjectionTime:            test.ParseDuration("8s"),
-			MaxEjectionPercent:          test.PointerOf(uint32(88)),
-			SplitExternalAndLocalErrors: test.PointerOf(true),
+			MaxEjectionPercent:          pointer.To(uint32(88)),
+			SplitExternalAndLocalErrors: pointer.To(true),
 			Detectors: &api.Detectors{
 				TotalFailures: &api.DetectorTotalFailures{
-					Consecutive: test.PointerOf(uint32(12)),
+					Consecutive: pointer.To(uint32(12)),
 				},
 				GatewayFailures: &api.DetectorGatewayFailures{
-					Consecutive: test.PointerOf(uint32(91)),
+					Consecutive: pointer.To(uint32(91)),
 				},
 				LocalOriginFailures: &api.DetectorLocalOriginFailures{
-					Consecutive: test.PointerOf(uint32(3)),
+					Consecutive: pointer.To(uint32(3)),
 				},
 				SuccessRate: &api.DetectorSuccessRateFailures{
-					MinimumHosts:            test.PointerOf(uint32(33)),
-					RequestVolume:           test.PointerOf(uint32(99)),
-					StandardDeviationFactor: test.PointerOf(uint32(1900)),
+					MinimumHosts:            pointer.To(uint32(33)),
+					RequestVolume:           pointer.To(uint32(99)),
+					StandardDeviationFactor: pointer.To(uint32(1900)),
 				},
 				FailurePercentage: &api.DetectorFailurePercentageFailures{
-					MinimumHosts:  test.PointerOf(uint32(32)),
-					RequestVolume: test.PointerOf(uint32(182)),
-					Threshold:     test.PointerOf(uint32(80)),
+					MinimumHosts:  pointer.To(uint32(32)),
+					RequestVolume: pointer.To(uint32(182)),
+					Threshold:     pointer.To(uint32(80)),
 				},
 			},
 		}

--- a/pkg/plugins/policies/meshhealthcheck/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshhealthcheck/plugin/v1alpha1/plugin_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/kumahq/kuma/pkg/test"
 	"github.com/kumahq/kuma/pkg/test/resources/builders"
 	"github.com/kumahq/kuma/pkg/test/resources/samples"
+	"github.com/kumahq/kuma/pkg/util/pointer"
 	xds_context "github.com/kumahq/kuma/pkg/xds/context"
 	envoy_common "github.com/kumahq/kuma/pkg/xds/envoy"
 	"github.com/kumahq/kuma/pkg/xds/envoy/clusters"
@@ -142,11 +143,11 @@ var _ = Describe("MeshHealthCheck", func() {
 							HealthyThreshold:             1,
 							InitialJitter:                test.ParseDuration("13s"),
 							IntervalJitter:               test.ParseDuration("15s"),
-							IntervalJitterPercent:        policies_xds.PointerOf[int32](10),
-							HealthyPanicThreshold:        policies_xds.PointerOf[int32](11),
-							FailTrafficOnPanic:           policies_xds.PointerOf[bool](true),
-							EventLogPath:                 policies_xds.PointerOf[string]("/tmp/log.txt"),
-							AlwaysLogHealthCheckFailures: policies_xds.PointerOf[bool](false),
+							IntervalJitterPercent:        pointer.To[int32](10),
+							HealthyPanicThreshold:        pointer.To[int32](11),
+							FailTrafficOnPanic:           pointer.To(true),
+							EventLogPath:                 pointer.To("/tmp/log.txt"),
+							AlwaysLogHealthCheckFailures: pointer.To(false),
 							NoTrafficInterval:            test.ParseDuration("16s"),
 							Http: &api.HttpHealthCheck{
 								Disabled: false,
@@ -157,12 +158,12 @@ var _ = Describe("MeshHealthCheck", func() {
 											Key:   "x-some-header",
 											Value: "value",
 										},
-										Append: policies_xds.PointerOf[bool](true),
+										Append: pointer.To(true),
 									},
 								},
 								ExpectedStatuses: &[]int32{200, 201},
 							},
-							ReuseConnection: policies_xds.PointerOf[bool](true),
+							ReuseConnection: pointer.To(true),
 						},
 					},
 				}},
@@ -211,7 +212,7 @@ healthChecks:
 							HealthyThreshold:   1,
 							Tcp: &api.TcpHealthCheck{
 								Disabled: false,
-								Send:     policies_xds.PointerOf[string]("cGluZwo="),
+								Send:     pointer.To("cGluZwo="),
 								Receive:  &[]string{"cG9uZwo="},
 							},
 						},

--- a/pkg/plugins/policies/meshratelimit/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshratelimit/plugin/v1alpha1/plugin_test.go
@@ -127,12 +127,12 @@ var _ = Describe("MeshRateLimit", func() {
 								HTTP: &api.LocalHTTP{
 									RequestRate: &api.Rate{Num: 100, Interval: *test.ParseDuration("10s")},
 									OnRateLimit: &api.OnRateLimit{
-										Status: test.PointerOf(uint32(444)),
+										Status: pointer.To(uint32(444)),
 										Headers: &[]api.HeaderValue{
 											{
 												Key:    "x-kuma-rate-limit-header",
 												Value:  "test-value",
-												Append: test.PointerOf(true),
+												Append: pointer.To(true),
 											},
 											{
 												Key:   "x-kuma-rate-limit",
@@ -213,12 +213,12 @@ var _ = Describe("MeshRateLimit", func() {
 										Interval: *test.ParseDuration("10s"),
 									},
 									OnRateLimit: &api.OnRateLimit{
-										Status: test.PointerOf(uint32(444)),
+										Status: pointer.To(uint32(444)),
 										Headers: &[]api.HeaderValue{
 											{
 												Key:    "x-kuma-rate-limit-header",
 												Value:  "test-value",
-												Append: test.PointerOf(true),
+												Append: pointer.To(true),
 											},
 											{
 												Key:   "x-kuma-rate-limit",
@@ -419,12 +419,12 @@ var _ = Describe("MeshRateLimit", func() {
 									Interval: v1.Duration{Duration: 10 * time.Second},
 								},
 								OnRateLimit: &api.OnRateLimit{
-									Status: test.PointerOf(uint32(444)),
+									Status: pointer.To(uint32(444)),
 									Headers: &[]api.HeaderValue{
 										{
 											Key:    "x-kuma-rate-limit-header",
 											Value:  "test-value",
-											Append: test.PointerOf(true),
+											Append: pointer.To(true),
 										},
 										{
 											Key:   "x-kuma-rate-limit",

--- a/pkg/plugins/policies/meshretry/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshretry/plugin/v1alpha1/plugin_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/kumahq/kuma/pkg/test/matchers"
 	"github.com/kumahq/kuma/pkg/test/resources/builders"
 	test_xds "github.com/kumahq/kuma/pkg/test/xds"
+	"github.com/kumahq/kuma/pkg/util/pointer"
 	util_proto "github.com/kumahq/kuma/pkg/util/proto"
 	envoy_common "github.com/kumahq/kuma/pkg/xds/envoy"
 	. "github.com/kumahq/kuma/pkg/xds/envoy/listeners"
@@ -96,7 +97,7 @@ var _ = Describe("MeshRetry", func() {
 						Subset: core_xds.Subset{},
 						Conf: api.Conf{
 							HTTP: &api.HTTP{
-								NumRetries:    test.PointerOf[uint32](1),
+								NumRetries:    pointer.To[uint32](1),
 								PerTryTimeout: test.ParseDuration("2s"),
 								BackOff: &api.BackOff{
 									BaseInterval: test.ParseDuration("3s"),
@@ -176,7 +177,7 @@ var _ = Describe("MeshRetry", func() {
 						}},
 						Conf: api.Conf{
 							GRPC: &api.GRPC{
-								NumRetries:    test.PointerOf[uint32](11),
+								NumRetries:    pointer.To[uint32](11),
 								PerTryTimeout: test.ParseDuration("12s"),
 								BackOff: &api.BackOff{
 									BaseInterval: test.ParseDuration("13s"),
@@ -221,7 +222,7 @@ var _ = Describe("MeshRetry", func() {
 						Subset: core_xds.Subset{},
 						Conf: api.Conf{
 							TCP: &api.TCP{
-								MaxConnectAttempt: test.PointerOf[uint32](21),
+								MaxConnectAttempt: pointer.To[uint32](21),
 							},
 						},
 					},

--- a/pkg/plugins/policies/xds/testutil.go
+++ b/pkg/plugins/policies/xds/testutil.go
@@ -21,10 +21,6 @@ func ResourceArrayShouldEqual(resources core_xds.ResourceList, expected []string
 	Expect(len(resources)).To(Equal(len(expected)))
 }
 
-func PointerOf[T any](value T) *T {
-	return &value
-}
-
 type NameConfigurer struct {
 	Name string
 }

--- a/pkg/test/api_types.go
+++ b/pkg/test/api_types.go
@@ -6,10 +6,6 @@ import (
 	k8s "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func PointerOf[T any](value T) *T {
-	return &value
-}
-
 func ParseDuration(duration string) *k8s.Duration {
 	d, err := time.ParseDuration(duration)
 	if err != nil {


### PR DESCRIPTION
We have 3 functions that are doing exactly the same thing. Use function from the `pointer` package.

Signed-off-by: Ilya Lobkov <ilya.lobkov@konghq.com>

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [X] Link to docs PR or issue --
- [X] Link to UI issue or PR --
- [X] Is the [issue worked on linked][1]? --
- [X] The PR does not hardcode values that might break projects that depend on kuma (e.g. "kumahq" as a image registry) --
- [X] The PR will work for both Linux and Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [X] Unit Tests --
- [X] E2E Tests --
- [X] Manual Universal Tests --
- [X] Manual Kubernetes Tests --
- [X] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [X] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [X] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
