### PR TITLE
ci(CHANGELOG.md): improve excluded patterns for commits

### DIFF
--- a/tools/releases/changelog/github.go
+++ b/tools/releases/changelog/github.go
@@ -234,10 +234,14 @@ func NewCommitInfo(commit GQLCommit) *CommitInfo {
 		return nil
 	case "":
 		// Ignore prs with usually ignored prefix
-		for _, v := range []string{"build:", "ci:", "ci(", "test(", "refactor(", "chore(ci)", "fix(ci)", "fix(test)", "tests(", "build(", "docs(madr)"} {
+		for _, v := range []string{"build", "ci", "test", "refactor", "fix(ci)", "fix(test)", "docs"} {
 			if strings.HasPrefix(commit.Message, v) {
 				return nil
 			}
+		}
+		// Only prs with chore(deps) are included
+		if strings.HasPrefix(commit.Message, "chore") && !strings.HasPrefix(commit.Message, "chore(deps)") {
+			return nil
 		}
 		// Use the pr.Title as a changelog entry
 		res.Changelog = pr.Title


### PR DESCRIPTION
include chore except chore(deps) and rely on the fact we're using conventional commits

Signed-off-by: Charly Molter <charly.molter@konghq.com>

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] Link to docs PR or issue --
- [x] Link to UI issue or PR --
- [x] Is the [issue worked on linked][1]? --
- [x] The PR does not hardcode values that might break projects that depend on kuma (e.g. "kumahq" as a image registry) --
- [x] The PR will work for both Linux and Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Unit Tests --
- [x] E2E Tests --
- [x] Manual Universal Tests --
- [x] Manual Kubernetes Tests --
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [x] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
