### PR TITLE
chore: run arm on branch when full test matrix is enabled

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -197,11 +197,11 @@ jobs:
     executor:
       name: vm-<< parameters.arch >>
     steps:
+    - checkout
     - when:
         condition: {equal: [arm64, << parameters.arch >>]}
         steps:
           - skip_on_branch
-    - checkout
     - run:
         # Label based skip-test runs
         name: "Check if skip"
@@ -381,13 +381,13 @@ jobs:
     executor: # we are using linux/arm64 and linux/amd64 vm's for build
       name: vm-<< parameters.arch >>
     steps:
+    - checkout
     - when:
         condition: {equal: [arm64, << parameters.arch >>]}
         steps:
           - skip_on_branch
     - install_build_tools:
         go_arch: <<parameters.arch>>
-    - checkout
     - restore_cache:
         keys:
         # prefer the exact match

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,7 +68,7 @@ commands:
     - run:
         name: "Skip the job on the branch"
         command: |
-          if [[ "<< pipeline.git.branch >>" != "master" && "<< pipeline.git.branch >>" != "release-"* ]]; then
+          if [[ "<< pipeline.git.branch >>" != "master" && "<< pipeline.git.branch >>" != "release-"* && $(./tools/ci/has_label.sh ci/run-full-matrix) != "true" ]]; then
             circleci-agent step halt
             exit 0
           fi


### PR DESCRIPTION
We need to run arm when full matrix is enabled.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [ ] Link to docs PR or issue --
- [ ] Link to UI issue or PR --
- [ ] Is the [issue worked on linked][1]? --
- [ ] The PR does not hardcode values that might break projects that depend on kuma (e.g. "kumahq" as a image registry) --
- [ ] The PR will work for both Linux and Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [ ] Unit Tests --
- [ ] E2E Tests --
- [ ] Manual Universal Tests --
- [ ] Manual Kubernetes Tests --
- [ ] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [ ] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [ ] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
