### PR TITLE
fix: 'append' in MeshRateLimit should be 'true' by default

### DIFF
--- a/app/kumactl/cmd/install/testdata/install-control-plane.defaults.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.defaults.golden.yaml
@@ -1265,6 +1265,7 @@ spec:
                                       items:
                                         properties:
                                           append:
+                                            default: true
                                             description: Should the header be appended
                                             type: boolean
                                           key:

--- a/app/kumactl/cmd/install/testdata/install-control-plane.gateway-api-present-not-enabled.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.gateway-api-present-not-enabled.yaml
@@ -1265,6 +1265,7 @@ spec:
                                       items:
                                         properties:
                                           append:
+                                            default: true
                                             description: Should the header be appended
                                             type: boolean
                                           key:

--- a/app/kumactl/cmd/install/testdata/install-control-plane.gateway-api-present.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.gateway-api-present.yaml
@@ -1397,6 +1397,7 @@ spec:
                                       items:
                                         properties:
                                           append:
+                                            default: true
                                             description: Should the header be appended
                                             type: boolean
                                           key:

--- a/app/kumactl/cmd/install/testdata/install-control-plane.with-helm-set.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.with-helm-set.yaml
@@ -1285,6 +1285,7 @@ spec:
                                       items:
                                         properties:
                                           append:
+                                            default: true
                                             description: Should the header be appended
                                             type: boolean
                                           key:

--- a/app/kumactl/cmd/install/testdata/install-crds.all.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-crds.all.golden.yaml
@@ -2436,6 +2436,7 @@ spec:
                                       items:
                                         properties:
                                           append:
+                                            default: true
                                             description: Should the header be appended
                                             type: boolean
                                           key:

--- a/app/kumactl/cmd/install/testdata/install-crds.experimental-gatewayapi.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-crds.experimental-gatewayapi.golden.yaml
@@ -2568,6 +2568,7 @@ spec:
                                       items:
                                         properties:
                                           append:
+                                            default: true
                                             description: Should the header be appended
                                             type: boolean
                                           key:

--- a/deployments/charts/kuma/crds/kuma.io_meshratelimits.yaml
+++ b/deployments/charts/kuma/crds/kuma.io_meshratelimits.yaml
@@ -66,6 +66,7 @@ spec:
                                       items:
                                         properties:
                                           append:
+                                            default: true
                                             description: Should the header be appended
                                             type: boolean
                                           key:

--- a/pkg/plugins/policies/meshratelimit/api/v1alpha1/meshratelimit.go
+++ b/pkg/plugins/policies/meshratelimit/api/v1alpha1/meshratelimit.go
@@ -60,6 +60,7 @@ type HeaderValue struct {
 	// Header value
 	Value string `json:"value"`
 	// Should the header be appended
+	// +kubebuilder:default=true
 	Append *bool `json:"append,omitempty"`
 }
 

--- a/pkg/plugins/policies/meshratelimit/api/v1alpha1/schema.yaml
+++ b/pkg/plugins/policies/meshratelimit/api/v1alpha1/schema.yaml
@@ -38,6 +38,7 @@ properties:
                               items:
                                 properties:
                                   append:
+                                    default: true
                                     description: Should the header be appended
                                     type: boolean
                                   key:

--- a/pkg/plugins/policies/meshratelimit/k8s/crd/kuma.io_meshratelimits.yaml
+++ b/pkg/plugins/policies/meshratelimit/k8s/crd/kuma.io_meshratelimits.yaml
@@ -66,6 +66,7 @@ spec:
                                       items:
                                         properties:
                                           append:
+                                            default: true
                                             description: Should the header be appended
                                             type: boolean
                                           key:

--- a/pkg/plugins/policies/meshratelimit/plugin/v1alpha1/testdata/basic_listener_1.golden.yaml
+++ b/pkg/plugins/policies/meshratelimit/plugin/v1alpha1/testdata/basic_listener_1.golden.yaml
@@ -47,7 +47,7 @@ filterChains:
                   header:
                     key: x-kuma-rate-limit-header
                     value: test-value
-                - append: false
+                - append: true
                   header:
                     key: x-kuma-rate-limit
                     value: other-value

--- a/pkg/plugins/policies/meshratelimit/plugin/v1alpha1/testdata/gateway_basic_routes.golden.yaml
+++ b/pkg/plugins/policies/meshratelimit/plugin/v1alpha1/testdata/gateway_basic_routes.golden.yaml
@@ -35,7 +35,7 @@ virtualHosts:
           header:
             key: x-kuma-rate-limit-header
             value: test-value
-        - append: false
+        - append: true
           header:
             key: x-kuma-rate-limit
             value: other-value

--- a/pkg/plugins/policies/meshratelimit/plugin/xds/configurer.go
+++ b/pkg/plugins/policies/meshratelimit/plugin/xds/configurer.go
@@ -26,11 +26,15 @@ func RateLimitConfigurationFromPolicy(rl *api.LocalHTTP) *rate_limit.RateLimitCo
 	var status uint32
 	if rl.OnRateLimit != nil {
 		for _, h := range pointer.Deref(rl.OnRateLimit.Headers) {
-			headers = append(headers, &rate_limit.Headers{
+			header := &rate_limit.Headers{
 				Key:    h.Key,
 				Value:  h.Value,
-				Append: pointer.Deref(h.Append),
-			})
+				Append: true,
+			}
+			if h.Append != nil {
+				header.Append = *h.Append
+			}
+			headers = append(headers, header)
 		}
 		status = pointer.Deref(rl.OnRateLimit.Status)
 	}


### PR DESCRIPTION
In Envoy if `Append` is not set then it's true by default:

> **_Append_** 
_Should the value be appended? If true (default), the value is appended to existing values. Otherwise it replaces any existing values. This field is deprecated and please use [append_action](https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/core/v3/base.proto#envoy-v3-api-field-config-core-v3-headervalueoption-append-action) as replacement._

We already have this behavior in MeshHealthCheck.

Signed-off-by: Ilya Lobkov <ilya.lobkov@konghq.com>

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [X] Link to docs PR or issue --
- [X] Link to UI issue or PR --
- [X] Is the [issue worked on linked][1]? --
- [X] The PR does not hardcode values that might break projects that depend on kuma (e.g. "kumahq" as a image registry) --
- [X] The PR will work for both Linux and Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [X] Unit Tests --
- [X] E2E Tests --
- [X] Manual Universal Tests --
- [X] Manual Kubernetes Tests --
- [X] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [X] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [X] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
