### PR TITLE
feat(build): automatically apply security updates for release branches

### DIFF
--- a/.github/workflows/update-insecure-dependencies.yaml
+++ b/.github/workflows/update-insecure-dependencies.yaml
@@ -36,9 +36,8 @@ jobs:
       - name: "Prepare commit body - before"
         id: prepare_commit_body_before
         run: |
-          SCAN_OUTPUT_BEFORE=$(osv-scanner --lockfile=go.mod | tr "+" "|" | awk 'NR>3 {print last} {last=$0}' || true)
           echo "SCAN_OUTPUT_BEFORE<<EOF" >> $GITHUB_ENV
-          echo "$SCAN_OUTPUT_BEFORE" >> $GITHUB_ENV
+          osv-scanner --lockfile=go.mod | tr "+" "|" | awk 'NR>3 {print last} {last=$0}' || true >> $GITHUB_ENV
           echo "EOF" >> $GITHUB_ENV
       - name: "Update dependencies"
         id: update
@@ -48,9 +47,8 @@ jobs:
       - name: "Prepare commit body - after"
         id: prepare_commit_body_after
         run: |
-          SCAN_OUTPUT_AFTER=$(osv-scanner --lockfile=go.mod | tr "+" "|" | awk 'NR>3 {print last} {last=$0}' || true)
           echo "SCAN_OUTPUT_AFTER<<EOF" >> $GITHUB_ENV
-          echo "$SCAN_OUTPUT_AFTER" >> $GITHUB_ENV
+          osv-scanner --lockfile=go.mod | tr "+" "|" | awk 'NR>3 {print last} {last=$0}' || true >> $GITHUB_ENV
           echo "EOF" >> $GITHUB_ENV
       - name: "Create Pull Request"
         uses: peter-evans/create-pull-request@v4

--- a/.github/workflows/update-insecure-dependencies.yaml
+++ b/.github/workflows/update-insecure-dependencies.yaml
@@ -1,0 +1,75 @@
+name: "Update insecure dependencies"
+
+on:
+  workflow_dispatch: { }
+  schedule:
+    - cron: 0 8 * * *
+jobs:
+  update-insecure-dependencies:
+    strategy:
+      matrix:
+        branch:
+          - "release-2.0"
+          - "release-1.8"
+          - "release-1.7"
+          - "release-1.6"
+          - "release-1.5"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate GitHub app token
+        id: github-app-token
+        uses: tibdex/github-app-token@021a2405c7f990db57f5eae5397423dcc554159c # v1.7.0
+        with:
+          app_id: ${{ secrets.APP_ID }}
+          private_key: ${{ secrets.APP_PRIVATE_KEY }}
+      - name: "Clone Kuma"
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ matrix.branch }}
+      - uses: actions/setup-go@v3
+        with:
+          go-version: "~1.18.9"
+      - name: "Install tools"
+        run: |
+          sudo apt install -y jq git
+          GOBIN=/usr/local/bin/ go install github.com/google/osv-scanner/cmd/osv-scanner@v1
+      - name: "Prepare commit body - before"
+        id: prepare_commit_body_before
+        run: |
+          SCAN_OUTPUT_BEFORE=$(osv-scanner --lockfile=go.mod | tr "+" "|" | awk 'NR>3 {print last} {last=$0}' || true)
+          echo "SCAN_OUTPUT_BEFORE<<EOF" >> $GITHUB_ENV
+          echo "$SCAN_OUTPUT_BEFORE" >> $GITHUB_ENV
+          echo "EOF" >> $GITHUB_ENV
+      - name: "Update dependencies"
+        id: update
+        run: |
+          osv-scanner --lockfile=go.mod --json | jq '.results[].packages[].package.name' | xargs -I {} go get -u {}
+          go mod tidy
+      - name: "Prepare commit body - after"
+        id: prepare_commit_body_after
+        run: |
+          SCAN_OUTPUT_AFTER=$(osv-scanner --lockfile=go.mod | tr "+" "|" | awk 'NR>3 {print last} {last=$0}' || true)
+          echo "SCAN_OUTPUT_AFTER<<EOF" >> $GITHUB_ENV
+          echo "$SCAN_OUTPUT_AFTER" >> $GITHUB_ENV
+          echo "EOF" >> $GITHUB_ENV
+      - name: "Create Pull Request"
+        uses: peter-evans/create-pull-request@v4
+        with:
+          commit-message: "chore(deps): security update"
+          signoff: true
+          branch: chore/security-updates-${{ matrix.branch }}
+          body: |
+            Scan output:
+
+            Before update:
+            ${{ env.SCAN_OUTPUT_BEFORE }}
+
+            After update:
+            ${{ env.SCAN_OUTPUT_AFTER }}
+          delete-branch: true
+          title: "chore(deps): security update"
+          draft: false
+          labels: dependencies
+          token: ${{ steps.github-app-token.outputs.token }}
+          committer: kumahq[bot] <110050114+kumahq[bot]@users.noreply.github.com>
+          author: kumahq[bot] <110050114+kumahq[bot]@users.noreply.github.com>

--- a/.github/workflows/update-insecure-dependencies.yaml
+++ b/.github/workflows/update-insecure-dependencies.yaml
@@ -14,6 +14,7 @@ jobs:
           - "release-1.7"
           - "release-1.6"
           - "release-1.5"
+          - "master"
     runs-on: ubuntu-latest
     steps:
       - name: Generate GitHub app token
@@ -31,7 +32,6 @@ jobs:
           go-version: "~1.18.9"
       - name: "Install tools"
         run: |
-          sudo apt install -y jq git
           GOBIN=/usr/local/bin/ go install github.com/google/osv-scanner/cmd/osv-scanner@v1
       - name: "Prepare commit body - before"
         id: prepare_commit_body_before

--- a/.github/workflows/update-insecure-dependencies.yaml
+++ b/.github/workflows/update-insecure-dependencies.yaml
@@ -32,7 +32,7 @@ jobs:
           go-version: "~1.18.9"
       - name: "Install tools"
         run: |
-          GOBIN=/usr/local/bin/ go install github.com/google/osv-scanner/cmd/osv-scanner@v1
+          go install github.com/google/osv-scanner/cmd/osv-scanner@v1
       - name: "Prepare commit body - before"
         id: prepare_commit_body_before
         run: |


### PR DESCRIPTION
Example PRs:
- https://github.com/slonka/kuma/pull/9
- https://github.com/slonka/kuma/pull/10

Example output:
- https://github.com/slonka/kuma/actions/runs/3956613355/jobs/6776020642

Once the PR is merged a new one won't be created. Also running action multiple times just updates the PR if there are things to update.

Signed-off-by: slonka <slonka@users.noreply.github.com>

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [X] Link to docs PR or issue -- will issue link if the PR get's accepted
- [X] Link to UI issue or PR -- not a UI issue
- [X] Is the [issue worked on linked][1]? --
- [X] The PR does not hardcode values that might break projects that depend on kuma (e.g. "kumahq" as a image registry) --
- [X] The PR will work for both Linux and Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [X] Unit Tests -- only manual tests
- [X] E2E Tests --
- [X] Manual Universal Tests --
- [X] Manual Kubernetes Tests --
- [X] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [X] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? -- no, actions are taken from main branch
- [X] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
