### PR TITLE
chore: use direct mode to import images in k3d

### DIFF
--- a/mk/k3d.mk
+++ b/mk/k3d.mk
@@ -113,7 +113,7 @@ k3d/stop/all:
 .PHONY: k3d/load/images
 k3d/load/images:
 	# https://github.com/k3d-io/k3d/issues/900 can cause failures that simple retry will fix
-	for i in 1 2 3 4 5; do $(K3D_BIN) image import --mode=direct $(KUMA_IMAGES) --cluster=$(KIND_CLUSTER_NAME) --verbose && s=0 && break || s=$$? && echo "Image import failed. Retrying..."; done; (exit $$s)
+	for i in {1..5}; do $(K3D_BIN) image import --mode=direct $(KUMA_IMAGES) --cluster=$(KIND_CLUSTER_NAME) --verbose && s=0 && break || s=$$? && echo "Image import failed. Retrying..."; done; (exit $$s)
 
 .PHONY: k3d/load
 k3d/load:

--- a/mk/k3d.mk
+++ b/mk/k3d.mk
@@ -113,7 +113,7 @@ k3d/stop/all:
 .PHONY: k3d/load/images
 k3d/load/images:
 	# https://github.com/k3d-io/k3d/issues/900 can cause failures that simple retry will fix
-	@$(K3D_BIN) image import $(KUMA_IMAGES) --cluster=$(KIND_CLUSTER_NAME) --verbose || $(K3D_BIN) image import $(KUMA_IMAGES) --cluster=$(KIND_CLUSTER_NAME) --verbose
+	for i in 1 2 3 4 5; do $(K3D_BIN) image import --mode=direct $(KUMA_IMAGES) --cluster=$(KIND_CLUSTER_NAME) --verbose && s=0 && break || s=$$? && echo "Image import failed. Retrying..."; done; (exit $$s)
 
 .PHONY: k3d/load
 k3d/load:


### PR DESCRIPTION
There are two modes of importing images in K3D, "direct" and "node-tools".

Because "direct" mode was not reliable enough, K3D team switched back to "node-tools" by default in K3D 5.4.0 that we [recently upgraded to](https://github.com/kumahq/kuma/pull/5518). The problem is that "node-tools" also can fail and in a worse way because it returns exit code 0, so we cannot retry. See https://github.com/k3d-io/k3d/issues/1072

Our CI is really flaky recently because of this. Here is [an example](https://circleci.com/api/v1.1/project/github/kumahq/kuma/304857/output/109/0?file=true&allocation-id=63c91ee2f9823b684de59c4b-0-build%2FOMN51VPD).

This PR switches image import to "direct" once again, but with more retries.

We already use direct mode [here](https://github.com/kumahq/kuma/blob/master/test/framework/k8s_cluster.go#L1193).
What _might_ be a problem is that this command may be stuck, see https://github.com/kumahq/kuma/pull/5667 . If this will be the case "outside of executing from Go" we can add a similar timeout in Makefiles.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [X] Link to docs PR or issue --
- [X] Link to UI issue or PR --
- [X] Is the [issue worked on linked][1]? --
- [X] The PR does not hardcode values that might break projects that depend on kuma (e.g. "kumahq" as a image registry) --
- [X] The PR will work for both Linux and Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [X] Unit Tests --
- [X] E2E Tests --
- [X] Manual Universal Tests --
- [X] Manual Kubernetes Tests --
- [X] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [X] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [X] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
