### PR TITLE
test(e2e): rewrite old CNI race condition test

### DIFF
--- a/test/framework/dataplane.go
+++ b/test/framework/dataplane.go
@@ -16,3 +16,11 @@ func IsDataplaneOnline(cluster Cluster, mesh, name string) (bool, bool, error) {
 	}
 	return false, false, nil
 }
+
+func DataplaneReceivedConfig(cluster Cluster, mesh, name string) (bool, error) {
+	out, err := cluster.GetKumactlOptions().RunKumactlAndGetOutput("inspect", "dataplanes", "--mesh", mesh, "-o", "yaml", name)
+	if err != nil {
+		return false, err
+	}
+	return strings.Contains(out, `responsesAcknowledged`), nil
+}


### PR DESCRIPTION
I noticed that we have a flake https://app.circleci.com/pipelines/github/kumahq/kuma/19011/workflows/5523f07e-d7d0-47a1-961e-0a5ecd716a6d/jobs/305878

It's because when we spin up K3D node and load images. It may take more than the 40s (thanks to retries) which the initial CNI delay was set to.
I changed this to 40000s (it does not matter when it comes up).

Additionally, I rewrote this test, because `Install(TestServer)` has retries. We were waiting 6 minutes (!) for test server to fail. I changed the logic so we check that DPP received the config, but test-server container is consistently not ready. This way we do this in ~15s and we save 6 mins.

On top of that, I noticed that we don't really need to spin up a new node to check this behavior, so I removed the logic of creating a new node. If you feel strongly that we should keep it, I can revert this part.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [X] Link to docs PR or issue --
- [X] Link to UI issue or PR --
- [X] Is the [issue worked on linked][1]? --
- [X] The PR does not hardcode values that might break projects that depend on kuma (e.g. "kumahq" as a image registry) --
- [X] The PR will work for both Linux and Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [X] Unit Tests --
- [X] E2E Tests --
- [X] Manual Universal Tests --
- [X] Manual Kubernetes Tests --
- [X] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [X] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [X] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
