### PR TITLE
chore(deps): run arm cache only when label or not PR

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -151,7 +151,7 @@ jobs:
         command: |
           if [[ ! $(./tools/ci/has_label.sh ci/run-full-matrix) == "true" ]]; then
             if [[ "<< pipeline.git.branch >>" != "master" && "<< pipeline.git.branch >>" != "release-"* ]]; then
-              if [[ "<< parameters.executor >>" == "vm-amd64" ]]; then
+              if [[ "<< parameters.executor >>" == "vm-arm64" ]]; then
                 echo "Not creating cache for arm64 on branch"
                 circleci-agent step halt
                 exit 0

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -146,6 +146,18 @@ jobs:
         type: string
         default: golang
     steps:
+    - run:
+        name: "Check if skip"
+        command: |
+          if [[ ! $(./tools/ci/has_label.sh ci/run-full-matrix) == "true" ]]; then
+            if [[ "<< pipeline.git.branch >>" != "master" && "<< pipeline.git.branch >>" != "release-"* ]]; then
+              if [[ "<< parameters.executor >>" == "vm-amd64" ]]; then
+                echo "Not creating cache for arm64 on branch"
+                circleci-agent step halt
+                exit 0
+              fi
+            fi
+          fi
     - when:
         condition: {equal: [vm-amd64, << parameters.executor >>]}
         steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -149,9 +149,9 @@ jobs:
     - run:
         name: "Check if skip"
         command: |
-          if [[ ! $(./tools/ci/has_label.sh ci/run-full-matrix) == "true" ]]; then
+          if [[ "<< parameters.executor >>" == *"arm64" ]]; then
             if [[ "<< pipeline.git.branch >>" != "master" && "<< pipeline.git.branch >>" != "release-"* ]]; then
-              if [[ "<< parameters.executor >>" == "vm-arm64" ]]; then
+              if [[ ! $(./tools/ci/has_label.sh ci/run-full-matrix) == "true" ]]; then
                 echo "Not creating cache for arm64 on branch"
                 circleci-agent step halt
                 exit 0


### PR DESCRIPTION

- [X] Link to docs PR or issue --
- [X] Link to UI issue or PR --
- [X] Is the [issue worked on linked][1]? --
- [X] The PR does not hardcode values that might break projects that depend on kuma (e.g. "kumahq" as a image registry) --
- [X] The PR will work for both Linux and Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [X] Unit Tests --
- [X] E2E Tests --
- [X] Manual Universal Tests --
- [X] Manual Kubernetes Tests --
- [X] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [X] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [X] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
