### PR TITLE
feat(build): add regex disable for packages in security update

### DIFF
--- a/.github/workflows/update-insecure-dependencies.yaml
+++ b/.github/workflows/update-insecure-dependencies.yaml
@@ -4,6 +4,8 @@ on:
   workflow_dispatch: { }
   schedule:
     - cron: 0 8 * * *
+env:
+  IGNORE_PACKAGES: "github.com/aws/aws-sdk-go"
 jobs:
   update-insecure-dependencies:
     strategy:
@@ -43,7 +45,7 @@ jobs:
       - name: "Update dependencies"
         id: update
         run: |
-          osv-scanner --lockfile=go.mod --json | jq '.results[].packages[].package.name' | xargs -I {} go get -u {}
+          osv-scanner --lockfile=go.mod --json | jq '.results[].packages[].package.name' | grep -Ev ${{ env.IGNORE_PACKAGES }} | xargs -I {} go get -u {}
           go mod tidy
       - name: "Prepare commit body - after"
         id: prepare_commit_body_after
@@ -66,6 +68,8 @@ jobs:
 
             After update:
             ${{ env.SCAN_OUTPUT_AFTER }}
+            
+            If a package is showing up in the scan but the script is not trying to update it then it might be in env.IGNORE_PACKAGES regex
           delete-branch: true
           title: "chore(deps): security update"
           draft: false


### PR DESCRIPTION
aws-sdk is released daily and this bug https://osv.dev/vulnerability/GO-2022-0646 has no fix since Feb 2022. This might be a bug in osv or an actuall bug on aws-sdk. Let's disable it for now and if dependabot detects a bug on master we will update manually release branches.

Signed-off-by: slonka <slonka@users.noreply.github.com>

Action output here: https://github.com/kumahq/kuma/actions/runs/3966613586. No PRs were created because there were no changes.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [ ] Link to docs PR or issue --
- [ ] Link to UI issue or PR --
- [ ] Is the [issue worked on linked][1]? --
- [ ] The PR does not hardcode values that might break projects that depend on kuma (e.g. "kumahq" as a image registry) --
- [ ] The PR will work for both Linux and Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [ ] Unit Tests --
- [ ] E2E Tests --
- [ ] Manual Universal Tests --
- [ ] Manual Kubernetes Tests --
- [ ] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [ ] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [ ] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
