### PR TITLE
fix(kuma-cp): fix appending of pointer to slice in policies config

### DIFF
--- a/pkg/core/xds/merge.go
+++ b/pkg/core/xds/merge.go
@@ -189,6 +189,12 @@ func clearAppendSlices(val reflect.Value) {
 			if valField.Elem().Kind() == reflect.Struct {
 				clearAppendSlices(valField)
 			}
+			if valField.Elem().Kind() == reflect.Slice {
+				mergeByKey := strings.Contains(field.Tag.Get(policyMergeTag), mergeValuesByKey)
+				if strings.HasPrefix(field.Name, appendSlicesPrefix) || mergeByKey {
+					valField.Elem().Set(reflect.Zero(valField.Elem().Type()))
+				}
+			}
 		}
 	}
 }
@@ -217,6 +223,13 @@ func appendSlices(dst reflect.Value, src reflect.Value) {
 		case reflect.Pointer:
 			if dstField.Elem().Kind() == reflect.Struct {
 				appendSlices(dstField, srcField)
+			}
+			if dstField.Elem().Kind() == reflect.Slice {
+				mergeByKey := strings.Contains(field.Tag.Get(policyMergeTag), mergeValuesByKey)
+				if strings.HasPrefix(field.Name, appendSlicesPrefix) || mergeByKey {
+					s := reflect.AppendSlice(dstField.Elem(), srcField.Elem())
+					dstField.Elem().Set(s)
+				}
 			}
 		}
 	}

--- a/pkg/core/xds/merge_test.go
+++ b/pkg/core/xds/merge_test.go
@@ -14,11 +14,12 @@ var _ = Describe("MergeConfs", func() {
 		AppendInts []int
 	}
 	type policy struct {
-		FieldString   string `json:"fieldString,omitempty"`
-		Strings       []string
-		AppendStrings []string
-		Sub           subPolicy
-		SubPtr        *subPolicy `json:"subPtr,omitempty"`
+		FieldString            string `json:"fieldString,omitempty"`
+		Strings                []string
+		AppendStrings          []string
+		AppendPointerToStrings *[]string
+		Sub                    subPolicy
+		SubPtr                 *subPolicy `json:"subPtr,omitempty"`
 	}
 
 	type testCase struct {
@@ -44,9 +45,10 @@ var _ = Describe("MergeConfs", func() {
 		Entry("should replace slices by default but append slices that start with append", testCase{
 			policies: []policy{
 				{
-					FieldString:   "p1",
-					Strings:       []string{"p1"},
-					AppendStrings: []string{"p1"},
+					FieldString:            "p1",
+					Strings:                []string{"p1"},
+					AppendStrings:          []string{"p1"},
+					AppendPointerToStrings: &[]string{"p1"},
 					Sub: subPolicy{
 						Ints:       []int{1},
 						AppendInts: []int{1},
@@ -57,9 +59,10 @@ var _ = Describe("MergeConfs", func() {
 					},
 				},
 				{
-					FieldString:   "p2",
-					Strings:       []string{"p2"},
-					AppendStrings: []string{"p2"},
+					FieldString:            "p2",
+					Strings:                []string{"p2"},
+					AppendStrings:          []string{"p2"},
+					AppendPointerToStrings: &[]string{"p2"},
 					Sub: subPolicy{
 						Ints:       []int{2},
 						AppendInts: []int{2},
@@ -70,8 +73,9 @@ var _ = Describe("MergeConfs", func() {
 					},
 				},
 				{
-					Strings:       []string{"p3"},
-					AppendStrings: []string{"p3"},
+					Strings:                []string{"p3"},
+					AppendStrings:          []string{"p3"},
+					AppendPointerToStrings: &[]string{"p3"},
 					Sub: subPolicy{
 						Ints:       []int{3},
 						AppendInts: []int{3},
@@ -83,9 +87,10 @@ var _ = Describe("MergeConfs", func() {
 				},
 			},
 			expected: policy{
-				FieldString:   "p2",
-				Strings:       []string{"p3"},
-				AppendStrings: []string{"p1", "p2", "p3"},
+				FieldString:            "p2",
+				Strings:                []string{"p3"},
+				AppendStrings:          []string{"p1", "p2", "p3"},
+				AppendPointerToStrings: &[]string{"p1", "p2", "p3"},
 				Sub: subPolicy{
 					Ints:       []int{3},
 					AppendInts: []int{1, 2, 3},


### PR DESCRIPTION
Signed-off-by: Marcin Skalski <marcin.skalski@konghq.com>

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] Link to docs PR or issue --
- [x] Link to UI issue or PR --
- [x] Is the [issue worked on linked][1]? --
- [x] The PR does not hardcode values that might break projects that depend on kuma (e.g. "kumahq" as a image registry) --
- [x] The PR will work for both Linux and Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Unit Tests --
- [x] E2E Tests --
- [x] Manual Universal Tests --
- [x] Manual Kubernetes Tests --
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [x] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
