### PR TITLE
feat(policies): improve rules api

### DIFF
--- a/app/kuma-dp/pkg/dataplane/metrics/merge_test.go
+++ b/app/kuma-dp/pkg/dataplane/metrics/merge_test.go
@@ -11,8 +11,8 @@ import (
 	. "github.com/onsi/gomega"
 
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
-	"github.com/kumahq/kuma/pkg/plugins/runtime/gateway/route"
 	envoy_names "github.com/kumahq/kuma/pkg/xds/envoy/names"
+	envoy "github.com/kumahq/kuma/pkg/xds/envoy/tags"
 )
 
 func toLines(r io.Reader) []string {
@@ -92,17 +92,12 @@ var _ = Describe("Detect mergable clusters", func() {
 	})
 
 	It("should crack gateway cluster names", func() {
-		clusterName, err := route.DestinationClusterName(
-			&route.Destination{
-				Destination: map[string]string{
-					mesh_proto.ServiceTag: "foo-service",
-					mesh_proto.ZoneTag:    "foo-zone",
-				},
-			},
-			map[string]string{
-				"custom": "tag",
-			},
-		)
+		clusterName, err := envoy.Tags(map[string]string{
+			mesh_proto.ServiceTag: "foo-service",
+			mesh_proto.ZoneTag:    "foo-zone",
+		}).DestinationClusterName(map[string]string{
+			"custom": "tag",
+		})
 		Expect(err).To(Succeed())
 		Expect(clusterName).ToNot(BeEmpty())
 

--- a/app/kumactl/cmd/install/install_helpers_test.go
+++ b/app/kumactl/cmd/install/install_helpers_test.go
@@ -23,8 +23,8 @@ func ExpectMatchesGoldenFiles(actual []byte, goldenFilePath string) {
 	Expect(err).ToNot(HaveOccurred())
 	expectedManifests := data.SplitYAML(data.File{Data: expected})
 
-	Expect(len(actualManifests)).To(Equal(len(expectedManifests)), golden.RerunMsg)
+	Expect(len(actualManifests)).To(Equal(len(expectedManifests)), golden.RerunMsg(goldenFilePath))
 	for i := range expectedManifests {
-		Expect(actualManifests[i]).To(MatchYAML(expectedManifests[i]), golden.RerunMsg)
+		Expect(actualManifests[i]).To(MatchYAML(expectedManifests[i]), golden.RerunMsg(goldenFilePath))
 	}
 }

--- a/pkg/api-server/inspect_endpoints.go
+++ b/pkg/api-server/inspect_endpoints.go
@@ -574,7 +574,7 @@ func inspectRulesAttachment(cfg *kuma_cp.Config, builder xds_context.MeshContext
 			rest_errors.HandleError(response, err, "Could not get MatchedPolicies")
 			return
 		}
-		rulesAttachments := inspect.BuildRulesAttachments(matchedPolicies.Dynamic, proxy.Dataplane.Spec.Networking)
+		rulesAttachments := inspect.BuildRulesAttachments(matchedPolicies.Dynamic, proxy.Dataplane.Spec.Networking, meshContext.VIPDomains)
 		resp := api_server_types.RuleInspectResponse{}
 		for _, ruleAttachment := range rulesAttachments {
 			subset := map[string]string{}
@@ -597,7 +597,9 @@ func inspectRulesAttachment(cfg *kuma_cp.Config, builder xds_context.MeshContext
 			resp.Items = append(resp.Items, api_server_types.RuleInspectEntry{
 				Type:       ruleAttachment.Type,
 				Name:       ruleAttachment.Name,
+				Addresses:  ruleAttachment.Addresses,
 				Service:    ruleAttachment.Service,
+				Tags:       ruleAttachment.Tags,
 				PolicyType: string(ruleAttachment.PolicyType),
 				Subset:     subset,
 				Conf:       ruleAttachment.Rule.Conf,

--- a/pkg/api-server/testdata/inspect_changed_state_after.json
+++ b/pkg/api-server/testdata/inspect_changed_state_after.json
@@ -10,7 +10,7 @@
    "attachments": [
     {
      "type": "inbound",
-     "name": "192.168.0.1:80:81",
+     "name": "127.0.0.1:80:8080",
      "service": "redis"
     }
    ]

--- a/pkg/api-server/testdata/inspect_changed_state_before.json
+++ b/pkg/api-server/testdata/inspect_changed_state_before.json
@@ -10,7 +10,7 @@
    "attachments": [
     {
      "type": "inbound",
-     "name": "192.168.0.1:80:81",
+     "name": "127.0.0.1:80:8080",
      "service": "backend"
     }
    ]
@@ -24,7 +24,7 @@
    "attachments": [
     {
      "type": "inbound",
-     "name": "192.168.0.1:80:81",
+     "name": "127.0.0.1:80:8080",
      "service": "redis"
     }
    ]

--- a/pkg/api-server/testdata/inspect_circuit-breaker.json
+++ b/pkg/api-server/testdata/inspect_circuit-breaker.json
@@ -10,8 +10,8 @@
    "attachments": [
     {
      "type": "service",
-     "name": "gateway",
-     "service": "gateway"
+     "name": "elastic",
+     "service": "elastic"
     },
     {
      "type": "service",
@@ -29,8 +29,8 @@
    "attachments": [
     {
      "type": "service",
-     "name": "gateway",
-     "service": "gateway"
+     "name": "elastic",
+     "service": "elastic"
     }
    ]
   }

--- a/pkg/api-server/testdata/inspect_dataplane.json
+++ b/pkg/api-server/testdata/inspect_dataplane.json
@@ -18,7 +18,7 @@
   },
   {
    "type": "inbound",
-   "name": "192.168.0.1:80:81",
+   "name": "127.0.0.1:80:8080",
    "service": "backend",
    "matchedPolicies": {
     "FaultInjection": [
@@ -50,8 +50,8 @@
   },
   {
    "type": "outbound",
-   "name": "192.168.0.2:8080",
-   "service": "web",
+   "name": "127.0.0.1:10001",
+   "service": "redis",
    "matchedPolicies": {
     "Timeout": [
      {
@@ -66,8 +66,8 @@
   },
   {
    "type": "service",
-   "name": "gateway",
-   "service": "gateway",
+   "name": "elastic",
+   "service": "elastic",
    "matchedPolicies": {
     "HealthCheck": [
      {

--- a/pkg/api-server/testdata/inspect_dataplane_rules.golden.json
+++ b/pkg/api-server/testdata/inspect_dataplane_rules.golden.json
@@ -2,9 +2,35 @@
  "total": 3,
  "items": [
   {
-   "type": "destinationSubset",
-   "name": "127.0.0.1:10001",
+   "type": "SingleItem",
+   "policyType": "MeshTrace",
+   "subset": {},
+   "conf": {
+    "backends": [
+     {
+      "zipkin": {
+       "url": "http://jaeger-collector.mesh-observability:9411/api/v2/spans"
+      }
+     }
+    ]
+   },
+   "origins": [
+    {
+     "mesh": "default",
+     "name": "mtp-1"
+    }
+   ]
+  },
+  {
+   "type": "DestinationSubset",
+   "name": "backend",
+   "addresses": [
+    "127.0.0.1:10001"
+   ],
    "service": "backend",
+   "tags": {
+    "kuma.io/service": "backend"
+   },
    "policyType": "MeshAccessLog",
    "subset": {},
    "conf": {
@@ -24,9 +50,16 @@
    ]
   },
   {
-   "type": "clientSubset",
-   "name": "192.168.0.2:80",
+   "type": "ClientSubset",
+   "name": "web-e816eaf96a14245f",
+   "addresses": [
+    "192.168.0.2:80"
+   ],
    "service": "web",
+   "tags": {
+    "kuma.io/protocol": "http",
+    "kuma.io/service": "web"
+   },
    "policyType": "MeshTrafficPermission",
    "subset": {
     "kuma.io/service": "client",
@@ -34,28 +67,6 @@
    },
    "conf": {
     "action": "DENY"
-   },
-   "origins": [
-    {
-     "mesh": "default",
-     "name": "mtp-1"
-    }
-   ]
-  },
-  {
-   "type": "singleItem",
-   "name": "dataplane",
-   "service": "",
-   "policyType": "MeshTrace",
-   "subset": {},
-   "conf": {
-    "backends": [
-     {
-      "zipkin": {
-       "url": "http://jaeger-collector.mesh-observability:9411/api/v2/spans"
-      }
-     }
-    ]
    },
    "origins": [
     {

--- a/pkg/api-server/testdata/inspect_dataplane_rules_subset.golden.json
+++ b/pkg/api-server/testdata/inspect_dataplane_rules_subset.golden.json
@@ -1,0 +1,170 @@
+{
+ "total": 6,
+ "items": [
+  {
+   "type": "SingleItem",
+   "policyType": "MeshTrace",
+   "subset": {},
+   "conf": {
+    "backends": [
+     {
+      "zipkin": {
+       "url": "http://jaeger-collector.mesh-observability:9411/api/v2/spans"
+      }
+     }
+    ]
+   },
+   "origins": [
+    {
+     "mesh": "default",
+     "name": "mtp-1"
+    }
+   ]
+  },
+  {
+   "type": "DestinationSubset",
+   "name": "backend",
+   "addresses": [
+    "10.3.2.3:2300",
+    "240.0.0.0:80"
+   ],
+   "service": "backend",
+   "tags": {
+    "kuma.io/service": "backend"
+   },
+   "policyType": "MeshAccessLog",
+   "subset": {},
+   "conf": {
+    "backends": [
+     {
+      "file": {
+       "path": "/tmp/access.logs"
+      }
+     }
+    ]
+   },
+   "origins": [
+    {
+     "mesh": "default",
+     "name": "mal-1"
+    }
+   ]
+  },
+  {
+   "type": "DestinationSubset",
+   "name": "backend-618c322a4d7e5dd7",
+   "addresses": [
+    "240.0.0.1:2300"
+   ],
+   "service": "backend",
+   "tags": {
+    "kuma.io/service": "backend",
+    "version": "2"
+   },
+   "policyType": "MeshAccessLog",
+   "subset": {},
+   "conf": {
+    "backends": [
+     {
+      "file": {
+       "path": "/tmp/access.logs"
+      }
+     }
+    ]
+   },
+   "origins": [
+    {
+     "mesh": "default",
+     "name": "mal-1"
+    }
+   ]
+  },
+  {
+   "type": "DestinationSubset",
+   "name": "backend-c703a1b1c0b78a12",
+   "addresses": [
+    "240.0.0.2:2300"
+   ],
+   "service": "backend",
+   "tags": {
+    "kuma.io/service": "backend",
+    "version": "1"
+   },
+   "policyType": "MeshAccessLog",
+   "subset": {},
+   "conf": {
+    "backends": [
+     {
+      "file": {
+       "path": "/tmp/access.logs"
+      }
+     }
+    ]
+   },
+   "origins": [
+    {
+     "mesh": "default",
+     "name": "mal-1"
+    }
+   ]
+  },
+  {
+   "type": "ClientSubset",
+   "name": "web-e816eaf96a14245f",
+   "addresses": [
+    "127.0.0.1:80"
+   ],
+   "service": "web",
+   "tags": {
+    "kuma.io/protocol": "http",
+    "kuma.io/service": "web"
+   },
+   "policyType": "MeshTrafficPermission",
+   "subset": {
+    "kuma.io/service": "client",
+    "kuma.io/zone": "east",
+    "version": "2"
+   },
+   "conf": {
+    "action": "ALLOW"
+   },
+   "origins": [
+    {
+     "mesh": "default",
+     "name": "mtp-1"
+    },
+    {
+     "mesh": "default",
+     "name": "mtp-2"
+    }
+   ]
+  },
+  {
+   "type": "ClientSubset",
+   "name": "web-e816eaf96a14245f",
+   "addresses": [
+    "127.0.0.1:80"
+   ],
+   "service": "web",
+   "tags": {
+    "kuma.io/protocol": "http",
+    "kuma.io/service": "web"
+   },
+   "policyType": "MeshTrafficPermission",
+   "subset": {
+    "kuma.io/service": "client",
+    "kuma.io/zone": "east",
+    "version": "!2"
+   },
+   "conf": {
+    "action": "DENY"
+   },
+   "origins": [
+    {
+     "mesh": "default",
+     "name": "mtp-1"
+    }
+   ]
+  }
+ ]
+}

--- a/pkg/api-server/testdata/inspect_fault-injection.json
+++ b/pkg/api-server/testdata/inspect_fault-injection.json
@@ -10,12 +10,12 @@
    "attachments": [
     {
      "type": "inbound",
-     "name": "192.168.0.1:80:81",
+     "name": "127.0.0.1:80:8080",
      "service": "backend"
     },
     {
      "type": "inbound",
-     "name": "192.168.0.2:80:81",
+     "name": "127.0.0.1:81:8081",
      "service": "redis"
     }
    ]
@@ -24,13 +24,13 @@
    "kind": "SidecarDataplane",
    "dataplane": {
     "mesh": "mesh-1",
-    "name": "gateway-1"
+    "name": "elastic-1"
    },
    "attachments": [
     {
      "type": "inbound",
-     "name": "192.168.0.1:80:81",
-     "service": "gateway"
+     "name": "127.0.0.1:80:8080",
+     "service": "elastic"
     }
    ]
   }

--- a/pkg/api-server/testdata/inspect_gateway_dataplane.json
+++ b/pkg/api-server/testdata/inspect_gateway_dataplane.json
@@ -2,7 +2,7 @@
  "kind": "MeshGatewayDataplane",
  "gateway": {
   "mesh": "default",
-  "name": "gateway"
+  "name": "elastic"
  },
  "listeners": [
   {

--- a/pkg/api-server/testdata/inspect_health-check.json
+++ b/pkg/api-server/testdata/inspect_health-check.json
@@ -10,8 +10,8 @@
    "attachments": [
     {
      "type": "service",
-     "name": "gateway",
-     "service": "gateway"
+     "name": "elastic",
+     "service": "elastic"
     },
     {
      "type": "service",
@@ -29,8 +29,8 @@
    "attachments": [
     {
      "type": "service",
-     "name": "gateway",
-     "service": "gateway"
+     "name": "elastic",
+     "service": "elastic"
     }
    ]
   }

--- a/pkg/api-server/testdata/inspect_rate-limit.json
+++ b/pkg/api-server/testdata/inspect_rate-limit.json
@@ -5,17 +5,17 @@
    "kind": "SidecarDataplane",
    "dataplane": {
     "mesh": "mesh-1",
-    "name": "gateway-1"
+    "name": "elastic-1"
    },
    "attachments": [
     {
      "type": "inbound",
-     "name": "192.168.0.1:80:81",
-     "service": "gateway"
+     "name": "127.0.0.1:80:8080",
+     "service": "elastic"
     },
     {
      "type": "outbound",
-     "name": "192.168.0.4:8080",
+     "name": "127.0.0.1:10003",
      "service": "es"
     }
    ]

--- a/pkg/api-server/testdata/inspect_retry.json
+++ b/pkg/api-server/testdata/inspect_retry.json
@@ -42,8 +42,8 @@
    "attachments": [
     {
      "type": "service",
-     "name": "gateway",
-     "service": "gateway"
+     "name": "elastic",
+     "service": "elastic"
     },
     {
      "type": "service",
@@ -61,8 +61,8 @@
    "attachments": [
     {
      "type": "service",
-     "name": "gateway",
-     "service": "gateway"
+     "name": "elastic",
+     "service": "elastic"
     }
    ]
   }

--- a/pkg/api-server/testdata/inspect_timeout.json
+++ b/pkg/api-server/testdata/inspect_timeout.json
@@ -10,13 +10,13 @@
    "attachments": [
     {
      "type": "outbound",
-     "name": "192.168.0.2:8080",
+     "name": "127.0.0.1:10001",
      "service": "redis"
     },
     {
      "type": "outbound",
-     "name": "192.168.0.3:8080",
-     "service": "gateway"
+     "name": "127.0.0.1:10002",
+     "service": "elastic"
     }
    ]
   },
@@ -29,8 +29,8 @@
    "attachments": [
     {
      "type": "outbound",
-     "name": "192.168.0.2:8080",
-     "service": "gateway"
+     "name": "127.0.0.1:10001",
+     "service": "elastic"
     }
    ]
   }

--- a/pkg/api-server/testdata/inspect_traffic-log.json
+++ b/pkg/api-server/testdata/inspect_traffic-log.json
@@ -10,8 +10,8 @@
    "attachments": [
     {
      "type": "service",
-     "name": "gateway",
-     "service": "gateway"
+     "name": "elastic",
+     "service": "elastic"
     },
     {
      "type": "service",
@@ -29,8 +29,8 @@
    "attachments": [
     {
      "type": "service",
-     "name": "gateway",
-     "service": "gateway"
+     "name": "elastic",
+     "service": "elastic"
     }
    ]
   }

--- a/pkg/api-server/testdata/inspect_traffic-permission.json
+++ b/pkg/api-server/testdata/inspect_traffic-permission.json
@@ -10,7 +10,7 @@
    "attachments": [
     {
      "type": "inbound",
-     "name": "192.168.0.1:80:81",
+     "name": "127.0.0.1:80:8080",
      "service": "backend"
     }
    ]
@@ -24,7 +24,7 @@
    "attachments": [
     {
      "type": "inbound",
-     "name": "192.168.0.1:80:81",
+     "name": "127.0.0.1:80:8080",
      "service": "redis"
     }
    ]
@@ -33,13 +33,13 @@
    "kind": "SidecarDataplane",
    "dataplane": {
     "mesh": "default",
-    "name": "gateway-1"
+    "name": "elastic-1"
    },
    "attachments": [
     {
      "type": "inbound",
-     "name": "192.168.0.1:80:81",
-     "service": "gateway"
+     "name": "127.0.0.1:80:8080",
+     "service": "elastic"
     }
    ]
   }

--- a/pkg/api-server/testdata/inspect_traffic-route.json
+++ b/pkg/api-server/testdata/inspect_traffic-route.json
@@ -10,12 +10,12 @@
    "attachments": [
     {
      "type": "outbound",
-     "name": "192.168.0.2:8080",
+     "name": "127.0.0.1:10001",
      "service": "redis"
     },
     {
      "type": "outbound",
-     "name": "192.168.0.4:8080",
+     "name": "127.0.0.1:10002",
      "service": "web"
     }
    ]
@@ -29,12 +29,12 @@
    "attachments": [
     {
      "type": "outbound",
-     "name": "192.168.0.2:8080",
-     "service": "gateway"
+     "name": "127.0.0.1:10001",
+     "service": "elastic"
     },
     {
      "type": "outbound",
-     "name": "192.168.0.4:8080",
+     "name": "127.0.0.1:10002",
      "service": "web"
     }
    ]

--- a/pkg/api-server/types/inspect.go
+++ b/pkg/api-server/types/inspect.go
@@ -221,8 +221,10 @@ type RuleInspectResponse struct {
 
 type RuleInspectEntry struct {
 	Type       string                  `json:"type"`
-	Name       string                  `json:"name"`
-	Service    string                  `json:"service"`
+	Name       string                  `json:"name,omitempty"`
+	Addresses  []string                `json:"addresses,omitempty"`
+	Service    string                  `json:"service,omitempty"`
+	Tags       map[string]string       `json:"tags,omitempty"`
 	PolicyType string                  `json:"policyType"`
 	Subset     map[string]string       `json:"subset"`
 	Conf       core_model.ResourceSpec `json:"conf"`

--- a/pkg/core/xds/inspect/rules.go
+++ b/pkg/core/xds/inspect/rules.go
@@ -7,33 +7,45 @@ import (
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	core_model "github.com/kumahq/kuma/pkg/core/resources/model"
 	core_xds "github.com/kumahq/kuma/pkg/core/xds"
+	"github.com/kumahq/kuma/pkg/xds/envoy/tags"
 )
 
-const ClientRuleAttachmentType = "clientSubset"
-const DestinationRuleAttachmentType = "destinationSubset"
-const SingleItemRuleAttachmentType = "singleItem"
+const ClientRuleAttachmentType = "ClientSubset"
+const DestinationRuleAttachmentType = "DestinationSubset"
+const SingleItemRuleAttachmentType = "SingleItem"
 
 type RuleAttachment struct {
 	Type       string
 	Name       string
+	Addresses  []string
 	Service    string
+	Tags       map[string]string
 	PolicyType core_model.ResourceType
 	Rule       core_xds.Rule
 }
 
-func BuildRulesAttachments(
-	matchedPoliciesByType map[core_model.ResourceType]core_xds.TypedMatchingPolicies,
-	networking *mesh_proto.Dataplane_Networking,
-) []RuleAttachment {
+func (r *RuleAttachment) AddAddress(address string) {
+	for _, a := range r.Addresses {
+		if a == address {
+			return
+		}
+	}
+	r.Addresses = append(r.Addresses, address)
+}
+
+func BuildRulesAttachments(matchedPoliciesByType map[core_model.ResourceType]core_xds.TypedMatchingPolicies, networking *mesh_proto.Dataplane_Networking, domains []core_xds.VIPDomains) []RuleAttachment {
+	domainsByAddress := map[string][]string{}
+	for _, d := range domains {
+		domainsByAddress[d.Address] = append(domainsByAddress[d.Address], d.Domains...)
+	}
 	var attachments []RuleAttachment
 
 	for typ, matched := range matchedPoliciesByType {
 		attachments = append(attachments, getInboundRuleAttachments(matched.FromRules.Rules, networking, typ)...)
-		attachments = append(attachments, getOutboundRuleAttachments(matched.ToRules.Rules, networking, typ)...)
+		attachments = append(attachments, getOutboundRuleAttachments(matched.ToRules.Rules, networking, typ, domainsByAddress)...)
 		if len(matched.SingleItemRules.Rules) > 0 {
 			attachment := RuleAttachment{
 				Type:       SingleItemRuleAttachmentType,
-				Name:       "dataplane",
 				PolicyType: typ,
 				Rule:       *matched.SingleItemRules.Rules[0],
 			}
@@ -54,22 +66,28 @@ func getInboundRuleAttachments(
 	networking *mesh_proto.Dataplane_Networking,
 	typ core_model.ResourceType,
 ) []RuleAttachment {
-	inboundServices := map[core_xds.InboundListener]string{}
+	inboundServices := map[core_xds.InboundListener]tags.Tags{}
 	for _, inbound := range networking.GetInbound() {
 		iface := networking.ToInboundInterface(inbound)
 		inboundServices[core_xds.InboundListener{
 			Address: iface.DataplaneIP,
 			Port:    iface.DataplanePort,
-		}] = inbound.GetService()
+		}] = inbound.GetTags()
 	}
 
 	var attachments []RuleAttachment
 	for inbound, rules := range fromRules {
 		for _, rule := range rules {
+			name, err := inboundServices[inbound].DestinationClusterName(nil)
+			if err != nil {
+				panic(err)
+			}
 			attachment := RuleAttachment{
 				Type:       ClientRuleAttachmentType,
-				Name:       inbound.String(),
-				Service:    inboundServices[inbound],
+				Name:       name,
+				Tags:       inboundServices[inbound],
+				Addresses:  []string{inbound.String()},
+				Service:    inboundServices[inbound][mesh_proto.ServiceTag],
 				PolicyType: typ,
 				Rule:       *rule,
 			}
@@ -79,27 +97,41 @@ func getInboundRuleAttachments(
 	return attachments
 }
 
-func getOutboundRuleAttachments(
-	rules core_xds.Rules,
-	networking *mesh_proto.Dataplane_Networking,
-	typ core_model.ResourceType,
-) []RuleAttachment {
+func getOutboundRuleAttachments(rules core_xds.Rules, networking *mesh_proto.Dataplane_Networking, typ core_model.ResourceType, domainsByAddress map[string][]string) []RuleAttachment {
 	var attachments []RuleAttachment
+	byUniqueClusterName := map[string]*RuleAttachment{}
 	for _, outbound := range networking.Outbound {
-		subset := core_xds.SubsetFromTags(outbound.GetTagsIncludingLegacy())
-		computedRule := rules.Compute(subset)
-		if computedRule == nil {
-			continue
+		outboundTags := outbound.GetTagsIncludingLegacy()
+		name, err := tags.Tags(outboundTags).DestinationClusterName(nil)
+		if err != nil {
+			// Error is impossible here (there's always a service on Outbound)
+			panic(err)
+		}
+		attachment := byUniqueClusterName[name]
+		if attachment == nil {
+			subset := core_xds.SubsetFromTags(outboundTags)
+			computedRule := rules.Compute(subset)
+			if computedRule == nil {
+				continue
+			}
+			attachments = append(attachments, RuleAttachment{
+				Name:       name,
+				Type:       DestinationRuleAttachmentType,
+				Service:    outboundTags[mesh_proto.ServiceTag],
+				Tags:       outboundTags,
+				PolicyType: typ,
+				Rule:       *computedRule,
+			})
+			attachment = &attachments[len(attachments)-1]
+			byUniqueClusterName[name] = attachment
 		}
 		oface := networking.ToOutboundInterface(outbound)
-		attachment := RuleAttachment{
-			Type:       DestinationRuleAttachmentType,
-			Name:       fmt.Sprintf("%s:%d", oface.DataplaneIP, oface.DataplanePort),
-			Service:    outbound.GetTagsIncludingLegacy()[mesh_proto.ServiceTag],
-			PolicyType: typ,
-			Rule:       *computedRule,
+		// reverse lookup address
+		for _, d := range domainsByAddress[oface.DataplaneIP] {
+			attachment.AddAddress(fmt.Sprintf("%s:%d", d, oface.DataplanePort))
 		}
-		attachments = append(attachments, attachment)
+		// Add the ip anyway
+		attachment.AddAddress(fmt.Sprintf("%s:%d", oface.DataplaneIP, oface.DataplanePort))
 	}
 	return attachments
 }

--- a/pkg/plugins/policies/meshtimeout/plugin/v1alpha1/plugin.go
+++ b/pkg/plugins/policies/meshtimeout/plugin/v1alpha1/plugin.go
@@ -16,7 +16,6 @@ import (
 	plugin_xds "github.com/kumahq/kuma/pkg/plugins/policies/meshtimeout/plugin/xds"
 	policies_xds "github.com/kumahq/kuma/pkg/plugins/policies/xds"
 	gateway_plugin "github.com/kumahq/kuma/pkg/plugins/runtime/gateway"
-	gateway_route "github.com/kumahq/kuma/pkg/plugins/runtime/gateway/route"
 	xds_context "github.com/kumahq/kuma/pkg/xds/context"
 	envoy_names "github.com/kumahq/kuma/pkg/xds/envoy/names"
 )
@@ -133,7 +132,7 @@ func applyToGateway(
 		for _, hostInfo := range listenerInfo.HostInfos {
 			destinations := gateway_plugin.RouteDestinationsMutable(hostInfo.Entries)
 			for _, dest := range destinations {
-				clusterName, err := gateway_route.DestinationClusterName(dest, hostInfo.Host.Tags)
+				clusterName, err := dest.Destination.DestinationClusterName(hostInfo.Host.Tags)
 				if err != nil {
 					continue
 				}

--- a/pkg/plugins/runtime/gateway/cluster_generator.go
+++ b/pkg/plugins/runtime/gateway/cluster_generator.go
@@ -222,10 +222,7 @@ func buildClusterResource(
 
 	cluster := msg.(*envoy_cluster_v3.Cluster)
 
-	name, err := route.DestinationClusterName(
-		dest,
-		identifyingTags,
-	)
+	name, err := dest.Destination.DestinationClusterName(identifyingTags)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/plugins/runtime/gateway/route/builders.go
+++ b/pkg/plugins/runtime/gateway/route/builders.go
@@ -1,14 +1,8 @@
 package route
 
 import (
-	"crypto/sha256"
-	"fmt"
-	"sort"
-
 	envoy_config_route "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
-	"github.com/pkg/errors"
 
-	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	"github.com/kumahq/kuma/pkg/xds/envoy"
 )
 
@@ -57,49 +51,4 @@ func (f RouteMustConfigureFunc) Configure(r *envoy_config_route.Route) error {
 	}
 
 	return nil
-}
-
-// DestinationClusterName generates a unique cluster name for the
-// destination. The destination must contain at least a service tag.
-func DestinationClusterName(
-	d *Destination,
-	identifyingTags map[string]string,
-) (string, error) {
-	serviceName := d.Destination[mesh_proto.ServiceTag]
-	if serviceName == "" {
-		return "", errors.Errorf("missing %s tag", mesh_proto.ServiceTag)
-	}
-
-	// If cluster is splitting the target service with selector tags,
-	// hash the tag names to generate a unique cluster name.
-	var keys []string
-	for k := range d.Destination {
-		keys = append(keys, k)
-	}
-
-	sort.Strings(keys)
-
-	h := sha256.New()
-
-	// destination tags from route
-	for _, k := range keys {
-		h.Write([]byte(k))
-		h.Write([]byte(d.Destination[k]))
-	}
-
-	keys = []string{}
-	for k := range identifyingTags {
-		keys = append(keys, k)
-	}
-	sort.Strings(keys)
-
-	// identifyingTags contains listener, meshGateway and Dataplane tags
-	for _, k := range keys {
-		h.Write([]byte(k))
-		h.Write([]byte(identifyingTags[k]))
-	}
-
-	// The qualifier is 16 hex digits. Unscientifically balancing the length
-	// of the hex against the likelihood of collisions.
-	return fmt.Sprintf("%s-%x", serviceName, h.Sum(nil)[:8]), nil
 }

--- a/pkg/test/golden/update_files.go
+++ b/pkg/test/golden/update_files.go
@@ -1,7 +1,9 @@
 package golden
 
 import (
+	"fmt"
 	"os"
+	"path/filepath"
 )
 
 func UpdateGoldenFiles() bool {
@@ -9,4 +11,10 @@ func UpdateGoldenFiles() bool {
 	return found && value == "true"
 }
 
-const RerunMsg = "Rerun the test with UPDATE_GOLDEN_FILES=true flag. Example: make test UPDATE_GOLDEN_FILES=true"
+func RerunMsg(path string) string {
+	absPath, err := filepath.Abs(path)
+	if err != nil {
+		absPath = path + " Failed to retrieve cwd"
+	}
+	return fmt.Sprintf("Rerun the test with UPDATE_GOLDEN_FILES=true flag to update file: %s. Example: make test UPDATE_GOLDEN_FILES=true", absPath)
+}

--- a/pkg/test/matchers/golden.go
+++ b/pkg/test/matchers/golden.go
@@ -78,7 +78,7 @@ func (g *GoldenMatcher) FailureMessage(actual interface{}) string {
 	if err != nil {
 		return err.Error()
 	}
-	return golden.RerunMsg + "\n\n" + g.Matcher.FailureMessage(actualContent)
+	return golden.RerunMsg(g.GoldenFilePath) + "\n\n" + g.Matcher.FailureMessage(actualContent)
 }
 
 func (g *GoldenMatcher) NegatedFailureMessage(actual interface{}) string {

--- a/pkg/test/resources/builders/dataplane_builder.go
+++ b/pkg/test/resources/builders/dataplane_builder.go
@@ -27,7 +27,9 @@ func Dataplane() *DataplaneBuilder {
 				Name: "dp-1",
 			},
 			Spec: &mesh_proto.Dataplane{
-				Networking: &mesh_proto.Dataplane_Networking{},
+				Networking: &mesh_proto.Dataplane_Networking{
+					Address: "127.0.0.1",
+				},
 			},
 		},
 	}
@@ -81,6 +83,14 @@ func (d *DataplaneBuilder) WithServices(services ...string) *DataplaneBuilder {
 	return d
 }
 
+func (d *DataplaneBuilder) WithHttpServices(services ...string) *DataplaneBuilder {
+	d.WithoutInbounds()
+	for _, service := range services {
+		d.AddInboundHttpOfService(service)
+	}
+	return d
+}
+
 func (d *DataplaneBuilder) WithoutInbounds() *DataplaneBuilder {
 	d.res.Spec.Networking.Inbound = nil
 	return d
@@ -96,6 +106,10 @@ func (d *DataplaneBuilder) WithInboundOfTagsMap(tags map[string]string) *Datapla
 
 func (d *DataplaneBuilder) AddInboundOfService(service string) *DataplaneBuilder {
 	return d.AddInboundOfTags(mesh_proto.ServiceTag, service)
+}
+
+func (d *DataplaneBuilder) AddInboundHttpOfService(service string) *DataplaneBuilder {
+	return d.AddInboundOfTags(mesh_proto.ServiceTag, service, mesh_proto.ProtocolTag, "http")
 }
 
 func (d *DataplaneBuilder) AddInboundOfTags(tags ...string) *DataplaneBuilder {
@@ -172,6 +186,13 @@ func (d *DataplaneBuilder) WithBuiltInGateway(name string) *DataplaneBuilder {
 			mesh_proto.ServiceTag: name,
 		},
 		Type: mesh_proto.Dataplane_Networking_Gateway_BUILTIN,
+	}
+	return d
+}
+
+func (d *DataplaneBuilder) WithAdminPort(i int) *DataplaneBuilder {
+	d.res.Spec.Networking.Admin = &mesh_proto.EnvoyAdmin{
+		Port: uint32(i),
 	}
 	return d
 }

--- a/pkg/test/resources/builders/zoneegress_builder.go
+++ b/pkg/test/resources/builders/zoneegress_builder.go
@@ -1,0 +1,83 @@
+package builders
+
+import (
+	"context"
+
+	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
+	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
+	core_model "github.com/kumahq/kuma/pkg/core/resources/model"
+	"github.com/kumahq/kuma/pkg/core/resources/store"
+	test_model "github.com/kumahq/kuma/pkg/test/resources/model"
+)
+
+type ZoneEgressBuilder struct {
+	res *core_mesh.ZoneEgressResource
+}
+
+func ZoneEgress() *ZoneEgressBuilder {
+	return &ZoneEgressBuilder{
+		res: &core_mesh.ZoneEgressResource{
+			Meta: &test_model.ResourceMeta{
+				Mesh: core_model.NoMesh,
+				Name: "zoneegress-1",
+			},
+			Spec: &mesh_proto.ZoneEgress{
+				Networking: &mesh_proto.ZoneEgress_Networking{
+					Address: "127.0.0.1",
+				},
+			},
+		},
+	}
+}
+
+func (b *ZoneEgressBuilder) Build() *core_mesh.ZoneEgressResource {
+	if err := b.res.Validate(); err != nil {
+		panic(err)
+	}
+	return b.res
+}
+
+func (b *ZoneEgressBuilder) Create(s store.ResourceStore) error {
+	return s.Create(context.Background(), b.Build(), store.CreateBy(b.Key()))
+}
+
+func (b *ZoneEgressBuilder) Key() core_model.ResourceKey {
+	return core_model.MetaToResourceKey(b.res.GetMeta())
+}
+
+func (b *ZoneEgressBuilder) With(fn func(*core_mesh.ZoneEgressResource)) *ZoneEgressBuilder {
+	fn(b.res)
+	return b
+}
+
+func (b *ZoneEgressBuilder) WithName(name string) *ZoneEgressBuilder {
+	b.res.Meta.(*test_model.ResourceMeta).Name = name
+	return b
+}
+
+func (b *ZoneEgressBuilder) WithVersion(version string) *ZoneEgressBuilder {
+	b.res.Meta.(*test_model.ResourceMeta).Version = version
+	return b
+}
+
+func (b *ZoneEgressBuilder) WithAddress(address string) *ZoneEgressBuilder {
+	b.res.Spec.Networking.Address = address
+	return b
+}
+
+func (b *ZoneEgressBuilder) WithZone(zone string) *ZoneEgressBuilder {
+	b.res.Spec.Zone = zone
+	return b
+}
+
+func (b *ZoneEgressBuilder) WithAdminPort(i int) *ZoneEgressBuilder {
+	b.res.Spec.Networking.Admin = &mesh_proto.EnvoyAdmin{
+		Port: uint32(i),
+	}
+	return b
+}
+
+func (b *ZoneEgressBuilder) WithPort(port uint32) *ZoneEgressBuilder {
+	b.res.Spec.Networking.Port = port
+	return b
+}

--- a/pkg/test/resources/builders/zoneingress_builder.go
+++ b/pkg/test/resources/builders/zoneingress_builder.go
@@ -1,0 +1,93 @@
+package builders
+
+import (
+	"context"
+
+	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
+	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
+	core_model "github.com/kumahq/kuma/pkg/core/resources/model"
+	"github.com/kumahq/kuma/pkg/core/resources/store"
+	test_model "github.com/kumahq/kuma/pkg/test/resources/model"
+)
+
+type ZoneIngressBuilder struct {
+	res *core_mesh.ZoneIngressResource
+}
+
+func ZoneIngress() *ZoneIngressBuilder {
+	return &ZoneIngressBuilder{
+		res: &core_mesh.ZoneIngressResource{
+			Meta: &test_model.ResourceMeta{
+				Mesh: core_model.NoMesh,
+				Name: "zoneingress-1",
+			},
+			Spec: &mesh_proto.ZoneIngress{
+				Networking: &mesh_proto.ZoneIngress_Networking{
+					Address: "127.0.0.1",
+				},
+			},
+		},
+	}
+}
+
+func (b *ZoneIngressBuilder) Build() *core_mesh.ZoneIngressResource {
+	if err := b.res.Validate(); err != nil {
+		panic(err)
+	}
+	return b.res
+}
+
+func (b *ZoneIngressBuilder) Create(s store.ResourceStore) error {
+	return s.Create(context.Background(), b.Build(), store.CreateBy(b.Key()))
+}
+
+func (b *ZoneIngressBuilder) Key() core_model.ResourceKey {
+	return core_model.MetaToResourceKey(b.res.GetMeta())
+}
+
+func (b *ZoneIngressBuilder) With(fn func(*core_mesh.ZoneIngressResource)) *ZoneIngressBuilder {
+	fn(b.res)
+	return b
+}
+
+func (b *ZoneIngressBuilder) WithName(name string) *ZoneIngressBuilder {
+	b.res.Meta.(*test_model.ResourceMeta).Name = name
+	return b
+}
+
+func (b *ZoneIngressBuilder) WithVersion(version string) *ZoneIngressBuilder {
+	b.res.Meta.(*test_model.ResourceMeta).Version = version
+	return b
+}
+
+func (b *ZoneIngressBuilder) WithAddress(address string) *ZoneIngressBuilder {
+	b.res.Spec.Networking.Address = address
+	return b
+}
+
+func (b *ZoneIngressBuilder) WithZone(zone string) *ZoneIngressBuilder {
+	b.res.Spec.Zone = zone
+	return b
+}
+
+func (b *ZoneIngressBuilder) WithAdminPort(i int) *ZoneIngressBuilder {
+	b.res.Spec.Networking.Admin = &mesh_proto.EnvoyAdmin{
+		Port: uint32(i),
+	}
+	return b
+}
+
+func (b *ZoneIngressBuilder) WithAdvertisedAddress(addr string) *ZoneIngressBuilder {
+	b.res.Spec.Networking.AdvertisedAddress = addr
+	return b
+}
+
+func (b *ZoneIngressBuilder) WithPort(port uint32) *ZoneIngressBuilder {
+	b.res.Spec.Networking.Port = port
+	return b
+}
+
+func (b *ZoneIngressBuilder) WithAdvertisedPort(port uint32) *ZoneIngressBuilder {
+	b.res.Spec.Networking.AdvertisedPort = port
+	return b
+}

--- a/pkg/xds/envoy/tags/cluster_name_test.go
+++ b/pkg/xds/envoy/tags/cluster_name_test.go
@@ -1,44 +1,45 @@
-package gateway_test
+package tags_test
 
 import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"github.com/kumahq/kuma/pkg/plugins/runtime/gateway/route"
+	"github.com/kumahq/kuma/pkg/xds/envoy/tags"
 )
 
 var _ = Describe("Cluster name", func() {
-	NameOf := func(tags ...string) string {
+	NameOf := func(kv ...string) string {
 
 		// Tags have to come in pairs.
-		Expect(len(tags) % 2).To(BeZero())
+		Expect(len(kv) % 2).To(BeZero())
 
-		d := route.Destination{
-			Destination: map[string]string{},
+		t := tags.Tags(map[string]string{})
+		for i := 0; i < len(kv); i += 2 {
+			t[kv[i]] = kv[i+1]
 		}
 
-		for i := 0; i < len(tags); i += 2 {
-			d.Destination[tags[i]] = tags[i+1]
-		}
-
-		name, err := route.DestinationClusterName(&d, map[string]string{})
+		name, err := t.DestinationClusterName(nil)
 		Expect(err).To(Succeed())
 
 		return name
 	}
 
 	It("should require the service tag", func() {
-		_, err := route.DestinationClusterName(
-			&route.Destination{
-				Destination: map[string]string{
-					"somemthing":   "else",
-					"kuma.io/zone": "one",
-				},
-			},
-			map[string]string{},
-		)
+		_, err := tags.Tags(map[string]string{
+			"somemthing":   "else",
+			"kuma.io/zone": "one",
+		}).DestinationClusterName(nil)
 
 		Expect(err).To(Not(Succeed()))
+	})
+
+	It("with only service tag don't do a hash", func() {
+		res, err := tags.Tags(map[string]string{
+			"kuma.io/service": "one",
+		}).DestinationClusterName(nil)
+
+		Expect(err).To(Succeed())
+		Expect(res).To(Equal("one"))
 	})
 
 	It("should start with the service name", func() {
@@ -81,30 +82,20 @@ var _ = Describe("Cluster name", func() {
 	})
 
 	It("should generate different names for different tags", func() {
-		n1, err := route.DestinationClusterName(
-			&route.Destination{
-				Destination: map[string]string{
-					"kuma.io/service": "one",
-				},
-			},
-			map[string]string{
-				"tag1": "value1",
-				"tag2": "value2",
-			},
-		)
+		n1, err := tags.Tags(map[string]string{
+			"kuma.io/service": "one",
+		}).DestinationClusterName(map[string]string{
+			"tag1": "value1",
+			"tag2": "value2",
+		})
 		Expect(err).To(Succeed())
 
-		n2, err := route.DestinationClusterName(
-			&route.Destination{
-				Destination: map[string]string{
-					"kuma.io/service": "one",
-				},
-			},
-			map[string]string{
-				"tag1": "value3",
-				"abc":  "value2",
-			},
-		)
+		n2, err := tags.Tags(map[string]string{
+			"kuma.io/service": "one",
+		}).DestinationClusterName(map[string]string{
+			"tag1": "value3",
+			"abc":  "value2",
+		})
 		Expect(err).To(Succeed())
 
 		Expect(n1).ToNot(Equal(n2))

--- a/pkg/xds/envoy/tags/match.go
+++ b/pkg/xds/envoy/tags/match.go
@@ -1,6 +1,7 @@
 package tags
 
 import (
+	"crypto/sha256"
 	"errors"
 	"fmt"
 	"sort"
@@ -13,6 +14,54 @@ import (
 const TagsHeaderName = "x-kuma-tags"
 
 type Tags map[string]string
+
+// DestinationClusterName generates a unique cluster name for the
+// destination. identifyingTags are useful for adding extra metadata outside of just tags. Tags must at least contain `kuma.io/service`
+func (t Tags) DestinationClusterName(
+	identifyingTags map[string]string,
+) (string, error) {
+	serviceName := t[mesh_proto.ServiceTag]
+	if serviceName == "" {
+		return "", fmt.Errorf("missing %s tag", mesh_proto.ServiceTag)
+	}
+	// If there's no tags other than serviceName just return the serviceName
+	if len(identifyingTags) == 0 && len(t) == 1 {
+		return serviceName, nil
+	}
+
+	// If cluster is splitting the target service with selector tags,
+	// hash the tag names to generate a unique cluster name.
+	var keys []string
+	for k := range t {
+		keys = append(keys, k)
+	}
+
+	sort.Strings(keys)
+
+	h := sha256.New()
+
+	// destination tags from route
+	for _, k := range keys {
+		h.Write([]byte(k))
+		h.Write([]byte(t[k]))
+	}
+
+	keys = []string{}
+	for k := range identifyingTags {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	// identifyingTags contains listener, meshGateway and Dataplane tags
+	for _, k := range keys {
+		h.Write([]byte(k))
+		h.Write([]byte(identifyingTags[k]))
+	}
+
+	// The qualifier is 16 hex digits. Unscientifically balancing the length
+	// of the hex against the likelihood of collisions.
+	return fmt.Sprintf("%s-%x", serviceName, h.Sum(nil)[:8]), nil
+}
 
 func (t Tags) WithoutTags(tags ...string) Tags {
 	tagSet := map[string]bool{}


### PR DESCRIPTION
- Add VIPs and hostnames to an `addresses` field
- Group matches by clusterName to avoid repetition when they are the same
- Add tags to each entry to be able to understand more precisely which outbound this is for
- Improve output of golden match failure to have the filename
- Move DestinationCluster to xds/envoy/tags

Signed-off-by: Charly Molter <charly.molter@konghq.com>

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] Link to docs PR or issue --
- [x] Link to UI issue or PR --
- [x] Is the [issue worked on linked][1]? --
- [x] The PR does not hardcode values that might break projects that depend on kuma (e.g. "kumahq" as a image registry) --
- [x] The PR will work for both Linux and Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Unit Tests --
- [x] E2E Tests --
- [x] Manual Universal Tests --
- [x] Manual Kubernetes Tests --
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [x] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
