### PR TITLE
chore: remove dependabot branch updates since they do not work

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,54 +6,7 @@ updates:
       interval: "weekly"
     labels:
       - "dependencies"
-  - package-ecosystem: "gomod"
-    # Setting open-pull-requests-limit to 0 means that dependabot will not
-    # update regular dependencies on this target branch, but still provide
-    # security updates for our gomod dependencies
-    open-pull-requests-limit: 0
-    target-branch: "release-1.5"
-    directory: "/"
-    schedule:
-      interval: "daily" # it's UTC, so I just want to check if it properly triggers today, will change this when checked
-      time: "13:05"
-    labels:
-      - "dependencies/security"
-  - package-ecosystem: "gomod"
-    open-pull-requests-limit: 0
-    target-branch: "release-1.6"
-    directory: "/"
-    schedule:
-      interval: "daily"
-      time: "13:05"
-    labels:
-      - "dependencies/security"
-  - package-ecosystem: "gomod"
-    open-pull-requests-limit: 0
-    target-branch: "release-1.7"
-    directory: "/"
-    schedule:
-      interval: "daily"
-      time: "13:05"
-    labels:
-      - "dependencies/security"
-  - package-ecosystem: "gomod"
-    open-pull-requests-limit: 0
-    target-branch: "release-1.8"
-    directory: "/"
-    schedule:
-      interval: "daily"
-      time: "13:05"
-    labels:
-      - "dependencies/security"
-  - package-ecosystem: "gomod"
-    open-pull-requests-limit: 0
-    target-branch: "release-2.0" # current release
-    directory: "/"
-    schedule:
-      interval: "daily"
-      time: "13:05"
-    labels:
-      - "dependencies/security"
+      
   - package-ecosystem: "docker"
     directory: "/tools/releases/dockerfiles"
     schedule:


### PR DESCRIPTION
Signed-off-by: slonka <slonka@users.noreply.github.com>

remove dependabot branch updates since they do not work

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [ ] Link to docs PR or issue --
- [ ] Link to UI issue or PR --
- [ ] Is the [issue worked on linked][1]? --
- [ ] The PR does not hardcode values that might break projects that depend on kuma (e.g. "kumahq" as a image registry) --
- [ ] The PR will work for both Linux and Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [ ] Unit Tests --
- [ ] E2E Tests --
- [ ] Manual Universal Tests --
- [ ] Manual Kubernetes Tests --
- [ ] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [ ] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [ ] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
