### PR TITLE
ci: fix load image retries

### DIFF
--- a/mk/k3d.mk
+++ b/mk/k3d.mk
@@ -113,7 +113,7 @@ k3d/stop/all:
 .PHONY: k3d/load/images
 k3d/load/images:
 	# https://github.com/k3d-io/k3d/issues/900 can cause failures that simple retry will fix
-	for i in {1..5}; do $(K3D_BIN) image import --mode=direct $(KUMA_IMAGES) --cluster=$(KIND_CLUSTER_NAME) --verbose && s=0 && break || s=$$? && echo "Image import failed. Retrying..."; done; (exit $$s)
+	for i in 1 2 3 4 5; do $(K3D_BIN) image import --mode=direct $(KUMA_IMAGES) --cluster=$(KIND_CLUSTER_NAME) --verbose && s=0 && break || s=$$? && echo "Image import failed. Retrying..."; done; (exit $$s)
 
 .PHONY: k3d/load
 k3d/load:


### PR DESCRIPTION
`{1..5}` results in retires not being executed.
Here is an example of this https://app.circleci.com/pipelines/github/kumahq/kuma/19097/workflows/717ee01b-9664-46b1-80cf-238538a74f31/jobs/308760 also confirmed on my VM.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [ ] Link to docs PR or issue --
- [ ] Link to UI issue or PR --
- [ ] Is the [issue worked on linked][1]? --
- [ ] The PR does not hardcode values that might break projects that depend on kuma (e.g. "kumahq" as a image registry) --
- [ ] The PR will work for both Linux and Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [ ] Unit Tests --
- [ ] E2E Tests --
- [ ] Manual Universal Tests --
- [ ] Manual Kubernetes Tests --
- [ ] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [ ] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [ ] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
