### PR TITLE
fix: update MeshRetry API with mergeable slice

### DIFF
--- a/app/kumactl/cmd/install/testdata/install-control-plane.defaults.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.defaults.golden.yaml
@@ -2196,6 +2196,9 @@ spec:
                                         minLength: 1
                                         pattern: ^[a-z0-9!#$%&'*+\-.^_\x60|~]+$
                                         type: string
+                                    required:
+                                    - format
+                                    - name
                                     type: object
                                   type: array
                               type: object
@@ -2271,6 +2274,9 @@ spec:
                                         minLength: 1
                                         pattern: ^[a-z0-9!#$%&'*+\-.^_\x60|~]+$
                                         type: string
+                                    required:
+                                    - format
+                                    - name
                                     type: object
                                   type: array
                               type: object

--- a/app/kumactl/cmd/install/testdata/install-control-plane.gateway-api-present-not-enabled.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.gateway-api-present-not-enabled.yaml
@@ -2196,6 +2196,9 @@ spec:
                                         minLength: 1
                                         pattern: ^[a-z0-9!#$%&'*+\-.^_\x60|~]+$
                                         type: string
+                                    required:
+                                    - format
+                                    - name
                                     type: object
                                   type: array
                               type: object
@@ -2271,6 +2274,9 @@ spec:
                                         minLength: 1
                                         pattern: ^[a-z0-9!#$%&'*+\-.^_\x60|~]+$
                                         type: string
+                                    required:
+                                    - format
+                                    - name
                                     type: object
                                   type: array
                               type: object

--- a/app/kumactl/cmd/install/testdata/install-control-plane.gateway-api-present.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.gateway-api-present.yaml
@@ -2393,6 +2393,9 @@ spec:
                                         minLength: 1
                                         pattern: ^[a-z0-9!#$%&'*+\-.^_\x60|~]+$
                                         type: string
+                                    required:
+                                    - format
+                                    - name
                                     type: object
                                   type: array
                               type: object
@@ -2468,6 +2471,9 @@ spec:
                                         minLength: 1
                                         pattern: ^[a-z0-9!#$%&'*+\-.^_\x60|~]+$
                                         type: string
+                                    required:
+                                    - format
+                                    - name
                                     type: object
                                   type: array
                               type: object

--- a/app/kumactl/cmd/install/testdata/install-control-plane.with-helm-set.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.with-helm-set.yaml
@@ -2216,6 +2216,9 @@ spec:
                                         minLength: 1
                                         pattern: ^[a-z0-9!#$%&'*+\-.^_\x60|~]+$
                                         type: string
+                                    required:
+                                    - format
+                                    - name
                                     type: object
                                   type: array
                               type: object
@@ -2291,6 +2294,9 @@ spec:
                                         minLength: 1
                                         pattern: ^[a-z0-9!#$%&'*+\-.^_\x60|~]+$
                                         type: string
+                                    required:
+                                    - format
+                                    - name
                                     type: object
                                   type: array
                               type: object

--- a/app/kumactl/cmd/install/testdata/install-crds.all.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-crds.all.golden.yaml
@@ -3367,6 +3367,9 @@ spec:
                                         minLength: 1
                                         pattern: ^[a-z0-9!#$%&'*+\-.^_\x60|~]+$
                                         type: string
+                                    required:
+                                    - format
+                                    - name
                                     type: object
                                   type: array
                               type: object
@@ -3442,6 +3445,9 @@ spec:
                                         minLength: 1
                                         pattern: ^[a-z0-9!#$%&'*+\-.^_\x60|~]+$
                                         type: string
+                                    required:
+                                    - format
+                                    - name
                                     type: object
                                   type: array
                               type: object

--- a/app/kumactl/cmd/install/testdata/install-crds.experimental-gatewayapi.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-crds.experimental-gatewayapi.golden.yaml
@@ -3519,6 +3519,9 @@ spec:
                                         minLength: 1
                                         pattern: ^[a-z0-9!#$%&'*+\-.^_\x60|~]+$
                                         type: string
+                                    required:
+                                    - format
+                                    - name
                                     type: object
                                   type: array
                               type: object
@@ -3594,6 +3597,9 @@ spec:
                                         minLength: 1
                                         pattern: ^[a-z0-9!#$%&'*+\-.^_\x60|~]+$
                                         type: string
+                                    required:
+                                    - format
+                                    - name
                                     type: object
                                   type: array
                               type: object

--- a/deployments/charts/kuma/crds/kuma.io_meshretries.yaml
+++ b/deployments/charts/kuma/crds/kuma.io_meshretries.yaml
@@ -138,6 +138,9 @@ spec:
                                         minLength: 1
                                         pattern: ^[a-z0-9!#$%&'*+\-.^_\x60|~]+$
                                         type: string
+                                    required:
+                                    - format
+                                    - name
                                     type: object
                                   type: array
                               type: object
@@ -213,6 +216,9 @@ spec:
                                         minLength: 1
                                         pattern: ^[a-z0-9!#$%&'*+\-.^_\x60|~]+$
                                         type: string
+                                    required:
+                                    - format
+                                    - name
                                     type: object
                                   type: array
                               type: object

--- a/pkg/plugins/policies/meshretry/api/v1alpha1/meshretry.go
+++ b/pkg/plugins/policies/meshretry/api/v1alpha1/meshretry.go
@@ -218,7 +218,7 @@ type RateLimitedBackOff struct {
 	// ResetHeaders specifies the list of headers (like Retry-After or X-RateLimit-Reset) to match against the response.
 	// Headers are tried in order, and matched case-insensitive. The first header to be parsed successfully is used.
 	// If no headers match the default exponential BackOff is used instead.
-	ResetHeaders []ResetHeader `json:"resetHeaders,omitempty"`
+	ResetHeaders *[]ResetHeader `json:"resetHeaders,omitempty"`
 	// MaxInterval is a maximal amount of time which will be taken between retries.
 	// Default is 300 seconds.
 	MaxInterval *k8s.Duration `json:"maxInterval,omitempty"`
@@ -242,9 +242,9 @@ var RateLimitFormatEnumToEnvoyValue = map[RateLimitFormat]envoy_route.RetryPolic
 
 type ResetHeader struct {
 	// The Name of the reset header.
-	Name common_api.HeaderName `json:"name,omitempty"`
+	Name common_api.HeaderName `json:"name"`
 	// The format of the reset header, either Seconds or UnixTimestamp.
-	Format RateLimitFormat `json:"format,omitempty"`
+	Format RateLimitFormat `json:"format"`
 }
 
 type HeaderMatchType string

--- a/pkg/plugins/policies/meshretry/api/v1alpha1/schema.yaml
+++ b/pkg/plugins/policies/meshretry/api/v1alpha1/schema.yaml
@@ -87,6 +87,9 @@ properties:
                                 minLength: 1
                                 pattern: ^[a-z0-9!#$%&'*+\-.^_\x60|~]+$
                                 type: string
+                            required:
+                              - format
+                              - name
                             type: object
                           type: array
                       type: object
@@ -138,6 +141,9 @@ properties:
                                 minLength: 1
                                 pattern: ^[a-z0-9!#$%&'*+\-.^_\x60|~]+$
                                 type: string
+                            required:
+                              - format
+                              - name
                             type: object
                           type: array
                       type: object

--- a/pkg/plugins/policies/meshretry/api/v1alpha1/validator.go
+++ b/pkg/plugins/policies/meshretry/api/v1alpha1/validator.go
@@ -162,13 +162,13 @@ func validateRateLimitedBackOff(rateLimitedBackOff *RateLimitedBackOff) validato
 		verr.Add(validators.ValidateDurationGreaterThanZero(path.Field("maxInterval"), *rateLimitedBackOff.MaxInterval))
 	}
 
-	if len(rateLimitedBackOff.ResetHeaders) == 0 {
+	if rateLimitedBackOff.ResetHeaders == nil {
 		verr.AddViolationAt(path.Field("resetHeaders"), validators.MustBeDefined)
-	}
-
-	for i, header := range rateLimitedBackOff.ResetHeaders {
-		index := path.Field("resetHeaders").Index(i)
-		verr.Add(validators.ValidateStringDefined(index.Field("name"), string(header.Name)))
+	} else {
+		for i, header := range *rateLimitedBackOff.ResetHeaders {
+			index := path.Field("resetHeaders").Index(i)
+			verr.Add(validators.ValidateStringDefined(index.Field("name"), string(header.Name)))
+		}
 	}
 
 	return verr

--- a/pkg/plugins/policies/meshretry/api/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/plugins/policies/meshretry/api/v1alpha1/zz_generated.deepcopy.go
@@ -222,8 +222,12 @@ func (in *RateLimitedBackOff) DeepCopyInto(out *RateLimitedBackOff) {
 	*out = *in
 	if in.ResetHeaders != nil {
 		in, out := &in.ResetHeaders, &out.ResetHeaders
-		*out = make([]ResetHeader, len(*in))
-		copy(*out, *in)
+		*out = new([]ResetHeader)
+		if **in != nil {
+			in, out := *in, *out
+			*out = make([]ResetHeader, len(*in))
+			copy(*out, *in)
+		}
 	}
 	if in.MaxInterval != nil {
 		in, out := &in.MaxInterval, &out.MaxInterval

--- a/pkg/plugins/policies/meshretry/k8s/crd/kuma.io_meshretries.yaml
+++ b/pkg/plugins/policies/meshretry/k8s/crd/kuma.io_meshretries.yaml
@@ -138,6 +138,9 @@ spec:
                                         minLength: 1
                                         pattern: ^[a-z0-9!#$%&'*+\-.^_\x60|~]+$
                                         type: string
+                                    required:
+                                    - format
+                                    - name
                                     type: object
                                   type: array
                               type: object
@@ -213,6 +216,9 @@ spec:
                                         minLength: 1
                                         pattern: ^[a-z0-9!#$%&'*+\-.^_\x60|~]+$
                                         type: string
+                                    required:
+                                    - format
+                                    - name
                                     type: object
                                   type: array
                               type: object

--- a/pkg/plugins/policies/meshretry/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshretry/plugin/v1alpha1/plugin_test.go
@@ -104,7 +104,7 @@ var _ = Describe("MeshRetry", func() {
 								},
 								RateLimitedBackOff: &api.RateLimitedBackOff{
 									MaxInterval: test.ParseDuration("5s"),
-									ResetHeaders: []api.ResetHeader{
+									ResetHeaders: &[]api.ResetHeader{
 										{
 											Name:   "retry-after-http",
 											Format: "Seconds",
@@ -184,7 +184,7 @@ var _ = Describe("MeshRetry", func() {
 								},
 								RateLimitedBackOff: &api.RateLimitedBackOff{
 									MaxInterval: test.ParseDuration("15s"),
-									ResetHeaders: []api.ResetHeader{
+									ResetHeaders: &[]api.ResetHeader{
 										{
 											Name:   "retry-after-grpc",
 											Format: "Seconds",

--- a/pkg/plugins/policies/meshretry/plugin/xds/configurer.go
+++ b/pkg/plugins/policies/meshretry/plugin/xds/configurer.go
@@ -13,6 +13,7 @@ import (
 
 	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	api "github.com/kumahq/kuma/pkg/plugins/policies/meshretry/api/v1alpha1"
+	"github.com/kumahq/kuma/pkg/util/pointer"
 	util_proto "github.com/kumahq/kuma/pkg/util/proto"
 	v3 "github.com/kumahq/kuma/pkg/xds/envoy/listeners/v3"
 )
@@ -149,7 +150,7 @@ func configureRateLimitedRetryBackOff(rateLimitedBackOff *api.RateLimitedBackOff
 	rateLimitedRetryBackoff := &envoy_route.RetryPolicy_RateLimitedRetryBackOff{
 		ResetHeaders: []*envoy_route.RetryPolicy_ResetHeader{},
 	}
-	for _, resetHeader := range rateLimitedBackOff.ResetHeaders {
+	for _, resetHeader := range pointer.Deref(rateLimitedBackOff.ResetHeaders) {
 		rateLimitedRetryBackoff.ResetHeaders = append(rateLimitedRetryBackoff.ResetHeaders, &envoy_route.RetryPolicy_ResetHeader{
 			Name:   string(resetHeader.Name),
 			Format: api.RateLimitFormatEnumToEnvoyValue[resetHeader.Format],


### PR DESCRIPTION
* Make `default.http.rateLimitBackoff.resetHeaders` mergeable (added pointer)
* Make `default.http.rateLimitBackoff.resetHeaders.name` required (removed omitempty)
* Make `default.http.rateLimitBackoff.resetHeaders.format` required (removed omitempty)

Signed-off-by: Ilya Lobkov <ilya.lobkov@konghq.com>

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [X] Link to docs PR or issue --
- [X] Link to UI issue or PR --
- [X] Is the [issue worked on linked][1]? --
- [X] The PR does not hardcode values that might break projects that depend on kuma (e.g. "kumahq" as a image registry) --
- [X] The PR will work for both Linux and Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [X] Unit Tests --
- [X] E2E Tests --
- [X] Manual Universal Tests --
- [X] Manual Kubernetes Tests --
- [X] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [X] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [X] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
