### PR TITLE
chore: fix file not found

### DIFF
--- a/tools/envoy/fetch.sh
+++ b/tools/envoy/fetch.sh
@@ -31,7 +31,6 @@ function download_envoy() {
     "https://github.com/kumahq/envoy-builds/releases/download/${ENVOY_TAG}/${binary_name}.tar.gz")
 
     if [ "$status" -ne "200" ]; then
-        rm "${BINARY_PATH}"
         msg_err "Error: failed downloading Envoy: ${status} error"
     fi
 


### PR DESCRIPTION
[CI sometimes fails](https://app.circleci.com/pipelines/github/kumahq/kuma/19014/workflows/918e91e5-548e-4596-b949-735722615eae/jobs/306006) with "no such a file" on rm, but if the download does not succeed (status != 200) then there won't be any file to remove. 

This won't make the CI pass but at least there will be a correct error message.

Signed-off-by: slonka <slonka@users.noreply.github.com>

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [ ] Link to docs PR or issue --
- [ ] Link to UI issue or PR --
- [ ] Is the [issue worked on linked][1]? --
- [ ] The PR does not hardcode values that might break projects that depend on kuma (e.g. "kumahq" as a image registry) --
- [ ] The PR will work for both Linux and Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [ ] Unit Tests --
- [ ] E2E Tests --
- [ ] Manual Universal Tests --
- [ ] Manual Kubernetes Tests --
- [ ] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [ ] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [ ] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
