### PR TITLE
test(unit): use mock clock in inspect tests

### DIFF
--- a/app/kumactl/cmd/inspect/inspect_dataplane_test.go
+++ b/app/kumactl/cmd/inspect/inspect_dataplane_test.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"path"
 	"path/filepath"
-	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -59,8 +58,7 @@ var _ = Describe("kumactl inspect dataplane", func() {
 				response: response,
 			}
 
-			rootCtx, err := test_kumactl.MakeRootContext(time.Now(), nil)
-			Expect(err).ToNot(HaveOccurred())
+			rootCtx := test_kumactl.MakeMinimalRootContext()
 
 			rootCtx.Runtime.NewDataplaneInspectClient = func(client util_http.Client) resources.DataplaneInspectClient {
 				return testClient

--- a/app/kumactl/cmd/inspect/inspect_meshgateway_test.go
+++ b/app/kumactl/cmd/inspect/inspect_meshgateway_test.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"path"
 	"path/filepath"
-	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -49,9 +48,7 @@ var _ = DescribeTable("kumactl inspect meshgateway",
 			response: response,
 		}
 
-		rootCtx, err := test_kumactl.MakeRootContext(time.Now(), nil)
-		Expect(err).ToNot(HaveOccurred())
-
+		rootCtx := test_kumactl.MakeMinimalRootContext()
 		rootCtx.Runtime.NewMeshGatewayInspectClient = func(client util_http.Client) resources.MeshGatewayInspectClient {
 			return testClient
 		}

--- a/app/kumactl/cmd/inspect/inspect_policy_test.go
+++ b/app/kumactl/cmd/inspect/inspect_policy_test.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"path"
 	"path/filepath"
-	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -47,9 +46,7 @@ var _ = Describe("kumactl inspect POLICY", func() {
 			entryList := &api_server_types.PolicyInspectEntryList{}
 			Expect(json.Unmarshal(rawResponse, entryList)).To(Succeed())
 
-			rootCtx, err := test_kumactl.MakeRootContext(time.Now(), nil)
-			Expect(err).ToNot(HaveOccurred())
-
+			rootCtx := test_kumactl.MakeMinimalRootContext()
 			rootCtx.Runtime.NewPolicyInspectClient = func(client util_http.Client) resources.PolicyInspectClient {
 				return &testPolicyInspectClient{
 					response: entryList,

--- a/pkg/test/kumactl/context.go
+++ b/pkg/test/kumactl/context.go
@@ -22,10 +22,15 @@ var defaultNewBaseAPIServerClient = func(server *config_proto.ControlPlaneCoordi
 	return nil, nil
 }
 
+var rootTime, _ = time.Parse(time.RFC3339, "2008-04-27T16:05:36.995Z")
+
 func MakeMinimalRootContext() *kumactl_cmd.RootContext {
 	return &kumactl_cmd.RootContext{
 		Args: defaultArgs,
 		Runtime: kumactl_cmd.RootRuntime{
+			Now: func() time.Time {
+				return rootTime
+			},
 			Registry:               registry.NewTypeRegistry(),
 			NewAPIServerClient:     defaultNewAPIServerClient,
 			NewBaseAPIServerClient: defaultNewBaseAPIServerClient,


### PR DESCRIPTION
Apparently, there is a race condition with `time.Now()` for inspect tests visible in arm64
```
[1674482952] Inspect Cmd Suite - 36/36 specs - 4 procs ••••••••••••••••••••••••••••••••••••
------------------------------
[ReportAfterSuite] PASSED [0.152 seconds]
[ReportAfterSuite] Autogenerated ReportAfterSuite for --junit-report
autogenerated by Ginkgo

  Captured StdOut/StdErr Output >>
  ==================
  WARNING: DATA RACE
  Read at 0x000005393530 by goroutine 90:
    time.Now()
        time/time.go:1079 +0xc8
    time.sendTime()
        time/sleep.go:145 +0x44

  Previous write at 0x000005393530 by goroutine 65:
    [failed to restore the stack]

  Goroutine 90 (running) created at:
    [failed to restore the stack]
  ==================
  << Captured StdOut/StdErr Output
------------------------------
 SUCCESS! 365.685157ms 
coverage: 78.6% of statements
[1674482952] Install Cmd Suite - 58/58 specs - 4 procs •••••••••••••••••••••••••••••••••••••••••••••••••••••••••• SUCCESS! 34.108851553s 
```

https://app.circleci.com/pipelines/github/kumahq/kuma/19109/workflows/5b72c17e-da5a-49f2-acdd-edf58d02126b/jobs/309240

This sounds like a bug in Go or Ginkgo.
We don't need to (and ideally we should not) use `time.Now()` in tests.


### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [X] Link to docs PR or issue --
- [X] Link to UI issue or PR --
- [X] Is the [issue worked on linked][1]? --
- [X] The PR does not hardcode values that might break projects that depend on kuma (e.g. "kumahq" as a image registry) --
- [X] The PR will work for both Linux and Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [X] Unit Tests --
- [X] E2E Tests --
- [X] Manual Universal Tests --
- [X] Manual Kubernetes Tests --
- [X] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [X] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [X] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
