### PR TITLE
chore: fix version sh pipe exit

### DIFF
--- a/tools/releases/version.sh
+++ b/tools/releases/version.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 
-set -o errexit
-set -o pipefail
-
 function envoy_version() {
+  set -o errexit
+  set -o pipefail
+  set -o nounset
   # Returns Envoy version by ENVOY_TAG:
   # - if ENVOY_TAG is a real git tag like 'v1.20.0' then the version is equal to '1.20.0' (without the first letter 'v').
   # - if ENVOY_TAG is a commit hash then the version will look like '1.20.1-dev-b16d390f'
@@ -21,6 +21,9 @@ function envoy_version() {
   else
     echo "${ENVOY_VERSION}-${ENVOY_TAG:0:8}"
   fi
+  set +o errexit
+  set +o pipefail
+  set +o nounset
 }
 
 function version_info() {


### PR DESCRIPTION
Signed-off-by: slonka <slonka@users.noreply.github.com>

The old version (release-2.0) of [envoy/version.sh](https://github.com/kumahq/kuma/blob/release-2.0/tools/envoy/version.sh#L3-L4) and [releases/version.sh](https://github.com/kumahq/kuma/blob/release-2.0/tools/releases/version.sh) had different settings for `pipefail` and `errexit`. When this got merged together in this [PR](https://github.com/kumahq/kuma/pull/5291/files#diff-19e661817a5cc3d4d91d0e62ac68a4a68ffbecac0d64b7a4e8a680a34e8b7f08L1) I didn't know it made a difference so I merged that. Now it should be fine since I only set `pipefail` and `errexit` in the envoy_version function.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [ ] Link to docs PR or issue --
- [ ] Link to UI issue or PR --
- [ ] Is the [issue worked on linked][1]? --
- [ ] The PR does not hardcode values that might break projects that depend on kuma (e.g. "kumahq" as a image registry) --
- [ ] The PR will work for both Linux and Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [ ] Unit Tests --
- [ ] E2E Tests --
- [ ] Manual Universal Tests --
- [ ] Manual Kubernetes Tests --
- [ ] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [ ] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [ ] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
