### PR TITLE
feat(kuma-cp): restore default leader election mechanism

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -32,6 +32,10 @@ Make sure you are using a recent `kumactl` or that you use the right path if usi
 
 The sidecar container is always injected first (since [#5436](https://github.com/kumahq/kuma/pull/5436)). This should only impact you when modifying the sidecar container with a container-patch. If you do so, upgrade Kuma and then change your container patch to modify the right container.
 
+This version changes the leader election mechanism from leader for life to the more robust leader with lease.
+As the result, during the upgrade you may have two leaders in the cluster.
+This should not impact the system in any significant way other than logs like `resource was already updated`.
+
 ### Kumactl
 
 `--valid-for` must be set for all token types, before it was defaulting to 10 years.

--- a/app/kumactl/cmd/install/testdata/install-control-plane.cni-enabled.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.cni-enabled.golden.yaml
@@ -592,10 +592,6 @@ spec:
               value: "kuma-system"
             - name: KUMA_STORE_TYPE
               value: "kubernetes"
-            - name: POD_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.name
             - name: KUMA_INTER_CP_CATALOG_INSTANCE_ADDRESS
               valueFrom:
                 fieldRef:

--- a/app/kumactl/cmd/install/testdata/install-control-plane.cni-experimental-enabled.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.cni-experimental-enabled.golden.yaml
@@ -614,10 +614,6 @@ spec:
               value: "kuma-system"
             - name: KUMA_STORE_TYPE
               value: "kubernetes"
-            - name: POD_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.name
             - name: KUMA_INTER_CP_CATALOG_INSTANCE_ADDRESS
               valueFrom:
                 fieldRef:

--- a/app/kumactl/cmd/install/testdata/install-control-plane.defaults.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.defaults.golden.yaml
@@ -5303,10 +5303,6 @@ spec:
               value: "kuma-system"
             - name: KUMA_STORE_TYPE
               value: "kubernetes"
-            - name: POD_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.name
             - name: KUMA_INTER_CP_CATALOG_INSTANCE_ADDRESS
               valueFrom:
                 fieldRef:

--- a/app/kumactl/cmd/install/testdata/install-control-plane.gateway-api-present-not-enabled.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.gateway-api-present-not-enabled.yaml
@@ -5303,10 +5303,6 @@ spec:
               value: "kuma-system"
             - name: KUMA_STORE_TYPE
               value: "kubernetes"
-            - name: POD_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.name
             - name: KUMA_INTER_CP_CATALOG_INSTANCE_ADDRESS
               valueFrom:
                 fieldRef:

--- a/app/kumactl/cmd/install/testdata/install-control-plane.gateway-api-present.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.gateway-api-present.yaml
@@ -5459,10 +5459,6 @@ spec:
               value: "kuma-system"
             - name: KUMA_STORE_TYPE
               value: "kubernetes"
-            - name: POD_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.name
             - name: KUMA_INTER_CP_CATALOG_INSTANCE_ADDRESS
               valueFrom:
                 fieldRef:

--- a/app/kumactl/cmd/install/testdata/install-control-plane.global.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.global.golden.yaml
@@ -431,10 +431,6 @@ spec:
               value: "kuma-system"
             - name: KUMA_STORE_TYPE
               value: "kubernetes"
-            - name: POD_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.name
             - name: KUMA_INTER_CP_CATALOG_INSTANCE_ADDRESS
               valueFrom:
                 fieldRef:

--- a/app/kumactl/cmd/install/testdata/install-control-plane.override-env-vars.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.override-env-vars.golden.yaml
@@ -414,10 +414,6 @@ spec:
               value: "kuma-system"
             - name: KUMA_STORE_TYPE
               value: "kubernetes"
-            - name: POD_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.name
             - name: KUMA_INTER_CP_CATALOG_INSTANCE_ADDRESS
               valueFrom:
                 fieldRef:

--- a/app/kumactl/cmd/install/testdata/install-control-plane.overrides.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.overrides.golden.yaml
@@ -430,10 +430,6 @@ spec:
               value: "kuma"
             - name: KUMA_STORE_TYPE
               value: "kubernetes"
-            - name: POD_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.name
             - name: KUMA_INTER_CP_CATALOG_INSTANCE_ADDRESS
               valueFrom:
                 fieldRef:

--- a/app/kumactl/cmd/install/testdata/install-control-plane.registry.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.registry.golden.yaml
@@ -414,10 +414,6 @@ spec:
               value: "kuma-system"
             - name: KUMA_STORE_TYPE
               value: "kubernetes"
-            - name: POD_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.name
             - name: KUMA_INTER_CP_CATALOG_INSTANCE_ADDRESS
               valueFrom:
                 fieldRef:

--- a/app/kumactl/cmd/install/testdata/install-control-plane.tproxy-ebpf-experimental-enabled.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.tproxy-ebpf-experimental-enabled.golden.yaml
@@ -424,10 +424,6 @@ spec:
               value: "kuma-system"
             - name: KUMA_STORE_TYPE
               value: "kubernetes"
-            - name: POD_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.name
             - name: KUMA_INTER_CP_CATALOG_INSTANCE_ADDRESS
               valueFrom:
                 fieldRef:

--- a/app/kumactl/cmd/install/testdata/install-control-plane.with-egress.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.with-egress.golden.yaml
@@ -445,10 +445,6 @@ spec:
               value: "kuma-system"
             - name: KUMA_STORE_TYPE
               value: "kubernetes"
-            - name: POD_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.name
             - name: KUMA_INTER_CP_CATALOG_INSTANCE_ADDRESS
               valueFrom:
                 fieldRef:

--- a/app/kumactl/cmd/install/testdata/install-control-plane.with-helm-set.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.with-helm-set.yaml
@@ -5369,10 +5369,6 @@ spec:
               value: "kuma-system"
             - name: KUMA_STORE_TYPE
               value: "kubernetes"
-            - name: POD_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.name
             - name: KUMA_INTER_CP_CATALOG_INSTANCE_ADDRESS
               valueFrom:
                 fieldRef:

--- a/app/kumactl/cmd/install/testdata/install-control-plane.with-helm-values.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.with-helm-values.yaml
@@ -414,10 +414,6 @@ spec:
               value: "kuma-system"
             - name: KUMA_STORE_TYPE
               value: "kubernetes"
-            - name: POD_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.name
             - name: KUMA_INTER_CP_CATALOG_INSTANCE_ADDRESS
               valueFrom:
                 fieldRef:

--- a/app/kumactl/cmd/install/testdata/install-control-plane.with-ingress.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.with-ingress.golden.yaml
@@ -449,10 +449,6 @@ spec:
               value: "kuma-system"
             - name: KUMA_STORE_TYPE
               value: "kubernetes"
-            - name: POD_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.name
             - name: KUMA_INTER_CP_CATALOG_INSTANCE_ADDRESS
               valueFrom:
                 fieldRef:

--- a/app/kumactl/cmd/install/testdata/install-control-plane.zone.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.zone.golden.yaml
@@ -418,10 +418,6 @@ spec:
               value: "kuma-system"
             - name: KUMA_STORE_TYPE
               value: "kubernetes"
-            - name: POD_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.name
             - name: KUMA_INTER_CP_CATALOG_INSTANCE_ADDRESS
               valueFrom:
                 fieldRef:

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/empty.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/empty.golden.yaml
@@ -414,10 +414,6 @@ spec:
               value: "kuma-system"
             - name: KUMA_STORE_TYPE
               value: "kubernetes"
-            - name: POD_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.name
             - name: KUMA_INTER_CP_CATALOG_INSTANCE_ADDRESS
               valueFrom:
                 fieldRef:

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/fix4485.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/fix4485.golden.yaml
@@ -437,10 +437,6 @@ spec:
               value: "kuma-system"
             - name: KUMA_STORE_TYPE
               value: "kubernetes"
-            - name: POD_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.name
             - name: KUMA_INTER_CP_CATALOG_INSTANCE_ADDRESS
               valueFrom:
                 fieldRef:

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/fix4496.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/fix4496.golden.yaml
@@ -460,10 +460,6 @@ spec:
               value: "kuma-system"
             - name: KUMA_STORE_TYPE
               value: "kubernetes"
-            - name: POD_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.name
             - name: KUMA_INTER_CP_CATALOG_INSTANCE_ADDRESS
               valueFrom:
                 fieldRef:

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/fix4935.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/fix4935.golden.yaml
@@ -668,10 +668,6 @@ spec:
               value: "kuma-system"
             - name: KUMA_STORE_TYPE
               value: "kubernetes"
-            - name: POD_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.name
             - name: KUMA_INTER_CP_CATALOG_INSTANCE_ADDRESS
               valueFrom:
                 fieldRef:

--- a/deployments/charts/kuma/templates/cp-deployment.yaml
+++ b/deployments/charts/kuma/templates/cp-deployment.yaml
@@ -92,10 +92,6 @@ spec:
                   name: {{ $element.Secret }}
                   key: {{ $element.Key }}
           {{- end }}
-            - name: POD_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.name
             - name: KUMA_INTER_CP_CATALOG_INSTANCE_ADDRESS
               valueFrom:
                 fieldRef:

--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,6 @@ require (
 	github.com/natefinch/atomic v1.0.1
 	github.com/onsi/ginkgo/v2 v2.7.0
 	github.com/onsi/gomega v1.25.0
-	github.com/operator-framework/operator-lib v0.11.0
 	github.com/patrickmn/go-cache v2.1.0+incompatible
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.14.0
@@ -52,7 +51,7 @@ require (
 	go.uber.org/zap v1.24.0
 	golang.org/x/exp v0.0.0-20221212164502-fae10dda9338
 	golang.org/x/net v0.5.0
-	golang.org/x/sync v0.1.0
+	golang.org/x/sync v0.1.0 // indirect
 	golang.org/x/sys v0.4.0
 	golang.org/x/text v0.6.0
 	golang.org/x/time v0.3.0

--- a/go.sum
+++ b/go.sum
@@ -1114,8 +1114,6 @@ github.com/opencontainers/selinux v1.8.0/go.mod h1:RScLhm78qiWa2gbVCcGkC7tCGdgk3
 github.com/opencontainers/selinux v1.8.2/go.mod h1:MUIHuUEvKB1wtJjQdOyYRgOnLD2xAPP8dBsCoU0KuF8=
 github.com/opencontainers/selinux v1.10.0/go.mod h1:2i0OySw99QjzBBQByd1Gr9gSjvuho1lHsJxIJ3gGbJI=
 github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
-github.com/operator-framework/operator-lib v0.11.0 h1:eYzqpiOfq9WBI4Trddisiq/X9BwCisZd3rIzmHRC9Z8=
-github.com/operator-framework/operator-lib v0.11.0/go.mod h1:RpyKhFAoG6DmKTDIwMuO6pI3LRc8IE9rxEYWy476o6g=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/patrickmn/go-cache v2.1.0+incompatible h1:HRMgzkcYKYpi3C8ajMPV8OFXaaRUnok+kx1WdO15EQc=
 github.com/patrickmn/go-cache v2.1.0+incompatible/go.mod h1:3Qf8kWWT7OJRJbdiICTKqZju1ZixQ/KpMGzzAfe6+WQ=

--- a/pkg/plugins/bootstrap/k8s/plugin.go
+++ b/pkg/plugins/bootstrap/k8s/plugin.go
@@ -2,25 +2,19 @@ package k8s
 
 import (
 	"context"
-	"encoding/json"
 	"os"
 	"strconv"
 	"time"
 
-	"github.com/operator-framework/operator-lib/leader"
 	"github.com/pkg/errors"
-	"golang.org/x/sync/errgroup"
 	kube_core "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kube_runtime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/rest"
 	kube_ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	kube_client "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/cluster"
-	kube_ctrlr "sigs.k8s.io/controller-runtime/pkg/controller"
 	kube_manager "sigs.k8s.io/controller-runtime/pkg/manager"
 
 	config_core "github.com/kumahq/kuma/pkg/config/core"
@@ -54,16 +48,20 @@ func (p *plugin) BeforeBootstrap(b *core_runtime.Builder, cfg core_plugins.Plugi
 		return err
 	}
 	config := kube_ctrl.GetConfigOrDie()
+	systemNamespace := b.Config().Store.Kubernetes.SystemNamespace
 	mgr, err := kube_ctrl.NewManager(
 		config,
 		kube_ctrl.Options{
 			Scheme:   scheme,
 			NewCache: kuma_kube_cache.New,
 			// Admission WebHook Server
-			Host:           b.Config().Runtime.Kubernetes.AdmissionServer.Address,
-			Port:           int(b.Config().Runtime.Kubernetes.AdmissionServer.Port),
-			CertDir:        b.Config().Runtime.Kubernetes.AdmissionServer.CertDir,
-			LeaderElection: false,
+			Host:                    b.Config().Runtime.Kubernetes.AdmissionServer.Address,
+			Port:                    int(b.Config().Runtime.Kubernetes.AdmissionServer.Port),
+			CertDir:                 b.Config().Runtime.Kubernetes.AdmissionServer.CertDir,
+			LeaderElection:          true,
+			LeaderElectionID:        "cp-leader-lease",
+			LeaderElectionNamespace: systemNamespace,
+			Logger:                  core.Log.WithName("kube-manager"),
 
 			// Disable metrics bind address as we serve metrics some other way.
 			MetricsBindAddress: "0",
@@ -73,27 +71,13 @@ func (p *plugin) BeforeBootstrap(b *core_runtime.Builder, cfg core_plugins.Plugi
 		return err
 	}
 
-	systemNamespace := b.Config().Store.Kubernetes.SystemNamespace
-
 	secretClient, err := createSecretClient(b.AppCtx(), scheme, systemNamespace, config, mgr.GetRESTMapper())
 	if err != nil {
 		return err
 	}
 
-	// We can't pass kubeComponentManager into NewManagerContext because of
-	// conflicting method signatures.
-	kubeManagerWrapper := &kubeManagerWrapper{
-		Manager:     mgr,
-		controllers: nil,
-	}
-	b.WithExtensions(k8s_extensions.NewManagerContext(b.Extensions(), kubeManagerWrapper))
-
-	kcm := &kubeComponentManager{
-		kubeManagerWrapper:         kubeManagerWrapper,
-		oldLeaderElectionNamespace: systemNamespace,
-		leaderComponents:           nil,
-	}
-	b.WithComponentManager(kcm)
+	b.WithExtensions(k8s_extensions.NewManagerContext(b.Extensions(), mgr))
+	b.WithComponentManager(&kubeComponentManager{Manager: mgr})
 
 	b.WithExtensions(k8s_extensions.NewSecretClientContext(b.Extensions(), secretClient))
 	if expTime := b.Config().Runtime.Kubernetes.MarshalingCacheExpirationTime.Duration; expTime > 0 {
@@ -176,161 +160,15 @@ func (p *plugin) Order() int {
 	return core_plugins.EnvironmentPreparingOrder
 }
 
-// kubeManagerWrapper exists in order to intercept Manager.Add calls on
-// controllers so that we can start them independently of Manager.Start.
-type kubeManagerWrapper struct {
-	kube_ctrl.Manager
-	controllers []kube_ctrlr.Controller
-}
-
-// Add calls Manager.Add and passes the runnable.
-// If the runnable is a Controller, it will not be immediately Added.
-// Controllers must be explicitly added by calling AddControllers.
-func (kmw *kubeManagerWrapper) Add(runnable kube_manager.Runnable) error {
-	if ctrler, ok := runnable.(kube_ctrlr.Controller); ok {
-		kmw.controllers = append(kmw.controllers, ctrler)
-		return nil
-	}
-	return kmw.Manager.Add(runnable)
-}
-
-// AddControllers calls Manager.Add on any accumulated controllers.
-func (kmw *kubeManagerWrapper) AddControllersToManager() error {
-	for _, c := range kmw.controllers {
-		if err := kmw.Manager.Add(c); err != nil {
-			return errors.Wrap(err, "add controller error")
-		}
-	}
-	return nil
-}
-
 type kubeComponentManager struct {
-	*kubeManagerWrapper
-	oldLeaderElectionNamespace string
-	leaderComponents           []component.Component
-	gracefulComponents         []component.GracefulComponent
+	kube_ctrl.Manager
+	gracefulComponents []component.GracefulComponent
 }
 
 var _ component.Manager = &kubeComponentManager{}
 
-type leaderAnnotation struct {
-	HolderIdentity       string `json:"holderIdentity"`
-	LeaseDurationSeconds int    `json:"leaseDurationSeconds"`
-	AcquireTime          string `json:"acquireTime"`
-	RenewTime            string `json:"renewTime"`
-	LeaderTransitions    int    `json:"leaderTransistions"`
-}
-
-var blockerHolderId = "cp-leader-lock-transition"
-var oldLeaderConfigMapName = "kuma-cp-leader"
-
-func makeOldLockAnnotation() string {
-	nowStr := time.Now().Format(time.RFC3339)
-	annot := &leaderAnnotation{
-		HolderIdentity:       blockerHolderId,
-		LeaseDurationSeconds: 99999999999999999,
-		AcquireTime:          nowStr,
-		RenewTime:            nowStr,
-		LeaderTransitions:    0,
-	}
-
-	annotJson, _ := json.Marshal(annot)
-	return string(annotJson)
-}
-
-// startLeaderComponents adds all components that need leader election to the
-// Manager. The Manager should be running already, any components added after
-// that are started immediately.
-func (cm *kubeComponentManager) startLeaderComponents() error {
-	for _, c := range cm.leaderComponents {
-		if err := cm.Manager.Add(&componentRunnableAdaptor{Component: c}); err != nil {
-			return errors.Wrap(err, "add component error")
-		}
-	}
-	return cm.kubeManagerWrapper.AddControllersToManager()
-}
-
-// Previous versions of kuma-cp used a timeout lock for leader election. We now
-// keep the election for the lifetime of the pod. This function forces any previous
-// style leader to see itself as having lost its election, and locks out any
-// further old leaders.
-//
-// Only call this after acquiring new-style leader election, so as to only contend
-// with old leaders over old locks.
-func (cm *kubeComponentManager) forceTakeOldLock(ctx context.Context) error {
-	log.Info("checking for deprecated leader locks")
-	client := cm.Manager.GetClient()
-	ns := cm.oldLeaderElectionNamespace
-
-	pod := &kube_core.Pod{}
-	if err := client.Get(ctx, kube_client.ObjectKey{
-		Namespace: ns,
-		Name:      os.Getenv("POD_NAME"),
-	}, pod); err != nil {
-		log.Error(err, "unable to retrieve this pod")
-		return err
-	}
-
-	owner := &metav1.OwnerReference{
-		APIVersion: "v1",
-		Kind:       "Pod",
-		Name:       pod.ObjectMeta.Name,
-		UID:        pod.ObjectMeta.UID,
-	}
-
-	var mustWait = false
-
-	for {
-		newLock := &kube_core.ConfigMap{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:            oldLeaderConfigMapName,
-				Namespace:       ns,
-				OwnerReferences: []metav1.OwnerReference{*owner},
-				Annotations: map[string]string{
-					"control-plane.alpha.kubernetes.io/leader": makeOldLockAnnotation(),
-				},
-			},
-		}
-
-		// Numerous potential races between new and old CP leader in this loop. Just keep
-		// trying to grab the lock until it succeeds. Since the old leader will
-		// politely die when we acquire lock, and we are relentless, we will eventually
-		// prevail.
-
-		err := client.Create(ctx, newLock)
-		switch {
-		case err == nil:
-			// Acquired old lock.
-			if mustWait {
-				log.Info("waiting 30 seconds for old leader to terminate")
-				time.Sleep(30 * time.Second)
-			}
-			return nil
-		case apierrors.IsAlreadyExists(err):
-			log.Info("existing deprecated lock found; stealing")
-			mustWait = true
-
-			existing := &kube_core.ConfigMap{}
-			key := kube_client.ObjectKey{Namespace: ns, Name: oldLeaderConfigMapName}
-			err = client.Get(ctx, key, existing)
-			if err != nil {
-				log.Error(err, "error reading old lock; trying again")
-				break
-			}
-
-			err := client.Delete(ctx, existing)
-			if err != nil {
-				log.Error(err, "error deleting old lock; trying again")
-			}
-		default:
-			log.Error(err, "error creating ConfigMap; trying again")
-		}
-		time.Sleep(1 * time.Second)
-	}
-}
-
 func (cm *kubeComponentManager) Start(done <-chan struct{}) error {
-	baseCtx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(context.Background())
 	go func() {
 		defer cancel()
 		<-done
@@ -338,36 +176,10 @@ func (cm *kubeComponentManager) Start(done <-chan struct{}) error {
 
 	defer cm.waitForDone()
 
-	eg, ctx := errgroup.WithContext(baseCtx)
-
-	eg.Go(func() error {
-		return cm.Manager.Start(ctx)
-	})
-
-	eg.Go(func() error {
-		// The manager is always elected but this lets us wait until we're sure
-		// the other components have started, so we can wait until the Manager
-		// _would_ do leader election
-		select {
-		case <-ctx.Done():
-			return nil
-		case <-cm.Manager.Elected():
-		}
-
-		if err := leader.Become(ctx, "cp-leader"); err != nil {
-			return errors.Wrap(err, "leader lock failure")
-		}
-
-		// This CP will now be leader. But first, destroy deprecated leader lock,
-		// forcing any old leaders to restart as non-leaders.
-		if err := cm.forceTakeOldLock(ctx); err != nil {
-			return errors.Wrap(err, "error attempting to clean up deprecated lock")
-		}
-
-		return cm.startLeaderComponents()
-	})
-
-	return errors.Wrap(eg.Wait(), "error running Kubernetes Manager")
+	if err := cm.Manager.Start(ctx); err != nil {
+		return errors.Wrap(err, "error running Kubernetes Manager")
+	}
+	return nil
 }
 
 // Extra check that component.Component implements LeaderElectionRunnable so the leader election works so we won't break leader election on K8S when refactoring component.Component
@@ -380,10 +192,7 @@ func (k *kubeComponentManager) Add(components ...component.Component) error {
 		if gc, ok := c.(component.GracefulComponent); ok {
 			k.gracefulComponents = append(k.gracefulComponents, gc)
 		}
-
-		if c.NeedLeaderElection() {
-			k.leaderComponents = append(k.leaderComponents, c)
-		} else if err := k.Manager.Add(&componentRunnableAdaptor{Component: c}); err != nil {
+		if err := k.Manager.Add(&componentRunnableAdaptor{Component: c}); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
Switching for leader for life brought more problems than solutions https://github.com/kumahq/kuma/pull/3023

One of the problems was noticed on GCP and AWS where Node migration happened and the old leader CP Pod was stuck. The result was that no new leader was chosen and Pod with sidecar injection was never up.

One of the reasons for leader for life migration was Kube API throttling when CP was under big pressure. Since then, we reduced calls to storage. If this is still a problem, we can bump the lease duration and lease renewal time.

Fix #5709

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] Link to docs PR or issue --
- [X] Link to UI issue or PR --
- [X] Is the [issue worked on linked][1]? --
- [X] The PR does not hardcode values that might break projects that depend on kuma (e.g. "kumahq" as a image registry) --
- [X] The PR will work for both Linux and Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [X] Unit Tests --
- [X] E2E Tests --
- [X] Manual Universal Tests --
- [X] Manual Kubernetes Tests --
- [X] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [X] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [X] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
