### PR TITLE
fix(kuma-cp): fix the way how we set FractionalPercent in envoy

### DIFF
--- a/pkg/plugins/policies/meshfaultinjection/plugin/v1alpha1/testdata/basic_listener_1.golden.yaml
+++ b/pkg/plugins/policies/meshfaultinjection/plugin/v1alpha1/testdata/basic_listener_1.golden.yaml
@@ -30,7 +30,7 @@ filterChains:
               limitKbps: "111000"
             percentage:
               denominator: TEN_THOUSAND
-              numerator: 629000
+              numerator: 6290
       - name: envoy.filters.http.router
         typedConfig:
           '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router

--- a/pkg/plugins/policies/meshfaultinjection/plugin/v1alpha1/testdata/gateway_basic_listener.golden.yaml
+++ b/pkg/plugins/policies/meshfaultinjection/plugin/v1alpha1/testdata/gateway_basic_listener.golden.yaml
@@ -46,7 +46,7 @@ filterChains:
               limitKbps: "111000"
             percentage:
               denominator: TEN_THOUSAND
-              numerator: 629000
+              numerator: 6290
       - name: envoy.filters.http.router
         typedConfig:
           '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router

--- a/pkg/plugins/runtime/gateway/testdata/http/04-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/04-gateway-route.yaml
@@ -154,7 +154,7 @@ Routes:
             - cluster: echo-mirror-90205ae37cc0294e
               runtimeFraction:
                 defaultValue:
-                  denominator: TEN_THOUSAND
+                  denominator: MILLION
                   numerator: 10
             retryPolicy:
               numRetries: 5

--- a/pkg/plugins/runtime/gateway/testdata/http/06-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/06-gateway-route.yaml
@@ -173,7 +173,7 @@ Routes:
             - cluster: echo-mirror-90205ae37cc0294e
               runtimeFraction:
                 defaultValue:
-                  denominator: TEN_THOUSAND
+                  denominator: MILLION
                   numerator: 10
             retryPolicy:
               numRetries: 5

--- a/pkg/plugins/runtime/gateway/testdata/https/04-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/04-gateway-route.yaml
@@ -180,7 +180,7 @@ Routes:
             - cluster: echo-mirror-90205ae37cc0294e
               runtimeFraction:
                 defaultValue:
-                  denominator: TEN_THOUSAND
+                  denominator: MILLION
                   numerator: 10
             retryPolicy:
               numRetries: 5

--- a/pkg/plugins/runtime/gateway/testdata/https/06-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/06-gateway-route.yaml
@@ -199,7 +199,7 @@ Routes:
             - cluster: echo-mirror-90205ae37cc0294e
               runtimeFraction:
                 defaultValue:
-                  denominator: TEN_THOUSAND
+                  denominator: MILLION
                   numerator: 10
             retryPolicy:
               numRetries: 5

--- a/pkg/xds/envoy/listeners/v3/fault_injection_configurer_test.go
+++ b/pkg/xds/envoy/listeners/v3/fault_injection_configurer_test.go
@@ -46,7 +46,7 @@ var _ = Describe("FaultInjectionConfigurer", func() {
 					},
 					Conf: &mesh_proto.FaultInjection_Conf{
 						Delay: &mesh_proto.FaultInjection_Conf_Delay{
-							Percentage: util_proto.Double(50),
+							Percentage: util_proto.Double(50.5),
 							Value:      util_proto.Duration(time.Second * 5),
 						},
 					},
@@ -65,7 +65,8 @@ var _ = Describe("FaultInjectionConfigurer", func() {
                     delay:
                       fixedDelay: 5s
                       percentage:
-                        numerator: 50
+                        denominator: TEN_THOUSAND
+                        numerator: 5050
                     headers:
                     - name: x-kuma-tags
                       safeRegexMatch:

--- a/pkg/xds/envoy/listeners/v3/util.go
+++ b/pkg/xds/envoy/listeners/v3/util.go
@@ -81,8 +81,8 @@ func NewUnexpectedFilterConfigTypeError(actual, expected proto.Message) error {
 }
 
 func ConvertPercentage(percentage *wrapperspb.DoubleValue) *envoy_type.FractionalPercent {
-	const tenThousand = 10000
-	const million = 1000000
+	const tenThousand = 10_000
+	const hundred = 100
 
 	isInteger := func(f float64) bool {
 		return math.Floor(f) == f
@@ -96,16 +96,16 @@ func ConvertPercentage(percentage *wrapperspb.DoubleValue) *envoy_type.Fractiona
 		}
 	}
 
-	tenThousandTimes := tenThousand * value
-	if isInteger(tenThousandTimes) {
+	hundredTime := hundred * value
+	if isInteger(hundredTime) {
 		return &envoy_type.FractionalPercent{
-			Numerator:   uint32(tenThousandTimes),
+			Numerator:   uint32(hundredTime),
 			Denominator: envoy_type.FractionalPercent_TEN_THOUSAND,
 		}
 	}
 
 	return &envoy_type.FractionalPercent{
-		Numerator:   uint32(math.Round(million * value)),
+		Numerator:   uint32(math.Round(tenThousand * value)),
 		Denominator: envoy_type.FractionalPercent_MILLION,
 	}
 }

--- a/pkg/xds/envoy/listeners/v3/util_test.go
+++ b/pkg/xds/envoy/listeners/v3/util_test.go
@@ -204,19 +204,19 @@ var _ = Describe("ConvertPercentage", func() {
 		}),
 		Entry("fractional input with 1 digit after dot", testCase{
 			input:    util_proto.Double(50.1),
-			expected: &envoy_type.FractionalPercent{Numerator: 501000, Denominator: envoy_type.FractionalPercent_TEN_THOUSAND},
+			expected: &envoy_type.FractionalPercent{Numerator: 5010, Denominator: envoy_type.FractionalPercent_TEN_THOUSAND},
 		}),
 		Entry("fractional input with 5 digit after dot", testCase{
 			input:    util_proto.Double(50.12345),
-			expected: &envoy_type.FractionalPercent{Numerator: 50123450, Denominator: envoy_type.FractionalPercent_MILLION},
+			expected: &envoy_type.FractionalPercent{Numerator: 501235, Denominator: envoy_type.FractionalPercent_MILLION},
 		}),
 		Entry("fractional input with 7 digit after dot, last digit less than 5", testCase{
 			input:    util_proto.Double(50.1234561),
-			expected: &envoy_type.FractionalPercent{Numerator: 50123456, Denominator: envoy_type.FractionalPercent_MILLION},
+			expected: &envoy_type.FractionalPercent{Numerator: 501235, Denominator: envoy_type.FractionalPercent_MILLION},
 		}),
 		Entry("fractional input with 7 digit after dot, last digit more than 5", testCase{
 			input:    util_proto.Double(50.1234567),
-			expected: &envoy_type.FractionalPercent{Numerator: 50123457, Denominator: envoy_type.FractionalPercent_MILLION},
+			expected: &envoy_type.FractionalPercent{Numerator: 501235, Denominator: envoy_type.FractionalPercent_MILLION},
 		}),
 	)
 })


### PR DESCRIPTION
[FractionalPercent](https://www.envoyproxy.io/docs/envoy/latest/api-v3/type/v3/percent.proto#type-v3-fractionalpercent) works as a `x/100`, `x/10_000` or `x/1_000_000`. In case the value is bigger than Denominator then it is 100%. Our percentage didn't work properly because e.g. 50.5 was mapped to (50.5 * 10_000)/ 10_000 which is higher 10_000 which makes it 100% always. 

- [X] Link to docs PR or issue --
- [X] Link to UI issue or PR --
- [X] Is the [issue worked on linked][1]? --
- [X] The PR does not hardcode values that might break projects that depend on kuma (e.g. "kumahq" as a image registry) --
- [X] The PR will work for both Linux and Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [X] Unit Tests --
- [X] E2E Tests --
- [X] Manual Universal Tests --
- [X] Manual Kubernetes Tests --
- [X] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [X] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [X] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
