### PR TITLE
fix(kuma-cp): kds deadlock in unit tests

### DIFF
--- a/pkg/test/grpc/serverstream.go
+++ b/pkg/test/grpc/serverstream.go
@@ -2,11 +2,12 @@ package grpc
 
 import (
 	"context"
-	"github.com/kumahq/kuma/pkg/core/resources/registry"
 	"io"
 
 	envoy_sd "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
 	"google.golang.org/grpc"
+
+	"github.com/kumahq/kuma/pkg/core/resources/registry"
 )
 
 type MockServerStream struct {

--- a/pkg/test/grpc/serverstream.go
+++ b/pkg/test/grpc/serverstream.go
@@ -2,6 +2,7 @@ package grpc
 
 import (
 	"context"
+	"github.com/kumahq/kuma/pkg/core/resources/registry"
 	"io"
 
 	envoy_sd "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
@@ -64,7 +65,7 @@ func (stream *MockServerStream) ClientStream(stopCh chan struct{}) *MockClientSt
 func NewMockServerStream() *MockServerStream {
 	return &MockServerStream{
 		Ctx:    context.Background(),
-		SentCh: make(chan *envoy_sd.DiscoveryResponse, 10),
-		RecvCh: make(chan *envoy_sd.DiscoveryRequest, 10),
+		SentCh: make(chan *envoy_sd.DiscoveryResponse, len(registry.Global().ObjectTypes())),
+		RecvCh: make(chan *envoy_sd.DiscoveryRequest, len(registry.Global().ObjectTypes())),
 	}
 }


### PR DESCRIPTION
Signed-off-by: slonka <slonka@users.noreply.github.com>

In a [PR created](https://github.com/kumahq/kuma/pull/5373/files#diff-2104f7b8e3347efa0b0a472b5414d92f6e20e072479e7ac6416080e6f26b176bR130) by @jakubdyszkiewicz he uses a buffer of size `len(registry.Global().ObjectTypes())` but in our tests we still use still use `10` and I think that's why the job `dev-linux` and `dev-darwin` failed on `make test` via a deadlock:
- https://app.circleci.com/pipelines/github/kumahq/kuma/19121/workflows/58598d2c-afdc-4f2e-a8c5-6c3085f714d5/jobs/309710?invite=true#step-108-185
- https://app.circleci.com/pipelines/github/kumahq/kuma/19052/workflows/54d02b1b-0e67-431d-9964-e2c3cd6f8f0c/jobs/307144?invite=true#step-108-185
- https://app.circleci.com/pipelines/github/kumahq/kuma/18819/workflows/55f1f2f4-7917-4202-ba4c-5f32e152fc58/jobs/299612?invite=true#step-108-1380
- (and others)

I was able to reproduce this after ~10 attempts with `--until-it-fails` and after this change it does not fail after > 100 attempts.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [ ] Link to docs PR or issue --
- [ ] Link to UI issue or PR --
- [ ] Is the [issue worked on linked][1]? --
- [ ] The PR does not hardcode values that might break projects that depend on kuma (e.g. "kumahq" as a image registry) --
- [ ] The PR will work for both Linux and Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [ ] Unit Tests --
- [ ] E2E Tests --
- [ ] Manual Universal Tests --
- [ ] Manual Kubernetes Tests --
- [ ] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [ ] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [ ] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
