### PR TITLE
fix(kuma-cp): should set only once header for MeshRateLimit

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 [![][kuma-logo]][kuma-url]
 
 **Builds**
+[![CircleCI release-2.1](https://img.shields.io/circleci/build/github/kumahq/kuma/release-2.1?label=release-2.1)](https://circleci.com/gh/kumahq/kuma/tree/release-2.1)
 [![CircleCI release-2.0](https://img.shields.io/circleci/build/github/kumahq/kuma/release-2.0?label=release-2.0)](https://circleci.com/gh/kumahq/kuma/tree/release-2.0)
 [![CircleCI release-1.8](https://img.shields.io/circleci/build/github/kumahq/kuma/release-1.8?label=release-1.8)](https://circleci.com/gh/kumahq/kuma/tree/release-1.8)
 [![CircleCI release-1.7](https://img.shields.io/circleci/build/github/kumahq/kuma/release-1.7?label=release-1.7)](https://circleci.com/gh/kumahq/kuma/tree/release-1.7)

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,6 +8,8 @@ does not have any particular instructions.
 
 ## Upcoming release
 
+## Upgrade to `2.1.x`
+
 ### **Breaking changes**
 
 #### **Naming Serviceless dataplanes has changed**

--- a/app/kumactl/cmd/inspect/inspect_dataplane_test.go
+++ b/app/kumactl/cmd/inspect/inspect_dataplane_test.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"path"
 	"path/filepath"
-	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -59,8 +58,7 @@ var _ = Describe("kumactl inspect dataplane", func() {
 				response: response,
 			}
 
-			rootCtx, err := test_kumactl.MakeRootContext(time.Now(), nil)
-			Expect(err).ToNot(HaveOccurred())
+			rootCtx := test_kumactl.MakeMinimalRootContext()
 
 			rootCtx.Runtime.NewDataplaneInspectClient = func(client util_http.Client) resources.DataplaneInspectClient {
 				return testClient

--- a/app/kumactl/cmd/inspect/inspect_meshgateway_test.go
+++ b/app/kumactl/cmd/inspect/inspect_meshgateway_test.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"path"
 	"path/filepath"
-	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -49,9 +48,7 @@ var _ = DescribeTable("kumactl inspect meshgateway",
 			response: response,
 		}
 
-		rootCtx, err := test_kumactl.MakeRootContext(time.Now(), nil)
-		Expect(err).ToNot(HaveOccurred())
-
+		rootCtx := test_kumactl.MakeMinimalRootContext()
 		rootCtx.Runtime.NewMeshGatewayInspectClient = func(client util_http.Client) resources.MeshGatewayInspectClient {
 			return testClient
 		}

--- a/app/kumactl/cmd/inspect/inspect_policy_test.go
+++ b/app/kumactl/cmd/inspect/inspect_policy_test.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"path"
 	"path/filepath"
-	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -47,9 +46,7 @@ var _ = Describe("kumactl inspect POLICY", func() {
 			entryList := &api_server_types.PolicyInspectEntryList{}
 			Expect(json.Unmarshal(rawResponse, entryList)).To(Succeed())
 
-			rootCtx, err := test_kumactl.MakeRootContext(time.Now(), nil)
-			Expect(err).ToNot(HaveOccurred())
-
+			rootCtx := test_kumactl.MakeMinimalRootContext()
 			rootCtx.Runtime.NewPolicyInspectClient = func(client util_http.Client) resources.PolicyInspectClient {
 				return &testPolicyInspectClient{
 					response: entryList,

--- a/pkg/plugins/policies/meshratelimit/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshratelimit/plugin/v1alpha1/plugin_test.go
@@ -139,6 +139,12 @@ var _ = Describe("MeshRateLimit", func() {
 													Value: "other-value",
 												},
 											},
+											Set: []api.HeaderKeyValue{
+												{
+													Name:  "x-kuma-rate-limit-header-set",
+													Value: "test-value",
+												},
+											},
 										},
 									},
 								},

--- a/pkg/plugins/policies/meshratelimit/plugin/v1alpha1/testdata/basic_listener_1.golden.yaml
+++ b/pkg/plugins/policies/meshratelimit/plugin/v1alpha1/testdata/basic_listener_1.golden.yaml
@@ -51,6 +51,10 @@ filterChains:
                   header:
                     key: x-kuma-rate-limit
                     value: other-value
+                - append: false
+                  header:
+                    key: x-kuma-rate-limit-header-set
+                    value: test-value
                 statPrefix: rate_limit
                 status:
                   code: 444

--- a/pkg/plugins/policies/meshratelimit/plugin/xds/configurer.go
+++ b/pkg/plugins/policies/meshratelimit/plugin/xds/configurer.go
@@ -38,15 +38,6 @@ func RateLimitConfigurationFromPolicy(rl *api.LocalHTTP) *rate_limit.RateLimitCo
 				onRateLimit.Headers = append(onRateLimit.Headers, &rate_limit.Headers{
 					Key:    string(header.Name),
 					Value:  val,
-					Append: true,
-				})
-			}
-		}
-		for _, header := range pointer.Deref(rl.OnRateLimit.Headers).Set {
-			for _, val := range strings.Split(string(header.Value), ",") {
-				onRateLimit.Headers = append(onRateLimit.Headers, &rate_limit.Headers{
-					Key:    string(header.Name),
-					Value:  val,
 					Append: false,
 				})
 			}

--- a/pkg/test/kumactl/context.go
+++ b/pkg/test/kumactl/context.go
@@ -22,10 +22,15 @@ var defaultNewBaseAPIServerClient = func(server *config_proto.ControlPlaneCoordi
 	return nil, nil
 }
 
+var rootTime, _ = time.Parse(time.RFC3339, "2008-04-27T16:05:36.995Z")
+
 func MakeMinimalRootContext() *kumactl_cmd.RootContext {
 	return &kumactl_cmd.RootContext{
 		Args: defaultArgs,
 		Runtime: kumactl_cmd.RootRuntime{
+			Now: func() time.Time {
+				return rootTime
+			},
 			Registry:               registry.NewTypeRegistry(),
 			NewAPIServerClient:     defaultNewAPIServerClient,
 			NewBaseAPIServerClient: defaultNewBaseAPIServerClient,


### PR DESCRIPTION
- [X] Link to docs PR or issue --
- [X] Link to UI issue or PR --
- [X] Is the [issue worked on linked][1]? --
- [X] The PR does not hardcode values that might break projects that depend on kuma (e.g. "kumahq" as a image registry) --
- [X] The PR will work for both Linux and Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [X] Unit Tests --
- [X] E2E Tests --
- [X] Manual Universal Tests --
- [X] Manual Kubernetes Tests --
- [X] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [X] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [X] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
