### PR TITLE
fix(kuma-cp): should set only once header for MeshRateLimit

### DIFF
--- a/pkg/plugins/policies/meshratelimit/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshratelimit/plugin/v1alpha1/plugin_test.go
@@ -139,6 +139,12 @@ var _ = Describe("MeshRateLimit", func() {
 													Value: "other-value",
 												},
 											},
+											Set: []api.HeaderKeyValue{
+												{
+													Name:  "x-kuma-rate-limit-header-set",
+													Value: "test-value",
+												},
+											},
 										},
 									},
 								},

--- a/pkg/plugins/policies/meshratelimit/plugin/v1alpha1/testdata/basic_listener_1.golden.yaml
+++ b/pkg/plugins/policies/meshratelimit/plugin/v1alpha1/testdata/basic_listener_1.golden.yaml
@@ -51,6 +51,10 @@ filterChains:
                   header:
                     key: x-kuma-rate-limit
                     value: other-value
+                - append: false
+                  header:
+                    key: x-kuma-rate-limit-header-set
+                    value: test-value
                 statPrefix: rate_limit
                 status:
                   code: 444

--- a/pkg/plugins/policies/meshratelimit/plugin/xds/configurer.go
+++ b/pkg/plugins/policies/meshratelimit/plugin/xds/configurer.go
@@ -38,15 +38,6 @@ func RateLimitConfigurationFromPolicy(rl *api.LocalHTTP) *rate_limit.RateLimitCo
 				onRateLimit.Headers = append(onRateLimit.Headers, &rate_limit.Headers{
 					Key:    string(header.Name),
 					Value:  val,
-					Append: true,
-				})
-			}
-		}
-		for _, header := range pointer.Deref(rl.OnRateLimit.Headers).Set {
-			for _, val := range strings.Split(string(header.Value), ",") {
-				onRateLimit.Headers = append(onRateLimit.Headers, &rate_limit.Headers{
-					Key:    string(header.Name),
-					Value:  val,
 					Append: false,
 				})
 			}


### PR DESCRIPTION

- [X] Link to docs PR or issue --
- [X] Link to UI issue or PR --
- [X] Is the [issue worked on linked][1]? --
- [X] The PR does not hardcode values that might break projects that depend on kuma (e.g. "kumahq" as a image registry) --
- [X] The PR will work for both Linux and Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [X] Unit Tests --
- [X] E2E Tests --
- [X] Manual Universal Tests --
- [X] Manual Kubernetes Tests --
- [X] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [X] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [X] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
