### PR TITLE
fix(kuma-cp): meshratelimit doesn't support MeshGatewayRoute

### DIFF
--- a/pkg/plugins/policies/meshratelimit/api/v1alpha1/validator.go
+++ b/pkg/plugins/policies/meshratelimit/api/v1alpha1/validator.go
@@ -6,7 +6,6 @@ import (
 	common_api "github.com/kumahq/kuma/api/common/v1alpha1"
 	"github.com/kumahq/kuma/pkg/core/validators"
 	matcher_validators "github.com/kumahq/kuma/pkg/plugins/policies/matchers/validators"
-	"github.com/kumahq/kuma/pkg/util/pointer"
 )
 
 func (r *MeshRateLimitResource) validate() error {
@@ -105,8 +104,4 @@ func validateRate(path validators.PathBuilder, rate *Rate) validators.Validation
 	verr.Add(validators.ValidateIntegerGreaterThan(path.Field("num"), rate.Num, 0))
 	verr.Add(validators.ValidateDurationGreaterThan(path.Field("interval"), &rate.Interval, 50*time.Millisecond))
 	return verr
-}
-
-func isTcp(conf Conf) bool {
-	return pointer.Deref(conf.Local).TCP != nil
 }

--- a/pkg/plugins/policies/meshratelimit/api/v1alpha1/validator_test.go
+++ b/pkg/plugins/policies/meshratelimit/api/v1alpha1/validator_test.go
@@ -273,6 +273,8 @@ from:
           interval: 500ms`,
 				expected: `
 violations:
+  - field: spec.targetRef.kind
+    message: value is not supported
   - field: spec.from[0].targetRef.kind
     message: value is not supported`}),
 			Entry("empty default", testCase{
@@ -286,6 +288,8 @@ from:
   default: {}`,
 				expected: `
 violations:
+  - field: spec.targetRef.kind
+    message: value is not supported
   - field: spec.from[0].default.local
     message: must be defined`}),
 			Entry("neither tcp or http defined", testCase{
@@ -300,6 +304,8 @@ from:
     local: {}`,
 				expected: `
 violations:
+  - field: spec.targetRef.kind
+    message: value is not supported
   - field: spec.from[0].default.local
     message: 'must have at least one defined: tcp, http'`}),
 			Entry("empty tcp", testCase{


### PR DESCRIPTION
- [X] Link to docs PR or issue --
- [X] Link to UI issue or PR --
- [X] Is the [issue worked on linked][1]? -- Fix: #5864
- [X] The PR does not hardcode values that might break projects that depend on kuma (e.g. "kumahq" as a image registry) --
- [X] The PR will work for both Linux and Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [X] Unit Tests --
- [X] E2E Tests --
- [X] Manual Universal Tests --
- [X] Manual Kubernetes Tests --
- [X] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [X] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [X] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
