### PR TITLE
fix(kuma-cp): configure split clusters for new policies

### DIFF
--- a/pkg/plugins/policies/meshcircuitbreaker/plugin/v1alpha1/plugin.go
+++ b/pkg/plugins/policies/meshcircuitbreaker/plugin/v1alpha1/plugin.go
@@ -92,7 +92,7 @@ func applyToOutbounds(
 ) error {
 	targetedClusters := policies_xds.GatherTargetedClusters(dataplane.Spec.Networking.GetOutbound(), outboundSplitClusters, outboundClusters)
 
-	for cluster, serviceName := range *targetedClusters {
+	for cluster, serviceName := range targetedClusters {
 		if err := configure(rules.Rules, core_xds.MeshService(serviceName), cluster); err != nil {
 			return err
 		}

--- a/pkg/plugins/policies/meshcircuitbreaker/plugin/v1alpha1/testdata/outbound_split_cluster_0_connection_limits_outlier_detection.golden.yaml
+++ b/pkg/plugins/policies/meshcircuitbreaker/plugin/v1alpha1/testdata/outbound_split_cluster_0_connection_limits_outlier_detection.golden.yaml
@@ -1,0 +1,29 @@
+circuitBreakers:
+  thresholds:
+  - maxConnectionPools: 1111
+    maxConnections: 2222
+    maxPendingRequests: 3333
+    maxRequests: 4444
+    maxRetries: 5555
+name: other-service-_0_
+outlierDetection:
+  baseEjectionTime: 8s
+  consecutive5xx: 12
+  consecutiveGatewayFailure: 91
+  consecutiveLocalOriginFailure: 3
+  enforcingConsecutive5xx: 100
+  enforcingConsecutiveGatewayFailure: 100
+  enforcingConsecutiveLocalOriginFailure: 100
+  enforcingFailurePercentage: 100
+  enforcingFailurePercentageLocalOrigin: 100
+  enforcingLocalOriginSuccessRate: 100
+  enforcingSuccessRate: 100
+  failurePercentageMinimumHosts: 32
+  failurePercentageRequestVolume: 182
+  failurePercentageThreshold: 80
+  interval: 10s
+  maxEjectionPercent: 88
+  splitExternalLocalOriginErrors: true
+  successRateMinimumHosts: 33
+  successRateRequestVolume: 99
+  successRateStdevFactor: 1900

--- a/pkg/plugins/policies/meshcircuitbreaker/plugin/v1alpha1/testdata/outbound_split_cluster_connection_limits_outlier_detection.golden.yaml
+++ b/pkg/plugins/policies/meshcircuitbreaker/plugin/v1alpha1/testdata/outbound_split_cluster_connection_limits_outlier_detection.golden.yaml
@@ -1,0 +1,29 @@
+circuitBreakers:
+  thresholds:
+  - maxConnectionPools: 1111
+    maxConnections: 2222
+    maxPendingRequests: 3333
+    maxRequests: 4444
+    maxRetries: 5555
+name: other-service
+outlierDetection:
+  baseEjectionTime: 8s
+  consecutive5xx: 12
+  consecutiveGatewayFailure: 91
+  consecutiveLocalOriginFailure: 3
+  enforcingConsecutive5xx: 100
+  enforcingConsecutiveGatewayFailure: 100
+  enforcingConsecutiveLocalOriginFailure: 100
+  enforcingFailurePercentage: 100
+  enforcingFailurePercentageLocalOrigin: 100
+  enforcingLocalOriginSuccessRate: 100
+  enforcingSuccessRate: 100
+  failurePercentageMinimumHosts: 32
+  failurePercentageRequestVolume: 182
+  failurePercentageThreshold: 80
+  interval: 10s
+  maxEjectionPercent: 88
+  splitExternalLocalOriginErrors: true
+  successRateMinimumHosts: 33
+  successRateRequestVolume: 99
+  successRateStdevFactor: 1900

--- a/pkg/plugins/policies/meshhealthcheck/plugin/v1alpha1/plugin.go
+++ b/pkg/plugins/policies/meshhealthcheck/plugin/v1alpha1/plugin.go
@@ -3,7 +3,6 @@ package v1alpha1
 import (
 	envoy_cluster "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
 
-	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	core_plugins "github.com/kumahq/kuma/pkg/core/plugins"
 	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	core_xds "github.com/kumahq/kuma/pkg/core/xds"
@@ -43,20 +42,9 @@ func (p plugin) Apply(rs *core_xds.ResourceSet, _ xds_context.Context, proxy *co
 }
 
 func applyToOutbounds(rules core_xds.ToRules, outboundClusters map[string]*envoy_cluster.Cluster, outboundSplitClusters map[string][]*envoy_cluster.Cluster, dataplane *core_mesh.DataplaneResource, routing core_xds.Routing) error {
-	targetedClusters := map[*envoy_cluster.Cluster]string{}
-	for _, outbound := range dataplane.Spec.Networking.GetOutbound() {
-		serviceName := outbound.GetTagsIncludingLegacy()[mesh_proto.ServiceTag]
-		for _, splitCluster := range outboundSplitClusters[serviceName] {
-			targetedClusters[splitCluster] = serviceName
-		}
+	targetedClusters := policies_xds.GatherTargetedClusters(dataplane.Spec.Networking.GetOutbound(), outboundSplitClusters, outboundClusters)
 
-		cluster, ok := outboundClusters[serviceName]
-		if ok {
-			targetedClusters[cluster] = serviceName
-		}
-	}
-
-	for cluster, serviceName := range targetedClusters {
+	for cluster, serviceName := range *targetedClusters {
 		protocol := policies_xds.InferProtocol(routing, serviceName)
 
 		if err := configure(dataplane, rules.Rules, core_xds.MeshService(serviceName), protocol, cluster); err != nil {

--- a/pkg/plugins/policies/meshhealthcheck/plugin/v1alpha1/plugin.go
+++ b/pkg/plugins/policies/meshhealthcheck/plugin/v1alpha1/plugin.go
@@ -44,7 +44,7 @@ func (p plugin) Apply(rs *core_xds.ResourceSet, _ xds_context.Context, proxy *co
 func applyToOutbounds(rules core_xds.ToRules, outboundClusters map[string]*envoy_cluster.Cluster, outboundSplitClusters map[string][]*envoy_cluster.Cluster, dataplane *core_mesh.DataplaneResource, routing core_xds.Routing) error {
 	targetedClusters := policies_xds.GatherTargetedClusters(dataplane.Spec.Networking.GetOutbound(), outboundSplitClusters, outboundClusters)
 
-	for cluster, serviceName := range *targetedClusters {
+	for cluster, serviceName := range targetedClusters {
 		protocol := policies_xds.InferProtocol(routing, serviceName)
 
 		if err := configure(dataplane, rules.Rules, core_xds.MeshService(serviceName), protocol, cluster); err != nil {

--- a/pkg/plugins/policies/meshhealthcheck/plugin/v1alpha1/testdata/basic_grpc_health_check_cluster.golden.yaml
+++ b/pkg/plugins/policies/meshhealthcheck/plugin/v1alpha1/testdata/basic_grpc_health_check_cluster.golden.yaml
@@ -1,0 +1,9 @@
+healthChecks:
+- grpcHealthCheck:
+    authority: grpc-client.default.svc.cluster.local
+    serviceName: grpc-client
+  healthyThreshold: 1
+  interval: 10s
+  timeout: 2s
+  unhealthyThreshold: 3
+name: echo-grpc

--- a/pkg/plugins/policies/meshhealthcheck/plugin/v1alpha1/testdata/basic_http_health_check_cluster.golden.yaml
+++ b/pkg/plugins/policies/meshhealthcheck/plugin/v1alpha1/testdata/basic_http_health_check_cluster.golden.yaml
@@ -1,0 +1,36 @@
+commonLbConfig:
+  healthyPanicThreshold:
+    value: 62.9
+  zoneAwareLbConfig:
+    failTrafficOnPanic: true
+healthChecks:
+- eventLogPath: /tmp/log.txt
+  healthyThreshold: 1
+  httpHealthCheck:
+    expectedStatuses:
+    - end: "201"
+      start: "200"
+    - end: "202"
+      start: "201"
+    path: /health
+    requestHeadersToAdd:
+    - header:
+        key: x-kuma-tags
+        value: '&kuma.io/service=backend&'
+    - append: true
+      header:
+        key: x-some-header
+        value: value
+    - append: false
+      header:
+        key: x-some-other-header
+        value: value
+  initialJitter: 13s
+  interval: 10s
+  intervalJitter: 15s
+  intervalJitterPercent: 10
+  noTrafficInterval: 16s
+  reuseConnection: true
+  timeout: 2s
+  unhealthyThreshold: 3
+name: echo-http

--- a/pkg/plugins/policies/meshhealthcheck/plugin/v1alpha1/testdata/basic_http_health_check_split_cluster.golden.yaml
+++ b/pkg/plugins/policies/meshhealthcheck/plugin/v1alpha1/testdata/basic_http_health_check_split_cluster.golden.yaml
@@ -1,0 +1,36 @@
+commonLbConfig:
+  healthyPanicThreshold:
+    value: 62.9
+  zoneAwareLbConfig:
+    failTrafficOnPanic: true
+healthChecks:
+- eventLogPath: /tmp/log.txt
+  healthyThreshold: 1
+  httpHealthCheck:
+    expectedStatuses:
+    - end: "201"
+      start: "200"
+    - end: "202"
+      start: "201"
+    path: /health
+    requestHeadersToAdd:
+    - header:
+        key: x-kuma-tags
+        value: '&kuma.io/service=backend&'
+    - append: true
+      header:
+        key: x-some-header
+        value: value
+    - append: false
+      header:
+        key: x-some-other-header
+        value: value
+  initialJitter: 13s
+  interval: 10s
+  intervalJitter: 15s
+  intervalJitterPercent: 10
+  noTrafficInterval: 16s
+  reuseConnection: true
+  timeout: 2s
+  unhealthyThreshold: 3
+name: echo-http-_0_

--- a/pkg/plugins/policies/meshhealthcheck/plugin/v1alpha1/testdata/basic_tcp_health_check_cluster.golden.yaml
+++ b/pkg/plugins/policies/meshhealthcheck/plugin/v1alpha1/testdata/basic_tcp_health_check_cluster.golden.yaml
@@ -1,0 +1,11 @@
+healthChecks:
+- healthyThreshold: 1
+  interval: 10s
+  tcpHealthCheck:
+    receive:
+    - text: 634739755a776f3d
+    send:
+      text: 63476c755a776f3d
+  timeout: 2s
+  unhealthyThreshold: 3
+name: echo-tcp

--- a/pkg/plugins/policies/meshtimeout/plugin/testdata/http_outbound_split_cluster.golden.yaml
+++ b/pkg/plugins/policies/meshtimeout/plugin/testdata/http_outbound_split_cluster.golden.yaml
@@ -1,0 +1,9 @@
+connectTimeout: 10s
+name: other-service-_0_
+typedExtensionProtocolOptions:
+  envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+    '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+    commonHttpProtocolOptions:
+      idleTimeout: 3600s
+      maxConnectionDuration: 600s
+      maxStreamDuration: 600s

--- a/pkg/plugins/policies/xds/clusters.go
+++ b/pkg/plugins/policies/xds/clusters.go
@@ -61,7 +61,7 @@ func GatherTargetedClusters(
 	outbounds []*mesh_proto.Dataplane_Networking_Outbound,
 	outboundSplitClusters map[string][]*envoy_cluster.Cluster,
 	outboundClusters map[string]*envoy_cluster.Cluster,
-) *map[*envoy_cluster.Cluster]string {
+) map[*envoy_cluster.Cluster]string {
 	targetedClusters := map[*envoy_cluster.Cluster]string{}
 	for _, outbound := range outbounds {
 		serviceName := outbound.GetTagsIncludingLegacy()[mesh_proto.ServiceTag]
@@ -75,7 +75,7 @@ func GatherTargetedClusters(
 		}
 	}
 
-	return &targetedClusters
+	return targetedClusters
 }
 
 func InferProtocol(routing core_xds.Routing, serviceName string) core_mesh.Protocol {

--- a/test/e2e_env/universal/universal_suite_test.go
+++ b/test/e2e_env/universal/universal_suite_test.go
@@ -6,7 +6,38 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 
 	"github.com/kumahq/kuma/pkg/test"
+	"github.com/kumahq/kuma/test/e2e_env/universal/api"
+	"github.com/kumahq/kuma/test/e2e_env/universal/auth"
+	"github.com/kumahq/kuma/test/e2e_env/universal/compatibility"
+	"github.com/kumahq/kuma/test/e2e_env/universal/externalservices"
+	"github.com/kumahq/kuma/test/e2e_env/universal/gateway"
+	"github.com/kumahq/kuma/test/e2e_env/universal/grpc"
+	"github.com/kumahq/kuma/test/e2e_env/universal/healthcheck"
+	"github.com/kumahq/kuma/test/e2e_env/universal/inspect"
+	"github.com/kumahq/kuma/test/e2e_env/universal/matching"
+	"github.com/kumahq/kuma/test/e2e_env/universal/membership"
+	"github.com/kumahq/kuma/test/e2e_env/universal/meshaccesslog"
+	"github.com/kumahq/kuma/test/e2e_env/universal/meshfaultinjection"
 	"github.com/kumahq/kuma/test/e2e_env/universal/meshhealthcheck"
+	"github.com/kumahq/kuma/test/e2e_env/universal/meshproxypatch"
+	"github.com/kumahq/kuma/test/e2e_env/universal/meshratelimit"
+	"github.com/kumahq/kuma/test/e2e_env/universal/meshretry"
+	"github.com/kumahq/kuma/test/e2e_env/universal/meshtrafficpermission"
+	"github.com/kumahq/kuma/test/e2e_env/universal/mtls"
+	"github.com/kumahq/kuma/test/e2e_env/universal/observability"
+	"github.com/kumahq/kuma/test/e2e_env/universal/projectedsatoken"
+	"github.com/kumahq/kuma/test/e2e_env/universal/proxytemplate"
+	"github.com/kumahq/kuma/test/e2e_env/universal/ratelimit"
+	"github.com/kumahq/kuma/test/e2e_env/universal/reachableservices"
+	"github.com/kumahq/kuma/test/e2e_env/universal/resilience"
+	"github.com/kumahq/kuma/test/e2e_env/universal/retry"
+	"github.com/kumahq/kuma/test/e2e_env/universal/timeout"
+	"github.com/kumahq/kuma/test/e2e_env/universal/trafficlog"
+	"github.com/kumahq/kuma/test/e2e_env/universal/trafficpermission"
+	"github.com/kumahq/kuma/test/e2e_env/universal/trafficroute"
+	"github.com/kumahq/kuma/test/e2e_env/universal/transparentproxy"
+	"github.com/kumahq/kuma/test/e2e_env/universal/virtualoutbound"
+	"github.com/kumahq/kuma/test/e2e_env/universal/zoneegress"
 	"github.com/kumahq/kuma/test/framework/envs/universal"
 )
 
@@ -16,47 +47,46 @@ func TestE2E(t *testing.T) {
 
 var _ = SynchronizedBeforeSuite(universal.SetupAndGetState, universal.RestoreState)
 
-// var _ = Describe("User Auth", auth.UserAuth)
-// var _ = Describe("DP Auth", auth.DpAuth, Ordered)
-// var _ = Describe("Gateway", gateway.Gateway, Ordered)
-// var _ = Describe("Gateway - Cross-mesh", gateway.CrossMeshGatewayOnUniversal, Ordered)
-// var _ = Describe("HealthCheck panic threshold", healthcheck.HealthCheckPanicThreshold, Ordered)
-// var _ = Describe("HealthCheck", healthcheck.Policy)
-// var _ = Describe("MeshHealthCheck panic threshold", meshhealthcheck.MeshHealthCheckPanicThreshold, Ordered)
+var _ = Describe("User Auth", auth.UserAuth)
+var _ = Describe("DP Auth", auth.DpAuth, Ordered)
+var _ = Describe("Gateway", gateway.Gateway, Ordered)
+var _ = Describe("Gateway - Cross-mesh", gateway.CrossMeshGatewayOnUniversal, Ordered)
+var _ = Describe("HealthCheck panic threshold", healthcheck.HealthCheckPanicThreshold, Ordered)
+var _ = Describe("HealthCheck", healthcheck.Policy)
+var _ = Describe("MeshHealthCheck panic threshold", meshhealthcheck.MeshHealthCheckPanicThreshold, Ordered)
 var _ = Describe("MeshHealthCheck", meshhealthcheck.MeshHealthCheck)
-
-// var _ = Describe("Service Probes", healthcheck.ServiceProbes, Ordered)
-// var _ = Describe("External Services", externalservices.Policy, Ordered)
-// var _ = Describe("External Services through Zone Egress", externalservices.ThroughZoneEgress, Ordered)
-// var _ = Describe("Inspect", inspect.Inspect, Ordered)
-// var _ = Describe("Applications Metrics", observability.ApplicationsMetrics, Ordered)
-// var _ = Describe("Tracing", observability.Tracing, Ordered)
-// var _ = Describe("MeshTrace", observability.PluginTest, Ordered)
-// var _ = Describe("Membership", membership.Membership, Ordered)
-// var _ = Describe("Traffic Logging", trafficlog.TCPLogging, Ordered)
-// var _ = Describe("MeshAccessLog", meshaccesslog.TestPlugin, Ordered)
-// var _ = Describe("Timeout", timeout.Policy, Ordered)
-// var _ = Describe("Retry", retry.Policy, Ordered)
-// var _ = Describe("MeshRetry", meshretry.HttpRetry, Ordered)
-// var _ = Describe("MeshRetry", meshretry.GrpcRetry, Ordered)
-// var _ = Describe("RateLimit", ratelimit.Policy, Ordered)
-// var _ = Describe("ProxyTemplate", proxytemplate.ProxyTemplate, Ordered)
-// var _ = Describe("MeshProxyPatch", meshproxypatch.MeshProxyPatch, Ordered)
-// var _ = Describe("Matching", matching.Matching, Ordered)
-// var _ = Describe("Mtls", mtls.Policy, Ordered)
-// var _ = Describe("Reachable Services", reachableservices.ReachableServices, Ordered)
-// var _ = Describe("Apis", api.Api, Ordered)
-// var _ = Describe("Traffic Permission", trafficpermission.TrafficPermissionUniversal, Ordered)
-// var _ = Describe("Traffic Route", trafficroute.TrafficRoute, Ordered)
-// var _ = Describe("Zone Egress", zoneegress.ExternalServices, Ordered)
-// var _ = Describe("Virtual Outbound", virtualoutbound.VirtualOutbound, Ordered)
-// var _ = Describe("Transparent Proxy", transparentproxy.TransparentProxy, Ordered)
-// var _ = Describe("Mesh Traffic Permission", meshtrafficpermission.MeshTrafficPermissionUniversal, Ordered)
-// var _ = Describe("GRPC", grpc.GRPC, Ordered)
-// var _ = Describe("MeshRateLimit", meshratelimit.Policy, Ordered)
-// var _ = Describe("MeshTimeout", timeout.PluginTest, Ordered)
-// var _ = Describe("Projected Service Account Token", projectedsatoken.ProjectedServiceAccountToken, Ordered)
-// var _ = Describe("Compatibility", compatibility.UniversalCompatibility, Label("arm-not-supported"), Ordered)
-// var _ = Describe("Resilience", resilience.ResilienceStandaloneUniversal, Ordered)
-// var _ = Describe("Leader Election", resilience.LeaderElectionPostgres, Ordered)
-// var _ = Describe("MeshFaultInjection", meshfaultinjection.Policy, Ordered)
+var _ = Describe("Service Probes", healthcheck.ServiceProbes, Ordered)
+var _ = Describe("External Services", externalservices.Policy, Ordered)
+var _ = Describe("External Services through Zone Egress", externalservices.ThroughZoneEgress, Ordered)
+var _ = Describe("Inspect", inspect.Inspect, Ordered)
+var _ = Describe("Applications Metrics", observability.ApplicationsMetrics, Ordered)
+var _ = Describe("Tracing", observability.Tracing, Ordered)
+var _ = Describe("MeshTrace", observability.PluginTest, Ordered)
+var _ = Describe("Membership", membership.Membership, Ordered)
+var _ = Describe("Traffic Logging", trafficlog.TCPLogging, Ordered)
+var _ = Describe("MeshAccessLog", meshaccesslog.TestPlugin, Ordered)
+var _ = Describe("Timeout", timeout.Policy, Ordered)
+var _ = Describe("Retry", retry.Policy, Ordered)
+var _ = Describe("MeshRetry", meshretry.HttpRetry, Ordered)
+var _ = Describe("MeshRetry", meshretry.GrpcRetry, Ordered)
+var _ = Describe("RateLimit", ratelimit.Policy, Ordered)
+var _ = Describe("ProxyTemplate", proxytemplate.ProxyTemplate, Ordered)
+var _ = Describe("MeshProxyPatch", meshproxypatch.MeshProxyPatch, Ordered)
+var _ = Describe("Matching", matching.Matching, Ordered)
+var _ = Describe("Mtls", mtls.Policy, Ordered)
+var _ = Describe("Reachable Services", reachableservices.ReachableServices, Ordered)
+var _ = Describe("Apis", api.Api, Ordered)
+var _ = Describe("Traffic Permission", trafficpermission.TrafficPermissionUniversal, Ordered)
+var _ = Describe("Traffic Route", trafficroute.TrafficRoute, Ordered)
+var _ = Describe("Zone Egress", zoneegress.ExternalServices, Ordered)
+var _ = Describe("Virtual Outbound", virtualoutbound.VirtualOutbound, Ordered)
+var _ = Describe("Transparent Proxy", transparentproxy.TransparentProxy, Ordered)
+var _ = Describe("Mesh Traffic Permission", meshtrafficpermission.MeshTrafficPermissionUniversal, Ordered)
+var _ = Describe("GRPC", grpc.GRPC, Ordered)
+var _ = Describe("MeshRateLimit", meshratelimit.Policy, Ordered)
+var _ = Describe("MeshTimeout", timeout.PluginTest, Ordered)
+var _ = Describe("Projected Service Account Token", projectedsatoken.ProjectedServiceAccountToken, Ordered)
+var _ = Describe("Compatibility", compatibility.UniversalCompatibility, Label("arm-not-supported"), Ordered)
+var _ = Describe("Resilience", resilience.ResilienceStandaloneUniversal, Ordered)
+var _ = Describe("Leader Election", resilience.LeaderElectionPostgres, Ordered)
+var _ = Describe("MeshFaultInjection", meshfaultinjection.Policy, Ordered)

--- a/test/e2e_env/universal/universal_suite_test.go
+++ b/test/e2e_env/universal/universal_suite_test.go
@@ -6,38 +6,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 
 	"github.com/kumahq/kuma/pkg/test"
-	"github.com/kumahq/kuma/test/e2e_env/universal/api"
-	"github.com/kumahq/kuma/test/e2e_env/universal/auth"
-	"github.com/kumahq/kuma/test/e2e_env/universal/compatibility"
-	"github.com/kumahq/kuma/test/e2e_env/universal/externalservices"
-	"github.com/kumahq/kuma/test/e2e_env/universal/gateway"
-	"github.com/kumahq/kuma/test/e2e_env/universal/grpc"
-	"github.com/kumahq/kuma/test/e2e_env/universal/healthcheck"
-	"github.com/kumahq/kuma/test/e2e_env/universal/inspect"
-	"github.com/kumahq/kuma/test/e2e_env/universal/matching"
-	"github.com/kumahq/kuma/test/e2e_env/universal/membership"
-	"github.com/kumahq/kuma/test/e2e_env/universal/meshaccesslog"
-	"github.com/kumahq/kuma/test/e2e_env/universal/meshfaultinjection"
 	"github.com/kumahq/kuma/test/e2e_env/universal/meshhealthcheck"
-	"github.com/kumahq/kuma/test/e2e_env/universal/meshproxypatch"
-	"github.com/kumahq/kuma/test/e2e_env/universal/meshratelimit"
-	"github.com/kumahq/kuma/test/e2e_env/universal/meshretry"
-	"github.com/kumahq/kuma/test/e2e_env/universal/meshtrafficpermission"
-	"github.com/kumahq/kuma/test/e2e_env/universal/mtls"
-	"github.com/kumahq/kuma/test/e2e_env/universal/observability"
-	"github.com/kumahq/kuma/test/e2e_env/universal/projectedsatoken"
-	"github.com/kumahq/kuma/test/e2e_env/universal/proxytemplate"
-	"github.com/kumahq/kuma/test/e2e_env/universal/ratelimit"
-	"github.com/kumahq/kuma/test/e2e_env/universal/reachableservices"
-	"github.com/kumahq/kuma/test/e2e_env/universal/resilience"
-	"github.com/kumahq/kuma/test/e2e_env/universal/retry"
-	"github.com/kumahq/kuma/test/e2e_env/universal/timeout"
-	"github.com/kumahq/kuma/test/e2e_env/universal/trafficlog"
-	"github.com/kumahq/kuma/test/e2e_env/universal/trafficpermission"
-	"github.com/kumahq/kuma/test/e2e_env/universal/trafficroute"
-	"github.com/kumahq/kuma/test/e2e_env/universal/transparentproxy"
-	"github.com/kumahq/kuma/test/e2e_env/universal/virtualoutbound"
-	"github.com/kumahq/kuma/test/e2e_env/universal/zoneegress"
 	"github.com/kumahq/kuma/test/framework/envs/universal"
 )
 
@@ -47,46 +16,47 @@ func TestE2E(t *testing.T) {
 
 var _ = SynchronizedBeforeSuite(universal.SetupAndGetState, universal.RestoreState)
 
-var _ = Describe("User Auth", auth.UserAuth)
-var _ = Describe("DP Auth", auth.DpAuth, Ordered)
-var _ = Describe("Gateway", gateway.Gateway, Ordered)
-var _ = Describe("Gateway - Cross-mesh", gateway.CrossMeshGatewayOnUniversal, Ordered)
-var _ = Describe("HealthCheck panic threshold", healthcheck.HealthCheckPanicThreshold, Ordered)
-var _ = Describe("HealthCheck", healthcheck.Policy)
-var _ = Describe("MeshHealthCheck panic threshold", meshhealthcheck.MeshHealthCheckPanicThreshold, Ordered)
+// var _ = Describe("User Auth", auth.UserAuth)
+// var _ = Describe("DP Auth", auth.DpAuth, Ordered)
+// var _ = Describe("Gateway", gateway.Gateway, Ordered)
+// var _ = Describe("Gateway - Cross-mesh", gateway.CrossMeshGatewayOnUniversal, Ordered)
+// var _ = Describe("HealthCheck panic threshold", healthcheck.HealthCheckPanicThreshold, Ordered)
+// var _ = Describe("HealthCheck", healthcheck.Policy)
+// var _ = Describe("MeshHealthCheck panic threshold", meshhealthcheck.MeshHealthCheckPanicThreshold, Ordered)
 var _ = Describe("MeshHealthCheck", meshhealthcheck.MeshHealthCheck)
-var _ = Describe("Service Probes", healthcheck.ServiceProbes, Ordered)
-var _ = Describe("External Services", externalservices.Policy, Ordered)
-var _ = Describe("External Services through Zone Egress", externalservices.ThroughZoneEgress, Ordered)
-var _ = Describe("Inspect", inspect.Inspect, Ordered)
-var _ = Describe("Applications Metrics", observability.ApplicationsMetrics, Ordered)
-var _ = Describe("Tracing", observability.Tracing, Ordered)
-var _ = Describe("MeshTrace", observability.PluginTest, Ordered)
-var _ = Describe("Membership", membership.Membership, Ordered)
-var _ = Describe("Traffic Logging", trafficlog.TCPLogging, Ordered)
-var _ = Describe("MeshAccessLog", meshaccesslog.TestPlugin, Ordered)
-var _ = Describe("Timeout", timeout.Policy, Ordered)
-var _ = Describe("Retry", retry.Policy, Ordered)
-var _ = Describe("MeshRetry", meshretry.HttpRetry, Ordered)
-var _ = Describe("MeshRetry", meshretry.GrpcRetry, Ordered)
-var _ = Describe("RateLimit", ratelimit.Policy, Ordered)
-var _ = Describe("ProxyTemplate", proxytemplate.ProxyTemplate, Ordered)
-var _ = Describe("MeshProxyPatch", meshproxypatch.MeshProxyPatch, Ordered)
-var _ = Describe("Matching", matching.Matching, Ordered)
-var _ = Describe("Mtls", mtls.Policy, Ordered)
-var _ = Describe("Reachable Services", reachableservices.ReachableServices, Ordered)
-var _ = Describe("Apis", api.Api, Ordered)
-var _ = Describe("Traffic Permission", trafficpermission.TrafficPermissionUniversal, Ordered)
-var _ = Describe("Traffic Route", trafficroute.TrafficRoute, Ordered)
-var _ = Describe("Zone Egress", zoneegress.ExternalServices, Ordered)
-var _ = Describe("Virtual Outbound", virtualoutbound.VirtualOutbound, Ordered)
-var _ = Describe("Transparent Proxy", transparentproxy.TransparentProxy, Ordered)
-var _ = Describe("Mesh Traffic Permission", meshtrafficpermission.MeshTrafficPermissionUniversal, Ordered)
-var _ = Describe("GRPC", grpc.GRPC, Ordered)
-var _ = Describe("MeshRateLimit", meshratelimit.Policy, Ordered)
-var _ = Describe("MeshTimeout", timeout.PluginTest, Ordered)
-var _ = Describe("Projected Service Account Token", projectedsatoken.ProjectedServiceAccountToken, Ordered)
-var _ = Describe("Compatibility", compatibility.UniversalCompatibility, Label("arm-not-supported"), Ordered)
-var _ = Describe("Resilience", resilience.ResilienceStandaloneUniversal, Ordered)
-var _ = Describe("Leader Election", resilience.LeaderElectionPostgres, Ordered)
-var _ = Describe("MeshFaultInjection", meshfaultinjection.Policy, Ordered)
+
+// var _ = Describe("Service Probes", healthcheck.ServiceProbes, Ordered)
+// var _ = Describe("External Services", externalservices.Policy, Ordered)
+// var _ = Describe("External Services through Zone Egress", externalservices.ThroughZoneEgress, Ordered)
+// var _ = Describe("Inspect", inspect.Inspect, Ordered)
+// var _ = Describe("Applications Metrics", observability.ApplicationsMetrics, Ordered)
+// var _ = Describe("Tracing", observability.Tracing, Ordered)
+// var _ = Describe("MeshTrace", observability.PluginTest, Ordered)
+// var _ = Describe("Membership", membership.Membership, Ordered)
+// var _ = Describe("Traffic Logging", trafficlog.TCPLogging, Ordered)
+// var _ = Describe("MeshAccessLog", meshaccesslog.TestPlugin, Ordered)
+// var _ = Describe("Timeout", timeout.Policy, Ordered)
+// var _ = Describe("Retry", retry.Policy, Ordered)
+// var _ = Describe("MeshRetry", meshretry.HttpRetry, Ordered)
+// var _ = Describe("MeshRetry", meshretry.GrpcRetry, Ordered)
+// var _ = Describe("RateLimit", ratelimit.Policy, Ordered)
+// var _ = Describe("ProxyTemplate", proxytemplate.ProxyTemplate, Ordered)
+// var _ = Describe("MeshProxyPatch", meshproxypatch.MeshProxyPatch, Ordered)
+// var _ = Describe("Matching", matching.Matching, Ordered)
+// var _ = Describe("Mtls", mtls.Policy, Ordered)
+// var _ = Describe("Reachable Services", reachableservices.ReachableServices, Ordered)
+// var _ = Describe("Apis", api.Api, Ordered)
+// var _ = Describe("Traffic Permission", trafficpermission.TrafficPermissionUniversal, Ordered)
+// var _ = Describe("Traffic Route", trafficroute.TrafficRoute, Ordered)
+// var _ = Describe("Zone Egress", zoneegress.ExternalServices, Ordered)
+// var _ = Describe("Virtual Outbound", virtualoutbound.VirtualOutbound, Ordered)
+// var _ = Describe("Transparent Proxy", transparentproxy.TransparentProxy, Ordered)
+// var _ = Describe("Mesh Traffic Permission", meshtrafficpermission.MeshTrafficPermissionUniversal, Ordered)
+// var _ = Describe("GRPC", grpc.GRPC, Ordered)
+// var _ = Describe("MeshRateLimit", meshratelimit.Policy, Ordered)
+// var _ = Describe("MeshTimeout", timeout.PluginTest, Ordered)
+// var _ = Describe("Projected Service Account Token", projectedsatoken.ProjectedServiceAccountToken, Ordered)
+// var _ = Describe("Compatibility", compatibility.UniversalCompatibility, Label("arm-not-supported"), Ordered)
+// var _ = Describe("Resilience", resilience.ResilienceStandaloneUniversal, Ordered)
+// var _ = Describe("Leader Election", resilience.LeaderElectionPostgres, Ordered)
+// var _ = Describe("MeshFaultInjection", meshfaultinjection.Policy, Ordered)


### PR DESCRIPTION
New policies are not applied for split clusters because names are not matching a service name. Added change to group split clusters by service name.
- [X] Link to docs PR or issue --
- [X] Link to UI issue or PR --
- [X] Is the [issue worked on linked][1]? --
- [X] The PR does not hardcode values that might break projects that depend on kuma (e.g. "kumahq" as a image registry) --
- [X] The PR will work for both Linux and Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [X] Unit Tests --
- [X] E2E Tests --
- [X] Manual Universal Tests --
- [X] Manual Kubernetes Tests --
- [X] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [X] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [X] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
