### PR TITLE
ci: use "ref_name" instead of "refName" in GH action

### DIFF
--- a/.github/workflows/pr-merged.yaml
+++ b/.github/workflows/pr-merged.yaml
@@ -27,7 +27,7 @@ jobs:
               pr = context.payload.pull_request.number;
             } else if (context.eventName == "push") {
               const versionRegex = /v?(\d+)\.(\d+)\.\d+/;
-              const versionMatch = context.github.refName.match(versionRegex);
+              const versionMatch = context.github.ref_name.match(versionRegex);
               if (!versionMatch) {
                 return;
               }


### PR DESCRIPTION
Signed-off-by: Ilya Lobkov <ilya.lobkov@konghq.com>

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [X] Link to docs PR or issue --
- [X] Link to UI issue or PR --
- [X] Is the [issue worked on linked][1]? --
- [X] The PR does not hardcode values that might break projects that depend on kuma (e.g. "kumahq" as a image registry) --
- [X] The PR will work for both Linux and Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [X] Unit Tests --
- [X] E2E Tests --
- [X] Manual Universal Tests --
- [X] Manual Kubernetes Tests --
- [X] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [X] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? -- Yes
- [X] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
