### PR TITLE
ci(commitlint): disallow scope `policies` and empty scopes

### DIFF
--- a/.github/commitlint.config.js
+++ b/.github/commitlint.config.js
@@ -9,7 +9,8 @@ module.exports = {
     "header-max-length": [0],
     // Disable some common mistyped scopes and some that should be used
     "scope-enum": [2, "never", [
-      "kumacp", "kumadp", "kumacni", "kumainit", "*", "madr", "test", "ci", "perf"
-    ]]
+      "kumacp", "kumadp", "kumacni", "kumainit", "*", "madr", "test", "ci", "perf", "policies"
+    ]],
+    "scope-empty": [2, "never"]
   },
 };

--- a/.github/workflows/lifecycle.yml
+++ b/.github/workflows/lifecycle.yml
@@ -48,11 +48,11 @@ jobs:
       - name: "Create Pull Request"
         uses: peter-evans/create-pull-request@v4
         with:
-          commit-message: "chore: updating README"
+          commit-message: "chore(README.md): refreshing active releases"
           signoff: true
           branch: chore/update-health
           delete-branch: true
-          title: "chore: updating README"
+          title: "chore(README.md): refreshing active releases"
           draft: false
           labels: ci/auto-merge,ci/skip-test
           token: ${{ steps.github-app-token.outputs.token }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -212,9 +212,18 @@ it is at your discretion, but here are some of the most frequent ones:
 - **kuma-dp**: A change that affects the data-plane
 - **kumactl**: A change to the kumactl
 - **deps**: When updating dependencies (to be used with the `chore` prefix)
+- **api-server**: When changing to admin api
+- **xds**: When changing something related to xds
+- **kds**: When change something related to kds
+- **MeshRetry**: When changing a specific policy
+- **policy**: When changing something that affects all policies
 - **conf**: Configuration-related changes (new values, improvements...)
-- `*`: When the change affects too many parts of the codebase at once (this
-  should be rare and avoided)
+
+The usual casing for scope is to use singular kebab-case except if it's a public api in which
+case use whatever the public name is (which usually is PascalCase).
+This is why you can have `feat(api-server)` but `fix(MeshRetry)`.
+
+Missing or `*` scope is not allowed. There's usually always something you can put
 
 ##### Subject
 


### PR DESCRIPTION
This makes changelog generation better at the small cost
of more restrictive PR message format

Signed-off-by: Charly Molter <charly.molter@konghq.com>

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] Link to docs PR or issue --
- [x] Link to UI issue or PR --
- [x] Is the [issue worked on linked][1]? --
- [x] The PR does not hardcode values that might break projects that depend on kuma (e.g. "kumahq" as a image registry) --
- [x] The PR will work for both Linux and Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Unit Tests --
- [x] E2E Tests --
- [x] Manual Universal Tests --
- [x] Manual Kubernetes Tests --
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [x] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
