### PR TITLE
ci(.github): modify helm-release to allow inheriting action

### DIFF
--- a/.github/workflows/helm-release.yaml
+++ b/.github/workflows/helm-release.yaml
@@ -29,6 +29,7 @@ env:
   GH_EMAIL: "<41898282+github-actions[bot]@users.noreply.github.com>"
   GH_OWNER: ${{ github.repository_owner }}
   GITHUB_APP: "true"
+  KUMA_DIR: "."
 
 jobs:
   package:
@@ -46,8 +47,8 @@ jobs:
           curl -L "https://github.com/helm/chart-releaser/releases/download/v${CR_VERSION}/chart-releaser_${CR_VERSION}_linux_amd64.tar.gz" | sudo tar xvz --directory /usr/bin cr
 
           make dev/tools
-          git checkout go.*
       - name: Update chart versions
+        id: update-chart-version
         run: |
           git config user.name "${GH_USER}"
           git config user.email "${GH_EMAIL}"
@@ -56,19 +57,19 @@ jobs:
           if [[ ${{ github.event_name }} == "push" ]]; then
             args="${args} --dev"
           fi
-
-          ./tools/releases/helm.sh ${args}
-
+          ${{ env.KUMA_DIR }}/tools/releases/helm.sh ${args}
+      - name: Commit chart versions
+        run: |
           git add -u deployments/charts
           # This commit never ends up in the repo
-          git commit -m "ci(helm): update versions"
+          git commit --allow-empty -m "ci(helm): update versions"
       - name: Package chart
         id: package
         run: |
-          ./tools/releases/helm.sh --package
+          ${{ env.KUMA_DIR }}/tools/releases/helm.sh --package
 
           PKG_FILENAME=$(find .cr-release-packages -type f -printf "%f\n")
-          echo "::set-output name=filename::${PKG_FILENAME}"
+          echo "filename=${PKG_FILENAME}" >> $GITHUB_OUTPUT
       - name: Upload packaged chart
         uses: actions/upload-artifact@v3
         with:


### PR DESCRIPTION
This will make it easier for child repo to reuse this

Signed-off-by: Charly Molter <charly.molter@konghq.com>

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] Link to docs PR or issue --
- [x] Link to UI issue or PR --
- [x] Is the [issue worked on linked][1]? --
- [x] The PR does not hardcode values that might break projects that depend on kuma (e.g. "kumahq" as a image registry) --
- [x] The PR will work for both Linux and Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Unit Tests --
- [x] E2E Tests --
- [x] Manual Universal Tests --
- [x] Manual Kubernetes Tests --
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [x] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
