### PR TITLE
test(e2e): check MeshHTTPRoute with ExternalService

### DIFF
--- a/test/e2e_env/kubernetes/meshhttproute/test.go
+++ b/test/e2e_env/kubernetes/meshhttproute/test.go
@@ -7,6 +7,8 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
+	"github.com/kumahq/kuma/pkg/plugins/policies/meshhttproute/api/v1alpha1"
 	. "github.com/kumahq/kuma/test/framework"
 	"github.com/kumahq/kuma/test/framework/client"
 	"github.com/kumahq/kuma/test/framework/deployments/testserver"
@@ -31,6 +33,10 @@ func Test() {
 				testserver.WithMesh(meshName),
 				testserver.WithNamespace(namespace),
 			)).
+			Install(testserver.Install(
+				testserver.WithNamespace(namespace),
+				testserver.WithName("external-service"),
+			)).
 			Setup(kubernetes.Cluster)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -38,10 +44,17 @@ func Test() {
 			k8s.RunKubectlE(kubernetes.Cluster.GetTesting(), kubernetes.Cluster.GetKubectlOptions(), "delete", "trafficroute", "route-all-meshhttproute"),
 		).To(Succeed())
 	})
+
+	E2EAfterEach(func() {
+		Expect(DeleteMeshResources(kubernetes.Cluster, meshName, v1alpha1.MeshHTTPRouteResourceTypeDescriptor)).To(Succeed())
+		Expect(DeleteMeshResources(kubernetes.Cluster, meshName, core_mesh.ExternalServiceResourceTypeDescriptor)).To(Succeed())
+	})
+
 	E2EAfterAll(func() {
 		Expect(kubernetes.Cluster.TriggerDeleteNamespace(namespace)).To(Succeed())
 		Expect(kubernetes.Cluster.DeleteMesh(meshName)).To(Succeed())
 	})
+
 	It("should use MeshHTTPRoute if any MeshHTTPRoutes are present", func() {
 		Eventually(func(g Gomega) {
 			_, err := client.CollectResponse(kubernetes.Cluster, "test-client", "test-server_meshhttproute_svc_80.mesh", client.FromKubernetesPod(namespace, "test-client"))
@@ -72,6 +85,70 @@ spec:
 			response, err := client.CollectResponse(kubernetes.Cluster, "test-client", "test-server_meshhttproute_svc_80.mesh", client.FromKubernetesPod(namespace, "test-client"))
 			g.Expect(err).ToNot(HaveOccurred())
 			g.Expect(response.Instance).To(HavePrefix("test-server"))
+		}, "30s", "1s").Should(Succeed())
+	})
+
+	It("should split traffic between internal and external services", func() {
+		// given
+		Expect(kubernetes.Cluster.Install(YamlK8s(fmt.Sprintf(`
+apiVersion: kuma.io/v1alpha1
+kind: ExternalService
+metadata:
+  name: external-service-1
+  namespace: %s
+mesh: %s
+spec:
+  tags:
+    kuma.io/service: external-service
+    kuma.io/protocol: http
+  networking:
+    address: external-service.%s.svc.cluster.local:80 # .svc.cluster.local is needed, otherwise Kubernetes will resolve this to the real IP
+`, Config.KumaNamespace, meshName, namespace)))).To(Succeed())
+
+		// when
+		Expect(YamlK8s(fmt.Sprintf(`
+apiVersion: kuma.io/v1alpha1
+kind: MeshHTTPRoute
+metadata:
+  name: route-2
+  namespace: %s
+  labels:
+    kuma.io/mesh: %s
+spec:
+  targetRef:
+    kind: MeshService
+    name: test-client_%s_svc_80
+  to:
+    - targetRef:
+        kind: MeshService
+        name: test-server_meshhttproute_svc_80
+      rules: 
+        - matches:
+            - path: 
+                type: Prefix
+                value: /
+          default:
+            backendRefs:
+              - kind: MeshService
+                name: test-server_meshhttproute_svc_80
+                weight: 50
+              - kind: MeshService
+                name: external-service
+                weight: 50
+`, Config.KumaNamespace, meshName, meshName))(kubernetes.Cluster)).To(Succeed())
+
+		// then receive responses from 'test-server_meshhttproute_svc_80'
+		Eventually(func(g Gomega) {
+			response, err := client.CollectResponse(kubernetes.Cluster, "test-client", "test-server_meshhttproute_svc_80.mesh", client.FromKubernetesPod(namespace, "test-client"))
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(response.Instance).To(HavePrefix("test-server"))
+		}, "30s", "1s").Should(Succeed())
+
+		// and then receive responses from 'external-service'
+		Eventually(func(g Gomega) {
+			response, err := client.CollectResponse(kubernetes.Cluster, "test-client", "test-server_meshhttproute_svc_80.mesh", client.FromKubernetesPod(namespace, "test-client"))
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(response.Instance).To(HavePrefix("external-service"))
 		}, "30s", "1s").Should(Succeed())
 	})
 }


### PR DESCRIPTION
Signed-off-by: Ilya Lobkov <ilya.lobkov@konghq.com>

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [X] Link to docs PR or issue --
- [X] Link to UI issue or PR -- 
- [X] Is the [issue worked on linked][1]? -- https://github.com/kumahq/kuma/issues/5505
- [X] The PR does not hardcode values that might break projects that depend on kuma (e.g. "kumahq" as a image registry) --
- [X] The PR will work for both Linux and Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [X] Unit Tests --
- [X] E2E Tests --
- [X] Manual Universal Tests --
- [X] Manual Kubernetes Tests --
- [X] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [X] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [X] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
