### PR TITLE
fix(MeshTimeout): apply MeshTimeout defaults when one of: from or to …

### DIFF
--- a/pkg/plugins/policies/meshtimeout/plugin/testdata/default_inbound_cluster.golden.yaml
+++ b/pkg/plugins/policies/meshtimeout/plugin/testdata/default_inbound_cluster.golden.yaml
@@ -1,0 +1,9 @@
+connectTimeout: 5s
+name: localhost:8080
+typedExtensionProtocolOptions:
+  envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+    '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+    commonHttpProtocolOptions:
+      idleTimeout: 3600s
+      maxConnectionDuration: 0s
+      maxStreamDuration: 0s

--- a/pkg/plugins/policies/meshtimeout/plugin/testdata/default_inbound_listener.golden.yaml
+++ b/pkg/plugins/policies/meshtimeout/plugin/testdata/default_inbound_listener.golden.yaml
@@ -1,0 +1,33 @@
+address:
+  socketAddress:
+    address: 127.0.0.1
+    portValue: 80
+enableReusePort: false
+filterChains:
+- filters:
+  - name: envoy.filters.network.http_connection_manager
+    typedConfig:
+      '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+      httpFilters:
+      - name: envoy.filters.http.router
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+      routeConfig:
+        name: inbound:backend
+        requestHeadersToRemove:
+        - x-kuma-tags
+        validateClusters: false
+        virtualHosts:
+        - domains:
+          - '*'
+          name: backend
+          routes:
+          - match:
+              prefix: /
+            route:
+              cluster: backend
+              timeout: 15s
+      statPrefix: inbound_127_0_0_1_80
+      streamIdleTimeout: 1800s
+name: inbound:127.0.0.1:80
+trafficDirection: INBOUND

--- a/pkg/plugins/policies/meshtimeout/plugin/testdata/default_outbound_cluster.golden.yaml
+++ b/pkg/plugins/policies/meshtimeout/plugin/testdata/default_outbound_cluster.golden.yaml
@@ -1,0 +1,9 @@
+connectTimeout: 5s
+name: other-service
+typedExtensionProtocolOptions:
+  envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+    '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+    commonHttpProtocolOptions:
+      idleTimeout: 3600s
+      maxConnectionDuration: 0s
+      maxStreamDuration: 0s

--- a/pkg/plugins/policies/meshtimeout/plugin/testdata/default_outbound_listener.golden.yaml
+++ b/pkg/plugins/policies/meshtimeout/plugin/testdata/default_outbound_listener.golden.yaml
@@ -1,0 +1,34 @@
+address:
+  socketAddress:
+    address: 127.0.0.1
+    portValue: 10001
+filterChains:
+- filters:
+  - name: envoy.filters.network.http_connection_manager
+    typedConfig:
+      '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+      httpFilters:
+      - name: envoy.filters.http.router
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+      routeConfig:
+        name: outbound:backend
+        requestHeadersToAdd:
+        - header:
+            key: x-kuma-tags
+            value: '&kuma.io/service=web&'
+        validateClusters: false
+        virtualHosts:
+        - domains:
+          - '*'
+          name: backend
+          routes:
+          - match:
+              prefix: /
+            route:
+              cluster: backend
+              timeout: 15s
+      statPrefix: outbound_127_0_0_1_10001
+      streamIdleTimeout: 1800s
+name: outbound:127.0.0.1:10001
+trafficDirection: OUTBOUND

--- a/pkg/plugins/policies/meshtimeout/plugin/testdata/modified_inbound_cluster.golden.yaml
+++ b/pkg/plugins/policies/meshtimeout/plugin/testdata/modified_inbound_cluster.golden.yaml
@@ -1,0 +1,9 @@
+connectTimeout: 10s
+name: localhost:8080
+typedExtensionProtocolOptions:
+  envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+    '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+    commonHttpProtocolOptions:
+      idleTimeout: 3600s
+      maxConnectionDuration: 600s
+      maxStreamDuration: 600s

--- a/pkg/plugins/policies/meshtimeout/plugin/testdata/modified_inbound_listener.golden.yaml
+++ b/pkg/plugins/policies/meshtimeout/plugin/testdata/modified_inbound_listener.golden.yaml
@@ -1,0 +1,33 @@
+address:
+  socketAddress:
+    address: 127.0.0.1
+    portValue: 80
+enableReusePort: false
+filterChains:
+- filters:
+  - name: envoy.filters.network.http_connection_manager
+    typedConfig:
+      '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+      httpFilters:
+      - name: envoy.filters.http.router
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+      routeConfig:
+        name: inbound:backend
+        requestHeadersToRemove:
+        - x-kuma-tags
+        validateClusters: false
+        virtualHosts:
+        - domains:
+          - '*'
+          name: backend
+          routes:
+          - match:
+              prefix: /
+            route:
+              cluster: backend
+              timeout: 5s
+      statPrefix: inbound_127_0_0_1_80
+      streamIdleTimeout: 1s
+name: inbound:127.0.0.1:80
+trafficDirection: INBOUND

--- a/pkg/plugins/policies/meshtimeout/plugin/testdata/modified_outbound_cluster.golden.yaml
+++ b/pkg/plugins/policies/meshtimeout/plugin/testdata/modified_outbound_cluster.golden.yaml
@@ -1,0 +1,9 @@
+connectTimeout: 10s
+name: other-service
+typedExtensionProtocolOptions:
+  envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+    '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+    commonHttpProtocolOptions:
+      idleTimeout: 3600s
+      maxConnectionDuration: 0s
+      maxStreamDuration: 0s

--- a/pkg/plugins/policies/meshtimeout/plugin/testdata/modified_outbound_listener.golden.yaml
+++ b/pkg/plugins/policies/meshtimeout/plugin/testdata/modified_outbound_listener.golden.yaml
@@ -1,0 +1,34 @@
+address:
+  socketAddress:
+    address: 127.0.0.1
+    portValue: 10001
+filterChains:
+- filters:
+  - name: envoy.filters.network.http_connection_manager
+    typedConfig:
+      '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+      httpFilters:
+      - name: envoy.filters.http.router
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+      routeConfig:
+        name: outbound:backend
+        requestHeadersToAdd:
+        - header:
+            key: x-kuma-tags
+            value: '&kuma.io/service=web&'
+        validateClusters: false
+        virtualHosts:
+        - domains:
+          - '*'
+          name: backend
+          routes:
+          - match:
+              prefix: /
+            route:
+              cluster: backend
+              timeout: 15s
+      statPrefix: outbound_127_0_0_1_10001
+      streamIdleTimeout: 1800s
+name: outbound:127.0.0.1:10001
+trafficDirection: OUTBOUND

--- a/pkg/plugins/policies/meshtimeout/plugin/testdata/original_inbound_cluster.golden.yaml
+++ b/pkg/plugins/policies/meshtimeout/plugin/testdata/original_inbound_cluster.golden.yaml
@@ -1,0 +1,1 @@
+name: localhost:8080

--- a/pkg/plugins/policies/meshtimeout/plugin/testdata/original_inbound_listener.golden.yaml
+++ b/pkg/plugins/policies/meshtimeout/plugin/testdata/original_inbound_listener.golden.yaml
@@ -1,0 +1,32 @@
+address:
+  socketAddress:
+    address: 127.0.0.1
+    portValue: 80
+enableReusePort: false
+filterChains:
+- filters:
+  - name: envoy.filters.network.http_connection_manager
+    typedConfig:
+      '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+      httpFilters:
+      - name: envoy.filters.http.router
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+      routeConfig:
+        name: inbound:backend
+        requestHeadersToRemove:
+        - x-kuma-tags
+        validateClusters: false
+        virtualHosts:
+        - domains:
+          - '*'
+          name: backend
+          routes:
+          - match:
+              prefix: /
+            route:
+              cluster: backend
+              timeout: 0s
+      statPrefix: inbound_127_0_0_1_80
+name: inbound:127.0.0.1:80
+trafficDirection: INBOUND

--- a/pkg/plugins/policies/meshtimeout/plugin/testdata/original_outbound_cluster.golden.yaml
+++ b/pkg/plugins/policies/meshtimeout/plugin/testdata/original_outbound_cluster.golden.yaml
@@ -1,0 +1,1 @@
+name: other-service

--- a/pkg/plugins/policies/meshtimeout/plugin/testdata/original_outbound_listener.golden.yaml
+++ b/pkg/plugins/policies/meshtimeout/plugin/testdata/original_outbound_listener.golden.yaml
@@ -1,0 +1,33 @@
+address:
+  socketAddress:
+    address: 127.0.0.1
+    portValue: 10001
+filterChains:
+- filters:
+  - name: envoy.filters.network.http_connection_manager
+    typedConfig:
+      '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+      httpFilters:
+      - name: envoy.filters.http.router
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+      routeConfig:
+        name: outbound:backend
+        requestHeadersToAdd:
+        - header:
+            key: x-kuma-tags
+            value: '&kuma.io/service=web&'
+        validateClusters: false
+        virtualHosts:
+        - domains:
+          - '*'
+          name: backend
+          routes:
+          - match:
+              prefix: /
+            route:
+              cluster: backend
+              timeout: 0s
+      statPrefix: outbound_127_0_0_1_10001
+name: outbound:127.0.0.1:10001
+trafficDirection: OUTBOUND

--- a/pkg/plugins/policies/meshtimeout/plugin/v1alpha1/plugin.go
+++ b/pkg/plugins/policies/meshtimeout/plugin/v1alpha1/plugin.go
@@ -38,6 +38,9 @@ func (p plugin) Apply(rs *core_xds.ResourceSet, ctx xds_context.Context, proxy *
 	if !ok {
 		return nil
 	}
+	if len(policies.ToRules.Rules) == 0 && len(policies.FromRules.Rules) == 0 {
+		return nil
+	}
 
 	listeners := policies_xds.GatherListeners(rs)
 	clusters := policies_xds.GatherClusters(rs)
@@ -69,10 +72,7 @@ func applyToInbounds(fromRules core_xds.FromRules, inboundListeners map[core_xds
 			continue
 		}
 
-		rules, ok := fromRules.Rules[listenerKey]
-		if !ok {
-			continue
-		}
+		rules := fromRules.Rules[listenerKey]
 
 		cluster, ok := inboundClusters[createInboundClusterName(inbound.ServicePort, listenerKey.Port)]
 		if !ok {
@@ -185,10 +185,14 @@ func applyToGateway(
 
 func configure(rules core_xds.Rules, subset core_xds.Subset, protocol core_mesh.Protocol, listener *envoy_listener.Listener, cluster *envoy_cluster.Cluster, routeActions []*envoy_route.RouteAction) error {
 	var conf api.Conf
-	if computed := rules.Compute(subset); computed != nil {
-		conf = computed.Conf.(api.Conf)
+	if rules == nil {
+		conf = api.Conf{}
 	} else {
-		return nil
+		if computed := rules.Compute(subset); computed != nil {
+			conf = computed.Conf.(api.Conf)
+		} else {
+			return nil
+		}
 	}
 
 	configurer := plugin_xds.Configurer{


### PR DESCRIPTION
…section is missing

Fixes: #5850
Signed-off-by: Marcin Skalski <marcin.skalski@konghq.com>

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] Link to docs PR or issue --
- [x] Link to UI issue or PR --
- [x] Is the [issue worked on linked][1]? --
- [x] The PR does not hardcode values that might break projects that depend on kuma (e.g. "kumahq" as a image registry) --
- [x] The PR will work for both Linux and Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Unit Tests --
- [x] E2E Tests --
- [x] Manual Universal Tests --
- [x] Manual Kubernetes Tests --
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [x] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
