### PR TITLE
test(e2e): allow to provide functions to k8s/universal e2e tests

### DIFF
--- a/test/e2e_env/kubernetes/kubernetes_suite_test.go
+++ b/test/e2e_env/kubernetes/kubernetes_suite_test.go
@@ -37,7 +37,7 @@ func TestE2E(t *testing.T) {
 	test.RunE2ESpecs(t, "E2E Kubernetes Suite")
 }
 
-var _ = SynchronizedBeforeSuite(kubernetes.SetupAndGetState, kubernetes.RestoreState)
+var _ = SynchronizedBeforeSuite(func() []byte { return kubernetes.SetupAndGetState() }, kubernetes.RestoreState)
 
 // SynchronizedAfterSuite keeps the main process alive until all other processes finish.
 // Otherwise, we would close port-forward to the CP and remaining tests executed in different processes may fail.

--- a/test/e2e_env/universal/universal_suite_test.go
+++ b/test/e2e_env/universal/universal_suite_test.go
@@ -45,7 +45,7 @@ func TestE2E(t *testing.T) {
 	test.RunE2ESpecs(t, "E2E Universal Suite")
 }
 
-var _ = SynchronizedBeforeSuite(universal.SetupAndGetState, universal.RestoreState)
+var _ = SynchronizedBeforeSuite(func() []byte { return universal.SetupAndGetState() }, universal.RestoreState)
 
 var _ = Describe("User Auth", auth.UserAuth)
 var _ = Describe("DP Auth", auth.DpAuth, Ordered)

--- a/test/framework/envs/kubernetes/env.go
+++ b/test/framework/envs/kubernetes/env.go
@@ -33,10 +33,7 @@ func SetupAndGetState(opts ...framework.KumaDeploymentOption) []byte {
 		framework.WithEgress(),
 	}, opts...)
 	Eventually(func() error {
-		return Cluster.Install(
-			framework.Kuma(core.Standalone,
-				kumaOpts...,
-			))
+		return Cluster.Install(framework.Kuma(core.Standalone, kumaOpts...))
 	}, "90s", "3s").Should(Succeed())
 	portFwd := Cluster.GetKuma().(*framework.K8sControlPlane).PortFwd()
 

--- a/test/framework/envs/universal/env.go
+++ b/test/framework/envs/universal/env.go
@@ -19,9 +19,7 @@ func SetupAndGetState(opts ...framework.KumaDeploymentOption) []byte {
 		framework.WithEnv("KUMA_STORE_UNSAFE_DELETE", "true"),
 		framework.WithEnv("KUMA_XDS_SERVER_DATAPLANE_STATUS_FLUSH_INTERVAL", "1s"), // speed up some tests by flushing stats quicker than default 10s
 	}, opts...)
-	Expect(Cluster.Install(framework.Kuma(core.Standalone,
-		kumaOpts...,
-	))).To(Succeed())
+	Expect(Cluster.Install(framework.Kuma(core.Standalone, kumaOpts...))).To(Succeed())
 	Expect(Cluster.Install(framework.EgressUniversal(func(zone string) (string, error) {
 		return Cluster.GetKuma().GenerateZoneEgressToken("")
 	}))).To(Succeed())

--- a/test/framework/envs/universal/env.go
+++ b/test/framework/envs/universal/env.go
@@ -12,12 +12,15 @@ import (
 var Cluster *framework.UniversalCluster
 
 // SetupAndGetState to be used with Ginkgo SynchronizedBeforeSuite
-func SetupAndGetState() []byte {
+func SetupAndGetState(opts ...framework.KumaDeploymentOption) []byte {
 	Cluster = framework.NewUniversalCluster(framework.NewTestingT(), framework.Kuma3, framework.Silent)
 	framework.E2EDeferCleanup(Cluster.DismissCluster)
-	Expect(Cluster.Install(framework.Kuma(core.Standalone,
+	kumaOpts := append([]framework.KumaDeploymentOption{
 		framework.WithEnv("KUMA_STORE_UNSAFE_DELETE", "true"),
 		framework.WithEnv("KUMA_XDS_SERVER_DATAPLANE_STATUS_FLUSH_INTERVAL", "1s"), // speed up some tests by flushing stats quicker than default 10s
+	}, opts...)
+	Expect(Cluster.Install(framework.Kuma(core.Standalone,
+		kumaOpts...,
 	))).To(Succeed())
 	Expect(Cluster.Install(framework.EgressUniversal(func(zone string) (string, error) {
 		return Cluster.GetKuma().GenerateZoneEgressToken("")


### PR DESCRIPTION
If any fork would like to setup a cluster with a bit different setup we are not allowing it without overriding the whole setup of the cluster. I've added a change that allows passing additional configuration.

- [X] Link to docs PR or issue --
- [X] Link to UI issue or PR --
- [X] Is the [issue worked on linked][1]? --
- [X] The PR does not hardcode values that might break projects that depend on kuma (e.g. "kumahq" as a image registry) --
- [X] The PR will work for both Linux and Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [X] Unit Tests --
- [X] E2E Tests --
- [X] Manual Universal Tests --
- [X] Manual Kubernetes Tests --
- [X] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [X] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [X] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
