### PR TITLE
feat(meshhttproute): add path modifier to redirect

### DIFF
--- a/app/kumactl/cmd/install/testdata/install-control-plane.defaults.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.defaults.golden.yaml
@@ -1232,6 +1232,25 @@ spec:
                                           minLength: 1
                                           pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                                           type: string
+                                        path:
+                                          description: Path defines parameters used
+                                            to modify the path of the incoming request.
+                                            The modified path is then used to construct
+                                            the location header. When empty, the request
+                                            path is used as-is.
+                                          properties:
+                                            replaceFullPath:
+                                              type: string
+                                            replacePrefixMatch:
+                                              type: string
+                                            type:
+                                              enum:
+                                              - ReplaceFullPath
+                                              - ReplacePrefixMatch
+                                              type: string
+                                          required:
+                                          - type
+                                          type: object
                                         port:
                                           description: Port is the port to be used
                                             in the value of the `Location` header
@@ -1319,21 +1338,15 @@ spec:
                                     urlRewrite:
                                       properties:
                                         hostname:
-                                          description: "PreciseHostname is the fully
-                                            qualified domain name of a network host.
-                                            This matches the RFC 1123 definition of
-                                            a hostname with 1 notable exception that
-                                            numeric IP addresses are not allowed.
-                                            \n Note that as per RFC1035 and RFC1123,
-                                            a *label* must consist of lower case alphanumeric
-                                            characters or '-', and must start and
-                                            end with an alphanumeric character. No
-                                            other punctuation is allowed."
+                                          description: Hostname is the value to be
+                                            used to replace the host header value
+                                            during forwarding.
                                           maxLength: 253
                                           minLength: 1
                                           pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                                           type: string
                                         path:
+                                          description: Path defines a path rewrite.
                                           properties:
                                             replaceFullPath:
                                               type: string

--- a/app/kumactl/cmd/install/testdata/install-control-plane.gateway-api-present-not-enabled.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.gateway-api-present-not-enabled.yaml
@@ -1232,6 +1232,25 @@ spec:
                                           minLength: 1
                                           pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                                           type: string
+                                        path:
+                                          description: Path defines parameters used
+                                            to modify the path of the incoming request.
+                                            The modified path is then used to construct
+                                            the location header. When empty, the request
+                                            path is used as-is.
+                                          properties:
+                                            replaceFullPath:
+                                              type: string
+                                            replacePrefixMatch:
+                                              type: string
+                                            type:
+                                              enum:
+                                              - ReplaceFullPath
+                                              - ReplacePrefixMatch
+                                              type: string
+                                          required:
+                                          - type
+                                          type: object
                                         port:
                                           description: Port is the port to be used
                                             in the value of the `Location` header
@@ -1319,21 +1338,15 @@ spec:
                                     urlRewrite:
                                       properties:
                                         hostname:
-                                          description: "PreciseHostname is the fully
-                                            qualified domain name of a network host.
-                                            This matches the RFC 1123 definition of
-                                            a hostname with 1 notable exception that
-                                            numeric IP addresses are not allowed.
-                                            \n Note that as per RFC1035 and RFC1123,
-                                            a *label* must consist of lower case alphanumeric
-                                            characters or '-', and must start and
-                                            end with an alphanumeric character. No
-                                            other punctuation is allowed."
+                                          description: Hostname is the value to be
+                                            used to replace the host header value
+                                            during forwarding.
                                           maxLength: 253
                                           minLength: 1
                                           pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                                           type: string
                                         path:
+                                          description: Path defines a path rewrite.
                                           properties:
                                             replaceFullPath:
                                               type: string

--- a/app/kumactl/cmd/install/testdata/install-control-plane.gateway-api-present.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.gateway-api-present.yaml
@@ -1384,6 +1384,25 @@ spec:
                                           minLength: 1
                                           pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                                           type: string
+                                        path:
+                                          description: Path defines parameters used
+                                            to modify the path of the incoming request.
+                                            The modified path is then used to construct
+                                            the location header. When empty, the request
+                                            path is used as-is.
+                                          properties:
+                                            replaceFullPath:
+                                              type: string
+                                            replacePrefixMatch:
+                                              type: string
+                                            type:
+                                              enum:
+                                              - ReplaceFullPath
+                                              - ReplacePrefixMatch
+                                              type: string
+                                          required:
+                                          - type
+                                          type: object
                                         port:
                                           description: Port is the port to be used
                                             in the value of the `Location` header
@@ -1471,21 +1490,15 @@ spec:
                                     urlRewrite:
                                       properties:
                                         hostname:
-                                          description: "PreciseHostname is the fully
-                                            qualified domain name of a network host.
-                                            This matches the RFC 1123 definition of
-                                            a hostname with 1 notable exception that
-                                            numeric IP addresses are not allowed.
-                                            \n Note that as per RFC1035 and RFC1123,
-                                            a *label* must consist of lower case alphanumeric
-                                            characters or '-', and must start and
-                                            end with an alphanumeric character. No
-                                            other punctuation is allowed."
+                                          description: Hostname is the value to be
+                                            used to replace the host header value
+                                            during forwarding.
                                           maxLength: 253
                                           minLength: 1
                                           pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                                           type: string
                                         path:
+                                          description: Path defines a path rewrite.
                                           properties:
                                             replaceFullPath:
                                               type: string

--- a/app/kumactl/cmd/install/testdata/install-control-plane.with-helm-set.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.with-helm-set.yaml
@@ -1252,6 +1252,25 @@ spec:
                                           minLength: 1
                                           pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                                           type: string
+                                        path:
+                                          description: Path defines parameters used
+                                            to modify the path of the incoming request.
+                                            The modified path is then used to construct
+                                            the location header. When empty, the request
+                                            path is used as-is.
+                                          properties:
+                                            replaceFullPath:
+                                              type: string
+                                            replacePrefixMatch:
+                                              type: string
+                                            type:
+                                              enum:
+                                              - ReplaceFullPath
+                                              - ReplacePrefixMatch
+                                              type: string
+                                          required:
+                                          - type
+                                          type: object
                                         port:
                                           description: Port is the port to be used
                                             in the value of the `Location` header
@@ -1339,21 +1358,15 @@ spec:
                                     urlRewrite:
                                       properties:
                                         hostname:
-                                          description: "PreciseHostname is the fully
-                                            qualified domain name of a network host.
-                                            This matches the RFC 1123 definition of
-                                            a hostname with 1 notable exception that
-                                            numeric IP addresses are not allowed.
-                                            \n Note that as per RFC1035 and RFC1123,
-                                            a *label* must consist of lower case alphanumeric
-                                            characters or '-', and must start and
-                                            end with an alphanumeric character. No
-                                            other punctuation is allowed."
+                                          description: Hostname is the value to be
+                                            used to replace the host header value
+                                            during forwarding.
                                           maxLength: 253
                                           minLength: 1
                                           pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                                           type: string
                                         path:
+                                          description: Path defines a path rewrite.
                                           properties:
                                             replaceFullPath:
                                               type: string

--- a/app/kumactl/cmd/install/testdata/install-crds.all.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-crds.all.golden.yaml
@@ -2403,6 +2403,25 @@ spec:
                                           minLength: 1
                                           pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                                           type: string
+                                        path:
+                                          description: Path defines parameters used
+                                            to modify the path of the incoming request.
+                                            The modified path is then used to construct
+                                            the location header. When empty, the request
+                                            path is used as-is.
+                                          properties:
+                                            replaceFullPath:
+                                              type: string
+                                            replacePrefixMatch:
+                                              type: string
+                                            type:
+                                              enum:
+                                              - ReplaceFullPath
+                                              - ReplacePrefixMatch
+                                              type: string
+                                          required:
+                                          - type
+                                          type: object
                                         port:
                                           description: Port is the port to be used
                                             in the value of the `Location` header
@@ -2490,21 +2509,15 @@ spec:
                                     urlRewrite:
                                       properties:
                                         hostname:
-                                          description: "PreciseHostname is the fully
-                                            qualified domain name of a network host.
-                                            This matches the RFC 1123 definition of
-                                            a hostname with 1 notable exception that
-                                            numeric IP addresses are not allowed.
-                                            \n Note that as per RFC1035 and RFC1123,
-                                            a *label* must consist of lower case alphanumeric
-                                            characters or '-', and must start and
-                                            end with an alphanumeric character. No
-                                            other punctuation is allowed."
+                                          description: Hostname is the value to be
+                                            used to replace the host header value
+                                            during forwarding.
                                           maxLength: 253
                                           minLength: 1
                                           pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                                           type: string
                                         path:
+                                          description: Path defines a path rewrite.
                                           properties:
                                             replaceFullPath:
                                               type: string

--- a/app/kumactl/cmd/install/testdata/install-crds.experimental-gatewayapi.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-crds.experimental-gatewayapi.golden.yaml
@@ -2555,6 +2555,25 @@ spec:
                                           minLength: 1
                                           pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                                           type: string
+                                        path:
+                                          description: Path defines parameters used
+                                            to modify the path of the incoming request.
+                                            The modified path is then used to construct
+                                            the location header. When empty, the request
+                                            path is used as-is.
+                                          properties:
+                                            replaceFullPath:
+                                              type: string
+                                            replacePrefixMatch:
+                                              type: string
+                                            type:
+                                              enum:
+                                              - ReplaceFullPath
+                                              - ReplacePrefixMatch
+                                              type: string
+                                          required:
+                                          - type
+                                          type: object
                                         port:
                                           description: Port is the port to be used
                                             in the value of the `Location` header
@@ -2642,21 +2661,15 @@ spec:
                                     urlRewrite:
                                       properties:
                                         hostname:
-                                          description: "PreciseHostname is the fully
-                                            qualified domain name of a network host.
-                                            This matches the RFC 1123 definition of
-                                            a hostname with 1 notable exception that
-                                            numeric IP addresses are not allowed.
-                                            \n Note that as per RFC1035 and RFC1123,
-                                            a *label* must consist of lower case alphanumeric
-                                            characters or '-', and must start and
-                                            end with an alphanumeric character. No
-                                            other punctuation is allowed."
+                                          description: Hostname is the value to be
+                                            used to replace the host header value
+                                            during forwarding.
                                           maxLength: 253
                                           minLength: 1
                                           pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                                           type: string
                                         path:
+                                          description: Path defines a path rewrite.
                                           properties:
                                             replaceFullPath:
                                               type: string

--- a/deployments/charts/kuma/crds/kuma.io_meshhttproutes.yaml
+++ b/deployments/charts/kuma/crds/kuma.io_meshhttproutes.yaml
@@ -183,6 +183,25 @@ spec:
                                           minLength: 1
                                           pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                                           type: string
+                                        path:
+                                          description: Path defines parameters used
+                                            to modify the path of the incoming request.
+                                            The modified path is then used to construct
+                                            the Location header. When empty, the request
+                                            path is used as-is.
+                                          properties:
+                                            replaceFullPath:
+                                              type: string
+                                            replacePrefixMatch:
+                                              type: string
+                                            type:
+                                              enum:
+                                              - ReplaceFullPath
+                                              - ReplacePrefixMatch
+                                              type: string
+                                          required:
+                                          - type
+                                          type: object
                                         port:
                                           description: Port is the port to be used
                                             in the value of the `Location` header
@@ -270,21 +289,15 @@ spec:
                                     urlRewrite:
                                       properties:
                                         hostname:
-                                          description: "PreciseHostname is the fully
-                                            qualified domain name of a network host.
-                                            This matches the RFC 1123 definition of
-                                            a hostname with 1 notable exception that
-                                            numeric IP addresses are not allowed.
-                                            \n Note that as per RFC1035 and RFC1123,
-                                            a *label* must consist of lower case alphanumeric
-                                            characters or '-', and must start and
-                                            end with an alphanumeric character. No
-                                            other punctuation is allowed."
+                                          description: Hostname is the value to be
+                                            used to replace the Host header value
+                                            during forwarding.
                                           maxLength: 253
                                           minLength: 1
                                           pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                                           type: string
                                         path:
+                                          description: Path defines a path rewrite.
                                           properties:
                                             replaceFullPath:
                                               type: string

--- a/deployments/charts/kuma/crds/kuma.io_meshhttproutes.yaml
+++ b/deployments/charts/kuma/crds/kuma.io_meshhttproutes.yaml
@@ -187,7 +187,7 @@ spec:
                                           description: Path defines parameters used
                                             to modify the path of the incoming request.
                                             The modified path is then used to construct
-                                            the Location header. When empty, the request
+                                            the location header. When empty, the request
                                             path is used as-is.
                                           properties:
                                             replaceFullPath:
@@ -290,7 +290,7 @@ spec:
                                       properties:
                                         hostname:
                                           description: Hostname is the value to be
-                                            used to replace the Host header value
+                                            used to replace the host header value
                                             during forwarding.
                                           maxLength: 253
                                           minLength: 1

--- a/pkg/plugins/policies/meshhttproute/api/v1alpha1/meshhttproute.go
+++ b/pkg/plugins/policies/meshhttproute/api/v1alpha1/meshhttproute.go
@@ -142,7 +142,7 @@ type RequestRedirect struct {
 	Scheme   *string          `json:"scheme,omitempty"`
 	Hostname *PreciseHostname `json:"hostname,omitempty"`
 	// Path defines parameters used to modify the path of the incoming request.
-	// The modified path is then used to construct the Location header.
+	// The modified path is then used to construct the location header.
 	// When empty, the request path is used as-is.
 	Path *PathRewrite `json:"path,omitempty"`
 	// Port is the port to be used in the value of the `Location`
@@ -171,7 +171,7 @@ type PathRewrite struct {
 }
 
 type URLRewrite struct {
-	// Hostname is the value to be used to replace the Host header value during forwarding.
+	// Hostname is the value to be used to replace the host header value during forwarding.
 	Hostname *PreciseHostname `json:"hostname,omitempty"`
 	// Path defines a path rewrite.
 	Path *PathRewrite `json:"path,omitempty"`

--- a/pkg/plugins/policies/meshhttproute/api/v1alpha1/meshhttproute.go
+++ b/pkg/plugins/policies/meshhttproute/api/v1alpha1/meshhttproute.go
@@ -141,10 +141,13 @@ type RequestRedirect struct {
 	// +kubebuilder:validation:Enum=http;https
 	Scheme   *string          `json:"scheme,omitempty"`
 	Hostname *PreciseHostname `json:"hostname,omitempty"`
+	// Path defines parameters used to modify the path of the incoming request.
+	// The modified path is then used to construct the Location header.
+	// When empty, the request path is used as-is.
+	Path *PathRewrite `json:"path,omitempty"`
 	// Port is the port to be used in the value of the `Location`
 	// header in the response.
 	// When empty, port (if specified) of the request is used.
-	//
 	Port *PortNumber `json:"port,omitempty"`
 	// StatusCode is the HTTP status code to be used in response.
 	//
@@ -168,8 +171,10 @@ type PathRewrite struct {
 }
 
 type URLRewrite struct {
+	// Hostname is the value to be used to replace the Host header value during forwarding.
 	Hostname *PreciseHostname `json:"hostname,omitempty"`
-	Path     *PathRewrite     `json:"path,omitempty"`
+	// Path defines a path rewrite.
+	Path *PathRewrite `json:"path,omitempty"`
 }
 
 type Filter struct {
@@ -178,7 +183,6 @@ type Filter struct {
 	ResponseHeaderModifier *HeaderModifier  `json:"responseHeaderModifier,omitempty"`
 	RequestRedirect        *RequestRedirect `json:"requestRedirect,omitempty"`
 	URLRewrite             *URLRewrite      `json:"urlRewrite,omitempty"`
-	// TODO: add path to redirect after adding URL rewrite
 }
 
 type BackendRef struct {

--- a/pkg/plugins/policies/meshhttproute/api/v1alpha1/schema.yaml
+++ b/pkg/plugins/policies/meshhttproute/api/v1alpha1/schema.yaml
@@ -136,7 +136,7 @@ properties:
                                   pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                                   type: string
                                 path:
-                                  description: Path defines parameters used to modify the path of the incoming request. The modified path is then used to construct the Location header. When empty, the request path is used as-is.
+                                  description: Path defines parameters used to modify the path of the incoming request. The modified path is then used to construct the location header. When empty, the request path is used as-is.
                                   properties:
                                     replaceFullPath:
                                       type: string
@@ -229,7 +229,7 @@ properties:
                             urlRewrite:
                               properties:
                                 hostname:
-                                  description: Hostname is the value to be used to replace the Host header value during forwarding.
+                                  description: Hostname is the value to be used to replace the host header value during forwarding.
                                   maxLength: 253
                                   minLength: 1
                                   pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$

--- a/pkg/plugins/policies/meshhttproute/api/v1alpha1/schema.yaml
+++ b/pkg/plugins/policies/meshhttproute/api/v1alpha1/schema.yaml
@@ -135,6 +135,21 @@ properties:
                                   minLength: 1
                                   pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                                   type: string
+                                path:
+                                  description: Path defines parameters used to modify the path of the incoming request. The modified path is then used to construct the Location header. When empty, the request path is used as-is.
+                                  properties:
+                                    replaceFullPath:
+                                      type: string
+                                    replacePrefixMatch:
+                                      type: string
+                                    type:
+                                      enum:
+                                        - ReplaceFullPath
+                                        - ReplacePrefixMatch
+                                      type: string
+                                  required:
+                                    - type
+                                  type: object
                                 port:
                                   description: Port is the port to be used in the value of the `Location` header in the response. When empty, port (if specified) of the request is used.
                                   format: int32
@@ -214,12 +229,13 @@ properties:
                             urlRewrite:
                               properties:
                                 hostname:
-                                  description: "PreciseHostname is the fully qualified domain name of a network host. This matches the RFC 1123 definition of a hostname with 1 notable exception that numeric IP addresses are not allowed. \n Note that as per RFC1035 and RFC1123, a *label* must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character. No other punctuation is allowed."
+                                  description: Hostname is the value to be used to replace the Host header value during forwarding.
                                   maxLength: 253
                                   minLength: 1
                                   pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                                   type: string
                                 path:
+                                  description: Path defines a path rewrite.
                                   properties:
                                     replaceFullPath:
                                       type: string

--- a/pkg/plugins/policies/meshhttproute/api/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/plugins/policies/meshhttproute/api/v1alpha1/zz_generated.deepcopy.go
@@ -224,6 +224,11 @@ func (in *RequestRedirect) DeepCopyInto(out *RequestRedirect) {
 		*out = new(PreciseHostname)
 		**out = **in
 	}
+	if in.Path != nil {
+		in, out := &in.Path, &out.Path
+		*out = new(PathRewrite)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.Port != nil {
 		in, out := &in.Port, &out.Port
 		*out = new(PortNumber)

--- a/pkg/plugins/policies/meshhttproute/k8s/crd/kuma.io_meshhttproutes.yaml
+++ b/pkg/plugins/policies/meshhttproute/k8s/crd/kuma.io_meshhttproutes.yaml
@@ -183,6 +183,25 @@ spec:
                                           minLength: 1
                                           pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                                           type: string
+                                        path:
+                                          description: Path defines parameters used
+                                            to modify the path of the incoming request.
+                                            The modified path is then used to construct
+                                            the Location header. When empty, the request
+                                            path is used as-is.
+                                          properties:
+                                            replaceFullPath:
+                                              type: string
+                                            replacePrefixMatch:
+                                              type: string
+                                            type:
+                                              enum:
+                                              - ReplaceFullPath
+                                              - ReplacePrefixMatch
+                                              type: string
+                                          required:
+                                          - type
+                                          type: object
                                         port:
                                           description: Port is the port to be used
                                             in the value of the `Location` header
@@ -270,21 +289,15 @@ spec:
                                     urlRewrite:
                                       properties:
                                         hostname:
-                                          description: "PreciseHostname is the fully
-                                            qualified domain name of a network host.
-                                            This matches the RFC 1123 definition of
-                                            a hostname with 1 notable exception that
-                                            numeric IP addresses are not allowed.
-                                            \n Note that as per RFC1035 and RFC1123,
-                                            a *label* must consist of lower case alphanumeric
-                                            characters or '-', and must start and
-                                            end with an alphanumeric character. No
-                                            other punctuation is allowed."
+                                          description: Hostname is the value to be
+                                            used to replace the Host header value
+                                            during forwarding.
                                           maxLength: 253
                                           minLength: 1
                                           pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                                           type: string
                                         path:
+                                          description: Path defines a path rewrite.
                                           properties:
                                             replaceFullPath:
                                               type: string

--- a/pkg/plugins/policies/meshhttproute/k8s/crd/kuma.io_meshhttproutes.yaml
+++ b/pkg/plugins/policies/meshhttproute/k8s/crd/kuma.io_meshhttproutes.yaml
@@ -187,7 +187,7 @@ spec:
                                           description: Path defines parameters used
                                             to modify the path of the incoming request.
                                             The modified path is then used to construct
-                                            the Location header. When empty, the request
+                                            the location header. When empty, the request
                                             path is used as-is.
                                           properties:
                                             replaceFullPath:
@@ -290,7 +290,7 @@ spec:
                                       properties:
                                         hostname:
                                           description: Hostname is the value to be
-                                            used to replace the Host header value
+                                            used to replace the host header value
                                             during forwarding.
                                           maxLength: 253
                                           minLength: 1

--- a/pkg/plugins/policies/meshhttproute/xds/filters.go
+++ b/pkg/plugins/policies/meshhttproute/xds/filters.go
@@ -20,7 +20,7 @@ func routeFilter(filter api.Filter, route *envoy_route.Route, matchesPrefix bool
 	case api.ResponseHeaderModifierType:
 		responseHeaderModifier(*filter.ResponseHeaderModifier, route)
 	case api.RequestRedirectType:
-		requestRedirect(*filter.RequestRedirect, route)
+		requestRedirect(*filter.RequestRedirect, route, matchesPrefix)
 	case api.URLRewriteType:
 		urlRewrite(*filter.URLRewrite, route, matchesPrefix)
 	}
@@ -75,7 +75,7 @@ func responseHeaderModifier(mod api.HeaderModifier, envoyRoute *envoy_route.Rout
 	envoyRoute.ResponseHeadersToRemove = append(envoyRoute.ResponseHeadersToRemove, removes...)
 }
 
-func requestRedirect(redirect api.RequestRedirect, envoyRoute *envoy_route.Route) {
+func requestRedirect(redirect api.RequestRedirect, envoyRoute *envoy_route.Route, withPrefixMatch bool) {
 	envoyRedirect := &envoy_route.RedirectAction{}
 	if redirect.Hostname != nil {
 		envoyRedirect.HostRedirect = string(*redirect.Hostname)
@@ -86,6 +86,44 @@ func requestRedirect(redirect api.RequestRedirect, envoyRoute *envoy_route.Route
 	if redirect.Scheme != nil {
 		envoyRedirect.SchemeRewriteSpecifier = &envoy_route.RedirectAction_SchemeRedirect{
 			SchemeRedirect: *redirect.Scheme,
+		}
+	}
+	if redirect.Path != nil {
+		switch redirect.Path.Type {
+		case api.ReplaceFullPathType:
+			envoyRedirect.PathRewriteSpecifier = &envoy_route.RedirectAction_RegexRewrite{
+				RegexRewrite: &envoy_type_matcher.RegexMatchAndSubstitute{
+					Pattern: &envoy_type_matcher.RegexMatcher{
+						EngineType: &envoy_type_matcher.RegexMatcher_GoogleRe2{
+							GoogleRe2: &envoy_type_matcher.RegexMatcher_GoogleRE2{},
+						},
+						Regex: `.*`,
+					},
+					Substitution: *redirect.Path.ReplaceFullPath,
+				},
+			}
+		case api.ReplacePrefixMatchType:
+			if withPrefixMatch {
+				if envoyRoute.Match.GetPath() != "" {
+					// We have the "exact /prefix" match case
+					envoyRedirect.PathRewriteSpecifier = &envoy_route.RedirectAction_RegexRewrite{
+						RegexRewrite: &envoy_type_matcher.RegexMatchAndSubstitute{
+							Pattern: &envoy_type_matcher.RegexMatcher{
+								EngineType: &envoy_type_matcher.RegexMatcher_GoogleRe2{
+									GoogleRe2: &envoy_type_matcher.RegexMatcher_GoogleRE2{},
+								},
+								Regex: `.*`,
+							},
+							Substitution: *redirect.Path.ReplacePrefixMatch,
+						},
+					}
+				} else if envoyRoute.Match.GetPrefix() != "" {
+					// We have the "prefix /prefix/" match case
+					envoyRedirect.PathRewriteSpecifier = &envoy_route.RedirectAction_PrefixRewrite{
+						PrefixRewrite: *redirect.Path.ReplacePrefixMatch,
+					}
+				}
+			}
 		}
 	}
 

--- a/test/framework/client/collect.go
+++ b/test/framework/client/collect.go
@@ -338,6 +338,7 @@ type FailureResponse struct {
 	ContentType  string `json:"content_type"`
 	URL          string `json:"url"`
 	EffectiveURL string `json:"url_effective"`
+	RedirectURL  string `json:"redirect_url"`
 }
 
 // CollectFailure runs Curl to fetch a URL that is expected to fail. The


### PR DESCRIPTION
Signed-off-by: Ilya Lobkov <ilya.lobkov@konghq.com>

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [X] Link to docs PR or issue --
- [X] Link to UI issue or PR --
- [X] Is the [issue worked on linked][1]? -- Fix https://github.com/kumahq/kuma/issues/5795
- [X] The PR does not hardcode values that might break projects that depend on kuma (e.g. "kumahq" as a image registry) --
- [X] The PR will work for both Linux and Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [X] Unit Tests --
- [X] E2E Tests --
- [X] Manual Universal Tests --
- [X] Manual Kubernetes Tests --
- [X] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [X] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [X] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
