### PR TITLE
fix(helm): dont specify a default type for extraSecrets

### DIFF
--- a/app/kumactl/cmd/install/testdata/install-control-plane.dump-values.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.dump-values.yaml
@@ -231,11 +231,15 @@ controlPlane:
     # -- Kuma CP Image tag. When not specified, the value is copied from global.tag
     tag:
 
-  # -- (list of { Env: string, Secret: string, Key: string }) Secrets to add as environment variables,
+  # -- (object with { Env: string, Secret: string, Key: string }) Secrets to add as environment variables,
   # where `Env` is the name of the env variable,
   # `Secret` is the name of the Secret,
   # and `Key` is the key of the Secret value to use
   secrets:
+  #  someConfig:
+  #    name: some-config
+  #    mountPath: /etc/some-config
+  #    readOnly: true
 
   # -- Additional environment variables that will be passed to the control plane
   envVars: { }
@@ -250,10 +254,11 @@ controlPlane:
 #          extra-config-value
 
   # -- Additional secrets to mount into the control plane
-  extraSecrets: [ ]
-#    - name: extra-config
-#      mountPath: /etc/extra-config
-#      readOnly: true
+  extraSecrets:
+  #  extraConfig:
+  #    name: extra-config
+  #    mountPath: /etc/extra-config
+  #    readOnly: true
 
   webhooks:
     validator:

--- a/deployments/charts/kuma/README.md
+++ b/deployments/charts/kuma/README.md
@@ -71,10 +71,10 @@ A Helm chart for the Kuma Control Plane
 | controlPlane.image.pullPolicy | string | `"IfNotPresent"` | Kuma CP ImagePullPolicy |
 | controlPlane.image.repository | string | `"kuma-cp"` | Kuma CP image repository |
 | controlPlane.image.tag | string | `nil` | Kuma CP Image tag. When not specified, the value is copied from global.tag |
-| controlPlane.secrets | list of { Env: string, Secret: string, Key: string } | `nil` | Secrets to add as environment variables, where `Env` is the name of the env variable, `Secret` is the name of the Secret, and `Key` is the key of the Secret value to use |
+| controlPlane.secrets | object with { Env: string, Secret: string, Key: string } | `nil` | Secrets to add as environment variables, where `Env` is the name of the env variable, `Secret` is the name of the Secret, and `Key` is the key of the Secret value to use |
 | controlPlane.envVars | object | `{}` | Additional environment variables that will be passed to the control plane |
 | controlPlane.extraConfigMaps | list | `[]` | Additional config maps to mount into the control plane, with optional inline values |
-| controlPlane.extraSecrets | list | `[]` | Additional secrets to mount into the control plane |
+| controlPlane.extraSecrets | object with { name: string, mountPath: string, readOnly: string } | `nil` | Additional secrets to mount into the control plane, where `Env` is the name of the env variable, `Secret` is the name of the Secret, and `Key` is the key of the Secret value to use |
 | controlPlane.webhooks.validator.additionalRules | string | `""` | Additional rules to apply on Kuma validator webhook. Useful when building custom policy on top of Kuma. |
 | controlPlane.webhooks.ownerReference.additionalRules | string | `""` | Additional rules to apply on Kuma owner reference webhook. Useful when building custom policy on top of Kuma. |
 | controlPlane.hostNetwork | bool | `false` | Specifies if the deployment should be started in hostNetwork mode. |

--- a/deployments/charts/kuma/values.yaml
+++ b/deployments/charts/kuma/values.yaml
@@ -231,11 +231,15 @@ controlPlane:
     # -- Kuma CP Image tag. When not specified, the value is copied from global.tag
     tag:
 
-  # -- (list of { Env: string, Secret: string, Key: string }) Secrets to add as environment variables,
+  # -- (object with { Env: string, Secret: string, Key: string }) Secrets to add as environment variables,
   # where `Env` is the name of the env variable,
   # `Secret` is the name of the Secret,
   # and `Key` is the key of the Secret value to use
   secrets:
+  #  someSecret:
+  #    Secret: some-secret
+  #    Key: secret_key
+  #    Env: SOME_SECRET
 
   # -- Additional environment variables that will be passed to the control plane
   envVars: { }
@@ -249,11 +253,15 @@ controlPlane:
 #        extra-config-key: |
 #          extra-config-value
 
-  # -- Additional secrets to mount into the control plane
+  # -- (object with { name: string, mountPath: string, readOnly: string }) Additional secrets to mount into the control plane,
+  # where `Env` is the name of the env variable,
+  # `Secret` is the name of the Secret,
+  # and `Key` is the key of the Secret value to use
   extraSecrets:
-#    - name: extra-config
-#      mountPath: /etc/extra-config
-#      readOnly: true
+  #  extraConfig:
+  #    name: extra-config
+  #    mountPath: /etc/extra-config
+  #    readOnly: true
 
   webhooks:
     validator:

--- a/deployments/charts/kuma/values.yaml
+++ b/deployments/charts/kuma/values.yaml
@@ -250,7 +250,7 @@ controlPlane:
 #          extra-config-value
 
   # -- Additional secrets to mount into the control plane
-  extraSecrets: [ ]
+  extraSecrets:
 #    - name: extra-config
 #      mountPath: /etc/extra-config
 #      readOnly: true


### PR DESCRIPTION
Generally it is better to use objects/dicts over lists because the former can be used in the exact same way as the latter and the former adds the functionality of being able to specify which element by name. 

Also, in Helm, lists are overridden completely when using subsequent values.yaml files. On the other hand, objects/dicts are merged, making it easier to create a base values.yaml and override it with values-{env}.yaml without having to copy/paste a lot of stuff. 

See this StackOverflow question: https://stackoverflow.com/questions/59394422/helm-charts-with-multiple-lists-in-multiple-values-files

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [ ] Link to docs PR or issue --
- [ ] Link to UI issue or PR --
- [ ] Is the [issue worked on linked][1]? --
- [ ] The PR does not hardcode values that might break projects that depend on kuma (e.g. "kumahq" as a image registry) --
- [ ] The PR will work for both Linux and Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [ ] Unit Tests --
- [ ] E2E Tests --
- [ ] Manual Universal Tests --
- [ ] Manual Kubernetes Tests --
- [ ] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [ ] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [ ] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
