### PR TITLE
feat(tokens): allow kid to be a string

### DIFF
--- a/pkg/core/managers/apis/mesh/mesh_manager_test.go
+++ b/pkg/core/managers/apis/mesh/mesh_manager_test.go
@@ -90,7 +90,7 @@ var _ = Describe("Mesh Manager", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			// and Dataplane Token Signing Key for the mesh exists
-			key := tokens.SigningKeyResourceKey(issuer.DataplaneTokenSigningKeyPrefix(meshName), tokens.DefaultSerialNumber, meshName)
+			key := tokens.SigningKeyResourceKey(issuer.DataplaneTokenSigningKeyPrefix(meshName), tokens.DefaultKeyID, meshName)
 			err = secretManager.Get(context.Background(), system.NewSecretResource(), store.GetBy(key))
 			Expect(err).ToNot(HaveOccurred())
 		})

--- a/pkg/core/tokens/compatibility_test.go
+++ b/pkg/core/tokens/compatibility_test.go
@@ -91,7 +91,7 @@ var _ = Describe("Compatibility with old ASN.1 format", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		// when new PEM-encoded signing key is created
-		err = signingKeyManager.CreateSigningKey(ctx, 1)
+		err = signingKeyManager.CreateSigningKey(ctx, "1")
 		Expect(err).ToNot(HaveOccurred())
 
 		// then old token is valid

--- a/pkg/core/tokens/file_signing_key_manager.go
+++ b/pkg/core/tokens/file_signing_key_manager.go
@@ -12,32 +12,32 @@ import (
 
 // fileSigningKeyManager is a key manager that only manages one key from specified file
 type fileSigningKeyManager struct {
-	path string
-	kid  string
+	path  string
+	keyID KeyID
 }
 
 var _ SigningKeyManager = &fileSigningKeyManager{}
 
-func NewFileSigningKeyManager(path string, kid string) SigningKeyManager {
+func NewFileSigningKeyManager(path string, keyID KeyID) SigningKeyManager {
 	return &fileSigningKeyManager{
-		path: path,
-		kid:  kid,
+		path:  path,
+		keyID: keyID,
 	}
 }
 
-func (f *fileSigningKeyManager) GetLatestSigningKey(_ context.Context) (*rsa.PrivateKey, string, error) {
+func (f *fileSigningKeyManager) GetLatestSigningKey(context.Context) (*rsa.PrivateKey, KeyID, error) {
 	content, err := os.ReadFile(f.path)
 	if err != nil {
 		return nil, "", err
 	}
 	key, err := util_rsa.FromPEMBytesToPrivateKey(content)
-	return key, f.kid, err
+	return key, f.keyID, err
 }
 
-func (f *fileSigningKeyManager) CreateDefaultSigningKey(ctx context.Context) error {
+func (f *fileSigningKeyManager) CreateDefaultSigningKey(context.Context) error {
 	return errors.New("it's not possible to create key when using file signing key manager")
 }
 
-func (f *fileSigningKeyManager) CreateSigningKey(ctx context.Context, serialNumber int) error {
+func (f *fileSigningKeyManager) CreateSigningKey(context.Context, KeyID) error {
 	return errors.New("it's not possible to create key when using file signing key manager")
 }

--- a/pkg/core/tokens/issuer.go
+++ b/pkg/core/tokens/issuer.go
@@ -32,7 +32,7 @@ func NewTokenIssuer(signingKeyAccessor SigningKeyManager) Issuer {
 var _ Issuer = &jwtTokenIssuer{}
 
 func (j *jwtTokenIssuer) Generate(ctx context.Context, claims Claims, validFor time.Duration) (Token, error) {
-	signingKey, serialNumber, err := j.signingKeyManager.GetLatestSigningKey(ctx)
+	signingKey, keyID, err := j.signingKeyManager.GetLatestSigningKey(ctx)
 	if err != nil {
 		return "", err
 	}
@@ -46,7 +46,7 @@ func (j *jwtTokenIssuer) Generate(ctx context.Context, claims Claims, validFor t
 	})
 
 	token := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
-	token.Header[KeyIDHeader] = serialNumber
+	token.Header[KeyIDHeader] = keyID
 	tokenString, err := token.SignedString(signingKey)
 	if err != nil {
 		return "", errors.Wrap(err, "could not sign a token")

--- a/pkg/core/tokens/issuer_test.go
+++ b/pkg/core/tokens/issuer_test.go
@@ -109,7 +109,7 @@ var _ = Describe("Token issuer", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			// when new signing key with higher serial number is created
-			err = signingKeyManager.CreateSigningKey(ctx, 2)
+			err = signingKeyManager.CreateSigningKey(ctx, "2")
 			Expect(err).ToNot(HaveOccurred())
 
 			// and a new token is generated
@@ -123,7 +123,7 @@ var _ = Describe("Token issuer", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			// when first signing key is deleted
-			err = store.Delete(ctx, system.NewGlobalSecretResource(), core_store.DeleteBy(tokens.SigningKeyResourceKey(TestTokenSigningKeyPrefix, tokens.DefaultSerialNumber, core_model.NoMesh)))
+			err = store.Delete(ctx, system.NewGlobalSecretResource(), core_store.DeleteBy(tokens.SigningKeyResourceKey(TestTokenSigningKeyPrefix, tokens.DefaultKeyID, core_model.NoMesh)))
 			Expect(err).ToNot(HaveOccurred())
 
 			// then old tokens are no longer valid

--- a/pkg/core/tokens/meshed_signing_key_accessor.go
+++ b/pkg/core/tokens/meshed_signing_key_accessor.go
@@ -30,8 +30,8 @@ func NewMeshedSigningKeyAccessor(resManager manager.ReadOnlyResourceManager, sig
 	}
 }
 
-func (s *meshedSigningKeyAccessor) GetPublicKey(ctx context.Context, serialNumber int) (*rsa.PublicKey, error) {
-	keyBytes, err := s.getKeyBytes(ctx, serialNumber)
+func (s *meshedSigningKeyAccessor) GetPublicKey(ctx context.Context, keyID KeyID) (*rsa.PublicKey, error) {
+	keyBytes, err := s.getKeyBytes(ctx, keyID)
 	if err != nil {
 		return nil, err
 	}
@@ -42,14 +42,14 @@ func (s *meshedSigningKeyAccessor) GetPublicKey(ctx context.Context, serialNumbe
 	return &key.PublicKey, nil
 }
 
-func (s *meshedSigningKeyAccessor) getKeyBytes(ctx context.Context, serialNumber int) ([]byte, error) {
+func (s *meshedSigningKeyAccessor) getKeyBytes(ctx context.Context, keyID KeyID) ([]byte, error) {
 	resource := system.NewSecretResource()
-	if err := s.resManager.Get(ctx, resource, store.GetBy(SigningKeyResourceKey(s.signingKeyPrefix, serialNumber, s.mesh))); err != nil {
+	if err := s.resManager.Get(ctx, resource, store.GetBy(SigningKeyResourceKey(s.signingKeyPrefix, keyID, s.mesh))); err != nil {
 		if store.IsResourceNotFound(err) {
 			return nil, &SigningKeyNotFound{
-				SerialNumber: serialNumber,
-				Prefix:       s.signingKeyPrefix,
-				Mesh:         s.mesh,
+				KeyID:  keyID,
+				Prefix: s.signingKeyPrefix,
+				Mesh:   s.mesh,
 			}
 		}
 		return nil, errors.Wrap(err, "could not retrieve signing key")
@@ -57,6 +57,6 @@ func (s *meshedSigningKeyAccessor) getKeyBytes(ctx context.Context, serialNumber
 	return resource.Spec.GetData().GetValue(), nil
 }
 
-func (s *meshedSigningKeyAccessor) GetLegacyKey(ctx context.Context, serialNumber int) ([]byte, error) {
-	return s.getKeyBytes(ctx, serialNumber)
+func (s *meshedSigningKeyAccessor) GetLegacyKey(ctx context.Context, keyID KeyID) ([]byte, error) {
+	return s.getKeyBytes(ctx, keyID)
 }

--- a/pkg/core/tokens/meshed_signing_key_manager.go
+++ b/pkg/core/tokens/meshed_signing_key_manager.go
@@ -32,7 +32,7 @@ type meshedSigningKeyManager struct {
 
 var _ SigningKeyManager = &meshedSigningKeyManager{}
 
-func (s *meshedSigningKeyManager) GetLatestSigningKey(ctx context.Context) (*rsa.PrivateKey, string, error) {
+func (s *meshedSigningKeyManager) GetLatestSigningKey(ctx context.Context) (*rsa.PrivateKey, KeyID, error) {
 	resources := system.SecretResourceList{}
 	if err := s.manager.List(ctx, &resources, store.ListByMesh(s.mesh)); err != nil {
 		return nil, "", errors.Wrap(err, "could not retrieve signing key from secret manager")
@@ -41,10 +41,10 @@ func (s *meshedSigningKeyManager) GetLatestSigningKey(ctx context.Context) (*rsa
 }
 
 func (s *meshedSigningKeyManager) CreateDefaultSigningKey(ctx context.Context) error {
-	return s.CreateSigningKey(ctx, DefaultSerialNumber)
+	return s.CreateSigningKey(ctx, DefaultKeyID)
 }
 
-func (s *meshedSigningKeyManager) CreateSigningKey(ctx context.Context, serialNumber int) error {
+func (s *meshedSigningKeyManager) CreateSigningKey(ctx context.Context, keyID KeyID) error {
 	key, err := NewSigningKey()
 	if err != nil {
 		return err
@@ -56,5 +56,5 @@ func (s *meshedSigningKeyManager) CreateSigningKey(ctx context.Context, serialNu
 			Value: key,
 		},
 	}
-	return s.manager.Create(ctx, secret, store.CreateBy(SigningKeyResourceKey(s.signingKeyPrefix, serialNumber, s.mesh)))
+	return s.manager.Create(ctx, secret, store.CreateBy(SigningKeyResourceKey(s.signingKeyPrefix, keyID, s.mesh)))
 }

--- a/pkg/core/tokens/public_key_secret_signing_key_accessor.go
+++ b/pkg/core/tokens/public_key_secret_signing_key_accessor.go
@@ -27,8 +27,8 @@ func NewSigningKeyFromPublicKeyAccessor(resManager manager.ReadOnlyResourceManag
 	}
 }
 
-func (s *signingKeyFromPublicKeyAccessor) GetPublicKey(ctx context.Context, serialNumber int) (*rsa.PublicKey, error) {
-	keyBytes, err := s.getKeyBytes(ctx, serialNumber)
+func (s *signingKeyFromPublicKeyAccessor) GetPublicKey(ctx context.Context, keyID KeyID) (*rsa.PublicKey, error) {
+	keyBytes, err := s.getKeyBytes(ctx, keyID)
 	if err != nil {
 		return nil, err
 	}
@@ -36,12 +36,12 @@ func (s *signingKeyFromPublicKeyAccessor) GetPublicKey(ctx context.Context, seri
 	return keyBytesToRsaPublicKey(keyBytes)
 }
 
-func (s *signingKeyFromPublicKeyAccessor) getKeyBytes(ctx context.Context, serialNumber int) ([]byte, error) {
-	return getKeyBytes(ctx, s.resManager, s.signingKeyPrefix, serialNumber)
+func (s *signingKeyFromPublicKeyAccessor) getKeyBytes(ctx context.Context, keyID KeyID) ([]byte, error) {
+	return getKeyBytes(ctx, s.resManager, s.signingKeyPrefix, keyID)
 }
 
 // GetLegacyKey is not supported for this accessor as it's not used for signing
 // keys from pre 1.4.x version of Kuma, where we used symmetric HMAC256 method of signing DP keys.
-func (s *signingKeyFromPublicKeyAccessor) GetLegacyKey(_ context.Context, _ int) ([]byte, error) {
+func (s *signingKeyFromPublicKeyAccessor) GetLegacyKey(_ context.Context, _ string) ([]byte, error) {
 	return nil, errors.New("legacy key are not supported")
 }

--- a/pkg/core/tokens/signing_key_accessor.go
+++ b/pkg/core/tokens/signing_key_accessor.go
@@ -12,10 +12,10 @@ import (
 // In that case, we could provide only public key to the CP via static configuration.
 // So we can easily do this by providing separate implementation for this interface.
 type SigningKeyAccessor interface {
-	GetPublicKey(ctx context.Context, serialNumber int) (*rsa.PublicKey, error)
+	GetPublicKey(context.Context, KeyID) (*rsa.PublicKey, error)
 	// GetLegacyKey returns legacy key. In pre 1.4.x version of Kuma, we used symmetric HMAC256 method of signing DP keys.
 	// In that case, we have to retrieve private key even for verification.
-	GetLegacyKey(ctx context.Context, serialNumber int) ([]byte, error)
+	GetLegacyKey(context.Context, KeyID) ([]byte, error)
 }
 
 type signingKeyAccessor struct {
@@ -32,8 +32,8 @@ func NewSigningKeyAccessor(resManager manager.ReadOnlyResourceManager, signingKe
 	}
 }
 
-func (s *signingKeyAccessor) GetPublicKey(ctx context.Context, serialNumber int) (*rsa.PublicKey, error) {
-	keyBytes, err := getKeyBytes(ctx, s.resManager, s.signingKeyPrefix, serialNumber)
+func (s *signingKeyAccessor) GetPublicKey(ctx context.Context, keyID KeyID) (*rsa.PublicKey, error) {
+	keyBytes, err := getKeyBytes(ctx, s.resManager, s.signingKeyPrefix, keyID)
 	if err != nil {
 		return nil, err
 	}
@@ -45,6 +45,6 @@ func (s *signingKeyAccessor) GetPublicKey(ctx context.Context, serialNumber int)
 	return &key.PublicKey, nil
 }
 
-func (s *signingKeyAccessor) GetLegacyKey(ctx context.Context, serialNumber int) ([]byte, error) {
-	return getKeyBytes(ctx, s.resManager, s.signingKeyPrefix, serialNumber)
+func (s *signingKeyAccessor) GetLegacyKey(ctx context.Context, keyID KeyID) ([]byte, error) {
+	return getKeyBytes(ctx, s.resManager, s.signingKeyPrefix, keyID)
 }

--- a/pkg/core/tokens/signing_key_manager.go
+++ b/pkg/core/tokens/signing_key_manager.go
@@ -17,7 +17,7 @@ import (
 )
 
 const (
-	DefaultSerialNumber = 1
+	DefaultKeyID = "1"
 )
 
 // SigningKeyManager manages tokens's signing keys.
@@ -28,7 +28,7 @@ const (
 type SigningKeyManager interface {
 	GetLatestSigningKey(context.Context) (*rsa.PrivateKey, string, error)
 	CreateDefaultSigningKey(context.Context) error
-	CreateSigningKey(ctx context.Context, serialNumber int) error
+	CreateSigningKey(ctx context.Context, keyID KeyID) error
 }
 
 func NewSigningKeyManager(manager manager.ResourceManager, signingKeyPrefix string) SigningKeyManager {
@@ -69,9 +69,9 @@ func latestSigningKey(list model.ResourceList, prefix string, mesh string) (*rsa
 
 	if signingKey == nil {
 		return nil, "", &SigningKeyNotFound{
-			SerialNumber: DefaultSerialNumber,
-			Prefix:       prefix,
-			Mesh:         mesh,
+			KeyID:  DefaultKeyID,
+			Prefix: prefix,
+			Mesh:   mesh,
 		}
 	}
 
@@ -84,10 +84,10 @@ func latestSigningKey(list model.ResourceList, prefix string, mesh string) (*rsa
 }
 
 func (s *signingKeyManager) CreateDefaultSigningKey(ctx context.Context) error {
-	return s.CreateSigningKey(ctx, DefaultSerialNumber)
+	return s.CreateSigningKey(ctx, DefaultKeyID)
 }
 
-func (s *signingKeyManager) CreateSigningKey(ctx context.Context, serialNumber int) error {
+func (s *signingKeyManager) CreateSigningKey(ctx context.Context, keyID KeyID) error {
 	key, err := NewSigningKey()
 	if err != nil {
 		return err
@@ -99,5 +99,5 @@ func (s *signingKeyManager) CreateSigningKey(ctx context.Context, serialNumber i
 			Value: key,
 		},
 	}
-	return s.manager.Create(ctx, secret, store.CreateBy(SigningKeyResourceKey(s.signingKeyPrefix, serialNumber, model.NoMesh)))
+	return s.manager.Create(ctx, secret, store.CreateBy(SigningKeyResourceKey(s.signingKeyPrefix, keyID, model.NoMesh)))
 }

--- a/pkg/core/tokens/token.go
+++ b/pkg/core/tokens/token.go
@@ -10,6 +10,10 @@ type Claims interface {
 	SetRegisteredClaims(claims jwt.RegisteredClaims)
 }
 
+type KeyID = string
+
+const KeyIDFallbackValue = "0"
+
 type KeyIDFallback interface {
 	// KeyIDFallback Marker function to indicate this can be used for tokens with v0
 	// This will be removed with https://github.com/kumahq/kuma/issues/5519

--- a/pkg/defaults/mesh/mesh.go
+++ b/pkg/defaults/mesh/mesh.go
@@ -62,7 +62,7 @@ func EnsureDefaultMeshResources(ctx context.Context, resManager manager.Resource
 		return errors.Wrap(err, "could not create default Dataplane Token Signing Key")
 	}
 	if created {
-		resKey := tokens.SigningKeyResourceKey(issuer.DataplaneTokenSigningKeyPrefix(meshName), tokens.DefaultSerialNumber, meshName)
+		resKey := tokens.SigningKeyResourceKey(issuer.DataplaneTokenSigningKeyPrefix(meshName), tokens.DefaultKeyID, meshName)
 		log.Info("default Dataplane Token Signing Key created", "mesh", meshName, "name", resKey.Name)
 	} else {
 		log.Info("Dataplane Token Signing Key already exists", "mesh", meshName)

--- a/pkg/defaults/mesh/mesh_test.go
+++ b/pkg/defaults/mesh/mesh_test.go
@@ -47,7 +47,7 @@ var _ = Describe("EnsureDefaultMeshResources", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		// and Dataplane Token Signing Key for the mesh exists
-		err = resManager.Get(context.Background(), system.NewSecretResource(), core_store.GetBy(tokens.SigningKeyResourceKey(issuer.DataplaneTokenSigningKeyPrefix(model.DefaultMesh), tokens.DefaultSerialNumber, model.DefaultMesh)))
+		err = resManager.Get(context.Background(), system.NewSecretResource(), core_store.GetBy(tokens.SigningKeyResourceKey(issuer.DataplaneTokenSigningKeyPrefix(model.DefaultMesh), tokens.DefaultKeyID, model.DefaultMesh)))
 		Expect(err).ToNot(HaveOccurred())
 	})
 
@@ -69,7 +69,7 @@ var _ = Describe("EnsureDefaultMeshResources", func() {
 		Expect(err).ToNot(HaveOccurred())
 		err = resManager.Get(context.Background(), core_mesh.NewRetryResource(), core_store.GetByKey("retry-all-default", model.DefaultMesh))
 		Expect(err).ToNot(HaveOccurred())
-		err = resManager.Get(context.Background(), system.NewSecretResource(), core_store.GetBy(tokens.SigningKeyResourceKey(issuer.DataplaneTokenSigningKeyPrefix(model.DefaultMesh), tokens.DefaultSerialNumber, model.DefaultMesh)))
+		err = resManager.Get(context.Background(), system.NewSecretResource(), core_store.GetBy(tokens.SigningKeyResourceKey(issuer.DataplaneTokenSigningKeyPrefix(model.DefaultMesh), tokens.DefaultKeyID, model.DefaultMesh)))
 		Expect(err).ToNot(HaveOccurred())
 	})
 })


### PR DESCRIPTION
Because of offline signing, users can now bring their own tokens to the system. That means that `kid` can be more than just a number and we should allow to put anything here. Vault for example uses UUID. 

I did a bunch of renaming from "serial number" to keyID to be more JWT native. I also adjusted the naming to `keyID` instead of `kid`.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [X] Link to docs PR or issue --
- [X] Link to UI issue or PR --
- [X] Is the [issue worked on linked][1]? --
- [X] The PR does not hardcode values that might break projects that depend on kuma (e.g. "kumahq" as a image registry) --
- [X] The PR will work for both Linux and Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [X] Unit Tests --
- [X] E2E Tests --
- [X] Manual Universal Tests --
- [X] Manual Kubernetes Tests --
- [X] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [X] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [X] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
