### PR TITLE
feat(api-server): manual mTLS

### DIFF
--- a/pkg/config/api-server/config.go
+++ b/pkg/config/api-server/config.go
@@ -99,6 +99,10 @@ type ApiServerHTTPSConfig struct {
 	TlsMaxVersion string `json:"tlsMaxVersion" envconfig:"kuma_api_server_https_tls_max_version"`
 	// TlsCipherSuites defines the list of ciphers to use
 	TlsCipherSuites []string `json:"tlsCipherSuites" envconfig:"kuma_api_server_https_tls_cipher_suites"`
+	// If true, then HTTPS connection will require client cert.
+	RequireClientCert bool `json:"requireClientCert" envconfig:"kuma_api_server_https_require_client_cert"`
+	// Path to the CA certificate which is used to sign client certificates. It is used only for verifying client certificates.
+	TlsCaFile string `json:"tlsCaFile" envconfig:"kuma_api_server_https_tls_ca_file"`
 }
 
 func (a *ApiServerHTTPSConfig) Validate() error {

--- a/pkg/config/app/kuma-cp/kuma-cp.defaults.yaml
+++ b/pkg/config/app/kuma-cp/kuma-cp.defaults.yaml
@@ -146,12 +146,16 @@ apiServer:
     tlsCertFile: "" # ENV: KUMA_API_SERVER_HTTPS_TLS_CERT_FILE
     # Path to TLS key file. Autoconfigured from KUMA_GENERAL_TLS_KEY_FILE if empty
     tlsKeyFile: "" # ENV: KUMA_API_SERVER_HTTPS_TLS_KEY_FILE
+    # Path to the CA certificate which is used to sign client certificates. It is used only for verifying client certificates.
+    tlsCaFile: "" # ENV: KUMA_API_SERVER_HTTPS_CLIENT_CERTS_CA_FILE
     # TlsMinVersion the minimum version of TLS used across all the Kuma Servers.
     tlsMinVersion: "TLSv1_2" # ENV: KUMA_API_SERVER_HTTPS_TLS_MIN_VERSION
     # TlsMaxVersion the maximum version of TLS used across all the Kuma Servers.
     tlsMaxVersion: # ENV: KUMA_API_SERVER_HTTPS_TLS_MAX_VERSION
     # TlsCipherSuites the list of cipher suites to be used across all the Kuma Servers.
     tlsCipherSuites: [] # ENV: KUMA_API_SERVER_HTTPS_TLS_CIPHER_SUITES
+    # If true, then HTTPS connection will require client cert.
+    requireClientCert: false # ENV: KUMA_API_SERVER_HTTPS_REQUIRE_CLIENT_CERT
   # Authentication configuration for administrative endpoints like Dataplane Token or managing Secrets
   auth:
     # Directory of authorized client certificates (only validate in HTTPS)

--- a/pkg/config/loader_test.go
+++ b/pkg/config/loader_test.go
@@ -126,9 +126,11 @@ var _ = Describe("Config loader", func() {
 			Expect(cfg.ApiServer.HTTPS.Port).To(Equal(uint32(15682)))
 			Expect(cfg.ApiServer.HTTPS.TlsCertFile).To(Equal("/cert"))
 			Expect(cfg.ApiServer.HTTPS.TlsKeyFile).To(Equal("/key"))
+			Expect(cfg.ApiServer.HTTPS.TlsCaFile).To(Equal("/ca"))
 			Expect(cfg.ApiServer.HTTPS.TlsMinVersion).To(Equal("TLSv1_3"))
 			Expect(cfg.ApiServer.HTTPS.TlsMaxVersion).To(Equal("TLSv1_3"))
 			Expect(cfg.ApiServer.HTTPS.TlsCipherSuites).To(Equal([]string{"TLS_RSA_WITH_AES_128_CBC_SHA", "TLS_AES_256_GCM_SHA384"}))
+			Expect(cfg.ApiServer.HTTPS.RequireClientCert).To(BeTrue())
 			Expect(cfg.ApiServer.Auth.ClientCertsDir).To(Equal("/certs"))
 			Expect(cfg.ApiServer.Authn.LocalhostIsAdmin).To(Equal(false))
 			Expect(cfg.ApiServer.Authn.Type).To(Equal("custom-authn"))
@@ -362,9 +364,11 @@ apiServer:
     port: 15682 # ENV: KUMA_API_SERVER_HTTPS_PORT
     tlsCertFile: "/cert" # ENV: KUMA_API_SERVER_HTTPS_TLS_CERT_FILE
     tlsKeyFile: "/key" # ENV: KUMA_API_SERVER_HTTPS_TLS_KEY_FILE
+    tlsCaFile: "/ca"
     tlsMinVersion: TLSv1_3
     tlsMaxVersion: TLSv1_3
     tlsCipherSuites: ["TLS_RSA_WITH_AES_128_CBC_SHA", "TLS_AES_256_GCM_SHA384"]
+    requireClientCert: true
   auth:
     clientCertsDir: "/certs" # ENV: KUMA_API_SERVER_AUTH_CLIENT_CERTS_DIR
   authn:
@@ -635,9 +639,11 @@ proxy:
 				"KUMA_API_SERVER_HTTPS_INTERFACE":                                                          "192.168.0.2",
 				"KUMA_API_SERVER_HTTPS_TLS_CERT_FILE":                                                      "/cert",
 				"KUMA_API_SERVER_HTTPS_TLS_KEY_FILE":                                                       "/key",
+				"KUMA_API_SERVER_HTTPS_TLS_CA_FILE":                                                        "/ca",
 				"KUMA_API_SERVER_HTTPS_TLS_MIN_VERSION":                                                    "TLSv1_3",
 				"KUMA_API_SERVER_HTTPS_TLS_MAX_VERSION":                                                    "TLSv1_3",
 				"KUMA_API_SERVER_HTTPS_TLS_CIPHER_SUITES":                                                  "TLS_RSA_WITH_AES_128_CBC_SHA,TLS_AES_256_GCM_SHA384",
+				"KUMA_API_SERVER_HTTPS_REQUIRE_CLIENT_CERT":                                                "true",
 				"KUMA_API_SERVER_AUTH_CLIENT_CERTS_DIR":                                                    "/certs",
 				"KUMA_API_SERVER_AUTHN_TYPE":                                                               "custom-authn",
 				"KUMA_API_SERVER_AUTHN_LOCALHOST_IS_ADMIN":                                                 "false",


### PR DESCRIPTION
Adds the ability to enable mTLS to HTTPS API Server. It does not require to use deprecated authentication method of adminClientCert. You can use it with any auth method including user tokens.

I tested manually. I'm figuring out E2E test.

Fix #5976

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [X] Link to docs PR or issue --
- [X] Link to UI issue or PR --
- [X] Is the [issue worked on linked][1]? --
- [x] The PR does not hardcode values that might break projects that depend on kuma (e.g. "kumahq" as a image registry) --
- [X] The PR will work for both Linux and Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [X] Unit Tests --
- [X] E2E Tests --
- [X] Manual Universal Tests --
- [X] Manual Kubernetes Tests --
- [X] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [X] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [X] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
