### PR TITLE
fix(helm): use custom CA in egress and ingress too

### DIFF
--- a/app/kumactl/cmd/install/testdata/install-control-plane.with-helm-set.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.with-helm-set.yaml
@@ -5537,7 +5537,7 @@ spec:
             - name: KUMA_CONTROL_PLANE_URL
               value: "https://kuma-control-plane.kuma-system:5678"
             - name: KUMA_CONTROL_PLANE_CA_CERT_FILE
-              value: /var/run/secrets/kuma.io/tls-cert/ca.crt
+              value: /var/run/secrets/kuma.io/cp-ca/ca.crt
             - name: KUMA_DATAPLANE_NAME
               value: $(POD_NAME).$(POD_NAMESPACE)
             - name: KUMA_DATAPLANE_DRAIN_TIME
@@ -5577,13 +5577,16 @@ spec:
               cpu: 1000m
               memory: 512Mi
           volumeMounts:
-            - name: kuma-tls-cert
-              mountPath: /var/run/secrets/kuma.io/tls-cert
+            - name: control-plane-ca
+              mountPath: /var/run/secrets/kuma.io/cp-ca
               readOnly: true
       volumes:
-        - name: kuma-tls-cert
+        - name: control-plane-ca
           secret:
-            secretName: kuma-tls-cert
+            secretName: "kuma-tls-cert"
+            items:
+              - key: ca.crt
+                path: ca.crt
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -5655,7 +5658,7 @@ spec:
             - name: KUMA_CONTROL_PLANE_URL
               value: "https://kuma-control-plane.kuma-system:5678"
             - name: KUMA_CONTROL_PLANE_CA_CERT_FILE
-              value: /var/run/secrets/kuma.io/tls-cert/ca.crt
+              value: /var/run/secrets/kuma.io/cp-ca/ca.crt
             - name: KUMA_DATAPLANE_NAME
               value: $(POD_NAME).$(POD_NAMESPACE)
             - name: KUMA_DATAPLANE_DRAIN_TIME
@@ -5696,13 +5699,16 @@ spec:
               memory: 64Mi
           
           volumeMounts:
-            - name: kuma-tls-cert
-              mountPath: /var/run/secrets/kuma.io/tls-cert
+            - name: control-plane-ca
+              mountPath: /var/run/secrets/kuma.io/cp-ca
               readOnly: true
       volumes:
-        - name: kuma-tls-cert
+        - name: control-plane-ca
           secret:
-            secretName: kuma-tls-cert
+            secretName: "kuma-tls-cert"
+            items:
+              - key: ca.crt
+                path: ca.crt
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration

--- a/app/kumactl/cmd/install/testdata/install-control-plane.with-ingress.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.with-ingress.golden.yaml
@@ -574,7 +574,7 @@ spec:
             - name: KUMA_CONTROL_PLANE_URL
               value: "https://kuma-control-plane.kuma-system:5678"
             - name: KUMA_CONTROL_PLANE_CA_CERT_FILE
-              value: /var/run/secrets/kuma.io/tls-cert/ca.crt
+              value: /var/run/secrets/kuma.io/cp-ca/ca.crt
             - name: KUMA_DATAPLANE_NAME
               value: $(POD_NAME).$(POD_NAMESPACE)
             - name: KUMA_DATAPLANE_DRAIN_TIME
@@ -615,13 +615,16 @@ spec:
               memory: 64Mi
           
           volumeMounts:
-            - name: kuma-tls-cert
-              mountPath: /var/run/secrets/kuma.io/tls-cert
+            - name: control-plane-ca
+              mountPath: /var/run/secrets/kuma.io/cp-ca
               readOnly: true
       volumes:
-        - name: kuma-tls-cert
+        - name: control-plane-ca
           secret:
-            secretName: kuma-tls-cert
+            secretName: "kuma-tls-cert"
+            items:
+              - key: ca.crt
+                path: ca.crt
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/fix4496.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/fix4496.golden.yaml
@@ -587,7 +587,7 @@ spec:
             - name: KUMA_CONTROL_PLANE_URL
               value: "https://kuma-control-plane.kuma-system:5678"
             - name: KUMA_CONTROL_PLANE_CA_CERT_FILE
-              value: /var/run/secrets/kuma.io/tls-cert/ca.crt
+              value: /var/run/secrets/kuma.io/cp-ca/ca.crt
             - name: KUMA_DATAPLANE_NAME
               value: $(POD_NAME).$(POD_NAMESPACE)
             - name: KUMA_DATAPLANE_DRAIN_TIME
@@ -628,13 +628,16 @@ spec:
               memory: 64Mi
           
           volumeMounts:
-            - name: kuma-tls-cert
-              mountPath: /var/run/secrets/kuma.io/tls-cert
+            - name: control-plane-ca
+              mountPath: /var/run/secrets/kuma.io/cp-ca
               readOnly: true
       volumes:
-        - name: kuma-tls-cert
+        - name: control-plane-ca
           secret:
-            secretName: kuma-tls-cert
+            secretName: "kuma-tls-cert"
+            items:
+              - key: ca.crt
+                path: ca.crt
 ---
 apiVersion: networking.k8s.io/v1
 kind: Ingress

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/fix4935.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/fix4935.golden.yaml
@@ -795,7 +795,7 @@ spec:
             - name: KUMA_CONTROL_PLANE_URL
               value: "https://kuma-control-plane.kuma-system:5678"
             - name: KUMA_CONTROL_PLANE_CA_CERT_FILE
-              value: /var/run/secrets/kuma.io/tls-cert/ca.crt
+              value: /var/run/secrets/kuma.io/cp-ca/ca.crt
             - name: KUMA_DATAPLANE_NAME
               value: $(POD_NAME).$(POD_NAMESPACE)
             - name: KUMA_DATAPLANE_DRAIN_TIME
@@ -835,13 +835,16 @@ spec:
               cpu: 1000m
               memory: 512Mi
           volumeMounts:
-            - name: kuma-tls-cert
-              mountPath: /var/run/secrets/kuma.io/tls-cert
+            - name: control-plane-ca
+              mountPath: /var/run/secrets/kuma.io/cp-ca
               readOnly: true
       volumes:
-        - name: kuma-tls-cert
+        - name: control-plane-ca
           secret:
-            secretName: kuma-tls-cert
+            secretName: "kuma-tls-cert"
+            items:
+              - key: ca.crt
+                path: ca.crt
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -916,7 +919,7 @@ spec:
             - name: KUMA_CONTROL_PLANE_URL
               value: "https://kuma-control-plane.kuma-system:5678"
             - name: KUMA_CONTROL_PLANE_CA_CERT_FILE
-              value: /var/run/secrets/kuma.io/tls-cert/ca.crt
+              value: /var/run/secrets/kuma.io/cp-ca/ca.crt
             - name: KUMA_DATAPLANE_NAME
               value: $(POD_NAME).$(POD_NAMESPACE)
             - name: KUMA_DATAPLANE_DRAIN_TIME
@@ -957,13 +960,16 @@ spec:
               memory: 64Mi
           
           volumeMounts:
-            - name: kuma-tls-cert
-              mountPath: /var/run/secrets/kuma.io/tls-cert
+            - name: control-plane-ca
+              mountPath: /var/run/secrets/kuma.io/cp-ca
               readOnly: true
       volumes:
-        - name: kuma-tls-cert
+        - name: control-plane-ca
           secret:
-            secretName: kuma-tls-cert
+            secretName: "kuma-tls-cert"
+            items:
+              - key: ca.crt
+                path: ca.crt
 ---
 apiVersion: networking.k8s.io/v1
 kind: Ingress

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/fix5978.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/fix5978.golden.yaml
@@ -28,6 +28,16 @@ metadata:
     app.kubernetes.io/instance: kuma
 ---
 apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kuma-ingress
+  namespace: kuma-system
+  labels: 
+    app: kuma-ingress
+    app.kubernetes.io/name: kuma
+    app.kubernetes.io/instance: kuma
+---
+apiVersion: v1
 kind: ConfigMap
 metadata:
   name: kuma-control-plane-config
@@ -347,6 +357,27 @@ spec:
     app.kubernetes.io/name: kuma
     app.kubernetes.io/instance: kuma
 ---
+apiVersion: v1
+kind: Service
+metadata:
+  name: kuma-ingress
+  namespace: kuma-system
+  labels: 
+    app: kuma-ingress
+    app.kubernetes.io/name: kuma
+    app.kubernetes.io/instance: kuma
+  annotations:
+spec:
+  type: LoadBalancer
+  ports:
+    - port: 10001
+      protocol: TCP
+      targetPort: 10001
+  selector:
+    app: kuma-ingress
+    app.kubernetes.io/name: kuma
+    app.kubernetes.io/instance: kuma
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -426,7 +457,11 @@ spec:
             - name: KUMA_INJECTOR_INIT_CONTAINER_IMAGE
               value: "docker.io/kumahq/kuma-init:0.0.1"
             - name: KUMA_MODE
-              value: "standalone"
+              value: "zone"
+            - name: KUMA_MULTIZONE_ZONE_GLOBAL_ADDRESS
+              value: "grpcs://foo.com:3456"
+            - name: KUMA_MULTIZONE_ZONE_NAME
+              value: "east"
             - name: KUMA_RUNTIME_KUBERNETES_ADMISSION_SERVER_CERT_DIR
               value: "/var/run/secrets/kuma.io/tls-cert"
             - name: KUMA_RUNTIME_KUBERNETES_ADMISSION_SERVER_PORT
@@ -485,7 +520,7 @@ spec:
               mountPath: /var/run/secrets/kuma.io/tls-cert/tls.key
               subPath: tls.key
               readOnly: true
-            - name: general-tls-cert
+            - name: general-tls-cert-ca
               mountPath: /var/run/secrets/kuma.io/tls-cert/ca.crt
               subPath: ca.crt
               readOnly: true
@@ -496,6 +531,9 @@ spec:
         - name: general-tls-cert
           secret:
             secretName: general-tls-secret
+        - name: general-tls-cert-ca
+          secret:
+            secretName: my-custom-ca-name
         - name: kuma-control-plane-config
           configMap:
             name: kuma-control-plane-config
@@ -573,7 +611,7 @@ spec:
             - name: KUMA_DATAPLANE_NAME
               value: $(POD_NAME).$(POD_NAMESPACE)
             - name: KUMA_DATAPLANE_DRAIN_TIME
-              value: 60s
+              value: 30s
             - name: KUMA_DATAPLANE_RUNTIME_TOKEN_PATH
               value: /var/run/secrets/kubernetes.io/serviceaccount/token
             - name: KUMA_DATAPLANE_PROXY_TYPE
@@ -615,7 +653,129 @@ spec:
       volumes:
         - name: control-plane-ca
           secret:
-            secretName: "kuma-tls-cert"
+            secretName: "my-custom-ca-name"
+            items:
+              - key: ca.crt
+                path: ca.crt
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kuma-ingress
+  namespace: kuma-system
+  labels: 
+    app: kuma-ingress
+    app.kubernetes.io/name: kuma
+    app.kubernetes.io/instance: kuma
+spec:
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: kuma
+      app.kubernetes.io/instance: kuma
+      app: kuma-ingress
+  template:
+    metadata:
+      annotations:
+        kuma.io/ingress: enabled
+      labels:
+        app: kuma-ingress
+        app.kubernetes.io/name: kuma
+        app.kubernetes.io/instance: kuma
+    spec:
+      affinity: 
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: app.kubernetes.io/name
+                  operator: In
+                  values:
+                  - 'kuma'
+                - key: app.kubernetes.io/instance
+                  operator: In
+                  values:
+                  - 'kuma'
+                - key: app
+                  operator: In
+                  values:
+                  - kuma-ingress
+              topologyKey: kubernetes.io/hostname
+            weight: 100
+      serviceAccountName: kuma-ingress
+      nodeSelector:
+      
+        kubernetes.io/os: linux
+      terminationGracePeriodSeconds: 30
+      containers:
+        - name: ingress
+          image: "docker.io/kumahq/kuma-dp:0.0.1"
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: KUMA_CONTROL_PLANE_URL
+              value: "https://kuma-control-plane.kuma-system:5678"
+            - name: KUMA_CONTROL_PLANE_CA_CERT_FILE
+              value: /var/run/secrets/kuma.io/cp-ca/ca.crt
+            - name: KUMA_DATAPLANE_NAME
+              value: $(POD_NAME).$(POD_NAMESPACE)
+            - name: KUMA_DATAPLANE_DRAIN_TIME
+              value: 30s
+            - name: KUMA_DATAPLANE_RUNTIME_TOKEN_PATH
+              value: /var/run/secrets/kubernetes.io/serviceaccount/token
+            - name: KUMA_DATAPLANE_PROXY_TYPE
+              value: "ingress"
+          args:
+            - run
+            - --log-level=info
+          ports:
+            - containerPort: 10001
+          livenessProbe:
+            httpGet:
+              path: "/ready"
+              port: 9901
+            failureThreshold: 12
+            initialDelaySeconds: 60
+            periodSeconds: 5
+            successThreshold: 1
+            timeoutSeconds: 3
+          readinessProbe:
+            httpGet:
+              path: "/ready"
+              port: 9901
+            failureThreshold: 12
+            initialDelaySeconds: 1
+            periodSeconds: 5
+            successThreshold: 1
+            timeoutSeconds: 3
+          resources: 
+            limits:
+              cpu: 1000m
+              memory: 512Mi
+            requests:
+              cpu: 50m
+              memory: 64Mi
+          
+          volumeMounts:
+            - name: control-plane-ca
+              mountPath: /var/run/secrets/kuma.io/cp-ca
+              readOnly: true
+      volumes:
+        - name: control-plane-ca
+          secret:
+            secretName: "my-custom-ca-name"
             items:
               - key: ca.crt
                 path: ca.crt

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/fix5978.values.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/fix5978.values.yaml
@@ -1,0 +1,11 @@
+controlPlane:
+  mode: zone
+  zone: east
+  kdsGlobalAddress: "grpcs://foo.com:3456"
+  tls:
+    general:
+      caSecretName: my-custom-ca-name
+ingress:
+  enabled: true
+egress:
+  enabled: true

--- a/deployments/charts/kuma/templates/cp-deployment.yaml
+++ b/deployments/charts/kuma/templates/cp-deployment.yaml
@@ -191,11 +191,7 @@ spec:
               mountPath: /var/run/secrets/kuma.io/tls-cert/tls.key
               subPath: tls.key
               readOnly: true
-          {{- if .Values.controlPlane.tls.general.caSecretName }}
-            - name: general-tls-cert-ca
-          {{- else}}
-            - name: general-tls-cert
-          {{- end }}
+            - name: general-tls-cert{{- if .Values.controlPlane.tls.general.caSecretName }}-ca{{- end }}
               mountPath: /var/run/secrets/kuma.io/tls-cert/ca.crt
               subPath: ca.crt
               readOnly: true

--- a/deployments/charts/kuma/templates/egress-deployment.yaml
+++ b/deployments/charts/kuma/templates/egress-deployment.yaml
@@ -66,7 +66,7 @@ spec:
             - name: KUMA_CONTROL_PLANE_URL
               value: "https://{{ include "kuma.controlPlane.serviceName" . }}.{{ .Release.Namespace }}:5678"
             - name: KUMA_CONTROL_PLANE_CA_CERT_FILE
-              value: /var/run/secrets/kuma.io/tls-cert/ca.crt
+              value: /var/run/secrets/kuma.io/cp-ca/ca.crt
             - name: KUMA_DATAPLANE_NAME
               value: $(POD_NAME).$(POD_NAMESPACE)
             - name: KUMA_DATAPLANE_DRAIN_TIME
@@ -106,11 +106,14 @@ spec:
               cpu: 1000m
               memory: 512Mi
           volumeMounts:
-            - name: {{ include "kuma.name" . }}-tls-cert
-              mountPath: /var/run/secrets/kuma.io/tls-cert
+            - name: control-plane-ca
+              mountPath: /var/run/secrets/kuma.io/cp-ca
               readOnly: true
       volumes:
-        - name: {{ include "kuma.name" . }}-tls-cert
+        - name: control-plane-ca
           secret:
-            secretName: {{ include "kuma.name" . }}-tls-cert
-{{- end }}
+            secretName: {{.Values.controlPlane.tls.general.caSecretName | default (printf "%s-tls-cert" (include "kuma.name" .)) | quote }}
+            items:
+              - key: ca.crt
+                path: ca.crt
+  {{- end }}

--- a/deployments/charts/kuma/templates/ingress-deployment.yaml
+++ b/deployments/charts/kuma/templates/ingress-deployment.yaml
@@ -67,7 +67,7 @@ spec:
             - name: KUMA_CONTROL_PLANE_URL
               value: "https://{{ include "kuma.controlPlane.serviceName" . }}.{{ .Release.Namespace }}:5678"
             - name: KUMA_CONTROL_PLANE_CA_CERT_FILE
-              value: /var/run/secrets/kuma.io/tls-cert/ca.crt
+              value: /var/run/secrets/kuma.io/cp-ca/ca.crt
             - name: KUMA_DATAPLANE_NAME
               value: $(POD_NAME).$(POD_NAMESPACE)
             - name: KUMA_DATAPLANE_DRAIN_TIME
@@ -104,11 +104,14 @@ spec:
           lifecycle: {{ . | toYaml | nindent 12 }}
           {{ end }}
           volumeMounts:
-            - name: {{ include "kuma.name" . }}-tls-cert
-              mountPath: /var/run/secrets/kuma.io/tls-cert
+            - name: control-plane-ca
+              mountPath: /var/run/secrets/kuma.io/cp-ca
               readOnly: true
       volumes:
-        - name: {{ include "kuma.name" . }}-tls-cert
+        - name: control-plane-ca
           secret:
-            secretName: {{ include "kuma.name" . }}-tls-cert
+            secretName: {{.Values.controlPlane.tls.general.caSecretName | default (printf "%s-tls-cert" (include "kuma.name" .)) | quote }}
+            items:
+              - key: ca.crt
+                path: ca.crt
 {{- end }}


### PR DESCRIPTION
While we've always been able to pass a specific CA for control-plane certs it wasn't possible to use it for egress and ingress. Now we just use whatever is set. We also simplified the template when handling CAs

Fix #5978 

Signed-off-by: Charly Molter <charly.molter@konghq.com>

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] Link to docs PR or issue --
- [x] Link to UI issue or PR --
- [x] Is the [issue worked on linked][1]? --
- [x] The PR does not hardcode values that might break projects that depend on kuma (e.g. "kumahq" as a image registry) --
- [x] The PR will work for both Linux and Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Unit Tests --
- [x] E2E Tests --
- [x] Manual Universal Tests --
- [x] Manual Kubernetes Tests --
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [x] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
