### PR TITLE
feat(auth): separate authenticators for dp and zone proxy

### DIFF
--- a/pkg/core/runtime/runtime.go
+++ b/pkg/core/runtime/runtime.go
@@ -29,10 +29,8 @@ import (
 	"github.com/kumahq/kuma/pkg/tokens/builtin"
 	tokens_access "github.com/kumahq/kuma/pkg/tokens/builtin/access"
 	zone_access "github.com/kumahq/kuma/pkg/tokens/builtin/zone/access"
-	util_xds "github.com/kumahq/kuma/pkg/util/xds"
-	xds_auth "github.com/kumahq/kuma/pkg/xds/auth"
 	mesh "github.com/kumahq/kuma/pkg/xds/cache/mesh"
-	xds_hooks "github.com/kumahq/kuma/pkg/xds/hooks"
+	xds_runtime "github.com/kumahq/kuma/pkg/xds/runtime"
 	"github.com/kumahq/kuma/pkg/xds/secrets"
 )
 
@@ -67,11 +65,7 @@ type RuntimeContext interface {
 	Metrics() metrics.Metrics
 	EventReaderFactory() events.ListenerFactory
 	APIInstaller() api_server.APIInstaller
-	// XDSAuthenticator is used for any server that communicates via xDS
-	XDSAuthenticator() xds_auth.Authenticator
-	// XDSServerCallbacks is used for callbacks for the Envoy xDS server
-	XDSServerCallbacks() util_xds.Callbacks
-	XDSHooks() *xds_hooks.Hooks
+	XDS() xds_runtime.XDSRuntimeContext
 	CAProvider() secrets.CaProvider
 	DpServer() *dp_server.DpServer
 	KDSContext() *kds_context.Context
@@ -157,9 +151,7 @@ type runtimeContext struct {
 	metrics        metrics.Metrics
 	erf            events.ListenerFactory
 	apim           api_server.APIInstaller
-	xdsauth        xds_auth.Authenticator
-	xdsCallbacks   util_xds.Callbacks
-	xdsh           *xds_hooks.Hooks
+	xds            xds_runtime.XDSRuntimeContext
 	cap            secrets.CaProvider
 	dps            *dp_server.DpServer
 	kdsctx         *kds_context.Context
@@ -244,16 +236,8 @@ func (rc *runtimeContext) CAProvider() secrets.CaProvider {
 	return rc.cap
 }
 
-func (rc *runtimeContext) XDSAuthenticator() xds_auth.Authenticator {
-	return rc.xdsauth
-}
-
-func (rc *runtimeContext) XDSServerCallbacks() util_xds.Callbacks {
-	return rc.xdsCallbacks
-}
-
-func (rc *runtimeContext) XDSHooks() *xds_hooks.Hooks {
-	return rc.xdsh
+func (rc *runtimeContext) XDS() xds_runtime.XDSRuntimeContext {
+	return rc.xds
 }
 
 func (rc *runtimeContext) KDSContext() *kds_context.Context {

--- a/pkg/hds/components.go
+++ b/pkg/hds/components.go
@@ -47,15 +47,13 @@ func Setup(rt core_runtime.Runtime) error {
 }
 
 func DefaultCallbacks(rt core_runtime.Runtime, cache util_xds_v3.SnapshotCache) (hds_callbacks.Callbacks, error) {
-	authenticator := rt.XDSAuthenticator()
-
 	metrics, err := hds_metrics.NewMetrics(rt.Metrics())
 	if err != nil {
 		return nil, err
 	}
 
 	return hds_callbacks.Chain{
-		authn.NewCallbacks(rt.ResourceManager(), authenticator, authn.DPNotFoundRetry{
+		authn.NewCallbacks(rt.ResourceManager(), rt.XDS().DpProxyAuthenticator, authn.DPNotFoundRetry{
 			// Usually the difference between DP is created from ADS and HDS is initiated is less than 1 second, but just in case we set this higher.
 			Backoff:  1 * time.Second,
 			MaxTimes: 30,

--- a/pkg/plugins/bootstrap/k8s/plugin.go
+++ b/pkg/plugins/bootstrap/k8s/plugin.go
@@ -147,7 +147,7 @@ func (p *plugin) AfterBootstrap(b *core_runtime.Builder, _ core_plugins.PluginCo
 		return errors.Wrapf(err, "could not parse KUBERNETES_SERVICE_PORT environment variable")
 	}
 
-	b.XDSHooks().AddResourceSetHook(hooks.NewApiServerBypass(apiServerAddress, uint32(apiServerPort)))
+	b.XDS().Hooks.AddResourceSetHook(hooks.NewApiServerBypass(apiServerAddress, uint32(apiServerPort)))
 
 	return nil
 }

--- a/pkg/xds/auth/per_proxy_type_authenticator.go
+++ b/pkg/xds/auth/per_proxy_type_authenticator.go
@@ -1,0 +1,35 @@
+package auth
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+
+	"github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
+	core_model "github.com/kumahq/kuma/pkg/core/resources/model"
+)
+
+type perProxyTypeAuthenticator struct {
+	dpProxyAuthenticator   Authenticator
+	zoneProxyAuthenticator Authenticator
+}
+
+var _ Authenticator = &perProxyTypeAuthenticator{}
+
+func NewPerProxyTypeAuthenticator(dpProxyAuthenticator Authenticator, zoneProxyAuthenticator Authenticator) Authenticator {
+	return &perProxyTypeAuthenticator{
+		dpProxyAuthenticator:   dpProxyAuthenticator,
+		zoneProxyAuthenticator: zoneProxyAuthenticator,
+	}
+}
+
+func (p perProxyTypeAuthenticator) Authenticate(ctx context.Context, resource core_model.Resource, credential Credential) error {
+	switch resource.Descriptor().Name {
+	case mesh.ZoneIngressType, mesh.ZoneEgressType:
+		return p.zoneProxyAuthenticator.Authenticate(ctx, resource, credential)
+	case mesh.DataplaneType:
+		return p.dpProxyAuthenticator.Authenticate(ctx, resource, credential)
+	default:
+		return errors.New("unknown proxy type")
+	}
+}

--- a/pkg/xds/runtime/context.go
+++ b/pkg/xds/runtime/context.go
@@ -1,0 +1,32 @@
+package runtime
+
+import (
+	util_xds "github.com/kumahq/kuma/pkg/util/xds"
+	xds_auth "github.com/kumahq/kuma/pkg/xds/auth"
+	"github.com/kumahq/kuma/pkg/xds/auth/components"
+	xds_hooks "github.com/kumahq/kuma/pkg/xds/hooks"
+)
+
+type XDSRuntimeContext struct {
+	DpProxyAuthenticator   xds_auth.Authenticator
+	ZoneProxyAuthenticator xds_auth.Authenticator
+	Hooks                  *xds_hooks.Hooks
+	ServerCallbacks        util_xds.Callbacks
+}
+
+func Default(ctx components.Context) (XDSRuntimeContext, error) {
+	auth, err := components.DefaultAuthenticator(ctx)
+	if err != nil {
+		return XDSRuntimeContext{}, err
+	}
+
+	return XDSRuntimeContext{
+		Hooks:                  &xds_hooks.Hooks{},
+		DpProxyAuthenticator:   auth,
+		ZoneProxyAuthenticator: auth,
+	}, nil
+}
+
+func (x XDSRuntimeContext) PerProxyTypeAuthenticator() xds_auth.Authenticator {
+	return xds_auth.NewPerProxyTypeAuthenticator(x.DpProxyAuthenticator, x.ZoneProxyAuthenticator)
+}

--- a/pkg/xds/server/v3/components.go
+++ b/pkg/xds/server/v3/components.go
@@ -35,7 +35,7 @@ func RegisterXDS(
 ) error {
 	xdsContext := NewXdsContext()
 
-	authenticator := rt.XDSAuthenticator()
+	authenticator := rt.XDS().PerProxyTypeAuthenticator()
 	authCallbacks := auth.NewCallbacks(rt.ReadOnlyResourceManager(), authenticator, auth.DPNotFoundRetry{}) // no need to retry on DP Not Found because we are creating DP in DataplaneLifecycle callback
 
 	metadataTracker := xds_callbacks.NewDataplaneMetadataTracker()
@@ -61,7 +61,7 @@ func RegisterXDS(
 		newResourceWarmingForcer(xdsContext.Cache(), xdsContext.Hasher()),
 	}
 
-	if cb := rt.XDSServerCallbacks(); cb != nil {
+	if cb := rt.XDS().ServerCallbacks; cb != nil {
 		callbacks = append(callbacks, util_xds_v3.AdaptCallbacks(cb))
 	}
 
@@ -86,7 +86,7 @@ func DefaultReconciler(
 
 	return &reconciler{
 		generator: &TemplateSnapshotGenerator{
-			ResourceSetHooks:      rt.XDSHooks().ResourceSetHooks(),
+			ResourceSetHooks:      rt.XDS().Hooks.ResourceSetHooks(),
 			ProxyTemplateResolver: resolver,
 		},
 		cacher:         &simpleSnapshotCacher{xdsContext.Hasher(), xdsContext.Cache()},
@@ -111,7 +111,7 @@ func DefaultIngressReconciler(
 
 	return &reconciler{
 		generator: &TemplateSnapshotGenerator{
-			ResourceSetHooks:      rt.XDSHooks().ResourceSetHooks(),
+			ResourceSetHooks:      rt.XDS().Hooks.ResourceSetHooks(),
 			ProxyTemplateResolver: resolver,
 		},
 		cacher:         &simpleSnapshotCacher{xdsContext.Hasher(), xdsContext.Cache()},
@@ -136,7 +136,7 @@ func DefaultEgressReconciler(
 
 	return &reconciler{
 		generator: &TemplateSnapshotGenerator{
-			ResourceSetHooks:      rt.XDSHooks().ResourceSetHooks(),
+			ResourceSetHooks:      rt.XDS().Hooks.ResourceSetHooks(),
 			ProxyTemplateResolver: resolver,
 		},
 		cacher:         &simpleSnapshotCacher{xdsContext.Hasher(), xdsContext.Cache()},


### PR DESCRIPTION
Introduce the possibility to have a separate authenticator for dp and zone proxy.
This is in line with schemas https://github.com/kumahq/kuma/blob/master/docs/madr/decisions/019-offline-signing-tokens.md

Currently, we have to set `KUMA_DP_SERVER_AUTH_TYPE` to `dpToken` so Zone Ingress and Zone Egress authenticate with zone proxy which is strange.

I didn't want to add another method to RuntimeContext so I refactored xds components into the `XDSRuntimeContext`, a similar pattern as we did with KDS https://github.com/kumahq/kuma/blob/master/pkg/kds/context/context.go
I did not want to name it `XDSContext` to avoid the confusion with `XDSContext` used for xds generation.

I think long term proper name for this would be `XDSModule` and KumaCP RuntimeContext would depend on multiple modules, but I don't want to go into full refactoring now.

xref #4031

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [X] Link to docs PR or issue --
- [X] Link to UI issue or PR --
- [X] Is the [issue worked on linked][1]? --
- [X] The PR does not hardcode values that might break projects that depend on kuma (e.g. "kumahq" as a image registry) --
- [X] The PR will work for both Linux and Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [X] Unit Tests --
- [X] E2E Tests --
- [X] Manual Universal Tests --
- [X] Manual Kubernetes Tests --
- [X] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [X] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [X] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
