### PR TITLE
fix(e2e): check both clusters of MeshHTTPRoute to be unhealthy

### DIFF
--- a/test/e2e_env/universal/meshhealthcheck/policy.go
+++ b/test/e2e_env/universal/meshhealthcheck/policy.go
@@ -257,7 +257,7 @@ spec:
 				// there is no real attempt to setup a connection with test-server, but Envoy may return either
 				// empty response with EXIT_CODE = 0, or  'Ncat: Connection reset by peer.' with EXIT_CODE = 1
 				g.Expect(stdout).To(Or(BeEmpty(), ContainSubstring("Ncat: Connection reset by peer.")))
-			})
+			}).Should(Succeed())
 		})
 	}, Ordered)
 
@@ -417,8 +417,8 @@ spec:
 				Install(DemoClientUniversal("dp-demo-client", meshName,
 					WithTransparentProxy(true)),
 				).
-				Install(TestServerUniversal("test-server", meshName, WithArgs([]string{"health-check", "http"}), WithProtocol(mesh.ProtocolHTTP), WithServiceVersion("v1"))).
-				Install(TestServerUniversal("test-server", meshName, WithArgs([]string{"health-check", "http"}), WithProtocol(mesh.ProtocolHTTP), WithServiceVersion("v2"))).
+				Install(TestServerUniversal("test-server-1", meshName, WithArgs([]string{"health-check", "http"}), WithProtocol(mesh.ProtocolHTTP), WithServiceVersion("v1"))).
+				Install(TestServerUniversal("test-server-2", meshName, WithArgs([]string{"health-check", "http"}), WithProtocol(mesh.ProtocolHTTP), WithServiceVersion("v2"))).
 				Setup(universal.Cluster)
 			Expect(err).ToNot(HaveOccurred())
 
@@ -446,9 +446,17 @@ spec:
 			// update HealthCheck policy to check for another status code
 			Expect(YamlUniversal(healthCheck(meshName, "are-you-healthy", "500"))(universal.Cluster)).To(Succeed())
 
-			// wait cluster 'test-server' to be marked as unhealthy
+			// wait cluster 'test-server-_0_' to be marked as unhealthy
 			Eventually(func(g Gomega) {
-				cmd := []string{"/bin/bash", "-c", "\"curl localhost:9901/clusters | grep test-server\""}
+				cmd := []string{"/bin/bash", "-c", "\"curl localhost:9901/clusters | grep test-server-_0_\""}
+				stdout, _, err := universal.Cluster.Exec("", "", "dp-demo-client", cmd...)
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(stdout).To(ContainSubstring("health_flags::/failed_active_hc"))
+			}, "30s", "500ms").Should(Succeed())
+
+			// wait cluster 'test-server-_1_' to be marked as unhealthy
+			Eventually(func(g Gomega) {
+				cmd := []string{"/bin/bash", "-c", "\"curl localhost:9901/clusters | grep test-server-_1_\""}
 				stdout, _, err := universal.Cluster.Exec("", "", "dp-demo-client", cmd...)
 				g.Expect(err).ToNot(HaveOccurred())
 				g.Expect(stdout).To(ContainSubstring("health_flags::/failed_active_hc"))

--- a/test/e2e_env/universal/meshhealthcheck/policy.go
+++ b/test/e2e_env/universal/meshhealthcheck/policy.go
@@ -237,7 +237,7 @@ spec:
 				stdout, _, err := universal.Cluster.Exec("", "", "dp-demo-client-mtls", cmd...)
 				g.Expect(err).ToNot(HaveOccurred())
 				g.Expect(stdout).To(ContainSubstring("response"))
-			})
+			}).Should(Succeed())
 
 			// update HealthCheck policy to check for another 'recv' line
 			Expect(YamlUniversal(healthCheck(meshName, "test-server-mtls", "foo", "baz"))(universal.Cluster)).To(Succeed())

--- a/test/framework/universal_cluster.go
+++ b/test/framework/universal_cluster.go
@@ -296,6 +296,10 @@ func (c *UniversalCluster) DeployApp(opt ...AppDeploymentOption) error {
 	// container that isn't fully configured, and we need it to be
 	// recorded so that DismissCluster can clean it up.
 	Logf("Started universal app %q in container %q", opts.name, app.container)
+
+	if _, ok := c.apps[opts.name]; ok {
+		return errors.Errorf("app %q already exists", opts.name)
+	}
 	c.apps[opts.name] = app
 
 	if !opts.omitDataplane {


### PR DESCRIPTION
* MeshHTTPRoute creates 2 clusters `test-server_-0-` and `test-server_-1-`, we have to check both to be unhealthy
* Make it impossible to create 2 universal apps with the same names, because 1 of them won't be cleaned up after the test

Affects: `MeshHealthCheck HTTP with MeshHTTPRoute should mark host as unhealthy if it doesn't reply on health checks`

Signed-off-by: Ilya Lobkov <ilya.lobkov@konghq.com>

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [X] Link to docs PR or issue --
- [X] Link to UI issue or PR --
- [X] Is the [issue worked on linked][1]? --
- [X] The PR does not hardcode values that might break projects that depend on kuma (e.g. "kumahq" as a image registry) --
- [X] The PR will work for both Linux and Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [X] Unit Tests --
- [X] E2E Tests --
- [X] Manual Universal Tests --
- [X] Manual Kubernetes Tests --
- [X] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [X] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [X] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
