### PR TITLE
refactor(MeshHTTPRoute): check if a prefix match is defined when rewriting prefix

### DIFF
--- a/pkg/plugins/policies/meshhttproute/api/v1alpha1/validation.go
+++ b/pkg/plugins/policies/meshhttproute/api/v1alpha1/validation.go
@@ -54,7 +54,7 @@ func validateRules(rules []Rule) validators.ValidationError {
 	for i, rule := range rules {
 		path := validators.Root().Index(i)
 		errs.AddErrorAt(path.Field("matches"), validateMatches(rule.Matches))
-		errs.AddErrorAt(path.Field("filters"), validateFilters(rule.Default.Filters))
+		errs.AddErrorAt(path.Field("filters"), validateFilters(rule.Default.Filters, rule.Matches))
 	}
 
 	return errs
@@ -150,7 +150,18 @@ func validateQueryParams(matches []QueryParamsMatch) validators.ValidationError 
 	return errs
 }
 
-func validateFilters(filters *[]Filter) validators.ValidationError {
+func hasAnyMatchesWithoutPrefix(matches []Match) bool {
+	for _, match := range matches {
+		if match.Path == nil || match.Path.Type != Prefix {
+			return true
+		}
+	}
+
+	// No matches means a default / prefix
+	return false
+}
+
+func validateFilters(filters *[]Filter, matches []Match) validators.ValidationError {
 	var errs validators.ValidationError
 
 	if filters == nil {
@@ -171,6 +182,18 @@ func validateFilters(filters *[]Filter) validators.ValidationError {
 		case RequestRedirectType:
 			if filter.RequestRedirect == nil {
 				errs.AddViolationAt(path.Field("requestRedirect"), validators.MustBeDefined)
+				continue
+			}
+			if filter.RequestRedirect.Path != nil &&
+				filter.RequestRedirect.Path.ReplacePrefixMatch != nil &&
+				hasAnyMatchesWithoutPrefix(matches) {
+				errs.AddViolationAt(path.Field("requestRedirect").Field("path").Field("replacePrefixMatch"), "can only appear if all matches match a path prefix")
+			}
+		case URLRewriteType:
+			if filter.URLRewrite.Path != nil &&
+				filter.URLRewrite.Path.ReplacePrefixMatch != nil &&
+				hasAnyMatchesWithoutPrefix(matches) {
+				errs.AddViolationAt(path.Field("urlRewrite").Field("path").Field("replacePrefixMatch"), "can only appear if all matches match a path prefix")
 			}
 		}
 	}

--- a/pkg/plugins/policies/meshhttproute/api/v1alpha1/validation_test.go
+++ b/pkg/plugins/policies/meshhttproute/api/v1alpha1/validation_test.go
@@ -106,6 +106,42 @@ to:
         filters:
           - type: RequestHeaderModifier
 `),
+		ErrorCases("prefix rewrite without prefix match",
+			[]validators.Violation{{
+				Field:   `spec.to[0].rules[0].filters[0].urlRewrite.path.replacePrefixMatch`,
+				Message: "can only appear if all matches match a path prefix",
+			}, {
+				Field:   `spec.to[0].rules[0].filters[1].requestRedirect.path.replacePrefixMatch`,
+				Message: "can only appear if all matches match a path prefix",
+			}}, `
+type: MeshHTTPRoute
+mesh: mesh-1
+name: route-1
+targetRef:
+  kind: MeshService
+  name: frontend
+to:
+- targetRef:
+    kind: MeshService
+    name: frontend
+  rules:
+    - matches:
+      - path:
+          value: /prefix
+          type: Exact
+      default:
+        filters:
+          - type: URLRewrite
+            urlRewrite:
+              path:
+                type: ReplacePrefixMatch
+                replacePrefixMatch: /other
+          - type: RequestRedirect
+            requestRedirect:
+              path:
+                type: ReplacePrefixMatch
+                replacePrefixMatch: /other
+`),
 		ErrorCases("non-empty value for header present/absent match",
 			[]validators.Violation{{
 				Field:   `spec.to[0].rules[0].matches[0].headers[0].value`,
@@ -145,6 +181,35 @@ targetRef:
   kind: MeshService
   name: frontend
 to: []
+`),
+		Entry("prefix rewrite with prefix match", `
+type: MeshHTTPRoute
+mesh: mesh-1
+name: route-1
+targetRef:
+  kind: MeshService
+  name: frontend
+to:
+- targetRef:
+    kind: MeshService
+    name: frontend
+  rules:
+    - matches:
+      - path:
+          value: /prefix
+          type: Prefix
+      default:
+        filters:
+          - type: URLRewrite
+            urlRewrite:
+              path:
+                type: ReplacePrefixMatch
+                replacePrefixMatch: /other
+          - type: RequestRedirect
+            requestRedirect:
+              path:
+                type: ReplacePrefixMatch
+                replacePrefixMatch: /other
 `),
 	)
 })


### PR DESCRIPTION
### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] Link to docs PR or issue --
- [x] Link to UI issue or PR --
- [x] Is the [issue worked on linked][1]? -- Closes https://github.com/kumahq/kuma/issues/5922
- [x] The PR does not hardcode values that might break projects that depend on kuma (e.g. "kumahq" as a image registry) --
- [x] The PR will work for both Linux and Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Unit Tests --
- [x] E2E Tests -- none
- [x] Manual Universal Tests -- none
- [x] Manual Kubernetes Tests -- none
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [x] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
