### PR TITLE
feat(GatewayAPI): support ResponseHeaderModifier in HTTPRoute

### DIFF
--- a/pkg/plugins/runtime/k8s/controllers/gatewayapi/http_route_conversion.go
+++ b/pkg/plugins/runtime/k8s/controllers/gatewayapi/http_route_conversion.go
@@ -426,6 +426,26 @@ func (r *HTTPRouteReconciler) gapiToKumaFilters(
 			filter := pathRewriteToKuma(*p)
 			kumaFilters = append(kumaFilters, &filter)
 		}
+	case gatewayapi.HTTPRouteFilterResponseHeaderModifier:
+		filter := filter.ResponseHeaderModifier
+
+		var headerFilter mesh_proto.MeshGatewayRoute_HttpRoute_Filter_HeaderFilter
+
+		for _, set := range filter.Set {
+			headerFilter.Set = append(headerFilter.Set, k8sToKumaHeader(set))
+		}
+
+		for _, add := range filter.Add {
+			headerFilter.Add = append(headerFilter.Add, k8sToKumaHeader(add))
+		}
+
+		headerFilter.Remove = filter.Remove
+
+		kumaFilters = append(kumaFilters, &mesh_proto.MeshGatewayRoute_HttpRoute_Filter{
+			Filter: &mesh_proto.MeshGatewayRoute_HttpRoute_Filter_ResponseHeader{
+				ResponseHeader: &headerFilter,
+			},
+		})
 	default:
 		return nil, nil, fmt.Errorf("unsupported filter type %q", filter.Type)
 	}

--- a/test/e2e/gateway/gatewayapi/conformance_test.go
+++ b/test/e2e/gateway/gatewayapi/conformance_test.go
@@ -86,7 +86,7 @@ func TestConformance(t *testing.T) {
 		SupportedFeatures: map[suite.SupportedFeature]bool{
 			suite.SupportHTTPRouteQueryParamMatching:        true,
 			suite.SupportHTTPRouteMethodMatching:            true,
-			suite.SupportHTTPResponseHeaderModification:     false, // supported in MeshGatewayRoute not yet HTTPRoute
+			suite.SupportHTTPResponseHeaderModification:     true,
 			suite.SupportHTTPRoutePortRedirect:              true,
 			suite.SupportHTTPRouteSchemeRedirect:            true,
 			suite.SupportHTTPRoutePathRedirect:              false, // not yet supported


### PR DESCRIPTION
### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] Link to docs PR or issue --
- [x] Link to UI issue or PR --
- [x] Is the [issue worked on linked][1]? -- Closes #5317 
- [x] The PR does not hardcode values that might break projects that depend on kuma (e.g. "kumahq" as a image registry) --
- [x] The PR will work for both Linux and Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Unit Tests -- none
- [x] E2E Tests -- yes
- [x] Manual Universal Tests -- none
- [x] Manual Kubernetes Tests -- none 
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [x] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
