### PR TITLE
ci(.github): uses bot PAT instead of real user PAT

### DIFF
--- a/.github/workflows/pr-merged.yaml
+++ b/.github/workflows/pr-merged.yaml
@@ -19,7 +19,7 @@ jobs:
       - name: "Send repository dispatch event"
         uses: actions/github-script@v6
         with:
-          github-token: ${{ secrets.NOTIFY_GH_TOKEN }}
+          github-token: ${{ secrets.NOTIFY_BOT_PAT_TOKEN }}
           script: |
             let branch, pr;
             if (context.eventName == "pull_request_target") {


### PR DESCRIPTION
Switches to using a PAT generated using a dedicated bot account instead of a real user PAT.

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [ ] Link to docs PR or issue -- N.A.
- [ ] Link to UI issue or PR -- N.A.
- [x] Is the [issue worked on linked][1]? -- No, see above.
- [x] The PR does not hardcode values that might break projects that depend on kuma (e.g. "kumahq" as a image registry) --
- [ ] The PR will work for both Linux and Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS -- N.A.
- [ ] Unit Tests -- N.A.
- [ ] E2E Tests -- N.A.
- [ ] Manual Universal Tests -- N.A.
- [ ] Manual Kubernetes Tests -- N.A.
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? -- No
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? -- No
- [x] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests? No

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
