### PR TITLE
chore: replace k8s.gcr.io registry usage

### DIFF
--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.03.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.03.golden.yaml
@@ -119,7 +119,7 @@ spec:
   - args:
     - -conf
     - /etc/coredns/Corefile
-    image: k8s.gcr.io/coredns:1.3.1
+    image: registry.k8s.io/coredns:1.3.1
     imagePullPolicy: IfNotPresent
     livenessProbe:
       failureThreshold: 5

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.03.input.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.03.input.yaml
@@ -27,7 +27,7 @@ spec:
       secretName: coredns-token-9gmrh
   containers:
   - name: coredns
-    image: k8s.gcr.io/coredns:1.3.1
+    image: registry.k8s.io/coredns:1.3.1
     args:
     - "-conf"
     - "/etc/coredns/Corefile"


### PR DESCRIPTION
Kubernetes is [replacing the k8s.gcr.io registry](https://kubernetes.io/blog/2023/02/06/k8s-gcr-io-freeze-announcement/). Besides it just becoming frozen soon the new registry.k8s.io registry is also less costly to use so the sooner we can stop using the old one the better to help out upstream.