### PR TITLE
chore(MeshHTTPRoute): refactor cluster builder

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -136,4 +136,7 @@ issues:
       linters:
         - staticcheck
       text: "SA1019: rest_unversioned.From.Resource is deprecated"
+    - linters:
+        - staticcheck
+      text: "SA1019: .* for new policies use pkg/plugins/policies/xds/cluster.go"
 

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/clusters.go
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/clusters.go
@@ -61,7 +61,6 @@ func generateClusters(
 			} else {
 				edsClusterBuilder.
 					Configure(envoy_clusters.EdsCluster(clusterName)).
-					Configure(envoy_clusters.LB(cluster.LB())).
 					Configure(envoy_clusters.Http2())
 
 				if upstreamMeshName := cluster.Mesh(); upstreamMeshName != "" {

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/listeners.go
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/listeners.go
@@ -12,7 +12,7 @@ import (
 	core_xds "github.com/kumahq/kuma/pkg/core/xds"
 	api "github.com/kumahq/kuma/pkg/plugins/policies/meshhttproute/api/v1alpha1"
 	xds "github.com/kumahq/kuma/pkg/plugins/policies/meshhttproute/xds"
-	"github.com/kumahq/kuma/pkg/xds/envoy"
+	plugins_xds "github.com/kumahq/kuma/pkg/plugins/policies/xds"
 	envoy_common "github.com/kumahq/kuma/pkg/xds/envoy"
 	envoy_listeners "github.com/kumahq/kuma/pkg/xds/envoy/listeners"
 	envoy_listeners_v3 "github.com/kumahq/kuma/pkg/xds/envoy/listeners/v3"
@@ -28,7 +28,7 @@ func generateListeners(
 ) (*core_xds.ResourceSet, error) {
 	resources := core_xds.NewResourceSet()
 	splitCounter := &splitCounter{}
-	// ClusterCache (cluster hash -> cluster name) protects us from creating excessive amount of caches.
+	// ClusterCache (cluster hash -> cluster name) protects us from creating excessive amount of clusters.
 	// For one outbound we pick one traffic route so LB and Timeout are the same.
 	// If we have same split in many HTTP matches we can use the same cluster with different weight
 	clusterCache := map[string]string{}
@@ -52,20 +52,14 @@ func generateListeners(
 
 		var routes []xds.OutboundRoute
 		for _, route := range prepareRoutes(rules, serviceName) {
-			clusters := makeClusters(proxy, clusterCache, splitCounter, route.BackendRefs)
-			protocol := generator.InferProtocol(proxy, clusters)
-			switch protocol {
-			case core_mesh.ProtocolHTTP, core_mesh.ProtocolHTTP2:
-			default:
+			split := makeHTTPSplit(proxy, clusterCache, splitCounter, servicesAcc, route.BackendRefs)
+			if split == nil {
 				continue
 			}
-
-			servicesAcc.Add(clusters...)
-
 			routes = append(routes, xds.OutboundRoute{
-				Matches:  route.Matches,
-				Filters:  route.Filters,
-				Clusters: clusters,
+				Matches: route.Matches,
+				Filters: route.Filters,
+				Split:   split,
 			})
 		}
 
@@ -166,13 +160,14 @@ func (s *splitCounter) getAndIncrement() int {
 	return counter
 }
 
-func makeClusters(
+func makeHTTPSplit(
 	proxy *core_xds.Proxy,
 	clusterCache map[string]string,
-	splitCounter *splitCounter,
+	sc *splitCounter,
+	servicesAcc envoy_common.ServicesAccumulator,
 	refs []api.BackendRef,
-) []envoy.Cluster {
-	var clusters []envoy.Cluster
+) []*plugins_xds.Split {
+	var split []*plugins_xds.Split
 
 	for _, ref := range refs {
 		switch ref.Kind {
@@ -186,51 +181,61 @@ func makeClusters(
 			continue
 		}
 
-		name := service
-
-		if len(ref.Tags) > 0 {
-			name = envoy_names.GetSplitClusterName(service, splitCounter.getAndIncrement())
+		switch plugins_xds.InferProtocol(proxy.Routing, service) {
+		case core_mesh.ProtocolHTTP, core_mesh.ProtocolHTTP2:
+		default:
+			// We don't support splitting if at least one of the backendRefs is not HTTP
+			return nil
 		}
 
-		// The mesh tag is present here if this destination is generated
-		// from a cross-mesh MeshGateway listener virtual outbound.
-		// It is not part of the service tags.
-		if mesh, ok := ref.Tags[mesh_proto.MeshTag]; ok {
-			// The name should be distinct to the service & mesh combination
-			name = fmt.Sprintf("%s_%s", name, mesh)
-		}
-
-		// We assume that all the targets are either ExternalServices or not
-		// therefore we check only the first one
-		var isExternalService bool
-		if endpoints := proxy.Routing.OutboundTargets[service]; len(endpoints) > 0 {
-			isExternalService = endpoints[0].IsExternalService()
-		}
-		if endpoints := proxy.Routing.ExternalServiceOutboundTargets[service]; len(endpoints) > 0 {
-			isExternalService = true
-		}
-
+		clusterName := getClusterName(ref, sc)
+		isExternalService := plugins_xds.HasExternalService(proxy.Routing, service)
 		allTags := envoy_tags.Tags(ref.Tags).WithTags(mesh_proto.ServiceTag, ref.Name)
-		cluster := envoy_common.NewCluster(
-			envoy_common.WithService(service),
-			envoy_common.WithName(name),
-			envoy_common.WithWeight(uint32(ref.Weight)),
-			envoy_common.WithTags(allTags.WithoutTags(mesh_proto.MeshTag)),
-			envoy_common.WithExternalService(isExternalService),
-		)
 
-		if mesh, ok := ref.Tags[mesh_proto.MeshTag]; ok {
-			cluster.SetMesh(mesh)
+		if existingClusterName, ok := clusterCache[allTags.String()]; ok {
+			// cluster already exists, so adding only split
+			split = append(split, plugins_xds.NewSplitBuilder().
+				WithClusterName(existingClusterName).
+				WithWeight(uint32(ref.Weight)).
+				WithExternalService(isExternalService).
+				Build())
+			continue
 		}
 
-		if name, ok := clusterCache[allTags.String()]; ok {
-			cluster.SetName(name)
-		} else {
-			clusterCache[allTags.String()] = cluster.Name()
-		}
+		clusterCache[allTags.String()] = clusterName
 
-		clusters = append(clusters, cluster)
+		split = append(split, plugins_xds.NewSplitBuilder().
+			WithClusterName(clusterName).
+			WithWeight(uint32(ref.Weight)).
+			WithExternalService(isExternalService).
+			Build())
+
+		servicesAcc.Add(plugins_xds.NewClusterBuilder().
+			WithService(service).
+			WithName(clusterName).
+			WithMesh(ref.Tags[mesh_proto.MeshTag]).
+			WithTags(allTags.WithoutTags(mesh_proto.MeshTag)).
+			WithExternalService(isExternalService).
+			Build())
 	}
 
-	return clusters
+	return split
+}
+
+func getClusterName(ref api.BackendRef, sc *splitCounter) string {
+	name := ref.Name
+
+	if len(ref.Tags) > 0 {
+		name = envoy_names.GetSplitClusterName(name, sc.getAndIncrement())
+	}
+
+	// The mesh tag is present here if this destination is generated
+	// from a cross-mesh MeshGateway listener virtual outbound.
+	// It is not part of the service tags.
+	if mesh, ok := ref.Tags[mesh_proto.MeshTag]; ok {
+		// The name should be distinct to the service & mesh combination
+		name = fmt.Sprintf("%s_%s", name, mesh)
+	}
+
+	return name
 }

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/listeners.go
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/listeners.go
@@ -210,13 +210,17 @@ func makeHTTPSplit(
 			WithExternalService(isExternalService).
 			Build())
 
-		servicesAcc.Add(plugins_xds.NewClusterBuilder().
+		clusterBuilder := plugins_xds.NewClusterBuilder().
 			WithService(service).
 			WithName(clusterName).
-			WithMesh(ref.Tags[mesh_proto.MeshTag]).
 			WithTags(allTags.WithoutTags(mesh_proto.MeshTag)).
-			WithExternalService(isExternalService).
-			Build())
+			WithExternalService(isExternalService)
+
+		if mesh, ok := ref.Tags[mesh_proto.MeshTag]; ok {
+			clusterBuilder.WithMesh(mesh)
+		}
+
+		servicesAcc.Add(clusterBuilder.Build())
 	}
 
 	return split

--- a/pkg/plugins/policies/meshhttproute/xds/builder.go
+++ b/pkg/plugins/policies/meshhttproute/xds/builder.go
@@ -5,6 +5,7 @@ import (
 
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	api "github.com/kumahq/kuma/pkg/plugins/policies/meshhttproute/api/v1alpha1"
+	plugins_xds "github.com/kumahq/kuma/pkg/plugins/policies/xds"
 	envoy_common "github.com/kumahq/kuma/pkg/xds/envoy"
 	envoy_listeners_v3 "github.com/kumahq/kuma/pkg/xds/envoy/listeners/v3"
 	envoy_names "github.com/kumahq/kuma/pkg/xds/envoy/names"
@@ -12,9 +13,9 @@ import (
 )
 
 type OutboundRoute struct {
-	Matches  []api.Match
-	Filters  []api.Filter
-	Clusters []envoy_common.Cluster
+	Matches []api.Match
+	Filters []api.Filter
+	Split   []*plugins_xds.Split
 }
 
 type HttpOutboundRouteConfigurer struct {
@@ -31,9 +32,9 @@ func (c *HttpOutboundRouteConfigurer) Configure(filterChain *envoy_listener.Filt
 	for _, route := range c.Routes {
 		route := envoy_routes.AddVirtualHostConfigurer(
 			&RoutesConfigurer{
-				Matches:  route.Matches,
-				Filters:  route.Filters,
-				Clusters: route.Clusters,
+				Matches: route.Matches,
+				Filters: route.Filters,
+				Split:   route.Split,
 			})
 		virtualHostBuilder = virtualHostBuilder.Configure(route)
 	}

--- a/pkg/plugins/policies/xds/cluster.go
+++ b/pkg/plugins/policies/xds/cluster.go
@@ -1,0 +1,104 @@
+package xds
+
+import (
+	"fmt"
+
+	"github.com/pkg/errors"
+
+	"github.com/kumahq/kuma/pkg/xds/envoy/tags"
+)
+
+type Cluster struct {
+	service           string
+	name              string
+	tags              tags.Tags
+	mesh              string
+	isExternalService bool
+}
+
+func (c *Cluster) Service() string { return c.service }
+func (c *Cluster) Name() string    { return c.name }
+func (c *Cluster) Tags() tags.Tags { return c.tags }
+
+// Mesh returns a non-empty string only if the cluster is in a different mesh
+// from the context.
+func (c *Cluster) Mesh() string            { return c.mesh }
+func (c *Cluster) IsExternalService() bool { return c.isExternalService }
+func (c *Cluster) Hash() string            { return fmt.Sprintf("%s-%s", c.name, c.tags.String()) }
+
+type NewClusterOpt interface {
+	apply(cluster *Cluster)
+}
+
+type newClusterOptFunc func(cluster *Cluster)
+
+func (f newClusterOptFunc) apply(cluster *Cluster) {
+	f(cluster)
+}
+
+type ClusterBuilder struct {
+	opts []NewClusterOpt
+}
+
+func NewClusterBuilder() *ClusterBuilder {
+	return &ClusterBuilder{}
+}
+
+func (b *ClusterBuilder) Build() *Cluster {
+	c := &Cluster{}
+	for _, opt := range b.opts {
+		opt.apply(c)
+	}
+	if err := c.validate(); err != nil {
+		panic(err)
+	}
+	return c
+}
+
+func (b *ClusterBuilder) WithService(service string) *ClusterBuilder {
+	b.opts = append(b.opts, newClusterOptFunc(func(cluster *Cluster) {
+		cluster.service = service
+		if len(cluster.name) == 0 {
+			cluster.name = service
+		}
+	}))
+	return b
+}
+
+func (b *ClusterBuilder) WithName(name string) *ClusterBuilder {
+	b.opts = append(b.opts, newClusterOptFunc(func(cluster *Cluster) {
+		cluster.name = name
+		if len(cluster.service) == 0 {
+			cluster.service = name
+		}
+	}))
+	return b
+}
+
+func (b *ClusterBuilder) WithMesh(mesh string) *ClusterBuilder {
+	b.opts = append(b.opts, newClusterOptFunc(func(cluster *Cluster) {
+		cluster.mesh = mesh
+	}))
+	return b
+}
+
+func (b *ClusterBuilder) WithTags(tags tags.Tags) *ClusterBuilder {
+	b.opts = append(b.opts, newClusterOptFunc(func(cluster *Cluster) {
+		cluster.tags = tags
+	}))
+	return b
+}
+
+func (b *ClusterBuilder) WithExternalService(isExternalService bool) *ClusterBuilder {
+	b.opts = append(b.opts, newClusterOptFunc(func(cluster *Cluster) {
+		cluster.isExternalService = isExternalService
+	}))
+	return b
+}
+
+func (c *Cluster) validate() error {
+	if c.service == "" || c.name == "" {
+		return errors.New("either WithService() or WithName() should be called")
+	}
+	return nil
+}

--- a/pkg/plugins/policies/xds/split.go
+++ b/pkg/plugins/policies/xds/split.go
@@ -1,0 +1,59 @@
+package xds
+
+type Split struct {
+	clusterName string
+	weight      uint32
+
+	hasExternalService bool
+}
+
+func (s *Split) ClusterName() string      { return s.clusterName }
+func (s *Split) Weight() uint32           { return s.weight }
+func (s *Split) HasExternalService() bool { return s.hasExternalService }
+
+type NewSplitOpt interface {
+	apply(s *Split)
+}
+
+type newSplitOptFunc func(s *Split)
+
+func (f newSplitOptFunc) apply(s *Split) {
+	f(s)
+}
+
+type SplitBuilder struct {
+	opts []NewSplitOpt
+}
+
+func NewSplitBuilder() *SplitBuilder {
+	return &SplitBuilder{}
+}
+
+func (b *SplitBuilder) Build() *Split {
+	s := &Split{}
+	for _, opt := range b.opts {
+		opt.apply(s)
+	}
+	return s
+}
+
+func (b *SplitBuilder) WithClusterName(clusterName string) *SplitBuilder {
+	b.opts = append(b.opts, newSplitOptFunc(func(s *Split) {
+		s.clusterName = clusterName
+	}))
+	return b
+}
+
+func (b *SplitBuilder) WithWeight(weight uint32) *SplitBuilder {
+	b.opts = append(b.opts, newSplitOptFunc(func(s *Split) {
+		s.weight = weight
+	}))
+	return b
+}
+
+func (b *SplitBuilder) WithExternalService(hasExternalService bool) *SplitBuilder {
+	b.opts = append(b.opts, newSplitOptFunc(func(s *Split) {
+		s.hasExternalService = hasExternalService
+	}))
+	return b
+}

--- a/pkg/xds/envoy/listeners/v3/tcp_proxy_configurer.go
+++ b/pkg/xds/envoy/listeners/v3/tcp_proxy_configurer.go
@@ -53,7 +53,8 @@ func (c *TcpProxyConfigurer) tcpProxy() *envoy_tcp.TcpProxy {
 	}
 
 	var weightedClusters []*envoy_tcp.TcpProxy_WeightedCluster_ClusterWeight
-	for _, cluster := range c.Clusters {
+	for _, cl := range c.Clusters {
+		cluster := cl.(*envoy_common.ClusterImpl)
 		weightedCluster := &envoy_tcp.TcpProxy_WeightedCluster_ClusterWeight{
 			Name:   cluster.Name(),
 			Weight: cluster.Weight(),

--- a/pkg/xds/envoy/routes/v3/routes_configurer.go
+++ b/pkg/xds/envoy/routes/v3/routes_configurer.go
@@ -163,7 +163,8 @@ func (c RoutesConfigurer) hasExternal(clusters []envoy_common.Cluster) bool {
 func (c RoutesConfigurer) routeAction(clusters []envoy_common.Cluster, modify *mesh_proto.TrafficRoute_Http_Modify) *envoy_route.RouteAction {
 	routeAction := &envoy_route.RouteAction{}
 	if len(clusters) != 0 {
-		routeAction.Timeout = util_proto.Duration(clusters[0].Timeout().GetHttp().GetRequestTimeout().AsDuration())
+		cluster := clusters[0].(*envoy_common.ClusterImpl)
+		routeAction.Timeout = util_proto.Duration(cluster.Timeout().GetHttp().GetRequestTimeout().AsDuration())
 	}
 	if len(clusters) == 1 {
 		routeAction.ClusterSpecifier = &envoy_route.RouteAction_Cluster{
@@ -172,7 +173,8 @@ func (c RoutesConfigurer) routeAction(clusters []envoy_common.Cluster, modify *m
 	} else {
 		var weightedClusters []*envoy_route.WeightedCluster_ClusterWeight
 		var totalWeight uint32
-		for _, cluster := range clusters {
+		for _, c := range clusters {
+			cluster := c.(*envoy_common.ClusterImpl)
 			weightedClusters = append(weightedClusters, &envoy_route.WeightedCluster_ClusterWeight{
 				Name:   cluster.Name(),
 				Weight: util_proto.UInt32(cluster.Weight()),

--- a/pkg/xds/envoy/routes/v3/routes_configurer.go
+++ b/pkg/xds/envoy/routes/v3/routes_configurer.go
@@ -163,6 +163,8 @@ func (c RoutesConfigurer) hasExternal(clusters []envoy_common.Cluster) bool {
 func (c RoutesConfigurer) routeAction(clusters []envoy_common.Cluster, modify *mesh_proto.TrafficRoute_Http_Modify) *envoy_route.RouteAction {
 	routeAction := &envoy_route.RouteAction{}
 	if len(clusters) != 0 {
+		// Timeout can be configured only per outbound listener. So all clusters in the split
+		// must have the same timeout. That's why we can take the timeout from the first cluster.
 		cluster := clusters[0].(*envoy_common.ClusterImpl)
 		routeAction.Timeout = util_proto.Duration(cluster.Timeout().GetHttp().GetRequestTimeout().AsDuration())
 	}


### PR DESCRIPTION
We leaked unnecessary information into the `Cluster` abstraction:
```go
type Cluster struct {
	service           string
	name              string
	weight            uint32
	tags              tags.Tags
	mesh              string
	isExternalService bool
	lb                *mesh_proto.TrafficRoute_LoadBalancer
	timeout           *mesh_proto.Timeout_Conf
}
``` 
* `lb` and `timeout` are old policies protos
* `weight` is not a Cluster's attribute, it's route's attribute (2 routes can point to the same cluster with different weights)

This PR deprecates `Cluster` type and introduces 2 new types:
```go
type Cluster struct {
	service           string
	name              string
	tags              tags.Tags
	mesh              string
	isExternalService bool
}

type Split struct {
	clusterName string
	weight      uint32

	hasExternalService bool
}
```

It's important to untie `Cluster` and `Split` because for example for mirroring we want to be able to create a new cluster without creating a new split.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [X] Link to docs PR or issue --
- [X] Link to UI issue or PR --
- [X] Is the [issue worked on linked][1]? --
- [X] The PR does not hardcode values that might break projects that depend on kuma (e.g. "kumahq" as a image registry) --
- [X] The PR will work for both Linux and Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [X] Unit Tests --
- [X] E2E Tests --
- [X] Manual Universal Tests --
- [X] Manual Kubernetes Tests --
- [X] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [X] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [X] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
