### PR TITLE
ci(.github): don't check for kuma cni image in version < 1.8

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,7 +19,7 @@ env:
   BINARIES: "centos-amd64,darwin-amd64,darwin-arm64,debian-amd64,darwin-amd64,rhel-amd64,ubuntu-amd64,ubuntu-arm64"
   DOCKER_REPO: "kumahq"
   DOCKER_IMAGES: "kumactl,kuma-cp,kuma-dp,kuma-init,kuma-cni"
-  RELEASE: ${{ inputs.release || '0.0.0.0' }}
+  RELEASE: ${{ inputs.release || '0.0.0' }}
   CHECK: ${{ inputs.check }}
 jobs:
   release:
@@ -30,6 +30,10 @@ jobs:
         run: |
           echo $(go env GOPATH)/bin >> $GITHUB_PATH
           go install github.com/kumahq/ci-tools/cmd/release-tool@v0.2.1
+      - name: remove-cni
+        # CNI was only introduced in 1.7 so versions before should remove
+        if: startsWith(env.RELEASE, '1.7') || startsWith(env.RELEASE, '1.6')
+        run: echo DOCKER_IMAGES=${{env.DOCKER_IMAGES}} | sed 's/,kuma-cni//g' >> $GITHUB_ENV
       - name: create-release
         if: env.RELEASE != '0.0.0'
         env:


### PR DESCRIPTION
### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] Link to docs PR or issue --
- [x] Link to UI issue or PR --
- [x] Is the [issue worked on linked][1]? --
- [x] The PR does not hardcode values that might break projects that depend on kuma (e.g. "kumahq" as a image registry) --
- [x] The PR will work for both Linux and Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Unit Tests --
- [x] E2E Tests --
- [x] Manual Universal Tests --
- [x] Manual Kubernetes Tests --
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [x] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
