### PR TITLE
test(e2e): fix flake on external service with meshhttproute

### DIFF
--- a/test/e2e_env/kubernetes/meshhttproute/test.go
+++ b/test/e2e_env/kubernetes/meshhttproute/test.go
@@ -79,7 +79,7 @@ spec:
         kind: MeshService
         name: nonexistent-service-that-activates-default
       rules: []
-`, Config.KumaNamespace, meshName, meshName))(kubernetes.Cluster)).To(Succeed())
+`, Config.KumaNamespace, meshName, namespace))(kubernetes.Cluster)).To(Succeed())
 
 		Eventually(func(g Gomega) {
 			response, err := client.CollectResponse(kubernetes.Cluster, "test-client", "test-server_meshhttproute_svc_80.mesh", client.FromKubernetesPod(namespace, "test-client"))
@@ -94,16 +94,15 @@ spec:
 apiVersion: kuma.io/v1alpha1
 kind: ExternalService
 metadata:
-  name: external-service-1
-  namespace: %s
+  name: external-service-mhr
 mesh: %s
 spec:
   tags:
-    kuma.io/service: external-service
+    kuma.io/service: external-service-mhr
     kuma.io/protocol: http
   networking:
     address: external-service.%s.svc.cluster.local:80 # .svc.cluster.local is needed, otherwise Kubernetes will resolve this to the real IP
-`, Config.KumaNamespace, meshName, namespace)))).To(Succeed())
+`, meshName, namespace)))).To(Succeed())
 
 		// when
 		Expect(YamlK8s(fmt.Sprintf(`
@@ -133,7 +132,7 @@ spec:
                 name: test-server_meshhttproute_svc_80
                 weight: 50
               - kind: MeshService
-                name: external-service
+                name: external-service-mhr
                 weight: 50
 `, Config.KumaNamespace, meshName, meshName))(kubernetes.Cluster)).To(Succeed())
 


### PR DESCRIPTION
ExternalService is not namespaced scoped. We already have another test that is applying `external-service-1`, so one test will make other to fail.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [ ] [Link to relevant issue][1] as well as docs and UI issues --
- [ ] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [ ] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [ ] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [ ] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [ ] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
