### PR TITLE
feat(k8s): set `kubectl.kubernetes.io/default-container` `Pod` annotation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -69,6 +69,7 @@ require (
 	k8s.io/client-go v0.26.1
 	k8s.io/klog/v2 v2.90.0
 	k8s.io/kube-openapi v0.0.0-20221207184640-f3cff1453715
+	k8s.io/kubectl v0.26.1
 	k8s.io/utils v0.0.0-20221128185143-99ec85e7a448
 	sigs.k8s.io/controller-runtime v0.14.4
 	sigs.k8s.io/controller-tools v0.11.3

--- a/go.sum
+++ b/go.sum
@@ -2151,6 +2151,8 @@ k8s.io/kube-openapi v0.0.0-20210421082810-95288971da7e/go.mod h1:vHXdDvt9+2spS2R
 k8s.io/kube-openapi v0.0.0-20211109043538-20434351676c/go.mod h1:vHXdDvt9+2spS2Rx9ql3I8tycm3H9FDfdUoIuKCefvw=
 k8s.io/kube-openapi v0.0.0-20221207184640-f3cff1453715 h1:tBEbstoM+K0FiBV5KGAKQ0kuvf54v/hwpldiJt69w1s=
 k8s.io/kube-openapi v0.0.0-20221207184640-f3cff1453715/go.mod h1:+Axhij7bCpeqhklhUTe3xmOn6bWxolyZEeyaFpjGtl4=
+k8s.io/kubectl v0.26.1 h1:K8A0Jjlwg8GqrxOXxAbjY5xtmXYeYjLU96cHp2WMQ7s=
+k8s.io/kubectl v0.26.1/go.mod h1:miYFVzldVbdIiXMrHZYmL/EDWwJKM+F0sSsdxsATFPo=
 k8s.io/kubernetes v1.13.0/go.mod h1:ocZa8+6APFNC2tX1DZASIbocyYT5jHzqFVsY5aoB7Jk=
 k8s.io/utils v0.0.0-20201110183641-67b214c5f920/go.mod h1:jPW/WVKK9YHAvNhRxK0md/EJ228hCsBRufyofKtW8HA=
 k8s.io/utils v0.0.0-20210819203725-bdf08cb9a70a/go.mod h1:jPW/WVKK9YHAvNhRxK0md/EJ228hCsBRufyofKtW8HA=

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.01.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.01.golden.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   annotations:
+    kubectl.kubernetes.io/default-container: busybox
     kuma.io/envoy-admin-port: "9901"
     kuma.io/mesh: default
     kuma.io/sidecar-injected: "true"

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.02.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.02.golden.yaml
@@ -3,6 +3,7 @@ kind: Pod
 metadata:
   annotations:
     docs: Documentation
+    kubectl.kubernetes.io/default-container: busybox
     kuma.io/envoy-admin-port: "9901"
     kuma.io/mesh: default
     kuma.io/sidecar-injected: "true"

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.03.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.03.golden.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   annotations:
+    kubectl.kubernetes.io/default-container: coredns
     kuma.io/envoy-admin-port: "9901"
     kuma.io/mesh: default
     kuma.io/sidecar-injected: "true"

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.04.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.04.golden.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   annotations:
+    kubectl.kubernetes.io/default-container: busybox
     kuma.io/envoy-admin-port: "9901"
     kuma.io/mesh: demo
     kuma.io/sidecar-injected: "true"

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.05.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.05.golden.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   annotations:
+    kubectl.kubernetes.io/default-container: busybox
     kuma.io/envoy-admin-port: "9901"
     kuma.io/mesh: default
     kuma.io/sidecar-injected: "true"

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.06.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.06.golden.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   annotations:
+    kubectl.kubernetes.io/default-container: busybox
     kuma.io/envoy-admin-port: "9901"
     kuma.io/gateway: enabled
     kuma.io/mesh: default

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.07.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.07.golden.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   annotations:
+    kubectl.kubernetes.io/default-container: busybox
     kuma.io/envoy-admin-port: "9901"
     kuma.io/mesh: default
     kuma.io/sidecar-injected: "true"

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.08.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.08.golden.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   annotations:
+    kubectl.kubernetes.io/default-container: busybox
     kuma.io/envoy-admin-port: "9901"
     kuma.io/mesh: default
     kuma.io/sidecar-injected: "true"

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.09.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.09.golden.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   annotations:
+    kubectl.kubernetes.io/default-container: busybox
     kuma.io/envoy-admin-port: "9901"
     kuma.io/mesh: default
     kuma.io/sidecar-injected: "true"

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.10.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.10.golden.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   annotations:
+    kubectl.kubernetes.io/default-container: busybox
     kuma.io/envoy-admin-port: "9901"
     kuma.io/mesh: default
     kuma.io/sidecar-injected: "true"

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.11.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.11.golden.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   annotations:
+    kubectl.kubernetes.io/default-container: busybox
     kuma.io/envoy-admin-port: "9901"
     kuma.io/mesh: mesh-name-from-ns
     kuma.io/sidecar-injected: "true"

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.12.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.12.golden.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   annotations:
+    kubectl.kubernetes.io/default-container: busybox
     kuma.io/envoy-admin-port: "9901"
     kuma.io/mesh: mesh-name-from-pod
     kuma.io/sidecar-injected: "true"

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.13.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.13.golden.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   annotations:
+    kubectl.kubernetes.io/default-container: busybox
     kuma.io/envoy-admin-port: "9901"
     kuma.io/mesh: default
     kuma.io/sidecar-injected: "true"

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.14.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.14.golden.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   annotations:
+    kubectl.kubernetes.io/default-container: busybox
     kuma.io/envoy-admin-port: "9901"
     kuma.io/mesh: default
     kuma.io/sidecar-injected: "true"

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.15.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.15.golden.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   annotations:
+    kubectl.kubernetes.io/default-container: busybox
     kuma.io/envoy-admin-port: "9901"
     kuma.io/mesh: default
     kuma.io/sidecar-injected: "true"

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.16.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.16.golden.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   annotations:
+    kubectl.kubernetes.io/default-container: busybox
     kuma.io/envoy-admin-port: "9901"
     kuma.io/mesh: default
     kuma.io/sidecar-injected: "true"

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.17.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.17.golden.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   annotations:
+    kubectl.kubernetes.io/default-container: busybox
     kuma.io/envoy-admin-port: "9901"
     kuma.io/mesh: default
     kuma.io/sidecar-injected: "true"

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.18.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.18.golden.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   annotations:
+    kubectl.kubernetes.io/default-container: busybox
     kuma.io/envoy-admin-port: "9901"
     kuma.io/mesh: default
     kuma.io/sidecar-injected: "true"

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.19.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.19.golden.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   annotations:
+    kubectl.kubernetes.io/default-container: busybox
     kuma.io/envoy-admin-port: "9901"
     kuma.io/mesh: default
     kuma.io/sidecar-injected: "true"

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.20.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.20.golden.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   annotations:
+    kubectl.kubernetes.io/default-container: busybox
     kuma.io/envoy-admin-port: "9901"
     kuma.io/mesh: default
     kuma.io/sidecar-injected: "true"

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.21.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.21.golden.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   annotations:
+    kubectl.kubernetes.io/default-container: busybox
     kuma.io/envoy-admin-port: "9901"
     kuma.io/mesh: default
     kuma.io/sidecar-injected: "true"

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.22.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.22.golden.yaml
@@ -3,6 +3,7 @@ kind: Pod
 metadata:
   annotations:
     docs: Documentation
+    kubectl.kubernetes.io/default-container: busybox
     kuma.io/envoy-admin-port: "9901"
     kuma.io/mesh: default
     kuma.io/sidecar-env-vars: KUMA_DATAPLANE_DRAIN_TIME=5s;NEW_ENV_VAR=123

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.23.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.23.golden.yaml
@@ -3,6 +3,7 @@ kind: Pod
 metadata:
   annotations:
     docs: Documentation
+    kubectl.kubernetes.io/default-container: busybox
     kuma.io/builtin-dns: enabled
     kuma.io/builtin-dns-port: "25053"
     kuma.io/builtindns: enabled

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.24.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.24.golden.yaml
@@ -3,6 +3,7 @@ kind: Pod
 metadata:
   annotations:
     docs: Documentation
+    kubectl.kubernetes.io/default-container: busybox
     kuma.io/builtin-dns: enabled
     kuma.io/builtin-dns-port: "25053"
     kuma.io/builtindns: enabled

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.25.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.25.golden.yaml
@@ -3,6 +3,7 @@ kind: Pod
 metadata:
   annotations:
     docs: Documentation
+    kubectl.kubernetes.io/default-container: busybox
     kuma.io/builtin-dns: enabled
     kuma.io/builtin-dns-port: "25053"
     kuma.io/builtindns: enabled

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.26.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.26.golden.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   annotations:
+    kubectl.kubernetes.io/default-container: busybox
     kuma.io/envoy-admin-port: "9901"
     kuma.io/mesh: default
     kuma.io/service-account-token-volume: token

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.27.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.27.golden.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   annotations:
+    kubectl.kubernetes.io/default-container: busybox
     kuma.io/envoy-admin-port: "9901"
     kuma.io/mesh: default
     kuma.io/sidecar-drain-time: 10s

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.28.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.28.golden.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   annotations:
+    kubectl.kubernetes.io/default-container: busybox
     kuma.io/container-patches: container-patch-1
     kuma.io/envoy-admin-port: "9901"
     kuma.io/envoy-log-level: trace

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.29.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.29.golden.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   annotations:
+    kubectl.kubernetes.io/default-container: busybox
     kuma.io/builtin-dns: enabled
     kuma.io/builtin-dns-port: "25053"
     kuma.io/builtindns: enabled

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.30.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.30.golden.yaml
@@ -3,6 +3,7 @@ kind: Pod
 metadata:
   annotations:
     ignore-check.kube-linter.io/privileged-container: ebpf requires privileged-container
+    kubectl.kubernetes.io/default-container: busybox
     kuma.io/envoy-admin-port: "9901"
     kuma.io/mesh: default
     kuma.io/sidecar-injected: "true"


### PR DESCRIPTION
This allows `kubectl` commands like `exec`, `attach` and `run` to work properly. Especially important since #5436.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [x] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
