### PR TITLE
fix(kuma-cp): change default value for KubeOutboundsAsVIPs and fix multizone upgrade

### DIFF
--- a/app/kumactl/cmd/install/testdata/install-control-plane.dump-values.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.dump-values.yaml
@@ -426,7 +426,7 @@ ingress:
 
   # -- Number of seconds to wait before force killing the pod. Make sure to
   # update this if you add a preStop hook.
-  terminationGracePeriodSeconds: 30
+  terminationGracePeriodSeconds: 40
 
   # Horizontal Pod Autoscaling configuration
   autoscaling:

--- a/app/kumactl/cmd/install/testdata/install-control-plane.with-helm-set.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.with-helm-set.yaml
@@ -5699,7 +5699,7 @@ spec:
       nodeSelector:
       
         kubernetes.io/os: linux
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 40
       containers:
         - name: ingress
           image: "docker.io/kumahq/kuma-dp:0.0.1"

--- a/app/kumactl/cmd/install/testdata/install-control-plane.with-ingress.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.with-ingress.golden.yaml
@@ -557,7 +557,7 @@ spec:
       nodeSelector:
       
         kubernetes.io/os: linux
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 40
       containers:
         - name: ingress
           image: "docker.io/kumahq/kuma-dp:0.0.1"

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/fix4496.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/fix4496.golden.yaml
@@ -570,7 +570,7 @@ spec:
       nodeSelector:
       
         kubernetes.io/os: linux
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 40
       containers:
         - name: ingress
           image: "docker.io/kumahq/kuma-dp:0.0.1"

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/fix4935.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/fix4935.golden.yaml
@@ -902,7 +902,7 @@ spec:
       nodeSelector:
       
         kubernetes.io/os: linux
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 40
       containers:
         - name: ingress
           image: "docker.io/kumahq/kuma-dp:0.0.1"

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/fix5978.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/fix5978.golden.yaml
@@ -711,7 +711,7 @@ spec:
       nodeSelector:
       
         kubernetes.io/os: linux
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 40
       containers:
         - name: ingress
           image: "docker.io/kumahq/kuma-dp:0.0.1"

--- a/deployments/charts/kuma/README.md
+++ b/deployments/charts/kuma/README.md
@@ -113,7 +113,7 @@ A Helm chart for the Kuma Control Plane
 | ingress.replicas | int | `1` | Number of replicas of the Ingress. Ignored when autoscaling is enabled. |
 | ingress.resources | object | `{"limits":{"cpu":"1000m","memory":"512Mi"},"requests":{"cpu":"50m","memory":"64Mi"}}` | Define the resources to allocate to mesh ingress |
 | ingress.lifecycle | object | `{}` | Pod lifecycle settings (useful for adding a preStop hook, when using AWS ALB or NLB) |
-| ingress.terminationGracePeriodSeconds | int | `30` | Number of seconds to wait before force killing the pod. Make sure to update this if you add a preStop hook. |
+| ingress.terminationGracePeriodSeconds | int | `40` | Number of seconds to wait before force killing the pod. Make sure to update this if you add a preStop hook. |
 | ingress.autoscaling.enabled | bool | `false` | Whether to enable Horizontal Pod Autoscaling, which requires the [Metrics Server](https://github.com/kubernetes-sigs/metrics-server) in the cluster |
 | ingress.autoscaling.minReplicas | int | `2` | The minimum CP pods to allow |
 | ingress.autoscaling.maxReplicas | int | `5` | The max CP pods to scale to |

--- a/deployments/charts/kuma/values.yaml
+++ b/deployments/charts/kuma/values.yaml
@@ -426,7 +426,7 @@ ingress:
 
   # -- Number of seconds to wait before force killing the pod. Make sure to
   # update this if you add a preStop hook.
-  terminationGracePeriodSeconds: 30
+  terminationGracePeriodSeconds: 40
 
   # Horizontal Pod Autoscaling configuration
   autoscaling:

--- a/pkg/config/app/kuma-cp/config.go
+++ b/pkg/config/app/kuma-cp/config.go
@@ -209,7 +209,7 @@ var DefaultConfig = func() Config {
 		Access:      access.DefaultAccessConfig(),
 		Experimental: ExperimentalConfig{
 			GatewayAPI:          false,
-			KubeOutboundsAsVIPs: false,
+			KubeOutboundsAsVIPs: true,
 		},
 		Proxy:   xds.DefaultProxyConfig(),
 		InterCp: intercp.DefaultInterCpConfig(),

--- a/pkg/config/app/kuma-cp/kuma-cp.defaults.yaml
+++ b/pkg/config/app/kuma-cp/kuma-cp.defaults.yaml
@@ -572,7 +572,7 @@ experimental:
   gatewayAPI: false # ENV: KUMA_EXPERIMENTAL_GATEWAY_API
   # If true, instead of embedding kubernetes outbounds into Dataplane object, they are persisted next to VIPs in ConfigMap
   # This can improve performance, but it should be enabled only after all instances are migrated to version that supports this config
-  kubeOutboundsAsVIPs: false # ENV: KUMA_EXPERIMENTAL_KUBE_OUTBOUNDS_AS_VIPS
+  kubeOutboundsAsVIPs: true # ENV: KUMA_EXPERIMENTAL_KUBE_OUTBOUNDS_AS_VIPS
 
 proxy:
   gateway:


### PR DESCRIPTION


Fixes: #5884

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [x] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
