### PR TITLE
chore(kumactl): use location of the current clock

### DIFF
--- a/app/kumactl/cmd/inspect/inspect_dataplanes.go
+++ b/app/kumactl/cmd/inspect/inspect_dataplanes.go
@@ -111,6 +111,9 @@ func printDataplaneOverviews(now time.Time, dataplaneOverviews *core_mesh.Datapl
 				var certExpiration *time.Time
 				if dataplaneInsight.GetMTLS().GetCertificateExpirationTime() != nil {
 					certExpiration = util_proto.MustTimestampFromProto(dataplaneInsight.GetMTLS().GetCertificateExpirationTime())
+					// don't use time.Local so we don't have to override it in tests. Instead, use location of current clock (that can be overridden in tests)
+					inLocation := certExpiration.In(now.Location())
+					certExpiration = &inLocation
 				}
 				var lastCertGeneration *time.Time
 				if dataplaneInsight.GetMTLS().GetLastCertificateRegeneration() != nil {

--- a/app/kumactl/cmd/inspect/inspect_dataplanes_test.go
+++ b/app/kumactl/cmd/inspect/inspect_dataplanes_test.go
@@ -52,10 +52,9 @@ var _ = Describe("kumactl inspect dataplanes", func() {
 	var sampleDataplaneOverview []*core_mesh.DataplaneOverviewResource
 
 	BeforeEach(func() {
-		now, _ = time.Parse(time.RFC3339, "2019-07-17T18:08:41+00:00")
-		t1, _ = time.Parse(time.RFC3339, "2018-07-17T16:05:36.995+00:00")
-		t2, _ = time.Parse(time.RFC3339, "2019-07-17T16:05:36.995+00:00")
-		time.Local = time.UTC
+		now, _ = time.ParseInLocation(time.RFC3339, "2019-07-17T18:08:41+00:00", time.UTC)
+		t1, _ = time.ParseInLocation(time.RFC3339, "2018-07-17T16:05:36.995+00:00", time.UTC)
+		t2, _ = time.ParseInLocation(time.RFC3339, "2019-07-17T16:05:36.995+00:00", time.UTC)
 
 		sampleDataplaneOverview = []*core_mesh.DataplaneOverviewResource{
 			{

--- a/app/kumactl/cmd/inspect/inspect_meshes_test.go
+++ b/app/kumactl/cmd/inspect/inspect_meshes_test.go
@@ -76,7 +76,7 @@ var _ = Describe("kumactl inspect meshes", func() {
 		var rootCmd *cobra.Command
 		var buf *bytes.Buffer
 		var store core_store.ResourceStore
-		rootTime, _ := time.Parse(time.RFC3339, "2008-04-27T16:05:36.995Z")
+		rootTime, _ := time.ParseInLocation(time.RFC3339, "2008-04-27T16:05:36.995Z", time.UTC)
 
 		BeforeEach(func() {
 			store = memory_resources.NewStore()

--- a/app/kumactl/cmd/inspect/inspect_services_test.go
+++ b/app/kumactl/cmd/inspect/inspect_services_test.go
@@ -42,7 +42,7 @@ var _ = Describe("kumactl inspect services", func() {
 
 	var rootCmd *cobra.Command
 	var buf *bytes.Buffer
-	rootTime, _ := time.Parse(time.RFC3339, "2008-04-27T16:05:36.995Z")
+	rootTime, _ := time.ParseInLocation(time.RFC3339, "2008-04-27T16:05:36.995Z", time.UTC)
 
 	serviceOverviewResources := []*core_mesh.ServiceOverviewResource{
 		{

--- a/app/kumactl/cmd/inspect/inspect_zoneegresses_test.go
+++ b/app/kumactl/cmd/inspect/inspect_zoneegresses_test.go
@@ -45,10 +45,9 @@ var _ = Describe("kumactl inspect zoneegresses", func() {
 	var sampleZoneEgressOverview []*core_mesh.ZoneEgressOverviewResource
 
 	BeforeEach(func() {
-		now, _ = time.Parse(time.RFC3339, "2019-07-17T18:08:41+00:00")
-		t1, _ = time.Parse(time.RFC3339, "2018-07-17T16:05:36.995+00:00")
-		t2, _ = time.Parse(time.RFC3339, "2019-07-17T16:05:36.995+00:00")
-		time.Local = time.UTC
+		now, _ = time.ParseInLocation(time.RFC3339, "2019-07-17T18:08:41+00:00", time.UTC)
+		t1, _ = time.ParseInLocation(time.RFC3339, "2018-07-17T16:05:36.995+00:00", time.UTC)
+		t2, _ = time.ParseInLocation(time.RFC3339, "2019-07-17T16:05:36.995+00:00", time.UTC)
 
 		sampleZoneEgressOverview = []*core_mesh.ZoneEgressOverviewResource{
 			{

--- a/app/kumactl/cmd/inspect/inspect_zoneingresses_test.go
+++ b/app/kumactl/cmd/inspect/inspect_zoneingresses_test.go
@@ -45,10 +45,9 @@ var _ = Describe("kumactl inspect zone-ingresses", func() {
 	var sampleZoneIngressOverview []*core_mesh.ZoneIngressOverviewResource
 
 	BeforeEach(func() {
-		now, _ = time.Parse(time.RFC3339, "2019-07-17T18:08:41+00:00")
-		t1, _ = time.Parse(time.RFC3339, "2018-07-17T16:05:36.995+00:00")
-		t2, _ = time.Parse(time.RFC3339, "2019-07-17T16:05:36.995+00:00")
-		time.Local = time.UTC
+		now, _ = time.ParseInLocation(time.RFC3339, "2019-07-17T18:08:41+00:00", time.UTC)
+		t1, _ = time.ParseInLocation(time.RFC3339, "2018-07-17T16:05:36.995+00:00", time.UTC)
+		t2, _ = time.ParseInLocation(time.RFC3339, "2019-07-17T16:05:36.995+00:00", time.UTC)
 
 		sampleZoneIngressOverview = []*core_mesh.ZoneIngressOverviewResource{
 			{

--- a/app/kumactl/cmd/inspect/inspect_zones_test.go
+++ b/app/kumactl/cmd/inspect/inspect_zones_test.go
@@ -45,10 +45,9 @@ var _ = Describe("kumactl inspect zones", func() {
 	var sampleZoneOverview []*system_core.ZoneOverviewResource
 
 	BeforeEach(func() {
-		now, _ = time.Parse(time.RFC3339, "2019-07-17T18:08:41+00:00")
-		t1, _ = time.Parse(time.RFC3339, "2018-07-17T16:05:36.995+00:00")
-		t2, _ = time.Parse(time.RFC3339, "2019-07-17T16:05:36.995+00:00")
-		time.Local = time.UTC
+		now, _ = time.ParseInLocation(time.RFC3339, "2019-07-17T18:08:41+00:00", time.UTC)
+		t1, _ = time.ParseInLocation(time.RFC3339, "2018-07-17T16:05:36.995+00:00", time.UTC)
+		t2, _ = time.ParseInLocation(time.RFC3339, "2019-07-17T16:05:36.995+00:00", time.UTC)
 
 		sampleZoneOverview = []*system_core.ZoneOverviewResource{
 			{

--- a/app/kumactl/pkg/output/table/cells.go
+++ b/app/kumactl/pkg/output/table/cells.go
@@ -24,7 +24,7 @@ func Date(t *time.Time) string {
 	if t == nil {
 		return "-"
 	}
-	return t.In(time.Local).Format("2006-01-02 15:04:05")
+	return t.Format("2006-01-02 15:04:05")
 }
 
 func Number(v interface{}) string {


### PR DESCRIPTION
Chasing https://app.circleci.com/pipelines/github/kumahq/kuma/19774/workflows/f1a3081a-9dde-4006-9ed9-e2bf9f3dac65/jobs/331186 flake.

`inspect` package is the only one that overrides locale `time.Local = time.UTC`.

I changed the logic that `cells.go#Date` does not use it anymore and the date that we pass there has a locale of the current clock that we safely pass via context without overriding global variables.

It's just a hypothesis that this might be the cause since this flake is not reproducable outside of CI.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [x] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
