### PR TITLE
ci(.github): take least fixed version for security updates

### DIFF
--- a/.github/workflows/update-insecure-dependencies.yaml
+++ b/.github/workflows/update-insecure-dependencies.yaml
@@ -4,8 +4,6 @@ on:
   workflow_dispatch: { }
   schedule:
     - cron: 0 8 * * *
-env:
-  IGNORE_PACKAGES: "github.com/aws/aws-sdk-go"
 jobs:
   build-matrix:
     runs-on: ubuntu-latest
@@ -14,7 +12,7 @@ jobs:
     steps:
       - id: generate-matrix
         run: |
-          # The head -1 is because GITHUB_OUTPUT is easier to work with single line output and this file is created with automation in `lifecycle.yaml` 
+          # The head -1 is because GITHUB_OUTPUT is easier to work with single line output and this file is created with automation in `lifecycle.yaml`
           ACTIVE_BRANCHES=`gh api /repos/${{ github.repository }}/contents/active-branches.json --jq '.content | @base64d' | head -1`
           echo "branches=${ACTIVE_BRANCHES}" >> $GITHUB_OUTPUT
         env:
@@ -55,7 +53,22 @@ jobs:
       - name: "Update dependencies"
         id: update
         run: |
-          osv-scanner --lockfile=go.mod --json | jq '.results[].packages[].package.name' | grep -Ev ${{ env.IGNORE_PACKAGES }} | xargs -I {} go get -u {}
+          for dep in $(osv-scanner --lockfile=go.mod --json | jq -c '.results[].packages[] | .package.name as $vulnerablePackage | {
+            name: $vulnerablePackage,
+            current: .package.version,
+            fixedVersions: [.vulnerabilities[].affected[] | select(.package.name == $vulnerablePackage) | .ranges[].events[] | select(.fixed != null) | .fixed] | unique
+          } | select(.fixedVersions | length > 0)'); do
+            IFS=. read -r currentMajor currentMinor currentPatch <<< "$(jq -r .current <<< "$dep")"
+            # Update to the first version that's greater than our current version
+            for version in $(jq -cr .fixedVersions[] <<< "$dep" | sort -V); do # sort supports semver sort
+              IFS=. read -r fixMajor fixMinor fixPatch <<< "$version"
+              if ((currentMajor <= fixMajor)) && ((currentMinor <= fixMinor)) && ((currentPatch <= fixPatch)); then
+                package=$(jq -r .name <<< "$dep")
+                go get -u "$package"@v"$version"
+                break
+              fi
+            done
+          done
           go mod tidy
       - name: "Prepare commit body - after"
         id: prepare_commit_body_after
@@ -78,8 +91,8 @@ jobs:
 
             After update:
             ${{ env.SCAN_OUTPUT_AFTER }}
-            
-            If a package is showing up in the scan but the script is not trying to update it then it might be in env.IGNORE_PACKAGES regex
+
+            If a package is showing up in the scan but the script is not trying to update it then it might be because there is no fixed version yet.
           delete-branch: true
           title: "chore(deps): security update"
           draft: false

--- a/.github/workflows/update-insecure-dependencies.yaml
+++ b/.github/workflows/update-insecure-dependencies.yaml
@@ -53,23 +53,7 @@ jobs:
       - name: "Update dependencies"
         id: update
         run: |
-          for dep in $(osv-scanner --lockfile=go.mod --json | jq -c '.results[].packages[] | .package.name as $vulnerablePackage | {
-            name: $vulnerablePackage,
-            current: .package.version,
-            fixedVersions: [.vulnerabilities[].affected[] | select(.package.name == $vulnerablePackage) | .ranges[].events[] | select(.fixed != null) | .fixed] | unique
-          } | select(.fixedVersions | length > 0)'); do
-            IFS=. read -r currentMajor currentMinor currentPatch <<< "$(jq -r .current <<< "$dep")"
-            # Update to the first version that's greater than our current version
-            for version in $(jq -cr .fixedVersions[] <<< "$dep" | sort -V); do # sort supports semver sort
-              IFS=. read -r fixMajor fixMinor fixPatch <<< "$version"
-              if ((currentMajor <= fixMajor)) && ((currentMinor <= fixMinor)) && ((currentPatch <= fixPatch)); then
-                package=$(jq -r .name <<< "$dep")
-                go get -u "$package"@v"$version"
-                break
-              fi
-            done
-          done
-          go mod tidy
+          make update-vulnerable-dependencies
       - name: "Prepare commit body - after"
         id: prepare_commit_body_after
         run: |

--- a/mk/check.mk
+++ b/mk/check.mk
@@ -64,3 +64,7 @@ check: format helm-lint golangci-lint shellcheck kube-lint hadolint ## Dev: Run 
 		git ls-files --other --directory --exclude-standard --no-empty-directory && \
 		false \
 	)
+
+.PHONY: update-vulnerable-dependencies
+update-vulnerable-dependencies:
+	@./tools/ci/update-vulnerable-dependencies.sh

--- a/tools/ci/update-vulnerable-dependencies.sh
+++ b/tools/ci/update-vulnerable-dependencies.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+command -v osv-scanner >/dev/null 2>&1 || { echo >&2 "osv-scanner not installed!"; exit 1; }
+command -v jq >/dev/null 2>&1 || { echo >&2 "jq not installed!"; exit 1; }
+
+for dep in $(osv-scanner --lockfile=go.mod --json | jq -c '.results[].packages[] | .package.name as $vulnerablePackage | {
+  name: $vulnerablePackage,
+  current: .package.version,
+  fixedVersions: [.vulnerabilities[].affected[] | select(.package.name == $vulnerablePackage) | .ranges[].events[] | select(.fixed != null) | .fixed] | unique
+} | select(.fixedVersions | length > 0)'); do
+  IFS=. read -r currentMajor currentMinor currentPatch <<< "$(jq -r .current <<< "$dep")"
+  # Update to the first version that's greater than our current version
+  for version in $(jq -cr .fixedVersions[] <<< "$dep" | sort -V); do # sort supports semver sort
+    IFS=. read -r fixMajor fixMinor fixPatch <<< "$version"
+    # Do not downgrade in order to fix the vulnerability
+    if ((currentMajor <= fixMajor)) && ((currentMinor <= fixMinor)) && ((currentPatch <= fixPatch)); then
+      package=$(jq -r .name <<< "$dep")
+      go get -u "$package"@v"$version"
+      break
+    fi
+  done
+done
+go mod tidy
+


### PR DESCRIPTION
Tested by copy pasting the step contents into `update.sh` and running it on a previous commit, it seems to do the right thing.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues -- Closes https://github.com/kumahq/kuma/issues/6065
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [x] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
