### PR TITLE
ci(golangci-lint): fix make check on macOS

### DIFF
--- a/test/framework/network/netns/builder.go
+++ b/test/framework/network/netns/builder.go
@@ -269,7 +269,7 @@ func (b *Builder) Build() (*NetNS, error) {
 		// for the neighbor information for our veth-related addresses.
 		if err := netlink.NeighAdd(&netlink.Neigh{
 			LinkIndex:    mainLink.Attrs().Index,
-			State:        netlink.NUD_REACHABLE,
+			State:        NUD_REACHABLE,
 			IP:           peerAddr.IP,
 			HardwareAddr: peerLink.Attrs().HardwareAddr,
 		}); err != nil {
@@ -286,7 +286,7 @@ func (b *Builder) Build() (*NetNS, error) {
 		// netns.NewNamed calls unix.Unshare(CLONE_NEWNET) which requires CAP_SYS_ADMIN
 		// capability (ref. https://man7.org/linux/man-pages/man2/unshare.2.html)
 		nsName := genNetNSName(b.nameSeed, suffixA, suffixB)
-		newNS, err := netns.NewNamed(nsName)
+		newNS, err := netNsNewNamed(nsName)
 		if err != nil {
 			done <- fmt.Errorf("cannot create new network namespace: %s", err)
 		}
@@ -346,7 +346,7 @@ func (b *Builder) Build() (*NetNS, error) {
 		// for the neighbor information for our veth-related addresses.
 		if err := netlink.NeighAdd(&netlink.Neigh{
 			LinkIndex:    peerLink.Attrs().Index,
-			State:        netlink.NUD_REACHABLE,
+			State:        NUD_REACHABLE,
 			IP:           mainAddr.IP,
 			HardwareAddr: mainLink.Attrs().HardwareAddr,
 		}); err != nil {

--- a/test/framework/network/netns/netns.go
+++ b/test/framework/network/netns/netns.go
@@ -140,7 +140,7 @@ func (ns *NetNS) Cleanup() error {
 			}
 		}
 
-		if err := netns.DeleteNamed(ns.Name()); err != nil {
+		if err := netNsDeleteNamed(ns.Name()); err != nil {
 			errs = append(errs, fmt.Sprintf("cannot delete network namespace: %s", err))
 		}
 

--- a/test/framework/network/netns/wrap_linux.go
+++ b/test/framework/network/netns/wrap_linux.go
@@ -1,0 +1,18 @@
+//go:build linux
+
+package netns
+
+import (
+	"github.com/vishvananda/netlink"
+	"github.com/vishvananda/netns"
+)
+
+func netNsDeleteNamed(name string) error {
+	return netns.DeleteNamed(name)
+}
+
+func netNsNewNamed(name string) (netns.NsHandle, error) {
+	return netns.NewNamed(name)
+}
+
+const NUD_REACHABLE = netlink.NUD_REACHABLE

--- a/test/framework/network/netns/wrap_other.go
+++ b/test/framework/network/netns/wrap_other.go
@@ -1,0 +1,18 @@
+//go:build !linux
+
+package netns
+
+import (
+	"github.com/pkg/errors"
+	"github.com/vishvananda/netns"
+)
+
+func netNsDeleteNamed(string) error {
+	return errors.New("Only supported on linux")
+}
+
+func netNsNewNamed(string) (netns.NsHandle, error) {
+	return 0, errors.New("Only supported on linux")
+}
+
+const NUD_REACHABLE = 0x00


### PR DESCRIPTION
There were functions that would exist only in Linux. This would cause golangci-lint to fail when running on macOS.

We extracted these into sub functions and provided stubbed to be able to run checks without problems

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [x] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
