### PR TITLE
test(e2e/framework): allow to set CNI image in e2e conf

### DIFF
--- a/test/e2e/cni/taint_controller_race.go
+++ b/test/e2e/cni/taint_controller_race.go
@@ -69,8 +69,11 @@ metadata:
 			err := k8sCluster.CreateNode(nodeName, "second=true")
 			Expect(err).ToNot(HaveOccurred())
 
-			err = k8sCluster.LoadImages("kuma-dp", "kuma-cni", "kuma-universal")
-			Expect(err).ToNot(HaveOccurred())
+			Expect(k8sCluster.LoadImages(
+				Config.KumaDPImageRepo,
+				Config.KumaCNIImageRepo,
+				Config.KumaUniversalImageRepo,
+			)).ToNot(HaveOccurred())
 
 			err = NewClusterSetup().
 				Install(NamespaceWithSidecarInjection(TestNamespace)).

--- a/test/framework/config.go
+++ b/test/framework/config.go
@@ -36,6 +36,7 @@ type E2eConfig struct {
 	KumaCPImageRepo               string            `json:"cpImageRepo,omitempty" envconfig:"KUMA_CP_IMAGE_REPOSITORY"`
 	KumaDPImageRepo               string            `json:"dpImageRepo,omitempty" envconfig:"KUMA_DP_IMAGE_REPOSITORY"`
 	KumaInitImageRepo             string            `json:"initImageRepo,omitempty" envconfig:"KUMA_INIT_IMAGE_REPOSITORY"`
+	KumaCNIImageRepo              string            `json:"cniImageRepo,omitempty" envconfig:"KUMA_CNI_IMAGE_REPOSITORY"`
 	KumaUniversalImageRepo        string            `json:"universalImageRepo,omitempty"`
 	XDSApiVersion                 string            `json:"xdsVersion,omitempty" envconfig:"API_VERSION"`
 	K8sType                       K8sType           `json:"k8sType,omitempty" envconfig:"KUMA_K8S_TYPE"`
@@ -193,6 +194,7 @@ var defaultConf = E2eConfig{
 	KumaDPImageRepo:        "kuma-dp",
 	KumaInitImageRepo:      "kuma-init",
 	KumactlImageRepo:       "kumactl",
+	KumaCNIImageRepo:       "kuma-cni",
 
 	KumaUniversalEnvVars: map[string]string{},
 	KumaK8sCtlFlags:      map[string]string{},

--- a/test/framework/k8s_cluster.go
+++ b/test/framework/k8s_cluster.go
@@ -430,6 +430,7 @@ func (c *K8sCluster) genValues(mode string) map[string]string {
 
 	if c.opts.cniExperimental {
 		values["experimental.cni"] = "true"
+		values["cni.experimental.image.repository"] = Config.KumaCNIImageRepo
 	}
 
 	if Config.CIDR != "" {


### PR DESCRIPTION
Allow to set CNI image (repository) in e2e config and modify CNI taint e2e test to load images with repositories set from the e2e config

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [ ] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS -- it actually fixes one of these cases
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? -- NA
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [x] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
