### PR TITLE
test(e2e): increase timeout for getting Gateway API Gateway IP

### DIFF
--- a/test/e2e_env/kubernetes/gateway/gatewayapi.go
+++ b/test/e2e_env/kubernetes/gateway/gatewayapi.go
@@ -82,7 +82,7 @@ spec:
 			g.Expect(err).ToNot(HaveOccurred())
 			g.Expect(out).ToNot(BeEmpty())
 			ip = out
-		}, "60s", "1s").Should(Succeed(), "could not get a LoadBalancer IP of the Gateway")
+		}, "120s", "1s").Should(Succeed(), "could not get a LoadBalancer IP of the Gateway")
 		return ip
 	}
 


### PR DESCRIPTION
I suspect the ServiceLB can sometimes take much longer to reconcile LoadBalancer Services, I want to see if this can eliminate the flakes.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [x] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
