### PR TITLE
feat(api-server): whoami endpoint

### DIFF
--- a/pkg/api-server/server.go
+++ b/pkg/api-server/server.go
@@ -150,6 +150,7 @@ func NewApiServer(
 	if err := addIndexWsEndpoints(ws, getInstanceId, getClusterId, enableGUI, guiUrl); err != nil {
 		return nil, errors.Wrap(err, "could not create index webservice")
 	}
+	addWhoamiEndpoints(ws)
 	container.Add(ws)
 
 	path := cfg.ApiServer.BasePath

--- a/pkg/api-server/whoami_endpoint.go
+++ b/pkg/api-server/whoami_endpoint.go
@@ -1,0 +1,26 @@
+package api_server
+
+import (
+	"github.com/emicklei/go-restful/v3"
+
+	"github.com/kumahq/kuma/pkg/core/user"
+)
+
+type WhoamiResponse struct {
+	Name   string   `json:"name"`
+	Groups []string `json:"groups"`
+}
+
+func addWhoamiEndpoints(ws *restful.WebService) {
+	ws.Route(ws.GET("/who-am-i").To(func(req *restful.Request, resp *restful.Response) {
+		u := user.FromCtx(req.Request.Context())
+		whoamiResp := WhoamiResponse{
+			Name:   u.Name,
+			Groups: u.Groups,
+		}
+
+		if err := resp.WriteAsJson(whoamiResp); err != nil {
+			log.Error(err, "Could not write the who-am-i response")
+		}
+	}))
+}

--- a/pkg/api-server/whoami_endpoint_test.go
+++ b/pkg/api-server/whoami_endpoint_test.go
@@ -1,0 +1,47 @@
+package api_server_test
+
+import (
+	"io"
+	"net/http"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	api_server "github.com/kumahq/kuma/pkg/api-server"
+	"github.com/kumahq/kuma/pkg/test"
+)
+
+var _ = Describe("Whoami Endpoint", func() {
+
+	var stop = func() {}
+	var apiServer *api_server.ApiServer
+	BeforeEach(func() {
+		apiServer, _, stop = StartApiServer(NewTestApiServerConfigurer())
+	})
+	AfterEach(func() {
+		stop()
+	})
+
+	It("should return the user information", test.Within(5*time.Second, func() {
+		// when
+		resp, err := http.Get("http://" + apiServer.Address() + "/who-am-i")
+		Expect(err).ToNot(HaveOccurred())
+
+		// then
+		body, err := io.ReadAll(resp.Body)
+		Expect(err).ToNot(HaveOccurred())
+
+		// it's admin because of the default KUMA_API_SERVER_AUTHN_LOCALHOST_IS_ADMIN=true and the server is running on localhost
+		expected := `
+        {
+          "name": "mesh-system:admin",
+          "groups": [
+            "mesh-system:admin",
+            "mesh-system:authenticated"
+          ]
+        }`
+
+		Expect(body).To(MatchJSON(expected))
+	}))
+})


### PR DESCRIPTION
It's quite annoying that there is no convenient way to check if you successfully authenticated as user X. This PR adds an endpoint to check it.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [X] [Link to relevant issue][1] as well as docs and UI issues --
- [X] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [X] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [X] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [X] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [X] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
