### PR TITLE
build(tools/kubectl): remove default version and run as non root

### DIFF
--- a/tools/kubectl/Dockerfile
+++ b/tools/kubectl/Dockerfile
@@ -1,10 +1,12 @@
 ARG BASE_IMAGE=alpine:latest
 FROM ${BASE_IMAGE}
 ARG ARCH
-ARG KUBERNETES_RELEASE=v1.21.3
+ARG KUBERNETES_RELEASE
 RUN set -x \
  && wget -q -O /bin/kubectl https://storage.googleapis.com/kubernetes-release/release/${KUBERNETES_RELEASE}/bin/linux/${ARCH}/kubectl \
  && chmod +x /bin/kubectl
+
+USER nobody
 
 ENTRYPOINT ["kubectl"]
 CMD ["--help"]

--- a/tools/kubectl/docker-build-and-publish.sh
+++ b/tools/kubectl/docker-build-and-publish.sh
@@ -1,6 +1,8 @@
 #!/bin/sh
 
-: "${KUBERNETES_RELEASE:=v1.20.15}"
+set -e
+
+: "${KUBERNETES_RELEASE:?must be set!}"
 
 build_docker_image(){
     docker build --build-arg ARCH="${1?required}" \

--- a/tools/kubectl/docker-build-and-publish.sh
+++ b/tools/kubectl/docker-build-and-publish.sh
@@ -14,20 +14,20 @@ build_docker_image(){
 }
 
 echo "Building docker image for amd64 and kubernetes ${KUBERNETES_RELEASE}"
-build_docker_image amd64 amd64/alpine:latest ${KUBERNETES_RELEASE} .
+build_docker_image amd64 amd64/alpine:latest "${KUBERNETES_RELEASE}" .
 echo "Building docker image for arm64 and kubernetes ${KUBERNETES_RELEASE}"
-build_docker_image arm64 arm64v8/alpine:latest ${KUBERNETES_RELEASE} .
+build_docker_image arm64 arm64v8/alpine:latest "${KUBERNETES_RELEASE}" .
 echo "Building docker image for arm and kubernetes ${KUBERNETES_RELEASE}"
-build_docker_image arm arm32v7/alpine:latest ${KUBERNETES_RELEASE} .
+build_docker_image arm arm32v7/alpine:latest "${KUBERNETES_RELEASE}" .
 
-docker manifest create kumahq/kubectl:$KUBERNETES_RELEASE \
-  --amend kumahq/kubectl:${KUBERNETES_RELEASE}-amd64 \
-  --amend kumahq/kubectl:${KUBERNETES_RELEASE}-arm64 \
-  --amend kumahq/kubectl:${KUBERNETES_RELEASE}-arm 
+docker manifest create "kumahq/kubectl:$KUBERNETES_RELEASE" \
+  --amend "kumahq/kubectl:${KUBERNETES_RELEASE}-amd64" \
+  --amend "kumahq/kubectl:${KUBERNETES_RELEASE}-arm64" \
+  --amend "kumahq/kubectl:${KUBERNETES_RELEASE}-arm"
 
-docker manifest annotate kumahq/kubectl:$KUBERNETES_RELEASE kumahq/kubectl:$KUBERNETES_RELEASE-arm64 --os linux --arch arm64
-docker manifest annotate kumahq/kubectl:$KUBERNETES_RELEASE kumahq/kubectl:$KUBERNETES_RELEASE-amd64 --os linux --arch amd64
-docker manifest annotate kumahq/kubectl:$KUBERNETES_RELEASE kumahq/kubectl:$KUBERNETES_RELEASE-arm --os linux --arch arm
+docker manifest annotate "kumahq/kubectl:$KUBERNETES_RELEASE" "kumahq/kubectl:$KUBERNETES_RELEASE-arm64" --os linux --arch arm64
+docker manifest annotate "kumahq/kubectl:$KUBERNETES_RELEASE" "kumahq/kubectl:$KUBERNETES_RELEASE-amd64" --os linux --arch amd64
+docker manifest annotate "kumahq/kubectl:$KUBERNETES_RELEASE" "kumahq/kubectl:$KUBERNETES_RELEASE-arm" --os linux --arch arm
 
 echo "Publishing manifest"
-docker manifest push kumahq/kubectl:$KUBERNETES_RELEASE
+docker manifest push "kumahq/kubectl:$KUBERNETES_RELEASE"


### PR DESCRIPTION
This makes it unnecessary to set `runAsUser: ` in the various k8s `securityContexts` because it otherwise ran as root.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [x] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
