### PR TITLE
chore(meshhttproute): add extra validation

### DIFF
--- a/pkg/core/validators/types.go
+++ b/pkg/core/validators/types.go
@@ -151,7 +151,7 @@ func (p PathBuilder) concat(other PathBuilder) PathBuilder {
 	}
 
 	firstOther := other[0]
-	if !strings.HasPrefix(firstOther, "[") {
+	if !strings.HasPrefix(firstOther, "[") && !strings.HasPrefix(firstOther, ".") {
 		firstOther = "." + firstOther
 	}
 

--- a/pkg/plugins/policies/meshhttproute/api/v1alpha1/validation_test.go
+++ b/pkg/plugins/policies/meshhttproute/api/v1alpha1/validation_test.go
@@ -136,15 +136,19 @@ to:
 `),
 		ErrorCases("invalid HeaderModifier filter",
 			[]validators.Violation{{
-				Field:   `spec.to[0].rules[0].default.filters[0].requestHeaderModifier`,
-				Message: `headerModifier must have only one type defined: set, add, remove`,
+				Field:   `spec.to[0].rules[0].default.filters[0].requestHeaderModifier.set[1].name`,
+				Message: `duplicate header name`,
 			}, {
 				Field:   `spec.to[0].rules[0].default.filters[1].responseHeaderModifier`,
-				Message: `headerModifier must have only one type defined: set, add, remove`,
+				Message: `must have at least one defined: set, add, remove`,
 			}, {
-				Field:   `spec.to[0].rules[0].default.filters[2].responseHeaderModifier`,
-				Message: `headerModifier must have only one type defined: set, add, remove`,
-			}}, `
+				Field:   `spec.to[0].rules[0].default.filters[2].responseHeaderModifier.add[0].name`,
+				Message: `duplicate header name`,
+			}, {
+				Field:   `spec.to[0].rules[0].default.filters[2].responseHeaderModifier.remove[0].name`,
+				Message: `duplicate header name`,
+			},
+			}, `
 type: MeshHTTPRoute
 mesh: mesh-1
 name: route-1
@@ -163,9 +167,8 @@ to:
               set:
                 - name: foo
                   value: bar
-              add:
                 - name: foo
-                  value: bar
+                  value: bazz
           - type: ResponseHeaderModifier
             responseHeaderModifier: {}
           - type: ResponseHeaderModifier

--- a/pkg/test/resources/validation.go
+++ b/pkg/test/resources/validation.go
@@ -64,8 +64,10 @@ func DescribeErrorCases[T core_model.Resource](generator func() T, cases ...Tabl
 			}
 
 			// then
-			err := core_model.Validate(resource).(*validators.ValidationError)
-			Expect(err.Violations).To(ConsistOf(expected.Violations))
+			err := core_model.Validate(resource)
+			Expect(err).To(HaveOccurred())
+			verr := err.(*validators.ValidationError)
+			Expect(verr.Violations).To(ConsistOf(expected.Violations))
 		},
 		cases,
 	)


### PR DESCRIPTION
### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [X] [Link to relevant issue][1] as well as docs and UI issues -- Fix https://github.com/kumahq/kuma/issues/5799
- [X] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [X] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [X] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [X] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [X] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
