### PR TITLE
ci(ebpf): correctly build ebpf programs for each arch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,4 +15,5 @@ build/
 *.test
 
 # to embed ebpf programs by using go:embed, we have to copy programs first
-pkg/transparentproxy/ebpf/programs/mb_*
+pkg/transparentproxy/ebpf/programs/amd64/mb_*
+pkg/transparentproxy/ebpf/programs/arm64/mb_*

--- a/mk/ebpf.mk
+++ b/mk/ebpf.mk
@@ -32,7 +32,7 @@ define make_ebpf_targets
 $(1)/mb_*: | $(1)
 	curl --progress-bar --location $(TARBALL_URL)/all-$(3).tar.gz | tar -C $$(@D) -xz
 
-$(2)/mb_*: | $(2)
+$(2)/mb_*: | $(2) $(1)/mb_*
 	cp $(1)/mb_* $(2)
 
 # Make $(2) $(1) directories if they don't

--- a/mk/ebpf.mk
+++ b/mk/ebpf.mk
@@ -14,39 +14,41 @@
 
 RELEASE_TAG ?= main-dd8b1946a31a8ce03009a2743b18ebcc716cda61
 RELEASE_REPO ?= https://github.com/kumahq/merbridge
-TARBALL_NAME ?= all-$(GOARCH).tar.gz
 # You can provide your own url if the tarball with all ebpf programs should be
 # fetched from somewhere else
-TARBALL_URL ?= $(RELEASE_REPO)/releases/download/$(RELEASE_TAG)/$(TARBALL_NAME)
+TARBALL_URL ?= $(RELEASE_REPO)/releases/download/$(RELEASE_TAG)
 # Where should be placed directory with $(RELEASE_TAG) as name placed. We don't
-# allow to overwrite the final $(BUILD_OUTPUT_WITH_TAG) variable, as if someone
-# by mistake remove $(RELEASE_TAG) from the path, it may result in situation
-# where without realizing, ebpf programs are not re-fetched when $(RELEASE_TAG)
-# changes
-BUILD_OUTPUT ?= $(BUILD_DIR)/ebpf-$(GOARCH)
-BUILD_OUTPUT_WITH_TAG = $(BUILD_OUTPUT)/$(RELEASE_TAG)
-# Path where ebpf programs should be placed, to be compiled in when building
-# kumactl
+# allow to overwrite the final $(BUILD_OUTPUT) variable,  because without $(RELEASE_TAG) and $(GOARCH), it may result in situation
+# where without realizing, ebpf programs are not re-fetched when $(RELEASE_TAG) or $(GOARCH) changes
+BASE_BUILD_OUTPUT = build/ebpf/$(RELEASE_TAG)
+# Path where ebpf programs should be placed, to be compiled in when building kumactl
 COMPILE_IN_PATH ?= ./pkg/transparentproxy/ebpf/programs
 
 # We are placing ebpf programs inside $(BUILD_OUTPUT_WITH_TAG) directory first,
 # as by default it contains $(RELEASE_TAG) in the path, which means
 # if the tag changes, we will re-fetch programs
-.PHONY: build/ebpf
-build/ebpf: $(BUILD_OUTPUT_WITH_TAG)/mb_* $(COMPILE_IN_PATH)/mb_*
 
-$(BUILD_OUTPUT_WITH_TAG)/mb_*: | $(BUILD_OUTPUT_WITH_TAG)
-	curl --progress-bar --location $(TARBALL_URL) | tar -C $(@D) -xz
+define make_ebpf_targets
+$(1)/mb_*: | $(1)
+	curl --progress-bar --location $(TARBALL_URL)/all-$(3).tar.gz | tar -C $$(@D) -xz
 
-$(COMPILE_IN_PATH)/mb_*: | $(COMPILE_IN_PATH)
-	cp $(BUILD_OUTPUT_WITH_TAG)/mb_* $(COMPILE_IN_PATH)
+$(2)/mb_*: | $(2)
+	cp $(1)/mb_* $(2)
 
-# Make $(COMPILE_IN_PATH) $(BUILD_OUTPUT_WITH_TAG) directories if they don't
+# Make $(2) $(1) directories if they don't
 # exist
-$(COMPILE_IN_PATH) $(BUILD_OUTPUT_WITH_TAG):
-	mkdir -p $@
+$(1) $(2):
+	mkdir -p $$@
+endef
+
+EBF_ARCH:=amd64 arm64
+$(foreach elt,$(EBF_ARCH),$(eval $(call make_ebpf_targets,$(BASE_BUILD_OUTPUT)/$(elt),$(COMPILE_IN_PATH)/$(elt),$(elt))))
+
+EBF_TARGETS:=$(foreach elt,$(EBF_ARCH),$(BASE_BUILD_OUTPUT)/$(elt)/mb_* $(COMPILE_IN_PATH)/$(elt)/mb_*)
+.PHONY: build/ebpf
+build/ebpf: $(EBF_TARGETS)
 
 .PHONY: clean/ebpf
 clean/ebpf :
-	-rm -rf $(BUILD_OUTPUT_WITH_TAG) $(COMPILE_IN_PATH)/mb_*
-
+	-rm -rf $(BUILD_DIR)/ebpf
+	find $(COMPILE_IN_PATH) -type f -name 'mb_*' -exec rm {} \;

--- a/pkg/transparentproxy/ebpf/programs/amd64/programs.go
+++ b/pkg/transparentproxy/ebpf/programs/amd64/programs.go
@@ -1,0 +1,7 @@
+// go:build linux && amd64
+package amd64
+
+import "embed"
+
+//go:embed *
+var Programs embed.FS

--- a/pkg/transparentproxy/ebpf/programs/arm64/programs.go
+++ b/pkg/transparentproxy/ebpf/programs/arm64/programs.go
@@ -1,0 +1,7 @@
+// go:build linux && arm64
+package arm64
+
+import "embed"
+
+//go:embed *
+var Programs embed.FS

--- a/pkg/transparentproxy/ebpf/programs/programs.go
+++ b/pkg/transparentproxy/ebpf/programs/programs.go
@@ -1,8 +1,0 @@
-package programs
-
-import (
-	"embed"
-)
-
-//go:embed *
-var Programs embed.FS

--- a/pkg/transparentproxy/ebpf/programs/programs_amd64.go
+++ b/pkg/transparentproxy/ebpf/programs/programs_amd64.go
@@ -1,0 +1,7 @@
+//go:build linux && amd64
+
+package programs
+
+import "github.com/kumahq/kuma/pkg/transparentproxy/ebpf/programs/amd64"
+
+var Programs = amd64.Programs

--- a/pkg/transparentproxy/ebpf/programs/programs_arm64.go
+++ b/pkg/transparentproxy/ebpf/programs/programs_arm64.go
@@ -1,0 +1,7 @@
+//go:build linux && arm64
+
+package programs
+
+import "github.com/kumahq/kuma/pkg/transparentproxy/ebpf/programs/arm64"
+
+var Programs = arm64.Programs


### PR DESCRIPTION
Previously when building multiple arch at a time programs would be wrongly packages (we were packaging the host arch ebpf program regardless of the GOOS).

We now always add ebpf program for each arch and use build flags to set the correct set of programs

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [x] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
