### PR TITLE
ci(build): add build/distributions to replace distros.sh

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -401,7 +401,7 @@ jobs:
       - run:
           name: Build distributions
           command: make build/distributions
-      - run: or i in build/distributions/out/*.tar.gz; do echo $i; tar -tvf $i; done
+      - run: for i in build/distributions/out/*.tar.gz; do echo $i; tar -tvf $i; done
       - when:
           condition: <<parameters.publish>>
           steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -401,6 +401,7 @@ jobs:
       - run:
           name: Build distributions
           command: make build/distributions
+      - run: or i in build/distributions/out/*.tar.gz; do echo $i; tar -tvf $i; done
       - when:
           condition: <<parameters.publish>>
           steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -503,8 +503,6 @@ workflows:
               cniNetworkPlugin: [ calico ]
           parallelism: 1
           requires: [ build-<< matrix.arch >>, check ]
-      - distributions:
-          requires: [ build ]
       - release:
           # publish artifacts speculatively for normal commits
           filters: # only on master and release-* branches (never on PRs and tags)
@@ -523,3 +521,18 @@ workflows:
             tags:
               only: /.*/
           requires: [ test, test/e2e, test/e2e-legacy ]
+      # TMP job to try on branch
+      - distributions:
+          publish: true
+          requires: [ build ]
+      - distributions:
+          publish: true
+          filters: # only on tags
+            branches:
+              only:
+                - master
+                - /^release-.*/
+            tags:
+              only: /.*/
+          requires: [ test, test/e2e, test/e2e-legacy ]
+

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -401,7 +401,9 @@ jobs:
       - run:
           name: Build distributions
           command: make build/distributions
-      - run: for i in build/distributions/out/*.tar.gz; do echo $i; tar -tvf $i; done
+      - run:
+          name: inspect created tars
+          command: for i in build/distributions/out/*.tar.gz; do echo $i; tar -tvf $i; done
       - when:
           condition: <<parameters.publish>>
           steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -388,6 +388,26 @@ jobs:
         - artifacts-linux-<<parameters.arch>>
         - ebpf-<<parameters.arch>>
 
+  distributions:
+    parameters:
+      publish:
+        description: Whether or not to publish packages
+        type: boolean
+        default: false
+    executor: vm-amd64
+    steps:
+      - install_build_tools
+      - checkout
+      - run:
+          name: Build distributions
+          command: make build/distributions
+      - when:
+          condition: <<parameters.publish>>
+          steps:
+            - run:
+                name: Publish distributions to Pulp
+                command: make publish/pulp
+
   release:
     executor: vm-amd64
     steps:
@@ -480,6 +500,8 @@ workflows:
               cniNetworkPlugin: [ calico ]
           parallelism: 1
           requires: [ build-<< matrix.arch >>, check ]
+      - distributions:
+          requires: [ build ]
       - release:
           # publish artifacts speculatively for normal commits
           filters: # only on master and release-* branches (never on PRs and tags)

--- a/Makefile
+++ b/Makefile
@@ -29,3 +29,4 @@ include mk/docs.mk
 include mk/envoy.mk
 include mk/helm.mk
 include mk/ebpf.mk
+include mk/distribution.mk

--- a/mk/distribution.mk
+++ b/mk/distribution.mk
@@ -1,0 +1,80 @@
+DISTRIBUTION_NAME ?= kuma
+DISTRIBUTION_LICENSE_PATH ?= tools/releases/templates
+DISTRIBUTION_CONFIG_PATH ?= pkg/config/app/kuma-cp/kuma-cp.defaults.yaml
+DISTRIBUTION_TARGET_NAME = $(DISTRIBUTION_NAME)-$(BUILD_INFO_VERSION)
+# A list of all distributions
+# OS:ARCH:coredns:ENVOY_FLAVOUR:ENVOY_FLAVOUR
+# The second ENVOY_FLAVOUR is optional
+# If you don't want to include coredns just put an empty string
+DISTRIBUTION_LIST ?= linux:amd64:coredns:alpine-opt:centos-opt linux:arm64:coredns:alpine-opt darwin:amd64:coredns:darwin-opt darwin:arm64:coredns:darwin-opt
+
+PULP_HOST ?= "https://api.pulp.konnect-prod.konghq.com"
+PULP_PACKAGE_TYPE ?= mesh
+PULP_DIST_NAME ?= alpine
+
+# This function dynamically builds targets for building distribution packages and uploading them to pulp with a set of parameters
+define make_distributions_target
+build/distributions/$(1)-$(2)/$(DISTRIBUTION_TARGET_NAME): GOOS=$(1)
+build/distributions/$(1)-$(2)/$(DISTRIBUTION_TARGET_NAME): GOARCH=$(2)
+build/distributions/$(1)-$(2)/$(DISTRIBUTION_TARGET_NAME):
+	rm -rf $$@
+	mkdir -p $$@/bin $$@/conf
+	$(MAKE) build/kumactl GOOS=$(1) GOARCH=$(2)
+	cp build/artifacts-$(1)-$(2)/kumactl/kumactl $$@/bin
+	$(MAKE) build/kuma-cp GOOS=$(1) GOARCH=$(2)
+	cp build/artifacts-$(1)-$(2)/kuma-cp/kuma-cp $$@/bin
+	$(MAKE) build/kuma-dp GOOS=$(1) GOARCH=$(2)
+	cp build/artifacts-$(1)-$(2)/kuma-dp/kuma-dp $$@/bin
+	cp $(DISTRIBUTION_LICENSE_PATH)/* $$@
+	cp $(DISTRIBUTION_CONFIG_PATH) $$@/conf
+# CoreDNS doesn't always need to be included
+ifeq ($(3),coredns)
+	$(MAKE) build/coredns GOOS=$(1) GOARCH=$(2)
+	cp build/artifacts-$(1)-$(2)/coredns/coredns $$@/bin
+endif
+# A first possible envoy to package
+ifneq ($(4),)
+	$(MAKE) build/envoy/$(1)-$(2)/$(4)/envoy GOOS=$(1) GOARCH=$(2)
+	cp build/envoy/$(1)-$(2)/$(4)/envoy $$@/bin
+endif
+# A second possible envoy to package
+ifneq ($(5),)
+	$(MAKE) build/envoy/$(1)-$(2)/$(4)/envoy GOOS=$(1) GOARCH=$(2)
+	cp build/envoy/$(1)-$(2)/$(4)/envoy $$@/bin/envoy-$(5)
+endif
+	# Set permissions correctly
+	find $$@ -type f | xargs chmod 555
+	# Text files don't have executable access
+	find $$@ -type f -exec grep -I -q '' {} \; -print | xargs chmod 444
+
+build/distributions/out/$(DISTRIBUTION_TARGET_NAME)-$(1)-$(2).tar.gz: build/distributions/$(1)-$(2)/$(DISTRIBUTION_TARGET_NAME)
+	mkdir -p build/distributions/out
+	tar --strip-components 3 -czvf $$@ $$<
+	shasum -a 256 $$@ > $$@.sha256
+
+.PHONY: publish/pulp/$(DISTRIBUTION_TARGET_NAME)-$(1)-$(2)
+publish/pulp/$(DISTRIBUTION_TARGET_NAME)-$(1)-$(2):
+	docker run --rm \
+	  -e PULP_USERNAME="${PULP_USERNAME}" -e PULP_PASSWORD="${PULP_PASSWORD}" \
+	  -e PULP_HOST=$(PULP_HOST) \
+	  -v $(TOP)/build/distributions/out:/files:ro -it kong/release-script \
+	  --file /files/$(DISTRIBUTION_TARGET_NAME)-$(1)-$(2).tar.gz \
+	  --package-type $(PULP_PACKAGE_TYPE) --dist-name $(PULP_DIST_NAME) --publish
+endef
+
+# Call make_distribution_target with each combination
+$(foreach elt,$(DISTRIBUTION_LIST),$(eval $(call make_distributions_target,$(word 1, $(subst :, ,$(elt))),$(word 2, $(subst :, ,$(elt))),$(word 3, $(subst :, ,$(elt))),$(word 4, $(subst :, ,$(elt))),$(word 5, $(subst :, ,$(elt))))))
+
+# Create a main target which will call the tar.gz target for each distribution
+DIST_TARGETS:=$(foreach elt, $(DISTRIBUTION_LIST), build/distributions/out/$(DISTRIBUTION_TARGET_NAME)-$(word 1, $(subst :, ,$(elt)))-$(word 2, $(subst :, ,$(elt))).tar.gz)
+.PHONY: build/distributions
+build/distributions: $(DIST_TARGETS)
+
+# Create a main target which will publish to pulp each to the tar.gz built
+PULP_PUBLISH_TARGETS:=$(foreach elt, $(DISTRIBUTION_LIST), publish/pulp/$(DISTRIBUTION_TARGET_NAME)-$(word 1, $(subst :, ,$(elt)))-$(word 2, $(subst :, ,$(elt))))
+.PHONY: publish/pulp
+publish/pulp: $(PULP_PUBLISH_TARGETS)
+
+.PHONY: clean/distributions
+clean/distributions:
+	rm -rf build/distributions

--- a/mk/distribution.mk
+++ b/mk/distribution.mk
@@ -8,7 +8,7 @@ DISTRIBUTION_CONFIG_PATH ?= pkg/config/app/kuma-cp/kuma-cp.defaults.yaml
 DISTRIBUTION_LIST ?= linux:amd64:coredns:alpine-opt:centos-opt linux:arm64:coredns:alpine-opt darwin:amd64:coredns:darwin-opt darwin:arm64:coredns:darwin-opt
 
 PULP_HOST ?= "https://api.pulp.konnect-prod.konghq.com"
-PULP_PACKAGE_TYPE ?= mesh
+PULP_PACKAGE_TYPE ?= kuma
 PULP_DIST_NAME ?= $(DISTRIBUTION_NAME)-$(shell echo $(BUILD_INFO_VERSION) | awk -F '.' '{ print $$1"."$$2"."$$3 }')
 
 # This function dynamically builds targets for building distribution packages and uploading them to pulp with a set of parameters
@@ -58,8 +58,9 @@ publish/pulp/$(DISTRIBUTION_TARGET_NAME)-$(1)-$(2):
 	  -e PULP_HOST=$(PULP_HOST) \
 	  -v $(TOP)/build/distributions/out:/files:ro -it kong/release-script \
 	  --file /files/$(DISTRIBUTION_TARGET_NAME)-$(1)-$(2).tar.gz \
-	  --package-type $(PULP_PACKAGE_TYPE) --dist-name src --dist-version $(PULP_DIST_NAME) --publish
+	  --package-type $(PULP_PACKAGE_TYPE) --dist-name alpine
 endef
+# Removed --publish to see if internal publication works :)
 
 # Call make_distribution_target with each combination
 $(foreach elt,$(DISTRIBUTION_LIST),$(eval $(call make_distributions_target,$(word 1, $(subst :, ,$(elt))),$(word 2, $(subst :, ,$(elt))),$(word 3, $(subst :, ,$(elt))),$(word 4, $(subst :, ,$(elt))),$(word 5, $(subst :, ,$(elt))))))

--- a/mk/distribution.mk
+++ b/mk/distribution.mk
@@ -50,7 +50,6 @@ build/distributions/out/$(DISTRIBUTION_TARGET_NAME)-$(1)-$(2).tar.gz: build/dist
 	mkdir -p build/distributions/out
 	tar --strip-components 3 --numeric-owner -czvf $$@ $$<
 	shasum -a 256 $$@ > $$@.sha256
-	echo $(PULP_DIST_NAME)
 
 .PHONY: publish/pulp/$(DISTRIBUTION_TARGET_NAME)-$(1)-$(2)
 publish/pulp/$(DISTRIBUTION_TARGET_NAME)-$(1)-$(2):

--- a/mk/distribution.mk
+++ b/mk/distribution.mk
@@ -49,7 +49,7 @@ endif
 
 build/distributions/out/$(DISTRIBUTION_TARGET_NAME)-$(1)-$(2).tar.gz: build/distributions/$(1)-$(2)/$(DISTRIBUTION_TARGET_NAME)
 	mkdir -p build/distributions/out
-	tar --strip-components 3 -czvf $$@ $$<
+	tar --strip-components 3 --numeric-owner -czvf $$@ $$<
 	shasum -a 256 $$@ > $$@.sha256
 
 .PHONY: publish/pulp/$(DISTRIBUTION_TARGET_NAME)-$(1)-$(2)

--- a/mk/distribution.mk
+++ b/mk/distribution.mk
@@ -1,7 +1,6 @@
 DISTRIBUTION_NAME ?= kuma
 DISTRIBUTION_LICENSE_PATH ?= tools/releases/templates
 DISTRIBUTION_CONFIG_PATH ?= pkg/config/app/kuma-cp/kuma-cp.defaults.yaml
-DISTRIBUTION_TARGET_NAME = $(DISTRIBUTION_NAME)-$(BUILD_INFO_VERSION)
 # A list of all distributions
 # OS:ARCH:coredns:ENVOY_FLAVOUR:ENVOY_FLAVOUR
 # The second ENVOY_FLAVOUR is optional
@@ -10,7 +9,7 @@ DISTRIBUTION_LIST ?= linux:amd64:coredns:alpine-opt:centos-opt linux:arm64:cored
 
 PULP_HOST ?= "https://api.pulp.konnect-prod.konghq.com"
 PULP_PACKAGE_TYPE ?= mesh
-PULP_DIST_NAME ?= alpine
+PULP_DIST_NAME ?= $(DISTRIBUTION_NAME)-$(shell echo $(BUILD_INFO_VERSION) | awk -F '.' '{ print $$1"."$$2"."$$3 }')
 
 # This function dynamically builds targets for building distribution packages and uploading them to pulp with a set of parameters
 define make_distributions_target
@@ -51,6 +50,7 @@ build/distributions/out/$(DISTRIBUTION_TARGET_NAME)-$(1)-$(2).tar.gz: build/dist
 	mkdir -p build/distributions/out
 	tar --strip-components 3 --numeric-owner -czvf $$@ $$<
 	shasum -a 256 $$@ > $$@.sha256
+	echo $(PULP_DIST_NAME)
 
 .PHONY: publish/pulp/$(DISTRIBUTION_TARGET_NAME)-$(1)-$(2)
 publish/pulp/$(DISTRIBUTION_TARGET_NAME)-$(1)-$(2):

--- a/mk/distribution.mk
+++ b/mk/distribution.mk
@@ -58,7 +58,7 @@ publish/pulp/$(DISTRIBUTION_TARGET_NAME)-$(1)-$(2):
 	  -e PULP_HOST=$(PULP_HOST) \
 	  -v $(TOP)/build/distributions/out:/files:ro -it kong/release-script \
 	  --file /files/$(DISTRIBUTION_TARGET_NAME)-$(1)-$(2).tar.gz \
-	  --package-type $(PULP_PACKAGE_TYPE) --dist-name $(PULP_DIST_NAME) --publish
+	  --package-type $(PULP_PACKAGE_TYPE) --dist-name src --dist-version $(PULP_DIST_NAME) --publish
 endef
 
 # Call make_distribution_target with each combination

--- a/mk/envoy.mk
+++ b/mk/envoy.mk
@@ -63,3 +63,4 @@ build/envoy/$(GOOS)-$(GOARCH)/%/envoy:
 clean/envoy:
 	rm -rf ${SOURCE_DIR}
 	rm -rf build/artifacts-${GOOS}-${GOARCH}/envoy/
+	rm -rf build/envoy/

--- a/mk/envoy.mk
+++ b/mk/envoy.mk
@@ -1,5 +1,5 @@
 BUILD_ENVOY_FROM_SOURCES ?= false
-ENVOY_TAG ?= v1.22.7
+ENVOY_TAG ?= v$(ENVOY_VERSION)
 ENVOY_ARTIFACT_EXT ?=
 
 ifeq ($(GOOS),linux)
@@ -51,6 +51,13 @@ else
 	ENVOY_ARTIFACT_EXT=${ENVOY_ARTIFACT_EXT} \
 	BINARY_PATH=$@ ${KUMA_DIR}/tools/envoy/fetch.sh
 endif
+
+build/envoy/$(GOOS)-$(GOARCH)/%/envoy:
+	GOOS=$(GOOS) \
+	GOARCH=$(GOARCH) \
+	ENVOY_TARGET=$* \
+	ENVOY_TAG=$(ENVOY_TAG) \
+	BINARY_PATH=$@ ${KUMA_DIR}/tools/envoy/fetch.sh
 
 .PHONY: clean/envoy
 clean/envoy:

--- a/tools/envoy/fetch.sh
+++ b/tools/envoy/fetch.sh
@@ -35,9 +35,9 @@ function download_envoy() {
         msg_err "Error: failed downloading Envoy: ${status} error"
     fi
 
-    tar -C "$bin_dir" -xzvf "${tar_path}" envoy-"${ENVOY_DISTRO}"
+    tar -C "$bin_dir" -xzvf "${tar_path}"
     rm "$tar_path"
-    mv -f "${bin_dir}/envoy-${ENVOY_DISTRO}" "${BINARY_PATH}"
+    mv "${bin_dir}/envoy-${ENVOY_DISTRO}" "${BINARY_PATH}"
 
     [ -f "${BINARY_PATH}" ] && chmod +x "${BINARY_PATH}"
 }

--- a/tools/envoy/fetch.sh
+++ b/tools/envoy/fetch.sh
@@ -14,6 +14,7 @@ set -o nounset
 
 source "$(dirname -- "${BASH_SOURCE[0]}")/../common.sh"
 
+ENVOY_TARGET=${ENVOY_TARGET:-}
 function download_envoy() {
     local binary_name=$1
     local bin_dir
@@ -34,13 +35,19 @@ function download_envoy() {
         msg_err "Error: failed downloading Envoy: ${status} error"
     fi
 
-    tar -C "$bin_dir" -xzvf "${tar_path}"
+    tar -C "$bin_dir" -xzvf "${tar_path}" envoy-"${ENVOY_DISTRO}"
     rm "$tar_path"
-    mv "${bin_dir}/envoy-${ENVOY_DISTRO}" "${BINARY_PATH}"
+    mv -f "${bin_dir}/envoy-${ENVOY_DISTRO}" "${BINARY_PATH}"
 
     [ -f "${BINARY_PATH}" ] && chmod +x "${BINARY_PATH}"
 }
 
+if [[ -n "${ENVOY_TARGET}" ]]; then
+  BINARY_NAME="envoy-${GOOS}-${GOARCH}-${ENVOY_TAG}-${ENVOY_TARGET}"
+  ENVOY_DISTRO=$(echo "${ENVOY_TARGET}" | awk -F'-' '{ print $1 }')
+  download_envoy "${BINARY_NAME}"
+  exit 0
+fi
 if [[ -n "${ENVOY_TAG}" ]]; then
   BINARY_NAME="envoy-${GOOS}-${GOARCH}-${ENVOY_TAG}-${ENVOY_DISTRO}-opt${ENVOY_ARTIFACT_EXT}"
   download_envoy "${BINARY_NAME}"


### PR DESCRIPTION
Do everything in a Makefile to make this easier to inherit and provide the possibility to improve incremental builds

All output goes to `build/distributions` with the tar.gz in `build/distributions/out`

Don't remove distros.sh yet as we want to validate this is working correctly first

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [x] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
