### PR TITLE
docs(UPGRADE.md): add section about tproxy/cni v2

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -14,6 +14,60 @@ We now support version `v0.6.0` of the Gateway API. See the [upstream API
 changes](https://github.com/kubernetes-sigs/gateway-api/releases/tag/v0.6.0) for
 more info.
 
+### Transparent Proxy Engine v2 and CNI v2 as default
+
+As they matured, in the upcoming release Kuma will by default use transparent
+proxy engine v2 and CNI v2.
+
+If you want to still use v1 versions of these components, you will have to install 
+Kuma with provided `legacy.transparentProxy=true` or `legacy.cni.enabled=true`
+options.
+
+#### Examples
+
+##### CNI
+
+*Helm*
+
+```sh
+helm upgrade --install --create-namespace --namespace kuma-system \
+  --set "legacy.cni.enabled=true" \
+  --set "cni.enabled=true" \
+  --set "cni.chained=true" \
+  --set "cni.netDir=/etc/cni/net.d" \
+  --set "cni.binDir=/opt/cni/bin" \
+  --set "cni.confName=10-calico.conflist"
+  kuma kuma/kuma
+```
+
+*kumactl*
+
+```sh
+kumactl install control-plane \
+  --set "legacy.cni.enabled=true" \
+  --set "cni.enabled=true" \
+  --set "cni.chained=true" \
+  --set "cni.netDir=/etc/cni/net.d" \
+  --set "cni.binDir=/opt/cni/bin" \
+  --set "cni.confName=10-calico.conflist" \
+  | kubectl apply -f-
+```
+
+##### Transparent Proxy Engine
+
+*Helm*
+
+```sh
+helm upgrade --install --create-namespace --namespace kuma-system \
+  --set "legacy.transparentProxy=true" kuma kuma/kuma
+```
+
+*kumactl*
+
+```sh
+kumactl install control-plane --set "legacy.transparentProxy=true" | kubectl apply -f-
+```
+
 ## Upgrade to `2.1.x`
 
 ### **Breaking changes**


### PR DESCRIPTION
Update UPGRADE.md file with the section about tproxy/cni v2 which are now default

- [x] [Link to relevant issue][1] as well as docs and UI issues -- https://github.com/kumahq/kuma/issues/5880
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) -- NA
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? -- NA
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? -- It doesn't
- [x] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
