### PR TITLE
fix(validators): make Root().Field() == RootedAt()

### DIFF
--- a/pkg/core/validators/types.go
+++ b/pkg/core/validators/types.go
@@ -127,7 +127,11 @@ func Root() PathBuilder {
 }
 
 func (p PathBuilder) Field(name string) PathBuilder {
-	return append(p, fmt.Sprintf(".%s", name))
+	element := name
+	if len(p) > 0 {
+		element = fmt.Sprintf(".%s", element)
+	}
+	return append(p, element)
 }
 
 func (p PathBuilder) Index(index int) PathBuilder {
@@ -151,7 +155,7 @@ func (p PathBuilder) concat(other PathBuilder) PathBuilder {
 	}
 
 	firstOther := other[0]
-	if !strings.HasPrefix(firstOther, "[") && !strings.HasPrefix(firstOther, ".") {
+	if !strings.HasPrefix(firstOther, "[") {
 		firstOther = "." + firstOther
 	}
 

--- a/pkg/core/validators/types_test.go
+++ b/pkg/core/validators/types_test.go
@@ -117,7 +117,7 @@ var _ = Describe("Validation Error", func() {
 			}))
 		})
 
-		It("doesn't properly concatenate paths with Root().Field()", func() {
+		It("properly concatenates paths with Root().Field()", func() {
 			// given
 			path := validators.RootedAt("thing.spec")
 			err := validators.ValidationError{}
@@ -129,7 +129,7 @@ var _ = Describe("Validation Error", func() {
 			// then
 			Expect(err).To(Equal(validators.ValidationError{
 				Violations: []validators.Violation{
-					{Field: "thing.spec..field", Message: "something bad"},
+					{Field: "thing.spec.field", Message: "something bad"},
 				},
 			}))
 		})
@@ -229,8 +229,7 @@ var _ = Describe("PathBuilder", func() {
 		Expect(validators.RootedAt("spec").Field("sources").Index(0).Field("match").Key("service").String()).To(Equal(`spec.sources[0].match["service"]`))
 	})
 
-	It("Root().Field() and RootedAt() produce different output", func() {
-		Expect(validators.Root().Field("field").String()).To(Equal(".field"))
-		Expect(validators.RootedAt("field").String()).To(Equal("field"))
+	It("works with Root().Field() or RootedAt()", func() {
+		Expect(validators.Root().Field("field").String()).To(Equal(validators.RootedAt("field").String()))
 	})
 })

--- a/pkg/core/validators/types_test.go
+++ b/pkg/core/validators/types_test.go
@@ -116,6 +116,23 @@ var _ = Describe("Validation Error", func() {
 				},
 			}))
 		})
+
+		It("doesn't properly concatenate paths with Root().Field()", func() {
+			// given
+			path := validators.RootedAt("thing.spec")
+			err := validators.ValidationError{}
+			subErr := validators.ValidationError{}
+			subErr.AddViolationAt(validators.Root().Field("field"), "something bad")
+
+			// when
+			err.AddErrorAt(path, subErr)
+			// then
+			Expect(err).To(Equal(validators.ValidationError{
+				Violations: []validators.Violation{
+					{Field: "thing.spec..field", Message: "something bad"},
+				},
+			}))
+		})
 	})
 
 	Describe("Transform()", func() {
@@ -210,5 +227,10 @@ var _ = Describe("PathBuilder", func() {
 
 	It("should produce valid array index", func() {
 		Expect(validators.RootedAt("spec").Field("sources").Index(0).Field("match").Key("service").String()).To(Equal(`spec.sources[0].match["service"]`))
+	})
+
+	It("Root().Field() and RootedAt() produce different output", func() {
+		Expect(validators.Root().Field("field").String()).To(Equal(".field"))
+		Expect(validators.RootedAt("field").String()).To(Equal("field"))
 	})
 })


### PR DESCRIPTION
### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [x] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
