### PR TITLE
feat(kumactl): remove ca-cert or skip-verify requirement

### DIFF
--- a/app/kumactl/cmd/config/config_control_planes_add.go
+++ b/app/kumactl/cmd/config/config_control_planes_add.go
@@ -99,14 +99,9 @@ func newConfigControlPlanesAddCmd(pctx *kumactl_cmd.RootContext) *cobra.Command 
 }
 
 func validateArgs(args controlPlaneAddArgs, plugins map[string]plugins.AuthnPlugin) error {
-	url, err := net_url.ParseRequestURI(args.apiServerURL)
+	_, err := net_url.ParseRequestURI(args.apiServerURL)
 	if err != nil {
 		return errors.Wrap(err, "API Server URL is invalid")
-	}
-	if url.Scheme == "https" {
-		if args.caCertFile == "" && !args.skipVerify {
-			return errors.New("HTTPS is used. You need to specify either --ca-cert-file so kumactl can verify authenticity of the Control Plane or --skip-verify to skip verification")
-		}
 	}
 	if (args.clientKeyFile != "" && args.clientCertFile == "") || (args.clientKeyFile == "" && args.clientCertFile != "") {
 		return errors.New("Both --client-cert-file and --client-key-file needs to be specified")


### PR DESCRIPTION
Remove the requirement of providing ca-cert or skip-verify when https is used.
The user may just want to use a CA bundle in the system.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [X] [Link to relevant issue][1] as well as docs and UI issues --
- [X] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [X] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [X] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [X] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [X] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
