### PR TITLE
test(e2e): reenable Gateway API conformance tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -277,10 +277,10 @@ jobs:
             # Handle legacy tests on branch
             if [[ "<< pipeline.git.branch >>" != "master" && "<< pipeline.git.branch >>" != "release-"* ]]; then
               if [[ "<< parameters.target >>" == "test/e2e" ]]; then
-                skip "we do not run legacy E2E on branch by default. To run them add ci/run-e2e-legacy label"
+                skip "we do not run legacy E2E on branch by default. To run them add ci/run-full-matrix label"
               fi
               if [[ "<< parameters.cniNetworkPlugin >>" == "calico" || "<< parameters.k8sVersion >>" == "kindIpv6" || "<< parameters.k8sVersion >>" == "v1.20.15-k3s1" || "<< parameters.arch >>" == "arm64" ]]; then
-                  skip "Not running tests on PRs with kindIpv6, oldK8s, calico and arm64"
+                  skip "Not running tests on PRs with kindIpv6, oldK8s, calico or arm64"
               fi
             fi
 

--- a/test/e2e/gateway/gatewayapi/conformance_test.go
+++ b/test/e2e/gateway/gatewayapi/conformance_test.go
@@ -25,8 +25,9 @@ var maxNodePort = 30099
 // TestConformance runs as a `testing` test and not Ginkgo so we have to use an
 // explicit `g` to use Gomega.
 func TestConformance(t *testing.T) {
-	if os.Getenv("CIRCLE_NODE_INDEX") != "" && os.Getenv("CIRCLE_NODE_INDEX") != "4" {
-		t.Skip("Conformance tests are only run on job 4")
+	// this is like job-0
+	if os.Getenv("CIRCLE_NODE_INDEX") != "" && os.Getenv("CIRCLE_NODE_INDEX") != "0" {
+		t.Skip("Conformance tests are only run on job 0")
 	}
 	if Config.IPV6 {
 		t.Skip("On IPv6 we run on kind which doesn't support load balancers")


### PR DESCRIPTION
### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [x] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
