### PR TITLE
chore(gatewayapi): remove v1alpha2 usage 

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -12,7 +12,7 @@ does not have any particular instructions.
 
 We now support version `v0.6.0` of the Gateway API. See the [upstream API
 changes](https://github.com/kubernetes-sigs/gateway-api/releases/tag/v0.6.0) for
-more info.
+more info. We also no longer support v1alpha2 of Gateway API.
 
 ### Auth configuration of DP server in Kuma CP
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -12,7 +12,7 @@ does not have any particular instructions.
 
 We now support version `v0.6.0` of the Gateway API. See the [upstream API
 changes](https://github.com/kubernetes-sigs/gateway-api/releases/tag/v0.6.0) for
-more info. We also no longer support v1alpha2 of Gateway API.
+more info.
 
 ### Auth configuration of DP server in Kuma CP
 

--- a/api/mesh/v1alpha1/gateway.pb.go
+++ b/api/mesh/v1alpha1/gateway.pb.go
@@ -133,7 +133,7 @@ func (MeshGateway_Listener_Protocol) EnumDescriptor() ([]byte, []int) {
 // Each builtin dataplane instance can host exactly one Gateway
 // proxy configuration.
 //
-// Gateway aligns with the Kubernetes Gateway API v1alpha2. See that
+// Gateway aligns with the Kubernetes Gateway API. See that
 // spec for detailed documentation.
 type MeshGateway struct {
 	state         protoimpl.MessageState

--- a/api/mesh/v1alpha1/gateway.proto
+++ b/api/mesh/v1alpha1/gateway.proto
@@ -22,7 +22,7 @@ option (doc.config) = {
 // Each builtin dataplane instance can host exactly one Gateway
 // proxy configuration.
 //
-// Gateway aligns with the Kubernetes Gateway API v1alpha2. See that
+// Gateway aligns with the Kubernetes Gateway API. See that
 // spec for detailed documentation.
 message MeshGateway {
 

--- a/app/kumactl/cmd/install/testdata/install-control-plane.cni-enabled.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.cni-enabled.golden.yaml
@@ -536,7 +536,7 @@ spec:
     metadata:
       annotations:
         checksum/config: fd9d1d8386f97f2bd49e50f476520816168a1c9f60bbc43dec1347a64d239155
-        checksum/tls-secrets: 8fc117aa00b995fc1ec633b9f8f2be15e7f7c325460ce6c06bed414fd4bdc8e4
+        checksum/tls-secrets: aec0f89f48f1852775a87cd695d5a7033d774b4940ded38f1f380108e4b6633a
       labels: 
         app: kuma-control-plane
         app.kubernetes.io/name: kuma
@@ -939,7 +939,6 @@ webhooks:
       - apiGroups:
           - "gateway.networking.k8s.io"
         apiVersions:
-          - v1alpha2
           - v1beta1
         operations:
           - CREATE

--- a/app/kumactl/cmd/install/testdata/install-control-plane.cni-legacy-enabled.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.cni-legacy-enabled.golden.yaml
@@ -518,7 +518,7 @@ spec:
     metadata:
       annotations:
         checksum/config: fd9d1d8386f97f2bd49e50f476520816168a1c9f60bbc43dec1347a64d239155
-        checksum/tls-secrets: 8fc117aa00b995fc1ec633b9f8f2be15e7f7c325460ce6c06bed414fd4bdc8e4
+        checksum/tls-secrets: aec0f89f48f1852775a87cd695d5a7033d774b4940ded38f1f380108e4b6633a
       labels: 
         app: kuma-control-plane
         app.kubernetes.io/name: kuma
@@ -917,7 +917,6 @@ webhooks:
       - apiGroups:
           - "gateway.networking.k8s.io"
         apiVersions:
-          - v1alpha2
           - v1beta1
         operations:
           - CREATE

--- a/app/kumactl/cmd/install/testdata/install-control-plane.defaults.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.defaults.golden.yaml
@@ -5379,7 +5379,7 @@ spec:
     metadata:
       annotations:
         checksum/config: fd9d1d8386f97f2bd49e50f476520816168a1c9f60bbc43dec1347a64d239155
-        checksum/tls-secrets: 8fc117aa00b995fc1ec633b9f8f2be15e7f7c325460ce6c06bed414fd4bdc8e4
+        checksum/tls-secrets: aec0f89f48f1852775a87cd695d5a7033d774b4940ded38f1f380108e4b6633a
       labels: 
         app: kuma-control-plane
         app.kubernetes.io/name: kuma
@@ -5782,7 +5782,6 @@ webhooks:
       - apiGroups:
           - "gateway.networking.k8s.io"
         apiVersions:
-          - v1alpha2
           - v1beta1
         operations:
           - CREATE

--- a/app/kumactl/cmd/install/testdata/install-control-plane.gateway-api-present-not-enabled.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.gateway-api-present-not-enabled.yaml
@@ -5379,7 +5379,7 @@ spec:
     metadata:
       annotations:
         checksum/config: fd9d1d8386f97f2bd49e50f476520816168a1c9f60bbc43dec1347a64d239155
-        checksum/tls-secrets: 8fc117aa00b995fc1ec633b9f8f2be15e7f7c325460ce6c06bed414fd4bdc8e4
+        checksum/tls-secrets: aec0f89f48f1852775a87cd695d5a7033d774b4940ded38f1f380108e4b6633a
       labels: 
         app: kuma-control-plane
         app.kubernetes.io/name: kuma
@@ -5782,7 +5782,6 @@ webhooks:
       - apiGroups:
           - "gateway.networking.k8s.io"
         apiVersions:
-          - v1alpha2
           - v1beta1
         operations:
           - CREATE

--- a/app/kumactl/cmd/install/testdata/install-control-plane.gateway-api-present.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.gateway-api-present.yaml
@@ -5533,7 +5533,7 @@ spec:
     metadata:
       annotations:
         checksum/config: fd9d1d8386f97f2bd49e50f476520816168a1c9f60bbc43dec1347a64d239155
-        checksum/tls-secrets: 8fc117aa00b995fc1ec633b9f8f2be15e7f7c325460ce6c06bed414fd4bdc8e4
+        checksum/tls-secrets: aec0f89f48f1852775a87cd695d5a7033d774b4940ded38f1f380108e4b6633a
       labels: 
         app: kuma-control-plane
         app.kubernetes.io/name: kuma
@@ -5945,7 +5945,6 @@ webhooks:
       - apiGroups:
           - "gateway.networking.k8s.io"
         apiVersions:
-          - v1alpha2
           - v1beta1
         operations:
           - CREATE

--- a/app/kumactl/cmd/install/testdata/install-control-plane.global-universal-on-k8s.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.global-universal-on-k8s.golden.yaml
@@ -103,7 +103,7 @@ spec:
     metadata:
       annotations:
         checksum/config: fd9d1d8386f97f2bd49e50f476520816168a1c9f60bbc43dec1347a64d239155
-        checksum/tls-secrets: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
+        checksum/tls-secrets: 75a11da44c802486bc6f65640aa48a730f0f684c5c07a42ba3cd1735eb3fb070
       labels: 
         app: kuma-control-plane
         app.kubernetes.io/name: kuma

--- a/app/kumactl/cmd/install/testdata/install-control-plane.global.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.global.golden.yaml
@@ -357,7 +357,7 @@ spec:
     metadata:
       annotations:
         checksum/config: fd9d1d8386f97f2bd49e50f476520816168a1c9f60bbc43dec1347a64d239155
-        checksum/tls-secrets: 6a8a5ebea10cd0614847f009070d60475d7e6ca0338412c019ac1fcd85b368f1
+        checksum/tls-secrets: 8480fdd3f15ffced730fc82e11ffbda9185b1136bc42e0f86fbe558561188ded
       labels: 
         app: kuma-control-plane
         app.kubernetes.io/name: kuma
@@ -676,7 +676,6 @@ webhooks:
       - apiGroups:
           - "gateway.networking.k8s.io"
         apiVersions:
-          - v1alpha2
           - v1beta1
         operations:
           - CREATE

--- a/app/kumactl/cmd/install/testdata/install-control-plane.override-env-vars.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.override-env-vars.golden.yaml
@@ -340,7 +340,7 @@ spec:
     metadata:
       annotations:
         checksum/config: fd9d1d8386f97f2bd49e50f476520816168a1c9f60bbc43dec1347a64d239155
-        checksum/tls-secrets: 8fc117aa00b995fc1ec633b9f8f2be15e7f7c325460ce6c06bed414fd4bdc8e4
+        checksum/tls-secrets: aec0f89f48f1852775a87cd695d5a7033d774b4940ded38f1f380108e4b6633a
       labels: 
         app: kuma-control-plane
         app.kubernetes.io/name: kuma
@@ -743,7 +743,6 @@ webhooks:
       - apiGroups:
           - "gateway.networking.k8s.io"
         apiVersions:
-          - v1alpha2
           - v1beta1
         operations:
           - CREATE

--- a/app/kumactl/cmd/install/testdata/install-control-plane.overrides.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.overrides.golden.yaml
@@ -342,7 +342,7 @@ spec:
     metadata:
       annotations:
         checksum/config: 154c47a95fc93687dd1e825cea7f843d0fe8c450f82014d27cd7eb1a49f3bd35
-        checksum/tls-secrets: b81442fde20dcbd13bae4f77b63b947df494925fbc1bc658abeb2427957de26e
+        checksum/tls-secrets: 1cbb376e84f2135fb4ecb2ca398ad32f9a9a41d5cda0801647643aee6114ec69
       labels: 
         app: kuma-control-plane
         app.kubernetes.io/name: kuma
@@ -780,7 +780,6 @@ webhooks:
       - apiGroups:
           - "gateway.networking.k8s.io"
         apiVersions:
-          - v1alpha2
           - v1beta1
         operations:
           - CREATE

--- a/app/kumactl/cmd/install/testdata/install-control-plane.registry.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.registry.golden.yaml
@@ -340,7 +340,7 @@ spec:
     metadata:
       annotations:
         checksum/config: fd9d1d8386f97f2bd49e50f476520816168a1c9f60bbc43dec1347a64d239155
-        checksum/tls-secrets: 8fc117aa00b995fc1ec633b9f8f2be15e7f7c325460ce6c06bed414fd4bdc8e4
+        checksum/tls-secrets: aec0f89f48f1852775a87cd695d5a7033d774b4940ded38f1f380108e4b6633a
       labels: 
         app: kuma-control-plane
         app.kubernetes.io/name: kuma
@@ -743,7 +743,6 @@ webhooks:
       - apiGroups:
           - "gateway.networking.k8s.io"
         apiVersions:
-          - v1alpha2
           - v1beta1
         operations:
           - CREATE

--- a/app/kumactl/cmd/install/testdata/install-control-plane.tproxy-ebpf-experimental-enabled.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.tproxy-ebpf-experimental-enabled.golden.yaml
@@ -340,7 +340,7 @@ spec:
     metadata:
       annotations:
         checksum/config: fd9d1d8386f97f2bd49e50f476520816168a1c9f60bbc43dec1347a64d239155
-        checksum/tls-secrets: 8fc117aa00b995fc1ec633b9f8f2be15e7f7c325460ce6c06bed414fd4bdc8e4
+        checksum/tls-secrets: aec0f89f48f1852775a87cd695d5a7033d774b4940ded38f1f380108e4b6633a
       labels: 
         app: kuma-control-plane
         app.kubernetes.io/name: kuma
@@ -753,7 +753,6 @@ webhooks:
       - apiGroups:
           - "gateway.networking.k8s.io"
         apiVersions:
-          - v1alpha2
           - v1beta1
         operations:
           - CREATE

--- a/app/kumactl/cmd/install/testdata/install-control-plane.with-egress.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.with-egress.golden.yaml
@@ -371,7 +371,7 @@ spec:
     metadata:
       annotations:
         checksum/config: fd9d1d8386f97f2bd49e50f476520816168a1c9f60bbc43dec1347a64d239155
-        checksum/tls-secrets: 8fc117aa00b995fc1ec633b9f8f2be15e7f7c325460ce6c06bed414fd4bdc8e4
+        checksum/tls-secrets: aec0f89f48f1852775a87cd695d5a7033d774b4940ded38f1f380108e4b6633a
       labels: 
         app: kuma-control-plane
         app.kubernetes.io/name: kuma
@@ -894,7 +894,6 @@ webhooks:
       - apiGroups:
           - "gateway.networking.k8s.io"
         apiVersions:
-          - v1alpha2
           - v1beta1
         operations:
           - CREATE

--- a/app/kumactl/cmd/install/testdata/install-control-plane.with-helm-set.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.with-helm-set.yaml
@@ -5441,7 +5441,7 @@ spec:
     metadata:
       annotations:
         checksum/config: fd9d1d8386f97f2bd49e50f476520816168a1c9f60bbc43dec1347a64d239155
-        checksum/tls-secrets: 8fc117aa00b995fc1ec633b9f8f2be15e7f7c325460ce6c06bed414fd4bdc8e4
+        checksum/tls-secrets: aec0f89f48f1852775a87cd695d5a7033d774b4940ded38f1f380108e4b6633a
       labels: 
         app: kuma-control-plane
         app.kubernetes.io/name: kuma
@@ -6090,7 +6090,6 @@ webhooks:
       - apiGroups:
           - "gateway.networking.k8s.io"
         apiVersions:
-          - v1alpha2
           - v1beta1
         operations:
           - CREATE

--- a/app/kumactl/cmd/install/testdata/install-control-plane.with-helm-values.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.with-helm-values.yaml
@@ -340,7 +340,7 @@ spec:
     metadata:
       annotations:
         checksum/config: fd9d1d8386f97f2bd49e50f476520816168a1c9f60bbc43dec1347a64d239155
-        checksum/tls-secrets: 8fc117aa00b995fc1ec633b9f8f2be15e7f7c325460ce6c06bed414fd4bdc8e4
+        checksum/tls-secrets: aec0f89f48f1852775a87cd695d5a7033d774b4940ded38f1f380108e4b6633a
       labels: 
         app: kuma-control-plane
         app.kubernetes.io/name: kuma
@@ -743,7 +743,6 @@ webhooks:
       - apiGroups:
           - "gateway.networking.k8s.io"
         apiVersions:
-          - v1alpha2
           - v1beta1
         operations:
           - CREATE

--- a/app/kumactl/cmd/install/testdata/install-control-plane.with-ingress.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.with-ingress.golden.yaml
@@ -371,7 +371,7 @@ spec:
     metadata:
       annotations:
         checksum/config: fd9d1d8386f97f2bd49e50f476520816168a1c9f60bbc43dec1347a64d239155
-        checksum/tls-secrets: 8fc117aa00b995fc1ec633b9f8f2be15e7f7c325460ce6c06bed414fd4bdc8e4
+        checksum/tls-secrets: aec0f89f48f1852775a87cd695d5a7033d774b4940ded38f1f380108e4b6633a
       labels: 
         app: kuma-control-plane
         app.kubernetes.io/name: kuma
@@ -900,7 +900,6 @@ webhooks:
       - apiGroups:
           - "gateway.networking.k8s.io"
         apiVersions:
-          - v1alpha2
           - v1beta1
         operations:
           - CREATE

--- a/app/kumactl/cmd/install/testdata/install-control-plane.zone.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.zone.golden.yaml
@@ -340,7 +340,7 @@ spec:
     metadata:
       annotations:
         checksum/config: fd9d1d8386f97f2bd49e50f476520816168a1c9f60bbc43dec1347a64d239155
-        checksum/tls-secrets: 8fc117aa00b995fc1ec633b9f8f2be15e7f7c325460ce6c06bed414fd4bdc8e4
+        checksum/tls-secrets: aec0f89f48f1852775a87cd695d5a7033d774b4940ded38f1f380108e4b6633a
       labels: 
         app: kuma-control-plane
         app.kubernetes.io/name: kuma
@@ -747,7 +747,6 @@ webhooks:
       - apiGroups:
           - "gateway.networking.k8s.io"
         apiVersions:
-          - v1alpha2
           - v1beta1
         operations:
           - CREATE

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/empty.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/empty.golden.yaml
@@ -340,7 +340,7 @@ spec:
     metadata:
       annotations:
         checksum/config: fd9d1d8386f97f2bd49e50f476520816168a1c9f60bbc43dec1347a64d239155
-        checksum/tls-secrets: 8fc117aa00b995fc1ec633b9f8f2be15e7f7c325460ce6c06bed414fd4bdc8e4
+        checksum/tls-secrets: aec0f89f48f1852775a87cd695d5a7033d774b4940ded38f1f380108e4b6633a
       labels: 
         app: kuma-control-plane
         app.kubernetes.io/name: kuma
@@ -743,7 +743,6 @@ webhooks:
       - apiGroups:
           - "gateway.networking.k8s.io"
         apiVersions:
-          - v1alpha2
           - v1beta1
         operations:
           - CREATE

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/fix4485.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/fix4485.golden.yaml
@@ -362,7 +362,7 @@ spec:
     metadata:
       annotations:
         checksum/config: 3a137bbfcbbe6ba5a3997b30b1b047b2b080a9f912520a5fa683f11c4c6b6f3c
-        checksum/tls-secrets: 96f27a141c6eeb1a0fa942d203dab03a5676acd724e05b39ab89fa6c30b18904
+        checksum/tls-secrets: 21a5bace63b1c95d7e656d0bc795976c19be030f3b5adeb65af66938586014cb
       labels: 
         app: kuma-control-plane
         "foo": "baz"
@@ -774,7 +774,6 @@ webhooks:
       - apiGroups:
           - "gateway.networking.k8s.io"
         apiVersions:
-          - v1alpha2
           - v1beta1
         operations:
           - CREATE

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/fix4496.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/fix4496.golden.yaml
@@ -381,7 +381,7 @@ spec:
     metadata:
       annotations:
         checksum/config: 2f553eadd8f68661f4b1fd0b3ccbbc562943d89fa76f2f2ba2975541290fda71
-        checksum/tls-secrets: cdeb415632f434791619342a1825f67ebb1fa0561169567cdfd8a6802e2e6a8b
+        checksum/tls-secrets: 5c7c69d36fffdab97a20d107db74643f085811115baddffc66bcfeff606036f2
       labels: 
         app: kuma-control-plane
         "foo": "bar"
@@ -939,7 +939,6 @@ webhooks:
       - apiGroups:
           - "gateway.networking.k8s.io"
         apiVersions:
-          - v1alpha2
           - v1beta1
         operations:
           - CREATE

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/fix4935.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/fix4935.golden.yaml
@@ -606,7 +606,7 @@ spec:
     metadata:
       annotations:
         checksum/config: fd9d1d8386f97f2bd49e50f476520816168a1c9f60bbc43dec1347a64d239155
-        checksum/tls-secrets: 8fc117aa00b995fc1ec633b9f8f2be15e7f7c325460ce6c06bed414fd4bdc8e4
+        checksum/tls-secrets: aec0f89f48f1852775a87cd695d5a7033d774b4940ded38f1f380108e4b6633a
         bim: "bam"
         foo: "{\"bar\": \"baz\"}"
       labels: 
@@ -1289,7 +1289,6 @@ webhooks:
       - apiGroups:
           - "gateway.networking.k8s.io"
         apiVersions:
-          - v1alpha2
           - v1beta1
         operations:
           - CREATE

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/fix5978.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/fix5978.golden.yaml
@@ -402,7 +402,7 @@ spec:
     metadata:
       annotations:
         checksum/config: fd9d1d8386f97f2bd49e50f476520816168a1c9f60bbc43dec1347a64d239155
-        checksum/tls-secrets: 8fc117aa00b995fc1ec633b9f8f2be15e7f7c325460ce6c06bed414fd4bdc8e4
+        checksum/tls-secrets: aec0f89f48f1852775a87cd695d5a7033d774b4940ded38f1f380108e4b6633a
       labels: 
         app: kuma-control-plane
         app.kubernetes.io/name: kuma
@@ -1054,7 +1054,6 @@ webhooks:
       - apiGroups:
           - "gateway.networking.k8s.io"
         apiVersions:
-          - v1alpha2
           - v1beta1
         operations:
           - CREATE

--- a/deployments/charts/kuma/templates/cp-webhooks-and-secrets.yaml
+++ b/deployments/charts/kuma/templates/cp-webhooks-and-secrets.yaml
@@ -290,7 +290,6 @@ webhooks:
       - apiGroups:
           - "gateway.networking.k8s.io"
         apiVersions:
-          - v1alpha2
           - v1beta1
         operations:
           - CREATE

--- a/pkg/plugins/bootstrap/k8s/scheme.go
+++ b/pkg/plugins/bootstrap/k8s/scheme.go
@@ -5,7 +5,6 @@ import (
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	kube_runtime "k8s.io/apimachinery/pkg/runtime"
 	kube_client_scheme "k8s.io/client-go/kubernetes/scheme"
-	gatewayapi_alpha "sigs.k8s.io/gateway-api/apis/v1alpha2"
 	gatewayapi "sigs.k8s.io/gateway-api/apis/v1beta1"
 
 	"github.com/kumahq/kuma/pkg/plugins/policies"
@@ -27,9 +26,6 @@ func NewScheme() (*kube_runtime.Scheme, error) {
 	}
 	if err := apiextensionsv1.AddToScheme(s); err != nil {
 		return nil, errors.Wrapf(err, "could not add %q to scheme", apiextensionsv1.SchemeGroupVersion)
-	}
-	if err := gatewayapi_alpha.Install(s); err != nil {
-		return nil, errors.Wrapf(err, "could not add %q to scheme", gatewayapi.SchemeGroupVersion)
 	}
 	if err := gatewayapi.Install(s); err != nil {
 		return nil, errors.Wrapf(err, "could not add %q to scheme", gatewayapi.SchemeGroupVersion)

--- a/pkg/plugins/runtime/k8s/controllers/gatewayapi/gateway_controller.go
+++ b/pkg/plugins/runtime/k8s/controllers/gatewayapi/gateway_controller.go
@@ -17,7 +17,6 @@ import (
 	kube_handler "sigs.k8s.io/controller-runtime/pkg/handler"
 	kube_reconcile "sigs.k8s.io/controller-runtime/pkg/reconcile"
 	kube_source "sigs.k8s.io/controller-runtime/pkg/source"
-	gatewayapi_alpha "sigs.k8s.io/gateway-api/apis/v1alpha2"
 	gatewayapi "sigs.k8s.io/gateway-api/apis/v1beta1"
 
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
@@ -273,15 +272,15 @@ func gatewaysForGrant(l logr.Logger, client kube_client.Client) kube_handler.Map
 	l = l.WithName("gatewaysForGrant")
 
 	return func(obj kube_client.Object) []kube_reconcile.Request {
-		grant, ok := obj.(*gatewayapi_alpha.ReferenceGrant)
+		grant, ok := obj.(*gatewayapi.ReferenceGrant)
 		if !ok {
 			l.Error(nil, "unexpected error converting to be mapped %T object to GatewayGrant", obj)
 			return nil
 		}
 
-		var namespaces []gatewayapi_alpha.Namespace
+		var namespaces []gatewayapi.Namespace
 		for _, from := range grant.Spec.From {
-			if from.Group == gatewayapi_alpha.Group(gatewayapi.GroupVersion.Group) && from.Kind == "Gateway" {
+			if from.Group == gatewayapi.Group(gatewayapi.GroupVersion.Group) && from.Kind == "Gateway" {
 				namespaces = append(namespaces, from.Namespace)
 			}
 		}
@@ -348,7 +347,7 @@ func (r *GatewayReconciler) SetupWithManager(mgr kube_ctrl.Manager) error {
 			kube_handler.EnqueueRequestsFromMapFunc(gatewaysForConfig(r.Log, r.Client)),
 		).
 		Watches(
-			&kube_source.Kind{Type: &gatewayapi_alpha.ReferenceGrant{}},
+			&kube_source.Kind{Type: &gatewayapi.ReferenceGrant{}},
 			kube_handler.EnqueueRequestsFromMapFunc(gatewaysForGrant(r.Log, r.Client)),
 		).
 		Complete(r)

--- a/pkg/plugins/runtime/k8s/controllers/gatewayapi/http_route_controller.go
+++ b/pkg/plugins/runtime/k8s/controllers/gatewayapi/http_route_controller.go
@@ -15,7 +15,6 @@ import (
 	kube_handler "sigs.k8s.io/controller-runtime/pkg/handler"
 	kube_reconcile "sigs.k8s.io/controller-runtime/pkg/reconcile"
 	kube_source "sigs.k8s.io/controller-runtime/pkg/source"
-	gatewayapi_alpha "sigs.k8s.io/gateway-api/apis/v1alpha2"
 	gatewayapi "sigs.k8s.io/gateway-api/apis/v1beta1"
 
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
@@ -225,13 +224,13 @@ func routesForGrant(l logr.Logger, client kube_client.Client) kube_handler.MapFu
 	l = l.WithName("routesForGrant")
 
 	return func(obj kube_client.Object) []kube_reconcile.Request {
-		grant, ok := obj.(*gatewayapi_alpha.ReferenceGrant)
+		grant, ok := obj.(*gatewayapi.ReferenceGrant)
 		if !ok {
 			l.Error(nil, "unexpected error converting to be mapped %T object to GatewayGrant", obj)
 			return nil
 		}
 
-		var namespaces []gatewayapi_alpha.Namespace
+		var namespaces []gatewayapi.Namespace
 		for _, from := range grant.Spec.From {
 			if from.Group == gatewayapi.Group(gatewayapi.GroupVersion.Group) && from.Kind == common.HTTPRouteKind {
 				namespaces = append(namespaces, from.Namespace)
@@ -266,7 +265,7 @@ func (r *HTTPRouteReconciler) SetupWithManager(mgr kube_ctrl.Manager) error {
 			kube_handler.EnqueueRequestsFromMapFunc(routesForGateway(r.Log, r.Client)),
 		).
 		Watches(
-			&kube_source.Kind{Type: &gatewayapi_alpha.ReferenceGrant{}},
+			&kube_source.Kind{Type: &gatewayapi.ReferenceGrant{}},
 			kube_handler.EnqueueRequestsFromMapFunc(routesForGrant(r.Log, r.Client)),
 		).
 		Complete(r)

--- a/pkg/plugins/runtime/k8s/controllers/gatewayapi/policy/policy.go
+++ b/pkg/plugins/runtime/k8s/controllers/gatewayapi/policy/policy.go
@@ -8,15 +8,14 @@ import (
 	kube_schema "k8s.io/apimachinery/pkg/runtime/schema"
 	kube_types "k8s.io/apimachinery/pkg/types"
 	kube_client "sigs.k8s.io/controller-runtime/pkg/client"
-	gatewayapi_alpha "sigs.k8s.io/gateway-api/apis/v1alpha2"
 	gatewayapi "sigs.k8s.io/gateway-api/apis/v1beta1"
 )
 
 type PolicyReference struct {
-	from        gatewayapi_alpha.ReferenceGrantFrom
+	from        gatewayapi.ReferenceGrantFrom
 	toNamespace gatewayapi.Namespace
 	// always set when created via the exported functions
-	to gatewayapi_alpha.ReferenceGrantTo
+	to gatewayapi.ReferenceGrantTo
 }
 
 func (pr *PolicyReference) NamespacedNameReferredTo() kube_types.NamespacedName {
@@ -27,30 +26,30 @@ func (pr *PolicyReference) GroupKindReferredTo() kube_schema.GroupKind {
 	return kube_schema.GroupKind{Kind: string(pr.to.Kind), Group: string(pr.to.Group)}
 }
 
-func FromGatewayIn(namespace string) gatewayapi_alpha.ReferenceGrantFrom {
-	return gatewayapi_alpha.ReferenceGrantFrom{
+func FromGatewayIn(namespace string) gatewayapi.ReferenceGrantFrom {
+	return gatewayapi.ReferenceGrantFrom{
 		Kind:      "Gateway",
 		Group:     gatewayapi.GroupName,
 		Namespace: gatewayapi.Namespace(namespace),
 	}
 }
 
-func FromHTTPRouteIn(namespace string) gatewayapi_alpha.ReferenceGrantFrom {
-	return gatewayapi_alpha.ReferenceGrantFrom{
+func FromHTTPRouteIn(namespace string) gatewayapi.ReferenceGrantFrom {
+	return gatewayapi.ReferenceGrantFrom{
 		Kind:      "HTTPRoute",
 		Group:     gatewayapi.GroupName,
 		Namespace: gatewayapi.Namespace(namespace),
 	}
 }
 
-func PolicyReferenceBackend(from gatewayapi_alpha.ReferenceGrantFrom, to gatewayapi.BackendObjectReference) PolicyReference {
+func PolicyReferenceBackend(from gatewayapi.ReferenceGrantFrom, to gatewayapi.BackendObjectReference) PolicyReference {
 	ns := from.Namespace
 	if to.Namespace != nil {
 		ns = *to.Namespace
 	}
 	return PolicyReference{
 		from: from,
-		to: gatewayapi_alpha.ReferenceGrantTo{
+		to: gatewayapi.ReferenceGrantTo{
 			Kind:  *to.Kind,
 			Group: *to.Group,
 			Name:  &to.Name,
@@ -59,14 +58,14 @@ func PolicyReferenceBackend(from gatewayapi_alpha.ReferenceGrantFrom, to gateway
 	}
 }
 
-func PolicyReferenceSecret(from gatewayapi_alpha.ReferenceGrantFrom, to gatewayapi.SecretObjectReference) PolicyReference {
+func PolicyReferenceSecret(from gatewayapi.ReferenceGrantFrom, to gatewayapi.SecretObjectReference) PolicyReference {
 	ns := from.Namespace
 	if to.Namespace != nil {
 		ns = *to.Namespace
 	}
 	return PolicyReference{
 		from: from,
-		to: gatewayapi_alpha.ReferenceGrantTo{
+		to: gatewayapi.ReferenceGrantTo{
 			Kind:  *to.Kind,
 			Group: *to.Group,
 			Name:  &to.Name,
@@ -86,7 +85,7 @@ func IsReferencePermitted(
 		return true, nil
 	}
 
-	policies := &gatewayapi_alpha.ReferenceGrantList{}
+	policies := &gatewayapi.ReferenceGrantList{}
 	if err := client.List(ctx, policies, kube_client.InNamespace(reference.toNamespace)); err != nil {
 		return false, errors.Wrap(err, "failed to list ReferencePolicies")
 	}
@@ -104,7 +103,7 @@ func IsReferencePermitted(
 	return false, nil
 }
 
-func someFromMatches(from gatewayapi_alpha.ReferenceGrantFrom, permitted []gatewayapi_alpha.ReferenceGrantFrom) bool {
+func someFromMatches(from gatewayapi.ReferenceGrantFrom, permitted []gatewayapi.ReferenceGrantFrom) bool {
 	for _, permittedFrom := range permitted {
 		if reflect.DeepEqual(permittedFrom, from) {
 			return true
@@ -113,7 +112,7 @@ func someFromMatches(from gatewayapi_alpha.ReferenceGrantFrom, permitted []gatew
 	return false
 }
 
-func someToMatches(to gatewayapi_alpha.ReferenceGrantTo, permitted []gatewayapi_alpha.ReferenceGrantTo) bool {
+func someToMatches(to gatewayapi.ReferenceGrantTo, permitted []gatewayapi.ReferenceGrantTo) bool {
 	for _, permittedTo := range permitted {
 		if permittedTo.Group == to.Group &&
 			permittedTo.Kind == to.Kind &&

--- a/pkg/plugins/runtime/k8s/controllers/gatewayapi/policy/policy_test.go
+++ b/pkg/plugins/runtime/k8s/controllers/gatewayapi/policy/policy_test.go
@@ -8,7 +8,6 @@ import (
 	kube_meta "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kube_runtime "k8s.io/apimachinery/pkg/runtime"
 	kube_client_fake "sigs.k8s.io/controller-runtime/pkg/client/fake"
-	gatewayapi_alpha "sigs.k8s.io/gateway-api/apis/v1alpha2"
 	gatewayapi "sigs.k8s.io/gateway-api/apis/v1beta1"
 
 	"github.com/kumahq/kuma/pkg/plugins/bootstrap/k8s"
@@ -30,20 +29,20 @@ const (
 )
 
 var (
-	simplePolicy = gatewayapi_alpha.ReferenceGrant{
+	simplePolicy = gatewayapi.ReferenceGrant{
 		ObjectMeta: kube_meta.ObjectMeta{
 			Name:      "basic",
 			Namespace: otherNs,
 		},
-		Spec: gatewayapi_alpha.ReferenceGrantSpec{
-			From: []gatewayapi_alpha.ReferenceGrantFrom{
+		Spec: gatewayapi.ReferenceGrantSpec{
+			From: []gatewayapi.ReferenceGrantFrom{
 				{
 					Group:     gatewayapi.GroupName,
 					Kind:      "HTTPRoute",
 					Namespace: defaultNs,
 				},
 			},
-			To: []gatewayapi_alpha.ReferenceGrantTo{
+			To: []gatewayapi.ReferenceGrantTo{
 				{
 					Group: "",
 					Kind:  "Service",
@@ -129,9 +128,9 @@ var _ = Describe("ReferenceGrant support", func() {
 		})
 		It("checks names in .from", func() {
 			policyWithName := simplePolicy.DeepCopy()
-			permittedToExtSvcName := gatewayapi_alpha.ObjectName("specific-permitted-ext-svc")
+			permittedToExtSvcName := gatewayapi.ObjectName("specific-permitted-ext-svc")
 			policyWithName.Spec.To = append(policyWithName.Spec.To,
-				gatewayapi_alpha.ReferenceGrantTo{
+				gatewayapi.ReferenceGrantTo{
 					Group: kumaGroup,
 					Kind:  externalSvcKind,
 					Name:  &permittedToExtSvcName,

--- a/pkg/plugins/runtime/k8s/webhooks/gatewayapi_multizone_validator.go
+++ b/pkg/plugins/runtime/k8s/webhooks/gatewayapi_multizone_validator.go
@@ -8,7 +8,6 @@ import (
 	admission "k8s.io/api/admission/v1"
 	kube_webhook "sigs.k8s.io/controller-runtime/pkg/webhook"
 	kube_admission "sigs.k8s.io/controller-runtime/pkg/webhook/admission"
-	gatewayapi_alpha "sigs.k8s.io/gateway-api/apis/v1alpha2"
 	gatewayapi "sigs.k8s.io/gateway-api/apis/v1beta1"
 
 	config_core "github.com/kumahq/kuma/pkg/config/core"
@@ -43,12 +42,7 @@ func (g *GatewayAPIMultizoneValidator) Handle(_ context.Context, req kube_admiss
 
 		gatewayClass := &gatewayapi.GatewayClass{}
 		if err := g.Decoder.Decode(req, gatewayClass); err != nil {
-			gatewayClassAlpha := &gatewayapi_alpha.GatewayClass{}
-			if err := g.Decoder.Decode(req, gatewayClassAlpha); err != nil {
-				return kube_admission.Errored(http.StatusBadRequest, err)
-			}
-
-			controllerName = string(gatewayClassAlpha.Spec.ControllerName)
+			return kube_admission.Errored(http.StatusBadRequest, err)
 		} else {
 			controllerName = string(gatewayClass.Spec.ControllerName)
 		}

--- a/test/e2e/gateway/gatewayapi/conformance_test.go
+++ b/test/e2e/gateway/gatewayapi/conformance_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/gruntwork-io/terratest/modules/k8s"
 	. "github.com/onsi/gomega"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	apis_gatewayapi_alpha "sigs.k8s.io/gateway-api/apis/v1alpha2"
 	apis_gatewayapi "sigs.k8s.io/gateway-api/apis/v1beta1"
 	"sigs.k8s.io/gateway-api/conformance/tests"
 	"sigs.k8s.io/gateway-api/conformance/utils/suite"
@@ -66,7 +65,6 @@ func TestConformance(t *testing.T) {
 	client, err := client.New(clientConfig, client.Options{})
 	g.Expect(err).ToNot(HaveOccurred())
 
-	g.Expect(apis_gatewayapi_alpha.AddToScheme(client.Scheme())).To(Succeed())
 	g.Expect(apis_gatewayapi.AddToScheme(client.Scheme())).To(Succeed())
 
 	var validUniqueListenerPorts []apis_gatewayapi.PortNumber

--- a/test/e2e_env/kubernetes/gateway/gatewayapi.go
+++ b/test/e2e_env/kubernetes/gateway/gatewayapi.go
@@ -89,7 +89,7 @@ spec:
 	Describe("GatewayClass parametersRef", Ordered, func() {
 		gatewayName := "kuma-ha"
 		haGatewayClass := `
-apiVersion: gateway.networking.k8s.io/v1alpha2
+apiVersion: gateway.networking.k8s.io/v1beta1
 kind: GatewayClass
 metadata:
   name: ha-kuma
@@ -109,7 +109,7 @@ spec:
   replicas: 3`
 
 		haGateway := fmt.Sprintf(`
-apiVersion: gateway.networking.k8s.io/v1alpha2
+apiVersion: gateway.networking.k8s.io/v1beta1
 kind: Gateway
 metadata:
   name: %s
@@ -265,7 +265,7 @@ spec:
     - name: test-server-1
       port: 80
 ---
-apiVersion: gateway.networking.k8s.io/v1alpha2
+apiVersion: gateway.networking.k8s.io/v1beta1
 kind: HTTPRoute
 metadata:
   name: test-server-2
@@ -305,7 +305,7 @@ spec:
 		It("should route to external service", func() {
 			// given
 			routes := fmt.Sprintf(`
-apiVersion: gateway.networking.k8s.io/v1alpha2
+apiVersion: gateway.networking.k8s.io/v1beta1
 kind: HTTPRoute
 metadata:
   name: external-service
@@ -355,7 +355,7 @@ data:
 `, namespace)
 
 		gateway := fmt.Sprintf(`
-apiVersion: gateway.networking.k8s.io/v1alpha2
+apiVersion: gateway.networking.k8s.io/v1beta1
 kind: Gateway
 metadata:
   name: %s
@@ -394,7 +394,7 @@ spec:
 		It("should route the traffic using TLS", func() {
 			// given
 			route := fmt.Sprintf(`
-apiVersion: gateway.networking.k8s.io/v1alpha2
+apiVersion: gateway.networking.k8s.io/v1beta1
 kind: HTTPRoute
 metadata:
   name: test-server-paths
@@ -482,7 +482,7 @@ data:
 	Context("Upstream validation", func() {
 		It("should validate Gateway", func() {
 			gateway := fmt.Sprintf(`
-apiVersion: gateway.networking.k8s.io/v1alpha2
+apiVersion: gateway.networking.k8s.io/v1beta1
 kind: Gateway
 metadata:
   name: kuma-validate


### PR DESCRIPTION
This shouldn't require any changes for users since the CRDs determine which versions are served. With `v0.6.0`, `ReferenceGrant` is served at both versions. Otherwise we were already using `v1beta1` resources.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [x] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
