### PR TITLE
fix(tests/golden): fix install tproxy golden files

### DIFF
--- a/app/kumactl/cmd/install/testdata/install-transparent-proxy.defaults.golden.txt
+++ b/app/kumactl/cmd/install/testdata/install-transparent-proxy.defaults.golden.txt
@@ -6,11 +6,11 @@
 -A PREROUTING -p tcp -j (.*)_INBOUND
 -A OUTPUT -p tcp -j (.*)_OUTBOUND
 -A (.*)_INBOUND -p tcp -j (.*)_INBOUND_REDIRECT
--A (.*)_OUTBOUND -s 127.0.0.6/32 -o lo -j RETURN
--A (.*)_OUTBOUND -p tcp -o lo ! -d 127.0.0.1/32 -m owner --uid-owner 0 -j (.*)_INBOUND_REDIRECT
--A (.*)_OUTBOUND -p tcp -o lo -m owner ! --uid-owner 0 -j RETURN
+-A (.*)_OUTBOUND -s (.*) -o (.*) -j RETURN
+-A (.*)_OUTBOUND -p tcp -o (.*) ! -d (.*) -m owner --uid-owner 0 -j (.*)_INBOUND_REDIRECT
+-A (.*)_OUTBOUND -p tcp -o (.*) -m owner ! --uid-owner 0 -j RETURN
 -A (.*)_OUTBOUND -m owner --uid-owner 0 -j RETURN
--A (.*)_OUTBOUND -d 127.0.0.1/32 -j RETURN
+-A (.*)_OUTBOUND -d (.*) -j RETURN
 -A (.*)_OUTBOUND -j (.*)_OUTBOUND_REDIRECT
--A (.*)_INBOUND_REDIRECT -p tcp -j REDIRECT --to-ports 15006
+-A (.*)_INBOUND_REDIRECT -p tcp -j REDIRECT --to-ports (15006|15010)
 -A (.*)_OUTBOUND_REDIRECT -p tcp -j REDIRECT --to-ports 15001

--- a/app/kumactl/cmd/install/testdata/install-transparent-proxy.dns.golden.txt
+++ b/app/kumactl/cmd/install/testdata/install-transparent-proxy.dns.golden.txt
@@ -8,12 +8,12 @@
 -I OUTPUT 2 -p udp --dport 53 -j REDIRECT --to-ports 12345
 -A OUTPUT -p tcp -j (.*)_OUTBOUND
 -A (.*)_INBOUND -p tcp -j (.*)_INBOUND_REDIRECT
--A (.*)_OUTBOUND -s 127.0.0.6/32 -o lo -j RETURN
--A (.*)_OUTBOUND -p tcp ! --dport 53 -o lo ! -d 127.0.0.1/32 -m owner --uid-owner 0 -j (.*)_INBOUND_REDIRECT
--A (.*)_OUTBOUND -p tcp ! --dport 53 -o lo -m owner ! --uid-owner 0 -j RETURN
+-A (.*)_OUTBOUND -s (.*) -o (.*) -j RETURN
+-A (.*)_OUTBOUND -p tcp ! --dport 53 -o (.*) ! -d (.*) -m owner --uid-owner 0 -j (.*)_INBOUND_REDIRECT
+-A (.*)_OUTBOUND -p tcp ! --dport 53 -o (.*) -m owner ! --uid-owner 0 -j RETURN
 -A (.*)_OUTBOUND -m owner --uid-owner 0 -j RETURN
 -A (.*)_OUTBOUND -p tcp --dport 53 -j REDIRECT --to-ports 12345
--A (.*)_OUTBOUND -d 127.0.0.1/32 -j RETURN
+-A (.*)_OUTBOUND -d (.*) -j RETURN
 -A (.*)_OUTBOUND -j (.*)_OUTBOUND_REDIRECT
--A (.*)_INBOUND_REDIRECT -p tcp -j REDIRECT --to-ports 15006
+-A (.*)_INBOUND_REDIRECT -p tcp -j REDIRECT --to-ports (15006|15010)
 -A (.*)_OUTBOUND_REDIRECT -p tcp -j REDIRECT --to-ports 15001

--- a/app/kumactl/cmd/install/testdata/install-transparent-proxy.overrides.golden.txt
+++ b/app/kumactl/cmd/install/testdata/install-transparent-proxy.overrides.golden.txt
@@ -10,11 +10,11 @@
 -A (.*)_INBOUND -p tcp -j (.*)_INBOUND_REDIRECT
 -A (.*)_OUTBOUND -p tcp --dport 2000 -j RETURN
 -A (.*)_OUTBOUND -p tcp --dport 2001 -j RETURN
--A (.*)_OUTBOUND -s 127.0.0.6/32 -o lo -j RETURN
--A (.*)_OUTBOUND -p tcp -o lo ! -d 127.0.0.1/32 -m owner --uid-owner 0 -j (.*)_INBOUND_REDIRECT
--A (.*)_OUTBOUND -p tcp -o lo -m owner ! --uid-owner 0 -j RETURN
+-A (.*)_OUTBOUND -s (.*) -o (.*) -j RETURN
+-A (.*)_OUTBOUND -p tcp -o (.*) ! -d (.*) -m owner --uid-owner 0 -j (.*)_INBOUND_REDIRECT
+-A (.*)_OUTBOUND -p tcp -o (.*) -m owner ! --uid-owner 0 -j RETURN
 -A (.*)_OUTBOUND -m owner --uid-owner 0 -j RETURN
--A (.*)_OUTBOUND -d 127.0.0.1/32 -j RETURN
+-A (.*)_OUTBOUND -d (.*) -j RETURN
 -A (.*)_OUTBOUND -j (.*)_OUTBOUND_REDIRECT
 -A (.*)_INBOUND_REDIRECT -p tcp -j REDIRECT --to-ports 12346
 -A (.*)_OUTBOUND_REDIRECT -p tcp -j REDIRECT --to-ports 12345


### PR DESCRIPTION
Fix kumactl install transparent-proxy input golden files

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [ ] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) -- it fixes tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? -- 
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? -- it doesn't
- [x] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
