### PR TITLE
fix(kuma-cp): change validation of resources synced to global

### DIFF
--- a/pkg/api-server/resource_endpoints.go
+++ b/pkg/api-server/resource_endpoints.go
@@ -276,14 +276,13 @@ func (r *resourceEndpoints) validateResourceRequest(request *restful.Request, re
 	return err.OrNil()
 }
 
-// The resource is prefixed with the zone name and suffixed with the namespace
-// (if the K8s store is used in the global control-plane) when it is synchronized
+// The resource is prefixed with the zone name when it is synchronized
 // to global control-plane. It is important to notice that the zone is unaware
 // of the type of the store used by the global control-plane, so we must prepare
 // for the worst-case scenario. We don't have to check other plugabble policies
 // because zone doesn't allow to create policies on the zone.
 func (r *resourceEndpoints) doesNameLengthFitsGlobal(name string) bool {
-	return len(fmt.Sprintf("%s.%s.%s", r.zoneName, name, "default")) < 253
+	return len(fmt.Sprintf("%s.%s", r.zoneName, name)) < 253
 }
 
 func (r *resourceEndpoints) meshFromRequest(request *restful.Request) string {


### PR DESCRIPTION
### Checklist prior to review

"default" should not be taken account into the limit.
On Universal Global CP does not add "default".
On Kubernetes "default" is a namespace.

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [ ] [Link to relevant issue][1] as well as docs and UI issues --
- [ ] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [ ] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [ ] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [ ] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [ ] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
