### PR TITLE
build(generate): gofumpt compliant code

### DIFF
--- a/pkg/plugins/resources/k8s/native/api/v1alpha1/zz_generated.mesh.go
+++ b/pkg/plugins/resources/k8s/native/api/v1alpha1/zz_generated.mesh.go
@@ -270,7 +270,6 @@ func (cb *DataplaneInsight) GetSpec() (core_model.ResourceSpec, error) {
 func (cb *DataplaneInsight) SetSpec(spec core_model.ResourceSpec) {
 	if spec == nil {
 		cb.Status = nil
-
 		return
 	}
 

--- a/tools/resource-gen/main.go
+++ b/tools/resource-gen/main.go
@@ -124,7 +124,7 @@ func (cb *{{.ResourceType}}) SetSpec(spec core_model.ResourceSpec) {
 	if spec == nil {
 {{- if eq .ResourceType "DataplaneInsight" }}
 		cb.Status = nil
-{{ else }}
+{{- else }}
 		cb.Spec = nil
 {{- end }}
 		return
@@ -137,7 +137,7 @@ func (cb *{{.ResourceType}}) SetSpec(spec core_model.ResourceSpec) {
 
 {{ if eq .ResourceType "DataplaneInsight" }}
 	cb.Status = &apiextensionsv1.JSON{Raw: util_proto.MustMarshalJSON(s)}
-{{ else}}
+{{- else}}
 	cb.Spec = &apiextensionsv1.JSON{Raw: util_proto.MustMarshalJSON(s)}
 {{- end}}
 }


### PR DESCRIPTION
A small annoyance that `make generate` generated diffs until `make check` was run.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [x] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
