### PR TITLE
feat(e2e/universal): display full logs after fail

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -81,6 +81,8 @@ require (
 	sigs.k8s.io/yaml v1.3.0
 )
 
+require github.com/kennygrant/sanitize v1.2.4
+
 require (
 	cloud.google.com/go v0.107.0 // indirect
 	cloud.google.com/go/compute v1.15.1 // indirect
@@ -138,7 +140,6 @@ require (
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/jpillora/backoff v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
-	github.com/kennygrant/sanitize v1.2.4 // indirect
 	github.com/klauspost/compress v1.13.6 // indirect
 	github.com/magiconair/properties v1.8.7 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect

--- a/go.mod
+++ b/go.mod
@@ -138,6 +138,7 @@ require (
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/jpillora/backoff v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
+	github.com/kennygrant/sanitize v1.2.4 // indirect
 	github.com/klauspost/compress v1.13.6 // indirect
 	github.com/magiconair/properties v1.8.7 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect

--- a/go.mod
+++ b/go.mod
@@ -28,6 +28,7 @@ require (
 	github.com/gruntwork-io/terratest v0.41.11
 	github.com/hoisie/mustache v0.0.0-20160804235033-6375acf62c69
 	github.com/kelseyhightower/envconfig v1.4.0
+	github.com/kennygrant/sanitize v1.2.4
 	github.com/kumahq/protoc-gen-kumadoc v0.3.1
 	github.com/lib/pq v1.10.7
 	github.com/miekg/dns v1.1.51
@@ -80,8 +81,6 @@ require (
 	sigs.k8s.io/gateway-api v0.5.1
 	sigs.k8s.io/yaml v1.3.0
 )
-
-require github.com/kennygrant/sanitize v1.2.4
 
 require (
 	cloud.google.com/go v0.107.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -885,6 +885,8 @@ github.com/karrick/godirwalk v1.10.3/go.mod h1:RoGL9dQei4vP9ilrpETWE8CLOZ1kiN0Lh
 github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51/go.mod h1:CzGEWj7cYgsdH8dAjBGEr58BoE7ScuLd+fwFZ44+/x8=
 github.com/kelseyhightower/envconfig v1.4.0 h1:Im6hONhd3pLkfDFsbRgu68RDNkGF1r3dvMUtDTo2cv8=
 github.com/kelseyhightower/envconfig v1.4.0/go.mod h1:cccZRl6mQpaq41TPp5QxidR+Sa3axMbJDNb//FQX6Gg=
+github.com/kennygrant/sanitize v1.2.4 h1:gN25/otpP5vAsO2djbMhF/LQX6R7+O1TB4yv8NzpJ3o=
+github.com/kennygrant/sanitize v1.2.4/go.mod h1:LGsjYYtgxbetdg5owWB2mpgUL6e2nfw2eObZ0u0qvak=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=

--- a/test/e2e_env/universal/universal_suite_test.go
+++ b/test/e2e_env/universal/universal_suite_test.go
@@ -45,10 +45,12 @@ func TestE2E(t *testing.T) {
 	test.RunE2ESpecs(t, "E2E Universal Suite")
 }
 
-var _ = SynchronizedBeforeSuite(universal.SetupAndGetState, universal.RestoreState)
-var _ = BeforeEach(universal.RememberSpecID)
-var _ = AfterSuite(universal.WriteLogsIfFailed)
-var _ = AfterEach(universal.WriteLogsIfFailed)
+var (
+	_ = SynchronizedBeforeSuite(universal.SetupAndGetState, universal.RestoreState)
+	_ = BeforeEach(universal.RememberSpecID)
+	_ = AfterSuite(universal.WriteLogsIfFailed)
+	_ = AfterEach(universal.WriteLogsIfFailed)
+)
 
 var (
 	_ = Describe("User Auth", auth.UserAuth)

--- a/test/e2e_env/universal/universal_suite_test.go
+++ b/test/e2e_env/universal/universal_suite_test.go
@@ -46,6 +46,9 @@ func TestE2E(t *testing.T) {
 }
 
 var _ = SynchronizedBeforeSuite(universal.SetupAndGetState, universal.RestoreState)
+var _ = BeforeEach(universal.RememberSpecID)
+var _ = AfterSuite(universal.WriteLogsIfFailed)
+var _ = AfterEach(universal.WriteLogsIfFailed)
 
 var (
 	_ = Describe("User Auth", auth.UserAuth)

--- a/test/framework/config.go
+++ b/test/framework/config.go
@@ -3,6 +3,7 @@ package framework
 import (
 	"fmt"
 	"os"
+	"path"
 	"runtime"
 	"time"
 
@@ -51,6 +52,7 @@ type E2eConfig struct {
 	ZoneIngressApp                string            `json:"zoneIngressApp,omitempty" envconfig:"KUMA_ZONE_INGRESS_APP"`
 	Arch                          string            `json:"arch,omitempty" envconfig:"ARCH"`
 	KumaCpConfig                  KumaCpConfig      `json:"kumaCpConfig,omitempty" envconfig:"KUMA_CP_CONFIG"`
+	UniversalE2ELogsPath          string            `json:"universalE2ELogsPath,omitempty" envconfig:"UNIVERSAL_E2E_LOGS_PATH"`
 
 	SuiteConfig SuiteConfig `json:"suites,omitempty"`
 }
@@ -246,8 +248,9 @@ var defaultConf = E2eConfig{
 			},
 		},
 	},
-	ZoneEgressApp:  "kuma-egress",
-	ZoneIngressApp: "kuma-ingress",
+	ZoneEgressApp:        "kuma-egress",
+	ZoneIngressApp:       "kuma-ingress",
+	UniversalE2ELogsPath: path.Join(os.TempDir(), "e2e"),
 }
 
 func init() {

--- a/test/framework/deployments/externalservice/deployment.go
+++ b/test/framework/deployments/externalservice/deployment.go
@@ -35,19 +35,17 @@ func Install(name string, commands ...Command) framework.InstallFunc {
 		if len(commands) < 1 {
 			return errors.New("command list can't be empty")
 		}
-		switch cluster.(type) {
+		switch c := cluster.(type) {
 		case *framework.K8sCluster:
 			deployment = &k8SDeployment{
 				name: name,
 				cmd:  commands[0],
 			}
 		case *framework.UniversalCluster:
-			deployment = &UniversalDeployment{
-				name:     name,
-				commands: commands,
-				ports:    map[uint32]uint32{},
-				verbose:  cluster.Verbose(),
-			}
+			deployment = NewUniversalDeployment(c.LogsPath()).
+				WithName(name).
+				WithCommands(commands...).
+				WithVerbose(cluster.Verbose())
 		default:
 			return errors.New("invalid cluster")
 		}

--- a/test/framework/envoy_admin/tunnel/universal.go
+++ b/test/framework/envoy_admin/tunnel/universal.go
@@ -15,18 +15,20 @@ import (
 type UniversalTunnel struct {
 	t testing.TestingT
 
-	port string
+	logsPath string
+	port     string
 
 	verbose bool
 }
 
 var _ envoy_admin.Tunnel = &UniversalTunnel{}
 
-func NewUniversalEnvoyAdminTunnel(t testing.TestingT, port string, verbose bool) (envoy_admin.Tunnel, error) {
+func NewUniversalEnvoyAdminTunnel(t testing.TestingT, logsPath string, port string, verbose bool) (envoy_admin.Tunnel, error) {
 	return &UniversalTunnel{
-		t:       t,
-		port:    port,
-		verbose: verbose,
+		t:        t,
+		logsPath: logsPath,
+		port:     port,
+		verbose:  verbose,
 	}, nil
 }
 
@@ -37,7 +39,7 @@ func (t *UniversalTunnel) GetStats(name string) (*stats.Stats, error) {
 		"curl", "--silent", "--max-time", "3", "--fail", url,
 	}
 
-	app := ssh.NewApp("tunnel", t.verbose, t.port, nil, sshArgs)
+	app := ssh.NewApp("tunnel", t.logsPath, t.verbose, t.port, nil, sshArgs)
 
 	if err := app.Run(); err != nil {
 		return nil, err
@@ -61,7 +63,7 @@ func (t *UniversalTunnel) ResetCounters() error {
 		"'http://localhost:9901/reset_counters'",
 	}
 
-	app := ssh.NewApp("tunnel", t.verbose, t.port, nil, sshArgs)
+	app := ssh.NewApp("tunnel", t.logsPath, t.verbose, t.port, nil, sshArgs)
 
 	if err := app.Run(); err != nil {
 		return err

--- a/test/framework/envs/universal/env.go
+++ b/test/framework/envs/universal/env.go
@@ -2,11 +2,15 @@ package universal
 
 import (
 	"encoding/json"
+	"os"
+	"path"
 
+	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
 	"github.com/kumahq/kuma/pkg/config/core"
 	"github.com/kumahq/kuma/test/framework"
+	"github.com/kumahq/kuma/test/framework/universal_logs"
 )
 
 var Cluster *framework.UniversalCluster
@@ -52,4 +56,42 @@ func RestoreState(bytes []byte) {
 	Expect(err).ToNot(HaveOccurred())
 	Expect(Cluster.AddNetworking(state.ZoneEgress, framework.Config.ZoneEgressApp)).To(Succeed())
 	Cluster.SetCp(cp)
+}
+
+// WriteLogsIfFailed will read files used to put logs from universal tests
+func WriteLogsIfFailed(ctx SpecContext) {
+	if ctx.SpecReport().Failed() {
+		logsPath := universal_logs.GetPath(
+			framework.Config.UniversalE2ELogsPath,
+			ctx.SpecReport().FullText(),
+		)
+		spacer := "------------------------------\n"
+
+		dir, err := os.ReadDir(logsPath)
+		if err != nil {
+			GinkgoWriter.Printf("Attaching component logs failed: %s", err)
+			return
+		}
+
+		for _, file := range dir {
+			if !file.IsDir() {
+				logFilePath := path.Join(logsPath, file.Name())
+
+				bs, err := os.ReadFile(logFilePath)
+				if err != nil {
+					GinkgoWriter.Printf("Attaching component logs for %s failed: %s", logFilePath, err)
+					continue
+				}
+
+				GinkgoWriter.Printf("%sLogs from: %s\n%s%s", spacer, logFilePath, spacer, bs)
+			}
+		}
+	}
+}
+
+func RememberSpecID(ctx SpecContext) {
+	universal_logs.GenAndSavePath(
+		framework.Config.UniversalE2ELogsPath,
+		ctx.SpecReport().FullText(),
+	)
 }

--- a/test/framework/envs/universal/env.go
+++ b/test/framework/envs/universal/env.go
@@ -83,7 +83,8 @@ func WriteLogsIfFailed(ctx SpecContext) {
 					continue
 				}
 
-				GinkgoWriter.Printf("%sLogs from: %s\n%s%s", spacer, logFilePath, spacer, bs)
+				GinkgoWriter.Printf("%sLogs from: %s\n%s", spacer, logFilePath, spacer)
+				Expect(GinkgoWriter.Write(bs)).To(Succeed())
 			}
 		}
 	}

--- a/test/framework/envs/universal/env.go
+++ b/test/framework/envs/universal/env.go
@@ -84,7 +84,7 @@ func WriteLogsIfFailed(ctx SpecContext) {
 				}
 
 				GinkgoWriter.Printf("%sLogs from: %s\n%s", spacer, logFilePath, spacer)
-				Expect(GinkgoWriter.Write(bs)).To(Succeed())
+				Expect(GinkgoWriter.Write(bs)).Error().ToNot(HaveOccurred())
 			}
 		}
 	}

--- a/test/framework/setup.go
+++ b/test/framework/setup.go
@@ -299,6 +299,7 @@ func zoneRelatedResource(
 			cluster.GetTesting(),
 			uniCluster.name,
 			dpName,
+			uniCluster.logsPath,
 			"",
 			appType,
 			Config.IPV6,

--- a/test/framework/ssh/ssh.go
+++ b/test/framework/ssh/ssh.go
@@ -29,7 +29,7 @@ type App struct {
 	logFile *os.File
 }
 
-func NewApp(appName string, verbose bool, port string, envMap map[string]string, args []string) *App {
+func NewApp(appName string, logDirName string, verbose bool, port string, envMap map[string]string, args []string) *App {
 	app := &App{
 		port: port,
 	}
@@ -40,11 +40,10 @@ func NewApp(appName string, verbose bool, port string, envMap map[string]string,
 		"root@localhost", "-p", port,
 	}
 	for k, v := range envMap {
-		sshArgs = append(sshArgs, fmt.Sprintf("%s='%s'", k, utils.ShellEscape(v)))
+		sshArgs = append(sshArgs, fmt.Sprintf("%s=%s", k, utils.ShellEscape(v)))
 	}
 	sshArgs = append(sshArgs, args...)
 	app.cmd = exec.Command("ssh", sshArgs...)
-	logDirName := "/tmp/e2e"
 	err := os.MkdirAll(logDirName, os.ModePerm)
 	if err != nil {
 		panic(errors.Wrap(err, "could not create /tmp/e2e"))

--- a/test/framework/ssh/ssh.go
+++ b/test/framework/ssh/ssh.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"path"
 	"syscall"
 
 	"github.com/gruntwork-io/terratest/modules/logger"
@@ -29,7 +30,7 @@ type App struct {
 	logFile *os.File
 }
 
-func NewApp(appName string, logDirName string, verbose bool, port string, envMap map[string]string, args []string) *App {
+func NewApp(appName string, logsPath string, verbose bool, port string, envMap map[string]string, args []string) *App {
 	app := &App{
 		port: port,
 	}
@@ -44,11 +45,11 @@ func NewApp(appName string, logDirName string, verbose bool, port string, envMap
 	}
 	sshArgs = append(sshArgs, args...)
 	app.cmd = exec.Command("ssh", sshArgs...)
-	err := os.MkdirAll(logDirName, os.ModePerm)
+	err := os.MkdirAll(logsPath, os.ModePerm)
 	if err != nil {
 		panic(errors.Wrap(err, "could not create /tmp/e2e"))
 	}
-	logFileName := logDirName + "/" + appName
+	logFileName := path.Join(logsPath, appName)
 	app.logFile, err = os.OpenFile(logFileName, os.O_RDWR|os.O_APPEND|os.O_CREATE, 0o660)
 	if err != nil {
 		panic(errors.Wrap(err, "could not create "+logFileName))

--- a/test/framework/universal_cluster.go
+++ b/test/framework/universal_cluster.go
@@ -18,6 +18,7 @@ import (
 	"github.com/kumahq/kuma/test/framework/envoy_admin"
 	"github.com/kumahq/kuma/test/framework/envoy_admin/tunnel"
 	"github.com/kumahq/kuma/test/framework/ssh"
+	"github.com/kumahq/kuma/test/framework/universal_logs"
 )
 
 type UniversalNetworking struct {
@@ -38,6 +39,7 @@ type UniversalNetworkingState struct {
 
 type UniversalCluster struct {
 	t              testing.TestingT
+	logsPath       string
 	name           string
 	controlplane   *UniversalControlPlane
 	apps           map[string]*UniversalApp
@@ -56,6 +58,7 @@ var _ Cluster = &UniversalCluster{}
 func NewUniversalCluster(t *TestingT, name string, verbose bool) *UniversalCluster {
 	return &UniversalCluster{
 		t:              t,
+		logsPath:       universal_logs.GetPath(Config.UniversalE2ELogsPath, t.Name()),
 		name:           name,
 		apps:           map[string]*UniversalApp{},
 		verbose:        verbose,
@@ -65,6 +68,10 @@ func NewUniversalCluster(t *TestingT, name string, verbose bool) *UniversalClust
 		envoyTunnels:   map[string]envoy_admin.Tunnel{},
 		networking:     map[string]UniversalNetworking{},
 	}
+}
+
+func (c *UniversalCluster) LogsPath() string {
+	return c.logsPath
 }
 
 func (c *UniversalCluster) WithTimeout(timeout time.Duration) Cluster {
@@ -153,7 +160,7 @@ func (c *UniversalCluster) DeployKuma(mode core.CpMode, opt ...KumaDeploymentOpt
 		env["KUMA_MULTIZONE_ZONE_NAME"] = c.name
 	}
 
-	app, err := NewUniversalApp(c.t, c.name, AppModeCP, "", AppModeCP, c.opts.isipv6, true, []string{}, dockerVolumes, "")
+	app, err := NewUniversalApp(c.t, c.name, AppModeCP, c.logsPath, "", AppModeCP, c.opts.isipv6, true, []string{}, dockerVolumes, "")
 	if err != nil {
 		return err
 	}
@@ -290,7 +297,7 @@ func (c *UniversalCluster) DeployApp(opt ...AppDeploymentOption) error {
 
 	Logf("IPV6 is %v", opts.isipv6)
 
-	app, err := NewUniversalApp(c.t, c.name, opts.name, opts.mesh, AppMode(appname), opts.isipv6, *opts.verbose, caps, opts.dockerVolumes, opts.dockerContainerName)
+	app, err := NewUniversalApp(c.t, c.name, opts.name, c.logsPath, opts.mesh, AppMode(appname), opts.isipv6, *opts.verbose, caps, opts.dockerVolumes, opts.dockerContainerName)
 	if err != nil {
 		return err
 	}
@@ -373,7 +380,7 @@ func runPostgresMigration(kumaCP *UniversalApp, envVars map[string]string) error
 		return errors.New("missing public port: 22")
 	}
 
-	app := ssh.NewApp(kumaCP.containerName, kumaCP.verbose, sshPort, envVars, args)
+	app := ssh.NewApp(kumaCP.containerName, kumaCP.logsPath, kumaCP.verbose, sshPort, envVars, args)
 	if err := app.Run(); err != nil {
 		return errors.Errorf("db migration err: %s\nstderr :%s\nstdout %s", err.Error(), app.Err(), app.Out())
 	}
@@ -417,7 +424,7 @@ func (c *UniversalCluster) Exec(namespace, podName, appname string, cmd ...strin
 	if !ok {
 		return "", "", errors.Errorf("App %s not found", appname)
 	}
-	sshApp := ssh.NewApp(app.containerName, c.verbose, app.ports[sshPort], nil, cmd)
+	sshApp := ssh.NewApp(app.containerName, c.logsPath, c.verbose, app.ports[sshPort], nil, cmd)
 	err := sshApp.Run()
 	return sshApp.Out(), sshApp.Err(), err
 }
@@ -495,7 +502,7 @@ func (c *UniversalCluster) addIngressEnvoyTunnel() error {
 }
 
 func (c *UniversalCluster) createEnvoyTunnel(name string) error {
-	t, err := tunnel.NewUniversalEnvoyAdminTunnel(c.t, c.networking[name].ApiServerPort, c.verbose)
+	t, err := tunnel.NewUniversalEnvoyAdminTunnel(c.t, c.logsPath, c.networking[name].ApiServerPort, c.verbose)
 	if err != nil {
 		return err
 	}

--- a/test/framework/universal_controlplane.go
+++ b/test/framework/universal_controlplane.go
@@ -16,7 +16,7 @@ import (
 
 type UniversalControlPlane struct {
 	t            testing.TestingT
-	specLogsDir  string
+	logsPath     string
 	mode         core.CpMode
 	name         string
 	kumactl      *KumactlOptions
@@ -29,7 +29,7 @@ func NewUniversalControlPlane(t testing.TestingT, mode core.CpMode, clusterName 
 	kumactl := NewKumactlOptions(t, name, verbose)
 	ucp := &UniversalControlPlane{
 		t:            t,
-		specLogsDir:  universal_logs.GetPath(Config.UniversalE2ELogsPath, t.Name()),
+		logsPath:     universal_logs.GetPath(Config.UniversalE2ELogsPath, t.Name()),
 		mode:         mode,
 		name:         name,
 		kumactl:      kumactl,
@@ -82,7 +82,7 @@ func (c *UniversalControlPlane) GetAPIServerAddress() string {
 
 func (c *UniversalControlPlane) GetMetrics() (string, error) {
 	return retry.DoWithRetryE(c.t, "fetching CP metrics", DefaultRetries, DefaultTimeout, func() (string, error) {
-		sshApp := ssh.NewApp(c.name, c.specLogsDir, c.verbose, c.cpNetworking.SshPort, nil, []string{
+		sshApp := ssh.NewApp(c.name, c.logsPath, c.verbose, c.cpNetworking.SshPort, nil, []string{
 			"curl",
 			"--fail", "--show-error",
 			"http://localhost:5680/metrics",
@@ -111,7 +111,7 @@ func (c *UniversalControlPlane) generateToken(
 		func() (string, error) {
 			sshApp := ssh.NewApp(
 				c.name,
-				c.specLogsDir,
+				c.logsPath,
 				c.verbose,
 				c.cpNetworking.SshPort,
 				nil,
@@ -145,7 +145,7 @@ func (c *UniversalControlPlane) retrieveAdminToken() (string, error) {
 		func() (string, error) {
 			sshApp := ssh.NewApp(
 				c.name,
-				c.specLogsDir,
+				c.logsPath,
 				c.verbose, c.cpNetworking.SshPort, nil, []string{
 					"curl", "--fail", "--show-error",
 					"http://localhost:5681/global-secrets/admin-user-token",

--- a/test/framework/universal_logs/universal_logs.go
+++ b/test/framework/universal_logs/universal_logs.go
@@ -1,0 +1,47 @@
+package universal_logs
+
+import (
+	"path"
+	"sync"
+	"time"
+
+	"github.com/gruntwork-io/terratest/modules/random"
+	"github.com/kennygrant/sanitize"
+	"k8s.io/utils/strings"
+)
+
+var (
+	timePrefix = time.Now().Local().Format("060102_150405")
+	paths      = map[string]string{}
+	mutex      sync.RWMutex
+)
+
+func GenAndSavePath(logsPath, specName string) {
+	mutex.Lock()
+	defer mutex.Unlock()
+
+	if paths == nil {
+		paths = map[string]string{}
+	}
+
+	// Let's be sure we won't exceed max filename length
+	fileName := strings.ShortenString(sanitize.Name(specName), 243)
+
+	paths[specName] = path.Join(
+		logsPath,
+		timePrefix,
+		fileName+"-"+random.UniqueId(),
+	)
+}
+
+func GetPath(logsPath, specName string) string {
+	mutex.RLock()
+	defer mutex.RUnlock()
+
+	id, ok := paths[specName]
+	if !ok {
+		return path.Join(logsPath, timePrefix)
+	}
+
+	return id
+}

--- a/test/framework/universal_logs/universal_logs.go
+++ b/test/framework/universal_logs/universal_logs.go
@@ -20,10 +20,6 @@ func GenAndSavePath(logsPath, specName string) {
 	mutex.Lock()
 	defer mutex.Unlock()
 
-	if paths == nil {
-		paths = map[string]string{}
-	}
-
 	// Let's be sure we won't exceed max filename length
 	fileName := strings.ShortenString(sanitize.Name(specName), 243)
 


### PR DESCRIPTION
Logs which were for convinience saved under /tmp/e2e, now are wrapped by directories which names constists of suite start time.

Each universal component logs are also placed under directory with the name of the test (which is easier to find when needed).

When test fails, the logs are written to GinkgoWriter, so in CI we'll have access to them stright away.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [ ] [Link to relevant issue][1] as well as docs and UI issues --
- [ ] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [ ] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [ ] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [ ] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [ ] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
