### PR TITLE
fix(docker): set `SHELL` to an existing binary

### DIFF
--- a/tools/releases/dockerfiles/Dockerfile.base
+++ b/tools/releases/dockerfiles/Dockerfile.base
@@ -4,3 +4,5 @@ COPY /tools/releases/templates/LICENSE \
     /tools/releases/templates/README \
     /tools/releases/templates/NOTICE \
     /kuma/
+
+SHELL ["/busybox/busybox", "sh", "-c"]

--- a/tools/releases/dockerfiles/Dockerfile.base-root
+++ b/tools/releases/dockerfiles/Dockerfile.base-root
@@ -5,3 +5,5 @@ COPY /tools/releases/templates/LICENSE \
     /tools/releases/templates/README \
     /tools/releases/templates/NOTICE \
     /kuma/
+
+SHELL ["/busybox/busybox", "sh", "-c"]

--- a/tools/releases/dockerfiles/Dockerfile.static
+++ b/tools/releases/dockerfiles/Dockerfile.static
@@ -4,3 +4,5 @@ COPY /tools/releases/templates/LICENSE \
     /tools/releases/templates/README \
     /tools/releases/templates/NOTICE \
     /kuma/
+
+SHELL ["/busybox/busybox", "sh", "-c"]


### PR DESCRIPTION
Without this command, anything that uses [the "default shell" of the image, which is `["/bin/sh", "-c"]`](https://docs.docker.com/engine/reference/builder/#shell) will fail because this binary doesn't exist in images derived from this `Dockerfile`.

For example, if another `Dockerfile` `FROM`s these images and it uses the "shell form" of commands as described above, the image will be broken:

```
diff --git i/tools/releases/dockerfiles/Dockerfile.kuma-cp w/tools/releases/dockerfiles/Dockerfile.kuma-cp
index c6f1a6ce6..27893776a 100644
--- i/tools/releases/dockerfiles/Dockerfile.kuma-cp
+++ w/tools/releases/dockerfiles/Dockerfile.kuma-cp
@@ -3,4 +3,4 @@ FROM kumahq/static-debian11:no-push
 ARG ARCH
 COPY /build/artifacts-linux-$ARCH/kuma-cp/kuma-cp /usr/bin

-ENTRYPOINT ["kuma-cp"]
+ENTRYPOINT kuma-cp run
```

without `SHELL`:

```
❯ docker run docker.io/kumahq/kuma-cp:0.0.0-preview.vlocal-build
docker: Error response from daemon: failed to create shim task: OCI runtime create failed: runc create failed: unable to start container process: exec: "/bin/sh": stat /bin/sh: no such file or directory: unknown.
ERRO[0000] error waiting for container:
```

with `SHELL`:

```
❯ docker run docker.io/kumahq/kuma-cp:0.0.0-preview.vlocal-build
2023-03-02T14:17:02.463Z	INFO	Skipping reading config from file
```


### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues -- #5343 
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [x] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
