### PR TITLE
feat(kuma-cp): add a dedicated health endpoint

### DIFF
--- a/pkg/api-server/index_endpoints.go
+++ b/pkg/api-server/index_endpoints.go
@@ -20,7 +20,7 @@ func addIndexWsEndpoints(ws *restful.WebService, getInstanceId func() string, ge
 	if err != nil {
 		return err
 	}
-	ws.Route(ws.GET("/").To(func(req *restful.Request, resp *restful.Response) {
+	healthHandler := func(req *restful.Request, resp *restful.Response) {
 		if instanceId == "" {
 			instanceId = getInstanceId()
 		}
@@ -47,6 +47,8 @@ func addIndexWsEndpoints(ws *restful.WebService, getInstanceId func() string, ge
 		if err := resp.WriteAsJson(response); err != nil {
 			log.Error(err, "Could not write the index response")
 		}
-	}))
+	}
+	ws.Route(ws.GET("/").To(healthHandler))
+	ws.Route(ws.GET("/health/up").To(healthHandler))
 	return nil
 }


### PR DESCRIPTION
### Checklist prior to review

Proposed change to add a dedicated health endpoint to serve health information about the CP. Related to Kong/mink-charts#120. 

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [ ] [Link to relevant issue][1] as well as docs and UI issues --
- [ ] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [ ] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [ ] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [ ] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [ ] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
