### PR TITLE
chore(e2e): avoid redirecting DNS in Docker on darwin

### DIFF
--- a/test/framework/config.go
+++ b/test/framework/config.go
@@ -51,6 +51,7 @@ type E2eConfig struct {
 	ZoneEgressApp                 string            `json:"zoneEgressApp,omitempty" envconfig:"KUMA_ZONE_EGRESS_APP"`
 	ZoneIngressApp                string            `json:"zoneIngressApp,omitempty" envconfig:"KUMA_ZONE_INGRESS_APP"`
 	Arch                          string            `json:"arch,omitempty" envconfig:"ARCH"`
+	OS                            string            `json:"os,omitempty" envconfig:"OS"`
 	KumaCpConfig                  KumaCpConfig      `json:"kumaCpConfig,omitempty" envconfig:"KUMA_CP_CONFIG"`
 	UniversalE2ELogsPath          string            `json:"universalE2ELogsPath,omitempty" envconfig:"UNIVERSAL_E2E_LOGS_PATH"`
 
@@ -143,10 +144,14 @@ func (c E2eConfig) AutoConfigure() error {
 			return fmt.Errorf("you must set a supported KUMA_K8S_TYPE got:%s", Config.K8sType)
 		}
 	}
+
 	if Config.IPV6 && Config.CIDR == "" {
 		Config.CIDR = "fd00:fd00::/64"
 	}
+
 	Config.Arch = runtime.GOARCH
+	Config.OS = runtime.GOOS
+
 	return nil
 }
 

--- a/test/framework/universal_app.go
+++ b/test/framework/universal_app.go
@@ -490,6 +490,10 @@ func (s *UniversalApp) setupTransparent(cpIp string, builtindns bool, transparen
 	if builtindns {
 		args = append(args,
 			"--redirect-dns",
+		)
+	}
+	if builtindns && Config.OS != "darwin" {
+		args = append(args,
 			"--redirect-dns-upstream-target-chain", "DOCKER_OUTPUT",
 		)
 	}


### PR DESCRIPTION
There is no `DOCKER_OUTPUT` chain in Docker for Mac. So we don't have to redirect traffic to it. 

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [X] [Link to relevant issue][1] as well as docs and UI issues --
- [X] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [X] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [X] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [X] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [X] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
