### PR TITLE
Revert "chore(dp/cp/config): remove EnableLocalhostInboundClusters op…

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -84,24 +84,6 @@ helm upgrade --install --create-namespace --namespace kuma-system \
 kumactl install control-plane --set "legacy.transparentProxy=true" | kubectl apply -f-
 ```
 
-### Removal of deprecated options to reach applications bound to `localhost`
-
-The deprecated options `KUMA_DEFAULTS_ENABLE_LOCALHOST_INBOUND_CLUSTERS` and
-`defaults.enableLocalhostInboundClusters` were removed.
-
-This change affects only applications using transparent proxy.
-
-Applications that are binding to `localhost` won't be reachable anymore.
-This is the default behaviour from Kuma 1.8.0. Until now, it was possible to set
-a deprecated kuma-cp configurations `KUMA_DEFAULTS_ENABLE_LOCALHOST_INBOUND_CLUSTERS`
-or `defaults.enableLocalhostInboundClusters` to `true`, which was allowing to
-still reach these applications.
-
-One of the options to upgrade change address which the application is
-listening on, to `0.0.0.0`.
-Other option is to define `dataplane.networking.inbound[].serviceAddress`
-to the address which service is binding to.
-
 ## Upgrade to `2.1.x`
 
 ### **Breaking changes**

--- a/api/mesh/v1alpha1/dataplane.pb.go
+++ b/api/mesh/v1alpha1/dataplane.pb.go
@@ -358,7 +358,8 @@ type Dataplane_Networking_Inbound struct {
 	ServicePort uint32 `protobuf:"varint,4,opt,name=servicePort,proto3" json:"servicePort,omitempty"`
 	// Address of the service that requests will be forwarded to.
 	// Defaults to 'inbound.address', since Kuma DP should be deployed next
-	// to the service.
+	// to the service. When `KUMA_DEFAULTS_ENABLE_LOCALHOST_INBOUND_CLUSTERS`
+	// is true, this defaults to `127.0.0.1`.
 	ServiceAddress string `protobuf:"bytes,6,opt,name=serviceAddress,proto3" json:"serviceAddress,omitempty"`
 	// Address on which inbound listener will be exposed.
 	// Defaults to `networking.address`.

--- a/api/mesh/v1alpha1/dataplane.proto
+++ b/api/mesh/v1alpha1/dataplane.proto
@@ -66,7 +66,8 @@ message Dataplane {
 
       // Address of the service that requests will be forwarded to.
       // Defaults to 'inbound.address', since Kuma DP should be deployed next
-      // to the service.
+      // to the service. When `KUMA_DEFAULTS_ENABLE_LOCALHOST_INBOUND_CLUSTERS`
+      // is true, this defaults to `127.0.0.1`.
       string serviceAddress = 6;
 
       // Address on which inbound listener will be exposed.

--- a/api/mesh/v1alpha1/dataplane_helpers.go
+++ b/api/mesh/v1alpha1/dataplane_helpers.go
@@ -12,6 +12,10 @@ import (
 	"github.com/pkg/errors"
 )
 
+// To remove in the future.
+// TODO: https://github.com/kumahq/kuma/issues/4772
+var EnableLocalhostInboundClusters bool
+
 const (
 	// Mandatory tag that has a reserved meaning in Kuma.
 	ServiceTag     = "kuma.io/service"
@@ -158,7 +162,12 @@ func (n *Dataplane_Networking) ToInboundInterface(inbound *Dataplane_Networking_
 	if inbound.ServiceAddress != "" {
 		iface.WorkloadIP = inbound.ServiceAddress
 	} else {
-		iface.WorkloadIP = iface.DataplaneIP
+		switch EnableLocalhostInboundClusters {
+		case true:
+			iface.WorkloadIP = "127.0.0.1"
+		default:
+			iface.WorkloadIP = iface.DataplaneIP
+		}
 	}
 	if inbound.ServicePort != 0 {
 		iface.WorkloadPort = inbound.ServicePort

--- a/docs/generated/resources/proxy_dataplane.md
+++ b/docs/generated/resources/proxy_dataplane.md
@@ -77,7 +77,8 @@
         
             Address of the service that requests will be forwarded to.
             Defaults to 'inbound.address', since Kuma DP should be deployed next
-            to the service.    
+            to the service. When `KUMA_DEFAULTS_ENABLE_LOCALHOST_INBOUND_CLUSTERS`
+            is true, this defaults to `127.0.0.1`.    
         
         - `address` (optional)
         

--- a/pkg/config/app/kuma-cp/config.go
+++ b/pkg/config/app/kuma-cp/config.go
@@ -30,6 +30,11 @@ var _ config.Config = &Defaults{}
 type Defaults struct {
 	// If true, it skips creating the default Mesh
 	SkipMeshCreation bool `json:"skipMeshCreation" envconfig:"kuma_defaults_skip_mesh_creation"`
+	// If true, instead of providing inbound clusters with address of dataplane, generates cluster with localhost.
+	// Enabled can cause security threat by exposing application listing on localhost. This configuration is going to
+	// be removed in the future.
+	// TODO: https://github.com/kumahq/kuma/issues/4772
+	EnableLocalhostInboundClusters bool `json:"enableLocalhostInboundClusters" envconfig:"kuma_defaults_enable_localhost_inbound_clusters"`
 }
 
 func (d *Defaults) Sanitize() {
@@ -176,7 +181,8 @@ var DefaultConfig = func() Config {
 		BootstrapServer:            bootstrap.DefaultBootstrapServerConfig(),
 		Runtime:                    runtime.DefaultRuntimeConfig(),
 		Defaults: &Defaults{
-			SkipMeshCreation: false,
+			SkipMeshCreation:               false,
+			EnableLocalhostInboundClusters: false,
 		},
 		Metrics: &Metrics{
 			Dataplane: &DataplaneMetrics{

--- a/pkg/config/app/kuma-cp/kuma-cp.defaults.yaml
+++ b/pkg/config/app/kuma-cp/kuma-cp.defaults.yaml
@@ -347,6 +347,10 @@ runtime:
 defaults:
   # If true, it skips creating the default Mesh
   skipMeshCreation: false # ENV: KUMA_DEFAULTS_SKIP_MESH_CREATION
+  # If true, instead of providing inbound clusters with address of dataplane, generates cluster with localhost.
+  # Enabled can cause security threat by exposing application listing on localhost. This configuration is going to
+  # be removed in the future.
+  enableLocalhostInboundClusters: false #ENV: KUMA_DEFAULTS_ENABLE_LOCALHOST_INBOUND_CLUSTERS
 
 # Metrics configuration
 metrics:

--- a/pkg/config/loader_test.go
+++ b/pkg/config/loader_test.go
@@ -242,6 +242,7 @@ var _ = Describe("Config loader", func() {
 			Expect(cfg.Multizone.Zone.KDS.NackBackoff.Duration).To(Equal(21 * time.Second))
 
 			Expect(cfg.Defaults.SkipMeshCreation).To(BeTrue())
+			Expect(cfg.Defaults.EnableLocalhostInboundClusters).To(BeTrue())
 
 			Expect(cfg.Diagnostics.ServerPort).To(Equal(uint32(5003)))
 			Expect(cfg.Diagnostics.DebugEndpoints).To(BeTrue())
@@ -525,6 +526,7 @@ dnsServer:
   serviceVipPort: 9090
 defaults:
   skipMeshCreation: true
+  enableLocalhostInboundClusters: true
 diagnostics:
   serverPort: 5003
   debugEndpoints: true
@@ -775,6 +777,7 @@ proxy:
 				"KUMA_MULTIZONE_ZONE_KDS_NACK_BACKOFF":                                                     "21s",
 				"KUMA_MULTIZONE_GLOBAL_KDS_ZONE_INSIGHT_FLUSH_INTERVAL":                                    "5s",
 				"KUMA_DEFAULTS_SKIP_MESH_CREATION":                                                         "true",
+				"KUMA_DEFAULTS_ENABLE_LOCALHOST_INBOUND_CLUSTERS":                                          "true",
 				"KUMA_DIAGNOSTICS_SERVER_PORT":                                                             "5003",
 				"KUMA_DIAGNOSTICS_DEBUG_ENDPOINTS":                                                         "true",
 				"KUMA_DIAGNOSTICS_TLS_ENABLED":                                                             "true",

--- a/pkg/core/bootstrap/bootstrap.go
+++ b/pkg/core/bootstrap/bootstrap.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/pkg/errors"
 
+	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	"github.com/kumahq/kuma/pkg/api-server/customization"
 	kuma_cp "github.com/kumahq/kuma/pkg/config/app/kuma-cp"
 	config_core "github.com/kumahq/kuma/pkg/config/core"
@@ -150,6 +151,9 @@ func buildRuntime(appCtx context.Context, cfg kuma_cp.Config) (core_runtime.Runt
 		return nil, err
 	}
 	builder.WithXDS(xdsCtx)
+
+	// The setting should be removed, and there is no easy way to set it without breaking most of the code
+	mesh_proto.EnableLocalhostInboundClusters = builder.Config().Defaults.EnableLocalhostInboundClusters
 
 	builder.WithAccess(core_runtime.Access{
 		ResourceAccess:       resources_access.NewAdminResourceAccess(builder.Config().Access.Static.AdminResources),

--- a/pkg/xds/bootstrap/components.go
+++ b/pkg/xds/bootstrap/components.go
@@ -20,6 +20,7 @@ func RegisterBootstrap(rt core_runtime.Runtime) error {
 		rt.Config().DpServer.Authn.EnableReloadableTokens,
 		rt.Config().DpServer.Hds.Enabled,
 		rt.Config().GetEnvoyAdminPort(),
+		rt.Config().Defaults.EnableLocalhostInboundClusters,
 	)
 	if err != nil {
 		return err

--- a/pkg/xds/bootstrap/generator.go
+++ b/pkg/xds/bootstrap/generator.go
@@ -39,6 +39,7 @@ func NewDefaultBootstrapGenerator(
 	enableReloadableTokens bool,
 	hdsEnabled bool,
 	defaultAdminPort uint32,
+	enableLocalhostInboundCluster bool,
 ) (BootstrapGenerator, error) {
 	hostsAndIps, err := hostsAndIPsFromCertFile(dpServerCertFile)
 	if err != nil {
@@ -48,28 +49,30 @@ func NewDefaultBootstrapGenerator(
 		return nil, errors.Errorf("hostname: %s set by KUMA_BOOTSTRAP_SERVER_PARAMS_XDS_HOST is not available in the DP Server certificate. Available hostnames: %q. Change the hostname or generate certificate with proper hostname.", serverConfig.Params.XdsHost, hostsAndIps.slice())
 	}
 	return &bootstrapGenerator{
-		resManager:              resManager,
-		config:                  serverConfig,
-		proxyConfig:             proxyConfig,
-		xdsCertFile:             dpServerCertFile,
-		authEnabledForProxyType: authEnabledForProxyType,
-		enableReloadableTokens:  enableReloadableTokens,
-		hostsAndIps:             hostsAndIps,
-		hdsEnabled:              hdsEnabled,
-		defaultAdminPort:        defaultAdminPort,
+		resManager:                    resManager,
+		config:                        serverConfig,
+		proxyConfig:                   proxyConfig,
+		xdsCertFile:                   dpServerCertFile,
+		authEnabledForProxyType:       authEnabledForProxyType,
+		enableReloadableTokens:        enableReloadableTokens,
+		hostsAndIps:                   hostsAndIps,
+		hdsEnabled:                    hdsEnabled,
+		defaultAdminPort:              defaultAdminPort,
+		enableLocalhostInboundCluster: enableLocalhostInboundCluster,
 	}, nil
 }
 
 type bootstrapGenerator struct {
-	resManager              core_manager.ResourceManager
-	config                  *bootstrap_config.BootstrapServerConfig
-	proxyConfig             xds_config.Proxy
-	authEnabledForProxyType map[string]bool
-	enableReloadableTokens  bool
-	xdsCertFile             string
-	hostsAndIps             SANSet
-	hdsEnabled              bool
-	defaultAdminPort        uint32
+	resManager                    core_manager.ResourceManager
+	config                        *bootstrap_config.BootstrapServerConfig
+	proxyConfig                   xds_config.Proxy
+	authEnabledForProxyType       map[string]bool
+	enableReloadableTokens        bool
+	xdsCertFile                   string
+	hostsAndIps                   SANSet
+	hdsEnabled                    bool
+	defaultAdminPort              uint32
+	enableLocalhostInboundCluster bool
 }
 
 func (b *bootstrapGenerator) Generate(ctx context.Context, request types.BootstrapRequest) (proto.Message, KumaDpBootstrap, error) {
@@ -227,9 +230,15 @@ func (b *bootstrapGenerator) getMetricsAddress(
 ) string {
 	if metricsConfig.Address != "" {
 		return metricsConfig.Address
+	} else {
+		var address string
+		if b.enableLocalhostInboundCluster {
+			address = core_mesh.IPv4Loopback.String()
+		} else {
+			address = dataplane.Spec.GetNetworking().GetAddress()
+		}
+		return address
 	}
-
-	return dataplane.Spec.GetNetworking().GetAddress()
 }
 
 func (b *bootstrapGenerator) validateRequest(request types.BootstrapRequest) error {

--- a/pkg/xds/bootstrap/generator_test.go
+++ b/pkg/xds/bootstrap/generator_test.go
@@ -119,7 +119,7 @@ var _ = Describe("bootstrapGenerator", func() {
 				proxyConfig = *given.proxyConfig
 			}
 
-			generator, err := NewDefaultBootstrapGenerator(resManager, given.serverConfig, proxyConfig, filepath.Join("..", "..", "..", "test", "certs", "server-cert.pem"), given.dpAuthForProxyType, given.useTokenPath, given.hdsEnabled, 0)
+			generator, err := NewDefaultBootstrapGenerator(resManager, given.serverConfig, proxyConfig, filepath.Join("..", "..", "..", "test", "certs", "server-cert.pem"), given.dpAuthForProxyType, given.useTokenPath, given.hdsEnabled, 0, false)
 			Expect(err).ToNot(HaveOccurred())
 
 			// when
@@ -437,7 +437,7 @@ var _ = Describe("bootstrapGenerator", func() {
 			cfg := bootstrap_config.DefaultBootstrapServerConfig()
 			proxyCfg := xds_config.DefaultProxyConfig()
 
-			generator, err := NewDefaultBootstrapGenerator(resManager, cfg, proxyCfg, filepath.Join("..", "..", "..", "test", "certs", "server-cert.pem"), map[string]bool{}, false, true, 9901)
+			generator, err := NewDefaultBootstrapGenerator(resManager, cfg, proxyCfg, filepath.Join("..", "..", "..", "test", "certs", "server-cert.pem"), map[string]bool{}, false, true, 9901, false)
 			Expect(err).ToNot(HaveOccurred())
 
 			// when
@@ -575,7 +575,7 @@ Provide CA that was used to sign a certificate used in the control plane by usin
 		err = resManager.Create(context.Background(), dataplane, store.CreateByKey("name.namespace", "metrics"))
 		Expect(err).ToNot(HaveOccurred())
 
-		generator, err := NewDefaultBootstrapGenerator(resManager, config(), proxyCfg, filepath.Join("..", "..", "..", "test", "certs", "server-cert.pem"), authEnabled, false, false, 0)
+		generator, err := NewDefaultBootstrapGenerator(resManager, config(), proxyCfg, filepath.Join("..", "..", "..", "test", "certs", "server-cert.pem"), authEnabled, false, false, 0, false)
 		Expect(err).ToNot(HaveOccurred())
 
 		// when
@@ -670,7 +670,7 @@ Provide CA that was used to sign a certificate used in the control plane by usin
 		err = resManager.Create(context.Background(), dataplane, store.CreateByKey("name.namespace", "metrics"))
 		Expect(err).ToNot(HaveOccurred())
 
-		generator, err := NewDefaultBootstrapGenerator(resManager, config(), proxyCfg, filepath.Join("..", "..", "..", "test", "certs", "server-cert.pem"), authEnabled, false, false, 0)
+		generator, err := NewDefaultBootstrapGenerator(resManager, config(), proxyCfg, filepath.Join("..", "..", "..", "test", "certs", "server-cert.pem"), authEnabled, false, false, 0, false)
 		Expect(err).ToNot(HaveOccurred())
 
 		// when

--- a/pkg/xds/bootstrap/server_test.go
+++ b/pkg/xds/bootstrap/server_test.go
@@ -93,7 +93,7 @@ var _ = Describe("Bootstrap Server", func() {
 
 		proxyConfig := xds_config.DefaultProxyConfig()
 
-		generator, err := bootstrap.NewDefaultBootstrapGenerator(resManager, config, proxyConfig, filepath.Join("..", "..", "..", "test", "certs", "server-cert.pem"), authEnabled, false, true, 0)
+		generator, err := bootstrap.NewDefaultBootstrapGenerator(resManager, config, proxyConfig, filepath.Join("..", "..", "..", "test", "certs", "server-cert.pem"), authEnabled, false, true, 0, false)
 		Expect(err).ToNot(HaveOccurred())
 		bootstrapHandler := bootstrap.BootstrapHandler{
 			Generator: generator,

--- a/test/e2e_env/multizone/inbound_communication/inbound_passthrough_disabled.go
+++ b/test/e2e_env/multizone/inbound_communication/inbound_passthrough_disabled.go
@@ -66,6 +66,12 @@ func InboundPassthroughDisabled() {
 			Install(testserver.Install(
 				testserver.WithNamespace(namespace),
 				testserver.WithMesh(mesh),
+				testserver.WithName("k8s-test-server-localhost"),
+				testserver.WithEchoArgs("echo", "--instance", "k8s-bound-localhost", "--ip", localhostAddress),
+			)).
+			Install(testserver.Install(
+				testserver.WithNamespace(namespace),
+				testserver.WithMesh(mesh),
 				testserver.WithName("k8s-test-server-wildcard"),
 				testserver.WithEchoArgs("echo", "--instance", "k8s-bound-wildcard", "--ip", wildcardAddress),
 			)).
@@ -101,10 +107,26 @@ func InboundPassthroughDisabled() {
 				}).Should(Succeed())
 			},
 			Entry("on k8s binds to wildcard", "k8s-test-server-wildcard.inbound-passthrough-disabled.svc.80.mesh", "k8s-bound-wildcard"),
+			Entry("on k8s binds to localhost", "k8s-test-server-localhost.inbound-passthrough-disabled.svc.80.mesh", "k8s-bound-localhost"),
 			Entry("on universal binds to wildcard", "uni-test-server-wildcard.mesh", "uni-bound-wildcard"),
+			Entry("on universal binds to localhost", "uni-test-server-localhost.mesh", "uni-bound-localhost"),
 			Entry("on universal is not using transparent-proxy", "uni-test-server-wildcard-no-tp.mesh", "uni-bound-wildcard-no-tp"),
-			Entry("on k8s binds to pod", "k8s-test-server-pod.inbound-passthrough-disabled.svc.80.mesh", "k8s-bound-pod"),
-			Entry("on universal binds to containerip", "uni-test-server-containerip.mesh", "uni-bound-containerip"),
+		)
+		DescribeTable("should fail when application",
+			func(url string) {
+				Consistently(func(g Gomega) {
+					// when
+					_, err := client.CollectResponse(
+						multizone.KubeZone2, "demo-client", url,
+						client.FromKubernetesPod(namespace, "demo-client"),
+					)
+
+					// then
+					g.Expect(err).To(HaveOccurred())
+				}).Should(Succeed())
+			},
+			Entry("on k8s binds to pod", "k8s-test-server-pod.inbound-passthrough-disabled.svc.80.mesh"),
+			Entry("on universal binds to containerip", "uni-test-server-containerip.mesh"),
 		)
 	})
 
@@ -121,10 +143,23 @@ func InboundPassthroughDisabled() {
 				}).Should(Succeed())
 			},
 			Entry("on universal binds to wildcard", "uni-test-server-wildcard.mesh", "uni-bound-wildcard"),
+			Entry("on universal binds to localhost", "uni-test-server-localhost.mesh", "uni-bound-localhost"),
 			Entry("on universal is not using transparent-proxy", "uni-test-server-wildcard-no-tp.mesh", "uni-bound-wildcard-no-tp"),
 			Entry("on k8s binds to wildcard", "k8s-test-server-wildcard.inbound-passthrough-disabled.svc.80.mesh", "k8s-bound-wildcard"),
-			Entry("on universal binds to containerip", "uni-test-server-containerip.mesh", "uni-bound-containerip"),
-			Entry("on k8s binds to pod", "k8s-test-server-pod.inbound-passthrough-disabled.svc.80.mesh", "k8s-bound-pod"),
+			Entry("on k8s binds to localhost", "k8s-test-server-localhost.inbound-passthrough-disabled.svc.80.mesh", "k8s-bound-localhost"),
+		)
+		DescribeTable("should fail when application",
+			func(url string) {
+				Consistently(func(g Gomega) {
+					// when
+					_, err := client.CollectResponse(multizone.UniZone2, "uni-demo-client", url)
+
+					// then
+					Expect(err).To(HaveOccurred())
+				}).Should(Succeed())
+			},
+			Entry("on universal binds to containerip", "uni-test-server-containerip.mesh"),
+			Entry("on k8s binds to pod", "k8s-test-server-pod.inbound-passthrough-disabled.svc.80.mesh"),
 		)
 	})
 }

--- a/test/framework/envs/multizone/env.go
+++ b/test/framework/envs/multizone/env.go
@@ -66,6 +66,7 @@ func SetupAndGetState() []byte {
 	kubeZone2Options := append(
 		[]framework.KumaDeploymentOption{
 			WithEnv("KUMA_STORE_UNSAFE_DELETE", "true"),
+			WithEnv("KUMA_DEFAULTS_ENABLE_LOCALHOST_INBOUND_CLUSTERS", "true"),
 			WithIngress(),
 			WithIngressEnvoyAdminTunnel(),
 			WithEgress(),
@@ -109,6 +110,7 @@ func SetupAndGetState() []byte {
 		[]framework.KumaDeploymentOption{
 			WithGlobalAddress(Global.GetKuma().GetKDSServerAddress()),
 			WithEnv("KUMA_STORE_UNSAFE_DELETE", "true"),
+			WithEnv("KUMA_DEFAULTS_ENABLE_LOCALHOST_INBOUND_CLUSTERS", "true"),
 			WithEgressEnvoyAdminTunnel(),
 			WithIngressEnvoyAdminTunnel(),
 		},


### PR DESCRIPTION
…tion (#6214)"

This reverts commit 1e8033ba62cdef49143a85e245a8943483b11ced.

Reverting till https://github.com/kumahq/kuma/issues/5335 is fixed (Envoy 1.25)

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [ ] [Link to relevant issue][1] as well as docs and UI issues --
- [ ] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [ ] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [ ] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [ ] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [ ] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
