### PR TITLE
ci(pr-comments): handle more than 30 collaborators

### DIFF
--- a/.github/workflows/pr-comments.yaml
+++ b/.github/workflows/pr-comments.yaml
@@ -20,7 +20,7 @@ jobs:
       - name: check-maintainer
         run:  |
           # Ensure the commenter is a maintainer
-          if [[ `gh api  /repos/${{ github.repository }}/collaborators --jq '.[] | select (.permissions.maintain == true) | .login' | grep ${{ github.event.comment.user.login }}` ]]; then
+          if [[ `gh api  '/repos/${{ github.repository }}/collaborators?permission=maintain' --paginate --jq '.[].login' | grep ${{ github.event.comment.user.login }}` ]]; then
             gh api --method POST -f content='+1' ${{ github.event.comment.url }}/reactions
           else
             gh api --method POST -f content='-1' ${{ github.event.comment.url }}/reactions


### PR DESCRIPTION
We were not using --paginate so there was only the first 30 collaborators (the first page), this paginates over all pages

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [x] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
