### PR TITLE
feat(kuma-cp): allow Mesh default resources regeneration without deletion and restart

### DIFF
--- a/pkg/plugins/runtime/k8s/controllers/mesh_defaults_controller.go
+++ b/pkg/plugins/runtime/k8s/controllers/mesh_defaults_controller.go
@@ -48,6 +48,8 @@ func (r *MeshDefaultsReconciler) Reconcile(ctx context.Context, req kube_ctrl.Re
 	}
 	mesh.GetMeta().(*k8s.KubernetesMetaAdapter).GetAnnotations()[common_k8s.K8sMeshDefaultsGenerated] = "true"
 
+	r.Log.Info("marking mesh that default resources were generated", "mesh", req.Name)
+
 	if err := r.ResourceManager.Update(ctx, mesh); err != nil {
 		return kube_ctrl.Result{}, errors.Wrap(err, "could not mark Mesh that default resources were generated")
 	}

--- a/pkg/plugins/runtime/k8s/controllers/mesh_defaults_controller.go
+++ b/pkg/plugins/runtime/k8s/controllers/mesh_defaults_controller.go
@@ -7,11 +7,7 @@ import (
 	"github.com/pkg/errors"
 	kube_apierrs "k8s.io/apimachinery/pkg/api/errors"
 	kube_ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/builder"
-	"sigs.k8s.io/controller-runtime/pkg/event"
-	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
-	"github.com/kumahq/kuma/pkg/core"
 	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	"github.com/kumahq/kuma/pkg/core/resources/manager"
 	core_model "github.com/kumahq/kuma/pkg/core/resources/model"
@@ -38,8 +34,6 @@ func (r *MeshDefaultsReconciler) Reconcile(ctx context.Context, req kube_ctrl.Re
 	}
 
 	// Before creating default policies for the mesh we want to ensure that this mesh wasn't processed before.
-	// We can't rely on filtering by CreateFunc, because apparently it sends the create event every time resource
-	// is added to the underlying Informer. That's why on the Kuma CP restart Mesh will be processed the second time
 	if processed := mesh.GetMeta().(*k8s.KubernetesMetaAdapter).GetAnnotations()[common_k8s.K8sMeshDefaultsGenerated]; processed == "true" {
 		return kube_ctrl.Result{}, nil
 	}
@@ -53,31 +47,15 @@ func (r *MeshDefaultsReconciler) Reconcile(ctx context.Context, req kube_ctrl.Re
 		mesh.GetMeta().(*k8s.KubernetesMetaAdapter).Annotations = map[string]string{}
 	}
 	mesh.GetMeta().(*k8s.KubernetesMetaAdapter).GetAnnotations()[common_k8s.K8sMeshDefaultsGenerated] = "true"
-	r.Log.Info("marking mesh that default resources were generated", "mesh", req.Name)
-	if err := r.ResourceManager.Update(ctx, mesh, store.ModifiedAt(core.Now())); err != nil {
-		return kube_ctrl.Result{}, errors.Wrap(err, "could not update default mesh resources")
+
+	if err := r.ResourceManager.Update(ctx, mesh); err != nil {
+		return kube_ctrl.Result{}, errors.Wrap(err, "could not mark Mesh that default resources were generated")
 	}
 	return kube_ctrl.Result{}, nil
 }
 
 func (r *MeshDefaultsReconciler) SetupWithManager(mgr kube_ctrl.Manager) error {
 	return kube_ctrl.NewControllerManagedBy(mgr).
-		For(&mesh_k8s.Mesh{}, builder.WithPredicates(onlyCreate)).
+		For(&mesh_k8s.Mesh{}).
 		Complete(r)
-}
-
-// we only want to react on Create events. User may want to delete default resources, we don't want to add them again when they update the Mesh
-var onlyCreate = predicate.Funcs{
-	CreateFunc: func(event event.CreateEvent) bool {
-		return true
-	},
-	DeleteFunc: func(deleteEvent event.DeleteEvent) bool {
-		return false
-	},
-	UpdateFunc: func(updateEvent event.UpdateEvent) bool {
-		return false
-	},
-	GenericFunc: func(genericEvent event.GenericEvent) bool {
-		return false
-	},
 }


### PR DESCRIPTION
Feels more like this is how the annotation should work, given that we need it in the first place. There's no reason to filter only for `Create` events, which requires a restart to retrigger reconciliation.

WDYT?

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [x] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
