### PR TITLE
chore(cleanup): remove old builtindns annotations

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,6 +8,10 @@ does not have any particular instructions.
 
 ## Upcoming release
 
+### Removed deprecated annotations
+
+- `kuma.io/builtindns` and `kuma.io/builtindnsport` are removed in favour of `kuma.io/builtin-dns` and `kuma.io/builtin-dns-port` introduced in 1.8.0
+
 ### Helm
 
 There are new default values for `*.podSecurityContext` and `*.containerSecurityContext`, see `values.yaml`.

--- a/app/cni/pkg/cni/annotations.go
+++ b/app/cni/pkg/cni/annotations.go
@@ -26,8 +26,8 @@ var annotationRegistry = map[string]*annotationParam{
 	"inboundPortV6":        {"kuma.io/transparent-proxying-inbound-v6-port", defaultInboundPortV6, validatePortList},
 	"outboundPort":         {"kuma.io/transparent-proxying-outbound-port", defaultOutboundPort, validatePortList},
 	"isGateway":            {"kuma.io/gateway", "false", alwaysValidFunc},
-	"builtinDNS":           {"kuma.io/builtindns", "false", alwaysValidFunc},
-	"builtinDNSPort":       {"kuma.io/builtindnsport", defaultBuiltinDNSPort, validatePortList},
+	"builtinDNS":           {"kuma.io/builtin-dns", "false", alwaysValidFunc},
+	"builtinDNSPort":       {"kuma.io/builtin-dns-port", defaultBuiltinDNSPort, validatePortList},
 }
 
 type IntermediateConfig struct {

--- a/pkg/plugins/runtime/k8s/metadata/annotations.go
+++ b/pkg/plugins/runtime/k8s/metadata/annotations.go
@@ -71,9 +71,6 @@ const (
 	// KumaMetricsPrometheusPath to override `Mesh`-wide default path
 	KumaMetricsPrometheusPath = "prometheus.metrics.kuma.io/path"
 
-	// Remove with: https://github.com/kumahq/kuma/issues/4675
-	KumaBuiltinDNSDeprecated     = "kuma.io/builtindns"
-	KumaBuiltinDNSPortDeprecated = "kuma.io/builtindnsport"
 	// KumaBuiltinDNS the sidecar will use its builtin DNS
 	KumaBuiltinDNS     = "kuma.io/builtin-dns"
 	KumaBuiltinDNSPort = "kuma.io/builtin-dns-port"
@@ -110,8 +107,8 @@ const (
 )
 
 var PodAnnotationDeprecations = []Deprecation{
-	NewReplaceByDeprecation(KumaBuiltinDNSDeprecated, KumaBuiltinDNS),
-	NewReplaceByDeprecation(KumaBuiltinDNSPortDeprecated, KumaBuiltinDNSPort),
+	NewReplaceByDeprecation("kuma.io/builtindns", KumaBuiltinDNS, true),
+	NewReplaceByDeprecation("kuma.io/builtindnsport", KumaBuiltinDNSPort, true),
 	{
 		Key:     KumaSidecarInjectionAnnotation,
 		Message: "WARNING: you are using kuma.io/sidecar-injection as annotation. Please migrate it to label to have strong guarantee that application can only start with sidecar",
@@ -123,10 +120,14 @@ type Deprecation struct {
 	Message string
 }
 
-func NewReplaceByDeprecation(old, new string) Deprecation {
+func NewReplaceByDeprecation(old, new string, removed bool) Deprecation {
+	msg := fmt.Sprintf("'%s' is being replaced by: '%s'", old, new)
+	if removed {
+		msg = fmt.Sprintf("'%s' is no longer supported and it will be ignored, use '%s' instead", old, new)
+	}
 	return Deprecation{
 		Key:     old,
-		Message: fmt.Sprintf("'%s' is being replaced by: '%s'", old, new),
+		Message: msg,
 	}
 }
 

--- a/pkg/plugins/runtime/k8s/webhooks/injector/injector.go
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/injector.go
@@ -538,11 +538,11 @@ func (i *KumaInjector) NewAnnotations(pod *kube_core.Pod, mesh string, logger lo
 		}
 	}
 
-	enabled, _, err := podAnnotations.GetEnabledWithDefault(i.cfg.BuiltinDNS.Enabled, metadata.KumaBuiltinDNSDeprecated, metadata.KumaBuiltinDNS)
+	enabled, _, err := podAnnotations.GetEnabledWithDefault(i.cfg.BuiltinDNS.Enabled, metadata.KumaBuiltinDNS)
 	if err != nil {
 		return nil, err
 	}
-	port, _, err := podAnnotations.GetUint32WithDefault(i.cfg.BuiltinDNS.Port, metadata.KumaBuiltinDNSPortDeprecated, metadata.KumaBuiltinDNSPort)
+	port, _, err := podAnnotations.GetUint32WithDefault(i.cfg.BuiltinDNS.Port, metadata.KumaBuiltinDNSPort)
 	if err != nil {
 		return nil, err
 	}
@@ -551,9 +551,6 @@ func (i *KumaInjector) NewAnnotations(pod *kube_core.Pod, mesh string, logger lo
 		portVal := strconv.Itoa(int(port))
 		annotations[metadata.KumaBuiltinDNS] = metadata.AnnotationEnabled
 		annotations[metadata.KumaBuiltinDNSPort] = portVal
-		// TODO remove deprecation issue
-		annotations[metadata.KumaBuiltinDNSDeprecated] = metadata.AnnotationEnabled
-		annotations[metadata.KumaBuiltinDNSPortDeprecated] = portVal
 	}
 
 	if err := setVirtualProbesEnabledAnnotation(annotations, pod, i.cfg); err != nil {

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.23.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.23.golden.yaml
@@ -6,8 +6,6 @@ metadata:
     kubectl.kubernetes.io/default-container: busybox
     kuma.io/builtin-dns: enabled
     kuma.io/builtin-dns-port: "25053"
-    kuma.io/builtindns: enabled
-    kuma.io/builtindnsport: "25053"
     kuma.io/envoy-admin-port: "9901"
     kuma.io/mesh: default
     kuma.io/sidecar-env-vars: KUMA_DATAPLANE_DRAIN_TIME=5s;NEW_ENV_VAR=123

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.24.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.24.golden.yaml
@@ -6,8 +6,6 @@ metadata:
     kubectl.kubernetes.io/default-container: busybox
     kuma.io/builtin-dns: enabled
     kuma.io/builtin-dns-port: "25053"
-    kuma.io/builtindns: enabled
-    kuma.io/builtindnsport: "25053"
     kuma.io/envoy-admin-port: "9901"
     kuma.io/mesh: default
     kuma.io/sidecar-env-vars: KUMA_DATAPLANE_DRAIN_TIME=5s;NEW_ENV_VAR=123

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.25.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.25.golden.yaml
@@ -6,8 +6,6 @@ metadata:
     kubectl.kubernetes.io/default-container: busybox
     kuma.io/builtin-dns: enabled
     kuma.io/builtin-dns-port: "25053"
-    kuma.io/builtindns: enabled
-    kuma.io/builtindnsport: "25053"
     kuma.io/envoy-admin-port: "9901"
     kuma.io/mesh: default
     kuma.io/sidecar-env-vars: KUMA_DATAPLANE_DRAIN_TIME=5s;NEW_ENV_VAR=123

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.29.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.29.golden.yaml
@@ -5,8 +5,6 @@ metadata:
     kubectl.kubernetes.io/default-container: busybox
     kuma.io/builtin-dns: enabled
     kuma.io/builtin-dns-port: "25053"
-    kuma.io/builtindns: enabled
-    kuma.io/builtindnsport: "25053"
     kuma.io/envoy-admin-port: "9901"
     kuma.io/mesh: default
     kuma.io/sidecar-injected: "true"

--- a/pkg/transparentproxy/kubernetes/kubernetes.go
+++ b/pkg/transparentproxy/kubernetes/kubernetes.go
@@ -51,12 +51,12 @@ func NewPodRedirectForPod(transparentProxyV1 bool, pod *kube_core.Pod) (*PodRedi
 	var err error
 	podRedirect := &PodRedirect{}
 
-	podRedirect.BuiltinDNSEnabled, _, err = metadata.Annotations(pod.Annotations).GetEnabled(metadata.KumaBuiltinDNSDeprecated, metadata.KumaBuiltinDNS)
+	podRedirect.BuiltinDNSEnabled, _, err = metadata.Annotations(pod.Annotations).GetEnabled(metadata.KumaBuiltinDNS)
 	if err != nil {
 		return nil, err
 	}
 
-	podRedirect.BuiltinDNSPort, _, err = metadata.Annotations(pod.Annotations).GetUint32(metadata.KumaBuiltinDNSPortDeprecated, metadata.KumaBuiltinDNSPort)
+	podRedirect.BuiltinDNSPort, _, err = metadata.Annotations(pod.Annotations).GetUint32(metadata.KumaBuiltinDNSPort)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/transparentproxy/kubernetes/kubernetes_test.go
+++ b/pkg/transparentproxy/kubernetes/kubernetes_test.go
@@ -73,8 +73,6 @@ var _ = Describe("kubernetes", func() {
 			pod: &kube_core.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
-						metadata.KumaBuiltinDNSDeprecated:                       metadata.AnnotationEnabled,
-						metadata.KumaBuiltinDNSPortDeprecated:                   "25053",
 						metadata.KumaTrafficExcludeOutboundPorts:                "11000",
 						metadata.KumaTransparentProxyingOutboundPortAnnotation:  "25100",
 						metadata.KumaTrafficExcludeInboundPorts:                 "12000",
@@ -94,8 +92,6 @@ var _ = Describe("kubernetes", func() {
 				"--exclude-outbound-ports", "11000",
 				"--verbose",
 				"--skip-resolv-conf",
-				"--redirect-all-dns-traffic",
-				"--redirect-dns-port", "25053",
 			},
 		}),
 


### PR DESCRIPTION
These were deprecated since 1.8.0

Fix #4675

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [x] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
