### PR TITLE
ci(docker): quietly load docker images (backport #6229)

### DIFF
--- a/mk/docker.mk
+++ b/mk/docker.mk
@@ -108,27 +108,33 @@ docker/load/test: docker/load/kuma-universal
 
 .PHONY: docker/load/kuma-cp
 docker/load/kuma-cp: ${BUILD_DOCKER_IMAGES_DIR}/kuma-cp.tar
-	docker load --input ${BUILD_DOCKER_IMAGES_DIR}/kuma-cp.tar
+	docker load --quiet --input ${BUILD_DOCKER_IMAGES_DIR}/kuma-cp.tar
 
 .PHONY: docker/load/kuma-dp
 docker/load/kuma-dp: ${BUILD_DOCKER_IMAGES_DIR}/kuma-dp.tar
-	docker load --input ${BUILD_DOCKER_IMAGES_DIR}/kuma-dp.tar
+	docker load --quiet --input ${BUILD_DOCKER_IMAGES_DIR}/kuma-dp.tar
 
 .PHONY: docker/load/kumactl
 docker/load/kumactl: ${BUILD_DOCKER_IMAGES_DIR}/kumactl.tar
-	docker load --input ${BUILD_DOCKER_IMAGES_DIR}/kumactl.tar
+	docker load --quiet --input ${BUILD_DOCKER_IMAGES_DIR}/kumactl.tar
 
 .PHONY: docker/load/kuma-init
 docker/load/kuma-init: ${BUILD_DOCKER_IMAGES_DIR}/kuma-init.tar
-	docker load --input ${BUILD_DOCKER_IMAGES_DIR}/kuma-init.tar
+	docker load --quiet --input ${BUILD_DOCKER_IMAGES_DIR}/kuma-init.tar
 
+<<<<<<< HEAD
 .PHONY: docker/load/kuma-prometheus-sd
 docker/load/kuma-prometheus-sd: ${BUILD_DOCKER_IMAGES_DIR}/kuma-prometheus-sd.tar
 	docker load --input ${BUILD_DOCKER_IMAGES_DIR}/kuma-prometheus-sd.tar
+=======
+.PHONY: docker/load/kuma-cni
+docker/load/kuma-cni: ${BUILD_DOCKER_IMAGES_DIR}/kuma-cni.tar
+	docker load --quiet --input ${BUILD_DOCKER_IMAGES_DIR}/kuma-cni.tar
+>>>>>>> f7643c481 (ci(docker): quietly load docker images (#6229))
 
 .PHONY: docker/load/kuma-universal
 docker/load/kuma-universal: ${BUILD_DOCKER_IMAGES_DIR}/kuma-universal.tar
-	docker load --input ${BUILD_DOCKER_IMAGES_DIR}/kuma-universal.tar
+	docker load --quiet --input ${BUILD_DOCKER_IMAGES_DIR}/kuma-universal.tar
 
 .PHONY: docker/tag/kuma-cp
 docker/tag/kuma-cp:

--- a/mk/docker.mk
+++ b/mk/docker.mk
@@ -122,15 +122,9 @@ docker/load/kumactl: ${BUILD_DOCKER_IMAGES_DIR}/kumactl.tar
 docker/load/kuma-init: ${BUILD_DOCKER_IMAGES_DIR}/kuma-init.tar
 	docker load --quiet --input ${BUILD_DOCKER_IMAGES_DIR}/kuma-init.tar
 
-<<<<<<< HEAD
 .PHONY: docker/load/kuma-prometheus-sd
 docker/load/kuma-prometheus-sd: ${BUILD_DOCKER_IMAGES_DIR}/kuma-prometheus-sd.tar
-	docker load --input ${BUILD_DOCKER_IMAGES_DIR}/kuma-prometheus-sd.tar
-=======
-.PHONY: docker/load/kuma-cni
-docker/load/kuma-cni: ${BUILD_DOCKER_IMAGES_DIR}/kuma-cni.tar
-	docker load --quiet --input ${BUILD_DOCKER_IMAGES_DIR}/kuma-cni.tar
->>>>>>> f7643c481 (ci(docker): quietly load docker images (#6229))
+	docker load --quiet --input ${BUILD_DOCKER_IMAGES_DIR}/kuma-prometheus-sd.tar
 
 .PHONY: docker/load/kuma-universal
 docker/load/kuma-universal: ${BUILD_DOCKER_IMAGES_DIR}/kuma-universal.tar


### PR DESCRIPTION
### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [ ] [Link to relevant issue][1] as well as docs and UI issues --
- [ ] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [ ] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [ ] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [ ] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [ ] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
