### PR TITLE
fix(helm): security contexts for ebpf cleanup hook

### DIFF
--- a/app/kumactl/cmd/install/testdata/install-control-plane.dump-values.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.dump-values.yaml
@@ -664,6 +664,17 @@ hooks:
   containerSecurityContext:
     readOnlyRootFilesystem: true
 
+  # -- ebpf-cleanup hook needs write access to the root filesystem to clean ebpf programs
+  # Changing below values will potentially break ebpf cleanup completely,
+  # so be cautious when doing so.
+  ebpfCleanup:
+    # -- Security context at the pod level for crd/webhook/cleanup-ebpf
+    podSecurityContext:
+      runAsNonRoot: false
+    # -- Security context at the container level for crd/webhook/cleanup-ebpf
+    containerSecurityContext:
+      readOnlyRootFilesystem: false
+
 experimental:
   # -- If true, it installs experimental Gateway API support
   gatewayAPI: false

--- a/deployments/charts/kuma/README.md
+++ b/deployments/charts/kuma/README.md
@@ -166,6 +166,9 @@ A Helm chart for the Kuma Control Plane
 | hooks.tolerations | list | `[]` | Tolerations for the HELM hooks |
 | hooks.podSecurityContext | object | `{"runAsNonRoot":true}` | Security context at the pod level for crd/webhook/ns |
 | hooks.containerSecurityContext | object | `{"readOnlyRootFilesystem":true}` | Security context at the container level for crd/webhook/ns |
+| hooks.ebpfCleanup | object | `{"containerSecurityContext":{},"podSecurityContext":{}}` | ebpf-cleanup hook needs write access to the root filesystem to clean ebpf programs |
+| hooks.ebpfCleanup.podSecurityContext | object | `{}` | Security context at the pod level for crd/webhook/cleanup-ebpf |
+| hooks.ebpfCleanup.containerSecurityContext | object | `{}` | Security context at the container level for crd/webhook/cleanup-ebpf |
 | experimental.gatewayAPI | bool | `false` | If true, it installs experimental Gateway API support |
 | experimental.ebpf.enabled | bool | `false` | If true, ebpf will be used instead of using iptables to install/configure transparent proxy |
 | experimental.ebpf.instanceIPEnvVarName | string | `"INSTANCE_IP"` | Name of the environmental variable which will contain the IP address of a pod |

--- a/deployments/charts/kuma/README.md
+++ b/deployments/charts/kuma/README.md
@@ -166,9 +166,9 @@ A Helm chart for the Kuma Control Plane
 | hooks.tolerations | list | `[]` | Tolerations for the HELM hooks |
 | hooks.podSecurityContext | object | `{"runAsNonRoot":true}` | Security context at the pod level for crd/webhook/ns |
 | hooks.containerSecurityContext | object | `{"readOnlyRootFilesystem":true}` | Security context at the container level for crd/webhook/ns |
-| hooks.ebpfCleanup | object | `{"containerSecurityContext":{},"podSecurityContext":{}}` | ebpf-cleanup hook needs write access to the root filesystem to clean ebpf programs |
-| hooks.ebpfCleanup.podSecurityContext | object | `{}` | Security context at the pod level for crd/webhook/cleanup-ebpf |
-| hooks.ebpfCleanup.containerSecurityContext | object | `{}` | Security context at the container level for crd/webhook/cleanup-ebpf |
+| hooks.ebpfCleanup | object | `{"containerSecurityContext":{"readOnlyRootFilesystem":false},"podSecurityContext":{"runAsNonRoot":false}}` | ebpf-cleanup hook needs write access to the root filesystem to clean ebpf programs |
+| hooks.ebpfCleanup.podSecurityContext | object | `{"runAsNonRoot":false}` | Security context at the pod level for crd/webhook/cleanup-ebpf |
+| hooks.ebpfCleanup.containerSecurityContext | object | `{"readOnlyRootFilesystem":false}` | Security context at the container level for crd/webhook/cleanup-ebpf |
 | experimental.gatewayAPI | bool | `false` | If true, it installs experimental Gateway API support |
 | experimental.ebpf.enabled | bool | `false` | If true, ebpf will be used instead of using iptables to install/configure transparent proxy |
 | experimental.ebpf.instanceIPEnvVarName | string | `"INSTANCE_IP"` | Name of the environmental variable which will contain the IP address of a pod |

--- a/deployments/charts/kuma/README.md
+++ b/deployments/charts/kuma/README.md
@@ -166,7 +166,7 @@ A Helm chart for the Kuma Control Plane
 | hooks.tolerations | list | `[]` | Tolerations for the HELM hooks |
 | hooks.podSecurityContext | object | `{"runAsNonRoot":true}` | Security context at the pod level for crd/webhook/ns |
 | hooks.containerSecurityContext | object | `{"readOnlyRootFilesystem":true}` | Security context at the container level for crd/webhook/ns |
-| hooks.ebpfCleanup | object | `{"containerSecurityContext":{"readOnlyRootFilesystem":false},"podSecurityContext":{"runAsNonRoot":false}}` | ebpf-cleanup hook needs write access to the root filesystem to clean ebpf programs |
+| hooks.ebpfCleanup | object | `{"containerSecurityContext":{"readOnlyRootFilesystem":false},"podSecurityContext":{"runAsNonRoot":false}}` | ebpf-cleanup hook needs write access to the root filesystem to clean ebpf programs Changing below values will potentially break ebpf cleanup completely, so be cautious when doing so. |
 | hooks.ebpfCleanup.podSecurityContext | object | `{"runAsNonRoot":false}` | Security context at the pod level for crd/webhook/cleanup-ebpf |
 | hooks.ebpfCleanup.containerSecurityContext | object | `{"readOnlyRootFilesystem":false}` | Security context at the container level for crd/webhook/cleanup-ebpf |
 | experimental.gatewayAPI | bool | `false` | If true, it installs experimental Gateway API support |

--- a/deployments/charts/kuma/templates/post-delete-cleanup-ebpf-job.yaml
+++ b/deployments/charts/kuma/templates/post-delete-cleanup-ebpf-job.yaml
@@ -37,14 +37,14 @@ rules:
     resources:
       - pods
     verbs:
-      - watch 
+      - watch
       - delete
       - deletecollection
   - apiGroups: ["batch"]
     resources:
       - jobs
     verbs:
-      - watch 
+      - watch
       - create
       - delete
       - deletecollection
@@ -97,16 +97,16 @@ spec:
       {{ toYaml . | nindent 8 }}
       {{- end }}
       restartPolicy: OnFailure
-      {{- if .Values.hooks.podSecurityContext }}
+      {{- if .Values.hooks.ebpfCleanup.podSecurityContext }}
       securityContext:
-      {{ toYaml .Values.hooks.podSecurityContext | trim | nindent 8 }}
+      {{ toYaml .Values.hooks.ebpfCleanup.podSecurityContext | trim | nindent 8 }}
       {{- end }}
       containers:
         - name: post-delete-job
           image: {{ include "kuma.formatImage" (dict "image" .Values.dataPlane.initImage "root" $) | quote }}
-          {{- if .Values.hooks.containerSecurityContext }}
+          {{- if .Values.hooks.ebpfCleanup.containerSecurityContext }}
           securityContext:
-          {{ toYaml .Values.hooks.containerSecurityContext | trim | nindent 12 }}
+          {{ toYaml .Values.hooks.ebpfCleanup.containerSecurityContext | trim | nindent 12 }}
           {{- end }}
           resources:
              requests:

--- a/deployments/charts/kuma/values.yaml
+++ b/deployments/charts/kuma/values.yaml
@@ -665,6 +665,8 @@ hooks:
     readOnlyRootFilesystem: true
 
   # -- ebpf-cleanup hook needs write access to the root filesystem to clean ebpf programs
+  # Changing below values will potentially break ebpf cleanup completely,
+  # so be cautious when doing so.
   ebpfCleanup:
     # -- Security context at the pod level for crd/webhook/cleanup-ebpf
     podSecurityContext:

--- a/deployments/charts/kuma/values.yaml
+++ b/deployments/charts/kuma/values.yaml
@@ -664,6 +664,13 @@ hooks:
   containerSecurityContext:
     readOnlyRootFilesystem: true
 
+  # -- ebpf-cleanup hook needs write access to the root filesystem to clean ebpf programs
+  ebpfCleanup:
+    # -- Security context at the pod level for crd/webhook/cleanup-ebpf
+    podSecurityContext: {}
+    # -- Security context at the container level for crd/webhook/cleanup-ebpf
+    containerSecurityContext: {}
+
 experimental:
   # -- If true, it installs experimental Gateway API support
   gatewayAPI: false

--- a/deployments/charts/kuma/values.yaml
+++ b/deployments/charts/kuma/values.yaml
@@ -667,9 +667,11 @@ hooks:
   # -- ebpf-cleanup hook needs write access to the root filesystem to clean ebpf programs
   ebpfCleanup:
     # -- Security context at the pod level for crd/webhook/cleanup-ebpf
-    podSecurityContext: {}
+    podSecurityContext:
+      runAsNonRoot: false
     # -- Security context at the container level for crd/webhook/cleanup-ebpf
-    containerSecurityContext: {}
+    containerSecurityContext:
+      readOnlyRootFilesystem: false
 
 experimental:
   # -- If true, it installs experimental Gateway API support

--- a/mk/build.mk
+++ b/mk/build.mk
@@ -24,7 +24,7 @@ GO_BUILD := GOOS=${GOOS} GOARCH=${GOARCH} CGO_ENABLED=${CGO_ENABLED} go build -v
 GO_BUILD_COREDNS := GOOS=${GOOS} GOARCH=${GOARCH} CGO_ENABLED=${CGO_ENABLED} go build -v
 
 COREDNS_GIT_REPOSITORY ?= https://github.com/coredns/coredns.git
-COREDNS_VERSION ?= v1.10.0
+COREDNS_VERSION ?= v1.10.1
 COREDNS_TMP_DIRECTORY ?= $(BUILD_DIR)/coredns
 COREDNS_PLUGIN_CFG_PATH ?= $(TOOLS_DIR)/builds/coredns/templates/plugin.cfg
 


### PR DESCRIPTION
ebpf-cleanup hook needs write access to the root filesystem to clean ebpf programs

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [ ] [Link to relevant issue][1] as well as docs and UI issues --
- [ ] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [ ] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [ ] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [ ] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [ ] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
