### PR TITLE
fix(ci): fix kind path for ipv6 e2e tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -418,7 +418,7 @@ workflows:
             - check
       - e2e:
           # Avoids running expensive workflow on PRs
-          <<: *work_branch_workflow_filter
+#          <<: *work_branch_workflow_filter
           name: test/e2e-ipv6
           requires:
             - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -418,7 +418,7 @@ workflows:
             - check
       - e2e:
           # Avoids running expensive workflow on PRs
-#          <<: *work_branch_workflow_filter
+          <<: *work_branch_workflow_filter
           name: test/e2e-ipv6
           requires:
             - build

--- a/mk/kind.mk
+++ b/mk/kind.mk
@@ -40,7 +40,7 @@ endef
 CI_KIND_VERSION ?= v0.11.1
 CI_KUBERNETES_VERSION ?= v1.20.7@sha256:cbeaf907fc78ac97ce7b625e4bf0de16e3ea725daf6b04f930bd14c67c671ff9
 
-KIND_PATH := $(CI_TOOLS_DIR)/kind
+KIND_PATH := $(CI_TOOLS_BIN_DIR)/kind
 
 KUMA_MODE ?= standalone
 KUMA_NAMESPACE ?= kuma-system


### PR DESCRIPTION
CI for ibv6 e2e tests is broken since: https://github.com/kumahq/kuma/commit/f70345cfd0e595891dfa62d13a16eb509b94236f

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [ ] [Link to relevant issue][1] as well as docs and UI issues --
- [ ] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [ ] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [ ] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [ ] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [ ] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
