### PR TITLE
ci(e2e): move demo-client to a builder style

### DIFF
--- a/test/e2e/cni/old_cni_race_condition.go
+++ b/test/e2e/cni/old_cni_race_condition.go
@@ -37,7 +37,7 @@ func AppDeploymentWithCniAndNoTaintController() {
 				WithHelmReleaseName(releaseName),
 				WithHelmOpt("cni.delayStartupSeconds", "40000"),
 				WithHelmOpt("experimental.cni", "false"),
-				WithCNIV1(),
+				WithCNI(CNIVersion1),
 			)).
 			Setup(cluster)
 		// here we could patch the "command" of the CNI, kubectl patch ...

--- a/test/e2e/cni/taint_controller_race.go
+++ b/test/e2e/cni/taint_controller_race.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/kumahq/kuma/pkg/config/core"
 	. "github.com/kumahq/kuma/test/framework"
+	"github.com/kumahq/kuma/test/framework/deployments/democlient"
 	"github.com/kumahq/kuma/test/framework/deployments/testserver"
 )
 
@@ -77,12 +78,8 @@ metadata:
 
 			err = NewClusterSetup().
 				Install(NamespaceWithSidecarInjection(TestNamespace)).
-				Install(testserver.Install(func(opts *testserver.DeploymentOpts) {
-					opts.NodeSelector = map[string]string{
-						"second": "true",
-					}
-				})).
-				Install(DemoClientK8sWithAffinity("default", TestNamespace)).
+				Install(testserver.Install(testserver.WithNodeSelector(map[string]string{"second": "true"}))).
+				Install(democlient.Install(democlient.WithNamespace(TestNamespace), democlient.WithNodeSelector(map[string]string{"second": "true"}))).
 				Setup(cluster)
 			Expect(err).ToNot(HaveOccurred())
 

--- a/test/e2e/compatibility/cp_compatibility_kubernetes_multizone.go
+++ b/test/e2e/compatibility/cp_compatibility_kubernetes_multizone.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/kumahq/kuma/pkg/config/core"
 	. "github.com/kumahq/kuma/test/framework"
+	"github.com/kumahq/kuma/test/framework/deployments/democlient"
 )
 
 // Ensure that the upstream Kuma help repository is configured
@@ -110,7 +111,7 @@ metadata:
 		}, "30s", "1s").Should(ContainSubstring("demo"))
 
 		// when new resources is created on Zone
-		err = DemoClientK8s("default", TestNamespace)(zoneCluster)
+		err = democlient.Install(democlient.WithNamespace(TestNamespace), democlient.WithMesh("default"))(zoneCluster)
 
 		// then resource is synchronized to Global
 		Expect(err).ToNot(HaveOccurred())

--- a/test/e2e/externalservices/externalservices_kubernetes_without_egress.go
+++ b/test/e2e/externalservices/externalservices_kubernetes_without_egress.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/kumahq/kuma/pkg/config/core"
 	. "github.com/kumahq/kuma/test/framework"
+	"github.com/kumahq/kuma/test/framework/deployments/democlient"
 	"github.com/kumahq/kuma/test/framework/deployments/testserver"
 )
 
@@ -54,7 +55,7 @@ spec:
 			Install(Kuma(core.Standalone)).
 			Install(YamlK8s(fmt.Sprintf(meshDefaulMtlsOn, "false"))).
 			Install(NamespaceWithSidecarInjection(TestNamespace)).
-			Install(DemoClientK8s("default", TestNamespace)).
+			Install(democlient.Install(democlient.WithNamespace(TestNamespace), democlient.WithMesh("default"))).
 			Install(Namespace(externalServicesNamespace)).
 			Install(testserver.Install(
 				testserver.WithNamespace(externalServicesNamespace),

--- a/test/e2e/helm/kuma_helm_deploy_global_universal_mode_and_zone.go
+++ b/test/e2e/helm/kuma_helm_deploy_global_universal_mode_and_zone.go
@@ -12,6 +12,7 @@ import (
 	"github.com/kumahq/kuma/pkg/config/core"
 	. "github.com/kumahq/kuma/test/framework"
 	"github.com/kumahq/kuma/test/framework/client"
+	"github.com/kumahq/kuma/test/framework/deployments/democlient"
 	"github.com/kumahq/kuma/test/framework/deployments/postgres"
 	"github.com/kumahq/kuma/test/framework/deployments/testserver"
 )
@@ -90,7 +91,7 @@ stringData:
 				WithHelmOpt("ingress.enabled", "true"),
 			)).
 			Install(NamespaceWithSidecarInjection(TestNamespace)).
-			Install(DemoClientK8s("default", TestNamespace)).
+			Install(democlient.Install(democlient.WithNamespace(TestNamespace), democlient.WithMesh("default"))).
 			Install(testserver.Install()).
 			Setup(zoneCluster)
 		Expect(err).ToNot(HaveOccurred())

--- a/test/e2e/helm/kuma_helm_deploy_global_zone.go
+++ b/test/e2e/helm/kuma_helm_deploy_global_zone.go
@@ -19,6 +19,7 @@ import (
 	"github.com/kumahq/kuma/pkg/intercp/catalog"
 	. "github.com/kumahq/kuma/test/framework"
 	"github.com/kumahq/kuma/test/framework/client"
+	"github.com/kumahq/kuma/test/framework/deployments/democlient"
 	"github.com/kumahq/kuma/test/framework/deployments/testserver"
 )
 
@@ -72,7 +73,7 @@ interCp:
 				WithHelmOpt("ingress.enabled", "true"),
 			)).
 			Install(NamespaceWithSidecarInjection(TestNamespace)).
-			Install(DemoClientK8s("default", TestNamespace)).
+			Install(democlient.Install(democlient.WithNamespace(TestNamespace), democlient.WithMesh("default"))).
 			Install(testserver.Install()).
 			Setup(c2)
 		Expect(err).ToNot(HaveOccurred())

--- a/test/e2e/helm/kuma_helm_deploy_multi_apps.go
+++ b/test/e2e/helm/kuma_helm_deploy_multi_apps.go
@@ -12,10 +12,32 @@ import (
 
 	"github.com/kumahq/kuma/pkg/config/core"
 	. "github.com/kumahq/kuma/test/framework"
+	"github.com/kumahq/kuma/test/framework/deployments/democlient"
 	"github.com/kumahq/kuma/test/framework/deployments/testserver"
 )
 
-func dontSkip(Cluster) (string, bool) {
+func shouldSkip(cluster Cluster) (string, bool) {
+	version, err := cluster.GetK8sVersion()
+	Expect(err).To(Succeed())
+
+	// Just future proofing
+	if version.Major != 1 {
+		return fmt.Sprintf(
+			"default cni is not supported in version %d.%d.%d [supported <= 1.21.x]",
+			version.Major, version.Minor, version.Patch,
+		), true
+	}
+
+	// k3s from version 1.22 comes with flannel CNI plugin in version 1,
+	// which is not supported with our default/legacy kuma-cni plugin
+	// (max supported version is 0.4)
+	if version.Minor > 21 {
+		return fmt.Sprintf(
+			"default cni is not supported in version 1.%d.%d [supported <= 1.21.x]",
+			version.Minor, version.Patch,
+		), true
+	}
+
 	return "", false
 }
 
@@ -24,35 +46,6 @@ func AppDeploymentWithHelmChart() {
 	var skip bool
 
 	minReplicas := 3
-
-	setup := func(withCni KumaDeploymentOption, shouldSkip func(cluster Cluster) (string, bool)) {
-		cluster = NewK8sCluster(NewTestingT(), Kuma1, Silent).
-			WithTimeout(6 * time.Second).
-			WithRetries(60)
-
-		var msg string
-		if msg, skip = shouldSkip(cluster); skip {
-			Skip(msg)
-		}
-
-		err := NewClusterSetup().
-			Install(Kuma(core.Standalone,
-				WithInstallationMode(HelmInstallationMode),
-				WithHelmReleaseName(fmt.Sprintf("kuma-%s", strings.ToLower(random.UniqueId()))),
-				WithSkipDefaultMesh(true), // it's common case for HELM deployments that Mesh is also managed by HELM therefore it's not created by default
-				WithHelmOpt("controlPlane.autoscaling.enabled", "true"),
-				WithHelmOpt("controlPlane.autoscaling.minReplicas", strconv.Itoa(minReplicas)),
-				withCni,
-			)).
-			Install(MeshKubernetes("default")).
-			Install(NamespaceWithSidecarInjection(TestNamespace)).
-			Install(DemoClientK8s("default", TestNamespace)).
-			Install(testserver.Install()).
-			Setup(cluster)
-		Expect(err).ToNot(HaveOccurred())
-
-		Expect(cluster.(*K8sCluster).WaitApp(Config.KumaServiceName, Config.KumaNamespace, minReplicas)).To(Succeed())
-	}
 
 	E2EAfterEach(func() {
 		if !skip {
@@ -65,8 +58,38 @@ func AppDeploymentWithHelmChart() {
 
 	DescribeTable(
 		"Should deploy two apps",
-		func(withCni KumaDeploymentOption, shouldSkip func(cluster Cluster) (string, bool)) {
-			setup(withCni, shouldSkip)
+		func(cniVersion CNIVersion) {
+			cluster = NewK8sCluster(NewTestingT(), Kuma1, Silent).
+				WithTimeout(6 * time.Second).
+				WithRetries(60)
+
+			var msg string
+			annotations := map[string]string{}
+			if cniVersion == CNIVersion1 {
+				if msg, skip = shouldSkip(cluster); skip {
+					Skip(msg)
+				}
+				annotations["kuma.io/builtindnsport"] = "enabled"
+				annotations["kuma.io/builtindns"] = "15053"
+			}
+
+			err := NewClusterSetup().
+				Install(Kuma(core.Standalone,
+					WithInstallationMode(HelmInstallationMode),
+					WithHelmReleaseName(fmt.Sprintf("kuma-%s", strings.ToLower(random.UniqueId()))),
+					WithSkipDefaultMesh(true), // it's common case for HELM deployments that Mesh is also managed by HELM therefore it's not created by default
+					WithHelmOpt("controlPlane.autoscaling.enabled", "true"),
+					WithHelmOpt("controlPlane.autoscaling.minReplicas", strconv.Itoa(minReplicas)),
+					WithCNI(cniVersion),
+				)).
+				Install(MeshKubernetes("default")).
+				Install(NamespaceWithSidecarInjection(TestNamespace)).
+				Install(democlient.Install(democlient.WithNamespace(TestNamespace), democlient.WithPodAnnotations(annotations))).
+				Install(testserver.Install(testserver.WithPodAnnotations(annotations))).
+				Setup(cluster)
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(cluster.(*K8sCluster).WaitApp(Config.KumaServiceName, Config.KumaNamespace, minReplicas)).To(Succeed())
 
 			clientPodName, err := PodNameOfApp(cluster, "demo-client", TestNamespace)
 			Expect(err).ToNot(HaveOccurred())
@@ -92,30 +115,7 @@ func AppDeploymentWithHelmChart() {
 				g.Expect(stderr).To(ContainSubstring("HTTP/1.1 200 OK"))
 			}).Should(Succeed())
 		},
-		Entry("with cni v1 (legacy)", WithCNIV1(), func(cluster Cluster) (string, bool) {
-			version, err := cluster.GetK8sVersion()
-			Expect(err).To(Succeed())
-
-			// Just future proofing
-			if version.Major != 1 {
-				return fmt.Sprintf(
-					"default cni is not supported in version %d.%d.%d [supported <= 1.21.x]",
-					version.Major, version.Minor, version.Patch,
-				), true
-			}
-
-			// k3s from version 1.22 comes with flannel CNI plugin in version 1,
-			// which is not supported with our default/legacy kuma-cni plugin
-			// (max supported version is 0.4)
-			if version.Minor > 21 {
-				return fmt.Sprintf(
-					"default cni is not supported in version 1.%d.%d [supported <= 1.21.x]",
-					version.Minor, version.Patch,
-				), true
-			}
-
-			return "", false
-		}),
-		Entry("with cni v2 (default)", WithCNI(), dontSkip),
+		Entry("with cni v1 (legacy)", CNIVersion1),
+		Entry("with cni v2 (default)", CNIVersion2),
 	)
 }

--- a/test/e2e/virtualoutbound/virtualoutbound_k8s.go
+++ b/test/e2e/virtualoutbound/virtualoutbound_k8s.go
@@ -7,6 +7,7 @@ import (
 	config_core "github.com/kumahq/kuma/pkg/config/core"
 	. "github.com/kumahq/kuma/test/framework"
 	. "github.com/kumahq/kuma/test/framework/client"
+	"github.com/kumahq/kuma/test/framework/deployments/democlient"
 	"github.com/kumahq/kuma/test/framework/deployments/testserver"
 )
 
@@ -21,7 +22,7 @@ func VirtualOutboundOnK8s() {
 				WithEnv("KUMA_DNS_SERVER_SERVICE_VIP_ENABLED", "false"),
 			)).
 			Install(NamespaceWithSidecarInjection(TestNamespace)).
-			Install(DemoClientK8s("default", TestNamespace)).
+			Install(democlient.Install(democlient.WithNamespace(TestNamespace), democlient.WithMesh("default"))).
 			Install(testserver.Install(testserver.WithStatefulSet(true), testserver.WithReplicas(2))).
 			Setup(k8sCluster)
 		Expect(err).ToNot(HaveOccurred())

--- a/test/e2e/zoneegress/externalservices/zoneegress_externalservices_hybrid.go
+++ b/test/e2e/zoneegress/externalservices/zoneegress_externalservices_hybrid.go
@@ -9,6 +9,7 @@ import (
 
 	config_core "github.com/kumahq/kuma/pkg/config/core"
 	. "github.com/kumahq/kuma/test/framework"
+	"github.com/kumahq/kuma/test/framework/deployments/democlient"
 	"github.com/kumahq/kuma/test/framework/deployments/testserver"
 )
 
@@ -106,7 +107,7 @@ conf:
 		Expect(NewClusterSetup().
 			Install(Kuma(config_core.Zone, WithGlobalAddress(globalCP.GetKDSServerAddress()))). // do not deploy Egress
 			Install(NamespaceWithSidecarInjection(TestNamespace)).
-			Install(DemoClientK8s(nonDefaultMesh, TestNamespace)).
+			Install(democlient.Install(democlient.WithNamespace(TestNamespace), democlient.WithMesh(nonDefaultMesh))).
 			Install(testserver.Install(
 				testserver.WithName("es-test-server"),
 				testserver.WithNamespace("default"),

--- a/test/e2e_env/kubernetes/externalservices/externalservices.go
+++ b/test/e2e_env/kubernetes/externalservices/externalservices.go
@@ -8,6 +8,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	. "github.com/kumahq/kuma/test/framework"
+	"github.com/kumahq/kuma/test/framework/deployments/democlient"
 	"github.com/kumahq/kuma/test/framework/deployments/testserver"
 	"github.com/kumahq/kuma/test/framework/envs/kubernetes"
 )
@@ -44,7 +45,7 @@ spec:
 			Install(YamlK8s(meshPassthroughEnabled)).
 			Install(Namespace(namespace)).
 			Install(NamespaceWithSidecarInjection(clientNamespace)).
-			Install(DemoClientK8s(meshName, clientNamespace)).
+			Install(democlient.Install(democlient.WithNamespace(clientNamespace), democlient.WithMesh(meshName))).
 			Setup(kubernetes.Cluster)
 		Expect(err).ToNot(HaveOccurred())
 

--- a/test/e2e_env/kubernetes/gateway/cross-mesh.go
+++ b/test/e2e_env/kubernetes/gateway/cross-mesh.go
@@ -12,6 +12,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	. "github.com/kumahq/kuma/test/framework"
+	"github.com/kumahq/kuma/test/framework/deployments/democlient"
 	"github.com/kumahq/kuma/test/framework/deployments/testserver"
 	"github.com/kumahq/kuma/test/framework/envs/kubernetes"
 )
@@ -107,9 +108,9 @@ func CrossMeshGatewayOnKubernetes() {
 			Install(Namespace(gatewayClientOutsideMesh)).
 			Install(echoServerApp(gatewayMesh)).
 			Install(echoServerApp(gatewayOtherMesh)).
-			Install(DemoClientK8s(gatewayOtherMesh, gatewayClientNamespaceOtherMesh)).
-			Install(DemoClientK8s(gatewayMesh, gatewayClientNamespaceSameMesh)).
-			Install(DemoClientK8s(gatewayMesh, gatewayClientOutsideMesh)) // this will not be in the mesh
+			Install(democlient.Install(democlient.WithNamespace(gatewayClientNamespaceOtherMesh), democlient.WithMesh(gatewayOtherMesh))).
+			Install(democlient.Install(democlient.WithNamespace(gatewayClientNamespaceSameMesh), democlient.WithMesh(gatewayMesh))).
+			Install(democlient.Install(democlient.WithNamespace(gatewayClientOutsideMesh), democlient.WithMesh(gatewayMesh))) // this will not be in the mesh
 
 		Expect(setup.Setup(kubernetes.Cluster)).To(Succeed())
 

--- a/test/e2e_env/kubernetes/gateway/resources.go
+++ b/test/e2e_env/kubernetes/gateway/resources.go
@@ -8,6 +8,7 @@ import (
 
 	. "github.com/kumahq/kuma/test/framework"
 	"github.com/kumahq/kuma/test/framework/client"
+	"github.com/kumahq/kuma/test/framework/deployments/democlient"
 	"github.com/kumahq/kuma/test/framework/deployments/testserver"
 	"github.com/kumahq/kuma/test/framework/envs/kubernetes"
 )
@@ -83,8 +84,8 @@ spec:
 			Install(NamespaceWithSidecarInjection(namespace)).
 			Install(Namespace(waitingClientNamespace)).
 			Install(Namespace(curlingClientNamespace)).
-			Install(DemoClientK8s(meshName, waitingClientNamespace)).
-			Install(DemoClientK8s(meshName, curlingClientNamespace)).
+			Install(democlient.Install(democlient.WithNamespace(waitingClientNamespace), democlient.WithMesh(meshName))).
+			Install(democlient.Install(democlient.WithNamespace(curlingClientNamespace), democlient.WithMesh(meshName))).
 			Install(YamlK8s(meshGatewayWithoutLimit)).
 			Install(YamlK8s(MkGatewayInstance(gatewayName, namespace, meshName))).
 			Install(YamlK8s(httpRoute)).

--- a/test/e2e_env/kubernetes/inspect/inspect.go
+++ b/test/e2e_env/kubernetes/inspect/inspect.go
@@ -7,6 +7,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	. "github.com/kumahq/kuma/test/framework"
+	"github.com/kumahq/kuma/test/framework/deployments/democlient"
 	"github.com/kumahq/kuma/test/framework/envs/kubernetes"
 )
 
@@ -18,7 +19,7 @@ func Inspect() {
 		err := NewClusterSetup().
 			Install(NamespaceWithSidecarInjection(nsName)).
 			Install(MeshKubernetes(meshName)).
-			Install(DemoClientK8s(meshName, nsName)).
+			Install(democlient.Install(democlient.WithNamespace(nsName), democlient.WithMesh(meshName))).
 			Setup(kubernetes.Cluster)
 		Expect(err).ToNot(HaveOccurred())
 	})

--- a/test/e2e_env/kubernetes/k8s_api_bypass/k8s_api_bypass.go
+++ b/test/e2e_env/kubernetes/k8s_api_bypass/k8s_api_bypass.go
@@ -7,6 +7,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	. "github.com/kumahq/kuma/test/framework"
+	"github.com/kumahq/kuma/test/framework/deployments/democlient"
 	"github.com/kumahq/kuma/test/framework/envs/kubernetes"
 )
 
@@ -36,7 +37,7 @@ spec:
 		err := NewClusterSetup().
 			Install(YamlK8s(fmt.Sprintf(meshDefaultMtlsOn, "true"))).
 			Install(NamespaceWithSidecarInjection(namespace)).
-			Install(DemoClientK8s(meshName, namespace)).
+			Install(democlient.Install(democlient.WithNamespace(namespace), democlient.WithMesh(meshName))).
 			Setup(kubernetes.Cluster)
 		Expect(err).ToNot(HaveOccurred())
 

--- a/test/e2e_env/kubernetes/kic/kong_ingress.go
+++ b/test/e2e_env/kubernetes/kic/kong_ingress.go
@@ -9,6 +9,7 @@ import (
 
 	. "github.com/kumahq/kuma/test/framework"
 	"github.com/kumahq/kuma/test/framework/client"
+	"github.com/kumahq/kuma/test/framework/deployments/democlient"
 	"github.com/kumahq/kuma/test/framework/deployments/kic"
 	"github.com/kumahq/kuma/test/framework/deployments/testserver"
 	"github.com/kumahq/kuma/test/framework/envs/kubernetes"
@@ -54,7 +55,7 @@ func KICKubernetes() {
 			Install(MTLSMeshKubernetes(mesh)).
 			Install(NamespaceWithSidecarInjection(namespace)).
 			Install(Namespace(namespaceOutsideMesh)).
-			Install(DemoClientK8s(mesh, namespaceOutsideMesh)). // this will not be in the mesh
+			Install(democlient.Install(democlient.WithNamespace(namespaceOutsideMesh))). // the will not be in the mesh
 			Install(kic.KongIngressController(
 				kic.WithNamespace(namespace),
 				kic.WithMesh(mesh),

--- a/test/e2e_env/kubernetes/meshcircuitbreaker/meshcircuitbreaker.go
+++ b/test/e2e_env/kubernetes/meshcircuitbreaker/meshcircuitbreaker.go
@@ -10,6 +10,7 @@ import (
 	"github.com/kumahq/kuma/pkg/plugins/policies/meshcircuitbreaker/api/v1alpha1"
 	. "github.com/kumahq/kuma/test/framework"
 	. "github.com/kumahq/kuma/test/framework/client"
+	"github.com/kumahq/kuma/test/framework/deployments/democlient"
 	"github.com/kumahq/kuma/test/framework/deployments/testserver"
 	"github.com/kumahq/kuma/test/framework/envs/kubernetes"
 )
@@ -22,7 +23,7 @@ func MeshCircuitBreaker() {
 		err := NewClusterSetup().
 			Install(MeshKubernetes(mesh)).
 			Install(NamespaceWithSidecarInjection(namespace)).
-			Install(DemoClientK8s(mesh, namespace)).
+			Install(democlient.Install(democlient.WithNamespace(namespace), democlient.WithMesh(mesh))).
 			Install(testserver.Install(testserver.WithMesh(mesh), testserver.WithNamespace(namespace))).
 			Setup(kubernetes.Cluster)
 		Expect(err).ToNot(HaveOccurred())

--- a/test/e2e_env/kubernetes/meshtimeout/meshtimeout.go
+++ b/test/e2e_env/kubernetes/meshtimeout/meshtimeout.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/kumahq/kuma/pkg/plugins/policies/meshtimeout/api/v1alpha1"
 	. "github.com/kumahq/kuma/test/framework"
+	"github.com/kumahq/kuma/test/framework/deployments/democlient"
 	"github.com/kumahq/kuma/test/framework/deployments/testserver"
 	"github.com/kumahq/kuma/test/framework/envs/kubernetes"
 )
@@ -22,7 +23,7 @@ func MeshTimeout() {
 		err := NewClusterSetup().
 			Install(MeshKubernetes(mesh)).
 			Install(NamespaceWithSidecarInjection(namespace)).
-			Install(DemoClientK8s(mesh, namespace)).
+			Install(democlient.Install(democlient.WithNamespace(namespace), democlient.WithMesh(mesh))).
 			Install(testserver.Install(testserver.WithMesh(mesh), testserver.WithNamespace(namespace))).
 			Setup(kubernetes.Cluster)
 		Expect(err).ToNot(HaveOccurred())

--- a/test/e2e_env/kubernetes/observability/meshtrace.go
+++ b/test/e2e_env/kubernetes/observability/meshtrace.go
@@ -7,6 +7,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	. "github.com/kumahq/kuma/test/framework"
+	"github.com/kumahq/kuma/test/framework/deployments/democlient"
 	obs "github.com/kumahq/kuma/test/framework/deployments/observability"
 	"github.com/kumahq/kuma/test/framework/deployments/testserver"
 	"github.com/kumahq/kuma/test/framework/envs/kubernetes"
@@ -45,7 +46,7 @@ func PluginTest() {
 		err := NewClusterSetup().
 			Install(NamespaceWithSidecarInjection(ns)).
 			Install(MeshKubernetes(mesh)).
-			Install(DemoClientK8s(mesh, ns)).
+			Install(democlient.Install(democlient.WithNamespace(ns), democlient.WithMesh(mesh))).
 			Install(testserver.Install(testserver.WithMesh(mesh), testserver.WithNamespace(ns))).
 			Install(obs.Install(obsDeployment, obs.WithNamespace(obsNs), obs.WithComponents(obs.JaegerComponent))).
 			Setup(kubernetes.Cluster)

--- a/test/e2e_env/kubernetes/observability/tracing.go
+++ b/test/e2e_env/kubernetes/observability/tracing.go
@@ -7,6 +7,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	. "github.com/kumahq/kuma/test/framework"
+	"github.com/kumahq/kuma/test/framework/deployments/democlient"
 	obs "github.com/kumahq/kuma/test/framework/deployments/observability"
 	"github.com/kumahq/kuma/test/framework/deployments/testserver"
 	"github.com/kumahq/kuma/test/framework/envs/kubernetes"
@@ -55,7 +56,7 @@ func Tracing() {
 		err := NewClusterSetup().
 			Install(NamespaceWithSidecarInjection(ns)).
 			Install(MeshKubernetes(mesh)).
-			Install(DemoClientK8s(mesh, ns)).
+			Install(democlient.Install(democlient.WithNamespace(ns), democlient.WithMesh(mesh))).
 			Install(testserver.Install(testserver.WithMesh(mesh), testserver.WithNamespace(ns))).
 			Install(obs.Install(obsDeployment, obs.WithNamespace(obsNs), obs.WithComponents(obs.JaegerComponent))).
 			Setup(kubernetes.Cluster)

--- a/test/e2e_env/kubernetes/trafficlog/tcp_logging.go
+++ b/test/e2e_env/kubernetes/trafficlog/tcp_logging.go
@@ -12,6 +12,7 @@ import (
 	"github.com/pkg/errors"
 
 	. "github.com/kumahq/kuma/test/framework"
+	"github.com/kumahq/kuma/test/framework/deployments/democlient"
 	"github.com/kumahq/kuma/test/framework/deployments/testserver"
 	"github.com/kumahq/kuma/test/framework/envs/kubernetes"
 )
@@ -118,7 +119,7 @@ spec:
 				Install(YamlK8s(trafficLog.String())).
 				Install(NamespaceWithSidecarInjection(trafficNamespace)).
 				Install(Namespace(tcpSinkNamespace)).
-				Install(DemoClientK8s(meshName, trafficNamespace)).
+				Install(democlient.Install(democlient.WithNamespace(trafficNamespace), democlient.WithMesh(meshName))).
 				Install(YamlK8s(tcpSink.String())).
 				Install(WaitPodsAvailable(tcpSinkNamespace, tcpSinkAppName)).
 				Install(testserver.Install(

--- a/test/e2e_env/kubernetes/virtualoutbound/virtualoutbound.go
+++ b/test/e2e_env/kubernetes/virtualoutbound/virtualoutbound.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	. "github.com/kumahq/kuma/test/framework"
+	"github.com/kumahq/kuma/test/framework/deployments/democlient"
 	"github.com/kumahq/kuma/test/framework/deployments/testserver"
 	"github.com/kumahq/kuma/test/framework/envs/kubernetes"
 )
@@ -18,7 +19,7 @@ func VirtualOutbound() {
 		err := NewClusterSetup().
 			Install(MeshKubernetes(meshName)).
 			Install(NamespaceWithSidecarInjection(namespace)).
-			Install(DemoClientK8s(meshName, namespace)).
+			Install(democlient.Install(democlient.WithNamespace(namespace), democlient.WithMesh(meshName))).
 			Install(testserver.Install(
 				testserver.WithMesh(meshName),
 				testserver.WithNamespace(namespace),

--- a/test/e2e_env/multizone/connectivity/connectivity.go
+++ b/test/e2e_env/multizone/connectivity/connectivity.go
@@ -6,6 +6,7 @@ import (
 
 	. "github.com/kumahq/kuma/test/framework"
 	"github.com/kumahq/kuma/test/framework/client"
+	"github.com/kumahq/kuma/test/framework/deployments/democlient"
 	"github.com/kumahq/kuma/test/framework/deployments/testserver"
 	"github.com/kumahq/kuma/test/framework/envs/multizone"
 )
@@ -20,7 +21,7 @@ func Connectivity() {
 
 		err := NewClusterSetup().
 			Install(NamespaceWithSidecarInjection(namespace)).
-			Install(DemoClientK8s(meshName, namespace)).
+			Install(democlient.Install(democlient.WithNamespace(namespace), democlient.WithMesh(meshName))).
 			Setup(multizone.KubeZone1)
 		Expect(err).ToNot(HaveOccurred())
 

--- a/test/e2e_env/multizone/gateway/cross-mesh.go
+++ b/test/e2e_env/multizone/gateway/cross-mesh.go
@@ -11,6 +11,7 @@ import (
 	k8s_gateway "github.com/kumahq/kuma/test/e2e_env/kubernetes/gateway"
 	universal_gateway "github.com/kumahq/kuma/test/e2e_env/universal/gateway"
 	. "github.com/kumahq/kuma/test/framework"
+	"github.com/kumahq/kuma/test/framework/deployments/democlient"
 	"github.com/kumahq/kuma/test/framework/deployments/testserver"
 	"github.com/kumahq/kuma/test/framework/envoy_admin/stats"
 	"github.com/kumahq/kuma/test/framework/envs/multizone"
@@ -88,8 +89,8 @@ func CrossMeshGatewayOnMultizone() {
 			Install(NamespaceWithSidecarInjection(gatewayClientNamespaceSameMesh)).
 			Install(echoServerApp(gatewayMesh)).
 			Install(echoServerApp(gatewayOtherMesh)).
-			Install(DemoClientK8s(gatewayOtherMesh, gatewayClientNamespaceOtherMesh)).
-			Install(DemoClientK8s(gatewayMesh, gatewayClientNamespaceSameMesh)).
+			Install(democlient.Install(democlient.WithMesh(gatewayOtherMesh), democlient.WithNamespace(gatewayClientNamespaceOtherMesh))).
+			Install(democlient.Install(democlient.WithMesh(gatewayMesh), democlient.WithNamespace(gatewayClientNamespaceSameMesh))).
 			Install(YamlK8s(crossMeshGatewayInstanceYaml)).
 			Install(YamlK8s(edgeGatewayInstanceYaml))
 		Expect(gatewayZoneSetup.Setup(multizone.KubeZone1)).To(Succeed())
@@ -97,8 +98,8 @@ func CrossMeshGatewayOnMultizone() {
 		otherZoneSetup := NewClusterSetup().
 			Install(NamespaceWithSidecarInjection(gatewayClientNamespaceOtherMesh)).
 			Install(NamespaceWithSidecarInjection(gatewayClientNamespaceSameMesh)).
-			Install(DemoClientK8s(gatewayOtherMesh, gatewayClientNamespaceOtherMesh)).
-			Install(DemoClientK8s(gatewayMesh, gatewayClientNamespaceSameMesh))
+			Install(democlient.Install(democlient.WithMesh(gatewayOtherMesh), democlient.WithNamespace(gatewayClientNamespaceOtherMesh))).
+			Install(democlient.Install(democlient.WithMesh(gatewayMesh), democlient.WithNamespace(gatewayClientNamespaceSameMesh)))
 		Expect(otherZoneSetup.Setup(multizone.KubeZone2)).To(Succeed())
 	})
 

--- a/test/e2e_env/multizone/healthcheck/healthcheck.go
+++ b/test/e2e_env/multizone/healthcheck/healthcheck.go
@@ -9,6 +9,7 @@ import (
 	"github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	. "github.com/kumahq/kuma/test/framework"
 	"github.com/kumahq/kuma/test/framework/client"
+	"github.com/kumahq/kuma/test/framework/deployments/democlient"
 	"github.com/kumahq/kuma/test/framework/envs/multizone"
 )
 
@@ -24,7 +25,7 @@ func ApplicationOnUniversalClientOnK8s() {
 
 		err = NewClusterSetup().
 			Install(NamespaceWithSidecarInjection(namespace)).
-			Install(DemoClientK8s(meshName, namespace)).
+			Install(democlient.Install(democlient.WithNamespace(namespace), democlient.WithMesh(meshName))).
 			Setup(multizone.KubeZone1)
 		Expect(err).ToNot(HaveOccurred())
 

--- a/test/e2e_env/multizone/inbound_communication/inbound_passthrough.go
+++ b/test/e2e_env/multizone/inbound_communication/inbound_passthrough.go
@@ -6,6 +6,7 @@ import (
 
 	. "github.com/kumahq/kuma/test/framework"
 	"github.com/kumahq/kuma/test/framework/client"
+	"github.com/kumahq/kuma/test/framework/deployments/democlient"
 	"github.com/kumahq/kuma/test/framework/deployments/testserver"
 	"github.com/kumahq/kuma/test/framework/envs/multizone"
 )
@@ -68,7 +69,7 @@ func InboundPassthrough() {
 		// Kubernetes Zone 1
 		Expect(NewClusterSetup().
 			Install(NamespaceWithSidecarInjection(namespace)).
-			Install(DemoClientK8s(mesh, namespace)).
+			Install(democlient.Install(democlient.WithNamespace(namespace), democlient.WithMesh(mesh))).
 			Install(testserver.Install(
 				testserver.WithNamespace(namespace),
 				testserver.WithMesh(mesh),

--- a/test/e2e_env/multizone/inbound_communication/inbound_passthrough_disabled.go
+++ b/test/e2e_env/multizone/inbound_communication/inbound_passthrough_disabled.go
@@ -6,6 +6,7 @@ import (
 
 	. "github.com/kumahq/kuma/test/framework"
 	"github.com/kumahq/kuma/test/framework/client"
+	"github.com/kumahq/kuma/test/framework/deployments/democlient"
 	"github.com/kumahq/kuma/test/framework/deployments/testserver"
 	"github.com/kumahq/kuma/test/framework/envs/multizone"
 )
@@ -62,7 +63,7 @@ func InboundPassthroughDisabled() {
 		// Kubernetes Zone 1
 		Expect(NewClusterSetup().
 			Install(NamespaceWithSidecarInjection(namespace)).
-			Install(DemoClientK8s(mesh, namespace)).
+			Install(democlient.Install(democlient.WithNamespace(namespace), democlient.WithMesh(mesh))).
 			Install(testserver.Install(
 				testserver.WithNamespace(namespace),
 				testserver.WithMesh(mesh),

--- a/test/e2e_env/multizone/localityawarelb/locality_multizone_hybrid.go
+++ b/test/e2e_env/multizone/localityawarelb/locality_multizone_hybrid.go
@@ -9,6 +9,7 @@ import (
 
 	. "github.com/kumahq/kuma/test/framework"
 	"github.com/kumahq/kuma/test/framework/client"
+	"github.com/kumahq/kuma/test/framework/deployments/democlient"
 	"github.com/kumahq/kuma/test/framework/envoy_admin/stats"
 	"github.com/kumahq/kuma/test/framework/envs/multizone"
 )
@@ -101,7 +102,7 @@ func ExternalServicesWithLocalityAwareLb() {
 		// Kubernetes Zone 1
 		Expect(NewClusterSetup().
 			Install(NamespaceWithSidecarInjection(namespace)).
-			Install(DemoClientK8s(mesh, namespace)).
+			Install(democlient.Install(democlient.WithNamespace(namespace), democlient.WithMesh(mesh))).
 			Setup(multizone.KubeZone1)).ToNot(HaveOccurred())
 
 		Expect(NewClusterSetup().

--- a/test/e2e_env/multizone/meshtrafficpermission/meshtrafficpermission.go
+++ b/test/e2e_env/multizone/meshtrafficpermission/meshtrafficpermission.go
@@ -7,6 +7,7 @@ import (
 
 	policies_api "github.com/kumahq/kuma/pkg/plugins/policies/meshtrafficpermission/api/v1alpha1"
 	. "github.com/kumahq/kuma/test/framework"
+	"github.com/kumahq/kuma/test/framework/deployments/democlient"
 	"github.com/kumahq/kuma/test/framework/envs/multizone"
 )
 
@@ -33,7 +34,7 @@ func MeshTrafficPermission() {
 		// Kubernetes Zone 1
 		err = NewClusterSetup().
 			Install(NamespaceWithSidecarInjection(namespace)).
-			Install(DemoClientK8s(meshName, namespace)).
+			Install(democlient.Install(democlient.WithNamespace(namespace), democlient.WithMesh(meshName))).
 			Setup(multizone.KubeZone1)
 		Expect(err).ToNot(HaveOccurred())
 

--- a/test/e2e_env/multizone/sync/sync.go
+++ b/test/e2e_env/multizone/sync/sync.go
@@ -9,6 +9,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	. "github.com/kumahq/kuma/test/framework"
+	"github.com/kumahq/kuma/test/framework/deployments/democlient"
 	"github.com/kumahq/kuma/test/framework/envs/multizone"
 )
 
@@ -22,7 +23,7 @@ func Sync() {
 
 		err := NewClusterSetup().
 			Install(NamespaceWithSidecarInjection(namespace)).
-			Install(DemoClientK8s(meshName, namespace)).
+			Install(democlient.Install(democlient.WithNamespace(namespace), democlient.WithMesh(meshName))).
 			Setup(multizone.KubeZone1)
 		Expect(err).ToNot(HaveOccurred())
 

--- a/test/e2e_env/multizone/trafficpermission/trafficpermission.go
+++ b/test/e2e_env/multizone/trafficpermission/trafficpermission.go
@@ -7,6 +7,7 @@ import (
 
 	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	. "github.com/kumahq/kuma/test/framework"
+	"github.com/kumahq/kuma/test/framework/deployments/democlient"
 	"github.com/kumahq/kuma/test/framework/envs/multizone"
 )
 
@@ -31,7 +32,7 @@ func TrafficPermission() {
 		// Kubernetes Zone 1
 		err = NewClusterSetup().
 			Install(NamespaceWithSidecarInjection(namespace)).
-			Install(DemoClientK8s(meshName, namespace)).
+			Install(democlient.Install(democlient.WithNamespace(namespace), democlient.WithMesh(meshName))).
 			Setup(multizone.KubeZone1)
 		Expect(err).ToNot(HaveOccurred())
 

--- a/test/e2e_env/multizone/zoneegress/internal_services.go
+++ b/test/e2e_env/multizone/zoneegress/internal_services.go
@@ -7,6 +7,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	. "github.com/kumahq/kuma/test/framework"
+	"github.com/kumahq/kuma/test/framework/deployments/democlient"
 	"github.com/kumahq/kuma/test/framework/deployments/testserver"
 	"github.com/kumahq/kuma/test/framework/envoy_admin/stats"
 	"github.com/kumahq/kuma/test/framework/envs/multizone"
@@ -52,7 +53,7 @@ routing:
 		// Kubernetes Zone 1
 		err = NewClusterSetup().
 			Install(NamespaceWithSidecarInjection(namespace)).
-			Install(DemoClientK8s(meshName, namespace)).
+			Install(democlient.Install(democlient.WithNamespace(namespace), democlient.WithMesh(meshName))).
 			Setup(multizone.KubeZone1)
 		Expect(err).ToNot(HaveOccurred())
 

--- a/test/framework/deployments/democlient/deployment.go
+++ b/test/framework/deployments/democlient/deployment.go
@@ -1,4 +1,4 @@
-package testserver
+package democlient
 
 import (
 	"github.com/pkg/errors"
@@ -7,30 +7,21 @@ import (
 )
 
 type DeploymentOpts struct {
-	Name               string
-	Namespace          string
-	Mesh               string
-	ReachableServices  []string
-	WithStatefulSet    bool
-	ServiceAccount     string
-	echoArgs           []string
-	healthcheckTCPArgs []string
-	Replicas           int32
-	WaitingToBeReady   bool
-	EnableProbes       bool
-	PodAnnotations     map[string]string
-	NodeSelector       map[string]string
+	Name             string
+	Namespace        string
+	Mesh             string
+	WaitingToBeReady bool
+	PodAnnotations   map[string]string
+	NodeSelector     map[string]string
 }
 
 func DefaultDeploymentOpts() DeploymentOpts {
 	return DeploymentOpts{
 		Mesh:             "default",
-		Name:             "test-server",
+		Name:             "demo-client",
 		Namespace:        framework.TestNamespace,
-		Replicas:         1,
 		WaitingToBeReady: true,
 		PodAnnotations:   map[string]string{},
-		EnableProbes:     true,
 	}
 }
 
@@ -48,33 +39,9 @@ func WithName(name string) DeploymentOptsFn {
 	}
 }
 
-func WithReachableServices(services ...string) DeploymentOptsFn {
-	return func(opts *DeploymentOpts) {
-		opts.ReachableServices = services
-	}
-}
-
 func WithNamespace(namespace string) DeploymentOptsFn {
 	return func(opts *DeploymentOpts) {
 		opts.Namespace = namespace
-	}
-}
-
-func WithReplicas(n int32) DeploymentOptsFn {
-	return func(opts *DeploymentOpts) {
-		opts.Replicas = n
-	}
-}
-
-func WithStatefulSet(apply bool) DeploymentOptsFn {
-	return func(opts *DeploymentOpts) {
-		opts.WithStatefulSet = apply
-	}
-}
-
-func WithServiceAccount(serviceAccountName string) DeploymentOptsFn {
-	return func(opts *DeploymentOpts) {
-		opts.ServiceAccount = serviceAccountName
 	}
 }
 
@@ -84,27 +51,9 @@ func WithoutWaitingToBeReady() DeploymentOptsFn {
 	}
 }
 
-func WithEchoArgs(args ...string) DeploymentOptsFn {
-	return func(opts *DeploymentOpts) {
-		opts.echoArgs = args
-	}
-}
-
-func WithHealthCheckTCPArgs(args ...string) DeploymentOptsFn {
-	return func(opts *DeploymentOpts) {
-		opts.healthcheckTCPArgs = args
-	}
-}
-
 func WithPodAnnotations(annotations map[string]string) DeploymentOptsFn {
 	return func(opts *DeploymentOpts) {
 		opts.PodAnnotations = annotations
-	}
-}
-
-func WithoutProbes() DeploymentOptsFn {
-	return func(opts *DeploymentOpts) {
-		opts.EnableProbes = false
 	}
 }
 

--- a/test/framework/deployments/democlient/kubernetes.go
+++ b/test/framework/deployments/democlient/kubernetes.go
@@ -1,0 +1,120 @@
+package democlient
+
+import (
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+
+	"github.com/kumahq/kuma/test/framework"
+)
+
+type k8SDeployment struct {
+	opts DeploymentOpts
+}
+
+func (k *k8SDeployment) Name() string {
+	return k.opts.Name
+}
+
+func (k *k8SDeployment) deployment() *appsv1.Deployment {
+	return &appsv1.Deployment{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Deployment",
+			APIVersion: "apps/v1",
+		},
+		ObjectMeta: meta(k.opts.Namespace, k.Name()),
+		Spec: appsv1.DeploymentSpec{
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{"app": k.Name()},
+			},
+			Strategy: appsv1.DeploymentStrategy{
+				RollingUpdate: &appsv1.RollingUpdateDeployment{
+					MaxSurge:       &intstr.IntOrString{Type: intstr.Int, IntVal: 1},
+					MaxUnavailable: &intstr.IntOrString{Type: intstr.Int, IntVal: 0},
+				},
+			},
+			Template: k.podSpec(),
+		},
+	}
+}
+
+func (k *k8SDeployment) podSpec() corev1.PodTemplateSpec {
+	return corev1.PodTemplateSpec{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels:      map[string]string{"app": k.Name()},
+			Annotations: k.getAnnotations(),
+		},
+		Spec: corev1.PodSpec{
+			NodeSelector: k.opts.NodeSelector,
+			Containers: []corev1.Container{
+				{
+					Name:            k.Name(),
+					ImagePullPolicy: "IfNotPresent",
+					Image:           framework.Config.GetUniversalImage(),
+					Ports: []corev1.ContainerPort{
+						{ContainerPort: 3000},
+					},
+					Command: []string{"ncat"},
+					Args:    []string{"-lk", "-p", "3000"},
+					Resources: corev1.ResourceRequirements{
+						Limits: corev1.ResourceList{
+							"cpu":    resource.MustParse("50m"),
+							"memory": resource.MustParse("64Mi"),
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func (k *k8SDeployment) getAnnotations() map[string]string {
+	annotations := make(map[string]string)
+	annotations["kuma.io/mesh"] = k.opts.Mesh
+	for key, value := range k.opts.PodAnnotations {
+		annotations[key] = value
+	}
+	return annotations
+}
+
+func meta(namespace string, name string) metav1.ObjectMeta {
+	return metav1.ObjectMeta{
+		Name:      name,
+		Namespace: namespace,
+		Labels:    map[string]string{"app": name},
+	}
+}
+
+func (k *k8SDeployment) Deploy(cluster framework.Cluster) error {
+	funcs := []framework.InstallFunc{framework.YamlK8sObject(k.deployment())}
+	if k.opts.WaitingToBeReady {
+		funcs = append(funcs,
+			framework.WaitNumPods(k.opts.Namespace, 1, k.Name()),
+			framework.WaitPodsAvailable(k.opts.Namespace, k.Name()),
+		)
+	}
+	return framework.Combine(funcs...)(cluster)
+}
+
+func (k *k8SDeployment) Delete(cluster framework.Cluster) error {
+	// todo(jakubdyszkiewicz) right now we delete TestNamespace before we Dismiss the cluster
+	// This means that namespace is no longer available so the code below would throw an error
+	// If we ever switch DemoClient to be deployment and remove manual deletion of TestNamespace
+	// then we can rely on code below to delete tht deployment.
+
+	// k8s.KubectlDeleteFromString(
+	// 	cluster.GetTesting(),
+	// 	cluster.GetKubectlOptions(framework.TestNamespace),
+	// 	service,
+	// )
+	// k8s.KubectlDeleteFromString(
+	// 	cluster.GetTesting(),
+	// 	cluster.GetKubectlOptions(framework.TestNamespace),
+	// 	fmt.Sprintf(deployment, k.opts.Mesh, framework.GetUniversalImage()),
+	// )
+	return nil
+}
+
+var _ Deployment = &k8SDeployment{}

--- a/test/framework/interface.go
+++ b/test/framework/interface.go
@@ -295,22 +295,28 @@ func WithEgressEnvoyAdminTunnel() KumaDeploymentOption {
 	})
 }
 
+type CNIVersion string
+
+const (
+	CNIVersion1 CNIVersion = "v1"
+	CNIVersion2 CNIVersion = "v2"
+)
+
 func WithEgress() KumaDeploymentOption {
 	return KumaOptionFunc(func(o *kumaDeploymentOptions) {
 		o.zoneEgress = true
 	})
 }
 
-func WithCNI() KumaDeploymentOption {
+func WithCNI(version ...CNIVersion) KumaDeploymentOption {
+	if len(version) > 1 {
+		panic("only one arg is supported")
+	}
 	return KumaOptionFunc(func(o *kumaDeploymentOptions) {
 		o.cni = true
-	})
-}
-
-func WithCNIV1() KumaDeploymentOption {
-	return KumaOptionFunc(func(o *kumaDeploymentOptions) {
-		o.cni = true
-		o.cniV1 = true
+		if len(version) == 1 && version[0] == CNIVersion1 {
+			o.cniV1 = true
+		}
 	})
 }
 


### PR DESCRIPTION
This is more practical to do complex configuration of the demo client.

One example of this is when adding annotations to the pod. Also rewrite CNI compatibility test to make it easier to read

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [x] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
