### PR TITLE
refactor(helm): use values instead of dict in CP deployment template

### DIFF
--- a/app/kumactl/cmd/install/testdata/install-control-plane.dump-values.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.dump-values.yaml
@@ -273,39 +273,12 @@ controlPlane:
   hostNetwork: false
 
   # -- Security context at the pod level for control plane.
-  podSecurityContext: {}
-#    # The values below are examples. More values can be added as needed, since the field resolves as free form.
-#    # -- Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does.
-#    runAsNonRoot: true
-#    # -- The UID to run the entrypoint of the container process.
-#    runAsUser: 1000
-#    # -- The GID to run the entrypoint of the container process.
-#    runAsGroup: 3000
-#    # -- A special supplemental group that applies to all containers in a pod
-#    fsGroup: 2000
-#    fsGroupChangePolicy:
-#    # to support additional pod level securityContext parameters, please check:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#podsecuritycontext-v1-core
+  podSecurityContext:
+    runAsNonRoot: true
 
   # -- Security context at the container level for control plane.
-  containerSecurityContext: {} #for overlapping securityContext between pod and container, the container's value take precedence
-#    # The values below are examples. More values can be added as needed, since the field resolves as free form.
-#    # -- Controls whether a process can gain more privileges than its parent process.
-#    allowPrivilegeEscalation: false
-#    # -- The capabilities to add/drop when running containers
-#    capabilities:
-#      drop:
-#        - all
-#    # -- Whether this container has a read-only root filesystem.
-#    readOnlyRootFilesystem: true
-#    # -- Run container in privileged mode. Processes in privileged containers are essentially equivalent to root on the host.
-#    privileged: false
-#    # -- Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does.
-#    runAsNonRoot: true
-#    # -- The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext.
-#    runAsUser: 1000
-#    # -- The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in PodSecurityContext.
-#    runAsGroup: 3000
-#    #to support additional container level securityContext parameters, please check:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#securitycontext-v1-core
+  containerSecurityContext:
+    readOnlyRootFilesystem: true
 
 cni:
   # -- Install Kuma with CNI instead of proxy init container

--- a/deployments/charts/kuma/README.md
+++ b/deployments/charts/kuma/README.md
@@ -78,8 +78,8 @@ A Helm chart for the Kuma Control Plane
 | controlPlane.webhooks.validator.additionalRules | string | `""` | Additional rules to apply on Kuma validator webhook. Useful when building custom policy on top of Kuma. |
 | controlPlane.webhooks.ownerReference.additionalRules | string | `""` | Additional rules to apply on Kuma owner reference webhook. Useful when building custom policy on top of Kuma. |
 | controlPlane.hostNetwork | bool | `false` | Specifies if the deployment should be started in hostNetwork mode. |
-| controlPlane.podSecurityContext | object | `{}` | Security context at the pod level for control plane. |
-| controlPlane.containerSecurityContext | object | `{}` | Security context at the container level for control plane. |
+| controlPlane.podSecurityContext | object | `{"runAsNonRoot":true}` | Security context at the pod level for control plane. |
+| controlPlane.containerSecurityContext | object | `{"readOnlyRootFilesystem":true}` | Security context at the container level for control plane. |
 | cni.enabled | bool | `false` | Install Kuma with CNI instead of proxy init container |
 | cni.chained | bool | `false` | Install CNI in chained mode |
 | cni.netDir | string | `"/etc/cni/multus/net.d"` | Set the CNI install directory |

--- a/deployments/charts/kuma/templates/cp-deployment.yaml
+++ b/deployments/charts/kuma/templates/cp-deployment.yaml
@@ -61,7 +61,7 @@ spec:
       topologySpreadConstraints: {{ tpl (toYaml . | nindent 8) $ }}
       {{- end }}
       securityContext:
-      {{- toYaml (mergeOverwrite (dict "runAsNonRoot" true) .Values.controlPlane.podSecurityContext) | trim | nindent 8 }}
+      {{- toYaml .Values.controlPlane.podSecurityContext | trim | nindent 8 }}
       serviceAccountName: {{ include "kuma.name" . }}-control-plane
       automountServiceAccountToken: {{ .Values.controlPlane.automountServiceAccountToken }}
       {{- with .Values.controlPlane.nodeSelector }}
@@ -111,7 +111,7 @@ spec:
           image: {{ include "kuma.formatImage" (dict "image" .Values.controlPlane.image "root" $) | quote }}
           imagePullPolicy: {{ .Values.controlPlane.image.pullPolicy }}
           securityContext:
-          {{- toYaml (mergeOverwrite (dict "readOnlyRootFilesystem" true) .Values.controlPlane.containerSecurityContext) | trim | nindent 12 }}
+          {{- toYaml .Values.controlPlane.containerSecurityContext | trim | nindent 12 }}
           env:
           {{- range $key, $value := $mergedEnv }}
             - name: {{ $key }}

--- a/deployments/charts/kuma/values.yaml
+++ b/deployments/charts/kuma/values.yaml
@@ -273,39 +273,12 @@ controlPlane:
   hostNetwork: false
 
   # -- Security context at the pod level for control plane.
-  podSecurityContext: {}
-#    # The values below are examples. More values can be added as needed, since the field resolves as free form.
-#    # -- Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does.
-#    runAsNonRoot: true
-#    # -- The UID to run the entrypoint of the container process.
-#    runAsUser: 1000
-#    # -- The GID to run the entrypoint of the container process.
-#    runAsGroup: 3000
-#    # -- A special supplemental group that applies to all containers in a pod
-#    fsGroup: 2000
-#    fsGroupChangePolicy:
-#    # to support additional pod level securityContext parameters, please check:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#podsecuritycontext-v1-core
+  podSecurityContext:
+    runAsNonRoot: true
 
   # -- Security context at the container level for control plane.
-  containerSecurityContext: {} #for overlapping securityContext between pod and container, the container's value take precedence
-#    # The values below are examples. More values can be added as needed, since the field resolves as free form.
-#    # -- Controls whether a process can gain more privileges than its parent process.
-#    allowPrivilegeEscalation: false
-#    # -- The capabilities to add/drop when running containers
-#    capabilities:
-#      drop:
-#        - all
-#    # -- Whether this container has a read-only root filesystem.
-#    readOnlyRootFilesystem: true
-#    # -- Run container in privileged mode. Processes in privileged containers are essentially equivalent to root on the host.
-#    privileged: false
-#    # -- Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does.
-#    runAsNonRoot: true
-#    # -- The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext.
-#    runAsUser: 1000
-#    # -- The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in PodSecurityContext.
-#    runAsGroup: 3000
-#    #to support additional container level securityContext parameters, please check:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#securitycontext-v1-core
+  containerSecurityContext:
+    readOnlyRootFilesystem: true
 
 cni:
   # -- Install Kuma with CNI instead of proxy init container


### PR DESCRIPTION
Introduced in #6121, forgotten in #6177 

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues -- #6049 
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [x] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
