### PR TITLE
chore(helm): add kube-linter ignore annotations for CNI DaemonSet

### DIFF
--- a/app/kumactl/cmd/install/testdata/install-control-plane.cni-enabled.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.cni-enabled.golden.yaml
@@ -431,6 +431,10 @@ apiVersion: apps/v1
 metadata:
   name: kuma-cni-node
   namespace: kube-system
+  annotations:
+    ignore-check.kube-linter.io/host-network: "The containers modify the host's network namespace"
+    ignore-check.kube-linter.io/no-read-only-root-fs: "The containers modify the filesystem"
+    ignore-check.kube-linter.io/run-as-non-root: "The containers modify /proc"
   labels:
     app: kuma-cni
     app.kubernetes.io/name: kuma

--- a/app/kumactl/cmd/install/testdata/install-control-plane.cni-legacy-enabled.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.cni-legacy-enabled.golden.yaml
@@ -419,6 +419,10 @@ apiVersion: apps/v1
 metadata:
   name: kuma-cni-node
   namespace: kube-system
+  annotations:
+    ignore-check.kube-linter.io/host-network: "The containers modify the host's network namespace"
+    ignore-check.kube-linter.io/no-read-only-root-fs: "The containers modify the filesystem"
+    ignore-check.kube-linter.io/run-as-non-root: "The containers modify /proc"
   labels:
     app: kuma-cni
     app.kubernetes.io/name: kuma

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/fix4935.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/fix4935.golden.yaml
@@ -499,6 +499,10 @@ apiVersion: apps/v1
 metadata:
   name: kuma-cni-node
   namespace: kube-system
+  annotations:
+    ignore-check.kube-linter.io/host-network: "The containers modify the host's network namespace"
+    ignore-check.kube-linter.io/no-read-only-root-fs: "The containers modify the filesystem"
+    ignore-check.kube-linter.io/run-as-non-root: "The containers modify /proc"
   labels:
     app: kuma-cni
     app.kubernetes.io/name: kuma

--- a/deployments/charts/kuma/templates/cni-daemonset.yaml
+++ b/deployments/charts/kuma/templates/cni-daemonset.yaml
@@ -4,6 +4,10 @@ apiVersion: apps/v1
 metadata:
   name: {{ include "kuma.name" . }}-cni-node
   namespace: kube-system
+  annotations:
+    ignore-check.kube-linter.io/host-network: "The containers modify the host's network namespace"
+    ignore-check.kube-linter.io/no-read-only-root-fs: "The containers modify the filesystem"
+    ignore-check.kube-linter.io/run-as-non-root: "The containers modify /proc"
   labels: {{- include "kuma.cniLabels" . | nindent 4 }}
 spec:
   selector:


### PR DESCRIPTION
### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues -- #6049 
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [x] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
