### PR TITLE
fix(helm): set migration container resources and securityContext

### DIFF
--- a/app/kumactl/cmd/install/testdata/install-control-plane.global-universal-on-k8s.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.global-universal-on-k8s.golden.yaml
@@ -146,6 +146,8 @@ spec:
         - name: migration
           image: "docker.io/kumahq/kuma-cp:0.0.1"
           imagePullPolicy: IfNotPresent
+          securityContext:
+            readOnlyRootFilesystem: true
           env:
             - name: KUMA_DEFAULTS_SKIP_MESH_CREATION
               value: "false"
@@ -172,6 +174,12 @@ spec:
             - up
             - --log-level=info
             - --config-file=/etc/kuma.io/kuma-control-plane/config.yaml
+          resources:
+            limits:
+              memory: 256Mi
+            requests:
+              cpu: 500m
+              memory: 256Mi
           volumeMounts:
             - name: postgres-client-certs
               mountPath: /var/run/secrets/kuma.io/postgres-client-certs

--- a/deployments/charts/kuma/templates/cp-deployment.yaml
+++ b/deployments/charts/kuma/templates/cp-deployment.yaml
@@ -79,6 +79,8 @@ spec:
         - name: migration
           image: {{ include "kuma.formatImage" (dict "image" .Values.controlPlane.image "root" $) | quote }}
           imagePullPolicy: {{ .Values.controlPlane.image.pullPolicy }}
+          securityContext:
+          {{- toYaml .Values.controlPlane.containerSecurityContext | trim | nindent 12 }}
           env:
             {{- range $key, $value := $mergedEnv }}
             - name: {{ $key }}
@@ -96,6 +98,10 @@ spec:
             - up
             - --log-level=info
             - --config-file=/etc/kuma.io/kuma-control-plane/config.yaml
+          resources:
+            {{- if .Values.controlPlane.resources }}
+            {{- .Values.controlPlane.resources | toYaml | nindent 12 }}
+            {{- end }}
           volumeMounts:
           {{- if and .Values.postgres.tls.secretName (ne .Values.postgres.tls.mode "disable") }}
             - name: postgres-client-certs


### PR DESCRIPTION
~Waiting on #6253~

This just reapplies the same resource requests/limits as the main CP container, do we think this makes sense? Or do we need a separate `resources`?

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues -- #6049 
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [x] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
