### PR TITLE
ci(mk): move update-vulnerable-dependencies target to own file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,7 @@ include mk/dev.mk
 include mk/api.mk
 include mk/build.mk
 include mk/check.mk
+include mk/deps.mk
 include mk/test.mk
 include mk/generate.mk
 include mk/docker.mk

--- a/mk/check.mk
+++ b/mk/check.mk
@@ -58,7 +58,3 @@ check: format helm-lint golangci-lint shellcheck kube-lint ## Dev: Run code chec
 		git ls-files --other --directory --exclude-standard --no-empty-directory && \
 		false \
 	)
-
-.PHONY: update-vulnerable-dependencies
-update-vulnerable-dependencies:
-	@./tools/ci/update-vulnerable-dependencies.sh

--- a/mk/deps.mk
+++ b/mk/deps.mk
@@ -1,0 +1,3 @@
+.PHONY: update-vulnerable-dependencies
+update-vulnerable-dependencies:
+	@$(KUMA_DIR)/tools/ci/update-vulnerable-dependencies.sh


### PR DESCRIPTION
Manually backport #6199

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [x] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
