### PR TITLE
ci(mk): use GOENV on golangci-lint and do kubelint on all charts

### DIFF
--- a/mk/check.mk
+++ b/mk/check.mk
@@ -22,21 +22,17 @@ shellcheck:
 
 .PHONY: golangci-lint
 golangci-lint: ## Dev: Runs golangci-lint linter
-	GOMEMLIMIT=7GiB $(GOLANGCI_LINT) run --timeout=10m -v
+	GOMEMLIMIT=7GiB $(GOENV) $(GOLANGCI_LINT) run --timeout=10m -v
 
 .PHONY: golangci-lint-fmt
 golangci-lint-fmt:
-	GOMEMLIMIT=7GiB $(GOLANGCI_LINT) run --timeout=10m -v \
+	GOMEMLIMIT=7GiB $(GOENV) $(GOLANGCI_LINT) run --timeout=10m -v \
 		--disable-all \
 		--enable gofumpt
 
 .PHONY: helm-lint
 helm-lint:
-	for c in ./deployments/charts/*; do \
-  		if [ -d $$c ]; then \
-			$(HELM) lint --strict $$c; \
-		fi \
-	done
+	find ./deployments/charts -maxdepth 1 -mindepth 1 -type d -exec $(HELM) lint --strict {} \;
 
 .PHONY: ginkgo/unfocus
 ginkgo/unfocus:
@@ -54,7 +50,7 @@ format: fmt format/common
 
 .PHONY: kube-lint
 kube-lint:
-	$(KUBE_LINTER) lint deployments/charts/kuma
+	find ./deployments/charts -maxdepth 1 -mindepth 1 -type d -exec $(KUBE_LINTER) lint {} \;
 
 .PHONY: hadolint
 hadolint:


### PR DESCRIPTION
This enables overriding it more easily in sub projects

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [x] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
