### PR TITLE
chore(deps): bump go from 1.20.1 to 1.20.2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,10 +3,10 @@ version: 2.1 # Adds support for executors, parameterized jobs, etc
 reusable:
 
   constants:
-    - &go_version "1.20.1"
+    - &go_version "1.20.2"
 
   docker_images:
-    - &golang_image "cimg/go:1.20.1"
+    - &golang_image "cimg/go:1.20.2"
 
   vm_images:
     - &ubuntu_vm_image "ubuntu-2204:2022.10.2"

--- a/.github/workflows/blackbox-tests.yaml
+++ b/.github/workflows/blackbox-tests.yaml
@@ -16,7 +16,7 @@ jobs:
     - name: "Set up Go"
       uses: actions/setup-go@v3
       with:
-        go-version: "~1.20.1"
+        go-version: "~1.20.2"
 
     - name: "Configure go modules cache"
       uses: actions/cache@v3

--- a/.github/workflows/lifecycle.yml
+++ b/.github/workflows/lifecycle.yml
@@ -31,7 +31,7 @@ jobs:
           GITHUB_TOKEN: ${{ steps.github-app-token.outputs.token }}
       - uses: actions/setup-go@v3
         with:
-          go-version: "~1.20.1"
+          go-version: "~1.20.2"
       - name: refresh-active-branches
         run: |
           REPO="${{ github.repository }}"

--- a/.github/workflows/pr-comments.yaml
+++ b/.github/workflows/pr-comments.yaml
@@ -44,7 +44,7 @@ jobs:
           GITHUB_TOKEN: ${{ steps.github-app-token.outputs.token }}
       - uses: actions/setup-go@v3
         with:
-          go-version: "~1.20.1"
+          go-version: "~1.20.2"
       - uses: actions/cache@v3
         with:
           path: |

--- a/.github/workflows/update-insecure-dependencies.yaml
+++ b/.github/workflows/update-insecure-dependencies.yaml
@@ -39,7 +39,7 @@ jobs:
           ref: ${{ matrix.branch }}
       - uses: actions/setup-go@v3
         with:
-          go-version: "~1.20.1"
+          go-version: "~1.20.2"
       - name: "Install tools"
         run: |
           go install github.com/google/osv-scanner/cmd/osv-scanner@v1


### PR DESCRIPTION
### Checklist prior to review

Looks like this flake started to happen after Go upgrade
https://app.circleci.com/pipelines/github/kumahq/kuma/20498/workflows/5ee41e83-46f2-4536-b2d0-ba7ecf18febc/jobs/355715

only on arm64, looks like a bug in code coverage code. In 1.20.2 release note I see
```
go1.20.2 (released 2023-03-07) includes a security fix to the crypto/elliptic package, as well as bug fixes to the compiler, the covdata command, the linker, the runtime, and the crypto/ecdh, crypto/rsa, crypto/x509, os, and syscall packages. See the [Go 1.20.2 milestone](https://github.com/golang/go/issues?q=milestone%3AGo1.20.2+label%3ACherryPickApproved) on our issue tracker for details.
```

`the covdata command`. Let's try to update Go to see if that's the reason

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [X] [Link to relevant issue][1] as well as docs and UI issues --
- [X] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [X] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [X] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [X] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [X] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
