### PR TITLE
fix(kuma-cp): don't let CA requests for other meshes block generation

### DIFF
--- a/api/mesh/v1alpha1/mesh.pb.go
+++ b/api/mesh/v1alpha1/mesh.pb.go
@@ -1198,6 +1198,7 @@ type CertificateAuthorityBackend_RootChain struct {
 	unknownFields protoimpl.UnknownFields
 
 	// Timeout on request for to CA for root certificate chain.
+	// If not specified, defaults to 10s.
 	RequestTimeout *durationpb.Duration `protobuf:"bytes,1,opt,name=requestTimeout,proto3" json:"requestTimeout,omitempty"`
 }
 

--- a/api/mesh/v1alpha1/mesh.proto
+++ b/api/mesh/v1alpha1/mesh.proto
@@ -146,6 +146,7 @@ message CertificateAuthorityBackend {
   // RootChain defines settings related to CA root certificate chain.
   message RootChain {
     // Timeout on request for to CA for root certificate chain.
+    // If not specified, defaults to 10s.
     google.protobuf.Duration requestTimeout = 1;
   }
 

--- a/docs/generated/resources/other_mesh.md
+++ b/docs/generated/resources/other_mesh.md
@@ -56,6 +56,7 @@
             - `requestTimeout` (optional)
             
                 Timeout on request for to CA for root certificate chain.
+                If not specified, defaults to 10s.
 
 - `tracing` (optional)
 
@@ -250,6 +251,7 @@
     - `requestTimeout` (optional)
     
         Timeout on request for to CA for root certificate chain.
+        If not specified, defaults to 10s.
 ## Networking
 
 - `outbound` (optional)

--- a/pkg/xds/secrets/ca_provider.go
+++ b/pkg/xds/secrets/ca_provider.go
@@ -15,7 +15,7 @@ import (
 
 type CaProvider interface {
 	// Get returns all PEM encoded CAs, a list of CAs that were used to generate a secret and an error.
-	Get(context.Context, *core_mesh.MeshResource, *time.Duration) (*core_xds.CaSecret, []string, error)
+	Get(context.Context, *core_mesh.MeshResource) (*core_xds.CaSecret, []string, error)
 }
 
 func NewCaProvider(caManagers core_ca.Managers, metrics core_metrics.Metrics) (CaProvider, error) {
@@ -38,24 +38,20 @@ type meshCaProvider struct {
 	latencyMetrics *prometheus.SummaryVec
 }
 
-func (s *meshCaProvider) Get(ctx context.Context, mesh *core_mesh.MeshResource, timeout *time.Duration) (*core_xds.CaSecret, []string, error) {
+// Get retrieves the root CA for a given backend with a default timeout of 10
+// seconds.
+func (s *meshCaProvider) Get(ctx context.Context, mesh *core_mesh.MeshResource) (*core_xds.CaSecret, []string, error) {
 	backend := mesh.GetEnabledCertificateAuthorityBackend()
 	if backend == nil {
 		return nil, nil, errors.New("CA backend is nil")
 	}
 
-	backendTimeout := backend.GetRootChain().GetRequestTimeout()
-	if backendTimeout != nil {
-		backendTimeout := backendTimeout.AsDuration()
-		if timeout == nil || backendTimeout < *timeout {
-			timeout = &backendTimeout
-		}
+	timeout := 10 * time.Second
+	if backendTimeout := backend.GetRootChain().GetRequestTimeout(); backendTimeout != nil {
+		timeout = backendTimeout.AsDuration()
 	}
-	if timeout != nil {
-		var cancel context.CancelFunc
-		ctx, cancel = context.WithTimeout(ctx, *timeout)
-		defer cancel()
-	}
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
 
 	caManager, exist := s.caManagers[backend.Type]
 	if !exist {

--- a/pkg/xds/secrets/secrets.go
+++ b/pkg/xds/secrets/secrets.go
@@ -311,7 +311,7 @@ func (s *secrets) generateCerts(
 	}
 
 	if updateKinds.HasType(OwnMeshChange) {
-		caSecret, supportedBackends, err := s.caProvider.Get(ctx, mesh, nil)
+		caSecret, supportedBackends, err := s.caProvider.Get(ctx, mesh)
 		if err != nil {
 			return nil, errors.Wrap(err, "could not get mesh CA cert")
 		}
@@ -343,10 +343,7 @@ func (s *secrets) generateCerts(
 				continue
 			}
 
-			// We include this as a last resort to let providers from other
-			// meshes stop secret generation
-			timeout := 1 * time.Second
-			otherCa, _, err := s.caProvider.Get(ctx, otherMesh, &timeout)
+			otherCa, _, err := s.caProvider.Get(ctx, otherMesh)
 			if err != nil {
 				failedOtherMeshes = true
 				// The other CA is misconfigured but this can not affect

--- a/pkg/xds/secrets/secrets.go
+++ b/pkg/xds/secrets/secrets.go
@@ -311,7 +311,7 @@ func (s *secrets) generateCerts(
 	}
 
 	if updateKinds.HasType(OwnMeshChange) {
-		caSecret, supportedBackends, err := s.caProvider.Get(ctx, mesh)
+		caSecret, supportedBackends, err := s.caProvider.Get(ctx, mesh, nil)
 		if err != nil {
 			return nil, errors.Wrap(err, "could not get mesh CA cert")
 		}
@@ -343,7 +343,10 @@ func (s *secrets) generateCerts(
 				continue
 			}
 
-			otherCa, _, err := s.caProvider.Get(ctx, otherMesh)
+			// We include this as a last resort to let providers from other
+			// meshes stop secret generation
+			timeout := 1 * time.Second
+			otherCa, _, err := s.caProvider.Get(ctx, otherMesh, &timeout)
 			if err != nil {
 				failedOtherMeshes = true
 				// The other CA is misconfigured but this can not affect


### PR DESCRIPTION
This PR adds a default timeout to calls of `GetRootCert` for the case that the CA manager takes too long, so that it doesn't block generation, especially in the cross-mesh case.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [ ] [Link to relevant issue][1] as well as docs and UI issues --
- [ ] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [ ] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [ ] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [ ] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [ ] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
