### PR TITLE
refactor(kuma-cp): only generate other mesh CAs if cross-mesh MeshGateway in use

### DIFF
--- a/pkg/xds/generator/secrets/generator.go
+++ b/pkg/xds/generator/secrets/generator.go
@@ -106,8 +106,13 @@ func (g Generator) Generate(
 	}
 
 	if usedIdentity || len(usedCas) > 0 {
-		otherMeshes := ctx.Mesh.Resources.OtherMeshes().Items
-		identity, meshCas, err := ctx.ControlPlane.Secrets.GetForDataPlane(proxy.Dataplane, ctx.Mesh.Resource, otherMeshes)
+		var otherMeshes []*core_mesh.MeshResource
+		for _, otherMesh := range ctx.Mesh.Resources.OtherMeshes().Items {
+			if _, ok := usedCas[otherMesh.GetMeta().GetName()]; ok {
+				otherMeshes = append(otherMeshes, otherMesh)
+			}
+		}
+		identity, generatedMeshCAs, err := ctx.ControlPlane.Secrets.GetForDataPlane(proxy.Dataplane, ctx.Mesh.Resource, otherMeshes)
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to generate dataplane identity cert and CAs")
 		}
@@ -116,7 +121,7 @@ func (g Generator) Generate(
 
 		var addedCas []string
 		for mesh := range usedCas {
-			if ca, ok := meshCas[mesh]; ok {
+			if ca, ok := generatedMeshCAs[mesh]; ok {
 				resources.Add(createCaSecretResource(proxy.SecretsTracker.RequestCa(mesh).Name(), ca))
 			} else {
 				// We need to add _something_ here so that Envoy syncs the


### PR DESCRIPTION
This is safer and more efficient.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [ ] [Link to relevant issue][1] as well as docs and UI issues --
- [ ] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [ ] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [ ] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [ ] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [ ] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
