### PR TITLE
test(e2e): bump max length of gomega messages

### DIFF
--- a/pkg/test/ginkgo.go
+++ b/pkg/test/ginkgo.go
@@ -8,6 +8,7 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
+	"github.com/onsi/gomega/format"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
@@ -27,6 +28,8 @@ func RunE2ESpecs(t *testing.T, description string) {
 	gomega.SetDefaultConsistentlyPollingInterval(time.Millisecond * 200)
 	gomega.SetDefaultEventuallyPollingInterval(time.Millisecond * 500)
 	gomega.SetDefaultEventuallyTimeout(time.Second * 30)
+	// Set MaxLength to larger value than default 4000, so we can print objects full like Pod on test failure
+	format.MaxLength = 100000
 	runSpecs(t, description)
 }
 


### PR DESCRIPTION
Here for example we cannot see the full Pod definition on failure
https://app.circleci.com/pipelines/github/kumahq/kuma/20510/workflows/76b48c2c-7445-44cc-9006-a01690491857/jobs/356156

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [X] [Link to relevant issue][1] as well as docs and UI issues --
- [X] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [X] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [X] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [X] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [X] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
