### PR TITLE
build(mk): fix Envoy build for darwin arm64

### DIFF
--- a/tools/envoy/BUILD-darwin-arm64.patch
+++ b/tools/envoy/BUILD-darwin-arm64.patch
@@ -1,0 +1,29 @@
+--- BUILD	2023-03-15 12:12:00.000000000 +0000
++++ BUILD_NEW	2023-03-15 12:11:44.000000000 +0000
+@@ -52,9 +52,26 @@
+         "darwin": ":cc-compiler-darwin",
+         "armeabi-v7a|compiler": ":cc-compiler-armeabi-v7a",
+         "armeabi-v7a": ":cc-compiler-armeabi-v7a",
++        "darwin_arm64|clang": ":cc-compiler-darwin",
++        "darwin_arm64": ":cc-compiler-darwin",
+     },
+ )
+
++cc_toolchain(
++    name = "cc-compiler-darwin_arm64",
++    toolchain_identifier = "local",
++    toolchain_config = ":local",
++    all_files = ":compiler_deps",
++    ar_files = ":compiler_deps",
++    as_files = ":compiler_deps",
++    compiler_files = ":compiler_deps",
++    dwp_files = ":empty",
++    linker_files = ":compiler_deps",
++    objcopy_files = ":empty",
++    strip_files = ":empty",
++    supports_param_files = 1,
++    module_map = ":module.modulemap",
++)
+ cc_toolchain(
+     name = "cc-compiler-darwin",
+     toolchain_identifier = "local",

--- a/tools/envoy/build_darwin.sh
+++ b/tools/envoy/build_darwin.sh
@@ -11,6 +11,8 @@ mkdir -p "$(dirname "${BINARY_PATH}")"
 SOURCE_DIR="${SOURCE_DIR}" "${KUMA_DIR:-.}/tools/envoy/fetch_sources.sh"
 CONTRIB_ENABLED_MATRIX_SCRIPT=$(realpath "${KUMA_DIR:-.}/tools/envoy/contrib_enabled_matrix.py")
 
+PATCH_FILE=$(realpath "${KUMA_DIR:-.}/tools/envoy/BUILD-darwin-arm64.patch")
+
 pushd "${SOURCE_DIR}"
 
 BAZEL_BUILD_EXTRA_OPTIONS=${BAZEL_BUILD_EXTRA_OPTIONS:-""}
@@ -24,12 +26,16 @@ BAZEL_BUILD_OPTIONS=(
     "--define" "wasm=disabled"
     "${BAZEL_BUILD_EXTRA_OPTIONS[@]+"${BAZEL_BUILD_EXTRA_OPTIONS[@]}"}")
 
-CONTRIB_ENABLED_ARGS=$(python "${CONTRIB_ENABLED_MATRIX_SCRIPT}")
+read -ra CONTRIB_ENABLED_ARGS <<< "$(python "${CONTRIB_ENABLED_MATRIX_SCRIPT}")"
 
-# shellcheck disable=SC2086
-bazel build "${BAZEL_BUILD_OPTIONS[@]}" -c opt //contrib/exe:envoy-static ${CONTRIB_ENABLED_ARGS}
+bazel fetch '@local_config_cc//:toolchain'
+
+if [[ "$GOARCH" == "arm64" ]]; then
+    patch --forward "$(bazel info output_base)/external/local_config_cc/BUILD" "$PATCH_FILE"
+fi
+
+bazel build "${BAZEL_BUILD_OPTIONS[@]}" -c opt //contrib/exe:envoy-static "${CONTRIB_ENABLED_ARGS[@]}"
 
 popd
 
 cp "${SOURCE_DIR}"/bazel-bin/contrib/exe/envoy-static "${BINARY_PATH}"
-


### PR DESCRIPTION
As described in https://github.com/bazelbuild/bazel/issues/13514#issuecomment-847917936

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [x] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
