### PR TITLE
ci(make): refactor targets to have a dependency on other target

### DIFF
--- a/mk/build.mk
+++ b/mk/build.mk
@@ -48,28 +48,35 @@ build/release: $(patsubst %,build/%,$(BUILD_RELEASE_BINARIES)) ## Dev: Build all
 build/test: $(patsubst %,build/%,$(BUILD_TEST_BINARIES)) ## Dev: Build testing binaries
 
 .PHONY: build/linux-amd64
-build/linux-amd64:
-	GOOS=linux GOARCH=amd64 $(MAKE) build
+build/linux-amd64: GOOS=linux
+build/linux-amd64: GOARCH=amd64
+build/linux-amd64: build
 
 .PHONY: build/linux-arm64
-build/linux-arm64:
-	GOOS=linux GOARCH=arm64 $(MAKE) build
+build/linux-arm64: GOOS=linux
+build/linux-arm64: GOARCH=arm64
+build/linux-arm64: build
 
 .PHONY: build/release/linux-amd64
-build/release/linux-amd64:
-	GOOS=linux GOARCH=amd64 $(MAKE) build/release
+build/release/linux-amd64: GOOS=linux
+build/release/linux-amd64: GOARCH=amd64
+build/release/linux-amd64: build/release
 
 .PHONY: build/release/linux-arm64
-build/release/linux-arm64:
-	GOOS=linux GOARCH=arm64 $(MAKE) build/release
+build/release/linux-arm64: GOOS=linux
+build/release/linux-arm64: GOARCH=arm64
+build/release/linux-arm64: build/release
 
 .PHONY: build/test/linux-amd64
-build/test/linux-amd64:
-	GOOS=linux GOARCH=amd64 $(MAKE) build/test
+build/test/linux-amd64: GOOS=linux
+build/test/linux-amd64: GOARCH=amd64
+build/test/linux-amd64: build/test
 
 .PHONY: build/test/linux-arm64
-build/test/linux-arm64:
-	GOOS=linux GOARCH=amd64 $(MAKE) build/test
+build/test/linux-arm64: GOOS=linux
+build/test/linux-arm64: GOARCH=arm64
+build/test/linux-arm64: build/test
+
 
 .PHONY: build/kuma-cp
 build/kuma-cp: ## Dev: Build `Control Plane` binary
@@ -111,60 +118,74 @@ build/test-server: ## Dev: Build `test-server` binary
 	$(Build_Go_Application) ./test/server
 
 .PHONY: build/kuma-cni/linux-amd64
-build/kuma-cni/linux-amd64:
-	GOOS=linux GOARCH=amd64 $(MAKE) build/kuma-cni
+build/kuma-cni/linux-amd64: GOOS=linux
+build/kuma-cni/linux-amd64: GOARCH=amd64
+build/kuma-cni/linux-amd64: build/kuma-cni
 
 .PHONY: build/kuma-cni/linux-arm64
-build/kuma-cni/linux-arm64:
-	GOOS=linux GOARCH=arm64 $(MAKE) build/kuma-cni
+build/kuma-cni/linux-arm64: GOOS=linux
+build/kuma-cni/linux-arm64: GOARCH=arm64
+build/kuma-cni/linux-arm64: build/kuma-cni
 
 .PHONY: build/install-cni/linux-amd64
-build/install-cni/linux-amd64:
-	GOOS=linux GOARCH=amd64 $(MAKE) build/install-cni
+build/install-cni/linux-amd64: GOOS=linux
+build/install-cni/linux-amd64: GOARCH=amd64
+build/install-cni/linux-amd64: build/install-cni
 
 .PHONY: build/install-cni/linux-arm64
-build/install-cni/linux-arm64:
-	GOOS=linux GOARCH=arm64 $(MAKE) build/install-cni
+build/install-cni/linux-arm64: GOOS=linux
+build/install-cni/linux-arm64: GOARCH=arm64
+build/install-cni/linux-arm64: build/install-cni
 
 .PHONY: build/kuma-cp/linux-amd64
-build/kuma-cp/linux-amd64:
-	GOOS=linux GOARCH=amd64 $(MAKE) build/kuma-cp
+build/kuma-cp/linux-amd64: GOOS=linux
+build/kuma-cp/linux-amd64: GOARCH=amd64
+build/kuma-cp/linux-amd64: build/kuma-cp
 
 .PHONY: build/kuma-cp/linux-arm64
-build/kuma-cp/linux-arm64:
-	GOOS=linux GOARCH=arm64 $(MAKE) build/kuma-cp
+build/kuma-cp/linux-arm64: GOOS=linux
+build/kuma-cp/linux-arm64: GOARCH=arm64
+build/kuma-cp/linux-arm64: build/kuma-cp
 
 .PHONY: build/kuma-dp/linux-amd64
-build/kuma-dp/linux-amd64:
-	GOOS=linux GOARCH=amd64 $(MAKE) build/kuma-dp
+build/kuma-dp/linux-amd64: GOOS=linux
+build/kuma-dp/linux-amd64: GOARCH=amd64
+build/kuma-dp/linux-amd64: build/kuma-dp
 
 .PHONY: build/kuma-dp/linux-arm64
-build/kuma-dp/linux-arm64:
-	GOOS=linux GOARCH=arm64 $(MAKE) build/kuma-dp
+build/kuma-dp/linux-arm64: GOOS=linux
+build/kuma-dp/linux-arm64: GOARCH=arm64
+build/kuma-dp/linux-arm64: build/kuma-dp
 
 .PHONY: build/kumactl/linux-amd64
-build/kumactl/linux-amd64:
-	GOOS=linux GOARCH=amd64 $(MAKE) build/kumactl
+build/kumactl/linux-amd64: GOOS=linux
+build/kumactl/linux-amd64: GOARCH=amd64
+build/kumactl/linux-amd64: build/kumactl
 
 .PHONY: build/kumactl/linux-arm64
-build/kumactl/linux-arm64:
-	GOOS=linux GOARCH=arm64 $(MAKE) build/kumactl
+build/kumactl/linux-arm64: GOOS=linux
+build/kumactl/linux-arm64: GOARCH=arm64
+build/kumactl/linux-arm64: build/kumactl
 
 .PHONY: build/coredns/linux-amd64
-build/coredns/linux-amd64:
-	GOOS=linux GOARCH=amd64 $(MAKE) build/coredns
+build/coredns/linux-amd64: GOOS=linux
+build/coredns/linux-amd64: GOARCH=amd64
+build/coredns/linux-amd64: build/coredns
 
 .PHONY: build/coredns/linux-arm64
-build/coredns/linux-arm64:
-	GOOS=linux GOARCH=arm64 $(MAKE) build/coredns
+build/coredns/linux-arm64: GOOS=linux
+build/coredns/linux-arm64: GOARCH=arm64
+build/coredns/linux-arm64: build/coredns
 
 .PHONY: build/test-server/linux-amd64
-build/test-server/linux-amd64:
-	GOOS=linux GOARCH=amd64 $(MAKE) build/test-server
+build/test-server/linux-amd64: GOOS=linux
+build/test-server/linux-amd64: GOARCH=amd64
+build/test-server/linux-amd64: build/test-server
 
 .PHONY: build/test-server/linux-arm64
-build/test-server/linux-arm64:
-	GOOS=linux GOARCH=arm64 $(MAKE) build/test-server
+build/test-server/linux-arm64: GOOS=linux
+build/test-server/linux-arm64: GOARCH=arm64
+build/test-server/linux-arm64: build/test-server
 
 .PHONY: clean
 clean: clean/build ## Dev: Clean


### PR DESCRIPTION
When we follow this `$(MAKE) dependency` pattern, it seems that the order is not preserved so when we call this
```
.PHONY: test/something
test/something: build/kumactl build/kumactl/linux-${GOARCH}
```
We see that eBPF files are fetched twice.

With the change in the PR, the order is preserved and parallelization is still in place.

This was visible when running e2e-universal that runs `build/kumactl build/kumactl/linux-${GOARCH}`. Go complained that embedded ebpf programs has changed  which results in flaky CI https://app.circleci.com/pipelines/github/kumahq/kuma/20469/workflows/43b4152a-f794-4ba2-aca8-71ef5828fba2/jobs/354836

The other alternative would be to solve this on the "client" side so do this
```
.PHONY: test/e2e-universal
test/e2e-universal: images/test k3d/network/create
	$(MAKE) build/kumactl # <- this is not in dependency list
	$(E2E_ENV_VARS) $(GINKGO_TEST_E2E) $(UNIVERSAL_E2E_PKG_LIST)
```
but it's better to fix it in a way that we avoid the mistake in the future.

I also tried to convert this to autogenerate targets, but it seems that it's not possible.

![image](https://user-images.githubusercontent.com/5459824/225923029-87df3023-5ee6-4356-b1d9-2d9e495e90d4.png)


### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [X] [Link to relevant issue][1] as well as docs and UI issues --
- [X] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [X] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [X] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [X] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [X] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
