### PR TITLE
ci(coredns): use prebuilt coredns

### DIFF
--- a/mk/distribution.mk
+++ b/mk/distribution.mk
@@ -1,9 +1,10 @@
 DISTRIBUTION_LICENSE_PATH ?= tools/releases/templates
 DISTRIBUTION_CONFIG_PATH ?= pkg/config/app/kuma-cp/kuma-cp.defaults.yaml
 # A list of all distributions
-# OS:ARCH:coredns:ENVOY_FLAVOUR:ENVOY_FLAVOUR
+# OS:ARCH:COREDNS:ENVOY_FLAVOUR:ENVOY_FLAVOUR
 # The second ENVOY_FLAVOUR is optional
-# If you don't want to include coredns just put an empty string
+# COREDNS is always coredns(CORDNS_EXT)
+# If you don't want to include just put skip
 DISTRIBUTION_LIST ?= linux:amd64:coredns:alpine-opt:centos-opt linux:arm64:coredns:alpine-opt darwin:amd64:coredns:darwin-opt darwin:arm64:coredns:darwin-opt
 
 PULP_HOST ?= "https://api.pulp.konnect-prod.konghq.com"
@@ -31,9 +32,9 @@ build/distributions/$(1)-$(2)/$(DISTRIBUTION_TARGET_NAME):
 	cp build/artifacts-$(1)-$(2)/kuma-dp/kuma-dp $$@/bin
 	cp $(DISTRIBUTION_LICENSE_PATH)/* $$@
 	cp $(DISTRIBUTION_CONFIG_PATH) $$@/conf
-# CoreDNS doesn't always need to be included
-ifeq ($(3),coredns)
-	$(MAKE) build/coredns GOOS=$(1) GOARCH=$(2)
+# CoreDNS is not included when the value is `skip` otherwise it's used as the COREDNS_EXT (which is most commonly empty)
+ifneq ($(3),skip)
+	$(MAKE) build/coredns GOOS=$(1) GOARCH=$(2) COREDNS_EXT=$(subst coredns,,$(3))
 	cp build/artifacts-$(1)-$(2)/coredns/coredns $$@/bin
 endif
 # A first possible envoy to package

--- a/tools/builds/coredns/templates/plugin.cfg
+++ b/tools/builds/coredns/templates/plugin.cfg
@@ -1,6 +1,0 @@
-prometheus:metrics
-errors:errors
-log:log
-template:template
-alternate:github.com/coredns/alternate
-forward:forward


### PR DESCRIPTION
Use coredns binaries builtin in kumahq/coredns-builds This should reduce build times and make things a little simpler

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [x] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
