### PR TITLE
ci(circleci): always install build tools before checkout

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -183,6 +183,9 @@ jobs:
     executor:
       name: vm-<< parameters.arch >>
     steps:
+    - install_build_tools:
+        go_arch: << parameters.arch >>
+        go_os: linux
     - checkout
     - when:
         condition: {equal: [arm64, << parameters.arch >>]}
@@ -190,9 +193,6 @@ jobs:
           - halt_non_priority_job
     - halt_job_if_labeled:
         label: "ci/skip-test"
-    - install_build_tools:
-        go_arch: << parameters.arch >>
-        go_os: linux
     - restore_cache:
         keys:
         - vm-<< parameters.arch >>_go.mod_{{ checksum "go.sum" }}_{{ checksum "mk/dependencies/deps.lock" }}_{{ checksum ".circleci/config.yml" }}
@@ -248,6 +248,8 @@ jobs:
       name: vm-<< parameters.arch >>
     parallelism: << parameters.parallelism >>
     steps:
+      - install_build_tools:
+          go_arch: << parameters.arch >>
       - checkout
       - halt_job_if_labeled:
           label: "ci/skip-test"
@@ -289,8 +291,6 @@ jobs:
               skip "universal only runs on kind"
             fi
             echo "Continuing tests"
-      - install_build_tools:
-          go_arch: << parameters.arch >>
       - restore_cache:
           keys:
             - vm-<< parameters.arch >>_go.mod_{{ checksum "go.sum" }}_{{ checksum "mk/dependencies/deps.lock" }}_{{ checksum ".circleci/config.yml" }}
@@ -353,13 +353,13 @@ jobs:
     executor: # we are using linux/arm64 and linux/amd64 vm's for build
       name: vm-<< parameters.arch >>
     steps:
+    - install_build_tools:
+        go_arch: <<parameters.arch>>
     - checkout
     - when:
         condition: {equal: [arm64, << parameters.arch >>]}
         steps:
           - halt_non_priority_job
-    - install_build_tools:
-        go_arch: <<parameters.arch>>
     - restore_cache:
         keys:
         - golang_go.mod_{{ checksum "go.sum" }}_{{ checksum "mk/dependencies/deps.lock" }}_{{ checksum ".circleci/config.yml" }}


### PR DESCRIPTION
This is necessary to use go in pre checkout steps in child repo

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [x] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
