### PR TITLE
chore(policy-gen): update bootstrap to avoid generating plugin methods

### DIFF
--- a/pkg/core/plugins/interfaces.go
+++ b/pkg/core/plugins/interfaces.go
@@ -89,9 +89,22 @@ type AuthnAPIServerPlugin interface {
 // PolicyPlugin a plugin to add a Policy to Kuma
 type PolicyPlugin interface {
 	Plugin
-	// MatchedPolicies return all the policies of the plugins' type matching this dataplane. This is used in the inspect api and accessible in Apply through `proxy.Policies.Dynamic`
+	// MatchedPolicies return all the policies of the plugins' type matching this dataplane.
+	// This is used in the inspect api and accessible in Apply through `proxy.Policies.Dynamic`
 	MatchedPolicies(dataplane *core_mesh.DataplaneResource, resources xds_context.Resources) (core_xds.TypedMatchingPolicies, error)
 	// Apply to `rs` using the `ctx` and `proxy` the mutation for all policies of the type this plugin implements.
 	// You can access matching policies by using `proxy.Policies.Dynamic`.
 	Apply(rs *core_xds.ResourceSet, ctx xds_context.Context, proxy *core_xds.Proxy) error
+}
+
+var _ PolicyPlugin = &UnimplementedPolicyPlugin{}
+
+type UnimplementedPolicyPlugin struct{}
+
+func (u *UnimplementedPolicyPlugin) MatchedPolicies(*core_mesh.DataplaneResource, xds_context.Resources) (core_xds.TypedMatchingPolicies, error) {
+	return core_xds.TypedMatchingPolicies{}, errors.New("method is not implemented")
+}
+
+func (u *UnimplementedPolicyPlugin) Apply(*core_xds.ResourceSet, xds_context.Context, *core_xds.Proxy) error {
+	return errors.New("method is not implemented")
 }

--- a/pkg/plugins/policies/meshaccesslog/plugin/v1alpha1/plugin.go
+++ b/pkg/plugins/policies/meshaccesslog/plugin/v1alpha1/plugin.go
@@ -22,7 +22,9 @@ import (
 
 var _ core_plugins.PolicyPlugin = &plugin{}
 
-type plugin struct{}
+type plugin struct {
+	core_plugins.UnimplementedPolicyPlugin
+}
 
 func NewPlugin() core_plugins.Plugin {
 	return &plugin{}

--- a/pkg/plugins/policies/meshcircuitbreaker/plugin/v1alpha1/plugin.go
+++ b/pkg/plugins/policies/meshcircuitbreaker/plugin/v1alpha1/plugin.go
@@ -16,7 +16,9 @@ import (
 
 var _ core_plugins.PolicyPlugin = &plugin{}
 
-type plugin struct{}
+type plugin struct {
+	core_plugins.UnimplementedPolicyPlugin
+}
 
 func NewPlugin() core_plugins.Plugin {
 	return &plugin{}

--- a/pkg/plugins/policies/meshfaultinjection/plugin/v1alpha1/plugin.go
+++ b/pkg/plugins/policies/meshfaultinjection/plugin/v1alpha1/plugin.go
@@ -20,7 +20,9 @@ import (
 
 var _ core_plugins.PolicyPlugin = &plugin{}
 
-type plugin struct{}
+type plugin struct {
+	core_plugins.UnimplementedPolicyPlugin
+}
 
 func NewPlugin() core_plugins.Plugin {
 	return &plugin{}

--- a/pkg/plugins/policies/meshhealthcheck/plugin/v1alpha1/plugin.go
+++ b/pkg/plugins/policies/meshhealthcheck/plugin/v1alpha1/plugin.go
@@ -15,7 +15,9 @@ import (
 
 var _ core_plugins.PolicyPlugin = &plugin{}
 
-type plugin struct{}
+type plugin struct {
+	core_plugins.UnimplementedPolicyPlugin
+}
 
 func NewPlugin() core_plugins.Plugin {
 	return &plugin{}

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/plugin.go
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/plugin.go
@@ -32,7 +32,9 @@ type ToRouteRule struct {
 	Origin []core_model.ResourceMeta
 }
 
-type plugin struct{}
+type plugin struct {
+	core_plugins.UnimplementedPolicyPlugin
+}
 
 func NewPlugin() core_plugins.Plugin {
 	return &plugin{}

--- a/pkg/plugins/policies/meshloadbalancingstrategy/plugin/v1alpha1/plugin.go
+++ b/pkg/plugins/policies/meshloadbalancingstrategy/plugin/v1alpha1/plugin.go
@@ -20,7 +20,9 @@ import (
 
 var _ core_plugins.PolicyPlugin = &plugin{}
 
-type plugin struct{}
+type plugin struct {
+	core_plugins.UnimplementedPolicyPlugin
+}
 
 func NewPlugin() core_plugins.Plugin {
 	return &plugin{}

--- a/pkg/plugins/policies/meshproxypatch/plugin/v1alpha1/plugin.go
+++ b/pkg/plugins/policies/meshproxypatch/plugin/v1alpha1/plugin.go
@@ -17,7 +17,9 @@ type modificator interface {
 	apply(*core_xds.ResourceSet) error
 }
 
-type plugin struct{}
+type plugin struct {
+	core_plugins.UnimplementedPolicyPlugin
+}
 
 var _ core_plugins.PolicyPlugin = &plugin{}
 

--- a/pkg/plugins/policies/meshratelimit/plugin/v1alpha1/plugin.go
+++ b/pkg/plugins/policies/meshratelimit/plugin/v1alpha1/plugin.go
@@ -19,7 +19,9 @@ import (
 
 var _ core_plugins.PolicyPlugin = &plugin{}
 
-type plugin struct{}
+type plugin struct {
+	core_plugins.UnimplementedPolicyPlugin
+}
 
 func NewPlugin() core_plugins.Plugin {
 	return &plugin{}

--- a/pkg/plugins/policies/meshretry/plugin/v1alpha1/plugin.go
+++ b/pkg/plugins/policies/meshretry/plugin/v1alpha1/plugin.go
@@ -16,7 +16,9 @@ import (
 
 var _ core_plugins.PolicyPlugin = &plugin{}
 
-type plugin struct{}
+type plugin struct {
+	core_plugins.UnimplementedPolicyPlugin
+}
 
 func NewPlugin() core_plugins.Plugin {
 	return &plugin{}

--- a/pkg/plugins/policies/meshtimeout/plugin/v1alpha1/plugin.go
+++ b/pkg/plugins/policies/meshtimeout/plugin/v1alpha1/plugin.go
@@ -22,7 +22,9 @@ import (
 
 var _ core_plugins.PolicyPlugin = &plugin{}
 
-type plugin struct{}
+type plugin struct {
+	core_plugins.UnimplementedPolicyPlugin
+}
 
 func NewPlugin() core_plugins.Plugin {
 	return &plugin{}

--- a/pkg/plugins/policies/meshtrace/plugin/v1alpha1/plugin.go
+++ b/pkg/plugins/policies/meshtrace/plugin/v1alpha1/plugin.go
@@ -25,7 +25,9 @@ const OriginMeshTrace = "mesh-trace"
 
 var _ core_plugins.PolicyPlugin = &plugin{}
 
-type plugin struct{}
+type plugin struct {
+	core_plugins.UnimplementedPolicyPlugin
+}
 
 func NewPlugin() core_plugins.Plugin {
 	return &plugin{}

--- a/pkg/xds/sync/dataplane_proxy_builder.go
+++ b/pkg/xds/sync/dataplane_proxy_builder.go
@@ -159,7 +159,6 @@ func (p *DataplaneProxyBuilder) matchPolicies(meshContext xds_context.MeshContex
 		RateLimitsInbound:  ratelimits.Inbound,
 		RateLimitsOutbound: ratelimits.Outbound,
 		ProxyTemplate:      template.SelectProxyTemplate(dataplane, resources.ProxyTemplates().Items),
-		Dynamic:            map[core_model.ResourceType]core_xds.TypedMatchingPolicies{},
 	}
 	for name, p := range plugins.Plugins().PolicyPlugins() {
 		res, err := p.MatchedPolicies(dataplane, resources)

--- a/tools/policy-gen/bootstrap/root.go
+++ b/tools/policy-gen/bootstrap/root.go
@@ -222,39 +222,17 @@ var pluginTemplate = template.Must(template.New("").Option("missingkey=error").P
 	`package {{ .version }}
 
 import (
-	"github.com/kumahq/kuma/pkg/core"
-
 	core_plugins "github.com/kumahq/kuma/pkg/core/plugins"
-	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
-	core_xds "github.com/kumahq/kuma/pkg/core/xds"
-	{{- if .generateTargetRef }}
-	"github.com/kumahq/kuma/pkg/plugins/policies/matchers"
-	api "{{ .package }}"
-	{{- end}}
-	xds_context "github.com/kumahq/kuma/pkg/xds/context"
 )
 
 var _ core_plugins.PolicyPlugin = &plugin{}
-var log = core.Log.WithName("{{.name}}")
 
 type plugin struct {
+	core_plugins.UnimplementedPolicyPlugin
 }
 
 func NewPlugin() core_plugins.Plugin {
 	return &plugin{}
-}
-
-func (p plugin) MatchedPolicies(dataplane *core_mesh.DataplaneResource, resources xds_context.Resources) (core_xds.TypedMatchingPolicies, error) {
-	{{- if not .generateTargetRef }}
-	panic("implement me")
-	{{- else }}
-	return matchers.MatchedPolicies(api.{{ .name }}Type, dataplane, resources)
-	{{- end }}
-}
-
-func (p plugin) Apply(rs *core_xds.ResourceSet, ctx xds_context.Context, proxy *core_xds.Proxy) error {
-	log.Info("apply is not implemented")
-	return nil
 }
 `))
 


### PR DESCRIPTION
Replace method generation with `UnimplementedPolicyPlugin`. 

I'm planning to introduce additional methods in the PolicyPlugin interface (for Egress/Ingress matching), so it's better to not generate default method implementation in `policy-gen/bootstrap` and keep it only in `UnimplementedPolicyPlugin`.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [X] [Link to relevant issue][1] as well as docs and UI issues --
- [X] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [X] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [X] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [X] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [X] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
