### PR TITLE
ci(mk): run kube-lint on `install control-plane` golden files

### DIFF
--- a/mk/check.mk
+++ b/mk/check.mk
@@ -50,7 +50,13 @@ format: fmt format/common
 
 .PHONY: kube-lint
 kube-lint:
-	find ./deployments/charts -maxdepth 1 -mindepth 1 -type d -exec $(KUBE_LINTER) lint {} \;
+	@find ./deployments/charts -maxdepth 1 -mindepth 1 -type d -exec $(KUBE_LINTER) lint {} \;
+	@if [ -d ./app/kumactl/cmd/install/testdata ]; then \
+		find ./app/kumactl/cmd/install/testdata -maxdepth 1 -type f -name 'install-control-plane*.golden.yaml' -exec $(KUBE_LINTER) lint {} +; \
+	fi
+	@if [ -d ./app/kumactl/cmd/install/testdata/install-cp-helm ]; then \
+		find ./app/kumactl/cmd/install/testdata/install-cp-helm -maxdepth 1 -type f -name '*.golden.yaml' -exec $(KUBE_LINTER) lint {} +; \
+	fi
 
 .PHONY: hadolint
 hadolint:


### PR DESCRIPTION
### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues -- Closes https://github.com/kumahq/kuma/issues/6049
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [x] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
