### PR TITLE
ci(k8s): bump first supported version to v1.22

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ reusable:
   constants:
     - &go_version "1.20.2"
     - &lastK8sVersion v1.26.1-k3s1
-    - &firstK8sVersion v1.20.15-k3s1
+    - &firstK8sVersion v1.22.16-k3s1
 
   docker_images:
     - &golang_image "cimg/go:1.20.2"
@@ -227,7 +227,7 @@ jobs:
       k8sVersion:
         description: version of k3s to use or "kind" and "kindIpv6"
         type: string
-        default: v1.26.1-k3s1
+        default: *lastK8sVersion
       parallelism:
         description: level of parallelization
         type: integer
@@ -465,7 +465,7 @@ workflows:
           matrix:
             alias: test/e2e-legacy
             parameters:
-              k8sVersion: [ v1.20.15-k3s1, v1.26.1-k3s1, kind, kindIpv6 ]
+              k8sVersion: [ *firstK8sVersion, *lastK8sVersion, kind, kindIpv6 ]
               arch: [ amd64, arm64 ]
           parallelism: 3
           target: test/e2e

--- a/mk/k3d.mk
+++ b/mk/k3d.mk
@@ -1,4 +1,4 @@
-CI_K3S_VERSION ?= v1.20.15-k3s1
+CI_K3S_VERSION ?= v1.22.16-k3s1
 
 
 KUMA_MODE ?= standalone


### PR DESCRIPTION
### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [x] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
