### PR TITLE
feat(retry): create MADR for host selection

### DIFF
--- a/docs/madr/decisions/022-retry-host-selection.md
+++ b/docs/madr/decisions/022-retry-host-selection.md
@@ -20,7 +20,7 @@ Envoy has "host predicates" and "priority predicates" to enforce an additional l
 when selecting a host for the attempt. With `retry_host_predicate` we get:
 
 * don't retry on previously retried hosts
-* don't retry on canary hosts (the host should be preliminarily marked with `canary: true`)
+~~* don't retry on canary hosts (the host should be preliminarily marked with `canary: true`)~~ (doesn't make sense for us to implement)
 * don't retry on hosts with specified metadata key/value
 
 And with `retry_priority` we get:
@@ -32,7 +32,6 @@ These predicates can be combined into a single `hostSelection` section:
 ```yaml
 hostSelection:
   - predicate: OMIT_PREVIOUS_HOSTS
-  - predicate: OMIT_CANARY_HOSTS
   - predicate: OMIT_HOSTS_WITH_TAGS
     tags:
       env: dev
@@ -47,28 +46,40 @@ It allows configuring the maximum number of times host selection will be reattem
 
 ```go
 type HTTP struct {
-	// ...
-  HostSelection *[]Predicate `json:"hostSelection,omitempty"`
-  // ...
+    // ...
+    // HostSelection is a list of predicates that dictate how hosts should be selected
+    // when requests are retried.
+    HostSelection *[]Predicate `json:"hostSelection,omitempty"`
+    // HostSelectionMaxAttempts is the maximum number of times host selection will be
+    // reattempted before giving up, at which point the host that was last selected will
+    // be routed to. If unspecified, this will default to retrying once.
+    HostSelectionMaxAttempts *int64 `json:"hostSelectionMaxAttempts,omitempty"`
 }
+
+type PredicateType string
+
+var (
+    OmitPreviousHosts      PredicateType = "OmitPreviousHosts"
+    OmitHostsWithTags      PredicateType = "OmitHostsWithTags"
+    OmitPreviousPriorities PredicateType = "OmitPreviousPriorities"
+)
 
 type Predicate struct {
-	// Type is requested predicate mode. Available values are OMIT_PREVIOUS_HOSTS, OMIT_CANARY_HOSTS, 
-  // OMIT_HOSTS_WITH_TAGS, and OMIT_PREVIOUS_PRIORITIES.
-	Type *string `json:"predicate,omitempty"`
-	// Tags is a map of metadata to match against for selecting the omitted hosts. Required if Type is 
-  // OMIT_HOSTS_WITH_TAGS
-	Tags map[string]string `json:"tags,omitempty"`
-  // UpdateFrequency is how often the priority load should be updated based on previously attempted priorities. 
-  // Required if Type is OMIT_PREVIOUS_PRIORITIES. 
-  UpdateFrequency *uint32 `json:"tags,omitempty"`
+    // Type is requested predicate mode. Available values are OmitPreviousHosts, OmitHostsWithTags,
+    // and OmitPreviousPriorities.
+    PredicateType PredicateType `json:"predicate"`
+    // Tags is a map of metadata to match against for selecting the omitted hosts. Required if Type is
+    // OmitHostsWithTags
+    Tags map[string]string `json:"tags,omitempty"`
+    // UpdateFrequency is how often the priority load should be updated based on previously attempted priorities.
+    // Used for OmitPreviousPriorities. Default is 2 if not set.
+    UpdateFrequency int32 `json:"updateFrequency,omitempty"`
 }
-
 ```
 
 ## Considered Options
 
-* Implement these 3 fields / options
+* Implement these 3 fields / options.
 
 ## Decision Outcome
 

--- a/docs/madr/decisions/022-retry-host-selection.md
+++ b/docs/madr/decisions/022-retry-host-selection.md
@@ -1,0 +1,75 @@
+# Retry Host Selection
+
+* Status: accepted
+
+Technical Story: https://github.com/kumahq/kuma/issues/5897
+
+## Context and Problem Statement
+
+We want to add some additional retry fields plumbed through from Envoy to our Retry policy based on user demand. This is an HTTP only policy (no GRPC).
+
+```
+retry_priority
+retry_host_predicate
+host_selection_retry_max_attempts
+```
+
+### Design 
+
+Envoy has "host predicates" and "priority predicates" to enforce an additional logic 
+when selecting a host for the attempt. With `retry_host_predicate` we get:
+
+* don't retry on previously retried hosts
+* don't retry on canary hosts (the host should be preliminarily marked with `canary: true`)
+* don't retry on hosts with specified metadata key/value
+
+And with `retry_priority` we get:
+
+* don't retry on previous priorities
+
+These predicates can be combined into a single `hostSelection` section:
+
+```yaml
+hostSelection:
+  - predicate: OMIT_PREVIOUS_HOSTS
+  - predicate: OMIT_CANARY_HOSTS
+  - predicate: OMIT_HOSTS_WITH_TAGS
+    tags:
+      env: dev
+  - predicate: OMIT_PREVIOUS_PRIORITIES
+    updateFrequency: 2                                                                                  
+```
+
+Having configurable `hostSelection` implies exposing the `host_selection_retry_max_attempts` parameter as well.
+It allows configuring the maximum number of times host selection will be reattempted before giving up.
+
+### Implementation
+
+```go
+type HTTP struct {
+	// ...
+  HostSelection *[]Predicate `json:"hostSelection,omitempty"`
+  // ...
+}
+
+type Predicate struct {
+	// Type is requested predicate mode. Available values are OMIT_PREVIOUS_HOSTS, OMIT_CANARY_HOSTS, 
+  // OMIT_HOSTS_WITH_TAGS, and OMIT_PREVIOUS_PRIORITIES.
+	Type *string `json:"predicate,omitempty"`
+	// Tags is a map of metadata to match against for selecting the omitted hosts. Required if Type is 
+  // OMIT_HOSTS_WITH_TAGS
+	Tags map[string]string `json:"tags,omitempty"`
+  // UpdateFrequency is how often the priority load should be updated based on previously attempted priorities. 
+  // Required if Type is OMIT_PREVIOUS_PRIORITIES. 
+  UpdateFrequency *uint32 `json:"tags,omitempty"`
+}
+
+```
+
+## Considered Options
+
+* Implement these 3 fields / options
+
+## Decision Outcome
+
+Implement these 3 fields / options.


### PR DESCRIPTION
[Rendered](https://github.com/johnharris85/kuma/blob/cc904ea2bd850897baa704e94555016779a8c9d2/docs/madr/decisions/022-retry-host-selection.md)

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [x] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
