### PR TITLE
fix(kuma-cp): add components in runtime

### DIFF
--- a/pkg/core/runtime/component/component_manager_test.go
+++ b/pkg/core/runtime/component/component_manager_test.go
@@ -1,0 +1,64 @@
+package component_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/kumahq/kuma/pkg/core/runtime/component"
+	leader_memory "github.com/kumahq/kuma/pkg/plugins/leader/memory"
+)
+
+var _ = Describe("Component Manager", func() {
+	Context("Component Manager is running", func() {
+		var manager component.Manager
+		var stopCh chan struct{}
+
+		BeforeAll(func() {
+			// given
+			manager = component.NewManager(leader_memory.NewNeverLeaderElector())
+			chComponentBeforeStart := make(chan int)
+			err := manager.Add(component.ComponentFunc(func(_ <-chan struct{}) error {
+				close(chComponentBeforeStart)
+				return nil
+			}))
+
+			// when component manager is started
+			stopCh = make(chan struct{})
+			go func() {
+				defer GinkgoRecover()
+				Expect(manager.Start(stopCh)).To(Succeed())
+			}()
+
+			// then component added before Start() runs
+			Expect(err).ToNot(HaveOccurred())
+			Eventually(chComponentBeforeStart, "30s", "50ms").Should(BeClosed())
+		})
+
+		AfterAll(func() {
+			close(stopCh)
+		})
+
+		It("should be able to add component in runtime", func() {
+			// when component is added after Start()
+			chComponentAfterStart := make(chan int)
+			err := manager.Add(component.ComponentFunc(func(_ <-chan struct{}) error {
+				close(chComponentAfterStart)
+				return nil
+			}))
+
+			// then it runs
+			Expect(err).ToNot(HaveOccurred())
+			Eventually(chComponentAfterStart, "30s", "50ms").Should(BeClosed())
+		})
+
+		It("should not be able to add leader component", func() {
+			// when leader component is added after Start()
+			err := manager.Add(component.LeaderComponentFunc(func(_ <-chan struct{}) error {
+				return nil
+			}))
+
+			// then
+			Expect(err).To(Equal(component.LeaderComponentAddAfterStartErr))
+		})
+	})
+}, Ordered)

--- a/pkg/core/runtime/component/component_suite_test.go
+++ b/pkg/core/runtime/component/component_suite_test.go
@@ -1,0 +1,11 @@
+package component_test
+
+import (
+	"testing"
+
+	"github.com/kumahq/kuma/pkg/test"
+)
+
+func TestComponent(t *testing.T) {
+	test.RunSpecs(t, "Component Suite")
+}

--- a/test/e2e_env/universal/intercp/intercp.go
+++ b/test/e2e_env/universal/intercp/intercp.go
@@ -1,0 +1,17 @@
+package intercp
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/kumahq/kuma/test/framework/envs/universal"
+)
+
+func InterCP() {
+	It("should run inter cp server", func() {
+		Eventually(func(g Gomega) {
+			_, _, err := universal.Cluster.GetKuma().Exec("nc", "-z", "localhost", "5683")
+			g.Expect(err).ToNot(HaveOccurred())
+		}, "30s", "1s").Should(Succeed())
+	})
+}

--- a/test/e2e_env/universal/universal_suite_test.go
+++ b/test/e2e_env/universal/universal_suite_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/kumahq/kuma/test/e2e_env/universal/grpc"
 	"github.com/kumahq/kuma/test/e2e_env/universal/healthcheck"
 	"github.com/kumahq/kuma/test/e2e_env/universal/inspect"
+	"github.com/kumahq/kuma/test/e2e_env/universal/intercp"
 	"github.com/kumahq/kuma/test/e2e_env/universal/matching"
 	"github.com/kumahq/kuma/test/e2e_env/universal/membership"
 	"github.com/kumahq/kuma/test/e2e_env/universal/meshaccesslog"
@@ -99,4 +100,5 @@ var (
 	_ = Describe("Leader Election", resilience.LeaderElectionPostgres, Ordered)
 	_ = Describe("MeshFaultInjection", meshfaultinjection.Policy, Ordered)
 	_ = Describe("MeshLoadBalancingStrategy", meshloadbalancingstrategy.Policy, Ordered)
+	_ = Describe("InterCP Server", intercp.InterCP, Ordered)
 )


### PR DESCRIPTION
Fix #6349

This inlines our universal component manager to work just like kubernetes component manager, which means that we can add components in runtime and they are run.

However, currently with a limitation that we cannot add leader components after Start(). This is quite complicated to manage and we don't need it now (or never). At least this time we return an explicit error.

I also added a simple e2e test to see that inter cp server is actually running on universal.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [X] [Link to relevant issue][1] as well as docs and UI issues --
- [X] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [X] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [X] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [X] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [X] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
