### PR TITLE
test(e2e): use different KDS port

### DIFF
--- a/test/framework/constants.go
+++ b/test/framework/constants.go
@@ -21,8 +21,6 @@ const (
 	DefaultTimeout = 3 * time.Second
 
 	kdsPort             = 30685
-	loadBalancerKdsPort = 5685
-	xdsPort             = 5678
 )
 
 const (

--- a/test/framework/constants.go
+++ b/test/framework/constants.go
@@ -20,7 +20,7 @@ const (
 	DefaultRetries = 30
 	DefaultTimeout = 3 * time.Second
 
-	kdsPort             = 30685
+	universalKDSPort = 30685
 )
 
 const (

--- a/test/framework/constants.go
+++ b/test/framework/constants.go
@@ -20,7 +20,7 @@ const (
 	DefaultRetries = 30
 	DefaultTimeout = 3 * time.Second
 
-	universalKDSPort = 30685
+	universalKDSPort = 30686
 )
 
 const (

--- a/test/framework/interface.go
+++ b/test/framework/interface.go
@@ -563,7 +563,6 @@ type Cluster interface {
 type ControlPlane interface {
 	GetName() string
 	GetMetrics() (string, error)
-	GetXDSServerAddress() string
 	GetKDSServerAddress() string
 	GetKDSInsecureServerAddress() string
 	GetGlobalStatusAPI() string

--- a/test/framework/interface.go
+++ b/test/framework/interface.go
@@ -565,6 +565,7 @@ type ControlPlane interface {
 	GetMetrics() (string, error)
 	GetKDSServerAddress() string
 	GetKDSInsecureServerAddress() string
+	GetXDSServerAddress() string
 	GetGlobalStatusAPI() string
 	GetAPIServerAddress() string
 	GenerateDpToken(mesh, serviceName string) (string, error)

--- a/test/framework/setup.go
+++ b/test/framework/setup.go
@@ -243,7 +243,7 @@ func WaitUntilJobSucceed(namespace, app string) InstallFunc {
 	}
 }
 
-func zoneRelatedResource(
+func universalZoneRelatedResource(
 	tokenProvider func(zone string) (string, error),
 	appType AppMode,
 	resourceManifestFunc func(address string, port, advertisedPort int) string,
@@ -278,7 +278,7 @@ func zoneRelatedResource(
 
 		uniCluster.apps[dpName] = app
 		publicAddress := app.ip
-		dpYAML := resourceManifestFunc(publicAddress, kdsPort, kdsPort)
+		dpYAML := resourceManifestFunc(publicAddress, universalKDSPort, universalKDSPort)
 
 		zone := uniCluster.name
 		if uniCluster.controlplane.mode == core.Standalone {
@@ -305,7 +305,7 @@ func IngressUniversal(tokenProvider func(zone string) (string, error)) InstallFu
 		return fmt.Sprintf(ZoneIngress, address, port, advertisedPort)
 	}
 
-	return zoneRelatedResource(tokenProvider, AppIngress, manifestFunc)
+	return universalZoneRelatedResource(tokenProvider, AppIngress, manifestFunc)
 }
 
 func EgressUniversal(tokenProvider func(zone string) (string, error)) InstallFunc {
@@ -313,7 +313,7 @@ func EgressUniversal(tokenProvider func(zone string) (string, error)) InstallFun
 		return fmt.Sprintf(ZoneEgress, port)
 	}
 
-	return zoneRelatedResource(tokenProvider, AppEgress, manifestFunc)
+	return universalZoneRelatedResource(tokenProvider, AppEgress, manifestFunc)
 }
 
 func NamespaceWithSidecarInjection(namespace string) InstallFunc {

--- a/test/framework/universal_controlplane.go
+++ b/test/framework/universal_controlplane.go
@@ -69,10 +69,6 @@ func (c *UniversalControlPlane) GetKDSServerAddress() string {
 	return c.getKDSServerAddress(true)
 }
 
-func (c *UniversalControlPlane) GetXDSServerAddress() string {
-	return net.JoinHostPort(c.cpNetworking.IP, "5678")
-}
-
 func (c *UniversalControlPlane) getKDSServerAddress(secure bool) string {
 	protocol := "grpcs"
 	if !secure {

--- a/test/framework/universal_controlplane.go
+++ b/test/framework/universal_controlplane.go
@@ -69,6 +69,10 @@ func (c *UniversalControlPlane) GetKDSServerAddress() string {
 	return c.getKDSServerAddress(true)
 }
 
+func (c *UniversalControlPlane) GetXDSServerAddress() string {
+	return net.JoinHostPort(c.cpNetworking.IP, "5678")
+}
+
 func (c *UniversalControlPlane) getKDSServerAddress(secure bool) string {
 	protocol := "grpcs"
 	if !secure {


### PR DESCRIPTION
This conflicts with the default `nodePort` for the `global-zone-sync` `Service` and a Helm install is run concurrently with this test leading to flakes:

https://app.circleci.com/pipelines/github/kumahq/kuma/20794/workflows/68999f88-2cef-49e3-8a68-332c1a9fb6c8/jobs/365684

The `kdsPort` constants were messy and being used for both Helm and Universal tests.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [x] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
