### PR TITLE
fix(gatewayapi): always set an explicit HTTPRoute Parents in status

### DIFF
--- a/pkg/plugins/runtime/k8s/controllers/gatewayapi/http_route_status.go
+++ b/pkg/plugins/runtime/k8s/controllers/gatewayapi/http_route_status.go
@@ -30,7 +30,8 @@ func (r *HTTPRouteReconciler) updateStatus(ctx context.Context, route *gatewayap
 // mergeHTTPRouteStatus updates the route status with the list of conditions for
 // each parent ref by mutating the given HTTPRoute.
 func mergeHTTPRouteStatus(route *gatewayapi.HTTPRoute, parentConditions ParentConditions) {
-	var mergedStatuses []gatewayapi.RouteParentStatus
+	// we cannot set a `nil` list
+	mergedStatuses := []gatewayapi.RouteParentStatus{}
 	var previousStatuses []gatewayapi.RouteParentStatus
 
 	// partition statuses based on whether we control them


### PR DESCRIPTION
It doesn't have `omitempty` so this leads to update errors

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [x] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
