### PR TITLE
test(e2e): cleanup Gateway API test HTTPRoute resources

### DIFF
--- a/test/e2e_env/kubernetes/gateway/gatewayapi.go
+++ b/test/e2e_env/kubernetes/gateway/gatewayapi.go
@@ -243,6 +243,12 @@ spec:
 				g.Expect(err).ToNot(HaveOccurred())
 				g.Expect(resp.Instance).To(Equal("test-server-2"))
 			}, "30s", "1s").Should(Succeed())
+
+			Expect(k8s.KubectlDeleteFromStringE(
+				kubernetes.Cluster.GetTesting(),
+				kubernetes.Cluster.GetKubectlOptions(namespace),
+				route,
+			)).To(Succeed())
 		})
 
 		It("should route the traffic to test-server by header", func() {
@@ -300,6 +306,12 @@ spec:
 				g.Expect(err).ToNot(HaveOccurred())
 				g.Expect(resp.Instance).To(Equal("test-server-2"))
 			}, "30s", "1s").Should(Succeed())
+
+			Expect(k8s.KubectlDeleteFromStringE(
+				kubernetes.Cluster.GetTesting(),
+				kubernetes.Cluster.GetKubectlOptions(namespace),
+				routes,
+			)).To(Succeed())
 		})
 
 		It("should route to external service", func() {
@@ -335,6 +347,12 @@ spec:
 				g.Expect(err).ToNot(HaveOccurred())
 				g.Expect(resp.Instance).To(Equal("external-service"))
 			}, "30s", "1s").Should(Succeed())
+
+			Expect(k8s.KubectlDeleteFromStringE(
+				kubernetes.Cluster.GetTesting(),
+				kubernetes.Cluster.GetKubectlOptions(namespace),
+				routes,
+			)).To(Succeed())
 		})
 	})
 
@@ -431,6 +449,12 @@ spec:
 				g.Expect(err).ToNot(HaveOccurred())
 				g.Expect(resp.Instance).To(Equal("test-server-1"))
 			}, "30s", "1s").Should(Succeed())
+
+			Expect(k8s.KubectlDeleteFromStringE(
+				kubernetes.Cluster.GetTesting(),
+				kubernetes.Cluster.GetKubectlOptions(namespace),
+				route,
+			)).To(Succeed())
 		})
 
 		It("should manage Kuma Secret", func() {


### PR DESCRIPTION
### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [x] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
