### PR TITLE
fix(kuma-cp): add possibility to filter requests to dp server. 

### DIFF
--- a/pkg/core/bootstrap/bootstrap.go
+++ b/pkg/core/bootstrap/bootstrap.go
@@ -3,6 +3,7 @@ package bootstrap
 import (
 	"context"
 	"net"
+	"net/http"
 
 	"github.com/pkg/errors"
 
@@ -121,7 +122,9 @@ func buildRuntime(appCtx context.Context, cfg kuma_cp.Config) (core_runtime.Runt
 		return nil, err
 	}
 	builder.WithCAProvider(caProvider)
-	builder.WithDpServer(server.NewDpServer(*cfg.DpServer, builder.Metrics()))
+	builder.WithDpServer(server.NewDpServer(*cfg.DpServer, builder.Metrics(), func(writer http.ResponseWriter, request *http.Request) bool {
+		return true
+	}))
 	builder.WithKDSContext(kds_context.DefaultContext(appCtx, builder.ResourceManager(), cfg.Multizone.Zone.Name))
 	builder.WithInterCPClientPool(intercp.DefaultClientPool())
 

--- a/pkg/dp-server/server/server.go
+++ b/pkg/dp-server/server/server.go
@@ -28,16 +28,19 @@ const (
 	grpcKeepAliveTime        = 15 * time.Second
 )
 
+type Filter func(writer http.ResponseWriter, request *http.Request) bool
+
 type DpServer struct {
 	config         dp_server.DpServerConfig
 	httpMux        *http.ServeMux
 	grpcServer     *grpc.Server
+	filter         Filter
 	promMiddleware middleware.Middleware
 }
 
 var _ component.Component = &DpServer{}
 
-func NewDpServer(config dp_server.DpServerConfig, metrics metrics.Metrics) *DpServer {
+func NewDpServer(config dp_server.DpServerConfig, metrics metrics.Metrics, filter Filter) *DpServer {
 	grpcOptions := []grpc.ServerOption{
 		grpc.MaxConcurrentStreams(grpcMaxConcurrentStreams),
 		grpc.KeepaliveParams(keepalive.ServerParameters{
@@ -63,6 +66,7 @@ func NewDpServer(config dp_server.DpServerConfig, metrics metrics.Metrics) *DpSe
 		config:         config,
 		httpMux:        http.NewServeMux(),
 		grpcServer:     grpcServer,
+		filter:         filter,
 		promMiddleware: promMiddleware,
 	}
 }
@@ -115,6 +119,10 @@ func (d *DpServer) NeedLeaderElection() bool {
 }
 
 func (d *DpServer) handle(writer http.ResponseWriter, request *http.Request) {
+	if !d.filter(writer, request) {
+		return
+	}
+	// add filter function that will be in runtime, and we will implement it in kong-mesh
 	if request.ProtoMajor == 2 && strings.Contains(request.Header.Get("Content-Type"), "application/grpc") {
 		d.grpcServer.ServeHTTP(writer, request)
 	} else {

--- a/pkg/test/runtime/runtime.go
+++ b/pkg/test/runtime/runtime.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"net/http"
 	"time"
 
 	"github.com/pkg/errors"
@@ -110,7 +111,9 @@ func BuilderFor(appCtx context.Context, cfg kuma_cp.Config) (*core_runtime.Build
 		return nil, err
 	}
 	builder.WithXDS(xdsCtx)
-	builder.WithDpServer(server.NewDpServer(*cfg.DpServer, metrics))
+	builder.WithDpServer(server.NewDpServer(*cfg.DpServer, metrics, func(writer http.ResponseWriter, request *http.Request) bool {
+		return true
+	}))
 	builder.WithKDSContext(kds_context.DefaultContext(appCtx, builder.ResourceManager(), cfg.Multizone.Zone.Name))
 	caProvider, err := secrets.NewCaProvider(builder.CaManagers(), metrics)
 	if err != nil {

--- a/pkg/xds/bootstrap/server_test.go
+++ b/pkg/xds/bootstrap/server_test.go
@@ -89,7 +89,9 @@ var _ = Describe("Bootstrap Server", func() {
 			TlsKeyFile:        filepath.Join("..", "..", "..", "test", "certs", "server-key.pem"),
 			ReadHeaderTimeout: config_types.Duration{Duration: 5 * time.Second},
 		}
-		dpServer := server.NewDpServer(dpServerCfg, metrics)
+		dpServer := server.NewDpServer(dpServerCfg, metrics, func(writer http.ResponseWriter, request *http.Request) bool {
+			return true
+		})
 
 		proxyConfig := xds_config.DefaultProxyConfig()
 


### PR DESCRIPTION
Thanks to this change, projects based on Kuma will be able to modify flow of requests to dp server.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [x] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
