### PR TITLE
test(e2e): fix and reenable Gateway API TLS test

### DIFF
--- a/test/e2e_env/kubernetes/gateway/gatewayapi.go
+++ b/test/e2e_env/kubernetes/gateway/gatewayapi.go
@@ -128,6 +128,7 @@ spec:
 			Expect(YamlK8s(haConfig)(kubernetes.Cluster)).To(Succeed())
 			Expect(YamlK8s(haGatewayClass)(kubernetes.Cluster)).To(Succeed())
 			Expect(YamlK8s(haGateway)(kubernetes.Cluster)).To(Succeed())
+			Expect(WaitPodsAvailable(namespace, gatewayName)(kubernetes.Cluster)).To(Succeed())
 		})
 		E2EAfterAll(func() {
 			Expect(k8s.RunKubectlE(kubernetes.Cluster.GetTesting(), kubernetes.Cluster.GetKubectlOptions(namespace), "delete", "gateway", gatewayName)).To(Succeed())
@@ -177,6 +178,7 @@ spec:
 		BeforeAll(func() {
 			Expect(YamlK8s(gateway)(kubernetes.Cluster)).To(Succeed())
 			address = net.JoinHostPort(GatewayIP(gatewayName), "10080")
+			Expect(WaitPodsAvailable(namespace, gatewayName)(kubernetes.Cluster)).To(Succeed())
 		})
 		E2EAfterAll(func() {
 			Expect(k8s.RunKubectlE(kubernetes.Cluster.GetTesting(), kubernetes.Cluster.GetKubectlOptions(namespace), "delete", "gateway", gatewayName)).To(Succeed())
@@ -386,12 +388,13 @@ spec:
 			Expect(YamlK8s(secret)(kubernetes.Cluster)).To(Succeed())
 			Expect(YamlK8s(gateway)(kubernetes.Cluster)).To(Succeed())
 			ip = GatewayIP(gatewayName)
+			Expect(WaitPodsAvailable(namespace, gatewayName)(kubernetes.Cluster)).To(Succeed())
 		})
 		E2EAfterAll(func() {
 			Expect(k8s.RunKubectlE(kubernetes.Cluster.GetTesting(), kubernetes.Cluster.GetKubectlOptions(namespace), "delete", "gateway", gatewayName)).To(Succeed())
 		})
 
-		XIt("should route the traffic using TLS", func() {
+		It("should route the traffic using TLS", func() {
 			// given
 			route := fmt.Sprintf(`
 apiVersion: gateway.networking.k8s.io/v1beta1


### PR DESCRIPTION
We weren't waiting for the Gateway to be ready which lead to 30s+ times until requests succeeded.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues -- Closes https://github.com/kumahq/kuma/issues/6175
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [x] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
