### PR TITLE
ci(mk): add back GINKGO_EDITOR_INTEGRATION in test/e2e*

### DIFF
--- a/mk/e2e.new.mk
+++ b/mk/e2e.new.mk
@@ -20,6 +20,7 @@ E2E_ENV_VARS+= CLEANUP_LOGS_ON_SUCCESS=true
 else
 E2E_K8S_BIN_DEPS+= build/kumactl images
 E2E_UNIVERSAL_BIN_DEPS+= build/kumactl images/test
+E2E_ENV_VARS+= GINKGO_EDITOR_INTEGRATION=true
 endif
 
 # We don't use `go list` here because Ginkgo requires disk path names,


### PR DESCRIPTION
This is required to run tests with focus

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [x] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
