### PR TITLE
fix(kuma-cni): ipv6 iptables with provided gateway and CNI V2

### DIFF
--- a/app/cni/pkg/cni/injector_linux.go
+++ b/app/cni/pkg/cni/injector_linux.go
@@ -94,22 +94,21 @@ func mapToConfig(intermediateConfig *IntermediateConfig, logWriter *bufio.Writer
 	if err != nil {
 		return nil, err
 	}
+	inboundPortV6, err := convertToUint16("inbound port ipv6", intermediateConfig.inboundPortV6)
+	if err != nil {
+		return nil, err
+	}
+	enableIpV6, err := transparentproxy.ShouldEnableIPv6(inboundPortV6)
+	if err != nil {
+		return nil, err
+	}
+	cfg.IPv6 = enableIpV6
 	redirectInbound := !isGateway
 	if redirectInbound {
 		inboundPort, err := convertToUint16("inbound port", intermediateConfig.inboundPort)
 		if err != nil {
 			return nil, err
 		}
-
-		inboundPortV6, err := convertToUint16("inbound port ipv6", intermediateConfig.inboundPortV6)
-		if err != nil {
-			return nil, err
-		}
-		enableIpV6, err := transparentproxy.ShouldEnableIPv6(inboundPortV6)
-		if err != nil {
-			return nil, err
-		}
-		cfg.IPv6 = enableIpV6
 
 		excludedPorts, err := convertCommaSeparatedString(intermediateConfig.excludeInboundPorts)
 		if err != nil {

--- a/test/e2e_env/multizone/connectivity/cni_v2_ipv6_gateway.go
+++ b/test/e2e_env/multizone/connectivity/cni_v2_ipv6_gateway.go
@@ -1,0 +1,55 @@
+package connectivity
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/kumahq/kuma/pkg/plugins/runtime/k8s/metadata"
+	. "github.com/kumahq/kuma/test/framework"
+	"github.com/kumahq/kuma/test/framework/client"
+	"github.com/kumahq/kuma/test/framework/deployments/democlient"
+	"github.com/kumahq/kuma/test/framework/deployments/testserver"
+	"github.com/kumahq/kuma/test/framework/envs/multizone"
+)
+
+func GatewayIPV6CNIV2() {
+	namespace := "gw-ipv6-cniv2"
+	meshName := "gw-ipv6-cniv2"
+
+	BeforeAll(func() {
+		Expect(multizone.Global.Install(MTLSMeshUniversal(meshName))).To(Succeed())
+		Expect(WaitForMesh(meshName, multizone.Zones())).To(Succeed())
+
+		err := NewClusterSetup().
+			Install(NamespaceWithSidecarInjection(namespace)).
+			Install(democlient.Install(
+				democlient.WithNamespace(namespace),
+				democlient.WithMesh(meshName),
+				democlient.WithPodAnnotations(map[string]string{
+					metadata.KumaGatewayAnnotation: "enabled",
+				}),
+			)).
+			Install(testserver.Install(
+				testserver.WithNamespace(namespace),
+				testserver.WithMesh(meshName),
+				testserver.WithEchoArgs("echo", "--instance", "kube-test-server"),
+			)).
+			Setup(multizone.KubeZone2)
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	E2EAfterAll(func() {
+		Expect(multizone.KubeZone2.TriggerDeleteNamespace(namespace)).To(Succeed())
+		Expect(multizone.Global.DeleteMesh(meshName)).To(Succeed())
+	})
+
+	It("client should communicate with server", func() {
+		Eventually(func(g Gomega) {
+			response, err := client.CollectEchoResponse(multizone.KubeZone2, "demo-client", "http://test-server_gw-ipv6-cniv2_svc_80.mesh",
+				client.FromKubernetesPod(meshName, "demo-client"),
+			)
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(response.Instance).To(Equal("kube-test-server"))
+		}, "30s", "1s").Should(Succeed())
+	})
+}

--- a/test/e2e_env/multizone/multizone_suite_test.go
+++ b/test/e2e_env/multizone/multizone_suite_test.go
@@ -44,6 +44,7 @@ var (
 	_ = Describe("InboundPassthroughDisabled", inbound_communication.InboundPassthroughDisabled, Ordered)
 	_ = Describe("ZoneEgress Internal Services", zoneegress.InternalServices, Ordered)
 	_ = Describe("Connectivity", connectivity.Connectivity, Ordered)
+	_ = Describe("Connectivity Gateway IPV6 CNI V2", connectivity.GatewayIPV6CNIV2, Ordered)
 	_ = Describe("Sync", multizone_sync.Sync, Ordered)
 	_ = Describe("MeshTrafficPermission", meshtrafficpermission.MeshTrafficPermission, Ordered)
 	_ = Describe("Zone Disable", zonedisable.ZoneDisable, Ordered)


### PR DESCRIPTION
Fix #6017

`cfg.IPv6` was set only for non-gateways.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [ ] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [x] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
