### PR TITLE
ci(mk): fix targets for `make run/*`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,6 @@ include mk/check.mk
 include mk/test.mk
 include mk/generate.mk
 include mk/docker.mk
-include mk/run.mk
 include mk/kind.mk
 include mk/k3d.mk
 include mk/e2e.new.mk
@@ -30,3 +29,4 @@ include mk/envoy.mk
 include mk/helm.mk
 include mk/ebpf.mk
 include mk/distribution.mk
+include mk/run.mk

--- a/mk/distribution.mk
+++ b/mk/distribution.mk
@@ -15,6 +15,7 @@ PULP_DIST_VERSION ?= release
 ifneq (,$(findstring preview,$(BUILD_INFO_VERSION)))
 	PULP_DIST_VERSION=preview
 endif
+DISTRIBUTION_FOLDER=build/distributions/$(GOOS)-$(GOARCH)/$(DISTRIBUTION_TARGET_NAME)
 
 
 # This function dynamically builds targets for building distribution packages and uploading them to pulp with a set of parameters

--- a/mk/docker.mk
+++ b/mk/docker.mk
@@ -106,7 +106,7 @@ docker/save: $(patsubst %,docker/%/save,$(ALL_RELEASE_WITH_ARCH) $(ALL_TEST_WITH
 .PHONY: docker/load
 docker/load: $(patsubst %,docker/%/load,$(ALL_RELEASE_WITH_ARCH) $(ALL_TEST_WITH_ARCH))
 .PHONY: docker/tag
-docker/tag: docker/tag/test docker/tag/release
+docker/tag: docker/tag/test docker/tag/release ## Tag local arch containers with the version with the arch (this is mostly to use non multi-arch images as if they were released images in e2e tests)
 .PHONY: docker/tag/release
 docker/tag/release: $(patsubst %,docker/%/tag,$(ALL_RELEASE_WITH_ARCH))
 .PHONY: docker/tag/test

--- a/mk/docs.mk
+++ b/mk/docs.mk
@@ -18,7 +18,7 @@ docs/install/markdown: ## Generate CLI reference in markdown format
 .PHONY: docs/install/manpages
 docs/install/manpages: DESTDIR:=$(DESTDIR)/manpages
 docs/install/manpages: ## Generate CLI reference in man(1) format
-	@DESTDIR=$(DESTDIR) FORMAT=man $(GO_RUN) $(TOOLS_DIR)/docs/generate.go
+	@DESTDIR=$(DESTDIR) FORMAT=man go run $(TOOLS_DIR)/docs/generate.go
 
 .PHONY: docs/install/resources
 docs/install/resources: DESTDIR:=$(DESTDIR)/resources

--- a/mk/generate.mk
+++ b/mk/generate.mk
@@ -1,6 +1,5 @@
 ENVOY_IMPORTS := ./pkg/xds/envoy/imports.go
 PROTO_DIRS ?= ./pkg/config ./api
-
 CONTROLLER_GEN := go run -mod=mod sigs.k8s.io/controller-tools/cmd/controller-gen
 RESOURCE_GEN := go run -mod=mod $(TOOLS_DIR)/resource-gen/main.go
 POLICY_GEN := go run -mod=mod $(TOOLS_DIR)/policy-gen/generator/main.go
@@ -23,8 +22,8 @@ generate: $(GENERATE_TARGET)
 
 .PHONY: resources/type
 resources/type:
-	$(GO_RUN) $(TOOLS_DIR)/resource-gen/main.go -package mesh -generator type > pkg/core/resources/apis/mesh/zz_generated.resources.go
-	$(GO_RUN) $(TOOLS_DIR)/resource-gen/main.go -package system -generator type > pkg/core/resources/apis/system/zz_generated.resources.go
+	go run $(TOOLS_DIR)/resource-gen/main.go -package mesh -generator type > pkg/core/resources/apis/mesh/zz_generated.resources.go
+	go run $(TOOLS_DIR)/resource-gen/main.go -package system -generator type > pkg/core/resources/apis/system/zz_generated.resources.go
 
 .PHONY: protoc/pkg/config/app/kumactl/v1alpha1
 protoc/pkg/config/app/kumactl/v1alpha1:
@@ -43,7 +42,7 @@ generate_policy_targets = $(addprefix generate/policy/,$(policies))
 cleanup_policy_targets = $(addprefix cleanup/policy/,$(policies))
 
 GENERATE_POLICIES_TARGET ?= cleanup/crds cleanup/policies generate/deep-copy/common $(generate_policy_targets) generate/policy-import generate/policy-helm generate/builtin-crds generate/fix-embed
-generate/policies: $(GENERATE_POLICIES_TARGET)
+generate/policies: $(GENERATE_POLICIES_TARGET) ## Generate all policies written as plugins
 
 cleanup/crds:
 	rm -f ./deployments/charts/kuma/crds/*

--- a/mk/kind.mk
+++ b/mk/kind.mk
@@ -138,7 +138,7 @@ kind/deploy/example-app:
 	@KUBECONFIG=$(KIND_KUBECONFIG) $(KUBECTL) apply -n $(EXAMPLE_NAMESPACE) -f dev/examples/k8s/example-app/example-app.yaml
 
 .PHONY: run/k8s
-run/k8s: generate/builtin-crds ## Dev: Run Control Plane locally in Kubernetes mode
+run/k8s: build/kuma-cp generate/builtin-crds ## Dev: Run Control Plane locally in Kubernetes mode
 	$(KUBECTL) diff -f pkg/plugins/resources/k8s/native/config/crd/bases || $(KUBECTL) apply -f pkg/plugins/resources/k8s/native/config/crd/bases
 	KUBECONFIG=$(KIND_KUBECONFIG) \
 	KUMA_ENVIRONMENT=kubernetes \
@@ -147,7 +147,7 @@ run/k8s: generate/builtin-crds ## Dev: Run Control Plane locally in Kubernetes m
 	KUMA_SDS_SERVER_TLS_KEY_FILE=app/kuma-cp/cmd/testdata/tls.key \
 	KUMA_RUNTIME_KUBERNETES_ADMISSION_SERVER_PORT=$(CP_K8S_ADMISSION_PORT) \
 	KUMA_RUNTIME_KUBERNETES_ADMISSION_SERVER_CERT_DIR=app/kuma-cp/cmd/testdata \
-	$(GO_RUN) ./app/kuma-cp/main.go run --log-level=debug
+	$(BUILD_ARTIFACTS_DIR)/kuma-cp/kuma-cp --log-level=debug
 
 run/example/envoy/k8s: EXAMPLE_DATAPLANE_MESH=$(KIND_EXAMPLE_DATAPLANE_MESH)
 run/example/envoy/k8s: EXAMPLE_DATAPLANE_NAME=$(KIND_EXAMPLE_DATAPLANE_NAME)


### PR DESCRIPTION
- added `make run/kuma-cp POSTGRES_MODE=tls CP_STORE=postgres`
- added `make run/kuma-dp`
- added `make run/echo-server`

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [x] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
