### PR TITLE
fix(kuma-cp): add set filter method, so we could modify it easily in runtime

### DIFF
--- a/pkg/dp-server/server/server.go
+++ b/pkg/dp-server/server/server.go
@@ -139,3 +139,7 @@ func (d *DpServer) HTTPMux() *http.ServeMux {
 func (d *DpServer) GrpcServer() *grpc.Server {
 	return d.grpcServer
 }
+
+func (d *DpServer) SetFilter(filter Filter) {
+	d.filter = filter
+}


### PR DESCRIPTION


### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [x] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
