### PR TITLE
refactor(events): use channel for Recv instead of blocking

### DIFF
--- a/pkg/events/eventbus.go
+++ b/pkg/events/eventbus.go
@@ -2,8 +2,6 @@ package events
 
 import (
 	"sync"
-
-	"github.com/pkg/errors"
 )
 
 func NewEventBus() *EventBus {
@@ -46,14 +44,6 @@ type reader struct {
 	events chan Event
 }
 
-func (k *reader) Recv(stop <-chan struct{}) (Event, error) {
-	select {
-	case event, ok := <-k.events:
-		if !ok {
-			return nil, errors.New("end of events channel")
-		}
-		return event, nil
-	case <-stop:
-		return nil, ListenerStoppedErr
-	}
+func (k *reader) Recv() <-chan Event {
+	return k.events
 }

--- a/pkg/events/interfaces.go
+++ b/pkg/events/interfaces.go
@@ -25,7 +25,7 @@ type ResourceChangedEvent struct {
 var ListenerStoppedErr = errors.New("listener closed")
 
 type Listener interface {
-	Recv(stop <-chan struct{}) (Event, error)
+	Recv() <-chan Event
 }
 
 type Emitter interface {

--- a/pkg/insights/resyncer.go
+++ b/pkg/insights/resyncer.go
@@ -2,6 +2,7 @@ package insights
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 	"time"
@@ -134,43 +135,46 @@ func (r *resyncer) Start(stop <-chan struct{}) error {
 
 	eventReader := r.eventFactory.New()
 	for {
-		event, err := eventReader.Recv(stop)
-		if err == events.ListenerStoppedErr {
+		select {
+		case <-stop:
 			return nil
-		}
-		if err != nil {
-			return err
-		}
-		resourceChanged, ok := event.(events.ResourceChangedEvent)
-		if !ok {
-			continue
-		}
-		desc, err := r.registry.DescriptorFor(resourceChanged.Type)
-		if err != nil {
-			log.Error(err, "Resource is not registered in the registry, ignoring it", "resource", resourceChanged.Type)
-		}
-		if resourceChanged.Type == core_mesh.MeshType && resourceChanged.Operation == events.Delete {
-			r.deleteRateLimiter(resourceChanged.Key.Name)
-		}
-		if !r.getRateLimiter(resourceChanged.Key.Mesh).Allow() {
-			continue
-		}
-		if _, ok := resourcesAffectingServiceInsights[resourceChanged.Type]; ok {
-			if err := r.createOrUpdateServiceInsight(ctx, resourceChanged.Key.Mesh, time.Now()); err != nil {
-				log.Error(err, "unable to resync ServiceInsight", "mesh", resourceChanged.Key.Mesh)
+		case event, closed := <-eventReader.Recv():
+			if closed {
+				return errors.New("end of events channel")
 			}
-		}
-		if desc.Scope == model.ScopeGlobal {
-			continue
-		}
-		if resourceChanged.Operation == events.Update && resourceChanged.Type != core_mesh.DataplaneInsightType {
-			// 'Update' events doesn't affect MeshInsight except for DataplaneInsight,
-			// because that's how we find online/offline Dataplane's status
-			continue
-		}
-		if err := r.createOrUpdateMeshInsight(ctx, resourceChanged.Key.Mesh, time.Now()); err != nil {
-			log.Error(err, "unable to resync MeshInsight", "mesh", resourceChanged.Key.Mesh)
-			continue
+
+			resourceChanged, ok := event.(events.ResourceChangedEvent)
+			if !ok {
+				continue
+			}
+
+			desc, err := r.registry.DescriptorFor(resourceChanged.Type)
+			if err != nil {
+				log.Error(err, "Resource is not registered in the registry, ignoring it", "resource", resourceChanged.Type)
+			}
+			if resourceChanged.Type == core_mesh.MeshType && resourceChanged.Operation == events.Delete {
+				r.deleteRateLimiter(resourceChanged.Key.Name)
+			}
+			if !r.getRateLimiter(resourceChanged.Key.Mesh).Allow() {
+				continue
+			}
+			if _, ok := resourcesAffectingServiceInsights[resourceChanged.Type]; ok {
+				if err := r.createOrUpdateServiceInsight(ctx, resourceChanged.Key.Mesh, time.Now()); err != nil {
+					log.Error(err, "unable to resync ServiceInsight", "mesh", resourceChanged.Key.Mesh)
+				}
+			}
+			if desc.Scope == model.ScopeGlobal {
+				continue
+			}
+			if resourceChanged.Operation == events.Update && resourceChanged.Type != core_mesh.DataplaneInsightType {
+				// 'Update' events doesn't affect MeshInsight except for DataplaneInsight,
+				// because that's how we find online/offline Dataplane's status
+				continue
+			}
+			if err := r.createOrUpdateMeshInsight(ctx, resourceChanged.Key.Mesh, time.Now()); err != nil {
+				log.Error(err, "unable to resync MeshInsight", "mesh", resourceChanged.Key.Mesh)
+				continue
+			}
 		}
 	}
 }

--- a/pkg/insights/test/test_event_reader.go
+++ b/pkg/insights/test/test_event_reader.go
@@ -6,8 +6,8 @@ type TestEventReader struct {
 	Ch chan events.Event
 }
 
-func (t *TestEventReader) Recv(stop <-chan struct{}) (events.Event, error) {
-	return <-t.Ch, nil
+func (t *TestEventReader) Recv() <-chan events.Event {
+	return t.Ch
 }
 
 type TestEventReaderFactory struct {

--- a/pkg/plugins/resources/postgres/listener_test.go
+++ b/pkg/plugins/resources/postgres/listener_test.go
@@ -42,12 +42,14 @@ var _ = Describe("Events", func() {
 			listener := setupListeners(cfg, driverName, listenerErrCh, listenerStopCh)
 			go triggerNotifications(cfg, storeErrCh)
 
+			eventsChan := listener.Recv()
+
 			// when
-			event, err := listener.Recv(eventBusStopCh)
+			var resourceChanged kuma_events.ResourceChangedEvent
+			Eventually(eventsChan, "1s").Should(Receive(&resourceChanged))
+			Expect(eventBusStopCh).ToNot(BeClosed())
 
 			// then
-			Expect(err).To(Not(HaveOccurred()))
-			resourceChanged := event.(kuma_events.ResourceChangedEvent)
 			Expect(resourceChanged.Operation).To(Equal(kuma_events.Create))
 			Expect(resourceChanged.Type).To(Equal(model.ResourceType("Mesh")))
 
@@ -69,30 +71,24 @@ var _ = Describe("Events", func() {
 			listener := setupListeners(cfg, driverName, listenerErrCh, listenerStopCh)
 			go triggerNotifications(cfg, storeErrCh)
 
-			// when
-			event, err := listener.Recv(eventBusStopCh)
+			eventsChan := listener.Recv()
 
-			// then
-			Expect(err).To(Not(HaveOccurred()))
-			resourceChanged := event.(kuma_events.ResourceChangedEvent)
+			// when
+			var resourceChanged kuma_events.ResourceChangedEvent
+			Eventually(eventsChan, "1s").Should(Receive(&resourceChanged))
+			Expect(eventBusStopCh).ToNot(BeClosed())
+
 			Expect(resourceChanged.Operation).To(Equal(kuma_events.Create))
 			Expect(resourceChanged.Type).To(Equal(model.ResourceType("Mesh")))
 
-			// when postgres is stopped
-			err = c.Stop()
-
-			// then
-			Expect(err).To(Not(HaveOccurred()))
+			Expect(c.Stop()).To(Succeed())
 			Consistently(storeErrCh, "1s", "100ms").Should(Receive())
 
-			// when postgres is restarted
-			err = c.Start()
+			Expect(c.Start()).To(Succeed())
 
-			// then
-			Expect(err).To(Not(HaveOccurred()))
-			event, err = listener.Recv(eventBusStopCh)
-			Expect(err).To(Not(HaveOccurred()))
-			resourceChanged = event.(kuma_events.ResourceChangedEvent)
+			Eventually(eventsChan, "5s").Should(Receive(&resourceChanged))
+			Expect(eventBusStopCh).ToNot(BeClosed())
+
 			Expect(resourceChanged.Operation).To(Equal(kuma_events.Create))
 			Expect(resourceChanged.Type).To(Equal(model.ResourceType("Mesh")))
 		},


### PR DESCRIPTION
Having access to the channel makes it much easier to compose receiving events with reacting to other channels.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [x] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
