### PR TITLE
fix(helm): upgrade CRDs instead of installing missing CRDs

### DIFF
--- a/deployments/charts/kuma/templates/pre-upgrade-install-crds-job.yaml
+++ b/deployments/charts/kuma/templates/pre-upgrade-install-crds-job.yaml
@@ -1,6 +1,6 @@
 {{- if (and .Values.installCrdsOnUpgrade.enabled (eq .Values.controlPlane.environment "kubernetes")) }}
   {{ $hook := "pre-upgrade,pre-install" }}
-  {{- $serviceAccountName := printf "%s-install-missing-crds" (include "kuma.name" .) }}
+  {{- $serviceAccountName := printf "%s-install-crds" (include "kuma.name" .) }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -22,7 +22,7 @@ imagePullSecrets:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ include "kuma.name" . }}-install-missing-crds
+  name: {{ include "kuma.name" . }}-install-crds
   annotations:
     "helm.sh/hook": "{{ $hook }}"
     "helm.sh/hook-weight": "-1"
@@ -36,13 +36,15 @@ rules:
       - customresourcedefinitions
     verbs:
       - create
+      - patch
+      - update
       - list
       - get
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ include "kuma.name" . }}-install-missing-crds
+  name: {{ include "kuma.name" . }}-install-crds
   annotations:
     "helm.sh/hook": "{{ $hook }}"
     "helm.sh/hook-weight": "-1"
@@ -52,7 +54,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ include "kuma.name" . }}-install-missing-crds
+  name: {{ include "kuma.name" . }}-install-crds
 subjects:
   - kind: ServiceAccount
     name: {{ $serviceAccountName }}
@@ -61,7 +63,7 @@ subjects:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ include "kuma.name" . }}-install-missing-crds-scripts
+  name: {{ include "kuma.name" . }}-install-crds-scripts
   namespace: {{ .Release.Namespace }}
   annotations:
     "helm.sh/hook": "{{ $hook }}"
@@ -70,27 +72,31 @@ metadata:
   labels:
   {{- include "kuma.labels" . | nindent 4 }}
 data:
-  install_missing_crds.sh: |
+  install_crds.sh: |
     #!/usr/bin/env sh
+    set -e
 
-    if [ -s /kuma/missing/crds.yaml ]; then
-      echo "/kuma/missing/crds.yaml found and is not empty, adding crds"
-      kubectl create -f /kuma/missing/crds.yaml
+    if [ -s /kuma/crds/crds.yaml ]; then
+      echo "/kuma/crds/crds.yaml found and is not empty, adding crds"
+      kubectl apply -f /kuma/crds/crds.yaml
     else
-      echo "/kuma/missing/crds.yaml not found or empty, it looks like there is no missing crds"
+      echo "/kuma/crds/crds.yaml not found or empty, it looks like there is no crds to install"
     fi
-  save_missing_crds.sh: |
-    missing_crds="$(kumactl install crds --only-missing {{ if .Values.experimental.gatewayAPI }}--experimental-gatewayapi{{end}})"
+  save_crds.sh: |
+    #!/usr/bin/env sh
+    set -e
+    
+    crds="$(kumactl install crds --no-config {{ if .Values.experimental.gatewayAPI }}--experimental-gatewayapi{{end}})"
 
-    if [ -n "${missing_crds}" ]; then
-      echo "found missing crds - saving to /kuma/missing/crds.yaml"
-      echo "${missing_crds}" > /kuma/missing/crds.yaml
+    if [ -n "${crds}" ]; then
+      echo "found crds - saving to /kuma/crds/crds.yaml"
+      echo "${crds}" > /kuma/crds/crds.yaml
     fi
 ---
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: {{ template "kuma.name" . }}-install-missing-crds
+  name: {{ template "kuma.name" . }}-install-crds
   namespace: {{ .Release.Namespace }}
   labels:
   {{ include "kuma.labels" . | nindent 4 }}
@@ -100,7 +106,7 @@ metadata:
 spec:
   template:
     metadata:
-      name: {{ template "kuma.name" . }}-install-missing-crds-job
+      name: {{ template "kuma.name" . }}-install-crds-job
       labels:
     {{ include "kuma.labels" . | nindent 8 }}
     spec:
@@ -129,10 +135,10 @@ spec:
                cpu: "100m"
                memory: "256Mi"
           command:
-            - '/kuma/scripts/install_missing_crds.sh'
+            - '/kuma/scripts/install_crds.sh'
           volumeMounts:
-            - mountPath: /kuma/missing
-              name: missing-crds
+            - mountPath: /kuma/crds
+              name: crds
               readOnly: true
             - mountPath: /kuma/scripts
               name: scripts
@@ -150,18 +156,18 @@ spec:
                cpu: "100m"
                memory: "256Mi"
           volumeMounts:
-          - mountPath: /kuma/missing
-            name: missing-crds
+          - mountPath: /kuma/crds
+            name: crds
           - mountPath: /kuma/scripts
             name: scripts
             readOnly: true
           args:
-          - '/kuma/scripts/save_missing_crds.sh'
+          - '/kuma/scripts/save_crds.sh'
       volumes:
         - name: scripts
           configMap:
-            name: {{ include "kuma.name" . }}-install-missing-crds-scripts
+            name: {{ include "kuma.name" . }}-install-crds-scripts
             defaultMode: 0755
-        - name: missing-crds
+        - name: crds
           emptyDir: {}
 {{- end }}

--- a/deployments/charts/kuma/templates/pre-upgrade-install-crds-job.yaml
+++ b/deployments/charts/kuma/templates/pre-upgrade-install-crds-job.yaml
@@ -83,7 +83,6 @@ data:
       echo "/kuma/crds/crds.yaml not found or empty, it looks like there is no crds to install"
     fi
   save_crds.sh: |
-    #!/usr/bin/env sh
     set -e
     
     crds="$(kumactl install crds --no-config {{ if .Values.experimental.gatewayAPI }}--experimental-gatewayapi{{end}})"

--- a/test/e2e/helm/kuma_helm_upgrade.go
+++ b/test/e2e/helm/kuma_helm_upgrade.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/gruntwork-io/terratest/modules/k8s"
 	"github.com/gruntwork-io/terratest/modules/random"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -52,8 +53,19 @@ func UpgradingWithHelmChart() {
 
 			k8sCluster := cluster.(*K8sCluster)
 
-			err = k8sCluster.UpgradeKuma(core.Standalone, WithHelmReleaseName(releaseName))
+			err = k8sCluster.UpgradeKuma(core.Standalone, WithHelmReleaseName(releaseName), WithHelmChartPath(Config.HelmChartPath))
 			Expect(err).ToNot(HaveOccurred())
+
+			// when
+			out, err := k8s.RunKubectlAndGetOutputE(
+				k8sCluster.GetTesting(),
+				k8sCluster.GetKubectlOptions(),
+				"get", "crd", "meshtrafficpermissions.kuma.io", "-oyaml",
+			)
+
+			// then CRD is upgraded
+			Expect(out).To(ContainSubstring("AllowWithShadowDeny"))
+			// remove this when+then after initialChartVersion is changed to 2.1.x or later
 		},
 		func() []TableEntry {
 			var out []TableEntry

--- a/test/e2e/helm/kuma_helm_upgrade.go
+++ b/test/e2e/helm/kuma_helm_upgrade.go
@@ -64,6 +64,7 @@ func UpgradingWithHelmChart() {
 			)
 
 			// then CRD is upgraded
+			Expect(err).ToNot(HaveOccurred())
 			Expect(out).To(ContainSubstring("AllowWithShadowDeny"))
 			// remove this when+then after initialChartVersion is changed to 2.1.x or later
 		},

--- a/test/framework/config.go
+++ b/test/framework/config.go
@@ -210,7 +210,7 @@ var defaultConf = E2eConfig{
 	SuiteConfig: SuiteConfig{
 		Helm: HelmSuiteConfig{
 			Versions: []string{
-				"1.6.0",
+				"2.0.1",
 			},
 		},
 		Compatibility: CompatibilitySuiteConfig{


### PR DESCRIPTION
Fix #6201

Helm by default does not manage CRDs aside from installing them on the first Helm install.
That's why a long time ago we created a Helm pre-upgrade job that installs missing CRDs.
This solution worked so far because CRDs for the old policies did not have "content" in them.
With new policies, the CRDs have a definition of all the fields. In Kuma 2.1.0 we changed an enum in `MeshTrafficPermission` from `ALLOW` to `Allow`.

However, our job did not upgrade CRDs it only installed them if they were missing.
This PR changes the job to reapply CRDs and not only create them.

* I changed the job name from `install-missing-crds` to `install-crds`, to avoid confusion.
* I removed `--only-missing` arg to reapply all crds
* I added `--no-config` because the job was failing with `Error: Failed to create a directory "/home/nonroot/.kumactl": mkdir /home/nonroot/.kumactl: read-only file system`
* I added `set -e` to scripts because the job was silently failing.
* I added `WithHelmChartPath` in `Upgrade` in E2E. Without it, we didn't even upgrade, because of the initial `WithHelmChartPath(Config.HelmChartName)` opt-in install
* I changed the version we upgrade from to install the old MeshTrafficPermission. I piggybacked on the existing E2E test because upgrade HELM tests are pretty heavy.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [X] [Link to relevant issue][1] as well as docs and UI issues --
- [X] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [X] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [X] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [X] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [X] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
