### PR TITLE
test(e2e): fix helm upgrade test

### DIFF
--- a/test/e2e/helm/kuma_helm_upgrade.go
+++ b/test/e2e/helm/kuma_helm_upgrade.go
@@ -26,7 +26,7 @@ func UpgradingWithHelmChart() {
 		initialChartVersion string
 	}
 
-	PDescribeTable(
+	DescribeTable(
 		"should successfully upgrade Kuma via Helm",
 		func(given testCase) {
 			t := NewTestingT()
@@ -46,14 +46,17 @@ func UpgradingWithHelmChart() {
 					WithHelmReleaseName(releaseName),
 					WithHelmChartVersion(given.initialChartVersion),
 					WithoutHelmOpt("global.image.tag"),
-					WithHelmOpt("global.image.registry", Config.KumaImageRegistry),
 				)).
 				Setup(cluster)
 			Expect(err).ToNot(HaveOccurred())
 
 			k8sCluster := cluster.(*K8sCluster)
 
-			err = k8sCluster.UpgradeKuma(core.Standalone, WithHelmReleaseName(releaseName), WithHelmChartPath(Config.HelmChartPath))
+			err = k8sCluster.UpgradeKuma(core.Standalone,
+				WithHelmReleaseName(releaseName),
+				WithHelmChartPath(Config.HelmChartPath),
+				ClearNoHelmOpts(),
+			)
 			Expect(err).ToNot(HaveOccurred())
 
 			// when

--- a/test/framework/interface.go
+++ b/test/framework/interface.go
@@ -257,6 +257,12 @@ func WithoutHelmOpt(name string) KumaDeploymentOption {
 	})
 }
 
+func ClearNoHelmOpts() KumaDeploymentOption {
+	return KumaOptionFunc(func(o *kumaDeploymentOptions) {
+		o.noHelmOpts = nil
+	})
+}
+
 func WithEnv(name, value string) KumaDeploymentOption {
 	return KumaOptionFunc(func(o *kumaDeploymentOptions) {
 		o.env[name] = value


### PR DESCRIPTION
Before my recent PR https://github.com/kumahq/kuma/pull/6403 Helm Upgrade test did not even upgrade Kuma. It was executing Upgrade on the same Helm Kuma version.

Helm opts are stored in the ControlPlane object, therefore there are carried to Upgrade command. The problem was that the first install was calling `WithoutHelmOpt("global.image.tag")` so that it disable default override of `global.image.tag` https://github.com/kumahq/kuma/blob/master/test/framework/k8s_cluster.go#L409 . However, it was carried to `Upgrade()` call. Therefore it was using the default app version from helm which is https://github.com/kumahq/kuma/blob/master/deployments/charts/kuma/Chart.yaml#L6

This worked on my machine, because as I develop I had images with `0.0.0-preview.vlocal-build` tag locally.

I also removed `WithHelmOpt("global.image.registry", Config.KumaImageRegistry)` since it's redundant. There is already such default https://github.com/kumahq/kuma/blob/master/test/framework/k8s_cluster.go#L407

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [X] [Link to relevant issue][1] as well as docs and UI issues --
- [X] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [X] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [X] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [X] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [X] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
