### PR TITLE
chore(xds): don't use deprecated option `envoy.config.route.v3.WeightedCluster.total_weight`

### DIFF
--- a/pkg/plugins/policies/meshratelimit/plugin/v1alpha1/testdata/gateway_basic_routes.golden.yaml
+++ b/pkg/plugins/policies/meshratelimit/plugin/v1alpha1/testdata/gateway_basic_routes.golden.yaml
@@ -18,7 +18,6 @@ virtualHosts:
               key: x-kuma-tags
               value: '&kuma.io/service=sample-gateway&'
           weight: 1
-        totalWeight: 1
     typedPerFilterConfig:
       envoy.filters.http.local_ratelimit:
         '@type': type.googleapis.com/envoy.extensions.filters.http.local_ratelimit.v3.LocalRateLimit

--- a/pkg/plugins/policies/meshtimeout/plugin/testdata/gateway_route.golden.yaml
+++ b/pkg/plugins/policies/meshtimeout/plugin/testdata/gateway_route.golden.yaml
@@ -19,4 +19,3 @@ virtualHosts:
               key: x-kuma-tags
               value: '&kuma.io/service=sample-gateway&'
           weight: 1
-        totalWeight: 1

--- a/pkg/plugins/runtime/gateway/route/configurers.go
+++ b/pkg/plugins/runtime/gateway/route/configurers.go
@@ -451,12 +451,9 @@ func RouteActionForward(mesh *core_mesh.MeshResource, endpoints core_xds.Endpoin
 			byName[d.Name] = d
 		}
 
-		var total uint32
 		var weights []*envoy_config_route.WeightedCluster_ClusterWeight
 
 		for n, d := range byName {
-			total += d.Weight
-
 			var requestHeadersToAdd []*envoy_config_core.HeaderValueOption
 
 			isMeshCluster := mesh.ZoneEgressEnabled() || !HasExternalServiceEndpoint(mesh, endpoints, d)
@@ -479,8 +476,7 @@ func RouteActionForward(mesh *core_mesh.MeshResource, endpoints core_xds.Endpoin
 				Timeout: nil, // TODO(jpeach) support request timeout from the Timeout policy, but which one?
 				ClusterSpecifier: &envoy_config_route.RouteAction_WeightedClusters{
 					WeightedClusters: &envoy_config_route.WeightedCluster{
-						Clusters:    weights,
-						TotalWeight: util_proto.UInt32(total),
+						Clusters: weights,
 					},
 				},
 			},

--- a/pkg/plugins/runtime/gateway/testdata/http/01-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/01-gateway-route.yaml
@@ -136,7 +136,6 @@ Routes:
                     key: x-kuma-tags
                     value: '&kuma.io/service=gateway-default&'
                 weight: 1
-              totalWeight: 1
       - domains:
         - bar.example.com
         name: bar.example.com
@@ -160,7 +159,6 @@ Routes:
                     key: x-kuma-tags
                     value: '&kuma.io/service=gateway-default&'
                 weight: 1
-              totalWeight: 1
       - domains:
         - '*.example.com'
         name: '*.example.com'
@@ -184,7 +182,6 @@ Routes:
                     key: x-kuma-tags
                     value: '&kuma.io/service=gateway-default&'
                 weight: 1
-              totalWeight: 1
       - domains:
         - '*'
         name: '*'

--- a/pkg/plugins/runtime/gateway/testdata/http/02-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/02-gateway-route.yaml
@@ -136,7 +136,6 @@ Routes:
                     key: x-kuma-tags
                     value: '&kuma.io/service=gateway-default&'
                 weight: 1
-              totalWeight: 1
       - domains:
         - '*'
         name: '*'
@@ -160,7 +159,6 @@ Routes:
                     key: x-kuma-tags
                     value: '&kuma.io/service=gateway-default&'
                 weight: 1
-              totalWeight: 1
 Runtimes:
   Resources:
     gateway.listeners:

--- a/pkg/plugins/runtime/gateway/testdata/http/03-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/03-gateway-route.yaml
@@ -136,7 +136,6 @@ Routes:
                     key: x-kuma-tags
                     value: '&kuma.io/service=gateway-default&'
                 weight: 1
-              totalWeight: 1
 Runtimes:
   Resources:
     gateway.listeners:

--- a/pkg/plugins/runtime/gateway/testdata/http/04-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/04-gateway-route.yaml
@@ -172,7 +172,6 @@ Routes:
                     key: x-kuma-tags
                     value: '&kuma.io/service=gateway-default&'
                 weight: 1
-              totalWeight: 1
 Runtimes:
   Resources:
     gateway.listeners:

--- a/pkg/plugins/runtime/gateway/testdata/http/06-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/06-gateway-route.yaml
@@ -191,7 +191,6 @@ Routes:
                     key: x-kuma-tags
                     value: '&kuma.io/service=gateway-default&'
                 weight: 1
-              totalWeight: 1
 Runtimes:
   Resources:
     gateway.listeners:

--- a/pkg/plugins/runtime/gateway/testdata/http/07-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/07-gateway-route.yaml
@@ -136,7 +136,6 @@ Routes:
                     key: x-kuma-tags
                     value: '&kuma.io/service=gateway-default&'
                 weight: 1
-              totalWeight: 1
         - match:
             prefix: /api/
           route:
@@ -156,7 +155,6 @@ Routes:
                     key: x-kuma-tags
                     value: '&kuma.io/service=gateway-default&'
                 weight: 1
-              totalWeight: 1
 Runtimes:
   Resources:
     gateway.listeners:

--- a/pkg/plugins/runtime/gateway/testdata/http/08-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/08-gateway-route.yaml
@@ -180,7 +180,6 @@ Routes:
                     key: x-kuma-tags
                     value: '&kuma.io/service=gateway-default&'
                 weight: 1
-              totalWeight: 1
         - match:
             prefix: /api/
           route:
@@ -200,7 +199,6 @@ Routes:
                     key: x-kuma-tags
                     value: '&kuma.io/service=gateway-default&'
                 weight: 1
-              totalWeight: 1
 Runtimes:
   Resources:
     gateway.listeners:

--- a/pkg/plugins/runtime/gateway/testdata/http/09-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/09-gateway-route.yaml
@@ -138,7 +138,6 @@ Routes:
                     key: x-kuma-tags
                     value: '&kuma.io/service=gateway-default&'
                 weight: 1
-              totalWeight: 1
 Runtimes:
   Resources:
     gateway.listeners:

--- a/pkg/plugins/runtime/gateway/testdata/http/10-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/10-gateway-route.yaml
@@ -249,7 +249,6 @@ Routes:
                     key: x-kuma-tags
                     value: '&kuma.io/service=gateway-default&'
                 weight: 1
-              totalWeight: 1
         - match:
             headers:
             - name: Content-Type
@@ -273,7 +272,6 @@ Routes:
                     key: x-kuma-tags
                     value: '&kuma.io/service=gateway-default&'
                 weight: 1
-              totalWeight: 1
         - match:
             headers:
             - name: Language
@@ -297,7 +295,6 @@ Routes:
                     key: x-kuma-tags
                     value: '&kuma.io/service=gateway-default&'
                 weight: 1
-              totalWeight: 1
         - match:
             headers:
             - name: X-I-AM-PRESENT
@@ -320,7 +317,6 @@ Routes:
                     key: x-kuma-tags
                     value: '&kuma.io/service=gateway-default&'
                 weight: 1
-              totalWeight: 1
         - match:
             headers:
             - name: X-I-AM-ABSENT
@@ -343,7 +339,6 @@ Routes:
                     key: x-kuma-tags
                     value: '&kuma.io/service=gateway-default&'
                 weight: 1
-              totalWeight: 1
 Runtimes:
   Resources:
     gateway.listeners:

--- a/pkg/plugins/runtime/gateway/testdata/http/11-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/11-gateway-route.yaml
@@ -191,7 +191,6 @@ Routes:
                     key: x-kuma-tags
                     value: '&kuma.io/service=gateway-default&'
                 weight: 1
-              totalWeight: 1
         - match:
             prefix: /
             queryParameters:
@@ -215,7 +214,6 @@ Routes:
                     key: x-kuma-tags
                     value: '&kuma.io/service=gateway-default&'
                 weight: 1
-              totalWeight: 1
         - match:
             prefix: /
             queryParameters:
@@ -239,7 +237,6 @@ Routes:
                     key: x-kuma-tags
                     value: '&kuma.io/service=gateway-default&'
                 weight: 1
-              totalWeight: 1
 Runtimes:
   Resources:
     gateway.listeners:

--- a/pkg/plugins/runtime/gateway/testdata/http/12-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/12-gateway-route.yaml
@@ -143,7 +143,6 @@ Routes:
                     key: x-kuma-tags
                     value: '&kuma.io/service=gateway-default&'
                 weight: 1
-              totalWeight: 1
         - match:
             headers:
             - name: :method
@@ -170,7 +169,6 @@ Routes:
                     key: x-kuma-tags
                     value: '&kuma.io/service=gateway-default&'
                 weight: 1
-              totalWeight: 1
         - match:
             headers:
             - name: :method
@@ -197,7 +195,6 @@ Routes:
                     key: x-kuma-tags
                     value: '&kuma.io/service=gateway-default&'
                 weight: 1
-              totalWeight: 1
 Runtimes:
   Resources:
     gateway.listeners:

--- a/pkg/plugins/runtime/gateway/testdata/http/13-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/13-gateway-route.yaml
@@ -224,7 +224,6 @@ Routes:
                     key: x-kuma-tags
                     value: '&kuma.io/service=gateway-default&'
                 weight: 1
-              totalWeight: 1
         - match:
             path: /match/baz
           route:
@@ -244,7 +243,6 @@ Routes:
                     key: x-kuma-tags
                     value: '&kuma.io/service=gateway-default&'
                 weight: 1
-              totalWeight: 1
         - match:
             prefix: /match/baz/
           route:
@@ -264,7 +262,6 @@ Routes:
                     key: x-kuma-tags
                     value: '&kuma.io/service=gateway-default&'
                 weight: 1
-              totalWeight: 1
         - match:
             safeRegex:
               googleRe2: {}
@@ -286,7 +283,6 @@ Routes:
                     key: x-kuma-tags
                     value: '&kuma.io/service=gateway-default&'
                 weight: 1
-              totalWeight: 1
 Runtimes:
   Resources:
     gateway.listeners:

--- a/pkg/plugins/runtime/gateway/testdata/http/14-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/14-gateway-route.yaml
@@ -141,7 +141,6 @@ Routes:
                     key: x-kuma-tags
                     value: '&kuma.io/service=gateway-default&'
                 weight: 1
-              totalWeight: 1
 Runtimes:
   Resources:
     gateway.listeners:

--- a/pkg/plugins/runtime/gateway/testdata/http/15-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/15-gateway-route.yaml
@@ -224,7 +224,6 @@ Routes:
                     key: x-kuma-tags
                     value: '&kuma.io/service=gateway-default&'
                 weight: 1
-              totalWeight: 1
         - match:
             prefix: /api/
           route:
@@ -244,7 +243,6 @@ Routes:
                     key: x-kuma-tags
                     value: '&kuma.io/service=gateway-default&'
                 weight: 1
-              totalWeight: 1
         - match:
             prefix: /
           route:
@@ -269,7 +267,6 @@ Routes:
                     key: x-kuma-tags
                     value: '&kuma.io/service=gateway-default&'
                 weight: 1
-              totalWeight: 1
 Runtimes:
   Resources:
     gateway.listeners:

--- a/pkg/plugins/runtime/gateway/testdata/http/16-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/16-gateway-route.yaml
@@ -221,7 +221,6 @@ Routes:
                     key: x-kuma-tags
                     value: '&kuma.io/service=gateway-default&'
                 weight: 1
-              totalWeight: 1
         - match:
             prefix: /api/
           route:
@@ -241,7 +240,6 @@ Routes:
                     key: x-kuma-tags
                     value: '&kuma.io/service=gateway-default&'
                 weight: 1
-              totalWeight: 1
         - match:
             prefix: /
           route:
@@ -266,7 +264,6 @@ Routes:
                     key: x-kuma-tags
                     value: '&kuma.io/service=gateway-default&'
                 weight: 1
-              totalWeight: 1
 Runtimes:
   Resources:
     gateway.listeners:

--- a/pkg/plugins/runtime/gateway/testdata/http/17-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/17-gateway-route.yaml
@@ -242,7 +242,6 @@ Routes:
                     key: x-kuma-tags
                     value: '&kuma.io/service=gateway-default&'
                 weight: 1
-              totalWeight: 1
         - match:
             prefix: /api/
           route:
@@ -262,7 +261,6 @@ Routes:
                     key: x-kuma-tags
                     value: '&kuma.io/service=gateway-default&'
                 weight: 1
-              totalWeight: 1
         - match:
             prefix: /
           route:
@@ -287,7 +285,6 @@ Routes:
                     key: x-kuma-tags
                     value: '&kuma.io/service=gateway-default&'
                 weight: 1
-              totalWeight: 1
 Runtimes:
   Resources:
     gateway.listeners:

--- a/pkg/plugins/runtime/gateway/testdata/http/18-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/18-gateway-route.yaml
@@ -129,7 +129,6 @@ Routes:
               clusters:
               - name: external-httpbin-8490df2e58a77ae0
                 weight: 1
-              totalWeight: 1
 Runtimes:
   Resources:
     gateway.listeners:

--- a/pkg/plugins/runtime/gateway/testdata/http/19-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/19-gateway-route.yaml
@@ -143,7 +143,6 @@ Routes:
               clusters:
               - name: external-httpbin-8490df2e58a77ae0
                 weight: 1
-              totalWeight: 1
 Runtimes:
   Resources:
     gateway.listeners:

--- a/pkg/plugins/runtime/gateway/testdata/http/20-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/20-gateway-route.yaml
@@ -224,7 +224,6 @@ Routes:
                     key: x-kuma-tags
                     value: '&kuma.io/service=gateway-multihost&'
                 weight: 1
-              totalWeight: 1
       - domains:
         - three.example.com
         name: three.example.com
@@ -248,7 +247,6 @@ Routes:
                     key: x-kuma-tags
                     value: '&kuma.io/service=gateway-multihost&'
                 weight: 1
-              totalWeight: 1
       - domains:
         - one.example.com
         name: one.example.com
@@ -272,7 +270,6 @@ Routes:
                     key: x-kuma-tags
                     value: '&kuma.io/service=gateway-multihost&'
                 weight: 1
-              totalWeight: 1
 Runtimes:
   Resources:
     gateway.listeners:

--- a/pkg/plugins/runtime/gateway/testdata/http/21-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/21-gateway-route.yaml
@@ -224,7 +224,6 @@ Routes:
                     key: x-kuma-tags
                     value: '&kuma.io/service=gateway-default&'
                 weight: 1
-              totalWeight: 1
           typedPerFilterConfig:
             envoy.filters.http.local_ratelimit:
               '@type': type.googleapis.com/envoy.extensions.filters.http.local_ratelimit.v3.LocalRateLimit
@@ -260,7 +259,6 @@ Routes:
                     key: x-kuma-tags
                     value: '&kuma.io/service=gateway-default&'
                 weight: 1
-              totalWeight: 1
           typedPerFilterConfig:
             envoy.filters.http.local_ratelimit:
               '@type': type.googleapis.com/envoy.extensions.filters.http.local_ratelimit.v3.LocalRateLimit
@@ -301,7 +299,6 @@ Routes:
                     key: x-kuma-tags
                     value: '&kuma.io/service=gateway-default&'
                 weight: 1
-              totalWeight: 1
           typedPerFilterConfig:
             envoy.filters.http.local_ratelimit:
               '@type': type.googleapis.com/envoy.extensions.filters.http.local_ratelimit.v3.LocalRateLimit

--- a/pkg/plugins/runtime/gateway/testdata/http/22-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/22-gateway-route.yaml
@@ -180,7 +180,6 @@ Routes:
                     key: x-kuma-tags
                     value: '&kuma.io/service=gateway-default&'
                 weight: 1
-              totalWeight: 1
         - match:
             path: /
           route:
@@ -200,7 +199,6 @@ Routes:
                     key: x-kuma-tags
                     value: '&kuma.io/service=gateway-default&'
                 weight: 1
-              totalWeight: 1
       - domains:
         - '*'
         name: '*'

--- a/pkg/plugins/runtime/gateway/testdata/http/23-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/23-gateway-route.yaml
@@ -224,7 +224,6 @@ Routes:
                     key: x-kuma-tags
                     value: '&kuma.io/service=gateway-default&'
                 weight: 1
-              totalWeight: 1
         - match:
             path: /
           route:
@@ -244,7 +243,6 @@ Routes:
                     key: x-kuma-tags
                     value: '&kuma.io/service=gateway-default&'
                 weight: 1
-              totalWeight: 1
       - domains:
         - '*.com'
         name: '*.com'
@@ -268,7 +266,6 @@ Routes:
                     key: x-kuma-tags
                     value: '&kuma.io/service=gateway-default&'
                 weight: 1
-              totalWeight: 1
       - domains:
         - '*'
         name: '*'

--- a/pkg/plugins/runtime/gateway/testdata/http/24-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/24-gateway-route.yaml
@@ -180,7 +180,6 @@ Routes:
                     key: x-kuma-tags
                     value: '&kuma.io/service=gateway-default&'
                 weight: 1
-              totalWeight: 1
         - match:
             path: /
           route:
@@ -200,7 +199,6 @@ Routes:
                     key: x-kuma-tags
                     value: '&kuma.io/service=gateway-default&'
                 weight: 1
-              totalWeight: 1
       - domains:
         - '*.com'
         name: '*.com'
@@ -224,7 +222,6 @@ Routes:
                     key: x-kuma-tags
                     value: '&kuma.io/service=gateway-default&'
                 weight: 1
-              totalWeight: 1
       - domains:
         - '*'
         name: '*'

--- a/pkg/plugins/runtime/gateway/testdata/http/25-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/25-gateway-route.yaml
@@ -160,7 +160,6 @@ Routes:
                     key: x-kuma-tags
                     value: '&kuma.io/service=gateway-default&'
                 weight: 1
-              totalWeight: 1
 Runtimes:
   Resources:
     gateway.listeners:

--- a/pkg/plugins/runtime/gateway/testdata/http/26-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/26-gateway-route.yaml
@@ -146,7 +146,6 @@ Routes:
                     key: x-kuma-tags
                     value: '&kuma.io/service=gateway-default&'
                 weight: 1
-              totalWeight: 1
 Runtimes:
   Resources:
     gateway.listeners:

--- a/pkg/plugins/runtime/gateway/testdata/http/cross-mesh-gateway.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/cross-mesh-gateway.yaml
@@ -243,7 +243,6 @@ Routes:
                     key: x-kuma-tags
                     value: '&kuma.io/service=gateway-default&'
                 weight: 1
-              totalWeight: 1
         - match:
             path: /ext
           route:
@@ -259,7 +258,6 @@ Routes:
               clusters:
               - name: external-httpbin-823fa8131cdd67fa
                 weight: 1
-              totalWeight: 1
         - match:
             prefix: /echo/
           route:
@@ -279,7 +277,6 @@ Routes:
                     key: x-kuma-tags
                     value: '&kuma.io/service=gateway-default&'
                 weight: 1
-              totalWeight: 1
         - match:
             prefix: /ext/
           route:
@@ -295,7 +292,6 @@ Routes:
               clusters:
               - name: external-httpbin-823fa8131cdd67fa
                 weight: 1
-              totalWeight: 1
 Runtimes:
   Resources:
     gateway.listeners:

--- a/pkg/plugins/runtime/gateway/testdata/http/drop-prefix-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/drop-prefix-gateway-route.yaml
@@ -141,7 +141,6 @@ Routes:
                     key: x-kuma-tags
                     value: '&kuma.io/service=gateway-default&'
                 weight: 1
-              totalWeight: 1
         - match:
             prefix: /prefix/
           route:
@@ -162,7 +161,6 @@ Routes:
                     key: x-kuma-tags
                     value: '&kuma.io/service=gateway-default&'
                 weight: 1
-              totalWeight: 1
 Runtimes:
   Resources:
     gateway.listeners:

--- a/pkg/plugins/runtime/gateway/testdata/http/external-service-with-timeout-no-egress.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/external-service-with-timeout-no-egress.yaml
@@ -144,7 +144,6 @@ Routes:
               clusters:
               - name: external-httpbin-823fa8131cdd67fa
                 weight: 1
-              totalWeight: 1
         - match:
             prefix: /ext/
           route:
@@ -160,7 +159,6 @@ Routes:
               clusters:
               - name: external-httpbin-823fa8131cdd67fa
                 weight: 1
-              totalWeight: 1
 Runtimes:
   Resources:
     gateway.listeners:

--- a/pkg/plugins/runtime/gateway/testdata/http/no-timeout.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/no-timeout.yaml
@@ -135,7 +135,6 @@ Routes:
                     key: x-kuma-tags
                     value: '&kuma.io/service=gateway-default&'
                 weight: 1
-              totalWeight: 1
 Runtimes:
   Resources:
     gateway.listeners:

--- a/pkg/plugins/runtime/gateway/testdata/http/response-header-set-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/response-header-set-gateway-route.yaml
@@ -141,7 +141,6 @@ Routes:
                     key: x-kuma-tags
                     value: '&kuma.io/service=gateway-default&'
                 weight: 1
-              totalWeight: 1
 Runtimes:
   Resources:
     gateway.listeners:

--- a/pkg/plugins/runtime/gateway/testdata/http/retry-policy.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/retry-policy.yaml
@@ -220,7 +220,6 @@ Routes:
                     key: x-kuma-tags
                     value: '&kuma.io/service=gateway-default&'
                 weight: 1
-              totalWeight: 1
         - match:
             prefix: /api/
           route:
@@ -236,7 +235,6 @@ Routes:
                     key: x-kuma-tags
                     value: '&kuma.io/service=gateway-default&'
                 weight: 1
-              totalWeight: 1
         - match:
             prefix: /
           route:
@@ -257,7 +255,6 @@ Routes:
                     key: x-kuma-tags
                     value: '&kuma.io/service=gateway-default&'
                 weight: 1
-              totalWeight: 1
 Runtimes:
   Resources:
     gateway.listeners:

--- a/pkg/plugins/runtime/gateway/testdata/http/rewrite-prefix-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/rewrite-prefix-gateway-route.yaml
@@ -141,7 +141,6 @@ Routes:
                     key: x-kuma-tags
                     value: '&kuma.io/service=gateway-default&'
                 weight: 1
-              totalWeight: 1
         - match:
             prefix: /prefix/a/
           route:
@@ -162,7 +161,6 @@ Routes:
                     key: x-kuma-tags
                     value: '&kuma.io/service=gateway-default&'
                 weight: 1
-              totalWeight: 1
 Runtimes:
   Resources:
     gateway.listeners:

--- a/pkg/plugins/runtime/gateway/testdata/http/rewrite-prefix-trailing-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/rewrite-prefix-trailing-gateway-route.yaml
@@ -141,7 +141,6 @@ Routes:
                     key: x-kuma-tags
                     value: '&kuma.io/service=gateway-default&'
                 weight: 1
-              totalWeight: 1
         - match:
             prefix: /prefix/a/
           route:
@@ -162,7 +161,6 @@ Routes:
                     key: x-kuma-tags
                     value: '&kuma.io/service=gateway-default&'
                 weight: 1
-              totalWeight: 1
 Runtimes:
   Resources:
     gateway.listeners:

--- a/pkg/plugins/runtime/gateway/testdata/https/01-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/01-gateway-route.yaml
@@ -136,7 +136,6 @@ Routes:
                     key: x-kuma-tags
                     value: '&kuma.io/service=gateway-default&'
                 weight: 1
-              totalWeight: 1
       - domains:
         - bar.example.com
         name: bar.example.com
@@ -160,7 +159,6 @@ Routes:
                     key: x-kuma-tags
                     value: '&kuma.io/service=gateway-default&'
                 weight: 1
-              totalWeight: 1
       - domains:
         - '*.example.com'
         name: '*.example.com'
@@ -184,7 +182,6 @@ Routes:
                     key: x-kuma-tags
                     value: '&kuma.io/service=gateway-default&'
                 weight: 1
-              totalWeight: 1
       - domains:
         - '*'
         name: '*'

--- a/pkg/plugins/runtime/gateway/testdata/https/02-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/02-gateway-route.yaml
@@ -136,7 +136,6 @@ Routes:
                     key: x-kuma-tags
                     value: '&kuma.io/service=gateway-default&'
                 weight: 1
-              totalWeight: 1
       - domains:
         - '*'
         name: '*'
@@ -160,7 +159,6 @@ Routes:
                     key: x-kuma-tags
                     value: '&kuma.io/service=gateway-default&'
                 weight: 1
-              totalWeight: 1
 Runtimes:
   Resources:
     gateway.listeners:

--- a/pkg/plugins/runtime/gateway/testdata/https/03-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/03-gateway-route.yaml
@@ -162,7 +162,6 @@ Routes:
                     key: x-kuma-tags
                     value: '&kuma.io/service=gateway-default&'
                 weight: 1
-              totalWeight: 1
 Runtimes:
   Resources:
     gateway.listeners:

--- a/pkg/plugins/runtime/gateway/testdata/https/04-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/04-gateway-route.yaml
@@ -198,7 +198,6 @@ Routes:
                     key: x-kuma-tags
                     value: '&kuma.io/service=gateway-default&'
                 weight: 1
-              totalWeight: 1
 Runtimes:
   Resources:
     gateway.listeners:

--- a/pkg/plugins/runtime/gateway/testdata/https/06-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/06-gateway-route.yaml
@@ -217,7 +217,6 @@ Routes:
                     key: x-kuma-tags
                     value: '&kuma.io/service=gateway-default&'
                 weight: 1
-              totalWeight: 1
 Runtimes:
   Resources:
     gateway.listeners:

--- a/pkg/plugins/runtime/gateway/testdata/https/07-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/07-gateway-route.yaml
@@ -162,7 +162,6 @@ Routes:
                     key: x-kuma-tags
                     value: '&kuma.io/service=gateway-default&'
                 weight: 1
-              totalWeight: 1
         - match:
             prefix: /api/
           route:
@@ -182,7 +181,6 @@ Routes:
                     key: x-kuma-tags
                     value: '&kuma.io/service=gateway-default&'
                 weight: 1
-              totalWeight: 1
 Runtimes:
   Resources:
     gateway.listeners:

--- a/pkg/plugins/runtime/gateway/testdata/https/08-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/08-gateway-route.yaml
@@ -206,7 +206,6 @@ Routes:
                     key: x-kuma-tags
                     value: '&kuma.io/service=gateway-default&'
                 weight: 1
-              totalWeight: 1
         - match:
             prefix: /api/
           route:
@@ -226,7 +225,6 @@ Routes:
                     key: x-kuma-tags
                     value: '&kuma.io/service=gateway-default&'
                 weight: 1
-              totalWeight: 1
 Runtimes:
   Resources:
     gateway.listeners:

--- a/pkg/plugins/runtime/gateway/testdata/https/09-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/09-gateway-route.yaml
@@ -164,7 +164,6 @@ Routes:
                     key: x-kuma-tags
                     value: '&kuma.io/service=gateway-default&'
                 weight: 1
-              totalWeight: 1
 Runtimes:
   Resources:
     gateway.listeners:

--- a/pkg/plugins/runtime/gateway/testdata/https/10-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/10-gateway-route.yaml
@@ -275,7 +275,6 @@ Routes:
                     key: x-kuma-tags
                     value: '&kuma.io/service=gateway-default&'
                 weight: 1
-              totalWeight: 1
         - match:
             headers:
             - name: Content-Type
@@ -299,7 +298,6 @@ Routes:
                     key: x-kuma-tags
                     value: '&kuma.io/service=gateway-default&'
                 weight: 1
-              totalWeight: 1
         - match:
             headers:
             - name: Language
@@ -323,7 +321,6 @@ Routes:
                     key: x-kuma-tags
                     value: '&kuma.io/service=gateway-default&'
                 weight: 1
-              totalWeight: 1
         - match:
             headers:
             - name: X-I-AM-PRESENT
@@ -346,7 +343,6 @@ Routes:
                     key: x-kuma-tags
                     value: '&kuma.io/service=gateway-default&'
                 weight: 1
-              totalWeight: 1
         - match:
             headers:
             - name: X-I-AM-ABSENT
@@ -369,7 +365,6 @@ Routes:
                     key: x-kuma-tags
                     value: '&kuma.io/service=gateway-default&'
                 weight: 1
-              totalWeight: 1
 Runtimes:
   Resources:
     gateway.listeners:

--- a/pkg/plugins/runtime/gateway/testdata/https/11-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/11-gateway-route.yaml
@@ -217,7 +217,6 @@ Routes:
                     key: x-kuma-tags
                     value: '&kuma.io/service=gateway-default&'
                 weight: 1
-              totalWeight: 1
         - match:
             prefix: /
             queryParameters:
@@ -241,7 +240,6 @@ Routes:
                     key: x-kuma-tags
                     value: '&kuma.io/service=gateway-default&'
                 weight: 1
-              totalWeight: 1
         - match:
             prefix: /
             queryParameters:
@@ -265,7 +263,6 @@ Routes:
                     key: x-kuma-tags
                     value: '&kuma.io/service=gateway-default&'
                 weight: 1
-              totalWeight: 1
 Runtimes:
   Resources:
     gateway.listeners:

--- a/pkg/plugins/runtime/gateway/testdata/https/12-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/12-gateway-route.yaml
@@ -169,7 +169,6 @@ Routes:
                     key: x-kuma-tags
                     value: '&kuma.io/service=gateway-default&'
                 weight: 1
-              totalWeight: 1
         - match:
             headers:
             - name: :method
@@ -196,7 +195,6 @@ Routes:
                     key: x-kuma-tags
                     value: '&kuma.io/service=gateway-default&'
                 weight: 1
-              totalWeight: 1
         - match:
             headers:
             - name: :method
@@ -223,7 +221,6 @@ Routes:
                     key: x-kuma-tags
                     value: '&kuma.io/service=gateway-default&'
                 weight: 1
-              totalWeight: 1
 Runtimes:
   Resources:
     gateway.listeners:

--- a/pkg/plugins/runtime/gateway/testdata/https/13-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/13-gateway-route.yaml
@@ -250,7 +250,6 @@ Routes:
                     key: x-kuma-tags
                     value: '&kuma.io/service=gateway-default&'
                 weight: 1
-              totalWeight: 1
         - match:
             path: /match/baz
           route:
@@ -270,7 +269,6 @@ Routes:
                     key: x-kuma-tags
                     value: '&kuma.io/service=gateway-default&'
                 weight: 1
-              totalWeight: 1
         - match:
             prefix: /match/baz/
           route:
@@ -290,7 +288,6 @@ Routes:
                     key: x-kuma-tags
                     value: '&kuma.io/service=gateway-default&'
                 weight: 1
-              totalWeight: 1
         - match:
             safeRegex:
               googleRe2: {}
@@ -312,7 +309,6 @@ Routes:
                     key: x-kuma-tags
                     value: '&kuma.io/service=gateway-default&'
                 weight: 1
-              totalWeight: 1
 Runtimes:
   Resources:
     gateway.listeners:

--- a/pkg/plugins/runtime/gateway/testdata/https/14-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/14-gateway-route.yaml
@@ -167,7 +167,6 @@ Routes:
                     key: x-kuma-tags
                     value: '&kuma.io/service=gateway-default&'
                 weight: 1
-              totalWeight: 1
 Runtimes:
   Resources:
     gateway.listeners:

--- a/pkg/plugins/runtime/gateway/testdata/https/15-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/15-gateway-route.yaml
@@ -250,7 +250,6 @@ Routes:
                     key: x-kuma-tags
                     value: '&kuma.io/service=gateway-default&'
                 weight: 1
-              totalWeight: 1
         - match:
             prefix: /api/
           route:
@@ -270,7 +269,6 @@ Routes:
                     key: x-kuma-tags
                     value: '&kuma.io/service=gateway-default&'
                 weight: 1
-              totalWeight: 1
         - match:
             prefix: /
           route:
@@ -295,7 +293,6 @@ Routes:
                     key: x-kuma-tags
                     value: '&kuma.io/service=gateway-default&'
                 weight: 1
-              totalWeight: 1
 Runtimes:
   Resources:
     gateway.listeners:

--- a/pkg/plugins/runtime/gateway/testdata/https/16-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/16-gateway-route.yaml
@@ -247,7 +247,6 @@ Routes:
                     key: x-kuma-tags
                     value: '&kuma.io/service=gateway-default&'
                 weight: 1
-              totalWeight: 1
         - match:
             prefix: /api/
           route:
@@ -267,7 +266,6 @@ Routes:
                     key: x-kuma-tags
                     value: '&kuma.io/service=gateway-default&'
                 weight: 1
-              totalWeight: 1
         - match:
             prefix: /
           route:
@@ -292,7 +290,6 @@ Routes:
                     key: x-kuma-tags
                     value: '&kuma.io/service=gateway-default&'
                 weight: 1
-              totalWeight: 1
 Runtimes:
   Resources:
     gateway.listeners:

--- a/pkg/plugins/runtime/gateway/testdata/https/17-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/17-gateway-route.yaml
@@ -268,7 +268,6 @@ Routes:
                     key: x-kuma-tags
                     value: '&kuma.io/service=gateway-default&'
                 weight: 1
-              totalWeight: 1
         - match:
             prefix: /api/
           route:
@@ -288,7 +287,6 @@ Routes:
                     key: x-kuma-tags
                     value: '&kuma.io/service=gateway-default&'
                 weight: 1
-              totalWeight: 1
         - match:
             prefix: /
           route:
@@ -313,7 +311,6 @@ Routes:
                     key: x-kuma-tags
                     value: '&kuma.io/service=gateway-default&'
                 weight: 1
-              totalWeight: 1
 Runtimes:
   Resources:
     gateway.listeners:

--- a/pkg/plugins/runtime/gateway/testdata/https/18-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/18-gateway-route.yaml
@@ -155,7 +155,6 @@ Routes:
               clusters:
               - name: external-httpbin-8490df2e58a77ae0
                 weight: 1
-              totalWeight: 1
 Runtimes:
   Resources:
     gateway.listeners:

--- a/pkg/plugins/runtime/gateway/testdata/https/19-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/19-gateway-route.yaml
@@ -169,7 +169,6 @@ Routes:
               clusters:
               - name: external-httpbin-8490df2e58a77ae0
                 weight: 1
-              totalWeight: 1
 Runtimes:
   Resources:
     gateway.listeners:

--- a/pkg/plugins/runtime/gateway/testdata/https/20-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/20-gateway-route.yaml
@@ -376,7 +376,6 @@ Routes:
                     key: x-kuma-tags
                     value: '&kuma.io/service=gateway-multihost&'
                 weight: 1
-              totalWeight: 1
       - domains:
         - three.example.com
         name: three.example.com
@@ -406,7 +405,6 @@ Routes:
                     key: x-kuma-tags
                     value: '&kuma.io/service=gateway-multihost&'
                 weight: 1
-              totalWeight: 1
       - domains:
         - one.example.com
         name: one.example.com
@@ -436,7 +434,6 @@ Routes:
                     key: x-kuma-tags
                     value: '&kuma.io/service=gateway-multihost&'
                 weight: 1
-              totalWeight: 1
 Runtimes:
   Resources:
     gateway.listeners:

--- a/pkg/plugins/runtime/gateway/testdata/https/21-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/21-gateway-route.yaml
@@ -250,7 +250,6 @@ Routes:
                     key: x-kuma-tags
                     value: '&kuma.io/service=gateway-default&'
                 weight: 1
-              totalWeight: 1
           typedPerFilterConfig:
             envoy.filters.http.local_ratelimit:
               '@type': type.googleapis.com/envoy.extensions.filters.http.local_ratelimit.v3.LocalRateLimit
@@ -286,7 +285,6 @@ Routes:
                     key: x-kuma-tags
                     value: '&kuma.io/service=gateway-default&'
                 weight: 1
-              totalWeight: 1
           typedPerFilterConfig:
             envoy.filters.http.local_ratelimit:
               '@type': type.googleapis.com/envoy.extensions.filters.http.local_ratelimit.v3.LocalRateLimit
@@ -327,7 +325,6 @@ Routes:
                     key: x-kuma-tags
                     value: '&kuma.io/service=gateway-default&'
                 weight: 1
-              totalWeight: 1
           typedPerFilterConfig:
             envoy.filters.http.local_ratelimit:
               '@type': type.googleapis.com/envoy.extensions.filters.http.local_ratelimit.v3.LocalRateLimit

--- a/pkg/plugins/runtime/gateway/testdata/https/22-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/22-gateway-route.yaml
@@ -180,7 +180,6 @@ Routes:
                     key: x-kuma-tags
                     value: '&kuma.io/service=gateway-default&'
                 weight: 1
-              totalWeight: 1
         - match:
             path: /
           route:
@@ -200,7 +199,6 @@ Routes:
                     key: x-kuma-tags
                     value: '&kuma.io/service=gateway-default&'
                 weight: 1
-              totalWeight: 1
       - domains:
         - '*'
         name: '*'

--- a/pkg/plugins/runtime/gateway/testdata/https/23-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/23-gateway-route.yaml
@@ -224,7 +224,6 @@ Routes:
                     key: x-kuma-tags
                     value: '&kuma.io/service=gateway-default&'
                 weight: 1
-              totalWeight: 1
         - match:
             path: /
           route:
@@ -244,7 +243,6 @@ Routes:
                     key: x-kuma-tags
                     value: '&kuma.io/service=gateway-default&'
                 weight: 1
-              totalWeight: 1
       - domains:
         - '*.com'
         name: '*.com'
@@ -268,7 +266,6 @@ Routes:
                     key: x-kuma-tags
                     value: '&kuma.io/service=gateway-default&'
                 weight: 1
-              totalWeight: 1
       - domains:
         - '*'
         name: '*'

--- a/pkg/plugins/runtime/gateway/testdata/https/24-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/24-gateway-route.yaml
@@ -180,7 +180,6 @@ Routes:
                     key: x-kuma-tags
                     value: '&kuma.io/service=gateway-default&'
                 weight: 1
-              totalWeight: 1
         - match:
             path: /
           route:
@@ -200,7 +199,6 @@ Routes:
                     key: x-kuma-tags
                     value: '&kuma.io/service=gateway-default&'
                 weight: 1
-              totalWeight: 1
       - domains:
         - '*.com'
         name: '*.com'
@@ -224,7 +222,6 @@ Routes:
                     key: x-kuma-tags
                     value: '&kuma.io/service=gateway-default&'
                 weight: 1
-              totalWeight: 1
       - domains:
         - '*'
         name: '*'

--- a/pkg/plugins/runtime/gateway/testdata/https/25-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/25-gateway-route.yaml
@@ -186,7 +186,6 @@ Routes:
                     key: x-kuma-tags
                     value: '&kuma.io/service=gateway-default&'
                 weight: 1
-              totalWeight: 1
 Runtimes:
   Resources:
     gateway.listeners:

--- a/pkg/plugins/runtime/gateway/testdata/https/26-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/26-gateway-route.yaml
@@ -172,7 +172,6 @@ Routes:
                     key: x-kuma-tags
                     value: '&kuma.io/service=gateway-default&'
                 weight: 1
-              totalWeight: 1
 Runtimes:
   Resources:
     gateway.listeners:

--- a/pkg/plugins/runtime/gateway/testdata/https/cross-mesh-gateway.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/cross-mesh-gateway.yaml
@@ -243,7 +243,6 @@ Routes:
                     key: x-kuma-tags
                     value: '&kuma.io/service=gateway-default&'
                 weight: 1
-              totalWeight: 1
         - match:
             path: /ext
           route:
@@ -259,7 +258,6 @@ Routes:
               clusters:
               - name: external-httpbin-823fa8131cdd67fa
                 weight: 1
-              totalWeight: 1
         - match:
             prefix: /echo/
           route:
@@ -279,7 +277,6 @@ Routes:
                     key: x-kuma-tags
                     value: '&kuma.io/service=gateway-default&'
                 weight: 1
-              totalWeight: 1
         - match:
             prefix: /ext/
           route:
@@ -295,7 +292,6 @@ Routes:
               clusters:
               - name: external-httpbin-823fa8131cdd67fa
                 weight: 1
-              totalWeight: 1
 Runtimes:
   Resources:
     gateway.listeners:

--- a/pkg/plugins/runtime/gateway/testdata/https/drop-prefix-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/drop-prefix-gateway-route.yaml
@@ -167,7 +167,6 @@ Routes:
                     key: x-kuma-tags
                     value: '&kuma.io/service=gateway-default&'
                 weight: 1
-              totalWeight: 1
         - match:
             prefix: /prefix/
           route:
@@ -188,7 +187,6 @@ Routes:
                     key: x-kuma-tags
                     value: '&kuma.io/service=gateway-default&'
                 weight: 1
-              totalWeight: 1
 Runtimes:
   Resources:
     gateway.listeners:

--- a/pkg/plugins/runtime/gateway/testdata/https/external-service-with-timeout-no-egress.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/external-service-with-timeout-no-egress.yaml
@@ -144,7 +144,6 @@ Routes:
               clusters:
               - name: external-httpbin-823fa8131cdd67fa
                 weight: 1
-              totalWeight: 1
         - match:
             prefix: /ext/
           route:
@@ -160,7 +159,6 @@ Routes:
               clusters:
               - name: external-httpbin-823fa8131cdd67fa
                 weight: 1
-              totalWeight: 1
 Runtimes:
   Resources:
     gateway.listeners:

--- a/pkg/plugins/runtime/gateway/testdata/https/no-timeout.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/no-timeout.yaml
@@ -161,7 +161,6 @@ Routes:
                     key: x-kuma-tags
                     value: '&kuma.io/service=gateway-default&'
                 weight: 1
-              totalWeight: 1
 Runtimes:
   Resources:
     gateway.listeners:

--- a/pkg/plugins/runtime/gateway/testdata/https/response-header-set-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/response-header-set-gateway-route.yaml
@@ -167,7 +167,6 @@ Routes:
                     key: x-kuma-tags
                     value: '&kuma.io/service=gateway-default&'
                 weight: 1
-              totalWeight: 1
 Runtimes:
   Resources:
     gateway.listeners:

--- a/pkg/plugins/runtime/gateway/testdata/https/retry-policy.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/retry-policy.yaml
@@ -246,7 +246,6 @@ Routes:
                     key: x-kuma-tags
                     value: '&kuma.io/service=gateway-default&'
                 weight: 1
-              totalWeight: 1
         - match:
             prefix: /api/
           route:
@@ -262,7 +261,6 @@ Routes:
                     key: x-kuma-tags
                     value: '&kuma.io/service=gateway-default&'
                 weight: 1
-              totalWeight: 1
         - match:
             prefix: /
           route:
@@ -283,7 +281,6 @@ Routes:
                     key: x-kuma-tags
                     value: '&kuma.io/service=gateway-default&'
                 weight: 1
-              totalWeight: 1
 Runtimes:
   Resources:
     gateway.listeners:

--- a/pkg/plugins/runtime/gateway/testdata/https/rewrite-prefix-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/rewrite-prefix-gateway-route.yaml
@@ -167,7 +167,6 @@ Routes:
                     key: x-kuma-tags
                     value: '&kuma.io/service=gateway-default&'
                 weight: 1
-              totalWeight: 1
         - match:
             prefix: /prefix/a/
           route:
@@ -188,7 +187,6 @@ Routes:
                     key: x-kuma-tags
                     value: '&kuma.io/service=gateway-default&'
                 weight: 1
-              totalWeight: 1
 Runtimes:
   Resources:
     gateway.listeners:

--- a/pkg/plugins/runtime/gateway/testdata/https/rewrite-prefix-trailing-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/rewrite-prefix-trailing-gateway-route.yaml
@@ -167,7 +167,6 @@ Routes:
                     key: x-kuma-tags
                     value: '&kuma.io/service=gateway-default&'
                 weight: 1
-              totalWeight: 1
         - match:
             prefix: /prefix/a/
           route:
@@ -188,7 +187,6 @@ Routes:
                     key: x-kuma-tags
                     value: '&kuma.io/service=gateway-default&'
                 weight: 1
-              totalWeight: 1
 Runtimes:
   Resources:
     gateway.listeners:

--- a/pkg/xds/envoy/listeners/v3/http_outbound_route_configurer_test.go
+++ b/pkg/xds/envoy/listeners/v3/http_outbound_route_configurer_test.go
@@ -106,7 +106,6 @@ var _ = Describe("HttpOutboundRouteConfigurer", func() {
                               weight: 20
                             - name: backend-1
                               weight: 80
-                            totalWeight: 100
                   statPrefix: "127_0_0_1_18080"
             name: outbound:127.0.0.1:18080
             trafficDirection: OUTBOUND`,

--- a/pkg/xds/envoy/routes/v3/routes_configurer.go
+++ b/pkg/xds/envoy/routes/v3/routes_configurer.go
@@ -175,19 +175,16 @@ func (c RoutesConfigurer) routeAction(clusters []envoy_common.Cluster, modify *m
 		}
 	} else {
 		var weightedClusters []*envoy_route.WeightedCluster_ClusterWeight
-		var totalWeight uint32
 		for _, c := range clusters {
 			cluster := c.(*envoy_common.ClusterImpl)
 			weightedClusters = append(weightedClusters, &envoy_route.WeightedCluster_ClusterWeight{
 				Name:   cluster.Name(),
 				Weight: util_proto.UInt32(cluster.Weight()),
 			})
-			totalWeight += cluster.Weight()
 		}
 		routeAction.ClusterSpecifier = &envoy_route.RouteAction_WeightedClusters{
 			WeightedClusters: &envoy_route.WeightedCluster{
-				Clusters:    weightedClusters,
-				TotalWeight: util_proto.UInt32(totalWeight),
+				Clusters: weightedClusters,
 			},
 		}
 	}

--- a/pkg/xds/generator/testdata/outbound-proxy/08.envoy.golden.yaml
+++ b/pkg/xds/generator/testdata/outbound-proxy/08.envoy.golden.yaml
@@ -99,7 +99,6 @@ resources:
                       weight: 10
                     - name: es2-_1_
                       weight: 90
-                    totalWeight: 100
           statPrefix: es2
           streamIdleTimeout: 0s
     metadata:
@@ -150,7 +149,6 @@ resources:
                       weight: 10
                     - name: es2-_1_
                       weight: 90
-                    totalWeight: 100
           statPrefix: es2
           streamIdleTimeout: 0s
     metadata:
@@ -201,7 +199,6 @@ resources:
                       weight: 10
                     - name: es2-_1_
                       weight: 90
-                    totalWeight: 100
           statPrefix: es2
           streamIdleTimeout: 0s
     metadata:


### PR DESCRIPTION
[Envoy docs](https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/route/v3/route_components.proto#envoy-v3-api-field-config-route-v3-weightedcluster-total-weight)

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [x] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
