### PR TITLE
test(e2e): fix e2e/externalservices resources

### DIFF
--- a/test/e2e/externalservices/testdata/externalservice-http-server.yaml
+++ b/test/e2e/externalservices/testdata/externalservice-http-server.yaml
@@ -15,7 +15,7 @@ spec:
     - port: 10080
       name: http
       appProtocol: http
-      targetPort: 80
+      targetPort: 8080
   selector:
     app: externalservice-http-server
 
@@ -42,16 +42,16 @@ spec:
     spec:
       containers:
         - name: echo-server
-          image: mendhak/http-https-echo
+          image: mendhak/http-https-echo:23
           imagePullPolicy: IfNotPresent
           readinessProbe:
             httpGet:
               path: /
-              port: 80
+              port: 8080
             initialDelaySeconds: 3
             periodSeconds: 3
           ports:
-            - containerPort: 80
+            - containerPort: 8080
           resources:
             limits:
               cpu: 50m

--- a/test/e2e/externalservices/testdata/externalservice-https-server.yaml
+++ b/test/e2e/externalservices/testdata/externalservice-https-server.yaml
@@ -14,8 +14,8 @@ spec:
   ports:
     - port: 10080
       name: https
-      targetPort: 443
       appProtocol: http
+      targetPort: 8443
   selector:
     app: externalservice-https-server
 
@@ -42,16 +42,16 @@ spec:
     spec:
       containers:
         - name: echo-server
-          image: mendhak/http-https-echo
+          image: mendhak/http-https-echo:23
           imagePullPolicy: IfNotPresent
           readinessProbe:
             httpGet:
               path: /
-              port: 80
+              port: 8080
             initialDelaySeconds: 3
             periodSeconds: 3
           ports:
-            - containerPort: 443
+            - containerPort: 8443
           resources:
             limits:
               cpu: 50m


### PR DESCRIPTION
https://github.com/kumahq/kuma/pull/6393 is failing

This was fixed in https://github.com/kumahq/kuma/pull/4231, see [master](https://github.com/kumahq/kuma/blob/master/test/e2e/externalservices/testdata/externalservice-http-server.yaml) but not backported. It's not clear why it's failing now but it may be the `latest` tag has changed

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [x] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
