### PR TITLE
ci(stability): add curl --retry 3 --retry-all-errors

### DIFF
--- a/test/framework/client/collect.go
+++ b/test/framework/client/collect.go
@@ -28,6 +28,7 @@ type CollectResponsesOpts struct {
 	numberOfRequests      int
 	maxConcurrentRequests int
 	maxTime               int
+	maxCurlRetry          int
 	verbose               bool
 	cacert                string
 	URL                   string
@@ -48,6 +49,7 @@ func DefaultCollectResponsesOpts() CollectResponsesOpts {
 		numberOfRequests:      10,
 		maxConcurrentRequests: 10,
 		maxTime:               5,
+		maxCurlRetry:          3,
 		verbose:               false,
 		Method:                "GET",
 		Headers:               map[string]string{},
@@ -261,6 +263,8 @@ func CollectResponse(
 ) (string, string, error) {
 	opts := CollectOptions(destination, fn...)
 	cmd := collectCommand(opts, "curl",
+		"--retry", strconv.Itoa(opts.maxCurlRetry),
+		"--retry-all-errors",
 		"--request", opts.Method,
 		opts.ShellEscaped(opts.URL),
 	)


### PR DESCRIPTION
Quite often we see curl errors with flakes. Maybe retrying these will help.

rel: https://github.com/Kong/team-mesh/issues/88

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [x] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
