### PR TITLE
fix(policy): matcher with same key not the same value

### DIFF
--- a/pkg/core/xds/rules.go
+++ b/pkg/core/xds/rules.go
@@ -39,7 +39,7 @@ func (ss Subset) IsSubset(other Subset) bool {
 			if otherTag.Value == tag.Value && otherTag.Not != tag.Not {
 				return false
 			}
-			if otherTag.Value != tag.Value && otherTag.Not == tag.Not {
+			if otherTag.Value != tag.Value && !otherTag.Not && !tag.Not {
 				return false
 			}
 		}

--- a/pkg/core/xds/rules.go
+++ b/pkg/core/xds/rules.go
@@ -39,7 +39,7 @@ func (ss Subset) IsSubset(other Subset) bool {
 			if otherTag.Value == tag.Value && otherTag.Not != tag.Not {
 				return false
 			}
-			if otherTag.Value != tag.Value && !otherTag.Not {
+			if otherTag.Value != tag.Value && otherTag.Not == tag.Not {
 				return false
 			}
 		}

--- a/pkg/core/xds/rules_test.go
+++ b/pkg/core/xds/rules_test.go
@@ -310,6 +310,22 @@ var _ = Describe("Rules", func() {
 				},
 				confYAML: []byte(`action: Allow`),
 			}),
+			Entry("single matched not", testCase{
+				rules: xds.Rules{
+					{
+						Subset: []xds.Tag{
+							{Key: "key1", Value: "val1", Not: true},
+						},
+						Conf: meshtrafficpermission_api.Conf{
+							Action: "Allow",
+						},
+					},
+				},
+				subset: []xds.Tag{
+					{Key: "key1", Value: "val2"},
+				},
+				confYAML: []byte(`action: Allow`),
+			}),
 			Entry("single matched rule, rule and subset with negation", testCase{
 				rules: xds.Rules{
 					{


### PR DESCRIPTION
Fix #6426

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [X] [Link to relevant issue][1] as well as docs and UI issues --
- [X] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [X] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [X] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [X] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [X] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
