### PR TITLE
feat(mesh): MADR for disabling default policy creation

### DIFF
--- a/docs/madr/decisions/024-disable-default-policies.md
+++ b/docs/madr/decisions/024-disable-default-policies.md
@@ -15,19 +15,22 @@ to be able to disable that default creation of policies selectively.
 [here](https://github.com/kumahq/kuma/issues/3346#issuecomment-1006600634)).
 2. Add a binary (yes / no) `disableDefaultPolicies` option to the `Mesh` object.
 3. Add individual switches (e.g. `disableDefaultTrafficPermission`) for each policy.
+4. Add `skipDefaultPolicies` []string field to allow comma-separated list of policies to skip.
 
 ## Decision Outcome
 
-Chosen option: 3. Add individual switches (e.g. `disableDefaultTrafficPermission`) for each policy.
+Chosen option: 4. Add `skipDefaultPolicies` []string field to allow comma-separated list of policies to skip.
 
 ## Decision Drivers
 
 ### Pros
 - More granular control over what's created (good for testing as well)
 - Predictable, understandable behavior
+- Only adds a single additional field to Mesh configuration
 
 ### Cons
-- Adds multiple additional options to / clutters the `Mesh` object
+- CSV string fields can be a bit messy, but there is precedent in the codebase 
+(`kumactl install observability --components`).
 
 ## Open Questions
 

--- a/docs/madr/decisions/024-disable-default-policies.md
+++ b/docs/madr/decisions/024-disable-default-policies.md
@@ -1,0 +1,55 @@
+#  Disable Creation of Default Policies
+
+- Status: Accepted
+
+Technical Story: https://github.com/kumahq/kuma/issues/3346
+
+## Context and Problem Statement
+
+Everytime a mesh is created, we also create a set of default policies (TrafficPermission, Retry, Timeout, etc...). It's useful in a number of scenarios 
+to be able to disable that default creation of policies selectively.
+
+## Considered Options
+
+1. Overload the `skipDefaultMesh` switch to also mean disabling the creation of all default policies (as suggested 
+[here](https://github.com/kumahq/kuma/issues/3346#issuecomment-1006600634)).
+2. Add a binary (yes / no) `disableDefaultPolicies` option to the `Mesh` object.
+3. Add individual switches (e.g. `disableDefaultTrafficPermission`) for each policy.
+
+## Decision Outcome
+
+Chosen option: 3. Add individual switches (e.g. `disableDefaultTrafficPermission`) for each policy.
+
+## Decision Drivers
+
+### Pros
+- More granular control over what's created (good for testing as well)
+- Predictable, understandable behavior
+
+### Cons
+- Adds multiple additional options to / clutters the `Mesh` object
+
+## Open Questions
+
+Should this be `disableDefault<Policy>` or `enableDefault<Policy>` (as suggested 
+[here](https://github.com/kumahq/kuma/issues/3346#issuecomment-1209360627))? The former allows us to not introduce a 
+breaking change, but the latter makes more sense as new user maybe? 
+
+## Proposed Implementation
+
+Below is how the new fields would look on a `Mesh` object:
+
+```protobuf
+// Mesh defines configuration of a single mesh.
+message Mesh {
+
+    option (kuma.mesh.resource).name = "MeshResource";
+    option (kuma.mesh.resource).type = "Mesh";
+    
+    // ...
+    
+    // List of policies to skip creating by default when the mesh is created.
+    // e.g. TrafficPermission, MeshRetry, etc.
+    repeated string skipDefaultPolicies = 8;
+}
+```

--- a/docs/madr/decisions/024-disable-default-policies.md
+++ b/docs/madr/decisions/024-disable-default-policies.md
@@ -15,11 +15,11 @@ to be able to disable that default creation of policies selectively.
 [here](https://github.com/kumahq/kuma/issues/3346#issuecomment-1006600634)).
 2. Add a binary (yes / no) `disableDefaultPolicies` option to the `Mesh` object.
 3. Add individual switches (e.g. `disableDefaultTrafficPermission`) for each policy.
-4. Add `skipDefaultPolicies` []string field to allow comma-separated list of policies to skip.
+4. Add `skipCreatingInitialDefaultPolicies` []string field to allow comma-separated list of policies to skip.
 
 ## Decision Outcome
 
-Chosen option: 4. Add `skipDefaultPolicies` []string field to allow comma-separated list of policies to skip.
+Chosen option: 4. Add `skipCreatingInitialDefaultPolicies` []string field to allow comma-separated list of policies to skip.
 
 ## Decision Drivers
 
@@ -32,11 +32,13 @@ Chosen option: 4. Add `skipDefaultPolicies` []string field to allow comma-separa
 - CSV string fields can be a bit messy, but there is precedent in the codebase 
 (`kumactl install observability --components`).
 
-## Open Questions
+## Behaviors
 
-Should this be `disableDefault<Policy>` or `enableDefault<Policy>` (as suggested 
-[here](https://github.com/kumahq/kuma/issues/3346#issuecomment-1209360627))? The former allows us to not introduce a 
-breaking change, but the latter makes more sense as new user maybe? 
+This field is immutable once set, for the following reasons:
+- Unpredictable / undesirable behavior (deleting policies) once the Mesh is created / in-use.
+- The main probable use-case for this setting is to aid programmatic / automated flows for creating a Mesh with a 'blank slate'.
+
+In light of the above, name of the flag changed to `skipCreatingInitialDefaultPolicies`.
 
 ## Proposed Implementation
 
@@ -53,6 +55,21 @@ message Mesh {
     
     // List of policies to skip creating by default when the mesh is created.
     // e.g. TrafficPermission, MeshRetry, etc.
-    repeated string skipDefaultPolicies = 8;
+    repeated string skipCreatingInitialDefaultPolicies = 8;
 }
+```
+
+New configuration would look like:
+
+```yaml
+skipCreatingInitialDefaultPolicies:
+  - "MeshTrafficPermission"
+  - "MeshRetry"
+```
+
+The `skipCreatingInitialDefaultPolicies` list can also contain a wildcard `*` entry which will skip all default policies. E.g. 
+
+```yaml
+skipCreatingInitialDefaultPolicies:
+  - "*"
 ```


### PR DESCRIPTION
### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [x] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
