### PR TITLE
chore(ci): bump envoy to 1.22.10 envoy/version.sh

### DIFF
--- a/tools/envoy/version.sh
+++ b/tools/envoy/version.sh
@@ -8,7 +8,7 @@ set -o nounset
 # - if ENVOY_TAG is a real git tag like 'v1.20.0' then the version is equal to '1.20.0' (without the first letter 'v').
 # - if ENVOY_TAG is a commit hash then the version will look like '1.20.1-dev-b16d390f'
 
-ENVOY_TAG=${ENVOY_TAG:-"v1.22.7"}
+ENVOY_TAG=${ENVOY_TAG:-"v1.22.10"}
 ENVOY_VERSION=$(curl --silent --location "https://raw.githubusercontent.com/envoyproxy/envoy/${ENVOY_TAG}/VERSION.txt")
 
 # for envoy versions older than v1.22.0 file 'VERSION.txt' used to be called 'VERSION'


### PR DESCRIPTION
### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [ ] [Link to relevant issue][1] as well as docs and UI issues --
- [ ] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [ ] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [ ] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [ ] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [ ] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
