### PR TITLE
fix(MeshRetry): guard against multiple previous priorities

### DIFF
--- a/pkg/plugins/policies/meshretry/api/v1alpha1/validator.go
+++ b/pkg/plugins/policies/meshretry/api/v1alpha1/validator.go
@@ -181,6 +181,7 @@ func validateRateLimitedBackOff(rateLimitedBackOff *RateLimitedBackOff) validato
 func validateHostSelection(predicates *[]Predicate) validators.ValidationError {
 	var verr validators.ValidationError
 	path := validators.RootedAt("hostSelection")
+	var prioritySet bool
 
 	for i, predicate := range *predicates {
 		switch predicate.PredicateType {
@@ -189,9 +190,14 @@ func validateHostSelection(predicates *[]Predicate) validators.ValidationError {
 				verr.AddViolationAt(path.Index(i).Field("tags"), validators.MustBeDefined)
 			}
 		case OmitPreviousPriorities:
+			if prioritySet {
+				verr.AddViolationAt(path.Index(i).Field("predicate"), fmt.Sprintf("%v must only be specified once",
+					predicate.PredicateType))
+			}
 			if predicate.UpdateFrequency <= 0 {
 				verr.AddViolationAt(path.Index(i).Field("updateFrequency"), validators.MustBeDefinedAndGreaterThanZero)
 			}
+			prioritySet = true
 		case OmitPreviousHosts:
 		default:
 			verr.AddViolationAt(path.Index(i).Field("predicate"), fmt.Sprintf("unknown predicate type '%v'",

--- a/pkg/plugins/policies/meshretry/api/v1alpha1/validator_test.go
+++ b/pkg/plugins/policies/meshretry/api/v1alpha1/validator_test.go
@@ -461,6 +461,27 @@ violations:
   - field:  spec.to[0].default.conf.http.hostSelection[1].predicate
     message: unknown predicate type 'IncorrectPredicateType'`,
 			}),
+			Entry("OmitPreviousPriorities specified twice", testCase{
+				inputYaml: `
+targetRef:
+  kind: Mesh
+to:
+  - targetRef:
+      kind: Mesh
+    default:
+      http: 
+        hostSelection:
+          - predicate: OmitPreviousPriorities
+            updateFrequency: 3
+          - predicate: OmitPreviousHosts
+          - predicate: OmitPreviousPriorities
+            updateFrequency: 1
+`,
+				expected: `
+violations:
+  - field: spec.to[0].default.conf.http.hostSelection[2].predicate
+    message: OmitPreviousPriorities must only be specified once`,
+			}),
 		)
 	})
 })


### PR DESCRIPTION
### Checklist prior to review

Adds validation for the case where someone specifies `OmitPreviousPriorities` more than once. This wouldn't error today, but might result in unexpected behavior (we'll always just use the last one specified in the list).
<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [x] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
