### PR TITLE
ci(helm): no duplicates in helm chart package

### DIFF
--- a/tools/releases/helm.sh
+++ b/tools/releases/helm.sh
@@ -76,7 +76,7 @@ function package {
 
       tar -xzf "${f}" --directory "${tmpdir}"
 
-      tar -czvf "${f}" \
+      tar -czf "${f}" \
         --directory "${tmpdir}" \
         --owner 0 \
         --group 0 \

--- a/tools/releases/helm.sh
+++ b/tools/releases/helm.sh
@@ -80,8 +80,6 @@ function package {
         --directory "${tmpdir}" \
         --owner 0 \
         --group 0 \
-        --no-same-owner \
-        --no-same-permissions \
         "$(basename "${dir}")"
     done
 

--- a/tools/releases/helm.sh
+++ b/tools/releases/helm.sh
@@ -65,7 +65,21 @@ function package {
       find "${dir}/crds" -name "*meshgatewayconfigs.yaml" -delete
     fi
 
-    cr package \
+    # Chart Releaser is always packaging dependencies specified in Chart.yaml
+    # file first. The archives with packaged dependencies lands inside "charts"
+    # directory (i.e. deployments/[...]/charts/[dependency_name]-[version].tgz).
+    # When building the final chart package, it includes inside, the content of
+    # the "charts" directory. When it finds an archive there, it flattens it and
+    # includes in the final package as well. It means if the chart have any
+    # dependencies, the final chart's archive will contain duplicated manifests.
+    # As Chart Releaser will automatically download the dependencies and then
+    # will archive them, we can safely remove the content of "charts" directory
+    # to mitigate the above issue.
+    if [[ -d "${dir}/charts" ]]; then
+      rm -vrf "${dir}/charts/"*
+    fi
+
+   cr package \
       --package-path "${CHARTS_PACKAGE_PATH}" \
       "${dir}"
 


### PR DESCRIPTION
Chart Releaser is always packaging dependencies specified in Chart.yaml file first. The archives with packaged dependencies lands inside "charts" directory (i.e. deployments/[...]/charts/[dependency_name]-[version].tgz). When building the final chart package, it includes inside, the content of the "charts" directory. When it finds an archive there, it flattens it and includes in the final package as well. It means if the chart have any dependencies, the final chart's archive will contain duplicated manifests. To mitigate this issue we are unarchiving (which would remove duplicates) and archiving the chart again.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [ ] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [x] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

> Changelog: Modify helm.sh script to make sure no duplicate manifests will be present in packaged chart

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
