### PR TITLE
fix(kumactl): return after loading configuration from memory

### DIFF
--- a/app/kumactl/cmd/root.go
+++ b/app/kumactl/cmd/root.go
@@ -24,6 +24,7 @@ import (
 	"github.com/kumahq/kuma/pkg/core"
 	kuma_log "github.com/kumahq/kuma/pkg/log"
 	_ "github.com/kumahq/kuma/pkg/plugins/policies"
+
 	// Register gateway resources.
 	_ "github.com/kumahq/kuma/pkg/plugins/runtime/gateway/register"
 	// import Envoy protobuf definitions so (un)marshaling Envoy protobuf works
@@ -68,6 +69,7 @@ func NewRootCmd(root *kumactl_cmd.RootContext) *cobra.Command {
 
 			if root.Args.ConfigType == kumactl_cmd.InMemory {
 				root.LoadInMemoryConfig()
+				return nil
 			}
 
 			return root.LoadConfig()

--- a/app/kumactl/cmd/root.go
+++ b/app/kumactl/cmd/root.go
@@ -24,7 +24,6 @@ import (
 	"github.com/kumahq/kuma/pkg/core"
 	kuma_log "github.com/kumahq/kuma/pkg/log"
 	_ "github.com/kumahq/kuma/pkg/plugins/policies"
-
 	// Register gateway resources.
 	_ "github.com/kumahq/kuma/pkg/plugins/runtime/gateway/register"
 	// import Envoy protobuf definitions so (un)marshaling Envoy protobuf works


### PR DESCRIPTION
When `ConfigType` is `InMemory` we should return and use the default configuration. Previously we were overriding this with host configuration if it exists instead of returning one loaded from memory.

- [X] [Link to relevant issue][1] as well as docs and UI issues -- fix: #6159 
- [X] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [X] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [X] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [X] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [X] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
