### PR TITLE
build(helm): fix invalid reference `origin/gh-pages`

### DIFF
--- a/tools/releases/helm.sh
+++ b/tools/releases/helm.sh
@@ -98,7 +98,7 @@ function release {
     [ -z "$GH_REPO_URL" ] && GH_REPO_URL="https://${GH_TOKEN}@github.com/${GH_OWNER}/${GH_REPO}.git"
   fi
 
-  git clone --single-branch --branch "${GH_PAGES_BRANCH}" "$GH_REPO_URL"
+  git clone --branch "${GH_PAGES_BRANCH}" "$GH_REPO_URL"
 
   # First upload the packaged charts to the release
   cr upload \


### PR DESCRIPTION
https://github.com/kumahq/kuma/actions/runs/4688272466/jobs/8308573372#step:8:21

how did it work before?

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [ ] [Link to relevant issue][1] as well as docs and UI issues --
- [ ] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [ ] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [ ] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [ ] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [ ] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
