### PR TITLE
ci(mk): don't use `-it` in `docker exec` commands

### DIFF
--- a/mk/k3d.mk
+++ b/mk/k3d.mk
@@ -91,8 +91,8 @@ k3d/start: ${KIND_KUBECONFIG_DIR} k3d/network/create
 .PHONY: k3d/configure/ebpf
 k3d/configure/ebpf:
 ifeq ($(GOOS),darwin)
-	docker exec -it k3d-$(KIND_CLUSTER_NAME)-server-0 mount bpffs /sys/fs/bpf -t bpf && \
-	docker exec -it k3d-$(KIND_CLUSTER_NAME)-server-0 mount --make-shared /sys/fs/bpf
+	docker exec k3d-$(KIND_CLUSTER_NAME)-server-0 mount bpffs /sys/fs/bpf -t bpf && \
+	docker exec k3d-$(KIND_CLUSTER_NAME)-server-0 mount --make-shared /sys/fs/bpf
 endif
 
 .PHONY: k3d/wait


### PR DESCRIPTION
When this target is run as a dependency, like with `make test/e2e/debug`, it fails for me with:

```
/Library/Developer/CommandLineTools/usr/bin/make k3d/configure/ebpf
docker exec -it k3d-kuma-1-server-0 mount bpffs /sys/fs/bpf -t bpf && \
	docker exec -it k3d-kuma-1-server-0 mount --make-shared /sys/fs/bpf
the input device is not a TTY
make[3]: *** [k3d/configure/ebpf] Error 1
make[2]: *** [k3d/start] Error 2
make[1]: *** [test/e2e/k8s/start/cluster/kuma-1] Error 2
```

I don't think we want or need `-it` here.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [x] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
