### PR TITLE
ci(e2e/framework): allow getting xds address +more

### DIFF
--- a/test/framework/constants.go
+++ b/test/framework/constants.go
@@ -22,6 +22,7 @@ const (
 
 	kdsPort             = 30685
 	loadBalancerKdsPort = 5685
+	xdsPort             = 5678
 )
 
 const (

--- a/test/framework/interface.go
+++ b/test/framework/interface.go
@@ -563,6 +563,7 @@ type Cluster interface {
 type ControlPlane interface {
 	GetName() string
 	GetMetrics() (string, error)
+	GetXDSServerAddress() string
 	GetKDSServerAddress() string
 	GetKDSInsecureServerAddress() string
 	GetGlobalStatusAPI() string
@@ -571,5 +572,6 @@ type ControlPlane interface {
 	GenerateZoneIngressToken(zone string) (string, error)
 	GenerateZoneIngressLegacyToken(zone string) (string, error)
 	GenerateZoneEgressToken(zone string) (string, error)
+	GenerateZoneToken(zone string, scope []string) (string, error)
 	Exec(cmd ...string) (string, string, error)
 }


### PR DESCRIPTION
- Allow getting XDS server address in e2e framework
- Add option to generate zone token with manually specifying scope
- Add validation that `&K8sControlPlane{}` and `&UniversalControlPlane{}` fulfill `ControlPlane` interface 

This is necessary if we would like to test anything that relies on XDS, like ratelimit

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [ ] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? -- no
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? -- no
- [x] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

> Changelog: ci(e2e/framework): add in e2e framework option to get xds address and generate zone token with manually specified scope

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
