### PR TITLE
feat(GatewayAPI): initial GAMMA support

### DIFF
--- a/pkg/plugins/runtime/k8s/controllers/gatewayapi/attachment/attachment.go
+++ b/pkg/plugins/runtime/k8s/controllers/gatewayapi/attachment/attachment.go
@@ -176,9 +176,7 @@ func hostnamesIntersect(routeHostnames []gatewayapi.Hostname, listenerHostnames 
 	return false
 }
 
-// EvaluateParentRefAttachment reports whether a route in the given namespace can attach
-// via the given ParentRef.
-func EvaluateParentRefAttachment(
+func evaluateGatewayAttachment(
 	ctx context.Context,
 	client kube_client.Client,
 	routeHostnames []gatewayapi.Hostname,
@@ -210,4 +208,24 @@ func EvaluateParentRefAttachment(
 	}
 
 	return findRouteListenerAttachment(gateway, routeNs, ref.SectionName)
+}
+
+// EvaluateParentRefAttachment reports whether a route in the given namespace can attach
+// via the given ParentRef.
+func EvaluateParentRefAttachment(
+	ctx context.Context,
+	client kube_client.Client,
+	routeHostnames []gatewayapi.Hostname,
+	routeNs *kube_core.Namespace,
+	ref gatewayapi.ParentReference,
+) (Attachment, error) {
+	switch {
+	case *ref.Group == gatewayapi.Group(gatewayapi.GroupVersion.Group) && *ref.Kind == "Gateway":
+		return evaluateGatewayAttachment(ctx, client, routeHostnames, routeNs, ref)
+	case *ref.Group == kube_core.GroupName && *ref.Kind == "Service":
+		// Attaching to a Service can only affect requests coming from Services
+		// in the same Namespace or requests going to the Service.
+		return Allowed, nil
+	}
+	return Unknown, nil
 }

--- a/pkg/plugins/runtime/k8s/controllers/gatewayapi/http_route_controller.go
+++ b/pkg/plugins/runtime/k8s/controllers/gatewayapi/http_route_controller.go
@@ -81,7 +81,7 @@ func (r *HTTPRouteReconciler) Reconcile(ctx context.Context, req kube_ctrl.Reque
 		spec := meshRouteSpec
 		route := meshhttproute_k8s.MeshHTTPRoute{
 			ObjectMeta: kube_meta.ObjectMeta{
-				Name: fmt.Sprintf("%s-%s", httpRoute.Name, subName), Namespace: "kuma-system",
+				Name: fmt.Sprintf("%s-%s", httpRoute.Name, subName), Namespace: r.SystemNamespace,
 			},
 		}
 		if _, err := controllerutil.CreateOrUpdate(ctx, r.Client, &route, func() error {
@@ -156,7 +156,7 @@ func (r *HTTPRouteReconciler) gapiToKumaRoutes(
 						Match: tagsForRef(route, ref),
 					},
 				)
-			case *ref.Kind == gatewayapi.Kind("Service") && *ref.Group == "":
+			case *ref.Kind == gatewayapi.Kind("Service") && *ref.Group == kube_core.GroupName:
 				namespace := route.Namespace
 				if ref.Namespace != nil {
 					namespace = string(*ref.Namespace)

--- a/pkg/plugins/runtime/k8s/controllers/gatewayapi/http_route_controller.go
+++ b/pkg/plugins/runtime/k8s/controllers/gatewayapi/http_route_controller.go
@@ -62,13 +62,13 @@ func (r *HTTPRouteReconciler) Reconcile(ctx context.Context, req kube_ctrl.Reque
 
 	mesh := k8s_util.MeshOfByAnnotation(httpRoute, &ns)
 
-	spec, conditions, err := r.gapiToKumaRoutes(ctx, mesh, httpRoute)
+	gatewayRouteSpec, conditions, err := r.gapiToKumaRoutes(ctx, mesh, httpRoute)
 	if err != nil {
 		return kube_ctrl.Result{}, errors.Wrap(err, "error generating GatewayRoute.kuma.io")
 	}
 
-	if spec != nil {
-		if err := common.ReconcileLabelledObject(ctx, r.Log, r.TypeRegistry, r.Client, req.NamespacedName, mesh, &mesh_proto.MeshGatewayRoute{}, spec); err != nil {
+	if gatewayRouteSpec != nil {
+		if err := common.ReconcileLabelledObject(ctx, r.Log, r.TypeRegistry, r.Client, req.NamespacedName, mesh, &mesh_proto.MeshGatewayRoute{}, gatewayRouteSpec); err != nil {
 			return kube_ctrl.Result{}, errors.Wrap(err, "could not reconcile owned GatewayRoute.kuma.io")
 		}
 	}

--- a/pkg/plugins/runtime/k8s/controllers/gatewayapi/http_route_controller.go
+++ b/pkg/plugins/runtime/k8s/controllers/gatewayapi/http_route_controller.go
@@ -161,11 +161,6 @@ func (r *HTTPRouteReconciler) gapiToKumaRoutes(
 				if ref.Namespace != nil {
 					namespace = string(*ref.Namespace)
 				}
-				// TODO handle producer/consumer routes, for now only handle
-				// routes in the same namespace i.e. producer that apply to all requests
-				if namespace != route.Namespace {
-					continue
-				}
 				services = append(services,
 					kube_types.NamespacedName{Name: string(ref.Name), Namespace: namespace},
 				)

--- a/pkg/plugins/runtime/k8s/controllers/gatewayapi/http_route_controller.go
+++ b/pkg/plugins/runtime/k8s/controllers/gatewayapi/http_route_controller.go
@@ -2,6 +2,7 @@ package gatewayapi
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
@@ -14,6 +15,7 @@ import (
 	kube_types "k8s.io/apimachinery/pkg/types"
 	kube_ctrl "sigs.k8s.io/controller-runtime"
 	kube_client "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	kube_handler "sigs.k8s.io/controller-runtime/pkg/handler"
 	kube_reconcile "sigs.k8s.io/controller-runtime/pkg/reconcile"
 	kube_source "sigs.k8s.io/controller-runtime/pkg/source"
@@ -22,6 +24,8 @@ import (
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	"github.com/kumahq/kuma/pkg/core/resources/manager"
 	core_model "github.com/kumahq/kuma/pkg/core/resources/model"
+	meshhttproute_api "github.com/kumahq/kuma/pkg/plugins/policies/meshhttproute/api/v1alpha1"
+	meshhttproute_k8s "github.com/kumahq/kuma/pkg/plugins/policies/meshhttproute/k8s/v1alpha1"
 	k8s_registry "github.com/kumahq/kuma/pkg/plugins/resources/k8s/native/pkg/registry"
 	"github.com/kumahq/kuma/pkg/plugins/runtime/k8s/controllers/gatewayapi/attachment"
 	"github.com/kumahq/kuma/pkg/plugins/runtime/k8s/controllers/gatewayapi/common"
@@ -62,7 +66,7 @@ func (r *HTTPRouteReconciler) Reconcile(ctx context.Context, req kube_ctrl.Reque
 
 	mesh := k8s_util.MeshOfByAnnotation(httpRoute, &ns)
 
-	gatewayRouteSpec, conditions, err := r.gapiToKumaRoutes(ctx, mesh, httpRoute)
+	gatewayRouteSpec, meshRouteSpecs, conditions, err := r.gapiToKumaRoutes(ctx, mesh, httpRoute)
 	if err != nil {
 		return kube_ctrl.Result{}, errors.Wrap(err, "error generating GatewayRoute.kuma.io")
 	}
@@ -70,6 +74,21 @@ func (r *HTTPRouteReconciler) Reconcile(ctx context.Context, req kube_ctrl.Reque
 	if gatewayRouteSpec != nil {
 		if err := common.ReconcileLabelledObject(ctx, r.Log, r.TypeRegistry, r.Client, req.NamespacedName, mesh, &mesh_proto.MeshGatewayRoute{}, gatewayRouteSpec); err != nil {
 			return kube_ctrl.Result{}, errors.Wrap(err, "could not reconcile owned GatewayRoute.kuma.io")
+		}
+	}
+
+	for subName, meshRouteSpec := range meshRouteSpecs {
+		spec := meshRouteSpec
+		route := meshhttproute_k8s.MeshHTTPRoute{
+			ObjectMeta: kube_meta.ObjectMeta{
+				Name: fmt.Sprintf("%s-%s", httpRoute.Name, subName), Namespace: "kuma-system",
+			},
+		}
+		if _, err := controllerutil.CreateOrUpdate(ctx, r.Client, &route, func() error {
+			route.Spec = &spec
+			return nil
+		}); err != nil {
+			return kube_ctrl.Result{}, err
 		}
 	}
 
@@ -91,33 +110,35 @@ func (r *HTTPRouteReconciler) gapiToKumaRoutes(
 	route *gatewayapi.HTTPRoute,
 ) (
 	*mesh_proto.MeshGatewayRoute,
+	map[string]meshhttproute_api.MeshHTTPRoute,
 	ParentConditions,
 	error,
 ) {
 	routeNs := kube_core.Namespace{}
 	if err := r.Client.Get(ctx, kube_types.NamespacedName{Name: route.Namespace}, &routeNs); err != nil {
 		if kube_apierrs.IsNotFound(err) {
-			return nil, nil, nil
+			return nil, nil, nil, nil
 		} else {
-			return nil, nil, err
+			return nil, nil, nil, err
 		}
 	}
 
 	routeConf, routeConditions, err := r.gapiToKumaRouteConf(ctx, mesh, route)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
+
+	var services []kube_types.NamespacedName
+	var selectors []*mesh_proto.Selector
 
 	// The conditions we accumulate for each ParentRef
 	conditions := ParentConditions{}
-
-	var selectors []*mesh_proto.Selector
 
 	// Convert GAPI parent refs into selectors
 	for i, ref := range route.Spec.ParentRefs {
 		refAttachment, err := attachment.EvaluateParentRefAttachment(ctx, r.Client, route.Spec.Hostnames, &routeNs, ref)
 		if err != nil {
-			return nil, nil, errors.Wrapf(err, "unable to check parent ref %d", i)
+			return nil, nil, nil, errors.Wrapf(err, "unable to check parent ref %d", i)
 		}
 
 		refConditions := slices.Clone(routeConditions)
@@ -127,12 +148,28 @@ func (r *HTTPRouteReconciler) gapiToKumaRoutes(
 			// We don't care about this ref
 			continue
 		case attachment.Allowed:
-			selectors = append(
-				selectors,
-				&mesh_proto.Selector{
-					Match: tagsForRef(route, ref),
-				},
-			)
+			switch {
+			case *ref.Kind == gatewayapi.Kind("Gateway") && *ref.Group == gatewayapi.GroupName:
+				selectors = append(
+					selectors,
+					&mesh_proto.Selector{
+						Match: tagsForRef(route, ref),
+					},
+				)
+			case *ref.Kind == gatewayapi.Kind("Service") && *ref.Group == "":
+				namespace := route.Namespace
+				if ref.Namespace != nil {
+					namespace = string(*ref.Namespace)
+				}
+				// TODO handle producer/consumer routes, for now only handle
+				// routes in the same namespace i.e. producer that apply to all requests
+				if namespace != route.Namespace {
+					continue
+				}
+				services = append(services,
+					kube_types.NamespacedName{Name: string(ref.Name), Namespace: namespace},
+				)
+			}
 		default:
 			var reason string
 			switch refAttachment {
@@ -156,6 +193,11 @@ func (r *HTTPRouteReconciler) gapiToKumaRoutes(
 		conditions[ref] = refConditions
 	}
 
+	meshRoutes, err := r.gapiToMeshRouteSpecs(ctx, mesh, route, services)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
 	var kumaRoute *mesh_proto.MeshGatewayRoute
 
 	if routeConf != nil && len(selectors) > 0 {
@@ -166,7 +208,7 @@ func (r *HTTPRouteReconciler) gapiToKumaRoutes(
 		}
 	}
 
-	return kumaRoute, conditions, nil
+	return kumaRoute, meshRoutes, conditions, nil
 }
 
 func tagsForRef(referrer kube_client.Object, ref gatewayapi.ParentReference) map[string]string {

--- a/pkg/plugins/runtime/k8s/controllers/gatewayapi/http_route_conversion.go
+++ b/pkg/plugins/runtime/k8s/controllers/gatewayapi/http_route_conversion.go
@@ -172,10 +172,7 @@ type ResolvedRefsConditionFalse struct {
 	Message string
 }
 
-// gapiToKumaRef checks a reference and tries to resolve if it's supported by
-// Kuma. It returns a condition with Reason/Message if it fails or an error for
-// unexpected errors.
-func (r *HTTPRouteReconciler) gapiToKumaRef(
+func (r *HTTPRouteReconciler) uncheckedGapiToKumaRef(
 	ctx context.Context, mesh string, objectNamespace string, ref gatewayapi.BackendObjectReference,
 ) (map[string]string, *ResolvedRefsConditionFalse, error) {
 	unresolvedBackendTags := map[string]string{
@@ -186,17 +183,6 @@ func (r *HTTPRouteReconciler) gapiToKumaRef(
 
 	gk := policyRef.GroupKindReferredTo()
 	namespacedName := policyRef.NamespacedNameReferredTo()
-
-	if permitted, err := policy.IsReferencePermitted(ctx, r.Client, policyRef); err != nil {
-		return nil, nil, errors.Wrap(err, "couldn't determine if backend reference is permitted")
-	} else if !permitted {
-		return unresolvedBackendTags,
-			&ResolvedRefsConditionFalse{
-				Reason:  string(gatewayapi.RouteReasonRefNotPermitted),
-				Message: fmt.Sprintf("reference to %s %q not permitted by any ReferencePolicy", gk, namespacedName),
-			},
-			nil
-	}
 
 	switch {
 	case gk.Kind == "Service" && gk.Group == "":
@@ -244,6 +230,35 @@ func (r *HTTPRouteReconciler) gapiToKumaRef(
 			Message: "backend reference must be Service or externalservice.kuma.io",
 		},
 		nil
+}
+
+// gapiToKumaRef checks a reference and tries to resolve if it's supported by
+// Kuma. It returns a condition with Reason/Message if it fails or an error for
+// unexpected errors.
+func (r *HTTPRouteReconciler) gapiToKumaRef(
+	ctx context.Context, mesh string, objectNamespace string, ref gatewayapi.BackendObjectReference,
+) (map[string]string, *ResolvedRefsConditionFalse, error) {
+	unresolvedBackendTags := map[string]string{
+		mesh_proto.ServiceTag: gateway.UnresolvedBackendServiceTag,
+	}
+
+	policyRef := policy.PolicyReferenceBackend(policy.FromHTTPRouteIn(objectNamespace), ref)
+
+	gk := policyRef.GroupKindReferredTo()
+	namespacedName := policyRef.NamespacedNameReferredTo()
+
+	if permitted, err := policy.IsReferencePermitted(ctx, r.Client, policyRef); err != nil {
+		return nil, nil, errors.Wrap(err, "couldn't determine if backend reference is permitted")
+	} else if !permitted {
+		return unresolvedBackendTags,
+			&ResolvedRefsConditionFalse{
+				Reason:  string(gatewayapi.RouteReasonRefNotPermitted),
+				Message: fmt.Sprintf("reference to %s %q not permitted by any ReferencePolicy", gk, namespacedName),
+			},
+			nil
+	}
+
+	return r.uncheckedGapiToKumaRef(ctx, mesh, objectNamespace, ref)
 }
 
 func gapiToKumaMatch(match gatewayapi.HTTPRouteMatch) (*mesh_proto.MeshGatewayRoute_HttpRoute_Match, error) {

--- a/pkg/plugins/runtime/k8s/controllers/gatewayapi/http_route_conversion.go
+++ b/pkg/plugins/runtime/k8s/controllers/gatewayapi/http_route_conversion.go
@@ -8,6 +8,7 @@ import (
 	kube_core "k8s.io/api/core/v1"
 	kube_apierrs "k8s.io/apimachinery/pkg/api/errors"
 	kube_meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kube_client "sigs.k8s.io/controller-runtime/pkg/client"
 	gatewayapi "sigs.k8s.io/gateway-api/apis/v1beta1"
 
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
@@ -216,7 +217,7 @@ func (r *HTTPRouteReconciler) gapiToKumaRef(
 		}
 
 		return map[string]string{
-			mesh_proto.ServiceTag: k8s_util.ServiceTagFor(svc, &port),
+			mesh_proto.ServiceTag: k8s_util.ServiceTag(kube_client.ObjectKeyFromObject(svc), &port),
 		}, nil, nil
 	case gk.Kind == "ExternalService" && gk.Group == mesh_k8s.GroupVersion.Group:
 		resource := core_mesh.NewExternalServiceResource()

--- a/pkg/plugins/runtime/k8s/controllers/gatewayapi/mesh_http_route_conversion.go
+++ b/pkg/plugins/runtime/k8s/controllers/gatewayapi/mesh_http_route_conversion.go
@@ -121,6 +121,7 @@ func (r *HTTPRouteReconciler) gapiToKumaMeshRule(
 				Kind: common_api.MeshService,
 				Name: ref[mesh_proto.ServiceTag],
 			},
+			Weight: pointer.To(uint(*gapiBackendRef.Weight)),
 		})
 	}
 

--- a/pkg/plugins/runtime/k8s/controllers/gatewayapi/mesh_http_route_conversion.go
+++ b/pkg/plugins/runtime/k8s/controllers/gatewayapi/mesh_http_route_conversion.go
@@ -1,0 +1,132 @@
+package gatewayapi
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/pkg/errors"
+	kube_core "k8s.io/api/core/v1"
+	kube_types "k8s.io/apimachinery/pkg/types"
+	gatewayapi "sigs.k8s.io/gateway-api/apis/v1beta1"
+
+	common_api "github.com/kumahq/kuma/api/common/v1alpha1"
+	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
+	"github.com/kumahq/kuma/pkg/plugins/policies/meshhttproute/api/v1alpha1"
+	k8s_util "github.com/kumahq/kuma/pkg/plugins/runtime/k8s/util"
+	"github.com/kumahq/kuma/pkg/util/pointer"
+)
+
+func (r *HTTPRouteReconciler) gapiToMeshRouteSpecs(
+	ctx context.Context, mesh string, route *gatewayapi.HTTPRoute, svcs []kube_types.NamespacedName,
+) (map[string]v1alpha1.MeshHTTPRoute, error) {
+	routes := map[string]v1alpha1.MeshHTTPRoute{}
+
+	for _, svcRef := range svcs {
+		svc := kube_core.Service{}
+		if err := r.Client.Get(ctx, svcRef, &svc); err != nil {
+			return nil, errors.Wrap(err, "unable to get Service")
+		}
+		var ports []int32
+		for _, port := range svc.Spec.Ports {
+			ports = append(ports, port.Port)
+		}
+		for _, port := range ports {
+			p := port
+
+			rules, err := r.gapiToMeshRouteRules(ctx, mesh, route)
+			if err != nil {
+				return nil, err
+			}
+			serviceName := k8s_util.ServiceTag(
+				svcRef,
+				&p,
+			)
+
+			to := []v1alpha1.To{{
+				TargetRef: common_api.TargetRef{
+					Kind: common_api.MeshService,
+					Name: serviceName,
+				},
+				Rules: rules,
+			}}
+			routeSubName := fmt.Sprintf("%s-%s-%d", svc.Name, svc.Namespace, port)
+			routes[routeSubName] = v1alpha1.MeshHTTPRoute{
+				TargetRef: common_api.TargetRef{
+					Kind: common_api.Mesh,
+				},
+				To: to,
+			}
+		}
+	}
+
+	return routes, nil
+}
+
+func (r *HTTPRouteReconciler) gapiToMeshRouteRules(
+	ctx context.Context, mesh string, route *gatewayapi.HTTPRoute,
+) ([]v1alpha1.Rule, error) {
+	var rules []v1alpha1.Rule
+	for _, rule := range route.Spec.Rules {
+		kumaRule, err := r.gapiToKumaMeshRule(ctx, mesh, route, rule)
+		if err != nil {
+			return nil, err
+		}
+
+		rules = append(rules, kumaRule)
+	}
+
+	return rules, nil
+}
+
+func (r *HTTPRouteReconciler) gapiToKumaMeshRule(
+	ctx context.Context, mesh string, route *gatewayapi.HTTPRoute, rule gatewayapi.HTTPRouteRule,
+) (v1alpha1.Rule, error) {
+	var matches []v1alpha1.Match
+	var backendRefs []v1alpha1.BackendRef
+
+	for _, gapiMatch := range rule.Matches {
+		matches = append(matches, r.gapiToKumaMeshMatch(gapiMatch))
+	}
+
+	for _, gapiBackendRef := range rule.BackendRefs {
+		// TODO condition
+		ref, _, err := r.gapiToKumaRef(ctx, mesh, route.Namespace, gapiBackendRef.BackendObjectReference)
+		if err != nil {
+			return v1alpha1.Rule{}, err
+		}
+
+		backendRefs = append(backendRefs, v1alpha1.BackendRef{
+			TargetRef: common_api.TargetRef{
+				Kind: common_api.MeshService,
+				Name: ref[mesh_proto.ServiceTag],
+			},
+		})
+	}
+
+	return v1alpha1.Rule{
+		Matches: matches,
+		Default: v1alpha1.RuleConf{
+			BackendRefs: &backendRefs,
+		},
+	}, nil
+}
+
+func (r *HTTPRouteReconciler) gapiToKumaMeshMatch(gapiMatch gatewayapi.HTTPRouteMatch) v1alpha1.Match {
+	var match v1alpha1.Match
+
+	match.Path = &v1alpha1.PathMatch{
+		Type:  v1alpha1.PathMatchType(*gapiMatch.Path.Type),
+		Value: *gapiMatch.Path.Value,
+	}
+
+	for _, gapiHeader := range gapiMatch.Headers {
+		header := common_api.HeaderMatch{
+			Type:  pointer.To(common_api.HeaderMatchType(*gapiHeader.Type)),
+			Name:  common_api.HeaderName(gapiHeader.Name),
+			Value: common_api.HeaderValue(gapiHeader.Value),
+		}
+		match.Headers = append(match.Headers, header)
+	}
+
+	return match
+}

--- a/pkg/plugins/runtime/k8s/controllers/gatewayapi/mesh_http_route_conversion.go
+++ b/pkg/plugins/runtime/k8s/controllers/gatewayapi/mesh_http_route_conversion.go
@@ -110,7 +110,8 @@ func (r *HTTPRouteReconciler) gapiToKumaMeshRule(
 
 	for _, gapiBackendRef := range rule.BackendRefs {
 		// TODO condition
-		ref, _, err := r.gapiToKumaRef(ctx, mesh, route.Namespace, gapiBackendRef.BackendObjectReference)
+		// ReferenceGrants don't need to be taken into account for Mesh
+		ref, _, err := r.uncheckedGapiToKumaRef(ctx, mesh, route.Namespace, gapiBackendRef.BackendObjectReference)
 		if err != nil {
 			return v1alpha1.Rule{}, err
 		}

--- a/pkg/plugins/runtime/k8s/controllers/inbound_converter.go
+++ b/pkg/plugins/runtime/k8s/controllers/inbound_converter.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/pkg/errors"
 	kube_core "k8s.io/api/core/v1"
+	kube_client "sigs.k8s.io/controller-runtime/pkg/client"
 
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
@@ -164,7 +165,7 @@ func InboundTagsForService(zone string, pod *kube_core.Pod, svc *kube_core.Servi
 	tags[KubeNamespaceTag] = pod.Namespace
 	tags[KubeServiceTag] = svc.Name
 	tags[KubePortTag] = strconv.Itoa(int(svcPort.Port))
-	tags[mesh_proto.ServiceTag] = util_k8s.ServiceTagFor(svc, &svcPort.Port)
+	tags[mesh_proto.ServiceTag] = util_k8s.ServiceTag(kube_client.ObjectKeyFromObject(svc), &svcPort.Port)
 	if zone != "" {
 		tags[mesh_proto.ZoneTag] = zone
 	}

--- a/pkg/plugins/runtime/k8s/util/util.go
+++ b/pkg/plugins/runtime/k8s/util/util.go
@@ -8,6 +8,7 @@ import (
 	kube_core "k8s.io/api/core/v1"
 	kube_meta "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kube_labels "k8s.io/apimachinery/pkg/labels"
+	kube_types "k8s.io/apimachinery/pkg/types"
 	kube_intstr "k8s.io/apimachinery/pkg/util/intstr"
 	kube_client "sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -169,12 +170,12 @@ func MeshOfByLabelOrAnnotation(log logr.Logger, obj kube_client.Object, namespac
 	return model.DefaultMesh
 }
 
-// ServiceTagFor returns the canonical service name for a Kubernetes service,
+// ServiceTag returns the canonical service name for a Kubernetes service,
 // optionally with a specific port.
-func ServiceTagFor(svc *kube_core.Service, svcPort *int32) string {
+func ServiceTag(name kube_types.NamespacedName, svcPort *int32) string {
 	port := ""
 	if svcPort != nil {
 		port = fmt.Sprintf("_%d", *svcPort)
 	}
-	return fmt.Sprintf("%s_%s_svc%s", svc.Name, svc.Namespace, port)
+	return fmt.Sprintf("%s_%s_svc%s", name.Name, name.Namespace, port)
 }

--- a/pkg/plugins/runtime/k8s/util/util_test.go
+++ b/pkg/plugins/runtime/k8s/util/util_test.go
@@ -9,6 +9,7 @@ import (
 	kube_core "k8s.io/api/core/v1"
 	kube_meta "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kube_intstr "k8s.io/apimachinery/pkg/util/intstr"
+	kube_client "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/yaml"
 
 	"github.com/kumahq/kuma/pkg/plugins/runtime/k8s/util"
@@ -655,7 +656,7 @@ var _ = Describe("Util", func() {
 			}
 
 			// then
-			Expect(util.ServiceTagFor(svc, &svc.Spec.Ports[0].Port)).To(Equal("example_demo_svc_80"))
+			Expect(util.ServiceTag(kube_client.ObjectKeyFromObject(svc), &svc.Spec.Ports[0].Port)).To(Equal("example_demo_svc_80"))
 		})
 	})
 })


### PR DESCRIPTION
See https://gateway-api.sigs.k8s.io/geps/gep-1426/ for any questions about how this should actually work.

> Changelog: skip

~Blocked by https://github.com/kumahq/kuma/pull/6614~

- [x] Passes the Mesh conformance tests

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues -- #6508 
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [x] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
