### PR TITLE
ci(mk): don't rebuild distributions in publish

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -378,9 +378,11 @@ jobs:
         - golang_go.mod_{{ checksum "go.sum" }}_{{ checksum "mk/dependencies/deps.lock" }}_{{ checksum ".circleci/config.yml" }}
     - setenv_depending_on_priority:
         label: "ci/run-full-matrix"
-        env: ENABLED_GOARCHES="arm64 amd64"
+        env: ENABLED_GOARCHES="arm64 amd64" ENABLED_GOOSES="linux darwin"
     - run:
-        command: make build/distributions
+        command: make build
+    - run:
+        command: make -j build/distributions
     - run:
         command: make -j images
     - run:
@@ -413,9 +415,6 @@ jobs:
             - vm-amd64_go.mod_{{ checksum "go.sum" }}_{{ checksum "mk/dependencies/deps.lock" }}_{{ checksum ".circleci/config.yml" }}
       - attach_workspace:
           at: build
-      - run:
-          name: Build distributions
-          command: make build/distributions
       - run:
           name: inspect created tars
           command: for i in build/distributions/out/*.tar.gz; do echo $i; tar -tvf $i; done

--- a/mk/build.mk
+++ b/mk/build.mk
@@ -36,7 +36,9 @@ SUPPORTED_GOOSES ?= linux darwin
 ENABLED_GOARCHES ?= $(GOARCH)
 # This is a list of all osses enabled, this means generic targets like `make build/distributions` will build for each of these arches
 ENABLED_GOOSES ?= $(GOOS)
-ENABLED_ARCH_OS = $(foreach os,$(ENABLED_GOOSES),$(foreach arch,$(ENABLED_GOARCHES),$(os)-$(arch)))
+# We can remove some specific combination that may be invalid with this
+IGNORED_ARCH_OS ?=
+ENABLED_ARCH_OS = $(filter-out $(IGNORED_ARCH_OS), $(foreach os,$(ENABLED_GOOSES),$(foreach arch,$(ENABLED_GOARCHES),$(os)-$(arch))))
 
 .PHONY: build/info
 build/info: ## Dev: Show build info
@@ -44,6 +46,8 @@ build/info: ## Dev: Show build info
 	@echo tools-dir: $(CI_TOOLS_DIR)
 	@echo arch: supported=$(SUPPORTED_GOARCHES), enabled=$(ENABLED_GOARCHES)
 	@echo os: supported=$(SUPPORTED_GOOSES), enabled=$(ENABLED_GOOSES)
+	@echo ignored=$(IGNORED_ARCH_OS)
+	@echo enabled arch-os=$(ENABLED_ARCH_OS)
 
 .PHONY: build
 build: build/release build/test ## Dev: Build all binaries

--- a/mk/distribution.mk
+++ b/mk/distribution.mk
@@ -23,8 +23,7 @@ DISTRIBUTION_FOLDER=build/distributions/$(GOOS)-$(GOARCH)/$(DISTRIBUTION_TARGET_
 # $(3) - coredns extension to use (or `skip` if we shouldn't include COREDNS)
 # $(4) - primary envoy to use in the distribution (the binary that will be called `envoy`)
 define make_distributions_target
-build/distributions/$(1)-$(2)/$(DISTRIBUTION_TARGET_NAME):
-	@if [ ! -d build/artifacts-$(1)-$(2) ]; then echo "need to run 'make build' first!"; exit 1; fi
+build/distributions/$(1)-$(2)/$(DISTRIBUTION_TARGET_NAME): build/artifacts-$(1)-$(2)/kumactl build/artifacts-$(1)-$(2)/kuma-cp build/artifacts-$(1)-$(2)/kuma-dp
 	rm -rf $$@
 	mkdir -p $$@/bin $$@/conf
 	cp build/artifacts-$(1)-$(2)/kumactl/kumactl $$@/bin

--- a/mk/distribution.mk
+++ b/mk/distribution.mk
@@ -23,7 +23,8 @@ DISTRIBUTION_FOLDER=build/distributions/$(GOOS)-$(GOARCH)/$(DISTRIBUTION_TARGET_
 # $(3) - coredns extension to use (or `skip` if we shouldn't include COREDNS)
 # $(4) - primary envoy to use in the distribution (the binary that will be called `envoy`)
 define make_distributions_target
-build/distributions/$(1)-$(2)/$(DISTRIBUTION_TARGET_NAME): build/artifacts-$(1)-$(2)/kumactl build/artifacts-$(1)-$(2)/kuma-cp build/artifacts-$(1)-$(2)/kuma-dp
+build/distributions/$(1)-$(2)/$(DISTRIBUTION_TARGET_NAME):
+	@if [ ! -d build/artifacts-$(1)-$(2) ]; then echo "need to run 'make build' first!"; exit 1; fi
 	rm -rf $$@
 	mkdir -p $$@/bin $$@/conf
 	cp build/artifacts-$(1)-$(2)/kumactl/kumactl $$@/bin


### PR DESCRIPTION
The distributions are already part of build we should need to rebuild them. Also split build and distributions in 2 different tasks to be able to use -j for `make build/distributions`

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [x] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
