### PR TITLE
fix(kuma-cp): race condition when proxy connects to the same CP in less than KUMA_XDS_DATAPLANE_DEREGISTRATION_DELAY

### DIFF
--- a/test/framework/envs/universal/env.go
+++ b/test/framework/envs/universal/env.go
@@ -19,6 +19,7 @@ func SetupAndGetState() []byte {
 		[]framework.KumaDeploymentOption{
 			framework.WithEnv("KUMA_STORE_UNSAFE_DELETE", "true"),
 			framework.WithEnv("KUMA_XDS_SERVER_DATAPLANE_STATUS_FLUSH_INTERVAL", "1s"), // speed up some tests by flushing stats quicker than default 10s
+			framework.WithEnv("KUMA_XDS_DATAPLANE_DEREGISTRATION_DELAY", "0s"),         // we have only 1 Kuma CP instance so there is no risk setting this to 0
 		}, framework.KumaDeploymentOptionsFromConfig(framework.Config.KumaCpConfig.Standalone.Universal)...)
 	Expect(Cluster.Install(framework.Kuma(core.Standalone, kumaOptions...))).To(Succeed())
 	Expect(Cluster.Install(framework.EgressUniversal(func(zone string) (string, error) {


### PR DESCRIPTION
* fix `[It] Mtls enabling PERMISSIVE with no failed requests` flakiness by setting `KUMA_XDS_DATAPLANE_DEREGISTRATION_DELAY` to 0.
* make the writes to `proxyTypeByKey` atomic with the creating resources in the store
* refactor `dataplane_lifecycle.go`

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [X] [Link to relevant issue][1] as well as docs and UI issues --
- [X] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [X] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [X] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [X] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [X] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
