### PR TITLE
fix(MeshHTTPRoute): rename Prefix to PathPrefix

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -6,6 +6,14 @@ with `x.y.z` being the version you are planning to upgrade to.
 If such a section does not exist, the upgrade you want to perform
 does not have any particular instructions.
 
+## Upgrade to `2.3.x`
+
+### **Breaking changes**
+
+#### `MeshHTTPRoute`
+
+* Changed path match `type` from `Prefix` to `PathPrefix`
+
 ## Upgrade to `2.2.x`
 
 ### Universal

--- a/app/kumactl/cmd/install/testdata/install-control-plane.defaults.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.defaults.golden.yaml
@@ -1519,7 +1519,7 @@ spec:
                                     type:
                                       enum:
                                       - Exact
-                                      - Prefix
+                                      - PathPrefix
                                       - RegularExpression
                                       type: string
                                     value:

--- a/app/kumactl/cmd/install/testdata/install-control-plane.gateway-api-present-not-enabled.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.gateway-api-present-not-enabled.yaml
@@ -1519,7 +1519,7 @@ spec:
                                     type:
                                       enum:
                                       - Exact
-                                      - Prefix
+                                      - PathPrefix
                                       - RegularExpression
                                       type: string
                                     value:

--- a/app/kumactl/cmd/install/testdata/install-control-plane.gateway-api-present.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.gateway-api-present.yaml
@@ -1723,7 +1723,7 @@ spec:
                                     type:
                                       enum:
                                       - Exact
-                                      - Prefix
+                                      - PathPrefix
                                       - RegularExpression
                                       type: string
                                     value:

--- a/app/kumactl/cmd/install/testdata/install-control-plane.with-helm-set.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.with-helm-set.yaml
@@ -1539,7 +1539,7 @@ spec:
                                     type:
                                       enum:
                                       - Exact
-                                      - Prefix
+                                      - PathPrefix
                                       - RegularExpression
                                       type: string
                                     value:

--- a/app/kumactl/cmd/install/testdata/install-crds.all.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-crds.all.golden.yaml
@@ -2736,7 +2736,7 @@ spec:
                                     type:
                                       enum:
                                       - Exact
-                                      - Prefix
+                                      - PathPrefix
                                       - RegularExpression
                                       type: string
                                     value:

--- a/app/kumactl/cmd/install/testdata/install-crds.experimental-gatewayapi.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-crds.experimental-gatewayapi.golden.yaml
@@ -2940,7 +2940,7 @@ spec:
                                     type:
                                       enum:
                                       - Exact
-                                      - Prefix
+                                      - PathPrefix
                                       - RegularExpression
                                       type: string
                                     value:

--- a/deployments/charts/kuma/crds/kuma.io_meshhttproutes.yaml
+++ b/deployments/charts/kuma/crds/kuma.io_meshhttproutes.yaml
@@ -418,7 +418,7 @@ spec:
                                     type:
                                       enum:
                                       - Exact
-                                      - Prefix
+                                      - PathPrefix
                                       - RegularExpression
                                       type: string
                                     value:

--- a/pkg/plugins/policies/meshhttproute/api/v1alpha1/meshhttproute.go
+++ b/pkg/plugins/policies/meshhttproute/api/v1alpha1/meshhttproute.go
@@ -50,7 +50,7 @@ type Match struct {
 	Headers     []common_api.HeaderMatch `json:"headers,omitempty"`
 }
 
-// +kubebuilder:validation:Enum=Exact;Prefix;RegularExpression
+// +kubebuilder:validation:Enum=Exact;PathPrefix;RegularExpression
 type PathMatchType string
 
 // +kubebuilder:validation:Enum=CONNECT;DELETE;GET;HEAD;OPTIONS;PATCH;POST;PUT;TRACE
@@ -58,7 +58,7 @@ type Method string
 
 const (
 	Exact             PathMatchType = "Exact"
-	Prefix            PathMatchType = "Prefix"
+	PathPrefix        PathMatchType = "PathPrefix"
 	RegularExpression PathMatchType = "RegularExpression"
 )
 

--- a/pkg/plugins/policies/meshhttproute/api/v1alpha1/schema.yaml
+++ b/pkg/plugins/policies/meshhttproute/api/v1alpha1/schema.yaml
@@ -340,7 +340,7 @@ properties:
                             type:
                               enum:
                                 - Exact
-                                - Prefix
+                                - PathPrefix
                                 - RegularExpression
                               type: string
                             value:

--- a/pkg/plugins/policies/meshhttproute/api/v1alpha1/validation.go
+++ b/pkg/plugins/policies/meshhttproute/api/v1alpha1/validation.go
@@ -86,7 +86,7 @@ func validatePath(match *PathMatch) validators.ValidationError {
 	switch match.Type {
 	case RegularExpression:
 		break
-	case Prefix:
+	case PathPrefix:
 		if match.Value == "/" {
 			break
 		}
@@ -148,7 +148,7 @@ func validateQueryParams(matches []QueryParamsMatch) validators.ValidationError 
 
 func hasAnyMatchesWithoutPrefix(matches []Match) bool {
 	for _, match := range matches {
-		if match.Path == nil || match.Path.Type != Prefix {
+		if match.Path == nil || match.Path.Type != PathPrefix {
 			return true
 		}
 	}

--- a/pkg/plugins/policies/meshhttproute/api/v1alpha1/validation_test.go
+++ b/pkg/plugins/policies/meshhttproute/api/v1alpha1/validation_test.go
@@ -68,10 +68,10 @@ to:
           type: Exact
       - path:
           value: "/trailing/slash/"
-          type: Prefix
+          type: PathPrefix
       - path:
           value: "relative"
-          type: Prefix
+          type: PathPrefix
 `),
 		ErrorCase("repeated match query param names",
 			validators.Violation{
@@ -265,7 +265,7 @@ to:
   rules:
     - matches:
       - path:
-          type: Prefix
+          type: PathPrefix
           value: /
       default:
         backendRefs:
@@ -292,7 +292,7 @@ to:
   rules:
     - matches:
       - path:
-          type: Prefix
+          type: PathPrefix
           value: /
       default:
         filters:
@@ -330,7 +330,7 @@ to:
     - matches:
       - path:
           value: /prefix
-          type: Prefix
+          type: PathPrefix
       default:
         filters:
           - type: URLRewrite

--- a/pkg/plugins/policies/meshhttproute/k8s/crd/kuma.io_meshhttproutes.yaml
+++ b/pkg/plugins/policies/meshhttproute/k8s/crd/kuma.io_meshhttproutes.yaml
@@ -418,7 +418,7 @@ spec:
                                     type:
                                       enum:
                                       - Exact
-                                      - Prefix
+                                      - PathPrefix
                                       - RegularExpression
                                       type: string
                                     value:

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/listeners.go
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/listeners.go
@@ -119,7 +119,7 @@ func prepareRoutes(
 	catchAllMatch := []api.Match{{
 		Path: &api.PathMatch{
 			Value: "/",
-			Type:  api.Prefix,
+			Type:  api.PathPrefix,
 		},
 	}}
 

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/plugin_test.go
@@ -66,7 +66,7 @@ var _ = Describe("MeshHTTPRoute", func() {
 								Rules: []api.Rule{{
 									Matches: []api.Match{{
 										Path: &api.PathMatch{
-											Type:  api.Prefix,
+											Type:  api.PathPrefix,
 											Value: "/v1",
 										},
 									}},
@@ -88,7 +88,7 @@ var _ = Describe("MeshHTTPRoute", func() {
 								Rules: []api.Rule{{
 									Matches: []api.Match{{
 										Path: &api.PathMatch{
-											Type:  api.Prefix,
+											Type:  api.PathPrefix,
 											Value: "/v1",
 										},
 									}},
@@ -101,7 +101,7 @@ var _ = Describe("MeshHTTPRoute", func() {
 								}, {
 									Matches: []api.Match{{
 										Path: &api.PathMatch{
-											Type:  api.Prefix,
+											Type:  api.PathPrefix,
 											Value: "/v2",
 										},
 									}},
@@ -126,7 +126,7 @@ var _ = Describe("MeshHTTPRoute", func() {
 						Rules: []api.Rule{{
 							Matches: []api.Match{{
 								Path: &api.PathMatch{
-									Type:  api.Prefix,
+									Type:  api.PathPrefix,
 									Value: "/v1",
 								},
 							}},
@@ -140,7 +140,7 @@ var _ = Describe("MeshHTTPRoute", func() {
 						}, {
 							Matches: []api.Match{{
 								Path: &api.PathMatch{
-									Type:  api.Prefix,
+									Type:  api.PathPrefix,
 									Value: "/v2",
 								},
 							}},
@@ -273,7 +273,7 @@ var _ = Describe("MeshHTTPRoute", func() {
 											Rules: []api.Rule{{
 												Matches: []api.Match{{
 													Path: &api.PathMatch{
-														Type:  api.Prefix,
+														Type:  api.PathPrefix,
 														Value: "/v1",
 													},
 												}},
@@ -286,12 +286,12 @@ var _ = Describe("MeshHTTPRoute", func() {
 											}, {
 												Matches: []api.Match{{
 													Path: &api.PathMatch{
-														Type:  api.Prefix,
+														Type:  api.PathPrefix,
 														Value: "/v2",
 													},
 												}, {
 													Path: &api.PathMatch{
-														Type:  api.Prefix,
+														Type:  api.PathPrefix,
 														Value: "/v3",
 													},
 												}},
@@ -361,7 +361,7 @@ var _ = Describe("MeshHTTPRoute", func() {
 												Rules: []api.Rule{{
 													Matches: []api.Match{{
 														Path: &api.PathMatch{
-															Type:  api.Prefix,
+															Type:  api.PathPrefix,
 															Value: "/v1",
 														},
 													}},
@@ -453,7 +453,7 @@ var _ = Describe("MeshHTTPRoute", func() {
 												Rules: []api.Rule{{
 													Matches: []api.Match{{
 														Path: &api.PathMatch{
-															Type:  api.Prefix,
+															Type:  api.PathPrefix,
 															Value: "/v1",
 														},
 													}},
@@ -587,7 +587,7 @@ var _ = Describe("MeshHTTPRoute", func() {
 												Rules: []api.Rule{{
 													Matches: []api.Match{{
 														Path: &api.PathMatch{
-															Type:  api.Prefix,
+															Type:  api.PathPrefix,
 															Value: "/v1",
 														},
 													}},

--- a/pkg/plugins/policies/meshhttproute/xds/configurer.go
+++ b/pkg/plugins/policies/meshhttproute/xds/configurer.go
@@ -93,7 +93,7 @@ func (c RoutesConfigurer) routeMatch(matches []api.Match) []routeMatch {
 				routeQueryParamsMatch(envoyMatch, match.QueryParams)
 			}
 			routeHeadersMatch(envoyMatch, match.Headers)
-			if match.Path != nil && match.Path.Type == api.Prefix {
+			if match.Path != nil && match.Path.Type == api.PathPrefix {
 				allEnvoyMatches = append(allEnvoyMatches, routeMatch{envoyMatch, true})
 			} else {
 				allEnvoyMatches = append(allEnvoyMatches, routeMatch{envoyMatch, false})
@@ -113,7 +113,7 @@ func (c RoutesConfigurer) routePathMatch(match api.PathMatch) []*envoy_route.Rou
 				Path: match.Value,
 			},
 		}}
-	case api.Prefix:
+	case api.PathPrefix:
 		if match.Value == "/" {
 			return []*envoy_route.RouteMatch{{
 				PathSpecifier: &envoy_route.RouteMatch_Prefix{

--- a/pkg/xds/generator/ingress_generator_test.go
+++ b/pkg/xds/generator/ingress_generator_test.go
@@ -673,7 +673,7 @@ var _ = Describe("IngressGenerator", func() {
 							Rules: []v1alpha1.Rule{{
 								Matches: []v1alpha1.Match{{
 									Path: &v1alpha1.PathMatch{
-										Type:  v1alpha1.Prefix,
+										Type:  v1alpha1.PathPrefix,
 										Value: "/v1",
 									},
 								}},

--- a/test/e2e_env/kubernetes/meshhttproute/test.go
+++ b/test/e2e_env/kubernetes/meshhttproute/test.go
@@ -124,7 +124,7 @@ spec:
       rules: 
         - matches:
             - path: 
-                type: Prefix
+                type: PathPrefix
                 value: /
           default:
             backendRefs:
@@ -172,7 +172,7 @@ spec:
       rules: 
         - matches:
             - path: 
-                type: Prefix
+                type: PathPrefix
                 value: /
           default:
             filters:
@@ -218,7 +218,7 @@ spec:
       rules: 
         - matches:
             - path: 
-                type: Prefix
+                type: PathPrefix
                 value: /prefix
           default:
             filters:

--- a/test/e2e_env/multizone/meshhttproute/test.go
+++ b/test/e2e_env/multizone/meshhttproute/test.go
@@ -77,7 +77,7 @@ spec:
         - matches:
           - path:
               value: /
-              type: Prefix
+              type: PathPrefix
           default:
             backendRefs:
               - kind: MeshServiceSubset

--- a/test/e2e_env/universal/meshhealthcheck/policy.go
+++ b/test/e2e_env/universal/meshhealthcheck/policy.go
@@ -399,7 +399,7 @@ spec:
         - matches: 
             - path: 
                 value: /
-                type: Prefix
+                type: PathPrefix
           default: 
             backendRefs: 
               - kind: MeshServiceSubset


### PR DESCRIPTION
Name should match upstream Gateway API

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [x] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
