### PR TITLE
feat(mtls): generate certificates for Address and AdvertisedAddress for Dataplane and Ingress

### DIFF
--- a/pkg/envoy/admin/tls/pki.go
+++ b/pkg/envoy/admin/tls/pki.go
@@ -73,10 +73,14 @@ func GenerateClientCert(ca tls.Certificate) (util_tls.KeyPair, error) {
 	return util_tls.NewCert(*rootCert, ca.PrivateKey.(*rsa.PrivateKey), ClientCertSAN, util_tls.ClientCertType, util_tls.DefaultKeyType, ClientCertSAN)
 }
 
-func GenerateServerCert(ca tls.Certificate, ip string) (util_tls.KeyPair, error) {
+func GenerateServerCert(ca tls.Certificate, hosts ...string) (util_tls.KeyPair, error) {
 	rootCert, err := x509.ParseCertificate(ca.Certificate[0])
 	if err != nil {
 		return util_tls.KeyPair{}, err
 	}
-	return util_tls.NewCert(*rootCert, ca.PrivateKey.(*rsa.PrivateKey), ip, util_tls.ServerCertType, util_tls.DefaultKeyType, ip)
+	var commonName string
+	if len(hosts) > 0 {
+		commonName = hosts[0]
+	}
+	return util_tls.NewCert(*rootCert, ca.PrivateKey.(*rsa.PrivateKey), commonName, util_tls.ServerCertType, util_tls.DefaultKeyType, hosts...)
 }


### PR DESCRIPTION
As Egress doesn't have advertisedAddress.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [ ] [Link to relevant issue](https://github.com/kumahq/kuma/issues/6498) as well as docs and UI issues --
- [ ] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [ ] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [ ] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [ ] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [ ] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?


Signed-off-by: Matthieu MOREL <matthieu.morel35@gmail.com>