### PR TITLE
fix(docker/kumactl): add entrypoint to kumactl img

### DIFF
--- a/tools/releases/dockerfiles/kumactl.Dockerfile
+++ b/tools/releases/dockerfiles/kumactl.Dockerfile
@@ -5,3 +5,5 @@ ARG ARCH
 # override NOTICE
 COPY /tools/releases/templates/NOTICE-kumactl /kuma/NOTICE
 COPY /build/artifacts-linux-$ARCH/kumactl/kumactl /usr/bin/
+
+ENTRYPOINT ["/busybox/busybox", "sh", "-c"]


### PR DESCRIPTION
Without specifying entrypoint inside the Dockerfile, it was impossible to use the image without having to do it explicitly during the container start

It was impossible to do:
```sh
docker run kumahq/kumactl:2.2.0 kumactl version
# /busybox/sh: can't open 'kumactl': No such file or directory
```
and you had to explicitly specify entrypoint
```sh
docker run --entrypoint /usr/bin/kumactl kumahq/kumactl:2.2.0 version
# Client: Kuma 2.2.0
# Unable to connect to control plane: Get "http://localhost:5681/": dial tcp 127.0.0.1:5681: connect: connection refused
```
before:
```sh
docker run kumahq/kumactl:2.0.0 kumactl version
# Client: Kuma 2.0.0
# Unable to connect to control plane: Get "http://localhost:5681/": dial tcp 127.0.0.1:5681: connect: connection refused
```

Closes: https://github.com/kumahq/kuma/issues/6566

### Checklist prior to review

- [x] [Link to relevant issue][1] as well as docs and UI issues -- https://github.com/kumahq/kuma/issues/6566
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS -- it won't
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) -- no tests yet, but [this PR](https://github.com/kumahq/kuma/pull/6581) should solve this
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? -- you don't
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? -- I believe it should, as the changed behavior was introduced in 2.1.0
- [x] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
