### PR TITLE
test(e2e): fix app name collision flake

### DIFF
--- a/test/e2e_env/multizone/externalservices/externalservices_multizone_universal.go
+++ b/test/e2e_env/multizone/externalservices/externalservices_multizone_universal.go
@@ -83,10 +83,10 @@ routing:
 		external = NewUniversalCluster(NewTestingT(), clusterName4, Silent)
 
 		err := NewClusterSetup().
-			Install(TestServerExternalServiceUniversal("es-http", "", 80, false, WithDockerContainerName("kuma-es-4_es-http"))).
-			Install(TestServerExternalServiceUniversal("es-https", "", 443, true, WithDockerContainerName("kuma-es-4_es-https"))).
-			Install(TestServerExternalServiceUniversal("es-for-kuma-es-2", "", 80, false, WithDockerContainerName("kuma-es-4_es-for-kuma-es-2"))).
-			Install(TestServerExternalServiceUniversal("es-for-kuma-es-3", "", 80, false, WithDockerContainerName("kuma-es-4_es-for-kuma-es-3"))).
+			Install(TestServerExternalServiceUniversal("es-http", 80, false, WithDockerContainerName("kuma-es-4_es-http"))).
+			Install(TestServerExternalServiceUniversal("es-https", 443, true, WithDockerContainerName("kuma-es-4_es-https"))).
+			Install(TestServerExternalServiceUniversal("es-for-kuma-es-2", 80, false, WithDockerContainerName("kuma-es-4_es-for-kuma-es-2"))).
+			Install(TestServerExternalServiceUniversal("es-for-kuma-es-3", 80, false, WithDockerContainerName("kuma-es-4_es-for-kuma-es-3"))).
 			Setup(external)
 		Expect(err).ToNot(HaveOccurred())
 		externalUni = external.(*UniversalCluster)

--- a/test/e2e_env/universal/externalservices/externalservices.go
+++ b/test/e2e_env/universal/externalservices/externalservices.go
@@ -87,9 +87,9 @@ networking:
 
 		err := NewClusterSetup().
 			Install(YamlUniversal(meshDefaulMtlsOn)).
-			Install(TestServerExternalServiceUniversal(esHttpName, meshName, 80, false, WithDockerContainerName(esHttpContainerName))).
-			Install(TestServerExternalServiceUniversal(esHttpsName, meshName, 443, true, WithDockerContainerName(esHttpsContainerName))).
-			Install(TestServerExternalServiceUniversal(esHttp2Name, meshName, 81, false, WithDockerContainerName(esHttp2ContainerName))).
+			Install(TestServerExternalServiceUniversal(esHttpName, 80, false, WithDockerContainerName(esHttpContainerName))).
+			Install(TestServerExternalServiceUniversal(esHttpsName, 443, true, WithDockerContainerName(esHttpsContainerName))).
+			Install(TestServerExternalServiceUniversal(esHttp2Name, 81, false, WithDockerContainerName(esHttp2ContainerName))).
 			Install(DemoClientUniversal("demo-client", meshName, WithTransparentProxy(true))).
 			Setup(universal.Cluster)
 		Expect(err).ToNot(HaveOccurred())

--- a/test/e2e_env/universal/externalservices/zoneegress_externalservices.go
+++ b/test/e2e_env/universal/externalservices/zoneegress_externalservices.go
@@ -53,7 +53,7 @@ networking:
 
 		err = NewClusterSetup().
 			Install(YamlUniversal(meshDefaulMtlsOn)).
-			Install(TestServerExternalServiceUniversal("http-server", "", 80, false, WithDockerContainerName("kuma-es-ze_externalservice-http-server"))).
+			Install(TestServerExternalServiceUniversal("http-server", 80, false, WithDockerContainerName("kuma-es-ze_externalservice-http-server"))).
 			Install(DemoClientUniversal(AppModeDemoClient, "default", WithTransparentProxy(true))).
 			Install(EgressUniversal(func(zone string) (string, error) {
 				return cluster.GetKuma().GenerateZoneEgressToken("")

--- a/test/e2e_env/universal/ratelimit/ratelimit.go
+++ b/test/e2e_env/universal/ratelimit/ratelimit.go
@@ -39,7 +39,7 @@ conf:
 			Install(TestServerUniversal("test-server", meshName, WithArgs([]string{"echo", "--instance", "universal-1"}))).
 			Install(DemoClientUniversal("demo-client", meshName, WithTransparentProxy(true))).
 			Install(DemoClientUniversal("web", meshName, WithTransparentProxy(true))).
-			Install(TestServerExternalServiceUniversal("rate-limit", meshName, 80, false)).
+			Install(TestServerExternalServiceUniversal("rate-limit", 80, false)).
 			Setup(universal.Cluster)).To(Succeed())
 	})
 	E2EAfterAll(func() {

--- a/test/e2e_env/universal/trafficroute/traffic_route.go
+++ b/test/e2e_env/universal/trafficroute/traffic_route.go
@@ -42,7 +42,7 @@ func TrafficRoute() {
 				WithArgs([]string{"echo", "--instance", "another-test-server"}),
 				WithServiceName("another-test-server"),
 			)).
-			Install(TestServerExternalServiceUniversal("es-http", meshName, 80, false)).
+			Install(TestServerExternalServiceUniversal("es-http", 80, false)).
 			Install(DemoClientUniversal(AppModeDemoClient, meshName, WithTransparentProxy(true))).
 			Setup(universal.Cluster)).To(Succeed())
 

--- a/test/e2e_env/universal/trafficroute/traffic_route.go
+++ b/test/e2e_env/universal/trafficroute/traffic_route.go
@@ -42,11 +42,11 @@ func TrafficRoute() {
 				WithArgs([]string{"echo", "--instance", "another-test-server"}),
 				WithServiceName("another-test-server"),
 			)).
-			Install(TestServerExternalServiceUniversal("es-http", 80, false)).
+			Install(TestServerExternalServiceUniversal("route-es-http", 80, false)).
 			Install(DemoClientUniversal(AppModeDemoClient, meshName, WithTransparentProxy(true))).
 			Setup(universal.Cluster)).To(Succeed())
 
-		esHttpHostPort = net.JoinHostPort(universal.Cluster.GetApp("es-http").GetContainerName(), "80")
+		esHttpHostPort = net.JoinHostPort(universal.Cluster.GetApp("route-es-http").GetContainerName(), "80")
 	})
 
 	E2EAfterAll(func() {
@@ -201,16 +201,16 @@ conf:
         version: v1
     - weight: 50
       destination:
-        kuma.io/service: es-http
+        kuma.io/service: route-es-http
 `))).To(Succeed())
 		Expect(universal.Cluster.Install(YamlUniversal(fmt.Sprintf(`
 type: ExternalService
-name: es-http-1
+name: route-es-http-1
 mesh: trafficroute
 networking:
   address: %s
 tags:
-  kuma.io/service: es-http
+  kuma.io/service: route-es-http
   kuma.io/protocol: http
 `, esHttpHostPort)))).To(Succeed())
 
@@ -220,7 +220,7 @@ tags:
 			And(
 				HaveLen(2),
 				HaveKey(Equal(`echo-v1`)),
-				HaveKey(Equal(`es-http`)),
+				HaveKey(Equal(`route-es-http`)),
 			),
 		)
 	})
@@ -682,18 +682,18 @@ conf:
         version: v1
     - weight: 50
       destination:
-        kuma.io/service: es-http
+        kuma.io/service: route-es-http
   destination:
     kuma.io/service: test-server
 `)(universal.Cluster)).To(Succeed())
 			Expect(universal.Cluster.Install(YamlUniversal(fmt.Sprintf(`
 type: ExternalService
-name: es-http-1
+name: route-es-http-1
 mesh: trafficroute
 networking:
   address: %s
 tags:
-  kuma.io/service: es-http
+  kuma.io/service: route-es-http
   kuma.io/protocol: http
 `, esHttpHostPort)))).To(Succeed())
 
@@ -703,7 +703,7 @@ tags:
 				And(
 					HaveLen(2),
 					HaveKey(Equal(`echo-v1`)),
-					HaveKey(Equal(`es-http`)),
+					HaveKey(Equal(`route-es-http`)),
 				),
 			)
 		})

--- a/test/framework/setup.go
+++ b/test/framework/setup.go
@@ -428,7 +428,7 @@ func TcpSinkUniversal(name string, opt ...AppDeploymentOption) InstallFunc {
 	}
 }
 
-func TestServerExternalServiceUniversal(name string, mesh string, port int, tls bool, opt ...AppDeploymentOption) InstallFunc {
+func TestServerExternalServiceUniversal(name string, port int, tls bool, opt ...AppDeploymentOption) InstallFunc {
 	return func(cluster Cluster) error {
 		var opts appDeploymentOptions
 		opts.apply(opt...)


### PR DESCRIPTION
See https://app.circleci.com/pipelines/github/kumahq/kuma/21477/workflows/8c964ced-ff4a-440e-a22b-684acc13df40/jobs/388320

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [x] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
