### PR TITLE
chore(xds): don't overwrite auth handlers in runtime context

### DIFF
--- a/pkg/core/bootstrap/bootstrap.go
+++ b/pkg/core/bootstrap/bootstrap.go
@@ -148,7 +148,7 @@ func buildRuntime(appCtx context.Context, cfg kuma_cp.Config) (core_runtime.Runt
 		))
 	}
 
-	xdsCtx, err := xds_runtime.Default(builder) //nolint:contextcheck
+	xdsCtx, err := xds_runtime.WithDefaults(builder) //nolint:contextcheck
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/test/runtime/runtime.go
+++ b/pkg/test/runtime/runtime.go
@@ -106,7 +106,7 @@ func BuilderFor(appCtx context.Context, cfg kuma_cp.Config) (*core_runtime.Build
 	builder.WithEnvoyAdminClient(&DummyEnvoyAdminClient{})
 	builder.WithEventReaderFactory(events.NewEventBus())
 	builder.WithAPIManager(customization.NewAPIList())
-	xdsCtx, err := xds_runtime.Default(builder) //nolint:contextcheck
+	xdsCtx, err := xds_runtime.WithDefaults(builder) //nolint:contextcheck
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/xds/runtime/context.go
+++ b/pkg/xds/runtime/context.go
@@ -14,22 +14,35 @@ type XDSRuntimeContext struct {
 	ServerCallbacks        util_xds.Callbacks
 }
 
-func Default(ctx components.Context) (XDSRuntimeContext, error) {
-	dpProxyAuth, err := components.DefaultAuthenticator(ctx, ctx.Config().DpServer.Authn.DpProxy.Type)
-	if err != nil {
-		return XDSRuntimeContext{}, err
+type ContextWithXDS interface {
+	components.Context
+	XDS() XDSRuntimeContext
+}
+
+func WithDefaults(ctx ContextWithXDS) (XDSRuntimeContext, error) {
+	currentXDS := ctx.XDS()
+
+	if currentXDS.DpProxyAuthenticator == nil {
+		dpProxyAuth, err := components.DefaultAuthenticator(ctx, ctx.Config().DpServer.Authn.DpProxy.Type)
+		if err != nil {
+			return XDSRuntimeContext{}, err
+		}
+		currentXDS.DpProxyAuthenticator = dpProxyAuth
 	}
 
-	zoneProxyAuth, err := components.DefaultAuthenticator(ctx, ctx.Config().DpServer.Authn.ZoneProxy.Type)
-	if err != nil {
-		return XDSRuntimeContext{}, err
+	if currentXDS.ZoneProxyAuthenticator == nil {
+		zoneProxyAuth, err := components.DefaultAuthenticator(ctx, ctx.Config().DpServer.Authn.ZoneProxy.Type)
+		if err != nil {
+			return XDSRuntimeContext{}, err
+		}
+		currentXDS.ZoneProxyAuthenticator = zoneProxyAuth
 	}
 
-	return XDSRuntimeContext{
-		Hooks:                  &xds_hooks.Hooks{},
-		DpProxyAuthenticator:   dpProxyAuth,
-		ZoneProxyAuthenticator: zoneProxyAuth,
-	}, nil
+	if currentXDS.Hooks == nil {
+		currentXDS.Hooks = &xds_hooks.Hooks{}
+	}
+
+	return currentXDS, nil
 }
 
 func (x XDSRuntimeContext) PerProxyTypeAuthenticator() xds_auth.Authenticator {


### PR DESCRIPTION
This behavior was unintentionally changed in [#5991](https://github.com/kumahq/kuma/pull/5991/files#diff-b3cc8955e22d15be8a676a46643ccffc5283d26f2c0ef2fb21a73894d4933912L149-R151
)

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [x] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
