### PR TITLE
build: make it possible to tag non docker.io images

### DIFF
--- a/mk/docker.mk
+++ b/mk/docker.mk
@@ -1,13 +1,12 @@
 BUILD_DOCKER_IMAGES_DIR ?= $(BUILD_DIR)/docker-images-${GOARCH}
 KUMA_VERSION ?= master
 
-DOCKER_REPO ?= docker.io
-DOCKER_REGISTRY ?= kumahq
+DOCKER_REGISTRY ?= docker.io/kumahq
 DOCKER_USERNAME ?=
 DOCKER_API_KEY ?=
 
 define build_image
-$(addsuffix :$(BUILD_INFO_VERSION)$(if $(2),-$(2)),$(addprefix $(DOCKER_REPO)/$(DOCKER_REGISTRY)/,$(1)))
+$(addsuffix :$(BUILD_INFO_VERSION)$(if $(2),-$(2)),$(addprefix $(DOCKER_REGISTRY)/,$(1)))
 endef
 
 IMAGES_RELEASE += kuma-cp kuma-dp kumactl kuma-init kuma-cni
@@ -128,8 +127,8 @@ docker/purge: ## Dev: Remove all Docker containers, images, networks and volumes
 
 .PHONY: docker/login
 docker/login:
-	$(call GATE_PUSH,docker login -u $(DOCKER_USERNAME) -p $(DOCKER_API_KEY) $(DOCKER_REPO))
+	$(call GATE_PUSH,docker login -u $(DOCKER_USERNAME) -p $(DOCKER_API_KEY) $(DOCKER_REGISTRY))
 
 .PHONY: docker/logout
 docker/logout:
-	$(call GATE_PUSH,docker logout $(DOCKER_REPO))
+	$(call GATE_PUSH,docker logout $(DOCKER_REGISTRY))


### PR DESCRIPTION
There's no reason to separate these two path components. `docker login` works with a URL.

As is, there's no way to target a repo that consists of only `<hostname>/<imagename>`

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [x] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
