### PR TITLE
feat(helm): set readOnlyRootFilesystem on CNI, more explicit templates

### DIFF
--- a/app/kumactl/cmd/install/testdata/install-control-plane.cni-enabled.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.cni-enabled.golden.yaml
@@ -432,9 +432,7 @@ metadata:
   name: kuma-cni-node
   namespace: kube-system
   annotations:
-    ignore-check.kube-linter.io/host-network: "The containers modify the host's network namespace"
-    ignore-check.kube-linter.io/no-read-only-root-fs: "The containers modify the filesystem"
-    ignore-check.kube-linter.io/run-as-non-root: "The containers modify /proc"
+    ignore-check.kube-linter.io/run-as-non-root: "The container installs a CNI plugin"
   labels:
     app: kuma-cni
     app.kubernetes.io/name: kuma
@@ -479,6 +477,8 @@ spec:
       # Minimize downtime during a rolling upgrade or deletion; tell Kubernetes to do a "force
       # deletion": https://kubernetes.io/docs/concepts/workloads/pods/pod/#termination-of-pods.
       terminationGracePeriodSeconds: 5
+      securityContext:
+        {}
       containers:
         - name: install-cni
           image: "docker.io/kumahq/kuma-cni:0.0.1"
@@ -491,6 +491,11 @@ spec:
                 - /tmp/ready
           command: [ "sh", "-c", "--" ]
           args: [ "sleep 0 && exec /install-cni" ]
+          securityContext:
+            readOnlyRootFilesystem: true
+            runAsGroup: 0
+            runAsNonRoot: false
+            runAsUser: 0
           env:
             # Name of the CNI config file to create.
             - name: CNI_CONF_NAME
@@ -519,6 +524,8 @@ spec:
               name: cni-bin-dir
             - mountPath: /host/etc/cni/net.d
               name: cni-net-dir
+            - name: tmp
+              mountPath: /tmp
       volumes:
         # Used to install CNI.
         - name: cni-bin-dir
@@ -527,6 +534,8 @@ spec:
         - name: cni-net-dir
           hostPath:
             path: /etc/cni/multus/net.d
+        - name: tmp
+          emptyDir: {}
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/app/kumactl/cmd/install/testdata/install-control-plane.cni-legacy-enabled.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.cni-legacy-enabled.golden.yaml
@@ -420,9 +420,7 @@ metadata:
   name: kuma-cni-node
   namespace: kube-system
   annotations:
-    ignore-check.kube-linter.io/host-network: "The containers modify the host's network namespace"
-    ignore-check.kube-linter.io/no-read-only-root-fs: "The containers modify the filesystem"
-    ignore-check.kube-linter.io/run-as-non-root: "The containers modify /proc"
+    ignore-check.kube-linter.io/run-as-non-root: "The container installs a CNI plugin"
   labels:
     app: kuma-cni
     app.kubernetes.io/name: kuma
@@ -467,12 +465,19 @@ spec:
       # Minimize downtime during a rolling upgrade or deletion; tell Kubernetes to do a "force
       # deletion": https://kubernetes.io/docs/concepts/workloads/pods/pod/#termination-of-pods.
       terminationGracePeriodSeconds: 5
+      securityContext:
+        {}
       containers:
         - name: install-cni
           image: "docker.io/kumahq/install-cni:0.0.10"
           imagePullPolicy: IfNotPresent
           command: [ "/bin/sh", "-c", "--" ]
           args: [ "sleep 0 && exec /install-cni.sh" ]
+          securityContext:
+            readOnlyRootFilesystem: true
+            runAsGroup: 0
+            runAsNonRoot: false
+            runAsUser: 0
           env:
             # Name of the CNI config file to create.
             - name: CNI_CONF_NAME
@@ -501,6 +506,8 @@ spec:
               name: cni-bin-dir
             - mountPath: /host/etc/cni/net.d
               name: cni-net-dir
+            - name: tmp
+              mountPath: /tmp
       volumes:
         # Used to install CNI.
         - name: cni-bin-dir
@@ -509,6 +516,8 @@ spec:
         - name: cni-net-dir
           hostPath:
             path: /etc/cni/multus/net.d
+        - name: tmp
+          emptyDir: {}
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/app/kumactl/cmd/install/testdata/install-control-plane.dump-values.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.dump-values.yaml
@@ -334,27 +334,13 @@ cni:
 
   # -- Security context at the pod level for cni
   podSecurityContext: {}
-#    # The values below are examples. More values can be added as needed, since the field resolves as free form.
-#    runAsNonRoot: true
-#    runAsUser: 1000
-#    runAsGroup: 3000
-#    fsGroup: 2000
-#    fsGroupChangePolicy:
-#    # to support additional pod level securityContext parameters, please check:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#podsecuritycontext-v1-core
 
   # -- Security context at the container level for cni
-  containerSecurityContext: {} # for overlapping securityContext between pod and container, the container's value take precedence
-#    # The values below are examples. More values can be added as needed, since the field resolves as free form.
-#    allowPrivilegeEscalation: false
-#    capabilities:
-#      drop:
-#        - all
-#    readOnlyRootFilesystem: true
-#    privileged: false
-#    runAsNonRoot: true
-#    runAsUser: 1000
-#    runAsGroup: 3000
-#    # to support additional container level securityContext parameters, please check:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#securitycontext-v1-core
+  containerSecurityContext:
+    readOnlyRootFilesystem: true
+    runAsNonRoot: false
+    runAsUser: 0
+    runAsGroup: 0
 
 dataPlane:
   image:

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/fix4935.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/fix4935.golden.yaml
@@ -500,9 +500,7 @@ metadata:
   name: kuma-cni-node
   namespace: kube-system
   annotations:
-    ignore-check.kube-linter.io/host-network: "The containers modify the host's network namespace"
-    ignore-check.kube-linter.io/no-read-only-root-fs: "The containers modify the filesystem"
-    ignore-check.kube-linter.io/run-as-non-root: "The containers modify /proc"
+    ignore-check.kube-linter.io/run-as-non-root: "The container installs a CNI plugin"
   labels:
     app: kuma-cni
     app.kubernetes.io/name: kuma
@@ -549,6 +547,8 @@ spec:
       # Minimize downtime during a rolling upgrade or deletion; tell Kubernetes to do a "force
       # deletion": https://kubernetes.io/docs/concepts/workloads/pods/pod/#termination-of-pods.
       terminationGracePeriodSeconds: 5
+      securityContext:
+        {}
       containers:
         - name: install-cni
           image: "docker.io/kumahq/kuma-cni:0.0.1"
@@ -561,6 +561,11 @@ spec:
                 - /tmp/ready
           command: [ "sh", "-c", "--" ]
           args: [ "sleep 0 && exec /install-cni" ]
+          securityContext:
+            readOnlyRootFilesystem: true
+            runAsGroup: 0
+            runAsNonRoot: false
+            runAsUser: 0
           env:
             # Name of the CNI config file to create.
             - name: CNI_CONF_NAME
@@ -589,6 +594,8 @@ spec:
               name: cni-bin-dir
             - mountPath: /host/etc/cni/net.d
               name: cni-net-dir
+            - name: tmp
+              mountPath: /tmp
       volumes:
         # Used to install CNI.
         - name: cni-bin-dir
@@ -597,6 +604,8 @@ spec:
         - name: cni-net-dir
           hostPath:
             path: /etc/cni/multus/net.d
+        - name: tmp
+          emptyDir: {}
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/deployments/charts/kuma/README.md
+++ b/deployments/charts/kuma/README.md
@@ -102,7 +102,7 @@ A Helm chart for the Kuma Control Plane
 | cni.resources.requests.memory | string | `"100Mi"` |  |
 | cni.resources.limits.memory | string | `"100Mi"` |  |
 | cni.podSecurityContext | object | `{}` | Security context at the pod level for cni |
-| cni.containerSecurityContext | object | `{}` | Security context at the container level for cni |
+| cni.containerSecurityContext | object | `{"readOnlyRootFilesystem":true,"runAsGroup":0,"runAsNonRoot":false,"runAsUser":0}` | Security context at the container level for cni |
 | dataPlane.image.repository | string | `"kuma-dp"` | The Kuma DP image repository |
 | dataPlane.image.pullPolicy | string | `"IfNotPresent"` | Kuma DP ImagePullPolicy |
 | dataPlane.image.tag | string | `nil` | Kuma DP Image Tag. When not specified, the value is copied from global.tag |

--- a/deployments/charts/kuma/templates/cni-daemonset.yaml
+++ b/deployments/charts/kuma/templates/cni-daemonset.yaml
@@ -53,10 +53,8 @@ spec:
       # Minimize downtime during a rolling upgrade or deletion; tell Kubernetes to do a "force
       # deletion": https://kubernetes.io/docs/concepts/workloads/pods/pod/#termination-of-pods.
       terminationGracePeriodSeconds: 5
-      {{- if .Values.cni.podSecurityContext }}
       securityContext:
-      {{ toYaml .Values.cni.podSecurityContext | trim | nindent 8 }}
-      {{- end }}
+      {{- toYaml .Values.cni.podSecurityContext | trim | nindent 8 }}
       containers:
         - name: install-cni
           {{- if not .Values.legacy.cni.enabled }}
@@ -96,14 +94,10 @@ spec:
           command: [ "/bin/sh", "-c", "--" ]
           args: [ "sleep {{.Values.cni.delayStartupSeconds}} && exec /install-cni.sh" ]
           {{- end }}
-          {{- if .Values.experimental.ebpf.enabled }}
-          securityContext:
-            privileged: true
-          {{- else }}
-          {{- if .Values.cni.containerSecurityContext }}
           securityContext:
           {{- toYaml .Values.cni.containerSecurityContext | trim | nindent 12 }}
-          {{- end }}
+          {{- if .Values.experimental.ebpf.enabled }}
+            privileged: true
           {{- end }}
           {{- if not .Values.experimental.ebpf.enabled }}
           env:
@@ -140,6 +134,8 @@ spec:
               name: host-var-run
               mountPropagation: Bidirectional
             {{- end }}
+            - name: tmp
+              mountPath: /tmp
       volumes:
         # Used to install CNI.
         - name: cni-bin-dir
@@ -159,4 +155,6 @@ spec:
             path: /proc
           name: host-proc
         {{- end }}
+        - name: tmp
+          emptyDir: {}
 {{- end }}

--- a/deployments/charts/kuma/templates/cni-daemonset.yaml
+++ b/deployments/charts/kuma/templates/cni-daemonset.yaml
@@ -5,9 +5,7 @@ metadata:
   name: {{ include "kuma.name" . }}-cni-node
   namespace: kube-system
   annotations:
-    ignore-check.kube-linter.io/host-network: "The containers modify the host's network namespace"
-    ignore-check.kube-linter.io/no-read-only-root-fs: "The containers modify the filesystem"
-    ignore-check.kube-linter.io/run-as-non-root: "The containers modify /proc"
+    ignore-check.kube-linter.io/run-as-non-root: "The container installs a CNI plugin"
   labels: {{- include "kuma.cniLabels" . | nindent 4 }}
 spec:
   selector:

--- a/deployments/charts/kuma/values.yaml
+++ b/deployments/charts/kuma/values.yaml
@@ -334,27 +334,13 @@ cni:
 
   # -- Security context at the pod level for cni
   podSecurityContext: {}
-#    # The values below are examples. More values can be added as needed, since the field resolves as free form.
-#    runAsNonRoot: true
-#    runAsUser: 1000
-#    runAsGroup: 3000
-#    fsGroup: 2000
-#    fsGroupChangePolicy:
-#    # to support additional pod level securityContext parameters, please check:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#podsecuritycontext-v1-core
 
   # -- Security context at the container level for cni
-  containerSecurityContext: {} # for overlapping securityContext between pod and container, the container's value take precedence
-#    # The values below are examples. More values can be added as needed, since the field resolves as free form.
-#    allowPrivilegeEscalation: false
-#    capabilities:
-#      drop:
-#        - all
-#    readOnlyRootFilesystem: true
-#    privileged: false
-#    runAsNonRoot: true
-#    runAsUser: 1000
-#    runAsGroup: 3000
-#    # to support additional container level securityContext parameters, please check:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#securitycontext-v1-core
+  containerSecurityContext:
+    readOnlyRootFilesystem: true
+    runAsNonRoot: false
+    runAsUser: 0
+    runAsGroup: 0
 
 dataPlane:
   image:


### PR DESCRIPTION
Also make the `runAsNonRoot: false` more visible.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [x] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
