### PR TITLE
ci(dockerfiles): make entrypoints absolute

### DIFF
--- a/tools/releases/dockerfiles/kuma-cni.Dockerfile
+++ b/tools/releases/dockerfiles/kuma-cni.Dockerfile
@@ -1,10 +1,12 @@
 ARG ARCH
 FROM kumahq/base-root-debian11:no-push-$ARCH
-
 ARG ARCH
+
 COPY /build/artifacts-linux-$ARCH/kuma-cni/kuma-cni /opt/cni/bin/kuma-cni
 COPY /build/artifacts-linux-$ARCH/install-cni/install-cni /install-cni
 
 ENV PATH=$PATH:/opt/cni/bin
+
 WORKDIR /opt/cni/bin
-ENTRYPOINT [ "/install-cni" ]
+
+ENTRYPOINT ["/install-cni"]

--- a/tools/releases/dockerfiles/kuma-cp.Dockerfile
+++ b/tools/releases/dockerfiles/kuma-cp.Dockerfile
@@ -4,4 +4,4 @@ ARG ARCH
 
 COPY /build/artifacts-linux-${ARCH}/kuma-cp/kuma-cp /usr/bin
 
-ENTRYPOINT ["kuma-cp"]
+ENTRYPOINT ["/usr/bin/kuma-cp"]

--- a/tools/releases/dockerfiles/kuma-dp.Dockerfile
+++ b/tools/releases/dockerfiles/kuma-dp.Dockerfile
@@ -9,4 +9,4 @@ COPY /build/artifacts-linux-$ARCH/kuma-dp/kuma-dp \
 
 COPY --from=envoy /envoy /usr/bin/envoy
 
-ENTRYPOINT ["kuma-dp"]
+ENTRYPOINT ["/usr/bin/kuma-dp"]


### PR DESCRIPTION
To be consistent now all docker images have entrypoints in the form of absolute path.

I also adjusted the style of the kuma-cni dockerimage to be consistent with others in regards of new lines between instructions and spacing around item in entrypoint.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [ ] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) -- Tests will appear with: https://github.com/kumahq/kuma/pull/6581
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? -- you don't
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? -- It doesn't
- [x] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

> Changelog: ci(dockerfiles): make entrypoins absolute path + adjust style in regards of empty lines and spacing around value of entrypoint in kuma-init dockerfile

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
