### PR TITLE
ci(docker/tests): update container structure tests

### DIFF
--- a/tools/container-structure-test/kuma-init.yaml
+++ b/tools/container-structure-test/kuma-init.yaml
@@ -10,10 +10,10 @@ commandTests:
 - name: "Contains kumactl"
   command: kumactl
   args: ["version"]
-- name: "Contains iptables (legacy)"
+- name: "Contains iptables"
   command: iptables
   args: ["--version"]
-  expectedOutput: ["iptables v.*(legacy)"]
+  expectedOutput: ["iptables v.*"]
 
 metadataTest:
   entrypoint: ["/usr/bin/kumactl"]

--- a/tools/container-structure-test/kumactl.yaml
+++ b/tools/container-structure-test/kumactl.yaml
@@ -6,4 +6,4 @@ commandTests:
   args: ["version"]
 
 metadataTest:
-  entrypoint: ["/busybox/busybox", "sh", "-c"]
+  entrypoint: ["/usr/bin/kumactl"]


### PR DESCRIPTION
The entrypoint for kumactl image changed. I also adjusted iptables check in kuma-init container structure test and removed check if iptables is "legacy" or not as it's irrelevant.

xref: https://github.com/kumahq/kuma/pull/6596

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [ ] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) -- this PR contains test changes
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? -- we don't
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? -- it doesn't
- [ ] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
