### PR TITLE
ci(test/docker): don't check for legacy iptables

### DIFF
--- a/tools/container-structure-test/kuma-init.yaml
+++ b/tools/container-structure-test/kuma-init.yaml
@@ -10,10 +10,10 @@ commandTests:
 - name: "Contains kumactl"
   command: kumactl
   args: ["version"]
-- name: "Contains iptables (legacy)"
+- name: "Contains iptables"
   command: iptables
   args: ["--version"]
-  expectedOutput: ["iptables v.*(legacy)"]
+  expectedOutput: ["iptables v.*"]
 
 metadataTest:
   entrypoint: ["/usr/bin/kumactl"]


### PR DESCRIPTION
Don's check if iptables are legacy, as this check is irrelevant and makes reusability if container structure tests harder.

xref. https://github.com/kumahq/kuma/pull/6621

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [ ] [Link to relevant issue][1] as well as docs and UI issues --
- [ ] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [ ] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [ ] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [ ] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [ ] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
