### PR TITLE
test(e2e): remove FlakeAttempts

### DIFF
--- a/test/e2e_env/universal/matching/matching.go
+++ b/test/e2e_env/universal/matching/matching.go
@@ -32,8 +32,7 @@ func Matching() {
 		Expect(universal.Cluster.DeleteMesh(mesh)).To(Succeed())
 	})
 
-	// Added Flake because: https://github.com/kumahq/kuma/issues/4700
-	It("should both fault injections with the same destination proxy", FlakeAttempts(3), func() {
+	It("should both fault injections with the same destination proxy", func() {
 		Expect(YamlUniversal(fmt.Sprintf(`
 type: FaultInjection
 mesh: %s

--- a/test/e2e_env/universal/mtls/mtls.go
+++ b/test/e2e_env/universal/mtls/mtls.go
@@ -44,8 +44,7 @@ func Policy() {
 		Consistently(expectation).WithOffset(1).WithPolling(time.Millisecond * 250).WithTimeout(time.Second * 2).Should(Succeed())
 	}
 
-	// Added Flake because: https://github.com/kumahq/kuma/issues/4700
-	Describe("should support mode", FlakeAttempts(3), func() {
+	Describe("should support mode", func() {
 		publicAddress := func() string {
 			return net.JoinHostPort(universal.Cluster.GetApp("test-server").GetIP(), "80")
 		}
@@ -146,8 +145,7 @@ mtls:
 			g.Expect(stdout).To(ContainSubstring("HTTP/1.1 200 OK"))
 		}).Should(Succeed())
 	})
-	// Added Flake because: https://github.com/kumahq/kuma/issues/4700
-	DescribeTable("should enforce traffic permissions", FlakeAttempts(3),
+	DescribeTable("should enforce traffic permissions",
 		func(yaml string) {
 			err := NewClusterSetup().
 				Install(MeshUniversal(meshName)).

--- a/test/e2e_env/universal/ratelimit/ratelimit.go
+++ b/test/e2e_env/universal/ratelimit/ratelimit.go
@@ -83,8 +83,7 @@ conf:
 		Eventually(requestRateLimited("web", "test-server", 429), "10s", "100ms").Should(Succeed())
 	})
 
-	// Added Flake because: https://github.com/kumahq/kuma/issues/4700
-	It("should limit echo server as external service", FlakeAttempts(3), func() {
+	It("should limit echo server as external service", func() {
 		externalService := fmt.Sprintf(`
 type: ExternalService
 mesh: "%s"


### PR DESCRIPTION
Now we store artifacts for failed Universal tests. Let's remove FlakeAttempts and try to catch failures on CI.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [X] [Link to relevant issue][1] as well as docs and UI issues -- Fix #4700 
- [X] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [X] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [X] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [X] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [X] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
