### PR TITLE
fix(helm): change CNI priorityClass from system-cluster-critical to system-node-critical

### DIFF
--- a/deployments/charts/kuma/templates/cni-daemonset.yaml
+++ b/deployments/charts/kuma/templates/cni-daemonset.yaml
@@ -29,7 +29,7 @@ spec:
       # marks the pod as a critical add-on, ensuring it gets
       # priority scheduling and that its resources are reserved
       # if it ever gets evicted.
-      priorityClassName: system-cluster-critical
+      priorityClassName: system-node-critical
       {{- with .Values.cni.nodeSelector }}
       nodeSelector:
       {{ toYaml . | nindent 8 }}


### PR DESCRIPTION
The CNI is critical _to the node_, a higher priority than system-cluster-critical.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [ ] [Link to relevant issue][1] as well as docs and UI issues --
- [ ] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [ ] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [ ] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [ ] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [ ] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
