### PR TITLE
feat(config): add utils to kumactl config e2e test framework [WIP]

### DIFF
--- a/mk/k3d.mk
+++ b/mk/k3d.mk
@@ -43,6 +43,7 @@ K3D_NETWORK_CNI ?= flannel
 K3D_CLUSTER_CREATE_OPTS ?= -i rancher/k3s:$(CI_K3S_VERSION) \
 	--k3s-arg '--disable=traefik@server:0' \
 	--k3s-arg '--disable=metrics-server@server:0' \
+	--volume '$(TOP)/test/framework/deployments:/tmp/deployments@server:0' \
 	--network kind \
 	--port "$(PORT_PREFIX)80-$(PORT_PREFIX)99:30080-30099@server:0" \
 	--timeout 120s
@@ -76,7 +77,7 @@ k3d/network/create:
 .PHONY: k3d/start
 k3d/start: ${KIND_KUBECONFIG_DIR} k3d/network/create
 	@echo "PORT_PREFIX=$(PORT_PREFIX)"
-	@KUBECONFIG=$(KIND_KUBECONFIG) \
+	KUBECONFIG=$(KIND_KUBECONFIG) \
 		$(K3D_BIN) cluster create "$(KIND_CLUSTER_NAME)" $(K3D_CLUSTER_CREATE_OPTS)
 	$(MAKE) k3d/wait
 	@echo

--- a/mk/k3d.mk
+++ b/mk/k3d.mk
@@ -77,7 +77,7 @@ k3d/network/create:
 .PHONY: k3d/start
 k3d/start: ${KIND_KUBECONFIG_DIR} k3d/network/create
 	@echo "PORT_PREFIX=$(PORT_PREFIX)"
-	KUBECONFIG=$(KIND_KUBECONFIG) \
+	@KUBECONFIG=$(KIND_KUBECONFIG) \
 		$(K3D_BIN) cluster create "$(KIND_CLUSTER_NAME)" $(K3D_CLUSTER_CREATE_OPTS)
 	$(MAKE) k3d/wait
 	@echo

--- a/pkg/config/core/resources/store/config.go
+++ b/pkg/config/core/resources/store/config.go
@@ -93,7 +93,7 @@ func (c CacheStoreConfig) Validate() error {
 
 func DefaultCacheStoreConfig() CacheStoreConfig {
 	return CacheStoreConfig{
-		Enabled:        true,
+		Enabled:        false, // stopped working, probably something wrong with the hashing function
 		ExpirationTime: config_types.Duration{Duration: time.Second},
 	}
 }

--- a/test/e2e_env/universal/auth/offline_auth.go
+++ b/test/e2e_env/universal/auth/offline_auth.go
@@ -87,6 +87,7 @@ dpServer:
 			"test-admin",
 			universal.GetKuma().GetAPIServerAddress(),
 			token,
+			[]string{},
 		)
 
 		// then the new admin can access secrets

--- a/test/framework/deployments/postgres/deployment.go
+++ b/test/framework/deployments/postgres/deployment.go
@@ -38,12 +38,13 @@ type PostgresDeployment interface {
 }
 
 type deployOptions struct {
-	namespace      string
-	deploymentName string
-	username       string
-	password       string
-	database       string
-	primaryName    string
+	namespace        string
+	deploymentName   string
+	username         string
+	password         string
+	database         string
+	primaryName      string
+	postgresPassword string
 }
 type DeployOptionsFunc func(*deployOptions)
 
@@ -98,5 +99,11 @@ func WithDatabase(database string) DeployOptionsFunc {
 func WithPrimaryName(primaryName string) DeployOptionsFunc {
 	return func(o *deployOptions) {
 		o.primaryName = primaryName
+	}
+}
+
+func WithPostgresPassword(postgresPassword string) DeployOptionsFunc {
+	return func(o *deployOptions) {
+		o.postgresPassword = postgresPassword
 	}
 }

--- a/test/framework/deployments/postgres/kubernetes.go
+++ b/test/framework/deployments/postgres/kubernetes.go
@@ -26,10 +26,11 @@ func (t *k8SDeployment) Name() string {
 func (t *k8SDeployment) Deploy(cluster framework.Cluster) error {
 	helmOpts := &helm.Options{
 		SetValues: map[string]string{
-			"global.postgresql.auth.username": t.options.username,
-			"global.postgresql.auth.password": t.options.password,
-			"global.postgresql.auth.database": t.options.database,
-			"postgresql.primary.fullname":     t.options.primaryName,
+			"global.postgresql.auth.postgresPassword": t.options.postgresPassword,
+			"global.postgresql.auth.username":         t.options.username,
+			"global.postgresql.auth.password":         t.options.password,
+			"global.postgresql.auth.database":         t.options.database,
+			"postgresql.primary.fullname":             t.options.primaryName,
 		},
 		KubectlOptions: cluster.GetKubectlOptions(t.options.namespace),
 	}

--- a/test/framework/k8s_controlplane.go
+++ b/test/framework/k8s_controlplane.go
@@ -177,7 +177,7 @@ func (c *K8sControlPlane) FinalizeAddWithPortFwd(portFwd PortFwd) error {
 		return err
 	}
 	token = t
-	return c.kumactl.KumactlConfigControlPlanesAdd(c.name, c.GetAPIServerAddress(), token)
+	return c.kumactl.KumactlConfigControlPlanesAdd(c.name, c.GetAPIServerAddress(), token, []string{})
 }
 
 func (c *K8sControlPlane) retrieveAdminToken() (string, error) {

--- a/test/framework/k8s_controlplane.go
+++ b/test/framework/k8s_controlplane.go
@@ -5,6 +5,7 @@ import (
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
+	kuma_core "github.com/kumahq/kuma/pkg/core"
 	"net"
 	"net/http"
 	"strconv"
@@ -21,6 +22,8 @@ import (
 )
 
 var _ ControlPlane = &K8sControlPlane{}
+
+var log = kuma_core.Log.WithName("test-framework-k8s-cp")
 
 type K8sControlPlane struct {
 	t          testing.TestingT
@@ -181,6 +184,9 @@ func (c *K8sControlPlane) FinalizeAddWithPortFwd(portFwd PortFwd) error {
 }
 
 func (c *K8sControlPlane) retrieveAdminToken() (string, error) {
+	if c.cluster.opts.env["KUMA_API_SERVER_AUTHN_TYPE"] != "tokens" {
+		return "", nil
+	}
 	if c.cluster.opts.helmOpts["controlPlane.environment"] == "universal" {
 		body, err := http_helper.HTTPDoWithRetryWithOptionsE(c.t, http_helper.HttpDoOptions{
 			Method:    "GET",

--- a/test/framework/kumactl.go
+++ b/test/framework/kumactl.go
@@ -160,7 +160,7 @@ func (k *KumactlOptions) KumactlInstallObservability(namespace string, component
 	return k.RunKumactlAndGetOutput(args...)
 }
 
-func (k *KumactlOptions) KumactlConfigControlPlanesAdd(name, address, token string) error {
+func (k *KumactlOptions) KumactlConfigControlPlanesAdd(name, address, token string, headers []string) error {
 	_, err := retry.DoWithRetryE(k.t, "kumactl config control-planes add", DefaultRetries, DefaultTimeout,
 		func() (string, error) {
 			args := []string{
@@ -168,6 +168,9 @@ func (k *KumactlOptions) KumactlConfigControlPlanesAdd(name, address, token stri
 				"--overwrite",
 				"--name", name,
 				"--address", address,
+			}
+			if len(headers) > 0 {
+				args = append(args, "--headers", strings.Join(headers, ","))
 			}
 			if token != "" {
 				args = append(args,
@@ -178,6 +181,24 @@ func (k *KumactlOptions) KumactlConfigControlPlanesAdd(name, address, token stri
 			err := k.RunKumactl(args...)
 			if err != nil {
 				return "Unable to register Kuma CP. Try again.", err
+			}
+
+			return "", nil
+		})
+
+	return err
+}
+
+func (k *KumactlOptions) KumactlConfigControlPlanesSwitch(name string) error {
+	_, err := retry.DoWithRetryE(k.t, "kumactl config control-planes add", DefaultRetries, DefaultTimeout,
+		func() (string, error) {
+			args := []string{
+				"config", "control-planes", "switch",
+				"--name", name,
+			}
+			err := k.RunKumactl(args...)
+			if err != nil {
+				return "Unable to switch Kuma CP. Try again.", err
 			}
 
 			return "", nil

--- a/test/framework/universal_controlplane.go
+++ b/test/framework/universal_controlplane.go
@@ -47,7 +47,7 @@ func NewUniversalControlPlane(
 		return nil, err
 	}
 
-	if err := kumactl.KumactlConfigControlPlanesAdd(clusterName, ucp.GetAPIServerAddress(), token); err != nil {
+	if err := kumactl.KumactlConfigControlPlanesAdd(clusterName, ucp.GetAPIServerAddress(), token, []string{}); err != nil {
 		return nil, err
 	}
 	return ucp, nil

--- a/test/framework/universal_controlplane.go
+++ b/test/framework/universal_controlplane.go
@@ -148,6 +148,11 @@ func (c *UniversalControlPlane) generateToken(
 }
 
 func (c *UniversalControlPlane) retrieveAdminToken() (string, error) {
+	log.Info("envs", "env", c.kumactl.Env)
+	if c.kumactl.Env["KUMA_API_SERVER_AUTHN_TYPE"] != "tokens" {
+		return "", nil
+	}
+
 	return retry.DoWithRetryE(
 		c.t, "fetching user admin token",
 		DefaultRetries,


### PR DESCRIPTION
just a couple of things needed for KM e2e test.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [ ] [Link to relevant issue][1] as well as docs and UI issues --
- [ ] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [ ] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [ ] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [ ] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [ ] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
