### PR TITLE
fix(helm): use correct secret for CP CA in ingress/egress

### DIFF
--- a/app/kumactl/cmd/install/testdata/install-control-plane.with-egress.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.with-egress.golden.yaml
@@ -641,7 +641,7 @@ spec:
       volumes:
         - name: control-plane-ca
           secret:
-            secretName: "kuma-tls-cert"
+            secretName: "general-tls-secret"
             items:
               - key: ca.crt
                 path: ca.crt

--- a/app/kumactl/cmd/install/testdata/install-control-plane.with-helm-set.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.with-helm-set.yaml
@@ -6340,7 +6340,7 @@ spec:
       volumes:
         - name: control-plane-ca
           secret:
-            secretName: "kuma-tls-cert"
+            secretName: "general-tls-secret"
             items:
               - key: ca.crt
                 path: ca.crt
@@ -6472,7 +6472,7 @@ spec:
       volumes:
         - name: control-plane-ca
           secret:
-            secretName: "kuma-tls-cert"
+            secretName: "general-tls-secret"
             items:
               - key: ca.crt
                 path: ca.crt

--- a/app/kumactl/cmd/install/testdata/install-control-plane.with-ingress.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.with-ingress.golden.yaml
@@ -647,7 +647,7 @@ spec:
       volumes:
         - name: control-plane-ca
           secret:
-            secretName: "kuma-tls-cert"
+            secretName: "general-tls-secret"
             items:
               - key: ca.crt
                 path: ca.crt

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/fix4496.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/fix4496.golden.yaml
@@ -660,7 +660,7 @@ spec:
       volumes:
         - name: control-plane-ca
           secret:
-            secretName: "kuma-tls-cert"
+            secretName: "general-tls-secret"
             items:
               - key: ca.crt
                 path: ca.crt

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/fix4935.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/fix4935.golden.yaml
@@ -907,7 +907,7 @@ spec:
       volumes:
         - name: control-plane-ca
           secret:
-            secretName: "kuma-tls-cert"
+            secretName: "general-tls-secret"
             items:
               - key: ca.crt
                 path: ca.crt
@@ -1042,7 +1042,7 @@ spec:
       volumes:
         - name: control-plane-ca
           secret:
-            secretName: "kuma-tls-cert"
+            secretName: "general-tls-secret"
             items:
               - key: ca.crt
                 path: ca.crt

--- a/deployments/charts/kuma/templates/_helpers.tpl
+++ b/deployments/charts/kuma/templates/_helpers.tpl
@@ -297,6 +297,10 @@ env:
 {{- end }}
 {{- end }}
 
+{{- define "kuma.controlPlane.tls.general.caSecretName" -}}
+{{ .Values.controlPlane.tls.general.caSecretName | default .Values.controlPlane.tls.general.secretName | default (printf "%s-tls-cert" (include "kuma.name" .)) | quote }}
+{{- end }}
+
 {{- define "kuma.universal.defaultEnv" -}}
 env:
 - name: KUMA_GENERAL_WORK_DIR

--- a/deployments/charts/kuma/templates/egress-deployment.yaml
+++ b/deployments/charts/kuma/templates/egress-deployment.yaml
@@ -104,7 +104,7 @@ spec:
       volumes:
         - name: control-plane-ca
           secret:
-            secretName: {{.Values.controlPlane.tls.general.caSecretName | default (printf "%s-tls-cert" (include "kuma.name" .)) | quote }}
+            secretName: {{ include "kuma.controlPlane.tls.general.caSecretName" . }}
             items:
               - key: ca.crt
                 path: ca.crt

--- a/deployments/charts/kuma/templates/ingress-deployment.yaml
+++ b/deployments/charts/kuma/templates/ingress-deployment.yaml
@@ -108,7 +108,7 @@ spec:
       volumes:
         - name: control-plane-ca
           secret:
-            secretName: {{.Values.controlPlane.tls.general.caSecretName | default (printf "%s-tls-cert" (include "kuma.name" .)) | quote }}
+            secretName: {{ include "kuma.controlPlane.tls.general.caSecretName" . }}
             items:
               - key: ca.crt
                 path: ca.crt


### PR DESCRIPTION
IIUC currently there is a bug that appears when the user has set `secretName` but not `caSecretName`, which is allowed. In this case, the `Secret` `secretName` is supposed to have the `ca.crt` value so the CA should be fetched from there. But the chart as is uses the default `Secret`, which won't have been created, leading to an error starting the ingress/egress `Pods`.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [x] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
