### PR TITLE
fix(helm): set global flags before subcommand

### DIFF
--- a/app/kumactl/cmd/install/testdata/install-control-plane.cni-enabled.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.cni-enabled.golden.yaml
@@ -648,9 +648,9 @@ spec:
                 fieldRef:
                   fieldPath: status.podIP
           args:
-            - run
-            - --log-level=info
             - --log-output-path=
+            - --log-level=info
+            - run
             - --config-file=/etc/kuma.io/kuma-control-plane/config.yaml
           ports:
             - containerPort: 5680

--- a/app/kumactl/cmd/install/testdata/install-control-plane.cni-legacy-enabled.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.cni-legacy-enabled.golden.yaml
@@ -626,9 +626,9 @@ spec:
                 fieldRef:
                   fieldPath: status.podIP
           args:
-            - run
-            - --log-level=info
             - --log-output-path=
+            - --log-level=info
+            - run
             - --config-file=/etc/kuma.io/kuma-control-plane/config.yaml
           ports:
             - containerPort: 5680

--- a/app/kumactl/cmd/install/testdata/install-control-plane.defaults.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.defaults.golden.yaml
@@ -6094,9 +6094,9 @@ spec:
                 fieldRef:
                   fieldPath: status.podIP
           args:
-            - run
-            - --log-level=info
             - --log-output-path=
+            - --log-level=info
+            - run
             - --config-file=/etc/kuma.io/kuma-control-plane/config.yaml
           ports:
             - containerPort: 5680

--- a/app/kumactl/cmd/install/testdata/install-control-plane.gateway-api-present-not-enabled.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.gateway-api-present-not-enabled.yaml
@@ -6094,9 +6094,9 @@ spec:
                 fieldRef:
                   fieldPath: status.podIP
           args:
-            - run
-            - --log-level=info
             - --log-output-path=
+            - --log-level=info
+            - run
             - --config-file=/etc/kuma.io/kuma-control-plane/config.yaml
           ports:
             - containerPort: 5680

--- a/app/kumactl/cmd/install/testdata/install-control-plane.gateway-api-present.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.gateway-api-present.yaml
@@ -6301,9 +6301,9 @@ spec:
                 fieldRef:
                   fieldPath: status.podIP
           args:
-            - run
-            - --log-level=info
             - --log-output-path=
+            - --log-level=info
+            - run
             - --config-file=/etc/kuma.io/kuma-control-plane/config.yaml
           ports:
             - containerPort: 5680

--- a/app/kumactl/cmd/install/testdata/install-control-plane.global-universal-on-k8s.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.global-universal-on-k8s.golden.yaml
@@ -166,9 +166,9 @@ spec:
             - name: KUMA_STORE_TYPE
               value: "postgres"
           args:
+            - --log-level=info
             - migrate
             - up
-            - --log-level=info
             - --config-file=/etc/kuma.io/kuma-control-plane/config.yaml
           resources:
             limits:
@@ -212,9 +212,9 @@ spec:
                 fieldRef:
                   fieldPath: status.podIP
           args:
-            - run
-            - --log-level=info
             - --log-output-path=
+            - --log-level=info
+            - run
             - --config-file=/etc/kuma.io/kuma-control-plane/config.yaml
           ports:
             - containerPort: 5680

--- a/app/kumactl/cmd/install/testdata/install-control-plane.global.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.global.golden.yaml
@@ -446,9 +446,9 @@ spec:
                 fieldRef:
                   fieldPath: status.podIP
           args:
-            - run
-            - --log-level=info
             - --log-output-path=
+            - --log-level=info
+            - run
             - --config-file=/etc/kuma.io/kuma-control-plane/config.yaml
           ports:
             - containerPort: 5680

--- a/app/kumactl/cmd/install/testdata/install-control-plane.override-env-vars.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.override-env-vars.golden.yaml
@@ -430,9 +430,9 @@ spec:
                 fieldRef:
                   fieldPath: status.podIP
           args:
-            - run
-            - --log-level=info
             - --log-output-path=
+            - --log-level=info
+            - run
             - --config-file=/etc/kuma.io/kuma-control-plane/config.yaml
           ports:
             - containerPort: 5680

--- a/app/kumactl/cmd/install/testdata/install-control-plane.overrides.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.overrides.golden.yaml
@@ -446,9 +446,9 @@ spec:
                 fieldRef:
                   fieldPath: status.podIP
           args:
-            - run
-            - --log-level=info
             - --log-output-path=
+            - --log-level=info
+            - run
             - --config-file=/etc/kuma.io/kuma-control-plane/config.yaml
           ports:
             - containerPort: 5680

--- a/app/kumactl/cmd/install/testdata/install-control-plane.registry.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.registry.golden.yaml
@@ -430,9 +430,9 @@ spec:
                 fieldRef:
                   fieldPath: status.podIP
           args:
-            - run
-            - --log-level=info
             - --log-output-path=
+            - --log-level=info
+            - run
             - --config-file=/etc/kuma.io/kuma-control-plane/config.yaml
           ports:
             - containerPort: 5680

--- a/app/kumactl/cmd/install/testdata/install-control-plane.tproxy-ebpf-experimental-enabled.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.tproxy-ebpf-experimental-enabled.golden.yaml
@@ -440,9 +440,9 @@ spec:
                 fieldRef:
                   fieldPath: status.podIP
           args:
-            - run
-            - --log-level=info
             - --log-output-path=
+            - --log-level=info
+            - run
             - --config-file=/etc/kuma.io/kuma-control-plane/config.yaml
           ports:
             - containerPort: 5680

--- a/app/kumactl/cmd/install/testdata/install-control-plane.with-egress.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.with-egress.golden.yaml
@@ -461,9 +461,9 @@ spec:
                 fieldRef:
                   fieldPath: status.podIP
           args:
-            - run
-            - --log-level=info
             - --log-output-path=
+            - --log-level=info
+            - run
             - --config-file=/etc/kuma.io/kuma-control-plane/config.yaml
           ports:
             - containerPort: 5680

--- a/app/kumactl/cmd/install/testdata/install-control-plane.with-helm-set.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.with-helm-set.yaml
@@ -6160,9 +6160,9 @@ spec:
                 fieldRef:
                   fieldPath: status.podIP
           args:
-            - run
-            - --log-level=info
             - --log-output-path=
+            - --log-level=info
+            - run
             - --config-file=/etc/kuma.io/kuma-control-plane/config.yaml
           ports:
             - containerPort: 5680

--- a/app/kumactl/cmd/install/testdata/install-control-plane.with-helm-values.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.with-helm-values.yaml
@@ -430,9 +430,9 @@ spec:
                 fieldRef:
                   fieldPath: status.podIP
           args:
-            - run
-            - --log-level=info
             - --log-output-path=
+            - --log-level=info
+            - run
             - --config-file=/etc/kuma.io/kuma-control-plane/config.yaml
           ports:
             - containerPort: 5680

--- a/app/kumactl/cmd/install/testdata/install-control-plane.with-ingress.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.with-ingress.golden.yaml
@@ -465,9 +465,9 @@ spec:
                 fieldRef:
                   fieldPath: status.podIP
           args:
-            - run
-            - --log-level=info
             - --log-output-path=
+            - --log-level=info
+            - run
             - --config-file=/etc/kuma.io/kuma-control-plane/config.yaml
           ports:
             - containerPort: 5680

--- a/app/kumactl/cmd/install/testdata/install-control-plane.zone.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.zone.golden.yaml
@@ -434,9 +434,9 @@ spec:
                 fieldRef:
                   fieldPath: status.podIP
           args:
-            - run
-            - --log-level=info
             - --log-output-path=
+            - --log-level=info
+            - run
             - --config-file=/etc/kuma.io/kuma-control-plane/config.yaml
           ports:
             - containerPort: 5680

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/empty.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/empty.golden.yaml
@@ -430,9 +430,9 @@ spec:
                 fieldRef:
                   fieldPath: status.podIP
           args:
-            - run
-            - --log-level=info
             - --log-output-path=
+            - --log-level=info
+            - run
             - --config-file=/etc/kuma.io/kuma-control-plane/config.yaml
           ports:
             - containerPort: 5680

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/fix4485.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/fix4485.golden.yaml
@@ -453,9 +453,9 @@ spec:
                 fieldRef:
                   fieldPath: status.podIP
           args:
-            - run
-            - --log-level=info
             - --log-output-path=
+            - --log-level=info
+            - run
             - --config-file=/etc/kuma.io/kuma-control-plane/config.yaml
           ports:
             - containerPort: 5680

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/fix4496.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/fix4496.golden.yaml
@@ -476,9 +476,9 @@ spec:
                 fieldRef:
                   fieldPath: status.podIP
           args:
-            - run
-            - --log-level=info
             - --log-output-path=
+            - --log-level=info
+            - run
             - --config-file=/etc/kuma.io/kuma-control-plane/config.yaml
           ports:
             - containerPort: 5680

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/fix4935.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/fix4935.golden.yaml
@@ -724,9 +724,9 @@ spec:
                 fieldRef:
                   fieldPath: status.podIP
           args:
-            - run
-            - --log-level=info
             - --log-output-path=
+            - --log-level=info
+            - run
             - --config-file=/etc/kuma.io/kuma-control-plane/config.yaml
           ports:
             - containerPort: 5680

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/fix5978.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/fix5978.golden.yaml
@@ -496,9 +496,9 @@ spec:
                 fieldRef:
                   fieldPath: status.podIP
           args:
-            - run
-            - --log-level=info
             - --log-output-path=
+            - --log-level=info
+            - run
             - --config-file=/etc/kuma.io/kuma-control-plane/config.yaml
           ports:
             - containerPort: 5680

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/securityContext.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/securityContext.golden.yaml
@@ -431,9 +431,9 @@ spec:
                 fieldRef:
                   fieldPath: status.podIP
           args:
-            - run
-            - --log-level=info
             - --log-output-path=
+            - --log-level=info
+            - run
             - --config-file=/etc/kuma.io/kuma-control-plane/config.yaml
           ports:
             - containerPort: 5680

--- a/deployments/charts/kuma/templates/cp-deployment.yaml
+++ b/deployments/charts/kuma/templates/cp-deployment.yaml
@@ -94,9 +94,9 @@ spec:
                   key: {{ $element.Key }}
           {{- end }}
           args:
+            - --log-level=info
             - migrate
             - up
-            - --log-level=info
             - --config-file=/etc/kuma.io/kuma-control-plane/config.yaml
           resources:
             {{- if .Values.controlPlane.resources }}
@@ -146,9 +146,9 @@ spec:
                 fieldRef:
                   fieldPath: status.podIP
           args:
-            - run
-            - --log-level={{ .Values.controlPlane.logLevel }}
             - --log-output-path={{ .Values.controlPlane.logOutputPath }}
+            - --log-level={{ .Values.controlPlane.logLevel }}
+            - run
             - --config-file=/etc/kuma.io/kuma-control-plane/config.yaml
           ports:
             - containerPort: 5680


### PR DESCRIPTION
This solves issues with subcommands that may do additional work manipulating flags.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [ ] [Link to relevant issue][1] as well as docs and UI issues --
- [ ] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [ ] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [ ] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [ ] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [ ] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
