### PR TITLE
ci(k8s): use metallb instead of servicelb

### DIFF
--- a/mk/k3d.mk
+++ b/mk/k3d.mk
@@ -1,5 +1,5 @@
 CI_K3S_VERSION ?= $(K8S_MIN_VERSION)
-
+METALLB_VERSION ?= v0.13.9
 
 KUMA_MODE ?= standalone
 KUMA_NAMESPACE ?= kuma-system
@@ -99,7 +99,7 @@ endif
 
 .PHONY: k3d/configure/metallb
 k3d/configure/metallb:
-	KUBECONFIG=$(KIND_KUBECONFIG) $(KUBECTL) apply -f https://raw.githubusercontent.com/metallb/metallb/v0.13.9/config/manifests/metallb-native.yaml
+	KUBECONFIG=$(KIND_KUBECONFIG) $(KUBECTL) apply -f https://raw.githubusercontent.com/metallb/metallb/$(METALLB_VERSION)/config/manifests/metallb-native.yaml
 	@KUBECONFIG=$(KIND_KUBECONFIG) $(KUBECTL) wait --timeout=90s --for=condition=Ready -n metallb-system --all pods
 	SUBNET=$$(docker network inspect kind --format '{{ (index .IPAM.Config 0).Subnet }}') \
 		yq '(select(.kind == "IPAddressPool") | .spec.addresses[0]) = env(SUBNET)' mk/metallb-k3d.yaml \

--- a/mk/k3d.mk
+++ b/mk/k3d.mk
@@ -43,6 +43,7 @@ K3D_NETWORK_CNI ?= flannel
 K3D_CLUSTER_CREATE_OPTS ?= -i rancher/k3s:$(CI_K3S_VERSION) \
 	--k3s-arg '--disable=traefik@server:0' \
 	--k3s-arg '--disable=metrics-server@server:0' \
+	--k3s-arg '--disable=servicelb@server:0' \
 	--network kind \
 	--port "$(PORT_PREFIX)80-$(PORT_PREFIX)99:30080-30099@server:0" \
 	--timeout 120s
@@ -87,6 +88,7 @@ k3d/start: ${KIND_KUBECONFIG_DIR} k3d/network/create
 	@echo '<<< ------------------------------------------------------------- <<<'
 	@echo
 	$(MAKE) k3d/configure/ebpf
+	$(MAKE) k3d/configure/metallb
 
 .PHONY: k3d/configure/ebpf
 k3d/configure/ebpf:
@@ -95,10 +97,18 @@ ifeq ($(GOOS),darwin)
 	docker exec k3d-$(KIND_CLUSTER_NAME)-server-0 mount --make-shared /sys/fs/bpf
 endif
 
+.PHONY: k3d/configure/metallb
+k3d/configure/metallb:
+	KUBECONFIG=$(KIND_KUBECONFIG) $(KUBECTL) apply -f https://raw.githubusercontent.com/metallb/metallb/v0.13.9/config/manifests/metallb-native.yaml
+	@KUBECONFIG=$(KIND_KUBECONFIG) $(KUBECTL) wait --timeout=90s --for=condition=Ready -n metallb-system --all pods
+	SUBNET=$$(docker network inspect kind --format '{{ (index .IPAM.Config 0).Subnet }}') \
+		yq '(select(.kind == "IPAddressPool") | .spec.addresses[0]) = env(SUBNET)' mk/metallb-k3d.yaml \
+	| KUBECONFIG=$(KIND_KUBECONFIG) $(KUBECTL) apply -f -
+
 .PHONY: k3d/wait
 k3d/wait:
 	until \
-		 KUBECONFIG=$(KIND_KUBECONFIG) $(KUBECTL) wait -n kube-system --timeout=5s --for condition=Ready --all pods ; \
+		 KUBECONFIG=$(KIND_KUBECONFIG) $(KUBECTL) wait -n kube-system --timeout=5s --for condition=Ready --all pods; \
 	do echo "Waiting for the cluster to come up" && sleep 1; done
 
 .PHONY: k3d/stop

--- a/mk/metallb-k3d-kuma-1.yaml
+++ b/mk/metallb-k3d-kuma-1.yaml
@@ -5,7 +5,8 @@ metadata:
   name: example
   namespace: metallb-system
 spec:
-  addresses: [] # set by make target
+  addresses:
+    - 172.18.1.0/24
 ---
 apiVersion: metallb.io/v1beta1
 kind: L2Advertisement

--- a/mk/metallb-k3d-kuma-2.yaml
+++ b/mk/metallb-k3d-kuma-2.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: metallb.io/v1beta1
+kind: IPAddressPool
+metadata:
+  name: example
+  namespace: metallb-system
+spec:
+  addresses:
+    - 172.18.2.0/24
+---
+apiVersion: metallb.io/v1beta1
+kind: L2Advertisement
+metadata:
+  name: empty
+  namespace: metallb-system

--- a/mk/metallb-k3d.yaml
+++ b/mk/metallb-k3d.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: metallb.io/v1beta1
+kind: IPAddressPool
+metadata:
+  name: example
+  namespace: metallb-system
+spec:
+  addresses: [] # set by make target
+---
+apiVersion: metallb.io/v1beta1
+kind: L2Advertisement
+metadata:
+  name: empty
+  namespace: metallb-system


### PR DESCRIPTION
This keeps us independent of servicelb changes arbitrarily depending on the k8s version, see https://github.com/kumahq/kuma/pull/6365

It also appears to allocates a separate IP for each LoadBalancer as opposed to a port on the same IP for each LoadBalancer... 

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [x] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
