### PR TITLE
feat(api-server): add ability to get k8s format of a resource

### DIFF
--- a/pkg/api-server/resource_endpoints.go
+++ b/pkg/api-server/resource_endpoints.go
@@ -18,8 +18,10 @@ import (
 	rest_v1alpha1 "github.com/kumahq/kuma/pkg/core/resources/model/rest/v1alpha1"
 	"github.com/kumahq/kuma/pkg/core/resources/store"
 	rest_errors "github.com/kumahq/kuma/pkg/core/rest/errors"
+	"github.com/kumahq/kuma/pkg/core/rest/errors/types"
 	"github.com/kumahq/kuma/pkg/core/user"
 	"github.com/kumahq/kuma/pkg/core/validators"
+	"github.com/kumahq/kuma/pkg/plugins/resources/k8s"
 )
 
 const (
@@ -38,6 +40,7 @@ type resourceEndpoints struct {
 	resManager     manager.ResourceManager
 	descriptor     model.ResourceTypeDescriptor
 	resourceAccess access.ResourceAccess
+	k8sMapper      k8s.ResourceMapper
 }
 
 func (r *resourceEndpoints) addFindEndpoint(ws *restful.WebService, pathPrefix string) {
@@ -67,7 +70,20 @@ func (r *resourceEndpoints) findResource(request *restful.Request, response *res
 	if err != nil {
 		rest_errors.HandleError(response, err, "Could not retrieve a resource")
 	} else {
-		res := rest.From.Resource(resource)
+		var res interface{}
+		switch request.QueryParameter("format") {
+		case "k8s", "kubernetes":
+			res, err = r.k8sMapper.Map(resource, request.QueryParameter("namespace"))
+			if err != nil {
+				rest_errors.HandleError(response, err, "k8s mapping failed")
+				return
+			}
+		case "universal", "":
+			res = rest.From.Resource(resource)
+		default:
+			rest_errors.WriteError(response, http.StatusBadRequest, types.Error{Title: fmt.Sprintf("invalid format %s", request.QueryParameter("format"))})
+			return
+		}
 		if err := response.WriteAsJson(res); err != nil {
 			core.Log.Error(err, "Could not write the response")
 		}

--- a/pkg/api-server/resource_endpoints.go
+++ b/pkg/api-server/resource_endpoints.go
@@ -40,7 +40,7 @@ type resourceEndpoints struct {
 	resManager     manager.ResourceManager
 	descriptor     model.ResourceTypeDescriptor
 	resourceAccess access.ResourceAccess
-	k8sMapper      k8s.ResourceMapper
+	k8sMapper      k8s.ResourceMapperFunc
 }
 
 func (r *resourceEndpoints) addFindEndpoint(ws *restful.WebService, pathPrefix string) {
@@ -73,7 +73,7 @@ func (r *resourceEndpoints) findResource(request *restful.Request, response *res
 		var res interface{}
 		switch request.QueryParameter("format") {
 		case "k8s", "kubernetes":
-			res, err = r.k8sMapper.Map(resource, request.QueryParameter("namespace"))
+			res, err = r.k8sMapper(resource, request.QueryParameter("namespace"))
 			if err != nil {
 				rest_errors.HandleError(response, err, "k8s mapping failed")
 				return

--- a/pkg/api-server/server.go
+++ b/pkg/api-server/server.go
@@ -37,6 +37,7 @@ import (
 	"github.com/kumahq/kuma/pkg/dns/vips"
 	"github.com/kumahq/kuma/pkg/envoy/admin"
 	"github.com/kumahq/kuma/pkg/metrics"
+	"github.com/kumahq/kuma/pkg/plugins/resources/k8s"
 	"github.com/kumahq/kuma/pkg/tokens/builtin"
 	tokens_server "github.com/kumahq/kuma/pkg/tokens/builtin/server"
 	util_prometheus "github.com/kumahq/kuma/pkg/util/prometheus"
@@ -236,6 +237,7 @@ func addResourcesEndpoints(ws *restful.WebService, defs []model.ResourceTypeDesc
 			definition.ReadOnly = true
 		}
 		endpoints := resourceEndpoints{
+			k8sMapper:      k8s.NewMapper(cfg.Store.Kubernetes.SystemNamespace, cfg.Store.Type, k8s.NewSimpleKubeFactory()),
 			mode:           cfg.Mode,
 			resManager:     resManager,
 			descriptor:     definition,

--- a/pkg/api-server/server.go
+++ b/pkg/api-server/server.go
@@ -232,7 +232,7 @@ func addResourcesEndpoints(ws *restful.WebService, defs []model.ResourceTypeDesc
 	}
 	globalInsightsEndpoints.addEndpoint(ws)
 
-	var k8sMapper k8s.ResourceMapper
+	var k8sMapper k8s.ResourceMapperFunc
 	switch cfg.Store.Type {
 	case config_store.KubernetesStore:
 		k8sMapper = k8s.NewKubernetesMapper(k8s.NewSimpleKubeFactory())

--- a/pkg/plugins/resources/k8s/mapper.go
+++ b/pkg/plugins/resources/k8s/mapper.go
@@ -1,0 +1,60 @@
+package k8s
+
+import (
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/kumahq/kuma/pkg/config/core/resources/store"
+	"github.com/kumahq/kuma/pkg/core/resources/model"
+	k8s_model "github.com/kumahq/kuma/pkg/plugins/resources/k8s/native/pkg/model"
+	util_k8s "github.com/kumahq/kuma/pkg/util/k8s"
+)
+
+type ResourceMapper interface {
+	Map(resource model.Resource, namespace string) (k8s_model.KubernetesObject, error)
+}
+type ResourceMapperFunc func(resource model.Resource, namespace string) (k8s_model.KubernetesObject, error)
+
+func (f ResourceMapperFunc) Map(resource model.Resource, namespace string) (k8s_model.KubernetesObject, error) {
+	return f(resource, namespace)
+}
+
+func NewMapper(systemNamespace string, storeType store.StoreType, kubeFactory KubeFactory) ResourceMapper {
+	return ResourceMapperFunc(func(resource model.Resource, namespace string) (k8s_model.KubernetesObject, error) {
+		if storeType == store.KubernetesStore {
+			// If we're on k8s we should just return the k8s object as is.
+			res, err := (&SimpleConverter{KubeFactory: kubeFactory}).ToKubernetesObject(resource)
+			if err != nil {
+				return nil, err
+			}
+			if namespace != "" {
+				res.SetNamespace(namespace)
+			}
+			return res, err
+		}
+		// otherwise we create a k8s resource with the universal object we have.
+		rs, err := kubeFactory.NewObject(resource)
+		if err != nil {
+			return nil, err
+		}
+		if rs.Scope() == k8s_model.ScopeNamespace {
+			name, ns, err := util_k8s.CoreNameToK8sName(resource.GetMeta().GetName())
+			if err != nil {
+				// if the original resource doesn't look like a kubernetes name ("name"."namespace")`, just use the default namespace.
+				// this is in the case where someone calls this on a universal cluster. Exporting is a use-case for this.
+				ns = systemNamespace
+				name = resource.GetMeta().GetName()
+			}
+			if namespace != "" { // If the user is forcing the namespace accept it.
+				ns = namespace
+			}
+			rs.SetName(name)
+			rs.SetNamespace(ns)
+		} else {
+			rs.SetName(resource.GetMeta().GetName())
+		}
+		rs.SetMesh(resource.GetMeta().GetMesh())
+		rs.SetCreationTimestamp(v1.NewTime(resource.GetMeta().GetCreationTime()))
+		rs.SetSpec(resource.GetSpec())
+		return rs, nil
+	})
+}

--- a/pkg/plugins/resources/k8s/mapper_test.go
+++ b/pkg/plugins/resources/k8s/mapper_test.go
@@ -26,7 +26,7 @@ var _ = Describe("KubernetesStore template", func() {
 			in.SetMeta(&rest_v1alpha1.ResourceMeta{Name: "foo", Mesh: "default"})
 
 			mapper := k8s.NewInferenceMapper("core-ns", &k8s.SimpleKubeFactory{KubeTypes: kubeTypes})
-			res, err := mapper.Map(in, "")
+			res, err := mapper(in, "")
 
 			Expect(err).ToNot(HaveOccurred())
 			Expect(res.GetMesh()).To(Equal("default"))
@@ -39,7 +39,7 @@ var _ = Describe("KubernetesStore template", func() {
 			in.SetMeta(&rest_v1alpha1.ResourceMeta{Name: "foo.namespace", Mesh: "default"})
 
 			mapper := k8s.NewInferenceMapper("core-ns", &k8s.SimpleKubeFactory{KubeTypes: kubeTypes})
-			res, err := mapper.Map(in, "")
+			res, err := mapper(in, "")
 
 			Expect(err).ToNot(HaveOccurred())
 			Expect(res.GetMesh()).To(Equal("default"))
@@ -52,7 +52,7 @@ var _ = Describe("KubernetesStore template", func() {
 			in.SetMeta(&rest_v1alpha1.ResourceMeta{Name: "foo", Mesh: "default"})
 
 			mapper := k8s.NewInferenceMapper("core-ns", &k8s.SimpleKubeFactory{KubeTypes: kubeTypes})
-			res, err := mapper.Map(in, "my-ns")
+			res, err := mapper(in, "my-ns")
 
 			Expect(err).ToNot(HaveOccurred())
 			Expect(res.GetMesh()).To(Equal("default"))
@@ -66,7 +66,7 @@ var _ = Describe("KubernetesStore template", func() {
 			in.SetMeta(&k8s.KubernetesMetaAdapter{ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "a-namespace", Labels: map[string]string{"hello": "world"}}, Mesh: "default"})
 
 			mapper := k8s.NewKubernetesMapper(&k8s.SimpleKubeFactory{KubeTypes: kubeTypes})
-			res, err := mapper.Map(in, "")
+			res, err := mapper(in, "")
 
 			Expect(err).ToNot(HaveOccurred())
 			Expect(res.GetMesh()).To(Equal("default"))
@@ -80,7 +80,7 @@ var _ = Describe("KubernetesStore template", func() {
 			in.SetMeta(&k8s.KubernetesMetaAdapter{ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "a-namespace", Labels: map[string]string{"hello": "world"}}, Mesh: "default"})
 
 			mapper := k8s.NewKubernetesMapper(&k8s.SimpleKubeFactory{KubeTypes: kubeTypes})
-			res, err := mapper.Map(in, "my-ns")
+			res, err := mapper(in, "my-ns")
 
 			Expect(err).ToNot(HaveOccurred())
 			Expect(res.GetMesh()).To(Equal("default"))
@@ -98,7 +98,7 @@ var _ = Describe("KubernetesStore template", func() {
 			in.SetMeta(&rest_v1alpha1.ResourceMeta{Name: "foo", Mesh: "default"})
 
 			mapper := k8s.NewInferenceMapper("core-ns", &k8s.SimpleKubeFactory{KubeTypes: kubeTypes})
-			res, err := mapper.Map(in, "my-ns")
+			res, err := mapper(in, "my-ns")
 
 			Expect(err).ToNot(HaveOccurred())
 			Expect(res.GetMesh()).To(Equal("default"))
@@ -110,7 +110,7 @@ var _ = Describe("KubernetesStore template", func() {
 			in.SetMeta(&k8s.KubernetesMetaAdapter{ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "a-namespace", Labels: map[string]string{"hello": "world"}}, Mesh: "default"})
 
 			mapper := k8s.NewKubernetesMapper(&k8s.SimpleKubeFactory{KubeTypes: kubeTypes})
-			res, err := mapper.Map(in, "my-ns")
+			res, err := mapper(in, "my-ns")
 
 			Expect(err).ToNot(HaveOccurred())
 			Expect(res.GetMesh()).To(Equal("default"))

--- a/pkg/plugins/resources/k8s/mapper_test.go
+++ b/pkg/plugins/resources/k8s/mapper_test.go
@@ -6,7 +6,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
-	store2 "github.com/kumahq/kuma/pkg/config/core/resources/store"
 	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	rest_v1alpha1 "github.com/kumahq/kuma/pkg/core/resources/model/rest/v1alpha1"
 	core_mtp "github.com/kumahq/kuma/pkg/plugins/policies/meshtrafficpermission/api/v1alpha1"
@@ -22,11 +21,11 @@ var _ = Describe("KubernetesStore template", func() {
 		Expect(kubeTypes.RegisterObjectType(&core_mtp.MeshTrafficPermission{}, &k8s_mtp.MeshTrafficPermission{})).To(Succeed())
 		Expect(kubeTypes.RegisterObjectType(&mesh_proto.Mesh{}, &mesh_k8s.Mesh{})).To(Succeed())
 
-		It("works passing no namespace on memory store", func() {
+		It("works passing no namespace on inference", func() {
 			in := core_mtp.NewMeshTrafficPermissionResource()
 			in.SetMeta(&rest_v1alpha1.ResourceMeta{Name: "foo", Mesh: "default"})
 
-			mapper := k8s.NewMapper("core-ns", store2.MemoryStore, &k8s.SimpleKubeFactory{KubeTypes: kubeTypes})
+			mapper := k8s.NewInferenceMapper("core-ns", &k8s.SimpleKubeFactory{KubeTypes: kubeTypes})
 			res, err := mapper.Map(in, "")
 
 			Expect(err).ToNot(HaveOccurred())
@@ -35,11 +34,11 @@ var _ = Describe("KubernetesStore template", func() {
 			Expect(res.GetNamespace()).To(Equal("core-ns"))
 		})
 
-		It("works with namespace in name on memory store", func() {
+		It("works with namespace in name on inference", func() {
 			in := core_mtp.NewMeshTrafficPermissionResource()
 			in.SetMeta(&rest_v1alpha1.ResourceMeta{Name: "foo.namespace", Mesh: "default"})
 
-			mapper := k8s.NewMapper("core-ns", store2.MemoryStore, &k8s.SimpleKubeFactory{KubeTypes: kubeTypes})
+			mapper := k8s.NewInferenceMapper("core-ns", &k8s.SimpleKubeFactory{KubeTypes: kubeTypes})
 			res, err := mapper.Map(in, "")
 
 			Expect(err).ToNot(HaveOccurred())
@@ -48,11 +47,11 @@ var _ = Describe("KubernetesStore template", func() {
 			Expect(res.GetNamespace()).To(Equal("namespace"))
 		})
 
-		It("works passing namespace on memory store", func() {
+		It("works passing namespace on inference", func() {
 			in := core_mtp.NewMeshTrafficPermissionResource()
 			in.SetMeta(&rest_v1alpha1.ResourceMeta{Name: "foo", Mesh: "default"})
 
-			mapper := k8s.NewMapper("core-ns", store2.MemoryStore, &k8s.SimpleKubeFactory{KubeTypes: kubeTypes})
+			mapper := k8s.NewInferenceMapper("core-ns", &k8s.SimpleKubeFactory{KubeTypes: kubeTypes})
 			res, err := mapper.Map(in, "my-ns")
 
 			Expect(err).ToNot(HaveOccurred())
@@ -66,7 +65,7 @@ var _ = Describe("KubernetesStore template", func() {
 			in.SetMeta(&rest_v1alpha1.ResourceMeta{Name: "foo", Mesh: "default"})
 			in.SetMeta(&k8s.KubernetesMetaAdapter{ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "a-namespace", Labels: map[string]string{"hello": "world"}}, Mesh: "default"})
 
-			mapper := k8s.NewMapper("core-ns", store2.KubernetesStore, &k8s.SimpleKubeFactory{KubeTypes: kubeTypes})
+			mapper := k8s.NewKubernetesMapper(&k8s.SimpleKubeFactory{KubeTypes: kubeTypes})
 			res, err := mapper.Map(in, "")
 
 			Expect(err).ToNot(HaveOccurred())
@@ -80,7 +79,7 @@ var _ = Describe("KubernetesStore template", func() {
 			in := core_mtp.NewMeshTrafficPermissionResource()
 			in.SetMeta(&k8s.KubernetesMetaAdapter{ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "a-namespace", Labels: map[string]string{"hello": "world"}}, Mesh: "default"})
 
-			mapper := k8s.NewMapper("core-ns", store2.KubernetesStore, &k8s.SimpleKubeFactory{KubeTypes: kubeTypes})
+			mapper := k8s.NewKubernetesMapper(&k8s.SimpleKubeFactory{KubeTypes: kubeTypes})
 			res, err := mapper.Map(in, "my-ns")
 
 			Expect(err).ToNot(HaveOccurred())
@@ -94,11 +93,11 @@ var _ = Describe("KubernetesStore template", func() {
 		kubeTypes := k8s_registry.NewTypeRegistry()
 		Expect(kubeTypes.RegisterObjectType(&mesh_proto.Mesh{}, &mesh_k8s.Mesh{})).To(Succeed())
 
-		It("works with in memory", func() {
+		It("works with inference", func() {
 			in := core_mesh.NewMeshResource()
 			in.SetMeta(&rest_v1alpha1.ResourceMeta{Name: "foo", Mesh: "default"})
 
-			mapper := k8s.NewMapper("core-ns", store2.MemoryStore, &k8s.SimpleKubeFactory{KubeTypes: kubeTypes})
+			mapper := k8s.NewInferenceMapper("core-ns", &k8s.SimpleKubeFactory{KubeTypes: kubeTypes})
 			res, err := mapper.Map(in, "my-ns")
 
 			Expect(err).ToNot(HaveOccurred())
@@ -110,7 +109,7 @@ var _ = Describe("KubernetesStore template", func() {
 			in := core_mesh.NewMeshResource()
 			in.SetMeta(&k8s.KubernetesMetaAdapter{ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "a-namespace", Labels: map[string]string{"hello": "world"}}, Mesh: "default"})
 
-			mapper := k8s.NewMapper("core-ns", store2.KubernetesStore, &k8s.SimpleKubeFactory{KubeTypes: kubeTypes})
+			mapper := k8s.NewKubernetesMapper(&k8s.SimpleKubeFactory{KubeTypes: kubeTypes})
 			res, err := mapper.Map(in, "my-ns")
 
 			Expect(err).ToNot(HaveOccurred())

--- a/pkg/plugins/resources/k8s/mapper_test.go
+++ b/pkg/plugins/resources/k8s/mapper_test.go
@@ -1,0 +1,122 @@
+package k8s_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
+	store2 "github.com/kumahq/kuma/pkg/config/core/resources/store"
+	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
+	rest_v1alpha1 "github.com/kumahq/kuma/pkg/core/resources/model/rest/v1alpha1"
+	core_mtp "github.com/kumahq/kuma/pkg/plugins/policies/meshtrafficpermission/api/v1alpha1"
+	k8s_mtp "github.com/kumahq/kuma/pkg/plugins/policies/meshtrafficpermission/k8s/v1alpha1"
+	"github.com/kumahq/kuma/pkg/plugins/resources/k8s"
+	mesh_k8s "github.com/kumahq/kuma/pkg/plugins/resources/k8s/native/api/v1alpha1"
+	k8s_registry "github.com/kumahq/kuma/pkg/plugins/resources/k8s/native/pkg/registry"
+)
+
+var _ = Describe("KubernetesStore template", func() {
+	Context("on namespaced entity", func() {
+		kubeTypes := k8s_registry.NewTypeRegistry()
+		Expect(kubeTypes.RegisterObjectType(&core_mtp.MeshTrafficPermission{}, &k8s_mtp.MeshTrafficPermission{})).To(Succeed())
+		Expect(kubeTypes.RegisterObjectType(&mesh_proto.Mesh{}, &mesh_k8s.Mesh{})).To(Succeed())
+
+		It("works passing no namespace on memory store", func() {
+			in := core_mtp.NewMeshTrafficPermissionResource()
+			in.SetMeta(&rest_v1alpha1.ResourceMeta{Name: "foo", Mesh: "default"})
+
+			mapper := k8s.NewMapper("core-ns", store2.MemoryStore, &k8s.SimpleKubeFactory{KubeTypes: kubeTypes})
+			res, err := mapper.Map(in, "")
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(res.GetMesh()).To(Equal("default"))
+			Expect(res.GetName()).To(Equal("foo"))
+			Expect(res.GetNamespace()).To(Equal("core-ns"))
+		})
+
+		It("works with namespace in name on memory store", func() {
+			in := core_mtp.NewMeshTrafficPermissionResource()
+			in.SetMeta(&rest_v1alpha1.ResourceMeta{Name: "foo.namespace", Mesh: "default"})
+
+			mapper := k8s.NewMapper("core-ns", store2.MemoryStore, &k8s.SimpleKubeFactory{KubeTypes: kubeTypes})
+			res, err := mapper.Map(in, "")
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(res.GetMesh()).To(Equal("default"))
+			Expect(res.GetName()).To(Equal("foo"))
+			Expect(res.GetNamespace()).To(Equal("namespace"))
+		})
+
+		It("works passing namespace on memory store", func() {
+			in := core_mtp.NewMeshTrafficPermissionResource()
+			in.SetMeta(&rest_v1alpha1.ResourceMeta{Name: "foo", Mesh: "default"})
+
+			mapper := k8s.NewMapper("core-ns", store2.MemoryStore, &k8s.SimpleKubeFactory{KubeTypes: kubeTypes})
+			res, err := mapper.Map(in, "my-ns")
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(res.GetMesh()).To(Equal("default"))
+			Expect(res.GetName()).To(Equal("foo"))
+			Expect(res.GetNamespace()).To(Equal("my-ns"))
+		})
+
+		It("works passing no namespace on k8s store", func() {
+			in := core_mtp.NewMeshTrafficPermissionResource()
+			in.SetMeta(&rest_v1alpha1.ResourceMeta{Name: "foo", Mesh: "default"})
+			in.SetMeta(&k8s.KubernetesMetaAdapter{ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "a-namespace", Labels: map[string]string{"hello": "world"}}, Mesh: "default"})
+
+			mapper := k8s.NewMapper("core-ns", store2.KubernetesStore, &k8s.SimpleKubeFactory{KubeTypes: kubeTypes})
+			res, err := mapper.Map(in, "")
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(res.GetMesh()).To(Equal("default"))
+			Expect(res.GetName()).To(Equal("foo"))
+			Expect(res.GetNamespace()).To(Equal("a-namespace"))
+			Expect(res.GetLabels()).To(Equal(map[string]string{"hello": "world"}))
+		})
+
+		It("works passing namespace on k8s store", func() {
+			in := core_mtp.NewMeshTrafficPermissionResource()
+			in.SetMeta(&k8s.KubernetesMetaAdapter{ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "a-namespace", Labels: map[string]string{"hello": "world"}}, Mesh: "default"})
+
+			mapper := k8s.NewMapper("core-ns", store2.KubernetesStore, &k8s.SimpleKubeFactory{KubeTypes: kubeTypes})
+			res, err := mapper.Map(in, "my-ns")
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(res.GetMesh()).To(Equal("default"))
+			Expect(res.GetName()).To(Equal("foo"))
+			Expect(res.GetNamespace()).To(Equal("my-ns"))
+			Expect(res.GetLabels()).To(Equal(map[string]string{"hello": "world"}))
+		})
+	})
+	Context("on cluster scoped entity", func() {
+		kubeTypes := k8s_registry.NewTypeRegistry()
+		Expect(kubeTypes.RegisterObjectType(&mesh_proto.Mesh{}, &mesh_k8s.Mesh{})).To(Succeed())
+
+		It("works with in memory", func() {
+			in := core_mesh.NewMeshResource()
+			in.SetMeta(&rest_v1alpha1.ResourceMeta{Name: "foo", Mesh: "default"})
+
+			mapper := k8s.NewMapper("core-ns", store2.MemoryStore, &k8s.SimpleKubeFactory{KubeTypes: kubeTypes})
+			res, err := mapper.Map(in, "my-ns")
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(res.GetMesh()).To(Equal("default"))
+			Expect(res.GetName()).To(Equal("foo"))
+		})
+
+		It("works with kubernetes", func() {
+			in := core_mesh.NewMeshResource()
+			in.SetMeta(&k8s.KubernetesMetaAdapter{ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "a-namespace", Labels: map[string]string{"hello": "world"}}, Mesh: "default"})
+
+			mapper := k8s.NewMapper("core-ns", store2.KubernetesStore, &k8s.SimpleKubeFactory{KubeTypes: kubeTypes})
+			res, err := mapper.Map(in, "my-ns")
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(res.GetMesh()).To(Equal("default"))
+			Expect(res.GetName()).To(Equal("foo"))
+			Expect(res.GetLabels()).To(Equal(map[string]string{"hello": "world"}))
+		})
+	})
+})

--- a/test/e2e_env/kubernetes/api/api.go
+++ b/test/e2e_env/kubernetes/api/api.go
@@ -7,12 +7,12 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"github.com/kumahq/kuma/test/framework/envs/universal"
+	"github.com/kumahq/kuma/test/framework/envs/kubernetes"
 )
 
 func Api() {
 	It("Works with /policies", func() {
-		r, err := http.Get(universal.Cluster.GetKuma().GetAPIServerAddress() + "/policies")
+		r, err := http.Get(kubernetes.Cluster.GetKuma().GetAPIServerAddress() + "/policies")
 		Expect(err).ToNot(HaveOccurred())
 		defer r.Body.Close()
 
@@ -22,7 +22,7 @@ func Api() {
 	})
 
 	It("Works with /", func() {
-		r, err := http.Get(universal.Cluster.GetKuma().GetAPIServerAddress())
+		r, err := http.Get(kubernetes.Cluster.GetKuma().GetAPIServerAddress())
 		Expect(err).ToNot(HaveOccurred())
 		defer r.Body.Close()
 
@@ -32,7 +32,7 @@ func Api() {
 	})
 
 	It("Get k8s version of default mesh", func() {
-		r, err := http.Get(universal.Cluster.GetKuma().GetAPIServerAddress() + "/meshes/default?format=k8s")
+		r, err := http.Get(kubernetes.Cluster.GetKuma().GetAPIServerAddress() + "/meshes/default?format=k8s")
 		Expect(err).ToNot(HaveOccurred())
 		defer r.Body.Close()
 
@@ -44,8 +44,8 @@ func Api() {
 		Expect(res["apiVersion"]).To(Equal("kuma.io/v1alpha1"))
 	})
 
-	It("Get universal version of default mesh", func() {
-		r, err := http.Get(universal.Cluster.GetKuma().GetAPIServerAddress() + "/meshes/default")
+	It("Get kubernetes version of default mesh", func() {
+		r, err := http.Get(kubernetes.Cluster.GetKuma().GetAPIServerAddress() + "/meshes/default")
 		Expect(err).ToNot(HaveOccurred())
 		defer r.Body.Close()
 

--- a/test/e2e_env/kubernetes/kubernetes_suite_test.go
+++ b/test/e2e_env/kubernetes/kubernetes_suite_test.go
@@ -6,6 +6,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 
 	"github.com/kumahq/kuma/pkg/test"
+	"github.com/kumahq/kuma/test/e2e_env/kubernetes/api"
 	"github.com/kumahq/kuma/test/e2e_env/kubernetes/container_patch"
 	"github.com/kumahq/kuma/test/e2e_env/kubernetes/defaults"
 	"github.com/kumahq/kuma/test/e2e_env/kubernetes/externalservices"
@@ -76,4 +77,5 @@ var (
 	_ = Describe("MeshProxyPatch", meshproxypatch.MeshProxyPatch, Ordered)
 	_ = Describe("MeshFaultInjection", meshfaultinjection.API, Ordered)
 	_ = Describe("MeshHTTPRoute", meshhttproute.Test, Ordered)
+	_ = Describe("Apis", api.Api, Ordered)
 )


### PR DESCRIPTION
For any GET call an optional parameter `?format=k8s` can be passed to get the resource as a k8s resource.
You can also use `?namespace=<whatever>` to use a override the namespace.

This aims to have the UI always show universal resources and only provide a `copy as k8s` button that does this call.

Fix #6658

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [x] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
