### PR TITLE
chore(GatewayAPI): allow gatewayapi group name for GAMMA parentRefs

### DIFF
--- a/pkg/plugins/runtime/k8s/controllers/gatewayapi/attachment/attachment.go
+++ b/pkg/plugins/runtime/k8s/controllers/gatewayapi/attachment/attachment.go
@@ -220,9 +220,9 @@ func EvaluateParentRefAttachment(
 	ref gatewayapi.ParentReference,
 ) (Attachment, error) {
 	switch {
-	case *ref.Group == gatewayapi.Group(gatewayapi.GroupVersion.Group) && *ref.Kind == "Gateway":
+	case *ref.Kind == "Gateway" && *ref.Group == gatewayapi.GroupName:
 		return evaluateGatewayAttachment(ctx, client, routeHostnames, routeNs, ref)
-	case *ref.Group == kube_core.GroupName && *ref.Kind == "Service":
+	case *ref.Kind == "Service" && (*ref.Group == kube_core.GroupName || *ref.Group == gatewayapi.GroupName):
 		// Attaching to a Service can only affect requests coming from Services
 		// in the same Namespace or requests going to the Service.
 		return Allowed, nil

--- a/pkg/plugins/runtime/k8s/controllers/gatewayapi/http_route_controller.go
+++ b/pkg/plugins/runtime/k8s/controllers/gatewayapi/http_route_controller.go
@@ -149,14 +149,14 @@ func (r *HTTPRouteReconciler) gapiToKumaRoutes(
 			continue
 		case attachment.Allowed:
 			switch {
-			case *ref.Kind == gatewayapi.Kind("Gateway") && *ref.Group == gatewayapi.GroupName:
+			case *ref.Kind == "Gateway" && *ref.Group == gatewayapi.GroupName:
 				selectors = append(
 					selectors,
 					&mesh_proto.Selector{
 						Match: tagsForRef(route, ref),
 					},
 				)
-			case *ref.Kind == gatewayapi.Kind("Service") && *ref.Group == kube_core.GroupName:
+			case *ref.Kind == "Service" && (*ref.Group == kube_core.GroupName || *ref.Group == gatewayapi.GroupName):
 				namespace := route.Namespace
 				if ref.Namespace != nil {
 					namespace = string(*ref.Namespace)


### PR DESCRIPTION
This is the default for this field so don't be strict about setting `: ""`.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [x] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
