### PR TITLE
ci(mk): use KUMA_DIR in metallb resources path

### DIFF
--- a/mk/k3d.mk
+++ b/mk/k3d.mk
@@ -104,7 +104,7 @@ k3d/configure/metallb:
 	SUBNET=$$(docker network inspect kind --format '{{ (index .IPAM.Config 0).Subnet }}'); if [ $${SUBNET} != "172.18.0.0/16" ]; then \
 		   echo "Unexpected docker network, expecting 172.18.0.0/16"; exit 1; \
 	fi
-	KUBECONFIG=$(KIND_KUBECONFIG) $(KUBECTL) apply -f mk/metallb-k3d-$(KIND_CLUSTER_NAME).yaml
+	KUBECONFIG=$(KIND_KUBECONFIG) $(KUBECTL) apply -f $(KUMA_DIR)/mk/metallb-k3d-$(KIND_CLUSTER_NAME).yaml
 
 .PHONY: k3d/wait
 k3d/wait:


### PR DESCRIPTION
### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [x] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
