### PR TITLE
test(e2e): configurable headers to api requests

### DIFF
--- a/mk/k3d.mk
+++ b/mk/k3d.mk
@@ -44,6 +44,7 @@ K3D_CLUSTER_CREATE_OPTS ?= -i rancher/k3s:$(CI_K3S_VERSION) \
 	--k3s-arg '--disable=traefik@server:0' \
 	--k3s-arg '--disable=metrics-server@server:0' \
 	--k3s-arg '--disable=servicelb@server:0' \
+	--volume '$(TOP)/test/framework/deployments:/tmp/deployments@server:0' \
 	--network kind \
 	--port "$(PORT_PREFIX)80-$(PORT_PREFIX)99:30080-30099@server:0" \
 	--timeout 120s

--- a/test/e2e_env/universal/auth/offline_auth.go
+++ b/test/e2e_env/universal/auth/offline_auth.go
@@ -87,6 +87,7 @@ dpServer:
 			"test-admin",
 			universal.GetKuma().GetAPIServerAddress(),
 			token,
+			[]string{},
 		)
 
 		// then the new admin can access secrets

--- a/test/e2e_env/universal/auth/user_auth.go
+++ b/test/e2e_env/universal/auth/user_auth.go
@@ -24,6 +24,7 @@ func UserAuth() {
 			"test-admin",
 			universal.Cluster.GetKuma().GetAPIServerAddress(),
 			token,
+			nil,
 		)
 
 		// then the new admin can access secrets
@@ -46,6 +47,7 @@ func UserAuth() {
 			"test-user",
 			universal.Cluster.GetKuma().GetAPIServerAddress(),
 			token,
+			nil,
 		)
 
 		// then the new member can access dataplanes but not secrets because they are not admin

--- a/test/framework/deployments/postgres/deployment.go
+++ b/test/framework/deployments/postgres/deployment.go
@@ -38,12 +38,13 @@ type PostgresDeployment interface {
 }
 
 type deployOptions struct {
-	namespace      string
-	deploymentName string
-	username       string
-	password       string
-	database       string
-	primaryName    string
+	namespace        string
+	deploymentName   string
+	username         string
+	password         string
+	database         string
+	primaryName      string
+	postgresPassword string
 }
 type DeployOptionsFunc func(*deployOptions)
 
@@ -98,5 +99,11 @@ func WithDatabase(database string) DeployOptionsFunc {
 func WithPrimaryName(primaryName string) DeployOptionsFunc {
 	return func(o *deployOptions) {
 		o.primaryName = primaryName
+	}
+}
+
+func WithPostgresPassword(postgresPassword string) DeployOptionsFunc {
+	return func(o *deployOptions) {
+		o.postgresPassword = postgresPassword
 	}
 }

--- a/test/framework/deployments/postgres/kubernetes.go
+++ b/test/framework/deployments/postgres/kubernetes.go
@@ -26,10 +26,11 @@ func (t *k8SDeployment) Name() string {
 func (t *k8SDeployment) Deploy(cluster framework.Cluster) error {
 	helmOpts := &helm.Options{
 		SetValues: map[string]string{
-			"global.postgresql.auth.username": t.options.username,
-			"global.postgresql.auth.password": t.options.password,
-			"global.postgresql.auth.database": t.options.database,
-			"postgresql.primary.fullname":     t.options.primaryName,
+			"global.postgresql.auth.postgresPassword": t.options.postgresPassword,
+			"global.postgresql.auth.username":         t.options.username,
+			"global.postgresql.auth.password":         t.options.password,
+			"global.postgresql.auth.database":         t.options.database,
+			"postgresql.primary.fullname":             t.options.primaryName,
 		},
 		KubectlOptions: cluster.GetKubectlOptions(t.options.namespace),
 	}

--- a/test/framework/envs/kubernetes/env.go
+++ b/test/framework/envs/kubernetes/env.go
@@ -61,6 +61,7 @@ func RestoreState(bytes []byte) {
 		Cluster,
 		Cluster.Verbose(),
 		1,
+		nil, // headers were not configured in setup
 	)
 	Expect(cp.FinalizeAddWithPortFwd(portFwd)).To(Succeed())
 	Cluster.SetCP(cp)

--- a/test/framework/envs/multizone/env.go
+++ b/test/framework/envs/multizone/env.go
@@ -175,6 +175,7 @@ func RestoreState(bytes []byte) {
 		Global.Name(),
 		Global.Verbose(),
 		state.Global.KumaCp,
+		nil,
 	)
 	Expect(err).ToNot(HaveOccurred())
 	Global.SetCp(cp)
@@ -188,6 +189,7 @@ func RestoreState(bytes []byte) {
 		KubeZone1,
 		KubeZone1.Verbose(),
 		1,
+		nil,
 	)
 	Expect(kubeCp.FinalizeAddWithPortFwd(state.KubeZone1.KumaCp)).To(Succeed())
 	KubeZone1.SetCP(kubeCp)
@@ -203,6 +205,7 @@ func RestoreState(bytes []byte) {
 		KubeZone2,
 		KubeZone2.Verbose(),
 		1,
+		nil, // headers were not configured in setup
 	)
 	Expect(kubeCp.FinalizeAddWithPortFwd(state.KubeZone2.KumaCp)).To(Succeed())
 	KubeZone2.SetCP(kubeCp)
@@ -217,6 +220,7 @@ func RestoreState(bytes []byte) {
 		UniZone1.Name(),
 		UniZone1.Verbose(),
 		state.UniZone1.KumaCp,
+		nil, // headers were not configured in setup
 	)
 	Expect(err).ToNot(HaveOccurred())
 	UniZone1.SetCp(cp)
@@ -231,6 +235,7 @@ func RestoreState(bytes []byte) {
 		UniZone2.Name(),
 		UniZone2.Verbose(),
 		state.UniZone2.KumaCp,
+		nil, // headers were not configured in setup
 	)
 	Expect(err).ToNot(HaveOccurred())
 	UniZone2.SetCp(cp)

--- a/test/framework/envs/universal/env.go
+++ b/test/framework/envs/universal/env.go
@@ -49,6 +49,7 @@ func RestoreState(bytes []byte) {
 		Cluster.Name(),
 		Cluster.Verbose(),
 		state.KumaCp,
+		nil, // headers were not configured in setup
 	)
 	Expect(err).ToNot(HaveOccurred())
 	Expect(Cluster.AddNetworking(state.ZoneEgress, framework.Config.ZoneEgressApp)).To(Succeed())

--- a/test/framework/interface.go
+++ b/test/framework/interface.go
@@ -47,6 +47,7 @@ type kumaDeploymentOptions struct {
 	runPostgresMigration        bool
 	yamlConfig                  string
 	transparentProxyV1          bool
+	apiHeaders                  []string
 
 	// Functions to apply to each mesh after the control plane
 	// is provisioned.
@@ -350,6 +351,12 @@ type MeshUpdateFunc func(mesh *mesh_proto.Mesh) *mesh_proto.Mesh
 func WithMeshUpdate(mesh string, u MeshUpdateFunc) KumaDeploymentOption {
 	return KumaOptionFunc(func(o *kumaDeploymentOptions) {
 		o.meshUpdateFuncs[mesh] = append(o.meshUpdateFuncs[mesh], u)
+	})
+}
+
+func WithApiHeaders(headers ...string) KumaDeploymentOption {
+	return KumaOptionFunc(func(o *kumaDeploymentOptions) {
+		o.apiHeaders = headers
 	})
 }
 

--- a/test/framework/k8s_cluster.go
+++ b/test/framework/k8s_cluster.go
@@ -528,7 +528,7 @@ func (c *K8sCluster) DeployKuma(mode core.CpMode, opt ...KumaDeploymentOption) e
 		replicas = c.opts.cpReplicas
 	}
 
-	c.controlplane = NewK8sControlPlane(c.t, mode, c.name, c.kubeconfig, c, c.verbose, replicas)
+	c.controlplane = NewK8sControlPlane(c.t, mode, c.name, c.kubeconfig, c, c.verbose, replicas, c.opts.apiHeaders)
 
 	switch mode {
 	case core.Zone:

--- a/test/framework/k8s_controlplane.go
+++ b/test/framework/k8s_controlplane.go
@@ -192,7 +192,7 @@ func (c *K8sControlPlane) FinalizeAddWithPortFwd(portFwd PortFwd) error {
 }
 
 func (c *K8sControlPlane) retrieveAdminToken() (string, error) {
-	if c.cluster.opts.env["KUMA_API_SERVER_AUTHN_TYPE"] != "tokens" {
+	if authnType, exist := c.cluster.opts.env["KUMA_API_SERVER_AUTHN_TYPE"]; exist && authnType != "tokens" {
 		return "", nil
 	}
 	if c.cluster.opts.helmOpts["controlPlane.environment"] == "universal" {

--- a/test/framework/kumactl.go
+++ b/test/framework/kumactl.go
@@ -160,7 +160,7 @@ func (k *KumactlOptions) KumactlInstallObservability(namespace string, component
 	return k.RunKumactlAndGetOutput(args...)
 }
 
-func (k *KumactlOptions) KumactlConfigControlPlanesAdd(name, address, token string) error {
+func (k *KumactlOptions) KumactlConfigControlPlanesAdd(name, address, token string, headers []string) error {
 	_, err := retry.DoWithRetryE(k.t, "kumactl config control-planes add", DefaultRetries, DefaultTimeout,
 		func() (string, error) {
 			args := []string{
@@ -168,6 +168,9 @@ func (k *KumactlOptions) KumactlConfigControlPlanesAdd(name, address, token stri
 				"--overwrite",
 				"--name", name,
 				"--address", address,
+			}
+			if len(headers) > 0 {
+				args = append(args, "--headers", strings.Join(headers, ","))
 			}
 			if token != "" {
 				args = append(args,
@@ -184,6 +187,10 @@ func (k *KumactlOptions) KumactlConfigControlPlanesAdd(name, address, token stri
 		})
 
 	return err
+}
+
+func (k *KumactlOptions) KumactlConfigControlPlanesSwitch(name string) error {
+	return k.RunKumactl("config", "control-planes", "switch", "--name", name)
 }
 
 // KumactlUpdateObject fetches an object and updates it after the update function is applied to it.

--- a/test/framework/universal_cluster.go
+++ b/test/framework/universal_cluster.go
@@ -177,7 +177,7 @@ func (c *UniversalCluster) DeployKuma(mode core.CpMode, opt ...KumaDeploymentOpt
 		ApiServerPort: app.ports["5681"],
 		SshPort:       app.ports["22"],
 	}
-	c.controlplane, err = NewUniversalControlPlane(c.t, mode, c.name, c.verbose, pf)
+	c.controlplane, err = NewUniversalControlPlane(c.t, mode, c.name, c.verbose, pf, c.opts.apiHeaders)
 	if err != nil {
 		return err
 	}

--- a/test/framework/universal_controlplane.go
+++ b/test/framework/universal_controlplane.go
@@ -31,6 +31,7 @@ func NewUniversalControlPlane(
 	clusterName string,
 	verbose bool,
 	networking UniversalNetworking,
+	apiHeaders []string,
 ) (*UniversalControlPlane, error) {
 	name := clusterName + "-" + mode
 	kumactl := NewKumactlOptions(t, name, verbose)
@@ -47,7 +48,7 @@ func NewUniversalControlPlane(
 		return nil, err
 	}
 
-	if err := kumactl.KumactlConfigControlPlanesAdd(clusterName, ucp.GetAPIServerAddress(), token); err != nil {
+	if err := kumactl.KumactlConfigControlPlanesAdd(clusterName, ucp.GetAPIServerAddress(), token, apiHeaders); err != nil {
 		return nil, err
 	}
 	return ucp, nil
@@ -148,6 +149,10 @@ func (c *UniversalControlPlane) generateToken(
 }
 
 func (c *UniversalControlPlane) retrieveAdminToken() (string, error) {
+	if c.kumactl.Env["KUMA_API_SERVER_AUTHN_TYPE"] != "tokens" {
+		return "", nil
+	}
+
 	return retry.DoWithRetryE(
 		c.t, "fetching user admin token",
 		DefaultRetries,

--- a/test/framework/universal_controlplane.go
+++ b/test/framework/universal_controlplane.go
@@ -149,10 +149,6 @@ func (c *UniversalControlPlane) generateToken(
 }
 
 func (c *UniversalControlPlane) retrieveAdminToken() (string, error) {
-	if c.kumactl.Env["KUMA_API_SERVER_AUTHN_TYPE"] != "tokens" {
-		return "", nil
-	}
-
 	return retry.DoWithRetryE(
 		c.t, "fetching user admin token",
 		DefaultRetries,


### PR DESCRIPTION
### Checklist prior to review

* Add functionality to add headers to API requests.
* Skip retrieving admin tokens if auth type is different.
* Add functionality to configure postgres password.
* Don't know exactly why volume mount was added, see PR below.

Deprecates https://github.com/kumahq/kuma/pull/6642

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [ ] [Link to relevant issue][1] as well as docs and UI issues --
- [ ] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [ ] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [ ] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [ ] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [ ] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
