### PR TITLE
ci(.circleci): don't prefix all jobs with 'test/e2e'

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -226,7 +226,7 @@ jobs:
       target:
         description: makefile target
         type: string
-        default: "test/e2e"
+        default: "e2e"
       arch:
         description: The golang arch
         type: string
@@ -251,7 +251,7 @@ jobs:
       - when:
           condition:
             or:
-              - {equal: [test/e2e, << parameters.target >>]}
+              - {equal: [e2e, << parameters.target >>]}
               - {equal: [calico, << parameters.cniNetworkPlugin >>]}
               - {equal: [kindIpv6, << parameters.k8sVersion >>]}
               - {equal: [arm64, << parameters.arch >>]}
@@ -278,10 +278,10 @@ jobs:
             }
 
             # Handle invalid test combinations
-            if [[ "<< parameters.k8sVersion >>" == "kind" && "<< parameters.target >>" != "test/e2e-universal" ]]; then
-              skip "kind should only be used when testing ipv6 or with test/e2e-universal"
+            if [[ "<< parameters.k8sVersion >>" == "kind" && "<< parameters.target >>" != "e2e-universal" ]]; then
+              skip "kind should only be used when testing ipv6 or with e2e-universal"
             fi
-            if [[ "<< parameters.k8sVersion >>" != kind* && "<< parameters.target >>" == "test/e2e-universal" ]]; then
+            if [[ "<< parameters.k8sVersion >>" != kind* && "<< parameters.target >>" == "e2e-universal" ]]; then
               skip "universal only runs on kind"
             fi
             echo "Continuing tests"
@@ -336,11 +336,11 @@ jobs:
               export KUMA_DELTA_KDS=true
             fi
 
-            if [[ "<< parameters.target >>" == "test/e2e" ]]; then
+            if [[ "<< parameters.target >>" == "e2e" ]]; then
               export GINKGO_E2E_LABEL_FILTERS="job-$CIRCLE_NODE_INDEX"
             fi
             env
-            make ${MAKE_PARAMETERS} CI=true << parameters.target >>
+            make ${MAKE_PARAMETERS} CI=true test/<< parameters.target >>
       - store_test_results:
           path: build/reports
       - store_artifacts:
@@ -464,46 +464,46 @@ workflows:
               arch: [amd64, arm64]
           requires: [build, go_cache-vm-<< matrix.arch >>]
       - e2e:
-          name: test/e2e-legacy-k8s:<< matrix.arch >>-<< matrix.k8sVersion >>
+          name: e2e-legacy-k8s:<< matrix.arch >>-<< matrix.k8sVersion >>
           matrix:
-            alias: test/e2e-legacy
+            alias: e2e-legacy
             parameters:
               k8sVersion: [<< pipeline.parameters.first_k8s_version >>, << pipeline.parameters.last_k8s_version >>, kind, kindIpv6]
               arch: [amd64, arm64]
           parallelism: 3
-          target: test/e2e
+          target: e2e
           requires: [build, go_cache-vm-<< matrix.arch >>]
       - e2e:
           name: << matrix.target >>:<< matrix.arch >>-<< matrix.k8sVersion >>
           matrix:
-            alias: test/e2e
+            alias: e2e
             parameters:
               k8sVersion: [<< pipeline.parameters.first_k8s_version >>, << pipeline.parameters.last_k8s_version >>, kind, kindIpv6]
-              target: [test/e2e-kubernetes, test/e2e-universal, test/e2e-multizone]
+              target: [e2e-kubernetes, e2e-universal, e2e-multizone]
               arch: [amd64, arm64]
           requires: [build, go_cache-vm-<< matrix.arch >>]
       - e2e:
           name: << matrix.target >>:<< matrix.arch >>-<< matrix.k8sVersion >>-delta-kds
           matrix:
-            alias: test/e2e-delta-kds
+            alias: e2e-delta-kds
             parameters:
               k8sVersion: [<< pipeline.parameters.last_k8s_version >>]
-              target: [test/e2e-multizone]
+              target: [e2e-multizone]
               arch: [amd64]
               deltaKDS: [true]
           requires: [build, go_cache-vm-amd64]
       - e2e:
           name: << matrix.target >>:<< matrix.arch >>-<< matrix.k8sVersion >>-calico
           matrix:
-            alias: test/e2e-calico
+            alias: e2e-calico
             parameters:
               k8sVersion: [<< pipeline.parameters.last_k8s_version >>]
-              target: [test/e2e-multizone]
+              target: [e2e-multizone]
               arch: [amd64]
               cniNetworkPlugin: [calico]
           requires: [build, go_cache-vm-amd64]
       - container-structure:
-          name: test/container-structure
+          name: container-structure
           requires: [build]
       - distributions:
-          requires: [test, test/e2e, test/e2e-legacy, test/container-structure]
+          requires: [test, e2e, e2e-legacy, container-structure]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -224,9 +224,9 @@ jobs:
         type: integer
         default: 1
       target:
-        description: makefile target
+        description: makefile target without test/e2e prefix
         type: string
-        default: "e2e"
+        default: ""
       arch:
         description: The golang arch
         type: string
@@ -278,10 +278,10 @@ jobs:
             }
 
             # Handle invalid test combinations
-            if [[ "<< parameters.k8sVersion >>" == "kind" && "<< parameters.target >>" != "e2e-universal" ]]; then
+            if [[ "<< parameters.k8sVersion >>" == "kind" && "<< parameters.target >>" != "universal" ]]; then
               skip "kind should only be used when testing ipv6 or with e2e-universal"
             fi
-            if [[ "<< parameters.k8sVersion >>" != kind* && "<< parameters.target >>" == "e2e-universal" ]]; then
+            if [[ "<< parameters.k8sVersion >>" != kind* && "<< parameters.target >>" == "universal" ]]; then
               skip "universal only runs on kind"
             fi
             echo "Continuing tests"
@@ -336,11 +336,16 @@ jobs:
               export KUMA_DELTA_KDS=true
             fi
 
-            if [[ "<< parameters.target >>" == "e2e" ]]; then
+            if [[ "<< parameters.target >>" == "" ]]; then
               export GINKGO_E2E_LABEL_FILTERS="job-$CIRCLE_NODE_INDEX"
             fi
             env
-            make ${MAKE_PARAMETERS} CI=true test/<< parameters.target >>
+            if [[ "<< parameters.target >>" != "" ]]; then
+              target="test/e2e-<< parameters.target >>"
+            else
+              target="test/e2e"
+            fi
+            make ${MAKE_PARAMETERS} CI=true "${target}"
       - store_test_results:
           path: build/reports
       - store_artifacts:
@@ -464,14 +469,14 @@ workflows:
               arch: [amd64, arm64]
           requires: [build, go_cache-vm-<< matrix.arch >>]
       - e2e:
-          name: e2e-legacy-k8s:<< matrix.arch >>-<< matrix.k8sVersion >>
+          name: legacy-k8s:<< matrix.arch >>-<< matrix.k8sVersion >>
           matrix:
-            alias: e2e-legacy
+            alias: legacy
             parameters:
               k8sVersion: [<< pipeline.parameters.first_k8s_version >>, << pipeline.parameters.last_k8s_version >>, kind, kindIpv6]
               arch: [amd64, arm64]
           parallelism: 3
-          target: e2e
+          target: ""
           requires: [build, go_cache-vm-<< matrix.arch >>]
       - e2e:
           name: << matrix.target >>:<< matrix.arch >>-<< matrix.k8sVersion >>
@@ -479,26 +484,26 @@ workflows:
             alias: e2e
             parameters:
               k8sVersion: [<< pipeline.parameters.first_k8s_version >>, << pipeline.parameters.last_k8s_version >>, kind, kindIpv6]
-              target: [e2e-kubernetes, e2e-universal, e2e-multizone]
+              target: [kubernetes, universal, multizone]
               arch: [amd64, arm64]
           requires: [build, go_cache-vm-<< matrix.arch >>]
       - e2e:
           name: << matrix.target >>:<< matrix.arch >>-<< matrix.k8sVersion >>-delta-kds
           matrix:
-            alias: e2e-delta-kds
+            alias: delta-kds
             parameters:
               k8sVersion: [<< pipeline.parameters.last_k8s_version >>]
-              target: [e2e-multizone]
+              target: [multizone]
               arch: [amd64]
               deltaKDS: [true]
           requires: [build, go_cache-vm-amd64]
       - e2e:
           name: << matrix.target >>:<< matrix.arch >>-<< matrix.k8sVersion >>-calico
           matrix:
-            alias: e2e-calico
+            alias: calico
             parameters:
               k8sVersion: [<< pipeline.parameters.last_k8s_version >>]
-              target: [e2e-multizone]
+              target: [multizone]
               arch: [amd64]
               cniNetworkPlugin: [calico]
           requires: [build, go_cache-vm-amd64]
@@ -506,4 +511,4 @@ workflows:
           name: container-structure
           requires: [build]
       - distributions:
-          requires: [test, e2e, e2e-legacy, container-structure]
+          requires: [test, e2e, legacy, container-structure]

--- a/mk/k3d.mk
+++ b/mk/k3d.mk
@@ -55,7 +55,7 @@ endif
 
 ifdef CI
 ifeq ($(GOOS),linux)
-ifneq (,$(findstring e2e-legacy,$(CIRCLE_JOB)))
+ifneq (,$(findstring legacy,$(CIRCLE_JOB)))
 	K3D_CLUSTER_CREATE_OPTS += --volume "/sys/fs/bpf:/sys/fs/bpf:shared"
 endif
 endif


### PR DESCRIPTION
The CircleCI UI is horrible and everything after `:` is hidden.

See [before](https://app.circleci.com/pipelines/github/kumahq/kuma/21807/workflows/dfa05249-ea74-4a76-9f62-6fe5901b7d67) vs ~[after](https://app.circleci.com/pipelines/github/kumahq/kuma/21815/workflows/f54ff654-affe-4474-bd22-4c9a82205e96)~ [after](https://app.circleci.com/pipelines/github/kumahq/kuma/21895/workflows/820c2cb7-da85-4e3b-ba46-a1346c783dc6)

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [x] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
