### PR TITLE
fix(GatewayAPI): respect Service port in parentRef

### DIFF
--- a/pkg/plugins/runtime/k8s/controllers/gatewayapi/http_route_controller.go
+++ b/pkg/plugins/runtime/k8s/controllers/gatewayapi/http_route_controller.go
@@ -169,7 +169,7 @@ func (r *HTTPRouteReconciler) gapiToKumaRoutes(
 					}
 					continue // TODO what does the spec say? does NoMatchingParent apply?
 				}
-				services = append(services, serviceAndPorts(&svc))
+				services = append(services, serviceAndPorts(&svc, ref.Port))
 			}
 		default:
 			var reason string

--- a/pkg/plugins/runtime/k8s/controllers/gatewayapi/mesh_http_route_conversion.go
+++ b/pkg/plugins/runtime/k8s/controllers/gatewayapi/mesh_http_route_conversion.go
@@ -22,10 +22,13 @@ type ServiceAndPorts struct {
 	Ports []int32
 }
 
-func serviceAndPorts(svc *kube_core.Service) ServiceAndPorts {
+func serviceAndPorts(svc *kube_core.Service, port *gatewayapi.PortNumber) ServiceAndPorts {
 	var ports []int32
 	for _, port := range svc.Spec.Ports {
 		ports = append(ports, port.Port)
+	}
+	if port != nil {
+		ports = []int32{int32(*port)}
 	}
 	return ServiceAndPorts{
 		Name:  kube_client.ObjectKeyFromObject(svc),


### PR DESCRIPTION
> Changelog: skip

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues -- https://github.com/kumahq/kuma/issues/6508
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [x] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
