### PR TITLE
feat(kds): multitenancy

### DIFF
--- a/pkg/kds/v2/reconcile/reconciler.go
+++ b/pkg/kds/v2/reconcile/reconciler.go
@@ -158,5 +158,6 @@ func (r *reconciler) hashId(ctx context.Context, node *envoy_core.Node) (string,
 	if err != nil {
 		return "", err
 	}
-	return r.hasher.ID(node) + tenantID, nil
+	util_kds_v2.FillTenantMetadata(tenantID, node)
+	return r.hasher.ID(node), nil
 }

--- a/pkg/kds/v2/server/server_suite_test.go
+++ b/pkg/kds/v2/server/server_suite_test.go
@@ -1,0 +1,11 @@
+package server_test
+
+import (
+	"testing"
+
+	"github.com/kumahq/kuma/pkg/test"
+)
+
+func TestServer(t *testing.T) {
+	test.RunSpecs(t, "Server Suite")
+}

--- a/pkg/kds/v2/server/tenant_callback.go
+++ b/pkg/kds/v2/server/tenant_callback.go
@@ -1,0 +1,52 @@
+package server
+
+import (
+	"context"
+	"errors"
+	"sync"
+
+	envoy_sd "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
+	envoy_xds "github.com/envoyproxy/go-control-plane/pkg/server/v3"
+
+	"github.com/kumahq/kuma/pkg/kds/v2/util"
+	"github.com/kumahq/kuma/pkg/multitenant"
+	util_xds_v3 "github.com/kumahq/kuma/pkg/util/xds/v3"
+)
+
+type tenancyCallbacks struct {
+	tenants multitenant.Tenants
+
+	sync.RWMutex
+	streamToCtx map[int64]context.Context
+	util_xds_v3.NoopCallbacks
+}
+
+func NewTenancyCallbacks(tenants multitenant.Tenants) envoy_xds.Callbacks {
+	return &tenancyCallbacks{
+		tenants:     tenants,
+		streamToCtx: map[int64]context.Context{},
+	}
+}
+
+func (c *tenancyCallbacks) OnDeltaStreamOpen(ctx context.Context, streamID int64, _ string) error {
+	c.Lock()
+	c.streamToCtx[streamID] = ctx
+	c.Unlock()
+	return nil
+}
+
+func (c *tenancyCallbacks) OnStreamDeltaRequest(streamID int64, request *envoy_sd.DeltaDiscoveryRequest) error {
+	c.RLock()
+	defer c.RUnlock()
+	ctx, ok := c.streamToCtx[streamID]
+	if !ok {
+		// it should not happen, but just in case it's better to fail
+		return errors.New("context is missing")
+	}
+	tenantID, err := c.tenants.GetID(ctx)
+	if err != nil {
+		return err
+	}
+	util.FillTenantMetadata(tenantID, request.Node)
+	return nil
+}

--- a/pkg/kds/v2/server/tenant_callback_test.go
+++ b/pkg/kds/v2/server/tenant_callback_test.go
@@ -1,0 +1,49 @@
+package server_test
+
+import (
+	"context"
+
+	envoy_core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	envoy_sd "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/kumahq/kuma/pkg/kds/v2/server"
+	"github.com/kumahq/kuma/pkg/kds/v2/util"
+	"github.com/kumahq/kuma/pkg/multitenant"
+)
+
+var _ = Describe("Tenant callbacks", func() {
+	It("should enrich metadata with tenant info", func() {
+		// given
+		streamID := int64(1)
+		callbacks := server.NewTenancyCallbacks(&sampleTenants{})
+
+		// when
+		err := callbacks.OnDeltaStreamOpen(multitenant.WithTenant(context.Background(), "sample"), streamID, "")
+		Expect(err).ToNot(HaveOccurred())
+
+		req := &envoy_sd.DeltaDiscoveryRequest{
+			Node: &envoy_core.Node{},
+		}
+		err = callbacks.OnStreamDeltaRequest(streamID, req)
+
+		// then
+		Expect(err).ToNot(HaveOccurred())
+
+		tenant, ok := util.TenantFromMetadata(req.GetNode())
+		Expect(ok).To(BeTrue())
+		Expect(tenant).To(Equal("sample"))
+	})
+})
+
+type sampleTenants struct{}
+
+func (s sampleTenants) GetID(ctx context.Context) (string, error) {
+	tenant, _ := multitenant.TenantFromCtx(ctx)
+	return tenant, nil
+}
+
+func (s sampleTenants) GetIDs(ctx context.Context) ([]string, error) {
+	return nil, nil
+}

--- a/pkg/kds/v2/util/multitenancy.go
+++ b/pkg/kds/v2/util/multitenancy.go
@@ -1,0 +1,23 @@
+package util
+
+import (
+	envoy_core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	"google.golang.org/protobuf/types/known/structpb"
+)
+
+const tenantMetadataKey = "tenant"
+
+func FillTenantMetadata(tenantID string, node *envoy_core.Node) {
+	if node.Metadata == nil {
+		node.Metadata = &structpb.Struct{}
+	}
+	if node.Metadata.Fields == nil {
+		node.Metadata.Fields = map[string]*structpb.Value{}
+	}
+	node.Metadata.Fields[tenantMetadataKey] = structpb.NewStringValue(tenantID)
+}
+
+func TenantFromMetadata(node *envoy_core.Node) (string, bool) {
+	val, ok := node.GetMetadata().GetFields()[tenantMetadataKey]
+	return val.GetStringValue(), ok
+}

--- a/test/framework/interface.go
+++ b/test/framework/interface.go
@@ -48,6 +48,7 @@ type kumaDeploymentOptions struct {
 	yamlConfig                  string
 	transparentProxyV1          bool
 	apiHeaders                  []string
+	zoneName                    string
 
 	// Functions to apply to each mesh after the control plane
 	// is provisioned.
@@ -357,6 +358,12 @@ func WithMeshUpdate(mesh string, u MeshUpdateFunc) KumaDeploymentOption {
 func WithApiHeaders(headers ...string) KumaDeploymentOption {
 	return KumaOptionFunc(func(o *kumaDeploymentOptions) {
 		o.apiHeaders = headers
+	})
+}
+
+func WithZoneName(zoneName string) KumaDeploymentOption {
+	return KumaOptionFunc(func(o *kumaDeploymentOptions) {
+		o.zoneName = zoneName
 	})
 }
 

--- a/test/framework/k8s_cluster.go
+++ b/test/framework/k8s_cluster.go
@@ -307,6 +307,7 @@ func (c *K8sCluster) deployKumaViaKubectl(mode string) error {
 
 func (c *K8sCluster) yamlForKumaViaKubectl(mode string) (string, error) {
 	argsMap := map[string]string{
+		"--mode":                      mode,
 		"--namespace":                 Config.KumaNamespace,
 		"--control-plane-repository":  Config.KumaCPImageRepo,
 		"--dataplane-repository":      Config.KumaDPImageRepo,
@@ -332,7 +333,15 @@ func (c *K8sCluster) yamlForKumaViaKubectl(mode string) (string, error) {
 
 	switch mode {
 	case core.Zone:
+		zoneName := c.opts.zoneName
+		if zoneName == "" {
+			zoneName = c.GetKumactlOptions().CPName
+		}
+		argsMap["--zone"] = zoneName
 		argsMap["--kds-global-address"] = c.opts.globalAddress
+	}
+	if !Config.UseLoadBalancer {
+		argsMap["--use-node-port"] = ""
 	}
 
 	if c.opts.zoneIngress {
@@ -445,7 +454,11 @@ func (c *K8sCluster) genValues(mode string) map[string]string {
 			values["controlPlane.globalZoneSyncService.type"] = "NodePort"
 		}
 	case core.Zone:
-		values["controlPlane.zone"] = c.GetKumactlOptions().CPName
+		zoneName := c.opts.zoneName
+		if zoneName == "" {
+			zoneName = c.GetKumactlOptions().CPName
+		}
+		values["controlPlane.zone"] = zoneName
 		values["controlPlane.kdsGlobalAddress"] = c.opts.globalAddress
 	}
 

--- a/test/framework/kumactl.go
+++ b/test/framework/kumactl.go
@@ -13,7 +13,6 @@ import (
 	"github.com/gruntwork-io/terratest/modules/testing"
 	"github.com/pkg/errors"
 
-	"github.com/kumahq/kuma/pkg/config/core"
 	core_model "github.com/kumahq/kuma/pkg/core/resources/model"
 	"github.com/kumahq/kuma/pkg/core/resources/model/rest"
 )
@@ -132,17 +131,6 @@ func storeConfigToTempFile(name string, configData string) (string, error) {
 func (k *KumactlOptions) KumactlInstallCP(mode string, args ...string) (string, error) {
 	cmd := []string{
 		"install", "control-plane",
-	}
-
-	cmd = append(cmd, "--mode", mode)
-	switch mode {
-	case core.Zone:
-		cmd = append(cmd, "--zone", k.CPName)
-		fallthrough
-	case core.Global:
-		if !Config.UseLoadBalancer {
-			cmd = append(cmd, "--use-node-port")
-		}
 	}
 
 	cmd = append(cmd, args...)

--- a/test/framework/universal_cluster.go
+++ b/test/framework/universal_cluster.go
@@ -150,7 +150,11 @@ func (c *UniversalCluster) DeployKuma(mode core.CpMode, opt ...KumaDeploymentOpt
 
 	cmd := []string{"kuma-cp", "run", "--config-file", "/kuma/kuma-cp.conf"}
 	if mode == core.Zone {
-		env["KUMA_MULTIZONE_ZONE_NAME"] = c.name
+		zoneName := c.opts.zoneName
+		if zoneName == "" {
+			zoneName = c.name
+		}
+		env["KUMA_MULTIZONE_ZONE_NAME"] = zoneName
 	}
 
 	app, err := NewUniversalApp(c.t, c.name, AppModeCP, "", AppModeCP, c.opts.isipv6, true, []string{}, dockerVolumes, "")


### PR DESCRIPTION
### Checklist prior to review

Make KDS multitenant. Propagate tenant from context to node metadata via callbacks.
Additionally, I made adjustments to E2E framework to be able to pass zone name.

Fix #6632

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [x] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
