### PR TITLE
ci(.github): add backport action to replace mergify

### DIFF
--- a/.github/workflows/backport.yaml
+++ b/.github/workflows/backport.yaml
@@ -1,0 +1,10 @@
+name: backport
+on:
+  pull_request_target:
+    types: [labeled, closed]
+jobs:
+  maybe-backport:
+    uses: kumahq/.github/.github/workflows/wfc_backport.yml@main
+    secrets:
+      appId: ${{ secrets.APP_ID }}
+      appPrivateKey: ${{ secrets.APP_PRIVATE_KEY }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -280,8 +280,8 @@ Changes that are to be backported should only be critical bug fixes of one of th
 - Security
 - CI/CD (anything related to the release process)
 
-If you think your PR applies and should be backported please add a comment: `@mergifyio backport <release-1.x> <release-1.y>...`.
-Once the PR is approved and merged mergifyio will open a new PR with the backport for each of the branches. If you backport a change it's your responsibility to make sure the backport succeeds.
+If you think your PR applies and should be backported please add the label: `backport`.
+Once the PR is approved and merged the action `backport.yaml` will open a new PR with the backport for each of the maintained branches. If you backport a change it's your responsibility to make sure the backports goes through.
 
 #### Reviewing
 


### PR DESCRIPTION
We use this when adding the `backport` label

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [x] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
