### PR TITLE
docs(MADR): `MeshGateway` as `targetRef.kind`

### DIFF
--- a/docs/madr/decisions/026-meshgateway-targetref.md
+++ b/docs/madr/decisions/026-meshgateway-targetref.md
@@ -91,7 +91,7 @@ spec:
 ```
 
 We can use the following policy with `sectionName` to target only traffic over
-the `HTTPS` listener.
+the `HTTPS` listener on port `8443`.
 
 ```yaml
 apiVersion: kuma.io/v1alpha1
@@ -105,8 +105,8 @@ spec:
     sectionName: https
 ```
 
-In every policy implementation, we should make sure the Envoy config we generate
-is coherent, given that more than one `spec.listeners` can be merged into
+Note that in every policy implementation, we must make sure the Envoy config we
+generate is coherent, given that more than one `spec.listeners` can be merged into
 a single Envoy listener. There is no 1-1 correspondence guaranteed between Envoy
 listeners and `MeshGateway` listeners.
 

--- a/docs/madr/decisions/026-meshgateway-targetref.md
+++ b/docs/madr/decisions/026-meshgateway-targetref.md
@@ -56,7 +56,11 @@ For this kind of policy we can imagine a new `spec.from.targetRef.kind: External
 Chosen option: `MeshGateway` as `kind` with `targetRef.sectionName`
 
 `targetRef.kind: MeshGateway` applies the policy to all `Dataplanes` matched by
-the matchers on the `MeshGateway` object. Further specifying `sectionName`
+the matchers on the `MeshGateway` object and all listeners configured in the
+`MeshGateway`. It has the same semantics as `{ kind: MeshService, name:
+<kuma.io/service matched by the MeshGateway> }`
+
+Further specifying `sectionName`
 narrows this to a specific listener. `MeshGateway` listeners don't have explicit
 names but users can use a reserved tag to give them a canonical name that
 policies can match on. The Gateway API implementation uses the

--- a/docs/madr/decisions/026-meshgateway-targetref.md
+++ b/docs/madr/decisions/026-meshgateway-targetref.md
@@ -57,6 +57,8 @@ For this kind of policy we can imagine a new `spec.from.targetRef.kind: External
 
 Chosen option: `MeshGateway` as `kind` with `targetRef.tags`
 
+### Matching
+
 `targetRef.kind: MeshGateway` applies the policy to all `Dataplanes` matched by
 the matchers on the `MeshGateway` object and all listeners configured in the
 `MeshGateway`. It has the same semantics as `{ kind: MeshService, name:
@@ -108,6 +110,17 @@ Note that in every policy implementation, we must make sure the Envoy config we
 generate is coherent, given that more than one `spec.listeners` can be merged into
 a single Envoy listener. There is no 1-1 correspondence guaranteed between Envoy
 listeners and `MeshGateway` listeners.
+
+### Specificity
+
+The ordering of `kinds` that can affect builtin gateway resources is the
+following:
+
+`Mesh` > `MeshSubset` > `MeshGateway`
+
+In other words, resources that target `Mesh` and `MeshSubset` also target
+builtin gateway resources and are less specific than `MeshGateway`. See [the
+policy matching MADR](./005-policy-matching.md#Overlapping) for more.
 
 ### Positive Consequences
 

--- a/docs/madr/decisions/026-meshgateway-targetref.md
+++ b/docs/madr/decisions/026-meshgateway-targetref.md
@@ -30,10 +30,11 @@ to set policy for incoming traffic is not supported in any policy.
 Part of the reason for this is that the paradigm that `spec.targetRef` tells us
 which sidecars have their config modified by a given policy would no longer apply.
 
-Nevertheless it may be interesting to consider exactly which policies, if any,
-_would_ this make sense for? `MeshTimeout`, for example.
-One could imagine a new kind that applies to non-mesh
-traffic `spec.targetRef.kind: External`.
+### Policies targetting incoming traffic
+
+We should consider which policies make sense with `spec.targetRef.kind: MeshGateway`
+for targetting _incoming traffic_, i.e. not using `spec.to` but rather `spec.from`.
+For this kind of policy we can imagine a new `spec.from.targetRef.kind: External`.
 
 ## Decision Drivers
 

--- a/docs/madr/decisions/026-meshgateway-targetref.md
+++ b/docs/madr/decisions/026-meshgateway-targetref.md
@@ -1,0 +1,72 @@
+# `MeshGateway` as `targetRef.kind`
+
+- Status: accepted
+
+Technical Story: https://github.com/kumahq/kuma/issues/6590
+
+## Context and Problem Statement
+
+With `targetRef` policies, the only way to target a builtin gateway at the moment
+is to use the `kuma.io/service` values the `MeshGateway` matches as
+`MeshService`.
+
+This may be somewhat unintuitive since a `MeshGateway` consists of not only a
+`Dataplane`, where a `kuma.io/service` value is actually set, but also the
+`MeshGateway` resource where the listener configuration is held.
+
+It may be more intuitive to allow referring directly to a `MeshGateway` resource
+but this isn't yet supported.
+
+Another decision is how a policy can be restricted to a single listener of a
+`MeshGateway`.
+
+This MADR does not address narrowing to a specific route resource or route match.
+
+### `spec.to.targetRef`
+
+This MADR also makes clear that currently `spec.to.targetRef` for a `MeshGateway`
+to set policy for incoming traffic is not supported in any policy.
+
+Part of the reason for this is that the paradigm that `spec.targetRef` tells us
+which sidecars have their config modified by a given policy would no longer apply.
+
+Nevertheless it may be interesting to consider exactly which policies, if any,
+_would_ this make sense for? `MeshTimeout`, for example.
+One could imagine a new kind that applies to non-mesh
+traffic `spec.targetRef.kind: External`.
+
+## Decision Drivers
+
+- Allow users to refer directly to the `MeshGateway` resource itself
+
+## Considered Options
+
+- Leave out `MeshGateway` as a `kind`
+- Support `MeshGateway` as a `kind` but not specific listeners
+- Support `MeshGateway` as a `kind` with the option of setting
+  `targetRef.listener`
+- Support `MeshGateway` as a `kind` but also `MeshGatewayListener` where
+  `targetRef.listener` can be set
+- Support `MeshGateway` as a `kind` with the option of setting
+  `targetRef.sectionName`
+
+## Decision Outcome
+
+Chosen option: `MeshGateway` as `kind` with `targetRef.sectionName`
+
+`targetRef.kind: MeshGateway` applies the policy to all `Dataplanes` matched by
+the matchers on the `MeshGateway` object. Further specifying `sectionName`
+narrows this to a specific listener. In the implementation, we should make sure
+this works even given the merging of more than one `spec.listeners` into
+single Envoy listeners.
+
+### Positive Consequences
+
+- We can target a specific listener
+- Allows for flexibility of using `sectionName` for _other_ `kinds` that may
+  have the concept of narrowing applicability of policies
+- Naming things is hard, `sectionName` is at least known from Gateway API
+
+### Negative Consequences
+
+- Further complicates the `targetRef` schema, we already have `.tags`


### PR DESCRIPTION
This just addresses the gateway and its listeners, not routes.

I think it's also a good place to discuss what it could or would mean for `spec.to.targetRef.kind: MeshGateway`.

[Rendered](https://github.com/michaelbeaumont/kuma/blob/docs/madr-meshgateway-kind/docs/madr/decisions/026-meshgateway-targetref.md)

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues -- https://github.com/kumahq/kuma/issues/6590
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [x] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
