### PR TITLE
fix(kuma-cp): reset idleTimeout from the old Timeout policy

### DIFF
--- a/pkg/plugins/policies/meshtimeout/plugin/testdata/basic_inbound_listener.golden.yaml
+++ b/pkg/plugins/policies/meshtimeout/plugin/testdata/basic_inbound_listener.golden.yaml
@@ -8,6 +8,8 @@ filterChains:
   - name: envoy.filters.network.http_connection_manager
     typedConfig:
       '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+      commonHttpProtocolOptions:
+        idleTimeout: 0s
       httpFilters:
       - name: envoy.filters.http.router
         typedConfig:

--- a/pkg/plugins/policies/meshtimeout/plugin/testdata/default_inbound_listener.golden.yaml
+++ b/pkg/plugins/policies/meshtimeout/plugin/testdata/default_inbound_listener.golden.yaml
@@ -8,6 +8,8 @@ filterChains:
   - name: envoy.filters.network.http_connection_manager
     typedConfig:
       '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+      commonHttpProtocolOptions:
+        idleTimeout: 0s
       httpFilters:
       - name: envoy.filters.http.router
         typedConfig:

--- a/pkg/plugins/policies/meshtimeout/plugin/testdata/default_outbound_listener.golden.yaml
+++ b/pkg/plugins/policies/meshtimeout/plugin/testdata/default_outbound_listener.golden.yaml
@@ -7,6 +7,8 @@ filterChains:
   - name: envoy.filters.network.http_connection_manager
     typedConfig:
       '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+      commonHttpProtocolOptions:
+        idleTimeout: 0s
       httpFilters:
       - name: envoy.filters.http.router
         typedConfig:

--- a/pkg/plugins/policies/meshtimeout/plugin/testdata/http_outbound_listener.golden.yaml
+++ b/pkg/plugins/policies/meshtimeout/plugin/testdata/http_outbound_listener.golden.yaml
@@ -7,6 +7,8 @@ filterChains:
   - name: envoy.filters.network.http_connection_manager
     typedConfig:
       '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+      commonHttpProtocolOptions:
+        idleTimeout: 0s
       httpFilters:
       - name: envoy.filters.http.router
         typedConfig:

--- a/pkg/plugins/policies/meshtimeout/plugin/testdata/modified_inbound_listener.golden.yaml
+++ b/pkg/plugins/policies/meshtimeout/plugin/testdata/modified_inbound_listener.golden.yaml
@@ -8,6 +8,8 @@ filterChains:
   - name: envoy.filters.network.http_connection_manager
     typedConfig:
       '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+      commonHttpProtocolOptions:
+        idleTimeout: 0s
       httpFilters:
       - name: envoy.filters.http.router
         typedConfig:

--- a/pkg/plugins/policies/meshtimeout/plugin/testdata/modified_outbound_listener.golden.yaml
+++ b/pkg/plugins/policies/meshtimeout/plugin/testdata/modified_outbound_listener.golden.yaml
@@ -7,6 +7,8 @@ filterChains:
   - name: envoy.filters.network.http_connection_manager
     typedConfig:
       '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+      commonHttpProtocolOptions:
+        idleTimeout: 0s
       httpFilters:
       - name: envoy.filters.http.router
         typedConfig:

--- a/pkg/plugins/policies/meshtimeout/plugin/testdata/outbound_with_defaults_listener.golden.yaml
+++ b/pkg/plugins/policies/meshtimeout/plugin/testdata/outbound_with_defaults_listener.golden.yaml
@@ -7,6 +7,8 @@ filterChains:
   - name: envoy.filters.network.http_connection_manager
     typedConfig:
       '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+      commonHttpProtocolOptions:
+        idleTimeout: 0s
       httpFilters:
       - name: envoy.filters.http.router
         typedConfig:

--- a/pkg/plugins/policies/meshtimeout/plugin/v1alpha1/plugin.go
+++ b/pkg/plugins/policies/meshtimeout/plugin/v1alpha1/plugin.go
@@ -190,6 +190,8 @@ func configure(rules core_xds.Rules, subset core_xds.Subset, protocol core_mesh.
 		if computed := rules.Compute(subset); computed != nil {
 			conf = computed.Conf.(api.Conf)
 		} else {
+			// We're not touching outbounds if there are no rules for them.
+			// Normally we expect default MeshTimeout policy to define ".to[].targetRef.kind: Mesh"
 			return nil
 		}
 	}

--- a/pkg/plugins/policies/meshtimeout/plugin/xds/configurer.go
+++ b/pkg/plugins/policies/meshtimeout/plugin/xds/configurer.go
@@ -48,6 +48,8 @@ func (c *Configurer) ConfigureListener(listener *envoy_listener.Listener) error 
 			hcm.StreamIdleTimeout = util_proto.Duration(defaultStreamIdleTimeout)
 			c.configureRequestTimeout(hcm.GetRouteConfig())
 		}
+		// old Timeout policy configures idleTimeout on listener while MeshTimeout sets this in cluster
+		hcm.CommonHttpProtocolOptions.IdleTimeout = util_proto.Duration(0)
 		return nil
 	}
 	tcpTimeouts := func(proxy *envoy_tcp.TcpProxy) error {

--- a/pkg/plugins/policies/meshtimeout/plugin/xds/configurer.go
+++ b/pkg/plugins/policies/meshtimeout/plugin/xds/configurer.go
@@ -49,6 +49,9 @@ func (c *Configurer) ConfigureListener(listener *envoy_listener.Listener) error 
 			c.configureRequestTimeout(hcm.GetRouteConfig())
 		}
 		// old Timeout policy configures idleTimeout on listener while MeshTimeout sets this in cluster
+		if hcm.CommonHttpProtocolOptions == nil {
+			hcm.CommonHttpProtocolOptions = &envoy_core.HttpProtocolOptions{}
+		}
 		hcm.CommonHttpProtocolOptions.IdleTimeout = util_proto.Duration(0)
 		return nil
 	}


### PR DESCRIPTION
### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [X] [Link to relevant issue][1] as well as docs and UI issues -- https://github.com/kumahq/kuma/issues/6644
- [X] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [X] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [X] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [X] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [X] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
