### PR TITLE
fix(MeshHTTPRoute): don't assume HTTP2 if backend has unknown protocol

### DIFF
--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/clusters.go
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/clusters.go
@@ -52,16 +52,21 @@ func generateClusters(
 				}
 
 				switch protocol {
-				case core_mesh.ProtocolHTTP:
-					edsClusterBuilder.Configure(envoy_clusters.Http())
 				case core_mesh.ProtocolHTTP2, core_mesh.ProtocolGRPC:
 					edsClusterBuilder.Configure(envoy_clusters.Http2())
 				default:
+					edsClusterBuilder.Configure(envoy_clusters.Http())
 				}
 			} else {
 				edsClusterBuilder.
-					Configure(envoy_clusters.EdsCluster(clusterName)).
-					Configure(envoy_clusters.Http2())
+					Configure(envoy_clusters.EdsCluster(clusterName))
+
+				switch protocol {
+				case core_mesh.ProtocolHTTP, core_mesh.ProtocolHTTP2, core_mesh.ProtocolGRPC:
+					edsClusterBuilder.Configure(envoy_clusters.Http2())
+				default:
+					edsClusterBuilder.Configure(envoy_clusters.Http())
+				}
 
 				if upstreamMeshName := cluster.Mesh(); upstreamMeshName != "" {
 					for _, otherMesh := range append(meshCtx.Resources.OtherMeshes().Items, meshCtx.Resource) {

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/plugin_test.go
@@ -556,7 +556,7 @@ var _ = Describe("MeshHTTPRoute", func() {
 				"payments": []core_xds.Endpoint{{
 					Target: "192.168.0.6",
 					Port:   8086,
-					Tags:   map[string]string{"kuma.io/service": "payments", "kuma.io/protocol": "http", "region": "us", "version": "v1", "env": "dev"},
+					Tags:   map[string]string{"kuma.io/service": "payments", "region": "us", "version": "v1", "env": "dev"},
 					Weight: 1,
 				}},
 			}

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/request-mirror.clusters.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/request-mirror.clusters.golden.yaml
@@ -26,4 +26,4 @@ resources:
       envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
         '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
         explicitHttpConfig:
-          http2ProtocolOptions: {}
+          httpProtocolOptions: {}

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/request-mirror.endpoints.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/request-mirror.endpoints.golden.yaml
@@ -35,11 +35,9 @@ resources:
           filterMetadata:
             envoy.lb:
               env: dev
-              kuma.io/protocol: http
               region: us
               version: v1
             envoy.transport_socket_match:
               env: dev
-              kuma.io/protocol: http
               region: us
               version: v1


### PR DESCRIPTION
Unfortunately this way of solving the problem makes `x-kuma-tags` visible for HTTP destinations. We set these tags on the RouteConfiguration, I don't think we can set this per cluster.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [x] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
