### PR TITLE
fix(GatewayAPI): reconcile Gateways on Secret changes

### DIFF
--- a/pkg/plugins/runtime/k8s/controllers/gatewayapi/gateway_status.go
+++ b/pkg/plugins/runtime/k8s/controllers/gatewayapi/gateway_status.go
@@ -94,7 +94,7 @@ func attachedRoutesForListeners(
 ) (AttachedRoutesForListeners, error) {
 	var routes gatewayapi.HTTPRouteList
 	if err := client.List(ctx, &routes, kube_client.MatchingFields{
-		gatewayIndexField: kube_client.ObjectKeyFromObject(gateway).String(),
+		gatewayOfRouteIndexField: kube_client.ObjectKeyFromObject(gateway).String(),
 	}); err != nil {
 		return nil, errors.Wrap(err, "unexpected error listing HTTPRoutes")
 	}


### PR DESCRIPTION
Important for example if a Secret appears or disappears and it's used in an HTTPS listener.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [x] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
