### PR TITLE
fix(MeshGateway): don't strip ports from host

### DIFF
--- a/pkg/plugins/policies/meshfaultinjection/plugin/v1alpha1/testdata/gateway_basic_listener.golden.yaml
+++ b/pkg/plugins/policies/meshfaultinjection/plugin/v1alpha1/testdata/gateway_basic_listener.golden.yaml
@@ -62,7 +62,6 @@ filterChains:
       serverName: Kuma Gateway
       statPrefix: sample-gateway
       streamIdleTimeout: 5s
-      stripAnyHostPort: true
       useRemoteAddress: true
 listenerFilters:
 - name: envoy.filters.listener.tls_inspector

--- a/pkg/plugins/policies/meshratelimit/plugin/v1alpha1/testdata/gateway_basic_listener.golden.yaml
+++ b/pkg/plugins/policies/meshratelimit/plugin/v1alpha1/testdata/gateway_basic_listener.golden.yaml
@@ -45,7 +45,6 @@ filterChains:
       serverName: Kuma Gateway
       statPrefix: sample-gateway
       streamIdleTimeout: 5s
-      stripAnyHostPort: true
       useRemoteAddress: true
 listenerFilters:
 - name: envoy.filters.listener.tls_inspector

--- a/pkg/plugins/policies/meshratelimit/plugin/v1alpha1/testdata/gateway_basic_routes.golden.yaml
+++ b/pkg/plugins/policies/meshratelimit/plugin/v1alpha1/testdata/gateway_basic_routes.golden.yaml
@@ -1,3 +1,4 @@
+ignorePortInHostMatching: true
 name: sample-gateway:HTTP:8080
 requestHeadersToRemove:
 - x-kuma-tags

--- a/pkg/plugins/policies/meshtimeout/plugin/testdata/gateway_listener.golden.yaml
+++ b/pkg/plugins/policies/meshtimeout/plugin/testdata/gateway_listener.golden.yaml
@@ -45,7 +45,6 @@ filterChains:
       serverName: Kuma Gateway
       statPrefix: sample-gateway
       streamIdleTimeout: 5s
-      stripAnyHostPort: true
       useRemoteAddress: true
 listenerFilters:
 - name: envoy.filters.listener.tls_inspector

--- a/pkg/plugins/policies/meshtimeout/plugin/testdata/gateway_route.golden.yaml
+++ b/pkg/plugins/policies/meshtimeout/plugin/testdata/gateway_route.golden.yaml
@@ -1,3 +1,4 @@
+ignorePortInHostMatching: true
 name: sample-gateway:HTTP:8080
 requestHeadersToRemove:
 - x-kuma-tags

--- a/pkg/plugins/runtime/gateway/filter_chain_generator.go
+++ b/pkg/plugins/runtime/gateway/filter_chain_generator.go
@@ -269,7 +269,6 @@ func newFilterChain(ctx xds_context.MeshContext, info GatewayListenerInfo) *envo
 	// Add edge proxy recommendations.
 	builder.Configure(
 		envoy_listeners.EnablePathNormalization(),
-		envoy_listeners.StripHostPort(),
 		envoy_listeners.AddFilterChainConfigurer(
 			envoy_listeners_v3.HttpConnectionManagerMustConfigureFunc(func(hcm *envoy_hcm.HttpConnectionManager) {
 				hcm.UseRemoteAddress = util_proto.Bool(true)

--- a/pkg/plugins/runtime/gateway/route_configuration_generator.go
+++ b/pkg/plugins/runtime/gateway/route_configuration_generator.go
@@ -16,6 +16,7 @@ func GenerateRouteConfig(info GatewayListenerInfo) *envoy_routes.RouteConfigurat
 	return envoy_routes.NewRouteConfigurationBuilder(info.Proxy.APIVersion).
 		Configure(
 			envoy_routes.CommonRouteConfiguration(info.Listener.ResourceName),
+			envoy_routes.IgnorePortInHostMatching(),
 			// TODO(jpeach) propagate merged listener tags.
 			// Ideally we would propagate the tags header
 			// to mesh services but not to external services,

--- a/pkg/plugins/runtime/gateway/testdata/01-gateway-listener.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/01-gateway-listener.yaml
@@ -52,7 +52,6 @@ Listeners:
             serverName: Kuma Gateway
             statPrefix: gateway-default
             streamIdleTimeout: 5s
-            stripAnyHostPort: true
             useRemoteAddress: true
       listenerFilters:
       - name: envoy.filters.listener.tls_inspector

--- a/pkg/plugins/runtime/gateway/testdata/01-gateway-listener.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/01-gateway-listener.yaml
@@ -63,6 +63,7 @@ Listeners:
 Routes:
   Resources:
     edge-gateway:HTTP:8080:
+      ignorePortInHostMatching: true
       name: edge-gateway:HTTP:8080
       requestHeadersToRemove:
       - x-kuma-tags

--- a/pkg/plugins/runtime/gateway/testdata/02-gateway-listener.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/02-gateway-listener.yaml
@@ -119,6 +119,7 @@ Listeners:
 Routes:
   Resources:
     edge-gateway:HTTP:8080:
+      ignorePortInHostMatching: true
       name: edge-gateway:HTTP:8080
       requestHeadersToRemove:
       - x-kuma-tags
@@ -136,6 +137,7 @@ Routes:
           match:
             prefix: /
     edge-gateway:HTTP:9090:
+      ignorePortInHostMatching: true
       name: edge-gateway:HTTP:9090
       requestHeadersToRemove:
       - x-kuma-tags

--- a/pkg/plugins/runtime/gateway/testdata/02-gateway-listener.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/02-gateway-listener.yaml
@@ -52,7 +52,6 @@ Listeners:
             serverName: Kuma Gateway
             statPrefix: gateway-default
             streamIdleTimeout: 5s
-            stripAnyHostPort: true
             useRemoteAddress: true
       listenerFilters:
       - name: envoy.filters.listener.tls_inspector
@@ -109,7 +108,6 @@ Listeners:
             serverName: Kuma Gateway
             statPrefix: gateway-default
             streamIdleTimeout: 5s
-            stripAnyHostPort: true
             useRemoteAddress: true
       listenerFilters:
       - name: envoy.filters.listener.tls_inspector

--- a/pkg/plugins/runtime/gateway/testdata/03-gateway-listener.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/03-gateway-listener.yaml
@@ -89,6 +89,7 @@ Listeners:
 Routes:
   Resources:
     tracing-gateway:HTTP:8080:
+      ignorePortInHostMatching: true
       name: tracing-gateway:HTTP:8080
       requestHeadersToRemove:
       - x-kuma-tags

--- a/pkg/plugins/runtime/gateway/testdata/03-gateway-listener.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/03-gateway-listener.yaml
@@ -67,7 +67,6 @@ Listeners:
             serverName: Kuma Gateway
             statPrefix: gateway-default
             streamIdleTimeout: 5s
-            stripAnyHostPort: true
             tracing:
               overallSampling:
                 value: 100

--- a/pkg/plugins/runtime/gateway/testdata/04-gateway-listener.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/04-gateway-listener.yaml
@@ -72,6 +72,7 @@ Listeners:
 Routes:
   Resources:
     logging-gateway:HTTP:8080:
+      ignorePortInHostMatching: true
       name: logging-gateway:HTTP:8080
       requestHeadersToRemove:
       - x-kuma-tags

--- a/pkg/plugins/runtime/gateway/testdata/04-gateway-listener.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/04-gateway-listener.yaml
@@ -61,7 +61,6 @@ Listeners:
             serverName: Kuma Gateway
             statPrefix: gateway-default
             streamIdleTimeout: 5s
-            stripAnyHostPort: true
             useRemoteAddress: true
       listenerFilters:
       - name: envoy.filters.listener.tls_inspector

--- a/pkg/plugins/runtime/gateway/testdata/05-gateway-listener.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/05-gateway-listener.yaml
@@ -56,7 +56,6 @@ Listeners:
             serverName: Kuma Gateway
             statPrefix: gateway-default
             streamIdleTimeout: 5s
-            stripAnyHostPort: true
             useRemoteAddress: true
         transportSocket:
           name: envoy.transport_sockets.tls
@@ -119,7 +118,6 @@ Listeners:
             serverName: Kuma Gateway
             statPrefix: gateway-default
             streamIdleTimeout: 5s
-            stripAnyHostPort: true
             useRemoteAddress: true
         transportSocket:
           name: envoy.transport_sockets.tls
@@ -182,7 +180,6 @@ Listeners:
             serverName: Kuma Gateway
             statPrefix: gateway-default
             streamIdleTimeout: 5s
-            stripAnyHostPort: true
             useRemoteAddress: true
         transportSocket:
           name: envoy.transport_sockets.tls
@@ -243,7 +240,6 @@ Listeners:
             serverName: Kuma Gateway
             statPrefix: gateway-default
             streamIdleTimeout: 5s
-            stripAnyHostPort: true
             useRemoteAddress: true
         transportSocket:
           name: envoy.transport_sockets.tls

--- a/pkg/plugins/runtime/gateway/testdata/05-gateway-listener.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/05-gateway-listener.yaml
@@ -267,6 +267,7 @@ Listeners:
 Routes:
   Resources:
     default-gateway:HTTPS:443:
+      ignorePortInHostMatching: true
       name: default-gateway:HTTPS:443
       requestHeadersToRemove:
       - x-kuma-tags

--- a/pkg/plugins/runtime/gateway/testdata/http/01-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/01-gateway-route.yaml
@@ -96,7 +96,6 @@ Listeners:
             serverName: Kuma Gateway
             statPrefix: gateway-default
             streamIdleTimeout: 5s
-            stripAnyHostPort: true
             useRemoteAddress: true
       listenerFilters:
       - name: envoy.filters.listener.tls_inspector

--- a/pkg/plugins/runtime/gateway/testdata/http/01-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/01-gateway-route.yaml
@@ -107,6 +107,7 @@ Listeners:
 Routes:
   Resources:
     edge-gateway:HTTP:8080:
+      ignorePortInHostMatching: true
       name: edge-gateway:HTTP:8080
       requestHeadersToRemove:
       - x-kuma-tags

--- a/pkg/plugins/runtime/gateway/testdata/http/02-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/02-gateway-route.yaml
@@ -96,7 +96,6 @@ Listeners:
             serverName: Kuma Gateway
             statPrefix: gateway-default
             streamIdleTimeout: 5s
-            stripAnyHostPort: true
             useRemoteAddress: true
       listenerFilters:
       - name: envoy.filters.listener.tls_inspector

--- a/pkg/plugins/runtime/gateway/testdata/http/02-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/02-gateway-route.yaml
@@ -107,6 +107,7 @@ Listeners:
 Routes:
   Resources:
     edge-gateway:HTTP:8080:
+      ignorePortInHostMatching: true
       name: edge-gateway:HTTP:8080
       requestHeadersToRemove:
       - x-kuma-tags

--- a/pkg/plugins/runtime/gateway/testdata/http/03-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/03-gateway-route.yaml
@@ -96,7 +96,6 @@ Listeners:
             serverName: Kuma Gateway
             statPrefix: gateway-default
             streamIdleTimeout: 5s
-            stripAnyHostPort: true
             useRemoteAddress: true
       listenerFilters:
       - name: envoy.filters.listener.tls_inspector

--- a/pkg/plugins/runtime/gateway/testdata/http/03-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/03-gateway-route.yaml
@@ -107,6 +107,7 @@ Listeners:
 Routes:
   Resources:
     edge-gateway:HTTP:8080:
+      ignorePortInHostMatching: true
       name: edge-gateway:HTTP:8080
       requestHeadersToRemove:
       - x-kuma-tags

--- a/pkg/plugins/runtime/gateway/testdata/http/04-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/04-gateway-route.yaml
@@ -126,7 +126,6 @@ Listeners:
             serverName: Kuma Gateway
             statPrefix: gateway-default
             streamIdleTimeout: 5s
-            stripAnyHostPort: true
             useRemoteAddress: true
       listenerFilters:
       - name: envoy.filters.listener.tls_inspector

--- a/pkg/plugins/runtime/gateway/testdata/http/04-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/04-gateway-route.yaml
@@ -137,6 +137,7 @@ Listeners:
 Routes:
   Resources:
     edge-gateway:HTTP:8080:
+      ignorePortInHostMatching: true
       name: edge-gateway:HTTP:8080
       requestHeadersToRemove:
       - x-kuma-tags

--- a/pkg/plugins/runtime/gateway/testdata/http/05-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/05-gateway-route.yaml
@@ -52,7 +52,6 @@ Listeners:
             serverName: Kuma Gateway
             statPrefix: gateway-default
             streamIdleTimeout: 5s
-            stripAnyHostPort: true
             useRemoteAddress: true
       listenerFilters:
       - name: envoy.filters.listener.tls_inspector

--- a/pkg/plugins/runtime/gateway/testdata/http/05-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/05-gateway-route.yaml
@@ -63,6 +63,7 @@ Listeners:
 Routes:
   Resources:
     edge-gateway:HTTP:8080:
+      ignorePortInHostMatching: true
       name: edge-gateway:HTTP:8080
       requestHeadersToRemove:
       - x-kuma-tags

--- a/pkg/plugins/runtime/gateway/testdata/http/06-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/06-gateway-route.yaml
@@ -126,7 +126,6 @@ Listeners:
             serverName: Kuma Gateway
             statPrefix: gateway-default
             streamIdleTimeout: 5s
-            stripAnyHostPort: true
             useRemoteAddress: true
       listenerFilters:
       - name: envoy.filters.listener.tls_inspector

--- a/pkg/plugins/runtime/gateway/testdata/http/06-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/06-gateway-route.yaml
@@ -137,6 +137,7 @@ Listeners:
 Routes:
   Resources:
     edge-gateway:HTTP:8080:
+      ignorePortInHostMatching: true
       name: edge-gateway:HTTP:8080
       requestHeadersToRemove:
       - x-kuma-tags

--- a/pkg/plugins/runtime/gateway/testdata/http/07-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/07-gateway-route.yaml
@@ -96,7 +96,6 @@ Listeners:
             serverName: Kuma Gateway
             statPrefix: gateway-default
             streamIdleTimeout: 5s
-            stripAnyHostPort: true
             useRemoteAddress: true
       listenerFilters:
       - name: envoy.filters.listener.tls_inspector

--- a/pkg/plugins/runtime/gateway/testdata/http/07-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/07-gateway-route.yaml
@@ -107,6 +107,7 @@ Listeners:
 Routes:
   Resources:
     edge-gateway:HTTP:8080:
+      ignorePortInHostMatching: true
       name: edge-gateway:HTTP:8080
       requestHeadersToRemove:
       - x-kuma-tags

--- a/pkg/plugins/runtime/gateway/testdata/http/08-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/08-gateway-route.yaml
@@ -151,6 +151,7 @@ Listeners:
 Routes:
   Resources:
     edge-gateway:HTTP:8080:
+      ignorePortInHostMatching: true
       name: edge-gateway:HTTP:8080
       requestHeadersToRemove:
       - x-kuma-tags

--- a/pkg/plugins/runtime/gateway/testdata/http/08-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/08-gateway-route.yaml
@@ -140,7 +140,6 @@ Listeners:
             serverName: Kuma Gateway
             statPrefix: gateway-default
             streamIdleTimeout: 5s
-            stripAnyHostPort: true
             useRemoteAddress: true
       listenerFilters:
       - name: envoy.filters.listener.tls_inspector

--- a/pkg/plugins/runtime/gateway/testdata/http/09-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/09-gateway-route.yaml
@@ -96,7 +96,6 @@ Listeners:
             serverName: Kuma Gateway
             statPrefix: gateway-default
             streamIdleTimeout: 5s
-            stripAnyHostPort: true
             useRemoteAddress: true
       listenerFilters:
       - name: envoy.filters.listener.tls_inspector

--- a/pkg/plugins/runtime/gateway/testdata/http/09-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/09-gateway-route.yaml
@@ -107,6 +107,7 @@ Listeners:
 Routes:
   Resources:
     edge-gateway:HTTP:8080:
+      ignorePortInHostMatching: true
       name: edge-gateway:HTTP:8080
       requestHeadersToRemove:
       - x-kuma-tags

--- a/pkg/plugins/runtime/gateway/testdata/http/10-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/10-gateway-route.yaml
@@ -200,7 +200,6 @@ Listeners:
             serverName: Kuma Gateway
             statPrefix: gateway-default
             streamIdleTimeout: 5s
-            stripAnyHostPort: true
             useRemoteAddress: true
       listenerFilters:
       - name: envoy.filters.listener.tls_inspector

--- a/pkg/plugins/runtime/gateway/testdata/http/10-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/10-gateway-route.yaml
@@ -211,6 +211,7 @@ Listeners:
 Routes:
   Resources:
     edge-gateway:HTTP:8080:
+      ignorePortInHostMatching: true
       name: edge-gateway:HTTP:8080
       requestHeadersToRemove:
       - x-kuma-tags

--- a/pkg/plugins/runtime/gateway/testdata/http/11-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/11-gateway-route.yaml
@@ -151,6 +151,7 @@ Listeners:
 Routes:
   Resources:
     edge-gateway:HTTP:8080:
+      ignorePortInHostMatching: true
       name: edge-gateway:HTTP:8080
       requestHeadersToRemove:
       - x-kuma-tags

--- a/pkg/plugins/runtime/gateway/testdata/http/11-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/11-gateway-route.yaml
@@ -140,7 +140,6 @@ Listeners:
             serverName: Kuma Gateway
             statPrefix: gateway-default
             streamIdleTimeout: 5s
-            stripAnyHostPort: true
             useRemoteAddress: true
       listenerFilters:
       - name: envoy.filters.listener.tls_inspector

--- a/pkg/plugins/runtime/gateway/testdata/http/12-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/12-gateway-route.yaml
@@ -96,7 +96,6 @@ Listeners:
             serverName: Kuma Gateway
             statPrefix: gateway-default
             streamIdleTimeout: 5s
-            stripAnyHostPort: true
             useRemoteAddress: true
       listenerFilters:
       - name: envoy.filters.listener.tls_inspector

--- a/pkg/plugins/runtime/gateway/testdata/http/12-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/12-gateway-route.yaml
@@ -107,6 +107,7 @@ Listeners:
 Routes:
   Resources:
     edge-gateway:HTTP:8080:
+      ignorePortInHostMatching: true
       name: edge-gateway:HTTP:8080
       requestHeadersToRemove:
       - x-kuma-tags

--- a/pkg/plugins/runtime/gateway/testdata/http/13-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/13-gateway-route.yaml
@@ -195,6 +195,7 @@ Listeners:
 Routes:
   Resources:
     edge-gateway:HTTP:8080:
+      ignorePortInHostMatching: true
       name: edge-gateway:HTTP:8080
       requestHeadersToRemove:
       - x-kuma-tags

--- a/pkg/plugins/runtime/gateway/testdata/http/13-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/13-gateway-route.yaml
@@ -184,7 +184,6 @@ Listeners:
             serverName: Kuma Gateway
             statPrefix: gateway-default
             streamIdleTimeout: 5s
-            stripAnyHostPort: true
             useRemoteAddress: true
       listenerFilters:
       - name: envoy.filters.listener.tls_inspector

--- a/pkg/plugins/runtime/gateway/testdata/http/14-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/14-gateway-route.yaml
@@ -96,7 +96,6 @@ Listeners:
             serverName: Kuma Gateway
             statPrefix: gateway-default
             streamIdleTimeout: 5s
-            stripAnyHostPort: true
             useRemoteAddress: true
       listenerFilters:
       - name: envoy.filters.listener.tls_inspector

--- a/pkg/plugins/runtime/gateway/testdata/http/14-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/14-gateway-route.yaml
@@ -107,6 +107,7 @@ Listeners:
 Routes:
   Resources:
     edge-gateway:HTTP:8080:
+      ignorePortInHostMatching: true
       name: edge-gateway:HTTP:8080
       requestHeadersToRemove:
       - x-kuma-tags

--- a/pkg/plugins/runtime/gateway/testdata/http/15-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/15-gateway-route.yaml
@@ -195,6 +195,7 @@ Listeners:
 Routes:
   Resources:
     edge-gateway:HTTP:8080:
+      ignorePortInHostMatching: true
       name: edge-gateway:HTTP:8080
       requestHeadersToRemove:
       - x-kuma-tags

--- a/pkg/plugins/runtime/gateway/testdata/http/15-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/15-gateway-route.yaml
@@ -184,7 +184,6 @@ Listeners:
             serverName: Kuma Gateway
             statPrefix: gateway-default
             streamIdleTimeout: 5s
-            stripAnyHostPort: true
             useRemoteAddress: true
       listenerFilters:
       - name: envoy.filters.listener.tls_inspector

--- a/pkg/plugins/runtime/gateway/testdata/http/16-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/16-gateway-route.yaml
@@ -192,6 +192,7 @@ Listeners:
 Routes:
   Resources:
     edge-gateway:HTTP:8080:
+      ignorePortInHostMatching: true
       name: edge-gateway:HTTP:8080
       requestHeadersToRemove:
       - x-kuma-tags

--- a/pkg/plugins/runtime/gateway/testdata/http/16-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/16-gateway-route.yaml
@@ -181,7 +181,6 @@ Listeners:
             serverName: Kuma Gateway
             statPrefix: gateway-default
             streamIdleTimeout: 5s
-            stripAnyHostPort: true
             useRemoteAddress: true
       listenerFilters:
       - name: envoy.filters.listener.tls_inspector

--- a/pkg/plugins/runtime/gateway/testdata/http/17-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/17-gateway-route.yaml
@@ -213,6 +213,7 @@ Listeners:
 Routes:
   Resources:
     edge-gateway:HTTP:8080:
+      ignorePortInHostMatching: true
       name: edge-gateway:HTTP:8080
       requestHeadersToRemove:
       - x-kuma-tags

--- a/pkg/plugins/runtime/gateway/testdata/http/17-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/17-gateway-route.yaml
@@ -202,7 +202,6 @@ Listeners:
             serverName: Kuma Gateway
             statPrefix: gateway-default
             streamIdleTimeout: 5s
-            stripAnyHostPort: true
             useRemoteAddress: true
       listenerFilters:
       - name: envoy.filters.listener.tls_inspector

--- a/pkg/plugins/runtime/gateway/testdata/http/18-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/18-gateway-route.yaml
@@ -93,7 +93,6 @@ Listeners:
             serverName: Kuma Gateway
             statPrefix: gateway-default
             streamIdleTimeout: 5s
-            stripAnyHostPort: true
             useRemoteAddress: true
       listenerFilters:
       - name: envoy.filters.listener.tls_inspector

--- a/pkg/plugins/runtime/gateway/testdata/http/18-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/18-gateway-route.yaml
@@ -104,6 +104,7 @@ Listeners:
 Routes:
   Resources:
     edge-gateway:HTTP:8080:
+      ignorePortInHostMatching: true
       name: edge-gateway:HTTP:8080
       requestHeadersToRemove:
       - x-kuma-tags

--- a/pkg/plugins/runtime/gateway/testdata/http/19-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/19-gateway-route.yaml
@@ -118,6 +118,7 @@ Listeners:
 Routes:
   Resources:
     edge-gateway:HTTP:8080:
+      ignorePortInHostMatching: true
       name: edge-gateway:HTTP:8080
       requestHeadersToRemove:
       - x-kuma-tags

--- a/pkg/plugins/runtime/gateway/testdata/http/19-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/19-gateway-route.yaml
@@ -107,7 +107,6 @@ Listeners:
             serverName: Kuma Gateway
             statPrefix: gateway-default
             streamIdleTimeout: 5s
-            stripAnyHostPort: true
             useRemoteAddress: true
       listenerFilters:
       - name: envoy.filters.listener.tls_inspector

--- a/pkg/plugins/runtime/gateway/testdata/http/20-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/20-gateway-route.yaml
@@ -184,7 +184,6 @@ Listeners:
             serverName: Kuma Gateway
             statPrefix: gateway-multihost
             streamIdleTimeout: 5s
-            stripAnyHostPort: true
             useRemoteAddress: true
       listenerFilters:
       - name: envoy.filters.listener.tls_inspector

--- a/pkg/plugins/runtime/gateway/testdata/http/20-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/20-gateway-route.yaml
@@ -195,6 +195,7 @@ Listeners:
 Routes:
   Resources:
     gateway-multihost:HTTP:9080:
+      ignorePortInHostMatching: true
       name: gateway-multihost:HTTP:9080
       requestHeadersToRemove:
       - x-kuma-tags

--- a/pkg/plugins/runtime/gateway/testdata/http/21-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/21-gateway-route.yaml
@@ -195,6 +195,7 @@ Listeners:
 Routes:
   Resources:
     edge-gateway:HTTP:8080:
+      ignorePortInHostMatching: true
       name: edge-gateway:HTTP:8080
       requestHeadersToRemove:
       - x-kuma-tags

--- a/pkg/plugins/runtime/gateway/testdata/http/21-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/21-gateway-route.yaml
@@ -184,7 +184,6 @@ Listeners:
             serverName: Kuma Gateway
             statPrefix: gateway-default
             streamIdleTimeout: 5s
-            stripAnyHostPort: true
             useRemoteAddress: true
       listenerFilters:
       - name: envoy.filters.listener.tls_inspector

--- a/pkg/plugins/runtime/gateway/testdata/http/22-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/22-gateway-route.yaml
@@ -151,6 +151,7 @@ Listeners:
 Routes:
   Resources:
     edge-gateway:HTTP:8080:
+      ignorePortInHostMatching: true
       name: edge-gateway:HTTP:8080
       requestHeadersToRemove:
       - x-kuma-tags

--- a/pkg/plugins/runtime/gateway/testdata/http/22-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/22-gateway-route.yaml
@@ -140,7 +140,6 @@ Listeners:
             serverName: Kuma Gateway
             statPrefix: gateway-default
             streamIdleTimeout: 5s
-            stripAnyHostPort: true
             useRemoteAddress: true
       listenerFilters:
       - name: envoy.filters.listener.tls_inspector

--- a/pkg/plugins/runtime/gateway/testdata/http/23-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/23-gateway-route.yaml
@@ -195,6 +195,7 @@ Listeners:
 Routes:
   Resources:
     edge-gateway:HTTP:8080:
+      ignorePortInHostMatching: true
       name: edge-gateway:HTTP:8080
       requestHeadersToRemove:
       - x-kuma-tags

--- a/pkg/plugins/runtime/gateway/testdata/http/23-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/23-gateway-route.yaml
@@ -184,7 +184,6 @@ Listeners:
             serverName: Kuma Gateway
             statPrefix: gateway-default
             streamIdleTimeout: 5s
-            stripAnyHostPort: true
             useRemoteAddress: true
       listenerFilters:
       - name: envoy.filters.listener.tls_inspector

--- a/pkg/plugins/runtime/gateway/testdata/http/24-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/24-gateway-route.yaml
@@ -151,6 +151,7 @@ Listeners:
 Routes:
   Resources:
     edge-gateway:HTTP:8080:
+      ignorePortInHostMatching: true
       name: edge-gateway:HTTP:8080
       requestHeadersToRemove:
       - x-kuma-tags

--- a/pkg/plugins/runtime/gateway/testdata/http/24-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/24-gateway-route.yaml
@@ -140,7 +140,6 @@ Listeners:
             serverName: Kuma Gateway
             statPrefix: gateway-default
             streamIdleTimeout: 5s
-            stripAnyHostPort: true
             useRemoteAddress: true
       listenerFilters:
       - name: envoy.filters.listener.tls_inspector

--- a/pkg/plugins/runtime/gateway/testdata/http/25-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/25-gateway-route.yaml
@@ -120,7 +120,6 @@ Listeners:
             serverName: Kuma Gateway
             statPrefix: gateway-default
             streamIdleTimeout: 5s
-            stripAnyHostPort: true
             useRemoteAddress: true
       listenerFilters:
       - name: envoy.filters.listener.tls_inspector

--- a/pkg/plugins/runtime/gateway/testdata/http/25-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/25-gateway-route.yaml
@@ -131,6 +131,7 @@ Listeners:
 Routes:
   Resources:
     edge-gateway:HTTP:8080:
+      ignorePortInHostMatching: true
       name: edge-gateway:HTTP:8080
       requestHeadersToRemove:
       - x-kuma-tags

--- a/pkg/plugins/runtime/gateway/testdata/http/26-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/26-gateway-route.yaml
@@ -117,6 +117,7 @@ Listeners:
 Routes:
   Resources:
     edge-gateway:HTTP:8080:
+      ignorePortInHostMatching: true
       name: edge-gateway:HTTP:8080
       requestHeadersToRemove:
       - x-kuma-tags

--- a/pkg/plugins/runtime/gateway/testdata/http/26-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/26-gateway-route.yaml
@@ -106,7 +106,6 @@ Listeners:
             serverName: Kuma Gateway
             statPrefix: gateway-default
             streamIdleTimeout: 5s
-            stripAnyHostPort: true
             useRemoteAddress: true
       listenerFilters:
       - name: envoy.filters.listener.tls_inspector

--- a/pkg/plugins/runtime/gateway/testdata/http/cross-mesh-gateway.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/cross-mesh-gateway.yaml
@@ -208,6 +208,7 @@ Listeners:
 Routes:
   Resources:
     edge-gateway:HTTP:8080:
+      ignorePortInHostMatching: true
       name: edge-gateway:HTTP:8080
       requestHeadersToRemove:
       - x-kuma-tags

--- a/pkg/plugins/runtime/gateway/testdata/http/cross-mesh-gateway.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/cross-mesh-gateway.yaml
@@ -179,7 +179,6 @@ Listeners:
             serverName: Kuma Gateway
             statPrefix: gateway-default
             streamIdleTimeout: 5s
-            stripAnyHostPort: true
             useRemoteAddress: true
         transportSocket:
           name: envoy.transport_sockets.tls

--- a/pkg/plugins/runtime/gateway/testdata/http/drop-prefix-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/drop-prefix-gateway-route.yaml
@@ -96,7 +96,6 @@ Listeners:
             serverName: Kuma Gateway
             statPrefix: gateway-default
             streamIdleTimeout: 5s
-            stripAnyHostPort: true
             useRemoteAddress: true
       listenerFilters:
       - name: envoy.filters.listener.tls_inspector

--- a/pkg/plugins/runtime/gateway/testdata/http/drop-prefix-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/drop-prefix-gateway-route.yaml
@@ -107,6 +107,7 @@ Listeners:
 Routes:
   Resources:
     edge-gateway:HTTP:8080:
+      ignorePortInHostMatching: true
       name: edge-gateway:HTTP:8080
       requestHeadersToRemove:
       - x-kuma-tags

--- a/pkg/plugins/runtime/gateway/testdata/http/external-service-with-timeout-no-egress.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/external-service-with-timeout-no-egress.yaml
@@ -119,6 +119,7 @@ Listeners:
 Routes:
   Resources:
     edge-gateway:HTTP:8080:
+      ignorePortInHostMatching: true
       name: edge-gateway:HTTP:8080
       requestHeadersToRemove:
       - x-kuma-tags

--- a/pkg/plugins/runtime/gateway/testdata/http/external-service-with-timeout-no-egress.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/external-service-with-timeout-no-egress.yaml
@@ -108,7 +108,6 @@ Listeners:
             serverName: Kuma Gateway
             statPrefix: gateway-default
             streamIdleTimeout: 5s
-            stripAnyHostPort: true
             useRemoteAddress: true
       listenerFilters:
       - name: envoy.filters.listener.tls_inspector

--- a/pkg/plugins/runtime/gateway/testdata/http/http-tcp-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/http-tcp-route.yaml
@@ -52,7 +52,6 @@ Listeners:
             serverName: Kuma Gateway
             statPrefix: gateway-default
             streamIdleTimeout: 5s
-            stripAnyHostPort: true
             useRemoteAddress: true
       listenerFilters:
       - name: envoy.filters.listener.tls_inspector

--- a/pkg/plugins/runtime/gateway/testdata/http/http-tcp-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/http-tcp-route.yaml
@@ -63,6 +63,7 @@ Listeners:
 Routes:
   Resources:
     edge-gateway:HTTP:8080:
+      ignorePortInHostMatching: true
       name: edge-gateway:HTTP:8080
       requestHeadersToRemove:
       - x-kuma-tags

--- a/pkg/plugins/runtime/gateway/testdata/http/no-timeout.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/no-timeout.yaml
@@ -96,7 +96,6 @@ Listeners:
             serverName: Kuma Gateway
             statPrefix: gateway-default
             streamIdleTimeout: 5s
-            stripAnyHostPort: true
             useRemoteAddress: true
       listenerFilters:
       - name: envoy.filters.listener.tls_inspector

--- a/pkg/plugins/runtime/gateway/testdata/http/no-timeout.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/no-timeout.yaml
@@ -107,6 +107,7 @@ Listeners:
 Routes:
   Resources:
     edge-gateway:HTTP:8080:
+      ignorePortInHostMatching: true
       name: edge-gateway:HTTP:8080
       requestHeadersToRemove:
       - x-kuma-tags

--- a/pkg/plugins/runtime/gateway/testdata/http/response-header-set-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/response-header-set-gateway-route.yaml
@@ -96,7 +96,6 @@ Listeners:
             serverName: Kuma Gateway
             statPrefix: gateway-default
             streamIdleTimeout: 5s
-            stripAnyHostPort: true
             useRemoteAddress: true
       listenerFilters:
       - name: envoy.filters.listener.tls_inspector

--- a/pkg/plugins/runtime/gateway/testdata/http/response-header-set-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/response-header-set-gateway-route.yaml
@@ -107,6 +107,7 @@ Listeners:
 Routes:
   Resources:
     edge-gateway:HTTP:8080:
+      ignorePortInHostMatching: true
       name: edge-gateway:HTTP:8080
       requestHeadersToRemove:
       - x-kuma-tags

--- a/pkg/plugins/runtime/gateway/testdata/http/retry-policy.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/retry-policy.yaml
@@ -195,6 +195,7 @@ Listeners:
 Routes:
   Resources:
     edge-gateway:HTTP:8080:
+      ignorePortInHostMatching: true
       name: edge-gateway:HTTP:8080
       requestHeadersToRemove:
       - x-kuma-tags

--- a/pkg/plugins/runtime/gateway/testdata/http/retry-policy.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/retry-policy.yaml
@@ -184,7 +184,6 @@ Listeners:
             serverName: Kuma Gateway
             statPrefix: gateway-default
             streamIdleTimeout: 5s
-            stripAnyHostPort: true
             useRemoteAddress: true
       listenerFilters:
       - name: envoy.filters.listener.tls_inspector

--- a/pkg/plugins/runtime/gateway/testdata/http/rewrite-prefix-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/rewrite-prefix-gateway-route.yaml
@@ -96,7 +96,6 @@ Listeners:
             serverName: Kuma Gateway
             statPrefix: gateway-default
             streamIdleTimeout: 5s
-            stripAnyHostPort: true
             useRemoteAddress: true
       listenerFilters:
       - name: envoy.filters.listener.tls_inspector

--- a/pkg/plugins/runtime/gateway/testdata/http/rewrite-prefix-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/rewrite-prefix-gateway-route.yaml
@@ -107,6 +107,7 @@ Listeners:
 Routes:
   Resources:
     edge-gateway:HTTP:8080:
+      ignorePortInHostMatching: true
       name: edge-gateway:HTTP:8080
       requestHeadersToRemove:
       - x-kuma-tags

--- a/pkg/plugins/runtime/gateway/testdata/http/rewrite-prefix-trailing-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/rewrite-prefix-trailing-gateway-route.yaml
@@ -96,7 +96,6 @@ Listeners:
             serverName: Kuma Gateway
             statPrefix: gateway-default
             streamIdleTimeout: 5s
-            stripAnyHostPort: true
             useRemoteAddress: true
       listenerFilters:
       - name: envoy.filters.listener.tls_inspector

--- a/pkg/plugins/runtime/gateway/testdata/http/rewrite-prefix-trailing-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/rewrite-prefix-trailing-gateway-route.yaml
@@ -107,6 +107,7 @@ Listeners:
 Routes:
   Resources:
     edge-gateway:HTTP:8080:
+      ignorePortInHostMatching: true
       name: edge-gateway:HTTP:8080
       requestHeadersToRemove:
       - x-kuma-tags

--- a/pkg/plugins/runtime/gateway/testdata/http/unresolved-backend.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/unresolved-backend.yaml
@@ -52,7 +52,6 @@ Listeners:
             serverName: Kuma Gateway
             statPrefix: gateway-default
             streamIdleTimeout: 5s
-            stripAnyHostPort: true
             useRemoteAddress: true
       listenerFilters:
       - name: envoy.filters.listener.tls_inspector

--- a/pkg/plugins/runtime/gateway/testdata/http/unresolved-backend.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/unresolved-backend.yaml
@@ -63,6 +63,7 @@ Listeners:
 Routes:
   Resources:
     edge-gateway:HTTP:8080:
+      ignorePortInHostMatching: true
       name: edge-gateway:HTTP:8080
       requestHeadersToRemove:
       - x-kuma-tags

--- a/pkg/plugins/runtime/gateway/testdata/https/01-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/01-gateway-route.yaml
@@ -96,7 +96,6 @@ Listeners:
             serverName: Kuma Gateway
             statPrefix: gateway-default
             streamIdleTimeout: 5s
-            stripAnyHostPort: true
             useRemoteAddress: true
       listenerFilters:
       - name: envoy.filters.listener.tls_inspector

--- a/pkg/plugins/runtime/gateway/testdata/https/01-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/01-gateway-route.yaml
@@ -107,6 +107,7 @@ Listeners:
 Routes:
   Resources:
     edge-gateway:HTTP:8080:
+      ignorePortInHostMatching: true
       name: edge-gateway:HTTP:8080
       requestHeadersToRemove:
       - x-kuma-tags

--- a/pkg/plugins/runtime/gateway/testdata/https/02-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/02-gateway-route.yaml
@@ -96,7 +96,6 @@ Listeners:
             serverName: Kuma Gateway
             statPrefix: gateway-default
             streamIdleTimeout: 5s
-            stripAnyHostPort: true
             useRemoteAddress: true
       listenerFilters:
       - name: envoy.filters.listener.tls_inspector

--- a/pkg/plugins/runtime/gateway/testdata/https/02-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/02-gateway-route.yaml
@@ -107,6 +107,7 @@ Listeners:
 Routes:
   Resources:
     edge-gateway:HTTP:8080:
+      ignorePortInHostMatching: true
       name: edge-gateway:HTTP:8080
       requestHeadersToRemove:
       - x-kuma-tags

--- a/pkg/plugins/runtime/gateway/testdata/https/03-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/03-gateway-route.yaml
@@ -100,7 +100,6 @@ Listeners:
             serverName: Kuma Gateway
             statPrefix: gateway-default
             streamIdleTimeout: 5s
-            stripAnyHostPort: true
             useRemoteAddress: true
         transportSocket:
           name: envoy.transport_sockets.tls

--- a/pkg/plugins/runtime/gateway/testdata/https/03-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/03-gateway-route.yaml
@@ -127,6 +127,7 @@ Listeners:
 Routes:
   Resources:
     edge-gateway:HTTPS:8080:
+      ignorePortInHostMatching: true
       name: edge-gateway:HTTPS:8080
       requestHeadersToRemove:
       - x-kuma-tags

--- a/pkg/plugins/runtime/gateway/testdata/https/04-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/04-gateway-route.yaml
@@ -157,6 +157,7 @@ Listeners:
 Routes:
   Resources:
     edge-gateway:HTTPS:8080:
+      ignorePortInHostMatching: true
       name: edge-gateway:HTTPS:8080
       requestHeadersToRemove:
       - x-kuma-tags

--- a/pkg/plugins/runtime/gateway/testdata/https/04-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/04-gateway-route.yaml
@@ -130,7 +130,6 @@ Listeners:
             serverName: Kuma Gateway
             statPrefix: gateway-default
             streamIdleTimeout: 5s
-            stripAnyHostPort: true
             useRemoteAddress: true
         transportSocket:
           name: envoy.transport_sockets.tls

--- a/pkg/plugins/runtime/gateway/testdata/https/05-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/05-gateway-route.yaml
@@ -83,6 +83,7 @@ Listeners:
 Routes:
   Resources:
     edge-gateway:HTTPS:8080:
+      ignorePortInHostMatching: true
       name: edge-gateway:HTTPS:8080
       requestHeadersToRemove:
       - x-kuma-tags

--- a/pkg/plugins/runtime/gateway/testdata/https/05-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/05-gateway-route.yaml
@@ -56,7 +56,6 @@ Listeners:
             serverName: Kuma Gateway
             statPrefix: gateway-default
             streamIdleTimeout: 5s
-            stripAnyHostPort: true
             useRemoteAddress: true
         transportSocket:
           name: envoy.transport_sockets.tls

--- a/pkg/plugins/runtime/gateway/testdata/https/06-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/06-gateway-route.yaml
@@ -157,6 +157,7 @@ Listeners:
 Routes:
   Resources:
     edge-gateway:HTTPS:8080:
+      ignorePortInHostMatching: true
       name: edge-gateway:HTTPS:8080
       requestHeadersToRemove:
       - x-kuma-tags

--- a/pkg/plugins/runtime/gateway/testdata/https/06-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/06-gateway-route.yaml
@@ -130,7 +130,6 @@ Listeners:
             serverName: Kuma Gateway
             statPrefix: gateway-default
             streamIdleTimeout: 5s
-            stripAnyHostPort: true
             useRemoteAddress: true
         transportSocket:
           name: envoy.transport_sockets.tls

--- a/pkg/plugins/runtime/gateway/testdata/https/07-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/07-gateway-route.yaml
@@ -100,7 +100,6 @@ Listeners:
             serverName: Kuma Gateway
             statPrefix: gateway-default
             streamIdleTimeout: 5s
-            stripAnyHostPort: true
             useRemoteAddress: true
         transportSocket:
           name: envoy.transport_sockets.tls

--- a/pkg/plugins/runtime/gateway/testdata/https/07-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/07-gateway-route.yaml
@@ -127,6 +127,7 @@ Listeners:
 Routes:
   Resources:
     edge-gateway:HTTPS:8080:
+      ignorePortInHostMatching: true
       name: edge-gateway:HTTPS:8080
       requestHeadersToRemove:
       - x-kuma-tags

--- a/pkg/plugins/runtime/gateway/testdata/https/08-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/08-gateway-route.yaml
@@ -171,6 +171,7 @@ Listeners:
 Routes:
   Resources:
     edge-gateway:HTTPS:8080:
+      ignorePortInHostMatching: true
       name: edge-gateway:HTTPS:8080
       requestHeadersToRemove:
       - x-kuma-tags

--- a/pkg/plugins/runtime/gateway/testdata/https/08-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/08-gateway-route.yaml
@@ -144,7 +144,6 @@ Listeners:
             serverName: Kuma Gateway
             statPrefix: gateway-default
             streamIdleTimeout: 5s
-            stripAnyHostPort: true
             useRemoteAddress: true
         transportSocket:
           name: envoy.transport_sockets.tls

--- a/pkg/plugins/runtime/gateway/testdata/https/09-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/09-gateway-route.yaml
@@ -100,7 +100,6 @@ Listeners:
             serverName: Kuma Gateway
             statPrefix: gateway-default
             streamIdleTimeout: 5s
-            stripAnyHostPort: true
             useRemoteAddress: true
         transportSocket:
           name: envoy.transport_sockets.tls

--- a/pkg/plugins/runtime/gateway/testdata/https/09-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/09-gateway-route.yaml
@@ -127,6 +127,7 @@ Listeners:
 Routes:
   Resources:
     edge-gateway:HTTPS:8080:
+      ignorePortInHostMatching: true
       name: edge-gateway:HTTPS:8080
       requestHeadersToRemove:
       - x-kuma-tags

--- a/pkg/plugins/runtime/gateway/testdata/https/10-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/10-gateway-route.yaml
@@ -204,7 +204,6 @@ Listeners:
             serverName: Kuma Gateway
             statPrefix: gateway-default
             streamIdleTimeout: 5s
-            stripAnyHostPort: true
             useRemoteAddress: true
         transportSocket:
           name: envoy.transport_sockets.tls

--- a/pkg/plugins/runtime/gateway/testdata/https/10-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/10-gateway-route.yaml
@@ -231,6 +231,7 @@ Listeners:
 Routes:
   Resources:
     edge-gateway:HTTPS:8080:
+      ignorePortInHostMatching: true
       name: edge-gateway:HTTPS:8080
       requestHeadersToRemove:
       - x-kuma-tags

--- a/pkg/plugins/runtime/gateway/testdata/https/11-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/11-gateway-route.yaml
@@ -171,6 +171,7 @@ Listeners:
 Routes:
   Resources:
     edge-gateway:HTTPS:8080:
+      ignorePortInHostMatching: true
       name: edge-gateway:HTTPS:8080
       requestHeadersToRemove:
       - x-kuma-tags

--- a/pkg/plugins/runtime/gateway/testdata/https/11-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/11-gateway-route.yaml
@@ -144,7 +144,6 @@ Listeners:
             serverName: Kuma Gateway
             statPrefix: gateway-default
             streamIdleTimeout: 5s
-            stripAnyHostPort: true
             useRemoteAddress: true
         transportSocket:
           name: envoy.transport_sockets.tls

--- a/pkg/plugins/runtime/gateway/testdata/https/12-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/12-gateway-route.yaml
@@ -100,7 +100,6 @@ Listeners:
             serverName: Kuma Gateway
             statPrefix: gateway-default
             streamIdleTimeout: 5s
-            stripAnyHostPort: true
             useRemoteAddress: true
         transportSocket:
           name: envoy.transport_sockets.tls

--- a/pkg/plugins/runtime/gateway/testdata/https/12-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/12-gateway-route.yaml
@@ -127,6 +127,7 @@ Listeners:
 Routes:
   Resources:
     edge-gateway:HTTPS:8080:
+      ignorePortInHostMatching: true
       name: edge-gateway:HTTPS:8080
       requestHeadersToRemove:
       - x-kuma-tags

--- a/pkg/plugins/runtime/gateway/testdata/https/13-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/13-gateway-route.yaml
@@ -215,6 +215,7 @@ Listeners:
 Routes:
   Resources:
     edge-gateway:HTTPS:8080:
+      ignorePortInHostMatching: true
       name: edge-gateway:HTTPS:8080
       requestHeadersToRemove:
       - x-kuma-tags

--- a/pkg/plugins/runtime/gateway/testdata/https/13-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/13-gateway-route.yaml
@@ -188,7 +188,6 @@ Listeners:
             serverName: Kuma Gateway
             statPrefix: gateway-default
             streamIdleTimeout: 5s
-            stripAnyHostPort: true
             useRemoteAddress: true
         transportSocket:
           name: envoy.transport_sockets.tls

--- a/pkg/plugins/runtime/gateway/testdata/https/14-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/14-gateway-route.yaml
@@ -100,7 +100,6 @@ Listeners:
             serverName: Kuma Gateway
             statPrefix: gateway-default
             streamIdleTimeout: 5s
-            stripAnyHostPort: true
             useRemoteAddress: true
         transportSocket:
           name: envoy.transport_sockets.tls

--- a/pkg/plugins/runtime/gateway/testdata/https/14-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/14-gateway-route.yaml
@@ -127,6 +127,7 @@ Listeners:
 Routes:
   Resources:
     edge-gateway:HTTPS:8080:
+      ignorePortInHostMatching: true
       name: edge-gateway:HTTPS:8080
       requestHeadersToRemove:
       - x-kuma-tags

--- a/pkg/plugins/runtime/gateway/testdata/https/15-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/15-gateway-route.yaml
@@ -215,6 +215,7 @@ Listeners:
 Routes:
   Resources:
     edge-gateway:HTTPS:8080:
+      ignorePortInHostMatching: true
       name: edge-gateway:HTTPS:8080
       requestHeadersToRemove:
       - x-kuma-tags

--- a/pkg/plugins/runtime/gateway/testdata/https/15-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/15-gateway-route.yaml
@@ -188,7 +188,6 @@ Listeners:
             serverName: Kuma Gateway
             statPrefix: gateway-default
             streamIdleTimeout: 5s
-            stripAnyHostPort: true
             useRemoteAddress: true
         transportSocket:
           name: envoy.transport_sockets.tls

--- a/pkg/plugins/runtime/gateway/testdata/https/16-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/16-gateway-route.yaml
@@ -185,7 +185,6 @@ Listeners:
             serverName: Kuma Gateway
             statPrefix: gateway-default
             streamIdleTimeout: 5s
-            stripAnyHostPort: true
             useRemoteAddress: true
         transportSocket:
           name: envoy.transport_sockets.tls

--- a/pkg/plugins/runtime/gateway/testdata/https/16-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/16-gateway-route.yaml
@@ -212,6 +212,7 @@ Listeners:
 Routes:
   Resources:
     edge-gateway:HTTPS:8080:
+      ignorePortInHostMatching: true
       name: edge-gateway:HTTPS:8080
       requestHeadersToRemove:
       - x-kuma-tags

--- a/pkg/plugins/runtime/gateway/testdata/https/17-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/17-gateway-route.yaml
@@ -233,6 +233,7 @@ Listeners:
 Routes:
   Resources:
     edge-gateway:HTTPS:8080:
+      ignorePortInHostMatching: true
       name: edge-gateway:HTTPS:8080
       requestHeadersToRemove:
       - x-kuma-tags

--- a/pkg/plugins/runtime/gateway/testdata/https/17-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/17-gateway-route.yaml
@@ -206,7 +206,6 @@ Listeners:
             serverName: Kuma Gateway
             statPrefix: gateway-default
             streamIdleTimeout: 5s
-            stripAnyHostPort: true
             useRemoteAddress: true
         transportSocket:
           name: envoy.transport_sockets.tls

--- a/pkg/plugins/runtime/gateway/testdata/https/18-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/18-gateway-route.yaml
@@ -97,7 +97,6 @@ Listeners:
             serverName: Kuma Gateway
             statPrefix: gateway-default
             streamIdleTimeout: 5s
-            stripAnyHostPort: true
             useRemoteAddress: true
         transportSocket:
           name: envoy.transport_sockets.tls

--- a/pkg/plugins/runtime/gateway/testdata/https/18-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/18-gateway-route.yaml
@@ -124,6 +124,7 @@ Listeners:
 Routes:
   Resources:
     edge-gateway:HTTPS:8080:
+      ignorePortInHostMatching: true
       name: edge-gateway:HTTPS:8080
       requestHeadersToRemove:
       - x-kuma-tags

--- a/pkg/plugins/runtime/gateway/testdata/https/19-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/19-gateway-route.yaml
@@ -111,7 +111,6 @@ Listeners:
             serverName: Kuma Gateway
             statPrefix: gateway-default
             streamIdleTimeout: 5s
-            stripAnyHostPort: true
             useRemoteAddress: true
         transportSocket:
           name: envoy.transport_sockets.tls

--- a/pkg/plugins/runtime/gateway/testdata/https/19-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/19-gateway-route.yaml
@@ -138,6 +138,7 @@ Listeners:
 Routes:
   Resources:
     edge-gateway:HTTPS:8080:
+      ignorePortInHostMatching: true
       name: edge-gateway:HTTPS:8080
       requestHeadersToRemove:
       - x-kuma-tags

--- a/pkg/plugins/runtime/gateway/testdata/https/20-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/20-gateway-route.yaml
@@ -339,6 +339,7 @@ Listeners:
 Routes:
   Resources:
     gateway-multihost:HTTPS:9443:
+      ignorePortInHostMatching: true
       name: gateway-multihost:HTTPS:9443
       requestHeadersToRemove:
       - x-kuma-tags

--- a/pkg/plugins/runtime/gateway/testdata/https/20-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/20-gateway-route.yaml
@@ -188,7 +188,6 @@ Listeners:
             serverName: Kuma Gateway
             statPrefix: gateway-multihost
             streamIdleTimeout: 5s
-            stripAnyHostPort: true
             useRemoteAddress: true
         transportSocket:
           name: envoy.transport_sockets.tls
@@ -251,7 +250,6 @@ Listeners:
             serverName: Kuma Gateway
             statPrefix: gateway-multihost
             streamIdleTimeout: 5s
-            stripAnyHostPort: true
             useRemoteAddress: true
         transportSocket:
           name: envoy.transport_sockets.tls
@@ -314,7 +312,6 @@ Listeners:
             serverName: Kuma Gateway
             statPrefix: gateway-multihost
             streamIdleTimeout: 5s
-            stripAnyHostPort: true
             useRemoteAddress: true
         transportSocket:
           name: envoy.transport_sockets.tls

--- a/pkg/plugins/runtime/gateway/testdata/https/21-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/21-gateway-route.yaml
@@ -215,6 +215,7 @@ Listeners:
 Routes:
   Resources:
     edge-gateway:HTTPS:8080:
+      ignorePortInHostMatching: true
       name: edge-gateway:HTTPS:8080
       requestHeadersToRemove:
       - x-kuma-tags

--- a/pkg/plugins/runtime/gateway/testdata/https/21-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/21-gateway-route.yaml
@@ -188,7 +188,6 @@ Listeners:
             serverName: Kuma Gateway
             statPrefix: gateway-default
             streamIdleTimeout: 5s
-            stripAnyHostPort: true
             useRemoteAddress: true
         transportSocket:
           name: envoy.transport_sockets.tls

--- a/pkg/plugins/runtime/gateway/testdata/https/22-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/22-gateway-route.yaml
@@ -151,6 +151,7 @@ Listeners:
 Routes:
   Resources:
     edge-gateway:HTTP:8080:
+      ignorePortInHostMatching: true
       name: edge-gateway:HTTP:8080
       requestHeadersToRemove:
       - x-kuma-tags

--- a/pkg/plugins/runtime/gateway/testdata/https/22-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/22-gateway-route.yaml
@@ -140,7 +140,6 @@ Listeners:
             serverName: Kuma Gateway
             statPrefix: gateway-default
             streamIdleTimeout: 5s
-            stripAnyHostPort: true
             useRemoteAddress: true
       listenerFilters:
       - name: envoy.filters.listener.tls_inspector

--- a/pkg/plugins/runtime/gateway/testdata/https/23-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/23-gateway-route.yaml
@@ -195,6 +195,7 @@ Listeners:
 Routes:
   Resources:
     edge-gateway:HTTP:8080:
+      ignorePortInHostMatching: true
       name: edge-gateway:HTTP:8080
       requestHeadersToRemove:
       - x-kuma-tags

--- a/pkg/plugins/runtime/gateway/testdata/https/23-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/23-gateway-route.yaml
@@ -184,7 +184,6 @@ Listeners:
             serverName: Kuma Gateway
             statPrefix: gateway-default
             streamIdleTimeout: 5s
-            stripAnyHostPort: true
             useRemoteAddress: true
       listenerFilters:
       - name: envoy.filters.listener.tls_inspector

--- a/pkg/plugins/runtime/gateway/testdata/https/24-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/24-gateway-route.yaml
@@ -151,6 +151,7 @@ Listeners:
 Routes:
   Resources:
     edge-gateway:HTTP:8080:
+      ignorePortInHostMatching: true
       name: edge-gateway:HTTP:8080
       requestHeadersToRemove:
       - x-kuma-tags

--- a/pkg/plugins/runtime/gateway/testdata/https/24-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/24-gateway-route.yaml
@@ -140,7 +140,6 @@ Listeners:
             serverName: Kuma Gateway
             statPrefix: gateway-default
             streamIdleTimeout: 5s
-            stripAnyHostPort: true
             useRemoteAddress: true
       listenerFilters:
       - name: envoy.filters.listener.tls_inspector

--- a/pkg/plugins/runtime/gateway/testdata/https/25-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/25-gateway-route.yaml
@@ -124,7 +124,6 @@ Listeners:
             serverName: Kuma Gateway
             statPrefix: gateway-default
             streamIdleTimeout: 5s
-            stripAnyHostPort: true
             useRemoteAddress: true
         transportSocket:
           name: envoy.transport_sockets.tls

--- a/pkg/plugins/runtime/gateway/testdata/https/25-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/25-gateway-route.yaml
@@ -151,6 +151,7 @@ Listeners:
 Routes:
   Resources:
     edge-gateway:HTTPS:8080:
+      ignorePortInHostMatching: true
       name: edge-gateway:HTTPS:8080
       requestHeadersToRemove:
       - x-kuma-tags

--- a/pkg/plugins/runtime/gateway/testdata/https/26-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/26-gateway-route.yaml
@@ -110,7 +110,6 @@ Listeners:
             serverName: Kuma Gateway
             statPrefix: gateway-default
             streamIdleTimeout: 5s
-            stripAnyHostPort: true
             useRemoteAddress: true
         transportSocket:
           name: envoy.transport_sockets.tls

--- a/pkg/plugins/runtime/gateway/testdata/https/26-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/26-gateway-route.yaml
@@ -137,6 +137,7 @@ Listeners:
 Routes:
   Resources:
     edge-gateway:HTTPS:8080:
+      ignorePortInHostMatching: true
       name: edge-gateway:HTTPS:8080
       requestHeadersToRemove:
       - x-kuma-tags

--- a/pkg/plugins/runtime/gateway/testdata/https/cross-mesh-gateway.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/cross-mesh-gateway.yaml
@@ -208,6 +208,7 @@ Listeners:
 Routes:
   Resources:
     edge-gateway:HTTP:8080:
+      ignorePortInHostMatching: true
       name: edge-gateway:HTTP:8080
       requestHeadersToRemove:
       - x-kuma-tags

--- a/pkg/plugins/runtime/gateway/testdata/https/cross-mesh-gateway.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/cross-mesh-gateway.yaml
@@ -179,7 +179,6 @@ Listeners:
             serverName: Kuma Gateway
             statPrefix: gateway-default
             streamIdleTimeout: 5s
-            stripAnyHostPort: true
             useRemoteAddress: true
         transportSocket:
           name: envoy.transport_sockets.tls

--- a/pkg/plugins/runtime/gateway/testdata/https/drop-prefix-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/drop-prefix-gateway-route.yaml
@@ -100,7 +100,6 @@ Listeners:
             serverName: Kuma Gateway
             statPrefix: gateway-default
             streamIdleTimeout: 5s
-            stripAnyHostPort: true
             useRemoteAddress: true
         transportSocket:
           name: envoy.transport_sockets.tls

--- a/pkg/plugins/runtime/gateway/testdata/https/drop-prefix-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/drop-prefix-gateway-route.yaml
@@ -127,6 +127,7 @@ Listeners:
 Routes:
   Resources:
     edge-gateway:HTTPS:8080:
+      ignorePortInHostMatching: true
       name: edge-gateway:HTTPS:8080
       requestHeadersToRemove:
       - x-kuma-tags

--- a/pkg/plugins/runtime/gateway/testdata/https/external-service-with-timeout-no-egress.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/external-service-with-timeout-no-egress.yaml
@@ -119,6 +119,7 @@ Listeners:
 Routes:
   Resources:
     edge-gateway:HTTP:8080:
+      ignorePortInHostMatching: true
       name: edge-gateway:HTTP:8080
       requestHeadersToRemove:
       - x-kuma-tags

--- a/pkg/plugins/runtime/gateway/testdata/https/external-service-with-timeout-no-egress.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/external-service-with-timeout-no-egress.yaml
@@ -108,7 +108,6 @@ Listeners:
             serverName: Kuma Gateway
             statPrefix: gateway-default
             streamIdleTimeout: 5s
-            stripAnyHostPort: true
             useRemoteAddress: true
       listenerFilters:
       - name: envoy.filters.listener.tls_inspector

--- a/pkg/plugins/runtime/gateway/testdata/https/http-tcp-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/http-tcp-route.yaml
@@ -83,6 +83,7 @@ Listeners:
 Routes:
   Resources:
     edge-gateway:HTTPS:8080:
+      ignorePortInHostMatching: true
       name: edge-gateway:HTTPS:8080
       requestHeadersToRemove:
       - x-kuma-tags

--- a/pkg/plugins/runtime/gateway/testdata/https/http-tcp-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/http-tcp-route.yaml
@@ -56,7 +56,6 @@ Listeners:
             serverName: Kuma Gateway
             statPrefix: gateway-default
             streamIdleTimeout: 5s
-            stripAnyHostPort: true
             useRemoteAddress: true
         transportSocket:
           name: envoy.transport_sockets.tls

--- a/pkg/plugins/runtime/gateway/testdata/https/no-timeout.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/no-timeout.yaml
@@ -100,7 +100,6 @@ Listeners:
             serverName: Kuma Gateway
             statPrefix: gateway-default
             streamIdleTimeout: 5s
-            stripAnyHostPort: true
             useRemoteAddress: true
         transportSocket:
           name: envoy.transport_sockets.tls

--- a/pkg/plugins/runtime/gateway/testdata/https/no-timeout.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/no-timeout.yaml
@@ -127,6 +127,7 @@ Listeners:
 Routes:
   Resources:
     edge-gateway:HTTPS:8080:
+      ignorePortInHostMatching: true
       name: edge-gateway:HTTPS:8080
       requestHeadersToRemove:
       - x-kuma-tags

--- a/pkg/plugins/runtime/gateway/testdata/https/response-header-set-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/response-header-set-gateway-route.yaml
@@ -100,7 +100,6 @@ Listeners:
             serverName: Kuma Gateway
             statPrefix: gateway-default
             streamIdleTimeout: 5s
-            stripAnyHostPort: true
             useRemoteAddress: true
         transportSocket:
           name: envoy.transport_sockets.tls

--- a/pkg/plugins/runtime/gateway/testdata/https/response-header-set-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/response-header-set-gateway-route.yaml
@@ -127,6 +127,7 @@ Listeners:
 Routes:
   Resources:
     edge-gateway:HTTPS:8080:
+      ignorePortInHostMatching: true
       name: edge-gateway:HTTPS:8080
       requestHeadersToRemove:
       - x-kuma-tags

--- a/pkg/plugins/runtime/gateway/testdata/https/retry-policy.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/retry-policy.yaml
@@ -215,6 +215,7 @@ Listeners:
 Routes:
   Resources:
     edge-gateway:HTTPS:8080:
+      ignorePortInHostMatching: true
       name: edge-gateway:HTTPS:8080
       requestHeadersToRemove:
       - x-kuma-tags

--- a/pkg/plugins/runtime/gateway/testdata/https/retry-policy.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/retry-policy.yaml
@@ -188,7 +188,6 @@ Listeners:
             serverName: Kuma Gateway
             statPrefix: gateway-default
             streamIdleTimeout: 5s
-            stripAnyHostPort: true
             useRemoteAddress: true
         transportSocket:
           name: envoy.transport_sockets.tls

--- a/pkg/plugins/runtime/gateway/testdata/https/rewrite-prefix-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/rewrite-prefix-gateway-route.yaml
@@ -100,7 +100,6 @@ Listeners:
             serverName: Kuma Gateway
             statPrefix: gateway-default
             streamIdleTimeout: 5s
-            stripAnyHostPort: true
             useRemoteAddress: true
         transportSocket:
           name: envoy.transport_sockets.tls

--- a/pkg/plugins/runtime/gateway/testdata/https/rewrite-prefix-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/rewrite-prefix-gateway-route.yaml
@@ -127,6 +127,7 @@ Listeners:
 Routes:
   Resources:
     edge-gateway:HTTPS:8080:
+      ignorePortInHostMatching: true
       name: edge-gateway:HTTPS:8080
       requestHeadersToRemove:
       - x-kuma-tags

--- a/pkg/plugins/runtime/gateway/testdata/https/rewrite-prefix-trailing-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/rewrite-prefix-trailing-gateway-route.yaml
@@ -100,7 +100,6 @@ Listeners:
             serverName: Kuma Gateway
             statPrefix: gateway-default
             streamIdleTimeout: 5s
-            stripAnyHostPort: true
             useRemoteAddress: true
         transportSocket:
           name: envoy.transport_sockets.tls

--- a/pkg/plugins/runtime/gateway/testdata/https/rewrite-prefix-trailing-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/rewrite-prefix-trailing-gateway-route.yaml
@@ -127,6 +127,7 @@ Listeners:
 Routes:
   Resources:
     edge-gateway:HTTPS:8080:
+      ignorePortInHostMatching: true
       name: edge-gateway:HTTPS:8080
       requestHeadersToRemove:
       - x-kuma-tags

--- a/pkg/plugins/runtime/gateway/testdata/https/unresolved-backend.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/unresolved-backend.yaml
@@ -83,6 +83,7 @@ Listeners:
 Routes:
   Resources:
     edge-gateway:HTTPS:8080:
+      ignorePortInHostMatching: true
       name: edge-gateway:HTTPS:8080
       requestHeadersToRemove:
       - x-kuma-tags

--- a/pkg/plugins/runtime/gateway/testdata/https/unresolved-backend.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/unresolved-backend.yaml
@@ -56,7 +56,6 @@ Listeners:
             serverName: Kuma Gateway
             statPrefix: gateway-default
             streamIdleTimeout: 5s
-            stripAnyHostPort: true
             useRemoteAddress: true
         transportSocket:
           name: envoy.transport_sockets.tls

--- a/pkg/xds/envoy/routes/configurers.go
+++ b/pkg/xds/envoy/routes/configurers.go
@@ -110,3 +110,12 @@ func CommonRouteConfiguration(name string) RouteConfigurationBuilderOpt {
 			Name: name,
 		})
 }
+
+func IgnorePortInHostMatching() RouteConfigurationBuilderOpt {
+	return AddRouteConfigurationConfigurer(
+		v3.RouteConfigurationConfigureFunc(func(rc *envoy_route.RouteConfiguration) error {
+			rc.IgnorePortInHostMatching = true
+			return nil
+		}),
+	)
+}

--- a/test/e2e_env/kubernetes/gateway/gateway.go
+++ b/test/e2e_env/kubernetes/gateway/gateway.go
@@ -136,12 +136,25 @@ spec:
 			Expect(err).ToNot(HaveOccurred())
 		})
 
-		It("should proxy to service via HTTP", func() {
+		It("should proxy to service via HTTP without port in host", func() {
 			Eventually(func(g Gomega) {
 				response, err := client.CollectEchoResponse(
 					kubernetes.Cluster, "demo-client",
 					"http://simple-gateway.simple-gateway:8080/",
 					client.WithHeader("host", "example.kuma.io"),
+					client.FromKubernetesPod(clientNamespace, "demo-client"),
+				)
+
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(response.Instance).To(Equal("echo-server"))
+			}, "30s", "1s").Should(Succeed())
+		})
+		It("should proxy to service via HTTP with port in host", func() {
+			Eventually(func(g Gomega) {
+				response, err := client.CollectEchoResponse(
+					kubernetes.Cluster, "demo-client",
+					"http://simple-gateway.simple-gateway:8080/",
+					client.WithHeader("host", "example.kuma.io:8080"),
 					client.FromKubernetesPod(clientNamespace, "demo-client"),
 				)
 


### PR DESCRIPTION
This was included presumably so that we can match hosts without caring about the port but it actually _mutates_ the incoming request, which a gateway should try to avoid. There's a relatively new option `ignore_port_in_host_matching` we can use instead. Also added [a test that fails when we remove `strip_any_host_port`](https://app.circleci.com/pipelines/github/kumahq/kuma/21935/workflows/a743fb5b-6378-4353-8bde-e24efd0bf1a0/jobs/403521) then succeeds when `ignore_port_in_host_matching` is included.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [x] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
