### PR TITLE
chore(MeshGateway): remove comment, not using strip_any_host_port anymore

### DIFF
--- a/pkg/plugins/runtime/gateway/route/configurers.go
+++ b/pkg/plugins/runtime/gateway/route/configurers.go
@@ -365,10 +365,6 @@ func RouteActionRedirect(redirect *Redirection, port uint32) RouteConfigurer {
 		if redirect.Port > 0 {
 			envoyRedirect.PortRedirect = redirect.Port
 		} else {
-			// Here explicitly set the port the listener is listening on
-			// because apparently strip_any_host_port actually changes the port
-			// of the request even for redirecting...
-			// Looks like https://github.com/envoyproxy/envoy/issues/19589
 			envoyRedirect.PortRedirect = port
 		}
 		if rewrite := redirect.PathRewrite; rewrite != nil {


### PR DESCRIPTION
Left over from #6755 

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [x] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
