### PR TITLE
ci(lint): clean up useless excluded-rules from golangci-lint.yml

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -129,22 +129,6 @@ issues:
     - linters: # AdminPort is deprecated, but it's used to support backwards compatibility
         - staticcheck
       text: "SA1019: c.Runtime.Kubernetes.Injector.SidecarContainer.AdminPort is deprecated: Use KUMA_BOOTSTRAP_SERVER_PARAMS_ADMIN_PORT instead."
-    - path: pkg/api-server/inspect_endpoints.go
-      linters:
-        - staticcheck
-      text: "SA1019: rest_unversioned.From.Resource is deprecated"
-    - path: pkg/api-server/types/inspect_test.go
-      linters:
-        - staticcheck
-      text: "SA1019: rest_unversioned.From.Resource is deprecated"
-    - path: pkg/api-server/service_insight_endpoints.go
-      linters:
-        - staticcheck
-      text: "SA1019: rest_unversioned.From.Resource is deprecated"
     - linters:
         - staticcheck
       text: "SA1019: .* for new policies use pkg/plugins/policies/xds/cluster.go"
-    - linters:
-        - gosec
-      path: pkg/transparent-proxy/istio
-


### PR DESCRIPTION
`staticcheck` and `gosec` don't see any errors anymore

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [ ] [Link to relevant issue][1] as well as docs and UI issues --
- [ ] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [ ] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [ ] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [ ] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [ ] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
