### PR TITLE
test(e2e): add option to set init scripts for postgres

### DIFF
--- a/test/framework/deployments/postgres/deployment.go
+++ b/test/framework/deployments/postgres/deployment.go
@@ -45,6 +45,7 @@ type deployOptions struct {
 	database         string
 	primaryName      string
 	postgresPassword string
+	initScript       string
 }
 type DeployOptionsFunc func(*deployOptions)
 
@@ -105,5 +106,11 @@ func WithPrimaryName(primaryName string) DeployOptionsFunc {
 func WithPostgresPassword(postgresPassword string) DeployOptionsFunc {
 	return func(o *deployOptions) {
 		o.postgresPassword = postgresPassword
+	}
+}
+
+func WithInitScript(initScript string) DeployOptionsFunc {
+	return func(o *deployOptions) {
+		o.initScript = initScript
 	}
 }

--- a/test/framework/deployments/postgres/kubernetes.go
+++ b/test/framework/deployments/postgres/kubernetes.go
@@ -1,6 +1,8 @@
 package postgres
 
 import (
+	"fmt"
+
 	"github.com/gruntwork-io/terratest/modules/helm"
 
 	"github.com/kumahq/kuma/test/framework"
@@ -33,6 +35,23 @@ func (t *k8SDeployment) Deploy(cluster framework.Cluster) error {
 			"postgresql.primary.fullname":             t.options.primaryName,
 		},
 		KubectlOptions: cluster.GetKubectlOptions(t.options.namespace),
+	}
+	if t.options.initScript != "" {
+		initScriptCfg := fmt.Sprintf(`
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: init-script
+  namespace: %s
+data:
+  0001-load.sql: "%s"
+`, t.options.namespace, t.options.initScript)
+		if err := cluster.Install(framework.YamlK8s(initScriptCfg)); err != nil {
+			return err
+		}
+		helmOpts.SetValues["primary.initdb.scriptsConfigMap"] = "init-script"
+		helmOpts.SetValues["primary.initdb.user"] = "postgres"
+		helmOpts.SetValues["primary.initdb.password"] = t.options.postgresPassword
 	}
 
 	err := helm.AddRepoE(cluster.GetTesting(), helmOpts, "bitnami", "https://charts.bitnami.com/bitnami")


### PR DESCRIPTION
### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [ ] [Link to relevant issue][1] as well as docs and UI issues --
- [ ] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [ ] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [ ] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [ ] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [ ] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
