### PR TITLE
Revert "ci(lint): clean up useless excluded-rules from golangci-lint.yml"

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -129,6 +129,22 @@ issues:
     - linters: # AdminPort is deprecated, but it's used to support backwards compatibility
         - staticcheck
       text: "SA1019: c.Runtime.Kubernetes.Injector.SidecarContainer.AdminPort is deprecated: Use KUMA_BOOTSTRAP_SERVER_PARAMS_ADMIN_PORT instead."
+    - path: pkg/api-server/inspect_endpoints.go
+      linters:
+        - staticcheck
+      text: "SA1019: rest_unversioned.From.Resource is deprecated"
+    - path: pkg/api-server/types/inspect_test.go
+      linters:
+        - staticcheck
+      text: "SA1019: rest_unversioned.From.Resource is deprecated"
+    - path: pkg/api-server/service_insight_endpoints.go
+      linters:
+        - staticcheck
+      text: "SA1019: rest_unversioned.From.Resource is deprecated"
     - linters:
         - staticcheck
       text: "SA1019: .* for new policies use pkg/plugins/policies/xds/cluster.go"
+    - linters:
+        - gosec
+      path: pkg/transparent-proxy/istio
+


### PR DESCRIPTION
@mmorel-35 I'm sorry for the confusion, but as @michaelbeaumont mentioned some of the rules are still potentially being used. We'll remove legacy tproxy code in 2.4.0, and we should remove other deprecated code before removing the rules 😞 

Reverts kumahq/kuma#6769