### PR TITLE
fix(MeshHTTPRoute): require at least one match

### DIFF
--- a/app/kumactl/cmd/install/testdata/install-control-plane.defaults.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.defaults.golden.yaml
@@ -1459,6 +1459,8 @@ spec:
                                 type: array
                             type: object
                           matches:
+                            description: Matches describes how to match HTTP requests
+                              this rule should be applied to.
                             items:
                               properties:
                                 headers:
@@ -1547,6 +1549,7 @@ spec:
                                     type: object
                                   type: array
                               type: object
+                            minItems: 1
                             type: array
                         required:
                         - default

--- a/app/kumactl/cmd/install/testdata/install-control-plane.gateway-api-present-not-enabled.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.gateway-api-present-not-enabled.yaml
@@ -1459,6 +1459,8 @@ spec:
                                 type: array
                             type: object
                           matches:
+                            description: Matches describes how to match HTTP requests
+                              this rule should be applied to.
                             items:
                               properties:
                                 headers:
@@ -1547,6 +1549,7 @@ spec:
                                     type: object
                                   type: array
                               type: object
+                            minItems: 1
                             type: array
                         required:
                         - default

--- a/app/kumactl/cmd/install/testdata/install-control-plane.gateway-api-present.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.gateway-api-present.yaml
@@ -1662,6 +1662,8 @@ spec:
                                 type: array
                             type: object
                           matches:
+                            description: Matches describes how to match HTTP requests
+                              this rule should be applied to.
                             items:
                               properties:
                                 headers:
@@ -1750,6 +1752,7 @@ spec:
                                     type: object
                                   type: array
                               type: object
+                            minItems: 1
                             type: array
                         required:
                         - default

--- a/app/kumactl/cmd/install/testdata/install-control-plane.with-helm-set.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.with-helm-set.yaml
@@ -1479,6 +1479,8 @@ spec:
                                 type: array
                             type: object
                           matches:
+                            description: Matches describes how to match HTTP requests
+                              this rule should be applied to.
                             items:
                               properties:
                                 headers:
@@ -1567,6 +1569,7 @@ spec:
                                     type: object
                                   type: array
                               type: object
+                            minItems: 1
                             type: array
                         required:
                         - default

--- a/app/kumactl/cmd/install/testdata/install-crds.all.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-crds.all.golden.yaml
@@ -2730,6 +2730,8 @@ spec:
                                 type: array
                             type: object
                           matches:
+                            description: Matches describes how to match HTTP requests
+                              this rule should be applied to.
                             items:
                               properties:
                                 headers:
@@ -2818,6 +2820,7 @@ spec:
                                     type: object
                                   type: array
                               type: object
+                            minItems: 1
                             type: array
                         required:
                         - default

--- a/app/kumactl/cmd/install/testdata/install-crds.experimental-gatewayapi.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-crds.experimental-gatewayapi.golden.yaml
@@ -2933,6 +2933,8 @@ spec:
                                 type: array
                             type: object
                           matches:
+                            description: Matches describes how to match HTTP requests
+                              this rule should be applied to.
                             items:
                               properties:
                                 headers:
@@ -3021,6 +3023,7 @@ spec:
                                     type: object
                                   type: array
                               type: object
+                            minItems: 1
                             type: array
                         required:
                         - default

--- a/deployments/charts/kuma/crds/kuma.io_meshhttproutes.yaml
+++ b/deployments/charts/kuma/crds/kuma.io_meshhttproutes.yaml
@@ -365,6 +365,8 @@ spec:
                                 type: array
                             type: object
                           matches:
+                            description: Matches describes how to match HTTP requests
+                              this rule should be applied to.
                             items:
                               properties:
                                 headers:
@@ -453,6 +455,7 @@ spec:
                                     type: object
                                   type: array
                               type: object
+                            minItems: 1
                             type: array
                         required:
                         - default

--- a/pkg/plugins/policies/meshhttproute/api/v1alpha1/meshhttproute.go
+++ b/pkg/plugins/policies/meshhttproute/api/v1alpha1/meshhttproute.go
@@ -35,6 +35,9 @@ type To struct {
 }
 
 type Rule struct {
+	// Matches describes how to match HTTP requests this rule should be applied
+	// to.
+	// +kubebuilder:validation:MinItems=1
 	Matches []Match `json:"matches" policyMerge:"mergeKey"`
 	// Default holds routing rules that can be merged with rules from other
 	// policies.

--- a/pkg/plugins/policies/meshhttproute/api/v1alpha1/schema.yaml
+++ b/pkg/plugins/policies/meshhttproute/api/v1alpha1/schema.yaml
@@ -294,6 +294,7 @@ properties:
                         type: array
                     type: object
                   matches:
+                    description: Matches describes how to match HTTP requests this rule should be applied to.
                     items:
                       properties:
                         headers:
@@ -372,6 +373,7 @@ properties:
                             type: object
                           type: array
                       type: object
+                    minItems: 1
                     type: array
                 required:
                   - default

--- a/pkg/plugins/policies/meshhttproute/k8s/crd/kuma.io_meshhttproutes.yaml
+++ b/pkg/plugins/policies/meshhttproute/k8s/crd/kuma.io_meshhttproutes.yaml
@@ -365,6 +365,8 @@ spec:
                                 type: array
                             type: object
                           matches:
+                            description: Matches describes how to match HTTP requests
+                              this rule should be applied to.
                             items:
                               properties:
                                 headers:
@@ -453,6 +455,7 @@ spec:
                                     type: object
                                   type: array
                               type: object
+                            minItems: 1
                             type: array
                         required:
                         - default


### PR DESCRIPTION
### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [x] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
