### PR TITLE
feat(multitenancy): postgres events

### DIFF
--- a/pkg/events/eventbus.go
+++ b/pkg/events/eventbus.go
@@ -40,11 +40,7 @@ func (b *EventBus) Send(event Event) {
 	switch e := event.(type) {
 	case ResourceChangedEvent:
 		for _, channel := range b.subscribers {
-			channel <- ResourceChangedEvent{
-				Operation: e.Operation,
-				Type:      e.Type,
-				Key:       e.Key,
-			}
+			channel <- e
 		}
 	}
 }

--- a/pkg/events/interfaces.go
+++ b/pkg/events/interfaces.go
@@ -20,6 +20,7 @@ type ResourceChangedEvent struct {
 	Operation Op
 	Type      model.ResourceType
 	Key       model.ResourceKey
+	TenantID  string
 }
 
 var ListenerStoppedErr = errors.New("listener closed")

--- a/pkg/plugins/resources/postgres/events/listener.go
+++ b/pkg/plugins/resources/postgres/events/listener.go
@@ -61,9 +61,10 @@ func (k *listener) Start(stop <-chan struct{}) error {
 			obj := &struct {
 				Action string `json:"action"`
 				Data   struct {
-					Name string `json:"name"`
-					Mesh string `json:"mesh"`
-					Type string `json:"type"`
+					Name     string `json:"name"`
+					Mesh     string `json:"mesh"`
+					Type     string `json:"type"`
+					TenantID string `json:"tenant_id"` // It is always empty with current implementation
 				}
 			}{}
 			if err := json.Unmarshal([]byte(n.Payload), obj); err != nil {
@@ -86,6 +87,7 @@ func (k *listener) Start(stop <-chan struct{}) error {
 				Operation: op,
 				Type:      model.ResourceType(obj.Data.Type),
 				Key:       model.ResourceKey{Mesh: obj.Data.Mesh, Name: obj.Data.Name},
+				TenantID:  obj.Data.TenantID,
 			})
 		case <-stop:
 			log.Info("stop")

--- a/pkg/plugins/resources/postgres/migrations/data/1610445956_update_notify_event.up.sql
+++ b/pkg/plugins/resources/postgres/migrations/data/1610445956_update_notify_event.up.sql
@@ -14,11 +14,13 @@ BEGIN
             'name', OLD.name,
             'mesh', OLD.mesh,
             'type', OLD.type);
+        -- tenant_id is always empty so do not include it in JSON
     ELSE
         data = json_build_object(
                 'name', NEW.name,
                 'mesh', NEW.mesh,
                 'type', NEW.type);
+        -- tenant_id is always empty so do not include it in JSON
     END IF;
 
     -- Construct the notification as a JSON string.


### PR DESCRIPTION
### Checklist prior to review

Fix #6746

Remove iterating over all tenants in resyncer.
Give possibility to plug in tenant to events.

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [X] [Link to relevant issue][1] as well as docs and UI issues --
- [X] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [X] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [X] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [X] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [X] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
