### PR TITLE
feat(insights): include tenant id in insights info key

### DIFF
--- a/pkg/insights/resyncer.go
+++ b/pkg/insights/resyncer.go
@@ -69,7 +69,7 @@ type resyncer struct {
 	// info provides an information about the last sync for both ServiceInsight and MeshInsight
 	// Previously this data was stored in the Resource itself, but since resyncer runs only on leader
 	// we can just save this in memory and save requests to the DB.
-	infos                map[model.ResourceKey]syncInfo
+	infos                map[string]syncInfo
 	infosMux             sync.RWMutex
 	addressPortGenerator func(string) string
 
@@ -99,7 +99,7 @@ func NewResyncer(config *Config, tenantFn multitenant.Tenants) component.Compone
 		rm:                   config.ResourceManager,
 		rateLimiterFactory:   config.RateLimiterFactory,
 		rateLimiters:         map[string]*rate.Limiter{},
-		infos:                map[model.ResourceKey]syncInfo{},
+		infos:                map[string]syncInfo{},
 		registry:             config.Registry,
 		addressPortGenerator: config.AddressPortGenerator,
 		now:                  config.Now,
@@ -207,7 +207,7 @@ func (r *resyncer) createOrUpdateServiceInsights(ctx context.Context, now time.T
 		return err
 	}
 	for _, mesh := range meshes.Items {
-		if need := r.needResyncServiceInsight(mesh.GetMeta().GetName()); !need {
+		if need := r.needResyncServiceInsight(ctx, mesh.GetMeta().GetName()); !need {
 			continue
 		}
 		err := r.createOrUpdateServiceInsight(ctx, mesh.GetMeta().GetName(), now)
@@ -308,11 +308,11 @@ func (r *resyncer) createOrUpdateServiceInsight(ctx context.Context, mesh string
 	}
 
 	key := ServiceInsightKey(mesh)
-	info, _ := r.getInfo(key)
+	info, _ := r.getInfo(ctx, key)
 	if proto.Equal(info.resource, insight) {
 		log.V(1).Info("no need to update ServiceInsight because the resource is the same")
 		info.lastSync = now
-		r.setInfo(key, info)
+		r.setInfo(ctx, key, info)
 		return nil
 	}
 
@@ -333,7 +333,7 @@ func (r *resyncer) createOrUpdateServiceInsight(ctx context.Context, mesh string
 		return err
 	}
 	log.V(1).Info("ServiceInsights updated")
-	r.setInfo(key, syncInfo{
+	r.setInfo(ctx, key, syncInfo{
 		resource: insight,
 		lastSync: now,
 	})
@@ -346,7 +346,7 @@ func (r *resyncer) createOrUpdateMeshInsights(ctx context.Context, now time.Time
 		return err
 	}
 	for _, mesh := range meshes.Items {
-		if need := r.needResyncMeshInsight(mesh.GetMeta().GetName()); !need {
+		if need := r.needResyncMeshInsight(ctx, mesh.GetMeta().GetName()); !need {
 			continue
 		}
 		err := r.createOrUpdateMeshInsight(ctx, mesh.GetMeta().GetName(), now)
@@ -471,11 +471,11 @@ func (r *resyncer) createOrUpdateMeshInsight(ctx context.Context, mesh string, n
 	}
 
 	key := MeshInsightKey(mesh)
-	info, _ := r.getInfo(key)
+	info, _ := r.getInfo(ctx, key)
 	if proto.Equal(info.resource, insight) {
 		log.V(1).Info("no need to update MeshInsight because the resource is the same")
 		info.lastSync = now
-		r.setInfo(key, info)
+		r.setInfo(ctx, key, info)
 		return nil
 	}
 
@@ -496,7 +496,7 @@ func (r *resyncer) createOrUpdateMeshInsight(ctx context.Context, mesh string, n
 		return err
 	}
 	log.V(1).Info("MeshInsight updated")
-	r.setInfo(key, syncInfo{
+	r.setInfo(ctx, key, syncInfo{
 		resource: insight,
 		lastSync: now,
 	})
@@ -557,32 +557,34 @@ func getOrDefault(version string) string {
 	return version
 }
 
-func (r *resyncer) needResyncServiceInsight(mesh string) bool {
-	info, exist := r.getInfo(ServiceInsightKey(mesh))
+func (r *resyncer) needResyncServiceInsight(ctx context.Context, mesh string) bool {
+	info, exist := r.getInfo(ctx, ServiceInsightKey(mesh))
 	return !exist || core.Now().Sub(info.lastSync) > r.minResyncTimeout
 }
 
-func (r *resyncer) needResyncMeshInsight(mesh string) bool {
-	info, exist := r.getInfo(MeshInsightKey(mesh))
+func (r *resyncer) needResyncMeshInsight(ctx context.Context, mesh string) bool {
+	info, exist := r.getInfo(ctx, MeshInsightKey(mesh))
 	return !exist || core.Now().Sub(info.lastSync) > r.minResyncTimeout
 }
 
-func (r *resyncer) getInfo(key model.ResourceKey) (syncInfo, bool) {
+func (r *resyncer) getInfo(ctx context.Context, key model.ResourceKey) (syncInfo, bool) {
 	r.infosMux.RLock()
 	defer r.infosMux.RUnlock()
-	info, ok := r.infos[key]
+	tenantID, _ := multitenant.TenantFromCtx(ctx)
+	info, ok := r.infos[key.Name+key.Mesh+":"+tenantID]
 	return info, ok
 }
 
-func (r *resyncer) setInfo(key model.ResourceKey, info syncInfo) {
+func (r *resyncer) setInfo(ctx context.Context, key model.ResourceKey, info syncInfo) {
 	r.infosMux.Lock()
-	r.infos[key] = info
+	tenantID, _ := multitenant.TenantFromCtx(ctx)
+	r.infos[key.Name+key.Mesh+":"+tenantID] = info
 	r.infosMux.Unlock()
 }
 
 func (r *resyncer) clearInfos() {
 	r.infosMux.Lock()
-	r.infos = map[model.ResourceKey]syncInfo{}
+	r.infos = map[string]syncInfo{}
 	r.infosMux.Unlock()
 }
 


### PR DESCRIPTION
Take into account tenant id when storing info about insights.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [X] [Link to relevant issue][1] as well as docs and UI issues --
- [X] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [X] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [X] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [X] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [X] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
