### PR TITLE
test(e2e/framework): allow to set protocol for test-server

### DIFF
--- a/test/framework/deployments/testserver/deployment.go
+++ b/test/framework/deployments/testserver/deployment.go
@@ -20,6 +20,7 @@ type DeploymentOpts struct {
 	EnableProbes       bool
 	PodAnnotations     map[string]string
 	NodeSelector       map[string]string
+	protocol           string
 }
 
 func DefaultDeploymentOpts() DeploymentOpts {
@@ -31,6 +32,7 @@ func DefaultDeploymentOpts() DeploymentOpts {
 		WaitingToBeReady: true,
 		PodAnnotations:   map[string]string{},
 		EnableProbes:     true,
+		protocol:         "http",
 	}
 }
 
@@ -111,6 +113,12 @@ func WithoutProbes() DeploymentOptsFn {
 func WithNodeSelector(selector map[string]string) DeploymentOptsFn {
 	return func(opts *DeploymentOpts) {
 		opts.NodeSelector = selector
+	}
+}
+
+func WithProtocol(protocol string) DeploymentOptsFn {
+	return func(opts *DeploymentOpts) {
+		opts.protocol = protocol
 	}
 }
 

--- a/test/framework/deployments/testserver/deployment.go
+++ b/test/framework/deployments/testserver/deployment.go
@@ -116,7 +116,7 @@ func WithNodeSelector(selector map[string]string) DeploymentOptsFn {
 	}
 }
 
-func WithProtocol(protocol string) DeploymentOptsFn {
+func WithServicePortAppProtocol(protocol string) DeploymentOptsFn {
 	return func(opts *DeploymentOpts) {
 		opts.protocol = protocol
 	}

--- a/test/framework/deployments/testserver/kubernetes.go
+++ b/test/framework/deployments/testserver/kubernetes.go
@@ -21,7 +21,7 @@ func (k *k8SDeployment) Name() string {
 }
 
 func (k *k8SDeployment) service() *corev1.Service {
-	appProtocol := "http"
+	appProtocol := k.opts.protocol
 	if len(k.opts.healthcheckTCPArgs) > 0 {
 		appProtocol = "tcp"
 	}


### PR DESCRIPTION
It's functionality helpful for writing e2e tests for MeshTCPRoute in the future

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues
  - there are no relevant issues
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s)
  - I tested it manually on k3d cluster
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)?
  - no need as it's a change for e2e tests framework
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? 
  - it doesn't
- [x] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?
  - there is no need

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
