### PR TITLE
chore(deps): fix version of cert-manager in gen. resources

### DIFF
--- a/app/kumactl/cmd/install/testdata/install-control-plane.defaults.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.defaults.golden.yaml
@@ -189,7 +189,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.12.0
+    controller-gen.kubebuilder.io/version: v0.11.4
   name: meshfaultinjections.kuma.io
 spec:
   group: kuma.io
@@ -796,7 +796,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.12.0
+    controller-gen.kubebuilder.io/version: v0.11.4
   name: meshhealthchecks.kuma.io
 spec:
   group: kuma.io
@@ -1098,7 +1098,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.12.0
+    controller-gen.kubebuilder.io/version: v0.11.4
   name: meshhttproutes.kuma.io
 spec:
   group: kuma.io
@@ -1641,7 +1641,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.12.0
+    controller-gen.kubebuilder.io/version: v0.11.4
   name: meshloadbalancingstrategies.kuma.io
 spec:
   group: kuma.io
@@ -2055,7 +2055,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.12.0
+    controller-gen.kubebuilder.io/version: v0.11.4
   name: meshproxypatches.kuma.io
 spec:
   group: kuma.io
@@ -2558,7 +2558,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.12.0
+    controller-gen.kubebuilder.io/version: v0.11.4
   name: meshratelimits.kuma.io
 spec:
   group: kuma.io
@@ -2828,7 +2828,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.12.0
+    controller-gen.kubebuilder.io/version: v0.11.4
   name: meshretries.kuma.io
 spec:
   group: kuma.io
@@ -3224,7 +3224,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.12.0
+    controller-gen.kubebuilder.io/version: v0.11.4
   name: meshtimeouts.kuma.io
 spec:
   group: kuma.io
@@ -3466,7 +3466,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.12.0
+    controller-gen.kubebuilder.io/version: v0.11.4
   name: meshtraces.kuma.io
 spec:
   group: kuma.io
@@ -3686,7 +3686,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.12.0
+    controller-gen.kubebuilder.io/version: v0.11.4
   name: meshtrafficpermissions.kuma.io
 spec:
   group: kuma.io
@@ -4709,7 +4709,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.12.0
+    controller-gen.kubebuilder.io/version: v0.11.4
   name: meshaccesslogs.kuma.io
 spec:
   group: kuma.io
@@ -5079,7 +5079,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.12.0
+    controller-gen.kubebuilder.io/version: v0.11.4
   name: meshcircuitbreakers.kuma.io
 spec:
   group: kuma.io

--- a/app/kumactl/cmd/install/testdata/install-control-plane.gateway-api-present-not-enabled.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.gateway-api-present-not-enabled.yaml
@@ -189,7 +189,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.12.0
+    controller-gen.kubebuilder.io/version: v0.11.4
   name: meshfaultinjections.kuma.io
 spec:
   group: kuma.io
@@ -796,7 +796,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.12.0
+    controller-gen.kubebuilder.io/version: v0.11.4
   name: meshhealthchecks.kuma.io
 spec:
   group: kuma.io
@@ -1098,7 +1098,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.12.0
+    controller-gen.kubebuilder.io/version: v0.11.4
   name: meshhttproutes.kuma.io
 spec:
   group: kuma.io
@@ -1641,7 +1641,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.12.0
+    controller-gen.kubebuilder.io/version: v0.11.4
   name: meshloadbalancingstrategies.kuma.io
 spec:
   group: kuma.io
@@ -2055,7 +2055,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.12.0
+    controller-gen.kubebuilder.io/version: v0.11.4
   name: meshproxypatches.kuma.io
 spec:
   group: kuma.io
@@ -2558,7 +2558,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.12.0
+    controller-gen.kubebuilder.io/version: v0.11.4
   name: meshratelimits.kuma.io
 spec:
   group: kuma.io
@@ -2828,7 +2828,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.12.0
+    controller-gen.kubebuilder.io/version: v0.11.4
   name: meshretries.kuma.io
 spec:
   group: kuma.io
@@ -3224,7 +3224,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.12.0
+    controller-gen.kubebuilder.io/version: v0.11.4
   name: meshtimeouts.kuma.io
 spec:
   group: kuma.io
@@ -3466,7 +3466,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.12.0
+    controller-gen.kubebuilder.io/version: v0.11.4
   name: meshtraces.kuma.io
 spec:
   group: kuma.io
@@ -3686,7 +3686,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.12.0
+    controller-gen.kubebuilder.io/version: v0.11.4
   name: meshtrafficpermissions.kuma.io
 spec:
   group: kuma.io
@@ -4709,7 +4709,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.12.0
+    controller-gen.kubebuilder.io/version: v0.11.4
   name: meshaccesslogs.kuma.io
 spec:
   group: kuma.io
@@ -5079,7 +5079,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.12.0
+    controller-gen.kubebuilder.io/version: v0.11.4
   name: meshcircuitbreakers.kuma.io
 spec:
   group: kuma.io

--- a/app/kumactl/cmd/install/testdata/install-control-plane.gateway-api-present.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.gateway-api-present.yaml
@@ -189,7 +189,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.12.0
+    controller-gen.kubebuilder.io/version: v0.11.4
   name: meshfaultinjections.kuma.io
 spec:
   group: kuma.io
@@ -1000,7 +1000,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.12.0
+    controller-gen.kubebuilder.io/version: v0.11.4
   name: meshhealthchecks.kuma.io
 spec:
   group: kuma.io
@@ -1302,7 +1302,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.12.0
+    controller-gen.kubebuilder.io/version: v0.11.4
   name: meshhttproutes.kuma.io
 spec:
   group: kuma.io
@@ -1845,7 +1845,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.12.0
+    controller-gen.kubebuilder.io/version: v0.11.4
   name: meshloadbalancingstrategies.kuma.io
 spec:
   group: kuma.io
@@ -2259,7 +2259,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.12.0
+    controller-gen.kubebuilder.io/version: v0.11.4
   name: meshproxypatches.kuma.io
 spec:
   group: kuma.io
@@ -2806,7 +2806,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.12.0
+    controller-gen.kubebuilder.io/version: v0.11.4
   name: meshratelimits.kuma.io
 spec:
   group: kuma.io
@@ -3032,7 +3032,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.12.0
+    controller-gen.kubebuilder.io/version: v0.11.4
   name: meshretries.kuma.io
 spec:
   group: kuma.io
@@ -3428,7 +3428,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.12.0
+    controller-gen.kubebuilder.io/version: v0.11.4
   name: meshtimeouts.kuma.io
 spec:
   group: kuma.io
@@ -3670,7 +3670,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.12.0
+    controller-gen.kubebuilder.io/version: v0.11.4
   name: meshtraces.kuma.io
 spec:
   group: kuma.io
@@ -3890,7 +3890,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.12.0
+    controller-gen.kubebuilder.io/version: v0.11.4
   name: meshtrafficpermissions.kuma.io
 spec:
   group: kuma.io
@@ -4913,7 +4913,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.12.0
+    controller-gen.kubebuilder.io/version: v0.11.4
   name: meshaccesslogs.kuma.io
 spec:
   group: kuma.io
@@ -5283,7 +5283,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.12.0
+    controller-gen.kubebuilder.io/version: v0.11.4
   name: meshcircuitbreakers.kuma.io
 spec:
   group: kuma.io

--- a/app/kumactl/cmd/install/testdata/install-control-plane.with-helm-set.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.with-helm-set.yaml
@@ -209,7 +209,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.12.0
+    controller-gen.kubebuilder.io/version: v0.11.4
   name: meshfaultinjections.kuma.io
 spec:
   group: kuma.io
@@ -816,7 +816,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.12.0
+    controller-gen.kubebuilder.io/version: v0.11.4
   name: meshhealthchecks.kuma.io
 spec:
   group: kuma.io
@@ -1118,7 +1118,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.12.0
+    controller-gen.kubebuilder.io/version: v0.11.4
   name: meshhttproutes.kuma.io
 spec:
   group: kuma.io
@@ -1661,7 +1661,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.12.0
+    controller-gen.kubebuilder.io/version: v0.11.4
   name: meshloadbalancingstrategies.kuma.io
 spec:
   group: kuma.io
@@ -2075,7 +2075,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.12.0
+    controller-gen.kubebuilder.io/version: v0.11.4
   name: meshproxypatches.kuma.io
 spec:
   group: kuma.io
@@ -2578,7 +2578,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.12.0
+    controller-gen.kubebuilder.io/version: v0.11.4
   name: meshratelimits.kuma.io
 spec:
   group: kuma.io
@@ -2848,7 +2848,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.12.0
+    controller-gen.kubebuilder.io/version: v0.11.4
   name: meshretries.kuma.io
 spec:
   group: kuma.io
@@ -3244,7 +3244,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.12.0
+    controller-gen.kubebuilder.io/version: v0.11.4
   name: meshtimeouts.kuma.io
 spec:
   group: kuma.io
@@ -3486,7 +3486,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.12.0
+    controller-gen.kubebuilder.io/version: v0.11.4
   name: meshtraces.kuma.io
 spec:
   group: kuma.io
@@ -3706,7 +3706,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.12.0
+    controller-gen.kubebuilder.io/version: v0.11.4
   name: meshtrafficpermissions.kuma.io
 spec:
   group: kuma.io
@@ -4729,7 +4729,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.12.0
+    controller-gen.kubebuilder.io/version: v0.11.4
   name: meshaccesslogs.kuma.io
 spec:
   group: kuma.io
@@ -5099,7 +5099,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.12.0
+    controller-gen.kubebuilder.io/version: v0.11.4
   name: meshcircuitbreakers.kuma.io
 spec:
   group: kuma.io

--- a/app/kumactl/cmd/install/testdata/install-crds.all.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-crds.all.golden.yaml
@@ -395,7 +395,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.12.0
+    controller-gen.kubebuilder.io/version: v0.11.4
   name: meshaccesslogs.kuma.io
 spec:
   group: kuma.io
@@ -765,7 +765,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.12.0
+    controller-gen.kubebuilder.io/version: v0.11.4
   name: meshcircuitbreakers.kuma.io
 spec:
   group: kuma.io
@@ -1460,7 +1460,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.12.0
+    controller-gen.kubebuilder.io/version: v0.11.4
   name: meshfaultinjections.kuma.io
 spec:
   group: kuma.io
@@ -2067,7 +2067,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.12.0
+    controller-gen.kubebuilder.io/version: v0.11.4
   name: meshhealthchecks.kuma.io
 spec:
   group: kuma.io
@@ -2369,7 +2369,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.12.0
+    controller-gen.kubebuilder.io/version: v0.11.4
   name: meshhttproutes.kuma.io
 spec:
   group: kuma.io
@@ -2912,7 +2912,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.12.0
+    controller-gen.kubebuilder.io/version: v0.11.4
   name: meshloadbalancingstrategies.kuma.io
 spec:
   group: kuma.io
@@ -3326,7 +3326,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.12.0
+    controller-gen.kubebuilder.io/version: v0.11.4
   name: meshproxypatches.kuma.io
 spec:
   group: kuma.io
@@ -3829,7 +3829,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.12.0
+    controller-gen.kubebuilder.io/version: v0.11.4
   name: meshratelimits.kuma.io
 spec:
   group: kuma.io
@@ -4055,7 +4055,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.12.0
+    controller-gen.kubebuilder.io/version: v0.11.4
   name: meshretries.kuma.io
 spec:
   group: kuma.io
@@ -4451,7 +4451,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.12.0
+    controller-gen.kubebuilder.io/version: v0.11.4
   name: meshtimeouts.kuma.io
 spec:
   group: kuma.io
@@ -4693,7 +4693,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.12.0
+    controller-gen.kubebuilder.io/version: v0.11.4
   name: meshtraces.kuma.io
 spec:
   group: kuma.io
@@ -4913,7 +4913,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.12.0
+    controller-gen.kubebuilder.io/version: v0.11.4
   name: meshtrafficpermissions.kuma.io
 spec:
   group: kuma.io

--- a/app/kumactl/cmd/install/testdata/install-crds.experimental-gatewayapi.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-crds.experimental-gatewayapi.golden.yaml
@@ -395,7 +395,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.12.0
+    controller-gen.kubebuilder.io/version: v0.11.4
   name: meshaccesslogs.kuma.io
 spec:
   group: kuma.io
@@ -765,7 +765,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.12.0
+    controller-gen.kubebuilder.io/version: v0.11.4
   name: meshcircuitbreakers.kuma.io
 spec:
   group: kuma.io
@@ -1460,7 +1460,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.12.0
+    controller-gen.kubebuilder.io/version: v0.11.4
   name: meshfaultinjections.kuma.io
 spec:
   group: kuma.io
@@ -2271,7 +2271,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.12.0
+    controller-gen.kubebuilder.io/version: v0.11.4
   name: meshhealthchecks.kuma.io
 spec:
   group: kuma.io
@@ -2573,7 +2573,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.12.0
+    controller-gen.kubebuilder.io/version: v0.11.4
   name: meshhttproutes.kuma.io
 spec:
   group: kuma.io
@@ -3116,7 +3116,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.12.0
+    controller-gen.kubebuilder.io/version: v0.11.4
   name: meshloadbalancingstrategies.kuma.io
 spec:
   group: kuma.io
@@ -3530,7 +3530,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.12.0
+    controller-gen.kubebuilder.io/version: v0.11.4
   name: meshproxypatches.kuma.io
 spec:
   group: kuma.io
@@ -4033,7 +4033,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.12.0
+    controller-gen.kubebuilder.io/version: v0.11.4
   name: meshratelimits.kuma.io
 spec:
   group: kuma.io
@@ -4259,7 +4259,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.12.0
+    controller-gen.kubebuilder.io/version: v0.11.4
   name: meshretries.kuma.io
 spec:
   group: kuma.io
@@ -4655,7 +4655,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.12.0
+    controller-gen.kubebuilder.io/version: v0.11.4
   name: meshtimeouts.kuma.io
 spec:
   group: kuma.io
@@ -4897,7 +4897,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.12.0
+    controller-gen.kubebuilder.io/version: v0.11.4
   name: meshtraces.kuma.io
 spec:
   group: kuma.io
@@ -5117,7 +5117,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.12.0
+    controller-gen.kubebuilder.io/version: v0.11.4
   name: meshtrafficpermissions.kuma.io
 spec:
   group: kuma.io

--- a/deployments/charts/kuma/crds/kuma.io_meshaccesslogs.yaml
+++ b/deployments/charts/kuma/crds/kuma.io_meshaccesslogs.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.12.0
+    controller-gen.kubebuilder.io/version: v0.11.4
   name: meshaccesslogs.kuma.io
 spec:
   group: kuma.io

--- a/deployments/charts/kuma/crds/kuma.io_meshcircuitbreakers.yaml
+++ b/deployments/charts/kuma/crds/kuma.io_meshcircuitbreakers.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.12.0
+    controller-gen.kubebuilder.io/version: v0.11.4
   name: meshcircuitbreakers.kuma.io
 spec:
   group: kuma.io

--- a/deployments/charts/kuma/crds/kuma.io_meshfaultinjections.yaml
+++ b/deployments/charts/kuma/crds/kuma.io_meshfaultinjections.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.12.0
+    controller-gen.kubebuilder.io/version: v0.11.4
   name: meshfaultinjections.kuma.io
 spec:
   group: kuma.io

--- a/deployments/charts/kuma/crds/kuma.io_meshhealthchecks.yaml
+++ b/deployments/charts/kuma/crds/kuma.io_meshhealthchecks.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.12.0
+    controller-gen.kubebuilder.io/version: v0.11.4
   name: meshhealthchecks.kuma.io
 spec:
   group: kuma.io

--- a/deployments/charts/kuma/crds/kuma.io_meshhttproutes.yaml
+++ b/deployments/charts/kuma/crds/kuma.io_meshhttproutes.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.12.0
+    controller-gen.kubebuilder.io/version: v0.11.4
   name: meshhttproutes.kuma.io
 spec:
   group: kuma.io

--- a/deployments/charts/kuma/crds/kuma.io_meshloadbalancingstrategies.yaml
+++ b/deployments/charts/kuma/crds/kuma.io_meshloadbalancingstrategies.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.12.0
+    controller-gen.kubebuilder.io/version: v0.11.4
   name: meshloadbalancingstrategies.kuma.io
 spec:
   group: kuma.io

--- a/deployments/charts/kuma/crds/kuma.io_meshproxypatches.yaml
+++ b/deployments/charts/kuma/crds/kuma.io_meshproxypatches.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.12.0
+    controller-gen.kubebuilder.io/version: v0.11.4
   name: meshproxypatches.kuma.io
 spec:
   group: kuma.io

--- a/deployments/charts/kuma/crds/kuma.io_meshratelimits.yaml
+++ b/deployments/charts/kuma/crds/kuma.io_meshratelimits.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.12.0
+    controller-gen.kubebuilder.io/version: v0.11.4
   name: meshratelimits.kuma.io
 spec:
   group: kuma.io

--- a/deployments/charts/kuma/crds/kuma.io_meshretries.yaml
+++ b/deployments/charts/kuma/crds/kuma.io_meshretries.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.12.0
+    controller-gen.kubebuilder.io/version: v0.11.4
   name: meshretries.kuma.io
 spec:
   group: kuma.io

--- a/deployments/charts/kuma/crds/kuma.io_meshtimeouts.yaml
+++ b/deployments/charts/kuma/crds/kuma.io_meshtimeouts.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.12.0
+    controller-gen.kubebuilder.io/version: v0.11.4
   name: meshtimeouts.kuma.io
 spec:
   group: kuma.io

--- a/deployments/charts/kuma/crds/kuma.io_meshtraces.yaml
+++ b/deployments/charts/kuma/crds/kuma.io_meshtraces.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.12.0
+    controller-gen.kubebuilder.io/version: v0.11.4
   name: meshtraces.kuma.io
 spec:
   group: kuma.io

--- a/deployments/charts/kuma/crds/kuma.io_meshtrafficpermissions.yaml
+++ b/deployments/charts/kuma/crds/kuma.io_meshtrafficpermissions.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.12.0
+    controller-gen.kubebuilder.io/version: v0.11.4
   name: meshtrafficpermissions.kuma.io
 spec:
   group: kuma.io

--- a/pkg/plugins/policies/donothingpolicy/k8s/crd/kuma.io_donothingpolicies.yaml
+++ b/pkg/plugins/policies/donothingpolicy/k8s/crd/kuma.io_donothingpolicies.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.12.0
+    controller-gen.kubebuilder.io/version: v0.11.4
   name: donothingpolicies.kuma.io
 spec:
   group: kuma.io

--- a/pkg/plugins/policies/meshaccesslog/k8s/crd/kuma.io_meshaccesslogs.yaml
+++ b/pkg/plugins/policies/meshaccesslog/k8s/crd/kuma.io_meshaccesslogs.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.12.0
+    controller-gen.kubebuilder.io/version: v0.11.4
   name: meshaccesslogs.kuma.io
 spec:
   group: kuma.io

--- a/pkg/plugins/policies/meshcircuitbreaker/k8s/crd/kuma.io_meshcircuitbreakers.yaml
+++ b/pkg/plugins/policies/meshcircuitbreaker/k8s/crd/kuma.io_meshcircuitbreakers.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.12.0
+    controller-gen.kubebuilder.io/version: v0.11.4
   name: meshcircuitbreakers.kuma.io
 spec:
   group: kuma.io

--- a/pkg/plugins/policies/meshfaultinjection/k8s/crd/kuma.io_meshfaultinjections.yaml
+++ b/pkg/plugins/policies/meshfaultinjection/k8s/crd/kuma.io_meshfaultinjections.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.12.0
+    controller-gen.kubebuilder.io/version: v0.11.4
   name: meshfaultinjections.kuma.io
 spec:
   group: kuma.io

--- a/pkg/plugins/policies/meshhealthcheck/k8s/crd/kuma.io_meshhealthchecks.yaml
+++ b/pkg/plugins/policies/meshhealthcheck/k8s/crd/kuma.io_meshhealthchecks.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.12.0
+    controller-gen.kubebuilder.io/version: v0.11.4
   name: meshhealthchecks.kuma.io
 spec:
   group: kuma.io

--- a/pkg/plugins/policies/meshhttproute/k8s/crd/kuma.io_meshhttproutes.yaml
+++ b/pkg/plugins/policies/meshhttproute/k8s/crd/kuma.io_meshhttproutes.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.12.0
+    controller-gen.kubebuilder.io/version: v0.11.4
   name: meshhttproutes.kuma.io
 spec:
   group: kuma.io

--- a/pkg/plugins/policies/meshloadbalancingstrategy/k8s/crd/kuma.io_meshloadbalancingstrategies.yaml
+++ b/pkg/plugins/policies/meshloadbalancingstrategy/k8s/crd/kuma.io_meshloadbalancingstrategies.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.12.0
+    controller-gen.kubebuilder.io/version: v0.11.4
   name: meshloadbalancingstrategies.kuma.io
 spec:
   group: kuma.io

--- a/pkg/plugins/policies/meshproxypatch/k8s/crd/kuma.io_meshproxypatches.yaml
+++ b/pkg/plugins/policies/meshproxypatch/k8s/crd/kuma.io_meshproxypatches.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.12.0
+    controller-gen.kubebuilder.io/version: v0.11.4
   name: meshproxypatches.kuma.io
 spec:
   group: kuma.io

--- a/pkg/plugins/policies/meshratelimit/k8s/crd/kuma.io_meshratelimits.yaml
+++ b/pkg/plugins/policies/meshratelimit/k8s/crd/kuma.io_meshratelimits.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.12.0
+    controller-gen.kubebuilder.io/version: v0.11.4
   name: meshratelimits.kuma.io
 spec:
   group: kuma.io

--- a/pkg/plugins/policies/meshretry/k8s/crd/kuma.io_meshretries.yaml
+++ b/pkg/plugins/policies/meshretry/k8s/crd/kuma.io_meshretries.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.12.0
+    controller-gen.kubebuilder.io/version: v0.11.4
   name: meshretries.kuma.io
 spec:
   group: kuma.io

--- a/pkg/plugins/policies/meshtimeout/k8s/crd/kuma.io_meshtimeouts.yaml
+++ b/pkg/plugins/policies/meshtimeout/k8s/crd/kuma.io_meshtimeouts.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.12.0
+    controller-gen.kubebuilder.io/version: v0.11.4
   name: meshtimeouts.kuma.io
 spec:
   group: kuma.io

--- a/pkg/plugins/policies/meshtrace/k8s/crd/kuma.io_meshtraces.yaml
+++ b/pkg/plugins/policies/meshtrace/k8s/crd/kuma.io_meshtraces.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.12.0
+    controller-gen.kubebuilder.io/version: v0.11.4
   name: meshtraces.kuma.io
 spec:
   group: kuma.io

--- a/pkg/plugins/policies/meshtrafficpermission/k8s/crd/kuma.io_meshtrafficpermissions.yaml
+++ b/pkg/plugins/policies/meshtrafficpermission/k8s/crd/kuma.io_meshtrafficpermissions.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.12.0
+    controller-gen.kubebuilder.io/version: v0.11.4
   name: meshtrafficpermissions.kuma.io
 spec:
   group: kuma.io


### PR DESCRIPTION
Fixed version of cert-manager (after bump to 0.12.0) in generated resources (policy-related and golden files)

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues
  - there is no relevant issue
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS
  - It won't
- [ ] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)?
  - There is no need as it's not user-facing change
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? 
  - It doesn't as the bump of cert-manager happened only on master
- [x] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?
  - There is no need

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
