### PR TITLE
chore(MeshTCPRoute): make to[].rules optional

### DIFF
--- a/pkg/plugins/policies/meshtcproute/api/v1alpha1/meshtcproute.go
+++ b/pkg/plugins/policies/meshtcproute/api/v1alpha1/meshtcproute.go
@@ -48,9 +48,8 @@ type To struct {
 	TargetRef common_api.TargetRef `json:"targetRef"`
 	// Rules contains the routing rules applies to a combination of top-level
 	// targetRef and the targetRef in this entry.
-	// +kubebuilder:validation:MinItems=1
 	// +kubebuilder:validation:MaxItems=1
-	Rules []Rule `json:"rules"`
+	Rules []Rule `json:"rules,omitempty"`
 }
 
 type Rule struct {
@@ -60,11 +59,12 @@ type Rule struct {
 }
 
 type RuleConf struct {
-	BackendRefs *[]BackendRef `json:"backendRefs,omitempty"`
+	// +kubebuilder:validation:MinItems=1
+	BackendRefs []BackendRef `json:"backendRefs"`
 }
 
 type BackendRef struct {
-	common_api.TargetRef `json:",omitempty"`
+	common_api.TargetRef `json:","`
 	// +kubebuilder:validation:Minimum=0
 	// +kubebuilder:default=1
 	Weight *uint `json:"weight,omitempty"`

--- a/pkg/plugins/policies/meshtcproute/api/v1alpha1/schema.yaml
+++ b/pkg/plugins/policies/meshtcproute/api/v1alpha1/schema.yaml
@@ -78,13 +78,15 @@ properties:
                               minimum: 0
                               type: integer
                           type: object
+                        minItems: 1
                         type: array
+                    required:
+                      - backendRefs
                     type: object
                 required:
                   - default
                 type: object
               maxItems: 1
-              minItems: 1
               type: array
             targetRef:
               description: TargetRef is a reference to the resource that represents a group of destinations.
@@ -111,7 +113,6 @@ properties:
                   type: object
               type: object
           required:
-            - rules
             - targetRef
           type: object
         minItems: 1

--- a/pkg/plugins/policies/meshtcproute/api/v1alpha1/validator.go
+++ b/pkg/plugins/policies/meshtcproute/api/v1alpha1/validator.go
@@ -18,14 +18,17 @@ func (r *MeshTCPRouteResource) validate() error {
 }
 
 func validateTop(targetRef common_api.TargetRef) validators.ValidationError {
-	return matcher_validators.ValidateTargetRef(targetRef, &matcher_validators.ValidateTargetRefOpts{
-		SupportedKinds: []common_api.TargetRefKind{
-			common_api.Mesh,
-			common_api.MeshSubset,
-			common_api.MeshService,
-			common_api.MeshServiceSubset,
+	return matcher_validators.ValidateTargetRef(
+		targetRef,
+		&matcher_validators.ValidateTargetRefOpts{
+			SupportedKinds: []common_api.TargetRefKind{
+				common_api.Mesh,
+				common_api.MeshSubset,
+				common_api.MeshService,
+				common_api.MeshServiceSubset,
+			},
 		},
-	})
+	)
 }
 
 func validateTo(to []To) validators.ValidationError {
@@ -33,11 +36,17 @@ func validateTo(to []To) validators.ValidationError {
 
 	for idx, toItem := range to {
 		path := validators.RootedAt("to").Index(idx)
-		verr.AddErrorAt(path.Field("targetRef"), matcher_validators.ValidateTargetRef(toItem.TargetRef, &matcher_validators.ValidateTargetRefOpts{
-			SupportedKinds: []common_api.TargetRefKind{
-				common_api.MeshService,
-			},
-		}))
+
+		verr.AddErrorAt(
+			path.Field("targetRef"),
+			matcher_validators.ValidateTargetRef(toItem.TargetRef,
+				&matcher_validators.ValidateTargetRefOpts{
+					SupportedKinds: []common_api.TargetRefKind{
+						common_api.MeshService,
+					},
+				},
+			),
+		)
 		verr.AddErrorAt(path.Field("rules"), validateRules(toItem.Rules))
 	}
 
@@ -49,28 +58,34 @@ func validateRules(rules []Rule) validators.ValidationError {
 
 	for i, rule := range rules {
 		path := validators.Root().Index(i)
-		verr.AddErrorAt(path.Field("default").Field("backendRefs"), validateBackendRefs(rule.Default.BackendRefs))
+
+		verr.AddErrorAt(path.Field("default").Field("backendRefs"),
+			validateBackendRefs(rule.Default.BackendRefs),
+		)
 	}
 
 	return verr
 }
 
-func validateBackendRefs(backendRefs *[]BackendRef) validators.ValidationError {
+func validateBackendRefs(backendRefs []BackendRef) validators.ValidationError {
 	var verr validators.ValidationError
 
 	if backendRefs == nil {
 		return verr
 	}
 
-	for i, backendRef := range *backendRefs {
+	for i, backendRef := range backendRefs {
 		verr.AddErrorAt(
 			validators.Root().Index(i),
-			matcher_validators.ValidateTargetRef(backendRef.TargetRef, &matcher_validators.ValidateTargetRefOpts{
-				SupportedKinds: []common_api.TargetRefKind{
-					common_api.MeshService,
-					common_api.MeshServiceSubset,
+			matcher_validators.ValidateTargetRef(
+				backendRef.TargetRef,
+				&matcher_validators.ValidateTargetRefOpts{
+					SupportedKinds: []common_api.TargetRefKind{
+						common_api.MeshService,
+						common_api.MeshServiceSubset,
+					},
 				},
-			}),
+			),
 		)
 	}
 

--- a/pkg/plugins/policies/meshtcproute/api/v1alpha1/validator_test.go
+++ b/pkg/plugins/policies/meshtcproute/api/v1alpha1/validator_test.go
@@ -26,11 +26,6 @@ to:
 - targetRef:
     kind: MeshService
     name: backend
-  rules:
-  - default:
-      backendRefs:
-      - kind: MeshService
-        name: other
 `),
 		ErrorCase("spec.to.targetRef error",
 			validators.Violation{
@@ -47,11 +42,6 @@ to:
 - targetRef:
     kind: BlahBlah
     name: backend
-  rules:
-  - default:
-      backendRefs:
-      - kind: MeshService
-        name: other
 `),
 		ErrorCase("invalid backendRefs",
 			validators.Violation{
@@ -78,7 +68,7 @@ to:
 	)
 	DescribeValidCases(
 		api.NewMeshTCPRouteResource,
-		Entry("accepts valid resource", `
+		Entry("accepts valid resource with to.rules", `
 type: MeshTCPRoute
 mesh: mesh-1
 name: route-1
@@ -94,6 +84,18 @@ to:
       backendRefs:
       - kind: MeshService
         name: other
+`),
+		Entry("accepts valid resource without to.rules", `
+type: MeshTCPRoute
+mesh: mesh-1
+name: route-1
+targetRef:
+  kind: MeshService
+  name: frontend
+to:
+- targetRef:
+    kind: MeshService
+    name: backend
 `),
 	)
 })

--- a/pkg/plugins/policies/meshtcproute/api/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/plugins/policies/meshtcproute/api/v1alpha1/zz_generated.deepcopy.go
@@ -72,13 +72,9 @@ func (in *RuleConf) DeepCopyInto(out *RuleConf) {
 	*out = *in
 	if in.BackendRefs != nil {
 		in, out := &in.BackendRefs, &out.BackendRefs
-		*out = new([]BackendRef)
-		if **in != nil {
-			in, out := *in, *out
-			*out = make([]BackendRef, len(*in))
-			for i := range *in {
-				(*in)[i].DeepCopyInto(&(*out)[i])
-			}
+		*out = make([]BackendRef, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
 }

--- a/pkg/plugins/policies/meshtcproute/k8s/crd/kuma.io_meshtcproutes.yaml
+++ b/pkg/plugins/policies/meshtcproute/k8s/crd/kuma.io_meshtcproutes.yaml
@@ -111,13 +111,15 @@ spec:
                                       minimum: 0
                                       type: integer
                                   type: object
+                                minItems: 1
                                 type: array
+                            required:
+                            - backendRefs
                             type: object
                         required:
                         - default
                         type: object
                       maxItems: 1
-                      minItems: 1
                       type: array
                     targetRef:
                       description: TargetRef is a reference to the resource that represents
@@ -149,7 +151,6 @@ spec:
                           type: object
                       type: object
                   required:
-                  - rules
                   - targetRef
                   type: object
                 minItems: 1


### PR DESCRIPTION
There is currently no validation if the
`to.rules[].default.backendRefs` doesn't direct the traffic to the same target as matched in `to.targetRef`.
It means the configuration as below is valid:
```yaml
targetRef:
  kind: MeshService
  name: frontend
to:
- targetRef:
    kind: MeshService
    name: backend
  rules:
  - default:
      backendRefs:
      - targetRef:
          kind: MeshService
          name: backend
```
Why are we not disallowing it during the validation you might ask? We don't as:
- it's non-breaking behaviour to have a route which direct the traffic to the same destination
- it would involve doing very heavy validation otherwise (we would have to compute potential splits and check it summarized backendRefs don't point to the same destination etc.)
- there is assumption that route-policies like `MeshTCPRoute` will in the near future allow to target `MeshGateway`s as a root targets. It makes this structure perfectly valid

Because of reasons stated above, I believe there is no need to enforce specification of the rules property, and this PR makes this field optional, so the example above might be simplified to:
```yaml
targetRef:
  kind: MeshService
  name: frontend
to:
- targetRef:
    kind: MeshService
    name: backend
```

As now you'll be able to apply policy without specifying `to.rules` and there is no matching capabilities for tcp routes, every rule should contain at least one `backendRef`. This PR makes `backendRefs` field required to contain at least 1 `backendRef`.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues
  - https://github.com/kumahq/kuma/issues/6787
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS
  - it won't
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s)
  - adjusted validator tests + tested if validation works manually on a local k3d cluster
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)?
  - you don't as it's non-released yet policy
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? 
  - it doesn't
- [x] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?
  - there is no need

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
