### PR TITLE
feat(kuma-cp): allow to specify protocol for globalZone sync service

### DIFF
--- a/app/kumactl/cmd/install/testdata/install-control-plane.dump-values.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.dump-values.yaml
@@ -152,6 +152,8 @@ controlPlane:
     annotations: { }
     # -- Port on which Global Zone Sync Service is exposed
     port: 5685
+    # -- Protocol of the service port
+    protocol: grpc
 
   defaults:
     # -- Whether to skip creating the default Mesh

--- a/deployments/charts/kuma/README.md
+++ b/deployments/charts/kuma/README.md
@@ -52,6 +52,7 @@ A Helm chart for the Kuma Control Plane
 | controlPlane.globalZoneSyncService.loadBalancerIP | string | `nil` | Optionally specify IP to be used by cloud provider when configuring load balancer |
 | controlPlane.globalZoneSyncService.annotations | object | `{}` | Additional annotations to put on the Global Zone Sync Service |
 | controlPlane.globalZoneSyncService.port | int | `5685` | Port on which Global Zone Sync Service is exposed |
+| controlPlane.globalZoneSyncService.protocol | string | `"grpc"` | Protocol of the Global Zone Sync service port |
 | controlPlane.defaults.skipMeshCreation | bool | `false` | Whether to skip creating the default Mesh |
 | controlPlane.automountServiceAccountToken | bool | `true` | Whether to automountServiceAccountToken for cp. Optionally set to false |
 | controlPlane.resources | object | `{"limits":{"memory":"256Mi"},"requests":{"cpu":"500m","memory":"256Mi"}}` | Optionally override the resource spec |

--- a/deployments/charts/kuma/templates/cp-global-sync-service.yaml
+++ b/deployments/charts/kuma/templates/cp-global-sync-service.yaml
@@ -16,7 +16,7 @@ spec:
   {{- end }}
   ports:
     - port: {{ .Values.controlPlane.globalZoneSyncService.port }}
-      appProtocol: grpc
+      appProtocol: {{ .Values.controlPlane.globalZoneSyncService.protocol }}
   {{- if eq .Values.controlPlane.globalZoneSyncService.type "NodePort" }}
       nodePort: 30685
   {{- end }}

--- a/deployments/charts/kuma/values.yaml
+++ b/deployments/charts/kuma/values.yaml
@@ -152,6 +152,8 @@ controlPlane:
     annotations: { }
     # -- Port on which Global Zone Sync Service is exposed
     port: 5685
+    # -- Protocol of the Global Zone Sync service port
+    protocol: grpc
 
   defaults:
     # -- Whether to skip creating the default Mesh


### PR DESCRIPTION
We should allow to configure protocol in case a user would like to expose it as a TCP service

- [X] [Link to relevant issue][1] as well as docs and UI issues --
- [X] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [X] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [X] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [X] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [X] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
