### PR TITLE
chore(kuma-cp): add weights to xds.Cluster interface

### DIFF
--- a/pkg/plugins/policies/xds/cluster.go
+++ b/pkg/plugins/policies/xds/cluster.go
@@ -11,6 +11,7 @@ import (
 type Cluster struct {
 	service           string
 	name              string
+	weight            uint32
 	tags              tags.Tags
 	mesh              string
 	isExternalService bool
@@ -18,6 +19,7 @@ type Cluster struct {
 
 func (c *Cluster) Service() string { return c.service }
 func (c *Cluster) Name() string    { return c.name }
+func (c *Cluster) Weight() uint32  { return c.weight }
 func (c *Cluster) Tags() tags.Tags { return c.tags }
 
 // Mesh returns a non-empty string only if the cluster is in a different mesh
@@ -41,7 +43,7 @@ type ClusterBuilder struct {
 }
 
 func NewClusterBuilder() *ClusterBuilder {
-	return &ClusterBuilder{}
+	return (&ClusterBuilder{}).WithWeight(1)
 }
 
 func (b *ClusterBuilder) Build() *Cluster {
@@ -71,6 +73,13 @@ func (b *ClusterBuilder) WithName(name string) *ClusterBuilder {
 		if len(cluster.service) == 0 {
 			cluster.service = name
 		}
+	}))
+	return b
+}
+
+func (b *ClusterBuilder) WithWeight(weight uint32) *ClusterBuilder {
+	b.opts = append(b.opts, newClusterOptFunc(func(cluster *Cluster) {
+		cluster.weight = weight
 	}))
 	return b
 }

--- a/pkg/xds/envoy/listeners/v3/tcp_proxy_configurer.go
+++ b/pkg/xds/envoy/listeners/v3/tcp_proxy_configurer.go
@@ -53,8 +53,7 @@ func (c *TcpProxyConfigurer) tcpProxy() *envoy_tcp.TcpProxy {
 	}
 
 	var weightedClusters []*envoy_tcp.TcpProxy_WeightedCluster_ClusterWeight
-	for _, cl := range c.Clusters {
-		cluster := cl.(*envoy_common.ClusterImpl)
+	for _, cluster := range c.Clusters {
 		weightedCluster := &envoy_tcp.TcpProxy_WeightedCluster_ClusterWeight{
 			Name:   cluster.Name(),
 			Weight: cluster.Weight(),

--- a/pkg/xds/envoy/types.go
+++ b/pkg/xds/envoy/types.go
@@ -17,6 +17,7 @@ import (
 type Cluster interface {
 	Service() string
 	Name() string
+	Weight() uint32
 	Mesh() string
 	Tags() tags.Tags
 	Hash() string


### PR DESCRIPTION
This setting is necessary to allow MeshTCPRoute to create "splits" without the need of using deprecated abstractions like ClusterImpl. I also think it's quite elegant solution which allows to remove type assertion to ClusterImpl in TcpProxyConfigurator, when there are more clusters provided as parameters.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues
  - https://github.com/kumahq/kuma/issues/6787
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS
  - it won't
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s)
  - tested manually
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)?
  - there is no need, as so use this feature, it has to be explicit
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? 
  - it doesn't
- [x] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?
  - there is no need

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
