### PR TITLE
chore(MeshTCPRoute): fix GetDefault for the policy

### DIFF
--- a/pkg/plugins/policies/meshtcproute/api/v1alpha1/helpers.go
+++ b/pkg/plugins/policies/meshtcproute/api/v1alpha1/helpers.go
@@ -1,11 +1,20 @@
 package v1alpha1
 
-type PolicyDefault struct {
-	Rules []Rule
-}
+import (
+	"github.com/kumahq/kuma/pkg/util/pointer"
+)
 
 func (x *To) GetDefault() interface{} {
-	return PolicyDefault{
-		Rules: x.Rules,
+	if len(x.Rules) == 0 {
+		return Rule{
+			Default: RuleConf{
+				BackendRefs: []BackendRef{{
+					TargetRef: x.TargetRef,
+					Weight:    pointer.To(uint(1)),
+				}},
+			},
+		}
 	}
+
+	return x.Rules[0]
 }

--- a/pkg/plugins/policies/meshtcproute/api/v1alpha1/helpers.go
+++ b/pkg/plugins/policies/meshtcproute/api/v1alpha1/helpers.go
@@ -1,5 +1,11 @@
 package v1alpha1
 
+type PolicyDefault struct {
+	Rules []Rule
+}
+
 func (x *To) GetDefault() interface{} {
-	return x.Rules[0]
+	return PolicyDefault{
+		Rules: x.Rules,
+	}
 }


### PR DESCRIPTION
Rules may be empty, which might cause out of index access errors. In this case we are constructing the rule with the values from the `to[].targetRef`.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues
  - https://github.com/kumahq/kuma/issues/6787
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS
  - it won't
- [ ] Tests (Unit test, E2E tests, manual test on universal and k8s)
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)?
  - there is no need as the policy was not yet released
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? 
  - there is no need as the policy was not yet released
- [x] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?
  - there is no need

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
