### PR TITLE
fix(GatewayAPI): properly handle owned MeshHTTPRoutes

### DIFF
--- a/pkg/plugins/runtime/k8s/controllers/gatewayapi/gateway_controller.go
+++ b/pkg/plugins/runtime/k8s/controllers/gatewayapi/gateway_controller.go
@@ -50,7 +50,7 @@ func (r *GatewayReconciler) Reconcile(ctx context.Context, req kube_ctrl.Request
 		if kube_apierrs.IsNotFound(err) {
 			// We don't know the mesh, but we don't need it to delete our
 			// object.
-			err := common.ReconcileLabelledObject(ctx, r.Log, r.TypeRegistry, r.Client, req.NamespacedName, core_model.NoMesh, &mesh_proto.MeshGateway{}, nil)
+			err := common.ReconcileLabelledObject(ctx, r.Log, r.TypeRegistry, r.Client, req.NamespacedName, core_model.NoMesh, &mesh_proto.MeshGateway{}, "", nil)
 			return kube_ctrl.Result{}, errors.Wrap(err, "could not delete owned MeshGateway.kuma.io")
 		}
 
@@ -88,7 +88,12 @@ func (r *GatewayReconciler) Reconcile(ctx context.Context, req kube_ctrl.Request
 
 	var gatewayInstance *mesh_k8s.MeshGatewayInstance
 	if gatewaySpec != nil {
-		if err := common.ReconcileLabelledObject(ctx, r.Log, r.TypeRegistry, r.Client, req.NamespacedName, mesh, &mesh_proto.MeshGateway{}, gatewaySpec); err != nil {
+		resources := map[string]core_model.ResourceSpec{
+			common.OwnedPolicyName(req.NamespacedName): gatewaySpec,
+		}
+		if err := common.ReconcileLabelledObject(
+			ctx, r.Log, r.TypeRegistry, r.Client, req.NamespacedName, mesh, &mesh_proto.MeshGateway{}, "", resources,
+		); err != nil {
 			return kube_ctrl.Result{}, errors.Wrap(err, "could not reconcile owned MeshGateway.kuma.io")
 		}
 

--- a/pkg/plugins/runtime/k8s/controllers/gatewayapi/http_route_controller.go
+++ b/pkg/plugins/runtime/k8s/controllers/gatewayapi/http_route_controller.go
@@ -51,7 +51,7 @@ func (r *HTTPRouteReconciler) Reconcile(ctx context.Context, req kube_ctrl.Reque
 		if kube_apierrs.IsNotFound(err) {
 			// We don't know the mesh, but we don't need it to delete our
 			// object.
-			err := common.ReconcileLabelledObject(ctx, r.Log, r.TypeRegistry, r.Client, req.NamespacedName, core_model.NoMesh, &mesh_proto.MeshGatewayRoute{}, nil)
+			err := common.ReconcileLabelledObject(ctx, r.Log, r.TypeRegistry, r.Client, req.NamespacedName, core_model.NoMesh, &mesh_proto.MeshGatewayRoute{}, "", nil)
 			return kube_ctrl.Result{}, errors.Wrap(err, "could not delete owned GatewayRoute.kuma.io")
 		}
 
@@ -71,7 +71,12 @@ func (r *HTTPRouteReconciler) Reconcile(ctx context.Context, req kube_ctrl.Reque
 	}
 
 	if gatewayRouteSpec != nil {
-		if err := common.ReconcileLabelledObject(ctx, r.Log, r.TypeRegistry, r.Client, req.NamespacedName, mesh, &mesh_proto.MeshGatewayRoute{}, gatewayRouteSpec); err != nil {
+		resources := map[string]core_model.ResourceSpec{
+			common.OwnedPolicyName(req.NamespacedName): gatewayRouteSpec,
+		}
+		if err := common.ReconcileLabelledObject(
+			ctx, r.Log, r.TypeRegistry, r.Client, req.NamespacedName, mesh, &mesh_proto.MeshGatewayRoute{}, "", resources,
+		); err != nil {
 			return kube_ctrl.Result{}, errors.Wrap(err, "could not reconcile owned GatewayRoute.kuma.io")
 		}
 	}

--- a/pkg/plugins/runtime/k8s/controllers/gatewayapi/mesh_http_route_conversion.go
+++ b/pkg/plugins/runtime/k8s/controllers/gatewayapi/mesh_http_route_conversion.go
@@ -12,6 +12,7 @@ import (
 
 	common_api "github.com/kumahq/kuma/api/common/v1alpha1"
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
+	core_model "github.com/kumahq/kuma/pkg/core/resources/model"
 	"github.com/kumahq/kuma/pkg/plugins/policies/meshhttproute/api/v1alpha1"
 	"github.com/kumahq/kuma/pkg/plugins/runtime/k8s/controllers"
 	k8s_util "github.com/kumahq/kuma/pkg/plugins/runtime/k8s/util"
@@ -39,8 +40,8 @@ func serviceAndPorts(svc *kube_core.Service, port *gatewayapi.PortNumber) Servic
 
 func (r *HTTPRouteReconciler) gapiToMeshRouteSpecs(
 	ctx context.Context, mesh string, route *gatewayapi.HTTPRoute, svcs []ServiceAndPorts,
-) (map[string]v1alpha1.MeshHTTPRoute, error) {
-	routes := map[string]v1alpha1.MeshHTTPRoute{}
+) (map[string]core_model.ResourceSpec, error) {
+	routes := map[string]core_model.ResourceSpec{}
 
 	for _, svcRef := range svcs {
 		for _, port := range svcRef.Ports {
@@ -75,8 +76,11 @@ func (r *HTTPRouteReconciler) gapiToMeshRouteSpecs(
 					Kind: common_api.Mesh,
 				}
 			}
-			routeSubName := fmt.Sprintf("%s-%s-%d", svcRef.Name.Name, svcRef.Name.Namespace, port)
-			routes[routeSubName] = v1alpha1.MeshHTTPRoute{
+			routeSubName := fmt.Sprintf(
+				"%s-%s-%s.%s.%d",
+				route.Name, route.Namespace, svcRef.Name.Name, svcRef.Name.Namespace, port,
+			)
+			routes[routeSubName] = &v1alpha1.MeshHTTPRoute{
 				TargetRef: targetRef,
 				To:        to,
 			}


### PR DESCRIPTION
Now deletion is handled

> Changelog: skip

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues -- #6508 
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [x] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
