### PR TITLE
test(MeshTCPRoute): add e2e test for colision with MeshHTTPRoute

### DIFF
--- a/test/e2e_env/kubernetes/meshtcproute/test.go
+++ b/test/e2e_env/kubernetes/meshtcproute/test.go
@@ -248,7 +248,7 @@ spec:
 		}, "30s", "1s").Should(Succeed())
 	})
 
-	It("should use MeshHTTPRoute if both MeshTCPRoutes and MeshHTTPRoute "+
+	It("should use MeshHTTPRoute if both MeshTCPRoute and MeshHTTPRoute "+
 		"are present and point to the same source and destination", func() {
 		// given
 		Eventually(func(g Gomega) {

--- a/test/e2e_env/kubernetes/meshtcproute/test.go
+++ b/test/e2e_env/kubernetes/meshtcproute/test.go
@@ -34,6 +34,11 @@ func Test() {
 				testserver.WithNamespace(namespace),
 			)).
 			Install(testserver.Install(
+				testserver.WithName("test-http-server-2"),
+				testserver.WithMesh(meshName),
+				testserver.WithNamespace(namespace),
+			)).
+			Install(testserver.Install(
 				testserver.WithName("test-tcp-server"),
 				testserver.WithServicePortAppProtocol("tcp"),
 				testserver.WithMesh(meshName),
@@ -240,6 +245,103 @@ spec:
 			)
 			g.Expect(err).ToNot(HaveOccurred())
 			g.Expect(response.Instance).To(HavePrefix("external-tcp-service"))
+		}, "30s", "1s").Should(Succeed())
+	})
+
+	It("should use MeshHTTPRoute if both MeshTCPRoutes and MeshHTTPRoute "+
+		"are present and point to the same source and destination", func() {
+		// given
+		Eventually(func(g Gomega) {
+			g.Expect(client.CollectEchoResponse(
+				kubernetes.Cluster,
+				"test-client",
+				"test-http-server_meshtcproute_svc_80.mesh",
+				client.FromKubernetesPod(namespace, "test-client"),
+			)).Error().To(HaveOccurred())
+		}, "30s", "1s").Should(Succeed())
+
+		Expect(kubernetes.Cluster.Install(YamlK8s(fmt.Sprintf(`
+apiVersion: kuma.io/v1alpha1
+kind: ExternalService
+metadata:
+  name: external-tcp-service-mtcpr
+mesh: %s
+spec:
+  tags:
+    kuma.io/service: external-tcp-service
+    kuma.io/protocol: tcp
+  networking:
+    # .svc.cluster.local is needed, otherwise Kubernetes will resolve this
+    # to the real IP
+    address: external-tcp-service.%s.svc.cluster.local:80
+`, meshName, namespace)))).To(Succeed())
+
+		// when
+		meshRoutes := func(meshName string, namespace string) string {
+			meshHTTPRoute := fmt.Sprintf(`
+apiVersion: kuma.io/v1alpha1
+kind: MeshHTTPRoute
+metadata:
+  name: http-route
+  namespace: %s
+  labels:
+    kuma.io/mesh: %s
+spec:
+  targetRef:
+    kind: MeshService
+    name: test-client_%s_svc_80
+  to:
+  - targetRef:
+      kind: MeshService
+      name: test-http-server_meshtcproute_svc_80
+    rules:
+    - matches:
+      - path:
+          type: PathPrefix
+          value: "/"
+      default:
+        backendRefs:
+        - kind: MeshService
+          name: test-http-server-2_meshtcproute_svc_80
+`, Config.KumaNamespace, meshName, namespace)
+			meshTCPRoute := fmt.Sprintf(`
+apiVersion: kuma.io/v1alpha1
+kind: MeshTCPRoute
+metadata:
+  name: tcp-route
+  namespace: %s
+  labels:
+    kuma.io/mesh: %s
+spec:
+  targetRef:
+    kind: MeshService
+    name: test-client_%s_svc_80
+  to:
+  - targetRef:
+      kind: MeshService
+      name: test-http-server_meshtcproute_svc_80
+    rules:
+    - default:
+        backendRefs:
+        - kind: MeshService
+          name: external-tcp-service
+`, Config.KumaNamespace, meshName, namespace)
+			return fmt.Sprintf("%s\n---%s", meshTCPRoute, meshHTTPRoute)
+		}
+
+		Expect(YamlK8s(meshRoutes(meshName, namespace))(kubernetes.Cluster)).
+			To(Succeed())
+
+		// then
+		Eventually(func(g Gomega) {
+			response, err := client.CollectEchoResponse(
+				kubernetes.Cluster,
+				"test-client",
+				"test-http-server_meshtcproute_svc_80.mesh",
+				client.FromKubernetesPod(namespace, "test-client"),
+			)
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(response.Instance).To(HavePrefix("test-http-server-2"))
 		}, "30s", "1s").Should(Succeed())
 	})
 }


### PR DESCRIPTION
When both `MeshHTTPRoute` and `MeshTCPRoute` sources and destination matches, `MeshHTTPRoute` should take precedence.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues
  - https://github.com/kumahq/kuma/issues/6787
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS
  - It won't as this PR contains only new e2e test
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s)
  - This PR contains e2e test, which is currently "paused", till the full implementation will be finished
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)?
  - You don't as it's only e2e test + this policy was not yet released
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? 
  - You don't as it's only e2e test + this policy was not yet released
- [x] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?
  - There is no need

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
