### PR TITLE
test(MeshTCPRoute): small name fix in e2e test case

### DIFF
--- a/test/e2e_env/kubernetes/meshtcproute/test.go
+++ b/test/e2e_env/kubernetes/meshtcproute/test.go
@@ -216,7 +216,7 @@ spec:
 			response, err := client.CollectEchoResponse(
 				kubernetes.Cluster,
 				"test-client",
-				"test-tcp-server_meshtcproute_svc_80.mesh",
+				"test-http-server_meshtcproute_svc_80.mesh",
 				client.FromKubernetesPod(namespace, "test-client"),
 			)
 			g.Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
Very small fix in the name of service in e2e test case for MeshTCPRoute

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues
  - https://github.com/kumahq/kuma/issues/6787
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS
  - it won't
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s)
  - it's a fix in an e2e test case actually
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)?
  - there is no need
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? 
  - there is no need
- [x] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?
  - there is no need

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
