### PR TITLE
refactor(MeshHTTPRoute): pull up parts of xds generation

### DIFF
--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/plugin.go
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/plugin.go
@@ -9,6 +9,7 @@ import (
 	core_xds "github.com/kumahq/kuma/pkg/core/xds"
 	"github.com/kumahq/kuma/pkg/plugins/policies/matchers"
 	api "github.com/kumahq/kuma/pkg/plugins/policies/meshhttproute/api/v1alpha1"
+	meshroute_xds "github.com/kumahq/kuma/pkg/plugins/policies/xds/meshroute"
 	xds_context "github.com/kumahq/kuma/pkg/xds/context"
 	envoy_common "github.com/kumahq/kuma/pkg/xds/envoy"
 )
@@ -83,13 +84,13 @@ func ApplyToOutbounds(
 
 	services := servicesAcc.Services()
 
-	clusters, err := generateClusters(proxy, ctx.Mesh, services)
+	clusters, err := meshroute_xds.GenerateClusters(proxy, ctx.Mesh, services)
 	if err != nil {
 		return errors.Wrap(err, "couldn't generate cluster resources")
 	}
 	rs.AddSet(clusters)
 
-	endpoints, err := generateEndpoints(proxy, ctx, services)
+	endpoints, err := meshroute_xds.GenerateEndpoints(proxy, ctx, services)
 	if err != nil {
 		return errors.Wrap(err, "couldn't generate endpoint resources")
 	}

--- a/pkg/plugins/policies/xds/meshroute/clusters.go
+++ b/pkg/plugins/policies/xds/meshroute/clusters.go
@@ -1,4 +1,4 @@
-package v1alpha1
+package meshroute
 
 import (
 	"github.com/pkg/errors"
@@ -13,7 +13,7 @@ import (
 	"github.com/kumahq/kuma/pkg/xds/generator"
 )
 
-func generateClusters(
+func GenerateClusters(
 	proxy *core_xds.Proxy,
 	meshCtx xds_context.MeshContext,
 	services envoy_common.Services,

--- a/pkg/plugins/policies/xds/meshroute/listeners.go
+++ b/pkg/plugins/policies/xds/meshroute/listeners.go
@@ -1,0 +1,44 @@
+package meshroute
+
+import (
+	"fmt"
+
+	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
+	"github.com/kumahq/kuma/pkg/xds/envoy/names"
+)
+
+// SplitCounter
+// Whenever `split` is specified in the TrafficRoute which has more than
+// kuma.io/service tag we generate a separate Envoy cluster with _X_ suffix.
+// SplitCounter ensures that we have different X for every split in one
+// Dataplane. Each split is distinct for the whole Dataplane so we can avoid
+// accidental cluster overrides.
+type SplitCounter struct {
+	counter int
+}
+
+func (s *SplitCounter) GetAndIncrement() int {
+	counter := s.counter
+	s.counter++
+	return counter
+}
+
+func GetClusterName(
+	name string,
+	tags map[string]string,
+	sc *SplitCounter,
+) string {
+	if len(tags) > 0 {
+		name = names.GetSplitClusterName(name, sc.GetAndIncrement())
+	}
+
+	// The mesh tag is present here if this destination is generated
+	// from a cross-mesh MeshGateway listener virtual outbound.
+	// It is not part of the service tags.
+	if mesh, ok := tags[mesh_proto.MeshTag]; ok {
+		// The name should be distinct to the service & mesh combination
+		name = fmt.Sprintf("%s_%s", name, mesh)
+	}
+
+	return name
+}


### PR DESCRIPTION
As for `MeshTCPRoute` endpoints and clusters generation will be the same instead of copying this code, I took it out and made it reusable.

I had also changed `GetClusterName` definition, to be reusable, so instead of taking concrete targetRefs from `MeshHTTPRoute`, now we need to provide `name` and `tags` as separate arguments.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues
  - https://github.com/kumahq/kuma/issues/6787
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS
  - It will not, as these changes are not modifying functionality and touches only internal API
- [ ] Tests (Unit test, E2E tests, manual test on universal and k8s)
  - That's the good question - should I add unit tests for now exported functions? 🤔 
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)?
  - there is no need, as it's not changing any logic
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? 
  - there is no need as these changes are necessary only for non-released yet `MeshTCPRoute` policy, which won't be backported
- [x] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?
  - there is no need

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
