### PR TITLE
feat(MeshTCPRoute): add policy logic

### DIFF
--- a/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/listeners.go
+++ b/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/listeners.go
@@ -1,0 +1,101 @@
+package v1alpha1
+
+import (
+	"github.com/pkg/errors"
+
+	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
+	core_xds "github.com/kumahq/kuma/pkg/core/xds"
+	meshhttproute_api "github.com/kumahq/kuma/pkg/plugins/policies/meshhttproute/api/v1alpha1"
+	plugins_xds "github.com/kumahq/kuma/pkg/plugins/policies/xds"
+	meshroute_xds "github.com/kumahq/kuma/pkg/plugins/policies/xds/meshroute"
+	envoy_common "github.com/kumahq/kuma/pkg/xds/envoy"
+	envoy_listeners "github.com/kumahq/kuma/pkg/xds/envoy/listeners"
+	envoy_names "github.com/kumahq/kuma/pkg/xds/envoy/names"
+	envoy_tags "github.com/kumahq/kuma/pkg/xds/envoy/tags"
+	"github.com/kumahq/kuma/pkg/xds/generator"
+)
+
+func generateListeners(
+	proxy *core_xds.Proxy,
+	toRulesTCP core_xds.Rules,
+	servicesAccumulator envoy_common.ServicesAccumulator,
+) (*core_xds.ResourceSet, error) {
+	resources := core_xds.NewResourceSet()
+	// Cluster cache protects us from creating excessive amount of clusters.
+	// For one outbound we pick one traffic route, so LB and Timeout are
+	// the same.
+	clusterCache := map[string]struct{}{}
+	sc := &meshroute_xds.SplitCounter{}
+	networking := proxy.Dataplane.Spec.GetNetworking()
+	routing := proxy.Routing
+	toRulesHTTP := proxy.Policies.Dynamic[meshhttproute_api.MeshHTTPRouteType].
+		ToRules.Rules
+
+	for _, outbound := range networking.GetOutbound() {
+		tags := outbound.GetTagsIncludingLegacy()
+		serviceName := tags[mesh_proto.ServiceTag]
+		protocol := plugins_xds.InferProtocol(routing, serviceName)
+
+		backendRefs := getBackendRefs(toRulesTCP, toRulesHTTP, serviceName,
+			protocol)
+		if len(backendRefs) == 0 {
+			continue
+		}
+
+		clusters := getClusters(routing, clusterCache, sc, servicesAccumulator,
+			backendRefs)
+		filterChain := buildFilterChain(proxy, serviceName, clusters)
+
+		listener, err := buildOutboundListener(proxy, outbound, filterChain)
+		if err != nil {
+			return nil, errors.Wrap(err, "cannot build listener")
+		}
+
+		resources.Add(&core_xds.Resource{
+			Name:     listener.GetName(),
+			Origin:   generator.OriginOutbound,
+			Resource: listener,
+		})
+	}
+
+	return resources, nil
+}
+
+func buildOutboundListener(
+	proxy *core_xds.Proxy,
+	outbound *mesh_proto.Dataplane_Networking_Outbound,
+	opts ...envoy_listeners.ListenerBuilderOpt,
+) (envoy_common.NamedResource, error) {
+	oface := proxy.Dataplane.Spec.GetNetworking().ToOutboundInterface(outbound)
+	tags := outbound.GetTagsIncludingLegacy()
+	builder := envoy_listeners.NewListenerBuilder(proxy.APIVersion)
+
+	// build listener name in format: "outbound:[IP]:[Port]"
+	// i.e. "outbound:240.0.0.0:80"
+	outboundListenerName := envoy_names.GetOutboundListenerName(
+		oface.DataplaneIP,
+		oface.DataplanePort,
+	)
+
+	outboundListener := envoy_listeners.OutboundListener(
+		outboundListenerName,
+		oface.DataplaneIP,
+		oface.DataplanePort,
+		core_xds.SocketAddressProtocolTCP,
+	)
+
+	tproxy := envoy_listeners.TransparentProxying(
+		proxy.Dataplane.Spec.GetNetworking().GetTransparentProxying(),
+	)
+
+	tagsMetadata := envoy_listeners.TagsMetadata(
+		envoy_tags.Tags(tags).WithoutTags(mesh_proto.MeshTag),
+	)
+
+	return builder.Configure(
+		outboundListener,
+		tproxy,
+		tagsMetadata,
+	).Configure(opts...).Build()
+}
+

--- a/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/listeners_backendrefs.go
+++ b/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/listeners_backendrefs.go
@@ -1,0 +1,56 @@
+package v1alpha1
+
+import (
+	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
+	core_xds "github.com/kumahq/kuma/pkg/core/xds"
+	api "github.com/kumahq/kuma/pkg/plugins/policies/meshtcproute/api/v1alpha1"
+)
+
+func matchingHTTPRuleExist(
+	httpRules core_xds.Rules,
+	serviceName string,
+	protocol core_mesh.Protocol,
+) bool {
+	switch protocol {
+	case core_mesh.ProtocolHTTP, core_mesh.ProtocolHTTP2, core_mesh.ProtocolGRPC:
+	default:
+		return false
+	}
+
+	for _, httpRule := range httpRules {
+		if httpRule.Subset.IsSubset(core_xds.MeshService(serviceName)) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func getTCPBackendRefs(
+	tcpRules core_xds.Rules,
+	serviceName string,
+) []api.BackendRef {
+	for _, tcpRule := range tcpRules {
+		if tcpRule.Subset.IsSubset(core_xds.MeshService(serviceName)) {
+			return tcpRule.Conf.(api.Rule).Default.BackendRefs
+		}
+	}
+
+	return nil
+}
+
+func getBackendRefs(
+	tcpRules core_xds.Rules,
+	httpRules core_xds.Rules,
+	serviceName string,
+	protocol core_mesh.Protocol,
+) []api.BackendRef {
+	// If the outbounds protocol is http-like and there exists MeshHTTPRoute
+	// with rule targeting the same MeshService as MeshTCPRoute, it should take
+	// precedence over the latter
+	if matchingHTTPRuleExist(httpRules, serviceName, protocol) {
+		return nil
+	}
+
+	return getTCPBackendRefs(tcpRules, serviceName)
+}

--- a/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/listeners_clusters.go
+++ b/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/listeners_clusters.go
@@ -1,0 +1,67 @@
+package v1alpha1
+
+import (
+	common_api "github.com/kumahq/kuma/api/common/v1alpha1"
+	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
+	core_xds "github.com/kumahq/kuma/pkg/core/xds"
+	api "github.com/kumahq/kuma/pkg/plugins/policies/meshtcproute/api/v1alpha1"
+	plugins_xds "github.com/kumahq/kuma/pkg/plugins/policies/xds"
+	meshroute_xds "github.com/kumahq/kuma/pkg/plugins/policies/xds/meshroute"
+	"github.com/kumahq/kuma/pkg/util/pointer"
+	envoy_common "github.com/kumahq/kuma/pkg/xds/envoy"
+	envoy_tags "github.com/kumahq/kuma/pkg/xds/envoy/tags"
+)
+
+func getClusters(
+	routing core_xds.Routing,
+	clusterCache map[string]struct{},
+	sc *meshroute_xds.SplitCounter,
+	servicesAccumulator envoy_common.ServicesAccumulator,
+	backendRefs []api.BackendRef,
+) []envoy_common.Cluster {
+	var clusters []envoy_common.Cluster
+
+	for _, ref := range backendRefs {
+		switch ref.Kind {
+		case common_api.MeshService, common_api.MeshServiceSubset:
+		default:
+			continue
+		}
+
+		serviceName := ref.Name
+		if pointer.DerefOr(ref.Weight, 1) == 0 {
+			continue
+		}
+
+		clusterName := meshroute_xds.GetClusterName(ref.Name, ref.Tags, sc)
+		isExternalService := plugins_xds.HasExternalService(routing, ref.Name)
+		refHash := ref.TargetRef.Hash()
+
+		clusterBuilder := plugins_xds.NewClusterBuilder().
+			WithService(serviceName).
+			WithName(clusterName).
+			WithWeight(uint32(pointer.DerefOr(ref.Weight, 1))).
+			WithTags(envoy_tags.Tags(ref.Tags).
+				WithTags(mesh_proto.ServiceTag, ref.Name).
+				WithoutTags(mesh_proto.MeshTag)).
+			WithExternalService(isExternalService)
+
+		if mesh, ok := ref.Tags[mesh_proto.MeshTag]; ok {
+			clusterBuilder.WithMesh(mesh)
+		}
+
+		cluster := clusterBuilder.Build()
+
+		clusters = append(clusters, cluster)
+
+		// cluster doesn't exist yet, so we should create a cache entry, and
+		// add it to the service accumulator
+		if _, ok := clusterCache[refHash]; !ok {
+			clusterCache[refHash] = struct{}{}
+
+			servicesAccumulator.Add(cluster)
+		}
+	}
+
+	return clusters
+}

--- a/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/listeners_filterchain.go
+++ b/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/listeners_filterchain.go
@@ -1,0 +1,19 @@
+package v1alpha1
+
+import (
+	core_xds "github.com/kumahq/kuma/pkg/core/xds"
+	envoy_common "github.com/kumahq/kuma/pkg/xds/envoy"
+	envoy_listeners "github.com/kumahq/kuma/pkg/xds/envoy/listeners"
+)
+
+func buildFilterChain(
+	proxy *core_xds.Proxy,
+	serviceName string,
+	clusters []envoy_common.Cluster,
+) envoy_listeners.ListenerBuilderOpt {
+	tcpProxy := envoy_listeners.TcpProxy(serviceName, clusters...)
+	builder := envoy_listeners.NewFilterChainBuilder(proxy.APIVersion).
+		Configure(tcpProxy)
+
+	return envoy_listeners.FilterChain(builder)
+}

--- a/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/plugin.go
+++ b/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/plugin.go
@@ -1,12 +1,16 @@
 package v1alpha1
 
 import (
+	"github.com/pkg/errors"
+
 	core_plugins "github.com/kumahq/kuma/pkg/core/plugins"
 	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	core_xds "github.com/kumahq/kuma/pkg/core/xds"
 	"github.com/kumahq/kuma/pkg/plugins/policies/matchers"
 	api "github.com/kumahq/kuma/pkg/plugins/policies/meshtcproute/api/v1alpha1"
+	meshroute_xds "github.com/kumahq/kuma/pkg/plugins/policies/xds/meshroute"
 	xds_context "github.com/kumahq/kuma/pkg/xds/context"
+	envoy_common "github.com/kumahq/kuma/pkg/xds/envoy"
 )
 
 var _ core_plugins.PolicyPlugin = &plugin{}
@@ -17,10 +21,45 @@ func NewPlugin() core_plugins.Plugin {
 	return &plugin{}
 }
 
-func (p plugin) MatchedPolicies(dataplane *core_mesh.DataplaneResource, resources xds_context.Resources) (core_xds.TypedMatchingPolicies, error) {
+func (p plugin) MatchedPolicies(
+	dataplane *core_mesh.DataplaneResource,
+	resources xds_context.Resources,
+) (core_xds.TypedMatchingPolicies, error) {
 	return matchers.MatchedPolicies(api.MeshTCPRouteType, dataplane, resources)
 }
 
-func (p plugin) Apply(rs *core_xds.ResourceSet, ctx xds_context.Context, proxy *core_xds.Proxy) error {
+func (p plugin) Apply(
+	rs *core_xds.ResourceSet,
+	ctx xds_context.Context,
+	proxy *core_xds.Proxy,
+) error {
+	tcpRules := proxy.Policies.Dynamic[api.MeshTCPRouteType].ToRules.Rules
+	if len(tcpRules) == 0 {
+		return nil
+	}
+
+	servicesAccumulator := envoy_common.NewServicesAccumulator(
+		ctx.Mesh.ServiceTLSReadiness)
+
+	listeners, err := generateListeners(proxy, tcpRules, servicesAccumulator)
+	if err != nil {
+		return errors.Wrap(err, "couldn't generate listener resources")
+	}
+	rs.AddSet(listeners)
+
+	services := servicesAccumulator.Services()
+
+	clusters, err := meshroute_xds.GenerateClusters(proxy, ctx.Mesh, services)
+	if err != nil {
+		return errors.Wrap(err, "couldn't generate cluster resources")
+	}
+	rs.AddSet(clusters)
+
+	endpoints, err := meshroute_xds.GenerateEndpoints(proxy, ctx, services)
+	if err != nil {
+		return errors.Wrap(err, "couldn't generate endpoint resources")
+	}
+	rs.AddSet(endpoints)
+
 	return nil
 }

--- a/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/plugin_test.go
@@ -41,7 +41,7 @@ func getResource(
 	return actual
 }
 
-var _ = PDescribe("MeshTCPRoute", func() {
+var _ = Describe("MeshTCPRoute", func() {
 	type policiesTestCase struct {
 		dataplane      *core_mesh.DataplaneResource
 		resources      xds_context.Resources

--- a/test/e2e_env/kubernetes/kubernetes_suite_test.go
+++ b/test/e2e_env/kubernetes/kubernetes_suite_test.go
@@ -78,6 +78,6 @@ var (
 	_ = Describe("MeshProxyPatch", meshproxypatch.MeshProxyPatch, Ordered)
 	_ = Describe("MeshFaultInjection", meshfaultinjection.API, Ordered)
 	_ = Describe("MeshHTTPRoute", meshhttproute.Test, Ordered)
-	_ = PDescribe("MeshTCPRoute", meshtcproute.Test, Ordered)
+	_ = Describe("MeshTCPRoute", meshtcproute.Test, Ordered)
 	_ = Describe("Apis", api.Api, Ordered)
 )


### PR DESCRIPTION
This PR introduces logic for applying `MeshTCPRoute` policy, enables already existing unit tests for verification of generated xds resources and enables already existing e2e tests.

Closes: https://github.com/kumahq/kuma/issues/6787

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues
  - https://github.com/kumahq/kuma-website/pull/1341
  - https://github.com/kumahq/kuma/issues/6787
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS
  - it won't
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s)
  - all tests are already merged, this PR enables them
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)?
  - there is no need as it's a new policy
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? 
  - there is no need as it's a new policy
- [x] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?
  - there is no need

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
