### PR TITLE
feat(helm): add possibility to extend secrets for cp in helm charts when reusing kuma charts

### DIFF
--- a/deployments/charts/kuma/templates/_helpers.tpl
+++ b/deployments/charts/kuma/templates/_helpers.tpl
@@ -172,6 +172,9 @@ returns: formatted image string
 {{- define "kuma.parentEnv" -}}
 {{- end -}}
 
+{{- define "kuma.parentSecrets" -}}
+{{- end -}}
+
 {{- define "kuma.defaultEnv" -}}
 {{ if (and (eq .Values.controlPlane.environment "universal") (not (eq .Values.controlPlane.mode "global"))) }}
   {{ fail "Currently you can only run universal mode on kubernetes in a global mode, this limitation might be lifted in the future" }}

--- a/deployments/charts/kuma/templates/cp-deployment.yaml
+++ b/deployments/charts/kuma/templates/cp-deployment.yaml
@@ -25,6 +25,9 @@
 {{- end }}
 {{- $envVarsCopy := deepCopy .Values.controlPlane.envVars }}
 {{- $mergedEnv := merge $envVarsCopy $defaultEnvDict }}
+{{- $defaultSecrets := include "kuma.parentSecrets" . | fromYaml }}
+{{- $extraSecrets := .Values.controlPlane.extraSecrets }}
+{{- $mergedSecrets := merge $extraSecrets $defaultSecrets }}
 
 apiVersion: apps/v1
 kind: Deployment
@@ -241,10 +244,11 @@ spec:
               mountPath: {{ $extraConfigMap.mountPath }}
               readOnly: {{ $extraConfigMap.readOnly }}
           {{- end }}
-          {{- range $extraSecret := .Values.controlPlane.extraSecrets }}
-            - name: {{ $extraSecret.name }}
-              mountPath: {{ $extraSecret.mountPath }}
-              readOnly: {{ $extraSecret.readOnly }}
+          {{- range $mergedSecret := $mergedSecrets }}
+            - name: {{ $mergedSecret.name }}
+              mountPath: {{ $mergedSecret.mountPath }}
+              subPath: {{ $mergedSecret.subPath }}
+              readOnly: {{ $mergedSecret.readOnly }}
           {{- end }}
             - name: tmp
               mountPath: /tmp
@@ -323,10 +327,10 @@ spec:
           configMap:
             name: {{ $extraConfigMap.name }}
         {{- end }}
-        {{- range $extraSecret := .Values.controlPlane.extraSecrets }}
-        - name: {{ $extraSecret.name }}
+        {{- range $mergedSecret := $mergedSecrets }}
+        - name: {{ $mergedSecret.name }}
           secret:
-            secretName: {{ $extraSecret.name }}
+            secretName: {{ $mergedSecret.name }}
         {{- end }}
         - name: tmp
           emptyDir: {}


### PR DESCRIPTION


### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [x] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
