### PR TITLE
feat(kuma-cp): allow to override resource store plugin

### DIFF
--- a/pkg/core/plugins/registry.go
+++ b/pkg/core/plugins/registry.go
@@ -144,9 +144,6 @@ func (r *registry) Register(name PluginName, plugin Plugin) error {
 		r.bootstrap[name] = bp
 	}
 	if rsp, ok := plugin.(ResourceStorePlugin); ok {
-		if old, exists := r.resourceStore[name]; exists {
-			return pluginAlreadyRegisteredError(resourceStorePlugin, name, old, rsp)
-		}
 		r.resourceStore[name] = rsp
 	}
 	if ssp, ok := plugin.(SecretStorePlugin); ok {


### PR DESCRIPTION
### Checklist prior to review

This check defeats the purpose of resource store plugin. You can put resource store in BeforeBootstrap, but it's then overridden by plugin. You cannot put your resource store in AfterBootstrap because it's used across all components during bootstrap

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [ ] [Link to relevant issue][1] as well as docs and UI issues --
- [ ] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [ ] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [ ] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [ ] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [ ] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
