### PR TITLE
refactor(xds/builders): remove redundant structures

### DIFF
--- a/pkg/plugins/policies/xds/testutil.go
+++ b/pkg/plugins/policies/xds/testutil.go
@@ -33,7 +33,7 @@ func (n *NameConfigurer) Configure(c *envoy_cluster.Cluster) error {
 }
 
 func WithName(name string) clusters_builder.ClusterBuilderOpt {
-	return clusters_builder.ClusterBuilderOptFunc(func(config *clusters_builder.ClusterBuilderConfig) {
-		config.AddV3(&NameConfigurer{Name: name})
+	return clusters_builder.ClusterBuilderOptFunc(func(builder *clusters_builder.ClusterBuilder) {
+		builder.AddConfigurer(&NameConfigurer{Name: name})
 	})
 }

--- a/pkg/test/xds/name_configurer.go
+++ b/pkg/test/xds/name_configurer.go
@@ -17,8 +17,8 @@ func (n *NameConfigurer) Configure(c *envoy_cluster.Cluster) error {
 }
 
 func WithName(name string) clusters_builder.ClusterBuilderOpt {
-	return clusters_builder.ClusterBuilderOptFunc(func(config *clusters_builder.ClusterBuilderConfig) {
-		config.AddV3(&NameConfigurer{Name: name})
+	return clusters_builder.ClusterBuilderOptFunc(func(builder *clusters_builder.ClusterBuilder) {
+		builder.AddConfigurer(&NameConfigurer{Name: name})
 	})
 }
 

--- a/pkg/xds/envoy/clusters/configurers.go
+++ b/pkg/xds/envoy/clusters/configurers.go
@@ -12,20 +12,20 @@ import (
 )
 
 func OutlierDetection(circuitBreaker *core_mesh.CircuitBreakerResource) ClusterBuilderOpt {
-	return ClusterBuilderOptFunc(func(config *ClusterBuilderConfig) {
-		config.AddV3(&v3.OutlierDetectionConfigurer{CircuitBreaker: circuitBreaker})
+	return ClusterBuilderOptFunc(func(builder *ClusterBuilder) {
+		builder.AddConfigurer(&v3.OutlierDetectionConfigurer{CircuitBreaker: circuitBreaker})
 	})
 }
 
 func CircuitBreaker(circuitBreaker *core_mesh.CircuitBreakerResource) ClusterBuilderOpt {
-	return ClusterBuilderOptFunc(func(config *ClusterBuilderConfig) {
-		config.AddV3(&v3.CircuitBreakerConfigurer{CircuitBreaker: circuitBreaker})
+	return ClusterBuilderOptFunc(func(builder *ClusterBuilder) {
+		builder.AddConfigurer(&v3.CircuitBreakerConfigurer{CircuitBreaker: circuitBreaker})
 	})
 }
 
 func ClientSideMTLS(tracker core_xds.SecretsTracker, mesh *core_mesh.MeshResource, upstreamService string, upstreamTLSReady bool, tags []envoy_tags.Tags) ClusterBuilderOpt {
-	return ClusterBuilderOptFunc(func(config *ClusterBuilderConfig) {
-		config.AddV3(&v3.ClientSideMTLSConfigurer{
+	return ClusterBuilderOptFunc(func(builder *ClusterBuilder) {
+		builder.AddConfigurer(&v3.ClientSideMTLSConfigurer{
 			SecretsTracker:   tracker,
 			UpstreamMesh:     mesh,
 			UpstreamService:  upstreamService,
@@ -37,8 +37,8 @@ func ClientSideMTLS(tracker core_xds.SecretsTracker, mesh *core_mesh.MeshResourc
 }
 
 func CrossMeshClientSideMTLS(tracker core_xds.SecretsTracker, localMesh *core_mesh.MeshResource, upstreamMesh *core_mesh.MeshResource, upstreamService string, upstreamTLSReady bool, tags []envoy_tags.Tags) ClusterBuilderOpt {
-	return ClusterBuilderOptFunc(func(config *ClusterBuilderConfig) {
-		config.AddV3(&v3.ClientSideMTLSConfigurer{
+	return ClusterBuilderOptFunc(func(builder *ClusterBuilder) {
+		builder.AddConfigurer(&v3.ClientSideMTLSConfigurer{
 			SecretsTracker:   tracker,
 			UpstreamMesh:     upstreamMesh,
 			UpstreamService:  upstreamService,
@@ -51,8 +51,8 @@ func CrossMeshClientSideMTLS(tracker core_xds.SecretsTracker, localMesh *core_me
 
 // UnknownDestinationClientSideMTLS configures cluster with mTLS for a mesh but without extensive destination verification (only Mesh is verified)
 func UnknownDestinationClientSideMTLS(tracker core_xds.SecretsTracker, mesh *core_mesh.MeshResource) ClusterBuilderOpt {
-	return ClusterBuilderOptFunc(func(config *ClusterBuilderConfig) {
-		config.AddV3(&v3.ClientSideMTLSConfigurer{
+	return ClusterBuilderOptFunc(func(builder *ClusterBuilder) {
+		builder.AddConfigurer(&v3.ClientSideMTLSConfigurer{
 			SecretsTracker:   tracker,
 			UpstreamMesh:     mesh,
 			UpstreamService:  "*",
@@ -64,37 +64,37 @@ func UnknownDestinationClientSideMTLS(tracker core_xds.SecretsTracker, mesh *cor
 }
 
 func ClientSideTLS(endpoints []core_xds.Endpoint) ClusterBuilderOpt {
-	return ClusterBuilderOptFunc(func(config *ClusterBuilderConfig) {
-		config.AddV3(&v3.ClientSideTLSConfigurer{
+	return ClusterBuilderOptFunc(func(builder *ClusterBuilder) {
+		builder.AddConfigurer(&v3.ClientSideTLSConfigurer{
 			Endpoints: endpoints,
 		})
 	})
 }
 
 func EdsCluster(name string) ClusterBuilderOpt {
-	return ClusterBuilderOptFunc(func(config *ClusterBuilderConfig) {
-		config.AddV3(&v3.EdsClusterConfigurer{
+	return ClusterBuilderOptFunc(func(builder *ClusterBuilder) {
+		builder.AddConfigurer(&v3.EdsClusterConfigurer{
 			Name: name,
 		})
-		config.AddV3(&v3.AltStatNameConfigurer{})
+		builder.AddConfigurer(&v3.AltStatNameConfigurer{})
 	})
 }
 
 // ProvidedEndpointCluster sets the cluster with the defined endpoints, this is useful when endpoints are not discovered using EDS, so we don't use EdsCluster
 func ProvidedEndpointCluster(name string, hasIPv6 bool, endpoints ...core_xds.Endpoint) ClusterBuilderOpt {
-	return ClusterBuilderOptFunc(func(config *ClusterBuilderConfig) {
-		config.AddV3(&v3.ProvidedEndpointClusterConfigurer{
+	return ClusterBuilderOptFunc(func(builder *ClusterBuilder) {
+		builder.AddConfigurer(&v3.ProvidedEndpointClusterConfigurer{
 			Name:      name,
 			Endpoints: endpoints,
 			HasIPv6:   hasIPv6,
 		})
-		config.AddV3(&v3.AltStatNameConfigurer{})
+		builder.AddConfigurer(&v3.AltStatNameConfigurer{})
 	})
 }
 
 func HealthCheck(protocol core_mesh.Protocol, healthCheck *core_mesh.HealthCheckResource) ClusterBuilderOpt {
-	return ClusterBuilderOptFunc(func(config *ClusterBuilderConfig) {
-		config.AddV3(&v3.HealthCheckConfigurer{
+	return ClusterBuilderOptFunc(func(builder *ClusterBuilder) {
+		builder.AddConfigurer(&v3.HealthCheckConfigurer{
 			HealthCheck: healthCheck,
 			Protocol:    protocol,
 		})
@@ -118,24 +118,24 @@ func HealthCheck(protocol core_mesh.Protocol, healthCheck *core_mesh.HealthCheck
 //     version: v1
 //     Only one cluster "backend" is generated for such dataplane, but with lb subset by version.
 func LbSubset(tagSets envoy_tags.TagKeysSlice) ClusterBuilderOptFunc {
-	return func(config *ClusterBuilderConfig) {
-		config.AddV3(&v3.LbSubsetConfigurer{
+	return func(builder *ClusterBuilder) {
+		builder.AddConfigurer(&v3.LbSubsetConfigurer{
 			TagKeysSets: tagSets,
 		})
 	}
 }
 
 func LB(lb *mesh_proto.TrafficRoute_LoadBalancer) ClusterBuilderOpt {
-	return ClusterBuilderOptFunc(func(config *ClusterBuilderConfig) {
-		config.AddV3(&v3.LbConfigurer{
+	return ClusterBuilderOptFunc(func(builder *ClusterBuilder) {
+		builder.AddConfigurer(&v3.LbConfigurer{
 			Lb: lb,
 		})
 	})
 }
 
 func Timeout(timeout *mesh_proto.Timeout_Conf, protocol core_mesh.Protocol) ClusterBuilderOpt {
-	return ClusterBuilderOptFunc(func(config *ClusterBuilderConfig) {
-		config.AddV3(&v3.TimeoutConfigurer{
+	return ClusterBuilderOptFunc(func(builder *ClusterBuilder) {
+		builder.AddConfigurer(&v3.TimeoutConfigurer{
 			Protocol: protocol,
 			Conf:     timeout,
 		})
@@ -143,25 +143,25 @@ func Timeout(timeout *mesh_proto.Timeout_Conf, protocol core_mesh.Protocol) Clus
 }
 
 func DefaultTimeout() ClusterBuilderOpt {
-	return ClusterBuilderOptFunc(func(config *ClusterBuilderConfig) {
-		config.AddV3(&v3.TimeoutConfigurer{
+	return ClusterBuilderOptFunc(func(builder *ClusterBuilder) {
+		builder.AddConfigurer(&v3.TimeoutConfigurer{
 			Protocol: core_mesh.ProtocolTCP,
 		})
 	})
 }
 
 func PassThroughCluster(name string) ClusterBuilderOpt {
-	return ClusterBuilderOptFunc(func(config *ClusterBuilderConfig) {
-		config.AddV3(&v3.PassThroughClusterConfigurer{
+	return ClusterBuilderOptFunc(func(builder *ClusterBuilder) {
+		builder.AddConfigurer(&v3.PassThroughClusterConfigurer{
 			Name: name,
 		})
-		config.AddV3(&v3.AltStatNameConfigurer{})
+		builder.AddConfigurer(&v3.AltStatNameConfigurer{})
 	})
 }
 
 func UpstreamBindConfig(address string, port uint32) ClusterBuilderOpt {
-	return ClusterBuilderOptFunc(func(config *ClusterBuilderConfig) {
-		config.AddV3(&v3.UpstreamBindConfigConfigurer{
+	return ClusterBuilderOptFunc(func(builder *ClusterBuilder) {
+		builder.AddConfigurer(&v3.UpstreamBindConfigConfigurer{
 			Address: address,
 			Port:    port,
 		})
@@ -169,27 +169,27 @@ func UpstreamBindConfig(address string, port uint32) ClusterBuilderOpt {
 }
 
 func ConnectionBufferLimit(bytes uint32) ClusterBuilderOpt {
-	return ClusterBuilderOptFunc(func(config *ClusterBuilderConfig) {
-		config.AddV3(v3.ClusterMustConfigureFunc(func(c *envoy_cluster.Cluster) {
+	return ClusterBuilderOptFunc(func(builder *ClusterBuilder) {
+		builder.AddConfigurer(v3.ClusterMustConfigureFunc(func(c *envoy_cluster.Cluster) {
 			c.PerConnectionBufferLimitBytes = wrapperspb.UInt32(bytes)
 		}))
 	})
 }
 
 func Http2() ClusterBuilderOpt {
-	return ClusterBuilderOptFunc(func(config *ClusterBuilderConfig) {
-		config.AddV3(&v3.Http2Configurer{})
+	return ClusterBuilderOptFunc(func(builder *ClusterBuilder) {
+		builder.AddConfigurer(&v3.Http2Configurer{})
 	})
 }
 
 func Http2FromEdge() ClusterBuilderOpt {
-	return ClusterBuilderOptFunc(func(config *ClusterBuilderConfig) {
-		config.AddV3(&v3.Http2Configurer{EdgeProxyWindowSizes: true})
+	return ClusterBuilderOptFunc(func(builder *ClusterBuilder) {
+		builder.AddConfigurer(&v3.Http2Configurer{EdgeProxyWindowSizes: true})
 	})
 }
 
 func Http() ClusterBuilderOpt {
-	return ClusterBuilderOptFunc(func(config *ClusterBuilderConfig) {
-		config.AddV3(&v3.HttpConfigurer{})
+	return ClusterBuilderOptFunc(func(builder *ClusterBuilder) {
+		builder.AddConfigurer(&v3.HttpConfigurer{})
 	})
 }

--- a/pkg/xds/envoy/routes/route_configuration_builder.go
+++ b/pkg/xds/envoy/routes/route_configuration_builder.go
@@ -14,7 +14,7 @@ import (
 // The goal of RouteConfigurationBuilderOpt is to facilitate fluent RouteConfigurationBuilder API.
 type RouteConfigurationBuilderOpt interface {
 	// ApplyTo adds RouteConfigurationConfigurer(s) to the RouteConfigurationBuilder.
-	ApplyTo(config *RouteConfigurationBuilderConfig)
+	ApplyTo(builder *RouteConfigurationBuilder)
 }
 
 func NewRouteConfigurationBuilder(apiVersion core_xds.APIVersion) *RouteConfigurationBuilder {
@@ -26,15 +26,16 @@ func NewRouteConfigurationBuilder(apiVersion core_xds.APIVersion) *RouteConfigur
 // RouteConfigurationBuilder is responsible for generating an Envoy RouteConfiguration
 // by applying a series of RouteConfigurationConfigurers.
 type RouteConfigurationBuilder struct {
-	apiVersion core_xds.APIVersion
-	config     RouteConfigurationBuilderConfig
+	apiVersion  core_xds.APIVersion
+	configurers []v3.RouteConfigurationConfigurer
 }
 
 // Configure configures RouteConfigurationBuilder by adding individual RouteConfigurationConfigurers.
 func (b *RouteConfigurationBuilder) Configure(opts ...RouteConfigurationBuilderOpt) *RouteConfigurationBuilder {
 	for _, opt := range opts {
-		opt.ApplyTo(&b.config)
+		opt.ApplyTo(b)
 	}
+
 	return b
 }
 
@@ -43,7 +44,7 @@ func (b *RouteConfigurationBuilder) Build() (envoy.NamedResource, error) {
 	switch b.apiVersion {
 	case envoy.APIV3:
 		routeConfiguration := envoy_route_v3.RouteConfiguration{}
-		for _, configurer := range b.config.ConfigurersV3 {
+		for _, configurer := range b.configurers {
 			if err := configurer.Configure(&routeConfiguration); err != nil {
 				return nil, err
 			}
@@ -54,28 +55,22 @@ func (b *RouteConfigurationBuilder) Build() (envoy.NamedResource, error) {
 	}
 }
 
-// RouteConfigurationBuilderConfig holds configuration of a RouteConfigurationBuilder.
-type RouteConfigurationBuilderConfig struct {
-	// A series of RouteConfigurationConfigurers to apply to Envoy RouteConfiguration.
-	ConfigurersV3 []v3.RouteConfigurationConfigurer
-}
-
-// Add appends a given RouteConfigurationConfigurer to the end of the chain.
-func (c *RouteConfigurationBuilderConfig) AddV3(configurer v3.RouteConfigurationConfigurer) {
-	c.ConfigurersV3 = append(c.ConfigurersV3, configurer)
+// AddConfigurer appends a given RouteConfigurationConfigurer to the end of the chain.
+func (b *RouteConfigurationBuilder) AddConfigurer(configurer v3.RouteConfigurationConfigurer) {
+	b.configurers = append(b.configurers, configurer)
 }
 
 // RouteConfigurationBuilderOptFunc is a convenience type adapter.
-type RouteConfigurationBuilderOptFunc func(config *RouteConfigurationBuilderConfig)
+type RouteConfigurationBuilderOptFunc func(builder *RouteConfigurationBuilder)
 
-func (f RouteConfigurationBuilderOptFunc) ApplyTo(config *RouteConfigurationBuilderConfig) {
-	f(config)
+func (f RouteConfigurationBuilderOptFunc) ApplyTo(builder *RouteConfigurationBuilder) {
+	f(builder)
 }
 
 // AddRouteConfigurationConfigurer produces an option that adds the given
-// configurer to the route coonfiguration builder.
+// configurer to the route configuration builder.
 func AddRouteConfigurationConfigurer(c v3.RouteConfigurationConfigurer) RouteConfigurationBuilderOpt {
-	return RouteConfigurationBuilderOptFunc(func(config *RouteConfigurationBuilderConfig) {
-		config.AddV3(c)
+	return RouteConfigurationBuilderOptFunc(func(builder *RouteConfigurationBuilder) {
+		builder.AddConfigurer(c)
 	})
 }


### PR DESCRIPTION
In the quest of simplifying our code base I found that structures `*BuilderConfig` are completely unnecessary and only obscure our code base to the point I had to draw on paper all the structures necessary to build one portion of envoy configuration.

I believe removing them doesn't remove any functionality and make everything a bit simpler.

When moving `*BuilderConfig.AddV3` methods to `*Builder` structs, instead of using the name `AddV3`, I changed it to `AddConfigurer` and stripped V3 from the name, as we currently don't have any V2 configurers.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues
  - there is no relevant issue
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS
  - it won't
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s)
  - it's a refactor, so existing tests should be enough
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)?
  - there is no need, as it's not an user facing change
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? 
  - it doesn't
- [x] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?
  - there is no need

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
