### PR TITLE
chore(gateway): remove deprecated envoy APIs from route configurers

### DIFF
--- a/pkg/plugins/runtime/gateway/route/configurers.go
+++ b/pkg/plugins/runtime/gateway/route/configurers.go
@@ -180,6 +180,7 @@ func RouteMatchRegexQuery(name string, regex string) RouteConfigurer {
 
 func RouteAppendHeader(name string, value string) *envoy_config_core.HeaderValueOption {
 	return &envoy_config_core.HeaderValueOption{
+		AppendAction: envoy_config_core.HeaderValueOption_APPEND_IF_EXISTS_OR_ADD,
 		Header: &envoy_config_core.HeaderValue{
 			Key:   http.CanonicalHeaderKey(name),
 			Value: value,

--- a/pkg/plugins/runtime/gateway/testdata/http/05-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/05-gateway-route.yaml
@@ -80,7 +80,6 @@ Routes:
             portRedirect: 8080
             regexRewrite:
               pattern:
-                googleRe2: {}
                 regex: .*
               substitution: /redirected
             responseCode: FOUND

--- a/pkg/plugins/runtime/gateway/testdata/http/06-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/06-gateway-route.yaml
@@ -150,20 +150,18 @@ Routes:
         - match:
             path: /
           requestHeadersToAdd:
-          - append: false
+          - appendAction: OVERWRITE_IF_EXISTS_OR_ADD
             header:
               key: Set-Header-One
               value: one
-          - append: false
+          - appendAction: OVERWRITE_IF_EXISTS_OR_ADD
             header:
               key: Set-Header-Two
               value: two
-          - append: true
-            header:
+          - header:
               key: Append-Forwarded
               value: "yes"
-          - append: true
-            header:
+          - header:
               key: Append-Forwarded
               value: please
           requestHeadersToRemove:

--- a/pkg/plugins/runtime/gateway/testdata/http/09-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/09-gateway-route.yaml
@@ -119,7 +119,6 @@ Routes:
         routes:
         - match:
             safeRegex:
-              googleRe2: {}
               regex: ^/api/v[0-9]+$
           route:
             clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR

--- a/pkg/plugins/runtime/gateway/testdata/http/10-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/10-gateway-route.yaml
@@ -224,13 +224,13 @@ Routes:
         - match:
             headers:
             - name: Content-Type
-              safeRegexMatch:
-                googleRe2: {}
-                regex: application/.*
+              stringMatch:
+                safeRegex:
+                  regex: application/.*
             - name: Language
-              safeRegexMatch:
-                googleRe2: {}
-                regex: .*sh
+              stringMatch:
+                safeRegex:
+                  regex: .*sh
             prefix: /
           route:
             clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR

--- a/pkg/plugins/runtime/gateway/testdata/http/11-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/11-gateway-route.yaml
@@ -167,12 +167,10 @@ Routes:
             - name: Content-Type
               stringMatch:
                 safeRegex:
-                  googleRe2: {}
                   regex: application/.*
             - name: Language
               stringMatch:
                 safeRegex:
-                  googleRe2: {}
                   regex: .*sh
           route:
             clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR

--- a/pkg/plugins/runtime/gateway/testdata/http/13-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/13-gateway-route.yaml
@@ -267,7 +267,6 @@ Routes:
                 weight: 1
         - match:
             safeRegex:
-              googleRe2: {}
               regex: /match/foo
           route:
             clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR

--- a/pkg/plugins/runtime/gateway/testdata/http/drop-prefix-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/drop-prefix-gateway-route.yaml
@@ -123,7 +123,6 @@ Routes:
             clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
             regexRewrite:
               pattern:
-                googleRe2: {}
                 regex: .*
               substitution: /
             retryPolicy:

--- a/pkg/plugins/runtime/gateway/testdata/http/response-header-set-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/response-header-set-gateway-route.yaml
@@ -120,7 +120,7 @@ Routes:
         - match:
             prefix: /
           responseHeadersToAdd:
-          - append: false
+          - appendAction: OVERWRITE_IF_EXISTS_OR_ADD
             header:
               key: X-Kuma-Test
               value: value

--- a/pkg/plugins/runtime/gateway/testdata/http/rewrite-prefix-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/rewrite-prefix-gateway-route.yaml
@@ -123,7 +123,6 @@ Routes:
             portRedirect: 8080
             regexRewrite:
               pattern:
-                googleRe2: {}
                 regex: .*
               substitution: /a
             responseCode: FOUND
@@ -134,7 +133,6 @@ Routes:
             clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
             regexRewrite:
               pattern:
-                googleRe2: {}
                 regex: .*
               substitution: /a
             retryPolicy:

--- a/pkg/plugins/runtime/gateway/testdata/http/rewrite-prefix-trailing-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/rewrite-prefix-trailing-gateway-route.yaml
@@ -123,7 +123,6 @@ Routes:
             clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
             regexRewrite:
               pattern:
-                googleRe2: {}
                 regex: .*
               substitution: /a
             retryPolicy:

--- a/pkg/plugins/runtime/gateway/testdata/https/05-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/05-gateway-route.yaml
@@ -106,7 +106,6 @@ Routes:
             portRedirect: 8080
             regexRewrite:
               pattern:
-                googleRe2: {}
                 regex: .*
               substitution: /redirected
             responseCode: FOUND

--- a/pkg/plugins/runtime/gateway/testdata/https/06-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/06-gateway-route.yaml
@@ -176,20 +176,18 @@ Routes:
         - match:
             path: /
           requestHeadersToAdd:
-          - append: false
+          - appendAction: OVERWRITE_IF_EXISTS_OR_ADD
             header:
               key: Set-Header-One
               value: one
-          - append: false
+          - appendAction: OVERWRITE_IF_EXISTS_OR_ADD
             header:
               key: Set-Header-Two
               value: two
-          - append: true
-            header:
+          - header:
               key: Append-Forwarded
               value: "yes"
-          - append: true
-            header:
+          - header:
               key: Append-Forwarded
               value: please
           requestHeadersToRemove:

--- a/pkg/plugins/runtime/gateway/testdata/https/09-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/09-gateway-route.yaml
@@ -145,7 +145,6 @@ Routes:
         routes:
         - match:
             safeRegex:
-              googleRe2: {}
               regex: ^/api/v[0-9]+$
           route:
             clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR

--- a/pkg/plugins/runtime/gateway/testdata/https/10-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/10-gateway-route.yaml
@@ -250,13 +250,13 @@ Routes:
         - match:
             headers:
             - name: Content-Type
-              safeRegexMatch:
-                googleRe2: {}
-                regex: application/.*
+              stringMatch:
+                safeRegex:
+                  regex: application/.*
             - name: Language
-              safeRegexMatch:
-                googleRe2: {}
-                regex: .*sh
+              stringMatch:
+                safeRegex:
+                  regex: .*sh
             prefix: /
           route:
             clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR

--- a/pkg/plugins/runtime/gateway/testdata/https/11-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/11-gateway-route.yaml
@@ -193,12 +193,10 @@ Routes:
             - name: Content-Type
               stringMatch:
                 safeRegex:
-                  googleRe2: {}
                   regex: application/.*
             - name: Language
               stringMatch:
                 safeRegex:
-                  googleRe2: {}
                   regex: .*sh
           route:
             clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR

--- a/pkg/plugins/runtime/gateway/testdata/https/13-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/13-gateway-route.yaml
@@ -293,7 +293,6 @@ Routes:
                 weight: 1
         - match:
             safeRegex:
-              googleRe2: {}
               regex: /match/foo
           route:
             clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR

--- a/pkg/plugins/runtime/gateway/testdata/https/drop-prefix-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/drop-prefix-gateway-route.yaml
@@ -149,7 +149,6 @@ Routes:
             clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
             regexRewrite:
               pattern:
-                googleRe2: {}
                 regex: .*
               substitution: /
             retryPolicy:

--- a/pkg/plugins/runtime/gateway/testdata/https/response-header-set-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/response-header-set-gateway-route.yaml
@@ -146,7 +146,7 @@ Routes:
         - match:
             prefix: /
           responseHeadersToAdd:
-          - append: false
+          - appendAction: OVERWRITE_IF_EXISTS_OR_ADD
             header:
               key: X-Kuma-Test
               value: value

--- a/pkg/plugins/runtime/gateway/testdata/https/rewrite-prefix-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/rewrite-prefix-gateway-route.yaml
@@ -149,7 +149,6 @@ Routes:
             portRedirect: 8080
             regexRewrite:
               pattern:
-                googleRe2: {}
                 regex: .*
               substitution: /a
             responseCode: FOUND
@@ -160,7 +159,6 @@ Routes:
             clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
             regexRewrite:
               pattern:
-                googleRe2: {}
                 regex: .*
               substitution: /a
             retryPolicy:

--- a/pkg/plugins/runtime/gateway/testdata/https/rewrite-prefix-trailing-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/rewrite-prefix-trailing-gateway-route.yaml
@@ -149,7 +149,6 @@ Routes:
             clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
             regexRewrite:
               pattern:
-                googleRe2: {}
                 regex: .*
               substitution: /a
             retryPolicy:


### PR DESCRIPTION
1. Setting `EngineType` is optional from Envoy v1.24 (ref. https://github.com/envoyproxy/envoy/issue/24256#issuecomment-1333078240) so we can safely remove:
   ```
   EngineType: &envoy_type_matcher.RegexMatcher_GoogleRe2{
      GoogleRe2: &envoy_type_matcher.RegexMatcher_GoogleRE2{},
   }
   ``` 
   it means I was also able to remove redundant now helper function `regexOf`.
3. Usage of `HeaderMatcher_SafeRegexMatch` is deprecated in favor of `HeaderMatcher_StringMatch`
4. `HeaderValueOption` instead of `Append` there is suggestion to use: `AppendAction: envoy_config_core.HeaderValueOption_OVERWRITE_IF_EXISTS_OR_ADD`
5. Small typo fix in the comment of `RouteDeleteResponseHeader` function

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues
  - no relevant issue
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS
  - it shouldn't
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s)
  - updated golden files
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)?
  - there is no need
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? 
  - I don't believe it does
- [x] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?
  - there is no need

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
