### PR TITLE
fix(kuma-cp): make zone insight context independent from parent

### DIFF
--- a/pkg/kds/server/status_sink.go
+++ b/pkg/kds/server/status_sink.go
@@ -93,7 +93,6 @@ func (s *zoneInsightSink) Start(ctx context.Context, stop <-chan struct{}) {
 			flush()
 		case <-stop:
 			flush()
-			cancel()
 			return
 		}
 	}


### PR DESCRIPTION
When we are using parent context and the stream is canceled function responsible for flushing stats to the database is also canceled and fails. We need a separate context that still can flush data after the parent context is closed but the stream is not fully destroyed. That happens when using pgx and postgres. I am not sure if this is the best way to fix it.


- [X] [Link to relevant issue][1] as well as docs and UI issues --
- [X] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [X] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [X] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [X] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [X] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
