### PR TITLE
chore(kuma-cp): add convenience Clusters method to ServicesAccumulator

### DIFF
--- a/pkg/xds/envoy/types.go
+++ b/pkg/xds/envoy/types.go
@@ -195,6 +195,19 @@ func (sa ServicesAccumulator) Services() Services {
 	return sa.services
 }
 
+// Clusters returns a slice of all clusters gathered in all accumulated
+// services. This is a convenience method, which may be used whenever there is
+// need to configure tcpProxy with weighted clusters (like in MeshTCPProxy)
+func (sa ServicesAccumulator) Clusters() []Cluster {
+	var clusters []Cluster
+
+	for _, service := range sa.services {
+		clusters = append(clusters, service.clusters...)
+	}
+
+	return clusters
+}
+
 func (sa ServicesAccumulator) Add(clusters ...Cluster) {
 	for _, c := range clusters {
 		if sa.services[c.Service()] == nil {


### PR DESCRIPTION
Clusters returns a slice of all clusters gathered in all accumulated services. This is a convenience method, which may be used whenever there is need to configure tcpProxy with weighted clusters (like in MeshTCPProxy)

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues
  - https://github.com/kumahq/kuma/pull/6873
  - https://github.com/kumahq/kuma/issues/6787
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS
  - it won't
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s)
  - this is just a convenience function, not used anywhere yet, so no tests were carried out
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)?
  - there is no need
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? 
  - there is no need
- [x] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?
  - there is no need

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
