### PR TITLE
chore(MeshHTTPRoute): refactor makeHTTPsplit function + add weights to clusters

### DIFF
--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/listeners.go
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/listeners.go
@@ -193,12 +193,13 @@ func makeSplit(
 		clusterName := meshroute_xds.GetClusterName(ref.Name, ref.Tags, sc)
 		isExternalService := plugins_xds.HasExternalService(proxy.Routing, service)
 		refHash := ref.TargetRef.Hash()
+		refWeight := uint32(pointer.DerefOr(ref.Weight, 1))
 
 		if existingClusterName, ok := clusterCache[refHash]; ok {
 			// cluster already exists, so adding only split
 			split = append(split, plugins_xds.NewSplitBuilder().
 				WithClusterName(existingClusterName).
-				WithWeight(uint32(pointer.DerefOr(ref.Weight, 1))).
+				WithWeight(refWeight).
 				WithExternalService(isExternalService).
 				Build())
 			continue
@@ -208,7 +209,7 @@ func makeSplit(
 
 		split = append(split, plugins_xds.NewSplitBuilder().
 			WithClusterName(clusterName).
-			WithWeight(uint32(pointer.DerefOr(ref.Weight, 1))).
+			WithWeight(refWeight).
 			WithExternalService(isExternalService).
 			Build())
 

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/listeners.go
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/listeners.go
@@ -54,14 +54,14 @@ func generateListeners(
 		protocol := plugins_xds.InferProtocol(proxy.Routing, serviceName)
 		var routes []xds.OutboundRoute
 		for _, route := range prepareRoutes(rules, serviceName, protocol) {
-			split := makeHTTPSplit(proxy, clusterCache, splitCounter, servicesAcc, route.BackendRefs)
+			split := makeSplit(proxy, clusterCache, splitCounter, servicesAcc, route.BackendRefs)
 			if split == nil {
 				continue
 			}
 			for _, filter := range route.Filters {
 				if filter.Type == api.RequestMirrorType {
 					// we need to create a split for the mirror backend
-					_ = makeHTTPSplit(proxy, clusterCache, splitCounter, servicesAcc,
+					_ = makeSplit(proxy, clusterCache, splitCounter, servicesAcc,
 						[]common_api.BackendRef{{
 							TargetRef: filter.RequestMirror.BackendRef,
 							Weight:    pointer.To[uint](1), // any non-zero value
@@ -169,7 +169,7 @@ func prepareRoutes(
 	return routes
 }
 
-func makeHTTPSplit(
+func makeSplit(
 	proxy *core_xds.Proxy,
 	clusterCache map[string]string,
 	sc *meshroute_xds.SplitCounter,

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/listeners.go
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/listeners.go
@@ -168,4 +168,3 @@ func prepareRoutes(
 
 	return routes
 }
-

--- a/pkg/plugins/policies/meshhttproute/xds/builder.go
+++ b/pkg/plugins/policies/meshhttproute/xds/builder.go
@@ -5,7 +5,6 @@ import (
 
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	api "github.com/kumahq/kuma/pkg/plugins/policies/meshhttproute/api/v1alpha1"
-	plugins_xds "github.com/kumahq/kuma/pkg/plugins/policies/xds"
 	envoy_common "github.com/kumahq/kuma/pkg/xds/envoy"
 	envoy_listeners_v3 "github.com/kumahq/kuma/pkg/xds/envoy/listeners/v3"
 	envoy_names "github.com/kumahq/kuma/pkg/xds/envoy/names"
@@ -15,7 +14,7 @@ import (
 type OutboundRoute struct {
 	Matches                 []api.Match
 	Filters                 []api.Filter
-	Split                   []*plugins_xds.Split
+	Split                   []envoy_common.Split
 	BackendRefToClusterName map[string]string
 }
 

--- a/pkg/plugins/policies/meshhttproute/xds/configurer.go
+++ b/pkg/plugins/policies/meshhttproute/xds/configurer.go
@@ -9,15 +9,15 @@ import (
 
 	api "github.com/kumahq/kuma/pkg/plugins/policies/meshhttproute/api/v1alpha1"
 	"github.com/kumahq/kuma/pkg/plugins/policies/meshhttproute/xds/filters"
-	plugins_xds "github.com/kumahq/kuma/pkg/plugins/policies/xds"
 	"github.com/kumahq/kuma/pkg/plugins/runtime/gateway/route"
 	util_proto "github.com/kumahq/kuma/pkg/util/proto"
+	envoy_common "github.com/kumahq/kuma/pkg/xds/envoy"
 )
 
 type RoutesConfigurer struct {
 	Matches                 []api.Match
 	Filters                 []api.Filter
-	Split                   []*plugins_xds.Split
+	Split                   []envoy_common.Split
 	BackendRefToClusterName map[string]string
 }
 
@@ -200,7 +200,7 @@ func routeQueryParamsMatch(envoyMatch *envoy_route.RouteMatch, matches []api.Que
 	}
 }
 
-func (c RoutesConfigurer) hasExternal(split []*plugins_xds.Split) bool {
+func (c RoutesConfigurer) hasExternal(split []envoy_common.Split) bool {
 	for _, s := range split {
 		if s.HasExternalService() {
 			return true
@@ -209,7 +209,7 @@ func (c RoutesConfigurer) hasExternal(split []*plugins_xds.Split) bool {
 	return false
 }
 
-func (c RoutesConfigurer) routeAction(split []*plugins_xds.Split) *envoy_route.RouteAction {
+func (c RoutesConfigurer) routeAction(split []envoy_common.Split) *envoy_route.RouteAction {
 	routeAction := &envoy_route.RouteAction{
 		// this timeout should be updated by the MeshTimeout plugin
 		Timeout: util_proto.Duration(0),

--- a/pkg/plugins/policies/xds/cluster.go
+++ b/pkg/plugins/policies/xds/cluster.go
@@ -11,7 +11,6 @@ import (
 type Cluster struct {
 	service           string
 	name              string
-	weight            uint32
 	tags              tags.Tags
 	mesh              string
 	isExternalService bool
@@ -19,7 +18,6 @@ type Cluster struct {
 
 func (c *Cluster) Service() string { return c.service }
 func (c *Cluster) Name() string    { return c.name }
-func (c *Cluster) Weight() uint32  { return c.weight }
 func (c *Cluster) Tags() tags.Tags { return c.tags }
 
 // Mesh returns a non-empty string only if the cluster is in a different mesh
@@ -43,7 +41,7 @@ type ClusterBuilder struct {
 }
 
 func NewClusterBuilder() *ClusterBuilder {
-	return (&ClusterBuilder{}).WithWeight(1)
+	return &ClusterBuilder{}
 }
 
 func (b *ClusterBuilder) Build() *Cluster {
@@ -73,13 +71,6 @@ func (b *ClusterBuilder) WithName(name string) *ClusterBuilder {
 		if len(cluster.service) == 0 {
 			cluster.service = name
 		}
-	}))
-	return b
-}
-
-func (b *ClusterBuilder) WithWeight(weight uint32) *ClusterBuilder {
-	b.opts = append(b.opts, newClusterOptFunc(func(cluster *Cluster) {
-		cluster.weight = weight
 	}))
 	return b
 }

--- a/pkg/plugins/policies/xds/meshroute/listeners.go
+++ b/pkg/plugins/policies/xds/meshroute/listeners.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
-	"github.com/kumahq/kuma/pkg/xds/envoy/names"
+	envoy_names "github.com/kumahq/kuma/pkg/xds/envoy/names"
 )
 
 // SplitCounter
@@ -29,7 +29,7 @@ func GetClusterName(
 	sc *SplitCounter,
 ) string {
 	if len(tags) > 0 {
-		name = names.GetSplitClusterName(name, sc.GetAndIncrement())
+		name = envoy_names.GetSplitClusterName(name, sc.GetAndIncrement())
 	}
 
 	// The mesh tag is present here if this destination is generated

--- a/pkg/plugins/policies/xds/meshroute/listeners.go
+++ b/pkg/plugins/policies/xds/meshroute/listeners.go
@@ -111,9 +111,5 @@ func MakeSplit(
 		clusterBuilders[refHash] = clusterBuilder
 	}
 
-	for refHash, clusterBuilder := range clusterBuilders {
-		servicesAcc.Add(clusterBuilder.WithWeight(weights[refHash]).Build())
-	}
-
 	return split
 }

--- a/pkg/plugins/policies/xds/meshroute/listeners.go
+++ b/pkg/plugins/policies/xds/meshroute/listeners.go
@@ -55,8 +55,8 @@ func MakeSplit(
 	sc *SplitCounter,
 	servicesAcc envoy_common.ServicesAccumulator,
 	refs []common_api.BackendRef,
-) []*plugins_xds.Split {
-	var split []*plugins_xds.Split
+) []envoy_common.Split {
+	var split []envoy_common.Split
 	clusterBuilders := map[string]*plugins_xds.ClusterBuilder{}
 	weights := map[string]uint32{}
 

--- a/pkg/plugins/policies/xds/split.go
+++ b/pkg/plugins/policies/xds/split.go
@@ -1,14 +1,18 @@
 package xds
 
+import "github.com/kumahq/kuma/pkg/xds/envoy/tags"
+
 type Split struct {
 	clusterName string
 	weight      uint32
+	lbMetadata  tags.Tags
 
 	hasExternalService bool
 }
 
 func (s *Split) ClusterName() string      { return s.clusterName }
 func (s *Split) Weight() uint32           { return s.weight }
+func (s *Split) LBMetadata() tags.Tags    { return s.lbMetadata }
 func (s *Split) HasExternalService() bool { return s.hasExternalService }
 
 type NewSplitOpt interface {

--- a/pkg/xds/envoy/listeners/filter_chain_configurers.go
+++ b/pkg/xds/envoy/listeners/filter_chain_configurers.go
@@ -89,6 +89,7 @@ func (s *splitAdapter) HasExternalService() bool { return s.hasExternalService }
 func TcpProxy(statsName string, clusters ...envoy_common.Cluster) FilterChainBuilderOpt {
 	var splits []envoy_common.Split
 	for _, cluster := range clusters {
+		cluster := cluster.(*envoy_common.ClusterImpl)
 		splits = append(splits, &splitAdapter{
 			clusterName:        cluster.Name(),
 			weight:             cluster.Weight(),
@@ -106,6 +107,7 @@ func TcpProxy(statsName string, clusters ...envoy_common.Cluster) FilterChainBui
 func TcpProxyWithMetadata(statsName string, clusters ...envoy_common.Cluster) FilterChainBuilderOpt {
 	var splits []envoy_common.Split
 	for _, cluster := range clusters {
+		cluster := cluster.(*envoy_common.ClusterImpl)
 		splits = append(splits, &splitAdapter{
 			clusterName:        cluster.Name(),
 			weight:             cluster.Weight(),

--- a/pkg/xds/envoy/listeners/v3/tcp_proxy_configurer.go
+++ b/pkg/xds/envoy/listeners/v3/tcp_proxy_configurer.go
@@ -12,13 +12,13 @@ import (
 
 type TcpProxyConfigurer struct {
 	StatsName string
-	// Clusters to forward traffic to.
-	Clusters    []envoy_common.Cluster
+	// Splits to forward traffic to.
+	Splits      []envoy_common.Split
 	UseMetadata bool
 }
 
 func (c *TcpProxyConfigurer) Configure(filterChain *envoy_listener.FilterChain) error {
-	if len(c.Clusters) == 0 {
+	if len(c.Splits) == 0 {
 		return nil
 	}
 	tcpProxy := c.tcpProxy()
@@ -42,24 +42,24 @@ func (c *TcpProxyConfigurer) tcpProxy() *envoy_tcp.TcpProxy {
 		StatPrefix: util_xds.SanitizeMetric(c.StatsName),
 	}
 
-	if len(c.Clusters) == 1 {
+	if len(c.Splits) == 1 {
 		proxy.ClusterSpecifier = &envoy_tcp.TcpProxy_Cluster{
-			Cluster: c.Clusters[0].Name(),
+			Cluster: c.Splits[0].ClusterName(),
 		}
 		if c.UseMetadata {
-			proxy.MetadataMatch = envoy_metadata.LbMetadata(c.Clusters[0].Tags())
+			proxy.MetadataMatch = envoy_metadata.LbMetadata(c.Splits[0].LBMetadata())
 		}
 		return &proxy
 	}
 
 	var weightedClusters []*envoy_tcp.TcpProxy_WeightedCluster_ClusterWeight
-	for _, cluster := range c.Clusters {
+	for _, split := range c.Splits {
 		weightedCluster := &envoy_tcp.TcpProxy_WeightedCluster_ClusterWeight{
-			Name:   cluster.Name(),
-			Weight: cluster.Weight(),
+			Name:   split.ClusterName(),
+			Weight: split.Weight(),
 		}
 		if c.UseMetadata {
-			weightedCluster.MetadataMatch = envoy_metadata.LbMetadata(cluster.Tags())
+			weightedCluster.MetadataMatch = envoy_metadata.LbMetadata(split.LBMetadata())
 		}
 		weightedClusters = append(weightedClusters, weightedCluster)
 	}

--- a/pkg/xds/envoy/types.go
+++ b/pkg/xds/envoy/types.go
@@ -24,6 +24,13 @@ type Cluster interface {
 	IsExternalService() bool
 }
 
+type Split interface {
+	ClusterName() string
+	Weight() uint32
+	LBMetadata() tags.Tags
+	HasExternalService() bool
+}
+
 // Deprecated: for new policies use pkg/plugins/policies/xds/cluster.go
 type ClusterImpl struct {
 	service           string

--- a/pkg/xds/envoy/types.go
+++ b/pkg/xds/envoy/types.go
@@ -17,7 +17,6 @@ import (
 type Cluster interface {
 	Service() string
 	Name() string
-	Weight() uint32
 	Mesh() string
 	Tags() tags.Tags
 	Hash() string


### PR DESCRIPTION
I'm moving out this function to more suitable place after small changes, so please review this on commit by commit bases, as I tried to be very particular to make it easier to review.

* Rename `makeHTTPSplit` to `makeSplit`
  This function has potential to be used in other policies, like `MeshTCPRoute` and it's making `[]*plugins_xds.Split`, which are not necessarily bound to the http. I believe the new name is more appropriate now.
* Assign ref weight to variable
  Ref weight is already being used in two places, but with the changes allowing to add clusters to service accumulator with weight summed from all refs pointing to the same cluster it will be used once more.
* Clusters in ServiceAccumulator with summed weights
  When adding clusters to service accumulator now we are assigning a weight which is a sum of all weights from refs pointing to the same destination.
  Having weight in cluster doesn't affect splits which are used by `MeshHTTPRoute`. Services in service accumulator will also contain the same amount of clusters. The only difference will be the clusters will now contain appropriate weights, which might be used in other route policies like `MeshTCPRoute`.
* Set consistent import alias for `envoy_names`
  Set consistent with other parts of code import alias for `github.com/kumahq/kuma/pkg/xds/envoy/names` - `envoy-names`
* Export and move to more appropriate place `MakeSplit` function
  This function can be used in other route policies like `MeshTCPRoute`, so moving it to more generic place is appropriate I believe.

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues
  - https://github.com/kumahq/kuma/pull/6873#discussion_r1211377734
  - https://github.com/kumahq/kuma/issues/6787
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS
  - it won't
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s)
  - this change should be transparent for the current policies, so no new tests were carried out
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)?
  - there is no need
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? 
  - there is no need
- [x] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?
  - there is no need

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
