### PR TITLE
chore(build): append values of test binaries and images

### DIFF
--- a/mk/build.mk
+++ b/mk/build.mk
@@ -25,7 +25,7 @@ COREDNS_VERSION = v1.10.1
 # List of binaries that we have build/release build rules for.
 BUILD_RELEASE_BINARIES := kuma-cp kuma-dp kumactl coredns kuma-cni install-cni envoy
 # List of binaries that we have build/test build roles for.
-BUILD_TEST_BINARIES := test-server
+BUILD_TEST_BINARIES += test-server
 
 # This is a list of all architecture supported, this means we'll define targets for all these architectures
 SUPPORTED_GOARCHES ?= amd64 arm64

--- a/mk/docker.mk
+++ b/mk/docker.mk
@@ -11,7 +11,7 @@ $(addsuffix :$(BUILD_INFO_VERSION)$(if $(2),-$(2)),$(addprefix $(DOCKER_REGISTRY
 endef
 
 IMAGES_RELEASE += kuma-cp kuma-dp kumactl kuma-init kuma-cni
-IMAGES_TEST = kuma-universal
+IMAGES_TEST += kuma-universal
 KUMA_IMAGES = $(call build_image,$(IMAGES_RELEASE) $(IMAGES_TEST))
 
 .PHONY: images/show


### PR DESCRIPTION
That allows other projects using Kuma to define test-specific binaries without overriding the default one.

- [X] [Link to relevant issue][1] as well as docs and UI issues --
- [X] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [X] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [X] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [X] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [X] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
