### PR TITLE
refactor(MeshTimeout): untangle cluster and listener configuration

### DIFF
--- a/pkg/plugins/policies/meshtimeout/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshtimeout/plugin/v1alpha1/plugin_test.go
@@ -390,6 +390,15 @@ var _ = Describe("MeshTimeout", func() {
 					},
 				},
 			},
+			Routing: core_xds.Routing{
+				OutboundTargets: core_xds.EndpointMap{
+					"backend": []core_xds.Endpoint{{
+						Tags: map[string]string{
+							"kuma.io/protocol": "http",
+						},
+					}},
+				},
+			},
 		}
 		gatewayGenerator := gateway_plugin.NewGenerator("test-zone")
 		generatedResources, err := gatewayGenerator.Generate(context, &proxy)
@@ -410,7 +419,7 @@ var _ = Describe("MeshTimeout", func() {
 		toRules: core_xds.ToRules{
 			Rules: []*core_xds.Rule{
 				{
-					Subset: core_xds.Subset{},
+					Subset: core_xds.MeshSubset(),
 					Conf: api.Conf{
 						ConnectionTimeout: test.ParseDuration("10s"),
 						IdleTimeout:       test.ParseDuration("1h"),
@@ -428,7 +437,7 @@ var _ = Describe("MeshTimeout", func() {
 		toRules: core_xds.ToRules{
 			Rules: []*core_xds.Rule{
 				{
-					Subset: core_xds.Subset{},
+					Subset: core_xds.MeshSubset(),
 					Conf: api.Conf{
 						ConnectionTimeout: test.ParseDuration("10s"),
 						IdleTimeout:       test.ParseDuration("1h"),


### PR DESCRIPTION
We need to apply configuration to clusters regardless of whether there is a corresponding outbound listener.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues -- Closes #5643
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [x] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
