### PR TITLE
fix(kuma-cp): wait for zone to create insights with admin streams

### DIFF
--- a/pkg/intercp/envoyadmin/forwarding_kds_client.go
+++ b/pkg/intercp/envoyadmin/forwarding_kds_client.go
@@ -157,7 +157,6 @@ func (f *forwardingKdsEnvoyAdminClient) globalInstanceID(ctx context.Context, zo
 	if err := f.resManager.Get(ctx, zoneInsightRes, core_store.GetByKey(zone, core_model.NoMesh)); err != nil {
 		return "", err
 	}
-	zoneInsightRes.Spec.GetEnvoyAdminStreams().GetConfigDumpGlobalInstanceId()
 	streams := zoneInsightRes.Spec.GetEnvoyAdminStreams()
 	var globalInstanceID string
 	switch rpcName {


### PR DESCRIPTION
### Checklist prior to review

ZoneInsight sets ownership to Zone therefore we cannot create ZoneInsight without Zone. When Zone CP starts it initiates KDS, xds config, stats and cluster streams at the same time. There is a high chance that the zone was not yet created by KDS stream and xds config, stats, cluster is terminated. 

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [X] [Link to relevant issue][1] as well as docs and UI issues --
- [X] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [X] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [X] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [X] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [X] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword

> Changelog: skip