### PR TITLE
perf(k8s): omit fetching other dataplanes when vips are in the config map

### DIFF
--- a/pkg/plugins/runtime/k8s/controllers/pod_controller.go
+++ b/pkg/plugins/runtime/k8s/controllers/pod_controller.go
@@ -127,9 +127,13 @@ func (r *PodReconciler) reconcileDataplane(ctx context.Context, pod *kube_core.P
 		return err
 	}
 
-	others, err := r.findOtherDataplanes(ctx, pod, &ns)
-	if err != nil {
-		return err
+	var others []*mesh_k8s.Dataplane
+	// we don't need other Dataplane objects when outbounds are stored in ConfigMap
+	if !r.PodConverter.KubeOutboundsAsVIPs {
+		others, err = r.findOtherDataplanes(ctx, pod, &ns)
+		if err != nil {
+			return err
+		}
 	}
 
 	if err := r.createOrUpdateDataplane(ctx, pod, &ns, services, others); err != nil {


### PR DESCRIPTION
### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [ ] [Link to relevant issue][1] as well as docs and UI issues --
- [ ] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [ ] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [ ] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [ ] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [ ] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
