### PR TITLE
ci(mk): disable pager in `make check`

### DIFF
--- a/mk/check.mk
+++ b/mk/check.mk
@@ -70,13 +70,13 @@ lint: helm-lint golangci-lint shellcheck kube-lint hadolint ginkgo/lint
 .PHONY: check
 check: format/common lint ## Dev: Run code checks (go fmt, go vet, ...)
 	@untracked() { git ls-files --other --directory --exclude-standard --no-empty-directory; }; \
-	diff() { git diff --name-only; }; \
+	diff() { git --no-pager diff --name-only; }; \
 	if [ $$(untracked | wc -l) -gt 0 ]; then \
 		FAILED=true; \
 		echo "The following files are untracked:"; \
 		untracked; \
 	fi; \
-	if [ $$(diff | wc -l) -gt 0 ]; then \
+	if [ $$(git --no-pager diff | wc -l) -gt 0 ]; then \
 		FAILED=true; \
 		echo "The following changes (result of code generators and code checks) have been detected:"; \
 		diff; \

--- a/mk/check.mk
+++ b/mk/check.mk
@@ -76,7 +76,7 @@ check: format/common lint ## Dev: Run code checks (go fmt, go vet, ...)
 		echo "The following files are untracked:"; \
 		untracked; \
 	fi; \
-	if [ $$(git --no-pager diff | wc -l) -gt 0 ]; then \
+	if [ $$(diff | wc -l) -gt 0 ]; then \
 		FAILED=true; \
 		echo "The following changes (result of code generators and code checks) have been detected:"; \
 		diff; \


### PR DESCRIPTION
use git diff for diff and disable pager so the ci is not stuck waiting for exit

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [ ] [Link to relevant issue][1] as well as docs and UI issues --
- [ ] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [ ] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [ ] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [ ] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [ ] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
