### PR TITLE
feat(kuma-cp): add possibility to configure kubernetes client qps and…

### DIFF
--- a/docs/generated/kuma-cp.md
+++ b/docs/generated/kuma-cp.md
@@ -354,6 +354,14 @@ runtime:
         # Path where compiled eBPF programs are placed
         programsSourcePath: /kuma/ebpf # ENV: KUMA_RUNTIME_KUBERNETES_INJECTOR_EBPF_PROGRAMS_SOURCE_PATH
     marshalingCacheExpirationTime: 5m # ENV: KUMA_RUNTIME_KUBERNETES_MARSHALING_CACHE_EXPIRATION_TIME
+    # Kubernetes client configuration
+    clientConfig:
+      # Qps defines maximum requests kubernetes client is allowed to make per second.
+      # Default value 100. If set to 0 kube-client default value of 5 will be used.
+      qps: 100
+      # BurstQps defines maximum burst requests kubernetes client is allowed to make per second
+      # Default value 100. If set to 0 kube-client default value of 10 will be used.
+      burstQps: 100
   # Universal-specific configuration
   universal:
     # DataplaneCleanupAge defines how long Dataplane should be offline to be cleaned up by GC

--- a/pkg/config/app/kuma-cp/kuma-cp.defaults.yaml
+++ b/pkg/config/app/kuma-cp/kuma-cp.defaults.yaml
@@ -351,6 +351,14 @@ runtime:
         # Path where compiled eBPF programs are placed
         programsSourcePath: /kuma/ebpf # ENV: KUMA_RUNTIME_KUBERNETES_INJECTOR_EBPF_PROGRAMS_SOURCE_PATH
     marshalingCacheExpirationTime: 5m # ENV: KUMA_RUNTIME_KUBERNETES_MARSHALING_CACHE_EXPIRATION_TIME
+    # Kubernetes client configuration
+    clientConfig:
+      # Qps defines maximum requests kubernetes client is allowed to make per second.
+      # Default value 100. If set to 0 kube-client default value of 5 will be used.
+      qps: 100
+      # BurstQps defines maximum burst requests kubernetes client is allowed to make per second
+      # Default value 100. If set to 0 kube-client default value of 10 will be used.
+      burstQps: 100
   # Universal-specific configuration
   universal:
     # DataplaneCleanupAge defines how long Dataplane should be offline to be cleaned up by GC

--- a/pkg/config/loader_test.go
+++ b/pkg/config/loader_test.go
@@ -212,7 +212,7 @@ var _ = Describe("Config loader", func() {
 			Expect(cfg.Runtime.Kubernetes.Injector.EBPF.TCAttachIface).To(Equal("veth1"))
 			Expect(cfg.Runtime.Kubernetes.Injector.EBPF.ProgramsSourcePath).To(Equal("/kuma/baz"))
 			Expect(cfg.Runtime.Kubernetes.NodeTaintController.CniNamespace).To(Equal("kuma-system"))
-			Expect(cfg.Runtime.Kubernetes.ClientConfig.Qps).To(Equal(float32(100)))
+			Expect(cfg.Runtime.Kubernetes.ClientConfig.Qps).To(Equal(100))
 			Expect(cfg.Runtime.Kubernetes.ClientConfig.BurstQps).To(Equal(100))
 			Expect(cfg.Runtime.Universal.DataplaneCleanupAge.Duration).To(Equal(1 * time.Hour))
 

--- a/pkg/config/loader_test.go
+++ b/pkg/config/loader_test.go
@@ -212,6 +212,8 @@ var _ = Describe("Config loader", func() {
 			Expect(cfg.Runtime.Kubernetes.Injector.EBPF.TCAttachIface).To(Equal("veth1"))
 			Expect(cfg.Runtime.Kubernetes.Injector.EBPF.ProgramsSourcePath).To(Equal("/kuma/baz"))
 			Expect(cfg.Runtime.Kubernetes.NodeTaintController.CniNamespace).To(Equal("kuma-system"))
+			Expect(cfg.Runtime.Kubernetes.ClientConfig.Qps).To(Equal(float32(100)))
+			Expect(cfg.Runtime.Kubernetes.ClientConfig.BurstQps).To(Equal(100))
 			Expect(cfg.Runtime.Universal.DataplaneCleanupAge.Duration).To(Equal(1 * time.Hour))
 
 			Expect(cfg.Reports.Enabled).To(BeFalse())
@@ -498,6 +500,9 @@ runtime:
         cgroupPath: /faz/daz/zaz
         tcAttachIface: veth1
         programsSourcePath: /kuma/baz
+    clientConfig:
+      qps: 100
+      burstQps: 100
 reports:
   enabled: false
 general:
@@ -765,6 +770,8 @@ proxy:
 				"KUMA_RUNTIME_KUBERNETES_VIRTUAL_PROBES_ENABLED":                                           "false",
 				"KUMA_RUNTIME_KUBERNETES_VIRTUAL_PROBES_PORT":                                              "1111",
 				"KUMA_RUNTIME_KUBERNETES_EXCEPTIONS_LABELS":                                                "openshift.io/build.name:value1,openshift.io/deployer-pod-for.name:value2",
+				"KUMA_RUNTIME_KUBERNETES_CLIENT_CONFIG_QPS":                                                "100",
+				"KUMA_RUNTIME_KUBERNETES_CLIENT_CONFIG_BURST_QPS":                                          "100",
 				"KUMA_RUNTIME_UNIVERSAL_DATAPLANE_CLEANUP_AGE":                                             "1h",
 				"KUMA_GENERAL_TLS_CERT_FILE":                                                               "/tmp/cert",
 				"KUMA_GENERAL_TLS_KEY_FILE":                                                                "/tmp/key",

--- a/pkg/config/plugins/runtime/k8s/config.go
+++ b/pkg/config/plugins/runtime/k8s/config.go
@@ -97,6 +97,10 @@ func DefaultKubernetesRuntimeConfig() *KubernetesRuntimeConfig {
 			CniApp:       "",
 			CniNamespace: "kube-system",
 		},
+		ClientConfig: ClientConfig{
+			Qps:      100,
+			BurstQps: 100,
+		},
 	}
 }
 
@@ -125,9 +129,11 @@ type KubernetesRuntimeConfig struct {
 }
 
 type ClientConfig struct {
-	// Qps defines maximum requests kubernetes client is allowed to make per second
+	// Qps defines maximum requests kubernetes client is allowed to make per second.
+	// Default value 100. If set to 0 kube-client default value of 5 will be used.
 	Qps float32 `json:"qps" envconfig:"kuma_runtime_kubernetes_client_config_qps"`
 	// BurstQps defines maximum burst requests kubernetes client is allowed to make per second
+	// Default value 100. If set to 0 kube-client default value of 10 will be used.
 	BurstQps int `json:"burstQps" envconfig:"kuma_runtime_kubernetes_client_config_burst_qps"`
 }
 

--- a/pkg/config/plugins/runtime/k8s/config.go
+++ b/pkg/config/plugins/runtime/k8s/config.go
@@ -120,6 +120,15 @@ type KubernetesRuntimeConfig struct {
 	ControlPlaneServiceName string `json:"controlPlaneServiceName,omitempty" envconfig:"kuma_runtime_kubernetes_control_plane_service_name"`
 	// NodeTaintController that prevents applications from scheduling until CNI is ready.
 	NodeTaintController NodeTaintController `json:"nodeTaintController"`
+	// Kubernetes client configuration
+	ClientConfig ClientConfig `json:"clientConfig"`
+}
+
+type ClientConfig struct {
+	// Qps defines maximum requests kubernetes client is allowed to make per second
+	Qps float32 `json:"qps" envconfig:"kuma_runtime_kubernetes_client_config_qps"`
+	// BurstQps defines maximum burst requests kubernetes client is allowed to make per second
+	BurstQps int `json:"burstQps" envconfig:"kuma_runtime_kubernetes_client_config_burst_qps"`
 }
 
 // Configuration of the Admission WebHook Server implemented by the Control Plane.

--- a/pkg/config/plugins/runtime/k8s/config.go
+++ b/pkg/config/plugins/runtime/k8s/config.go
@@ -131,7 +131,7 @@ type KubernetesRuntimeConfig struct {
 type ClientConfig struct {
 	// Qps defines maximum requests kubernetes client is allowed to make per second.
 	// Default value 100. If set to 0 kube-client default value of 5 will be used.
-	Qps float32 `json:"qps" envconfig:"kuma_runtime_kubernetes_client_config_qps"`
+	Qps int `json:"qps" envconfig:"kuma_runtime_kubernetes_client_config_qps"`
 	// BurstQps defines maximum burst requests kubernetes client is allowed to make per second
 	// Default value 100. If set to 0 kube-client default value of 10 will be used.
 	BurstQps int `json:"burstQps" envconfig:"kuma_runtime_kubernetes_client_config_burst_qps"`

--- a/pkg/config/plugins/runtime/k8s/testdata/default-config.golden.yaml
+++ b/pkg/config/plugins/runtime/k8s/testdata/default-config.golden.yaml
@@ -2,6 +2,9 @@ admissionServer:
   address: ""
   certDir: ""
   port: 5443
+clientConfig:
+  burstQps: 100
+  qps: 100
 controlPlaneServiceName: kuma-control-plane
 injector:
   builtinDNS:

--- a/pkg/plugins/bootstrap/k8s/plugin.go
+++ b/pkg/plugins/bootstrap/k8s/plugin.go
@@ -13,6 +13,7 @@ import (
 	"k8s.io/client-go/rest"
 	kube_ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	kube_client "sigs.k8s.io/controller-runtime/pkg/client"
 	kube_manager "sigs.k8s.io/controller-runtime/pkg/manager"
 
@@ -66,6 +67,11 @@ func (p *plugin) BeforeBootstrap(b *core_runtime.Builder, cfg core_plugins.Plugi
 
 			// Disable metrics bind address as we serve metrics some other way.
 			MetricsBindAddress: "0",
+			NewClient: func(config *rest.Config, options kube_client.Options) (kube_client.Client, error) {
+				config.QPS = b.Config().Runtime.Kubernetes.ClientConfig.Qps
+				config.Burst = b.Config().Runtime.Kubernetes.ClientConfig.BurstQps
+				return client.New(config, options)
+			},
 		},
 	)
 	if err != nil {


### PR DESCRIPTION
… burst qps

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [x] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
