### PR TITLE
fix(MeshTimeout): only apply Mesh targeted HTTP timeouts for MeshGateway

### DIFF
--- a/pkg/plugins/policies/meshtimeout/plugin/testdata/no-route-level-timeouts.gateway.cluster.golden.yaml
+++ b/pkg/plugins/policies/meshtimeout/plugin/testdata/no-route-level-timeouts.gateway.cluster.golden.yaml
@@ -1,0 +1,17 @@
+connectTimeout: 5s
+edsClusterConfig:
+  edsConfig:
+    ads: {}
+    resourceApiVersion: V3
+name: backend-26cb64fa4e85e7b7
+perConnectionBufferLimitBytes: 32768
+type: EDS
+typedExtensionProtocolOptions:
+  envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+    '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+    commonHttpProtocolOptions:
+      idleTimeout: 3600s
+      maxConnectionDuration: 0s
+      maxStreamDuration: 0s
+    explicitHttpConfig:
+      httpProtocolOptions: {}

--- a/pkg/plugins/policies/meshtimeout/plugin/testdata/no-route-level-timeouts.gateway.listener.golden.yaml
+++ b/pkg/plugins/policies/meshtimeout/plugin/testdata/no-route-level-timeouts.gateway.listener.golden.yaml
@@ -1,0 +1,55 @@
+address:
+  socketAddress:
+    address: 192.168.0.1
+    portValue: 8080
+enableReusePort: true
+filterChains:
+- filters:
+  - name: envoy.filters.network.http_connection_manager
+    typedConfig:
+      '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+      commonHttpProtocolOptions:
+        headersWithUnderscoresAction: REJECT_REQUEST
+        idleTimeout: 300s
+      http2ProtocolOptions:
+        allowConnect: true
+        initialConnectionWindowSize: 1048576
+        initialStreamWindowSize: 65536
+        maxConcurrentStreams: 100
+      httpFilters:
+      - name: envoy.filters.http.local_ratelimit
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.filters.http.local_ratelimit.v3.LocalRateLimit
+          statPrefix: rate_limit
+      - name: gzip-compress
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.filters.http.compressor.v3.Compressor
+          compressorLibrary:
+            name: gzip
+            typedConfig:
+              '@type': type.googleapis.com/envoy.extensions.compression.gzip.compressor.v3.Gzip
+          responseDirectionConfig:
+            disableOnEtagHeader: true
+      - name: envoy.filters.http.router
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+      mergeSlashes: true
+      normalizePath: true
+      pathWithEscapedSlashesAction: UNESCAPE_AND_REDIRECT
+      rds:
+        configSource:
+          ads: {}
+          resourceApiVersion: V3
+        routeConfigName: sample-gateway:HTTP:8080
+      requestHeadersTimeout: 0.500s
+      serverName: Kuma Gateway
+      statPrefix: sample-gateway
+      streamIdleTimeout: 5s
+      useRemoteAddress: true
+listenerFilters:
+- name: envoy.filters.listener.tls_inspector
+  typedConfig:
+    '@type': type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
+name: sample-gateway:HTTP:8080
+perConnectionBufferLimitBytes: 32768
+trafficDirection: INBOUND

--- a/pkg/plugins/policies/meshtimeout/plugin/testdata/no-route-level-timeouts.gateway.route.golden.yaml
+++ b/pkg/plugins/policies/meshtimeout/plugin/testdata/no-route-level-timeouts.gateway.route.golden.yaml
@@ -13,7 +13,6 @@ virtualHosts:
     route:
       clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
       idleTimeout: 5s
-      timeout: 24s
       weightedClusters:
         clusters:
         - name: backend-26cb64fa4e85e7b7

--- a/pkg/plugins/policies/meshtimeout/plugin/testdata/no-route-level-timeouts.gateway.route.golden.yaml
+++ b/pkg/plugins/policies/meshtimeout/plugin/testdata/no-route-level-timeouts.gateway.route.golden.yaml
@@ -1,0 +1,30 @@
+ignorePortInHostMatching: true
+name: sample-gateway:HTTP:8080
+requestHeadersToRemove:
+- x-kuma-tags
+validateClusters: false
+virtualHosts:
+- domains:
+  - '*'
+  name: '*'
+  routes:
+  - match:
+      path: /
+    route:
+      clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
+      idleTimeout: 5s
+      timeout: 24s
+      weightedClusters:
+        clusters:
+        - name: backend-26cb64fa4e85e7b7
+          requestHeadersToAdd:
+          - header:
+              key: x-kuma-tags
+              value: '&kuma.io/service=sample-gateway&'
+          weight: 1
+        - name: other-service-7ab0707c3913adf1
+          requestHeadersToAdd:
+          - header:
+              key: x-kuma-tags
+              value: '&kuma.io/service=sample-gateway&'
+          weight: 1

--- a/pkg/test/resources/builders/gateway_route_builder.go
+++ b/pkg/test/resources/builders/gateway_route_builder.go
@@ -51,7 +51,16 @@ func (gr *GatewayRouteBuilder) WithGateway(gatewayName string) *GatewayRouteBuil
 	return gr
 }
 
-func (gr *GatewayRouteBuilder) WithExactMatchHttpRoute(path string, backend string) *GatewayRouteBuilder {
+func (gr *GatewayRouteBuilder) WithExactMatchHttpRoute(path string, backendServices ...string) *GatewayRouteBuilder {
+	var backends []*mesh_proto.MeshGatewayRoute_Backend
+	for _, backendService := range backendServices {
+		backends = append(backends, &mesh_proto.MeshGatewayRoute_Backend{
+			Weight: 1,
+			Destination: map[string]string{
+				"kuma.io/service": backendService,
+			},
+		})
+	}
 	gr.res.Spec.Conf = &mesh_proto.MeshGatewayRoute_Conf{
 		Route: &mesh_proto.MeshGatewayRoute_Conf_Http{
 			Http: &mesh_proto.MeshGatewayRoute_HttpRoute{
@@ -63,14 +72,7 @@ func (gr *GatewayRouteBuilder) WithExactMatchHttpRoute(path string, backend stri
 								Value: path,
 							}},
 						},
-						Backends: []*mesh_proto.MeshGatewayRoute_Backend{
-							{
-								Weight: 1,
-								Destination: map[string]string{
-									"kuma.io/service": backend,
-								},
-							},
-						},
+						Backends: backends,
 					},
 				},
 			},


### PR DESCRIPTION
See the test expectation difference.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues -- Closes https://github.com/kumahq/kuma/issues/6761
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [x] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
