### PR TITLE
perf(k8s): don't reconcile all pods when a service changes

### DIFF
--- a/pkg/plugins/runtime/k8s/controllers/pod_controller.go
+++ b/pkg/plugins/runtime/k8s/controllers/pod_controller.go
@@ -371,10 +371,8 @@ func (r *PodReconciler) createOrUpdateEgress(ctx context.Context, pod *kube_core
 func (r *PodReconciler) SetupWithManager(mgr kube_ctrl.Manager) error {
 	return kube_ctrl.NewControllerManagedBy(mgr).
 		For(&kube_core.Pod{}).
-		// on Service update reconcile affected Pods (all Pods in the same namespace)
+		// on Service update reconcile affected Pods (all Pods selected by this service)
 		Watches(&kube_core.Service{}, kube_handler.EnqueueRequestsFromMapFunc(ServiceToPodsMapper(r.Log, mgr.GetClient()))).
-		// on ExternalService update reconcile affected Pods (all Pods in the same mesh)
-		Watches(&mesh_k8s.ExternalService{}, kube_handler.EnqueueRequestsFromMapFunc(ExternalServiceToPodsMapper(r.Log, mgr.GetClient()))).
 		Watches(&kube_core.ConfigMap{}, kube_handler.EnqueueRequestsFromMapFunc(ConfigMapToPodsMapper(r.Log, r.SystemNamespace, mgr.GetClient()))).
 		Complete(r)
 }
@@ -384,50 +382,14 @@ func ServiceToPodsMapper(l logr.Logger, client kube_client.Client) kube_handler.
 	return func(ctx context.Context, obj kube_client.Object) []kube_reconile.Request {
 		// List Pods in the same namespace as a Service
 		pods := &kube_core.PodList{}
-		if err := client.List(ctx, pods, kube_client.InNamespace(obj.GetNamespace())); err != nil {
+		if err := client.List(ctx, pods, kube_client.InNamespace(obj.GetNamespace()), kube_client.MatchingLabels(obj.(*kube_core.Service).Spec.Selector)); err != nil {
 			l.WithValues("service", obj.GetName()).Error(err, "failed to fetch Pods")
 			return nil
 		}
-
 		var req []kube_reconile.Request
 		for _, pod := range pods.Items {
 			req = append(req, kube_reconile.Request{
 				NamespacedName: kube_types.NamespacedName{Namespace: pod.Namespace, Name: pod.Name},
-			})
-		}
-		return req
-	}
-}
-
-func ExternalServiceToPodsMapper(l logr.Logger, client kube_client.Client) kube_handler.MapFunc {
-	l = l.WithName("external-service-to-pods-mapper")
-	return func(ctx context.Context, obj kube_client.Object) []kube_reconile.Request {
-		cause, ok := obj.(*mesh_k8s.ExternalService)
-		if !ok {
-			l.WithValues("externalService", obj.GetName()).Error(errors.Errorf("wrong argument type: expected %T, got %T", cause, obj), "wrong argument type")
-			return nil
-		}
-
-		// List Dataplanes in the same Mesh as the original
-		dataplanes := &mesh_k8s.DataplaneList{}
-		if err := client.List(ctx, dataplanes); err != nil {
-			l.WithValues("dataplane", obj.GetName()).Error(err, "failed to fetch Dataplanes")
-			return nil
-		}
-
-		var req []kube_reconile.Request
-		for i := range dataplanes.Items {
-			dataplane := dataplanes.Items[i]
-			// skip Dataplanes from other Meshes
-			if dataplane.Mesh != cause.Mesh {
-				continue
-			}
-			ownerRef := kube_meta.GetControllerOf(&dataplane)
-			if ownerRef == nil || ownerRef.Kind != "Pod" {
-				continue
-			}
-			req = append(req, kube_reconile.Request{
-				NamespacedName: kube_types.NamespacedName{Namespace: dataplane.Namespace, Name: ownerRef.Name},
 			})
 		}
 		return req

--- a/pkg/plugins/runtime/k8s/controllers/pod_controller_test.go
+++ b/pkg/plugins/runtime/k8s/controllers/pod_controller_test.go
@@ -22,7 +22,6 @@ import (
 	"github.com/kumahq/kuma/pkg/core/config/manager"
 	core_manager "github.com/kumahq/kuma/pkg/core/resources/manager"
 	"github.com/kumahq/kuma/pkg/dns/vips"
-	"github.com/kumahq/kuma/pkg/log"
 	"github.com/kumahq/kuma/pkg/plugins/resources/k8s"
 	mesh_k8s "github.com/kumahq/kuma/pkg/plugins/resources/k8s/native/api/v1alpha1"
 	"github.com/kumahq/kuma/pkg/plugins/resources/memory"
@@ -630,30 +629,5 @@ var _ = Describe("PodReconciler", func() {
 			}),
 		})
 		Expect(err).NotTo(HaveOccurred())
-
-		l := log.NewLogger(log.InfoLevel)
-		mapper := ExternalServiceToPodsMapper(l, kubeClient)
-		es := &mesh_k8s.ExternalService{
-			Mesh: "mesh-1",
-			ObjectMeta: kube_meta.ObjectMeta{
-				Namespace: "demo",
-				Name:      "es-1",
-			},
-			Spec: mesh_k8s.ToSpec(&mesh_proto.ExternalService{
-				Networking: &mesh_proto.ExternalService_Networking{
-					Address: "httpbin.org:443",
-				},
-				Tags: map[string]string{
-					mesh_proto.ServiceTag: "httpbin",
-				},
-			}),
-		}
-		requests := mapper(context.Background(), es)
-		requestsStr := []string{}
-		for _, r := range requests {
-			requestsStr = append(requestsStr, r.Name)
-		}
-		Expect(requestsStr).To(HaveLen(2))
-		Expect(requestsStr).To(ConsistOf("dp-1", "dp-2"))
 	})
 })


### PR DESCRIPTION
- only reconcile pods that are selected by this service
- don't reconcile pods when external services are updated

Fix #6985

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [x] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
