### PR TITLE
ci(makefile): build platform dependent tools

### DIFF
--- a/mk/generate.mk
+++ b/mk/generate.mk
@@ -1,6 +1,6 @@
 ENVOY_IMPORTS := ./pkg/xds/envoy/imports.go
-RESOURCE_GEN := $(KUMA_DIR)/build/tools/resource-gen
-POLICY_GEN := $(KUMA_DIR)/build/tools/policy-gen/generator
+RESOURCE_GEN := $(KUMA_DIR)/build/tools-${GOOS}-${GOARCH}/resource-gen
+POLICY_GEN := $(KUMA_DIR)/build/tools-${GOOS}-${GOARCH}/policy-gen/generator
 
 PROTO_DIRS ?= ./pkg/config ./api ./pkg/plugins ./test/server/grpc/api
 GO_MODULE ?= github.com/kumahq/kuma
@@ -18,7 +18,7 @@ generate/protos:
 
 .PHONY: clean/tools
 clean/tools:
-	rm -rf $(KUMA_DIR)/build/tools
+	rm -rf $(KUMA_DIR)/build/tools-*
 
 .PHONY: clean/proto
 clean/protos: ## Dev: Remove auto-generated Protobuf files
@@ -29,10 +29,10 @@ clean/protos: ## Dev: Remove auto-generated Protobuf files
 generate: generate/protos $(if $(findstring ./api,$(PROTO_DIRS)),resources/type generate/builtin-crds) generate/policies $(EXTRA_GENERATE_DEPS_TARGETS) ## Dev: Run all code generation
 
 $(POLICY_GEN):
-	cd $(KUMA_DIR) && go build -o ./build/tools/policy-gen/generator ./tools/policy-gen/generator/main.go
+	cd $(KUMA_DIR) && go build -o $(POLICY_GEN) ./tools/policy-gen/generator/main.go
 
 $(RESOURCE_GEN):
-	cd $(KUMA_DIR) && go build -o ./build/tools/resource-gen ./tools/resource-gen/main.go
+	cd $(KUMA_DIR) && go build -o $(RESOURCE_GEN) ./tools/resource-gen/main.go
 
 .PHONY: resources/type
 resources/type: $(RESOURCE_GEN)

--- a/mk/generate.mk
+++ b/mk/generate.mk
@@ -1,6 +1,6 @@
 ENVOY_IMPORTS := ./pkg/xds/envoy/imports.go
-RESOURCE_GEN := ./build/tools-${GOOS}-${GOARCH}/resource-gen
-POLICY_GEN := ./build/tools-${GOOS}-${GOARCH}/policy-gen/generator
+RESOURCE_GEN := $(KUMA_DIR)/build/tools-${GOOS}-${GOARCH}/resource-gen
+POLICY_GEN := $(KUMA_DIR)/build/tools-${GOOS}-${GOARCH}/policy-gen/generator
 
 PROTO_DIRS ?= ./pkg/config ./api ./pkg/plugins ./test/server/grpc/api
 GO_MODULE ?= github.com/kumahq/kuma
@@ -29,10 +29,10 @@ clean/protos: ## Dev: Remove auto-generated Protobuf files
 generate: generate/protos $(if $(findstring ./api,$(PROTO_DIRS)),resources/type generate/builtin-crds) generate/policies $(EXTRA_GENERATE_DEPS_TARGETS) ## Dev: Run all code generation
 
 $(POLICY_GEN):
-	cd $(KUMA_DIR) && go build -o $(POLICY_GEN) ./tools/policy-gen/generator/main.go
+	cd $(KUMA_DIR) && go build -o ./build/tools-${GOOS}-${GOARCH}/policy-gen/generator ./tools/policy-gen/generator/main.go
 
 $(RESOURCE_GEN):
-	cd $(KUMA_DIR) && go build -o $(RESOURCE_GEN) ./tools/resource-gen/main.go
+	cd $(KUMA_DIR) && go build -o ./build/tools-${GOOS}-${GOARCH}/resource-gen ./tools/resource-gen/main.go
 
 .PHONY: resources/type
 resources/type: $(RESOURCE_GEN)

--- a/mk/generate.mk
+++ b/mk/generate.mk
@@ -1,6 +1,6 @@
 ENVOY_IMPORTS := ./pkg/xds/envoy/imports.go
-RESOURCE_GEN := $(KUMA_DIR)/build/tools-${GOOS}-${GOARCH}/resource-gen
-POLICY_GEN := $(KUMA_DIR)/build/tools-${GOOS}-${GOARCH}/policy-gen/generator
+RESOURCE_GEN := ./build/tools-${GOOS}-${GOARCH}/resource-gen
+POLICY_GEN := ./build/tools-${GOOS}-${GOARCH}/policy-gen/generator
 
 PROTO_DIRS ?= ./pkg/config ./api ./pkg/plugins ./test/server/grpc/api
 GO_MODULE ?= github.com/kumahq/kuma
@@ -18,7 +18,7 @@ generate/protos:
 
 .PHONY: clean/tools
 clean/tools:
-	rm -rf $(KUMA_DIR)/build/tools-*
+	rm -rf ./build/tools-*
 
 .PHONY: clean/proto
 clean/protos: ## Dev: Remove auto-generated Protobuf files

--- a/mk/generate.mk
+++ b/mk/generate.mk
@@ -18,7 +18,7 @@ generate/protos:
 
 .PHONY: clean/tools
 clean/tools:
-	rm -rf ./build/tools-*
+	rm -rf $(KUMA_DIR)/build/tools-*
 
 .PHONY: clean/proto
 clean/protos: ## Dev: Remove auto-generated Protobuf files


### PR DESCRIPTION
I tend to sync code across my MacBook and linux VM. Because tools are synced, the binaries don't work on the other system. This PR adds GOOS and GOARCH to tools directory name just like we do for other build artifacts

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [X] [Link to relevant issue][1] as well as docs and UI issues --
- [X] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [X] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [X] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [X] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [X] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
