### PR TITLE
feat(kuma-cp): add possibility to configure concurrent reconciliation…

### DIFF
--- a/docs/generated/kuma-cp.md
+++ b/docs/generated/kuma-cp.md
@@ -354,9 +354,11 @@ runtime:
         # Path where compiled eBPF programs are placed
         programsSourcePath: /kuma/ebpf # ENV: KUMA_RUNTIME_KUBERNETES_INJECTOR_EBPF_PROGRAMS_SOURCE_PATH
     marshalingCacheExpirationTime: 5m # ENV: KUMA_RUNTIME_KUBERNETES_MARSHALING_CACHE_EXPIRATION_TIME
-    # MaxConcurrentReconciles defines maximum concurrent reconciliations of kubernetes resources
-    # Default value 10. If set to 0 kube-client default value of 1 will be used.
-    maxConcurrentReconciles: 10 # ENV: KUMA_RUNTIME_KUBERNETES_MAX_CONCURRENT_RECONCILES
+    # Kubernetes's resources reconciliation concurrency configuration
+    controllersConcurrency:
+      # PodController defines maximum concurrent reconciliations of Pod resources
+      # Default value 10. If set to 0 kube controller-runtime default value of 1 will be used.
+      podController: 10 # ENV: KUMA_RUNTIME_KUBERNETES_CONTROLLERS_CONCURRENCY_POD_CONTROLLER
     # Kubernetes client configuration
     clientConfig:
       # Qps defines maximum requests kubernetes client is allowed to make per second.

--- a/docs/generated/kuma-cp.md
+++ b/docs/generated/kuma-cp.md
@@ -354,6 +354,9 @@ runtime:
         # Path where compiled eBPF programs are placed
         programsSourcePath: /kuma/ebpf # ENV: KUMA_RUNTIME_KUBERNETES_INJECTOR_EBPF_PROGRAMS_SOURCE_PATH
     marshalingCacheExpirationTime: 5m # ENV: KUMA_RUNTIME_KUBERNETES_MARSHALING_CACHE_EXPIRATION_TIME
+    # MaxConcurrentReconciles defines maximum concurrent reconciliations of kubernetes resources
+    # Default value 10. If set to 0 kube-client default value of 1 will be used.
+    maxConcurrentReconciles: 10 # ENV: KUMA_RUNTIME_KUBERNETES_MAX_CONCURRENT_RECONCILES
     # Kubernetes client configuration
     clientConfig:
       # Qps defines maximum requests kubernetes client is allowed to make per second.

--- a/pkg/config/app/kuma-cp/kuma-cp.defaults.yaml
+++ b/pkg/config/app/kuma-cp/kuma-cp.defaults.yaml
@@ -351,9 +351,11 @@ runtime:
         # Path where compiled eBPF programs are placed
         programsSourcePath: /kuma/ebpf # ENV: KUMA_RUNTIME_KUBERNETES_INJECTOR_EBPF_PROGRAMS_SOURCE_PATH
     marshalingCacheExpirationTime: 5m # ENV: KUMA_RUNTIME_KUBERNETES_MARSHALING_CACHE_EXPIRATION_TIME
-    # MaxConcurrentReconciles defines maximum concurrent reconciliations of kubernetes resources
-    # Default value 10. If set to 0 kube-client default value of 1 will be used.
-    maxConcurrentReconciles: 10 # ENV: KUMA_RUNTIME_KUBERNETES_MAX_CONCURRENT_RECONCILES
+    # Kubernetes's resources reconciliation concurrency configuration
+    controllersConcurrency:
+      # PodController defines maximum concurrent reconciliations of Pod resources
+      # Default value 10. If set to 0 kube controller-runtime default value of 1 will be used.
+      podController: 10 # ENV: KUMA_RUNTIME_KUBERNETES_CONTROLLERS_CONCURRENCY_POD_CONTROLLER
     # Kubernetes client configuration
     clientConfig:
       # Qps defines maximum requests kubernetes client is allowed to make per second.

--- a/pkg/config/app/kuma-cp/kuma-cp.defaults.yaml
+++ b/pkg/config/app/kuma-cp/kuma-cp.defaults.yaml
@@ -351,6 +351,9 @@ runtime:
         # Path where compiled eBPF programs are placed
         programsSourcePath: /kuma/ebpf # ENV: KUMA_RUNTIME_KUBERNETES_INJECTOR_EBPF_PROGRAMS_SOURCE_PATH
     marshalingCacheExpirationTime: 5m # ENV: KUMA_RUNTIME_KUBERNETES_MARSHALING_CACHE_EXPIRATION_TIME
+    # MaxConcurrentReconciles defines maximum concurrent reconciliations of kubernetes resources
+    # Default value 10. If set to 0 kube-client default value of 1 will be used.
+    maxConcurrentReconciles: 10 # ENV: KUMA_RUNTIME_KUBERNETES_MAX_CONCURRENT_RECONCILES
     # Kubernetes client configuration
     clientConfig:
       # Qps defines maximum requests kubernetes client is allowed to make per second.

--- a/pkg/config/loader_test.go
+++ b/pkg/config/loader_test.go
@@ -212,6 +212,7 @@ var _ = Describe("Config loader", func() {
 			Expect(cfg.Runtime.Kubernetes.Injector.EBPF.TCAttachIface).To(Equal("veth1"))
 			Expect(cfg.Runtime.Kubernetes.Injector.EBPF.ProgramsSourcePath).To(Equal("/kuma/baz"))
 			Expect(cfg.Runtime.Kubernetes.NodeTaintController.CniNamespace).To(Equal("kuma-system"))
+			Expect(cfg.Runtime.Kubernetes.MaxConcurrentReconciles).To(Equal(10))
 			Expect(cfg.Runtime.Kubernetes.ClientConfig.Qps).To(Equal(100))
 			Expect(cfg.Runtime.Kubernetes.ClientConfig.BurstQps).To(Equal(100))
 			Expect(cfg.Runtime.Universal.DataplaneCleanupAge.Duration).To(Equal(1 * time.Hour))
@@ -501,6 +502,7 @@ runtime:
         cgroupPath: /faz/daz/zaz
         tcAttachIface: veth1
         programsSourcePath: /kuma/baz
+    maxConcurrentReconciles: 10
     clientConfig:
       qps: 100
       burstQps: 100
@@ -772,6 +774,7 @@ proxy:
 				"KUMA_RUNTIME_KUBERNETES_VIRTUAL_PROBES_ENABLED":                                           "false",
 				"KUMA_RUNTIME_KUBERNETES_VIRTUAL_PROBES_PORT":                                              "1111",
 				"KUMA_RUNTIME_KUBERNETES_EXCEPTIONS_LABELS":                                                "openshift.io/build.name:value1,openshift.io/deployer-pod-for.name:value2",
+				"KUMA_RUNTIME_KUBERNETES_MAX_CONCURRENT_RECONCILES":                                        "10",
 				"KUMA_RUNTIME_KUBERNETES_CLIENT_CONFIG_QPS":                                                "100",
 				"KUMA_RUNTIME_KUBERNETES_CLIENT_CONFIG_BURST_QPS":                                          "100",
 				"KUMA_RUNTIME_UNIVERSAL_DATAPLANE_CLEANUP_AGE":                                             "1h",

--- a/pkg/config/loader_test.go
+++ b/pkg/config/loader_test.go
@@ -212,7 +212,7 @@ var _ = Describe("Config loader", func() {
 			Expect(cfg.Runtime.Kubernetes.Injector.EBPF.TCAttachIface).To(Equal("veth1"))
 			Expect(cfg.Runtime.Kubernetes.Injector.EBPF.ProgramsSourcePath).To(Equal("/kuma/baz"))
 			Expect(cfg.Runtime.Kubernetes.NodeTaintController.CniNamespace).To(Equal("kuma-system"))
-			Expect(cfg.Runtime.Kubernetes.MaxConcurrentReconciles).To(Equal(10))
+			Expect(cfg.Runtime.Kubernetes.ControllersConcurrency.PodController).To(Equal(10))
 			Expect(cfg.Runtime.Kubernetes.ClientConfig.Qps).To(Equal(100))
 			Expect(cfg.Runtime.Kubernetes.ClientConfig.BurstQps).To(Equal(100))
 			Expect(cfg.Runtime.Universal.DataplaneCleanupAge.Duration).To(Equal(1 * time.Hour))
@@ -502,7 +502,8 @@ runtime:
         cgroupPath: /faz/daz/zaz
         tcAttachIface: veth1
         programsSourcePath: /kuma/baz
-    maxConcurrentReconciles: 10
+    controllersConcurrency: 
+      podController: 10
     clientConfig:
       qps: 100
       burstQps: 100
@@ -774,7 +775,7 @@ proxy:
 				"KUMA_RUNTIME_KUBERNETES_VIRTUAL_PROBES_ENABLED":                                           "false",
 				"KUMA_RUNTIME_KUBERNETES_VIRTUAL_PROBES_PORT":                                              "1111",
 				"KUMA_RUNTIME_KUBERNETES_EXCEPTIONS_LABELS":                                                "openshift.io/build.name:value1,openshift.io/deployer-pod-for.name:value2",
-				"KUMA_RUNTIME_KUBERNETES_MAX_CONCURRENT_RECONCILES":                                        "10",
+				"KUMA_RUNTIME_KUBERNETES_CONTROLLERS_CONCURRENCY_POD_CONTROLLER":                           "10",
 				"KUMA_RUNTIME_KUBERNETES_CLIENT_CONFIG_QPS":                                                "100",
 				"KUMA_RUNTIME_KUBERNETES_CLIENT_CONFIG_BURST_QPS":                                          "100",
 				"KUMA_RUNTIME_UNIVERSAL_DATAPLANE_CLEANUP_AGE":                                             "1h",

--- a/pkg/config/plugins/runtime/k8s/config.go
+++ b/pkg/config/plugins/runtime/k8s/config.go
@@ -97,6 +97,7 @@ func DefaultKubernetesRuntimeConfig() *KubernetesRuntimeConfig {
 			CniApp:       "",
 			CniNamespace: "kube-system",
 		},
+		MaxConcurrentReconciles: 10,
 		ClientConfig: ClientConfig{
 			Qps:      100,
 			BurstQps: 100,
@@ -124,6 +125,9 @@ type KubernetesRuntimeConfig struct {
 	ControlPlaneServiceName string `json:"controlPlaneServiceName,omitempty" envconfig:"kuma_runtime_kubernetes_control_plane_service_name"`
 	// NodeTaintController that prevents applications from scheduling until CNI is ready.
 	NodeTaintController NodeTaintController `json:"nodeTaintController"`
+	// MaxConcurrentReconciles defines maximum concurrent reconciliations of kubernetes resources
+	// Default value 10. If set to 0 kube-client default value of 1 will be used.
+	MaxConcurrentReconciles int `json:"maxConcurrentReconciles" envconfig:"kuma_runtime_kubernetes_max_concurrent_reconciles"`
 	// Kubernetes client configuration
 	ClientConfig ClientConfig `json:"clientConfig"`
 }

--- a/pkg/config/plugins/runtime/k8s/config.go
+++ b/pkg/config/plugins/runtime/k8s/config.go
@@ -97,7 +97,9 @@ func DefaultKubernetesRuntimeConfig() *KubernetesRuntimeConfig {
 			CniApp:       "",
 			CniNamespace: "kube-system",
 		},
-		MaxConcurrentReconciles: 10,
+		ControllersConcurrency: ControllersConcurrency{
+			PodController: 10,
+		},
 		ClientConfig: ClientConfig{
 			Qps:      100,
 			BurstQps: 100,
@@ -125,11 +127,16 @@ type KubernetesRuntimeConfig struct {
 	ControlPlaneServiceName string `json:"controlPlaneServiceName,omitempty" envconfig:"kuma_runtime_kubernetes_control_plane_service_name"`
 	// NodeTaintController that prevents applications from scheduling until CNI is ready.
 	NodeTaintController NodeTaintController `json:"nodeTaintController"`
-	// MaxConcurrentReconciles defines maximum concurrent reconciliations of kubernetes resources
-	// Default value 10. If set to 0 kube-client default value of 1 will be used.
-	MaxConcurrentReconciles int `json:"maxConcurrentReconciles" envconfig:"kuma_runtime_kubernetes_max_concurrent_reconciles"`
+	// Kubernetes's resources reconciliation concurrency configuration
+	ControllersConcurrency ControllersConcurrency `json:"controllersConcurrency"`
 	// Kubernetes client configuration
 	ClientConfig ClientConfig `json:"clientConfig"`
+}
+
+type ControllersConcurrency struct {
+	// PodController defines maximum concurrent reconciliations of Pod resources
+	// Default value 10. If set to 0 kube controller-runtime default value of 1 will be used.
+	PodController int `json:"podController" envconfig:"kuma_runtime_kubernetes_controllers_concurrency_pod_controller"`
 }
 
 type ClientConfig struct {

--- a/pkg/config/plugins/runtime/k8s/testdata/default-config.golden.yaml
+++ b/pkg/config/plugins/runtime/k8s/testdata/default-config.golden.yaml
@@ -59,6 +59,7 @@ injector:
   virtualProbesEnabled: true
   virtualProbesPort: 9000
 marshalingCacheExpirationTime: 5m0s
+maxConcurrentReconciles: 10
 nodeTaintController:
   cniApp: ""
   cniNamespace: kube-system

--- a/pkg/config/plugins/runtime/k8s/testdata/default-config.golden.yaml
+++ b/pkg/config/plugins/runtime/k8s/testdata/default-config.golden.yaml
@@ -6,6 +6,8 @@ clientConfig:
   burstQps: 100
   qps: 100
 controlPlaneServiceName: kuma-control-plane
+controllersConcurrency:
+  podController: 10
 injector:
   builtinDNS:
     enabled: true
@@ -59,7 +61,6 @@ injector:
   virtualProbesEnabled: true
   virtualProbesPort: 9000
 marshalingCacheExpirationTime: 5m0s
-maxConcurrentReconciles: 10
 nodeTaintController:
   cniApp: ""
   cniNamespace: kube-system

--- a/pkg/plugins/bootstrap/k8s/plugin.go
+++ b/pkg/plugins/bootstrap/k8s/plugin.go
@@ -14,7 +14,6 @@ import (
 	kube_ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	kube_client "sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/config"
 	kube_manager "sigs.k8s.io/controller-runtime/pkg/manager"
 
 	config_core "github.com/kumahq/kuma/pkg/config/core"
@@ -70,9 +69,6 @@ func (p *plugin) BeforeBootstrap(b *core_runtime.Builder, cfg core_plugins.Plugi
 
 			// Disable metrics bind address as we serve metrics some other way.
 			MetricsBindAddress: "0",
-			Controller: config.Controller{
-				MaxConcurrentReconciles: b.Config().Runtime.Kubernetes.MaxConcurrentReconciles,
-			},
 		},
 	)
 	if err != nil {

--- a/pkg/plugins/bootstrap/k8s/plugin.go
+++ b/pkg/plugins/bootstrap/k8s/plugin.go
@@ -14,6 +14,7 @@ import (
 	kube_ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	kube_client "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/config"
 	kube_manager "sigs.k8s.io/controller-runtime/pkg/manager"
 
 	config_core "github.com/kumahq/kuma/pkg/config/core"
@@ -69,6 +70,9 @@ func (p *plugin) BeforeBootstrap(b *core_runtime.Builder, cfg core_plugins.Plugi
 
 			// Disable metrics bind address as we serve metrics some other way.
 			MetricsBindAddress: "0",
+			Controller: config.Controller{
+				MaxConcurrentReconciles: b.Config().Runtime.Kubernetes.MaxConcurrentReconciles,
+			},
 		},
 	)
 	if err != nil {

--- a/pkg/plugins/runtime/k8s/controllers/pod_controller.go
+++ b/pkg/plugins/runtime/k8s/controllers/pod_controller.go
@@ -13,6 +13,7 @@ import (
 	kube_record "k8s.io/client-go/tools/record"
 	kube_ctrl "sigs.k8s.io/controller-runtime"
 	kube_client "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	kube_controllerutil "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	kube_handler "sigs.k8s.io/controller-runtime/pkg/handler"
 	kube_reconile "sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -368,8 +369,9 @@ func (r *PodReconciler) createOrUpdateEgress(ctx context.Context, pod *kube_core
 	return nil
 }
 
-func (r *PodReconciler) SetupWithManager(mgr kube_ctrl.Manager) error {
+func (r *PodReconciler) SetupWithManager(mgr kube_ctrl.Manager, maxConcurrentReconciles int) error {
 	return kube_ctrl.NewControllerManagedBy(mgr).
+		WithOptions(controller.Options{MaxConcurrentReconciles: maxConcurrentReconciles}).
 		For(&kube_core.Pod{}).
 		// on Service update reconcile affected Pods (all Pods selected by this service)
 		Watches(&kube_core.Service{}, kube_handler.EnqueueRequestsFromMapFunc(ServiceToPodsMapper(r.Log, mgr.GetClient()))).

--- a/pkg/plugins/runtime/k8s/plugin.go
+++ b/pkg/plugins/runtime/k8s/plugin.go
@@ -180,7 +180,7 @@ func addPodReconciler(mgr kube_ctrl.Manager, rt core_runtime.Runtime, converter 
 		Persistence:       vips.NewPersistence(rt.ResourceManager(), rt.ConfigManager()),
 		SystemNamespace:   rt.Config().Store.Kubernetes.SystemNamespace,
 	}
-	return reconciler.SetupWithManager(mgr)
+	return reconciler.SetupWithManager(mgr, rt.Config().Runtime.Kubernetes.ControllersConcurrency.PodController)
 }
 
 func addPodStatusReconciler(mgr kube_ctrl.Manager, rt core_runtime.Runtime, converter k8s_common.Converter) error {


### PR DESCRIPTION
… of kubernetes resources

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [x] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
