### PR TITLE
feat(kuma-cp): remove unnecessary reconciliation of pods on configmap…

### DIFF
--- a/pkg/plugins/runtime/k8s/controllers/pod_controller.go
+++ b/pkg/plugins/runtime/k8s/controllers/pod_controller.go
@@ -373,7 +373,6 @@ func (r *PodReconciler) SetupWithManager(mgr kube_ctrl.Manager) error {
 		For(&kube_core.Pod{}).
 		// on Service update reconcile affected Pods (all Pods selected by this service)
 		Watches(&kube_core.Service{}, kube_handler.EnqueueRequestsFromMapFunc(ServiceToPodsMapper(r.Log, mgr.GetClient()))).
-		Watches(&kube_core.ConfigMap{}, kube_handler.EnqueueRequestsFromMapFunc(ConfigMapToPodsMapper(r.Log, r.SystemNamespace, mgr.GetClient()))).
 		Complete(r)
 }
 
@@ -390,47 +389,6 @@ func ServiceToPodsMapper(l logr.Logger, client kube_client.Client) kube_handler.
 		for _, pod := range pods.Items {
 			req = append(req, kube_reconile.Request{
 				NamespacedName: kube_types.NamespacedName{Namespace: pod.Namespace, Name: pod.Name},
-			})
-		}
-		return req
-	}
-}
-
-func ConfigMapToPodsMapper(l logr.Logger, ns string, client kube_client.Client) kube_handler.MapFunc {
-	l = l.WithName("configmap-to-pods-mapper")
-	return func(ctx context.Context, obj kube_client.Object) []kube_reconile.Request {
-		if obj.GetNamespace() != ns {
-			return nil
-		}
-		mesh, ok := vips.MeshFromConfigKey(obj.GetName())
-		if !ok {
-			return nil
-		}
-
-		// List Dataplanes in the same Mesh as the original
-		dataplanes := &mesh_k8s.DataplaneList{}
-		if err := client.List(ctx, dataplanes); err != nil {
-			l.WithValues("dataplane", obj.GetName()).Error(err, "failed to fetch Dataplanes")
-			return nil
-		}
-
-		var req []kube_reconile.Request
-		for i := range dataplanes.Items {
-			dataplane := dataplanes.Items[i]
-			// skip Dataplanes from other Meshes
-			if dataplane.Mesh != mesh {
-				continue
-			}
-			// skip itself
-			if dataplane.Namespace == obj.GetNamespace() && dataplane.Name == obj.GetName() {
-				continue
-			}
-			ownerRef := kube_meta.GetControllerOf(&dataplane)
-			if ownerRef == nil || ownerRef.Kind != "Pod" {
-				continue
-			}
-			req = append(req, kube_reconile.Request{
-				NamespacedName: kube_types.NamespacedName{Namespace: dataplane.Namespace, Name: ownerRef.Name},
 			})
 		}
 		return req


### PR DESCRIPTION
… change. This was needed when we were building outbounds from ConfigMap, now it is obsolete

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [x] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
