### PR TITLE
feat(api-server): make errors compliant with aip 193

### DIFF
--- a/app/kumactl/pkg/errors/formatter.go
+++ b/app/kumactl/pkg/errors/formatter.go
@@ -25,9 +25,19 @@ func FormatErrorWrapper(fn func(*cobra.Command, []string) error) func(*cobra.Com
 }
 
 func formatApiServerError(apiErr *types.Error) error {
-	msg := fmt.Sprintf("%s (%s)", apiErr.Title, apiErr.Details)
-	for _, cause := range apiErr.Causes {
-		msg += fmt.Sprintf("\n* %s: %s", cause.Field, cause.Message)
+	// Get rid of back compat when we remove `Details` and `Causes`
+	if apiErr.Detail == "" {
+		apiErr.Detail = apiErr.Details
+	}
+	msg := fmt.Sprintf("%s (%s)", apiErr.Title, apiErr.Detail)
+	if apiErr.Causes != nil && apiErr.InvalidParameters == nil {
+		for _, cause := range apiErr.Causes {
+			msg += fmt.Sprintf("\n* %s: %s", cause.Field, cause.Message)
+		}
+	} else {
+		for _, cause := range apiErr.InvalidParameters {
+			msg += fmt.Sprintf("\n* %s: %s", cause.Field, cause.Reason)
+		}
 	}
 	return errors.New(msg)
 }

--- a/app/kumactl/pkg/resources/request.go
+++ b/app/kumactl/pkg/resources/request.go
@@ -23,7 +23,7 @@ func doRequest(client util_http.Client, ctx context.Context, req *http.Request) 
 	if resp.StatusCode/100 >= 4 {
 		kumaErr := error_types.Error{}
 		if err := json.Unmarshal(b, &kumaErr); err == nil {
-			if kumaErr.Title != "" && kumaErr.Details != "" {
+			if kumaErr.Title != "" {
 				return resp.StatusCode, b, &kumaErr
 			}
 		}

--- a/pkg/api-server/auth_test.go
+++ b/pkg/api-server/auth_test.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"path"
 	"path/filepath"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -14,6 +15,7 @@ import (
 	api_server "github.com/kumahq/kuma/pkg/api-server"
 	config "github.com/kumahq/kuma/pkg/config/api-server"
 	"github.com/kumahq/kuma/pkg/plugins/authn/api-server/certs"
+	"github.com/kumahq/kuma/pkg/test/matchers"
 	"github.com/kumahq/kuma/pkg/tls"
 	http2 "github.com/kumahq/kuma/pkg/util/http"
 )
@@ -97,10 +99,10 @@ var _ = Describe("Auth test", func() {
 		// then
 		Expect(err).ToNot(HaveOccurred())
 		Expect(resp.StatusCode).To(Equal(403))
-		body, err := io.ReadAll(resp.Body)
+		bytes, err := io.ReadAll(resp.Body)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(resp.Body.Close()).To(Succeed())
-		Expect(string(body)).To(MatchJSON(`{"title": "Access Denied", "details": "user \"mesh-system:anonymous/mesh-system:unauthenticated\" cannot access the resource of type \"Secret\""}`))
+		Expect(bytes).To(matchers.MatchGoldenJSON(path.Join("testdata", "auth-admin-non-localhost.golden.json")))
 	})
 
 	It("should be block an access to admin endpoints from other machine using HTTPS without proper client certs", func() {
@@ -110,10 +112,10 @@ var _ = Describe("Auth test", func() {
 		// then
 		Expect(err).ToNot(HaveOccurred())
 		Expect(resp.StatusCode).To(Equal(403))
-		body, err := io.ReadAll(resp.Body)
+		bytes, err := io.ReadAll(resp.Body)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(resp.Body.Close()).To(Succeed())
-		Expect(string(body)).To(MatchJSON(`{"title": "Access Denied", "details": "user \"mesh-system:anonymous/mesh-system:unauthenticated\" cannot access the resource of type \"Secret\""}`))
+		Expect(bytes).To(matchers.MatchGoldenJSON(path.Join("testdata", "auth-admin-https-bad-creds.golden.json")))
 	})
 })
 

--- a/pkg/api-server/read_only_resource_endpoints_test.go
+++ b/pkg/api-server/read_only_resource_endpoints_test.go
@@ -2,6 +2,7 @@ package api_server_test
 
 import (
 	"io"
+	"path"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -14,6 +15,7 @@ import (
 	rest_v1alpha1 "github.com/kumahq/kuma/pkg/core/resources/model/rest/v1alpha1"
 	"github.com/kumahq/kuma/pkg/core/resources/store"
 	"github.com/kumahq/kuma/pkg/plugins/resources/memory"
+	"github.com/kumahq/kuma/pkg/test/matchers"
 )
 
 var _ = Describe("Read only Resource Endpoints", func() {
@@ -82,13 +84,10 @@ var _ = Describe("Read only Resource Endpoints", func() {
 
 			// then
 			Expect(response.StatusCode).To(Equal(405))
-			body, err := io.ReadAll(response.Body)
+			bytes, err := io.ReadAll(response.Body)
 
 			Expect(err).NotTo(HaveOccurred())
-			Expect(string(body)).To(Equal(
-				"On Kubernetes you cannot change the state of Kuma resources with 'kumactl apply' or via the HTTP API." +
-					" As a best practice, you should always be using 'kubectl apply' instead." +
-					" You can still use 'kumactl' or the HTTP API to make read-only operations. On Universal this limitation does not apply.\n"))
+			Expect(bytes).To(matchers.MatchGoldenJSON(path.Join("testdata", "resource-read-only_put.golden.json")))
 		})
 	})
 
@@ -99,13 +98,10 @@ var _ = Describe("Read only Resource Endpoints", func() {
 
 			// then
 			Expect(response.StatusCode).To(Equal(405))
-			body, err := io.ReadAll(response.Body)
+			bytes, err := io.ReadAll(response.Body)
 
 			Expect(err).NotTo(HaveOccurred())
-			Expect(string(body)).To(Equal(
-				"On Kubernetes you cannot change the state of Kuma resources with 'kumactl apply' or via the HTTP API." +
-					" As a best practice, you should always be using 'kubectl apply' instead." +
-					" You can still use 'kumactl' or the HTTP API to make read-only operations. On Universal this limitation does not apply.\n"))
+			Expect(bytes).To(matchers.MatchGoldenJSON(path.Join("testdata", "resource-read-only_delete.golden.json")))
 		})
 	})
 })

--- a/pkg/api-server/resource_endpoints_test.go
+++ b/pkg/api-server/resource_endpoints_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"path"
 
 	"github.com/emicklei/go-restful/v3"
 	. "github.com/onsi/ginkgo/v2"
@@ -19,6 +20,7 @@ import (
 	"github.com/kumahq/kuma/pkg/core/resources/store"
 	core_metrics "github.com/kumahq/kuma/pkg/metrics"
 	"github.com/kumahq/kuma/pkg/plugins/resources/memory"
+	"github.com/kumahq/kuma/pkg/test/matchers"
 	test_metrics "github.com/kumahq/kuma/pkg/test/metrics"
 )
 
@@ -123,17 +125,7 @@ var _ = Describe("Resource Endpoints Zone", func() {
 			// and
 			bytes, err := io.ReadAll(response.Body)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(bytes).To(MatchJSON(`
-			{
-				"title": "Could not process a resource",
-				"details": "Resource is not valid",
-				"causes": [
-					{
-						"field": "name",
-						"message": "the length of the name must be shorter"
-					}
-				]
-			  }`))
+			Expect(bytes).To(matchers.MatchGoldenJSON(path.Join("testdata", "resource_name-too-long.golden.json")))
 		})
 	})
 })
@@ -208,12 +200,7 @@ var _ = Describe("Resource Endpoints", func() {
 			// and
 			bytes, err := io.ReadAll(response.Body)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(bytes).To(MatchJSON(`
-			{
-				"title": "Could not retrieve a resource",
-				"details": "Not found"
-			}
-			`))
+			Expect(bytes).To(matchers.MatchGoldenJSON(path.Join("testdata", "resource_not-found.golden.json")))
 		})
 
 		It("should list resources", func() {
@@ -404,18 +391,7 @@ var _ = Describe("Resource Endpoints", func() {
 			// and
 			bytes, err := io.ReadAll(response.Body)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(bytes).To(MatchJSON(`
-			{
-				"title": "Could not retrieve resources",
-				"details": "Invalid offset",
-				"causes": [
-					{
-						"field": "offset",
-						"message": "Invalid format"
-					}
-				]
-			}
-			`))
+			Expect(bytes).To(matchers.MatchGoldenJSON(path.Join("testdata", "resource_page-offset-invalid.golden.json")))
 		})
 
 		It("should return 400 with error on invalid size type", func() {
@@ -431,18 +407,7 @@ var _ = Describe("Resource Endpoints", func() {
 			// and
 			bytes, err := io.ReadAll(response.Body)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(bytes).To(MatchJSON(`
-			{
-				"title": "Could not retrieve resources",
-				"details": "Invalid page size",
-				"causes": [
-					{
-						"field": "size",
-						"message": "Invalid format"
-					}
-				]
-			}
-			`))
+			Expect(bytes).To(matchers.MatchGoldenJSON(path.Join("testdata", "resource_page-size-invalid.golden.json")))
 		})
 
 		It("should return 400 with error when page size exceeded the limit", func() {
@@ -458,18 +423,7 @@ var _ = Describe("Resource Endpoints", func() {
 			// and
 			bytes, err := io.ReadAll(response.Body)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(bytes).To(MatchJSON(`
-			{
-				"title": "Could not retrieve resources",
-				"details": "Invalid page size",
-				"causes": [
-					{
-						"field": "size",
-						"message": "Invalid page size of 2000. Maximum page size is 1000"
-					}
-				]
-			}
-			`))
+			Expect(bytes).To(matchers.MatchGoldenJSON(path.Join("testdata", "resource_page-size-too-large.golden.json")))
 		})
 	})
 
@@ -576,18 +530,7 @@ var _ = Describe("Resource Endpoints", func() {
 			// and
 			bytes, err := io.ReadAll(response.Body)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(bytes).To(MatchJSON(`
-			{
-				"title": "Could not process a resource",
-				"details": "Resource is not valid",
-				"causes": [
-					{
-						"field": "type",
-						"message": "type from the URL has to be the same as in body"
-					}
-				]
-			}
-			`))
+			Expect(bytes).To(matchers.MatchGoldenJSON(path.Join("testdata", "resource_incoherent-types.golden.json")))
 		})
 
 		It("should return 400 on the name that is different from request", func() {
@@ -628,18 +571,7 @@ var _ = Describe("Resource Endpoints", func() {
 			// and
 			bytes, err := io.ReadAll(response.Body)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(bytes).To(MatchJSON(`
-			{
-				"title": "Could not process a resource",
-				"details": "Resource is not valid",
-				"causes": [
-					{
-						"field": "name",
-						"message": "name from the URL has to be the same as in body"
-					}
-				]
-			}
-			`))
+			Expect(bytes).To(matchers.MatchGoldenJSON(path.Join("testdata", "resource_incoherent-names.golden.json")))
 		})
 
 		It("should return 400 on the mesh that is different from request", func() {
@@ -680,17 +612,7 @@ var _ = Describe("Resource Endpoints", func() {
 			// and
 			bytes, err := io.ReadAll(response.Body)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(bytes).To(MatchJSON(`
-			{
-				"title": "Could not process a resource",
-				"details": "Resource is not valid",
-				"causes": [
-					{
-						"field": "mesh",
-						"message": "mesh from the URL has to be the same as in body"
-					}
-				]
-			}`))
+			Expect(bytes).To(matchers.MatchGoldenJSON(path.Join("testdata", "resource_incoherent-mesh.golden.json")))
 		})
 
 		It("should return 400 on validation error", func() {
@@ -725,22 +647,11 @@ var _ = Describe("Resource Endpoints", func() {
 			Expect(response.StatusCode).To(Equal(400))
 
 			// when
-			respBytes, err := io.ReadAll(response.Body)
+			bytes, err := io.ReadAll(response.Body)
 
 			// then
 			Expect(err).ToNot(HaveOccurred())
-			Expect(respBytes).To(MatchJSON(`
-			{
-				"title": "Could not process a resource",
-				"details": "Resource is not valid",
-				"causes": [
-					{
-						"field": "conf",
-						"message": "requires either \"destination\" or \"split\""
-					}
-				]
-			}
-			`))
+			Expect(bytes).To(matchers.MatchGoldenJSON(path.Join("testdata", "resource_invalid-conf.golden.json")))
 		})
 
 		It("should return 400 on invalid name and mesh", func() {
@@ -783,26 +694,11 @@ var _ = Describe("Resource Endpoints", func() {
 			Expect(response.StatusCode).To(Equal(400))
 
 			// when
-			respBytes, err := io.ReadAll(response.Body)
+			bytes, err := io.ReadAll(response.Body)
 
 			// then
 			Expect(err).ToNot(HaveOccurred())
-			Expect(respBytes).To(MatchJSON(`
-			{
-				"title": "Could not process a resource",
-				"details": "Resource is not valid",
-				"causes": [
-					{
-						"field": "name",
-						"message": "invalid characters. Valid characters are numbers, lowercase latin letters and '-', '_' symbols."
-					},
-					{
-						"field": "mesh",
-						"message": "invalid characters. Valid characters are numbers, lowercase latin letters and '-', '_' symbols."
-					}
-				]
-			}
-			`))
+			Expect(bytes).To(matchers.MatchGoldenJSON(path.Join("testdata", "resource_name-mesh.golden.json")))
 		})
 
 		It("should return 400 when mesh does not exist", func() {
@@ -837,22 +733,11 @@ var _ = Describe("Resource Endpoints", func() {
 			response := client.put(res)
 
 			// when
-			respBytes, err := io.ReadAll(response.Body)
+			bytes, err := io.ReadAll(response.Body)
 
 			// then
 			Expect(err).ToNot(HaveOccurred())
-			Expect(respBytes).To(MatchJSON(`
-			{
-				"title": "Could not create a resource",
-				"details": "Mesh is not found",
-				"causes": [
-					{
-						"field": "mesh",
-						"message": "mesh of name default is not found"
-					}
-          		]
-			}
-			`))
+			Expect(bytes).To(matchers.MatchGoldenJSON(path.Join("testdata", "resource_mesh-not-found.golden.json")))
 		})
 	})
 
@@ -884,12 +769,7 @@ var _ = Describe("Resource Endpoints", func() {
 			// and
 			bytes, err := io.ReadAll(response.Body)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(bytes).To(MatchJSON(`
-			{
-				"title": "Could not delete a resource",
-				"details": "Not found"
-			}
-			`))
+			Expect(bytes).To(matchers.MatchGoldenJSON(path.Join("testdata", "resource-delete_not-found.golden.json")))
 		})
 	})
 

--- a/pkg/api-server/testdata/auth-admin-https-bad-creds.golden.json
+++ b/pkg/api-server/testdata/auth-admin-https-bad-creds.golden.json
@@ -1,0 +1,7 @@
+{
+ "type": "/std-errors",
+ "status": "403",
+ "title": "Access Denied",
+ "detail": "user \"mesh-system:anonymous/mesh-system:unauthenticated\" cannot access the resource of type \"Secret\"",
+ "details": "user \"mesh-system:anonymous/mesh-system:unauthenticated\" cannot access the resource of type \"Secret\""
+}

--- a/pkg/api-server/testdata/auth-admin-non-localhost.golden.json
+++ b/pkg/api-server/testdata/auth-admin-non-localhost.golden.json
@@ -1,0 +1,7 @@
+{
+ "type": "/std-errors",
+ "status": "403",
+ "title": "Access Denied",
+ "detail": "user \"mesh-system:anonymous/mesh-system:unauthenticated\" cannot access the resource of type \"Secret\"",
+ "details": "user \"mesh-system:anonymous/mesh-system:unauthenticated\" cannot access the resource of type \"Secret\""
+}

--- a/pkg/api-server/testdata/inspect_xds_remote_zoneingress.json
+++ b/pkg/api-server/testdata/inspect_xds_remote_zoneingress.json
@@ -1,4 +1,7 @@
 {
+ "type": "/std-errors",
+ "status": "400",
  "title": "Could not connect to zone ingress that resides in another zone",
+ "detail": "Resource is not valid",
  "details": "Resource is not valid"
 }

--- a/pkg/api-server/testdata/resource-delete_not-found.golden.json
+++ b/pkg/api-server/testdata/resource-delete_not-found.golden.json
@@ -1,0 +1,7 @@
+{
+ "type": "/std-errors",
+ "status": "404",
+ "title": "Could not delete a resource",
+ "detail": "Not found",
+ "details": "Not found"
+}

--- a/pkg/api-server/testdata/resource-read-only_delete.golden.json
+++ b/pkg/api-server/testdata/resource-read-only_delete.golden.json
@@ -1,0 +1,7 @@
+{
+ "type": "/std-errors",
+ "status": "405",
+ "title": "Method not Allowed",
+ "detail": "Method not allowed",
+ "details": "Method not allowed"
+}

--- a/pkg/api-server/testdata/resource-read-only_put.golden.json
+++ b/pkg/api-server/testdata/resource-read-only_put.golden.json
@@ -1,0 +1,7 @@
+{
+ "type": "/std-errors",
+ "status": "405",
+ "title": "Method not Allowed",
+ "detail": "Method not allowed",
+ "details": "Method not allowed"
+}

--- a/pkg/api-server/testdata/resource_incoherent-mesh.golden.json
+++ b/pkg/api-server/testdata/resource_incoherent-mesh.golden.json
@@ -1,0 +1,19 @@
+{
+ "type": "/std-errors",
+ "status": "400",
+ "title": "Could not process a resource",
+ "detail": "Resource is not valid",
+ "invalid_parameters": [
+  {
+   "field": "mesh",
+   "reason": "mesh from the URL has to be the same as in body"
+  }
+ ],
+ "details": "Resource is not valid",
+ "causes": [
+  {
+   "field": "mesh",
+   "message": "mesh from the URL has to be the same as in body"
+  }
+ ]
+}

--- a/pkg/api-server/testdata/resource_incoherent-names.golden.json
+++ b/pkg/api-server/testdata/resource_incoherent-names.golden.json
@@ -1,0 +1,19 @@
+{
+ "type": "/std-errors",
+ "status": "400",
+ "title": "Could not process a resource",
+ "detail": "Resource is not valid",
+ "invalid_parameters": [
+  {
+   "field": "name",
+   "reason": "name from the URL has to be the same as in body"
+  }
+ ],
+ "details": "Resource is not valid",
+ "causes": [
+  {
+   "field": "name",
+   "message": "name from the URL has to be the same as in body"
+  }
+ ]
+}

--- a/pkg/api-server/testdata/resource_incoherent-types.golden.json
+++ b/pkg/api-server/testdata/resource_incoherent-types.golden.json
@@ -1,0 +1,19 @@
+{
+ "type": "/std-errors",
+ "status": "400",
+ "title": "Could not process a resource",
+ "detail": "Resource is not valid",
+ "invalid_parameters": [
+  {
+   "field": "type",
+   "reason": "type from the URL has to be the same as in body"
+  }
+ ],
+ "details": "Resource is not valid",
+ "causes": [
+  {
+   "field": "type",
+   "message": "type from the URL has to be the same as in body"
+  }
+ ]
+}

--- a/pkg/api-server/testdata/resource_invalid-conf.golden.json
+++ b/pkg/api-server/testdata/resource_invalid-conf.golden.json
@@ -1,0 +1,19 @@
+{
+ "type": "/std-errors",
+ "status": "400",
+ "title": "Could not process a resource",
+ "detail": "Resource is not valid",
+ "invalid_parameters": [
+  {
+   "field": "conf",
+   "reason": "requires either \"destination\" or \"split\""
+  }
+ ],
+ "details": "Resource is not valid",
+ "causes": [
+  {
+   "field": "conf",
+   "message": "requires either \"destination\" or \"split\""
+  }
+ ]
+}

--- a/pkg/api-server/testdata/resource_mesh-not-found.golden.json
+++ b/pkg/api-server/testdata/resource_mesh-not-found.golden.json
@@ -1,0 +1,19 @@
+{
+ "type": "/std-errors",
+ "status": "400",
+ "title": "Could not create a resource",
+ "detail": "Mesh is not found",
+ "invalid_parameters": [
+  {
+   "field": "mesh",
+   "reason": "mesh of name default is not found"
+  }
+ ],
+ "details": "Mesh is not found",
+ "causes": [
+  {
+   "field": "mesh",
+   "message": "mesh of name default is not found"
+  }
+ ]
+}

--- a/pkg/api-server/testdata/resource_name-mesh.golden.json
+++ b/pkg/api-server/testdata/resource_name-mesh.golden.json
@@ -1,0 +1,27 @@
+{
+ "type": "/std-errors",
+ "status": "400",
+ "title": "Could not process a resource",
+ "detail": "Resource is not valid",
+ "invalid_parameters": [
+  {
+   "field": "name",
+   "reason": "invalid characters. Valid characters are numbers, lowercase latin letters and '-', '_' symbols."
+  },
+  {
+   "field": "mesh",
+   "reason": "invalid characters. Valid characters are numbers, lowercase latin letters and '-', '_' symbols."
+  }
+ ],
+ "details": "Resource is not valid",
+ "causes": [
+  {
+   "field": "name",
+   "message": "invalid characters. Valid characters are numbers, lowercase latin letters and '-', '_' symbols."
+  },
+  {
+   "field": "mesh",
+   "message": "invalid characters. Valid characters are numbers, lowercase latin letters and '-', '_' symbols."
+  }
+ ]
+}

--- a/pkg/api-server/testdata/resource_name-too-long.golden.json
+++ b/pkg/api-server/testdata/resource_name-too-long.golden.json
@@ -1,0 +1,19 @@
+{
+ "type": "/std-errors",
+ "status": "400",
+ "title": "Could not process a resource",
+ "detail": "Resource is not valid",
+ "invalid_parameters": [
+  {
+   "field": "name",
+   "reason": "the length of the name must be shorter"
+  }
+ ],
+ "details": "Resource is not valid",
+ "causes": [
+  {
+   "field": "name",
+   "message": "the length of the name must be shorter"
+  }
+ ]
+}

--- a/pkg/api-server/testdata/resource_not-found.golden.json
+++ b/pkg/api-server/testdata/resource_not-found.golden.json
@@ -1,0 +1,7 @@
+{
+ "type": "/std-errors",
+ "status": "404",
+ "title": "Could not retrieve a resource",
+ "detail": "Not found",
+ "details": "Not found"
+}

--- a/pkg/api-server/testdata/resource_page-offset-invalid.golden.json
+++ b/pkg/api-server/testdata/resource_page-offset-invalid.golden.json
@@ -1,0 +1,19 @@
+{
+ "type": "/std-errors",
+ "status": "400",
+ "title": "Could not retrieve resources",
+ "detail": "Invalid offset",
+ "invalid_parameters": [
+  {
+   "field": "offset",
+   "reason": "Invalid format"
+  }
+ ],
+ "details": "Invalid offset",
+ "causes": [
+  {
+   "field": "offset",
+   "message": "Invalid format"
+  }
+ ]
+}

--- a/pkg/api-server/testdata/resource_page-size-invalid.golden.json
+++ b/pkg/api-server/testdata/resource_page-size-invalid.golden.json
@@ -1,0 +1,19 @@
+{
+ "type": "/std-errors",
+ "status": "400",
+ "title": "Could not retrieve resources",
+ "detail": "Invalid page size",
+ "invalid_parameters": [
+  {
+   "field": "size",
+   "reason": "Invalid format"
+  }
+ ],
+ "details": "Invalid page size",
+ "causes": [
+  {
+   "field": "size",
+   "message": "Invalid format"
+  }
+ ]
+}

--- a/pkg/api-server/testdata/resource_page-size-too-large.golden.json
+++ b/pkg/api-server/testdata/resource_page-size-too-large.golden.json
@@ -1,0 +1,19 @@
+{
+ "type": "/std-errors",
+ "status": "400",
+ "title": "Could not retrieve resources",
+ "detail": "Invalid page size",
+ "invalid_parameters": [
+  {
+   "field": "size",
+   "reason": "Invalid page size of 2000. Maximum page size is 1000"
+  }
+ ],
+ "details": "Invalid page size",
+ "causes": [
+  {
+   "field": "size",
+   "message": "Invalid page size of 2000. Maximum page size is 1000"
+  }
+ ]
+}

--- a/pkg/core/rest/errors/error_handler.go
+++ b/pkg/core/rest/errors/error_handler.go
@@ -2,6 +2,7 @@ package errors
 
 import (
 	"fmt"
+	"strconv"
 
 	"github.com/emicklei/go-restful/v3"
 	"github.com/pkg/errors"
@@ -26,9 +27,10 @@ func HandleError(response *restful.Response, err error, title string) {
 	case errors.Is(err, &store.PreconditionError{}):
 		var err2 *store.PreconditionError
 		errors.As(err, &err2)
-		WriteError(response, 400, types.Error{
-			Title:   "Bad Request",
-			Details: err2.Reason,
+		writeError(response, types.Error{
+			Status: "400",
+			Title:  "Bad Request",
+			Detail: err2.Reason,
 		})
 	case err == store.ErrorInvalidOffset:
 		handleInvalidOffset(title, response)
@@ -42,6 +44,13 @@ func HandleError(response *restful.Response, err error, title string) {
 		handleInvalidPageSize(title, response)
 	case tokens.IsSigningKeyNotFound(err):
 		handleSigningKeyNotFound(err, response)
+	case errors.Is(err, &MethodNotAllowed{}):
+		writeError(response, types.Error{
+			Status: "405",
+			Title:  "Method not Allowed",
+			Detail: err.Error(),
+		})
+
 	case errors.Is(err, &access.AccessDeniedError{}):
 		var accessErr *access.AccessDeniedError
 		errors.As(err, &accessErr)
@@ -61,141 +70,164 @@ func HandleError(response *restful.Response, err error, title string) {
 
 func handleIssuerDisabled(err error, title string, response *restful.Response) {
 	kumaErr := types.Error{
-		Title:   title,
-		Details: err.Error(),
+		Status: "400",
+		Title:  title,
+		Detail: err.Error(),
 	}
-	WriteError(response, 400, kumaErr)
+	writeError(response, kumaErr)
 }
 
 func handleInvalidPageSize(title string, response *restful.Response) {
 	kumaErr := types.Error{
-		Title:   title,
-		Details: "Invalid page size",
-		Causes: []types.Cause{
+		Status: "400",
+		Title:  title,
+		Detail: "Invalid page size",
+		InvalidParameters: []types.InvalidParameter{
 			{
-				Field:   "size",
-				Message: "Invalid format",
+				Field:  "size",
+				Reason: "Invalid format",
 			},
 		},
 	}
-	WriteError(response, 400, kumaErr)
+	writeError(response, kumaErr)
 }
 
 func handleNotFound(title string, response *restful.Response) {
 	kumaErr := types.Error{
-		Title:   title,
-		Details: "Not found",
+		Status: "404",
+		Title:  title,
+		Detail: "Not found",
 	}
-	WriteError(response, 404, kumaErr)
+	writeError(response, kumaErr)
 }
 
 func handlePreconditionFailed(title string, response *restful.Response) {
 	kumaErr := types.Error{
-		Title:   title,
-		Details: "Precondition Failed",
+		Status: "412",
+		Title:  title,
+		Detail: "Precondition Failed",
 	}
-	WriteError(response, 412, kumaErr)
+	writeError(response, kumaErr)
 }
 
 func handleMeshNotFound(title string, err *manager.MeshNotFoundError, response *restful.Response) {
 	kumaErr := types.Error{
-		Title:   title,
-		Details: "Mesh is not found",
-		Causes: []types.Cause{
+		Status: "400",
+		Title:  title,
+		Detail: "Mesh is not found",
+		InvalidParameters: []types.InvalidParameter{
 			{
-				Field:   "mesh",
-				Message: fmt.Sprintf("mesh of name %s is not found", err.Mesh),
+				Field:  "mesh",
+				Reason: fmt.Sprintf("mesh of name %s is not found", err.Mesh),
 			},
 		},
 	}
-	WriteError(response, 400, kumaErr)
+	writeError(response, kumaErr)
 }
 
 func handleValidationError(title string, err *validators.ValidationError, response *restful.Response) {
 	kumaErr := types.Error{
-		Title:   title,
-		Details: "Resource is not valid",
+		Status: "400",
+		Title:  title,
+		Detail: "Resource is not valid",
 	}
 	for _, violation := range err.Violations {
-		kumaErr.Causes = append(kumaErr.Causes, types.Cause{
-			Field:   violation.Field,
-			Message: violation.Message,
+		kumaErr.InvalidParameters = append(kumaErr.InvalidParameters, types.InvalidParameter{
+			Field:  violation.Field,
+			Reason: violation.Message,
 		})
 	}
-	WriteError(response, 400, kumaErr)
+	writeError(response, kumaErr)
 }
 
 func handleInvalidOffset(title string, response *restful.Response) {
 	kumaErr := types.Error{
-		Title:   title,
-		Details: "Invalid offset",
-		Causes: []types.Cause{
+		Status: "400",
+		Title:  title,
+		Detail: "Invalid offset",
+		InvalidParameters: []types.InvalidParameter{
 			{
-				Field:   "offset",
-				Message: "Invalid format",
+				Field:  "offset",
+				Reason: "Invalid format",
 			},
 		},
 	}
-	WriteError(response, 400, kumaErr)
+	writeError(response, kumaErr)
 }
 
 func handleMaxPageSizeExceeded(title string, err error, response *restful.Response) {
 	kumaErr := types.Error{
-		Title:   title,
-		Details: "Invalid page size",
-		Causes: []types.Cause{
+		Status: "400",
+		Title:  title,
+		Detail: "Invalid page size",
+		InvalidParameters: []types.InvalidParameter{
 			{
-				Field:   "size",
-				Message: err.Error(),
+				Field:  "size",
+				Reason: err.Error(),
 			},
 		},
 	}
-	WriteError(response, 400, kumaErr)
+	writeError(response, kumaErr)
 }
 
 func handleUnknownError(err error, title string, response *restful.Response) {
 	core.Log.Error(err, title)
 	kumaErr := types.Error{
-		Title:   title,
-		Details: "Internal Server Error",
+		Status: "500",
+		Title:  title,
+		Detail: "Internal Server Error",
 	}
-	WriteError(response, 500, kumaErr)
+	writeError(response, kumaErr)
 }
 
 func handleSigningKeyNotFound(err error, response *restful.Response) {
 	kumaErr := types.Error{
-		Title:   "Signing Key not found",
-		Details: err.Error(),
+		Status: "404",
+		Title:  "Signing Key not found",
+		Detail: err.Error(),
 	}
-	WriteError(response, 404, kumaErr)
+	writeError(response, kumaErr)
 }
 
 func handleAccessDenied(err *access.AccessDeniedError, response *restful.Response) {
 	kumaErr := types.Error{
-		Title:   "Access Denied",
-		Details: err.Reason,
+		Status: "403",
+		Title:  "Access Denied",
+		Detail: err.Reason,
 	}
-	WriteError(response, 403, kumaErr)
+	writeError(response, kumaErr)
 }
 
 func handleUnauthenticated(err *Unauthenticated, title string, response *restful.Response) {
 	kumaErr := types.Error{
-		Title:   title,
-		Details: err.Error(),
+		Status: "401",
+		Title:  title,
+		Detail: err.Error(),
 	}
-	WriteError(response, 401, kumaErr)
+	writeError(response, kumaErr)
 }
 
 func handleTenantMissing(err error, title string, response *restful.Response) {
 	kumaErr := types.Error{
-		Title:   title,
-		Details: err.Error(),
+		Status: "400",
+		Title:  title,
+		Detail: err.Error(),
 	}
-	WriteError(response, 400, kumaErr)
+	writeError(response, kumaErr)
 }
 
-func WriteError(response *restful.Response, httpStatus int, kumaErr types.Error) {
-	if err := response.WriteHeaderAndJson(httpStatus, kumaErr, "application/json"); err != nil {
+func writeError(response *restful.Response, kumaErr types.Error) {
+	// Fix to handle legacy errors
+	kumaErr.Type = "/std-errors"
+	kumaErr.Details = kumaErr.Detail
+	for _, ip := range kumaErr.InvalidParameters {
+		kumaErr.Causes = append(kumaErr.Causes, types.Cause{Field: ip.Field, Message: ip.Reason})
+	}
+	httpStatusCode, err := strconv.Atoi(kumaErr.Status)
+	if err != nil {
+		httpStatusCode = 500
+	}
+	if err := response.WriteHeaderAndJson(httpStatusCode, kumaErr, "application/json"); err != nil {
 		core.Log.Error(err, "Could not write the error response")
 	}
 }

--- a/pkg/core/rest/errors/errors.go
+++ b/pkg/core/rest/errors/errors.go
@@ -5,3 +5,9 @@ type Unauthenticated struct{}
 func (u *Unauthenticated) Error() string {
 	return "Unauthenticated"
 }
+
+type MethodNotAllowed struct{}
+
+func (m *MethodNotAllowed) Error() string {
+	return "Method not allowed"
+}

--- a/pkg/core/rest/errors/types/error.go
+++ b/pkg/core/rest/errors/types/error.go
@@ -2,16 +2,40 @@ package types
 
 import "fmt"
 
+// Error following https://kong-aip.netlify.app/aip/193/
 type Error struct {
-	Title   string  `json:"title"`
-	Details string  `json:"details"`
-	Causes  []Cause `json:"causes,omitempty"`
+	// Type a unique identifier for this error.
+	Type string `json:"type"`
+	// Status The HTTP status code of the error.
+	Status string `json:"status"`
+	// Title A short, human-readable summary of the problem.
+	// It should not change between occurrences of a problem, except for localization.
+	// Should be provided as "Sentence case" for direct use in the UI
+	Title string `json:"title"`
+	// Detail A human readable explanation specific to this occurrence of the problem.
+	Detail string `json:"detail"`
+	// Instance Used to return the correlation ID back to the user if present
+	Instance string `json:"instance,omitempty"`
+	// InvalidParameters
+	InvalidParameters []InvalidParameter `json:"invalid_parameters,omitempty"`
+
+	// Deprecated
+	Details string `json:"details"`
+	// Deprecated
+	Causes []Cause `json:"causes,omitempty"`
+}
+
+type InvalidParameter struct {
+	Field   string   `json:"field"`
+	Reason  string   `json:"reason"`
+	Rule    string   `json:"rule,omitempty"`
+	Choices []string `json:"choices,omitempty"`
 }
 
 func (e *Error) Error() string {
-	msg := fmt.Sprintf("%s (%s)", e.Title, e.Details)
-	for _, cause := range e.Causes {
-		msg += fmt.Sprintf(";%s=%s ", cause.Field, cause.Message)
+	msg := fmt.Sprintf("%s (%s)", e.Title, e.Detail)
+	for _, cause := range e.InvalidParameters {
+		msg += fmt.Sprintf(";%s=%s ", cause.Field, cause.Reason)
 	}
 	return msg
 }

--- a/pkg/mads/v1/service/http.go
+++ b/pkg/mads/v1/service/http.go
@@ -34,6 +34,7 @@ func (s *service) handleDiscovery(req *restful.Request, res *restful.Response) {
 	if err := jsonpb.Unmarshal(req.Request.Body, discoveryReq); err != nil {
 		writeBadRequestError(res, rest_error_types.Error{
 			Title:   "Could not parse request body",
+			Detail:  err.Error(),
 			Details: err.Error(),
 		})
 		return
@@ -45,6 +46,7 @@ func (s *service) handleDiscovery(req *restful.Request, res *restful.Response) {
 	if err != nil {
 		writeBadRequestError(res, rest_error_types.Error{
 			Title:   "Could not parse fetch-timeout",
+			Detail:  err.Error(),
 			Details: err.Error(),
 		})
 		return

--- a/pkg/plugins/authn/api-server/tokens/ws/testdata/ws-0-validFor.golden.json
+++ b/pkg/plugins/authn/api-server/tokens/ws/testdata/ws-0-validFor.golden.json
@@ -1,0 +1,19 @@
+{
+  "type": "/std-errors",
+  "status": "400",
+  "title": "Invalid request",
+  "detail": "Resource is not valid",
+  "invalid_parameters": [
+    {
+      "field": "validFor",
+      "reason": "cannot be empty or nil"
+    }
+  ],
+  "details": "Resource is not valid",
+  "causes": [
+    {
+      "field": "validFor",
+      "message": "cannot be empty or nil"
+    }
+  ]
+}

--- a/pkg/plugins/authn/api-server/tokens/ws/testdata/ws-missing-validFor.golden.json
+++ b/pkg/plugins/authn/api-server/tokens/ws/testdata/ws-missing-validFor.golden.json
@@ -1,0 +1,19 @@
+{
+ "type": "/std-errors",
+ "status": "400",
+ "title": "Invalid request",
+ "detail": "Resource is not valid",
+ "invalid_parameters": [
+  {
+   "field": "validFor",
+   "reason": "cannot be empty"
+  }
+ ],
+ "details": "Resource is not valid",
+ "causes": [
+  {
+   "field": "validFor",
+   "message": "cannot be empty"
+  }
+ ]
+}

--- a/pkg/plugins/authn/api-server/tokens/ws/testdata/ws-no-name.golden.json
+++ b/pkg/plugins/authn/api-server/tokens/ws/testdata/ws-no-name.golden.json
@@ -1,0 +1,19 @@
+{
+  "type": "/std-errors",
+  "status": "400",
+  "title": "Invalid request",
+  "detail": "Resource is not valid",
+  "invalid_parameters": [
+    {
+      "field": "name",
+      "reason": "cannot be empty"
+    }
+  ],
+  "details": "Resource is not valid",
+  "causes": [
+    {
+      "field": "name",
+      "message": "cannot be empty"
+    }
+  ]
+}

--- a/pkg/plugins/authn/api-server/tokens/ws/testdata/ws-token-issuer-disabled.golden.json
+++ b/pkg/plugins/authn/api-server/tokens/ws/testdata/ws-token-issuer-disabled.golden.json
@@ -1,0 +1,7 @@
+{
+  "type": "/std-errors",
+  "status": "400",
+  "title": "Could not issue a token",
+  "detail": "issuing tokens using the control plane is disabled.",
+  "details": "issuing tokens using the control plane is disabled."
+}

--- a/pkg/plugins/resources/remote/store.go
+++ b/pkg/plugins/resources/remote/store.go
@@ -186,7 +186,7 @@ func (s *remoteStore) doRequest(ctx context.Context, req *http.Request) (int, []
 	if resp.StatusCode/100 >= 4 {
 		kumaErr := types.Error{}
 		if err := json.Unmarshal(b, &kumaErr); err == nil {
-			if kumaErr.Title != "" && kumaErr.Details != "" {
+			if kumaErr.Title != "" {
 				return resp.StatusCode, b, &kumaErr
 			}
 		}

--- a/pkg/tokens/client.go
+++ b/pkg/tokens/client.go
@@ -46,7 +46,7 @@ func (tc TokenClient) Generate(tokenReq any) (string, error) {
 	if resp.StatusCode != http.StatusOK {
 		var kumaErr error_types.Error
 		if err := json.Unmarshal(body, &kumaErr); err == nil {
-			if kumaErr.Title != "" && kumaErr.Details != "" {
+			if kumaErr.Title != "" {
 				return "", &kumaErr
 			}
 		}


### PR DESCRIPTION
We've decided to start following for our apis: https://kong-aip.netlify.app/aip/193/

This PR makes errors return both the old and new fields for back compatibility.
In a future version we'll be able to remove old fields

We also have error responses in golden files for easier changes.

Fix #6136

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [x] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
