### PR TITLE
fix(kuma-cp/multizone): trim namespace suffix from plugin policies names

### DIFF
--- a/pkg/kds/context/context.go
+++ b/pkg/kds/context/context.go
@@ -13,6 +13,8 @@ import (
 
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	system_proto "github.com/kumahq/kuma/api/system/v1alpha1"
+	kuma_cp "github.com/kumahq/kuma/pkg/config/app/kuma-cp"
+	config_store "github.com/kumahq/kuma/pkg/config/core/resources/store"
 	"github.com/kumahq/kuma/pkg/core"
 	config_manager "github.com/kumahq/kuma/pkg/core/config/manager"
 	"github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
@@ -48,17 +50,29 @@ type Context struct {
 	ServerStreamInterceptors []grpc.StreamServerInterceptor
 }
 
-func DefaultContext(ctx context.Context, manager manager.ResourceManager, zone string) *Context {
+func DefaultContext(
+	ctx context.Context,
+	manager manager.ResourceManager,
+	cfg kuma_cp.Config,
+) *Context {
 	configs := map[string]bool{
 		config_manager.ClusterIdConfigKey: true,
 	}
 
+	globalResourceMappers := CompositeResourceMapper(
+		MapZoneTokenSigningKeyGlobalToPublicKey,
+		RemoveK8sSystemNamespaceSuffixFromPluginOriginatedResourcesMapper(
+			cfg.Store.Type,
+			cfg.Store.Kubernetes.SystemNamespace,
+		),
+	)
+
 	return &Context{
 		ZoneClientCtx:        ctx,
 		GlobalProvidedFilter: GlobalProvidedFilter(manager, configs),
-		ZoneProvidedFilter:   ZoneProvidedFilter(zone),
+		ZoneProvidedFilter:   ZoneProvidedFilter(cfg.Multizone.Zone.Name),
 		Configs:              configs,
-		GlobalResourceMapper: MapZoneTokenSigningKeyGlobalToPublicKey,
+		GlobalResourceMapper: globalResourceMappers,
 		ZoneResourceMapper:   MapInsightResourcesZeroGeneration,
 		EnvoyAdminRPCs:       service.NewEnvoyAdminRPCs(),
 	}
@@ -71,6 +85,10 @@ func CompositeResourceMapper(mappers ...reconcile.ResourceMapper) reconcile.Reso
 	return func(r model.Resource) (model.Resource, error) {
 		var err error
 		for _, mapper := range mappers {
+			if mapper == nil {
+				continue
+			}
+
 			r, err = mapper(r)
 			if err != nil {
 				return r, err
@@ -142,6 +160,31 @@ func MapZoneTokenSigningKeyGlobalToPublicKey(
 	}
 
 	return r, nil
+}
+
+// RemoveK8sSystemNamespaceSuffixFromPluginOriginatedResourcesMapper is a mapper
+// responsible for removing control plane system namespace suffixes from names
+// of plugin originated resources if resources are stored in kubernetes. Plugin
+// originated resources could be namespace scoped, but in this case, they
+// will be synced from the zone to global, so this mapper can be used as
+// a GlobalResourceMapper as the ones synced from global to zones will always be
+// placed in system namespace of the global control plane.
+func RemoveK8sSystemNamespaceSuffixFromPluginOriginatedResourcesMapper(
+	storeType config_store.StoreType,
+	k8sSystemNamespace string,
+) reconcile.ResourceMapper {
+	// This mapper is intended for kubernetes only
+	if storeType != config_store.KubernetesStore {
+		return nil
+	}
+
+	return func(r model.Resource) (model.Resource, error) {
+		if r.Descriptor().IsPluginOriginated {
+			util.TrimSuffixFromName(r, k8sSystemNamespace)
+		}
+
+		return r, nil
+	}
 }
 
 // GlobalProvidedFilter returns ResourceFilter which filters Resources provided by Global, specifically

--- a/pkg/kds/context/context_test.go
+++ b/pkg/kds/context/context_test.go
@@ -510,16 +510,26 @@ var _ = Describe("Context", func() {
 				name:         "foo.custom-namespace",
 				expectedName: "foo.custom-namespace",
 			}),
-			Entry("shouldn't be removed when store type is not kubernetes ",
+			Entry("shouldn't be removed when store type is not kubernetes",
 				testCase{
 					isResourcePluginOriginated: true,
 					config: config{
-						storeType:          config_store.MemoryStore,
+						storeType:          config_store.PostgresStore,
 						k8sSystemNamespace: "custom-namespace",
 					},
 					name:         "foo.custom-namespace",
 					expectedName: "foo.custom-namespace",
 				}),
+			Entry("shouldn't be removed when suffix is not k8s system "+
+				"namespace", testCase{
+				isResourcePluginOriginated: true,
+				config: config{
+					storeType:          config_store.KubernetesStore,
+					k8sSystemNamespace: "kuma-system",
+				},
+				name:         "foo.custom-namespace",
+				expectedName: "foo.custom-namespace",
+			}),
 		)
 	})
 })

--- a/pkg/kds/context/context_test.go
+++ b/pkg/kds/context/context_test.go
@@ -9,6 +9,8 @@ import (
 
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	system_proto "github.com/kumahq/kuma/api/system/v1alpha1"
+	kuma_cp "github.com/kumahq/kuma/pkg/config/app/kuma-cp"
+	config_store "github.com/kumahq/kuma/pkg/config/core/resources/store"
 	config_manager "github.com/kumahq/kuma/pkg/core/config/manager"
 	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	core_system "github.com/kumahq/kuma/pkg/core/resources/apis/system"
@@ -38,8 +40,12 @@ var _ = Describe("Context", func() {
 		}
 
 		BeforeEach(func() {
+			cfg := kuma_cp.DefaultConfig()
+			cfg.Store.Type = config_store.KubernetesStore
+			cfg.Multizone.Zone.Name = "zone"
+
 			rm = manager.NewResourceManager(memory.NewStore())
-			defaultContext := context.DefaultContext(stdcontext.Background(), rm, "zone")
+			defaultContext := context.DefaultContext(stdcontext.Background(), rm, cfg)
 			mapper = defaultContext.ZoneResourceMapper
 		})
 
@@ -432,5 +438,88 @@ var _ = Describe("Context", func() {
 				entries,
 			)
 		})
+	})
+	Describe("GlobalResourceMapper", func() {
+		type config struct {
+			storeType          config_store.StoreType
+			k8sSystemNamespace string
+		}
+
+		type testCase struct {
+			config                     config
+			name                       string
+			expectedName               string
+			isResourcePluginOriginated bool
+		}
+
+		genConfig := func(caseCfg config) kuma_cp.Config {
+			cfg := kuma_cp.DefaultConfig()
+
+			if caseCfg.storeType != "" {
+				cfg.Store.Type = caseCfg.storeType
+			}
+
+			if caseCfg.k8sSystemNamespace != "" {
+				cfg.Store.Kubernetes.SystemNamespace = caseCfg.k8sSystemNamespace
+			}
+
+			return cfg
+		}
+
+		resource := func(given testCase) model.Resource {
+			descriptor := model.ResourceTypeDescriptor{
+				IsPluginOriginated: given.isResourcePluginOriginated,
+			}
+
+			meta := &test_model.ResourceMeta{Name: given.name}
+
+			return &test_model.Resource{TypeDescriptor: descriptor, Meta: meta}
+		}
+
+		DescribeTable("system namespace suffix from in resource names",
+			func(given testCase) {
+				// given
+				ctx := stdcontext.Background()
+				rm := manager.NewResourceManager(memory.NewStore())
+				cfg := genConfig(given.config)
+				kdsCtx := context.DefaultContext(ctx, rm, cfg)
+
+				// when
+				out, _ := kdsCtx.GlobalResourceMapper(resource(given))
+
+				// then
+				Expect(out.GetMeta().GetName()).To(Equal(given.expectedName))
+			},
+			Entry("should be removed when store type is kubernetes "+
+				"and resource is plugin originated", testCase{
+				isResourcePluginOriginated: true,
+				config: config{
+					storeType:          config_store.KubernetesStore,
+					k8sSystemNamespace: "custom-namespace",
+				},
+				name:         "foo.custom-namespace",
+				expectedName: "foo",
+			}),
+			Entry("shouldn't be removed when store type is kubernetes "+
+				"and resource isn't plugin originated", testCase{
+				isResourcePluginOriginated: false,
+				config: config{
+					storeType:          config_store.KubernetesStore,
+					k8sSystemNamespace: "custom-namespace",
+				},
+				name:         "foo.custom-namespace",
+				expectedName: "foo.custom-namespace",
+			}),
+			Entry("shouldn't be removed when store type is not kubernetes ",
+				testCase{
+					isResourcePluginOriginated: true,
+					config: config{
+						storeType:          config_store.MemoryStore,
+						k8sSystemNamespace: "custom-namespace",
+					},
+					name:         "foo.custom-namespace",
+					expectedName: "foo.custom-namespace",
+				}),
+		)
 	})
 })

--- a/pkg/kds/util/resource.go
+++ b/pkg/kds/util/resource.go
@@ -84,6 +84,16 @@ func AddSuffixToNames(rs []model.Resource, suffix string) {
 	}
 }
 
+// TrimSuffixFromName is responsible for removing provided suffix with preceding
+// dot from the name of provided model.Resource.
+func TrimSuffixFromName(r model.Resource, suffix string) {
+	dotSuffix := fmt.Sprintf(".%s", suffix)
+	newName := strings.TrimSuffix(r.GetMeta().GetName(), dotSuffix)
+	newMeta := CloneResourceMetaWithNewName(r.GetMeta(), newName)
+
+	r.SetMeta(newMeta)
+}
+
 func AddSuffixToResourceKeyNames(rk []model.ResourceKey, suffix string) []model.ResourceKey {
 	for idx, r := range rk {
 		rk[idx].Name = fmt.Sprintf("%s.%s", r.Name, suffix)

--- a/pkg/kds/util/resource_test.go
+++ b/pkg/kds/util/resource_test.go
@@ -1,0 +1,45 @@
+package util_test
+
+import (
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/kumahq/kuma/pkg/kds/util"
+	test_model "github.com/kumahq/kuma/pkg/test/resources/model"
+)
+
+var _ = Describe("TrimSuffixFromName", func() {
+	type testCase struct {
+		name   string
+		suffix string
+	}
+
+	name := func(given testCase) string {
+		return fmt.Sprintf("%s.%s", given.name, given.suffix)
+	}
+
+	DescribeTable("should remove provided suffix from the name of "+
+		"the provided resource",
+		func(given testCase) {
+			// given
+			meta := &test_model.ResourceMeta{Name: name(given)}
+			resource := &test_model.Resource{Meta: meta}
+
+			// when
+			util.TrimSuffixFromName(resource, given.suffix)
+
+			// then
+			Expect(resource.GetMeta().GetName()).To(Equal(given.name))
+		},
+		// entry description generator
+		func(given testCase) string {
+			return fmt.Sprintf("name: %q, suffix: %q", name(given), given.suffix)
+		},
+		Entry(nil, testCase{name: "foo", suffix: "bar"}),
+		Entry(nil, testCase{name: "bar", suffix: "baz"}),
+		Entry(nil, testCase{name: "baz", suffix: "kuma-system"}),
+		Entry(nil, testCase{name: "faz", suffix: "daz.kuma-system"}),
+	)
+})

--- a/pkg/kds/util/util_suite_test.go
+++ b/pkg/kds/util/util_suite_test.go
@@ -1,0 +1,11 @@
+package util_test
+
+import (
+	"testing"
+
+	"github.com/kumahq/kuma/pkg/test"
+)
+
+func TestZoneSync(t *testing.T) {
+	test.RunSpecs(t, "Util Suite")
+}

--- a/pkg/kds/v2/client/zone_sync_test.go
+++ b/pkg/kds/v2/client/zone_sync_test.go
@@ -10,6 +10,7 @@ import (
 
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	"github.com/kumahq/kuma/api/system/v1alpha1"
+	kuma_cp "github.com/kumahq/kuma/pkg/config/app/kuma-cp"
 	"github.com/kumahq/kuma/pkg/core"
 	config_manager "github.com/kumahq/kuma/pkg/core/config/manager"
 	"github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
@@ -65,7 +66,10 @@ var _ = Describe("Zone Delta Sync", func() {
 		globalStore = memory.NewStore()
 		wg := &sync.WaitGroup{}
 
-		kdsCtx := kds_context.DefaultContext(context.Background(), manager.NewResourceManager(globalStore), "global")
+		cfg := kuma_cp.DefaultConfig()
+		cfg.Multizone.Zone.Name = "global"
+
+		kdsCtx := kds_context.DefaultContext(context.Background(), manager.NewResourceManager(globalStore), cfg)
 		srv, err := setup.StartDeltaServer(globalStore, "global", registry.Global().ObjectTypes(model.HasKDSFlag(model.ConsumedByZone)), kdsCtx.GlobalProvidedFilter, kdsCtx.GlobalResourceMapper)
 		Expect(err).ToNot(HaveOccurred())
 		serverStream := grpc.NewMockDeltaServerStream()

--- a/pkg/kds/zone/components_test.go
+++ b/pkg/kds/zone/components_test.go
@@ -10,6 +10,7 @@ import (
 
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	"github.com/kumahq/kuma/api/system/v1alpha1"
+	kuma_cp "github.com/kumahq/kuma/pkg/config/app/kuma-cp"
 	"github.com/kumahq/kuma/pkg/core"
 	config_manager "github.com/kumahq/kuma/pkg/core/config/manager"
 	"github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
@@ -172,7 +173,10 @@ var _ = Describe("Zone Sync", func() {
 			globalStore = memory.NewStore()
 			wg := &sync.WaitGroup{}
 
-			kdsCtx := kds_context.DefaultContext(context.Background(), manager.NewResourceManager(globalStore), "global")
+			cfg := kuma_cp.DefaultConfig()
+			cfg.Multizone.Zone.Name = "global"
+
+			kdsCtx := kds_context.DefaultContext(context.Background(), manager.NewResourceManager(globalStore), cfg)
 			srv, err := setup.StartServer(globalStore, "global", registry.Global().ObjectTypes(model.HasKDSFlag(model.ConsumedByZone)), kdsCtx.GlobalProvidedFilter, kdsCtx.GlobalResourceMapper)
 			Expect(err).ToNot(HaveOccurred())
 			serverStream := grpc.NewMockServerStream()
@@ -240,7 +244,10 @@ var _ = Describe("Zone Sync", func() {
 			globalStore = memory.NewStore()
 			wg := &sync.WaitGroup{}
 
-			kdsCtx := kds_context.DefaultContext(context.Background(), manager.NewResourceManager(globalStore), "global")
+			cfg := kuma_cp.DefaultConfig()
+			cfg.Multizone.Zone.Name = "global"
+
+			kdsCtx := kds_context.DefaultContext(context.Background(), manager.NewResourceManager(globalStore), cfg)
 			srv, err := setup.StartDeltaServer(globalStore, "global", registry.Global().ObjectTypes(model.HasKDSFlag(model.ConsumedByZone)), kdsCtx.GlobalProvidedFilter, kdsCtx.GlobalResourceMapper)
 			Expect(err).ToNot(HaveOccurred())
 			serverStream := grpc.NewMockDeltaServerStream()

--- a/pkg/test/resources/model/resource.go
+++ b/pkg/test/resources/model/resource.go
@@ -6,7 +6,37 @@ import (
 	core_model "github.com/kumahq/kuma/pkg/core/resources/model"
 )
 
-var _ core_model.ResourceMeta = &ResourceMeta{}
+var (
+	_ core_model.Resource     = &Resource{}
+	_ core_model.ResourceMeta = &ResourceMeta{}
+)
+
+type Resource struct {
+	Meta           core_model.ResourceMeta
+	Spec           core_model.ResourceSpec
+	TypeDescriptor core_model.ResourceTypeDescriptor
+}
+
+func (r *Resource) SetMeta(meta core_model.ResourceMeta) {
+	r.Meta = meta
+}
+
+func (r *Resource) SetSpec(spec core_model.ResourceSpec) error {
+	r.Spec = spec
+	return nil
+}
+
+func (r *Resource) GetMeta() core_model.ResourceMeta {
+	return r.Meta
+}
+
+func (r *Resource) GetSpec() core_model.ResourceSpec {
+	return r.Spec
+}
+
+func (r *Resource) Descriptor() core_model.ResourceTypeDescriptor {
+	return r.TypeDescriptor
+}
 
 type ResourceMeta struct {
 	Mesh             string

--- a/pkg/test/runtime/runtime.go
+++ b/pkg/test/runtime/runtime.go
@@ -116,7 +116,7 @@ func BuilderFor(appCtx context.Context, cfg kuma_cp.Config) (*core_runtime.Build
 	builder.WithDpServer(server.NewDpServer(*cfg.DpServer, metrics, func(writer http.ResponseWriter, request *http.Request) bool {
 		return true
 	}))
-	builder.WithKDSContext(kds_context.DefaultContext(appCtx, builder.ResourceManager(), cfg.Multizone.Zone.Name))
+	builder.WithKDSContext(kds_context.DefaultContext(appCtx, builder.ResourceManager(), cfg))
 	caProvider, err := secrets.NewCaProvider(builder.CaManagers(), metrics)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Trim system namespace suffix from names of plugin originated policies when syncing resources from global to zones in multizone mode.

Closes: https://github.com/kumahq/kuma/issues/6999

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues
  - https://github.com/kumahq/kuma/issues/6999
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS
  - It won't
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s)
  - Added unit tests + manually tested on k3d clusters
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)?
  - There is no need
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? 
  - There is no need
- [x] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?
> Changelog: fix(kuma-cp/multizone): trim system namespace suffix from names of plugin originated policies when syncing resources from global to zones in multizone mode.

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
