### PR TITLE
test(framework): allow to disable verifyKuma and kumactl config on CP installation

### DIFF
--- a/test/framework/interface.go
+++ b/test/framework/interface.go
@@ -49,6 +49,8 @@ type kumaDeploymentOptions struct {
 	transparentProxyV1          bool
 	apiHeaders                  []string
 	zoneName                    string
+	verifyKuma					bool
+	setupKumactl				bool
 
 	// Functions to apply to each mesh after the control plane
 	// is provisioned.
@@ -62,6 +64,8 @@ func (k *kumaDeploymentOptions) apply(opts ...KumaDeploymentOption) {
 	k.env = map[string]string{}
 	k.meshUpdateFuncs = map[string][]func(*mesh_proto.Mesh) *mesh_proto.Mesh{}
 	k.transparentProxyV1 = true
+	k.verifyKuma = true
+	k.setupKumactl = true
 
 	// Apply options.
 	for _, o := range opts {
@@ -364,6 +368,18 @@ func WithApiHeaders(headers ...string) KumaDeploymentOption {
 func WithZoneName(zoneName string) KumaDeploymentOption {
 	return KumaOptionFunc(func(o *kumaDeploymentOptions) {
 		o.zoneName = zoneName
+	})
+}
+
+func WithoutVerifyingKuma() KumaDeploymentOption {
+	return KumaOptionFunc(func(o *kumaDeploymentOptions) {
+		o.verifyKuma = false
+	})
+}
+
+func WithoutConfigureKumactl() KumaDeploymentOption {
+	return KumaOptionFunc(func(o *kumaDeploymentOptions) {
+		o.setupKumactl = false
 	})
 }
 

--- a/test/framework/interface.go
+++ b/test/framework/interface.go
@@ -49,8 +49,8 @@ type kumaDeploymentOptions struct {
 	transparentProxyV1          bool
 	apiHeaders                  []string
 	zoneName                    string
-	verifyKuma					bool
-	setupKumactl				bool
+	verifyKuma                  bool
+	setupKumactl                bool
 
 	// Functions to apply to each mesh after the control plane
 	// is provisioned.
@@ -377,7 +377,7 @@ func WithoutVerifyingKuma() KumaDeploymentOption {
 	})
 }
 
-func WithoutConfigureKumactl() KumaDeploymentOption {
+func WithoutConfiguringKumactl() KumaDeploymentOption {
 	return KumaOptionFunc(func(o *kumaDeploymentOptions) {
 		o.setupKumactl = false
 	})

--- a/test/framework/k8s_cluster.go
+++ b/test/framework/k8s_cluster.go
@@ -666,7 +666,10 @@ func (c *K8sCluster) DeployKuma(mode core.CpMode, opt ...KumaDeploymentOption) e
 		}
 	}
 
-	return c.VerifyKuma()
+	if c.opts.verifyKuma{
+		return c.VerifyKuma()
+	}
+	return nil
 }
 
 func (c *K8sCluster) UpgradeKuma(mode string, opt ...KumaDeploymentOption) error {

--- a/test/framework/k8s_controlplane.go
+++ b/test/framework/k8s_controlplane.go
@@ -192,6 +192,9 @@ func (c *K8sControlPlane) FinalizeAddWithPortFwd(portFwd PortFwd) error {
 }
 
 func (c *K8sControlPlane) retrieveAdminToken() (string, error) {
+	if !c.cluster.opts.setupKumactl {
+		return "", nil
+	}
 	if authnType, exist := c.cluster.opts.env["KUMA_API_SERVER_AUTHN_TYPE"]; exist && authnType != "tokens" {
 		return "", nil
 	}

--- a/test/framework/universal_cluster.go
+++ b/test/framework/universal_cluster.go
@@ -181,7 +181,7 @@ func (c *UniversalCluster) DeployKuma(mode core.CpMode, opt ...KumaDeploymentOpt
 		ApiServerPort: app.ports["5681"],
 		SshPort:       app.ports["22"],
 	}
-	c.controlplane, err = NewUniversalControlPlane(c.t, mode, c.name, c.verbose, pf, c.opts.apiHeaders)
+	c.controlplane, err = NewUniversalControlPlane(c.t, mode, c.name, c.verbose, pf, c.opts.apiHeaders, c.opts.setupKumactl)
 	if err != nil {
 		return err
 	}
@@ -201,7 +201,10 @@ func (c *UniversalCluster) DeployKuma(mode core.CpMode, opt ...KumaDeploymentOpt
 		}
 	}
 
-	return c.VerifyKuma()
+	if c.opts.verifyKuma {
+		return c.VerifyKuma()
+	}
+	return nil
 }
 
 func (c *UniversalCluster) GetKuma() ControlPlane {

--- a/test/framework/universal_controlplane.go
+++ b/test/framework/universal_controlplane.go
@@ -23,6 +23,7 @@ type UniversalControlPlane struct {
 	kumactl      *KumactlOptions
 	verbose      bool
 	cpNetworking UniversalNetworking
+	setupKumactl bool
 }
 
 func NewUniversalControlPlane(
@@ -32,6 +33,7 @@ func NewUniversalControlPlane(
 	verbose bool,
 	networking UniversalNetworking,
 	apiHeaders []string,
+	setupKumactl bool,
 ) (*UniversalControlPlane, error) {
 	name := clusterName + "-" + mode
 	kumactl := NewKumactlOptions(t, name, verbose)
@@ -42,6 +44,7 @@ func NewUniversalControlPlane(
 		kumactl:      kumactl,
 		verbose:      verbose,
 		cpNetworking: networking,
+		setupKumactl: setupKumactl,
 	}
 	token, err := ucp.retrieveAdminToken()
 	if err != nil {
@@ -149,6 +152,9 @@ func (c *UniversalControlPlane) generateToken(
 }
 
 func (c *UniversalControlPlane) retrieveAdminToken() (string, error) {
+	if !c.setupKumactl {
+		return "", nil
+	}
 	return retry.DoWithRetryE(
 		c.t, "fetching user admin token",
 		DefaultRetries,


### PR DESCRIPTION
### Checklist prior to review

During the setup, we might don't want to verify if kuma started.

- [X] [Link to relevant issue][1] as well as docs and UI issues --
- [X] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [X] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [X] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [X] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [X] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
