### PR TITLE
refactor(helper): make mesh_proto.Merge helper function generic

### DIFF
--- a/api/mesh/v1alpha1/dataplane_helpers.go
+++ b/api/mesh/v1alpha1/dataplane_helpers.go
@@ -326,6 +326,11 @@ func Merge[TagSet ~map[string]string](other ...TagSet) TagSet {
 	return merged
 }
 
+// MergeAs is just syntactic sugar which converts merged result to assumed type
+func MergeAs[R ~map[string]string, T ~map[string]string](other ...T) R {
+	return R(Merge(other...))
+}
+
 func (t SingleValueTagSet) Exclude(key string) SingleValueTagSet {
 	rv := SingleValueTagSet{}
 	for k, v := range t {

--- a/api/mesh/v1alpha1/dataplane_helpers.go
+++ b/api/mesh/v1alpha1/dataplane_helpers.go
@@ -314,8 +314,8 @@ func (t SingleValueTagSet) Keys() []string {
 	return keys
 }
 
-func Merge(other ...SingleValueTagSet) SingleValueTagSet {
-	merged := SingleValueTagSet{}
+func Merge[TagSet ~map[string]string](other ...TagSet) TagSet {
+	merged := TagSet{}
 
 	for _, t := range other {
 		for k, v := range t {

--- a/pkg/xds/generator/ingress_generator.go
+++ b/pkg/xds/generator/ingress_generator.go
@@ -226,7 +226,7 @@ func (_ IngressGenerator) destinations(
 				}
 				destinations[service] = append(
 					destinations[service],
-					tags.Tags(mesh_proto.Merge(selector.GetMatch(), gateway.Spec.GetTags(), listener.GetTags())),
+					mesh_proto.Merge(selector.GetMatch(), gateway.Spec.GetTags(), listener.GetTags()),
 				)
 			}
 		}

--- a/pkg/xds/ingress/dataplane.go
+++ b/pkg/xds/ingress/dataplane.go
@@ -151,12 +151,12 @@ func getIngressAvailableMeshGateways(meshName string, meshGateways []*core_mesh.
 
 	tagSets := tagSets{}
 	for _, endpointTags := range endpoints {
-		tagSets.addInstanceOfTags(meshName, envoy.Tags(mesh_proto.Merge(
+		tagSets.addInstanceOfTags(meshName, mesh_proto.Merge(
 			map[string]string{
 				mesh_proto.MeshTag: meshName,
 			},
 			endpointTags,
-		)))
+		))
 	}
 
 	return tagSets.toAvailableServices()

--- a/pkg/xds/ingress/dataplane.go
+++ b/pkg/xds/ingress/dataplane.go
@@ -151,7 +151,7 @@ func getIngressAvailableMeshGateways(meshName string, meshGateways []*core_mesh.
 
 	tagSets := tagSets{}
 	for _, endpointTags := range endpoints {
-		tagSets.addInstanceOfTags(meshName, mesh_proto.Merge(
+		tagSets.addInstanceOfTags(meshName, mesh_proto.MergeAs[envoy.Tags](
 			map[string]string{
 				mesh_proto.MeshTag: meshName,
 			},

--- a/pkg/xds/ingress/outbound.go
+++ b/pkg/xds/ingress/outbound.go
@@ -59,9 +59,9 @@ func BuildEndpointMap(
 				outbound[serviceName] = append(outbound[serviceName], core_xds.Endpoint{
 					Target: dpNetworking.GetAddress(),
 					Port:   listener.GetPort(),
-					Tags: tags.Tags(mesh_proto.Merge(
+					Tags: mesh_proto.Merge[tags.Tags](
 						dpTags, gateway.Spec.GetTags(), listener.GetTags(),
-					)).WithTags("mesh", dataplane.GetMeta().GetMesh()),
+					).WithTags("mesh", dataplane.GetMeta().GetMesh()),
 					Weight: 1,
 				})
 			}


### PR DESCRIPTION
It's unnecessary to assume concrete type if underlying one is `map[string]string`. It makes it slightly more reusable.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues
  - There is no relevant issue
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS
  - It won't
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s)
  - There are no new tests and all existing unit tests are passing
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)?
  - There is no need as this change should be transparent
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? 
  - There is no need
- [x] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?
  - There is no need

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
