### PR TITLE
fix(MeshRetry): set MeshGateway retry on routes not virtual hosts

### DIFF
--- a/pkg/plugins/policies/meshretry/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshretry/plugin/v1alpha1/plugin_test.go
@@ -3,6 +3,7 @@ package v1alpha1_test
 import (
 	"fmt"
 	"path/filepath"
+	"time"
 
 	envoy_resource "github.com/envoyproxy/go-control-plane/pkg/resource/v3"
 	. "github.com/onsi/ginkgo/v2"
@@ -22,6 +23,7 @@ import (
 	"github.com/kumahq/kuma/pkg/test"
 	"github.com/kumahq/kuma/pkg/test/matchers"
 	"github.com/kumahq/kuma/pkg/test/resources/builders"
+	test_model "github.com/kumahq/kuma/pkg/test/resources/model"
 	"github.com/kumahq/kuma/pkg/test/resources/samples"
 	test_xds "github.com/kumahq/kuma/pkg/test/xds"
 	"github.com/kumahq/kuma/pkg/util/pointer"
@@ -268,6 +270,48 @@ var _ = Describe("MeshRetry", func() {
 			resources := xds_context.NewResources()
 			resources.MeshLocalResources[core_mesh.MeshGatewayType] = &core_mesh.MeshGatewayResourceList{
 				Items: given.gateways,
+			}
+			resources.MeshLocalResources[core_mesh.RetryType] = &core_mesh.RetryResourceList{
+				Items: []*core_mesh.RetryResource{{
+					Meta: &test_model.ResourceMeta{Name: "retry1"},
+					Spec: &mesh_proto.Retry{
+						Sources: []*mesh_proto.Selector{
+							{
+								Match: map[string]string{
+									mesh_proto.ServiceTag: "*",
+								},
+							},
+						},
+						Destinations: []*mesh_proto.Selector{
+							{
+								Match: map[string]string{
+									mesh_proto.ServiceTag: "*",
+								},
+							},
+						},
+						Conf: &mesh_proto.Retry_Conf{
+							Http: &mesh_proto.Retry_Conf_Http{
+								NumRetries:    util_proto.UInt32(5),
+								PerTryTimeout: util_proto.Duration(16 * time.Second),
+								BackOff: &mesh_proto.Retry_Conf_BackOff{
+									BaseInterval: util_proto.Duration(25 * time.Millisecond),
+									MaxInterval:  util_proto.Duration(250 * time.Millisecond),
+								},
+							},
+							Tcp: &mesh_proto.Retry_Conf_Tcp{
+								MaxConnectAttempts: 5,
+							},
+							Grpc: &mesh_proto.Retry_Conf_Grpc{
+								NumRetries:    util_proto.UInt32(5),
+								PerTryTimeout: util_proto.Duration(16 * time.Second),
+								BackOff: &mesh_proto.Retry_Conf_BackOff{
+									BaseInterval: util_proto.Duration(25 * time.Millisecond),
+									MaxInterval:  util_proto.Duration(250 * time.Millisecond),
+								},
+							},
+						},
+					},
+				}},
 			}
 			resources.MeshLocalResources[core_mesh.MeshGatewayRouteType] = &core_mesh.MeshGatewayRouteResourceList{
 				Items: given.gatewayRoutes,

--- a/pkg/plugins/policies/meshretry/plugin/v1alpha1/testdata/gateway.http.routes.golden.yaml
+++ b/pkg/plugins/policies/meshretry/plugin/v1alpha1/testdata/gateway.http.routes.golden.yaml
@@ -7,78 +7,6 @@ virtualHosts:
 - domains:
   - '*'
   name: '*'
-  retryPolicy:
-    hostSelectionRetryMaxAttempts: "2"
-    numRetries: 1
-    perTryTimeout: 2s
-    rateLimitedRetryBackOff:
-      maxInterval: 5s
-      resetHeaders:
-      - name: retry-after-http
-      - format: UNIX_TIMESTAMP
-        name: x-retry-after-http
-    retriableHeaders:
-    - name: x-retry-regex
-      stringMatch:
-        safeRegex:
-          googleRe2: {}
-          regex: .*
-    - name: x-retry-exact
-      stringMatch:
-        exact: exact-value
-    retriableRequestHeaders:
-    - name: :method
-      stringMatch:
-        exact: CONNECT
-    - name: :method
-      stringMatch:
-        exact: DELETE
-    - name: :method
-      stringMatch:
-        exact: GET
-    - name: :method
-      stringMatch:
-        exact: HEAD
-    - name: :method
-      stringMatch:
-        exact: OPTIONS
-    - name: :method
-      stringMatch:
-        exact: PATCH
-    - name: :method
-      stringMatch:
-        exact: POST
-    - name: :method
-      stringMatch:
-        exact: PUT
-    - name: :method
-      stringMatch:
-        exact: TRACE
-    - name: x-retry-prefix
-      stringMatch:
-        prefix: prefix-
-    retriableStatusCodes:
-    - 429
-    retryBackOff:
-      baseInterval: 3s
-      maxInterval: 4s
-    retryHostPredicate:
-    - name: envoy.retry_host_predicates.previous_hosts
-      typedConfig:
-        '@type': type.googleapis.com/envoy.extensions.retry.host.previous_hosts.v3.PreviousHostsPredicate
-    - name: envoy.retry_host_predicates.omit_host_metadata
-      typedConfig:
-        '@type': type.googleapis.com/envoy.extensions.retry.host.omit_host_metadata.v3.OmitHostMetadataConfig
-        metadataMatch:
-          filterMetadata:
-            envoy.lb:
-              test: test
-    retryOn: 5xx,gateway-error,reset,retriable-4xx,connect-failure,envoy-ratelimited,refused-stream,http3-post-connect-failure,retriable-status-codes
-    retryPriority:
-      name: envoy.retry_priorities.previous_priorities
-      typedConfig:
-        '@type': type.googleapis.com/envoy.extensions.retry.priority.previous_priorities.v3.PreviousPrioritiesConfig
-        updateFrequency: 2
   routes:
   - match:
       path: /
@@ -86,12 +14,77 @@ virtualHosts:
       clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
       idleTimeout: 5s
       retryPolicy:
-        numRetries: 5
-        perTryTimeout: 16s
+        hostSelectionRetryMaxAttempts: "2"
+        numRetries: 1
+        perTryTimeout: 2s
+        rateLimitedRetryBackOff:
+          maxInterval: 5s
+          resetHeaders:
+          - name: retry-after-http
+          - format: UNIX_TIMESTAMP
+            name: x-retry-after-http
+        retriableHeaders:
+        - name: x-retry-regex
+          stringMatch:
+            safeRegex:
+              googleRe2: {}
+              regex: .*
+        - name: x-retry-exact
+          stringMatch:
+            exact: exact-value
+        retriableRequestHeaders:
+        - name: :method
+          stringMatch:
+            exact: CONNECT
+        - name: :method
+          stringMatch:
+            exact: DELETE
+        - name: :method
+          stringMatch:
+            exact: GET
+        - name: :method
+          stringMatch:
+            exact: HEAD
+        - name: :method
+          stringMatch:
+            exact: OPTIONS
+        - name: :method
+          stringMatch:
+            exact: PATCH
+        - name: :method
+          stringMatch:
+            exact: POST
+        - name: :method
+          stringMatch:
+            exact: PUT
+        - name: :method
+          stringMatch:
+            exact: TRACE
+        - name: x-retry-prefix
+          stringMatch:
+            prefix: prefix-
+        retriableStatusCodes:
+        - 429
         retryBackOff:
-          baseInterval: 0.025s
-          maxInterval: 0.250s
-        retryOn: gateway-error,connect-failure,refused-stream
+          baseInterval: 3s
+          maxInterval: 4s
+        retryHostPredicate:
+        - name: envoy.retry_host_predicates.previous_hosts
+          typedConfig:
+            '@type': type.googleapis.com/envoy.extensions.retry.host.previous_hosts.v3.PreviousHostsPredicate
+        - name: envoy.retry_host_predicates.omit_host_metadata
+          typedConfig:
+            '@type': type.googleapis.com/envoy.extensions.retry.host.omit_host_metadata.v3.OmitHostMetadataConfig
+            metadataMatch:
+              filterMetadata:
+                envoy.lb:
+                  test: test
+        retryOn: 5xx,gateway-error,reset,retriable-4xx,connect-failure,envoy-ratelimited,refused-stream,http3-post-connect-failure,retriable-status-codes
+        retryPriority:
+          name: envoy.retry_priorities.previous_priorities
+          typedConfig:
+            '@type': type.googleapis.com/envoy.extensions.retry.priority.previous_priorities.v3.PreviousPrioritiesConfig
+            updateFrequency: 2
       weightedClusters:
         clusters:
         - name: backend-26cb64fa4e85e7b7

--- a/pkg/plugins/policies/meshretry/plugin/v1alpha1/testdata/gateway.http.routes.golden.yaml
+++ b/pkg/plugins/policies/meshretry/plugin/v1alpha1/testdata/gateway.http.routes.golden.yaml
@@ -85,6 +85,13 @@ virtualHosts:
     route:
       clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
       idleTimeout: 5s
+      retryPolicy:
+        numRetries: 5
+        perTryTimeout: 16s
+        retryBackOff:
+          baseInterval: 0.025s
+          maxInterval: 0.250s
+        retryOn: gateway-error,connect-failure,refused-stream
       weightedClusters:
         clusters:
         - name: backend-26cb64fa4e85e7b7

--- a/pkg/plugins/policies/meshretry/plugin/v1alpha1/testdata/grpc.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshretry/plugin/v1alpha1/testdata/grpc.listeners.golden.yaml
@@ -22,24 +22,24 @@ filterChains:
         - domains:
           - '*'
           name: backend
-          retryPolicy:
-            numRetries: 11
-            perTryTimeout: 12s
-            rateLimitedRetryBackOff:
-              maxInterval: 15s
-              resetHeaders:
-              - name: retry-after-grpc
-              - format: UNIX_TIMESTAMP
-                name: x-retry-after-grpc
-            retryBackOff:
-              baseInterval: 13s
-              maxInterval: 14s
-            retryOn: canceled,deadline-exceeded,internal,resource-exhausted,unavailable
           routes:
           - match:
               prefix: /
             route:
               cluster: backend
+              retryPolicy:
+                numRetries: 11
+                perTryTimeout: 12s
+                rateLimitedRetryBackOff:
+                  maxInterval: 15s
+                  resetHeaders:
+                  - name: retry-after-grpc
+                  - format: UNIX_TIMESTAMP
+                    name: x-retry-after-grpc
+                retryBackOff:
+                  baseInterval: 13s
+                  maxInterval: 14s
+                retryOn: canceled,deadline-exceeded,internal,resource-exhausted,unavailable
               timeout: 0s
       statPrefix: outbound_127_0_0_1_10002
 name: outbound:127.0.0.1:10002

--- a/pkg/plugins/policies/meshretry/plugin/v1alpha1/testdata/http.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshretry/plugin/v1alpha1/testdata/http.listeners.golden.yaml
@@ -22,83 +22,83 @@ filterChains:
         - domains:
           - '*'
           name: backend
-          retryPolicy:
-            hostSelectionRetryMaxAttempts: "2"
-            numRetries: 1
-            perTryTimeout: 2s
-            rateLimitedRetryBackOff:
-              maxInterval: 5s
-              resetHeaders:
-              - name: retry-after-http
-              - format: UNIX_TIMESTAMP
-                name: x-retry-after-http
-            retriableHeaders:
-            - name: x-retry-regex
-              stringMatch:
-                safeRegex:
-                  googleRe2: {}
-                  regex: .*
-            - name: x-retry-exact
-              stringMatch:
-                exact: exact-value
-            retriableRequestHeaders:
-            - name: :method
-              stringMatch:
-                exact: CONNECT
-            - name: :method
-              stringMatch:
-                exact: DELETE
-            - name: :method
-              stringMatch:
-                exact: GET
-            - name: :method
-              stringMatch:
-                exact: HEAD
-            - name: :method
-              stringMatch:
-                exact: OPTIONS
-            - name: :method
-              stringMatch:
-                exact: PATCH
-            - name: :method
-              stringMatch:
-                exact: POST
-            - name: :method
-              stringMatch:
-                exact: PUT
-            - name: :method
-              stringMatch:
-                exact: TRACE
-            - name: x-retry-prefix
-              stringMatch:
-                prefix: prefix-
-            retriableStatusCodes:
-            - 429
-            retryBackOff:
-              baseInterval: 3s
-              maxInterval: 4s
-            retryHostPredicate:
-            - name: envoy.retry_host_predicates.previous_hosts
-              typedConfig:
-                '@type': type.googleapis.com/envoy.extensions.retry.host.previous_hosts.v3.PreviousHostsPredicate
-            - name: envoy.retry_host_predicates.omit_host_metadata
-              typedConfig:
-                '@type': type.googleapis.com/envoy.extensions.retry.host.omit_host_metadata.v3.OmitHostMetadataConfig
-                metadataMatch:
-                  filterMetadata:
-                    envoy.lb:
-                      test: test
-            retryOn: 5xx,gateway-error,reset,retriable-4xx,connect-failure,envoy-ratelimited,refused-stream,http3-post-connect-failure,retriable-status-codes
-            retryPriority:
-              name: envoy.retry_priorities.previous_priorities
-              typedConfig:
-                '@type': type.googleapis.com/envoy.extensions.retry.priority.previous_priorities.v3.PreviousPrioritiesConfig
-                updateFrequency: 2
           routes:
           - match:
               prefix: /
             route:
               cluster: backend
+              retryPolicy:
+                hostSelectionRetryMaxAttempts: "2"
+                numRetries: 1
+                perTryTimeout: 2s
+                rateLimitedRetryBackOff:
+                  maxInterval: 5s
+                  resetHeaders:
+                  - name: retry-after-http
+                  - format: UNIX_TIMESTAMP
+                    name: x-retry-after-http
+                retriableHeaders:
+                - name: x-retry-regex
+                  stringMatch:
+                    safeRegex:
+                      googleRe2: {}
+                      regex: .*
+                - name: x-retry-exact
+                  stringMatch:
+                    exact: exact-value
+                retriableRequestHeaders:
+                - name: :method
+                  stringMatch:
+                    exact: CONNECT
+                - name: :method
+                  stringMatch:
+                    exact: DELETE
+                - name: :method
+                  stringMatch:
+                    exact: GET
+                - name: :method
+                  stringMatch:
+                    exact: HEAD
+                - name: :method
+                  stringMatch:
+                    exact: OPTIONS
+                - name: :method
+                  stringMatch:
+                    exact: PATCH
+                - name: :method
+                  stringMatch:
+                    exact: POST
+                - name: :method
+                  stringMatch:
+                    exact: PUT
+                - name: :method
+                  stringMatch:
+                    exact: TRACE
+                - name: x-retry-prefix
+                  stringMatch:
+                    prefix: prefix-
+                retriableStatusCodes:
+                - 429
+                retryBackOff:
+                  baseInterval: 3s
+                  maxInterval: 4s
+                retryHostPredicate:
+                - name: envoy.retry_host_predicates.previous_hosts
+                  typedConfig:
+                    '@type': type.googleapis.com/envoy.extensions.retry.host.previous_hosts.v3.PreviousHostsPredicate
+                - name: envoy.retry_host_predicates.omit_host_metadata
+                  typedConfig:
+                    '@type': type.googleapis.com/envoy.extensions.retry.host.omit_host_metadata.v3.OmitHostMetadataConfig
+                    metadataMatch:
+                      filterMetadata:
+                        envoy.lb:
+                          test: test
+                retryOn: 5xx,gateway-error,reset,retriable-4xx,connect-failure,envoy-ratelimited,refused-stream,http3-post-connect-failure,retriable-status-codes
+                retryPriority:
+                  name: envoy.retry_priorities.previous_priorities
+                  typedConfig:
+                    '@type': type.googleapis.com/envoy.extensions.retry.priority.previous_priorities.v3.PreviousPrioritiesConfig
+                    updateFrequency: 2
               timeout: 0s
       statPrefix: outbound_127_0_0_1_10001
 name: outbound:127.0.0.1:10001

--- a/pkg/plugins/policies/meshretry/plugin/xds/configurer.go
+++ b/pkg/plugins/policies/meshretry/plugin/xds/configurer.go
@@ -78,7 +78,12 @@ func (c *Configurer) ConfigureRoute(route *envoy_route.RouteConfiguration) error
 	}
 
 	for _, virtualHost := range route.VirtualHosts {
-		virtualHost.RetryPolicy = policy
+		for _, route := range virtualHost.Routes {
+			switch a := route.GetAction().(type) {
+			case *envoy_route.Route_Route:
+				a.Route.RetryPolicy = policy
+			}
+		}
 	}
 
 	return nil


### PR DESCRIPTION
The gateway plugin sets them on the routes so these weren't taking effect given the default retry.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [x] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
