### PR TITLE
fix(kuma-cp): add missing validation for MeshTimeout

### DIFF
--- a/pkg/plugins/policies/meshtimeout/api/v1alpha1/validator_test.go
+++ b/pkg/plugins/policies/meshtimeout/api/v1alpha1/validator_test.go
@@ -78,6 +78,18 @@ to:
     default:
       http:
         requestTimeout: 1s`),
+			Entry("top-level TargetRefKind is MeshHTTPRoute", `
+targetRef:
+  kind: MeshHTTPRoute
+  name: route-1
+to:
+  - targetRef:
+      kind: Mesh
+    default:
+      http:
+        requestTimeout: 1s
+        streamIdleTimeout: 2s
+`),
 		)
 
 		type testCase struct {
@@ -225,9 +237,18 @@ to:
         requestTimeout: 1s
         streamIdleTimeout: 1h
         maxStreamDuration: 1h
-        maxConnectionDuration: 1h`,
+        maxConnectionDuration: 1h
+from:
+  - targetRef:
+      kind: Mesh
+    default:
+      connectionTimeout: 11s`,
 				expected: `
 violations:
+  - field: spec.from
+    message: must not be defined
+  - field: spec.to[0].targetRef.kind
+    message: value is not supported
   - field: spec.to[0].default.connectionTimeout
     message: can't be specified when top-level TargetRef is referencing MeshHTTPRoute
   - field: spec.to[0].default.idleTimeout


### PR DESCRIPTION
### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [X] [Link to relevant issue][1] as well as docs and UI issues --
- [X] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [X] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [X] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [X] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [X] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
