### PR TITLE
feat(webhook): warn/fail if containers use same UID as sidecar

### DIFF
--- a/pkg/plugins/runtime/k8s/webhooks/injector/injector_test.go
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/injector_test.go
@@ -639,6 +639,22 @@ spec:
                   kuma.io/sidecar-injection: enabled`,
 			cfgFile: "inject.ebpf.config.yaml",
 		}),
+		Entry("31. with duplicate container/sidecar uid", testCase{
+			num: "31",
+			mesh: `
+              apiVersion: kuma.io/v1alpha1
+              kind: Mesh
+              metadata:
+                name: default`,
+			namespace: `
+              apiVersion: v1
+              kind: Namespace
+              metadata:
+                name: default
+                labels:
+                  kuma.io/sidecar-injection: enabled`,
+			cfgFile: "inject.config.yaml",
+		}),
 	)
 
 	DescribeTable("should not inject Kuma into a Pod",
@@ -748,56 +764,27 @@ spec:
 		}),
 	)
 
-	Describe("should fail", func() {
-		It("when pod is annotated with the name of non-existing patch", func() {
+	DescribeTable("should fail w/error",
+		func(given testCase) {
 			// setup
-			ctx := context.Background()
-			configFile := "testdata/inject.config.yaml"
-			inputFile := "testdata/inject.shouldfail.1.input.yaml"
+			inputFile := filepath.Join("testdata", fmt.Sprintf("inject.shouldfail.%s.input.yaml", given.num))
 
 			var cfg conf.Injector
-			Expect(config.Load(configFile, &cfg)).To(Succeed())
-
+			Expect(config.Load(filepath.Join("testdata", given.cfgFile), &cfg)).To(Succeed())
 			cfg.CaCertFile = caCertPath
-
-			injector, err := inject.New(
-				cfg,
-				"http://kuma-control-plane.kuma-system:5681",
-				k8sClient,
-				k8s.NewSimpleConverter(),
-				9901,
-				systemNamespace,
-			)
-			Expect(err).To(Succeed())
-
-			mesh := []byte(`
-              apiVersion: kuma.io/v1alpha1
-              kind: Mesh
-              metadata:
-                name: default`)
-
-			namespace := []byte(`
-              apiVersion: v1
-              kind: Namespace
-              metadata:
-                name: default
-                labels:
-                  kuma.io/sidecar-injection: enabled`)
+			injector, err := inject.New(cfg, "http://kuma-control-plane.kuma-system:5681", k8sClient, k8s.NewSimpleConverter(), 9901, systemNamespace)
+			Expect(err).ToNot(HaveOccurred())
 
 			// and create mesh
-			decoder := serializer.
-				NewCodecFactory(k8sClientScheme).
-				UniversalDeserializer()
-
-			obj, _, errMesh := decoder.Decode(mesh, nil, nil)
-			Expect(errMesh).To(Succeed())
-
-			Expect(k8sClient.Create(ctx, obj.(kube_client.Object))).To(Succeed())
-
-			ns, _, errNs := decoder.Decode(namespace, nil, nil)
-			Expect(errNs).To(Succeed())
-
-			Expect(k8sClient.Update(ctx, ns.(kube_client.Object))).To(Succeed())
+			decoder := serializer.NewCodecFactory(k8sClientScheme).UniversalDeserializer()
+			obj, _, errMesh := decoder.Decode([]byte(given.mesh), nil, nil)
+			Expect(errMesh).ToNot(HaveOccurred())
+			errCreate := k8sClient.Create(context.Background(), obj.(kube_client.Object))
+			Expect(errCreate).ToNot(HaveOccurred())
+			ns, _, errNs := decoder.Decode([]byte(given.namespace), nil, nil)
+			Expect(errNs).ToNot(HaveOccurred())
+			errUpd := k8sClient.Update(context.Background(), ns.(kube_client.Object))
+			Expect(errUpd).ToNot(HaveOccurred())
 
 			// given
 			pod := &kube_core.Pod{}
@@ -806,17 +793,54 @@ spec:
 			// when
 			input, err := os.ReadFile(inputFile)
 			// then
-			Expect(err).To(Succeed())
+			Expect(err).ToNot(HaveOccurred())
 			// when
 			err = yaml.Unmarshal(input, pod)
 			// then
-			Expect(err).To(Succeed())
+			Expect(err).ToNot(HaveOccurred())
 
 			By("injecting Kuma")
 			// when
-			err = injector.InjectKuma(ctx, pod)
+			err = injector.InjectKuma(context.Background(), pod)
 			// then
-			Expect(err).ToNot(Succeed())
-		})
-	})
+			Expect(err).To(HaveOccurred())
+			for _, container := range pod.Spec.Containers {
+				Expect(container.Name).To(Not(BeEquivalentTo(k8s_util.KumaSidecarContainerName)))
+			}
+		},
+		Entry("1. Pod annotated with name of non-existing patch", testCase{
+			num: "1",
+			mesh: `
+              apiVersion: kuma.io/v1alpha1
+              kind: Mesh
+              metadata:
+                name: default
+              spec: {}`,
+			namespace: `
+              apiVersion: v1
+              kind: Namespace
+              metadata:
+                name: default
+                labels:
+                  kuma.io/sidecar-injection: enabled`,
+			cfgFile: "inject.config.yaml",
+		}),
+		Entry("2. Pod with existing container using same UID as sidecar", testCase{
+			num: "2",
+			mesh: `
+              apiVersion: kuma.io/v1alpha1
+              kind: Mesh
+              metadata:
+                name: default
+              spec: {}`,
+			namespace: `
+              apiVersion: v1
+              kind: Namespace
+              metadata:
+                name: default
+                labels:
+                  kuma.io/sidecar-injection: enabled`,
+			cfgFile: "inject.config.yaml",
+		}),
+	)
 }, Ordered)

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.31.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.31.golden.yaml
@@ -1,0 +1,167 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    kubectl.kubernetes.io/default-container: busybox
+    kuma.io/envoy-admin-port: "9901"
+    kuma.io/mesh: default
+    kuma.io/sidecar-injected: "true"
+    kuma.io/sidecar-uid: "5678"
+    kuma.io/transparent-proxying: enabled
+    kuma.io/transparent-proxying-ebpf: disabled
+    kuma.io/transparent-proxying-inbound-port: "15006"
+    kuma.io/transparent-proxying-inbound-v6-port: "15010"
+    kuma.io/transparent-proxying-outbound-port: "15001"
+    kuma.io/virtual-probes: enabled
+    kuma.io/virtual-probes-port: "9000"
+  creationTimestamp: null
+  labels:
+    run: busybox
+  name: busybox
+spec:
+  containers:
+  - args:
+    - run
+    - --log-level=info
+    - --concurrency=2
+    env:
+    - name: POD_NAME
+      valueFrom:
+        fieldRef:
+          apiVersion: v1
+          fieldPath: metadata.name
+    - name: POD_NAMESPACE
+      valueFrom:
+        fieldRef:
+          apiVersion: v1
+          fieldPath: metadata.namespace
+    - name: INSTANCE_IP
+      valueFrom:
+        fieldRef:
+          apiVersion: v1
+          fieldPath: status.podIP
+    - name: KUMA_CONTROL_PLANE_CA_CERT
+      value: |
+        -----BEGIN CERTIFICATE-----
+        MIIDMzCCAhugAwIBAgIQDhlInfsXYHamKN+29qnQvzANBgkqhkiG9w0BAQsFADAP
+        MQ0wCwYDVQQDEwRrdW1hMB4XDTIxMDQwMjEwMjIyNloXDTMxMDMzMTEwMjIyNlow
+        DzENMAsGA1UEAxMEa3VtYTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEB
+        AL4GGg+e2O7eA12F0F6v2rr8j2iVSFKepnZtL15lrCds6lqK50sXWOw8PKZp2ihA
+        XJVTSZzKasyLDTAR9VYQjTpE526EzvtdthSagf32QWW+wY6LMpEdexKOOCx2se55
+        Rd97L33yYPfgX15OYliHPD056jjhotHLdN2lpy7+STDvQyRnXAu73YkY37Ed4hI4
+        t/V6soHyEGNcDhm9p5fBGqz0njBbQkp2lTY5/kj42qB7Q6rCM2tbPsEMooeAAw5m
+        hyY4xj0tP9ucqlUz8gc+6o8HDNst8NeJXZktWn+COytjr/NzGgS22kvSDphisJot
+        o0FyoIOdAtxC1qxXXR+XuUUCAwEAAaOBijCBhzAOBgNVHQ8BAf8EBAMCAqQwHQYD
+        VR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMBMA8GA1UdEwEB/wQFMAMBAf8wHQYD
+        VR0OBBYEFKRLkgIzX/OjKw9idepuQ/RMtT+AMCYGA1UdEQQfMB2CCWxvY2FsaG9z
+        dIcQ/QChIwAAAAAAAAAAAAAAATANBgkqhkiG9w0BAQsFAAOCAQEAPs5yJZhoYlGW
+        CpA8dSISivM8/8iBNQ3fVwP63ft0EJLMVGu2RFZ4/UAJ/rUPSGN8xhXSk5+1d56a
+        /kaH9rX0HaRIHHlxA7iPUKxAj44x9LKmqPHToL3XlWY1AXzvicW9d+GM2FaQee+I
+        leaqLbz0AZvlnu271Z1CeaACuU9GljujvyiTTE9naHUEqvHgSpPtilJalyJ5/zIl
+        Z9F0+UWt3TOYMs5g+SCt0MwHTNbisbmewpcFFJzjt2kvtrc9t9dkF81xhcS19w7q
+        h1AeP3RRlLl7bv9EAVXEmIavih/29PA3ZSy+pbYNW7jNJHjMQ4hQ0E+xcCazU/O4
+        ypWGaanvPg==
+        -----END CERTIFICATE-----
+    - name: KUMA_CONTROL_PLANE_URL
+      value: http://kuma-control-plane.kuma-system:5681
+    - name: KUMA_DATAPLANE_DRAIN_TIME
+      value: 31s
+    - name: KUMA_DATAPLANE_MESH
+      value: default
+    - name: KUMA_DATAPLANE_NAME
+      value: $(POD_NAME).$(POD_NAMESPACE)
+    - name: KUMA_DATAPLANE_RUNTIME_TOKEN_PATH
+      value: /var/run/secrets/kubernetes.io/serviceaccount/token
+    - name: KUMA_DNS_ENABLED
+      value: "false"
+    image: kuma/kuma-sidecar:latest
+    imagePullPolicy: IfNotPresent
+    livenessProbe:
+      failureThreshold: 212
+      httpGet:
+        path: /ready
+        port: 9901
+      initialDelaySeconds: 260
+      periodSeconds: 25
+      successThreshold: 1
+      timeoutSeconds: 23
+    name: kuma-sidecar
+    readinessProbe:
+      failureThreshold: 112
+      httpGet:
+        path: /ready
+        port: 9901
+      initialDelaySeconds: 11
+      periodSeconds: 15
+      successThreshold: 11
+      timeoutSeconds: 13
+    resources:
+      limits:
+        cpu: 1100m
+        memory: 1512Mi
+      requests:
+        cpu: 150m
+        memory: 164Mi
+    securityContext:
+      readOnlyRootFilesystem: true
+      runAsGroup: 5678
+      runAsUser: 5678
+    volumeMounts:
+    - mountPath: /tmp
+      name: kuma-sidecar-tmp
+  - image: busybox
+    name: busybox
+    resources: {}
+    securityContext:
+      runAsUser: 10000
+  initContainers:
+  - command:
+    - sh
+    - -c
+    - sleep 5
+    image: busybox
+    name: init
+    resources: {}
+    securityContext:
+      runAsUser: 5678
+  - args:
+    - --redirect-outbound-port
+    - "15001"
+    - --redirect-inbound=true
+    - --redirect-inbound-port
+    - "15006"
+    - --redirect-inbound-port-v6
+    - "15010"
+    - --kuma-dp-uid
+    - "5678"
+    - --exclude-inbound-ports
+    - ""
+    - --exclude-outbound-ports
+    - ""
+    - --verbose
+    - --skip-resolv-conf
+    command:
+    - /usr/bin/kumactl
+    - install
+    - transparent-proxy
+    image: kuma/kuma-init:latest
+    imagePullPolicy: IfNotPresent
+    name: kuma-init
+    resources:
+      limits:
+        cpu: 100m
+        memory: 50M
+      requests:
+        cpu: 20m
+        memory: 20M
+    securityContext:
+      capabilities:
+        add:
+        - NET_ADMIN
+        - NET_RAW
+      runAsGroup: 0
+      runAsUser: 0
+  volumes:
+  - emptyDir: {}
+    name: kuma-sidecar-tmp
+status: {}

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.31.input.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.31.input.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: busybox
+  labels:
+    run: busybox
+spec:
+  containers:
+    - name: busybox
+      image: busybox
+      securityContext:
+        runAsUser: 10000
+  initContainers:
+    - name: init
+      image: busybox
+      command: ['sh', '-c', 'sleep 5']
+      securityContext:
+        runAsUser: 5678

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.shouldfail.2.input.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.shouldfail.2.input.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: busybox
+  labels:
+    run: busybox
+spec:
+  containers:
+    - name: busybox
+      image: busybox
+      securityContext:
+        runAsUser: 5678


### PR DESCRIPTION
If we attempt injection of the sidecar into a pod where a container shares the sidecar UID, the following behavior now happens:

- Init container: Warning printed to the logs, this use case might be deliberate (to give internet access to some init container)
- Regular container: Now errors. This is unpredictable / unsupported behavior.

This changes _existing_ behavior, but is not really breaking. Because this happens to affect you then your state is probably broken anyway.

Also refactored the `should fail` test setup for the injector as we now have multiple tests (converted to `DescribeTable` for consistency with the others).

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [x] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
