### PR TITLE
feat(kuma-cp/helpers): skip iteration when only one arg. in tags merge

### DIFF
--- a/api/mesh/v1alpha1/dataplane_helpers.go
+++ b/api/mesh/v1alpha1/dataplane_helpers.go
@@ -315,6 +315,12 @@ func (t SingleValueTagSet) Keys() []string {
 }
 
 func Merge[TagSet ~map[string]string](other ...TagSet) TagSet {
+	// Small optimization, to not iterate over the whole map if only one
+	// argument is provided
+	if len(other) == 1 {
+		return other[0]
+	}
+
 	merged := TagSet{}
 
 	for _, t := range other {


### PR DESCRIPTION
Very small optimization in dataplane helpers for tags merging, to not iterate over the whole map if only one argument is passed, as we can safely return the argument itself then.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues
  - https://github.com/kumahq/kuma/pull/7030#discussion_r1230725147
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS
  - It won't as it's very small optimization
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s)
  - There is no new tests as it's very small optimization
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)?
  - There is no need
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? 
  - There is no need
- [x] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?
> Changelog: feat(kuma-cp/helpers): skip iteration over the whole map when only one argument is passed in dataplane helper function: `TagSet.Merge`

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
