### PR TITLE
feat(kuma-cp): implement MeshTrafficPermisson for ExternalServices with ZoneEgress

### DIFF
--- a/pkg/plugins/policies/core/xds/listeners.go
+++ b/pkg/plugins/policies/core/xds/listeners.go
@@ -15,7 +15,7 @@ import (
 type Listeners struct {
 	Inbound         map[core_rules.InboundListener]*envoy_listener.Listener
 	Outbound        map[mesh_proto.OutboundInterface]*envoy_listener.Listener
-	Egress          map[core_rules.InboundListener]*envoy_listener.Listener
+	Egress          *envoy_listener.Listener
 	Gateway         map[core_rules.InboundListener]*envoy_listener.Listener
 	Ipv4Passthrough *envoy_listener.Listener
 	Ipv6Passthrough *envoy_listener.Listener
@@ -26,7 +26,6 @@ func GatherListeners(rs *xds.ResourceSet) Listeners {
 	listeners := Listeners{
 		Inbound:      map[core_rules.InboundListener]*envoy_listener.Listener{},
 		Outbound:     map[mesh_proto.OutboundInterface]*envoy_listener.Listener{},
-		Egress:       map[core_rules.InboundListener]*envoy_listener.Listener{},
 		Gateway:      map[core_rules.InboundListener]*envoy_listener.Listener{},
 		DirectAccess: map[generator.Endpoint]*envoy_listener.Listener{},
 	}
@@ -47,10 +46,7 @@ func GatherListeners(rs *xds.ResourceSet) Listeners {
 				Port:    address.GetPortValue(),
 			}] = listener
 		case egress_generator.OriginEgress:
-			listeners.Egress[core_rules.InboundListener{
-				Address: address.GetAddress(),
-				Port:    address.GetPortValue(),
-			}] = listener
+			listeners.Egress = listener
 		case generator.OriginTransparent:
 			switch listener.Name {
 			case generator.OutboundNameIPv4:

--- a/pkg/plugins/policies/core/xds/listeners.go
+++ b/pkg/plugins/policies/core/xds/listeners.go
@@ -26,6 +26,7 @@ func GatherListeners(rs *xds.ResourceSet) Listeners {
 	listeners := Listeners{
 		Inbound:      map[core_rules.InboundListener]*envoy_listener.Listener{},
 		Outbound:     map[mesh_proto.OutboundInterface]*envoy_listener.Listener{},
+		Egress:       map[core_rules.InboundListener]*envoy_listener.Listener{},
 		Gateway:      map[core_rules.InboundListener]*envoy_listener.Listener{},
 		DirectAccess: map[generator.Endpoint]*envoy_listener.Listener{},
 	}
@@ -46,7 +47,7 @@ func GatherListeners(rs *xds.ResourceSet) Listeners {
 				Port:    address.GetPortValue(),
 			}] = listener
 		case egress_generator.OriginEgress:
-			listeners.Inbound[core_rules.InboundListener{
+			listeners.Egress[core_rules.InboundListener{
 				Address: address.GetAddress(),
 				Port:    address.GetPortValue(),
 			}] = listener
@@ -71,6 +72,5 @@ func GatherListeners(rs *xds.ResourceSet) Listeners {
 			continue
 		}
 	}
-
 	return listeners
 }

--- a/pkg/plugins/policies/meshtrafficpermission/plugin/v1alpha1/plugin.go
+++ b/pkg/plugins/policies/meshtrafficpermission/plugin/v1alpha1/plugin.go
@@ -1,6 +1,8 @@
 package v1alpha1
 
 import (
+	"fmt"
+
 	envoy_listener "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
 	envoy_resource "github.com/envoyproxy/go-control-plane/pkg/resource/v3"
 
@@ -10,6 +12,7 @@ import (
 	core_xds "github.com/kumahq/kuma/pkg/core/xds"
 	"github.com/kumahq/kuma/pkg/plugins/policies/core/matchers"
 	core_rules "github.com/kumahq/kuma/pkg/plugins/policies/core/rules"
+	policies_xds "github.com/kumahq/kuma/pkg/plugins/policies/core/xds"
 	api "github.com/kumahq/kuma/pkg/plugins/policies/meshtrafficpermission/api/v1alpha1"
 	v3 "github.com/kumahq/kuma/pkg/plugins/policies/meshtrafficpermission/xds"
 	xds_context "github.com/kumahq/kuma/pkg/xds/context"
@@ -17,8 +20,8 @@ import (
 )
 
 var (
-	_   core_plugins.PolicyPlugin = &plugin{}
-	log                           = core.Log.WithName("MeshTrafficPermission")
+	_   core_plugins.EgressPolicyPlugin = &plugin{}
+	log                                 = core.Log.WithName("MeshTrafficPermission")
 )
 
 type plugin struct{}
@@ -31,26 +34,27 @@ func (p plugin) MatchedPolicies(dataplane *core_mesh.DataplaneResource, resource
 	return matchers.MatchedPolicies(api.MeshTrafficPermissionType, dataplane, resources)
 }
 
+func (p plugin) EgressMatchedPolicies(es *core_mesh.ExternalServiceResource, resources xds_context.Resources) (core_xds.TypedMatchingPolicies, error) {
+	return matchers.EgressMatchedPolicies(api.MeshTrafficPermissionType, es, resources)
+}
+
 func (p plugin) Apply(rs *core_xds.ResourceSet, ctx xds_context.Context, proxy *core_xds.Proxy) error {
-	if proxy.Dataplane == nil {
-		// MeshTrafficPermission policy is applied only on DPP
-		// todo(lobkovilya): add support for ExternalService and ZoneEgress, https://github.com/kumahq/kuma/issues/5050
-		return nil
+	if proxy.ZoneEgressProxy != nil {
+		return p.configureEgress(rs, proxy)
 	}
 
-	if proxy.Dataplane.Spec.IsBuiltinGateway() {
-		return nil
-	}
-
-	mtp, ok := proxy.Policies.Dynamic[api.MeshTrafficPermissionType]
-	if !ok {
+	if proxy.Dataplane == nil || proxy.Dataplane.Spec.IsBuiltinGateway() {
 		return nil
 	}
 
 	if !ctx.Mesh.Resource.MTLSEnabled() {
 		log.V(1).Info("skip applying MeshTrafficPermission, MTLS is disabled",
-			"proxyName", proxy.Dataplane.GetMeta().GetName(),
 			"mesh", ctx.Mesh.Resource.GetMeta().GetName())
+		return nil
+	}
+
+	mtp, ok := proxy.Policies.Dynamic[api.MeshTrafficPermissionType]
+	if !ok {
 		return nil
 	}
 
@@ -79,6 +83,49 @@ func (p plugin) Apply(rs *core_xds.ResourceSet, ctx xds_context.Context, proxy *
 		for _, filterChain := range listener.FilterChains {
 			if err := configurer.Configure(filterChain); err != nil {
 				return err
+			}
+		}
+	}
+	return nil
+}
+
+func (p plugin) configureEgress(rs *core_xds.ResourceSet, proxy *core_xds.Proxy) error {
+	listeners := policies_xds.GatherListeners(rs)
+	for _, resource := range proxy.ZoneEgressProxy.MeshResourcesList {
+		if !resource.Mesh.MTLSEnabled() {
+			log.V(1).Info("skip applying MeshTrafficPermission, MTLS is disabled",
+				"mesh", resource.Mesh.GetMeta().GetName())
+			continue
+		}
+		for _, es := range resource.ExternalServices {
+			meshName := resource.Mesh.GetMeta().GetName()
+			esName := es.Meta.GetName()
+			policies, ok := resource.Dynamic[esName]
+			if !ok {
+				continue
+			}
+			mtp, ok := policies[api.MeshTrafficPermissionType]
+			if !ok {
+				continue
+			}
+			l := listeners.Egress[core_rules.InboundListener{
+				Address: proxy.ZoneEgressProxy.ZoneEgressResource.Spec.Networking.Address,
+				Port:    proxy.ZoneEgressProxy.ZoneEgressResource.Spec.Networking.Port,
+			}]
+
+			for _, rule := range mtp.FromRules.Rules {
+				configurer := &v3.RBACConfigurer{
+					StatsName: l.Name,
+					Rules:     rule,
+					Mesh:      resource.Mesh.GetMeta().GetName(),
+				}
+				for _, filterChain := range l.FilterChains {
+					if filterChain.Name == fmt.Sprintf("%s_%s", esName, meshName) {
+						if err := configurer.Configure(filterChain); err != nil {
+							return err
+						}
+					}
+				}
 			}
 		}
 	}

--- a/pkg/plugins/policies/meshtrafficpermission/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshtrafficpermission/plugin/v1alpha1/plugin_test.go
@@ -15,96 +15,100 @@ import (
 	policies_api "github.com/kumahq/kuma/pkg/plugins/policies/meshtrafficpermission/api/v1alpha1"
 	meshtrafficpermission "github.com/kumahq/kuma/pkg/plugins/policies/meshtrafficpermission/plugin/v1alpha1"
 	"github.com/kumahq/kuma/pkg/test/matchers"
+	"github.com/kumahq/kuma/pkg/test/resources/builders"
 	test_model "github.com/kumahq/kuma/pkg/test/resources/model"
 	util_proto "github.com/kumahq/kuma/pkg/util/proto"
 	xds_context "github.com/kumahq/kuma/pkg/xds/context"
 	"github.com/kumahq/kuma/pkg/xds/envoy"
 	"github.com/kumahq/kuma/pkg/xds/envoy/listeners"
 	"github.com/kumahq/kuma/pkg/xds/generator"
+	"github.com/kumahq/kuma/pkg/xds/generator/egress"
 )
 
-var _ = Describe("Apply", func() {
-	It("should enrich matching listener with RBAC filter", func() {
-		// given
-		rs := core_xds.NewResourceSet()
+var _ = Describe("RBAC", func() {
+	Context("for Dataplane", func() {
+		It("should enrich matching listener with RBAC filter", func() {
+			// given
+			rs := core_xds.NewResourceSet()
 
-		// listener that matches
-		listener, err := listeners.NewListenerBuilder(envoy.APIV3).
-			Configure(listeners.InboundListener("test_listener", "192.168.0.1", 8080, core_xds.SocketAddressProtocolTCP)).
-			Configure(listeners.FilterChain(listeners.NewFilterChainBuilder(envoy.APIV3).
-				Configure(listeners.HttpConnectionManager("test_listener", false)))).
-			Build()
-		Expect(err).ToNot(HaveOccurred())
-		rs.Add(&core_xds.Resource{
-			Name:     listener.GetName(),
-			Origin:   generator.OriginInbound,
-			Resource: listener,
-		})
+			// listener that matches
+			listener, err := listeners.NewListenerBuilder(envoy.APIV3).
+				Configure(listeners.InboundListener("test_listener", "192.168.0.1", 8080, core_xds.SocketAddressProtocolTCP)).
+				Configure(listeners.FilterChain(listeners.NewFilterChainBuilder(envoy.APIV3).
+					Configure(listeners.HttpConnectionManager("test_listener", false)))).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+			rs.Add(&core_xds.Resource{
+				Name:     listener.GetName(),
+				Origin:   generator.OriginInbound,
+				Resource: listener,
+			})
 
-		// listener that is originated from inbound proxy generator but won't match
-		listener2, err := listeners.NewListenerBuilder(envoy.APIV3).
-			Configure(listeners.InboundListener("test_listener2", "192.168.0.1", 8081, core_xds.SocketAddressProtocolTCP)).
-			Configure(listeners.FilterChain(listeners.NewFilterChainBuilder(envoy.APIV3).
-				Configure(listeners.HttpConnectionManager("test_listener2", false)))).
-			Build()
-		Expect(err).ToNot(HaveOccurred())
-		rs.Add(&core_xds.Resource{
-			Name:     listener2.GetName(),
-			Origin:   generator.OriginInbound,
-			Resource: listener2,
-		})
+			// listener that is originated from inbound proxy generator but won't match
+			listener2, err := listeners.NewListenerBuilder(envoy.APIV3).
+				Configure(listeners.InboundListener("test_listener2", "192.168.0.1", 8081, core_xds.SocketAddressProtocolTCP)).
+				Configure(listeners.FilterChain(listeners.NewFilterChainBuilder(envoy.APIV3).
+					Configure(listeners.HttpConnectionManager("test_listener2", false)))).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+			rs.Add(&core_xds.Resource{
+				Name:     listener2.GetName(),
+				Origin:   generator.OriginInbound,
+				Resource: listener2,
+			})
 
-		// listener that matches but is not originated from inbound proxy generator
-		listener3, err := listeners.NewListenerBuilder(envoy.APIV3).
-			Configure(listeners.InboundListener("test_listener3", "192.168.0.1", 8082, core_xds.SocketAddressProtocolTCP)).
-			Configure(listeners.FilterChain(listeners.NewFilterChainBuilder(envoy.APIV3).
-				Configure(listeners.HttpConnectionManager("test_listener3", false)))).
-			Build()
-		Expect(err).ToNot(HaveOccurred())
-		rs.Add(&core_xds.Resource{
-			Name:     listener3.GetName(),
-			Origin:   "not-inbound-origin",
-			Resource: listener3,
-		})
+			// listener that matches but is not originated from inbound proxy generator
+			listener3, err := listeners.NewListenerBuilder(envoy.APIV3).
+				Configure(listeners.InboundListener("test_listener3", "192.168.0.1", 8082, core_xds.SocketAddressProtocolTCP)).
+				Configure(listeners.FilterChain(listeners.NewFilterChainBuilder(envoy.APIV3).
+					Configure(listeners.HttpConnectionManager("test_listener3", false)))).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+			rs.Add(&core_xds.Resource{
+				Name:     listener3.GetName(),
+				Origin:   "not-inbound-origin",
+				Resource: listener3,
+			})
 
-		// mesh with enabled mTLS
-		ctx := xds_context.Context{
-			Mesh: xds_context.MeshContext{
-				Resource: &mesh.MeshResource{
-					Meta: &test_model.ResourceMeta{Name: "mesh-1", Mesh: core_model.NoMesh},
-					Spec: &mesh_proto.Mesh{
-						Mtls: &mesh_proto.Mesh_Mtls{
-							EnabledBackend: "builtin-1",
-							Backends: []*mesh_proto.CertificateAuthorityBackend{
-								{
-									Name: "builtin-1",
-									Type: "builtin",
+			// mesh with enabled mTLS
+			ctx := xds_context.Context{
+				Mesh: xds_context.MeshContext{
+					Resource: &mesh.MeshResource{
+						Meta: &test_model.ResourceMeta{Name: "mesh-1", Mesh: core_model.NoMesh},
+						Spec: &mesh_proto.Mesh{
+							Mtls: &mesh_proto.Mesh_Mtls{
+								EnabledBackend: "builtin-1",
+								Backends: []*mesh_proto.CertificateAuthorityBackend{
+									{
+										Name: "builtin-1",
+										Type: "builtin",
+									},
 								},
 							},
 						},
 					},
 				},
-			},
-		}
+			}
 
-		proxy := &core_xds.Proxy{
-			Dataplane: &mesh.DataplaneResource{
-				Meta: &test_model.ResourceMeta{Name: "dp1", Mesh: "mesh-1"},
-			},
-			Policies: core_xds.MatchedPolicies{
-				Dynamic: map[core_model.ResourceType]core_xds.TypedMatchingPolicies{
-					policies_api.MeshTrafficPermissionType: {
-						FromRules: core_rules.FromRules{
-							Rules: map[core_rules.InboundListener]core_rules.Rules{
-								{
-									Address: "192.168.0.1", Port: 8080,
-								}: {
+			proxy := &core_xds.Proxy{
+				Dataplane: &mesh.DataplaneResource{
+					Meta: &test_model.ResourceMeta{Name: "dp1", Mesh: "mesh-1"},
+				},
+				Policies: core_xds.MatchedPolicies{
+					Dynamic: map[core_model.ResourceType]core_xds.TypedMatchingPolicies{
+						policies_api.MeshTrafficPermissionType: {
+							FromRules: core_rules.FromRules{
+								Rules: map[core_rules.InboundListener]core_rules.Rules{
 									{
-										Subset: []core_rules.Tag{
-											{Key: mesh_proto.ServiceTag, Value: "frontend"},
-										},
-										Conf: policies_api.Conf{
-											Action: "Allow",
+										Address: "192.168.0.1", Port: 8080,
+									}: {
+										{
+											Subset: []core_rules.Tag{
+												{Key: mesh_proto.ServiceTag, Value: "frontend"},
+											},
+											Conf: policies_api.Conf{
+												Action: "Allow",
+											},
 										},
 									},
 								},
@@ -112,19 +116,190 @@ var _ = Describe("Apply", func() {
 						},
 					},
 				},
-			},
-		}
+			}
 
-		// when
-		p := meshtrafficpermission.NewPlugin().(plugins.PolicyPlugin)
-		err = p.Apply(rs, ctx, proxy)
-		Expect(err).ToNot(HaveOccurred())
+			// when
+			p := meshtrafficpermission.NewPlugin().(plugins.PolicyPlugin)
+			err = p.Apply(rs, ctx, proxy)
+			Expect(err).ToNot(HaveOccurred())
 
-		// then
-		resp, err := rs.List().ToDeltaDiscoveryResponse()
-		Expect(err).ToNot(HaveOccurred())
-		bytes, err := util_proto.ToYAML(resp)
-		Expect(err).ToNot(HaveOccurred())
-		Expect(bytes).To(matchers.MatchGoldenYAML(path.Join("testdata", "apply.golden.yaml")))
+			// then
+			resp, err := rs.List().ToDeltaDiscoveryResponse()
+			Expect(err).ToNot(HaveOccurred())
+			bytes, err := util_proto.ToYAML(resp)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(bytes).To(matchers.MatchGoldenYAML(path.Join("testdata", "apply.golden.yaml")))
+		})
+	})
+
+	Context("for ZoneEgress", func() {
+		It("should enrich matching listener with RBAC filter", func() {
+			// given
+			rs := core_xds.NewResourceSet()
+
+			// listener that matches
+			listener, err := listeners.NewListenerBuilder(envoy.APIV3).
+				Configure(listeners.InboundListener("test_listener", "192.168.0.1", 10002, core_xds.SocketAddressProtocolTCP)).
+				Configure(
+					listeners.FilterChain(listeners.NewFilterChainBuilder(envoy.APIV3).Configure(
+						listeners.Name("external-service-1_mesh-1"),
+						listeners.MatchTransportProtocol("tls"),
+						listeners.MatchServerNames("external-service-1{mesh=mesh-1}"),
+						listeners.HttpConnectionManager("external-service-1", false),
+					)),
+					listeners.FilterChain(listeners.NewFilterChainBuilder(envoy.APIV3).Configure(
+						listeners.Name("external-service-2_mesh-1"),
+						listeners.MatchTransportProtocol("tls"),
+						listeners.MatchServerNames("external-service-2{mesh=mesh-1}"),
+						listeners.TCPProxy("external-service-2"),
+					)),
+					listeners.FilterChain(listeners.NewFilterChainBuilder(envoy.APIV3).Configure(
+						listeners.Name("external-service-1_mesh-2"),
+						listeners.MatchTransportProtocol("tls"),
+						listeners.MatchServerNames("external-service-1{mesh=mesh-2}"),
+						listeners.TCPProxy("external-service-1"),
+					)),
+					listeners.FilterChain(listeners.NewFilterChainBuilder(envoy.APIV3).Configure(
+						listeners.Name("internal-service-1_mesh-1"),
+						listeners.MatchTransportProtocol("tls"),
+						listeners.MatchServerNames("internal-service-1{mesh=mesh-1}"),
+						listeners.TCPProxy("internal-service-1"),
+					)),
+				).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+			rs.Add(&core_xds.Resource{
+				Name:     listener.GetName(),
+				Origin:   egress.OriginEgress,
+				Resource: listener,
+			})
+
+			// mesh with enabled mTLS and egress
+			ctx := xds_context.Context{
+				Mesh: xds_context.MeshContext{
+					Resource: &mesh.MeshResource{
+						Meta: &test_model.ResourceMeta{Name: "mesh-1", Mesh: core_model.NoMesh},
+						Spec: &mesh_proto.Mesh{
+							Mtls: &mesh_proto.Mesh_Mtls{
+								EnabledBackend: "builtin-1",
+								Backends: []*mesh_proto.CertificateAuthorityBackend{
+									{
+										Name: "builtin-1",
+										Type: "builtin",
+									},
+								},
+							},
+							Routing: &mesh_proto.Routing{
+								ZoneEgress: true,
+							},
+						},
+					},
+				},
+			}
+
+			proxy := &core_xds.Proxy{
+				APIVersion: envoy.APIV3,
+				ZoneEgressProxy: &core_xds.ZoneEgressProxy{
+					ZoneEgressResource: &mesh.ZoneEgressResource{
+						Meta: &test_model.ResourceMeta{Name: "dp1", Mesh: "mesh-1"},
+						Spec: &mesh_proto.ZoneEgress{
+							Networking: &mesh_proto.ZoneEgress_Networking{
+								Address: "192.168.0.1",
+								Port:    10002,
+							},
+						},
+					},
+					ZoneIngresses: []*mesh.ZoneIngressResource{},
+					MeshResourcesList: []*core_xds.MeshResources{
+						{
+							Mesh: builders.Mesh().WithName("mesh-1").WithEnabledMTLSBackend("ca-1").WithBuiltinMTLSBackend("ca-1").Build(),
+							ExternalServices: []*mesh.ExternalServiceResource{
+								{
+									Meta: &test_model.ResourceMeta{
+										Mesh: "mesh-1",
+										Name: "external-service-1",
+									},
+									Spec: &mesh_proto.ExternalService{
+										Tags: map[string]string{
+											"kuma.io/service": "external-service-1",
+										},
+										Networking: &mesh_proto.ExternalService_Networking{
+											Address: "externalservice-1.org",
+										},
+									},
+								},
+							},
+							Dynamic: core_xds.ExternalServiceDynamicPolicies{
+								"external-service-1": {
+									policies_api.MeshTrafficPermissionType: core_xds.TypedMatchingPolicies{
+										FromRules: core_rules.FromRules{
+											Rules: map[core_rules.InboundListener]core_rules.Rules{
+												{
+													Address: "192.168.0.1", Port: 10002,
+												}: {
+													{
+														Subset: core_rules.MeshService("frontend"),
+														Conf:   policies_api.Conf{Action: policies_api.Allow},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+						{
+							Mesh: builders.Mesh().WithName("mesh-2").WithEnabledMTLSBackend("ca-2").WithBuiltinMTLSBackend("ca-2").Build(),
+							ExternalServices: []*mesh.ExternalServiceResource{
+								{
+									Meta: &test_model.ResourceMeta{
+										Mesh: "mesh-2",
+										Name: "external-service-1",
+									},
+									Spec: &mesh_proto.ExternalService{
+										Tags: map[string]string{
+											"kuma.io/service": "external-service-1",
+										},
+										Networking: &mesh_proto.ExternalService_Networking{
+											Address: "externalservice-1.org",
+										},
+									},
+								},
+							},
+							Dynamic: core_xds.ExternalServiceDynamicPolicies{
+								"external-service-1": {
+									policies_api.MeshTrafficPermissionType: core_xds.TypedMatchingPolicies{
+										FromRules: core_rules.FromRules{
+											Rules: map[core_rules.InboundListener]core_rules.Rules{
+												{
+													Address: "192.168.0.1", Port: 10002,
+												}: {
+													{
+														Subset: core_rules.MeshSubset(),
+														Conf:   policies_api.Conf{Action: policies_api.Allow},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+
+			// when
+			p := meshtrafficpermission.NewPlugin().(plugins.PolicyPlugin)
+			err = p.Apply(rs, ctx, proxy)
+			Expect(err).ToNot(HaveOccurred())
+
+			// then
+			resp, err := rs.List().ToDeltaDiscoveryResponse()
+			Expect(err).ToNot(HaveOccurred())
+			bytes, err := util_proto.ToYAML(resp)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(bytes).To(matchers.MatchGoldenYAML(path.Join("testdata", "apply-egress.golden.yaml")))
+		})
 	})
 })

--- a/pkg/plugins/policies/meshtrafficpermission/plugin/v1alpha1/testdata/apply-egress.golden.yaml
+++ b/pkg/plugins/policies/meshtrafficpermission/plugin/v1alpha1/testdata/apply-egress.golden.yaml
@@ -1,0 +1,66 @@
+resources:
+- name: test_listener
+  resource:
+    '@type': type.googleapis.com/envoy.config.listener.v3.Listener
+    address:
+      socketAddress:
+        address: 192.168.0.1
+        portValue: 10002
+    enableReusePort: false
+    filterChains:
+    - filterChainMatch:
+        serverNames:
+        - external-service-1{mesh=mesh-1}
+        transportProtocol: tls
+      filters:
+      - name: envoy.filters.network.rbac
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.filters.network.rbac.v3.RBAC
+          rules:
+            policies:
+              MeshTrafficPermission:
+                permissions:
+                - any: true
+                principals:
+                - authenticated:
+                    principalName:
+                      exact: spiffe://mesh-1/frontend
+          statPrefix: test_listener.
+      - name: envoy.filters.network.http_connection_manager
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+          httpFilters:
+          - name: envoy.filters.http.router
+            typedConfig:
+              '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+          statPrefix: external-service-1
+      name: external-service-1_mesh-1
+    - filterChainMatch:
+        serverNames:
+        - external-service-2{mesh=mesh-1}
+        transportProtocol: tls
+      name: external-service-2_mesh-1
+    - filterChainMatch:
+        serverNames:
+        - external-service-1{mesh=mesh-2}
+        transportProtocol: tls
+      filters:
+      - name: envoy.filters.network.rbac
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.filters.network.rbac.v3.RBAC
+          rules:
+            policies:
+              MeshTrafficPermission:
+                permissions:
+                - any: true
+                principals:
+                - any: true
+          statPrefix: test_listener.
+      name: external-service-1_mesh-2
+    - filterChainMatch:
+        serverNames:
+        - internal-service-1{mesh=mesh-1}
+        transportProtocol: tls
+      name: internal-service-1_mesh-1
+    name: test_listener
+    trafficDirection: INBOUND

--- a/pkg/test/resources/builders/mesh_builder.go
+++ b/pkg/test/resources/builders/mesh_builder.go
@@ -55,7 +55,9 @@ func (m *MeshBuilder) WithEnabledMTLSBackend(name string) *MeshBuilder {
 }
 
 func (m *MeshBuilder) WithBuiltinMTLSBackend(name string) *MeshBuilder {
-	m.res.Spec.Mtls = &mesh_proto.Mesh_Mtls{}
+	if m.res.Spec.Mtls == nil {
+		m.res.Spec.Mtls = &mesh_proto.Mesh_Mtls{}
+	}
 	return m.AddBuiltinMTLSBackend(name)
 }
 

--- a/pkg/xds/envoy/listeners/filter_chain_configurers.go
+++ b/pkg/xds/envoy/listeners/filter_chain_configurers.go
@@ -246,6 +246,13 @@ func Retry(
 		}))
 }
 
+func Name(name string) FilterChainBuilderOpt {
+	return AddFilterChainConfigurer(
+		&v3.FilterChainNameConfigurer{
+			Name: name,
+		})
+}
+
 func Timeout(timeout *mesh_proto.Timeout_Conf, protocol core_mesh.Protocol) FilterChainBuilderOpt {
 	return AddFilterChainConfigurer(&v3.TimeoutConfigurer{
 		Conf:     timeout,

--- a/pkg/xds/envoy/listeners/v3/filter_chain_name_configurer.go
+++ b/pkg/xds/envoy/listeners/v3/filter_chain_name_configurer.go
@@ -1,0 +1,12 @@
+package v3
+
+import envoy_listener "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
+
+type FilterChainNameConfigurer struct {
+	Name string
+}
+
+func (f *FilterChainNameConfigurer) Configure(filterChain *envoy_listener.FilterChain) error {
+	filterChain.Name = f.Name
+	return nil
+}

--- a/pkg/xds/envoy/names/resource_names.go
+++ b/pkg/xds/envoy/names/resource_names.go
@@ -110,3 +110,7 @@ func GetMeshClusterName(meshName string, serviceName string) string {
 func GetSecretName(category string, scope string, identifier string) string {
 	return Join(category, scope, identifier)
 }
+
+func GetEgressFilterChainName(serviceName string, meshName string) string {
+	return fmt.Sprintf("%s_%s", serviceName, meshName)
+}

--- a/pkg/xds/generator/egress/external_services_generator.go
+++ b/pkg/xds/generator/egress/external_services_generator.go
@@ -1,6 +1,8 @@
 package egress
 
 import (
+	"fmt"
+
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	core_xds "github.com/kumahq/kuma/pkg/core/xds"
@@ -172,6 +174,7 @@ func (g *ExternalServicesGenerator) addFilterChains(
 			)
 
 			filterChainBuilder := envoy_listeners.NewFilterChainBuilder(apiVersion).Configure(
+				envoy_listeners.Name(fmt.Sprintf("%s_%s", serviceName, meshName)),
 				envoy_listeners.ServerSideMTLS(meshResources.Mesh, secretsTracker),
 				envoy_listeners.MatchTransportProtocol("tls"),
 				envoy_listeners.MatchServerNames(sni),

--- a/pkg/xds/generator/egress/external_services_generator.go
+++ b/pkg/xds/generator/egress/external_services_generator.go
@@ -1,8 +1,6 @@
 package egress
 
 import (
-	"fmt"
-
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	core_xds "github.com/kumahq/kuma/pkg/core/xds"
@@ -10,6 +8,7 @@ import (
 	envoy_common "github.com/kumahq/kuma/pkg/xds/envoy"
 	envoy_clusters "github.com/kumahq/kuma/pkg/xds/envoy/clusters"
 	envoy_listeners "github.com/kumahq/kuma/pkg/xds/envoy/listeners"
+	"github.com/kumahq/kuma/pkg/xds/envoy/names"
 	envoy_names "github.com/kumahq/kuma/pkg/xds/envoy/names"
 	"github.com/kumahq/kuma/pkg/xds/envoy/tags"
 	"github.com/kumahq/kuma/pkg/xds/envoy/tls"
@@ -174,7 +173,7 @@ func (g *ExternalServicesGenerator) addFilterChains(
 			)
 
 			filterChainBuilder := envoy_listeners.NewFilterChainBuilder(apiVersion).Configure(
-				envoy_listeners.Name(fmt.Sprintf("%s_%s", serviceName, meshName)),
+				envoy_listeners.Name(names.GetEgressFilterChainName(serviceName, meshName)),
 				envoy_listeners.ServerSideMTLS(meshResources.Mesh, secretsTracker),
 				envoy_listeners.MatchTransportProtocol("tls"),
 				envoy_listeners.MatchServerNames(sni),

--- a/pkg/xds/generator/egress/generator.go
+++ b/pkg/xds/generator/egress/generator.go
@@ -122,7 +122,6 @@ func (g Generator) Generate(
 
 		resources.AddSet(rs)
 	}
-
 	return resources, nil
 }
 

--- a/pkg/xds/generator/egress/testdata/01.externalservice-only.golden.yaml
+++ b/pkg/xds/generator/egress/testdata/01.externalservice-only.golden.yaml
@@ -76,6 +76,7 @@ resources:
                   cluster: mesh-1:externalservice-1
                   timeout: 0s
           statPrefix: externalservice-1
+      name: externalservice-1_mesh-1
       transportSocket:
         name: envoy.transport_sockets.tls
         typedConfig:

--- a/pkg/xds/generator/egress/testdata/03.mixed-services.golden.yaml
+++ b/pkg/xds/generator/egress/testdata/03.mixed-services.golden.yaml
@@ -233,6 +233,7 @@ resources:
                   cluster: mesh-1:externalservice-1
                   timeout: 0s
           statPrefix: externalservice-1
+      name: externalservice-1_mesh-1
       transportSocket:
         name: envoy.transport_sockets.tls
         typedConfig:
@@ -292,6 +293,7 @@ resources:
                   cluster: mesh-1:externalservice-2
                   timeout: 0s
           statPrefix: externalservice-2
+      name: externalservice-2_mesh-1
       transportSocket:
         name: envoy.transport_sockets.tls
         typedConfig:

--- a/pkg/xds/generator/egress/testdata/04.mixed-services-custom-trafficroute.golden.yaml
+++ b/pkg/xds/generator/egress/testdata/04.mixed-services-custom-trafficroute.golden.yaml
@@ -193,6 +193,7 @@ resources:
                   cluster: mesh-1:externalservice-2
                   timeout: 0s
           statPrefix: externalservice-2
+      name: externalservice-2_mesh-1
       transportSocket:
         name: envoy.transport_sockets.tls
         typedConfig:

--- a/pkg/xds/generator/egress/testdata/05.mixed-services-with-custom-trafficpermissions.golden.yaml
+++ b/pkg/xds/generator/egress/testdata/05.mixed-services-with-custom-trafficpermissions.golden.yaml
@@ -235,6 +235,7 @@ resources:
                   cluster: mesh-1:externalservice-1
                   timeout: 0s
           statPrefix: externalservice-1
+      name: externalservice-1_mesh-1
       transportSocket:
         name: envoy.transport_sockets.tls
         typedConfig:
@@ -288,6 +289,7 @@ resources:
                   cluster: mesh-1:externalservice-2
                   timeout: 0s
           statPrefix: externalservice-2
+      name: externalservice-2_mesh-1
       transportSocket:
         name: envoy.transport_sockets.tls
         typedConfig:

--- a/pkg/xds/generator/egress/testdata/06.mixed-services-with-external-in-other-zone.golden.yaml
+++ b/pkg/xds/generator/egress/testdata/06.mixed-services-with-external-in-other-zone.golden.yaml
@@ -233,6 +233,7 @@ resources:
                   cluster: mesh-1:externalservice-1
                   timeout: 0s
           statPrefix: externalservice-1
+      name: externalservice-1_mesh-1
       transportSocket:
         name: envoy.transport_sockets.tls
         typedConfig:


### PR DESCRIPTION
### Checklist prior to review

- [X] [Link to relevant issue][1] as well as docs and UI issues --
- [X] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [X] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [X] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [X] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [X] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
