### PR TITLE
fix(kuma-cp): use port instead of target port of a headless service

### DIFF
--- a/pkg/plugins/runtime/k8s/controllers/kube_hosts_converter.go
+++ b/pkg/plugins/runtime/k8s/controllers/kube_hosts_converter.go
@@ -43,7 +43,7 @@ func KubeHosts(
 			for _, endpoint := range endpoints[serviceTag] {
 				hostnameEntry := vips.NewHostEntry(endpoint.Address)
 				err := view.Add(hostnameEntry, vips.OutboundEntry{
-					Port: endpoint.Port,
+					Port: port,
 					TagSet: map[string]string{
 						mesh_proto.ServiceTag:  serviceTag,
 						mesh_proto.InstanceTag: endpoint.Instance,

--- a/test/e2e_env/kubernetes/connectivity/headless_services.go
+++ b/test/e2e_env/kubernetes/connectivity/headless_services.go
@@ -1,0 +1,87 @@
+package connectivity
+
+import (
+	"github.com/gruntwork-io/terratest/modules/k8s"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+
+	. "github.com/kumahq/kuma/test/framework"
+	"github.com/kumahq/kuma/test/framework/client"
+	"github.com/kumahq/kuma/test/framework/deployments/testserver"
+	"github.com/kumahq/kuma/test/framework/envs/kubernetes"
+)
+
+func HeadlessServices() {
+	meshName := "reachable-svc"
+	namespace := "headless-svc"
+
+	BeforeAll(func() {
+		err := NewClusterSetup().
+			Install(MTLSMeshKubernetes(meshName)).
+			Install(NamespaceWithSidecarInjection(namespace)).
+			Install(testserver.Install(
+				testserver.WithName("demo-client"),
+				testserver.WithMesh(meshName),
+				testserver.WithNamespace(namespace),
+			)).
+			Install(testserver.Install(
+				testserver.WithName("test-server"),
+				testserver.WithMesh(meshName),
+				testserver.WithNamespace(namespace),
+			)).
+			Setup(kubernetes.Cluster)
+		Expect(err).ToNot(HaveOccurred())
+
+		err = k8s.RunKubectlE(
+			kubernetes.Cluster.GetTesting(),
+			kubernetes.Cluster.GetKubectlOptions(namespace),
+			"delete", "svc", "test-server", "-n", namespace,
+		)
+		Expect(err).ToNot(HaveOccurred())
+
+		// create headless service with port that is not the same as app port
+		headlessSvc := &corev1.Service{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "Service",
+				APIVersion: "v1",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-server-headless",
+				Namespace: namespace,
+			},
+			Spec: corev1.ServiceSpec{
+				Ports: []corev1.ServicePort{
+					{
+						Name:       "main",
+						Port:       int32(9090),
+						TargetPort: intstr.FromString("main"),
+					},
+				},
+				Selector: map[string]string{
+					"app": "test-server",
+				},
+			},
+		}
+		Expect(kubernetes.Cluster.Install(YamlK8sObject(headlessSvc))).To(Succeed())
+	})
+
+	E2EAfterAll(func() {
+		Expect(kubernetes.Cluster.TriggerDeleteNamespace(namespace)).To(Succeed())
+		Expect(kubernetes.Cluster.DeleteMesh(meshName))
+	})
+
+	It("should be able to connect to the headless service", func() {
+		Eventually(func(g Gomega) {
+			_, err := client.CollectEchoResponse(
+				kubernetes.Cluster,
+				"demo-client",
+				"test-server-headless:9090",
+				client.FromKubernetesPod(namespace, "demo-client"),
+			)
+			g.Expect(err).ToNot(HaveOccurred())
+		}, "30s", "1s").Should(Succeed())
+	})
+}

--- a/test/e2e_env/kubernetes/kubernetes_suite_test.go
+++ b/test/e2e_env/kubernetes/kubernetes_suite_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/kumahq/kuma/pkg/test"
 	"github.com/kumahq/kuma/test/e2e_env/kubernetes/api"
+	"github.com/kumahq/kuma/test/e2e_env/kubernetes/connectivity"
 	"github.com/kumahq/kuma/test/e2e_env/kubernetes/container_patch"
 	"github.com/kumahq/kuma/test/e2e_env/kubernetes/defaults"
 	"github.com/kumahq/kuma/test/e2e_env/kubernetes/externalservices"
@@ -46,6 +47,7 @@ var _ = SynchronizedBeforeSuite(kubernetes.SetupAndGetState, kubernetes.RestoreS
 var _ = SynchronizedAfterSuite(func() {}, func() {})
 
 var (
+	_ = Describe("Connectivity - Headless Services", connectivity.HeadlessServices, Ordered)
 	_ = Describe("Virtual Probes", healthcheck.VirtualProbes, Ordered)
 	_ = Describe("Gateway", gateway.Gateway, Ordered)
 	_ = Describe("Gateway - Cross-mesh", gateway.CrossMeshGatewayOnKubernetes, Ordered)


### PR DESCRIPTION
### Checklist prior to review

We took target port instead of port for headless services, so whenever there was a headless service with port != target port it wouldn't work.

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [X] [Link to relevant issue][1] as well as docs and UI issues --
- [X] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [X] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [X] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [X] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [X] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
