### PR TITLE
fix(MeshGatewayInstance): don't overwrite annotations/labels in managed Service

### DIFF
--- a/pkg/plugins/runtime/k8s/controllers/gateway_instance_controller.go
+++ b/pkg/plugins/runtime/k8s/controllers/gateway_instance_controller.go
@@ -125,11 +125,21 @@ func (r *GatewayInstanceReconciler) createOrUpdateService(
 			}
 
 			svcAnnotations := map[string]string{metadata.KumaGatewayAnnotation: metadata.AnnotationBuiltin}
+			svcLabels := map[string]string{}
+
+			if obj != nil {
+				for k, v := range obj.GetAnnotations() {
+					svcAnnotations[k] = v
+				}
+				for k, v := range obj.GetLabels() {
+					svcLabels[k] = v
+				}
+			}
+
 			for k, v := range gatewayInstance.Spec.ServiceTemplate.Metadata.Annotations {
 				svcAnnotations[k] = v
 			}
 
-			svcLabels := map[string]string{}
 			for k, v := range gatewayInstance.Spec.ServiceTemplate.Metadata.Labels {
 				svcLabels[k] = v
 			}


### PR DESCRIPTION
### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [x] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
