### PR TITLE
test(e2e): fix mesh in headless service test

### DIFF
--- a/test/e2e_env/kubernetes/connectivity/headless_services.go
+++ b/test/e2e_env/kubernetes/connectivity/headless_services.go
@@ -15,7 +15,7 @@ import (
 )
 
 func HeadlessServices() {
-	meshName := "reachable-svc"
+	meshName := "headless-svc"
 	namespace := "headless-svc"
 
 	BeforeAll(func() {

--- a/test/e2e_env/kubernetes/kubernetes_suite_test.go
+++ b/test/e2e_env/kubernetes/kubernetes_suite_test.go
@@ -47,7 +47,6 @@ var _ = SynchronizedBeforeSuite(kubernetes.SetupAndGetState, kubernetes.RestoreS
 var _ = SynchronizedAfterSuite(func() {}, func() {})
 
 var (
-	_ = Describe("Connectivity - Headless Services", connectivity.HeadlessServices, Ordered)
 	_ = Describe("Virtual Probes", healthcheck.VirtualProbes, Ordered)
 	_ = Describe("Gateway", gateway.Gateway, Ordered)
 	_ = Describe("Gateway - Cross-mesh", gateway.CrossMeshGatewayOnKubernetes, Ordered)
@@ -82,4 +81,5 @@ var (
 	_ = Describe("MeshHTTPRoute", meshhttproute.Test, Ordered)
 	_ = Describe("MeshTCPRoute", meshtcproute.Test, Ordered)
 	_ = Describe("Apis", api.Api, Ordered)
+	_ = Describe("Connectivity - Headless Services", connectivity.HeadlessServices, Ordered)
 )


### PR DESCRIPTION
I also changed the order of a test to see if this is really caused by this headless test or is it just because it's the first test

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [ ] [Link to relevant issue][1] as well as docs and UI issues --
- [ ] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [ ] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [ ] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [ ] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [ ] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
