### PR TITLE
fix(kuma-cp): add backward compatible reading of virtual outbound from config

### DIFF
--- a/docs/generated/kuma-cp.md
+++ b/docs/generated/kuma-cp.md
@@ -683,7 +683,9 @@ experimental:
   kubeOutboundsAsVIPs: true # ENV: KUMA_EXPERIMENTAL_KUBE_OUTBOUNDS_AS_VIPS
   # Tag first virtual outbound model is compressed version of default Virtual Outbound model
   # It is recommended to use tag first model for deployments with more than 2k services
-  # This is not backward compatible model.
+  # You can enable this flag on existing deployment. In order to downgrade cp with this flag enabled
+  # you need to first disable this flag and redeploy cp, after config is rewritten to default
+  # format you can downgrade your cp
   useTagFirstVirtualOutboundModel: false # ENV: KUMA_EXPERIMENTAL_USE_TAG_FIRST_VIRTUAL_OUTBOUND_MODEL
   # If true, KDS will sync using incremental xDS updates
   kdsDeltaEnabled: false # ENV: KUMA_EXPERIMENTAL_KDS_DELTA_ENABLED

--- a/pkg/config/app/kuma-cp/config.go
+++ b/pkg/config/app/kuma-cp/config.go
@@ -352,7 +352,9 @@ type ExperimentalConfig struct {
 	KDSDeltaEnabled bool `json:"kdsDeltaEnabled" envconfig:"KUMA_EXPERIMENTAL_KDS_DELTA_ENABLED"`
 	// Tag first virtual outbound model is compressed version of default Virtual Outbound model
 	// It is recommended to use tag first model for deployments with more than 2k services
-	// This is not backward compatible model.
+	// You can enable this flag on existing deployment. In order to downgrade cp with this flag enabled
+	// you need to first disable this flag and redeploy cp, after config is rewritten to default
+	// format you can downgrade your cp
 	UseTagFirstVirtualOutboundModel bool `json:"useTagFirstVirtualOutboundModel" envconfig:"KUMA_EXPERIMENTAL_USE_TAG_FIRST_VIRTUAL_OUTBOUND_MODEL"`
 }
 

--- a/pkg/config/app/kuma-cp/kuma-cp.defaults.yaml
+++ b/pkg/config/app/kuma-cp/kuma-cp.defaults.yaml
@@ -680,7 +680,9 @@ experimental:
   kubeOutboundsAsVIPs: true # ENV: KUMA_EXPERIMENTAL_KUBE_OUTBOUNDS_AS_VIPS
   # Tag first virtual outbound model is compressed version of default Virtual Outbound model
   # It is recommended to use tag first model for deployments with more than 2k services
-  # This is not backward compatible model.
+  # You can enable this flag on existing deployment. In order to downgrade cp with this flag enabled
+  # you need to first disable this flag and redeploy cp, after config is rewritten to default
+  # format you can downgrade your cp
   useTagFirstVirtualOutboundModel: false # ENV: KUMA_EXPERIMENTAL_USE_TAG_FIRST_VIRTUAL_OUTBOUND_MODEL
   # If true, KDS will sync using incremental xDS updates
   kdsDeltaEnabled: false # ENV: KUMA_EXPERIMENTAL_KDS_DELTA_ENABLED

--- a/pkg/dns/vips/persistence.go
+++ b/pkg/dns/vips/persistence.go
@@ -63,13 +63,15 @@ func (m *Persistence) GetByMesh(ctx context.Context, mesh string) (*VirtualOutbo
 	}
 
 	var virtualOutboundView *VirtualOutboundMeshView
-	if m.useTagFirstView {
-		res := NewEmptyTagFirstOutboundView()
-		if err := json.Unmarshal([]byte(resource.Spec.GetConfig()), &res); err != nil {
-			return nil, err
-		}
+	// try reading new format
+	res := NewEmptyTagFirstOutboundView()
+	if err := json.Unmarshal([]byte(resource.Spec.GetConfig()), &res); err != nil {
+		return nil, err
+	}
+	if len(res.PerService) != 0 {
 		virtualOutboundView = res.ToVirtualOutboundView()
 	} else {
+		// fall back to default
 		res := map[HostnameEntry]VirtualOutbound{}
 		if err := json.Unmarshal([]byte(resource.Spec.GetConfig()), &res); err != nil {
 			return nil, err

--- a/pkg/dns/vips/persistence_test.go
+++ b/pkg/dns/vips/persistence_test.go
@@ -107,6 +107,10 @@ var _ = Describe("Meshed Persistence", func() {
 						Meta: &model.ResourceMeta{Name: "kuma-mesh-3-dns-vips"},
 						Spec: &system_proto.Config{Config: `{"0:backend_3":{"address":"240.0.2.1","outbounds":[{"TagSet":{"kuma.io/service":"backend_3"}}]},"0:frontend_3":{"address":"240.0.2.3","outbounds":[{"TagSet":{"kuma.io/service":"frontend_3"}}]},"1:host.com":{"address":"240.0.1.4","outbounds":[{"TagSet":{"kuma.io/service":"external-host"}}]}}`},
 					},
+					"kuma-mesh-4-dns-vips": {
+						Meta: &model.ResourceMeta{Name: "kuma-mesh-4-dns-vips"},
+						Spec: &system_proto.Config{Config: `{"v":{"backend_2":{"oe":[{"ap":[{"a":"240.0.1.1","o":"svc"}]}]},"frontend_2":{"oe":[{"ap":[{"a":"240.0.1.3","o":"svc"}]}]},"postgres_2":{"oe":[{"ap":[{"a":"240.0.1.0","o":"svc"}]}]}}}`},
+					},
 				},
 			}, false)
 		})
@@ -119,6 +123,18 @@ var _ = Describe("Meshed Persistence", func() {
 				vips.NewServiceEntry("frontend_2"): {Address: "240.0.1.3", Outbounds: []vips.OutboundEntry{{TagSet: map[string]string{mesh_proto.ServiceTag: "frontend_2"}, Origin: ""}}},
 				vips.NewServiceEntry("postgres_2"): {Address: "240.0.1.0", Outbounds: []vips.OutboundEntry{{TagSet: map[string]string{mesh_proto.ServiceTag: "postgres_2"}, Origin: ""}}},
 				vips.NewServiceEntry("redis_2"):    {Address: "240.0.1.2", Outbounds: []vips.OutboundEntry{{TagSet: map[string]string{mesh_proto.ServiceTag: "redis_2"}, Origin: ""}}},
+			})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(actual).To(Equal(expected))
+		})
+
+		It("should return vips for mesh in new format", func() {
+			actual, err := meshedPersistence.GetByMesh(context.Background(), "mesh-4")
+			Expect(err).ToNot(HaveOccurred())
+			expected, err := vips.NewVirtualOutboundView(map[vips.HostnameEntry]vips.VirtualOutbound{
+				vips.NewServiceEntry("backend_2"):  {Address: "240.0.1.1", Outbounds: []vips.OutboundEntry{{TagSet: map[string]string{mesh_proto.ServiceTag: "backend_2"}, Origin: "service"}}},
+				vips.NewServiceEntry("frontend_2"): {Address: "240.0.1.3", Outbounds: []vips.OutboundEntry{{TagSet: map[string]string{mesh_proto.ServiceTag: "frontend_2"}, Origin: "service"}}},
+				vips.NewServiceEntry("postgres_2"): {Address: "240.0.1.0", Outbounds: []vips.OutboundEntry{{TagSet: map[string]string{mesh_proto.ServiceTag: "postgres_2"}, Origin: "service"}}},
 			})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(actual).To(Equal(expected))


### PR DESCRIPTION
…m config

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [x] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
