### PR TITLE
Revert "fix(kuma-dp): honour app content-type (#6783)"

### DIFF
--- a/app/kuma-dp/pkg/dataplane/metrics/server.go
+++ b/app/kuma-dp/pkg/dataplane/metrics/server.go
@@ -5,8 +5,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"math"
-	"mime"
 	"net"
 	"net/http"
 	"net/url"
@@ -32,23 +30,6 @@ var (
 var (
 	prometheusRequestHeaders = []string{"accept", "accept-encoding", "user-agent", "x-prometheus-scrape-timeout-seconds"}
 	logger                   = core.Log.WithName("metrics-hijacker")
-
-	// holds prometheus content types in order of priority.
-	prometheusPriorityContentType = []expfmt.Format{
-		expfmt.FmtOpenMetrics_1_0_0,
-		expfmt.FmtOpenMetrics_0_0_1,
-		expfmt.FmtText,
-		expfmt.FmtUnknown,
-	}
-
-	// Reverse mapping of prometheusPriorityContentType for faster lookup.
-	prometheusPriorityContentTypeLookup = func(expformats []expfmt.Format) map[expfmt.Format]int32 {
-		reverseMapping := map[expfmt.Format]int32{}
-		for priority, format := range expformats {
-			reverseMapping[format] = int32(priority)
-		}
-		return reverseMapping
-	}(prometheusPriorityContentType)
 )
 
 var _ component.Component = &Hijacker{}
@@ -172,27 +153,19 @@ func rewriteMetricsURL(address string, port uint32, path string, queryModifier Q
 func (s *Hijacker) ServeHTTP(writer http.ResponseWriter, req *http.Request) {
 	ctx := req.Context()
 	out := make(chan []byte, len(s.applicationsToScrape))
-	contentTypes := make(chan expfmt.Format, len(s.applicationsToScrape))
 	var wg sync.WaitGroup
 	done := make(chan []byte)
 	wg.Add(len(s.applicationsToScrape))
 	go func() {
 		wg.Wait()
-		close(out)
-		close(contentTypes)
 		close(done)
+		close(out)
 	}()
 
 	for _, app := range s.applicationsToScrape {
 		go func(app ApplicationToScrape) {
 			defer wg.Done()
-			content, contentType := s.getStats(ctx, req, app)
-			out <- content
-
-			// It's possible to track the highest priority content type seen,
-			// but that would require mutex.
-			// I would prefer to calculate it later at one go
-			contentTypes <- contentType
+			out <- s.getStats(ctx, req, app)
 		}(app)
 	}
 
@@ -200,7 +173,8 @@ func (s *Hijacker) ServeHTTP(writer http.ResponseWriter, req *http.Request) {
 	case <-ctx.Done():
 		return
 	case <-done:
-		writer.Header().Set(hdrContentType, string(selectContentType(contentTypes, req.Header)))
+		// default format returned by prometheus
+		writer.Header().Set("content-type", string(expfmt.FmtText))
 		for resp := range out {
 			if _, err := writer.Write(resp); err != nil {
 				logger.Error(err, "error while writing the response")
@@ -212,44 +186,11 @@ func (s *Hijacker) ServeHTTP(writer http.ResponseWriter, req *http.Request) {
 	}
 }
 
-// selectContentType selects the highest priority content type supported by the applications.
-// If no valid content type is returned by the applications, it returns the highest priority
-// content type supported by the scraper.
-func selectContentType(contentTypes <-chan expfmt.Format, reqHeader http.Header) expfmt.Format {
-	// Tracks highest negotiated content type priority.
-	// Lower number means higher priority
-	//
-	// We should not simply use the highest priority content type even if `application/openmetrics-text`
-	// is the superset of `text/plain`, as it might not be
-	// supported by the applications or the user might be using older prom scraper.
-	// So it's better to choose the highest negotiated content type between the apps and the scraper.
-	var ctPriority int32 = math.MaxInt32
-	ct := expfmt.FmtUnknown
-	for contentType := range contentTypes {
-		priority, valid := prometheusPriorityContentTypeLookup[contentType]
-		if !valid {
-			continue
-		}
-		if priority < ctPriority {
-			ctPriority = priority
-			ct = contentType
-		}
-	}
-
-	// If no valid content type is returned by the applications,
-	// use the highest priority content type supported by the scraper.
-	if ct == expfmt.FmtUnknown {
-		ct = expfmt.NegotiateIncludingOpenMetrics(reqHeader)
-	}
-
-	return ct
-}
-
-func (s *Hijacker) getStats(ctx context.Context, initReq *http.Request, app ApplicationToScrape) ([]byte, expfmt.Format) {
+func (s *Hijacker) getStats(ctx context.Context, initReq *http.Request, app ApplicationToScrape) []byte {
 	req, err := http.NewRequest("GET", rewriteMetricsURL(app.Address, app.Port, app.Path, app.QueryModifier, initReq.URL), nil)
 	if err != nil {
 		logger.Error(err, "failed to create request")
-		return nil, ""
+		return nil
 	}
 	s.passRequestHeaders(req.Header, initReq.Header)
 	req = req.WithContext(ctx)
@@ -267,27 +208,25 @@ func (s *Hijacker) getStats(ctx context.Context, initReq *http.Request, app Appl
 	}
 	if err != nil {
 		logger.Error(err, "failed call", "name", app.Name, "path", app.Path, "port", app.Port)
-		return nil, ""
+		return nil
 	}
-
-	respContentType := responseFormat(resp.Header)
 
 	var bodyBytes []byte
 	if app.Mutator != nil {
 		buf := new(bytes.Buffer)
 		if err := app.Mutator(resp.Body, buf); err != nil {
 			logger.Error(err, "failed while mutating data", "name", app.Name, "path", app.Path, "port", app.Port)
-			return nil, ""
+			return nil
 		}
 		bodyBytes = buf.Bytes()
 	} else {
 		bodyBytes, err = io.ReadAll(resp.Body)
 		if err != nil {
 			logger.Error(err, "failed while writing", "name", app.Name, "path", app.Path, "port", app.Port)
-			return nil, ""
+			return nil
 		}
 	}
-	return bodyBytes, respContentType
+	return bodyBytes
 }
 
 func (s *Hijacker) passRequestHeaders(into http.Header, from http.Header) {
@@ -303,53 +242,4 @@ func (s *Hijacker) passRequestHeaders(into http.Header, from http.Header) {
 
 func (s *Hijacker) NeedLeaderElection() bool {
 	return false
-}
-
-const (
-	hdrContentType           = "Content-Type"
-	textType                 = "text/plain"
-	textVersion              = "0.0.4"
-	openmetricsType          = "application/openmetrics-text"
-	openmetricsVersion_1_0_0 = "1.0.0"
-	openmetricsVersion_0_0_1 = "0.0.1"
-	protoType                = `application/vnd.google.protobuf`
-	protoProtocol            = `io.prometheus.client.MetricFamily`
-)
-
-// responseFormat extracts the correct format from a HTTP response header.
-// If no matching format can be found FormatUnknown is returned.
-func responseFormat(h http.Header) expfmt.Format {
-	ct := h.Get(hdrContentType)
-
-	mediatype, params, err := mime.ParseMediaType(ct)
-	if err != nil {
-		return expfmt.FmtUnknown
-	}
-
-	version := params["version"]
-
-	switch mediatype {
-	case protoType:
-		p := params["proto"]
-		e := params["encoding"]
-		// only delimited encoding is supported by prometheus scraper
-		if p == protoProtocol && e == "delimited" {
-			return expfmt.FmtProtoDelim
-		}
-
-	case textType:
-		if version == textVersion {
-			return expfmt.FmtText
-		}
-
-	case openmetricsType:
-		if version == openmetricsVersion_0_0_1 {
-			return expfmt.FmtOpenMetrics_0_0_1
-		}
-		if version == openmetricsVersion_1_0_0 {
-			return expfmt.FmtOpenMetrics_1_0_0
-		}
-	}
-
-	return expfmt.FmtUnknown
 }

--- a/app/kuma-dp/pkg/dataplane/metrics/server_test.go
+++ b/app/kuma-dp/pkg/dataplane/metrics/server_test.go
@@ -1,12 +1,10 @@
 package metrics
 
 import (
-	"net/http"
 	"net/url"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/prometheus/common/expfmt"
 )
 
 var _ = Describe("Rewriting the metrics URL", func() {
@@ -43,83 +41,6 @@ var _ = Describe("Rewriting the metrics URL", func() {
 			adminPort:     80,
 			expected:      "http://127.0.0.1:80/stats",
 			queryModifier: RemoveQueryParameters,
-		}),
-	)
-})
-
-var _ = Describe("Select Content Type", func() {
-	var reqHeader http.Header
-	BeforeEach(func() {
-		reqHeader = make(http.Header)
-	})
-
-	It("should honor app content-type", func() {
-		contentTypes := make(chan expfmt.Format, 3)
-		contentTypes <- expfmt.FmtOpenMetrics_0_0_1
-		contentTypes <- expfmt.Format("")
-		contentTypes <- expfmt.FmtText
-		close(contentTypes)
-		reqHeader.Add("Accept", "application/openmetrics-text;version=1.0.0,application/openmetrics-text;version=0.0.1;q=0.75,text/plain;version=0.0.4;q=0.5,*/*;q=0.1")
-
-		actualContentType := selectContentType(contentTypes, reqHeader)
-		Expect(actualContentType).To(Equal(expfmt.FmtOpenMetrics_0_0_1))
-	})
-
-	It("should honor max supported accept type when app returns invalid content-type", func() {
-		contentTypes := make(chan expfmt.Format, 1)
-		contentTypes <- expfmt.Format("invalid_content_type")
-		close(contentTypes)
-		reqHeader.Add("Accept", "application/openmetrics-text;version=1.0.0,application/openmetrics-text;version=0.0.1;q=0.75,text/plain;version=0.0.4;q=0.5,*/*;q=0.1")
-
-		actualContentType := selectContentType(contentTypes, reqHeader)
-		Expect(actualContentType).To(Equal(expfmt.FmtOpenMetrics_1_0_0))
-	})
-
-	It("should use highest priority content-type available", func() {
-		contentTypes := make(chan expfmt.Format, 1)
-		contentTypes <- expfmt.Format("invalid_content_type")
-		close(contentTypes)
-		reqHeader.Add("Accept", "*/*")
-
-		actualContentType := selectContentType(contentTypes, reqHeader)
-		Expect(actualContentType).To(Equal(expfmt.FmtText))
-	})
-})
-
-var _ = Describe("Response Format", func() {
-	type testCase struct {
-		contentType    string
-		expectedFormat expfmt.Format
-	}
-	DescribeTable("should",
-		func(given testCase) {
-			h := make(http.Header)
-			h.Set(hdrContentType, given.contentType)
-			Expect(responseFormat(h)).To(Equal(given.expectedFormat))
-		},
-		Entry("return FmtProtoDelim for a 'delimited protobuf content type' response", testCase{
-			contentType:    "application/vnd.google.protobuf; proto=io.prometheus.client.MetricFamily; encoding=delimited",
-			expectedFormat: expfmt.FmtProtoDelim,
-		}),
-		Entry("return FmtUnknown for a 'text protobuf content type' response", testCase{
-			contentType:    "application/vnd.google.protobuf; proto=io.prometheus.client.MetricFamily; encoding=text",
-			expectedFormat: expfmt.FmtUnknown,
-		}),
-		Entry("return FmtText for a 'text plain with v0.0.4 content type' response", testCase{
-			contentType:    "text/plain; version=0.0.4",
-			expectedFormat: expfmt.FmtText,
-		}),
-		Entry("return FmtOpenMetrics_1_0_0 for a 'openmetrics v1.0.0 content type' response", testCase{
-			contentType:    "application/openmetrics-text; version=1.0.0",
-			expectedFormat: expfmt.FmtOpenMetrics_1_0_0,
-		}),
-		Entry("return FmtOpenMetrics_0_0_1 for a 'openmetrics v0.0.1 content type' response", testCase{
-			contentType:    "application/openmetrics-text; version=0.0.1",
-			expectedFormat: expfmt.FmtOpenMetrics_0_0_1,
-		}),
-		Entry("return FmtUnknown for a 'invalid content type' response", testCase{
-			contentType:    "application/invalid",
-			expectedFormat: expfmt.FmtUnknown,
 		}),
 	)
 })

--- a/test/e2e_env/universal/observability/applications_metrics.go
+++ b/test/e2e_env/universal/observability/applications_metrics.go
@@ -206,7 +206,6 @@ metrics:
 		Eventually(func(g Gomega) {
 			stdout, _, err := client.CollectResponse(
 				universal.Cluster, "test-server-dp-metrics", "http://"+net.JoinHostPort(ip, "5555")+"/stats?filter=concurrency",
-				client.WithHeader("Accept", "text/plain; version=0.0.4; charset=utf-8"),
 				client.WithVerbose(),
 			)
 
@@ -237,14 +236,13 @@ metrics:
 		Eventually(func(g Gomega) {
 			stdout, _, err := client.CollectResponse(
 				universal.Cluster, "test-server-dp-metrics-localhost", "http://"+net.JoinHostPort(ip, "1234")+"/metrics?filter=concurrency",
-				client.WithHeader("Accept", "application/openmetrics-text;version=1.0.0,application/openmetrics-text;version=0.0.1;q=0.75,text/plain;version=0.0.4;q=0.5,*/*;q=0.1"),
 				client.WithVerbose(),
 			)
 
 			// then
 			g.Expect(err).ToNot(HaveOccurred())
 			g.Expect(stdout).ToNot(BeNil())
-			g.Expect(stdout).To(ContainSubstring(string(expfmt.FmtOpenMetrics_1_0_0)))
+			g.Expect(stdout).To(ContainSubstring(string(expfmt.FmtText)))
 
 			// path doesn't have defined address
 			g.Expect(stdout).ToNot(ContainSubstring("localhost-bound-not-exposed"))


### PR DESCRIPTION
This reverts commit b178614aa2bcbd02691b4f016c1499df43229d30.

Reverted PR: https://github.com/kumahq/kuma/pull/6783

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [X] [Link to relevant issue][1] as well as docs and UI issues -- https://github.com/kumahq/kuma/issues/7093
- [X] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [X] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [X] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [X] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [X] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
