### PR TITLE
fix(kuma-cp): do not require certs on https api port

### DIFF
--- a/pkg/api-server/server.go
+++ b/pkg/api-server/server.go
@@ -38,6 +38,7 @@ import (
 	"github.com/kumahq/kuma/pkg/dns/vips"
 	"github.com/kumahq/kuma/pkg/envoy/admin"
 	"github.com/kumahq/kuma/pkg/metrics"
+	"github.com/kumahq/kuma/pkg/plugins/authn/api-server/certs"
 	"github.com/kumahq/kuma/pkg/plugins/resources/k8s"
 	"github.com/kumahq/kuma/pkg/tokens/builtin"
 	tokens_server "github.com/kumahq/kuma/pkg/tokens/builtin/server"
@@ -438,8 +439,8 @@ func configureMTLS(tlsConfig *tls.Config, cfg api_server.ApiServerConfig) error 
 	tlsConfig.ClientCAs = clientCertPool
 	if cfg.HTTPS.RequireClientCert {
 		tlsConfig.ClientAuth = tls.RequireAndVerifyClientCert
-	} else {
-		tlsConfig.ClientAuth = tls.VerifyClientCertIfGiven // client certs are required only for some endpoints
+	} else if cfg.Authn.Type == certs.PluginName {
+		tlsConfig.ClientAuth = tls.VerifyClientCertIfGiven // client certs are required only for some endpoints when using admin client cert
 	}
 	return nil
 }


### PR DESCRIPTION
In this PR https://github.com/kumahq/kuma/pull/5979 we introduced a change when user can set mTLS and still use tokens.
With this change, we set `VerifyClientCertIfGiven` always which is not correct if someone does not want to do mTLS. `VerifyClientCertIfGiven` was required in the first place for adminClientCert auth method.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [X] [Link to relevant issue][1] as well as docs and UI issues --
- [X] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [X] Tests (Unit test, E2E tests, manual test on universal and k8s) -- Quite impossible to test it :/
- [X] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [X] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [X] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
