### PR TITLE
feat(xds): named resources (clusters) builders require name

### DIFF
--- a/pkg/plugins/bootstrap/k8s/xds/hooks/api_server_bypass.go
+++ b/pkg/plugins/bootstrap/k8s/xds/hooks/api_server_bypass.go
@@ -49,8 +49,8 @@ func (h ApiServerBypass) Modify(resources *core_xds.ResourceSet, ctx xds_context
 		return errors.Wrapf(err, "could not generate listener: %s", apiServerBypassHookResourcesName)
 	}
 
-	cluster, err := envoy_clusters.NewClusterBuilder(proxy.APIVersion).
-		Configure(envoy_clusters.PassThroughCluster(apiServerBypassHookResourcesName)).
+	cluster, err := envoy_clusters.NewClusterBuilder(proxy.APIVersion, apiServerBypassHookResourcesName).
+		Configure(envoy_clusters.PassThroughCluster()).
 		Configure(envoy_clusters.DefaultTimeout()).
 		Build()
 	if err != nil {

--- a/pkg/plugins/policies/core/xds/meshroute/clusters.go
+++ b/pkg/plugins/policies/core/xds/meshroute/clusters.go
@@ -26,15 +26,15 @@ func GenerateClusters(
 		tlsReady := service.TLSReady()
 
 		for _, cluster := range service.Clusters() {
-			edsClusterBuilder := envoy_clusters.NewClusterBuilder(proxy.APIVersion)
-
 			clusterName := cluster.Name()
+			edsClusterBuilder := envoy_clusters.NewClusterBuilder(proxy.APIVersion, clusterName)
+
 			clusterTags := []envoy_tags.Tags{cluster.Tags()}
 
 			if service.HasExternalService() {
 				if meshCtx.Resource.ZoneEgressEnabled() {
 					edsClusterBuilder.
-						Configure(envoy_clusters.EdsCluster(clusterName)).
+						Configure(envoy_clusters.EdsCluster()).
 						Configure(envoy_clusters.ClientSideMTLS(
 							proxy.SecretsTracker,
 							meshCtx.Resource,
@@ -47,7 +47,7 @@ func GenerateClusters(
 					isIPv6 := proxy.Dataplane.IsIPv6()
 
 					edsClusterBuilder.
-						Configure(envoy_clusters.ProvidedEndpointCluster(clusterName, isIPv6, endpoints...)).
+						Configure(envoy_clusters.ProvidedEndpointCluster(isIPv6, endpoints...)).
 						Configure(envoy_clusters.ClientSideTLS(endpoints))
 				}
 
@@ -60,7 +60,7 @@ func GenerateClusters(
 				}
 			} else {
 				edsClusterBuilder.
-					Configure(envoy_clusters.EdsCluster(clusterName)).
+					Configure(envoy_clusters.EdsCluster()).
 					Configure(envoy_clusters.Http2())
 
 				if upstreamMeshName := cluster.Mesh(); upstreamMeshName != "" {

--- a/pkg/plugins/policies/core/xds/testutil.go
+++ b/pkg/plugins/policies/core/xds/testutil.go
@@ -3,12 +3,10 @@ package xds
 import (
 	_ "embed"
 
-	envoy_cluster "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
 	. "github.com/onsi/gomega"
 
 	core_xds "github.com/kumahq/kuma/pkg/core/xds"
 	util_proto "github.com/kumahq/kuma/pkg/util/proto"
-	clusters_builder "github.com/kumahq/kuma/pkg/xds/envoy/clusters"
 )
 
 func ResourceArrayShouldEqual(resources core_xds.ResourceList, expected []string) {
@@ -21,19 +19,4 @@ func ResourceArrayShouldEqual(resources core_xds.ResourceList, expected []string
 		Expect(actual).To(MatchYAML(expected[i]))
 	}
 	Expect(resources).To(HaveLen(len(expected)))
-}
-
-type NameConfigurer struct {
-	Name string
-}
-
-func (n *NameConfigurer) Configure(c *envoy_cluster.Cluster) error {
-	c.Name = n.Name
-	return nil
-}
-
-func WithName(name string) clusters_builder.ClusterBuilderOpt {
-	return clusters_builder.ClusterBuilderOptFunc(func(builder *clusters_builder.ClusterBuilder) {
-		builder.AddConfigurer(&NameConfigurer{Name: name})
-	})
 }

--- a/pkg/plugins/policies/meshaccesslog/plugin/xds/clusters.go
+++ b/pkg/plugins/policies/meshaccesslog/plugin/xds/clusters.go
@@ -24,8 +24,8 @@ func HandleClusters(backendEndpoints EndpointAccumulator, rs *core_xds.ResourceS
 		endpoint := xdsEndpoint(backendEndpoint)
 
 		clusterName := backendEndpoints.clusterForEndpoint(backendEndpoint)
-		res, err := clusters.NewClusterBuilder(proxy.APIVersion).
-			Configure(clusters.ProvidedEndpointCluster(string(clusterName), proxy.Dataplane.IsIPv6(), endpoint)).
+		res, err := clusters.NewClusterBuilder(proxy.APIVersion, string(clusterName)).
+			Configure(clusters.ProvidedEndpointCluster(proxy.Dataplane.IsIPv6(), endpoint)).
 			Configure(clusters.ClientSideTLS([]core_xds.Endpoint{endpoint})).
 			Configure(clusters.DefaultTimeout()).
 			Configure(clusters.Http2()).

--- a/pkg/plugins/policies/meshhealthcheck/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshhealthcheck/plugin/v1alpha1/plugin_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/kumahq/kuma/pkg/core/xds"
 	core_xds "github.com/kumahq/kuma/pkg/core/xds"
 	core_rules "github.com/kumahq/kuma/pkg/plugins/policies/core/rules"
-	policies_xds "github.com/kumahq/kuma/pkg/plugins/policies/core/xds"
 	api "github.com/kumahq/kuma/pkg/plugins/policies/meshhealthcheck/api/v1alpha1"
 	plugin "github.com/kumahq/kuma/pkg/plugins/policies/meshhealthcheck/plugin/v1alpha1"
 	gateway_plugin "github.com/kumahq/kuma/pkg/plugins/runtime/gateway"
@@ -48,15 +47,13 @@ var _ = Describe("MeshHealthCheck", func() {
 		{
 			Name:   "cluster-echo-http",
 			Origin: generator.OriginOutbound,
-			Resource: clusters.NewClusterBuilder(envoy_common.APIV3).
-				Configure(policies_xds.WithName(httpServiceTag)).
+			Resource: clusters.NewClusterBuilder(envoy_common.APIV3, httpServiceTag).
 				MustBuild(),
 		},
 		{
 			Name:   "cluster-echo-http-_0_",
 			Origin: generator.OriginOutbound,
-			Resource: clusters.NewClusterBuilder(envoy_common.APIV3).
-				Configure(policies_xds.WithName(splitHttpServiceTag)).
+			Resource: clusters.NewClusterBuilder(envoy_common.APIV3, splitHttpServiceTag).
 				MustBuild(),
 		},
 	}
@@ -64,8 +61,7 @@ var _ = Describe("MeshHealthCheck", func() {
 		{
 			Name:   "cluster-echo-tcp",
 			Origin: generator.OriginOutbound,
-			Resource: clusters.NewClusterBuilder(envoy_common.APIV3).
-				Configure(policies_xds.WithName(tcpServiceTag)).
+			Resource: clusters.NewClusterBuilder(envoy_common.APIV3, tcpServiceTag).
 				MustBuild(),
 		},
 	}
@@ -73,8 +69,7 @@ var _ = Describe("MeshHealthCheck", func() {
 		{
 			Name:   "cluster-echo-grpc",
 			Origin: generator.OriginOutbound,
-			Resource: clusters.NewClusterBuilder(envoy_common.APIV3).
-				Configure(policies_xds.WithName(grpcServiceTag)).
+			Resource: clusters.NewClusterBuilder(envoy_common.APIV3, grpcServiceTag).
 				MustBuild(),
 		},
 	}

--- a/pkg/plugins/policies/meshloadbalancingstrategy/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshloadbalancingstrategy/plugin/v1alpha1/plugin_test.go
@@ -72,8 +72,8 @@ var _ = Describe("MeshLoadBalancingStrategy", func() {
 				{
 					Name:   "cluster-backend",
 					Origin: generator.OriginOutbound,
-					Resource: clusters.NewClusterBuilder(envoy_common.APIV3).
-						Configure(clusters.EdsCluster("backend")).
+					Resource: clusters.NewClusterBuilder(envoy_common.APIV3, "backend").
+						Configure(clusters.EdsCluster()).
 						MustBuild(),
 				},
 				{
@@ -103,9 +103,8 @@ var _ = Describe("MeshLoadBalancingStrategy", func() {
 				{
 					Name:   "cluster-payment",
 					Origin: generator.OriginOutbound,
-					Resource: clusters.NewClusterBuilder(envoy_common.APIV3).
+					Resource: clusters.NewClusterBuilder(envoy_common.APIV3, "payment").
 						Configure(clusters.ProvidedEndpointCluster(
-							"payment",
 							false,
 							core_xds.Endpoint{
 								Target: "192.168.0.1",
@@ -267,8 +266,8 @@ var _ = Describe("MeshLoadBalancingStrategy", func() {
 				{
 					Name:   "mesh-1:eds-cluster",
 					Origin: egress.OriginEgress,
-					Resource: clusters.NewClusterBuilder(envoy_common.APIV3).
-						Configure(clusters.EdsCluster("mesh-1:eds-cluster")).
+					Resource: clusters.NewClusterBuilder(envoy_common.APIV3, "mesh-1:eds-cluster").
+						Configure(clusters.EdsCluster()).
 						MustBuild(),
 				},
 				{
@@ -298,9 +297,8 @@ var _ = Describe("MeshLoadBalancingStrategy", func() {
 				{
 					Name:   "mesh-2:static-cluster",
 					Origin: egress.OriginEgress,
-					Resource: clusters.NewClusterBuilder(envoy_common.APIV3).
+					Resource: clusters.NewClusterBuilder(envoy_common.APIV3, "mesh-2:static-cluster").
 						Configure(clusters.ProvidedEndpointCluster(
-							"mesh-2:static-cluster",
 							false,
 							core_xds.Endpoint{
 								Target: "192.168.0.1",

--- a/pkg/plugins/policies/meshloadbalancingstrategy/plugin/xds/lbconfigurer_test.go
+++ b/pkg/plugins/policies/meshloadbalancingstrategy/plugin/xds/lbconfigurer_test.go
@@ -5,7 +5,6 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	policies_xds "github.com/kumahq/kuma/pkg/plugins/policies/core/xds"
 	api "github.com/kumahq/kuma/pkg/plugins/policies/meshloadbalancingstrategy/api/v1alpha1"
 	"github.com/kumahq/kuma/pkg/plugins/policies/meshloadbalancingstrategy/plugin/xds"
 	"github.com/kumahq/kuma/pkg/util/pointer"
@@ -26,8 +25,7 @@ var _ = Describe("LBConfigurer", func() {
 			configurer := &xds.LoadBalancerConfigurer{
 				LoadBalancer: given.conf,
 			}
-			cluster := clusters.NewClusterBuilder(envoy.APIV3).
-				Configure(policies_xds.WithName("test")).
+			cluster := clusters.NewClusterBuilder(envoy.APIV3, "test").
 				MustBuild()
 
 			// when

--- a/pkg/plugins/policies/meshproxypatch/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshproxypatch/plugin/v1alpha1/plugin_test.go
@@ -58,8 +58,7 @@ var _ = Describe("MeshProxyPatch", func() {
 				{
 					Name:   "echo-http",
 					Origin: generator.OriginOutbound,
-					Resource: clusters.NewClusterBuilder(envoy_common.APIV3).
-						Configure(policies_xds.WithName("echo-http")).
+					Resource: clusters.NewClusterBuilder(envoy_common.APIV3, "echo-http").
 						MustBuild(),
 				},
 			},

--- a/pkg/plugins/policies/meshtrace/plugin/v1alpha1/plugin.go
+++ b/pkg/plugins/policies/meshtrace/plugin/v1alpha1/plugin.go
@@ -167,7 +167,6 @@ func applyToClusters(rules core_rules.SingleItemRules, rs *xds.ResourceSet, prox
 	var endpoint *xds.Endpoint
 	var provider string
 
-	builder := clusters.NewClusterBuilder(proxy.APIVersion)
 	switch {
 	case backend.Zipkin != nil:
 		endpoint = endpointForZipkin(backend.Zipkin)
@@ -178,10 +177,14 @@ func applyToClusters(rules core_rules.SingleItemRules, rs *xds.ResourceSet, prox
 	case backend.OpenTelemetry != nil:
 		endpoint = endpointForOpenTelemetry(backend.OpenTelemetry)
 		provider = plugin_xds.OpenTelemetryProviderName
+	}
+	builder := clusters.NewClusterBuilder(proxy.APIVersion, plugin_xds.GetTracingClusterName(provider))
+
+	if backend.OpenTelemetry != nil {
 		builder.Configure(clusters.Http2())
 	}
 
-	res, err := builder.Configure(clusters.ProvidedEndpointCluster(plugin_xds.GetTracingClusterName(provider), proxy.Dataplane.IsIPv6(), *endpoint)).
+	res, err := builder.Configure(clusters.ProvidedEndpointCluster(proxy.Dataplane.IsIPv6(), *endpoint)).
 		Configure(clusters.ClientSideTLS([]xds.Endpoint{*endpoint})).
 		Configure(clusters.DefaultTimeout()).Build()
 	if err != nil {

--- a/pkg/test/xds/name_configurer.go
+++ b/pkg/test/xds/name_configurer.go
@@ -1,29 +1,10 @@
 package xds
 
 import (
-	envoy_cluster "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
-
 	envoy_common "github.com/kumahq/kuma/pkg/xds/envoy"
 	clusters_builder "github.com/kumahq/kuma/pkg/xds/envoy/clusters"
 )
 
-type NameConfigurer struct {
-	Name string
-}
-
-func (n *NameConfigurer) Configure(c *envoy_cluster.Cluster) error {
-	c.Name = n.Name
-	return nil
-}
-
-func WithName(name string) clusters_builder.ClusterBuilderOpt {
-	return clusters_builder.ClusterBuilderOptFunc(func(builder *clusters_builder.ClusterBuilder) {
-		builder.AddConfigurer(&NameConfigurer{Name: name})
-	})
-}
-
 func ClusterWithName(name string) envoy_common.NamedResource {
-	return clusters_builder.NewClusterBuilder(envoy_common.APIV3).
-		Configure(WithName(name)).
-		MustBuild()
+	return clusters_builder.NewClusterBuilder(envoy_common.APIV3, name).MustBuild()
 }

--- a/pkg/xds/envoy/clusters/configurers.go
+++ b/pkg/xds/envoy/clusters/configurers.go
@@ -71,20 +71,18 @@ func ClientSideTLS(endpoints []core_xds.Endpoint) ClusterBuilderOpt {
 	})
 }
 
-func EdsCluster(name string) ClusterBuilderOpt {
+func EdsCluster() ClusterBuilderOpt {
 	return ClusterBuilderOptFunc(func(builder *ClusterBuilder) {
-		builder.AddConfigurer(&v3.EdsClusterConfigurer{
-			Name: name,
-		})
+		builder.AddConfigurer(&v3.EdsClusterConfigurer{})
 		builder.AddConfigurer(&v3.AltStatNameConfigurer{})
 	})
 }
 
 // ProvidedEndpointCluster sets the cluster with the defined endpoints, this is useful when endpoints are not discovered using EDS, so we don't use EdsCluster
-func ProvidedEndpointCluster(name string, hasIPv6 bool, endpoints ...core_xds.Endpoint) ClusterBuilderOpt {
+func ProvidedEndpointCluster(hasIPv6 bool, endpoints ...core_xds.Endpoint) ClusterBuilderOpt {
 	return ClusterBuilderOptFunc(func(builder *ClusterBuilder) {
 		builder.AddConfigurer(&v3.ProvidedEndpointClusterConfigurer{
-			Name:      name,
+			Name:      builder.name,
 			Endpoints: endpoints,
 			HasIPv6:   hasIPv6,
 		})
@@ -150,11 +148,9 @@ func DefaultTimeout() ClusterBuilderOpt {
 	})
 }
 
-func PassThroughCluster(name string) ClusterBuilderOpt {
+func PassThroughCluster() ClusterBuilderOpt {
 	return ClusterBuilderOptFunc(func(builder *ClusterBuilder) {
-		builder.AddConfigurer(&v3.PassThroughClusterConfigurer{
-			Name: name,
-		})
+		builder.AddConfigurer(&v3.PassThroughClusterConfigurer{})
 		builder.AddConfigurer(&v3.AltStatNameConfigurer{})
 	})
 }

--- a/pkg/xds/envoy/clusters/v3/circuit_breaker_configurer_test.go
+++ b/pkg/xds/envoy/clusters/v3/circuit_breaker_configurer_test.go
@@ -21,8 +21,8 @@ var _ = Describe("CircuitBreakerConfigurer", func() {
 	DescribeTable("should generate proper Envoy config",
 		func(given testCase) {
 			// when
-			cluster, err := clusters.NewClusterBuilder(envoy.APIV3).
-				Configure(clusters.EdsCluster(given.clusterName)).
+			cluster, err := clusters.NewClusterBuilder(envoy.APIV3, given.clusterName).
+				Configure(clusters.EdsCluster()).
 				Configure(clusters.CircuitBreaker(given.circuitBreaker)).
 				Configure(clusters.Timeout(DefaultTimeout(), core_mesh.ProtocolTCP)).
 				Build()
@@ -35,6 +35,7 @@ var _ = Describe("CircuitBreakerConfigurer", func() {
 			Expect(actual).To(MatchYAML(given.expected))
 		},
 		Entry("CircuitBreaker with thresholds", testCase{
+			clusterName: "backend",
 			circuitBreaker: &core_mesh.CircuitBreakerResource{
 				Spec: &mesh_proto.CircuitBreaker{
 					Conf: &mesh_proto.CircuitBreaker_Conf{
@@ -59,6 +60,7 @@ var _ = Describe("CircuitBreakerConfigurer", func() {
           edsConfig:
             ads: {}
             resourceApiVersion: V3
+        name: backend
         type: EDS`,
 		}),
 	)

--- a/pkg/xds/envoy/clusters/v3/client_side_mtls_configurer_test.go
+++ b/pkg/xds/envoy/clusters/v3/client_side_mtls_configurer_test.go
@@ -26,8 +26,8 @@ var _ = Describe("EdsClusterConfigurer", func() {
 		func(given testCase) {
 			// when
 			tracker := envoy.NewSecretsTracker(given.mesh.GetMeta().GetName(), nil)
-			cluster, err := clusters.NewClusterBuilder(envoy.APIV3).
-				Configure(clusters.EdsCluster(given.clusterName)).
+			cluster, err := clusters.NewClusterBuilder(envoy.APIV3, given.clusterName).
+				Configure(clusters.EdsCluster()).
 				Configure(clusters.ClientSideMTLS(tracker, given.mesh, given.clientService, true, given.tags)).
 				Configure(clusters.Timeout(DefaultTimeout(), core_mesh.ProtocolTCP)).
 				Build()

--- a/pkg/xds/envoy/clusters/v3/client_side_tls_configurer_test.go
+++ b/pkg/xds/envoy/clusters/v3/client_side_tls_configurer_test.go
@@ -21,8 +21,8 @@ var _ = Describe("ClientSideTLSConfigurer", func() {
 	DescribeTable("should generate proper Envoy config",
 		func(given testCase) {
 			// when
-			cluster, err := clusters.NewClusterBuilder(envoy.APIV3).
-				Configure(clusters.EdsCluster(given.clusterName)).
+			cluster, err := clusters.NewClusterBuilder(envoy.APIV3, given.clusterName).
+				Configure(clusters.EdsCluster()).
 				Configure(clusters.ClientSideTLS(given.endpoints)).
 				Configure(clusters.Timeout(DefaultTimeout(), core_mesh.ProtocolTCP)).
 				Build()

--- a/pkg/xds/envoy/clusters/v3/eds_cluster_configurer.go
+++ b/pkg/xds/envoy/clusters/v3/eds_cluster_configurer.go
@@ -5,14 +5,11 @@ import (
 	envoy_core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 )
 
-type EdsClusterConfigurer struct {
-	Name string
-}
+type EdsClusterConfigurer struct{}
 
 var _ ClusterConfigurer = &EdsClusterConfigurer{}
 
 func (e *EdsClusterConfigurer) Configure(c *envoy_cluster.Cluster) error {
-	c.Name = e.Name
 	c.ClusterDiscoveryType = &envoy_cluster.Cluster_Type{Type: envoy_cluster.Cluster_EDS}
 	c.EdsClusterConfig = &envoy_cluster.Cluster_EdsClusterConfig{
 		EdsConfig: &envoy_core.ConfigSource{

--- a/pkg/xds/envoy/clusters/v3/eds_cluster_configurer_test.go
+++ b/pkg/xds/envoy/clusters/v3/eds_cluster_configurer_test.go
@@ -25,8 +25,8 @@ var _ = Describe("EdsClusterConfigurer", func() {
         type: EDS`
 
 		// when
-		cluster, err := clusters.NewClusterBuilder(envoy.APIV3).
-			Configure(clusters.EdsCluster(clusterName)).
+		cluster, err := clusters.NewClusterBuilder(envoy.APIV3, clusterName).
+			Configure(clusters.EdsCluster()).
 			Configure(clusters.Timeout(DefaultTimeout(), core_mesh.ProtocolTCP)).
 			Build()
 

--- a/pkg/xds/envoy/clusters/v3/endpoint_cluster_configurer.go
+++ b/pkg/xds/envoy/clusters/v3/endpoint_cluster_configurer.go
@@ -22,7 +22,6 @@ func (e *ProvidedEndpointClusterConfigurer) Configure(c *envoy_cluster.Cluster) 
 	if len(e.Endpoints) == 0 {
 		return errors.New("cluster must have at least 1 endpoint")
 	}
-	c.Name = e.Name
 	if len(e.Endpoints) > 1 {
 		c.LbPolicy = envoy_cluster.Cluster_ROUND_ROBIN
 	}

--- a/pkg/xds/envoy/clusters/v3/endpoint_cluster_configurer_test.go
+++ b/pkg/xds/envoy/clusters/v3/endpoint_cluster_configurer_test.go
@@ -35,8 +35,8 @@ var _ = Describe("ProvidedEndpointClusterConfigurer", func() {
         type: STRICT_DNS`
 
 		// when
-		cluster, err := clusters.NewClusterBuilder(envoy.APIV3).
-			Configure(clusters.ProvidedEndpointCluster(clusterName, false,
+		cluster, err := clusters.NewClusterBuilder(envoy.APIV3, clusterName).
+			Configure(clusters.ProvidedEndpointCluster(false,
 				core_xds.Endpoint{
 					Target: address,
 					Port:   port,
@@ -80,8 +80,8 @@ var _ = Describe("ProvidedEndpointClusterConfigurer", func() {
         type: STRICT_DNS`
 
 		// when
-		cluster, err := clusters.NewClusterBuilder(envoy.APIV3).
-			Configure(clusters.ProvidedEndpointCluster(clusterName, true,
+		cluster, err := clusters.NewClusterBuilder(envoy.APIV3, clusterName).
+			Configure(clusters.ProvidedEndpointCluster(true,
 				core_xds.Endpoint{
 					Target: address,
 					Port:   port,
@@ -124,8 +124,8 @@ var _ = Describe("ProvidedEndpointClusterConfigurer", func() {
         type: STATIC`
 
 		// when
-		cluster, err := clusters.NewClusterBuilder(envoy.APIV3).
-			Configure(clusters.ProvidedEndpointCluster(clusterName, false, core_xds.Endpoint{Target: address, Port: port})).
+		cluster, err := clusters.NewClusterBuilder(envoy.APIV3, clusterName).
+			Configure(clusters.ProvidedEndpointCluster(false, core_xds.Endpoint{Target: address, Port: port})).
 			Configure(clusters.Timeout(DefaultTimeout(), core_mesh.ProtocolTCP)).
 			Build()
 
@@ -156,8 +156,8 @@ var _ = Describe("ProvidedEndpointClusterConfigurer", func() {
         type: STATIC`
 
 		// when
-		cluster, err := clusters.NewClusterBuilder(envoy.APIV3).
-			Configure(clusters.ProvidedEndpointCluster(clusterName, false, core_xds.Endpoint{UnixDomainPath: path})).
+		cluster, err := clusters.NewClusterBuilder(envoy.APIV3, clusterName).
+			Configure(clusters.ProvidedEndpointCluster(false, core_xds.Endpoint{UnixDomainPath: path})).
 			Configure(clusters.Timeout(DefaultTimeout(), core_mesh.ProtocolTCP)).
 			Build()
 

--- a/pkg/xds/envoy/clusters/v3/health_check_configurer_test.go
+++ b/pkg/xds/envoy/clusters/v3/health_check_configurer_test.go
@@ -24,8 +24,8 @@ var _ = Describe("HealthCheckConfigurer", func() {
 	DescribeTable("should generate proper Envoy config",
 		func(given testCase) {
 			// when
-			cluster, err := clusters.NewClusterBuilder(envoy.APIV3).
-				Configure(clusters.EdsCluster(given.clusterName)).
+			cluster, err := clusters.NewClusterBuilder(envoy.APIV3, given.clusterName).
+				Configure(clusters.EdsCluster()).
 				Configure(clusters.HealthCheck(core_mesh.ProtocolHTTP, given.healthCheck)).
 				Configure(clusters.Timeout(DefaultTimeout(), core_mesh.ProtocolTCP)).
 				Build()

--- a/pkg/xds/envoy/clusters/v3/http2_configurer_test.go
+++ b/pkg/xds/envoy/clusters/v3/http2_configurer_test.go
@@ -13,6 +13,7 @@ var _ = Describe("Http2Configurer", func() {
 	It("should generate proper Envoy config", func() {
 		// given
 		expected := `
+        name: http2
         typedExtensionProtocolOptions:
           envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
             '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
@@ -20,7 +21,7 @@ var _ = Describe("Http2Configurer", func() {
               http2ProtocolOptions: {}`
 
 		// when
-		cluster, err := clusters.NewClusterBuilder(envoy.APIV3).
+		cluster, err := clusters.NewClusterBuilder(envoy.APIV3, "http2").
 			Configure(clusters.Http2()).
 			Build()
 

--- a/pkg/xds/envoy/clusters/v3/http_configurer_test.go
+++ b/pkg/xds/envoy/clusters/v3/http_configurer_test.go
@@ -13,6 +13,7 @@ var _ = Describe("HttpConfigurer", func() {
 	It("should generate proper Envoy config", func() {
 		// given
 		expected := `
+        name: http
         typedExtensionProtocolOptions:
           envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
             '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
@@ -20,7 +21,7 @@ var _ = Describe("HttpConfigurer", func() {
               httpProtocolOptions: {}`
 
 		// when
-		cluster, err := clusters.NewClusterBuilder(envoy.APIV3).
+		cluster, err := clusters.NewClusterBuilder(envoy.APIV3, "http").
 			Configure(clusters.Http()).
 			Build()
 

--- a/pkg/xds/envoy/clusters/v3/lb_configurer_test.go
+++ b/pkg/xds/envoy/clusters/v3/lb_configurer_test.go
@@ -21,8 +21,8 @@ var _ = Describe("Lb", func() {
 	DescribeTable("should generate proper Envoy config",
 		func(given testCase) {
 			// when
-			cluster, err := clusters.NewClusterBuilder(envoy.APIV3).
-				Configure(clusters.EdsCluster(given.clusterName)).
+			cluster, err := clusters.NewClusterBuilder(envoy.APIV3, given.clusterName).
+				Configure(clusters.EdsCluster()).
 				Configure(clusters.LB(given.lb)).
 				Configure(clusters.Timeout(DefaultTimeout(), core_mesh.ProtocolTCP)).
 				Build()

--- a/pkg/xds/envoy/clusters/v3/lb_subset_configurer_test.go
+++ b/pkg/xds/envoy/clusters/v3/lb_subset_configurer_test.go
@@ -21,8 +21,8 @@ var _ = Describe("LbSubset", func() {
 	DescribeTable("should generate proper Envoy config",
 		func(given testCase) {
 			// when
-			cluster, err := clusters.NewClusterBuilder(envoy.APIV3).
-				Configure(clusters.EdsCluster(given.clusterName)).
+			cluster, err := clusters.NewClusterBuilder(envoy.APIV3, given.clusterName).
+				Configure(clusters.EdsCluster()).
 				Configure(clusters.LbSubset(given.tags)).
 				Configure(clusters.Timeout(DefaultTimeout(), core_mesh.ProtocolTCP)).
 				Build()

--- a/pkg/xds/envoy/clusters/v3/outlier_detection_configurer_test.go
+++ b/pkg/xds/envoy/clusters/v3/outlier_detection_configurer_test.go
@@ -21,8 +21,8 @@ var _ = Describe("OutlierDetectionConfigurer", func() {
 	DescribeTable("should generate proper Envoy config",
 		func(given testCase) {
 			// when
-			cluster, err := clusters.NewClusterBuilder(envoy.APIV3).
-				Configure(clusters.EdsCluster(given.clusterName)).
+			cluster, err := clusters.NewClusterBuilder(envoy.APIV3, given.clusterName).
+				Configure(clusters.EdsCluster()).
 				Configure(clusters.OutlierDetection(given.circuitBreaker)).
 				Configure(clusters.Timeout(DefaultTimeout(), core_mesh.ProtocolTCP)).
 				Build()
@@ -35,6 +35,7 @@ var _ = Describe("OutlierDetectionConfigurer", func() {
 			Expect(actual).To(MatchYAML(given.expected))
 		},
 		Entry("CircuitBreaker with TotalError detector, default values", testCase{
+			clusterName: "backend",
 			circuitBreaker: &core_mesh.CircuitBreakerResource{
 				Spec: &mesh_proto.CircuitBreaker{
 					Conf: &mesh_proto.CircuitBreaker_Conf{
@@ -50,6 +51,7 @@ var _ = Describe("OutlierDetectionConfigurer", func() {
               edsConfig:
                 ads: {}
                 resourceApiVersion: V3
+            name: backend
             outlierDetection:
               enforcingConsecutive5xx: 100
               enforcingConsecutiveGatewayFailure: 0
@@ -59,6 +61,7 @@ var _ = Describe("OutlierDetectionConfigurer", func() {
             type: EDS`,
 		}),
 		Entry("CircuitBreaker with GatewayError detector, default values", testCase{
+			clusterName: "backend",
 			circuitBreaker: &core_mesh.CircuitBreakerResource{
 				Spec: &mesh_proto.CircuitBreaker{
 					Conf: &mesh_proto.CircuitBreaker_Conf{
@@ -74,6 +77,7 @@ var _ = Describe("OutlierDetectionConfigurer", func() {
               edsConfig:
                 ads: {}
                 resourceApiVersion: V3
+            name: backend
             outlierDetection:
               enforcingConsecutive5xx: 0
               enforcingConsecutiveGatewayFailure: 100
@@ -83,6 +87,7 @@ var _ = Describe("OutlierDetectionConfigurer", func() {
             type: EDS`,
 		}),
 		Entry("CircuitBreaker with LocalError detector, default values", testCase{
+			clusterName: "backend",
 			circuitBreaker: &core_mesh.CircuitBreakerResource{
 				Spec: &mesh_proto.CircuitBreaker{
 					Conf: &mesh_proto.CircuitBreaker_Conf{
@@ -98,6 +103,7 @@ var _ = Describe("OutlierDetectionConfigurer", func() {
               edsConfig:
                 ads: {}
                 resourceApiVersion: V3
+            name: backend
             outlierDetection:
               enforcingConsecutive5xx: 0
               enforcingConsecutiveGatewayFailure: 0
@@ -107,6 +113,7 @@ var _ = Describe("OutlierDetectionConfigurer", func() {
             type: EDS`,
 		}),
 		Entry("CircuitBreaker with all error detectors, custom values", testCase{
+			clusterName: "backend",
 			circuitBreaker: &core_mesh.CircuitBreakerResource{
 				Spec: &mesh_proto.CircuitBreaker{
 					Conf: &mesh_proto.CircuitBreaker_Conf{
@@ -124,6 +131,7 @@ var _ = Describe("OutlierDetectionConfigurer", func() {
               edsConfig:
                 ads: {}
                 resourceApiVersion: V3
+            name: backend
             outlierDetection:
               consecutive5xx: 21
               consecutiveGatewayFailure: 11
@@ -136,6 +144,7 @@ var _ = Describe("OutlierDetectionConfigurer", func() {
             type: EDS`,
 		}),
 		Entry("CircuitBreaker with StandardDeviation detector, default values", testCase{
+			clusterName: "backend",
 			circuitBreaker: &core_mesh.CircuitBreakerResource{
 				Spec: &mesh_proto.CircuitBreaker{
 					Conf: &mesh_proto.CircuitBreaker_Conf{
@@ -151,6 +160,7 @@ var _ = Describe("OutlierDetectionConfigurer", func() {
               edsConfig:
                 ads: {}
                 resourceApiVersion: V3
+            name: backend
             outlierDetection:
               enforcingConsecutive5xx: 0
               enforcingConsecutiveGatewayFailure: 0
@@ -161,6 +171,7 @@ var _ = Describe("OutlierDetectionConfigurer", func() {
             type: EDS`,
 		}),
 		Entry("CircuitBreaker with StandardDeviation detector, custom values", testCase{
+			clusterName: "backend",
 			circuitBreaker: &core_mesh.CircuitBreakerResource{
 				Spec: &mesh_proto.CircuitBreaker{
 					Conf: &mesh_proto.CircuitBreaker_Conf{
@@ -180,6 +191,7 @@ var _ = Describe("OutlierDetectionConfigurer", func() {
               edsConfig:
                 ads: {}
                 resourceApiVersion: V3
+            name: backend
             outlierDetection:
               enforcingConsecutive5xx: 0
               enforcingConsecutiveGatewayFailure: 0
@@ -193,6 +205,7 @@ var _ = Describe("OutlierDetectionConfigurer", func() {
             type: EDS`,
 		}),
 		Entry("CircuitBreaker with Failure detector, default values", testCase{
+			clusterName: "backend",
 			circuitBreaker: &core_mesh.CircuitBreakerResource{
 				Spec: &mesh_proto.CircuitBreaker{
 					Conf: &mesh_proto.CircuitBreaker_Conf{
@@ -208,6 +221,7 @@ var _ = Describe("OutlierDetectionConfigurer", func() {
               edsConfig:
                 ads: {}
                 resourceApiVersion: V3
+            name: backend
             outlierDetection:
               enforcingConsecutive5xx: 0
               enforcingConsecutiveGatewayFailure: 0
@@ -218,6 +232,7 @@ var _ = Describe("OutlierDetectionConfigurer", func() {
             type: EDS`,
 		}),
 		Entry("CircuitBreaker with Failure detector, custom values", testCase{
+			clusterName: "backend",
 			circuitBreaker: &core_mesh.CircuitBreakerResource{
 				Spec: &mesh_proto.CircuitBreaker{
 					Conf: &mesh_proto.CircuitBreaker_Conf{
@@ -237,6 +252,7 @@ var _ = Describe("OutlierDetectionConfigurer", func() {
               edsConfig:
                 ads: {}
                 resourceApiVersion: V3
+            name: backend
             outlierDetection:
               enforcingConsecutive5xx: 0
               enforcingConsecutiveGatewayFailure: 0

--- a/pkg/xds/envoy/clusters/v3/pass_through_cluster_configurer.go
+++ b/pkg/xds/envoy/clusters/v3/pass_through_cluster_configurer.go
@@ -4,14 +4,11 @@ import (
 	envoy_cluster "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
 )
 
-type PassThroughClusterConfigurer struct {
-	Name string
-}
+type PassThroughClusterConfigurer struct{}
 
 var _ ClusterConfigurer = &PassThroughClusterConfigurer{}
 
 func (p *PassThroughClusterConfigurer) Configure(c *envoy_cluster.Cluster) error {
-	c.Name = p.Name
 	c.ClusterDiscoveryType = &envoy_cluster.Cluster_Type{Type: envoy_cluster.Cluster_ORIGINAL_DST}
 	c.LbPolicy = envoy_cluster.Cluster_CLUSTER_PROVIDED
 	return nil

--- a/pkg/xds/envoy/clusters/v3/pass_through_cluster_configurer_test.go
+++ b/pkg/xds/envoy/clusters/v3/pass_through_cluster_configurer_test.go
@@ -22,8 +22,8 @@ var _ = Describe("PassThroughClusterConfigurer", func() {
         type: ORIGINAL_DST`
 
 		// when
-		cluster, err := clusters.NewClusterBuilder(envoy.APIV3).
-			Configure(clusters.PassThroughCluster(clusterName)).
+		cluster, err := clusters.NewClusterBuilder(envoy.APIV3, clusterName).
+			Configure(clusters.PassThroughCluster()).
 			Configure(clusters.Timeout(DefaultTimeout(), core_mesh.ProtocolTCP)).
 			Build()
 

--- a/pkg/xds/envoy/clusters/v3/timeout_configurer_test.go
+++ b/pkg/xds/envoy/clusters/v3/timeout_configurer_test.go
@@ -52,8 +52,8 @@ var _ = Describe("TimeoutConfigurer", func() {
 	DescribeTable("should set timeouts for outbound HTTP cluster",
 		func(given testCase) {
 			// given
-			cluster, err := clusters.NewClusterBuilder(envoy.APIV3).
-				Configure(clusters.EdsCluster("backend")).
+			cluster, err := clusters.NewClusterBuilder(envoy.APIV3, "backend").
+				Configure(clusters.EdsCluster()).
 				Configure(clusters.Timeout(given.timeout, core_mesh.ProtocolHTTP)).
 				Build()
 			Expect(err).ToNot(HaveOccurred())
@@ -119,8 +119,8 @@ typedExtensionProtocolOptions:
 	DescribeTable("should set timeouts for outbound GRPC cluster",
 		func(given testCase) {
 			// given
-			cluster, err := clusters.NewClusterBuilder(envoy.APIV3).
-				Configure(clusters.EdsCluster("backend")).
+			cluster, err := clusters.NewClusterBuilder(envoy.APIV3, "backend").
+				Configure(clusters.EdsCluster()).
 				Configure(clusters.Timeout(given.timeout, core_mesh.ProtocolGRPC)).
 				Build()
 			Expect(err).ToNot(HaveOccurred())
@@ -186,8 +186,8 @@ typedExtensionProtocolOptions:
 
 	It("should set timeouts for inbound HTTP cluster", func() {
 		// given
-		cluster, err := clusters.NewClusterBuilder(envoy.APIV3).
-			Configure(clusters.ProvidedEndpointCluster("localhost:8080", false, core_xds.Endpoint{Target: "192.168.0.1", Port: 8080})).
+		cluster, err := clusters.NewClusterBuilder(envoy.APIV3, "localhost:8080").
+			Configure(clusters.ProvidedEndpointCluster(false, core_xds.Endpoint{Target: "192.168.0.1", Port: 8080})).
 			Configure(clusters.Timeout(mesh.DefaultInboundTimeout(), core_mesh.ProtocolHTTP)).
 			Build()
 		Expect(err).ToNot(HaveOccurred())

--- a/pkg/xds/generator/admin_proxy_generator.go
+++ b/pkg/xds/generator/admin_proxy_generator.go
@@ -45,8 +45,8 @@ func (g AdminProxyGenerator) Generate(ctx xds_context.Context, proxy *core_xds.P
 	// as a gateway to another host.
 	adminAddress := "127.0.0.1"
 	envoyAdminClusterName := envoy_names.GetEnvoyAdminClusterName()
-	cluster, err := envoy_clusters.NewClusterBuilder(proxy.APIVersion).
-		Configure(envoy_clusters.ProvidedEndpointCluster(envoyAdminClusterName, false, core_xds.Endpoint{Target: adminAddress, Port: adminPort})).
+	cluster, err := envoy_clusters.NewClusterBuilder(proxy.APIVersion, envoyAdminClusterName).
+		Configure(envoy_clusters.ProvidedEndpointCluster(false, core_xds.Endpoint{Target: adminAddress, Port: adminPort})).
 		Configure(envoy_clusters.DefaultTimeout()).
 		Build()
 	if err != nil {

--- a/pkg/xds/generator/direct_access_proxy_generator.go
+++ b/pkg/xds/generator/direct_access_proxy_generator.go
@@ -73,8 +73,8 @@ func (_ DirectAccessProxyGenerator) Generate(ctx xds_context.Context, proxy *cor
 		})
 	}
 
-	directAccessCluster, err := envoy_clusters.NewClusterBuilder(proxy.APIVersion).
-		Configure(envoy_clusters.PassThroughCluster("direct_access")).
+	directAccessCluster, err := envoy_clusters.NewClusterBuilder(proxy.APIVersion, "direct_access").
+		Configure(envoy_clusters.PassThroughCluster()).
 		Configure(envoy_clusters.UnknownDestinationClientSideMTLS(proxy.SecretsTracker, ctx.Mesh.Resource)).
 		Configure(envoy_clusters.DefaultTimeout()).
 		Build()

--- a/pkg/xds/generator/egress/external_services_generator.go
+++ b/pkg/xds/generator/egress/external_services_generator.go
@@ -78,9 +78,8 @@ func (*ExternalServicesGenerator) generateCDS(
 		// name as we would overwrite some clusters with the latest one
 		clusterName := envoy_names.GetMeshClusterName(meshName, serviceName)
 
-		clusterBuilder := envoy_clusters.NewClusterBuilder(apiVersion).
+		clusterBuilder := envoy_clusters.NewClusterBuilder(apiVersion, clusterName).
 			Configure(envoy_clusters.ProvidedEndpointCluster(
-				clusterName,
 				isIPV6,
 				endpoints...,
 			)).

--- a/pkg/xds/generator/egress/internal_services_generator.go
+++ b/pkg/xds/generator/egress/internal_services_generator.go
@@ -102,8 +102,8 @@ func (*InternalServicesGenerator) generateCDS(
 		// name as we would overwrite some clusters with the latest one
 		clusterName := envoy_names.GetMeshClusterName(meshName, serviceName)
 
-		edsCluster, err := envoy_clusters.NewClusterBuilder(apiVersion).
-			Configure(envoy_clusters.EdsCluster(clusterName)).
+		edsCluster, err := envoy_clusters.NewClusterBuilder(apiVersion, clusterName).
+			Configure(envoy_clusters.EdsCluster()).
 			Configure(envoy_clusters.LbSubset(tagKeySlice)).
 			Configure(envoy_clusters.DefaultTimeout()).
 			Build()

--- a/pkg/xds/generator/inbound_proxy_generator.go
+++ b/pkg/xds/generator/inbound_proxy_generator.go
@@ -36,8 +36,8 @@ func (g InboundProxyGenerator) Generate(ctx xds_context.Context, proxy *core_xds
 
 		// generate CDS resource
 		localClusterName := envoy_names.GetLocalClusterName(endpoint.WorkloadPort)
-		clusterBuilder := envoy_clusters.NewClusterBuilder(proxy.APIVersion).
-			Configure(envoy_clusters.ProvidedEndpointCluster(localClusterName, false, core_xds.Endpoint{Target: endpoint.WorkloadIP, Port: endpoint.WorkloadPort})).
+		clusterBuilder := envoy_clusters.NewClusterBuilder(proxy.APIVersion, localClusterName).
+			Configure(envoy_clusters.ProvidedEndpointCluster(false, core_xds.Endpoint{Target: endpoint.WorkloadIP, Port: endpoint.WorkloadPort})).
 			Configure(envoy_clusters.Timeout(defaults_mesh.DefaultInboundTimeout(), protocol))
 		// localhost traffic is routed dirrectly to the application, in case of other interface we are going to set source address to
 		if proxy.Dataplane.IsUsingTransparentProxy() && (endpoint.WorkloadIP != core_mesh.IPv4Loopback.String() || endpoint.WorkloadIP != core_mesh.IPv6Loopback.String()) {

--- a/pkg/xds/generator/ingress_generator.go
+++ b/pkg/xds/generator/ingress_generator.go
@@ -196,8 +196,8 @@ func (i IngressGenerator) generateCDS(
 			envoy_tags.With("mesh"),
 		)
 
-		edsCluster, err := envoy_clusters.NewClusterBuilder(apiVersion).
-			Configure(envoy_clusters.EdsCluster(clusterName)).
+		edsCluster, err := envoy_clusters.NewClusterBuilder(apiVersion, clusterName).
+			Configure(envoy_clusters.EdsCluster()).
 			Configure(envoy_clusters.LbSubset(tagKeySlice)).
 			Configure(envoy_clusters.DefaultTimeout()).
 			Build()

--- a/pkg/xds/generator/prometheus_endpoint_generator.go
+++ b/pkg/xds/generator/prometheus_endpoint_generator.go
@@ -60,8 +60,8 @@ func (g PrometheusEndpointGenerator) Generate(ctx xds_context.Context, proxy *co
 
 	statsPath := "/" + buildEnvoyMetricsFilter(prometheusEndpoint)
 	metricsHijackerClusterName := envoy_names.GetMetricsHijackerClusterName()
-	cluster, err := envoy_clusters.NewClusterBuilder(proxy.APIVersion).
-		Configure(envoy_clusters.ProvidedEndpointCluster(metricsHijackerClusterName, proxy.Dataplane.IsIPv6(),
+	cluster, err := envoy_clusters.NewClusterBuilder(proxy.APIVersion, metricsHijackerClusterName).
+		Configure(envoy_clusters.ProvidedEndpointCluster(proxy.Dataplane.IsIPv6(),
 			core_xds.Endpoint{
 				UnixDomainPath: envoy_common.MetricsHijackerSocketName(proxy.Dataplane.Meta.GetName(), proxy.Dataplane.Meta.GetMesh()),
 			},

--- a/pkg/xds/generator/tracing_proxy_generator.go
+++ b/pkg/xds/generator/tracing_proxy_generator.go
@@ -53,8 +53,8 @@ func (t TracingProxyGenerator) Generate(ctx xds_context.Context, proxy *core_xds
 	}
 
 	clusterName := names.GetTracingClusterName(tracingBackend.Name)
-	res, err := clusters.NewClusterBuilder(proxy.APIVersion).
-		Configure(clusters.ProvidedEndpointCluster(clusterName, proxy.Dataplane.IsIPv6(), *endpoint)).
+	res, err := clusters.NewClusterBuilder(proxy.APIVersion, clusterName).
+		Configure(clusters.ProvidedEndpointCluster(proxy.Dataplane.IsIPv6(), *endpoint)).
 		Configure(clusters.ClientSideTLS([]core_xds.Endpoint{*endpoint})).
 		Configure(clusters.DefaultTimeout()).
 		Build()

--- a/pkg/xds/generator/transparent_proxy_generator.go
+++ b/pkg/xds/generator/transparent_proxy_generator.go
@@ -66,8 +66,8 @@ func (_ TransparentProxyGenerator) generate(ctx xds_context.Context, proxy *mode
 	var err error
 
 	if ctx.Mesh.Resource.Spec.IsPassthrough() {
-		outboundPassThroughCluster, err = envoy_clusters.NewClusterBuilder(proxy.APIVersion).
-			Configure(envoy_clusters.PassThroughCluster(outboundName)).
+		outboundPassThroughCluster, err = envoy_clusters.NewClusterBuilder(proxy.APIVersion, outboundName).
+			Configure(envoy_clusters.PassThroughCluster()).
 			Configure(envoy_clusters.DefaultTimeout()).
 			Build()
 		if err != nil {
@@ -93,8 +93,8 @@ func (_ TransparentProxyGenerator) generate(ctx xds_context.Context, proxy *mode
 		return nil, errors.Wrapf(err, "could not generate listener: %s", outboundName)
 	}
 
-	inboundPassThroughCluster, err := envoy_clusters.NewClusterBuilder(proxy.APIVersion).
-		Configure(envoy_clusters.PassThroughCluster(inboundName)).
+	inboundPassThroughCluster, err := envoy_clusters.NewClusterBuilder(proxy.APIVersion, inboundName).
+		Configure(envoy_clusters.PassThroughCluster()).
 		Configure(envoy_clusters.UpstreamBindConfig(inPassThroughIP, 0)).
 		Configure(envoy_clusters.DefaultTimeout()).
 		Build()


### PR DESCRIPTION
Defines the cluster name as a required field for the builder constructor function and adds a validation in the final build function   to throw an error if the field is blank.
It also removes the name assignation from several configurers. It asserts that the name shall be known when the builder is instantiated.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [ ] [Link to relevant issue][1] as well as docs and UI issues -- #2538
- [ ] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [ ] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [ ] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [ ] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [ ] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
