### PR TITLE
feat(xds): named resources (listeners) builders require name

### DIFF
--- a/pkg/plugins/bootstrap/k8s/xds/hooks/api_server_bypass.go
+++ b/pkg/plugins/bootstrap/k8s/xds/hooks/api_server_bypass.go
@@ -38,8 +38,8 @@ func (h ApiServerBypass) Modify(resources *core_xds.ResourceSet, ctx xds_context
 		return nil
 	}
 
-	listener, err := envoy_listeners.NewListenerBuilder(proxy.APIVersion).
-		Configure(envoy_listeners.OutboundListener(apiServerBypassHookResourcesName, h.Address, h.Port, core_xds.SocketAddressProtocolTCP)).
+	listener, err := envoy_listeners.NewOutboundListenerBuilder(proxy.APIVersion, h.Address, h.Port, core_xds.SocketAddressProtocolTCP).
+		WithName(apiServerBypassHookResourcesName).
 		Configure(envoy_listeners.FilterChain(envoy_listeners.NewFilterChainBuilder(proxy.APIVersion).
 			Configure(envoy_listeners.TcpProxyDeprecated(apiServerBypassHookResourcesName, envoy_common.NewCluster(envoy_common.WithService(apiServerBypassHookResourcesName)))))).
 		Configure(envoy_listeners.NoBindToPort()).

--- a/pkg/plugins/bootstrap/k8s/xds/hooks/api_server_bypass.go
+++ b/pkg/plugins/bootstrap/k8s/xds/hooks/api_server_bypass.go
@@ -39,7 +39,7 @@ func (h ApiServerBypass) Modify(resources *core_xds.ResourceSet, ctx xds_context
 	}
 
 	listener, err := envoy_listeners.NewOutboundListenerBuilder(proxy.APIVersion, h.Address, h.Port, core_xds.SocketAddressProtocolTCP).
-		WithName(apiServerBypassHookResourcesName).
+		WithOverwriteName(apiServerBypassHookResourcesName).
 		Configure(envoy_listeners.FilterChain(envoy_listeners.NewFilterChainBuilder(proxy.APIVersion).
 			Configure(envoy_listeners.TcpProxyDeprecated(apiServerBypassHookResourcesName, envoy_common.NewCluster(envoy_common.WithService(apiServerBypassHookResourcesName)))))).
 		Configure(envoy_listeners.NoBindToPort()).

--- a/pkg/plugins/policies/meshaccesslog/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshaccesslog/plugin/v1alpha1/plugin_test.go
@@ -118,8 +118,7 @@ var _ = Describe("MeshAccessLog", func() {
 			resources: []core_xds.Resource{{
 				Name:   "outbound",
 				Origin: generator.OriginOutbound,
-				Resource: NewListenerBuilder(envoy_common.APIV3).
-					Configure(OutboundListener("outbound:127.0.0.1:27777", "127.0.0.1", 27777, core_xds.SocketAddressProtocolTCP)).
+				Resource: NewOutboundListenerBuilder(envoy_common.APIV3, "127.0.0.1", 27777, core_xds.SocketAddressProtocolTCP).
 					Configure(FilterChain(NewFilterChainBuilder(envoy_common.APIV3).
 						Configure(HttpConnectionManager("127.0.0.1:27777", false)).
 						Configure(
@@ -204,8 +203,7 @@ var _ = Describe("MeshAccessLog", func() {
 			resources: []core_xds.Resource{{
 				Name:   "outbound",
 				Origin: generator.OriginOutbound,
-				Resource: NewListenerBuilder(envoy_common.APIV3).
-					Configure(OutboundListener("outbound:127.0.0.1:27777", "127.0.0.1", 27777, core_xds.SocketAddressProtocolTCP)).
+				Resource: NewOutboundListenerBuilder(envoy_common.APIV3, "127.0.0.1", 27777, core_xds.SocketAddressProtocolTCP).
 					Configure(FilterChain(NewFilterChainBuilder(envoy_common.APIV3).
 						Configure(TcpProxyDeprecated(
 							"127.0.0.1:27777",
@@ -260,8 +258,7 @@ var _ = Describe("MeshAccessLog", func() {
 			resources: []core_xds.Resource{{
 				Name:   "outbound",
 				Origin: generator.OriginOutbound,
-				Resource: NewListenerBuilder(envoy_common.APIV3).
-					Configure(OutboundListener("outbound:127.0.0.1:27777", "127.0.0.1", 27777, core_xds.SocketAddressProtocolTCP)).
+				Resource: NewOutboundListenerBuilder(envoy_common.APIV3, "127.0.0.1", 27777, core_xds.SocketAddressProtocolTCP).
 					Configure(FilterChain(NewFilterChainBuilder(envoy_common.APIV3).
 						Configure(TcpProxyDeprecated(
 							"127.0.0.1:27777",
@@ -319,8 +316,7 @@ var _ = Describe("MeshAccessLog", func() {
 			resources: []core_xds.Resource{{
 				Name:   "outbound",
 				Origin: generator.OriginOutbound,
-				Resource: NewListenerBuilder(envoy_common.APIV3).
-					Configure(OutboundListener("outbound:127.0.0.1:27777", "127.0.0.1", 27777, core_xds.SocketAddressProtocolTCP)).
+				Resource: NewOutboundListenerBuilder(envoy_common.APIV3, "127.0.0.1", 27777, core_xds.SocketAddressProtocolTCP).
 					Configure(FilterChain(NewFilterChainBuilder(envoy_common.APIV3).
 						Configure(TcpProxyDeprecated(
 							"127.0.0.1:27777",
@@ -381,8 +377,7 @@ var _ = Describe("MeshAccessLog", func() {
 			resources: []core_xds.Resource{{
 				Name:   "outbound",
 				Origin: generator.OriginOutbound,
-				Resource: NewListenerBuilder(envoy_common.APIV3).
-					Configure(OutboundListener("outbound:127.0.0.1:27777", "127.0.0.1", 27777, core_xds.SocketAddressProtocolTCP)).
+				Resource: NewOutboundListenerBuilder(envoy_common.APIV3, "127.0.0.1", 27777, core_xds.SocketAddressProtocolTCP).
 					Configure(FilterChain(NewFilterChainBuilder(envoy_common.APIV3).
 						Configure(TcpProxyDeprecated(
 							"127.0.0.1:27777",
@@ -438,8 +433,7 @@ var _ = Describe("MeshAccessLog", func() {
 			resources: []core_xds.Resource{{
 				Name:   "other-service",
 				Origin: generator.OriginOutbound,
-				Resource: NewListenerBuilder(envoy_common.APIV3).
-					Configure(OutboundListener("outbound:127.0.0.1:27777", "127.0.0.1", 27777, core_xds.SocketAddressProtocolTCP)).
+				Resource: NewOutboundListenerBuilder(envoy_common.APIV3, "127.0.0.1", 27777, core_xds.SocketAddressProtocolTCP).
 					Configure(FilterChain(NewFilterChainBuilder(envoy_common.APIV3).
 						Configure(TcpProxyDeprecated(
 							"127.0.0.1:27777",
@@ -452,8 +446,7 @@ var _ = Describe("MeshAccessLog", func() {
 			}, {
 				Name:   "foo",
 				Origin: generator.OriginOutbound,
-				Resource: NewListenerBuilder(envoy_common.APIV3).
-					Configure(OutboundListener("outbound:127.0.0.1:27778", "127.0.0.1", 27778, core_xds.SocketAddressProtocolTCP)).
+				Resource: NewOutboundListenerBuilder(envoy_common.APIV3, "127.0.0.1", 27778, core_xds.SocketAddressProtocolTCP).
 					Configure(FilterChain(NewFilterChainBuilder(envoy_common.APIV3).
 						Configure(TcpProxyDeprecated(
 							"127.0.0.1:27778",
@@ -466,8 +459,7 @@ var _ = Describe("MeshAccessLog", func() {
 			}, {
 				Name:   "bar",
 				Origin: generator.OriginOutbound,
-				Resource: NewListenerBuilder(envoy_common.APIV3).
-					Configure(OutboundListener("outbound:127.0.0.1:27779", "127.0.0.1", 27779, core_xds.SocketAddressProtocolTCP)).
+				Resource: NewOutboundListenerBuilder(envoy_common.APIV3, "127.0.0.1", 27779, core_xds.SocketAddressProtocolTCP).
 					Configure(FilterChain(NewFilterChainBuilder(envoy_common.APIV3).
 						Configure(TcpProxyDeprecated(
 							"127.0.0.1:27779",
@@ -546,7 +538,8 @@ var _ = Describe("MeshAccessLog", func() {
 					},
 				},
 			},
-			expectedClusters: []string{`
+			expectedClusters: []string{
+				`
             altStatName: meshaccesslog_opentelemetry_0
             connectTimeout: 10s
             dnsLookupFamily: V4_ONLY
@@ -586,7 +579,8 @@ var _ = Describe("MeshAccessLog", func() {
                     '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
                     explicitHttpConfig:
                         http2ProtocolOptions: {}
-            `},
+            `,
+			},
 			expectedListeners: []string{
 				`
             address:
@@ -677,8 +671,7 @@ var _ = Describe("MeshAccessLog", func() {
 			resources: []core_xds.Resource{{
 				Name:   "outbound",
 				Origin: generator.OriginOutbound,
-				Resource: NewListenerBuilder(envoy_common.APIV3).
-					Configure(OutboundListener("outbound:127.0.0.1:27777", "127.0.0.1", 27777, core_xds.SocketAddressProtocolTCP)).
+				Resource: NewOutboundListenerBuilder(envoy_common.APIV3, "127.0.0.1", 27777, core_xds.SocketAddressProtocolTCP).
 					Configure(FilterChain(NewFilterChainBuilder(envoy_common.APIV3).
 						Configure(TcpProxyDeprecated(
 							"127.0.0.1:27777",
@@ -737,8 +730,7 @@ var _ = Describe("MeshAccessLog", func() {
 			resources: []core_xds.Resource{{
 				Name:   "outbound",
 				Origin: generator.OriginOutbound,
-				Resource: NewListenerBuilder(envoy_common.APIV3).
-					Configure(OutboundListener("outbound:127.0.0.1:27777", "127.0.0.1", 27777, core_xds.SocketAddressProtocolTCP)).
+				Resource: NewOutboundListenerBuilder(envoy_common.APIV3, "127.0.0.1", 27777, core_xds.SocketAddressProtocolTCP).
 					Configure(FilterChain(NewFilterChainBuilder(envoy_common.APIV3).
 						Configure(TcpProxyDeprecated(
 							"127.0.0.1:27777",
@@ -801,8 +793,7 @@ var _ = Describe("MeshAccessLog", func() {
 			resources: []core_xds.Resource{{
 				Name:   "outbound",
 				Origin: generator.OriginOutbound,
-				Resource: NewListenerBuilder(envoy_common.APIV3).
-					Configure(OutboundListener("outbound:127.0.0.1:27777", "127.0.0.1", 27777, core_xds.SocketAddressProtocolTCP)).
+				Resource: NewOutboundListenerBuilder(envoy_common.APIV3, "127.0.0.1", 27777, core_xds.SocketAddressProtocolTCP).
 					Configure(FilterChain(NewFilterChainBuilder(envoy_common.APIV3).
 						Configure(HttpConnectionManager("127.0.0.1:27777", false)).
 						Configure(
@@ -883,8 +874,7 @@ var _ = Describe("MeshAccessLog", func() {
 			resources: []core_xds.Resource{{
 				Name:   "inbound",
 				Origin: generator.OriginInbound,
-				Resource: NewListenerBuilder(envoy_common.APIV3).
-					Configure(InboundListener("inbound:127.0.0.1:17777", "127.0.0.1", 17777, core_xds.SocketAddressProtocolTCP)).
+				Resource: NewInboundListenerBuilder(envoy_common.APIV3, "127.0.0.1", 17777, core_xds.SocketAddressProtocolTCP).
 					Configure(FilterChain(NewFilterChainBuilder(envoy_common.APIV3).
 						Configure(HttpConnectionManager("127.0.0.1:17777", false)).
 						Configure(

--- a/pkg/plugins/policies/meshfaultinjection/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshfaultinjection/plugin/v1alpha1/plugin_test.go
@@ -86,8 +86,7 @@ var _ = Describe("MeshFaultInjection", func() {
 				{
 					Name:   "inbound:127.0.0.1:17777",
 					Origin: generator.OriginInbound,
-					Resource: NewListenerBuilder(envoy_common.APIV3).
-						Configure(InboundListener("inbound:127.0.0.1:17777", "127.0.0.1", 17777, core_xds.SocketAddressProtocolTCP)).
+					Resource: NewInboundListenerBuilder(envoy_common.APIV3, "127.0.0.1", 17777, core_xds.SocketAddressProtocolTCP).
 						Configure(FilterChain(NewFilterChainBuilder(envoy_common.APIV3).
 							Configure(HttpConnectionManager("127.0.0.1:17777", false)).
 							Configure(
@@ -108,8 +107,7 @@ var _ = Describe("MeshFaultInjection", func() {
 				{
 					Name:   "inbound:127.0.0.1:17778",
 					Origin: generator.OriginInbound,
-					Resource: NewListenerBuilder(envoy_common.APIV3).
-						Configure(InboundListener("inbound:127.0.0.1:17778", "127.0.0.1", 17778, core_xds.SocketAddressProtocolTCP)).
+					Resource: NewInboundListenerBuilder(envoy_common.APIV3, "127.0.0.1", 17778, core_xds.SocketAddressProtocolTCP).
 						Configure(FilterChain(NewFilterChainBuilder(envoy_common.APIV3).
 							Configure(TcpProxyDeprecated("127.0.0.1:17778", envoy_common.NewCluster(envoy_common.WithName("frontend")))),
 						)).MustBuild(),

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/listeners.go
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/listeners.go
@@ -18,7 +18,6 @@ import (
 	envoy_common "github.com/kumahq/kuma/pkg/xds/envoy"
 	envoy_listeners "github.com/kumahq/kuma/pkg/xds/envoy/listeners"
 	envoy_listeners_v3 "github.com/kumahq/kuma/pkg/xds/envoy/listeners/v3"
-	envoy_names "github.com/kumahq/kuma/pkg/xds/envoy/names"
 	envoy_tags "github.com/kumahq/kuma/pkg/xds/envoy/tags"
 	"github.com/kumahq/kuma/pkg/xds/generator"
 )
@@ -38,10 +37,8 @@ func generateListeners(
 	for _, outbound := range proxy.Dataplane.Spec.GetNetworking().GetOutbound() {
 		serviceName := outbound.GetTagsIncludingLegacy()[mesh_proto.ServiceTag]
 		oface := proxy.Dataplane.Spec.Networking.ToOutboundInterface(outbound)
-		outboundListenerName := envoy_names.GetOutboundListenerName(oface.DataplaneIP, oface.DataplanePort)
 
-		listenerBuilder := envoy_listeners.NewListenerBuilder(proxy.APIVersion).
-			Configure(envoy_listeners.OutboundListener(outboundListenerName, oface.DataplaneIP, oface.DataplanePort, core_xds.SocketAddressProtocolTCP)).
+		listenerBuilder := envoy_listeners.NewOutboundListenerBuilder(proxy.APIVersion, oface.DataplaneIP, oface.DataplanePort, core_xds.SocketAddressProtocolTCP).
 			Configure(envoy_listeners.TransparentProxying(proxy.Dataplane.Spec.Networking.GetTransparentProxying())).
 			Configure(envoy_listeners.TagsMetadata(envoy_tags.Tags(outbound.GetTagsIncludingLegacy()).WithoutTags(mesh_proto.MeshTag)))
 

--- a/pkg/plugins/policies/meshloadbalancingstrategy/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshloadbalancingstrategy/plugin/v1alpha1/plugin_test.go
@@ -129,8 +129,7 @@ var _ = Describe("MeshLoadBalancingStrategy", func() {
 				{
 					Name:   "listener-backend",
 					Origin: generator.OriginOutbound,
-					Resource: NewListenerBuilder(envoy_common.APIV3).
-						Configure(OutboundListener("outbound:127.0.0.1:27777", "127.0.0.1", 27777, core_xds.SocketAddressProtocolTCP)).
+					Resource: NewOutboundListenerBuilder(envoy_common.APIV3, "127.0.0.1", 27777, core_xds.SocketAddressProtocolTCP).
 						Configure(FilterChain(NewFilterChainBuilder(envoy_common.APIV3).
 							Configure(HttpConnectionManager("127.0.0.1:27777", false)).
 							Configure(
@@ -154,8 +153,7 @@ var _ = Describe("MeshLoadBalancingStrategy", func() {
 				{
 					Name:   "listener-payments",
 					Origin: generator.OriginOutbound,
-					Resource: NewListenerBuilder(envoy_common.APIV3).
-						Configure(OutboundListener("outbound:127.0.0.1:27778", "127.0.0.1", 27778, core_xds.SocketAddressProtocolTCP)).
+					Resource: NewOutboundListenerBuilder(envoy_common.APIV3, "127.0.0.1", 27778, core_xds.SocketAddressProtocolTCP).
 						Configure(FilterChain(NewFilterChainBuilder(envoy_common.APIV3).
 							Configure(HttpConnectionManager("127.0.0.1:27778", false)).
 							Configure(

--- a/pkg/plugins/policies/meshratelimit/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshratelimit/plugin/v1alpha1/plugin_test.go
@@ -90,8 +90,7 @@ var _ = Describe("MeshRateLimit", func() {
 				{
 					Name:   "inbound:127.0.0.1:17777",
 					Origin: generator.OriginInbound,
-					Resource: NewListenerBuilder(envoy_common.APIV3).
-						Configure(InboundListener("inbound:127.0.0.1:17777", "127.0.0.1", 17777, core_xds.SocketAddressProtocolTCP)).
+					Resource: NewInboundListenerBuilder(envoy_common.APIV3, "127.0.0.1", 17777, core_xds.SocketAddressProtocolTCP).
 						Configure(FilterChain(NewFilterChainBuilder(envoy_common.APIV3).
 							Configure(HttpConnectionManager("127.0.0.1:17777", false)).
 							Configure(
@@ -112,8 +111,7 @@ var _ = Describe("MeshRateLimit", func() {
 				{
 					Name:   "inbound:127.0.0.1:17778",
 					Origin: generator.OriginInbound,
-					Resource: NewListenerBuilder(envoy_common.APIV3).
-						Configure(InboundListener("inbound:127.0.0.1:17778", "127.0.0.1", 17778, core_xds.SocketAddressProtocolTCP)).
+					Resource: NewInboundListenerBuilder(envoy_common.APIV3, "127.0.0.1", 17778, core_xds.SocketAddressProtocolTCP).
 						Configure(FilterChain(NewFilterChainBuilder(envoy_common.APIV3).
 							Configure(TcpProxyDeprecated("127.0.0.1:17778", envoy_common.NewCluster(envoy_common.WithName("frontend")))),
 						)).MustBuild(),
@@ -175,8 +173,7 @@ var _ = Describe("MeshRateLimit", func() {
 				{
 					Name:   "inbound:127.0.0.1:17777",
 					Origin: generator.OriginInbound,
-					Resource: NewListenerBuilder(envoy_common.APIV3).
-						Configure(InboundListener("inbound:127.0.0.1:17777", "127.0.0.1", 17777, core_xds.SocketAddressProtocolTCP)).
+					Resource: NewInboundListenerBuilder(envoy_common.APIV3, "127.0.0.1", 17777, core_xds.SocketAddressProtocolTCP).
 						Configure(FilterChain(NewFilterChainBuilder(envoy_common.APIV3).
 							Configure(HttpConnectionManager("127.0.0.1:17777", false)).
 							Configure(
@@ -283,8 +280,7 @@ var _ = Describe("MeshRateLimit", func() {
 			resources: []*core_xds.Resource{{
 				Name:   "inbound:127.0.0.1:17778",
 				Origin: generator.OriginInbound,
-				Resource: NewListenerBuilder(envoy_common.APIV3).
-					Configure(InboundListener("inbound:127.0.0.1:17778", "127.0.0.1", 17778, core_xds.SocketAddressProtocolTCP)).
+				Resource: NewInboundListenerBuilder(envoy_common.APIV3, "127.0.0.1", 17778, core_xds.SocketAddressProtocolTCP).
 					Configure(FilterChain(NewFilterChainBuilder(envoy_common.APIV3).
 						Configure(TcpProxyDeprecated("127.0.0.1:17778", envoy_common.NewCluster(envoy_common.WithName("frontend")))),
 					)).MustBuild(),
@@ -311,8 +307,7 @@ var _ = Describe("MeshRateLimit", func() {
 			resources: []*core_xds.Resource{{
 				Name:   "inbound:127.0.0.1:17777",
 				Origin: generator.OriginInbound,
-				Resource: NewListenerBuilder(envoy_common.APIV3).
-					Configure(InboundListener("inbound:127.0.0.1:17777", "127.0.0.1", 17777, core_xds.SocketAddressProtocolTCP)).
+				Resource: NewInboundListenerBuilder(envoy_common.APIV3, "127.0.0.1", 17777, core_xds.SocketAddressProtocolTCP).
 					Configure(FilterChain(NewFilterChainBuilder(envoy_common.APIV3).
 						Configure(HttpConnectionManager("127.0.0.1:17777", false)).
 						Configure(
@@ -352,8 +347,7 @@ var _ = Describe("MeshRateLimit", func() {
 			resources: []*core_xds.Resource{{
 				Name:   "inbound:127.0.0.1:17778",
 				Origin: generator.OriginInbound,
-				Resource: NewListenerBuilder(envoy_common.APIV3).
-					Configure(InboundListener("inbound:127.0.0.1:17778", "127.0.0.1", 17778, core_xds.SocketAddressProtocolTCP)).
+				Resource: NewInboundListenerBuilder(envoy_common.APIV3, "127.0.0.1", 17778, core_xds.SocketAddressProtocolTCP).
 					Configure(FilterChain(NewFilterChainBuilder(envoy_common.APIV3).
 						Configure(TcpProxyDeprecated("127.0.0.1:17778", envoy_common.NewCluster(envoy_common.WithName("frontend")))),
 					)).MustBuild(),
@@ -379,8 +373,7 @@ var _ = Describe("MeshRateLimit", func() {
 			resources: []*core_xds.Resource{{
 				Name:   "inbound:127.0.0.1:17777",
 				Origin: generator.OriginInbound,
-				Resource: NewListenerBuilder(envoy_common.APIV3).
-					Configure(InboundListener("inbound:127.0.0.1:17777", "127.0.0.1", 17777, core_xds.SocketAddressProtocolTCP)).
+				Resource: NewInboundListenerBuilder(envoy_common.APIV3, "127.0.0.1", 17777, core_xds.SocketAddressProtocolTCP).
 					Configure(FilterChain(NewFilterChainBuilder(envoy_common.APIV3).
 						Configure(HttpConnectionManager("127.0.0.1:17777", false)).
 						Configure(

--- a/pkg/plugins/policies/meshretry/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshretry/plugin/v1alpha1/plugin_test.go
@@ -464,8 +464,7 @@ func getResourceYaml(list core_xds.ResourceList) []byte {
 }
 
 func httpListener(port uint32) envoy_common.NamedResource {
-	return NewListenerBuilder(envoy_common.APIV3).
-		Configure(OutboundListener(fmt.Sprintf("outbound:127.0.0.1:%d", port), "127.0.0.1", port, core_xds.SocketAddressProtocolTCP)).
+	return NewOutboundListenerBuilder(envoy_common.APIV3, "127.0.0.1", port, core_xds.SocketAddressProtocolTCP).
 		Configure(FilterChain(NewFilterChainBuilder(envoy_common.APIV3).
 			Configure(HttpConnectionManager(fmt.Sprintf("outbound:127.0.0.1:%d", port), false)).
 			Configure(HttpOutboundRoute(
@@ -486,8 +485,7 @@ func httpListener(port uint32) envoy_common.NamedResource {
 }
 
 func tcpListener(port uint32) envoy_common.NamedResource {
-	return NewListenerBuilder(envoy_common.APIV3).
-		Configure(OutboundListener(fmt.Sprintf("outbound:127.0.0.1:%d", port), "127.0.0.1", port, core_xds.SocketAddressProtocolTCP)).
+	return NewOutboundListenerBuilder(envoy_common.APIV3, "127.0.0.1", port, core_xds.SocketAddressProtocolTCP).
 		Configure(FilterChain(NewFilterChainBuilder(envoy_common.APIV3).
 			Configure(TcpProxyDeprecated(
 				fmt.Sprintf("outbound:127.0.0.1:%d", port),

--- a/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/listeners.go
+++ b/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/listeners.go
@@ -12,7 +12,6 @@ import (
 	meshhttproute_api "github.com/kumahq/kuma/pkg/plugins/policies/meshhttproute/api/v1alpha1"
 	envoy_common "github.com/kumahq/kuma/pkg/xds/envoy"
 	envoy_listeners "github.com/kumahq/kuma/pkg/xds/envoy/listeners"
-	envoy_names "github.com/kumahq/kuma/pkg/xds/envoy/names"
 	envoy_tags "github.com/kumahq/kuma/pkg/xds/envoy/tags"
 	"github.com/kumahq/kuma/pkg/xds/generator"
 )
@@ -69,17 +68,11 @@ func buildOutboundListener(
 ) (envoy_common.NamedResource, error) {
 	oface := proxy.Dataplane.Spec.GetNetworking().ToOutboundInterface(outbound)
 	tags := outbound.GetTagsIncludingLegacy()
-	builder := envoy_listeners.NewListenerBuilder(proxy.APIVersion)
 
 	// build listener name in format: "outbound:[IP]:[Port]"
 	// i.e. "outbound:240.0.0.0:80"
-	outboundListenerName := envoy_names.GetOutboundListenerName(
-		oface.DataplaneIP,
-		oface.DataplanePort,
-	)
-
-	outboundListener := envoy_listeners.OutboundListener(
-		outboundListenerName,
+	builder := envoy_listeners.NewOutboundListenerBuilder(
+		proxy.APIVersion,
 		oface.DataplaneIP,
 		oface.DataplanePort,
 		core_xds.SocketAddressProtocolTCP,
@@ -94,7 +87,6 @@ func buildOutboundListener(
 	)
 
 	return builder.Configure(
-		outboundListener,
 		tproxy,
 		tagsMetadata,
 	).Configure(opts...).Build()

--- a/pkg/plugins/policies/meshtrace/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshtrace/plugin/v1alpha1/plugin_test.go
@@ -36,16 +36,14 @@ var _ = Describe("MeshTrace", func() {
 			{
 				Name:   "inbound",
 				Origin: generator.OriginInbound,
-				Resource: NewListenerBuilder(envoy_common.APIV3).
-					Configure(InboundListener("inbound:127.0.0.1:17777", "127.0.0.1", 17777, core_xds.SocketAddressProtocolTCP)).
+				Resource: NewInboundListenerBuilder(envoy_common.APIV3, "127.0.0.1", 17777, core_xds.SocketAddressProtocolTCP).
 					Configure(FilterChain(NewFilterChainBuilder(envoy_common.APIV3).
 						Configure(HttpConnectionManager("127.0.0.1:17777", false)),
 					)).MustBuild(),
 			}, {
 				Name:   "outbound",
 				Origin: generator.OriginOutbound,
-				Resource: NewListenerBuilder(envoy_common.APIV3).
-					Configure(OutboundListener("outbound:127.0.0.1:27777", "127.0.0.1", 27777, core_xds.SocketAddressProtocolTCP)).
+				Resource: NewOutboundListenerBuilder(envoy_common.APIV3, "127.0.0.1", 27777, core_xds.SocketAddressProtocolTCP).
 					Configure(FilterChain(NewFilterChainBuilder(envoy_common.APIV3).
 						Configure(HttpConnectionManager("127.0.0.1:27777", false)),
 					)).MustBuild(),
@@ -227,7 +225,8 @@ var _ = Describe("MeshTrace", func() {
             name: outbound:127.0.0.1:27777
             trafficDirection: OUTBOUND`,
 			},
-			expectedClusters: []string{`
+			expectedClusters: []string{
+				`
             altStatName: meshtrace_zipkin
             connectTimeout: 10s
             dnsLookupFamily: V4_ONLY
@@ -242,7 +241,8 @@ var _ = Describe("MeshTrace", func() {
                                     portValue: 9411
             name: meshtrace:zipkin
             type: STRICT_DNS
-`},
+`,
+			},
 		}),
 		Entry("inbound/outbound for opentelemetry", testCase{
 			resources: inboundAndOutbound(),
@@ -270,7 +270,8 @@ var _ = Describe("MeshTrace", func() {
 					},
 				},
 			},
-			expectedListeners: []string{`
+			expectedListeners: []string{
+				`
             address:
               socketAddress:
                 address: 127.0.0.1
@@ -356,8 +357,10 @@ var _ = Describe("MeshTrace", func() {
                           value: 50
             name: outbound:127.0.0.1:27777
             trafficDirection: OUTBOUND
-`},
-			expectedClusters: []string{`
+`,
+			},
+			expectedClusters: []string{
+				`
             altStatName: meshtrace_opentelemetry
             connectTimeout: 10s
             dnsLookupFamily: V4_ONLY
@@ -377,7 +380,8 @@ var _ = Describe("MeshTrace", func() {
                     '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
                     explicitHttpConfig:
                         http2ProtocolOptions: {}
-`},
+`,
+			},
 		}),
 		Entry("inbound/outbound for datadog", testCase{
 			resources: inboundAndOutbound(),
@@ -453,7 +457,8 @@ var _ = Describe("MeshTrace", func() {
             name: outbound:127.0.0.1:27777
             trafficDirection: OUTBOUND`,
 			},
-			expectedClusters: []string{`
+			expectedClusters: []string{
+				`
             altStatName: meshtrace_datadog
             connectTimeout: 10s
             dnsLookupFamily: V4_ONLY
@@ -468,7 +473,8 @@ var _ = Describe("MeshTrace", func() {
                                     portValue: 8126
             name: meshtrace:datadog
             type: STRICT_DNS
-`},
+`,
+			},
 		}),
 		Entry("sampling is empty", testCase{
 			resources: inboundAndOutbound(),
@@ -547,7 +553,8 @@ var _ = Describe("MeshTrace", func() {
             name: outbound:127.0.0.1:27777
             trafficDirection: OUTBOUND`,
 			},
-			expectedClusters: []string{`
+			expectedClusters: []string{
+				`
             altStatName: meshtrace_zipkin
             connectTimeout: 10s
             dnsLookupFamily: V4_ONLY
@@ -562,7 +569,8 @@ var _ = Describe("MeshTrace", func() {
                                     portValue: 9411
             name: meshtrace:zipkin
             type: STRICT_DNS
-`},
+`,
+			},
 		}),
 		Entry("backends list is empty", testCase{
 			resources: inboundAndOutbound(),

--- a/pkg/plugins/policies/meshtrafficpermission/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshtrafficpermission/plugin/v1alpha1/plugin_test.go
@@ -32,8 +32,8 @@ var _ = Describe("RBAC", func() {
 			rs := core_xds.NewResourceSet()
 
 			// listener that matches
-			listener, err := listeners.NewListenerBuilder(envoy.APIV3).
-				Configure(listeners.InboundListener("test_listener", "192.168.0.1", 8080, core_xds.SocketAddressProtocolTCP)).
+			listener, err := listeners.NewInboundListenerBuilder(envoy.APIV3, "192.168.0.1", 8080, core_xds.SocketAddressProtocolTCP).
+				WithName("test_listener").
 				Configure(listeners.FilterChain(listeners.NewFilterChainBuilder(envoy.APIV3).
 					Configure(listeners.HttpConnectionManager("test_listener", false)))).
 				Build()
@@ -45,8 +45,8 @@ var _ = Describe("RBAC", func() {
 			})
 
 			// listener that is originated from inbound proxy generator but won't match
-			listener2, err := listeners.NewListenerBuilder(envoy.APIV3).
-				Configure(listeners.InboundListener("test_listener2", "192.168.0.1", 8081, core_xds.SocketAddressProtocolTCP)).
+			listener2, err := listeners.NewInboundListenerBuilder(envoy.APIV3, "192.168.0.1", 8081, core_xds.SocketAddressProtocolTCP).
+				WithName("test_listener2").
 				Configure(listeners.FilterChain(listeners.NewFilterChainBuilder(envoy.APIV3).
 					Configure(listeners.HttpConnectionManager("test_listener2", false)))).
 				Build()
@@ -58,8 +58,8 @@ var _ = Describe("RBAC", func() {
 			})
 
 			// listener that matches but is not originated from inbound proxy generator
-			listener3, err := listeners.NewListenerBuilder(envoy.APIV3).
-				Configure(listeners.InboundListener("test_listener3", "192.168.0.1", 8082, core_xds.SocketAddressProtocolTCP)).
+			listener3, err := listeners.NewInboundListenerBuilder(envoy.APIV3, "192.168.0.1", 8082, core_xds.SocketAddressProtocolTCP).
+				WithName("test_listener3").
 				Configure(listeners.FilterChain(listeners.NewFilterChainBuilder(envoy.APIV3).
 					Configure(listeners.HttpConnectionManager("test_listener3", false)))).
 				Build()
@@ -138,8 +138,8 @@ var _ = Describe("RBAC", func() {
 			rs := core_xds.NewResourceSet()
 
 			// listener that matches
-			listener, err := listeners.NewListenerBuilder(envoy.APIV3).
-				Configure(listeners.InboundListener("test_listener", "192.168.0.1", 10002, core_xds.SocketAddressProtocolTCP)).
+			listener, err := listeners.NewInboundListenerBuilder(envoy.APIV3, "192.168.0.1", 10002, core_xds.SocketAddressProtocolTCP).
+				WithName("test_listener").
 				Configure(
 					listeners.FilterChain(listeners.NewFilterChainBuilder(envoy.APIV3).Configure(
 						listeners.Name("external-service-1_mesh-1"),

--- a/pkg/plugins/policies/meshtrafficpermission/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshtrafficpermission/plugin/v1alpha1/plugin_test.go
@@ -33,7 +33,7 @@ var _ = Describe("RBAC", func() {
 
 			// listener that matches
 			listener, err := listeners.NewInboundListenerBuilder(envoy.APIV3, "192.168.0.1", 8080, core_xds.SocketAddressProtocolTCP).
-				WithName("test_listener").
+				WithOverwriteName("test_listener").
 				Configure(listeners.FilterChain(listeners.NewFilterChainBuilder(envoy.APIV3).
 					Configure(listeners.HttpConnectionManager("test_listener", false)))).
 				Build()
@@ -46,7 +46,7 @@ var _ = Describe("RBAC", func() {
 
 			// listener that is originated from inbound proxy generator but won't match
 			listener2, err := listeners.NewInboundListenerBuilder(envoy.APIV3, "192.168.0.1", 8081, core_xds.SocketAddressProtocolTCP).
-				WithName("test_listener2").
+				WithOverwriteName("test_listener2").
 				Configure(listeners.FilterChain(listeners.NewFilterChainBuilder(envoy.APIV3).
 					Configure(listeners.HttpConnectionManager("test_listener2", false)))).
 				Build()
@@ -59,7 +59,7 @@ var _ = Describe("RBAC", func() {
 
 			// listener that matches but is not originated from inbound proxy generator
 			listener3, err := listeners.NewInboundListenerBuilder(envoy.APIV3, "192.168.0.1", 8082, core_xds.SocketAddressProtocolTCP).
-				WithName("test_listener3").
+				WithOverwriteName("test_listener3").
 				Configure(listeners.FilterChain(listeners.NewFilterChainBuilder(envoy.APIV3).
 					Configure(listeners.HttpConnectionManager("test_listener3", false)))).
 				Build()
@@ -139,7 +139,7 @@ var _ = Describe("RBAC", func() {
 
 			// listener that matches
 			listener, err := listeners.NewInboundListenerBuilder(envoy.APIV3, "192.168.0.1", 10002, core_xds.SocketAddressProtocolTCP).
-				WithName("test_listener").
+				WithOverwriteName("test_listener").
 				Configure(
 					listeners.FilterChain(listeners.NewFilterChainBuilder(envoy.APIV3).Configure(
 						listeners.Name("external-service-1_mesh-1"),

--- a/pkg/plugins/runtime/gateway/listener_generator.go
+++ b/pkg/plugins/runtime/gateway/listener_generator.go
@@ -54,8 +54,13 @@ func GenerateListener(info GatewayListenerInfo) (*envoy_listeners.ListenerBuilde
 	}
 
 	// TODO(jpeach) if proxy protocol is enabled, add the proxy protocol listener filter.
-	return envoy_listeners.NewInboundListenerBuilder(info.Proxy.APIVersion, address, port, core_xds.SocketAddressProtocolTCP).
-		WithName(name).
+	return envoy_listeners.NewInboundListenerBuilder(
+		info.Proxy.APIVersion,
+		address,
+		port,
+		core_xds.SocketAddressProtocolTCP,
+	).
+	WithOverwriteName(name).
 		Configure(
 			// Limit default buffering for edge connections.
 			envoy_listeners.ConnectionBufferLimit(DefaultConnectionBuffer),

--- a/pkg/plugins/runtime/gateway/listener_generator.go
+++ b/pkg/plugins/runtime/gateway/listener_generator.go
@@ -54,11 +54,9 @@ func GenerateListener(info GatewayListenerInfo) (*envoy_listeners.ListenerBuilde
 	}
 
 	// TODO(jpeach) if proxy protocol is enabled, add the proxy protocol listener filter.
-	return envoy_listeners.NewListenerBuilder(info.Proxy.APIVersion).
+	return envoy_listeners.NewInboundListenerBuilder(info.Proxy.APIVersion, address, port, core_xds.SocketAddressProtocolTCP).
+		WithName(name).
 		Configure(
-			envoy_listeners.InboundListener(
-				name,
-				address, port, core_xds.SocketAddressProtocolTCP),
 			// Limit default buffering for edge connections.
 			envoy_listeners.ConnectionBufferLimit(DefaultConnectionBuffer),
 			// Roughly balance incoming connections.

--- a/pkg/plugins/runtime/gateway/listener_generator.go
+++ b/pkg/plugins/runtime/gateway/listener_generator.go
@@ -60,7 +60,7 @@ func GenerateListener(info GatewayListenerInfo) (*envoy_listeners.ListenerBuilde
 		port,
 		core_xds.SocketAddressProtocolTCP,
 	).
-	WithOverwriteName(name).
+		WithOverwriteName(name).
 		Configure(
 			// Limit default buffering for edge connections.
 			envoy_listeners.ConnectionBufferLimit(DefaultConnectionBuffer),

--- a/pkg/plugins/runtime/k8s/controllers/pod_converter_test.go
+++ b/pkg/plugins/runtime/k8s/controllers/pod_converter_test.go
@@ -462,7 +462,8 @@ var _ = Describe("PodToDataplane(..)", func() {
 			},
 			Entry("Pod with a Service but mismatching ports", testCase{
 				pod: pod,
-				services: []string{`
+				services: []string{
+					`
                 spec:
                   clusterIP: 192.168.0.1
                   ports:
@@ -478,7 +479,8 @@ var _ = Describe("PodToDataplane(..)", func() {
                   - # defaults to TCP protocol
                     port: 6060
                     targetPort: diagnostics
-`},
+`,
+				},
 				expectedErr: `A service that selects pod example was found, but it doesn't match any container ports.`,
 			}),
 		)

--- a/pkg/xds/envoy/listeners/filter_chain_configurer_test.go
+++ b/pkg/xds/envoy/listeners/filter_chain_configurer_test.go
@@ -12,7 +12,6 @@ import (
 
 var _ = Describe("ListenerFilterChainConfigurer", func() {
 	type testCase struct {
-		listenerName     string
 		listenerProtocol xds.SocketAddressProtocol
 		listenerAddress  string
 		listenerPort     uint32
@@ -23,8 +22,7 @@ var _ = Describe("ListenerFilterChainConfigurer", func() {
 		DescribeTable("should generate proper Envoy config",
 			func(given testCase) {
 				// when
-				listener, err := NewListenerBuilder(envoy.APIV3).
-					Configure(InboundListener(given.listenerName, given.listenerAddress, given.listenerPort, given.listenerProtocol)).
+				listener, err := NewInboundListenerBuilder(envoy.APIV3, given.listenerAddress, given.listenerPort, given.listenerProtocol).
 					Configure(FilterChain(NewFilterChainBuilder(envoy.APIV3))).
 					Build()
 				// then
@@ -38,7 +36,6 @@ var _ = Describe("ListenerFilterChainConfigurer", func() {
 				Expect(actual).To(MatchYAML(given.expected))
 			},
 			Entry("basic TCP listener with an empty filter chain", testCase{
-				listenerName:     "inbound:192.168.0.1:8080",
 				listenerProtocol: xds.SocketAddressProtocolTCP,
 				listenerAddress:  "192.168.0.1",
 				listenerPort:     8080,

--- a/pkg/xds/envoy/listeners/listener_builder.go
+++ b/pkg/xds/envoy/listeners/listener_builder.go
@@ -27,17 +27,33 @@ func NewListenerBuilder(apiVersion core_xds.APIVersion, name string) *ListenerBu
 
 // NewInboundListenerBuilder creates an Inbound ListenBuilder
 // with a default name: inbound:address:port
-func NewInboundListenerBuilder(apiVersion core_xds.APIVersion, address string, port uint32, protocol core_xds.SocketAddressProtocol) *ListenerBuilder {
-	return NewListenerBuilder(apiVersion, envoy_names.GetInboundListenerName(address, port)).Configure(InboundListener(address, port, protocol))
+func NewInboundListenerBuilder(
+	apiVersion core_xds.APIVersion,
+	address string,
+	port uint32,
+	protocol core_xds.SocketAddressProtocol,
+) *ListenerBuilder {
+	listenerName := envoy_names.GetInboundListenerName(address, port)
+	
+	return NewListenerBuilder(apiVersion, listenerName).
+		Configure(InboundListener(address, port, protocol))
 }
 
 // NewOutboundListenerBuilder creates an Outbound ListenBuilder
 // with a default name: outbound:address:port
-func NewOutboundListenerBuilder(apiVersion core_xds.APIVersion, address string, port uint32, protocol core_xds.SocketAddressProtocol) *ListenerBuilder {
-	return NewListenerBuilder(apiVersion, envoy_names.GetOutboundListenerName(address, port)).Configure(OutboundListener(address, port, protocol))
+func NewOutboundListenerBuilder(
+	apiVersion core_xds.APIVersion,
+	address string,
+	port uint32,
+	protocol core_xds.SocketAddressProtocol,
+) *ListenerBuilder {
+	listenerName := envoy_names.GetOutboundListenerName(address, port)
+	
+	return NewListenerBuilder(apiVersion, listenerName).
+		Configure(OutboundListener(address, port, protocol))
 }
 
-func (b *ListenerBuilder) WithName(name string) *ListenerBuilder {
+func (b *ListenerBuilder) WithOverwriteName(name string) *ListenerBuilder {
 	b.name = name
 	return b
 }
@@ -71,8 +87,8 @@ func (b *ListenerBuilder) Build() (envoy.NamedResource, error) {
 				return nil, err
 			}
 		}
-		if len(listener.GetName()) == 0 {
-			return nil, errors.New("listener name is undefined")
+		if listener.GetName() == "" {
+			return nil, errors.New("listener name is required, but it was not provided")
 		}
 		return &listener, nil
 	default:

--- a/pkg/xds/envoy/listeners/listener_builder.go
+++ b/pkg/xds/envoy/listeners/listener_builder.go
@@ -34,7 +34,7 @@ func NewInboundListenerBuilder(
 	protocol core_xds.SocketAddressProtocol,
 ) *ListenerBuilder {
 	listenerName := envoy_names.GetInboundListenerName(address, port)
-	
+
 	return NewListenerBuilder(apiVersion, listenerName).
 		Configure(InboundListener(address, port, protocol))
 }
@@ -48,7 +48,7 @@ func NewOutboundListenerBuilder(
 	protocol core_xds.SocketAddressProtocol,
 ) *ListenerBuilder {
 	listenerName := envoy_names.GetOutboundListenerName(address, port)
-	
+
 	return NewListenerBuilder(apiVersion, listenerName).
 		Configure(OutboundListener(address, port, protocol))
 }

--- a/pkg/xds/envoy/listeners/listener_builder.go
+++ b/pkg/xds/envoy/listeners/listener_builder.go
@@ -7,6 +7,7 @@ import (
 	core_xds "github.com/kumahq/kuma/pkg/core/xds"
 	"github.com/kumahq/kuma/pkg/xds/envoy"
 	v3 "github.com/kumahq/kuma/pkg/xds/envoy/listeners/v3"
+	envoy_names "github.com/kumahq/kuma/pkg/xds/envoy/names"
 )
 
 // ListenerBuilderOpt is a configuration option for ListenerBuilder.
@@ -17,10 +18,28 @@ type ListenerBuilderOpt interface {
 	ApplyTo(builder *ListenerBuilder)
 }
 
-func NewListenerBuilder(apiVersion core_xds.APIVersion) *ListenerBuilder {
+func NewListenerBuilder(apiVersion core_xds.APIVersion, name string) *ListenerBuilder {
 	return &ListenerBuilder{
 		apiVersion: apiVersion,
+		name:       name,
 	}
+}
+
+// NewInboundListenerBuilder creates an Inbound ListenBuilder
+// with a default name: inbound:address:port
+func NewInboundListenerBuilder(apiVersion core_xds.APIVersion, address string, port uint32, protocol core_xds.SocketAddressProtocol) *ListenerBuilder {
+	return NewListenerBuilder(apiVersion, envoy_names.GetInboundListenerName(address, port)).Configure(InboundListener(address, port, protocol))
+}
+
+// NewOutboundListenerBuilder creates an Outbound ListenBuilder
+// with a default name: outbound:address:port
+func NewOutboundListenerBuilder(apiVersion core_xds.APIVersion, address string, port uint32, protocol core_xds.SocketAddressProtocol) *ListenerBuilder {
+	return NewListenerBuilder(apiVersion, envoy_names.GetOutboundListenerName(address, port)).Configure(OutboundListener(address, port, protocol))
+}
+
+func (b *ListenerBuilder) WithName(name string) *ListenerBuilder {
+	b.name = name
+	return b
 }
 
 // ListenerBuilder is responsible for generating an Envoy listener
@@ -28,6 +47,7 @@ func NewListenerBuilder(apiVersion core_xds.APIVersion) *ListenerBuilder {
 type ListenerBuilder struct {
 	apiVersion  core_xds.APIVersion
 	configurers []v3.ListenerConfigurer
+	name        string
 }
 
 // Configure configures ListenerBuilder by adding individual ListenerConfigurers.
@@ -43,11 +63,16 @@ func (b *ListenerBuilder) Configure(opts ...ListenerBuilderOpt) *ListenerBuilder
 func (b *ListenerBuilder) Build() (envoy.NamedResource, error) {
 	switch b.apiVersion {
 	case envoy.APIV3:
-		listener := envoy_listener_v3.Listener{}
+		listener := envoy_listener_v3.Listener{
+			Name: b.name,
+		}
 		for _, configurer := range b.configurers {
 			if err := configurer.Configure(&listener); err != nil {
 				return nil, err
 			}
+		}
+		if len(listener.GetName()) == 0 {
+			return nil, errors.New("listener name is undefined")
 		}
 		return &listener, nil
 	default:
@@ -62,6 +87,10 @@ func (b *ListenerBuilder) MustBuild() envoy.NamedResource {
 	}
 
 	return listener
+}
+
+func (b *ListenerBuilder) GetName() string {
+	return b.name
 }
 
 // AddConfigurer appends a given ListenerConfigurer to the end of the chain.

--- a/pkg/xds/envoy/listeners/listener_configurers.go
+++ b/pkg/xds/envoy/listeners/listener_configurers.go
@@ -17,21 +17,19 @@ func OriginalDstForwarder() ListenerBuilderOpt {
 	return AddListenerConfigurer(&v3.OriginalDstForwarderConfigurer{})
 }
 
-func InboundListener(listenerName string, address string, port uint32, protocol core_xds.SocketAddressProtocol) ListenerBuilderOpt {
+func InboundListener(address string, port uint32, protocol core_xds.SocketAddressProtocol) ListenerBuilderOpt {
 	return AddListenerConfigurer(&v3.InboundListenerConfigurer{
-		Protocol:     protocol,
-		ListenerName: listenerName,
-		Address:      address,
-		Port:         port,
+		Protocol: protocol,
+		Address:  address,
+		Port:     port,
 	})
 }
 
-func OutboundListener(listenerName string, address string, port uint32, protocol core_xds.SocketAddressProtocol) ListenerBuilderOpt {
+func OutboundListener(address string, port uint32, protocol core_xds.SocketAddressProtocol) ListenerBuilderOpt {
 	return AddListenerConfigurer(&v3.OutboundListenerConfigurer{
-		Protocol:     protocol,
-		ListenerName: listenerName,
-		Address:      address,
-		Port:         port,
+		Protocol: protocol,
+		Address:  address,
+		Port:     port,
 	})
 }
 

--- a/pkg/xds/envoy/listeners/v3/dns_configurer_test.go
+++ b/pkg/xds/envoy/listeners/v3/dns_configurer_test.go
@@ -23,8 +23,8 @@ var _ = Describe("DNSConfigurer", func() {
 	DescribeTable("should generate proper Envoy config",
 		func(given testCase) {
 			// when
-			listener, err := NewListenerBuilder(envoy.APIV3).
-				Configure(InboundListener(names.GetDNSListenerName(), "192.168.0.1", 1234, xds.SocketAddressProtocolUDP)).
+			listener, err := NewInboundListenerBuilder(envoy.APIV3, "192.168.0.1", 1234, xds.SocketAddressProtocolUDP).
+				WithName(names.GetDNSListenerName()).
 				Configure(DNS(given.vips, given.emptyDnsPort, &mesh_proto.EnvoyVersion{Version: given.envoyVersion})).
 				Build()
 			// then

--- a/pkg/xds/envoy/listeners/v3/dns_configurer_test.go
+++ b/pkg/xds/envoy/listeners/v3/dns_configurer_test.go
@@ -24,7 +24,7 @@ var _ = Describe("DNSConfigurer", func() {
 		func(given testCase) {
 			// when
 			listener, err := NewInboundListenerBuilder(envoy.APIV3, "192.168.0.1", 1234, xds.SocketAddressProtocolUDP).
-				WithName(names.GetDNSListenerName()).
+				WithOverwriteName(names.GetDNSListenerName()).
 				Configure(DNS(given.vips, given.emptyDnsPort, &mesh_proto.EnvoyVersion{Version: given.envoyVersion})).
 				Build()
 			// then

--- a/pkg/xds/envoy/listeners/v3/http_access_log_configurer_test.go
+++ b/pkg/xds/envoy/listeners/v3/http_access_log_configurer_test.go
@@ -15,7 +15,6 @@ import (
 
 var _ = Describe("HttpAccessLogConfigurer", func() {
 	type testCase struct {
-		listenerName       string
 		listenerAddress    string
 		listenerPort       uint32
 		listenerProtocol   core_xds.SocketAddressProtocol
@@ -63,8 +62,7 @@ var _ = Describe("HttpAccessLogConfigurer", func() {
 			}
 
 			// when
-			listener, err := NewListenerBuilder(envoy.APIV3).
-				Configure(OutboundListener(given.listenerName, given.listenerAddress, given.listenerPort, given.listenerProtocol)).
+			listener, err := NewOutboundListenerBuilder(envoy.APIV3, given.listenerAddress, given.listenerPort, given.listenerProtocol).
 				Configure(FilterChain(NewFilterChainBuilder(envoy.APIV3).
 					Configure(HttpConnectionManager(given.statsName, false)).
 					Configure(HttpAccessLog(mesh, envoy.TrafficDirectionOutbound, sourceService, destinationService, given.backend, proxy)))).
@@ -79,7 +77,6 @@ var _ = Describe("HttpAccessLogConfigurer", func() {
 			Expect(actual).To(MatchYAML(given.expected))
 		},
 		Entry("basic http_connection_manager without access log", testCase{
-			listenerName:    "outbound:127.0.0.1:27070",
 			listenerAddress: "127.0.0.1",
 			listenerPort:    27070,
 			statsName:       "backend",
@@ -105,7 +102,6 @@ var _ = Describe("HttpAccessLogConfigurer", func() {
 `,
 		}),
 		Entry("basic http_connection_manager with file access log", testCase{
-			listenerName:    "outbound:127.0.0.1:27070",
 			listenerAddress: "127.0.0.1",
 			listenerPort:    27070,
 			statsName:       "backend",
@@ -145,7 +141,6 @@ var _ = Describe("HttpAccessLogConfigurer", func() {
             trafficDirection: OUTBOUND`,
 		}),
 		Entry("basic http_connection_manager with tcp access log", testCase{
-			listenerName:    "outbound:127.0.0.1:27070",
 			listenerAddress: "127.0.0.1",
 			listenerPort:    27070,
 			statsName:       "backend",
@@ -190,7 +185,6 @@ var _ = Describe("HttpAccessLogConfigurer", func() {
             trafficDirection: OUTBOUND`,
 		}),
 		Entry("basic http_connection_manager with legacy tcp access log", testCase{
-			listenerName:    "outbound:127.0.0.1:27070",
 			listenerAddress: "127.0.0.1",
 			listenerPort:    27070,
 			statsName:       "backend",

--- a/pkg/xds/envoy/listeners/v3/http_connection_manager_configurer_test.go
+++ b/pkg/xds/envoy/listeners/v3/http_connection_manager_configurer_test.go
@@ -12,7 +12,6 @@ import (
 
 var _ = Describe("HttpConnectionManagerConfigurer", func() {
 	type testCase struct {
-		listenerName     string
 		listenerProtocol xds.SocketAddressProtocol
 		listenerAddress  string
 		listenerPort     uint32
@@ -23,8 +22,7 @@ var _ = Describe("HttpConnectionManagerConfigurer", func() {
 	DescribeTable("should generate proper Envoy config",
 		func(given testCase) {
 			// when
-			listener, err := NewListenerBuilder(envoy.APIV3).
-				Configure(InboundListener(given.listenerName, given.listenerAddress, given.listenerPort, given.listenerProtocol)).
+			listener, err := NewInboundListenerBuilder(envoy.APIV3, given.listenerAddress, given.listenerPort, given.listenerProtocol).
 				Configure(FilterChain(NewFilterChainBuilder(envoy.APIV3).
 					Configure(HttpConnectionManager(given.statsName, true)))).
 				Build()
@@ -38,7 +36,6 @@ var _ = Describe("HttpConnectionManagerConfigurer", func() {
 			Expect(actual).To(MatchYAML(given.expected))
 		},
 		Entry("basic http_connection_manager", testCase{
-			listenerName:    "inbound:192.168.0.1:8080",
 			listenerAddress: "192.168.0.1",
 			listenerPort:    8080,
 			statsName:       "localhost:8080",

--- a/pkg/xds/envoy/listeners/v3/http_inbound_routes_configurer_test.go
+++ b/pkg/xds/envoy/listeners/v3/http_inbound_routes_configurer_test.go
@@ -44,7 +44,6 @@ var _ = Describe("HttpInboundRouteConfigurer", func() {
 	}
 
 	type testCase struct {
-		listenerName     string
 		listenerProtocol xds.SocketAddressProtocol
 		listenerAddress  string
 		listenerPort     uint32
@@ -57,8 +56,7 @@ var _ = Describe("HttpInboundRouteConfigurer", func() {
 	DescribeTable("should generate proper Envoy config",
 		func(given testCase) {
 			// when
-			listener, err := NewListenerBuilder(envoy_common.APIV3).
-				Configure(InboundListener(given.listenerName, given.listenerAddress, given.listenerPort, given.listenerProtocol)).
+			listener, err := NewInboundListenerBuilder(envoy_common.APIV3, given.listenerAddress, given.listenerPort, given.listenerProtocol).
 				Configure(FilterChain(NewFilterChainBuilder(envoy_common.APIV3).
 					Configure(HttpConnectionManager(given.statsName, true)).
 					Configure(HttpInboundRoutes(given.service, given.routes)))).
@@ -73,7 +71,6 @@ var _ = Describe("HttpInboundRouteConfigurer", func() {
 			Expect(actual).To(MatchYAML(given.expected))
 		},
 		Entry("basic http_connection_manager with a single destination cluster", testCase{
-			listenerName:    "inbound:192.168.0.1:8080",
 			listenerAddress: "192.168.0.1",
 			listenerPort:    8080,
 			statsName:       "localhost:8080",
@@ -118,7 +115,6 @@ var _ = Describe("HttpInboundRouteConfigurer", func() {
 `,
 		}),
 		Entry("basic http_connection_manager with a single destination cluster and rate limiter", testCase{
-			listenerName:    "inbound:192.168.0.1:8080",
 			listenerAddress: "192.168.0.1",
 			listenerPort:    8080,
 			statsName:       "localhost:8080",
@@ -205,7 +201,6 @@ var _ = Describe("HttpInboundRouteConfigurer", func() {
 `,
 		}),
 		Entry("basic http_connection_manager with a single destination cluster and rate limiter with sources", testCase{
-			listenerName:    "inbound:192.168.0.1:8080",
 			listenerAddress: "192.168.0.1",
 			listenerPort:    8080,
 			statsName:       "localhost:8080",

--- a/pkg/xds/envoy/listeners/v3/http_outbound_route_configurer_test.go
+++ b/pkg/xds/envoy/listeners/v3/http_outbound_route_configurer_test.go
@@ -28,7 +28,7 @@ var _ = Describe("HttpOutboundRouteConfigurer", func() {
 		func(given testCase) {
 			// when
 			listener, err := NewOutboundListenerBuilder(envoy_common.APIV3, given.listenerAddress, given.listenerPort, given.listenerProtocol).
-				WithName(given.listenerName).
+				WithOverwriteName(given.listenerName).
 				Configure(FilterChain(NewFilterChainBuilder(envoy_common.APIV3).
 					Configure(HttpConnectionManager(given.statsName, false)).
 					Configure(HttpOutboundRoute(given.service, given.routes, given.dpTags)))).

--- a/pkg/xds/envoy/listeners/v3/http_outbound_route_configurer_test.go
+++ b/pkg/xds/envoy/listeners/v3/http_outbound_route_configurer_test.go
@@ -27,8 +27,8 @@ var _ = Describe("HttpOutboundRouteConfigurer", func() {
 	DescribeTable("should generate proper Envoy config",
 		func(given testCase) {
 			// when
-			listener, err := NewListenerBuilder(envoy_common.APIV3).
-				Configure(OutboundListener(given.listenerName, given.listenerAddress, given.listenerPort, given.listenerProtocol)).
+			listener, err := NewOutboundListenerBuilder(envoy_common.APIV3, given.listenerAddress, given.listenerPort, given.listenerProtocol).
+				WithName(given.listenerName).
 				Configure(FilterChain(NewFilterChainBuilder(envoy_common.APIV3).
 					Configure(HttpConnectionManager(given.statsName, false)).
 					Configure(HttpOutboundRoute(given.service, given.routes, given.dpTags)))).

--- a/pkg/xds/envoy/listeners/v3/http_route_configurer_test.go
+++ b/pkg/xds/envoy/listeners/v3/http_route_configurer_test.go
@@ -13,13 +13,14 @@ import (
 
 var _ = Describe("HttpDynamicRouteConfigurer", func() {
 	It("should generate proper Envoy config", func() {
-		listener, err := NewListenerBuilder(envoy_common.APIV3).Configure(
-			InboundListener("inbound", "127.0.0.1", 99, xds.SocketAddressProtocolTCP),
-			FilterChain(NewFilterChainBuilder(envoy_common.APIV3).Configure(
-				HttpConnectionManager("inbound", false),
-				HttpDynamicRoute("routes/inbound"),
-			)),
-		).Build()
+		listener, err := NewInboundListenerBuilder(envoy_common.APIV3, "127.0.0.1", 99, xds.SocketAddressProtocolTCP).
+			WithName("inbound").
+			Configure(
+				FilterChain(NewFilterChainBuilder(envoy_common.APIV3).Configure(
+					HttpConnectionManager("inbound", false),
+					HttpDynamicRoute("routes/inbound"),
+				)),
+			).Build()
 
 		Expect(err).ToNot(HaveOccurred())
 
@@ -54,13 +55,14 @@ var _ = Describe("HttpDynamicRouteConfigurer", func() {
 
 var _ = Describe("HttpScopedRouteConfigurer", func() {
 	It("should fail", func() {
-		_, err := NewListenerBuilder(envoy_common.APIV3).Configure(
-			InboundListener("inbound", "127.0.0.1", 99, xds.SocketAddressProtocolTCP),
-			FilterChain(NewFilterChainBuilder(envoy_common.APIV3).Configure(
-				HttpConnectionManager("inbound", false),
-				AddFilterChainConfigurer(&HttpScopedRouteConfigurer{}),
-			)),
-		).Build()
+		_, err := NewInboundListenerBuilder(envoy_common.APIV3, "127.0.0.1", 99, xds.SocketAddressProtocolTCP).
+			WithName("inbound").
+			Configure(
+				FilterChain(NewFilterChainBuilder(envoy_common.APIV3).Configure(
+					HttpConnectionManager("inbound", false),
+					AddFilterChainConfigurer(&HttpScopedRouteConfigurer{}),
+				)),
+			).Build()
 
 		Expect(err).To(HaveOccurred())
 	})

--- a/pkg/xds/envoy/listeners/v3/http_route_configurer_test.go
+++ b/pkg/xds/envoy/listeners/v3/http_route_configurer_test.go
@@ -14,7 +14,7 @@ import (
 var _ = Describe("HttpDynamicRouteConfigurer", func() {
 	It("should generate proper Envoy config", func() {
 		listener, err := NewInboundListenerBuilder(envoy_common.APIV3, "127.0.0.1", 99, xds.SocketAddressProtocolTCP).
-			WithName("inbound").
+			WithOverwriteName("inbound").
 			Configure(
 				FilterChain(NewFilterChainBuilder(envoy_common.APIV3).Configure(
 					HttpConnectionManager("inbound", false),
@@ -56,7 +56,7 @@ var _ = Describe("HttpDynamicRouteConfigurer", func() {
 var _ = Describe("HttpScopedRouteConfigurer", func() {
 	It("should fail", func() {
 		_, err := NewInboundListenerBuilder(envoy_common.APIV3, "127.0.0.1", 99, xds.SocketAddressProtocolTCP).
-			WithName("inbound").
+			WithOverwriteName("inbound").
 			Configure(
 				FilterChain(NewFilterChainBuilder(envoy_common.APIV3).Configure(
 					HttpConnectionManager("inbound", false),

--- a/pkg/xds/envoy/listeners/v3/inbound_listener_configurer.go
+++ b/pkg/xds/envoy/listeners/v3/inbound_listener_configurer.go
@@ -9,14 +9,12 @@ import (
 )
 
 type InboundListenerConfigurer struct {
-	Protocol     core_xds.SocketAddressProtocol
-	ListenerName string
-	Address      string
-	Port         uint32
+	Protocol core_xds.SocketAddressProtocol
+	Address  string
+	Port     uint32
 }
 
 func (c *InboundListenerConfigurer) Configure(l *envoy_listener.Listener) error {
-	l.Name = c.ListenerName
 	l.EnableReusePort = util_proto.Bool(c.Protocol == core_xds.SocketAddressProtocolUDP)
 	l.TrafficDirection = envoy_core.TrafficDirection_INBOUND
 	l.Address = &envoy_core.Address{

--- a/pkg/xds/envoy/listeners/v3/inbound_listener_configurer_test.go
+++ b/pkg/xds/envoy/listeners/v3/inbound_listener_configurer_test.go
@@ -12,7 +12,6 @@ import (
 
 var _ = Describe("InboundListenerConfigurer", func() {
 	type testCase struct {
-		listenerName     string
 		listenerProtocol xds.SocketAddressProtocol
 		listenerAddress  string
 		listenerPort     uint32
@@ -22,8 +21,7 @@ var _ = Describe("InboundListenerConfigurer", func() {
 	DescribeTable("should generate proper Envoy config",
 		func(given testCase) {
 			// when
-			listener, err := NewListenerBuilder(envoy.APIV3).
-				Configure(InboundListener(given.listenerName, given.listenerAddress, given.listenerPort, given.listenerProtocol)).
+			listener, err := NewInboundListenerBuilder(envoy.APIV3, given.listenerAddress, given.listenerPort, given.listenerProtocol).
 				Build()
 			// then
 			Expect(err).ToNot(HaveOccurred())
@@ -35,7 +33,6 @@ var _ = Describe("InboundListenerConfigurer", func() {
 			Expect(actual).To(MatchYAML(given.expected))
 		},
 		Entry("basic TCP listener", testCase{
-			listenerName:     "inbound:192.168.0.1:8080",
 			listenerProtocol: xds.SocketAddressProtocolTCP,
 			listenerAddress:  "192.168.0.1",
 			listenerPort:     8080,
@@ -50,7 +47,6 @@ var _ = Describe("InboundListenerConfigurer", func() {
 `,
 		}),
 		Entry("basic UDP listener", testCase{
-			listenerName:     "inbound:192.168.0.1:8080",
 			listenerProtocol: xds.SocketAddressProtocolUDP,
 			listenerAddress:  "192.168.0.1",
 			listenerPort:     8080,

--- a/pkg/xds/envoy/listeners/v3/kafka_configurer_test.go
+++ b/pkg/xds/envoy/listeners/v3/kafka_configurer_test.go
@@ -12,7 +12,6 @@ import (
 
 var _ = Describe("TcpProxyConfigurer", func() {
 	type testCase struct {
-		listenerName     string
 		listenerProtocol xds.SocketAddressProtocol
 		listenerAddress  string
 		listenerPort     uint32
@@ -24,8 +23,7 @@ var _ = Describe("TcpProxyConfigurer", func() {
 	DescribeTable("should generate proper Envoy config",
 		func(given testCase) {
 			// when
-			listener, err := NewListenerBuilder(envoy_common.APIV3).
-				Configure(InboundListener(given.listenerName, given.listenerAddress, given.listenerPort, given.listenerProtocol)).
+			listener, err := NewInboundListenerBuilder(envoy_common.APIV3, given.listenerAddress, given.listenerPort, given.listenerProtocol).
 				Configure(FilterChain(NewFilterChainBuilder(envoy_common.APIV3).
 					Configure(TcpProxyDeprecated(given.statsName, given.clusters...)))).
 				Build()
@@ -39,7 +37,6 @@ var _ = Describe("TcpProxyConfigurer", func() {
 			Expect(actual).To(MatchYAML(given.expected))
 		},
 		Entry("basic tcp_proxy with a single destination cluster", testCase{
-			listenerName:    "inbound:192.168.0.1:8080",
 			listenerAddress: "192.168.0.1",
 			listenerPort:    8080,
 			statsName:       "localhost:8080",
@@ -67,7 +64,6 @@ var _ = Describe("TcpProxyConfigurer", func() {
 `,
 		}),
 		Entry("basic tcp_proxy with weighted destination clusters", testCase{
-			listenerName:    "inbound:127.0.0.1:5432",
 			listenerAddress: "127.0.0.1",
 			listenerPort:    5432,
 			statsName:       "db",

--- a/pkg/xds/envoy/listeners/v3/listener_configurer_test.go
+++ b/pkg/xds/envoy/listeners/v3/listener_configurer_test.go
@@ -19,7 +19,7 @@ var _ = Describe("Miscellaneous Listener configurers", func() {
 	DescribeTable("should generate proper Envoy config",
 		func(given testCase) {
 			// when
-			listener := NewListenerBuilder(envoy.APIV3)
+			listener := NewListenerBuilder(envoy.APIV3, "test_listener")
 
 			listener.Configure(given.opt)
 
@@ -35,31 +35,46 @@ var _ = Describe("Miscellaneous Listener configurers", func() {
 		},
 		Entry("noop 1", testCase{
 			opt:      AddListenerConfigurer(v3.ListenerConfigureFunc(nil)),
-			expected: "{}",
+			expected: "name: test_listener",
 		}),
 		Entry("noop 2", testCase{
 			opt:      AddListenerConfigurer(v3.ListenerMustConfigureFunc(nil)),
-			expected: "{}",
+			expected: "name: test_listener",
 		}),
 		Entry("connection buffer limit", testCase{
-			opt:      ConnectionBufferLimit(123),
-			expected: "perConnectionBufferLimitBytes: 123",
+			opt: ConnectionBufferLimit(123),
+			expected: `
+name: test_listener
+perConnectionBufferLimitBytes: 123
+`,
 		}),
 		Entry("enable reuse port enabled", testCase{
-			opt:      EnableReusePort(true),
-			expected: "enableReusePort: true",
+			opt: EnableReusePort(true),
+			expected: `
+enableReusePort: true
+name: test_listener
+`,
 		}),
 		Entry("enable reuse port disabled", testCase{
-			opt:      EnableReusePort(false),
-			expected: "enableReusePort: false",
+			opt: EnableReusePort(false),
+			expected: `
+enableReusePort: false
+name: test_listener
+`,
 		}),
 		Entry("enable freebind", testCase{
-			opt:      EnableFreebind(true),
-			expected: "freebind: true",
+			opt: EnableFreebind(true),
+			expected: `
+freebind: true
+name: test_listener
+`,
 		}),
 		Entry("disable freebind", testCase{
-			opt:      EnableFreebind(false),
-			expected: "freebind: false",
+			opt: EnableFreebind(false),
+			expected: `
+freebind: false
+name: test_listener
+`,
 		}),
 	)
 })

--- a/pkg/xds/envoy/listeners/v3/max_connect_attempts_configurer_test.go
+++ b/pkg/xds/envoy/listeners/v3/max_connect_attempts_configurer_test.go
@@ -41,8 +41,8 @@ var _ = Describe("MaxConnectAttemptsConfigurer", func() {
 			}
 
 			// when
-			listener, err := NewListenerBuilder(envoy_common.APIV3).
-				Configure(OutboundListener(given.listenerName, given.listenerAddress, given.listenerPort, given.listenerProtocol)).
+			listener, err := NewOutboundListenerBuilder(envoy_common.APIV3, given.listenerAddress, given.listenerPort, given.listenerProtocol).
+				WithName(given.listenerName).
 				Configure(FilterChain(NewFilterChainBuilder(envoy_common.APIV3).
 					Configure(TcpProxyDeprecated(given.statsName, given.clusters...)).
 					Configure(MaxConnectAttempts(retry)))).

--- a/pkg/xds/envoy/listeners/v3/max_connect_attempts_configurer_test.go
+++ b/pkg/xds/envoy/listeners/v3/max_connect_attempts_configurer_test.go
@@ -42,7 +42,7 @@ var _ = Describe("MaxConnectAttemptsConfigurer", func() {
 
 			// when
 			listener, err := NewOutboundListenerBuilder(envoy_common.APIV3, given.listenerAddress, given.listenerPort, given.listenerProtocol).
-				WithName(given.listenerName).
+				WithOverwriteName(given.listenerName).
 				Configure(FilterChain(NewFilterChainBuilder(envoy_common.APIV3).
 					Configure(TcpProxyDeprecated(given.statsName, given.clusters...)).
 					Configure(MaxConnectAttempts(retry)))).

--- a/pkg/xds/envoy/listeners/v3/network_access_log_configurer_test.go
+++ b/pkg/xds/envoy/listeners/v3/network_access_log_configurer_test.go
@@ -61,7 +61,7 @@ var _ = Describe("NetworkAccessLogConfigurer", func() {
 
 			// when
 			listener, err := NewOutboundListenerBuilder(envoy_common.APIV3, given.listenerAddress, given.listenerPort, given.listenerProtocol).
-				WithName(given.listenerName).
+				WithOverwriteName(given.listenerName).
 				Configure(FilterChain(NewFilterChainBuilder(envoy_common.APIV3).
 					Configure(TcpProxyDeprecated(given.statsName, given.clusters...)).
 					Configure(NetworkAccessLog(meshName, envoy_common.TrafficDirectionUnspecified, sourceService, destinationService, given.backend, proxy)))).

--- a/pkg/xds/envoy/listeners/v3/network_access_log_configurer_test.go
+++ b/pkg/xds/envoy/listeners/v3/network_access_log_configurer_test.go
@@ -60,8 +60,8 @@ var _ = Describe("NetworkAccessLogConfigurer", func() {
 			}
 
 			// when
-			listener, err := NewListenerBuilder(envoy_common.APIV3).
-				Configure(OutboundListener(given.listenerName, given.listenerAddress, given.listenerPort, given.listenerProtocol)).
+			listener, err := NewOutboundListenerBuilder(envoy_common.APIV3, given.listenerAddress, given.listenerPort, given.listenerProtocol).
+				WithName(given.listenerName).
 				Configure(FilterChain(NewFilterChainBuilder(envoy_common.APIV3).
 					Configure(TcpProxyDeprecated(given.statsName, given.clusters...)).
 					Configure(NetworkAccessLog(meshName, envoy_common.TrafficDirectionUnspecified, sourceService, destinationService, given.backend, proxy)))).

--- a/pkg/xds/envoy/listeners/v3/network_rbac_configurer_test.go
+++ b/pkg/xds/envoy/listeners/v3/network_rbac_configurer_test.go
@@ -29,8 +29,7 @@ var _ = Describe("NetworkRbacConfigurer", func() {
 	DescribeTable("should generate proper Envoy config",
 		func(given testCase) {
 			// when
-			listener, err := NewListenerBuilder(envoy_common.APIV3).
-				Configure(InboundListener(given.listenerName, given.listenerAddress, given.listenerPort, given.listenerProtocol)).
+			listener, err := NewInboundListenerBuilder(envoy_common.APIV3, given.listenerAddress, given.listenerPort, given.listenerProtocol).
 				Configure(FilterChain(NewFilterChainBuilder(envoy_common.APIV3).
 					Configure(TcpProxyDeprecated(given.statsName, given.clusters...)).
 					Configure(NetworkRBAC(given.listenerName, given.rbacEnabled, given.permission)))).

--- a/pkg/xds/envoy/listeners/v3/original_dst_forwarder_configurer_test.go
+++ b/pkg/xds/envoy/listeners/v3/original_dst_forwarder_configurer_test.go
@@ -24,8 +24,8 @@ var _ = Describe("OriginalDstForwarderConfigurer", func() {
 	DescribeTable("should generate proper Envoy config",
 		func(given testCase) {
 			// when
-			listener, err := NewListenerBuilder(envoy_common.APIV3).
-				Configure(OutboundListener(given.listenerName, given.listenerAddress, given.listenerPort, given.listenerProtocol)).
+			listener, err := NewOutboundListenerBuilder(envoy_common.APIV3, given.listenerAddress, given.listenerPort, given.listenerProtocol).
+				WithName(given.listenerName).
 				Configure(FilterChain(NewFilterChainBuilder(envoy_common.APIV3).
 					Configure(TcpProxyDeprecated(given.statsName, given.clusters...)))).
 				Configure(OriginalDstForwarder()).

--- a/pkg/xds/envoy/listeners/v3/original_dst_forwarder_configurer_test.go
+++ b/pkg/xds/envoy/listeners/v3/original_dst_forwarder_configurer_test.go
@@ -25,7 +25,7 @@ var _ = Describe("OriginalDstForwarderConfigurer", func() {
 		func(given testCase) {
 			// when
 			listener, err := NewOutboundListenerBuilder(envoy_common.APIV3, given.listenerAddress, given.listenerPort, given.listenerProtocol).
-				WithName(given.listenerName).
+				WithOverwriteName(given.listenerName).
 				Configure(FilterChain(NewFilterChainBuilder(envoy_common.APIV3).
 					Configure(TcpProxyDeprecated(given.statsName, given.clusters...)))).
 				Configure(OriginalDstForwarder()).

--- a/pkg/xds/envoy/listeners/v3/outbound_listener_configurer.go
+++ b/pkg/xds/envoy/listeners/v3/outbound_listener_configurer.go
@@ -8,14 +8,12 @@ import (
 )
 
 type OutboundListenerConfigurer struct {
-	ListenerName string
-	Address      string
-	Port         uint32
-	Protocol     core_xds.SocketAddressProtocol
+	Address  string
+	Port     uint32
+	Protocol core_xds.SocketAddressProtocol
 }
 
 func (c *OutboundListenerConfigurer) Configure(l *envoy_api.Listener) error {
-	l.Name = c.ListenerName
 	l.TrafficDirection = envoy_core.TrafficDirection_OUTBOUND
 	l.Address = &envoy_core.Address{
 		Address: &envoy_core.Address_SocketAddress{

--- a/pkg/xds/envoy/listeners/v3/outbound_listener_configurer_test.go
+++ b/pkg/xds/envoy/listeners/v3/outbound_listener_configurer_test.go
@@ -22,8 +22,8 @@ var _ = Describe("OutboundListenerConfigurer", func() {
 	DescribeTable("should generate proper Envoy config",
 		func(given testCase) {
 			// when
-			listener, err := NewListenerBuilder(envoy.APIV3).
-				Configure(OutboundListener(given.listenerName, given.listenerAddress, given.listenerPort, given.listenerProtocol)).
+			listener, err := NewOutboundListenerBuilder(envoy.APIV3, given.listenerAddress, given.listenerPort, given.listenerProtocol).
+				WithName(given.listenerName).
 				Build()
 			// then
 			Expect(err).ToNot(HaveOccurred())

--- a/pkg/xds/envoy/listeners/v3/outbound_listener_configurer_test.go
+++ b/pkg/xds/envoy/listeners/v3/outbound_listener_configurer_test.go
@@ -23,7 +23,7 @@ var _ = Describe("OutboundListenerConfigurer", func() {
 		func(given testCase) {
 			// when
 			listener, err := NewOutboundListenerBuilder(envoy.APIV3, given.listenerAddress, given.listenerPort, given.listenerProtocol).
-				WithName(given.listenerName).
+				WithOverwriteName(given.listenerName).
 				Build()
 			// then
 			Expect(err).ToNot(HaveOccurred())

--- a/pkg/xds/envoy/listeners/v3/server_mtls_configurer_test.go
+++ b/pkg/xds/envoy/listeners/v3/server_mtls_configurer_test.go
@@ -15,7 +15,6 @@ import (
 
 var _ = Describe("ServerMtlsConfigurer", func() {
 	type testCase struct {
-		listenerName     string
 		listenerProtocol core_xds.SocketAddressProtocol
 		listenerAddress  string
 		listenerPort     uint32
@@ -29,8 +28,7 @@ var _ = Describe("ServerMtlsConfigurer", func() {
 		func(given testCase) {
 			// when
 			tracker := envoy_common.NewSecretsTracker(given.mesh.GetMeta().GetName(), nil)
-			listener, err := NewListenerBuilder(envoy_common.APIV3).
-				Configure(InboundListener(given.listenerName, given.listenerAddress, given.listenerPort, given.listenerProtocol)).
+			listener, err := NewInboundListenerBuilder(envoy_common.APIV3, given.listenerAddress, given.listenerPort, given.listenerProtocol).
 				Configure(FilterChain(NewFilterChainBuilder(envoy_common.APIV3).
 					Configure(ServerSideMTLS(given.mesh, tracker)).
 					Configure(TcpProxyDeprecated(given.statsName, given.clusters...)))).
@@ -45,7 +43,6 @@ var _ = Describe("ServerMtlsConfigurer", func() {
 			Expect(actual).To(MatchYAML(given.expected))
 		},
 		Entry("basic tcp_proxy with mTLS", testCase{
-			listenerName:    "inbound:192.168.0.1:8080",
 			listenerAddress: "192.168.0.1",
 			listenerPort:    8080,
 			statsName:       "localhost:8080",
@@ -109,7 +106,6 @@ var _ = Describe("ServerMtlsConfigurer", func() {
 `,
 		}),
 		Entry("basic tcp_proxy with mTLS and Dataplane credentials", testCase{
-			listenerName:    "inbound:192.168.0.1:8080",
 			listenerAddress: "192.168.0.1",
 			listenerPort:    8080,
 			statsName:       "localhost:8080",

--- a/pkg/xds/envoy/listeners/v3/server_static_mtls_test.go
+++ b/pkg/xds/envoy/listeners/v3/server_static_mtls_test.go
@@ -27,8 +27,7 @@ var _ = Describe("ServerSideStaticMTLS", func() {
 		)
 
 		// when
-		listener, err := NewListenerBuilder(envoy_common.APIV3).
-			Configure(InboundListener("inbound:192.168.0.1:8080", "192.168.0.1", 8080, core_xds.SocketAddressProtocolTCP)).
+		listener, err := NewInboundListenerBuilder(envoy_common.APIV3, "192.168.0.1", 8080, core_xds.SocketAddressProtocolTCP).
 			Configure(FilterChain(NewFilterChainBuilder(envoy_common.APIV3).
 				Configure(ServerSideStaticMTLS(certs)).
 				Configure(TcpProxyDeprecated("localhost:8080", cluster)))).

--- a/pkg/xds/envoy/listeners/v3/static_endpoints_configurer_test.go
+++ b/pkg/xds/envoy/listeners/v3/static_endpoints_configurer_test.go
@@ -25,7 +25,7 @@ var _ = Describe("StaticEndpointsConfigurer", func() {
 		func(given testCase) {
 			// when
 			listener, err := NewInboundListenerBuilder(envoy_common.APIV3, given.listenerAddress, given.listenerPort, given.listenerProtocol).
-				WithName(given.listenerName).
+				WithOverwriteName(given.listenerName).
 				Configure(FilterChain(NewFilterChainBuilder(envoy_common.APIV3).
 					Configure(StaticEndpoints(given.listenerName,
 						[]*envoy_common.StaticEndpointPath{

--- a/pkg/xds/envoy/listeners/v3/static_endpoints_configurer_test.go
+++ b/pkg/xds/envoy/listeners/v3/static_endpoints_configurer_test.go
@@ -24,8 +24,8 @@ var _ = Describe("StaticEndpointsConfigurer", func() {
 	DescribeTable("should generate proper Envoy config",
 		func(given testCase) {
 			// when
-			listener, err := NewListenerBuilder(envoy_common.APIV3).
-				Configure(InboundListener(given.listenerName, given.listenerAddress, given.listenerPort, given.listenerProtocol)).
+			listener, err := NewInboundListenerBuilder(envoy_common.APIV3, given.listenerAddress, given.listenerPort, given.listenerProtocol).
+				WithName(given.listenerName).
 				Configure(FilterChain(NewFilterChainBuilder(envoy_common.APIV3).
 					Configure(StaticEndpoints(given.listenerName,
 						[]*envoy_common.StaticEndpointPath{

--- a/pkg/xds/envoy/listeners/v3/tags_metadata_configurer_test.go
+++ b/pkg/xds/envoy/listeners/v3/tags_metadata_configurer_test.go
@@ -24,7 +24,7 @@ var _ = Describe("TagsMetadataConfigurer", func() {
 		func(given testCase) {
 			// when
 			listener, err := NewInboundListenerBuilder(envoy_common.APIV3, given.listenerAddress, given.listenerPort, given.listenerProtocol).
-				WithName(given.listenerName).
+				WithOverwriteName(given.listenerName).
 				Configure(TagsMetadata(given.tags)).
 				Build()
 

--- a/pkg/xds/envoy/listeners/v3/tags_metadata_configurer_test.go
+++ b/pkg/xds/envoy/listeners/v3/tags_metadata_configurer_test.go
@@ -23,8 +23,8 @@ var _ = Describe("TagsMetadataConfigurer", func() {
 	DescribeTable("should generate proper Envoy config",
 		func(given testCase) {
 			// when
-			listener, err := NewListenerBuilder(envoy_common.APIV3).
-				Configure(InboundListener(given.listenerName, given.listenerAddress, given.listenerPort, given.listenerProtocol)).
+			listener, err := NewInboundListenerBuilder(envoy_common.APIV3, given.listenerAddress, given.listenerPort, given.listenerProtocol).
+				WithName(given.listenerName).
 				Configure(TagsMetadata(given.tags)).
 				Build()
 

--- a/pkg/xds/envoy/listeners/v3/tcp_proxy_configurer_test.go
+++ b/pkg/xds/envoy/listeners/v3/tcp_proxy_configurer_test.go
@@ -12,7 +12,6 @@ import (
 
 var _ = Describe("TcpProxyConfigurer", func() {
 	type testCase struct {
-		listenerName     string
 		listenerProtocol xds.SocketAddressProtocol
 		listenerAddress  string
 		listenerPort     uint32
@@ -24,8 +23,7 @@ var _ = Describe("TcpProxyConfigurer", func() {
 	DescribeTable("should generate proper Envoy config with metadata",
 		func(given testCase) {
 			// when
-			listener, err := NewListenerBuilder(envoy_common.APIV3).
-				Configure(InboundListener(given.listenerName, given.listenerAddress, given.listenerPort, given.listenerProtocol)).
+			listener, err := NewInboundListenerBuilder(envoy_common.APIV3, given.listenerAddress, given.listenerPort, given.listenerProtocol).
 				Configure(FilterChain(NewFilterChainBuilder(envoy_common.APIV3).
 					Configure(TcpProxyDeprecatedWithMetadata(given.statsName, given.clusters...)))).
 				Build()
@@ -39,7 +37,6 @@ var _ = Describe("TcpProxyConfigurer", func() {
 			Expect(actual).To(MatchYAML(given.expected))
 		},
 		Entry("basic tcp_proxy with a single destination cluster", testCase{
-			listenerName:    "inbound:192.168.0.1:8080",
 			listenerAddress: "192.168.0.1",
 			listenerPort:    8080,
 			statsName:       "localhost:8080",
@@ -70,7 +67,6 @@ var _ = Describe("TcpProxyConfigurer", func() {
 `,
 		}),
 		Entry("basic tcp_proxy with weighted destination clusters", testCase{
-			listenerName:    "inbound:127.0.0.1:5432",
 			listenerAddress: "127.0.0.1",
 			listenerPort:    5432,
 			statsName:       "db",
@@ -120,8 +116,7 @@ var _ = Describe("TcpProxyConfigurer", func() {
 	DescribeTable("should generate proper Envoy config without metadata",
 		func(given testCase) {
 			// when
-			listener, err := NewListenerBuilder(envoy_common.APIV3).
-				Configure(InboundListener(given.listenerName, given.listenerAddress, given.listenerPort, given.listenerProtocol)).
+			listener, err := NewInboundListenerBuilder(envoy_common.APIV3, given.listenerAddress, given.listenerPort, given.listenerProtocol).
 				Configure(FilterChain(NewFilterChainBuilder(envoy_common.APIV3).
 					Configure(TcpProxyDeprecated(given.statsName, given.clusters...)))).
 				Build()
@@ -135,7 +130,6 @@ var _ = Describe("TcpProxyConfigurer", func() {
 			Expect(actual).To(MatchYAML(given.expected))
 		},
 		Entry("basic tcp_proxy with a single destination cluster", testCase{
-			listenerName:    "inbound:192.168.0.1:8080",
 			listenerAddress: "192.168.0.1",
 			listenerPort:    8080,
 			statsName:       "localhost:8080",
@@ -164,7 +158,6 @@ var _ = Describe("TcpProxyConfigurer", func() {
 `,
 		}),
 		Entry("basic tcp_proxy with weighted destination clusters", testCase{
-			listenerName:    "inbound:127.0.0.1:5432",
 			listenerAddress: "127.0.0.1",
 			listenerPort:    5432,
 			statsName:       "db",

--- a/pkg/xds/envoy/listeners/v3/timeout_configurer_test.go
+++ b/pkg/xds/envoy/listeners/v3/timeout_configurer_test.go
@@ -52,8 +52,7 @@ var _ = Describe("TimeoutConfigurer", func() {
 	DescribeTable("should set timeouts for outbound TCP listener",
 		func(given testCase) {
 			// given
-			listener, err := NewListenerBuilder(envoy_common.APIV3).
-				Configure(OutboundListener("outbound:192.168.0.1:8080", "192.168.0.1", 8080, xds.SocketAddressProtocolTCP)).
+			listener, err := NewOutboundListenerBuilder(envoy_common.APIV3, "192.168.0.1", 8080, xds.SocketAddressProtocolTCP).
 				Configure(FilterChain(NewFilterChainBuilder(envoy_common.APIV3).
 					Configure(TcpProxyDeprecated("localhost:8080", envoy_common.NewCluster(envoy_common.WithName("backend")))).
 					Configure(Timeout(given.timeout, core_mesh.ProtocolTCP)))).
@@ -109,8 +108,7 @@ trafficDirection: OUTBOUND`,
 	DescribeTable("should set timeouts for outbound HTTP listener",
 		func(given testCase) {
 			// given
-			listener, err := NewListenerBuilder(envoy_common.APIV3).
-				Configure(OutboundListener("outbound:192.168.0.1:8080", "192.168.0.1", 8080, xds.SocketAddressProtocolTCP)).
+			listener, err := NewOutboundListenerBuilder(envoy_common.APIV3, "192.168.0.1", 8080, xds.SocketAddressProtocolTCP).
 				Configure(FilterChain(NewFilterChainBuilder(envoy_common.APIV3).
 					Configure(HttpConnectionManager("localhost:8080", false)).
 					Configure(Timeout(given.timeout, core_mesh.ProtocolHTTP)))).
@@ -198,8 +196,7 @@ trafficDirection: OUTBOUND`,
 	DescribeTable("should set timeouts for outbound GRPC listener",
 		func(given testCase) {
 			// given
-			listener, err := NewListenerBuilder(envoy_common.APIV3).
-				Configure(OutboundListener("outbound:192.168.0.1:8080", "192.168.0.1", 8080, xds.SocketAddressProtocolTCP)).
+			listener, err := NewOutboundListenerBuilder(envoy_common.APIV3, "192.168.0.1", 8080, xds.SocketAddressProtocolTCP).
 				Configure(FilterChain(NewFilterChainBuilder(envoy_common.APIV3).
 					Configure(HttpConnectionManager("localhost:8080", false)).
 					Configure(Timeout(given.timeout, core_mesh.ProtocolGRPC)))).
@@ -286,8 +283,7 @@ trafficDirection: OUTBOUND`,
 
 	It("should set timeouts for inbound TCP listener", func() {
 		// given
-		listener, err := NewListenerBuilder(envoy_common.APIV3).
-			Configure(InboundListener("inbound:192.168.0.1:8080", "192.168.0.1", 8080, xds.SocketAddressProtocolTCP)).
+		listener, err := NewInboundListenerBuilder(envoy_common.APIV3, "192.168.0.1", 8080, xds.SocketAddressProtocolTCP).
 			Configure(FilterChain(NewFilterChainBuilder(envoy_common.APIV3).
 				Configure(TcpProxyDeprecated("localhost:8080", envoy_common.NewCluster(envoy_common.WithName("backend")))).
 				Configure(Timeout(mesh.DefaultInboundTimeout(), core_mesh.ProtocolTCP)))).
@@ -321,8 +317,7 @@ trafficDirection: INBOUND
 
 	It("should set timeouts for inbound HTTP listener", func() {
 		// given
-		listener, err := NewListenerBuilder(envoy_common.APIV3).
-			Configure(InboundListener("inbound:192.168.0.1:8080", "192.168.0.1", 8080, xds.SocketAddressProtocolTCP)).
+		listener, err := NewInboundListenerBuilder(envoy_common.APIV3, "192.168.0.1", 8080, xds.SocketAddressProtocolTCP).
 			Configure(FilterChain(NewFilterChainBuilder(envoy_common.APIV3).
 				Configure(HttpConnectionManager("localhost:8080", false)).
 				Configure(Timeout(mesh.DefaultInboundTimeout(), core_mesh.ProtocolHTTP)))).

--- a/pkg/xds/envoy/listeners/v3/tracing_configurer_test.go
+++ b/pkg/xds/envoy/listeners/v3/tracing_configurer_test.go
@@ -23,8 +23,7 @@ var _ = Describe("TracingConfigurer", func() {
 	DescribeTable("should generate proper Envoy config",
 		func(given testCase) {
 			// when
-			listener, err := NewListenerBuilder(envoy.APIV3).
-				Configure(InboundListener("inbound:192.168.0.1:8080", "192.168.0.1", 8080, xds.SocketAddressProtocolTCP)).
+			listener, err := NewInboundListenerBuilder(envoy.APIV3, "192.168.0.1", 8080, xds.SocketAddressProtocolTCP).
 				Configure(FilterChain(NewFilterChainBuilder(envoy.APIV3).
 					Configure(HttpConnectionManager("localhost:8080", false)).
 					Configure(Tracing(given.backend, "service", given.direction, given.destination)))).

--- a/pkg/xds/envoy/listeners/v3/transparent_proxying_configurer_test.go
+++ b/pkg/xds/envoy/listeners/v3/transparent_proxying_configurer_test.go
@@ -13,7 +13,6 @@ import (
 
 var _ = Describe("TransparentProxyingConfigurer", func() {
 	type testCase struct {
-		listenerName        string
 		listenerProtocol    xds.SocketAddressProtocol
 		listenerAddress     string
 		listenerPort        uint32
@@ -24,8 +23,7 @@ var _ = Describe("TransparentProxyingConfigurer", func() {
 	DescribeTable("should generate proper Envoy config",
 		func(given testCase) {
 			// when
-			listener, err := NewListenerBuilder(envoy.APIV3).
-				Configure(InboundListener(given.listenerName, given.listenerAddress, given.listenerPort, given.listenerProtocol)).
+			listener, err := NewInboundListenerBuilder(envoy.APIV3, given.listenerAddress, given.listenerPort, given.listenerProtocol).
 				Configure(TransparentProxying(given.transparentProxying)).
 				Build()
 			// then
@@ -38,7 +36,6 @@ var _ = Describe("TransparentProxyingConfigurer", func() {
 			Expect(actual).To(MatchYAML(given.expected))
 		},
 		Entry("basic listener with transparent proxying", testCase{
-			listenerName:    "inbound:192.168.0.1:8080",
 			listenerAddress: "192.168.0.1",
 			listenerPort:    8080,
 			transparentProxying: &mesh_proto.Dataplane_Networking_TransparentProxying{
@@ -58,7 +55,6 @@ var _ = Describe("TransparentProxyingConfigurer", func() {
 `,
 		}),
 		Entry("basic listener without transparent proxying", testCase{
-			listenerName:        "inbound:192.168.0.1:8080",
 			listenerAddress:     "192.168.0.1",
 			listenerPort:        8080,
 			transparentProxying: &mesh_proto.Dataplane_Networking_TransparentProxying{},

--- a/pkg/xds/envoy/routes/v3/retry_configurer_test.go
+++ b/pkg/xds/envoy/routes/v3/retry_configurer_test.go
@@ -16,7 +16,6 @@ import (
 
 var _ = Describe("RetryConfigurer", func() {
 	type testCase struct {
-		listenerName     string
 		listenerAddress  string
 		listenerPort     uint32
 		listenerProtocol core_xds.SocketAddressProtocol
@@ -32,8 +31,7 @@ var _ = Describe("RetryConfigurer", func() {
 	DescribeTable("should generate proper Envoy config",
 		func(given testCase) {
 			// when
-			listener, err := NewListenerBuilder(envoy_common.APIV3).
-				Configure(OutboundListener(given.listenerName, given.listenerAddress, given.listenerPort, given.listenerProtocol)).
+			listener, err := NewOutboundListenerBuilder(envoy_common.APIV3, given.listenerAddress, given.listenerPort, given.listenerProtocol).
 				Configure(FilterChain(NewFilterChainBuilder(envoy_common.APIV3).
 					Configure(HttpConnectionManager(given.statsName, false)).
 					Configure(HttpOutboundRoute(
@@ -54,7 +52,6 @@ var _ = Describe("RetryConfigurer", func() {
 		},
 		Entry("basic http_connection_manager with an outbound route"+
 			" and simple http retry policy", testCase{
-			listenerName:    "outbound:127.0.0.1:17777",
 			listenerAddress: "127.0.0.1",
 			listenerPort:    17777,
 			statsName:       "127.0.0.1:17777",
@@ -130,7 +127,6 @@ var _ = Describe("RetryConfigurer", func() {
 		}),
 		Entry("basic http_connection_manager with an outbound route"+
 			" and more complex http retry policy", testCase{
-			listenerName:    "outbound:127.0.0.1:18080",
 			listenerAddress: "127.0.0.1",
 			listenerPort:    18080,
 			statsName:       "127.0.0.1:18080",
@@ -211,7 +207,6 @@ var _ = Describe("RetryConfigurer", func() {
 		}),
 		Entry("basic http_connection_manager with an outbound route"+
 			" and simple grpc retry policy", testCase{
-			listenerName:    "outbound:127.0.0.1:17777",
 			listenerAddress: "127.0.0.1",
 			listenerPort:    17777,
 			statsName:       "127.0.0.1:17777",
@@ -279,7 +274,6 @@ var _ = Describe("RetryConfigurer", func() {
 		}),
 		Entry("basic http_connection_manager with an outbound route"+
 			" and more complex http retry policy", testCase{
-			listenerName:    "outbound:127.0.0.1:18080",
 			listenerAddress: "127.0.0.1",
 			listenerPort:    18080,
 			statsName:       "127.0.0.1:18080",
@@ -360,7 +354,6 @@ var _ = Describe("RetryConfigurer", func() {
 		}),
 		Entry("basic http_connection_manager with an outbound route"+
 			" and more complex http retry policy", testCase{
-			listenerName:    "outbound:127.0.0.1:18080",
 			listenerAddress: "127.0.0.1",
 			listenerPort:    18080,
 			statsName:       "127.0.0.1:18080",

--- a/pkg/xds/generator/admin_proxy_generator.go
+++ b/pkg/xds/generator/admin_proxy_generator.go
@@ -76,7 +76,7 @@ func (g AdminProxyGenerator) Generate(ctx xds_context.Context, proxy *core_xds.P
 		))
 
 		listener, err := envoy_listeners.NewInboundListenerBuilder(proxy.APIVersion, g.getAddress(proxy), adminPort, core_xds.SocketAddressProtocolTCP).
-			WithName(envoy_names.GetAdminListenerName()).
+			WithOverwriteName(envoy_names.GetAdminListenerName()).
 			Configure(envoy_listeners.TLSInspector()).
 			Configure(filterChains...).
 			Build()

--- a/pkg/xds/generator/admin_proxy_generator.go
+++ b/pkg/xds/generator/admin_proxy_generator.go
@@ -75,8 +75,8 @@ func (g AdminProxyGenerator) Generate(ctx xds_context.Context, proxy *core_xds.P
 			Configure(envoy_listeners.ServerSideStaticMTLS(proxy.EnvoyAdminMTLSCerts)),
 		))
 
-		listener, err := envoy_listeners.NewListenerBuilder(proxy.APIVersion).
-			Configure(envoy_listeners.InboundListener(envoy_names.GetAdminListenerName(), g.getAddress(proxy), adminPort, core_xds.SocketAddressProtocolTCP)).
+		listener, err := envoy_listeners.NewInboundListenerBuilder(proxy.APIVersion, g.getAddress(proxy), adminPort, core_xds.SocketAddressProtocolTCP).
+			WithName(envoy_names.GetAdminListenerName()).
 			Configure(envoy_listeners.TLSInspector()).
 			Configure(filterChains...).
 			Build()

--- a/pkg/xds/generator/direct_access_proxy_generator.go
+++ b/pkg/xds/generator/direct_access_proxy_generator.go
@@ -50,7 +50,7 @@ func (_ DirectAccessProxyGenerator) Generate(ctx xds_context.Context, proxy *cor
 	for _, endpoint := range endpoints {
 		name := DirectAccessEndpointName(endpoint)
 		listener, err := envoy_listeners.NewOutboundListenerBuilder(proxy.APIVersion, endpoint.Address, endpoint.Port, core_xds.SocketAddressProtocolTCP).
-			WithName(name).
+			WithOverwriteName(name).
 			Configure(envoy_listeners.FilterChain(envoy_listeners.NewFilterChainBuilder(proxy.APIVersion).
 				Configure(envoy_listeners.TcpProxyDeprecated(name, envoy_common.NewCluster(envoy_common.WithService("direct_access")))).
 				Configure(envoy_listeners.NetworkAccessLog(

--- a/pkg/xds/generator/direct_access_proxy_generator.go
+++ b/pkg/xds/generator/direct_access_proxy_generator.go
@@ -49,8 +49,8 @@ func (_ DirectAccessProxyGenerator) Generate(ctx xds_context.Context, proxy *cor
 
 	for _, endpoint := range endpoints {
 		name := DirectAccessEndpointName(endpoint)
-		listener, err := envoy_listeners.NewListenerBuilder(proxy.APIVersion).
-			Configure(envoy_listeners.OutboundListener(name, endpoint.Address, endpoint.Port, core_xds.SocketAddressProtocolTCP)).
+		listener, err := envoy_listeners.NewOutboundListenerBuilder(proxy.APIVersion, endpoint.Address, endpoint.Port, core_xds.SocketAddressProtocolTCP).
+			WithName(name).
 			Configure(envoy_listeners.FilterChain(envoy_listeners.NewFilterChainBuilder(proxy.APIVersion).
 				Configure(envoy_listeners.TcpProxyDeprecated(name, envoy_common.NewCluster(envoy_common.WithService("direct_access")))).
 				Configure(envoy_listeners.NetworkAccessLog(

--- a/pkg/xds/generator/dns_generator.go
+++ b/pkg/xds/generator/dns_generator.go
@@ -47,7 +47,7 @@ func (g DNSGenerator) Generate(ctx xds_context.Context, proxy *core_xds.Proxy) (
 	}
 
 	listener, err := envoy_listeners.NewInboundListenerBuilder(proxy.APIVersion, "127.0.0.1", dnsPort, core_xds.SocketAddressProtocolUDP).
-		WithName(names.GetDNSListenerName()).
+		WithOverwriteName(names.GetDNSListenerName()).
 		Configure(envoy_listeners.DNS(vips, emptyDnsPort, proxy.Metadata.Version.Envoy)).
 		Build()
 	if err != nil {

--- a/pkg/xds/generator/dns_generator.go
+++ b/pkg/xds/generator/dns_generator.go
@@ -46,8 +46,8 @@ func (g DNSGenerator) Generate(ctx xds_context.Context, proxy *core_xds.Proxy) (
 		}
 	}
 
-	listener, err := envoy_listeners.NewListenerBuilder(proxy.APIVersion).
-		Configure(envoy_listeners.InboundListener(names.GetDNSListenerName(), "127.0.0.1", dnsPort, core_xds.SocketAddressProtocolUDP)).
+	listener, err := envoy_listeners.NewInboundListenerBuilder(proxy.APIVersion, "127.0.0.1", dnsPort, core_xds.SocketAddressProtocolUDP).
+		WithName(names.GetDNSListenerName()).
 		Configure(envoy_listeners.DNS(vips, emptyDnsPort, proxy.Metadata.Version.Envoy)).
 		Build()
 	if err != nil {

--- a/pkg/xds/generator/egress/generator.go
+++ b/pkg/xds/generator/egress/generator.go
@@ -47,11 +47,12 @@ func makeListenerBuilder(
 	address := networking.GetAddress()
 	port := networking.GetPort()
 
-	return envoy_listeners.NewInboundListenerBuilder(apiVersion,
-		address, port,
+	return envoy_listeners.NewInboundListenerBuilder(
+		apiVersion,
+		address,
+		port,
 		core_xds.SocketAddressProtocolTCP,
 	).Configure(envoy_listeners.TLSInspector())
-}
 
 func (g Generator) Generate(
 	ctx xds_context.Context,

--- a/pkg/xds/generator/egress/generator.go
+++ b/pkg/xds/generator/egress/generator.go
@@ -10,7 +10,6 @@ import (
 	xds_context "github.com/kumahq/kuma/pkg/xds/context"
 	envoy_common "github.com/kumahq/kuma/pkg/xds/envoy"
 	envoy_listeners "github.com/kumahq/kuma/pkg/xds/envoy/listeners"
-	envoy_names "github.com/kumahq/kuma/pkg/xds/envoy/names"
 	envoy_tags "github.com/kumahq/kuma/pkg/xds/envoy/tags"
 	generator_secrets "github.com/kumahq/kuma/pkg/xds/generator/secrets"
 )
@@ -48,15 +47,10 @@ func makeListenerBuilder(
 	address := networking.GetAddress()
 	port := networking.GetPort()
 
-	return envoy_listeners.NewListenerBuilder(apiVersion).
-		Configure(
-			envoy_listeners.InboundListener(
-				envoy_names.GetInboundListenerName(address, port),
-				address, port,
-				core_xds.SocketAddressProtocolTCP,
-			),
-			envoy_listeners.TLSInspector(),
-		)
+	return envoy_listeners.NewInboundListenerBuilder(apiVersion,
+		address, port,
+		core_xds.SocketAddressProtocolTCP,
+	).Configure(envoy_listeners.TLSInspector())
 }
 
 func (g Generator) Generate(

--- a/pkg/xds/generator/egress/generator.go
+++ b/pkg/xds/generator/egress/generator.go
@@ -53,6 +53,7 @@ func makeListenerBuilder(
 		port,
 		core_xds.SocketAddressProtocolTCP,
 	).Configure(envoy_listeners.TLSInspector())
+}
 
 func (g Generator) Generate(
 	ctx xds_context.Context,

--- a/pkg/xds/generator/inbound_proxy_generator.go
+++ b/pkg/xds/generator/inbound_proxy_generator.go
@@ -128,8 +128,7 @@ func (g InboundProxyGenerator) Generate(ctx xds_context.Context, proxy *core_xds
 					proxy.Policies.TrafficPermissions[endpoint]))
 		}
 
-		listenerBuilder := envoy_listeners.NewListenerBuilder(proxy.APIVersion).
-			Configure(envoy_listeners.InboundListener(inboundListenerName, endpoint.DataplaneIP, endpoint.DataplanePort, core_xds.SocketAddressProtocolTCP)).
+		listenerBuilder := envoy_listeners.NewInboundListenerBuilder(proxy.APIVersion, endpoint.DataplaneIP, endpoint.DataplanePort, core_xds.SocketAddressProtocolTCP).
 			Configure(envoy_listeners.TransparentProxying(proxy.Dataplane.Spec.Networking.GetTransparentProxying())).
 			Configure(envoy_listeners.TagsMetadata(iface.GetTags()))
 

--- a/pkg/xds/generator/ingress_generator.go
+++ b/pkg/xds/generator/ingress_generator.go
@@ -84,15 +84,11 @@ func (i IngressGenerator) generateLDS(
 ) (envoy_common.NamedResource, error) {
 	networking := ingress.Spec.GetNetworking()
 	address, port := networking.GetAddress(), networking.GetPort()
-	inboundListenerName := envoy_names.GetInboundListenerName(address, port)
-	inboundListenerBuilder := envoy_listeners.NewListenerBuilder(apiVersion).
-		Configure(envoy_listeners.InboundListener(
-			inboundListenerName,
-			address,
-			port,
-			core_xds.SocketAddressProtocolTCP,
-		)).
-		Configure(envoy_listeners.TLSInspector())
+	inboundListenerBuilder := envoy_listeners.NewInboundListenerBuilder(apiVersion,
+		address,
+		port,
+		core_xds.SocketAddressProtocolTCP,
+	).Configure(envoy_listeners.TLSInspector())
 
 	if len(ingress.Spec.AvailableServices) == 0 {
 		inboundListenerBuilder = inboundListenerBuilder.

--- a/pkg/xds/generator/ingress_generator.go
+++ b/pkg/xds/generator/ingress_generator.go
@@ -84,7 +84,8 @@ func (i IngressGenerator) generateLDS(
 ) (envoy_common.NamedResource, error) {
 	networking := ingress.Spec.GetNetworking()
 	address, port := networking.GetAddress(), networking.GetPort()
-	inboundListenerBuilder := envoy_listeners.NewInboundListenerBuilder(apiVersion,
+	inboundListenerBuilder := envoy_listeners.NewInboundListenerBuilder(
+		apiVersion,
 		address,
 		port,
 		core_xds.SocketAddressProtocolTCP,

--- a/pkg/xds/generator/outbound_proxy_generator.go
+++ b/pkg/xds/generator/outbound_proxy_generator.go
@@ -183,8 +183,7 @@ func (OutboundProxyGenerator) generateLDS(ctx xds_context.Context, proxy *model.
 			Configure(envoy_listeners.Timeout(timeoutPolicyConf, protocol))
 		return filterChainBuilder
 	}()
-	listener, err := envoy_listeners.NewListenerBuilder(proxy.APIVersion).
-		Configure(envoy_listeners.OutboundListener(outboundListenerName, oface.DataplaneIP, oface.DataplanePort, model.SocketAddressProtocolTCP)).
+	listener, err := envoy_listeners.NewOutboundListenerBuilder(proxy.APIVersion, oface.DataplaneIP, oface.DataplanePort, model.SocketAddressProtocolTCP).
 		Configure(envoy_listeners.FilterChain(filterChainBuilder)).
 		Configure(envoy_listeners.TransparentProxying(proxy.Dataplane.Spec.Networking.GetTransparentProxying())).
 		Configure(envoy_listeners.TagsMetadata(envoy_tags.Tags(outbound.GetTagsIncludingLegacy()).WithoutTags(mesh_proto.MeshTag))).

--- a/pkg/xds/generator/probe_generator.go
+++ b/pkg/xds/generator/probe_generator.go
@@ -58,7 +58,7 @@ func (g ProbeProxyGenerator) Generate(ctx xds_context.Context, proxy *model.Prox
 	}
 
 	probeListener, err := envoy_listeners.NewInboundListenerBuilder(proxy.APIVersion, proxy.Dataplane.Spec.GetNetworking().GetAddress(), probes.Port, model.SocketAddressProtocolTCP).
-		WithName(listenerName).
+		WithOverwriteName(listenerName).
 		Configure(envoy_listeners.FilterChain(envoy_listeners.NewFilterChainBuilder(proxy.APIVersion).
 			Configure(envoy_listeners.HttpConnectionManager(listenerName, false)).
 			Configure(envoy_listeners.HttpStaticRoute(envoy_routes.NewRouteConfigurationBuilder(proxy.APIVersion, routeConfigurationName).

--- a/pkg/xds/generator/probe_generator.go
+++ b/pkg/xds/generator/probe_generator.go
@@ -57,8 +57,8 @@ func (g ProbeProxyGenerator) Generate(ctx xds_context.Context, proxy *model.Prox
 		}
 	}
 
-	probeListener, err := envoy_listeners.NewListenerBuilder(proxy.APIVersion).
-		Configure(envoy_listeners.InboundListener(listenerName, proxy.Dataplane.Spec.GetNetworking().GetAddress(), probes.Port, model.SocketAddressProtocolTCP)).
+	probeListener, err := envoy_listeners.NewInboundListenerBuilder(proxy.APIVersion, proxy.Dataplane.Spec.GetNetworking().GetAddress(), probes.Port, model.SocketAddressProtocolTCP).
+		WithName(listenerName).
 		Configure(envoy_listeners.FilterChain(envoy_listeners.NewFilterChainBuilder(proxy.APIVersion).
 			Configure(envoy_listeners.HttpConnectionManager(listenerName, false)).
 			Configure(envoy_listeners.HttpStaticRoute(envoy_routes.NewRouteConfigurationBuilder(proxy.APIVersion, routeConfigurationName).

--- a/pkg/xds/generator/prometheus_endpoint_generator.go
+++ b/pkg/xds/generator/prometheus_endpoint_generator.go
@@ -89,8 +89,8 @@ func (g PrometheusEndpointGenerator) Generate(ctx xds_context.Context, proxy *co
 	iface := proxy.Dataplane.Spec.GetNetworking().ToInboundInterface(inbound)
 	var listener envoy_common.NamedResource
 	if secureMetrics(prometheusEndpoint, ctx.Mesh.Resource) {
-		listener, err = envoy_listeners.NewListenerBuilder(proxy.APIVersion).
-			Configure(envoy_listeners.InboundListener(prometheusListenerName, prometheusEndpointAddress, prometheusEndpoint.Port, core_xds.SocketAddressProtocolTCP)).
+		listener, err = envoy_listeners.NewInboundListenerBuilder(proxy.APIVersion, prometheusEndpointAddress, prometheusEndpoint.Port, core_xds.SocketAddressProtocolTCP).
+			WithName(prometheusListenerName).
 			// generate filter chain that does not require mTLS when DP scrapes itself (for example DP next to Prometheus Server)
 			Configure(envoy_listeners.FilterChain(
 				envoy_listeners.NewFilterChainBuilder(proxy.APIVersion).Configure(
@@ -120,8 +120,8 @@ func (g PrometheusEndpointGenerator) Generate(ctx xds_context.Context, proxy *co
 			)).
 			Build()
 	} else {
-		listener, err = envoy_listeners.NewListenerBuilder(proxy.APIVersion).
-			Configure(envoy_listeners.InboundListener(prometheusListenerName, prometheusEndpointAddress, prometheusEndpoint.Port, core_xds.SocketAddressProtocolTCP)).
+		listener, err = envoy_listeners.NewInboundListenerBuilder(proxy.APIVersion, prometheusEndpointAddress, prometheusEndpoint.Port, core_xds.SocketAddressProtocolTCP).
+			WithName(prometheusListenerName).
 			Configure(envoy_listeners.FilterChain(envoy_listeners.NewFilterChainBuilder(proxy.APIVersion).
 				Configure(envoy_listeners.StaticEndpoints(prometheusListenerName, []*envoy_common.StaticEndpointPath{
 					{

--- a/pkg/xds/generator/prometheus_endpoint_generator.go
+++ b/pkg/xds/generator/prometheus_endpoint_generator.go
@@ -90,7 +90,7 @@ func (g PrometheusEndpointGenerator) Generate(ctx xds_context.Context, proxy *co
 	var listener envoy_common.NamedResource
 	if secureMetrics(prometheusEndpoint, ctx.Mesh.Resource) {
 		listener, err = envoy_listeners.NewInboundListenerBuilder(proxy.APIVersion, prometheusEndpointAddress, prometheusEndpoint.Port, core_xds.SocketAddressProtocolTCP).
-			WithName(prometheusListenerName).
+			WithOverwriteName(prometheusListenerName).
 			// generate filter chain that does not require mTLS when DP scrapes itself (for example DP next to Prometheus Server)
 			Configure(envoy_listeners.FilterChain(
 				envoy_listeners.NewFilterChainBuilder(proxy.APIVersion).Configure(
@@ -121,7 +121,7 @@ func (g PrometheusEndpointGenerator) Generate(ctx xds_context.Context, proxy *co
 			Build()
 	} else {
 		listener, err = envoy_listeners.NewInboundListenerBuilder(proxy.APIVersion, prometheusEndpointAddress, prometheusEndpoint.Port, core_xds.SocketAddressProtocolTCP).
-			WithName(prometheusListenerName).
+			WithOverwriteName(prometheusListenerName).
 			Configure(envoy_listeners.FilterChain(envoy_listeners.NewFilterChainBuilder(proxy.APIVersion).
 				Configure(envoy_listeners.StaticEndpoints(prometheusListenerName, []*envoy_common.StaticEndpointPath{
 					{

--- a/pkg/xds/generator/transparent_proxy_generator.go
+++ b/pkg/xds/generator/transparent_proxy_generator.go
@@ -76,7 +76,7 @@ func (_ TransparentProxyGenerator) generate(ctx xds_context.Context, proxy *mode
 	}
 
 	outboundListener, err = envoy_listeners.NewOutboundListenerBuilder(proxy.APIVersion, allIP, redirectPortOutbound, model.SocketAddressProtocolTCP).
-		WithName(outboundName).
+		WithOverwriteName(outboundName).
 		Configure(envoy_listeners.FilterChain(envoy_listeners.NewFilterChainBuilder(proxy.APIVersion).
 			Configure(envoy_listeners.TcpProxyDeprecated(outboundName, envoy_common.NewCluster(envoy_common.WithService(outboundName)))).
 			Configure(envoy_listeners.NetworkAccessLog(
@@ -103,7 +103,7 @@ func (_ TransparentProxyGenerator) generate(ctx xds_context.Context, proxy *mode
 	}
 
 	inboundListener, err := envoy_listeners.NewInboundListenerBuilder(proxy.APIVersion, allIP, redirectPortInbound, model.SocketAddressProtocolTCP).
-		WithName(inboundName).
+		WithOverwriteName(inboundName).
 		Configure(envoy_listeners.FilterChain(envoy_listeners.NewFilterChainBuilder(proxy.APIVersion).
 			Configure(envoy_listeners.TcpProxyDeprecated(inboundName, envoy_common.NewCluster(envoy_common.WithService(inboundName)))))).
 		Configure(envoy_listeners.OriginalDstForwarder()).

--- a/pkg/xds/generator/transparent_proxy_generator.go
+++ b/pkg/xds/generator/transparent_proxy_generator.go
@@ -75,8 +75,8 @@ func (_ TransparentProxyGenerator) generate(ctx xds_context.Context, proxy *mode
 		}
 	}
 
-	outboundListener, err = envoy_listeners.NewListenerBuilder(proxy.APIVersion).
-		Configure(envoy_listeners.OutboundListener(outboundName, allIP, redirectPortOutbound, model.SocketAddressProtocolTCP)).
+	outboundListener, err = envoy_listeners.NewOutboundListenerBuilder(proxy.APIVersion, allIP, redirectPortOutbound, model.SocketAddressProtocolTCP).
+		WithName(outboundName).
 		Configure(envoy_listeners.FilterChain(envoy_listeners.NewFilterChainBuilder(proxy.APIVersion).
 			Configure(envoy_listeners.TcpProxyDeprecated(outboundName, envoy_common.NewCluster(envoy_common.WithService(outboundName)))).
 			Configure(envoy_listeners.NetworkAccessLog(
@@ -102,8 +102,8 @@ func (_ TransparentProxyGenerator) generate(ctx xds_context.Context, proxy *mode
 		return nil, errors.Wrapf(err, "could not generate cluster: %s", inboundName)
 	}
 
-	inboundListener, err := envoy_listeners.NewListenerBuilder(proxy.APIVersion).
-		Configure(envoy_listeners.InboundListener(inboundName, allIP, redirectPortInbound, model.SocketAddressProtocolTCP)).
+	inboundListener, err := envoy_listeners.NewInboundListenerBuilder(proxy.APIVersion, allIP, redirectPortInbound, model.SocketAddressProtocolTCP).
+		WithName(inboundName).
 		Configure(envoy_listeners.FilterChain(envoy_listeners.NewFilterChainBuilder(proxy.APIVersion).
 			Configure(envoy_listeners.TcpProxyDeprecated(inboundName, envoy_common.NewCluster(envoy_common.WithService(inboundName)))))).
 		Configure(envoy_listeners.OriginalDstForwarder()).


### PR DESCRIPTION
Defines the listener name as a required field for the builder constructor function and adds a validation in the final build function to throw an error if the field is blank.
It defines a default name for inbound and outbound listeners, but a `withName` function allows to define a custom name.
It also removes the name assignation from several configurers. It asserts that the name shall be known when the builder is instantiated.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [ ] [Link to relevant issue][1] as well as docs and UI issues -- #2538
- [ ] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [ ] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [ ] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [ ] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [ ] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
