### PR TITLE
feat(xds): named resources (routes configuration) builders require name

### DIFF
--- a/pkg/plugins/policies/meshhttproute/xds/builder.go
+++ b/pkg/plugins/policies/meshhttproute/xds/builder.go
@@ -42,8 +42,8 @@ func (c *HttpOutboundRouteConfigurer) Configure(filterChain *envoy_listener.Filt
 		virtualHostBuilder = virtualHostBuilder.Configure(route)
 	}
 	static := envoy_listeners_v3.HttpStaticRouteConfigurer{
-		Builder: envoy_routes.NewRouteConfigurationBuilder(envoy_common.APIV3).
-			Configure(envoy_routes.CommonRouteConfiguration(envoy_names.GetOutboundRouteName(c.Service))).
+		Builder: envoy_routes.NewRouteConfigurationBuilder(envoy_common.APIV3, envoy_names.GetOutboundRouteName(c.Service)).
+			Configure(envoy_routes.CommonRouteConfiguration()).
 			Configure(envoy_routes.TagsHeader(c.DpTags)).
 			Configure(envoy_routes.VirtualHost(virtualHostBuilder)),
 	}

--- a/pkg/plugins/runtime/gateway/route_configuration_generator.go
+++ b/pkg/plugins/runtime/gateway/route_configuration_generator.go
@@ -13,9 +13,9 @@ func GenerateRouteConfig(info GatewayListenerInfo) *envoy_routes.RouteConfigurat
 		return nil
 	}
 
-	return envoy_routes.NewRouteConfigurationBuilder(info.Proxy.APIVersion).
+	return envoy_routes.NewRouteConfigurationBuilder(info.Proxy.APIVersion, info.Listener.ResourceName).
 		Configure(
-			envoy_routes.CommonRouteConfiguration(info.Listener.ResourceName),
+			envoy_routes.CommonRouteConfiguration(),
 			envoy_routes.IgnorePortInHostMatching(),
 			// TODO(jpeach) propagate merged listener tags.
 			// Ideally we would propagate the tags header

--- a/pkg/xds/envoy/listeners/v3/http_inbound_routes_configurer.go
+++ b/pkg/xds/envoy/listeners/v3/http_inbound_routes_configurer.go
@@ -20,8 +20,8 @@ func (c *HttpInboundRouteConfigurer) Configure(filterChain *envoy_listener.Filte
 	routeName := envoy_names.GetInboundRouteName(c.Service)
 
 	static := HttpStaticRouteConfigurer{
-		Builder: envoy_routes.NewRouteConfigurationBuilder(envoy_common.APIV3).
-			Configure(envoy_routes.CommonRouteConfiguration(routeName)).
+		Builder: envoy_routes.NewRouteConfigurationBuilder(envoy_common.APIV3, routeName).
+			Configure(envoy_routes.CommonRouteConfiguration()).
 			Configure(envoy_routes.ResetTagsHeader()).
 			Configure(envoy_routes.VirtualHost(envoy_virtual_hosts.NewVirtualHostBuilder(envoy_common.APIV3).
 				Configure(envoy_virtual_hosts.CommonVirtualHost(c.Service)).

--- a/pkg/xds/envoy/listeners/v3/http_outbound_route_configurer.go
+++ b/pkg/xds/envoy/listeners/v3/http_outbound_route_configurer.go
@@ -20,8 +20,8 @@ var _ FilterChainConfigurer = &HttpOutboundRouteConfigurer{}
 
 func (c *HttpOutboundRouteConfigurer) Configure(filterChain *envoy_listener.FilterChain) error {
 	static := HttpStaticRouteConfigurer{
-		Builder: envoy_routes.NewRouteConfigurationBuilder(envoy_common.APIV3).
-			Configure(envoy_routes.CommonRouteConfiguration(envoy_names.GetOutboundRouteName(c.Service))).
+		Builder: envoy_routes.NewRouteConfigurationBuilder(envoy_common.APIV3, envoy_names.GetOutboundRouteName(c.Service)).
+			Configure(envoy_routes.CommonRouteConfiguration()).
 			Configure(envoy_routes.TagsHeader(c.DpTags)).
 			Configure(envoy_routes.VirtualHost(envoy_virtual_hosts.NewVirtualHostBuilder(envoy_common.APIV3).
 				Configure(envoy_virtual_hosts.CommonVirtualHost(c.Service)).

--- a/pkg/xds/envoy/routes/configurers.go
+++ b/pkg/xds/envoy/routes/configurers.go
@@ -33,11 +33,9 @@ func VirtualHost(builder *envoy_virtual_hosts.VirtualHostBuilder) RouteConfigura
 		}))
 }
 
-func CommonRouteConfiguration(name string) RouteConfigurationBuilderOpt {
+func CommonRouteConfiguration() RouteConfigurationBuilderOpt {
 	return AddRouteConfigurationConfigurer(
-		&v3.CommonRouteConfigurationConfigurer{
-			Name: name,
-		})
+		&v3.CommonRouteConfigurationConfigurer{})
 }
 
 func IgnorePortInHostMatching() RouteConfigurationBuilderOpt {

--- a/pkg/xds/envoy/routes/v3/common_route_configuration_configurer.go
+++ b/pkg/xds/envoy/routes/v3/common_route_configuration_configurer.go
@@ -6,12 +6,9 @@ import (
 	util_proto "github.com/kumahq/kuma/pkg/util/proto"
 )
 
-type CommonRouteConfigurationConfigurer struct {
-	Name string
-}
+type CommonRouteConfigurationConfigurer struct{}
 
 func (c CommonRouteConfigurationConfigurer) Configure(routeConfiguration *envoy_route.RouteConfiguration) error {
-	routeConfiguration.Name = c.Name
 	routeConfiguration.ValidateClusters = util_proto.Bool(false)
 	return nil
 }

--- a/pkg/xds/envoy/routes/v3/reset_tags_header_configurer_test.go
+++ b/pkg/xds/envoy/routes/v3/reset_tags_header_configurer_test.go
@@ -12,7 +12,7 @@ import (
 var _ = Describe("ResetTagsHeaderConfigurer", func() {
 	It("should generate proper Envoy config", func() {
 		// when
-		routeConfiguration, err := routes.NewRouteConfigurationBuilder(envoy.APIV3).
+		routeConfiguration, err := routes.NewRouteConfigurationBuilder(envoy.APIV3, "route_configuration").
 			Configure(routes.ResetTagsHeader()).
 			Build()
 		// then
@@ -24,6 +24,7 @@ var _ = Describe("ResetTagsHeaderConfigurer", func() {
 		Expect(err).ToNot(HaveOccurred())
 		// and
 		Expect(actual).To(MatchYAML(`
+            name: route_configuration
             requestHeadersToRemove:
               - x-kuma-tags`))
 	})

--- a/pkg/xds/envoy/routes/v3/tags_header_configurer_test.go
+++ b/pkg/xds/envoy/routes/v3/tags_header_configurer_test.go
@@ -19,7 +19,7 @@ var _ = Describe("TagsHeaderConfigurer", func() {
 	DescribeTable("should generate proper Envoy config",
 		func(given testCase) {
 			// when
-			routeConfiguration, err := routes.NewRouteConfigurationBuilder(envoy.APIV3).
+			routeConfiguration, err := routes.NewRouteConfigurationBuilder(envoy.APIV3, "route_configuration").
 				Configure(routes.TagsHeader(given.tags)).
 				Build()
 			// then
@@ -39,6 +39,7 @@ var _ = Describe("TagsHeaderConfigurer", func() {
 				"tag1": {"value11": true, "value12": true},
 			},
 			expected: `
+            name: route_configuration
             requestHeadersToAdd:
             - header:
                 key: x-kuma-tags
@@ -46,7 +47,7 @@ var _ = Describe("TagsHeaderConfigurer", func() {
 		}),
 		Entry("empty tags", testCase{
 			tags:     map[string]map[string]bool{},
-			expected: `{}`,
+			expected: `name: route_configuration`,
 		}),
 	)
 })

--- a/pkg/xds/envoy/virtualhosts/virtual_host_configurer_test.go
+++ b/pkg/xds/envoy/virtualhosts/virtual_host_configurer_test.go
@@ -24,7 +24,7 @@ var _ = Describe("RouteConfigurationVirtualHostConfigurer", func() {
 		DescribeTable("should generate proper Envoy config",
 			func(given testCase) {
 				// when
-				routeConfiguration, err := NewRouteConfigurationBuilder(envoy.APIV3).
+				routeConfiguration, err := NewRouteConfigurationBuilder(envoy.APIV3, "route_configuration").
 					Configure(VirtualHost(NewVirtualHostBuilder(envoy.APIV3).
 						Configure(given.opts...))).
 					Build()
@@ -41,6 +41,7 @@ var _ = Describe("RouteConfigurationVirtualHostConfigurer", func() {
 			Entry("basic virtual host", testCase{
 				opts: []Opt{CommonVirtualHost("backend")},
 				expected: `
+            name: route_configuration
             virtualHosts:
             - domains:
               - '*'
@@ -53,6 +54,7 @@ var _ = Describe("RouteConfigurationVirtualHostConfigurer", func() {
 					DomainNames("foo.example.com", "bar.example.com"),
 				},
 				expected: `
+            name: route_configuration
             virtualHosts:
             - domains:
               - foo.example.com
@@ -66,6 +68,7 @@ var _ = Describe("RouteConfigurationVirtualHostConfigurer", func() {
 					DomainNames(),
 				},
 				expected: `
+            name: route_configuration
             virtualHosts:
             - domains:
               - '*'
@@ -91,6 +94,7 @@ var _ = Describe("RouteConfigurationVirtualHostConfigurer", func() {
 					),
 				},
 				expected: `
+            name: route_configuration
             virtualHosts:
             - domains:
               - '*'

--- a/pkg/xds/generator/probe_generator.go
+++ b/pkg/xds/generator/probe_generator.go
@@ -15,8 +15,9 @@ import (
 
 const (
 	// OriginProbes is a marker to indicate by which ProxyGenerator resources were generated.
-	OriginProbe  = "probe"
-	listenerName = "probe:listener"
+	OriginProbe            = "probe"
+	listenerName           = "probe:listener"
+	routeConfigurationName = "probe:route_configuration"
 )
 
 type ProbeProxyGenerator struct{}
@@ -60,7 +61,7 @@ func (g ProbeProxyGenerator) Generate(ctx xds_context.Context, proxy *model.Prox
 		Configure(envoy_listeners.InboundListener(listenerName, proxy.Dataplane.Spec.GetNetworking().GetAddress(), probes.Port, model.SocketAddressProtocolTCP)).
 		Configure(envoy_listeners.FilterChain(envoy_listeners.NewFilterChainBuilder(proxy.APIVersion).
 			Configure(envoy_listeners.HttpConnectionManager(listenerName, false)).
-			Configure(envoy_listeners.HttpStaticRoute(envoy_routes.NewRouteConfigurationBuilder(proxy.APIVersion).
+			Configure(envoy_listeners.HttpStaticRoute(envoy_routes.NewRouteConfigurationBuilder(proxy.APIVersion, routeConfigurationName).
 				Configure(envoy_routes.VirtualHost(virtualHostBuilder)))))).
 		Configure(envoy_listeners.TransparentProxying(proxy.Dataplane.Spec.Networking.GetTransparentProxying())).
 		Build()

--- a/pkg/xds/generator/testdata/probe/01.envoy.golden.yaml
+++ b/pkg/xds/generator/testdata/probe/01.envoy.golden.yaml
@@ -16,6 +16,7 @@ resources:
             typedConfig:
               '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
           routeConfig:
+            name: probe:route_configuration
             virtualHosts:
             - domains:
               - '*'

--- a/pkg/xds/generator/testdata/probe/03.envoy.golden.yaml
+++ b/pkg/xds/generator/testdata/probe/03.envoy.golden.yaml
@@ -16,6 +16,7 @@ resources:
             typedConfig:
               '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
           routeConfig:
+            name: probe:route_configuration
             virtualHosts:
             - domains:
               - '*'

--- a/pkg/xds/generator/testdata/probe/04.envoy.golden.yaml
+++ b/pkg/xds/generator/testdata/probe/04.envoy.golden.yaml
@@ -16,6 +16,7 @@ resources:
             typedConfig:
               '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
           routeConfig:
+            name: probe:route_configuration
             virtualHosts:
             - domains:
               - '*'


### PR DESCRIPTION
Defines the route configuration name as a required field for the builder constructor function and adds a validation in the final build function to throw an error if the field is blank.

It also removes the name assignation from common route configuration configurers. It asserts that the name shall be known when the builder is instantiated.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [ ] [Link to relevant issue][1] as well as docs and UI issues -- #2538
- [ ] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [ ] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [ ] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [ ] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [ ] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
