### PR TITLE
feat(policy): add `targetRef.kind` `MeshGateway`

### DIFF
--- a/api/common/v1alpha1/ref.go
+++ b/api/common/v1alpha1/ref.go
@@ -14,6 +14,7 @@ type TargetRefKind string
 var (
 	Mesh              TargetRefKind = "Mesh"
 	MeshSubset        TargetRefKind = "MeshSubset"
+	MeshGateway       TargetRefKind = "MeshGateway"
 	MeshService       TargetRefKind = "MeshService"
 	MeshServiceSubset TargetRefKind = "MeshServiceSubset"
 	MeshHTTPRoute     TargetRefKind = "MeshHTTPRoute"
@@ -22,9 +23,10 @@ var (
 var order = map[TargetRefKind]int{
 	Mesh:              1,
 	MeshSubset:        2,
-	MeshService:       3,
-	MeshServiceSubset: 4,
-	MeshHTTPRoute:     5,
+	MeshGateway:       3,
+	MeshService:       4,
+	MeshServiceSubset: 5,
+	MeshHTTPRoute:     6,
 }
 
 func (k TargetRefKind) Less(o TargetRefKind) bool {
@@ -34,7 +36,7 @@ func (k TargetRefKind) Less(o TargetRefKind) bool {
 // TargetRef defines structure that allows attaching policy to various objects
 type TargetRef struct {
 	// Kind of the referenced resource
-	// +kubebuilder:validation:Enum=Mesh;MeshSubset;MeshService;MeshServiceSubset;MeshHTTPRoute
+	// +kubebuilder:validation:Enum=Mesh;MeshSubset;MeshGateway;MeshService;MeshServiceSubset;MeshHTTPRoute
 	Kind TargetRefKind `json:"kind,omitempty"`
 	// Name of the referenced resource. Can only be used with kinds: `MeshService`,
 	// `MeshServiceSubset` and `MeshGatewayRoute`

--- a/app/kumactl/cmd/install/testdata/install-control-plane.defaults.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.defaults.golden.yaml
@@ -313,6 +313,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGateway
                           - MeshService
                           - MeshServiceSubset
                           - MeshHTTPRoute
@@ -347,6 +348,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGateway
                     - MeshService
                     - MeshServiceSubset
                     - MeshHTTPRoute
@@ -838,6 +840,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGateway
                     - MeshService
                     - MeshServiceSubset
                     - MeshHTTPRoute
@@ -1063,6 +1066,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGateway
                           - MeshService
                           - MeshServiceSubset
                           - MeshHTTPRoute
@@ -1140,6 +1144,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGateway
                     - MeshService
                     - MeshServiceSubset
                     - MeshHTTPRoute
@@ -1183,6 +1188,7 @@ spec:
                                       enum:
                                       - Mesh
                                       - MeshSubset
+                                      - MeshGateway
                                       - MeshService
                                       - MeshServiceSubset
                                       - MeshHTTPRoute
@@ -1276,6 +1282,7 @@ spec:
                                               enum:
                                               - Mesh
                                               - MeshSubset
+                                              - MeshGateway
                                               - MeshService
                                               - MeshServiceSubset
                                               - MeshHTTPRoute
@@ -1568,6 +1575,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGateway
                           - MeshService
                           - MeshServiceSubset
                           - MeshHTTPRoute
@@ -1686,6 +1694,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGateway
                     - MeshService
                     - MeshServiceSubset
                     - MeshHTTPRoute
@@ -2022,6 +2031,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGateway
                           - MeshService
                           - MeshServiceSubset
                           - MeshHTTPRoute
@@ -2529,6 +2539,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGateway
                     - MeshService
                     - MeshServiceSubset
                     - MeshHTTPRoute
@@ -2722,6 +2733,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGateway
                           - MeshService
                           - MeshServiceSubset
                           - MeshHTTPRoute
@@ -2756,6 +2768,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGateway
                     - MeshService
                     - MeshServiceSubset
                     - MeshHTTPRoute
@@ -2872,6 +2885,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGateway
                     - MeshService
                     - MeshServiceSubset
                     - MeshHTTPRoute
@@ -3191,6 +3205,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGateway
                           - MeshService
                           - MeshServiceSubset
                           - MeshHTTPRoute
@@ -3268,6 +3283,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGateway
                     - MeshService
                     - MeshServiceSubset
                     - MeshHTTPRoute
@@ -3311,6 +3327,7 @@ spec:
                                       enum:
                                       - Mesh
                                       - MeshSubset
+                                      - MeshGateway
                                       - MeshService
                                       - MeshServiceSubset
                                       - MeshHTTPRoute
@@ -3355,6 +3372,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGateway
                           - MeshService
                           - MeshServiceSubset
                           - MeshHTTPRoute
@@ -3484,6 +3502,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGateway
                           - MeshService
                           - MeshServiceSubset
                           - MeshHTTPRoute
@@ -3518,6 +3537,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGateway
                     - MeshService
                     - MeshServiceSubset
                     - MeshHTTPRoute
@@ -3598,6 +3618,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGateway
                           - MeshService
                           - MeshServiceSubset
                           - MeshHTTPRoute
@@ -3823,6 +3844,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGateway
                     - MeshService
                     - MeshServiceSubset
                     - MeshHTTPRoute
@@ -3913,6 +3935,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGateway
                           - MeshService
                           - MeshServiceSubset
                           - MeshHTTPRoute
@@ -3947,6 +3970,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGateway
                     - MeshService
                     - MeshServiceSubset
                     - MeshHTTPRoute
@@ -5040,6 +5064,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGateway
                           - MeshService
                           - MeshServiceSubset
                           - MeshHTTPRoute
@@ -5074,6 +5099,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGateway
                     - MeshService
                     - MeshServiceSubset
                     - MeshHTTPRoute
@@ -5223,6 +5249,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGateway
                           - MeshService
                           - MeshServiceSubset
                           - MeshHTTPRoute
@@ -5556,6 +5583,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGateway
                           - MeshService
                           - MeshServiceSubset
                           - MeshHTTPRoute
@@ -5590,6 +5618,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGateway
                     - MeshService
                     - MeshServiceSubset
                     - MeshHTTPRoute
@@ -5874,6 +5903,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGateway
                           - MeshService
                           - MeshServiceSubset
                           - MeshHTTPRoute

--- a/app/kumactl/cmd/install/testdata/install-control-plane.gateway-api-present-not-enabled.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.gateway-api-present-not-enabled.yaml
@@ -313,6 +313,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGateway
                           - MeshService
                           - MeshServiceSubset
                           - MeshHTTPRoute
@@ -347,6 +348,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGateway
                     - MeshService
                     - MeshServiceSubset
                     - MeshHTTPRoute
@@ -838,6 +840,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGateway
                     - MeshService
                     - MeshServiceSubset
                     - MeshHTTPRoute
@@ -1063,6 +1066,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGateway
                           - MeshService
                           - MeshServiceSubset
                           - MeshHTTPRoute
@@ -1140,6 +1144,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGateway
                     - MeshService
                     - MeshServiceSubset
                     - MeshHTTPRoute
@@ -1183,6 +1188,7 @@ spec:
                                       enum:
                                       - Mesh
                                       - MeshSubset
+                                      - MeshGateway
                                       - MeshService
                                       - MeshServiceSubset
                                       - MeshHTTPRoute
@@ -1276,6 +1282,7 @@ spec:
                                               enum:
                                               - Mesh
                                               - MeshSubset
+                                              - MeshGateway
                                               - MeshService
                                               - MeshServiceSubset
                                               - MeshHTTPRoute
@@ -1568,6 +1575,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGateway
                           - MeshService
                           - MeshServiceSubset
                           - MeshHTTPRoute
@@ -1686,6 +1694,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGateway
                     - MeshService
                     - MeshServiceSubset
                     - MeshHTTPRoute
@@ -2022,6 +2031,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGateway
                           - MeshService
                           - MeshServiceSubset
                           - MeshHTTPRoute
@@ -2529,6 +2539,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGateway
                     - MeshService
                     - MeshServiceSubset
                     - MeshHTTPRoute
@@ -2722,6 +2733,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGateway
                           - MeshService
                           - MeshServiceSubset
                           - MeshHTTPRoute
@@ -2756,6 +2768,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGateway
                     - MeshService
                     - MeshServiceSubset
                     - MeshHTTPRoute
@@ -2872,6 +2885,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGateway
                     - MeshService
                     - MeshServiceSubset
                     - MeshHTTPRoute
@@ -3191,6 +3205,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGateway
                           - MeshService
                           - MeshServiceSubset
                           - MeshHTTPRoute
@@ -3268,6 +3283,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGateway
                     - MeshService
                     - MeshServiceSubset
                     - MeshHTTPRoute
@@ -3311,6 +3327,7 @@ spec:
                                       enum:
                                       - Mesh
                                       - MeshSubset
+                                      - MeshGateway
                                       - MeshService
                                       - MeshServiceSubset
                                       - MeshHTTPRoute
@@ -3355,6 +3372,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGateway
                           - MeshService
                           - MeshServiceSubset
                           - MeshHTTPRoute
@@ -3484,6 +3502,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGateway
                           - MeshService
                           - MeshServiceSubset
                           - MeshHTTPRoute
@@ -3518,6 +3537,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGateway
                     - MeshService
                     - MeshServiceSubset
                     - MeshHTTPRoute
@@ -3598,6 +3618,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGateway
                           - MeshService
                           - MeshServiceSubset
                           - MeshHTTPRoute
@@ -3823,6 +3844,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGateway
                     - MeshService
                     - MeshServiceSubset
                     - MeshHTTPRoute
@@ -3913,6 +3935,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGateway
                           - MeshService
                           - MeshServiceSubset
                           - MeshHTTPRoute
@@ -3947,6 +3970,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGateway
                     - MeshService
                     - MeshServiceSubset
                     - MeshHTTPRoute
@@ -5040,6 +5064,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGateway
                           - MeshService
                           - MeshServiceSubset
                           - MeshHTTPRoute
@@ -5074,6 +5099,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGateway
                     - MeshService
                     - MeshServiceSubset
                     - MeshHTTPRoute
@@ -5223,6 +5249,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGateway
                           - MeshService
                           - MeshServiceSubset
                           - MeshHTTPRoute
@@ -5556,6 +5583,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGateway
                           - MeshService
                           - MeshServiceSubset
                           - MeshHTTPRoute
@@ -5590,6 +5618,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGateway
                     - MeshService
                     - MeshServiceSubset
                     - MeshHTTPRoute
@@ -5874,6 +5903,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGateway
                           - MeshService
                           - MeshServiceSubset
                           - MeshHTTPRoute

--- a/app/kumactl/cmd/install/testdata/install-control-plane.gateway-api-present.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.gateway-api-present.yaml
@@ -313,6 +313,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGateway
                           - MeshService
                           - MeshServiceSubset
                           - MeshHTTPRoute
@@ -347,6 +348,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGateway
                     - MeshService
                     - MeshServiceSubset
                     - MeshHTTPRoute
@@ -1042,6 +1044,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGateway
                     - MeshService
                     - MeshServiceSubset
                     - MeshHTTPRoute
@@ -1267,6 +1270,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGateway
                           - MeshService
                           - MeshServiceSubset
                           - MeshHTTPRoute
@@ -1344,6 +1348,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGateway
                     - MeshService
                     - MeshServiceSubset
                     - MeshHTTPRoute
@@ -1387,6 +1392,7 @@ spec:
                                       enum:
                                       - Mesh
                                       - MeshSubset
+                                      - MeshGateway
                                       - MeshService
                                       - MeshServiceSubset
                                       - MeshHTTPRoute
@@ -1480,6 +1486,7 @@ spec:
                                               enum:
                                               - Mesh
                                               - MeshSubset
+                                              - MeshGateway
                                               - MeshService
                                               - MeshServiceSubset
                                               - MeshHTTPRoute
@@ -1772,6 +1779,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGateway
                           - MeshService
                           - MeshServiceSubset
                           - MeshHTTPRoute
@@ -1890,6 +1898,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGateway
                     - MeshService
                     - MeshServiceSubset
                     - MeshHTTPRoute
@@ -2226,6 +2235,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGateway
                           - MeshService
                           - MeshServiceSubset
                           - MeshHTTPRoute
@@ -2733,6 +2743,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGateway
                     - MeshService
                     - MeshServiceSubset
                     - MeshHTTPRoute
@@ -2970,6 +2981,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGateway
                           - MeshService
                           - MeshServiceSubset
                           - MeshHTTPRoute
@@ -3004,6 +3016,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGateway
                     - MeshService
                     - MeshServiceSubset
                     - MeshHTTPRoute
@@ -3076,6 +3089,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGateway
                     - MeshService
                     - MeshServiceSubset
                     - MeshHTTPRoute
@@ -3395,6 +3409,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGateway
                           - MeshService
                           - MeshServiceSubset
                           - MeshHTTPRoute
@@ -3472,6 +3487,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGateway
                     - MeshService
                     - MeshServiceSubset
                     - MeshHTTPRoute
@@ -3515,6 +3531,7 @@ spec:
                                       enum:
                                       - Mesh
                                       - MeshSubset
+                                      - MeshGateway
                                       - MeshService
                                       - MeshServiceSubset
                                       - MeshHTTPRoute
@@ -3559,6 +3576,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGateway
                           - MeshService
                           - MeshServiceSubset
                           - MeshHTTPRoute
@@ -3688,6 +3706,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGateway
                           - MeshService
                           - MeshServiceSubset
                           - MeshHTTPRoute
@@ -3722,6 +3741,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGateway
                     - MeshService
                     - MeshServiceSubset
                     - MeshHTTPRoute
@@ -3802,6 +3822,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGateway
                           - MeshService
                           - MeshServiceSubset
                           - MeshHTTPRoute
@@ -4027,6 +4048,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGateway
                     - MeshService
                     - MeshServiceSubset
                     - MeshHTTPRoute
@@ -4117,6 +4139,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGateway
                           - MeshService
                           - MeshServiceSubset
                           - MeshHTTPRoute
@@ -4151,6 +4174,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGateway
                     - MeshService
                     - MeshServiceSubset
                     - MeshHTTPRoute
@@ -5244,6 +5268,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGateway
                           - MeshService
                           - MeshServiceSubset
                           - MeshHTTPRoute
@@ -5278,6 +5303,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGateway
                     - MeshService
                     - MeshServiceSubset
                     - MeshHTTPRoute
@@ -5427,6 +5453,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGateway
                           - MeshService
                           - MeshServiceSubset
                           - MeshHTTPRoute
@@ -5760,6 +5787,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGateway
                           - MeshService
                           - MeshServiceSubset
                           - MeshHTTPRoute
@@ -5794,6 +5822,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGateway
                     - MeshService
                     - MeshServiceSubset
                     - MeshHTTPRoute
@@ -6078,6 +6107,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGateway
                           - MeshService
                           - MeshServiceSubset
                           - MeshHTTPRoute

--- a/app/kumactl/cmd/install/testdata/install-control-plane.with-helm-set.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.with-helm-set.yaml
@@ -333,6 +333,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGateway
                           - MeshService
                           - MeshServiceSubset
                           - MeshHTTPRoute
@@ -367,6 +368,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGateway
                     - MeshService
                     - MeshServiceSubset
                     - MeshHTTPRoute
@@ -858,6 +860,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGateway
                     - MeshService
                     - MeshServiceSubset
                     - MeshHTTPRoute
@@ -1083,6 +1086,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGateway
                           - MeshService
                           - MeshServiceSubset
                           - MeshHTTPRoute
@@ -1160,6 +1164,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGateway
                     - MeshService
                     - MeshServiceSubset
                     - MeshHTTPRoute
@@ -1203,6 +1208,7 @@ spec:
                                       enum:
                                       - Mesh
                                       - MeshSubset
+                                      - MeshGateway
                                       - MeshService
                                       - MeshServiceSubset
                                       - MeshHTTPRoute
@@ -1296,6 +1302,7 @@ spec:
                                               enum:
                                               - Mesh
                                               - MeshSubset
+                                              - MeshGateway
                                               - MeshService
                                               - MeshServiceSubset
                                               - MeshHTTPRoute
@@ -1588,6 +1595,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGateway
                           - MeshService
                           - MeshServiceSubset
                           - MeshHTTPRoute
@@ -1706,6 +1714,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGateway
                     - MeshService
                     - MeshServiceSubset
                     - MeshHTTPRoute
@@ -2042,6 +2051,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGateway
                           - MeshService
                           - MeshServiceSubset
                           - MeshHTTPRoute
@@ -2549,6 +2559,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGateway
                     - MeshService
                     - MeshServiceSubset
                     - MeshHTTPRoute
@@ -2742,6 +2753,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGateway
                           - MeshService
                           - MeshServiceSubset
                           - MeshHTTPRoute
@@ -2776,6 +2788,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGateway
                     - MeshService
                     - MeshServiceSubset
                     - MeshHTTPRoute
@@ -2892,6 +2905,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGateway
                     - MeshService
                     - MeshServiceSubset
                     - MeshHTTPRoute
@@ -3211,6 +3225,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGateway
                           - MeshService
                           - MeshServiceSubset
                           - MeshHTTPRoute
@@ -3288,6 +3303,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGateway
                     - MeshService
                     - MeshServiceSubset
                     - MeshHTTPRoute
@@ -3331,6 +3347,7 @@ spec:
                                       enum:
                                       - Mesh
                                       - MeshSubset
+                                      - MeshGateway
                                       - MeshService
                                       - MeshServiceSubset
                                       - MeshHTTPRoute
@@ -3375,6 +3392,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGateway
                           - MeshService
                           - MeshServiceSubset
                           - MeshHTTPRoute
@@ -3504,6 +3522,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGateway
                           - MeshService
                           - MeshServiceSubset
                           - MeshHTTPRoute
@@ -3538,6 +3557,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGateway
                     - MeshService
                     - MeshServiceSubset
                     - MeshHTTPRoute
@@ -3618,6 +3638,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGateway
                           - MeshService
                           - MeshServiceSubset
                           - MeshHTTPRoute
@@ -3843,6 +3864,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGateway
                     - MeshService
                     - MeshServiceSubset
                     - MeshHTTPRoute
@@ -3933,6 +3955,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGateway
                           - MeshService
                           - MeshServiceSubset
                           - MeshHTTPRoute
@@ -3967,6 +3990,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGateway
                     - MeshService
                     - MeshServiceSubset
                     - MeshHTTPRoute
@@ -5060,6 +5084,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGateway
                           - MeshService
                           - MeshServiceSubset
                           - MeshHTTPRoute
@@ -5094,6 +5119,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGateway
                     - MeshService
                     - MeshServiceSubset
                     - MeshHTTPRoute
@@ -5243,6 +5269,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGateway
                           - MeshService
                           - MeshServiceSubset
                           - MeshHTTPRoute
@@ -5576,6 +5603,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGateway
                           - MeshService
                           - MeshServiceSubset
                           - MeshHTTPRoute
@@ -5610,6 +5638,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGateway
                     - MeshService
                     - MeshServiceSubset
                     - MeshHTTPRoute
@@ -5894,6 +5923,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGateway
                           - MeshService
                           - MeshServiceSubset
                           - MeshHTTPRoute

--- a/app/kumactl/cmd/install/testdata/install-crds.all.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-crds.all.golden.yaml
@@ -559,6 +559,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGateway
                           - MeshService
                           - MeshServiceSubset
                           - MeshHTTPRoute
@@ -593,6 +594,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGateway
                     - MeshService
                     - MeshServiceSubset
                     - MeshHTTPRoute
@@ -742,6 +744,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGateway
                           - MeshService
                           - MeshServiceSubset
                           - MeshHTTPRoute
@@ -1075,6 +1078,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGateway
                           - MeshService
                           - MeshServiceSubset
                           - MeshHTTPRoute
@@ -1109,6 +1113,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGateway
                     - MeshService
                     - MeshServiceSubset
                     - MeshHTTPRoute
@@ -1393,6 +1398,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGateway
                           - MeshService
                           - MeshServiceSubset
                           - MeshHTTPRoute
@@ -1596,6 +1602,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGateway
                           - MeshService
                           - MeshServiceSubset
                           - MeshHTTPRoute
@@ -1630,6 +1637,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGateway
                     - MeshService
                     - MeshServiceSubset
                     - MeshHTTPRoute
@@ -2121,6 +2129,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGateway
                     - MeshService
                     - MeshServiceSubset
                     - MeshHTTPRoute
@@ -2346,6 +2355,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGateway
                           - MeshService
                           - MeshServiceSubset
                           - MeshHTTPRoute
@@ -2423,6 +2433,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGateway
                     - MeshService
                     - MeshServiceSubset
                     - MeshHTTPRoute
@@ -2466,6 +2477,7 @@ spec:
                                       enum:
                                       - Mesh
                                       - MeshSubset
+                                      - MeshGateway
                                       - MeshService
                                       - MeshServiceSubset
                                       - MeshHTTPRoute
@@ -2559,6 +2571,7 @@ spec:
                                               enum:
                                               - Mesh
                                               - MeshSubset
+                                              - MeshGateway
                                               - MeshService
                                               - MeshServiceSubset
                                               - MeshHTTPRoute
@@ -2851,6 +2864,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGateway
                           - MeshService
                           - MeshServiceSubset
                           - MeshHTTPRoute
@@ -2969,6 +2983,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGateway
                     - MeshService
                     - MeshServiceSubset
                     - MeshHTTPRoute
@@ -3305,6 +3320,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGateway
                           - MeshService
                           - MeshServiceSubset
                           - MeshHTTPRoute
@@ -3812,6 +3828,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGateway
                     - MeshService
                     - MeshServiceSubset
                     - MeshHTTPRoute
@@ -4005,6 +4022,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGateway
                           - MeshService
                           - MeshServiceSubset
                           - MeshHTTPRoute
@@ -4039,6 +4057,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGateway
                     - MeshService
                     - MeshServiceSubset
                     - MeshHTTPRoute
@@ -4111,6 +4130,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGateway
                     - MeshService
                     - MeshServiceSubset
                     - MeshHTTPRoute
@@ -4430,6 +4450,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGateway
                           - MeshService
                           - MeshServiceSubset
                           - MeshHTTPRoute
@@ -4507,6 +4528,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGateway
                     - MeshService
                     - MeshServiceSubset
                     - MeshHTTPRoute
@@ -4550,6 +4572,7 @@ spec:
                                       enum:
                                       - Mesh
                                       - MeshSubset
+                                      - MeshGateway
                                       - MeshService
                                       - MeshServiceSubset
                                       - MeshHTTPRoute
@@ -4594,6 +4617,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGateway
                           - MeshService
                           - MeshServiceSubset
                           - MeshHTTPRoute
@@ -4723,6 +4747,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGateway
                           - MeshService
                           - MeshServiceSubset
                           - MeshHTTPRoute
@@ -4757,6 +4782,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGateway
                     - MeshService
                     - MeshServiceSubset
                     - MeshHTTPRoute
@@ -4837,6 +4863,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGateway
                           - MeshService
                           - MeshServiceSubset
                           - MeshHTTPRoute
@@ -5062,6 +5089,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGateway
                     - MeshService
                     - MeshServiceSubset
                     - MeshHTTPRoute
@@ -5152,6 +5180,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGateway
                           - MeshService
                           - MeshServiceSubset
                           - MeshHTTPRoute
@@ -5186,6 +5215,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGateway
                     - MeshService
                     - MeshServiceSubset
                     - MeshHTTPRoute

--- a/app/kumactl/cmd/install/testdata/install-crds.experimental-gatewayapi.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-crds.experimental-gatewayapi.golden.yaml
@@ -559,6 +559,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGateway
                           - MeshService
                           - MeshServiceSubset
                           - MeshHTTPRoute
@@ -593,6 +594,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGateway
                     - MeshService
                     - MeshServiceSubset
                     - MeshHTTPRoute
@@ -742,6 +744,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGateway
                           - MeshService
                           - MeshServiceSubset
                           - MeshHTTPRoute
@@ -1075,6 +1078,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGateway
                           - MeshService
                           - MeshServiceSubset
                           - MeshHTTPRoute
@@ -1109,6 +1113,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGateway
                     - MeshService
                     - MeshServiceSubset
                     - MeshHTTPRoute
@@ -1393,6 +1398,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGateway
                           - MeshService
                           - MeshServiceSubset
                           - MeshHTTPRoute
@@ -1596,6 +1602,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGateway
                           - MeshService
                           - MeshServiceSubset
                           - MeshHTTPRoute
@@ -1630,6 +1637,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGateway
                     - MeshService
                     - MeshServiceSubset
                     - MeshHTTPRoute
@@ -2325,6 +2333,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGateway
                     - MeshService
                     - MeshServiceSubset
                     - MeshHTTPRoute
@@ -2550,6 +2559,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGateway
                           - MeshService
                           - MeshServiceSubset
                           - MeshHTTPRoute
@@ -2627,6 +2637,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGateway
                     - MeshService
                     - MeshServiceSubset
                     - MeshHTTPRoute
@@ -2670,6 +2681,7 @@ spec:
                                       enum:
                                       - Mesh
                                       - MeshSubset
+                                      - MeshGateway
                                       - MeshService
                                       - MeshServiceSubset
                                       - MeshHTTPRoute
@@ -2763,6 +2775,7 @@ spec:
                                               enum:
                                               - Mesh
                                               - MeshSubset
+                                              - MeshGateway
                                               - MeshService
                                               - MeshServiceSubset
                                               - MeshHTTPRoute
@@ -3055,6 +3068,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGateway
                           - MeshService
                           - MeshServiceSubset
                           - MeshHTTPRoute
@@ -3173,6 +3187,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGateway
                     - MeshService
                     - MeshServiceSubset
                     - MeshHTTPRoute
@@ -3509,6 +3524,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGateway
                           - MeshService
                           - MeshServiceSubset
                           - MeshHTTPRoute
@@ -4016,6 +4032,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGateway
                     - MeshService
                     - MeshServiceSubset
                     - MeshHTTPRoute
@@ -4209,6 +4226,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGateway
                           - MeshService
                           - MeshServiceSubset
                           - MeshHTTPRoute
@@ -4243,6 +4261,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGateway
                     - MeshService
                     - MeshServiceSubset
                     - MeshHTTPRoute
@@ -4315,6 +4334,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGateway
                     - MeshService
                     - MeshServiceSubset
                     - MeshHTTPRoute
@@ -4634,6 +4654,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGateway
                           - MeshService
                           - MeshServiceSubset
                           - MeshHTTPRoute
@@ -4711,6 +4732,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGateway
                     - MeshService
                     - MeshServiceSubset
                     - MeshHTTPRoute
@@ -4754,6 +4776,7 @@ spec:
                                       enum:
                                       - Mesh
                                       - MeshSubset
+                                      - MeshGateway
                                       - MeshService
                                       - MeshServiceSubset
                                       - MeshHTTPRoute
@@ -4798,6 +4821,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGateway
                           - MeshService
                           - MeshServiceSubset
                           - MeshHTTPRoute
@@ -4927,6 +4951,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGateway
                           - MeshService
                           - MeshServiceSubset
                           - MeshHTTPRoute
@@ -4961,6 +4986,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGateway
                     - MeshService
                     - MeshServiceSubset
                     - MeshHTTPRoute
@@ -5041,6 +5067,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGateway
                           - MeshService
                           - MeshServiceSubset
                           - MeshHTTPRoute
@@ -5266,6 +5293,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGateway
                     - MeshService
                     - MeshServiceSubset
                     - MeshHTTPRoute
@@ -5356,6 +5384,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGateway
                           - MeshService
                           - MeshServiceSubset
                           - MeshHTTPRoute
@@ -5390,6 +5419,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGateway
                     - MeshService
                     - MeshServiceSubset
                     - MeshHTTPRoute

--- a/deployments/charts/kuma/crds/kuma.io_meshaccesslogs.yaml
+++ b/deployments/charts/kuma/crds/kuma.io_meshaccesslogs.yaml
@@ -165,6 +165,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGateway
                           - MeshService
                           - MeshServiceSubset
                           - MeshHTTPRoute
@@ -199,6 +200,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGateway
                     - MeshService
                     - MeshServiceSubset
                     - MeshHTTPRoute
@@ -348,6 +350,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGateway
                           - MeshService
                           - MeshServiceSubset
                           - MeshHTTPRoute

--- a/deployments/charts/kuma/crds/kuma.io_meshcircuitbreakers.yaml
+++ b/deployments/charts/kuma/crds/kuma.io_meshcircuitbreakers.yaml
@@ -301,6 +301,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGateway
                           - MeshService
                           - MeshServiceSubset
                           - MeshHTTPRoute
@@ -335,6 +336,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGateway
                     - MeshService
                     - MeshServiceSubset
                     - MeshHTTPRoute
@@ -619,6 +621,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGateway
                           - MeshService
                           - MeshServiceSubset
                           - MeshHTTPRoute

--- a/deployments/charts/kuma/crds/kuma.io_meshfaultinjections.yaml
+++ b/deployments/charts/kuma/crds/kuma.io_meshfaultinjections.yaml
@@ -127,6 +127,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGateway
                           - MeshService
                           - MeshServiceSubset
                           - MeshHTTPRoute
@@ -161,6 +162,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGateway
                     - MeshService
                     - MeshServiceSubset
                     - MeshHTTPRoute

--- a/deployments/charts/kuma/crds/kuma.io_meshhealthchecks.yaml
+++ b/deployments/charts/kuma/crds/kuma.io_meshhealthchecks.yaml
@@ -45,6 +45,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGateway
                     - MeshService
                     - MeshServiceSubset
                     - MeshHTTPRoute
@@ -270,6 +271,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGateway
                           - MeshService
                           - MeshServiceSubset
                           - MeshHTTPRoute

--- a/deployments/charts/kuma/crds/kuma.io_meshhttproutes.yaml
+++ b/deployments/charts/kuma/crds/kuma.io_meshhttproutes.yaml
@@ -45,6 +45,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGateway
                     - MeshService
                     - MeshServiceSubset
                     - MeshHTTPRoute
@@ -88,6 +89,7 @@ spec:
                                       enum:
                                       - Mesh
                                       - MeshSubset
+                                      - MeshGateway
                                       - MeshService
                                       - MeshServiceSubset
                                       - MeshHTTPRoute
@@ -181,6 +183,7 @@ spec:
                                               enum:
                                               - Mesh
                                               - MeshSubset
+                                              - MeshGateway
                                               - MeshService
                                               - MeshServiceSubset
                                               - MeshHTTPRoute
@@ -473,6 +476,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGateway
                           - MeshService
                           - MeshServiceSubset
                           - MeshHTTPRoute

--- a/deployments/charts/kuma/crds/kuma.io_meshloadbalancingstrategies.yaml
+++ b/deployments/charts/kuma/crds/kuma.io_meshloadbalancingstrategies.yaml
@@ -46,6 +46,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGateway
                     - MeshService
                     - MeshServiceSubset
                     - MeshHTTPRoute
@@ -382,6 +383,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGateway
                           - MeshService
                           - MeshServiceSubset
                           - MeshHTTPRoute

--- a/deployments/charts/kuma/crds/kuma.io_meshproxypatches.yaml
+++ b/deployments/charts/kuma/crds/kuma.io_meshproxypatches.yaml
@@ -475,6 +475,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGateway
                     - MeshService
                     - MeshServiceSubset
                     - MeshHTTPRoute

--- a/deployments/charts/kuma/crds/kuma.io_meshratelimits.yaml
+++ b/deployments/charts/kuma/crds/kuma.io_meshratelimits.yaml
@@ -165,6 +165,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGateway
                           - MeshService
                           - MeshServiceSubset
                           - MeshHTTPRoute
@@ -199,6 +200,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGateway
                     - MeshService
                     - MeshServiceSubset
                     - MeshHTTPRoute

--- a/deployments/charts/kuma/crds/kuma.io_meshretries.yaml
+++ b/deployments/charts/kuma/crds/kuma.io_meshretries.yaml
@@ -45,6 +45,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGateway
                     - MeshService
                     - MeshServiceSubset
                     - MeshHTTPRoute
@@ -364,6 +365,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGateway
                           - MeshService
                           - MeshServiceSubset
                           - MeshHTTPRoute

--- a/deployments/charts/kuma/crds/kuma.io_meshtcproutes.yaml
+++ b/deployments/charts/kuma/crds/kuma.io_meshtcproutes.yaml
@@ -45,6 +45,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGateway
                     - MeshService
                     - MeshServiceSubset
                     - MeshHTTPRoute
@@ -88,6 +89,7 @@ spec:
                                       enum:
                                       - Mesh
                                       - MeshSubset
+                                      - MeshGateway
                                       - MeshService
                                       - MeshServiceSubset
                                       - MeshHTTPRoute
@@ -132,6 +134,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGateway
                           - MeshService
                           - MeshServiceSubset
                           - MeshHTTPRoute

--- a/deployments/charts/kuma/crds/kuma.io_meshtimeouts.yaml
+++ b/deployments/charts/kuma/crds/kuma.io_meshtimeouts.yaml
@@ -96,6 +96,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGateway
                           - MeshService
                           - MeshServiceSubset
                           - MeshHTTPRoute
@@ -130,6 +131,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGateway
                     - MeshService
                     - MeshServiceSubset
                     - MeshHTTPRoute
@@ -210,6 +212,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGateway
                           - MeshService
                           - MeshServiceSubset
                           - MeshHTTPRoute

--- a/deployments/charts/kuma/crds/kuma.io_meshtraces.yaml
+++ b/deployments/charts/kuma/crds/kuma.io_meshtraces.yaml
@@ -193,6 +193,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGateway
                     - MeshService
                     - MeshServiceSubset
                     - MeshHTTPRoute

--- a/deployments/charts/kuma/crds/kuma.io_meshtrafficpermissions.yaml
+++ b/deployments/charts/kuma/crds/kuma.io_meshtrafficpermissions.yaml
@@ -63,6 +63,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGateway
                           - MeshService
                           - MeshServiceSubset
                           - MeshHTTPRoute
@@ -97,6 +98,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGateway
                     - MeshService
                     - MeshServiceSubset
                     - MeshHTTPRoute

--- a/pkg/plugins/policies/core/matchers/dataplane_test.go
+++ b/pkg/plugins/policies/core/matchers/dataplane_test.go
@@ -16,8 +16,9 @@ import (
 	"github.com/kumahq/kuma/pkg/core/resources/registry"
 	_ "github.com/kumahq/kuma/pkg/plugins/policies"
 	"github.com/kumahq/kuma/pkg/plugins/policies/core/matchers"
+	mal_api "github.com/kumahq/kuma/pkg/plugins/policies/meshaccesslog/api/v1alpha1"
 	"github.com/kumahq/kuma/pkg/plugins/policies/meshhttproute/api/v1alpha1"
-	policies_api "github.com/kumahq/kuma/pkg/plugins/policies/meshtrafficpermission/api/v1alpha1"
+	mtp_api "github.com/kumahq/kuma/pkg/plugins/policies/meshtrafficpermission/api/v1alpha1"
 	test_matchers "github.com/kumahq/kuma/pkg/test/matchers"
 )
 
@@ -107,7 +108,7 @@ var _ = Describe("MatchedPolicies", func() {
 			resources, _ := readPolicies(given.policiesFile)
 
 			// when
-			policies, err := matchers.MatchedPolicies(policies_api.MeshTrafficPermissionType, dpp, resources)
+			policies, err := matchers.MatchedPolicies(mtp_api.MeshTrafficPermissionType, dpp, resources)
 			Expect(err).ToNot(HaveOccurred())
 
 			// then
@@ -157,7 +158,7 @@ var _ = Describe("MatchedPolicies", func() {
 
 			resources, _ := readPolicies(given.policiesFile)
 
-			policies, err := matchers.MatchedPolicies(policies_api.MeshTrafficPermissionType, dpp, resources)
+			policies, err := matchers.MatchedPolicies(mal_api.MeshAccessLogType, dpp, resources)
 			Expect(err).ToNot(HaveOccurred())
 
 			bytes, err := yaml.Marshal(policies.FromRules)

--- a/pkg/plugins/policies/core/matchers/dataplane_test.go
+++ b/pkg/plugins/policies/core/matchers/dataplane_test.go
@@ -16,9 +16,9 @@ import (
 	"github.com/kumahq/kuma/pkg/core/resources/registry"
 	_ "github.com/kumahq/kuma/pkg/plugins/policies"
 	"github.com/kumahq/kuma/pkg/plugins/policies/core/matchers"
-	mal_api "github.com/kumahq/kuma/pkg/plugins/policies/meshaccesslog/api/v1alpha1"
+	meshaccesslog_api "github.com/kumahq/kuma/pkg/plugins/policies/meshaccesslog/api/v1alpha1"
 	"github.com/kumahq/kuma/pkg/plugins/policies/meshhttproute/api/v1alpha1"
-	mtp_api "github.com/kumahq/kuma/pkg/plugins/policies/meshtrafficpermission/api/v1alpha1"
+	meshtrafficpermission_api "github.com/kumahq/kuma/pkg/plugins/policies/meshtrafficpermission/api/v1alpha1"
 	test_matchers "github.com/kumahq/kuma/pkg/test/matchers"
 )
 
@@ -108,7 +108,7 @@ var _ = Describe("MatchedPolicies", func() {
 			resources, _ := readPolicies(given.policiesFile)
 
 			// when
-			policies, err := matchers.MatchedPolicies(mtp_api.MeshTrafficPermissionType, dpp, resources)
+			policies, err := matchers.MatchedPolicies(meshtrafficpermission_api.MeshTrafficPermissionType, dpp, resources)
 			Expect(err).ToNot(HaveOccurred())
 
 			// then
@@ -158,7 +158,7 @@ var _ = Describe("MatchedPolicies", func() {
 
 			resources, _ := readPolicies(given.policiesFile)
 
-			policies, err := matchers.MatchedPolicies(mal_api.MeshAccessLogType, dpp, resources)
+			policies, err := matchers.MatchedPolicies(meshaccesslog_api.MeshAccessLogType, dpp, resources)
 			Expect(err).ToNot(HaveOccurred())
 
 			bytes, err := yaml.Marshal(policies.FromRules)

--- a/pkg/plugins/policies/core/matchers/testdata/matchedpolicies/meshgateways/01.golden.yaml
+++ b/pkg/plugins/policies/core/matchers/testdata/matchedpolicies/meshgateways/01.golden.yaml
@@ -45,3 +45,21 @@ Rules:
       name: servicesubset
       type: MeshAccessLog
     Subset: []
+  127.0.0.1:8082:
+  - Conf:
+      backends:
+      - file:
+          path: /gateway
+        type: File
+    Origin:
+    - creationTime: "0001-01-01T00:00:00Z"
+      mesh: mesh-1
+      modificationTime: "0001-01-01T00:00:00Z"
+      name: gateway
+      type: MeshAccessLog
+    - creationTime: "0001-01-01T00:00:00Z"
+      mesh: mesh-1
+      modificationTime: "0001-01-01T00:00:00Z"
+      name: mesh
+      type: MeshAccessLog
+    Subset: []

--- a/pkg/plugins/policies/core/matchers/testdata/matchedpolicies/meshgateways/01.golden.yaml
+++ b/pkg/plugins/policies/core/matchers/testdata/matchedpolicies/meshgateways/01.golden.yaml
@@ -1,26 +1,32 @@
 Rules:
   127.0.0.1:8080:
   - Conf:
-      action: Deny
+      backends:
+      - file:
+          path: /mesh
+        type: File
     Origin:
     - creationTime: "0001-01-01T00:00:00Z"
       mesh: mesh-1
       modificationTime: "0001-01-01T00:00:00Z"
-      name: mtp-1
-      type: MeshTrafficPermission
+      name: mesh
+      type: MeshAccessLog
     Subset: []
   127.0.0.1:8081:
   - Conf:
-      action: Allow
+      backends:
+      - file:
+          path: /servicesubset
+        type: File
     Origin:
     - creationTime: "0001-01-01T00:00:00Z"
       mesh: mesh-1
       modificationTime: "0001-01-01T00:00:00Z"
-      name: mtp-1
-      type: MeshTrafficPermission
+      name: mesh
+      type: MeshAccessLog
     - creationTime: "0001-01-01T00:00:00Z"
       mesh: mesh-1
       modificationTime: "0001-01-01T00:00:00Z"
-      name: mtp-2
-      type: MeshTrafficPermission
+      name: servicesubset
+      type: MeshAccessLog
     Subset: []

--- a/pkg/plugins/policies/core/matchers/testdata/matchedpolicies/meshgateways/01.golden.yaml
+++ b/pkg/plugins/policies/core/matchers/testdata/matchedpolicies/meshgateways/01.golden.yaml
@@ -3,9 +3,19 @@ Rules:
   - Conf:
       backends:
       - file:
-          path: /mesh
+          path: /gateway-listener
         type: File
     Origin:
+    - creationTime: "0001-01-01T00:00:00Z"
+      mesh: mesh-1
+      modificationTime: "0001-01-01T00:00:00Z"
+      name: gateway
+      type: MeshAccessLog
+    - creationTime: "0001-01-01T00:00:00Z"
+      mesh: mesh-1
+      modificationTime: "0001-01-01T00:00:00Z"
+      name: gatewaylistener
+      type: MeshAccessLog
     - creationTime: "0001-01-01T00:00:00Z"
       mesh: mesh-1
       modificationTime: "0001-01-01T00:00:00Z"
@@ -19,6 +29,11 @@ Rules:
           path: /servicesubset
         type: File
     Origin:
+    - creationTime: "0001-01-01T00:00:00Z"
+      mesh: mesh-1
+      modificationTime: "0001-01-01T00:00:00Z"
+      name: gateway
+      type: MeshAccessLog
     - creationTime: "0001-01-01T00:00:00Z"
       mesh: mesh-1
       modificationTime: "0001-01-01T00:00:00Z"

--- a/pkg/plugins/policies/core/matchers/testdata/matchedpolicies/meshgateways/01.policies.yaml
+++ b/pkg/plugins/policies/core/matchers/testdata/matchedpolicies/meshgateways/01.policies.yaml
@@ -1,7 +1,7 @@
 ---
-type: MeshTrafficPermission
+type: MeshAccessLog
 mesh: mesh-1
-name: mtp-1
+name: mesh
 spec:
  targetRef:
   kind: Mesh
@@ -9,11 +9,14 @@ spec:
   - targetRef:
      kind: Mesh
     default:
-     action: Deny
+      backends:
+        - type: File
+          file:
+            path: /mesh
 ---
-type: MeshTrafficPermission
+type: MeshAccessLog
 mesh: mesh-1
-name: mtp-2
+name: servicesubset
 spec:
  targetRef:
   kind: MeshServiceSubset
@@ -24,7 +27,10 @@ spec:
   - targetRef:
      kind: Mesh
     default:
-     action: Allow
+      backends:
+        - type: File
+          file:
+            path: /servicesubset
 ---
 type: MeshGateway
 mesh: mesh-1

--- a/pkg/plugins/policies/core/matchers/testdata/matchedpolicies/meshgateways/01.policies.yaml
+++ b/pkg/plugins/policies/core/matchers/testdata/matchedpolicies/meshgateways/01.policies.yaml
@@ -66,6 +66,24 @@ spec:
           file:
             path: /gateway-listener
 ---
+type: MeshAccessLog
+mesh: mesh-1
+name: nonmatchinggatewaylistener
+spec:
+ targetRef:
+  kind: MeshGateway
+  name: other-gateway
+  tags:
+    listener: three
+ from:
+  - targetRef:
+     kind: Mesh
+    default:
+      backends:
+        - type: File
+          file:
+            path: /shouldnt-be-applied
+---
 type: MeshGateway
 mesh: mesh-1
 name: gateway-1
@@ -82,3 +100,7 @@ conf:
     protocol: HTTP
     tags:
      listener: two
+  - port: 8082
+    protocol: HTTP
+    tags:
+     listener: three

--- a/pkg/plugins/policies/core/matchers/testdata/matchedpolicies/meshgateways/01.policies.yaml
+++ b/pkg/plugins/policies/core/matchers/testdata/matchedpolicies/meshgateways/01.policies.yaml
@@ -32,6 +32,40 @@ spec:
           file:
             path: /servicesubset
 ---
+type: MeshAccessLog
+mesh: mesh-1
+name: gateway
+spec:
+ targetRef:
+  kind: MeshGateway
+  name: gateway-1
+ from:
+  - targetRef:
+     kind: Mesh
+    default:
+      backends:
+        - type: File
+          file:
+            path: /gateway
+---
+type: MeshAccessLog
+mesh: mesh-1
+name: gatewaylistener
+spec:
+ targetRef:
+  kind: MeshGateway
+  name: gateway-1
+  tags:
+    listener: one
+ from:
+  - targetRef:
+     kind: Mesh
+    default:
+      backends:
+        - type: File
+          file:
+            path: /gateway-listener
+---
 type: MeshGateway
 mesh: mesh-1
 name: gateway-1

--- a/pkg/plugins/policies/donothingpolicy/api/v1alpha1/schema.yaml
+++ b/pkg/plugins/policies/donothingpolicy/api/v1alpha1/schema.yaml
@@ -34,6 +34,7 @@ properties:
                   enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGateway
                     - MeshService
                     - MeshServiceSubset
                     - MeshHTTPRoute
@@ -62,6 +63,7 @@ properties:
             enum:
               - Mesh
               - MeshSubset
+              - MeshGateway
               - MeshService
               - MeshServiceSubset
               - MeshHTTPRoute
@@ -97,6 +99,7 @@ properties:
                   enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGateway
                     - MeshService
                     - MeshServiceSubset
                     - MeshHTTPRoute

--- a/pkg/plugins/policies/donothingpolicy/k8s/crd/kuma.io_donothingpolicies.yaml
+++ b/pkg/plugins/policies/donothingpolicy/k8s/crd/kuma.io_donothingpolicies.yaml
@@ -58,6 +58,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGateway
                           - MeshService
                           - MeshServiceSubset
                           - MeshHTTPRoute
@@ -92,6 +93,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGateway
                     - MeshService
                     - MeshServiceSubset
                     - MeshHTTPRoute
@@ -134,6 +136,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGateway
                           - MeshService
                           - MeshServiceSubset
                           - MeshHTTPRoute

--- a/pkg/plugins/policies/meshaccesslog/api/v1alpha1/schema.yaml
+++ b/pkg/plugins/policies/meshaccesslog/api/v1alpha1/schema.yaml
@@ -134,6 +134,7 @@ properties:
                   enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGateway
                     - MeshService
                     - MeshServiceSubset
                     - MeshHTTPRoute
@@ -162,6 +163,7 @@ properties:
             enum:
               - Mesh
               - MeshSubset
+              - MeshGateway
               - MeshService
               - MeshServiceSubset
               - MeshHTTPRoute
@@ -297,6 +299,7 @@ properties:
                   enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGateway
                     - MeshService
                     - MeshServiceSubset
                     - MeshHTTPRoute

--- a/pkg/plugins/policies/meshaccesslog/api/v1alpha1/validator.go
+++ b/pkg/plugins/policies/meshaccesslog/api/v1alpha1/validator.go
@@ -27,6 +27,7 @@ func validateTop(targetRef common_api.TargetRef) validators.ValidationError {
 		SupportedKinds: []common_api.TargetRefKind{
 			common_api.Mesh,
 			common_api.MeshSubset,
+			common_api.MeshGateway,
 			common_api.MeshService,
 			common_api.MeshServiceSubset,
 		},

--- a/pkg/plugins/policies/meshaccesslog/k8s/crd/kuma.io_meshaccesslogs.yaml
+++ b/pkg/plugins/policies/meshaccesslog/k8s/crd/kuma.io_meshaccesslogs.yaml
@@ -165,6 +165,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGateway
                           - MeshService
                           - MeshServiceSubset
                           - MeshHTTPRoute
@@ -199,6 +200,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGateway
                     - MeshService
                     - MeshServiceSubset
                     - MeshHTTPRoute
@@ -348,6 +350,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGateway
                           - MeshService
                           - MeshServiceSubset
                           - MeshHTTPRoute

--- a/pkg/plugins/policies/meshcircuitbreaker/api/v1alpha1/schema.yaml
+++ b/pkg/plugins/policies/meshcircuitbreaker/api/v1alpha1/schema.yaml
@@ -137,6 +137,7 @@ properties:
                   enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGateway
                     - MeshService
                     - MeshServiceSubset
                     - MeshHTTPRoute
@@ -165,6 +166,7 @@ properties:
             enum:
               - Mesh
               - MeshSubset
+              - MeshGateway
               - MeshService
               - MeshServiceSubset
               - MeshHTTPRoute
@@ -303,6 +305,7 @@ properties:
                   enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGateway
                     - MeshService
                     - MeshServiceSubset
                     - MeshHTTPRoute

--- a/pkg/plugins/policies/meshcircuitbreaker/k8s/crd/kuma.io_meshcircuitbreakers.yaml
+++ b/pkg/plugins/policies/meshcircuitbreaker/k8s/crd/kuma.io_meshcircuitbreakers.yaml
@@ -301,6 +301,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGateway
                           - MeshService
                           - MeshServiceSubset
                           - MeshHTTPRoute
@@ -335,6 +336,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGateway
                     - MeshService
                     - MeshServiceSubset
                     - MeshHTTPRoute
@@ -619,6 +621,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGateway
                           - MeshService
                           - MeshServiceSubset
                           - MeshHTTPRoute

--- a/pkg/plugins/policies/meshfaultinjection/api/v1alpha1/schema.yaml
+++ b/pkg/plugins/policies/meshfaultinjection/api/v1alpha1/schema.yaml
@@ -87,6 +87,7 @@ properties:
                   enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGateway
                     - MeshService
                     - MeshServiceSubset
                     - MeshHTTPRoute
@@ -115,6 +116,7 @@ properties:
             enum:
               - Mesh
               - MeshSubset
+              - MeshGateway
               - MeshService
               - MeshServiceSubset
               - MeshHTTPRoute

--- a/pkg/plugins/policies/meshfaultinjection/k8s/crd/kuma.io_meshfaultinjections.yaml
+++ b/pkg/plugins/policies/meshfaultinjection/k8s/crd/kuma.io_meshfaultinjections.yaml
@@ -127,6 +127,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGateway
                           - MeshService
                           - MeshServiceSubset
                           - MeshHTTPRoute
@@ -161,6 +162,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGateway
                     - MeshService
                     - MeshServiceSubset
                     - MeshHTTPRoute

--- a/pkg/plugins/policies/meshhealthcheck/api/v1alpha1/schema.yaml
+++ b/pkg/plugins/policies/meshhealthcheck/api/v1alpha1/schema.yaml
@@ -23,6 +23,7 @@ properties:
             enum:
               - Mesh
               - MeshSubset
+              - MeshGateway
               - MeshService
               - MeshServiceSubset
               - MeshHTTPRoute
@@ -191,6 +192,7 @@ properties:
                   enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGateway
                     - MeshService
                     - MeshServiceSubset
                     - MeshHTTPRoute

--- a/pkg/plugins/policies/meshhealthcheck/k8s/crd/kuma.io_meshhealthchecks.yaml
+++ b/pkg/plugins/policies/meshhealthcheck/k8s/crd/kuma.io_meshhealthchecks.yaml
@@ -45,6 +45,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGateway
                     - MeshService
                     - MeshServiceSubset
                     - MeshHTTPRoute
@@ -270,6 +271,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGateway
                           - MeshService
                           - MeshServiceSubset
                           - MeshHTTPRoute

--- a/pkg/plugins/policies/meshhttproute/api/v1alpha1/schema.yaml
+++ b/pkg/plugins/policies/meshhttproute/api/v1alpha1/schema.yaml
@@ -23,6 +23,7 @@ properties:
             enum:
               - Mesh
               - MeshSubset
+              - MeshGateway
               - MeshService
               - MeshServiceSubset
               - MeshHTTPRoute
@@ -59,6 +60,7 @@ properties:
                               enum:
                                 - Mesh
                                 - MeshSubset
+                                - MeshGateway
                                 - MeshService
                                 - MeshServiceSubset
                                 - MeshHTTPRoute
@@ -140,6 +142,7 @@ properties:
                                       enum:
                                         - Mesh
                                         - MeshSubset
+                                        - MeshGateway
                                         - MeshService
                                         - MeshServiceSubset
                                         - MeshHTTPRoute
@@ -389,6 +392,7 @@ properties:
                   enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGateway
                     - MeshService
                     - MeshServiceSubset
                     - MeshHTTPRoute

--- a/pkg/plugins/policies/meshhttproute/k8s/crd/kuma.io_meshhttproutes.yaml
+++ b/pkg/plugins/policies/meshhttproute/k8s/crd/kuma.io_meshhttproutes.yaml
@@ -45,6 +45,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGateway
                     - MeshService
                     - MeshServiceSubset
                     - MeshHTTPRoute
@@ -88,6 +89,7 @@ spec:
                                       enum:
                                       - Mesh
                                       - MeshSubset
+                                      - MeshGateway
                                       - MeshService
                                       - MeshServiceSubset
                                       - MeshHTTPRoute
@@ -181,6 +183,7 @@ spec:
                                               enum:
                                               - Mesh
                                               - MeshSubset
+                                              - MeshGateway
                                               - MeshService
                                               - MeshServiceSubset
                                               - MeshHTTPRoute
@@ -473,6 +476,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGateway
                           - MeshService
                           - MeshServiceSubset
                           - MeshHTTPRoute

--- a/pkg/plugins/policies/meshloadbalancingstrategy/api/v1alpha1/schema.yaml
+++ b/pkg/plugins/policies/meshloadbalancingstrategy/api/v1alpha1/schema.yaml
@@ -23,6 +23,7 @@ properties:
             enum:
               - Mesh
               - MeshSubset
+              - MeshGateway
               - MeshService
               - MeshServiceSubset
               - MeshHTTPRoute
@@ -257,6 +258,7 @@ properties:
                   enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGateway
                     - MeshService
                     - MeshServiceSubset
                     - MeshHTTPRoute

--- a/pkg/plugins/policies/meshloadbalancingstrategy/k8s/crd/kuma.io_meshloadbalancingstrategies.yaml
+++ b/pkg/plugins/policies/meshloadbalancingstrategy/k8s/crd/kuma.io_meshloadbalancingstrategies.yaml
@@ -46,6 +46,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGateway
                     - MeshService
                     - MeshServiceSubset
                     - MeshHTTPRoute
@@ -382,6 +383,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGateway
                           - MeshService
                           - MeshServiceSubset
                           - MeshHTTPRoute

--- a/pkg/plugins/policies/meshproxypatch/api/v1alpha1/schema.yaml
+++ b/pkg/plugins/policies/meshproxypatch/api/v1alpha1/schema.yaml
@@ -336,6 +336,7 @@ properties:
             enum:
               - Mesh
               - MeshSubset
+              - MeshGateway
               - MeshService
               - MeshServiceSubset
               - MeshHTTPRoute

--- a/pkg/plugins/policies/meshproxypatch/k8s/crd/kuma.io_meshproxypatches.yaml
+++ b/pkg/plugins/policies/meshproxypatch/k8s/crd/kuma.io_meshproxypatches.yaml
@@ -475,6 +475,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGateway
                     - MeshService
                     - MeshServiceSubset
                     - MeshHTTPRoute

--- a/pkg/plugins/policies/meshratelimit/api/v1alpha1/schema.yaml
+++ b/pkg/plugins/policies/meshratelimit/api/v1alpha1/schema.yaml
@@ -127,6 +127,7 @@ properties:
                   enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGateway
                     - MeshService
                     - MeshServiceSubset
                     - MeshHTTPRoute
@@ -155,6 +156,7 @@ properties:
             enum:
               - Mesh
               - MeshSubset
+              - MeshGateway
               - MeshService
               - MeshServiceSubset
               - MeshHTTPRoute

--- a/pkg/plugins/policies/meshratelimit/k8s/crd/kuma.io_meshratelimits.yaml
+++ b/pkg/plugins/policies/meshratelimit/k8s/crd/kuma.io_meshratelimits.yaml
@@ -165,6 +165,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGateway
                           - MeshService
                           - MeshServiceSubset
                           - MeshHTTPRoute
@@ -199,6 +200,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGateway
                     - MeshService
                     - MeshServiceSubset
                     - MeshHTTPRoute

--- a/pkg/plugins/policies/meshretry/api/v1alpha1/schema.yaml
+++ b/pkg/plugins/policies/meshretry/api/v1alpha1/schema.yaml
@@ -23,6 +23,7 @@ properties:
             enum:
               - Mesh
               - MeshSubset
+              - MeshGateway
               - MeshService
               - MeshServiceSubset
               - MeshHTTPRoute
@@ -251,6 +252,7 @@ properties:
                   enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGateway
                     - MeshService
                     - MeshServiceSubset
                     - MeshHTTPRoute

--- a/pkg/plugins/policies/meshretry/k8s/crd/kuma.io_meshretries.yaml
+++ b/pkg/plugins/policies/meshretry/k8s/crd/kuma.io_meshretries.yaml
@@ -45,6 +45,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGateway
                     - MeshService
                     - MeshServiceSubset
                     - MeshHTTPRoute
@@ -364,6 +365,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGateway
                           - MeshService
                           - MeshServiceSubset
                           - MeshHTTPRoute

--- a/pkg/plugins/policies/meshtcproute/api/v1alpha1/schema.yaml
+++ b/pkg/plugins/policies/meshtcproute/api/v1alpha1/schema.yaml
@@ -23,6 +23,7 @@ properties:
             enum:
               - Mesh
               - MeshSubset
+              - MeshGateway
               - MeshService
               - MeshServiceSubset
               - MeshHTTPRoute
@@ -59,6 +60,7 @@ properties:
                               enum:
                                 - Mesh
                                 - MeshSubset
+                                - MeshGateway
                                 - MeshService
                                 - MeshServiceSubset
                                 - MeshHTTPRoute
@@ -97,6 +99,7 @@ properties:
                   enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGateway
                     - MeshService
                     - MeshServiceSubset
                     - MeshHTTPRoute

--- a/pkg/plugins/policies/meshtcproute/k8s/crd/kuma.io_meshtcproutes.yaml
+++ b/pkg/plugins/policies/meshtcproute/k8s/crd/kuma.io_meshtcproutes.yaml
@@ -45,6 +45,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGateway
                     - MeshService
                     - MeshServiceSubset
                     - MeshHTTPRoute
@@ -88,6 +89,7 @@ spec:
                                       enum:
                                       - Mesh
                                       - MeshSubset
+                                      - MeshGateway
                                       - MeshService
                                       - MeshServiceSubset
                                       - MeshHTTPRoute
@@ -132,6 +134,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGateway
                           - MeshService
                           - MeshServiceSubset
                           - MeshHTTPRoute

--- a/pkg/plugins/policies/meshtimeout/api/v1alpha1/schema.yaml
+++ b/pkg/plugins/policies/meshtimeout/api/v1alpha1/schema.yaml
@@ -53,6 +53,7 @@ properties:
                   enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGateway
                     - MeshService
                     - MeshServiceSubset
                     - MeshHTTPRoute
@@ -81,6 +82,7 @@ properties:
             enum:
               - Mesh
               - MeshSubset
+              - MeshGateway
               - MeshService
               - MeshServiceSubset
               - MeshHTTPRoute
@@ -135,6 +137,7 @@ properties:
                   enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGateway
                     - MeshService
                     - MeshServiceSubset
                     - MeshHTTPRoute

--- a/pkg/plugins/policies/meshtimeout/k8s/crd/kuma.io_meshtimeouts.yaml
+++ b/pkg/plugins/policies/meshtimeout/k8s/crd/kuma.io_meshtimeouts.yaml
@@ -96,6 +96,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGateway
                           - MeshService
                           - MeshServiceSubset
                           - MeshHTTPRoute
@@ -130,6 +131,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGateway
                     - MeshService
                     - MeshServiceSubset
                     - MeshHTTPRoute
@@ -210,6 +212,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGateway
                           - MeshService
                           - MeshServiceSubset
                           - MeshHTTPRoute

--- a/pkg/plugins/policies/meshtrace/api/v1alpha1/schema.yaml
+++ b/pkg/plugins/policies/meshtrace/api/v1alpha1/schema.yaml
@@ -136,6 +136,7 @@ properties:
             enum:
               - Mesh
               - MeshSubset
+              - MeshGateway
               - MeshService
               - MeshServiceSubset
               - MeshHTTPRoute

--- a/pkg/plugins/policies/meshtrace/k8s/crd/kuma.io_meshtraces.yaml
+++ b/pkg/plugins/policies/meshtrace/k8s/crd/kuma.io_meshtraces.yaml
@@ -193,6 +193,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGateway
                     - MeshService
                     - MeshServiceSubset
                     - MeshHTTPRoute

--- a/pkg/plugins/policies/meshtrafficpermission/api/v1alpha1/schema.yaml
+++ b/pkg/plugins/policies/meshtrafficpermission/api/v1alpha1/schema.yaml
@@ -38,6 +38,7 @@ properties:
                   enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGateway
                     - MeshService
                     - MeshServiceSubset
                     - MeshHTTPRoute
@@ -66,6 +67,7 @@ properties:
             enum:
               - Mesh
               - MeshSubset
+              - MeshGateway
               - MeshService
               - MeshServiceSubset
               - MeshHTTPRoute

--- a/pkg/plugins/policies/meshtrafficpermission/k8s/crd/kuma.io_meshtrafficpermissions.yaml
+++ b/pkg/plugins/policies/meshtrafficpermission/k8s/crd/kuma.io_meshtrafficpermissions.yaml
@@ -63,6 +63,7 @@ spec:
                           enum:
                           - Mesh
                           - MeshSubset
+                          - MeshGateway
                           - MeshService
                           - MeshServiceSubset
                           - MeshHTTPRoute
@@ -97,6 +98,7 @@ spec:
                     enum:
                     - Mesh
                     - MeshSubset
+                    - MeshGateway
                     - MeshService
                     - MeshServiceSubset
                     - MeshHTTPRoute


### PR DESCRIPTION
This enables it for MeshAccessLog, mostly so I can test it, but I'll go otherwise one by one and enable it after this PR.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues -- #6956 
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [x] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
