### PR TITLE
chore(MeshAccessLog): fix bad merge of #7112

### DIFF
--- a/pkg/plugins/policies/meshaccesslog/plugin/v1alpha1/testdata/basic-gateway.gateway.listener.golden.yaml
+++ b/pkg/plugins/policies/meshaccesslog/plugin/v1alpha1/testdata/basic-gateway.gateway.listener.golden.yaml
@@ -42,6 +42,7 @@ filterChains:
       - name: envoy.filters.http.router
         typedConfig:
           '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+          startChildSpan: true
       mergeSlashes: true
       normalizePath: true
       pathWithEscapedSlashesAction: UNESCAPE_AND_REDIRECT


### PR DESCRIPTION
### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [x] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
