### PR TITLE
chore(e2e): unpause MeshTCPRoute e2e multizone test

### DIFF
--- a/test/e2e_env/multizone/multizone_suite_test.go
+++ b/test/e2e_env/multizone/multizone_suite_test.go
@@ -50,7 +50,7 @@ var (
 	_ = Describe("TrafficPermission", trafficpermission.TrafficPermission, Ordered)
 	_ = Describe("TrafficRoute", trafficroute.TrafficRoute, Ordered)
 	_ = Describe("MeshHTTPRoute", meshhttproute.Test, Ordered)
-	_ = PDescribe("MeshTCPRoute", meshtcproute.Test, Ordered)
+	_ = Describe("MeshTCPRoute", meshtcproute.Test, Ordered)
 	_ = Describe("InboundPassthrough", inbound_communication.InboundPassthrough, Ordered)
 	_ = Describe("InboundPassthroughDisabled", inbound_communication.InboundPassthroughDisabled, Ordered)
 	_ = Describe("ZoneEgress Internal Services", zoneegress.InternalServices, Ordered)


### PR DESCRIPTION
Unpausing MeshTCPRoute e2e multizone tests, which should happen earlier and is an oversight.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s)
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)?
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? 
- [x] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

> Changelog: skip

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
