### PR TITLE
fix(k8s): tolerate unknown `appProtocol`

### DIFF
--- a/pkg/plugins/runtime/k8s/controllers/pod_converter_test.go
+++ b/pkg/plugins/runtime/k8s/controllers/pod_converter_test.go
@@ -844,7 +844,7 @@ var _ = Describe("ProtocolTagFor(..)", func() {
 		}),
 		Entry("appProtocol has an unknown value", testCase{
 			appProtocol: utilpointer.String("not-yet-supported-protocol"),
-			expected:    "not-yet-supported-protocol", // we want Kuma's behavior to be straightforward to a user (just copy appProtocol lowercase value)
+			expected:    "tcp", // we want Kuma's behavior to be straightforward to a user (appProtocol is not Kuma specific)
 		}),
 		Entry("appProtocol has a lowercase value", testCase{
 			appProtocol: utilpointer.String("HtTp"),

--- a/pkg/plugins/runtime/k8s/controllers/testdata/01.dataplane.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/01.dataplane.yaml
@@ -33,7 +33,7 @@ spec:
         k8s.kuma.io/namespace: demo
         k8s.kuma.io/service-name: sample
         k8s.kuma.io/service-port: "7071"
-        kuma.io/protocol: mongo
+        kuma.io/protocol: tcp
         kuma.io/service: sample_playground_svc_7071
         kuma.io/zone: zone-1
         version: "0.1"

--- a/pkg/plugins/runtime/k8s/controllers/testdata/10.dataplane.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/10.dataplane.yaml
@@ -31,7 +31,7 @@ spec:
         k8s.kuma.io/namespace: demo
         k8s.kuma.io/service-name: sample
         k8s.kuma.io/service-port: "7071"
-        kuma.io/protocol: mongo
+        kuma.io/protocol: tcp
         kuma.io/service: sample_playground_svc_7071
         kuma.io/zone: zone-1
         version: "0.1"

--- a/pkg/plugins/runtime/k8s/controllers/testdata/11.dataplane.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/11.dataplane.yaml
@@ -34,7 +34,7 @@ spec:
         k8s.kuma.io/namespace: demo
         k8s.kuma.io/service-name: sample
         k8s.kuma.io/service-port: "7071"
-        kuma.io/protocol: mongo
+        kuma.io/protocol: tcp
         kuma.io/service: sample_playground_svc_7071
         kuma.io/zone: zone-1
         version: "0.1"


### PR DESCRIPTION
Also allow the `kuma.io` annotation to set the protocol if the `appProtocol` isn't understood.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [x] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
