### PR TITLE
ci: clean before format

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -368,7 +368,7 @@ jobs:
       - run:
           command: make dev/tools
       - run:
-          command: make clean
+          command: make clean/build
       - run:
           command: make check
       - run:

--- a/mk/check.mk
+++ b/mk/check.mk
@@ -45,7 +45,7 @@ ginkgo/lint:
 	go run $(TOOLS_DIR)/ci/check_test_files.go
 
 .PHONY: format/common
-format/common: generate docs tidy ginkgo/unfocus fmt/ci
+format/common: clean/generated clean/docs generate docs tidy ginkgo/unfocus fmt/ci
 
 .PHONY: format
 format: fmt format/common


### PR DESCRIPTION
There are situations where without cleanup before generating policies or other resources, we could have locally different results of `make check` or `make format` than on CI, where before `make check` `make clean` command was run.

I believe we can expect appropriate clean targets to be added as requirements in `make format/common` target.

It also fixes `/format` commend command, which starts `make format` as a github action

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues
  - No relevant issue
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS
  - It won't
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s)
  - No additional tests as this is just CI-related change
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)?
  - There is no need
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? 
  - There is no need
- [x] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

> Changelog: skip

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
