### PR TITLE
feat(e2e): add possibility to configure kubeconfig location in e2e test cluster

### DIFF
--- a/test/framework/k8s_cluster.go
+++ b/test/framework/k8s_cluster.go
@@ -84,8 +84,9 @@ func (c *K8sCluster) WithTimeout(timeout time.Duration) Cluster {
 	return c
 }
 
-func (c *K8sCluster) WithKubeConfig(kubeConfigPath string) {
+func (c *K8sCluster) WithKubeConfig(kubeConfigPath string) Cluster {
 	c.kubeconfig = kubeConfigPath
+	return c
 }
 
 func (c *K8sCluster) createPortForward(

--- a/test/framework/k8s_cluster.go
+++ b/test/framework/k8s_cluster.go
@@ -84,6 +84,10 @@ func (c *K8sCluster) WithTimeout(timeout time.Duration) Cluster {
 	return c
 }
 
+func (c *K8sCluster) WithKubeConfig(kubeConfigPath string) {
+	c.kubeconfig = kubeConfigPath
+}
+
 func (c *K8sCluster) createPortForward(
 	t testing.TestingT,
 	kubectlOptions *k8s.KubectlOptions,


### PR DESCRIPTION


### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [x] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
