### PR TITLE
feat(MeshTimeout): allow top level targetRef.kind MeshGateway

### DIFF
--- a/pkg/plugins/policies/meshtimeout/api/v1alpha1/validator.go
+++ b/pkg/plugins/policies/meshtimeout/api/v1alpha1/validator.go
@@ -23,6 +23,7 @@ func validateTop(targetRef common_api.TargetRef) validators.ValidationError {
 		SupportedKinds: []common_api.TargetRefKind{
 			common_api.Mesh,
 			common_api.MeshSubset,
+			common_api.MeshGateway,
 			common_api.MeshService,
 			common_api.MeshServiceSubset,
 			common_api.MeshHTTPRoute,
@@ -36,7 +37,7 @@ func validateFrom(from []From, topLevelKind common_api.TargetRefKind) validators
 	fromPath := validators.RootedAt("from")
 
 	switch topLevelKind {
-	case common_api.MeshHTTPRoute:
+	case common_api.MeshHTTPRoute, common_api.MeshGateway:
 		if len(from) != 0 {
 			verr.AddViolationAt(fromPath, validators.MustNotBeDefined)
 		}
@@ -64,7 +65,7 @@ func validateTo(to []To, topLevelKind common_api.TargetRefKind) validators.Valid
 
 		var supportedKinds []common_api.TargetRefKind
 		switch topLevelKind {
-		case common_api.MeshHTTPRoute:
+		case common_api.MeshHTTPRoute, common_api.MeshGateway:
 			supportedKinds = []common_api.TargetRefKind{
 				common_api.Mesh,
 			}

--- a/pkg/plugins/policies/meshtimeout/api/v1alpha1/validator_test.go
+++ b/pkg/plugins/policies/meshtimeout/api/v1alpha1/validator_test.go
@@ -258,6 +258,35 @@ violations:
   - field: spec.to[0].default.http.maxConnectionDuration
     message: can't be specified when top-level TargetRef is referencing MeshHTTPRoute`,
 			}),
+			Entry("top-level targetRef is referencing MeshGateway", testCase{
+				inputYaml: `
+targetRef:
+  kind: MeshGateway
+  name: gateway-1
+to:
+  - targetRef:
+      kind: MeshService
+      name: web-backend
+    default:
+      connectionTimeout: 10s
+      idleTimeout: 1h
+      http:
+        requestTimeout: 1s
+        streamIdleTimeout: 1h
+        maxStreamDuration: 1h
+        maxConnectionDuration: 1h
+from:
+  - targetRef:
+      kind: Mesh
+    default:
+      connectionTimeout: 11s`,
+				expected: `
+violations:
+  - field: spec.from
+    message: must not be defined
+  - field: spec.to[0].targetRef.kind
+    message: value is not supported`,
+			}),
 		)
 	})
 })


### PR DESCRIPTION
### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues -- #6956 
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [x] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
