### PR TITLE
test(e2e): improve observability deployment

### DIFF
--- a/test/framework/deployments/observability/deployment.go
+++ b/test/framework/deployments/observability/deployment.go
@@ -20,7 +20,7 @@ type Deployment interface {
 type deployOptions struct {
 	namespace      string
 	deploymentName string
-	components     []string
+	components     []Component
 }
 type deployOptionsFunc func(*deployOptions)
 
@@ -45,14 +45,16 @@ const (
 
 func WithComponents(components ...Component) deployOptionsFunc {
 	return func(o *deployOptions) {
-		for _, c := range components {
-			o.components = append(o.components, string(c))
-		}
+		o.components = components
 	}
 }
 
 func Install(name string, optFns ...deployOptionsFunc) framework.InstallFunc {
-	opts := &deployOptions{deploymentName: name, namespace: framework.Config.DefaultObservabilityNamespace}
+	opts := &deployOptions{
+		deploymentName: name,
+		namespace:      framework.Config.DefaultObservabilityNamespace,
+		components:     []Component{JaegerComponent, PrometheusComponent, GrafanaComponent, LokiComponent},
+	}
 	for _, optFn := range optFns {
 		optFn(opts)
 	}


### PR DESCRIPTION
1. observability deployment had a dependency on Kuma with `cluster.GetKuma().GetName()`, but Kuma should not be needed to deploy it
2. Using it without jaeger was impossible. If you do `WithComponent(prometheus)` the code was still trying to port forward jaeger.
3. I also used a couple of test helpers to shorten the code.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [ ] [Link to relevant issue][1] as well as docs and UI issues --
- [ ] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [ ] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [ ] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [ ] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [ ] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
