### PR TITLE
fix(kuma-cp): don't return from opentelemetry Start

### DIFF
--- a/pkg/plugins/runtime/opentelemetry/plugin.go
+++ b/pkg/plugins/runtime/opentelemetry/plugin.go
@@ -42,13 +42,11 @@ func (t *tracer) Start(stop <-chan struct{}) error {
 		return err
 	}
 
-	go func() {
-		<-stop
-		log.Info("stopping")
-		if err := shutdown(context.Background()); err != nil {
-			log.Error(err, "shutting down")
-		}
-	}()
+	<-stop
+	log.Info("stopping")
+	if err := shutdown(context.Background()); err != nil {
+		log.Error(err, "shutting down")
+	}
 
 	return nil
 }


### PR DESCRIPTION
### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [x] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
