### PR TITLE
feat(metrics): expose kube controller manager metrics

### DIFF
--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -6,9 +6,13 @@ import (
 	"google.golang.org/grpc"
 )
 
-type Metrics interface {
+type RegistererGatherer interface {
 	prometheus.Registerer
 	prometheus.Gatherer
+}
+
+type Metrics interface {
+	RegistererGatherer
 
 	RegisterGRPC(*grpc.Server)
 	GRPCServerInterceptors() []grpc.ServerOption
@@ -44,26 +48,29 @@ func (m *metrics) GRPCClientInterceptors() []grpc.DialOption {
 var _ Metrics = &metrics{}
 
 func NewMetrics(zone string) (Metrics, error) {
-	registry := prometheus.NewRegistry()
-	registerer := prometheus.WrapRegistererWith(map[string]string{
+	return NewMetricsOfRegistererGatherer(zone, prometheus.NewRegistry())
+}
+
+func NewMetricsOfRegistererGatherer(zone string, registererGatherer RegistererGatherer) (Metrics, error) {
+	wrappedRegisterer := prometheus.WrapRegistererWith(map[string]string{
 		"zone": zone,
-	}, registry)
+	}, registererGatherer)
 
 	grpcServerMetrics := grpc_prometheus.NewServerMetrics()
-	if err := registry.Register(grpcServerMetrics); err != nil {
+	if err := wrappedRegisterer.Register(grpcServerMetrics); err != nil {
 		return nil, err
 	}
 	grpcServerMetrics.EnableHandlingTimeHistogram()
 
 	grpcClientMetrics := grpc_prometheus.NewClientMetrics()
-	if err := registry.Register(grpcClientMetrics); err != nil {
+	if err := wrappedRegisterer.Register(grpcClientMetrics); err != nil {
 		return nil, err
 	}
 	grpcClientMetrics.EnableClientHandlingTimeHistogram()
 
 	m := &metrics{
-		Registerer:        registerer,
-		Gatherer:          registry,
+		Registerer:        wrappedRegisterer,
+		Gatherer:          registererGatherer,
 		grpcServerMetrics: grpcServerMetrics,
 		grpcClientMetrics: grpcClientMetrics,
 	}


### PR DESCRIPTION
### Checklist prior to review

Fix #2927

This is a bit tricky, because Kube Controller Manager registers all the metrics in `init()` methods.
Because of this we cannot easily replace their `kube_metrics.Registerer` with our instance. Instead, we can take their instance and use it to register our metrics and use their gatherer to our metrics server.

I wanted to prefix all Kube Controller Manager metrics, but it seems to be quite hard to do. I tried with `prometheus.WrapRegistererWithPrefix`, but all metrics are already registered after I try to swap it. We could try to have a custom Gatherer implementation and add prefix to kube metrics, but it would require to explicitly have a list of kube metrics, we would need to maintain and update it.

Kube Controller Manager also registers standard Go metrics that we register so we need to handle this case.

Damn global variables and init methods!

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [X] [Link to relevant issue][1] as well as docs and UI issues --
- [X] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [X] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [X] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [X] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [X] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
