### PR TITLE
feat(kumactl): include opentelemetry collector in observability

### DIFF
--- a/app/kumactl/data/fs.go
+++ b/app/kumactl/data/fs.go
@@ -56,6 +56,14 @@ func InstallDeprecatedTracingFS() fs.FS {
 	return fsys
 }
 
+func InstallOpenTelemetryFS() fs.FS {
+	fsys, err := fs.Sub(InstallData, "install/k8s/opentelemetry")
+	if err != nil {
+		panic(err)
+	}
+	return fsys
+}
+
 func InstallDemoFS() fs.FS {
 	fsys, err := fs.Sub(InstallData, "install/k8s/demo")
 	if err != nil {

--- a/app/kumactl/data/install/k8s/opentelemetry/collector.yaml
+++ b/app/kumactl/data/install/k8s/opentelemetry/collector.yaml
@@ -1,0 +1,115 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: opentelemetry-collector-conf
+  namespace: mesh-observability
+  labels:
+    app: opentelemetry-collector
+data:
+  opentelemetry-collector-config: |
+    receivers:
+      otlp:
+        protocols:
+          grpc:
+    processors:
+      batch:
+    exporters:
+      zipkin:
+        # Export to zipkin for easy querying
+        endpoint: http://zipkin.mesh-observability.svc:9411/api/v2/spans
+      logging:
+        loglevel: debug
+    service:
+      pipelines:
+        logs:
+          receivers: [otlp]
+          processors: [batch]
+          exporters:
+            - logging
+        traces:
+          receivers:
+          - otlp
+          exporters:
+            - zipkin
+            - logging
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: opentelemetry-collector
+  namespace: mesh-observability
+  labels:
+    app: opentelemetry-collector
+spec:
+  ports:
+    - name: grpc-otlp
+      port: 4317
+      protocol: TCP
+      targetPort: 4317
+  selector:
+    app: opentelemetry-collector
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: opentelemetry-collector
+  namespace: mesh-observability
+spec:
+  selector:
+    matchLabels:
+      app: opentelemetry-collector
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app: opentelemetry-collector
+    spec:
+      containers:
+        - command:
+            - "/otelcol"
+            - "--config=/conf/opentelemetry-collector-config.yaml"
+          env:
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.name
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+          image: otel/opentelemetry-collector:0.80.0
+          imagePullPolicy: IfNotPresent
+          name: opentelemetry-collector
+          ports:
+            - containerPort: 4317
+              protocol: TCP
+          resources:
+            limits:
+              cpu: "2"
+              memory: 4Gi
+            requests:
+              cpu: 200m
+              memory: 400Mi
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+          volumeMounts:
+            - name: opentelemetry-collector-config-vol
+              mountPath: /conf
+      restartPolicy: Always
+      terminationGracePeriodSeconds: 30
+      volumes:
+        - configMap:
+            defaultMode: 420
+            items:
+              - key: opentelemetry-collector-config
+                path: opentelemetry-collector-config.yaml
+            name: opentelemetry-collector-conf
+          name: opentelemetry-collector-config-vol
+


### PR DESCRIPTION
Now that we have otel in kuma-cp as well as MeshAccessLog and MeshTrace, this makes it easier to test the functionality. They're visible in the zipkin UI and output to stdout. In the future, we can upgrade Grafana to make them queryable there.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [x] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
