### PR TITLE
fix(kuma-cp): handle external services with permissive mtls

### DIFF
--- a/pkg/xds/context/mesh_context_builder.go
+++ b/pkg/xds/context/mesh_context_builder.go
@@ -408,7 +408,11 @@ func (m *meshContextBuilder) resolveTLSReadiness(mesh *core_mesh.MeshResource, s
 	}
 
 	for svc, insight := range serviceInsights.Items[0].Spec.GetServices() {
-		tlsReady[svc] = insight.IssuedBackends[backend.Name] == (insight.Dataplanes.Offline + insight.Dataplanes.Online)
+		if insight.ServiceType == mesh_proto.ServiceInsight_Service_external {
+			tlsReady[svc] = true
+		} else {
+			tlsReady[svc] = insight.IssuedBackends[backend.Name] == (insight.Dataplanes.Offline + insight.Dataplanes.Online)
+		}
 	}
 	return tlsReady
 }

--- a/test/e2e_env/kubernetes/externalservices/permissive_mtls.go
+++ b/test/e2e_env/kubernetes/externalservices/permissive_mtls.go
@@ -1,0 +1,86 @@
+package externalservices
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	. "github.com/kumahq/kuma/test/framework"
+	"github.com/kumahq/kuma/test/framework/client"
+	"github.com/kumahq/kuma/test/framework/deployments/democlient"
+	"github.com/kumahq/kuma/test/framework/deployments/testserver"
+	"github.com/kumahq/kuma/test/framework/envs/kubernetes"
+)
+
+func PermissiveMTLS() {
+	meshName := "perm-external-services"
+	namespace := "perm-external-services"
+	clientNamespace := "perm-client-external-services"
+
+	mesh := `
+apiVersion: kuma.io/v1alpha1
+kind: Mesh
+metadata:
+  name: perm-external-services
+spec:
+  mtls:
+    enabledBackend: ca-1
+    backends:
+      - name: ca-1
+        type: builtin
+        mode: PERMISSIVE
+  networking:
+    outbound:
+      passthrough: false
+  routing:
+    zoneEgress: true
+`
+
+	tlsExternalService := `
+apiVersion: kuma.io/v1alpha1
+kind: ExternalService
+mesh: perm-external-services
+metadata:
+  name: perm-tls-external-service
+spec:
+  tags:
+    kuma.io/service: perm-tls-external-service
+    kuma.io/protocol: http
+  networking:
+    address: perm-tls-external-service.perm-external-services.svc.cluster.local:80 # .svc.cluster.local is needed, otherwise Kubernetes will resolve this to the real IP
+    tls:
+      enabled: true
+`
+
+	BeforeAll(func() {
+		err := NewClusterSetup().
+			Install(YamlK8s(mesh)).
+			Install(YamlK8s(tlsExternalService)).
+			Install(Namespace(namespace)).
+			Install(NamespaceWithSidecarInjection(clientNamespace)).
+			Install(democlient.Install(democlient.WithNamespace(clientNamespace), democlient.WithMesh(meshName))).
+			Install(testserver.Install(
+				testserver.WithNamespace(namespace),
+				testserver.WithEchoArgs("--tls", "--crt=/kuma/server.crt", "--key=/kuma/server.key"),
+				testserver.WithName("perm-tls-external-service"),
+				testserver.WithoutProbes(), // not compatible with TLS
+			)).
+			Setup(kubernetes.Cluster)
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	E2EAfterAll(func() {
+		Expect(kubernetes.Cluster.TriggerDeleteNamespace(clientNamespace)).To(Succeed())
+		Expect(kubernetes.Cluster.TriggerDeleteNamespace(namespace)).To(Succeed())
+		Expect(kubernetes.Cluster.DeleteMesh(meshName)).To(Succeed())
+	})
+
+	It("should access external service", func() {
+		Eventually(func(g Gomega) {
+			_, err := client.CollectEchoResponse(
+				kubernetes.Cluster, "demo-client", "http://perm-tls-external-service.mesh",
+				client.FromKubernetesPod(clientNamespace, "demo-client"),
+			)
+			g.Expect(err).ToNot(HaveOccurred())
+		}, "30s", "1s").Should(Succeed())
+	})
+}

--- a/test/e2e_env/kubernetes/kubernetes_suite_test.go
+++ b/test/e2e_env/kubernetes/kubernetes_suite_test.go
@@ -67,6 +67,7 @@ var (
 	_ = Describe("Reachable Services", reachableservices.ReachableServices, Ordered)
 	_ = Describe("Defaults", defaults.Defaults, Ordered)
 	_ = Describe("External Services", externalservices.ExternalServices, Ordered)
+	_ = Describe("External Services Permissive MTLS", externalservices.PermissiveMTLS, Ordered)
 	_ = Describe("Virtual Outbound", virtualoutbound.VirtualOutbound, Ordered)
 	_ = Describe("Kong Ingress Controller", Label("arm-not-supported"), kic.KICKubernetes, Ordered)
 	_ = Describe("MeshTrafficPermission API", meshtrafficpermission.API, Ordered)


### PR DESCRIPTION
### Checklist prior to review

While technically it's not an issue on master I want to have test/code parity between master an release-2.3 branch.

On the release branch we have `.Dataplanes.Total` which we don't fill anymore, therefore we had to switch to Offline + Online.
On the release branch Service Insight for some reason increment number of Total DP, but does not increment Offline nor Offline so we end up with `false` on 
`insight.IssuedBackends[backend.Name] == insight.Dataplanes.Total` condition.

Fix #7140

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [X] [Link to relevant issue][1] as well as docs and UI issues --
- [X] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [X] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [X] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [X] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [X] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
