### PR TITLE
feat(MeshRetry): allow top level targetRef kind MeshGateway

### DIFF
--- a/pkg/plugins/policies/meshretry/api/v1alpha1/validator_test.go
+++ b/pkg/plugins/policies/meshretry/api/v1alpha1/validator_test.go
@@ -482,6 +482,23 @@ violations:
   - field: spec.to[0].default.conf.http.hostSelection[2].predicate
     message: OmitPreviousPriorities must only be specified once`,
 			}),
+			Entry("top-level targetRef MeshGateway", testCase{
+				inputYaml: `
+targetRef:
+  kind: MeshGateway
+  name: gateway-1
+to:
+  - targetRef:
+      kind: MeshService
+      name: web-backend
+    default:
+      tcp:
+        maxConnectAttempt: 5`,
+				expected: `
+violations:
+  - field: spec.to[0].targetRef.kind
+    message: value is not supported`,
+			}),
 		)
 	})
 })


### PR DESCRIPTION
### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues -- 
  #6956 
  https://github.com/kumahq/kuma-website/issues/1393
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [x] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
