### PR TITLE
fix(MeshTrafficPermission): use serviceName instead of resource name for egress MTP

### DIFF
--- a/pkg/plugins/policies/meshtrafficpermission/plugin/v1alpha1/plugin.go
+++ b/pkg/plugins/policies/meshtrafficpermission/plugin/v1alpha1/plugin.go
@@ -4,6 +4,7 @@ import (
 	envoy_listener "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
 	envoy_resource "github.com/envoyproxy/go-control-plane/pkg/resource/v3"
 
+	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	"github.com/kumahq/kuma/pkg/core"
 	core_plugins "github.com/kumahq/kuma/pkg/core/plugins"
 	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
@@ -99,7 +100,10 @@ func (p plugin) configureEgress(rs *core_xds.ResourceSet, proxy *core_xds.Proxy)
 		}
 		for _, es := range resource.ExternalServices {
 			meshName := resource.Mesh.GetMeta().GetName()
-			esName := es.Meta.GetName()
+			esName, ok := es.Spec.GetTags()[mesh_proto.ServiceTag]
+			if !ok {
+				continue
+			}
 			policies, ok := resource.Dynamic[esName]
 			if !ok {
 				continue

--- a/pkg/plugins/policies/meshtrafficpermission/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshtrafficpermission/plugin/v1alpha1/plugin_test.go
@@ -213,7 +213,7 @@ var _ = Describe("RBAC", func() {
 								{
 									Meta: &test_model.ResourceMeta{
 										Mesh: "mesh-1",
-										Name: "external-service-1",
+										Name: "es-1",
 									},
 									Spec: &mesh_proto.ExternalService{
 										Tags: map[string]string{
@@ -250,7 +250,7 @@ var _ = Describe("RBAC", func() {
 								{
 									Meta: &test_model.ResourceMeta{
 										Mesh: "mesh-2",
-										Name: "external-service-1",
+										Name: "es-1",
 									},
 									Spec: &mesh_proto.ExternalService{
 										Tags: map[string]string{

--- a/test/e2e_env/multizone/meshtrafficpermission/meshtrafficpermission.go
+++ b/test/e2e_env/multizone/meshtrafficpermission/meshtrafficpermission.go
@@ -19,7 +19,7 @@ func externalService(mesh string, ip string) InstallFunc {
 	return YamlUniversal(fmt.Sprintf(`
 type: ExternalService
 mesh: "%s"
-name: external-service
+name: es-1
 tags:
   kuma.io/service: external-service
   kuma.io/protocol: http


### PR DESCRIPTION
### Checklist prior to review

- [X] [Link to relevant issue][1] as well as docs and UI issues -- fix: #7164 
- [X] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [X] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [X] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [X] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [X] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
