### PR TITLE
ci(e2e): don't add version flags to kumactl when version is "unknown"

### DIFF
--- a/test/framework/k8s_cluster.go
+++ b/test/framework/k8s_cluster.go
@@ -292,7 +292,7 @@ func (c *K8sCluster) yamlForKumaViaKubectl(mode string) (string, error) {
 		argsMap["--dataplane-init-registry"] = Config.KumaImageRegistry
 	}
 
-	if Config.KumaImageTag != "" {
+	if Config.KumaImageTag != "" && Config.KumaImageTag != "unknown" {
 		argsMap["--control-plane-version"] = Config.KumaImageTag
 		argsMap["--dataplane-version"] = Config.KumaImageTag
 		argsMap["--dataplane-init-version"] = Config.KumaImageTag

--- a/test/framework/k8s_controlplane.go
+++ b/test/framework/k8s_controlplane.go
@@ -228,7 +228,7 @@ func (c *K8sControlPlane) InstallCP(args ...string) (string, error) {
 	defer func() {
 		c.kumactl.Env = oldEnv // restore kumactl environment
 	}()
-	return c.kumactl.KumactlInstallCP(c.mode, args...)
+	return c.kumactl.KumactlInstallCP(args...)
 }
 
 func (c *K8sControlPlane) GetKDSInsecureServerAddress() string {

--- a/test/framework/kumactl.go
+++ b/test/framework/kumactl.go
@@ -128,7 +128,7 @@ func storeConfigToTempFile(name string, configData string) (string, error) {
 	return tmpfile.Name(), err
 }
 
-func (k *KumactlOptions) KumactlInstallCP(mode string, args ...string) (string, error) {
+func (k *KumactlOptions) KumactlInstallCP(args ...string) (string, error) {
 	cmd := []string{
 		"install", "control-plane",
 	}


### PR DESCRIPTION
When using the e2e framework from other projects `kuma_version.Build.Version` could be set to `unknown`. So it's better not to add CLI version flags and rely on `kumactl` version.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [X] [Link to relevant issue][1] as well as docs and UI issues --
- [X] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [X] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [X] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [X] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [X] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
