### PR TITLE
ci(tracing): add span.type attribute to pgx tracer

### DIFF
--- a/pkg/plugins/resources/postgres/pgx_store.go
+++ b/pkg/plugins/resources/postgres/pgx_store.go
@@ -14,6 +14,7 @@ import (
 	_ "github.com/jackc/pgx/v5/stdlib"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
+	"go.opentelemetry.io/otel/attribute"
 
 	config "github.com/kumahq/kuma/pkg/config/plugins/resources/postgres"
 	core_model "github.com/kumahq/kuma/pkg/core/resources/model"
@@ -27,6 +28,11 @@ type pgxResourceStore struct {
 }
 
 var _ store.ResourceStore = &pgxResourceStore{}
+
+// This attribute is necessary for tracing integrations like Datadog, to have
+// full insights into sql queries connected with traces.
+// ref. https://github.com/DataDog/dd-trace-go/blob/3d97fcec9f8b21fdd821af526d27d4335b26da66/contrib/database/sql/conn.go#L290
+var spanTypeAttribute = attribute.String("span.type", "sql")
 
 func NewPgxStore(metrics core_metrics.Metrics, config config.PostgresStoreConfig, customizer pgx_config.PgxConfigCustomization) (store.ResourceStore, error) {
 	pool, err := connect(config, customizer)
@@ -62,7 +68,7 @@ func connect(postgresStoreConfig config.PostgresStoreConfig, customizer pgx_conf
 	pgxConfig.MaxConnLifetime = postgresStoreConfig.MaxConnectionLifetime.Duration
 	pgxConfig.MaxConnLifetimeJitter = postgresStoreConfig.MaxConnectionLifetime.Duration
 	pgxConfig.HealthCheckPeriod = postgresStoreConfig.HealthCheckInterval.Duration
-	pgxConfig.ConnConfig.Tracer = otelpgx.NewTracer()
+	pgxConfig.ConnConfig.Tracer = otelpgx.NewTracer(otelpgx.WithAttributes(spanTypeAttribute))
 	customizer.Customize(pgxConfig)
 
 	if err != nil {

--- a/pkg/plugins/resources/postgres/pgx_store.go
+++ b/pkg/plugins/resources/postgres/pgx_store.go
@@ -32,7 +32,7 @@ var _ store.ResourceStore = &pgxResourceStore{}
 // This attribute is necessary for tracing integrations like Datadog, to have
 // full insights into sql queries connected with traces.
 // ref. https://github.com/DataDog/dd-trace-go/blob/3d97fcec9f8b21fdd821af526d27d4335b26da66/contrib/database/sql/conn.go#L290
-var spanTypeAttribute = attribute.String("span.type", "sql")
+var spanTypeSQLAttribute = attribute.String("span.type", "sql")
 
 func NewPgxStore(metrics core_metrics.Metrics, config config.PostgresStoreConfig, customizer pgx_config.PgxConfigCustomization) (store.ResourceStore, error) {
 	pool, err := connect(config, customizer)
@@ -68,7 +68,7 @@ func connect(postgresStoreConfig config.PostgresStoreConfig, customizer pgx_conf
 	pgxConfig.MaxConnLifetime = postgresStoreConfig.MaxConnectionLifetime.Duration
 	pgxConfig.MaxConnLifetimeJitter = postgresStoreConfig.MaxConnectionLifetime.Duration
 	pgxConfig.HealthCheckPeriod = postgresStoreConfig.HealthCheckInterval.Duration
-	pgxConfig.ConnConfig.Tracer = otelpgx.NewTracer(otelpgx.WithAttributes(spanTypeAttribute))
+	pgxConfig.ConnConfig.Tracer = otelpgx.NewTracer(otelpgx.WithAttributes(spanTypeSQLAttribute))
 	customizer.Customize(pgxConfig)
 
 	if err != nil {


### PR DESCRIPTION
This attribute is necessary for tracing integrations like Datadog, to have full insights into sql queries connected with traces.
ref. https://github.com/DataDog/dd-trace-go/blob/3d97fcec9f8b21fdd821af526d27d4335b26da66/contrib/database/sql/conn.go#L290

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues
  - No relevant issues
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS
  - It won't
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s)
  - Manual tests on private/temporary datadog account
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)?
  - There is no need
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? 
  - There is no need
- [x] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?
> Changelog: skip

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
