### PR TITLE
chore(kuma-dp): fix missing type in accesslogs streamer on windows

### DIFF
--- a/app/kuma-dp/pkg/dataplane/accesslogs/streamer_windows.go
+++ b/app/kuma-dp/pkg/dataplane/accesslogs/streamer_windows.go
@@ -18,7 +18,7 @@ func (s *accessLogStreamer) NeedLeaderElection() bool {
 	return false
 }
 
-func NewAccessLogStreamer(address) *accessLogStreamer {
+func NewAccessLogStreamer(address string) *accessLogStreamer {
 	return &accessLogStreamer{
 		address: address,
 	}


### PR DESCRIPTION
### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues
  - No relevant issue
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS
  - It won't (it actually fixes it)
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s)
  - No tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)?
  - There is no need as it was not released yet
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? 
  - There is no need
- [x] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?
> Changelog: skip

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword