### PR TITLE
refactor(log): get tenantId from ctx

### DIFF
--- a/pkg/core/tokens/default_signing_key.go
+++ b/pkg/core/tokens/default_signing_key.go
@@ -54,7 +54,7 @@ func (d *defaultSigningKeyComponent) Start(stop <-chan struct{}) error {
 }
 
 func CreateDefaultSigningKeyIfNotExist(ctx context.Context, log logr.Logger, signingKeyManager SigningKeyManager) error {
-	logger := kuma_log.DecorateWithCtx(log, ctx)
+	logger := kuma_log.AddFieldsFromCtx(log, ctx)
 	_, _, err := signingKeyManager.GetLatestSigningKey(ctx)
 	if err == nil {
 		logger.V(1).Info("signing key already exists. Skip creating.")

--- a/pkg/defaults/envoy_admin_ca.go
+++ b/pkg/defaults/envoy_admin_ca.go
@@ -41,7 +41,7 @@ func (e EnvoyAdminCaDefaultComponent) NeedLeaderElection() bool {
 }
 
 func EnsureEnvoyAdminCaExist(ctx context.Context, resManager manager.ResourceManager) error {
-	logger := kuma_log.DecorateWithCtx(log, ctx)
+	logger := kuma_log.AddFieldsFromCtx(log, ctx)
 	_, err := tls.LoadCA(ctx, resManager)
 	if err == nil {
 		logger.V(1).Info("Envoy Admin CA already exists. Skip creating Envoy Admin CA.")

--- a/pkg/defaults/mesh.go
+++ b/pkg/defaults/mesh.go
@@ -15,7 +15,7 @@ var defaultMeshKey = core_model.ResourceKey{
 }
 
 func CreateMeshIfNotExist(ctx context.Context, resManager core_manager.ResourceManager) error {
-	logger := kuma_log.DecorateWithCtx(log, ctx)
+	logger := kuma_log.AddFieldsFromCtx(log, ctx)
 	mesh := core_mesh.NewMeshResource()
 	err := resManager.Get(ctx, mesh, core_store.GetBy(defaultMeshKey))
 	if err == nil {

--- a/pkg/defaults/mesh/mesh.go
+++ b/pkg/defaults/mesh/mesh.go
@@ -30,7 +30,7 @@ func EnsureDefaultMeshResources(ctx context.Context, resManager manager.Resource
 	ensureMux.Lock()
 	defer ensureMux.Unlock()
 
-	logger := kuma_log.DecorateWithCtx(log, ctx).WithValues("mesh", meshName)
+	logger := kuma_log.AddFieldsFromCtx(log, ctx).WithValues("mesh", meshName)
 
 	logger.Info("ensuring default resources for Mesh exist")
 

--- a/pkg/log/logger.go
+++ b/pkg/log/logger.go
@@ -93,11 +93,10 @@ func newZapLoggerTo(destWriter io.Writer, level LogLevel, opts ...zap.Option) *z
 
 const tenantLoggerKey = "tenantID"
 
-// DecorateWithCtx will check if provided context contain tracing span and
+// AddFieldsFromCtx will check if provided context contain tracing span and
 // if the span is currently recording. If so, it will add trace_id and span_id
-// to logged values. It will also add to logger values from fields added to
-// context earlier by CtxWithFields functions.
-func DecorateWithCtx(logger logr.Logger, ctx context.Context) logr.Logger {
+// to logged values. It will also add the tenant id to the logged values.
+func AddFieldsFromCtx(logger logr.Logger, ctx context.Context) logr.Logger {
 	if span := trace.SpanFromContext(ctx); span.IsRecording() {
 		logger = logger.WithValues(
 			"trace_id", span.SpanContext().TraceID(),

--- a/pkg/multitenant/multitenant.go
+++ b/pkg/multitenant/multitenant.go
@@ -6,8 +6,6 @@ import (
 
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
-
-	kuma_log "github.com/kumahq/kuma/pkg/log"
 )
 
 const observabilityAttributeName = "tenantID"
@@ -42,10 +40,7 @@ func WithTenant(ctx context.Context, tenantId string) context.Context {
 		span.SetAttributes(attribute.String(observabilityAttributeName, tenantId))
 	}
 
-	return kuma_log.CtxWithFields(
-		context.WithValue(ctx, tenantCtx{}, tenantId),
-		observabilityAttributeName, tenantId,
-	)
+	return context.WithValue(ctx, tenantCtx{}, tenantId)
 }
 
 func TenantFromCtx(ctx context.Context) (string, bool) {

--- a/pkg/multitenant/multitenant.go
+++ b/pkg/multitenant/multitenant.go
@@ -8,7 +8,7 @@ import (
 	"go.opentelemetry.io/otel/trace"
 )
 
-const observabilityAttributeName = "tenantID"
+const spanAttributeName = "tenantID"
 
 // GlobalTenantID is a unique ID used for storing resources that are not tenant-aware
 var GlobalTenantID = ""
@@ -37,7 +37,7 @@ func (s singleTenant) GetIDs(context.Context) ([]string, error) {
 
 func WithTenant(ctx context.Context, tenantId string) context.Context {
 	if span := trace.SpanFromContext(ctx); span.IsRecording() {
-		span.SetAttributes(attribute.String(observabilityAttributeName, tenantId))
+		span.SetAttributes(attribute.String(spanAttributeName, tenantId))
 	}
 
 	return context.WithValue(ctx, tenantCtx{}, tenantId)


### PR DESCRIPTION
So the source of truth for tenant ID is just one key in the context.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [x] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
