### PR TITLE
chore(logging/tracing): allow to modify trace/span id logging

### DIFF
--- a/pkg/core/bootstrap/bootstrap.go
+++ b/pkg/core/bootstrap/bootstrap.go
@@ -105,7 +105,7 @@ func buildRuntime(appCtx context.Context, cfg kuma_cp.Config) (core_runtime.Runt
 		Mesh:      mesh_managers.NewMeshValidator(builder.CaManagers(), builder.ResourceStore()),
 	})
 
-	if err := initializeResourceManager(cfg, builder); err != nil {
+	if err := initializeResourceManager(cfg, builder); err != nil { //nolint:contextcheck
 		return nil, err
 	}
 
@@ -381,6 +381,7 @@ func initializeResourceManager(cfg kuma_cp.Config, builder *core_runtime.Builder
 			registry.Global(),
 			builder.ResourceValidators().Mesh,
 			cfg.Store.UnsafeDelete,
+			builder.Extensions(),
 		),
 	)
 

--- a/pkg/core/managers/apis/mesh/mesh_manager.go
+++ b/pkg/core/managers/apis/mesh/mesh_manager.go
@@ -23,6 +23,7 @@ func NewMeshManager(
 	registry core_registry.TypeRegistry,
 	validator MeshValidator,
 	unsafeDelete bool,
+	extensions context.Context,
 ) core_manager.ResourceManager {
 	return &meshManager{
 		store:         store,
@@ -31,6 +32,7 @@ func NewMeshManager(
 		registry:      registry,
 		meshValidator: validator,
 		unsafeDelete:  unsafeDelete,
+		extensions:    extensions,
 	}
 }
 
@@ -41,6 +43,7 @@ type meshManager struct {
 	registry      core_registry.TypeRegistry
 	meshValidator MeshValidator
 	unsafeDelete  bool
+	extensions    context.Context
 }
 
 func (m *meshManager) Get(ctx context.Context, resource core_model.Resource, fs ...core_store.GetOptionsFunc) error {
@@ -82,7 +85,13 @@ func (m *meshManager) Create(ctx context.Context, resource core_model.Resource, 
 	if err := m.store.Create(ctx, mesh, append(fs, core_store.CreatedAt(time.Now()))...); err != nil {
 		return err
 	}
-	if err := defaults_mesh.EnsureDefaultMeshResources(ctx, m.otherManagers, opts.Name, mesh.Spec.GetSkipCreatingInitialPolicies()); err != nil {
+	if err := defaults_mesh.EnsureDefaultMeshResources(
+		ctx,
+		m.otherManagers,
+		opts.Name,
+		mesh.Spec.GetSkipCreatingInitialPolicies(),
+		m.extensions,
+	); err != nil {
 		return err
 	}
 	return nil

--- a/pkg/core/managers/apis/mesh/mesh_manager_test.go
+++ b/pkg/core/managers/apis/mesh/mesh_manager_test.go
@@ -49,8 +49,8 @@ var _ = Describe("Mesh Manager", func() {
 
 		manager := manager.NewResourceManager(resStore)
 		validator := mesh.NewMeshValidator(caManagers, resStore)
-		resManager = mesh.NewMeshManager(resStore, manager, caManagers, test_resources.Global(), validator, false)
-		unsafeDeleteResManager = mesh.NewMeshManager(resStore, manager, caManagers, test_resources.Global(), validator, true)
+		resManager = mesh.NewMeshManager(resStore, manager, caManagers, test_resources.Global(), validator, false, context.Background())
+		unsafeDeleteResManager = mesh.NewMeshManager(resStore, manager, caManagers, test_resources.Global(), validator, true, context.Background())
 	})
 
 	Describe("Create()", func() {

--- a/pkg/core/tokens/default_signing_key.go
+++ b/pkg/core/tokens/default_signing_key.go
@@ -17,15 +17,22 @@ type defaultSigningKeyComponent struct {
 	signingKeyManager SigningKeyManager
 	log               logr.Logger
 	ctx               context.Context
+	extensions        context.Context
 }
 
 var _ component.Component = &defaultSigningKeyComponent{}
 
-func NewDefaultSigningKeyComponent(ctx context.Context, signingKeyManager SigningKeyManager, log logr.Logger) component.Component {
+func NewDefaultSigningKeyComponent(
+	ctx context.Context,
+	signingKeyManager SigningKeyManager,
+	log logr.Logger,
+	extensions context.Context,
+) component.Component {
 	return &defaultSigningKeyComponent{
 		signingKeyManager: signingKeyManager,
 		log:               log,
 		ctx:               ctx,
+		extensions:        extensions,
 	}
 }
 
@@ -37,7 +44,7 @@ func (d *defaultSigningKeyComponent) Start(stop <-chan struct{}) error {
 		defer close(errChan)
 		backoff := retry.WithMaxDuration(10*time.Minute, retry.NewConstant(5*time.Second)) // if after this time we cannot create a resource - something is wrong and we should return an error which will restart CP.
 		err := retry.Do(ctx, backoff, func(ctx context.Context) error {
-			return retry.RetryableError(CreateDefaultSigningKeyIfNotExist(ctx, d.log, d.signingKeyManager)) // retry all errors
+			return retry.RetryableError(CreateDefaultSigningKeyIfNotExist(ctx, d.log, d.signingKeyManager, d.extensions)) // retry all errors
 		})
 		if err != nil {
 			// Retry this operation since on Kubernetes, secrets are validated.
@@ -53,8 +60,13 @@ func (d *defaultSigningKeyComponent) Start(stop <-chan struct{}) error {
 	}
 }
 
-func CreateDefaultSigningKeyIfNotExist(ctx context.Context, log logr.Logger, signingKeyManager SigningKeyManager) error {
-	logger := kuma_log.AddFieldsFromCtx(log, ctx)
+func CreateDefaultSigningKeyIfNotExist(
+	ctx context.Context,
+	log logr.Logger,
+	signingKeyManager SigningKeyManager,
+	extensions context.Context,
+) error {
+	logger := kuma_log.AddFieldsFromCtx(log, ctx, extensions)
 	_, _, err := signingKeyManager.GetLatestSigningKey(ctx)
 	if err == nil {
 		logger.V(1).Info("signing key already exists. Skip creating.")

--- a/pkg/defaults/components_test.go
+++ b/pkg/defaults/components_test.go
@@ -29,7 +29,7 @@ var _ = Describe("Defaults Component", func() {
 			}
 			store := resources_memory.NewStore()
 			manager = core_manager.NewResourceManager(store)
-			component = defaults.NewDefaultsComponent(cfg, core.Standalone, core.UniversalEnvironment, manager, store)
+			component = defaults.NewDefaultsComponent(cfg, core.Standalone, core.UniversalEnvironment, manager, store, context.Background())
 		})
 
 		It("should create default mesh", func() {
@@ -82,7 +82,7 @@ var _ = Describe("Defaults Component", func() {
 			}
 			store := resources_memory.NewStore()
 			manager = core_manager.NewResourceManager(store)
-			component = defaults.NewDefaultsComponent(cfg, core.Standalone, core.UniversalEnvironment, manager, store)
+			component = defaults.NewDefaultsComponent(cfg, core.Standalone, core.UniversalEnvironment, manager, store, context.Background())
 		})
 
 		It("should not create default mesh", func() {

--- a/pkg/defaults/envoy_admin_ca_test.go
+++ b/pkg/defaults/envoy_admin_ca_test.go
@@ -21,6 +21,7 @@ var _ = Describe("Envoy Admin CA defaults", func() {
 		manager := core_manager.NewResourceManager(store)
 		component := defaults.EnvoyAdminCaDefaultComponent{
 			ResManager: manager,
+			Extensions: context.Background(),
 		}
 
 		// when

--- a/pkg/defaults/mesh.go
+++ b/pkg/defaults/mesh.go
@@ -14,8 +14,12 @@ var defaultMeshKey = core_model.ResourceKey{
 	Name: core_model.DefaultMesh,
 }
 
-func CreateMeshIfNotExist(ctx context.Context, resManager core_manager.ResourceManager) error {
-	logger := kuma_log.AddFieldsFromCtx(log, ctx)
+func CreateMeshIfNotExist(
+	ctx context.Context,
+	resManager core_manager.ResourceManager,
+	extensions context.Context,
+) error {
+	logger := kuma_log.AddFieldsFromCtx(log, ctx, extensions)
 	mesh := core_mesh.NewMeshResource()
 	err := resManager.Get(ctx, mesh, core_store.GetBy(defaultMeshKey))
 	if err == nil {

--- a/pkg/defaults/mesh/mesh.go
+++ b/pkg/defaults/mesh/mesh.go
@@ -26,11 +26,17 @@ var log = core.Log.WithName("defaults").WithName("mesh")
 // 2 invocation can check that TrafficPermission is absent, but it was just created, so it tries to created it which results in error
 var ensureMux = sync.Mutex{}
 
-func EnsureDefaultMeshResources(ctx context.Context, resManager manager.ResourceManager, meshName string, skippedPolicies []string) error {
+func EnsureDefaultMeshResources(
+	ctx context.Context,
+	resManager manager.ResourceManager,
+	meshName string,
+	skippedPolicies []string,
+	extensions context.Context,
+) error {
 	ensureMux.Lock()
 	defer ensureMux.Unlock()
 
-	logger := kuma_log.AddFieldsFromCtx(log, ctx).WithValues("mesh", meshName)
+	logger := kuma_log.AddFieldsFromCtx(log, ctx, extensions).WithValues("mesh", meshName)
 
 	logger.Info("ensuring default resources for Mesh exist")
 

--- a/pkg/defaults/mesh/mesh_test.go
+++ b/pkg/defaults/mesh/mesh_test.go
@@ -30,7 +30,7 @@ var _ = Describe("EnsureDefaultMeshResources", func() {
 
 	It("should create default resources", func() {
 		// when
-		err := mesh.EnsureDefaultMeshResources(context.Background(), resManager, model.DefaultMesh, []string{})
+		err := mesh.EnsureDefaultMeshResources(context.Background(), resManager, model.DefaultMesh, []string{}, context.Background())
 		Expect(err).ToNot(HaveOccurred())
 
 		// then default TrafficPermission for the mesh exist
@@ -52,11 +52,11 @@ var _ = Describe("EnsureDefaultMeshResources", func() {
 
 	It("should ignore subsequent calls to EnsureDefaultMeshResources", func() {
 		// given already ensured default resources
-		err := mesh.EnsureDefaultMeshResources(context.Background(), resManager, model.DefaultMesh, []string{})
+		err := mesh.EnsureDefaultMeshResources(context.Background(), resManager, model.DefaultMesh, []string{}, context.Background())
 		Expect(err).ToNot(HaveOccurred())
 
 		// when ensuring again
-		err = mesh.EnsureDefaultMeshResources(context.Background(), resManager, model.DefaultMesh, []string{})
+		err = mesh.EnsureDefaultMeshResources(context.Background(), resManager, model.DefaultMesh, []string{}, context.Background())
 
 		// then
 		Expect(err).ToNot(HaveOccurred())
@@ -74,7 +74,7 @@ var _ = Describe("EnsureDefaultMeshResources", func() {
 
 	It("should skip creating all default policies", func() {
 		// when
-		err := mesh.EnsureDefaultMeshResources(context.Background(), resManager, model.DefaultMesh, []string{"*"})
+		err := mesh.EnsureDefaultMeshResources(context.Background(), resManager, model.DefaultMesh, []string{"*"}, context.Background())
 		Expect(err).ToNot(HaveOccurred())
 
 		// then default TrafficPermission doesn't exist
@@ -96,7 +96,7 @@ var _ = Describe("EnsureDefaultMeshResources", func() {
 
 	It("should skip creating selected default policies", func() {
 		// when
-		err := mesh.EnsureDefaultMeshResources(context.Background(), resManager, model.DefaultMesh, []string{"TrafficPermission", "Retry"})
+		err := mesh.EnsureDefaultMeshResources(context.Background(), resManager, model.DefaultMesh, []string{"TrafficPermission", "Retry"}, context.Background())
 		Expect(err).ToNot(HaveOccurred())
 
 		// then default TrafficPermission doesn't exist

--- a/pkg/plugins/authn/api-server/tokens/plugin.go
+++ b/pkg/plugins/authn/api-server/tokens/plugin.go
@@ -77,7 +77,7 @@ func (c *plugin) AfterBootstrap(context *plugins.MutablePluginContext, config pl
 	}
 	ctx := go_context.Background()
 	signingKeyManager := core_tokens.NewSigningKeyManager(context.ResourceManager(), issuer.UserTokenSigningKeyPrefix)
-	component := core_tokens.NewDefaultSigningKeyComponent(ctx, signingKeyManager, log)
+	component := core_tokens.NewDefaultSigningKeyComponent(ctx, signingKeyManager, log, context.Extensions())
 	if err := context.ComponentManager().Add(component); err != nil {
 		return err
 	}

--- a/pkg/plugins/extensions/logger/context.go
+++ b/pkg/plugins/extensions/logger/context.go
@@ -1,0 +1,29 @@
+package logger
+
+import (
+	"context"
+
+	"go.opentelemetry.io/otel/trace"
+)
+
+type spanLogValuesProcessorKey struct{}
+
+// SpanLogValuesProcessor should be a function which process received
+// trace.Span. Returned []]interface{} will be later added as logger values.
+type SpanLogValuesProcessor func(trace.Span) []interface{}
+
+// NewSpanLogValuesProcessorContext will enrich the provided context with
+// the provided spanLogValuesProcessor. It may be useful for any application
+// which depends on Kuma, but wants to for example transform trace/span ids
+// from otel to datadog format.
+func NewSpanLogValuesProcessorContext(
+	ctx context.Context,
+	fn SpanLogValuesProcessor,
+) context.Context {
+	return context.WithValue(ctx, spanLogValuesProcessorKey{}, fn)
+}
+
+func FromSpanLogValuesProcessorContext(ctx context.Context) (SpanLogValuesProcessor, bool) {
+	fn, ok := ctx.Value(spanLogValuesProcessorKey{}).(SpanLogValuesProcessor)
+	return fn, ok
+}

--- a/pkg/plugins/runtime/k8s/controllers/mesh_defaults_controller.go
+++ b/pkg/plugins/runtime/k8s/controllers/mesh_defaults_controller.go
@@ -22,6 +22,7 @@ import (
 type MeshDefaultsReconciler struct {
 	ResourceManager manager.ResourceManager
 	Log             logr.Logger
+	Extensions      context.Context
 }
 
 func (r *MeshDefaultsReconciler) Reconcile(ctx context.Context, req kube_ctrl.Request) (kube_ctrl.Result, error) {
@@ -39,7 +40,13 @@ func (r *MeshDefaultsReconciler) Reconcile(ctx context.Context, req kube_ctrl.Re
 	}
 
 	r.Log.Info("ensuring that default mesh resources exist", "mesh", req.Name)
-	if err := defaults_mesh.EnsureDefaultMeshResources(ctx, r.ResourceManager, req.Name, mesh.Spec.GetSkipCreatingInitialPolicies()); err != nil {
+	if err := defaults_mesh.EnsureDefaultMeshResources(
+		ctx,
+		r.ResourceManager,
+		req.Name,
+		mesh.Spec.GetSkipCreatingInitialPolicies(),
+		r.Extensions,
+	); err != nil {
 		return kube_ctrl.Result{}, errors.Wrap(err, "could not create default mesh resources")
 	}
 

--- a/pkg/plugins/runtime/k8s/controllers/mesh_defaults_controller_test.go
+++ b/pkg/plugins/runtime/k8s/controllers/mesh_defaults_controller_test.go
@@ -60,6 +60,7 @@ var _ = Describe("MeshDefaultsReconciler", func() {
 		reconciler = &controllers.MeshDefaultsReconciler{
 			ResourceManager: customizableManager,
 			Log:             logr.Discard(),
+			Extensions:      context.Background(),
 		}
 	})
 

--- a/pkg/plugins/runtime/k8s/plugin.go
+++ b/pkg/plugins/runtime/k8s/plugin.go
@@ -150,6 +150,7 @@ func addMeshReconciler(mgr kube_ctrl.Manager, rt core_runtime.Runtime, converter
 	defaultsReconciller := &k8s_controllers.MeshDefaultsReconciler{
 		ResourceManager: rt.ResourceManager(),
 		Log:             core.Log.WithName("controllers").WithName("mesh-defaults"),
+		Extensions:      rt.Extensions(),
 	}
 	if err := defaultsReconciller.SetupWithManager(mgr); err != nil {
 		return errors.Wrap(err, "could not setup mesh defaults reconciller")

--- a/pkg/test/runtime/runtime.go
+++ b/pkg/test/runtime/runtime.go
@@ -92,7 +92,7 @@ func BuilderFor(appCtx context.Context, cfg kuma_cp.Config) (*core_runtime.Build
 			Mesh:      mesh_managers.NewMeshValidator(builder.CaManagers(), builder.ResourceStore()),
 		})
 
-	rm := newResourceManager(builder)
+	rm := newResourceManager(builder) //nolint:contextcheck
 	builder.WithResourceManager(rm).
 		WithReadOnlyResourceManager(rm)
 
@@ -162,6 +162,7 @@ func newResourceManager(builder *core_runtime.Builder) core_manager.Customizable
 		registry.Global(),
 		builder.ResourceValidators().Mesh,
 		builder.Config().Store.UnsafeDelete,
+		builder.Extensions(),
 	)
 	customManagers[core_mesh.MeshType] = meshManager
 


### PR DESCRIPTION
By enriching context with span processing function, we can modify default logging behaviour when tracing is enabled from logging `trace_id` and `span_id` fields to something else.

It allows any application which depends on Kuma, but wants to for example transform trace/span idsfrom otel to datadog format, to do that.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues
  - No relevant issues
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS
  - It won't
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s)
  - Tested manually
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)?
  - There is no need
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? 
  - There is no need
- [x] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?
> Changelog: skip

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
