### PR TITLE
feat(kuma-cp): allow to disable resources count metrics

### DIFF
--- a/docs/generated/kuma-cp.md
+++ b/docs/generated/kuma-cp.md
@@ -396,6 +396,9 @@ metrics:
     minResyncTimeout: 1s # ENV: KUMA_METRICS_MESH_MIN_RESYNC_TIMEOUT
     # Max time that MeshInsight could spend without resync
     maxResyncTimeout: 20s # ENV: KUMA_METRICS_MESH_MAX_RESYNC_TIMEOUT
+  controlPlane:
+    # If true metrics show number of resources in the system should be reported
+    reportResourcesCount: true # ENV: KUMA_METRICS_CONTROL_PLANE_REPORT_RESOURCES_COUNT
 
 # Reports configuration
 reports:

--- a/docs/generated/raw/kuma-cp.yaml
+++ b/docs/generated/raw/kuma-cp.yaml
@@ -393,6 +393,9 @@ metrics:
     minResyncTimeout: 1s # ENV: KUMA_METRICS_MESH_MIN_RESYNC_TIMEOUT
     # Max time that MeshInsight could spend without resync
     maxResyncTimeout: 20s # ENV: KUMA_METRICS_MESH_MAX_RESYNC_TIMEOUT
+  controlPlane:
+    # If true metrics show number of resources in the system should be reported
+    reportResourcesCount: true # ENV: KUMA_METRICS_CONTROL_PLANE_REPORT_RESOURCES_COUNT
 
 # Reports configuration
 reports:

--- a/pkg/config/app/kuma-cp/config.go
+++ b/pkg/config/app/kuma-cp/config.go
@@ -43,9 +43,10 @@ func (d *Defaults) Validate() error {
 }
 
 type Metrics struct {
-	Dataplane *DataplaneMetrics `json:"dataplane"`
-	Zone      *ZoneMetrics      `json:"zone"`
-	Mesh      *MeshMetrics      `json:"mesh"`
+	Dataplane    *DataplaneMetrics    `json:"dataplane"`
+	Zone         *ZoneMetrics         `json:"zone"`
+	Mesh         *MeshMetrics         `json:"mesh"`
+	ControlPlane *ControlPlaneMetrics `json:"controlPlane"`
 }
 
 func (m *Metrics) Sanitize() {
@@ -93,6 +94,12 @@ type MeshMetrics struct {
 	MinResyncTimeout config_types.Duration `json:"minResyncTimeout" envconfig:"kuma_metrics_mesh_min_resync_timeout"`
 	// MaxResyncTimeout is a maximum time that MeshInsight could spend without resync
 	MaxResyncTimeout config_types.Duration `json:"maxResyncTimeout" envconfig:"kuma_metrics_mesh_max_resync_timeout"`
+}
+
+type ControlPlaneMetrics struct {
+	// ReportResourcesCount if true will report metrics with the count of resources.
+	// Default: true
+	ReportResourcesCount bool `json:"reportResourcesCount" envconfig:"kuma_metrics_control_plane_report_resources_count"`
 }
 
 func (d *MeshMetrics) Sanitize() {
@@ -195,6 +202,9 @@ var DefaultConfig = func() Config {
 			Mesh: &MeshMetrics{
 				MinResyncTimeout: config_types.Duration{Duration: 1 * time.Second},
 				MaxResyncTimeout: config_types.Duration{Duration: 20 * time.Second},
+			},
+			ControlPlane: &ControlPlaneMetrics{
+				ReportResourcesCount: true,
 			},
 		},
 		Reports: &Reports{

--- a/pkg/config/app/kuma-cp/kuma-cp.defaults.yaml
+++ b/pkg/config/app/kuma-cp/kuma-cp.defaults.yaml
@@ -393,6 +393,9 @@ metrics:
     minResyncTimeout: 1s # ENV: KUMA_METRICS_MESH_MIN_RESYNC_TIMEOUT
     # Max time that MeshInsight could spend without resync
     maxResyncTimeout: 20s # ENV: KUMA_METRICS_MESH_MAX_RESYNC_TIMEOUT
+  controlPlane:
+    # If true metrics show number of resources in the system should be reported
+    reportResourcesCount: true # ENV: KUMA_METRICS_CONTROL_PLANE_REPORT_RESOURCES_COUNT
 
 # Reports configuration
 reports:

--- a/pkg/config/loader_test.go
+++ b/pkg/config/loader_test.go
@@ -279,6 +279,7 @@ var _ = Describe("Config loader", func() {
 			Expect(cfg.Metrics.Mesh.MaxResyncTimeout.Duration).To(Equal(27 * time.Second))
 			Expect(cfg.Metrics.Dataplane.SubscriptionLimit).To(Equal(47))
 			Expect(cfg.Metrics.Dataplane.IdleTimeout.Duration).To(Equal(1 * time.Minute))
+			Expect(cfg.Metrics.ControlPlane.ReportResourcesCount).To(BeTrue())
 
 			Expect(cfg.DpServer.TlsCertFile).To(Equal("/test/path"))
 			Expect(cfg.DpServer.TlsKeyFile).To(Equal("/test/path/key"))
@@ -577,6 +578,8 @@ metrics:
   dataplane:
     subscriptionLimit: 47
     idleTimeout: 1m
+  controlPlane:
+    reportResourcesCount: true
 dpServer:
   tlsCertFile: /test/path
   tlsKeyFile: /test/path/key
@@ -837,6 +840,7 @@ proxy:
 				"KUMA_METRICS_MESH_MIN_RESYNC_TIMEOUT":                                                     "35s",
 				"KUMA_METRICS_DATAPLANE_SUBSCRIPTION_LIMIT":                                                "47",
 				"KUMA_METRICS_DATAPLANE_IDLE_TIMEOUT":                                                      "1m",
+				"KUMA_METRICS_CONTROL_PLANE_REPORT_RESOURCES_COUNT":                                        "true",
 				"KUMA_DP_SERVER_TLS_CERT_FILE":                                                             "/test/path",
 				"KUMA_DP_SERVER_TLS_KEY_FILE":                                                              "/test/path/key",
 				"KUMA_DP_SERVER_TLS_MIN_VERSION":                                                           "TLSv1_3",

--- a/pkg/metrics/components/cp_info.go
+++ b/pkg/metrics/components/cp_info.go
@@ -59,13 +59,16 @@ func Setup(rt runtime.Runtime) error {
 	// We don't want to use cached ResourceManager because the cache is just for a couple of seconds
 	// and we will be retrieving resources every minute. There is no other place in the system for now that needs all resources from all meshes
 	// therefore it makes no sense to cache all content of the Database in the cache.
-	counter, err := metrics.NewStoreCounter(rt.ResourceManager(), rt.Metrics(), rt.Tenants())
-	if err != nil {
-		return err
+	if rt.Config().Metrics.ControlPlane.ReportResourcesCount {
+		counter, err := metrics.NewStoreCounter(rt.ResourceManager(), rt.Metrics(), rt.Tenants())
+		if err != nil {
+			return err
+		}
+		if err := rt.Add(counter); err != nil {
+			return err
+		}
 	}
-	if err := rt.Add(counter); err != nil {
-		return err
-	}
+
 	return nil
 }
 


### PR DESCRIPTION
### Checklist prior to review

Currently, we are reporting metrics for each resource name with the number of resources. When we introduced multitenancy we also increased the cardinality of the metrics. In the case of many tenants, metrics can be really expensive. Now we are able to disable it because i feel like there is no point to report aggregated metrics with the count of all the resources.

- [X] [Link to relevant issue][1] as well as docs and UI issues --
- [X] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [X] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [X] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [X] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [X] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
