### PR TITLE
feat(kumactl): define User-Agent

### DIFF
--- a/app/kumactl/pkg/client/api_server_client.go
+++ b/app/kumactl/pkg/client/api_server_client.go
@@ -1,18 +1,28 @@
 package client
 
 import (
+	"fmt"
 	"net/http"
 	"net/url"
+	"runtime"
 	"time"
 
 	"github.com/pkg/errors"
 
 	config_proto "github.com/kumahq/kuma/pkg/config/app/kumactl/v1alpha1"
 	util_http "github.com/kumahq/kuma/pkg/util/http"
+	kuma_version "github.com/kumahq/kuma/pkg/version"
 )
 
 func ApiServerClient(coordinates *config_proto.ControlPlaneCoordinates_ApiServer, timeout time.Duration) (util_http.Client, error) {
-	headers := make(map[string]string)
+	headers := map[string]string{
+		"User-Agent": fmt.Sprintf("kumactl/%s (%s; %s; %s/%s)",
+			kuma_version.Build.Version,
+			runtime.GOOS,
+			runtime.GOARCH,
+			kuma_version.Build.Product,
+			kuma_version.Build.GitCommit[:7]),
+	}
 	baseURL, err := url.Parse(coordinates.Url)
 	if err != nil {
 		return nil, errors.Wrapf(err, "Failed to parse API Server URL")


### PR DESCRIPTION
Defines the User-Agent value kumactl/1.0.0 (Linux; amd64; Kuma/a1f30b4) With 
* 1.0.0 : the version of Kuma,
* Kuma : the name of the Product
* a1f30b4 : the short git commit

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [ ] [Link to relevant issue][1] as well as docs and UI issues -- #7298
- [ ] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [ ] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [ ] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [ ] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [ ] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
