### PR TITLE
fix(dist): ensure rel flags are flags

### DIFF
--- a/mk/distribution.mk
+++ b/mk/distribution.mk
@@ -69,8 +69,8 @@ publish/pulp/$(DISTRIBUTION_TARGET_NAME)-$(1)-$(2):
 	  -e PULP_USERNAME="${PULP_USERNAME}" -e PULP_PASSWORD="${PULP_PASSWORD}" \
 	  -e PULP_HOST=$(PULP_HOST) \
 	  -v $(TOP)/build/distributions/out:/files:ro -it $(PULP_RELEASE_IMAGE) \
-	  release --file /files/$(DISTRIBUTION_TARGET_NAME)-$(1)-$(2).tar.gz \
-	  --package-type $(PULP_PACKAGE_TYPE) --dist-name binaries --dist-version $(PULP_DIST_VERSION) --publish)
+	  release --file=/files/$(DISTRIBUTION_TARGET_NAME)-$(1)-$(2).tar.gz \
+	  --package-type=$(PULP_PACKAGE_TYPE) --dist-name=binaries --dist-version=$(PULP_DIST_VERSION) --publish)
 endef
 
 # These are meant to be used inside foreach


### PR DESCRIPTION
This resolves an issue with the release process that was causing uploads using the `kong/release-scirpt` container to fail:
```
determining if pulp upload is wanted... yes
usage: release-scripts [-h] {repository,repo,artifact,art,release,rel} ...
release-scripts: error: argument command: invalid choice: '/files/kuma-2.2.3-linux-amd64.tar.gz' (choose from 'repository', 'repo', 'artifact', 'art', 'release', 'rel')
make: *** [mk/distribution.mk:84: publish/pulp/kuma-2.2.3-linux-amd64] Error 2

Exited with code exit status 2
```