### PR TITLE
fix(kuma-cp): handle advertisied address in zone ingress

### DIFF
--- a/pkg/xds/ingress/outbound.go
+++ b/pkg/xds/ingress/outbound.go
@@ -33,7 +33,7 @@ func BuildEndpointMap(
 			}
 			iface := dataplane.Spec.GetNetworking().ToInboundInterface(inbound)
 			outbound[service] = append(outbound[service], core_xds.Endpoint{
-				Target: iface.DataplaneIP,
+				Target: iface.DataplaneAdvertisedIP,
 				Port:   iface.DataplanePort,
 				Tags:   withMesh,
 				Weight: 1,

--- a/pkg/xds/ingress/outbound_test.go
+++ b/pkg/xds/ingress/outbound_test.go
@@ -184,6 +184,41 @@ var _ = Describe("IngressTrafficRoute", func() {
 					},
 				},
 			}),
+			Entry("data plane proxy with advertised address", testCase{
+				destinations: core_xds.DestinationMap{
+					"redis": []mesh_proto.TagSelector{
+						{mesh_proto.ServiceTag: "redis"},
+					},
+				},
+				dataplanes: []*core_mesh.DataplaneResource{
+					{
+						Meta: &test_model.ResourceMeta{Mesh: "default"},
+						Spec: &mesh_proto.Dataplane{
+							Networking: &mesh_proto.Dataplane_Networking{
+								AdvertisedAddress: "192.168.0.2",
+								Address:           "192.168.0.1",
+								Inbound: []*mesh_proto.Dataplane_Networking_Inbound{
+									{
+										Tags:        map[string]string{mesh_proto.ServiceTag: "redis"},
+										Port:        6379,
+										ServicePort: 16379,
+									},
+								},
+							},
+						},
+					},
+				},
+				expected: core_xds.EndpointMap{
+					"redis": []core_xds.Endpoint{
+						{
+							Target: "192.168.0.2",
+							Port:   6379,
+							Tags:   map[string]string{mesh_proto.ServiceTag: "redis", "mesh": "default"},
+							Weight: 1,
+						},
+					},
+				},
+			}),
 		)
 	})
 })


### PR DESCRIPTION
### Checklist prior to review

Fix #6545

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [X] [Link to relevant issue][1] as well as docs and UI issues --
- [X] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [X] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [X] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [X] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [X] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
