### PR TITLE
fix(kuma-cp): order resources for building VIPs

### DIFF
--- a/pkg/dns/vips_allocator.go
+++ b/pkg/dns/vips_allocator.go
@@ -228,7 +228,7 @@ func (d *VIPsAllocator) BuildVirtualOutboundMeshView(ctx context.Context, mesh s
 		return nil, err
 	}
 	// TODO(lukidzi): after switching to use the resource store as in the code for tests
-	// we should switch to `ListOrdered` https://github.com/kumahq/kuma/issues/5417
+	// we should switch to `ListOrdered` https://github.com/kumahq/kuma/issues/7356
 	sort.SliceStable(externalServices.Items, func(i, j int) bool {
 		return (externalServices.Items[i].GetMeta().GetName() < externalServices.Items[j].GetMeta().GetName())
 	})

--- a/pkg/dns/vips_allocator.go
+++ b/pkg/dns/vips_allocator.go
@@ -227,6 +227,8 @@ func (d *VIPsAllocator) BuildVirtualOutboundMeshView(ctx context.Context, mesh s
 	if err := d.rm.List(ctx, &externalServices, store.ListByMesh(mesh)); err != nil {
 		return nil, err
 	}
+	// TODO(lukidzi): after switching to use the resource store as in the code for tests
+	// we should switch to `ListOrdered` https://github.com/kumahq/kuma/issues/5417
 	sort.SliceStable(externalServices.Items, func(i, j int) bool {
 		return (externalServices.Items[i].GetMeta().GetName() < externalServices.Items[j].GetMeta().GetName())
 	})

--- a/pkg/dns/vips_allocator.go
+++ b/pkg/dns/vips_allocator.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"sort"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -226,6 +227,10 @@ func (d *VIPsAllocator) BuildVirtualOutboundMeshView(ctx context.Context, mesh s
 	if err := d.rm.List(ctx, &externalServices, store.ListByMesh(mesh)); err != nil {
 		return nil, err
 	}
+	sort.SliceStable(externalServices.Items, func(i, j int) bool {
+		return (externalServices.Items[i].GetMeta().GetName() < externalServices.Items[j].GetMeta().GetName())
+	})
+
 	for _, es := range externalServices.Items {
 		tags := map[string]string{mesh_proto.ServiceTag: es.Spec.GetService()}
 		if d.serviceVipEnabled {


### PR DESCRIPTION
### Checklist prior to review

It looks like resources are not ordered; whenever we do a `List` call, we can get resources in a different order. I've added sorting of the resources to make it stable in case we have a duplicate of the resource and we should use the first in order not randomly.

I tried to use `store.ListOrdered` but it seems not implemented for `memory` and `k8s`? Should we implement it on the store level? WDYT?
- [X] [Link to relevant issue][1] as well as docs and UI issues --
- [X] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [X] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [X] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [X] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [X] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
