### PR TITLE
ci(e2e): remove `kubernetes.io/arch: arm64`

### DIFF
--- a/test/framework/k8s_cluster.go
+++ b/test/framework/k8s_cluster.go
@@ -280,12 +280,6 @@ func (c *K8sCluster) yamlForKumaViaKubectl(mode string) (string, error) {
 		"--dataplane-repository":      Config.KumaDPImageRepo,
 		"--dataplane-init-repository": Config.KumaInitImageRepo,
 	}
-	if Config.Arch == "arm64" {
-		argsMap["--control-plane-node-selector"] = "kubernetes.io/arch=arm64"
-		argsMap["--cni-node-selector"] = "kubernetes.io/arch=arm64"
-		argsMap["--ingress-node-selector"] = "kubernetes.io/arch=arm64"
-		argsMap["--egress-node-selector"] = "kubernetes.io/arch=arm64"
-	}
 	if Config.KumaImageRegistry != "" {
 		argsMap["--control-plane-registry"] = Config.KumaImageRegistry
 		argsMap["--dataplane-registry"] = Config.KumaImageRegistry
@@ -371,13 +365,6 @@ func (c *K8sCluster) genValues(mode string) map[string]string {
 		"dataPlane.image.repository":             Config.KumaDPImageRepo,
 		"dataPlane.initImage.repository":         Config.KumaInitImageRepo,
 		"controlPlane.defaults.skipMeshCreation": strconv.FormatBool(c.opts.skipDefaultMesh),
-	}
-	if Config.Arch == "arm64" {
-		values[`controlPlane.nodeSelector.kubernetes\.io/arch`] = "arm64"
-		values[`cni.nodeSelector.kubernetes\.io/arch`] = "arm64"
-		values[`ingress.nodeSelector.kubernetes\.io/arch`] = "arm64"
-		values[`egress.nodeSelector.kubernetes\.io/arch`] = "arm64"
-		values[`hooks.nodeSelector.kubernetes\.io/arch`] = "arm64"
 	}
 	if Config.KumaImageRegistry != "" {
 		values["global.image.registry"] = Config.KumaImageRegistry


### PR DESCRIPTION
Should've deleted this right after https://github.com/kumahq/kuma/pull/4335. We don't need node selectors since our images support both platforms.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [X] [Link to relevant issue][1] as well as docs and UI issues --
- [X] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [X] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [X] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [X] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [X] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
