### PR TITLE
ci(.github): add patch tag push workflow

### DIFF
--- a/.github/workflows/push-patch-tag.yaml
+++ b/.github/workflows/push-patch-tag.yaml
@@ -1,0 +1,29 @@
+name: "Push patch tag"
+
+on:
+  workflow_dispatch:
+    inputs:
+      release-branch:
+        description: <major>.<minor> to release a patch version for
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          ref: "release-${{ inputs.release-branch }}"
+      - name: "Push next tag"
+        run: |
+          lastGitTag=$(git describe --tags --abbrev=0)
+          IFS=. read -r major minor patch <<< "${lastGitTag}"
+          version="${major}.${minor}.$((++patch))"
+
+          git tag "${version}"
+          git push origin "${version}"


### PR DESCRIPTION
### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [x] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
