### PR TITLE
perf(xds): use aggregated mesh context for zone proxies

### DIFF
--- a/pkg/xds/context/aggregate_mesh_context.go
+++ b/pkg/xds/context/aggregate_mesh_context.go
@@ -15,10 +15,10 @@ func AggregateMeshContexts(
 	ctx context.Context,
 	resManager manager.ReadOnlyResourceManager,
 	fetcher meshContextFetcher,
-) (MeshContexts, error) {
+) (AggregatedMeshContexts, error) {
 	var meshList core_mesh.MeshResourceList
 	if err := resManager.List(ctx, &meshList, core_store.ListOrdered()); err != nil {
-		return MeshContexts{}, err
+		return AggregatedMeshContexts{}, err
 	}
 
 	var meshContexts []MeshContext
@@ -26,7 +26,7 @@ func AggregateMeshContexts(
 	for _, mesh := range meshList.Items {
 		meshCtx, err := fetcher(ctx, mesh.GetMeta().GetName())
 		if err != nil {
-			return MeshContexts{}, err
+			return AggregatedMeshContexts{}, err
 		}
 		meshContexts = append(meshContexts, meshCtx)
 		meshContextsByName[mesh.Meta.GetName()] = meshCtx
@@ -39,7 +39,7 @@ func AggregateMeshContexts(
 		}
 	}
 
-	result := MeshContexts{
+	result := AggregatedMeshContexts{
 		Hash:               aggregatedHash(meshContexts),
 		Meshes:             meshList.Items,
 		MeshContextsByName: meshContextsByName,

--- a/pkg/xds/context/aggregate_mesh_context.go
+++ b/pkg/xds/context/aggregate_mesh_context.go
@@ -1,0 +1,57 @@
+package context
+
+import (
+	"context"
+
+	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
+	"github.com/kumahq/kuma/pkg/core/resources/manager"
+	core_store "github.com/kumahq/kuma/pkg/core/resources/store"
+	"github.com/kumahq/kuma/pkg/xds/cache/sha256"
+)
+
+type meshContextFetcher = func(ctx context.Context, meshName string) (MeshContext, error)
+
+func AggregateMeshContexts(
+	ctx context.Context,
+	resManager manager.ReadOnlyResourceManager,
+	fetcher meshContextFetcher,
+) (MeshContexts, error) {
+	var meshList core_mesh.MeshResourceList
+	if err := resManager.List(ctx, &meshList, core_store.ListOrdered()); err != nil {
+		return MeshContexts{}, err
+	}
+
+	var meshContexts []MeshContext
+	meshContextsByName := map[string]MeshContext{}
+	for _, mesh := range meshList.Items {
+		meshCtx, err := fetcher(ctx, mesh.GetMeta().GetName())
+		if err != nil {
+			return MeshContexts{}, err
+		}
+		meshContexts = append(meshContexts, meshCtx)
+		meshContextsByName[mesh.Meta.GetName()] = meshCtx
+	}
+
+	egressByName := map[string]*core_mesh.ZoneEgressResource{}
+	if len(meshContexts) > 0 {
+		for _, egress := range meshContexts[0].Resources.ZoneEgresses().Items {
+			egressByName[egress.Meta.GetName()] = egress
+		}
+	}
+
+	result := MeshContexts{
+		Hash:               aggregatedHash(meshContexts),
+		Meshes:             meshList.Items,
+		MeshContextsByName: meshContextsByName,
+		ZoneEgressByName:   egressByName,
+	}
+	return result, nil
+}
+
+func aggregatedHash(meshContexts []MeshContext) string {
+	var hash string
+	for _, meshCtx := range meshContexts {
+		hash += meshCtx.Hash
+	}
+	return sha256.Hash(hash)
+}

--- a/pkg/xds/context/context.go
+++ b/pkg/xds/context/context.go
@@ -74,3 +74,41 @@ func (mc *MeshContext) GetLoggingBackend(tl *core_mesh.TrafficLogResource) *mesh
 		return lb
 	}
 }
+
+// MeshContexts is an aggregate of all MeshContexts across all meshes
+type MeshContexts struct {
+	Hash               string
+	Meshes             []*core_mesh.MeshResource
+	MeshContextsByName map[string]MeshContext
+	ZoneEgressByName   map[string]*core_mesh.ZoneEgressResource
+}
+
+func (m MeshContexts) AllDataplanes() []*core_mesh.DataplaneResource {
+	var resources []*core_mesh.DataplaneResource
+	for _, meshCtx := range m.MeshContextsByName {
+		resources = append(resources, meshCtx.Resources.Dataplanes().Items...)
+	}
+	return resources
+}
+
+func (m MeshContexts) ZoneEgresses() []*core_mesh.ZoneEgressResource {
+	for _, meshCtx := range m.MeshContextsByName {
+		return meshCtx.Resources.ZoneEgresses().Items // all mesh contexts has the same list
+	}
+	return nil
+}
+
+func (m MeshContexts) ZoneIngresses() []*core_mesh.ZoneIngressResource {
+	for _, meshCtx := range m.MeshContextsByName {
+		return meshCtx.Resources.ZoneIngresses().Items // all mesh contexts has the same list
+	}
+	return nil
+}
+
+func (m MeshContexts) AllMeshGateways() []*core_mesh.MeshGatewayResource {
+	var resources []*core_mesh.MeshGatewayResource
+	for _, meshCtx := range m.MeshContextsByName {
+		resources = append(resources, meshCtx.Resources.MeshGateways().Items...)
+	}
+	return resources
+}

--- a/pkg/xds/context/context.go
+++ b/pkg/xds/context/context.go
@@ -75,39 +75,51 @@ func (mc *MeshContext) GetLoggingBackend(tl *core_mesh.TrafficLogResource) *mesh
 	}
 }
 
-// MeshContexts is an aggregate of all MeshContexts across all meshes
-type MeshContexts struct {
+// AggregatedMeshContexts is an aggregate of all MeshContext across all meshes
+type AggregatedMeshContexts struct {
 	Hash               string
 	Meshes             []*core_mesh.MeshResource
 	MeshContextsByName map[string]MeshContext
 	ZoneEgressByName   map[string]*core_mesh.ZoneEgressResource
 }
 
-func (m MeshContexts) AllDataplanes() []*core_mesh.DataplaneResource {
+// MustGetMeshContext panics if there is no mesh context for given mesh. Call it when iterating over .Meshes
+// There is a guarantee that for every Mesh in .Meshes there is a MeshContext.
+func (m AggregatedMeshContexts) MustGetMeshContext(meshName string) MeshContext {
+	meshCtx, ok := m.MeshContextsByName[meshName]
+	if !ok {
+		panic("there should be a corresponding mesh context for every mesh in mesh contexts")
+	}
+	return meshCtx
+}
+
+func (m AggregatedMeshContexts) AllDataplanes() []*core_mesh.DataplaneResource {
 	var resources []*core_mesh.DataplaneResource
-	for _, meshCtx := range m.MeshContextsByName {
+	for _, mesh := range m.Meshes {
+		meshCtx := m.MustGetMeshContext(mesh.Meta.GetName())
 		resources = append(resources, meshCtx.Resources.Dataplanes().Items...)
 	}
 	return resources
 }
 
-func (m MeshContexts) ZoneEgresses() []*core_mesh.ZoneEgressResource {
+func (m AggregatedMeshContexts) ZoneEgresses() []*core_mesh.ZoneEgressResource {
 	for _, meshCtx := range m.MeshContextsByName {
 		return meshCtx.Resources.ZoneEgresses().Items // all mesh contexts has the same list
 	}
 	return nil
 }
 
-func (m MeshContexts) ZoneIngresses() []*core_mesh.ZoneIngressResource {
+func (m AggregatedMeshContexts) ZoneIngresses() []*core_mesh.ZoneIngressResource {
 	for _, meshCtx := range m.MeshContextsByName {
 		return meshCtx.Resources.ZoneIngresses().Items // all mesh contexts has the same list
 	}
 	return nil
 }
 
-func (m MeshContexts) AllMeshGateways() []*core_mesh.MeshGatewayResource {
+func (m AggregatedMeshContexts) AllMeshGateways() []*core_mesh.MeshGatewayResource {
 	var resources []*core_mesh.MeshGatewayResource
-	for _, meshCtx := range m.MeshContextsByName {
+	for _, mesh := range m.Meshes {
+		meshCtx := m.MustGetMeshContext(mesh.Meta.GetName())
 		resources = append(resources, meshCtx.Resources.MeshGateways().Items...)
 	}
 	return resources

--- a/pkg/xds/sync/components.go
+++ b/pkg/xds/sync/components.go
@@ -1,12 +1,9 @@
 package sync
 
 import (
-	"context"
-
 	kuma_cp "github.com/kumahq/kuma/pkg/config/app/kuma-cp"
 	"github.com/kumahq/kuma/pkg/core"
 	core_runtime "github.com/kumahq/kuma/pkg/core/runtime"
-	"github.com/kumahq/kuma/pkg/core/user"
 	core_xds "github.com/kumahq/kuma/pkg/core/xds"
 	xds_context "github.com/kumahq/kuma/pkg/xds/context"
 	xds_metrics "github.com/kumahq/kuma/pkg/xds/metrics"
@@ -29,29 +26,18 @@ func DefaultIngressProxyBuilder(
 	apiVersion core_xds.APIVersion,
 ) *IngressProxyBuilder {
 	return &IngressProxyBuilder{
-		ResManager:         rt.ResourceManager(),
-		ReadOnlyResManager: rt.ReadOnlyResourceManager(),
-		LookupIP:           rt.LookupIP(),
-		apiVersion:         apiVersion,
-		meshCache:          rt.MeshCache(),
-		zone:               rt.Config().Multizone.Zone.Name,
-		ingressTagFilters:  rt.Config().Experimental.IngressTagFilters,
+		ResManager:        rt.ResourceManager(),
+		LookupIP:          rt.LookupIP(),
+		apiVersion:        apiVersion,
+		zone:              rt.Config().Multizone.Zone.Name,
+		ingressTagFilters: rt.Config().Experimental.IngressTagFilters,
 	}
 }
 
-func DefaultEgressProxyBuilder(
-	ctx context.Context,
-	rt core_runtime.Runtime,
-	apiVersion core_xds.APIVersion,
-) *EgressProxyBuilder {
+func DefaultEgressProxyBuilder(rt core_runtime.Runtime, apiVersion core_xds.APIVersion) *EgressProxyBuilder {
 	return &EgressProxyBuilder{
-		ctx:                ctx,
-		ResManager:         rt.ResourceManager(),
-		ReadOnlyResManager: rt.ReadOnlyResourceManager(),
-		LookupIP:           rt.LookupIP(),
-		meshCache:          rt.MeshCache(),
-		apiVersion:         apiVersion,
-		zone:               rt.Config().Multizone.Zone.Name,
+		apiVersion: apiVersion,
+		zone:       rt.Config().Multizone.Zone.Name,
 	}
 }
 
@@ -65,7 +51,6 @@ func DefaultDataplaneWatchdogFactory(
 	envoyCpCtx *xds_context.ControlPlaneContext,
 	apiVersion core_xds.APIVersion,
 ) (DataplaneWatchdogFactory, error) {
-	ctx := user.Ctx(context.Background(), user.ControlPlane)
 	config := rt.Config()
 
 	dataplaneProxyBuilder := DefaultDataplaneProxyBuilder(
@@ -78,11 +63,7 @@ func DefaultDataplaneWatchdogFactory(
 		apiVersion,
 	)
 
-	egressProxyBuilder := DefaultEgressProxyBuilder(
-		ctx,
-		rt,
-		apiVersion,
-	)
+	egressProxyBuilder := DefaultEgressProxyBuilder(rt, apiVersion)
 
 	deps := DataplaneWatchdogDependencies{
 		DataplaneProxyBuilder: dataplaneProxyBuilder,

--- a/pkg/xds/sync/dataplane_proxy_builder.go
+++ b/pkg/xds/sync/dataplane_proxy_builder.go
@@ -7,7 +7,6 @@ import (
 	"github.com/pkg/errors"
 
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
-	"github.com/kumahq/kuma/pkg/core"
 	"github.com/kumahq/kuma/pkg/core/faultinjections"
 	"github.com/kumahq/kuma/pkg/core/logs"
 	manager_dataplane "github.com/kumahq/kuma/pkg/core/managers/apis/dataplane"
@@ -23,8 +22,6 @@ import (
 	"github.com/kumahq/kuma/pkg/xds/template"
 	xds_topology "github.com/kumahq/kuma/pkg/xds/topology"
 )
-
-var syncLog = core.Log.WithName("sync")
 
 type DataplaneProxyBuilder struct {
 	Zone       string

--- a/pkg/xds/sync/dataplane_watchdog.go
+++ b/pkg/xds/sync/dataplane_watchdog.go
@@ -165,7 +165,25 @@ func (d *DataplaneWatchdog) syncIngress(ctx context.Context, metadata *core_xds.
 		ControlPlane: d.EnvoyCpCtx,
 		Mesh:         xds_context.MeshContext{}, // ZoneIngress does not have a mesh!
 	}
-	proxy, err := d.IngressProxyBuilder.Build(ctx, d.key)
+
+	meshContexts, err := xds_context.AggregateMeshContexts(ctx, d.ResManager, d.MeshCache.GetMeshContext)
+	if err != nil {
+		return SyncResult{}, err
+	}
+
+	result := SyncResult{
+		ProxyType: mesh_proto.IngressProxyType,
+	}
+	syncForConfig := meshContexts.Hash != d.lastHash
+	if !syncForConfig {
+		result.Status = SkipStatus
+		return result, nil
+	}
+	if syncForConfig {
+		d.log.V(1).Info("snapshot hash updated, reconcile", "prev", d.lastHash, "current", meshContexts.Hash)
+	}
+
+	proxy, err := d.IngressProxyBuilder.Build(ctx, d.key, meshContexts)
 	if err != nil {
 		return SyncResult{}, err
 	}
@@ -180,12 +198,10 @@ func (d *DataplaneWatchdog) syncIngress(ctx context.Context, metadata *core_xds.
 	if err != nil {
 		return SyncResult{}, err
 	}
-	result := SyncResult{
-		ProxyType: mesh_proto.IngressProxyType,
-		Status:    GeneratedStatus,
-	}
 	if changed {
 		result.Status = ChangedStatus
+	} else {
+		result.Status = GeneratedStatus
 	}
 	return result, nil
 }
@@ -198,7 +214,24 @@ func (d *DataplaneWatchdog) syncEgress(ctx context.Context, metadata *core_xds.D
 		Mesh:         xds_context.MeshContext{}, // ZoneEgress does not have a mesh!
 	}
 
-	proxy, err := d.EgressProxyBuilder.Build(ctx, d.key)
+	meshContexts, err := xds_context.AggregateMeshContexts(ctx, d.ResManager, d.MeshCache.GetMeshContext)
+	if err != nil {
+		return SyncResult{}, err
+	}
+
+	result := SyncResult{
+		ProxyType: mesh_proto.EgressProxyType,
+	}
+	syncForConfig := meshContexts.Hash != d.lastHash
+	if !syncForConfig {
+		result.Status = SkipStatus
+		return result, nil
+	}
+	if syncForConfig {
+		d.log.V(1).Info("snapshot hash updated, reconcile", "prev", d.lastHash, "current", meshContexts.Hash)
+	}
+
+	proxy, err := d.EgressProxyBuilder.Build(ctx, d.key, meshContexts)
 	if err != nil {
 		return SyncResult{}, err
 	}
@@ -213,12 +246,10 @@ func (d *DataplaneWatchdog) syncEgress(ctx context.Context, metadata *core_xds.D
 	if err != nil {
 		return SyncResult{}, err
 	}
-	result := SyncResult{
-		ProxyType: mesh_proto.IngressProxyType,
-		Status:    GeneratedStatus,
-	}
 	if changed {
 		result.Status = ChangedStatus
+	} else {
+		result.Status = GeneratedStatus
 	}
 	return result, nil
 }

--- a/pkg/xds/sync/dataplane_watchdog.go
+++ b/pkg/xds/sync/dataplane_watchdog.go
@@ -166,7 +166,7 @@ func (d *DataplaneWatchdog) syncIngress(ctx context.Context, metadata *core_xds.
 		Mesh:         xds_context.MeshContext{}, // ZoneIngress does not have a mesh!
 	}
 
-	meshContexts, err := xds_context.AggregateMeshContexts(ctx, d.ResManager, d.MeshCache.GetMeshContext)
+	aggregatedMeshCtxs, err := xds_context.AggregateMeshContexts(ctx, d.ResManager, d.MeshCache.GetMeshContext)
 	if err != nil {
 		return SyncResult{}, err
 	}
@@ -174,16 +174,16 @@ func (d *DataplaneWatchdog) syncIngress(ctx context.Context, metadata *core_xds.
 	result := SyncResult{
 		ProxyType: mesh_proto.IngressProxyType,
 	}
-	syncForConfig := meshContexts.Hash != d.lastHash
+	syncForConfig := aggregatedMeshCtxs.Hash != d.lastHash
 	if !syncForConfig {
 		result.Status = SkipStatus
 		return result, nil
 	}
 	if syncForConfig {
-		d.log.V(1).Info("snapshot hash updated, reconcile", "prev", d.lastHash, "current", meshContexts.Hash)
+		d.log.V(1).Info("snapshot hash updated, reconcile", "prev", d.lastHash, "current", aggregatedMeshCtxs.Hash)
 	}
 
-	proxy, err := d.IngressProxyBuilder.Build(ctx, d.key, meshContexts)
+	proxy, err := d.IngressProxyBuilder.Build(ctx, d.key, aggregatedMeshCtxs)
 	if err != nil {
 		return SyncResult{}, err
 	}
@@ -214,7 +214,7 @@ func (d *DataplaneWatchdog) syncEgress(ctx context.Context, metadata *core_xds.D
 		Mesh:         xds_context.MeshContext{}, // ZoneEgress does not have a mesh!
 	}
 
-	meshContexts, err := xds_context.AggregateMeshContexts(ctx, d.ResManager, d.MeshCache.GetMeshContext)
+	aggregatedMeshCtxs, err := xds_context.AggregateMeshContexts(ctx, d.ResManager, d.MeshCache.GetMeshContext)
 	if err != nil {
 		return SyncResult{}, err
 	}
@@ -222,16 +222,16 @@ func (d *DataplaneWatchdog) syncEgress(ctx context.Context, metadata *core_xds.D
 	result := SyncResult{
 		ProxyType: mesh_proto.EgressProxyType,
 	}
-	syncForConfig := meshContexts.Hash != d.lastHash
+	syncForConfig := aggregatedMeshCtxs.Hash != d.lastHash
 	if !syncForConfig {
 		result.Status = SkipStatus
 		return result, nil
 	}
 	if syncForConfig {
-		d.log.V(1).Info("snapshot hash updated, reconcile", "prev", d.lastHash, "current", meshContexts.Hash)
+		d.log.V(1).Info("snapshot hash updated, reconcile", "prev", d.lastHash, "current", aggregatedMeshCtxs.Hash)
 	}
 
-	proxy, err := d.EgressProxyBuilder.Build(ctx, d.key, meshContexts)
+	proxy, err := d.EgressProxyBuilder.Build(ctx, d.key, aggregatedMeshCtxs)
 	if err != nil {
 		return SyncResult{}, err
 	}

--- a/pkg/xds/sync/proxy_builder_test.go
+++ b/pkg/xds/sync/proxy_builder_test.go
@@ -102,18 +102,16 @@ var _ = Describe("Proxy Builder", func() {
 	initializeStore(ctx, rt.ResourceManager(), "default_resources.yaml")
 
 	Describe("Build() zone egress", func() {
-		egressProxyBuilder := sync.DefaultEgressProxyBuilder(
-			ctx,
-			rt,
-			envoy_common.APIV3,
-		)
+		egressProxyBuilder := sync.DefaultEgressProxyBuilder(rt, envoy_common.APIV3)
 
 		It("should build proxy object for egress", func() {
 			// given
 			rk := core_model.ResourceKey{Name: "zone-egress-1"}
+			meshContexts, err := xds_context.AggregateMeshContexts(ctx, rt.ReadOnlyResourceManager(), meshCache.GetMeshContext)
+			Expect(err).ToNot(HaveOccurred())
 
 			// when
-			proxy, err := egressProxyBuilder.Build(ctx, rk)
+			proxy, err := egressProxyBuilder.Build(ctx, rk, meshContexts)
 			Expect(err).ToNot(HaveOccurred())
 
 			// then
@@ -193,9 +191,11 @@ var _ = Describe("Proxy Builder", func() {
 		It("should build proxy object for ingress", func() {
 			// given
 			rk := core_model.ResourceKey{Name: "zone-ingress-zone-1"}
+			meshContexts, err := xds_context.AggregateMeshContexts(ctx, rt.ReadOnlyResourceManager(), meshCache.GetMeshContext)
+			Expect(err).ToNot(HaveOccurred())
 
 			// when
-			proxy, err := ingressProxyBuilder.Build(ctx, rk)
+			proxy, err := ingressProxyBuilder.Build(ctx, rk, meshContexts)
 			Expect(err).ToNot(HaveOccurred())
 
 			// then


### PR DESCRIPTION
### Checklist prior to review

With the recent VirtualOutbound cross zone work I noticed that we can heavily use MeshContext from specific meshes. If we do, then it's very easy to avoid unnecessary zone proxies XDS generation by checking the aggregated mesh hash following the same pattern as we do for regular DP proxies.

This improvement reduces:
* Number of queries to DB, instead of doing separate DB queries to all DPPs or all MeshGateways we can just aggregate all from all mesh contexts
* Number of XDS reconciliations for zone proxies if there are no changes in the system

Note: I'm not sure if `MeshContexts` is a good name. It can be easily confused with `MeshContext` when reading the code. Should this be `AggregatedMeshContexts`? `AllMeshContexts`?

`meshContextFetcher` is introduced so we don't have dependency on mesh cache in xds/context.

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [ ] [Link to relevant issue][1] as well as docs and UI issues --
- [ ] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [ ] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [ ] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [ ] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [ ] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
