### PR TITLE
ci(actions): add action to add backport label to prs based on changed files

### DIFF
--- a/.github/workflows/auto-backport.yaml
+++ b/.github/workflows/auto-backport.yaml
@@ -6,10 +6,10 @@ env:
   PREDEFINED_GLOBS: ".github/**/*,.circleci/**/*,Makefile,mk/**/*,tools/**/*,.golangci.yml,.kube-linter.yaml"
   LABEL_TO_ADD: backport
   NO_BACKPORT_AUTOLABEL: no-backport-autolabel
-permissions:
-  issues: write
 jobs:
   backport_label:
+    permissions:
+      issues: write
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code

--- a/.github/workflows/auto-backport.yaml
+++ b/.github/workflows/auto-backport.yaml
@@ -9,10 +9,20 @@ env:
 jobs:
   backport_label:
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
+      - name: Generate GitHub app token
+        id: github-app-token
+        uses: tibdex/github-app-token@b62528385c34dbc9f38e5f4225ac829252d1ea92 # v1.8.0
+        with:
+          app_id: ${{ secrets.APP_ID }}
+          private_key: ${{ secrets.APP_PRIVATE_KEY }}
       - name: Check diff and add label
+        env:
+          GITHUB_TOKEN: ${{ steps.github-app-token.outputs.token }}
         run: |
           git fetch origin master:refs/remotes/origin/master
           tools/ci/needs_backporting.sh "${{ github.repository }}" "${{ github.event.pull_request.number }}" "origin/${{ github.base_ref }}" "HEAD" "$PREDEFINED_GLOBS" "$LABEL_TO_ADD" "$NO_BACKPORT_AUTOLABEL"

--- a/.github/workflows/auto-backport.yaml
+++ b/.github/workflows/auto-backport.yaml
@@ -18,4 +18,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          tools/ci/needs_backporting.sh "${{ github.repository }}" "${{ github.event.pull_request.number }}" "${{ github.base_ref }}" "${{ github.head_ref }}" "$PREDEFINED_GLOBS" "$LABEL_TO_ADD" "$NO_BACKPORT_AUTOLABEL"
+          tools/ci/needs_backporting.sh "${{ github.repository }}" "${{ github.event.pull_request.number }}" "origin/${{ github.base_ref }}" "HEAD" "$PREDEFINED_GLOBS" "$LABEL_TO_ADD" "$NO_BACKPORT_AUTOLABEL"

--- a/.github/workflows/auto-backport.yaml
+++ b/.github/workflows/auto-backport.yaml
@@ -3,14 +3,16 @@ on:
   pull_request:
     types: [opened, synchronize]
 env:
-  PREDEFINED_GLOBS: ".github/**/*,.circleci/**/*,mk/**/*,tools/ci/**/*"
+  PREDEFINED_GLOBS: ".github/**/*,.circleci/**/*,Makefile,mk/**/*,tools/**/*,.golangci.yml,.kube-linter.yaml"
   LABEL_TO_ADD: backport
 jobs:
   backport_label:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 300
       - name: Check diff and add label
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/auto-backport.yaml
+++ b/.github/workflows/auto-backport.yaml
@@ -6,6 +6,8 @@ env:
   PREDEFINED_GLOBS: ".github/**/*,.circleci/**/*,Makefile,mk/**/*,tools/**/*,.golangci.yml,.kube-linter.yaml"
   LABEL_TO_ADD: backport
   NO_BACKPORT_AUTOLABEL: no-backport-autolabel
+permissions:
+  issues: write
 jobs:
   backport_label:
     runs-on: ubuntu-latest

--- a/.github/workflows/auto-backport.yaml
+++ b/.github/workflows/auto-backport.yaml
@@ -5,6 +5,7 @@ on:
 env:
   PREDEFINED_GLOBS: ".github/**/*,.circleci/**/*,Makefile,mk/**/*,tools/**/*,.golangci.yml,.kube-linter.yaml"
   LABEL_TO_ADD: backport
+  NO_BACKPORT_AUTOLABEL: no-backport-autolabel
 jobs:
   backport_label:
     runs-on: ubuntu-latest
@@ -16,4 +17,4 @@ jobs:
       - name: Check diff and add label
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: tools/ci/needs_backporting.sh "${{ github.repository }}" "${{ github.event.pull_request.number }}" "${{ github.base_ref }}" "${{ github.head_ref }}" "$PREDEFINED_GLOBS" "$LABEL_TO_ADD"
+        run: tools/ci/needs_backporting.sh "${{ github.repository }}" "${{ github.event.pull_request.number }}" "${{ github.base_ref }}" "${{ github.head_ref }}" "$PREDEFINED_GLOBS" "$LABEL_TO_ADD" "$NO_BACKPORT_AUTOLABEL"

--- a/.github/workflows/auto-backport.yaml
+++ b/.github/workflows/auto-backport.yaml
@@ -8,9 +8,8 @@ env:
   NO_BACKPORT_AUTOLABEL: no-backport-autolabel
 jobs:
   backport_label:
-    permissions:
-      issues: write
     runs-on: ubuntu-latest
+    permissions: write-all
     steps:
       - name: Checkout code
         uses: actions/checkout@v3

--- a/.github/workflows/auto-backport.yaml
+++ b/.github/workflows/auto-backport.yaml
@@ -10,17 +10,9 @@ jobs:
   backport_label:
     runs-on: ubuntu-latest
     steps:
-      - name: Generate GitHub app token
-        id: github-app-token
-        uses: tibdex/github-app-token@b62528385c34dbc9f38e5f4225ac829252d1ea92 # v1.8.0
-        with:
-          app_id: ${{ secrets.APP_ID }}
-          private_key: ${{ secrets.APP_PRIVATE_KEY }}
       - name: Checkout code
         uses: actions/checkout@v3
       - name: Check diff and add label
-        env:
-          GITHUB_TOKEN: ${{ steps.github-app-token.outputs.token }}
         run: |
           git fetch origin master:refs/remotes/origin/master
           tools/ci/needs_backporting.sh "${{ github.repository }}" "${{ github.event.pull_request.number }}" "origin/${{ github.base_ref }}" "HEAD" "$PREDEFINED_GLOBS" "$LABEL_TO_ADD" "$NO_BACKPORT_AUTOLABEL"

--- a/.github/workflows/auto-backport.yaml
+++ b/.github/workflows/auto-backport.yaml
@@ -1,0 +1,17 @@
+name: Auto backport label
+on:
+  pull_request:
+    types: [opened, synchronize]
+env:
+  PREDEFINED_GLOBS: ".github/**/*,.circleci/**/*,mk/**/*,tools/ci/**/*"
+  LABEL_TO_ADD: backport
+jobs:
+  backport_label:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Check diff and add label
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: tools/ci/needs_backporting.sh "${{ github.repository }}" "${{ github.event.pull_request.number }}" "${{ github.base_ref }}" "${{ github.head_ref }}" "$PREDEFINED_GLOBS" "$LABEL_TO_ADD"

--- a/.github/workflows/auto-backport.yaml
+++ b/.github/workflows/auto-backport.yaml
@@ -18,6 +18,6 @@ jobs:
           fetch-depth: 0
       - name: Check diff and add label
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
           tools/ci/needs_backporting.sh "${{ github.repository }}" "${{ github.event.pull_request.number }}" "origin/${{ github.base_ref }}" "HEAD" "$PREDEFINED_GLOBS" "$LABEL_TO_ADD" "$NO_BACKPORT_AUTOLABEL"

--- a/.github/workflows/auto-backport.yaml
+++ b/.github/workflows/auto-backport.yaml
@@ -9,14 +9,18 @@ env:
 jobs:
   backport_label:
     runs-on: ubuntu-latest
-    permissions: write-all
     steps:
+      - name: Generate GitHub app token
+        id: github-app-token
+        uses: tibdex/github-app-token@b62528385c34dbc9f38e5f4225ac829252d1ea92 # v1.8.0
+        with:
+          app_id: ${{ secrets.APP_ID }}
+          private_key: ${{ secrets.APP_PRIVATE_KEY }}
       - name: Checkout code
         uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
       - name: Check diff and add label
         env:
-          GITHUB_TOKEN: ${{ github.token }}
+          GITHUB_TOKEN: ${{ steps.github-app-token.outputs.token }}
         run: |
+          git fetch origin master:refs/remotes/origin/master
           tools/ci/needs_backporting.sh "${{ github.repository }}" "${{ github.event.pull_request.number }}" "origin/${{ github.base_ref }}" "HEAD" "$PREDEFINED_GLOBS" "$LABEL_TO_ADD" "$NO_BACKPORT_AUTOLABEL"

--- a/.github/workflows/auto-backport.yaml
+++ b/.github/workflows/auto-backport.yaml
@@ -12,9 +12,10 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
       - name: Check diff and add label
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          git fetch origin master:refs/remotes/origin/master
           tools/ci/needs_backporting.sh "${{ github.repository }}" "${{ github.event.pull_request.number }}" "${{ github.base_ref }}" "${{ github.head_ref }}" "$PREDEFINED_GLOBS" "$LABEL_TO_ADD" "$NO_BACKPORT_AUTOLABEL"

--- a/.github/workflows/auto-backport.yaml
+++ b/.github/workflows/auto-backport.yaml
@@ -12,9 +12,9 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
-        with:
-          fetch-depth: 300
       - name: Check diff and add label
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: tools/ci/needs_backporting.sh "${{ github.repository }}" "${{ github.event.pull_request.number }}" "${{ github.base_ref }}" "${{ github.head_ref }}" "$PREDEFINED_GLOBS" "$LABEL_TO_ADD" "$NO_BACKPORT_AUTOLABEL"
+        run: |
+          git fetch origin master:refs/remotes/origin/master
+          tools/ci/needs_backporting.sh "${{ github.repository }}" "${{ github.event.pull_request.number }}" "${{ github.base_ref }}" "${{ github.head_ref }}" "$PREDEFINED_GLOBS" "$LABEL_TO_ADD" "$NO_BACKPORT_AUTOLABEL"

--- a/tools/ci/needs_backporting.sh
+++ b/tools/ci/needs_backporting.sh
@@ -17,7 +17,7 @@ shopt -s globstar
 IFS=',' read -ra PREDEFINED_GLOBS_ARR <<< "$PREDEFINED_GLOBS"
 
 # Get the changed files in the PR using git diff
-CHANGED_FILES=$(git diff --name-only "$BASE_REF" "$HEAD_REF")
+CHANGED_FILES=$(git diff --name-only origin/"$BASE_REF" origin/"$HEAD_REF")
 echo "Changed files:"
 echo "$CHANGED_FILES"
 

--- a/tools/ci/needs_backporting.sh
+++ b/tools/ci/needs_backporting.sh
@@ -17,7 +17,7 @@ shopt -s globstar
 IFS=',' read -ra PREDEFINED_GLOBS_ARR <<< "$PREDEFINED_GLOBS"
 
 # Get the changed files in the PR using git diff
-CHANGED_FILES=$(git diff --name-only origin/"$BASE_REF" origin/"$HEAD_REF")
+CHANGED_FILES=$(git diff --name-only "$BASE_REF" "$HEAD_REF")
 echo "Changed files:"
 echo "$CHANGED_FILES"
 

--- a/tools/ci/needs_backporting.sh
+++ b/tools/ci/needs_backporting.sh
@@ -38,11 +38,12 @@ if [ ${#MATCHING_FILES[@]} -gt 0 ]; then
   printf '%s\n' "${MATCHING_FILES[@]}"
 
   if gh api repos/kumahq/kuma/issues/7450/labels | jq '.[].name' | grep -q "$NO_BACKPORT_AUTOLABEL" ; then
-    echo "Not doing anything, '$NO_BACKPORT_AUTOLABEL' label present."
+    echo "Removing $LABEL_TO_ADD because '$NO_BACKPORT_AUTOLABEL' label present."
+    gh issue edit "$PR_NUMBER" --remove-label "$LABEL_TO_ADD" -R "$REPO"
   else
     echo "Adding '$LABEL_TO_ADD' label to the pull request."
     gh issue edit "$PR_NUMBER" --add-label "$LABEL_TO_ADD" -R "$REPO"
   fi
 else
-  echo "No matching files found. Not adding any label."
+  echo "No matching files found. Not changing any label."
 fi

--- a/tools/ci/needs_backporting.sh
+++ b/tools/ci/needs_backporting.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+REPO=$1
+PR_NUMBER=$2
+BASE_REF=$3
+HEAD_REF=$4
+PREDEFINED_GLOBS=$5
+LABEL_TO_ADD=$6
+
+# Enable recursive globs, needs bash 4!
+shopt -s globstar
+
+# Convert the comma-separated globs to an array
+IFS=',' read -ra PREDEFINED_GLOBS_ARR <<< "$PREDEFINED_GLOBS"
+
+# Get the changed files in the PR using git diff
+CHANGED_FILES=$(git diff --name-only "$BASE_REF" "$HEAD_REF")
+echo "Changed files:"
+echo "$CHANGED_FILES"
+
+# Collect matching files in an array
+MATCHING_FILES=()
+for glob in "${PREDEFINED_GLOBS_ARR[@]}"; do
+  for file in $CHANGED_FILES; do
+    # shellcheck disable=SC2053
+    if [[ "$file" == $glob ]]; then
+      MATCHING_FILES+=("$file")
+    fi
+  done
+done
+
+# Check if there are any matching files before updating the issue
+if [ ${#MATCHING_FILES[@]} -gt 0 ]; then
+  echo "Matching files:"
+  printf '%s\n' "${MATCHING_FILES[@]}"
+
+  echo "Adding '$LABEL_TO_ADD' label to the pull request..."
+  gh issue edit "$PR_NUMBER" --add-label "$LABEL_TO_ADD" -R "$REPO"
+else
+  echo "No matching files found. Not adding any label."
+fi

--- a/tools/ci/needs_backporting.sh
+++ b/tools/ci/needs_backporting.sh
@@ -36,8 +36,9 @@ if [ ${#MATCHING_FILES[@]} -gt 0 ]; then
   echo "Matching files:"
   printf '%s\n' "${MATCHING_FILES[@]}"
 
-  echo "Adding '$LABEL_TO_ADD' label to the pull request..."
+  echo "Adding '$LABEL_TO_ADD' label to the pull request."
   gh issue edit "$PR_NUMBER" --add-label "$LABEL_TO_ADD" -R "$REPO"
 else
-  echo "No matching files found. Not adding any label."
+  echo "No matching files found. Removing existing label if present."
+  gh issue edit "$PR_NUMBER" --remove-label "$LABEL_TO_ADD" -R "$REPO"
 fi

--- a/tools/ci/needs_backporting.sh
+++ b/tools/ci/needs_backporting.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 REPO=$1
 PR_NUMBER=$2
 BASE_REF=$3

--- a/tools/ci/needs_backporting.sh
+++ b/tools/ci/needs_backporting.sh
@@ -8,6 +8,7 @@ BASE_REF=$3
 HEAD_REF=$4
 PREDEFINED_GLOBS=$5
 LABEL_TO_ADD=$6
+NO_BACKPORT_AUTOLABEL=$7
 
 # Enable recursive globs, needs bash 4!
 shopt -s globstar
@@ -36,9 +37,12 @@ if [ ${#MATCHING_FILES[@]} -gt 0 ]; then
   echo "Matching files:"
   printf '%s\n' "${MATCHING_FILES[@]}"
 
-  echo "Adding '$LABEL_TO_ADD' label to the pull request."
-  gh issue edit "$PR_NUMBER" --add-label "$LABEL_TO_ADD" -R "$REPO"
+  if gh api repos/kumahq/kuma/issues/7450/labels | jq '.[].name' | grep -q "$NO_BACKPORT_AUTOLABEL" ; then
+    echo "Not doing anything, '$NO_BACKPORT_AUTOLABEL' label present."
+  else
+    echo "Adding '$LABEL_TO_ADD' label to the pull request."
+    gh issue edit "$PR_NUMBER" --add-label "$LABEL_TO_ADD" -R "$REPO"
+  fi
 else
-  echo "No matching files found. Removing existing label if present."
-  gh issue edit "$PR_NUMBER" --remove-label "$LABEL_TO_ADD" -R "$REPO"
+  echo "No matching files found. Not adding any label."
 fi


### PR DESCRIPTION
Right now it does not work because it's not merged yet. It will work after it's merged.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [ ] [Link to relevant issue][1] as well as docs and UI issues --
- [ ] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [ ] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [ ] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [ ] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [ ] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
