### PR TITLE
ci(actions): check autolabel

### DIFF
--- a/mk/check.mk
+++ b/mk/check.mk
@@ -91,3 +91,5 @@ check: format/common lint ## Dev: Run code checks (go fmt, go vet, ...)
 .PHONY: update-vulnerable-dependencies
 update-vulnerable-dependencies:
 	@$(KUMA_DIR)/tools/ci/update-vulnerable-dependencies.sh
+
+# dummy change


### PR DESCRIPTION
checking if backport autolabel works

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [ ] [Link to relevant issue][1] as well as docs and UI issues --
- [ ] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [ ] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [ ] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [ ] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [ ] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
