### PR TITLE
chore(postgres): share db creation pool code

### DIFF
--- a/pkg/plugins/common/postgres/connection.go
+++ b/pkg/plugins/common/postgres/connection.go
@@ -1,11 +1,18 @@
 package postgres
 
 import (
+	"context"
 	"database/sql"
+	"math"
+	"time"
 
+	"github.com/exaring/otelpgx"
+	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/pkg/errors"
+	"go.opentelemetry.io/otel/attribute"
 
 	config "github.com/kumahq/kuma/pkg/config/plugins/resources/postgres"
+	pgx_config "github.com/kumahq/kuma/pkg/plugins/resources/postgres/config"
 )
 
 func ConnectToDb(cfg config.PostgresStoreConfig) (*sql.DB, error) {
@@ -27,4 +34,40 @@ func ConnectToDb(cfg config.PostgresStoreConfig) (*sql.DB, error) {
 	}
 
 	return db, nil
+}
+
+// This attribute is necessary for tracing integrations like Datadog, to have
+// full insights into sql queries connected with traces.
+// ref. https://github.com/DataDog/dd-trace-go/blob/3d97fcec9f8b21fdd821af526d27d4335b26da66/contrib/database/sql/conn.go#L290
+var spanTypeSQLAttribute = attribute.String("span.type", "sql")
+
+func ConnectToDbPgx(postgresStoreConfig config.PostgresStoreConfig, customizers ...pgx_config.PgxConfigCustomization) (*pgxpool.Pool, error) {
+	connectionString, err := postgresStoreConfig.ConnectionString()
+	if err != nil {
+		return nil, err
+	}
+	pgxConfig, err := pgxpool.ParseConfig(connectionString)
+
+	if postgresStoreConfig.MaxOpenConnections == 0 {
+		// pgx MaxCons must be > 0, see https://github.com/jackc/puddle/blob/c5402ce53663d3c6481ea83c2912c339aeb94adc/pool.go#L160
+		// so unlimited is just max int
+		pgxConfig.MaxConns = math.MaxInt32
+	} else {
+		pgxConfig.MaxConns = int32(postgresStoreConfig.MaxOpenConnections)
+	}
+	pgxConfig.MinConns = int32(postgresStoreConfig.MinOpenConnections)
+	pgxConfig.MaxConnIdleTime = time.Duration(postgresStoreConfig.ConnectionTimeout) * time.Second
+	pgxConfig.MaxConnLifetime = postgresStoreConfig.MaxConnectionLifetime.Duration
+	pgxConfig.MaxConnLifetimeJitter = postgresStoreConfig.MaxConnectionLifetime.Duration
+	pgxConfig.HealthCheckPeriod = postgresStoreConfig.HealthCheckInterval.Duration
+	pgxConfig.ConnConfig.Tracer = otelpgx.NewTracer(otelpgx.WithAttributes(spanTypeSQLAttribute))
+	for _, customizer := range customizers {
+		customizer.Customize(pgxConfig)
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	return pgxpool.NewWithConfig(context.Background(), pgxConfig)
 }

--- a/pkg/plugins/common/postgres/pgx_listener.go
+++ b/pkg/plugins/common/postgres/pgx_listener.go
@@ -34,11 +34,7 @@ var _ Listener = (*PgxListener)(nil)
 // NewPgxListener will create and initialize a PgxListener which will automatically connect and listen to the provided channel.
 func NewPgxListener(config postgres.PostgresStoreConfig, logger logr.Logger) (Listener, error) {
 	ctx := context.Background()
-	connectionString, err := config.ConnectionString()
-	if err != nil {
-		return nil, err
-	}
-	db, err := pgxpool.New(context.Background(), connectionString)
+	db, err := ConnectToDbPgx(config)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
### Checklist prior to review

I noticed that we repeat the code of pool creation across the code as well as Kong Mesh extensions. We should make it a common public function so all settings are respected. Bonus point is that we get tracing with other DB pools

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [ ] [Link to relevant issue][1] as well as docs and UI issues --
- [ ] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [ ] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [ ] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [ ] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [ ] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
