### PR TITLE
docs(MADR): use hash-suffix for policy naming during KDS sync

### DIFF
--- a/docs/madr/decisions/029-kds-sync-hash-suffix.md
+++ b/docs/madr/decisions/029-kds-sync-hash-suffix.md
@@ -1,0 +1,117 @@
+# Use hash-suffix for policy naming during KDS sync
+
+* Status: accepted
+
+Technical Story: https://github.com/kumahq/kuma/issues/3837
+
+## Context and Problem Statement
+
+Primary keys are different for resources on Universal and Kubernetes:
+
+* Universal: (name, namespace, mesh, type)
+* Kubernetes: (name, namespace, kind)
+
+This results in inconsistent state when Global(Universal) and Zone(Kubernetes):
+
+* Global(Universal):
+```yaml
+type: MeshTrafficPermission
+name: allow-all
+mesh: mesh-1
+spec: {}
+---
+type: MeshTrafficPermission
+name: allow-all
+mesh: mesh-2
+spec: {}
+```
+
+* Zone(Kubernetes):
+```yaml
+kind: MeshTrafficPermission
+metadata:
+  name: allow-all
+  namespace: kuma-system
+  labels:
+    kuma.io/mesh: mesh-1
+spec: {}
+```
+
+MeshTrafficPermission from `mesh-2` is not synced to Zone because there is already MeshTrafficPermission with 
+a key `(allow-all, kuma-system, MeshTrafficPermission)`.
+
+## Considered Options
+
+* use hash-suffix for a name when syncing policies
+* remove `mesh` from Universal primary key
+
+## Decision Outcome
+
+Chosen option: use hash-suffix for a name when syncing policies
+
+### Implementation
+
+KDS has client and server, server owns the resource, client receive update when resource is changing. 
+Depending on the resource type Global and Zone CP both act as a client and as a server:
+* Policies are created on Global CP (KDS Server), Zone CP receives copies of these policies (KDS Client). 
+* Data plane proxies are created on Zone CP (KDS Server), Global CP receives copies of DPPs (KDS Client).
+
+When this feature is implemented, KDS Server is going to name resources differently. Resource name is constructed like:
+
+```go
+name := fmt.Sprintf("%s-%s", resourceName, hash(resourceMesh, resourceZone, resourceNamespace))
+```
+
+Since renaming is happening on the KDS Server, KDS Client doesn't need to know anything about hashes. 
+It will automatically remove old policies and create new policies. 
+
+Information that we're using to build hash has to be set as `labels` on the resource. For example, 
+when syncing DPP from Zone to Global we'll get: 
+
+* Zone(Kubernetes)
+```
+kind: Dataplane
+metadata:
+  name: my-dpp
+  namespace: my-ns
+  labels: 
+    kuma.io/mesh: mesh-1
+```
+
+* Global(Kubernetes)
+```yaml
+kind: Dataplane
+metadata:
+  name: my-dpp-{{hash("mesh-1", "zone-1", "my-ns")}}
+  namespace: kuma-system
+  labels: 
+    kuma.io/mesh: mesh-1
+    kuma.io/namespace: my-ns
+    kuma.io/zone: zone-1
+```
+
+Universal doesn't have `labels` in the resource schema. That's why we have to introduce a new attribute 
+in `resources` table in Postgres called `labels`. 
+
+Implementation can be shipped in 2 steps:
+
+1. Do a bare minimum to unblock [#3837](https://github.com/kumahq/kuma/issues/3837). This means we add hash-suffixes
+to policies when syncing them from Global to Zone. Since such hash-suffix is built using only `mesh` we don't need to
+implement Universal labels at this step. 
+
+2. Implement Universal labels. This will unblock the use-case with Zone(Universal) and Global(Kubernetes). Also solves
+the issue with long names on k8s (because we're adding zone+namespace when syncing DPPs). This step also unblocks the 
+ongoing work related to Zone to Global policy sync. When implementing this step make sure Inspect API works in Multizone.
+
+## Pros and Cons of the Options <!-- optional -->
+
+### Use hash-suffix for a name when syncing policies
+
+* Good, because it's not a breaking change 
+* Good, because solves the problem of long names on k8s
+* Bad, because name doesn't tell much about the origin of the policy (user has to check labels)
+
+### Remove `mesh` from Universal primary key
+
+* Good, because naming is the same on k8s and Universal
+* Bad, because it's a breaking change, upgrade path is quite tricky


### PR DESCRIPTION
### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [X] [Link to relevant issue][1] as well as docs and UI issues -- https://github.com/kumahq/kuma/issues/3837
- [X] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [X] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [X] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [X] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --
- [ ] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
