### PR TITLE
feat(insights): change metrics to milliseconds

### DIFF
--- a/pkg/insights/resyncer.go
+++ b/pkg/insights/resyncer.go
@@ -190,8 +190,8 @@ func (r *resyncer) Start(stop <-chan struct{}) error {
 					continue
 				}
 				startProcessingTime := r.now()
-				r.idleTime.Observe(startProcessingTime.Sub(start).Seconds())
-				r.timeToProcessItem.Observe(startProcessingTime.Sub(event.time).Seconds())
+				r.idleTime.Observe(float64(startProcessingTime.Sub(start).Milliseconds()))
+				r.timeToProcessItem.Observe(float64(startProcessingTime.Sub(event.time).Milliseconds()))
 				if event.flag&FlagService == FlagService {
 					err := r.createOrUpdateServiceInsight(ctx, event.tenantId, event.mesh)
 					if err != nil {
@@ -204,7 +204,7 @@ func (r *resyncer) Start(stop <-chan struct{}) error {
 						log.Error(err, "unable to resync MeshInsight", "event", event)
 					}
 				}
-				r.itemProcessingTime.Observe(time.Since(startProcessingTime).Seconds())
+				r.itemProcessingTime.Observe(float64(time.Since(startProcessingTime).Milliseconds()))
 			}
 		}
 	}()


### PR DESCRIPTION
### Checklist prior to review

The pattern across the codebase is to store time metrics in milliseconds.

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [ ] [Link to relevant issue][1] as well as docs and UI issues --
- [ ] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [ ] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [ ] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [ ] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --
- [ ] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
