### PR TITLE
fix(insights): increment steps only in ticker

### DIFF
--- a/pkg/insights/resyncer.go
+++ b/pkg/insights/resyncer.go
@@ -214,10 +214,10 @@ func (r *resyncer) Start(stop <-chan struct{}) error {
 	ticker := r.tick(r.minResyncInterval)
 	steps := 0
 	for {
-		steps += 1
 		select {
 		// We tick every minResyncInterval and flush the batch so we process updates
 		case now := <-ticker:
+			steps += 1
 			// Every fullResyncInterval we also add to the batch an update for each existing entities so we refresh all of them
 			tickCtx, cancelTimeout := context.WithDeadline(ctx, now.Add(r.minResyncInterval))
 			if steps == r.stepsBeforeFullResync {


### PR DESCRIPTION
### Checklist prior to review

We incremented steps on the ticker and on the event. If we had `steps` on a value of 19 but received two events, we would jump over the 20, which is a trigger for full resync. 

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [X] [Link to relevant issue][1] as well as docs and UI issues --
- [X] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [X] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [X] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [X] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --
- [X] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword

> Changelog: skip