### PR TITLE
feat(api-server): allow WebService customization in plugins

### DIFF
--- a/pkg/api-server/api_server_suite_test.go
+++ b/pkg/api-server/api_server_suite_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/emicklei/go-restful/v3"
 	. "github.com/onsi/gomega"
 
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
@@ -247,6 +248,7 @@ func tryStartApiServer(t *testApiServerConfigurer) (*api_server.ApiServer, kuma_
 			ZoneIngressToken: builtin.NewZoneIngressTokenIssuer(resManager),
 			ZoneToken:        builtin.NewZoneTokenIssuer(resManager),
 		},
+		func(*restful.WebService) error { return nil },
 	)
 	if err != nil {
 		return nil, cfg, stop, err

--- a/pkg/api-server/customization/customization_suite_test.go
+++ b/pkg/api-server/customization/customization_suite_test.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/emicklei/go-restful/v3"
 	. "github.com/onsi/gomega"
 
 	api_server "github.com/kumahq/kuma/pkg/api-server"
@@ -84,6 +85,7 @@ func createTestApiServer(store store.ResourceStore, config *config_api_server.Ap
 			ZoneIngressToken: builtin.NewZoneIngressTokenIssuer(resManager),
 			ZoneToken:        builtin.NewZoneTokenIssuer(resManager),
 		},
+		func(*restful.WebService) error { return nil },
 	)
 	Expect(err).ToNot(HaveOccurred())
 	return apiServer

--- a/pkg/api-server/server.go
+++ b/pkg/api-server/server.go
@@ -99,6 +99,7 @@ func NewApiServer(
 	access runtime.Access,
 	envoyAdminClient admin.EnvoyAdminClient,
 	tokenIssuers builtin.TokenIssuers,
+	wsCustomize func(*restful.WebService) error,
 ) (*ApiServer, error) {
 	serverConfig := cfg.ApiServer
 	container := restful.NewContainer()
@@ -158,6 +159,12 @@ func NewApiServer(
 		return nil, errors.Wrap(err, "could not create index webservice")
 	}
 	addWhoamiEndpoints(ws)
+
+	ws.SetDynamicRoutes(true)
+	if err := wsCustomize(ws); err != nil {
+		return nil, errors.Wrap(err, "couldn't customize webservice")
+	}
+
 	container.Add(ws)
 
 	path := cfg.ApiServer.BasePath
@@ -479,6 +486,7 @@ func SetupServer(rt runtime.Runtime) error {
 		rt.Access(),
 		rt.EnvoyAdminClient(),
 		rt.TokenIssuers(),
+		rt.APIWebServiceCustomize(),
 	)
 	if err != nil {
 		return err

--- a/pkg/core/runtime/runtime.go
+++ b/pkg/core/runtime/runtime.go
@@ -5,6 +5,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/emicklei/go-restful/v3"
+
 	"github.com/kumahq/kuma/pkg/api-server/authn"
 	api_server "github.com/kumahq/kuma/pkg/api-server/customization"
 	kuma_cp "github.com/kumahq/kuma/pkg/config/app/kuma-cp"
@@ -82,6 +84,7 @@ type RuntimeContext interface {
 	InterCPClientPool() *client.Pool
 	PgxConfigCustomizationFn() config.PgxConfigCustomization
 	Tenants() multitenant.Tenants
+	APIWebServiceCustomize() func(ws *restful.WebService) error
 }
 
 type Access struct {
@@ -169,6 +172,7 @@ type runtimeContext struct {
 	interCpPool              *client.Pool
 	pgxConfigCustomizationFn config.PgxConfigCustomization
 	tenants                  multitenant.Tenants
+	apiWebServiceCustomize   func(*restful.WebService) error
 }
 
 func (rc *runtimeContext) Metrics() metrics.Metrics {
@@ -289,4 +293,11 @@ func (rc *runtimeContext) PgxConfigCustomizationFn() config.PgxConfigCustomizati
 
 func (rc *runtimeContext) Tenants() multitenant.Tenants {
 	return rc.tenants
+}
+
+func (rc *runtimeContext) APIWebServiceCustomize() func(*restful.WebService) error {
+	if rc.apiWebServiceCustomize == nil {
+		return func(*restful.WebService) error { return nil }
+	}
+	return rc.apiWebServiceCustomize
 }

--- a/pkg/test/kds/setup/server.go
+++ b/pkg/test/kds/setup/server.go
@@ -3,6 +3,8 @@ package setup
 import (
 	"time"
 
+	"github.com/emicklei/go-restful/v3"
+
 	kuma_cp "github.com/kumahq/kuma/pkg/config/app/kuma-cp"
 	"github.com/kumahq/kuma/pkg/core"
 	"github.com/kumahq/kuma/pkg/core/resources/manager"
@@ -46,6 +48,10 @@ func (t *testRuntimeContext) PgxConfigCustomizationFn() config.PgxConfigCustomiz
 
 func (t *testRuntimeContext) Tenants() multitenant.Tenants {
 	return t.tenants
+}
+
+func (t *testRuntimeContext) APIWebServiceCustomize() func(*restful.WebService) error {
+	return func(*restful.WebService) error { return nil }
 }
 
 func (t *testRuntimeContext) Add(c ...component.Component) error {


### PR DESCRIPTION
### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --
- [x] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
