### PR TITLE
test(e2e_env): don't cleanup if suite is failing

### DIFF
--- a/test/e2e_env/kubernetes/kubernetes_suite_test.go
+++ b/test/e2e_env/kubernetes/kubernetes_suite_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/kumahq/kuma/test/e2e_env/kubernetes/reachableservices"
 	"github.com/kumahq/kuma/test/e2e_env/kubernetes/trafficlog"
 	"github.com/kumahq/kuma/test/e2e_env/kubernetes/virtualoutbound"
+	. "github.com/kumahq/kuma/test/framework"
 	"github.com/kumahq/kuma/test/framework/envs/kubernetes"
 )
 
@@ -40,7 +41,7 @@ func TestE2E(t *testing.T) {
 	test.RunE2ESpecs(t, "E2E Kubernetes Suite")
 }
 
-var _ = SynchronizedBeforeSuite(kubernetes.SetupAndGetState, kubernetes.RestoreState)
+var _ = E2ESynchronizedBeforeSuite(kubernetes.SetupAndGetState, kubernetes.RestoreState)
 
 // SynchronizedAfterSuite keeps the main process alive until all other processes finish.
 // Otherwise, we would close port-forward to the CP and remaining tests executed in different processes may fail.

--- a/test/e2e_env/multizone/multizone_suite_test.go
+++ b/test/e2e_env/multizone/multizone_suite_test.go
@@ -34,7 +34,7 @@ func TestE2E(t *testing.T) {
 }
 
 var (
-	_ = SynchronizedBeforeSuite(multizone.SetupAndGetState, multizone.RestoreState)
+	_ = E2ESynchronizedBeforeSuite(multizone.SetupAndGetState, multizone.RestoreState)
 	_ = ReportAfterSuite("cleanup", func(report Report) {
 		if Config.CleanupLogsOnSuccess {
 			universal_logs.CleanupIfSuccess(Config.UniversalE2ELogsPath, report)

--- a/test/e2e_env/universal/universal_suite_test.go
+++ b/test/e2e_env/universal/universal_suite_test.go
@@ -50,7 +50,7 @@ func TestE2E(t *testing.T) {
 }
 
 var (
-	_ = SynchronizedBeforeSuite(universal.SetupAndGetState, universal.RestoreState)
+	_ = E2ESynchronizedBeforeSuite(universal.SetupAndGetState, universal.RestoreState)
 	_ = ReportAfterSuite("cleanup", func(report Report) {
 		if Config.CleanupLogsOnSuccess {
 			universal_logs.CleanupIfSuccess(Config.UniversalE2ELogsPath, report)

--- a/test/framework/ginkgo.go
+++ b/test/framework/ginkgo.go
@@ -37,6 +37,15 @@ func E2EAfterSuite(fn func()) bool {
 	return ginkgo.AfterSuite(doIfNoSkipCleanup(fn))
 }
 
+func E2ESynchronizedBeforeSuite(process1Body interface{}, allProcessBody interface{}, args ...interface{}) bool {
+	ginkgo.AfterEach(func() {
+		if ginkgo.CurrentSpecReport().Failed() {
+			suiteFailed = true
+		}
+	})
+	return ginkgo.SynchronizedBeforeSuite(process1Body, allProcessBody, args...)
+}
+
 func E2EBeforeSuite(fn func()) bool {
 	ginkgo.AfterEach(func() {
 		if ginkgo.CurrentSpecReport().Failed() {


### PR DESCRIPTION
This has been missing for a while...

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --
- [x] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
