### PR TITLE
fix(egress): use MeshHTTPRoutes for generation

### DIFF
--- a/api/common/v1alpha1/ref.go
+++ b/api/common/v1alpha1/ref.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 
 	"golang.org/x/exp/maps"
+
+	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 )
 
 type TargetRefKind string
@@ -59,6 +61,29 @@ func (in TargetRef) Hash() TargetRefHash {
 		orderedTags = append(orderedTags, fmt.Sprintf("%s=%s", k, in.Tags[k]))
 	}
 	return TargetRefHash(fmt.Sprintf("%s/%s/%s/%s", in.Kind, in.Name, strings.Join(orderedTags, "/"), in.Mesh))
+}
+
+func (in TargetRef) EnvoyTags() (map[string]string, bool) {
+	var service string
+	tags := map[string]string{}
+
+	switch in.Kind {
+	case MeshService:
+		service = in.Name
+	case MeshServiceSubset:
+		service = in.Name
+		tags = in.Tags
+	case Mesh:
+		service = mesh_proto.MatchAllTag
+	case MeshSubset:
+		service = mesh_proto.MatchAllTag
+		tags = in.Tags
+	default:
+		return nil, false
+	}
+
+	tags[mesh_proto.ServiceTag] = service
+	return tags, true
 }
 
 // BackendRef defines where to forward traffic.

--- a/pkg/core/xds/types.go
+++ b/pkg/core/xds/types.go
@@ -177,7 +177,7 @@ type ExternalServiceDynamicPolicies map[ServiceName]PluginOriginatedPolicies
 
 type MeshResources struct {
 	Mesh                           *core_mesh.MeshResource
-	TrafficRoutes                  []*core_mesh.TrafficRouteResource
+	Resources                      map[core_model.ResourceType]core_model.ResourceList
 	ExternalServices               []*core_mesh.ExternalServiceResource
 	ExternalServicePermissionMap   ExternalServicePermissionMap
 	EndpointMap                    EndpointMap

--- a/pkg/xds/generator/egress/external_services_generator.go
+++ b/pkg/xds/generator/egress/external_services_generator.go
@@ -30,7 +30,7 @@ func (g *ExternalServicesGenerator) Generate(
 	resources := core_xds.NewResourceSet()
 	apiVersion := proxy.APIVersion
 	endpointMap := meshResources.EndpointMap
-	destinations := buildDestinations(meshResources.TrafficRoutes)
+	destinations := buildDestinations(meshResources.Resources[core_mesh.TrafficRouteType])
 	services := g.buildServices(endpointMap, zone, meshResources)
 
 	g.addFilterChains(

--- a/pkg/xds/generator/egress/external_services_generator.go
+++ b/pkg/xds/generator/egress/external_services_generator.go
@@ -30,7 +30,11 @@ func (g *ExternalServicesGenerator) Generate(
 	resources := core_xds.NewResourceSet()
 	apiVersion := proxy.APIVersion
 	endpointMap := meshResources.EndpointMap
-	destinations := buildDestinations(meshResources.Resources[core_mesh.TrafficRouteType])
+	trafficRoutes := meshResources.Resources[core_mesh.TrafficRouteType].(*core_mesh.TrafficRouteResourceList)
+	destinations := buildDestinations(
+		trafficRoutes.Items,
+		nil,
+	)
 	services := g.buildServices(endpointMap, zone, meshResources)
 
 	g.addFilterChains(

--- a/pkg/xds/generator/egress/external_services_generator.go
+++ b/pkg/xds/generator/egress/external_services_generator.go
@@ -6,6 +6,7 @@ import (
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	core_xds "github.com/kumahq/kuma/pkg/core/xds"
+	meshhttproute_api "github.com/kumahq/kuma/pkg/plugins/policies/meshhttproute/api/v1alpha1"
 	xds_context "github.com/kumahq/kuma/pkg/xds/context"
 	envoy_common "github.com/kumahq/kuma/pkg/xds/envoy"
 	envoy_clusters "github.com/kumahq/kuma/pkg/xds/envoy/clusters"
@@ -31,9 +32,10 @@ func (g *ExternalServicesGenerator) Generate(
 	apiVersion := proxy.APIVersion
 	endpointMap := meshResources.EndpointMap
 	trafficRoutes := meshResources.Resources[core_mesh.TrafficRouteType].(*core_mesh.TrafficRouteResourceList)
+	httpRoutes := meshResources.Resources[meshhttproute_api.MeshHTTPRouteType].(*meshhttproute_api.MeshHTTPRouteResourceList)
 	destinations := buildDestinations(
 		trafficRoutes.Items,
-		nil,
+		httpRoutes.Items,
 	)
 	services := g.buildServices(endpointMap, zone, meshResources)
 

--- a/pkg/xds/generator/egress/generator.go
+++ b/pkg/xds/generator/egress/generator.go
@@ -9,6 +9,7 @@ import (
 	"github.com/kumahq/kuma/pkg/core"
 	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	core_xds "github.com/kumahq/kuma/pkg/core/xds"
+	meshhttproute_api "github.com/kumahq/kuma/pkg/plugins/policies/meshhttproute/api/v1alpha1"
 	xds_context "github.com/kumahq/kuma/pkg/xds/context"
 	envoy_common "github.com/kumahq/kuma/pkg/xds/envoy"
 	envoy_listeners "github.com/kumahq/kuma/pkg/xds/envoy/listeners"
@@ -126,6 +127,7 @@ func (g Generator) Generate(
 
 func buildDestinations(
 	trafficRoutes []*core_mesh.TrafficRouteResource,
+	_ []*meshhttproute_api.MeshHTTPRouteResource,
 ) map[string][]envoy_tags.Tags {
 	destinations := map[string][]envoy_tags.Tags{}
 

--- a/pkg/xds/generator/egress/generator.go
+++ b/pkg/xds/generator/egress/generator.go
@@ -14,6 +14,7 @@ import (
 	envoy_common "github.com/kumahq/kuma/pkg/xds/envoy"
 	envoy_listeners "github.com/kumahq/kuma/pkg/xds/envoy/listeners"
 	envoy_tags "github.com/kumahq/kuma/pkg/xds/envoy/tags"
+	"github.com/kumahq/kuma/pkg/xds/generator/routes"
 	generator_secrets "github.com/kumahq/kuma/pkg/xds/generator/secrets"
 )
 
@@ -127,7 +128,7 @@ func (g Generator) Generate(
 
 func buildDestinations(
 	trafficRoutes []*core_mesh.TrafficRouteResource,
-	_ []*meshhttproute_api.MeshHTTPRouteResource,
+	meshHTTPRoutes []*meshhttproute_api.MeshHTTPRouteResource,
 ) map[string][]envoy_tags.Tags {
 	destinations := map[string][]envoy_tags.Tags{}
 
@@ -144,6 +145,8 @@ func buildDestinations(
 			}
 		}
 	}
+
+	routes.AddMeshHTTPRouteDestinations(meshHTTPRoutes, destinations)
 
 	return destinations
 }

--- a/pkg/xds/generator/egress/generator_test.go
+++ b/pkg/xds/generator/egress/generator_test.go
@@ -99,8 +99,9 @@ var _ = Describe("EgressGenerator", func() {
 						meshResourcesMap[meshName] = &core_xds.MeshResources{}
 					}
 
-					meshResourcesMap[meshName].TrafficRoutes = append(
-						meshResourcesMap[meshName].TrafficRoutes,
+					routeList := meshResourcesMap[meshName].Resources[core_mesh.TrafficRouteType].(*core_mesh.TrafficRouteResourceList)
+					routeList.Items = append(
+						routeList.Items,
 						res.(*core_mesh.TrafficRouteResource),
 					)
 				}

--- a/pkg/xds/generator/egress/generator_test.go
+++ b/pkg/xds/generator/egress/generator_test.go
@@ -207,5 +207,13 @@ var _ = Describe("EgressGenerator", func() {
 			fileWithResourcesName: "06.mixed-services-with-external-in-other-zone.yaml",
 			expected:              "06.mixed-services-with-external-in-other-zone.golden.yaml",
 		}),
+		Entry("use default if a MeshHTTPRoute exists, internal", testCase{
+			fileWithResourcesName: "traffic-by-default-meshhttproute.yaml",
+			expected:              "traffic-by-default-meshhttproute.golden.yaml",
+		}),
+		Entry("subsets with MeshHTTPRoute, internal", testCase{
+			fileWithResourcesName: "subsets-with-meshhttproute.yaml",
+			expected:              "subsets-with-meshhttproute.golden.yaml",
+		}),
 	)
 })

--- a/pkg/xds/generator/egress/internal_services_generator.go
+++ b/pkg/xds/generator/egress/internal_services_generator.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
+	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	core_xds "github.com/kumahq/kuma/pkg/core/xds"
 	xds_context "github.com/kumahq/kuma/pkg/xds/context"
 	envoy_common "github.com/kumahq/kuma/pkg/xds/envoy"
@@ -29,7 +30,11 @@ func (g *InternalServicesGenerator) Generate(
 	zone := xdsCtx.ControlPlane.Zone
 	apiVersion := proxy.APIVersion
 	endpointMap := meshResources.EndpointMap
-	destinations := buildDestinations(meshResources.Resources[core_mesh.TrafficRouteType])
+	trafficRoutes := meshResources.Resources[core_mesh.TrafficRouteType].(*core_mesh.TrafficRouteResourceList)
+	destinations := buildDestinations(
+		trafficRoutes.Items,
+		nil,
+	)
 	services := g.buildServices(endpointMap, meshResources.Mesh.ZoneEgressEnabled(), zone)
 	meshName := meshResources.Mesh.GetMeta().GetName()
 

--- a/pkg/xds/generator/egress/internal_services_generator.go
+++ b/pkg/xds/generator/egress/internal_services_generator.go
@@ -29,7 +29,7 @@ func (g *InternalServicesGenerator) Generate(
 	zone := xdsCtx.ControlPlane.Zone
 	apiVersion := proxy.APIVersion
 	endpointMap := meshResources.EndpointMap
-	destinations := buildDestinations(meshResources.TrafficRoutes)
+	destinations := buildDestinations(meshResources.Resources[core_mesh.TrafficRouteType])
 	services := g.buildServices(endpointMap, meshResources.Mesh.ZoneEgressEnabled(), zone)
 	meshName := meshResources.Mesh.GetMeta().GetName()
 

--- a/pkg/xds/generator/egress/internal_services_generator.go
+++ b/pkg/xds/generator/egress/internal_services_generator.go
@@ -6,6 +6,7 @@ import (
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	core_xds "github.com/kumahq/kuma/pkg/core/xds"
+	meshhttproute_api "github.com/kumahq/kuma/pkg/plugins/policies/meshhttproute/api/v1alpha1"
 	xds_context "github.com/kumahq/kuma/pkg/xds/context"
 	envoy_common "github.com/kumahq/kuma/pkg/xds/envoy"
 	envoy_clusters "github.com/kumahq/kuma/pkg/xds/envoy/clusters"
@@ -31,9 +32,10 @@ func (g *InternalServicesGenerator) Generate(
 	apiVersion := proxy.APIVersion
 	endpointMap := meshResources.EndpointMap
 	trafficRoutes := meshResources.Resources[core_mesh.TrafficRouteType].(*core_mesh.TrafficRouteResourceList)
+	httpRoutes := meshResources.Resources[meshhttproute_api.MeshHTTPRouteType].(*meshhttproute_api.MeshHTTPRouteResourceList)
 	destinations := buildDestinations(
 		trafficRoutes.Items,
-		nil,
+		httpRoutes.Items,
 	)
 	services := g.buildServices(endpointMap, meshResources.Mesh.ZoneEgressEnabled(), zone)
 	meshName := meshResources.Mesh.GetMeta().GetName()

--- a/pkg/xds/generator/egress/testdata/input/subsets-with-meshhttproute.yaml
+++ b/pkg/xds/generator/egress/testdata/input/subsets-with-meshhttproute.yaml
@@ -1,0 +1,68 @@
+type: Mesh
+name: mesh-1
+mtls:
+  enabledBackend: ca-1
+  backends:
+  - name: ca-1
+    type: builtin
+---
+type: ZoneEgress
+name: zoneegress-1
+zone: zone-1
+networking:
+  address: 192.168.0.1
+  port: 10002
+---
+type: TrafficPermission
+name: allow-all-traffic
+mesh: mesh-1
+sources:
+- match:
+    kuma.io/service: '*'
+destinations:
+- match:
+    kuma.io/service: '*'
+---
+type: MeshHTTPRoute
+name: route-1
+mesh: mesh-1
+spec:
+  targetRef:
+    kind: MeshService
+    name: service-in-zone-1
+  to:
+    - targetRef:
+        kind: MeshService
+        name: service-in-zone-2
+      rules:
+        - matches:
+          - path:
+              value: /
+              type: PathPrefix
+          default:
+            backendRefs:
+              - kind: MeshServiceSubset
+                name: service-in-zone-2
+                weight: 1
+                tags:
+                  version: v1
+              - kind: MeshServiceSubset
+                name: service-in-zone-2
+                weight: 1
+                tags:
+                  version: v2
+---
+type: ZoneIngress
+name: zone-2-zoneingress-1
+zone: zone-2
+networking:
+  address: 10.0.0.254
+  advertisedAddress: 10.0.0.254
+  port: 10001
+  advertisedPort: 10001
+availableServices:
+- tags:
+    kuma.io/service: service-in-zone-2
+    kuma.io/protocol: http
+  instances: 3
+  mesh: mesh-1

--- a/pkg/xds/generator/egress/testdata/input/traffic-by-default-meshhttproute.yaml
+++ b/pkg/xds/generator/egress/testdata/input/traffic-by-default-meshhttproute.yaml
@@ -1,0 +1,60 @@
+type: Mesh
+name: mesh-1
+mtls:
+  enabledBackend: ca-1
+  backends:
+    - name: ca-1
+      type: builtin
+---
+type: ZoneEgress
+name: zoneegress-1
+zone: zone-1
+networking:
+  address: 192.168.0.1
+  port: 10002
+---
+type: TrafficPermission
+name: allow-all-traffic
+mesh: mesh-1
+sources:
+  - match:
+      kuma.io/service: "*"
+destinations:
+  - match:
+      kuma.io/service: "*"
+---
+type: MeshHTTPRoute
+name: route-1
+mesh: mesh-1
+spec:
+  targetRef:
+    kind: MeshService
+    name: other-service
+  to:
+    - targetRef:
+        kind: MeshService
+        name: non-existent
+      rules:
+        - matches:
+            - path:
+                value: /
+                type: PathPrefix
+          default:
+            backendRefs:
+              - kind: MeshService
+                name: non-existent
+---
+type: ZoneIngress
+name: zone-2-zoneingress-1
+zone: zone-2
+networking:
+  address: 10.0.0.254
+  advertisedAddress: 10.0.0.254
+  port: 10001
+  advertisedPort: 10001
+availableServices:
+  - tags:
+      kuma.io/service: service-in-zone-2
+      kuma.io/protocol: http
+    instances: 3
+    mesh: mesh-1

--- a/pkg/xds/generator/egress/testdata/subsets-with-meshhttproute.golden.yaml
+++ b/pkg/xds/generator/egress/testdata/subsets-with-meshhttproute.golden.yaml
@@ -1,0 +1,101 @@
+resources:
+- name: mesh-1:service-in-zone-2
+  resource:
+    '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
+    altStatName: mesh-1_service-in-zone-2
+    connectTimeout: 10s
+    edsClusterConfig:
+      edsConfig:
+        ads: {}
+        resourceApiVersion: V3
+    lbSubsetConfig:
+      fallbackPolicy: ANY_ENDPOINT
+      subsetSelectors:
+      - fallbackPolicy: NO_FALLBACK
+        keys:
+        - mesh
+      - fallbackPolicy: NO_FALLBACK
+        keys:
+        - mesh
+        - version
+    name: mesh-1:service-in-zone-2
+    type: EDS
+- name: mesh-1:service-in-zone-2
+  resource:
+    '@type': type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment
+    clusterName: mesh-1:service-in-zone-2
+    endpoints:
+    - lbEndpoints:
+      - endpoint:
+          address:
+            socketAddress:
+              address: 10.0.0.254
+              portValue: 10001
+        loadBalancingWeight: 3
+        metadata:
+          filterMetadata:
+            envoy.lb:
+              kuma.io/protocol: http
+              mesh: mesh-1
+            envoy.transport_socket_match:
+              kuma.io/protocol: http
+              mesh: mesh-1
+- name: inbound:192.168.0.1:10002
+  resource:
+    '@type': type.googleapis.com/envoy.config.listener.v3.Listener
+    address:
+      socketAddress:
+        address: 192.168.0.1
+        portValue: 10002
+    enableReusePort: false
+    filterChains:
+    - filterChainMatch:
+        serverNames:
+        - service-in-zone-2{mesh=mesh-1,version=v1}
+        transportProtocol: tls
+      filters:
+      - name: envoy.filters.network.tcp_proxy
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
+          cluster: mesh-1:service-in-zone-2
+          metadataMatch:
+            filterMetadata:
+              envoy.lb:
+                mesh: mesh-1
+                version: v1
+          statPrefix: mesh-1_service-in-zone-2
+    - filterChainMatch:
+        serverNames:
+        - service-in-zone-2{mesh=mesh-1,version=v2}
+        transportProtocol: tls
+      filters:
+      - name: envoy.filters.network.tcp_proxy
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
+          cluster: mesh-1:service-in-zone-2
+          metadataMatch:
+            filterMetadata:
+              envoy.lb:
+                mesh: mesh-1
+                version: v2
+          statPrefix: mesh-1_service-in-zone-2
+    - filterChainMatch:
+        serverNames:
+        - service-in-zone-2{mesh=mesh-1}
+        transportProtocol: tls
+      filters:
+      - name: envoy.filters.network.tcp_proxy
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
+          cluster: mesh-1:service-in-zone-2
+          metadataMatch:
+            filterMetadata:
+              envoy.lb:
+                mesh: mesh-1
+          statPrefix: mesh-1_service-in-zone-2
+    listenerFilters:
+    - name: envoy.filters.listener.tls_inspector
+      typedConfig:
+        '@type': type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
+    name: inbound:192.168.0.1:10002
+    trafficDirection: INBOUND

--- a/pkg/xds/generator/egress/testdata/traffic-by-default-meshhttproute.golden.yaml
+++ b/pkg/xds/generator/egress/testdata/traffic-by-default-meshhttproute.golden.yaml
@@ -1,0 +1,67 @@
+resources:
+- name: mesh-1:service-in-zone-2
+  resource:
+    '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
+    altStatName: mesh-1_service-in-zone-2
+    connectTimeout: 10s
+    edsClusterConfig:
+      edsConfig:
+        ads: {}
+        resourceApiVersion: V3
+    lbSubsetConfig:
+      fallbackPolicy: ANY_ENDPOINT
+      subsetSelectors:
+      - fallbackPolicy: NO_FALLBACK
+        keys:
+        - mesh
+    name: mesh-1:service-in-zone-2
+    type: EDS
+- name: mesh-1:service-in-zone-2
+  resource:
+    '@type': type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment
+    clusterName: mesh-1:service-in-zone-2
+    endpoints:
+    - lbEndpoints:
+      - endpoint:
+          address:
+            socketAddress:
+              address: 10.0.0.254
+              portValue: 10001
+        loadBalancingWeight: 3
+        metadata:
+          filterMetadata:
+            envoy.lb:
+              kuma.io/protocol: http
+              mesh: mesh-1
+            envoy.transport_socket_match:
+              kuma.io/protocol: http
+              mesh: mesh-1
+- name: inbound:192.168.0.1:10002
+  resource:
+    '@type': type.googleapis.com/envoy.config.listener.v3.Listener
+    address:
+      socketAddress:
+        address: 192.168.0.1
+        portValue: 10002
+    enableReusePort: false
+    filterChains:
+    - filterChainMatch:
+        serverNames:
+        - service-in-zone-2{mesh=mesh-1}
+        transportProtocol: tls
+      filters:
+      - name: envoy.filters.network.tcp_proxy
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
+          cluster: mesh-1:service-in-zone-2
+          metadataMatch:
+            filterMetadata:
+              envoy.lb:
+                mesh: mesh-1
+          statPrefix: mesh-1_service-in-zone-2
+    listenerFilters:
+    - name: envoy.filters.listener.tls_inspector
+      typedConfig:
+        '@type': type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
+    name: inbound:192.168.0.1:10002
+    trafficDirection: INBOUND

--- a/pkg/xds/generator/ingress_generator.go
+++ b/pkg/xds/generator/ingress_generator.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"sort"
 
-	common_api "github.com/kumahq/kuma/api/common/v1alpha1"
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	core_xds "github.com/kumahq/kuma/pkg/core/xds"
@@ -139,28 +138,6 @@ func (i IngressGenerator) generateLDS(
 	}
 
 	return inboundListenerBuilder.Build()
-}
-
-func tagsFromTargetRef(targetRef common_api.TargetRef) (envoy_tags.Tags, bool) {
-	var service string
-	tags := envoy_tags.Tags{}
-
-	switch targetRef.Kind {
-	case common_api.MeshService:
-		service = targetRef.Name
-	case common_api.MeshServiceSubset:
-		service = targetRef.Name
-		tags = targetRef.Tags
-	case common_api.Mesh:
-		service = mesh_proto.MatchAllTag
-	case common_api.MeshSubset:
-		service = mesh_proto.MatchAllTag
-		tags = targetRef.Tags
-	default:
-		return nil, false
-	}
-
-	return tags.WithTags(mesh_proto.ServiceTag, service), true
 }
 
 func (_ IngressGenerator) services(mr *core_xds.MeshIngressResources) []string {

--- a/pkg/xds/generator/ingress_generator_destinations.go
+++ b/pkg/xds/generator/ingress_generator_destinations.go
@@ -1,18 +1,14 @@
 package generator
 
 import (
-	"reflect"
-
-	"golang.org/x/exp/slices"
-
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	core_xds "github.com/kumahq/kuma/pkg/core/xds"
 	"github.com/kumahq/kuma/pkg/dns"
 	meshhttproute_api "github.com/kumahq/kuma/pkg/plugins/policies/meshhttproute/api/v1alpha1"
-	"github.com/kumahq/kuma/pkg/util/pointer"
 	xds_context "github.com/kumahq/kuma/pkg/xds/context"
 	envoy_tags "github.com/kumahq/kuma/pkg/xds/envoy/tags"
+	"github.com/kumahq/kuma/pkg/xds/generator/routes"
 )
 
 type destinations map[string]map[string][]envoy_tags.Tags
@@ -33,7 +29,7 @@ func buildDestinations(ingressProxy *core_xds.ZoneIngressProxy) destinations {
 		destForMesh := map[string][]envoy_tags.Tags{}
 		meshHTTPRoutes := res.ListOrEmpty(meshhttproute_api.MeshHTTPRouteType).(*meshhttproute_api.MeshHTTPRouteResourceList).Items
 		addTrafficRouteDestinations(res.TrafficRoutes().Items, destForMesh)
-		addMeshHTTPRouteDestinations(meshHTTPRoutes, destForMesh)
+		routes.AddMeshHTTPRouteDestinations(meshHTTPRoutes, destForMesh)
 		addGatewayRouteDestinations(res.GatewayRoutes().Items, destForMesh)
 		addMeshGatewayDestinations(res.MeshGateways().Items, destForMesh)
 		addVirtualOutboundDestinations(res.VirtualOutbounds().Items, availableSvcsByMesh[meshResources.Mesh.GetMeta().GetName()], destForMesh)
@@ -97,7 +93,7 @@ func addGatewayRouteDestinations(
 	}
 
 	for _, backend := range backends {
-		addDestination(backend.Destination, destinations)
+		routes.AddDestination(backend.Destination, destinations)
 	}
 }
 
@@ -107,95 +103,15 @@ func addTrafficRouteDestinations(
 ) {
 	for _, policy := range policies {
 		for _, split := range policy.Spec.Conf.GetSplitWithDestination() {
-			addDestination(split.Destination, destinations)
+			routes.AddDestination(split.Destination, destinations)
 		}
 
 		for _, http := range policy.Spec.Conf.Http {
 			for _, split := range http.GetSplitWithDestination() {
-				addDestination(split.Destination, destinations)
+				routes.AddDestination(split.Destination, destinations)
 			}
 		}
 	}
-}
-
-func addMeshHTTPRouteDestinations(
-	policies []*meshhttproute_api.MeshHTTPRouteResource,
-	destinations map[string][]envoy_tags.Tags,
-) {
-	addTrafficFlowByDefaultDestinationIfMeshHTTPRoutesExist(policies, destinations)
-
-	// Note that we're not merging these resources, but that's OK because the
-	// set of destinations after merging is a subset of the set we get here by
-	// iterating through them.
-	for _, policy := range policies {
-		for _, to := range policy.Spec.To {
-			if toTags, ok := tagsFromTargetRef(to.TargetRef); ok {
-				addMeshHTTPRouteToDestinations(to.Rules, toTags, destinations)
-			}
-		}
-	}
-}
-
-func addMeshHTTPRouteToDestinations(
-	rules []meshhttproute_api.Rule,
-	toTags envoy_tags.Tags,
-	destinations map[string][]envoy_tags.Tags,
-) {
-	for _, rule := range rules {
-		if rule.Default.BackendRefs == nil {
-			addDestination(toTags, destinations)
-			continue
-		}
-
-		for _, backendRef := range pointer.Deref(rule.Default.BackendRefs) {
-			if tags, ok := tagsFromTargetRef(backendRef.TargetRef); ok {
-				addDestination(tags, destinations)
-			}
-		}
-	}
-}
-
-func addDestination(tags map[string]string, destinations map[string][]envoy_tags.Tags) {
-	service := tags[mesh_proto.ServiceTag]
-	destinations[service] = append(destinations[service], tags)
-}
-
-// addTrafficFlowByDefaultDestinationIfMeshHTTPRoutesExist makes sure that when
-// at least one MeshHTTPRoute policy exists there will be a "match all"
-// destination pointing to all services (kuma.io/service:* -> kuma.io/service:*)
-// This logic is necessary because of conflicting behaviors of TrafficRoute and
-// MeshHTTPRoute policies. TrafficRoute expects that by default traffic doesn't
-// flow, and there is necessary TrafficRoute with appropriate configuration
-// to make communication between services possible. MeshHTTPRoute on the other
-// hand expects the traffic to flow by default. As a result, when there is
-// at least one MeshHTTPRoute policy present, traffic between services will flow
-// by default, when there is none, it will flow, when appropriate TrafficRoute
-// policy will exist.
-func addTrafficFlowByDefaultDestinationIfMeshHTTPRoutesExist(
-	policies []*meshhttproute_api.MeshHTTPRouteResource,
-	destinations map[string][]envoy_tags.Tags,
-) {
-	// If there are no MeshHTTPRoutes, we are not modifying destinations
-	if len(policies) == 0 {
-		return
-	}
-
-	// We need to add a destination to route any service to any instance of
-	// that service
-	matchAllTags := envoy_tags.Tags{mesh_proto.ServiceTag: mesh_proto.MatchAllTag}
-	matchAllDestinations := destinations[mesh_proto.MatchAllTag]
-	foundAllServicesDestination := slices.ContainsFunc(
-		matchAllDestinations,
-		func(tagsElem envoy_tags.Tags) bool {
-			return reflect.DeepEqual(tagsElem, matchAllTags)
-		},
-	)
-
-	if !foundAllServicesDestination {
-		matchAllDestinations = append(matchAllDestinations, matchAllTags)
-	}
-
-	destinations[mesh_proto.MatchAllTag] = matchAllDestinations
 }
 
 func addVirtualOutboundDestinations(

--- a/pkg/xds/generator/routes/routes.go
+++ b/pkg/xds/generator/routes/routes.go
@@ -1,0 +1,92 @@
+package routes
+
+import (
+	"reflect"
+
+	"golang.org/x/exp/slices"
+
+	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
+	meshhttproute_api "github.com/kumahq/kuma/pkg/plugins/policies/meshhttproute/api/v1alpha1"
+	"github.com/kumahq/kuma/pkg/util/pointer"
+	envoy_tags "github.com/kumahq/kuma/pkg/xds/envoy/tags"
+)
+
+func AddDestination(tags map[string]string, destinations map[string][]envoy_tags.Tags) {
+	service := tags[mesh_proto.ServiceTag]
+	destinations[service] = append(destinations[service], tags)
+}
+
+func AddMeshHTTPRouteDestinations(
+	policies []*meshhttproute_api.MeshHTTPRouteResource,
+	destinations map[string][]envoy_tags.Tags,
+) {
+	addTrafficFlowByDefaultDestinationIfMeshHTTPRoutesExist(policies, destinations)
+
+	// Note that we're not merging these resources, but that's OK because the
+	// set of destinations after merging is a subset of the set we get here by
+	// iterating through them.
+	for _, policy := range policies {
+		for _, to := range policy.Spec.To {
+			if toTags, ok := to.TargetRef.EnvoyTags(); ok {
+				addMeshHTTPRouteToDestinations(to.Rules, toTags, destinations)
+			}
+		}
+	}
+}
+
+func addMeshHTTPRouteToDestinations(
+	rules []meshhttproute_api.Rule,
+	toTags envoy_tags.Tags,
+	destinations map[string][]envoy_tags.Tags,
+) {
+	for _, rule := range rules {
+		if rule.Default.BackendRefs == nil {
+			AddDestination(toTags, destinations)
+			continue
+		}
+
+		for _, backendRef := range pointer.Deref(rule.Default.BackendRefs) {
+			if tags, ok := backendRef.TargetRef.EnvoyTags(); ok {
+				AddDestination(tags, destinations)
+			}
+		}
+	}
+}
+
+// addTrafficFlowByDefaultDestinationIfMeshHTTPRoutesExist makes sure that when
+// at least one MeshHTTPRoute policy exists there will be a "match all"
+// destination pointing to all services (kuma.io/service:* -> kuma.io/service:*)
+// This logic is necessary because of conflicting behaviors of TrafficRoute and
+// MeshHTTPRoute policies. TrafficRoute expects that by default traffic doesn't
+// flow, and there is necessary TrafficRoute with appropriate configuration
+// to make communication between services possible. MeshHTTPRoute on the other
+// hand expects the traffic to flow by default. As a result, when there is
+// at least one MeshHTTPRoute policy present, traffic between services will flow
+// by default, when there is none, it will flow, when appropriate TrafficRoute
+// policy will exist.
+func addTrafficFlowByDefaultDestinationIfMeshHTTPRoutesExist(
+	policies []*meshhttproute_api.MeshHTTPRouteResource,
+	destinations map[string][]envoy_tags.Tags,
+) {
+	// If there are no MeshHTTPRoutes, we are not modifying destinations
+	if len(policies) == 0 {
+		return
+	}
+
+	// We need to add a destination to route any service to any instance of
+	// that service
+	matchAllTags := envoy_tags.Tags{mesh_proto.ServiceTag: mesh_proto.MatchAllTag}
+	matchAllDestinations := destinations[mesh_proto.MatchAllTag]
+	foundAllServicesDestination := slices.ContainsFunc(
+		matchAllDestinations,
+		func(tagsElem envoy_tags.Tags) bool {
+			return reflect.DeepEqual(tagsElem, matchAllTags)
+		},
+	)
+
+	if !foundAllServicesDestination {
+		matchAllDestinations = append(matchAllDestinations, matchAllTags)
+	}
+
+	destinations[mesh_proto.MatchAllTag] = matchAllDestinations
+}

--- a/pkg/xds/sync/egress_proxy_builder.go
+++ b/pkg/xds/sync/egress_proxy_builder.go
@@ -14,6 +14,7 @@ import (
 	core_model "github.com/kumahq/kuma/pkg/core/resources/model"
 	core_store "github.com/kumahq/kuma/pkg/core/resources/store"
 	core_xds "github.com/kumahq/kuma/pkg/core/xds"
+	meshhttproute_api "github.com/kumahq/kuma/pkg/plugins/policies/meshhttproute/api/v1alpha1"
 	xds_context "github.com/kumahq/kuma/pkg/xds/context"
 	xds_topology "github.com/kumahq/kuma/pkg/xds/topology"
 )
@@ -66,9 +67,11 @@ func (p *EgressProxyBuilder) Build(
 		externalServices := meshCtx.Resources.ExternalServices().Items
 		faultInjections := meshCtx.Resources.FaultInjections().Items
 		rateLimits := meshCtx.Resources.RateLimits().Items
+		httpRoutes := meshCtx.Resources.ListOrEmpty(meshhttproute_api.MeshHTTPRouteType).(*meshhttproute_api.MeshHTTPRouteResourceList)
 
 		resourceMap := map[core_model.ResourceType]core_model.ResourceList{
-			core_mesh.TrafficRouteType: trafficRoutes,
+			core_mesh.TrafficRouteType:          trafficRoutes,
+			meshhttproute_api.MeshHTTPRouteType: httpRoutes,
 		}
 		meshResources := &core_xds.MeshResources{
 			Mesh:             mesh,

--- a/pkg/xds/sync/egress_proxy_builder.go
+++ b/pkg/xds/sync/egress_proxy_builder.go
@@ -62,14 +62,17 @@ func (p *EgressProxyBuilder) Build(
 		meshCtx := aggregatedMeshCtxs.MustGetMeshContext(meshName)
 
 		trafficPermissions := meshCtx.Resources.TrafficPermissions().Items
-		trafficRoutes := meshCtx.Resources.TrafficRoutes().Items
+		trafficRoutes := meshCtx.Resources.TrafficRoutes()
 		externalServices := meshCtx.Resources.ExternalServices().Items
 		faultInjections := meshCtx.Resources.FaultInjections().Items
 		rateLimits := meshCtx.Resources.RateLimits().Items
 
+		resourceMap := map[core_model.ResourceType]core_model.ResourceList{
+			core_mesh.TrafficRouteType: trafficRoutes,
+		}
 		meshResources := &core_xds.MeshResources{
 			Mesh:             mesh,
-			TrafficRoutes:    trafficRoutes,
+			Resources:        resourceMap,
 			ExternalServices: externalServices,
 			EndpointMap: xds_topology.BuildEgressEndpointMap(
 				ctx,

--- a/pkg/xds/sync/egress_proxy_builder.go
+++ b/pkg/xds/sync/egress_proxy_builder.go
@@ -67,7 +67,7 @@ func (p *EgressProxyBuilder) Build(
 		externalServices := meshCtx.Resources.ExternalServices().Items
 		faultInjections := meshCtx.Resources.FaultInjections().Items
 		rateLimits := meshCtx.Resources.RateLimits().Items
-		httpRoutes := meshCtx.Resources.ListOrEmpty(meshhttproute_api.MeshHTTPRouteType).(*meshhttproute_api.MeshHTTPRouteResourceList)
+		httpRoutes := meshCtx.Resources.ListOrEmpty(meshhttproute_api.MeshHTTPRouteType)
 
 		resourceMap := map[core_model.ResourceType]core_model.ResourceList{
 			core_mesh.TrafficRouteType:          trafficRoutes,

--- a/test/e2e_env/multizone/meshhttproute/test.go
+++ b/test/e2e_env/multizone/meshhttproute/test.go
@@ -15,11 +15,13 @@ import (
 
 func Test() {
 	noEgressMeshName := "meshhttproute"
+	egressMeshName := "meshhttproute-egress"
 
 	BeforeAll(func() {
 		// Global
 		Expect(multizone.Global.Install(MTLSMeshUniversal(noEgressMeshName))).To(Succeed())
-		for _, meshName := range []string{noEgressMeshName} {
+		Expect(multizone.Global.Install(MTLSMeshWithEgressUniversal(egressMeshName))).To(Succeed())
+		for _, meshName := range []string{noEgressMeshName, egressMeshName} {
 			Expect(WaitForMesh(meshName, multizone.Zones())).To(Succeed())
 
 			err := NewClusterSetup().
@@ -61,13 +63,13 @@ func Test() {
 	})
 
 	E2EAfterEach(func() {
-		for _, meshName := range []string{noEgressMeshName} {
+		for _, meshName := range []string{noEgressMeshName, egressMeshName} {
 			Expect(DeleteMeshResources(multizone.Global, meshName, v1alpha1.MeshHTTPRouteResourceTypeDescriptor)).To(Succeed())
 		}
 	})
 
 	E2EAfterAll(func() {
-		for _, meshName := range []string{noEgressMeshName} {
+		for _, meshName := range []string{noEgressMeshName, egressMeshName} {
 			Expect(multizone.UniZone2.DeleteMeshApps(meshName)).To(Succeed())
 			Expect(multizone.UniZone1.DeleteMeshApps(meshName)).To(Succeed())
 			Expect(multizone.Global.DeleteMesh(meshName)).To(Succeed())
@@ -115,6 +117,7 @@ spec:
 			}, "30s", "500ms").Should(Succeed())
 		},
 		Entry("without zoneEgress", noEgressMeshName),
+		Entry("with zoneEgress", egressMeshName),
 	)
 
 	It("should use MeshHTTPRoute for cross-zone with MeshServiceSubset", func() {

--- a/test/e2e_env/multizone/meshhttproute/test.go
+++ b/test/e2e_env/multizone/meshhttproute/test.go
@@ -14,62 +14,69 @@ import (
 )
 
 func Test() {
-	meshName := "meshhttproute"
+	noEgressMeshName := "meshhttproute"
 
 	BeforeAll(func() {
 		// Global
-		Expect(multizone.Global.Install(MTLSMeshUniversal(meshName))).To(Succeed())
-		Expect(WaitForMesh(meshName, multizone.Zones())).To(Succeed())
+		Expect(multizone.Global.Install(MTLSMeshUniversal(noEgressMeshName))).To(Succeed())
+		for _, meshName := range []string{noEgressMeshName} {
+			Expect(WaitForMesh(meshName, multizone.Zones())).To(Succeed())
 
-		err := NewClusterSetup().
-			Install(DemoClientUniversal(AppModeDemoClient, meshName, WithTransparentProxy(true))).
-			Install(TestServerUniversal("dp-echo-1", meshName,
-				WithArgs([]string{"echo", "--instance", "zone1"}),
-				WithServiceVersion("v1"),
-			)).
-			Setup(multizone.UniZone1)
-		Expect(err).ToNot(HaveOccurred())
+			err := NewClusterSetup().
+				Install(DemoClientUniversal(AppModeDemoClient+meshName, meshName, WithTransparentProxy(true), WithServiceName(AppModeDemoClient))).
+				Install(TestServerUniversal("dp-echo-1"+meshName, meshName,
+					WithArgs([]string{"echo", "--instance", "zone1"}),
+					WithServiceVersion("v1"),
+				)).
+				Setup(multizone.UniZone1)
+			Expect(err).ToNot(HaveOccurred())
 
-		err = NewClusterSetup().
-			Install(TestServerUniversal("dp-echo-2", meshName,
-				WithArgs([]string{"echo", "--instance", "zone2-v1"}),
-				WithServiceVersion("v1"),
-			)).
-			Setup(multizone.UniZone2)
-		Expect(err).ToNot(HaveOccurred())
+			err = NewClusterSetup().
+				Install(TestServerUniversal("dp-echo-2"+meshName, meshName,
+					WithArgs([]string{"echo", "--instance", "zone2-v1"}),
+					WithServiceVersion("v1"),
+				)).
+				Setup(multizone.UniZone2)
+			Expect(err).ToNot(HaveOccurred())
 
-		err = NewClusterSetup().
-			Install(TestServerUniversal("dp-echo-3", meshName,
-				WithArgs([]string{"echo", "--instance", "zone2-v2"}),
-				WithServiceVersion("v2"),
-			)).
-			Setup(multizone.UniZone2)
-		Expect(err).ToNot(HaveOccurred())
+			err = NewClusterSetup().
+				Install(TestServerUniversal("dp-echo-3"+meshName, meshName,
+					WithArgs([]string{"echo", "--instance", "zone2-v2"}),
+					WithServiceVersion("v2"),
+				)).
+				Setup(multizone.UniZone2)
+			Expect(err).ToNot(HaveOccurred())
 
-		err = NewClusterSetup().
-			Install(TestServerUniversal("dp-echo-4", meshName,
-				WithArgs([]string{"echo", "--instance", "alias-zone2"}),
-				WithServiceName("alias-test-server"),
-				WithServiceVersion("v2"),
-			)).
-			Setup(multizone.UniZone2)
-		Expect(err).ToNot(HaveOccurred())
+			err = NewClusterSetup().
+				Install(TestServerUniversal("dp-echo-4"+meshName, meshName,
+					WithArgs([]string{"echo", "--instance", "alias-zone2"}),
+					WithServiceName("alias-test-server"),
+					WithServiceVersion("v2"),
+				)).
+				Setup(multizone.UniZone2)
+			Expect(err).ToNot(HaveOccurred())
 
-		Expect(DeleteMeshResources(multizone.Global, meshName, core_mesh.TrafficRouteResourceTypeDescriptor)).To(Succeed())
+			Expect(DeleteMeshResources(multizone.Global, meshName, core_mesh.TrafficRouteResourceTypeDescriptor)).To(Succeed())
+		}
 	})
 
 	E2EAfterEach(func() {
-		Expect(DeleteMeshResources(multizone.Global, meshName, v1alpha1.MeshHTTPRouteResourceTypeDescriptor)).To(Succeed())
+		for _, meshName := range []string{noEgressMeshName} {
+			Expect(DeleteMeshResources(multizone.Global, meshName, v1alpha1.MeshHTTPRouteResourceTypeDescriptor)).To(Succeed())
+		}
 	})
 
 	E2EAfterAll(func() {
-		Expect(multizone.UniZone2.DeleteMeshApps(meshName)).To(Succeed())
-		Expect(multizone.UniZone1.DeleteMeshApps(meshName)).To(Succeed())
-		Expect(multizone.Global.DeleteMesh(meshName)).To(Succeed())
+		for _, meshName := range []string{noEgressMeshName} {
+			Expect(multizone.UniZone2.DeleteMeshApps(meshName)).To(Succeed())
+			Expect(multizone.UniZone1.DeleteMeshApps(meshName)).To(Succeed())
+			Expect(multizone.Global.DeleteMesh(meshName)).To(Succeed())
+		}
 	})
 
-	It("should use MeshHTTPRoute for cross-zone communication", func() {
-		Expect(YamlUniversal(fmt.Sprintf(`
+	DescribeTable("MeshHTTPRoute should work cross-zone",
+		func(meshName string) {
+			Expect(YamlUniversal(fmt.Sprintf(`
 type: MeshHTTPRoute
 name: route-1
 mesh: %s
@@ -95,18 +102,20 @@ spec:
                   kuma.io/zone: kuma-5
 `, meshName))(multizone.Global)).To(Succeed())
 
-		Eventually(func(g Gomega) {
-			response, err := client.CollectResponsesByInstance(multizone.UniZone1, "demo-client", "test-server.mesh")
-			g.Expect(err).ToNot(HaveOccurred())
-			g.Expect(response).To(
-				And(
-					Not(HaveKey(MatchRegexp(`^zone1.*`))),
-					Not(HaveKey(MatchRegexp(`^zone2.*`))),
-					HaveKeyWithValue(MatchRegexp(`^alias-zone2.*`), Not(BeNil())),
-				),
-			)
-		}, "30s", "500ms").Should(Succeed())
-	})
+			Eventually(func(g Gomega) {
+				response, err := client.CollectResponsesByInstance(multizone.UniZone1, AppModeDemoClient+meshName, "test-server.mesh")
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(response).To(
+					And(
+						Not(HaveKey(MatchRegexp(`^zone1.*`))),
+						Not(HaveKey(MatchRegexp(`^zone2.*`))),
+						HaveKeyWithValue(MatchRegexp(`^alias-zone2.*`), Not(BeNil())),
+					),
+				)
+			}, "30s", "500ms").Should(Succeed())
+		},
+		Entry("without zoneEgress", noEgressMeshName),
+	)
 
 	It("should use MeshHTTPRoute for cross-zone with MeshServiceSubset", func() {
 		Expect(YamlUniversal(fmt.Sprintf(`
@@ -138,10 +147,10 @@ spec:
                 weight: 1
                 tags:
                   version: v2
-`, meshName))(multizone.Global)).To(Succeed())
+`, noEgressMeshName))(multizone.Global)).To(Succeed())
 
 		Eventually(func(g Gomega) {
-			response, err := client.CollectResponsesByInstance(multizone.UniZone1, "demo-client", "test-server.mesh")
+			response, err := client.CollectResponsesByInstance(multizone.UniZone1, AppModeDemoClient+noEgressMeshName, "test-server.mesh")
 			g.Expect(err).ToNot(HaveOccurred())
 			g.Expect(response).To(
 				And(

--- a/test/framework/setup.go
+++ b/test/framework/setup.go
@@ -147,6 +147,21 @@ mtls:
 	return YamlUniversal(mesh)
 }
 
+func MTLSMeshWithEgressUniversal(name string) InstallFunc {
+	mesh := fmt.Sprintf(`
+type: Mesh
+name: %s
+mtls:
+  enabledBackend: ca-1
+  backends:
+    - name: ca-1
+      type: builtin
+routing:
+  zoneEgress: true
+`, name)
+	return YamlUniversal(mesh)
+}
+
 func YamlUniversal(yaml string) InstallFunc {
 	return func(cluster Cluster) error {
 		_, err := retry.DoWithRetryE(cluster.GetTesting(), "install yaml resource", DefaultRetries, DefaultTimeout,

--- a/test/framework/setup.go
+++ b/test/framework/setup.go
@@ -373,14 +373,18 @@ func DemoClientUniversal(name string, mesh string, opt ...AppDeploymentOption) I
 		args := []string{"ncat", "-lvk", "-p", "3000"}
 		appYaml := opts.appYaml
 		transparent := opts.transparent != nil && *opts.transparent // default false
+		serviceName := name
+		if opts.serviceName != "" {
+			serviceName = opts.serviceName
+		}
 		if appYaml == "" {
 			if transparent {
-				appYaml = fmt.Sprintf(DemoClientDataplaneTransparentProxy, mesh, "3000", name, redirectPortInbound, redirectPortInboundV6, redirectPortOutbound, strings.Join(opts.reachableServices, ","))
+				appYaml = fmt.Sprintf(DemoClientDataplaneTransparentProxy, mesh, "3000", serviceName, redirectPortInbound, redirectPortInboundV6, redirectPortOutbound, strings.Join(opts.reachableServices, ","))
 			} else {
 				if opts.serviceProbe {
-					appYaml = fmt.Sprintf(DemoClientDataplaneWithServiceProbe, mesh, "13000", "3000", name, "80", "8080")
+					appYaml = fmt.Sprintf(DemoClientDataplaneWithServiceProbe, mesh, "13000", "3000", serviceName, "80", "8080")
 				} else {
-					appYaml = fmt.Sprintf(DemoClientDataplane, mesh, "13000", "3000", name, "80", "8080")
+					appYaml = fmt.Sprintf(DemoClientDataplane, mesh, "13000", "3000", serviceName, "80", "8080")
 				}
 			}
 		}
@@ -389,7 +393,7 @@ func DemoClientUniversal(name string, mesh string, opt ...AppDeploymentOption) I
 			token := opts.token
 			var err error
 			if token == "" {
-				token, err = cluster.GetKuma().GenerateDpToken(mesh, name)
+				token, err = cluster.GetKuma().GenerateDpToken(mesh, serviceName)
 				if err != nil {
 					return err
 				}


### PR DESCRIPTION
Depends on #7507 

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues -- closes #5871, #6905
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --
- [x] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
