### PR TITLE
feat(kuma-cp): force routing through zone egress

### DIFF
--- a/pkg/xds/topology/outbound.go
+++ b/pkg/xds/topology/outbound.go
@@ -43,7 +43,7 @@ func BuildEgressEndpointMap(
 ) core_xds.EndpointMap {
 	outbound := core_xds.EndpointMap{}
 
-	fillIngressOutbounds(outbound, zoneIngresses, nil, localZone, mesh, nil)
+	fillIngressOutbounds(outbound, zoneIngresses, nil, localZone, mesh, nil, false)
 
 	fillExternalServicesReachableFromZone(ctx, outbound, externalServices, mesh, loader, localZone)
 
@@ -71,7 +71,7 @@ func BuildEdsEndpointMap(
 ) core_xds.EndpointMap {
 	outbound := core_xds.EndpointMap{}
 
-	ingressInstances := fillIngressOutbounds(outbound, zoneIngresses, zoneEgresses, localZone, mesh, nil)
+	ingressInstances := fillIngressOutbounds(outbound, zoneIngresses, zoneEgresses, localZone, mesh, nil, mesh.ZoneEgressEnabled())
 	endpointWeight := uint32(1)
 	if ingressInstances > 0 {
 		endpointWeight = ingressInstances
@@ -188,6 +188,7 @@ func BuildCrossMeshEndpointMap(
 		localZone,
 		mesh,
 		otherMesh,
+		mesh.ZoneEgressEnabled(),
 	)
 
 	endpointWeight := uint32(1)
@@ -244,6 +245,7 @@ func fillIngressOutbounds(
 	localZone string,
 	mesh *core_mesh.MeshResource,
 	otherMesh *core_mesh.MeshResource, // otherMesh is set if we are looking for specific crossmesh connections
+	routeThroughZoneEgress bool,
 ) uint32 {
 	ziInstances := map[string]struct{}{}
 
@@ -319,7 +321,7 @@ func fillIngressOutbounds(
 			//  ignore
 			// If zone egresses present, we want to pass the traffic:
 			// dp -> zone egress -> zone ingress -> dp
-			if mesh.ZoneEgressEnabled() && len(zoneEgresses) > 0 {
+			if routeThroughZoneEgress {
 				for _, ze := range zoneEgresses {
 					zeNetworking := ze.Spec.GetNetworking()
 					zeAddress := zeNetworking.GetAddress()
@@ -347,9 +349,6 @@ func fillIngressOutbounds(
 					Tags:     serviceTags,
 					Weight:   serviceInstances,
 					Locality: locality,
-				}
-				if mesh.ZoneEgressEnabled() && service.ExternalService {
-					endpoint.ExternalService = &core_xds.ExternalService{}
 				}
 
 				outbound[serviceName] = append(outbound[serviceName], endpoint)

--- a/pkg/xds/topology/outbound_test.go
+++ b/pkg/xds/topology/outbound_test.go
@@ -1193,6 +1193,24 @@ var _ = Describe("TrafficRoute", func() {
 					},
 					mesh: defaultMeshWithMTLSAndZoneEgress,
 					expected: core_xds.EndpointMap{
+						"service-in-zone2": []core_xds.Endpoint{
+							{
+								Target:   "192.168.0.100",
+								Port:     12345,
+								Tags:     map[string]string{mesh_proto.ServiceTag: "service-in-zone2", mesh_proto.ZoneTag: "zone-2", "mesh": "default"},
+								Weight:   2, // local weight is bumped to 2 to factor two instances of Ingresses
+								Locality: &core_xds.Locality{Zone: "zone-2", Priority: 0},
+							},
+						},
+						"test": []core_xds.Endpoint{
+							{
+								Target:   "192.168.0.100",
+								Port:     12345,
+								Tags:     map[string]string{mesh_proto.ServiceTag: "test", mesh_proto.ZoneTag: "zone-2", "mesh": "default"},
+								Weight:   3, // local weight is bumped to 2 to factor two instances of Ingresses
+								Locality: &core_xds.Locality{Zone: "zone-2", Priority: 0},
+							},
+						},
 						"httpbin": []core_xds.Endpoint{
 							{
 								Target:          "httpbin.org",

--- a/pkg/xds/topology/outbound_test.go
+++ b/pkg/xds/topology/outbound_test.go
@@ -1193,25 +1193,6 @@ var _ = Describe("TrafficRoute", func() {
 					},
 					mesh: defaultMeshWithMTLSAndZoneEgress,
 					expected: core_xds.EndpointMap{
-						"service-in-zone2": []core_xds.Endpoint{
-							{
-								Target:          "192.168.0.100",
-								Port:            12345,
-								Tags:            map[string]string{mesh_proto.ServiceTag: "service-in-zone2", mesh_proto.ZoneTag: "zone-2", "mesh": "default"},
-								Weight:          2, // local weight is bumped to 2 to factor two instances of Ingresses
-								Locality:        &core_xds.Locality{Zone: "zone-2", Priority: 0},
-								ExternalService: &core_xds.ExternalService{},
-							},
-						},
-						"test": []core_xds.Endpoint{
-							{
-								Target:   "192.168.0.100",
-								Port:     12345,
-								Tags:     map[string]string{mesh_proto.ServiceTag: "test", mesh_proto.ZoneTag: "zone-2", "mesh": "default"},
-								Weight:   3, // local weight is bumped to 2 to factor two instances of Ingresses
-								Locality: &core_xds.Locality{Zone: "zone-2", Priority: 0},
-							},
-						},
 						"httpbin": []core_xds.Endpoint{
 							{
 								Target:          "httpbin.org",


### PR DESCRIPTION
### Checklist prior to review

There was a logic that if you enabled `Mesh#routing.zoneEgress=true` and you didn't have egress deployed we still would route the traffic directly to zone ingress of other zones, but only for internal services (it would fail for external services). This can be misleading for users that expect their traffic to always go through zone egress when this setting is enabled.

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [X] [Link to relevant issue][1] as well as docs and UI issues --
- [X] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [X] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [X] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [X] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --
- [X] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
