### PR TITLE
test(e2e): do not use unsafe delete

### DIFF
--- a/test/e2e_env/universal/gateway/utils.go
+++ b/test/e2e_env/universal/gateway/utils.go
@@ -143,6 +143,7 @@ networking:
 
 		return universal.Cluster.DeployApp(
 			WithName(name),
+			WithMesh(mesh),
 			WithToken(token),
 			WithVerbose(),
 			WithYaml(dataplane),

--- a/test/e2e_env/universal/healthcheck/panic.go
+++ b/test/e2e_env/universal/healthcheck/panic.go
@@ -72,6 +72,9 @@ networking:
 
 	E2EAfterAll(func() {
 		Expect(universal.Cluster.DeleteMeshApps(meshName)).To(Succeed())
+		for i := 7; i <= 10; i++ {
+			Expect(universal.Cluster.GetKumactlOptions().RunKumactl("delete", "dataplane", fmt.Sprintf("dp-echo-%d", i), "-m", meshName)).To(Succeed())
+		}
 		Expect(universal.Cluster.DeleteMesh(meshName)).To(Succeed())
 	})
 

--- a/test/e2e_env/universal/meshhealthcheck/panic.go
+++ b/test/e2e_env/universal/meshhealthcheck/panic.go
@@ -74,6 +74,9 @@ networking:
 
 	E2EAfterAll(func() {
 		Expect(universal.Cluster.DeleteMeshApps(meshName)).To(Succeed())
+		for i := 7; i <= 10; i++ {
+			Expect(universal.Cluster.GetKumactlOptions().RunKumactl("delete", "dataplane", fmt.Sprintf("dp-echo-%d", i), "-m", meshName)).To(Succeed())
+		}
 		Expect(universal.Cluster.DeleteMesh(meshName)).To(Succeed())
 	})
 

--- a/test/e2e_env/universal/meshretry/grpc.go
+++ b/test/e2e_env/universal/meshretry/grpc.go
@@ -40,6 +40,7 @@ func GrpcRetry() {
 
 	E2EAfterAll(func() {
 		Expect(universal.Cluster.DeleteMeshApps(meshName)).To(Succeed())
+		Expect(universal.Cluster.GetKumactlOptions().RunKumactl("delete", "dataplane", "fake-echo-server", "-m", meshName)).To(Succeed())
 		Expect(universal.Cluster.DeleteMesh(meshName)).To(Succeed())
 	})
 

--- a/test/e2e_env/universal/meshretry/http.go
+++ b/test/e2e_env/universal/meshretry/http.go
@@ -30,6 +30,7 @@ func HttpRetry() {
 
 	E2EAfterAll(func() {
 		Expect(universal.Cluster.DeleteMeshApps(meshName)).To(Succeed())
+		Expect(universal.Cluster.GetKumactlOptions().RunKumactl("delete", "dataplane", "fake-echo-server", "-m", meshName)).To(Succeed())
 		Expect(universal.Cluster.DeleteMesh(meshName)).To(Succeed())
 	})
 

--- a/test/e2e_env/universal/retry/retry.go
+++ b/test/e2e_env/universal/retry/retry.go
@@ -30,6 +30,7 @@ func Policy() {
 
 	E2EAfterAll(func() {
 		Expect(universal.Cluster.DeleteMeshApps(meshName)).To(Succeed())
+		Expect(universal.Cluster.GetKumactlOptions().RunKumactl("delete", "dataplane", "fake-echo-server", "-m", meshName)).To(Succeed())
 		Expect(universal.Cluster.DeleteMesh(meshName)).To(Succeed())
 	})
 

--- a/test/framework/envs/kubernetes/env.go
+++ b/test/framework/envs/kubernetes/env.go
@@ -22,7 +22,6 @@ func SetupAndGetState() []byte {
 	)).To(Succeed())
 
 	kumaOptions := append([]framework.KumaDeploymentOption{
-		framework.WithEnv("KUMA_STORE_UNSAFE_DELETE", "true"),
 		framework.WithCtlOpts(map[string]string{
 			"--experimental-gatewayapi": "true",
 		}),

--- a/test/framework/envs/multizone/env.go
+++ b/test/framework/envs/multizone/env.go
@@ -36,10 +36,7 @@ type State struct {
 func SetupAndGetState() []byte {
 	Global = NewUniversalCluster(NewTestingT(), Kuma3, Silent)
 	E2EDeferCleanup(Global.DismissCluster) // clean up any containers if needed
-	globalOptions := append(
-		[]framework.KumaDeploymentOption{framework.WithEnv("KUMA_STORE_UNSAFE_DELETE", "true")},
-		framework.KumaDeploymentOptionsFromConfig(framework.Config.KumaCpConfig.Multizone.Global)...,
-	)
+	globalOptions := framework.KumaDeploymentOptionsFromConfig(framework.Config.KumaCpConfig.Multizone.Global)
 	Expect(Global.Install(Kuma(core.Global, globalOptions...))).To(Succeed())
 
 	wg := sync.WaitGroup{}
@@ -65,7 +62,6 @@ func SetupAndGetState() []byte {
 
 	kubeZone2Options := append(
 		[]framework.KumaDeploymentOption{
-			WithEnv("KUMA_STORE_UNSAFE_DELETE", "true"),
 			WithIngress(),
 			WithIngressEnvoyAdminTunnel(),
 			WithEgress(),
@@ -86,9 +82,9 @@ func SetupAndGetState() []byte {
 	uniZone1Options := append(
 		[]framework.KumaDeploymentOption{
 			WithGlobalAddress(Global.GetKuma().GetKDSServerAddress()),
-			WithEnv("KUMA_STORE_UNSAFE_DELETE", "true"),
 			WithEgressEnvoyAdminTunnel(),
 			WithIngressEnvoyAdminTunnel(),
+			framework.WithEnv("KUMA_XDS_DATAPLANE_DEREGISTRATION_DELAY", "0s"), // we have only 1 Kuma CP instance so there is no risk setting this to 0
 		},
 		framework.KumaDeploymentOptionsFromConfig(framework.Config.KumaCpConfig.Multizone.UniZone1)...,
 	)
@@ -108,9 +104,9 @@ func SetupAndGetState() []byte {
 	uniZone2Options := append(
 		[]framework.KumaDeploymentOption{
 			WithGlobalAddress(Global.GetKuma().GetKDSServerAddress()),
-			WithEnv("KUMA_STORE_UNSAFE_DELETE", "true"),
 			WithEgressEnvoyAdminTunnel(),
 			WithIngressEnvoyAdminTunnel(),
+			framework.WithEnv("KUMA_XDS_DATAPLANE_DEREGISTRATION_DELAY", "0s"), // we have only 1 Kuma CP instance so there is no risk setting this to 0
 		},
 		framework.KumaDeploymentOptionsFromConfig(framework.Config.KumaCpConfig.Multizone.UniZone2)...,
 	)

--- a/test/framework/envs/universal/env.go
+++ b/test/framework/envs/universal/env.go
@@ -17,7 +17,6 @@ func SetupAndGetState() []byte {
 	framework.E2EDeferCleanup(Cluster.DismissCluster)
 	kumaOptions := append(
 		[]framework.KumaDeploymentOption{
-			framework.WithEnv("KUMA_STORE_UNSAFE_DELETE", "true"),
 			framework.WithEnv("KUMA_XDS_SERVER_DATAPLANE_STATUS_FLUSH_INTERVAL", "1s"), // speed up some tests by flushing stats quicker than default 10s
 			framework.WithEnv("KUMA_XDS_DATAPLANE_DEREGISTRATION_DELAY", "0s"),         // we have only 1 Kuma CP instance so there is no risk setting this to 0
 		}, framework.KumaDeploymentOptionsFromConfig(framework.Config.KumaCpConfig.Standalone.Universal)...)

--- a/test/framework/gateway.go
+++ b/test/framework/gateway.go
@@ -21,7 +21,6 @@ networking:
       kuma.io/service: edge-gateway
 `, mesh)
 		return cluster.DeployApp(
-			WithKumactlFlow(),
 			WithName(name),
 			WithMesh(mesh),
 			WithToken(token),

--- a/test/framework/k8s_cluster.go
+++ b/test/framework/k8s_cluster.go
@@ -1003,7 +1003,11 @@ func (c *K8sCluster) TriggerDeleteNamespace(namespace string) error {
 }
 
 func (c *K8sCluster) DeleteMesh(mesh string) error {
-	return k8s.RunKubectlE(c.GetTesting(), c.GetKubectlOptions(), "delete", "mesh", mesh)
+	_, err := retry.DoWithRetryE(c.GetTesting(), "remove mesh", c.defaultRetries, c.defaultTimeout,
+		func() (string, error) {
+			return "", k8s.RunKubectlE(c.GetTesting(), c.GetKubectlOptions(), "delete", "mesh", mesh)
+		})
+	return err
 }
 
 func (c *K8sCluster) DeployApp(opt ...AppDeploymentOption) error {

--- a/test/framework/k8s_cluster.go
+++ b/test/framework/k8s_cluster.go
@@ -1003,10 +1003,12 @@ func (c *K8sCluster) TriggerDeleteNamespace(namespace string) error {
 }
 
 func (c *K8sCluster) DeleteMesh(mesh string) error {
+	now := time.Now()
 	_, err := retry.DoWithRetryE(c.GetTesting(), "remove mesh", c.defaultRetries, c.defaultTimeout,
 		func() (string, error) {
 			return "", k8s.RunKubectlE(c.GetTesting(), c.GetKubectlOptions(), "delete", "mesh", mesh)
 		})
+	Logf("mesh: " + mesh + " deleted in: " + time.Since(now).String())
 	return err
 }
 

--- a/test/framework/universal_cluster.go
+++ b/test/framework/universal_cluster.go
@@ -409,7 +409,7 @@ func (c *UniversalCluster) DeleteMesh(mesh string) error {
 		func() (string, error) {
 			return "", c.GetKumactlOptions().KumactlDelete("mesh", mesh, "")
 		})
-	Logf("mesh: " + mesh + " deleted in: " + time.Now().Sub(now).String())
+	Logf("mesh: " + mesh + " deleted in: " + time.Since(now).String())
 	return err
 }
 

--- a/test/framework/universal_cluster.go
+++ b/test/framework/universal_cluster.go
@@ -404,10 +404,12 @@ func (c *UniversalCluster) DeleteApp(appname string) error {
 }
 
 func (c *UniversalCluster) DeleteMesh(mesh string) error {
-	_, err := retry.DoWithRetryE(c.t, "remove mesh", DefaultRetries, DefaultTimeout,
+	now := time.Now()
+	_, err := retry.DoWithRetryE(c.t, "remove mesh", DefaultRetries, 1*time.Second,
 		func() (string, error) {
 			return "", c.GetKumactlOptions().KumactlDelete("mesh", mesh, "")
 		})
+	Logf("mesh: " + mesh + " deleted in: " + time.Now().Sub(now).String())
 	return err
 }
 

--- a/test/framework/universal_cluster.go
+++ b/test/framework/universal_cluster.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/gruntwork-io/terratest/modules/k8s"
+	"github.com/gruntwork-io/terratest/modules/retry"
 	"github.com/gruntwork-io/terratest/modules/testing"
 	"github.com/pkg/errors"
 	"go.uber.org/multierr"
@@ -403,7 +404,11 @@ func (c *UniversalCluster) DeleteApp(appname string) error {
 }
 
 func (c *UniversalCluster) DeleteMesh(mesh string) error {
-	return c.GetKumactlOptions().KumactlDelete("mesh", mesh, "")
+	_, err := retry.DoWithRetryE(c.t, "remove mesh", DefaultRetries, DefaultTimeout,
+		func() (string, error) {
+			return "", c.GetKumactlOptions().KumactlDelete("mesh", mesh, "")
+		})
+	return err
 }
 
 func (c *UniversalCluster) DeleteMeshApps(mesh string) error {


### PR DESCRIPTION
### Checklist prior to review

This PR gets rid of unsafe delete by default in E2E tests.
Unsafe delete lets you delete a mesh without extra validations like all DPPs are removed.

Because we wanted to get rid of mesh as soon as possible, we did not want to wait for all dpps to terminate. This worked although we saw quite a bit errors logs especially in multizone that mesh is no longer available because we were deleting mesh "too soon". Doing it the right way (delete dpps first) is closer to production env. We can now do this because `TriggerNamespaceDelete` deletes the pods immediately.

The only drawback is that we can no longer test misconfigured provided mesh mtls with gateway because CP prevents us to delete a secret that is used for a mesh.

The main advantage of this chance is that we reduce the number of error logs so it's easier to catch real errors.

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --
- [x] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
