### PR TITLE
fix(metrics): hijacker should not pass accept-encoding

### DIFF
--- a/app/kuma-dp/pkg/dataplane/metrics/server.go
+++ b/app/kuma-dp/pkg/dataplane/metrics/server.go
@@ -28,7 +28,7 @@ var (
 )
 
 var (
-	prometheusRequestHeaders = []string{"accept", "accept-encoding", "user-agent", "x-prometheus-scrape-timeout-seconds"}
+	prometheusRequestHeaders = []string{"accept", "user-agent", "x-prometheus-scrape-timeout-seconds"}
 	logger                   = core.Log.WithName("metrics-hijacker")
 
 	// holds prometheus content types in order of priority.


### PR DESCRIPTION
### Checklist prior to review

We should not pass accept-enconding further to apps when we aggregate metrics.
My prometheus server sends `accept-enconding: gzip` with request for metrics.
Golang client handles gzip automatically, but if you set this manually (our case) then it's up to the user to handle this. That's why we were merging metrics with compressed data.
https://go.dev/src/net/http/transport.go#L187

The solution is to not pass it through. We should not pass accept-encoding because there is no guarantee that our HTTP client can handle whatever prometheus wishes.

Why our E2E test missed this?
In our E2E test that checks app aggregate we scrape metrics manually https://github.com/kumahq/kuma/blob/master/test/e2e_env/universal/observability/applications_metrics.go
We should deploy prom and check it via prom, not curl directly (that would not set gzip). I'd like to improve e2e tests, but on separate PR since we are close to the release.

Fix #7093

- [X] [Link to relevant issue][1] as well as docs and UI issues --
- [X] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [X] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [X] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [X] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --
- [X] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
