### PR TITLE
feat(e2e): fix metrics tls test

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -21,6 +21,7 @@ linters:
     - unparam
     - unused
     - whitespace
+    - nosprintfhostport
 
 run:
   build-tags:

--- a/pkg/api-server/auth_test.go
+++ b/pkg/api-server/auth_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"strconv"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -85,7 +86,7 @@ var _ = Describe("Auth test", func() {
 
 	It("should be able to access admin endpoints using client certs and HTTPS", func() {
 		// when
-		resp, err := httpsClient.Get(fmt.Sprintf("https://%s:%d/secrets", externalIP, httpsPort))
+		resp, err := httpsClient.Get(fmt.Sprintf("https://%s/secrets", net.JoinHostPort(externalIP, strconv.Itoa(int(httpsPort)))))
 
 		// then
 		Expect(err).ToNot(HaveOccurred())
@@ -94,7 +95,7 @@ var _ = Describe("Auth test", func() {
 
 	It("should be block an access to admin endpoints from other machine using HTTP", func() {
 		// when
-		resp, err := http.Get(fmt.Sprintf("http://%s:%d/secrets", externalIP, httpPort))
+		resp, err := http.Get(fmt.Sprintf("http://%s/secrets", net.JoinHostPort(externalIP, strconv.Itoa(int(httpPort)))))
 
 		// then
 		Expect(err).ToNot(HaveOccurred())
@@ -107,7 +108,7 @@ var _ = Describe("Auth test", func() {
 
 	It("should be block an access to admin endpoints from other machine using HTTPS without proper client certs", func() {
 		// when
-		resp, err := httpsClientWithoutCerts.Get(fmt.Sprintf("https://%s:%d/secrets", externalIP, httpsPort))
+		resp, err := httpsClientWithoutCerts.Get(fmt.Sprintf("https://%s/secrets", net.JoinHostPort(externalIP, strconv.Itoa(int(httpsPort)))))
 
 		// then
 		Expect(err).ToNot(HaveOccurred())

--- a/test/e2e_env/kubernetes/gateway/resources.go
+++ b/test/e2e_env/kubernetes/gateway/resources.go
@@ -2,6 +2,7 @@ package gateway
 
 import (
 	"fmt"
+	"net"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -107,7 +108,7 @@ spec:
 	})
 
 	gatewayHost := fmt.Sprintf("%s.%s", gatewayName, namespace)
-	target := fmt.Sprintf("http://%s:8080", gatewayHost)
+	target := fmt.Sprintf("http://%s", net.JoinHostPort(gatewayHost, "8080"))
 
 	keepConnectionOpen := func() {
 		// Open TCP connections to the gateway

--- a/test/e2e_env/universal/observability/metrics.go
+++ b/test/e2e_env/universal/observability/metrics.go
@@ -2,6 +2,7 @@ package observability
 
 import (
 	"fmt"
+	"net"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -98,7 +99,7 @@ func PrometheusMetrics() {
 			stdout, _, err := client.CollectResponse(
 				universal.Cluster,
 				clientName,
-				fmt.Sprintf("http://%s:1234/metrics", host),
+				fmt.Sprintf("http://%s/metrics", net.JoinHostPort(host, "1234")),
 			)
 
 			// then


### PR DESCRIPTION
### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --
- [x] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
