### PR TITLE
feat(glibc): use the patched version

### DIFF
--- a/mk/build.mk
+++ b/mk/build.mk
@@ -104,7 +104,7 @@ build/artifacts-$(1)-$(2)/coredns:
 build/artifacts-$(1)-$(2)/envoy:
 	mkdir -p $$(@) && \
 	[ -f $$(@)/envoy ] || \
-	curl -s --fail --location https://github.com/kumahq/envoy-builds/releases/download/v$(ENVOY_VERSION)/envoy-$(1)-$(2)-v$(ENVOY_VERSION)$(ENVOY_EXT_$(1)_$(2)).tar.gz | tar -C $$(@) -xz
+	curl -s --fail --location https://github.com/kumahq/envoy-builds/releases/download/v1.27.0-glibc/envoy-$(1)-$(2)-v$(ENVOY_VERSION)$(ENVOY_EXT_$(1)_$(2)).tar.gz | tar -C $$(@) -xz
 
 .PHONY: build/artifacts-$(1)-$(2)/test-server
 build/artifacts-$(1)-$(2)/test-server:

--- a/mk/build.mk
+++ b/mk/build.mk
@@ -103,6 +103,7 @@ build/artifacts-$(1)-$(2)/coredns:
 .PHONY: build/artifacts-$(1)-$(2)/envoy
 build/artifacts-$(1)-$(2)/envoy:
 	mkdir -p $$(@) && \
+	mkdir -p $$(@)/usr && \
 	[ -f $$(@)/envoy ] || \
 	curl -s --fail --location https://github.com/kumahq/envoy-builds/releases/download/v1.27.0-glibc/envoy-$(1)-$(2)-v$(ENVOY_VERSION)$(ENVOY_EXT_$(1)_$(2)).tar.gz | tar -C $$(@) -xz
 

--- a/mk/build.mk
+++ b/mk/build.mk
@@ -103,7 +103,7 @@ build/artifacts-$(1)-$(2)/coredns:
 .PHONY: build/artifacts-$(1)-$(2)/envoy
 build/artifacts-$(1)-$(2)/envoy:
 	mkdir -p $$(@) && \
-	mkdir -p $$(@)/usr && \
+	mkdir -p $$(@)/glibc-compat && \
 	[ -f $$(@)/envoy ] || \
 	curl -s --fail --location https://github.com/kumahq/envoy-builds/releases/download/v1.27.0-glibc/envoy-$(1)-$(2)-v$(ENVOY_VERSION)$(ENVOY_EXT_$(1)_$(2)).tar.gz | tar -C $$(@) -xz
 

--- a/test/dockerfiles/universal.Dockerfile
+++ b/test/dockerfiles/universal.Dockerfile
@@ -14,6 +14,7 @@ RUN echo "# use this file to override default configuration of \`kuma-cp\`" > /k
 ADD /build/artifacts-linux-$ARCH/kuma-cp/kuma-cp /usr/bin
 ADD /build/artifacts-linux-$ARCH/kuma-dp/kuma-dp /usr/bin
 COPY --from=envoy /envoy /usr/bin/envoy
+COPY --from=envoy /usr /usr/bin/usr
 ADD /build/artifacts-linux-$ARCH/coredns/coredns /usr/bin
 ADD /build/artifacts-linux-$ARCH/kumactl/kumactl /usr/bin
 ADD /build/artifacts-linux-$ARCH/test-server/test-server /usr/bin

--- a/test/dockerfiles/universal.Dockerfile
+++ b/test/dockerfiles/universal.Dockerfile
@@ -14,7 +14,7 @@ RUN echo "# use this file to override default configuration of \`kuma-cp\`" > /k
 ADD /build/artifacts-linux-$ARCH/kuma-cp/kuma-cp /usr/bin
 ADD /build/artifacts-linux-$ARCH/kuma-dp/kuma-dp /usr/bin
 COPY --from=envoy /envoy /usr/bin/envoy
-COPY --from=envoy /usr /usr/bin/usr
+COPY --from=envoy /glibc/glibc-compat /usr/bin/glibc-compat
 ADD /build/artifacts-linux-$ARCH/coredns/coredns /usr/bin
 ADD /build/artifacts-linux-$ARCH/kumactl/kumactl /usr/bin
 ADD /build/artifacts-linux-$ARCH/test-server/test-server /usr/bin

--- a/tools/releases/dockerfiles/envoy.Dockerfile
+++ b/tools/releases/dockerfiles/envoy.Dockerfile
@@ -2,3 +2,4 @@ FROM debian:12@sha256:b91baba9c2cae5edbe3b0ff50ae8f05157e3ae6f018372dcfc3aba224a
 ARG ARCH
 
 COPY /build/artifacts-linux-$ARCH/envoy/envoy /envoy
+COPY /build/artifacts-linux-$ARCH/envoy/usr /glibc/usr

--- a/tools/releases/dockerfiles/envoy.Dockerfile
+++ b/tools/releases/dockerfiles/envoy.Dockerfile
@@ -2,4 +2,4 @@ FROM debian:12@sha256:b91baba9c2cae5edbe3b0ff50ae8f05157e3ae6f018372dcfc3aba224a
 ARG ARCH
 
 COPY /build/artifacts-linux-$ARCH/envoy/envoy /envoy
-COPY /build/artifacts-linux-$ARCH/envoy/usr /glibc/usr
+COPY /build/artifacts-linux-$ARCH/envoy/glibc-compat /glibc/glibc-compat

--- a/tools/releases/dockerfiles/kuma-dp.Dockerfile
+++ b/tools/releases/dockerfiles/kuma-dp.Dockerfile
@@ -8,5 +8,6 @@ COPY /build/artifacts-linux-$ARCH/kuma-dp/kuma-dp \
     /usr/bin/
 
 COPY --from=envoy /envoy /usr/bin/envoy
+COPY --from=envoy /glibc/usr /usr/bin/usr
 
 ENTRYPOINT ["/usr/bin/kuma-dp"]

--- a/tools/releases/dockerfiles/kuma-dp.Dockerfile
+++ b/tools/releases/dockerfiles/kuma-dp.Dockerfile
@@ -8,6 +8,6 @@ COPY /build/artifacts-linux-$ARCH/kuma-dp/kuma-dp \
     /usr/bin/
 
 COPY --from=envoy /envoy /usr/bin/envoy
-COPY --from=envoy /glibc/usr /usr/bin/usr
+COPY --from=envoy /glibc/glibc-compat /usr/bin/glibc-compat
 
 ENTRYPOINT ["/usr/bin/kuma-dp"]

--- a/tools/releases/version.sh
+++ b/tools/releases/version.sh
@@ -9,18 +9,8 @@ function envoy_version() {
   # - if ENVOY_TAG is a commit hash then the version will look like '1.20.1-dev-b16d390f'
 
   ENVOY_TAG=${ENVOY_TAG:-"v1.27.0"}
-  ENVOY_VERSION=$(curl --silent --location "https://raw.githubusercontent.com/envoyproxy/envoy/${ENVOY_TAG}/VERSION.txt")
+  echo "1.27.0"
 
-  # for envoy versions older than v1.22.0 file 'VERSION.txt' used to be called 'VERSION'
-  if [[ "${ENVOY_VERSION}" == "404: Not Found" ]]; then
-    ENVOY_VERSION=$(curl --silent --location --fail "https://raw.githubusercontent.com/envoyproxy/envoy/${ENVOY_TAG}/VERSION")
-  fi
-
-  if [[ "${ENVOY_TAG}" =~ ^v[0-9]*\.[0-9]*\.[0-9]*$ ]]; then
-    echo "${ENVOY_VERSION}"
-  else
-    echo "${ENVOY_VERSION}-${ENVOY_TAG:0:8}"
-  fi
   set +o errexit
   set +o pipefail
   set +o nounset


### PR DESCRIPTION
To check if this works https://github.com/kumahq/envoy-builds/pull/39 

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [ ] [Link to relevant issue][1] as well as docs and UI issues --
- [ ] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [ ] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [ ] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [ ] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --
- [ ] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
