### PR TITLE
fix(kuma-cp): universal mode don't log on every lock acquire attempt

### DIFF
--- a/pkg/plugins/leader/plugin.go
+++ b/pkg/plugins/leader/plugin.go
@@ -26,7 +26,7 @@ func NewLeaderElector(b *core_runtime.Builder) (component.LeaderElector, error) 
 			pglock.WithLeaseDuration(5*time.Second),
 			pglock.WithHeartbeatFrequency(1*time.Second),
 			pglock.WithOwner(b.GetInstanceId()),
-			pglock.WithLogger(&leader_postgres.KumaPqLockLogger{}),
+			pglock.WithLevelLogger(&leader_postgres.KumaPqLockLogger{}),
 		)
 		if err != nil {
 			return nil, errors.Wrap(err, "could not create postgres lock client")

--- a/pkg/plugins/leader/postgres/leader_elector.go
+++ b/pkg/plugins/leader/postgres/leader_elector.go
@@ -3,7 +3,7 @@ package postgres
 import (
 	"context"
 	"fmt"
-	"strings"
+	"strconv"
 	"sync/atomic"
 	"time"
 
@@ -101,10 +101,18 @@ func (p *postgresLeaderElector) IsLeader() bool {
 
 type KumaPqLockLogger struct{}
 
-func (k *KumaPqLockLogger) Println(msgParts ...interface{}) {
-	stringParts := make([]string, len(msgParts))
-	for i, msgPart := range msgParts {
-		stringParts[i] = fmt.Sprint(msgPart)
+func (k *KumaPqLockLogger) keyValues(args []interface{}) []interface{} {
+	var line []interface{}
+	for i, arg := range args {
+		line = append(append(line, strconv.Itoa(i)), fmt.Sprint(arg))
 	}
-	log.Info(strings.Join(stringParts, " "))
+	return line
+}
+
+func (k *KumaPqLockLogger) Error(msg string, args ...interface{}) {
+	log.Error(nil, msg, k.keyValues(args)...)
+}
+
+func (k *KumaPqLockLogger) Debug(msg string, args ...interface{}) {
+	log.V(1).Info(msg, k.keyValues(args)...)
 }


### PR DESCRIPTION
They chose kind of a weird interface for the logging, no option to add keys, just a list of values. So I added the arg number as a key, as opposed to just concatenating everything.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --
- [x] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
