### PR TITLE
feat(kds): experimental event based watchdog

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -334,6 +334,7 @@ jobs:
 
             if [[ "<< parameters.deltaKDS >>" == true ]]; then
               export KUMA_DELTA_KDS=true
+              export KUMA_EXPERIMENTAL_KDS_EVENT_BASED_WATCHDOG_ENABLED=true
             fi
 
             if [[ "<< parameters.target >>" == "" ]]; then

--- a/docs/generated/kuma-cp.md
+++ b/docs/generated/kuma-cp.md
@@ -710,6 +710,14 @@ experimental:
   # The drawback is that you cannot use filtered out tags for traffic routing.
   # If empty, no filter is applied.
   ingressTagFilters: [] # ENV: KUMA_EXPERIMENTAL_INGRESS_TAG_FILTERS
+  # KDS event based watchdog settings. It is a more optimal way to generate KDS snapshot config.
+  kdsEventBasedWatchdog:
+    # If true, then experimental event based watchdog to generate KDS snapshot is used.
+    enabled: false # ENV: KUMA_EXPERIMENTAL_KDS_EVENT_BASED_WATCHDOG_ENABLED
+    # How often we flush changes when experimental event based watchdog is used.
+    flushInterval: 5s # ENV: KUMA_EXPERIMENTAL_KDS_EVENT_BASED_WATCHDOG_FLUSH_INTERVAL
+    # How often we schedule full KDS resync when experimental event based watchdog is used.
+    fullResyncInterval: 60s # ENV: KUMA_EXPERIMENTAL_KDS_EVENT_BASED_WATCHDOG_FULL_RESYNC_INTERVAL
 
 proxy:
   gateway:

--- a/docs/generated/raw/kuma-cp.yaml
+++ b/docs/generated/raw/kuma-cp.yaml
@@ -707,6 +707,14 @@ experimental:
   # The drawback is that you cannot use filtered out tags for traffic routing.
   # If empty, no filter is applied.
   ingressTagFilters: [] # ENV: KUMA_EXPERIMENTAL_INGRESS_TAG_FILTERS
+  # KDS event based watchdog settings. It is a more optimal way to generate KDS snapshot config.
+  kdsEventBasedWatchdog:
+    # If true, then experimental event based watchdog to generate KDS snapshot is used.
+    enabled: false # ENV: KUMA_EXPERIMENTAL_KDS_EVENT_BASED_WATCHDOG_ENABLED
+    # How often we flush changes when experimental event based watchdog is used.
+    flushInterval: 5s # ENV: KUMA_EXPERIMENTAL_KDS_EVENT_BASED_WATCHDOG_FLUSH_INTERVAL
+    # How often we schedule full KDS resync when experimental event based watchdog is used.
+    fullResyncInterval: 60s # ENV: KUMA_EXPERIMENTAL_KDS_EVENT_BASED_WATCHDOG_FULL_RESYNC_INTERVAL
 
 proxy:
   gateway:

--- a/pkg/config/app/kuma-cp/config.go
+++ b/pkg/config/app/kuma-cp/config.go
@@ -232,6 +232,11 @@ var DefaultConfig = func() Config {
 			KDSDeltaEnabled:                 false,
 			UseTagFirstVirtualOutboundModel: false,
 			IngressTagFilters:               []string{},
+			KDSEventBasedWatchdog: ExperimentalKDSEventBasedWatchdog{
+				Enabled:            false,
+				FlushInterval:      config_types.Duration{Duration: 5 * time.Second},
+				FullResyncInterval: config_types.Duration{Duration: 1 * time.Minute},
+			},
 		},
 		Proxy:   xds.DefaultProxyConfig(),
 		InterCp: intercp.DefaultInterCpConfig(),
@@ -388,6 +393,17 @@ type ExperimentalConfig struct {
 	// The drawback is that you cannot use filtered out tags for traffic routing.
 	// If empty, no filter is applied.
 	IngressTagFilters []string `json:"ingressTagFilters" envconfig:"KUMA_EXPERIMENTAL_INGRESS_TAG_FILTERS"`
+	// KDS event based watchdog settings. It is a more optimal way to generate KDS snapshot config.
+	KDSEventBasedWatchdog ExperimentalKDSEventBasedWatchdog `json:"kdsEventBasedWatchdog"`
+}
+
+type ExperimentalKDSEventBasedWatchdog struct {
+	// If true, then experimental event based watchdog to generate KDS snapshot is used.
+	Enabled bool `json:"enabled" envconfig:"KUMA_EXPERIMENTAL_KDS_EVENT_BASED_WATCHDOG_ENABLED"`
+	// How often we flush changes when experimental event based watchdog is used.
+	FlushInterval config_types.Duration `json:"flushInterval" envconfig:"KUMA_EXPERIMENTAL_KDS_EVENT_BASED_WATCHDOG_FLUSH_INTERVAL"`
+	// How often we schedule full KDS resync when experimental event based watchdog is used.
+	FullResyncInterval config_types.Duration `json:"fullResyncInterval" envconfig:"KUMA_EXPERIMENTAL_KDS_EVENT_BASED_WATCHDOG_FULL_RESYNC_INTERVAL"`
 }
 
 func (e ExperimentalConfig) Validate() error {

--- a/pkg/config/app/kuma-cp/kuma-cp.defaults.yaml
+++ b/pkg/config/app/kuma-cp/kuma-cp.defaults.yaml
@@ -707,6 +707,14 @@ experimental:
   # The drawback is that you cannot use filtered out tags for traffic routing.
   # If empty, no filter is applied.
   ingressTagFilters: [] # ENV: KUMA_EXPERIMENTAL_INGRESS_TAG_FILTERS
+  # KDS event based watchdog settings. It is a more optimal way to generate KDS snapshot config.
+  kdsEventBasedWatchdog:
+    # If true, then experimental event based watchdog to generate KDS snapshot is used.
+    enabled: false # ENV: KUMA_EXPERIMENTAL_KDS_EVENT_BASED_WATCHDOG_ENABLED
+    # How often we flush changes when experimental event based watchdog is used.
+    flushInterval: 5s # ENV: KUMA_EXPERIMENTAL_KDS_EVENT_BASED_WATCHDOG_FLUSH_INTERVAL
+    # How often we schedule full KDS resync when experimental event based watchdog is used.
+    fullResyncInterval: 60s # ENV: KUMA_EXPERIMENTAL_KDS_EVENT_BASED_WATCHDOG_FULL_RESYNC_INTERVAL
 
 proxy:
   gateway:

--- a/pkg/config/loader_test.go
+++ b/pkg/config/loader_test.go
@@ -338,6 +338,9 @@ var _ = Describe("Config loader", func() {
 			Expect(cfg.Experimental.KDSDeltaEnabled).To(BeTrue())
 			Expect(cfg.Experimental.UseTagFirstVirtualOutboundModel).To(BeFalse())
 			Expect(cfg.Experimental.IngressTagFilters).To(ContainElements("kuma.io/service"))
+			Expect(cfg.Experimental.KDSEventBasedWatchdog.Enabled).To(BeTrue())
+			Expect(cfg.Experimental.KDSEventBasedWatchdog.FlushInterval.Duration).To(Equal(10 * time.Second))
+			Expect(cfg.Experimental.KDSEventBasedWatchdog.FullResyncInterval.Duration).To(Equal(15 * time.Second))
 
 			Expect(cfg.Proxy.Gateway.GlobalDownstreamMaxConnections).To(BeNumerically("==", 1))
 		},
@@ -664,6 +667,10 @@ experimental:
   kdsDeltaEnabled: true
   useTagFirstVirtualOutboundModel: false
   ingressTagFilters: ["kuma.io/service"]
+  kdsEventBasedWatchdog:
+    enabled: true
+    flushInterval: 10s
+    fullResyncInterval: 15s
 proxy:
   gateway:
     globalDownstreamMaxConnections: 1
@@ -906,6 +913,9 @@ proxy:
 				"KUMA_EXPERIMENTAL_KUBE_OUTBOUNDS_AS_VIPS":                                                 "true",
 				"KUMA_EXPERIMENTAL_USE_TAG_FIRST_VIRTUAL_OUTBOUND_MODEL":                                   "false",
 				"KUMA_EXPERIMENTAL_INGRESS_TAG_FILTERS":                                                    "kuma.io/service",
+				"KUMA_EXPERIMENTAL_KDS_EVENT_BASED_WATCHDOG_ENABLED":                                       "true",
+				"KUMA_EXPERIMENTAL_KDS_EVENT_BASED_WATCHDOG_FLUSH_INTERVAL":                                "10s",
+				"KUMA_EXPERIMENTAL_KDS_EVENT_BASED_WATCHDOG_FULL_RESYNC_INTERVAL":                          "15s",
 				"KUMA_PROXY_GATEWAY_GLOBAL_DOWNSTREAM_MAX_CONNECTIONS":                                     "1",
 				"KUMA_TRACING_OPENTELEMETRY_ENDPOINT":                                                      "otel-collector:4317",
 			},

--- a/pkg/kds/v2/reconcile/interfaces.go
+++ b/pkg/kds/v2/reconcile/interfaces.go
@@ -5,15 +5,18 @@ import (
 
 	envoy_core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	envoy_cache "github.com/envoyproxy/go-control-plane/pkg/cache/v3"
+
+	"github.com/kumahq/kuma/pkg/core/resources/model"
+	cache_kds_v2 "github.com/kumahq/kuma/pkg/kds/v2/cache"
 )
 
 // Reconciler re-computes configuration for a given node.
 type Reconciler interface {
-	Reconcile(context.Context, *envoy_core.Node) error
+	Reconcile(context.Context, *envoy_core.Node, map[model.ResourceType]struct{}) error
 	Clear(context.Context, *envoy_core.Node) error
 }
 
 // Generates a snapshot of xDS resources for a given node.
 type SnapshotGenerator interface {
-	GenerateSnapshot(context.Context, *envoy_core.Node) (envoy_cache.ResourceSnapshot, error)
+	GenerateSnapshot(context.Context, *envoy_core.Node, cache_kds_v2.SnapshotBuilder, map[model.ResourceType]struct{}) (envoy_cache.ResourceSnapshot, error)
 }

--- a/pkg/kds/v2/reconcile/snapshot_generator.go
+++ b/pkg/kds/v2/reconcile/snapshot_generator.go
@@ -24,10 +24,9 @@ func Any(context.Context, string, kds.Features, model.Resource) bool {
 	return true
 }
 
-func NewSnapshotGenerator(resourceManager core_manager.ReadOnlyResourceManager, types []model.ResourceType, filter reconcile.ResourceFilter, mapper reconcile.ResourceMapper) SnapshotGenerator {
+func NewSnapshotGenerator(resourceManager core_manager.ReadOnlyResourceManager, filter reconcile.ResourceFilter, mapper reconcile.ResourceMapper) SnapshotGenerator {
 	return &snapshotGenerator{
 		resourceManager: resourceManager,
-		resourceTypes:   types,
 		resourceFilter:  filter,
 		resourceMapper:  mapper,
 	}
@@ -35,7 +34,6 @@ func NewSnapshotGenerator(resourceManager core_manager.ReadOnlyResourceManager, 
 
 type snapshotGenerator struct {
 	resourceManager core_manager.ReadOnlyResourceManager
-	resourceTypes   []model.ResourceType
 	resourceFilter  reconcile.ResourceFilter
 	resourceMapper  reconcile.ResourceMapper
 }

--- a/pkg/kds/v2/reconcile/snapshot_generator.go
+++ b/pkg/kds/v2/reconcile/snapshot_generator.go
@@ -40,9 +40,8 @@ type snapshotGenerator struct {
 	resourceMapper  reconcile.ResourceMapper
 }
 
-func (s *snapshotGenerator) GenerateSnapshot(ctx context.Context, node *envoy_core.Node) (envoy_cache.ResourceSnapshot, error) {
-	builder := cache_kds_v2.NewSnapshotBuilder()
-	for _, typ := range s.resourceTypes {
+func (s *snapshotGenerator) GenerateSnapshot(ctx context.Context, node *envoy_core.Node, builder cache_kds_v2.SnapshotBuilder, resTypes map[model.ResourceType]struct{}) (envoy_cache.ResourceSnapshot, error) {
+	for typ := range resTypes {
 		resources, err := s.getResources(ctx, typ, node)
 		if err != nil {
 			return nil, err

--- a/pkg/kds/v2/reconcile/snapshot_generator.go
+++ b/pkg/kds/v2/reconcile/snapshot_generator.go
@@ -40,7 +40,12 @@ type snapshotGenerator struct {
 	resourceMapper  reconcile.ResourceMapper
 }
 
-func (s *snapshotGenerator) GenerateSnapshot(ctx context.Context, node *envoy_core.Node, builder cache_kds_v2.SnapshotBuilder, resTypes map[model.ResourceType]struct{}) (envoy_cache.ResourceSnapshot, error) {
+func (s *snapshotGenerator) GenerateSnapshot(
+	ctx context.Context,
+	node *envoy_core.Node,
+	builder cache_kds_v2.SnapshotBuilder,
+	resTypes map[model.ResourceType]struct{},
+) (envoy_cache.ResourceSnapshot, error) {
 	for typ := range resTypes {
 		resources, err := s.getResources(ctx, typ, node)
 		if err != nil {

--- a/pkg/kds/v2/server/components.go
+++ b/pkg/kds/v2/server/components.go
@@ -102,11 +102,11 @@ func newSyncTracker(
 		changedTypes[typ] = struct{}{}
 	}
 	return util_xds_v3.NewWatchdogCallbacks(func(ctx context.Context, node *envoy_core.Node, streamID int64) (util_watchdog.Watchdog, error) {
+		log := log.WithValues("streamID", streamID, "node", node)
 		if experimentalWatchdogCfg.Enabled {
 			return &EventBasedWatchdog{
 				Ctx:                  ctx,
 				Node:                 node,
-				StreamID:             streamID,
 				Listener:             eventBus.Subscribe(),
 				Reconciler:           reconciler,
 				ProvidedTypes:        changedTypes,

--- a/pkg/kds/v2/server/components.go
+++ b/pkg/kds/v2/server/components.go
@@ -37,7 +37,7 @@ func New(
 	nackBackoff time.Duration,
 ) (Server, error) {
 	hasher, cache := newKDSContext(log)
-	generator := reconcile_v2.NewSnapshotGenerator(rt.ReadOnlyResourceManager(), providedTypes, filter, mapper)
+	generator := reconcile_v2.NewSnapshotGenerator(rt.ReadOnlyResourceManager(), filter, mapper)
 	statsCallbacks, err := util_xds.NewStatsCallbacks(rt.Metrics(), "kds_delta")
 	if err != nil {
 		return nil, err

--- a/pkg/kds/v2/server/event_based_watchdog.go
+++ b/pkg/kds/v2/server/event_based_watchdog.go
@@ -19,7 +19,6 @@ import (
 type EventBasedWatchdog struct {
 	Ctx                  context.Context
 	Node                 *envoy_core.Node
-	StreamID             int64
 	Listener             events.Listener
 	Reconciler           reconcile.Reconciler
 	ProvidedTypes        map[model.ResourceType]struct{}

--- a/pkg/kds/v2/server/event_based_watchdog.go
+++ b/pkg/kds/v2/server/event_based_watchdog.go
@@ -47,6 +47,7 @@ func (e *EventBasedWatchdog) Start(stop <-chan struct{}) {
 			if err := e.Reconciler.Clear(e.Ctx, e.Node); err != nil {
 				e.Log.Error(err, "reconcile clear failed")
 			}
+			e.Listener.Close()
 			return
 		case <-flushTicker.C:
 			if len(changedTypes) == 0 {

--- a/pkg/kds/v2/server/event_based_watchdog.go
+++ b/pkg/kds/v2/server/event_based_watchdog.go
@@ -1,0 +1,83 @@
+package server
+
+import (
+	"context"
+	"time"
+
+	envoy_core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	"github.com/go-logr/logr"
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/kumahq/kuma/pkg/core"
+	"github.com/kumahq/kuma/pkg/core/resources/model"
+	"github.com/kumahq/kuma/pkg/events"
+	"github.com/kumahq/kuma/pkg/kds/v2/reconcile"
+	"github.com/kumahq/kuma/pkg/multitenant"
+	util_watchdog "github.com/kumahq/kuma/pkg/util/watchdog"
+)
+
+type EventBasedWatchdog struct {
+	Ctx                  context.Context
+	Node                 *envoy_core.Node
+	StreamID             int64
+	Listener             events.Listener
+	Reconciler           reconcile.Reconciler
+	ProvidedTypes        map[model.ResourceType]struct{}
+	KdsGenerations       prometheus.Summary
+	KdsGenerationsErrors prometheus.Counter
+	Log                  logr.Logger
+	FlushInterval        time.Duration
+	FullResyncInterval   time.Duration
+}
+
+var _ util_watchdog.Watchdog = &EventBasedWatchdog{}
+
+func (e *EventBasedWatchdog) Start(stop <-chan struct{}) {
+	tenantID, _ := multitenant.TenantFromCtx(e.Ctx)
+	flushTicker := time.NewTicker(e.FlushInterval)
+	defer flushTicker.Stop()
+	fullResyncTicker := time.NewTicker(e.FullResyncInterval)
+	defer fullResyncTicker.Stop()
+
+	// for the first reconcile assign all types
+	changedTypes := e.ProvidedTypes
+
+	for {
+		select {
+		case <-stop:
+			if err := e.Reconciler.Clear(e.Ctx, e.Node); err != nil {
+				e.Log.Error(err, "reconcile clear failed")
+			}
+			return
+		case <-flushTicker.C:
+			if len(changedTypes) == 0 {
+				continue
+			}
+			e.Log.V(1).Info("reconcile", "changedTypes", changedTypes)
+			start := core.Now()
+			if err := e.Reconciler.Reconcile(e.Ctx, e.Node, changedTypes); err != nil {
+				e.Log.Error(err, "reconcile failed", "changedTypes", changedTypes)
+				e.KdsGenerationsErrors.Inc()
+			} else {
+				e.KdsGenerations.Observe(float64(core.Now().Sub(start).Milliseconds()))
+				changedTypes = map[model.ResourceType]struct{}{}
+			}
+		case <-fullResyncTicker.C:
+			e.Log.V(1).Info("schedule full resync")
+			changedTypes = e.ProvidedTypes
+		case event := <-e.Listener.Recv():
+			resChange, ok := event.(events.ResourceChangedEvent)
+			if !ok {
+				continue
+			}
+			if resChange.TenantID != tenantID {
+				continue
+			}
+			if _, ok := e.ProvidedTypes[resChange.Type]; !ok {
+				continue
+			}
+			e.Log.V(1).Info("schedule sync for type", "typ", resChange.Type)
+			changedTypes[resChange.Type] = struct{}{}
+		}
+	}
+}

--- a/pkg/test/kds/setup/server.go
+++ b/pkg/test/kds/setup/server.go
@@ -12,6 +12,7 @@ import (
 	"github.com/kumahq/kuma/pkg/core/resources/store"
 	"github.com/kumahq/kuma/pkg/core/runtime"
 	"github.com/kumahq/kuma/pkg/core/runtime/component"
+	"github.com/kumahq/kuma/pkg/events"
 	"github.com/kumahq/kuma/pkg/kds/reconcile"
 	kds_server "github.com/kumahq/kuma/pkg/kds/server"
 	kds_server_v2 "github.com/kumahq/kuma/pkg/kds/v2/server"
@@ -28,6 +29,7 @@ type testRuntimeContext struct {
 	metrics                  core_metrics.Metrics
 	pgxConfigCustomizationFn config.PgxConfigCustomization
 	tenants                  multitenant.Tenants
+	eventBus                 events.EventBus
 }
 
 func (t *testRuntimeContext) Config() kuma_cp.Config {
@@ -48,6 +50,10 @@ func (t *testRuntimeContext) PgxConfigCustomizationFn() config.PgxConfigCustomiz
 
 func (t *testRuntimeContext) Tenants() multitenant.Tenants {
 	return t.tenants
+}
+
+func (t *testRuntimeContext) EventBus() events.EventBus {
+	return t.eventBus
 }
 
 func (t *testRuntimeContext) APIWebServiceCustomize() func(*restful.WebService) error {
@@ -85,6 +91,7 @@ func StartDeltaServer(store store.ResourceStore, clusterID string, providedTypes
 		metrics:                  metrics,
 		tenants:                  multitenant.SingleTenant,
 		pgxConfigCustomizationFn: config.NoopPgxConfigCustomizationFn,
+		eventBus:                 events.NewEventBus(),
 	}
 	return kds_server_v2.New(core.Log.WithName("kds-delta").WithName(clusterID), rt, providedTypes, clusterID, 100*time.Millisecond, providedFilter, providedMapper, false, 1*time.Second)
 }


### PR DESCRIPTION
### Checklist prior to review

A test of experimental event-based watchdog for KDS.
I tested it manually with E2E test and it looks ok. We want to deploy this on our dev environment to see the perf gain. This might be a default, but for now we want to put it behind a flag.

The idea is instead of querying DB resources every X interval we react on postgres events and only generate snapshot for changed resources. Every Y interval we do a full resync if for some reason we lose the event.

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [ ] [Link to relevant issue][1] as well as docs and UI issues --
- [ ] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [ ] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [ ] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [ ] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --
- [ ] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
