### PR TITLE
fix(kds): experimental watchdog concurrent map write

### DIFF
--- a/pkg/kds/v2/server/event_based_watchdog.go
+++ b/pkg/kds/v2/server/event_based_watchdog.go
@@ -7,6 +7,7 @@ import (
 	envoy_core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	"github.com/go-logr/logr"
 	"github.com/prometheus/client_golang/prometheus"
+	"golang.org/x/exp/maps"
 
 	"github.com/kumahq/kuma/pkg/core"
 	"github.com/kumahq/kuma/pkg/core/resources/model"
@@ -39,7 +40,7 @@ func (e *EventBasedWatchdog) Start(stop <-chan struct{}) {
 	defer fullResyncTicker.Stop()
 
 	// for the first reconcile assign all types
-	changedTypes := e.ProvidedTypes
+	changedTypes := maps.Clone(e.ProvidedTypes)
 
 	for {
 		select {
@@ -64,7 +65,7 @@ func (e *EventBasedWatchdog) Start(stop <-chan struct{}) {
 			}
 		case <-fullResyncTicker.C:
 			e.Log.V(1).Info("schedule full resync")
-			changedTypes = e.ProvidedTypes
+			changedTypes = maps.Clone(e.ProvidedTypes)
 		case event := <-e.Listener.Recv():
 			resChange, ok := event.(events.ResourceChangedEvent)
 			if !ok {


### PR DESCRIPTION
### Checklist prior to review

With @lukidzi we discovered that with heavy traffic we can get into concurrent map write, because we assign shared map instead of cloning it.

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [ ] [Link to relevant issue][1] as well as docs and UI issues --
- [ ] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [ ] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [ ] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [ ] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --
- [ ] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
