### PR TITLE
feat(kds): add metrics to event based watchdog

### DIFF
--- a/pkg/kds/v2/reconcile/interfaces.go
+++ b/pkg/kds/v2/reconcile/interfaces.go
@@ -12,7 +12,9 @@ import (
 
 // Reconciler re-computes configuration for a given node.
 type Reconciler interface {
-	Reconcile(context.Context, *envoy_core.Node, map[model.ResourceType]struct{}) error
+	// Reconcile reconciles state of node given changed resource types.
+	// Returns error and bool which is true if any resource was changed.
+	Reconcile(context.Context, *envoy_core.Node, map[model.ResourceType]struct{}) (error, bool)
 	Clear(context.Context, *envoy_core.Node) error
 }
 

--- a/pkg/kds/v2/server/event_based_watchdog_test.go
+++ b/pkg/kds/v2/server/event_based_watchdog_test.go
@@ -1,0 +1,139 @@
+package server
+
+import (
+	"context"
+	"time"
+
+	envoy_core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	"github.com/go-logr/logr"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
+	core_model "github.com/kumahq/kuma/pkg/core/resources/model"
+	"github.com/kumahq/kuma/pkg/events"
+	reconcile_v2 "github.com/kumahq/kuma/pkg/kds/v2/reconcile"
+	core_metrics "github.com/kumahq/kuma/pkg/metrics"
+	test_metrics "github.com/kumahq/kuma/pkg/test/metrics"
+)
+
+type staticReconciler struct {
+	changedResTypes chan map[core_model.ResourceType]struct{}
+}
+
+func (s staticReconciler) Reconcile(ctx context.Context, node *envoy_core.Node, m map[core_model.ResourceType]struct{}) (error, bool) {
+	s.changedResTypes <- m
+	return nil, true
+}
+
+func (s staticReconciler) Clear(ctx context.Context, node *envoy_core.Node) error {
+	return nil
+}
+
+var _ reconcile_v2.Reconciler = &staticReconciler{}
+
+var _ = Describe("Event Based Watchdog", func() {
+	var eventBus events.EventBus
+	var metrics core_metrics.Metrics
+	var reconciler *staticReconciler
+	var stopCh chan struct{}
+	var flushCh chan time.Time
+	var fullResyncCh chan time.Time
+	var watchdog *EventBasedWatchdog
+
+	BeforeAll(func() {
+		var err error
+		metrics, err = core_metrics.NewMetrics("")
+		Expect(err).ToNot(HaveOccurred())
+		kdsMetrics, err := NewMetrics(metrics)
+		Expect(err).ToNot(HaveOccurred())
+
+		eventBus = events.NewEventBus()
+
+		stopCh = make(chan struct{})
+		flushCh = make(chan time.Time)
+		fullResyncCh = make(chan time.Time)
+		reconciler = &staticReconciler{
+			changedResTypes: make(chan map[core_model.ResourceType]struct{}, 1),
+		}
+		watchdog = &EventBasedWatchdog{
+			Ctx:        context.Background(),
+			Node:       nil,
+			Listener:   eventBus.Subscribe(),
+			Reconciler: reconciler,
+			ProvidedTypes: map[core_model.ResourceType]struct{}{
+				mesh.TrafficPermissionType: {},
+				mesh.TrafficLogType:        {},
+				mesh.TrafficRouteType:      {},
+			},
+			Metrics: kdsMetrics,
+			Log:     logr.Discard(),
+			NewFlushTicker: func() *time.Ticker {
+				return &time.Ticker{C: flushCh}
+			},
+			NewFullResyncTicker: func() *time.Ticker {
+				return &time.Ticker{C: fullResyncCh}
+			},
+		}
+		go func() {
+			watchdog.Start(stopCh)
+		}()
+	})
+
+	AfterAll(func() {
+		close(stopCh)
+	})
+
+	It("should reconcile on the first flush", func() {
+		// when
+		flushCh <- time.Now()
+
+		// then
+		changedResTypes := <-reconciler.changedResTypes
+		Expect(changedResTypes).To(Equal(watchdog.ProvidedTypes))
+		Eventually(func(g Gomega) {
+			metric := test_metrics.FindMetric(metrics, "kds_delta_generation", "reason", ReasonResync)
+			g.Expect(metric).ToNot(BeNil())
+			g.Expect(*metric.Summary.SampleCount).To(BeEquivalentTo(1))
+		}, "10s", "50ms").Should(Succeed())
+	})
+
+	It("should reconcile on the events flush", func() {
+		// when
+		eventBus.Send(events.ResourceChangedEvent{
+			Type: mesh.TrafficPermissionType,
+		})
+		eventBus.Send(events.ResourceChangedEvent{
+			Type: mesh.TrafficLogType,
+		})
+		// Send is not blocking so there is no guarantee that we execute flush before watchdog consumed events
+		time.Sleep(500 * time.Millisecond)
+		flushCh <- time.Now()
+
+		// then
+		changedResTypes := <-reconciler.changedResTypes
+		Expect(changedResTypes).To(HaveLen(2))
+		Expect(changedResTypes).To(HaveKey(mesh.TrafficPermissionType))
+		Expect(changedResTypes).To(HaveKey(mesh.TrafficLogType))
+		Eventually(func(g Gomega) {
+			metric := test_metrics.FindMetric(metrics, "kds_delta_generation", "reason", ReasonEvent)
+			g.Expect(metric).ToNot(BeNil())
+			g.Expect(*metric.Summary.SampleCount).To(BeEquivalentTo(1))
+		}, "10s", "50ms").Should(Succeed())
+	})
+
+	It("should reconcile on the full resync", func() {
+		// when
+		fullResyncCh <- time.Now()
+		flushCh <- time.Now()
+
+		// then
+		changedResTypes := <-reconciler.changedResTypes
+		Expect(changedResTypes).To(Equal(watchdog.ProvidedTypes))
+		Eventually(func(g Gomega) {
+			metric := test_metrics.FindMetric(metrics, "kds_delta_generation", "reason", ReasonResync)
+			g.Expect(metric).ToNot(BeNil())
+			g.Expect(*metric.Summary.SampleCount).To(BeEquivalentTo(2))
+		}, "10s", "50ms").Should(Succeed())
+	})
+}, Ordered)

--- a/pkg/kds/v2/server/metrics.go
+++ b/pkg/kds/v2/server/metrics.go
@@ -1,0 +1,41 @@
+package server
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+
+	core_metrics "github.com/kumahq/kuma/pkg/metrics"
+)
+
+const (
+	ReasonResync    = "resync"
+	ReasonEvent     = "event"
+	ResultChanged   = "changed"
+	ResultNoChanges = "no_changes"
+)
+
+type Metrics struct {
+	KdsGenerations       *prometheus.SummaryVec
+	KdsGenerationsErrors prometheus.Counter
+}
+
+func NewMetrics(metrics core_metrics.Metrics) (*Metrics, error) {
+	kdsGenerations := prometheus.NewSummaryVec(prometheus.SummaryOpts{
+		Name:       "kds_delta_generation",
+		Help:       "Summary of KDS Snapshot generation",
+		Objectives: core_metrics.DefaultObjectives,
+	}, []string{"reason", "result"})
+
+	kdsGenerationsErrors := prometheus.NewCounter(prometheus.CounterOpts{
+		Help: "Counter of errors during KDS generation",
+		Name: "kds_delta_generation_errors",
+	})
+
+	if err := metrics.BulkRegister(kdsGenerations, kdsGenerationsErrors); err != nil {
+		return nil, err
+	}
+
+	return &Metrics{
+		KdsGenerations:       kdsGenerations,
+		KdsGenerationsErrors: kdsGenerationsErrors,
+	}, nil
+}


### PR DESCRIPTION
### Checklist prior to review

This PR adds more granular metrics to kds reconciller and unit tests to the experimental watchdog.

We want to measure what triggered watchdog flush (event or resync) and what is the result (was something changed or did we waste CPU time). This way we can discover how useful is resync and whether we can change the resync of 60s to something like 5mins or 1h etc and save CPU resources. 

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [X] [Link to relevant issue][1] as well as docs and UI issues --
- [X] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [X] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [X] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [X] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --
- [X] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
