### PR TITLE
perf(insights): fetch dp overviews once

### DIFF
--- a/pkg/insights/resyncer.go
+++ b/pkg/insights/resyncer.go
@@ -189,17 +189,27 @@ func (r *resyncer) Start(stop <-chan struct{}) error {
 					// Usually this shouldn't close if there's no closed context
 					continue
 				}
+				if event.flag == 0 {
+					continue
+				}
 				startProcessingTime := r.now()
 				r.idleTime.Observe(float64(startProcessingTime.Sub(start).Milliseconds()))
 				r.timeToProcessItem.Observe(float64(startProcessingTime.Sub(event.time).Milliseconds()))
+				tenantCtx := multitenant.WithTenant(ctx, event.tenantId)
+				dpOverviews, err := r.dpOverviews(tenantCtx, event.mesh)
+				if err != nil {
+					log.Error(err, "unable to get DataplaneOverviews to recompute insights", "event", event)
+					continue
+				}
+
 				if event.flag&FlagService == FlagService {
-					err := r.createOrUpdateServiceInsight(ctx, event.tenantId, event.mesh)
+					err := r.createOrUpdateServiceInsight(tenantCtx, event.mesh, dpOverviews)
 					if err != nil {
 						log.Error(err, "unable to resync ServiceInsight", "event", event)
 					}
 				}
 				if event.flag&FlagMesh == FlagMesh {
-					err := r.createOrUpdateMeshInsight(ctx, event.tenantId, event.mesh)
+					err := r.createOrUpdateMeshInsight(tenantCtx, event.mesh, dpOverviews)
 					if err != nil {
 						log.Error(err, "unable to resync MeshInsight", "event", event)
 					}
@@ -267,13 +277,29 @@ func (r *resyncer) Start(stop <-chan struct{}) error {
 				if resourceChanged.Type == core_mesh.DataplaneType || resourceChanged.Type == core_mesh.DataplaneInsightType || resourceChanged.Type == core_mesh.ExternalServiceType {
 					f |= FlagService
 				}
-				batch.add(r.now(), resourceChanged.TenantID, meshName, f)
+				if f != 0 {
+					batch.add(r.now(), resourceChanged.TenantID, meshName, f)
+				}
 			}
 		case <-stop:
 			log.Info("stop")
 			return nil
 		}
 	}
+}
+
+func (r *resyncer) dpOverviews(ctx context.Context, mesh string) ([]*core_mesh.DataplaneOverviewResource, error) {
+	dataplanes := &core_mesh.DataplaneResourceList{}
+	if err := r.rm.List(ctx, dataplanes, store.ListByMesh(mesh)); err != nil {
+		return nil, err
+	}
+
+	dpInsights := &core_mesh.DataplaneInsightResourceList{}
+	if err := r.rm.List(ctx, dpInsights, store.ListByMesh(mesh)); err != nil {
+		return nil, err
+	}
+	overviews := core_mesh.NewDataplaneOverviews(*dataplanes, *dpInsights)
+	return overviews.Items, nil
 }
 
 func (r *resyncer) addMeshesToBatch(ctx context.Context, batch *eventBatch, tenantID string) {
@@ -313,23 +339,13 @@ func populateInsight(serviceType mesh_proto.ServiceInsight_Service_Type, insight
 	}
 }
 
-func (r *resyncer) createOrUpdateServiceInsight(ctx context.Context, tenantId string, mesh string) error {
-	ctx = multitenant.WithTenant(ctx, tenantId)
+func (r *resyncer) createOrUpdateServiceInsight(ctx context.Context, mesh string, dpOverviews []*core_mesh.DataplaneOverviewResource) error {
 	log := kuma_log.AddFieldsFromCtx(log, ctx, context.Background()).WithValues("mesh", mesh) // Add info
 	insight := &mesh_proto.ServiceInsight{
 		Services: map[string]*mesh_proto.ServiceInsight_Service{},
 	}
-	dp := &core_mesh.DataplaneResourceList{}
-	if err := r.rm.List(ctx, dp, store.ListByMesh(mesh)); err != nil {
-		return err
-	}
-	dpInsights := &core_mesh.DataplaneInsightResourceList{}
-	if err := r.rm.List(ctx, dpInsights, store.ListByMesh(mesh)); err != nil {
-		return err
-	}
-	dpOverviews := core_mesh.NewDataplaneOverviews(*dp, *dpInsights)
 
-	for _, dpOverview := range dpOverviews.Items {
+	for _, dpOverview := range dpOverviews {
 		status, _ := dpOverview.GetStatus()
 		networking := dpOverview.Spec.GetDataplane().GetNetworking()
 		backend := dpOverview.Spec.GetDataplaneInsight().GetMTLS().GetIssuedBackend()
@@ -400,8 +416,7 @@ func (r *resyncer) createOrUpdateServiceInsight(ctx context.Context, tenantId st
 	return nil
 }
 
-func (r *resyncer) createOrUpdateMeshInsight(ctx context.Context, tenantId string, mesh string) error {
-	ctx = multitenant.WithTenant(ctx, tenantId)
+func (r *resyncer) createOrUpdateMeshInsight(ctx context.Context, mesh string, dpOverviews []*core_mesh.DataplaneOverviewResource) error {
 	log := kuma_log.AddFieldsFromCtx(log, ctx, context.Background()).WithValues("mesh", mesh) // Add info
 	insight := &mesh_proto.MeshInsight{
 		Dataplanes: &mesh_proto.MeshInsight_DataplaneStat{},
@@ -420,23 +435,10 @@ func (r *resyncer) createOrUpdateMeshInsight(ctx context.Context, tenantId strin
 		},
 	}
 
-	dataplanes := &core_mesh.DataplaneResourceList{}
-	if err := r.rm.List(ctx, dataplanes, store.ListByMesh(mesh)); err != nil {
-		return err
-	}
-
-	insight.Dataplanes.Total = uint32(len(dataplanes.GetItems()))
-
-	dpInsights := &core_mesh.DataplaneInsightResourceList{}
-	if err := r.rm.List(ctx, dpInsights, store.ListByMesh(mesh)); err != nil {
-		return err
-	}
-
+	insight.Dataplanes.Total = uint32(len(dpOverviews))
 	internalServices := map[string]struct{}{}
 
-	dpOverviews := core_mesh.NewDataplaneOverviews(*dataplanes, *dpInsights)
-
-	for _, dpOverview := range dpOverviews.Items {
+	for _, dpOverview := range dpOverviews {
 		dpInsight := dpOverview.Spec.DataplaneInsight
 		dpSubscription := dpInsight.GetLastSubscription().(*mesh_proto.DiscoverySubscription)
 		kumaDpVersion := getOrDefault(dpSubscription.GetVersion().GetKumaDp().GetVersion())


### PR DESCRIPTION
### Checklist prior to review

In many cases service insights are computed with mesh insights in one event.
I noticed that we fetch dp overviews in both `createOrUpdateServiceInsight` and `createOrUpdateMeshInsight`. This is probably the most expensive DB query in insights. This change fetches dp overviews once and pass it to both functions.

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [X] [Link to relevant issue][1] as well as docs and UI issues --
- [X] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [X] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [X] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [X] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --
- [X] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
