### PR TITLE
fix(xds): backwards compatibility on access logs paths

### DIFF
--- a/pkg/core/xds/metadata.go
+++ b/pkg/core/xds/metadata.go
@@ -142,7 +142,7 @@ func (m *DataplaneMetadata) GetVersion() *mesh_proto.Version {
 	return m.Version
 }
 
-func DataplaneMetadataFromXdsMetadata(xdsMetadata *structpb.Struct, tmpDir string) *DataplaneMetadata {
+func DataplaneMetadataFromXdsMetadata(xdsMetadata *structpb.Struct, tmpDir string, dpKey model.ResourceKey) *DataplaneMetadata {
 	// Be extra careful here about nil checks since xdsMetadata is a "user" input.
 	// Even if we know that something should not be nil since we are generating metadata,
 	// the DiscoveryRequest can still be crafted manually to crash the CP.
@@ -178,11 +178,9 @@ func DataplaneMetadataFromXdsMetadata(xdsMetadata *structpb.Struct, tmpDir strin
 	if xdsMetadata.Fields[FieldAccessLogSocketPath] != nil {
 		metadata.AccessLogSocketPath = xdsMetadata.Fields[FieldAccessLogSocketPath].GetStringValue()
 		metadata.MetricsSocketPath = xdsMetadata.Fields[FieldMetricsSocketPath].GetStringValue()
-	} else if metadata.Resource != nil {
-		name := metadata.Resource.GetMeta().GetName()
-		mesh := metadata.Resource.GetMeta().GetMesh()
-		metadata.AccessLogSocketPath = AccessLogSocketName(tmpDir, name, mesh)
-		metadata.MetricsSocketPath = MetricsHijackerSocketName(tmpDir, name, mesh)
+	} else {
+		metadata.AccessLogSocketPath = AccessLogSocketName(tmpDir, dpKey.Name, dpKey.Mesh)
+		metadata.MetricsSocketPath = MetricsHijackerSocketName(tmpDir, dpKey.Name, dpKey.Mesh)
 	}
 
 	if xdsMetadata.Fields[FieldMetricsCertPath] != nil {

--- a/pkg/xds/auth/callbacks.go
+++ b/pkg/xds/auth/callbacks.go
@@ -118,7 +118,11 @@ func (a *authCallbacks) stream(streamID core_xds.StreamID, req util_xds.Discover
 	}
 
 	if s.resource == nil {
-		md := core_xds.DataplaneMetadataFromXdsMetadata(req.Metadata(), os.TempDir())
+		proxyId, err := core_xds.ParseProxyIdFromString(req.NodeId())
+		if err != nil {
+			return stream{}, errors.Wrap(err, "invalid node ID")
+		}
+		md := core_xds.DataplaneMetadataFromXdsMetadata(req.Metadata(), os.TempDir(), proxyId.ToResourceKey())
 		res, err := a.resource(user.Ctx(s.ctx, user.ControlPlane), md, req.NodeId())
 		if err != nil {
 			return stream{}, err

--- a/pkg/xds/server/callbacks/dataplane_callbacks.go
+++ b/pkg/xds/server/callbacks/dataplane_callbacks.go
@@ -96,7 +96,7 @@ func (d *xdsCallbacks) OnStreamRequest(streamID core_xds.StreamID, request util_
 		return errors.Wrap(err, "invalid node ID")
 	}
 	dpKey := proxyId.ToResourceKey()
-	metadata := core_xds.DataplaneMetadataFromXdsMetadata(request.Metadata(), os.TempDir())
+	metadata := core_xds.DataplaneMetadataFromXdsMetadata(request.Metadata(), os.TempDir(), dpKey)
 	if metadata == nil {
 		return errors.New("metadata in xDS Node cannot be nil")
 	}

--- a/pkg/xds/server/callbacks/dataplane_status_tracker.go
+++ b/pkg/xds/server/callbacks/dataplane_status_tracker.go
@@ -129,26 +129,25 @@ func (c *dataplaneStatusTracker) OnStreamRequest(streamID int64, req util_xds.Di
 	defer state.mu.Unlock()
 
 	if state.dataplaneId == (core_model.ResourceKey{}) {
-		var dpType core_model.ResourceType
-		md := core_xds.DataplaneMetadataFromXdsMetadata(req.Metadata(), os.TempDir())
-
-		// If the dataplane was started with a resource YAML, then it
-		// will be serialized in the node metadata and we would know
-		// the underlying type directly. Since that is optional, we
-		// can't depend on it here, so we map from the proxy type,
-		// which is guaranteed.
-		switch md.GetProxyType() {
-		case mesh_proto.IngressProxyType:
-			dpType = core_mesh.ZoneIngressType
-		case mesh_proto.DataplaneProxyType:
-			dpType = core_mesh.DataplaneType
-		case mesh_proto.EgressProxyType:
-			dpType = core_mesh.ZoneEgressType
-		}
-
 		// Infer the Dataplane ID.
 		if proxyId, err := core_xds.ParseProxyIdFromString(req.NodeId()); err == nil {
 			state.dataplaneId = proxyId.ToResourceKey()
+			var dpType core_model.ResourceType
+			md := core_xds.DataplaneMetadataFromXdsMetadata(req.Metadata(), os.TempDir(), state.dataplaneId)
+
+			// If the dataplane was started with a resource YAML, then it
+			// will be serialized in the node metadata and we would know
+			// the underlying type directly. Since that is optional, we
+			// can't depend on it here, so we map from the proxy type,
+			// which is guaranteed.
+			switch md.GetProxyType() {
+			case mesh_proto.IngressProxyType:
+				dpType = core_mesh.ZoneIngressType
+			case mesh_proto.DataplaneProxyType:
+				dpType = core_mesh.DataplaneType
+			case mesh_proto.EgressProxyType:
+				dpType = core_mesh.ZoneEgressType
+			}
 
 			log := statusTrackerLog.WithValues(
 				"proxyName", state.dataplaneId.Name,


### PR DESCRIPTION
### Checklist prior to review

The problem was `else if metadata.Resource != nil {`. In case of indirect lifecycle (Kubernetes), we don't have resource in the metadata therefore `AccessLogSocketPath` was always empty which results in

```
2023-09-05T23:47:22.049Z	ERROR	xds-server.dataplane-sync-watchdog	OnTick() failed	{"dataplaneKey": {"Mesh":"xxx","Name":"xxx"}, "error": "invalid resource \"kuma:metrics:hijacker\": invalid Cluster.LoadAssignment: embedded message failed validation | caused by: invalid ClusterLoadAssignment.Endpoints[0]: embedded message failed validation | caused by: invalid LocalityLbEndpoints.LbEndpoints[0]: embedded message failed validation | caused by: invalid LbEndpoint.Endpoint: embedded message failed validation | caused by: invalid Endpoint.Address: embedded message failed validation | caused by: invalid Address.SocketAddress: embedded message failed validation | caused by: invalid SocketAddress.Address: value length must be at least 1 runes", "errorVerbose": "invalid Cluster.LoadAssignment: embedded message failed validation | caused by: invalid ClusterLoadAssignment.Endpoints[0]: embedded message failed validation | caused by: invalid LocalityLbEndpoints.LbEndpoints[0]: embedded message failed validation | caused by: invalid LbEndpoint.Endpoint: embedded message failed validation | caused by: invalid Endpoint.Address: embedded message failed validation | caused by: invalid Address.SocketAddress: embedded message failed validation | caused by: invalid SocketAddress.Address: value length must be at least 1 runes
```

The problem goes away on redeploy of DPPs, but we should have a seamless upgrade.

This was not caught by E2E test, because our upgrade tests are somewhat basic. Here is the action plan how to fix it for the future https://github.com/kumahq/kuma/issues/7663

The issue only affects 2.4 version.

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [X] [Link to relevant issue][1] as well as docs and UI issues --
- [X] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [X] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [X] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [X] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --
- [X] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
