### PR TITLE
feat(helm): allow to define service accounts annotations

### DIFF
--- a/app/kumactl/cmd/install/testdata/install-control-plane.dump-values.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.dump-values.yaml
@@ -238,6 +238,9 @@ controlPlane:
       # -- If true, TLS cert of the server is not verified.
       skipVerify: false
 
+  # -- Annotations to add for Control Plane's Service Account
+  serviceAccountAnnotations: { }
+
   image:
     # -- Kuma CP ImagePullPolicy
     pullPolicy: IfNotPresent

--- a/deployments/charts/kuma/README.md
+++ b/deployments/charts/kuma/README.md
@@ -74,6 +74,7 @@ A Helm chart for the Kuma Control Plane
 | controlPlane.tls.kdsZoneClient.create | bool | `false` | Whether to create the TLS secret in helm. |
 | controlPlane.tls.kdsZoneClient.cert | string | `""` | CA bundle that was used to sign the certificate of KDS Global Server. |
 | controlPlane.tls.kdsZoneClient.skipVerify | bool | `false` | If true, TLS cert of the server is not verified. |
+| controlPlane.serviceAccountAnnotations | object | `{}` | Annotations to add for Control Plane's Service Account |
 | controlPlane.image.pullPolicy | string | `"IfNotPresent"` | Kuma CP ImagePullPolicy |
 | controlPlane.image.repository | string | `"kuma-cp"` | Kuma CP image repository |
 | controlPlane.image.tag | string | `nil` | Kuma CP Image tag. When not specified, the value is copied from global.tag |

--- a/deployments/charts/kuma/templates/cp-rbac.yaml
+++ b/deployments/charts/kuma/templates/cp-rbac.yaml
@@ -4,6 +4,10 @@ metadata:
   name: {{ include "kuma.name" . }}-control-plane
   namespace: {{ .Release.Namespace }}
   labels: {{ include "kuma.cpLabels" . | nindent 4 }}
+  {{- with .Values.controlPlane.serviceAccountAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 {{- with .Values.global.imagePullSecrets }}
 imagePullSecrets:
   {{- range . }}

--- a/deployments/charts/kuma/values.yaml
+++ b/deployments/charts/kuma/values.yaml
@@ -238,6 +238,9 @@ controlPlane:
       # -- If true, TLS cert of the server is not verified.
       skipVerify: false
 
+  # -- Annotations to add for Control Plane's Service Account
+  serviceAccountAnnotations: { }
+
   image:
     # -- Kuma CP ImagePullPolicy
     pullPolicy: IfNotPresent

--- a/docs/generated/raw/helm-values.yaml
+++ b/docs/generated/raw/helm-values.yaml
@@ -238,6 +238,9 @@ controlPlane:
       # -- If true, TLS cert of the server is not verified.
       skipVerify: false
 
+  # -- Annotations to add for Control Plane's Service Account
+  serviceAccountAnnotations: { }
+
   image:
     # -- Kuma CP ImagePullPolicy
     pullPolicy: IfNotPresent


### PR DESCRIPTION
### Checklist prior to review

- [X] [Link to relevant issue][1] as well as docs and UI issues -- fix: https://github.com/kumahq/kuma/issues/7720
- [X] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [X] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [X] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [X] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --
- [X] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
