### PR TITLE
fix(kuma-cp): set error when KDS clients fails in goroutine

### DIFF
--- a/pkg/kds/global/components.go
+++ b/pkg/kds/global/components.go
@@ -87,6 +87,7 @@ func Setup(rt runtime.Runtime) error {
 		go func() {
 			if err := kdsServer.StreamKumaResources(session.ServerStream()); err != nil {
 				log.Error(err, "StreamKumaResources finished with an error")
+				session.SetError(err)
 			} else {
 				log.V(1).Info("StreamKumaResources finished gracefully")
 			}
@@ -100,6 +101,7 @@ func Setup(rt runtime.Runtime) error {
 		go func() {
 			if err := sink.Receive(); err != nil {
 				log.Error(err, "KDSSink finished with an error")
+				session.SetError(err)
 			} else {
 				log.V(1).Info("KDSSink finished gracefully")
 			}

--- a/pkg/kds/mux/client.go
+++ b/pkg/kds/mux/client.go
@@ -164,10 +164,7 @@ func (c *client) startGlobalToZoneSync(ctx context.Context, log logr.Logger, con
 		errorCh <- err
 		return
 	}
-	if err := c.globalToZoneCb.OnGlobalToZoneSyncStarted(stream); err != nil {
-		errorCh <- errors.Wrap(err, "closing Global to Zone Sync stream after callback error")
-		return
-	}
+	c.globalToZoneCb.OnGlobalToZoneSyncStarted(stream, errorCh)
 	<-stop
 	log.Info("Global to Zone Sync rpc stream stopped")
 	if err := stream.CloseSend(); err != nil {
@@ -183,10 +180,7 @@ func (c *client) startZoneToGlobalSync(ctx context.Context, log logr.Logger, con
 		errorCh <- err
 		return
 	}
-	if err := c.zoneToGlobalCb.OnZoneToGlobalSyncStarted(stream); err != nil {
-		errorCh <- errors.Wrap(err, "closing Zone to Global Sync stream after callback error")
-		return
-	}
+	c.zoneToGlobalCb.OnZoneToGlobalSyncStarted(stream, errorCh)
 	<-stop
 	log.Info("Zone to Global Sync rpc stream stopped")
 	if err := stream.CloseSend(); err != nil {

--- a/pkg/kds/mux/server.go
+++ b/pkg/kds/mux/server.go
@@ -43,16 +43,16 @@ func (f OnSessionStartedFunc) OnSessionStarted(session Session) error {
 	return f(session)
 }
 
-type OnGlobalToZoneSyncStartedFunc func(session mesh_proto.KDSSyncService_GlobalToZoneSyncClient) error
+type OnGlobalToZoneSyncStartedFunc func(session mesh_proto.KDSSyncService_GlobalToZoneSyncClient, errorCh chan error)
 
-func (f OnGlobalToZoneSyncStartedFunc) OnGlobalToZoneSyncStarted(session mesh_proto.KDSSyncService_GlobalToZoneSyncClient) error {
-	return f(session)
+func (f OnGlobalToZoneSyncStartedFunc) OnGlobalToZoneSyncStarted(session mesh_proto.KDSSyncService_GlobalToZoneSyncClient, errorCh chan error) {
+	f(session, errorCh)
 }
 
-type OnZoneToGlobalSyncStartedFunc func(session mesh_proto.KDSSyncService_ZoneToGlobalSyncClient) error
+type OnZoneToGlobalSyncStartedFunc func(session mesh_proto.KDSSyncService_ZoneToGlobalSyncClient, errorCh chan error)
 
-func (f OnZoneToGlobalSyncStartedFunc) OnZoneToGlobalSyncStarted(session mesh_proto.KDSSyncService_ZoneToGlobalSyncClient) error {
-	return f(session)
+func (f OnZoneToGlobalSyncStartedFunc) OnZoneToGlobalSyncStarted(session mesh_proto.KDSSyncService_ZoneToGlobalSyncClient, errorCh chan error) {
+	f(session, errorCh)
 }
 
 type server struct {


### PR DESCRIPTION
### Checklist prior to review

We are using bi-directional GRPC for the communication between zone and global. KDS might fail when trying to connect with the global and because of this, the zone might not be in sync with Global resources. Because of that, we are using a resilient component which is responsible for starting the code again in case of errors. It works well when an error is returned. But the zone code wasn't returning an error and that caused the component to not start again.

I am not sure how to exactly test it yet.

- [X] [Link to relevant issue][1] as well as docs and UI issues -- fix: https://github.com/kumahq/kuma/issues/7723
- [X] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [X] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [X] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [X] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --
- [X] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
