### PR TITLE
feat(events): configurable buffers and predicates

### DIFF
--- a/docs/generated/kuma-cp.md
+++ b/docs/generated/kuma-cp.md
@@ -735,5 +735,5 @@ tracing:
 eventBus:
   # BufferSize controls the buffer for every single event listener.
   # If we go over buffer, additional delay may happen to various operation like insight recomputation or KDS.
-  bufferSize: 20 # ENV: KUMA_EVENT_BUS_BUFFER_SIZE
+  bufferSize: 100 # ENV: KUMA_EVENT_BUS_BUFFER_SIZE
 ```

--- a/docs/generated/kuma-cp.md
+++ b/docs/generated/kuma-cp.md
@@ -730,4 +730,10 @@ proxy:
 tracing:
   openTelemetry:
     endpoint: "" # e.g. otel-collector:4317
+
+# Configuration of the event bus which is local to one instance of CP
+eventBus:
+  # BufferSize controls the buffer for every single event listener.
+  # If we go over buffer, additional delay may happen to various operation like insight recomputation or KDS.
+  bufferSize: 20 # ENV: KUMA_EVENT_BUS_BUFFER_SIZE
 ```

--- a/docs/generated/raw/kuma-cp.yaml
+++ b/docs/generated/raw/kuma-cp.yaml
@@ -727,3 +727,9 @@ proxy:
 tracing:
   openTelemetry:
     endpoint: "" # e.g. otel-collector:4317
+
+# Configuration of the event bus which is local to one instance of CP
+eventBus:
+  # BufferSize controls the buffer for every single event listener.
+  # If we go over buffer, additional delay may happen to various operation like insight recomputation or KDS.
+  bufferSize: 20 # ENV: KUMA_EVENT_BUS_BUFFER_SIZE

--- a/docs/generated/raw/kuma-cp.yaml
+++ b/docs/generated/raw/kuma-cp.yaml
@@ -732,4 +732,4 @@ tracing:
 eventBus:
   # BufferSize controls the buffer for every single event listener.
   # If we go over buffer, additional delay may happen to various operation like insight recomputation or KDS.
-  bufferSize: 20 # ENV: KUMA_EVENT_BUS_BUFFER_SIZE
+  bufferSize: 100 # ENV: KUMA_EVENT_BUS_BUFFER_SIZE

--- a/pkg/config/app/kuma-cp/config.go
+++ b/pkg/config/app/kuma-cp/config.go
@@ -14,6 +14,7 @@ import (
 	"github.com/kumahq/kuma/pkg/config/diagnostics"
 	dns_server "github.com/kumahq/kuma/pkg/config/dns-server"
 	dp_server "github.com/kumahq/kuma/pkg/config/dp-server"
+	"github.com/kumahq/kuma/pkg/config/eventbus"
 	"github.com/kumahq/kuma/pkg/config/intercp"
 	"github.com/kumahq/kuma/pkg/config/mads"
 	"github.com/kumahq/kuma/pkg/config/multizone"
@@ -169,6 +170,8 @@ type Config struct {
 	InterCp intercp.InterCpConfig `json:"interCp"`
 	// Tracing
 	Tracing tracing.Config `json:"tracing"`
+	// EventBus is a configuration of the event bus which is local to one instance of CP.
+	EventBus eventbus.Config `json:"eventBus"`
 }
 
 func (c *Config) Sanitize() {
@@ -238,8 +241,9 @@ var DefaultConfig = func() Config {
 				FullResyncInterval: config_types.Duration{Duration: 1 * time.Minute},
 			},
 		},
-		Proxy:   xds.DefaultProxyConfig(),
-		InterCp: intercp.DefaultInterCpConfig(),
+		Proxy:    xds.DefaultProxyConfig(),
+		InterCp:  intercp.DefaultInterCpConfig(),
+		EventBus: eventbus.Default(),
 	}
 }
 

--- a/pkg/config/app/kuma-cp/kuma-cp.defaults.yaml
+++ b/pkg/config/app/kuma-cp/kuma-cp.defaults.yaml
@@ -727,3 +727,9 @@ proxy:
 tracing:
   openTelemetry:
     endpoint: "" # e.g. otel-collector:4317
+
+# Configuration of the event bus which is local to one instance of CP
+eventBus:
+  # BufferSize controls the buffer for every single event listener.
+  # If we go over buffer, additional delay may happen to various operation like insight recomputation or KDS.
+  bufferSize: 20 # ENV: KUMA_EVENT_BUS_BUFFER_SIZE

--- a/pkg/config/app/kuma-cp/kuma-cp.defaults.yaml
+++ b/pkg/config/app/kuma-cp/kuma-cp.defaults.yaml
@@ -732,4 +732,4 @@ tracing:
 eventBus:
   # BufferSize controls the buffer for every single event listener.
   # If we go over buffer, additional delay may happen to various operation like insight recomputation or KDS.
-  bufferSize: 20 # ENV: KUMA_EVENT_BUS_BUFFER_SIZE
+  bufferSize: 100 # ENV: KUMA_EVENT_BUS_BUFFER_SIZE

--- a/pkg/config/eventbus/config.go
+++ b/pkg/config/eventbus/config.go
@@ -12,6 +12,6 @@ func (c Config) Validate() error {
 
 func Default() Config {
 	return Config{
-		BufferSize: 20,
+		BufferSize: 100,
 	}
 }

--- a/pkg/config/eventbus/config.go
+++ b/pkg/config/eventbus/config.go
@@ -1,0 +1,17 @@
+package eventbus
+
+type Config struct {
+	// BufferSize controls the buffer for every single event listener.
+	// If we go over buffer, additional delay may happen to various operation like insight recomputation or KDS.
+	BufferSize uint `json:"bufferSize" envconfig:"kuma_event_bus_buffer_size"`
+}
+
+func (c Config) Validate() error {
+	return nil
+}
+
+func Default() Config {
+	return Config{
+		BufferSize: 20,
+	}
+}

--- a/pkg/config/loader_test.go
+++ b/pkg/config/loader_test.go
@@ -344,6 +344,7 @@ var _ = Describe("Config loader", func() {
 			Expect(cfg.Experimental.KDSEventBasedWatchdog.FullResyncInterval.Duration).To(Equal(15 * time.Second))
 
 			Expect(cfg.Proxy.Gateway.GlobalDownstreamMaxConnections).To(BeNumerically("==", 1))
+			Expect(cfg.EventBus.BufferSize).To(Equal(uint(30)))
 		},
 		Entry("from config file", testCase{
 			envVars: map[string]string{},
@@ -676,6 +677,8 @@ experimental:
 proxy:
   gateway:
     globalDownstreamMaxConnections: 1
+eventBus:
+  bufferSize: 30
 `,
 		}),
 		Entry("from env variables", testCase{
@@ -921,6 +924,7 @@ proxy:
 				"KUMA_EXPERIMENTAL_KDS_EVENT_BASED_WATCHDOG_FULL_RESYNC_INTERVAL":                          "15s",
 				"KUMA_PROXY_GATEWAY_GLOBAL_DOWNSTREAM_MAX_CONNECTIONS":                                     "1",
 				"KUMA_TRACING_OPENTELEMETRY_ENDPOINT":                                                      "otel-collector:4317",
+				"KUMA_EVENT_BUS_BUFFER_SIZE":                                                               "30",
 			},
 			yamlFileConfig: "",
 		}),

--- a/pkg/core/bootstrap/bootstrap.go
+++ b/pkg/core/bootstrap/bootstrap.go
@@ -281,7 +281,10 @@ func initializeResourceStore(cfg kuma_cp.Config, builder *core_runtime.Builder) 
 		return err
 	}
 	builder.WithResourceStore(rs)
-	eventBus := events.NewEventBus(cfg.EventBus.BufferSize)
+	eventBus, err := events.NewEventBus(cfg.EventBus.BufferSize, builder.Metrics())
+	if err != nil {
+		return err
+	}
 	if err := plugin.EventListener(builder, eventBus); err != nil {
 		return err
 	}

--- a/pkg/core/bootstrap/bootstrap.go
+++ b/pkg/core/bootstrap/bootstrap.go
@@ -281,7 +281,7 @@ func initializeResourceStore(cfg kuma_cp.Config, builder *core_runtime.Builder) 
 		return err
 	}
 	builder.WithResourceStore(rs)
-	eventBus := events.NewEventBus()
+	eventBus := events.NewEventBus(cfg.EventBus.BufferSize)
 	if err := plugin.EventListener(builder, eventBus); err != nil {
 		return err
 	}

--- a/pkg/events/eventbus.go
+++ b/pkg/events/eventbus.go
@@ -26,6 +26,8 @@ type eventBus struct {
 	bufferSize  uint
 }
 
+// Subscribe subscribes to a stream of events given Predicates
+// Predicate should not block on I/O, otherwise the whole event bus can block.
 func (b *eventBus) Subscribe(predicates ...Predicate) Listener {
 	id := core.NewUUID()
 	b.mtx.Lock()

--- a/pkg/events/eventbus.go
+++ b/pkg/events/eventbus.go
@@ -3,7 +3,10 @@ package events
 import (
 	"sync"
 
+	"github.com/prometheus/client_golang/prometheus"
+
 	"github.com/kumahq/kuma/pkg/core"
+	core_metrics "github.com/kumahq/kuma/pkg/metrics"
 )
 
 var log = core.Log.WithName("eventbus")
@@ -13,21 +16,31 @@ type subscriber struct {
 	predicates []Predicate
 }
 
-func NewEventBus(bufferSize uint) EventBus {
+func NewEventBus(bufferSize uint, metrics core_metrics.Metrics) (EventBus, error) {
+	metric := prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "events_dropped",
+		Help: "Number of dropped events in event bus due to full channels",
+	})
+	if err := metrics.Register(metric); err != nil {
+		return nil, err
+	}
 	return &eventBus{
 		subscribers: map[string]subscriber{},
 		bufferSize:  bufferSize,
-	}
+		metric:      metric,
+	}, nil
 }
 
 type eventBus struct {
 	mtx         sync.RWMutex
 	subscribers map[string]subscriber
 	bufferSize  uint
+	metric      prometheus.Counter
 }
 
 // Subscribe subscribes to a stream of events given Predicates
 // Predicate should not block on I/O, otherwise the whole event bus can block.
+// All predicates must pass for the event to enqueued.
 func (b *eventBus) Subscribe(predicates ...Predicate) Listener {
 	id := core.NewUUID()
 	b.mtx.Lock()
@@ -62,7 +75,8 @@ func (b *eventBus) Send(event Event) {
 			select {
 			case sub.ch <- event:
 			default:
-				log.Info("event is not sent because the channel is full. Ignoring event. Consider increasing buffer size using KUMA_EVENT_BUS_BUFFER_SIZE",
+				b.metric.Inc()
+				log.Info("[WARNING] event is not sent because the channel is full. Ignoring event. Consider increasing buffer size using KUMA_EVENT_BUS_BUFFER_SIZE",
 					"bufferSize", b.bufferSize,
 					"event", event,
 				)

--- a/pkg/events/eventbus_suite_test.go
+++ b/pkg/events/eventbus_suite_test.go
@@ -1,0 +1,11 @@
+package events_test
+
+import (
+	"testing"
+
+	"github.com/kumahq/kuma/pkg/test"
+)
+
+func TestEvents(t *testing.T) {
+	test.RunSpecs(t, "Events Suite")
+}

--- a/pkg/events/eventbus_test.go
+++ b/pkg/events/eventbus_test.go
@@ -1,0 +1,59 @@
+package events_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/kumahq/kuma/pkg/events"
+)
+
+var _ = Describe("EventBus", func() {
+	chHadEvent := func(ch <-chan events.Event) bool {
+		select {
+		case <-ch:
+			return true
+		default:
+			return false
+		}
+	}
+
+	It("should not block on Send", func() {
+		// given
+		eventBus := events.NewEventBus(1)
+		listener := eventBus.Subscribe()
+		event1 := events.ResourceChangedEvent{TenantID: "1"}
+		event2 := events.ResourceChangedEvent{TenantID: "2"}
+
+		// when
+		eventBus.Send(event1)
+		eventBus.Send(event2)
+
+		// then
+		event := <-listener.Recv()
+		Expect(event).To(Equal(event1))
+
+		// and second event was ignored because buffer was full
+		Expect(chHadEvent(listener.Recv())).To(BeFalse())
+	})
+
+	It("should only send events matched predicate", func() {
+		// given
+		eventBus := events.NewEventBus(10)
+		listener := eventBus.Subscribe(func(event events.Event) bool {
+			return event.(events.ResourceChangedEvent).TenantID == "1"
+		})
+		event1 := events.ResourceChangedEvent{TenantID: "1"}
+		event2 := events.ResourceChangedEvent{TenantID: "2"}
+
+		// when
+		eventBus.Send(event1)
+		eventBus.Send(event2)
+
+		// then
+		event := <-listener.Recv()
+		Expect(event).To(Equal(event1))
+
+		// and second event was ignored, because it did not match predicate
+		Expect(chHadEvent(listener.Recv())).To(BeFalse())
+	})
+})

--- a/pkg/events/interfaces.go
+++ b/pkg/events/interfaces.go
@@ -34,12 +34,14 @@ type Listener interface {
 	Close()
 }
 
+type Predicate = func(event Event) bool
+
 type Emitter interface {
 	Send(Event)
 }
 
 type ListenerFactory interface {
-	Subscribe() Listener
+	Subscribe(...Predicate) Listener
 }
 
 type EventBus interface {

--- a/pkg/insights/test/test_event_reader.go
+++ b/pkg/insights/test/test_event_reader.go
@@ -21,6 +21,6 @@ type TestEventReaderFactory struct {
 	Reader *TestEventReader
 }
 
-func (t *TestEventReaderFactory) Subscribe() events.Listener {
+func (t *TestEventReaderFactory) Subscribe(...events.Predicate) events.Listener {
 	return t.Reader
 }

--- a/pkg/kds/v2/server/components.go
+++ b/pkg/kds/v2/server/components.go
@@ -95,7 +95,7 @@ func newSyncTracker(
 			return &EventBasedWatchdog{
 				Ctx:           ctx,
 				Node:          node,
-				Listener:      eventBus.Subscribe(),
+				EventBus:      eventBus,
 				Reconciler:    reconciler,
 				ProvidedTypes: changedTypes,
 				Metrics:       kdsMetrics,

--- a/pkg/kds/v2/server/event_based_watchdog.go
+++ b/pkg/kds/v2/server/event_based_watchdog.go
@@ -21,7 +21,7 @@ import (
 type EventBasedWatchdog struct {
 	Ctx                 context.Context
 	Node                *envoy_core.Node
-	Listener            events.Listener
+	EventBus            events.EventBus
 	Reconciler          reconcile.Reconciler
 	ProvidedTypes       map[model.ResourceType]struct{}
 	Metrics             *Metrics
@@ -34,6 +34,19 @@ var _ util_watchdog.Watchdog = &EventBasedWatchdog{}
 
 func (e *EventBasedWatchdog) Start(stop <-chan struct{}) {
 	tenantID, _ := multitenant.TenantFromCtx(e.Ctx)
+	listener := e.EventBus.Subscribe(func(event events.Event) bool {
+		resChange, ok := event.(events.ResourceChangedEvent)
+		if !ok {
+			return false
+		}
+		if resChange.TenantID != tenantID {
+			return false
+		}
+		if _, ok := e.ProvidedTypes[resChange.Type]; !ok {
+			return false
+		}
+		return true
+	})
 	flushTicker := e.NewFlushTicker()
 	defer flushTicker.Stop()
 	fullResyncTicker := e.NewFullResyncTicker()
@@ -51,7 +64,7 @@ func (e *EventBasedWatchdog) Start(stop <-chan struct{}) {
 			if err := e.Reconciler.Clear(e.Ctx, e.Node); err != nil {
 				e.Log.Error(err, "reconcile clear failed")
 			}
-			e.Listener.Close()
+			listener.Close()
 			return
 		case <-flushTicker.C:
 			if len(changedTypes) == 0 {
@@ -80,17 +93,8 @@ func (e *EventBasedWatchdog) Start(stop <-chan struct{}) {
 			e.Log.V(1).Info("schedule full resync")
 			changedTypes = maps.Clone(e.ProvidedTypes)
 			reasons[ReasonResync] = struct{}{}
-		case event := <-e.Listener.Recv():
-			resChange, ok := event.(events.ResourceChangedEvent)
-			if !ok {
-				continue
-			}
-			if resChange.TenantID != tenantID {
-				continue
-			}
-			if _, ok := e.ProvidedTypes[resChange.Type]; !ok {
-				continue
-			}
+		case event := <-listener.Recv():
+			resChange := event.(events.ResourceChangedEvent)
 			e.Log.V(1).Info("schedule sync for type", "typ", resChange.Type)
 			changedTypes[resChange.Type] = struct{}{}
 			reasons[ReasonEvent] = struct{}{}

--- a/pkg/kds/v2/server/event_based_watchdog_test.go
+++ b/pkg/kds/v2/server/event_based_watchdog_test.go
@@ -48,7 +48,7 @@ var _ = Describe("Event Based Watchdog", func() {
 		kdsMetrics, err := NewMetrics(metrics)
 		Expect(err).ToNot(HaveOccurred())
 
-		eventBus = events.NewEventBus()
+		eventBus = events.NewEventBus(10)
 
 		stopCh = make(chan struct{})
 		flushCh = make(chan time.Time)
@@ -59,7 +59,7 @@ var _ = Describe("Event Based Watchdog", func() {
 		watchdog = &EventBasedWatchdog{
 			Ctx:        context.Background(),
 			Node:       nil,
-			Listener:   eventBus.Subscribe(),
+			EventBus:   eventBus,
 			Reconciler: reconciler,
 			ProvidedTypes: map[core_model.ResourceType]struct{}{
 				mesh.TrafficPermissionType: {},

--- a/pkg/kds/v2/server/event_based_watchdog_test.go
+++ b/pkg/kds/v2/server/event_based_watchdog_test.go
@@ -48,7 +48,10 @@ var _ = Describe("Event Based Watchdog", func() {
 		kdsMetrics, err := NewMetrics(metrics)
 		Expect(err).ToNot(HaveOccurred())
 
-		eventBus = events.NewEventBus(10)
+		metrics, err := core_metrics.NewMetrics("")
+		Expect(err).ToNot(HaveOccurred())
+		eventBus, err = events.NewEventBus(10, metrics)
+		Expect(err).ToNot(HaveOccurred())
 
 		stopCh = make(chan struct{})
 		flushCh = make(chan time.Time)

--- a/pkg/plugins/resources/postgres/listener_test.go
+++ b/pkg/plugins/resources/postgres/listener_test.go
@@ -124,7 +124,10 @@ func setupStore(cfg postgres_config.PostgresStoreConfig, driverName string) stor
 
 func setupListeners(cfg postgres_config.PostgresStoreConfig, driverName string, listenerErrCh chan error, listenerStopCh chan struct{}) kuma_events.Listener {
 	cfg.DriverName = driverName
-	eventsBus := kuma_events.NewEventBus(20)
+	metrics, err := core_metrics.NewMetrics("")
+	Expect(err).ToNot(HaveOccurred())
+	eventsBus, err := kuma_events.NewEventBus(20, metrics)
+	Expect(err).ToNot(HaveOccurred())
 	listener := eventsBus.Subscribe()
 	l := postgres_events.NewListener(cfg, eventsBus)
 	resilientListener := component.NewResilientComponent(core.Log.WithName("postgres-event-listener-component"), l)

--- a/pkg/plugins/resources/postgres/listener_test.go
+++ b/pkg/plugins/resources/postgres/listener_test.go
@@ -124,7 +124,7 @@ func setupStore(cfg postgres_config.PostgresStoreConfig, driverName string) stor
 
 func setupListeners(cfg postgres_config.PostgresStoreConfig, driverName string, listenerErrCh chan error, listenerStopCh chan struct{}) kuma_events.Listener {
 	cfg.DriverName = driverName
-	eventsBus := kuma_events.NewEventBus()
+	eventsBus := kuma_events.NewEventBus(20)
 	listener := eventsBus.Subscribe()
 	l := postgres_events.NewListener(cfg, eventsBus)
 	resilientListener := component.NewResilientComponent(core.Log.WithName("postgres-event-listener-component"), l)

--- a/pkg/test/kds/setup/server.go
+++ b/pkg/test/kds/setup/server.go
@@ -91,7 +91,7 @@ func StartDeltaServer(store store.ResourceStore, clusterID string, providedTypes
 		metrics:                  metrics,
 		tenants:                  multitenant.SingleTenant,
 		pgxConfigCustomizationFn: config.NoopPgxConfigCustomizationFn,
-		eventBus:                 events.NewEventBus(),
+		eventBus:                 events.NewEventBus(20),
 	}
 	return kds_server_v2.New(core.Log.WithName("kds-delta").WithName(clusterID), rt, providedTypes, clusterID, 100*time.Millisecond, providedFilter, providedMapper, false, 1*time.Second)
 }

--- a/pkg/test/kds/setup/server.go
+++ b/pkg/test/kds/setup/server.go
@@ -85,13 +85,17 @@ func StartDeltaServer(store store.ResourceStore, clusterID string, providedTypes
 	if err != nil {
 		return nil, err
 	}
+	eventBus, err := events.NewEventBus(20, metrics)
+	if err != nil {
+		return nil, err
+	}
 	rt := &testRuntimeContext{
 		rom:                      manager.NewResourceManager(store),
 		cfg:                      kuma_cp.Config{},
 		metrics:                  metrics,
 		tenants:                  multitenant.SingleTenant,
 		pgxConfigCustomizationFn: config.NoopPgxConfigCustomizationFn,
-		eventBus:                 events.NewEventBus(20),
+		eventBus:                 eventBus,
 	}
 	return kds_server_v2.New(core.Log.WithName("kds-delta").WithName(clusterID), rt, providedTypes, clusterID, 100*time.Millisecond, providedFilter, providedMapper, false, 1*time.Second)
 }

--- a/pkg/test/runtime/runtime.go
+++ b/pkg/test/runtime/runtime.go
@@ -106,7 +106,11 @@ func BuilderFor(appCtx context.Context, cfg kuma_cp.Config) (*core_runtime.Build
 		return nil, errors.New("LookupIP not set, set one in your test to resolve things")
 	})
 	builder.WithEnvoyAdminClient(&DummyEnvoyAdminClient{})
-	builder.WithEventBus(events.NewEventBus(10))
+	eventBus, err := events.NewEventBus(10, metrics)
+	if err != nil {
+		return nil, err
+	}
+	builder.WithEventBus(eventBus)
 	builder.WithAPIManager(customization.NewAPIList())
 	xdsCtx, err := xds_runtime.WithDefaults(builder) //nolint:contextcheck
 	if err != nil {

--- a/pkg/test/runtime/runtime.go
+++ b/pkg/test/runtime/runtime.go
@@ -106,7 +106,7 @@ func BuilderFor(appCtx context.Context, cfg kuma_cp.Config) (*core_runtime.Build
 		return nil, errors.New("LookupIP not set, set one in your test to resolve things")
 	})
 	builder.WithEnvoyAdminClient(&DummyEnvoyAdminClient{})
-	builder.WithEventBus(events.NewEventBus())
+	builder.WithEventBus(events.NewEventBus(10))
 	builder.WithAPIManager(customization.NewAPIList())
 	xdsCtx, err := xds_runtime.WithDefaults(builder) //nolint:contextcheck
 	if err != nil {


### PR DESCRIPTION
### Checklist prior to review

This PR improves an event bus.

Until now, every event listener created a channel and whenever we send an event, we send it into a channel. This means that whenever there is a full channel we are stuck on `.Send`. The cause of this can be a single listener that is not reading fast enough.
I changed the event bus to drop the event in this case and emit a log. Additionally:
* I created a config for the channel buffer. If we see that listeners are not consuming events on time, we can always increase this buffer without releasing a new version of Kuma.
* I introduced predicates. For example, if there is a listener that only cares about a specific event we can define a predicate. This way we can avoid putting unnecessary events into a channel.

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [X] [Link to relevant issue][1] as well as docs and UI issues --
- [X] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [X] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [X] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [X] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --
- [X] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
