### PR TITLE
feat(store): conflict metrics

### DIFF
--- a/pkg/metrics/store/store.go
+++ b/pkg/metrics/store/store.go
@@ -12,8 +12,9 @@ import (
 )
 
 type MeteredStore struct {
-	delegate store.ResourceStore
-	metric   *prometheus.HistogramVec
+	delegate  store.ResourceStore
+	metric    *prometheus.HistogramVec
+	conflicts *prometheus.CounterVec
 }
 
 func NewMeteredStore(delegate store.ResourceStore, metrics core_metrics.Metrics) (*MeteredStore, error) {
@@ -23,8 +24,12 @@ func NewMeteredStore(delegate store.ResourceStore, metrics core_metrics.Metrics)
 			Name: "store",
 			Help: "Summary of Store operations",
 		}, []string{"operation", "resource_type"}),
+		conflicts: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name: "store_conflicts",
+			Help: "Counter of store conflicts while update",
+		}, []string{"resource_type"}),
 	}
-	if err := metrics.Register(meteredStore.metric); err != nil {
+	if err := metrics.BulkRegister(meteredStore.metric, meteredStore.conflicts); err != nil {
 		return nil, err
 	}
 	return &meteredStore, nil
@@ -43,7 +48,11 @@ func (m *MeteredStore) Update(ctx context.Context, resource model.Resource, opti
 	defer func() {
 		m.metric.WithLabelValues("update", string(resource.Descriptor().Name)).Observe(core.Now().Sub(start).Seconds())
 	}()
-	return m.delegate.Update(ctx, resource, optionsFunc...)
+	err := m.delegate.Update(ctx, resource, optionsFunc...)
+	if store.IsResourceConflict(err) {
+		m.conflicts.WithLabelValues(string(resource.Descriptor().Name)).Inc()
+	}
+	return err
 }
 
 func (m *MeteredStore) Delete(ctx context.Context, resource model.Resource, optionsFunc ...store.DeleteOptionsFunc) error {


### PR DESCRIPTION
### Checklist prior to review

Add metric for store conflicts

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [X] [Link to relevant issue][1] as well as docs and UI issues --
- [X] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [X] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [X] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [X] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --
- [X] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
