### PR TITLE
chore(helm): allow to disable all helm hooks

### DIFF
--- a/app/kumactl/cmd/install/testdata/install-control-plane.dump-values.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.dump-values.yaml
@@ -18,7 +18,7 @@ installCrdsOnUpgrade:
   imagePullSecrets: []
 
 # -- Whether to disable all helm hooks
-disableHelmHooks: false
+noHelmHooks: false
 
 controlPlane:
   # -- Environment that control plane is run in, useful when running universal global control plane on k8s

--- a/deployments/charts/kuma/README.md
+++ b/deployments/charts/kuma/README.md
@@ -16,7 +16,7 @@ A Helm chart for the Kuma Control Plane
 | patchSystemNamespace | bool | `true` | Whether to patch the target namespace with the system label |
 | installCrdsOnUpgrade.enabled | bool | `true` | Whether install new CRDs before upgrade (if any were introduced with the new version of Kuma) |
 | installCrdsOnUpgrade.imagePullSecrets | list | `[]` | The `imagePullSecrets` to attach to the Service Account running CRD installation. This field will be deprecated in a future release, please use .global.imagePullSecrets |
-| disableHelmHooks | bool | `false` | Whether to disable all helm hooks |
+| noHelmHooks | bool | `false` | Whether to disable all helm hooks |
 | controlPlane.environment | string | `"kubernetes"` | Environment that control plane is run in, useful when running universal global control plane on k8s |
 | controlPlane.extraLabels | object | `{}` | Labels to add to resources in addition to default labels |
 | controlPlane.logLevel | string | `"info"` | Kuma CP log level: one of off,info,debug |

--- a/deployments/charts/kuma/templates/NOTES.txt
+++ b/deployments/charts/kuma/templates/NOTES.txt
@@ -1,13 +1,13 @@
 The Kuma Control Plane has been installed!
 
 You can access the control-plane via either the GUI, kubectl, the HTTP API, or the kumactl CLI.
-{{- if .Values.disableHelmHooks }}
+{{- if .Values.noHelmHooks }}
 
 -------------------------------------------------------------------------------
 
  WARNING
 
-    When the "disableHelmHooks" value is provided, you will need to manually delete
+    When the "noHelmHooks" value is provided, you will need to manually delete
     the "ValidatingWebhookConfiguration" responsible for validating {{ include "kuma.name" . }} resources
     before you can uninstall Helm release. This is because the validation provided
     by the webhook is not necessary during the release removal and might potentially
@@ -17,7 +17,7 @@ You can access the control-plane via either the GUI, kubectl, the HTTP API, or t
 
  WARNING
 
-    When the disableHelmHooks value is set, Helm will not automatically update
+    When the "noHelmHooks" value is set, Helm will not automatically update
     the CustomResourceDefinitions (CRDs) when upgrading release. You must manually
     update the CRDs if the new {{ include "kuma.name" . }} version has changes
     to the CRDs. You can achieve this by calling the following command:
@@ -28,7 +28,7 @@ You can access the control-plane via either the GUI, kubectl, the HTTP API, or t
 
  WARNING
 
-    When the disableHelmHooks value is set, Helm will not automatically uninstall
+    When the "noHelmHooks" value is set, Helm will not automatically uninstall
     the eBPF resources. You will need to manually uninstall these resources after
     uninstalling Helm release. To do this, run the following command:
 

--- a/deployments/charts/kuma/templates/post-delete-cleanup-ebpf-job.yaml
+++ b/deployments/charts/kuma/templates/post-delete-cleanup-ebpf-job.yaml
@@ -1,4 +1,4 @@
-{{- if and (.Values.experimental.ebpf.enabled) (and (not .Values.cni.enabled) (not .Values.disableHelmHooks)) }}
+{{- if and (.Values.experimental.ebpf.enabled) (and (not .Values.cni.enabled) (not .Values.noHelmHooks)) }}
   {{- $serviceAccountName := printf "%s-cleanup-node-ebpf-job" (include "kuma.name" .) }}
 apiVersion: v1
 kind: ServiceAccount

--- a/deployments/charts/kuma/templates/pre-delete-webhooks.yaml
+++ b/deployments/charts/kuma/templates/pre-delete-webhooks.yaml
@@ -1,4 +1,4 @@
-{{- if and (eq .Values.controlPlane.environment "kubernetes") (not .Values.disableHelmHooks) }}
+{{- if and (eq .Values.controlPlane.environment "kubernetes") (not .Values.noHelmHooks) }}
 # HELM first deletes RBAC of Kuma, then it tries to delete Secrets. We've got validating webhook on Secrets.
 # But even that the policy of this webhook is Ignore, it fails because Kuma does not have permission to access Secrets anymore.
 # Therefore we first need to delete webhook so we can delete the rest of the deployment

--- a/deployments/charts/kuma/templates/pre-install-patch-namespace-job.yaml
+++ b/deployments/charts/kuma/templates/pre-install-patch-namespace-job.yaml
@@ -1,5 +1,5 @@
-{{- if .Values.disableHelmHooks }}
-  {{- $errorMessage := ".Values.disableHelmHooks is set. You must manually create and label the system namespace with kuma.io/system-namespace: \"true\" before installing or upgrading the chart" }}
+{{- if .Values.noHelmHooks }}
+  {{- $errorMessage := ".Values.noHelmHooks is set. You must manually create and label the system namespace with kuma.io/system-namespace: \"true\" before installing or upgrading the chart" }}
   {{- $systemNamespace := (lookup "v1" "Namespace" "" .Release.Namespace) }}
   {{- if not $systemNamespace }}
       {{- fail $errorMessage }}

--- a/deployments/charts/kuma/templates/pre-upgrade-install-crds-job.yaml
+++ b/deployments/charts/kuma/templates/pre-upgrade-install-crds-job.yaml
@@ -1,4 +1,4 @@
-{{- if (and .Values.installCrdsOnUpgrade.enabled (and (not .Values.disableHelmHooks) (eq .Values.controlPlane.environment "kubernetes"))) }}
+{{- if (and .Values.installCrdsOnUpgrade.enabled (and (not .Values.noHelmHooks) (eq .Values.controlPlane.environment "kubernetes"))) }}
   {{ $hook := "pre-upgrade,pre-install" }}
   {{- $serviceAccountName := printf "%s-install-crds" (include "kuma.name" .) }}
 apiVersion: v1

--- a/deployments/charts/kuma/values.yaml
+++ b/deployments/charts/kuma/values.yaml
@@ -18,7 +18,7 @@ installCrdsOnUpgrade:
   imagePullSecrets: []
 
 # -- Whether to disable all helm hooks
-disableHelmHooks: false
+noHelmHooks: false
 
 controlPlane:
   # -- Environment that control plane is run in, useful when running universal global control plane on k8s

--- a/docs/generated/raw/helm-values.yaml
+++ b/docs/generated/raw/helm-values.yaml
@@ -18,7 +18,7 @@ installCrdsOnUpgrade:
   imagePullSecrets: []
 
 # -- Whether to disable all helm hooks
-disableHelmHooks: false
+noHelmHooks: false
 
 controlPlane:
   # -- Environment that control plane is run in, useful when running universal global control plane on k8s


### PR DESCRIPTION
There is an option to set `noHelmHooks` which will as the name implies disable all helm hooks and add appropriate warnings in the notes after installation.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues
  - No relevant issue
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS
  - It won't
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s)
  - Manually tested on local k3d cluster
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)?
  - There is no need
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label)
  - Yes, this change needs to be backported as it may be necessary for someone with very strict security policy to not allow custom docker images (like the ones used for helm hooks)
- [x] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
