### PR TITLE
feat(postgres): support reader replica

### DIFF
--- a/docs/generated/kuma-cp.md
+++ b/docs/generated/kuma-cp.md
@@ -68,6 +68,14 @@ store:
     # MaxReconnectInterval (applied only when driverName=postgres) controls the maximum possible duration to wait before trying
     # to re-establish the database connection after connection loss.
     maxReconnectInterval: "60s" # ENV: KUMA_STORE_POSTGRES_MAX_RECONNECT_INTERVAL
+    # ReadReplica is a setting for a DB replica used only for read queries
+    readReplica:
+      # Host of the Postgres DB read replica. If not set, read replica is not used.
+      host: "" # ENV: KUMA_STORE_POSTGRES_READ_REPLICA_HOST
+      # Port of the Postgres DB read replica
+      port: 5432 # ENV: KUMA_STORE_POSTGRES_READ_REPLICA_PORT
+      # Ratio in [0-100] range. How many SELECT queries (out of 100) will use read replica.
+      ratio: 100 # ENV: KUMA_STORE_POSTGRES_READ_REPLICA_RATIO
 
   # Cache for read only operations. This cache is local to the instance of the control plane.
   cache:

--- a/docs/generated/raw/kuma-cp.yaml
+++ b/docs/generated/raw/kuma-cp.yaml
@@ -65,6 +65,14 @@ store:
     # MaxReconnectInterval (applied only when driverName=postgres) controls the maximum possible duration to wait before trying
     # to re-establish the database connection after connection loss.
     maxReconnectInterval: "60s" # ENV: KUMA_STORE_POSTGRES_MAX_RECONNECT_INTERVAL
+    # ReadReplica is a setting for a DB replica used only for read queries
+    readReplica:
+      # Host of the Postgres DB read replica. If not set, read replica is not used.
+      host: "" # ENV: KUMA_STORE_POSTGRES_READ_REPLICA_HOST
+      # Port of the Postgres DB read replica
+      port: 5432 # ENV: KUMA_STORE_POSTGRES_READ_REPLICA_PORT
+      # Ratio in [0-100] range. How many SELECT queries (out of 100) will use read replica.
+      ratio: 100 # ENV: KUMA_STORE_POSTGRES_READ_REPLICA_RATIO
 
   # Cache for read only operations. This cache is local to the instance of the control plane.
   cache:

--- a/pkg/config/app/kuma-cp/kuma-cp.defaults.yaml
+++ b/pkg/config/app/kuma-cp/kuma-cp.defaults.yaml
@@ -65,6 +65,14 @@ store:
     # MaxReconnectInterval (applied only when driverName=postgres) controls the maximum possible duration to wait before trying
     # to re-establish the database connection after connection loss.
     maxReconnectInterval: "60s" # ENV: KUMA_STORE_POSTGRES_MAX_RECONNECT_INTERVAL
+    # ReadReplica is a setting for a DB replica used only for read queries
+    readReplica:
+      # Host of the Postgres DB read replica. If not set, read replica is not used.
+      host: "" # ENV: KUMA_STORE_POSTGRES_READ_REPLICA_HOST
+      # Port of the Postgres DB read replica
+      port: 5432 # ENV: KUMA_STORE_POSTGRES_READ_REPLICA_PORT
+      # Ratio in [0-100] range. How many SELECT queries (out of 100) will use read replica.
+      ratio: 100 # ENV: KUMA_STORE_POSTGRES_READ_REPLICA_RATIO
 
   # Cache for read only operations. This cache is local to the instance of the control plane.
   cache:

--- a/pkg/config/loader_test.go
+++ b/pkg/config/loader_test.go
@@ -122,6 +122,10 @@ var _ = Describe("Config loader", func() {
 			Expect(cfg.Store.Postgres.TLS.CAPath).To(Equal("/path/to/rootCert"))
 			Expect(cfg.Store.Postgres.TLS.DisableSSLSNI).To(BeTrue())
 
+			Expect(cfg.Store.Postgres.ReadReplica.Host).To(Equal("ro.host"))
+			Expect(cfg.Store.Postgres.ReadReplica.Port).To(Equal(uint(35432)))
+			Expect(cfg.Store.Postgres.ReadReplica.Ratio).To(Equal(uint(80)))
+
 			Expect(cfg.ApiServer.ReadOnly).To(BeTrue())
 			Expect(cfg.ApiServer.HTTP.Enabled).To(BeFalse())
 			Expect(cfg.ApiServer.HTTP.Interface).To(Equal("192.168.0.1"))
@@ -376,6 +380,10 @@ store:
       keyPath: /path/to/key
       caPath: /path/to/rootCert
       disableSSLSNI: true
+    readReplica:
+      host: ro.host
+      port: 35432
+      ratio: 80
   kubernetes:
     systemNamespace: test-namespace
   cache:
@@ -713,6 +721,9 @@ eventBus:
 				"KUMA_STORE_POSTGRES_MIN_RECONNECT_INTERVAL":                                               "44s",
 				"KUMA_STORE_POSTGRES_MAX_RECONNECT_INTERVAL":                                               "55s",
 				"KUMA_STORE_POSTGRES_MAX_LIST_QUERY_ELEMENTS":                                              "111",
+				"KUMA_STORE_POSTGRES_READ_REPLICA_HOST":                                                    "ro.host",
+				"KUMA_STORE_POSTGRES_READ_REPLICA_PORT":                                                    "35432",
+				"KUMA_STORE_POSTGRES_READ_REPLICA_RATIO":                                                   "80",
 				"KUMA_STORE_KUBERNETES_SYSTEM_NAMESPACE":                                                   "test-namespace",
 				"KUMA_STORE_CACHE_ENABLED":                                                                 "false",
 				"KUMA_STORE_CACHE_EXPIRATION_TIME":                                                         "3s",

--- a/pkg/config/plugins/resources/postgres/config.go
+++ b/pkg/config/plugins/resources/postgres/config.go
@@ -77,6 +77,24 @@ type PostgresStoreConfig struct {
 	MaxReconnectInterval config_types.Duration `json:"maxReconnectInterval" envconfig:"kuma_store_postgres_max_reconnect_interval"`
 	// MaxListQueryElements defines maximum number of changed elements before requesting full list of elements from the store.
 	MaxListQueryElements uint32 `json:"maxListQueryElements" envconfig:"kuma_store_postgres_max_list_query_elements"`
+	// ReadReplica is a setting for a DB replica used only for read queries
+	ReadReplica ReadReplica `json:"readReplica"`
+}
+
+type ReadReplica struct {
+	// Host of the Postgres DB read replica. If not set, read replica is not used.
+	Host string `json:"host" envconfig:"kuma_store_postgres_read_replica_host"`
+	// Port of the Postgres DB read replica
+	Port uint `json:"port" envconfig:"kuma_store_postgres_read_replica_port"`
+	// Ratio in [0-100] range. How many SELECT queries (out of 100) will use read replica.
+	Ratio uint `json:"ratio" envconfig:"kuma_store_postgres_read_replica_ratio"`
+}
+
+func (cfg ReadReplica) Validate() error {
+	if cfg.Ratio > 100 {
+		return errors.New(".Ratio out of [0-100] range")
+	}
+	return nil
 }
 
 func (cfg PostgresStoreConfig) ConnectionString() (string, error) {
@@ -222,6 +240,9 @@ func (p *PostgresStoreConfig) Validate() error {
 	if p.HealthCheckInterval.Duration < 0 {
 		return errors.New("HealthCheckInterval should be greater than 0")
 	}
+	if err := p.ReadReplica.Validate(); err != nil {
+		return errors.Wrapf(err, "ReadReplica validation failed")
+	}
 	warning := "[WARNING] "
 	switch p.DriverName {
 	case DriverNamePgx:
@@ -277,6 +298,10 @@ func DefaultPostgresStoreConfig() *PostgresStoreConfig {
 		MaxConnectionLifetimeJitter: DefaultMaxConnectionLifetimeJitter,
 		HealthCheckInterval:         DefaultHealthCheckInterval,
 		MaxListQueryElements:        0,
+		ReadReplica: ReadReplica{
+			Port:  5432,
+			Ratio: 100,
+		},
 	}
 }
 

--- a/pkg/plugins/resources/postgres/pgx_store.go
+++ b/pkg/plugins/resources/postgres/pgx_store.go
@@ -3,6 +3,7 @@ package postgres
 import (
 	"context"
 	"fmt"
+	"math/rand"
 	"strconv"
 	"strings"
 	"time"
@@ -23,6 +24,8 @@ import (
 
 type pgxResourceStore struct {
 	pool                 *pgxpool.Pool
+	roPool               *pgxpool.Pool
+	roRatio              uint
 	maxListQueryElements uint32
 }
 
@@ -35,14 +38,29 @@ func NewPgxStore(metrics core_metrics.Metrics, config config.PostgresStoreConfig
 	if err != nil {
 		return nil, err
 	}
+	var roPool *pgxpool.Pool
+	if config.ReadReplica.Host != "" {
+		roConfig := config
+		roConfig.Host = config.ReadReplica.Host
+		roConfig.Port = int(config.ReadReplica.Port)
+		roPool, err = postgres.ConnectToDbPgx(roConfig)
+		if err != nil {
+			return nil, err
+		}
+		if err := registerMetrics(metrics, roPool, "ro"); err != nil {
+			return nil, errors.Wrapf(err, "could not register DB metrics")
+		}
+	}
 
-	if err := registerMetrics(metrics, pool); err != nil {
+	if err := registerMetrics(metrics, pool, "rw"); err != nil {
 		return nil, errors.Wrapf(err, "could not register DB metrics")
 	}
 
 	return &pgxResourceStore{
 		pool:                 pool,
+		roPool:               roPool,
 		maxListQueryElements: config.MaxListQueryElements,
+		roRatio:              config.ReadReplica.Ratio,
 	}, nil
 }
 
@@ -148,7 +166,7 @@ func (r *pgxResourceStore) Get(ctx context.Context, resource core_model.Resource
 	opts := store.NewGetOptions(fs...)
 
 	statement := `SELECT spec, version, creation_time, modification_time FROM resources WHERE name=$1 AND mesh=$2 AND type=$3;`
-	row := r.pool.QueryRow(ctx, statement, opts.Name, opts.Mesh, resource.Descriptor().Name)
+	row := r.pickRoPool().QueryRow(ctx, statement, opts.Name, opts.Mesh, resource.Descriptor().Name)
 
 	var spec string
 	var version int
@@ -178,6 +196,17 @@ func (r *pgxResourceStore) Get(ctx context.Context, resource core_model.Resource
 		return store.ErrorResourcePreconditionFailed(resource.Descriptor().Name, opts.Name, opts.Mesh)
 	}
 	return nil
+}
+
+func (r *pgxResourceStore) pickRoPool() *pgxpool.Pool {
+	if r.roPool == nil {
+		return r.pool
+	}
+	// #nosec G404 - math rand is enough
+	if rand.Int31n(101) <= int32(r.roRatio) {
+		return r.roPool
+	}
+	return r.pool
 }
 
 func (r *pgxResourceStore) List(ctx context.Context, resources core_model.ResourceList, args ...store.ListOptionsFunc) error {
@@ -225,7 +254,7 @@ func (r *pgxResourceStore) List(ctx context.Context, resources core_model.Resour
 	}
 	statement += " ORDER BY name, mesh"
 
-	rows, err := r.pool.Query(ctx, statement, statementArgs...)
+	rows, err := r.pickRoPool().Query(ctx, statement, statementArgs...)
 	if err != nil {
 		return errors.Wrapf(err, "failed to execute query: %s", statement)
 	}
@@ -286,15 +315,19 @@ func rowToItem(resources core_model.ResourceList, rows pgx.Rows) (core_model.Res
 
 func (r *pgxResourceStore) Close() error {
 	r.pool.Close()
+	if r.roPool != nil {
+		r.roPool.Close()
+	}
 	return nil
 }
 
-func registerMetrics(metrics core_metrics.Metrics, pool *pgxpool.Pool) error {
+func registerMetrics(metrics core_metrics.Metrics, pool *pgxpool.Pool, poolName string) error {
 	postgresCurrentConnectionMetric := prometheus.NewGaugeFunc(prometheus.GaugeOpts{
 		Name: "store_postgres_connections",
 		Help: "Current number of postgres store connections",
 		ConstLabels: map[string]string{
 			"type": "open_connections",
+			"pool": poolName,
 		},
 	}, func() float64 {
 		return float64(pool.Stat().TotalConns())
@@ -305,6 +338,7 @@ func registerMetrics(metrics core_metrics.Metrics, pool *pgxpool.Pool) error {
 		Help: "Current number of postgres store connections",
 		ConstLabels: map[string]string{
 			"type": "in_use",
+			"pool": poolName,
 		},
 	}, func() float64 {
 		return float64(pool.Stat().AcquiredConns())
@@ -315,6 +349,7 @@ func registerMetrics(metrics core_metrics.Metrics, pool *pgxpool.Pool) error {
 		Help: "Current number of postgres store connections",
 		ConstLabels: map[string]string{
 			"type": "idle",
+			"pool": poolName,
 		},
 	}, func() float64 {
 		return float64(pool.Stat().IdleConns())
@@ -323,6 +358,9 @@ func registerMetrics(metrics core_metrics.Metrics, pool *pgxpool.Pool) error {
 	postgresMaxOpenConnectionMetric := prometheus.NewGaugeFunc(prometheus.GaugeOpts{
 		Name: "store_postgres_connections_max",
 		Help: "Max postgres store open connections",
+		ConstLabels: map[string]string{
+			"pool": poolName,
+		},
 	}, func() float64 {
 		return float64(pool.Stat().MaxConns())
 	})
@@ -330,6 +368,9 @@ func registerMetrics(metrics core_metrics.Metrics, pool *pgxpool.Pool) error {
 	postgresWaitConnectionMetric := prometheus.NewGaugeFunc(prometheus.GaugeOpts{
 		Name: "store_postgres_connection_wait_count",
 		Help: "Current waiting postgres store connections",
+		ConstLabels: map[string]string{
+			"pool": poolName,
+		},
 	}, func() float64 {
 		return float64(pool.Stat().EmptyAcquireCount())
 	})
@@ -337,6 +378,9 @@ func registerMetrics(metrics core_metrics.Metrics, pool *pgxpool.Pool) error {
 	postgresWaitConnectionDurationMetric := prometheus.NewGaugeFunc(prometheus.GaugeOpts{
 		Name: "store_postgres_connection_wait_duration",
 		Help: "Time Blocked waiting for new connection in seconds",
+		ConstLabels: map[string]string{
+			"pool": poolName,
+		},
 	}, func() float64 {
 		return pool.Stat().AcquireDuration().Seconds()
 	})
@@ -346,6 +390,7 @@ func registerMetrics(metrics core_metrics.Metrics, pool *pgxpool.Pool) error {
 		Help: "Current number of closed postgres store connections",
 		ConstLabels: map[string]string{
 			"type": "max_idle_conns",
+			"pool": poolName,
 		},
 	}, func() float64 {
 		return float64(pool.Stat().MaxIdleDestroyCount())
@@ -356,6 +401,7 @@ func registerMetrics(metrics core_metrics.Metrics, pool *pgxpool.Pool) error {
 		Help: "Current number of closed postgres store connections",
 		ConstLabels: map[string]string{
 			"type": "conn_max_life_time",
+			"pool": poolName,
 		},
 	}, func() float64 {
 		return float64(pool.Stat().MaxLifetimeDestroyCount())
@@ -366,6 +412,7 @@ func registerMetrics(metrics core_metrics.Metrics, pool *pgxpool.Pool) error {
 		Help: "Cumulative count of acquires from the pool",
 		ConstLabels: map[string]string{
 			"type": "successful",
+			"pool": poolName,
 		},
 	}, func() float64 {
 		return float64(pool.Stat().AcquireCount())
@@ -376,6 +423,7 @@ func registerMetrics(metrics core_metrics.Metrics, pool *pgxpool.Pool) error {
 		Help: "Cumulative count of acquires from the pool",
 		ConstLabels: map[string]string{
 			"type": "canceled",
+			"pool": poolName,
 		},
 	}, func() float64 {
 		return float64(pool.Stat().CanceledAcquireCount())
@@ -386,6 +434,7 @@ func registerMetrics(metrics core_metrics.Metrics, pool *pgxpool.Pool) error {
 		Help: "Current number of postgres store connections",
 		ConstLabels: map[string]string{
 			"type": "constructing",
+			"pool": poolName,
 		},
 	}, func() float64 {
 		return float64(pool.Stat().ConstructingConns())
@@ -396,6 +445,7 @@ func registerMetrics(metrics core_metrics.Metrics, pool *pgxpool.Pool) error {
 		Help: "Current number of postgres store connections",
 		ConstLabels: map[string]string{
 			"type": "new",
+			"pool": poolName,
 		},
 	}, func() float64 {
 		return float64(pool.Stat().NewConnsCount())


### PR DESCRIPTION
### Checklist prior to review

Enable support for reader replica. If you use for example Aurora RDS, you can loadbalance requests between writer and reader. With this PR you can set host of a reader and ratio of requests that should go to a reader.

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [X] [Link to relevant issue][1] as well as docs and UI issues --
- [X] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [X] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [X] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [X] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --
- [X] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
