### PR TITLE
test(unit): do not panic on missing metric

### DIFF
--- a/pkg/insights/resyncer_test.go
+++ b/pkg/insights/resyncer_test.go
@@ -1111,7 +1111,7 @@ var _ = Describe("Insight Persistence", func() {
 			err := rm.Get(context.Background(), insight, store.GetByKey("mesh-1", model.NoMesh))
 			g.Expect(err).ToNot(HaveOccurred())
 			g.Expect(insight.Meta.GetVersion()).To(Equal("1"))
-			g.Expect(*test_metrics.FindMetric(metric, "insights_resyncer_event_time_processing", "result", "changed").Summary.SampleCount).To(Equal(uint64(1)))
+			g.Expect(test_metrics.FindMetric(metric, "insights_resyncer_event_time_processing", "result", "changed").GetSummary().GetSampleCount()).To(Equal(uint64(1)))
 		}).Should(Succeed())
 
 		eventCh <- events.ResourceChangedEvent{
@@ -1128,7 +1128,7 @@ var _ = Describe("Insight Persistence", func() {
 			err := rm.Get(context.Background(), insight, store.GetByKey("mesh-1", model.NoMesh))
 			g.Expect(err).ToNot(HaveOccurred())
 			g.Expect(insight.Meta.GetVersion()).To(Equal("1"))
-			g.Expect(*test_metrics.FindMetric(metric, "insights_resyncer_event_time_processing", "result", "no_changes").Summary.SampleCount).To(Equal(uint64(1)))
+			g.Expect(test_metrics.FindMetric(metric, "insights_resyncer_event_time_processing", "result", "no_changes").GetSummary().GetSampleCount()).To(Equal(uint64(1)))
 		}).Should(Succeed())
 	})
 })


### PR DESCRIPTION
### Checklist prior to review

It was visible here https://app.circleci.com/pipelines/github/kumahq/kuma/24830/workflows/1451fc5f-9455-4a8a-9fd4-b62213674c11/jobs/496399/tests

getters handle nulls

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [X] [Link to relevant issue][1] as well as docs and UI issues --
- [X] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [X] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [X] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [X] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --
- [X] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
