### PR TITLE
feat(store): add owner reference to the secrets

### DIFF
--- a/pkg/core/ca/manager.go
+++ b/pkg/core/ca/manager.go
@@ -16,7 +16,8 @@ type KeyPair = tls.KeyPair
 type Manager interface {
 	// ValidateBackend validates that backend configuration is correct
 	ValidateBackend(ctx context.Context, mesh string, backend *mesh_proto.CertificateAuthorityBackend) error
-	// EnsureBackends ensures the given CA backends managed by this manager are available
+	// EnsureBackends ensures the given CA backends managed by this manager are available.
+	// Since the secrets are now explicitly children of mesh we need to pass the whole mesh object so that we can properly set the owner.
 	EnsureBackends(ctx context.Context, mesh model.Resource, backends []*mesh_proto.CertificateAuthorityBackend) error
 	// UsedSecrets returns a list of secrets that are used by the manager
 	UsedSecrets(mesh string, backend *mesh_proto.CertificateAuthorityBackend) ([]string, error)

--- a/pkg/core/ca/manager.go
+++ b/pkg/core/ca/manager.go
@@ -2,9 +2,10 @@ package ca
 
 import (
 	"context"
-	"github.com/kumahq/kuma/pkg/core/resources/model"
+
 
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
+	"github.com/kumahq/kuma/pkg/core/resources/model"
 	"github.com/kumahq/kuma/pkg/tls"
 )
 

--- a/pkg/core/ca/manager.go
+++ b/pkg/core/ca/manager.go
@@ -2,6 +2,7 @@ package ca
 
 import (
 	"context"
+	"github.com/kumahq/kuma/pkg/core/resources/model"
 
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	"github.com/kumahq/kuma/pkg/tls"
@@ -16,7 +17,7 @@ type Manager interface {
 	// ValidateBackend validates that backend configuration is correct
 	ValidateBackend(ctx context.Context, mesh string, backend *mesh_proto.CertificateAuthorityBackend) error
 	// EnsureBackends ensures the given CA backends managed by this manager are available
-	EnsureBackends(ctx context.Context, mesh string, backends []*mesh_proto.CertificateAuthorityBackend) error
+	EnsureBackends(ctx context.Context, mesh model.Resource, backends []*mesh_proto.CertificateAuthorityBackend) error
 	// UsedSecrets returns a list of secrets that are used by the manager
 	UsedSecrets(mesh string, backend *mesh_proto.CertificateAuthorityBackend) ([]string, error)
 

--- a/pkg/core/ca/manager.go
+++ b/pkg/core/ca/manager.go
@@ -2,6 +2,7 @@ package ca
 
 import (
 	"context"
+
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	"github.com/kumahq/kuma/pkg/core/resources/model"
 	"github.com/kumahq/kuma/pkg/tls"

--- a/pkg/core/ca/manager.go
+++ b/pkg/core/ca/manager.go
@@ -2,8 +2,6 @@ package ca
 
 import (
 	"context"
-
-
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	"github.com/kumahq/kuma/pkg/core/resources/model"
 	"github.com/kumahq/kuma/pkg/tls"

--- a/pkg/core/managers/apis/mesh/mesh_helpers.go
+++ b/pkg/core/managers/apis/mesh/mesh_helpers.go
@@ -20,7 +20,7 @@ func EnsureCAs(ctx context.Context, caManagers core_ca.Managers, mesh *core_mesh
 		if !exist { // this should be caught by validator earlier
 			return errors.Errorf("CA manager for type %s does not exist", typ)
 		}
-		if err := caManager.EnsureBackends(ctx, meshName, backends); err != nil {
+		if err := caManager.EnsureBackends(ctx, mesh, backends); err != nil {
 			return errors.Wrapf(err, "could not ensure CA backends of type %s", typ)
 		}
 	}

--- a/pkg/core/managers/apis/mesh/mesh_manager.go
+++ b/pkg/core/managers/apis/mesh/mesh_manager.go
@@ -76,11 +76,11 @@ func (m *meshManager) Create(ctx context.Context, resource core_model.Resource, 
 	if err := m.meshValidator.ValidateCreate(ctx, opts.Name, mesh); err != nil {
 		return err
 	}
-	// persist Mesh
-	if err := m.store.Create(ctx, mesh, append(fs, core_store.CreatedAt(time.Now()))...); err != nil {
+	if err := EnsureCAs(ctx, m.caManagers, mesh, opts.Name); err != nil {
 		return err
 	}
-	if err := EnsureCAs(ctx, m.caManagers, mesh, opts.Name); err != nil {
+	// persist Mesh
+	if err := m.store.Create(ctx, mesh, append(fs, core_store.CreatedAt(time.Now()))...); err != nil {
 		return err
 	}
 	if err := defaults_mesh.EnsureDefaultMeshResources(

--- a/pkg/core/managers/apis/mesh/mesh_manager.go
+++ b/pkg/core/managers/apis/mesh/mesh_manager.go
@@ -76,11 +76,11 @@ func (m *meshManager) Create(ctx context.Context, resource core_model.Resource, 
 	if err := m.meshValidator.ValidateCreate(ctx, opts.Name, mesh); err != nil {
 		return err
 	}
-	if err := EnsureCAs(ctx, m.caManagers, mesh, opts.Name); err != nil {
-		return err
-	}
 	// persist Mesh
 	if err := m.store.Create(ctx, mesh, append(fs, core_store.CreatedAt(time.Now()))...); err != nil {
+		return err
+	}
+	if err := EnsureCAs(ctx, m.caManagers, mesh, opts.Name); err != nil {
 		return err
 	}
 	if err := defaults_mesh.EnsureDefaultMeshResources(

--- a/pkg/core/managers/apis/mesh/mesh_manager.go
+++ b/pkg/core/managers/apis/mesh/mesh_manager.go
@@ -80,6 +80,7 @@ func (m *meshManager) Create(ctx context.Context, resource core_model.Resource, 
 	if err := m.store.Create(ctx, mesh, append(fs, core_store.CreatedAt(time.Now()))...); err != nil {
 		return err
 	}
+	// We need to first persist the mesh so that we can hook up secrets (cert/key) as their owner in EnsureCAs.
 	if err := EnsureCAs(ctx, m.caManagers, mesh, opts.Name); err != nil {
 		return err
 	}

--- a/pkg/core/managers/apis/mesh/mesh_manager.go
+++ b/pkg/core/managers/apis/mesh/mesh_manager.go
@@ -8,7 +8,6 @@ import (
 
 	core_ca "github.com/kumahq/kuma/pkg/core/ca"
 	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
-	"github.com/kumahq/kuma/pkg/core/resources/apis/system"
 	core_manager "github.com/kumahq/kuma/pkg/core/resources/manager"
 	core_model "github.com/kumahq/kuma/pkg/core/resources/model"
 	core_registry "github.com/kumahq/kuma/pkg/core/resources/registry"
@@ -119,10 +118,7 @@ func (m *meshManager) Delete(ctx context.Context, resource core_model.Resource, 
 			return err
 		}
 	}
-	// delete all secrets
-	if err := m.otherManagers.DeleteAll(ctx, &system.SecretResourceList{}, core_store.DeleteAllByMesh(opts.Name)); err != nil {
-		return errors.Wrap(err, "could not delete associated secrets")
-	}
+	// secrets are deleted via owner reference
 	return notFoundErr
 }
 

--- a/pkg/core/managers/apis/mesh/mesh_manager.go
+++ b/pkg/core/managers/apis/mesh/mesh_manager.go
@@ -76,18 +76,17 @@ func (m *meshManager) Create(ctx context.Context, resource core_model.Resource, 
 	if err := m.meshValidator.ValidateCreate(ctx, opts.Name, mesh); err != nil {
 		return err
 	}
-	if err := EnsureCAs(ctx, m.caManagers, mesh, opts.Name); err != nil {
-		return err
-	}
-
 	// persist Mesh
 	if err := m.store.Create(ctx, mesh, append(fs, core_store.CreatedAt(time.Now()))...); err != nil {
+		return err
+	}
+	if err := EnsureCAs(ctx, m.caManagers, mesh, opts.Name); err != nil {
 		return err
 	}
 	if err := defaults_mesh.EnsureDefaultMeshResources(
 		ctx,
 		m.otherManagers,
-		opts.Name,
+		mesh,
 		mesh.Spec.GetSkipCreatingInitialPolicies(),
 		m.extensions,
 	); err != nil {

--- a/pkg/core/tokens/meshed_signing_key_manager.go
+++ b/pkg/core/tokens/meshed_signing_key_manager.go
@@ -3,6 +3,8 @@ package tokens
 import (
 	"context"
 	"crypto/rsa"
+	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
+	"github.com/kumahq/kuma/pkg/core/resources/model"
 
 	"github.com/pkg/errors"
 	"google.golang.org/protobuf/types/known/wrapperspb"
@@ -56,5 +58,11 @@ func (s *meshedSigningKeyManager) CreateSigningKey(ctx context.Context, keyID Ke
 			Value: key,
 		},
 	}
-	return s.manager.Create(ctx, secret, store.CreateBy(SigningKeyResourceKey(s.signingKeyPrefix, keyID, s.mesh)))
+
+	owner := core_mesh.NewMeshResource()
+	if err := s.manager.Get(ctx, owner, store.GetByKey(s.mesh, model.NoMesh)); err != nil {
+		return manager.MeshNotFound(s.mesh)
+	}
+
+	return s.manager.Create(ctx, secret, store.CreateWithOwner(owner), store.CreateBy(SigningKeyResourceKey(s.signingKeyPrefix, keyID, s.mesh)))
 }

--- a/pkg/core/tokens/meshed_signing_key_manager.go
+++ b/pkg/core/tokens/meshed_signing_key_manager.go
@@ -3,15 +3,15 @@ package tokens
 import (
 	"context"
 	"crypto/rsa"
-	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
-	"github.com/kumahq/kuma/pkg/core/resources/model"
 
 	"github.com/pkg/errors"
 	"google.golang.org/protobuf/types/known/wrapperspb"
 
 	system_proto "github.com/kumahq/kuma/api/system/v1alpha1"
+	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	"github.com/kumahq/kuma/pkg/core/resources/apis/system"
 	"github.com/kumahq/kuma/pkg/core/resources/manager"
+	"github.com/kumahq/kuma/pkg/core/resources/model"
 	"github.com/kumahq/kuma/pkg/core/resources/store"
 )
 

--- a/pkg/defaults/components.go
+++ b/pkg/defaults/components.go
@@ -123,7 +123,10 @@ func (d *defaultsComponent) Start(stop <-chan struct{}) error {
 			defer wg.Done()
 			// if after this time we cannot create a resource - something is wrong and we should return an error which will restart CP.
 			err := retry.Do(ctx, retry.WithMaxDuration(10*time.Minute, retry.NewConstant(5*time.Second)), func(ctx context.Context) error {
-				return retry.RetryableError(CreateMeshIfNotExist(ctx, d.resManager, d.extensions)) // retry all errors
+				return retry.RetryableError(func() error {
+					_, err := CreateMeshIfNotExist(ctx, d.resManager, d.extensions)
+					return err
+				}()) // retry all errors
 			})
 			if err != nil {
 				// Retry this operation since on Kubernetes Mesh needs to be validated and set default values.

--- a/pkg/defaults/mesh.go
+++ b/pkg/defaults/mesh.go
@@ -18,22 +18,22 @@ func CreateMeshIfNotExist(
 	ctx context.Context,
 	resManager core_manager.ResourceManager,
 	extensions context.Context,
-) error {
+) (*core_mesh.MeshResource, error) {
 	logger := kuma_log.AddFieldsFromCtx(log, ctx, extensions)
 	mesh := core_mesh.NewMeshResource()
 	err := resManager.Get(ctx, mesh, core_store.GetBy(defaultMeshKey))
 	if err == nil {
 		logger.V(1).Info("default Mesh already exists. Skip creating default Mesh.")
-		return nil
+		return mesh, nil
 	}
 	if !core_store.IsResourceNotFound(err) {
-		return err
+		return nil, err
 	}
 	logger.Info("trying to create default Mesh")
 	if err := resManager.Create(ctx, mesh, core_store.CreateBy(defaultMeshKey)); err != nil {
 		logger.V(1).Info("could not create default mesh", "err", err)
-		return err
+		return nil, err
 	}
 	logger.Info("default Mesh created")
-	return nil
+	return mesh, nil
 }

--- a/pkg/defaults/mesh/mesh.go
+++ b/pkg/defaults/mesh/mesh.go
@@ -29,18 +29,19 @@ var ensureMux = sync.Mutex{}
 func EnsureDefaultMeshResources(
 	ctx context.Context,
 	resManager manager.ResourceManager,
-	meshName string,
+	mesh model.Resource,
 	skippedPolicies []string,
 	extensions context.Context,
 ) error {
 	ensureMux.Lock()
 	defer ensureMux.Unlock()
 
+	meshName := mesh.GetMeta().GetName()
 	logger := kuma_log.AddFieldsFromCtx(log, ctx, extensions).WithValues("mesh", meshName)
 
 	logger.Info("ensuring default resources for Mesh exist")
 
-	created, err := ensureDataplaneTokenSigningKey(ctx, resManager, meshName)
+	created, err := ensureDataplaneTokenSigningKey(ctx, resManager, mesh)
 	if err != nil {
 		return errors.Wrap(err, "could not create default Dataplane Token Signing Key")
 	}

--- a/pkg/defaults/mesh/mesh_test.go
+++ b/pkg/defaults/mesh/mesh_test.go
@@ -19,18 +19,20 @@ import (
 
 var _ = Describe("EnsureDefaultMeshResources", func() {
 	var resManager manager.ResourceManager
+	var defaultMesh *core_mesh.MeshResource
 
 	BeforeEach(func() {
 		store := memory.NewStore()
 		resManager = manager.NewResourceManager(store)
+		defaultMesh = core_mesh.NewMeshResource()
 
-		err := resManager.Create(context.Background(), core_mesh.NewMeshResource(), core_store.CreateByKey(model.DefaultMesh, model.NoMesh))
+		err := resManager.Create(context.Background(), defaultMesh, core_store.CreateByKey(model.DefaultMesh, model.NoMesh))
 		Expect(err).ToNot(HaveOccurred())
 	})
 
 	It("should create default resources", func() {
 		// when
-		err := mesh.EnsureDefaultMeshResources(context.Background(), resManager, model.DefaultMesh, []string{}, context.Background())
+		err := mesh.EnsureDefaultMeshResources(context.Background(), resManager, defaultMesh, []string{}, context.Background())
 		Expect(err).ToNot(HaveOccurred())
 
 		// then default TrafficPermission for the mesh exist
@@ -52,11 +54,11 @@ var _ = Describe("EnsureDefaultMeshResources", func() {
 
 	It("should ignore subsequent calls to EnsureDefaultMeshResources", func() {
 		// given already ensured default resources
-		err := mesh.EnsureDefaultMeshResources(context.Background(), resManager, model.DefaultMesh, []string{}, context.Background())
+		err := mesh.EnsureDefaultMeshResources(context.Background(), resManager, defaultMesh, []string{}, context.Background())
 		Expect(err).ToNot(HaveOccurred())
 
 		// when ensuring again
-		err = mesh.EnsureDefaultMeshResources(context.Background(), resManager, model.DefaultMesh, []string{}, context.Background())
+		err = mesh.EnsureDefaultMeshResources(context.Background(), resManager, defaultMesh, []string{}, context.Background())
 
 		// then
 		Expect(err).ToNot(HaveOccurred())
@@ -74,7 +76,7 @@ var _ = Describe("EnsureDefaultMeshResources", func() {
 
 	It("should skip creating all default policies", func() {
 		// when
-		err := mesh.EnsureDefaultMeshResources(context.Background(), resManager, model.DefaultMesh, []string{"*"}, context.Background())
+		err := mesh.EnsureDefaultMeshResources(context.Background(), resManager, defaultMesh, []string{"*"}, context.Background())
 		Expect(err).ToNot(HaveOccurred())
 
 		// then default TrafficPermission doesn't exist
@@ -96,7 +98,7 @@ var _ = Describe("EnsureDefaultMeshResources", func() {
 
 	It("should skip creating selected default policies", func() {
 		// when
-		err := mesh.EnsureDefaultMeshResources(context.Background(), resManager, model.DefaultMesh, []string{"TrafficPermission", "Retry"}, context.Background())
+		err := mesh.EnsureDefaultMeshResources(context.Background(), resManager, defaultMesh, []string{"TrafficPermission", "Retry"}, context.Background())
 		Expect(err).ToNot(HaveOccurred())
 
 		// then default TrafficPermission doesn't exist

--- a/pkg/defaults/mesh/signing_key.go
+++ b/pkg/defaults/mesh/signing_key.go
@@ -2,9 +2,9 @@ package mesh
 
 import (
 	"context"
-	"github.com/kumahq/kuma/pkg/core/resources/model"
 
 	"github.com/kumahq/kuma/pkg/core/resources/manager"
+	"github.com/kumahq/kuma/pkg/core/resources/model"
 	"github.com/kumahq/kuma/pkg/core/tokens"
 	"github.com/kumahq/kuma/pkg/tokens/builtin/issuer"
 )

--- a/pkg/defaults/mesh/signing_key.go
+++ b/pkg/defaults/mesh/signing_key.go
@@ -2,13 +2,15 @@ package mesh
 
 import (
 	"context"
+	"github.com/kumahq/kuma/pkg/core/resources/model"
 
 	"github.com/kumahq/kuma/pkg/core/resources/manager"
 	"github.com/kumahq/kuma/pkg/core/tokens"
 	"github.com/kumahq/kuma/pkg/tokens/builtin/issuer"
 )
 
-func ensureDataplaneTokenSigningKey(ctx context.Context, resManager manager.ResourceManager, meshName string) (bool, error) {
+func ensureDataplaneTokenSigningKey(ctx context.Context, resManager manager.ResourceManager, mesh model.Resource) (bool, error) {
+	meshName := mesh.GetMeta().GetName()
 	signingKeyManager := tokens.NewMeshedSigningKeyManager(resManager, issuer.DataplaneTokenSigningKeyPrefix(meshName), meshName)
 	_, _, err := signingKeyManager.GetLatestSigningKey(ctx)
 	if err == nil {

--- a/pkg/plugins/ca/builtin/manager.go
+++ b/pkg/plugins/ca/builtin/manager.go
@@ -105,7 +105,11 @@ func (b *builtinCaManager) create(ctx context.Context, mesh string, backend *mes
 			Data: util_proto.Bytes(keyPair.CertPEM),
 		},
 	}
-	if err := b.secretManager.Create(ctx, certSecret, core_store.CreateBy(certSecretResKey(mesh, backend.Name))); err != nil {
+	owner := core_mesh.NewMeshResource()
+	if err := b.secretManager.Get(ctx, owner, core_store.GetByKey(mesh, core_model.NoMesh)); err != nil {
+		return manager.MeshNotFound(mesh)
+	}
+	if err := b.secretManager.Create(ctx, certSecret, core_store.CreateWithOwner(owner), core_store.CreateBy(certSecretResKey(mesh, backend.Name))); err != nil {
 		if !core_store.IsResourceAlreadyExists(err) {
 			return err
 		}
@@ -117,7 +121,7 @@ func (b *builtinCaManager) create(ctx context.Context, mesh string, backend *mes
 			Data: util_proto.Bytes(keyPair.KeyPEM),
 		},
 	}
-	if err := b.secretManager.Create(ctx, keySecret, core_store.CreateBy(keySecretResKey(mesh, backend.Name))); err != nil {
+	if err := b.secretManager.Create(ctx, keySecret, core_store.CreateWithOwner(owner), core_store.CreateBy(keySecretResKey(mesh, backend.Name))); err != nil {
 		if !core_store.IsResourceAlreadyExists(err) {
 			return err
 		}

--- a/pkg/plugins/ca/builtin/manager_test.go
+++ b/pkg/plugins/ca/builtin/manager_test.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"crypto/x509"
 	"encoding/pem"
-	"github.com/kumahq/kuma/pkg/core/resources/model"
 	"time"
+
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -17,6 +17,7 @@ import (
 	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	"github.com/kumahq/kuma/pkg/core/resources/apis/system"
 	"github.com/kumahq/kuma/pkg/core/resources/manager"
+	"github.com/kumahq/kuma/pkg/core/resources/model"
 	core_store "github.com/kumahq/kuma/pkg/core/resources/store"
 	"github.com/kumahq/kuma/pkg/core/secrets/cipher"
 	secret_manager "github.com/kumahq/kuma/pkg/core/secrets/manager"

--- a/pkg/plugins/ca/builtin/manager_test.go
+++ b/pkg/plugins/ca/builtin/manager_test.go
@@ -43,6 +43,7 @@ var _ = Describe("Builtin CA Manager", func() {
 		secretManager = secret_manager.NewSecretManager(store.NewSecretStore(memoryStore), cipher.None(), nil, false)
 		caManager = builtin.NewBuiltinCaManager(secretManager)
 		mesh = core_mesh.NewMeshResource()
+		// Since mesh is the owner of secrets we can't operate on secrets without having the mesh in the store
 		err := rm.Create(context.Background(), mesh, core_store.CreateByKey(model.DefaultMesh, model.NoMesh))
 		Expect(err).ToNot(HaveOccurred())
 	})

--- a/pkg/plugins/ca/builtin/manager_test.go
+++ b/pkg/plugins/ca/builtin/manager_test.go
@@ -5,8 +5,6 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"time"
-
-
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"sigs.k8s.io/yaml"

--- a/pkg/plugins/ca/builtin/manager_test.go
+++ b/pkg/plugins/ca/builtin/manager_test.go
@@ -5,6 +5,7 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"time"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"sigs.k8s.io/yaml"

--- a/pkg/plugins/ca/provided/manager.go
+++ b/pkg/plugins/ca/provided/manager.go
@@ -3,7 +3,6 @@ package provided
 import (
 	"context"
 
-
 	"github.com/pkg/errors"
 
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"

--- a/pkg/plugins/ca/provided/manager.go
+++ b/pkg/plugins/ca/provided/manager.go
@@ -2,7 +2,7 @@ package provided
 
 import (
 	"context"
-	"github.com/kumahq/kuma/pkg/core/resources/model"
+
 
 	"github.com/pkg/errors"
 
@@ -11,6 +11,7 @@ import (
 	ca_issuer "github.com/kumahq/kuma/pkg/core/ca/issuer"
 	"github.com/kumahq/kuma/pkg/core/datasource"
 	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
+	"github.com/kumahq/kuma/pkg/core/resources/model"
 	"github.com/kumahq/kuma/pkg/core/validators"
 	"github.com/kumahq/kuma/pkg/plugins/ca/provided/config"
 	util_proto "github.com/kumahq/kuma/pkg/util/proto"

--- a/pkg/plugins/ca/provided/manager.go
+++ b/pkg/plugins/ca/provided/manager.go
@@ -2,6 +2,7 @@ package provided
 
 import (
 	"context"
+	"github.com/kumahq/kuma/pkg/core/resources/model"
 
 	"github.com/pkg/errors"
 
@@ -79,7 +80,7 @@ func (p *providedCaManager) getCa(ctx context.Context, mesh string, backend *mes
 	return pair, nil
 }
 
-func (p *providedCaManager) EnsureBackends(ctx context.Context, mesh string, backend []*mesh_proto.CertificateAuthorityBackend) error {
+func (p *providedCaManager) EnsureBackends(ctx context.Context, mesh model.Resource, backend []*mesh_proto.CertificateAuthorityBackend) error {
 	return nil // Cert and Key are created by user and pointed in the configuration which is validated first
 }
 

--- a/pkg/plugins/resources/postgres/store_template_test.go
+++ b/pkg/plugins/resources/postgres/store_template_test.go
@@ -42,8 +42,10 @@ var _ = Describe("PostgresStore template", func() {
 		}
 	}
 
+	test_store.ExecuteStoreTests(createStore("pgx", 0), "pgx")
 	test_store.ExecuteStoreTests(createStore("pgx", 4), "pgx")
 	test_store.ExecuteOwnerTests(createStore("pgx", 0), "pgx")
+	test_store.ExecuteStoreTests(createStore("pq", 0), "pq")
 	test_store.ExecuteStoreTests(createStore("pq", 4), "pq")
 	test_store.ExecuteOwnerTests(createStore("pq", 0), "pq")
 })

--- a/pkg/plugins/resources/postgres/store_template_test.go
+++ b/pkg/plugins/resources/postgres/store_template_test.go
@@ -42,10 +42,10 @@ var _ = Describe("PostgresStore template", func() {
 		}
 	}
 
-	test_store.ExecuteStoreTests(createStore("pgx", 0), "pgx")
-	test_store.ExecuteStoreTests(createStore("pgx", 4), "pgx")
+	//test_store.ExecuteStoreTests(createStore("pgx", 0), "pgx")
+	//test_store.ExecuteStoreTests(createStore("pgx", 4), "pgx")
 	test_store.ExecuteOwnerTests(createStore("pgx", 0), "pgx")
-	test_store.ExecuteStoreTests(createStore("pq", 0), "pq")
-	test_store.ExecuteStoreTests(createStore("pq", 4), "pq")
-	test_store.ExecuteOwnerTests(createStore("pq", 0), "pq")
+	//test_store.ExecuteStoreTests(createStore("pq", 0), "pq")
+	//test_store.ExecuteStoreTests(createStore("pq", 4), "pq")
+	//test_store.ExecuteOwnerTests(createStore("pq", 0), "pq")
 })

--- a/pkg/plugins/resources/postgres/store_template_test.go
+++ b/pkg/plugins/resources/postgres/store_template_test.go
@@ -42,10 +42,8 @@ var _ = Describe("PostgresStore template", func() {
 		}
 	}
 
-	//test_store.ExecuteStoreTests(createStore("pgx", 0), "pgx")
-	//test_store.ExecuteStoreTests(createStore("pgx", 4), "pgx")
+	test_store.ExecuteStoreTests(createStore("pgx", 4), "pgx")
 	test_store.ExecuteOwnerTests(createStore("pgx", 0), "pgx")
-	//test_store.ExecuteStoreTests(createStore("pq", 0), "pq")
-	//test_store.ExecuteStoreTests(createStore("pq", 4), "pq")
-	//test_store.ExecuteOwnerTests(createStore("pq", 0), "pq")
+	test_store.ExecuteStoreTests(createStore("pq", 4), "pq")
+	test_store.ExecuteOwnerTests(createStore("pq", 0), "pq")
 })

--- a/pkg/plugins/runtime/k8s/controllers/mesh_defaults_controller.go
+++ b/pkg/plugins/runtime/k8s/controllers/mesh_defaults_controller.go
@@ -43,7 +43,7 @@ func (r *MeshDefaultsReconciler) Reconcile(ctx context.Context, req kube_ctrl.Re
 	if err := defaults_mesh.EnsureDefaultMeshResources(
 		ctx,
 		r.ResourceManager,
-		req.Name,
+		mesh,
 		mesh.Spec.GetSkipCreatingInitialPolicies(),
 		r.Extensions,
 	); err != nil {

--- a/pkg/plugins/runtime/k8s/controllers/mesh_defaults_controller_test.go
+++ b/pkg/plugins/runtime/k8s/controllers/mesh_defaults_controller_test.go
@@ -2,12 +2,12 @@ package controllers_test
 
 import (
 	"context"
+	bootstrap_k8s "github.com/kumahq/kuma/pkg/plugins/bootstrap/k8s"
 
 	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	kube_core "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	kube_types "k8s.io/apimachinery/pkg/types"
 	kube_ctrl "sigs.k8s.io/controller-runtime"
 	kube_client "sigs.k8s.io/controller-runtime/pkg/client"
@@ -43,7 +43,9 @@ var _ = Describe("MeshDefaultsReconciler", func() {
 		store, err := k8s.NewStore(kubeClient, k8sClientScheme, k8s.NewSimpleConverter())
 		Expect(err).ToNot(HaveOccurred())
 
-		secretStore, err := secrets_k8s.NewStore(kubeClient, kubeClient, runtime.NewScheme(), "default")
+		scheme, err := bootstrap_k8s.NewScheme()
+		Expect(err).ToNot(HaveOccurred())
+		secretStore, err := secrets_k8s.NewStore(kubeClient, kubeClient, scheme, "default")
 		Expect(err).ToNot(HaveOccurred())
 
 		resourceManager = resources_manager.NewResourceManager(store)

--- a/pkg/plugins/runtime/k8s/controllers/mesh_defaults_controller_test.go
+++ b/pkg/plugins/runtime/k8s/controllers/mesh_defaults_controller_test.go
@@ -43,6 +43,8 @@ var _ = Describe("MeshDefaultsReconciler", func() {
 		store, err := k8s.NewStore(kubeClient, k8sClientScheme, k8s.NewSimpleConverter())
 		Expect(err).ToNot(HaveOccurred())
 
+		// we need to bring in the actual scheme we're using so that the Mesh CRD can be hooked up as owner,
+		// otherwise we will get "no kind is registered for the type v1alpha1.Mesh in scheme"
 		scheme, err := bootstrap_k8s.NewScheme()
 		Expect(err).ToNot(HaveOccurred())
 		secretStore, err := secrets_k8s.NewStore(kubeClient, kubeClient, scheme, "default")

--- a/pkg/plugins/runtime/k8s/controllers/mesh_defaults_controller_test.go
+++ b/pkg/plugins/runtime/k8s/controllers/mesh_defaults_controller_test.go
@@ -2,7 +2,6 @@ package controllers_test
 
 import (
 	"context"
-	bootstrap_k8s "github.com/kumahq/kuma/pkg/plugins/bootstrap/k8s"
 
 	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2"
@@ -21,6 +20,7 @@ import (
 	core_store "github.com/kumahq/kuma/pkg/core/resources/store"
 	secret_cipher "github.com/kumahq/kuma/pkg/core/secrets/cipher"
 	secret_manager "github.com/kumahq/kuma/pkg/core/secrets/manager"
+	bootstrap_k8s "github.com/kumahq/kuma/pkg/plugins/bootstrap/k8s"
 	"github.com/kumahq/kuma/pkg/plugins/resources/k8s"
 	"github.com/kumahq/kuma/pkg/plugins/runtime/k8s/controllers"
 	secrets_k8s "github.com/kumahq/kuma/pkg/plugins/secrets/k8s"

--- a/pkg/plugins/runtime/k8s/controllers/mesh_defaults_controller_test.go
+++ b/pkg/plugins/runtime/k8s/controllers/mesh_defaults_controller_test.go
@@ -7,6 +7,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	kube_core "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	kube_types "k8s.io/apimachinery/pkg/types"
 	kube_ctrl "sigs.k8s.io/controller-runtime"
 	kube_client "sigs.k8s.io/controller-runtime/pkg/client"
@@ -42,7 +43,7 @@ var _ = Describe("MeshDefaultsReconciler", func() {
 		store, err := k8s.NewStore(kubeClient, k8sClientScheme, k8s.NewSimpleConverter())
 		Expect(err).ToNot(HaveOccurred())
 
-		secretStore, err := secrets_k8s.NewStore(kubeClient, kubeClient, "default")
+		secretStore, err := secrets_k8s.NewStore(kubeClient, kubeClient, runtime.NewScheme(), "default")
 		Expect(err).ToNot(HaveOccurred())
 
 		resourceManager = resources_manager.NewResourceManager(store)

--- a/pkg/plugins/secrets/k8s/plugin.go
+++ b/pkg/plugins/secrets/k8s/plugin.go
@@ -17,9 +17,13 @@ func init() {
 }
 
 func (p *plugin) NewSecretStore(pc core_plugins.PluginContext, _ core_plugins.PluginConfig) (secret_store.SecretStore, error) {
+	mgr, ok := k8s_extensions.FromManagerContext(pc.Extensions())
+	if !ok {
+		return nil, errors.Errorf("k8s controller runtime Manager hasn't been configured")
+	}
 	client, ok := k8s_extensions.FromSecretClientContext(pc.Extensions())
 	if !ok {
 		return nil, errors.Errorf("secret client hasn't been configured")
 	}
-	return NewStore(client, client, pc.Config().Store.Kubernetes.SystemNamespace)
+	return NewStore(client, client, mgr.GetScheme(), pc.Config().Store.Kubernetes.SystemNamespace)
 }

--- a/pkg/plugins/secrets/k8s/store.go
+++ b/pkg/plugins/secrets/k8s/store.go
@@ -3,8 +3,6 @@ package k8s
 import (
 	"context"
 	"fmt"
-	"github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
-	"github.com/kumahq/kuma/pkg/plugins/resources/k8s"
 	"time"
 
 	"github.com/pkg/errors"
@@ -16,11 +14,13 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	system_proto "github.com/kumahq/kuma/api/system/v1alpha1"
+	"github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	secret_model "github.com/kumahq/kuma/pkg/core/resources/apis/system"
 	core_model "github.com/kumahq/kuma/pkg/core/resources/model"
 	core_store "github.com/kumahq/kuma/pkg/core/resources/store"
 	secret_store "github.com/kumahq/kuma/pkg/core/secrets/store"
 	common_k8s "github.com/kumahq/kuma/pkg/plugins/common/k8s"
+	"github.com/kumahq/kuma/pkg/plugins/resources/k8s"
 	"github.com/kumahq/kuma/pkg/plugins/runtime/k8s/metadata"
 	util_proto "github.com/kumahq/kuma/pkg/util/proto"
 )
@@ -28,23 +28,23 @@ import (
 var _ secret_store.SecretStore = &KubernetesStore{}
 
 type KubernetesStore struct {
-	reader           kube_client.Reader
-	writer           kube_client.Writer
-	scheme           *runtime.Scheme
-	secretsConverter Converter
+	reader             kube_client.Reader
+	writer             kube_client.Writer
+	scheme             *runtime.Scheme
+	secretsConverter   Converter
 	resourcesConverter common_k8s.Converter
 	// Namespace to store Secrets in, e.g. namespace where Control Plane is installed to
-	namespace          string
+	namespace string
 }
 
 func NewStore(reader kube_client.Reader, writer kube_client.Writer, scheme *runtime.Scheme, namespace string) (secret_store.SecretStore, error) {
 	return &KubernetesStore{
-		reader:           reader,
-		writer:           writer,
-		scheme:           scheme,
-		secretsConverter: DefaultConverter(),
+		reader:             reader,
+		writer:             writer,
+		scheme:             scheme,
+		secretsConverter:   DefaultConverter(),
 		resourcesConverter: k8s.NewSimpleConverter(),
-		namespace:        namespace,
+		namespace:          namespace,
 	}, nil
 }
 

--- a/pkg/plugins/secrets/k8s/store.go
+++ b/pkg/plugins/secrets/k8s/store.go
@@ -14,7 +14,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	system_proto "github.com/kumahq/kuma/api/system/v1alpha1"
-	"github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	secret_model "github.com/kumahq/kuma/pkg/core/resources/apis/system"
 	core_model "github.com/kumahq/kuma/pkg/core/resources/model"
 	core_store "github.com/kumahq/kuma/pkg/core/resources/store"
@@ -64,14 +63,7 @@ func (s *KubernetesStore) Create(ctx context.Context, r core_model.Resource, fs 
 	}
 
 	if opts.Owner != nil {
-		var k8sOwner kube_meta.Object
-
-		switch opts.Owner.Descriptor().Name {
-		case secret_model.SecretType, secret_model.GlobalSecretType:
-			k8sOwner, err = s.secretsConverter.ToKubernetesObject(opts.Owner)
-		case mesh.MeshType:
-			k8sOwner, err = s.resourcesConverter.ToKubernetesObject(opts.Owner)
-		}
+		k8sOwner, err := s.resourcesConverter.ToKubernetesObject(opts.Owner)
 		if err != nil {
 			return errors.Wrap(err, "failed to convert core model into k8s counterpart")
 		}

--- a/pkg/plugins/secrets/k8s/store.go
+++ b/pkg/plugins/secrets/k8s/store.go
@@ -27,10 +27,11 @@ import (
 var _ secret_store.SecretStore = &KubernetesStore{}
 
 type KubernetesStore struct {
-	reader             kube_client.Reader
-	writer             kube_client.Writer
-	scheme             *runtime.Scheme
-	secretsConverter   Converter
+	reader           kube_client.Reader
+	writer           kube_client.Writer
+	scheme           *runtime.Scheme
+	secretsConverter Converter
+	// secrets have a special converter, and we need to convert the mesh object since it's the owner
 	resourcesConverter common_k8s.Converter
 	// Namespace to store Secrets in, e.g. namespace where Control Plane is installed to
 	namespace string

--- a/pkg/plugins/secrets/k8s/store_test.go
+++ b/pkg/plugins/secrets/k8s/store_test.go
@@ -9,6 +9,7 @@ import (
 	kube_core "k8s.io/api/core/v1"
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -77,7 +78,7 @@ var _ = Describe("KubernetesStore", func() {
 		})
 		Expect(err).ToNot(HaveOccurred())
 
-		s, err = k8s.NewStore(k8sClient, k8sClient, ns)
+		s, err = k8s.NewStore(k8sClient, k8sClient, runtime.NewScheme(), ns)
 		Expect(err).ToNot(HaveOccurred())
 	})
 

--- a/pkg/plugins/secrets/k8s/store_test.go
+++ b/pkg/plugins/secrets/k8s/store_test.go
@@ -78,6 +78,8 @@ var _ = Describe("KubernetesStore", func() {
 		})
 		Expect(err).ToNot(HaveOccurred())
 
+		// we need to bring in the actual scheme we're using so that the Mesh CRD can be hooked up as owner,
+		// otherwise we will get "no kind is registered for the type v1alpha1.Mesh in scheme"
 		s, err = k8s.NewStore(k8sClient, k8sClient, runtime.NewScheme(), ns)
 		Expect(err).ToNot(HaveOccurred())
 	})

--- a/pkg/test/store/owner_test_template.go
+++ b/pkg/test/store/owner_test_template.go
@@ -32,7 +32,7 @@ func ExecuteOwnerTests(
 	})
 
 	Context("Store: "+storeName, func() {
-		FIt("should delete secret when its owner is deleted", func() {
+		It("should delete secret when its owner is deleted", func() {
 			// setup
 			meshRes := core_mesh.NewMeshResource()
 			err := s.Create(context.Background(), meshRes, store.CreateByKey(mesh, model.NoMesh))

--- a/pkg/test/store/owner_test_template.go
+++ b/pkg/test/store/owner_test_template.go
@@ -3,7 +3,6 @@ package store
 import (
 	"context"
 	"fmt"
-	secret_model "github.com/kumahq/kuma/pkg/core/resources/apis/system"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -11,6 +10,7 @@ import (
 
 	"github.com/kumahq/kuma/api/mesh/v1alpha1"
 	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
+	secret_model "github.com/kumahq/kuma/pkg/core/resources/apis/system"
 	"github.com/kumahq/kuma/pkg/core/resources/model"
 	"github.com/kumahq/kuma/pkg/core/resources/store"
 )

--- a/pkg/xds/secrets/secrets_test.go
+++ b/pkg/xds/secrets/secrets_test.go
@@ -102,6 +102,7 @@ var _ = Describe("Secrets", Ordered, func() {
 	}
 
 	BeforeAll(func() {
+		// since we actually create a mesh, and it goes through validation we have a default limit of 1
 		core_mesh.AllowedMTLSBackends = 2
 	})
 

--- a/pkg/xds/secrets/secrets_test.go
+++ b/pkg/xds/secrets/secrets_test.go
@@ -2,8 +2,6 @@ package secrets_test
 
 import (
 	"context"
-	"github.com/kumahq/kuma/pkg/core/resources/manager"
-	"github.com/kumahq/kuma/pkg/core/resources/store"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -13,7 +11,9 @@ import (
 	"github.com/kumahq/kuma/pkg/core"
 	core_ca "github.com/kumahq/kuma/pkg/core/ca"
 	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
+	"github.com/kumahq/kuma/pkg/core/resources/manager"
 	core_model "github.com/kumahq/kuma/pkg/core/resources/model"
+	"github.com/kumahq/kuma/pkg/core/resources/store"
 	"github.com/kumahq/kuma/pkg/core/secrets/cipher"
 	secrets_manager "github.com/kumahq/kuma/pkg/core/secrets/manager"
 	secrets_store "github.com/kumahq/kuma/pkg/core/secrets/store"

--- a/test/e2e_env/kubernetes/gateway/gateway.go
+++ b/test/e2e_env/kubernetes/gateway/gateway.go
@@ -41,7 +41,7 @@ spec:
       tls:
         mode: TERMINATE
         certificates:
-        - secret: example-kuma-io-certificate
+        - secret: kuma-io-certificate-k8s
       tags:
         hostname: example.kuma.io
     - port: 8082
@@ -56,7 +56,7 @@ spec:
 apiVersion: v1
 kind: Secret
 metadata:
-  name: example-kuma-io-certificate
+  name: kuma-io-certificate-k8s
   namespace: %s
   labels:
     kuma.io/mesh: simple-gateway 

--- a/test/e2e_env/kubernetes/gateway/gateway.go
+++ b/test/e2e_env/kubernetes/gateway/gateway.go
@@ -18,7 +18,6 @@ func Gateway() {
 	meshName := "simple-gateway"
 	namespace := "simple-gateway"
 	clientNamespace := "client-simple-gateway"
-
 	meshGateway := `
 apiVersion: kuma.io/v1alpha1
 kind: MeshGateway
@@ -41,7 +40,14 @@ spec:
       tls:
         mode: TERMINATE
         certificates:
-        - secret: kuma-io-certificate-k8s
+        - secret: kuma-io-certificate-k8s` +
+		// secret names have to be unique because
+		// we're removing secrets using owner reference, and we're relying on async namespace deletion,
+		// so we could have a situation where the secrets are not yet deleted,
+		// and we're trying to create a new mesh with the same secret name which k8s treats as changing the mesh of the secret
+		// and results in "cannot change mesh of the Secret. Delete the Secret first and apply it again."
+		// https://app.circleci.com/pipelines/github/kumahq/kuma/24848/workflows/f33edb5a-74cb-45ae-b0c2-4b14bf289585/jobs/497239
+		`
       tags:
         hostname: example.kuma.io
     - port: 8082

--- a/test/e2e_env/kubernetes/gateway/mtls.go
+++ b/test/e2e_env/kubernetes/gateway/mtls.go
@@ -53,7 +53,7 @@ spec:
       tls:
         mode: TERMINATE
         certificates:
-        - secret: example-kuma-io-certificate
+        - secret: kuma-io-certificate-k8s-mtls
       tags:
         name: tls-terminate
 `
@@ -67,7 +67,7 @@ spec:
 apiVersion: v1
 kind: Secret
 metadata:
-  name: example-kuma-io-certificate
+  name: kuma-io-certificate-k8s-mtls
   namespace: %s
   labels:
     kuma.io/mesh: gateway-mtls


### PR DESCRIPTION
based on https://github.com/kumahq/kuma/pull/7736 

closes https://github.com/kumahq/kuma/issues/3276

you can check parent project PR to see how it works there

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [X] [Link to relevant issue][1] as well as docs and UI issues --
- [X] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [X] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [X] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [X] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --
- [X] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
