### PR TITLE
fix(gatewayapi): don't set RefNotPermitted for GAMMA routes

### DIFF
--- a/pkg/plugins/runtime/k8s/controllers/gatewayapi/conversion.go
+++ b/pkg/plugins/runtime/k8s/controllers/gatewayapi/conversion.go
@@ -1,0 +1,27 @@
+package gatewayapi
+
+import (
+	kube_apimeta "k8s.io/apimachinery/pkg/api/meta"
+	kube_meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+	gatewayapi "sigs.k8s.io/gateway-api/apis/v1beta1"
+)
+
+func prepareConditions(conditions []kube_meta.Condition) []kube_meta.Condition {
+	for _, condition := range []kube_meta.Condition{
+		{
+			Type:   string(gatewayapi.RouteConditionAccepted),
+			Status: kube_meta.ConditionTrue,
+			Reason: string(gatewayapi.RouteReasonAccepted),
+		}, {
+			Type:   string(gatewayapi.RouteConditionResolvedRefs),
+			Status: kube_meta.ConditionTrue,
+			Reason: string(gatewayapi.RouteReasonResolvedRefs),
+		},
+	} {
+		if kube_apimeta.FindStatusCondition(conditions, condition.Type) == nil {
+			kube_apimeta.SetStatusCondition(&conditions, condition)
+		}
+	}
+
+	return conditions
+}

--- a/pkg/plugins/runtime/k8s/controllers/gatewayapi/http_route_controller.go
+++ b/pkg/plugins/runtime/k8s/controllers/gatewayapi/http_route_controller.go
@@ -136,14 +136,14 @@ func (r *HTTPRouteReconciler) gapiToKumaRoutes(
 	// The conditions we accumulate for each ParentRef
 	conditions := ParentConditions{}
 
+	notAcceptedConditions := map[gatewayapi.ParentReference]string{}
+
 	// Convert GAPI parent refs into selectors
 	for i, ref := range route.Spec.ParentRefs {
 		refAttachment, err := attachment.EvaluateParentRefAttachment(ctx, r.Client, route.Spec.Hostnames, &routeNs, ref)
 		if err != nil {
 			return nil, nil, nil, errors.Wrapf(err, "unable to check parent ref %d", i)
 		}
-
-		refConditions := slices.Clone(routeConditions)
 
 		switch refAttachment {
 		case attachment.Unknown:
@@ -183,22 +183,33 @@ func (r *HTTPRouteReconciler) gapiToKumaRoutes(
 			case attachment.NoMatchingParent:
 				reason = string(gatewayapi.RouteReasonNoMatchingParent)
 			}
+			notAcceptedConditions[ref] = reason
+		}
+	}
 
-			if !kube_apimeta.IsStatusConditionFalse(refConditions, string(gatewayapi.RouteConditionAccepted)) {
-				kube_apimeta.SetStatusCondition(&refConditions, kube_meta.Condition{
-					Type:   string(gatewayapi.RouteConditionAccepted),
-					Status: kube_meta.ConditionFalse,
-					Reason: reason,
-				})
-			}
+	meshRoutes, meshRouteConditions, err := r.gapiToMeshRouteSpecs(ctx, mesh, route, services)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	for _, ref := range route.Spec.ParentRefs {
+		var refConditions []kube_meta.Condition
+		switch {
+		case *ref.Kind == "Gateway" && *ref.Group == gatewayapi.GroupName:
+			refConditions = slices.Clone(routeConditions)
+		case *ref.Kind == "Service" && (*ref.Group == kube_core.GroupName || *ref.Group == gatewayapi.GroupName):
+			refConditions = slices.Clone(meshRouteConditions)
+		}
+
+		if reason, notAccepted := notAcceptedConditions[ref]; notAccepted && !kube_apimeta.IsStatusConditionFalse(refConditions, string(gatewayapi.RouteConditionAccepted)) {
+			kube_apimeta.SetStatusCondition(&refConditions, kube_meta.Condition{
+				Type:   string(gatewayapi.RouteConditionAccepted),
+				Status: kube_meta.ConditionFalse,
+				Reason: reason,
+			})
 		}
 
 		conditions[ref] = refConditions
-	}
-
-	meshRoutes, err := r.gapiToMeshRouteSpecs(ctx, mesh, route, services)
-	if err != nil {
-		return nil, nil, nil, err
 	}
 
 	var kumaRoute *mesh_proto.MeshGatewayRoute

--- a/pkg/plugins/runtime/k8s/controllers/gatewayapi/http_route_conversion.go
+++ b/pkg/plugins/runtime/k8s/controllers/gatewayapi/http_route_conversion.go
@@ -127,21 +127,7 @@ func (r *HTTPRouteReconciler) gapiToKumaRouteConf(
 		}
 	}
 
-	for _, condition := range []kube_meta.Condition{
-		{
-			Type:   string(gatewayapi.RouteConditionAccepted),
-			Status: kube_meta.ConditionTrue,
-			Reason: string(gatewayapi.RouteReasonAccepted),
-		}, {
-			Type:   string(gatewayapi.RouteConditionResolvedRefs),
-			Status: kube_meta.ConditionTrue,
-			Reason: string(gatewayapi.RouteReasonResolvedRefs),
-		},
-	} {
-		if kube_apimeta.FindStatusCondition(conditions, condition.Type) == nil {
-			kube_apimeta.SetStatusCondition(&conditions, condition)
-		}
-	}
+	conditions = prepareConditions(conditions)
 
 	var routeConf *mesh_proto.MeshGatewayRoute_Conf
 	if len(rules) > 0 {


### PR DESCRIPTION
We weren't actually checking whether a ref is permitted when converting for GAMMA, which is correct, but we reused the condition list from the gateway case.

Closes #7764 

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --
- [x] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
