### PR TITLE
chore(metrics): rename reasons

### DIFF
--- a/pkg/insights/resyncer.go
+++ b/pkg/insights/resyncer.go
@@ -29,7 +29,7 @@ var log = core.Log.WithName("mesh-insight-resyncer")
 
 const (
 	ReasonResync    = "resync"
-	ReasonTrigger   = "trigger"
+	ReasonForce     = "force"
 	ReasonEvent     = "event"
 	ResultChanged   = "changed"
 	ResultNoChanges = "no_changes"
@@ -266,7 +266,7 @@ func (r *resyncer) Start(stop <-chan struct{}) error {
 						anyChanged = true
 					}
 				}
-				reason := strings.Join(util_maps.SortedKeys(event.reasons), "&")
+				reason := strings.Join(util_maps.SortedKeys(event.reasons), "_and_")
 				result := ResultNoChanges
 				if anyChanged {
 					result = ResultChanged
@@ -323,7 +323,7 @@ func (r *resyncer) Start(stop <-chan struct{}) error {
 			}
 			if triggerEvent, ok := event.(events.TriggerInsightsComputationEvent); ok {
 				ctx := context.Background()
-				r.addMeshesToBatch(ctx, batch, triggerEvent.TenantID, ReasonTrigger)
+				r.addMeshesToBatch(ctx, batch, triggerEvent.TenantID, ReasonForce)
 				if err := batch.flush(ctx, resyncEvents); err != nil {
 					log.Error(err, "Flush of batch didn't complete, some insights won't be refreshed until next tick")
 				}

--- a/pkg/kds/v2/server/event_based_watchdog.go
+++ b/pkg/kds/v2/server/event_based_watchdog.go
@@ -70,7 +70,7 @@ func (e *EventBasedWatchdog) Start(stop <-chan struct{}) {
 			if len(changedTypes) == 0 {
 				continue
 			}
-			reason := strings.Join(util_maps.SortedKeys(reasons), "&")
+			reason := strings.Join(util_maps.SortedKeys(reasons), "_and_")
 			e.Log.V(1).Info("reconcile", "changedTypes", changedTypes, "reason", reason)
 			start := core.Now()
 			err, changed := e.Reconciler.Reconcile(e.Ctx, e.Node, changedTypes)


### PR DESCRIPTION
### Checklist prior to review

Feedback from the team that trigger was not clear. `&` does not map great for Datadog

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [ ] [Link to relevant issue][1] as well as docs and UI issues --
- [ ] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [ ] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [ ] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [ ] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --
- [ ] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
