### PR TITLE
fix(kds): delta delivery metric

### DIFF
--- a/pkg/kds/v2/reconcile/reconciler.go
+++ b/pkg/kds/v2/reconcile/reconciler.go
@@ -60,7 +60,7 @@ func (r *reconciler) Clear(ctx context.Context, node *envoy_core.Node) error {
 		return nil
 	}
 	for _, typ := range util_kds_v2.GetSupportedTypes() {
-		r.statsCallbacks.DiscardConfig(snapshot.GetVersion(typ))
+		r.statsCallbacks.DiscardConfig(node.Id + typ)
 	}
 	return nil
 }
@@ -99,7 +99,7 @@ func (r *reconciler) Reconcile(ctx context.Context, node *envoy_core.Node, chang
 	new, changed := r.Version(new, old)
 	if changed {
 		r.logChanges(new, old, node)
-		r.meterConfigReadyForDelivery(new, old)
+		r.meterConfigReadyForDelivery(new, old, node.Id)
 		return r.cache.SetSnapshot(ctx, id, new), true
 	}
 	return nil, false
@@ -164,10 +164,10 @@ func (r *reconciler) logChanges(new envoy_cache.ResourceSnapshot, old envoy_cach
 	}
 }
 
-func (r *reconciler) meterConfigReadyForDelivery(new envoy_cache.ResourceSnapshot, old envoy_cache.ResourceSnapshot) {
+func (r *reconciler) meterConfigReadyForDelivery(new envoy_cache.ResourceSnapshot, old envoy_cache.ResourceSnapshot, nodeID string) {
 	for _, typ := range util_kds_v2.GetSupportedTypes() {
 		if old == nil || old.GetVersion(typ) != new.GetVersion(typ) {
-			r.statsCallbacks.ConfigReadyForDelivery(new.GetVersion(typ))
+			r.statsCallbacks.ConfigReadyForDelivery(nodeID + typ)
 		}
 	}
 }


### PR DESCRIPTION
### Checklist prior to review

Fix KDS delta delivery metric

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [X] [Link to relevant issue][1] as well as docs and UI issues --
- [X] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [X] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [X] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [X] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --
- [X] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
