### PR TITLE
feat(kds): resource sync metric

### DIFF
--- a/pkg/kds/global/components.go
+++ b/pkg/kds/global/components.go
@@ -79,7 +79,10 @@ func Setup(rt runtime.Runtime) error {
 	}
 
 	resourceSyncer := sync_store.NewResourceSyncer(kdsGlobalLog, rt.ResourceStore())
-	resourceSyncerV2 := kds_sync_store_v2.NewResourceSyncer(kdsDeltaGlobalLog, rt.ResourceStore())
+	resourceSyncerV2, err := kds_sync_store_v2.NewResourceSyncer(kdsDeltaGlobalLog, rt.ResourceStore(), rt.Metrics())
+	if err != nil {
+		return err
+	}
 	kubeFactory := resources_k8s.NewSimpleKubeFactory()
 	onSessionStarted := mux.OnSessionStartedFunc(func(session mux.Session) error {
 		log := kdsGlobalLog.WithValues("peer-id", session.PeerID())

--- a/pkg/kds/global/components_test.go
+++ b/pkg/kds/global/components_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/kumahq/kuma/pkg/kds/reconcile"
 	sync_store "github.com/kumahq/kuma/pkg/kds/store"
 	sync_store_v2 "github.com/kumahq/kuma/pkg/kds/v2/store"
+	core_metrics "github.com/kumahq/kuma/pkg/metrics"
 	"github.com/kumahq/kuma/pkg/plugins/resources/memory"
 	"github.com/kumahq/kuma/pkg/test/grpc"
 	kds_setup "github.com/kumahq/kuma/pkg/test/kds/setup"
@@ -247,7 +248,10 @@ var _ = Describe("Global Sync", func() {
 
 			// Start 1 Kuma CP Global
 			globalStore = memory.NewStore()
-			globalSyncer = sync_store_v2.NewResourceSyncer(core.Log, globalStore)
+			metrics, err := core_metrics.NewMetrics("")
+			Expect(err).ToNot(HaveOccurred())
+			globalSyncer, err = sync_store_v2.NewResourceSyncer(core.Log, globalStore, metrics)
+			Expect(err).ToNot(HaveOccurred())
 			stopCh := make(chan struct{})
 			clientStreams := []*grpc.MockDeltaClientStream{}
 			for _, ss := range serverStreams {

--- a/pkg/kds/v2/client/zone_sync_test.go
+++ b/pkg/kds/v2/client/zone_sync_test.go
@@ -22,6 +22,7 @@ import (
 	kds_context "github.com/kumahq/kuma/pkg/kds/context"
 	client_v2 "github.com/kumahq/kuma/pkg/kds/v2/client"
 	sync_store_v2 "github.com/kumahq/kuma/pkg/kds/v2/store"
+	core_metrics "github.com/kumahq/kuma/pkg/metrics"
 	"github.com/kumahq/kuma/pkg/plugins/resources/memory"
 	"github.com/kumahq/kuma/pkg/test/grpc"
 	"github.com/kumahq/kuma/pkg/test/kds/samples"
@@ -86,7 +87,10 @@ var _ = Describe("Zone Delta Sync", func() {
 		clientStream := serverStream.ClientStream(stop)
 
 		zoneStore = memory.NewStore()
-		zoneSyncer = sync_store_v2.NewResourceSyncer(core.Log.WithName("kds-syncer"), zoneStore)
+		metrics, err := core_metrics.NewMetrics("")
+		Expect(err).ToNot(HaveOccurred())
+		zoneSyncer, err = sync_store_v2.NewResourceSyncer(core.Log.WithName("kds-syncer"), zoneStore, metrics)
+		Expect(err).ToNot(HaveOccurred())
 
 		wg.Add(1)
 		go func() {

--- a/pkg/kds/v2/store/sync_test.go
+++ b/pkg/kds/v2/store/sync_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/kumahq/kuma/pkg/core/resources/store"
 	client_v2 "github.com/kumahq/kuma/pkg/kds/v2/client"
 	sync_store "github.com/kumahq/kuma/pkg/kds/v2/store"
+	core_metrics "github.com/kumahq/kuma/pkg/metrics"
 	"github.com/kumahq/kuma/pkg/plugins/resources/memory"
 	. "github.com/kumahq/kuma/pkg/test/matchers"
 	model2 "github.com/kumahq/kuma/pkg/test/resources/model"
@@ -46,7 +47,10 @@ var _ = Describe("SyncResourceStoreDelta", func() {
 
 	BeforeEach(func() {
 		resourceStore = memory.NewStore()
-		syncer = sync_store.NewResourceSyncer(core.Log, resourceStore)
+		metrics, err := core_metrics.NewMetrics("")
+		Expect(err).ToNot(HaveOccurred())
+		syncer, err = sync_store.NewResourceSyncer(core.Log, resourceStore, metrics)
+		Expect(err).ToNot(HaveOccurred())
 	})
 
 	It("should create new resources in empty store", func() {

--- a/pkg/kds/zone/components.go
+++ b/pkg/kds/zone/components.go
@@ -72,7 +72,10 @@ func Setup(rt core_runtime.Runtime) error {
 		return err
 	}
 	resourceSyncer := sync_store.NewResourceSyncer(kdsZoneLog, rt.ResourceStore())
-	resourceSyncerV2 := kds_sync_store_v2.NewResourceSyncer(kdsDeltaZoneLog, rt.ResourceStore())
+	resourceSyncerV2, err := kds_sync_store_v2.NewResourceSyncer(kdsDeltaZoneLog, rt.ResourceStore(), rt.Metrics())
+	if err != nil {
+		return err
+	}
 	kubeFactory := resources_k8s.NewSimpleKubeFactory()
 	cfg := rt.Config()
 	cfgForDisplay, err := config.ConfigForDisplay(&cfg)

--- a/pkg/kds/zone/components_test.go
+++ b/pkg/kds/zone/components_test.go
@@ -25,6 +25,7 @@ import (
 	kds_client_v2 "github.com/kumahq/kuma/pkg/kds/v2/client"
 	sync_store_v2 "github.com/kumahq/kuma/pkg/kds/v2/store"
 	"github.com/kumahq/kuma/pkg/kds/zone"
+	core_metrics "github.com/kumahq/kuma/pkg/metrics"
 	"github.com/kumahq/kuma/pkg/plugins/resources/memory"
 	"github.com/kumahq/kuma/pkg/test/grpc"
 	"github.com/kumahq/kuma/pkg/test/kds/samples"
@@ -264,7 +265,10 @@ var _ = Describe("Zone Sync", func() {
 			clientStream := serverStream.ClientStream(stop)
 
 			zoneStore = memory.NewStore()
-			zoneSyncer = sync_store_v2.NewResourceSyncer(core.Log.WithName("kds-syncer"), zoneStore)
+			metrics, err := core_metrics.NewMetrics("")
+			Expect(err).ToNot(HaveOccurred())
+			zoneSyncer, err = sync_store_v2.NewResourceSyncer(core.Log.WithName("kds-syncer"), zoneStore, metrics)
+			Expect(err).ToNot(HaveOccurred())
 
 			wg.Add(1)
 			go func() {


### PR DESCRIPTION
### Checklist prior to review

We have metrics of KDS traffic, KDS processing on the producer side (snapshot generation latency), but we don't have metric of processing events on the consumer side (resource syncer). This PR introduces this metric. I picked Historgram instead of Summary this time. With other histograms it seems to be updated more frequently, we may want to update our other summary metrics.

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [X] [Link to relevant issue][1] as well as docs and UI issues --
- [X] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [X] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [X] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [X] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --
- [X] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
