### PR TITLE
fix(api): dataplane overview pagination

### DIFF
--- a/pkg/api-server/dataplane_overview_endpoints.go
+++ b/pkg/api-server/dataplane_overview_endpoints.go
@@ -119,8 +119,6 @@ func (r *dataplaneOverviewEndpoints) inspectDataplanes(request *restful.Request,
 		return
 	}
 
-	// pagination is not supported yet so we need to override pagination total items after retaining dataplanes
-	overviews.GetPagination().SetTotal(uint32(len(overviews.Items)))
 	restList := rest.From.ResourceList(&overviews)
 	restList.Next = nextLink(request, overviews.GetPagination().NextOffset)
 	if err := response.WriteAsJson(restList); err != nil {

--- a/pkg/api-server/dataplane_overview_endpoints_test.go
+++ b/pkg/api-server/dataplane_overview_endpoints_test.go
@@ -290,5 +290,17 @@ var _ = Describe("Dataplane Overview Endpoints", func() {
 				expectedJson: fmt.Sprintf(`{"total": 2, "items": [%s, %s], "next": null}`, gatewayBuiltinJson, gatewayDelegatedJson),
 			}),
 		)
+
+		It("should paginate correctly", func() {
+			// when
+			response, err := http.Get("http://" + apiServer.Address() + "/meshes/mesh1/dataplanes+insights?size=1")
+			Expect(err).ToNot(HaveOccurred())
+
+			// then
+			Expect(response.StatusCode).To(Equal(200))
+			body, err := io.ReadAll(response.Body)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(string(body)).To(MatchJSON(fmt.Sprintf(`{"total": 3, "items": [%s], "next": "http://%s/meshes/mesh1/dataplanes+insights?offset=1&size=1"}`, dp1Json, apiServer.Address())))
+		})
 	})
 })


### PR DESCRIPTION
### Checklist prior to review

Fix https://github.com/kumahq/kuma/issues/7801

When we introduced the endpoint we were filtering items in this file therefore we had to set a total to all items we fetched. Some time ago we changed this to pass filter function to the store. This means that `overviews.Item` was after pagination and filtering was done.

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --
- [x] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
