### PR TITLE
fix(metrics): resources synced

### DIFF
--- a/pkg/kds/v2/store/sync.go
+++ b/pkg/kds/v2/store/sync.go
@@ -96,7 +96,7 @@ func NewResourceSyncer(
 func (s *syncResourceStore) Sync(syncCtx context.Context, upstreamResponse client_v2.UpstreamResponse, fs ...SyncOptionFunc) error {
 	now := core.Now()
 	defer func() {
-		s.metric.Observe(float64(time.Since(now)))
+		s.metric.Observe(float64(time.Since(now).Milliseconds()) / 1000)
 	}()
 	opts := NewSyncOptions(fs...)
 	ctx := user.Ctx(syncCtx, user.ControlPlane)


### PR DESCRIPTION
### Checklist prior to review

Default histograms expect seconds. Here are buckets
```
kds_resources_sync_bucket{zone="Global",le="0.005"} 0
kds_resources_sync_bucket{zone="Global",le="0.01"} 0
kds_resources_sync_bucket{zone="Global",le="0.025"} 0
kds_resources_sync_bucket{zone="Global",le="0.05"} 0
kds_resources_sync_bucket{zone="Global",le="0.1"} 0
kds_resources_sync_bucket{zone="Global",le="0.25"} 0
kds_resources_sync_bucket{zone="Global",le="0.5"} 0
kds_resources_sync_bucket{zone="Global",le="1"} 0
kds_resources_sync_bucket{zone="Global",le="2.5"} 6
kds_resources_sync_bucket{zone="Global",le="5"} 6
kds_resources_sync_bucket{zone="Global",le="10"} 6
kds_resources_sync_bucket{zone="Global",le="+Inf"} 6
kds_resources_sync_sum{zone="Global"} 6.01
kds_resources_sync_count{zone="Global"} 6
```

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [ ] [Link to relevant issue][1] as well as docs and UI issues --
- [ ] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [ ] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [ ] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [ ] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --
- [ ] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword

> Changelog: skip
