### PR TITLE
feat(api-server): add filtering on list external-services and dataplanes

### DIFF
--- a/api/mesh/v1alpha1/externalservice_helpers.go
+++ b/api/mesh/v1alpha1/externalservice_helpers.go
@@ -17,6 +17,10 @@ func (es *ExternalService) MatchTags(selector TagSelector) bool {
 	return selector.Matches(es.Tags)
 }
 
+func (es *ExternalService) MatchTagsFuzzy(selector TagSelector) bool {
+	return selector.MatchesFuzzy(es.Tags)
+}
+
 func (es *ExternalService) GetService() string {
 	if es == nil {
 		return ""

--- a/pkg/api-server/dataplane_overview_endpoints.go
+++ b/pkg/api-server/dataplane_overview_endpoints.go
@@ -19,6 +19,7 @@ import (
 type dataplaneOverviewEndpoints struct {
 	resManager     manager.ResourceManager
 	resourceAccess access.ResourceAccess
+	filter         func(request *restful.Request) (store.ListFilterFunc, error)
 }
 
 func (r *dataplaneOverviewEndpoints) addFindEndpoint(ws *restful.WebService, pathPrefix string) {
@@ -106,7 +107,7 @@ func (r *dataplaneOverviewEndpoints) inspectDataplanes(request *restful.Request,
 		return
 	}
 
-	filter, err := genFilter(request)
+	filter, err := r.filter(request)
 	if err != nil {
 		rest_errors.HandleError(request.Request.Context(), response, err, "Could not retrieve dataplane overviews")
 		return

--- a/pkg/api-server/filters/filtering.go
+++ b/pkg/api-server/filters/filtering.go
@@ -48,7 +48,9 @@ func Resource(resDescriptor core_model.ResourceTypeDescriptor) func(request *res
 			}, nil
 		}
 	default:
-		return nil
+		return func(request *restful.Request) (store.ListFilterFunc, error) {
+			return nil, nil
+		}
 	}
 }
 

--- a/pkg/api-server/filters/filtering.go
+++ b/pkg/api-server/filters/filtering.go
@@ -1,4 +1,4 @@
-package api_server
+package filters
 
 import (
 	"reflect"
@@ -12,6 +12,45 @@ import (
 	"github.com/kumahq/kuma/pkg/core/resources/store"
 	"github.com/kumahq/kuma/pkg/core/validators"
 )
+
+// Resource return a store filter depending on the resource. We take a descriptor so that we can do advance filtering options
+// For example we could make a filter that works on top level targetRef by looking at the descriptor info
+func Resource(resDescriptor core_model.ResourceTypeDescriptor) func(request *restful.Request) (store.ListFilterFunc, error) {
+	switch resDescriptor.Name {
+	case mesh.DataplaneType:
+		return func(request *restful.Request) (store.ListFilterFunc, error) {
+			gatewayFilter, err := gatewayModeFilterFromParameter(request)
+			if err != nil {
+				return nil, err
+			}
+
+			tags := parseTags(request.QueryParameters("tag"))
+
+			return func(rs core_model.Resource) bool {
+				dataplane := rs.(*mesh.DataplaneResource)
+				if !gatewayFilter(dataplane.Spec.GetNetworking().GetGateway()) {
+					return false
+				}
+
+				if !dataplane.Spec.MatchTagsFuzzy(tags) {
+					return false
+				}
+
+				return true
+			}, nil
+		}
+	case mesh.ExternalServiceType:
+		return func(request *restful.Request) (store.ListFilterFunc, error) {
+			tags := parseTags(request.QueryParameters("tag"))
+
+			return func(rs core_model.Resource) bool {
+				return rs.(*mesh.ExternalServiceResource).Spec.MatchTagsFuzzy(tags)
+			}, nil
+		}
+	default:
+		return nil
+	}
+}
 
 type DpFilter func(*mesh_proto.Dataplane_Networking_Gateway) bool
 
@@ -50,28 +89,6 @@ func gatewayModeFilterFromParameter(request *restful.Request) (DpFilter, error) 
 			return true
 		}, nil
 	}
-}
-
-func genFilter(request *restful.Request) (store.ListFilterFunc, error) {
-	gatewayFilter, err := gatewayModeFilterFromParameter(request)
-	if err != nil {
-		return nil, err
-	}
-
-	tags := parseTags(request.QueryParameters("tag"))
-
-	return func(rs core_model.Resource) bool {
-		dataplane := rs.(*mesh.DataplaneResource)
-		if !gatewayFilter(dataplane.Spec.GetNetworking().GetGateway()) {
-			return false
-		}
-
-		if !dataplane.Spec.MatchTagsFuzzy(tags) {
-			return false
-		}
-
-		return true
-	}, nil
 }
 
 // Tags should be passed in form of ?tag=service:mobile&tag=version:v1

--- a/pkg/api-server/resource_endpoints.go
+++ b/pkg/api-server/resource_endpoints.go
@@ -40,6 +40,7 @@ type resourceEndpoints struct {
 	descriptor     model.ResourceTypeDescriptor
 	resourceAccess access.ResourceAccess
 	k8sMapper      k8s.ResourceMapperFunc
+	filter         func(request *restful.Request) (store.ListFilterFunc, error)
 }
 
 func (r *resourceEndpoints) addFindEndpoint(ws *restful.WebService, pathPrefix string) {
@@ -115,9 +116,14 @@ func (r *resourceEndpoints) listResources(request *restful.Request, response *re
 		rest_errors.HandleError(request.Request.Context(), response, err, "Could not retrieve resources")
 		return
 	}
+	filter, err := r.filter(request)
+	if err != nil {
+		rest_errors.HandleError(request.Request.Context(), response, err, "Could not retrieve resources")
+		return
+	}
 
 	list := r.descriptor.NewList()
-	if err := r.resManager.List(request.Request.Context(), list, store.ListByMesh(meshName), store.ListByPage(page.size, page.offset)); err != nil {
+	if err := r.resManager.List(request.Request.Context(), list, store.ListByMesh(meshName), store.ListByFilterFunc(filter), store.ListByPage(page.size, page.offset)); err != nil {
 		rest_errors.HandleError(request.Request.Context(), response, err, "Could not retrieve resources")
 	} else {
 		restList := rest.From.ResourceList(list)

--- a/pkg/api-server/server.go
+++ b/pkg/api-server/server.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/kumahq/kuma/pkg/api-server/authn"
 	"github.com/kumahq/kuma/pkg/api-server/customization"
+	"github.com/kumahq/kuma/pkg/api-server/filters"
 	api_server "github.com/kumahq/kuma/pkg/config/api-server"
 	kuma_cp "github.com/kumahq/kuma/pkg/config/app/kuma-cp"
 	config_core "github.com/kumahq/kuma/pkg/config/core"
@@ -241,6 +242,7 @@ func addResourcesEndpoints(
 	dpOverviewEndpoints := dataplaneOverviewEndpoints{
 		resManager:     resManager,
 		resourceAccess: resourceAccess,
+		filter:         filters.Resource(mesh.DataplaneResourceTypeDescriptor),
 	}
 	dpOverviewEndpoints.addListEndpoint(ws, "/meshes/{mesh}")
 	dpOverviewEndpoints.addFindEndpoint(ws, "/meshes/{mesh}")
@@ -296,6 +298,7 @@ func addResourcesEndpoints(
 			resManager:     resManager,
 			descriptor:     definition,
 			resourceAccess: resourceAccess,
+			filter:         filters.Resource(definition),
 		}
 		if cfg.Mode == config_core.Zone && cfg.Multizone != nil && cfg.Multizone.Zone != nil {
 			endpoints.zoneName = cfg.Multizone.Zone.Name


### PR DESCRIPTION
This also opens the path to adding more filters to the api depending on the resource descriptor

Fix #5908

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --
- [x] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
