### PR TITLE
fix(kds): call CloseSend and exit a goroutine when sync fails to start

### DIFF
--- a/pkg/kds/mux/client.go
+++ b/pkg/kds/mux/client.go
@@ -175,7 +175,7 @@ func (c *client) startGlobalToZoneSync(ctx context.Context, log logr.Logger, con
 	case err := <-processingErrorsCh:
 		if status.Code(err) == codes.Unimplemented {
 			log.Error(err, "Global to Zone Sync rpc stream failed, because Global CP does not implement this rpc. Upgrade Global CP.")
-			// backwards compatibility. Do not rethrow error, so KDS multiplex can still operate.
+			// backwards compatibility. Do not rethrow error, so Admin RPC can still operate.
 			return
 		}
 		log.Error(err, "Global to Zone Sync rpc stream failed, will restart in background")
@@ -183,6 +183,7 @@ func (c *client) startGlobalToZoneSync(ctx context.Context, log logr.Logger, con
 			log.Error(err, "CloseSend returned an error")
 		}
 		errorCh <- err
+		return
 	}
 }
 
@@ -205,7 +206,7 @@ func (c *client) startZoneToGlobalSync(ctx context.Context, log logr.Logger, con
 	case err := <-processingErrorsCh:
 		if status.Code(err) == codes.Unimplemented {
 			log.Error(err, "Zone to Global Sync rpc stream failed, because Global CP does not implement this rpc. Upgrade Global CP.")
-			// backwards compatibility. Do not rethrow error, so KDS multiplex can still operate.
+			// backwards compatibility. Do not rethrow error, so Admin RPC can still operate.
 			return
 		}
 		log.Error(err, "Zone to Global Sync rpc stream failed, will restart in background")
@@ -213,6 +214,7 @@ func (c *client) startZoneToGlobalSync(ctx context.Context, log logr.Logger, con
 			log.Error(err, "CloseSend returned an error")
 		}
 		errorCh <- err
+		return
 	}
 }
 


### PR DESCRIPTION
### Checklist prior to review

While running locally I've noticed that` when Zone cannot connect to the Global` we were incorrectly handling errors. Stop channel reacts only on signal and it was hanging on this line until zone was terminated. That cause that method `CloseSend` wasn't called and coroutine was hanging causing leak of goroutines. It shouldn't leak the connection though.

- [X] [Link to relevant issue][1] as well as docs and UI issues --
- [X] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [X] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [X] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [X] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --
- [X] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
