### PR TITLE
feat(kuma-cp): fix global insight endpoint zone cp count

### DIFF
--- a/pkg/insights/globalinsight/global_insight_service.go
+++ b/pkg/insights/globalinsight/global_insight_service.go
@@ -151,17 +151,9 @@ func (gis *defaultGlobalInsightService) aggregateZoneControlPlanes(
 	}
 
 	for _, zoneInsight := range zoneInsights.GetItems() {
-		subscriptions := zoneInsight.GetSpec().(*system_proto.ZoneInsight).GetSubscriptions()
-
-		for _, subscription := range subscriptions {
-			globalInsight.Zones.ControlPlanes.Total += 1
-
-			disconnected := subscription.GetDisconnectTime()
-			connected := subscription.GetConnectTime().AsTime()
-
-			if disconnected == nil || disconnected.AsTime().Before(connected) {
-				globalInsight.Zones.ControlPlanes.Online += 1
-			}
+		globalInsight.Zones.ControlPlanes.Total += 1
+		if zoneInsight.GetSpec().(*system_proto.ZoneInsight).IsOnline() {
+			globalInsight.Zones.ControlPlanes.Online += 1
 		}
 	}
 
@@ -178,14 +170,9 @@ func (gis *defaultGlobalInsightService) aggregateZoneIngresses(
 	}
 
 	for _, zoneIngressInsight := range zoneIngressInsights.GetItems() {
-		subscriptions := zoneIngressInsight.GetSpec().(*mesh_proto.ZoneIngressInsight).GetSubscriptions()
-
-		for _, subscription := range subscriptions {
-			globalInsight.Zones.ZoneIngresses.Total += 1
-
-			if subscription.GetDisconnectTime() == nil {
-				globalInsight.Zones.ZoneIngresses.Online += 1
-			}
+		globalInsight.Zones.ZoneIngresses.Total += 1
+		if zoneIngressInsight.GetSpec().(*mesh_proto.ZoneIngressInsight).IsOnline() {
+			globalInsight.Zones.ZoneIngresses.Online += 1
 		}
 	}
 
@@ -202,14 +189,9 @@ func (gis *defaultGlobalInsightService) aggregateZoneEgresses(
 	}
 
 	for _, zoneEgressInsight := range zoneEgressInsights.GetItems() {
-		subscriptions := zoneEgressInsight.GetSpec().(*mesh_proto.ZoneEgressInsight).GetSubscriptions()
-
-		for _, subscription := range subscriptions {
-			globalInsight.Zones.ZoneEgresses.Total += 1
-
-			if subscription.GetDisconnectTime() == nil {
-				globalInsight.Zones.ZoneEgresses.Online += 1
-			}
+		globalInsight.Zones.ZoneEgresses.Total += 1
+		if zoneEgressInsight.GetSpec().(*mesh_proto.ZoneEgressInsight).IsOnline() {
+			globalInsight.Zones.ZoneEgresses.Online += 1
 		}
 	}
 

--- a/pkg/insights/globalinsight/global_insight_service_test.go
+++ b/pkg/insights/globalinsight/global_insight_service_test.go
@@ -45,17 +45,17 @@ var _ = Describe("Global Insight", func() {
 		Expect(err).ToNot(HaveOccurred())
 		err = createServiceInsight("si-2", "payments", rs)
 		Expect(err).ToNot(HaveOccurred())
-		err = createZoneInsight("zi-1", rs)
+		err = createZoneInsight("zi-1", true, rs)
 		Expect(err).ToNot(HaveOccurred())
-		err = createZoneInsight("zi-2", rs)
+		err = createZoneInsight("zi-2", false, rs)
 		Expect(err).ToNot(HaveOccurred())
-		err = createZoneIngressInsight("zii-1", "default", rs)
+		err = createZoneIngressInsight("zii-1", "default", true, rs)
 		Expect(err).ToNot(HaveOccurred())
-		err = createZoneIngressInsight("zii-2", "payments", rs)
+		err = createZoneIngressInsight("zii-2", "payments", false, rs)
 		Expect(err).ToNot(HaveOccurred())
-		err = createZoneEgressInsight("zei-1", "default", rs)
+		err = createZoneEgressInsight("zei-1", "default", true, rs)
 		Expect(err).ToNot(HaveOccurred())
-		err = createZoneEgressInsight("zei-1", "payments", rs)
+		err = createZoneEgressInsight("zei-1", "payments", false, rs)
 		Expect(err).ToNot(HaveOccurred())
 
 		// when
@@ -109,43 +109,53 @@ func createServiceInsight(name string, mesh string, rs store.ResourceStore) erro
 		Create(rs)
 }
 
-func createZoneInsight(name string, rs store.ResourceStore) error {
-	return builders.ZoneInsight().
-		WithName(name).
-		AddSubscription(&system_proto.KDSSubscription{
+func createZoneInsight(name string, online bool, rs store.ResourceStore) error {
+	builder := builders.ZoneInsight().WithName(name)
+
+	if online {
+		builder.AddSubscription(&system_proto.KDSSubscription{
 			ConnectTime: util_proto.MustTimestampProto(time.Unix(1694779925, 0)),
-		}).
-		AddSubscription(&system_proto.KDSSubscription{
+		})
+	} else {
+		builder.AddSubscription(&system_proto.KDSSubscription{
 			ConnectTime:    util_proto.MustTimestampProto(time.Unix(1694779805, 0)),
 			DisconnectTime: util_proto.MustTimestampProto(time.Unix(1694779925, 0)),
-		}).
-		Create(rs)
+		})
+	}
+
+	return builder.Create(rs)
 }
 
-func createZoneIngressInsight(name string, mesh string, rs store.ResourceStore) error {
-	return builders.ZoneIngressInsight().
-		WithName(name).
-		WithMesh(mesh).
-		AddSubscription(&mesh_proto.DiscoverySubscription{
+func createZoneIngressInsight(name string, mesh string, online bool, rs store.ResourceStore) error {
+	builder := builders.ZoneIngressInsight().WithName(name).WithMesh(mesh)
+
+	if online {
+		builder.AddSubscription(&mesh_proto.DiscoverySubscription{
 			ConnectTime: util_proto.MustTimestampProto(time.Unix(1694779805, 0)),
-		}).
-		AddSubscription(&mesh_proto.DiscoverySubscription{
+		})
+	} else {
+		builder.AddSubscription(&mesh_proto.DiscoverySubscription{
 			ConnectTime:    util_proto.MustTimestampProto(time.Unix(1694779805, 0)),
 			DisconnectTime: util_proto.MustTimestampProto(time.Unix(1694779925, 0)),
-		}).
-		Create(rs)
+		})
+	}
+
+	return builder.Create(rs)
 }
 
-func createZoneEgressInsight(name string, mesh string, rs store.ResourceStore) error {
-	return builders.ZoneEgressInsight().
-		WithName(name).
-		WithMesh(mesh).
-		AddSubscription(&mesh_proto.DiscoverySubscription{
+func createZoneEgressInsight(name string, mesh string, online bool, rs store.ResourceStore) error {
+	builder := builders.ZoneEgressInsight().WithName(name).WithMesh(mesh)
+
+	if online {
+		builder.AddSubscription(&mesh_proto.DiscoverySubscription{
 			ConnectTime: util_proto.MustTimestampProto(time.Unix(1694779805, 0)),
-		}).
-		AddSubscription(&mesh_proto.DiscoverySubscription{
+		})
+	} else {
+		builder.AddSubscription(&mesh_proto.DiscoverySubscription{
 			ConnectTime:    util_proto.MustTimestampProto(time.Unix(1694779805, 0)),
 			DisconnectTime: util_proto.MustTimestampProto(time.Unix(1694779925, 0)),
-		}).
-		Create(rs)
+		})
+	}
+
+	return builder.Create(rs)
 }

--- a/pkg/insights/globalinsight/testdata/full_global_insight.golden.json
+++ b/pkg/insights/globalinsight/testdata/full_global_insight.golden.json
@@ -51,16 +51,16 @@
   },
   "zones": {
     "controlPlanes": {
-      "online": 2,
-      "total": 4
+      "online": 1,
+      "total": 2
     },
     "zoneEgresses": {
-      "online": 2,
-      "total": 4
+      "online": 1,
+      "total": 2
     },
     "zoneIngresses": {
-      "online": 2,
-      "total": 4
+      "online": 1,
+      "total": 2
     }
   }
 }


### PR DESCRIPTION
Fixes: #7851

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --
- [x] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
