### PR TITLE
chore(kuma-cp): improve logging

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -22,6 +22,7 @@ linters:
     - unused
     - whitespace
     - nosprintfhostport
+    - loggercheck
 
 run:
   build-tags:

--- a/app/kuma-cp/cmd/run.go
+++ b/app/kuma-cp/cmd/run.go
@@ -145,12 +145,12 @@ func newRunCmdWithOpts(opts kuma_cmd.RunCmdOpts) *cobra.Command {
 				return err
 			}
 
-			runLog.Info("Stop signal received. Waiting 3 seconds for components to stop gracefully...")
+			runLog.Info("stop signal received. Waiting 3 seconds for components to stop gracefully...")
 			select {
 			case <-ctx.Done():
 			case <-time.After(gracefullyShutdownDuration):
 			}
-			runLog.Info("Stopping Control Plane")
+			runLog.Info("stopping Control Plane")
 			return nil
 		},
 	}

--- a/pkg/config/loader.go
+++ b/pkg/config/loader.go
@@ -16,7 +16,7 @@ func Load(file string, cfg Config) error {
 
 func LoadWithOption(file string, cfg Config, strict bool, includeEnv bool, validate bool) error {
 	if file == "" {
-		core.Log.Info("Skipping reading config from file")
+		core.Log.WithName("config").Info("skipping reading config from file")
 	} else if err := loadFromFile(file, cfg, strict); err != nil {
 		return err
 	}

--- a/pkg/core/alias.go
+++ b/pkg/core/alias.go
@@ -28,14 +28,15 @@ var (
 		c := make(chan os.Signal, 3)
 		signal.Notify(c, syscall.SIGINT, syscall.SIGTERM)
 		go func() {
+			logger := Log.WithName("runtime")
 			s := <-c
-			Log.Info("Received signal, stopping instance gracefully", "signal", s.String())
+			logger.Info("received signal, stopping instance gracefully", "signal", s.String())
 			gracefulCancel()
 			s = <-c
-			Log.Info("Received second signal, stopping instance", "signal", s.String())
+			logger.Info("received second signal, stopping instance", "signal", s.String())
 			cancel()
 			s = <-c
-			Log.Info("Received third signal, force exit", "signal", s.String())
+			logger.Info("received third signal, force exit", "signal", s.String())
 			os.Exit(1)
 		}()
 		return gracefulCtx, ctx

--- a/pkg/core/secrets/manager/validator.go
+++ b/pkg/core/secrets/manager/validator.go
@@ -53,7 +53,7 @@ func (s *secretValidator) ValidateDelete(ctx context.Context, name string, mesh 
 	for _, backend := range meshRes.Spec.GetMtls().GetBackends() {
 		used, err := s.secretUsedByMTLSBackend(name, meshRes.GetMeta().GetName(), backend)
 		if err != nil {
-			log.Info("Error while checking if secret is used by mTLS backend. Deleting secret anyway", err)
+			log.Info("error while checking if secret is used by mTLS backend. Deleting secret anyway", "cause", err)
 		}
 		if used {
 			verr.AddViolation("name", fmt.Sprintf(`The secret %q that you are trying to remove is currently in use in Mesh %q in mTLS backend %q. Please remove the reference from the %q backend before removing the secret.`, name, mesh, backend.Name, backend.Name))

--- a/pkg/insights/resyncer.go
+++ b/pkg/insights/resyncer.go
@@ -244,7 +244,6 @@ func (r *resyncer) Start(stop <-chan struct{}) error {
 				start := r.now()
 				select {
 				case <-ctx.Done():
-					log.Info("stopped resyncEvents loop")
 					return
 				case event, more := <-resyncEvents:
 					if !more {

--- a/pkg/mads/v1/generator/assignments.go
+++ b/pkg/mads/v1/generator/assignments.go
@@ -29,7 +29,7 @@ func (g MonitoringAssignmentsGenerator) Generate(args generator.Args) ([]*core_x
 
 		prometheusEndpoint, err := dataplane.GetPrometheusConfig(mesh)
 		if err != nil {
-			log.Info("could not get prometheus endpoint from the dataplane", err)
+			log.Info("could not get prometheus endpoint from the dataplane", "cause", err)
 			// does not return error to not break MADS for other dataplanes
 			continue
 		}

--- a/pkg/plugins/policies/core/matchers/dataplane.go
+++ b/pkg/plugins/policies/core/matchers/dataplane.go
@@ -136,7 +136,7 @@ func resolveTargetRefs(rl []core_model.Resource, resources xds_context.Resources
 		case common_api.MeshHTTPRoute:
 			mhr := resolveMeshHTTPRouteRef(r.GetMeta(), policy.GetTargetRef().Name, resources)
 			if mhr == nil {
-				core.Log.Info("unable to resolve TargetRef", "mesh", r.GetMeta().GetMesh(),
+				core.Log.WithName("matchers").Info("unable to resolve TargetRef", "mesh", r.GetMeta().GetMesh(),
 					"policyType", r.Descriptor().Name, "policyName", r.GetMeta().GetName(),
 					"targetRefKind", policy.GetTargetRef().Kind, "targetRefName", policy.GetTargetRef().Name,
 				)

--- a/pkg/plugins/runtime/k8s/controllers/gatewayapi/gateway_class_controller.go
+++ b/pkg/plugins/runtime/k8s/controllers/gatewayapi/gateway_class_controller.go
@@ -3,6 +3,7 @@ package gatewayapi
 import (
 	"context"
 	"fmt"
+	"reflect"
 
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
@@ -186,7 +187,7 @@ func gatewayClassesForConfig(l logr.Logger, client kube_client.Client) kube_hand
 	return func(ctx context.Context, obj kube_client.Object) []kube_reconcile.Request {
 		config, ok := obj.(*mesh_k8s.MeshGatewayConfig)
 		if !ok {
-			l.Error(nil, "unexpected error converting to be mapped %T object to MeshGatewayConfig", obj)
+			l.Error(nil, "unexpected error converting to be mapped object to MeshGatewayConfig", "typ", reflect.TypeOf(obj))
 			return nil
 		}
 

--- a/pkg/plugins/runtime/k8s/controllers/gatewayapi/gateway_controller.go
+++ b/pkg/plugins/runtime/k8s/controllers/gatewayapi/gateway_controller.go
@@ -2,6 +2,7 @@ package gatewayapi
 
 import (
 	"context"
+	"reflect"
 
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
@@ -178,7 +179,7 @@ func gatewaysForRoute(l logr.Logger) kube_handler.MapFunc {
 	return func(_ context.Context, obj kube_client.Object) []kube_reconcile.Request {
 		route, ok := obj.(*gatewayapi.HTTPRoute)
 		if !ok {
-			l.Error(nil, "unexpected error converting to be mapped %T object to HTTPRoute", obj)
+			l.Error(nil, "unexpected error converting to be mapped object to HTTPRoute", "typ", reflect.TypeOf(obj))
 			return nil
 		}
 
@@ -209,7 +210,7 @@ func gatewaysForClass(l logr.Logger, client kube_client.Client) kube_handler.Map
 	return func(ctx context.Context, obj kube_client.Object) []kube_reconcile.Request {
 		class, ok := obj.(*gatewayapi.GatewayClass)
 		if !ok {
-			l.Error(nil, "unexpected error converting to be mapped %T object to GatewayClass", obj)
+			l.Error(nil, "unexpected error converting to be mapped object to GatewayClass", "typ", reflect.TypeOf(obj))
 			return nil
 		}
 
@@ -240,7 +241,7 @@ func gatewaysForConfig(l logr.Logger, client kube_client.Client) kube_handler.Ma
 	return func(ctx context.Context, obj kube_client.Object) []kube_reconcile.Request {
 		config, ok := obj.(*mesh_k8s.MeshGatewayConfig)
 		if !ok {
-			l.Error(nil, "unexpected error converting to be mapped %T object to MeshGatewayConfig", obj)
+			l.Error(nil, "unexpected error converting to be mapped object to MeshGatewayConfig", "typ", reflect.TypeOf(obj))
 			return nil
 		}
 
@@ -281,7 +282,7 @@ func gatewaysForGrant(l logr.Logger, client kube_client.Client) kube_handler.Map
 	return func(ctx context.Context, obj kube_client.Object) []kube_reconcile.Request {
 		grant, ok := obj.(*gatewayapi.ReferenceGrant)
 		if !ok {
-			l.Error(nil, "unexpected error converting to be mapped %T object to GatewayGrant", obj)
+			l.Error(nil, "unexpected error converting to be mapped object to GatewayGrant", "typ", reflect.TypeOf(obj))
 			return nil
 		}
 
@@ -320,7 +321,7 @@ func gatewaysForSecret(l logr.Logger, client kube_client.Client) kube_handler.Ma
 	return func(ctx context.Context, obj kube_client.Object) []kube_reconcile.Request {
 		secret, ok := obj.(*kube_core.Secret)
 		if !ok {
-			l.Error(nil, "unexpected error converting to be mapped %T object to Secret", obj)
+			l.Error(nil, "unexpected error converting to be mapped object to Secret", "typ", reflect.TypeOf(obj))
 			return nil
 		}
 

--- a/pkg/plugins/runtime/k8s/controllers/gatewayapi/http_route_controller.go
+++ b/pkg/plugins/runtime/k8s/controllers/gatewayapi/http_route_controller.go
@@ -2,6 +2,7 @@ package gatewayapi
 
 import (
 	"context"
+	"reflect"
 
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
@@ -248,7 +249,7 @@ func routesForGateway(l logr.Logger, client kube_client.Client) kube_handler.Map
 	return func(ctx context.Context, obj kube_client.Object) []kube_reconcile.Request {
 		gateway, ok := obj.(*gatewayapi.Gateway)
 		if !ok {
-			l.Error(nil, "unexpected error converting to be mapped %T object to Gateway", obj)
+			l.Error(nil, "unexpected error converting to be mapped object to Gateway", "typ", reflect.TypeOf(obj))
 			return nil
 		}
 
@@ -282,7 +283,7 @@ func routesForGrant(l logr.Logger, client kube_client.Client) kube_handler.MapFu
 	return func(ctx context.Context, obj kube_client.Object) []kube_reconcile.Request {
 		grant, ok := obj.(*gatewayapi.ReferenceGrant)
 		if !ok {
-			l.Error(nil, "unexpected error converting to be mapped %T object to GatewayGrant", obj)
+			l.Error(nil, "unexpected error converting to be mapped object to GatewayGrant", "typ", reflect.TypeOf(obj))
 			return nil
 		}
 

--- a/pkg/xds/context/context.go
+++ b/pkg/xds/context/context.go
@@ -50,7 +50,7 @@ func (mc *MeshContext) GetTracingBackend(tt *core_mesh.TrafficTraceResource) *me
 		return nil
 	}
 	if tb := mc.Resource.GetTracingBackend(tt.Spec.GetConf().GetBackend()); tb == nil {
-		core.Log.Info("Tracing backend is not found. Ignoring.",
+		core.Log.WithName("xds").Info("Tracing backend is not found. Ignoring.",
 			"backendName", tt.Spec.GetConf().GetBackend(),
 			"trafficTraceName", tt.GetMeta().GetName(),
 			"trafficTraceMesh", tt.GetMeta().GetMesh())
@@ -65,7 +65,7 @@ func (mc *MeshContext) GetLoggingBackend(tl *core_mesh.TrafficLogResource) *mesh
 		return nil
 	}
 	if lb := mc.Resource.GetLoggingBackend(tl.Spec.GetConf().GetBackend()); lb == nil {
-		core.Log.Info("Logging backend is not found. Ignoring.",
+		core.Log.WithName("xds").Info("Logging backend is not found. Ignoring.",
 			"backendName", tl.Spec.GetConf().GetBackend(),
 			"trafficLogName", tl.GetMeta().GetName(),
 			"trafficLogMesh", tl.GetMeta().GetMesh())


### PR DESCRIPTION
### Checklist prior to review

* Add linter
* Fix linter problems (mainly `%T`)
* Name all unnamed logs (it does not map well with a Datadog)
* Remove `stopped resyncEvents loop` logs because with 100 loops it's quite a spam and it can only log this when the whole component is down which we already log.

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [ ] [Link to relevant issue][1] as well as docs and UI issues --
- [ ] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [ ] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [ ] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [ ] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --
- [ ] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
