### PR TITLE
fix: multiple typos

### DIFF
--- a/app/kumactl/cmd/completion/testdata/fish.golden
+++ b/app/kumactl/cmd/completion/testdata/fish.golden
@@ -79,7 +79,7 @@ function __kumactl_clear_perform_completion_once_result
     __kumactl_debug ""
     __kumactl_debug "========= clearing previously set __kumactl_perform_completion_once_result variable =========="
     set --erase __kumactl_perform_completion_once_result
-    __kumactl_debug "Succesfully erased the variable __kumactl_perform_completion_once_result"
+    __kumactl_debug "Successfully erased the variable __kumactl_perform_completion_once_result"
 end
 
 function __kumactl_requires_order_preservation

--- a/app/kumactl/cmd/completion/testdata/fish.golden
+++ b/app/kumactl/cmd/completion/testdata/fish.golden
@@ -79,7 +79,7 @@ function __kumactl_clear_perform_completion_once_result
     __kumactl_debug ""
     __kumactl_debug "========= clearing previously set __kumactl_perform_completion_once_result variable =========="
     set --erase __kumactl_perform_completion_once_result
-    __kumactl_debug "Successfully erased the variable __kumactl_perform_completion_once_result"
+    __kumactl_debug "Succesfully erased the variable __kumactl_perform_completion_once_result"
 end
 
 function __kumactl_requires_order_preservation

--- a/docs/madr/decisions/000-template.md
+++ b/docs/madr/decisions/000-template.md
@@ -1,6 +1,6 @@
 # {short title of solved problem and solution}
 
-* Status: {rejected | accepted | deprecated | superseded by [ADR-0005](0005-example.md) | implemented in `<link to releavant PR/issue...>`} <!-- recomended to have the status as accepted proactively and then to change it if needed -->
+* Status: {rejected | accepted | deprecated | superseded by [ADR-0005](0005-example.md) | implemented in `<link to releavant PR/issue...>`} <!-- recommended to have the status as accepted proactively and then to change it if needed -->
 
 Technical Story: {description | ticket/issue URL} <!-- link to the github issue -->
 

--- a/mk/kind.mk
+++ b/mk/kind.mk
@@ -8,7 +8,7 @@ KIND_KUBECONFIG_DIR := $(HOME)/.kube
 # This is the name of the current config file to use.
 KIND_KUBECONFIG := $(KIND_KUBECONFIG_DIR)/kind-$(KIND_CLUSTER_NAME)-config
 
-# Ensure Kubernetes tooling only gets the config we explicity specify.
+# Ensure Kubernetes tooling only gets the config we explicitly specify.
 unexport KUBECONFIG
 
 METRICS_SERVER_VERSION := 0.4.1


### PR DESCRIPTION
### Checklist prior to review

> Changelog: skip

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --
- [x] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
