### PR TITLE
chore(kuma-cp): remove default prefix from PreconditionError.Reason

### DIFF
--- a/pkg/core/resources/store/store.go
+++ b/pkg/core/resources/store/store.go
@@ -156,9 +156,13 @@ type PreconditionError struct {
 }
 
 func (a *PreconditionError) Error() string {
-	return "invalid format: " + a.Reason
+	return a.Reason
 }
 
 func (a *PreconditionError) Is(err error) bool {
 	return reflect.TypeOf(a) == reflect.TypeOf(err)
+}
+
+func PreconditionFormatError(reason string) *PreconditionError {
+	return &PreconditionError{Reason: "invalid format: " + reason}
 }

--- a/pkg/plugins/resources/k8s/store.go
+++ b/pkg/plugins/resources/k8s/store.go
@@ -206,7 +206,7 @@ func (s *KubernetesStore) List(ctx context.Context, rs core_model.ResourceList, 
 
 func k8sNameNamespace(coreName string, scope k8s_model.Scope) (string, string, error) {
 	if coreName == "" {
-		return "", "", &store.PreconditionError{Reason: "name can't be empty"}
+		return "", "", store.PreconditionFormatError("name can't be empty")
 	}
 	switch scope {
 	case k8s_model.ScopeCluster:
@@ -214,7 +214,7 @@ func k8sNameNamespace(coreName string, scope k8s_model.Scope) (string, string, e
 	case k8s_model.ScopeNamespace:
 		name, ns, err := util_k8s.CoreNameToK8sName(coreName)
 		if err != nil {
-			return "", "", &store.PreconditionError{Reason: err.Error()}
+			return "", "", store.PreconditionFormatError(err.Error())
 		}
 		return name, ns, nil
 	default:

--- a/test/e2e_env/kubernetes/inspect/inspect.go
+++ b/test/e2e_env/kubernetes/inspect/inspect.go
@@ -32,7 +32,7 @@ func Inspect() {
 	It("should return bad request on invalid name(#4985)", func() {
 		_, err := kubernetes.Cluster.GetKumactlOptions().RunKumactlAndGetOutput("inspect", "dataplane", "-m", meshName, "dummy-name", "--type=config-dump")
 		Expect(err).To(HaveOccurred())
-		Expect(err.Error()).To(ContainSubstring(`Bad Request (name "dummy-name" must include namespace after the dot, ex. "name.namespace")`))
+		Expect(err.Error()).To(ContainSubstring(`Bad Request (invalid format: name "dummy-name" must include namespace after the dot, ex. "name.namespace")`))
 	})
 
 	It("should return envoy config_dump", func() {


### PR DESCRIPTION
Enterprise distributions can use this type of error to return not only format related errors.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues
  - No relevant issue
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS
  - It won't
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s)
  - Manually tested - it's a trivial change, so I don't think there is need to introduce new unit tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)?
  - There is no need
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label)
  - There is no need
- [x] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?
> Changelog: skip

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
