### PR TITLE
feat(kds): execute filters on envoy admin streams

### DIFF
--- a/pkg/kds/global/components.go
+++ b/pkg/kds/global/components.go
@@ -146,13 +146,22 @@ func Setup(rt runtime.Runtime) error {
 			}
 		}()
 	})
+	var streamInterceptors []service.StreamInterceptor
+	for _, filter := range rt.KDSContext().GlobalServerFiltersV2 {
+		streamInterceptors = append(streamInterceptors, filter)
+	}
 	return rt.Add(component.NewResilientComponent(kdsGlobalLog.WithName("kds-mux-client"), mux.NewServer(
 		onSessionStarted,
 		rt.KDSContext().GlobalServerFilters,
 		rt.KDSContext().ServerStreamInterceptors,
 		*rt.Config().Multizone.Global.KDS,
 		rt.Metrics(),
-		service.NewGlobalKDSServiceServer(rt.KDSContext().EnvoyAdminRPCs, rt.ResourceManager(), rt.GetInstanceId()),
+		service.NewGlobalKDSServiceServer(
+			rt.KDSContext().EnvoyAdminRPCs,
+			rt.ResourceManager(),
+			rt.GetInstanceId(),
+			streamInterceptors,
+		),
 		mux.NewKDSSyncServiceServer(
 			onGlobalToZoneSyncConnect,
 			onZoneToGlobalSyncConnect,

--- a/pkg/kds/service/server.go
+++ b/pkg/kds/service/server.go
@@ -27,10 +27,15 @@ import (
 
 var log = core.Log.WithName("kds-service")
 
+type StreamInterceptor interface {
+	InterceptServerStream(stream grpc.ServerStream) error
+}
+
 type GlobalKDSServiceServer struct {
 	envoyAdminRPCs EnvoyAdminRPCs
 	resManager     manager.ResourceManager
 	instanceID     string
+	filters        []StreamInterceptor
 	mesh_proto.UnimplementedGlobalKDSServiceServer
 }
 
@@ -38,11 +43,13 @@ func NewGlobalKDSServiceServer(
 	envoyAdminRPCs EnvoyAdminRPCs,
 	resManager manager.ResourceManager,
 	instanceID string,
+	filters []StreamInterceptor,
 ) *GlobalKDSServiceServer {
 	return &GlobalKDSServiceServer{
 		envoyAdminRPCs: envoyAdminRPCs,
 		resManager:     resManager,
 		instanceID:     instanceID,
+		filters:        filters,
 	}
 }
 
@@ -102,6 +109,12 @@ func (g *GlobalKDSServiceServer) streamEnvoyAdminRPC(
 	}
 	clientID := ClientID(stream.Context(), zone)
 	logger := log.WithValues("rpc", rpcName, "clientID", clientID)
+	for _, filter := range g.filters {
+		if err := filter.InterceptServerStream(stream); err != nil {
+			logger.Info("stream interceptor terminating the stream", "cause", err)
+			return status.Error(codes.InvalidArgument, "invalid stream")
+		}
+	}
 	logger.Info("Envoy Admin RPC stream started")
 	rpc.ClientConnected(clientID, stream)
 	if err := g.storeStreamConnection(stream.Context(), zone, rpcName, g.instanceID); err != nil {

--- a/pkg/kds/service/server.go
+++ b/pkg/kds/service/server.go
@@ -111,8 +111,12 @@ func (g *GlobalKDSServiceServer) streamEnvoyAdminRPC(
 	logger := log.WithValues("rpc", rpcName, "clientID", clientID)
 	for _, filter := range g.filters {
 		if err := filter.InterceptServerStream(stream); err != nil {
-			logger.Info("stream interceptor terminating the stream", "cause", err)
-			return status.Error(codes.InvalidArgument, "invalid stream")
+			if status.Code(err) == codes.InvalidArgument {
+				logger.Info("stream interceptor terminating the stream", "cause", err)
+			} else {
+				logger.Error(err, "stream interceptor terminating the stream")
+			}
+			return err
 		}
 	}
 	logger.Info("Envoy Admin RPC stream started")


### PR DESCRIPTION
### Checklist prior to review

Execute the same interceptors as with KDS to be able to plug in extra functionallity

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [ ] [Link to relevant issue][1] as well as docs and UI issues --
- [ ] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [ ] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [ ] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [ ] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --
- [ ] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
