### PR TITLE
chore(kds): tenant logging

### DIFF
--- a/pkg/kds/global/components.go
+++ b/pkg/kds/global/components.go
@@ -31,6 +31,7 @@ import (
 	kds_client_v2 "github.com/kumahq/kuma/pkg/kds/v2/client"
 	kds_server_v2 "github.com/kumahq/kuma/pkg/kds/v2/server"
 	kds_sync_store_v2 "github.com/kumahq/kuma/pkg/kds/v2/store"
+	kuma_log "github.com/kumahq/kuma/pkg/log"
 	resources_k8s "github.com/kumahq/kuma/pkg/plugins/resources/k8s"
 	k8s_model "github.com/kumahq/kuma/pkg/plugins/resources/k8s/native/pkg/model"
 	util_proto "github.com/kumahq/kuma/pkg/util/proto"
@@ -79,13 +80,14 @@ func Setup(rt runtime.Runtime) error {
 	}
 
 	resourceSyncer := sync_store.NewResourceSyncer(kdsGlobalLog, rt.ResourceStore())
-	resourceSyncerV2, err := kds_sync_store_v2.NewResourceSyncer(kdsDeltaGlobalLog, rt.ResourceStore(), rt.Metrics())
+	resourceSyncerV2, err := kds_sync_store_v2.NewResourceSyncer(kdsDeltaGlobalLog, rt.ResourceStore(), rt.Metrics(), rt.Extensions())
 	if err != nil {
 		return err
 	}
 	kubeFactory := resources_k8s.NewSimpleKubeFactory()
 	onSessionStarted := mux.OnSessionStartedFunc(func(session mux.Session) error {
 		log := kdsGlobalLog.WithValues("peer-id", session.PeerID())
+		log = kuma_log.AddFieldsFromCtx(log, session.ClientStream().Context(), rt.Extensions())
 		log.Info("new session created")
 		go func() {
 			if err := kdsServer.StreamKumaResources(session.ServerStream()); err != nil {
@@ -118,6 +120,7 @@ func Setup(rt runtime.Runtime) error {
 			errChan <- err
 		}
 		log := kdsDeltaGlobalLog.WithValues("peer-id", clientId)
+		log = kuma_log.AddFieldsFromCtx(log, stream.Context(), rt.Extensions())
 		log.Info("Global To Zone new session created")
 		if err := createZoneIfAbsent(stream.Context(), log, clientId, rt.ResourceManager()); err != nil {
 			errChan <- errors.Wrap(err, "Global CP could not create a zone")
@@ -135,6 +138,7 @@ func Setup(rt runtime.Runtime) error {
 			errChan <- err
 		}
 		log := kdsDeltaGlobalLog.WithValues("peer-id", clientId)
+		log = kuma_log.AddFieldsFromCtx(log, stream.Context(), rt.Extensions())
 		kdsStream := kds_client_v2.NewDeltaKDSStream(stream, clientId, "")
 		sink := kds_client_v2.NewKDSSyncClient(log, reg.ObjectTypes(model.HasKDSFlag(model.ConsumedByGlobal)), kdsStream,
 			kds_sync_store_v2.GlobalSyncCallback(stream.Context(), resourceSyncerV2, rt.Config().Store.Type == store_config.KubernetesStore, kubeFactory, rt.Config().Store.Kubernetes.SystemNamespace))
@@ -161,11 +165,13 @@ func Setup(rt runtime.Runtime) error {
 			rt.ResourceManager(),
 			rt.GetInstanceId(),
 			streamInterceptors,
+			rt.Extensions(),
 		),
 		mux.NewKDSSyncServiceServer(
 			onGlobalToZoneSyncConnect,
 			onZoneToGlobalSyncConnect,
 			rt.KDSContext().GlobalServerFiltersV2,
+			rt.Extensions(),
 		),
 	)))
 }

--- a/pkg/kds/global/components_test.go
+++ b/pkg/kds/global/components_test.go
@@ -250,7 +250,7 @@ var _ = Describe("Global Sync", func() {
 			globalStore = memory.NewStore()
 			metrics, err := core_metrics.NewMetrics("")
 			Expect(err).ToNot(HaveOccurred())
-			globalSyncer, err = sync_store_v2.NewResourceSyncer(core.Log, globalStore, metrics)
+			globalSyncer, err = sync_store_v2.NewResourceSyncer(core.Log, globalStore, metrics, context.Background())
 			Expect(err).ToNot(HaveOccurred())
 			stopCh := make(chan struct{})
 			clientStreams := []*grpc.MockDeltaClientStream{}

--- a/pkg/kds/v2/client/zone_sync_test.go
+++ b/pkg/kds/v2/client/zone_sync_test.go
@@ -89,7 +89,7 @@ var _ = Describe("Zone Delta Sync", func() {
 		zoneStore = memory.NewStore()
 		metrics, err := core_metrics.NewMetrics("")
 		Expect(err).ToNot(HaveOccurred())
-		zoneSyncer, err = sync_store_v2.NewResourceSyncer(core.Log.WithName("kds-syncer"), zoneStore, metrics)
+		zoneSyncer, err = sync_store_v2.NewResourceSyncer(core.Log.WithName("kds-syncer"), zoneStore, metrics, context.Background())
 		Expect(err).ToNot(HaveOccurred())
 
 		wg.Add(1)

--- a/pkg/kds/v2/reconcile/interfaces.go
+++ b/pkg/kds/v2/reconcile/interfaces.go
@@ -5,6 +5,7 @@ import (
 
 	envoy_core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	envoy_cache "github.com/envoyproxy/go-control-plane/pkg/cache/v3"
+	"github.com/go-logr/logr"
 
 	"github.com/kumahq/kuma/pkg/core/resources/model"
 	cache_kds_v2 "github.com/kumahq/kuma/pkg/kds/v2/cache"
@@ -14,7 +15,7 @@ import (
 type Reconciler interface {
 	// Reconcile reconciles state of node given changed resource types.
 	// Returns error and bool which is true if any resource was changed.
-	Reconcile(context.Context, *envoy_core.Node, map[model.ResourceType]struct{}) (error, bool)
+	Reconcile(context.Context, *envoy_core.Node, map[model.ResourceType]struct{}, logr.Logger) (error, bool)
 	Clear(context.Context, *envoy_core.Node) error
 }
 

--- a/pkg/kds/v2/server/components.go
+++ b/pkg/kds/v2/server/components.go
@@ -19,6 +19,7 @@ import (
 	kds_server "github.com/kumahq/kuma/pkg/kds/server"
 	reconcile_v2 "github.com/kumahq/kuma/pkg/kds/v2/reconcile"
 	"github.com/kumahq/kuma/pkg/kds/v2/util"
+	kuma_log "github.com/kumahq/kuma/pkg/log"
 	core_metrics "github.com/kumahq/kuma/pkg/metrics"
 	util_watchdog "github.com/kumahq/kuma/pkg/util/watchdog"
 	util_xds "github.com/kumahq/kuma/pkg/util/xds"
@@ -43,7 +44,16 @@ func New(
 		return nil, err
 	}
 	reconciler := reconcile_v2.NewReconciler(hasher, cache, generator, rt.Config().Mode, statsCallbacks, rt.Tenants())
-	syncTracker, err := newSyncTracker(log, reconciler, refresh, rt.Metrics(), providedTypes, rt.EventBus(), rt.Config().Experimental.KDSEventBasedWatchdog)
+	syncTracker, err := newSyncTracker(
+		log,
+		reconciler,
+		refresh,
+		rt.Metrics(),
+		providedTypes,
+		rt.EventBus(),
+		rt.Config().Experimental.KDSEventBasedWatchdog,
+		rt.Extensions(),
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -81,6 +91,7 @@ func newSyncTracker(
 	providedTypes []model.ResourceType,
 	eventBus events.EventBus,
 	experimentalWatchdogCfg kuma_cp.ExperimentalKDSEventBasedWatchdog,
+	extensions context.Context,
 ) (envoy_xds.Callbacks, error) {
 	kdsMetrics, err := NewMetrics(metrics)
 	if err != nil {
@@ -91,7 +102,8 @@ func newSyncTracker(
 		changedTypes[typ] = struct{}{}
 	}
 	return util_xds_v3.NewWatchdogCallbacks(func(ctx context.Context, node *envoy_core.Node, streamID int64) (util_watchdog.Watchdog, error) {
-		log := log.WithValues("streamID", streamID, "node", node)
+		log := log.WithValues("streamID", streamID, "nodeID", node.Id)
+		log = kuma_log.AddFieldsFromCtx(log, ctx, extensions)
 		if experimentalWatchdogCfg.Enabled {
 			return &EventBasedWatchdog{
 				Ctx:           ctx,
@@ -131,7 +143,7 @@ func newSyncTracker(
 			OnTick: func(context.Context) error {
 				start := core.Now()
 				log.V(1).Info("on tick")
-				err, changed := reconciler.Reconcile(ctx, node, changedTypes)
+				err, changed := reconciler.Reconcile(ctx, node, changedTypes, log)
 				if err != nil {
 					result := ResultNoChanges
 					if changed {

--- a/pkg/kds/v2/server/event_based_watchdog.go
+++ b/pkg/kds/v2/server/event_based_watchdog.go
@@ -73,7 +73,7 @@ func (e *EventBasedWatchdog) Start(stop <-chan struct{}) {
 			reason := strings.Join(util_maps.SortedKeys(reasons), "_and_")
 			e.Log.V(1).Info("reconcile", "changedTypes", changedTypes, "reason", reason)
 			start := core.Now()
-			err, changed := e.Reconciler.Reconcile(e.Ctx, e.Node, changedTypes)
+			err, changed := e.Reconciler.Reconcile(e.Ctx, e.Node, changedTypes, e.Log)
 			if err != nil {
 				e.Log.Error(err, "reconcile failed", "changedTypes", changedTypes, "reason", reason)
 				e.Metrics.KdsGenerationsErrors.Inc()

--- a/pkg/kds/v2/server/event_based_watchdog.go
+++ b/pkg/kds/v2/server/event_based_watchdog.go
@@ -74,7 +74,7 @@ func (e *EventBasedWatchdog) Start(stop <-chan struct{}) {
 			reason := strings.Join(util_maps.SortedKeys(reasons), "_and_")
 			e.Log.V(1).Info("reconcile", "changedTypes", changedTypes, "reason", reason)
 			start := core.Now()
-			err, changed := e.Reconciler.Reconcile(e.Ctx, e.Node, changedTypes, e.Log))
+			err, changed := e.Reconciler.Reconcile(e.Ctx, e.Node, changedTypes, e.Log)
 			if err != nil && !errors.Is(err, context.Canceled) {
 				e.Log.Error(err, "reconcile failed", "changedTypes", changedTypes, "reason", reason)
 				e.Metrics.KdsGenerationErrors.Inc()

--- a/pkg/kds/v2/server/event_based_watchdog_test.go
+++ b/pkg/kds/v2/server/event_based_watchdog_test.go
@@ -21,7 +21,7 @@ type staticReconciler struct {
 	changedResTypes chan map[core_model.ResourceType]struct{}
 }
 
-func (s staticReconciler) Reconcile(ctx context.Context, node *envoy_core.Node, m map[core_model.ResourceType]struct{}) (error, bool) {
+func (s staticReconciler) Reconcile(ctx context.Context, node *envoy_core.Node, m map[core_model.ResourceType]struct{}, logger logr.Logger) (error, bool) {
 	s.changedResTypes <- m
 	return nil, true
 }

--- a/pkg/kds/v2/store/sync.go
+++ b/pkg/kds/v2/store/sync.go
@@ -21,6 +21,7 @@ import (
 	"github.com/kumahq/kuma/pkg/core/user"
 	"github.com/kumahq/kuma/pkg/kds/util"
 	client_v2 "github.com/kumahq/kuma/pkg/kds/v2/client"
+	kuma_log "github.com/kumahq/kuma/pkg/log"
 	core_metrics "github.com/kumahq/kuma/pkg/metrics"
 	resources_k8s "github.com/kumahq/kuma/pkg/plugins/resources/k8s"
 	k8s_model "github.com/kumahq/kuma/pkg/plugins/resources/k8s/native/pkg/model"
@@ -72,12 +73,14 @@ type syncResourceStore struct {
 	log           logr.Logger
 	resourceStore store.ResourceStore
 	metric        prometheus.Histogram
+	extensions    context.Context
 }
 
 func NewResourceSyncer(
 	log logr.Logger,
 	resourceStore store.ResourceStore,
 	metrics core_metrics.Metrics,
+	extensions context.Context,
 ) (ResourceSyncer, error) {
 	metric := prometheus.NewHistogram(prometheus.HistogramOpts{
 		Name: "kds_resources_sync",
@@ -90,6 +93,7 @@ func NewResourceSyncer(
 		log:           log,
 		resourceStore: resourceStore,
 		metric:        metric,
+		extensions:    extensions,
 	}, nil
 }
 
@@ -101,6 +105,7 @@ func (s *syncResourceStore) Sync(syncCtx context.Context, upstreamResponse clien
 	opts := NewSyncOptions(fs...)
 	ctx := user.Ctx(syncCtx, user.ControlPlane)
 	log := s.log.WithValues("type", upstreamResponse.Type)
+	log = kuma_log.AddFieldsFromCtx(log, ctx, s.extensions)
 	upstream := upstreamResponse.AddedResources
 	downstream, err := registry.Global().NewList(upstreamResponse.Type)
 	if err != nil {

--- a/pkg/kds/v2/store/sync_test.go
+++ b/pkg/kds/v2/store/sync_test.go
@@ -49,7 +49,7 @@ var _ = Describe("SyncResourceStoreDelta", func() {
 		resourceStore = memory.NewStore()
 		metrics, err := core_metrics.NewMetrics("")
 		Expect(err).ToNot(HaveOccurred())
-		syncer, err = sync_store.NewResourceSyncer(core.Log, resourceStore, metrics)
+		syncer, err = sync_store.NewResourceSyncer(core.Log, resourceStore, metrics, context.Background())
 		Expect(err).ToNot(HaveOccurred())
 	})
 

--- a/pkg/kds/zone/components.go
+++ b/pkg/kds/zone/components.go
@@ -72,7 +72,7 @@ func Setup(rt core_runtime.Runtime) error {
 		return err
 	}
 	resourceSyncer := sync_store.NewResourceSyncer(kdsZoneLog, rt.ResourceStore())
-	resourceSyncerV2, err := kds_sync_store_v2.NewResourceSyncer(kdsDeltaZoneLog, rt.ResourceStore(), rt.Metrics())
+	resourceSyncerV2, err := kds_sync_store_v2.NewResourceSyncer(kdsDeltaZoneLog, rt.ResourceStore(), rt.Metrics(), rt.Extensions())
 	if err != nil {
 		return err
 	}

--- a/pkg/kds/zone/components_test.go
+++ b/pkg/kds/zone/components_test.go
@@ -267,7 +267,7 @@ var _ = Describe("Zone Sync", func() {
 			zoneStore = memory.NewStore()
 			metrics, err := core_metrics.NewMetrics("")
 			Expect(err).ToNot(HaveOccurred())
-			zoneSyncer, err = sync_store_v2.NewResourceSyncer(core.Log.WithName("kds-syncer"), zoneStore, metrics)
+			zoneSyncer, err = sync_store_v2.NewResourceSyncer(core.Log.WithName("kds-syncer"), zoneStore, metrics, context.Background())
 			Expect(err).ToNot(HaveOccurred())
 
 			wg.Add(1)

--- a/pkg/test/kds/setup/server.go
+++ b/pkg/test/kds/setup/server.go
@@ -1,6 +1,7 @@
 package setup
 
 import (
+	"context"
 	"time"
 
 	"github.com/emicklei/go-restful/v3"
@@ -54,6 +55,10 @@ func (t *testRuntimeContext) Tenants() multitenant.Tenants {
 
 func (t *testRuntimeContext) EventBus() events.EventBus {
 	return t.eventBus
+}
+
+func (t *testRuntimeContext) Extensions() context.Context {
+	return context.Background()
 }
 
 func (t *testRuntimeContext) APIWebServiceCustomize() func(*restful.WebService) error {


### PR DESCRIPTION
### Checklist prior to review

Adding missing tenant ID logging.
I really dislike piping through this Extensions object :( I need to think if this can be refactored to something more sane.

xref #7907

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [ ] [Link to relevant issue][1] as well as docs and UI issues --
- [ ] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [ ] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [ ] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [ ] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --
- [ ] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
