### PR TITLE
fix(kds): don't inc KdsGenerationErrors when context canceled

### DIFF
--- a/pkg/kds/v2/server/components.go
+++ b/pkg/kds/v2/server/components.go
@@ -143,7 +143,7 @@ func newSyncTracker(
 				return err
 			},
 			OnError: func(err error) {
-				kdsMetrics.KdsGenerationsErrors.Inc()
+				kdsMetrics.KdsGenerationErrors.Inc()
 				log.Error(err, "OnTick() failed")
 			},
 			OnStop: func() {

--- a/pkg/kds/v2/server/event_based_watchdog.go
+++ b/pkg/kds/v2/server/event_based_watchdog.go
@@ -76,7 +76,7 @@ func (e *EventBasedWatchdog) Start(stop <-chan struct{}) {
 			err, changed := e.Reconciler.Reconcile(e.Ctx, e.Node, changedTypes)
 			if err != nil {
 				e.Log.Error(err, "reconcile failed", "changedTypes", changedTypes, "reason", reason)
-				e.Metrics.KdsGenerationsErrors.Inc()
+				e.Metrics.KdsGenerationErrors.Inc()
 			} else {
 				result := ResultNoChanges
 				if changed {

--- a/pkg/kds/v2/server/event_based_watchdog.go
+++ b/pkg/kds/v2/server/event_based_watchdog.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"time"
 
@@ -74,7 +75,7 @@ func (e *EventBasedWatchdog) Start(stop <-chan struct{}) {
 			e.Log.V(1).Info("reconcile", "changedTypes", changedTypes, "reason", reason)
 			start := core.Now()
 			err, changed := e.Reconciler.Reconcile(e.Ctx, e.Node, changedTypes)
-			if err != nil {
+			if err != nil && !errors.Is(err, context.Canceled) {
 				e.Log.Error(err, "reconcile failed", "changedTypes", changedTypes, "reason", reason)
 				e.Metrics.KdsGenerationErrors.Inc()
 			} else {

--- a/pkg/kds/v2/server/metrics.go
+++ b/pkg/kds/v2/server/metrics.go
@@ -14,8 +14,8 @@ const (
 )
 
 type Metrics struct {
-	KdsGenerations       *prometheus.SummaryVec
-	KdsGenerationsErrors prometheus.Counter
+	KdsGenerations      *prometheus.SummaryVec
+	KdsGenerationErrors prometheus.Counter
 }
 
 func NewMetrics(metrics core_metrics.Metrics) (*Metrics, error) {
@@ -35,7 +35,7 @@ func NewMetrics(metrics core_metrics.Metrics) (*Metrics, error) {
 	}
 
 	return &Metrics{
-		KdsGenerations:       kdsGenerations,
-		KdsGenerationsErrors: kdsGenerationsErrors,
+		KdsGenerations:      kdsGenerations,
+		KdsGenerationErrors: kdsGenerationsErrors,
 	}, nil
 }


### PR DESCRIPTION
Note: as a consequence, the canceled reconcile run is no longer "represented" in the metrics. It's not fully clear to me whether this would lead to inconsistencies.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --
- [x] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
