### PR TITLE
feat(store): consistent gets for read replica

### DIFF
--- a/pkg/core/resources/manager/manager.go
+++ b/pkg/core/resources/manager/manager.go
@@ -130,7 +130,7 @@ var ErrSkipUpsert = errors.New("don't do upsert")
 func Upsert(ctx context.Context, manager ResourceManager, key model.ResourceKey, resource model.Resource, fn func(resource model.Resource) error, fs ...UpsertFunc) error {
 	upsert := func(ctx context.Context) error {
 		create := false
-		err := manager.Get(ctx, resource, store.GetBy(key))
+		err := manager.Get(ctx, resource, store.GetBy(key), store.GetConsistent())
 		if err != nil {
 			if store.IsResourceNotFound(err) {
 				create = true

--- a/pkg/core/resources/store/options.go
+++ b/pkg/core/resources/store/options.go
@@ -114,9 +114,10 @@ func NewDeleteAllOptions(fs ...DeleteAllOptionsFunc) *DeleteAllOptions {
 }
 
 type GetOptions struct {
-	Name    string
-	Mesh    string
-	Version string
+	Name       string
+	Mesh       string
+	Version    string
+	Consistent bool
 }
 
 type GetOptionsFunc func(*GetOptions)
@@ -143,6 +144,13 @@ func GetByKey(name, mesh string) GetOptionsFunc {
 func GetByVersion(version string) GetOptionsFunc {
 	return func(opts *GetOptions) {
 		opts.Version = version
+	}
+}
+
+// GetConsistent forces consistency if storage provides eventual consistency like read replica for Postgres.
+func GetConsistent() GetOptionsFunc {
+	return func(opts *GetOptions) {
+		opts.Consistent = true
 	}
 }
 

--- a/pkg/plugins/resources/postgres/pgx_store.go
+++ b/pkg/plugins/resources/postgres/pgx_store.go
@@ -166,7 +166,11 @@ func (r *pgxResourceStore) Get(ctx context.Context, resource core_model.Resource
 	opts := store.NewGetOptions(fs...)
 
 	statement := `SELECT spec, version, creation_time, modification_time FROM resources WHERE name=$1 AND mesh=$2 AND type=$3;`
-	row := r.pickRoPool().QueryRow(ctx, statement, opts.Name, opts.Mesh, resource.Descriptor().Name)
+	pool := r.pickRoPool()
+	if opts.Consistent {
+		pool = r.pool
+	}
+	row := pool.QueryRow(ctx, statement, opts.Name, opts.Mesh, resource.Descriptor().Name)
 
 	var spec string
 	var version int


### PR DESCRIPTION
### Checklist prior to review

So whenever we use read replica for postgres and execute Upsert, we reduce chance of read replica lag.

Fix https://github.com/kumahq/kuma/issues/7922

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [X] [Link to relevant issue][1] as well as docs and UI issues --
- [X] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [X] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [X] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [X] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --
- [X] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
