### PR TITLE
feat(insights): jitter zone insights upsert

### DIFF
--- a/docs/generated/kuma-cp.md
+++ b/docs/generated/kuma-cp.md
@@ -87,9 +87,11 @@ store:
   # Upsert (get and update) configuration
   upsert:
     # Base time for exponential backoff on upsert operations when retry is enabled
-    conflictRetryBaseBackoff: 100ms # ENV: KUMA_STORE_UPSERT_CONFLICT_RETRY_BASE_BACKOFF
+    conflictRetryBaseBackoff: 200ms # ENV: KUMA_STORE_UPSERT_CONFLICT_RETRY_BASE_BACKOFF
     # Max retries on upsert (get and update) operation when retry is enabled
-    conflictRetryMaxTimes: 5 # ENV: KUMA_STORE_UPSERT_CONFLICT_RETRY_MAX_TIMES
+    conflictRetryMaxTimes: 10 # ENV: KUMA_STORE_UPSERT_CONFLICT_RETRY_MAX_TIMES
+    # Percentage of jitter. For example: if backoff is 20s, and this value 10, the backoff will be between 18s and 22s.
+    conflictRetryJitterPercent: 30 # ENV: KUMA_STORE_UPSERT_CONFLICT_RETRY_JITTER_PERCENT
 
   # If true, skips validation of resource delete.
   # For example you don't have to delete all Dataplane objects before you delete a Mesh

--- a/docs/generated/raw/kuma-cp.yaml
+++ b/docs/generated/raw/kuma-cp.yaml
@@ -84,9 +84,11 @@ store:
   # Upsert (get and update) configuration
   upsert:
     # Base time for exponential backoff on upsert operations when retry is enabled
-    conflictRetryBaseBackoff: 100ms # ENV: KUMA_STORE_UPSERT_CONFLICT_RETRY_BASE_BACKOFF
+    conflictRetryBaseBackoff: 200ms # ENV: KUMA_STORE_UPSERT_CONFLICT_RETRY_BASE_BACKOFF
     # Max retries on upsert (get and update) operation when retry is enabled
-    conflictRetryMaxTimes: 5 # ENV: KUMA_STORE_UPSERT_CONFLICT_RETRY_MAX_TIMES
+    conflictRetryMaxTimes: 10 # ENV: KUMA_STORE_UPSERT_CONFLICT_RETRY_MAX_TIMES
+    # Percentage of jitter. For example: if backoff is 20s, and this value 10, the backoff will be between 18s and 22s.
+    conflictRetryJitterPercent: 30 # ENV: KUMA_STORE_UPSERT_CONFLICT_RETRY_JITTER_PERCENT
 
   # If true, skips validation of resource delete.
   # For example you don't have to delete all Dataplane objects before you delete a Mesh

--- a/pkg/config/app/kuma-cp/kuma-cp.defaults.yaml
+++ b/pkg/config/app/kuma-cp/kuma-cp.defaults.yaml
@@ -84,9 +84,11 @@ store:
   # Upsert (get and update) configuration
   upsert:
     # Base time for exponential backoff on upsert operations when retry is enabled
-    conflictRetryBaseBackoff: 100ms # ENV: KUMA_STORE_UPSERT_CONFLICT_RETRY_BASE_BACKOFF
+    conflictRetryBaseBackoff: 200ms # ENV: KUMA_STORE_UPSERT_CONFLICT_RETRY_BASE_BACKOFF
     # Max retries on upsert (get and update) operation when retry is enabled
-    conflictRetryMaxTimes: 5 # ENV: KUMA_STORE_UPSERT_CONFLICT_RETRY_MAX_TIMES
+    conflictRetryMaxTimes: 10 # ENV: KUMA_STORE_UPSERT_CONFLICT_RETRY_MAX_TIMES
+    # Percentage of jitter. For example: if backoff is 20s, and this value 10, the backoff will be between 18s and 22s.
+    conflictRetryJitterPercent: 30 # ENV: KUMA_STORE_UPSERT_CONFLICT_RETRY_JITTER_PERCENT
 
   # If true, skips validation of resource delete.
   # For example you don't have to delete all Dataplane objects before you delete a Mesh

--- a/pkg/config/core/resources/store/config.go
+++ b/pkg/config/core/resources/store/config.go
@@ -100,8 +100,9 @@ func DefaultCacheStoreConfig() CacheStoreConfig {
 
 func DefaultUpsertConfig() UpsertConfig {
 	return UpsertConfig{
-		ConflictRetryBaseBackoff: config_types.Duration{Duration: 100 * time.Millisecond},
-		ConflictRetryMaxTimes:    5,
+		ConflictRetryBaseBackoff:   config_types.Duration{Duration: 200 * time.Millisecond},
+		ConflictRetryMaxTimes:      10,
+		ConflictRetryJitterPercent: 30,
 	}
 }
 
@@ -110,6 +111,8 @@ type UpsertConfig struct {
 	ConflictRetryBaseBackoff config_types.Duration `json:"conflictRetryBaseBackoff" envconfig:"kuma_store_upsert_conflict_retry_base_backoff"`
 	// Max retries on upsert (get and update) operation when retry is enabled
 	ConflictRetryMaxTimes uint `json:"conflictRetryMaxTimes" envconfig:"kuma_store_upsert_conflict_retry_max_times"`
+	// Percentage of jitter. For example: if backoff is 20s, and this value 10, the backoff will be between 18s and 22s.
+	ConflictRetryJitterPercent uint `json:"conflictRetryJitterPercent" envconfig:"kuma_store_upsert_conflict_retry_jitter_percent"`
 }
 
 func (u *UpsertConfig) Sanitize() {

--- a/pkg/config/loader_test.go
+++ b/pkg/config/loader_test.go
@@ -114,7 +114,8 @@ var _ = Describe("Config loader", func() {
 			Expect(cfg.Store.Cache.ExpirationTime.Duration).To(Equal(3 * time.Second))
 
 			Expect(cfg.Store.Upsert.ConflictRetryBaseBackoff.Duration).To(Equal(4 * time.Second))
-			Expect(cfg.Store.Upsert.ConflictRetryMaxTimes).To(Equal(uint(10)))
+			Expect(cfg.Store.Upsert.ConflictRetryMaxTimes).To(Equal(uint(15)))
+			Expect(cfg.Store.Upsert.ConflictRetryJitterPercent).To(Equal(uint(10)))
 
 			Expect(cfg.Store.Postgres.TLS.Mode).To(Equal(postgres.VerifyFull))
 			Expect(cfg.Store.Postgres.TLS.CertPath).To(Equal("/path/to/cert"))
@@ -393,7 +394,8 @@ store:
     expirationTime: 3s
   upsert:
     conflictRetryBaseBackoff: 4s
-    conflictRetryMaxTimes: 10
+    conflictRetryMaxTimes: 15
+    conflictRetryJitterPercent: 10
 bootstrapServer:
   params:
     adminPort: 1234
@@ -732,7 +734,8 @@ eventBus:
 				"KUMA_STORE_CACHE_ENABLED":                                                                 "false",
 				"KUMA_STORE_CACHE_EXPIRATION_TIME":                                                         "3s",
 				"KUMA_STORE_UPSERT_CONFLICT_RETRY_BASE_BACKOFF":                                            "4s",
-				"KUMA_STORE_UPSERT_CONFLICT_RETRY_MAX_TIMES":                                               "10",
+				"KUMA_STORE_UPSERT_CONFLICT_RETRY_MAX_TIMES":                                               "15",
+				"KUMA_STORE_UPSERT_CONFLICT_RETRY_JITTER_PERCENT":                                          "10",
 				"KUMA_API_SERVER_READ_ONLY":                                                                "true",
 				"KUMA_API_SERVER_HTTP_PORT":                                                                "15681",
 				"KUMA_API_SERVER_HTTP_INTERFACE":                                                           "192.168.0.1",

--- a/pkg/core/resources/manager/manager.go
+++ b/pkg/core/resources/manager/manager.go
@@ -100,8 +100,9 @@ func (r *resourcesManager) Update(ctx context.Context, resource model.Resource, 
 }
 
 type ConflictRetry struct {
-	BaseBackoff time.Duration
-	MaxTimes    uint
+	BaseBackoff   time.Duration
+	MaxTimes      uint
+	JitterPercent uint
 }
 
 type UpsertOpts struct {
@@ -110,10 +111,11 @@ type UpsertOpts struct {
 
 type UpsertFunc func(opts *UpsertOpts)
 
-func WithConflictRetry(baseBackoff time.Duration, maxTimes uint) UpsertFunc {
+func WithConflictRetry(baseBackoff time.Duration, maxTimes uint, jitterPercent uint) UpsertFunc {
 	return func(opts *UpsertOpts) {
 		opts.ConflictRetry.BaseBackoff = baseBackoff
 		opts.ConflictRetry.MaxTimes = maxTimes
+		opts.ConflictRetry.JitterPercent = jitterPercent
 	}
 }
 
@@ -155,7 +157,9 @@ func Upsert(ctx context.Context, manager ResourceManager, key model.ResourceKey,
 	if opts.ConflictRetry.BaseBackoff <= 0 || opts.ConflictRetry.MaxTimes == 0 {
 		return upsert(ctx)
 	}
-	backoff := retry.WithMaxRetries(uint64(opts.ConflictRetry.MaxTimes), retry.NewExponential(opts.ConflictRetry.BaseBackoff))
+	backoff := retry.NewExponential(opts.ConflictRetry.BaseBackoff)
+	backoff = retry.WithMaxRetries(uint64(opts.ConflictRetry.MaxTimes), backoff)
+	backoff = retry.WithJitterPercent(uint64(opts.ConflictRetry.JitterPercent), backoff)
 	return retry.Do(ctx, backoff, func(ctx context.Context) error {
 		resource.SetMeta(nil)
 		specType := reflect.TypeOf(resource.GetSpec()).Elem()

--- a/pkg/kds/global/components.go
+++ b/pkg/kds/global/components.go
@@ -166,6 +166,7 @@ func Setup(rt runtime.Runtime) error {
 			rt.GetInstanceId(),
 			streamInterceptors,
 			rt.Extensions(),
+			rt.Config().Store.Upsert,
 		),
 		mux.NewKDSSyncServiceServer(
 			onGlobalToZoneSyncConnect,

--- a/pkg/kds/server/components.go
+++ b/pkg/kds/server/components.go
@@ -68,7 +68,7 @@ func DefaultStatusTracker(rt core_runtime.Runtime, log logr.Logger) StatusTracke
 				return time.NewTicker(rt.Config().Metrics.Zone.IdleTimeout.Duration / 2)
 			},
 			rt.Config().Multizone.Global.KDS.ZoneInsightFlushInterval.Duration/10,
-			NewZonesInsightStore(rt.ResourceManager()),
+			NewZonesInsightStore(rt.ResourceManager(), rt.Config().Store.Upsert),
 			l,
 		)
 	}, log)

--- a/pkg/kds/service/server.go
+++ b/pkg/kds/service/server.go
@@ -185,6 +185,7 @@ func (g *GlobalKDSServiceServer) storeStreamConnection(ctx context.Context, zone
 	// it might be the case that each Envoy Admin stream will land on separate instance.
 	// In this case, all instances will try to update Zone Insight which will result in conflicts.
 	// Since it's unusual to immediately execute envoy admin rpcs after zone is connected, 0-10s delay should be fine.
+	// #nosec G404 - math rand is enough
 	time.Sleep(time.Duration(rand.Int31n(10000)) * time.Millisecond)
 
 	zoneInsight := system.NewZoneInsightResource()

--- a/pkg/kds/v2/server/components.go
+++ b/pkg/kds/v2/server/components.go
@@ -79,7 +79,7 @@ func DefaultStatusTracker(rt core_runtime.Runtime, log logr.Logger) StatusTracke
 			return time.NewTicker(rt.Config().Multizone.Global.KDS.ZoneInsightFlushInterval.Duration)
 		}, func() *time.Ticker {
 			return time.NewTicker(rt.Config().Metrics.Zone.IdleTimeout.Duration / 2)
-		}, rt.Config().Multizone.Global.KDS.ZoneInsightFlushInterval.Duration/10, kds_server.NewZonesInsightStore(rt.ResourceManager()), l)
+		}, rt.Config().Multizone.Global.KDS.ZoneInsightFlushInterval.Duration/10, kds_server.NewZonesInsightStore(rt.ResourceManager(), rt.Config().Store.Upsert), l)
 	}, log)
 }
 


### PR DESCRIPTION
### Checklist prior to review

* Use upsert settings once again (it was used at some point and then dropped?). This way we can customize those values without releasing new version
* Add jitter for storing envoy streams
* Add jitter to upserts
* Change default values to 200ms, max 10 retries and 30% jitter.

Fix #https://github.com/kumahq/kuma/issues/7921

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [X] [Link to relevant issue][1] as well as docs and UI issues --
- [X] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [X] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [X] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [X] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --
- [X] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
