### PR TITLE
test(unit): fix flaky "should return error when admin address is not allowed" test

### DIFF
--- a/pkg/xds/generator/admin_proxy_generator.go
+++ b/pkg/xds/generator/admin_proxy_generator.go
@@ -5,9 +5,9 @@ import (
 
 	"github.com/asaskevich/govalidator"
 	"github.com/pkg/errors"
-	"golang.org/x/exp/maps"
 
 	core_xds "github.com/kumahq/kuma/pkg/core/xds"
+	util_maps "github.com/kumahq/kuma/pkg/util/maps"
 	xds_context "github.com/kumahq/kuma/pkg/xds/context"
 	envoy_common "github.com/kumahq/kuma/pkg/xds/envoy"
 	envoy_clusters "github.com/kumahq/kuma/pkg/xds/envoy/clusters"
@@ -60,7 +60,7 @@ func (g AdminProxyGenerator) Generate(ctx context.Context, xdsCtx xds_context.Co
 	envoyAdminClusterName := envoy_names.GetEnvoyAdminClusterName()
 	adminAddress := proxy.Metadata.GetAdminAddress()
 	if _, ok := adminAddressAllowedValues[adminAddress]; !ok {
-		return nil, errors.Errorf("envoy admin cluster is not allowed to have addresses other than %v", maps.Keys(adminAddressAllowedValues))
+		return nil, errors.Errorf("envoy admin cluster is not allowed to have addresses other than %v", util_maps.SortedKeys(adminAddressAllowedValues))
 	}
 	switch adminAddress {
 	case "", "0.0.0.0":

--- a/pkg/xds/generator/admin_proxy_generator_test.go
+++ b/pkg/xds/generator/admin_proxy_generator_test.go
@@ -135,6 +135,6 @@ var _ = Describe("AdminProxyGenerator", func() {
 		// when
 		_, err := generator.Generate(context.Background(), ctx, proxy)
 		Expect(err).To(HaveOccurred())
-		Expect(err.Error()).To(Equal(`envoy admin cluster is not allowed to have addresses other than [127.0.0.1 0.0.0.0 ::1 :: ]`))
+		Expect(err.Error()).To(Equal(`envoy admin cluster is not allowed to have addresses other than [ 0.0.0.0 127.0.0.1 :: ::1]`))
 	})
 })


### PR DESCRIPTION
Introduced a flaky test in https://github.com/kumahq/kuma/pull/7909, this is a fix

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [X] [Link to relevant issue][1] as well as docs and UI issues --
- [X] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [X] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [X] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [X] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --
- [X] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
