### PR TITLE
feat(kuma-cp): make OpenTelemetry control plane tracing fully configurable

### DIFF
--- a/pkg/config/loader_test.go
+++ b/pkg/config/loader_test.go
@@ -693,6 +693,10 @@ proxy:
     globalDownstreamMaxConnections: 1
 eventBus:
   bufferSize: 30
+tracing:
+  openTelemetry:
+    enabled: true
+    endpoint: collector:4317
 `,
 		}),
 		Entry("from env variables", testCase{
@@ -944,6 +948,7 @@ eventBus:
 				"KUMA_EXPERIMENTAL_KDS_EVENT_BASED_WATCHDOG_DELAY_FULL_RESYNC":                             "true",
 				"KUMA_PROXY_GATEWAY_GLOBAL_DOWNSTREAM_MAX_CONNECTIONS":                                     "1",
 				"KUMA_TRACING_OPENTELEMETRY_ENDPOINT":                                                      "otel-collector:4317",
+				"KUMA_TRACING_OPENTELEMETRY_ENABLED":                                                       "true",
 				"KUMA_EVENT_BUS_BUFFER_SIZE":                                                               "30",
 			},
 			yamlFileConfig: "",

--- a/pkg/config/tracing/config.go
+++ b/pkg/config/tracing/config.go
@@ -14,7 +14,8 @@ func (c Config) Validate() error {
 
 type OpenTelemetry struct {
 	Enabled bool `json:"enabled,omitempty" envconfig:"kuma_tracing_opentelemetry_enabled"`
-	// Deprecated: Use generic OTEL_EXPORTER_OTLP_ENDPOINT instead.
+	// This field is deprecated. Use generic OTEL_EXPORTER_OTLP_* variables
+	// instead.
 	// Address of OpenTelemetry collector.
 	// E.g. otel-collector:4317
 	Endpoint string `json:"endpoint,omitempty" envconfig:"kuma_tracing_opentelemetry_endpoint"`

--- a/pkg/config/tracing/config.go
+++ b/pkg/config/tracing/config.go
@@ -13,6 +13,8 @@ func (c Config) Validate() error {
 }
 
 type OpenTelemetry struct {
+	Enabled bool `json:"enabled,omitempty" envconfig:"kuma_tracing_opentelemetry_enabled"`
+	// DEPRECATED: Use generic OTEL_EXPORTER_OTLP_ENDPOINT instead.
 	// Address of OpenTelemetry collector.
 	// E.g. otel-collector:4317
 	Endpoint string `json:"endpoint,omitempty" envconfig:"kuma_tracing_opentelemetry_endpoint"`

--- a/pkg/config/tracing/config.go
+++ b/pkg/config/tracing/config.go
@@ -14,7 +14,7 @@ func (c Config) Validate() error {
 
 type OpenTelemetry struct {
 	Enabled bool `json:"enabled,omitempty" envconfig:"kuma_tracing_opentelemetry_enabled"`
-	// DEPRECATED: Use generic OTEL_EXPORTER_OTLP_ENDPOINT instead.
+	// Deprecated: Use generic OTEL_EXPORTER_OTLP_ENDPOINT instead.
 	// Address of OpenTelemetry collector.
 	// E.g. otel-collector:4317
 	Endpoint string `json:"endpoint,omitempty" envconfig:"kuma_tracing_opentelemetry_endpoint"`


### PR DESCRIPTION
Closes https://github.com/kumahq/kuma/issues/7161

The upstream library checks for `OTLP_EXPORTER_OTEL_*` variables.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --
- [x] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
