### PR TITLE
fix(kuma-cp): use default value when choiceCount is 0

### DIFF
--- a/pkg/core/resources/apis/mesh/traffic_route_validator.go
+++ b/pkg/core/resources/apis/mesh/traffic_route_validator.go
@@ -251,7 +251,11 @@ func (d *TrafficRouteResource) validateLb() validators.ValidationError {
 
 	switch lb.LbType.(type) {
 	case *mesh_proto.TrafficRoute_LoadBalancer_LeastRequest_:
-
+		lbConfig := lb.GetLeastRequest()
+		if lbConfig != nil && lbConfig.ChoiceCount == 1 {
+			root := validators.RootedAt("conf.loadBalancer.leastRequest.choiceCount")
+			err.AddViolationAt(root, "value must be greater than or equal to 2")
+		}
 	case *mesh_proto.TrafficRoute_LoadBalancer_RingHash_:
 		lbConfig := lb.GetRingHash()
 		switch lbConfig.HashFunction {

--- a/pkg/core/resources/apis/mesh/traffic_route_validator_test.go
+++ b/pkg/core/resources/apis/mesh/traffic_route_validator_test.go
@@ -645,6 +645,25 @@ var _ = Describe("TrafficRoute", func() {
                 - field: conf.http[0].modify.responseHeaders.remove[0].name
                   message: host header and HTTP/2 pseudo-headers are not allowed to be modified`,
 			}),
+			Entry("loadBalancer - not allowed choice count less than 2", testCase{
+				route: `
+                sources:
+                - match:
+                    kuma.io/service: web
+                destinations:
+                - match:
+                    kuma.io/service: backend
+                conf:
+                  loadBalancer:
+                    leastRequest:
+                      choiceCount: 1
+                  destination:
+                    kuma.io/service: backend`,
+				expected: `
+                violations:
+                - field: conf.loadBalancer.leastRequest.choiceCount
+                  message: value must be greater than or equal to 2`,
+			}),
 		)
 	})
 })

--- a/pkg/xds/envoy/clusters/v3/lb_configurer.go
+++ b/pkg/xds/envoy/clusters/v3/lb_configurer.go
@@ -10,6 +10,8 @@ import (
 	util_proto "github.com/kumahq/kuma/pkg/util/proto"
 )
 
+const DefaultChoiceCount = 2
+
 type LbConfigurer struct {
 	Lb *mesh_proto.TrafficRoute_LoadBalancer
 }
@@ -31,6 +33,11 @@ func (e *LbConfigurer) Configure(c *envoy_cluster.Cluster) error {
 		c.LbPolicy = envoy_cluster.Cluster_LEAST_REQUEST
 
 		lbConfig := e.Lb.GetLeastRequest()
+		if lbConfig == nil || lbConfig.GetChoiceCount() == 0 {
+			lbConfig = &mesh_proto.TrafficRoute_LoadBalancer_LeastRequest{
+				ChoiceCount: DefaultChoiceCount,
+			}
+		}
 		c.LbConfig = &envoy_cluster.Cluster_LeastRequestLbConfig_{
 			LeastRequestLbConfig: &envoy_cluster.Cluster_LeastRequestLbConfig{
 				ChoiceCount: util_proto.UInt32(lbConfig.ChoiceCount),

--- a/pkg/xds/envoy/clusters/v3/lb_configurer_test.go
+++ b/pkg/xds/envoy/clusters/v3/lb_configurer_test.go
@@ -69,6 +69,23 @@ var _ = Describe("Lb", func() {
             name: backend
             type: EDS`,
 		}),
+		Entry("least request with default", testCase{
+			clusterName: "backend",
+			lb: &mesh_proto.TrafficRoute_LoadBalancer{
+				LbType: &mesh_proto.TrafficRoute_LoadBalancer_LeastRequest_{},
+			},
+			expected: `
+            connectTimeout: 5s
+            edsClusterConfig:
+              edsConfig:
+                ads: {}
+                resourceApiVersion: V3
+            lbPolicy: LEAST_REQUEST
+            leastRequestLbConfig:
+              choiceCount: 2
+            name: backend
+            type: EDS`,
+		}),
 		Entry("ring hash", testCase{
 			clusterName: "backend",
 			lb: &mesh_proto.TrafficRoute_LoadBalancer{


### PR DESCRIPTION
### Checklist prior to review

Api says that when `choiceCount` is not defined we are using a default value of 2 which is correct from the envoy perspective but not from kuma API. 

`GetLeastRequest()` returns an object that has `choiceCount` equal 0, so when a user creates a policy without `choiceCount` it doesn't fail on the API but will fail on xds configuration generation because envoy requires a minimum value of 2.  
I've changed a bit how validation works now:
* validate object if the value is equal 1, that won't cause xds configuration to fail and break the sidecar
* when the value is equal to 0 we assume that it's an empty object and we set it to default 2


- [X] [Link to relevant issue][1] as well as docs and UI issues -- fix: https://github.com/kumahq/kuma/issues/7932
- [X] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [X] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [X] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [X] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --
- [X] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
