### PR TITLE
fix(kuma-cp): don't add `postStart` hook to builtin gateway even if `waitForDataplaneReady: true`

### DIFF
--- a/pkg/plugins/runtime/k8s/plugin_gateway.go
+++ b/pkg/plugins/runtime/k8s/plugin_gateway.go
@@ -64,7 +64,7 @@ func addGatewayReconcilers(mgr kube_ctrl.Manager, rt core_runtime.Runtime, conve
 	}
 
 	proxyFactory := containers.NewDataplaneProxyFactory(cpURL, caCert, rt.Config().GetEnvoyAdminPort(),
-		cfg.SidecarContainer.DataplaneContainer, cfg.BuiltinDNS, cfg.SidecarContainer.WaitForDataplaneReady)
+		cfg.SidecarContainer.DataplaneContainer, cfg.BuiltinDNS, false)
 
 	kubeConfig := mgr.GetConfig()
 

--- a/test/framework/envs/multizone/env.go
+++ b/test/framework/envs/multizone/env.go
@@ -53,6 +53,14 @@ func SetupAndGetState() []byte {
 		},
 		framework.KumaDeploymentOptionsFromConfig(framework.Config.KumaCpConfig.Multizone.KubeZone1)...,
 	)
+	if Config.IPV6 {
+		// if the underneath clusters support IPv6, we'll configure kuma-1 with waitForDataplaneReady feature and
+		// envoy admin binding to ::1 address
+		kubeZone1Options = append(kubeZone1Options,
+			WithEnv("KUMA_RUNTIME_KUBERNETES_INJECTOR_SIDECAR_CONTAINER_WAIT_FOR_DATAPLANE_READY", "true"),
+			WithEnv("KUMA_BOOTSTRAP_SERVER_PARAMS_ADMIN_ADDRESS", "::1"),
+		)
+	}
 	KubeZone1 = NewK8sCluster(NewTestingT(), Kuma1, Verbose)
 	go func() {
 		defer GinkgoRecover()


### PR DESCRIPTION
Changes:
* always pass `waitForDataplaneReady: false` when generating builtin gateway pod
* bind envoy admin to `::1` and set `waitForDataplaneReady: true` in e2e-multizone

Note: even though `postStart` hook should be completely harmless for builtin gateway for some reason it doesn't work. Builtin gateway pod spends 3m in `ContainerCreating` phase, restarts, and then works as expected. @lukidzi do you know why this can happen? 

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [X] [Link to relevant issue][1] as well as docs and UI issues --
- [X] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [X] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [X] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [X] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --
- [X] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
