### PR TITLE
chore(kuma-cp): fix check if OpenTelemetry is enabled

### DIFF
--- a/pkg/plugins/runtime/opentelemetry/plugin.go
+++ b/pkg/plugins/runtime/opentelemetry/plugin.go
@@ -57,7 +57,7 @@ func (t *tracer) NeedLeaderElection() bool {
 
 func (p *plugin) Customize(rt core_runtime.Runtime) error {
 	otel := rt.Config().Tracing.OpenTelemetry
-	if !otel.Enabled || otel.Endpoint == "" {
+	if !otel.Enabled && otel.Endpoint == "" {
 		return nil
 	}
 


### PR DESCRIPTION
The check only worked if both were set, which defeats the purpose.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --
- [x] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
