### PR TITLE
chore(kds): reduce zone insights conflicts

### DIFF
--- a/pkg/kds/server/status_sink.go
+++ b/pkg/kds/server/status_sink.go
@@ -73,7 +73,7 @@ func (s *zoneInsightSink) Start(ctx context.Context, stop <-chan struct{}) {
 		}
 
 		if err := s.store.Upsert(gracefulCtx, zone, currentState); err != nil {
-			if store.IsResourceConflict(err) {
+			if store.IsResourceConflict(err) || store.IsResourceAlreadyExists(err) {
 				s.log.V(1).Info("failed to flush ZoneInsight because it was updated in other place. Will retry in the next tick", "zone", zone)
 			} else {
 				s.log.Error(err, "failed to flush zone status", "zone", zone)
@@ -118,5 +118,5 @@ func (s *zoneInsightStore) Upsert(ctx context.Context, zone string, subscription
 	zoneInsight := system.NewZoneInsightResource()
 	return manager.Upsert(ctx, s.resManager, key, zoneInsight, func(resource core_model.Resource) error {
 		return zoneInsight.Spec.UpdateSubscription(subscription)
-	}, manager.WithConflictRetry(s.upsertCfg.ConflictRetryBaseBackoff.Duration, s.upsertCfg.ConflictRetryMaxTimes, s.upsertCfg.ConflictRetryJitterPercent)) // we need retry because Envoy Admin RPC may also update the insight.
+	})
 }

--- a/pkg/kds/service/server.go
+++ b/pkg/kds/service/server.go
@@ -136,14 +136,6 @@ func (g *GlobalKDSServiceServer) streamEnvoyAdminRPC(
 		return status.Error(codes.Internal, "could not store stream connection")
 	}
 	logger.Info("stored stream connection")
-	defer func() {
-		rpc.ClientDisconnected(clientID)
-		// stream.Context() is cancelled here, we need to use another ctx
-		ctx := multitenant.CopyIntoCtx(stream.Context(), context.Background())
-		if err := g.storeStreamConnection(ctx, zone, rpcName, ""); err != nil {
-			logger.Error(err, "could not clear stream connection information in ZoneInsight")
-		}
-	}()
 	for {
 		resp, err := recv()
 		if err == io.EOF {


### PR DESCRIPTION
### Checklist prior to review

* Storing empty admin operations stream is really not that useful, we won't be able to execute envoy admin operation anyways.
* Remove conflict retry from kds status sink at the cost of potentially longer time to see the zone online

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [ ] [Link to relevant issue][1] as well as docs and UI issues --
- [ ] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [ ] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [ ] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [ ] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --
- [ ] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
