### PR TITLE
fix(kuma-cp): meta validation compatible with Kubernetes naming rules

### DIFF
--- a/app/kuma-dp/cmd/dataplane.go
+++ b/app/kuma-dp/cmd/dataplane.go
@@ -46,7 +46,7 @@ func readResource(cmd *cobra.Command, r *kuma_dp.DataplaneRuntime) (model.Resour
 		return nil, err
 	}
 
-	if err := core_mesh.ValidateMeta(res.GetMeta().GetName(), res.GetMeta().GetMesh(), res.Descriptor().Scope); err.HasViolations() {
+	if err := core_mesh.ValidateMetaBackwardsCompatible(res.GetMeta(), res.Descriptor().Scope); err.HasViolations() {
 		return nil, &err
 	}
 

--- a/app/kumactl/cmd/apply/apply.go
+++ b/app/kumactl/cmd/apply/apply.go
@@ -116,7 +116,7 @@ $ kumactl apply -f https://example.com/resource.yaml
 				if err != nil {
 					return errors.Wrap(err, "YAML contains invalid resource")
 				}
-				if err := mesh.ValidateMeta(res.GetMeta().GetName(), res.GetMeta().GetMesh(), res.Descriptor().Scope); err.HasViolations() {
+				if err := mesh.ValidateMetaBackwardsCompatible(res.GetMeta(), res.Descriptor().Scope); err.HasViolations() {
 					return err.OrNil()
 				}
 				resources = append(resources, res)

--- a/pkg/api-server/resource_endpoints.go
+++ b/pkg/api-server/resource_endpoints.go
@@ -166,18 +166,21 @@ func (r *resourceEndpoints) createOrUpdateResource(request *restful.Request, res
 		return
 	}
 
-	if err := r.validateResourceRequest(request, resourceRest.GetMeta()); err != nil {
+	create := false
+	resource := r.descriptor.NewObject()
+	if err := r.resManager.Get(request.Request.Context(), resource, store.GetByKey(name, meshName)); err != nil && store.IsResourceNotFound(err) {
+		create = true
+	} else if err != nil {
+		rest_errors.HandleError(request.Request.Context(), response, err, "Could not find a resource")
+	}
+
+	if err := r.validateResourceRequest(request, resourceRest.GetMeta(), create); err != nil {
 		rest_errors.HandleError(request.Request.Context(), response, err, "Could not process a resource")
 		return
 	}
 
-	resource := r.descriptor.NewObject()
-	if err := r.resManager.Get(request.Request.Context(), resource, store.GetByKey(name, meshName)); err != nil {
-		if store.IsResourceNotFound(err) {
-			r.createResource(request.Request.Context(), name, meshName, resourceRest.GetSpec(), response)
-		} else {
-			rest_errors.HandleError(request.Request.Context(), response, err, "Could not find a resource")
-		}
+	if create {
+		r.createResource(request.Request.Context(), name, meshName, resourceRest.GetSpec(), response)
 	} else {
 		r.updateResource(request.Request.Context(), resource, resourceRest.GetSpec(), response)
 	}
@@ -272,7 +275,7 @@ func (r *resourceEndpoints) deleteResource(request *restful.Request, response *r
 	}
 }
 
-func (r *resourceEndpoints) validateResourceRequest(request *restful.Request, resourceMeta rest_v1alpha1.ResourceMeta) error {
+func (r *resourceEndpoints) validateResourceRequest(request *restful.Request, resourceMeta rest_v1alpha1.ResourceMeta, create bool) error {
 	var err validators.ValidationError
 	name := request.PathParameter("name")
 	meshName := r.meshFromRequest(request)
@@ -288,7 +291,11 @@ func (r *resourceEndpoints) validateResourceRequest(request *restful.Request, re
 	if r.descriptor.Scope == model.ScopeMesh && meshName != resourceMeta.Mesh {
 		err.AddViolation("mesh", "mesh from the URL has to be the same as in body")
 	}
-	err.AddError("", mesh.ValidateMeta(name, meshName, r.descriptor.Scope))
+	if create {
+		err.AddError("", mesh.ValidateMeta(resourceMeta, r.descriptor.Scope))
+	} else {
+		err.AddError("", mesh.ValidateMetaBackwardsCompatible(resourceMeta, r.descriptor.Scope))
+	}
 	return err.OrNil()
 }
 

--- a/pkg/core/resources/apis/mesh/meta_validator.go
+++ b/pkg/core/resources/apis/mesh/meta_validator.go
@@ -8,12 +8,12 @@ import (
 )
 
 var (
-	backwardCompatRegexp = regexp.MustCompile("^[0-9a-z-_.]*$")
+	backwardCompatRegexp = regexp.MustCompile(`^[0-9a-z-_.]*$`)
 	backwardCompatErrMsg = "invalid characters. Valid characters are numbers, lowercase latin letters and '-', '_', '.' symbols."
 )
 
 var (
-	identifierRegexp = regexp.MustCompile("^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$")
+	identifierRegexp = regexp.MustCompile(`^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$`)
 	identifierErrMsg = "invalid characters. A lowercase RFC 1123 subdomain must consist of lower case alphanumeric " +
 		"characters, '-' or '.', and must start and end with an alphanumeric character"
 )

--- a/pkg/core/resources/apis/mesh/meta_validator.go
+++ b/pkg/core/resources/apis/mesh/meta_validator.go
@@ -3,33 +3,56 @@ package mesh
 import (
 	"regexp"
 
-	"github.com/kumahq/kuma/pkg/core/resources/model"
+	core_model "github.com/kumahq/kuma/pkg/core/resources/model"
 	"github.com/kumahq/kuma/pkg/core/validators"
 )
 
-var nameMeshRegexp = regexp.MustCompile("^[0-9a-z-_]*$")
+var (
+	backwardCompatRegexp = regexp.MustCompile("^[0-9a-z-_.]*$")
+	backwardCompatErrMsg = "invalid characters. Valid characters are numbers, lowercase latin letters and '-', '_', '.' symbols."
+)
 
-func ValidateMeta(name, mesh string, scope model.ResourceScope) validators.ValidationError {
+var (
+	identifierRegexp = regexp.MustCompile("^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$")
+	identifierErrMsg = "invalid characters. A lowercase RFC 1123 subdomain must consist of lower case alphanumeric " +
+		"characters, '-' or '.', and must start and end with an alphanumeric character"
+)
+
+func ValidateMeta(m core_model.ResourceMeta, scope core_model.ResourceScope) validators.ValidationError {
 	var err validators.ValidationError
-	if name == "" {
-		err.AddViolation("name", "cannot be empty")
-	}
-	if !nameMeshRegexp.MatchString(name) {
-		err.AddViolation("name", "invalid characters. Valid characters are numbers, lowercase latin letters and '-', '_' symbols.")
-	}
-	err.Add(ValidateMesh(mesh, scope))
+	err.AddError("name", validateIdentifier(m.GetName(), identifierRegexp, identifierErrMsg))
+	err.Add(ValidateMesh(m.GetMesh(), scope))
 	return err
 }
 
-func ValidateMesh(mesh string, scope model.ResourceScope) validators.ValidationError {
+// ValidateMetaBackwardsCompatible allows 'name' and 'mesh' to contain '_'. Should be called when updating existing
+// resources or on the clients (like 'kumactl' or 'kuma-dp') when it's not clear if it's create or update operation.
+//
+// We're going to remove this function in Kuma 2.7.x
+func ValidateMetaBackwardsCompatible(m core_model.ResourceMeta, scope core_model.ResourceScope) validators.ValidationError {
 	var err validators.ValidationError
-	if scope == model.ScopeMesh {
-		if mesh == "" {
-			err.AddViolation("mesh", "cannot be empty")
-		}
-		if !nameMeshRegexp.MatchString(mesh) {
-			err.AddViolation("mesh", "invalid characters. Valid characters are numbers, lowercase latin letters and '-', '_' symbols.")
-		}
+	err.AddError("name", validateIdentifier(m.GetName(), backwardCompatRegexp, backwardCompatErrMsg))
+	err.Add(ValidateMesh(m.GetMesh(), scope))
+	return err
+}
+
+// ValidateMesh checks that resource's mesh matches the old regex (with '_'). Even if user creates entirely new resource,
+// we can't check resource's mesh against the new regex, because Mesh resource itself can be old and contain '_' in its name.
+// All new Mesh resources will have their name validated against new regex.
+func ValidateMesh(mesh string, scope core_model.ResourceScope) validators.ValidationError {
+	var err validators.ValidationError
+	if scope == core_model.ScopeMesh {
+		err.AddError("mesh", validateIdentifier(mesh, backwardCompatRegexp, backwardCompatErrMsg))
+	}
+	return err
+}
+
+func validateIdentifier(identifier string, r *regexp.Regexp, errMsg string) validators.ValidationError {
+	var err validators.ValidationError
+	if identifier == "" {
+		err.AddViolation("", "cannot be empty")
+	} else if !r.MatchString(identifier) {
+		err.AddViolation("", errMsg)
 	}
 	return err
 }

--- a/pkg/core/resources/apis/mesh/meta_validator_test.go
+++ b/pkg/core/resources/apis/mesh/meta_validator_test.go
@@ -1,0 +1,146 @@
+package mesh_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"sigs.k8s.io/yaml"
+
+	"github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
+	core_model "github.com/kumahq/kuma/pkg/core/resources/model"
+	test_model "github.com/kumahq/kuma/pkg/test/resources/model"
+)
+
+var _ = Describe("Meta", func() {
+	type testCase struct {
+		meta     core_model.ResourceMeta
+		scope    core_model.ResourceScope
+		expected string
+	}
+
+	Describe("ValidateMeta", func() {
+
+		DescribeTable("should pass validation",
+			func(given testCase) {
+				Expect(mesh.ValidateMeta(given.meta, given.scope).Violations).To(BeEmpty())
+			},
+			Entry("mesh-scoped valid name and mesh", testCase{
+				meta:  &test_model.ResourceMeta{Mesh: "mesh-1", Name: "name-1"},
+				scope: core_model.ScopeMesh,
+			}),
+			Entry("global-scoped valid name", testCase{
+				meta:  &test_model.ResourceMeta{Mesh: "", Name: "name-1"},
+				scope: core_model.ScopeGlobal,
+			}),
+			Entry("global-scoped valid name with dot", testCase{
+				meta:  &test_model.ResourceMeta{Mesh: "", Name: "default.name-1"},
+				scope: core_model.ScopeGlobal,
+			}),
+			Entry("mesh-scoped ", testCase{
+				meta:  &test_model.ResourceMeta{Mesh: "", Name: "default.name-1"},
+				scope: core_model.ScopeGlobal,
+			}),
+		)
+
+		DescribeTable("should validate fields",
+			func(given testCase) {
+
+				verr := mesh.ValidateMeta(given.meta, given.scope)
+				// and
+				actual, err := yaml.Marshal(verr)
+
+				// then
+				Expect(err).ToNot(HaveOccurred())
+				// and
+				Expect(actual).To(MatchYAML(given.expected))
+			},
+			Entry("empty name", testCase{
+				meta:  &test_model.ResourceMeta{Mesh: "mesh-1", Name: ""},
+				scope: core_model.ScopeMesh,
+				expected: `
+violations:
+ - field: name
+   message: cannot be empty`,
+			}),
+			Entry("empty mesh", testCase{
+				meta:  &test_model.ResourceMeta{Mesh: "", Name: "name-1"},
+				scope: core_model.ScopeMesh,
+				expected: `
+violations:
+ - field: mesh
+   message: cannot be empty`,
+			}),
+			Entry("name with 2 dot", testCase{
+				meta:  &test_model.ResourceMeta{Mesh: "mesh-1", Name: "two..dots"},
+				scope: core_model.ScopeMesh,
+				expected: `
+violations:
+ - field: name
+   message: invalid characters. A lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character`,
+			}),
+			Entry("name with underscore", testCase{
+				meta:  &test_model.ResourceMeta{Mesh: "mesh-1", Name: "under_score"},
+				scope: core_model.ScopeMesh,
+				expected: `
+violations:
+ - field: name
+   message: invalid characters. A lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character`,
+			}),
+		)
+	})
+
+	Describe("ValidateMetaBackwardsCompatible", func() {
+
+		DescribeTable("should pass validation",
+			func(given testCase) {
+				Expect(mesh.ValidateMetaBackwardsCompatible(given.meta, given.scope).Violations).To(BeEmpty())
+			},
+			Entry("mesh-scoped valid name and mesh", testCase{
+				meta:  &test_model.ResourceMeta{Mesh: "mesh-1", Name: "name-1"},
+				scope: core_model.ScopeMesh,
+			}),
+			Entry("global-scoped valid name", testCase{
+				meta:  &test_model.ResourceMeta{Mesh: "", Name: "name-1"},
+				scope: core_model.ScopeGlobal,
+			}),
+			Entry("global-scoped valid name with dot", testCase{
+				meta:  &test_model.ResourceMeta{Mesh: "", Name: "default.name-1"},
+				scope: core_model.ScopeGlobal,
+			}),
+			Entry("name with underscore", testCase{
+				meta:  &test_model.ResourceMeta{Mesh: "mesh-1", Name: "name-1_2"},
+				scope: core_model.ScopeMesh,
+			}),
+		)
+
+		DescribeTable("should validate fields",
+			func(given testCase) {
+
+				verr := mesh.ValidateMetaBackwardsCompatible(given.meta, given.scope)
+				// and
+				actual, err := yaml.Marshal(verr)
+
+				// then
+				Expect(err).ToNot(HaveOccurred())
+				// and
+				Expect(actual).To(MatchYAML(given.expected))
+			},
+			Entry("empty name", testCase{
+				meta:  &test_model.ResourceMeta{Mesh: "mesh-1", Name: ""},
+				scope: core_model.ScopeMesh,
+				expected: `
+violations:
+ - field: name
+   message: cannot be empty`,
+			}),
+			Entry("empty mesh", testCase{
+				meta:  &test_model.ResourceMeta{Mesh: "", Name: "name-1"},
+				scope: core_model.ScopeMesh,
+				expected: `
+violations:
+ - field: mesh
+   message: cannot be empty`,
+			}),
+		)
+	})
+
+})

--- a/pkg/core/resources/apis/mesh/meta_validator_test.go
+++ b/pkg/core/resources/apis/mesh/meta_validator_test.go
@@ -18,7 +18,6 @@ var _ = Describe("Meta", func() {
 	}
 
 	Describe("ValidateMeta", func() {
-
 		DescribeTable("should pass validation",
 			func(given testCase) {
 				Expect(mesh.ValidateMeta(given.meta, given.scope).Violations).To(BeEmpty())
@@ -43,7 +42,6 @@ var _ = Describe("Meta", func() {
 
 		DescribeTable("should validate fields",
 			func(given testCase) {
-
 				verr := mesh.ValidateMeta(given.meta, given.scope)
 				// and
 				actual, err := yaml.Marshal(verr)
@@ -89,7 +87,6 @@ violations:
 	})
 
 	Describe("ValidateMetaBackwardsCompatible", func() {
-
 		DescribeTable("should pass validation",
 			func(given testCase) {
 				Expect(mesh.ValidateMetaBackwardsCompatible(given.meta, given.scope).Violations).To(BeEmpty())
@@ -114,7 +111,6 @@ violations:
 
 		DescribeTable("should validate fields",
 			func(given testCase) {
-
 				verr := mesh.ValidateMetaBackwardsCompatible(given.meta, given.scope)
 				// and
 				actual, err := yaml.Marshal(verr)
@@ -142,5 +138,4 @@ violations:
 			}),
 		)
 	})
-
 })


### PR DESCRIPTION
### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [ ] [Link to relevant issue][1] as well as docs and UI issues --
- [ ] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [ ] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [ ] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [ ] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --
- [ ] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
