### PR TITLE
perf(store): postgres transactions

### DIFF
--- a/pkg/core/bootstrap/bootstrap.go
+++ b/pkg/core/bootstrap/bootstrap.go
@@ -277,11 +277,12 @@ func initializeResourceStore(cfg kuma_cp.Config, builder *core_runtime.Builder) 
 		return errors.Wrapf(err, "could not retrieve store %s plugin", pluginName)
 	}
 
-	rs, err := plugin.NewResourceStore(builder, pluginConfig)
+	rs, transactions, err := plugin.NewResourceStore(builder, pluginConfig)
 	if err != nil {
 		return err
 	}
 	builder.WithResourceStore(core_store.NewCustomizableResourceStore(rs))
+	builder.WithTransactions(transactions)
 	eventBus, err := events.NewEventBus(cfg.EventBus.BufferSize, builder.Metrics())
 	if err != nil {
 		return err

--- a/pkg/core/plugins/interfaces.go
+++ b/pkg/core/plugins/interfaces.go
@@ -47,7 +47,7 @@ type (
 	DbVersion           = uint
 	ResourceStorePlugin interface {
 		Plugin
-		NewResourceStore(PluginContext, PluginConfig) (core_store.ResourceStore, error)
+		NewResourceStore(PluginContext, PluginConfig) (core_store.ResourceStore, core_store.Transactions, error)
 		Migrate(PluginContext, PluginConfig) (DbVersion, error)
 		EventListener(PluginContext, events.Emitter) error
 	}

--- a/pkg/core/resources/manager/manager.go
+++ b/pkg/core/resources/manager/manager.go
@@ -107,6 +107,7 @@ type ConflictRetry struct {
 
 type UpsertOpts struct {
 	ConflictRetry ConflictRetry
+	Transactions  store.Transactions
 }
 
 type UpsertFunc func(opts *UpsertOpts)
@@ -119,8 +120,16 @@ func WithConflictRetry(baseBackoff time.Duration, maxTimes uint, jitterPercent u
 	}
 }
 
+func WithTransactions(transactions store.Transactions) UpsertFunc {
+	return func(opts *UpsertOpts) {
+		opts.Transactions = transactions
+	}
+}
+
 func NewUpsertOpts(fs ...UpsertFunc) UpsertOpts {
-	opts := UpsertOpts{}
+	opts := UpsertOpts{
+		Transactions: store.NoTransactions{},
+	}
 	for _, f := range fs {
 		f(&opts)
 	}
@@ -130,30 +139,32 @@ func NewUpsertOpts(fs ...UpsertFunc) UpsertOpts {
 var ErrSkipUpsert = errors.New("don't do upsert")
 
 func Upsert(ctx context.Context, manager ResourceManager, key model.ResourceKey, resource model.Resource, fn func(resource model.Resource) error, fs ...UpsertFunc) error {
+	opts := NewUpsertOpts(fs...)
 	upsert := func(ctx context.Context) error {
-		create := false
-		err := manager.Get(ctx, resource, store.GetBy(key), store.GetConsistent())
-		if err != nil {
-			if store.IsResourceNotFound(err) {
-				create = true
-			} else {
+		return store.InTx(ctx, opts.Transactions, func(ctx context.Context) error {
+			create := false
+			err := manager.Get(ctx, resource, store.GetBy(key), store.GetConsistent())
+			if err != nil {
+				if store.IsResourceNotFound(err) {
+					create = true
+				} else {
+					return err
+				}
+			}
+			if err := fn(resource); err != nil {
+				if err == ErrSkipUpsert { // Way to skip inserts when there are no change
+					return nil
+				}
 				return err
 			}
-		}
-		if err := fn(resource); err != nil {
-			if err == ErrSkipUpsert { // Way to skip inserts when there are no change
-				return nil
+			if create {
+				return manager.Create(ctx, resource, store.CreateBy(key))
+			} else {
+				return manager.Update(ctx, resource)
 			}
-			return err
-		}
-		if create {
-			return manager.Create(ctx, resource, store.CreateBy(key))
-		} else {
-			return manager.Update(ctx, resource)
-		}
+		})
 	}
 
-	opts := NewUpsertOpts(fs...)
 	if opts.ConflictRetry.BaseBackoff <= 0 || opts.ConflictRetry.MaxTimes == 0 {
 		return upsert(ctx)
 	}

--- a/pkg/core/resources/store/transactions.go
+++ b/pkg/core/resources/store/transactions.go
@@ -1,0 +1,73 @@
+package store
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+	"go.uber.org/multierr"
+)
+
+type txCtx struct{}
+
+func CtxWithTx(ctx context.Context, tx Transaction) context.Context {
+	return context.WithValue(ctx, txCtx{}, tx)
+}
+
+func TxFromCtx(ctx context.Context) (Transaction, bool) {
+	if value, ok := ctx.Value(txCtx{}).(Transaction); ok {
+		return value, true
+	}
+	return nil, false
+}
+
+type Transaction interface {
+	Commit(ctx context.Context) error
+	Rollback(ctx context.Context) error
+}
+
+// Transactions is a producer of transactions if a resource store support transactions.
+// Transactions are never required for consistency in Kuma, because there are ResourceStores that does not support transactions.
+// However, in a couple of cases executing queries in transaction can improve the performance.
+//
+// In case of Postgres, you may set hooks when retrieve and release connections for the connection pool.
+// In this case, if you create multiple resources, you need to acquire connection and execute hooks for each create.
+// If you create transaction for it, you execute hooks once and you hold the connection.
+//
+// Transaction is propagated implicitly through Context.
+type Transactions interface {
+	Begin(ctx context.Context) (Transaction, error)
+}
+
+func InTx(ctx context.Context, transactions Transactions, fn func(ctx context.Context) error) error {
+	tx, err := transactions.Begin(ctx)
+	if err != nil {
+		return err
+	}
+	if err := fn(CtxWithTx(ctx, tx)); err != nil {
+		if rollbackErr := tx.Rollback(ctx); rollbackErr != nil {
+			return multierr.Append(errors.Wrap(rollbackErr, "could not rollback transaction"), err)
+		}
+		return err
+	}
+	return tx.Commit(ctx)
+}
+
+type NoopTransaction struct{}
+
+func (n NoopTransaction) Commit(context.Context) error {
+	return nil
+}
+
+func (n NoopTransaction) Rollback(context.Context) error {
+	return nil
+}
+
+var _ Transaction = &NoopTransaction{}
+
+type NoTransactions struct{}
+
+func (n NoTransactions) Begin(context.Context) (Transaction, error) {
+	return NoopTransaction{}, nil
+}
+
+var _ Transactions = &NoTransactions{}

--- a/pkg/core/runtime/builder.go
+++ b/pkg/core/runtime/builder.go
@@ -40,6 +40,7 @@ import (
 type BuilderContext interface {
 	ComponentManager() component.Manager
 	ResourceStore() core_store.CustomizableResourceStore
+	Transactions() core_store.Transactions
 	SecretStore() store.SecretStore
 	ConfigStore() core_store.ResourceStore
 	ResourceManager() core_manager.CustomizableResourceManager
@@ -73,6 +74,7 @@ type Builder struct {
 	rs             core_store.CustomizableResourceStore
 	ss             store.SecretStore
 	cs             core_store.ResourceStore
+	txs            core_store.Transactions
 	rm             core_manager.CustomizableResourceManager
 	rom            core_manager.ReadOnlyResourceManager
 	gis            globalinsight.GlobalInsightService
@@ -129,6 +131,11 @@ func (b *Builder) WithComponentManager(cm component.Manager) *Builder {
 
 func (b *Builder) WithResourceStore(rs core_store.CustomizableResourceStore) *Builder {
 	b.rs = rs
+	return b
+}
+
+func (b *Builder) WithTransactions(txs core_store.Transactions) *Builder {
+	b.txs = txs
 	return b
 }
 
@@ -294,6 +301,9 @@ func (b *Builder) Build() (Runtime, error) {
 	if b.rs == nil {
 		return nil, errors.Errorf("ResourceStore has not been configured")
 	}
+	if b.txs == nil {
+		return nil, errors.Errorf("Transactions has not been configured")
+	}
 	if b.rm == nil {
 		return nil, errors.Errorf("ResourceManager has not been configured")
 	}
@@ -367,6 +377,7 @@ func (b *Builder) Build() (Runtime, error) {
 			rm:                       b.rm,
 			rom:                      b.rom,
 			rs:                       b.rs,
+			txs:                      b.txs,
 			ss:                       b.ss,
 			cam:                      b.cam,
 			gis:                      b.gis,
@@ -405,6 +416,10 @@ func (b *Builder) ComponentManager() component.Manager {
 
 func (b *Builder) ResourceStore() core_store.CustomizableResourceStore {
 	return b.rs
+}
+
+func (b *Builder) Transactions() core_store.Transactions {
+	return b.txs
 }
 
 func (b *Builder) SecretStore() store.SecretStore {

--- a/pkg/core/runtime/runtime.go
+++ b/pkg/core/runtime/runtime.go
@@ -58,6 +58,7 @@ type RuntimeContext interface {
 	DataSourceLoader() datasource.Loader
 	ResourceManager() core_manager.ResourceManager
 	ResourceStore() core_store.ResourceStore
+	Transactions() core_store.Transactions
 	ReadOnlyResourceManager() core_manager.ReadOnlyResourceManager
 	SecretStore() store.SecretStore
 	ConfigStore() core_store.ResourceStore
@@ -147,6 +148,7 @@ type runtimeContext struct {
 	cfg                      kuma_cp.Config
 	rm                       core_manager.ResourceManager
 	rs                       core_store.ResourceStore
+	txs                      core_store.Transactions
 	ss                       store.SecretStore
 	cs                       core_store.ResourceStore
 	gis                      globalinsight.GlobalInsightService
@@ -204,6 +206,10 @@ func (rc *runtimeContext) ResourceManager() core_manager.ResourceManager {
 
 func (rc *runtimeContext) ResourceStore() core_store.ResourceStore {
 	return rc.rs
+}
+
+func (rc *runtimeContext) Transactions() core_store.Transactions {
+	return rc.txs
 }
 
 func (rc *runtimeContext) SecretStore() store.SecretStore {

--- a/pkg/kds/global/components.go
+++ b/pkg/kds/global/components.go
@@ -80,7 +80,7 @@ func Setup(rt runtime.Runtime) error {
 	}
 
 	resourceSyncer := sync_store.NewResourceSyncer(kdsGlobalLog, rt.ResourceStore())
-	resourceSyncerV2, err := kds_sync_store_v2.NewResourceSyncer(kdsDeltaGlobalLog, rt.ResourceStore(), rt.Metrics(), rt.Extensions())
+	resourceSyncerV2, err := kds_sync_store_v2.NewResourceSyncer(kdsDeltaGlobalLog, rt.ResourceStore(), rt.Transactions(), rt.Metrics(), rt.Extensions())
 	if err != nil {
 		return err
 	}

--- a/pkg/kds/global/components_test.go
+++ b/pkg/kds/global/components_test.go
@@ -250,7 +250,7 @@ var _ = Describe("Global Sync", func() {
 			globalStore = memory.NewStore()
 			metrics, err := core_metrics.NewMetrics("")
 			Expect(err).ToNot(HaveOccurred())
-			globalSyncer, err = sync_store_v2.NewResourceSyncer(core.Log, globalStore, metrics, context.Background())
+			globalSyncer, err = sync_store_v2.NewResourceSyncer(core.Log, globalStore, store.NoTransactions{}, metrics, context.Background())
 			Expect(err).ToNot(HaveOccurred())
 			stopCh := make(chan struct{})
 			clientStreams := []*grpc.MockDeltaClientStream{}

--- a/pkg/kds/server/components.go
+++ b/pkg/kds/server/components.go
@@ -68,7 +68,12 @@ func DefaultStatusTracker(rt core_runtime.Runtime, log logr.Logger) StatusTracke
 				return time.NewTicker(rt.Config().Metrics.Zone.IdleTimeout.Duration / 2)
 			},
 			rt.Config().Multizone.Global.KDS.ZoneInsightFlushInterval.Duration/10,
-			NewZonesInsightStore(rt.ResourceManager(), rt.Config().Store.Upsert, rt.Config().Metrics.Zone.CompactFinishedSubscriptions),
+			NewZonesInsightStore(
+				rt.ResourceManager(),
+				rt.Config().Store.Upsert,
+				rt.Config().Metrics.Zone.CompactFinishedSubscriptions,
+				rt.Transactions(),
+			),
 			l,
 			rt.Extensions(),
 		)

--- a/pkg/kds/server/status_sink.go
+++ b/pkg/kds/server/status_sink.go
@@ -111,11 +111,13 @@ func NewZonesInsightStore(
 	resManager manager.ResourceManager,
 	upsertCfg config_store.UpsertConfig,
 	compactFinished bool,
+	transactions store.Transactions,
 ) ZoneInsightStore {
 	return &zoneInsightStore{
 		resManager:      resManager,
 		upsertCfg:       upsertCfg,
 		compactFinished: compactFinished,
+		transactions:    transactions,
 	}
 }
 
@@ -125,6 +127,7 @@ type zoneInsightStore struct {
 	resManager      manager.ResourceManager
 	upsertCfg       config_store.UpsertConfig
 	compactFinished bool
+	transactions    store.Transactions
 }
 
 func (s *zoneInsightStore) Upsert(ctx context.Context, zone string, subscription *system_proto.KDSSubscription) error {
@@ -142,5 +145,5 @@ func (s *zoneInsightStore) Upsert(ctx context.Context, zone string, subscription
 			zoneInsight.Spec.CompactFinished()
 		}
 		return nil
-	})
+	}, manager.WithTransactions(s.transactions))
 }

--- a/pkg/kds/v2/client/zone_sync_test.go
+++ b/pkg/kds/v2/client/zone_sync_test.go
@@ -89,7 +89,7 @@ var _ = Describe("Zone Delta Sync", func() {
 		zoneStore = memory.NewStore()
 		metrics, err := core_metrics.NewMetrics("")
 		Expect(err).ToNot(HaveOccurred())
-		zoneSyncer, err = sync_store_v2.NewResourceSyncer(core.Log.WithName("kds-syncer"), zoneStore, metrics, context.Background())
+		zoneSyncer, err = sync_store_v2.NewResourceSyncer(core.Log.WithName("kds-syncer"), zoneStore, store.NoTransactions{}, metrics, context.Background())
 		Expect(err).ToNot(HaveOccurred())
 
 		wg.Add(1)

--- a/pkg/kds/v2/server/components.go
+++ b/pkg/kds/v2/server/components.go
@@ -79,7 +79,12 @@ func DefaultStatusTracker(rt core_runtime.Runtime, log logr.Logger) StatusTracke
 			return time.NewTicker(rt.Config().Multizone.Global.KDS.ZoneInsightFlushInterval.Duration)
 		}, func() *time.Ticker {
 			return time.NewTicker(rt.Config().Metrics.Zone.IdleTimeout.Duration / 2)
-		}, rt.Config().Multizone.Global.KDS.ZoneInsightFlushInterval.Duration/10, kds_server.NewZonesInsightStore(rt.ResourceManager(), rt.Config().Store.Upsert, rt.Config().Metrics.Zone.CompactFinishedSubscriptions), l, rt.Extensions())
+		}, rt.Config().Multizone.Global.KDS.ZoneInsightFlushInterval.Duration/10, kds_server.NewZonesInsightStore(
+			rt.ResourceManager(),
+			rt.Config().Store.Upsert,
+			rt.Config().Metrics.Zone.CompactFinishedSubscriptions,
+			rt.Transactions(),
+		), l, rt.Extensions())
 	}, log)
 }
 

--- a/pkg/kds/v2/store/sync_test.go
+++ b/pkg/kds/v2/store/sync_test.go
@@ -49,7 +49,7 @@ var _ = Describe("SyncResourceStoreDelta", func() {
 		resourceStore = memory.NewStore()
 		metrics, err := core_metrics.NewMetrics("")
 		Expect(err).ToNot(HaveOccurred())
-		syncer, err = sync_store.NewResourceSyncer(core.Log, resourceStore, metrics, context.Background())
+		syncer, err = sync_store.NewResourceSyncer(core.Log, resourceStore, store.NoTransactions{}, metrics, context.Background())
 		Expect(err).ToNot(HaveOccurred())
 	})
 

--- a/pkg/kds/zone/components.go
+++ b/pkg/kds/zone/components.go
@@ -72,7 +72,7 @@ func Setup(rt core_runtime.Runtime) error {
 		return err
 	}
 	resourceSyncer := sync_store.NewResourceSyncer(kdsZoneLog, rt.ResourceStore())
-	resourceSyncerV2, err := kds_sync_store_v2.NewResourceSyncer(kdsDeltaZoneLog, rt.ResourceStore(), rt.Metrics(), rt.Extensions())
+	resourceSyncerV2, err := kds_sync_store_v2.NewResourceSyncer(kdsDeltaZoneLog, rt.ResourceStore(), rt.Transactions(), rt.Metrics(), rt.Extensions())
 	if err != nil {
 		return err
 	}

--- a/pkg/kds/zone/components_test.go
+++ b/pkg/kds/zone/components_test.go
@@ -267,7 +267,7 @@ var _ = Describe("Zone Sync", func() {
 			zoneStore = memory.NewStore()
 			metrics, err := core_metrics.NewMetrics("")
 			Expect(err).ToNot(HaveOccurred())
-			zoneSyncer, err = sync_store_v2.NewResourceSyncer(core.Log.WithName("kds-syncer"), zoneStore, metrics, context.Background())
+			zoneSyncer, err = sync_store_v2.NewResourceSyncer(core.Log.WithName("kds-syncer"), zoneStore, store.NoTransactions{}, metrics, context.Background())
 			Expect(err).ToNot(HaveOccurred())
 
 			wg.Add(1)

--- a/pkg/plugins/resources/k8s/plugin.go
+++ b/pkg/plugins/resources/k8s/plugin.go
@@ -18,16 +18,17 @@ func init() {
 	core_plugins.Register(core_plugins.Kubernetes, &plugin{})
 }
 
-func (p *plugin) NewResourceStore(pc core_plugins.PluginContext, _ core_plugins.PluginConfig) (core_store.ResourceStore, error) {
+func (p *plugin) NewResourceStore(pc core_plugins.PluginContext, _ core_plugins.PluginConfig) (core_store.ResourceStore, core_store.Transactions, error) {
 	mgr, ok := k8s_runtime.FromManagerContext(pc.Extensions())
 	if !ok {
-		return nil, errors.Errorf("k8s controller runtime Manager hasn't been configured")
+		return nil, nil, errors.Errorf("k8s controller runtime Manager hasn't been configured")
 	}
 	converter, ok := k8s_runtime.FromResourceConverterContext(pc.Extensions())
 	if !ok {
-		return nil, errors.Errorf("k8s resource converter hasn't been configured")
+		return nil, nil, errors.Errorf("k8s resource converter hasn't been configured")
 	}
-	return NewStore(mgr.GetClient(), mgr.GetScheme(), converter)
+	store, err := NewStore(mgr.GetClient(), mgr.GetScheme(), converter)
+	return store, core_store.NoTransactions{}, err
 }
 
 func (p *plugin) Migrate(pc core_plugins.PluginContext, config core_plugins.PluginConfig) (core_plugins.DbVersion, error) {

--- a/pkg/plugins/resources/memory/plugin.go
+++ b/pkg/plugins/resources/memory/plugin.go
@@ -20,9 +20,9 @@ func init() {
 	core_plugins.Register(core_plugins.Memory, &plugin{})
 }
 
-func (p *plugin) NewResourceStore(pc core_plugins.PluginContext, _ core_plugins.PluginConfig) (core_store.ResourceStore, error) {
+func (p *plugin) NewResourceStore(pc core_plugins.PluginContext, _ core_plugins.PluginConfig) (core_store.ResourceStore, core_store.Transactions, error) {
 	log.Info("kuma-cp runs with an in-memory database and its state isn't preserved between restarts. Keep in mind that an in-memory database cannot be used with multiple instances of the control plane.")
-	return NewStore(), nil
+	return NewStore(), core_store.NoTransactions{}, nil
 }
 
 func (p *plugin) Migrate(pc core_plugins.PluginContext, config core_plugins.PluginConfig) (core_plugins.DbVersion, error) {

--- a/pkg/plugins/resources/postgres/pgx_store.go
+++ b/pkg/plugins/resources/postgres/pgx_store.go
@@ -107,8 +107,8 @@ func (r *pgxResourceStore) Create(ctx context.Context, resource core_model.Resou
 		ownerType,
 	}
 	tx, exist := store.TxFromCtx(ctx)
-	if exist {
-		_, err = tx.(pgx.Tx).Exec(ctx, statement, args...)
+	if pgxTx, ok := tx.(pgx.Tx); exist && ok {
+		_, err = pgxTx.Exec(ctx, statement, args...)
 	} else {
 		_, err = r.pool.Exec(ctx, statement, args...)
 	}
@@ -154,8 +154,8 @@ func (r *pgxResourceStore) Update(ctx context.Context, resource core_model.Resou
 	}
 	tx, exist := store.TxFromCtx(ctx)
 	var result pgconn.CommandTag
-	if exist {
-		result, err = tx.(pgx.Tx).Exec(ctx, statement, args...)
+	if pgxTx, ok := tx.(pgx.Tx); exist && ok {
+		result, err = pgxTx.Exec(ctx, statement, args...)
 	} else {
 		result, err = r.pool.Exec(ctx, statement, args...)
 	}
@@ -185,8 +185,8 @@ func (r *pgxResourceStore) Delete(ctx context.Context, resource core_model.Resou
 	tx, exist := store.TxFromCtx(ctx)
 	var result pgconn.CommandTag
 	var err error
-	if exist {
-		result, err = tx.(pgx.Tx).Exec(ctx, statement, args...)
+	if pgxTx, ok := tx.(pgx.Tx); exist && ok {
+		result, err = pgxTx.Exec(ctx, statement, args...)
 	} else {
 		result, err = r.pool.Exec(ctx, statement, args...)
 	}
@@ -207,8 +207,8 @@ func (r *pgxResourceStore) Get(ctx context.Context, resource core_model.Resource
 	args := []any{opts.Name, opts.Mesh, resource.Descriptor().Name}
 	tx, exist := store.TxFromCtx(ctx)
 	var row pgx.Row
-	if exist {
-		row = tx.(pgx.Tx).QueryRow(ctx, statement, args...)
+	if pgxTx, ok := tx.(pgx.Tx); exist && ok {
+		row = pgxTx.QueryRow(ctx, statement, args...)
 	} else {
 		pool := r.pickRoPool()
 		if opts.Consistent {
@@ -306,8 +306,8 @@ func (r *pgxResourceStore) List(ctx context.Context, resources core_model.Resour
 	tx, exist := store.TxFromCtx(ctx)
 	var rows pgx.Rows
 	var err error
-	if exist {
-		rows, err = tx.(pgx.Tx).Query(ctx, statement, statementArgs...)
+	if pgxTx, ok := tx.(pgx.Tx); exist && ok {
+		rows, err = pgxTx.Query(ctx, statement, statementArgs...)
 	} else {
 		rows, err = r.pickRoPool().Query(ctx, statement, statementArgs...)
 	}

--- a/pkg/plugins/resources/postgres/pgx_store.go
+++ b/pkg/plugins/resources/postgres/pgx_store.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgxpool"
 	_ "github.com/jackc/pgx/v5/stdlib"
 	"github.com/pkg/errors"
@@ -31,9 +32,17 @@ type pgxResourceStore struct {
 
 type ResourceNamesByMesh map[string][]string
 
-var _ store.ResourceStore = &pgxResourceStore{}
+var (
+	_ store.ResourceStore = &pgxResourceStore{}
+	_ store.Transactions  = &pgxResourceStore{}
+)
 
-func NewPgxStore(metrics core_metrics.Metrics, config config.PostgresStoreConfig, customizer pgx_config.PgxConfigCustomization) (store.ResourceStore, error) {
+type TransactionableResourceStore interface {
+	store.ResourceStore
+	store.Transactions
+}
+
+func NewPgxStore(metrics core_metrics.Metrics, config config.PostgresStoreConfig, customizer pgx_config.PgxConfigCustomization) (TransactionableResourceStore, error) {
 	pool, err := postgres.ConnectToDbPgx(config, customizer)
 	if err != nil {
 		return nil, err
@@ -85,8 +94,24 @@ func (r *pgxResourceStore) Create(ctx context.Context, resource core_model.Resou
 
 	version := 0
 	statement := `INSERT INTO resources VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10);`
-	_, err = r.pool.Exec(ctx, statement, opts.Name, opts.Mesh, resource.Descriptor().Name, version, string(bytes),
-		opts.CreationTime.UTC(), opts.CreationTime.UTC(), ownerName, ownerMesh, ownerType)
+	args := []any{
+		opts.Name,
+		opts.Mesh,
+		resource.Descriptor().Name,
+		version,
+		string(bytes),
+		opts.CreationTime.UTC(),
+		opts.CreationTime.UTC(),
+		ownerName,
+		ownerMesh,
+		ownerType,
+	}
+	tx, exist := store.TxFromCtx(ctx)
+	if exist {
+		_, err = tx.(pgx.Tx).Exec(ctx, statement, args...)
+	} else {
+		_, err = r.pool.Exec(ctx, statement, args...)
+	}
 	if err != nil {
 		if strings.Contains(err.Error(), duplicateKeyErrorMsg) {
 			return store.ErrorResourceAlreadyExists(resource.Descriptor().Name, opts.Name, opts.Mesh)
@@ -118,9 +143,7 @@ func (r *pgxResourceStore) Update(ctx context.Context, resource core_model.Resou
 		return errors.Wrap(err, "failed to convert meta version to int")
 	}
 	statement := `UPDATE resources SET spec=$1, version=$2, modification_time=$3 WHERE name=$4 AND mesh=$5 AND type=$6 AND version=$7;`
-	result, err := r.pool.Exec(
-		ctx,
-		statement,
+	args := []any{
 		string(bytes),
 		newVersion,
 		opts.ModificationTime.UTC(),
@@ -128,7 +151,14 @@ func (r *pgxResourceStore) Update(ctx context.Context, resource core_model.Resou
 		resource.GetMeta().GetMesh(),
 		resource.Descriptor().Name,
 		version,
-	)
+	}
+	tx, exist := store.TxFromCtx(ctx)
+	var result pgconn.CommandTag
+	if exist {
+		result, err = tx.(pgx.Tx).Exec(ctx, statement, args...)
+	} else {
+		result, err = r.pool.Exec(ctx, statement, args...)
+	}
 	if err != nil {
 		return errors.Wrapf(err, "failed to execute query %s", statement)
 	}
@@ -151,7 +181,15 @@ func (r *pgxResourceStore) Delete(ctx context.Context, resource core_model.Resou
 	opts := store.NewDeleteOptions(fs...)
 
 	statement := `DELETE FROM resources WHERE name=$1 AND type=$2 AND mesh=$3`
-	result, err := r.pool.Exec(ctx, statement, opts.Name, resource.Descriptor().Name, opts.Mesh)
+	args := []any{opts.Name, resource.Descriptor().Name, opts.Mesh}
+	tx, exist := store.TxFromCtx(ctx)
+	var result pgconn.CommandTag
+	var err error
+	if exist {
+		result, err = tx.(pgx.Tx).Exec(ctx, statement, args...)
+	} else {
+		result, err = r.pool.Exec(ctx, statement, args...)
+	}
 	if err != nil {
 		return errors.Wrapf(err, "failed to execute query: %s", statement)
 	}
@@ -166,11 +204,18 @@ func (r *pgxResourceStore) Get(ctx context.Context, resource core_model.Resource
 	opts := store.NewGetOptions(fs...)
 
 	statement := `SELECT spec, version, creation_time, modification_time FROM resources WHERE name=$1 AND mesh=$2 AND type=$3;`
-	pool := r.pickRoPool()
-	if opts.Consistent {
-		pool = r.pool
+	args := []any{opts.Name, opts.Mesh, resource.Descriptor().Name}
+	tx, exist := store.TxFromCtx(ctx)
+	var row pgx.Row
+	if exist {
+		row = tx.(pgx.Tx).QueryRow(ctx, statement, args...)
+	} else {
+		pool := r.pickRoPool()
+		if opts.Consistent {
+			pool = r.pool
+		}
+		row = pool.QueryRow(ctx, statement, args...)
 	}
-	row := pool.QueryRow(ctx, statement, opts.Name, opts.Mesh, resource.Descriptor().Name)
 
 	var spec string
 	var version int
@@ -258,7 +303,15 @@ func (r *pgxResourceStore) List(ctx context.Context, resources core_model.Resour
 	}
 	statement += " ORDER BY name, mesh"
 
-	rows, err := r.pickRoPool().Query(ctx, statement, statementArgs...)
+	tx, exist := store.TxFromCtx(ctx)
+	var rows pgx.Rows
+	var err error
+	if exist {
+		rows, err = tx.(pgx.Tx).Query(ctx, statement, statementArgs...)
+	} else {
+		rows, err = r.pickRoPool().Query(ctx, statement, statementArgs...)
+	}
+
 	if err != nil {
 		return errors.Wrapf(err, "failed to execute query: %s", statement)
 	}
@@ -464,4 +517,8 @@ func registerMetrics(metrics core_metrics.Metrics, pool *pgxpool.Pool, poolName 
 		return err
 	}
 	return nil
+}
+
+func (r *pgxResourceStore) Begin(ctx context.Context) (store.Transaction, error) {
+	return r.pool.Begin(ctx)
 }

--- a/pkg/test/runtime/runtime.go
+++ b/pkg/test/runtime/runtime.go
@@ -86,6 +86,7 @@ func BuilderFor(appCtx context.Context, cfg kuma_cp.Config) (*core_runtime.Build
 	builder.
 		WithComponentManager(component.NewManager(leader_memory.NewAlwaysLeaderElector())).
 		WithResourceStore(store.NewCustomizableResourceStore(store.NewPaginationStore(resources_memory.NewStore()))).
+		WithTransactions(store.NoTransactions{}).
 		WithSecretStore(secret_store.NewSecretStore(builder.ResourceStore())).
 		WithResourceValidators(core_runtime.ResourceValidators{
 			Dataplane: dataplane.NewMembershipValidator(),


### PR DESCRIPTION
### Checklist prior to review

Introducing postgres transactions.
This PR does NOT introduce need for transactions in Kuma, this is just a perf optimization for stores that support transactions.

#### Enrich ResourceStore vs new interface
I introduced a new interface called Transactions, so the transaction can be used by either ResourceStore and ResourceManager. If I would add a new method in ResourceStore we would also add this to ResourceManager.

#### Transaction in Context vs store opts
I decided to propagate transaction implicitly in context instead of explicitly in store opts like `CreateInTx(tx)`. This is more flexible with less changes to the code. We could also for example open a transaction when we create new Mesh without adding `CreateInTx` to every call.

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [X] [Link to relevant issue][1] as well as docs and UI issues --
- [X] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [X] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [X] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [X] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --
- [X] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
