### PR TITLE
feat(kds): response backoff

### DIFF
--- a/docs/generated/kuma-cp.md
+++ b/docs/generated/kuma-cp.md
@@ -496,6 +496,9 @@ multizone:
       nackBackoff: 5s # ENV: KUMA_MULTIZONE_GLOBAL_KDS_NACK_BACKOFF
       # DisableSOTW if true doesn't expose SOTW version of KDS. Default: false
       disableSOTW: false # ENV: KUMA_MULTIZONE_GLOBAL_KDS_DISABLE_SOTW
+      # Response backoff is a time Global CP waits before sending ACK/NACK.
+      # This is a way to slow down Zone CP from sending resources too often.
+      responseBackoff: 0s # ENV: KUMA_MULTIZONE_GLOBAL_KDS_RESPONSE_BACKOFF
   zone:
     # Kuma Zone name used to mark the zone dataplane resources
     name: "" # ENV: KUMA_MULTIZONE_ZONE_NAME
@@ -516,6 +519,9 @@ multizone:
       msgSendTimeout: 60s # ENV: KUMA_MULTIZONE_ZONE_KDS_MSG_SEND_TIMEOUT
       # Backoff that is executed when the zone control plane is sending the response that was previously rejected by global control plane
       nackBackoff: 5s # ENV: KUMA_MULTIZONE_ZONE_KDS_NACK_BACKOFF
+      # Response backoff is a time Zone CP waits before sending ACK/NACK.
+      # This is a way to slow down Global CP from sending resources too often.
+      responseBackoff: 0s # ENV: KUMA_MULTIZONE_ZONE_KDS_RESPONSE_BACKOFF
 
 # Diagnostics configuration
 diagnostics:

--- a/docs/generated/raw/kuma-cp.yaml
+++ b/docs/generated/raw/kuma-cp.yaml
@@ -493,6 +493,9 @@ multizone:
       nackBackoff: 5s # ENV: KUMA_MULTIZONE_GLOBAL_KDS_NACK_BACKOFF
       # DisableSOTW if true doesn't expose SOTW version of KDS. Default: false
       disableSOTW: false # ENV: KUMA_MULTIZONE_GLOBAL_KDS_DISABLE_SOTW
+      # Response backoff is a time Global CP waits before sending ACK/NACK.
+      # This is a way to slow down Zone CP from sending resources too often.
+      responseBackoff: 0s # ENV: KUMA_MULTIZONE_GLOBAL_KDS_RESPONSE_BACKOFF
   zone:
     # Kuma Zone name used to mark the zone dataplane resources
     name: "" # ENV: KUMA_MULTIZONE_ZONE_NAME
@@ -513,6 +516,9 @@ multizone:
       msgSendTimeout: 60s # ENV: KUMA_MULTIZONE_ZONE_KDS_MSG_SEND_TIMEOUT
       # Backoff that is executed when the zone control plane is sending the response that was previously rejected by global control plane
       nackBackoff: 5s # ENV: KUMA_MULTIZONE_ZONE_KDS_NACK_BACKOFF
+      # Response backoff is a time Zone CP waits before sending ACK/NACK.
+      # This is a way to slow down Global CP from sending resources too often.
+      responseBackoff: 0s # ENV: KUMA_MULTIZONE_ZONE_KDS_RESPONSE_BACKOFF
 
 # Diagnostics configuration
 diagnostics:

--- a/pkg/config/app/kuma-cp/kuma-cp.defaults.yaml
+++ b/pkg/config/app/kuma-cp/kuma-cp.defaults.yaml
@@ -493,6 +493,9 @@ multizone:
       nackBackoff: 5s # ENV: KUMA_MULTIZONE_GLOBAL_KDS_NACK_BACKOFF
       # DisableSOTW if true doesn't expose SOTW version of KDS. Default: false
       disableSOTW: false # ENV: KUMA_MULTIZONE_GLOBAL_KDS_DISABLE_SOTW
+      # Response backoff is a time Global CP waits before sending ACK/NACK.
+      # This is a way to slow down Zone CP from sending resources too often.
+      responseBackoff: 0s # ENV: KUMA_MULTIZONE_GLOBAL_KDS_RESPONSE_BACKOFF
   zone:
     # Kuma Zone name used to mark the zone dataplane resources
     name: "" # ENV: KUMA_MULTIZONE_ZONE_NAME
@@ -513,6 +516,9 @@ multizone:
       msgSendTimeout: 60s # ENV: KUMA_MULTIZONE_ZONE_KDS_MSG_SEND_TIMEOUT
       # Backoff that is executed when the zone control plane is sending the response that was previously rejected by global control plane
       nackBackoff: 5s # ENV: KUMA_MULTIZONE_ZONE_KDS_NACK_BACKOFF
+      # Response backoff is a time Zone CP waits before sending ACK/NACK.
+      # This is a way to slow down Global CP from sending resources too often.
+      responseBackoff: 0s # ENV: KUMA_MULTIZONE_ZONE_KDS_RESPONSE_BACKOFF
 
 # Diagnostics configuration
 diagnostics:

--- a/pkg/config/loader_test.go
+++ b/pkg/config/loader_test.go
@@ -252,6 +252,7 @@ var _ = Describe("Config loader", func() {
 			Expect(cfg.Multizone.Global.KDS.MsgSendTimeout.Duration).To(Equal(10 * time.Second))
 			Expect(cfg.Multizone.Global.KDS.NackBackoff.Duration).To(Equal(11 * time.Second))
 			Expect(cfg.Multizone.Global.KDS.DisableSOTW).To(BeTrue())
+			Expect(cfg.Multizone.Global.KDS.ResponseBackoff.Duration).To(Equal(time.Second))
 			Expect(cfg.Multizone.Zone.GlobalAddress).To(Equal("grpc://1.1.1.1:5685"))
 			Expect(cfg.Multizone.Zone.Name).To(Equal("zone-1"))
 			Expect(cfg.Multizone.Zone.KDS.RootCAFile).To(Equal("/rootCa"))
@@ -259,6 +260,7 @@ var _ = Describe("Config loader", func() {
 			Expect(cfg.Multizone.Zone.KDS.MaxMsgSize).To(Equal(uint32(2)))
 			Expect(cfg.Multizone.Zone.KDS.MsgSendTimeout.Duration).To(Equal(20 * time.Second))
 			Expect(cfg.Multizone.Zone.KDS.NackBackoff.Duration).To(Equal(21 * time.Second))
+			Expect(cfg.Multizone.Zone.KDS.ResponseBackoff.Duration).To(Equal(2 * time.Second))
 			Expect(cfg.Multizone.Zone.KDS.TlsSkipVerify).To(BeTrue())
 
 			Expect(cfg.Defaults.SkipMeshCreation).To(BeTrue())
@@ -564,6 +566,7 @@ multizone:
       maxMsgSize: 1
       msgSendTimeout: 10s
       nackBackoff: 11s
+      responseBackoff: 1s
       disableSOTW: true
   zone:
     globalAddress: "grpc://1.1.1.1:5685"
@@ -574,6 +577,7 @@ multizone:
       maxMsgSize: 2
       msgSendTimeout: 20s
       nackBackoff: 21s
+      responseBackoff: 2s
       tlsSkipVerify: true
 dnsServer:
   domain: test-domain
@@ -861,6 +865,7 @@ tracing:
 				"KUMA_MULTIZONE_GLOBAL_KDS_MAX_MSG_SIZE":                                                   "1",
 				"KUMA_MULTIZONE_GLOBAL_KDS_MSG_SEND_TIMEOUT":                                               "10s",
 				"KUMA_MULTIZONE_GLOBAL_KDS_NACK_BACKOFF":                                                   "11s",
+				"KUMA_MULTIZONE_GLOBAL_KDS_RESPONSE_BACKOFF":                                               "1s",
 				"KUMA_MULTIZONE_GLOBAL_KDS_DISABLE_SOTW":                                                   "true",
 				"KUMA_MULTIZONE_ZONE_GLOBAL_ADDRESS":                                                       "grpc://1.1.1.1:5685",
 				"KUMA_MULTIZONE_ZONE_NAME":                                                                 "zone-1",
@@ -869,6 +874,7 @@ tracing:
 				"KUMA_MULTIZONE_ZONE_KDS_MAX_MSG_SIZE":                                                     "2",
 				"KUMA_MULTIZONE_ZONE_KDS_MSG_SEND_TIMEOUT":                                                 "20s",
 				"KUMA_MULTIZONE_ZONE_KDS_NACK_BACKOFF":                                                     "21s",
+				"KUMA_MULTIZONE_ZONE_KDS_RESPONSE_BACKOFF":                                                 "2s",
 				"KUMA_MULTIZONE_ZONE_KDS_TLS_SKIP_VERIFY":                                                  "true",
 				"KUMA_EXPERIMENTAL_KDS_DELTA_ENABLED":                                                      "true",
 				"KUMA_MULTIZONE_GLOBAL_KDS_ZONE_INSIGHT_FLUSH_INTERVAL":                                    "5s",

--- a/pkg/config/multizone/kds.go
+++ b/pkg/config/multizone/kds.go
@@ -37,6 +37,9 @@ type KdsServerConfig struct {
 	NackBackoff config_types.Duration `json:"nackBackoff" envconfig:"kuma_multizone_global_kds_nack_backoff"`
 	// DisableSOTW if true doesn't expose SOTW version of KDS. Default: false
 	DisableSOTW bool `json:"disableSOTW" envconfig:"kuma_multizone_global_kds_disable_sotw"`
+	// ResponseBackoff is a time Global CP waits before sending ACK/NACK.
+	// This is a way to slow down Zone CP from sending resources too often.
+	ResponseBackoff config_types.Duration `json:"responseBackoff" envconfig:"kuma_multizone_global_kds_response_backoff"`
 }
 
 var _ config.Config = &KdsServerConfig{}
@@ -88,6 +91,9 @@ type KdsClientConfig struct {
 	MsgSendTimeout config_types.Duration `json:"msgSendTimeout" envconfig:"kuma_multizone_zone_kds_msg_send_timeout"`
 	// Backoff that is executed when the zone control plane is sending the response that was previously rejected by global control plane.
 	NackBackoff config_types.Duration `json:"nackBackoff" envconfig:"kuma_multizone_zone_kds_nack_backoff"`
+	// ResponseBackoff is a time Zone CP waits before sending ACK/NACK.
+	// This is a way to slow down Global CP from sending resources too often.
+	ResponseBackoff config_types.Duration `json:"responseBackoff" envconfig:"kuma_multizone_zone_kds_response_backoff"`
 }
 
 var _ config.Config = &KdsClientConfig{}

--- a/pkg/kds/global/components.go
+++ b/pkg/kds/global/components.go
@@ -140,8 +140,13 @@ func Setup(rt runtime.Runtime) error {
 		log := kdsDeltaGlobalLog.WithValues("peer-id", clientId)
 		log = kuma_log.AddFieldsFromCtx(log, stream.Context(), rt.Extensions())
 		kdsStream := kds_client_v2.NewDeltaKDSStream(stream, clientId, "")
-		sink := kds_client_v2.NewKDSSyncClient(log, reg.ObjectTypes(model.HasKDSFlag(model.ConsumedByGlobal)), kdsStream,
-			kds_sync_store_v2.GlobalSyncCallback(stream.Context(), resourceSyncerV2, rt.Config().Store.Type == store_config.KubernetesStore, kubeFactory, rt.Config().Store.Kubernetes.SystemNamespace))
+		sink := kds_client_v2.NewKDSSyncClient(
+			log,
+			reg.ObjectTypes(model.HasKDSFlag(model.ConsumedByGlobal)),
+			kdsStream,
+			kds_sync_store_v2.GlobalSyncCallback(stream.Context(), resourceSyncerV2, rt.Config().Store.Type == store_config.KubernetesStore, kubeFactory, rt.Config().Store.Kubernetes.SystemNamespace),
+			rt.Config().Multizone.Global.KDS.ResponseBackoff.Duration,
+		)
 		go func() {
 			if err := sink.Receive(); err != nil {
 				errChan <- errors.Wrap(err, "KDSSyncClient finished with an error")

--- a/pkg/kds/v2/client/zone_sync_test.go
+++ b/pkg/kds/v2/client/zone_sync_test.go
@@ -37,7 +37,7 @@ var _ = Describe("Zone Delta Sync", func() {
 			core.Log.WithName("kds-sink"),
 			registry.Global().ObjectTypes(model.HasKDSFlag(model.ConsumedByZone)),
 			client_v2.NewDeltaKDSStream(cs, zoneName, ""),
-			sync_store_v2.ZoneSyncCallback(context.Background(), configs, resourceSyncer, false, zoneName, nil, "kuma-system"),
+			sync_store_v2.ZoneSyncCallback(context.Background(), configs, resourceSyncer, false, zoneName, nil, "kuma-system"), 0,
 		)
 	}
 	ingressFunc := func(zone string) *mesh_proto.ZoneIngress {

--- a/pkg/kds/zone/components.go
+++ b/pkg/kds/zone/components.go
@@ -118,7 +118,10 @@ func Setup(rt core_runtime.Runtime) error {
 
 	onGlobalToZoneSyncStarted := mux.OnGlobalToZoneSyncStartedFunc(func(stream mesh_proto.KDSSyncService_GlobalToZoneSyncClient, errChan chan error) {
 		log := kdsDeltaZoneLog.WithValues("kds-version", "v2")
-		syncClient := kds_client_v2.NewKDSSyncClient(log, reg.ObjectTypes(model.HasKDSFlag(model.ConsumedByZone)), kds_client_v2.NewDeltaKDSStream(stream, zone, string(cfgJson)),
+		syncClient := kds_client_v2.NewKDSSyncClient(
+			log,
+			reg.ObjectTypes(model.HasKDSFlag(model.ConsumedByZone)),
+			kds_client_v2.NewDeltaKDSStream(stream, zone, string(cfgJson)),
 			kds_sync_store_v2.ZoneSyncCallback(
 				stream.Context(),
 				rt.KDSContext().Configs,
@@ -128,6 +131,7 @@ func Setup(rt core_runtime.Runtime) error {
 				kubeFactory,
 				rt.Config().Store.Kubernetes.SystemNamespace,
 			),
+			rt.Config().Multizone.Zone.KDS.ResponseBackoff.Duration,
 		)
 		go func() {
 			if err := syncClient.Receive(); err != nil {

--- a/pkg/kds/zone/components_test.go
+++ b/pkg/kds/zone/components_test.go
@@ -238,6 +238,7 @@ var _ = Describe("Zone Sync", func() {
 				registry.Global().ObjectTypes(model.HasKDSFlag(model.ConsumedByZone)),
 				kds_client_v2.NewDeltaKDSStream(cs, zoneName, ""),
 				sync_store_v2.ZoneSyncCallback(context.Background(), configs, resourceSyncer, false, zoneName, nil, "kuma-system"),
+				0,
 			)
 		}
 

--- a/pkg/test/kds/setup/client.go
+++ b/pkg/test/kds/setup/client.go
@@ -26,7 +26,7 @@ func StartDeltaClient(clientStreams []*grpc.MockDeltaClientStream, resourceTypes
 	for i := 0; i < len(clientStreams); i++ {
 		clientID := fmt.Sprintf("client-%d", i)
 		item := clientStreams[i]
-		comp := kds_client_v2.NewKDSSyncClient(core.Log.WithName("kds").WithName(clientID), resourceTypes, kds_client_v2.NewDeltaKDSStream(item, clientID, ""), cb)
+		comp := kds_client_v2.NewKDSSyncClient(core.Log.WithName("kds").WithName(clientID), resourceTypes, kds_client_v2.NewDeltaKDSStream(item, clientID, ""), cb, 0)
 		go func() {
 			_ = comp.Receive()
 			_ = item.CloseSend()


### PR DESCRIPTION
### Checklist prior to review

Response backoff is a way to rate limit clients from sending data too often.
Let's say we have a Zone CP that has many constant changes to Dataplane objects. With the default 1s `KUMA_MULTIZONE_ZONE_KDS_REFRESH_INTERVAL` we will aggregate changes every 1s and send this to global. However, Global CP may want to slow down Zone CP from changing resources too often.

The communication looks like this
Global CP sends DeltaDiscoveryRequest
Zone CP sends DeltaDiscoveryResponse with DP list
Global CP saves DPPs and sends ACK (DeltaDiscoveryRequest)
Zone CP sends DeltaDiscoveryResponse with DP list
Global CP saves DPPs and sends ACK...

If Global CP waits to send ACK after it saves DPPs, Zone CP won't send a new list. Instead, it will aggregate changes over time.

This is a setting for all resources, NOT per resource type because we have one loop of DeltaDiscoveryResponse. We don't wait for the initial DeltaDiscoveryResponse because when Zone CP connects first, it sends a request for every resource type.

The default is set to 0 so we won't change the current behavior.

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [X] [Link to relevant issue][1] as well as docs and UI issues --
- [X] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [X] Tests (Unit test, E2E tests, manual test on universal and k8s) -- tested manually, not sure how to test it well in e2e tests.
- [X] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [X] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --
- [X] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
