### PR TITLE
refactor(xds): route configurers

### DIFF
--- a/pkg/plugins/runtime/gateway/route_table_generator.go
+++ b/pkg/plugins/runtime/gateway/route_table_generator.go
@@ -64,7 +64,7 @@ func GenerateVirtualHost(
 				envoy_routes.RouteMatchExactPath(e.Match.ExactPath),
 				envoy_routes.RouteMatchPrefixPath(e.Match.PrefixPath),
 				envoy_routes.RouteMatchRegexPath(e.Match.RegexPath),
-				envoy_routes.RouteMatchExactHeader(":method", e.Match.Method),
+				envoy_routes.RouteMatchExactMethod(e.Match.Method),
 
 				route.RouteActionRedirect(e.Action.Redirect, info.Listener.Port),
 				route.RouteActionForward(ctx.Mesh.Resource, info.OutboundEndpoints, info.Proxy.Dataplane.Spec.TagSet(), e.Action.Forward),

--- a/pkg/xds/envoy/routes/route_configurers.go
+++ b/pkg/xds/envoy/routes/route_configurers.go
@@ -83,6 +83,11 @@ func RouteMatchExactHeader(name string, value string) RouteConfigurer {
 	})
 }
 
+// RouteMatchExactMethod appends an exact match for the value of the HTTP request method.
+func RouteMatchExactMethod(value string) RouteConfigurer {
+	return RouteMatchExactHeader(":method", value)
+}
+
 // RouteMatchRegexHeader appends a regex match for the value of the named HTTP request header.
 func RouteMatchRegexHeader(name string, regex string) RouteConfigurer {
 	if name == "" || regex == "" {


### PR DESCRIPTION
### Checklist prior to review

Every Route is now created with the help RouteBuilder.
Some Configurers has been reused and the RouteMatchExactMethod been created.

The naming of the import for envoy packages has also been uniformed to not include the v3 version.


<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [ ] [Link to relevant issue][1] as well as docs and UI issues --
- [ ] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [ ] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [ ] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [ ] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --
- [ ] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
