### PR TITLE
ci(circleci): install qemu on `build` to be able to build arm64 docker

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -359,6 +359,10 @@ jobs:
   build:
     executor: vm-xlarge-amd64
     steps:
+      - run: # required to build arm64 images
+          command: |
+            sudo apt-get update
+            sudo apt-get install -y qemu-user-static binfmt-support
       - install_build_tools
       - checkout
       - setenv_depending_on_priority:
@@ -371,14 +375,14 @@ jobs:
           command: make dev/tools
       - run:
           command: make clean
-      # - run:
-      # command: make check
+      - run:
+          command: make check
       - run:
           command: make build
       - run:
           command: make -j build/distributions
       - run:
-          command: make images
+          command: make -j images
       - run:
           command: make -j docker/save
       - save_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -371,14 +371,14 @@ jobs:
           command: make dev/tools
       - run:
           command: make clean
-      - run:
-          command: make check
+      # - run:
+      # command: make check
       - run:
           command: make build
       - run:
           command: make -j build/distributions
       - run:
-          command: make -j images
+          command: make images
       - run:
           command: make -j docker/save
       - save_cache:


### PR DESCRIPTION
### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --
- [x] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
