### PR TITLE
chore(kuma-cp): gRPC shutdown logging

### DIFF
--- a/app/kuma-cp/cmd/run.go
+++ b/app/kuma-cp/cmd/run.go
@@ -148,9 +148,10 @@ func newRunCmdWithOpts(opts kuma_cmd.RunCmdOpts) *cobra.Command {
 			runLog.Info("stop signal received. Waiting 3 seconds for components to stop gracefully...")
 			select {
 			case <-ctx.Done():
+				runLog.Info("all components have stopped")
 			case <-time.After(gracefullyShutdownDuration):
+				runLog.Info("forcefully stopped")
 			}
-			runLog.Info("stopping Control Plane")
 			return nil
 		},
 	}

--- a/pkg/intercp/server/server.go
+++ b/pkg/intercp/server/server.go
@@ -102,8 +102,9 @@ func (d *InterCpServer) Start(stop <-chan struct{}) error {
 
 	select {
 	case <-stop:
-		log.Info("stopping")
+		log.Info("stopping gracefully")
 		d.grpcServer.GracefulStop()
+		log.Info("stopped")
 		return nil
 	case err := <-errChan:
 		return err

--- a/pkg/kds/mux/server.go
+++ b/pkg/kds/mux/server.go
@@ -160,6 +160,7 @@ func (s *server) Start(stop <-chan struct{}) error {
 	case <-stop:
 		muxServerLog.Info("stopping gracefully")
 		grpcServer.GracefulStop()
+		muxServerLog.Info("stopped")
 		return nil
 	case err := <-errChan:
 		return err


### PR DESCRIPTION
### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --
- [x] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
