### PR TITLE
fix(MeshFaultInjection): include tags negation in header matching

### DIFF
--- a/pkg/plugins/policies/meshfaultinjection/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshfaultinjection/plugin/v1alpha1/plugin_test.go
@@ -116,32 +116,61 @@ var _ = Describe("MeshFaultInjection", func() {
 			},
 			fromRules: core_rules.FromRules{
 				Rules: map[core_rules.InboundListener]core_rules.Rules{
-					{Address: "127.0.0.1", Port: 17777}: {{
-						Subset: core_rules.Subset{
-							{
-								Key:   "kuma.io/service",
-								Value: "demo-client",
-							},
-						},
-						Conf: api.Conf{
-							Http: &[]api.FaultInjectionConf{
+					{Address: "127.0.0.1", Port: 17777}: {
+						{
+							Subset: core_rules.Subset{
 								{
-									Abort: &api.AbortConf{
-										HttpStatus: int32(444),
-										Percentage: intstr.FromString("12"),
-									},
-									Delay: &api.DelayConf{
-										Value:      *test.ParseDuration("55s"),
-										Percentage: intstr.FromString("55"),
-									},
-									ResponseBandwidth: &api.ResponseBandwidthConf{
-										Limit:      "111mbps",
-										Percentage: intstr.FromString("62.9"),
+									Key:   "kuma.io/service",
+									Value: "demo-client",
+								},
+							},
+							Conf: api.Conf{
+								Http: &[]api.FaultInjectionConf{
+									{
+										Abort: &api.AbortConf{
+											HttpStatus: int32(444),
+											Percentage: intstr.FromString("12"),
+										},
+										Delay: &api.DelayConf{
+											Value:      *test.ParseDuration("55s"),
+											Percentage: intstr.FromString("55"),
+										},
+										ResponseBandwidth: &api.ResponseBandwidthConf{
+											Limit:      "111mbps",
+											Percentage: intstr.FromString("62.9"),
+										},
 									},
 								},
 							},
 						},
-					}},
+						{
+							Subset: core_rules.Subset{
+								{
+									Key:   "kuma.io/service",
+									Value: "demo-client",
+									Not:   true,
+								},
+							},
+							Conf: api.Conf{
+								Http: &[]api.FaultInjectionConf{
+									{
+										Abort: &api.AbortConf{
+											HttpStatus: 111,
+											Percentage: intstr.FromInt32(11),
+										},
+										Delay: &api.DelayConf{
+											Value:      *test.ParseDuration("22s"),
+											Percentage: intstr.FromInt32(22),
+										},
+										ResponseBandwidth: &api.ResponseBandwidthConf{
+											Limit:      "333mbps",
+											Percentage: intstr.FromString("33.3"),
+										},
+									},
+								},
+							},
+						},
+					},
 					{Address: "127.0.0.1", Port: 17778}: {{
 						Subset: core_rules.Subset{},
 						Conf: api.Conf{

--- a/pkg/plugins/policies/meshfaultinjection/plugin/v1alpha1/testdata/basic_listener_1.golden.yaml
+++ b/pkg/plugins/policies/meshfaultinjection/plugin/v1alpha1/testdata/basic_listener_1.golden.yaml
@@ -22,15 +22,40 @@ filterChains:
               numerator: 55
           headers:
           - name: x-kuma-tags
-            safeRegexMatch:
-              googleRe2: {}
-              regex: .*&kuma.io/service=[^&]*demo-client[,&].*
+            stringMatch:
+              safeRegex:
+                googleRe2: {}
+                regex: .*&kuma.io/service=[^&]*demo-client[,&].*
           responseRateLimit:
             fixedLimit:
               limitKbps: "111000"
             percentage:
               denominator: TEN_THOUSAND
               numerator: 6290
+      - name: envoy.filters.http.fault
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.filters.http.fault.v3.HTTPFault
+          abort:
+            httpStatus: 111
+            percentage:
+              numerator: 11
+          delay:
+            fixedDelay: 22s
+            percentage:
+              numerator: 22
+          headers:
+          - invertMatch: true
+            name: x-kuma-tags
+            stringMatch:
+              safeRegex:
+                googleRe2: {}
+                regex: .*&kuma.io/service=[^&]*demo-client[,&].*
+          responseRateLimit:
+            fixedLimit:
+              limitKbps: "333000"
+            percentage:
+              denominator: MILLION
+              numerator: 333000
       - name: envoy.filters.http.router
         typedConfig:
           '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router

--- a/pkg/plugins/policies/meshfaultinjection/plugin/xds/configurer.go
+++ b/pkg/plugins/policies/meshfaultinjection/plugin/xds/configurer.go
@@ -56,9 +56,7 @@ func (c *Configurer) ConfigureHttpListener(filterChain *envoy_listener.FilterCha
 			config.ResponseRateLimit = rrl
 
 			if len(c.From) > 0 {
-				config.Headers = []*envoy_route.HeaderMatcher{
-					c.createHeaders(c.From),
-				}
+				config.Headers = c.createHeaders(c.From)
 			}
 
 			pbst, err := util_proto.MarshalAnyDeterministic(config)
@@ -80,27 +78,42 @@ func (c *Configurer) ConfigureHttpListener(filterChain *envoy_listener.FilterCha
 	return nil
 }
 
-func (c *Configurer) createHeaders(from core_xds.Subset) *envoy_route.HeaderMatcher {
-	tagsMap := map[string]string{}
-	for _, tag := range from {
-		tagsMap[tag.Key] = tag.Value
-	}
-
-	var selectorRegexs []string
-	selectorRegexs = append(selectorRegexs, tags.MatchingRegex(tagsMap))
-	regexOR := tags.RegexOR(selectorRegexs...)
-
+func regexHeaderMatcher(regex string, invert bool) *envoy_route.HeaderMatcher {
 	return &envoy_route.HeaderMatcher{
 		Name: tags.TagsHeaderName,
-		HeaderMatchSpecifier: &envoy_route.HeaderMatcher_SafeRegexMatch{
-			SafeRegexMatch: &envoy_type_matcher.RegexMatcher{
-				EngineType: &envoy_type_matcher.RegexMatcher_GoogleRe2{
-					GoogleRe2: &envoy_type_matcher.RegexMatcher_GoogleRE2{},
+		HeaderMatchSpecifier: &envoy_route.HeaderMatcher_StringMatch{
+			StringMatch: &envoy_type_matcher.StringMatcher{
+				MatchPattern: &envoy_type_matcher.StringMatcher_SafeRegex{
+					SafeRegex: &envoy_type_matcher.RegexMatcher{
+						EngineType: &envoy_type_matcher.RegexMatcher_GoogleRe2{},
+						Regex:      regex,
+					},
 				},
-				Regex: regexOR,
 			},
 		},
+		InvertMatch: invert,
 	}
+}
+
+func (c *Configurer) createHeaders(from core_xds.Subset) []*envoy_route.HeaderMatcher {
+	tagsMap := map[bool]map[string]string{false: {}, true: {}}
+	for _, tag := range from {
+		tagsMap[tag.Not][tag.Key] = tag.Value
+	}
+
+	var matchers []*envoy_route.HeaderMatcher
+
+	notNegated := tagsMap[false]
+	if len(notNegated) > 0 {
+		matchers = append(matchers, regexHeaderMatcher(tags.MatchingRegex(notNegated), false))
+	}
+
+	negated := tagsMap[true]
+	if len(negated) > 0 {
+		matchers = append(matchers, regexHeaderMatcher(tags.MatchingRegex(negated), true))
+	}
+
+	return matchers
 }
 
 func (c *Configurer) convertDelay(delay *api.DelayConf) (*envoy_filter_fault.FaultDelay, error) {


### PR DESCRIPTION
Take into account tags negation when generating header matchers for MeshFaultInjection policy.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues
  - Closes: https://github.com/kumahq/kuma/issues/7728
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS
  - It won't
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s)
  - Unit tests updated
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)?
  - There is no need
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label)
  - It doesn't
- [x] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
