### PR TITLE
feat(MeshProxyPatch): allow policy to target MeshGateway resources

### DIFF
--- a/pkg/plugins/policies/core/matchers/dataplane.go
+++ b/pkg/plugins/policies/core/matchers/dataplane.go
@@ -230,17 +230,20 @@ func listenersSelectedByMeshGatewayRef(
 	dpp *core_mesh.DataplaneResource,
 	gateway *core_mesh.MeshGatewayResource,
 ) []core_rules.InboundListener {
-	result := []core_rules.InboundListener{}
-	if name == gateway.GetMeta().GetName() {
-		for _, listener := range gateway.Spec.GetConf().GetListeners() {
-			if mesh_proto.TagSelector(tags).Matches(listener.GetTags()) {
-				result = append(result, core_rules.InboundListener{
-					Address: dpp.Spec.GetNetworking().GetAddress(),
-					Port:    listener.Port,
-				})
-			}
+	if gateway == nil || name != gateway.GetMeta().GetName() {
+		return nil
+	}
+
+	var result []core_rules.InboundListener
+	for _, listener := range gateway.Spec.GetConf().GetListeners() {
+		if mesh_proto.TagSelector(tags).Matches(listener.GetTags()) {
+			result = append(result, core_rules.InboundListener{
+				Address: dpp.Spec.GetNetworking().GetAddress(),
+				Port:    listener.Port,
+			})
 		}
 	}
+
 	return result
 }
 

--- a/pkg/plugins/policies/meshproxypatch/api/v1alpha1/validator.go
+++ b/pkg/plugins/policies/meshproxypatch/api/v1alpha1/validator.go
@@ -37,6 +37,7 @@ func validateTop(targetRef common_api.TargetRef) validators.ValidationError {
 			common_api.MeshSubset,
 			common_api.MeshService,
 			common_api.MeshServiceSubset,
+			common_api.MeshGateway,
 		},
 	})
 	return targetRefErr

--- a/pkg/plugins/policies/meshproxypatch/api/v1alpha1/validator_test.go
+++ b/pkg/plugins/policies/meshproxypatch/api/v1alpha1/validator_test.go
@@ -256,6 +256,45 @@ default:
   - httpFilter:
       operation: Remove
     `),
+			Entry("modifications for MeshGateway", `
+targetRef:
+  kind: MeshGateway
+  name: gateway
+default:
+  appendModifications:
+  - cluster:
+      operation: Patch
+      jsonPatches:
+        - op: replace
+          path: /foo/bar
+          value: baz
+        - op: replace
+          path: /foo
+          value:
+            bar: baz
+  - listener:
+      operation: Add
+      value: |
+        name: xyz
+        address:
+          socketAddress:
+            address: 192.168.0.1
+            portValue: 8080
+  - networkFilter:
+      operation: AddFirst
+      value: |
+        name: envoy.filters.network.tcp_proxy
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
+          cluster: backend
+  - httpFilter:
+      operation: AddFirst
+      value: |
+        name: envoy.filters.http.router
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+          dynamicStats: false
+    `),
 		)
 
 		type testCase struct {


### PR DESCRIPTION
Allow MeshProxyPatch to target MeshGateway resources

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues
  - Closes https://github.com/kumahq/kuma/issues/7623
  - [x] Docs: https://github.com/kumahq/kuma-website/pull/1485
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS
  - It won't
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s)
  - Unit tests updated
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)?
  - There is no need
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label)
  - There is no need
- [x] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
