### PR TITLE
fix(shutdown): try forceful stop after 3 seconds

### DIFF
--- a/app/kuma-cp/cmd/run.go
+++ b/app/kuma-cp/cmd/run.go
@@ -30,7 +30,7 @@ import (
 
 var runLog = controlPlaneLog.WithName("run")
 
-const gracefullyShutdownDuration = 3 * time.Second
+const gracefullyShutdownDuration = 5 * time.Second
 
 // This is the open file limit below which the control plane may not
 // reasonably have enough descriptors to accept all its clients.

--- a/pkg/kds/mux/server.go
+++ b/pkg/kds/mux/server.go
@@ -158,9 +158,15 @@ func (s *server) Start(stop <-chan struct{}) error {
 
 	select {
 	case <-stop:
+		timer := time.AfterFunc(3 * time.Second, func() {
+			muxServerLog.Info("stopping forcefully")
+			grpcServer.Stop()
+			muxServerLog.Info("stopped forcefully")
+		})
+		defer timer.Stop()
 		muxServerLog.Info("stopping gracefully")
 		grpcServer.GracefulStop()
-		muxServerLog.Info("stopped")
+		muxServerLog.Info("stopped gracefully")
 		return nil
 	case err := <-errChan:
 		return err


### PR DESCRIPTION
### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [ ] [Link to relevant issue][1] as well as docs and UI issues --
- [ ] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [ ] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [ ] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [ ] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --
- [ ] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
