### PR TITLE
fix(kuma-cp): store correct last seen time in ZoneWatch

### DIFF
--- a/pkg/kds/mux/zone_watch.go
+++ b/pkg/kds/mux/zone_watch.go
@@ -108,15 +108,6 @@ func (zw *ZoneWatch) Start(stop <-chan struct{}) error {
 		case e := <-connectionWatch.Recv():
 			newStream := e.(service.ZoneOpenedStream)
 
-			ctx := multitenant.WithTenant(context.TODO(), newStream.TenantID)
-			zoneInsight := system.NewZoneInsightResource()
-
-			log := kuma_log.AddFieldsFromCtx(zw.log, ctx, zw.extensions)
-			if err := zw.rm.Get(ctx, zoneInsight, store.GetByKey(newStream.Zone, model.NoMesh)); err != nil {
-				log.Info("error getting ZoneInsight", "zone", newStream.Zone)
-				continue
-			}
-
 			// We keep a record of the time we open a stream.
 			// This is to prevent the zone from timing out on a poll
 			// where the last health check is still from a previous connect, so:

--- a/pkg/kds/mux/zone_watch.go
+++ b/pkg/kds/mux/zone_watch.go
@@ -121,7 +121,7 @@ func (zw *ZoneWatch) Start(stop <-chan struct{}) error {
 			zw.zones[zoneTenant{
 				tenantID: newStream.TenantID,
 				zone:     newStream.Zone,
-			}] = time.Now()
+			}] = core.Now()
 		case <-stop:
 			return nil
 		}


### PR DESCRIPTION
Changed some logic in the original PR https://github.com/kumahq/kuma/pull/7821/commits/0356948b8a2a4887fd4160338d9c133467378134 without updating the saved time.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --
- [x] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword

> Changelog: skip