### PR TITLE
feat(kuma-cp): turn off cla cache - testing perf

### DIFF
--- a/pkg/xds/cache/cla/cache.go
+++ b/pkg/xds/cache/cla/cache.go
@@ -2,7 +2,6 @@ package cla
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	"google.golang.org/protobuf/proto"
@@ -11,7 +10,6 @@ import (
 	"github.com/kumahq/kuma/pkg/core/xds"
 	"github.com/kumahq/kuma/pkg/metrics"
 	"github.com/kumahq/kuma/pkg/xds/cache/once"
-	"github.com/kumahq/kuma/pkg/xds/cache/sha256"
 	envoy_common "github.com/kumahq/kuma/pkg/xds/envoy"
 	envoy_endpoints "github.com/kumahq/kuma/pkg/xds/envoy/endpoints"
 )
@@ -37,30 +35,26 @@ func NewCache(
 }
 
 func (c *Cache) GetCLA(ctx context.Context, meshName, meshHash string, cluster envoy_common.Cluster, apiVersion xds.APIVersion, endpointMap xds.EndpointMap) (proto.Message, error) {
-	key := sha256.Hash(fmt.Sprintf("%s:%s:%s:%s", apiVersion, meshName, cluster.Hash(), meshHash))
+	matchTags := map[string]string{}
+	for tag, val := range cluster.Tags() {
+		if tag != mesh_proto.ServiceTag {
+			matchTags[tag] = val
+		}
+	}
 
-	elt, err := c.cache.GetOrRetrieve(ctx, key, once.RetrieverFunc(func(ctx context.Context, key string) (interface{}, error) {
-		matchTags := map[string]string{}
-		for tag, val := range cluster.Tags() {
-			if tag != mesh_proto.ServiceTag {
-				matchTags[tag] = val
+	// For the majority of cases we don't have custom tags, we can just take a slice
+	endpoints := endpointMap[cluster.Service()]
+	if len(matchTags) > 0 {
+		endpoints = []xds.Endpoint{}
+		for _, endpoint := range endpointMap[cluster.Service()] {
+			if endpoint.ContainsTags(matchTags) {
+				endpoints = append(endpoints, endpoint)
 			}
 		}
-
-		// For the majority of cases we don't have custom tags, we can just take a slice
-		endpoints := endpointMap[cluster.Service()]
-		if len(matchTags) > 0 {
-			endpoints = []xds.Endpoint{}
-			for _, endpoint := range endpointMap[cluster.Service()] {
-				if endpoint.ContainsTags(matchTags) {
-					endpoints = append(endpoints, endpoint)
-				}
-			}
-		}
-		return envoy_endpoints.CreateClusterLoadAssignment(cluster.Name(), endpoints, apiVersion)
-	}))
+	}
+	elt, err := envoy_endpoints.CreateClusterLoadAssignment(cluster.Name(), endpoints, apiVersion)
 	if err != nil {
 		return nil, err
 	}
-	return elt.(proto.Message), nil
+	return elt, nil
 }


### PR DESCRIPTION
### Checklist prior to review

- [ ] [Link to relevant issue][1] as well as docs and UI issues --
- [ ] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [ ] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [ ] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [ ] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --
- [ ] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
