### PR TITLE
feat(kuma-cp): add unary interceptors to KDS server

### DIFF
--- a/pkg/kds/context/context.go
+++ b/pkg/kds/context/context.go
@@ -49,6 +49,7 @@ type Context struct {
 
 	EnvoyAdminRPCs           service.EnvoyAdminRPCs
 	ServerStreamInterceptors []grpc.StreamServerInterceptor
+	ServerUnaryInterceptor   []grpc.UnaryServerInterceptor
 }
 
 func DefaultContext(

--- a/pkg/kds/global/components.go
+++ b/pkg/kds/global/components.go
@@ -182,6 +182,7 @@ func Setup(rt runtime.Runtime) error {
 		onSessionStarted,
 		rt.KDSContext().GlobalServerFilters,
 		rt.KDSContext().ServerStreamInterceptors,
+		rt.KDSContext().ServerUnaryInterceptor,
 		*rt.Config().Multizone.Global.KDS,
 		rt.Metrics(),
 		service.NewGlobalKDSServiceServer(

--- a/pkg/kds/mux/server.go
+++ b/pkg/kds/mux/server.go
@@ -65,6 +65,7 @@ type server struct {
 	serviceServer        *service.GlobalKDSServiceServer
 	kdsSyncServiceServer *KDSSyncServiceServer
 	streamInterceptors   []grpc.StreamServerInterceptor
+	unaryInterceptors    []grpc.UnaryServerInterceptor
 	mesh_proto.UnimplementedMultiplexServiceServer
 }
 
@@ -74,6 +75,7 @@ func NewServer(
 	callbacks Callbacks,
 	filters []Filter,
 	streamInterceptors []grpc.StreamServerInterceptor,
+	unaryInterceptors []grpc.UnaryServerInterceptor,
 	config multizone.KdsServerConfig,
 	metrics core_metrics.Metrics,
 	serviceServer *service.GlobalKDSServiceServer,
@@ -87,6 +89,7 @@ func NewServer(
 		serviceServer:        serviceServer,
 		kdsSyncServiceServer: kdsSyncServiceServer,
 		streamInterceptors:   streamInterceptors,
+		unaryInterceptors:    unaryInterceptors,
 	}
 }
 
@@ -127,6 +130,7 @@ func (s *server) Start(stop <-chan struct{}) error {
 	}
 	grpcOptions = append(
 		grpcOptions,
+		grpc.ChainUnaryInterceptor(s.unaryInterceptors...),
 		grpc.ChainUnaryInterceptor(otelgrpc.UnaryServerInterceptor()),
 	)
 	grpcServer := grpc.NewServer(grpcOptions...)


### PR DESCRIPTION
Do we also need interceptors like https://github.com/kumahq/kuma/blob/c795edf1e6c503bfb9e414069932016eaa729f29/pkg/kds/global/components.go#L190-L194

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

> Changelog: skip
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
