### PR TITLE
fix(controller): add namespace to `deleteObjectIfExist` in pod controller

### DIFF
--- a/pkg/plugins/runtime/k8s/controllers/pod_controller.go
+++ b/pkg/plugins/runtime/k8s/controllers/pod_controller.go
@@ -179,7 +179,7 @@ func (r *PodReconciler) reconcileBuiltinGatewayDataplane(ctx context.Context, po
 func (r *PodReconciler) reconcileZoneIngress(ctx context.Context, pod *kube_core.Pod, log logr.Logger) error {
 	if pod.Status.PodIP == "" {
 		zi := &mesh_k8s.ZoneIngress{
-			ObjectMeta: kube_meta.ObjectMeta{Name: pod.Name},
+			ObjectMeta: kube_meta.ObjectMeta{Name: pod.Name, Namespace: pod.Namespace},
 		}
 		return r.deleteObjectIfExist(ctx, zi, "pod IP is empty", log)
 	}
@@ -201,7 +201,7 @@ func (r *PodReconciler) reconcileZoneIngress(ctx context.Context, pod *kube_core
 func (r *PodReconciler) reconcileZoneEgress(ctx context.Context, pod *kube_core.Pod, log logr.Logger) error {
 	if pod.Status.PodIP == "" {
 		zi := &mesh_k8s.ZoneEgress{
-			ObjectMeta: kube_meta.ObjectMeta{Name: pod.Name},
+			ObjectMeta: kube_meta.ObjectMeta{Name: pod.Name, Namespace: pod.Namespace},
 		}
 		return r.deleteObjectIfExist(ctx, zi, "pod IP is empty", log)
 	}


### PR DESCRIPTION
A user hit a case where the reconciler was erroring out because the namespace was empty:

```
2023-10-18T07:14:05.899Z	ERROR	kube-manager	Reconciler error	{"controller": "pod", "controllerGroup": "", "controllerKind": "Pod", "Pod": {"name":"kong-mesh-egress-bfcb465b6-k4n7n","namespace":"kong-mesh-system"}, "namespace": "kong-mesh-system", "name": "kong-mesh-egress-bfcb465b6-k4n7n", "reconcileID": "83e8afbd-9083-47c3-bada-13f61241480f", "error": "could not delete &TypeMeta{Kind:,APIVersion:,} kong-mesh-egress-bfcb465b6-k4n7n/: an empty namespace may not be set when a resource name is provided", "errorVerbose": "an empty namespace may not be set when a resource name is provided\ncould not delete &TypeMeta{Kind:,APIVersion:,} kong-mesh-egress-bfcb465b6-k4n7n/\ngithub.com/kumahq/kuma/pkg/plugins/runtime/k8s/controllers.(*PodReconciler).deleteObjectIfExist\n\tgithub.com/kumahq/kuma@v0.0.0-20230803100833-c56df80922be/pkg/plugins/runtime/k8s/controllers/pod_controller.go:158\ngithub.com/kumahq/kuma/pkg/plugins/runtime/k8s/controllers.(*PodReconciler).reconcileZoneEgress\n\tgithub.com/kumahq/kuma@v0.0.0-20230803100833-c56df80922be/pkg/plugins/runtime/k8s/controllers/pod_controller.go:206\ngithub.com/kumahq/kuma/pkg/plugins/runtime/k8s/controllers.(*PodReconciler).Reconcile\n\tgithub.com/kumahq/kuma@v0.0.0-20230803100833-c56df80922be/pkg/plugins/runtime/k8s/controllers/pod_controller.go:85\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Reconcile\n\tsigs.k8s.io/controller-runtime@v0.15.0/pkg/internal/controller/controller.go:118\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler\n\tsigs.k8s.io/controller-runtime@v0.15.0/pkg/internal/controller/controller.go:314\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem\n\tsigs.k8s.io/controller-runtime@v0.15.0/pkg/internal/controller/controller.go:265\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2\n\tsigs.k8s.io/controller-runtime@v0.15.0/pkg/internal/controller/controller.go:226\nruntime.goexit\n\truntime/asm_amd64.s:1598"}
```

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [X] [Link to relevant issue][1] as well as docs and UI issues -- not reported via issue
- [X] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [X] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [X] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [X] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
