### PR TITLE
chore(helm): allow ommiting prometheus annotations on cp service

### DIFF
--- a/deployments/charts/kuma/README.md
+++ b/deployments/charts/kuma/README.md
@@ -46,6 +46,7 @@ A Helm chart for the Kuma Control Plane
 | controlPlane.service.enabled | bool | `true` | Whether to create a service resource. |
 | controlPlane.service.name | string | `nil` | Optionally override of the Kuma Control Plane Service's name |
 | controlPlane.service.type | string | `"ClusterIP"` | Service type of the Kuma Control Plane |
+| controlPlane.service.includePrometheusAnnotations | bool | `true` | Whether to put the default prometheus.io/scrape and prometheus.io/port annotations on the Kuma Control Plane service |
 | controlPlane.service.annotations | object | `{}` | Additional annotations to put on the Kuma Control Plane |
 | controlPlane.ingress.enabled | bool | `false` | Install K8s Ingress resource that exposes GUI and API |
 | controlPlane.ingress.ingressClassName | string | `nil` | IngressClass defines which controller will implement the resource |

--- a/deployments/charts/kuma/templates/cp-service.yaml
+++ b/deployments/charts/kuma/templates/cp-service.yaml
@@ -6,8 +6,10 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels: {{ include "kuma.cpLabels" . | nindent 4 }}
   annotations:
+    {{- if .Values.controlPlane.service.includePrometheusAnnotations }}
     prometheus.io/scrape: "true"
     prometheus.io/port: "5680"
+    {{- end }}
     {{- range $key, $value := .Values.controlPlane.service.annotations }}
     {{ $key }}: {{ $value | quote }}
     {{- end }}

--- a/deployments/charts/kuma/values.yaml
+++ b/deployments/charts/kuma/values.yaml
@@ -140,6 +140,10 @@ controlPlane:
     # -- Service type of the Kuma Control Plane
     type: ClusterIP
 
+    # -- Whether to put the default prometheus.io/scrape and prometheus.io/port
+    # annotations on the Kuma Control Plane service
+    includePrometheusAnnotations: true
+
     # -- Additional annotations to put on the Kuma Control Plane
     annotations: { }
 

--- a/docs/generated/raw/helm-values.yaml
+++ b/docs/generated/raw/helm-values.yaml
@@ -140,6 +140,10 @@ controlPlane:
     # -- Service type of the Kuma Control Plane
     type: ClusterIP
 
+    # -- Whether to put the default prometheus.io/scrape and prometheus.io/port
+    # annotations on the Kuma Control Plane service
+    includePrometheusAnnotations: true
+
     # -- Additional annotations to put on the Kuma Control Plane
     annotations: { }
 


### PR DESCRIPTION
 Allow omitting prometheus.io/scrape and prometheus.io/port annotations on control plane services.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues
  - no relevant issue
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS
  - It won't
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s)
  - Don't forget `ci/` labels to run additional/fewer tests
  - no tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)?
  - there is no need
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label)
  - There is no need

> Changelog: skip

<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
