### PR TITLE
fix(api-server): avoid panic when there no insight for entity

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,7 +8,7 @@ does not have any particular instructions.
 
 ## Upgrade to `2.5.x`
 
-#### More strict validation rules for resource names
+### More strict validation rules for resource names
 
 In order to be compatible with Kubernetes naming policy we updated the validation rules. Old rule:
 
@@ -19,6 +19,19 @@ New rule:
 > A lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character
 
 New rule is applied for CREATE operations. The old rule is still applied for UPDATE, but this is going to change in Kuma 2.7.x or later.
+
+### API
+
+#### overview API coherency
+
+These endpoints are getting replaced to achieve more coherency on the API:
+
+- `/meshes/{mesh}/zoneegressoverviews` moves to `/meshes/{mesh}/zoneegresses/-overview`
+- `/meshes/{mesh}/zoneingresses+insights` moves to `/meshes/{mesh}/zone-ingresses/-overview`
+- `/meshes/{mesh}/dataplanes+insights` moves to `/meshes/{mesh}/dataplanes/-overview`
+- `/zones+insights` moves to `/zones/-overview`
+
+While you can use the old API they will be removed in a future version
 
 ## Upgrade to `2.4.x`
 

--- a/pkg/api-server/testdata/_meshes_mesh1_dataplanes+insights.json
+++ b/pkg/api-server/testdata/_meshes_mesh1_dataplanes+insights.json
@@ -1,0 +1,133 @@
+{
+ "total": 4,
+ "items": [
+  {
+   "type": "DataplaneOverview",
+   "mesh": "mesh1",
+   "name": "dp-1",
+   "creationTime": "2018-07-17T16:05:36.995Z",
+   "modificationTime": "2018-07-17T16:05:36.995Z",
+   "dataplane": {
+    "networking": {
+     "address": "127.0.0.1",
+     "inbound": [
+      {
+       "port": 1234,
+       "tags": {
+        "service": "backend",
+        "tagcolumn": "tag:v",
+        "version": "v1"
+       }
+      }
+     ]
+    }
+   },
+   "dataplaneInsight": {
+    "subscriptions": [
+     {
+      "id": "stream-id-1",
+      "controlPlaneInstanceId": "cp-1",
+      "connectTime": "2019-07-01T00:00:00Z",
+      "status": {
+       "total": {},
+       "cds": {},
+       "eds": {},
+       "lds": {},
+       "rds": {}
+      }
+     }
+    ]
+   }
+  },
+  {
+   "type": "DataplaneOverview",
+   "mesh": "mesh1",
+   "name": "dp-no-insights",
+   "creationTime": "2018-07-17T16:05:36.995Z",
+   "modificationTime": "2018-07-17T16:05:36.995Z",
+   "dataplane": {
+    "networking": {
+     "address": "127.0.0.1",
+     "inbound": [
+      {
+       "port": 1234,
+       "tags": {
+        "service": "backend",
+        "tagcolumn": "tag:v",
+        "version": "v1"
+       }
+      }
+     ]
+    }
+   }
+  },
+  {
+   "type": "DataplaneOverview",
+   "mesh": "mesh1",
+   "name": "gateway-builtin",
+   "creationTime": "2018-07-17T16:05:36.995Z",
+   "modificationTime": "2018-07-17T16:05:36.995Z",
+   "dataplane": {
+    "networking": {
+     "address": "127.0.0.1",
+     "gateway": {
+      "tags": {
+       "service": "gateway"
+      },
+      "type": "BUILTIN"
+     }
+    }
+   },
+   "dataplaneInsight": {
+    "subscriptions": [
+     {
+      "id": "stream-id-1",
+      "controlPlaneInstanceId": "cp-1",
+      "connectTime": "2019-07-01T00:00:00Z",
+      "status": {
+       "total": {},
+       "cds": {},
+       "eds": {},
+       "lds": {},
+       "rds": {}
+      }
+     }
+    ]
+   }
+  },
+  {
+   "type": "DataplaneOverview",
+   "mesh": "mesh1",
+   "name": "gateway-delegated",
+   "creationTime": "2018-07-17T16:05:36.995Z",
+   "modificationTime": "2018-07-17T16:05:36.995Z",
+   "dataplane": {
+    "networking": {
+     "address": "127.0.0.1",
+     "gateway": {
+      "tags": {
+       "service": "gateway"
+      }
+     }
+    }
+   },
+   "dataplaneInsight": {
+    "subscriptions": [
+     {
+      "id": "stream-id-1",
+      "controlPlaneInstanceId": "cp-1",
+      "connectTime": "2019-07-01T00:00:00Z",
+      "status": {
+       "total": {},
+       "cds": {},
+       "eds": {},
+       "lds": {},
+       "rds": {}
+      }
+     }
+    ]
+   }
+  }
+ ],
+ "next": null
+}

--- a/pkg/api-server/testdata/_meshes_mesh1_dataplanes+insights?gateway=builtin.json
+++ b/pkg/api-server/testdata/_meshes_mesh1_dataplanes+insights?gateway=builtin.json
@@ -1,0 +1,40 @@
+{
+ "total": 1,
+ "items": [
+  {
+   "type": "DataplaneOverview",
+   "mesh": "mesh1",
+   "name": "gateway-builtin",
+   "creationTime": "2018-07-17T16:05:36.995Z",
+   "modificationTime": "2018-07-17T16:05:36.995Z",
+   "dataplane": {
+    "networking": {
+     "address": "127.0.0.1",
+     "gateway": {
+      "tags": {
+       "service": "gateway"
+      },
+      "type": "BUILTIN"
+     }
+    }
+   },
+   "dataplaneInsight": {
+    "subscriptions": [
+     {
+      "id": "stream-id-1",
+      "controlPlaneInstanceId": "cp-1",
+      "connectTime": "2019-07-01T00:00:00Z",
+      "status": {
+       "total": {},
+       "cds": {},
+       "eds": {},
+       "lds": {},
+       "rds": {}
+      }
+     }
+    ]
+   }
+  }
+ ],
+ "next": null
+}

--- a/pkg/api-server/testdata/_meshes_mesh1_dataplanes+insights?gateway=delegated.json
+++ b/pkg/api-server/testdata/_meshes_mesh1_dataplanes+insights?gateway=delegated.json
@@ -1,0 +1,39 @@
+{
+ "total": 1,
+ "items": [
+  {
+   "type": "DataplaneOverview",
+   "mesh": "mesh1",
+   "name": "gateway-delegated",
+   "creationTime": "2018-07-17T16:05:36.995Z",
+   "modificationTime": "2018-07-17T16:05:36.995Z",
+   "dataplane": {
+    "networking": {
+     "address": "127.0.0.1",
+     "gateway": {
+      "tags": {
+       "service": "gateway"
+      }
+     }
+    }
+   },
+   "dataplaneInsight": {
+    "subscriptions": [
+     {
+      "id": "stream-id-1",
+      "controlPlaneInstanceId": "cp-1",
+      "connectTime": "2019-07-01T00:00:00Z",
+      "status": {
+       "total": {},
+       "cds": {},
+       "eds": {},
+       "lds": {},
+       "rds": {}
+      }
+     }
+    ]
+   }
+  }
+ ],
+ "next": null
+}

--- a/pkg/api-server/testdata/_meshes_mesh1_dataplanes+insights?gateway=true.json
+++ b/pkg/api-server/testdata/_meshes_mesh1_dataplanes+insights?gateway=true.json
@@ -1,0 +1,73 @@
+{
+ "total": 2,
+ "items": [
+  {
+   "type": "DataplaneOverview",
+   "mesh": "mesh1",
+   "name": "gateway-builtin",
+   "creationTime": "2018-07-17T16:05:36.995Z",
+   "modificationTime": "2018-07-17T16:05:36.995Z",
+   "dataplane": {
+    "networking": {
+     "address": "127.0.0.1",
+     "gateway": {
+      "tags": {
+       "service": "gateway"
+      },
+      "type": "BUILTIN"
+     }
+    }
+   },
+   "dataplaneInsight": {
+    "subscriptions": [
+     {
+      "id": "stream-id-1",
+      "controlPlaneInstanceId": "cp-1",
+      "connectTime": "2019-07-01T00:00:00Z",
+      "status": {
+       "total": {},
+       "cds": {},
+       "eds": {},
+       "lds": {},
+       "rds": {}
+      }
+     }
+    ]
+   }
+  },
+  {
+   "type": "DataplaneOverview",
+   "mesh": "mesh1",
+   "name": "gateway-delegated",
+   "creationTime": "2018-07-17T16:05:36.995Z",
+   "modificationTime": "2018-07-17T16:05:36.995Z",
+   "dataplane": {
+    "networking": {
+     "address": "127.0.0.1",
+     "gateway": {
+      "tags": {
+       "service": "gateway"
+      }
+     }
+    }
+   },
+   "dataplaneInsight": {
+    "subscriptions": [
+     {
+      "id": "stream-id-1",
+      "controlPlaneInstanceId": "cp-1",
+      "connectTime": "2019-07-01T00:00:00Z",
+      "status": {
+       "total": {},
+       "cds": {},
+       "eds": {},
+       "lds": {},
+       "rds": {}
+      }
+     }
+    ]
+   }
+  }
+ ],
+ "next": null
+}

--- a/pkg/api-server/testdata/_meshes_mesh1_dataplanes+insights?name=gateway.json
+++ b/pkg/api-server/testdata/_meshes_mesh1_dataplanes+insights?name=gateway.json
@@ -1,0 +1,73 @@
+{
+ "total": 2,
+ "items": [
+  {
+   "type": "DataplaneOverview",
+   "mesh": "mesh1",
+   "name": "gateway-builtin",
+   "creationTime": "2018-07-17T16:05:36.995Z",
+   "modificationTime": "2018-07-17T16:05:36.995Z",
+   "dataplane": {
+    "networking": {
+     "address": "127.0.0.1",
+     "gateway": {
+      "tags": {
+       "service": "gateway"
+      },
+      "type": "BUILTIN"
+     }
+    }
+   },
+   "dataplaneInsight": {
+    "subscriptions": [
+     {
+      "id": "stream-id-1",
+      "controlPlaneInstanceId": "cp-1",
+      "connectTime": "2019-07-01T00:00:00Z",
+      "status": {
+       "total": {},
+       "cds": {},
+       "eds": {},
+       "lds": {},
+       "rds": {}
+      }
+     }
+    ]
+   }
+  },
+  {
+   "type": "DataplaneOverview",
+   "mesh": "mesh1",
+   "name": "gateway-delegated",
+   "creationTime": "2018-07-17T16:05:36.995Z",
+   "modificationTime": "2018-07-17T16:05:36.995Z",
+   "dataplane": {
+    "networking": {
+     "address": "127.0.0.1",
+     "gateway": {
+      "tags": {
+       "service": "gateway"
+      }
+     }
+    }
+   },
+   "dataplaneInsight": {
+    "subscriptions": [
+     {
+      "id": "stream-id-1",
+      "controlPlaneInstanceId": "cp-1",
+      "connectTime": "2019-07-01T00:00:00Z",
+      "status": {
+       "total": {},
+       "cds": {},
+       "eds": {},
+       "lds": {},
+       "rds": {}
+      }
+     }
+    ]
+   }
+  }
+ ],
+ "next": null
+}

--- a/pkg/api-server/testdata/_meshes_mesh1_dataplanes+insights?name=tew.json
+++ b/pkg/api-server/testdata/_meshes_mesh1_dataplanes+insights?name=tew.json
@@ -1,0 +1,73 @@
+{
+ "total": 2,
+ "items": [
+  {
+   "type": "DataplaneOverview",
+   "mesh": "mesh1",
+   "name": "gateway-builtin",
+   "creationTime": "2018-07-17T16:05:36.995Z",
+   "modificationTime": "2018-07-17T16:05:36.995Z",
+   "dataplane": {
+    "networking": {
+     "address": "127.0.0.1",
+     "gateway": {
+      "tags": {
+       "service": "gateway"
+      },
+      "type": "BUILTIN"
+     }
+    }
+   },
+   "dataplaneInsight": {
+    "subscriptions": [
+     {
+      "id": "stream-id-1",
+      "controlPlaneInstanceId": "cp-1",
+      "connectTime": "2019-07-01T00:00:00Z",
+      "status": {
+       "total": {},
+       "cds": {},
+       "eds": {},
+       "lds": {},
+       "rds": {}
+      }
+     }
+    ]
+   }
+  },
+  {
+   "type": "DataplaneOverview",
+   "mesh": "mesh1",
+   "name": "gateway-delegated",
+   "creationTime": "2018-07-17T16:05:36.995Z",
+   "modificationTime": "2018-07-17T16:05:36.995Z",
+   "dataplane": {
+    "networking": {
+     "address": "127.0.0.1",
+     "gateway": {
+      "tags": {
+       "service": "gateway"
+      }
+     }
+    }
+   },
+   "dataplaneInsight": {
+    "subscriptions": [
+     {
+      "id": "stream-id-1",
+      "controlPlaneInstanceId": "cp-1",
+      "connectTime": "2019-07-01T00:00:00Z",
+      "status": {
+       "total": {},
+       "cds": {},
+       "eds": {},
+       "lds": {},
+       "rds": {}
+      }
+     }
+    ]
+   }
+  }
+ ],
+ "next": null
+}

--- a/pkg/api-server/testdata/_meshes_mesh1_dataplanes+insights?tag=service:backend&tag=version:v1.json
+++ b/pkg/api-server/testdata/_meshes_mesh1_dataplanes+insights?tag=service:backend&tag=version:v1.json
@@ -1,0 +1,66 @@
+{
+ "total": 2,
+ "items": [
+  {
+   "type": "DataplaneOverview",
+   "mesh": "mesh1",
+   "name": "dp-1",
+   "creationTime": "2018-07-17T16:05:36.995Z",
+   "modificationTime": "2018-07-17T16:05:36.995Z",
+   "dataplane": {
+    "networking": {
+     "address": "127.0.0.1",
+     "inbound": [
+      {
+       "port": 1234,
+       "tags": {
+        "service": "backend",
+        "tagcolumn": "tag:v",
+        "version": "v1"
+       }
+      }
+     ]
+    }
+   },
+   "dataplaneInsight": {
+    "subscriptions": [
+     {
+      "id": "stream-id-1",
+      "controlPlaneInstanceId": "cp-1",
+      "connectTime": "2019-07-01T00:00:00Z",
+      "status": {
+       "total": {},
+       "cds": {},
+       "eds": {},
+       "lds": {},
+       "rds": {}
+      }
+     }
+    ]
+   }
+  },
+  {
+   "type": "DataplaneOverview",
+   "mesh": "mesh1",
+   "name": "dp-no-insights",
+   "creationTime": "2018-07-17T16:05:36.995Z",
+   "modificationTime": "2018-07-17T16:05:36.995Z",
+   "dataplane": {
+    "networking": {
+     "address": "127.0.0.1",
+     "inbound": [
+      {
+       "port": 1234,
+       "tags": {
+        "service": "backend",
+        "tagcolumn": "tag:v",
+        "version": "v1"
+       }
+      }
+     ]
+    }
+   }
+  }
+ ],
+ "next": null
+}

--- a/pkg/api-server/testdata/_meshes_mesh1_dataplanes+insights?tag=service:backend&tag=version:v2.json
+++ b/pkg/api-server/testdata/_meshes_mesh1_dataplanes+insights?tag=service:backend&tag=version:v2.json
@@ -1,0 +1,5 @@
+{
+ "total": 0,
+ "items": [],
+ "next": null
+}

--- a/pkg/api-server/testdata/_meshes_mesh1_dataplanes+insights?tag=service:backend.json
+++ b/pkg/api-server/testdata/_meshes_mesh1_dataplanes+insights?tag=service:backend.json
@@ -1,0 +1,66 @@
+{
+ "total": 2,
+ "items": [
+  {
+   "type": "DataplaneOverview",
+   "mesh": "mesh1",
+   "name": "dp-1",
+   "creationTime": "2018-07-17T16:05:36.995Z",
+   "modificationTime": "2018-07-17T16:05:36.995Z",
+   "dataplane": {
+    "networking": {
+     "address": "127.0.0.1",
+     "inbound": [
+      {
+       "port": 1234,
+       "tags": {
+        "service": "backend",
+        "tagcolumn": "tag:v",
+        "version": "v1"
+       }
+      }
+     ]
+    }
+   },
+   "dataplaneInsight": {
+    "subscriptions": [
+     {
+      "id": "stream-id-1",
+      "controlPlaneInstanceId": "cp-1",
+      "connectTime": "2019-07-01T00:00:00Z",
+      "status": {
+       "total": {},
+       "cds": {},
+       "eds": {},
+       "lds": {},
+       "rds": {}
+      }
+     }
+    ]
+   }
+  },
+  {
+   "type": "DataplaneOverview",
+   "mesh": "mesh1",
+   "name": "dp-no-insights",
+   "creationTime": "2018-07-17T16:05:36.995Z",
+   "modificationTime": "2018-07-17T16:05:36.995Z",
+   "dataplane": {
+    "networking": {
+     "address": "127.0.0.1",
+     "inbound": [
+      {
+       "port": 1234,
+       "tags": {
+        "service": "backend",
+        "tagcolumn": "tag:v",
+        "version": "v1"
+       }
+      }
+     ]
+    }
+   }
+  }
+ ],
+ "next": null
+}

--- a/pkg/api-server/testdata/_meshes_mesh1_dataplanes+insights?tag=service:ck.json
+++ b/pkg/api-server/testdata/_meshes_mesh1_dataplanes+insights?tag=service:ck.json
@@ -1,0 +1,66 @@
+{
+ "total": 2,
+ "items": [
+  {
+   "type": "DataplaneOverview",
+   "mesh": "mesh1",
+   "name": "dp-1",
+   "creationTime": "2018-07-17T16:05:36.995Z",
+   "modificationTime": "2018-07-17T16:05:36.995Z",
+   "dataplane": {
+    "networking": {
+     "address": "127.0.0.1",
+     "inbound": [
+      {
+       "port": 1234,
+       "tags": {
+        "service": "backend",
+        "tagcolumn": "tag:v",
+        "version": "v1"
+       }
+      }
+     ]
+    }
+   },
+   "dataplaneInsight": {
+    "subscriptions": [
+     {
+      "id": "stream-id-1",
+      "controlPlaneInstanceId": "cp-1",
+      "connectTime": "2019-07-01T00:00:00Z",
+      "status": {
+       "total": {},
+       "cds": {},
+       "eds": {},
+       "lds": {},
+       "rds": {}
+      }
+     }
+    ]
+   }
+  },
+  {
+   "type": "DataplaneOverview",
+   "mesh": "mesh1",
+   "name": "dp-no-insights",
+   "creationTime": "2018-07-17T16:05:36.995Z",
+   "modificationTime": "2018-07-17T16:05:36.995Z",
+   "dataplane": {
+    "networking": {
+     "address": "127.0.0.1",
+     "inbound": [
+      {
+       "port": 1234,
+       "tags": {
+        "service": "backend",
+        "tagcolumn": "tag:v",
+        "version": "v1"
+       }
+      }
+     ]
+    }
+   }
+  }
+ ],
+ "next": null
+}

--- a/pkg/api-server/testdata/_meshes_mesh1_dataplanes+insights?tag=tagcolumn:tag:v.json
+++ b/pkg/api-server/testdata/_meshes_mesh1_dataplanes+insights?tag=tagcolumn:tag:v.json
@@ -1,0 +1,66 @@
+{
+ "total": 2,
+ "items": [
+  {
+   "type": "DataplaneOverview",
+   "mesh": "mesh1",
+   "name": "dp-1",
+   "creationTime": "2018-07-17T16:05:36.995Z",
+   "modificationTime": "2018-07-17T16:05:36.995Z",
+   "dataplane": {
+    "networking": {
+     "address": "127.0.0.1",
+     "inbound": [
+      {
+       "port": 1234,
+       "tags": {
+        "service": "backend",
+        "tagcolumn": "tag:v",
+        "version": "v1"
+       }
+      }
+     ]
+    }
+   },
+   "dataplaneInsight": {
+    "subscriptions": [
+     {
+      "id": "stream-id-1",
+      "controlPlaneInstanceId": "cp-1",
+      "connectTime": "2019-07-01T00:00:00Z",
+      "status": {
+       "total": {},
+       "cds": {},
+       "eds": {},
+       "lds": {},
+       "rds": {}
+      }
+     }
+    ]
+   }
+  },
+  {
+   "type": "DataplaneOverview",
+   "mesh": "mesh1",
+   "name": "dp-no-insights",
+   "creationTime": "2018-07-17T16:05:36.995Z",
+   "modificationTime": "2018-07-17T16:05:36.995Z",
+   "dataplane": {
+    "networking": {
+     "address": "127.0.0.1",
+     "inbound": [
+      {
+       "port": 1234,
+       "tags": {
+        "service": "backend",
+        "tagcolumn": "tag:v",
+        "version": "v1"
+       }
+      }
+     ]
+    }
+   }
+  }
+ ],
+ "next": null
+}

--- a/pkg/core/resources/apis/mesh/zz_generated.resources.go
+++ b/pkg/core/resources/apis/mesh/zz_generated.resources.go
@@ -5,6 +5,7 @@
 package mesh
 
 import (
+	"errors"
 	"fmt"
 
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
@@ -398,10 +399,17 @@ func (t *DataplaneOverviewResource) Descriptor() model.ResourceTypeDescriptor {
 
 func (t *DataplaneOverviewResource) SetOverviewSpec(resource model.Resource, insight model.Resource) error {
 	t.SetMeta(resource.GetMeta())
-	return t.SetSpec(&mesh_proto.DataplaneOverview{
-		Dataplane:        resource.GetSpec().(*mesh_proto.Dataplane),
-		DataplaneInsight: insight.GetSpec().(*mesh_proto.DataplaneInsight),
-	})
+	overview := &mesh_proto.DataplaneOverview{
+		Dataplane: resource.GetSpec().(*mesh_proto.Dataplane),
+	}
+	if insight != nil {
+		ins, ok := insight.GetSpec().(*mesh_proto.DataplaneInsight)
+		if !ok {
+			return errors.New("failed to convert to insight type 'DataplaneInsight'")
+		}
+		overview.DataplaneInsight = ins
+	}
+	return t.SetSpec(overview)
 }
 
 var _ model.ResourceList = &DataplaneOverviewResourceList{}
@@ -2770,10 +2778,17 @@ func (t *ZoneEgressOverviewResource) Descriptor() model.ResourceTypeDescriptor {
 
 func (t *ZoneEgressOverviewResource) SetOverviewSpec(resource model.Resource, insight model.Resource) error {
 	t.SetMeta(resource.GetMeta())
-	return t.SetSpec(&mesh_proto.ZoneEgressOverview{
-		ZoneEgress:        resource.GetSpec().(*mesh_proto.ZoneEgress),
-		ZoneEgressInsight: insight.GetSpec().(*mesh_proto.ZoneEgressInsight),
-	})
+	overview := &mesh_proto.ZoneEgressOverview{
+		ZoneEgress: resource.GetSpec().(*mesh_proto.ZoneEgress),
+	}
+	if insight != nil {
+		ins, ok := insight.GetSpec().(*mesh_proto.ZoneEgressInsight)
+		if !ok {
+			return errors.New("failed to convert to insight type 'ZoneEgressInsight'")
+		}
+		overview.ZoneEgressInsight = ins
+	}
+	return t.SetSpec(overview)
 }
 
 var _ model.ResourceList = &ZoneEgressOverviewResourceList{}
@@ -3102,10 +3117,17 @@ func (t *ZoneIngressOverviewResource) Descriptor() model.ResourceTypeDescriptor 
 
 func (t *ZoneIngressOverviewResource) SetOverviewSpec(resource model.Resource, insight model.Resource) error {
 	t.SetMeta(resource.GetMeta())
-	return t.SetSpec(&mesh_proto.ZoneIngressOverview{
-		ZoneIngress:        resource.GetSpec().(*mesh_proto.ZoneIngress),
-		ZoneIngressInsight: insight.GetSpec().(*mesh_proto.ZoneIngressInsight),
-	})
+	overview := &mesh_proto.ZoneIngressOverview{
+		ZoneIngress: resource.GetSpec().(*mesh_proto.ZoneIngress),
+	}
+	if insight != nil {
+		ins, ok := insight.GetSpec().(*mesh_proto.ZoneIngressInsight)
+		if !ok {
+			return errors.New("failed to convert to insight type 'ZoneIngressInsight'")
+		}
+		overview.ZoneIngressInsight = ins
+	}
+	return t.SetSpec(overview)
 }
 
 var _ model.ResourceList = &ZoneIngressOverviewResourceList{}

--- a/pkg/core/resources/apis/system/zz_generated.resources.go
+++ b/pkg/core/resources/apis/system/zz_generated.resources.go
@@ -5,6 +5,7 @@
 package system
 
 import (
+	"errors"
 	"fmt"
 
 	system_proto "github.com/kumahq/kuma/api/system/v1alpha1"
@@ -497,10 +498,17 @@ func (t *ZoneOverviewResource) Descriptor() model.ResourceTypeDescriptor {
 
 func (t *ZoneOverviewResource) SetOverviewSpec(resource model.Resource, insight model.Resource) error {
 	t.SetMeta(resource.GetMeta())
-	return t.SetSpec(&system_proto.ZoneOverview{
-		Zone:        resource.GetSpec().(*system_proto.Zone),
-		ZoneInsight: insight.GetSpec().(*system_proto.ZoneInsight),
-	})
+	overview := &system_proto.ZoneOverview{
+		Zone: resource.GetSpec().(*system_proto.Zone),
+	}
+	if insight != nil {
+		ins, ok := insight.GetSpec().(*system_proto.ZoneInsight)
+		if !ok {
+			return errors.New("failed to convert to insight type 'ZoneInsight'")
+		}
+		overview.ZoneInsight = ins
+	}
+	return t.SetSpec(overview)
 }
 
 var _ model.ResourceList = &ZoneOverviewResourceList{}

--- a/tools/resource-gen/main.go
+++ b/tools/resource-gen/main.go
@@ -193,6 +193,7 @@ var ResourceTemplate = template.Must(template.New("resource").Funcs(map[string]a
 package {{.Package}}
 
 import (
+	"errors"
 	"fmt"
 
 	{{$pkg}} "github.com/kumahq/kuma/api/{{.Package}}/v1alpha1"
@@ -260,10 +261,17 @@ func (t *{{.ResourceName}}) Descriptor() model.ResourceTypeDescriptor {
 
 func (t *{{.ResourceName}}) SetOverviewSpec(resource model.Resource, insight model.Resource) error {
 	t.SetMeta(resource.GetMeta())
-	return t.SetSpec(&{{$pkg}}.{{.ProtoType}}{
+	overview := &{{$pkg}}.{{.ProtoType}}{
 		{{$baseType}}: resource.GetSpec().(*{{$pkg}}.{{$baseType}}),
-		{{$baseType}}Insight: insight.GetSpec().(*{{$pkg}}.{{$baseType}}Insight),
-	})
+	}
+	if insight != nil {
+		ins, ok := insight.GetSpec().(*{{$pkg}}.{{$baseType}}Insight)
+		if !ok {
+			return errors.New("failed to convert to insight type '{{$baseType}}Insight'")
+		}
+		overview.{{$baseType}}Insight = ins
+	}
+	return t.SetSpec(overview)
 }
 {{- end }}
 


### PR DESCRIPTION
This was causing panic if we ask for the overview before any insight was created.

We've also updated UPGRADE.md to notify of the deprecation

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
