### PR TITLE
ci(security): filter out kuma from security update

### DIFF
--- a/tools/ci/update-vulnerable-dependencies.sh
+++ b/tools/ci/update-vulnerable-dependencies.sh
@@ -9,7 +9,7 @@ for dep in $(osv-scanner --lockfile=go.mod --json | jq -c '.results[].packages[]
   name: $vulnerablePackage,
   current: .package.version,
   fixedVersions: [.vulnerabilities[].affected[] | select(.package.name == $vulnerablePackage) | .ranges[].events[] | select(.fixed != null) | .fixed] | unique
-} | select(.fixedVersions | length > 0)'); do
+} | select(.fixedVersions | length > 0) | select(.name != "github.com/kumahq/kuma")'); do
   IFS=. read -r currentMajor currentMinor currentPatch <<< "$(jq -r .current <<< "$dep")"
   # Update to the first version that's greater than our current version
   for version in $(jq -cr .fixedVersions[] <<< "$dep" | sort -V); do # sort supports semver sort


### PR DESCRIPTION
since the publishing of [our CVE advisory](https://github.com/kumahq/kuma/security/advisories/GHSA-9wmc-rg4h-28wv) in Kuma and it being picked up by osv scanner https://osv.dev/vulnerability/GHSA-9wmc-rg4h-28wv our security update action is failing in parent project (it's trying to update to 2.0.8 per our policy of upgrading deps to the lowest one that is patched).

This PR simply filters out kuma from that job.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues -- not reported via issue
- [X] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [X] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [X] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [X] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) -- yes

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
