### PR TITLE
refactor(kuma-dp): put Corefile into embedded FS

### DIFF
--- a/app/kuma-dp/pkg/dataplane/dnsserver/Corefile
+++ b/app/kuma-dp/pkg/dataplane/dnsserver/Corefile
@@ -1,0 +1,15 @@
+.:{{ .CoreDNSPort }} {
+    forward . 127.0.0.1:{{ .EnvoyDNSPort }}
+    # We want all requests to be sent to the Envoy DNS Filter, unsuccessful responses should be forwarded to the original DNS server.
+    # For example: requests other than A, AAAA and SRV will return NOTIMP when hitting the envoy filter and should be sent to the original DNS server.
+    # Codes from: https://github.com/miekg/dns/blob/master/msg.go#L138
+    alternate NOTIMP,FORMERR,NXDOMAIN,SERVFAIL,REFUSED . /etc/resolv.conf
+    prometheus localhost:{{ .PrometheusPort }}
+    errors
+}
+
+.:{{ .CoreDNSEmptyPort }} {
+    template ANY ANY . {
+      rcode NXDOMAIN
+    }
+}

--- a/app/kuma-dp/pkg/dataplane/dnsserver/config_file.go
+++ b/app/kuma-dp/pkg/dataplane/dnsserver/config_file.go
@@ -1,6 +1,7 @@
 package dnsserver
 
 import (
+	"embed"
 	"os"
 	"path/filepath"
 
@@ -8,6 +9,9 @@ import (
 
 	kuma_dp "github.com/kumahq/kuma/pkg/config/app/kuma-dp"
 )
+
+//go:embed Corefile
+var config embed.FS
 
 func GenerateConfigFile(cfg kuma_dp.DNS, config []byte) (string, error) {
 	configFile := filepath.Join(cfg.ConfigDir, "Corefile")

--- a/app/kuma-dp/pkg/dataplane/dnsserver/dnsserver_test.go
+++ b/app/kuma-dp/pkg/dataplane/dnsserver/dnsserver_test.go
@@ -132,7 +132,8 @@ var _ = Describe("DNS Server", func() {
     template ANY ANY . {
       rcode NXDOMAIN
     }
-}`))
+}
+`))
 		}))
 
 		It("should return an error if DNS Server crashes", test.Within(10*time.Second, func() {


### PR DESCRIPTION
We can link to this file directly instead of having it copy pasted in the docs.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
