### PR TITLE
fix(kuma-cp): fix Zone{In|E}gress sync when no mesh

### DIFF
--- a/pkg/xds/context/mesh_context_builder.go
+++ b/pkg/xds/context/mesh_context_builder.go
@@ -329,19 +329,19 @@ func (m *meshContextBuilder) hash(mesh *core_mesh.MeshResource, resources Resour
 			allResources = append(allResources, rl.GetItems()...)
 		}
 	}
-	return sha256.Hash(m.hashResources(allResources...))
+	return sha256.Hash(hashResources(allResources...))
 }
 
-func (m *meshContextBuilder) hashResources(rs ...core_model.Resource) string {
-	hashes := []string{}
+func hashResources(rs ...core_model.Resource) string {
+	var hashes []string
 	for _, r := range rs {
-		hashes = append(hashes, m.hashResource(r))
+		hashes = append(hashes, hashResource(r))
 	}
 	sort.Strings(hashes)
 	return strings.Join(hashes, ",")
 }
 
-func (m *meshContextBuilder) hashResource(r core_model.Resource) string {
+func hashResource(r core_model.Resource) string {
 	switch v := r.(type) {
 	// In case of hashing Dataplane we are also adding '.Spec.Networking.Address' and `.Spec.Networking.Ingress.PublicAddress` into hash.
 	// The address could be a domain name and right now we resolve it right after fetching

--- a/pkg/xds/sync/dataplane_watchdog.go
+++ b/pkg/xds/sync/dataplane_watchdog.go
@@ -180,9 +180,9 @@ func (d *DataplaneWatchdog) syncIngress(ctx context.Context, metadata *core_xds.
 		result.Status = SkipStatus
 		return result, nil
 	}
-	if syncForConfig {
-		d.log.V(1).Info("snapshot hash updated, reconcile", "prev", d.lastHash, "current", aggregatedMeshCtxs.Hash)
-	}
+
+	d.log.V(1).Info("snapshot hash updated, reconcile", "prev", d.lastHash, "current", aggregatedMeshCtxs.Hash)
+	d.lastHash = aggregatedMeshCtxs.Hash
 
 	proxy, err := d.IngressProxyBuilder.Build(ctx, d.key, aggregatedMeshCtxs)
 	if err != nil {
@@ -228,9 +228,9 @@ func (d *DataplaneWatchdog) syncEgress(ctx context.Context, metadata *core_xds.D
 		result.Status = SkipStatus
 		return result, nil
 	}
-	if syncForConfig {
-		d.log.V(1).Info("snapshot hash updated, reconcile", "prev", d.lastHash, "current", aggregatedMeshCtxs.Hash)
-	}
+
+	d.log.V(1).Info("snapshot hash updated, reconcile", "prev", d.lastHash, "current", aggregatedMeshCtxs.Hash)
+	d.lastHash = aggregatedMeshCtxs.Hash
 
 	proxy, err := d.EgressProxyBuilder.Build(ctx, d.key, aggregatedMeshCtxs)
 	if err != nil {

--- a/pkg/xds/sync/egress_proxy_builder.go
+++ b/pkg/xds/sync/egress_proxy_builder.go
@@ -30,7 +30,7 @@ func (p *EgressProxyBuilder) Build(
 ) (*core_xds.Proxy, error) {
 	zoneEgress, ok := aggregatedMeshCtxs.ZoneEgressByName[key.Name]
 	if !ok {
-		return nil, core_store.ErrorResourceNotFound(core_mesh.DataplaneType, key.Name, key.Mesh)
+		return nil, core_store.ErrorResourceNotFound(core_mesh.ZoneEgressType, key.Name, key.Mesh)
 	}
 
 	// As egress is using SNI to identify the services, we need to filter out


### PR DESCRIPTION
- Add ZoneEgresses to AggregatetMeshContexts when there is no mesh.
- Sync ZoneIngresses and ZoneEgresses only when the hash changes.
- Return an error with the correct resource type (ZoneEgress) when a ZoneEgress cannot be found.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues
  - No relevant issue
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS
  - It won't
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s)
  - Don't forget `ci/` labels to run additional/fewer tests
  - Manually tested on k3d
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)?
  - There is no need
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label)
  - It does

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
