### PR TITLE
chore(xds): improve error logging

### DIFF
--- a/pkg/core/permissions/matcher.go
+++ b/pkg/core/permissions/matcher.go
@@ -54,7 +54,7 @@ func MatchExternalServicesTrafficPermissions(
 	dataplane *core_mesh.DataplaneResource,
 	externalServices *core_mesh.ExternalServiceResourceList,
 	permissions *core_mesh.TrafficPermissionResourceList,
-) ([]*core_mesh.ExternalServiceResource, error) {
+) []*core_mesh.ExternalServiceResource {
 	var matchedExternalServices []*core_mesh.ExternalServiceResource
 
 	externalServicePermissions := BuildExternalServicesPermissionsMap(externalServices, permissions.Items)
@@ -73,7 +73,7 @@ func MatchExternalServicesTrafficPermissions(
 			matchedExternalServices = append(matchedExternalServices, externalService)
 		}
 	}
-	return matchedExternalServices, nil
+	return matchedExternalServices
 }
 
 type ExternalServicePermissions map[string]*core_mesh.TrafficPermissionResource

--- a/pkg/core/permissions/matcher_test.go
+++ b/pkg/core/permissions/matcher_test.go
@@ -204,8 +204,7 @@ var _ = Describe("Match", func() {
 				tp := &core_mesh.TrafficPermissionResourceList{
 					Items: given.policies,
 				}
-				matchedEs, err := permissions.MatchExternalServicesTrafficPermissions(given.dataplane, es, tp)
-				Expect(err).ToNot(HaveOccurred())
+				matchedEs := permissions.MatchExternalServicesTrafficPermissions(given.dataplane, es, tp)
 
 				Expect(given.expected).To(HaveLen(len(matchedEs)))
 				for _, externalService := range matchedEs {

--- a/pkg/plugins/runtime/gateway/generator.go
+++ b/pkg/plugins/runtime/gateway/generator.go
@@ -107,9 +107,7 @@ func (g *FilterChainGenerators) For(ctx xds_context.Context, info GatewayListene
 // policies.
 func gatewayListenerInfoFromProxy(
 	ctx context.Context, meshCtx *xds_context.MeshContext, proxy *core_xds.Proxy,
-) (
-	[]GatewayListenerInfo, error,
-) {
+) []GatewayListenerInfo {
 	gateway := xds_topology.SelectGateway(meshCtx.Resources.Gateways().Items, proxy.Dataplane.Spec.Matches)
 
 	if gateway == nil {
@@ -119,7 +117,7 @@ func gatewayListenerInfoFromProxy(
 			"service", proxy.Dataplane.Spec.GetIdentifyingService(),
 		)
 
-		return nil, nil
+		return nil
 	}
 
 	log.V(1).Info(fmt.Sprintf("matched gateway %q to dataplane %q",
@@ -147,12 +145,9 @@ func gatewayListenerInfoFromProxy(
 
 	var listenerInfos []GatewayListenerInfo
 
-	matchedExternalServices, err := permissions.MatchExternalServicesTrafficPermissions(
+	matchedExternalServices := permissions.MatchExternalServicesTrafficPermissions(
 		proxy.Dataplane, externalServices, meshCtx.Resources.TrafficPermissions(),
 	)
-	if err != nil {
-		return nil, errors.Wrap(err, "unable to find external services matched by traffic permissions")
-	}
 
 	outboundEndpoints := core_xds.EndpointMap{}
 	for k, v := range meshCtx.EndpointMap {
@@ -197,7 +192,7 @@ func gatewayListenerInfoFromProxy(
 		})
 	}
 
-	return listenerInfos, nil
+	return listenerInfos
 }
 
 func (g Generator) Generate(ctx context.Context, xdsCtx xds_context.Context, proxy *core_xds.Proxy) (*core_xds.ResourceSet, error) {

--- a/pkg/plugins/runtime/gateway/plugin.go
+++ b/pkg/plugins/runtime/gateway/plugin.go
@@ -49,13 +49,7 @@ func (p *plugin) Apply(ctx context.Context, meshContext xds_context.MeshContext,
 	if proxy.Dataplane == nil || !proxy.Dataplane.Spec.IsBuiltinGateway() {
 		return nil
 	}
-	l, err := gatewayListenerInfoFromProxy(
-		ctx, &meshContext, proxy,
-	)
-	if err != nil {
-		return err
-	}
-	proxy.RuntimeExtensions[metadata.PluginName] = l
+	proxy.RuntimeExtensions[metadata.PluginName] = gatewayListenerInfoFromProxy(ctx, &meshContext, proxy)
 	return nil
 }
 

--- a/pkg/xds/context/mesh_context_builder.go
+++ b/pkg/xds/context/mesh_context_builder.go
@@ -5,6 +5,8 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/pkg/errors"
+
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	"github.com/kumahq/kuma/pkg/core"
 	"github.com/kumahq/kuma/pkg/core/datasource"
@@ -79,12 +81,12 @@ func (m *meshContextBuilder) Build(ctx context.Context, meshName string) (MeshCo
 func (m *meshContextBuilder) BuildIfChanged(ctx context.Context, meshName string, latestMeshCtx *MeshContext) (*MeshContext, error) {
 	mesh := core_mesh.NewMeshResource()
 	if err := m.rm.Get(ctx, mesh, core_store.GetByKey(meshName, core_model.NoMesh)); err != nil {
-		return nil, err
+		return nil, errors.Wrapf(err, "could not fetch mesh %s", meshName)
 	}
 
 	resources, err := m.fetchResources(ctx, mesh)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "could not fetch resources")
 	}
 	m.resolveAddresses(resources)
 
@@ -103,7 +105,7 @@ func (m *meshContextBuilder) BuildIfChanged(ctx context.Context, meshName string
 
 	virtualOutboundView, err := m.vipsPersistence.GetByMesh(ctx, mesh.GetMeta().GetName())
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "could not fetch vips")
 	}
 	// resolve all the domains
 	domains, outbounds := xds_topology.VIPOutbounds(virtualOutboundView, m.topLevelDomain, m.vipPort)
@@ -210,7 +212,7 @@ func (m *meshContextBuilder) fetchResources(ctx context.Context, mesh *core_mesh
 		case core_mesh.MeshType:
 			meshes := &core_mesh.MeshResourceList{}
 			if err := m.rm.List(ctx, meshes, core_store.ListOrdered()); err != nil {
-				return Resources{}, err
+				return Resources{}, errors.Wrap(err, "could not list meshes")
 			}
 			otherMeshes := &core_mesh.MeshResourceList{}
 			for _, someMesh := range meshes.Items {
@@ -224,20 +226,20 @@ func (m *meshContextBuilder) fetchResources(ctx context.Context, mesh *core_mesh
 		case core_mesh.ZoneIngressType:
 			zoneIngresses := &core_mesh.ZoneIngressResourceList{}
 			if err := m.rm.List(ctx, zoneIngresses, core_store.ListOrdered()); err != nil {
-				return Resources{}, err
+				return Resources{}, errors.Wrap(err, "could not list zone ingresses")
 			}
 			resources.MeshLocalResources[typ] = zoneIngresses
 		case core_mesh.ZoneEgressType:
 			zoneEgresses := &core_mesh.ZoneEgressResourceList{}
 			if err := m.rm.List(ctx, zoneEgresses, core_store.ListOrdered()); err != nil {
-				return Resources{}, err
+				return Resources{}, errors.Wrap(err, "could not list zone egresses")
 			}
 			resources.MeshLocalResources[typ] = zoneEgresses
 		case system.ConfigType:
 			configs := &system.ConfigResourceList{}
 			var items []*system.ConfigResource
 			if err := m.rm.List(ctx, configs, core_store.ListOrdered()); err != nil {
-				return Resources{}, err
+				return Resources{}, errors.Wrap(err, "could not list configs")
 			}
 			for _, config := range configs.Items {
 				if configInHash(config.Meta.GetName(), mesh.Meta.GetName()) {
@@ -256,7 +258,7 @@ func (m *meshContextBuilder) fetchResources(ctx context.Context, mesh *core_mesh
 
 			insights := &core_mesh.ServiceInsightResourceList{}
 			if err := m.rm.List(ctx, insights, core_store.ListByMesh(mesh.Meta.GetName()), core_store.ListOrdered()); err != nil {
-				return Resources{}, err
+				return Resources{}, errors.Wrap(err, "could not list service insights")
 			}
 
 			resources.MeshLocalResources[typ] = insights
@@ -266,7 +268,7 @@ func (m *meshContextBuilder) fetchResources(ctx context.Context, mesh *core_mesh
 				return Resources{}, err
 			}
 			if err := m.rm.List(ctx, rlist, core_store.ListByMesh(mesh.Meta.GetName()), core_store.ListOrdered()); err != nil {
-				return Resources{}, err
+				return Resources{}, errors.Wrapf(err, "could not list %s", typ)
 			}
 			resources.MeshLocalResources[typ] = rlist
 		}
@@ -286,7 +288,7 @@ func (m *meshContextBuilder) fetchResources(ctx context.Context, mesh *core_mesh
 				return gateway.(*core_mesh.MeshGatewayResource).Spec.IsCrossMesh()
 			},
 		); err != nil {
-			return Resources{}, err
+			return Resources{}, errors.Wrap(err, "could not fetch cross mesh resources")
 		}
 	}
 	if _, ok := m.typeSet[core_mesh.DataplaneType]; ok {
@@ -302,7 +304,7 @@ func (m *meshContextBuilder) fetchResources(ctx context.Context, mesh *core_mesh
 				return dataplane.(*core_mesh.DataplaneResource).Spec.IsBuiltinGateway()
 			},
 		); err != nil {
-			return Resources{}, err
+			return Resources{}, errors.Wrap(err, "could not fetch cross mesh resources")
 		}
 	}
 

--- a/pkg/xds/sync/dataplane_proxy_builder.go
+++ b/pkg/xds/sync/dataplane_proxy_builder.go
@@ -34,14 +34,11 @@ func (p *DataplaneProxyBuilder) Build(ctx context.Context, key core_model.Resour
 		return nil, core_store.ErrorResourceNotFound(core_mesh.DataplaneType, key.Name, key.Mesh)
 	}
 
-	routing, destinations, err := p.resolveRouting(ctx, meshContext, dp)
-	if err != nil {
-		return nil, err
-	}
+	routing, destinations := p.resolveRouting(ctx, meshContext, dp)
 
 	matchedPolicies, err := p.matchPolicies(meshContext, dp, destinations)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "could not match policies")
 	}
 
 	matchedPolicies.TrafficRoutes = routing.TrafficRoutes
@@ -69,7 +66,7 @@ func (p *DataplaneProxyBuilder) Build(ctx context.Context, key core_model.Resour
 	for k, pl := range core_plugins.Plugins().ProxyPlugins() {
 		err := pl.Apply(ctx, meshContext, proxy)
 		if err != nil {
-			return nil, errors.Wrapf(err, "Failed applying proxy plugin: %s", k)
+			return nil, errors.Wrapf(err, "failed applying proxy plugin: %s", k)
 		}
 	}
 	return proxy, nil
@@ -79,11 +76,8 @@ func (p *DataplaneProxyBuilder) resolveRouting(
 	ctx context.Context,
 	meshContext xds_context.MeshContext,
 	dataplane *core_mesh.DataplaneResource,
-) (*core_xds.Routing, core_xds.DestinationMap, error) {
-	matchedExternalServices, err := permissions.MatchExternalServicesTrafficPermissions(dataplane, meshContext.Resources.ExternalServices(), meshContext.Resources.TrafficPermissions())
-	if err != nil {
-		return nil, nil, err
-	}
+) (*core_xds.Routing, core_xds.DestinationMap) {
+	matchedExternalServices := permissions.MatchExternalServicesTrafficPermissions(dataplane, meshContext.Resources.ExternalServices(), meshContext.Resources.TrafficPermissions())
 
 	p.resolveVIPOutbounds(meshContext, dataplane)
 
@@ -105,7 +99,7 @@ func (p *DataplaneProxyBuilder) resolveRouting(
 		OutboundTargets:                meshContext.EndpointMap,
 		ExternalServiceOutboundTargets: endpointMap,
 	}
-	return routing, destinations, nil
+	return routing, destinations
 }
 
 func (p *DataplaneProxyBuilder) resolveVIPOutbounds(meshContext xds_context.MeshContext, dataplane *core_mesh.DataplaneResource) {


### PR DESCRIPTION
### Checklist prior to review

Improve XDS error handling. One user ended up with such log
```
2023-10-09T17:23:42.781Z	ERROR	xds-server.dataplane-sync-watchdog	OnTick() failed	{"dataplaneKey": {"Mesh":"xxx","Name":"xxx"}, "error": "EOF"}
```
which is not enough context to figure out what is going on.

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [X] [Link to relevant issue][1] as well as docs and UI issues --
- [X] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [X] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [X] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [X] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
