### PR TITLE
fix(kuma-cp): don't unset disconnectTime in ZoneInsight subscriptions

### DIFF
--- a/api/system/v1alpha1/zone_insight_helpers.go
+++ b/api/system/v1alpha1/zone_insight_helpers.go
@@ -66,6 +66,10 @@ func (x *ZoneInsight) UpdateSubscription(s generic.Subscription) error {
 	}
 	i, old := x.GetSubscription(kdsSubscription.Id)
 	if old != nil {
+		// We don't want to unset DisconnectTime
+		if old.DisconnectTime != nil {
+			kdsSubscription.DisconnectTime = old.DisconnectTime
+		}
 		x.Subscriptions[i] = kdsSubscription
 	} else {
 		x.finalizeSubscriptions()


### PR DESCRIPTION
I think [`ZoneInsightSink` can unset `disconnectTime`](https://github.com/kumahq/kuma/blob/152408bf7a8b02d712b25b4b32558b96d7b6f401/pkg/kds/server/status_sink.go#L142) that has been [marked disconnected in `UpdateSubscription`](https://github.com/kumahq/kuma/blob/152408bf7a8b02d712b25b4b32558b96d7b6f401/api/system/v1alpha1/zone_insight_helpers.go#L71) because it doesn't take the value from the current `ZoneInsight` but rather [takes the subscription](https://github.com/kumahq/kuma/blob/152408bf7a8b02d712b25b4b32558b96d7b6f401/pkg/kds/server/status_sink.go#L77) instead [from `streamState`](https://github.com/kumahq/kuma/blob/152408bf7a8b02d712b25b4b32558b96d7b6f401/pkg/kds/server/status_tracker.go#L139).

Changing this in `UpdateSubscription` is one way to ensure this doesn't happen.  

See https://github.com/kumahq/kuma/issues/7535

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
