### PR TITLE
fix(kuma-cp): improve ZoneInsight subscription management

### DIFF
--- a/api/generic/insights.go
+++ b/api/generic/insights.go
@@ -14,6 +14,15 @@ func AllSubscriptions[S Subscription, T interface{ GetSubscriptions() []S }](t T
 	return subs
 }
 
+func GetSubscription[S Subscription, T interface{ GetSubscriptions() []S }](t T, id string) Subscription {
+	for _, s := range t.GetSubscriptions() {
+		if s.GetId() == id {
+			return s
+		}
+	}
+	return nil
+}
+
 type Insight interface {
 	proto.Message
 	IsOnline() bool

--- a/api/generic/insights.go
+++ b/api/generic/insights.go
@@ -6,6 +6,14 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
+func AllSubscriptions[S Subscription, T interface{ GetSubscriptions() []S }](t T) []Subscription {
+	var subs []Subscription
+	for _, s := range t.GetSubscriptions() {
+		subs = append(subs, s)
+	}
+	return subs
+}
+
 type Insight interface {
 	proto.Message
 	IsOnline() bool

--- a/api/generic/insights.go
+++ b/api/generic/insights.go
@@ -9,7 +9,10 @@ import (
 type Insight interface {
 	proto.Message
 	IsOnline() bool
+	// TODO Deprecated: bad
 	GetLastSubscription() Subscription
+	GetSubscription(id string) Subscription
+	GetOnlineSubscriptions() []Subscription
 	UpdateSubscription(Subscription) error
 }
 

--- a/api/generic/insights.go
+++ b/api/generic/insights.go
@@ -9,10 +9,8 @@ import (
 type Insight interface {
 	proto.Message
 	IsOnline() bool
-	// TODO Deprecated: bad
-	GetLastSubscription() Subscription
 	GetSubscription(id string) Subscription
-	GetOnlineSubscriptions() []Subscription
+	AllSubscriptions() []Subscription
 	UpdateSubscription(Subscription) error
 }
 
@@ -20,5 +18,6 @@ type Subscription interface {
 	proto.Message
 	GetId() string
 	GetGeneration() uint32
+	IsOnline() bool
 	SetDisconnectTime(time time.Time)
 }

--- a/api/mesh/v1alpha1/dataplane_insight_helpers.go
+++ b/api/mesh/v1alpha1/dataplane_insight_helpers.go
@@ -57,11 +57,7 @@ func (x *DataplaneInsight) IsOnline() bool {
 }
 
 func (x *DataplaneInsight) AllSubscriptions() []generic.Subscription {
-	var subs []generic.Subscription
-	for _, s := range x.GetSubscriptions() {
-		subs = append(subs, s)
-	}
-	return subs
+	return generic.AllSubscriptions[*DiscoverySubscription](x)
 }
 
 func (x *DataplaneInsight) GetSubscription(id string) generic.Subscription {

--- a/api/mesh/v1alpha1/dataplane_insight_helpers.go
+++ b/api/mesh/v1alpha1/dataplane_insight_helpers.go
@@ -61,12 +61,7 @@ func (x *DataplaneInsight) AllSubscriptions() []generic.Subscription {
 }
 
 func (x *DataplaneInsight) GetSubscription(id string) generic.Subscription {
-	for _, s := range x.GetSubscriptions() {
-		if s.Id == id {
-			return s
-		}
-	}
-	return nil
+	return generic.GetSubscription[*DiscoverySubscription](x, id)
 }
 
 func (x *DataplaneInsight) UpdateCert(generation time.Time, expiration time.Time, issuedBackend string, supportedBackends []string) error {

--- a/api/mesh/v1alpha1/dataplane_insight_helpers.go
+++ b/api/mesh/v1alpha1/dataplane_insight_helpers.go
@@ -56,12 +56,10 @@ func (x *DataplaneInsight) IsOnline() bool {
 	return false
 }
 
-func (x *DataplaneInsight) GetOnlineSubscriptions() []generic.Subscription {
+func (x *DataplaneInsight) AllSubscriptions() []generic.Subscription {
 	var subs []generic.Subscription
 	for _, s := range x.GetSubscriptions() {
-		if s.ConnectTime != nil && s.DisconnectTime == nil {
-			subs = append(subs, s)
-		}
+		subs = append(subs, s)
 	}
 	return subs
 }
@@ -135,6 +133,10 @@ func (x *DataplaneInsight) GetLastSubscription() generic.Subscription {
 
 func (x *DiscoverySubscription) SetDisconnectTime(t time.Time) {
 	x.DisconnectTime = util_proto.MustTimestampProto(t)
+}
+
+func (x *DiscoverySubscription) IsOnline() bool {
+	return x.GetConnectTime() != nil && x.GetDisconnectTime() == nil
 }
 
 func (x *DataplaneInsight) Sum(v func(*DiscoverySubscription) uint64) uint64 {

--- a/api/mesh/v1alpha1/dataplane_insight_helpers_test.go
+++ b/api/mesh/v1alpha1/dataplane_insight_helpers_test.go
@@ -120,8 +120,8 @@ var _ = Describe("DataplaneHelpers", func() {
 				})).To(Succeed())
 
 				// then
-				_, subscription := dataplaneInsight.GetSubscription("2")
-				Expect(subscription.DisconnectTime).ToNot(BeNil())
+				subscription := dataplaneInsight.GetSubscription("2")
+				Expect(subscription.(*DiscoverySubscription).DisconnectTime).ToNot(BeNil())
 			})
 
 			It("should return error for wrong subscription type", func() {

--- a/api/mesh/v1alpha1/zone_ingress_insight_helpers.go
+++ b/api/mesh/v1alpha1/zone_ingress_insight_helpers.go
@@ -58,12 +58,10 @@ func (x *ZoneIngressInsight) IsOnline() bool {
 	return false
 }
 
-func (x *ZoneIngressInsight) GetOnlineSubscriptions() []generic.Subscription {
+func (x *ZoneIngressInsight) AllSubscriptions() []generic.Subscription {
 	var subs []generic.Subscription
 	for _, s := range x.GetSubscriptions() {
-		if s.ConnectTime != nil && s.DisconnectTime == nil {
-			subs = append(subs, s)
-		}
+		subs = append(subs, s)
 	}
 	return subs
 }

--- a/api/mesh/v1alpha1/zone_ingress_insight_helpers.go
+++ b/api/mesh/v1alpha1/zone_ingress_insight_helpers.go
@@ -59,11 +59,7 @@ func (x *ZoneIngressInsight) IsOnline() bool {
 }
 
 func (x *ZoneIngressInsight) AllSubscriptions() []generic.Subscription {
-	var subs []generic.Subscription
-	for _, s := range x.GetSubscriptions() {
-		subs = append(subs, s)
-	}
-	return subs
+	return generic.AllSubscriptions[*DiscoverySubscription](x)
 }
 
 func (x *ZoneIngressInsight) GetLastSubscription() generic.Subscription {

--- a/api/mesh/v1alpha1/zone_ingress_insight_helpers.go
+++ b/api/mesh/v1alpha1/zone_ingress_insight_helpers.go
@@ -9,13 +9,13 @@ import (
 
 var _ generic.Insight = &ZoneIngressInsight{}
 
-func (x *ZoneIngressInsight) GetSubscription(id string) (int, *DiscoverySubscription) {
-	for i, s := range x.GetSubscriptions() {
+func (x *ZoneIngressInsight) GetSubscription(id string) generic.Subscription {
+	for _, s := range x.GetSubscriptions() {
 		if s.Id == id {
-			return i, s
+			return s
 		}
 	}
-	return -1, nil
+	return nil
 }
 
 func (x *ZoneIngressInsight) UpdateSubscription(s generic.Subscription) error {
@@ -26,13 +26,14 @@ func (x *ZoneIngressInsight) UpdateSubscription(s generic.Subscription) error {
 	if !ok {
 		return errors.Errorf("invalid type %T for ZoneIngressInsight", s)
 	}
-	i, old := x.GetSubscription(discoverySubscription.Id)
-	if old != nil {
-		x.Subscriptions[i] = discoverySubscription
-	} else {
-		x.finalizeSubscriptions()
-		x.Subscriptions = append(x.Subscriptions, discoverySubscription)
+	for i, sub := range x.GetSubscriptions() {
+		if sub.GetId() == discoverySubscription.Id {
+			x.Subscriptions[i] = discoverySubscription
+			return nil
+		}
 	}
+	x.finalizeSubscriptions()
+	x.Subscriptions = append(x.Subscriptions, discoverySubscription)
 	return nil
 }
 
@@ -55,6 +56,16 @@ func (x *ZoneIngressInsight) IsOnline() bool {
 		}
 	}
 	return false
+}
+
+func (x *ZoneIngressInsight) GetOnlineSubscriptions() []generic.Subscription {
+	var subs []generic.Subscription
+	for _, s := range x.GetSubscriptions() {
+		if s.ConnectTime != nil && s.DisconnectTime == nil {
+			subs = append(subs, s)
+		}
+	}
+	return subs
 }
 
 func (x *ZoneIngressInsight) GetLastSubscription() generic.Subscription {

--- a/api/mesh/v1alpha1/zone_ingress_insight_helpers.go
+++ b/api/mesh/v1alpha1/zone_ingress_insight_helpers.go
@@ -10,12 +10,7 @@ import (
 var _ generic.Insight = &ZoneIngressInsight{}
 
 func (x *ZoneIngressInsight) GetSubscription(id string) generic.Subscription {
-	for _, s := range x.GetSubscriptions() {
-		if s.Id == id {
-			return s
-		}
-	}
-	return nil
+	return generic.GetSubscription[*DiscoverySubscription](x, id)
 }
 
 func (x *ZoneIngressInsight) UpdateSubscription(s generic.Subscription) error {

--- a/api/mesh/v1alpha1/zone_ingress_insight_helpers_test.go
+++ b/api/mesh/v1alpha1/zone_ingress_insight_helpers_test.go
@@ -38,8 +38,8 @@ var _ = Describe("Zone Ingress Insights", func() {
 			})).To(Succeed())
 
 			// then
-			_, subscription := zoneInsight.GetSubscription("2")
-			Expect(subscription.DisconnectTime).ToNot(BeNil())
+			subscription := zoneInsight.GetSubscription("2")
+			Expect(subscription.(*mesh_proto.DiscoverySubscription).DisconnectTime).ToNot(BeNil())
 		})
 
 		It("should return error for wrong subscription type", func() {

--- a/api/mesh/v1alpha1/zoneegressinsight_helpers.go
+++ b/api/mesh/v1alpha1/zoneegressinsight_helpers.go
@@ -58,7 +58,7 @@ func (x *ZoneEgressInsight) IsOnline() bool {
 	return false
 }
 
-func (x *ZoneEgressInsight) GetOnlineSubscriptions() []generic.Subscription {
+func (x *ZoneEgressInsight) AllSubscriptions() []generic.Subscription {
 	var subs []generic.Subscription
 	for _, s := range x.GetSubscriptions() {
 		if s.ConnectTime != nil && s.DisconnectTime == nil {

--- a/api/mesh/v1alpha1/zoneegressinsight_helpers.go
+++ b/api/mesh/v1alpha1/zoneegressinsight_helpers.go
@@ -59,13 +59,7 @@ func (x *ZoneEgressInsight) IsOnline() bool {
 }
 
 func (x *ZoneEgressInsight) AllSubscriptions() []generic.Subscription {
-	var subs []generic.Subscription
-	for _, s := range x.GetSubscriptions() {
-		if s.ConnectTime != nil && s.DisconnectTime == nil {
-			subs = append(subs, s)
-		}
-	}
-	return subs
+	return generic.AllSubscriptions[*DiscoverySubscription](x)
 }
 
 func (x *ZoneEgressInsight) GetLastSubscription() generic.Subscription {

--- a/api/mesh/v1alpha1/zoneegressinsight_helpers.go
+++ b/api/mesh/v1alpha1/zoneegressinsight_helpers.go
@@ -10,12 +10,7 @@ import (
 var _ generic.Insight = &ZoneEgressInsight{}
 
 func (x *ZoneEgressInsight) GetSubscription(id string) generic.Subscription {
-	for _, s := range x.GetSubscriptions() {
-		if s.Id == id {
-			return s
-		}
-	}
-	return nil
+	return generic.GetSubscription[*DiscoverySubscription](x, id)
 }
 
 func (x *ZoneEgressInsight) UpdateSubscription(s generic.Subscription) error {

--- a/api/mesh/v1alpha1/zoneegressinsight_helpers_test.go
+++ b/api/mesh/v1alpha1/zoneegressinsight_helpers_test.go
@@ -38,8 +38,8 @@ var _ = Describe("Zone Egress Insights", func() {
 			})).To(Succeed())
 
 			// then
-			_, subscription := zoneInsight.GetSubscription("2")
-			Expect(subscription.DisconnectTime).ToNot(BeNil())
+			subscription := zoneInsight.GetSubscription("2")
+			Expect(subscription.(*mesh_proto.DiscoverySubscription)).ToNot(BeNil())
 		})
 
 		It("should return error for wrong subscription type", func() {

--- a/api/system/v1alpha1/zone_insight_helpers.go
+++ b/api/system/v1alpha1/zone_insight_helpers.go
@@ -45,11 +45,7 @@ func (x *ZoneInsight) IsOnline() bool {
 }
 
 func (x *ZoneInsight) AllSubscriptions() []generic.Subscription {
-	var subs []generic.Subscription
-	for _, s := range x.GetSubscriptions() {
-		subs = append(subs, s)
-	}
-	return subs
+	return generic.AllSubscriptions[*KDSSubscription](x)
 }
 
 func (x *KDSSubscription) SetDisconnectTime(time time.Time) {

--- a/api/system/v1alpha1/zone_insight_helpers.go
+++ b/api/system/v1alpha1/zone_insight_helpers.go
@@ -19,12 +19,7 @@ func NewSubscriptionStatus() *KDSSubscriptionStatus {
 }
 
 func (x *ZoneInsight) GetSubscription(id string) generic.Subscription {
-	for _, s := range x.GetSubscriptions() {
-		if s.Id == id {
-			return s
-		}
-	}
-	return nil
+	return generic.GetSubscription[*KDSSubscription](x, id)
 }
 
 func (x *ZoneInsight) GetLastSubscription() generic.Subscription {

--- a/api/system/v1alpha1/zone_insight_helpers.go
+++ b/api/system/v1alpha1/zone_insight_helpers.go
@@ -7,7 +7,6 @@ import (
 	timestamppb "google.golang.org/protobuf/types/known/timestamppb"
 
 	"github.com/kumahq/kuma/api/generic"
-	util_proto "github.com/kumahq/kuma/pkg/util/proto"
 )
 
 var _ generic.Insight = &ZoneInsight{}
@@ -78,7 +77,6 @@ func (x *ZoneInsight) UpdateSubscription(s generic.Subscription) error {
 			return nil
 		}
 	}
-	x.finalizeSubscriptions()
 	x.Subscriptions = append(x.Subscriptions, kdsSubscription)
 	return nil
 }
@@ -90,18 +88,6 @@ func (x *ZoneInsight) CompactFinished() {
 		x.Subscriptions[i].Config = ""
 		if status := x.Subscriptions[i].Status; status != nil {
 			status.Stat = map[string]*KDSServiceStats{}
-		}
-	}
-}
-
-// If Global CP was killed ungracefully then we can get a subscription without a DisconnectTime.
-// Because of the way we process subscriptions the lack of DisconnectTime on old subscription
-// will cause wrong status.
-func (x *ZoneInsight) finalizeSubscriptions() {
-	now := util_proto.Now()
-	for _, subscription := range x.GetSubscriptions() {
-		if subscription.DisconnectTime == nil {
-			subscription.DisconnectTime = now
 		}
 	}
 }

--- a/api/system/v1alpha1/zone_insight_helpers.go
+++ b/api/system/v1alpha1/zone_insight_helpers.go
@@ -44,18 +44,20 @@ func (x *ZoneInsight) IsOnline() bool {
 	return false
 }
 
-func (x *ZoneInsight) GetOnlineSubscriptions() []generic.Subscription {
+func (x *ZoneInsight) AllSubscriptions() []generic.Subscription {
 	var subs []generic.Subscription
 	for _, s := range x.GetSubscriptions() {
-		if s.ConnectTime != nil && s.DisconnectTime == nil {
-			subs = append(subs, s)
-		}
+		subs = append(subs, s)
 	}
 	return subs
 }
 
 func (x *KDSSubscription) SetDisconnectTime(time time.Time) {
 	x.DisconnectTime = timestamppb.New(time)
+}
+
+func (x *KDSSubscription) IsOnline() bool {
+	return x.GetConnectTime() != nil && x.GetDisconnectTime() == nil
 }
 
 func (x *ZoneInsight) Sum(v func(*KDSSubscription) uint64) uint64 {

--- a/api/system/v1alpha1/zone_insight_helpers_test.go
+++ b/api/system/v1alpha1/zone_insight_helpers_test.go
@@ -15,6 +15,33 @@ var _ = Describe("Zone Insights", func() {
 	t1, _ := time.Parse(time.RFC3339, "2018-07-17T16:05:36.995+00:00")
 
 	Context("UpdateSubscription", func() {
+		It("should leave subscriptions in a valid state", func() {
+			// given
+			zoneInsight := &system_proto.ZoneInsight{
+				Subscriptions: []*system_proto.KDSSubscription{
+					{
+						Id:             "1",
+						ConnectTime:    util_proto.MustTimestampProto(t1),
+						DisconnectTime: util_proto.MustTimestampProto(t1.Add(1 * time.Hour)),
+					},
+					{
+						Id:          "2",
+						ConnectTime: util_proto.MustTimestampProto(t1.Add(2 * time.Hour)),
+					},
+				},
+			}
+
+			// when
+			Expect(zoneInsight.UpdateSubscription(&system_proto.KDSSubscription{
+				Id:          "3",
+				ConnectTime: util_proto.MustTimestampProto(t1.Add(3 * time.Hour)),
+			})).To(Succeed())
+
+			// then
+			subscription := zoneInsight.GetSubscription("2")
+			Expect(subscription.(*system_proto.KDSSubscription).DisconnectTime).ToNot(BeNil())
+		})
+
 		It("should return error for wrong subscription type", func() {
 			// given
 			zoneInsight := &system_proto.ZoneInsight{

--- a/api/system/v1alpha1/zone_insight_helpers_test.go
+++ b/api/system/v1alpha1/zone_insight_helpers_test.go
@@ -38,8 +38,8 @@ var _ = Describe("Zone Insights", func() {
 			})).To(Succeed())
 
 			// then
-			_, subscription := zoneInsight.GetSubscription("2")
-			Expect(subscription.DisconnectTime).ToNot(BeNil())
+			subscription := zoneInsight.GetSubscription("2")
+			Expect(subscription.(*system_proto.KDSSubscription).DisconnectTime).ToNot(BeNil())
 		})
 
 		It("should return error for wrong subscription type", func() {

--- a/api/system/v1alpha1/zone_insight_helpers_test.go
+++ b/api/system/v1alpha1/zone_insight_helpers_test.go
@@ -15,33 +15,6 @@ var _ = Describe("Zone Insights", func() {
 	t1, _ := time.Parse(time.RFC3339, "2018-07-17T16:05:36.995+00:00")
 
 	Context("UpdateSubscription", func() {
-		It("should leave subscriptions in a valid state", func() {
-			// given
-			zoneInsight := &system_proto.ZoneInsight{
-				Subscriptions: []*system_proto.KDSSubscription{
-					{
-						Id:             "1",
-						ConnectTime:    util_proto.MustTimestampProto(t1),
-						DisconnectTime: util_proto.MustTimestampProto(t1.Add(1 * time.Hour)),
-					},
-					{
-						Id:          "2",
-						ConnectTime: util_proto.MustTimestampProto(t1.Add(2 * time.Hour)),
-					},
-				},
-			}
-
-			// when
-			Expect(zoneInsight.UpdateSubscription(&system_proto.KDSSubscription{
-				Id:          "3",
-				ConnectTime: util_proto.MustTimestampProto(t1.Add(3 * time.Hour)),
-			})).To(Succeed())
-
-			// then
-			subscription := zoneInsight.GetSubscription("2")
-			Expect(subscription.(*system_proto.KDSSubscription).DisconnectTime).ToNot(BeNil())
-		})
-
 		It("should return error for wrong subscription type", func() {
 			// given
 			zoneInsight := &system_proto.ZoneInsight{

--- a/pkg/gc/components.go
+++ b/pkg/gc/components.go
@@ -73,7 +73,7 @@ func setupFinalizer(rt runtime.Runtime) error {
 		return errors.Errorf("unknown Kuma CP mode %s", rt.Config().Mode)
 	}
 
-	finalizer, err := NewSubscriptionFinalizer(rt.ResourceManager(), rt.Tenants(), newTicker, rt.Metrics(), resourceTypes...)
+	finalizer, err := NewSubscriptionFinalizer(rt.ResourceManager(), rt.Tenants(), newTicker, rt.Metrics(), rt.Extensions(), resourceTypes...)
 	if err != nil {
 		return err
 	}

--- a/pkg/gc/finalizer.go
+++ b/pkg/gc/finalizer.go
@@ -151,7 +151,10 @@ func (f *subscriptionFinalizer) checkGeneration(ctx context.Context, typ core_mo
 		subsToFinalize := map[string]struct{}{}
 		newWatchedSubs := subscriptionGenerationMap{}
 
-		for _, sub := range insight.GetOnlineSubscriptions() {
+		for _, sub := range insight.AllSubscriptions() {
+			if !sub.IsOnline() {
+				continue
+			}
 			id := sub.GetId()
 			if gen, ok := lastGens[id]; !ok || gen != sub.GetGeneration() {
 				newWatchedSubs[id] = sub.GetGeneration()

--- a/pkg/gc/finalizer_test.go
+++ b/pkg/gc/finalizer_test.go
@@ -34,7 +34,7 @@ var _ = Describe("Subscription Finalizer", func() {
 		Expect(err).ToNot(HaveOccurred())
 		finalizer, err := gc.NewSubscriptionFinalizer(rm, multitenant.SingleTenant, func() *time.Ticker {
 			return &time.Ticker{C: ticks}
-		}, metrics, system.ZoneInsightType)
+		}, metrics, context.Background(), system.ZoneInsightType)
 		Expect(err).ToNot(HaveOccurred())
 		go func() {
 			stopped <- finalizer.Start(stop)

--- a/pkg/xds/server/callbacks/dataplane_lifecycle.go
+++ b/pkg/xds/server/callbacks/dataplane_lifecycle.go
@@ -251,8 +251,12 @@ func (d *DataplaneLifecycle) proxyConnectedToAnotherCP(
 		return false, errors.Wrap(err, "could not get insight to determine if we can delete proxy object")
 	}
 
-	sub := insight.GetSpec().(generic.Insight).GetLastSubscription().(*mesh_proto.DiscoverySubscription)
-	if sub != nil && sub.ControlPlaneInstanceId != d.cpInstanceID {
+	subs := insight.GetSpec().(generic.Insight).AllSubscriptions()
+	if len(subs) == 0 {
+		return false, nil
+	}
+
+	if sub := subs[len(subs)-1].(*mesh_proto.DiscoverySubscription); sub.ControlPlaneInstanceId != d.cpInstanceID {
 		log.Info("no need to deregister proxy. It has already connected to another instance", "newCPInstanceID", sub.ControlPlaneInstanceId)
 		return true, nil
 	}

--- a/pkg/xds/server/callbacks/dataplane_status_sink_test.go
+++ b/pkg/xds/server/callbacks/dataplane_status_sink_test.go
@@ -8,7 +8,6 @@ import (
 	. "github.com/onsi/gomega"
 	"google.golang.org/protobuf/proto"
 
-	"github.com/kumahq/kuma/api/generic"
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	"github.com/kumahq/kuma/pkg/core/resources/manager"
@@ -81,7 +80,7 @@ var _ = Describe("DataplaneInsightSink", func() {
 			latestOperation = &create
 
 			// and
-			Expect(util_proto.ToYAML(latestOperation.DiscoverySubscription)).To(MatchYAML(`
+			Expect(util_proto.ToYAML(latestOperation.Subscriptions[len(latestOperation.Subscriptions)-1])).To(MatchYAML(`
             connectTime: "2019-07-01T00:00:00Z"
             controlPlaneInstanceId: control-plane-01
             id: 3287995C-7E11-41FB-9479-7D39337F845D
@@ -114,7 +113,7 @@ var _ = Describe("DataplaneInsightSink", func() {
 				}
 			}, "1s", "1ms").Should(BeTrue())
 			// and
-			Expect(util_proto.ToYAML(latestOperation.DiscoverySubscription)).To(MatchYAML(`
+			Expect(util_proto.ToYAML(latestOperation.Subscriptions[len(latestOperation.Subscriptions)-1])).To(MatchYAML(`
             connectTime: "2019-07-01T00:00:00Z"
             controlPlaneInstanceId: control-plane-01
             id: 3287995C-7E11-41FB-9479-7D39337F845D
@@ -255,8 +254,8 @@ var _ manager.ResourceManager = &DataplaneInsightStoreRecorder{}
 
 type DataplaneInsightOperation struct {
 	core_model.ResourceKey
-	*mesh_proto.DiscoverySubscription
 	*mesh_proto.DataplaneInsight_MTLS
+	Subscriptions []*mesh_proto.DiscoverySubscription
 }
 
 type DataplaneInsightStoreRecorder struct {
@@ -272,7 +271,7 @@ func (d *DataplaneInsightStoreRecorder) Create(ctx context.Context, resource cor
 	opts := core_store.NewCreateOptions(optionsFunc...)
 	d.Creates <- DataplaneInsightOperation{
 		ResourceKey:           core_model.ResourceKey{Mesh: opts.Mesh, Name: opts.Name},
-		DiscoverySubscription: resource.GetSpec().(generic.Insight).GetLastSubscription().(*mesh_proto.DiscoverySubscription),
+		Subscriptions:         resource.GetSpec().(*mesh_proto.DataplaneInsight).Subscriptions,
 		DataplaneInsight_MTLS: resource.GetSpec().(*mesh_proto.DataplaneInsight).MTLS,
 	}
 	return nil
@@ -284,7 +283,7 @@ func (d *DataplaneInsightStoreRecorder) Update(ctx context.Context, resource cor
 	}
 	d.Updates <- DataplaneInsightOperation{
 		ResourceKey:           core_model.ResourceKey{Mesh: resource.GetMeta().GetMesh(), Name: resource.GetMeta().GetName()},
-		DiscoverySubscription: resource.GetSpec().(generic.Insight).GetLastSubscription().(*mesh_proto.DiscoverySubscription),
+		Subscriptions:         resource.GetSpec().(*mesh_proto.DataplaneInsight).Subscriptions,
 		DataplaneInsight_MTLS: resource.GetSpec().(*mesh_proto.DataplaneInsight).MTLS,
 	}
 	return nil


### PR DESCRIPTION
See #7535 

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
