### PR TITLE
feat(kuma-cp): added query parameter to filter services by name

### DIFF
--- a/pkg/api-server/service_insight_endpoints.go
+++ b/pkg/api-server/service_insight_endpoints.go
@@ -111,7 +111,7 @@ func (s *serviceInsightEndpoints) expandInsights(serviceInsightList *mesh.Servic
 	restItems := []rest.Resource{} // Needs to be set to avoid returning nil and have the api return []
 	for _, insight := range serviceInsightList.Items {
 		for serviceName, stat := range insight.Spec.Services {
-			if strings.Contains(serviceName, nameContains){
+			if strings.Contains(serviceName, nameContains) {
 				s.fillStaticInfo(serviceName, stat)
 				out := rest.From.Resource(insight)
 				res := out.(*rest_unversioned.Resource)

--- a/pkg/api-server/service_insight_endpoints.go
+++ b/pkg/api-server/service_insight_endpoints.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"sort"
 	"strconv"
+	"strings"
 
 	"github.com/emicklei/go-restful/v3"
 
@@ -61,6 +62,7 @@ func (s *serviceInsightEndpoints) addListEndpoint(ws *restful.WebService, pathPr
 		Doc(fmt.Sprintf("List of %s", s.descriptor.Name)).
 		Param(ws.PathParameter("size", "size of page").DataType("int")).
 		Param(ws.PathParameter("offset", "offset of page to list").DataType("string")).
+		Param(ws.QueryParameter("name", "a pattern to select only services that contain these characters").DataType("string")).
 		Returns(200, "OK", nil))
 }
 
@@ -74,7 +76,8 @@ func (s *serviceInsightEndpoints) listResources(request *restful.Request, respon
 		return
 	}
 
-	items := s.expandInsights(serviceInsightList)
+	nameContains := request.QueryParameter("name")
+	items := s.expandInsights(serviceInsightList, nameContains)
 	restList := rest.ResourceList{
 		Total: uint32(len(items)),
 		Items: items,
@@ -104,16 +107,18 @@ func (s *serviceInsightEndpoints) fillStaticInfo(name string, stat *v1alpha1.Ser
 // 2) Mesh+Name is a key on Universal, but not on Kubernetes, so if there are two services of the same name in different Meshes we would have problems with naming.
 // From the API perspective it's better to provide ServiceInsight per Service, not per Mesh.
 // For this reason, this method expand the one ServiceInsight resource for the mesh to resource per service
-func (s *serviceInsightEndpoints) expandInsights(serviceInsightList *mesh.ServiceInsightResourceList) []rest.Resource {
+func (s *serviceInsightEndpoints) expandInsights(serviceInsightList *mesh.ServiceInsightResourceList, nameContains string) []rest.Resource {
 	restItems := []rest.Resource{} // Needs to be set to avoid returning nil and have the api return []
 	for _, insight := range serviceInsightList.Items {
 		for serviceName, stat := range insight.Spec.Services {
-			s.fillStaticInfo(serviceName, stat)
-			out := rest.From.Resource(insight)
-			res := out.(*rest_unversioned.Resource)
-			res.Meta.Name = serviceName
-			res.Spec = stat
-			restItems = append(restItems, out)
+			if strings.Contains(serviceName, nameContains){
+				s.fillStaticInfo(serviceName, stat)
+				out := rest.From.Resource(insight)
+				res := out.(*rest_unversioned.Resource)
+				res.Meta.Name = serviceName
+				res.Spec = stat
+				restItems = append(restItems, out)
+			}
 		}
 	}
 

--- a/pkg/api-server/service_insight_endpoints_test.go
+++ b/pkg/api-server/service_insight_endpoints_test.go
@@ -350,7 +350,7 @@ var _ = Describe("Service Insight Endpoints", func() {
 }
 `,
 		}),
-	Entry("with pagination and name filter", testCase{
+		Entry("with pagination and name filter", testCase{
 			params: "?size=1&name=end",
 			expected: `
 {

--- a/pkg/api-server/service_insight_endpoints_test.go
+++ b/pkg/api-server/service_insight_endpoints_test.go
@@ -350,5 +350,55 @@ var _ = Describe("Service Insight Endpoints", func() {
 }
 `,
 		}),
+	Entry("with pagination and name filter", testCase{
+			params: "?size=1&name=end",
+			expected: `
+{
+  "total": 2,
+  "items": [
+	{
+	  "type": "ServiceInsight",
+	  "mesh": "mesh-1",
+	  "name": "backend",
+	  "creationTime": "2018-07-17T16:05:36.995Z",
+	  "modificationTime": "2018-07-17T16:05:36.995Z",
+      "status": "partially_degraded",
+      "dataplanes": {
+	    "total": 100,
+	    "online": 70,
+	    "offline": 30
+      },
+      "addressPort": "backend.mesh:80"
+	}
+  ],
+  "next": "http://{{address}}/service-insights?name=end&offset=1&size=1"
+}
+`,
+		}),
+		Entry("with second page and name filter", testCase{
+			params: "?size=1&offset=1&name=end",
+			expected: `
+{
+  "total": 2,
+  "items": [
+	{
+	  "type": "ServiceInsight",
+	  "mesh": "mesh-1",
+	  "name": "frontend",
+	  "creationTime": "2018-07-17T16:05:36.995Z",
+	  "modificationTime": "2018-07-17T16:05:36.995Z",
+      "status": "partially_degraded",
+      "dataplanes": {
+	    "total": 20,
+	    "online": 19,
+	    "offline": 1
+      },
+      "addressPort": "frontend.mesh:80"
+	}
+  ],
+  "next": null
+}
+`,
+		}),
 	)
 })


### PR DESCRIPTION
### Checklist prior to review

- [X] [Link to relevant issue][1] as well as docs and UI issues -- fix: https://github.com/kumahq/kuma/issues/8106
- [X] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [X] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [X] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [X] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
