### PR TITLE
build(go): remove no longer needed `experimental` build tag

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -25,8 +25,6 @@ linters:
     - loggercheck
 
 run:
-  build-tags:
-    - experimental
   skip-files:
     - app/kumactl/pkg/k8s/kubectl_proxy.go # excluded to keep as close to original file from K8S repository
     - pkg/xds/server/server.go # excluded to keep as close to original file from Envoy repository

--- a/mk/build.mk
+++ b/mk/build.mk
@@ -11,8 +11,7 @@ LD_FLAGS := -ldflags="-s -w $(build_info_ld_flags) $(EXTRA_LD_FLAGS)"
 
 EXTRA_GOENV ?=
 GOENV=CGO_ENABLED=0 $(EXTRA_GOENV)
-# add -tags=experimental for Gateway API conformance profiles
-GOFLAGS := -trimpath -tags=experimental $(EXTRA_GOFLAGS)
+GOFLAGS := -trimpath $(EXTRA_GOFLAGS)
 
 TOP := $(shell pwd)
 BUILD_DIR ?= $(TOP)/build


### PR DESCRIPTION
No longer needed for gateway-api, added in #7374 

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
