### PR TITLE
fix(api-server): move -overview to _overview

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -36,10 +36,10 @@ New rule is applied for CREATE operations. The old rule is still applied for UPD
 
 These endpoints are getting replaced to achieve more coherency on the API:
 
-- `/meshes/{mesh}/zoneegressoverviews` moves to `/meshes/{mesh}/zoneegresses/-overview`
-- `/meshes/{mesh}/zoneingresses+insights` moves to `/meshes/{mesh}/zone-ingresses/-overview`
-- `/meshes/{mesh}/dataplanes+insights` moves to `/meshes/{mesh}/dataplanes/-overview`
-- `/zones+insights` moves to `/zones/-overview`
+- `/meshes/{mesh}/zoneegressoverviews` moves to `/meshes/{mesh}/zoneegresses/_overview`
+- `/meshes/{mesh}/zoneingresses+insights` moves to `/meshes/{mesh}/zone-ingresses/_overview`
+- `/meshes/{mesh}/dataplanes+insights` moves to `/meshes/{mesh}/dataplanes/_overview`
+- `/zones+insights` moves to `/zones/_overview`
 
 While you can use the old API they will be removed in a future version
 

--- a/pkg/api-server/dataplane_overview_endpoints_test.go
+++ b/pkg/api-server/dataplane_overview_endpoints_test.go
@@ -126,77 +126,6 @@ var _ = Describe("Dataplane Overview Endpoints", func() {
 		Expect(err).ToNot(HaveOccurred())
 	})
 
-	gatewayDelegatedJson := `
-{
-	"type": "DataplaneOverview",
-	"name": "gateway-delegated",
-	"mesh": "mesh1",
-	"creationTime": "2018-07-17T16:05:36.995Z",
-	"modificationTime": "2018-07-17T16:05:36.995Z",
-	"dataplane": {
-		"networking": {
-			"address": "127.0.0.1",
-			"gateway": {
-				"tags": {
-					"service": "gateway"
-				}
-            }
-		}
-	},
-	"dataplaneInsight": {
-		"subscriptions": [
-			{
-				"id": "stream-id-1",
-				"controlPlaneInstanceId": "cp-1",
-				"connectTime": "2019-07-01T00:00:00Z",
-				"status": {
-					"total": {},
-					"cds": {},
-					"eds": {},
-					"lds": {},
-					"rds": {}
-				}
-			}
-		]
-	}
-}`
-
-	gatewayBuiltinJson := `
-{
-	"type": "DataplaneOverview",
-	"name": "gateway-builtin",
-	"mesh": "mesh1",
-	"creationTime": "2018-07-17T16:05:36.995Z",
-	"modificationTime": "2018-07-17T16:05:36.995Z",
-	"dataplane": {
-		"networking": {
-			"address": "127.0.0.1",
-			"gateway": {
-				"type": "BUILTIN",
-				"tags": {
-					"service": "gateway"
-				}
-            }
-		}
-	},
-	"dataplaneInsight": {
-		"subscriptions": [
-			{
-				"id": "stream-id-1",
-				"controlPlaneInstanceId": "cp-1",
-				"connectTime": "2019-07-01T00:00:00Z",
-				"status": {
-					"total": {},
-					"cds": {},
-					"eds": {},
-					"lds": {},
-					"rds": {}
-				}
-			}
-		]
-	}
-}`
-
 	dp1Json := `
 {
 	"type": "DataplaneOverview",
@@ -251,8 +180,7 @@ var _ = Describe("Dataplane Overview Endpoints", func() {
 		})
 
 		type testCase struct {
-			url          string
-			expectedJson string
+			url string
 		}
 
 		DescribeTable("Listing resources filtering by tag",
@@ -275,48 +203,40 @@ var _ = Describe("Dataplane Overview Endpoints", func() {
 				Expect(body).To(matchers.MatchGoldenJSON("testdata", goldenFileName))
 			},
 			Entry("should list all when no tag is provided", testCase{
-				url:          "meshes/mesh1/dataplanes+insights",
-				expectedJson: fmt.Sprintf(`{"total": 3, "items": [%s, %s, %s], "next": null}`, dp1Json, gatewayBuiltinJson, gatewayDelegatedJson),
+				url: "meshes/mesh1/dataplanes+insights",
 			}),
 			Entry("should list with only one matching tag", testCase{
-				url:          "meshes/mesh1/dataplanes+insights?tag=service:backend",
-				expectedJson: fmt.Sprintf(`{"total": 1, "items": [%s], "next": null}`, dp1Json),
+				url: "meshes/mesh1/dataplanes+insights?tag=service:backend",
 			}),
 			Entry("should list with only subset tag", testCase{
-				url:          "meshes/mesh1/dataplanes+insights?tag=service:ck",
-				expectedJson: fmt.Sprintf(`{"total": 1, "items": [%s], "next": null}`, dp1Json),
+				url: "meshes/mesh1/dataplanes+insights?tag=service:ck",
 			}),
 			Entry("should list all with all matching tags", testCase{
-				url:          "meshes/mesh1/dataplanes+insights?tag=service:backend&tag=version:v1",
-				expectedJson: fmt.Sprintf(`{"total": 1, "items": [%s], "next": null}`, dp1Json),
+				url: "meshes/mesh1/dataplanes+insights?tag=service:backend&tag=version:v1",
 			}),
 			Entry("should list all with all matching tags with value with a column", testCase{
-				url:          "meshes/mesh1/dataplanes+insights?tag=tagcolumn:tag:v",
-				expectedJson: fmt.Sprintf(`{"total": 1, "items": [%s], "next": null}`, dp1Json),
+				url: "meshes/mesh1/dataplanes+insights?tag=tagcolumn:tag:v",
 			}),
 			Entry("should not list when any tag is not matching", testCase{
-				url:          "meshes/mesh1/dataplanes+insights?tag=service:backend&tag=version:v2",
-				expectedJson: `{"total": 0, "items": [], "next": null}`,
+				url: "meshes/mesh1/dataplanes+insights?tag=service:backend&tag=version:v2",
 			}),
 			Entry("should list only gateway dataplanes", testCase{
-				url:          "meshes/mesh1/dataplanes+insights?gateway=true",
-				expectedJson: fmt.Sprintf(`{"total": 2, "items": [%s, %s], "next": null}`, gatewayBuiltinJson, gatewayDelegatedJson),
+				url: "meshes/mesh1/dataplanes+insights?gateway=true",
 			}),
 			Entry("should list only gateway builtin", testCase{
-				url:          "meshes/mesh1/dataplanes+insights?gateway=builtin",
-				expectedJson: fmt.Sprintf(`{"total": 1, "items": [%s], "next": null}`, gatewayBuiltinJson),
+				url: "meshes/mesh1/dataplanes+insights?gateway=builtin",
 			}),
 			Entry("should list only gateway delegated", testCase{
-				url:          "meshes/mesh1/dataplanes+insights?gateway=delegated",
-				expectedJson: fmt.Sprintf(`{"total": 1, "items": [%s], "next": null}`, gatewayDelegatedJson),
+				url: "meshes/mesh1/dataplanes+insights?gateway=delegated",
 			}),
 			Entry("should list only dataplanes that starts with gateway", testCase{
-				url:          "meshes/mesh1/dataplanes+insights?name=gateway",
-				expectedJson: fmt.Sprintf(`{"total": 2, "items": [%s, %s], "next": null}`, gatewayBuiltinJson, gatewayDelegatedJson),
+				url: "meshes/mesh1/dataplanes+insights?name=gateway",
 			}),
 			Entry("should list only dataplanes that contains with tew", testCase{
-				url:          "meshes/mesh1/dataplanes+insights?name=tew",
-				expectedJson: fmt.Sprintf(`{"total": 2, "items": [%s, %s], "next": null}`, gatewayBuiltinJson, gatewayDelegatedJson),
+				url: "meshes/mesh1/dataplanes+insights?name=tew",
+			}),
+			Entry("should list only dataplanes that contains with tew using _overview", testCase{
+				url: "meshes/mesh1/dataplanes/_overview?name=tew",
 			}),
 		)
 

--- a/pkg/api-server/resource_endpoints.go
+++ b/pkg/api-server/resource_endpoints.go
@@ -67,7 +67,7 @@ func (r *resourceEndpoints) addFindEndpoint(ws *restful.WebService, pathPrefix s
 		Returns(404, "Not found", nil))
 	if r.descriptor.HasInsights() {
 		route := r.findResource(true)
-		ws.Route(ws.GET(pathPrefix+"/{name}/-overview").To(route).
+		ws.Route(ws.GET(pathPrefix+"/{name}/_overview").To(route).
 			Doc(fmt.Sprintf("Get overview of a %s", r.descriptor.WsPath)).
 			Param(ws.PathParameter("name", fmt.Sprintf("Name of a %s", r.descriptor.Name)).DataType("string")).
 			Returns(200, "OK", nil).
@@ -150,7 +150,7 @@ func (r *resourceEndpoints) addListEndpoint(ws *restful.WebService, pathPrefix s
 		Returns(200, "OK", nil))
 	if r.descriptor.HasInsights() {
 		route := r.listResources(true)
-		ws.Route(ws.GET(pathPrefix+"/-overview").To(route).
+		ws.Route(ws.GET(pathPrefix+"/_overview").To(route).
 			Doc(fmt.Sprintf("Get a %s", r.descriptor.WsPath)).
 			Param(ws.QueryParameter("size", "size of page").DataType("int")).
 			Param(ws.QueryParameter("offset", "offset of page to list").DataType("string")).

--- a/pkg/api-server/testdata/meshes_mesh1_dataplanes_overview_name_tew.json
+++ b/pkg/api-server/testdata/meshes_mesh1_dataplanes_overview_name_tew.json
@@ -1,0 +1,73 @@
+{
+ "total": 2,
+ "items": [
+  {
+   "type": "DataplaneOverview",
+   "mesh": "mesh1",
+   "name": "gateway-builtin",
+   "creationTime": "2018-07-17T16:05:36.995Z",
+   "modificationTime": "2018-07-17T16:05:36.995Z",
+   "dataplane": {
+    "networking": {
+     "address": "127.0.0.1",
+     "gateway": {
+      "tags": {
+       "service": "gateway"
+      },
+      "type": "BUILTIN"
+     }
+    }
+   },
+   "dataplaneInsight": {
+    "subscriptions": [
+     {
+      "id": "stream-id-1",
+      "controlPlaneInstanceId": "cp-1",
+      "connectTime": "2019-07-01T00:00:00Z",
+      "status": {
+       "total": {},
+       "cds": {},
+       "eds": {},
+       "lds": {},
+       "rds": {}
+      }
+     }
+    ]
+   }
+  },
+  {
+   "type": "DataplaneOverview",
+   "mesh": "mesh1",
+   "name": "gateway-delegated",
+   "creationTime": "2018-07-17T16:05:36.995Z",
+   "modificationTime": "2018-07-17T16:05:36.995Z",
+   "dataplane": {
+    "networking": {
+     "address": "127.0.0.1",
+     "gateway": {
+      "tags": {
+       "service": "gateway"
+      }
+     }
+    }
+   },
+   "dataplaneInsight": {
+    "subscriptions": [
+     {
+      "id": "stream-id-1",
+      "controlPlaneInstanceId": "cp-1",
+      "connectTime": "2019-07-01T00:00:00Z",
+      "status": {
+       "total": {},
+       "cds": {},
+       "eds": {},
+       "lds": {},
+       "rds": {}
+      }
+     }
+    ]
+   }
+  }
+ ],
+ "next": null
+}


### PR DESCRIPTION
Update https://github.com/kumahq/kuma/pull/7999 to be conformant with other API choices made in #8148

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

> Changelog: feat(api-server): add /_overview for all types that have overviews

<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
