### PR TITLE
feat(kuma-dp): allow token generator to be a component

### DIFF
--- a/app/kuma-dp/cmd/context.go
+++ b/app/kuma-dp/cmd/context.go
@@ -20,7 +20,7 @@ type RootContext struct {
 	ComponentManager         component.Manager
 	BootstrapGenerator       envoy.BootstrapConfigFactoryFunc
 	BootstrapDynamicMetadata map[string]string
-	DataplaneTokenGenerator  func(*kumadp.Config) error
+	DataplaneTokenGenerator  func(cfg *kumadp.Config) (component.Component, error)
 	Config                   *kumadp.Config
 	LogLevel                 log.LogLevel
 }
@@ -29,23 +29,25 @@ var features = []string{core_xds.FeatureTCPAccessLogViaNamedPipe}
 
 // defaultDataplaneTokenGenerator uses only given tokens or paths from the
 // config.
-func defaultDataplaneTokenGenerator(cfg *kumadp.Config) error {
+func defaultDataplaneTokenGenerator(cfg *kumadp.Config) (component.Component, error) {
 	if cfg.DataplaneRuntime.Token != "" {
 		path := filepath.Join(cfg.DataplaneRuntime.ConfigDir, cfg.Dataplane.Name)
 		if err := writeFile(path, []byte(cfg.DataplaneRuntime.Token), 0o600); err != nil {
 			runLog.Error(err, "unable to create file with dataplane token")
-			return err
+			return nil, err
 		}
 		cfg.DataplaneRuntime.TokenPath = path
 	}
 
 	if cfg.DataplaneRuntime.TokenPath != "" {
 		if err := kumadp_config.ValidateTokenPath(cfg.DataplaneRuntime.TokenPath); err != nil {
-			return errors.Wrapf(err, "dataplane token is invalid, in Kubernetes you must mount a serviceAccount token, in universal you must start your proxy with a generated token.")
+			return nil, errors.Wrapf(err, "dataplane token is invalid, in Kubernetes you must mount a serviceAccount token, in universal you must start your proxy with a generated token.")
 		}
 	}
 
-	return nil
+	return component.ComponentFunc(func(<-chan struct{}) error {
+		return nil
+	}), nil
 }
 
 func DefaultRootContext() *RootContext {

--- a/app/kuma-dp/cmd/run.go
+++ b/app/kuma-dp/cmd/run.go
@@ -130,7 +130,8 @@ func newRunCmd(opts kuma_cmd.RunCmdOpts, rootCtx *RootContext) *cobra.Command {
 			return nil
 		},
 		PostRunE: func(cmd *cobra.Command, _ []string) error {
-			if err := rootCtx.DataplaneTokenGenerator(cfg); err != nil {
+			tokenComp, err := rootCtx.DataplaneTokenGenerator(cfg)
+			if err != nil {
 				runLog.Error(err, "unable to get or generate dataplane token")
 				return err
 			}
@@ -147,6 +148,7 @@ func newRunCmd(opts kuma_cmd.RunCmdOpts, rootCtx *RootContext) *cobra.Command {
 			gracefulCtx, ctx := opts.SetupSignalHandler()
 			accessLogSocketPath := core_xds.AccessLogSocketName(cfg.DataplaneRuntime.SocketDir, cfg.Dataplane.Name, cfg.Dataplane.Mesh)
 			components := []component.Component{
+				tokenComp,
 				component.NewResilientComponent(
 					runLog.WithName("access-log-streamer"),
 					accesslogs.NewAccessLogStreamer(accessLogSocketPath),


### PR DESCRIPTION
### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

> Changelog: skip

<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
