### PR TITLE
feat(kuma-cp): add basedOnKuma in cp_info metric

### DIFF
--- a/pkg/metrics/components/cp_info.go
+++ b/pkg/metrics/components/cp_info.go
@@ -12,18 +12,13 @@ import (
 )
 
 func Setup(rt runtime.Runtime) error {
+	labels := version.Build.AsMap()
+	labels["instance_id"] = rt.GetInstanceId()
+	labels["cluster_id"] = rt.GetClusterId()
 	cpInfoMetric := prometheus.NewGaugeFunc(prometheus.GaugeOpts{
-		Name: "cp_info",
-		Help: "Static information about the CP instance",
-		ConstLabels: map[string]string{
-			"instance_id": rt.GetInstanceId(),
-			"cluster_id":  rt.GetClusterId(),
-			"product":     version.Product,
-			"version":     version.Build.Version,
-			"build_date":  version.Build.BuildDate,
-			"git_commit":  version.Build.GitCommit,
-			"git_tag":     version.Build.GitTag,
-		},
+		Name:        "cp_info",
+		Help:        "Static information about the CP instance",
+		ConstLabels: labels,
 	}, func() float64 {
 		return 1.0
 	})

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -42,14 +42,39 @@ func (b BuildInfo) FormatDetailedProductInfo() string {
 	)
 }
 
+func shortCommit(c string) string {
+	if len(c) < 7 {
+		return c
+	}
+	return c[:7]
+}
+
+func (b BuildInfo) AsMap() map[string]string {
+	res := map[string]string{
+		"product":    b.Product,
+		"version":    b.Version,
+		"build_date": b.BuildDate,
+		"git_commit": shortCommit(b.GitCommit),
+		"git_tag":    b.GitTag,
+	}
+	if b.BasedOnKuma != "" {
+		res["based_on_kuma"] = shortCommit(b.BasedOnKuma)
+	}
+	return res
+}
+
 func (b BuildInfo) UserAgent(component string) string {
+	commit := shortCommit(b.GitCommit)
+	if b.BasedOnKuma != "" {
+		commit = fmt.Sprintf("%s/kuma-%s", commit, shortCommit(b.BasedOnKuma))
+	}
 	return fmt.Sprintf("%s/%s (%s; %s; %s/%s)",
 		component,
 		b.Version,
 		runtime.GOOS,
 		runtime.GOARCH,
 		b.Product,
-		b.GitCommit[:7])
+		commit)
 }
 
 var Build BuildInfo


### PR DESCRIPTION
This is useful for entreprise distributions

Fix #8143

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
