### PR TITLE
feat(kuma-cp): increase possible values in e2e test

### DIFF
--- a/test/e2e_env/multizone/localityawarelb/locality_aware_multizone_hybrid.go
+++ b/test/e2e_env/multizone/localityawarelb/locality_aware_multizone_hybrid.go
@@ -367,10 +367,10 @@ spec:
 		// then
 		failedRequests, err := failRequestCount(multizone.KubeZone2, "demo-client-mesh-route")
 		Expect(err).ToNot(HaveOccurred())
-		Expect(failedRequests).To(BeNumerically("~", 45, 15))
+		Expect(failedRequests).To(BeNumerically("~", 50, 15))
 		successRequests, err := successRequestCount(multizone.KubeZone2, "demo-client-mesh-route")
 		Expect(err).ToNot(HaveOccurred())
-		Expect(successRequests).To(BeNumerically("~", 45, 15))
+		Expect(successRequests).To(BeNumerically("~", 50, 15))
 	})
 }
 

--- a/test/e2e_env/multizone/localityawarelb/locality_aware_multizone_hybrid.go
+++ b/test/e2e_env/multizone/localityawarelb/locality_aware_multizone_hybrid.go
@@ -367,10 +367,10 @@ spec:
 		// then
 		failedRequests, err := failRequestCount(multizone.KubeZone2, "demo-client-mesh-route")
 		Expect(err).ToNot(HaveOccurred())
-		Expect(failedRequests).To(BeNumerically("~", 45, 10))
+		Expect(failedRequests).To(BeNumerically("~", 45, 15))
 		successRequests, err := successRequestCount(multizone.KubeZone2, "demo-client-mesh-route")
 		Expect(err).ToNot(HaveOccurred())
-		Expect(successRequests).To(BeNumerically("~", 45, 10))
+		Expect(successRequests).To(BeNumerically("~", 45, 15))
 	})
 }
 


### PR DESCRIPTION
### Checklist prior to review

Test seems flaky and this should reduce it. Traffic might not be distributed equally and only with higher number of requests it can reduce the difference

- [ ] [Link to relevant issue][1] as well as docs and UI issues --
- [ ] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [ ] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [ ] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [ ] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
