### PR TITLE
test(e2e): add 80/20 split for local only services

### DIFF
--- a/test/e2e_env/multizone/trafficroute/trafficroute.go
+++ b/test/e2e_env/multizone/trafficroute/trafficroute.go
@@ -374,6 +374,8 @@ conf:
 					"echo-v2": Not(BeNil()),
 					"echo-v3": Not(BeNil()),
 					"echo-v4": Not(BeNil()),
+					"echo-v5": Not(BeNil()),
+					"echo-v6": Not(BeNil()),
 					// todo(jakubdyszkiewicz) uncomment when https://github.com/kumahq/kuma/issues/2563 is fixed
 					// HaveKeyWithValue(MatchRegexp(`.*echo-v1.*`), BeNumerically("~", 10, 1)),
 					// HaveKeyWithValue(MatchRegexp(`.*echo-v2.*`), BeNumerically("~", 10, 1)),

--- a/test/e2e_env/multizone/trafficroute/trafficroute.go
+++ b/test/e2e_env/multizone/trafficroute/trafficroute.go
@@ -404,6 +404,8 @@ routing:
 			}, "30s", "500ms").Should(
 				MatchAllKeys(Keys{
 					"echo-v1": Not(BeNil()),
+					"echo-v5": Not(BeNil()),
+					"echo-v6": Not(BeNil()),
 				}),
 			)
 		})


### PR DESCRIPTION
I've noticed a few flakes of the 80/20 test for mutlizone:
  * https://app.circleci.com/pipelines/github/kumahq/kuma/26017/workflows/3f9768e0-16c2-445d-b7d7-5b823d59afbf/jobs/537004
  * https://app.circleci.com/pipelines/github/kumahq/kuma/25961/workflows/4cc86364-a616-426c-befd-af0c8b2d650f/jobs/534954

This PR adds a similar test for local traffic, so we can observe if the problem relates exclusively to multizone traffic. 

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [X] [Link to relevant issue][1] as well as docs and UI issues --
- [X] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [X] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [X] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [X] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
