### PR TITLE
feat(kuma-dp): support setting Envoy's --component-log-level

### DIFF
--- a/app/kuma-dp/cmd/run.go
+++ b/app/kuma-dp/cmd/run.go
@@ -288,6 +288,7 @@ func newRunCmd(opts kuma_cmd.RunCmdOpts, rootCtx *RootContext) *cobra.Command {
 	cmd.PersistentFlags().StringVarP(&cfg.DataplaneRuntime.ResourcePath, "dataplane-file", "d", "", "Path to Dataplane template to apply (YAML or JSON)")
 	cmd.PersistentFlags().StringToStringVarP(&cfg.DataplaneRuntime.ResourceVars, "dataplane-var", "v", map[string]string{}, "Variables to replace Dataplane template")
 	cmd.PersistentFlags().StringVar(&cfg.DataplaneRuntime.EnvoyLogLevel, "envoy-log-level", "", "Envoy log level. Available values are: [trace][debug][info][warning|warn][error][critical][off]. By default it inherits Kuma DP logging level.")
+	cmd.PersistentFlags().StringVar(&cfg.DataplaneRuntime.EnvoyComponentLogLevel, "envoy-component-log-level", "", "Configures Envoy's --component-log-level")
 	cmd.PersistentFlags().StringVar(&cfg.DataplaneRuntime.Metrics.CertPath, "metrics-cert-path", cfg.DataplaneRuntime.Metrics.CertPath, "A path to the certificate for metrics listener")
 	cmd.PersistentFlags().StringVar(&cfg.DataplaneRuntime.Metrics.KeyPath, "metrics-key-path", cfg.DataplaneRuntime.Metrics.KeyPath, "A path to the certificate key for metrics listener")
 	cmd.PersistentFlags().BoolVar(&cfg.DNS.Enabled, "dns-enabled", cfg.DNS.Enabled, "If true then builtin DNS functionality is enabled and CoreDNS server is started")

--- a/app/kuma-dp/pkg/dataplane/envoy/envoy.go
+++ b/app/kuma-dp/pkg/dataplane/envoy/envoy.go
@@ -119,6 +119,10 @@ func (e *Envoy) Start(stop <-chan struct{}) error {
 		"--log-level", e.opts.Config.DataplaneRuntime.EnvoyLogLevel,
 	}
 
+	if e.opts.Config.DataplaneRuntime.EnvoyComponentLogLevel != "" {
+		args = append(args, "--component-log-level", e.opts.Config.DataplaneRuntime.EnvoyComponentLogLevel)
+	}
+
 	// If the concurrency is explicit, use that. On Linux, users
 	// can also implicitly set concurrency using cpusets.
 	if e.opts.Config.DataplaneRuntime.Concurrency > 0 {

--- a/docs/generated/cmd/kuma-dp/kuma-dp_run.md
+++ b/docs/generated/cmd/kuma-dp/kuma-dp_run.md
@@ -32,6 +32,7 @@ kuma-dp run [flags]
       --dns-prometheus-port uint32                A port for exposing Prometheus stats (default 19153)
       --dns-server-config-dir string              Directory in which DNS Server config will be generated
       --drain-time duration                       drain time for Envoy connections on Kuma DP shutdown (default 30s)
+      --envoy-component-log-level string          Configures Envoy's --component-log-level
       --envoy-log-level string                    Envoy log level. Available values are: [trace][debug][info][warning|warn][error][critical][off]. By default it inherits Kuma DP logging level.
   -h, --help                                      help for run
       --mesh string                               Mesh that Dataplane belongs to

--- a/pkg/config/app/kuma-dp/config.go
+++ b/pkg/config/app/kuma-dp/config.go
@@ -189,6 +189,8 @@ type DataplaneRuntime struct {
 	// Available values are: [trace][debug][info][warning|warn][error][critical][off]
 	// By default it inherits Kuma DP logging level.
 	EnvoyLogLevel string `json:"envoyLogLevel,omitempty" envconfig:"kuma_dataplane_runtime_envoy_log_level"`
+	// EnvoyComponentLogLevel configures Envoy's --component-log-level
+	EnvoyComponentLogLevel string `json:"envoyComponentLogLevel,omitempty" envconfig:"kuma_dataplane_runtime_envoy_component_log_level"`
 	// Resources defines the resources for this proxy.
 	Resources DataplaneResources `json:"resources,omitempty"`
 	// SocketDir dir to store socket used between Envoy and the dp process

--- a/pkg/config/app/kuma-dp/config.go
+++ b/pkg/config/app/kuma-dp/config.go
@@ -189,7 +189,8 @@ type DataplaneRuntime struct {
 	// Available values are: [trace][debug][info][warning|warn][error][critical][off]
 	// By default it inherits Kuma DP logging level.
 	EnvoyLogLevel string `json:"envoyLogLevel,omitempty" envconfig:"kuma_dataplane_runtime_envoy_log_level"`
-	// EnvoyComponentLogLevel configures Envoy's --component-log-level
+	// EnvoyComponentLogLevel configures Envoy's --component-log-level and uses
+	// the exact same syntax: https://www.envoyproxy.io/docs/envoy/latest/operations/cli#cmdoption-component-log-level
 	EnvoyComponentLogLevel string `json:"envoyComponentLogLevel,omitempty" envconfig:"kuma_dataplane_runtime_envoy_component_log_level"`
 	// Resources defines the resources for this proxy.
 	Resources DataplaneResources `json:"resources,omitempty"`

--- a/pkg/plugins/runtime/k8s/containers/factory.go
+++ b/pkg/plugins/runtime/k8s/containers/factory.go
@@ -271,6 +271,12 @@ func (i *DataplaneProxyFactory) sidecarEnvVars(mesh string, podAnnotations map[s
 			Value: logLevel,
 		}
 	}
+	if complogLevel, exist := metadata.Annotations(podAnnotations).GetString(metadata.KumaEnvoyComponentLogLevel); exist {
+		envVars["KUMA_DATAPLANE_RUNTIME_ENVOY_COMPONENT_LOG_LEVEL"] = kube_core.EnvVar{
+			Name:  "KUMA_DATAPLANE_RUNTIME_ENVOY_COMPONENT_LOG_LEVEL",
+			Value: complogLevel,
+		}
+	}
 
 	// override defaults with cfg env vars
 	for envName, envVal := range i.ContainerConfig.EnvVars {

--- a/pkg/plugins/runtime/k8s/metadata/annotations.go
+++ b/pkg/plugins/runtime/k8s/metadata/annotations.go
@@ -95,7 +95,8 @@ const (
 
 	// KumaEnvoyLogLevel allows to control Envoy log level.
 	// Available values are: [trace][debug][info][warning|warn][error][critical][off]
-	KumaEnvoyLogLevel = "kuma.io/envoy-log-level"
+	KumaEnvoyLogLevel          = "kuma.io/envoy-log-level"
+	KumaEnvoyComponentLogLevel = "kuma.io/envoy-component-log-level"
 
 	// KumaMetricsPrometheusAggregatePath allows to specify which path for specific app should request for metrics
 	KumaMetricsPrometheusAggregatePath = "prometheus.metrics.kuma.io/aggregate-%s-path"


### PR DESCRIPTION
### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
