### PR TITLE
test(kumactl) adjust matcher for install tproxy test

### DIFF
--- a/app/kumactl/cmd/install/install_transparent_proxy_test.go
+++ b/app/kumactl/cmd/install/install_transparent_proxy_test.go
@@ -88,7 +88,7 @@ var _ = Describe("kumactl install transparent proxy", func() {
 				)
 			},
 			errorMatcher: HavePrefix("# [WARNING] error occurred when validating if 'conntrack' iptables module is present. Rules for DNS conntrack zone splitting won't be applied:"),
-			goldenFile:   "install-transparent-proxy.dns.golden.txt",
+			goldenFile:   "install-transparent-proxy.dns.no-conntrack.golden.txt",
 		}),
 		Entry("should generate defaults with user id and DNS redirected when no conntrack module present", testCase{
 			extraArgs: []string{
@@ -103,7 +103,7 @@ var _ = Describe("kumactl install transparent proxy", func() {
 					"# [WARNING] error occurred when validating if 'conntrack' iptables module is present. Rules for DNS conntrack zone splitting won't be applied:",
 				)
 			},
-			goldenFile:   "install-transparent-proxy.dns.no-conntrack.golden.txt",
+			goldenFile:   "install-transparent-proxy.dns.golden.txt",
 		}),
 		Entry("should generate defaults with user id and DNS redirected without conntrack zone splitting and log deprecate", testCase{
 			extraArgs: []string{

--- a/app/kumactl/cmd/install/install_transparent_proxy_test.go
+++ b/app/kumactl/cmd/install/install_transparent_proxy_test.go
@@ -74,7 +74,7 @@ var _ = Describe("kumactl install transparent proxy", func() {
 			},
 			goldenFile: "install-transparent-proxy.defaults.golden.txt",
 		}),
-		Entry("should generate defaults with user id and DNS redirected", testCase{
+		Entry("should generate defaults with user id and DNS redirected when no conntrack module present", testCase{
 			extraArgs: []string{
 				"--kuma-dp-uid", "0",
 				"--redirect-all-dns-traffic",
@@ -90,7 +90,7 @@ var _ = Describe("kumactl install transparent proxy", func() {
 			errorMatcher: HavePrefix("# [WARNING] error occurred when validating if 'conntrack' iptables module is present. Rules for DNS conntrack zone splitting won't be applied:"),
 			goldenFile:   "install-transparent-proxy.dns.no-conntrack.golden.txt",
 		}),
-		Entry("should generate defaults with user id and DNS redirected when no conntrack module present", testCase{
+		Entry("should generate defaults with user id and DNS redirected", testCase{
 			extraArgs: []string{
 				"--kuma-dp-uid", "0",
 				"--redirect-all-dns-traffic",

--- a/app/kumactl/cmd/install/install_transparent_proxy_test.go
+++ b/app/kumactl/cmd/install/install_transparent_proxy_test.go
@@ -113,7 +113,7 @@ var _ = Describe("kumactl install transparent proxy", func() {
 				"--redirect-dns-upstream-target-chain", "DOCKER_OUTPUT",
 				"--skip-dns-conntrack-zone-split",
 			},
-			goldenFile: "install-transparent-proxy.dns.golden.txt",
+			goldenFile: "install-transparent-proxy.dns.no-conntrack.golden.txt",
 		}),
 		Entry("should generate defaults with overrides", testCase{
 			extraArgs: []string{

--- a/app/kumactl/cmd/install/install_transparent_proxy_test.go
+++ b/app/kumactl/cmd/install/install_transparent_proxy_test.go
@@ -23,8 +23,8 @@ var _ = Describe("kumactl install transparent proxy", func() {
 	})
 
 	type testCase struct {
-		skip      func(stdout, stderr *bytes.Buffer) bool
-		extraArgs []string
+		skip         func(stdout, stderr *bytes.Buffer) bool
+		extraArgs    []string
 		goldenFile   string
 		errorMatcher gomega_types.GomegaMatcher
 	}
@@ -103,7 +103,7 @@ var _ = Describe("kumactl install transparent proxy", func() {
 					"# [WARNING] error occurred when validating if 'conntrack' iptables module is present. Rules for DNS conntrack zone splitting won't be applied:",
 				)
 			},
-			goldenFile:   "install-transparent-proxy.dns.golden.txt",
+			goldenFile: "install-transparent-proxy.dns.golden.txt",
 		}),
 		Entry("should generate defaults with user id and DNS redirected without conntrack zone splitting and log deprecate", testCase{
 			extraArgs: []string{

--- a/app/kumactl/cmd/install/install_transparent_proxy_test.go
+++ b/app/kumactl/cmd/install/install_transparent_proxy_test.go
@@ -75,7 +75,10 @@ var _ = Describe("kumactl install transparent proxy", func() {
 				"--redirect-dns-port", "12345",
 				"--redirect-dns-upstream-target-chain", "DOCKER_OUTPUT",
 			},
-			errorMatcher: HavePrefix("# [WARNING] error occurred when validating if 'conntrack' iptables module is present. Rules for DNS conntrack zone splitting won't be applied:"),
+			errorMatcher: Or(
+				HavePrefix("# [WARNING] error occurred when validating if 'conntrack' iptables module is present. Rules for DNS conntrack zone splitting won't be applied:"), // macOS
+				BeEmpty(), // linux
+			),
 			goldenFile:   "install-transparent-proxy.dns.golden.txt",
 		}),
 		Entry("should generate defaults with user id and DNS redirected without conntrack zone splitting and log deprecate", testCase{

--- a/app/kumactl/cmd/install/install_transparent_proxy_test.go
+++ b/app/kumactl/cmd/install/install_transparent_proxy_test.go
@@ -23,7 +23,8 @@ var _ = Describe("kumactl install transparent proxy", func() {
 	})
 
 	type testCase struct {
-		extraArgs    []string
+		skip      func(stdout, stderr *bytes.Buffer) bool
+		extraArgs []string
 		goldenFile   string
 		errorMatcher gomega_types.GomegaMatcher
 	}
@@ -38,6 +39,11 @@ var _ = Describe("kumactl install transparent proxy", func() {
 
 			// when
 			err := rootCmd.Execute()
+
+			if given.skip != nil && !given.skip(stdout, stderr) {
+				Skip("test skipped")
+			}
+
 			// then
 			Expect(err).ToNot(HaveOccurred())
 			// and
@@ -75,11 +81,29 @@ var _ = Describe("kumactl install transparent proxy", func() {
 				"--redirect-dns-port", "12345",
 				"--redirect-dns-upstream-target-chain", "DOCKER_OUTPUT",
 			},
-			errorMatcher: Or(
-				HavePrefix("# [WARNING] error occurred when validating if 'conntrack' iptables module is present. Rules for DNS conntrack zone splitting won't be applied:"), // macOS
-				BeEmpty(), // linux
-			),
+			skip: func(stdout, stderr *bytes.Buffer) bool {
+				return strings.HasPrefix(
+					stderr.String(),
+					"# [WARNING] error occurred when validating if 'conntrack' iptables module is present. Rules for DNS conntrack zone splitting won't be applied:",
+				)
+			},
+			errorMatcher: HavePrefix("# [WARNING] error occurred when validating if 'conntrack' iptables module is present. Rules for DNS conntrack zone splitting won't be applied:"),
 			goldenFile:   "install-transparent-proxy.dns.golden.txt",
+		}),
+		Entry("should generate defaults with user id and DNS redirected when no conntrack module present", testCase{
+			extraArgs: []string{
+				"--kuma-dp-uid", "0",
+				"--redirect-all-dns-traffic",
+				"--redirect-dns-port", "12345",
+				"--redirect-dns-upstream-target-chain", "DOCKER_OUTPUT",
+			},
+			skip: func(stdout, stderr *bytes.Buffer) bool {
+				return !strings.HasPrefix(
+					stderr.String(),
+					"# [WARNING] error occurred when validating if 'conntrack' iptables module is present. Rules for DNS conntrack zone splitting won't be applied:",
+				)
+			},
+			goldenFile:   "install-transparent-proxy.dns.no-conntrack.golden.txt",
 		}),
 		Entry("should generate defaults with user id and DNS redirected without conntrack zone splitting and log deprecate", testCase{
 			extraArgs: []string{

--- a/app/kumactl/cmd/install/testdata/install-transparent-proxy.dns.golden.txt
+++ b/app/kumactl/cmd/install/testdata/install-transparent-proxy.dns.golden.txt
@@ -1,3 +1,9 @@
+* raw
+-A PREROUTING -p udp --sport 53 -j CT --zone 1
+-A OUTPUT -p udp --dport 53 -m owner --uid-owner 0 -j CT --zone 1
+-A OUTPUT -p udp --sport 12345 -m owner --uid-owner 0 -j CT --zone 2
+-A OUTPUT -p udp --dport 53 -j CT --zone 2
+COMMIT
 * nat
 -N KUMA_MESH_INBOUND
 -N KUMA_MESH_OUTBOUND

--- a/app/kumactl/cmd/install/testdata/install-transparent-proxy.dns.no-conntrack.golden.txt
+++ b/app/kumactl/cmd/install/testdata/install-transparent-proxy.dns.no-conntrack.golden.txt
@@ -1,0 +1,27 @@
+* raw
+-A PREROUTING -p udp --sport 53 -j CT --zone 1
+-A OUTPUT -p udp --dport 53 -m owner --uid-owner 0 -j CT --zone 1
+-A OUTPUT -p udp --sport 12345 -m owner --uid-owner 0 -j CT --zone 2
+-A OUTPUT -p udp --dport 53 -j CT --zone 2
+COMMIT
+* nat
+-N KUMA_MESH_INBOUND
+-N KUMA_MESH_OUTBOUND
+-N KUMA_MESH_INBOUND_REDIRECT
+-N KUMA_MESH_OUTBOUND_REDIRECT
+-A PREROUTING -p tcp -j KUMA_MESH_INBOUND
+-I OUTPUT 1 -p udp --dport 53 -m owner --uid-owner 0 -j DOCKER_OUTPUT
+-I OUTPUT 2 -p udp --dport 53 -j REDIRECT --to-ports 12345
+-A OUTPUT -p tcp -j KUMA_MESH_OUTBOUND
+-A KUMA_MESH_INBOUND -p tcp -j KUMA_MESH_INBOUND_REDIRECT
+-A KUMA_MESH_OUTBOUND -s subnetPlaceholder/mask -o ifPlaceholder -j RETURN
+-A KUMA_MESH_OUTBOUND -p tcp ! --dport 53 -o ifPlaceholder ! -d subnetPlaceholder/mask -m owner --uid-owner 0 -j KUMA_MESH_INBOUND_REDIRECT
+-A KUMA_MESH_OUTBOUND -p tcp ! --dport 53 -o ifPlaceholder -m owner ! --uid-owner 0 -j RETURN
+-A KUMA_MESH_OUTBOUND -m owner --uid-owner 0 -j RETURN
+-A KUMA_MESH_OUTBOUND -p tcp --dport 53 -j REDIRECT --to-ports 12345
+-A KUMA_MESH_OUTBOUND -d subnetPlaceholder/mask -j RETURN
+-A KUMA_MESH_OUTBOUND -j KUMA_MESH_OUTBOUND_REDIRECT
+-A KUMA_MESH_INBOUND_REDIRECT -p tcp -j REDIRECT --to-ports inboundPort
+-A KUMA_MESH_OUTBOUND_REDIRECT -p tcp -j REDIRECT --to-ports 15001
+COMMIT
+# Transparent proxy set up successfully, you can now run kuma-dp using transparent-proxy.

--- a/app/kumactl/cmd/install/testdata/install-transparent-proxy.dns.no-conntrack.golden.txt
+++ b/app/kumactl/cmd/install/testdata/install-transparent-proxy.dns.no-conntrack.golden.txt
@@ -1,9 +1,3 @@
-* raw
--A PREROUTING -p udp --sport 53 -j CT --zone 1
--A OUTPUT -p udp --dport 53 -m owner --uid-owner 0 -j CT --zone 1
--A OUTPUT -p udp --sport 12345 -m owner --uid-owner 0 -j CT --zone 2
--A OUTPUT -p udp --dport 53 -j CT --zone 2
-COMMIT
 * nat
 -N KUMA_MESH_INBOUND
 -N KUMA_MESH_OUTBOUND


### PR DESCRIPTION
### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues
  - no relevant issue
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS
  - it won't
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s)
  - it contains only changes in tests
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)?
  - no need
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label)
  - no need

> Changelog: skip

<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
