### PR TITLE
test(e2e): revert implementation of delete deployment for test-server

### DIFF
--- a/test/e2e_env/multizone/localityawarelb/locality_aware_multizone_hybrid.go
+++ b/test/e2e_env/multizone/localityawarelb/locality_aware_multizone_hybrid.go
@@ -402,7 +402,7 @@ func resetCounter(cluster Cluster, name string, namespace string) error {
 }
 
 // TODO(lukidzi): use test-server implementation: https://github.com/kumahq/kuma/issues/8245
-func DeleteK8sApp(c Cluster, name string, namespace string) error{
+func DeleteK8sApp(c Cluster, name string, namespace string) error {
 	if err := k8s.RunKubectlE(c.GetTesting(), c.GetKubectlOptions(namespace), "delete", "service", name); err != nil {
 		return err
 	}

--- a/test/e2e_env/multizone/localityawarelb/locality_aware_multizone_hybrid.go
+++ b/test/e2e_env/multizone/localityawarelb/locality_aware_multizone_hybrid.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/gruntwork-io/terratest/modules/k8s"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
@@ -290,7 +291,7 @@ spec:
 		}, "30s", "5s").Should(HaveKeyWithValue(Equal(`test-server-zone-1`), BeNumerically("==", 100)))
 
 		// when zone kuma-1-zone is disabled
-		Expect(multizone.KubeZone1.DeleteDeployment("test-server")).To(Succeed())
+		Expect(DeleteK8sApp(multizone.KubeZone1, "test-server", namespace)).To(Succeed())
 
 		// then traffic should goes to k8s
 		Eventually(func(g Gomega) {
@@ -398,4 +399,15 @@ func resetCounter(cluster Cluster, name string, namespace string) error {
 		client.WithMethod("POST"),
 	)
 	return err
+}
+
+// TODO(lukidzi): use test-server implementation: https://github.com/kumahq/kuma/issues/8245
+func DeleteK8sApp(c Cluster, name string, namespace string) error{
+	if err := k8s.RunKubectlE(c.GetTesting(), c.GetKubectlOptions(namespace), "delete", "service", name); err != nil {
+		return err
+	}
+	if err := k8s.RunKubectlE(c.GetTesting(), c.GetKubectlOptions(namespace), "delete", "deployment", name); err != nil {
+		return err
+	}
+	return nil
 }

--- a/test/framework/deployments/testserver/kubernetes.go
+++ b/test/framework/deployments/testserver/kubernetes.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/gruntwork-io/terratest/modules/k8s"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -312,12 +311,14 @@ func (k *k8SDeployment) Delete(c framework.Cluster) error {
 	// This means that namespace is no longer available so the code below would throw an error
 	// If we ever switch DemoClient to be deployment and remove manual deletion of TestNamespace
 	// then we can rely on code below to delete tht deployment.
-	if err := k8s.RunKubectlE(c.GetTesting(), c.GetKubectlOptions(k.opts.Namespace), "delete", "service", k.opts.Name); err != nil {
-		return err
-	}
-	if err := k8s.RunKubectlE(c.GetTesting(), c.GetKubectlOptions(k.opts.Namespace), "delete", "deployment", k.opts.Name); err != nil {
-		return err
-	}
+
+	// TODO(lukidzi): https://github.com/kumahq/kuma/issues/8245
+	// if err := k8s.RunKubectlE(c.GetTesting(), c.GetKubectlOptions(k.opts.Namespace), "delete", "service", k.opts.Name); err != nil {
+	// 	return err
+	// }
+	// if err := k8s.RunKubectlE(c.GetTesting(), c.GetKubectlOptions(k.opts.Namespace), "delete", "deployment", k.opts.Name); err != nil {
+	// 	return err
+	// }
 	return nil
 }
 


### PR DESCRIPTION
### Checklist prior to review

To be investigated in https://github.com/kumahq/kuma/issues/8245

- [ ] [Link to relevant issue][1] as well as docs and UI issues --
- [ ] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [ ] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [ ] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [ ] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
