### PR TITLE
test(e2e): increase ranges of possible value

### DIFF
--- a/test/e2e_env/multizone/localityawarelb/locality_aware_multizone_hybrid.go
+++ b/test/e2e_env/multizone/localityawarelb/locality_aware_multizone_hybrid.go
@@ -338,13 +338,13 @@ spec:
 		Eventually(func() (map[string]int, error) {
 			return client.CollectResponsesByInstance(
 				multizone.KubeZone2, "demo-client-mesh-route", "test-server-mesh-route_locality-aware-lb_svc_80.mesh",
-				client.WithNumberOfRequests(100),
+				client.WithNumberOfRequests(200),
 				client.FromKubernetesPod(namespace, "demo-client-mesh-route"),
 			)
-		}, "30s", "5s").Should(
+		}, "30s", "10s").Should(
 			And(
-				HaveKeyWithValue(Equal(`test-server-mesh-route-zone-1`), BeNumerically("~", 50, 15)),
-				HaveKeyWithValue(Equal(`test-server-mesh-route-zone-5`), BeNumerically("~", 50, 15)),
+				HaveKeyWithValue(Equal(`test-server-mesh-route-zone-1`), BeNumerically("~", 100, 20)),
+				HaveKeyWithValue(Equal(`test-server-mesh-route-zone-5`), BeNumerically("~", 100, 20)),
 			),
 		)
 
@@ -357,7 +357,7 @@ spec:
 		// and generate some traffic
 		_, err := client.CollectResponsesAndFailures(
 			multizone.KubeZone2, "demo-client-mesh-route", "test-server-mesh-route_locality-aware-lb_svc_80.mesh",
-			client.WithNumberOfRequests(100),
+			client.WithNumberOfRequests(200),
 			client.NoFail(),
 			client.WithoutRetries(),
 			client.FromKubernetesPod(namespace, "demo-client-mesh-route"),
@@ -367,10 +367,10 @@ spec:
 		// then
 		failedRequests, err := failRequestCount(multizone.KubeZone2, "demo-client-mesh-route")
 		Expect(err).ToNot(HaveOccurred())
-		Expect(failedRequests).To(BeNumerically("~", 50, 15))
+		Expect(failedRequests).To(BeNumerically("~", 100, 20))
 		successRequests, err := successRequestCount(multizone.KubeZone2, "demo-client-mesh-route")
 		Expect(err).ToNot(HaveOccurred())
-		Expect(successRequests).To(BeNumerically("~", 50, 15))
+		Expect(successRequests).To(BeNumerically("~", 100, 20))
 	})
 }
 

--- a/test/e2e_env/multizone/localityawarelb/locality_aware_multizone_hybrid.go
+++ b/test/e2e_env/multizone/localityawarelb/locality_aware_multizone_hybrid.go
@@ -343,8 +343,8 @@ spec:
 			)
 		}, "30s", "5s").Should(
 			And(
-				HaveKeyWithValue(Equal(`test-server-mesh-route-zone-1`), BeNumerically("~", 50, 10)),
-				HaveKeyWithValue(Equal(`test-server-mesh-route-zone-5`), BeNumerically("~", 50, 10)),
+				HaveKeyWithValue(Equal(`test-server-mesh-route-zone-1`), BeNumerically("~", 50, 15)),
+				HaveKeyWithValue(Equal(`test-server-mesh-route-zone-5`), BeNumerically("~", 50, 15)),
 			),
 		)
 


### PR DESCRIPTION
### Checklist prior to review


- [ ] [Link to relevant issue][1] as well as docs and UI issues --
- [ ] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [ ] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [ ] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [ ] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
