### PR TITLE
chore(metrics): do not shorten commit in basedOnKuma cp_metric

### DIFF
--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -58,7 +58,7 @@ func (b BuildInfo) AsMap() map[string]string {
 		"git_tag":    b.GitTag,
 	}
 	if b.BasedOnKuma != "" {
-		res["based_on_kuma"] = shortCommit(b.BasedOnKuma)
+		res["based_on_kuma"] = b.BasedOnKuma
 	}
 	return res
 }
@@ -66,7 +66,7 @@ func (b BuildInfo) AsMap() map[string]string {
 func (b BuildInfo) UserAgent(component string) string {
 	commit := shortCommit(b.GitCommit)
 	if b.BasedOnKuma != "" {
-		commit = fmt.Sprintf("%s/kuma-%s", commit, shortCommit(b.BasedOnKuma))
+		commit = fmt.Sprintf("%s/kuma-%s", commit, b.BasedOnKuma)
 	}
 	return fmt.Sprintf("%s/%s (%s; %s; %s/%s)",
 		component,


### PR DESCRIPTION
otherwise on previews we will get (7 chars):

```
based_on_kuma:0.0.0-p
```

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [X] [Link to relevant issue][1] as well as docs and UI issues --
- [X] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [X] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [X] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [X] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
