### PR TITLE
fix(core): better lifecycle when context is getting cancelled

### DIFF
--- a/app/kuma-dp/cmd/run.go
+++ b/app/kuma-dp/cmd/run.go
@@ -160,17 +160,13 @@ func newRunCmd(opts kuma_cmd.RunCmdOpts, rootCtx *RootContext) *cobra.Command {
 				Dataplane: rest.From.Resource(proxyResource),
 				Stdout:    cmd.OutOrStdout(),
 				Stderr:    cmd.OutOrStderr(),
-				Quit:      shouldQuit,
 			}
 
-			if cfg.DNS.Enabled &&
-				cfg.Dataplane.ProxyType != string(mesh_proto.IngressProxyType) &&
-				cfg.Dataplane.ProxyType != string(mesh_proto.EgressProxyType) {
+			if cfg.DNS.Enabled && !cfg.Dataplane.IsZoneProxy() {
 				dnsOpts := &dnsserver.Opts{
 					Config: *cfg,
 					Stdout: cmd.OutOrStdout(),
 					Stderr: cmd.OutOrStderr(),
-					Quit:   shouldQuit,
 				}
 
 				dnsServer, err := dnsserver.New(dnsOpts)

--- a/app/kuma-dp/pkg/dataplane/command/build_command_darwin.go
+++ b/app/kuma-dp/pkg/dataplane/command/build_command_darwin.go
@@ -1,4 +1,4 @@
-//go:build linux
+//go:build darwin
 
 package command
 
@@ -18,7 +18,6 @@ func BuildCommand(
 ) *exec.Cmd {
 	command := baseBuildCommand(ctx, stdout, stderr, name, args...)
 	command.SysProcAttr = &syscall.SysProcAttr{
-		Pdeathsig: syscall.SIGKILL,
 		// Set those attributes so the new process won't receive the signals from a parent automatically.
 		Setpgid: true,
 		Pgid:    0,

--- a/app/kuma-dp/pkg/dataplane/command/build_command_windows.go
+++ b/app/kuma-dp/pkg/dataplane/command/build_command_windows.go
@@ -15,9 +15,7 @@ func BuildCommand(
 	name string,
 	args ...string,
 ) *exec.Cmd {
-	command := exec.CommandContext(ctx, name, args...)
-	command.Stdout = stdout
-	command.Stderr = stderr
+	command := baseBuildCommand(ctx, stdout, stderr, name, args)
 	// todo(jakubdyszkiewicz): do not propagate SIGTERM
 
 	return command

--- a/pkg/config/app/kuma-dp/config.go
+++ b/pkg/config/app/kuma-dp/config.go
@@ -153,6 +153,11 @@ func (d *Dataplane) PostProcess() error {
 	return nil
 }
 
+func (d *Dataplane) IsZoneProxy() bool {
+	return d.ProxyType == string(mesh_proto.IngressProxyType) ||
+		d.ProxyType == string(mesh_proto.EgressProxyType)
+}
+
 func validateMeshOrName[V ~string](typ string, value V) error {
 	if value == "" {
 		return errors.Errorf("%s must be non-empty", typ)
@@ -345,7 +350,7 @@ type DNS struct {
 	CoreDNSConfigTemplatePath string `json:"coreDnsConfigTemplatePath,omitempty" envconfig:"kuma_dns_core_dns_config_template_path"`
 	// Dir to store auto-generated DNS Server config in.
 	ConfigDir string `json:"configDir,omitempty" envconfig:"kuma_dns_config_dir"`
-	// Port where Prometheus stats will be exposed for the DNS Server
+	// PrometheusPort where Prometheus stats will be exposed for the DNS Server
 	PrometheusPort uint32 `json:"prometheusPort,omitempty" envconfig:"kuma_dns_prometheus_port"`
 }
 


### PR DESCRIPTION
- For kuma-dp we properly shutdown when context is closed
- In KDS the client cancelled being closed make all the components stop

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
