### PR TITLE
fix(core): better lifecycle when context is getting cancelled

### DIFF
--- a/app/kuma-dp/pkg/dataplane/command/build_command_darwin.go
+++ b/app/kuma-dp/pkg/dataplane/command/build_command_darwin.go
@@ -1,4 +1,4 @@
-//go:build linux
+//go:build darwin
 
 package command
 
@@ -18,7 +18,6 @@ func BuildCommand(
 ) *exec.Cmd {
 	command := baseBuildCommand(ctx, stdout, stderr, name, args...)
 	command.SysProcAttr = &syscall.SysProcAttr{
-		Pdeathsig: syscall.SIGKILL,
 		// Set those attributes so the new process won't receive the signals from a parent automatically.
 		Setpgid: true,
 		Pgid:    0,

--- a/app/kuma-dp/pkg/dataplane/command/build_command_windows.go
+++ b/app/kuma-dp/pkg/dataplane/command/build_command_windows.go
@@ -15,9 +15,7 @@ func BuildCommand(
 	name string,
 	args ...string,
 ) *exec.Cmd {
-	command := exec.CommandContext(ctx, name, args...)
-	command.Stdout = stdout
-	command.Stderr = stderr
+	command := baseBuildCommand(ctx, stdout, stderr, name, args)
 	// todo(jakubdyszkiewicz): do not propagate SIGTERM
 
 	return command

--- a/app/kuma-dp/pkg/dataplane/dnsserver/dnsserver.go
+++ b/app/kuma-dp/pkg/dataplane/dnsserver/dnsserver.go
@@ -49,6 +49,9 @@ func New(opts *Opts) (*DNSServer, error) {
 	if err != nil {
 		return nil, errors.Wrapf(err, "could not find coreDNS executable")
 	}
+	if opts.OnFinish == nil {
+		opts.OnFinish = func() {}
+	}
 
 	return &DNSServer{opts: opts, path: dnsServerPath}, nil
 }

--- a/app/kuma-dp/pkg/dataplane/dnsserver/dnsserver.go
+++ b/app/kuma-dp/pkg/dataplane/dnsserver/dnsserver.go
@@ -30,10 +30,10 @@ type DNSServer struct {
 var _ component.GracefulComponent = &DNSServer{}
 
 type Opts struct {
-	Config kuma_dp.Config
-	Stdout io.Writer
-	Stderr io.Writer
-	Quit   chan struct{}
+	Config   kuma_dp.Config
+	Stdout   io.Writer
+	Stderr   io.Writer
+	OnFinish context.CancelFunc
 }
 
 func lookupDNSServerPath(configuredPath string) (string, error) {
@@ -47,8 +47,7 @@ func lookupDNSServerPath(configuredPath string) (string, error) {
 func New(opts *Opts) (*DNSServer, error) {
 	dnsServerPath, err := lookupDNSServerPath(opts.Config.DNS.CoreDNSBinaryPath)
 	if err != nil {
-		runLog.Error(err, "could not find the DNS Server executable in your path")
-		return nil, err
+		return nil, errors.Wrapf(err, "could not find coreDNS executable")
 	}
 
 	return &DNSServer{opts: opts, path: dnsServerPath}, nil
@@ -59,7 +58,7 @@ func (s *DNSServer) GetVersion() (string, error) {
 	command := exec.Command(path, "--version")
 	output, err := command.Output()
 	if err != nil {
-		return "", err
+		return "", errors.Wrapf(err, "failed to execute coreDNS at path %s", path)
 	}
 
 	match := regexp.MustCompile(`CoreDNS-(.*)`).FindSubmatch(output)
@@ -76,6 +75,12 @@ func (s *DNSServer) NeedLeaderElection() bool {
 
 func (s *DNSServer) Start(stop <-chan struct{}) error {
 	s.wg.Add(1)
+	// Component should only be considered done after CoreDNS exists.
+	// Otherwise, we may not propagate SIGTERM on time.
+	defer func() {
+		s.wg.Done()
+		s.opts.OnFinish()
+	}()
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -129,33 +134,18 @@ func (s *DNSServer) Start(stop <-chan struct{}) error {
 		return err
 	}
 
-	done := make(chan error, 1)
-
 	go func() {
-		done <- command.Wait()
-		// Component should only be considered done after CoreDNS exists.
-		// Otherwise, we may not propagate SIGTERM on time.
-		s.wg.Done()
-	}()
-
-	select {
-	case <-stop:
+		<-stop
 		runLog.Info("stopping DNS Server")
 		cancel()
-		return nil
-	case err := <-done:
-		if err != nil {
-			runLog.Error(err, "DNS Server terminated with an error")
-		} else {
-			runLog.Info("DNS Server terminated successfully")
-		}
-
-		if s.opts.Quit != nil {
-			close(s.opts.Quit)
-		}
-
+	}()
+	err = command.Wait()
+	if err != nil && !errors.Is(err, context.Canceled) {
+		runLog.Error(err, "DNS Server terminated with an error")
 		return err
 	}
+	runLog.Info("DNS Server terminated successfully")
+	return nil
 }
 
 func (s *DNSServer) WaitForDone() {

--- a/app/kuma-dp/pkg/dataplane/envoy/envoy.go
+++ b/app/kuma-dp/pkg/dataplane/envoy/envoy.go
@@ -55,6 +55,9 @@ func New(opts Opts) (*Envoy, error) {
 	if _, err := lookupEnvoyPath(opts.Config.DataplaneRuntime.BinaryPath); err != nil {
 		return nil, errors.Wrap(err, "could not find envoy executable")
 	}
+	if opts.OnFinish == nil {
+		opts.OnFinish = func() {}
+	}
 	return &Envoy{opts: opts}, nil
 }
 

--- a/app/kuma-dp/pkg/dataplane/envoy/envoy.go
+++ b/app/kuma-dp/pkg/dataplane/envoy/envoy.go
@@ -48,13 +48,12 @@ type Opts struct {
 	Dataplane       rest.Resource
 	Stdout          io.Writer
 	Stderr          io.Writer
-	Quit            chan struct{}
+	OnFinish        func()
 }
 
 func New(opts Opts) (*Envoy, error) {
 	if _, err := lookupEnvoyPath(opts.Config.DataplaneRuntime.BinaryPath); err != nil {
-		runLog.Error(err, "could not find the envoy executable in your path")
-		return nil, err
+		return nil, errors.Wrap(err, "could not find envoy executable")
 	}
 	return &Envoy{opts: opts}, nil
 }
@@ -87,6 +86,12 @@ func lookupEnvoyPath(configuredPath string) (string, error) {
 
 func (e *Envoy) Start(stop <-chan struct{}) error {
 	e.wg.Add(1)
+	// Component should only be considered done after Envoy exists.
+	// Otherwise, we may not propagate SIGTERM on time.
+	defer func() {
+		e.wg.Done()
+		e.opts.OnFinish()
+	}()
 
 	configFile, err := GenerateBootstrapFile(e.opts.Config.DataplaneRuntime, e.opts.BootstrapConfig)
 	if err != nil {
@@ -144,31 +149,18 @@ func (e *Envoy) Start(stop <-chan struct{}) error {
 		runLog.Error(err, "envoy executable failed", "path", resolvedPath, "arguments", args)
 		return err
 	}
-	done := make(chan error, 1)
 	go func() {
-		done <- command.Wait()
-		// Component should only be considered done after Envoy exists.
-		// Otherwise, we may not propagate SIGTERM on time.
-		e.wg.Done()
-	}()
-
-	select {
-	case <-stop:
+		<-stop
 		runLog.Info("stopping Envoy")
 		cancel()
-		return nil
-	case err := <-done:
-		if err != nil {
-			runLog.Error(err, "Envoy terminated with an error")
-		} else {
-			runLog.Info("Envoy terminated successfully")
-		}
-		if e.opts.Quit != nil {
-			close(e.opts.Quit)
-		}
-
+	}()
+	err = command.Wait()
+	if err != nil && !errors.Is(err, context.Canceled) {
+		runLog.Error(err, "Envoy terminated with an error")
 		return err
 	}
+	runLog.Info("Envoy terminated successfully")
+	return nil
 }
 
 func (e *Envoy) WaitForDone() {

--- a/pkg/config/app/kuma-dp/config.go
+++ b/pkg/config/app/kuma-dp/config.go
@@ -153,6 +153,11 @@ func (d *Dataplane) PostProcess() error {
 	return nil
 }
 
+func (d *Dataplane) IsZoneProxy() bool {
+	return d.ProxyType == string(mesh_proto.IngressProxyType) ||
+		d.ProxyType == string(mesh_proto.EgressProxyType)
+}
+
 func validateMeshOrName[V ~string](typ string, value V) error {
 	if value == "" {
 		return errors.Errorf("%s must be non-empty", typ)
@@ -345,7 +350,7 @@ type DNS struct {
 	CoreDNSConfigTemplatePath string `json:"coreDnsConfigTemplatePath,omitempty" envconfig:"kuma_dns_core_dns_config_template_path"`
 	// Dir to store auto-generated DNS Server config in.
 	ConfigDir string `json:"configDir,omitempty" envconfig:"kuma_dns_config_dir"`
-	// Port where Prometheus stats will be exposed for the DNS Server
+	// PrometheusPort where Prometheus stats will be exposed for the DNS Server
 	PrometheusPort uint32 `json:"prometheusPort,omitempty" envconfig:"kuma_dns_prometheus_port"`
 }
 


### PR DESCRIPTION
- For kuma-dp we properly shutdown when context is closed
- In KDS the client cancelled being closed make all the components stop

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
