### PR TITLE
fix(kuma-cp): change affinityTag field in MeshLoadBalancingStrategy t…

### DIFF
--- a/app/kumactl/cmd/install/testdata/install-control-plane.defaults.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.defaults.golden.yaml
@@ -2151,8 +2151,6 @@ spec:
                                     - key
                                     type: object
                                   type: array
-                              required:
-                              - affinityTags
                               type: object
                           type: object
                       type: object

--- a/app/kumactl/cmd/install/testdata/install-control-plane.gateway-api-present-not-enabled.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.gateway-api-present-not-enabled.yaml
@@ -2151,8 +2151,6 @@ spec:
                                     - key
                                     type: object
                                   type: array
-                              required:
-                              - affinityTags
                               type: object
                           type: object
                       type: object

--- a/app/kumactl/cmd/install/testdata/install-control-plane.gateway-api-present.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.gateway-api-present.yaml
@@ -2355,8 +2355,6 @@ spec:
                                     - key
                                     type: object
                                   type: array
-                              required:
-                              - affinityTags
                               type: object
                           type: object
                       type: object

--- a/app/kumactl/cmd/install/testdata/install-control-plane.with-helm-set.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.with-helm-set.yaml
@@ -2171,8 +2171,6 @@ spec:
                                     - key
                                     type: object
                                   type: array
-                              required:
-                              - affinityTags
                               type: object
                           type: object
                       type: object

--- a/app/kumactl/cmd/install/testdata/install-crds.all.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-crds.all.golden.yaml
@@ -3456,8 +3456,6 @@ spec:
                                     - key
                                     type: object
                                   type: array
-                              required:
-                              - affinityTags
                               type: object
                           type: object
                       type: object

--- a/app/kumactl/cmd/install/testdata/install-crds.experimental-gatewayapi.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-crds.experimental-gatewayapi.golden.yaml
@@ -3660,8 +3660,6 @@ spec:
                                     - key
                                     type: object
                                   type: array
-                              required:
-                              - affinityTags
                               type: object
                           type: object
                       type: object

--- a/deployments/charts/kuma/crds/kuma.io_meshloadbalancingstrategies.yaml
+++ b/deployments/charts/kuma/crds/kuma.io_meshloadbalancingstrategies.yaml
@@ -479,8 +479,6 @@ spec:
                                     - key
                                     type: object
                                   type: array
-                              required:
-                              - affinityTags
                               type: object
                           type: object
                       type: object

--- a/docs/generated/openapi.yaml
+++ b/docs/generated/openapi.yaml
@@ -4126,8 +4126,6 @@ components:
                                     - key
                                   type: object
                                 type: array
-                            required:
-                              - affinityTags
                             type: object
                         type: object
                     type: object

--- a/docs/generated/raw/crds/kuma.io_meshloadbalancingstrategies.yaml
+++ b/docs/generated/raw/crds/kuma.io_meshloadbalancingstrategies.yaml
@@ -479,8 +479,6 @@ spec:
                                     - key
                                     type: object
                                   type: array
-                              required:
-                              - affinityTags
                               type: object
                           type: object
                       type: object

--- a/pkg/plugins/policies/meshloadbalancingstrategy/api/v1alpha1/meshloadbalancingstrategy.go
+++ b/pkg/plugins/policies/meshloadbalancingstrategy/api/v1alpha1/meshloadbalancingstrategy.go
@@ -48,7 +48,7 @@ type LocalityAwareness struct {
 
 type LocalZone struct {
 	// AffinityTags list of tags for local zone load balancing.
-	AffinityTags []AffinityTag `json:"affinityTags"`
+	AffinityTags *[]AffinityTag `json:"affinityTags,omitempty"`
 }
 
 type AffinityTag struct {

--- a/pkg/plugins/policies/meshloadbalancingstrategy/api/v1alpha1/schema.yaml
+++ b/pkg/plugins/policies/meshloadbalancingstrategy/api/v1alpha1/schema.yaml
@@ -317,8 +317,6 @@ properties:
                               - key
                             type: object
                           type: array
-                      required:
-                        - affinityTags
                       type: object
                   type: object
               type: object

--- a/pkg/plugins/policies/meshloadbalancingstrategy/api/v1alpha1/validator.go
+++ b/pkg/plugins/policies/meshloadbalancingstrategy/api/v1alpha1/validator.go
@@ -7,6 +7,7 @@ import (
 	common_api "github.com/kumahq/kuma/api/common/v1alpha1"
 	"github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	"github.com/kumahq/kuma/pkg/core/validators"
+	"github.com/kumahq/kuma/pkg/util/pointer"
 )
 
 func (r *MeshLoadBalancingStrategyResource) validate() error {
@@ -71,7 +72,7 @@ func validateLocalZone(localZone *LocalZone) validators.ValidationError {
 	}
 
 	var weightSpecified int
-	for idx, affinityTag := range localZone.AffinityTags {
+	for idx, affinityTag := range pointer.Deref(localZone.AffinityTags) {
 		path := validators.RootedAt("affinityTags").Index(idx)
 		if affinityTag.Key == "" {
 			verr.AddViolationAt(path.Field("key"), validators.MustNotBeEmpty)
@@ -82,7 +83,7 @@ func validateLocalZone(localZone *LocalZone) validators.ValidationError {
 		}
 	}
 
-	if weightSpecified > 0 && weightSpecified != len(localZone.AffinityTags) {
+	if weightSpecified > 0 && weightSpecified != len(pointer.Deref(localZone.AffinityTags)) {
 		verr.AddViolation("affinityTags", "all or none affinity tags should have weight")
 	}
 	return verr

--- a/pkg/plugins/policies/meshloadbalancingstrategy/api/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/plugins/policies/meshloadbalancingstrategy/api/v1alpha1/zz_generated.deepcopy.go
@@ -322,9 +322,13 @@ func (in *LocalZone) DeepCopyInto(out *LocalZone) {
 	*out = *in
 	if in.AffinityTags != nil {
 		in, out := &in.AffinityTags, &out.AffinityTags
-		*out = make([]AffinityTag, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
+		*out = new([]AffinityTag)
+		if **in != nil {
+			in, out := *in, *out
+			*out = make([]AffinityTag, len(*in))
+			for i := range *in {
+				(*in)[i].DeepCopyInto(&(*out)[i])
+			}
 		}
 	}
 }

--- a/pkg/plugins/policies/meshloadbalancingstrategy/k8s/crd/kuma.io_meshloadbalancingstrategies.yaml
+++ b/pkg/plugins/policies/meshloadbalancingstrategy/k8s/crd/kuma.io_meshloadbalancingstrategies.yaml
@@ -479,8 +479,6 @@ spec:
                                     - key
                                     type: object
                                   type: array
-                              required:
-                              - affinityTags
                               type: object
                           type: object
                       type: object

--- a/pkg/plugins/policies/meshloadbalancingstrategy/plugin/v1alpha1/plugin.go
+++ b/pkg/plugins/policies/meshloadbalancingstrategy/plugin/v1alpha1/plugin.go
@@ -321,5 +321,5 @@ func (p plugin) configureCluster(c *envoy_cluster.Cluster, config api.Conf) erro
 }
 
 func shouldUseLocalityWeightedLb(config api.Conf) bool {
-	return config.LocalityAwareness != nil && config.LocalityAwareness.LocalZone != nil && len(config.LocalityAwareness.LocalZone.AffinityTags) > 0
+	return config.LocalityAwareness != nil && config.LocalityAwareness.LocalZone != nil && len(pointer.Deref(config.LocalityAwareness.LocalZone.AffinityTags)) > 0
 }

--- a/pkg/plugins/policies/meshloadbalancingstrategy/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshloadbalancingstrategy/plugin/v1alpha1/plugin_test.go
@@ -448,7 +448,7 @@ var _ = Describe("MeshLoadBalancingStrategy", func() {
 											},
 											LocalityAwareness: &v1alpha1.LocalityAwareness{
 												LocalZone: &v1alpha1.LocalZone{
-													AffinityTags: []v1alpha1.AffinityTag{
+													AffinityTags: &[]v1alpha1.AffinityTag{
 														{
 															Key:    "k8s.io/node",
 															Weight: pointer.To[uint32](9000),
@@ -520,7 +520,7 @@ var _ = Describe("MeshLoadBalancingStrategy", func() {
 											},
 											LocalityAwareness: &v1alpha1.LocalityAwareness{
 												LocalZone: &v1alpha1.LocalZone{
-													AffinityTags: []v1alpha1.AffinityTag{
+													AffinityTags: &[]v1alpha1.AffinityTag{
 														{
 															Key:    "k8s.io/node",
 															Weight: pointer.To[uint32](9000),
@@ -649,7 +649,7 @@ var _ = Describe("MeshLoadBalancingStrategy", func() {
 											},
 											LocalityAwareness: &v1alpha1.LocalityAwareness{
 												LocalZone: &v1alpha1.LocalZone{
-													AffinityTags: []v1alpha1.AffinityTag{
+													AffinityTags: &[]v1alpha1.AffinityTag{
 														{
 															Key:    "k8s.io/node",
 															Weight: pointer.To[uint32](9000),
@@ -721,7 +721,7 @@ var _ = Describe("MeshLoadBalancingStrategy", func() {
 											},
 											LocalityAwareness: &v1alpha1.LocalityAwareness{
 												LocalZone: &v1alpha1.LocalZone{
-													AffinityTags: []v1alpha1.AffinityTag{
+													AffinityTags: &[]v1alpha1.AffinityTag{
 														{
 															Key:    "k8s.io/node",
 															Weight: pointer.To[uint32](9000),
@@ -853,7 +853,7 @@ var _ = Describe("MeshLoadBalancingStrategy", func() {
 											},
 											LocalityAwareness: &v1alpha1.LocalityAwareness{
 												LocalZone: &v1alpha1.LocalZone{
-													AffinityTags: []v1alpha1.AffinityTag{
+													AffinityTags: &[]v1alpha1.AffinityTag{
 														{
 															Key:    "k8s.io/node",
 															Weight: pointer.To[uint32](9000),
@@ -1205,7 +1205,7 @@ var _ = Describe("MeshLoadBalancingStrategy", func() {
 											},
 											LocalityAwareness: &v1alpha1.LocalityAwareness{
 												LocalZone: &v1alpha1.LocalZone{
-													AffinityTags: []v1alpha1.AffinityTag{
+													AffinityTags: &[]v1alpha1.AffinityTag{
 														{
 															Key: "k8s.io/node",
 														},

--- a/pkg/plugins/policies/meshloadbalancingstrategy/plugin/v1alpha1/priority.go
+++ b/pkg/plugins/policies/meshloadbalancingstrategy/plugin/v1alpha1/priority.go
@@ -31,8 +31,8 @@ func GetLocalityGroups(conf *api.Conf, inboundTags mesh_proto.MultiValueTagSet, 
 func getLocalLbGroups(conf *api.Conf, inboundTags mesh_proto.MultiValueTagSet) []LocalLbGroup {
 	var localGroups []LocalLbGroup
 	if conf.LocalityAwareness.LocalZone != nil {
-		rulesLen := len(conf.LocalityAwareness.LocalZone.AffinityTags)
-		for i, tag := range conf.LocalityAwareness.LocalZone.AffinityTags {
+		rulesLen := len(pointer.Deref(conf.LocalityAwareness.LocalZone.AffinityTags))
+		for i, tag := range pointer.Deref(conf.LocalityAwareness.LocalZone.AffinityTags) {
 			values := inboundTags.Values(tag.Key)
 			// when weights are not provided we are generating weights by ourselves
 			// the first rule has the highest priority which is 9 * 10^(number of rules - rules position -1)


### PR DESCRIPTION
### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
