### PR TITLE
fix(k8s): don't temporarily remove all AvailableServices on ZoneIngress Pod reconciliations

### DIFF
--- a/pkg/plugins/runtime/k8s/controllers/pod_controller_test.go
+++ b/pkg/plugins/runtime/k8s/controllers/pod_controller_test.go
@@ -277,10 +277,13 @@ var _ = Describe("PodReconciler", func() {
 			}).Build()
 
 		reconciler = &PodReconciler{
-			Client:            kubeClient,
-			EventRecorder:     kube_record.NewFakeRecorder(10),
-			Scheme:            k8sClientScheme,
-			Log:               core.Log.WithName("test"),
+			Client:        kubeClient,
+			EventRecorder: kube_record.NewFakeRecorder(10),
+			Scheme:        k8sClientScheme,
+			Log:           core.Log.WithName("test"),
+			PodConverter: PodConverter{
+				ResourceConverter: k8s.NewSimpleConverter(),
+			},
 			SystemNamespace:   "kuma-system",
 			Persistence:       vips.NewPersistence(core_manager.NewResourceManager(memory.NewStore()), manager.NewConfigManager(memory.NewStore()), false),
 			ResourceConverter: k8s.NewSimpleConverter(),

--- a/pkg/plugins/runtime/k8s/controllers/pod_converter_test.go
+++ b/pkg/plugins/runtime/k8s/controllers/pod_converter_test.go
@@ -305,9 +305,10 @@ var _ = Describe("PodToDataplane(..)", func() {
 			}
 
 			converter := PodConverter{
-				ServiceGetter: nil,
-				NodeGetter:    nodeGetter,
-				Zone:          "zone-1",
+				ServiceGetter:     nil,
+				NodeGetter:        nodeGetter,
+				ResourceConverter: k8s.NewSimpleConverter(),
+				Zone:              "zone-1",
 			}
 
 			// when
@@ -394,9 +395,10 @@ var _ = Describe("PodToDataplane(..)", func() {
 			}
 
 			converter := PodConverter{
-				ServiceGetter: nil,
-				NodeGetter:    nodeGetter,
-				Zone:          "zone-1",
+				ServiceGetter:     nil,
+				NodeGetter:        nodeGetter,
+				ResourceConverter: k8s.NewSimpleConverter(),
+				Zone:              "zone-1",
 			}
 
 			// when
@@ -449,7 +451,9 @@ var _ = Describe("PodToDataplane(..)", func() {
 		DescribeTable("should return a descriptive error",
 			func(given testCase) {
 				// given
-				converter := PodConverter{}
+				converter := PodConverter{
+					ResourceConverter: k8s.NewSimpleConverter(),
+				}
 
 				pod := &kube_core.Pod{}
 				err := yaml.Unmarshal([]byte(given.pod), pod)

--- a/pkg/plugins/runtime/k8s/controllers/testdata/ingress/ingress-exists.existing-dataplane.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/ingress/ingress-exists.existing-dataplane.yaml
@@ -1,0 +1,14 @@
+metadata:
+  creationTimestamp: null
+spec:
+  networking:
+    address: 192.168.0.1
+    advertisedAddress: 192.168.100.1
+    advertisedPort: 10001
+    port: 10001
+  availableServices:
+  - tags:
+      kuma.io/service: service-1-zone-2
+      kuma.io/protocol: http
+    instances: 3
+    mesh: mesh-1

--- a/pkg/plugins/runtime/k8s/controllers/testdata/ingress/ingress-exists.golden.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/ingress/ingress-exists.golden.yaml
@@ -1,0 +1,8 @@
+metadata:
+  creationTimestamp: null
+spec:
+  networking:
+    address: 192.168.0.1
+    advertisedAddress: 192.168.100.1
+    advertisedPort: 10001
+    port: 10001

--- a/pkg/plugins/runtime/k8s/controllers/testdata/ingress/ingress-exists.golden.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/ingress/ingress-exists.golden.yaml
@@ -1,6 +1,12 @@
 metadata:
   creationTimestamp: null
 spec:
+  availableServices:
+  - instances: 3
+    mesh: mesh-1
+    tags:
+      kuma.io/protocol: http
+      kuma.io/service: service-1-zone-2
   networking:
     address: 192.168.0.1
     advertisedAddress: 192.168.100.1

--- a/pkg/plugins/runtime/k8s/controllers/testdata/ingress/ingress-exists.pod.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/ingress/ingress-exists.pod.yaml
@@ -1,0 +1,13 @@
+metadata:
+  namespace: kuma-system
+  name: kuma-ingress
+  labels:
+    app: kuma-ingress
+  annotations:
+    kuma.io/ingress: enabled
+spec:
+  containers:
+    - ports:
+        - containerPort: 10001
+status:
+  podIP: 192.168.0.1

--- a/pkg/plugins/runtime/k8s/controllers/testdata/ingress/ingress-exists.services-for-pod.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/ingress/ingress-exists.services-for-pod.yaml
@@ -1,0 +1,15 @@
+---
+metadata:
+  namespace: kuma-system
+  name: kuma-ingress
+spec:
+  type: LoadBalancer
+  ports:
+    - port: 10001
+      targetPort: 10001
+  selector:
+    app: kuma-ingress
+status:
+  loadBalancer:
+    ingress:
+      - ip: 192.168.100.1


### PR DESCRIPTION
instead of https://github.com/kumahq/kuma/pull/8300

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword

