### PR TITLE
ci(e2e): improve stability of locality aware e2e test

### DIFF
--- a/test/e2e_env/multizone/localityawarelb/locality_aware_multizone_hybrid_egress.go
+++ b/test/e2e_env/multizone/localityawarelb/locality_aware_multizone_hybrid_egress.go
@@ -152,9 +152,9 @@ spec:
 			return client.CollectResponsesByInstance(multizone.UniZone1, "demo-client_locality-aware-lb-egress_svc", "test-server_locality-aware-lb-egress_svc_80.mesh", client.WithNumberOfRequests(300))
 		}, "2m", "10s").Should(
 			And(
-				HaveKeyWithValue(Equal(`test-server-zone-4`), BeNumerically("~", 200, 30)),
-				HaveKeyWithValue(Equal(`test-server-zone-5`), BeNumerically("~", 50, 30)),
-				HaveKeyWithValue(Equal(`test-server-zone-1`), BeNumerically("~", 50, 30)),
+				HaveKeyWithValue(Equal(`test-server-zone-4`), BeNumerically("~", 200, 40)),
+				HaveKeyWithValue(Equal(`test-server-zone-5`), BeNumerically("~", 50, 40)),
+				HaveKeyWithValue(Equal(`test-server-zone-1`), BeNumerically("~", 50, 40)),
 			),
 		)
 


### PR DESCRIPTION
### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
