### PR TITLE
feat(kuma-cp): map BadRequest error to 400

### DIFF
--- a/pkg/core/rest/errors/error_handler.go
+++ b/pkg/core/rest/errors/error_handler.go
@@ -39,6 +39,12 @@ func HandleError(ctx context.Context, response *restful.Response, err error, tit
 			Title:  "Bad Request",
 			Detail: err.Error(),
 		}
+	case errors.Is(err, &BadRequest{}):
+		kumaErr = &types.Error{
+			Status: 400,
+			Title:  title,
+			Detail: err.Error(),
+		}
 	case manager.IsMeshNotFound(err):
 		kumaErr = &types.Error{
 			Status: 400,

--- a/pkg/core/rest/errors/error_handler.go
+++ b/pkg/core/rest/errors/error_handler.go
@@ -33,7 +33,10 @@ func HandleError(ctx context.Context, response *restful.Response, err error, tit
 			Title:  title,
 			Detail: "Not found",
 		}
-	case errors.Is(err, &rest.InvalidResourceError{}) || errors.Is(err, &registry.InvalidResourceTypeError{}) || errors.Is(err, &store.PreconditionError{}) || errors.Is(err, &BadRequest{}):
+	case errors.Is(err, &rest.InvalidResourceError{}):
+	case errors.Is(err, &registry.InvalidResourceTypeError{}):
+	case errors.Is(err, &store.PreconditionError{}):
+	case errors.Is(err, &BadRequest{}):
 		kumaErr = &types.Error{
 			Status: 400,
 			Title:  "Bad Request",

--- a/pkg/core/rest/errors/error_handler.go
+++ b/pkg/core/rest/errors/error_handler.go
@@ -33,16 +33,10 @@ func HandleError(ctx context.Context, response *restful.Response, err error, tit
 			Title:  title,
 			Detail: "Not found",
 		}
-	case errors.Is(err, &rest.InvalidResourceError{}) || errors.Is(err, &registry.InvalidResourceTypeError{}) || errors.Is(err, &store.PreconditionError{}):
+	case errors.Is(err, &rest.InvalidResourceError{}) || errors.Is(err, &registry.InvalidResourceTypeError{}) || errors.Is(err, &store.PreconditionError{}) || errors.Is(err, &BadRequest{}):
 		kumaErr = &types.Error{
 			Status: 400,
 			Title:  "Bad Request",
-			Detail: err.Error(),
-		}
-	case errors.Is(err, &BadRequest{}):
-		kumaErr = &types.Error{
-			Status: 400,
-			Title:  title,
 			Detail: err.Error(),
 		}
 	case manager.IsMeshNotFound(err):

--- a/pkg/core/rest/errors/error_handler.go
+++ b/pkg/core/rest/errors/error_handler.go
@@ -33,10 +33,7 @@ func HandleError(ctx context.Context, response *restful.Response, err error, tit
 			Title:  title,
 			Detail: "Not found",
 		}
-	case errors.Is(err, &rest.InvalidResourceError{}):
-	case errors.Is(err, &registry.InvalidResourceTypeError{}):
-	case errors.Is(err, &store.PreconditionError{}):
-	case errors.Is(err, &BadRequest{}):
+	case errors.Is(err, &rest.InvalidResourceError{}), errors.Is(err, &registry.InvalidResourceTypeError{}), errors.Is(err, &store.PreconditionError{}), errors.Is(err, &BadRequest{}):
 		kumaErr = &types.Error{
 			Status: 400,
 			Title:  "Bad Request",

--- a/pkg/core/rest/errors/errors.go
+++ b/pkg/core/rest/errors/errors.go
@@ -38,7 +38,7 @@ func NewBadRequestError(msg string) error {
 }
 
 func (e *BadRequest) Error() string {
-	if e.msg != "" {
+	if e.msg == "" {
 		return "bad request"
 	}
 	return fmt.Sprintf("bad request: %s", e.msg)


### PR DESCRIPTION
### Checklist prior to review

- [ ] [Link to relevant issue][1] as well as docs and UI issues --
- [ ] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [ ] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [ ] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [ ] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
