### PR TITLE
fix(kuma-cni): support port exclusion for UIDs

### DIFF
--- a/app/cni/pkg/cni/annotations.go
+++ b/app/cni/pkg/cni/annotations.go
@@ -18,28 +18,32 @@ const (
 )
 
 var annotationRegistry = map[string]*annotationParam{
-	"inject":               {"kuma.io/sidecar-injection", "", alwaysValidFunc},
-	"ports":                {"kuma.io/envoy-admin-port", "", validatePortList},
-	"excludeInboundPorts":  {"traffic.kuma.io/exclude-inbound-ports", defaultRedirectExcludePort, validatePortList},
-	"excludeOutboundPorts": {"traffic.kuma.io/exclude-outbound-ports", defaultRedirectExcludePort, validatePortList},
-	"inboundPort":          {"kuma.io/transparent-proxying-inbound-port", defaultInboundPort, validatePortList},
-	"inboundPortV6":        {"kuma.io/transparent-proxying-inbound-v6-port", defaultInboundPortV6, validatePortList},
-	"outboundPort":         {"kuma.io/transparent-proxying-outbound-port", defaultOutboundPort, validatePortList},
-	"isGateway":            {"kuma.io/gateway", "false", alwaysValidFunc},
-	"builtinDNS":           {"kuma.io/builtin-dns", "false", alwaysValidFunc},
-	"builtinDNSPort":       {"kuma.io/builtin-dns-port", defaultBuiltinDNSPort, validatePortList},
+	"inject":                         {"kuma.io/sidecar-injection", "", alwaysValidFunc},
+	"ports":                          {"kuma.io/envoy-admin-port", "", validatePortList},
+	"excludeInboundPorts":            {"traffic.kuma.io/exclude-inbound-ports", defaultRedirectExcludePort, validatePortList},
+	"excludeOutboundPorts":           {"traffic.kuma.io/exclude-outbound-ports", defaultRedirectExcludePort, validatePortList},
+	"inboundPort":                    {"kuma.io/transparent-proxying-inbound-port", defaultInboundPort, validatePortList},
+	"inboundPortV6":                  {"kuma.io/transparent-proxying-inbound-v6-port", defaultInboundPortV6, validatePortList},
+	"outboundPort":                   {"kuma.io/transparent-proxying-outbound-port", defaultOutboundPort, validatePortList},
+	"isGateway":                      {"kuma.io/gateway", "false", alwaysValidFunc},
+	"builtinDNS":                     {"kuma.io/builtin-dns", "false", alwaysValidFunc},
+	"builtinDNSPort":                 {"kuma.io/builtin-dns-port", defaultBuiltinDNSPort, validatePortList},
+	"excludeOutboundTCPPortsForUIDs": {"traffic.kuma.io/exclude-outbound-tcp-ports-for-uids", "", alwaysValidFunc},
+	"excludeOutboundUDPPortsForUIDs": {"traffic.kuma.io/exclude-outbound-udp-ports-for-uids", "", alwaysValidFunc},
 }
 
 type IntermediateConfig struct {
-	targetPort           string
-	inboundPort          string
-	inboundPortV6        string
-	noRedirectUID        string
-	excludeInboundPorts  string
-	excludeOutboundPorts string
-	isGateway            string
-	builtinDNS           string
-	builtinDNSPort       string
+	targetPort                     string
+	inboundPort                    string
+	inboundPortV6                  string
+	noRedirectUID                  string
+	excludeInboundPorts            string
+	excludeOutboundPorts           string
+	excludeOutboundTCPPortsForUIDs string
+	excludeOutboundUDPPortsForUIDs string
+	isGateway                      string
+	builtinDNS                     string
+	builtinDNSPort                 string
 }
 
 type annotationValidationFunc func(value string) error
@@ -110,14 +114,16 @@ func NewIntermediateConfig(annotations map[string]string) (*IntermediateConfig, 
 	intermediateConfig.noRedirectUID = defaultNoRedirectUID
 
 	allFields := map[string]*string{
-		"outboundPort":         &intermediateConfig.targetPort,
-		"inboundPort":          &intermediateConfig.inboundPort,
-		"inboundPortV6":        &intermediateConfig.inboundPortV6,
-		"excludeInboundPorts":  &intermediateConfig.excludeInboundPorts,
-		"excludeOutboundPorts": &intermediateConfig.excludeOutboundPorts,
-		"isGateway":            &intermediateConfig.isGateway,
-		"builtinDNS":           &intermediateConfig.builtinDNS,
-		"builtinDNSPort":       &intermediateConfig.builtinDNSPort,
+		"outboundPort":                   &intermediateConfig.targetPort,
+		"inboundPort":                    &intermediateConfig.inboundPort,
+		"inboundPortV6":                  &intermediateConfig.inboundPortV6,
+		"excludeInboundPorts":            &intermediateConfig.excludeInboundPorts,
+		"excludeOutboundPorts":           &intermediateConfig.excludeOutboundPorts,
+		"isGateway":                      &intermediateConfig.isGateway,
+		"builtinDNS":                     &intermediateConfig.builtinDNS,
+		"builtinDNSPort":                 &intermediateConfig.builtinDNSPort,
+		"excludeOutboundTCPPortsForUIDs": &intermediateConfig.excludeOutboundTCPPortsForUIDs,
+		"excludeOutboundUDPPortsForUIDs": &intermediateConfig.excludeOutboundUDPPortsForUIDs,
 	}
 
 	for fieldName, fieldPointer := range allFields {

--- a/app/cni/pkg/cni/annotations.go
+++ b/app/cni/pkg/cni/annotations.go
@@ -29,9 +29,13 @@ var annotationRegistry = map[string]*annotationParam{
 	"builtinDNS":                  {"kuma.io/builtin-dns", "false", alwaysValidFunc},
 	"builtinDNSPort":              {"kuma.io/builtin-dns-port", defaultBuiltinDNSPort, validatePortList},
 	"excludeOutboundPortsForUIDs": {"traffic.kuma.io/exclude-outbound-ports-for-uids", "", alwaysValidFunc},
+	"noRedirectUID":               {"kuma.io/sidecar-uid", defaultNoRedirectUID, alwaysValidFunc},
 }
 
 type IntermediateConfig struct {
+	// while https://github.com/kumahq/kuma/issues/8324 is not implemented, when changing the config,
+	// keep in mind to update all other places listed in the issue
+
 	targetPort                  string
 	inboundPort                 string
 	inboundPortV6               string
@@ -109,7 +113,6 @@ func getAnnotationOrDefault(name string, annotations map[string]string) (string,
 // NewIntermediateConfig returns a new IntermediateConfig Object constructed from a list of ports and annotations
 func NewIntermediateConfig(annotations map[string]string) (*IntermediateConfig, error) {
 	intermediateConfig := &IntermediateConfig{}
-	intermediateConfig.noRedirectUID = defaultNoRedirectUID
 
 	allFields := map[string]*string{
 		"outboundPort":                &intermediateConfig.targetPort,
@@ -121,6 +124,7 @@ func NewIntermediateConfig(annotations map[string]string) (*IntermediateConfig, 
 		"builtinDNS":                  &intermediateConfig.builtinDNS,
 		"builtinDNSPort":              &intermediateConfig.builtinDNSPort,
 		"excludeOutboundPortsForUIDs": &intermediateConfig.excludeOutboundPortsForUIDs,
+		"noRedirectUID":               &intermediateConfig.noRedirectUID,
 	}
 
 	for fieldName, fieldPointer := range allFields {

--- a/app/cni/pkg/cni/annotations.go
+++ b/app/cni/pkg/cni/annotations.go
@@ -18,32 +18,30 @@ const (
 )
 
 var annotationRegistry = map[string]*annotationParam{
-	"inject":                         {"kuma.io/sidecar-injection", "", alwaysValidFunc},
-	"ports":                          {"kuma.io/envoy-admin-port", "", validatePortList},
-	"excludeInboundPorts":            {"traffic.kuma.io/exclude-inbound-ports", defaultRedirectExcludePort, validatePortList},
-	"excludeOutboundPorts":           {"traffic.kuma.io/exclude-outbound-ports", defaultRedirectExcludePort, validatePortList},
-	"inboundPort":                    {"kuma.io/transparent-proxying-inbound-port", defaultInboundPort, validatePortList},
-	"inboundPortV6":                  {"kuma.io/transparent-proxying-inbound-v6-port", defaultInboundPortV6, validatePortList},
-	"outboundPort":                   {"kuma.io/transparent-proxying-outbound-port", defaultOutboundPort, validatePortList},
-	"isGateway":                      {"kuma.io/gateway", "false", alwaysValidFunc},
-	"builtinDNS":                     {"kuma.io/builtin-dns", "false", alwaysValidFunc},
-	"builtinDNSPort":                 {"kuma.io/builtin-dns-port", defaultBuiltinDNSPort, validatePortList},
-	"excludeOutboundTCPPortsForUIDs": {"traffic.kuma.io/exclude-outbound-tcp-ports-for-uids", "", alwaysValidFunc},
-	"excludeOutboundUDPPortsForUIDs": {"traffic.kuma.io/exclude-outbound-udp-ports-for-uids", "", alwaysValidFunc},
+	"inject":                      {"kuma.io/sidecar-injection", "", alwaysValidFunc},
+	"ports":                       {"kuma.io/envoy-admin-port", "", validatePortList},
+	"excludeInboundPorts":         {"traffic.kuma.io/exclude-inbound-ports", defaultRedirectExcludePort, validatePortList},
+	"excludeOutboundPorts":        {"traffic.kuma.io/exclude-outbound-ports", defaultRedirectExcludePort, validatePortList},
+	"inboundPort":                 {"kuma.io/transparent-proxying-inbound-port", defaultInboundPort, validatePortList},
+	"inboundPortV6":               {"kuma.io/transparent-proxying-inbound-v6-port", defaultInboundPortV6, validatePortList},
+	"outboundPort":                {"kuma.io/transparent-proxying-outbound-port", defaultOutboundPort, validatePortList},
+	"isGateway":                   {"kuma.io/gateway", "false", alwaysValidFunc},
+	"builtinDNS":                  {"kuma.io/builtin-dns", "false", alwaysValidFunc},
+	"builtinDNSPort":              {"kuma.io/builtin-dns-port", defaultBuiltinDNSPort, validatePortList},
+	"excludeOutboundPortsForUIDs": {"traffic.kuma.io/exclude-outbound-ports-for-uids", "", alwaysValidFunc},
 }
 
 type IntermediateConfig struct {
-	targetPort                     string
-	inboundPort                    string
-	inboundPortV6                  string
-	noRedirectUID                  string
-	excludeInboundPorts            string
-	excludeOutboundPorts           string
-	excludeOutboundTCPPortsForUIDs string
-	excludeOutboundUDPPortsForUIDs string
-	isGateway                      string
-	builtinDNS                     string
-	builtinDNSPort                 string
+	targetPort                  string
+	inboundPort                 string
+	inboundPortV6               string
+	noRedirectUID               string
+	excludeInboundPorts         string
+	excludeOutboundPorts        string
+	excludeOutboundPortsForUIDs string
+	isGateway                   string
+	builtinDNS                  string
+	builtinDNSPort              string
 }
 
 type annotationValidationFunc func(value string) error
@@ -114,16 +112,15 @@ func NewIntermediateConfig(annotations map[string]string) (*IntermediateConfig, 
 	intermediateConfig.noRedirectUID = defaultNoRedirectUID
 
 	allFields := map[string]*string{
-		"outboundPort":                   &intermediateConfig.targetPort,
-		"inboundPort":                    &intermediateConfig.inboundPort,
-		"inboundPortV6":                  &intermediateConfig.inboundPortV6,
-		"excludeInboundPorts":            &intermediateConfig.excludeInboundPorts,
-		"excludeOutboundPorts":           &intermediateConfig.excludeOutboundPorts,
-		"isGateway":                      &intermediateConfig.isGateway,
-		"builtinDNS":                     &intermediateConfig.builtinDNS,
-		"builtinDNSPort":                 &intermediateConfig.builtinDNSPort,
-		"excludeOutboundTCPPortsForUIDs": &intermediateConfig.excludeOutboundTCPPortsForUIDs,
-		"excludeOutboundUDPPortsForUIDs": &intermediateConfig.excludeOutboundUDPPortsForUIDs,
+		"outboundPort":                &intermediateConfig.targetPort,
+		"inboundPort":                 &intermediateConfig.inboundPort,
+		"inboundPortV6":               &intermediateConfig.inboundPortV6,
+		"excludeInboundPorts":         &intermediateConfig.excludeInboundPorts,
+		"excludeOutboundPorts":        &intermediateConfig.excludeOutboundPorts,
+		"isGateway":                   &intermediateConfig.isGateway,
+		"builtinDNS":                  &intermediateConfig.builtinDNS,
+		"builtinDNSPort":              &intermediateConfig.builtinDNSPort,
+		"excludeOutboundPortsForUIDs": &intermediateConfig.excludeOutboundPortsForUIDs,
 	}
 
 	for fieldName, fieldPointer := range allFields {

--- a/app/cni/pkg/cni/annotations_test.go
+++ b/app/cni/pkg/cni/annotations_test.go
@@ -1,0 +1,24 @@
+package cni
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("NewIntermediateConfig", func() {
+	It("should set UID to default value if annotation is not specified", func() {
+		a := map[string]string{}
+		cfg, err := NewIntermediateConfig(a)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(cfg.noRedirectUID).To(Equal(defaultNoRedirectUID))
+	})
+
+	It("should override UID when annotation is specified", func() {
+		a := map[string]string{
+			"kuma.io/sidecar-uid": "1234",
+		}
+		cfg, err := NewIntermediateConfig(a)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(cfg.noRedirectUID).To(Equal("1234"))
+	})
+})

--- a/app/cni/pkg/cni/injector_linux.go
+++ b/app/cni/pkg/cni/injector_linux.go
@@ -79,11 +79,15 @@ func mapToConfig(intermediateConfig *IntermediateConfig, logWriter *bufio.Writer
 	}
 
 	excludePortsForUIDs := []string{}
-	for _, portAndUID := range strings.Split(intermediateConfig.excludeOutboundTCPPortsForUIDs, ";") {
-		excludePortsForUIDs = append(excludePortsForUIDs, fmt.Sprintf("tcp:%s", portAndUID))
+	if intermediateConfig.excludeOutboundTCPPortsForUIDs != "" {
+		for _, portAndUID := range strings.Split(intermediateConfig.excludeOutboundTCPPortsForUIDs, ";") {
+			excludePortsForUIDs = append(excludePortsForUIDs, fmt.Sprintf("tcp:%s", portAndUID))
+		}
 	}
-	for _, portAndUID := range strings.Split(intermediateConfig.excludeOutboundUDPPortsForUIDs, ";") {
-		excludePortsForUIDs = append(excludePortsForUIDs, fmt.Sprintf("udp:%s", portAndUID))
+	if intermediateConfig.excludeOutboundUDPPortsForUIDs != "" {
+		for _, portAndUID := range strings.Split(intermediateConfig.excludeOutboundUDPPortsForUIDs, ";") {
+			excludePortsForUIDs = append(excludePortsForUIDs, fmt.Sprintf("udp:%s", portAndUID))
+		}
 	}
 
 	excludePortsForUIDsParsed, err := transparentproxy.ParseExcludePortsForUIDs(excludePortsForUIDs)

--- a/app/cni/pkg/cni/injector_linux.go
+++ b/app/cni/pkg/cni/injector_linux.go
@@ -3,7 +3,6 @@ package cni
 import (
 	"bufio"
 	"bytes"
-	"fmt"
 	"strconv"
 	"strings"
 
@@ -79,15 +78,8 @@ func mapToConfig(intermediateConfig *IntermediateConfig, logWriter *bufio.Writer
 	}
 
 	excludePortsForUIDs := []string{}
-	if intermediateConfig.excludeOutboundTCPPortsForUIDs != "" {
-		for _, portAndUID := range strings.Split(intermediateConfig.excludeOutboundTCPPortsForUIDs, ";") {
-			excludePortsForUIDs = append(excludePortsForUIDs, fmt.Sprintf("tcp:%s", portAndUID))
-		}
-	}
-	if intermediateConfig.excludeOutboundUDPPortsForUIDs != "" {
-		for _, portAndUID := range strings.Split(intermediateConfig.excludeOutboundUDPPortsForUIDs, ";") {
-			excludePortsForUIDs = append(excludePortsForUIDs, fmt.Sprintf("udp:%s", portAndUID))
-		}
+	if intermediateConfig.excludeOutboundPortsForUIDs != "" {
+		excludePortsForUIDs = strings.Split(intermediateConfig.excludeOutboundPortsForUIDs, ";")
 	}
 
 	excludePortsForUIDsParsed, err := transparentproxy.ParseExcludePortsForUIDs(excludePortsForUIDs)

--- a/pkg/transparentproxy/kubernetes/kubernetes.go
+++ b/pkg/transparentproxy/kubernetes/kubernetes.go
@@ -27,6 +27,9 @@ import (
 )
 
 type PodRedirect struct {
+	// while https://github.com/kumahq/kuma/issues/8324 is not implemented, when changing the config,
+	// keep in mind to update all other places listed in the issue
+
 	BuiltinDNSEnabled                        bool
 	BuiltinDNSPort                           uint32
 	ExcludeOutboundPorts                     string

--- a/pkg/transparentproxy/transparentproxy_v2.go
+++ b/pkg/transparentproxy/transparentproxy_v2.go
@@ -122,7 +122,7 @@ func (tp *TransparentProxyV2) Setup(tpConfig *config.TransparentProxyConfig) (st
 	}
 	var excludeOutboundPortsForUids []config.UIDsToPorts
 	if len(tpConfig.ExcludedOutboundsForUIDs) > 0 {
-		excludeOutboundPortsForUids, err = parseExcludePortsForUIDs(tpConfig.ExcludedOutboundsForUIDs)
+		excludeOutboundPortsForUids, err = ParseExcludePortsForUIDs(tpConfig.ExcludedOutboundsForUIDs)
 		if err != nil {
 			return "", errors.Wrap(err, "parsing excluded outbound ports for uids failed")
 		}
@@ -194,7 +194,7 @@ func (tp *TransparentProxyV2) Setup(tpConfig *config.TransparentProxyConfig) (st
 	return Setup(cfg)
 }
 
-func parseExcludePortsForUIDs(excludeOutboundPortsForUIDs []string) ([]config.UIDsToPorts, error) {
+func ParseExcludePortsForUIDs(excludeOutboundPortsForUIDs []string) ([]config.UIDsToPorts, error) {
 	var uidsToPorts []config.UIDsToPorts
 	for _, excludePort := range excludeOutboundPortsForUIDs {
 		parts := strings.Split(excludePort, ":")

--- a/test/e2e/cni/e2e_suite_test.go
+++ b/test/e2e/cni/e2e_suite_test.go
@@ -13,5 +13,7 @@ func TestE2E(t *testing.T) {
 	test.RunE2ESpecs(t, "E2E CNI Suite")
 }
 
-var _ = Describe("Taint controller", Label("job-0"), Label("kind-not-supported"), Label("legacy-k3s-not-supported"), cni.AppDeploymentWithCniAndTaintController)
-var _ = Describe("Connectivity - Exclude Outbound Port", Label("job-0"), Label("kind-not-supported"), Label("legacy-k3s-not-supported"), cni.ExcludeOutboundPort, Ordered)
+var (
+	_ = Describe("Taint controller", Label("job-0"), Label("kind-not-supported"), Label("legacy-k3s-not-supported"), cni.AppDeploymentWithCniAndTaintController)
+	_ = Describe("Connectivity - Exclude Outbound Port", Label("job-0"), Label("kind-not-supported"), Label("legacy-k3s-not-supported"), cni.ExcludeOutboundPort, Ordered)
+)

--- a/test/e2e/cni/e2e_suite_test.go
+++ b/test/e2e/cni/e2e_suite_test.go
@@ -14,3 +14,4 @@ func TestE2E(t *testing.T) {
 }
 
 var _ = Describe("Taint controller", Label("job-0"), Label("kind-not-supported"), Label("legacy-k3s-not-supported"), cni.AppDeploymentWithCniAndTaintController)
+var _ = Describe("Connectivity - Exclude Outbound Port", Label("job-0"), Label("kind-not-supported"), Label("legacy-k3s-not-supported"), cni.ExcludeOutboundPort, Ordered)

--- a/test/e2e/cni/exclude_outbound_port.go
+++ b/test/e2e/cni/exclude_outbound_port.go
@@ -68,8 +68,7 @@ func ExcludeOutboundPort() {
 			testserver.WithMesh(meshName),
 			testserver.WithNamespace(namespace),
 			testserver.WithPodAnnotations(map[string]string{
-				metadata.KumaTrafficExcludeOutboundTCPPortsForUIDs: "80:1234",
-				metadata.KumaTrafficExcludeOutboundUDPPortsForUIDs: "53:1234",
+				metadata.KumaTrafficExcludeOutboundPortsForUIDs: "tcp:80:1234;udp:53:1234",
 			}),
 			testserver.AddInitContainer(corev1.Container{
 				Name:            "init-test-server",

--- a/test/e2e/cni/exclude_outbound_port.go
+++ b/test/e2e/cni/exclude_outbound_port.go
@@ -20,7 +20,6 @@ import (
 
 func ExcludeOutboundPort() {
 	meshName := "exclude-outbound-port"
-	nodeName := fmt.Sprintf("second-%s", strings.ToLower(random.UniqueId()))
 
 	namespace := "exclude-outbound-port"
 	namespaceExternal := "exclude-outbound-port-external"
@@ -61,7 +60,6 @@ func ExcludeOutboundPort() {
 		Expect(cluster.DeleteNamespace(namespaceExternal)).To(Succeed())
 		Expect(cluster.DeleteKuma()).To(Succeed())
 		Expect(cluster.DismissCluster()).To(Succeed())
-		Expect(k8sCluster.DeleteNode("k3d-" + nodeName + "-0")).To(Succeed())
 	})
 
 	It("should be able to use network from init container if we ignore ports for uid", func() {

--- a/test/e2e/cni/exclude_outbound_port.go
+++ b/test/e2e/cni/exclude_outbound_port.go
@@ -1,0 +1,94 @@
+package cni
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/gruntwork-io/terratest/modules/random"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+
+	"github.com/kumahq/kuma/pkg/config/core"
+	"github.com/kumahq/kuma/pkg/plugins/runtime/k8s/metadata"
+	"github.com/kumahq/kuma/pkg/util/pointer"
+	. "github.com/kumahq/kuma/test/framework"
+	"github.com/kumahq/kuma/test/framework/deployments/testserver"
+)
+
+func ExcludeOutboundPort() {
+	meshName := "exclude-outbound-port"
+	nodeName := fmt.Sprintf("second-%s", strings.ToLower(random.UniqueId()))
+
+	namespace := "exclude-outbound-port"
+	namespaceExternal := "exclude-outbound-port-external"
+
+	var cluster Cluster
+	var k8sCluster *K8sCluster
+
+	BeforeAll(func() {
+		k8sCluster = NewK8sCluster(NewTestingT(), Kuma1, Silent)
+		cluster = k8sCluster.
+			WithTimeout(6 * time.Second).
+			WithRetries(60)
+
+		releaseName := fmt.Sprintf("kuma-%s", strings.ToLower(random.UniqueId()))
+
+		Expect(NewClusterSetup().
+			Install(Kuma(core.Standalone,
+				WithInstallationMode(HelmInstallationMode),
+				WithHelmReleaseName(releaseName),
+				WithSkipDefaultMesh(true), // it's common case for HELM deployments that Mesh is also managed by HELM therefore it's not created by default
+				WithHelmOpt("cni.delayStartupSeconds", "40"),
+				WithHelmOpt("cni.logLevel", "debug"),
+				WithCNI(),
+			)).
+			Install(MTLSMeshKubernetes(meshName)).
+			Install(NamespaceWithSidecarInjection(namespace)).
+			Install(Namespace(namespaceExternal)).
+			Install(testserver.Install(
+				testserver.WithName("test-server"),
+				testserver.WithMesh(meshName),
+				testserver.WithNamespace(namespaceExternal),
+			)).
+			Setup(cluster)).To(Succeed())
+	})
+
+	E2EAfterAll(func() {
+		Expect(cluster.DeleteNamespace(namespace)).To(Succeed())
+		Expect(cluster.DeleteNamespace(namespaceExternal)).To(Succeed())
+		Expect(cluster.DeleteKuma()).To(Succeed())
+		Expect(cluster.DismissCluster()).To(Succeed())
+		Expect(k8sCluster.DeleteNode("k3d-" + nodeName + "-0")).To(Succeed())
+	})
+
+	It("should be able to use network from init container if we ignore ports for uid", func() {
+		Expect(cluster.Install(testserver.Install(
+			testserver.WithName("test-server"),
+			testserver.WithMesh(meshName),
+			testserver.WithNamespace(namespace),
+			testserver.WithPodAnnotations(map[string]string{
+				metadata.KumaTrafficExcludeOutboundTCPPortsForUIDs: "80:1234",
+				metadata.KumaTrafficExcludeOutboundUDPPortsForUIDs: "53:1234",
+			}),
+			testserver.AddInitContainer(corev1.Container{
+				Name:            "init-test-server",
+				Image:           Config.GetUniversalImage(),
+				ImagePullPolicy: "IfNotPresent",
+				Command:         []string{"curl"},
+				Args:            []string{"-v", "-m", "3", "--fail", "test-server.exclude-outbound-port-external.svc.cluster.local:80"},
+				Resources: corev1.ResourceRequirements{
+					Limits: corev1.ResourceList{
+						"cpu":    resource.MustParse("50m"),
+						"memory": resource.MustParse("64Mi"),
+					},
+				},
+				SecurityContext: &corev1.SecurityContext{
+					RunAsUser: pointer.To(int64(1234)),
+				},
+			}),
+		))).To(Succeed())
+	})
+}


### PR DESCRIPTION
Kuma Init container supports the following pod annotations:
* `traffic.kuma.io/exclude-outbound-tcp-ports-for-uids`
* `traffic.kuma.io/exclude-outbound-udp-ports-for-uids`

but Kuma CNI doesn't. Current PR adds support for these annotations for Kuma CNI. 

[Ideally](https://github.com/kumahq/kuma/issues/8320), we'd like to converge Kuma CNI and Transparent Proxy code bases to share parsing and config structures.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [X] [Link to relevant issue][1] as well as docs and UI issues --
- [X] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [X] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [X] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [X] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
