### PR TITLE
test(gui): fix gui test not working on branches that start with release-x.y*

### DIFF
--- a/pkg/api-server/gui_handler_test.go
+++ b/pkg/api-server/gui_handler_test.go
@@ -57,8 +57,7 @@ var _ = Describe("GUI Server", func() {
 			Expect(received).To(WithTransform(func(in []byte) []byte {
 				// Remove the part of the file name that changes always
 				r := regexp.MustCompile(`index[\-\.][a-z0-9]+\.`).ReplaceAll(in, []byte("index."))
-				r = regexp.MustCompile(`"[0-9]+\.[0-9]+\.[0-9]+[^"]*"`).ReplaceAll(r, []byte(`"0.0.0"`))
-				r = regexp.MustCompile(`"unknown"`).ReplaceAll(r, []byte(`"0.0.0"`))
+				r = regexp.MustCompile(`"version":"[^"]*"`).ReplaceAll(r, []byte(`"version":"0.0.0"`))
 				if r[len(r)-1] != '\n' {
 					r = append(r, '\n')
 				}


### PR DESCRIPTION
closes https://github.com/kumahq/kuma/issues/8329

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
