### PR TITLE
chore(actions): add the 'build-test-distribute' GitHub Action, runs on amd64 arch, label switches supported

### DIFF
--- a/.github/workflows/build-test-distribute.yaml
+++ b/.github/workflows/build-test-distribute.yaml
@@ -57,8 +57,6 @@ jobs:
       - uses: actions/setup-go@v4
         with:
           go-version-file: go.mod
-      # GitHub actions does not share cache across multiple jobs,
-      # so we have to operate cache in each job and action file
       - uses: actions/cache@v3
         with:
           path: |
@@ -129,8 +127,6 @@ jobs:
       - uses: actions/setup-go@v4
         with:
           go-version-file: go.mod
-      # GitHub actions does not share cache across multiple jobs,
-      # so we have to operate cache in each job and action file
       - uses: actions/cache@v3
         with:
           path: |

--- a/.github/workflows/build-test-distribute.yaml
+++ b/.github/workflows/build-test-distribute.yaml
@@ -1,7 +1,9 @@
-name: "distribute"
+name: "build-test-distribute"
 on:
   push:
-    branches: ["master"]
+    branches: ["master", "release-*"]
+  pull_request_target:
+    branches: ["master", "release-*"]
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -9,23 +11,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: "Install basic tools"
-        # `unzip`    is necessary to install `protoc`
-        # `gcc`      is necessary to run `go test -race`
-        # `git`      is necessary because the CircleCI version is different somehow ¯\_(ツ)_/¯
-        # `xz-utils` is necessary to decompress xz files
-        run: |
-          if [ -r /etc/os-release ]; then source /etc/os-release; fi
-          case "$ID" in
-          ubuntu)
-            if ! command -v sudo 2>&1 >/dev/null; then
-              apt update
-              apt install -y sudo
-            fi
-            sudo apt update
-            sudo env DEBIAN_FRONTEND=noninteractive apt install -y curl git make unzip gcc xz-utils
-            ;;
-          esac
       - uses: actions/setup-go@v4
         with:
           go-version-file: go.mod
@@ -52,15 +37,19 @@ jobs:
           make -j images
       - run: |
           make -j docker/save
+      - name: Pack artifact
+        run: |
+          tar -czf build.tar.gz ./build
       - name: Temporarily saving build output
         uses: actions/upload-artifact@v2
         with:
           name: build-output
-          path: build
+          path: build.tar.gz
           retention-days: 1
   test:
     needs: build
     runs-on: ubuntu-latest
+    if: ${{ ! contains(github.event.pull_request.labels.*.name, 'ci/skip-test') }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -111,17 +100,29 @@ jobs:
         run: |
           rm -rf ./build
       - uses: actions/download-artifact@v2
+        if: ${{ ! contains(github.event.pull_request.labels.*.name, 'ci/skip-container-structure-test') }}
         with:
           name: build-output
-          path: build
-      - run: |
+      - name: Unpack artifact
+        run: |
+          tar -xzf build.tar.gz
+      - name: Prepare for container structure test
+        if: ${{ ! contains(github.event.pull_request.labels.*.name, 'ci/skip-container-structure-test') }}
+        run: |
           sudo apt-get update; sudo apt-get install -y qemu-user-static binfmt-support
-      - run: |
+      - name: Run container structure test
+        if: ${{ ! contains(github.event.pull_request.labels.*.name, 'ci/skip-container-structure-test') }}
+        run: |
           make test/container-structure
   distributions:
     needs: test
+    # this jobs will still run even if "test" is skipped
+    if: ${{ always() }}
     runs-on: ubuntu-latest
     steps:
+      - name: "Check if force push"
+        if: ${{ contains(github.event.pull_request.labels.*.name, 'ci/force-publish') }}
+        run: 'echo "ALLOW_PUSH=true" >> $GITHUB_ENV'
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
@@ -140,7 +141,9 @@ jobs:
       - uses: actions/download-artifact@v2
         with:
           name: build-output
-          path: build
+      - name: Unpack artifact
+        run: |
+          tar -xzf build.tar.gz
       - name: Inspect created tars
         run: |
           for i in build/distributions/out/*.tar.gz; do echo $i; tar -tvf $i; done
@@ -160,3 +163,82 @@ jobs:
           trap on_exit EXIT
           make docker/push
           make docker/manifest
+  e2e_legacy:
+    name: "legacy-k8s:${{ matrix.arch }}-${{ matrix.k8sVersion }}"
+    needs: build
+    uses: kumahq/kuma/.github/workflows/e2e.yaml@master
+    strategy:
+      matrix:
+        k8sVersion:
+          - kind
+          - kindIpv6
+          - v1.23.17-k3s1
+          - v1.28.1-k3s1
+        arch:
+          - amd64
+          - arm64
+    with:
+      k8sVersion: ${{ matrix.k8sVersion }}
+      arch: ${{ matrix.arch }}
+      parallelism: 3
+      target: ""
+  e2e_main:
+    name: "${{ matrix.target }}:${{ matrix.arch }}-${{ matrix.k8sVersion }}"
+    needs: build
+    uses: kumahq/kuma/.github/workflows/e2e.yaml@master
+    strategy:
+      matrix:
+        k8sVersion:
+          - kind
+          - kindIpv6
+          - v1.23.17-k3s1
+          - v1.28.1-k3s1
+        target:
+          - kubernetes
+          - universal
+          - multizone
+        arch:
+          - amd64
+          - arm64
+    with:
+      k8sVersion: ${{ matrix.k8sVersion }}
+      target: ${{ matrix.target }}
+      arch: ${{ matrix.arch }}
+  e2e_delta_kds:
+    name: "${{ matrix.target }}:${{ matrix.arch }}-${{ matrix.k8sVersion }}-delta-kds"
+    needs: build
+    uses: kumahq/kuma/.github/workflows/e2e.yaml@master
+    strategy:
+      matrix:
+        k8sVersion:
+          - v1.28.1-k3s1
+        target:
+          - multizone
+        arch:
+          - amd64
+        deltaKDS:
+          - true
+    with:
+      k8sVersion: ${{ matrix.k8sVersion }}
+      target: ${{ matrix.arch }}
+      arch: ${{ matrix.arch }}
+      deltaKDS: ${{ matrix.deltaKDS }}
+  e2e_calico:
+    name: "${{ matrix.target }}:${{ matrix.arch }}-${{ matrix.k8sVersion }}-calico"
+    needs: build
+    uses: kumahq/kuma/.github/workflows/e2e.yaml@master
+    strategy:
+      matrix:
+        k8sVersion:
+          - v1.28.1-k3s1
+        target:
+          - multizone
+        arch:
+          - amd64
+        cniNetworkPlugin:
+          - calico
+    with:
+      k8sVersion: ${{ matrix.k8sVersion }}
+      target: ${{ matrix.arch }}
+      arch: ${{ matrix.arch }}
+      cniNetworkPlugin: ${{ matrix.cniNetworkPlugin }}

--- a/.github/workflows/distribute.yaml
+++ b/.github/workflows/distribute.yaml
@@ -9,7 +9,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
       - name: "Install basic tools"
         # `unzip`    is necessary to install `protoc`
         # `gcc`      is necessary to run `go test -race`
@@ -27,28 +26,20 @@ jobs:
             sudo env DEBIAN_FRONTEND=noninteractive apt install -y curl git make unzip gcc xz-utils
             ;;
           esac
-      # GitHub actions does not share cache across multiple jobs,
-      # so we have to operate cache in each job and action file
-      - id: retrieve-cache
-        uses: actions/cache/restore@v3
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/.kuma-dev
-          key: ${{ runner.os }}-build-${{ hashFiles('**/go.sum') }}-${{ hashFiles('mk/dependencies/deps.lock') }}
       - uses: actions/setup-go@v4
         with:
           go-version-file: go.mod
-      - if: steps.retrieve-cache.outputs.cache-hit != 'true'
-        run: |
-          make dev/tools
-      - if: steps.retrieve-cache.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v3
+      # GitHub actions does not share cache across multiple jobs,
+      # so we have to operate cache in each job and action file
+      - uses: actions/cache@v3
         with:
           path: |
-            ~/.cache/go-build
             ~/.kuma-dev
-          key: ${{ runner.os }}-build-${{ hashFiles('**/go.sum') }}-${{ hashFiles('mk/dependencies/deps.lock') }}
+          key: ${{ runner.os }}-devtools-${{ hashFiles('mk/dependencies/deps.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-devtools
+      - run: |
+          make dev/tools
       - run: |
           make clean
       - run: |
@@ -74,30 +65,18 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
       - uses: actions/setup-go@v4
         with:
           go-version-file: go.mod
-      - name: "Install basic tools"
-        run: |
-          if [ -r /etc/os-release ]; then source /etc/os-release; fi
-          case "$ID" in
-          ubuntu)
-            if ! command -v sudo 2>&1 >/dev/null; then
-              apt update
-              apt install -y sudo
-            fi
-            sudo apt update
-            sudo env DEBIAN_FRONTEND=noninteractive apt install -y curl git make unzip gcc xz-utils
-            ;;
-          esac
-      - uses: actions/cache/restore@v3
+      # GitHub actions does not share cache across multiple jobs,
+      # so we have to operate cache in each job and action file
+      - uses: actions/cache@v3
         with:
           path: |
-            ~/.cache/go-build
             ~/.kuma-dev
-          key: ${{ runner.os }}-build-${{ hashFiles('**/go.sum') }}-${{ hashFiles('mk/dependencies/deps.lock') }}
-          fail-on-cache-miss: true
+          key: ${{ runner.os }}-devtools-${{ hashFiles('mk/dependencies/deps.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-devtools
       - name: Free up disk space for the Runner
         run: |
           # source: https://github.com/apache/flink/blob/master/tools/azure-pipelines/free_disk_space.sh
@@ -146,30 +125,18 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
       - uses: actions/setup-go@v4
         with:
           go-version-file: go.mod
-      - name: "Install basic tools"
-        run: |
-          if [ -r /etc/os-release ]; then source /etc/os-release; fi
-          case "$ID" in
-          ubuntu)
-            if ! command -v sudo 2>&1 >/dev/null; then
-              apt update
-              apt install -y sudo
-            fi
-            sudo apt update
-            sudo env DEBIAN_FRONTEND=noninteractive apt install -y curl git make unzip gcc xz-utils
-            ;;
-          esac
-      - uses: actions/cache/restore@v3
+      # GitHub actions does not share cache across multiple jobs,
+      # so we have to operate cache in each job and action file
+      - uses: actions/cache@v3
         with:
           path: |
-            ~/.cache/go-build
             ~/.kuma-dev
-          key: ${{ runner.os }}-build-${{ hashFiles('**/go.sum') }}-${{ hashFiles('mk/dependencies/deps.lock') }}
-          fail-on-cache-miss: true
+          key: ${{ runner.os }}-devtools-${{ hashFiles('mk/dependencies/deps.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-devtools
       - uses: actions/download-artifact@v2
         with:
           name: build-output

--- a/.github/workflows/distribute.yaml
+++ b/.github/workflows/distribute.yaml
@@ -1,0 +1,195 @@
+name: "distribute"
+on:
+  push:
+    branches: ["master"]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+      - name: "Install basic tools"
+        # `unzip`    is necessary to install `protoc`
+        # `gcc`      is necessary to run `go test -race`
+        # `git`      is necessary because the CircleCI version is different somehow ¯\_(ツ)_/¯
+        # `xz-utils` is necessary to decompress xz files
+        run: |
+          if [ -r /etc/os-release ]; then source /etc/os-release; fi
+          case "$ID" in
+          ubuntu)
+            if ! command -v sudo 2>&1 >/dev/null; then
+              apt update
+              apt install -y sudo
+            fi
+            sudo apt update
+            sudo env DEBIAN_FRONTEND=noninteractive apt install -y curl git make unzip gcc xz-utils
+            ;;
+          esac
+      # GitHub actions does not share cache across multiple jobs,
+      # so we have to operate cache in each job and action file
+      - id: retrieve-cache
+        uses: actions/cache/restore@v3
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/.kuma-dev
+          key: ${{ runner.os }}-build-${{ hashFiles('**/go.sum') }}-${{ hashFiles('mk/dependencies/deps.lock') }}
+      - uses: actions/setup-go@v4
+        with:
+          go-version-file: go.mod
+      - if: steps.retrieve-cache.outputs.cache-hit != 'true'
+        run: |
+          make dev/tools
+      - if: steps.retrieve-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v3
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/.kuma-dev
+          key: ${{ runner.os }}-build-${{ hashFiles('**/go.sum') }}-${{ hashFiles('mk/dependencies/deps.lock') }}
+      - run: |
+          make clean
+      - run: |
+          make check
+      - run: |
+          make build
+      - run: |
+          make -j build/distributions
+      - run: |
+          make -j images
+      - run: |
+          make -j docker/save
+      - name: Temporarily saving build output
+        uses: actions/upload-artifact@v2
+        with:
+          name: build-output
+          path: build
+          retention-days: 1
+  test:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+      - uses: actions/setup-go@v4
+        with:
+          go-version-file: go.mod
+      - name: "Install basic tools"
+        run: |
+          if [ -r /etc/os-release ]; then source /etc/os-release; fi
+          case "$ID" in
+          ubuntu)
+            if ! command -v sudo 2>&1 >/dev/null; then
+              apt update
+              apt install -y sudo
+            fi
+            sudo apt update
+            sudo env DEBIAN_FRONTEND=noninteractive apt install -y curl git make unzip gcc xz-utils
+            ;;
+          esac
+      - uses: actions/cache/restore@v3
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/.kuma-dev
+          key: ${{ runner.os }}-build-${{ hashFiles('**/go.sum') }}-${{ hashFiles('mk/dependencies/deps.lock') }}
+          fail-on-cache-miss: true
+      - name: Free up disk space for the Runner
+        run: |
+          # source: https://github.com/apache/flink/blob/master/tools/azure-pipelines/free_disk_space.sh
+          echo "=============================================================================="
+          echo "Freeing up disk space on CI system"
+          echo "=============================================================================="
+          echo "Listing 100 largest packages"
+          dpkg-query -Wf '${Installed-Size}\t${Package}\n' | sort -n | tail -n 100
+          df -h
+          echo "Removing large packages"
+          sudo apt-get remove -y '^ghc-8.*' || true
+          sudo apt-get remove -y '^dotnet-.*' || true
+          sudo apt-get remove -y '^llvm-.*' || true
+          sudo apt-get remove -y 'php.*' || true
+          sudo apt-get remove -y azure-cli google-cloud-sdk hhvm google-chrome-stable firefox powershell mono-devel  || true
+          sudo apt-get autoremove -y
+          sudo apt-get clean
+          echo "Removing large directories"
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc
+          docker system prune --all -f
+          sudo df -h
+      - name: Run tests
+        run: |
+          make test TEST_REPORTS=1
+      - name: Save test reports
+        uses: actions/upload-artifact@v2
+        with:
+          name: test-reports
+          path: build/reports
+          retention-days: 30
+      - name: Cleanup build folder
+        run: |
+          rm -rf ./build
+      - uses: actions/download-artifact@v2
+        with:
+          name: build-output
+          path: build
+      - run: |
+          sudo apt-get update; sudo apt-get install -y qemu-user-static binfmt-support
+      - run: |
+          make test/container-structure
+  distributions:
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+      - uses: actions/setup-go@v4
+        with:
+          go-version-file: go.mod
+      - name: "Install basic tools"
+        run: |
+          if [ -r /etc/os-release ]; then source /etc/os-release; fi
+          case "$ID" in
+          ubuntu)
+            if ! command -v sudo 2>&1 >/dev/null; then
+              apt update
+              apt install -y sudo
+            fi
+            sudo apt update
+            sudo env DEBIAN_FRONTEND=noninteractive apt install -y curl git make unzip gcc xz-utils
+            ;;
+          esac
+      - uses: actions/cache/restore@v3
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/.kuma-dev
+          key: ${{ runner.os }}-build-${{ hashFiles('**/go.sum') }}-${{ hashFiles('mk/dependencies/deps.lock') }}
+          fail-on-cache-miss: true
+      - uses: actions/download-artifact@v2
+        with:
+          name: build-output
+          path: build
+      - name: Inspect created tars
+        run: |
+          for i in build/distributions/out/*.tar.gz; do echo $i; tar -tvf $i; done
+      - name: Publish distributions to Pulp
+        run: |
+          make publish/pulp
+      - name: Load images
+        run: |
+          make docker/load
+      - name: Publish images
+        run: |-
+          make docker/login
+          # ensure we always logout
+          function on_exit() {
+            make docker/logout
+          }
+          trap on_exit EXIT
+          make docker/push
+          make docker/manifest

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -1,0 +1,177 @@
+name: e2e
+on:
+  workflow_call:
+    inputs:
+      k8sVersion:
+        description: version of k3s to use or "kind" and "kindIpv6"
+        type: string
+        default: v1.28.1-k3s1
+        required: false
+      parallelism:
+        description: level of parallelization
+        type: number
+        default: 1
+        required: false
+      target:
+        description: makefile target without e2e prefix
+        type: string
+        default: ""
+        required: false
+      arch:
+        description: The golang arch
+        type: string
+        default: amd64
+        required: false
+      cniNetworkPlugin:
+        description: The CNI networking plugin to use [flannel | calico]
+        type: string
+        default: flannel
+        required: false
+      deltaKDS:
+        description: if should run tests with new implementation of KDS
+        type: boolean
+        default: false
+        required: false
+env:
+  first_k8s_version: "v1.23.17-k3s1"
+  last_k8s_version: "v1.28.1-k3s1"
+jobs:
+  e2e:
+    runs-on: ubuntu-latest
+    # runs-on: ${{ inputs.arch == 'amd64' && 'ubuntu-latest' || 'arm64-not-supported' }}
+    steps:
+      - id: check_if_should_skip
+        name: "Check if the job should be skipped"
+        run: |
+          echo "Running with: \
+            k8s: ${{ inputs.k8sVersion }} \
+            target: ${{ inputs.target }} \
+            parallelism: ${{ inputs.parallelism }} \
+            arch: ${{ inputs.arch }} \
+            cniNetworkPlugin: ${{ inputs.cniNetworkPlugin }} \
+            "
+          function skip() {
+            echo "$1"
+            echo "skip=true" >> $GITHUB_OUTPUT
+            exit 0
+          }
+
+          SKIP_CI_LABEL="${{ contains(github.event.pull_request.labels.*.name, 'ci/skip-test') || contains(github.event.pull_request.labels.*.name, 'ci/skip-e2e-test')  }}"
+          if [[ "$SKIP_CI_LABEL" == "true" ]]; then
+            skip "Halting job because the pull request contained a 'ci/skip-*' label."
+          fi
+
+          NON_PRIORITY=
+          if [[ "" == "${{ inputs.target }}" ]] || [[ "calico" == "${{ inputs.cniNetworkPlugin }}" ]] || [[ "arm64" == "${{ inputs.arch }}" ]] || [[ "true" == "${{ inputs.deltaKDS }}" ]] || [[ "kindIpv6" == "${{ inputs.k8sVersion }}" ]] || [[ "${{ env.first_k8s_version }}" == "${{ inputs.k8sVersion }}" ]]; then
+            NON_PRIORITY=1
+          fi
+
+          RUN_FULL_MATRIX="${{ contains(github.event.pull_request.labels.*.name, 'ci/run-full-matrix') }}"
+          if [[ "$NON_PRIORITY" == "1" ]] && [[ "$RUN_FULL_MATRIX" == "false" ]]; then
+            skip "Halting job because non priority job detected and no label 'ci/run-full-matrix' was found on the pull request."
+          fi
+
+          if [[ "arm64" == "${{ inputs.arch }}" ]]; then
+            skip "Halting job because arm64 runners are currently not supported by GitHub Actions."
+          fi
+
+
+          # Handle invalid test combinations
+          if [[ "${{ inputs.k8sVersion }}" == "kind" && "${{ inputs.target }}" != "universal" ]]; then
+            skip "Non valid job combination, halting job reason: kind should only be used when testing ipv6 or with e2e-universal."
+          fi
+
+          if [[ "${{ inputs.k8sVersion }}" != kind* && "${{ inputs.target }}" == "universal" ]]; then
+            skip "Non valid job combination, halting job reason: universal only runs on kind."
+          fi
+
+          echo "Continuing tests."
+      - uses: actions/checkout@v4
+        if: ${{ steps.check_if_should_skip.outputs.skip != 'true' }}
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-go@v4
+        if: ${{ steps.check_if_should_skip.outputs.skip != 'true' }}
+        with:
+          go-version-file: go.mod
+      - uses: actions/cache@v3
+        if: ${{ steps.check_if_should_skip.outputs.skip != 'true' }}
+        with:
+          path: |
+            ~/.kuma-dev
+          key: ${{ runner.os }}-devtools-${{ hashFiles('mk/dependencies/deps.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-devtools
+      - uses: actions/download-artifact@v2
+        if: ${{ steps.check_if_should_skip.outputs.skip != 'true' }}
+        with:
+          name: build-output
+      - name: Unpack artifact
+        if: ${{ steps.check_if_should_skip.outputs.skip != 'true' }}
+        run: |
+          tar -xzf build.tar.gz
+      - name: "Setup helm"
+        if: ${{ steps.check_if_should_skip.outputs.skip != 'true' }}
+        run: |
+          make dev/set-kuma-helm-repo
+      # CircleCI's DNS on IPV6 prevents resolving inside Kind. When change to 8.8.8.8 and remove "search" section (. removes it), resolving works again
+      - if: ${{ 'kindIpv6' == inputs.k8sVersion && steps.check_if_should_skip.outputs.skip != 'true' }}
+        name: Enable IPV6 and change DNS
+        run: |
+          cat \<<'EOF' | sudo tee /etc/docker/daemon.json
+          {
+            "ipv6": true,
+            "fixed-cidr-v6": "2001:db8:1::/64",
+            "dns": ["8.8.8.8"],
+            "dns-search": ["."]
+          }
+          EOF
+          sudo service docker restart
+      - name: "Run E2E tests"
+        if: ${{ steps.check_if_should_skip.outputs.skip != 'true' }}
+        run: |
+          if [[ "${{ inputs.k8sVersion }}" == "kindIpv6" ]]; then
+            export IPV6=true
+            export K8S_CLUSTER_TOOL=kind
+            export KUMA_DEFAULT_RETRIES=60
+            export KUMA_DEFAULT_TIMEOUT="6s"
+          fi
+          if [[ "${{ inputs.k8sVersion }}" != "kind"* ]]; then
+            export CI_K3S_VERSION=${{ inputs.k8sVersion }}
+            export K3D_NETWORK_CNI=${{ inputs.cniNetworkPlugin }}
+          fi
+          if [[ "${{ inputs.arch }}" == "arm64" ]]; then
+            export MAKE_PARAMETERS="-j1"
+          else
+            export MAKE_PARAMETERS="-j2"
+          fi
+
+          if [[ "${{ inputs.deltaKDS }}" == true ]]; then
+            export KUMA_DELTA_KDS=true
+            export KUMA_EXPERIMENTAL_KDS_EVENT_BASED_WATCHDOG_ENABLED=true
+          fi
+
+          if [[ "${{ inputs.target }}" == "" ]]; then
+            export GINKGO_E2E_LABEL_FILTERS="job-$CIRCLE_NODE_INDEX"
+          fi
+          env
+          if [[ "${{ inputs.target }}" != "" ]]; then
+            target="test/e2e-${{ inputs.target }}"
+          else
+            target="test/e2e"
+          fi
+          make ${MAKE_PARAMETERS} CI=true "${target}"
+      - name: Store e2e test reports
+        if: ${{ steps.check_if_should_skip.outputs.skip != 'true' }}
+        uses: actions/upload-artifact@v2
+        with:
+          name: e2e-test-reports
+          path: build/reports
+          retention-days: 30
+      - name: Store e2e test logs
+        if: ${{ steps.check_if_should_skip.outputs.skip != 'true' }}
+        uses: actions/upload-artifact@v2
+        with:
+          name: e2e-test-logs
+          path: /tmp/e2e
+          retention-days: 30

--- a/mk/check.mk
+++ b/mk/check.mk
@@ -33,6 +33,14 @@ golangci-lint-fmt:
 .PHONY: fmt/ci
 fmt/ci:
 	$(CI_TOOLS_BIN_DIR)/yq -i '.parameters.go_version.default = "$(GO_VERSION)" | .parameters.first_k8s_version.default = "$(K8S_MIN_VERSION)" | .parameters.last_k8s_version.default = "$(K8S_MAX_VERSION)"' .circleci/config.yml
+
+	# if a multi-line string block in a YAML file is merged into a single-line value, check if there is any line ending with spaces within that block
+	$(CI_TOOLS_BIN_DIR)/yq -i '.on.workflow_call.inputs.k8sVersion.default = "$(K8S_MAX_VERSION)" | .env.first_k8s_version="$(K8S_MIN_VERSION)" | .env.last_k8s_version="$(K8S_MAX_VERSION)"'  .github/workflows/e2e.yaml
+	$(CI_TOOLS_BIN_DIR)/yq -i '.jobs.e2e_legacy.strategy.matrix.k8sVersion = ["kind", "kindIpv6", "$(K8S_MIN_VERSION)", "$(K8S_MAX_VERSION)"]' ./.github/workflows/build-test-distribute.yaml
+	$(CI_TOOLS_BIN_DIR)/yq -i '.jobs.e2e_main.strategy.matrix.k8sVersion = ["kind", "kindIpv6", "$(K8S_MIN_VERSION)", "$(K8S_MAX_VERSION)"]' ./.github/workflows/build-test-distribute.yaml
+	$(CI_TOOLS_BIN_DIR)/yq -i '.jobs.e2e_delta_kds.strategy.matrix.k8sVersion = ["$(K8S_MAX_VERSION)"]' ./.github/workflows/build-test-distribute.yaml
+	$(CI_TOOLS_BIN_DIR)/yq -i '.jobs.e2e_calico.strategy.matrix.k8sVersion = ["$(K8S_MAX_VERSION)"]' ./.github/workflows/build-test-distribute.yaml
+
 	find .github/workflows -name '*ml' | xargs -n 1 $(CI_TOOLS_BIN_DIR)/yq -i '(.jobs.* | select(. | has("steps")) | .steps[] | select(.uses == "golangci/golangci-lint-action*") | .with.version) |= "$(GOLANGCI_LINT_VERSION)"'
 
 .PHONY: helm-lint


### PR DESCRIPTION
### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues
  - N/A
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS 
  - Confirmed
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s)
  - N/A
  - [x] Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? 
  - No need
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label)
  - No need

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
