### PR TITLE
feat(kuma-cp): move KDS hash suffix under a feature flag

### DIFF
--- a/docs/generated/kuma-cp.md
+++ b/docs/generated/kuma-cp.md
@@ -746,6 +746,9 @@ experimental:
   # If true then control plane computes reachable services automatically based on MeshTrafficPermission.
   # Lack of MeshTrafficPermission is treated as Deny the traffic.
   autoReachableServices: false # ENV: KUMA_EXPERIMENTAL_AUTO_REACHABLE_SERVICES
+  # KDSSyncNameWithHashSuffix if true then during KDS sync resource name is going to be suffixed with hash.
+  # The hash is computed based on various resource characteristics like mesh, namespace, etc.
+  KDSSyncNameWithHashSuffix: false # ENV: KUMA_EXPERIMENTAL_KDS_SYNC_NAME_WITH_HASH_SUFFIX
 
 proxy:
   gateway:

--- a/docs/generated/kuma-cp.md
+++ b/docs/generated/kuma-cp.md
@@ -747,7 +747,9 @@ experimental:
   # Lack of MeshTrafficPermission is treated as Deny the traffic.
   autoReachableServices: false # ENV: KUMA_EXPERIMENTAL_AUTO_REACHABLE_SERVICES
   # KDSSyncNameWithHashSuffix if true then during KDS sync resource name is going to be suffixed with hash.
-  # The hash is computed based on various resource characteristics like mesh, namespace, etc.
+  # The hash is computed based on various resource characteristics like mesh, namespace, etc. The feature prevents name
+  # collisions when syncing policies with the same names but different meshes from Global(Universal) to Zone(Kubernetes).
+  # More extensive explanation of the problem and solution can be found in the MADR https://github.com/kumahq/kuma/blob/master/docs/madr/decisions/029-kds-sync-hash-suffix.md
   KDSSyncNameWithHashSuffix: false # ENV: KUMA_EXPERIMENTAL_KDS_SYNC_NAME_WITH_HASH_SUFFIX
 
 proxy:

--- a/docs/generated/raw/kuma-cp.yaml
+++ b/docs/generated/raw/kuma-cp.yaml
@@ -743,6 +743,9 @@ experimental:
   # If true then control plane computes reachable services automatically based on MeshTrafficPermission.
   # Lack of MeshTrafficPermission is treated as Deny the traffic.
   autoReachableServices: false # ENV: KUMA_EXPERIMENTAL_AUTO_REACHABLE_SERVICES
+  # KDSSyncNameWithHashSuffix if true then during KDS sync resource name is going to be suffixed with hash.
+  # The hash is computed based on various resource characteristics like mesh, namespace, etc.
+  KDSSyncNameWithHashSuffix: false # ENV: KUMA_EXPERIMENTAL_KDS_SYNC_NAME_WITH_HASH_SUFFIX
 
 proxy:
   gateway:

--- a/docs/generated/raw/kuma-cp.yaml
+++ b/docs/generated/raw/kuma-cp.yaml
@@ -744,7 +744,9 @@ experimental:
   # Lack of MeshTrafficPermission is treated as Deny the traffic.
   autoReachableServices: false # ENV: KUMA_EXPERIMENTAL_AUTO_REACHABLE_SERVICES
   # KDSSyncNameWithHashSuffix if true then during KDS sync resource name is going to be suffixed with hash.
-  # The hash is computed based on various resource characteristics like mesh, namespace, etc.
+  # The hash is computed based on various resource characteristics like mesh, namespace, etc. The feature prevents name
+  # collisions when syncing policies with the same names but different meshes from Global(Universal) to Zone(Kubernetes).
+  # More extensive explanation of the problem and solution can be found in the MADR https://github.com/kumahq/kuma/blob/master/docs/madr/decisions/029-kds-sync-hash-suffix.md
   KDSSyncNameWithHashSuffix: false # ENV: KUMA_EXPERIMENTAL_KDS_SYNC_NAME_WITH_HASH_SUFFIX
 
 proxy:

--- a/pkg/config/app/kuma-cp/config.go
+++ b/pkg/config/app/kuma-cp/config.go
@@ -254,6 +254,7 @@ var DefaultConfig = func() Config {
 				FullResyncInterval: config_types.Duration{Duration: 1 * time.Minute},
 				DelayFullResync:    false,
 			},
+			KDSSyncNameWithHashSuffix: false,
 		},
 		Proxy:    xds.DefaultProxyConfig(),
 		InterCp:  intercp.DefaultInterCpConfig(),
@@ -417,6 +418,9 @@ type ExperimentalConfig struct {
 	// If true then control plane computes reachable services automatically based on MeshTrafficPermission.
 	// Lack of MeshTrafficPermission is treated as Deny the traffic.
 	AutoReachableServices bool `json:"autoReachableServices" envconfig:"KUMA_EXPERIMENTAL_AUTO_REACHABLE_SERVICES"`
+	// KDSSyncNameWithHashSuffix if true then during KDS sync resource name is going to be suffixed with hash.
+	// The hash is computed based on various resource characteristics like mesh, namespace, etc.
+	KDSSyncNameWithHashSuffix bool `json:"kdsSyncNameWithHashSuffix" envconfig:"KUMA_EXPERIMENTAL_KDS_SYNC_NAME_WITH_HASH_SUFFIX"`
 }
 
 type ExperimentalKDSEventBasedWatchdog struct {

--- a/pkg/config/app/kuma-cp/kuma-cp.defaults.yaml
+++ b/pkg/config/app/kuma-cp/kuma-cp.defaults.yaml
@@ -743,6 +743,9 @@ experimental:
   # If true then control plane computes reachable services automatically based on MeshTrafficPermission.
   # Lack of MeshTrafficPermission is treated as Deny the traffic.
   autoReachableServices: false # ENV: KUMA_EXPERIMENTAL_AUTO_REACHABLE_SERVICES
+  # KDSSyncNameWithHashSuffix if true then during KDS sync resource name is going to be suffixed with hash.
+  # The hash is computed based on various resource characteristics like mesh, namespace, etc.
+  KDSSyncNameWithHashSuffix: false # ENV: KUMA_EXPERIMENTAL_KDS_SYNC_NAME_WITH_HASH_SUFFIX
 
 proxy:
   gateway:

--- a/pkg/config/app/kuma-cp/kuma-cp.defaults.yaml
+++ b/pkg/config/app/kuma-cp/kuma-cp.defaults.yaml
@@ -744,7 +744,9 @@ experimental:
   # Lack of MeshTrafficPermission is treated as Deny the traffic.
   autoReachableServices: false # ENV: KUMA_EXPERIMENTAL_AUTO_REACHABLE_SERVICES
   # KDSSyncNameWithHashSuffix if true then during KDS sync resource name is going to be suffixed with hash.
-  # The hash is computed based on various resource characteristics like mesh, namespace, etc.
+  # The hash is computed based on various resource characteristics like mesh, namespace, etc. The feature prevents name
+  # collisions when syncing policies with the same names but different meshes from Global(Universal) to Zone(Kubernetes).
+  # More extensive explanation of the problem and solution can be found in the MADR https://github.com/kumahq/kuma/blob/master/docs/madr/decisions/029-kds-sync-hash-suffix.md
   KDSSyncNameWithHashSuffix: false # ENV: KUMA_EXPERIMENTAL_KDS_SYNC_NAME_WITH_HASH_SUFFIX
 
 proxy:

--- a/pkg/config/loader_test.go
+++ b/pkg/config/loader_test.go
@@ -701,6 +701,7 @@ experimental:
     fullResyncInterval: 15s
     delayFullResync: true
   autoReachableServices: true
+  kdsSyncNameWithHashSuffix: true
 proxy:
   gateway:
     globalDownstreamMaxConnections: 1
@@ -965,6 +966,7 @@ tracing:
 				"KUMA_EXPERIMENTAL_KDS_EVENT_BASED_WATCHDOG_FULL_RESYNC_INTERVAL":                          "15s",
 				"KUMA_EXPERIMENTAL_KDS_EVENT_BASED_WATCHDOG_DELAY_FULL_RESYNC":                             "true",
 				"KUMA_EXPERIMENTAL_AUTO_REACHABLE_SERVICES":                                                "true",
+				"KUMA_EXPERIMENTAL_KDS_SYNC_NAME_WITH_HASH_SUFFIX":                                         "true",
 				"KUMA_PROXY_GATEWAY_GLOBAL_DOWNSTREAM_MAX_CONNECTIONS":                                     "1",
 				"KUMA_TRACING_OPENTELEMETRY_ENDPOINT":                                                      "otel-collector:4317",
 				"KUMA_TRACING_OPENTELEMETRY_ENABLED":                                                       "true",

--- a/pkg/kds/context/context_test.go
+++ b/pkg/kds/context/context_test.go
@@ -464,6 +464,8 @@ var _ = Describe("Context", func() {
 				cfg.Store.Kubernetes.SystemNamespace = caseCfg.k8sSystemNamespace
 			}
 
+			cfg.Experimental.KDSSyncNameWithHashSuffix = true
+
 			return cfg
 		}
 

--- a/test/framework/config.go
+++ b/test/framework/config.go
@@ -162,6 +162,8 @@ func (c E2eConfig) AutoConfigure() error {
 	Config.Arch = runtime.GOARCH
 	Config.OS = runtime.GOOS
 
+	Config.KumaCpConfig.Multizone.Global.Envs["KUMA_EXPERIMENTAL_KDS_SYNC_NAME_WITH_HASH_SUFFIX"] = "true"
+
 	return nil
 }
 

--- a/test/framework/envs/multizone/env.go
+++ b/test/framework/envs/multizone/env.go
@@ -37,8 +37,6 @@ func SetupAndGetState() []byte {
 	Global = NewUniversalCluster(NewTestingT(), Kuma3, Silent)
 	E2EDeferCleanup(Global.DismissCluster) // clean up any containers if needed
 	globalOptions := framework.KumaDeploymentOptionsFromConfig(framework.Config.KumaCpConfig.Multizone.Global)
-	globalOptions = append(globalOptions,
-		WithEnv("KUMA_EXPERIMENTAL_KDS_SYNC_NAME_WITH_HASH_SUFFIX", "true"))
 	Expect(Global.Install(Kuma(core.Global, globalOptions...))).To(Succeed())
 
 	wg := sync.WaitGroup{}

--- a/test/framework/envs/multizone/env.go
+++ b/test/framework/envs/multizone/env.go
@@ -37,6 +37,8 @@ func SetupAndGetState() []byte {
 	Global = NewUniversalCluster(NewTestingT(), Kuma3, Silent)
 	E2EDeferCleanup(Global.DismissCluster) // clean up any containers if needed
 	globalOptions := framework.KumaDeploymentOptionsFromConfig(framework.Config.KumaCpConfig.Multizone.Global)
+	globalOptions = append(globalOptions,
+		WithEnv("KUMA_EXPERIMENTAL_KDS_SYNC_NAME_WITH_HASH_SUFFIX", "true"))
 	Expect(Global.Install(Kuma(core.Global, globalOptions...))).To(Succeed())
 
 	wg := sync.WaitGroup{}


### PR DESCRIPTION
### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [ ] [Link to relevant issue][1] as well as docs and UI issues --
- [ ] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [ ] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [ ] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [ ] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
