### PR TITLE
fix(tproxy): allow value 0 in --max-retries flag for tproxy install

### DIFF
--- a/app/kumactl/cmd/install/install_transparent_proxy.go
+++ b/app/kumactl/cmd/install/install_transparent_proxy.go
@@ -15,6 +15,7 @@ import (
 	"github.com/kumahq/kuma/pkg/transparentproxy"
 	"github.com/kumahq/kuma/pkg/transparentproxy/config"
 	"github.com/kumahq/kuma/pkg/transparentproxy/firewalld"
+	"github.com/kumahq/kuma/pkg/util/pointer"
 )
 
 type transparentProxyArgs struct {
@@ -78,7 +79,7 @@ func newInstallTransparentProxy() *cobra.Command {
 		VnetNetworks:                   []string{},
 		Wait:                           5,
 		WaitInterval:                   0,
-		MaxRetries:                     5,
+		MaxRetries:                     4,
 		SleepBetweenRetries:            2 * time.Second,
 	}
 	cmd := &cobra.Command{
@@ -280,7 +281,7 @@ func configureTransparentProxy(cmd *cobra.Command, args *transparentProxyArgs) e
 		Stderr:                    cmd.ErrOrStderr(),
 		Wait:                      args.Wait,
 		WaitInterval:              args.WaitInterval,
-		MaxRetries:                args.MaxRetries,
+		MaxRetries:                pointer.To(args.MaxRetries),
 		SleepBetweenRetries:       args.SleepBetweenRetries,
 	}
 	tp = transparentproxy.V2()

--- a/docs/generated/cmd/kumactl/kumactl_install_transparent-proxy.md
+++ b/docs/generated/cmd/kumactl/kumactl_install_transparent-proxy.md
@@ -75,7 +75,7 @@ kumactl install transparent-proxy [flags]
   -h, --help                                                                            help for transparent-proxy
       --kuma-dp-uid string                                                              the uid of the user that will run kuma-dp
       --kuma-dp-user string                                                             the user that will run kuma-dp
-      --max-retries int                                                                 flag can be used to specify the maximum number of times to retry an installation before giving up (default 5)
+      --max-retries int                                                                 flag can be used to specify the maximum number of times to retry an installation before giving up (default 4)
       --redirect-all-dns-traffic                                                        redirect all DNS traffic to a specified port, unlike --redirect-dns this will not be limited to the dns servers identified in /etc/resolve.conf
       --redirect-dns                                                                    redirect only DNS requests targeted to the servers listed in /etc/resolv.conf to a specified port
       --redirect-dns-port string                                                        the port where the DNS agent is listening (default "15053")

--- a/pkg/transparentproxy/config/config.go
+++ b/pkg/transparentproxy/config/config.go
@@ -6,6 +6,8 @@ import (
 	"os"
 	"os/exec"
 	"time"
+
+	"github.com/kumahq/kuma/pkg/util/pointer"
 )
 
 type TransparentProxyConfig struct {
@@ -38,7 +40,7 @@ type TransparentProxyConfig struct {
 	RestoreLegacy             bool
 	Wait                      uint
 	WaitInterval              uint
-	MaxRetries                int
+	MaxRetries                *int
 	SleepBetweenRetries       time.Duration
 }
 
@@ -122,7 +124,7 @@ type LogConfig struct {
 }
 
 type RetryConfig struct {
-	MaxRetries         int
+	MaxRetries         *int
 	SleepBetweenReties time.Duration
 }
 
@@ -272,7 +274,7 @@ func defaultConfig() Config {
 		Wait:         5,
 		WaitInterval: 0,
 		Retry: RetryConfig{
-			MaxRetries:         4,
+			MaxRetries:         pointer.To(4),
 			SleepBetweenReties: 2 * time.Second,
 		},
 	}
@@ -413,7 +415,7 @@ func MergeConfigWithDefaults(cfg Config) Config {
 	result.WaitInterval = cfg.WaitInterval
 
 	// .Retry
-	if cfg.Retry.MaxRetries > 0 {
+	if cfg.Retry.MaxRetries != nil {
 		result.Retry.MaxRetries = cfg.Retry.MaxRetries
 	}
 


### PR DESCRIPTION
When running `kumactl install transparent-proxy`, the default behavior with the `--max-retries` flag is set to `0` should not be treated as if the flag wasn't provided. Instead, the value `0` should be accepted as a valid option and should be used to disable retries.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues
  - no relevant issue
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS
  - it won't
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s)
  - manually tested
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)?
  - there is no need
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label)
  - there is no need

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
