### PR TITLE
fix(observability): change Grafana container UID to be different from initContainer UID

### DIFF
--- a/app/kumactl/cmd/install/testdata/install-observability.defaults.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-observability.defaults.golden.yaml
@@ -11993,12 +11993,12 @@ spec:
         checksum/dashboards-json-config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
         checksum/sc-dashboard-provider-config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
         checksum/secret: 281444758252a4bdd272546732dfb8e2be87be71b795d2aadc3726e3524f63e3
-        traffic.kuma.io/exclude-outbound-ports-for-uids: tcp:80,443:472;udp:53:472 # needed when running kuma CNI
+        traffic.kuma.io/exclude-outbound-ports-for-uids: tcp:80,443:1472;udp:53:1472 # needed when running kuma CNI
     spec:
       serviceAccountName: grafana
       securityContext:
         fsGroup: 472
-        runAsUser: 472
+        runAsUser: 1472
       initContainers:
         - name: init-plugins
           image: alpine
@@ -12046,6 +12046,8 @@ spec:
               port: 3000
           resources:
             {}
+          securityContext:
+            runAsUser: 472
       volumes:
         - name: config
           configMap:

--- a/app/kumactl/cmd/install/testdata/install-observability.no-jaeger.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-observability.no-jaeger.golden.yaml
@@ -11993,12 +11993,12 @@ spec:
         checksum/dashboards-json-config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
         checksum/sc-dashboard-provider-config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
         checksum/secret: 281444758252a4bdd272546732dfb8e2be87be71b795d2aadc3726e3524f63e3
-        traffic.kuma.io/exclude-outbound-ports-for-uids: tcp:80,443:472;udp:53:472 # needed when running kuma CNI
+        traffic.kuma.io/exclude-outbound-ports-for-uids: tcp:80,443:1472;udp:53:1472 # needed when running kuma CNI
     spec:
       serviceAccountName: grafana
       securityContext:
         fsGroup: 472
-        runAsUser: 472
+        runAsUser: 1472
       initContainers:
         - name: init-plugins
           image: alpine
@@ -12046,6 +12046,8 @@ spec:
               port: 3000
           resources:
             {}
+          securityContext:
+            runAsUser: 472
       volumes:
         - name: config
           configMap:

--- a/app/kumactl/cmd/install/testdata/install-observability.no-loki.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-observability.no-loki.golden.yaml
@@ -11993,12 +11993,12 @@ spec:
         checksum/dashboards-json-config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
         checksum/sc-dashboard-provider-config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
         checksum/secret: 281444758252a4bdd272546732dfb8e2be87be71b795d2aadc3726e3524f63e3
-        traffic.kuma.io/exclude-outbound-ports-for-uids: tcp:80,443:472;udp:53:472 # needed when running kuma CNI
+        traffic.kuma.io/exclude-outbound-ports-for-uids: tcp:80,443:1472;udp:53:1472 # needed when running kuma CNI
     spec:
       serviceAccountName: grafana
       securityContext:
         fsGroup: 472
-        runAsUser: 472
+        runAsUser: 1472
       initContainers:
         - name: init-plugins
           image: alpine
@@ -12046,6 +12046,8 @@ spec:
               port: 3000
           resources:
             {}
+          securityContext:
+            runAsUser: 472
       volumes:
         - name: config
           configMap:

--- a/app/kumactl/cmd/install/testdata/install-observability.no-prometheus.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-observability.no-prometheus.golden.yaml
@@ -11440,12 +11440,12 @@ spec:
         checksum/dashboards-json-config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
         checksum/sc-dashboard-provider-config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
         checksum/secret: 281444758252a4bdd272546732dfb8e2be87be71b795d2aadc3726e3524f63e3
-        traffic.kuma.io/exclude-outbound-ports-for-uids: tcp:80,443:472;udp:53:472 # needed when running kuma CNI
+        traffic.kuma.io/exclude-outbound-ports-for-uids: tcp:80,443:1472;udp:53:1472 # needed when running kuma CNI
     spec:
       serviceAccountName: grafana
       securityContext:
         fsGroup: 472
-        runAsUser: 472
+        runAsUser: 1472
       initContainers:
         - name: init-plugins
           image: alpine
@@ -11493,6 +11493,8 @@ spec:
               port: 3000
           resources:
             {}
+          securityContext:
+            runAsUser: 472
       volumes:
         - name: config
           configMap:

--- a/app/kumactl/cmd/install/testdata/install-observability.overrides.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-observability.overrides.golden.yaml
@@ -11993,12 +11993,12 @@ spec:
         checksum/dashboards-json-config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
         checksum/sc-dashboard-provider-config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
         checksum/secret: 281444758252a4bdd272546732dfb8e2be87be71b795d2aadc3726e3524f63e3
-        traffic.kuma.io/exclude-outbound-ports-for-uids: tcp:80,443:472;udp:53:472 # needed when running kuma CNI
+        traffic.kuma.io/exclude-outbound-ports-for-uids: tcp:80,443:1472;udp:53:1472 # needed when running kuma CNI
     spec:
       serviceAccountName: grafana
       securityContext:
         fsGroup: 472
-        runAsUser: 472
+        runAsUser: 1472
       initContainers:
         - name: init-plugins
           image: alpine
@@ -12046,6 +12046,8 @@ spec:
               port: 3000
           resources:
             {}
+          securityContext:
+            runAsUser: 472
       volumes:
         - name: config
           configMap:

--- a/app/kumactl/data/install/k8s/metrics/grafana/grafana.yaml
+++ b/app/kumactl/data/install/k8s/metrics/grafana/grafana.yaml
@@ -249,12 +249,12 @@ spec:
         checksum/dashboards-json-config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
         checksum/sc-dashboard-provider-config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
         checksum/secret: 281444758252a4bdd272546732dfb8e2be87be71b795d2aadc3726e3524f63e3
-        traffic.kuma.io/exclude-outbound-ports-for-uids: tcp:80,443:472;udp:53:472 # needed when running kuma CNI
+        traffic.kuma.io/exclude-outbound-ports-for-uids: tcp:80,443:1472;udp:53:1472 # needed when running kuma CNI
     spec:
       serviceAccountName: grafana
       securityContext:
         fsGroup: 472
-        runAsUser: 472
+        runAsUser: 1472
       initContainers:
         - name: init-plugins
           image: alpine
@@ -302,6 +302,8 @@ spec:
               port: 3000
           resources:
             {}
+          securityContext:
+            runAsUser: 472
       volumes:
         - name: config
           configMap:


### PR DESCRIPTION
That way we can exclude traffic only for the initContainer.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [X] [Link to relevant issue][1] as well as docs and UI issues --
- [X] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [X] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [X] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [X] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

> Changelog: skip

<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
