### PR TITLE
ci(actions): made build/test/check run in parallel in build-test-distribute workflow

### DIFF
--- a/.github/workflows/build-test-distribute.yaml
+++ b/.github/workflows/build-test-distribute.yaml
@@ -56,6 +56,7 @@ jobs:
       - run: |
           make clean
       - run: |
+          make generate
           make build
       - run: |
           make -j build/distributions
@@ -85,7 +86,7 @@ jobs:
         run: |
           make test/container-structure
   test:
-    needs: ["check", "build"]
+    needs: ["check"]
     runs-on: ubuntu-latest
     if: ${{ ! contains(github.event.pull_request.labels.*.name, 'ci/skip-test') }}
     steps:
@@ -118,7 +119,7 @@ jobs:
           path: build/reports
           retention-days: 30
   distributions:
-    needs: test
+    needs: ["build", "test"]
     if: ${{ always() && !failure() && !cancelled() }}
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/build-test-distribute.yaml
+++ b/.github/workflows/build-test-distribute.yaml
@@ -30,15 +30,29 @@ jobs:
           make check
   build:
     runs-on: ubuntu-latest
-    needs: ["check"]
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: "Check to run on all arch/os combinations"
-        if: ${{ contains(github.event.pull_request.labels.*.name, 'ci/run-full-matrix') }}
+      - name: "Check if run on releasable ref"
+        id: "releasable_ref_checker"
+        if: |
+          ${{
+            (github.ref == 'refs/branch/master') ||
+            startsWith(github.ref, 'refs/branch/release-')  ||
+            startsWith(github.ref, 'refs/tags/') ||
+          false }}
         run: |
-          echo 'ENABLED_GOARCHES="arm64 amd64" ENABLED_GOOSES="linux darwin"' >> $GITHUB_ENV
+          echo "releasable=true" >> $GITHUB_OUTPUT
+      - name: "Check if should run on all arch/os combinations"
+        if: |
+          ${{
+            contains(github.event.pull_request.labels.*.name, 'ci/run-full-matrix') ||
+            'true' == steps.releasable_ref_checker.outputs.releasable
+          }}
+        run: |
+          echo 'ENABLED_GOARCHES=arm64 amd64' >> $GITHUB_ENV
+          echo 'ENABLED_GOOSES=linux darwin' >> $GITHUB_ENV
       - uses: actions/setup-go@v4
         with:
           go-version-file: go.mod
@@ -54,9 +68,6 @@ jobs:
       - run: |
           make dev/tools
       - run: |
-          make clean
-      - run: |
-          make generate
           make build
       - run: |
           make -j build/distributions
@@ -86,7 +97,6 @@ jobs:
         run: |
           make test/container-structure
   test:
-    needs: ["check"]
     runs-on: ubuntu-latest
     if: ${{ ! contains(github.event.pull_request.labels.*.name, 'ci/skip-test') }}
     steps:
@@ -119,24 +129,38 @@ jobs:
           path: build/reports
           retention-days: 30
   distributions:
-    needs: ["build", "test"]
+    needs: ["check", "build", "test"]
     if: ${{ always() && !failure() && !cancelled() }}
     runs-on: ubuntu-latest
     steps:
-      - name: "Check if force push"
+      - name: "Check if run on releasable ref"
+        id: "releasable_ref_checker"
         if: |
           ${{
-            contains(github.event.pull_request.labels.*.name, 'ci/force-publish') ||
             (github.ref == 'refs/branch/master') ||
             startsWith(github.ref, 'refs/branch/release-')  ||
             startsWith(github.ref, 'refs/tags/') ||
           false }}
         run: |
-          echo "ALLOW_PUSH=true" >> $GITHUB_ENV
-      - name: "Check if run on all arch/os combinations"
-        if: ${{ contains(github.event.pull_request.labels.*.name, 'ci/run-full-matrix') }}
+          echo "releasable=true" >> $GITHUB_OUTPUT
+      - name: "Check if force push"
+        if: |
+          ${{
+            contains(github.event.pull_request.labels.*.name, 'ci/force-publish') ||
+          false }}
+        # Open up the following conditions when we don't generate artifacts on CircleCI
+        #  'true' == steps.releasable_ref_checker.outputs.releasable ||
         run: |
-          echo 'ENABLED_GOARCHES="arm64 amd64" ENABLED_GOOSES="linux darwin"' >> $GITHUB_ENV
+          echo 'ALLOW_PUSH=true' >> $GITHUB_ENV
+      - name: "Check if should run on all arch/os combinations"
+        if: |
+          ${{
+            contains(github.event.pull_request.labels.*.name, 'ci/run-full-matrix') ||
+            'true' == steps.releasable_ref_checker.outputs.releasable
+          }}
+        run: |
+          echo 'ENABLED_GOARCHES=arm64 amd64' >> $GITHUB_ENV
+          echo 'ENABLED_GOOSES=linux darwin' >> $GITHUB_ENV
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
@@ -153,6 +177,7 @@ jobs:
       - uses: actions/download-artifact@v3
         with:
           name: build-output
+          path: build
       - name: Inspect created tars
         run: |
           for i in build/distributions/out/*.tar.gz; do echo $i; tar -tvf $i; done

--- a/.github/workflows/build-test-distribute.yaml
+++ b/.github/workflows/build-test-distribute.yaml
@@ -6,8 +6,31 @@ on:
   pull_request_target:
     branches: ["master", "release-*"]
 jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-go@v4
+        with:
+          go-version-file: go.mod
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/.kuma-dev
+          key: ${{ runner.os }}-devtools-${{ hashFiles('mk/dependencies/deps.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-devtools
+      - run: |
+          make dev/tools
+      - run: |
+          make clean
+      - run: |
+          make check
   build:
     runs-on: ubuntu-latest
+    needs: [ "check" ]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -28,8 +51,6 @@ jobs:
           make dev/tools
       - run: |
           make clean
-      - run: |
-          make check
       - run: |
           make build
       - run: |
@@ -56,7 +77,7 @@ jobs:
         run: |
           make test/container-structure
   test:
-    needs: build
+    needs: [ "check", "build" ]
     runs-on: ubuntu-latest
     if: ${{ ! contains(github.event.pull_request.labels.*.name, 'ci/skip-test') }}
     steps:
@@ -75,21 +96,6 @@ jobs:
             ${{ runner.os }}-devtools
       - name: Free up disk space for the Runner
         run: |
-          # source: https://github.com/apache/flink/blob/master/tools/azure-pipelines/free_disk_space.sh
-          echo "=============================================================================="
-          echo "Freeing up disk space on CI system"
-          echo "=============================================================================="
-          echo "Listing 100 largest packages"
-          dpkg-query -Wf '${Installed-Size}\t${Package}\n' | sort -n | tail -n 100
-          df -h
-          echo "Removing large packages"
-          sudo apt-get remove -y '^ghc-8.*' || true
-          sudo apt-get remove -y '^dotnet-.*' || true
-          sudo apt-get remove -y '^llvm-.*' || true
-          sudo apt-get remove -y 'php.*' || true
-          sudo apt-get remove -y azure-cli google-cloud-sdk hhvm google-chrome-stable firefox powershell mono-devel  || true
-          sudo apt-get autoremove -y
-          sudo apt-get clean
           echo "Removing large directories"
           sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc
           docker system prune --all -f

--- a/.github/workflows/build-test-distribute.yaml
+++ b/.github/workflows/build-test-distribute.yaml
@@ -1,7 +1,7 @@
 name: "build-test-distribute"
 on:
   push:
-    branches: ["master", "release-*", "gh-actions-build-test-dist"]
+    branches: ["master", "release-*", "!*-merge-master"]
     tags: ["*"]
   pull_request_target:
     branches: ["master", "release-*"]
@@ -39,21 +39,6 @@ jobs:
         run: |
           echo 'ENABLED_GOARCHES=arm64 amd64' >> $GITHUB_ENV
           echo 'ENABLED_GOOSES=linux darwin' >> $GITHUB_ENV
-          # some steps don't support cross running, so write the actual arch down here.
-          ARCH=$(uname -m)
-          case $ARCH in
-            aarch64)
-            RUNNER_ARCH=arm64
-            ;;
-            x86_64)
-            RUNNER_ARCH=amd64
-            ;;
-            *)
-            echo "Unsupported arch '$ARCH'"
-            exit 1
-            ;;
-          esac
-          echo "RUNNER_ARCH=$RUNNER_ARCH" >> $GITHUB_ENV
       - uses: actions/setup-go@v4
         with:
           go-version-file: go.mod
@@ -72,10 +57,13 @@ jobs:
           make build
       - run: |
           make -j build/distributions
+      - name: Install dependencies for cross builds
+        run: |
+          sudo apt-get update; sudo apt-get install -y qemu-user-static binfmt-support
       - run: |
-          ENABLED_GOARCHES=$RUNNER_ARCH make -j images
+          make -j images
       - run: |
-          ENABLED_GOARCHES=$RUNNER_ARCH make -j docker/save
+          make -j docker/save
       - name: Cleanup redundant build outputs
         run: |
           find  ./build/artifacts-* -maxdepth 0 -type d | xargs -I % rm -rf %
@@ -89,14 +77,10 @@ jobs:
           name: build-output
           path: build
           retention-days: 1
-      - name: Prepare for container structure test
-        if: ${{ !contains(github.event.pull_request.labels.*.name, 'ci/skip-container-structure-test') && !contains(github.event.pull_request.labels.*.name, 'ci/skip-test') }}
-        run: |
-          sudo apt-get update; sudo apt-get install -y qemu-user-static binfmt-support
       - name: Run container structure test
         if: ${{ !contains(github.event.pull_request.labels.*.name, 'ci/skip-container-structure-test') && !contains(github.event.pull_request.labels.*.name, 'ci/skip-test') }}
         run: |
-          ENABLED_GOARCHES=$RUNNER_ARCH make test/container-structure
+          make test/container-structure
   test:
     runs-on: ubuntu-latest
     if: ${{ ! contains(github.event.pull_request.labels.*.name, 'ci/skip-test') }}
@@ -116,9 +100,11 @@ jobs:
             ${{ runner.os }}-devtools
       - name: Free up disk space for the Runner
         run: |
-          echo "Removing large directories"
+          echo "Disk usage before cleanup"
+          sudo df -h
           sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc
           docker system prune --all -f
+          echo "Disk usage after cleanup"
           sudo df -h
       - name: Run tests
         run: |
@@ -139,29 +125,15 @@ jobs:
         run: |
           echo 'ENABLED_GOARCHES=arm64 amd64' >> $GITHUB_ENV
           echo 'ENABLED_GOOSES=linux darwin' >> $GITHUB_ENV
-          # some steps don't support cross running, so write the actual arch down here.
-          ARCH=$(uname -m)
-          case $ARCH in
-            aarch64)
-            RUNNER_ARCH=arm64
-            ;;
-            x86_64)
-            RUNNER_ARCH=amd64
-            ;;
-            *)
-            echo "Unsupported arch '$ARCH'"
-            exit 1
-            ;;
-          esac
-          echo "RUNNER_ARCH=$RUNNER_ARCH" >> $GITHUB_ENV
       - name: "Check if force push"
-        if: |
-          contains(github.event.pull_request.labels.*.name, 'ci/force-publish') ||
-          false
+        if: contains(github.event.pull_request.labels.*.name, 'ci/force-publish')
         # Open up the following conditions when we don't generate artifacts on CircleCI
-        #  github.event_name == 'push' ||
+        #  github.event_name == 'push'
         run: |
           echo 'ALLOW_PUSH=true' >> $GITHUB_ENV
+      - name: Install dependencies for cross builds
+        run: |
+          sudo apt-get update; sudo apt-get install -y qemu-user-static binfmt-support
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
@@ -187,7 +159,7 @@ jobs:
           make publish/pulp
       - name: Load images
         run: |
-          ENABLED_GOARCHES=$RUNNER_ARCH make docker/load
+          make docker/load
       - name: Publish images
         run: |-
           make docker/login
@@ -196,5 +168,5 @@ jobs:
             make docker/logout
           }
           trap on_exit EXIT
-          ENABLED_GOARCHES=$RUNNER_ARCH make docker/push
-          ENABLED_GOARCHES=$RUNNER_ARCH make docker/manifest
+          make docker/push
+          make docker/manifest

--- a/.github/workflows/build-test-distribute.yaml
+++ b/.github/workflows/build-test-distribute.yaml
@@ -1,7 +1,7 @@
 name: "build-test-distribute"
 on:
   push:
-    branches: ["master", "release-*"]
+    branches: ["master", "release-*", "gh-actions-build-test-dist"]
     tags: ["*"]
   pull_request_target:
     branches: ["master", "release-*"]
@@ -34,23 +34,12 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: "Check if run on releasable ref"
-        id: "releasable_ref_checker"
-        if: |
-          (github.ref == 'refs/branch/master') ||
-          startsWith(github.ref, 'refs/branch/release-')  ||
-          startsWith(github.ref, 'refs/tags/') ||
-          false
-        run: |
-          echo "releasable=true" >> $GITHUB_OUTPUT
       - name: "Check if should run on all arch/os combinations"
-        if: |
-          contains(github.event.pull_request.labels.*.name, 'ci/run-full-matrix') ||
-          'true' == steps.releasable_ref_checker.outputs.releasable
+        if: github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'ci/run-full-matrix')
         run: |
           echo 'ENABLED_GOARCHES=arm64 amd64' >> $GITHUB_ENV
           echo 'ENABLED_GOOSES=linux darwin' >> $GITHUB_ENV
-          # some steps don't support cross running, so write the actual arch down here. 
+          # some steps don't support cross running, so write the actual arch down here.
           ARCH=$(uname -m)
           case $ARCH in
             aarch64)
@@ -65,7 +54,6 @@ jobs:
             ;;
           esac
           echo "RUNNER_ARCH=$RUNNER_ARCH" >> $GITHUB_ENV
-
       - uses: actions/setup-go@v4
         with:
           go-version-file: go.mod
@@ -146,31 +134,12 @@ jobs:
     if: ${{ always() && !failure() && !cancelled() }}
     runs-on: ubuntu-latest
     steps:
-      - name: "Check if run on releasable ref"
-        id: "releasable_ref_checker"
-        if: |
-          (github.ref == 'refs/branch/master') ||
-          startsWith(github.ref, 'refs/branch/release-')  ||
-          startsWith(github.ref, 'refs/tags/') ||
-          false
-        run: |
-          echo "releasable=true" >> $GITHUB_OUTPUT
-      - name: "Check if force push"
-        if: |
-          contains(github.event.pull_request.labels.*.name, 'ci/force-publish') ||
-          false
-        # Open up the following conditions when we don't generate artifacts on CircleCI
-        #  'true' == steps.releasable_ref_checker.outputs.releasable ||
-        run: |
-          echo 'ALLOW_PUSH=true' >> $GITHUB_ENV
       - name: "Check if should run on all arch/os combinations"
-        if: |
-          contains(github.event.pull_request.labels.*.name, 'ci/run-full-matrix') ||
-          'true' == steps.releasable_ref_checker.outputs.releasable
+        if: github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'ci/run-full-matrix')
         run: |
           echo 'ENABLED_GOARCHES=arm64 amd64' >> $GITHUB_ENV
           echo 'ENABLED_GOOSES=linux darwin' >> $GITHUB_ENV
-          # some steps don't support cross running, so write the actual arch down here. 
+          # some steps don't support cross running, so write the actual arch down here.
           ARCH=$(uname -m)
           case $ARCH in
             aarch64)
@@ -185,6 +154,14 @@ jobs:
             ;;
           esac
           echo "RUNNER_ARCH=$RUNNER_ARCH" >> $GITHUB_ENV
+      - name: "Check if force push"
+        if: |
+          contains(github.event.pull_request.labels.*.name, 'ci/force-publish') ||
+          false
+        # Open up the following conditions when we don't generate artifacts on CircleCI
+        #  github.event_name == 'push' ||
+        run: |
+          echo 'ALLOW_PUSH=true' >> $GITHUB_ENV
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0

--- a/.github/workflows/build-test-distribute.yaml
+++ b/.github/workflows/build-test-distribute.yaml
@@ -50,6 +50,22 @@ jobs:
         run: |
           echo 'ENABLED_GOARCHES=arm64 amd64' >> $GITHUB_ENV
           echo 'ENABLED_GOOSES=linux darwin' >> $GITHUB_ENV
+          # some steps don't support cross running, so write the actual arch down here. 
+          ARCH=$(uname -m)
+          case $ARCH in
+            aarch64)
+            RUNNER_ARCH=arm64
+            ;;
+            x86_64)
+            RUNNER_ARCH=amd64
+            ;;
+            *)
+            echo "Unsupported arch '$ARCH'"
+            exit 1
+            ;;
+          esac
+          echo "RUNNER_ARCH=$RUNNER_ARCH" >> $GITHUB_ENV
+
       - uses: actions/setup-go@v4
         with:
           go-version-file: go.mod
@@ -69,9 +85,9 @@ jobs:
       - run: |
           make -j build/distributions
       - run: |
-          make -j images
+          ENABLED_GOARCHES=$RUNNER_ARCH make -j images
       - run: |
-          make -j docker/save
+          ENABLED_GOARCHES=$RUNNER_ARCH make -j docker/save
       - name: Cleanup redundant build outputs
         run: |
           find  ./build/artifacts-* -maxdepth 0 -type d | xargs -I % rm -rf %
@@ -92,7 +108,7 @@ jobs:
       - name: Run container structure test
         if: ${{ !contains(github.event.pull_request.labels.*.name, 'ci/skip-container-structure-test') && !contains(github.event.pull_request.labels.*.name, 'ci/skip-test') }}
         run: |
-          make test/container-structure
+          ENABLED_GOARCHES=$RUNNER_ARCH make test/container-structure
   test:
     runs-on: ubuntu-latest
     if: ${{ ! contains(github.event.pull_request.labels.*.name, 'ci/skip-test') }}
@@ -154,6 +170,21 @@ jobs:
         run: |
           echo 'ENABLED_GOARCHES=arm64 amd64' >> $GITHUB_ENV
           echo 'ENABLED_GOOSES=linux darwin' >> $GITHUB_ENV
+          # some steps don't support cross running, so write the actual arch down here. 
+          ARCH=$(uname -m)
+          case $ARCH in
+            aarch64)
+            RUNNER_ARCH=arm64
+            ;;
+            x86_64)
+            RUNNER_ARCH=amd64
+            ;;
+            *)
+            echo "Unsupported arch '$ARCH'"
+            exit 1
+            ;;
+          esac
+          echo "RUNNER_ARCH=$RUNNER_ARCH" >> $GITHUB_ENV
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
@@ -179,7 +210,7 @@ jobs:
           make publish/pulp
       - name: Load images
         run: |
-          make docker/load
+          ENABLED_GOARCHES=$RUNNER_ARCH make docker/load
       - name: Publish images
         run: |-
           make docker/login
@@ -188,5 +219,5 @@ jobs:
             make docker/logout
           }
           trap on_exit EXIT
-          make docker/push
-          make docker/manifest
+          ENABLED_GOARCHES=$RUNNER_ARCH make docker/push
+          ENABLED_GOARCHES=$RUNNER_ARCH make docker/manifest

--- a/.github/workflows/build-test-distribute.yaml
+++ b/.github/workflows/build-test-distribute.yaml
@@ -35,6 +35,10 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - name: "Check to run on all arch/os combinations"
+        if: ${{ contains(github.event.pull_request.labels.*.name, 'ci/run-full-matrix') }}
+        run: |
+          echo 'ENABLED_GOARCHES="arm64 amd64" ENABLED_GOOSES="linux darwin"' >> $GITHUB_ENV
       - uses: actions/setup-go@v4
         with:
           go-version-file: go.mod
@@ -115,16 +119,19 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Check if force push"
+        if: |
+            ${{ 
+              contains(github.event.pull_request.labels.*.name, 'ci/force-publish') ||
+              (github.ref == 'refs/branch/master') ||
+              startsWith(github.ref, 'refs/branch/release-')  ||
+              startsWith(github.ref, 'refs/tags/') ||
+            false }}
         run: |
-          PR_FORCE_PUBLISH="${{ contains(github.event.pull_request.labels.*.name, 'ci/force-publish') }}"
-          RUN_ON_MASTER="${{ github.ref == 'refs/branch/master' }}"
-          RUN_ON_RELEASE="${{ startsWith(github.ref, 'refs/branch/release-') }}"
-          RUN_ON_TAG="${{ startsWith(github.ref, 'refs/tags/') }}"
-          ALL_CONDITIONS="$PR_FORCE_PUBLISH-$RUN_ON_MASTER-$RUN_ON_RELEASE-$RUN_ON_TAG"
-
-          if [[ "$ALL_CONDITIONS" == *"true"* ]]; then
-            'echo "ALLOW_PUSH=true" >> $GITHUB_ENV'
-          fi
+          echo "ALLOW_PUSH=true" >> $GITHUB_ENV
+      - name: "Check if run on all arch/os combinations"
+        if: ${{ contains(github.event.pull_request.labels.*.name, 'ci/run-full-matrix') }}
+        run: |
+          echo 'ENABLED_GOARCHES="arm64 amd64" ENABLED_GOOSES="linux darwin"' >> $GITHUB_ENV
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0

--- a/.github/workflows/build-test-distribute.yaml
+++ b/.github/workflows/build-test-distribute.yaml
@@ -1,7 +1,7 @@
 name: "build-test-distribute"
 on:
   push:
-    branches: ["master", "release-*", "gh-actions-build-test-dist"]
+    branches: ["master", "release-*"]
     tags: ["*"]
   pull_request_target:
     branches: ["master", "release-*"]
@@ -37,19 +37,16 @@ jobs:
       - name: "Check if run on releasable ref"
         id: "releasable_ref_checker"
         if: |
-          ${{
-            (github.ref == 'refs/branch/master') ||
-            startsWith(github.ref, 'refs/branch/release-')  ||
-            startsWith(github.ref, 'refs/tags/') ||
-          false }}
+          (github.ref == 'refs/branch/master') ||
+          startsWith(github.ref, 'refs/branch/release-')  ||
+          startsWith(github.ref, 'refs/tags/') ||
+          false
         run: |
           echo "releasable=true" >> $GITHUB_OUTPUT
       - name: "Check if should run on all arch/os combinations"
         if: |
-          ${{
-            contains(github.event.pull_request.labels.*.name, 'ci/run-full-matrix') ||
-            'true' == steps.releasable_ref_checker.outputs.releasable
-          }}
+          contains(github.event.pull_request.labels.*.name, 'ci/run-full-matrix') ||
+          'true' == steps.releasable_ref_checker.outputs.releasable
         run: |
           echo 'ENABLED_GOARCHES=arm64 amd64' >> $GITHUB_ENV
           echo 'ENABLED_GOOSES=linux darwin' >> $GITHUB_ENV
@@ -127,7 +124,7 @@ jobs:
         with:
           name: test-reports
           path: build/reports
-          retention-days: 30
+          retention-days: 7
   distributions:
     needs: ["check", "build", "test"]
     if: ${{ always() && !failure() && !cancelled() }}
@@ -136,28 +133,24 @@ jobs:
       - name: "Check if run on releasable ref"
         id: "releasable_ref_checker"
         if: |
-          ${{
-            (github.ref == 'refs/branch/master') ||
-            startsWith(github.ref, 'refs/branch/release-')  ||
-            startsWith(github.ref, 'refs/tags/') ||
-          false }}
+          (github.ref == 'refs/branch/master') ||
+          startsWith(github.ref, 'refs/branch/release-')  ||
+          startsWith(github.ref, 'refs/tags/') ||
+          false
         run: |
           echo "releasable=true" >> $GITHUB_OUTPUT
       - name: "Check if force push"
         if: |
-          ${{
-            contains(github.event.pull_request.labels.*.name, 'ci/force-publish') ||
-          false }}
+          contains(github.event.pull_request.labels.*.name, 'ci/force-publish') ||
+          false
         # Open up the following conditions when we don't generate artifacts on CircleCI
         #  'true' == steps.releasable_ref_checker.outputs.releasable ||
         run: |
           echo 'ALLOW_PUSH=true' >> $GITHUB_ENV
       - name: "Check if should run on all arch/os combinations"
         if: |
-          ${{
-            contains(github.event.pull_request.labels.*.name, 'ci/run-full-matrix') ||
-            'true' == steps.releasable_ref_checker.outputs.releasable
-          }}
+          contains(github.event.pull_request.labels.*.name, 'ci/run-full-matrix') ||
+          'true' == steps.releasable_ref_checker.outputs.releasable
         run: |
           echo 'ENABLED_GOARCHES=arm64 amd64' >> $GITHUB_ENV
           echo 'ENABLED_GOOSES=linux darwin' >> $GITHUB_ENV

--- a/.github/workflows/build-test-distribute.yaml
+++ b/.github/workflows/build-test-distribute.yaml
@@ -1,7 +1,7 @@
 name: "build-test-distribute"
 on:
   push:
-    branches: ["master", "release-*"]
+    branches: ["master", "release-*", "gh-actions-build-test-dist"]
     tags: ["*"]
   pull_request_target:
     branches: ["master", "release-*"]
@@ -30,7 +30,7 @@ jobs:
           make check
   build:
     runs-on: ubuntu-latest
-    needs: [ "check" ]
+    needs: ["check"]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -63,14 +63,18 @@ jobs:
           make -j images
       - run: |
           make -j docker/save
-      - name: Pack artifact
+      - name: Cleanup redundant build outputs
         run: |
-          tar -czf build.tar.gz ./build
-      - name: Temporarily saving build output
+          find  ./build/artifacts-* -maxdepth 0 -type d | xargs -I % rm -rf %
+          find ./build/distributions/* -maxdepth 0 -type d | grep -v '/out' | xargs -I % rm -rf %
+          find  ./build/tools-* -maxdepth 0 -type d | xargs -I % rm -rf %
+          rm -rf ./build/oapitmp
+          rm -rf ./build/ebpf/
+      - name: Upload build output
         uses: actions/upload-artifact@v3
         with:
           name: build-output
-          path: build.tar.gz
+          path: build
           retention-days: 1
       - name: Prepare for container structure test
         if: ${{ !contains(github.event.pull_request.labels.*.name, 'ci/skip-container-structure-test') && !contains(github.event.pull_request.labels.*.name, 'ci/skip-test') }}
@@ -81,7 +85,7 @@ jobs:
         run: |
           make test/container-structure
   test:
-    needs: [ "check", "build" ]
+    needs: ["check", "build"]
     runs-on: ubuntu-latest
     if: ${{ ! contains(github.event.pull_request.labels.*.name, 'ci/skip-test') }}
     steps:
@@ -120,12 +124,12 @@ jobs:
     steps:
       - name: "Check if force push"
         if: |
-            ${{ 
-              contains(github.event.pull_request.labels.*.name, 'ci/force-publish') ||
-              (github.ref == 'refs/branch/master') ||
-              startsWith(github.ref, 'refs/branch/release-')  ||
-              startsWith(github.ref, 'refs/tags/') ||
-            false }}
+          ${{
+            contains(github.event.pull_request.labels.*.name, 'ci/force-publish') ||
+            (github.ref == 'refs/branch/master') ||
+            startsWith(github.ref, 'refs/branch/release-')  ||
+            startsWith(github.ref, 'refs/tags/') ||
+          false }}
         run: |
           echo "ALLOW_PUSH=true" >> $GITHUB_ENV
       - name: "Check if run on all arch/os combinations"
@@ -148,9 +152,6 @@ jobs:
       - uses: actions/download-artifact@v3
         with:
           name: build-output
-      - name: Unpack artifact
-        run: |
-          tar -xzf build.tar.gz
       - name: Inspect created tars
         run: |
           for i in build/distributions/out/*.tar.gz; do echo $i; tar -tvf $i; done


### PR DESCRIPTION
### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues 
  - N/A
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS 
  - Confirmed.
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) 
  - No need.
  - [x] Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)?
  - No need.
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label)
  - labeled

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword

This PR makes these jobs run in parallel to speed the overall run:
- build
- test
- check

A successful run can be found here: https://github.com/jijiechen/kuma/actions/runs/6878015850

This PR also includes some other related minor improvements.