### PR TITLE
ci(docs): auto-trigger workflows on release and docs change

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -30,6 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        ref: "master"
       - uses: actions/setup-go@v4
         with:
           go-version-file: go.mod
@@ -37,10 +38,6 @@ jobs:
         run: |
           echo $(go env GOPATH)/bin >> $GITHUB_PATH
           go install github.com/kumahq/ci-tools/cmd/release-tool@latest
-      - name: remove-cni
-        # CNI was only introduced in 1.7 so versions before should remove
-        if: startsWith(env.RELEASE, '1.7') || startsWith(env.RELEASE, '1.6')
-        run: echo DOCKER_IMAGES=${{env.DOCKER_IMAGES}} | sed 's/,kuma-cni//g' >> $GITHUB_ENV
       - name: create-release
         if: env.RELEASE != '0.0.0'
         env:
@@ -98,10 +95,11 @@ jobs:
           commit-message: "docs(CHANGELOG.md): updating changelog and version files"
           signoff: true
           branch: chore/update-changelog
+          base: master
           delete-branch: true
           title: "docs(CHANGELOG.md): updating changelog and version files"
           draft: false
-          labels: ci/skip-test
+          labels: ci/skip-test,ci/auto-merge
           token: ${{ steps.github-app-token.outputs.token }}
           committer: kumahq[bot] <110050114+kumahq[bot]@users.noreply.github.com>
           author: kumahq[bot] <110050114+kumahq[bot]@users.noreply.github.com>

--- a/.github/workflows/update-docs.yaml
+++ b/.github/workflows/update-docs.yaml
@@ -1,5 +1,11 @@
 name: "Update docs"
 on:
+  push:
+    paths:
+      - CHANGELOG.md
+      - versions.yml
+      - UPGRADE.md
+      - docs/generated/raw/**
   workflow_dispatch: {}
   schedule:
     - cron: 0 8 * * *


### PR DESCRIPTION
This means that the person that releases doesn't have to do anything for the docs PR to make its way.

- The update-docs workflows now triggers on push to paths that are synced to docs
- The release workflow is fixed for when we trigger a release

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
