### PR TITLE
fix(ZoneEgress): rewrite host header on ExternalService requests

### DIFF
--- a/pkg/xds/generator/egress/external_services_generator.go
+++ b/pkg/xds/generator/egress/external_services_generator.go
@@ -176,6 +176,7 @@ func (g *ExternalServicesGenerator) addFilterChains(
 				envoy_common.WithName(clusterName),
 				envoy_common.WithService(serviceName),
 				envoy_common.WithTags(meshDestination.WithoutTags(mesh_proto.ServiceTag)),
+				envoy_common.WithExternalService(true),
 			)
 
 			filterChainBuilder := envoy_listeners.NewFilterChainBuilder(apiVersion, names.GetEgressFilterChainName(serviceName, meshName)).Configure(

--- a/pkg/xds/generator/egress/testdata/01.externalservice-only.golden.yaml
+++ b/pkg/xds/generator/egress/testdata/01.externalservice-only.golden.yaml
@@ -73,6 +73,7 @@ resources:
               - match:
                   prefix: /
                 route:
+                  autoHostRewrite: true
                   cluster: mesh-1:externalservice-1
                   timeout: 0s
           statPrefix: externalservice-1

--- a/pkg/xds/generator/egress/testdata/03.mixed-services.golden.yaml
+++ b/pkg/xds/generator/egress/testdata/03.mixed-services.golden.yaml
@@ -210,6 +210,7 @@ resources:
               - match:
                   prefix: /
                 route:
+                  autoHostRewrite: true
                   cluster: mesh-1:externalservice-1
                   timeout: 0s
           statPrefix: externalservice-1
@@ -270,6 +271,7 @@ resources:
               - match:
                   prefix: /
                 route:
+                  autoHostRewrite: true
                   cluster: mesh-1:externalservice-2
                   timeout: 0s
           statPrefix: externalservice-2

--- a/pkg/xds/generator/egress/testdata/04.mixed-services-custom-trafficroute.golden.yaml
+++ b/pkg/xds/generator/egress/testdata/04.mixed-services-custom-trafficroute.golden.yaml
@@ -190,6 +190,7 @@ resources:
               - match:
                   prefix: /
                 route:
+                  autoHostRewrite: true
                   cluster: mesh-1:externalservice-2
                   timeout: 0s
           statPrefix: externalservice-2

--- a/pkg/xds/generator/egress/testdata/05.mixed-services-with-custom-trafficpermissions.golden.yaml
+++ b/pkg/xds/generator/egress/testdata/05.mixed-services-with-custom-trafficpermissions.golden.yaml
@@ -212,6 +212,7 @@ resources:
               - match:
                   prefix: /
                 route:
+                  autoHostRewrite: true
                   cluster: mesh-1:externalservice-1
                   timeout: 0s
           statPrefix: externalservice-1
@@ -266,6 +267,7 @@ resources:
               - match:
                   prefix: /
                 route:
+                  autoHostRewrite: true
                   cluster: mesh-1:externalservice-2
                   timeout: 0s
           statPrefix: externalservice-2

--- a/pkg/xds/generator/egress/testdata/06.mixed-services-with-external-in-other-zone.golden.yaml
+++ b/pkg/xds/generator/egress/testdata/06.mixed-services-with-external-in-other-zone.golden.yaml
@@ -200,6 +200,7 @@ resources:
               - match:
                   prefix: /
                 route:
+                  autoHostRewrite: true
                   cluster: mesh-1:externalservice-1
                   timeout: 0s
           statPrefix: externalservice-1


### PR DESCRIPTION
We do this for requests when not using ZoneEgress.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
