### PR TITLE
test(policy): introduce new resources builders for tests

### DIFF
--- a/pkg/plugins/policies/meshhealthcheck/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshhealthcheck/plugin/v1alpha1/plugin_test.go
@@ -124,7 +124,7 @@ var _ = Describe("MeshHealthCheck", func() {
 						},
 					},
 				}).
-				WithRoutingBuilder(
+				WithRouting(
 					xds_builders.Routing().
 						WithOutboundTargets(
 							xds_builders.EndpointMap().

--- a/pkg/plugins/policies/meshhealthcheck/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshhealthcheck/plugin/v1alpha1/plugin_test.go
@@ -124,30 +124,16 @@ var _ = Describe("MeshHealthCheck", func() {
 						},
 					},
 				}).
-				WithRouting(xds.Routing{
-					OutboundTargets: map[core_xds.ServiceName][]core_xds.Endpoint{
-						httpServiceTag: {
-							{
-								Tags: map[string]string{mesh_proto.ProtocolTag: core_mesh.ProtocolHTTP},
-							},
-						},
-						splitHttpServiceTag: {
-							{
-								Tags: map[string]string{mesh_proto.ProtocolTag: core_mesh.ProtocolHTTP},
-							},
-						},
-						grpcServiceTag: {
-							{
-								Tags: map[string]string{mesh_proto.ProtocolTag: core_mesh.ProtocolGRPC},
-							},
-						},
-						tcpServiceTag: {
-							{
-								Tags: map[string]string{mesh_proto.ProtocolTag: core_mesh.ProtocolTCP},
-							},
-						},
-					},
-				}).
+				WithRoutingBuilder(
+					xds_builders.Routing().
+						WithOutboundTargets(
+							xds_builders.EndpointMap().
+								AddEndpoint(httpServiceTag, xds_samples.HttpEndpointBuilder()).
+								AddEndpoint(splitHttpServiceTag, xds_samples.HttpEndpointBuilder()).
+								AddEndpoint(grpcServiceTag, xds_samples.GrpcEndpointBuilder()).
+								AddEndpoint(tcpServiceTag, xds_samples.TcpEndpointBuilder()),
+						),
+				).
 				Build()
 			plugin := plugin.NewPlugin().(core_plugins.PolicyPlugin)
 

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/plugin_test.go
@@ -203,7 +203,7 @@ var _ = Describe("MeshHTTPRoute", func() {
 				xdsContext: *xds_builders.Context().WithEndpointMap(outboundTargets).Build(),
 				proxy: xds_builders.Proxy().
 					WithDataplane(samples.DataplaneWebBuilder()).
-					WithRoutingBuilder(xds_builders.Routing().WithOutboundTargets(outboundTargets)).
+					WithRouting(xds_builders.Routing().WithOutboundTargets(outboundTargets)).
 					// This is a policy that doesn't apply to these services on
 					// purpose, so that the plugin is activated
 					// TODO: remove this when the plugin runs by default
@@ -238,7 +238,7 @@ var _ = Describe("MeshHTTPRoute", func() {
 				xdsContext: *xds_builders.Context().WithEndpointMap(outboundTargets).Build(),
 				proxy: xds_builders.Proxy().
 					WithDataplane(samples.DataplaneWebBuilder()).
-					WithRoutingBuilder(xds_builders.Routing().WithOutboundTargets(outboundTargets)).
+					WithRouting(xds_builders.Routing().WithOutboundTargets(outboundTargets)).
 					WithPolicies(core_xds.MatchedPolicies{
 						Dynamic: map[core_model.ResourceType]core_xds.TypedMatchingPolicies{
 							api.MeshHTTPRouteType: {
@@ -322,7 +322,7 @@ var _ = Describe("MeshHTTPRoute", func() {
 				xdsContext: *xds_builders.Context().WithEndpointMap(outboundTargets).Build(),
 				proxy: xds_builders.Proxy().
 					WithDataplane(samples.DataplaneWebBuilder()).
-					WithRoutingBuilder(xds_builders.Routing().WithOutboundTargets(outboundTargets)).
+					WithRouting(xds_builders.Routing().WithOutboundTargets(outboundTargets)).
 					WithPolicies(core_xds.MatchedPolicies{
 						Dynamic: map[core_model.ResourceType]core_xds.TypedMatchingPolicies{
 							api.MeshHTTPRouteType: {
@@ -363,7 +363,7 @@ var _ = Describe("MeshHTTPRoute", func() {
 				xdsContext: *xds_builders.Context().WithEndpointMap(outboundTargets).Build(),
 				proxy: xds_builders.Proxy().
 					WithDataplane(samples.DataplaneWebBuilder()).
-					WithRoutingBuilder(xds_builders.Routing().WithOutboundTargets(outboundTargets)).
+					WithRouting(xds_builders.Routing().WithOutboundTargets(outboundTargets)).
 					WithPolicies(core_xds.MatchedPolicies{
 						Dynamic: map[core_model.ResourceType]core_xds.TypedMatchingPolicies{
 							api.MeshHTTPRouteType: {
@@ -442,7 +442,7 @@ var _ = Describe("MeshHTTPRoute", func() {
 				xdsContext: *xds_builders.Context().WithEndpointMap(outboundTargets).Build(),
 				proxy: xds_builders.Proxy().
 					WithDataplane(samples.DataplaneWebBuilder()).
-					WithRoutingBuilder(xds_builders.Routing().WithOutboundTargets(outboundTargets)).
+					WithRouting(xds_builders.Routing().WithOutboundTargets(outboundTargets)).
 					WithPolicies(core_xds.MatchedPolicies{
 						Dynamic: map[core_model.ResourceType]core_xds.TypedMatchingPolicies{
 							api.MeshHTTPRouteType: {
@@ -491,7 +491,7 @@ var _ = Describe("MeshHTTPRoute", func() {
 				xdsContext: *xds_builders.Context().WithEndpointMap(outboundTargets).Build(),
 				proxy: xds_builders.Proxy().
 					WithDataplane(samples.DataplaneWebBuilder()).
-					WithRoutingBuilder(xds_builders.Routing().WithOutboundTargets(outboundTargets)).
+					WithRouting(xds_builders.Routing().WithOutboundTargets(outboundTargets)).
 					WithPolicies(core_xds.MatchedPolicies{
 						Dynamic: map[core_model.ResourceType]core_xds.TypedMatchingPolicies{
 							api.MeshHTTPRouteType: {
@@ -549,7 +549,7 @@ var _ = Describe("MeshHTTPRoute", func() {
 				xdsContext: *xds_builders.Context().WithEndpointMap(outboundTargets).Build(),
 				proxy: xds_builders.Proxy().
 					WithDataplane(samples.DataplaneWebBuilder()).
-					WithRoutingBuilder(xds_builders.Routing().WithOutboundTargets(outboundTargets)).
+					WithRouting(xds_builders.Routing().WithOutboundTargets(outboundTargets)).
 					WithPolicies(core_xds.MatchedPolicies{
 						Dynamic: map[core_model.ResourceType]core_xds.TypedMatchingPolicies{
 							api.MeshHTTPRouteType: {

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/plugin_test.go
@@ -11,6 +11,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 
 	common_api "github.com/kumahq/kuma/api/common/v1alpha1"
+	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	core_plugins "github.com/kumahq/kuma/pkg/core/plugins"
 	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	core_model "github.com/kumahq/kuma/pkg/core/resources/model"
@@ -192,21 +193,17 @@ var _ = Describe("MeshHTTPRoute", func() {
 			Expect(getResource(resourceSet, envoy_resource.EndpointType)).To(matchers.MatchGoldenYAML(filepath.Join("testdata", name+".endpoints.golden.yaml")))
 		},
 		Entry("default-route", func() outboundsTestCase {
-			outboundTargets := core_xds.EndpointMap{
-				"backend": []core_xds.Endpoint{{
-					Target: "192.168.0.4",
-					Port:   8084,
-					Tags:   map[string]string{"kuma.io/service": "backend", "kuma.io/protocol": "http", "region": "us"},
-					Weight: 1,
-				}},
-			}
+			outboundTargets := xds_builders.EndpointMap().
+				AddEndpoint("backend", xds_builders.Endpoint().
+					WithTarget("192.168.0.4").
+					WithPort(8084).
+					WithWeight(1).
+					WithTags(mesh_proto.ServiceTag, "backend", mesh_proto.ProtocolTag, core_mesh.ProtocolHTTP, "region", "us"))
 			return outboundsTestCase{
 				xdsContext: *xds_builders.Context().WithEndpointMap(outboundTargets).Build(),
 				proxy: xds_builders.Proxy().
 					WithDataplane(samples.DataplaneWebBuilder()).
-					WithRouting(core_xds.Routing{
-						OutboundTargets: outboundTargets,
-					}).
+					WithRoutingBuilder(xds_builders.Routing().WithOutboundTargets(outboundTargets)).
 					// This is a policy that doesn't apply to these services on
 					// purpose, so that the plugin is activated
 					// TODO: remove this when the plugin runs by default
@@ -225,26 +222,23 @@ var _ = Describe("MeshHTTPRoute", func() {
 			}
 		}()),
 		Entry("basic", func() outboundsTestCase {
-			outboundTargets := core_xds.EndpointMap{
-				"backend": []core_xds.Endpoint{{
-					Target: "192.168.0.4",
-					Port:   8084,
-					Tags:   map[string]string{"kuma.io/service": "backend", "kuma.io/protocol": "http", "region": "eu"},
-					Weight: 1,
-				}, {
-					Target: "192.168.0.5",
-					Port:   8084,
-					Tags:   map[string]string{"kuma.io/service": "backend", "kuma.io/protocol": "http", "region": "us"},
-					Weight: 1,
-				}},
-			}
+			outboundTargets := xds_builders.EndpointMap().
+				AddEndpoints("backend",
+					xds_builders.Endpoint().
+						WithTarget("192.168.0.4").
+						WithPort(8084).
+						WithWeight(1).
+						WithTags(mesh_proto.ServiceTag, "backend", mesh_proto.ProtocolTag, core_mesh.ProtocolHTTP, "region", "eu"),
+					xds_builders.Endpoint().
+						WithTarget("192.168.0.5").
+						WithPort(8084).
+						WithWeight(1).
+						WithTags(mesh_proto.ServiceTag, "backend", mesh_proto.ProtocolTag, core_mesh.ProtocolHTTP, "region", "us"))
 			return outboundsTestCase{
 				xdsContext: *xds_builders.Context().WithEndpointMap(outboundTargets).Build(),
 				proxy: xds_builders.Proxy().
 					WithDataplane(samples.DataplaneWebBuilder()).
-					WithRouting(core_xds.Routing{
-						OutboundTargets: outboundTargets,
-					}).
+					WithRoutingBuilder(xds_builders.Routing().WithOutboundTargets(outboundTargets)).
 					WithPolicies(core_xds.MatchedPolicies{
 						Dynamic: map[core_model.ResourceType]core_xds.TypedMatchingPolicies{
 							api.MeshHTTPRouteType: {
@@ -307,32 +301,28 @@ var _ = Describe("MeshHTTPRoute", func() {
 			}
 		}()),
 		Entry("mixed-tcp-and-http-outbounds", func() outboundsTestCase {
-			outboundTargets := core_xds.EndpointMap{
-				"backend": []core_xds.Endpoint{{
-					Target: "192.168.0.4",
-					Port:   8084,
-					Tags:   map[string]string{"kuma.io/service": "backend", "kuma.io/protocol": "http", "region": "eu"},
-					Weight: 1,
-				}, {
-					Target: "192.168.0.5",
-					Port:   8084,
-					Tags:   map[string]string{"kuma.io/service": "backend", "kuma.io/protocol": "http", "region": "us"},
-					Weight: 1,
-				}},
-				"other-tcp": []core_xds.Endpoint{{
-					Target: "192.168.0.10",
-					Port:   8084,
-					Tags:   map[string]string{"kuma.io/service": "other-tcp", "kuma.io/protocol": "tcp", "region": "eu"},
-					Weight: 1,
-				}},
-			}
+			outboundTargets := xds_builders.EndpointMap().
+				AddEndpoints("backend",
+					xds_builders.Endpoint().
+						WithTarget("192.168.0.4").
+						WithPort(8084).
+						WithWeight(1).
+						WithTags(mesh_proto.ServiceTag, "backend", mesh_proto.ProtocolTag, core_mesh.ProtocolHTTP, "region", "eu"),
+					xds_builders.Endpoint().
+						WithTarget("192.168.0.5").
+						WithPort(8084).
+						WithWeight(1).
+						WithTags(mesh_proto.ServiceTag, "backend", mesh_proto.ProtocolTag, core_mesh.ProtocolHTTP, "region", "us")).
+				AddEndpoint("other-tcp", xds_builders.Endpoint().
+					WithTarget("192.168.0.10").
+					WithPort(8084).
+					WithWeight(1).
+					WithTags(mesh_proto.ServiceTag, "other-tcp", mesh_proto.ProtocolTag, core_mesh.ProtocolTCP, "region", "eu"))
 			return outboundsTestCase{
 				xdsContext: *xds_builders.Context().WithEndpointMap(outboundTargets).Build(),
 				proxy: xds_builders.Proxy().
 					WithDataplane(samples.DataplaneWebBuilder()).
-					WithRouting(core_xds.Routing{
-						OutboundTargets: outboundTargets,
-					}).
+					WithRoutingBuilder(xds_builders.Routing().WithOutboundTargets(outboundTargets)).
 					WithPolicies(core_xds.MatchedPolicies{
 						Dynamic: map[core_model.ResourceType]core_xds.TypedMatchingPolicies{
 							api.MeshHTTPRouteType: {
@@ -363,21 +353,17 @@ var _ = Describe("MeshHTTPRoute", func() {
 			}
 		}()),
 		Entry("header-modifiers", func() outboundsTestCase {
-			outboundTargets := core_xds.EndpointMap{
-				"backend": []core_xds.Endpoint{{
-					Target: "192.168.0.4",
-					Port:   8084,
-					Tags:   map[string]string{"kuma.io/service": "backend", "kuma.io/protocol": "http", "region": "us"},
-					Weight: 1,
-				}},
-			}
+			outboundTargets := xds_builders.EndpointMap().
+				AddEndpoint("backend", xds_builders.Endpoint().
+					WithTarget("192.168.0.4").
+					WithPort(8084).
+					WithWeight(1).
+					WithTags(mesh_proto.ServiceTag, "backend", mesh_proto.ProtocolTag, core_mesh.ProtocolHTTP, "region", "us"))
 			return outboundsTestCase{
 				xdsContext: *xds_builders.Context().WithEndpointMap(outboundTargets).Build(),
 				proxy: xds_builders.Proxy().
 					WithDataplane(samples.DataplaneWebBuilder()).
-					WithRouting(core_xds.Routing{
-						OutboundTargets: outboundTargets,
-					}).
+					WithRoutingBuilder(xds_builders.Routing().WithOutboundTargets(outboundTargets)).
 					WithPolicies(core_xds.MatchedPolicies{
 						Dynamic: map[core_model.ResourceType]core_xds.TypedMatchingPolicies{
 							api.MeshHTTPRouteType: {
@@ -446,21 +432,17 @@ var _ = Describe("MeshHTTPRoute", func() {
 			}
 		}()),
 		Entry("url-rewrite", func() outboundsTestCase {
-			outboundTargets := core_xds.EndpointMap{
-				"backend": []core_xds.Endpoint{{
-					Target: "192.168.0.4",
-					Port:   8084,
-					Tags:   map[string]string{"kuma.io/service": "backend", "kuma.io/protocol": "http", "region": "us"},
-					Weight: 1,
-				}},
-			}
+			outboundTargets := xds_builders.EndpointMap().
+				AddEndpoint("backend", xds_builders.Endpoint().
+					WithTarget("192.168.0.4").
+					WithPort(8084).
+					WithWeight(1).
+					WithTags(mesh_proto.ServiceTag, "backend", mesh_proto.ProtocolTag, core_mesh.ProtocolHTTP, "region", "us"))
 			return outboundsTestCase{
 				xdsContext: *xds_builders.Context().WithEndpointMap(outboundTargets).Build(),
 				proxy: xds_builders.Proxy().
 					WithDataplane(samples.DataplaneWebBuilder()).
-					WithRouting(core_xds.Routing{
-						OutboundTargets: outboundTargets,
-					}).
+					WithRoutingBuilder(xds_builders.Routing().WithOutboundTargets(outboundTargets)).
 					WithPolicies(core_xds.MatchedPolicies{
 						Dynamic: map[core_model.ResourceType]core_xds.TypedMatchingPolicies{
 							api.MeshHTTPRouteType: {
@@ -499,21 +481,17 @@ var _ = Describe("MeshHTTPRoute", func() {
 			}
 		}()),
 		Entry("headers-match", func() outboundsTestCase {
-			outboundTargets := core_xds.EndpointMap{
-				"backend": []core_xds.Endpoint{{
-					Target: "192.168.0.4",
-					Port:   8084,
-					Tags:   map[string]string{"kuma.io/service": "backend", "kuma.io/protocol": "http", "region": "us"},
-					Weight: 1,
-				}},
-			}
+			outboundTargets := xds_builders.EndpointMap().
+				AddEndpoint("backend", xds_builders.Endpoint().
+					WithTarget("192.168.0.4").
+					WithPort(8084).
+					WithWeight(1).
+					WithTags(mesh_proto.ServiceTag, "backend", mesh_proto.ProtocolTag, core_mesh.ProtocolHTTP, "region", "us"))
 			return outboundsTestCase{
 				xdsContext: *xds_builders.Context().WithEndpointMap(outboundTargets).Build(),
 				proxy: xds_builders.Proxy().
 					WithDataplane(samples.DataplaneWebBuilder()).
-					WithRouting(core_xds.Routing{
-						OutboundTargets: outboundTargets,
-					}).
+					WithRoutingBuilder(xds_builders.Routing().WithOutboundTargets(outboundTargets)).
 					WithPolicies(core_xds.MatchedPolicies{
 						Dynamic: map[core_model.ResourceType]core_xds.TypedMatchingPolicies{
 							api.MeshHTTPRouteType: {
@@ -556,27 +534,22 @@ var _ = Describe("MeshHTTPRoute", func() {
 			}
 		}()),
 		Entry("request-mirror", func() outboundsTestCase {
-			outboundTargets := core_xds.EndpointMap{
-				"backend": []core_xds.Endpoint{{
-					Target: "192.168.0.4",
-					Port:   8084,
-					Tags:   map[string]string{"kuma.io/service": "backend", "kuma.io/protocol": "http", "region": "us"},
-					Weight: 1,
-				}},
-				"payments": []core_xds.Endpoint{{
-					Target: "192.168.0.6",
-					Port:   8086,
-					Tags:   map[string]string{"kuma.io/service": "payments", "kuma.io/protocol": "http", "region": "us", "version": "v1", "env": "dev"},
-					Weight: 1,
-				}},
-			}
+			outboundTargets := xds_builders.EndpointMap().
+				AddEndpoint("backend", xds_builders.Endpoint().
+					WithTarget("192.168.0.4").
+					WithPort(8084).
+					WithWeight(1).
+					WithTags(mesh_proto.ServiceTag, "backend", mesh_proto.ProtocolTag, core_mesh.ProtocolHTTP, "region", "us")).
+				AddEndpoint("payments", xds_builders.Endpoint().
+					WithTarget("192.168.0.6").
+					WithPort(8086).
+					WithWeight(1).
+					WithTags(mesh_proto.ServiceTag, "payments", mesh_proto.ProtocolTag, core_mesh.ProtocolHTTP, "region", "us", "version", "v1", "env", "dev"))
 			return outboundsTestCase{
 				xdsContext: *xds_builders.Context().WithEndpointMap(outboundTargets).Build(),
 				proxy: xds_builders.Proxy().
 					WithDataplane(samples.DataplaneWebBuilder()).
-					WithRouting(core_xds.Routing{
-						OutboundTargets: outboundTargets,
-					}).
+					WithRoutingBuilder(xds_builders.Routing().WithOutboundTargets(outboundTargets)).
 					WithPolicies(core_xds.MatchedPolicies{
 						Dynamic: map[core_model.ResourceType]core_xds.TypedMatchingPolicies{
 							api.MeshHTTPRouteType: {

--- a/pkg/plugins/policies/meshloadbalancingstrategy/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshloadbalancingstrategy/plugin/v1alpha1/plugin_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/kumahq/kuma/pkg/test/resources/builders"
 	"github.com/kumahq/kuma/pkg/test/resources/samples"
 	xds_builders "github.com/kumahq/kuma/pkg/test/xds/builders"
+	xds_samples "github.com/kumahq/kuma/pkg/test/xds/samples"
 	"github.com/kumahq/kuma/pkg/util/pointer"
 	util_proto "github.com/kumahq/kuma/pkg/util/proto"
 	xds_context "github.com/kumahq/kuma/pkg/xds/context"
@@ -174,20 +175,7 @@ var _ = Describe("MeshLoadBalancingStrategy", func() {
 						},
 					},
 				},
-				Routing: core_xds.Routing{
-					OutboundTargets: map[core_xds.ServiceName][]core_xds.Endpoint{
-						"backend": {
-							{
-								Tags: map[string]string{mesh_proto.ProtocolTag: core_mesh.ProtocolHTTP},
-							},
-						},
-						"payment": {
-							{
-								Tags: map[string]string{mesh_proto.ProtocolTag: core_mesh.ProtocolHTTP},
-							},
-						},
-					},
-				},
+				Routing: paymentsAndBackendRouting(),
 			},
 		}),
 		Entry("egress", testCase{
@@ -1224,7 +1212,7 @@ var _ = Describe("MeshLoadBalancingStrategy", func() {
 	)
 	type gatewayTestCase struct {
 		name        string
-		endpointMap core_xds.EndpointMap
+		endpointMap *xds_builders.EndpointMapBuilder
 		toRules     core_rules.ToRules
 	}
 	DescribeTable("should generate proper Envoy config for MeshGateways",
@@ -1291,12 +1279,11 @@ var _ = Describe("MeshLoadBalancingStrategy", func() {
 		},
 		Entry("basic outbound cluster", gatewayTestCase{
 			name: "basic",
-			endpointMap: map[core_xds.ServiceName][]core_xds.Endpoint{
-				"backend": {
-					createEndpointWith("test-zone", "192.168.1.1", map[string]string{}),
-					createEndpointWith("test-zone-2", "192.168.1.2", map[string]string{}),
-				},
-			},
+			endpointMap: xds_builders.EndpointMap().
+				AddEndpoints("backend",
+					createEndpointBuilderWith("test-zone", "192.168.1.1", map[string]string{}),
+					createEndpointBuilderWith("test-zone-2", "192.168.1.2", map[string]string{}),
+				),
 			toRules: core_rules.ToRules{
 				Rules: []*core_rules.Rule{
 					{
@@ -1333,18 +1320,17 @@ var _ = Describe("MeshLoadBalancingStrategy", func() {
 		}),
 		Entry("locality aware gateway", gatewayTestCase{
 			name: "locality_aware",
-			endpointMap: map[core_xds.ServiceName][]core_xds.Endpoint{
-				"backend": {
-					createEndpointWith("test-zone", "192.168.1.1", map[string]string{"k8s.io/node": "node1"}),
-					createEndpointWith("test-zone", "192.168.1.2", map[string]string{"k8s.io/node": "node2"}),
-					createEndpointWith("test-zone", "192.168.1.3", map[string]string{"k8s.io/az": "test"}),
-					createEndpointWith("test-zone", "192.168.1.4", map[string]string{"k8s.io/region": "test"}),
-					createEndpointWith("zone-2", "192.168.1.5", map[string]string{}),
-					createEndpointWith("zone-3", "192.168.1.6", map[string]string{}),
-					createEndpointWith("zone-4", "192.168.1.7", map[string]string{}),
-					createEndpointWith("zone-5", "192.168.1.8", map[string]string{}),
-				},
-			},
+			endpointMap: xds_builders.EndpointMap().
+				AddEndpoints("backend",
+					createEndpointBuilderWith("test-zone", "192.168.1.1", map[string]string{"k8s.io/node": "node1"}),
+					createEndpointBuilderWith("test-zone", "192.168.1.2", map[string]string{"k8s.io/node": "node2"}),
+					createEndpointBuilderWith("test-zone", "192.168.1.3", map[string]string{"k8s.io/az": "test"}),
+					createEndpointBuilderWith("test-zone", "192.168.1.4", map[string]string{"k8s.io/region": "test"}),
+					createEndpointBuilderWith("zone-2", "192.168.1.5", map[string]string{}),
+					createEndpointBuilderWith("zone-3", "192.168.1.6", map[string]string{}),
+					createEndpointBuilderWith("zone-4", "192.168.1.7", map[string]string{}),
+					createEndpointBuilderWith("zone-5", "192.168.1.8", map[string]string{}),
+				),
 			toRules: core_rules.ToRules{
 				Rules: []*core_rules.Rule{
 					{
@@ -1402,39 +1388,33 @@ var _ = Describe("MeshLoadBalancingStrategy", func() {
 })
 
 func createEndpointWith(zone string, ip string, extraTags map[string]string) core_xds.Endpoint {
-	tags := map[string]string{
-		mesh_proto.ProtocolTag: core_mesh.ProtocolHTTP,
-		mesh_proto.ZoneTag:     zone,
-	}
+	return *xds_builders.Endpoint().
+		WithTarget(ip).
+		WithPort(8080).
+		WithTags(mesh_proto.ProtocolTag, core_mesh.ProtocolHTTP, mesh_proto.ZoneTag, zone).
+		AddTagsMap(extraTags).
+		WithZone(zone).
+		Build()
+}
 
-	for k, v := range extraTags {
-		tags[k] = v
-	}
-
-	return core_xds.Endpoint{
-		Target:   ip,
-		Port:     8080,
-		Tags:     tags,
-		Locality: &core_xds.Locality{Zone: zone, Priority: 0},
-	}
+func createEndpointBuilderWith(zone string, ip string, extraTags map[string]string) *xds_builders.EndpointBuilder {
+	return xds_builders.Endpoint().
+		WithTarget(ip).
+		WithPort(8080).
+		WithTags(mesh_proto.ProtocolTag, core_mesh.ProtocolHTTP, mesh_proto.ZoneTag, zone).
+		AddTagsMap(extraTags).
+		WithZone(zone)
 }
 
 // TODO move to routing builder
 func paymentsAndBackendRouting() core_xds.Routing {
-	return core_xds.Routing{
-		OutboundTargets: map[core_xds.ServiceName][]core_xds.Endpoint{
-			"backend": {
-				{
-					Tags: map[string]string{mesh_proto.ProtocolTag: core_mesh.ProtocolHTTP},
-				},
-			},
-			"payment": {
-				{
-					Tags: map[string]string{mesh_proto.ProtocolTag: core_mesh.ProtocolHTTP},
-				},
-			},
-		},
-	}
+	return *xds_builders.Routing().
+		WithOutboundTargets(
+			xds_builders.EndpointMap().
+				AddEndpoint("backend", xds_samples.HttpEndpointBuilder()).
+				AddEndpoint("payment", xds_samples.HttpEndpointBuilder()),
+		).
+		Build()
 }
 
 func paymentsListener() envoy_common.NamedResource {

--- a/pkg/plugins/policies/meshloadbalancingstrategy/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshloadbalancingstrategy/plugin/v1alpha1/plugin_test.go
@@ -175,7 +175,7 @@ var _ = Describe("MeshLoadBalancingStrategy", func() {
 						},
 					},
 				},
-				Routing: paymentsAndBackendRouting(),
+				Routing: *paymentsAndBackendRouting().Build(),
 			},
 		}),
 		Entry("egress", testCase{
@@ -1407,14 +1407,13 @@ func createEndpointBuilderWith(zone string, ip string, extraTags map[string]stri
 }
 
 // TODO move to routing builder
-func paymentsAndBackendRouting() core_xds.Routing {
-	return *xds_builders.Routing().
+func paymentsAndBackendRouting() *xds_builders.RoutingBuilder {
+	return xds_builders.Routing().
 		WithOutboundTargets(
 			xds_builders.EndpointMap().
 				AddEndpoint("backend", xds_samples.HttpEndpointBuilder()).
 				AddEndpoint("payment", xds_samples.HttpEndpointBuilder()),
-		).
-		Build()
+		)
 }
 
 func paymentsListener() envoy_common.NamedResource {

--- a/pkg/plugins/policies/meshretry/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshretry/plugin/v1alpha1/plugin_test.go
@@ -59,7 +59,7 @@ var _ = Describe("MeshRetry", func() {
 				WithAddress("127.0.0.1").
 				AddOutboundsToServices("http-service", "grpc-service", "tcp-service").
 				WithInboundOfTags(mesh_proto.ServiceTag, "backend", mesh_proto.ProtocolTag, "http")).
-			WithRoutingBuilder(
+			WithRouting(
 				xds_builders.Routing().
 					WithOutboundTargets(xds_builders.EndpointMap().
 						AddEndpoint("http-service", xds_samples.HttpEndpointBuilder()).

--- a/pkg/plugins/policies/meshretry/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshretry/plugin/v1alpha1/plugin_test.go
@@ -59,25 +59,14 @@ var _ = Describe("MeshRetry", func() {
 				WithAddress("127.0.0.1").
 				AddOutboundsToServices("http-service", "grpc-service", "tcp-service").
 				WithInboundOfTags(mesh_proto.ServiceTag, "backend", mesh_proto.ProtocolTag, "http")).
-			WithRouting(core_xds.Routing{
-				OutboundTargets: core_xds.EndpointMap{
-					"http-service": []core_xds.Endpoint{{
-						Tags: map[string]string{
-							"kuma.io/protocol": "http",
-						},
-					}},
-					"tcp-service": []core_xds.Endpoint{{
-						Tags: map[string]string{
-							"kuma.io/protocol": "tcp",
-						},
-					}},
-					"grpc-service": []core_xds.Endpoint{{
-						Tags: map[string]string{
-							"kuma.io/protocol": "grpc",
-						},
-					}},
-				},
-			}).
+			WithRoutingBuilder(
+				xds_builders.Routing().
+					WithOutboundTargets(xds_builders.EndpointMap().
+						AddEndpoint("http-service", xds_samples.HttpEndpointBuilder()).
+						AddEndpoint("tcp-service", xds_samples.TcpEndpointBuilder()).
+						AddEndpoint("grpc-service", xds_samples.GrpcEndpointBuilder()),
+					),
+			).
 			WithPolicies(xds.MatchedPolicies{
 				Dynamic: map[core_model.ResourceType]xds.TypedMatchingPolicies{
 					api.MeshRetryType: {

--- a/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/plugin_test.go
@@ -273,7 +273,7 @@ var _ = Describe("MeshTCPRoute", func() {
 				xdsContext: *xds_builders.Context().WithEndpointMap(outboundTargets).Build(),
 				proxy: xds_builders.Proxy().
 					WithDataplane(samples.DataplaneWebBuilder()).
-					WithRoutingBuilder(
+					WithRouting(
 						xds_builders.Routing().
 							WithOutboundTargets(outboundTargets).
 							WithExternalServiceOutboundTargets(externalServiceOutboundTargets),
@@ -324,7 +324,7 @@ var _ = Describe("MeshTCPRoute", func() {
 				xdsContext: *xds_builders.Context().WithEndpointMap(outboundTargets).Build(),
 				proxy: xds_builders.Proxy().
 					WithDataplane(samples.DataplaneWebBuilder()).
-					WithRoutingBuilder(xds_builders.Routing().WithOutboundTargets(outboundTargets)).
+					WithRouting(xds_builders.Routing().WithOutboundTargets(outboundTargets)).
 					WithPolicies(policies).
 					Build(),
 			}
@@ -406,7 +406,7 @@ var _ = Describe("MeshTCPRoute", func() {
 				xdsContext: *xds_builders.Context().WithEndpointMap(outboundTargets).Build(),
 				proxy: xds_builders.Proxy().
 					WithDataplane(samples.DataplaneWebBuilder()).
-					WithRoutingBuilder(xds_builders.Routing().WithOutboundTargets(outboundTargets)).
+					WithRouting(xds_builders.Routing().WithOutboundTargets(outboundTargets)).
 					WithPolicies(policies).
 					Build(),
 			}
@@ -488,7 +488,7 @@ var _ = Describe("MeshTCPRoute", func() {
 				xdsContext: *xds_builders.Context().WithEndpointMap(outboundTargets).Build(),
 				proxy: xds_builders.Proxy().
 					WithDataplane(samples.DataplaneWebBuilder()).
-					WithRoutingBuilder(xds_builders.Routing().WithOutboundTargets(outboundTargets)).
+					WithRouting(xds_builders.Routing().WithOutboundTargets(outboundTargets)).
 					WithPolicies(policies).
 					Build(),
 			}

--- a/pkg/plugins/policies/meshtimeout/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshtimeout/plugin/v1alpha1/plugin_test.go
@@ -61,7 +61,7 @@ var _ = Describe("MeshTimeout", func() {
 				WithAddress("127.0.0.1").
 				AddOutboundsToServices("other-service", "second-service").
 				WithInboundOfTags(mesh_proto.ServiceTag, "backend", mesh_proto.ProtocolTag, "http")).
-			WithRoutingBuilder(
+			WithRouting(
 				xds_builders.Routing().
 					WithOutboundTargets(
 						xds_builders.EndpointMap().
@@ -428,7 +428,7 @@ var _ = Describe("MeshTimeout", func() {
 		xdsCtx := xds_samples.SampleContextWith(resources)
 		proxy := xds_builders.Proxy().
 			WithDataplane(samples.GatewayDataplaneBuilder()).
-			WithRoutingBuilder(xds_builders.Routing().
+			WithRouting(xds_builders.Routing().
 				WithOutboundTargets(
 					xds_builders.EndpointMap().
 						AddEndpoint("backend", xds_samples.HttpEndpointBuilder()).

--- a/pkg/plugins/policies/meshtimeout/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshtimeout/plugin/v1alpha1/plugin_test.go
@@ -61,25 +61,15 @@ var _ = Describe("MeshTimeout", func() {
 				WithAddress("127.0.0.1").
 				AddOutboundsToServices("other-service", "second-service").
 				WithInboundOfTags(mesh_proto.ServiceTag, "backend", mesh_proto.ProtocolTag, "http")).
-			WithRouting(core_xds.Routing{
-				OutboundTargets: core_xds.EndpointMap{
-					"other-service": []core_xds.Endpoint{{
-						Tags: map[string]string{
-							"kuma.io/protocol": "http",
-						},
-					}},
-					"other-service-_0_": []core_xds.Endpoint{{
-						Tags: map[string]string{
-							"kuma.io/protocol": "http",
-						},
-					}},
-					"second-service": []core_xds.Endpoint{{
-						Tags: map[string]string{
-							"kuma.io/protocol": "tcp",
-						},
-					}},
-				},
-			}).
+			WithRoutingBuilder(
+				xds_builders.Routing().
+					WithOutboundTargets(
+						xds_builders.EndpointMap().
+							AddEndpoint("other-service", xds_samples.HttpEndpointBuilder()).
+							AddEndpoint("other-service-_0_", xds_samples.HttpEndpointBuilder()).
+							AddEndpoint("second-service", xds_samples.TcpEndpointBuilder()),
+					),
+			).
 			WithPolicies(xds.MatchedPolicies{
 				Dynamic: map[core_model.ResourceType]xds.TypedMatchingPolicies{
 					api.MeshTimeoutType: {
@@ -438,20 +428,13 @@ var _ = Describe("MeshTimeout", func() {
 		xdsCtx := xds_samples.SampleContextWith(resources)
 		proxy := xds_builders.Proxy().
 			WithDataplane(samples.GatewayDataplaneBuilder()).
-			WithRouting(core_xds.Routing{
-				OutboundTargets: core_xds.EndpointMap{
-					"backend": []core_xds.Endpoint{{
-						Tags: map[string]string{
-							"kuma.io/protocol": "http",
-						},
-					}},
-					"other-service": []core_xds.Endpoint{{
-						Tags: map[string]string{
-							"kuma.io/protocol": "http",
-						},
-					}},
-				},
-			}).
+			WithRoutingBuilder(xds_builders.Routing().
+				WithOutboundTargets(
+					xds_builders.EndpointMap().
+						AddEndpoint("backend", xds_samples.HttpEndpointBuilder()).
+						AddEndpoint("other-service", xds_samples.HttpEndpointBuilder()),
+				),
+			).
 			WithPolicies(xds.MatchedPolicies{
 				Dynamic: map[core_model.ResourceType]xds.TypedMatchingPolicies{
 					api.MeshTimeoutType: {

--- a/pkg/test/resources/builders/dataplane_builder.go
+++ b/pkg/test/resources/builders/dataplane_builder.go
@@ -99,7 +99,7 @@ func (d *DataplaneBuilder) WithoutInbounds() *DataplaneBuilder {
 }
 
 func (d *DataplaneBuilder) WithInboundOfTags(tagsKV ...string) *DataplaneBuilder {
-	return d.WithInboundOfTagsMap(tagsKVToMap(tagsKV))
+	return d.WithInboundOfTagsMap(TagsKVToMap(tagsKV))
 }
 
 func (d *DataplaneBuilder) WithInboundOfTagsMap(tags map[string]string) *DataplaneBuilder {
@@ -115,7 +115,7 @@ func (d *DataplaneBuilder) AddInboundHttpOfService(service string) *DataplaneBui
 }
 
 func (d *DataplaneBuilder) AddInboundOfTags(tags ...string) *DataplaneBuilder {
-	return d.AddInboundOfTagsMap(tagsKVToMap(tags))
+	return d.AddInboundOfTagsMap(TagsKVToMap(tags))
 }
 
 func (d *DataplaneBuilder) AddInboundOfTagsMap(tags map[string]string) *DataplaneBuilder {
@@ -169,7 +169,7 @@ func (d *DataplaneBuilder) WithTransparentProxying(redirectPortOutbound, redirec
 	return d
 }
 
-func tagsKVToMap(tagsKV []string) map[string]string {
+func TagsKVToMap(tagsKV []string) map[string]string {
 	if len(tagsKV)%2 == 1 {
 		panic("tagsKV has to have even number of arguments")
 	}

--- a/pkg/test/resources/builders/targetref_builder.go
+++ b/pkg/test/resources/builders/targetref_builder.go
@@ -13,7 +13,7 @@ func TargetRefMesh() common_api.TargetRef {
 func TargetRefMeshSubset(kv ...string) common_api.TargetRef {
 	return common_api.TargetRef{
 		Kind: "MeshSubset",
-		Tags: tagsKVToMap(kv),
+		Tags: TagsKVToMap(kv),
 	}
 }
 
@@ -28,6 +28,6 @@ func TargetRefServiceSubset(name string, kv ...string) common_api.TargetRef {
 	return common_api.TargetRef{
 		Kind: "MeshServiceSubset",
 		Name: name,
-		Tags: tagsKVToMap(kv),
+		Tags: TagsKVToMap(kv),
 	}
 }

--- a/pkg/test/xds/builders/context_builder.go
+++ b/pkg/test/xds/builders/context_builder.go
@@ -37,9 +37,9 @@ func (mc *ContextBuilder) With(fn func(*xds_context.Context)) *ContextBuilder {
 	return mc
 }
 
-func (mc *ContextBuilder) WithEndpointMap(endpointMap core_xds.EndpointMap) *ContextBuilder {
-	mc.res.Mesh.EndpointMap = endpointMap
-	mc.res.ControlPlane.CLACache.(*xds.DummyCLACache).OutboundTargets = endpointMap
+func (mc *ContextBuilder) WithEndpointMap(endpointMap *EndpointMapBuilder) *ContextBuilder {
+	mc.res.Mesh.EndpointMap = endpointMap.Build()
+	mc.res.ControlPlane.CLACache.(*xds.DummyCLACache).OutboundTargets = endpointMap.Build()
 	return mc
 }
 

--- a/pkg/test/xds/builders/endpoint_builder.go
+++ b/pkg/test/xds/builders/endpoint_builder.go
@@ -1,0 +1,84 @@
+package builders
+
+import (
+	"github.com/kumahq/kuma/pkg/core/xds"
+	"github.com/kumahq/kuma/pkg/test/resources/builders"
+)
+
+type EndpointBuilder struct {
+	res *xds.Endpoint
+}
+
+func Endpoint() *EndpointBuilder {
+	return &EndpointBuilder{res: &xds.Endpoint{
+		Target:          "192.168.0.1",
+		UnixDomainPath:  "",
+		Port:            0,
+		Tags:            nil,
+		Weight:          0,
+		Locality:        nil,
+		ExternalService: nil,
+	}}
+}
+
+func (e *EndpointBuilder) Build() *xds.Endpoint {
+	return e.res
+}
+
+func (e *EndpointBuilder) With(fn func(*xds.Endpoint)) *EndpointBuilder {
+	fn(e.res)
+	return e
+}
+
+func (e *EndpointBuilder) WithTags(tagsKV ...string) *EndpointBuilder {
+	e.WithTagsMap(builders.TagsKVToMap(tagsKV))
+	return e
+}
+
+func (e *EndpointBuilder) WithTagsMap(tags map[string]string) *EndpointBuilder {
+	e.res.Tags = tags
+	return e
+}
+
+func (e *EndpointBuilder) AddTagsMap(tags map[string]string) *EndpointBuilder {
+	for k, v := range tags {
+		e.res.Tags[k] = v
+	}
+	return e
+}
+
+func (e *EndpointBuilder) WithTarget(target string) *EndpointBuilder {
+	e.res.Target = target
+	return e
+}
+
+func (e *EndpointBuilder) WithPort(port uint32) *EndpointBuilder {
+	e.res.Port = port
+	return e
+}
+
+func (e *EndpointBuilder) WithWeight(weight uint32) *EndpointBuilder {
+	e.res.Weight = weight
+	return e
+}
+
+func (e *EndpointBuilder) WithZone(zone string) *EndpointBuilder {
+	if e.res.Locality == nil {
+		e.res.Locality = &xds.Locality{}
+	}
+	e.res.Locality.Zone = zone
+	return e
+}
+
+func (e *EndpointBuilder) WithPriority(priority uint32) *EndpointBuilder {
+	if e.res.Locality == nil {
+		e.res.Locality = &xds.Locality{}
+	}
+	e.res.Locality.Priority = priority
+	return e
+}
+
+func (e *EndpointBuilder) WithExternalService(externalService *xds.ExternalService) *EndpointBuilder {
+	e.res.ExternalService = externalService
+	return e
+}

--- a/pkg/test/xds/builders/endpointmap_builder.go
+++ b/pkg/test/xds/builders/endpointmap_builder.go
@@ -1,0 +1,32 @@
+package builders
+
+import "github.com/kumahq/kuma/pkg/core/xds"
+
+type EndpointMapBuilder struct {
+	res xds.EndpointMap
+}
+
+func EndpointMap() *EndpointMapBuilder {
+	return &EndpointMapBuilder{res: xds.EndpointMap{}}
+}
+
+func (em *EndpointMapBuilder) Build() xds.EndpointMap {
+	return em.res
+}
+
+func (em *EndpointMapBuilder) With(fn func(xds.EndpointMap)) *EndpointMapBuilder {
+	fn(em.res)
+	return em
+}
+
+func (em *EndpointMapBuilder) AddEndpoint(service xds.ServiceName, endpoint *EndpointBuilder) *EndpointMapBuilder {
+	em.res[service] = append(em.res[service], *endpoint.Build())
+	return em
+}
+
+func (em *EndpointMapBuilder) AddEndpoints(service xds.ServiceName, endpoints ...*EndpointBuilder) *EndpointMapBuilder {
+	for _, endpoint := range endpoints {
+		em.res[service] = append(em.res[service], *endpoint.Build())
+	}
+	return em
+}

--- a/pkg/test/xds/builders/proxy_builder.go
+++ b/pkg/test/xds/builders/proxy_builder.go
@@ -64,3 +64,8 @@ func (p *ProxyBuilder) WithRouting(routing xds.Routing) *ProxyBuilder {
 	p.res.Routing = routing
 	return p
 }
+
+func (p *ProxyBuilder) WithRoutingBuilder(routing *RoutingBuilder) *ProxyBuilder {
+	p.res.Routing = *routing.Build()
+	return p
+}

--- a/pkg/test/xds/builders/proxy_builder.go
+++ b/pkg/test/xds/builders/proxy_builder.go
@@ -60,12 +60,7 @@ func (p *ProxyBuilder) WithPolicies(policies xds.MatchedPolicies) *ProxyBuilder 
 	return p
 }
 
-func (p *ProxyBuilder) WithRouting(routing xds.Routing) *ProxyBuilder {
-	p.res.Routing = routing
-	return p
-}
-
-func (p *ProxyBuilder) WithRoutingBuilder(routing *RoutingBuilder) *ProxyBuilder {
+func (p *ProxyBuilder) WithRouting(routing *RoutingBuilder) *ProxyBuilder {
 	p.res.Routing = *routing.Build()
 	return p
 }

--- a/pkg/test/xds/builders/routing_builder.go
+++ b/pkg/test/xds/builders/routing_builder.go
@@ -1,0 +1,36 @@
+package builders
+
+import "github.com/kumahq/kuma/pkg/core/xds"
+
+type RoutingBuilder struct {
+	res *xds.Routing
+}
+
+func Routing() *RoutingBuilder {
+	return &RoutingBuilder{
+		res: &xds.Routing{
+			TrafficRoutes:                  xds.RouteMap{},
+			OutboundTargets:                xds.EndpointMap{},
+			ExternalServiceOutboundTargets: xds.EndpointMap{},
+		},
+	}
+}
+
+func (r *RoutingBuilder) Build() *xds.Routing {
+	return r.res
+}
+
+func (r *RoutingBuilder) With(fn func(*xds.Routing)) *RoutingBuilder {
+	fn(r.res)
+	return r
+}
+
+func (r *RoutingBuilder) WithOutboundTargets(outboundTargets *EndpointMapBuilder) *RoutingBuilder {
+	r.res.OutboundTargets = outboundTargets.Build()
+	return r
+}
+
+func (r *RoutingBuilder) WithExternalServiceOutboundTargets(externalServiceOutboundTargets *EndpointMapBuilder) *RoutingBuilder {
+	r.res.ExternalServiceOutboundTargets = externalServiceOutboundTargets.Build()
+	return r
+}

--- a/pkg/test/xds/samples/endpoint_samples.go
+++ b/pkg/test/xds/samples/endpoint_samples.go
@@ -1,0 +1,19 @@
+package samples
+
+import (
+	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
+	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
+	xds_builders "github.com/kumahq/kuma/pkg/test/xds/builders"
+)
+
+func HttpEndpointBuilder() *xds_builders.EndpointBuilder {
+	return xds_builders.Endpoint().WithTags(mesh_proto.ProtocolTag, core_mesh.ProtocolHTTP)
+}
+
+func TcpEndpointBuilder() *xds_builders.EndpointBuilder {
+	return xds_builders.Endpoint().WithTags(mesh_proto.ProtocolTag, core_mesh.ProtocolTCP)
+}
+
+func GrpcEndpointBuilder() *xds_builders.EndpointBuilder {
+	return xds_builders.Endpoint().WithTags(mesh_proto.ProtocolTag, core_mesh.ProtocolGRPC)
+}

--- a/pkg/test/xds/samples/meshcontext_samples.go
+++ b/pkg/test/xds/samples/meshcontext_samples.go
@@ -1,7 +1,6 @@
 package samples
 
 import (
-	core_xds "github.com/kumahq/kuma/pkg/core/xds"
 	"github.com/kumahq/kuma/pkg/test/resources/samples"
 	"github.com/kumahq/kuma/pkg/test/xds/builders"
 	xds_context "github.com/kumahq/kuma/pkg/xds/context"
@@ -15,14 +14,9 @@ func SampleContextWith(resources xds_context.Resources) xds_context.Context {
 	return *builders.Context().
 		WithMesh(samples.MeshDefaultBuilder()).
 		WithResources(resources).
-		WithEndpointMap(map[core_xds.ServiceName][]core_xds.Endpoint{
-			"some-service": {
-				{
-					Tags: map[string]string{
-						"app": "some-service",
-					},
-				},
-			},
-		}).
+		WithEndpointMap(
+			builders.EndpointMap().
+				AddEndpoint("some-service", builders.Endpoint().WithTags("app", "some-service")),
+		).
 		Build()
 }


### PR DESCRIPTION
### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
