### PR TITLE
test(policy): introduce new resources builders for tests

### DIFF
--- a/pkg/plugins/policies/meshaccesslog/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshaccesslog/plugin/v1alpha1/plugin_test.go
@@ -14,7 +14,6 @@ import (
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	core_plugins "github.com/kumahq/kuma/pkg/core/plugins"
 	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
-	core_model "github.com/kumahq/kuma/pkg/core/resources/model"
 	"github.com/kumahq/kuma/pkg/core/xds"
 	core_xds "github.com/kumahq/kuma/pkg/core/xds"
 	core_rules "github.com/kumahq/kuma/pkg/plugins/policies/core/rules"
@@ -73,15 +72,9 @@ var _ = Describe("MeshAccessLog", func() {
 						).
 						AddOutbounds(given.outbounds),
 				).
-				WithPolicies(xds.MatchedPolicies{
-					Dynamic: map[core_model.ResourceType]xds.TypedMatchingPolicies{
-						api.MeshAccessLogType: {
-							Type:      api.MeshAccessLogType,
-							ToRules:   given.toRules,
-							FromRules: given.fromRules,
-						},
-					},
-				}).
+				WithPolicies(
+					xds_builders.MatchedPolicies().WithPolicy(api.MeshAccessLogType, given.toRules, given.fromRules),
+				).
 				Build()
 			plugin := plugin.NewPlugin().(core_plugins.PolicyPlugin)
 
@@ -969,14 +962,7 @@ var _ = Describe("MeshAccessLog", func() {
 						WithMesh("default").
 						WithBuiltInGateway("gateway"),
 				).
-				WithPolicies(xds.MatchedPolicies{
-					Dynamic: map[core_model.ResourceType]xds.TypedMatchingPolicies{
-						api.MeshAccessLogType: {
-							Type:    api.MeshAccessLogType,
-							ToRules: given.toRules,
-						},
-					},
-				}).
+				WithPolicies(xds_builders.MatchedPolicies().WithToPolicy(api.MeshAccessLogType, given.toRules)).
 				Build()
 
 			for n, p := range core_plugins.Plugins().ProxyPlugins() {

--- a/pkg/plugins/policies/meshfaultinjection/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshfaultinjection/plugin/v1alpha1/plugin_test.go
@@ -12,7 +12,6 @@ import (
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	core_plugins "github.com/kumahq/kuma/pkg/core/plugins"
 	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
-	core_model "github.com/kumahq/kuma/pkg/core/resources/model"
 	core_xds "github.com/kumahq/kuma/pkg/core/xds"
 	core_rules "github.com/kumahq/kuma/pkg/plugins/policies/core/rules"
 	api "github.com/kumahq/kuma/pkg/plugins/policies/meshfaultinjection/api/v1alpha1"
@@ -65,14 +64,7 @@ var _ = Describe("MeshFaultInjection", func() {
 								WithService("frontend"),
 						),
 				).
-				WithPolicies(core_xds.MatchedPolicies{
-					Dynamic: map[core_model.ResourceType]core_xds.TypedMatchingPolicies{
-						api.MeshFaultInjectionType: {
-							Type:      api.MeshFaultInjectionType,
-							FromRules: given.fromRules,
-						},
-					},
-				}).
+				WithPolicies(xds_builders.MatchedPolicies().WithFromPolicy(api.MeshFaultInjectionType, given.fromRules)).
 				Build()
 			plugin := plugin.NewPlugin().(core_plugins.PolicyPlugin)
 
@@ -239,14 +231,7 @@ var _ = Describe("MeshFaultInjection", func() {
 		xdsCtx := xds_samples.SampleContextWith(resources)
 		proxy := xds_builders.Proxy().
 			WithDataplane(samples.GatewayDataplaneBuilder()).
-			WithPolicies(core_xds.MatchedPolicies{
-				Dynamic: map[core_model.ResourceType]core_xds.TypedMatchingPolicies{
-					api.MeshFaultInjectionType: {
-						Type:      api.MeshFaultInjectionType,
-						FromRules: fromRules,
-					},
-				},
-			}).
+			WithPolicies(xds_builders.MatchedPolicies().WithFromPolicy(api.MeshFaultInjectionType, fromRules)).
 			Build()
 		for n, p := range core_plugins.Plugins().ProxyPlugins() {
 			Expect(p.Apply(context.Background(), xdsCtx.Mesh, proxy)).To(Succeed(), n)

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/plugin_test.go
@@ -207,18 +207,15 @@ var _ = Describe("MeshHTTPRoute", func() {
 					// This is a policy that doesn't apply to these services on
 					// purpose, so that the plugin is activated
 					// TODO: remove this when the plugin runs by default
-					WithPolicies(core_xds.MatchedPolicies{
-						Dynamic: map[core_model.ResourceType]core_xds.TypedMatchingPolicies{
-							api.MeshHTTPRouteType: {
-								ToRules: core_rules.ToRules{
-									Rules: core_rules.Rules{{
-										Subset: core_rules.MeshService("some-nonexistent-service"),
-										Conf:   api.PolicyDefault{},
-									}},
-								},
-							},
-						},
-					}).Build(),
+					WithPolicies(
+						xds_builders.MatchedPolicies().WithToPolicy(api.MeshHTTPRouteType, core_rules.ToRules{
+							Rules: core_rules.Rules{{
+								Subset: core_rules.MeshService("some-nonexistent-service"),
+								Conf:   api.PolicyDefault{},
+							}},
+						}),
+					).
+					Build(),
 			}
 		}()),
 		Entry("basic", func() outboundsTestCase {
@@ -239,64 +236,61 @@ var _ = Describe("MeshHTTPRoute", func() {
 				proxy: xds_builders.Proxy().
 					WithDataplane(samples.DataplaneWebBuilder()).
 					WithRouting(xds_builders.Routing().WithOutboundTargets(outboundTargets)).
-					WithPolicies(core_xds.MatchedPolicies{
-						Dynamic: map[core_model.ResourceType]core_xds.TypedMatchingPolicies{
-							api.MeshHTTPRouteType: {
-								ToRules: core_rules.ToRules{
-									Rules: core_rules.Rules{{
-										Conf: api.PolicyDefault{
-											Rules: []api.Rule{{
-												Matches: []api.Match{{
-													Path: &api.PathMatch{
-														Type:  api.PathPrefix,
-														Value: "/v1",
-													},
-												}},
-												Default: api.RuleConf{
-													BackendRefs: &[]common_api.BackendRef{{
-														TargetRef: builders.TargetRefService("backend"),
-														Weight:    pointer.To(uint(100)),
-													}},
-												},
-											}, {
-												Matches: []api.Match{{
-													Path: &api.PathMatch{
-														Type:  api.PathPrefix,
-														Value: "/v2",
-													},
-												}, {
-													Path: &api.PathMatch{
-														Type:  api.PathPrefix,
-														Value: "/v3",
-													},
-												}},
-												Default: api.RuleConf{
-													BackendRefs: &[]common_api.BackendRef{{
-														TargetRef: builders.TargetRefServiceSubset("backend", "region", "us"),
-														Weight:    pointer.To(uint(100)),
-													}},
-												},
-											}, {
-												Matches: []api.Match{{
-													QueryParams: []api.QueryParamsMatch{{
-														Type:  api.ExactQueryMatch,
-														Name:  "v1",
-														Value: "true",
-													}},
-												}},
-												Default: api.RuleConf{
-													BackendRefs: &[]common_api.BackendRef{{
-														TargetRef: builders.TargetRefService("backend"),
-														Weight:    pointer.To(uint(100)),
-													}},
+					WithPolicies(
+						xds_builders.MatchedPolicies().
+							WithToPolicy(api.MeshHTTPRouteType, core_rules.ToRules{
+								Rules: core_rules.Rules{{
+									Conf: api.PolicyDefault{
+										Rules: []api.Rule{{
+											Matches: []api.Match{{
+												Path: &api.PathMatch{
+													Type:  api.PathPrefix,
+													Value: "/v1",
 												},
 											}},
-										},
-									}},
-								},
-							},
-						},
-					}).
+											Default: api.RuleConf{
+												BackendRefs: &[]common_api.BackendRef{{
+													TargetRef: builders.TargetRefService("backend"),
+													Weight:    pointer.To(uint(100)),
+												}},
+											},
+										}, {
+											Matches: []api.Match{{
+												Path: &api.PathMatch{
+													Type:  api.PathPrefix,
+													Value: "/v2",
+												},
+											}, {
+												Path: &api.PathMatch{
+													Type:  api.PathPrefix,
+													Value: "/v3",
+												},
+											}},
+											Default: api.RuleConf{
+												BackendRefs: &[]common_api.BackendRef{{
+													TargetRef: builders.TargetRefServiceSubset("backend", "region", "us"),
+													Weight:    pointer.To(uint(100)),
+												}},
+											},
+										}, {
+											Matches: []api.Match{{
+												QueryParams: []api.QueryParamsMatch{{
+													Type:  api.ExactQueryMatch,
+													Name:  "v1",
+													Value: "true",
+												}},
+											}},
+											Default: api.RuleConf{
+												BackendRefs: &[]common_api.BackendRef{{
+													TargetRef: builders.TargetRefService("backend"),
+													Weight:    pointer.To(uint(100)),
+												}},
+											},
+										}},
+									},
+								}},
+							}),
+					).
 					Build(),
 			}
 		}()),
@@ -323,32 +317,29 @@ var _ = Describe("MeshHTTPRoute", func() {
 				proxy: xds_builders.Proxy().
 					WithDataplane(samples.DataplaneWebBuilder()).
 					WithRouting(xds_builders.Routing().WithOutboundTargets(outboundTargets)).
-					WithPolicies(core_xds.MatchedPolicies{
-						Dynamic: map[core_model.ResourceType]core_xds.TypedMatchingPolicies{
-							api.MeshHTTPRouteType: {
-								ToRules: core_rules.ToRules{
-									Rules: core_rules.Rules{{
-										Conf: api.PolicyDefault{
-											Rules: []api.Rule{{
-												Matches: []api.Match{{
-													Path: &api.PathMatch{
-														Type:  api.PathPrefix,
-														Value: "/",
-													},
-												}},
-												Default: api.RuleConf{
-													BackendRefs: &[]common_api.BackendRef{{
-														TargetRef: builders.TargetRefService("backend"),
-														Weight:    pointer.To(uint(100)),
-													}},
+					WithPolicies(
+						xds_builders.MatchedPolicies().
+							WithToPolicy(api.MeshHTTPRouteType, core_rules.ToRules{
+								Rules: core_rules.Rules{{
+									Conf: api.PolicyDefault{
+										Rules: []api.Rule{{
+											Matches: []api.Match{{
+												Path: &api.PathMatch{
+													Type:  api.PathPrefix,
+													Value: "/",
 												},
 											}},
-										},
-									}},
-								},
-							},
-						},
-					}).
+											Default: api.RuleConf{
+												BackendRefs: &[]common_api.BackendRef{{
+													TargetRef: builders.TargetRefService("backend"),
+													Weight:    pointer.To(uint(100)),
+												}},
+											},
+										}},
+									},
+								}},
+							}),
+					).
 					Build(),
 			}
 		}()),
@@ -364,70 +355,67 @@ var _ = Describe("MeshHTTPRoute", func() {
 				proxy: xds_builders.Proxy().
 					WithDataplane(samples.DataplaneWebBuilder()).
 					WithRouting(xds_builders.Routing().WithOutboundTargets(outboundTargets)).
-					WithPolicies(core_xds.MatchedPolicies{
-						Dynamic: map[core_model.ResourceType]core_xds.TypedMatchingPolicies{
-							api.MeshHTTPRouteType: {
-								ToRules: core_rules.ToRules{
-									Rules: core_rules.Rules{
-										{
-											Subset: core_rules.MeshService("backend"),
-											Conf: api.PolicyDefault{
-												Rules: []api.Rule{{
-													Matches: []api.Match{{
-														Path: &api.PathMatch{
-															Type:  api.PathPrefix,
-															Value: "/v1",
-														},
-													}},
-													Default: api.RuleConf{
-														Filters: &[]api.Filter{{
-															Type: api.RequestHeaderModifierType,
-															RequestHeaderModifier: &api.HeaderModifier{
-																Add: []api.HeaderKeyValue{{
-																	Name:  "request-add-header",
-																	Value: "add-value",
-																}},
-																Set: []api.HeaderKeyValue{{
-																	Name:  "request-set-header",
-																	Value: "set-value",
-																}, {
-																	Name:  "request-set-header-multiple",
-																	Value: "one-value,second-value",
-																}},
-																Remove: []string{
-																	"request-header-to-remove",
-																},
-															},
-														}, {
-															Type: api.ResponseHeaderModifierType,
-															ResponseHeaderModifier: &api.HeaderModifier{
-																Add: []api.HeaderKeyValue{{
-																	Name:  "response-add-header",
-																	Value: "add-value",
-																}},
-																Set: []api.HeaderKeyValue{{
-																	Name:  "response-set-header",
-																	Value: "set-value",
-																}},
-																Remove: []string{
-																	"response-header-to-remove",
-																},
-															},
-														}, {
-															Type: api.RequestRedirectType,
-															RequestRedirect: &api.RequestRedirect{
-																Scheme: pointer.To("other"),
-															},
-														}},
+					WithPolicies(
+						xds_builders.MatchedPolicies().
+							WithToPolicy(api.MeshHTTPRouteType, core_rules.ToRules{
+								Rules: core_rules.Rules{
+									{
+										Subset: core_rules.MeshService("backend"),
+										Conf: api.PolicyDefault{
+											Rules: []api.Rule{{
+												Matches: []api.Match{{
+													Path: &api.PathMatch{
+														Type:  api.PathPrefix,
+														Value: "/v1",
 													},
 												}},
-											},
+												Default: api.RuleConf{
+													Filters: &[]api.Filter{{
+														Type: api.RequestHeaderModifierType,
+														RequestHeaderModifier: &api.HeaderModifier{
+															Add: []api.HeaderKeyValue{{
+																Name:  "request-add-header",
+																Value: "add-value",
+															}},
+															Set: []api.HeaderKeyValue{{
+																Name:  "request-set-header",
+																Value: "set-value",
+															}, {
+																Name:  "request-set-header-multiple",
+																Value: "one-value,second-value",
+															}},
+															Remove: []string{
+																"request-header-to-remove",
+															},
+														},
+													}, {
+														Type: api.ResponseHeaderModifierType,
+														ResponseHeaderModifier: &api.HeaderModifier{
+															Add: []api.HeaderKeyValue{{
+																Name:  "response-add-header",
+																Value: "add-value",
+															}},
+															Set: []api.HeaderKeyValue{{
+																Name:  "response-set-header",
+																Value: "set-value",
+															}},
+															Remove: []string{
+																"response-header-to-remove",
+															},
+														},
+													}, {
+														Type: api.RequestRedirectType,
+														RequestRedirect: &api.RequestRedirect{
+															Scheme: pointer.To("other"),
+														},
+													}},
+												},
+											}},
 										},
 									},
 								},
-							},
-						},
-					}).
+							}),
+					).
 					Build(),
 			}
 		}()),
@@ -443,40 +431,36 @@ var _ = Describe("MeshHTTPRoute", func() {
 				proxy: xds_builders.Proxy().
 					WithDataplane(samples.DataplaneWebBuilder()).
 					WithRouting(xds_builders.Routing().WithOutboundTargets(outboundTargets)).
-					WithPolicies(core_xds.MatchedPolicies{
-						Dynamic: map[core_model.ResourceType]core_xds.TypedMatchingPolicies{
-							api.MeshHTTPRouteType: {
-								ToRules: core_rules.ToRules{
-									Rules: core_rules.Rules{
-										{
-											Subset: core_rules.MeshService("backend"),
-											Conf: api.PolicyDefault{
-												Rules: []api.Rule{{
-													Matches: []api.Match{{
-														Path: &api.PathMatch{
-															Type:  api.PathPrefix,
-															Value: "/v1",
+					WithPolicies(
+						xds_builders.MatchedPolicies().WithToPolicy(api.MeshHTTPRouteType, core_rules.ToRules{
+							Rules: core_rules.Rules{
+								{
+									Subset: core_rules.MeshService("backend"),
+									Conf: api.PolicyDefault{
+										Rules: []api.Rule{{
+											Matches: []api.Match{{
+												Path: &api.PathMatch{
+													Type:  api.PathPrefix,
+													Value: "/v1",
+												},
+											}},
+											Default: api.RuleConf{
+												Filters: &[]api.Filter{{
+													Type: api.URLRewriteType,
+													URLRewrite: &api.URLRewrite{
+														Path: &api.PathRewrite{
+															Type:               api.ReplacePrefixMatchType,
+															ReplacePrefixMatch: pointer.To("/v2"),
 														},
-													}},
-													Default: api.RuleConf{
-														Filters: &[]api.Filter{{
-															Type: api.URLRewriteType,
-															URLRewrite: &api.URLRewrite{
-																Path: &api.PathRewrite{
-																	Type:               api.ReplacePrefixMatchType,
-																	ReplacePrefixMatch: pointer.To("/v2"),
-																},
-															},
-														}},
 													},
 												}},
 											},
-										},
+										}},
 									},
 								},
 							},
-						},
-					}).
+						}),
+					).
 					Build(),
 			}
 		}()),
@@ -492,44 +476,41 @@ var _ = Describe("MeshHTTPRoute", func() {
 				proxy: xds_builders.Proxy().
 					WithDataplane(samples.DataplaneWebBuilder()).
 					WithRouting(xds_builders.Routing().WithOutboundTargets(outboundTargets)).
-					WithPolicies(core_xds.MatchedPolicies{
-						Dynamic: map[core_model.ResourceType]core_xds.TypedMatchingPolicies{
-							api.MeshHTTPRouteType: {
-								ToRules: core_rules.ToRules{
-									Rules: core_rules.Rules{
-										{
-											Subset: core_rules.MeshService("backend"),
-											Conf: api.PolicyDefault{
-												Rules: []api.Rule{{
-													Matches: []api.Match{{
-														Headers: []common_api.HeaderMatch{{
-															Type:  pointer.To(common_api.HeaderMatchExact),
-															Name:  "foo-exact",
-															Value: "bar",
-														}, {
-															Type: pointer.To(common_api.HeaderMatchPresent),
-															Name: "foo-present",
-														}, {
-															Type:  pointer.To(common_api.HeaderMatchRegularExpression),
-															Name:  "foo-regex",
-															Value: "x.*y",
-														}, {
-															Type: pointer.To(common_api.HeaderMatchAbsent),
-															Name: "foo-absent",
-														}, {
-															Type:  pointer.To(common_api.HeaderMatchPrefix),
-															Name:  "foo-prefix",
-															Value: "x",
-														}},
+					WithPolicies(
+						xds_builders.MatchedPolicies().
+							WithToPolicy(api.MeshHTTPRouteType, core_rules.ToRules{
+								Rules: core_rules.Rules{
+									{
+										Subset: core_rules.MeshService("backend"),
+										Conf: api.PolicyDefault{
+											Rules: []api.Rule{{
+												Matches: []api.Match{{
+													Headers: []common_api.HeaderMatch{{
+														Type:  pointer.To(common_api.HeaderMatchExact),
+														Name:  "foo-exact",
+														Value: "bar",
+													}, {
+														Type: pointer.To(common_api.HeaderMatchPresent),
+														Name: "foo-present",
+													}, {
+														Type:  pointer.To(common_api.HeaderMatchRegularExpression),
+														Name:  "foo-regex",
+														Value: "x.*y",
+													}, {
+														Type: pointer.To(common_api.HeaderMatchAbsent),
+														Name: "foo-absent",
+													}, {
+														Type:  pointer.To(common_api.HeaderMatchPrefix),
+														Name:  "foo-prefix",
+														Value: "x",
 													}},
 												}},
-											},
+											}},
 										},
 									},
 								},
-							},
-						},
-					}).
+							}),
+					).
 					Build(),
 			}
 		}()),
@@ -550,57 +531,54 @@ var _ = Describe("MeshHTTPRoute", func() {
 				proxy: xds_builders.Proxy().
 					WithDataplane(samples.DataplaneWebBuilder()).
 					WithRouting(xds_builders.Routing().WithOutboundTargets(outboundTargets)).
-					WithPolicies(core_xds.MatchedPolicies{
-						Dynamic: map[core_model.ResourceType]core_xds.TypedMatchingPolicies{
-							api.MeshHTTPRouteType: {
-								ToRules: core_rules.ToRules{
-									Rules: core_rules.Rules{
-										{
-											Subset: core_rules.MeshService("backend"),
-											Conf: api.PolicyDefault{
-												Rules: []api.Rule{{
-													Matches: []api.Match{{
-														Path: &api.PathMatch{
-															Type:  api.PathPrefix,
-															Value: "/v1",
-														},
-													}},
-													Default: api.RuleConf{
-														Filters: &[]api.Filter{
-															{
-																Type: api.RequestMirrorType,
-																RequestMirror: &api.RequestMirror{
-																	Percentage: pointer.To(intstr.FromString("99.9")),
-																	BackendRef: common_api.TargetRef{
-																		Kind: common_api.MeshServiceSubset,
-																		Name: "payments",
-																		Tags: map[string]string{
-																			"version": "v1",
-																			"region":  "us",
-																			"env":     "dev",
-																		},
+					WithPolicies(
+						xds_builders.MatchedPolicies().
+							WithToPolicy(api.MeshHTTPRouteType, core_rules.ToRules{
+								Rules: core_rules.Rules{
+									{
+										Subset: core_rules.MeshService("backend"),
+										Conf: api.PolicyDefault{
+											Rules: []api.Rule{{
+												Matches: []api.Match{{
+													Path: &api.PathMatch{
+														Type:  api.PathPrefix,
+														Value: "/v1",
+													},
+												}},
+												Default: api.RuleConf{
+													Filters: &[]api.Filter{
+														{
+															Type: api.RequestMirrorType,
+															RequestMirror: &api.RequestMirror{
+																Percentage: pointer.To(intstr.FromString("99.9")),
+																BackendRef: common_api.TargetRef{
+																	Kind: common_api.MeshServiceSubset,
+																	Name: "payments",
+																	Tags: map[string]string{
+																		"version": "v1",
+																		"region":  "us",
+																		"env":     "dev",
 																	},
 																},
 															},
-															{
-																Type: api.RequestMirrorType,
-																RequestMirror: &api.RequestMirror{
-																	BackendRef: common_api.TargetRef{
-																		Kind: common_api.MeshService,
-																		Name: "backend",
-																	},
+														},
+														{
+															Type: api.RequestMirrorType,
+															RequestMirror: &api.RequestMirror{
+																BackendRef: common_api.TargetRef{
+																	Kind: common_api.MeshService,
+																	Name: "backend",
 																},
 															},
 														},
 													},
-												}},
-											},
+												},
+											}},
 										},
 									},
 								},
-							},
-						},
-					}).
+							}),
+					).
 					Build(),
 			}
 		}()),

--- a/pkg/plugins/policies/meshproxypatch/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshproxypatch/plugin/v1alpha1/plugin_test.go
@@ -6,7 +6,6 @@ import (
 	. "github.com/onsi/gomega"
 
 	core_plugins "github.com/kumahq/kuma/pkg/core/plugins"
-	core_model "github.com/kumahq/kuma/pkg/core/resources/model"
 	core_xds "github.com/kumahq/kuma/pkg/core/xds"
 	core_rules "github.com/kumahq/kuma/pkg/plugins/policies/core/rules"
 	policies_xds "github.com/kumahq/kuma/pkg/plugins/policies/core/xds"
@@ -39,14 +38,7 @@ var _ = Describe("MeshProxyPatch", func() {
 			context := xds_samples.SampleContext()
 			proxy := xds_builders.Proxy().
 				WithDataplane(samples.DataplaneBackendBuilder()).
-				WithPolicies(core_xds.MatchedPolicies{
-					Dynamic: map[core_model.ResourceType]core_xds.TypedMatchingPolicies{
-						api.MeshProxyPatchType: {
-							Type:            api.MeshProxyPatchType,
-							SingleItemRules: given.rules,
-						},
-					},
-				}).
+				WithPolicies(xds_builders.MatchedPolicies().WithSingleItemPolicy(api.MeshProxyPatchType, given.rules)).
 				Build()
 			plugin := plugin.NewPlugin().(core_plugins.PolicyPlugin)
 

--- a/pkg/plugins/policies/meshretry/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshretry/plugin/v1alpha1/plugin_test.go
@@ -14,8 +14,6 @@ import (
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	core_plugins "github.com/kumahq/kuma/pkg/core/plugins"
 	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
-	core_model "github.com/kumahq/kuma/pkg/core/resources/model"
-	"github.com/kumahq/kuma/pkg/core/xds"
 	core_xds "github.com/kumahq/kuma/pkg/core/xds"
 	core_rules "github.com/kumahq/kuma/pkg/plugins/policies/core/rules"
 	api "github.com/kumahq/kuma/pkg/plugins/policies/meshretry/api/v1alpha1"
@@ -67,14 +65,7 @@ var _ = Describe("MeshRetry", func() {
 						AddEndpoint("grpc-service", xds_samples.GrpcEndpointBuilder()),
 					),
 			).
-			WithPolicies(xds.MatchedPolicies{
-				Dynamic: map[core_model.ResourceType]xds.TypedMatchingPolicies{
-					api.MeshRetryType: {
-						Type:    api.MeshRetryType,
-						ToRules: given.toRules,
-					},
-				},
-			}).
+			WithPolicies(xds_builders.MatchedPolicies().WithToPolicy(api.MeshRetryType, given.toRules)).
 			Build()
 
 		// when
@@ -310,14 +301,7 @@ var _ = Describe("MeshRetry", func() {
 			xdsCtx := xds_samples.SampleContextWith(resources)
 			proxy := xds_builders.Proxy().
 				WithDataplane(samples.GatewayDataplaneBuilder()).
-				WithPolicies(xds.MatchedPolicies{
-					Dynamic: map[core_model.ResourceType]xds.TypedMatchingPolicies{
-						api.MeshRetryType: {
-							Type:    api.MeshRetryType,
-							ToRules: given.toRules,
-						},
-					},
-				}).
+				WithPolicies(xds_builders.MatchedPolicies().WithToPolicy(api.MeshRetryType, given.toRules)).
 				Build()
 			for n, p := range core_plugins.Plugins().ProxyPlugins() {
 				Expect(p.Apply(context.Background(), xdsCtx.Mesh, proxy)).To(Succeed(), n)

--- a/pkg/plugins/policies/meshtimeout/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshtimeout/plugin/v1alpha1/plugin_test.go
@@ -13,8 +13,6 @@ import (
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	core_plugins "github.com/kumahq/kuma/pkg/core/plugins"
 	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
-	core_model "github.com/kumahq/kuma/pkg/core/resources/model"
-	"github.com/kumahq/kuma/pkg/core/xds"
 	core_xds "github.com/kumahq/kuma/pkg/core/xds"
 	core_rules "github.com/kumahq/kuma/pkg/plugins/policies/core/rules"
 	plugins_xds "github.com/kumahq/kuma/pkg/plugins/policies/core/xds"
@@ -70,15 +68,9 @@ var _ = Describe("MeshTimeout", func() {
 							AddEndpoint("second-service", xds_samples.TcpEndpointBuilder()),
 					),
 			).
-			WithPolicies(xds.MatchedPolicies{
-				Dynamic: map[core_model.ResourceType]xds.TypedMatchingPolicies{
-					api.MeshTimeoutType: {
-						Type:      api.MeshTimeoutType,
-						ToRules:   given.toRules,
-						FromRules: given.fromRules,
-					},
-				},
-			}).
+			WithPolicies(
+				xds_builders.MatchedPolicies().WithPolicy(api.MeshTimeoutType, given.toRules, given.fromRules),
+			).
 			Build()
 
 		// when
@@ -435,14 +427,7 @@ var _ = Describe("MeshTimeout", func() {
 						AddEndpoint("other-service", xds_samples.HttpEndpointBuilder()),
 				),
 			).
-			WithPolicies(xds.MatchedPolicies{
-				Dynamic: map[core_model.ResourceType]xds.TypedMatchingPolicies{
-					api.MeshTimeoutType: {
-						Type:    api.MeshTimeoutType,
-						ToRules: given.toRules,
-					},
-				},
-			}).
+			WithPolicies(xds_builders.MatchedPolicies().WithToPolicy(api.MeshTimeoutType, given.toRules)).
 			Build()
 
 		Expect(gateway_plugin.NewPlugin().(core_plugins.ProxyPlugin).Apply(context.Background(), xdsCtx.Mesh, proxy)).To(Succeed())

--- a/pkg/plugins/policies/meshtrace/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshtrace/plugin/v1alpha1/plugin_test.go
@@ -7,8 +7,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 
 	core_plugins "github.com/kumahq/kuma/pkg/core/plugins"
-	core_model "github.com/kumahq/kuma/pkg/core/resources/model"
-	"github.com/kumahq/kuma/pkg/core/xds"
 	core_xds "github.com/kumahq/kuma/pkg/core/xds"
 	core_rules "github.com/kumahq/kuma/pkg/plugins/policies/core/rules"
 	policies_xds "github.com/kumahq/kuma/pkg/plugins/policies/core/xds"
@@ -59,24 +57,19 @@ var _ = Describe("MeshTrace", func() {
 
 			context := xds_samples.SampleContext()
 			proxy := xds_builders.Proxy().
-				WithDataplane(builders.Dataplane().
-					WithName("backend").
-					AddInbound(builders.Inbound().
-						WithService("backend").
-						WithAddress("127.0.0.1").
-						WithPort(17777)).
-					AddOutbound(builders.Outbound().
-						WithService("other-service").
-						WithAddress("127.0.0.1").
-						WithPort(27777))).
-				WithPolicies(xds.MatchedPolicies{
-					Dynamic: map[core_model.ResourceType]xds.TypedMatchingPolicies{
-						api.MeshTraceType: {
-							Type:            api.MeshTraceType,
-							SingleItemRules: given.singleItemRules,
-						},
-					},
-				}).
+				WithDataplane(
+					builders.Dataplane().
+						WithName("backend").
+						AddInbound(builders.Inbound().
+							WithService("backend").
+							WithAddress("127.0.0.1").
+							WithPort(17777)).
+						AddOutbound(builders.Outbound().
+							WithService("other-service").
+							WithAddress("127.0.0.1").
+							WithPort(27777)),
+				).
+				WithPolicies(xds_builders.MatchedPolicies().WithSingleItemPolicy(api.MeshTraceType, given.singleItemRules)).
 				Build()
 			plugin := plugin.NewPlugin().(core_plugins.PolicyPlugin)
 

--- a/pkg/test/xds/builders/matchedpolicies_builder.go
+++ b/pkg/test/xds/builders/matchedpolicies_builder.go
@@ -1,0 +1,66 @@
+package builders
+
+import (
+	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
+	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
+	core_model "github.com/kumahq/kuma/pkg/core/resources/model"
+	"github.com/kumahq/kuma/pkg/core/xds"
+	"github.com/kumahq/kuma/pkg/plugins/policies/core/rules"
+)
+
+type MatchedPoliciesBuilder struct {
+	res *xds.MatchedPolicies
+}
+
+func MatchedPolicies() *MatchedPoliciesBuilder {
+	return &MatchedPoliciesBuilder{res: &xds.MatchedPolicies{
+		RateLimitsInbound: map[mesh_proto.InboundInterface][]*core_mesh.RateLimitResource{},
+		Dynamic:           map[core_model.ResourceType]xds.TypedMatchingPolicies{},
+	}}
+}
+
+func (mp *MatchedPoliciesBuilder) Build() *xds.MatchedPolicies {
+	return mp.res
+}
+
+func (mp *MatchedPoliciesBuilder) With(fn func(policies *xds.MatchedPolicies)) *MatchedPoliciesBuilder {
+	fn(mp.res)
+	return mp
+}
+
+func (mp *MatchedPoliciesBuilder) WithToPolicy(resourceType core_model.ResourceType, toRules rules.ToRules) *MatchedPoliciesBuilder {
+	mp.res.Dynamic[resourceType] = xds.TypedMatchingPolicies{
+		Type:    resourceType,
+		ToRules: toRules,
+	}
+	return mp
+}
+
+func (mp *MatchedPoliciesBuilder) WithFromPolicy(resourceType core_model.ResourceType, fromRules rules.FromRules) *MatchedPoliciesBuilder {
+	mp.res.Dynamic[resourceType] = xds.TypedMatchingPolicies{
+		Type:      resourceType,
+		FromRules: fromRules,
+	}
+	return mp
+}
+
+func (mp *MatchedPoliciesBuilder) WithSingleItemPolicy(resourceType core_model.ResourceType, singleItemRules rules.SingleItemRules) *MatchedPoliciesBuilder {
+	mp.res.Dynamic[resourceType] = xds.TypedMatchingPolicies{
+		SingleItemRules: singleItemRules,
+	}
+	return mp
+}
+
+func (mp *MatchedPoliciesBuilder) WithPolicy(resourceType core_model.ResourceType, toRules rules.ToRules, fromRules rules.FromRules) *MatchedPoliciesBuilder {
+	mp.res.Dynamic[resourceType] = xds.TypedMatchingPolicies{
+		Type:      resourceType,
+		ToRules:   toRules,
+		FromRules: fromRules,
+	}
+	return mp
+}
+
+func (mp *MatchedPoliciesBuilder) WithRateLimitsInbound(ratelimitInbound map[mesh_proto.InboundInterface][]*core_mesh.RateLimitResource) *MatchedPoliciesBuilder {
+	mp.res.RateLimitsInbound = ratelimitInbound
+	return mp
+}

--- a/pkg/test/xds/builders/proxy_builder.go
+++ b/pkg/test/xds/builders/proxy_builder.go
@@ -55,8 +55,8 @@ func (p *ProxyBuilder) WithMetadata(metadata *xds.DataplaneMetadata) *ProxyBuild
 	return p
 }
 
-func (p *ProxyBuilder) WithPolicies(policies xds.MatchedPolicies) *ProxyBuilder {
-	p.res.Policies = policies
+func (p *ProxyBuilder) WithPolicies(policies *MatchedPoliciesBuilder) *ProxyBuilder {
+	p.res.Policies = *policies.Build()
 	return p
 }
 


### PR DESCRIPTION
### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
