### PR TITLE
chore(kuma-cp): don't use deprecated HeaderValueOption.Append

### DIFF
--- a/pkg/plugins/policies/meshhealthcheck/plugin/v1alpha1/testdata/basic.gateway_cluster.golden.yaml
+++ b/pkg/plugins/policies/meshhealthcheck/plugin/v1alpha1/testdata/basic.gateway_cluster.golden.yaml
@@ -26,11 +26,10 @@ healthChecks:
     - header:
         key: x-kuma-tags
         value: '&kuma.io/service=sample-gateway&'
-    - append: true
-      header:
+    - header:
         key: x-some-header
         value: value
-    - append: false
+    - appendAction: OVERWRITE_IF_EXISTS_OR_ADD
       header:
         key: x-some-other-header
         value: value

--- a/pkg/plugins/policies/meshhealthcheck/plugin/v1alpha1/testdata/basic_http_health_check_cluster.golden.yaml
+++ b/pkg/plugins/policies/meshhealthcheck/plugin/v1alpha1/testdata/basic_http_health_check_cluster.golden.yaml
@@ -21,11 +21,10 @@ healthChecks:
     - header:
         key: x-kuma-tags
         value: '&kuma.io/service=backend&'
-    - append: true
-      header:
+    - header:
         key: x-some-header
         value: value
-    - append: false
+    - appendAction: OVERWRITE_IF_EXISTS_OR_ADD
       header:
         key: x-some-other-header
         value: value

--- a/pkg/plugins/policies/meshhealthcheck/plugin/v1alpha1/testdata/basic_http_health_check_split_cluster.golden.yaml
+++ b/pkg/plugins/policies/meshhealthcheck/plugin/v1alpha1/testdata/basic_http_health_check_split_cluster.golden.yaml
@@ -21,11 +21,10 @@ healthChecks:
     - header:
         key: x-kuma-tags
         value: '&kuma.io/service=backend&'
-    - append: true
-      header:
+    - header:
         key: x-some-header
         value: value
-    - append: false
+    - appendAction: OVERWRITE_IF_EXISTS_OR_ADD
       header:
         key: x-some-other-header
         value: value

--- a/pkg/plugins/policies/meshhealthcheck/plugin/xds/configurer.go
+++ b/pkg/plugins/policies/meshhealthcheck/plugin/xds/configurer.go
@@ -130,7 +130,7 @@ func mapHttpHeaders(headers *api.HeaderModifier, srcTags v1alpha1.MultiValueTagS
 					Key:   string(header.Name),
 					Value: val,
 				},
-				Append: util_proto.Bool(true),
+				AppendAction: envoy_core.HeaderValueOption_APPEND_IF_EXISTS_OR_ADD,
 			})
 		}
 	}
@@ -141,7 +141,7 @@ func mapHttpHeaders(headers *api.HeaderModifier, srcTags v1alpha1.MultiValueTagS
 					Key:   string(header.Name),
 					Value: val,
 				},
-				Append: util_proto.Bool(false),
+				AppendAction: envoy_core.HeaderValueOption_OVERWRITE_IF_EXISTS_OR_ADD,
 			})
 		}
 	}

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/header-modifiers.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/header-modifiers.listeners.golden.yaml
@@ -34,31 +34,28 @@ resources:
                 redirect:
                   schemeRedirect: other
                 requestHeadersToAdd:
-                - append: false
+                - appendAction: OVERWRITE_IF_EXISTS_OR_ADD
                   header:
                     key: request-set-header
                     value: set-value
-                - append: false
+                - appendAction: OVERWRITE_IF_EXISTS_OR_ADD
                   header:
                     key: request-set-header-multiple
                     value: one-value
-                - append: true
-                  header:
+                - header:
                     key: request-set-header-multiple
                     value: second-value
-                - append: true
-                  header:
+                - header:
                     key: request-add-header
                     value: add-value
                 requestHeadersToRemove:
                 - request-header-to-remove
                 responseHeadersToAdd:
-                - append: false
+                - appendAction: OVERWRITE_IF_EXISTS_OR_ADD
                   header:
                     key: response-set-header
                     value: set-value
-                - append: true
-                  header:
+                - header:
                     key: response-add-header
                     value: add-value
                 responseHeadersToRemove:
@@ -69,31 +66,28 @@ resources:
                 redirect:
                   schemeRedirect: other
                 requestHeadersToAdd:
-                - append: false
+                - appendAction: OVERWRITE_IF_EXISTS_OR_ADD
                   header:
                     key: request-set-header
                     value: set-value
-                - append: false
+                - appendAction: OVERWRITE_IF_EXISTS_OR_ADD
                   header:
                     key: request-set-header-multiple
                     value: one-value
-                - append: true
-                  header:
+                - header:
                     key: request-set-header-multiple
                     value: second-value
-                - append: true
-                  header:
+                - header:
                     key: request-add-header
                     value: add-value
                 requestHeadersToRemove:
                 - request-header-to-remove
                 responseHeadersToAdd:
-                - append: false
+                - appendAction: OVERWRITE_IF_EXISTS_OR_ADD
                   header:
                     key: response-set-header
                     value: set-value
-                - append: true
-                  header:
+                - header:
                     key: response-add-header
                     value: add-value
                 responseHeadersToRemove:

--- a/pkg/plugins/policies/meshhttproute/xds/filters/requestheadermodifier.go
+++ b/pkg/plugins/policies/meshhttproute/xds/filters/requestheadermodifier.go
@@ -8,7 +8,6 @@ import (
 
 	common_api "github.com/kumahq/kuma/api/common/v1alpha1"
 	api "github.com/kumahq/kuma/pkg/plugins/policies/meshhttproute/api/v1alpha1"
-	util_proto "github.com/kumahq/kuma/pkg/util/proto"
 )
 
 type RequestHeaderModifierConfigurer struct {
@@ -35,8 +34,12 @@ func headerModifiers(mod api.HeaderModifier) ([]*envoy_config_core.HeaderValueOp
 
 	for _, set := range mod.Set {
 		for i, headerValue := range headerValues(set.Value) {
+			appendAction := envoy_config_core.HeaderValueOption_OVERWRITE_IF_EXISTS_OR_ADD
+			if i > 0 {
+				appendAction = envoy_config_core.HeaderValueOption_APPEND_IF_EXISTS_OR_ADD
+			}
 			replace := &envoy_config_core.HeaderValueOption{
-				Append: util_proto.Bool(i > 0),
+				AppendAction: appendAction,
 				Header: &envoy_config_core.HeaderValue{
 					Key:   string(set.Name),
 					Value: headerValue,
@@ -48,7 +51,7 @@ func headerModifiers(mod api.HeaderModifier) ([]*envoy_config_core.HeaderValueOp
 	for _, add := range mod.Add {
 		for _, headerValue := range headerValues(add.Value) {
 			appendOption := &envoy_config_core.HeaderValueOption{
-				Append: util_proto.Bool(true),
+				AppendAction: envoy_config_core.HeaderValueOption_APPEND_IF_EXISTS_OR_ADD,
 				Header: &envoy_config_core.HeaderValue{
 					Key:   string(add.Name),
 					Value: headerValue,

--- a/pkg/plugins/policies/meshratelimit/plugin/v1alpha1/testdata/basic_listener_1.golden.yaml
+++ b/pkg/plugins/policies/meshratelimit/plugin/v1alpha1/testdata/basic_listener_1.golden.yaml
@@ -43,15 +43,13 @@ filterChains:
                     numerator: 100
                   runtimeKey: local_rate_limit_enforced
                 responseHeadersToAdd:
-                - append: true
-                  header:
+                - header:
                     key: x-kuma-rate-limit-header
                     value: test-value
-                - append: true
-                  header:
+                - header:
                     key: x-kuma-rate-limit
                     value: other-value
-                - append: false
+                - appendAction: OVERWRITE_IF_EXISTS_OR_ADD
                   header:
                     key: x-kuma-rate-limit-header-set
                     value: test-value

--- a/pkg/plugins/policies/meshratelimit/plugin/v1alpha1/testdata/gateway_basic_routes.golden.yaml
+++ b/pkg/plugins/policies/meshratelimit/plugin/v1alpha1/testdata/gateway_basic_routes.golden.yaml
@@ -33,12 +33,10 @@ virtualHosts:
             numerator: 100
           runtimeKey: local_rate_limit_enforced
         responseHeadersToAdd:
-        - append: true
-          header:
+        - header:
             key: x-kuma-rate-limit-header
             value: test-value
-        - append: true
-          header:
+        - header:
             key: x-kuma-rate-limit
             value: other-value
         statPrefix: rate_limit

--- a/pkg/plugins/runtime/gateway/testdata/05-gateway-listener.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/05-gateway-listener.yaml
@@ -282,7 +282,7 @@ Routes:
         name: foo.example.com
         requireTls: ALL
         responseHeadersToAdd:
-        - append: false
+        - appendAction: OVERWRITE_IF_EXISTS_OR_ADD
           header:
             key: Strict-Transport-Security
             value: max-age=31536000; includeSubDomains
@@ -299,7 +299,7 @@ Routes:
         name: bar.example.com
         requireTls: ALL
         responseHeadersToAdd:
-        - append: false
+        - appendAction: OVERWRITE_IF_EXISTS_OR_ADD
           header:
             key: Strict-Transport-Security
             value: max-age=31536000; includeSubDomains
@@ -316,7 +316,7 @@ Routes:
         name: '*.example.com'
         requireTls: ALL
         responseHeadersToAdd:
-        - append: false
+        - appendAction: OVERWRITE_IF_EXISTS_OR_ADD
           header:
             key: Strict-Transport-Security
             value: max-age=31536000; includeSubDomains
@@ -333,7 +333,7 @@ Routes:
         name: '*'
         requireTls: ALL
         responseHeadersToAdd:
-        - append: false
+        - appendAction: OVERWRITE_IF_EXISTS_OR_ADD
           header:
             key: Strict-Transport-Security
             value: max-age=31536000; includeSubDomains

--- a/pkg/plugins/runtime/gateway/testdata/http/cross-mesh-gateway.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/cross-mesh-gateway.yaml
@@ -624,7 +624,7 @@ Routes:
         name: '*'
         requireTls: ALL
         responseHeadersToAdd:
-        - append: false
+        - appendAction: OVERWRITE_IF_EXISTS_OR_ADD
           header:
             key: Strict-Transport-Security
             value: max-age=31536000; includeSubDomains
@@ -717,7 +717,7 @@ Routes:
         name: internal-cross-mesh.mesh
         requireTls: ALL
         responseHeadersToAdd:
-        - append: false
+        - appendAction: OVERWRITE_IF_EXISTS_OR_ADD
           header:
             key: Strict-Transport-Security
             value: max-age=31536000; includeSubDomains
@@ -886,7 +886,7 @@ Routes:
         name: cross-mesh2.mesh
         requireTls: ALL
         responseHeadersToAdd:
-        - append: false
+        - appendAction: OVERWRITE_IF_EXISTS_OR_ADD
           header:
             key: Strict-Transport-Security
             value: max-age=31536000; includeSubDomains
@@ -972,7 +972,7 @@ Routes:
         name: cross-mesh.mesh
         requireTls: ALL
         responseHeadersToAdd:
-        - append: false
+        - appendAction: OVERWRITE_IF_EXISTS_OR_ADD
           header:
             key: Strict-Transport-Security
             value: max-age=31536000; includeSubDomains
@@ -1058,7 +1058,7 @@ Routes:
         name: '*'
         requireTls: ALL
         responseHeadersToAdd:
-        - append: false
+        - appendAction: OVERWRITE_IF_EXISTS_OR_ADD
           header:
             key: Strict-Transport-Security
             value: max-age=31536000; includeSubDomains

--- a/pkg/plugins/runtime/gateway/testdata/https/03-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/03-gateway-route.yaml
@@ -139,7 +139,7 @@ Routes:
         name: echo.example.com
         requireTls: ALL
         responseHeadersToAdd:
-        - append: false
+        - appendAction: OVERWRITE_IF_EXISTS_OR_ADD
           header:
             key: Strict-Transport-Security
             value: max-age=31536000; includeSubDomains

--- a/pkg/plugins/runtime/gateway/testdata/https/04-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/04-gateway-route.yaml
@@ -169,7 +169,7 @@ Routes:
         name: echo.example.com
         requireTls: ALL
         responseHeadersToAdd:
-        - append: false
+        - appendAction: OVERWRITE_IF_EXISTS_OR_ADD
           header:
             key: Strict-Transport-Security
             value: max-age=31536000; includeSubDomains

--- a/pkg/plugins/runtime/gateway/testdata/https/05-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/05-gateway-route.yaml
@@ -95,7 +95,7 @@ Routes:
         name: echo.example.com
         requireTls: ALL
         responseHeadersToAdd:
-        - append: false
+        - appendAction: OVERWRITE_IF_EXISTS_OR_ADD
           header:
             key: Strict-Transport-Security
             value: max-age=31536000; includeSubDomains

--- a/pkg/plugins/runtime/gateway/testdata/https/06-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/06-gateway-route.yaml
@@ -169,7 +169,7 @@ Routes:
         name: echo.example.com
         requireTls: ALL
         responseHeadersToAdd:
-        - append: false
+        - appendAction: OVERWRITE_IF_EXISTS_OR_ADD
           header:
             key: Strict-Transport-Security
             value: max-age=31536000; includeSubDomains

--- a/pkg/plugins/runtime/gateway/testdata/https/07-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/07-gateway-route.yaml
@@ -139,7 +139,7 @@ Routes:
         name: echo.example.com
         requireTls: ALL
         responseHeadersToAdd:
-        - append: false
+        - appendAction: OVERWRITE_IF_EXISTS_OR_ADD
           header:
             key: Strict-Transport-Security
             value: max-age=31536000; includeSubDomains

--- a/pkg/plugins/runtime/gateway/testdata/https/08-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/08-gateway-route.yaml
@@ -183,7 +183,7 @@ Routes:
         name: echo.example.com
         requireTls: ALL
         responseHeadersToAdd:
-        - append: false
+        - appendAction: OVERWRITE_IF_EXISTS_OR_ADD
           header:
             key: Strict-Transport-Security
             value: max-age=31536000; includeSubDomains

--- a/pkg/plugins/runtime/gateway/testdata/https/09-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/09-gateway-route.yaml
@@ -139,7 +139,7 @@ Routes:
         name: echo.example.com
         requireTls: ALL
         responseHeadersToAdd:
-        - append: false
+        - appendAction: OVERWRITE_IF_EXISTS_OR_ADD
           header:
             key: Strict-Transport-Security
             value: max-age=31536000; includeSubDomains

--- a/pkg/plugins/runtime/gateway/testdata/https/10-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/10-gateway-route.yaml
@@ -243,7 +243,7 @@ Routes:
         name: echo.example.com
         requireTls: ALL
         responseHeadersToAdd:
-        - append: false
+        - appendAction: OVERWRITE_IF_EXISTS_OR_ADD
           header:
             key: Strict-Transport-Security
             value: max-age=31536000; includeSubDomains

--- a/pkg/plugins/runtime/gateway/testdata/https/11-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/11-gateway-route.yaml
@@ -183,7 +183,7 @@ Routes:
         name: echo.example.com
         requireTls: ALL
         responseHeadersToAdd:
-        - append: false
+        - appendAction: OVERWRITE_IF_EXISTS_OR_ADD
           header:
             key: Strict-Transport-Security
             value: max-age=31536000; includeSubDomains

--- a/pkg/plugins/runtime/gateway/testdata/https/12-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/12-gateway-route.yaml
@@ -139,7 +139,7 @@ Routes:
         name: echo.example.com
         requireTls: ALL
         responseHeadersToAdd:
-        - append: false
+        - appendAction: OVERWRITE_IF_EXISTS_OR_ADD
           header:
             key: Strict-Transport-Security
             value: max-age=31536000; includeSubDomains

--- a/pkg/plugins/runtime/gateway/testdata/https/13-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/13-gateway-route.yaml
@@ -227,7 +227,7 @@ Routes:
         name: echo.example.com
         requireTls: ALL
         responseHeadersToAdd:
-        - append: false
+        - appendAction: OVERWRITE_IF_EXISTS_OR_ADD
           header:
             key: Strict-Transport-Security
             value: max-age=31536000; includeSubDomains

--- a/pkg/plugins/runtime/gateway/testdata/https/14-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/14-gateway-route.yaml
@@ -139,7 +139,7 @@ Routes:
         name: echo.example.com
         requireTls: ALL
         responseHeadersToAdd:
-        - append: false
+        - appendAction: OVERWRITE_IF_EXISTS_OR_ADD
           header:
             key: Strict-Transport-Security
             value: max-age=31536000; includeSubDomains

--- a/pkg/plugins/runtime/gateway/testdata/https/15-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/15-gateway-route.yaml
@@ -227,7 +227,7 @@ Routes:
         name: echo.example.com
         requireTls: ALL
         responseHeadersToAdd:
-        - append: false
+        - appendAction: OVERWRITE_IF_EXISTS_OR_ADD
           header:
             key: Strict-Transport-Security
             value: max-age=31536000; includeSubDomains

--- a/pkg/plugins/runtime/gateway/testdata/https/16-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/16-gateway-route.yaml
@@ -224,7 +224,7 @@ Routes:
         name: echo.example.com
         requireTls: ALL
         responseHeadersToAdd:
-        - append: false
+        - appendAction: OVERWRITE_IF_EXISTS_OR_ADD
           header:
             key: Strict-Transport-Security
             value: max-age=31536000; includeSubDomains

--- a/pkg/plugins/runtime/gateway/testdata/https/17-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/17-gateway-route.yaml
@@ -245,7 +245,7 @@ Routes:
         name: echo.example.com
         requireTls: ALL
         responseHeadersToAdd:
-        - append: false
+        - appendAction: OVERWRITE_IF_EXISTS_OR_ADD
           header:
             key: Strict-Transport-Security
             value: max-age=31536000; includeSubDomains

--- a/pkg/plugins/runtime/gateway/testdata/https/18-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/18-gateway-route.yaml
@@ -136,7 +136,7 @@ Routes:
         name: echo.example.com
         requireTls: ALL
         responseHeadersToAdd:
-        - append: false
+        - appendAction: OVERWRITE_IF_EXISTS_OR_ADD
           header:
             key: Strict-Transport-Security
             value: max-age=31536000; includeSubDomains

--- a/pkg/plugins/runtime/gateway/testdata/https/19-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/19-gateway-route.yaml
@@ -150,7 +150,7 @@ Routes:
         name: echo.example.com
         requireTls: ALL
         responseHeadersToAdd:
-        - append: false
+        - appendAction: OVERWRITE_IF_EXISTS_OR_ADD
           header:
             key: Strict-Transport-Security
             value: max-age=31536000; includeSubDomains

--- a/pkg/plugins/runtime/gateway/testdata/https/20-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/20-gateway-route.yaml
@@ -353,7 +353,7 @@ Routes:
         name: two.example.com
         requireTls: ALL
         responseHeadersToAdd:
-        - append: false
+        - appendAction: OVERWRITE_IF_EXISTS_OR_ADD
           header:
             key: Strict-Transport-Security
             value: max-age=31536000; includeSubDomains
@@ -384,7 +384,7 @@ Routes:
         name: three.example.com
         requireTls: ALL
         responseHeadersToAdd:
-        - append: false
+        - appendAction: OVERWRITE_IF_EXISTS_OR_ADD
           header:
             key: Strict-Transport-Security
             value: max-age=31536000; includeSubDomains
@@ -415,7 +415,7 @@ Routes:
         name: one.example.com
         requireTls: ALL
         responseHeadersToAdd:
-        - append: false
+        - appendAction: OVERWRITE_IF_EXISTS_OR_ADD
           header:
             key: Strict-Transport-Security
             value: max-age=31536000; includeSubDomains

--- a/pkg/plugins/runtime/gateway/testdata/https/21-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/21-gateway-route.yaml
@@ -227,7 +227,7 @@ Routes:
         name: echo.example.com
         requireTls: ALL
         responseHeadersToAdd:
-        - append: false
+        - appendAction: OVERWRITE_IF_EXISTS_OR_ADD
           header:
             key: Strict-Transport-Security
             value: max-age=31536000; includeSubDomains

--- a/pkg/plugins/runtime/gateway/testdata/https/25-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/25-gateway-route.yaml
@@ -163,7 +163,7 @@ Routes:
         name: echo.example.com
         requireTls: ALL
         responseHeadersToAdd:
-        - append: false
+        - appendAction: OVERWRITE_IF_EXISTS_OR_ADD
           header:
             key: Strict-Transport-Security
             value: max-age=31536000; includeSubDomains

--- a/pkg/plugins/runtime/gateway/testdata/https/26-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/26-gateway-route.yaml
@@ -149,7 +149,7 @@ Routes:
         name: echo.example.com
         requireTls: ALL
         responseHeadersToAdd:
-        - append: false
+        - appendAction: OVERWRITE_IF_EXISTS_OR_ADD
           header:
             key: Strict-Transport-Security
             value: max-age=31536000; includeSubDomains

--- a/pkg/plugins/runtime/gateway/testdata/https/cross-mesh-gateway.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/cross-mesh-gateway.yaml
@@ -624,7 +624,7 @@ Routes:
         name: '*'
         requireTls: ALL
         responseHeadersToAdd:
-        - append: false
+        - appendAction: OVERWRITE_IF_EXISTS_OR_ADD
           header:
             key: Strict-Transport-Security
             value: max-age=31536000; includeSubDomains
@@ -717,7 +717,7 @@ Routes:
         name: internal-cross-mesh.mesh
         requireTls: ALL
         responseHeadersToAdd:
-        - append: false
+        - appendAction: OVERWRITE_IF_EXISTS_OR_ADD
           header:
             key: Strict-Transport-Security
             value: max-age=31536000; includeSubDomains
@@ -886,7 +886,7 @@ Routes:
         name: cross-mesh2.mesh
         requireTls: ALL
         responseHeadersToAdd:
-        - append: false
+        - appendAction: OVERWRITE_IF_EXISTS_OR_ADD
           header:
             key: Strict-Transport-Security
             value: max-age=31536000; includeSubDomains
@@ -972,7 +972,7 @@ Routes:
         name: cross-mesh.mesh
         requireTls: ALL
         responseHeadersToAdd:
-        - append: false
+        - appendAction: OVERWRITE_IF_EXISTS_OR_ADD
           header:
             key: Strict-Transport-Security
             value: max-age=31536000; includeSubDomains
@@ -1058,7 +1058,7 @@ Routes:
         name: '*'
         requireTls: ALL
         responseHeadersToAdd:
-        - append: false
+        - appendAction: OVERWRITE_IF_EXISTS_OR_ADD
           header:
             key: Strict-Transport-Security
             value: max-age=31536000; includeSubDomains

--- a/pkg/plugins/runtime/gateway/testdata/https/drop-prefix-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/drop-prefix-gateway-route.yaml
@@ -139,7 +139,7 @@ Routes:
         name: echo.example.com
         requireTls: ALL
         responseHeadersToAdd:
-        - append: false
+        - appendAction: OVERWRITE_IF_EXISTS_OR_ADD
           header:
             key: Strict-Transport-Security
             value: max-age=31536000; includeSubDomains

--- a/pkg/plugins/runtime/gateway/testdata/https/http-tcp-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/http-tcp-route.yaml
@@ -95,7 +95,7 @@ Routes:
         name: echo.example.com
         requireTls: ALL
         responseHeadersToAdd:
-        - append: false
+        - appendAction: OVERWRITE_IF_EXISTS_OR_ADD
           header:
             key: Strict-Transport-Security
             value: max-age=31536000; includeSubDomains

--- a/pkg/plugins/runtime/gateway/testdata/https/no-timeout.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/no-timeout.yaml
@@ -139,7 +139,7 @@ Routes:
         name: echo.example.com
         requireTls: ALL
         responseHeadersToAdd:
-        - append: false
+        - appendAction: OVERWRITE_IF_EXISTS_OR_ADD
           header:
             key: Strict-Transport-Security
             value: max-age=31536000; includeSubDomains

--- a/pkg/plugins/runtime/gateway/testdata/https/response-header-set-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/response-header-set-gateway-route.yaml
@@ -139,7 +139,7 @@ Routes:
         name: echo.example.com
         requireTls: ALL
         responseHeadersToAdd:
-        - append: false
+        - appendAction: OVERWRITE_IF_EXISTS_OR_ADD
           header:
             key: Strict-Transport-Security
             value: max-age=31536000; includeSubDomains

--- a/pkg/plugins/runtime/gateway/testdata/https/retry-policy.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/retry-policy.yaml
@@ -227,7 +227,7 @@ Routes:
         name: echo.example.com
         requireTls: ALL
         responseHeadersToAdd:
-        - append: false
+        - appendAction: OVERWRITE_IF_EXISTS_OR_ADD
           header:
             key: Strict-Transport-Security
             value: max-age=31536000; includeSubDomains

--- a/pkg/plugins/runtime/gateway/testdata/https/rewrite-prefix-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/rewrite-prefix-gateway-route.yaml
@@ -139,7 +139,7 @@ Routes:
         name: echo.example.com
         requireTls: ALL
         responseHeadersToAdd:
-        - append: false
+        - appendAction: OVERWRITE_IF_EXISTS_OR_ADD
           header:
             key: Strict-Transport-Security
             value: max-age=31536000; includeSubDomains

--- a/pkg/plugins/runtime/gateway/testdata/https/rewrite-prefix-trailing-gateway-route.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/rewrite-prefix-trailing-gateway-route.yaml
@@ -139,7 +139,7 @@ Routes:
         name: echo.example.com
         requireTls: ALL
         responseHeadersToAdd:
-        - append: false
+        - appendAction: OVERWRITE_IF_EXISTS_OR_ADD
           header:
             key: Strict-Transport-Security
             value: max-age=31536000; includeSubDomains

--- a/pkg/plugins/runtime/gateway/testdata/https/unresolved-backend.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/unresolved-backend.yaml
@@ -95,7 +95,7 @@ Routes:
         name: echo.example.com
         requireTls: ALL
         responseHeadersToAdd:
-        - append: false
+        - appendAction: OVERWRITE_IF_EXISTS_OR_ADD
           header:
             key: Strict-Transport-Security
             value: max-age=31536000; includeSubDomains

--- a/pkg/xds/envoy/clusters/v3/health_check_configurer.go
+++ b/pkg/xds/envoy/clusters/v3/health_check_configurer.go
@@ -34,12 +34,16 @@ func mapHttpHeaders(
 ) []*envoy_core.HeaderValueOption {
 	var envoyHeaders []*envoy_core.HeaderValueOption
 	for _, header := range headers {
+		appendAction := envoy_core.HeaderValueOption_OVERWRITE_IF_EXISTS_OR_ADD
+		if header.Append.Value {
+			appendAction = envoy_core.HeaderValueOption_APPEND_IF_EXISTS_OR_ADD
+		}
 		envoyHeaders = append(envoyHeaders, &envoy_core.HeaderValueOption{
 			Header: &envoy_core.HeaderValue{
 				Key:   header.Header.Key,
 				Value: header.Header.Value,
 			},
-			Append: header.Append,
+			AppendAction: appendAction,
 		})
 	}
 	return envoyHeaders

--- a/pkg/xds/envoy/clusters/v3/health_check_configurer_test.go
+++ b/pkg/xds/envoy/clusters/v3/health_check_configurer_test.go
@@ -222,7 +222,7 @@ var _ = Describe("HealthCheckConfigurer", func() {
                   start: "201"
                 path: /foo
                 requestHeadersToAdd:
-                - append: false
+                - appendAction: OVERWRITE_IF_EXISTS_OR_ADD
                   header:
                     key: foobar
                     value: foobaz
@@ -299,7 +299,7 @@ var _ = Describe("HealthCheckConfigurer", func() {
                   start: "201"
                 path: /foo
                 requestHeadersToAdd:
-                - append: false
+                - appendAction: OVERWRITE_IF_EXISTS_OR_ADD
                   header:
                     key: foobar
                     value: foobaz

--- a/pkg/xds/envoy/listeners/v3/http_inbound_routes_configurer_test.go
+++ b/pkg/xds/envoy/listeners/v3/http_inbound_routes_configurer_test.go
@@ -186,7 +186,7 @@ var _ = Describe("HttpInboundRouteConfigurer", func() {
                                 numerator: 100
                               runtimeKey: local_rate_limit_enforced
                             responseHeadersToAdd:
-                            - append: false
+                            - appendAction: OVERWRITE_IF_EXISTS_OR_ADD
                               header:
                                 key: x-local-rate-limit
                                 value: "true"
@@ -284,7 +284,7 @@ var _ = Describe("HttpInboundRouteConfigurer", func() {
                                 numerator: 100
                               runtimeKey: local_rate_limit_enforced
                             responseHeadersToAdd:
-                            - append: false
+                            - appendAction: OVERWRITE_IF_EXISTS_OR_ADD
                               header:
                                 key: x-local-rate-limit
                                 value: "true"

--- a/pkg/xds/envoy/listeners/v3/http_outbound_route_configurer_test.go
+++ b/pkg/xds/envoy/listeners/v3/http_outbound_route_configurer_test.go
@@ -244,14 +244,14 @@ var _ = Describe("HttpOutboundRouteConfigurer", func() {
                             name: :method
                           prefix: /asd
                         requestHeadersToAdd:
-                        - append: false
+                        - appendAction: OVERWRITE_IF_EXISTS_OR_ADD
                           header:
                             key: test-add
                             value: abc
                         requestHeadersToRemove:
                         - test-remove
                         responseHeadersToAdd:
-                        - append: false
+                        - appendAction: OVERWRITE_IF_EXISTS_OR_ADD
                           header:
                             key: test-add
                             value: abc

--- a/pkg/xds/envoy/routes/v3/ratelimit.go
+++ b/pkg/xds/envoy/routes/v3/ratelimit.go
@@ -70,12 +70,16 @@ func NewRateLimitConfiguration(rlHttp *RateLimitConfiguration) (*anypb.Any, erro
 		}
 		responseHeaders = []*envoy_config_core_v3.HeaderValueOption{}
 		for _, h := range rlHttp.OnRateLimit.Headers {
+			appendAction := envoy_config_core_v3.HeaderValueOption_OVERWRITE_IF_EXISTS_OR_ADD
+			if h.Append {
+				appendAction = envoy_config_core_v3.HeaderValueOption_APPEND_IF_EXISTS_OR_ADD
+			}
 			responseHeaders = append(responseHeaders, &envoy_config_core_v3.HeaderValueOption{
 				Header: &envoy_config_core_v3.HeaderValue{
 					Key:   h.Key,
 					Value: h.Value,
 				},
-				Append: proto.Bool(h.Append),
+				AppendAction: appendAction,
 			})
 		}
 	}

--- a/pkg/xds/envoy/virtualhosts/configurer.go
+++ b/pkg/xds/envoy/virtualhosts/configurer.go
@@ -5,7 +5,6 @@ import (
 	envoy_config_route_v3 "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
 
 	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
-	util_proto "github.com/kumahq/kuma/pkg/util/proto"
 	envoy_common "github.com/kumahq/kuma/pkg/xds/envoy"
 	envoy_routes_v3 "github.com/kumahq/kuma/pkg/xds/envoy/routes/v3"
 )
@@ -53,7 +52,7 @@ func SetResponseHeader(name string, value string) VirtualHostBuilderOpt {
 	return AddVirtualHostConfigurer(
 		VirtualHostMustConfigureFunc(func(vh *envoy_config_route_v3.VirtualHost) {
 			hsts := &envoy_config_core_v3.HeaderValueOption{
-				Append: util_proto.Bool(false),
+				AppendAction: envoy_config_core_v3.HeaderValueOption_OVERWRITE_IF_EXISTS_OR_ADD,
 				Header: &envoy_config_core_v3.HeaderValue{
 					Key:   name,
 					Value: value,

--- a/pkg/xds/envoy/virtualhosts/routes_configurer.go
+++ b/pkg/xds/envoy/virtualhosts/routes_configurer.go
@@ -44,12 +44,16 @@ func (c RoutesConfigurer) Configure(virtualHost *envoy_config_route_v3.VirtualHo
 
 func (c RoutesConfigurer) setHeadersModifications(route *envoy_config_route_v3.Route, modify *mesh_proto.TrafficRoute_Http_Modify) {
 	for _, add := range modify.GetRequestHeaders().GetAdd() {
+		appendAction := envoy_config_core_v3.HeaderValueOption_OVERWRITE_IF_EXISTS_OR_ADD
+		if add.Append {
+			appendAction = envoy_config_core_v3.HeaderValueOption_APPEND_IF_EXISTS_OR_ADD
+		}
 		route.RequestHeadersToAdd = append(route.RequestHeadersToAdd, &envoy_config_core_v3.HeaderValueOption{
 			Header: &envoy_config_core_v3.HeaderValue{
 				Key:   add.Name,
 				Value: add.Value,
 			},
-			Append: util_proto.Bool(add.Append),
+			AppendAction: appendAction,
 		})
 	}
 	for _, remove := range modify.GetRequestHeaders().GetRemove() {
@@ -57,12 +61,16 @@ func (c RoutesConfigurer) setHeadersModifications(route *envoy_config_route_v3.R
 	}
 
 	for _, add := range modify.GetResponseHeaders().GetAdd() {
+		appendAction := envoy_config_core_v3.HeaderValueOption_OVERWRITE_IF_EXISTS_OR_ADD
+		if add.Append {
+			appendAction = envoy_config_core_v3.HeaderValueOption_APPEND_IF_EXISTS_OR_ADD
+		}
 		route.ResponseHeadersToAdd = append(route.ResponseHeadersToAdd, &envoy_config_core_v3.HeaderValueOption{
 			Header: &envoy_config_core_v3.HeaderValue{
 				Key:   add.Name,
 				Value: add.Value,
 			},
-			Append: util_proto.Bool(add.Append),
+			AppendAction: appendAction,
 		})
 	}
 	for _, remove := range modify.GetResponseHeaders().GetRemove() {

--- a/pkg/xds/generator/testdata/inbound-proxy/3-envoy-config.golden.yaml
+++ b/pkg/xds/generator/testdata/inbound-proxy/3-envoy-config.golden.yaml
@@ -199,7 +199,7 @@ resources:
                         numerator: 100
                       runtimeKey: local_rate_limit_enforced
                     responseHeadersToAdd:
-                    - append: false
+                    - appendAction: OVERWRITE_IF_EXISTS_OR_ADD
                       header:
                         key: x-rate-limited
                         value: "true"

--- a/pkg/xds/generator/testdata/inbound-proxy/4-envoy-config.golden.yaml
+++ b/pkg/xds/generator/testdata/inbound-proxy/4-envoy-config.golden.yaml
@@ -209,7 +209,7 @@ resources:
                         numerator: 100
                       runtimeKey: local_rate_limit_enforced
                     responseHeadersToAdd:
-                    - append: false
+                    - appendAction: OVERWRITE_IF_EXISTS_OR_ADD
                       header:
                         key: x-rate-limited
                         value: "true"

--- a/pkg/xds/generator/testdata/inbound-proxy/5-envoy-config.golden.yaml
+++ b/pkg/xds/generator/testdata/inbound-proxy/5-envoy-config.golden.yaml
@@ -209,7 +209,7 @@ resources:
                         numerator: 100
                       runtimeKey: local_rate_limit_enforced
                     responseHeadersToAdd:
-                    - append: false
+                    - appendAction: OVERWRITE_IF_EXISTS_OR_ADD
                       header:
                         key: x-rate-limited
                         value: "true"
@@ -316,7 +316,7 @@ resources:
                         numerator: 100
                       runtimeKey: local_rate_limit_enforced
                     responseHeadersToAdd:
-                    - append: false
+                    - appendAction: OVERWRITE_IF_EXISTS_OR_ADD
                       header:
                         key: x-rate-limited
                         value: "true"
@@ -443,7 +443,7 @@ resources:
                         numerator: 100
                       runtimeKey: local_rate_limit_enforced
                     responseHeadersToAdd:
-                    - append: false
+                    - appendAction: OVERWRITE_IF_EXISTS_OR_ADD
                       header:
                         key: x-rate-limited
                         value: "true"

--- a/pkg/xds/generator/testdata/inbound-proxy/6-envoy-config.golden.yaml
+++ b/pkg/xds/generator/testdata/inbound-proxy/6-envoy-config.golden.yaml
@@ -219,7 +219,7 @@ resources:
                         numerator: 100
                       runtimeKey: local_rate_limit_enforced
                     responseHeadersToAdd:
-                    - append: false
+                    - appendAction: OVERWRITE_IF_EXISTS_OR_ADD
                       header:
                         key: x-rate-limited
                         value: "true"
@@ -326,7 +326,7 @@ resources:
                         numerator: 100
                       runtimeKey: local_rate_limit_enforced
                     responseHeadersToAdd:
-                    - append: false
+                    - appendAction: OVERWRITE_IF_EXISTS_OR_ADD
                       header:
                         key: x-rate-limited
                         value: "true"
@@ -453,7 +453,7 @@ resources:
                         numerator: 100
                       runtimeKey: local_rate_limit_enforced
                     responseHeadersToAdd:
-                    - append: false
+                    - appendAction: OVERWRITE_IF_EXISTS_OR_ADD
                       header:
                         key: x-rate-limited
                         value: "true"


### PR DESCRIPTION
### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
