### PR TITLE
fix(MeshHTTPRoute): use 302 as default status code on Universal to match Kubernetes

### DIFF
--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/header-modifiers.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/header-modifiers.listeners.golden.yaml
@@ -32,6 +32,7 @@ resources:
                   path: /v1
                 name: bzv64o+joRk33jfDADgGv5ar4QyONO0NEVKnoBfJW/E=
                 redirect:
+                  responseCode: FOUND
                   schemeRedirect: other
                 requestHeadersToAdd:
                 - append: false
@@ -67,6 +68,7 @@ resources:
                   prefix: /v1/
                 name: bzv64o+joRk33jfDADgGv5ar4QyONO0NEVKnoBfJW/E=
                 redirect:
+                  responseCode: FOUND
                   schemeRedirect: other
                 requestHeadersToAdd:
                 - append: false

--- a/pkg/plugins/policies/meshhttproute/xds/filters/requestredirect.go
+++ b/pkg/plugins/policies/meshhttproute/xds/filters/requestredirect.go
@@ -52,7 +52,7 @@ func (f *RequestRedirectConfigurer) Configure(envoyRoute *envoy_route.Route) err
 		}
 	}
 
-	switch pointer.DerefOr(redirect.StatusCode, 301) {
+	switch pointer.DerefOr(redirect.StatusCode, 302) {
 	case 301:
 		envoyRedirect.ResponseCode = envoy_route.RedirectAction_MOVED_PERMANENTLY
 	case 302:


### PR DESCRIPTION
### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues -- #8286 
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
