### PR TITLE
chore(k8s): don't record Event on context.Canceled

### DIFF
--- a/pkg/plugins/runtime/k8s/controllers/pod_controller.go
+++ b/pkg/plugins/runtime/k8s/controllers/pod_controller.go
@@ -16,7 +16,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	kube_controllerutil "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	kube_handler "sigs.k8s.io/controller-runtime/pkg/handler"
-	kube_reconile "sigs.k8s.io/controller-runtime/pkg/reconcile"
+	kube_reconcile "sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	"github.com/kumahq/kuma/pkg/core/resources/model"
@@ -384,16 +384,16 @@ func (r *PodReconciler) SetupWithManager(mgr kube_ctrl.Manager, maxConcurrentRec
 
 func ServiceToPodsMapper(l logr.Logger, client kube_client.Client) kube_handler.MapFunc {
 	l = l.WithName("service-to-pods-mapper")
-	return func(ctx context.Context, obj kube_client.Object) []kube_reconile.Request {
+	return func(ctx context.Context, obj kube_client.Object) []kube_reconcile.Request {
 		// List Pods in the same namespace as a Service
 		pods := &kube_core.PodList{}
 		if err := client.List(ctx, pods, kube_client.InNamespace(obj.GetNamespace()), kube_client.MatchingLabels(obj.(*kube_core.Service).Spec.Selector)); err != nil {
 			l.WithValues("service", obj.GetName()).Error(err, "failed to fetch Pods")
 			return nil
 		}
-		var req []kube_reconile.Request
+		var req []kube_reconcile.Request
 		for _, pod := range pods.Items {
-			req = append(req, kube_reconile.Request{
+			req = append(req, kube_reconcile.Request{
 				NamespacedName: kube_types.NamespacedName{Namespace: pod.Namespace, Name: pod.Name},
 			})
 		}

--- a/pkg/plugins/runtime/k8s/controllers/pod_controller.go
+++ b/pkg/plugins/runtime/k8s/controllers/pod_controller.go
@@ -286,6 +286,10 @@ func (r *PodReconciler) createOrUpdateDataplane(
 	})
 	log := r.Log.WithValues("pod", kube_types.NamespacedName{Namespace: pod.Namespace, Name: pod.Name})
 	if err != nil {
+		if errors.Is(err, context.Canceled) {
+			return nil
+		}
+
 		log.Error(err, "unable to create/update Dataplane", "operationResult", operationResult)
 		r.EventRecorder.Eventf(pod, kube_core.EventTypeWarning, FailedToGenerateKumaDataplaneReason, "Failed to generate Kuma Dataplane: %s", err.Error())
 		return err

--- a/pkg/plugins/runtime/k8s/controllers/pod_controller.go
+++ b/pkg/plugins/runtime/k8s/controllers/pod_controller.go
@@ -286,12 +286,11 @@ func (r *PodReconciler) createOrUpdateDataplane(
 	})
 	log := r.Log.WithValues("pod", kube_types.NamespacedName{Namespace: pod.Namespace, Name: pod.Name})
 	if err != nil {
-		if errors.Is(err, context.Canceled) {
-			return nil
+		if !errors.Is(err, context.Canceled) {
+			log.Error(err, "unable to create/update Dataplane", "operationResult", operationResult)
+			r.EventRecorder.Eventf(pod, kube_core.EventTypeWarning, FailedToGenerateKumaDataplaneReason, "Failed to generate Kuma Dataplane: %s", err.Error())
 		}
 
-		log.Error(err, "unable to create/update Dataplane", "operationResult", operationResult)
-		r.EventRecorder.Eventf(pod, kube_core.EventTypeWarning, FailedToGenerateKumaDataplaneReason, "Failed to generate Kuma Dataplane: %s", err.Error())
 		return err
 	}
 	switch operationResult {


### PR DESCRIPTION
### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
