### PR TITLE
refactor(kuma-cp): use context.WithoutCancel where possible

### DIFF
--- a/pkg/kds/server/status_sink.go
+++ b/pkg/kds/server/status_sink.go
@@ -16,7 +16,6 @@ import (
 	"github.com/kumahq/kuma/pkg/core/resources/store"
 	"github.com/kumahq/kuma/pkg/core/user"
 	kuma_log "github.com/kumahq/kuma/pkg/log"
-	"github.com/kumahq/kuma/pkg/multitenant"
 )
 
 type ZoneInsightSink interface {
@@ -68,7 +67,7 @@ func (s *zoneInsightSink) Start(ctx context.Context, stop <-chan struct{}) {
 	var lastStoredState *system_proto.KDSSubscription
 	var generation uint32
 
-	gracefulCtx, cancel := context.WithCancel(multitenant.CopyIntoCtx(ctx, context.Background()))
+	gracefulCtx, cancel := context.WithCancel(context.WithoutCancel(ctx))
 	defer cancel()
 
 	log := kuma_log.AddFieldsFromCtx(s.log, ctx, s.extensions)

--- a/pkg/multitenant/multitenant.go
+++ b/pkg/multitenant/multitenant.go
@@ -62,13 +62,4 @@ func TenantFromCtx(ctx context.Context) (string, bool) {
 	return value, ok
 }
 
-// CopyIntoCtx copies tenant information from src context to dst context
-func CopyIntoCtx(src context.Context, dst context.Context) context.Context {
-	tenantId, ok := TenantFromCtx(src)
-	if !ok {
-		return dst
-	}
-	return WithTenant(dst, tenantId)
-}
-
 var TenantMissingErr = errors.New("tenant is missing")


### PR DESCRIPTION
### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
