### PR TITLE
ci(actions): trigger E2E tests on CircleCI manually from GitHub Actions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,6 +13,27 @@ parameters:
   ubuntu_image:
     type: string
     default: "ubuntu-2204:2022.10.2"
+  manual_e2e:
+    type: boolean
+    default: false
+  e2e_param_k8s_version:
+    type: string
+    default: ""
+  e2e_param_arch:
+    type: string
+    default: ""
+  e2e_param_parallelism:
+    type: integer
+    default: 1
+  e2e_param_target:
+    type: string
+    default: ""
+  e2e_param_cni_network_plugin:
+    type: string
+    default: flannel
+  e2e_param_legacy_kds:
+    type: boolean
+    default: false
 # See https://circleci.com/docs/2.0/configuration-reference/#commands-requires-version-21.
 commands:
   install_build_tools:
@@ -517,3 +538,20 @@ workflows:
           requires: [build]
       - distributions:
           requires: [test, container-structure]
+  manual-e2e:
+    when:
+      equal: [true, << pipeline.parameters.manual_e2e >>]
+    jobs:
+      - go_cache:
+          name: go_cache-<< pipeline.parameters.e2e_param_arch >>
+          arch: << pipeline.parameters.e2e_param_arch >>
+      - build:
+          name: build
+      - e2e:
+          k8sVersion: << pipeline.parameters.e2e_param_k8s_version >>
+          parallelism: << pipeline.parameters.e2e_param_parallelism >>
+          target: << pipeline.parameters.e2e_param_target >>
+          arch: << pipeline.parameters.e2e_param_arch >>
+          cniNetworkPlugin: << pipeline.parameters.e2e_param_cni_network_plugin >>
+          legacyKDS: << pipeline.parameters.e2e_param_legacy_kds >>
+          requires: [build, go_cache-<< pipeline.parameters.e2e_param_arch >>]

--- a/.github/actions/e2e/action.yaml
+++ b/.github/actions/e2e/action.yaml
@@ -1,0 +1,44 @@
+name: 'Kuma E2E'
+description: 'Run end to end tests for kuma'
+inputs:
+  k8sVersion:
+    description: version of k3s to use or "kind" and "kindIpv6"
+    default: v1.28.1-k3s1
+    required: false
+  parallelism:
+    description: level of parallelization
+    default: '1'
+    required: false
+  target:
+    description: makefile target without e2e prefix
+    default: ""
+    required: false
+  arch:
+    description: The golang arch
+    default: amd64
+    required: false
+  cniNetworkPlugin:
+    description: The CNI networking plugin to use [flannel | calico]
+    default: flannel
+    required: false
+  deltaKDS:
+    description: if should run tests with new implementation of KDS
+    default: 'false'
+    required: false
+runs:
+  using: "composite"
+  steps:
+    - run: |
+        echo "All inputs:"
+        echo "Running with: \
+            k8s: ${{ inputs.k8sVersion }} \
+            target: ${{ inputs.target }} \
+            parallelism: ${{ inputs.parallelism }} \
+            arch: ${{ inputs.arch }} \
+            cniNetworkPlugin: ${{ inputs.cniNetworkPlugin }} \
+            "
+      shell: bash
+    - id: random-number-generator
+      run: |
+        echo "Invoking CircleCI (todo)"
+      shell: bash

--- a/.github/actions/e2e/action.yaml
+++ b/.github/actions/e2e/action.yaml
@@ -21,9 +21,13 @@ inputs:
     description: The CNI networking plugin to use [flannel | calico]
     default: flannel
     required: false
-  deltaKDS:
+  legacyKDS:
     description: if should run tests with new implementation of KDS
     default: 'false'
+    required: false
+  secureCircleCIToken:
+    description: The personal access token used to invoke CircleCI API (not project API Token)
+    default: ''
     required: false
 runs:
   using: "composite"
@@ -38,7 +42,36 @@ runs:
             cniNetworkPlugin: ${{ inputs.cniNetworkPlugin }} \
             "
       shell: bash
-    - id: random-number-generator
-      run: |
-        echo "Invoking CircleCI (todo)"
+    - run: |
+        # Trigger CircleCI manually, reference: https://github.com/CircleCI-Public/trigger-circleci-pipeline-action/blob/main/dist/index.js#L16310
+        
+        BODY='{"parameters": { "manual_e2e": true, "e2e_param_k8s_version": "${{ inputs.k8sVersion }}", "e2e_param_arch": "${{ inputs.arch }}", "e2e_param_parallelism": ${{ inputs.parallelism }}, "e2e_param_target": "${{ inputs.target }}", "e2e_param_cni_network_plugin": "${{ inputs.cniNetworkPlugin }}", "e2e_param_legacy_kds": ${{ inputs.legacyKDS }}  } }'
+        
+        if [ "${{ github.ref_type }}" == "tag" ]]; then
+          BODY=$(echo $BODY | jq -rc '.+= {"tag": "${{ github.ref_name }}"}')
+        else
+          BODY=$(echo $BODY | jq -rc '.+= {"branch": "${{ github.ref_name }}"}')
+        fi
+        
+        CIRCLE_CI_API_PATH=https://circleci.com/api/v2/project/gh/${{ github.repository }}/pipeline
+        echo "Calling CircleCI api with parameters:
+          URL: $CIRCLE_CI_API_PATH
+          BODY: $BODY"
+        
+        if [ "${{ inputs.secureCircleCIToken }}" == "" ]; then
+          echo "Skipping request CircleCI because secret 'CIRCLECI_TOKEN' not set." 
+          exit 0
+        fi
+        
+        VERBOSE=
+        if [ "${{ runner.debug }}" == "1" ]; then
+          VERBOSE='-v'
+        fi
+        
+        curl $VERBOSE --fail -X POST $CIRCLE_CI_API_PATH \
+          --header "content-type: application/json" \
+          --header "x-attribution-login: ${{ github.actor }}" \
+          --header "x-attribution-actor-id: ${{ github.actor }}" \
+          --header "Circle-Token: ${{ inputs.secureCircleCIToken }}" \
+          --data "$BODY"
       shell: bash

--- a/.github/workflows/build-test-distribute.yaml
+++ b/.github/workflows/build-test-distribute.yaml
@@ -179,7 +179,7 @@ jobs:
     outputs:
       slow: ${{ steps.generate-matrix.outputs.slow }}
       main: ${{ steps.generate-matrix.outputs.main }}
-      delta_kds: ${{ steps.generate-matrix.outputs.delta_kds }}
+      legacy_kds: ${{ steps.generate-matrix.outputs.legacy_kds }}
       cni: ${{ steps.generate-matrix.outputs.cni }}
     steps:
       - name: Install jq
@@ -194,20 +194,14 @@ jobs:
             exit 0
           fi
 
-          JQ_PATH=$(which jq)
-          if [ "$JQ_PATH" == "" ]; then
-            echo "Could not find devtool 'jq', please check if 'check' job has run correctly prior to this job."
-            exit 1
-          fi
-
           ALL_K8S_VERSION='{"k8sVersion":["kind", "kindIpv6", "${{ env.K8S_MIN_VERSION }}", "${{ env.K8S_MAX_VERSION }}"]}'
           ALL_ARCH='{"arch": ["amd64", "arm64"]}'
           ALL_TARGET='{"target": ["kubernetes", "universal", "multizone"]}'
           SINGLE_ENV='{"k8sVersion": ["${{ env.K8S_MAX_VERSION }}"], "target": ["multizone"], "arch":["amd64"]}'
-          ALL_DELTA_KDS='{"deltaKDS": [true]}'
+          ALL_LEGACY_KDS='{"legacyKDS": [true]}'
           ALL_CNI='{"cniNetworkPlugin": ["calico"]}'
 
-          # GitHub Actions does not support ARM64
+          # arm64 is treated as a non-priority
           EXCLUDE_ARM64='[{"arch": "arm64"}]'
 
           # kind should only be used when testing ipv6 or with e2e-universal
@@ -220,24 +214,24 @@ jobs:
           EXCLUDE_MAIN_NON_PRIORITY='[{"k8sVersion":"kindIpv6"}, {"k8sVersion": "${{ env.K8S_MIN_VERSION }}"}]'
 
           # Default matrix
-          SLOW=$(echo '{}' | $JQ_PATH -rc ".exclude += $EXCLUDE_ARM64" | $JQ_PATH -rc ". += $ALL_K8S_VERSION | . += $ALL_ARCH")
-          MAIN=$(echo '{}' | $JQ_PATH -rc ".exclude += $EXCLUDE_ARM64" | $JQ_PATH -rc ". += $ALL_K8S_VERSION | . += $ALL_ARCH | . += $ALL_TARGET" | $JQ_PATH -rc ".exclude += $EXCLUDE_KIND | .exclude += $EXCLUDE_UNIVERSAL" )
-          DELTA_KDS=$(echo '{}' | $JQ_PATH -rc ".exclude += $EXCLUDE_ARM64" | $JQ_PATH -rc ". += $ALL_DELTA_KDS | . += $SINGLE_ENV")
-          CNI=$(echo '{}' | $JQ_PATH -rc ".exclude += $EXCLUDE_ARM64" | $JQ_PATH -rc ". += $ALL_CNI | . += $SINGLE_ENV")
+          SLOW=$(echo '{}' | jq -rc ". += $ALL_K8S_VERSION | . += $ALL_ARCH")
+          MAIN=$(echo '{}' | jq -rc ". += $ALL_K8S_VERSION | . += $ALL_ARCH | . += $ALL_TARGET" | jq -rc ".exclude += $EXCLUDE_KIND | .exclude += $EXCLUDE_UNIVERSAL" )
+          LEGACY_KDS=$(echo '{}' | jq -rc ". += $ALL_LEGACY_KDS | . += $SINGLE_ENV")
+          CNI=$(echo '{}' | jq -rc ". += $ALL_CNI | . += $SINGLE_ENV")
 
           RUN_FULL_MATRIX="${{ contains(github.event.pull_request.labels.*.name, 'ci/run-full-matrix') }}"
           if [[ "$RUN_FULL_MATRIX" == "false" ]]; then
             echo "Skipping non priority e2e tests, because no label 'ci/run-full-matrix' was found on the pull request."
 
             SLOW=''         # target==""
-            DELTA_KDS=''    # deltaKDS=="true"
+            LEGACY_KDS=''   # legacyKDS=="true"
             CNI=''          # cniNetworkPlugin=="calico"
-            MAIN=$(echo $MAIN | $JQ_PATH -rc ".exclude += $EXCLUDE_ARM64 | .exclude += $EXCLUDE_MAIN_NON_PRIORITY")
+            MAIN=$(echo $MAIN | jq -rc ".exclude += $EXCLUDE_ARM64 | .exclude += $EXCLUDE_MAIN_NON_PRIORITY")
           fi
 
           echo "slow=$SLOW" >> $GITHUB_OUTPUT
           echo "main=$MAIN" >> $GITHUB_OUTPUT
-          echo "delta_kds=$DELTA_KDS" >> $GITHUB_OUTPUT
+          echo "legacy_kds=$LEGACY_KDS" >> $GITHUB_OUTPUT
           echo "cni=$CNI" >> $GITHUB_OUTPUT
   e2e_slow:
     name: "legacy-k8s:${{ matrix.arch }}-${{ matrix.k8sVersion }}"
@@ -250,6 +244,9 @@ jobs:
       - run: |
           echo "k8sVersion: ${{ matrix.k8sVersion }}"
           echo "arch: ${{ matrix.arch }}"
+      - name: Install jq
+        run: |
+          sudo apt-get install -y jq
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
@@ -259,6 +256,7 @@ jobs:
           arch: ${{ matrix.arch }}
           parallelism: 3
           target: ""
+          secureCircleCIToken: ${{ secrets.CIRCLECI_TOKEN }}
   e2e_main:
     name: "${{ matrix.target }}:${{ matrix.arch }}-${{ matrix.k8sVersion }}"
     runs-on: ubuntu-latest
@@ -271,6 +269,9 @@ jobs:
           echo "k8sVersion: ${{ matrix.k8sVersion }}"
           echo "target: ${{ matrix.target }}"
           echo "arch: ${{ matrix.arch }}"
+      - name: Install jq
+        run: |
+          sudo apt-get install -y jq
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
@@ -279,19 +280,23 @@ jobs:
           k8sVersion: ${{ matrix.k8sVersion }}
           target: ${{ matrix.target }}
           arch: ${{ matrix.arch }}
-  e2e_delta_kds:
-    name: "${{ matrix.target }}:${{ matrix.arch }}-${{ matrix.k8sVersion }}-delta-kds"
+          secureCircleCIToken: ${{ secrets.CIRCLECI_TOKEN }}
+  e2e_legacy_kds:
+    name: "${{ matrix.target }}:${{ matrix.arch }}-${{ matrix.k8sVersion }}-legacy-kds"
     runs-on: ubuntu-latest
     needs: ["gen_e2e_matrix"]
-    if: needs.gen_e2e_matrix.outputs.delta_kds != ''
+    if: needs.gen_e2e_matrix.outputs.legacy_kds != ''
     strategy:
-      matrix: ${{ fromJSON(needs.gen_e2e_matrix.outputs.delta_kds) }}
+      matrix: ${{ fromJSON(needs.gen_e2e_matrix.outputs.legacy_kds) }}
     steps:
       - run: |
           echo "k8sVersion: ${{ matrix.k8sVersion }}"
           echo "target: ${{ matrix.target }}"
           echo "arch: ${{ matrix.arch }}"
-          echo "deltaKDS: ${{ matrix.arch }}"
+          echo "legacyKDS: ${{ matrix.arch }}"
+      - name: Install jq
+        run: |
+          sudo apt-get install -y jq
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
@@ -300,7 +305,8 @@ jobs:
           k8sVersion: ${{ matrix.k8sVersion }}
           target: ${{ matrix.arch }}
           arch: ${{ matrix.arch }}
-          deltaKDS: ${{ matrix.deltaKDS }}
+          legacyKDS: ${{ matrix.legacyKDS }}
+          secureCircleCIToken: ${{ secrets.CIRCLECI_TOKEN }}
   e2e_calico:
     name: "${{ matrix.target }}:${{ matrix.arch }}-${{ matrix.k8sVersion }}-calico"
     runs-on: ubuntu-latest
@@ -314,6 +320,9 @@ jobs:
           echo "target: ${{ matrix.target }}"
           echo "arch: ${{ matrix.arch }}"
           echo "cniNetworkPlugin: ${{ matrix.cniNetworkPlugin }}"
+      - name: Install jq
+        run: |
+          sudo apt-get install -y jq
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
@@ -323,3 +332,4 @@ jobs:
           target: ${{ matrix.arch }}
           arch: ${{ matrix.arch }}
           cniNetworkPlugin: ${{ matrix.cniNetworkPlugin }}
+          secureCircleCIToken: ${{ secrets.CIRCLECI_TOKEN }}

--- a/.github/workflows/build-test-distribute.yaml
+++ b/.github/workflows/build-test-distribute.yaml
@@ -5,6 +5,9 @@ on:
     tags: ["*"]
   pull_request_target:
     branches: ["master", "release-*"]
+env:
+  K8S_MIN_VERSION: v1.23.17-k3s1
+  K8S_MAX_VERSION: v1.28.1-k3s1
 jobs:
   check:
     runs-on: ubuntu-latest
@@ -170,3 +173,153 @@ jobs:
           trap on_exit EXIT
           make docker/push
           make docker/manifest
+  gen_e2e_matrix:
+    runs-on: ubuntu-latest
+    needs: ["build"]
+    outputs:
+      slow: ${{ steps.generate-matrix.outputs.slow }}
+      main: ${{ steps.generate-matrix.outputs.main }}
+      delta_kds: ${{ steps.generate-matrix.outputs.delta_kds }}
+      cni: ${{ steps.generate-matrix.outputs.cni }}
+    steps:
+      - name: Install jq
+        run: |
+          sudo apt-get install -y jq
+      - id: generate-matrix
+        name: Generate matrix
+        run: |
+          SKIP_CI_LABEL="${{ contains(github.event.pull_request.labels.*.name, 'ci/skip-test') || contains(github.event.pull_request.labels.*.name, 'ci/skip-e2e-test')  }}"
+          if [[ "$SKIP_CI_LABEL" == "true" ]]; then
+            echo "Skipping e2e jobs because the pull request contained a 'ci/skip-*' label."
+            exit 0
+          fi
+
+          JQ_PATH=$(which jq)
+          if [ "$JQ_PATH" == "" ]; then
+            echo "Could not find devtool 'jq', please check if 'check' job has run correctly prior to this job."
+            exit 1
+          fi
+
+          ALL_K8S_VERSION='{"k8sVersion":["kind", "kindIpv6", "${{ env.K8S_MIN_VERSION }}", "${{ env.K8S_MAX_VERSION }}"]}'
+          ALL_ARCH='{"arch": ["amd64", "arm64"]}'
+          ALL_TARGET='{"target": ["kubernetes", "universal", "multizone"]}'
+          SINGLE_ENV='{"k8sVersion": ["${{ env.K8S_MAX_VERSION }}"], "target": ["multizone"], "arch":["amd64"]}'
+          ALL_DELTA_KDS='{"deltaKDS": [true]}'
+          ALL_CNI='{"cniNetworkPlugin": ["calico"]}'
+
+          # GitHub Actions does not support ARM64
+          EXCLUDE_ARM64='[{"arch": "arm64"}]'
+
+          # kind should only be used when testing ipv6 or with e2e-universal
+          EXCLUDE_KIND='[{"k8sVersion":"kind", "target": "kubernetes"}, {"k8sVersion":"kind", "target": "multizone"}]'
+
+          # universal only runs on kind
+          EXCLUDE_UNIVERSAL='[{"target":"universal", "k8sVersion":"${{ env.K8S_MIN_VERSION }}"}, {"target":"universal", "k8sVersion":"${{ env.K8S_MAX_VERSION }}"}]'
+
+          # non priority main e2e
+          EXCLUDE_MAIN_NON_PRIORITY='[{"k8sVersion":"kindIpv6"}, {"k8sVersion": "${{ env.K8S_MIN_VERSION }}"}]'
+
+          # Default matrix
+          SLOW=$(echo '{}' | $JQ_PATH -rc ".exclude += $EXCLUDE_ARM64" | $JQ_PATH -rc ". += $ALL_K8S_VERSION | . += $ALL_ARCH")
+          MAIN=$(echo '{}' | $JQ_PATH -rc ".exclude += $EXCLUDE_ARM64" | $JQ_PATH -rc ". += $ALL_K8S_VERSION | . += $ALL_ARCH | . += $ALL_TARGET" | $JQ_PATH -rc ".exclude += $EXCLUDE_KIND | .exclude += $EXCLUDE_UNIVERSAL" )
+          DELTA_KDS=$(echo '{}' | $JQ_PATH -rc ".exclude += $EXCLUDE_ARM64" | $JQ_PATH -rc ". += $ALL_DELTA_KDS | . += $SINGLE_ENV")
+          CNI=$(echo '{}' | $JQ_PATH -rc ".exclude += $EXCLUDE_ARM64" | $JQ_PATH -rc ". += $ALL_CNI | . += $SINGLE_ENV")
+
+          RUN_FULL_MATRIX="${{ contains(github.event.pull_request.labels.*.name, 'ci/run-full-matrix') }}"
+          if [[ "$RUN_FULL_MATRIX" == "false" ]]; then
+            echo "Skipping non priority e2e tests, because no label 'ci/run-full-matrix' was found on the pull request."
+
+            SLOW=''         # target==""
+            DELTA_KDS=''    # deltaKDS=="true"
+            CNI=''          # cniNetworkPlugin=="calico"
+            MAIN=$(echo $MAIN | $JQ_PATH -rc ".exclude += $EXCLUDE_ARM64 | .exclude += $EXCLUDE_MAIN_NON_PRIORITY")
+          fi
+
+          echo "slow=$SLOW" >> $GITHUB_OUTPUT
+          echo "main=$MAIN" >> $GITHUB_OUTPUT
+          echo "delta_kds=$DELTA_KDS" >> $GITHUB_OUTPUT
+          echo "cni=$CNI" >> $GITHUB_OUTPUT
+  e2e_slow:
+    name: "legacy-k8s:${{ matrix.arch }}-${{ matrix.k8sVersion }}"
+    runs-on: ubuntu-latest
+    needs: ["gen_e2e_matrix"]
+    if: needs.gen_e2e_matrix.outputs.slow != ''
+    strategy:
+      matrix: ${{ fromJSON(needs.gen_e2e_matrix.outputs.slow) }}
+    steps:
+      - run: |
+          echo "k8sVersion: ${{ matrix.k8sVersion }}"
+          echo "arch: ${{ matrix.arch }}"
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: ./.github/actions/e2e
+        with:
+          k8sVersion: ${{ matrix.k8sVersion }}
+          arch: ${{ matrix.arch }}
+          parallelism: 3
+          target: ""
+  e2e_main:
+    name: "${{ matrix.target }}:${{ matrix.arch }}-${{ matrix.k8sVersion }}"
+    runs-on: ubuntu-latest
+    needs: ["gen_e2e_matrix"]
+    if: needs.gen_e2e_matrix.outputs.main != ''
+    strategy:
+      matrix: ${{ fromJSON(needs.gen_e2e_matrix.outputs.main) }}
+    steps:
+      - run: |
+          echo "k8sVersion: ${{ matrix.k8sVersion }}"
+          echo "target: ${{ matrix.target }}"
+          echo "arch: ${{ matrix.arch }}"
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: ./.github/actions/e2e
+        with:
+          k8sVersion: ${{ matrix.k8sVersion }}
+          target: ${{ matrix.target }}
+          arch: ${{ matrix.arch }}
+  e2e_delta_kds:
+    name: "${{ matrix.target }}:${{ matrix.arch }}-${{ matrix.k8sVersion }}-delta-kds"
+    runs-on: ubuntu-latest
+    needs: ["gen_e2e_matrix"]
+    if: needs.gen_e2e_matrix.outputs.delta_kds != ''
+    strategy:
+      matrix: ${{ fromJSON(needs.gen_e2e_matrix.outputs.delta_kds) }}
+    steps:
+      - run: |
+          echo "k8sVersion: ${{ matrix.k8sVersion }}"
+          echo "target: ${{ matrix.target }}"
+          echo "arch: ${{ matrix.arch }}"
+          echo "deltaKDS: ${{ matrix.arch }}"
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: ./.github/actions/e2e
+        with:
+          k8sVersion: ${{ matrix.k8sVersion }}
+          target: ${{ matrix.arch }}
+          arch: ${{ matrix.arch }}
+          deltaKDS: ${{ matrix.deltaKDS }}
+  e2e_calico:
+    name: "${{ matrix.target }}:${{ matrix.arch }}-${{ matrix.k8sVersion }}-calico"
+    runs-on: ubuntu-latest
+    needs: ["gen_e2e_matrix"]
+    if: needs.gen_e2e_matrix.outputs.cni != ''
+    strategy:
+      matrix: ${{ fromJSON(needs.gen_e2e_matrix.outputs.cni) }}
+    steps:
+      - run: |
+          echo "k8sVersion: ${{ matrix.k8sVersion }}"
+          echo "target: ${{ matrix.target }}"
+          echo "arch: ${{ matrix.arch }}"
+          echo "cniNetworkPlugin: ${{ matrix.cniNetworkPlugin }}"
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: ./.github/actions/e2e
+        with:
+          k8sVersion: ${{ matrix.k8sVersion }}
+          target: ${{ matrix.arch }}
+          arch: ${{ matrix.arch }}
+          cniNetworkPlugin: ${{ matrix.cniNetworkPlugin }}


### PR DESCRIPTION
### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues
  - N/A
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS
  - Confirmed
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s)
  - Manually tested
  - Don't forget `ci/` labels to run additional/fewer tests
    - Added
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)?
  - No need
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label)
  - No need

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->


This PR adds the ability to trigger E2E tests on CircilCI manually from GitHub Actions.

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
