### PR TITLE
fix(metrics): unify zone name in metrics for k8s and universal

### DIFF
--- a/pkg/core/bootstrap/bootstrap.go
+++ b/pkg/core/bootstrap/bootstrap.go
@@ -219,15 +219,7 @@ func initializeMetrics(builder *core_runtime.Builder) error {
 		// do not configure if it was already configured in BeforeBootstrap
 		return nil
 	}
-	zoneName := ""
-	switch builder.Config().Mode {
-	case config_core.Zone:
-		zoneName = builder.Config().Multizone.Zone.Name
-	case config_core.Global:
-		zoneName = "Global"
-	case config_core.Standalone:
-		zoneName = "Standalone"
-	}
+	zoneName := metrics.ZoneNameOrMode(builder.Config().Mode, builder.Config().Multizone.Zone.Name)
 	metrics, err := metrics.NewMetrics(zoneName)
 	if err != nil {
 		return err

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -89,15 +89,14 @@ func (m *metrics) BulkRegister(cs ...prometheus.Collector) error {
 }
 
 func ZoneNameOrMode(mode config_core.CpMode, name string) string {
-	zoneName := ""
 	switch mode {
 	case config_core.Zone:
-		zoneName = name
+		return name
 	case config_core.Global:
-		zoneName = "Global"
+		return "Global"
 	case config_core.Standalone:
-		zoneName = "Standalone"
+		return "Standalone"
+	default:
+		return ""
 	}
-
-	return zoneName
 }

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -2,6 +2,7 @@ package metrics
 
 import (
 	grpc_prometheus "github.com/grpc-ecosystem/go-grpc-prometheus"
+	config_core "github.com/kumahq/kuma/pkg/config/core"
 	"github.com/prometheus/client_golang/prometheus"
 	"google.golang.org/grpc"
 )
@@ -84,4 +85,18 @@ func (m *metrics) BulkRegister(cs ...prometheus.Collector) error {
 		}
 	}
 	return nil
+}
+
+func ZoneNameOrMode(mode config_core.CpMode, name string) string {
+	zoneName := ""
+	switch mode {
+	case config_core.Zone:
+		zoneName = name
+	case config_core.Global:
+		zoneName = "Global"
+	case config_core.Standalone:
+		zoneName = "Standalone"
+	}
+
+	return zoneName
 }

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -2,9 +2,10 @@ package metrics
 
 import (
 	grpc_prometheus "github.com/grpc-ecosystem/go-grpc-prometheus"
-	config_core "github.com/kumahq/kuma/pkg/config/core"
 	"github.com/prometheus/client_golang/prometheus"
 	"google.golang.org/grpc"
+
+	config_core "github.com/kumahq/kuma/pkg/config/core"
 )
 
 type RegistererGatherer interface {

--- a/pkg/plugins/bootstrap/k8s/plugin.go
+++ b/pkg/plugins/bootstrap/k8s/plugin.go
@@ -100,10 +100,7 @@ func (p *plugin) BeforeBootstrap(b *core_runtime.Builder, cfg core_plugins.Plugi
 		b.WithExtensions(k8s_extensions.NewResourceConverterContext(b.Extensions(), k8s.NewSimpleConverter()))
 	}
 	b.WithExtensions(k8s_extensions.NewCompositeValidatorContext(b.Extensions(), &k8s_common.CompositeValidator{}))
-	zoneName := "Standalone"
-	if b.Config().Mode == config_core.Zone {
-		zoneName = b.Config().Multizone.Zone.Name
-	}
+	zoneName := core_metrics.ZoneNameOrMode(b.Config().Mode, b.Config().Multizone.Zone.Name)
 	metrics, err := core_metrics.NewMetricsOfRegistererGatherer(zoneName, kube_metrics.Registry)
 	if err != nil {
 		return err


### PR DESCRIPTION
Otherwise we get different "zone" in metrics for global cp

![image](https://github.com/kumahq/kuma/assets/2753650/8c59d67d-8032-470a-86eb-333f3ed2e861)

vs 

<img width="312" alt="image" src="https://github.com/kumahq/kuma/assets/2753650/072f2bfe-f432-470c-a7b0-b623a154a7ee">

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [X] [Link to relevant issue][1] as well as docs and UI issues -- not reported by issue
- [X] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [X] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [X] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [X] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
