### PR TITLE
chore(kuma-cp): remove PseudoMeta, we already have test_model.ResourceMeta

### DIFF
--- a/pkg/xds/topology/router.go
+++ b/pkg/xds/topology/router.go
@@ -2,7 +2,6 @@ package topology
 
 import (
 	"context"
-	"time"
 
 	"google.golang.org/protobuf/proto"
 
@@ -10,38 +9,9 @@ import (
 	"github.com/kumahq/kuma/pkg/core/policy"
 	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	core_manager "github.com/kumahq/kuma/pkg/core/resources/manager"
-	core_model "github.com/kumahq/kuma/pkg/core/resources/model"
 	core_store "github.com/kumahq/kuma/pkg/core/resources/store"
 	core_xds "github.com/kumahq/kuma/pkg/core/xds"
 )
-
-type pseudoMeta struct {
-	Name string
-}
-
-func (m *pseudoMeta) GetMesh() string {
-	return ""
-}
-
-func (m *pseudoMeta) GetName() string {
-	return m.Name
-}
-
-func (m *pseudoMeta) GetNameExtensions() core_model.ResourceNameExtensions {
-	return core_model.ResourceNameExtensionsUnsupported
-}
-
-func (m *pseudoMeta) GetVersion() string {
-	return ""
-}
-
-func (m *pseudoMeta) GetCreationTime() time.Time {
-	return time.Now()
-}
-
-func (m *pseudoMeta) GetModificationTime() time.Time {
-	return time.Now()
-}
 
 // GetRoutes picks a single the most specific route for each outbound interface of a given Dataplane.
 func GetRoutes(ctx context.Context, dataplane *core_mesh.DataplaneResource, manager core_manager.ReadOnlyResourceManager) (core_xds.RouteMap, error) {

--- a/pkg/xds/topology/router_helper_test.go
+++ b/pkg/xds/topology/router_helper_test.go
@@ -1,3 +1,0 @@
-package topology
-
-type PseudoMeta = pseudoMeta

--- a/pkg/xds/topology/router_test.go
+++ b/pkg/xds/topology/router_test.go
@@ -613,7 +613,7 @@ var _ = Describe("TrafficRoute", func() {
 				},
 				routes: []*core_mesh.TrafficRouteResource{
 					{
-						Meta: &PseudoMeta{
+						Meta: &test_model.ResourceMeta{
 							Name: "route-all-default",
 						},
 						Spec: &mesh_proto.TrafficRoute{
@@ -643,7 +643,7 @@ var _ = Describe("TrafficRoute", func() {
 						DataplaneIP:   "127.0.0.1",
 						DataplanePort: 1234,
 					}: &core_mesh.TrafficRouteResource{
-						Meta: &PseudoMeta{
+						Meta: &test_model.ResourceMeta{
 							Name: "route-all-default",
 						},
 						Spec: &mesh_proto.TrafficRoute{
@@ -667,7 +667,7 @@ var _ = Describe("TrafficRoute", func() {
 						DataplaneIP:   "127.0.0.1",
 						DataplanePort: 1235,
 					}: &core_mesh.TrafficRouteResource{
-						Meta: &PseudoMeta{
+						Meta: &test_model.ResourceMeta{
 							Name: "route-all-default",
 						},
 						Spec: &mesh_proto.TrafficRoute{
@@ -715,7 +715,7 @@ var _ = Describe("TrafficRoute", func() {
 				},
 				routes: []*core_mesh.TrafficRouteResource{
 					{
-						Meta: &PseudoMeta{
+						Meta: &test_model.ResourceMeta{
 							Name: "route-all-default",
 						},
 						Spec: &mesh_proto.TrafficRoute{
@@ -766,7 +766,7 @@ var _ = Describe("TrafficRoute", func() {
 						DataplaneIP:   "127.0.0.1",
 						DataplanePort: 1234,
 					}: &core_mesh.TrafficRouteResource{
-						Meta: &PseudoMeta{
+						Meta: &test_model.ResourceMeta{
 							Name: "route-all-default",
 						},
 						Spec: &mesh_proto.TrafficRoute{


### PR DESCRIPTION
I'm going to extend the ResourceMeta interface with the GetLabels method, so I looked through existing implementations to remove implementations we don't need.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [X] [Link to relevant issue][1] as well as docs and UI issues --
- [X] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [X] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [X] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [X] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
