### PR TITLE
chore(kuma-cp): allow to pass more apiWebServiceCustomize fns

### DIFF
--- a/pkg/core/runtime/builder.go
+++ b/pkg/core/runtime/builder.go
@@ -103,7 +103,7 @@ type Builder struct {
 	*runtimeInfo
 	pgxConfigCustomizationFn config.PgxConfigCustomization
 	tenants                  multitenant.Tenants
-	apiWebServiceCustomize   func(*restful.WebService) error
+	apiWebServiceCustomize   []func(*restful.WebService) error
 }
 
 func BuilderFor(appCtx context.Context, cfg kuma_cp.Config) (*Builder, error) {
@@ -290,7 +290,7 @@ func (b *Builder) WithPgxConfigCustomizationFn(pgxConfigCustomizationFn config.P
 }
 
 func (b *Builder) WithAPIWebServiceCustomize(customize func(*restful.WebService) error) *Builder {
-	b.apiWebServiceCustomize = customize
+	b.apiWebServiceCustomize = append(b.apiWebServiceCustomize, customize)
 	return b
 }
 
@@ -542,9 +542,6 @@ func (b *Builder) Tenants() multitenant.Tenants {
 	return b.tenants
 }
 
-func (b *Builder) APIWebServiceCustomize() func(*restful.WebService) error {
-	if b.apiWebServiceCustomize == nil {
-		return func(*restful.WebService) error { return nil }
-	}
+func (b *Builder) APIWebServiceCustomize() []func(*restful.WebService) error {
 	return b.apiWebServiceCustomize
 }

--- a/pkg/core/runtime/runtime_suite_test.go
+++ b/pkg/core/runtime/runtime_suite_test.go
@@ -1,0 +1,11 @@
+package runtime_test
+
+import (
+	"testing"
+
+	"github.com/kumahq/kuma/pkg/test"
+)
+
+func TestRuntime(t *testing.T) {
+	test.RunSpecs(t, "Runtime Suite")
+}

--- a/pkg/core/runtime/runtime_test.go
+++ b/pkg/core/runtime/runtime_test.go
@@ -1,0 +1,73 @@
+package runtime_test
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/emicklei/go-restful/v3"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	kuma_cp "github.com/kumahq/kuma/pkg/config/app/kuma-cp"
+	test_api_server "github.com/kumahq/kuma/pkg/test/api_server"
+	test_runtime "github.com/kumahq/kuma/pkg/test/runtime"
+)
+
+func return200ForPath(path string) func(ws *restful.WebService) error {
+	return func(ws *restful.WebService) error {
+		ws.Route(
+			ws.GET(path).To(func(req *restful.Request, res *restful.Response) {
+				res.WriteHeader(http.StatusOK)
+			}),
+		)
+
+		return nil
+	}
+}
+
+var _ = Describe("APIWebServiceCustomize", func() {
+	var stop chan struct{}
+
+	AfterEach(func() {
+		if stop != nil {
+			close(stop)
+		}
+	})
+
+	It("should allow for multiple customization functions", func() {
+		// given
+		cfg := kuma_cp.DefaultConfig()
+		cfg.ApiServer.HTTPS.Enabled = false
+		cfg.ApiServer.HTTP.Interface = "127.0.0.1"
+		builder, err := test_runtime.BuilderFor(context.Background(), cfg)
+		Expect(err).ToNot(HaveOccurred())
+
+		// when
+		rt, err := builder.
+			WithAPIWebServiceCustomize(return200ForPath("/foo")).
+			WithAPIWebServiceCustomize(return200ForPath("/bar")).
+			Build()
+		Expect(err).ToNot(HaveOccurred())
+
+		apiServer, err := test_api_server.NewApiServer(cfg, rt)
+		Expect(err).To(Succeed())
+
+		stop = make(chan struct{})
+		go func() {
+			defer GinkgoRecover()
+
+			Expect(apiServer.Start(stop)).To(Succeed())
+		}()
+
+		// then
+		Eventually(func(g Gomega) {
+			fooRes, err := http.Get("http://" + apiServer.Address() + "/foo")
+			g.Expect(err).To(Succeed())
+			g.Expect(fooRes.StatusCode).To(Equal(http.StatusOK))
+
+			barRes, err := http.Get("http://" + apiServer.Address() + "/bar")
+			g.Expect(err).To(Succeed())
+			g.Expect(barRes.StatusCode).To(Equal(http.StatusOK))
+		}).Should(Succeed())
+	})
+})

--- a/pkg/test/api_server/api_server.go
+++ b/pkg/test/api_server/api_server.go
@@ -1,0 +1,46 @@
+package api_server
+
+import (
+	"net"
+
+	"github.com/kumahq/kuma/pkg/api-server"
+	"github.com/kumahq/kuma/pkg/config/app/kuma-cp"
+	"github.com/kumahq/kuma/pkg/core/resources/model"
+	"github.com/kumahq/kuma/pkg/core/resources/registry"
+	"github.com/kumahq/kuma/pkg/core/runtime"
+	"github.com/kumahq/kuma/pkg/dns/vips"
+	"github.com/kumahq/kuma/pkg/xds/context"
+	"github.com/kumahq/kuma/pkg/xds/server"
+)
+
+func NewApiServer(cfg kuma_cp.Config, runtime runtime.Runtime) (*api_server.ApiServer, error) {
+	return api_server.NewApiServer(
+		runtime.ResourceManager(),
+		context.NewMeshContextBuilder(
+			runtime.ResourceManager(),
+			server.MeshResourceTypes(),
+			net.LookupIP,
+			cfg.Multizone.Zone.Name,
+			vips.NewPersistence(
+				runtime.ResourceManager(),
+				runtime.ConfigManager(),
+				cfg.Experimental.UseTagFirstVirtualOutboundModel,
+			),
+			cfg.DNSServer.Domain,
+			cfg.DNSServer.ServiceVipPort,
+			context.AnyToAnyReachableServicesGraphBuilder,
+		),
+		runtime.APIInstaller(),
+		registry.Global().ObjectDescriptors(model.HasWsEnabled()),
+		&cfg,
+		runtime.Metrics(),
+		runtime.GetInstanceId,
+		runtime.GetClusterId,
+		runtime.APIServerAuthenticator(),
+		runtime.Access(),
+		runtime.EnvoyAdminClient(),
+		runtime.TokenIssuers(),
+		runtime.APIWebServiceCustomize(),
+		runtime.GlobalInsightService(),
+	)
+}

--- a/pkg/test/runtime/runtime.go
+++ b/pkg/test/runtime/runtime.go
@@ -30,6 +30,7 @@ import (
 	secret_store "github.com/kumahq/kuma/pkg/core/secrets/store"
 	"github.com/kumahq/kuma/pkg/dns/vips"
 	"github.com/kumahq/kuma/pkg/dp-server/server"
+	"github.com/kumahq/kuma/pkg/envoy/admin/access"
 	"github.com/kumahq/kuma/pkg/events"
 	"github.com/kumahq/kuma/pkg/intercp"
 	kds_context "github.com/kumahq/kuma/pkg/kds/context"
@@ -131,6 +132,7 @@ func BuilderFor(appCtx context.Context, cfg kuma_cp.Config) (*core_runtime.Build
 	builder.WithAccess(core_runtime.Access{
 		ResourceAccess:       resources_access.NewAdminResourceAccess(builder.Config().Access.Static.AdminResources),
 		DataplaneTokenAccess: tokens_access.NewStaticGenerateDataplaneTokenAccess(builder.Config().Access.Static.GenerateDPToken),
+		EnvoyAdminAccess:     access.NoopEnvoyAdminAccess{},
 	})
 	builder.WithTokenIssuers(tokens_builtin.TokenIssuers{
 		DataplaneToken:   tokens_builtin.NewDataplaneTokenIssuer(builder.ResourceManager()),


### PR DESCRIPTION
So far when used `WithAPIWebServiceCustomize` more than once, only the last function was being used and others silently ignored. Now we can customize WebService multiple times

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues
  - no relevant issue
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS
  - it won't
- [ ] Tests (Unit test, E2E tests, manual test on universal and k8s)
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)?
  - there is no need
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label)
  - there is no need

> Changelog: skip

<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
