### PR TITLE
ci(actions): fixing make check failure caused by YAML formatting

### DIFF
--- a/.github/actions/e2e/action.yaml
+++ b/.github/actions/e2e/action.yaml
@@ -21,7 +21,7 @@ inputs:
     description: The CNI networking plugin to use [flannel | calico]
     default: flannel
     required: false
-  deltaKDS:
+  legacyKDS:
     description: if should run tests with new implementation of KDS
     default: 'false'
     required: false
@@ -38,7 +38,7 @@ runs:
             cniNetworkPlugin: ${{ inputs.cniNetworkPlugin }} \
             "
       shell: bash
-    - id: random-number-generator
+    - id: circleci-trigger
       run: |
         echo "Invoking CircleCI (todo)"
       shell: bash

--- a/.github/workflows/build-test-distribute.yaml
+++ b/.github/workflows/build-test-distribute.yaml
@@ -206,7 +206,7 @@ jobs:
               {"legacyKDS": true},
               {"target": "kubernetes", "k8sVersion":"kind"},
               {"target": "multizone", "k8sVersion":"kind"},
-              {"target":"universal", "k8sVersion":"${{ env.K8S_MIN_VERSION }}"}, 
+              {"target":"universal", "k8sVersion":"${{ env.K8S_MIN_VERSION }}"},
               {"target":"universal", "k8sVersion":"${{ env.K8S_MAX_VERSION }}"}
             ],
             "include":[

--- a/.github/workflows/build-test-distribute.yaml
+++ b/.github/workflows/build-test-distribute.yaml
@@ -216,7 +216,7 @@ jobs:
           }
           END
           )
-          
+
           MATRIX_SLOW=$(echo $BASE_MATRIX_SLOW | jq -rc)
           MATRIX_ENV=$(echo $BASE_MATRIX_ENV | jq -rc)
 
@@ -225,7 +225,7 @@ jobs:
             echo "Skipping non priority e2e tests, because no label 'ci/run-full-matrix' was found on the pull request and not pushing on a releasable branch."
 
             MATRIX_SLOW=''  # target==""
-          
+
             # non priority main e2e
             EXCLUDE_ARM64='[{"arch": "arm64"}]'
             EXCLUDE_MAIN_NON_PRIORITY='[{"k8sVersion":"kindIpv6"}, {"k8sVersion": "${{ env.K8S_MIN_VERSION }}"}]'

--- a/.github/workflows/build-test-distribute.yaml
+++ b/.github/workflows/build-test-distribute.yaml
@@ -186,7 +186,7 @@ jobs:
           sudo apt-get install -y jq
       - id: generate-matrix
         name: Generate matrix
-        run: |
+        run: |-
           BASE_MATRIX_SLOW=$(cat <<-END
           {
             "k8sVersion": ["kind", "kindIpv6", "${{ env.K8S_MIN_VERSION }}", "${{ env.K8S_MAX_VERSION }}"],

--- a/mk/check.mk
+++ b/mk/check.mk
@@ -33,6 +33,7 @@ golangci-lint-fmt:
 .PHONY: fmt/ci
 fmt/ci:
 	$(CI_TOOLS_BIN_DIR)/yq -i '.parameters.go_version.default = "$(GO_VERSION)" | .parameters.first_k8s_version.default = "$(K8S_MIN_VERSION)" | .parameters.last_k8s_version.default = "$(K8S_MAX_VERSION)"' .circleci/config.yml
+	$(CI_TOOLS_BIN_DIR)/yq -i '.env.K8S_MIN_VERSION = "$(K8S_MIN_VERSION)" | .env.K8S_MAX_VERSION = "$(K8S_MAX_VERSION)"' .github/workflows/build-test-distribute.yaml
 	find .github/workflows -name '*ml' | xargs -n 1 $(CI_TOOLS_BIN_DIR)/yq -i '(.jobs.* | select(. | has("steps")) | .steps[] | select(.uses == "golangci/golangci-lint-action*") | .with.version) |= "$(GOLANGCI_LINT_VERSION)"'
 
 .PHONY: helm-lint


### PR DESCRIPTION
### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues
  - Fixes the [GitHub Action Run](https://github.com/kumahq/kuma/actions/runs/6970118730/job/18967372501)
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS
  - Confirmed
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s)
  - Manually tested
  - Don't forget `ci/` labels to run additional/fewer tests
    - Done
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? 
  - No need.
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) 
  - Added

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

This PR fixes the [GitHub Action Run](https://github.com/kumahq/kuma/actions/runs/6970118730/job/18967372501)

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
