### PR TITLE
chore(helm): remove old webhook for injection annotations

### DIFF
--- a/app/kumactl/cmd/install/testdata/install-control-plane.cni-enabled.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.cni-enabled.golden.yaml
@@ -565,7 +565,7 @@ spec:
     metadata:
       annotations:
         checksum/config: fd9d1d8386f97f2bd49e50f476520816168a1c9f60bbc43dec1347a64d239155
-        checksum/tls-secrets: ec0bc0b5613dc75c86fb3dc148f404db4eaec3e3817ee4eba2a70fd1bc535999
+        checksum/tls-secrets: ef229d2d8e83f89fc76345a85158c87105b2b3553cbfbba83b25dce66479a6e3
       labels: 
         app: kuma-control-plane
         app.kubernetes.io/name: kuma
@@ -848,30 +848,6 @@ webhooks:
     objectSelector:
       matchLabels:
         kuma.io/sidecar-injection: enabled
-    clientConfig:
-      caBundle: XYZ
-      service:
-        namespace: kuma-system
-        name: kuma-control-plane
-        path: /inject-sidecar
-    rules:
-      - apiGroups:
-          - ""
-        apiVersions:
-          - v1
-        operations:
-          - CREATE
-        resources:
-          - pods
-    sideEffects: None
-  - name: kuma-injector.kuma.io
-    admissionReviewVersions: ["v1"]
-    failurePolicy: Ignore 
-    namespaceSelector:
-      matchExpressions:
-        - key: kubernetes.io/metadata.name
-          operator: NotIn
-          values: ["kube-system"]
     clientConfig:
       caBundle: XYZ
       service:

--- a/app/kumactl/cmd/install/testdata/install-control-plane.defaults.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.defaults.golden.yaml
@@ -6503,7 +6503,7 @@ spec:
     metadata:
       annotations:
         checksum/config: fd9d1d8386f97f2bd49e50f476520816168a1c9f60bbc43dec1347a64d239155
-        checksum/tls-secrets: ec0bc0b5613dc75c86fb3dc148f404db4eaec3e3817ee4eba2a70fd1bc535999
+        checksum/tls-secrets: ef229d2d8e83f89fc76345a85158c87105b2b3553cbfbba83b25dce66479a6e3
       labels: 
         app: kuma-control-plane
         app.kubernetes.io/name: kuma
@@ -6782,30 +6782,6 @@ webhooks:
     objectSelector:
       matchLabels:
         kuma.io/sidecar-injection: enabled
-    clientConfig:
-      caBundle: XYZ
-      service:
-        namespace: kuma-system
-        name: kuma-control-plane
-        path: /inject-sidecar
-    rules:
-      - apiGroups:
-          - ""
-        apiVersions:
-          - v1
-        operations:
-          - CREATE
-        resources:
-          - pods
-    sideEffects: None
-  - name: kuma-injector.kuma.io
-    admissionReviewVersions: ["v1"]
-    failurePolicy: Ignore 
-    namespaceSelector:
-      matchExpressions:
-        - key: kubernetes.io/metadata.name
-          operator: NotIn
-          values: ["kube-system"]
     clientConfig:
       caBundle: XYZ
       service:

--- a/app/kumactl/cmd/install/testdata/install-control-plane.gateway-api-present-not-enabled.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.gateway-api-present-not-enabled.yaml
@@ -6503,7 +6503,7 @@ spec:
     metadata:
       annotations:
         checksum/config: fd9d1d8386f97f2bd49e50f476520816168a1c9f60bbc43dec1347a64d239155
-        checksum/tls-secrets: ec0bc0b5613dc75c86fb3dc148f404db4eaec3e3817ee4eba2a70fd1bc535999
+        checksum/tls-secrets: ef229d2d8e83f89fc76345a85158c87105b2b3553cbfbba83b25dce66479a6e3
       labels: 
         app: kuma-control-plane
         app.kubernetes.io/name: kuma
@@ -6782,30 +6782,6 @@ webhooks:
     objectSelector:
       matchLabels:
         kuma.io/sidecar-injection: enabled
-    clientConfig:
-      caBundle: XYZ
-      service:
-        namespace: kuma-system
-        name: kuma-control-plane
-        path: /inject-sidecar
-    rules:
-      - apiGroups:
-          - ""
-        apiVersions:
-          - v1
-        operations:
-          - CREATE
-        resources:
-          - pods
-    sideEffects: None
-  - name: kuma-injector.kuma.io
-    admissionReviewVersions: ["v1"]
-    failurePolicy: Ignore 
-    namespaceSelector:
-      matchExpressions:
-        - key: kubernetes.io/metadata.name
-          operator: NotIn
-          values: ["kube-system"]
     clientConfig:
       caBundle: XYZ
       service:

--- a/app/kumactl/cmd/install/testdata/install-control-plane.gateway-api-present.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.gateway-api-present.yaml
@@ -6709,7 +6709,7 @@ spec:
     metadata:
       annotations:
         checksum/config: fd9d1d8386f97f2bd49e50f476520816168a1c9f60bbc43dec1347a64d239155
-        checksum/tls-secrets: ec0bc0b5613dc75c86fb3dc148f404db4eaec3e3817ee4eba2a70fd1bc535999
+        checksum/tls-secrets: ef229d2d8e83f89fc76345a85158c87105b2b3553cbfbba83b25dce66479a6e3
       labels: 
         app: kuma-control-plane
         app.kubernetes.io/name: kuma
@@ -6997,30 +6997,6 @@ webhooks:
     objectSelector:
       matchLabels:
         kuma.io/sidecar-injection: enabled
-    clientConfig:
-      caBundle: XYZ
-      service:
-        namespace: kuma-system
-        name: kuma-control-plane
-        path: /inject-sidecar
-    rules:
-      - apiGroups:
-          - ""
-        apiVersions:
-          - v1
-        operations:
-          - CREATE
-        resources:
-          - pods
-    sideEffects: None
-  - name: kuma-injector.kuma.io
-    admissionReviewVersions: ["v1"]
-    failurePolicy: Ignore 
-    namespaceSelector:
-      matchExpressions:
-        - key: kubernetes.io/metadata.name
-          operator: NotIn
-          values: ["kube-system"]
     clientConfig:
       caBundle: XYZ
       service:

--- a/app/kumactl/cmd/install/testdata/install-control-plane.override-env-vars.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.override-env-vars.golden.yaml
@@ -351,7 +351,7 @@ spec:
     metadata:
       annotations:
         checksum/config: fd9d1d8386f97f2bd49e50f476520816168a1c9f60bbc43dec1347a64d239155
-        checksum/tls-secrets: ec0bc0b5613dc75c86fb3dc148f404db4eaec3e3817ee4eba2a70fd1bc535999
+        checksum/tls-secrets: ef229d2d8e83f89fc76345a85158c87105b2b3553cbfbba83b25dce66479a6e3
       labels: 
         app: kuma-control-plane
         app.kubernetes.io/name: kuma
@@ -630,30 +630,6 @@ webhooks:
     objectSelector:
       matchLabels:
         kuma.io/sidecar-injection: enabled
-    clientConfig:
-      caBundle: XYZ
-      service:
-        namespace: kuma-system
-        name: kuma-control-plane
-        path: /inject-sidecar
-    rules:
-      - apiGroups:
-          - ""
-        apiVersions:
-          - v1
-        operations:
-          - CREATE
-        resources:
-          - pods
-    sideEffects: None
-  - name: kuma-injector.kuma.io
-    admissionReviewVersions: ["v1"]
-    failurePolicy: Ignore 
-    namespaceSelector:
-      matchExpressions:
-        - key: kubernetes.io/metadata.name
-          operator: NotIn
-          values: ["kube-system"]
     clientConfig:
       caBundle: XYZ
       service:

--- a/app/kumactl/cmd/install/testdata/install-control-plane.overrides.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.overrides.golden.yaml
@@ -353,7 +353,7 @@ spec:
     metadata:
       annotations:
         checksum/config: 154c47a95fc93687dd1e825cea7f843d0fe8c450f82014d27cd7eb1a49f3bd35
-        checksum/tls-secrets: 74d9573a31dfa8171397dc0692e08ce3032ed6976cd073b893b51a2289a09338
+        checksum/tls-secrets: 3aeba87ff12b47b7074c452407f925cdbc3e2edc608b2592efa1081ac26dc7dd
       labels: 
         app: kuma-control-plane
         app.kubernetes.io/name: kuma
@@ -667,30 +667,6 @@ webhooks:
     objectSelector:
       matchLabels:
         kuma.io/sidecar-injection: enabled
-    clientConfig:
-      caBundle: XYZ
-      service:
-        namespace: kuma
-        name: kuma-ctrl-plane
-        path: /inject-sidecar
-    rules:
-      - apiGroups:
-          - ""
-        apiVersions:
-          - v1
-        operations:
-          - CREATE
-        resources:
-          - pods
-    sideEffects: None
-  - name: kuma-injector.kuma.io
-    admissionReviewVersions: ["v1"]
-    failurePolicy: Ignore 
-    namespaceSelector:
-      matchExpressions:
-        - key: kubernetes.io/metadata.name
-          operator: NotIn
-          values: ["kube-system"]
     clientConfig:
       caBundle: XYZ
       service:

--- a/app/kumactl/cmd/install/testdata/install-control-plane.registry.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.registry.golden.yaml
@@ -351,7 +351,7 @@ spec:
     metadata:
       annotations:
         checksum/config: fd9d1d8386f97f2bd49e50f476520816168a1c9f60bbc43dec1347a64d239155
-        checksum/tls-secrets: ec0bc0b5613dc75c86fb3dc148f404db4eaec3e3817ee4eba2a70fd1bc535999
+        checksum/tls-secrets: ef229d2d8e83f89fc76345a85158c87105b2b3553cbfbba83b25dce66479a6e3
       labels: 
         app: kuma-control-plane
         app.kubernetes.io/name: kuma
@@ -630,30 +630,6 @@ webhooks:
     objectSelector:
       matchLabels:
         kuma.io/sidecar-injection: enabled
-    clientConfig:
-      caBundle: XYZ
-      service:
-        namespace: kuma-system
-        name: kuma-control-plane
-        path: /inject-sidecar
-    rules:
-      - apiGroups:
-          - ""
-        apiVersions:
-          - v1
-        operations:
-          - CREATE
-        resources:
-          - pods
-    sideEffects: None
-  - name: kuma-injector.kuma.io
-    admissionReviewVersions: ["v1"]
-    failurePolicy: Ignore 
-    namespaceSelector:
-      matchExpressions:
-        - key: kubernetes.io/metadata.name
-          operator: NotIn
-          values: ["kube-system"]
     clientConfig:
       caBundle: XYZ
       service:

--- a/app/kumactl/cmd/install/testdata/install-control-plane.tproxy-ebpf-experimental-enabled.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.tproxy-ebpf-experimental-enabled.golden.yaml
@@ -351,7 +351,7 @@ spec:
     metadata:
       annotations:
         checksum/config: fd9d1d8386f97f2bd49e50f476520816168a1c9f60bbc43dec1347a64d239155
-        checksum/tls-secrets: ec0bc0b5613dc75c86fb3dc148f404db4eaec3e3817ee4eba2a70fd1bc535999
+        checksum/tls-secrets: ef229d2d8e83f89fc76345a85158c87105b2b3553cbfbba83b25dce66479a6e3
       labels: 
         app: kuma-control-plane
         app.kubernetes.io/name: kuma
@@ -640,30 +640,6 @@ webhooks:
     objectSelector:
       matchLabels:
         kuma.io/sidecar-injection: enabled
-    clientConfig:
-      caBundle: XYZ
-      service:
-        namespace: kuma-system
-        name: kuma-control-plane
-        path: /inject-sidecar
-    rules:
-      - apiGroups:
-          - ""
-        apiVersions:
-          - v1
-        operations:
-          - CREATE
-        resources:
-          - pods
-    sideEffects: None
-  - name: kuma-injector.kuma.io
-    admissionReviewVersions: ["v1"]
-    failurePolicy: Ignore 
-    namespaceSelector:
-      matchExpressions:
-        - key: kubernetes.io/metadata.name
-          operator: NotIn
-          values: ["kube-system"]
     clientConfig:
       caBundle: XYZ
       service:

--- a/app/kumactl/cmd/install/testdata/install-control-plane.with-egress.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.with-egress.golden.yaml
@@ -382,7 +382,7 @@ spec:
     metadata:
       annotations:
         checksum/config: fd9d1d8386f97f2bd49e50f476520816168a1c9f60bbc43dec1347a64d239155
-        checksum/tls-secrets: ec0bc0b5613dc75c86fb3dc148f404db4eaec3e3817ee4eba2a70fd1bc535999
+        checksum/tls-secrets: ef229d2d8e83f89fc76345a85158c87105b2b3553cbfbba83b25dce66479a6e3
       labels: 
         app: kuma-control-plane
         app.kubernetes.io/name: kuma
@@ -790,30 +790,6 @@ webhooks:
     objectSelector:
       matchLabels:
         kuma.io/sidecar-injection: enabled
-    clientConfig:
-      caBundle: XYZ
-      service:
-        namespace: kuma-system
-        name: kuma-control-plane
-        path: /inject-sidecar
-    rules:
-      - apiGroups:
-          - ""
-        apiVersions:
-          - v1
-        operations:
-          - CREATE
-        resources:
-          - pods
-    sideEffects: None
-  - name: kuma-injector.kuma.io
-    admissionReviewVersions: ["v1"]
-    failurePolicy: Ignore 
-    namespaceSelector:
-      matchExpressions:
-        - key: kubernetes.io/metadata.name
-          operator: NotIn
-          values: ["kube-system"]
     clientConfig:
       caBundle: XYZ
       service:

--- a/app/kumactl/cmd/install/testdata/install-control-plane.with-helm-set.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.with-helm-set.yaml
@@ -6565,7 +6565,7 @@ spec:
     metadata:
       annotations:
         checksum/config: fd9d1d8386f97f2bd49e50f476520816168a1c9f60bbc43dec1347a64d239155
-        checksum/tls-secrets: ec0bc0b5613dc75c86fb3dc148f404db4eaec3e3817ee4eba2a70fd1bc535999
+        checksum/tls-secrets: ef229d2d8e83f89fc76345a85158c87105b2b3553cbfbba83b25dce66479a6e3
       labels: 
         app: kuma-control-plane
         app.kubernetes.io/name: kuma
@@ -7108,30 +7108,6 @@ webhooks:
     objectSelector:
       matchLabels:
         kuma.io/sidecar-injection: enabled
-    clientConfig:
-      caBundle: XYZ
-      service:
-        namespace: kuma-system
-        name: kuma-control-plane
-        path: /inject-sidecar
-    rules:
-      - apiGroups:
-          - ""
-        apiVersions:
-          - v1
-        operations:
-          - CREATE
-        resources:
-          - pods
-    sideEffects: None
-  - name: kuma-injector.kuma.io
-    admissionReviewVersions: ["v1"]
-    failurePolicy: Ignore 
-    namespaceSelector:
-      matchExpressions:
-        - key: kubernetes.io/metadata.name
-          operator: NotIn
-          values: ["kube-system"]
     clientConfig:
       caBundle: XYZ
       service:

--- a/app/kumactl/cmd/install/testdata/install-control-plane.with-helm-values.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.with-helm-values.yaml
@@ -351,7 +351,7 @@ spec:
     metadata:
       annotations:
         checksum/config: fd9d1d8386f97f2bd49e50f476520816168a1c9f60bbc43dec1347a64d239155
-        checksum/tls-secrets: ec0bc0b5613dc75c86fb3dc148f404db4eaec3e3817ee4eba2a70fd1bc535999
+        checksum/tls-secrets: ef229d2d8e83f89fc76345a85158c87105b2b3553cbfbba83b25dce66479a6e3
       labels: 
         app: kuma-control-plane
         app.kubernetes.io/name: kuma
@@ -630,30 +630,6 @@ webhooks:
     objectSelector:
       matchLabels:
         kuma.io/sidecar-injection: enabled
-    clientConfig:
-      caBundle: XYZ
-      service:
-        namespace: kuma-system
-        name: kuma-control-plane
-        path: /inject-sidecar
-    rules:
-      - apiGroups:
-          - ""
-        apiVersions:
-          - v1
-        operations:
-          - CREATE
-        resources:
-          - pods
-    sideEffects: None
-  - name: kuma-injector.kuma.io
-    admissionReviewVersions: ["v1"]
-    failurePolicy: Ignore 
-    namespaceSelector:
-      matchExpressions:
-        - key: kubernetes.io/metadata.name
-          operator: NotIn
-          values: ["kube-system"]
     clientConfig:
       caBundle: XYZ
       service:

--- a/app/kumactl/cmd/install/testdata/install-control-plane.with-ingress.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.with-ingress.golden.yaml
@@ -382,7 +382,7 @@ spec:
     metadata:
       annotations:
         checksum/config: fd9d1d8386f97f2bd49e50f476520816168a1c9f60bbc43dec1347a64d239155
-        checksum/tls-secrets: ec0bc0b5613dc75c86fb3dc148f404db4eaec3e3817ee4eba2a70fd1bc535999
+        checksum/tls-secrets: ef229d2d8e83f89fc76345a85158c87105b2b3553cbfbba83b25dce66479a6e3
       labels: 
         app: kuma-control-plane
         app.kubernetes.io/name: kuma
@@ -796,30 +796,6 @@ webhooks:
     objectSelector:
       matchLabels:
         kuma.io/sidecar-injection: enabled
-    clientConfig:
-      caBundle: XYZ
-      service:
-        namespace: kuma-system
-        name: kuma-control-plane
-        path: /inject-sidecar
-    rules:
-      - apiGroups:
-          - ""
-        apiVersions:
-          - v1
-        operations:
-          - CREATE
-        resources:
-          - pods
-    sideEffects: None
-  - name: kuma-injector.kuma.io
-    admissionReviewVersions: ["v1"]
-    failurePolicy: Ignore 
-    namespaceSelector:
-      matchExpressions:
-        - key: kubernetes.io/metadata.name
-          operator: NotIn
-          values: ["kube-system"]
     clientConfig:
       caBundle: XYZ
       service:

--- a/app/kumactl/cmd/install/testdata/install-control-plane.zone.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.zone.golden.yaml
@@ -351,7 +351,7 @@ spec:
     metadata:
       annotations:
         checksum/config: fd9d1d8386f97f2bd49e50f476520816168a1c9f60bbc43dec1347a64d239155
-        checksum/tls-secrets: ec0bc0b5613dc75c86fb3dc148f404db4eaec3e3817ee4eba2a70fd1bc535999
+        checksum/tls-secrets: ef229d2d8e83f89fc76345a85158c87105b2b3553cbfbba83b25dce66479a6e3
       labels: 
         app: kuma-control-plane
         app.kubernetes.io/name: kuma
@@ -634,30 +634,6 @@ webhooks:
     objectSelector:
       matchLabels:
         kuma.io/sidecar-injection: enabled
-    clientConfig:
-      caBundle: XYZ
-      service:
-        namespace: kuma-system
-        name: kuma-control-plane
-        path: /inject-sidecar
-    rules:
-      - apiGroups:
-          - ""
-        apiVersions:
-          - v1
-        operations:
-          - CREATE
-        resources:
-          - pods
-    sideEffects: None
-  - name: kuma-injector.kuma.io
-    admissionReviewVersions: ["v1"]
-    failurePolicy: Ignore 
-    namespaceSelector:
-      matchExpressions:
-        - key: kubernetes.io/metadata.name
-          operator: NotIn
-          values: ["kube-system"]
     clientConfig:
       caBundle: XYZ
       service:

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/doNotChangeTlsChecksum.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/doNotChangeTlsChecksum.golden.yaml
@@ -645,30 +645,6 @@ webhooks:
         resources:
           - pods
     sideEffects: None
-  - name: kuma-injector.kuma.io
-    admissionReviewVersions: ["v1"]
-    failurePolicy: Ignore 
-    namespaceSelector:
-      matchExpressions:
-        - key: kubernetes.io/metadata.name
-          operator: NotIn
-          values: ["kube-system"]
-    clientConfig:
-      caBundle: XYZ
-      service:
-        namespace: kuma-system
-        name: kuma-control-plane
-        path: /inject-sidecar
-    rules:
-      - apiGroups:
-          - ""
-        apiVersions:
-          - v1
-        operations:
-          - CREATE
-        resources:
-          - pods
-    sideEffects: None
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/empty.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/empty.golden.yaml
@@ -351,7 +351,7 @@ spec:
     metadata:
       annotations:
         checksum/config: fd9d1d8386f97f2bd49e50f476520816168a1c9f60bbc43dec1347a64d239155
-        checksum/tls-secrets: ec0bc0b5613dc75c86fb3dc148f404db4eaec3e3817ee4eba2a70fd1bc535999
+        checksum/tls-secrets: ef229d2d8e83f89fc76345a85158c87105b2b3553cbfbba83b25dce66479a6e3
       labels: 
         app: kuma-control-plane
         app.kubernetes.io/name: kuma
@@ -630,30 +630,6 @@ webhooks:
     objectSelector:
       matchLabels:
         kuma.io/sidecar-injection: enabled
-    clientConfig:
-      caBundle: XYZ
-      service:
-        namespace: kuma-system
-        name: kuma-control-plane
-        path: /inject-sidecar
-    rules:
-      - apiGroups:
-          - ""
-        apiVersions:
-          - v1
-        operations:
-          - CREATE
-        resources:
-          - pods
-    sideEffects: None
-  - name: kuma-injector.kuma.io
-    admissionReviewVersions: ["v1"]
-    failurePolicy: Ignore 
-    namespaceSelector:
-      matchExpressions:
-        - key: kubernetes.io/metadata.name
-          operator: NotIn
-          values: ["kube-system"]
     clientConfig:
       caBundle: XYZ
       service:

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/fix4485.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/fix4485.golden.yaml
@@ -373,7 +373,7 @@ spec:
     metadata:
       annotations:
         checksum/config: 3a137bbfcbbe6ba5a3997b30b1b047b2b080a9f912520a5fa683f11c4c6b6f3c
-        checksum/tls-secrets: 0aa16161b78299954cdd990017f8466194fb21f0ce2655a6e0593b7effb20760
+        checksum/tls-secrets: e68055a5f807d40c227179eff2841dea4ad0c3bc8f61799374ae1517d9d29490
       labels: 
         app: kuma-control-plane
         "foo": "baz"
@@ -660,30 +660,6 @@ webhooks:
     objectSelector:
       matchLabels:
         kuma.io/sidecar-injection: enabled
-    clientConfig:
-      caBundle: XYZ
-      service:
-        namespace: kuma-system
-        name: kuma-control-plane
-        path: /inject-sidecar
-    rules:
-      - apiGroups:
-          - ""
-        apiVersions:
-          - v1
-        operations:
-          - CREATE
-        resources:
-          - pods
-    sideEffects: None
-  - name: kuma-injector.kuma.io
-    admissionReviewVersions: ["v1"]
-    failurePolicy: Ignore 
-    namespaceSelector:
-      matchExpressions:
-        - key: kubernetes.io/metadata.name
-          operator: NotIn
-          values: ["kube-system"]
     clientConfig:
       caBundle: XYZ
       service:

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/fix4496.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/fix4496.golden.yaml
@@ -392,7 +392,7 @@ spec:
     metadata:
       annotations:
         checksum/config: 2f553eadd8f68661f4b1fd0b3ccbbc562943d89fa76f2f2ba2975541290fda71
-        checksum/tls-secrets: 898408447c01709a9e7cb02e9250f64d1c84589507dc58042520d76cfa8a9c34
+        checksum/tls-secrets: 3b3d8ecf760b979e540444ea6101495dd56d5228620a8604dcac2f6a12764231
       labels: 
         app: kuma-control-plane
         "foo": "bar"
@@ -834,30 +834,6 @@ webhooks:
     objectSelector:
       matchLabels:
         kuma.io/sidecar-injection: enabled
-    clientConfig:
-      caBundle: XYZ
-      service:
-        namespace: kuma-system
-        name: kuma-control-plane
-        path: /inject-sidecar
-    rules:
-      - apiGroups:
-          - ""
-        apiVersions:
-          - v1
-        operations:
-          - CREATE
-        resources:
-          - pods
-    sideEffects: None
-  - name: kuma-injector.kuma.io
-    admissionReviewVersions: ["v1"]
-    failurePolicy: Ignore 
-    namespaceSelector:
-      matchExpressions:
-        - key: kubernetes.io/metadata.name
-          operator: NotIn
-          values: ["kube-system"]
     clientConfig:
       caBundle: XYZ
       service:

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/fix4935.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/fix4935.golden.yaml
@@ -635,7 +635,7 @@ spec:
     metadata:
       annotations:
         checksum/config: fd9d1d8386f97f2bd49e50f476520816168a1c9f60bbc43dec1347a64d239155
-        checksum/tls-secrets: ec0bc0b5613dc75c86fb3dc148f404db4eaec3e3817ee4eba2a70fd1bc535999
+        checksum/tls-secrets: ef229d2d8e83f89fc76345a85158c87105b2b3553cbfbba83b25dce66479a6e3
         bim: "bam"
         foo: "{\"bar\": \"baz\"}"
       labels: 
@@ -1216,30 +1216,6 @@ webhooks:
     objectSelector:
       matchLabels:
         kuma.io/sidecar-injection: enabled
-    clientConfig:
-      caBundle: XYZ
-      service:
-        namespace: kuma-system
-        name: kuma-control-plane
-        path: /inject-sidecar
-    rules:
-      - apiGroups:
-          - ""
-        apiVersions:
-          - v1
-        operations:
-          - CREATE
-        resources:
-          - pods
-    sideEffects: None
-  - name: kuma-injector.kuma.io
-    admissionReviewVersions: ["v1"]
-    failurePolicy: Ignore 
-    namespaceSelector:
-      matchExpressions:
-        - key: kubernetes.io/metadata.name
-          operator: NotIn
-          values: ["kube-system"]
     clientConfig:
       caBundle: XYZ
       service:

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/fix5978.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/fix5978.golden.yaml
@@ -413,7 +413,7 @@ spec:
     metadata:
       annotations:
         checksum/config: fd9d1d8386f97f2bd49e50f476520816168a1c9f60bbc43dec1347a64d239155
-        checksum/tls-secrets: ec0bc0b5613dc75c86fb3dc148f404db4eaec3e3817ee4eba2a70fd1bc535999
+        checksum/tls-secrets: ef229d2d8e83f89fc76345a85158c87105b2b3553cbfbba83b25dce66479a6e3
       labels: 
         app: kuma-control-plane
         app.kubernetes.io/name: kuma
@@ -959,30 +959,6 @@ webhooks:
     objectSelector:
       matchLabels:
         kuma.io/sidecar-injection: enabled
-    clientConfig:
-      caBundle: XYZ
-      service:
-        namespace: kuma-system
-        name: kuma-control-plane
-        path: /inject-sidecar
-    rules:
-      - apiGroups:
-          - ""
-        apiVersions:
-          - v1
-        operations:
-          - CREATE
-        resources:
-          - pods
-    sideEffects: None
-  - name: kuma-injector.kuma.io
-    admissionReviewVersions: ["v1"]
-    failurePolicy: Ignore 
-    namespaceSelector:
-      matchExpressions:
-        - key: kubernetes.io/metadata.name
-          operator: NotIn
-          values: ["kube-system"]
     clientConfig:
       caBundle: XYZ
       service:

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/fix7724.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/fix7724.golden.yaml
@@ -354,7 +354,7 @@ spec:
     metadata:
       annotations:
         checksum/config: fd9d1d8386f97f2bd49e50f476520816168a1c9f60bbc43dec1347a64d239155
-        checksum/tls-secrets: ec0bc0b5613dc75c86fb3dc148f404db4eaec3e3817ee4eba2a70fd1bc535999
+        checksum/tls-secrets: ef229d2d8e83f89fc76345a85158c87105b2b3553cbfbba83b25dce66479a6e3
       labels: 
         app: kuma-control-plane
         app.kubernetes.io/name: kuma
@@ -633,30 +633,6 @@ webhooks:
     objectSelector:
       matchLabels:
         kuma.io/sidecar-injection: enabled
-    clientConfig:
-      caBundle: XYZ
-      service:
-        namespace: kuma-system
-        name: kuma-control-plane
-        path: /inject-sidecar
-    rules:
-      - apiGroups:
-          - ""
-        apiVersions:
-          - v1
-        operations:
-          - CREATE
-        resources:
-          - pods
-    sideEffects: None
-  - name: kuma-injector.kuma.io
-    admissionReviewVersions: ["v1"]
-    failurePolicy: Ignore 
-    namespaceSelector:
-      matchExpressions:
-        - key: kubernetes.io/metadata.name
-          operator: NotIn
-          values: ["kube-system"]
     clientConfig:
       caBundle: XYZ
       service:

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/fix7824.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/fix7824.golden.yaml
@@ -428,7 +428,7 @@ spec:
     metadata:
       annotations:
         checksum/config: fd9d1d8386f97f2bd49e50f476520816168a1c9f60bbc43dec1347a64d239155
-        checksum/tls-secrets: ec0bc0b5613dc75c86fb3dc148f404db4eaec3e3817ee4eba2a70fd1bc535999
+        checksum/tls-secrets: ef229d2d8e83f89fc76345a85158c87105b2b3553cbfbba83b25dce66479a6e3
       labels: 
         app: kuma-control-plane
         app.kubernetes.io/name: kuma
@@ -1034,30 +1034,6 @@ webhooks:
     objectSelector:
       matchLabels:
         kuma.io/sidecar-injection: enabled
-    clientConfig:
-      caBundle: XYZ
-      service:
-        namespace: kuma-system
-        name: kuma-control-plane
-        path: /inject-sidecar
-    rules:
-      - apiGroups:
-          - ""
-        apiVersions:
-          - v1
-        operations:
-          - CREATE
-        resources:
-          - pods
-    sideEffects: None
-  - name: kuma-injector.kuma.io
-    admissionReviewVersions: ["v1"]
-    failurePolicy: Ignore 
-    namespaceSelector:
-      matchExpressions:
-        - key: kubernetes.io/metadata.name
-          operator: NotIn
-          values: ["kube-system"]
     clientConfig:
       caBundle: XYZ
       service:

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/minReadySeconds.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/minReadySeconds.golden.yaml
@@ -351,7 +351,7 @@ spec:
     metadata:
       annotations:
         checksum/config: fd9d1d8386f97f2bd49e50f476520816168a1c9f60bbc43dec1347a64d239155
-        checksum/tls-secrets: ec0bc0b5613dc75c86fb3dc148f404db4eaec3e3817ee4eba2a70fd1bc535999
+        checksum/tls-secrets: ef229d2d8e83f89fc76345a85158c87105b2b3553cbfbba83b25dce66479a6e3
       labels: 
         app: kuma-control-plane
         app.kubernetes.io/name: kuma
@@ -630,30 +630,6 @@ webhooks:
     objectSelector:
       matchLabels:
         kuma.io/sidecar-injection: enabled
-    clientConfig:
-      caBundle: XYZ
-      service:
-        namespace: kuma-system
-        name: kuma-control-plane
-        path: /inject-sidecar
-    rules:
-      - apiGroups:
-          - ""
-        apiVersions:
-          - v1
-        operations:
-          - CREATE
-        resources:
-          - pods
-    sideEffects: None
-  - name: kuma-injector.kuma.io
-    admissionReviewVersions: ["v1"]
-    failurePolicy: Ignore 
-    namespaceSelector:
-      matchExpressions:
-        - key: kubernetes.io/metadata.name
-          operator: NotIn
-          values: ["kube-system"]
     clientConfig:
       caBundle: XYZ
       service:

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/securityContext.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/securityContext.golden.yaml
@@ -351,7 +351,7 @@ spec:
     metadata:
       annotations:
         checksum/config: fd9d1d8386f97f2bd49e50f476520816168a1c9f60bbc43dec1347a64d239155
-        checksum/tls-secrets: ec0bc0b5613dc75c86fb3dc148f404db4eaec3e3817ee4eba2a70fd1bc535999
+        checksum/tls-secrets: ef229d2d8e83f89fc76345a85158c87105b2b3553cbfbba83b25dce66479a6e3
       labels: 
         app: kuma-control-plane
         app.kubernetes.io/name: kuma
@@ -631,30 +631,6 @@ webhooks:
     objectSelector:
       matchLabels:
         kuma.io/sidecar-injection: enabled
-    clientConfig:
-      caBundle: XYZ
-      service:
-        namespace: kuma-system
-        name: kuma-control-plane
-        path: /inject-sidecar
-    rules:
-      - apiGroups:
-          - ""
-        apiVersions:
-          - v1
-        operations:
-          - CREATE
-        resources:
-          - pods
-    sideEffects: None
-  - name: kuma-injector.kuma.io
-    admissionReviewVersions: ["v1"]
-    failurePolicy: Ignore 
-    namespaceSelector:
-      matchExpressions:
-        - key: kubernetes.io/metadata.name
-          operator: NotIn
-          values: ["kube-system"]
     clientConfig:
       caBundle: XYZ
       service:

--- a/deployments/charts/kuma/templates/cp-webhooks-and-secrets.yaml
+++ b/deployments/charts/kuma/templates/cp-webhooks-and-secrets.yaml
@@ -180,30 +180,6 @@ webhooks:
         resources:
           - pods
     sideEffects: None
-  - name: kuma-injector.kuma.io
-    admissionReviewVersions: ["v1"]
-    failurePolicy: Ignore {{/* Failure policy is hardcoded as Ignore because any other mode will cause CP to be unable to start after all instances are down */}}
-    namespaceSelector:
-      matchExpressions:
-        - key: kubernetes.io/metadata.name
-          operator: NotIn
-          values: ["kube-system"]
-    clientConfig:
-      caBundle: {{ $caBundle }}
-      service:
-        namespace: {{ .Release.Namespace }}
-        name: {{ include "kuma.controlPlane.serviceName" . }}
-        path: /inject-sidecar
-    rules:
-      - apiGroups:
-          - ""
-        apiVersions:
-          - v1
-        operations:
-          - CREATE
-        resources:
-          - pods
-    sideEffects: None
   {{- end }}
 ---
 apiVersion: admissionregistration.k8s.io/v1


### PR DESCRIPTION
### Checklist prior to review

Fix #7974

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [ ] [Link to relevant issue][1] as well as docs and UI issues --
- [ ] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [ ] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [ ] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [ ] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
