### PR TITLE
feat(api-server): skip auth on specific endpoints

### DIFF
--- a/pkg/api-server/authn/skip.go
+++ b/pkg/api-server/authn/skip.go
@@ -1,0 +1,32 @@
+package authn
+
+import (
+	"strings"
+
+	"github.com/emicklei/go-restful/v3"
+)
+
+const (
+	MetadataAuthKey  = "auth"
+	MetadataAuthSkip = "skip"
+)
+
+// UnauthorizedPathPrefixes is another way to add path prefixes as unauthorized endpoint.
+// Prefer MetadataAuthKey, use UnauthorizedPathPrefixes if needed.
+var UnauthorizedPathPrefixes = map[string]struct{}{
+	"/gui": {},
+}
+
+func SkipAuth(request *restful.Request) bool {
+	if route := request.SelectedRoute(); route != nil {
+		if route.Metadata()[MetadataAuthKey] == MetadataAuthSkip {
+			return true
+		}
+	}
+	for prefix := range UnauthorizedPathPrefixes {
+		if strings.HasPrefix(request.Request.RequestURI, prefix) {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/api-server/index_endpoints.go
+++ b/pkg/api-server/index_endpoints.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/emicklei/go-restful/v3"
 
+	"github.com/kumahq/kuma/pkg/api-server/authn"
 	"github.com/kumahq/kuma/pkg/api-server/types"
 	kuma_version "github.com/kumahq/kuma/pkg/version"
 )
@@ -20,33 +21,35 @@ func addIndexWsEndpoints(ws *restful.WebService, getInstanceId func() string, ge
 	if err != nil {
 		return err
 	}
-	ws.Route(ws.GET("/").To(func(req *restful.Request, resp *restful.Response) {
-		if instanceId == "" {
-			instanceId = getInstanceId()
-		}
+	ws.Route(ws.GET("/").
+		Metadata(authn.MetadataAuthKey, authn.MetadataAuthSkip).
+		To(func(req *restful.Request, resp *restful.Response) {
+			if instanceId == "" {
+				instanceId = getInstanceId()
+			}
 
-		if clusterId == "" {
-			clusterId = getClusterId()
-		}
+			if clusterId == "" {
+				clusterId = getClusterId()
+			}
 
-		if !enableGUI {
-			guiURL = ""
-		}
+			if !enableGUI {
+				guiURL = ""
+			}
 
-		response := types.IndexResponse{
-			Hostname:    hostname,
-			Tagline:     kuma_version.Product,
-			Product:     kuma_version.Product,
-			Version:     kuma_version.Build.Version,
-			BasedOnKuma: kuma_version.Build.BasedOnKuma,
-			InstanceId:  instanceId,
-			ClusterId:   clusterId,
-			GuiURL:      guiURL,
-		}
+			response := types.IndexResponse{
+				Hostname:    hostname,
+				Tagline:     kuma_version.Product,
+				Product:     kuma_version.Product,
+				Version:     kuma_version.Build.Version,
+				BasedOnKuma: kuma_version.Build.BasedOnKuma,
+				InstanceId:  instanceId,
+				ClusterId:   clusterId,
+				GuiURL:      guiURL,
+			}
 
-		if err := resp.WriteAsJson(response); err != nil {
-			log.Error(err, "Could not write the index response")
-		}
-	}))
+			if err := resp.WriteAsJson(response); err != nil {
+				log.Error(err, "Could not write the index response")
+			}
+		}))
 	return nil
 }

--- a/pkg/plugins/authn/api-server/tokens/authenticator.go
+++ b/pkg/plugins/authn/api-server/tokens/authenticator.go
@@ -18,6 +18,10 @@ var log = core.Log.WithName("plugins").WithName("authn").WithName("api-server").
 
 func UserTokenAuthenticator(validator issuer.UserTokenValidator) authn.Authenticator {
 	return func(request *restful.Request, response *restful.Response, chain *restful.FilterChain) {
+		if authn.SkipAuth(request) {
+			chain.ProcessFilter(request, response)
+			return
+		}
 		authnHeader := request.Request.Header.Get("authorization")
 		if user.FromCtx(request.Request.Context()).Name == user.Anonymous.Name && // do not overwrite existing user
 			authnHeader != "" &&


### PR DESCRIPTION
### Checklist prior to review

Fix #3576

It will also simplify logic in KM

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [ ] [Link to relevant issue][1] as well as docs and UI issues --
- [ ] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [ ] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [ ] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [ ] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
