### PR TITLE
fix(k8s): support injection with label kuma.io/sidecar-injection: 'true'

### DIFF
--- a/app/kumactl/cmd/install/testdata/install-control-plane.cni-enabled.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.cni-enabled.golden.yaml
@@ -565,7 +565,7 @@ spec:
     metadata:
       annotations:
         checksum/config: fd9d1d8386f97f2bd49e50f476520816168a1c9f60bbc43dec1347a64d239155
-        checksum/tls-secrets: ef229d2d8e83f89fc76345a85158c87105b2b3553cbfbba83b25dce66479a6e3
+        checksum/tls-secrets: 87b73793dde9ce325cf7c6f129e091e2a9a4f88a44b1f01663fd0f1a18e6472b
       labels: 
         app: kuma-control-plane
         app.kubernetes.io/name: kuma
@@ -820,7 +820,7 @@ webhooks:
           values: ["kube-system"]
         - key: kuma.io/sidecar-injection
           operator: In
-          values: ["enabled"]
+          values: ["enabled", "true"]
     clientConfig:
       caBundle: XYZ
       service:

--- a/app/kumactl/cmd/install/testdata/install-control-plane.defaults.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.defaults.golden.yaml
@@ -6503,7 +6503,7 @@ spec:
     metadata:
       annotations:
         checksum/config: fd9d1d8386f97f2bd49e50f476520816168a1c9f60bbc43dec1347a64d239155
-        checksum/tls-secrets: ef229d2d8e83f89fc76345a85158c87105b2b3553cbfbba83b25dce66479a6e3
+        checksum/tls-secrets: 87b73793dde9ce325cf7c6f129e091e2a9a4f88a44b1f01663fd0f1a18e6472b
       labels: 
         app: kuma-control-plane
         app.kubernetes.io/name: kuma
@@ -6754,7 +6754,7 @@ webhooks:
           values: ["kube-system"]
         - key: kuma.io/sidecar-injection
           operator: In
-          values: ["enabled"]
+          values: ["enabled", "true"]
     clientConfig:
       caBundle: XYZ
       service:

--- a/app/kumactl/cmd/install/testdata/install-control-plane.gateway-api-present-not-enabled.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.gateway-api-present-not-enabled.yaml
@@ -6503,7 +6503,7 @@ spec:
     metadata:
       annotations:
         checksum/config: fd9d1d8386f97f2bd49e50f476520816168a1c9f60bbc43dec1347a64d239155
-        checksum/tls-secrets: ef229d2d8e83f89fc76345a85158c87105b2b3553cbfbba83b25dce66479a6e3
+        checksum/tls-secrets: 87b73793dde9ce325cf7c6f129e091e2a9a4f88a44b1f01663fd0f1a18e6472b
       labels: 
         app: kuma-control-plane
         app.kubernetes.io/name: kuma
@@ -6754,7 +6754,7 @@ webhooks:
           values: ["kube-system"]
         - key: kuma.io/sidecar-injection
           operator: In
-          values: ["enabled"]
+          values: ["enabled", "true"]
     clientConfig:
       caBundle: XYZ
       service:

--- a/app/kumactl/cmd/install/testdata/install-control-plane.gateway-api-present.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.gateway-api-present.yaml
@@ -6709,7 +6709,7 @@ spec:
     metadata:
       annotations:
         checksum/config: fd9d1d8386f97f2bd49e50f476520816168a1c9f60bbc43dec1347a64d239155
-        checksum/tls-secrets: ef229d2d8e83f89fc76345a85158c87105b2b3553cbfbba83b25dce66479a6e3
+        checksum/tls-secrets: 87b73793dde9ce325cf7c6f129e091e2a9a4f88a44b1f01663fd0f1a18e6472b
       labels: 
         app: kuma-control-plane
         app.kubernetes.io/name: kuma
@@ -6969,7 +6969,7 @@ webhooks:
           values: ["kube-system"]
         - key: kuma.io/sidecar-injection
           operator: In
-          values: ["enabled"]
+          values: ["enabled", "true"]
     clientConfig:
       caBundle: XYZ
       service:

--- a/app/kumactl/cmd/install/testdata/install-control-plane.override-env-vars.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.override-env-vars.golden.yaml
@@ -351,7 +351,7 @@ spec:
     metadata:
       annotations:
         checksum/config: fd9d1d8386f97f2bd49e50f476520816168a1c9f60bbc43dec1347a64d239155
-        checksum/tls-secrets: ef229d2d8e83f89fc76345a85158c87105b2b3553cbfbba83b25dce66479a6e3
+        checksum/tls-secrets: 87b73793dde9ce325cf7c6f129e091e2a9a4f88a44b1f01663fd0f1a18e6472b
       labels: 
         app: kuma-control-plane
         app.kubernetes.io/name: kuma
@@ -602,7 +602,7 @@ webhooks:
           values: ["kube-system"]
         - key: kuma.io/sidecar-injection
           operator: In
-          values: ["enabled"]
+          values: ["enabled", "true"]
     clientConfig:
       caBundle: XYZ
       service:

--- a/app/kumactl/cmd/install/testdata/install-control-plane.overrides.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.overrides.golden.yaml
@@ -353,7 +353,7 @@ spec:
     metadata:
       annotations:
         checksum/config: 154c47a95fc93687dd1e825cea7f843d0fe8c450f82014d27cd7eb1a49f3bd35
-        checksum/tls-secrets: 3aeba87ff12b47b7074c452407f925cdbc3e2edc608b2592efa1081ac26dc7dd
+        checksum/tls-secrets: 3e0ab2f55dec9eabdcebdbecb8f5df63aad2bb24b18658a22ddb370fbe8cc9a7
       labels: 
         app: kuma-control-plane
         app.kubernetes.io/name: kuma
@@ -639,7 +639,7 @@ webhooks:
           values: ["kube-system"]
         - key: kuma.io/sidecar-injection
           operator: In
-          values: ["enabled"]
+          values: ["enabled", "true"]
     clientConfig:
       caBundle: XYZ
       service:

--- a/app/kumactl/cmd/install/testdata/install-control-plane.registry.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.registry.golden.yaml
@@ -351,7 +351,7 @@ spec:
     metadata:
       annotations:
         checksum/config: fd9d1d8386f97f2bd49e50f476520816168a1c9f60bbc43dec1347a64d239155
-        checksum/tls-secrets: ef229d2d8e83f89fc76345a85158c87105b2b3553cbfbba83b25dce66479a6e3
+        checksum/tls-secrets: 87b73793dde9ce325cf7c6f129e091e2a9a4f88a44b1f01663fd0f1a18e6472b
       labels: 
         app: kuma-control-plane
         app.kubernetes.io/name: kuma
@@ -602,7 +602,7 @@ webhooks:
           values: ["kube-system"]
         - key: kuma.io/sidecar-injection
           operator: In
-          values: ["enabled"]
+          values: ["enabled", "true"]
     clientConfig:
       caBundle: XYZ
       service:

--- a/app/kumactl/cmd/install/testdata/install-control-plane.tproxy-ebpf-experimental-enabled.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.tproxy-ebpf-experimental-enabled.golden.yaml
@@ -351,7 +351,7 @@ spec:
     metadata:
       annotations:
         checksum/config: fd9d1d8386f97f2bd49e50f476520816168a1c9f60bbc43dec1347a64d239155
-        checksum/tls-secrets: ef229d2d8e83f89fc76345a85158c87105b2b3553cbfbba83b25dce66479a6e3
+        checksum/tls-secrets: 87b73793dde9ce325cf7c6f129e091e2a9a4f88a44b1f01663fd0f1a18e6472b
       labels: 
         app: kuma-control-plane
         app.kubernetes.io/name: kuma
@@ -612,7 +612,7 @@ webhooks:
           values: ["kube-system"]
         - key: kuma.io/sidecar-injection
           operator: In
-          values: ["enabled"]
+          values: ["enabled", "true"]
     clientConfig:
       caBundle: XYZ
       service:

--- a/app/kumactl/cmd/install/testdata/install-control-plane.with-egress.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.with-egress.golden.yaml
@@ -382,7 +382,7 @@ spec:
     metadata:
       annotations:
         checksum/config: fd9d1d8386f97f2bd49e50f476520816168a1c9f60bbc43dec1347a64d239155
-        checksum/tls-secrets: ef229d2d8e83f89fc76345a85158c87105b2b3553cbfbba83b25dce66479a6e3
+        checksum/tls-secrets: 87b73793dde9ce325cf7c6f129e091e2a9a4f88a44b1f01663fd0f1a18e6472b
       labels: 
         app: kuma-control-plane
         app.kubernetes.io/name: kuma
@@ -762,7 +762,7 @@ webhooks:
           values: ["kube-system"]
         - key: kuma.io/sidecar-injection
           operator: In
-          values: ["enabled"]
+          values: ["enabled", "true"]
     clientConfig:
       caBundle: XYZ
       service:

--- a/app/kumactl/cmd/install/testdata/install-control-plane.with-helm-set.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.with-helm-set.yaml
@@ -6565,7 +6565,7 @@ spec:
     metadata:
       annotations:
         checksum/config: fd9d1d8386f97f2bd49e50f476520816168a1c9f60bbc43dec1347a64d239155
-        checksum/tls-secrets: ef229d2d8e83f89fc76345a85158c87105b2b3553cbfbba83b25dce66479a6e3
+        checksum/tls-secrets: 87b73793dde9ce325cf7c6f129e091e2a9a4f88a44b1f01663fd0f1a18e6472b
       labels: 
         app: kuma-control-plane
         app.kubernetes.io/name: kuma
@@ -7080,7 +7080,7 @@ webhooks:
           values: ["kube-system"]
         - key: kuma.io/sidecar-injection
           operator: In
-          values: ["enabled"]
+          values: ["enabled", "true"]
     clientConfig:
       caBundle: XYZ
       service:

--- a/app/kumactl/cmd/install/testdata/install-control-plane.with-helm-values.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.with-helm-values.yaml
@@ -351,7 +351,7 @@ spec:
     metadata:
       annotations:
         checksum/config: fd9d1d8386f97f2bd49e50f476520816168a1c9f60bbc43dec1347a64d239155
-        checksum/tls-secrets: ef229d2d8e83f89fc76345a85158c87105b2b3553cbfbba83b25dce66479a6e3
+        checksum/tls-secrets: 87b73793dde9ce325cf7c6f129e091e2a9a4f88a44b1f01663fd0f1a18e6472b
       labels: 
         app: kuma-control-plane
         app.kubernetes.io/name: kuma
@@ -602,7 +602,7 @@ webhooks:
           values: ["kube-system"]
         - key: kuma.io/sidecar-injection
           operator: In
-          values: ["enabled"]
+          values: ["enabled", "true"]
     clientConfig:
       caBundle: XYZ
       service:

--- a/app/kumactl/cmd/install/testdata/install-control-plane.with-ingress.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.with-ingress.golden.yaml
@@ -382,7 +382,7 @@ spec:
     metadata:
       annotations:
         checksum/config: fd9d1d8386f97f2bd49e50f476520816168a1c9f60bbc43dec1347a64d239155
-        checksum/tls-secrets: ef229d2d8e83f89fc76345a85158c87105b2b3553cbfbba83b25dce66479a6e3
+        checksum/tls-secrets: 87b73793dde9ce325cf7c6f129e091e2a9a4f88a44b1f01663fd0f1a18e6472b
       labels: 
         app: kuma-control-plane
         app.kubernetes.io/name: kuma
@@ -768,7 +768,7 @@ webhooks:
           values: ["kube-system"]
         - key: kuma.io/sidecar-injection
           operator: In
-          values: ["enabled"]
+          values: ["enabled", "true"]
     clientConfig:
       caBundle: XYZ
       service:

--- a/app/kumactl/cmd/install/testdata/install-control-plane.zone.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.zone.golden.yaml
@@ -351,7 +351,7 @@ spec:
     metadata:
       annotations:
         checksum/config: fd9d1d8386f97f2bd49e50f476520816168a1c9f60bbc43dec1347a64d239155
-        checksum/tls-secrets: ef229d2d8e83f89fc76345a85158c87105b2b3553cbfbba83b25dce66479a6e3
+        checksum/tls-secrets: 87b73793dde9ce325cf7c6f129e091e2a9a4f88a44b1f01663fd0f1a18e6472b
       labels: 
         app: kuma-control-plane
         app.kubernetes.io/name: kuma
@@ -606,7 +606,7 @@ webhooks:
           values: ["kube-system"]
         - key: kuma.io/sidecar-injection
           operator: In
-          values: ["enabled"]
+          values: ["enabled", "true"]
     clientConfig:
       caBundle: XYZ
       service:

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/doNotChangeTlsChecksum.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/doNotChangeTlsChecksum.golden.yaml
@@ -601,7 +601,7 @@ webhooks:
           values: ["kube-system"]
         - key: kuma.io/sidecar-injection
           operator: In
-          values: ["enabled"]
+          values: ["enabled", "true"]
     clientConfig:
       caBundle: XYZ
       service:

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/empty.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/empty.golden.yaml
@@ -351,7 +351,7 @@ spec:
     metadata:
       annotations:
         checksum/config: fd9d1d8386f97f2bd49e50f476520816168a1c9f60bbc43dec1347a64d239155
-        checksum/tls-secrets: ef229d2d8e83f89fc76345a85158c87105b2b3553cbfbba83b25dce66479a6e3
+        checksum/tls-secrets: 87b73793dde9ce325cf7c6f129e091e2a9a4f88a44b1f01663fd0f1a18e6472b
       labels: 
         app: kuma-control-plane
         app.kubernetes.io/name: kuma
@@ -602,7 +602,7 @@ webhooks:
           values: ["kube-system"]
         - key: kuma.io/sidecar-injection
           operator: In
-          values: ["enabled"]
+          values: ["enabled", "true"]
     clientConfig:
       caBundle: XYZ
       service:

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/fix4485.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/fix4485.golden.yaml
@@ -373,7 +373,7 @@ spec:
     metadata:
       annotations:
         checksum/config: 3a137bbfcbbe6ba5a3997b30b1b047b2b080a9f912520a5fa683f11c4c6b6f3c
-        checksum/tls-secrets: e68055a5f807d40c227179eff2841dea4ad0c3bc8f61799374ae1517d9d29490
+        checksum/tls-secrets: a44b05a430d992e10a97a29ff3ca2a740ddedc54a0fa1a5fec36135c14e6787c
       labels: 
         app: kuma-control-plane
         "foo": "baz"
@@ -632,7 +632,7 @@ webhooks:
           values: ["kube-system"]
         - key: kuma.io/sidecar-injection
           operator: In
-          values: ["enabled"]
+          values: ["enabled", "true"]
     clientConfig:
       caBundle: XYZ
       service:

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/fix4496.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/fix4496.golden.yaml
@@ -392,7 +392,7 @@ spec:
     metadata:
       annotations:
         checksum/config: 2f553eadd8f68661f4b1fd0b3ccbbc562943d89fa76f2f2ba2975541290fda71
-        checksum/tls-secrets: 3b3d8ecf760b979e540444ea6101495dd56d5228620a8604dcac2f6a12764231
+        checksum/tls-secrets: bbdeda16186121d659a66091c69b294596118df8028d3c7f93521d859169e6f5
       labels: 
         app: kuma-control-plane
         "foo": "bar"
@@ -806,7 +806,7 @@ webhooks:
           values: ["kube-system"]
         - key: kuma.io/sidecar-injection
           operator: In
-          values: ["enabled"]
+          values: ["enabled", "true"]
     clientConfig:
       caBundle: XYZ
       service:

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/fix4935.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/fix4935.golden.yaml
@@ -635,7 +635,7 @@ spec:
     metadata:
       annotations:
         checksum/config: fd9d1d8386f97f2bd49e50f476520816168a1c9f60bbc43dec1347a64d239155
-        checksum/tls-secrets: ef229d2d8e83f89fc76345a85158c87105b2b3553cbfbba83b25dce66479a6e3
+        checksum/tls-secrets: 87b73793dde9ce325cf7c6f129e091e2a9a4f88a44b1f01663fd0f1a18e6472b
         bim: "bam"
         foo: "{\"bar\": \"baz\"}"
       labels: 
@@ -1188,7 +1188,7 @@ webhooks:
           values: ["kube-system"]
         - key: kuma.io/sidecar-injection
           operator: In
-          values: ["enabled"]
+          values: ["enabled", "true"]
     clientConfig:
       caBundle: XYZ
       service:

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/fix5978.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/fix5978.golden.yaml
@@ -413,7 +413,7 @@ spec:
     metadata:
       annotations:
         checksum/config: fd9d1d8386f97f2bd49e50f476520816168a1c9f60bbc43dec1347a64d239155
-        checksum/tls-secrets: ef229d2d8e83f89fc76345a85158c87105b2b3553cbfbba83b25dce66479a6e3
+        checksum/tls-secrets: 87b73793dde9ce325cf7c6f129e091e2a9a4f88a44b1f01663fd0f1a18e6472b
       labels: 
         app: kuma-control-plane
         app.kubernetes.io/name: kuma
@@ -931,7 +931,7 @@ webhooks:
           values: ["kube-system"]
         - key: kuma.io/sidecar-injection
           operator: In
-          values: ["enabled"]
+          values: ["enabled", "true"]
     clientConfig:
       caBundle: XYZ
       service:

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/fix7724.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/fix7724.golden.yaml
@@ -354,7 +354,7 @@ spec:
     metadata:
       annotations:
         checksum/config: fd9d1d8386f97f2bd49e50f476520816168a1c9f60bbc43dec1347a64d239155
-        checksum/tls-secrets: ef229d2d8e83f89fc76345a85158c87105b2b3553cbfbba83b25dce66479a6e3
+        checksum/tls-secrets: 87b73793dde9ce325cf7c6f129e091e2a9a4f88a44b1f01663fd0f1a18e6472b
       labels: 
         app: kuma-control-plane
         app.kubernetes.io/name: kuma
@@ -605,7 +605,7 @@ webhooks:
           values: ["kube-system"]
         - key: kuma.io/sidecar-injection
           operator: In
-          values: ["enabled"]
+          values: ["enabled", "true"]
     clientConfig:
       caBundle: XYZ
       service:

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/fix7824.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/fix7824.golden.yaml
@@ -428,7 +428,7 @@ spec:
     metadata:
       annotations:
         checksum/config: fd9d1d8386f97f2bd49e50f476520816168a1c9f60bbc43dec1347a64d239155
-        checksum/tls-secrets: ef229d2d8e83f89fc76345a85158c87105b2b3553cbfbba83b25dce66479a6e3
+        checksum/tls-secrets: 87b73793dde9ce325cf7c6f129e091e2a9a4f88a44b1f01663fd0f1a18e6472b
       labels: 
         app: kuma-control-plane
         app.kubernetes.io/name: kuma
@@ -1006,7 +1006,7 @@ webhooks:
           values: ["kube-system"]
         - key: kuma.io/sidecar-injection
           operator: In
-          values: ["enabled"]
+          values: ["enabled", "true"]
     clientConfig:
       caBundle: XYZ
       service:

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/minReadySeconds.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/minReadySeconds.golden.yaml
@@ -351,7 +351,7 @@ spec:
     metadata:
       annotations:
         checksum/config: fd9d1d8386f97f2bd49e50f476520816168a1c9f60bbc43dec1347a64d239155
-        checksum/tls-secrets: ef229d2d8e83f89fc76345a85158c87105b2b3553cbfbba83b25dce66479a6e3
+        checksum/tls-secrets: 87b73793dde9ce325cf7c6f129e091e2a9a4f88a44b1f01663fd0f1a18e6472b
       labels: 
         app: kuma-control-plane
         app.kubernetes.io/name: kuma
@@ -602,7 +602,7 @@ webhooks:
           values: ["kube-system"]
         - key: kuma.io/sidecar-injection
           operator: In
-          values: ["enabled"]
+          values: ["enabled", "true"]
     clientConfig:
       caBundle: XYZ
       service:

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/securityContext.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/securityContext.golden.yaml
@@ -351,7 +351,7 @@ spec:
     metadata:
       annotations:
         checksum/config: fd9d1d8386f97f2bd49e50f476520816168a1c9f60bbc43dec1347a64d239155
-        checksum/tls-secrets: ef229d2d8e83f89fc76345a85158c87105b2b3553cbfbba83b25dce66479a6e3
+        checksum/tls-secrets: 87b73793dde9ce325cf7c6f129e091e2a9a4f88a44b1f01663fd0f1a18e6472b
       labels: 
         app: kuma-control-plane
         app.kubernetes.io/name: kuma
@@ -603,7 +603,7 @@ webhooks:
           values: ["kube-system"]
         - key: kuma.io/sidecar-injection
           operator: In
-          values: ["enabled"]
+          values: ["enabled", "true"]
     clientConfig:
       caBundle: XYZ
       service:

--- a/deployments/charts/kuma/templates/cp-webhooks-and-secrets.yaml
+++ b/deployments/charts/kuma/templates/cp-webhooks-and-secrets.yaml
@@ -136,7 +136,7 @@ webhooks:
           values: ["kube-system"]
         - key: kuma.io/sidecar-injection
           operator: In
-          values: ["enabled"]
+          values: ["enabled", "true"]
     clientConfig:
       caBundle: {{ $caBundle }}
       service:


### PR DESCRIPTION
Everywhere else we support both `'true'` and `'enabled'` 

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
