### PR TITLE
ci(actions): run amd64 E2E on GitHub actions and arm64 on CircleCI

### DIFF
--- a/.github/workflows/build-test-distribute.yaml
+++ b/.github/workflows/build-test-distribute.yaml
@@ -34,19 +34,14 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
+      # GitHub actions does not share cache across multiple jobs,
+      # so we have to operate cache in each job and action file
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: "Check if should run on all arch/os combinations"
-        if: github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'ci/run-full-matrix')
-        run: |
-          echo 'ENABLED_GOARCHES=arm64 amd64' >> $GITHUB_ENV
-          echo 'ENABLED_GOOSES=linux darwin' >> $GITHUB_ENV
       - uses: actions/setup-go@v4
         with:
           go-version-file: go.mod
-      # GitHub actions does not share cache across multiple jobs,
-      # so we have to operate cache in each job and action file
       - uses: actions/cache@v3
         with:
           path: |
@@ -56,6 +51,11 @@ jobs:
             ${{ runner.os }}-devtools
       - run: |
           make dev/tools
+      - name: "Check if should run on all arch/os combinations"
+        if: github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'ci/run-full-matrix')
+        run: |
+          echo 'ENABLED_GOARCHES=arm64 amd64' >> $GITHUB_ENV
+          echo 'ENABLED_GOOSES=linux darwin' >> $GITHUB_ENV
       - run: |
           make build
       - run: |
@@ -120,9 +120,14 @@ jobs:
           retention-days: 7
   distributions:
     needs: ["check", "test", "test_e2e", "test_e2e_env"]
-    if: ${{ always() && !failure() && !cancelled() }}
+    if: ${{ always() }}
     runs-on: ubuntu-latest
     steps:
+      # see https://stackoverflow.com/a/67532120/4907315
+      - name: "Halt due to previous failures"
+        run: |
+          exit 1
+        if: ${{ contains(needs.*.result, 'failure')|| contains(needs.*.result, 'cancelled') }}
       - name: "Check if should run on all arch/os combinations"
         if: github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'ci/run-full-matrix')
         run: |

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -29,8 +29,7 @@ on:
       circleCIToken:
         required: true
 jobs:
-  e2e_gh_actions:
-    if: ${{ inputs.arch == 'amd64' }}
+  e2e:
     runs-on: ubuntu-latest
     steps:
       - name: "Print parameters"
@@ -43,37 +42,33 @@ jobs:
               arch: ${{ inputs.arch }} \
               cniNetworkPlugin: ${{ inputs.cniNetworkPlugin }} \
               "
-      - uses: actions/checkout@v4
+      - name: "GitHub Actions: check out code"
+        if: ${{ inputs.arch == 'amd64' }}
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: actions/setup-go@v4
+      - name: "GitHub Actions: setup go"
+        if: ${{ inputs.arch == 'amd64' }}
+        uses: actions/setup-go@v4
         with:
           go-version-file: go.mod
-      - uses: actions/cache@v3
+      - name: "GitHub Actions: set up cache"
+        if: ${{ inputs.arch == 'amd64' }}
+        uses: actions/cache@v3
         with:
           path: |
             ~/.kuma-dev
           key: ${{ runner.os }}-devtools-${{ hashFiles('mk/dependencies/deps.lock') }}
           restore-keys: |
             ${{ runner.os }}-devtools
-      - uses: actions/download-artifact@v3
+      - name: "GitHub Actions: download build artifacts"
+        if: ${{ inputs.arch == 'amd64' }}
+        uses: actions/download-artifact@v3
         with:
           name: build-output
           path: build
-      - name: Install build tools
-        run: |
-          command: |
-            if ! command -v sudo 2>&1 >/dev/null; then
-              apt update
-              apt install -y sudo
-            fi
-
-            sudo apt update
-            sudo env DEBIAN_FRONTEND=noninteractive apt install -y curl git make unzip gcc xz-utils
-      - name: "Setup Helm"
-        run: |
-          make dev/set-kuma-helm-repo
-      - name: "Extract artifacts"
+      - name: "GitHub Actions: extract artifacts"
+        if: ${{ inputs.arch == 'amd64' }}
         run: |
           echo "Extracting artifacts..."
           ARCH='${{ inputs.arch }}'
@@ -93,7 +88,12 @@ jobs:
             mkdir -p $DEST_DIR/$BIN
             cp $SRC_DIR/$BIN $DEST_DIR/$BIN/
           done
-      - name: "Run E2E tests"
+      - name: "GitHub Actions: setup helm"
+        if: ${{ inputs.arch == 'amd64' }}
+        run: |
+          make dev/set-kuma-helm-repo
+      - name: "GitHub Actions: run E2E tests"
+        if: ${{ inputs.arch == 'amd64' }}
         run: |
           if [[ "${{ inputs.k8sVersion }}" == "kindIpv6" ]]; then
             export IPV6=true
@@ -125,30 +125,20 @@ jobs:
             target="test/e2e"
           fi
           make ${MAKE_PARAMETERS} CI=true "${target}"
-  e2e_circleci:
-    if: ${{ inputs.arch != 'amd64' }}
-    runs-on: ubuntu-latest
-    steps:
-      - name: "Print parameters"
-        run: |
-          echo "All inputs:"
-          echo "Running with: \
-              k8s: ${{ inputs.k8sVersion }} \
-              target: ${{ inputs.target }} \
-              parallelism: ${{ inputs.parallelism }} \
-              arch: ${{ inputs.arch }} \
-              cniNetworkPlugin: ${{ inputs.cniNetworkPlugin }} \
-              "
-      - name: Expose github action artifact variables
+
+      - name: "CircleCI: expose github action artifact variables"
+        if: ${{ inputs.arch != 'amd64' }}
         uses: actions/github-script@v6
         with:
           script: |
             core.exportVariable('ACTIONS_RUNTIME_URL', process.env['ACTIONS_RUNTIME_URL'])
             core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env['ACTIONS_RUNTIME_TOKEN'])
-      - name: Install jq
+      - name: "CircleCI: install jq"
+        if: ${{ inputs.arch != 'amd64' }}
         run: |
           sudo apt-get install -y jq
-      - name: "Trigger a new pipeline workflow on CircleCI"
+      - name: "CircleCI: trigger a new pipeline workflow on CircleCI"
+        if: ${{ inputs.arch != 'amd64' }}
         id: circle-ci-trigger
         run: |
           # Trigger CircleCI manually, reference: https://github.com/CircleCI-Public/trigger-circleci-pipeline-action/blob/main/src/lib/CircleCIPipelineTrigger.ts#L82
@@ -226,8 +216,8 @@ jobs:
           echo ''
           echo "CircleCI pipeline triggered successfully, pipeline id: $PIPELINE_ID"
           echo "Check CircleCI workflow details at: https://app.circleci.com/pipelines/gh/${{ github.repository }}/$PIPELINE_NUMBER/workflows/$WORKFLOW_ID"
-      - name: "Check run status of pipeline workflow on CircleCI"
-        if: steps.circle-ci-trigger.outputs.workflow_id != ''
+      - name: "CircleCI: check run status of pipeline workflow on CircleCI"
+        if: ${{ inputs.arch != 'amd64' && steps.circle-ci-trigger.outputs.workflow_id != '' }}
         run: |
           set -e
           if [ "${{ runner.debug }}" == "1" ]; then
@@ -252,8 +242,8 @@ jobs:
             cat $OUTPUT_FILE
             rm $OUTPUT_FILE
             if [ "$STATUS_CODE" == "429" ]; then
-              # we are exceeding rate limit
-              echo "{}"
+              # we are exceeding rate limit, try again later
+              echo '{"status": ""}'
               return
             fi
             if [ $STATUS_CODE -lt 200 ] || [ $STATUS_CODE -gt 399 ] ; then
@@ -289,8 +279,8 @@ jobs:
           echo "Check CircleCI workflow details at: https://app.circleci.com/pipelines/gh/${{ github.repository }}/$PIPELINE_NUMBER/workflows/$WORKFLOW_ID"
           echo "Tracking workflow status:"
           check_workflow '${{ steps.circle-ci-trigger.outputs.workflow_id }}'
-      - name: Cancel CircleCI running if requested
-        if: cancelled() && steps.circle-ci-trigger.outputs.workflow_id != ''
+      - name: "CircleCI: cancel CircleCI running if requested"
+        if: ${{ inputs.arch != 'amd64' && cancelled() && steps.circle-ci-trigger.outputs.workflow_id != '' }}
         run: |
           set -e
           if [ "${{ runner.debug }}" == "1" ]; then

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -29,7 +29,104 @@ on:
       circleCIToken:
         required: true
 jobs:
-  e2e:
+  e2e_gh_actions:
+    if: ${{ inputs.arch == 'amd64' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Print parameters"
+        run: |
+          echo "All inputs:"
+          echo "Running with: \
+              k8s: ${{ inputs.k8sVersion }} \
+              target: ${{ inputs.target }} \
+              parallelism: ${{ inputs.parallelism }} \
+              arch: ${{ inputs.arch }} \
+              cniNetworkPlugin: ${{ inputs.cniNetworkPlugin }} \
+              "
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-go@v4
+        with:
+          go-version-file: go.mod
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/.kuma-dev
+          key: ${{ runner.os }}-devtools-${{ hashFiles('mk/dependencies/deps.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-devtools
+      - uses: actions/download-artifact@v3
+        with:
+          name: build-output
+          path: build
+      - name: Install build tools
+        run: |
+          command: |
+            if ! command -v sudo 2>&1 >/dev/null; then
+              apt update
+              apt install -y sudo
+            fi
+
+            sudo apt update
+            sudo env DEBIAN_FRONTEND=noninteractive apt install -y curl git make unzip gcc xz-utils
+      - name: "Setup Helm"
+        run: |
+          make dev/set-kuma-helm-repo
+      - name: "Extract artifacts"
+        run: |
+          echo "Extracting artifacts..."
+          ARCH='${{ inputs.arch }}'
+          ARTIFACT=$(find build/distributions/out/kuma-*-linux-$ARCH.tar.gz)
+          if [[ "$ARTIFACT" == "" ]]; then
+            echo "Could not find built artifact for linux($ARCH)."
+            exit 1
+          fi
+          cat $ARTIFACT.sha256 | sha256sum --check
+
+          mkdir build/distributions/artifacts
+          tar -xzf $ARTIFACT -C build/distributions/artifacts
+
+          SRC_DIR=$(find build/distributions/artifacts/*/bin -type d)
+          DEST_DIR=build/artifacts-linux-$ARCH
+          for BIN in $(ls $SRC_DIR); do
+            mkdir -p $DEST_DIR/$BIN
+            cp $SRC_DIR/$BIN $DEST_DIR/$BIN/
+          done
+      - name: "Run E2E tests"
+        run: |
+          if [[ "${{ inputs.k8sVersion }}" == "kindIpv6" ]]; then
+            export IPV6=true
+            export K8S_CLUSTER_TOOL=kind
+            export KUMA_DEFAULT_RETRIES=60
+            export KUMA_DEFAULT_TIMEOUT="6s"
+          fi
+          if [[ "${{ inputs.k8sVersion }}" != "kind"* ]]; then
+            export CI_K3S_VERSION=${{ inputs.k8sVersion }}
+            export K3D_NETWORK_CNI=${{ inputs.cniNetworkPlugin }}
+          fi
+          if [[ "${{ inputs.arch }}" == "arm64" ]]; then
+            export MAKE_PARAMETERS="-j1"
+          else
+            export MAKE_PARAMETERS="-j2"
+          fi
+
+          if [[ "${{ inputs.legacyKDS }}" == true ]]; then
+            export KUMA_LEGACY_KDS=true
+          fi
+
+          if [[ "${{ inputs.target }}" == "" ]]; then
+            export GINKGO_E2E_LABEL_FILTERS="job-$CIRCLE_NODE_INDEX"
+          fi
+          env
+          if [[ "${{ inputs.target }}" != "" ]]; then
+            target="test/e2e-${{ inputs.target }}"
+          else
+            target="test/e2e"
+          fi
+          make ${MAKE_PARAMETERS} CI=true "${target}"
+  e2e_circleci:
+    if: ${{ inputs.arch != 'amd64' }}
     runs-on: ubuntu-latest
     steps:
       - name: "Print parameters"


### PR DESCRIPTION
### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues
  - N/A
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS
  - Confirmed
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s)
  - Manually tested
  - Don't forget `ci/` labels to run additional/fewer tests
    - Added
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)?
  - No need
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) 
  - No need to back-port.

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

This PR follows the previous one at [here](https://github.com/kumahq/kuma/pull/8457) and supports running E2E tests on GitHub Actions when `arch is amd64`, other arches will still run on CircleCI

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
