### PR TITLE
ci(actions): do not run kuma-commit workflow when trigger E2E on CircleCI; use pull_request_target on PRs to master

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -679,6 +679,8 @@ jobs:
 workflows:
   version: 2
   kuma-commit:
+    when:
+      equal: ["", << pipeline.parameters.gh_action_build_artifact_name >>]
     jobs:
       - go_cache:
           name: go_cache-<< matrix.arch >>

--- a/.github/workflows/build-test-distribute.yaml
+++ b/.github/workflows/build-test-distribute.yaml
@@ -3,7 +3,7 @@ on:
   push:
     branches: ["master", "release-*", "!*-merge-master"]
     tags: ["*"]
-  pull_request:
+  pull_request_target:
     branches: ["master", "release-*"]
 env:
   K8S_MIN_VERSION: v1.23.17-k3s1


### PR DESCRIPTION
In the latest GitHub Actions run, there  are two issues:
1. a successful trigger of E2E will also run `kuma-commit` workflow which is redundant since we already run  it on every `push` event
2. the PR checks are not providing secrets according to GitHub security policies. An example run could be found [here](https://github.com/kumahq/kuma/actions/runs/7022080252/job/19105818733).

This PR is to fix these issues.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues
  - N/A
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS
  - Confirmed
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s)
  - Manually tested
  - Don't forget `ci/` labels to run additional/fewer tests
    - Added
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? 
  - No need
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label)
  - No need.

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
