### PR TITLE
ci(actions): disable e2e tests because they are not stable for the moment

### DIFF
--- a/.github/workflows/build-test-distribute.yaml
+++ b/.github/workflows/build-test-distribute.yaml
@@ -119,7 +119,8 @@ jobs:
           path: build/reports
           retention-days: 7
   distributions:
-    needs: ["check", "test", "test_e2e", "test_e2e_env"]
+    needs: ["build", "check", "test"]
+    # needs: ["check", "test", "test_e2e", "test_e2e_env"]
     if: ${{ always() }}
     runs-on: ubuntu-latest
     steps:
@@ -181,7 +182,8 @@ jobs:
   gen_e2e_matrix:
     runs-on: ubuntu-latest
     needs: ["build"]
-    if: ${{ !contains(github.event.pull_request.labels.*.name, 'ci/skip-test') && !contains(github.event.pull_request.labels.*.name, 'ci/skip-e2e-test') }}
+    if: false
+    # if: ${{ !contains(github.event.pull_request.labels.*.name, 'ci/skip-test') && !contains(github.event.pull_request.labels.*.name, 'ci/skip-e2e-test') }}
     outputs:
       test_e2e: ${{ steps.generate-matrix.outputs.test_e2e }}
       test_e2e_env: ${{ steps.generate-matrix.outputs.test_e2e_env }}


### PR DESCRIPTION
Skips the e2e tests for now, and open up when they are stable.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues
  - N/A
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS
  - Confirmed 
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s)
  - N/A
  - Don't forget `ci/` labels to run additional/fewer tests
    - Added
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)?
  - No need
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) 
  - No need

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
