### PR TITLE
chore(finalizer): add retry to finalizer

### DIFF
--- a/pkg/gc/components.go
+++ b/pkg/gc/components.go
@@ -73,7 +73,7 @@ func setupFinalizer(rt runtime.Runtime) error {
 		return errors.Errorf("unknown Kuma CP mode %s", rt.Config().Mode)
 	}
 
-	finalizer, err := NewSubscriptionFinalizer(rt.ResourceManager(), rt.Tenants(), newTicker, rt.Metrics(), rt.Extensions(), resourceTypes...)
+	finalizer, err := NewSubscriptionFinalizer(rt.ResourceManager(), rt.Tenants(), newTicker, rt.Metrics(), rt.Extensions(), rt.Config().Store.Upsert, resourceTypes...)
 	if err != nil {
 		return err
 	}

--- a/pkg/gc/finalizer.go
+++ b/pkg/gc/finalizer.go
@@ -181,7 +181,7 @@ func (f *subscriptionFinalizer) checkGeneration(ctx context.Context, typ core_mo
 				}
 			}
 			return nil
-		}); err != nil {
+		}, manager.WithConflictRetry(500 * time.Millisecond, 3, 30)); err != nil {
 			return errors.Wrap(err, "unable to upsert insight")
 		}
 

--- a/pkg/gc/finalizer.go
+++ b/pkg/gc/finalizer.go
@@ -4,10 +4,12 @@ import (
 	"context"
 	"time"
 
+
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/kumahq/kuma/api/generic"
+	"github.com/kumahq/kuma/pkg/config/core/resources/store"
 	"github.com/kumahq/kuma/pkg/core"
 	"github.com/kumahq/kuma/pkg/core/resources/manager"
 	core_model "github.com/kumahq/kuma/pkg/core/resources/model"
@@ -53,16 +55,10 @@ type subscriptionFinalizer struct {
 	tenants        multitenant.Tenants
 	metric         prometheus.Summary
 	extensions     context.Context
+	upsert         store.UpsertConfig
 }
 
-func NewSubscriptionFinalizer(
-	rm manager.ResourceManager,
-	tenants multitenant.Tenants,
-	newTicker func() *time.Ticker,
-	metrics core_metrics.Metrics,
-	extensions context.Context,
-	types ...core_model.ResourceType,
-) (component.Component, error) {
+func NewSubscriptionFinalizer(rm manager.ResourceManager, tenants multitenant.Tenants, newTicker func() *time.Ticker, metrics core_metrics.Metrics, extensions context.Context, upsert store.UpsertConfig, types ...core_model.ResourceType) (component.Component, error) {
 	for _, typ := range types {
 		if !isInsightType(typ) {
 			return nil, errors.Errorf("%q type is not an Insight", typ)
@@ -86,6 +82,7 @@ func NewSubscriptionFinalizer(
 		tenants:        tenants,
 		metric:         metric,
 		extensions:     extensions,
+		upsert:         upsert,
 	}, nil
 }
 
@@ -181,7 +178,7 @@ func (f *subscriptionFinalizer) checkGeneration(ctx context.Context, typ core_mo
 				}
 			}
 			return nil
-		}, manager.WithConflictRetry(500 * time.Millisecond, 3, 30)); err != nil {
+		}, manager.WithConflictRetry(f.upsert.ConflictRetryBaseBackoff.Duration, f.upsert.ConflictRetryMaxTimes, f.upsert.ConflictRetryJitterPercent)); err != nil {
 			return errors.Wrap(err, "unable to upsert insight")
 		}
 

--- a/pkg/gc/finalizer.go
+++ b/pkg/gc/finalizer.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"time"
 
-
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 

--- a/pkg/gc/finalizer_test.go
+++ b/pkg/gc/finalizer_test.go
@@ -9,6 +9,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	system_proto "github.com/kumahq/kuma/api/system/v1alpha1"
+	store_config "github.com/kumahq/kuma/pkg/config/core/resources/store"
 	"github.com/kumahq/kuma/pkg/core/resources/apis/system"
 	"github.com/kumahq/kuma/pkg/core/resources/manager"
 	core_manager "github.com/kumahq/kuma/pkg/core/resources/manager"
@@ -35,7 +36,7 @@ var _ = Describe("Subscription Finalizer", func() {
 		Expect(err).ToNot(HaveOccurred())
 		finalizer, err := gc.NewSubscriptionFinalizer(rm, multitenant.SingleTenant, func() *time.Ticker {
 			return &time.Ticker{C: ticks}
-		}, metrics, context.Background(), system.ZoneInsightType)
+		}, metrics, context.Background(), store_config.DefaultUpsertConfig(), system.ZoneInsightType)
 		Expect(err).ToNot(HaveOccurred())
 		go func() {
 			stopped <- finalizer.Start(stop)


### PR DESCRIPTION
Coming from service review.

Do we want to make this configurable?

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [X] [Link to relevant issue][1] as well as docs and UI issues --
- [X] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [X] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [X] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [X] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
