### PR TITLE
test(unit): add json patch merge test

### DIFF
--- a/pkg/plugins/policies/core/jsonpatch/jsonpatch_suite_test.go
+++ b/pkg/plugins/policies/core/jsonpatch/jsonpatch_suite_test.go
@@ -1,0 +1,11 @@
+package jsonpatch_test
+
+import (
+	"testing"
+
+	"github.com/kumahq/kuma/pkg/test"
+)
+
+func TestPlugin(t *testing.T) {
+	test.RunSpecs(t, "JSON Patch")
+}

--- a/pkg/plugins/policies/core/jsonpatch/merge_test.go
+++ b/pkg/plugins/policies/core/jsonpatch/merge_test.go
@@ -1,0 +1,75 @@
+package jsonpatch_test
+
+import (
+	accesslogv3 "github.com/envoyproxy/go-control-plane/envoy/config/accesslog/v3"
+	grpcv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/access_loggers/grpc/v3"
+	open_telemetryv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/access_loggers/open_telemetry/v3"
+	envoy_hcm "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	common_api "github.com/kumahq/kuma/api/common/v1alpha1"
+	"github.com/kumahq/kuma/pkg/plugins/policies/core/jsonpatch"
+	"github.com/kumahq/kuma/pkg/util/pointer"
+	util_proto "github.com/kumahq/kuma/pkg/util/proto"
+)
+
+var _ = Describe("Json Patch merge", func() {
+	hcm := &envoy_hcm.HttpConnectionManager{
+		HttpFilters: []*envoy_hcm.HttpFilter{},
+		AccessLog: []*accesslogv3.AccessLog{
+			{
+				Name: "envoy.access_loggers.open_telemetry",
+				ConfigType: &accesslogv3.AccessLog_TypedConfig{
+					TypedConfig: util_proto.MustMarshalAny(&open_telemetryv3.OpenTelemetryAccessLogConfig{
+						CommonConfig: &grpcv3.CommonGrpcAccessLogConfig{
+							LogName: "a",
+						},
+					}),
+				},
+			},
+		},
+	}
+
+	It("should merge for camelCase", func() {
+		// given
+		patches := []common_api.JsonPatchBlock{
+			{
+				Op:    "replace",
+				Path:  pointer.To("/accessLog/0/typedConfig/commonConfig/logName"),
+				Value: []byte(`"y"`),
+			},
+		}
+
+		// when
+		hcmAny := util_proto.MustMarshalAny(hcm)
+		mergedHcmAny, err := jsonpatch.MergeJsonPatchAny(hcmAny, patches)
+
+		// then
+		Expect(err).ToNot(HaveOccurred())
+		mergedHcm := &envoy_hcm.HttpConnectionManager{}
+		err = util_proto.UnmarshalAnyTo(mergedHcmAny, mergedHcm)
+		Expect(err).ToNot(HaveOccurred())
+		mergedOtel := &open_telemetryv3.OpenTelemetryAccessLogConfig{}
+		err = util_proto.UnmarshalAnyTo(mergedHcm.AccessLog[0].GetTypedConfig(), mergedOtel)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(mergedOtel.CommonConfig.LogName).To(Equal("y"))
+	})
+
+	It("should should not merge for snake_case", func() {
+		// given
+		patches := []common_api.JsonPatchBlock{
+			{
+				Op:    "replace",
+				Path:  pointer.To("/access_log/0/typed_config/common_config/log_name"),
+				Value: []byte(`"y"`),
+			},
+		}
+
+		// when
+		_, err := jsonpatch.MergeJsonPatchAny(util_proto.MustMarshalAny(hcm), patches)
+
+		// then
+		Expect(err).To(HaveOccurred())
+	})
+})


### PR DESCRIPTION
### Checklist prior to review

Adds test that would be useful for my debugging. It was far from obvious that I have to use camelCase instead of snake_case, because Envoy returns snake_case from /config_dump. I'll also add this to docs.

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [ ] [Link to relevant issue][1] as well as docs and UI issues --
- [ ] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [ ] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [ ] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [ ] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
