### PR TITLE
test(e2e): add retries to prevent some flakes

### DIFF
--- a/test/e2e/helm/kuma_helm_deploy_global_universal_mode_and_zone.go
+++ b/test/e2e/helm/kuma_helm_deploy_global_universal_mode_and_zone.go
@@ -111,18 +111,18 @@ stringData:
 
 	It("should deploy Zone and Global on 2 clusters", func() {
 		// mesh is synced to zone
-		Eventually(func() string {
+		Eventually(func(g Gomega) {
 			output, err := zoneCluster.GetKumactlOptions().RunKumactlAndGetOutput("get", "meshes")
-			Expect(err).ToNot(HaveOccurred())
-			return output
-		}, "5s", "500ms").Should(ContainSubstring("default"))
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(output).To(ContainSubstring("default"))
+		}, "5s", "500ms").Should(Succeed())
 
 		// and dataplanes are synced to global
-		Eventually(func() string {
+		Eventually(func(g Gomega) {
 			output, err := globalCluster.GetKumactlOptions().RunKumactlAndGetOutput("get", "dataplanes")
-			Expect(err).ToNot(HaveOccurred())
-			return output
-		}, "5s", "500ms").Should(ContainSubstring("kuma-2-zone.demo-client"))
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(output).To(ContainSubstring("kuma-2-zone.demo-client"))
+		}, "5s", "500ms").Should(Succeed())
 	})
 
 	It("communication in between apps in zone works", func() {

--- a/test/e2e_env/multizone/localityawarelb/locality_aware_multizone_hybrid.go
+++ b/test/e2e_env/multizone/localityawarelb/locality_aware_multizone_hybrid.go
@@ -302,7 +302,7 @@ spec:
 		}).Should(Succeed())
 	})
 
-	It("should route based on the strategy when split defined", func() {
+	It("should route based on the strategy when split defined", FlakeAttempts(3), func() {
 		// given
 		Expect(YamlUniversal(fmt.Sprintf(`
 type: MeshHTTPRoute

--- a/test/e2e_env/multizone/localityawarelb/locality_aware_multizone_hybrid_egress.go
+++ b/test/e2e_env/multizone/localityawarelb/locality_aware_multizone_hybrid_egress.go
@@ -146,7 +146,7 @@ spec:
 		Expect(multizone.Global.DeleteMesh(mesh)).To(Succeed())
 	})
 
-	It("should route based on defined strategy with egress enabled", func() {
+	It("should route based on defined strategy with egress enabled", FlakeAttempts(3), func() {
 		// no lb priorities
 		Eventually(func() (map[string]int, error) {
 			return client.CollectResponsesByInstance(multizone.UniZone1, "demo-client_locality-aware-lb-egress_svc", "test-server_locality-aware-lb-egress_svc_80.mesh", client.WithNumberOfRequests(300))


### PR DESCRIPTION
The CI is unstable enough to just retry these tests

ref #4700

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
