### PR TITLE
chore(tests): explain use of WithSkipDefaultMesh better

### DIFF
--- a/test/e2e/helm/kuma_helm_deploy_global_and_zone_universal_mode.go
+++ b/test/e2e/helm/kuma_helm_deploy_global_and_zone_universal_mode.go
@@ -70,8 +70,9 @@ stringData:
 
 		err = NewClusterSetup().
 			Install(Kuma(core.Zone,
-				// it's required because we check if Kuma is ready,
-				// and we use "kubectl get mesh" which is not available in universal mode
+				// WithSkipDefaultMesh is required because we check if Kuma is ready by using "kubectl get mesh"
+				// here in the framework https://github.com/kumahq/kuma/blob/1633d34ad116dd1e618f4a27dd1526f5ff7d8bde/test/framework/k8s_cluster.go#L564
+				// but on universal mode we use postgres to manage resources so without this it will fail making the test suite fail
 				WithSkipDefaultMesh(true),
 				WithInstallationMode(HelmInstallationMode),
 				WithHelmReleaseName(releaseName),

--- a/test/e2e/helm/kuma_helm_deploy_global_universal_mode_and_zone.go
+++ b/test/e2e/helm/kuma_helm_deploy_global_universal_mode_and_zone.go
@@ -60,8 +60,9 @@ stringData:
 
 		err = NewClusterSetup().
 			Install(Kuma(core.Global,
-				// it's required because we check if Kuma is ready,
-				// and we use "kubectl get mesh" which is not available in universal mode
+				// WithSkipDefaultMesh is required because we check if Kuma is ready by using "kubectl get mesh"
+				// here in the framework https://github.com/kumahq/kuma/blob/1633d34ad116dd1e618f4a27dd1526f5ff7d8bde/test/framework/k8s_cluster.go#L564
+				// but on universal mode we use postgres to manage resources so without this it will fail making the test suite fail
 				WithSkipDefaultMesh(true),
 				WithInstallationMode(HelmInstallationMode),
 				WithHelmReleaseName(releaseName),


### PR DESCRIPTION
### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [ ] [Link to relevant issue][1] as well as docs and UI issues --
- [ ] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [ ] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [ ] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [ ] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
