### PR TITLE
feat(kds): log additional gRPC status codes at info level

### DIFF
--- a/pkg/kds/service/server.go
+++ b/pkg/kds/service/server.go
@@ -154,9 +154,10 @@ func (g *GlobalKDSServiceServer) streamEnvoyAdminRPC(
 	logger = kuma_log.AddFieldsFromCtx(logger, stream.Context(), g.extensions)
 	for _, filter := range g.filters {
 		if err := filter.InterceptServerStream(stream); err != nil {
-			if status.Code(err) == codes.InvalidArgument {
+			switch status.Code(err) {
+			case codes.InvalidArgument, codes.Unauthenticated, codes.PermissionDenied:
 				logger.Info("stream interceptor terminating the stream", "cause", err)
-			} else {
+			default:
 				logger.Error(err, "stream interceptor terminating the stream")
 			}
 			return err


### PR DESCRIPTION
This way we can use more of the existing gRPC status codes in authorizers and not have them logged as errors in the CP.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
