### PR TITLE
chore(zoneproxies): don't fail when mesh was deleted

### DIFF
--- a/pkg/xds/context/aggregate_mesh_context.go
+++ b/pkg/xds/context/aggregate_mesh_context.go
@@ -28,6 +28,10 @@ func AggregateMeshContexts(
 	for _, mesh := range meshList.Items {
 		meshCtx, err := fetcher(ctx, mesh.GetMeta().GetName())
 		if err != nil {
+			if core_store.IsResourceNotFound(err) {
+				// When the mesh no longer exists it's likely because it was removed since, let's just skip it.
+				continue
+			}
 			return AggregatedMeshContexts{}, err
 		}
 		meshContexts = append(meshContexts, meshCtx)

--- a/pkg/xds/server/v3/reconcile.go
+++ b/pkg/xds/server/v3/reconcile.go
@@ -93,7 +93,7 @@ func (r *reconciler) Reconcile(ctx context.Context, xdsCtx xds_context.Context, 
 	}
 	log.Info("config has changed", "versions", changed)
 
-	if err := r.cacher.Cache(node, snapshot); err != nil {
+	if err := r.cacher.Cache(ctx, node, snapshot); err != nil {
 		return false, errors.Wrap(err, "failed to store snapshot")
 	}
 
@@ -191,7 +191,7 @@ func (s *TemplateSnapshotGenerator) GenerateSnapshot(ctx context.Context, xdsCtx
 
 type snapshotCacher interface {
 	Get(*envoy_core.Node) (*envoy_cache.Snapshot, error)
-	Cache(*envoy_core.Node, *envoy_cache.Snapshot) error
+	Cache(context.Context, *envoy_core.Node, *envoy_cache.Snapshot) error
 	Clear(*envoy_core.Node)
 }
 
@@ -212,8 +212,8 @@ func (s *simpleSnapshotCacher) Get(node *envoy_core.Node) (*envoy_cache.Snapshot
 	return nil, err
 }
 
-func (s *simpleSnapshotCacher) Cache(node *envoy_core.Node, snapshot *envoy_cache.Snapshot) error {
-	return s.store.SetSnapshot(context.TODO(), s.hasher.ID(node), snapshot)
+func (s *simpleSnapshotCacher) Cache(ctx context.Context, node *envoy_core.Node, snapshot *envoy_cache.Snapshot) error {
+	return s.store.SetSnapshot(ctx, s.hasher.ID(node), snapshot)
 }
 
 func (s *simpleSnapshotCacher) Clear(node *envoy_core.Node) {


### PR DESCRIPTION
To build the aggregateMeshContext we first list the meshes and then retrieve the MeshContext. It's possible that between these 2 operations a mesh was deleted.
We simply ignore these now, the worst that can happen is that a mesh is ignored for a short time from the Egress which seems unlikely.

This should suppress a lot of error logs on the CP

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues --
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
