### PR TITLE
chore(kuma-cp): unify timeouts between policies

### DIFF
--- a/pkg/defaults/mesh/timeout.go
+++ b/pkg/defaults/mesh/timeout.go
@@ -1,11 +1,10 @@
 package mesh
 
 import (
-	"time"
-
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
 	"github.com/kumahq/kuma/pkg/core/resources/model"
+	policies_defaults "github.com/kumahq/kuma/pkg/plugins/policies/core/defaults"
 	util_proto "github.com/kumahq/kuma/pkg/util/proto"
 )
 
@@ -19,14 +18,14 @@ var DefaultTimeoutResource = func() model.Resource {
 				Match: mesh_proto.MatchAnyService(),
 			}},
 			Conf: &mesh_proto.Timeout_Conf{
-				ConnectTimeout: util_proto.Duration(5 * time.Second),
+				ConnectTimeout: util_proto.Duration(policies_defaults.DefaultConnectTimeout),
 				Tcp: &mesh_proto.Timeout_Conf_Tcp{
-					IdleTimeout: util_proto.Duration(1 * time.Hour),
+					IdleTimeout: util_proto.Duration(policies_defaults.DefaultIdleTimeout),
 				},
 				Http: &mesh_proto.Timeout_Conf_Http{
-					IdleTimeout:       util_proto.Duration(1 * time.Hour),
-					RequestTimeout:    util_proto.Duration(15 * time.Second),
-					StreamIdleTimeout: util_proto.Duration(30 * time.Minute),
+					IdleTimeout:       util_proto.Duration(policies_defaults.DefaultIdleTimeout),
+					RequestTimeout:    util_proto.Duration(policies_defaults.DefaultRequestTimeout),
+					StreamIdleTimeout: util_proto.Duration(policies_defaults.DefaultStreamIdleTimeout),
 				},
 			},
 		},
@@ -39,17 +38,16 @@ var DefaultTimeoutResource = func() model.Resource {
 // bigger than outbound side timeouts or disabled.
 var DefaultInboundTimeout = func() *mesh_proto.Timeout_Conf {
 	const factor = 2
-	upstream := DefaultTimeoutResource().(*core_mesh.TimeoutResource).Spec.GetConf()
 
 	return &mesh_proto.Timeout_Conf{
-		ConnectTimeout: util_proto.Duration(factor * upstream.GetConnectTimeout().AsDuration()),
+		ConnectTimeout: util_proto.Duration(factor * policies_defaults.DefaultConnectTimeout),
 		Tcp: &mesh_proto.Timeout_Conf_Tcp{
-			IdleTimeout: util_proto.Duration(factor * upstream.GetTcp().GetIdleTimeout().AsDuration()),
+			IdleTimeout: util_proto.Duration(factor * policies_defaults.DefaultIdleTimeout),
 		},
 		Http: &mesh_proto.Timeout_Conf_Http{
 			RequestTimeout:    util_proto.Duration(0),
-			IdleTimeout:       util_proto.Duration(factor * upstream.GetHttp().GetIdleTimeout().AsDuration()),
-			StreamIdleTimeout: util_proto.Duration(factor * upstream.GetHttp().GetStreamIdleTimeout().AsDuration()),
+			IdleTimeout:       util_proto.Duration(factor * policies_defaults.DefaultIdleTimeout),
+			StreamIdleTimeout: util_proto.Duration(factor * policies_defaults.DefaultStreamIdleTimeout),
 			MaxStreamDuration: util_proto.Duration(0),
 		},
 	}

--- a/pkg/plugins/bootstrap/k8s/xds/hooks/testdata/api-server-bypass.yaml
+++ b/pkg/plugins/bootstrap/k8s/xds/hooks/testdata/api-server-bypass.yaml
@@ -3,7 +3,7 @@ resources:
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
     altStatName: plugins_bootstrap_k8s_hooks_apiServerBypass
-    connectTimeout: 10s
+    connectTimeout: 5s
     lbPolicy: CLUSTER_PROVIDED
     name: plugins:bootstrap:k8s:hooks:apiServerBypass
     type: ORIGINAL_DST

--- a/pkg/plugins/policies/core/defaults/consts.go
+++ b/pkg/plugins/policies/core/defaults/consts.go
@@ -1,0 +1,15 @@
+package defaults
+
+import (
+	"time"
+)
+
+// Timeouts
+const (
+	DefaultConnectTimeout        = 5 * time.Second
+	DefaultIdleTimeout           = time.Hour
+	DefaultStreamIdleTimeout     = 30 * time.Minute
+	DefaultRequestTimeout        = 15 * time.Second
+	DefaultMaxStreamDuration     = 0
+	DefaultMaxConnectionDuration = 0
+)

--- a/pkg/plugins/policies/meshaccesslog/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshaccesslog/plugin/v1alpha1/plugin_test.go
@@ -506,7 +506,7 @@ var _ = Describe("MeshAccessLog", func() {
 			expectedClusters: []string{
 				`
             altStatName: meshaccesslog_opentelemetry_0
-            connectTimeout: 10s
+            connectTimeout: 5s
             dnsLookupFamily: V4_ONLY
             loadAssignment:
                 clusterName: meshaccesslog:opentelemetry:0
@@ -526,7 +526,7 @@ var _ = Describe("MeshAccessLog", func() {
                         http2ProtocolOptions: {}
             `, `
             altStatName: meshaccesslog_opentelemetry_1
-            connectTimeout: 10s
+            connectTimeout: 5s
             dnsLookupFamily: V4_ONLY
             loadAssignment:
                 clusterName: meshaccesslog:opentelemetry:1

--- a/pkg/plugins/policies/meshaccesslog/plugin/v1alpha1/testdata/basic-gateway.gateway.cluster.golden.yaml
+++ b/pkg/plugins/policies/meshaccesslog/plugin/v1alpha1/testdata/basic-gateway.gateway.cluster.golden.yaml
@@ -1,4 +1,4 @@
-connectTimeout: 10s
+connectTimeout: 5s
 edsClusterConfig:
   edsConfig:
     ads: {}

--- a/pkg/plugins/policies/meshcircuitbreaker/plugin/v1alpha1/testdata/basic.gateway_cluster.golden.yaml
+++ b/pkg/plugins/policies/meshcircuitbreaker/plugin/v1alpha1/testdata/basic.gateway_cluster.golden.yaml
@@ -5,7 +5,7 @@ circuitBreakers:
     maxPendingRequests: 3333
     maxRequests: 4444
     maxRetries: 5555
-connectTimeout: 10s
+connectTimeout: 5s
 edsClusterConfig:
   edsConfig:
     ads: {}

--- a/pkg/plugins/policies/meshhealthcheck/plugin/v1alpha1/testdata/basic.gateway_cluster.golden.yaml
+++ b/pkg/plugins/policies/meshhealthcheck/plugin/v1alpha1/testdata/basic.gateway_cluster.golden.yaml
@@ -3,7 +3,7 @@ commonLbConfig:
     value: 62.9
   zoneAwareLbConfig:
     failTrafficOnPanic: true
-connectTimeout: 10s
+connectTimeout: 5s
 edsClusterConfig:
   edsConfig:
     ads: {}

--- a/pkg/plugins/policies/meshloadbalancingstrategy/plugin/v1alpha1/testdata/basic.gateway_cluster.golden.yaml
+++ b/pkg/plugins/policies/meshloadbalancingstrategy/plugin/v1alpha1/testdata/basic.gateway_cluster.golden.yaml
@@ -1,4 +1,4 @@
-connectTimeout: 10s
+connectTimeout: 5s
 edsClusterConfig:
   edsConfig:
     ads: {}

--- a/pkg/plugins/policies/meshloadbalancingstrategy/plugin/v1alpha1/testdata/locality_aware.gateway_cluster.golden.yaml
+++ b/pkg/plugins/policies/meshloadbalancingstrategy/plugin/v1alpha1/testdata/locality_aware.gateway_cluster.golden.yaml
@@ -1,6 +1,6 @@
 commonLbConfig:
   localityWeightedLbConfig: {}
-connectTimeout: 10s
+connectTimeout: 5s
 edsClusterConfig:
   edsConfig:
     ads: {}

--- a/pkg/plugins/policies/meshtrace/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshtrace/plugin/v1alpha1/plugin_test.go
@@ -201,7 +201,7 @@ var _ = Describe("MeshTrace", func() {
 			expectedClusters: []string{
 				`
             altStatName: meshtrace_zipkin
-            connectTimeout: 10s
+            connectTimeout: 5s
             dnsLookupFamily: V4_ONLY
             loadAssignment:
                 clusterName: meshtrace:zipkin
@@ -335,7 +335,7 @@ var _ = Describe("MeshTrace", func() {
 			expectedClusters: []string{
 				`
             altStatName: meshtrace_opentelemetry
-            connectTimeout: 10s
+            connectTimeout: 5s
             dnsLookupFamily: V4_ONLY
             loadAssignment:
                 clusterName: meshtrace:opentelemetry
@@ -433,7 +433,7 @@ var _ = Describe("MeshTrace", func() {
 			expectedClusters: []string{
 				`
             altStatName: meshtrace_datadog
-            connectTimeout: 10s
+            connectTimeout: 5s
             dnsLookupFamily: V4_ONLY
             loadAssignment:
                 clusterName: meshtrace:datadog
@@ -529,7 +529,7 @@ var _ = Describe("MeshTrace", func() {
 			expectedClusters: []string{
 				`
             altStatName: meshtrace_zipkin
-            connectTimeout: 10s
+            connectTimeout: 5s
             dnsLookupFamily: V4_ONLY
             loadAssignment:
                 clusterName: meshtrace:zipkin

--- a/pkg/plugins/runtime/gateway/testdata/03-gateway-listener.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/03-gateway-listener.yaml
@@ -2,7 +2,7 @@ Clusters:
   Resources:
     tracing:jaeger-collector:
       altStatName: tracing_jaeger-collector
-      connectTimeout: 10s
+      connectTimeout: 5s
       dnsLookupFamily: V4_ONLY
       loadAssignment:
         clusterName: tracing:jaeger-collector

--- a/pkg/plugins/runtime/gateway/testdata/http/no-timeout.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/http/no-timeout.yaml
@@ -7,7 +7,7 @@ Clusters:
           maxPendingRequests: 1024
           maxRequests: 1024
           maxRetries: 3
-      connectTimeout: 10s
+      connectTimeout: 5s
       edsClusterConfig:
         edsConfig:
           ads: {}

--- a/pkg/plugins/runtime/gateway/testdata/https/no-timeout.yaml
+++ b/pkg/plugins/runtime/gateway/testdata/https/no-timeout.yaml
@@ -7,7 +7,7 @@ Clusters:
           maxPendingRequests: 1024
           maxRequests: 1024
           maxRetries: 3
-      connectTimeout: 10s
+      connectTimeout: 5s
       edsClusterConfig:
         edsConfig:
           ads: {}

--- a/pkg/xds/envoy/clusters/v3/timeout_configurer.go
+++ b/pkg/xds/envoy/clusters/v3/timeout_configurer.go
@@ -1,18 +1,15 @@
 package clusters
 
 import (
-	"time"
-
 	envoy_cluster "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
 	envoy_core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	envoy_upstream_http "github.com/envoyproxy/go-control-plane/envoy/extensions/upstreams/http/v3"
 
 	mesh_proto "github.com/kumahq/kuma/api/mesh/v1alpha1"
 	core_mesh "github.com/kumahq/kuma/pkg/core/resources/apis/mesh"
+	policies_defaults "github.com/kumahq/kuma/pkg/plugins/policies/core/defaults"
 	util_proto "github.com/kumahq/kuma/pkg/util/proto"
 )
-
-const defaultConnectTimeout = 10 * time.Second
 
 type TimeoutConfigurer struct {
 	Protocol core_mesh.Protocol
@@ -22,7 +19,7 @@ type TimeoutConfigurer struct {
 var _ ClusterConfigurer = &TimeoutConfigurer{}
 
 func (t *TimeoutConfigurer) Configure(cluster *envoy_cluster.Cluster) error {
-	cluster.ConnectTimeout = util_proto.Duration(t.Conf.GetConnectTimeoutOrDefault(defaultConnectTimeout))
+	cluster.ConnectTimeout = util_proto.Duration(t.Conf.GetConnectTimeoutOrDefault(policies_defaults.DefaultConnectTimeout))
 	switch t.Protocol {
 	case core_mesh.ProtocolHTTP, core_mesh.ProtocolHTTP2, core_mesh.ProtocolGRPC:
 		err := UpdateCommonHttpProtocolOptions(cluster, func(options *envoy_upstream_http.HttpProtocolOptions) {

--- a/pkg/xds/generator/egress/testdata/01.externalservice-only.golden.yaml
+++ b/pkg/xds/generator/egress/testdata/01.externalservice-only.golden.yaml
@@ -3,7 +3,7 @@ resources:
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
     altStatName: mesh-1_externalservice-1
-    connectTimeout: 10s
+    connectTimeout: 5s
     dnsLookupFamily: V4_ONLY
     loadAssignment:
       clusterName: mesh-1:externalservice-1

--- a/pkg/xds/generator/egress/testdata/02.internalservice-only.golden.yaml
+++ b/pkg/xds/generator/egress/testdata/02.internalservice-only.golden.yaml
@@ -3,7 +3,7 @@ resources:
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
     altStatName: mesh-1_service-in-zone-2
-    connectTimeout: 10s
+    connectTimeout: 5s
     edsClusterConfig:
       edsConfig:
         ads: {}

--- a/pkg/xds/generator/egress/testdata/03.mixed-services.golden.yaml
+++ b/pkg/xds/generator/egress/testdata/03.mixed-services.golden.yaml
@@ -3,7 +3,7 @@ resources:
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
     altStatName: mesh-1_externalservice-1
-    connectTimeout: 10s
+    connectTimeout: 5s
     dnsLookupFamily: V4_ONLY
     loadAssignment:
       clusterName: mesh-1:externalservice-1
@@ -34,7 +34,7 @@ resources:
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
     altStatName: mesh-1_externalservice-2
-    connectTimeout: 10s
+    connectTimeout: 5s
     dnsLookupFamily: V4_ONLY
     loadAssignment:
       clusterName: mesh-1:externalservice-2
@@ -89,7 +89,7 @@ resources:
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
     altStatName: mesh-1_service-1-zone-2
-    connectTimeout: 10s
+    connectTimeout: 5s
     edsClusterConfig:
       edsConfig:
         ads: {}
@@ -100,7 +100,7 @@ resources:
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
     altStatName: mesh-1_service-2-zone-2
-    connectTimeout: 10s
+    connectTimeout: 5s
     edsClusterConfig:
       edsConfig:
         ads: {}

--- a/pkg/xds/generator/egress/testdata/04.mixed-services-custom-trafficroute.golden.yaml
+++ b/pkg/xds/generator/egress/testdata/04.mixed-services-custom-trafficroute.golden.yaml
@@ -3,7 +3,7 @@ resources:
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
     altStatName: mesh-1_externalservice-1
-    connectTimeout: 10s
+    connectTimeout: 5s
     dnsLookupFamily: V4_ONLY
     loadAssignment:
       clusterName: mesh-1:externalservice-1
@@ -34,7 +34,7 @@ resources:
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
     altStatName: mesh-1_externalservice-2
-    connectTimeout: 10s
+    connectTimeout: 5s
     dnsLookupFamily: V4_ONLY
     loadAssignment:
       clusterName: mesh-1:externalservice-2

--- a/pkg/xds/generator/egress/testdata/05.mixed-services-with-custom-trafficpermissions.golden.yaml
+++ b/pkg/xds/generator/egress/testdata/05.mixed-services-with-custom-trafficpermissions.golden.yaml
@@ -3,7 +3,7 @@ resources:
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
     altStatName: mesh-1_externalservice-1
-    connectTimeout: 10s
+    connectTimeout: 5s
     dnsLookupFamily: V4_ONLY
     loadAssignment:
       clusterName: mesh-1:externalservice-1
@@ -34,7 +34,7 @@ resources:
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
     altStatName: mesh-1_externalservice-2
-    connectTimeout: 10s
+    connectTimeout: 5s
     dnsLookupFamily: V4_ONLY
     loadAssignment:
       clusterName: mesh-1:externalservice-2
@@ -89,7 +89,7 @@ resources:
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
     altStatName: mesh-1_service-1-zone-2
-    connectTimeout: 10s
+    connectTimeout: 5s
     edsClusterConfig:
       edsConfig:
         ads: {}
@@ -100,7 +100,7 @@ resources:
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
     altStatName: mesh-1_service-2-zone-2
-    connectTimeout: 10s
+    connectTimeout: 5s
     edsClusterConfig:
       edsConfig:
         ads: {}

--- a/pkg/xds/generator/egress/testdata/06.mixed-services-with-external-in-other-zone.golden.yaml
+++ b/pkg/xds/generator/egress/testdata/06.mixed-services-with-external-in-other-zone.golden.yaml
@@ -3,7 +3,7 @@ resources:
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
     altStatName: mesh-1_externalservice-1
-    connectTimeout: 10s
+    connectTimeout: 5s
     dnsLookupFamily: V4_ONLY
     loadAssignment:
       clusterName: mesh-1:externalservice-1
@@ -34,7 +34,7 @@ resources:
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
     altStatName: mesh-1_externalservice-2
-    connectTimeout: 10s
+    connectTimeout: 5s
     edsClusterConfig:
       edsConfig:
         ads: {}
@@ -45,7 +45,7 @@ resources:
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
     altStatName: mesh-1_service-1-zone-2
-    connectTimeout: 10s
+    connectTimeout: 5s
     edsClusterConfig:
       edsConfig:
         ads: {}
@@ -56,7 +56,7 @@ resources:
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
     altStatName: mesh-1_service-2-zone-2
-    connectTimeout: 10s
+    connectTimeout: 5s
     edsClusterConfig:
       edsConfig:
         ads: {}

--- a/pkg/xds/generator/egress/testdata/subsets-with-meshhttproute.golden.yaml
+++ b/pkg/xds/generator/egress/testdata/subsets-with-meshhttproute.golden.yaml
@@ -3,7 +3,7 @@ resources:
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
     altStatName: mesh-1_service-in-zone-2
-    connectTimeout: 10s
+    connectTimeout: 5s
     edsClusterConfig:
       edsConfig:
         ads: {}

--- a/pkg/xds/generator/egress/testdata/traffic-by-default-meshhttproute.golden.yaml
+++ b/pkg/xds/generator/egress/testdata/traffic-by-default-meshhttproute.golden.yaml
@@ -3,7 +3,7 @@ resources:
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
     altStatName: mesh-1_service-in-zone-2
-    connectTimeout: 10s
+    connectTimeout: 5s
     edsClusterConfig:
       edsConfig:
         ads: {}

--- a/pkg/xds/generator/testdata/admin/01.envoy-config.golden.yaml
+++ b/pkg/xds/generator/testdata/admin/01.envoy-config.golden.yaml
@@ -3,7 +3,7 @@ resources:
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
     altStatName: kuma_envoy_admin
-    connectTimeout: 10s
+    connectTimeout: 5s
     loadAssignment:
       clusterName: kuma:envoy:admin
       endpoints:

--- a/pkg/xds/generator/testdata/admin/02.envoy-config.golden.yaml
+++ b/pkg/xds/generator/testdata/admin/02.envoy-config.golden.yaml
@@ -3,7 +3,7 @@ resources:
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
     altStatName: kuma_envoy_admin
-    connectTimeout: 10s
+    connectTimeout: 5s
     loadAssignment:
       clusterName: kuma:envoy:admin
       endpoints:

--- a/pkg/xds/generator/testdata/admin/03.envoy-config.golden.yaml
+++ b/pkg/xds/generator/testdata/admin/03.envoy-config.golden.yaml
@@ -3,7 +3,7 @@ resources:
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
     altStatName: kuma_envoy_admin
-    connectTimeout: 10s
+    connectTimeout: 5s
     loadAssignment:
       clusterName: kuma:envoy:admin
       endpoints:

--- a/pkg/xds/generator/testdata/admin/04.envoy-config.golden.yaml
+++ b/pkg/xds/generator/testdata/admin/04.envoy-config.golden.yaml
@@ -3,7 +3,7 @@ resources:
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
     altStatName: kuma_envoy_admin
-    connectTimeout: 10s
+    connectTimeout: 5s
     loadAssignment:
       clusterName: kuma:envoy:admin
       endpoints:

--- a/pkg/xds/generator/testdata/admin/05.envoy-config.golden.yaml
+++ b/pkg/xds/generator/testdata/admin/05.envoy-config.golden.yaml
@@ -3,7 +3,7 @@ resources:
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
     altStatName: kuma_envoy_admin
-    connectTimeout: 10s
+    connectTimeout: 5s
     loadAssignment:
       clusterName: kuma:envoy:admin
       endpoints:

--- a/pkg/xds/generator/testdata/direct-access/03.envoy-config.golden.yaml
+++ b/pkg/xds/generator/testdata/direct-access/03.envoy-config.golden.yaml
@@ -2,7 +2,7 @@ resources:
 - name: direct_access
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
-    connectTimeout: 10s
+    connectTimeout: 5s
     lbPolicy: CLUSTER_PROVIDED
     name: direct_access
     type: ORIGINAL_DST

--- a/pkg/xds/generator/testdata/direct-access/04.envoy-config.golden.yaml
+++ b/pkg/xds/generator/testdata/direct-access/04.envoy-config.golden.yaml
@@ -2,7 +2,7 @@ resources:
 - name: direct_access
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
-    connectTimeout: 10s
+    connectTimeout: 5s
     lbPolicy: CLUSTER_PROVIDED
     name: direct_access
     type: ORIGINAL_DST

--- a/pkg/xds/generator/testdata/ingress/01.envoy.golden.yaml
+++ b/pkg/xds/generator/testdata/ingress/01.envoy.golden.yaml
@@ -3,7 +3,7 @@ resources:
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
     altStatName: mesh1_backend
-    connectTimeout: 10s
+    connectTimeout: 5s
     edsClusterConfig:
       edsConfig:
         ads: {}

--- a/pkg/xds/generator/testdata/ingress/03.envoy.golden.yaml
+++ b/pkg/xds/generator/testdata/ingress/03.envoy.golden.yaml
@@ -3,7 +3,7 @@ resources:
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
     altStatName: mesh1_backend
-    connectTimeout: 10s
+    connectTimeout: 5s
     edsClusterConfig:
       edsConfig:
         ads: {}

--- a/pkg/xds/generator/testdata/ingress/04.envoy.golden.yaml
+++ b/pkg/xds/generator/testdata/ingress/04.envoy.golden.yaml
@@ -3,7 +3,7 @@ resources:
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
     altStatName: mesh1_backend
-    connectTimeout: 10s
+    connectTimeout: 5s
     edsClusterConfig:
       edsConfig:
         ads: {}
@@ -23,7 +23,7 @@ resources:
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
     altStatName: mesh2_backend
-    connectTimeout: 10s
+    connectTimeout: 5s
     edsClusterConfig:
       edsConfig:
         ads: {}
@@ -34,7 +34,7 @@ resources:
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
     altStatName: mesh2_frontend
-    connectTimeout: 10s
+    connectTimeout: 5s
     edsClusterConfig:
       edsConfig:
         ads: {}

--- a/pkg/xds/generator/testdata/ingress/05.envoy.golden.yaml
+++ b/pkg/xds/generator/testdata/ingress/05.envoy.golden.yaml
@@ -3,7 +3,7 @@ resources:
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
     altStatName: mesh1_backend
-    connectTimeout: 10s
+    connectTimeout: 5s
     edsClusterConfig:
       edsConfig:
         ads: {}

--- a/pkg/xds/generator/testdata/ingress/meshgateway.envoy.golden.yaml
+++ b/pkg/xds/generator/testdata/ingress/meshgateway.envoy.golden.yaml
@@ -3,7 +3,7 @@ resources:
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
     altStatName: mesh1_backend
-    connectTimeout: 10s
+    connectTimeout: 5s
     edsClusterConfig:
       edsConfig:
         ads: {}
@@ -14,7 +14,7 @@ resources:
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
     altStatName: mesh2_mesh-gateway
-    connectTimeout: 10s
+    connectTimeout: 5s
     edsClusterConfig:
       edsConfig:
         ads: {}

--- a/pkg/xds/generator/testdata/ingress/virtual-outbound.envoy.golden.yaml
+++ b/pkg/xds/generator/testdata/ingress/virtual-outbound.envoy.golden.yaml
@@ -3,7 +3,7 @@ resources:
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
     altStatName: mesh1_backend
-    connectTimeout: 10s
+    connectTimeout: 5s
     edsClusterConfig:
       edsConfig:
         ads: {}

--- a/pkg/xds/generator/testdata/ingress/with-meshhttproute-subset.envoy.golden.yaml
+++ b/pkg/xds/generator/testdata/ingress/with-meshhttproute-subset.envoy.golden.yaml
@@ -3,7 +3,7 @@ resources:
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
     altStatName: mesh1_backend
-    connectTimeout: 10s
+    connectTimeout: 5s
     edsClusterConfig:
       edsConfig:
         ads: {}

--- a/pkg/xds/generator/testdata/ingress/with-meshhttproute.envoy.golden.yaml
+++ b/pkg/xds/generator/testdata/ingress/with-meshhttproute.envoy.golden.yaml
@@ -3,7 +3,7 @@ resources:
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
     altStatName: mesh1_backend
-    connectTimeout: 10s
+    connectTimeout: 5s
     edsClusterConfig:
       edsConfig:
         ads: {}

--- a/pkg/xds/generator/testdata/outbound-proxy/03.envoy.golden.yaml
+++ b/pkg/xds/generator/testdata/outbound-proxy/03.envoy.golden.yaml
@@ -21,7 +21,7 @@ resources:
 - name: api-http
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
-    connectTimeout: 10s
+    connectTimeout: 5s
     edsClusterConfig:
       edsConfig:
         ads: {}
@@ -84,7 +84,7 @@ resources:
 - name: backend
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
-    connectTimeout: 10s
+    connectTimeout: 5s
     edsClusterConfig:
       edsConfig:
         ads: {}
@@ -100,7 +100,7 @@ resources:
 - name: db-c182dd9f4bf584d7
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
-    connectTimeout: 10s
+    connectTimeout: 5s
     edsClusterConfig:
       edsConfig:
         ads: {}
@@ -115,7 +115,7 @@ resources:
 - name: db-f7d9086d4169338b
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
-    connectTimeout: 10s
+    connectTimeout: 5s
     edsClusterConfig:
       edsConfig:
         ads: {}

--- a/pkg/xds/generator/testdata/outbound-proxy/04.envoy.golden.yaml
+++ b/pkg/xds/generator/testdata/outbound-proxy/04.envoy.golden.yaml
@@ -2,7 +2,7 @@ resources:
 - name: api-http
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
-    connectTimeout: 10s
+    connectTimeout: 5s
     edsClusterConfig:
       edsConfig:
         ads: {}
@@ -91,7 +91,7 @@ resources:
 - name: backend
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
-    connectTimeout: 10s
+    connectTimeout: 5s
     edsClusterConfig:
       edsConfig:
         ads: {}
@@ -131,7 +131,7 @@ resources:
 - name: db-c182dd9f4bf584d7
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
-    connectTimeout: 10s
+    connectTimeout: 5s
     edsClusterConfig:
       edsConfig:
         ads: {}
@@ -170,7 +170,7 @@ resources:
 - name: db-f7d9086d4169338b
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
-    connectTimeout: 10s
+    connectTimeout: 5s
     edsClusterConfig:
       edsConfig:
         ads: {}

--- a/pkg/xds/generator/testdata/outbound-proxy/05.envoy.golden.yaml
+++ b/pkg/xds/generator/testdata/outbound-proxy/05.envoy.golden.yaml
@@ -2,7 +2,7 @@ resources:
 - name: es-be7aaa8dde77c2c8
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
-    connectTimeout: 10s
+    connectTimeout: 5s
     loadAssignment:
       clusterName: es-be7aaa8dde77c2c8
       endpoints:

--- a/pkg/xds/generator/testdata/outbound-proxy/08.envoy.golden.yaml
+++ b/pkg/xds/generator/testdata/outbound-proxy/08.envoy.golden.yaml
@@ -2,7 +2,7 @@ resources:
 - name: es2-b5516780eaf1ed13
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
-    connectTimeout: 10s
+    connectTimeout: 5s
     loadAssignment:
       clusterName: es2-b5516780eaf1ed13
       endpoints:
@@ -31,7 +31,7 @@ resources:
 - name: es2-d79214c8b3a5805b
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
-    connectTimeout: 10s
+    connectTimeout: 5s
     loadAssignment:
       clusterName: es2-d79214c8b3a5805b
       endpoints:

--- a/pkg/xds/generator/testdata/outbound-proxy/09.envoy.golden.yaml
+++ b/pkg/xds/generator/testdata/outbound-proxy/09.envoy.golden.yaml
@@ -2,7 +2,7 @@ resources:
 - name: api-http-5637c619d2781fec_mesh2
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
-    connectTimeout: 10s
+    connectTimeout: 5s
     edsClusterConfig:
       edsConfig:
         ads: {}

--- a/pkg/xds/generator/testdata/outbound-proxy/cluster-dots.envoy.golden.yaml
+++ b/pkg/xds/generator/testdata/outbound-proxy/cluster-dots.envoy.golden.yaml
@@ -3,7 +3,7 @@ resources:
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
     altStatName: backend_kuma-system
-    connectTimeout: 10s
+    connectTimeout: 5s
     edsClusterConfig:
       edsConfig:
         ads: {}
@@ -18,7 +18,7 @@ resources:
 - name: db-104dbb63d60dfdfa
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
-    connectTimeout: 10s
+    connectTimeout: 5s
     edsClusterConfig:
       edsConfig:
         ads: {}

--- a/pkg/xds/generator/testdata/profile-source/1-envoy-config.golden.yaml
+++ b/pkg/xds/generator/testdata/profile-source/1-envoy-config.golden.yaml
@@ -2,7 +2,7 @@ resources:
 - name: db
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
-    connectTimeout: 10s
+    connectTimeout: 5s
     edsClusterConfig:
       edsConfig:
         ads: {}
@@ -41,7 +41,7 @@ resources:
 - name: elastic
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
-    connectTimeout: 10s
+    connectTimeout: 5s
     edsClusterConfig:
       edsConfig:
         ads: {}
@@ -87,7 +87,7 @@ resources:
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
     altStatName: kuma_envoy_admin
-    connectTimeout: 10s
+    connectTimeout: 5s
     loadAssignment:
       clusterName: kuma:envoy:admin
       endpoints:

--- a/pkg/xds/generator/testdata/profile-source/2-envoy-config.golden.yaml
+++ b/pkg/xds/generator/testdata/profile-source/2-envoy-config.golden.yaml
@@ -2,7 +2,7 @@ resources:
 - name: db
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
-    connectTimeout: 10s
+    connectTimeout: 5s
     edsClusterConfig:
       edsConfig:
         ads: {}
@@ -41,7 +41,7 @@ resources:
 - name: elastic
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
-    connectTimeout: 10s
+    connectTimeout: 5s
     edsClusterConfig:
       edsConfig:
         ads: {}
@@ -87,7 +87,7 @@ resources:
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
     altStatName: inbound_passthrough_ipv4
-    connectTimeout: 10s
+    connectTimeout: 5s
     lbPolicy: CLUSTER_PROVIDED
     name: inbound:passthrough:ipv4
     type: ORIGINAL_DST
@@ -99,7 +99,7 @@ resources:
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
     altStatName: kuma_envoy_admin
-    connectTimeout: 10s
+    connectTimeout: 5s
     loadAssignment:
       clusterName: kuma:envoy:admin
       endpoints:
@@ -135,7 +135,7 @@ resources:
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
     altStatName: outbound_passthrough_ipv4
-    connectTimeout: 10s
+    connectTimeout: 5s
     lbPolicy: CLUSTER_PROVIDED
     name: outbound:passthrough:ipv4
     type: ORIGINAL_DST

--- a/pkg/xds/generator/testdata/profile-source/3-envoy-config.golden.yaml
+++ b/pkg/xds/generator/testdata/profile-source/3-envoy-config.golden.yaml
@@ -2,7 +2,7 @@ resources:
 - name: db
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
-    connectTimeout: 10s
+    connectTimeout: 5s
     edsClusterConfig:
       edsConfig:
         ads: {}
@@ -41,7 +41,7 @@ resources:
 - name: elastic
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
-    connectTimeout: 10s
+    connectTimeout: 5s
     edsClusterConfig:
       edsConfig:
         ads: {}
@@ -87,7 +87,7 @@ resources:
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
     altStatName: kuma_envoy_admin
-    connectTimeout: 10s
+    connectTimeout: 5s
     loadAssignment:
       clusterName: kuma:envoy:admin
       endpoints:
@@ -103,7 +103,7 @@ resources:
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
     altStatName: kuma_metrics_hijacker
-    connectTimeout: 10s
+    connectTimeout: 5s
     loadAssignment:
       clusterName: kuma:metrics:hijacker
       endpoints:

--- a/pkg/xds/generator/testdata/profile-source/4-envoy-config.golden.yaml
+++ b/pkg/xds/generator/testdata/profile-source/4-envoy-config.golden.yaml
@@ -2,7 +2,7 @@ resources:
 - name: db
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
-    connectTimeout: 10s
+    connectTimeout: 5s
     edsClusterConfig:
       edsConfig:
         ads: {}
@@ -41,7 +41,7 @@ resources:
 - name: elastic
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
-    connectTimeout: 10s
+    connectTimeout: 5s
     edsClusterConfig:
       edsConfig:
         ads: {}
@@ -87,7 +87,7 @@ resources:
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
     altStatName: inbound_passthrough_ipv4
-    connectTimeout: 10s
+    connectTimeout: 5s
     lbPolicy: CLUSTER_PROVIDED
     name: inbound:passthrough:ipv4
     type: ORIGINAL_DST
@@ -99,7 +99,7 @@ resources:
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
     altStatName: kuma_envoy_admin
-    connectTimeout: 10s
+    connectTimeout: 5s
     loadAssignment:
       clusterName: kuma:envoy:admin
       endpoints:
@@ -115,7 +115,7 @@ resources:
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
     altStatName: kuma_metrics_hijacker
-    connectTimeout: 10s
+    connectTimeout: 5s
     loadAssignment:
       clusterName: kuma:metrics:hijacker
       endpoints:
@@ -157,7 +157,7 @@ resources:
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
     altStatName: outbound_passthrough_ipv4
-    connectTimeout: 10s
+    connectTimeout: 5s
     lbPolicy: CLUSTER_PROVIDED
     name: outbound:passthrough:ipv4
     type: ORIGINAL_DST

--- a/pkg/xds/generator/testdata/prometheus-endpoint/custom.envoy-config.golden.yaml
+++ b/pkg/xds/generator/testdata/prometheus-endpoint/custom.envoy-config.golden.yaml
@@ -3,7 +3,7 @@ resources:
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
     altStatName: kuma_metrics_hijacker
-    connectTimeout: 10s
+    connectTimeout: 5s
     loadAssignment:
       clusterName: kuma:metrics:hijacker
       endpoints:

--- a/pkg/xds/generator/testdata/prometheus-endpoint/default-mtls.envoy-config.golden.yaml
+++ b/pkg/xds/generator/testdata/prometheus-endpoint/default-mtls.envoy-config.golden.yaml
@@ -3,7 +3,7 @@ resources:
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
     altStatName: kuma_metrics_hijacker
-    connectTimeout: 10s
+    connectTimeout: 5s
     loadAssignment:
       clusterName: kuma:metrics:hijacker
       endpoints:

--- a/pkg/xds/generator/testdata/prometheus-endpoint/default-without-hijacker.envoy-config.golden.yaml
+++ b/pkg/xds/generator/testdata/prometheus-endpoint/default-without-hijacker.envoy-config.golden.yaml
@@ -3,7 +3,7 @@ resources:
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
     altStatName: kuma_metrics_hijacker
-    connectTimeout: 10s
+    connectTimeout: 5s
     loadAssignment:
       clusterName: kuma:metrics:hijacker
       endpoints:

--- a/pkg/xds/generator/testdata/prometheus-endpoint/default.envoy-config.golden.yaml
+++ b/pkg/xds/generator/testdata/prometheus-endpoint/default.envoy-config.golden.yaml
@@ -3,7 +3,7 @@ resources:
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
     altStatName: kuma_metrics_hijacker
-    connectTimeout: 10s
+    connectTimeout: 5s
     loadAssignment:
       clusterName: kuma:metrics:hijacker
       endpoints:

--- a/pkg/xds/generator/testdata/prometheus-endpoint/delegated-tls-fallback.envoy-config.golden.yaml
+++ b/pkg/xds/generator/testdata/prometheus-endpoint/delegated-tls-fallback.envoy-config.golden.yaml
@@ -3,7 +3,7 @@ resources:
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
     altStatName: kuma_metrics_hijacker
-    connectTimeout: 10s
+    connectTimeout: 5s
     loadAssignment:
       clusterName: kuma:metrics:hijacker
       endpoints:

--- a/pkg/xds/generator/testdata/prometheus-endpoint/delegated-tls.envoy-config.golden.yaml
+++ b/pkg/xds/generator/testdata/prometheus-endpoint/delegated-tls.envoy-config.golden.yaml
@@ -3,7 +3,7 @@ resources:
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
     altStatName: kuma_metrics_hijacker
-    connectTimeout: 10s
+    connectTimeout: 5s
     loadAssignment:
       clusterName: kuma:metrics:hijacker
       endpoints:

--- a/pkg/xds/generator/testdata/prometheus-endpoint/disabled-tls.envoy-config.golden.yaml
+++ b/pkg/xds/generator/testdata/prometheus-endpoint/disabled-tls.envoy-config.golden.yaml
@@ -3,7 +3,7 @@ resources:
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
     altStatName: kuma_metrics_hijacker
-    connectTimeout: 10s
+    connectTimeout: 5s
     loadAssignment:
       clusterName: kuma:metrics:hijacker
       endpoints:

--- a/pkg/xds/generator/testdata/template-proxy/1-envoy-config.golden.yaml
+++ b/pkg/xds/generator/testdata/template-proxy/1-envoy-config.golden.yaml
@@ -3,7 +3,7 @@ resources:
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
     altStatName: inbound_passthrough_ipv4
-    connectTimeout: 10s
+    connectTimeout: 5s
     lbPolicy: CLUSTER_PROVIDED
     name: inbound:passthrough:ipv4
     type: ORIGINAL_DST
@@ -35,7 +35,7 @@ resources:
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
     altStatName: outbound_passthrough_ipv4
-    connectTimeout: 10s
+    connectTimeout: 5s
     lbPolicy: CLUSTER_PROVIDED
     name: outbound:passthrough:ipv4
     type: ORIGINAL_DST

--- a/pkg/xds/generator/testdata/tracing/datadog.envoy-config.golden.yaml
+++ b/pkg/xds/generator/testdata/tracing/datadog.envoy-config.golden.yaml
@@ -3,7 +3,7 @@ resources:
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
     altStatName: tracing_datadog
-    connectTimeout: 10s
+    connectTimeout: 5s
     dnsLookupFamily: V4_ONLY
     loadAssignment:
       clusterName: tracing:datadog

--- a/pkg/xds/generator/testdata/tracing/zipkin.envoy-config-https.golden.yaml
+++ b/pkg/xds/generator/testdata/tracing/zipkin.envoy-config-https.golden.yaml
@@ -3,7 +3,7 @@ resources:
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
     altStatName: tracing_zipkin
-    connectTimeout: 10s
+    connectTimeout: 5s
     dnsLookupFamily: V4_ONLY
     loadAssignment:
       clusterName: tracing:zipkin

--- a/pkg/xds/generator/testdata/tracing/zipkin.envoy-config.golden.yaml
+++ b/pkg/xds/generator/testdata/tracing/zipkin.envoy-config.golden.yaml
@@ -3,7 +3,7 @@ resources:
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
     altStatName: tracing_zipkin
-    connectTimeout: 10s
+    connectTimeout: 5s
     dnsLookupFamily: V4_ONLY
     loadAssignment:
       clusterName: tracing:zipkin

--- a/pkg/xds/generator/testdata/transparent-proxy/02.envoy.golden.yaml
+++ b/pkg/xds/generator/testdata/transparent-proxy/02.envoy.golden.yaml
@@ -3,7 +3,7 @@ resources:
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
     altStatName: inbound_passthrough_ipv4
-    connectTimeout: 10s
+    connectTimeout: 5s
     lbPolicy: CLUSTER_PROVIDED
     name: inbound:passthrough:ipv4
     type: ORIGINAL_DST
@@ -15,7 +15,7 @@ resources:
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
     altStatName: outbound_passthrough_ipv4
-    connectTimeout: 10s
+    connectTimeout: 5s
     lbPolicy: CLUSTER_PROVIDED
     name: outbound:passthrough:ipv4
     type: ORIGINAL_DST

--- a/pkg/xds/generator/testdata/transparent-proxy/03.envoy.golden.yaml
+++ b/pkg/xds/generator/testdata/transparent-proxy/03.envoy.golden.yaml
@@ -3,7 +3,7 @@ resources:
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
     altStatName: inbound_passthrough_ipv4
-    connectTimeout: 10s
+    connectTimeout: 5s
     lbPolicy: CLUSTER_PROVIDED
     name: inbound:passthrough:ipv4
     type: ORIGINAL_DST
@@ -15,7 +15,7 @@ resources:
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
     altStatName: outbound_passthrough_ipv4
-    connectTimeout: 10s
+    connectTimeout: 5s
     lbPolicy: CLUSTER_PROVIDED
     name: outbound:passthrough:ipv4
     type: ORIGINAL_DST

--- a/pkg/xds/generator/testdata/transparent-proxy/04.envoy.golden.yaml
+++ b/pkg/xds/generator/testdata/transparent-proxy/04.envoy.golden.yaml
@@ -3,7 +3,7 @@ resources:
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
     altStatName: inbound_passthrough_ipv4
-    connectTimeout: 10s
+    connectTimeout: 5s
     lbPolicy: CLUSTER_PROVIDED
     name: inbound:passthrough:ipv4
     type: ORIGINAL_DST
@@ -15,7 +15,7 @@ resources:
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
     altStatName: inbound_passthrough_ipv6
-    connectTimeout: 10s
+    connectTimeout: 5s
     lbPolicy: CLUSTER_PROVIDED
     name: inbound:passthrough:ipv6
     type: ORIGINAL_DST
@@ -27,7 +27,7 @@ resources:
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
     altStatName: outbound_passthrough_ipv4
-    connectTimeout: 10s
+    connectTimeout: 5s
     lbPolicy: CLUSTER_PROVIDED
     name: outbound:passthrough:ipv4
     type: ORIGINAL_DST
@@ -35,7 +35,7 @@ resources:
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
     altStatName: outbound_passthrough_ipv6
-    connectTimeout: 10s
+    connectTimeout: 5s
     lbPolicy: CLUSTER_PROVIDED
     name: outbound:passthrough:ipv6
     type: ORIGINAL_DST

--- a/pkg/xds/server/v3/testdata/hook-before-pt.golden.yaml
+++ b/pkg/xds/server/v3/testdata/hook-before-pt.golden.yaml
@@ -3,7 +3,7 @@ resources:
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
     altStatName: inbound_passthrough_ipv4
-    connectTimeout: 10s
+    connectTimeout: 5s
     lbPolicy: CLUSTER_PROVIDED
     name: inbound:passthrough:ipv4
     type: ORIGINAL_DST
@@ -55,7 +55,7 @@ resources:
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
     altStatName: outbound_passthrough_ipv4
-    connectTimeout: 10s
+    connectTimeout: 5s
     lbPolicy: CLUSTER_PROVIDED
     name: outbound:passthrough:ipv4
     type: ORIGINAL_DST

--- a/pkg/xds/server/v3/testdata/stable-es.golden.yaml
+++ b/pkg/xds/server/v3/testdata/stable-es.golden.yaml
@@ -2,7 +2,7 @@ resources:
 - name: es-with-tls
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
-    connectTimeout: 10s
+    connectTimeout: 5s
     dnsLookupFamily: V4_ONLY
     loadAssignment:
       clusterName: es-with-tls
@@ -141,7 +141,7 @@ resources:
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
     altStatName: inbound_passthrough_ipv4
-    connectTimeout: 10s
+    connectTimeout: 5s
     lbPolicy: CLUSTER_PROVIDED
     name: inbound:passthrough:ipv4
     type: ORIGINAL_DST
@@ -193,7 +193,7 @@ resources:
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
     altStatName: outbound_passthrough_ipv4
-    connectTimeout: 10s
+    connectTimeout: 5s
     lbPolicy: CLUSTER_PROVIDED
     name: outbound:passthrough:ipv4
     type: ORIGINAL_DST


### PR DESCRIPTION
Unify default `connectTimeout` between `MeshTimeout`, `Timeout` and when no policies present to `5s`.

Put consts with default timeouts in one place so all policies, could reuse them.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues
  - https://github.com/kumahq/kuma/issues/8260
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS
  - it won't
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s)
  - tests were updated
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)?
  - there is no need
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label)
  - there is no need

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
