### PR TITLE
feat(MeshHTTPRoute): support all matches with MeshGateway

### DIFF
--- a/pkg/plugins/runtime/gateway/route/table.go
+++ b/pkg/plugins/runtime/gateway/route/table.go
@@ -72,6 +72,7 @@ type Match struct {
 	RegexHeader   []KeyValue // name -> regex
 	AbsentHeader  []string
 	PresentHeader []string
+	PrefixHeader  []KeyValue
 
 	ExactQuery []KeyValue // param -> value
 	RegexQuery []KeyValue // param -> regex

--- a/pkg/plugins/runtime/gateway/route_table_generator.go
+++ b/pkg/plugins/runtime/gateway/route_table_generator.go
@@ -115,6 +115,10 @@ func GenerateVirtualHost(
 			routeBuilder.Configure(envoy_routes.RouteMatchPresentHeader(m, false))
 		}
 
+		for _, m := range e.Match.PrefixHeader {
+			routeBuilder.Configure(envoy_routes.RouteMatchPrefixHeader(m.Key, m.Value))
+		}
+
 		for _, m := range e.Match.ExactQuery {
 			routeBuilder.Configure(envoy_routes.RouteMatchExactQuery(m.Key, m.Value))
 		}

--- a/pkg/xds/envoy/routes/route_configurers.go
+++ b/pkg/xds/envoy/routes/route_configurers.go
@@ -125,6 +125,24 @@ func RouteMatchPresentHeader(name string, presentMatch bool) RouteConfigurer {
 	})
 }
 
+// RouteMatchPrefixHeader appends a prefix match for the names HTTP request header
+func RouteMatchPrefixHeader(name string, match string) RouteConfigurer {
+	if name == "" {
+		return RouteConfigureFunc(nil)
+	}
+
+	return RouteMustConfigureFunc(func(r *envoy_config_route_v3.Route) {
+		r.Match.Headers = append(r.Match.Headers,
+			&envoy_config_route_v3.HeaderMatcher{
+				Name: name,
+				HeaderMatchSpecifier: &envoy_config_route_v3.HeaderMatcher_PrefixMatch{
+					PrefixMatch: match,
+				},
+			},
+		)
+	})
+}
+
 // RouteMatchExactQuery appends an exact match for the value of the named query parameter.
 func RouteMatchExactQuery(name string, value string) RouteConfigurer {
 	if name == "" || value == "" {


### PR DESCRIPTION
### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues -- #8142 
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s) --
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label) --

> Changelog: skip

<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
