### PR TITLE
chore(MeshTimeout): improve policy's openapi schema

### DIFF
--- a/app/kumactl/cmd/install/testdata/install-control-plane.defaults.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.defaults.golden.yaml
@@ -3623,46 +3623,50 @@ spec:
                         of clients referenced in 'targetRef'
                       properties:
                         connectionTimeout:
+                          default: 5s
                           description: ConnectionTimeout specifies the amount of time
                             proxy will wait for an TCP connection to be established.
-                            Default value is 5 seconds. Cannot be set to 0.
+                            Cannot be set to "0".
                           type: string
                         http:
                           description: Http provides configuration for HTTP specific
                             timeouts
                           properties:
                             maxConnectionDuration:
+                              default: 0s
                               description: MaxConnectionDuration is the time after
                                 which a connection will be drained and/or closed,
                                 starting from when it was first established. Setting
-                                this timeout to 0 will disable it. Disabled by default.
+                                this timeout to "0s" will disable it.
                               type: string
                             maxStreamDuration:
+                              default: 0s
                               description: MaxStreamDuration is the maximum time that
                                 a stream’s lifetime will span. Setting this timeout
-                                to 0 will disable it. Disabled by default.
+                                to "0s" will disable it.
                               type: string
                             requestTimeout:
+                              default: 15s
                               description: RequestTimeout The amount of time that
                                 proxy will wait for the entire request to be received.
                                 The timer is activated when the request is initiated,
                                 and is disarmed when the last byte of the request
                                 is sent, OR when the response is initiated. Setting
-                                this timeout to 0 will disable it. Default is 15s.
+                                this timeout to "0s" will disable it.
                               type: string
                             streamIdleTimeout:
+                              default: 30s
                               description: StreamIdleTimeout is the amount of time
                                 that proxy will allow a stream to exist with no activity.
-                                Setting this timeout to 0 will disable it. Default
-                                is 30m
+                                Setting this timeout to "0s" will disable it.
                               type: string
                           type: object
                         idleTimeout:
+                          default: 1h
                           description: IdleTimeout is defined as the period in which
                             there are no bytes sent or received on connection Setting
-                            this timeout to 0 will disable it. Be cautious when disabling
-                            it because it can lead to connection leaking. Default
-                            value is 1h.
+                            this timeout to "0s" will disable it. Be cautious when
+                            disabling it because it can lead to connection leaking.
                           type: string
                       type: object
                     targetRef:
@@ -3702,7 +3706,7 @@ spec:
               targetRef:
                 description: TargetRef is a reference to the resource the policy takes
                   an effect on. The resource could be either a real store object or
-                  virtual resource defined inplace.
+                  virtual resource defined in-place.
                 properties:
                   kind:
                     description: Kind of the referenced resource
@@ -3739,46 +3743,50 @@ spec:
                         of destinations referenced in 'targetRef'
                       properties:
                         connectionTimeout:
+                          default: 5s
                           description: ConnectionTimeout specifies the amount of time
                             proxy will wait for an TCP connection to be established.
-                            Default value is 5 seconds. Cannot be set to 0.
+                            Cannot be set to "0".
                           type: string
                         http:
                           description: Http provides configuration for HTTP specific
                             timeouts
                           properties:
                             maxConnectionDuration:
+                              default: 0s
                               description: MaxConnectionDuration is the time after
                                 which a connection will be drained and/or closed,
                                 starting from when it was first established. Setting
-                                this timeout to 0 will disable it. Disabled by default.
+                                this timeout to "0s" will disable it.
                               type: string
                             maxStreamDuration:
+                              default: 0s
                               description: MaxStreamDuration is the maximum time that
                                 a stream’s lifetime will span. Setting this timeout
-                                to 0 will disable it. Disabled by default.
+                                to "0s" will disable it.
                               type: string
                             requestTimeout:
+                              default: 15s
                               description: RequestTimeout The amount of time that
                                 proxy will wait for the entire request to be received.
                                 The timer is activated when the request is initiated,
                                 and is disarmed when the last byte of the request
                                 is sent, OR when the response is initiated. Setting
-                                this timeout to 0 will disable it. Default is 15s.
+                                this timeout to "0s" will disable it.
                               type: string
                             streamIdleTimeout:
+                              default: 30s
                               description: StreamIdleTimeout is the amount of time
                                 that proxy will allow a stream to exist with no activity.
-                                Setting this timeout to 0 will disable it. Default
-                                is 30m
+                                Setting this timeout to "0s" will disable it.
                               type: string
                           type: object
                         idleTimeout:
+                          default: 1h
                           description: IdleTimeout is defined as the period in which
                             there are no bytes sent or received on connection Setting
-                            this timeout to 0 will disable it. Be cautious when disabling
-                            it because it can lead to connection leaking. Default
-                            value is 1h.
+                            this timeout to "0s" will disable it. Be cautious when
+                            disabling it because it can lead to connection leaking.
                           type: string
                       type: object
                     targetRef:
@@ -5288,7 +5296,7 @@ spec:
               targetRef:
                 description: TargetRef is a reference to the resource the policy takes
                   an effect on. The resource could be either a real store object or
-                  virtual resource defined inplace.
+                  virtual resource defined in-place.
                 properties:
                   kind:
                     description: Kind of the referenced resource

--- a/app/kumactl/cmd/install/testdata/install-control-plane.defaults.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.defaults.golden.yaml
@@ -5296,7 +5296,7 @@ spec:
               targetRef:
                 description: TargetRef is a reference to the resource the policy takes
                   an effect on. The resource could be either a real store object or
-                  virtual resource defined in-place.
+                  virtual resource defined inplace.
                 properties:
                   kind:
                     description: Kind of the referenced resource

--- a/app/kumactl/cmd/install/testdata/install-control-plane.gateway-api-present-not-enabled.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.gateway-api-present-not-enabled.yaml
@@ -3623,46 +3623,50 @@ spec:
                         of clients referenced in 'targetRef'
                       properties:
                         connectionTimeout:
+                          default: 5s
                           description: ConnectionTimeout specifies the amount of time
                             proxy will wait for an TCP connection to be established.
-                            Default value is 5 seconds. Cannot be set to 0.
+                            Cannot be set to "0".
                           type: string
                         http:
                           description: Http provides configuration for HTTP specific
                             timeouts
                           properties:
                             maxConnectionDuration:
+                              default: 0s
                               description: MaxConnectionDuration is the time after
                                 which a connection will be drained and/or closed,
                                 starting from when it was first established. Setting
-                                this timeout to 0 will disable it. Disabled by default.
+                                this timeout to "0s" will disable it.
                               type: string
                             maxStreamDuration:
+                              default: 0s
                               description: MaxStreamDuration is the maximum time that
                                 a stream’s lifetime will span. Setting this timeout
-                                to 0 will disable it. Disabled by default.
+                                to "0s" will disable it.
                               type: string
                             requestTimeout:
+                              default: 15s
                               description: RequestTimeout The amount of time that
                                 proxy will wait for the entire request to be received.
                                 The timer is activated when the request is initiated,
                                 and is disarmed when the last byte of the request
                                 is sent, OR when the response is initiated. Setting
-                                this timeout to 0 will disable it. Default is 15s.
+                                this timeout to "0s" will disable it.
                               type: string
                             streamIdleTimeout:
+                              default: 30s
                               description: StreamIdleTimeout is the amount of time
                                 that proxy will allow a stream to exist with no activity.
-                                Setting this timeout to 0 will disable it. Default
-                                is 30m
+                                Setting this timeout to "0s" will disable it.
                               type: string
                           type: object
                         idleTimeout:
+                          default: 1h
                           description: IdleTimeout is defined as the period in which
                             there are no bytes sent or received on connection Setting
-                            this timeout to 0 will disable it. Be cautious when disabling
-                            it because it can lead to connection leaking. Default
-                            value is 1h.
+                            this timeout to "0s" will disable it. Be cautious when
+                            disabling it because it can lead to connection leaking.
                           type: string
                       type: object
                     targetRef:
@@ -3702,7 +3706,7 @@ spec:
               targetRef:
                 description: TargetRef is a reference to the resource the policy takes
                   an effect on. The resource could be either a real store object or
-                  virtual resource defined inplace.
+                  virtual resource defined in-place.
                 properties:
                   kind:
                     description: Kind of the referenced resource
@@ -3739,46 +3743,50 @@ spec:
                         of destinations referenced in 'targetRef'
                       properties:
                         connectionTimeout:
+                          default: 5s
                           description: ConnectionTimeout specifies the amount of time
                             proxy will wait for an TCP connection to be established.
-                            Default value is 5 seconds. Cannot be set to 0.
+                            Cannot be set to "0".
                           type: string
                         http:
                           description: Http provides configuration for HTTP specific
                             timeouts
                           properties:
                             maxConnectionDuration:
+                              default: 0s
                               description: MaxConnectionDuration is the time after
                                 which a connection will be drained and/or closed,
                                 starting from when it was first established. Setting
-                                this timeout to 0 will disable it. Disabled by default.
+                                this timeout to "0s" will disable it.
                               type: string
                             maxStreamDuration:
+                              default: 0s
                               description: MaxStreamDuration is the maximum time that
                                 a stream’s lifetime will span. Setting this timeout
-                                to 0 will disable it. Disabled by default.
+                                to "0s" will disable it.
                               type: string
                             requestTimeout:
+                              default: 15s
                               description: RequestTimeout The amount of time that
                                 proxy will wait for the entire request to be received.
                                 The timer is activated when the request is initiated,
                                 and is disarmed when the last byte of the request
                                 is sent, OR when the response is initiated. Setting
-                                this timeout to 0 will disable it. Default is 15s.
+                                this timeout to "0s" will disable it.
                               type: string
                             streamIdleTimeout:
+                              default: 30s
                               description: StreamIdleTimeout is the amount of time
                                 that proxy will allow a stream to exist with no activity.
-                                Setting this timeout to 0 will disable it. Default
-                                is 30m
+                                Setting this timeout to "0s" will disable it.
                               type: string
                           type: object
                         idleTimeout:
+                          default: 1h
                           description: IdleTimeout is defined as the period in which
                             there are no bytes sent or received on connection Setting
-                            this timeout to 0 will disable it. Be cautious when disabling
-                            it because it can lead to connection leaking. Default
-                            value is 1h.
+                            this timeout to "0s" will disable it. Be cautious when
+                            disabling it because it can lead to connection leaking.
                           type: string
                       type: object
                     targetRef:
@@ -5288,7 +5296,7 @@ spec:
               targetRef:
                 description: TargetRef is a reference to the resource the policy takes
                   an effect on. The resource could be either a real store object or
-                  virtual resource defined inplace.
+                  virtual resource defined in-place.
                 properties:
                   kind:
                     description: Kind of the referenced resource

--- a/app/kumactl/cmd/install/testdata/install-control-plane.gateway-api-present-not-enabled.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.gateway-api-present-not-enabled.yaml
@@ -5296,7 +5296,7 @@ spec:
               targetRef:
                 description: TargetRef is a reference to the resource the policy takes
                   an effect on. The resource could be either a real store object or
-                  virtual resource defined in-place.
+                  virtual resource defined inplace.
                 properties:
                   kind:
                     description: Kind of the referenced resource

--- a/app/kumactl/cmd/install/testdata/install-control-plane.gateway-api-present.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.gateway-api-present.yaml
@@ -5500,7 +5500,7 @@ spec:
               targetRef:
                 description: TargetRef is a reference to the resource the policy takes
                   an effect on. The resource could be either a real store object or
-                  virtual resource defined in-place.
+                  virtual resource defined inplace.
                 properties:
                   kind:
                     description: Kind of the referenced resource

--- a/app/kumactl/cmd/install/testdata/install-control-plane.gateway-api-present.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.gateway-api-present.yaml
@@ -3827,46 +3827,50 @@ spec:
                         of clients referenced in 'targetRef'
                       properties:
                         connectionTimeout:
+                          default: 5s
                           description: ConnectionTimeout specifies the amount of time
                             proxy will wait for an TCP connection to be established.
-                            Default value is 5 seconds. Cannot be set to 0.
+                            Cannot be set to "0".
                           type: string
                         http:
                           description: Http provides configuration for HTTP specific
                             timeouts
                           properties:
                             maxConnectionDuration:
+                              default: 0s
                               description: MaxConnectionDuration is the time after
                                 which a connection will be drained and/or closed,
                                 starting from when it was first established. Setting
-                                this timeout to 0 will disable it. Disabled by default.
+                                this timeout to "0s" will disable it.
                               type: string
                             maxStreamDuration:
+                              default: 0s
                               description: MaxStreamDuration is the maximum time that
                                 a stream’s lifetime will span. Setting this timeout
-                                to 0 will disable it. Disabled by default.
+                                to "0s" will disable it.
                               type: string
                             requestTimeout:
+                              default: 15s
                               description: RequestTimeout The amount of time that
                                 proxy will wait for the entire request to be received.
                                 The timer is activated when the request is initiated,
                                 and is disarmed when the last byte of the request
                                 is sent, OR when the response is initiated. Setting
-                                this timeout to 0 will disable it. Default is 15s.
+                                this timeout to "0s" will disable it.
                               type: string
                             streamIdleTimeout:
+                              default: 30s
                               description: StreamIdleTimeout is the amount of time
                                 that proxy will allow a stream to exist with no activity.
-                                Setting this timeout to 0 will disable it. Default
-                                is 30m
+                                Setting this timeout to "0s" will disable it.
                               type: string
                           type: object
                         idleTimeout:
+                          default: 1h
                           description: IdleTimeout is defined as the period in which
                             there are no bytes sent or received on connection Setting
-                            this timeout to 0 will disable it. Be cautious when disabling
-                            it because it can lead to connection leaking. Default
-                            value is 1h.
+                            this timeout to "0s" will disable it. Be cautious when
+                            disabling it because it can lead to connection leaking.
                           type: string
                       type: object
                     targetRef:
@@ -3906,7 +3910,7 @@ spec:
               targetRef:
                 description: TargetRef is a reference to the resource the policy takes
                   an effect on. The resource could be either a real store object or
-                  virtual resource defined inplace.
+                  virtual resource defined in-place.
                 properties:
                   kind:
                     description: Kind of the referenced resource
@@ -3943,46 +3947,50 @@ spec:
                         of destinations referenced in 'targetRef'
                       properties:
                         connectionTimeout:
+                          default: 5s
                           description: ConnectionTimeout specifies the amount of time
                             proxy will wait for an TCP connection to be established.
-                            Default value is 5 seconds. Cannot be set to 0.
+                            Cannot be set to "0".
                           type: string
                         http:
                           description: Http provides configuration for HTTP specific
                             timeouts
                           properties:
                             maxConnectionDuration:
+                              default: 0s
                               description: MaxConnectionDuration is the time after
                                 which a connection will be drained and/or closed,
                                 starting from when it was first established. Setting
-                                this timeout to 0 will disable it. Disabled by default.
+                                this timeout to "0s" will disable it.
                               type: string
                             maxStreamDuration:
+                              default: 0s
                               description: MaxStreamDuration is the maximum time that
                                 a stream’s lifetime will span. Setting this timeout
-                                to 0 will disable it. Disabled by default.
+                                to "0s" will disable it.
                               type: string
                             requestTimeout:
+                              default: 15s
                               description: RequestTimeout The amount of time that
                                 proxy will wait for the entire request to be received.
                                 The timer is activated when the request is initiated,
                                 and is disarmed when the last byte of the request
                                 is sent, OR when the response is initiated. Setting
-                                this timeout to 0 will disable it. Default is 15s.
+                                this timeout to "0s" will disable it.
                               type: string
                             streamIdleTimeout:
+                              default: 30s
                               description: StreamIdleTimeout is the amount of time
                                 that proxy will allow a stream to exist with no activity.
-                                Setting this timeout to 0 will disable it. Default
-                                is 30m
+                                Setting this timeout to "0s" will disable it.
                               type: string
                           type: object
                         idleTimeout:
+                          default: 1h
                           description: IdleTimeout is defined as the period in which
                             there are no bytes sent or received on connection Setting
-                            this timeout to 0 will disable it. Be cautious when disabling
-                            it because it can lead to connection leaking. Default
-                            value is 1h.
+                            this timeout to "0s" will disable it. Be cautious when
+                            disabling it because it can lead to connection leaking.
                           type: string
                       type: object
                     targetRef:
@@ -5492,7 +5500,7 @@ spec:
               targetRef:
                 description: TargetRef is a reference to the resource the policy takes
                   an effect on. The resource could be either a real store object or
-                  virtual resource defined inplace.
+                  virtual resource defined in-place.
                 properties:
                   kind:
                     description: Kind of the referenced resource

--- a/app/kumactl/cmd/install/testdata/install-control-plane.with-helm-set.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.with-helm-set.yaml
@@ -3643,46 +3643,50 @@ spec:
                         of clients referenced in 'targetRef'
                       properties:
                         connectionTimeout:
+                          default: 5s
                           description: ConnectionTimeout specifies the amount of time
                             proxy will wait for an TCP connection to be established.
-                            Default value is 5 seconds. Cannot be set to 0.
+                            Cannot be set to "0".
                           type: string
                         http:
                           description: Http provides configuration for HTTP specific
                             timeouts
                           properties:
                             maxConnectionDuration:
+                              default: 0s
                               description: MaxConnectionDuration is the time after
                                 which a connection will be drained and/or closed,
                                 starting from when it was first established. Setting
-                                this timeout to 0 will disable it. Disabled by default.
+                                this timeout to "0s" will disable it.
                               type: string
                             maxStreamDuration:
+                              default: 0s
                               description: MaxStreamDuration is the maximum time that
                                 a stream’s lifetime will span. Setting this timeout
-                                to 0 will disable it. Disabled by default.
+                                to "0s" will disable it.
                               type: string
                             requestTimeout:
+                              default: 15s
                               description: RequestTimeout The amount of time that
                                 proxy will wait for the entire request to be received.
                                 The timer is activated when the request is initiated,
                                 and is disarmed when the last byte of the request
                                 is sent, OR when the response is initiated. Setting
-                                this timeout to 0 will disable it. Default is 15s.
+                                this timeout to "0s" will disable it.
                               type: string
                             streamIdleTimeout:
+                              default: 30s
                               description: StreamIdleTimeout is the amount of time
                                 that proxy will allow a stream to exist with no activity.
-                                Setting this timeout to 0 will disable it. Default
-                                is 30m
+                                Setting this timeout to "0s" will disable it.
                               type: string
                           type: object
                         idleTimeout:
+                          default: 1h
                           description: IdleTimeout is defined as the period in which
                             there are no bytes sent or received on connection Setting
-                            this timeout to 0 will disable it. Be cautious when disabling
-                            it because it can lead to connection leaking. Default
-                            value is 1h.
+                            this timeout to "0s" will disable it. Be cautious when
+                            disabling it because it can lead to connection leaking.
                           type: string
                       type: object
                     targetRef:
@@ -3722,7 +3726,7 @@ spec:
               targetRef:
                 description: TargetRef is a reference to the resource the policy takes
                   an effect on. The resource could be either a real store object or
-                  virtual resource defined inplace.
+                  virtual resource defined in-place.
                 properties:
                   kind:
                     description: Kind of the referenced resource
@@ -3759,46 +3763,50 @@ spec:
                         of destinations referenced in 'targetRef'
                       properties:
                         connectionTimeout:
+                          default: 5s
                           description: ConnectionTimeout specifies the amount of time
                             proxy will wait for an TCP connection to be established.
-                            Default value is 5 seconds. Cannot be set to 0.
+                            Cannot be set to "0".
                           type: string
                         http:
                           description: Http provides configuration for HTTP specific
                             timeouts
                           properties:
                             maxConnectionDuration:
+                              default: 0s
                               description: MaxConnectionDuration is the time after
                                 which a connection will be drained and/or closed,
                                 starting from when it was first established. Setting
-                                this timeout to 0 will disable it. Disabled by default.
+                                this timeout to "0s" will disable it.
                               type: string
                             maxStreamDuration:
+                              default: 0s
                               description: MaxStreamDuration is the maximum time that
                                 a stream’s lifetime will span. Setting this timeout
-                                to 0 will disable it. Disabled by default.
+                                to "0s" will disable it.
                               type: string
                             requestTimeout:
+                              default: 15s
                               description: RequestTimeout The amount of time that
                                 proxy will wait for the entire request to be received.
                                 The timer is activated when the request is initiated,
                                 and is disarmed when the last byte of the request
                                 is sent, OR when the response is initiated. Setting
-                                this timeout to 0 will disable it. Default is 15s.
+                                this timeout to "0s" will disable it.
                               type: string
                             streamIdleTimeout:
+                              default: 30s
                               description: StreamIdleTimeout is the amount of time
                                 that proxy will allow a stream to exist with no activity.
-                                Setting this timeout to 0 will disable it. Default
-                                is 30m
+                                Setting this timeout to "0s" will disable it.
                               type: string
                           type: object
                         idleTimeout:
+                          default: 1h
                           description: IdleTimeout is defined as the period in which
                             there are no bytes sent or received on connection Setting
-                            this timeout to 0 will disable it. Be cautious when disabling
-                            it because it can lead to connection leaking. Default
-                            value is 1h.
+                            this timeout to "0s" will disable it. Be cautious when
+                            disabling it because it can lead to connection leaking.
                           type: string
                       type: object
                     targetRef:
@@ -5308,7 +5316,7 @@ spec:
               targetRef:
                 description: TargetRef is a reference to the resource the policy takes
                   an effect on. The resource could be either a real store object or
-                  virtual resource defined inplace.
+                  virtual resource defined in-place.
                 properties:
                   kind:
                     description: Kind of the referenced resource

--- a/app/kumactl/cmd/install/testdata/install-control-plane.with-helm-set.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.with-helm-set.yaml
@@ -5316,7 +5316,7 @@ spec:
               targetRef:
                 description: TargetRef is a reference to the resource the policy takes
                   an effect on. The resource could be either a real store object or
-                  virtual resource defined in-place.
+                  virtual resource defined inplace.
                 properties:
                   kind:
                     description: Kind of the referenced resource

--- a/app/kumactl/cmd/install/testdata/install-crds.all.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-crds.all.golden.yaml
@@ -594,7 +594,7 @@ spec:
               targetRef:
                 description: TargetRef is a reference to the resource the policy takes
                   an effect on. The resource could be either a real store object or
-                  virtual resource defined in-place.
+                  virtual resource defined inplace.
                 properties:
                   kind:
                     description: Kind of the referenced resource

--- a/app/kumactl/cmd/install/testdata/install-crds.all.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-crds.all.golden.yaml
@@ -594,7 +594,7 @@ spec:
               targetRef:
                 description: TargetRef is a reference to the resource the policy takes
                   an effect on. The resource could be either a real store object or
-                  virtual resource defined inplace.
+                  virtual resource defined in-place.
                 properties:
                   kind:
                     description: Kind of the referenced resource
@@ -4884,46 +4884,50 @@ spec:
                         of clients referenced in 'targetRef'
                       properties:
                         connectionTimeout:
+                          default: 5s
                           description: ConnectionTimeout specifies the amount of time
                             proxy will wait for an TCP connection to be established.
-                            Default value is 5 seconds. Cannot be set to 0.
+                            Cannot be set to "0".
                           type: string
                         http:
                           description: Http provides configuration for HTTP specific
                             timeouts
                           properties:
                             maxConnectionDuration:
+                              default: 0s
                               description: MaxConnectionDuration is the time after
                                 which a connection will be drained and/or closed,
                                 starting from when it was first established. Setting
-                                this timeout to 0 will disable it. Disabled by default.
+                                this timeout to "0s" will disable it.
                               type: string
                             maxStreamDuration:
+                              default: 0s
                               description: MaxStreamDuration is the maximum time that
                                 a stream’s lifetime will span. Setting this timeout
-                                to 0 will disable it. Disabled by default.
+                                to "0s" will disable it.
                               type: string
                             requestTimeout:
+                              default: 15s
                               description: RequestTimeout The amount of time that
                                 proxy will wait for the entire request to be received.
                                 The timer is activated when the request is initiated,
                                 and is disarmed when the last byte of the request
                                 is sent, OR when the response is initiated. Setting
-                                this timeout to 0 will disable it. Default is 15s.
+                                this timeout to "0s" will disable it.
                               type: string
                             streamIdleTimeout:
+                              default: 30s
                               description: StreamIdleTimeout is the amount of time
                                 that proxy will allow a stream to exist with no activity.
-                                Setting this timeout to 0 will disable it. Default
-                                is 30m
+                                Setting this timeout to "0s" will disable it.
                               type: string
                           type: object
                         idleTimeout:
+                          default: 1h
                           description: IdleTimeout is defined as the period in which
                             there are no bytes sent or received on connection Setting
-                            this timeout to 0 will disable it. Be cautious when disabling
-                            it because it can lead to connection leaking. Default
-                            value is 1h.
+                            this timeout to "0s" will disable it. Be cautious when
+                            disabling it because it can lead to connection leaking.
                           type: string
                       type: object
                     targetRef:
@@ -4963,7 +4967,7 @@ spec:
               targetRef:
                 description: TargetRef is a reference to the resource the policy takes
                   an effect on. The resource could be either a real store object or
-                  virtual resource defined inplace.
+                  virtual resource defined in-place.
                 properties:
                   kind:
                     description: Kind of the referenced resource
@@ -5000,46 +5004,50 @@ spec:
                         of destinations referenced in 'targetRef'
                       properties:
                         connectionTimeout:
+                          default: 5s
                           description: ConnectionTimeout specifies the amount of time
                             proxy will wait for an TCP connection to be established.
-                            Default value is 5 seconds. Cannot be set to 0.
+                            Cannot be set to "0".
                           type: string
                         http:
                           description: Http provides configuration for HTTP specific
                             timeouts
                           properties:
                             maxConnectionDuration:
+                              default: 0s
                               description: MaxConnectionDuration is the time after
                                 which a connection will be drained and/or closed,
                                 starting from when it was first established. Setting
-                                this timeout to 0 will disable it. Disabled by default.
+                                this timeout to "0s" will disable it.
                               type: string
                             maxStreamDuration:
+                              default: 0s
                               description: MaxStreamDuration is the maximum time that
                                 a stream’s lifetime will span. Setting this timeout
-                                to 0 will disable it. Disabled by default.
+                                to "0s" will disable it.
                               type: string
                             requestTimeout:
+                              default: 15s
                               description: RequestTimeout The amount of time that
                                 proxy will wait for the entire request to be received.
                                 The timer is activated when the request is initiated,
                                 and is disarmed when the last byte of the request
                                 is sent, OR when the response is initiated. Setting
-                                this timeout to 0 will disable it. Default is 15s.
+                                this timeout to "0s" will disable it.
                               type: string
                             streamIdleTimeout:
+                              default: 30s
                               description: StreamIdleTimeout is the amount of time
                                 that proxy will allow a stream to exist with no activity.
-                                Setting this timeout to 0 will disable it. Default
-                                is 30m
+                                Setting this timeout to "0s" will disable it.
                               type: string
                           type: object
                         idleTimeout:
+                          default: 1h
                           description: IdleTimeout is defined as the period in which
                             there are no bytes sent or received on connection Setting
-                            this timeout to 0 will disable it. Be cautious when disabling
-                            it because it can lead to connection leaking. Default
-                            value is 1h.
+                            this timeout to "0s" will disable it. Be cautious when
+                            disabling it because it can lead to connection leaking.
                           type: string
                       type: object
                     targetRef:

--- a/app/kumactl/cmd/install/testdata/install-crds.experimental-gatewayapi.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-crds.experimental-gatewayapi.golden.yaml
@@ -594,7 +594,7 @@ spec:
               targetRef:
                 description: TargetRef is a reference to the resource the policy takes
                   an effect on. The resource could be either a real store object or
-                  virtual resource defined in-place.
+                  virtual resource defined inplace.
                 properties:
                   kind:
                     description: Kind of the referenced resource

--- a/app/kumactl/cmd/install/testdata/install-crds.experimental-gatewayapi.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-crds.experimental-gatewayapi.golden.yaml
@@ -594,7 +594,7 @@ spec:
               targetRef:
                 description: TargetRef is a reference to the resource the policy takes
                   an effect on. The resource could be either a real store object or
-                  virtual resource defined inplace.
+                  virtual resource defined in-place.
                 properties:
                   kind:
                     description: Kind of the referenced resource
@@ -5088,46 +5088,50 @@ spec:
                         of clients referenced in 'targetRef'
                       properties:
                         connectionTimeout:
+                          default: 5s
                           description: ConnectionTimeout specifies the amount of time
                             proxy will wait for an TCP connection to be established.
-                            Default value is 5 seconds. Cannot be set to 0.
+                            Cannot be set to "0".
                           type: string
                         http:
                           description: Http provides configuration for HTTP specific
                             timeouts
                           properties:
                             maxConnectionDuration:
+                              default: 0s
                               description: MaxConnectionDuration is the time after
                                 which a connection will be drained and/or closed,
                                 starting from when it was first established. Setting
-                                this timeout to 0 will disable it. Disabled by default.
+                                this timeout to "0s" will disable it.
                               type: string
                             maxStreamDuration:
+                              default: 0s
                               description: MaxStreamDuration is the maximum time that
                                 a stream’s lifetime will span. Setting this timeout
-                                to 0 will disable it. Disabled by default.
+                                to "0s" will disable it.
                               type: string
                             requestTimeout:
+                              default: 15s
                               description: RequestTimeout The amount of time that
                                 proxy will wait for the entire request to be received.
                                 The timer is activated when the request is initiated,
                                 and is disarmed when the last byte of the request
                                 is sent, OR when the response is initiated. Setting
-                                this timeout to 0 will disable it. Default is 15s.
+                                this timeout to "0s" will disable it.
                               type: string
                             streamIdleTimeout:
+                              default: 30s
                               description: StreamIdleTimeout is the amount of time
                                 that proxy will allow a stream to exist with no activity.
-                                Setting this timeout to 0 will disable it. Default
-                                is 30m
+                                Setting this timeout to "0s" will disable it.
                               type: string
                           type: object
                         idleTimeout:
+                          default: 1h
                           description: IdleTimeout is defined as the period in which
                             there are no bytes sent or received on connection Setting
-                            this timeout to 0 will disable it. Be cautious when disabling
-                            it because it can lead to connection leaking. Default
-                            value is 1h.
+                            this timeout to "0s" will disable it. Be cautious when
+                            disabling it because it can lead to connection leaking.
                           type: string
                       type: object
                     targetRef:
@@ -5167,7 +5171,7 @@ spec:
               targetRef:
                 description: TargetRef is a reference to the resource the policy takes
                   an effect on. The resource could be either a real store object or
-                  virtual resource defined inplace.
+                  virtual resource defined in-place.
                 properties:
                   kind:
                     description: Kind of the referenced resource
@@ -5204,46 +5208,50 @@ spec:
                         of destinations referenced in 'targetRef'
                       properties:
                         connectionTimeout:
+                          default: 5s
                           description: ConnectionTimeout specifies the amount of time
                             proxy will wait for an TCP connection to be established.
-                            Default value is 5 seconds. Cannot be set to 0.
+                            Cannot be set to "0".
                           type: string
                         http:
                           description: Http provides configuration for HTTP specific
                             timeouts
                           properties:
                             maxConnectionDuration:
+                              default: 0s
                               description: MaxConnectionDuration is the time after
                                 which a connection will be drained and/or closed,
                                 starting from when it was first established. Setting
-                                this timeout to 0 will disable it. Disabled by default.
+                                this timeout to "0s" will disable it.
                               type: string
                             maxStreamDuration:
+                              default: 0s
                               description: MaxStreamDuration is the maximum time that
                                 a stream’s lifetime will span. Setting this timeout
-                                to 0 will disable it. Disabled by default.
+                                to "0s" will disable it.
                               type: string
                             requestTimeout:
+                              default: 15s
                               description: RequestTimeout The amount of time that
                                 proxy will wait for the entire request to be received.
                                 The timer is activated when the request is initiated,
                                 and is disarmed when the last byte of the request
                                 is sent, OR when the response is initiated. Setting
-                                this timeout to 0 will disable it. Default is 15s.
+                                this timeout to "0s" will disable it.
                               type: string
                             streamIdleTimeout:
+                              default: 30s
                               description: StreamIdleTimeout is the amount of time
                                 that proxy will allow a stream to exist with no activity.
-                                Setting this timeout to 0 will disable it. Default
-                                is 30m
+                                Setting this timeout to "0s" will disable it.
                               type: string
                           type: object
                         idleTimeout:
+                          default: 1h
                           description: IdleTimeout is defined as the period in which
                             there are no bytes sent or received on connection Setting
-                            this timeout to 0 will disable it. Be cautious when disabling
-                            it because it can lead to connection leaking. Default
-                            value is 1h.
+                            this timeout to "0s" will disable it. Be cautious when
+                            disabling it because it can lead to connection leaking.
                           type: string
                       type: object
                     targetRef:

--- a/deployments/charts/kuma/crds/kuma.io_meshtimeouts.yaml
+++ b/deployments/charts/kuma/crds/kuma.io_meshtimeouts.yaml
@@ -52,46 +52,50 @@ spec:
                         of clients referenced in 'targetRef'
                       properties:
                         connectionTimeout:
+                          default: 5s
                           description: ConnectionTimeout specifies the amount of time
                             proxy will wait for an TCP connection to be established.
-                            Default value is 5 seconds. Cannot be set to 0.
+                            Cannot be set to "0".
                           type: string
                         http:
                           description: Http provides configuration for HTTP specific
                             timeouts
                           properties:
                             maxConnectionDuration:
+                              default: 0s
                               description: MaxConnectionDuration is the time after
                                 which a connection will be drained and/or closed,
                                 starting from when it was first established. Setting
-                                this timeout to 0 will disable it. Disabled by default.
+                                this timeout to "0s" will disable it.
                               type: string
                             maxStreamDuration:
+                              default: 0s
                               description: MaxStreamDuration is the maximum time that
                                 a stream’s lifetime will span. Setting this timeout
-                                to 0 will disable it. Disabled by default.
+                                to "0s" will disable it.
                               type: string
                             requestTimeout:
+                              default: 15s
                               description: RequestTimeout The amount of time that
                                 proxy will wait for the entire request to be received.
                                 The timer is activated when the request is initiated,
                                 and is disarmed when the last byte of the request
                                 is sent, OR when the response is initiated. Setting
-                                this timeout to 0 will disable it. Default is 15s.
+                                this timeout to "0s" will disable it.
                               type: string
                             streamIdleTimeout:
+                              default: 30s
                               description: StreamIdleTimeout is the amount of time
                                 that proxy will allow a stream to exist with no activity.
-                                Setting this timeout to 0 will disable it. Default
-                                is 30m
+                                Setting this timeout to "0s" will disable it.
                               type: string
                           type: object
                         idleTimeout:
+                          default: 1h
                           description: IdleTimeout is defined as the period in which
                             there are no bytes sent or received on connection Setting
-                            this timeout to 0 will disable it. Be cautious when disabling
-                            it because it can lead to connection leaking. Default
-                            value is 1h.
+                            this timeout to "0s" will disable it. Be cautious when
+                            disabling it because it can lead to connection leaking.
                           type: string
                       type: object
                     targetRef:
@@ -131,7 +135,7 @@ spec:
               targetRef:
                 description: TargetRef is a reference to the resource the policy takes
                   an effect on. The resource could be either a real store object or
-                  virtual resource defined inplace.
+                  virtual resource defined in-place.
                 properties:
                   kind:
                     description: Kind of the referenced resource
@@ -168,46 +172,50 @@ spec:
                         of destinations referenced in 'targetRef'
                       properties:
                         connectionTimeout:
+                          default: 5s
                           description: ConnectionTimeout specifies the amount of time
                             proxy will wait for an TCP connection to be established.
-                            Default value is 5 seconds. Cannot be set to 0.
+                            Cannot be set to "0".
                           type: string
                         http:
                           description: Http provides configuration for HTTP specific
                             timeouts
                           properties:
                             maxConnectionDuration:
+                              default: 0s
                               description: MaxConnectionDuration is the time after
                                 which a connection will be drained and/or closed,
                                 starting from when it was first established. Setting
-                                this timeout to 0 will disable it. Disabled by default.
+                                this timeout to "0s" will disable it.
                               type: string
                             maxStreamDuration:
+                              default: 0s
                               description: MaxStreamDuration is the maximum time that
                                 a stream’s lifetime will span. Setting this timeout
-                                to 0 will disable it. Disabled by default.
+                                to "0s" will disable it.
                               type: string
                             requestTimeout:
+                              default: 15s
                               description: RequestTimeout The amount of time that
                                 proxy will wait for the entire request to be received.
                                 The timer is activated when the request is initiated,
                                 and is disarmed when the last byte of the request
                                 is sent, OR when the response is initiated. Setting
-                                this timeout to 0 will disable it. Default is 15s.
+                                this timeout to "0s" will disable it.
                               type: string
                             streamIdleTimeout:
+                              default: 30s
                               description: StreamIdleTimeout is the amount of time
                                 that proxy will allow a stream to exist with no activity.
-                                Setting this timeout to 0 will disable it. Default
-                                is 30m
+                                Setting this timeout to "0s" will disable it.
                               type: string
                           type: object
                         idleTimeout:
+                          default: 1h
                           description: IdleTimeout is defined as the period in which
                             there are no bytes sent or received on connection Setting
-                            this timeout to 0 will disable it. Be cautious when disabling
-                            it because it can lead to connection leaking. Default
-                            value is 1h.
+                            this timeout to "0s" will disable it. Be cautious when
+                            disabling it because it can lead to connection leaking.
                           type: string
                       type: object
                     targetRef:

--- a/docs/generated/openapi.yaml
+++ b/docs/generated/openapi.yaml
@@ -5660,52 +5660,56 @@ components:
                       clients referenced in 'targetRef'
                     properties:
                       connectionTimeout:
+                        default: 5s
                         description: >-
                           ConnectionTimeout specifies the amount of time proxy
                           will wait for an TCP connection to be established.
-                          Default value is 5 seconds. Cannot be set to 0.
+                          Cannot be set to "0".
                         type: string
                       http:
                         description: Http provides configuration for HTTP specific timeouts
                         properties:
                           maxConnectionDuration:
+                            default: 0s
                             description: >-
                               MaxConnectionDuration is the time after which a
                               connection will be drained and/or closed, starting
                               from when it was first established. Setting this
-                              timeout to 0 will disable it. Disabled by default.
+                              timeout to "0s" will disable it.
                             type: string
                           maxStreamDuration:
+                            default: 0s
                             description: >-
                               MaxStreamDuration is the maximum time that a
                               stream’s lifetime will span. Setting this timeout
-                              to 0 will disable it. Disabled by default.
+                              to "0s" will disable it.
                             type: string
                           requestTimeout:
+                            default: 15s
                             description: >-
                               RequestTimeout The amount of time that proxy will
                               wait for the entire request to be received. The
                               timer is activated when the request is initiated,
                               and is disarmed when the last byte of the request
                               is sent, OR when the response is initiated.
-                              Setting this timeout to 0 will disable it. Default
-                              is 15s.
+                              Setting this timeout to "0s" will disable it.
                             type: string
                           streamIdleTimeout:
+                            default: 30s
                             description: >-
                               StreamIdleTimeout is the amount of time that proxy
                               will allow a stream to exist with no activity.
-                              Setting this timeout to 0 will disable it. Default
-                              is 30m
+                              Setting this timeout to "0s" will disable it.
                             type: string
                         type: object
                       idleTimeout:
+                        default: 1h
                         description: >-
                           IdleTimeout is defined as the period in which there
                           are no bytes sent or received on connection Setting
-                          this timeout to 0 will disable it. Be cautious when
+                          this timeout to "0s" will disable it. Be cautious when
                           disabling it because it can lead to connection
-                          leaking. Default value is 1h.
+                          leaking.
                         type: string
                     type: object
                   targetRef:
@@ -5751,7 +5755,7 @@ components:
               description: >-
                 TargetRef is a reference to the resource the policy takes an
                 effect on. The resource could be either a real store object or
-                virtual resource defined inplace.
+                virtual resource defined in-place.
               properties:
                 kind:
                   description: Kind of the referenced resource
@@ -5794,52 +5798,56 @@ components:
                       destinations referenced in 'targetRef'
                     properties:
                       connectionTimeout:
+                        default: 5s
                         description: >-
                           ConnectionTimeout specifies the amount of time proxy
                           will wait for an TCP connection to be established.
-                          Default value is 5 seconds. Cannot be set to 0.
+                          Cannot be set to "0".
                         type: string
                       http:
                         description: Http provides configuration for HTTP specific timeouts
                         properties:
                           maxConnectionDuration:
+                            default: 0s
                             description: >-
                               MaxConnectionDuration is the time after which a
                               connection will be drained and/or closed, starting
                               from when it was first established. Setting this
-                              timeout to 0 will disable it. Disabled by default.
+                              timeout to "0s" will disable it.
                             type: string
                           maxStreamDuration:
+                            default: 0s
                             description: >-
                               MaxStreamDuration is the maximum time that a
                               stream’s lifetime will span. Setting this timeout
-                              to 0 will disable it. Disabled by default.
+                              to "0s" will disable it.
                             type: string
                           requestTimeout:
+                            default: 15s
                             description: >-
                               RequestTimeout The amount of time that proxy will
                               wait for the entire request to be received. The
                               timer is activated when the request is initiated,
                               and is disarmed when the last byte of the request
                               is sent, OR when the response is initiated.
-                              Setting this timeout to 0 will disable it. Default
-                              is 15s.
+                              Setting this timeout to "0s" will disable it.
                             type: string
                           streamIdleTimeout:
+                            default: 30s
                             description: >-
                               StreamIdleTimeout is the amount of time that proxy
                               will allow a stream to exist with no activity.
-                              Setting this timeout to 0 will disable it. Default
-                              is 30m
+                              Setting this timeout to "0s" will disable it.
                             type: string
                         type: object
                       idleTimeout:
+                        default: 1h
                         description: >-
                           IdleTimeout is defined as the period in which there
                           are no bytes sent or received on connection Setting
-                          this timeout to 0 will disable it. Be cautious when
+                          this timeout to "0s" will disable it. Be cautious when
                           disabling it because it can lead to connection
-                          leaking. Default value is 1h.
+                          leaking.
                         type: string
                     type: object
                   targetRef:

--- a/docs/generated/raw/crds/kuma.io_meshtimeouts.yaml
+++ b/docs/generated/raw/crds/kuma.io_meshtimeouts.yaml
@@ -52,46 +52,50 @@ spec:
                         of clients referenced in 'targetRef'
                       properties:
                         connectionTimeout:
+                          default: 5s
                           description: ConnectionTimeout specifies the amount of time
                             proxy will wait for an TCP connection to be established.
-                            Default value is 5 seconds. Cannot be set to 0.
+                            Cannot be set to "0".
                           type: string
                         http:
                           description: Http provides configuration for HTTP specific
                             timeouts
                           properties:
                             maxConnectionDuration:
+                              default: 0s
                               description: MaxConnectionDuration is the time after
                                 which a connection will be drained and/or closed,
                                 starting from when it was first established. Setting
-                                this timeout to 0 will disable it. Disabled by default.
+                                this timeout to "0s" will disable it.
                               type: string
                             maxStreamDuration:
+                              default: 0s
                               description: MaxStreamDuration is the maximum time that
                                 a stream’s lifetime will span. Setting this timeout
-                                to 0 will disable it. Disabled by default.
+                                to "0s" will disable it.
                               type: string
                             requestTimeout:
+                              default: 15s
                               description: RequestTimeout The amount of time that
                                 proxy will wait for the entire request to be received.
                                 The timer is activated when the request is initiated,
                                 and is disarmed when the last byte of the request
                                 is sent, OR when the response is initiated. Setting
-                                this timeout to 0 will disable it. Default is 15s.
+                                this timeout to "0s" will disable it.
                               type: string
                             streamIdleTimeout:
+                              default: 30s
                               description: StreamIdleTimeout is the amount of time
                                 that proxy will allow a stream to exist with no activity.
-                                Setting this timeout to 0 will disable it. Default
-                                is 30m
+                                Setting this timeout to "0s" will disable it.
                               type: string
                           type: object
                         idleTimeout:
+                          default: 1h
                           description: IdleTimeout is defined as the period in which
                             there are no bytes sent or received on connection Setting
-                            this timeout to 0 will disable it. Be cautious when disabling
-                            it because it can lead to connection leaking. Default
-                            value is 1h.
+                            this timeout to "0s" will disable it. Be cautious when
+                            disabling it because it can lead to connection leaking.
                           type: string
                       type: object
                     targetRef:
@@ -131,7 +135,7 @@ spec:
               targetRef:
                 description: TargetRef is a reference to the resource the policy takes
                   an effect on. The resource could be either a real store object or
-                  virtual resource defined inplace.
+                  virtual resource defined in-place.
                 properties:
                   kind:
                     description: Kind of the referenced resource
@@ -168,46 +172,50 @@ spec:
                         of destinations referenced in 'targetRef'
                       properties:
                         connectionTimeout:
+                          default: 5s
                           description: ConnectionTimeout specifies the amount of time
                             proxy will wait for an TCP connection to be established.
-                            Default value is 5 seconds. Cannot be set to 0.
+                            Cannot be set to "0".
                           type: string
                         http:
                           description: Http provides configuration for HTTP specific
                             timeouts
                           properties:
                             maxConnectionDuration:
+                              default: 0s
                               description: MaxConnectionDuration is the time after
                                 which a connection will be drained and/or closed,
                                 starting from when it was first established. Setting
-                                this timeout to 0 will disable it. Disabled by default.
+                                this timeout to "0s" will disable it.
                               type: string
                             maxStreamDuration:
+                              default: 0s
                               description: MaxStreamDuration is the maximum time that
                                 a stream’s lifetime will span. Setting this timeout
-                                to 0 will disable it. Disabled by default.
+                                to "0s" will disable it.
                               type: string
                             requestTimeout:
+                              default: 15s
                               description: RequestTimeout The amount of time that
                                 proxy will wait for the entire request to be received.
                                 The timer is activated when the request is initiated,
                                 and is disarmed when the last byte of the request
                                 is sent, OR when the response is initiated. Setting
-                                this timeout to 0 will disable it. Default is 15s.
+                                this timeout to "0s" will disable it.
                               type: string
                             streamIdleTimeout:
+                              default: 30s
                               description: StreamIdleTimeout is the amount of time
                                 that proxy will allow a stream to exist with no activity.
-                                Setting this timeout to 0 will disable it. Default
-                                is 30m
+                                Setting this timeout to "0s" will disable it.
                               type: string
                           type: object
                         idleTimeout:
+                          default: 1h
                           description: IdleTimeout is defined as the period in which
                             there are no bytes sent or received on connection Setting
-                            this timeout to 0 will disable it. Be cautious when disabling
-                            it because it can lead to connection leaking. Default
-                            value is 1h.
+                            this timeout to "0s" will disable it. Be cautious when
+                            disabling it because it can lead to connection leaking.
                           type: string
                       type: object
                     targetRef:

--- a/pkg/plugins/policies/meshtimeout/api/v1alpha1/meshtimeout.go
+++ b/pkg/plugins/policies/meshtimeout/api/v1alpha1/meshtimeout.go
@@ -11,7 +11,7 @@ import (
 type MeshTimeout struct {
 	// TargetRef is a reference to the resource the policy takes an effect on.
 	// The resource could be either a real store object or virtual resource
-	// defined inplace.
+	// defined in-place.
 	TargetRef common_api.TargetRef `json:"targetRef"`
 	// To list makes a match between the consumed services and corresponding configurations
 	To []To `json:"to,omitempty"`
@@ -39,11 +39,13 @@ type From struct {
 
 type Conf struct {
 	// ConnectionTimeout specifies the amount of time proxy will wait for an TCP connection to be established.
-	// Default value is 5 seconds. Cannot be set to 0.
+	// Cannot be set to "0".
+	// +kubebuilder:default="5s"
 	ConnectionTimeout *k8s.Duration `json:"connectionTimeout,omitempty"`
 	// IdleTimeout is defined as the period in which there are no bytes sent or received on connection
-	// Setting this timeout to 0 will disable it. Be cautious when disabling it because
-	// it can lead to connection leaking. Default value is 1h.
+	// Setting this timeout to "0s" will disable it. Be cautious when disabling it because
+	// it can lead to connection leaking.
+	// +kubebuilder:default="1h"
 	IdleTimeout *k8s.Duration `json:"idleTimeout,omitempty"`
 	// Http provides configuration for HTTP specific timeouts
 	Http *Http `json:"http,omitempty"`
@@ -52,17 +54,19 @@ type Conf struct {
 type Http struct {
 	// RequestTimeout The amount of time that proxy will wait for the entire request to be received.
 	// The timer is activated when the request is initiated, and is disarmed when the last byte of the request is sent,
-	// OR when the response is initiated. Setting this timeout to 0 will disable it.
-	// Default is 15s.
+	// OR when the response is initiated. Setting this timeout to "0s" will disable it.
+	// +kubebuilder:default="15s"
 	RequestTimeout *k8s.Duration `json:"requestTimeout,omitempty"`
 	// StreamIdleTimeout is the amount of time that proxy will allow a stream to exist with no activity.
-	// Setting this timeout to 0 will disable it. Default is 30m
+	// Setting this timeout to "0s" will disable it.
+	// +kubebuilder:default="30s"
 	StreamIdleTimeout *k8s.Duration `json:"streamIdleTimeout,omitempty"`
 	// MaxStreamDuration is the maximum time that a stream’s lifetime will span.
-	// Setting this timeout to 0 will disable it. Disabled by default.
+	// Setting this timeout to "0s" will disable it.
+	// +kubebuilder:default="0s"
 	MaxStreamDuration *k8s.Duration `json:"maxStreamDuration,omitempty"`
 	// MaxConnectionDuration is the time after which a connection will be drained and/or closed,
-	// starting from when it was first established. Setting this timeout to 0 will disable it.
-	// Disabled by default.
+	// starting from when it was first established. Setting this timeout to "0s" will disable it.
+	// +kubebuilder:default="0s"
 	MaxConnectionDuration *k8s.Duration `json:"maxConnectionDuration,omitempty"`
 }

--- a/pkg/plugins/policies/meshtimeout/api/v1alpha1/schema.yaml
+++ b/pkg/plugins/policies/meshtimeout/api/v1alpha1/schema.yaml
@@ -23,26 +23,32 @@ properties:
               description: Default is a configuration specific to the group of clients referenced in 'targetRef'
               properties:
                 connectionTimeout:
-                  description: ConnectionTimeout specifies the amount of time proxy will wait for an TCP connection to be established. Default value is 5 seconds. Cannot be set to 0.
+                  default: 5s
+                  description: ConnectionTimeout specifies the amount of time proxy will wait for an TCP connection to be established. Cannot be set to "0".
                   type: string
                 http:
                   description: Http provides configuration for HTTP specific timeouts
                   properties:
                     maxConnectionDuration:
-                      description: MaxConnectionDuration is the time after which a connection will be drained and/or closed, starting from when it was first established. Setting this timeout to 0 will disable it. Disabled by default.
+                      default: 0s
+                      description: MaxConnectionDuration is the time after which a connection will be drained and/or closed, starting from when it was first established. Setting this timeout to "0s" will disable it.
                       type: string
                     maxStreamDuration:
-                      description: MaxStreamDuration is the maximum time that a stream’s lifetime will span. Setting this timeout to 0 will disable it. Disabled by default.
+                      default: 0s
+                      description: MaxStreamDuration is the maximum time that a stream’s lifetime will span. Setting this timeout to "0s" will disable it.
                       type: string
                     requestTimeout:
-                      description: RequestTimeout The amount of time that proxy will wait for the entire request to be received. The timer is activated when the request is initiated, and is disarmed when the last byte of the request is sent, OR when the response is initiated. Setting this timeout to 0 will disable it. Default is 15s.
+                      default: 15s
+                      description: RequestTimeout The amount of time that proxy will wait for the entire request to be received. The timer is activated when the request is initiated, and is disarmed when the last byte of the request is sent, OR when the response is initiated. Setting this timeout to "0s" will disable it.
                       type: string
                     streamIdleTimeout:
-                      description: StreamIdleTimeout is the amount of time that proxy will allow a stream to exist with no activity. Setting this timeout to 0 will disable it. Default is 30m
+                      default: 30s
+                      description: StreamIdleTimeout is the amount of time that proxy will allow a stream to exist with no activity. Setting this timeout to "0s" will disable it.
                       type: string
                   type: object
                 idleTimeout:
-                  description: IdleTimeout is defined as the period in which there are no bytes sent or received on connection Setting this timeout to 0 will disable it. Be cautious when disabling it because it can lead to connection leaking. Default value is 1h.
+                  default: 1h
+                  description: IdleTimeout is defined as the period in which there are no bytes sent or received on connection Setting this timeout to "0s" will disable it. Be cautious when disabling it because it can lead to connection leaking.
                   type: string
               type: object
             targetRef:
@@ -75,7 +81,7 @@ properties:
           type: object
         type: array
       targetRef:
-        description: TargetRef is a reference to the resource the policy takes an effect on. The resource could be either a real store object or virtual resource defined inplace.
+        description: TargetRef is a reference to the resource the policy takes an effect on. The resource could be either a real store object or virtual resource defined in-place.
         properties:
           kind:
             description: Kind of the referenced resource
@@ -107,26 +113,32 @@ properties:
               description: Default is a configuration specific to the group of destinations referenced in 'targetRef'
               properties:
                 connectionTimeout:
-                  description: ConnectionTimeout specifies the amount of time proxy will wait for an TCP connection to be established. Default value is 5 seconds. Cannot be set to 0.
+                  default: 5s
+                  description: ConnectionTimeout specifies the amount of time proxy will wait for an TCP connection to be established. Cannot be set to "0".
                   type: string
                 http:
                   description: Http provides configuration for HTTP specific timeouts
                   properties:
                     maxConnectionDuration:
-                      description: MaxConnectionDuration is the time after which a connection will be drained and/or closed, starting from when it was first established. Setting this timeout to 0 will disable it. Disabled by default.
+                      default: 0s
+                      description: MaxConnectionDuration is the time after which a connection will be drained and/or closed, starting from when it was first established. Setting this timeout to "0s" will disable it.
                       type: string
                     maxStreamDuration:
-                      description: MaxStreamDuration is the maximum time that a stream’s lifetime will span. Setting this timeout to 0 will disable it. Disabled by default.
+                      default: 0s
+                      description: MaxStreamDuration is the maximum time that a stream’s lifetime will span. Setting this timeout to "0s" will disable it.
                       type: string
                     requestTimeout:
-                      description: RequestTimeout The amount of time that proxy will wait for the entire request to be received. The timer is activated when the request is initiated, and is disarmed when the last byte of the request is sent, OR when the response is initiated. Setting this timeout to 0 will disable it. Default is 15s.
+                      default: 15s
+                      description: RequestTimeout The amount of time that proxy will wait for the entire request to be received. The timer is activated when the request is initiated, and is disarmed when the last byte of the request is sent, OR when the response is initiated. Setting this timeout to "0s" will disable it.
                       type: string
                     streamIdleTimeout:
-                      description: StreamIdleTimeout is the amount of time that proxy will allow a stream to exist with no activity. Setting this timeout to 0 will disable it. Default is 30m
+                      default: 30s
+                      description: StreamIdleTimeout is the amount of time that proxy will allow a stream to exist with no activity. Setting this timeout to "0s" will disable it.
                       type: string
                   type: object
                 idleTimeout:
-                  description: IdleTimeout is defined as the period in which there are no bytes sent or received on connection Setting this timeout to 0 will disable it. Be cautious when disabling it because it can lead to connection leaking. Default value is 1h.
+                  default: 1h
+                  description: IdleTimeout is defined as the period in which there are no bytes sent or received on connection Setting this timeout to "0s" will disable it. Be cautious when disabling it because it can lead to connection leaking.
                   type: string
               type: object
             targetRef:

--- a/pkg/plugins/policies/meshtimeout/k8s/crd/kuma.io_meshtimeouts.yaml
+++ b/pkg/plugins/policies/meshtimeout/k8s/crd/kuma.io_meshtimeouts.yaml
@@ -52,46 +52,50 @@ spec:
                         of clients referenced in 'targetRef'
                       properties:
                         connectionTimeout:
+                          default: 5s
                           description: ConnectionTimeout specifies the amount of time
                             proxy will wait for an TCP connection to be established.
-                            Default value is 5 seconds. Cannot be set to 0.
+                            Cannot be set to "0".
                           type: string
                         http:
                           description: Http provides configuration for HTTP specific
                             timeouts
                           properties:
                             maxConnectionDuration:
+                              default: 0s
                               description: MaxConnectionDuration is the time after
                                 which a connection will be drained and/or closed,
                                 starting from when it was first established. Setting
-                                this timeout to 0 will disable it. Disabled by default.
+                                this timeout to "0s" will disable it.
                               type: string
                             maxStreamDuration:
+                              default: 0s
                               description: MaxStreamDuration is the maximum time that
                                 a stream’s lifetime will span. Setting this timeout
-                                to 0 will disable it. Disabled by default.
+                                to "0s" will disable it.
                               type: string
                             requestTimeout:
+                              default: 15s
                               description: RequestTimeout The amount of time that
                                 proxy will wait for the entire request to be received.
                                 The timer is activated when the request is initiated,
                                 and is disarmed when the last byte of the request
                                 is sent, OR when the response is initiated. Setting
-                                this timeout to 0 will disable it. Default is 15s.
+                                this timeout to "0s" will disable it.
                               type: string
                             streamIdleTimeout:
+                              default: 30s
                               description: StreamIdleTimeout is the amount of time
                                 that proxy will allow a stream to exist with no activity.
-                                Setting this timeout to 0 will disable it. Default
-                                is 30m
+                                Setting this timeout to "0s" will disable it.
                               type: string
                           type: object
                         idleTimeout:
+                          default: 1h
                           description: IdleTimeout is defined as the period in which
                             there are no bytes sent or received on connection Setting
-                            this timeout to 0 will disable it. Be cautious when disabling
-                            it because it can lead to connection leaking. Default
-                            value is 1h.
+                            this timeout to "0s" will disable it. Be cautious when
+                            disabling it because it can lead to connection leaking.
                           type: string
                       type: object
                     targetRef:
@@ -131,7 +135,7 @@ spec:
               targetRef:
                 description: TargetRef is a reference to the resource the policy takes
                   an effect on. The resource could be either a real store object or
-                  virtual resource defined inplace.
+                  virtual resource defined in-place.
                 properties:
                   kind:
                     description: Kind of the referenced resource
@@ -168,46 +172,50 @@ spec:
                         of destinations referenced in 'targetRef'
                       properties:
                         connectionTimeout:
+                          default: 5s
                           description: ConnectionTimeout specifies the amount of time
                             proxy will wait for an TCP connection to be established.
-                            Default value is 5 seconds. Cannot be set to 0.
+                            Cannot be set to "0".
                           type: string
                         http:
                           description: Http provides configuration for HTTP specific
                             timeouts
                           properties:
                             maxConnectionDuration:
+                              default: 0s
                               description: MaxConnectionDuration is the time after
                                 which a connection will be drained and/or closed,
                                 starting from when it was first established. Setting
-                                this timeout to 0 will disable it. Disabled by default.
+                                this timeout to "0s" will disable it.
                               type: string
                             maxStreamDuration:
+                              default: 0s
                               description: MaxStreamDuration is the maximum time that
                                 a stream’s lifetime will span. Setting this timeout
-                                to 0 will disable it. Disabled by default.
+                                to "0s" will disable it.
                               type: string
                             requestTimeout:
+                              default: 15s
                               description: RequestTimeout The amount of time that
                                 proxy will wait for the entire request to be received.
                                 The timer is activated when the request is initiated,
                                 and is disarmed when the last byte of the request
                                 is sent, OR when the response is initiated. Setting
-                                this timeout to 0 will disable it. Default is 15s.
+                                this timeout to "0s" will disable it.
                               type: string
                             streamIdleTimeout:
+                              default: 30s
                               description: StreamIdleTimeout is the amount of time
                                 that proxy will allow a stream to exist with no activity.
-                                Setting this timeout to 0 will disable it. Default
-                                is 30m
+                                Setting this timeout to "0s" will disable it.
                               type: string
                           type: object
                         idleTimeout:
+                          default: 1h
                           description: IdleTimeout is defined as the period in which
                             there are no bytes sent or received on connection Setting
-                            this timeout to 0 will disable it. Be cautious when disabling
-                            it because it can lead to connection leaking. Default
-                            value is 1h.
+                            this timeout to "0s" will disable it. Be cautious when
+                            disabling it because it can lead to connection leaking.
                           type: string
                       type: object
                     targetRef:


### PR DESCRIPTION
Added kubebuilder annotations with defaults and examples to generate better openapi schema.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues
  - Closes https://github.com/kumahq/kuma/issues/8260
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS
  - It won't
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s)
  - No changes which would require new tests
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)?
  - There is no need
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label)
  - It doesn't

> Changelog: skip

<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
