### PR TITLE
chore(MeshAccessLog): improve policy's openapi schema

### DIFF
--- a/app/kumactl/cmd/install/testdata/install-control-plane.defaults.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.defaults.golden.yaml
@@ -5151,6 +5151,11 @@ spec:
                                       available on https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
                                     properties:
                                       json:
+                                        example:
+                                        - key: start_time
+                                          value: '%START_TIME%'
+                                        - key: bytes_received
+                                          value: '%BYTES_RECEIVED%'
                                         items:
                                           properties:
                                             key:
@@ -5160,8 +5165,10 @@ spec:
                                           type: object
                                         type: array
                                       omitEmptyValues:
+                                        default: false
                                         type: boolean
                                       plain:
+                                        example: '[%START_TIME%] %KUMA_MESH% %UPSTREAM_HOST%'
                                         type: string
                                       type:
                                         enum:
@@ -5174,6 +5181,8 @@ spec:
                                   path:
                                     description: Path to a file that logs will be
                                       written to
+                                    example: /tmp/access.log
+                                    minLength: 1
                                     type: string
                                 required:
                                 - path
@@ -5184,6 +5193,9 @@ spec:
                                   attributes:
                                     description: Attributes can contain placeholders
                                       available on https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
+                                    example:
+                                    - key: mesh
+                                      value: '%KUMA_MESH%'
                                     items:
                                       properties:
                                         key:
@@ -5196,6 +5208,12 @@ spec:
                                     description: Body is a raw string or an OTLP any
                                       value as described at https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/logs/data-model.md#field-body
                                       It can contain placeholders available on https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
+                                    example:
+                                      kvlistValue:
+                                        values:
+                                        - key: mesh
+                                          value:
+                                            stringValue: '%KUMA_MESH%'
                                     x-kubernetes-preserve-unknown-fields: true
                                   endpoint:
                                     description: Endpoint of OpenTelemetry collector.
@@ -5211,12 +5229,19 @@ spec:
                                 properties:
                                   address:
                                     description: Address of the TCP logging backend
+                                    example: 127.0.0.1:5000
+                                    minLength: 1
                                     type: string
                                   format:
                                     description: Format of access logs. Placeholders
                                       available on https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
                                     properties:
                                       json:
+                                        example:
+                                        - key: start_time
+                                          value: '%START_TIME%'
+                                        - key: bytes_received
+                                          value: '%BYTES_RECEIVED%'
                                         items:
                                           properties:
                                             key:
@@ -5226,8 +5251,10 @@ spec:
                                           type: object
                                         type: array
                                       omitEmptyValues:
+                                        default: false
                                         type: boolean
                                       plain:
+                                        example: '[%START_TIME%] %KUMA_MESH% %UPSTREAM_HOST%'
                                         type: string
                                       type:
                                         enum:
@@ -5288,7 +5315,7 @@ spec:
               targetRef:
                 description: TargetRef is a reference to the resource the policy takes
                   an effect on. The resource could be either a real store object or
-                  virtual resource defined inplace.
+                  virtual resource defined in-place.
                 properties:
                   kind:
                     description: Kind of the referenced resource
@@ -5336,6 +5363,11 @@ spec:
                                       available on https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
                                     properties:
                                       json:
+                                        example:
+                                        - key: start_time
+                                          value: '%START_TIME%'
+                                        - key: bytes_received
+                                          value: '%BYTES_RECEIVED%'
                                         items:
                                           properties:
                                             key:
@@ -5345,8 +5377,10 @@ spec:
                                           type: object
                                         type: array
                                       omitEmptyValues:
+                                        default: false
                                         type: boolean
                                       plain:
+                                        example: '[%START_TIME%] %KUMA_MESH% %UPSTREAM_HOST%'
                                         type: string
                                       type:
                                         enum:
@@ -5359,6 +5393,8 @@ spec:
                                   path:
                                     description: Path to a file that logs will be
                                       written to
+                                    example: /tmp/access.log
+                                    minLength: 1
                                     type: string
                                 required:
                                 - path
@@ -5369,6 +5405,9 @@ spec:
                                   attributes:
                                     description: Attributes can contain placeholders
                                       available on https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
+                                    example:
+                                    - key: mesh
+                                      value: '%KUMA_MESH%'
                                     items:
                                       properties:
                                         key:
@@ -5381,6 +5420,12 @@ spec:
                                     description: Body is a raw string or an OTLP any
                                       value as described at https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/logs/data-model.md#field-body
                                       It can contain placeholders available on https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
+                                    example:
+                                      kvlistValue:
+                                        values:
+                                        - key: mesh
+                                          value:
+                                            stringValue: '%KUMA_MESH%'
                                     x-kubernetes-preserve-unknown-fields: true
                                   endpoint:
                                     description: Endpoint of OpenTelemetry collector.
@@ -5396,12 +5441,19 @@ spec:
                                 properties:
                                   address:
                                     description: Address of the TCP logging backend
+                                    example: 127.0.0.1:5000
+                                    minLength: 1
                                     type: string
                                   format:
                                     description: Format of access logs. Placeholders
                                       available on https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
                                     properties:
                                       json:
+                                        example:
+                                        - key: start_time
+                                          value: '%START_TIME%'
+                                        - key: bytes_received
+                                          value: '%BYTES_RECEIVED%'
                                         items:
                                           properties:
                                             key:
@@ -5411,8 +5463,10 @@ spec:
                                           type: object
                                         type: array
                                       omitEmptyValues:
+                                        default: false
                                         type: boolean
                                       plain:
+                                        example: '[%START_TIME%] %KUMA_MESH% %UPSTREAM_HOST%'
                                         type: string
                                       type:
                                         enum:

--- a/app/kumactl/cmd/install/testdata/install-control-plane.gateway-api-present-not-enabled.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.gateway-api-present-not-enabled.yaml
@@ -5151,6 +5151,11 @@ spec:
                                       available on https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
                                     properties:
                                       json:
+                                        example:
+                                        - key: start_time
+                                          value: '%START_TIME%'
+                                        - key: bytes_received
+                                          value: '%BYTES_RECEIVED%'
                                         items:
                                           properties:
                                             key:
@@ -5160,8 +5165,10 @@ spec:
                                           type: object
                                         type: array
                                       omitEmptyValues:
+                                        default: false
                                         type: boolean
                                       plain:
+                                        example: '[%START_TIME%] %KUMA_MESH% %UPSTREAM_HOST%'
                                         type: string
                                       type:
                                         enum:
@@ -5174,6 +5181,8 @@ spec:
                                   path:
                                     description: Path to a file that logs will be
                                       written to
+                                    example: /tmp/access.log
+                                    minLength: 1
                                     type: string
                                 required:
                                 - path
@@ -5184,6 +5193,9 @@ spec:
                                   attributes:
                                     description: Attributes can contain placeholders
                                       available on https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
+                                    example:
+                                    - key: mesh
+                                      value: '%KUMA_MESH%'
                                     items:
                                       properties:
                                         key:
@@ -5196,6 +5208,12 @@ spec:
                                     description: Body is a raw string or an OTLP any
                                       value as described at https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/logs/data-model.md#field-body
                                       It can contain placeholders available on https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
+                                    example:
+                                      kvlistValue:
+                                        values:
+                                        - key: mesh
+                                          value:
+                                            stringValue: '%KUMA_MESH%'
                                     x-kubernetes-preserve-unknown-fields: true
                                   endpoint:
                                     description: Endpoint of OpenTelemetry collector.
@@ -5211,12 +5229,19 @@ spec:
                                 properties:
                                   address:
                                     description: Address of the TCP logging backend
+                                    example: 127.0.0.1:5000
+                                    minLength: 1
                                     type: string
                                   format:
                                     description: Format of access logs. Placeholders
                                       available on https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
                                     properties:
                                       json:
+                                        example:
+                                        - key: start_time
+                                          value: '%START_TIME%'
+                                        - key: bytes_received
+                                          value: '%BYTES_RECEIVED%'
                                         items:
                                           properties:
                                             key:
@@ -5226,8 +5251,10 @@ spec:
                                           type: object
                                         type: array
                                       omitEmptyValues:
+                                        default: false
                                         type: boolean
                                       plain:
+                                        example: '[%START_TIME%] %KUMA_MESH% %UPSTREAM_HOST%'
                                         type: string
                                       type:
                                         enum:
@@ -5288,7 +5315,7 @@ spec:
               targetRef:
                 description: TargetRef is a reference to the resource the policy takes
                   an effect on. The resource could be either a real store object or
-                  virtual resource defined inplace.
+                  virtual resource defined in-place.
                 properties:
                   kind:
                     description: Kind of the referenced resource
@@ -5336,6 +5363,11 @@ spec:
                                       available on https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
                                     properties:
                                       json:
+                                        example:
+                                        - key: start_time
+                                          value: '%START_TIME%'
+                                        - key: bytes_received
+                                          value: '%BYTES_RECEIVED%'
                                         items:
                                           properties:
                                             key:
@@ -5345,8 +5377,10 @@ spec:
                                           type: object
                                         type: array
                                       omitEmptyValues:
+                                        default: false
                                         type: boolean
                                       plain:
+                                        example: '[%START_TIME%] %KUMA_MESH% %UPSTREAM_HOST%'
                                         type: string
                                       type:
                                         enum:
@@ -5359,6 +5393,8 @@ spec:
                                   path:
                                     description: Path to a file that logs will be
                                       written to
+                                    example: /tmp/access.log
+                                    minLength: 1
                                     type: string
                                 required:
                                 - path
@@ -5369,6 +5405,9 @@ spec:
                                   attributes:
                                     description: Attributes can contain placeholders
                                       available on https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
+                                    example:
+                                    - key: mesh
+                                      value: '%KUMA_MESH%'
                                     items:
                                       properties:
                                         key:
@@ -5381,6 +5420,12 @@ spec:
                                     description: Body is a raw string or an OTLP any
                                       value as described at https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/logs/data-model.md#field-body
                                       It can contain placeholders available on https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
+                                    example:
+                                      kvlistValue:
+                                        values:
+                                        - key: mesh
+                                          value:
+                                            stringValue: '%KUMA_MESH%'
                                     x-kubernetes-preserve-unknown-fields: true
                                   endpoint:
                                     description: Endpoint of OpenTelemetry collector.
@@ -5396,12 +5441,19 @@ spec:
                                 properties:
                                   address:
                                     description: Address of the TCP logging backend
+                                    example: 127.0.0.1:5000
+                                    minLength: 1
                                     type: string
                                   format:
                                     description: Format of access logs. Placeholders
                                       available on https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
                                     properties:
                                       json:
+                                        example:
+                                        - key: start_time
+                                          value: '%START_TIME%'
+                                        - key: bytes_received
+                                          value: '%BYTES_RECEIVED%'
                                         items:
                                           properties:
                                             key:
@@ -5411,8 +5463,10 @@ spec:
                                           type: object
                                         type: array
                                       omitEmptyValues:
+                                        default: false
                                         type: boolean
                                       plain:
+                                        example: '[%START_TIME%] %KUMA_MESH% %UPSTREAM_HOST%'
                                         type: string
                                       type:
                                         enum:

--- a/app/kumactl/cmd/install/testdata/install-control-plane.gateway-api-present.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.gateway-api-present.yaml
@@ -5355,6 +5355,11 @@ spec:
                                       available on https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
                                     properties:
                                       json:
+                                        example:
+                                        - key: start_time
+                                          value: '%START_TIME%'
+                                        - key: bytes_received
+                                          value: '%BYTES_RECEIVED%'
                                         items:
                                           properties:
                                             key:
@@ -5364,8 +5369,10 @@ spec:
                                           type: object
                                         type: array
                                       omitEmptyValues:
+                                        default: false
                                         type: boolean
                                       plain:
+                                        example: '[%START_TIME%] %KUMA_MESH% %UPSTREAM_HOST%'
                                         type: string
                                       type:
                                         enum:
@@ -5378,6 +5385,8 @@ spec:
                                   path:
                                     description: Path to a file that logs will be
                                       written to
+                                    example: /tmp/access.log
+                                    minLength: 1
                                     type: string
                                 required:
                                 - path
@@ -5388,6 +5397,9 @@ spec:
                                   attributes:
                                     description: Attributes can contain placeholders
                                       available on https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
+                                    example:
+                                    - key: mesh
+                                      value: '%KUMA_MESH%'
                                     items:
                                       properties:
                                         key:
@@ -5400,6 +5412,12 @@ spec:
                                     description: Body is a raw string or an OTLP any
                                       value as described at https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/logs/data-model.md#field-body
                                       It can contain placeholders available on https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
+                                    example:
+                                      kvlistValue:
+                                        values:
+                                        - key: mesh
+                                          value:
+                                            stringValue: '%KUMA_MESH%'
                                     x-kubernetes-preserve-unknown-fields: true
                                   endpoint:
                                     description: Endpoint of OpenTelemetry collector.
@@ -5415,12 +5433,19 @@ spec:
                                 properties:
                                   address:
                                     description: Address of the TCP logging backend
+                                    example: 127.0.0.1:5000
+                                    minLength: 1
                                     type: string
                                   format:
                                     description: Format of access logs. Placeholders
                                       available on https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
                                     properties:
                                       json:
+                                        example:
+                                        - key: start_time
+                                          value: '%START_TIME%'
+                                        - key: bytes_received
+                                          value: '%BYTES_RECEIVED%'
                                         items:
                                           properties:
                                             key:
@@ -5430,8 +5455,10 @@ spec:
                                           type: object
                                         type: array
                                       omitEmptyValues:
+                                        default: false
                                         type: boolean
                                       plain:
+                                        example: '[%START_TIME%] %KUMA_MESH% %UPSTREAM_HOST%'
                                         type: string
                                       type:
                                         enum:
@@ -5492,7 +5519,7 @@ spec:
               targetRef:
                 description: TargetRef is a reference to the resource the policy takes
                   an effect on. The resource could be either a real store object or
-                  virtual resource defined inplace.
+                  virtual resource defined in-place.
                 properties:
                   kind:
                     description: Kind of the referenced resource
@@ -5540,6 +5567,11 @@ spec:
                                       available on https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
                                     properties:
                                       json:
+                                        example:
+                                        - key: start_time
+                                          value: '%START_TIME%'
+                                        - key: bytes_received
+                                          value: '%BYTES_RECEIVED%'
                                         items:
                                           properties:
                                             key:
@@ -5549,8 +5581,10 @@ spec:
                                           type: object
                                         type: array
                                       omitEmptyValues:
+                                        default: false
                                         type: boolean
                                       plain:
+                                        example: '[%START_TIME%] %KUMA_MESH% %UPSTREAM_HOST%'
                                         type: string
                                       type:
                                         enum:
@@ -5563,6 +5597,8 @@ spec:
                                   path:
                                     description: Path to a file that logs will be
                                       written to
+                                    example: /tmp/access.log
+                                    minLength: 1
                                     type: string
                                 required:
                                 - path
@@ -5573,6 +5609,9 @@ spec:
                                   attributes:
                                     description: Attributes can contain placeholders
                                       available on https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
+                                    example:
+                                    - key: mesh
+                                      value: '%KUMA_MESH%'
                                     items:
                                       properties:
                                         key:
@@ -5585,6 +5624,12 @@ spec:
                                     description: Body is a raw string or an OTLP any
                                       value as described at https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/logs/data-model.md#field-body
                                       It can contain placeholders available on https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
+                                    example:
+                                      kvlistValue:
+                                        values:
+                                        - key: mesh
+                                          value:
+                                            stringValue: '%KUMA_MESH%'
                                     x-kubernetes-preserve-unknown-fields: true
                                   endpoint:
                                     description: Endpoint of OpenTelemetry collector.
@@ -5600,12 +5645,19 @@ spec:
                                 properties:
                                   address:
                                     description: Address of the TCP logging backend
+                                    example: 127.0.0.1:5000
+                                    minLength: 1
                                     type: string
                                   format:
                                     description: Format of access logs. Placeholders
                                       available on https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
                                     properties:
                                       json:
+                                        example:
+                                        - key: start_time
+                                          value: '%START_TIME%'
+                                        - key: bytes_received
+                                          value: '%BYTES_RECEIVED%'
                                         items:
                                           properties:
                                             key:
@@ -5615,8 +5667,10 @@ spec:
                                           type: object
                                         type: array
                                       omitEmptyValues:
+                                        default: false
                                         type: boolean
                                       plain:
+                                        example: '[%START_TIME%] %KUMA_MESH% %UPSTREAM_HOST%'
                                         type: string
                                       type:
                                         enum:

--- a/app/kumactl/cmd/install/testdata/install-control-plane.with-helm-set.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.with-helm-set.yaml
@@ -5171,6 +5171,11 @@ spec:
                                       available on https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
                                     properties:
                                       json:
+                                        example:
+                                        - key: start_time
+                                          value: '%START_TIME%'
+                                        - key: bytes_received
+                                          value: '%BYTES_RECEIVED%'
                                         items:
                                           properties:
                                             key:
@@ -5180,8 +5185,10 @@ spec:
                                           type: object
                                         type: array
                                       omitEmptyValues:
+                                        default: false
                                         type: boolean
                                       plain:
+                                        example: '[%START_TIME%] %KUMA_MESH% %UPSTREAM_HOST%'
                                         type: string
                                       type:
                                         enum:
@@ -5194,6 +5201,8 @@ spec:
                                   path:
                                     description: Path to a file that logs will be
                                       written to
+                                    example: /tmp/access.log
+                                    minLength: 1
                                     type: string
                                 required:
                                 - path
@@ -5204,6 +5213,9 @@ spec:
                                   attributes:
                                     description: Attributes can contain placeholders
                                       available on https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
+                                    example:
+                                    - key: mesh
+                                      value: '%KUMA_MESH%'
                                     items:
                                       properties:
                                         key:
@@ -5216,6 +5228,12 @@ spec:
                                     description: Body is a raw string or an OTLP any
                                       value as described at https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/logs/data-model.md#field-body
                                       It can contain placeholders available on https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
+                                    example:
+                                      kvlistValue:
+                                        values:
+                                        - key: mesh
+                                          value:
+                                            stringValue: '%KUMA_MESH%'
                                     x-kubernetes-preserve-unknown-fields: true
                                   endpoint:
                                     description: Endpoint of OpenTelemetry collector.
@@ -5231,12 +5249,19 @@ spec:
                                 properties:
                                   address:
                                     description: Address of the TCP logging backend
+                                    example: 127.0.0.1:5000
+                                    minLength: 1
                                     type: string
                                   format:
                                     description: Format of access logs. Placeholders
                                       available on https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
                                     properties:
                                       json:
+                                        example:
+                                        - key: start_time
+                                          value: '%START_TIME%'
+                                        - key: bytes_received
+                                          value: '%BYTES_RECEIVED%'
                                         items:
                                           properties:
                                             key:
@@ -5246,8 +5271,10 @@ spec:
                                           type: object
                                         type: array
                                       omitEmptyValues:
+                                        default: false
                                         type: boolean
                                       plain:
+                                        example: '[%START_TIME%] %KUMA_MESH% %UPSTREAM_HOST%'
                                         type: string
                                       type:
                                         enum:
@@ -5308,7 +5335,7 @@ spec:
               targetRef:
                 description: TargetRef is a reference to the resource the policy takes
                   an effect on. The resource could be either a real store object or
-                  virtual resource defined inplace.
+                  virtual resource defined in-place.
                 properties:
                   kind:
                     description: Kind of the referenced resource
@@ -5356,6 +5383,11 @@ spec:
                                       available on https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
                                     properties:
                                       json:
+                                        example:
+                                        - key: start_time
+                                          value: '%START_TIME%'
+                                        - key: bytes_received
+                                          value: '%BYTES_RECEIVED%'
                                         items:
                                           properties:
                                             key:
@@ -5365,8 +5397,10 @@ spec:
                                           type: object
                                         type: array
                                       omitEmptyValues:
+                                        default: false
                                         type: boolean
                                       plain:
+                                        example: '[%START_TIME%] %KUMA_MESH% %UPSTREAM_HOST%'
                                         type: string
                                       type:
                                         enum:
@@ -5379,6 +5413,8 @@ spec:
                                   path:
                                     description: Path to a file that logs will be
                                       written to
+                                    example: /tmp/access.log
+                                    minLength: 1
                                     type: string
                                 required:
                                 - path
@@ -5389,6 +5425,9 @@ spec:
                                   attributes:
                                     description: Attributes can contain placeholders
                                       available on https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
+                                    example:
+                                    - key: mesh
+                                      value: '%KUMA_MESH%'
                                     items:
                                       properties:
                                         key:
@@ -5401,6 +5440,12 @@ spec:
                                     description: Body is a raw string or an OTLP any
                                       value as described at https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/logs/data-model.md#field-body
                                       It can contain placeholders available on https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
+                                    example:
+                                      kvlistValue:
+                                        values:
+                                        - key: mesh
+                                          value:
+                                            stringValue: '%KUMA_MESH%'
                                     x-kubernetes-preserve-unknown-fields: true
                                   endpoint:
                                     description: Endpoint of OpenTelemetry collector.
@@ -5416,12 +5461,19 @@ spec:
                                 properties:
                                   address:
                                     description: Address of the TCP logging backend
+                                    example: 127.0.0.1:5000
+                                    minLength: 1
                                     type: string
                                   format:
                                     description: Format of access logs. Placeholders
                                       available on https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
                                     properties:
                                       json:
+                                        example:
+                                        - key: start_time
+                                          value: '%START_TIME%'
+                                        - key: bytes_received
+                                          value: '%BYTES_RECEIVED%'
                                         items:
                                           properties:
                                             key:
@@ -5431,8 +5483,10 @@ spec:
                                           type: object
                                         type: array
                                       omitEmptyValues:
+                                        default: false
                                         type: boolean
                                       plain:
+                                        example: '[%START_TIME%] %KUMA_MESH% %UPSTREAM_HOST%'
                                         type: string
                                       type:
                                         enum:

--- a/app/kumactl/cmd/install/testdata/install-crds.all.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-crds.all.golden.yaml
@@ -457,6 +457,11 @@ spec:
                                       available on https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
                                     properties:
                                       json:
+                                        example:
+                                        - key: start_time
+                                          value: '%START_TIME%'
+                                        - key: bytes_received
+                                          value: '%BYTES_RECEIVED%'
                                         items:
                                           properties:
                                             key:
@@ -466,8 +471,10 @@ spec:
                                           type: object
                                         type: array
                                       omitEmptyValues:
+                                        default: false
                                         type: boolean
                                       plain:
+                                        example: '[%START_TIME%] %KUMA_MESH% %UPSTREAM_HOST%'
                                         type: string
                                       type:
                                         enum:
@@ -480,6 +487,8 @@ spec:
                                   path:
                                     description: Path to a file that logs will be
                                       written to
+                                    example: /tmp/access.log
+                                    minLength: 1
                                     type: string
                                 required:
                                 - path
@@ -490,6 +499,9 @@ spec:
                                   attributes:
                                     description: Attributes can contain placeholders
                                       available on https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
+                                    example:
+                                    - key: mesh
+                                      value: '%KUMA_MESH%'
                                     items:
                                       properties:
                                         key:
@@ -502,6 +514,12 @@ spec:
                                     description: Body is a raw string or an OTLP any
                                       value as described at https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/logs/data-model.md#field-body
                                       It can contain placeholders available on https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
+                                    example:
+                                      kvlistValue:
+                                        values:
+                                        - key: mesh
+                                          value:
+                                            stringValue: '%KUMA_MESH%'
                                     x-kubernetes-preserve-unknown-fields: true
                                   endpoint:
                                     description: Endpoint of OpenTelemetry collector.
@@ -517,12 +535,19 @@ spec:
                                 properties:
                                   address:
                                     description: Address of the TCP logging backend
+                                    example: 127.0.0.1:5000
+                                    minLength: 1
                                     type: string
                                   format:
                                     description: Format of access logs. Placeholders
                                       available on https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
                                     properties:
                                       json:
+                                        example:
+                                        - key: start_time
+                                          value: '%START_TIME%'
+                                        - key: bytes_received
+                                          value: '%BYTES_RECEIVED%'
                                         items:
                                           properties:
                                             key:
@@ -532,8 +557,10 @@ spec:
                                           type: object
                                         type: array
                                       omitEmptyValues:
+                                        default: false
                                         type: boolean
                                       plain:
+                                        example: '[%START_TIME%] %KUMA_MESH% %UPSTREAM_HOST%'
                                         type: string
                                       type:
                                         enum:
@@ -594,7 +621,7 @@ spec:
               targetRef:
                 description: TargetRef is a reference to the resource the policy takes
                   an effect on. The resource could be either a real store object or
-                  virtual resource defined inplace.
+                  virtual resource defined in-place.
                 properties:
                   kind:
                     description: Kind of the referenced resource
@@ -642,6 +669,11 @@ spec:
                                       available on https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
                                     properties:
                                       json:
+                                        example:
+                                        - key: start_time
+                                          value: '%START_TIME%'
+                                        - key: bytes_received
+                                          value: '%BYTES_RECEIVED%'
                                         items:
                                           properties:
                                             key:
@@ -651,8 +683,10 @@ spec:
                                           type: object
                                         type: array
                                       omitEmptyValues:
+                                        default: false
                                         type: boolean
                                       plain:
+                                        example: '[%START_TIME%] %KUMA_MESH% %UPSTREAM_HOST%'
                                         type: string
                                       type:
                                         enum:
@@ -665,6 +699,8 @@ spec:
                                   path:
                                     description: Path to a file that logs will be
                                       written to
+                                    example: /tmp/access.log
+                                    minLength: 1
                                     type: string
                                 required:
                                 - path
@@ -675,6 +711,9 @@ spec:
                                   attributes:
                                     description: Attributes can contain placeholders
                                       available on https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
+                                    example:
+                                    - key: mesh
+                                      value: '%KUMA_MESH%'
                                     items:
                                       properties:
                                         key:
@@ -687,6 +726,12 @@ spec:
                                     description: Body is a raw string or an OTLP any
                                       value as described at https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/logs/data-model.md#field-body
                                       It can contain placeholders available on https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
+                                    example:
+                                      kvlistValue:
+                                        values:
+                                        - key: mesh
+                                          value:
+                                            stringValue: '%KUMA_MESH%'
                                     x-kubernetes-preserve-unknown-fields: true
                                   endpoint:
                                     description: Endpoint of OpenTelemetry collector.
@@ -702,12 +747,19 @@ spec:
                                 properties:
                                   address:
                                     description: Address of the TCP logging backend
+                                    example: 127.0.0.1:5000
+                                    minLength: 1
                                     type: string
                                   format:
                                     description: Format of access logs. Placeholders
                                       available on https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
                                     properties:
                                       json:
+                                        example:
+                                        - key: start_time
+                                          value: '%START_TIME%'
+                                        - key: bytes_received
+                                          value: '%BYTES_RECEIVED%'
                                         items:
                                           properties:
                                             key:
@@ -717,8 +769,10 @@ spec:
                                           type: object
                                         type: array
                                       omitEmptyValues:
+                                        default: false
                                         type: boolean
                                       plain:
+                                        example: '[%START_TIME%] %KUMA_MESH% %UPSTREAM_HOST%'
                                         type: string
                                       type:
                                         enum:

--- a/app/kumactl/cmd/install/testdata/install-crds.experimental-gatewayapi.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-crds.experimental-gatewayapi.golden.yaml
@@ -457,6 +457,11 @@ spec:
                                       available on https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
                                     properties:
                                       json:
+                                        example:
+                                        - key: start_time
+                                          value: '%START_TIME%'
+                                        - key: bytes_received
+                                          value: '%BYTES_RECEIVED%'
                                         items:
                                           properties:
                                             key:
@@ -466,8 +471,10 @@ spec:
                                           type: object
                                         type: array
                                       omitEmptyValues:
+                                        default: false
                                         type: boolean
                                       plain:
+                                        example: '[%START_TIME%] %KUMA_MESH% %UPSTREAM_HOST%'
                                         type: string
                                       type:
                                         enum:
@@ -480,6 +487,8 @@ spec:
                                   path:
                                     description: Path to a file that logs will be
                                       written to
+                                    example: /tmp/access.log
+                                    minLength: 1
                                     type: string
                                 required:
                                 - path
@@ -490,6 +499,9 @@ spec:
                                   attributes:
                                     description: Attributes can contain placeholders
                                       available on https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
+                                    example:
+                                    - key: mesh
+                                      value: '%KUMA_MESH%'
                                     items:
                                       properties:
                                         key:
@@ -502,6 +514,12 @@ spec:
                                     description: Body is a raw string or an OTLP any
                                       value as described at https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/logs/data-model.md#field-body
                                       It can contain placeholders available on https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
+                                    example:
+                                      kvlistValue:
+                                        values:
+                                        - key: mesh
+                                          value:
+                                            stringValue: '%KUMA_MESH%'
                                     x-kubernetes-preserve-unknown-fields: true
                                   endpoint:
                                     description: Endpoint of OpenTelemetry collector.
@@ -517,12 +535,19 @@ spec:
                                 properties:
                                   address:
                                     description: Address of the TCP logging backend
+                                    example: 127.0.0.1:5000
+                                    minLength: 1
                                     type: string
                                   format:
                                     description: Format of access logs. Placeholders
                                       available on https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
                                     properties:
                                       json:
+                                        example:
+                                        - key: start_time
+                                          value: '%START_TIME%'
+                                        - key: bytes_received
+                                          value: '%BYTES_RECEIVED%'
                                         items:
                                           properties:
                                             key:
@@ -532,8 +557,10 @@ spec:
                                           type: object
                                         type: array
                                       omitEmptyValues:
+                                        default: false
                                         type: boolean
                                       plain:
+                                        example: '[%START_TIME%] %KUMA_MESH% %UPSTREAM_HOST%'
                                         type: string
                                       type:
                                         enum:
@@ -594,7 +621,7 @@ spec:
               targetRef:
                 description: TargetRef is a reference to the resource the policy takes
                   an effect on. The resource could be either a real store object or
-                  virtual resource defined inplace.
+                  virtual resource defined in-place.
                 properties:
                   kind:
                     description: Kind of the referenced resource
@@ -642,6 +669,11 @@ spec:
                                       available on https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
                                     properties:
                                       json:
+                                        example:
+                                        - key: start_time
+                                          value: '%START_TIME%'
+                                        - key: bytes_received
+                                          value: '%BYTES_RECEIVED%'
                                         items:
                                           properties:
                                             key:
@@ -651,8 +683,10 @@ spec:
                                           type: object
                                         type: array
                                       omitEmptyValues:
+                                        default: false
                                         type: boolean
                                       plain:
+                                        example: '[%START_TIME%] %KUMA_MESH% %UPSTREAM_HOST%'
                                         type: string
                                       type:
                                         enum:
@@ -665,6 +699,8 @@ spec:
                                   path:
                                     description: Path to a file that logs will be
                                       written to
+                                    example: /tmp/access.log
+                                    minLength: 1
                                     type: string
                                 required:
                                 - path
@@ -675,6 +711,9 @@ spec:
                                   attributes:
                                     description: Attributes can contain placeholders
                                       available on https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
+                                    example:
+                                    - key: mesh
+                                      value: '%KUMA_MESH%'
                                     items:
                                       properties:
                                         key:
@@ -687,6 +726,12 @@ spec:
                                     description: Body is a raw string or an OTLP any
                                       value as described at https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/logs/data-model.md#field-body
                                       It can contain placeholders available on https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
+                                    example:
+                                      kvlistValue:
+                                        values:
+                                        - key: mesh
+                                          value:
+                                            stringValue: '%KUMA_MESH%'
                                     x-kubernetes-preserve-unknown-fields: true
                                   endpoint:
                                     description: Endpoint of OpenTelemetry collector.
@@ -702,12 +747,19 @@ spec:
                                 properties:
                                   address:
                                     description: Address of the TCP logging backend
+                                    example: 127.0.0.1:5000
+                                    minLength: 1
                                     type: string
                                   format:
                                     description: Format of access logs. Placeholders
                                       available on https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
                                     properties:
                                       json:
+                                        example:
+                                        - key: start_time
+                                          value: '%START_TIME%'
+                                        - key: bytes_received
+                                          value: '%BYTES_RECEIVED%'
                                         items:
                                           properties:
                                             key:
@@ -717,8 +769,10 @@ spec:
                                           type: object
                                         type: array
                                       omitEmptyValues:
+                                        default: false
                                         type: boolean
                                       plain:
+                                        example: '[%START_TIME%] %KUMA_MESH% %UPSTREAM_HOST%'
                                         type: string
                                       type:
                                         enum:

--- a/deployments/charts/kuma/crds/kuma.io_meshaccesslogs.yaml
+++ b/deployments/charts/kuma/crds/kuma.io_meshaccesslogs.yaml
@@ -227,7 +227,7 @@ spec:
               targetRef:
                 description: TargetRef is a reference to the resource the policy takes
                   an effect on. The resource could be either a real store object or
-                  virtual resource defined inplace.
+                  virtual resource defined in-place.
                 properties:
                   kind:
                     description: Kind of the referenced resource

--- a/deployments/charts/kuma/crds/kuma.io_meshaccesslogs.yaml
+++ b/deployments/charts/kuma/crds/kuma.io_meshaccesslogs.yaml
@@ -63,6 +63,11 @@ spec:
                                       available on https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
                                     properties:
                                       json:
+                                        example:
+                                        - key: start_time
+                                          value: '%START_TIME%'
+                                        - key: bytes_received
+                                          value: '%BYTES_RECEIVED%'
                                         items:
                                           properties:
                                             key:
@@ -72,8 +77,10 @@ spec:
                                           type: object
                                         type: array
                                       omitEmptyValues:
+                                        default: false
                                         type: boolean
                                       plain:
+                                        example: '[%START_TIME%] %KUMA_MESH% %UPSTREAM_HOST%'
                                         type: string
                                       type:
                                         enum:
@@ -86,6 +93,8 @@ spec:
                                   path:
                                     description: Path to a file that logs will be
                                       written to
+                                    example: /tmp/access.log
+                                    minLength: 1
                                     type: string
                                 required:
                                 - path
@@ -96,6 +105,9 @@ spec:
                                   attributes:
                                     description: Attributes can contain placeholders
                                       available on https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
+                                    example:
+                                    - key: mesh
+                                      value: '%KUMA_MESH%'
                                     items:
                                       properties:
                                         key:
@@ -108,6 +120,12 @@ spec:
                                     description: Body is a raw string or an OTLP any
                                       value as described at https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/logs/data-model.md#field-body
                                       It can contain placeholders available on https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
+                                    example:
+                                      kvlistValue:
+                                        values:
+                                        - key: mesh
+                                          value:
+                                            stringValue: '%KUMA_MESH%'
                                     x-kubernetes-preserve-unknown-fields: true
                                   endpoint:
                                     description: Endpoint of OpenTelemetry collector.
@@ -123,12 +141,19 @@ spec:
                                 properties:
                                   address:
                                     description: Address of the TCP logging backend
+                                    example: 127.0.0.1:5000
+                                    minLength: 1
                                     type: string
                                   format:
                                     description: Format of access logs. Placeholders
                                       available on https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
                                     properties:
                                       json:
+                                        example:
+                                        - key: start_time
+                                          value: '%START_TIME%'
+                                        - key: bytes_received
+                                          value: '%BYTES_RECEIVED%'
                                         items:
                                           properties:
                                             key:
@@ -138,8 +163,10 @@ spec:
                                           type: object
                                         type: array
                                       omitEmptyValues:
+                                        default: false
                                         type: boolean
                                       plain:
+                                        example: '[%START_TIME%] %KUMA_MESH% %UPSTREAM_HOST%'
                                         type: string
                                       type:
                                         enum:
@@ -248,6 +275,11 @@ spec:
                                       available on https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
                                     properties:
                                       json:
+                                        example:
+                                        - key: start_time
+                                          value: '%START_TIME%'
+                                        - key: bytes_received
+                                          value: '%BYTES_RECEIVED%'
                                         items:
                                           properties:
                                             key:
@@ -257,8 +289,10 @@ spec:
                                           type: object
                                         type: array
                                       omitEmptyValues:
+                                        default: false
                                         type: boolean
                                       plain:
+                                        example: '[%START_TIME%] %KUMA_MESH% %UPSTREAM_HOST%'
                                         type: string
                                       type:
                                         enum:
@@ -271,6 +305,8 @@ spec:
                                   path:
                                     description: Path to a file that logs will be
                                       written to
+                                    example: /tmp/access.log
+                                    minLength: 1
                                     type: string
                                 required:
                                 - path
@@ -281,6 +317,9 @@ spec:
                                   attributes:
                                     description: Attributes can contain placeholders
                                       available on https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
+                                    example:
+                                    - key: mesh
+                                      value: '%KUMA_MESH%'
                                     items:
                                       properties:
                                         key:
@@ -293,6 +332,12 @@ spec:
                                     description: Body is a raw string or an OTLP any
                                       value as described at https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/logs/data-model.md#field-body
                                       It can contain placeholders available on https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
+                                    example:
+                                      kvlistValue:
+                                        values:
+                                        - key: mesh
+                                          value:
+                                            stringValue: '%KUMA_MESH%'
                                     x-kubernetes-preserve-unknown-fields: true
                                   endpoint:
                                     description: Endpoint of OpenTelemetry collector.
@@ -308,12 +353,19 @@ spec:
                                 properties:
                                   address:
                                     description: Address of the TCP logging backend
+                                    example: 127.0.0.1:5000
+                                    minLength: 1
                                     type: string
                                   format:
                                     description: Format of access logs. Placeholders
                                       available on https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
                                     properties:
                                       json:
+                                        example:
+                                        - key: start_time
+                                          value: '%START_TIME%'
+                                        - key: bytes_received
+                                          value: '%BYTES_RECEIVED%'
                                         items:
                                           properties:
                                             key:
@@ -323,8 +375,10 @@ spec:
                                           type: object
                                         type: array
                                       omitEmptyValues:
+                                        default: false
                                         type: boolean
                                       plain:
+                                        example: '[%START_TIME%] %KUMA_MESH% %UPSTREAM_HOST%'
                                         type: string
                                       type:
                                         enum:

--- a/docs/generated/openapi.yaml
+++ b/docs/generated/openapi.yaml
@@ -1807,7 +1807,7 @@ components:
               description: >-
                 TargetRef is a reference to the resource the policy takes an
                 effect on. The resource could be either a real store object or
-                virtual resource defined inplace.
+                virtual resource defined in-place.
               properties:
                 kind:
                   description: Kind of the referenced resource

--- a/docs/generated/openapi.yaml
+++ b/docs/generated/openapi.yaml
@@ -1626,6 +1626,11 @@ components:
                                     https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
                                   properties:
                                     json:
+                                      example:
+                                        - key: start_time
+                                          value: '%START_TIME%'
+                                        - key: bytes_received
+                                          value: '%BYTES_RECEIVED%'
                                       items:
                                         properties:
                                           key:
@@ -1635,8 +1640,12 @@ components:
                                         type: object
                                       type: array
                                     omitEmptyValues:
+                                      default: false
                                       type: boolean
                                     plain:
+                                      example: >-
+                                        [%START_TIME%] %KUMA_MESH%
+                                        %UPSTREAM_HOST%
                                       type: string
                                     type:
                                       enum:
@@ -1648,6 +1657,8 @@ components:
                                   type: object
                                 path:
                                   description: Path to a file that logs will be written to
+                                  example: /tmp/access.log
+                                  minLength: 1
                                   type: string
                               required:
                                 - path
@@ -1660,6 +1671,9 @@ components:
                                     Attributes can contain placeholders
                                     available on
                                     https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
+                                  example:
+                                    - key: mesh
+                                      value: '%KUMA_MESH%'
                                   items:
                                     properties:
                                       key:
@@ -1675,6 +1689,12 @@ components:
                                     https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/logs/data-model.md#field-body
                                     It can contain placeholders available on
                                     https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
+                                  example:
+                                    kvlistValue:
+                                      values:
+                                        - key: mesh
+                                          value:
+                                            stringValue: '%KUMA_MESH%'
                                   x-kubernetes-preserve-unknown-fields: true
                                 endpoint:
                                   description: >-
@@ -1691,6 +1711,8 @@ components:
                               properties:
                                 address:
                                   description: Address of the TCP logging backend
+                                  example: 127.0.0.1:5000
+                                  minLength: 1
                                   type: string
                                 format:
                                   description: >-
@@ -1699,6 +1721,11 @@ components:
                                     https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
                                   properties:
                                     json:
+                                      example:
+                                        - key: start_time
+                                          value: '%START_TIME%'
+                                        - key: bytes_received
+                                          value: '%BYTES_RECEIVED%'
                                       items:
                                         properties:
                                           key:
@@ -1708,8 +1735,12 @@ components:
                                         type: object
                                       type: array
                                     omitEmptyValues:
+                                      default: false
                                       type: boolean
                                     plain:
+                                      example: >-
+                                        [%START_TIME%] %KUMA_MESH%
+                                        %UPSTREAM_HOST%
                                       type: string
                                     type:
                                       enum:
@@ -1833,6 +1864,11 @@ components:
                                     https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
                                   properties:
                                     json:
+                                      example:
+                                        - key: start_time
+                                          value: '%START_TIME%'
+                                        - key: bytes_received
+                                          value: '%BYTES_RECEIVED%'
                                       items:
                                         properties:
                                           key:
@@ -1842,8 +1878,12 @@ components:
                                         type: object
                                       type: array
                                     omitEmptyValues:
+                                      default: false
                                       type: boolean
                                     plain:
+                                      example: >-
+                                        [%START_TIME%] %KUMA_MESH%
+                                        %UPSTREAM_HOST%
                                       type: string
                                     type:
                                       enum:
@@ -1855,6 +1895,8 @@ components:
                                   type: object
                                 path:
                                   description: Path to a file that logs will be written to
+                                  example: /tmp/access.log
+                                  minLength: 1
                                   type: string
                               required:
                                 - path
@@ -1867,6 +1909,9 @@ components:
                                     Attributes can contain placeholders
                                     available on
                                     https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
+                                  example:
+                                    - key: mesh
+                                      value: '%KUMA_MESH%'
                                   items:
                                     properties:
                                       key:
@@ -1882,6 +1927,12 @@ components:
                                     https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/logs/data-model.md#field-body
                                     It can contain placeholders available on
                                     https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
+                                  example:
+                                    kvlistValue:
+                                      values:
+                                        - key: mesh
+                                          value:
+                                            stringValue: '%KUMA_MESH%'
                                   x-kubernetes-preserve-unknown-fields: true
                                 endpoint:
                                   description: >-
@@ -1898,6 +1949,8 @@ components:
                               properties:
                                 address:
                                   description: Address of the TCP logging backend
+                                  example: 127.0.0.1:5000
+                                  minLength: 1
                                   type: string
                                 format:
                                   description: >-
@@ -1906,6 +1959,11 @@ components:
                                     https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
                                   properties:
                                     json:
+                                      example:
+                                        - key: start_time
+                                          value: '%START_TIME%'
+                                        - key: bytes_received
+                                          value: '%BYTES_RECEIVED%'
                                       items:
                                         properties:
                                           key:
@@ -1915,8 +1973,12 @@ components:
                                         type: object
                                       type: array
                                     omitEmptyValues:
+                                      default: false
                                       type: boolean
                                     plain:
+                                      example: >-
+                                        [%START_TIME%] %KUMA_MESH%
+                                        %UPSTREAM_HOST%
                                       type: string
                                     type:
                                       enum:

--- a/docs/generated/raw/crds/kuma.io_meshaccesslogs.yaml
+++ b/docs/generated/raw/crds/kuma.io_meshaccesslogs.yaml
@@ -227,7 +227,7 @@ spec:
               targetRef:
                 description: TargetRef is a reference to the resource the policy takes
                   an effect on. The resource could be either a real store object or
-                  virtual resource defined inplace.
+                  virtual resource defined in-place.
                 properties:
                   kind:
                     description: Kind of the referenced resource

--- a/docs/generated/raw/crds/kuma.io_meshaccesslogs.yaml
+++ b/docs/generated/raw/crds/kuma.io_meshaccesslogs.yaml
@@ -63,6 +63,11 @@ spec:
                                       available on https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
                                     properties:
                                       json:
+                                        example:
+                                        - key: start_time
+                                          value: '%START_TIME%'
+                                        - key: bytes_received
+                                          value: '%BYTES_RECEIVED%'
                                         items:
                                           properties:
                                             key:
@@ -72,8 +77,10 @@ spec:
                                           type: object
                                         type: array
                                       omitEmptyValues:
+                                        default: false
                                         type: boolean
                                       plain:
+                                        example: '[%START_TIME%] %KUMA_MESH% %UPSTREAM_HOST%'
                                         type: string
                                       type:
                                         enum:
@@ -86,6 +93,8 @@ spec:
                                   path:
                                     description: Path to a file that logs will be
                                       written to
+                                    example: /tmp/access.log
+                                    minLength: 1
                                     type: string
                                 required:
                                 - path
@@ -96,6 +105,9 @@ spec:
                                   attributes:
                                     description: Attributes can contain placeholders
                                       available on https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
+                                    example:
+                                    - key: mesh
+                                      value: '%KUMA_MESH%'
                                     items:
                                       properties:
                                         key:
@@ -108,6 +120,12 @@ spec:
                                     description: Body is a raw string or an OTLP any
                                       value as described at https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/logs/data-model.md#field-body
                                       It can contain placeholders available on https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
+                                    example:
+                                      kvlistValue:
+                                        values:
+                                        - key: mesh
+                                          value:
+                                            stringValue: '%KUMA_MESH%'
                                     x-kubernetes-preserve-unknown-fields: true
                                   endpoint:
                                     description: Endpoint of OpenTelemetry collector.
@@ -123,12 +141,19 @@ spec:
                                 properties:
                                   address:
                                     description: Address of the TCP logging backend
+                                    example: 127.0.0.1:5000
+                                    minLength: 1
                                     type: string
                                   format:
                                     description: Format of access logs. Placeholders
                                       available on https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
                                     properties:
                                       json:
+                                        example:
+                                        - key: start_time
+                                          value: '%START_TIME%'
+                                        - key: bytes_received
+                                          value: '%BYTES_RECEIVED%'
                                         items:
                                           properties:
                                             key:
@@ -138,8 +163,10 @@ spec:
                                           type: object
                                         type: array
                                       omitEmptyValues:
+                                        default: false
                                         type: boolean
                                       plain:
+                                        example: '[%START_TIME%] %KUMA_MESH% %UPSTREAM_HOST%'
                                         type: string
                                       type:
                                         enum:
@@ -248,6 +275,11 @@ spec:
                                       available on https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
                                     properties:
                                       json:
+                                        example:
+                                        - key: start_time
+                                          value: '%START_TIME%'
+                                        - key: bytes_received
+                                          value: '%BYTES_RECEIVED%'
                                         items:
                                           properties:
                                             key:
@@ -257,8 +289,10 @@ spec:
                                           type: object
                                         type: array
                                       omitEmptyValues:
+                                        default: false
                                         type: boolean
                                       plain:
+                                        example: '[%START_TIME%] %KUMA_MESH% %UPSTREAM_HOST%'
                                         type: string
                                       type:
                                         enum:
@@ -271,6 +305,8 @@ spec:
                                   path:
                                     description: Path to a file that logs will be
                                       written to
+                                    example: /tmp/access.log
+                                    minLength: 1
                                     type: string
                                 required:
                                 - path
@@ -281,6 +317,9 @@ spec:
                                   attributes:
                                     description: Attributes can contain placeholders
                                       available on https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
+                                    example:
+                                    - key: mesh
+                                      value: '%KUMA_MESH%'
                                     items:
                                       properties:
                                         key:
@@ -293,6 +332,12 @@ spec:
                                     description: Body is a raw string or an OTLP any
                                       value as described at https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/logs/data-model.md#field-body
                                       It can contain placeholders available on https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
+                                    example:
+                                      kvlistValue:
+                                        values:
+                                        - key: mesh
+                                          value:
+                                            stringValue: '%KUMA_MESH%'
                                     x-kubernetes-preserve-unknown-fields: true
                                   endpoint:
                                     description: Endpoint of OpenTelemetry collector.
@@ -308,12 +353,19 @@ spec:
                                 properties:
                                   address:
                                     description: Address of the TCP logging backend
+                                    example: 127.0.0.1:5000
+                                    minLength: 1
                                     type: string
                                   format:
                                     description: Format of access logs. Placeholders
                                       available on https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
                                     properties:
                                       json:
+                                        example:
+                                        - key: start_time
+                                          value: '%START_TIME%'
+                                        - key: bytes_received
+                                          value: '%BYTES_RECEIVED%'
                                         items:
                                           properties:
                                             key:
@@ -323,8 +375,10 @@ spec:
                                           type: object
                                         type: array
                                       omitEmptyValues:
+                                        default: false
                                         type: boolean
                                       plain:
+                                        example: '[%START_TIME%] %KUMA_MESH% %UPSTREAM_HOST%'
                                         type: string
                                       type:
                                         enum:

--- a/pkg/plugins/policies/meshaccesslog/api/v1alpha1/meshaccesslog.go
+++ b/pkg/plugins/policies/meshaccesslog/api/v1alpha1/meshaccesslog.go
@@ -12,7 +12,7 @@ import (
 type MeshAccessLog struct {
 	// TargetRef is a reference to the resource the policy takes an effect on.
 	// The resource could be either a real store object or virtual resource
-	// defined inplace.
+	// defined in-place.
 	TargetRef common_api.TargetRef `json:"targetRef"`
 	// To list makes a match between the consumed services and corresponding configurations
 	To []To `json:"to,omitempty"`

--- a/pkg/plugins/policies/meshaccesslog/api/v1alpha1/meshaccesslog.go
+++ b/pkg/plugins/policies/meshaccesslog/api/v1alpha1/meshaccesslog.go
@@ -64,6 +64,8 @@ type TCPBackend struct {
 	// https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
 	Format *Format `json:"format,omitempty"`
 	// Address of the TCP logging backend
+	// +kubebuilder:example="127.0.0.1:5000"
+	// +kubebuilder:validation:MinLength=1
 	Address string `json:"address"`
 }
 
@@ -71,11 +73,13 @@ type TCPBackend struct {
 type OtelBackend struct {
 	// Attributes can contain placeholders available on
 	// https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
+	// +kubebuilder:example={{key: "mesh", value: "%KUMA_MESH%"}}
 	Attributes []JsonValue `json:"attributes,omitempty"`
 	// Body is a raw string or an OTLP any value as described at
 	// https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/logs/data-model.md#field-body
 	// It can contain placeholders available on
 	// https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
+	// +kubebuilder:example={kvlistValue: {values: {{key: "mesh", value: {stringValue: "%KUMA_MESH%"}}}}}
 	Body *apiextensionsv1.JSON `json:"body,omitempty"`
 	// Endpoint of OpenTelemetry collector. An empty port defaults to 4317.
 	// +kubebuilder:example="otel-collector:4317"
@@ -89,6 +93,8 @@ type FileBackend struct {
 	// https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
 	Format *Format `json:"format,omitempty"`
 	// Path to a file that logs will be written to
+	// +kubebuilder:example="/tmp/access.log"
+	// +kubebuilder:validation:MinLength=1
 	Path string `json:"path"`
 }
 
@@ -101,10 +107,13 @@ const (
 )
 
 type Format struct {
-	Type            FormatType   `json:"type"`
-	Plain           *string      `json:"plain,omitempty"`
-	Json            *[]JsonValue `json:"json,omitempty"`
-	OmitEmptyValues *bool        `json:"omitEmptyValues,omitempty"`
+	Type FormatType `json:"type"`
+	// +kubebuilder:example="[%START_TIME%] %KUMA_MESH% %UPSTREAM_HOST%"
+	Plain *string `json:"plain,omitempty"`
+	// +kubebuilder:example={{key: "start_time", value: "%START_TIME%"},{key: "bytes_received", value: "%BYTES_RECEIVED%"}}
+	Json *[]JsonValue `json:"json,omitempty"`
+	// +kubebuilder:default=false
+	OmitEmptyValues *bool `json:"omitEmptyValues,omitempty"`
 }
 
 type JsonValue struct {

--- a/pkg/plugins/policies/meshaccesslog/api/v1alpha1/schema.yaml
+++ b/pkg/plugins/policies/meshaccesslog/api/v1alpha1/schema.yaml
@@ -32,6 +32,11 @@ properties:
                             description: Format of access logs. Placeholders available on https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
                             properties:
                               json:
+                                example:
+                                  - key: start_time
+                                    value: '%START_TIME%'
+                                  - key: bytes_received
+                                    value: '%BYTES_RECEIVED%'
                                 items:
                                   properties:
                                     key:
@@ -41,8 +46,10 @@ properties:
                                   type: object
                                 type: array
                               omitEmptyValues:
+                                default: false
                                 type: boolean
                               plain:
+                                example: '[%START_TIME%] %KUMA_MESH% %UPSTREAM_HOST%'
                                 type: string
                               type:
                                 enum:
@@ -54,6 +61,8 @@ properties:
                             type: object
                           path:
                             description: Path to a file that logs will be written to
+                            example: /tmp/access.log
+                            minLength: 1
                             type: string
                         required:
                           - path
@@ -63,6 +72,9 @@ properties:
                         properties:
                           attributes:
                             description: Attributes can contain placeholders available on https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
+                            example:
+                              - key: mesh
+                                value: '%KUMA_MESH%'
                             items:
                               properties:
                                 key:
@@ -73,6 +85,12 @@ properties:
                             type: array
                           body:
                             description: Body is a raw string or an OTLP any value as described at https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/logs/data-model.md#field-body It can contain placeholders available on https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
+                            example:
+                              kvlistValue:
+                                values:
+                                  - key: mesh
+                                    value:
+                                      stringValue: '%KUMA_MESH%'
                             x-kubernetes-preserve-unknown-fields: true
                           endpoint:
                             description: Endpoint of OpenTelemetry collector. An empty port defaults to 4317.
@@ -87,11 +105,18 @@ properties:
                         properties:
                           address:
                             description: Address of the TCP logging backend
+                            example: 127.0.0.1:5000
+                            minLength: 1
                             type: string
                           format:
                             description: Format of access logs. Placeholders available on https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
                             properties:
                               json:
+                                example:
+                                  - key: start_time
+                                    value: '%START_TIME%'
+                                  - key: bytes_received
+                                    value: '%BYTES_RECEIVED%'
                                 items:
                                   properties:
                                     key:
@@ -101,8 +126,10 @@ properties:
                                   type: object
                                 type: array
                               omitEmptyValues:
+                                default: false
                                 type: boolean
                               plain:
+                                example: '[%START_TIME%] %KUMA_MESH% %UPSTREAM_HOST%'
                                 type: string
                               type:
                                 enum:
@@ -197,6 +224,11 @@ properties:
                             description: Format of access logs. Placeholders available on https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
                             properties:
                               json:
+                                example:
+                                  - key: start_time
+                                    value: '%START_TIME%'
+                                  - key: bytes_received
+                                    value: '%BYTES_RECEIVED%'
                                 items:
                                   properties:
                                     key:
@@ -206,8 +238,10 @@ properties:
                                   type: object
                                 type: array
                               omitEmptyValues:
+                                default: false
                                 type: boolean
                               plain:
+                                example: '[%START_TIME%] %KUMA_MESH% %UPSTREAM_HOST%'
                                 type: string
                               type:
                                 enum:
@@ -219,6 +253,8 @@ properties:
                             type: object
                           path:
                             description: Path to a file that logs will be written to
+                            example: /tmp/access.log
+                            minLength: 1
                             type: string
                         required:
                           - path
@@ -228,6 +264,9 @@ properties:
                         properties:
                           attributes:
                             description: Attributes can contain placeholders available on https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
+                            example:
+                              - key: mesh
+                                value: '%KUMA_MESH%'
                             items:
                               properties:
                                 key:
@@ -238,6 +277,12 @@ properties:
                             type: array
                           body:
                             description: Body is a raw string or an OTLP any value as described at https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/logs/data-model.md#field-body It can contain placeholders available on https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
+                            example:
+                              kvlistValue:
+                                values:
+                                  - key: mesh
+                                    value:
+                                      stringValue: '%KUMA_MESH%'
                             x-kubernetes-preserve-unknown-fields: true
                           endpoint:
                             description: Endpoint of OpenTelemetry collector. An empty port defaults to 4317.
@@ -252,11 +297,18 @@ properties:
                         properties:
                           address:
                             description: Address of the TCP logging backend
+                            example: 127.0.0.1:5000
+                            minLength: 1
                             type: string
                           format:
                             description: Format of access logs. Placeholders available on https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
                             properties:
                               json:
+                                example:
+                                  - key: start_time
+                                    value: '%START_TIME%'
+                                  - key: bytes_received
+                                    value: '%BYTES_RECEIVED%'
                                 items:
                                   properties:
                                     key:
@@ -266,8 +318,10 @@ properties:
                                   type: object
                                 type: array
                               omitEmptyValues:
+                                default: false
                                 type: boolean
                               plain:
+                                example: '[%START_TIME%] %KUMA_MESH% %UPSTREAM_HOST%'
                                 type: string
                               type:
                                 enum:

--- a/pkg/plugins/policies/meshaccesslog/api/v1alpha1/schema.yaml
+++ b/pkg/plugins/policies/meshaccesslog/api/v1alpha1/schema.yaml
@@ -183,7 +183,7 @@ properties:
           type: object
         type: array
       targetRef:
-        description: TargetRef is a reference to the resource the policy takes an effect on. The resource could be either a real store object or virtual resource defined inplace.
+        description: TargetRef is a reference to the resource the policy takes an effect on. The resource could be either a real store object or virtual resource defined in-place.
         properties:
           kind:
             description: Kind of the referenced resource

--- a/pkg/plugins/policies/meshaccesslog/k8s/crd/kuma.io_meshaccesslogs.yaml
+++ b/pkg/plugins/policies/meshaccesslog/k8s/crd/kuma.io_meshaccesslogs.yaml
@@ -227,7 +227,7 @@ spec:
               targetRef:
                 description: TargetRef is a reference to the resource the policy takes
                   an effect on. The resource could be either a real store object or
-                  virtual resource defined inplace.
+                  virtual resource defined in-place.
                 properties:
                   kind:
                     description: Kind of the referenced resource

--- a/pkg/plugins/policies/meshaccesslog/k8s/crd/kuma.io_meshaccesslogs.yaml
+++ b/pkg/plugins/policies/meshaccesslog/k8s/crd/kuma.io_meshaccesslogs.yaml
@@ -63,6 +63,11 @@ spec:
                                       available on https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
                                     properties:
                                       json:
+                                        example:
+                                        - key: start_time
+                                          value: '%START_TIME%'
+                                        - key: bytes_received
+                                          value: '%BYTES_RECEIVED%'
                                         items:
                                           properties:
                                             key:
@@ -72,8 +77,10 @@ spec:
                                           type: object
                                         type: array
                                       omitEmptyValues:
+                                        default: false
                                         type: boolean
                                       plain:
+                                        example: '[%START_TIME%] %KUMA_MESH% %UPSTREAM_HOST%'
                                         type: string
                                       type:
                                         enum:
@@ -86,6 +93,8 @@ spec:
                                   path:
                                     description: Path to a file that logs will be
                                       written to
+                                    example: /tmp/access.log
+                                    minLength: 1
                                     type: string
                                 required:
                                 - path
@@ -96,6 +105,9 @@ spec:
                                   attributes:
                                     description: Attributes can contain placeholders
                                       available on https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
+                                    example:
+                                    - key: mesh
+                                      value: '%KUMA_MESH%'
                                     items:
                                       properties:
                                         key:
@@ -108,6 +120,12 @@ spec:
                                     description: Body is a raw string or an OTLP any
                                       value as described at https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/logs/data-model.md#field-body
                                       It can contain placeholders available on https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
+                                    example:
+                                      kvlistValue:
+                                        values:
+                                        - key: mesh
+                                          value:
+                                            stringValue: '%KUMA_MESH%'
                                     x-kubernetes-preserve-unknown-fields: true
                                   endpoint:
                                     description: Endpoint of OpenTelemetry collector.
@@ -123,12 +141,19 @@ spec:
                                 properties:
                                   address:
                                     description: Address of the TCP logging backend
+                                    example: 127.0.0.1:5000
+                                    minLength: 1
                                     type: string
                                   format:
                                     description: Format of access logs. Placeholders
                                       available on https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
                                     properties:
                                       json:
+                                        example:
+                                        - key: start_time
+                                          value: '%START_TIME%'
+                                        - key: bytes_received
+                                          value: '%BYTES_RECEIVED%'
                                         items:
                                           properties:
                                             key:
@@ -138,8 +163,10 @@ spec:
                                           type: object
                                         type: array
                                       omitEmptyValues:
+                                        default: false
                                         type: boolean
                                       plain:
+                                        example: '[%START_TIME%] %KUMA_MESH% %UPSTREAM_HOST%'
                                         type: string
                                       type:
                                         enum:
@@ -248,6 +275,11 @@ spec:
                                       available on https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
                                     properties:
                                       json:
+                                        example:
+                                        - key: start_time
+                                          value: '%START_TIME%'
+                                        - key: bytes_received
+                                          value: '%BYTES_RECEIVED%'
                                         items:
                                           properties:
                                             key:
@@ -257,8 +289,10 @@ spec:
                                           type: object
                                         type: array
                                       omitEmptyValues:
+                                        default: false
                                         type: boolean
                                       plain:
+                                        example: '[%START_TIME%] %KUMA_MESH% %UPSTREAM_HOST%'
                                         type: string
                                       type:
                                         enum:
@@ -271,6 +305,8 @@ spec:
                                   path:
                                     description: Path to a file that logs will be
                                       written to
+                                    example: /tmp/access.log
+                                    minLength: 1
                                     type: string
                                 required:
                                 - path
@@ -281,6 +317,9 @@ spec:
                                   attributes:
                                     description: Attributes can contain placeholders
                                       available on https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
+                                    example:
+                                    - key: mesh
+                                      value: '%KUMA_MESH%'
                                     items:
                                       properties:
                                         key:
@@ -293,6 +332,12 @@ spec:
                                     description: Body is a raw string or an OTLP any
                                       value as described at https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/logs/data-model.md#field-body
                                       It can contain placeholders available on https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
+                                    example:
+                                      kvlistValue:
+                                        values:
+                                        - key: mesh
+                                          value:
+                                            stringValue: '%KUMA_MESH%'
                                     x-kubernetes-preserve-unknown-fields: true
                                   endpoint:
                                     description: Endpoint of OpenTelemetry collector.
@@ -308,12 +353,19 @@ spec:
                                 properties:
                                   address:
                                     description: Address of the TCP logging backend
+                                    example: 127.0.0.1:5000
+                                    minLength: 1
                                     type: string
                                   format:
                                     description: Format of access logs. Placeholders
                                       available on https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
                                     properties:
                                       json:
+                                        example:
+                                        - key: start_time
+                                          value: '%START_TIME%'
+                                        - key: bytes_received
+                                          value: '%BYTES_RECEIVED%'
                                         items:
                                           properties:
                                             key:
@@ -323,8 +375,10 @@ spec:
                                           type: object
                                         type: array
                                       omitEmptyValues:
+                                        default: false
                                         type: boolean
                                       plain:
+                                        example: '[%START_TIME%] %KUMA_MESH% %UPSTREAM_HOST%'
                                         type: string
                                       type:
                                         enum:


### PR DESCRIPTION
Added kubebuilder annotations with defaults and examples to generate better openapi schema.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [x] [Link to relevant issue][1] as well as docs and UI issues
  - Closes https://github.com/kumahq/kuma/issues/8223
  - https://github.com/kumahq/kuma-website/issues/1538
  - https://github.com/kumahq/kuma/issues/8348#issuecomment-1832369151
- [x] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS
  - It won't
- [x] Tests (Unit test, E2E tests, manual test on universal and k8s)
  - No changes which would require new tests
  - Don't forget `ci/` labels to run additional/fewer tests
- [x] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)?
  - There is no need
- [x] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? ([this](https://github.com/kumahq/kuma/actions/workflows/auto-backport.yaml) GH action will add "backport" label based on these [file globs](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L6), if you want to prevent it from adding the "backport" label use [no-backport-autolabel](https://github.com/kumahq/kuma/blob/master/.github/workflows/auto-backport.yaml#L8) label)
  - It doesn't

> Changelog: skip

<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
